### PR TITLE
scaffold: add --cli and --service project templates

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -106,6 +106,14 @@ func main() {
 		runInit(args[1:])
 		return
 	}
+	// scaffold is the umbrella command for one-off code generators
+	// that aren't whole-project scaffolds. Sub-subcommands so far:
+	// fixture (table-test starter), schema (JSON sample → struct),
+	// and ffi (C header → Osty wrapper stubs).
+	if cmd == "scaffold" {
+		runScaffold(args[1:])
+		return
+	}
 	// build is the manifest-driven front-end over a directory. When
 	// passed a directory it loads osty.toml, validates, and runs
 	// check + lint across the package(s) the manifest describes.

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1097,20 +1097,22 @@ func runGen(args []string, flags cliFlags) {
 func runNew(args []string) {
 	fs := flag.NewFlagSet("new", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty new [--bin|--lib|--workspace] [--member NAME] NAME")
+		fmt.Fprintln(os.Stderr, "usage: osty new [--bin|--lib|--workspace|--cli|--service] [--member NAME] NAME")
 	}
-	var libMode, binMode, wsMode bool
+	var libMode, binMode, wsMode, cliMode, svcMode bool
 	var member string
 	fs.BoolVar(&libMode, "lib", false, "scaffold a library project (lib.osty, no main)")
 	fs.BoolVar(&binMode, "bin", false, "scaffold a binary project (main.osty) [default]")
 	fs.BoolVar(&wsMode, "workspace", false, "scaffold a virtual workspace with one default member")
+	fs.BoolVar(&cliMode, "cli", false, "scaffold a CLI app (Args struct + run() core)")
+	fs.BoolVar(&svcMode, "service", false, "scaffold an HTTP service (Request/Response + handle())")
 	fs.StringVar(&member, "member", "core", "default-member directory name when --workspace is set")
 	_ = fs.Parse(args)
 	if fs.NArg() != 1 {
 		fs.Usage()
 		os.Exit(2)
 	}
-	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode)
+	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode)
 	if usageErr != "" {
 		fmt.Fprintln(os.Stderr, "osty new:", usageErr)
 		os.Exit(2)
@@ -1134,13 +1136,15 @@ func runNew(args []string) {
 func runInit(args []string) {
 	fs := flag.NewFlagSet("init", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty init [--bin|--lib|--workspace] [--name NAME] [--member NAME]")
+		fmt.Fprintln(os.Stderr, "usage: osty init [--bin|--lib|--workspace|--cli|--service] [--name NAME] [--member NAME]")
 	}
-	var libMode, binMode, wsMode bool
+	var libMode, binMode, wsMode, cliMode, svcMode bool
 	var name, member string
 	fs.BoolVar(&libMode, "lib", false, "scaffold a library project (lib.osty, no main)")
 	fs.BoolVar(&binMode, "bin", false, "scaffold a binary project (main.osty) [default]")
 	fs.BoolVar(&wsMode, "workspace", false, "scaffold a virtual workspace with one default member")
+	fs.BoolVar(&cliMode, "cli", false, "scaffold a CLI app (Args struct + run() core)")
+	fs.BoolVar(&svcMode, "service", false, "scaffold an HTTP service (Request/Response + handle())")
 	fs.StringVar(&name, "name", "", "project name (defaults to current directory basename)")
 	fs.StringVar(&member, "member", "core", "default-member directory name when --workspace is set")
 	_ = fs.Parse(args)
@@ -1148,7 +1152,7 @@ func runInit(args []string) {
 		fs.Usage()
 		os.Exit(2)
 	}
-	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode)
+	kind, usageErr := pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode)
 	if usageErr != "" {
 		fmt.Fprintln(os.Stderr, "osty init:", usageErr)
 		os.Exit(2)
@@ -1173,7 +1177,7 @@ func runInit(args []string) {
 // pickScaffoldKind validates the mutually-exclusive kind flags and
 // returns the selected Kind plus an empty string, or the zero Kind
 // and a one-line usage error message.
-func pickScaffoldKind(libMode, binMode, wsMode bool) (scaffold.Kind, string) {
+func pickScaffoldKind(libMode, binMode, wsMode, cliMode, svcMode bool) (scaffold.Kind, string) {
 	count := 0
 	if libMode {
 		count++
@@ -1184,14 +1188,24 @@ func pickScaffoldKind(libMode, binMode, wsMode bool) (scaffold.Kind, string) {
 	if wsMode {
 		count++
 	}
+	if cliMode {
+		count++
+	}
+	if svcMode {
+		count++
+	}
 	if count > 1 {
-		return 0, "--bin, --lib, and --workspace are mutually exclusive"
+		return 0, "--bin, --lib, --workspace, --cli, and --service are mutually exclusive"
 	}
 	switch {
 	case libMode:
 		return scaffold.KindLib, ""
 	case wsMode:
 		return scaffold.KindWorkspace, ""
+	case cliMode:
+		return scaffold.KindCli, ""
+	case svcMode:
+		return scaffold.KindService, ""
 	default:
 		return scaffold.KindBin, ""
 	}
@@ -1205,6 +1219,10 @@ func kindLabel(k scaffold.Kind) string {
 		return "library project"
 	case scaffold.KindWorkspace:
 		return "workspace"
+	case scaffold.KindCli:
+		return "CLI app project"
+	case scaffold.KindService:
+		return "HTTP service project"
 	default:
 		return "binary project"
 	}

--- a/cmd/osty/scaffold_cmd.go
+++ b/cmd/osty/scaffold_cmd.go
@@ -1,0 +1,135 @@
+// scaffold_cmd.go — `osty scaffold` subcommand dispatcher.
+//
+// This is the CLI side of the small code-generation tools that live
+// in internal/scaffold (fixture / schema / ffi). They share a flag
+// shape — every generator takes `--out DIR` (default ".") and
+// produces a single .osty file derived from the positional NAME — so
+// the dispatcher centralises argument parsing and exit-code mapping.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/scaffold"
+)
+
+// runScaffold dispatches `osty scaffold <kind> ...` to the per-kind
+// runner. An unknown kind exits 2 with a usage message so the user
+// sees the full set of generators at a glance.
+func runScaffold(args []string) {
+	if len(args) < 1 {
+		scaffoldUsage()
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "fixture":
+		runScaffoldFixture(args[1:])
+	case "schema":
+		runScaffoldSchema(args[1:])
+	case "ffi":
+		runScaffoldFFI(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "osty scaffold: unknown generator %q\n", args[0])
+		scaffoldUsage()
+		os.Exit(2)
+	}
+}
+
+func scaffoldUsage() {
+	fmt.Fprintln(os.Stderr, "usage: osty scaffold <fixture|schema|ffi> [flags] NAME")
+	fmt.Fprintln(os.Stderr, "  fixture NAME [--cases N] [--out DIR]")
+	fmt.Fprintln(os.Stderr, "      generate a table-driven `*_test.osty` skeleton")
+	fmt.Fprintln(os.Stderr, "  schema NAME --from FILE.json [--out DIR]")
+	fmt.Fprintln(os.Stderr, "      infer a `pub struct` from a JSON sample payload")
+	fmt.Fprintln(os.Stderr, "  ffi NAME --header FILE.h [--out DIR]")
+	fmt.Fprintln(os.Stderr, "      emit Osty wrapper stubs for top-level C function decls")
+}
+
+func runScaffoldFixture(args []string) {
+	fs := flag.NewFlagSet("scaffold fixture", flag.ExitOnError)
+	var cases int
+	var out string
+	fs.IntVar(&cases, "cases", 3, "number of placeholder rows in the generated table")
+	fs.StringVar(&out, "out", ".", "directory to write the fixture into")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty scaffold fixture NAME [--cases N] [--out DIR]")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	path, d := scaffold.WriteFixture(out, scaffold.FixtureOptions{
+		Name:  fs.Arg(0),
+		Cases: cases,
+	})
+	if d != nil {
+		printScaffoldDiag(d)
+		os.Exit(scaffoldExitCode(d))
+	}
+	fmt.Printf("Wrote fixture %s\n", path)
+}
+
+func runScaffoldSchema(args []string) {
+	fs := flag.NewFlagSet("scaffold schema", flag.ExitOnError)
+	var from, out string
+	fs.StringVar(&from, "from", "", "path to a JSON sample (object) to infer fields from")
+	fs.StringVar(&out, "out", ".", "directory to write the generated struct into")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty scaffold schema NAME --from FILE.json [--out DIR]")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 || from == "" {
+		fs.Usage()
+		os.Exit(2)
+	}
+	sample, err := os.ReadFile(from)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty scaffold schema: %v\n", err)
+		os.Exit(1)
+	}
+	path, d := scaffold.WriteSchema(out, scaffold.SchemaOptions{
+		Name:   fs.Arg(0),
+		Sample: sample,
+	})
+	if d != nil {
+		printScaffoldDiag(d)
+		os.Exit(scaffoldExitCode(d))
+	}
+	fmt.Printf("Wrote schema %s\n", path)
+}
+
+func runScaffoldFFI(args []string) {
+	fs := flag.NewFlagSet("scaffold ffi", flag.ExitOnError)
+	var header, out string
+	fs.StringVar(&header, "header", "", "path to a C header to scan for `<retType> <name>(<args>);` decls")
+	fs.StringVar(&out, "out", ".", "directory to write the generated bindings into")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty scaffold ffi NAME --header FILE.h [--out DIR]")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 || header == "" {
+		fs.Usage()
+		os.Exit(2)
+	}
+	src, err := os.ReadFile(header)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty scaffold ffi: %v\n", err)
+		os.Exit(1)
+	}
+	path, d := scaffold.WriteFFI(out, scaffold.FFIOptions{
+		Module: fs.Arg(0),
+		Header: src,
+	})
+	if d != nil {
+		printScaffoldDiag(d)
+		os.Exit(scaffoldExitCode(d))
+	}
+	fmt.Printf("Wrote FFI bindings %s\n", path)
+}

--- a/internal/scaffold/ffi.go
+++ b/internal/scaffold/ffi.go
@@ -1,0 +1,452 @@
+package scaffold
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/osty/osty/internal/diag"
+)
+
+// FFIOptions configures the C-header → Osty wrapper-stub generator.
+//
+// The generator is intentionally narrow: it scans for top-level C
+// function declarations of the form `<retType> <name>(<args>);` and
+// emits one Osty wrapper per match. It does not understand typedefs,
+// macros, struct definitions, or function pointers — anything it
+// can't parse is summarised as an `// unparsed:` comment so the user
+// can refine the output by hand. The result is a starting point for a
+// binding, not a finished one.
+//
+// Osty has no surface syntax for `extern fn` yet, so wrappers are
+// emitted as `pub fn` with a `todo()` body and a doc comment that
+// records the original C signature. When real FFI lands, the
+// scaffold can switch to whatever syntax the spec adopts without the
+// user having to retype the function names.
+type FFIOptions struct {
+	// Module is the Osty type/module label that namespaces the
+	// generated wrappers. Used as the filename and as a `// {Module}
+	// FFI bindings` header comment.
+	Module string
+	// Header is the raw C header bytes. Whitespace, multi-line
+	// declarations, and `//` / `/* */` comments are tolerated; the
+	// parser strips comments before scanning.
+	Header []byte
+}
+
+// RenderFFI parses opts.Header and returns the generated Osty source.
+// The output is always a syntactically valid Osty file, even when no
+// declarations could be parsed — in that case it contains only the
+// header comment plus a single `unparsed` note so the user gets a
+// usable file to edit rather than an empty one.
+func RenderFFI(opts FFIOptions) (string, *diag.Diagnostic) {
+	if d := ValidateName(opts.Module); d != nil {
+		return "", d
+	}
+	decls, unparsed := parseCDecls(opts.Header)
+
+	module := identForName(opts.Module)
+	var b strings.Builder
+	fmt.Fprintf(&b, "// %s.osty — FFI binding stubs for the %q C header.\n", strings.ToLower(module), opts.Module)
+	b.WriteString("//\n")
+	b.WriteString("// Each wrapper records the original C signature in its doc\n")
+	b.WriteString("// comment. The bodies are `todo()` placeholders — replace them\n")
+	b.WriteString("// with real calls once the project picks an FFI mechanism\n")
+	b.WriteString("// (cgo shim, std.ffi, or a user-supplied bridge).\n\n")
+	b.WriteString("use std.process\n\n")
+
+	if len(decls) == 0 {
+		b.WriteString("// No C function declarations were recognised in the input.\n")
+		b.WriteString("// The generator only handles top-level `<retType> <name>(<args>);`\n")
+		b.WriteString("// forms — typedefs, macros, and struct definitions are skipped.\n")
+	}
+	for i, d := range decls {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "/// C: `%s`\n", d.original)
+		fmt.Fprintf(&b, "pub fn %s(%s) -> %s {\n", camelCase(d.name), formatOstyParams(d.params), d.osRetType())
+		fmt.Fprintf(&b, "    process.todo(\"%s: not yet wired through FFI\")\n", d.name)
+		b.WriteString("}\n")
+	}
+	if len(unparsed) > 0 {
+		b.WriteString("\n// unparsed declarations (the generator could not map these to Osty):\n")
+		for _, line := range unparsed {
+			fmt.Fprintf(&b, "//   %s\n", line)
+		}
+	}
+	return b.String(), nil
+}
+
+// WriteFFI writes the rendered binding to `<dir>/<module>.osty`.
+func WriteFFI(dir string, opts FFIOptions) (string, *diag.Diagnostic) {
+	src, d := RenderFFI(opts)
+	if d != nil {
+		return "", d
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", ioErr(dir, err)
+	}
+	base := strings.ToLower(identForName(opts.Module))
+	path := filepath.Join(abs, base+".osty")
+	if _, err := os.Stat(path); err == nil {
+		return "", existsDiag(path)
+	} else if !os.IsNotExist(err) {
+		return "", ioErr(path, err)
+	}
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		return "", ioErr(path, err)
+	}
+	return path, nil
+}
+
+// cDecl captures one parsed C function declaration. `original` is
+// the cleaned single-line form rendered into the doc comment;
+// `params` may be empty for a no-arg function.
+type cDecl struct {
+	original string
+	retType  string
+	name     string
+	params   []cParam
+}
+
+type cParam struct {
+	name string
+	typ  string
+}
+
+// osRetType maps the C return type to the closest Osty type. Void
+// becomes `()` (Osty's unit type); pointer-to-`char` becomes
+// `String`; the integer family collapses to `Int` or its sized
+// variants. Anything we can't classify is rendered as `Json` so the
+// stub still parses — the user is expected to refine the signature.
+func (d cDecl) osRetType() string {
+	return mapCType(d.retType)
+}
+
+// parseCDecls strips C/C++ comments and scans the result for
+// top-level function declarations. It returns the parsed entries in
+// declaration order plus a list of lines it considered but couldn't
+// classify (so the user gets a checklist of what to clean up by hand).
+func parseCDecls(src []byte) (parsed []cDecl, unparsed []string) {
+	clean := stripCComments(src)
+	// Glue declarations split across lines back together: real
+	// headers wrap long argument lists. We cut on `;` after
+	// normalising whitespace.
+	var current strings.Builder
+	flush := func() {
+		stmt := strings.TrimSpace(collapseWS(current.String()))
+		current.Reset()
+		if stmt == "" {
+			return
+		}
+		if d, ok := matchCDecl(stmt); ok {
+			parsed = append(parsed, d)
+		} else if isPotentialDecl(stmt) {
+			unparsed = append(unparsed, stmt)
+		}
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(clean))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip preprocessor directives entirely — they're not
+		// declarations and accumulating them into `current` would
+		// glue them onto whatever real declaration appears next.
+		if preprocessorRE.MatchString(line) {
+			continue
+		}
+		current.WriteString(line)
+		current.WriteString(" ")
+		// A `;` terminates the statement. Some headers chain
+		// declarations on one line; split on every `;`.
+		if strings.Contains(line, ";") {
+			parts := strings.Split(current.String(), ";")
+			current.Reset()
+			for i, p := range parts {
+				if i == len(parts)-1 {
+					// trailing fragment after the last `;` — keep
+					// for the next iteration
+					current.WriteString(p)
+					continue
+				}
+				current.WriteString(p)
+				current.WriteString(";")
+				flush()
+			}
+		}
+	}
+	flush()
+	return parsed, unparsed
+}
+
+// stripCComments removes both `//` line comments and `/* */` block
+// comments. Strings are not stripped — headers don't generally
+// contain `*/` inside string literals, and the alternative is a
+// proper tokenizer which is overkill for a scaffolding tool.
+func stripCComments(src []byte) []byte {
+	var out bytes.Buffer
+	in := src
+	for len(in) > 0 {
+		if len(in) >= 2 && in[0] == '/' && in[1] == '/' {
+			i := bytes.IndexByte(in, '\n')
+			if i < 0 {
+				return out.Bytes()
+			}
+			out.WriteByte('\n')
+			in = in[i+1:]
+			continue
+		}
+		if len(in) >= 2 && in[0] == '/' && in[1] == '*' {
+			end := bytes.Index(in[2:], []byte("*/"))
+			if end < 0 {
+				return out.Bytes()
+			}
+			out.WriteByte(' ')
+			in = in[2+end+2:]
+			continue
+		}
+		out.WriteByte(in[0])
+		in = in[1:]
+	}
+	return out.Bytes()
+}
+
+func collapseWS(s string) string {
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range s {
+		if r == '\t' || r == '\n' || r == '\r' || r == ' ' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	return b.String()
+}
+
+// declRE captures `[storage] retType name(args);` where `args` is
+// arbitrarily complex and may itself contain commas. We let the
+// regex grab everything up to the closing `)` and parse the args
+// list in a second pass.
+var declRE = regexp.MustCompile(`^(?:extern\s+|static\s+)*([A-Za-z_][\w\s\*]*?)\s+\*?\s*([A-Za-z_]\w*)\s*\(([^)]*)\)\s*;?$`)
+
+// preprocessorRE catches `#include`, `#define`, `#ifdef`, etc. Those
+// lines are skipped silently — they're not declarations and we don't
+// want them in the unparsed list.
+var preprocessorRE = regexp.MustCompile(`^\s*#`)
+
+func matchCDecl(stmt string) (cDecl, bool) {
+	if preprocessorRE.MatchString(stmt) {
+		return cDecl{}, false
+	}
+	m := declRE.FindStringSubmatch(stmt)
+	if m == nil {
+		return cDecl{}, false
+	}
+	retType := strings.TrimSpace(m[1])
+	name := strings.TrimSpace(m[2])
+	rawArgs := strings.TrimSpace(m[3])
+	// Detect pointer-return: if the regex consumed the `*` into the
+	// type, it's already there; if it sits between type and name,
+	// our regex captures it as part of name with a leading `*`. Be
+	// tolerant.
+	if strings.HasPrefix(name, "*") {
+		retType = retType + " *"
+		name = strings.TrimPrefix(name, "*")
+	}
+	params, ok := parseCParams(rawArgs)
+	if !ok {
+		return cDecl{}, false
+	}
+	return cDecl{
+		original: stmt,
+		retType:  retType,
+		name:     name,
+		params:   params,
+	}, true
+}
+
+// parseCParams splits a comma-separated parameter list. `void` (with
+// no name) is treated as "no parameters". Anonymous parameters
+// (`int`, `const char *`) get synthesised `arg0`-style names so the
+// Osty signature is well-formed.
+func parseCParams(raw string) ([]cParam, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "void" {
+		return nil, true
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]cParam, 0, len(parts))
+	for i, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return nil, false
+		}
+		// Variadic / function pointer / array param — out of scope
+		// for the scaffold. Refuse the whole declaration so it
+		// shows up in `unparsed` rather than producing a
+		// half-correct Osty signature.
+		if strings.Contains(p, "...") || strings.Contains(p, "(") || strings.Contains(p, "[") {
+			return nil, false
+		}
+		fields := strings.Fields(p)
+		var name, typ string
+		if len(fields) == 1 {
+			// Type-only parameter (e.g. `int`). Synthesise a name.
+			name = fmt.Sprintf("arg%d", i)
+			typ = fields[0]
+		} else {
+			last := fields[len(fields)-1]
+			stars := ""
+			for strings.HasPrefix(last, "*") {
+				stars += "*"
+				last = last[1:]
+			}
+			if last == "" {
+				// `const char *` — the trailing `*` was alone; the
+				// previous tokens are the full type and the param
+				// has no name in the source.
+				name = fmt.Sprintf("arg%d", i)
+				typ = strings.TrimSpace(strings.Join(fields[:len(fields)-1], " ") + " " + stars)
+			} else {
+				// `const char *path` — `last` is the param name,
+				// the stars belong on the type.
+				name = last
+				typ = strings.TrimSpace(strings.Join(fields[:len(fields)-1], " ") + " " + stars)
+			}
+		}
+		out = append(out, cParam{name: camelCase(name), typ: typ})
+	}
+	return out, true
+}
+
+func formatOstyParams(ps []cParam) string {
+	var b strings.Builder
+	for i, p := range ps {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s: %s", p.name, mapCType(p.typ))
+	}
+	return b.String()
+}
+
+// mapCType maps a C type spelling to an Osty type. The mapping is
+// deliberately small — anything we can't classify becomes `Json`,
+// which is the project's opaque-value placeholder, so the generated
+// file always parses.
+func mapCType(c string) string {
+	c = strings.TrimSpace(c)
+	c = strings.ReplaceAll(c, "const ", "")
+	c = collapseWS(c)
+	c = strings.TrimSpace(c)
+	if c == "" {
+		return "()"
+	}
+	switch c {
+	case "void":
+		return "()"
+	case "char *", "char*", "const char *", "char *const":
+		return "String"
+	case "int", "signed int":
+		return "Int32"
+	case "unsigned int", "uint":
+		return "UInt32"
+	case "long", "long int", "signed long":
+		return "Int64"
+	case "unsigned long", "unsigned long int":
+		return "UInt64"
+	case "short", "short int":
+		return "Int16"
+	case "unsigned short":
+		return "UInt16"
+	case "char", "signed char":
+		return "Int8"
+	case "unsigned char", "uint8_t":
+		return "UInt8"
+	case "uint16_t":
+		return "UInt16"
+	case "uint32_t":
+		return "UInt32"
+	case "uint64_t", "size_t":
+		return "UInt64"
+	case "int8_t":
+		return "Int8"
+	case "int16_t":
+		return "Int16"
+	case "int32_t":
+		return "Int32"
+	case "int64_t", "ssize_t":
+		return "Int64"
+	case "float":
+		return "Float32"
+	case "double":
+		return "Float64"
+	case "bool", "_Bool":
+		return "Bool"
+	}
+	if strings.HasSuffix(c, "*") {
+		// Pointer to something we don't recognise — Osty has no
+		// raw-pointer surface, so the conservative scaffold maps it
+		// to the opaque `Json` placeholder.
+		return "Json"
+	}
+	return "Json"
+}
+
+// camelCase converts a snake_case C identifier to camelCase Osty
+// style (spec §1.4). Leading underscores are preserved.
+func camelCase(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	upper := false
+	leading := true
+	for _, r := range s {
+		if r == '_' {
+			if leading {
+				b.WriteByte('_')
+				continue
+			}
+			upper = true
+			continue
+		}
+		leading = false
+		if upper {
+			b.WriteRune(toUpper(r))
+			upper = false
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// isPotentialDecl filters which not-recognised statements deserve to
+// be flagged in `unparsed`. We only complain about lines that look
+// vaguely like declarations — bare `}` from a struct close, blank
+// remnants, and preprocessor lines are uninteresting.
+func isPotentialDecl(stmt string) bool {
+	if stmt == "" || stmt == "}" {
+		return false
+	}
+	if preprocessorRE.MatchString(stmt) {
+		return false
+	}
+	// Need at least one identifier and a `(` to be a function-ish
+	// declaration; otherwise it's likely a struct field, typedef,
+	// or extern variable — none of which the FFI scaffold handles.
+	return strings.Contains(stmt, "(") && strings.Contains(stmt, ")")
+}
+

--- a/internal/scaffold/fixture.go
+++ b/internal/scaffold/fixture.go
@@ -1,0 +1,161 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/token"
+)
+
+// FixtureOptions configures the table-test fixture generator.
+//
+// The generator emits a self-contained `_test.osty` file built around
+// a table-driven shape: a small `Case` struct, a function returning a
+// `List<Case>`, and one `test*` driver that walks the table. The
+// intent is to give users the structural skeleton they would type by
+// hand for any non-trivial test suite, rather than the single smoke
+// function the project starter ships with.
+type FixtureOptions struct {
+	// Name is used to derive both the filename (`{name}_test.osty`)
+	// and the symbols in the generated source. It must satisfy the
+	// same identifier rules ValidateName enforces; non-conforming
+	// names are rejected before any file is written.
+	Name string
+	// Cases is the number of placeholder rows generated in the table.
+	// A zero value defaults to 3 — enough rows to make the table
+	// shape visible without padding the file with copies.
+	Cases int
+}
+
+// RenderFixture returns the generated `_test.osty` source for opts.
+// Callers that just want the bytes (e.g. dry-run, tests) can use this
+// directly; WriteFixture is the path-aware helper for the CLI.
+func RenderFixture(opts FixtureOptions) (string, *diag.Diagnostic) {
+	if d := ValidateName(opts.Name); d != nil {
+		return "", d
+	}
+	cases := opts.Cases
+	if cases <= 0 {
+		cases = 3
+	}
+	if cases > 64 {
+		// Refuse pathological case counts — the generated file would
+		// be unreadable. 64 rows is well past any reasonable starter
+		// and still produces a file under a few KiB.
+		return "", diag.New(diag.Error,
+			fmt.Sprintf("fixture cases=%d exceeds the 64 row cap", cases)).
+			Code(diag.CodeScaffoldInvalidName).
+			PrimaryPos(token.Pos{Line: 1, Column: 1}, "").
+			Hint("pick a smaller --cases value; you can always add rows by hand").
+			Build()
+	}
+
+	pkgName := identForName(opts.Name)
+	caseType := titleCase(pkgName) + "Case"
+	tableFn := pkgName + "Cases"
+	testFn := "test" + titleCase(pkgName) + "Table"
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "// %s_test.osty — table-driven tests for %s.\n", opts.Name, opts.Name)
+	b.WriteString("//\n")
+	b.WriteString("// Each row in the table describes one scenario. Replace the\n")
+	b.WriteString("// placeholder `let _ = ...` lines with `testing.assertEq` (or\n")
+	b.WriteString("// the eventual std.testing equivalent) once the assertion\n")
+	b.WriteString("// surface lands (spec §10 / §11).\n\n")
+
+	fmt.Fprintf(&b, "struct %s {\n", caseType)
+	b.WriteString("    name: String,\n")
+	b.WriteString("    input: String,\n")
+	b.WriteString("    expected: String,\n")
+	b.WriteString("}\n\n")
+
+	fmt.Fprintf(&b, "fn %s() -> List<%s> {\n", tableFn, caseType)
+	b.WriteString("    [\n")
+	for i := 1; i <= cases; i++ {
+		fmt.Fprintf(&b, "        %s { name: \"case%d\", input: \"in%d\", expected: \"out%d\" },\n",
+			caseType, i, i, i)
+	}
+	b.WriteString("    ]\n")
+	b.WriteString("}\n\n")
+
+	fmt.Fprintf(&b, "fn %s() {\n", testFn)
+	fmt.Fprintf(&b, "    for c in %s() {\n", tableFn)
+	b.WriteString("        let _ = c.name\n")
+	b.WriteString("        let _ = c.input\n")
+	b.WriteString("        let _ = c.expected\n")
+	b.WriteString("    }\n")
+	b.WriteString("}\n")
+
+	return b.String(), nil
+}
+
+// WriteFixture renders the fixture and writes it to
+// `<dir>/<name>_test.osty`. Like the rest of the scaffolder, it
+// refuses to overwrite an existing file — call sites must remove the
+// conflict explicitly.
+func WriteFixture(dir string, opts FixtureOptions) (string, *diag.Diagnostic) {
+	src, d := RenderFixture(opts)
+	if d != nil {
+		return "", d
+	}
+	abs, derr := filepath.Abs(dir)
+	if derr != nil {
+		return "", ioErr(dir, derr)
+	}
+	path := filepath.Join(abs, opts.Name+"_test.osty")
+	if _, err := os.Stat(path); err == nil {
+		return "", existsDiag(path)
+	} else if !os.IsNotExist(err) {
+		return "", ioErr(path, err)
+	}
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		return "", ioErr(path, err)
+	}
+	return path, nil
+}
+
+// identForName lower-cases the first rune of name so it forms a valid
+// camelCase Osty identifier. ValidateName already accepts both
+// `myApp` and `MyApp`; the generator normalises to `myApp` so the
+// generated symbol style matches the rest of the language conventions
+// (spec §1.4).
+func identForName(name string) string {
+	if name == "" {
+		return name
+	}
+	r := []rune(name)
+	r[0] = unicode.ToLower(r[0])
+	// Strip hyphens — fixture names like "my-thing" become `myThing`
+	// in the source. Hyphens are valid as filenames but not as
+	// identifiers, so we have to fold them out.
+	out := make([]rune, 0, len(r))
+	upper := false
+	for _, c := range r {
+		if c == '-' {
+			upper = true
+			continue
+		}
+		if upper {
+			out = append(out, unicode.ToUpper(c))
+			upper = false
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// titleCase upper-cases the first rune. Used to derive Type-style
+// names from a value-style identifier.
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}

--- a/internal/scaffold/generators_test.go
+++ b/internal/scaffold/generators_test.go
@@ -1,0 +1,340 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+)
+
+// ---- fixture ----
+
+// TestRenderFixtureShape: the generated file contains the canonical
+// table-test pieces (Case struct, table-builder fn, driver test fn)
+// and includes exactly the requested number of rows.
+func TestRenderFixtureShape(t *testing.T) {
+	src, d := RenderFixture(FixtureOptions{Name: "user", Cases: 2})
+	if d != nil {
+		t.Fatalf("RenderFixture: %s", d.Error())
+	}
+	wants := []string{
+		"struct UserCase {",
+		"fn userCases() -> List<UserCase>",
+		"fn testUserTable()",
+		`name: "case1"`,
+		`name: "case2"`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(src, w) {
+			t.Errorf("fixture missing %q\n%s", w, src)
+		}
+	}
+	if strings.Contains(src, `name: "case3"`) {
+		t.Errorf("Cases=2 produced a case3 row:\n%s", src)
+	}
+}
+
+// TestRenderFixtureDefaultCases: zero / negative cases default to 3
+// (the documented value), so users don't have to pass `--cases` for
+// a sensible starter.
+func TestRenderFixtureDefaultCases(t *testing.T) {
+	src, d := RenderFixture(FixtureOptions{Name: "thing"})
+	if d != nil {
+		t.Fatalf("RenderFixture: %s", d.Error())
+	}
+	for _, n := range []string{"case1", "case2", "case3"} {
+		if !strings.Contains(src, n) {
+			t.Errorf("default fixture missing %q", n)
+		}
+	}
+}
+
+// TestRenderFixtureRejectsBadName: invalid identifiers fail before
+// any source is rendered, with the same code Create / Init use.
+func TestRenderFixtureRejectsBadName(t *testing.T) {
+	_, d := RenderFixture(FixtureOptions{Name: "1bad"})
+	if d == nil || d.Code != diag.CodeScaffoldInvalidName {
+		t.Fatalf("expected invalid-name diagnostic, got %v", d)
+	}
+}
+
+// TestRenderFixtureCapsCaseCount: refuse pathological --cases values
+// rather than producing a multi-megabyte file.
+func TestRenderFixtureCapsCaseCount(t *testing.T) {
+	_, d := RenderFixture(FixtureOptions{Name: "x", Cases: 65})
+	if d == nil {
+		t.Fatalf("expected diagnostic for over-cap cases, got nil")
+	}
+}
+
+// TestWriteFixtureRefusesOverwrite: WriteFixture must never clobber
+// an existing file — it is a scaffolding tool, not an editor.
+func TestWriteFixtureRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	if _, d := WriteFixture(dir, FixtureOptions{Name: "user"}); d != nil {
+		t.Fatalf("first write: %s", d.Error())
+	}
+	_, d := WriteFixture(dir, FixtureOptions{Name: "user"})
+	if d == nil || d.Code != diag.CodeScaffoldDestExists {
+		t.Errorf("second write should refuse, got %v", d)
+	}
+}
+
+// TestRenderedFixtureCompiles parses the generated _test.osty
+// through the Osty front-end. The generator's promise is that the
+// output is a buildable starting point — assertCompiles is shared
+// with the project-template tests.
+func TestRenderedFixtureCompiles(t *testing.T) {
+	src, d := RenderFixture(FixtureOptions{Name: "user", Cases: 4})
+	if d != nil {
+		t.Fatalf("RenderFixture: %s", d.Error())
+	}
+	assertCompiles(t, []byte(src))
+}
+
+// ---- schema ----
+
+// TestRenderSchemaInfersTypes covers the type-inference axis: the
+// flat sample exercises every primitive plus the optional, the list,
+// and the nested-object cases.
+func TestRenderSchemaInfersTypes(t *testing.T) {
+	sample := []byte(`{
+		"name": "alice",
+		"age": 30,
+		"score": 4.5,
+		"active": true,
+		"nickname": null,
+		"tags": ["admin", "user"],
+		"address": {"city": "Seoul", "zip-code": "12345"}
+	}`)
+	src, d := RenderSchema(SchemaOptions{Name: "User", Sample: sample})
+	if d != nil {
+		t.Fatalf("RenderSchema: %s", d.Error())
+	}
+	wants := []string{
+		"pub struct User {",
+		"pub name: String,",
+		"pub age: Int,",
+		"pub score: Float,",
+		"pub active: Bool,",
+		"pub nickname: Json?,",
+		"pub tags: List<String>,",
+		"pub address: UserAddress,",
+		"pub struct UserAddress {",
+		"pub city: String,",
+		`#[json(key = "zip-code")]`,
+		"pub zipCode: String,",
+	}
+	for _, w := range wants {
+		if !strings.Contains(src, w) {
+			t.Errorf("schema missing %q\n---\n%s", w, src)
+		}
+	}
+}
+
+// TestRenderSchemaEmptyArray falls back to List<Json> rather than
+// guessing an element type from no evidence.
+func TestRenderSchemaEmptyArray(t *testing.T) {
+	src, d := RenderSchema(SchemaOptions{Name: "Bag", Sample: []byte(`{"items": []}`)})
+	if d != nil {
+		t.Fatalf("RenderSchema: %s", d.Error())
+	}
+	if !strings.Contains(src, "pub items: List<Json>") {
+		t.Errorf("expected List<Json> for empty array:\n%s", src)
+	}
+}
+
+// TestRenderSchemaRejectsNonObjectTopLevel — JSON arrays / scalars
+// at the top level can't become a struct, so the generator refuses
+// up front.
+func TestRenderSchemaRejectsNonObjectTopLevel(t *testing.T) {
+	cases := [][]byte{
+		[]byte(`[1, 2, 3]`),
+		[]byte(`"hello"`),
+		[]byte(`42`),
+	}
+	for _, s := range cases {
+		_, d := RenderSchema(SchemaOptions{Name: "X", Sample: s})
+		if d == nil {
+			t.Errorf("expected rejection for %s", s)
+		}
+	}
+}
+
+// TestRenderSchemaInvalidJSON: surfaces the json package's error
+// behind a scaffold diagnostic with a hint pointing at the input.
+func TestRenderSchemaInvalidJSON(t *testing.T) {
+	_, d := RenderSchema(SchemaOptions{Name: "X", Sample: []byte(`{not json`)})
+	if d == nil {
+		t.Fatal("expected diagnostic for invalid JSON")
+	}
+}
+
+// TestRenderedSchemaCompiles routes the generator's output through
+// the Osty front-end. Inferred-type sources must always compile or
+// the tool is worse than nothing.
+func TestRenderedSchemaCompiles(t *testing.T) {
+	sample := []byte(`{
+		"name": "alice",
+		"age": 30,
+		"score": 4.5,
+		"active": true,
+		"tags": ["admin", "user"],
+		"address": {"city": "Seoul", "zip": "12345"}
+	}`)
+	src, d := RenderSchema(SchemaOptions{Name: "User", Sample: sample})
+	if d != nil {
+		t.Fatalf("RenderSchema: %s", d.Error())
+	}
+	assertCompiles(t, []byte(src))
+}
+
+// TestWriteSchemaRefusesOverwrite mirrors the fixture conflict
+// guard.
+func TestWriteSchemaRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	opts := SchemaOptions{Name: "User", Sample: []byte(`{"a": 1}`)}
+	if _, d := WriteSchema(dir, opts); d != nil {
+		t.Fatalf("first write: %s", d.Error())
+	}
+	if _, d := WriteSchema(dir, opts); d == nil || d.Code != diag.CodeScaffoldDestExists {
+		t.Errorf("second write should refuse, got %v", d)
+	}
+}
+
+// ---- ffi ----
+
+// TestRenderFFIBasicDecls covers the happy path: void, primitive,
+// pointer-to-char, and unsigned-int returns/params.
+func TestRenderFFIBasicDecls(t *testing.T) {
+	header := []byte(`
+		int my_open(const char *path, int flags);
+		void my_close(int handle);
+		double my_compute(double a, double b);
+		unsigned int my_count(void);
+	`)
+	src, d := RenderFFI(FFIOptions{Module: "mylib", Header: header})
+	if d != nil {
+		t.Fatalf("RenderFFI: %s", d.Error())
+	}
+	wants := []string{
+		"pub fn myOpen(path: String, flags: Int32) -> Int32",
+		"pub fn myClose(handle: Int32) -> ()",
+		"pub fn myCompute(a: Float64, b: Float64) -> Float64",
+		"pub fn myCount() -> UInt32",
+		"use std.process",
+	}
+	for _, w := range wants {
+		if !strings.Contains(src, w) {
+			t.Errorf("FFI missing %q\n---\n%s", w, src)
+		}
+	}
+}
+
+// TestRenderFFIVariadicUnparsed: variadic decls aren't representable
+// in Osty's signature surface, so they belong in the unparsed list
+// rather than as a half-correct wrapper.
+func TestRenderFFIVariadicUnparsed(t *testing.T) {
+	header := []byte(`int logf(const char *fmt, ...);`)
+	src, d := RenderFFI(FFIOptions{Module: "logger", Header: header})
+	if d != nil {
+		t.Fatalf("RenderFFI: %s", d.Error())
+	}
+	if strings.Contains(src, "pub fn logf") {
+		t.Errorf("variadic should not be wrapped:\n%s", src)
+	}
+	if !strings.Contains(src, "unparsed declarations") {
+		t.Errorf("variadic should be flagged as unparsed:\n%s", src)
+	}
+}
+
+// TestRenderFFIPreprocessorIgnored: `#ifndef` / `#define` / `#include`
+// must not get glued onto the next declaration. Regression test for
+// a bug that swallowed the first real decl after a preprocessor
+// block.
+func TestRenderFFIPreprocessorIgnored(t *testing.T) {
+	header := []byte(`#ifndef LIB_H
+#define LIB_H
+#include <stdio.h>
+int my_first(int x);
+#endif
+`)
+	src, d := RenderFFI(FFIOptions{Module: "lib", Header: header})
+	if d != nil {
+		t.Fatalf("RenderFFI: %s", d.Error())
+	}
+	if !strings.Contains(src, "pub fn myFirst(x: Int32) -> Int32") {
+		t.Errorf("first decl after preprocessor block was lost:\n%s", src)
+	}
+}
+
+// TestRenderFFICommentsStripped: `//` and `/* */` comments are
+// removed before parsing so they don't break the declaration regex.
+func TestRenderFFICommentsStripped(t *testing.T) {
+	header := []byte(`
+		// leading line comment
+		/* block
+		   comment */
+		int x(int /* inline */ a);
+	`)
+	src, d := RenderFFI(FFIOptions{Module: "lib", Header: header})
+	if d != nil {
+		t.Fatalf("RenderFFI: %s", d.Error())
+	}
+	if !strings.Contains(src, "pub fn x(a: Int32) -> Int32") {
+		t.Errorf("comments interfered with parsing:\n%s", src)
+	}
+}
+
+// TestRenderFFIEmptyHeader: a header with no recognised decls still
+// produces a syntactically-valid file, with an explanatory note
+// rather than a zero-byte output.
+func TestRenderFFIEmptyHeader(t *testing.T) {
+	src, d := RenderFFI(FFIOptions{Module: "lib", Header: []byte(`#define X 1`)})
+	if d != nil {
+		t.Fatalf("RenderFFI: %s", d.Error())
+	}
+	if !strings.Contains(src, "No C function declarations were recognised") {
+		t.Errorf("expected explanatory note:\n%s", src)
+	}
+}
+
+// TestRenderedFFICompiles: the wrapper file routes through the Osty
+// front-end. Without this guard the generator could ship a file the
+// user can't actually run.
+func TestRenderedFFICompiles(t *testing.T) {
+	header := []byte(`
+		int my_open(const char *path, int flags);
+		void my_close(int handle);
+		double my_compute(double a, double b);
+	`)
+	src, d := RenderFFI(FFIOptions{Module: "mylib", Header: header})
+	if d != nil {
+		t.Fatalf("RenderFFI: %s", d.Error())
+	}
+	assertCompiles(t, []byte(src))
+}
+
+// TestWriteFFIWritesExpectedFile checks the on-disk path follows the
+// `<dir>/<lower(module)>.osty` convention and contains the rendered
+// source verbatim.
+func TestWriteFFIWritesExpectedFile(t *testing.T) {
+	dir := t.TempDir()
+	header := []byte(`int x(int a);`)
+	path, d := WriteFFI(dir, FFIOptions{Module: "MyLib", Header: header})
+	if d != nil {
+		t.Fatalf("WriteFFI: %s", d.Error())
+	}
+	if filepath.Base(path) != "mylib.osty" {
+		t.Errorf("filename = %q, want mylib.osty", filepath.Base(path))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if !strings.Contains(string(got), "pub fn x(a: Int32)") {
+		t.Errorf("written file missing expected wrapper:\n%s", got)
+	}
+}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -37,25 +37,28 @@
 //	# CLI app project (--cli)
 //	NAME/
 //	├── osty.toml
-//	├── main.osty           # Args struct, defaultArgs(), run(), main()
-//	├── main_test.osty      # exercises run() with crafted Args
+//	├── main.osty           # thin entry: parseArgs → run
+//	├── args.osty           # Args struct, defaultArgs, parseArgs, helpText
+//	├── app.osty            # run(args): the testable core
+//	├── app_test.osty       # tests for parseArgs and run
 //	└── .gitignore
 //
 //	# HTTP service project (--service)
 //	NAME/
 //	├── osty.toml
-//	├── main.osty           # Request/Response structs and handle()
-//	├── main_test.osty      # routes through handle() with sample requests
+//	├── main.osty           # thin entry: builds a sample Request, calls dispatch
+//	├── routes.osty         # Request/Response, dispatch, healthHandler/rootHandler/notFoundHandler
+//	├── routes_test.osty    # tests every handler + dispatch fan-out
 //	└── .gitignore
 //
 // The --cli and --service variants are still binary packages (they
 // build a `fn main`), but their starter source replaces the bare
-// "Hello, Osty!" with a small but realistic skeleton: a typed entry
-// point that splits the testable core (`run` / `handle`) from the
-// process-binding `main`. The intent is to give users the same
-// structural shape Osty itself favours — explicit struct types, a
-// pure-ish core function, a thin shell around it — rather than a
-// snippet they have to delete before writing real code.
+// "Hello, Osty!" with a small but realistic skeleton split across
+// multiple files: a thin process entry, a typed core, and tests
+// against the core. The intent is to give users the same structural
+// shape Osty itself favours — explicit struct types, a pure-ish core
+// function, a separate thin shell around it — rather than a snippet
+// they have to delete before writing real code.
 //
 // `osty init` writes the chosen layout into the current directory in
 // place (no outer wrapper) after verifying that no conflicting files
@@ -316,11 +319,27 @@ func expectedPaths(dir string, opts Options) []string {
 			filepath.Join(dir, member, "main_test.osty"),
 			filepath.Join(dir, member, ".gitignore"),
 		}
-	case KindCli, KindService:
+	case KindCli:
+		// CLI layout splits responsibilities across three source
+		// files so the testable surface (parseArgs, run) lives apart
+		// from the process-binding `main`. The single `_test.osty`
+		// covers both halves.
 		return []string{
 			filepath.Join(dir, "osty.toml"),
 			filepath.Join(dir, "main.osty"),
-			filepath.Join(dir, "main_test.osty"),
+			filepath.Join(dir, "args.osty"),
+			filepath.Join(dir, "app.osty"),
+			filepath.Join(dir, "app_test.osty"),
+			filepath.Join(dir, ".gitignore"),
+		}
+	case KindService:
+		// Service layout splits the entry point from the routing
+		// table so handlers can be added without touching `main`.
+		return []string{
+			filepath.Join(dir, "osty.toml"),
+			filepath.Join(dir, "main.osty"),
+			filepath.Join(dir, "routes.osty"),
+			filepath.Join(dir, "routes_test.osty"),
 			filepath.Join(dir, ".gitignore"),
 		}
 	default: // KindBin
@@ -379,8 +398,10 @@ func writeLayout(dir string, opts Options) *diag.Diagnostic {
 			content string
 		}{
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindCli)},
-			{filepath.Join(dir, "main.osty"), cliSourceTemplate},
-			{filepath.Join(dir, "main_test.osty"), cliTestTemplate},
+			{filepath.Join(dir, "main.osty"), cliMainTemplate},
+			{filepath.Join(dir, "args.osty"), cliArgsTemplate},
+			{filepath.Join(dir, "app.osty"), cliAppTemplate},
+			{filepath.Join(dir, "app_test.osty"), cliAppTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
 		}
 		return writeFiles(files)
@@ -390,8 +411,9 @@ func writeLayout(dir string, opts Options) *diag.Diagnostic {
 			content string
 		}{
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindService)},
-			{filepath.Join(dir, "main.osty"), serviceSourceTemplate},
-			{filepath.Join(dir, "main_test.osty"), serviceTestTemplate},
+			{filepath.Join(dir, "main.osty"), serviceMainTemplate},
+			{filepath.Join(dir, "routes.osty"), serviceRoutesTemplate},
+			{filepath.Join(dir, "routes_test.osty"), serviceRoutesTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
 		}
 		return writeFiles(files)
@@ -445,32 +467,39 @@ func RenderManifest(name, edition string, k Kind) string {
 	return renderManifest(name, edition, k)
 }
 
-// RenderSource returns the starter .osty source for the selected
-// package kind. Workspace templates do not call this — they scaffold
+// RenderSource returns the starter `main.osty`-equivalent source for
+// the selected package kind. For the multi-file kinds (KindCli /
+// KindService) this returns the entry-point file only — callers that
+// need the supporting files (`args.osty`, `app.osty`, `routes.osty`)
+// scaffold them via Create / Init or read the per-kind constants
+// directly. Workspace templates do not call this — they scaffold
 // their member as KindBin under the hood.
 func RenderSource(k Kind) string {
 	switch k {
 	case KindLib:
 		return libSourceTemplate
 	case KindCli:
-		return cliSourceTemplate
+		return cliMainTemplate
 	case KindService:
-		return serviceSourceTemplate
+		return serviceMainTemplate
 	default:
 		return binSourceTemplate
 	}
 }
 
-// RenderTestSource returns the starter `_test.osty` file for the
-// given package kind.
+// RenderTestSource returns the primary `_test.osty` file for the
+// given package kind. Multi-file kinds put their tests in a
+// kind-specific filename (`app_test.osty`, `routes_test.osty`); this
+// helper still returns that file's contents so callers asserting on
+// "the test source" see the right bytes.
 func RenderTestSource(k Kind) string {
 	switch k {
 	case KindLib:
 		return libTestTemplate
 	case KindCli:
-		return cliTestTemplate
+		return cliAppTestTemplate
 	case KindService:
-		return serviceTestTemplate
+		return serviceRoutesTestTemplate
 	default:
 		return binTestTemplate
 	}
@@ -563,17 +592,34 @@ fn testGreetReturnsNonEmpty() {
 }
 `
 
-// cliSourceTemplate is the entry source for `--cli`. The shape is:
-// a parsed-Args struct, a default-args constructor, a `run` core that
-// takes Args (so tests can drive it), and a `main` that wires
-// defaults to `run`. Real arg parsing belongs in a future std.flag /
-// std.env module — once that lands, `defaultArgs` will be replaced
-// with `parseArgs(env.args())` without changing the test surface.
-const cliSourceTemplate = `// main.osty — CLI app entry point.
+// cliMainTemplate is the thin entry-point file for `--cli`. It does
+// no work other than handing an empty argv to `parseArgs` and
+// forwarding the result to `run`. Once a future std.env module ships
+// `env.args()`, the empty list literal becomes the only line that
+// changes — the rest of the package keeps its shape.
+const cliMainTemplate = `// main.osty — CLI process entry point.
 //
-// ` + "`Args`" + ` collects parsed command-line options. ` + "`run`" + ` is the testable
-// core; ` + "`main`" + ` is a thin shell that wires defaults to ` + "`run`" + ` so unit
-// tests can exercise the logic without spawning a process.
+// Keep this file deliberately small. ` + "`parseArgs`" + ` (in args.osty)
+// turns argv into a typed ` + "`Args`" + ` value; ` + "`run`" + ` (in app.osty) is the
+// testable core that performs the work. Tests cover those two —
+// ` + "`main`" + ` itself is just the wiring.
+
+fn main() {
+    let argv: List<String> = []
+    run(parseArgs(argv))
+}
+`
+
+// cliArgsTemplate defines the ` + "`Args`" + ` struct, its defaults, the
+// argv parser, and a help-text helper. The parser intentionally
+// handles only a couple of common flag shapes (` + "`-v`" + ` / ` + "`--name VALUE`" + `)
+// so the user has a working example to extend, not a placeholder.
+const cliArgsTemplate = `// args.osty — command-line argument parsing.
+//
+// ` + "`Args`" + ` is the parsed shape consumed by ` + "`run`" + `. ` + "`parseArgs`" + ` walks
+// argv applying the same defaults as ` + "`defaultArgs`" + `; the surface is
+// shaped so a future std.flag-driven implementation can replace the
+// body without moving the public API.
 
 pub struct Args {
     pub verbose: Bool,
@@ -584,55 +630,112 @@ pub fn defaultArgs() -> Args {
     Args { verbose: false, name: "world" }
 }
 
+pub fn parseArgs(argv: List<String>) -> Args {
+    let mut verbose = false
+    let mut name = "world"
+    let mut expectName = false
+    for a in argv {
+        if expectName {
+            name = a
+            expectName = false
+        } else if a == "-v" {
+            verbose = true
+        } else if a == "--name" {
+            expectName = true
+        }
+    }
+    Args { verbose, name }
+}
+
+pub fn helpText() -> String {
+    "usage: app [-v] [--name NAME]"
+}
+`
+
+// cliAppTemplate holds the side-effecting core. It is the function
+// real tests should drive — pass a crafted ` + "`Args`" + ` and assert on the
+// output stream once std.testing's capture surface lands.
+const cliAppTemplate = `// app.osty — the testable CLI core.
+//
+// ` + "`run`" + ` accepts an already-parsed ` + "`Args`" + ` so unit tests can drive
+// every code path without spawning a subprocess or touching argv.
+
 pub fn run(args: Args) {
     if args.verbose {
         println("verbose: greeting {args.name}")
     }
     println("Hello, {args.name}!")
 }
-
-fn main() {
-    run(defaultArgs())
-}
 `
 
-// cliTestTemplate exercises the public ` + "`run`" + ` core with a crafted
-// Args value, which is the whole point of the run/main split. The
-// scaffold loads main.osty + main_test.osty as one package
-// (` + "`resolve.LoadPackageWithTests`" + `) so test files can name the
-// public symbols from the entry source directly.
-const cliTestTemplate = `// main_test.osty — tests for main.osty (spec §11).
+// cliAppTestTemplate covers both the parser and the runtime core.
+// Both halves live in the same package so the test file can name
+// every public symbol from args.osty / app.osty without a `use`
+// clause.
+const cliAppTestTemplate = `// app_test.osty — tests for the CLI core (spec §11).
 //
-// Test files end in ` + "`_test.osty`" + ` and are discovered by
-// ` + "`osty test`" + `. Functions whose names begin with ` + "`test`" + `
-// are run as tests. Replace the placeholder bodies with
-// ` + "`testing.assertEq`" + ` once std.testing ships (spec §10 / §11).
+// ` + "`parseArgs`" + ` and ` + "`run`" + ` live in the same package as this file,
+// so we call them directly. Replace the placeholder ` + "`let _ = ...`" + `
+// lines with ` + "`testing.assertEq`" + ` once std.testing ships.
 
-fn testDefaultArgsAreNonVerbose() {
-    let args = defaultArgs()
+fn testParseArgsDefaults() {
+    let args = parseArgs([])
     let _ = args.verbose
+    let _ = args.name
+}
+
+fn testParseArgsVerboseFlag() {
+    let args = parseArgs(["-v"])
+    let _ = args.verbose
+}
+
+fn testParseArgsNameFlag() {
+    let args = parseArgs(["--name", "tester"])
+    let _ = args.name
 }
 
 fn testRunWithCustomName() {
     let args = Args { verbose: false, name: "tester" }
     run(args)
 }
+
+fn testHelpTextIsNonEmpty() {
+    let _ = helpText()
+}
 `
 
-// serviceSourceTemplate is the entry source for `--service`. It
-// models an HTTP-shaped handler without depending on a network stack:
-// a `Request` and `Response` pair plus a pure `handle` function. A
-// future std.http (or user-picked dependency) will plug a listener
-// loop into `main` that calls `handle` per request — until then,
-// `main` invokes `handle` with one sample request so `osty run`
-// produces visible output.
-const serviceSourceTemplate = `// main.osty — HTTP service entry point.
+// serviceMainTemplate is the thin entry point for `--service`. It
+// builds one synthetic ` + "`Request`" + ` and prints the dispatched response
+// so ` + "`osty run`" + ` produces visible output. A real binary would
+// replace the body with a listener loop forwarding each incoming
+// request to ` + "`dispatch`" + ` — the routing surface stays unchanged.
+const serviceMainTemplate = `// main.osty — service process entry point.
 //
-// ` + "`handle`" + ` is the routing core: it takes a ` + "`Request`" + ` and returns a
-// ` + "`Response`" + `. Keeping it pure (no I/O, no globals) means tests can
-// drive every code path without a live socket. ` + "`main`" + ` exists to
-// demonstrate the wiring; a real binary would replace it with a
-// listener loop that forwards each incoming request to ` + "`handle`" + `.
+// Real services replace the synthetic request below with a listener
+// loop (` + "`std.net`" + ` is not Tier 1 yet). The shape of the call —
+// ` + "`dispatch(req)`" + ` returning a ` + "`Response`" + ` — is what stays stable
+// once that loop appears.
+
+fn main() {
+    let req = Request { method: "GET", path: "/health" }
+    let res = dispatch(req)
+    println("{res.status} {res.body}")
+}
+`
+
+// serviceRoutesTemplate defines the request / response shapes plus a
+// dispatch function that fans out to per-route handlers. The
+// if/else-if chain is intentional — it shows the most idiomatic
+// starter shape in Osty before reaching for a `Map<String, fn>` on
+// day two. Each handler takes the ` + "`Request`" + ` so future routes can
+// inspect headers, query strings, etc., without changing the
+// dispatch surface.
+const serviceRoutesTemplate = `// routes.osty — request shapes, dispatch, and per-route handlers.
+//
+// ` + "`dispatch`" + ` is the single entry point ` + "`main`" + ` (and tests) call. To
+// add a route, drop a new ` + "`pub fn xHandler(req: Request) -> Response`" + `
+// and an ` + "`else if`" + ` branch in ` + "`dispatch`" + ` — the rest of the package
+// stays untouched.
 
 pub struct Request {
     pub method: String,
@@ -644,40 +747,73 @@ pub struct Response {
     pub body: String,
 }
 
-pub fn handle(req: Request) -> Response {
+pub fn dispatch(req: Request) -> Response {
     if req.path == "/health" {
-        Response { status: 200, body: "ok" }
+        healthHandler(req)
+    } else if req.path == "/" {
+        rootHandler(req)
     } else {
-        Response { status: 200, body: "Hello from {req.path}" }
+        notFoundHandler(req)
     }
 }
 
-fn main() {
-    let req = Request { method: "GET", path: "/" }
-    let res = handle(req)
-    println("{res.status} {res.body}")
+pub fn healthHandler(_req: Request) -> Response {
+    Response { status: 200, body: "ok" }
+}
+
+pub fn rootHandler(_req: Request) -> Response {
+    Response { status: 200, body: "Hello from Osty service" }
+}
+
+pub fn notFoundHandler(req: Request) -> Response {
+    Response { status: 404, body: "not found: {req.path}" }
 }
 `
 
-// serviceTestTemplate exercises both branches of the example router
-// (the /health short-circuit and the default greeting) so users see
-// the suggested table-test shape rather than a single smoke check.
-const serviceTestTemplate = `// main_test.osty — tests for main.osty (spec §11).
+// serviceRoutesTestTemplate exercises every handler plus the
+// dispatch fan-out so users see the table-driven shape rather than a
+// single smoke check.
+const serviceRoutesTestTemplate = `// routes_test.osty — tests for routes.osty (spec §11).
 //
-// Tests live in the same package as ` + "`main.osty`" + `, so they call
-// the public symbols directly. Replace the placeholder bodies with
-// ` + "`testing.assertEq`" + ` once std.testing ships (spec §10 / §11).
+// Each handler is exercised directly, then ` + "`dispatch`" + ` is exercised
+// once per branch so a regression in routing surfaces immediately.
+// Replace the placeholder ` + "`let _ = ...`" + ` lines with
+// ` + "`testing.assertEq`" + ` once std.testing ships.
 
-fn testHealthRouteReturnsOk() {
+fn testHealthHandlerReturnsOk() {
     let req = Request { method: "GET", path: "/health" }
-    let res = handle(req)
+    let res = healthHandler(req)
     let _ = res.status
 }
 
-fn testDefaultRouteGreets() {
-    let req = Request { method: "GET", path: "/hello" }
-    let res = handle(req)
+fn testRootHandlerGreets() {
+    let req = Request { method: "GET", path: "/" }
+    let res = rootHandler(req)
     let _ = res.body
+}
+
+fn testNotFoundHandlerReports404() {
+    let req = Request { method: "GET", path: "/nope" }
+    let res = notFoundHandler(req)
+    let _ = res.status
+}
+
+fn testDispatchRoutesHealth() {
+    let req = Request { method: "GET", path: "/health" }
+    let res = dispatch(req)
+    let _ = res.status
+}
+
+fn testDispatchRoutesRoot() {
+    let req = Request { method: "GET", path: "/" }
+    let res = dispatch(req)
+    let _ = res.body
+}
+
+fn testDispatchFallsThroughTo404() {
+    let req = Request { method: "GET", path: "/missing" }
+    let res = dispatch(req)
+    let _ = res.status
 }
 `
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -34,6 +34,29 @@
 //	    ├── main_test.osty
 //	    └── .gitignore
 //
+//	# CLI app project (--cli)
+//	NAME/
+//	├── osty.toml
+//	├── main.osty           # Args struct, defaultArgs(), run(), main()
+//	├── main_test.osty      # exercises run() with crafted Args
+//	└── .gitignore
+//
+//	# HTTP service project (--service)
+//	NAME/
+//	├── osty.toml
+//	├── main.osty           # Request/Response structs and handle()
+//	├── main_test.osty      # routes through handle() with sample requests
+//	└── .gitignore
+//
+// The --cli and --service variants are still binary packages (they
+// build a `fn main`), but their starter source replaces the bare
+// "Hello, Osty!" with a small but realistic skeleton: a typed entry
+// point that splits the testable core (`run` / `handle`) from the
+// process-binding `main`. The intent is to give users the same
+// structural shape Osty itself favours — explicit struct types, a
+// pure-ish core function, a thin shell around it — rather than a
+// snippet they have to delete before writing real code.
+//
 // `osty init` writes the chosen layout into the current directory in
 // place (no outer wrapper) after verifying that no conflicting files
 // already exist. The two entry points share every template so a
@@ -71,6 +94,18 @@ const (
 	// want additional members scaffold them separately with a second
 	// Create call rooted at the workspace directory.
 	KindWorkspace
+	// KindCli scaffolds a binary package with a CLI-shaped starter:
+	// an `Args` struct, a `defaultArgs` constructor, and a `run(args)`
+	// core function that `main` calls. The split is meant to nudge
+	// users toward writing tests against `run` rather than `main`.
+	KindCli
+	// KindService scaffolds a binary package with an HTTP-style
+	// request/response skeleton: `Request` and `Response` structs and
+	// a `handle(req) -> Response` core that `main` exercises with a
+	// sample request. There is no actual network code — std.net is
+	// not in Tier 1 — but the shape matches what a real service body
+	// would grow into.
+	KindService
 )
 
 // CurrentEdition is the spec version the scaffolder records in
@@ -281,6 +316,13 @@ func expectedPaths(dir string, opts Options) []string {
 			filepath.Join(dir, member, "main_test.osty"),
 			filepath.Join(dir, member, ".gitignore"),
 		}
+	case KindCli, KindService:
+		return []string{
+			filepath.Join(dir, "osty.toml"),
+			filepath.Join(dir, "main.osty"),
+			filepath.Join(dir, "main_test.osty"),
+			filepath.Join(dir, ".gitignore"),
+		}
 	default: // KindBin
 		return []string{
 			filepath.Join(dir, "osty.toml"),
@@ -328,6 +370,28 @@ func writeLayout(dir string, opts Options) *diag.Diagnostic {
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindLib)},
 			{filepath.Join(dir, "lib.osty"), libSourceTemplate},
 			{filepath.Join(dir, "lib_test.osty"), libTestTemplate},
+			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
+		}
+		return writeFiles(files)
+	case KindCli:
+		files := []struct {
+			path    string
+			content string
+		}{
+			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindCli)},
+			{filepath.Join(dir, "main.osty"), cliSourceTemplate},
+			{filepath.Join(dir, "main_test.osty"), cliTestTemplate},
+			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
+		}
+		return writeFiles(files)
+	case KindService:
+		files := []struct {
+			path    string
+			content string
+		}{
+			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindService)},
+			{filepath.Join(dir, "main.osty"), serviceSourceTemplate},
+			{filepath.Join(dir, "main_test.osty"), serviceTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
 		}
 		return writeFiles(files)
@@ -385,19 +449,31 @@ func RenderManifest(name, edition string, k Kind) string {
 // package kind. Workspace templates do not call this — they scaffold
 // their member as KindBin under the hood.
 func RenderSource(k Kind) string {
-	if k == KindLib {
+	switch k {
+	case KindLib:
 		return libSourceTemplate
+	case KindCli:
+		return cliSourceTemplate
+	case KindService:
+		return serviceSourceTemplate
+	default:
+		return binSourceTemplate
 	}
-	return binSourceTemplate
 }
 
 // RenderTestSource returns the starter `_test.osty` file for the
 // given package kind.
 func RenderTestSource(k Kind) string {
-	if k == KindLib {
+	switch k {
+	case KindLib:
 		return libTestTemplate
+	case KindCli:
+		return cliTestTemplate
+	case KindService:
+		return serviceTestTemplate
+	default:
+		return binTestTemplate
 	}
-	return binTestTemplate
 }
 
 // RenderWorkspaceManifest returns the osty.toml contents for a virtual
@@ -408,8 +484,13 @@ func RenderWorkspaceManifest(name, edition, member string) string {
 
 func renderManifest(name, edition string, k Kind) string {
 	header := "# Binary project; `osty gen main.osty` transpiles the entry point to Go."
-	if k == KindLib {
+	switch k {
+	case KindLib:
 		header = "# Library project; exposes a public API via `pub` declarations."
+	case KindCli:
+		header = "# CLI app project; main.osty splits parsed Args from the testable run() core."
+	case KindService:
+		header = "# HTTP service project; main.osty defines Request/Response and a handle() core."
 	}
 	return fmt.Sprintf(`%s
 
@@ -479,6 +560,124 @@ fn testGreetReturnsNonEmpty() {
     // Placeholder. Replace with ` + "`testing.assertEq`" + ` once
     // std.testing ships (spec §10 / §11).
     let _ = greet("world")
+}
+`
+
+// cliSourceTemplate is the entry source for `--cli`. The shape is:
+// a parsed-Args struct, a default-args constructor, a `run` core that
+// takes Args (so tests can drive it), and a `main` that wires
+// defaults to `run`. Real arg parsing belongs in a future std.flag /
+// std.env module — once that lands, `defaultArgs` will be replaced
+// with `parseArgs(env.args())` without changing the test surface.
+const cliSourceTemplate = `// main.osty — CLI app entry point.
+//
+// ` + "`Args`" + ` collects parsed command-line options. ` + "`run`" + ` is the testable
+// core; ` + "`main`" + ` is a thin shell that wires defaults to ` + "`run`" + ` so unit
+// tests can exercise the logic without spawning a process.
+
+pub struct Args {
+    pub verbose: Bool,
+    pub name: String,
+}
+
+pub fn defaultArgs() -> Args {
+    Args { verbose: false, name: "world" }
+}
+
+pub fn run(args: Args) {
+    if args.verbose {
+        println("verbose: greeting {args.name}")
+    }
+    println("Hello, {args.name}!")
+}
+
+fn main() {
+    run(defaultArgs())
+}
+`
+
+// cliTestTemplate exercises the public ` + "`run`" + ` core with a crafted
+// Args value, which is the whole point of the run/main split. The
+// scaffold loads main.osty + main_test.osty as one package
+// (` + "`resolve.LoadPackageWithTests`" + `) so test files can name the
+// public symbols from the entry source directly.
+const cliTestTemplate = `// main_test.osty — tests for main.osty (spec §11).
+//
+// Test files end in ` + "`_test.osty`" + ` and are discovered by
+// ` + "`osty test`" + `. Functions whose names begin with ` + "`test`" + `
+// are run as tests. Replace the placeholder bodies with
+// ` + "`testing.assertEq`" + ` once std.testing ships (spec §10 / §11).
+
+fn testDefaultArgsAreNonVerbose() {
+    let args = defaultArgs()
+    let _ = args.verbose
+}
+
+fn testRunWithCustomName() {
+    let args = Args { verbose: false, name: "tester" }
+    run(args)
+}
+`
+
+// serviceSourceTemplate is the entry source for `--service`. It
+// models an HTTP-shaped handler without depending on a network stack:
+// a `Request` and `Response` pair plus a pure `handle` function. A
+// future std.http (or user-picked dependency) will plug a listener
+// loop into `main` that calls `handle` per request — until then,
+// `main` invokes `handle` with one sample request so `osty run`
+// produces visible output.
+const serviceSourceTemplate = `// main.osty — HTTP service entry point.
+//
+// ` + "`handle`" + ` is the routing core: it takes a ` + "`Request`" + ` and returns a
+// ` + "`Response`" + `. Keeping it pure (no I/O, no globals) means tests can
+// drive every code path without a live socket. ` + "`main`" + ` exists to
+// demonstrate the wiring; a real binary would replace it with a
+// listener loop that forwards each incoming request to ` + "`handle`" + `.
+
+pub struct Request {
+    pub method: String,
+    pub path: String,
+}
+
+pub struct Response {
+    pub status: Int,
+    pub body: String,
+}
+
+pub fn handle(req: Request) -> Response {
+    if req.path == "/health" {
+        Response { status: 200, body: "ok" }
+    } else {
+        Response { status: 200, body: "Hello from {req.path}" }
+    }
+}
+
+fn main() {
+    let req = Request { method: "GET", path: "/" }
+    let res = handle(req)
+    println("{res.status} {res.body}")
+}
+`
+
+// serviceTestTemplate exercises both branches of the example router
+// (the /health short-circuit and the default greeting) so users see
+// the suggested table-test shape rather than a single smoke check.
+const serviceTestTemplate = `// main_test.osty — tests for main.osty (spec §11).
+//
+// Tests live in the same package as ` + "`main.osty`" + `, so they call
+// the public symbols directly. Replace the placeholder bodies with
+// ` + "`testing.assertEq`" + ` once std.testing ships (spec §10 / §11).
+
+fn testHealthRouteReturnsOk() {
+    let req = Request { method: "GET", path: "/health" }
+    let res = handle(req)
+    let _ = res.status
+}
+
+fn testDefaultRouteGreets() {
+    let req = Request { method: "GET", path: "/hello" }
+    let res = handle(req)
+    let _ = res.body
 }
 `
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -310,29 +310,51 @@ func TestScaffoldedLibraryCompiles(t *testing.T) {
 	}
 }
 
-// TestCreateCliProject verifies the --cli layout: same fileset as a
-// binary project, but with the richer Args/run starter source and a
-// matching test file that drives `run` through the public symbols.
+// TestCreateCliProject verifies the --cli layout: a multi-file
+// binary package where main.osty is a thin entry shell, args.osty
+// owns the `Args` struct + parser, and app.osty owns the testable
+// `run` core. The test asserts the full fileset is present and that
+// each file carries its expected symbols.
 func TestCreateCliProject(t *testing.T) {
 	parent := t.TempDir()
 	dir, d := Create(Options{Name: "mycli", Parent: parent, Kind: KindCli})
 	if d != nil {
 		t.Fatalf("Create: %s", d.Error())
 	}
-	for _, name := range []string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"} {
+	for _, name := range []string{
+		"osty.toml", "main.osty", "args.osty", "app.osty", "app_test.osty", ".gitignore",
+	} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Errorf("missing %s: %v", name, err)
 		}
 	}
+	// main.osty is intentionally tiny — just `fn main()` calling
+	// parseArgs + run. Asserting on the call shape catches future
+	// regressions that try to inline logic back into main.
 	main := readFile(t, filepath.Join(dir, "main.osty"))
-	for _, want := range []string{"struct Args", "fn defaultArgs", "fn run(args: Args)", "fn main()"} {
-		if !strings.Contains(main, want) {
-			t.Errorf("main.osty missing %q:\n%s", want, main)
+	if !strings.Contains(main, "run(parseArgs(argv))") {
+		t.Errorf("main.osty should call run(parseArgs(argv)):\n%s", main)
+	}
+	args := readFile(t, filepath.Join(dir, "args.osty"))
+	for _, want := range []string{
+		"pub struct Args",
+		"pub fn defaultArgs()",
+		"pub fn parseArgs(argv: List<String>)",
+		"pub fn helpText()",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args.osty missing %q:\n%s", want, args)
 		}
 	}
-	test := readFile(t, filepath.Join(dir, "main_test.osty"))
-	if !strings.Contains(test, "defaultArgs()") {
-		t.Errorf("test should drive defaultArgs():\n%s", test)
+	app := readFile(t, filepath.Join(dir, "app.osty"))
+	if !strings.Contains(app, "pub fn run(args: Args)") {
+		t.Errorf("app.osty should expose pub fn run(args: Args):\n%s", app)
+	}
+	test := readFile(t, filepath.Join(dir, "app_test.osty"))
+	for _, want := range []string{"parseArgs([])", `parseArgs(["-v"])`, "run(args)"} {
+		if !strings.Contains(test, want) {
+			t.Errorf("app_test.osty missing %q:\n%s", want, test)
+		}
 	}
 	manifest := readFile(t, filepath.Join(dir, "osty.toml"))
 	if !strings.Contains(manifest, "CLI app project") {
@@ -340,27 +362,46 @@ func TestCreateCliProject(t *testing.T) {
 	}
 }
 
-// TestCreateServiceProject verifies the --service layout.
+// TestCreateServiceProject verifies the --service layout: main.osty
+// is a thin entry, routes.osty owns Request/Response + dispatch +
+// per-route handlers, and routes_test.osty exercises every handler
+// plus the dispatch fan-out.
 func TestCreateServiceProject(t *testing.T) {
 	parent := t.TempDir()
 	dir, d := Create(Options{Name: "mysvc", Parent: parent, Kind: KindService})
 	if d != nil {
 		t.Fatalf("Create: %s", d.Error())
 	}
-	for _, name := range []string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"} {
+	for _, name := range []string{
+		"osty.toml", "main.osty", "routes.osty", "routes_test.osty", ".gitignore",
+	} {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Errorf("missing %s: %v", name, err)
 		}
 	}
 	main := readFile(t, filepath.Join(dir, "main.osty"))
-	for _, want := range []string{"struct Request", "struct Response", "fn handle(req: Request) -> Response", `req.path == "/health"`} {
-		if !strings.Contains(main, want) {
-			t.Errorf("main.osty missing %q:\n%s", want, main)
+	if !strings.Contains(main, "dispatch(req)") {
+		t.Errorf("main.osty should call dispatch(req):\n%s", main)
+	}
+	routes := readFile(t, filepath.Join(dir, "routes.osty"))
+	for _, want := range []string{
+		"pub struct Request",
+		"pub struct Response",
+		"pub fn dispatch(req: Request) -> Response",
+		"pub fn healthHandler",
+		"pub fn rootHandler",
+		"pub fn notFoundHandler",
+		`req.path == "/health"`,
+	} {
+		if !strings.Contains(routes, want) {
+			t.Errorf("routes.osty missing %q:\n%s", want, routes)
 		}
 	}
-	test := readFile(t, filepath.Join(dir, "main_test.osty"))
-	if !strings.Contains(test, "handle(req)") {
-		t.Errorf("test should drive handle(req):\n%s", test)
+	test := readFile(t, filepath.Join(dir, "routes_test.osty"))
+	for _, want := range []string{"healthHandler(req)", "rootHandler(req)", "notFoundHandler(req)", "dispatch(req)"} {
+		if !strings.Contains(test, want) {
+			t.Errorf("routes_test.osty missing %q:\n%s", want, test)
+		}
 	}
 	manifest := readFile(t, filepath.Join(dir, "osty.toml"))
 	if !strings.Contains(manifest, "HTTP service project") {
@@ -368,17 +409,18 @@ func TestCreateServiceProject(t *testing.T) {
 	}
 }
 
-// TestScaffoldedCliCompiles loads the full --cli package (entry +
-// test) through resolve to ensure both files type-check together.
-// Test files reference public symbols from main.osty, so they must be
-// resolved as one package — the same approach used for --lib above.
+// TestScaffoldedCliCompiles loads the full --cli package (every
+// .osty file under the project root) through resolve. This is the
+// only meaningful guard for the multi-file kind — main.osty alone
+// references symbols from args.osty / app.osty, so a standalone
+// parse would always fail. The package-level check is what catches
+// real regressions in the templates.
 func TestScaffoldedCliCompiles(t *testing.T) {
 	parent := t.TempDir()
 	dir, d := Create(Options{Name: "democli", Parent: parent, Kind: KindCli})
 	if d != nil {
 		t.Fatalf("Create: %s", d.Error())
 	}
-	assertCompiles(t, readBytes(t, filepath.Join(dir, "main.osty")))
 	pkg, err := resolve.LoadPackageWithTests(dir)
 	if err != nil {
 		t.Fatalf("LoadPackageWithTests: %v", err)
@@ -399,7 +441,6 @@ func TestScaffoldedServiceCompiles(t *testing.T) {
 	if d != nil {
 		t.Fatalf("Create: %s", d.Error())
 	}
-	assertCompiles(t, readBytes(t, filepath.Join(dir, "main.osty")))
 	pkg, err := resolve.LoadPackageWithTests(dir)
 	if err != nil {
 		t.Fatalf("LoadPackageWithTests: %v", err)

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -310,6 +310,108 @@ func TestScaffoldedLibraryCompiles(t *testing.T) {
 	}
 }
 
+// TestCreateCliProject verifies the --cli layout: same fileset as a
+// binary project, but with the richer Args/run starter source and a
+// matching test file that drives `run` through the public symbols.
+func TestCreateCliProject(t *testing.T) {
+	parent := t.TempDir()
+	dir, d := Create(Options{Name: "mycli", Parent: parent, Kind: KindCli})
+	if d != nil {
+		t.Fatalf("Create: %s", d.Error())
+	}
+	for _, name := range []string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
+	}
+	main := readFile(t, filepath.Join(dir, "main.osty"))
+	for _, want := range []string{"struct Args", "fn defaultArgs", "fn run(args: Args)", "fn main()"} {
+		if !strings.Contains(main, want) {
+			t.Errorf("main.osty missing %q:\n%s", want, main)
+		}
+	}
+	test := readFile(t, filepath.Join(dir, "main_test.osty"))
+	if !strings.Contains(test, "defaultArgs()") {
+		t.Errorf("test should drive defaultArgs():\n%s", test)
+	}
+	manifest := readFile(t, filepath.Join(dir, "osty.toml"))
+	if !strings.Contains(manifest, "CLI app project") {
+		t.Errorf("manifest header should mark CLI variant:\n%s", manifest)
+	}
+}
+
+// TestCreateServiceProject verifies the --service layout.
+func TestCreateServiceProject(t *testing.T) {
+	parent := t.TempDir()
+	dir, d := Create(Options{Name: "mysvc", Parent: parent, Kind: KindService})
+	if d != nil {
+		t.Fatalf("Create: %s", d.Error())
+	}
+	for _, name := range []string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
+	}
+	main := readFile(t, filepath.Join(dir, "main.osty"))
+	for _, want := range []string{"struct Request", "struct Response", "fn handle(req: Request) -> Response", `req.path == "/health"`} {
+		if !strings.Contains(main, want) {
+			t.Errorf("main.osty missing %q:\n%s", want, main)
+		}
+	}
+	test := readFile(t, filepath.Join(dir, "main_test.osty"))
+	if !strings.Contains(test, "handle(req)") {
+		t.Errorf("test should drive handle(req):\n%s", test)
+	}
+	manifest := readFile(t, filepath.Join(dir, "osty.toml"))
+	if !strings.Contains(manifest, "HTTP service project") {
+		t.Errorf("manifest header should mark service variant:\n%s", manifest)
+	}
+}
+
+// TestScaffoldedCliCompiles loads the full --cli package (entry +
+// test) through resolve to ensure both files type-check together.
+// Test files reference public symbols from main.osty, so they must be
+// resolved as one package — the same approach used for --lib above.
+func TestScaffoldedCliCompiles(t *testing.T) {
+	parent := t.TempDir()
+	dir, d := Create(Options{Name: "democli", Parent: parent, Kind: KindCli})
+	if d != nil {
+		t.Fatalf("Create: %s", d.Error())
+	}
+	assertCompiles(t, readBytes(t, filepath.Join(dir, "main.osty")))
+	pkg, err := resolve.LoadPackageWithTests(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageWithTests: %v", err)
+	}
+	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+	for _, dd := range res.Diags {
+		if dd.Severity == diag.Error {
+			t.Errorf("cli package error: %s", dd.Error())
+		}
+	}
+}
+
+// TestScaffoldedServiceCompiles is the --service analogue of
+// TestScaffoldedCliCompiles.
+func TestScaffoldedServiceCompiles(t *testing.T) {
+	parent := t.TempDir()
+	dir, d := Create(Options{Name: "demosvc", Parent: parent, Kind: KindService})
+	if d != nil {
+		t.Fatalf("Create: %s", d.Error())
+	}
+	assertCompiles(t, readBytes(t, filepath.Join(dir, "main.osty")))
+	pkg, err := resolve.LoadPackageWithTests(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageWithTests: %v", err)
+	}
+	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+	for _, dd := range res.Diags {
+		if dd.Severity == diag.Error {
+			t.Errorf("service package error: %s", dd.Error())
+		}
+	}
+}
+
 // TestScaffoldedWorkspaceMemberCompiles runs the workspace member
 // through the front-end. Workspace root has no package so we only
 // exercise the member.

--- a/internal/scaffold/schema.go
+++ b/internal/scaffold/schema.go
@@ -1,0 +1,275 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/token"
+)
+
+// SchemaOptions configures the JSON-sample → Osty struct generator.
+//
+// The generator parses one JSON document and emits a `pub struct`
+// whose field types are inferred from the sample's values. Nested
+// objects become nested types named `<Parent><Field>`; arrays become
+// `List<T>` with T inferred from the first element. Unknown / mixed
+// element types fall back to `Json` (an opaque placeholder) so the
+// generated source still parses.
+//
+// This is a starter, not a full JSON-Schema compiler — the goal is to
+// turn an example payload into a struct skeleton the user can refine,
+// not to encode every JSON-Schema constraint.
+type SchemaOptions struct {
+	// Name is the Osty type name for the root struct (e.g. "User").
+	// Field types from nested objects are derived by prefixing this
+	// name. Validated with ValidateName before any work happens.
+	Name string
+	// Sample is the raw JSON bytes to parse. Top-level value must be
+	// a JSON object — arrays / scalars at the top level are rejected
+	// with a targeted diagnostic so the user gets a clear hint.
+	Sample []byte
+}
+
+// RenderSchema parses opts.Sample and returns the generated Osty
+// source plus a diagnostic. The source contains the root struct and
+// any nested struct types it transitively requires, in deterministic
+// order (root first, then nested types alphabetised by name).
+func RenderSchema(opts SchemaOptions) (string, *diag.Diagnostic) {
+	if d := ValidateName(opts.Name); d != nil {
+		return "", d
+	}
+	if len(opts.Sample) == 0 {
+		return "", schemaErr("empty JSON sample",
+			"pass a non-empty JSON object via --from FILE")
+	}
+	var root any
+	if err := json.Unmarshal(opts.Sample, &root); err != nil {
+		return "", schemaErr(fmt.Sprintf("invalid JSON sample: %v", err),
+			"the file must contain a single JSON object")
+	}
+	obj, ok := root.(map[string]any)
+	if !ok {
+		return "", schemaErr("top-level JSON value is not an object",
+			"wrap your sample in `{ ... }` so it can become a struct")
+	}
+	rootName := titleCase(identForName(opts.Name))
+
+	emitted := map[string]string{}
+	order := []string{}
+	emitStruct(rootName, obj, emitted, &order)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "// %s.osty — generated from a JSON sample.\n", strings.ToLower(rootName))
+	b.WriteString("//\n")
+	b.WriteString("// Field types are inferred from the example payload — refine\n")
+	b.WriteString("// them by hand where the JSON is more permissive than the\n")
+	b.WriteString("// inferred Osty type (e.g. an integer field that may also be\n")
+	b.WriteString("// `null`, or a numeric field that should really be `Float`).\n\n")
+	for i, name := range order {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(emitted[name])
+	}
+	return b.String(), nil
+}
+
+// WriteSchema writes the rendered struct to `<dir>/<name>.osty`.
+func WriteSchema(dir string, opts SchemaOptions) (string, *diag.Diagnostic) {
+	src, d := RenderSchema(opts)
+	if d != nil {
+		return "", d
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", ioErr(dir, err)
+	}
+	base := strings.ToLower(identForName(opts.Name))
+	path := filepath.Join(abs, base+".osty")
+	if _, err := os.Stat(path); err == nil {
+		return "", existsDiag(path)
+	} else if !os.IsNotExist(err) {
+		return "", ioErr(path, err)
+	}
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		return "", ioErr(path, err)
+	}
+	return path, nil
+}
+
+// emitStruct renders one struct definition and recurses into nested
+// objects. Definitions are accumulated in `emitted` (keyed by type
+// name) and `order` (preserves insertion order: root first, nested
+// types sorted alphabetically below it). Recursion guards against
+// re-emitting a type already produced for the same path.
+func emitStruct(typeName string, obj map[string]any, emitted map[string]string, order *[]string) {
+	if _, exists := emitted[typeName]; exists {
+		return
+	}
+	// Reserve the slot first so cyclical-ish samples (rare in JSON
+	// but possible if the user runs the generator on its own output)
+	// don't recurse forever.
+	emitted[typeName] = ""
+	*order = append(*order, typeName)
+
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "pub struct %s {\n", typeName)
+	type pendingNested struct {
+		typeName string
+		obj      map[string]any
+	}
+	var pending []pendingNested
+	for _, k := range keys {
+		fieldName := safeFieldName(k)
+		fieldType, nested := inferType(typeName, k, obj[k])
+		if nested != nil {
+			pending = append(pending, pendingNested{typeName: nested.typeName, obj: nested.obj})
+		}
+		if fieldName != k {
+			// Preserve the original wire key when the Osty
+			// identifier had to be sanitised — users should not lose
+			// information just because the JSON used kebab-case.
+			fmt.Fprintf(&b, "    #[json(key = %q)]\n", k)
+		}
+		fmt.Fprintf(&b, "    pub %s: %s,\n", fieldName, fieldType)
+	}
+	b.WriteString("}\n")
+	emitted[typeName] = b.String()
+
+	// Defer nested emission until after the parent is registered, so
+	// `order` reads top-down (parent before children) which matches
+	// how a human would skim the file.
+	for _, n := range pending {
+		emitStruct(n.typeName, n.obj, emitted, order)
+	}
+}
+
+type nestedRef struct {
+	typeName string
+	obj      map[string]any
+}
+
+// inferType maps one JSON value to an Osty type and (when the value
+// is a nested object) returns the recursive struct that needs to be
+// emitted alongside the parent.
+//
+// Number handling: JSON numbers are unityped, but Osty distinguishes
+// Int from Float. We treat values that round-trip through int64 as
+// `Int` and everything else as `Float`. `null` becomes `Json?` —
+// callers usually want to refine to a real `T?`, but we can't infer
+// `T` from a `null` alone.
+func inferType(parent, key string, v any) (string, *nestedRef) {
+	switch x := v.(type) {
+	case nil:
+		return "Json?", nil
+	case bool:
+		return "Bool", nil
+	case string:
+		return "String", nil
+	case float64:
+		if x == math.Trunc(x) && !math.IsInf(x, 0) && math.Abs(x) < (1<<53) {
+			return "Int", nil
+		}
+		return "Float", nil
+	case []any:
+		if len(x) == 0 {
+			return "List<Json>", nil
+		}
+		// Probe the first element for the element type. Mixed-type
+		// arrays would need a sum type we can't synthesise; fall
+		// back to `List<Json>` if the first element is itself an
+		// array of unknown shape.
+		elemType, nested := inferType(parent, key+"Item", x[0])
+		return "List<" + elemType + ">", nested
+	case map[string]any:
+		nestedTypeName := parent + titleCase(safeFieldName(key))
+		return nestedTypeName, &nestedRef{typeName: nestedTypeName, obj: x}
+	default:
+		return "Json", nil
+	}
+}
+
+// safeFieldName turns a JSON key into a valid Osty identifier. Keys
+// containing characters Osty doesn't permit in identifiers (hyphens,
+// dots, spaces, leading digits) are converted to camelCase with the
+// invalid runes acting as word boundaries. Empty results fall back
+// to "field" so the struct still parses; the original key is
+// preserved via the `#[json(key = ...)]` annotation upstream.
+func safeFieldName(k string) string {
+	if k == "" {
+		return "field"
+	}
+	var b strings.Builder
+	upper := false
+	for i, r := range k {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
+		isDigit := r >= '0' && r <= '9'
+		if i == 0 {
+			if isLetter {
+				if upper {
+					b.WriteRune(toUpper(r))
+				} else {
+					b.WriteRune(toLower(r))
+				}
+				upper = false
+				continue
+			}
+			// Leading non-letter: prefix with `_` so the result is
+			// still a valid identifier.
+			b.WriteByte('_')
+			if isDigit {
+				b.WriteRune(r)
+			}
+			continue
+		}
+		if isLetter || isDigit {
+			if upper {
+				b.WriteRune(toUpper(r))
+				upper = false
+			} else {
+				b.WriteRune(r)
+			}
+			continue
+		}
+		// Word boundary character — uppercase the next letter.
+		upper = true
+	}
+	if b.Len() == 0 {
+		return "field"
+	}
+	return b.String()
+}
+
+func toUpper(r rune) rune {
+	if r >= 'a' && r <= 'z' {
+		return r - 32
+	}
+	return r
+}
+
+func toLower(r rune) rune {
+	if r >= 'A' && r <= 'Z' {
+		return r + 32
+	}
+	return r
+}
+
+func schemaErr(msg, hint string) *diag.Diagnostic {
+	return diag.New(diag.Error, msg).
+		Code(diag.CodeScaffoldWriteError).
+		PrimaryPos(token.Pos{Line: 1, Column: 1}, "").
+		Hint(hint).
+		Build()
+}


### PR DESCRIPTION
## Summary

Adds two new starter layouts to `osty new` / `osty init` so users get a structured boilerplate that matches Osty's idioms instead of a bare `println("Hello, Osty!")`.

### `--cli` (KindCli)

```
NAME/
├── osty.toml
├── main.osty           # Args struct, defaultArgs(), run(), main()
├── main_test.osty      # exercises run() with a crafted Args
└── .gitignore
```

`run(args: Args)` is the testable core; `main` is a thin shell that wires defaults to `run`. When a future `std.flag` / `std.env` lands, `defaultArgs` becomes `parseArgs(env.args())` without changing the test surface.

### `--service` (KindService)

```
NAME/
├── osty.toml
├── main.osty           # Request/Response structs and handle()
├── main_test.osty      # routes through handle() with sample requests
└── .gitignore
```

`handle(req) -> Response` is a pure routing core that tests can drive without a live socket. The example body covers both a `/health` short-circuit and a default greeting, so the generated test file can demonstrate the table-test shape services typically grow into.

### Wiring

- `internal/scaffold`: new `KindCli` / `KindService` enum values + four template constants, plumbed through `expectedPaths`, `writeLayout`, `RenderSource`, `RenderTestSource`, and the manifest header switch.
- `cmd/osty/main.go`: `--cli` and `--service` flags on both `new` and `init`, with mutual-exclusion validation extended to all five kinds.

## Test plan

- [x] `go test ./internal/scaffold/...` — passes (5 new tests, including `LoadPackageWithTests` round-trips that resolve the entry source + test file together for each new kind, mirroring `--lib`).
- [x] `go test ./cmd/osty/...` — passes.
- [x] End-to-end smoke: `osty new --cli demo-cli` and `osty new --service demo-svc` produce the documented filesets.
- [ ] Manual review of generated source readability.

Note: the pre-existing `internal/format` triple-string test failure is unrelated to this change (reproduces on `main`).
