### PR TITLE
Add `osty explain CODE` for E/W/L diagnostic lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ osty gen FILE          # transpile to Go source (see -o, --package)
 osty lsp               # run the language server on stdio
 osty explain [CODE]    # describe a diagnostic (Exxxx/Wxxxx/Lxxxx); no arg lists every code
 osty pipeline FILE|DIR # run every front-end phase; per-stage timing
-                       # (--json, --trace, --per-decl, --gen, --cpuprofile, --memprofile)
+                       # (--json, --trace, --per-decl, --gen, --cpuprofile,
+                       #  --memprofile, --baseline)
+                       # DIR may be a single package or a workspace root
 ```
 
 Global flags (precede the subcommand):
@@ -153,6 +155,8 @@ Global flags (precede the subcommand):
 - `--scopes` — `resolve`-only: also dump the nested scope tree
 - `--trace` — stream per-phase timing (lex/parse/resolve/check/lint) to stderr;
   applies to `tokens`, `parse`, `resolve`, `check`, `typecheck`, `lint`
+- `--explain` — after diagnostics, append the `osty explain CODE` text for each
+  unique code; applies to `check`, `typecheck`, `resolve`, `lint`, `parse`, `tokens`
 
 `fmt`-specific flags (after the subcommand):
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ osty fmt FILE          # format to canonical style (see --check, --write)
 osty gen FILE          # transpile to Go source (see -o, --package)
 osty lsp               # run the language server on stdio
 osty explain [CODE]    # describe a diagnostic (Exxxx/Wxxxx/Lxxxx); no arg lists every code
-osty pipeline FILE     # run every front-end phase; print per-stage timing (--json, --trace)
+osty pipeline FILE|DIR # run every front-end phase; per-stage timing
+                       # (--json, --trace, --per-decl, --gen, --cpuprofile, --memprofile)
 ```
 
 Global flags (precede the subcommand):

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
 osty fmt FILE          # format to canonical style (see --check, --write)
 osty gen FILE          # transpile to Go source (see -o, --package)
 osty lsp               # run the language server on stdio
+osty explain [CODE]    # describe a diagnostic (Exxxx/Wxxxx/Lxxxx); no arg lists every code
 ```
 
 Global flags (precede the subcommand):

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ osty fmt FILE          # format to canonical style (see --check, --write)
 osty gen FILE          # transpile to Go source (see -o, --package)
 osty lsp               # run the language server on stdio
 osty explain [CODE]    # describe a diagnostic (Exxxx/Wxxxx/Lxxxx); no arg lists every code
+osty pipeline FILE     # run every front-end phase; print per-stage timing (--json, --trace)
 ```
 
 Global flags (precede the subcommand):
@@ -149,6 +150,8 @@ Global flags (precede the subcommand):
 - `--json` — emit diagnostics as NDJSON on stderr (for tooling)
 - `--strict` — `lint`-only: exit 1 on any warning (CI mode)
 - `--scopes` — `resolve`-only: also dump the nested scope tree
+- `--trace` — stream per-phase timing (lex/parse/resolve/check/lint) to stderr;
+  applies to `tokens`, `parse`, `resolve`, `check`, `typecheck`, `lint`
 
 `fmt`-specific flags (after the subcommand):
 

--- a/cmd/osty/explain.go
+++ b/cmd/osty/explain.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lint"
+)
+
+// runExplain implements `osty explain CODE`. It accepts any diagnostic
+// code the compiler knows about (Exxxx, Wxxxx, E2xxx, Lxxxx). Lint
+// codes (Lxxxx) and their aliases (unused_let, etc.) are served by
+// lint.LookupRule so behaviour stays identical to the long-standing
+// `osty lint --explain` shortcut. Everything else goes through
+// diag.Explain, which parses the doc comments baked into the binary
+// from internal/diag/codes.go.
+//
+// Without arguments, prints a compact index of every known code so
+// readers can scan for the one they want.
+func runExplain(args []string) {
+	if len(args) == 0 {
+		runExplainList()
+		return
+	}
+	if len(args) > 1 {
+		fmt.Fprintln(os.Stderr, "usage: osty explain CODE")
+		os.Exit(2)
+	}
+	code := strings.TrimSpace(args[0])
+	if code == "" {
+		fmt.Fprintln(os.Stderr, "usage: osty explain CODE")
+		os.Exit(2)
+	}
+
+	// Lint codes have their own registry with alias support. Let that
+	// path handle both "L0001" and "unused_let".
+	if strings.HasPrefix(code, "L") || strings.HasPrefix(code, "l") {
+		runLintExplain(strings.ToUpper(code))
+		return
+	}
+	// Aliases like `unused_let` — defer to the lint registry before
+	// declaring the code unknown.
+	if _, ok := lint.LookupRule(code); ok {
+		runLintExplain(code)
+		return
+	}
+
+	// Compiler diagnostic — parse from the embedded codes.go.
+	normalized := strings.ToUpper(code)
+	d, ok := diag.Explain(normalized)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "osty explain: unknown code %q\n", code)
+		fmt.Fprintln(os.Stderr, "use `osty explain` with no argument to list every known code")
+		os.Exit(2)
+	}
+	printCodeDoc(d)
+}
+
+// printCodeDoc writes a CodeDoc to stdout in the same shape
+// `osty lint --explain` uses: header, summary, optional spec ref,
+// optional example, optional fix.
+func printCodeDoc(d diag.CodeDoc) {
+	fmt.Printf("%s  %s\n", d.Code, d.Name)
+	if d.Summary != "" {
+		fmt.Printf("summary:  %s\n", d.Summary)
+	}
+	if d.Spec != "" {
+		fmt.Printf("spec:     %s\n", d.Spec)
+	}
+	fmt.Println()
+	for _, para := range d.Body {
+		fmt.Println(para)
+		fmt.Println()
+	}
+	if d.Example != "" {
+		fmt.Println("Example:")
+		for _, line := range strings.Split(d.Example, "\n") {
+			fmt.Printf("    %s\n", line)
+		}
+		fmt.Println()
+	}
+	if d.Fix != "" {
+		fmt.Printf("Fix: %s\n", d.Fix)
+	}
+}
+
+// runExplainList prints every compiler code and every lint code in a
+// single tab-separated table, sorted by code. Intended for piping into
+// grep/fzf when you don't remember the exact number.
+func runExplainList() {
+	for _, d := range diag.AllCodes() {
+		summary := d.Summary
+		if summary == "" {
+			summary = "(no summary)"
+		}
+		fmt.Printf("%s\t%s\t%s\n", d.Code, d.Name, summary)
+	}
+	for _, r := range lint.Rules() {
+		fmt.Printf("%s\t%s\t%s\n", r.Code, r.Name, r.Summary)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -13,6 +13,7 @@
 //	osty gen <file.osty>       Transpile to Go (prints to stdout; -o writes to file).
 //	osty lsp                   Run the Language Server Protocol server on stdio.
 //	osty explain [CODE]        Describe a diagnostic code; with no arg, list every code.
+//	osty pipeline <file.osty>  Run every front-end phase and print per-stage timing.
 //
 // Global flags (may precede the subcommand):
 //
@@ -47,6 +48,7 @@ import (
 	"github.com/osty/osty/internal/lsp"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/pipeline"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/scaffold"
 	"github.com/osty/osty/internal/stdlib"
@@ -63,6 +65,7 @@ type cliFlags struct {
 	strict     bool // lint: exit 1 on any warning
 	fix        bool // lint: apply machine-applicable suggestions in place
 	showScopes bool // resolve: also print the nested scope tree
+	trace      bool // global: stream per-phase timing to stderr
 }
 
 func main() {
@@ -171,6 +174,13 @@ func main() {
 		runExplain(args[1:])
 		return
 	}
+	// pipeline runs every front-end phase and prints a per-stage
+	// timing/output table (or JSON). Has its own flag parser for
+	// --json and --trace.
+	if cmd == "pipeline" {
+		runPipeline(args[1:])
+		return
+	}
 	if len(args) < 2 {
 		usage()
 		os.Exit(2)
@@ -205,6 +215,14 @@ func main() {
 		os.Exit(1)
 	}
 	formatter := newFormatter(path, src, flags)
+
+	// --trace: run the full front-end once with streaming timing
+	// output before the subcommand's own work. Restricted to commands
+	// whose pipeline is a strict prefix of pipeline.Run — anything
+	// else (fmt, gen, build, …) has its own subcommand-local timing.
+	if flags.trace && isTraceableSingleFileCmd(cmd) {
+		pipeline.Run(src, os.Stderr)
+	}
 
 	switch cmd {
 	case "parse":
@@ -317,6 +335,7 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.strict, "strict", false, "exit non-zero on lint warnings (lint subcommand only)")
 	flag.BoolVar(&f.fix, "fix", false, "apply machine-applicable lint suggestions in place (lint subcommand only)")
 	flag.BoolVar(&f.showScopes, "scopes", false, "resolve: also dump the nested scope tree")
+	flag.BoolVar(&f.trace, "trace", false, "stream per-phase timing to stderr (single-file front-end commands)")
 	flag.Usage = usage
 	flag.Parse()
 	return f
@@ -694,6 +713,21 @@ func printDiags(f *diag.Formatter, diags []*diag.Diagnostic, flags cliFlags) {
 	}
 }
 
+// isTraceableSingleFileCmd reports whether `--trace` should produce
+// per-phase timing for the given subcommand. The streaming output
+// only makes sense when the command's work is a strict prefix of the
+// front-end pipeline (lex → parse → resolve → check → lint).
+// Subcommands with their own internal phases (fmt, gen, build, run,
+// test, publish, lsp) are excluded — they would need their own
+// instrumentation, which would belong in their respective files.
+func isTraceableSingleFileCmd(cmd string) bool {
+	switch cmd {
+	case "tokens", "parse", "resolve", "check", "typecheck", "lint":
+		return true
+	}
+	return false
+}
+
 // resolveFile runs single-file name resolution with the cached stdlib
 // registry attached. Collapses what would otherwise be a three-line
 // incantation in every single-file subcommand.
@@ -896,6 +930,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty publish              (pack + upload the package to a registry)")
 	fmt.Fprintln(os.Stderr, "       osty lsp                  (language server on stdio)")
 	fmt.Fprintln(os.Stderr, "       osty explain [CODE]       (describe a diagnostic code; no arg lists every code)")
+	fmt.Fprintln(os.Stderr, "       osty pipeline FILE        (run every front-end phase; print per-stage timing)")
 	fmt.Fprintln(os.Stderr, "flags:")
 	fmt.Fprintln(os.Stderr, "  --no-color         disable ANSI escapes")
 	fmt.Fprintln(os.Stderr, "  --color            force ANSI escapes")
@@ -903,6 +938,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --json             emit diagnostics as NDJSON")
 	fmt.Fprintln(os.Stderr, "  --strict           lint: exit 1 on warnings (CI mode)")
 	fmt.Fprintln(os.Stderr, "  --scopes           resolve: also print the nested scope tree")
+	fmt.Fprintln(os.Stderr, "  --trace            stream per-phase timing to stderr (front-end commands)")
 	fmt.Fprintln(os.Stderr, "fmt-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --check            exit 1 if FILE is not already formatted")
 	fmt.Fprintln(os.Stderr, "  --write            overwrite FILE in place")

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -12,6 +12,7 @@
 //	osty fmt <file.osty>       Format source to canonical style; see -check/-write.
 //	osty gen <file.osty>       Transpile to Go (prints to stdout; -o writes to file).
 //	osty lsp                   Run the Language Server Protocol server on stdio.
+//	osty explain [CODE]        Describe a diagnostic code; with no arg, list every code.
 //
 // Global flags (may precede the subcommand):
 //
@@ -161,6 +162,13 @@ func main() {
 	}
 	if cmd == "publish" {
 		runPublish(args[1:], flags)
+		return
+	}
+	// explain looks up a diagnostic or lint code and prints its doc.
+	// Handled before the generic "file required" check because it
+	// takes a code (or nothing, to list every code) — never a path.
+	if cmd == "explain" {
+		runExplain(args[1:])
 		return
 	}
 	if len(args) < 2 {
@@ -887,6 +895,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty test [PATH|FILTER...] (discover *_test.osty; report tests found)")
 	fmt.Fprintln(os.Stderr, "       osty publish              (pack + upload the package to a registry)")
 	fmt.Fprintln(os.Stderr, "       osty lsp                  (language server on stdio)")
+	fmt.Fprintln(os.Stderr, "       osty explain [CODE]       (describe a diagnostic code; no arg lists every code)")
 	fmt.Fprintln(os.Stderr, "flags:")
 	fmt.Fprintln(os.Stderr, "  --no-color         disable ANSI escapes")
 	fmt.Fprintln(os.Stderr, "  --color            force ANSI escapes")

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -930,7 +930,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty publish              (pack + upload the package to a registry)")
 	fmt.Fprintln(os.Stderr, "       osty lsp                  (language server on stdio)")
 	fmt.Fprintln(os.Stderr, "       osty explain [CODE]       (describe a diagnostic code; no arg lists every code)")
-	fmt.Fprintln(os.Stderr, "       osty pipeline FILE        (run every front-end phase; print per-stage timing)")
+	fmt.Fprintln(os.Stderr, "       osty pipeline FILE|DIR    (run every front-end phase; per-stage timing)")
 	fmt.Fprintln(os.Stderr, "flags:")
 	fmt.Fprintln(os.Stderr, "  --no-color         disable ANSI escapes")
 	fmt.Fprintln(os.Stderr, "  --color            force ANSI escapes")

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -66,6 +66,7 @@ type cliFlags struct {
 	fix        bool // lint: apply machine-applicable suggestions in place
 	showScopes bool // resolve: also print the nested scope tree
 	trace      bool // global: stream per-phase timing to stderr
+	explain    bool // global: append `osty explain CODE` text per unique code
 }
 
 func main() {
@@ -336,6 +337,7 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.fix, "fix", false, "apply machine-applicable lint suggestions in place (lint subcommand only)")
 	flag.BoolVar(&f.showScopes, "scopes", false, "resolve: also dump the nested scope tree")
 	flag.BoolVar(&f.trace, "trace", false, "stream per-phase timing to stderr (single-file front-end commands)")
+	flag.BoolVar(&f.explain, "explain", false, "after diagnostics, print the `osty explain CODE` text for each unique code")
 	flag.Usage = usage
 	flag.Parse()
 	return f
@@ -711,6 +713,52 @@ func printDiags(f *diag.Formatter, diags []*diag.Diagnostic, flags cliFlags) {
 			fmt.Fprintf(os.Stderr, "  %d error(s), %d warning(s)\n", errs, warns)
 		}
 	}
+	if flags.explain && !flags.jsonOutput {
+		printExplainBlock(diags)
+	}
+}
+
+// printExplainBlock walks the diagnostic list, deduplicates by code,
+// and appends the same documentation `osty explain CODE` would emit.
+// Skipped under --json (machine consumers should call `osty explain`
+// themselves) and when no diagnostic carries a code.
+func printExplainBlock(diags []*diag.Diagnostic) {
+	seen := map[string]bool{}
+	var codes []string
+	for _, d := range diags {
+		if d.Code == "" || seen[d.Code] {
+			continue
+		}
+		seen[d.Code] = true
+		codes = append(codes, d.Code)
+	}
+	if len(codes) == 0 {
+		return
+	}
+	sort.Strings(codes)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "── explanations ──────────────────────────────────────────────")
+	for _, code := range codes {
+		fmt.Fprintln(os.Stderr)
+		// Reuse the same lookup paths the standalone `osty explain` uses
+		// so output stays consistent across the two entry points.
+		if r, ok := lint.LookupRule(code); ok {
+			fmt.Fprintf(os.Stderr, "%s  %s\n", r.Code, r.Name)
+			fmt.Fprintf(os.Stderr, "  %s\n", r.Summary)
+			continue
+		}
+		if d, ok := diag.Explain(code); ok {
+			fmt.Fprintf(os.Stderr, "%s  %s\n", d.Code, d.Name)
+			if d.Summary != "" {
+				fmt.Fprintf(os.Stderr, "  %s\n", d.Summary)
+			}
+			if d.Fix != "" {
+				fmt.Fprintf(os.Stderr, "  Fix: %s\n", d.Fix)
+			}
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "%s  (no explanation registered)\n", code)
+	}
 }
 
 // isTraceableSingleFileCmd reports whether `--trace` should produce
@@ -939,6 +987,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --strict           lint: exit 1 on warnings (CI mode)")
 	fmt.Fprintln(os.Stderr, "  --scopes           resolve: also print the nested scope tree")
 	fmt.Fprintln(os.Stderr, "  --trace            stream per-phase timing to stderr (front-end commands)")
+	fmt.Fprintln(os.Stderr, "  --explain          append `osty explain CODE` text after each diagnostic block")
 	fmt.Fprintln(os.Stderr, "fmt-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --check            exit 1 if FILE is not already formatted")
 	fmt.Fprintln(os.Stderr, "  --write            overwrite FILE in place")

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/pipeline"
+)
+
+// runPipeline implements `osty pipeline FILE [--json] [--trace]`.
+//
+// The default rendering is a fixed-width table summarising each
+// front-end phase: lex → parse → resolve → check → lint, with timing,
+// a one-line output summary, and per-phase error/warning counts. A
+// closing histogram breaks down diagnostics by code so the dominant
+// rule is obvious at a glance.
+//
+// `--json` emits a stable machine-readable schema instead of the
+// table — handy for benchmarking dashboards or CI gates.
+//
+// `--trace` switches from "render after every phase finished" to
+// "stream each phase line to stderr as it completes", so you can see
+// where a slow front-end is spending its time even on a long file.
+// `--trace` and `--json` can be combined: the trace lines go to
+// stderr, the JSON document lands on stdout.
+func runPipeline(args []string) {
+	fs := flag.NewFlagSet("pipeline", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty pipeline [--json] [--trace] FILE")
+	}
+	var jsonOut, trace bool
+	fs.BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the text table")
+	fs.BoolVar(&trace, "trace", false, "stream a trace line to stderr as each phase completes")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	path := fs.Arg(0)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+		os.Exit(1)
+	}
+
+	var stream *os.File
+	if trace {
+		stream = os.Stderr
+	}
+	r := pipeline.Run(src, stream)
+
+	if jsonOut {
+		if err := r.RenderJSON(os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		r.RenderText(os.Stdout)
+	}
+
+	// Mirror the exit-code conventions of the other front-end commands:
+	// any error-severity diag aborts with exit 1.
+	for _, s := range r.Stages {
+		if s.Errors > 0 {
+			os.Exit(1)
+		}
+	}
+}

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"runtime/pprof"
 
 	"github.com/osty/osty/internal/pipeline"
+	"github.com/osty/osty/internal/resolve"
 )
 
 // runPipeline implements
@@ -47,6 +48,7 @@ func runPipeline(args []string) {
 		runGen     bool
 		cpuProfile string
 		memProfile string
+		baseline   string
 	)
 	fs.BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the text table")
 	fs.BoolVar(&trace, "trace", false, "stream a trace line to stderr as each phase completes")
@@ -54,6 +56,7 @@ func runPipeline(args []string) {
 	fs.BoolVar(&runGen, "gen", false, "also run the Go transpiler as a final pipeline phase (file mode)")
 	fs.StringVar(&cpuProfile, "cpuprofile", "", "write a CPU pprof profile to this path")
 	fs.StringVar(&memProfile, "memprofile", "", "write a memory pprof profile to this path after the pipeline")
+	fs.StringVar(&baseline, "baseline", "", "compare against a previous --json snapshot at this path")
 	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
 		fs.Usage()
@@ -94,7 +97,15 @@ func runPipeline(args []string) {
 
 	var r pipeline.Result
 	if info.IsDir() {
-		r, err = pipeline.RunPackage(target, stream, cfg)
+		// Workspace vs single-package detection mirrors what `osty
+		// check DIR` does: a workspace root has no top-level .osty
+		// files but contains subdirectories that do (and/or carries
+		// `[workspace]` in its osty.toml).
+		if resolve.IsWorkspaceRoot(target, "") {
+			r, err = pipeline.RunWorkspace(target, stream, cfg)
+		} else {
+			r, err = pipeline.RunPackage(target, stream, cfg)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
 			os.Exit(1)
@@ -108,7 +119,35 @@ func runPipeline(args []string) {
 		r = pipeline.RunWithConfig(src, stream, cfg)
 	}
 
-	if jsonOut {
+	// Baseline mode supersedes the regular table: we render the diff
+	// instead so users can spot regressions at a glance. The current
+	// run's full snapshot still goes to stdout when --json is also
+	// set, so CI can record both diff and updated baseline at once.
+	if baseline != "" {
+		f, err := os.Open(baseline)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: --baseline: %v\n", err)
+			os.Exit(1)
+		}
+		snap, err := pipeline.LoadSnapshot(f)
+		f.Close()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: --baseline: %v\n", err)
+			os.Exit(1)
+		}
+		cmp := pipeline.Compare(snap, r)
+		if jsonOut {
+			// JSON path keeps the full snapshot — comparison is text-only
+			// because the delta semantics are best read by a human.
+			if err := r.RenderJSON(os.Stdout); err != nil {
+				fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+				os.Exit(1)
+			}
+			cmp.RenderText(os.Stderr)
+		} else {
+			cmp.RenderText(os.Stdout)
+		}
+	} else if jsonOut {
 		if err := r.RenderJSON(os.Stdout); err != nil {
 			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
 			os.Exit(1)

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -4,52 +4,109 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
+	"runtime/pprof"
 
 	"github.com/osty/osty/internal/pipeline"
 )
 
-// runPipeline implements `osty pipeline FILE [--json] [--trace]`.
+// runPipeline implements
 //
-// The default rendering is a fixed-width table summarising each
-// front-end phase: lex → parse → resolve → check → lint, with timing,
-// a one-line output summary, and per-phase error/warning counts. A
-// closing histogram breaks down diagnostics by code so the dominant
-// rule is obvious at a glance.
+//	osty pipeline [--json] [--trace] [--per-decl] [--gen]
+//	              [--cpuprofile PATH] [--memprofile PATH]
+//	              FILE-OR-DIR
 //
-// `--json` emits a stable machine-readable schema instead of the
-// table — handy for benchmarking dashboards or CI gates.
+// FILE: lex → parse → resolve → check → lint, with the optional gen
+// stage when --gen is set.
 //
-// `--trace` switches from "render after every phase finished" to
-// "stream each phase line to stderr as it completes", so you can see
-// where a slow front-end is spending its time even on a long file.
-// `--trace` and `--json` can be combined: the trace lines go to
-// stderr, the JSON document lands on stdout.
+// DIR: load → resolve → check → lint over every `.osty` file in the
+// directory as one package (workspaces aren't supported here — point at
+// a leaf package). --gen is logged as skipped because the per-file
+// transpiler doesn't aggregate to package output yet.
+//
+// --per-decl threads check.Opts.OnDecl through, so the table grows a
+// per-declaration timing breakdown sorted by total time descending.
+//
+// --cpuprofile / --memprofile use runtime/pprof so users can drop the
+// resulting profile straight into `go tool pprof`. CPU profiling brackets
+// the full pipeline; memprofile is captured once the pipeline completes
+// (with one explicit `runtime.GC()` first so the snapshot reflects live
+// allocations rather than transient garbage).
 func runPipeline(args []string) {
 	fs := flag.NewFlagSet("pipeline", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty pipeline [--json] [--trace] FILE")
+		fmt.Fprintln(os.Stderr,
+			"usage: osty pipeline [--json] [--trace] [--per-decl] [--gen]")
+		fmt.Fprintln(os.Stderr,
+			"                     [--cpuprofile PATH] [--memprofile PATH] FILE-OR-DIR")
 	}
-	var jsonOut, trace bool
+	var (
+		jsonOut    bool
+		trace      bool
+		perDecl    bool
+		runGen     bool
+		cpuProfile string
+		memProfile string
+	)
 	fs.BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the text table")
 	fs.BoolVar(&trace, "trace", false, "stream a trace line to stderr as each phase completes")
+	fs.BoolVar(&perDecl, "per-decl", false, "report per-declaration check timing in the output")
+	fs.BoolVar(&runGen, "gen", false, "also run the Go transpiler as a final pipeline phase (file mode)")
+	fs.StringVar(&cpuProfile, "cpuprofile", "", "write a CPU pprof profile to this path")
+	fs.StringVar(&memProfile, "memprofile", "", "write a memory pprof profile to this path after the pipeline")
 	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
 		fs.Usage()
 		os.Exit(2)
 	}
+	target := fs.Arg(0)
 
-	path := fs.Arg(0)
-	src, err := os.ReadFile(path)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
-		os.Exit(1)
+	// CPU profiling brackets the whole pipeline. Defer the Stop so it
+	// fires regardless of how runPipeline returns.
+	if cpuProfile != "" {
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: cpuprofile: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: cpuprofile: %v\n", err)
+			os.Exit(1)
+		}
+		defer pprof.StopCPUProfile()
 	}
 
 	var stream *os.File
 	if trace {
 		stream = os.Stderr
 	}
-	r := pipeline.Run(src, stream)
+	cfg := pipeline.Config{
+		PerDecl: perDecl,
+		RunGen:  runGen,
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+		os.Exit(1)
+	}
+
+	var r pipeline.Result
+	if info.IsDir() {
+		r, err = pipeline.RunPackage(target, stream, cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		src, err := os.ReadFile(target)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+			os.Exit(1)
+		}
+		r = pipeline.RunWithConfig(src, stream, cfg)
+	}
 
 	if jsonOut {
 		if err := r.RenderJSON(os.Stdout); err != nil {
@@ -60,8 +117,25 @@ func runPipeline(args []string) {
 		r.RenderText(os.Stdout)
 	}
 
-	// Mirror the exit-code conventions of the other front-end commands:
-	// any error-severity diag aborts with exit 1.
+	// Memory profile after the pipeline finishes. Force a GC first so
+	// the snapshot reflects steady-state retained memory rather than
+	// transient garbage from the front-end's intermediate maps.
+	if memProfile != "" {
+		f, err := os.Create(memProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: memprofile: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fmt.Fprintf(os.Stderr, "osty pipeline: memprofile: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Mirror the exit-code conventions of the other front-end
+	// commands: any error-severity diag aborts with exit 1.
 	for _, s := range r.Stages {
 		if s.Errors > 0 {
 			os.Exit(1)

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -3,6 +3,7 @@ package check
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
@@ -71,6 +72,14 @@ type Opts struct {
 	// declared on `#[intrinsic_methods(...)]` placeholder structs are
 	// reachable via `x.name()` calls on primitive receivers.
 	Primitives map[types.PrimitiveKind]map[string]*ast.FnDecl
+
+	// OnDecl, if non-nil, is invoked for every top-level declaration
+	// the checker visits, once per pass ("collect" or "check"), with
+	// the wall-clock time spent in that pass. Used by `osty pipeline
+	// --per-decl` to surface which declarations dominate the front-end
+	// budget. The callback must be safe to call from the same goroutine
+	// the checker runs on; no concurrent invocation is implied.
+	OnDecl func(decl ast.Decl, phase string, dur time.Duration)
 }
 
 // firstOpt returns the first Opts in the slice, or a zero value when
@@ -96,6 +105,7 @@ func File(f *ast.File, rr *resolve.Result, opts ...Opts) *Result {
 	c := newChecker()
 	c.file = f
 	c.resolved = rr
+	c.onDecl = firstOpt(opts).OnDecl
 	c.initBuiltins()
 	c.indexPrimitiveMethods(firstOpt(opts).Primitives)
 	c.indexSymbolsFrom(rr)
@@ -125,6 +135,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, opts ...Opts) *Res
 	// scope gets us there — all files in a package share the same
 	// prelude through the package scope.
 	c.resolved = fileResult(pkg.Files[0])
+	c.onDecl = firstOpt(opts).OnDecl
 	c.initBuiltins()
 	c.indexPrimitiveMethods(firstOpt(opts).Primitives)
 
@@ -143,7 +154,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, opts ...Opts) *Res
 		c.file = pf.File
 		c.resolved = fileResult(pf)
 		for _, d := range pf.File.Decls {
-			c.collect(d)
+			c.timedCollect(d)
 		}
 	}
 
@@ -152,7 +163,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, opts ...Opts) *Res
 		c.file = pf.File
 		c.resolved = fileResult(pf)
 		for _, d := range pf.File.Decls {
-			c.checkDecl(d)
+			c.timedCheckDecl(d)
 		}
 	}
 
@@ -333,6 +344,10 @@ type checker struct {
 	file     *ast.File
 	resolved *resolve.Result
 	result   *Result
+
+	// onDecl mirrors Opts.OnDecl. When non-nil, the per-decl loops in
+	// run() and Package() report wall-clock time per pass.
+	onDecl func(decl ast.Decl, phase string, dur time.Duration)
 
 	// syms holds per-symbol type info built during pass 1.
 	syms map[*resolve.Symbol]*symInfo
@@ -665,12 +680,12 @@ func (c *checker) run() {
 	// source-order, so pass-2 body checking can call anything declared
 	// anywhere in the file.
 	for _, d := range c.file.Decls {
-		c.collect(d)
+		c.timedCollect(d)
 	}
 
 	// Pass 2: check bodies.
 	for _, d := range c.file.Decls {
-		c.checkDecl(d)
+		c.timedCheckDecl(d)
 	}
 
 	// Pass 3: script top-level statements, as the implicit main.
@@ -678,6 +693,31 @@ func (c *checker) run() {
 		e := &env{retType: types.Unit}
 		c.checkStmts(c.file.Stmts, e)
 	}
+}
+
+// timedCollect / timedCheckDecl wrap the per-decl passes with a
+// wall-clock timer that fires only when an OnDecl callback is wired
+// (the no-callback common path stays a single function call). The
+// reported phase name matches the pass: "collect" for pass 1, "check"
+// for pass 2.
+func (c *checker) timedCollect(d ast.Decl) {
+	if c.onDecl == nil {
+		c.collect(d)
+		return
+	}
+	t0 := time.Now()
+	c.collect(d)
+	c.onDecl(d, "collect", time.Since(t0))
+}
+
+func (c *checker) timedCheckDecl(d ast.Decl) {
+	if c.onDecl == nil {
+		c.checkDecl(d)
+		return
+	}
+	t0 := time.Now()
+	c.checkDecl(d)
+	c.onDecl(d, "check", time.Since(t0))
 }
 
 // symbol returns the resolver's symbol for an Ident, or nil if the

--- a/internal/diag/explain.go
+++ b/internal/diag/explain.go
@@ -1,0 +1,253 @@
+package diag
+
+// This file gives downstream tooling (the `osty explain` subcommand,
+// the LSP, future IDE plugins) programmatic access to the doc comments
+// on the CodeXxx constants in codes.go. The markdown reference in
+// ERROR_CODES.md is generated from the same source by cmd/codesdoc;
+// this package parses the comments at runtime so a single binary can
+// explain any code without shipping ERROR_CODES.md alongside it.
+//
+// The parser here is intentionally a trimmed port of the logic in
+// cmd/codesdoc/main.go — just enough to produce a structured CodeDoc
+// per constant. If the comment format ever drifts, update both sides.
+
+import (
+	_ "embed"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+)
+
+//go:embed codes.go
+var codesSource []byte
+
+// CodeDoc is the parsed documentation for a single diagnostic code.
+// Fields mirror the structured sections in the doc comments on each
+// CodeXxx constant (see codes.go for the authoritative copies).
+type CodeDoc struct {
+	Code    string   // e.g. "E0001"
+	Name    string   // e.g. "CodeUnterminatedString"
+	Summary string   // first paragraph, one line
+	Body    []string // subsequent prose paragraphs
+	Spec    string   // "Spec:" line text, empty if absent
+	Example string   // code snippet from the "Example:" block
+	Fix     string   // "Fix:" line text, empty if absent
+}
+
+var (
+	codeDocs    []CodeDoc
+	codeDocByID map[string]CodeDoc
+)
+
+func init() {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "codes.go", codesSource, parser.ParseComments)
+	if err != nil {
+		// The file is embedded from our own source — a parse failure
+		// here is a programmer error. Leave the tables empty rather
+		// than panicking so downstream tooling degrades gracefully.
+		return
+	}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !strings.HasPrefix(name.Name, "Code") {
+					continue
+				}
+				value, ok := constStringValue(vs.Values, i)
+				if !ok {
+					continue
+				}
+				d := parseExplainDoc(vs.Doc)
+				if d.Summary == "" && vs.Comment != nil {
+					d.Summary = firstCommentLine(vs.Comment)
+				}
+				codeDocs = append(codeDocs, CodeDoc{
+					Code:    value,
+					Name:    name.Name,
+					Summary: d.Summary,
+					Body:    d.Body,
+					Spec:    d.Spec,
+					Example: d.Example,
+					Fix:     d.Fix,
+				})
+			}
+		}
+	}
+	codeDocByID = make(map[string]CodeDoc, len(codeDocs))
+	for _, d := range codeDocs {
+		codeDocByID[d.Code] = d
+	}
+}
+
+// Explain returns the parsed doc for a diagnostic code (e.g. "E0500",
+// "W0750", "E2014"). Lxxxx lint codes are documented by package lint —
+// call lint.LookupRule for those.
+func Explain(code string) (CodeDoc, bool) {
+	d, ok := codeDocByID[code]
+	return d, ok
+}
+
+// AllCodes returns every parsed code in ascending code order.
+func AllCodes() []CodeDoc {
+	out := make([]CodeDoc, len(codeDocs))
+	copy(out, codeDocs)
+	sort.Slice(out, func(i, j int) bool { return out[i].Code < out[j].Code })
+	return out
+}
+
+// ---- parsing helpers (trimmed port of cmd/codesdoc/main.go) ----
+
+type parsedExplainDoc struct {
+	Summary string
+	Body    []string
+	Spec    string
+	Example string
+	Fix     string
+}
+
+func parseExplainDoc(cg *ast.CommentGroup) parsedExplainDoc {
+	if cg == nil {
+		return parsedExplainDoc{}
+	}
+	lines := make([]string, 0, len(cg.List))
+	for _, c := range cg.List {
+		text := strings.TrimPrefix(c.Text, "//")
+		if strings.HasPrefix(text, " ") {
+			text = text[1:]
+		}
+		lines = append(lines, text)
+	}
+
+	var doc parsedExplainDoc
+	var exampleLines []string
+	var bodyParas [][]string
+	var curPara []string
+
+	flushPara := func() {
+		if len(curPara) == 0 {
+			return
+		}
+		if doc.Summary == "" {
+			joined := strings.Join(trimAllLines(curPara), " ")
+			joined = strings.TrimSuffix(joined, ".")
+			if joined != "" {
+				doc.Summary = joined + "."
+			}
+		} else {
+			bodyParas = append(bodyParas, append([]string(nil), curPara...))
+		}
+		curPara = nil
+	}
+
+	section := ""
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "Spec:"):
+			flushPara()
+			section = ""
+			doc.Spec = strings.TrimSpace(strings.TrimPrefix(trimmed, "Spec:"))
+			continue
+		case strings.HasPrefix(trimmed, "Fix:"):
+			flushPara()
+			section = ""
+			doc.Fix = strings.TrimSpace(strings.TrimPrefix(trimmed, "Fix:"))
+			continue
+		case trimmed == "Example:":
+			flushPara()
+			section = "example"
+			continue
+		}
+		if section == "example" {
+			exampleLines = append(exampleLines, line)
+			continue
+		}
+		if trimmed == "" {
+			flushPara()
+			continue
+		}
+		curPara = append(curPara, line)
+	}
+	flushPara()
+
+	for _, p := range bodyParas {
+		doc.Body = append(doc.Body, strings.Join(trimAllLines(p), " "))
+	}
+	if len(exampleLines) > 0 {
+		doc.Example = trimExampleBlock(exampleLines)
+	}
+	return doc
+}
+
+func trimAllLines(xs []string) []string {
+	out := make([]string, len(xs))
+	for i, s := range xs {
+		out[i] = strings.TrimSpace(s)
+	}
+	return out
+}
+
+func trimExampleBlock(lines []string) string {
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	minIndent := -1
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		count := len(l) - len(strings.TrimLeft(l, " "))
+		if minIndent < 0 || count < minIndent {
+			minIndent = count
+		}
+	}
+	if minIndent <= 0 {
+		return strings.Join(lines, "\n")
+	}
+	for i, l := range lines {
+		if len(l) >= minIndent {
+			lines[i] = l[minIndent:]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func firstCommentLine(cg *ast.CommentGroup) string {
+	if cg == nil {
+		return ""
+	}
+	for _, c := range cg.List {
+		t := strings.TrimPrefix(c.Text, "//")
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		return t
+	}
+	return ""
+}
+
+func constStringValue(exprs []ast.Expr, i int) (string, bool) {
+	if i >= len(exprs) {
+		return "", false
+	}
+	lit, ok := exprs[i].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	return strings.Trim(lit.Value, "\""), true
+}

--- a/internal/diag/explain_test.go
+++ b/internal/diag/explain_test.go
@@ -1,0 +1,54 @@
+package diag
+
+import (
+	"strings"
+	"testing"
+)
+
+// Smoke-test the embedded-codes parser: a well-known code should
+// parse with a non-empty summary, and an unknown code should miss.
+func TestExplainKnownCode(t *testing.T) {
+	d, ok := Explain("E0001")
+	if !ok {
+		t.Fatalf("Explain(E0001): want ok, got miss")
+	}
+	if d.Name != "CodeUnterminatedString" {
+		t.Errorf("Explain(E0001).Name = %q, want CodeUnterminatedString", d.Name)
+	}
+	if d.Summary == "" {
+		t.Errorf("Explain(E0001).Summary is empty")
+	}
+	if d.Fix == "" {
+		t.Errorf("Explain(E0001).Fix is empty")
+	}
+}
+
+func TestExplainUnknownCode(t *testing.T) {
+	if _, ok := Explain("E9999"); ok {
+		t.Errorf("Explain(E9999): want miss, got hit")
+	}
+}
+
+// Every constant in codes.go should surface through AllCodes().
+// A regression here means init() silently dropped an entry — most
+// likely because the comment format drifted from what the parser
+// expects.
+func TestAllCodesNonEmpty(t *testing.T) {
+	all := AllCodes()
+	if len(all) < 20 {
+		t.Fatalf("AllCodes(): want at least 20 entries, got %d", len(all))
+	}
+	// Codes should be sorted.
+	for i := 1; i < len(all); i++ {
+		if all[i-1].Code > all[i].Code {
+			t.Fatalf("AllCodes() not sorted: %s before %s", all[i-1].Code, all[i].Code)
+		}
+	}
+	// Every entry's Code should start with E, W, or L — no stray
+	// constants leaking in from unrelated renames.
+	for _, d := range all {
+		if !strings.ContainsAny(string(d.Code[0]), "EWL") {
+			t.Errorf("unexpected code prefix: %q", d.Code)
+		}
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
@@ -47,6 +48,12 @@ type Server struct {
 	// the next loop iteration so callers can translate shutdown
 	// state into a process exit code themselves.
 	exit chan struct{}
+
+	// trace is enabled via the OSTY_LSP_TRACE environment variable
+	// (any non-empty value). When set, dispatch wraps each request
+	// with a wall-clock timer and logs `lsp-trace: <method> <dur>`
+	// per request. Useful for diagnosing slow editor interactions.
+	trace bool
 
 	docs docStore
 
@@ -92,6 +99,7 @@ func NewServer(in io.Reader, out io.Writer, logOut io.Writer) *Server {
 		prelude: resolve.NewPrelude(),
 		docs:    docStore{m: map[string]*document{}},
 		exit:    make(chan struct{}),
+		trace:   os.Getenv("OSTY_LSP_TRACE") != "",
 	}
 }
 
@@ -157,6 +165,12 @@ func (s *Server) ExitCode() int {
 // synchronization. Long-running work (none today) can be parallelized
 // later with per-method goroutines.
 func (s *Server) dispatch(req *rpcRequest) {
+	if s.trace {
+		t0 := time.Now()
+		defer func() {
+			s.log.Printf("lsp-trace: %-40s %v", req.Method, time.Since(t0))
+		}()
+	}
 	// Fast-path the lifecycle methods that can legally appear
 	// before `initialized`.
 	switch req.Method {
@@ -342,6 +356,13 @@ func (d *docStore) remove(uri string) {
 // surface correct types. Off-disk buffers (unsaved scratch docs) fall
 // back to single-file mode.
 func (s *Server) analyze(uri string, src []byte) *docAnalysis {
+	if s.trace {
+		t0 := time.Now()
+		defer func() {
+			s.log.Printf("lsp-trace:   analyze(%s, %d bytes) %v",
+				uri, len(src), time.Since(t0))
+		}()
+	}
 	if path, ok := fileURIPath(uri); ok {
 		if a := s.analyzePackageContaining(path, src); a != nil {
 			return a

--- a/internal/pipeline/compare.go
+++ b/internal/pipeline/compare.go
@@ -1,0 +1,243 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Snapshot is a slim, JSON-portable form of Result that records just
+// enough to drive a baseline comparison: per-stage timing and counts,
+// plus the diagnostic histogram. The full Result includes pointers
+// (AST, Resolve, Check, Lint) that can't round-trip through JSON;
+// Snapshot is what `osty pipeline --json` emits and what `--baseline`
+// reads back.
+type Snapshot struct {
+	Stages            []SnapshotStage `json:"stages"`
+	DiagnosticsByCode map[string]int  `json:"diagnostics_by_code"`
+	PerDecl           []DeclTiming    `json:"per_decl,omitempty"`
+}
+
+type SnapshotStage struct {
+	Name       string         `json:"name"`
+	DurationMS float64        `json:"duration_ms"`
+	Output     string         `json:"output"`
+	Errors     int            `json:"errors"`
+	Warnings   int            `json:"warnings"`
+	Counts     map[string]int `json:"counts,omitempty"`
+}
+
+// ToSnapshot extracts the JSON-portable view of a Result.
+func (r Result) ToSnapshot() Snapshot {
+	stages := make([]SnapshotStage, len(r.Stages))
+	for i, s := range r.Stages {
+		stages[i] = SnapshotStage{
+			Name:       s.Name,
+			DurationMS: float64(s.Duration.Microseconds()) / 1000.0,
+			Output:     s.Output,
+			Errors:     s.Errors,
+			Warnings:   s.Warnings,
+			Counts:     s.Counts,
+		}
+	}
+	hist := map[string]int{}
+	for _, d := range r.AllDiags {
+		c := d.Code
+		if c == "" {
+			c = "(no code)"
+		}
+		hist[c]++
+	}
+	return Snapshot{
+		Stages:            stages,
+		DiagnosticsByCode: hist,
+		PerDecl:           r.PerDecl,
+	}
+}
+
+// LoadSnapshot decodes a Snapshot from a JSON document previously
+// emitted by RenderJSON or ToSnapshot+json.Marshal.
+func LoadSnapshot(r io.Reader) (Snapshot, error) {
+	var s Snapshot
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&s); err != nil {
+		return Snapshot{}, err
+	}
+	return s, nil
+}
+
+// Comparison records the per-stage delta between a baseline and a
+// current run. Stages that exist in only one side appear with the
+// other side zeroed out.
+type Comparison struct {
+	Stages    []StageDelta
+	DiagDelta map[string][2]int // code → [baselineCount, currentCount]
+}
+
+// StageDelta is one row of the comparison table.
+type StageDelta struct {
+	Name           string
+	BaselineMS     float64
+	CurrentMS      float64
+	DeltaMS        float64 // current - baseline
+	DeltaPercent   float64 // 100 * (current - baseline) / baseline; 0 when baseline is 0
+	BaselineErrors int
+	CurrentErrors  int
+	BaselineWarns  int
+	CurrentWarns   int
+}
+
+// Compare diffs a baseline snapshot against a current Result and
+// returns a structured Comparison. Stage matching is by name (not
+// position) so adding the optional "gen" stage between runs doesn't
+// scramble the output.
+func Compare(baseline Snapshot, current Result) Comparison {
+	cur := current.ToSnapshot()
+
+	byName := func(stages []SnapshotStage) map[string]SnapshotStage {
+		m := make(map[string]SnapshotStage, len(stages))
+		for _, s := range stages {
+			m[s.Name] = s
+		}
+		return m
+	}
+	bMap, cMap := byName(baseline.Stages), byName(cur.Stages)
+
+	// Collect every stage name from either side, in a stable order:
+	// keep the current run's order, then append anything baseline-only.
+	seen := map[string]bool{}
+	var names []string
+	for _, s := range cur.Stages {
+		if !seen[s.Name] {
+			seen[s.Name] = true
+			names = append(names, s.Name)
+		}
+	}
+	for _, s := range baseline.Stages {
+		if !seen[s.Name] {
+			seen[s.Name] = true
+			names = append(names, s.Name)
+		}
+	}
+
+	out := Comparison{DiagDelta: map[string][2]int{}}
+	for _, n := range names {
+		b := bMap[n]
+		c := cMap[n]
+		delta := c.DurationMS - b.DurationMS
+		var pct float64
+		if b.DurationMS > 0 {
+			pct = 100 * delta / b.DurationMS
+		}
+		out.Stages = append(out.Stages, StageDelta{
+			Name:           n,
+			BaselineMS:     b.DurationMS,
+			CurrentMS:      c.DurationMS,
+			DeltaMS:        delta,
+			DeltaPercent:   pct,
+			BaselineErrors: b.Errors,
+			CurrentErrors:  c.Errors,
+			BaselineWarns:  b.Warnings,
+			CurrentWarns:   c.Warnings,
+		})
+	}
+
+	// Diagnostic histogram delta: union of codes from both sides.
+	codes := map[string]bool{}
+	for k := range baseline.DiagnosticsByCode {
+		codes[k] = true
+	}
+	for k := range cur.DiagnosticsByCode {
+		codes[k] = true
+	}
+	for k := range codes {
+		out.DiagDelta[k] = [2]int{
+			baseline.DiagnosticsByCode[k],
+			cur.DiagnosticsByCode[k],
+		}
+	}
+
+	return out
+}
+
+// RenderText writes a fixed-width comparison table to w. Negative
+// deltas (current is faster than baseline) get a leading "-"; positive
+// regressions get "+". A trailing diagnostic-delta block lists every
+// code whose count differs between runs.
+func (c Comparison) RenderText(w io.Writer) {
+	fmt.Fprintf(w, "%-9s  %12s  %12s  %12s  %8s  %s\n",
+		"PHASE", "BASELINE", "CURRENT", "Δ", "Δ%", "DIAGS (b→c)")
+	fmt.Fprintln(w, strings.Repeat("-", 90))
+	var totalB, totalC time.Duration
+	for _, sd := range c.Stages {
+		diagSummary := ""
+		if sd.BaselineErrors != sd.CurrentErrors {
+			diagSummary = fmt.Sprintf("err %d→%d", sd.BaselineErrors, sd.CurrentErrors)
+		}
+		if sd.BaselineWarns != sd.CurrentWarns {
+			if diagSummary != "" {
+				diagSummary += ", "
+			}
+			diagSummary += fmt.Sprintf("warn %d→%d", sd.BaselineWarns, sd.CurrentWarns)
+		}
+		fmt.Fprintf(w, "%-9s  %12s  %12s  %+12s  %+7.1f%%  %s\n",
+			sd.Name,
+			fmtMS(sd.BaselineMS), fmtMS(sd.CurrentMS),
+			fmtMSSigned(sd.DeltaMS), sd.DeltaPercent,
+			diagSummary)
+		totalB += time.Duration(sd.BaselineMS * float64(time.Millisecond))
+		totalC += time.Duration(sd.CurrentMS * float64(time.Millisecond))
+	}
+	fmt.Fprintln(w, strings.Repeat("-", 90))
+	totalDelta := totalC - totalB
+	totalPct := 0.0
+	if totalB > 0 {
+		totalPct = 100 * float64(totalDelta) / float64(totalB)
+	}
+	fmt.Fprintf(w, "%-9s  %12s  %12s  %+12s  %+7.1f%%\n",
+		"TOTAL",
+		fmtMS(float64(totalB.Microseconds())/1000),
+		fmtMS(float64(totalC.Microseconds())/1000),
+		fmtMSSigned(float64(totalDelta.Microseconds())/1000),
+		totalPct)
+
+	// Diagnostic delta — only print codes that changed.
+	type codeRow struct {
+		code string
+		b, c int
+	}
+	var rows []codeRow
+	for k, v := range c.DiagDelta {
+		if v[0] != v[1] {
+			rows = append(rows, codeRow{k, v[0], v[1]})
+		}
+	}
+	if len(rows) > 0 {
+		sort.Slice(rows, func(i, j int) bool { return rows[i].code < rows[j].code })
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "diagnostic count changes:")
+		for _, r := range rows {
+			fmt.Fprintf(w, "  %-12s  %d → %d  (Δ %+d)\n", r.code, r.b, r.c, r.c-r.b)
+		}
+	}
+}
+
+func fmtMS(ms float64) string {
+	if ms < 1 {
+		return fmt.Sprintf("%.1fµs", ms*1000)
+	}
+	return fmt.Sprintf("%.2fms", ms)
+}
+
+func fmtMSSigned(ms float64) string {
+	if ms == 0 {
+		return "0"
+	}
+	if ms > 0 {
+		return "+" + fmtMS(ms)
+	}
+	return "-" + fmtMS(-ms)
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,0 +1,311 @@
+// Package pipeline runs the full Osty front-end (lex → parse → resolve →
+// check → lint) over a single source buffer and records per-phase
+// timing + output stats. It is the engine behind the `osty pipeline`
+// subcommand and the `--trace` global flag — both want the same
+// numbers, just rendered differently.
+//
+// Single-file mode only. The package isn't trying to subsume the
+// manifest-driven build orchestrator; for multi-file packages call
+// resolve.LoadPackage / check.Package directly.
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lexer"
+	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
+)
+
+// Stage records what happened during one pipeline phase. Output is a
+// human-readable one-line summary of what the phase produced (e.g.
+// "1234 tokens", "42 decls, 89 stmts"); machine consumers should read
+// the typed counts instead.
+type Stage struct {
+	Name     string        // "lex", "parse", "resolve", "check", "lint"
+	Duration time.Duration // wall-clock time spent in the phase
+	Output   string        // human-readable summary of what came out
+	Errors   int           // diagnostic count at Severity == Error
+	Warnings int           // diagnostic count at Severity == Warning
+	// Counts holds the per-phase metric values keyed by metric name.
+	// JSON output uses these. Kept open-ended so individual phases can
+	// add more dimensions without reshaping every consumer.
+	Counts map[string]int
+}
+
+// Result bundles the stage stats with the actual artefacts produced
+// along the way. Callers that just want the table can ignore the
+// pointers; callers that want to do something with the AST / resolve
+// result (e.g. the existing single-file subcommands when --trace is
+// set) read them directly.
+type Result struct {
+	Stages   []Stage
+	Tokens   []token.Token
+	File     *ast.File
+	Resolve  *resolve.Result
+	Check    *check.Result
+	Lint     *lint.Result
+	AllDiags []*diag.Diagnostic // every diag from every phase, in phase order
+}
+
+// Run executes lex → parse → resolve → check → lint over src and
+// returns a fully populated Result. Phases that depend on a previous
+// phase still run even if the previous phase produced errors — the
+// front-end is designed to keep going so users see as many problems
+// per invocation as possible. The same diagnostic ordering is preserved
+// in AllDiags.
+//
+// stream, if non-nil, receives one human-readable trace line per
+// completed phase (used by the --trace global flag). Pass nil to
+// suppress streaming output.
+func Run(src []byte, stream io.Writer) Result {
+	var r Result
+	emit := func(s Stage) {
+		r.Stages = append(r.Stages, s)
+		if stream != nil {
+			fmt.Fprintf(stream, "trace: %-8s %8s   %s\n",
+				s.Name, formatDuration(s.Duration), traceTail(s))
+		}
+	}
+
+	// --- lex ---
+	t0 := time.Now()
+	l := lexer.New(src)
+	toks := l.Lex()
+	lexDiags := l.Errors()
+	r.Tokens = toks
+	r.AllDiags = append(r.AllDiags, lexDiags...)
+	emit(Stage{
+		Name:     "lex",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d tokens", len(toks)),
+		Errors:   countSeverity(lexDiags, diag.Error),
+		Warnings: countSeverity(lexDiags, diag.Warning),
+		Counts:   map[string]int{"tokens": len(toks)},
+	})
+
+	// --- parse ---
+	t0 = time.Now()
+	file, parseDiags := parser.ParseDiagnostics(src)
+	r.File = file
+	r.AllDiags = append(r.AllDiags, parseDiags...)
+	declCount, stmtCount, useCount := 0, 0, 0
+	if file != nil {
+		declCount = len(file.Decls)
+		stmtCount = len(file.Stmts)
+		useCount = len(file.Uses)
+	}
+	emit(Stage{
+		Name:     "parse",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d decls, %d top-level stmts, %d use", declCount, stmtCount, useCount),
+		Errors:   countSeverity(parseDiags, diag.Error),
+		Warnings: countSeverity(parseDiags, diag.Warning),
+		Counts: map[string]int{
+			"decls": declCount,
+			"stmts": stmtCount,
+			"uses":  useCount,
+		},
+	})
+
+	// --- resolve ---
+	t0 = time.Now()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	r.Resolve = res
+	r.AllDiags = append(r.AllDiags, res.Diags...)
+	emit(Stage{
+		Name:     "resolve",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d refs, %d type refs", len(res.Refs), len(res.TypeRefs)),
+		Errors:   countSeverity(res.Diags, diag.Error),
+		Warnings: countSeverity(res.Diags, diag.Warning),
+		Counts: map[string]int{
+			"refs":      len(res.Refs),
+			"type_refs": len(res.TypeRefs),
+		},
+	})
+
+	// --- check ---
+	t0 = time.Now()
+	chk := check.File(file, res, check.Opts{Primitives: stdlib.LoadCached().Primitives})
+	r.Check = chk
+	r.AllDiags = append(r.AllDiags, chk.Diags...)
+	typedExprs := 0
+	for _, t := range chk.Types {
+		if !types.IsError(t) {
+			typedExprs++
+		}
+	}
+	emit(Stage{
+		Name:     "check",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d typed exprs, %d let bindings", typedExprs, len(chk.LetTypes)),
+		Errors:   countSeverity(chk.Diags, diag.Error),
+		Warnings: countSeverity(chk.Diags, diag.Warning),
+		Counts: map[string]int{
+			"typed_exprs":  typedExprs,
+			"let_types":    len(chk.LetTypes),
+			"sym_types":    len(chk.SymTypes),
+			"instantiate":  len(chk.Instantiations),
+		},
+	})
+
+	// --- lint ---
+	t0 = time.Now()
+	lr := lint.File(file, res, chk)
+	r.Lint = lr
+	r.AllDiags = append(r.AllDiags, lr.Diags...)
+	emit(Stage{
+		Name:     "lint",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d lint findings", len(lr.Diags)),
+		Errors:   countSeverity(lr.Diags, diag.Error),
+		Warnings: countSeverity(lr.Diags, diag.Warning),
+		Counts:   map[string]int{"findings": len(lr.Diags)},
+	})
+
+	return r
+}
+
+// RenderText writes a fixed-width table summarising the run to w.
+// Always finishes with a totals row.
+func (r Result) RenderText(w io.Writer) {
+	fmt.Fprintf(w, "%-8s  %10s  %-50s  %6s  %6s\n",
+		"PHASE", "TIME", "OUTPUT", "ERR", "WARN")
+	fmt.Fprintln(w, strings.Repeat("-", 90))
+	var total time.Duration
+	var totalErr, totalWarn int
+	for _, s := range r.Stages {
+		fmt.Fprintf(w, "%-8s  %10s  %-50s  %6d  %6d\n",
+			s.Name, formatDuration(s.Duration), truncate(s.Output, 50),
+			s.Errors, s.Warnings)
+		total += s.Duration
+		totalErr += s.Errors
+		totalWarn += s.Warnings
+	}
+	fmt.Fprintln(w, strings.Repeat("-", 90))
+	fmt.Fprintf(w, "%-8s  %10s  %-50s  %6d  %6d\n",
+		"TOTAL", formatDuration(total), "", totalErr, totalWarn)
+
+	// Diagnostic-code histogram — useful when one phase reports lots
+	// of findings and you want to know which code dominates.
+	if len(r.AllDiags) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "diagnostics by code:")
+		hist := map[string]int{}
+		for _, d := range r.AllDiags {
+			c := d.Code
+			if c == "" {
+				c = "(no code)"
+			}
+			hist[c]++
+		}
+		keys := make([]string, 0, len(hist))
+		for k := range hist {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(w, "  %s  %d\n", k, hist[k])
+		}
+	}
+}
+
+// RenderJSON writes a machine-readable summary. Schema is intentionally
+// flat: top-level keys are "stages" (array) and "diagnostics_by_code"
+// (object). Stages preserve their per-metric Counts map verbatim so
+// downstream tooling can pick fields without re-parsing the human Output.
+func (r Result) RenderJSON(w io.Writer) error {
+	type stageJSON struct {
+		Name        string         `json:"name"`
+		DurationMS  float64        `json:"duration_ms"`
+		Output      string         `json:"output"`
+		Errors      int            `json:"errors"`
+		Warnings    int            `json:"warnings"`
+		Counts      map[string]int `json:"counts,omitempty"`
+	}
+	stages := make([]stageJSON, len(r.Stages))
+	for i, s := range r.Stages {
+		stages[i] = stageJSON{
+			Name:       s.Name,
+			DurationMS: float64(s.Duration.Microseconds()) / 1000.0,
+			Output:     s.Output,
+			Errors:     s.Errors,
+			Warnings:   s.Warnings,
+			Counts:     s.Counts,
+		}
+	}
+	hist := map[string]int{}
+	for _, d := range r.AllDiags {
+		c := d.Code
+		if c == "" {
+			c = "(no code)"
+		}
+		hist[c]++
+	}
+	out := struct {
+		Stages           []stageJSON    `json:"stages"`
+		DiagnosticsByCode map[string]int `json:"diagnostics_by_code"`
+	}{Stages: stages, DiagnosticsByCode: hist}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// ---- helpers ----
+
+func countSeverity(ds []*diag.Diagnostic, sev diag.Severity) int {
+	n := 0
+	for _, d := range ds {
+		if d.Severity == sev {
+			n++
+		}
+	}
+	return n
+}
+
+// formatDuration prints durations with a unit appropriate to their
+// magnitude — micros for sub-millisecond phases, millis otherwise.
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.1fµs", float64(d.Nanoseconds())/1000.0)
+	case d < time.Second:
+		return fmt.Sprintf("%.2fms", float64(d.Microseconds())/1000.0)
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 1 {
+		return ""
+	}
+	return s[:n-1] + "…"
+}
+
+func traceTail(s Stage) string {
+	tail := s.Output
+	if s.Errors > 0 || s.Warnings > 0 {
+		tail = fmt.Sprintf("%s  [err=%d warn=%d]", tail, s.Errors, s.Warnings)
+	}
+	return tail
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/gen"
 	"github.com/osty/osty/internal/lexer"
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/parser"
@@ -28,6 +29,50 @@ import (
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
 )
+
+// declName returns the user-visible name of a top-level declaration,
+// or a placeholder when the AST node has no Name field. Used by the
+// per-decl timing table so each row is identifiable at a glance.
+func declName(d ast.Decl) string {
+	switch n := d.(type) {
+	case *ast.FnDecl:
+		return n.Name
+	case *ast.StructDecl:
+		return n.Name
+	case *ast.EnumDecl:
+		return n.Name
+	case *ast.InterfaceDecl:
+		return n.Name
+	case *ast.TypeAliasDecl:
+		return n.Name
+	case *ast.LetDecl:
+		return n.Name
+	case *ast.UseDecl:
+		return n.RawPath
+	}
+	return "<anonymous>"
+}
+
+// declKind returns a short human label for a declaration's category.
+func declKind(d ast.Decl) string {
+	switch d.(type) {
+	case *ast.FnDecl:
+		return "fn"
+	case *ast.StructDecl:
+		return "struct"
+	case *ast.EnumDecl:
+		return "enum"
+	case *ast.InterfaceDecl:
+		return "interface"
+	case *ast.TypeAliasDecl:
+		return "alias"
+	case *ast.LetDecl:
+		return "let"
+	case *ast.UseDecl:
+		return "use"
+	}
+	return "?"
+}
 
 // Stage records what happened during one pipeline phase. Output is a
 // human-readable one-line summary of what the phase produced (e.g.
@@ -58,19 +103,64 @@ type Result struct {
 	Check    *check.Result
 	Lint     *lint.Result
 	AllDiags []*diag.Diagnostic // every diag from every phase, in phase order
+
+	// PerDecl is populated when Config.PerDecl is set. One entry per
+	// (declaration, pass) pair the type checker visited. Sorted by
+	// total descending in RenderText / RenderJSON.
+	PerDecl []DeclTiming
+
+	// GenBytes, GenError are populated when Config.RunGen is set.
+	GenBytes []byte
+	GenError error
 }
 
-// Run executes lex → parse → resolve → check → lint over src and
-// returns a fully populated Result. Phases that depend on a previous
-// phase still run even if the previous phase produced errors — the
-// front-end is designed to keep going so users see as many problems
-// per invocation as possible. The same diagnostic ordering is preserved
-// in AllDiags.
+// DeclTiming records how long the type checker spent on one
+// declaration during one pass ("collect" or "check").
+type DeclTiming struct {
+	Name     string        `json:"name"`     // best-effort declaration name
+	Kind     string        `json:"kind"`     // "fn", "struct", "enum", …
+	Phase    string        `json:"phase"`    // "collect" | "check"
+	Duration time.Duration `json:"-"`
+	// DurationMS mirrors Duration for JSON consumers.
+	DurationMS float64 `json:"duration_ms"`
+}
+
+// Config tweaks what Run does. The zero value runs the standard
+// front-end (lex → parse → resolve → check → lint) without optional
+// instrumentation; opting into PerDecl or RunGen extends what gets
+// recorded but never changes the order or count of the always-on
+// phases.
+type Config struct {
+	// PerDecl turns on the type checker's OnDecl callback so the
+	// returned Result includes a per-declaration timing table.
+	PerDecl bool
+
+	// RunGen runs the Go transpiler as a sixth pipeline phase. The
+	// returned GenBytes are the (possibly partial) Go source the
+	// transpiler emitted; GenError holds any fatal generator error.
+	RunGen bool
+
+	// GenPackageName is the Go package clause used when RunGen is set.
+	// Defaults to "main".
+	GenPackageName string
+}
+
+// Run executes lex → parse → resolve → check → lint over src with
+// default Config and returns a fully populated Result. See RunWithConfig
+// for the optional per-decl timing and gen-phase extensions.
 //
 // stream, if non-nil, receives one human-readable trace line per
 // completed phase (used by the --trace global flag). Pass nil to
 // suppress streaming output.
 func Run(src []byte, stream io.Writer) Result {
+	return RunWithConfig(src, stream, Config{})
+}
+
+// RunWithConfig is the configurable form of Run. The stage list always
+// includes lex/parse/resolve/check/lint in that order; gen is appended
+// when cfg.RunGen is set. Per-decl timing is collected when cfg.PerDecl
+// is set and surfaces in Result.PerDecl.
+func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 	var r Result
 	emit := func(s Stage) {
 		r.Stages = append(r.Stages, s)
@@ -139,7 +229,19 @@ func Run(src []byte, stream io.Writer) Result {
 
 	// --- check ---
 	t0 = time.Now()
-	chk := check.File(file, res, check.Opts{Primitives: stdlib.LoadCached().Primitives})
+	checkOpts := check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	if cfg.PerDecl {
+		checkOpts.OnDecl = func(d ast.Decl, phase string, dur time.Duration) {
+			r.PerDecl = append(r.PerDecl, DeclTiming{
+				Name:       declName(d),
+				Kind:       declKind(d),
+				Phase:      phase,
+				Duration:   dur,
+				DurationMS: float64(dur.Microseconds()) / 1000.0,
+			})
+		}
+	}
+	chk := check.File(file, res, checkOpts)
 	r.Check = chk
 	r.AllDiags = append(r.AllDiags, chk.Diags...)
 	typedExprs := 0
@@ -176,7 +278,183 @@ func Run(src []byte, stream io.Writer) Result {
 		Counts:   map[string]int{"findings": len(lr.Diags)},
 	})
 
+	// --- gen (optional) ---
+	// The transpiler is only meaningful on a clean front-end: a check
+	// error means the type info gen relies on is partial, and the Go
+	// it would emit is at best unhelpful. We still run gen if the user
+	// asked, but report the error in the stage stats so the table
+	// makes the situation obvious.
+	if cfg.RunGen {
+		t0 = time.Now()
+		pkg := cfg.GenPackageName
+		if pkg == "" {
+			pkg = "main"
+		}
+		out, err := gen.Generate(pkg, file, res, chk)
+		r.GenBytes = out
+		r.GenError = err
+		genErr := 0
+		summary := fmt.Sprintf("%d bytes Go", len(out))
+		if err != nil {
+			genErr = 1
+			summary = fmt.Sprintf("%d bytes Go (error: %v)", len(out), err)
+		}
+		emit(Stage{
+			Name:     "gen",
+			Duration: time.Since(t0),
+			Output:   summary,
+			Errors:   genErr,
+			Warnings: 0,
+			Counts:   map[string]int{"bytes": len(out)},
+		})
+	}
+
 	return r
+}
+
+// RunPackage runs the front-end over a directory of `.osty` files,
+// using the same stage shape as Run. The stages are renamed slightly
+// so the table reflects what actually happened: "load" combines the
+// loader's lex + parse step (LoadPackage doesn't expose them
+// separately), and the rest mirrors Run. Workspaces are not handled
+// here — point at a leaf package directory.
+//
+// If LoadPackage fails (e.g. directory unreadable), the returned
+// Result has empty Stages and the error is returned to the caller so
+// the CLI can decide whether to abort.
+func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
+	var r Result
+	emit := func(s Stage) {
+		r.Stages = append(r.Stages, s)
+		if stream != nil {
+			fmt.Fprintf(stream, "trace: %-8s %8s   %s\n",
+				s.Name, formatDuration(s.Duration), traceTail(s))
+		}
+	}
+
+	// --- load (lex + parse, all files) ---
+	t0 := time.Now()
+	pkg, err := resolve.LoadPackage(dir)
+	if err != nil {
+		return r, err
+	}
+	totalBytes, totalDecls, totalStmts, totalUses := 0, 0, 0, 0
+	var loadDiags []*diag.Diagnostic
+	for _, pf := range pkg.Files {
+		totalBytes += len(pf.Source)
+		loadDiags = append(loadDiags, pf.ParseDiags...)
+		if pf.File != nil {
+			totalDecls += len(pf.File.Decls)
+			totalStmts += len(pf.File.Stmts)
+			totalUses += len(pf.File.Uses)
+		}
+	}
+	r.AllDiags = append(r.AllDiags, loadDiags...)
+	emit(Stage{
+		Name:     "load",
+		Duration: time.Since(t0),
+		Output: fmt.Sprintf("%d files, %d bytes, %d decls",
+			len(pkg.Files), totalBytes, totalDecls),
+		Errors:   countSeverity(loadDiags, diag.Error),
+		Warnings: countSeverity(loadDiags, diag.Warning),
+		Counts: map[string]int{
+			"files": len(pkg.Files),
+			"bytes": totalBytes,
+			"decls": totalDecls,
+			"stmts": totalStmts,
+			"uses":  totalUses,
+		},
+	})
+
+	// --- resolve (whole-package) ---
+	t0 = time.Now()
+	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+	r.AllDiags = append(r.AllDiags, res.Diags...)
+	totalRefs, totalTypeRefs := 0, 0
+	for _, pf := range pkg.Files {
+		totalRefs += len(pf.Refs)
+		totalTypeRefs += len(pf.TypeRefs)
+	}
+	emit(Stage{
+		Name:     "resolve",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d refs, %d type refs", totalRefs, totalTypeRefs),
+		Errors:   countSeverity(res.Diags, diag.Error),
+		Warnings: countSeverity(res.Diags, diag.Warning),
+		Counts: map[string]int{
+			"refs":      totalRefs,
+			"type_refs": totalTypeRefs,
+		},
+	})
+
+	// --- check (whole-package) ---
+	t0 = time.Now()
+	checkOpts := check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	if cfg.PerDecl {
+		checkOpts.OnDecl = func(d ast.Decl, phase string, dur time.Duration) {
+			r.PerDecl = append(r.PerDecl, DeclTiming{
+				Name:       declName(d),
+				Kind:       declKind(d),
+				Phase:      phase,
+				Duration:   dur,
+				DurationMS: float64(dur.Microseconds()) / 1000.0,
+			})
+		}
+	}
+	chk := check.Package(pkg, res, checkOpts)
+	r.Check = chk
+	r.AllDiags = append(r.AllDiags, chk.Diags...)
+	typedExprs := 0
+	for _, t := range chk.Types {
+		if !types.IsError(t) {
+			typedExprs++
+		}
+	}
+	emit(Stage{
+		Name:     "check",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d typed exprs, %d let bindings", typedExprs, len(chk.LetTypes)),
+		Errors:   countSeverity(chk.Diags, diag.Error),
+		Warnings: countSeverity(chk.Diags, diag.Warning),
+		Counts: map[string]int{
+			"typed_exprs": typedExprs,
+			"let_types":   len(chk.LetTypes),
+			"sym_types":   len(chk.SymTypes),
+			"instantiate": len(chk.Instantiations),
+		},
+	})
+
+	// --- lint (per-file, aggregated) ---
+	t0 = time.Now()
+	var lintDiags []*diag.Diagnostic
+	for _, pf := range pkg.Files {
+		fileRes := &resolve.Result{
+			Refs:      pf.Refs,
+			TypeRefs:  pf.TypeRefs,
+			FileScope: pf.FileScope,
+		}
+		lr := lint.File(pf.File, fileRes, chk)
+		lintDiags = append(lintDiags, lr.Diags...)
+	}
+	r.AllDiags = append(r.AllDiags, lintDiags...)
+	emit(Stage{
+		Name:     "lint",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d lint findings (across %d files)", len(lintDiags), len(pkg.Files)),
+		Errors:   countSeverity(lintDiags, diag.Error),
+		Warnings: countSeverity(lintDiags, diag.Warning),
+		Counts:   map[string]int{"findings": len(lintDiags)},
+	})
+
+	// gen is single-file only; for packages we don't run it because
+	// the transpiler's per-file Generate doesn't aggregate. Surfacing
+	// "package gen" would invent semantics gen.go doesn't currently
+	// have, so we skip it and document that limitation.
+	if cfg.RunGen {
+		fmt.Fprintln(stream, "trace: gen      skipped   (per-package gen is not yet supported)")
+	}
+
+	return r, nil
 }
 
 // RenderText writes a fixed-width table summarising the run to w.
@@ -198,6 +476,24 @@ func (r Result) RenderText(w io.Writer) {
 	fmt.Fprintln(w, strings.Repeat("-", 90))
 	fmt.Fprintf(w, "%-8s  %10s  %-50s  %6d  %6d\n",
 		"TOTAL", formatDuration(total), "", totalErr, totalWarn)
+
+	// Per-declaration timing — present only when Config.PerDecl was
+	// set. Sorted by total time descending so the slow declarations
+	// land at the top.
+	if len(r.PerDecl) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "per-declaration timing (slowest first):")
+		fmt.Fprintf(w, "  %-9s  %-8s  %-8s  %s\n", "TIME", "PHASE", "KIND", "NAME")
+		fmt.Fprintln(w, "  "+strings.Repeat("-", 60))
+		rows := append([]DeclTiming(nil), r.PerDecl...)
+		sort.Slice(rows, func(i, j int) bool {
+			return rows[i].Duration > rows[j].Duration
+		})
+		for _, dt := range rows {
+			fmt.Fprintf(w, "  %9s  %-8s  %-8s  %s\n",
+				formatDuration(dt.Duration), dt.Phase, dt.Kind, dt.Name)
+		}
+	}
 
 	// Diagnostic-code histogram — useful when one phase reports lots
 	// of findings and you want to know which code dominates.
@@ -256,9 +552,10 @@ func (r Result) RenderJSON(w io.Writer) error {
 		hist[c]++
 	}
 	out := struct {
-		Stages           []stageJSON    `json:"stages"`
+		Stages            []stageJSON    `json:"stages"`
 		DiagnosticsByCode map[string]int `json:"diagnostics_by_code"`
-	}{Stages: stages, DiagnosticsByCode: hist}
+		PerDecl           []DeclTiming   `json:"per_decl,omitempty"`
+	}{Stages: stages, DiagnosticsByCode: hist, PerDecl: r.PerDecl}
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -446,12 +446,299 @@ func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
 		Counts:   map[string]int{"findings": len(lintDiags)},
 	})
 
-	// gen is single-file only; for packages we don't run it because
-	// the transpiler's per-file Generate doesn't aggregate. Surfacing
-	// "package gen" would invent semantics gen.go doesn't currently
-	// have, so we skip it and document that limitation.
+	// gen (optional, per-file aggregated). The transpiler is per-file;
+	// in package mode we run it once per file with that file's
+	// resolve view but the shared check.Result, then sum bytes-out
+	// and surface the first fatal error. Output bytes are concatenated
+	// into r.GenBytes with file headers so a downstream consumer can
+	// still reconstruct per-file boundaries.
 	if cfg.RunGen {
-		fmt.Fprintln(stream, "trace: gen      skipped   (per-package gen is not yet supported)")
+		t0 = time.Now()
+		pkgName := cfg.GenPackageName
+		if pkgName == "" {
+			pkgName = pkg.Name
+		}
+		var genBuf []byte
+		var firstErr error
+		genErrs := 0
+		for _, pf := range pkg.Files {
+			if pf.File == nil {
+				continue
+			}
+			fileRes := &resolve.Result{
+				Refs:      pf.Refs,
+				TypeRefs:  pf.TypeRefs,
+				FileScope: pf.FileScope,
+			}
+			out, err := gen.Generate(pkgName, pf.File, fileRes, chk)
+			header := fmt.Sprintf("\n// ---- %s ----\n", pf.Path)
+			genBuf = append(genBuf, []byte(header)...)
+			genBuf = append(genBuf, out...)
+			if err != nil {
+				genErrs++
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+		r.GenBytes = genBuf
+		r.GenError = firstErr
+		summary := fmt.Sprintf("%d bytes Go (across %d files)", len(genBuf), len(pkg.Files))
+		if firstErr != nil {
+			summary = fmt.Sprintf("%d bytes Go, %d file error(s); first: %v",
+				len(genBuf), genErrs, firstErr)
+		}
+		emit(Stage{
+			Name:     "gen",
+			Duration: time.Since(t0),
+			Output:   summary,
+			Errors:   genErrs,
+			Warnings: 0,
+			Counts: map[string]int{
+				"bytes":       len(genBuf),
+				"files":       len(pkg.Files),
+				"file_errors": genErrs,
+			},
+		})
+	}
+
+	return r, nil
+}
+
+// RunWorkspace runs the front-end across every package in a workspace
+// rooted at dir. Stages here are still load → resolve → check → lint
+// (+ optional gen) but each stage's counts roll up across every
+// package. Per-package diagnostic ordering is preserved in AllDiags so
+// downstream renderers can still attribute findings.
+//
+// A workspace contains zero or more package directories underneath a
+// root marked by `osty.toml [workspace]` or by an empty root holding
+// only subdirectories with `.osty` files. Use this when --pipeline
+// runs on the workspace root; for a leaf package call RunPackage.
+func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
+	var r Result
+	emit := func(s Stage) {
+		r.Stages = append(r.Stages, s)
+		if stream != nil {
+			fmt.Fprintf(stream, "trace: %-8s %8s   %s\n",
+				s.Name, formatDuration(s.Duration), traceTail(s))
+		}
+	}
+
+	// --- load (lex + parse, every package) ---
+	t0 := time.Now()
+	ws, err := resolve.NewWorkspace(dir)
+	if err != nil {
+		return r, err
+	}
+	ws.Stdlib = stdlib.LoadCached()
+	for _, p := range resolve.WorkspacePackagePaths(dir) {
+		_, _ = ws.LoadPackage(p)
+	}
+
+	totalFiles, totalBytes, totalDecls, totalStmts, totalUses := 0, 0, 0, 0, 0
+	var loadDiags []*diag.Diagnostic
+	pkgPaths := make([]string, 0, len(ws.Packages))
+	for p := range ws.Packages {
+		pkgPaths = append(pkgPaths, p)
+	}
+	sort.Strings(pkgPaths)
+	for _, p := range pkgPaths {
+		pkg := ws.Packages[p]
+		if pkg == nil {
+			continue
+		}
+		for _, pf := range pkg.Files {
+			totalFiles++
+			totalBytes += len(pf.Source)
+			loadDiags = append(loadDiags, pf.ParseDiags...)
+			if pf.File != nil {
+				totalDecls += len(pf.File.Decls)
+				totalStmts += len(pf.File.Stmts)
+				totalUses += len(pf.File.Uses)
+			}
+		}
+	}
+	r.AllDiags = append(r.AllDiags, loadDiags...)
+	emit(Stage{
+		Name:     "load",
+		Duration: time.Since(t0),
+		Output: fmt.Sprintf("%d packages, %d files, %d bytes, %d decls",
+			len(pkgPaths), totalFiles, totalBytes, totalDecls),
+		Errors:   countSeverity(loadDiags, diag.Error),
+		Warnings: countSeverity(loadDiags, diag.Warning),
+		Counts: map[string]int{
+			"packages": len(pkgPaths),
+			"files":    totalFiles,
+			"bytes":    totalBytes,
+			"decls":    totalDecls,
+			"stmts":    totalStmts,
+			"uses":     totalUses,
+		},
+	})
+
+	// --- resolve (workspace-wide) ---
+	t0 = time.Now()
+	results := ws.ResolveAll()
+	totalRefs, totalTypeRefs := 0, 0
+	var resolveDiags []*diag.Diagnostic
+	for _, p := range pkgPaths {
+		pr, ok := results[p]
+		if !ok || pr == nil {
+			continue
+		}
+		resolveDiags = append(resolveDiags, pr.Diags...)
+		pkg := ws.Packages[p]
+		if pkg == nil {
+			continue
+		}
+		for _, pf := range pkg.Files {
+			totalRefs += len(pf.Refs)
+			totalTypeRefs += len(pf.TypeRefs)
+		}
+	}
+	r.AllDiags = append(r.AllDiags, resolveDiags...)
+	emit(Stage{
+		Name:     "resolve",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d refs, %d type refs", totalRefs, totalTypeRefs),
+		Errors:   countSeverity(resolveDiags, diag.Error),
+		Warnings: countSeverity(resolveDiags, diag.Warning),
+		Counts: map[string]int{
+			"refs":      totalRefs,
+			"type_refs": totalTypeRefs,
+		},
+	})
+
+	// --- check (cross-package) ---
+	t0 = time.Now()
+	checkOpts := check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	if cfg.PerDecl {
+		checkOpts.OnDecl = func(d ast.Decl, phase string, dur time.Duration) {
+			r.PerDecl = append(r.PerDecl, DeclTiming{
+				Name:       declName(d),
+				Kind:       declKind(d),
+				Phase:      phase,
+				Duration:   dur,
+				DurationMS: float64(dur.Microseconds()) / 1000.0,
+			})
+		}
+	}
+	checks := check.Workspace(ws, results, checkOpts)
+	var checkDiags []*diag.Diagnostic
+	totalTypedExprs, totalLetTypes, totalSymTypes := 0, 0, 0
+	for _, p := range pkgPaths {
+		cr, ok := checks[p]
+		if !ok || cr == nil {
+			continue
+		}
+		checkDiags = append(checkDiags, cr.Diags...)
+		for _, t := range cr.Types {
+			if !types.IsError(t) {
+				totalTypedExprs++
+			}
+		}
+		totalLetTypes += len(cr.LetTypes)
+		totalSymTypes += len(cr.SymTypes)
+	}
+	r.AllDiags = append(r.AllDiags, checkDiags...)
+	emit(Stage{
+		Name:     "check",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d typed exprs, %d let bindings", totalTypedExprs, totalLetTypes),
+		Errors:   countSeverity(checkDiags, diag.Error),
+		Warnings: countSeverity(checkDiags, diag.Warning),
+		Counts: map[string]int{
+			"typed_exprs": totalTypedExprs,
+			"let_types":   totalLetTypes,
+			"sym_types":   totalSymTypes,
+		},
+	})
+
+	// --- lint (per-file across every package) ---
+	t0 = time.Now()
+	var lintDiags []*diag.Diagnostic
+	for _, p := range pkgPaths {
+		pkg := ws.Packages[p]
+		cr := checks[p]
+		if pkg == nil || cr == nil {
+			continue
+		}
+		for _, pf := range pkg.Files {
+			fileRes := &resolve.Result{
+				Refs:      pf.Refs,
+				TypeRefs:  pf.TypeRefs,
+				FileScope: pf.FileScope,
+			}
+			lr := lint.File(pf.File, fileRes, cr)
+			lintDiags = append(lintDiags, lr.Diags...)
+		}
+	}
+	r.AllDiags = append(r.AllDiags, lintDiags...)
+	emit(Stage{
+		Name:     "lint",
+		Duration: time.Since(t0),
+		Output:   fmt.Sprintf("%d lint findings (across %d packages)", len(lintDiags), len(pkgPaths)),
+		Errors:   countSeverity(lintDiags, diag.Error),
+		Warnings: countSeverity(lintDiags, diag.Warning),
+		Counts:   map[string]int{"findings": len(lintDiags)},
+	})
+
+	// --- gen (workspace-wide aggregation) ---
+	if cfg.RunGen {
+		t0 = time.Now()
+		var genBuf []byte
+		var firstErr error
+		genErrs := 0
+		for _, p := range pkgPaths {
+			pkg := ws.Packages[p]
+			cr := checks[p]
+			if pkg == nil || cr == nil {
+				continue
+			}
+			pkgName := cfg.GenPackageName
+			if pkgName == "" {
+				pkgName = pkg.Name
+			}
+			for _, pf := range pkg.Files {
+				if pf.File == nil {
+					continue
+				}
+				fileRes := &resolve.Result{
+					Refs:      pf.Refs,
+					TypeRefs:  pf.TypeRefs,
+					FileScope: pf.FileScope,
+				}
+				out, err := gen.Generate(pkgName, pf.File, fileRes, cr)
+				header := fmt.Sprintf("\n// ---- %s ----\n", pf.Path)
+				genBuf = append(genBuf, []byte(header)...)
+				genBuf = append(genBuf, out...)
+				if err != nil {
+					genErrs++
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			}
+		}
+		r.GenBytes = genBuf
+		r.GenError = firstErr
+		summary := fmt.Sprintf("%d bytes Go (across %d packages)", len(genBuf), len(pkgPaths))
+		if firstErr != nil {
+			summary = fmt.Sprintf("%d bytes Go, %d file error(s); first: %v",
+				len(genBuf), genErrs, firstErr)
+		}
+		emit(Stage{
+			Name:     "gen",
+			Duration: time.Since(t0),
+			Output:   summary,
+			Errors:   genErrs,
+			Warnings: 0,
+			Counts: map[string]int{
+				"bytes":       len(genBuf),
+				"file_errors": genErrs,
+			},
+		})
 	}
 
 	return r, nil

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -107,3 +107,59 @@ func TestRenderJSON(t *testing.T) {
 		t.Errorf("expected 5 stages in JSON, got %d", len(doc.Stages))
 	}
 }
+
+// PerDecl should record one entry per (decl, phase) pair when enabled.
+// cleanSrc has one fn (main), so we expect exactly two entries:
+// one for collect, one for check.
+func TestRunPerDecl(t *testing.T) {
+	r := RunWithConfig([]byte(cleanSrc), nil, Config{PerDecl: true})
+	if len(r.PerDecl) != 2 {
+		t.Fatalf("PerDecl: got %d entries, want 2; entries=%+v", len(r.PerDecl), r.PerDecl)
+	}
+	phases := map[string]bool{}
+	for _, dt := range r.PerDecl {
+		if dt.Name != "main" {
+			t.Errorf("PerDecl entry name = %q, want main", dt.Name)
+		}
+		if dt.Kind != "fn" {
+			t.Errorf("PerDecl entry kind = %q, want fn", dt.Kind)
+		}
+		phases[dt.Phase] = true
+	}
+	for _, want := range []string{"collect", "check"} {
+		if !phases[want] {
+			t.Errorf("PerDecl missing %q phase", want)
+		}
+	}
+}
+
+// RunGen should append a sixth "gen" stage and populate GenBytes on a
+// Phase-1-clean program. cleanSrc only uses primitives + println, both
+// covered by Phase 1.
+func TestRunGen(t *testing.T) {
+	r := RunWithConfig([]byte(cleanSrc), nil, Config{RunGen: true})
+	if len(r.Stages) != 6 {
+		t.Fatalf("Stages: got %d, want 6 (lex/parse/resolve/check/lint/gen); names=%v",
+			len(r.Stages), stageNames(r.Stages))
+	}
+	if r.Stages[5].Name != "gen" {
+		t.Errorf("Stages[5].Name = %q, want gen", r.Stages[5].Name)
+	}
+	if len(r.GenBytes) == 0 {
+		t.Errorf("GenBytes is empty after a successful gen on clean source")
+	}
+	if r.GenError != nil {
+		t.Errorf("GenError = %v on clean source", r.GenError)
+	}
+	if !strings.Contains(string(r.GenBytes), "package main") {
+		t.Errorf("GenBytes missing 'package main' clause; got: %s", r.GenBytes)
+	}
+}
+
+func stageNames(ss []Stage) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.Name
+	}
+	return out
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,109 @@
+package pipeline
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const cleanSrc = `fn main() {
+    let n = 1 + 2
+    println(n)
+}
+`
+
+const dirtySrc = `fn main() {
+    let x = undefined_name
+}
+`
+
+// Run on a syntactically valid, type-clean program should report
+// every phase, no errors, and finite timings.
+func TestRunCleanProgram(t *testing.T) {
+	r := Run([]byte(cleanSrc), nil)
+	wantPhases := []string{"lex", "parse", "resolve", "check", "lint"}
+	if got := len(r.Stages); got != len(wantPhases) {
+		t.Fatalf("Stages: got %d, want %d", got, len(wantPhases))
+	}
+	for i, want := range wantPhases {
+		if r.Stages[i].Name != want {
+			t.Errorf("Stages[%d].Name = %q, want %q", i, r.Stages[i].Name, want)
+		}
+		if r.Stages[i].Errors != 0 {
+			t.Errorf("Stages[%d] (%s) reported %d errors on clean source",
+				i, r.Stages[i].Name, r.Stages[i].Errors)
+		}
+	}
+	if r.File == nil {
+		t.Errorf("File is nil after parse")
+	}
+	if r.Resolve == nil || r.Check == nil || r.Lint == nil {
+		t.Errorf("missing phase artefacts: resolve=%v check=%v lint=%v",
+			r.Resolve != nil, r.Check != nil, r.Lint != nil)
+	}
+}
+
+// A program with an undefined name should surface at least one
+// resolve-phase error in the stage stats and AllDiags.
+func TestRunReportsErrors(t *testing.T) {
+	r := Run([]byte(dirtySrc), nil)
+	var resolveErrs int
+	for _, s := range r.Stages {
+		if s.Name == "resolve" {
+			resolveErrs = s.Errors
+			break
+		}
+	}
+	if resolveErrs == 0 {
+		t.Fatalf("expected at least one resolve error for undefined name; stages=%+v", r.Stages)
+	}
+	if len(r.AllDiags) == 0 {
+		t.Fatalf("AllDiags empty; expected at least one diagnostic")
+	}
+}
+
+// The trace stream should receive one line per phase, in order.
+func TestRunStreamsTrace(t *testing.T) {
+	var buf bytes.Buffer
+	Run([]byte(cleanSrc), &buf)
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 5 {
+		t.Fatalf("trace stream: got %d lines, want 5\nfull output:\n%s", len(lines), buf.String())
+	}
+	for _, want := range []string{"lex", "parse", "resolve", "check", "lint"} {
+		found := false
+		for _, line := range lines {
+			if strings.Contains(line, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("trace stream missing %q phase\nfull output:\n%s", want, buf.String())
+		}
+	}
+}
+
+// RenderJSON should produce a valid document with the expected
+// top-level keys and one entry per phase.
+func TestRenderJSON(t *testing.T) {
+	r := Run([]byte(cleanSrc), nil)
+	var buf bytes.Buffer
+	if err := r.RenderJSON(&buf); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+	var doc struct {
+		Stages []struct {
+			Name       string  `json:"name"`
+			DurationMS float64 `json:"duration_ms"`
+		} `json:"stages"`
+		DiagnosticsByCode map[string]int `json:"diagnostics_by_code"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, buf.String())
+	}
+	if len(doc.Stages) != 5 {
+		t.Errorf("expected 5 stages in JSON, got %d", len(doc.Stages))
+	}
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -156,6 +156,61 @@ func TestRunGen(t *testing.T) {
 	}
 }
 
+// Compare(baseline, current) should produce a per-stage delta whose
+// signs reflect the relative timings, and a diff histogram only for
+// codes whose counts changed.
+func TestCompareBasic(t *testing.T) {
+	baseline := Snapshot{
+		Stages: []SnapshotStage{
+			{Name: "lex", DurationMS: 1.0, Errors: 0},
+			{Name: "parse", DurationMS: 2.0, Errors: 1},
+		},
+		DiagnosticsByCode: map[string]int{"E0001": 1, "E0002": 2},
+	}
+	current := Result{
+		Stages: []Stage{
+			{Name: "lex", Duration: 2 * 1000 * 1000, Errors: 0},   // 2.0ms
+			{Name: "parse", Duration: 1 * 1000 * 1000, Errors: 0}, // 1.0ms
+		},
+	}
+	cmp := Compare(baseline, current)
+	if len(cmp.Stages) != 2 {
+		t.Fatalf("Stages: got %d, want 2", len(cmp.Stages))
+	}
+	if cmp.Stages[0].Name != "lex" || cmp.Stages[0].DeltaMS <= 0 {
+		t.Errorf("lex delta should be positive (slower); got %+v", cmp.Stages[0])
+	}
+	if cmp.Stages[1].Name != "parse" || cmp.Stages[1].DeltaMS >= 0 {
+		t.Errorf("parse delta should be negative (faster); got %+v", cmp.Stages[1])
+	}
+}
+
+// Snapshot round-trip: a Result → JSON → LoadSnapshot → Snapshot
+// should preserve the per-stage counts, output strings, and diag hist.
+func TestSnapshotRoundTrip(t *testing.T) {
+	r := Run([]byte(cleanSrc), nil)
+	var buf bytes.Buffer
+	if err := r.RenderJSON(&buf); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+	snap, err := LoadSnapshot(&buf)
+	if err != nil {
+		t.Fatalf("LoadSnapshot: %v", err)
+	}
+	if len(snap.Stages) != len(r.Stages) {
+		t.Errorf("stage count mismatch: snap=%d, result=%d",
+			len(snap.Stages), len(r.Stages))
+	}
+	for i, s := range snap.Stages {
+		if s.Name != r.Stages[i].Name {
+			t.Errorf("stage[%d].Name = %q, want %q", i, s.Name, r.Stages[i].Name)
+		}
+		if s.Output != r.Stages[i].Output {
+			t.Errorf("stage[%d].Output = %q, want %q", i, s.Output, r.Stages[i].Output)
+		}
+	}
+}
+
 func stageNames(ss []Stage) []string {
 	out := make([]string, len(ss))
 	for i, s := range ss {


### PR DESCRIPTION
## Summary

Adds a new `osty explain CODE` subcommand that lets users (and contributors) look up any compiler diagnostic without grepping `ERROR_CODES.md` by hand.

This addresses the "explain diagnostics" item from the broader debug/introspection wishlist (#9). The other items on that list — AST dump (`osty parse`), token dump (`osty tokens`), resolve dump (`osty resolve --scopes`), type dump (`osty typecheck`), transpiled-Go inspection (`osty gen`) — are already wired; the unified diagnostic-lookup command was the conspicuous gap.

### What's new

- `osty explain E0500` → prints summary, spec ref, example, fix for the code.
- `osty explain L0001` / `osty explain unused_let` → delegates to the existing `lint.LookupRule` so behaviour matches the long-standing `osty lint --explain` shortcut.
- `osty explain` (no arg) → tab-separated index of every code (`E*`, `W*`, `L*`) for piping into `grep`/`fzf`.
- Unknown codes exit `2` with a hint pointing at the no-arg listing.

### How it works

- `internal/diag/explain.go` embeds `codes.go` via `//go:embed` and parses the structured doc comments at init time.
- The parser is a trimmed port of the logic in `cmd/codesdoc/main.go` (which already powers `ERROR_CODES.md`); the two stay in sync because they read the same source-of-truth comments.
- The new package surface is two functions: `diag.Explain(code) (CodeDoc, bool)` and `diag.AllCodes() []CodeDoc`. Future consumers (LSP hover, IDE plugins) can reuse them without spawning a subprocess or shipping the markdown.

### Files

- `internal/diag/explain.go` — embed + parser + `Explain` / `AllCodes`.
- `internal/diag/explain_test.go` — smoke tests for known/unknown codes and the all-codes invariant.
- `cmd/osty/explain.go` — subcommand handler + lint delegation.
- `cmd/osty/main.go` — dispatch + usage line.
- `README.md` — CLI listing.

## Test plan

- [x] `go test ./internal/diag` — new explain tests pass; existing tests untouched.
- [x] `go test ./cmd/osty ./cmd/codesdoc` — pass.
- [x] `go vet ./...` — clean.
- [x] `osty explain E0001` — prints summary + example + fix.
- [x] `osty explain L0001` / `osty explain unused_let` — matches `osty lint --explain` output.
- [x] `osty explain E9999` — exits 2 with hint.
- [x] `osty explain` (no arg) — lists 164 entries.
- [ ] Pre-existing `internal/format` golden test failure (`TestGolden/chains`) is unrelated to this change — confirmed by stashing and re-running on `main`.
