### PR TITLE
Add independent IR package

### DIFF
--- a/internal/ir/doc.go
+++ b/internal/ir/doc.go
@@ -1,7 +1,7 @@
-// Package ir defines an independent intermediate representation (IR) for
-// Osty programs. It is a self-contained, backend-agnostic tree that sits
-// between the type-checked front-end and the Go transpiler / future
-// backends.
+// Package ir defines an independent intermediate representation (IR)
+// for Osty programs. It is a self-contained, backend-agnostic tree
+// that sits between the type-checked front-end and the Go transpiler /
+// future backends.
 //
 // Pipeline position:
 //
@@ -9,36 +9,72 @@
 //
 // Goals:
 //
-//   - Independence. No node in this package references `ast`, `resolve`,
-//     or `check`. Backends may depend on `ir` alone. Types (`ir.Type`),
-//     declarations, statements and expressions are all self-describing:
-//     names resolve as plain strings, symbol references carry the kind
-//     they point at, and every expression stores its own type.
+//   - Independence. No node in this package references `ast`,
+//     `resolve`, or `check`. Backends may depend on `ir` alone. Types
+//     (`ir.Type`), declarations, statements, expressions and patterns
+//     are all self-describing: names resolve as plain strings, every
+//     expression stores its own type, and symbol classification is
+//     carried via enum kinds (IdentKind).
 //
-//   - Stability. The IR is a normalised view: syntactic sugar is pruned
-//     (parens unwrapped, `ExprStmt` around block-final expressions turned
-//     into `Block.Result`, turbofish dropped into the call's type args),
-//     untyped literals are resolved to their concrete primitive type,
-//     and source-order-only variants are merged (e.g. there is one
-//     `ForStmt` with a variant kind field instead of three AST kinds).
+//   - Stability. The IR is a normalised view: syntactic sugar is
+//     pruned (parens unwrapped, block-final expressions hoisted into
+//     Block.Result, turbofish folded into the call's type args), and
+//     constructs are classified into distinct nodes rather than a
+//     single polymorphic shape (MethodCall vs CallExpr, VariantLit vs
+//     CallExpr, IfLetExpr vs IfExpr, TupleAccess vs FieldExpr, etc.).
 //
-//   - Lossy where appropriate. Things irrelevant to later stages (doc
-//     comments, annotations other than `deprecated`/`json`, parser-
-//     suppression state) are dropped. Source positions are retained in a
-//     `Span` field on every node so diagnostics remain anchorable.
+//   - Lossy where appropriate. Doc comments, annotation metadata
+//     unused downstream, parser-suppression state, etc. are dropped.
+//     Every node keeps a Span so diagnostics remain anchorable.
 //
-// Lower(file, res, chk) is the canonical entry point. It returns a
-// *Module carrying every top-level declaration, script-mode statements
-// (if any), and a list of issues encountered during lowering. Lowering
-// is best-effort: constructs that are not yet supported collapse to an
-// IR `ErrorExpr` / `ErrorStmt` and append a note to the issue list — the
-// same "keep going so later problems surface" philosophy used by the
-// parser and resolver.
+// Surface area
 //
-// Phase 1 of the backend needs only a modest subset of Osty, so Lower
-// implements that subset today (primitives, fn decls, let bindings,
-// if/for/return, list literals, print intrinsics, user calls). Larger
-// surface area (structs, enums, match, `?`, generics, closures) is
-// staged in follow-on work; the IR types already carry nodes for those
-// so backends written against `ir` stay forward-compatible.
+//   - Module: package name, top-level Decls, script-mode Stmts.
+//   - Decls: FnDecl, StructDecl, EnumDecl, InterfaceDecl, TypeAliasDecl,
+//     LetDecl, UseDecl.
+//   - Stmts: Block, LetStmt, ExprStmt, AssignStmt (multi-target),
+//     ReturnStmt, BreakStmt, ContinueStmt, IfStmt, ForStmt (inf /
+//     while / range / in), DeferStmt, ChanSendStmt, MatchStmt,
+//     ErrorStmt.
+//   - Exprs: literals (int/float/bool/char/byte/string/unit), Ident,
+//     UnaryExpr, BinaryExpr, CoalesceExpr, QuestionExpr, CallExpr,
+//     IntrinsicCall (print-family), MethodCall, VariantLit, FieldExpr,
+//     TupleAccess, IndexExpr, ListLit, MapLit, TupleLit, StructLit,
+//     RangeLit, Closure, BlockExpr, IfExpr, IfLetExpr, MatchExpr,
+//     ErrorExpr.
+//   - Patterns: WildPat, IdentPat, LitPat, TuplePat, StructPat,
+//     VariantPat, RangePat, OrPat, BindingPat, ErrorPat.
+//   - Types: PrimType (with canonical singletons), NamedType,
+//     OptionalType, TupleType, FnType, TypeVar, ErrType.
+//
+// Tools
+//
+//   - Lower(pkg, file, res, chk) → (*Module, []error) — convert a
+//     type-checked AST into an IR Module. Non-fatal issues are
+//     returned separately; poisoned spots collapse to ErrorStmt /
+//     ErrorExpr / ErrorPat rather than panicking.
+//
+//   - Walk(v, n) / Inspect(n, fn) — pre-order traversal over every
+//     reachable Node (decl, stmt, expr, pattern).
+//
+//   - Print(m) / PrintNode(n) — stable S-expression-like debug
+//     renderer for tests and visual inspection.
+//
+//   - Validate(m) — lightweight structural sanity check useful during
+//     backend development.
+//
+// Known gaps (follow-on work)
+//
+//   - The Go transpiler (internal/gen) still consumes the AST
+//     directly. Rewriting it against `ir` is a substantial refactor
+//     tracked as a separate effort.
+//
+//   - Generic monomorphisation info (check.Result.Instantiations) is
+//     not yet threaded through; backends that need per-call-site
+//     type arguments should consult the checker until the IR
+//     surfaces them.
+//
+//   - Destructuring `for` heads lower to ForIn with an empty Var and
+//     a note; a ForDestructure variant may emerge when a consumer
+//     actually needs it.
 package ir

--- a/internal/ir/doc.go
+++ b/internal/ir/doc.go
@@ -1,0 +1,44 @@
+// Package ir defines an independent intermediate representation (IR) for
+// Osty programs. It is a self-contained, backend-agnostic tree that sits
+// between the type-checked front-end and the Go transpiler / future
+// backends.
+//
+// Pipeline position:
+//
+//	source → lexer → parser → resolve → check → ir (this package) → gen
+//
+// Goals:
+//
+//   - Independence. No node in this package references `ast`, `resolve`,
+//     or `check`. Backends may depend on `ir` alone. Types (`ir.Type`),
+//     declarations, statements and expressions are all self-describing:
+//     names resolve as plain strings, symbol references carry the kind
+//     they point at, and every expression stores its own type.
+//
+//   - Stability. The IR is a normalised view: syntactic sugar is pruned
+//     (parens unwrapped, `ExprStmt` around block-final expressions turned
+//     into `Block.Result`, turbofish dropped into the call's type args),
+//     untyped literals are resolved to their concrete primitive type,
+//     and source-order-only variants are merged (e.g. there is one
+//     `ForStmt` with a variant kind field instead of three AST kinds).
+//
+//   - Lossy where appropriate. Things irrelevant to later stages (doc
+//     comments, annotations other than `deprecated`/`json`, parser-
+//     suppression state) are dropped. Source positions are retained in a
+//     `Span` field on every node so diagnostics remain anchorable.
+//
+// Lower(file, res, chk) is the canonical entry point. It returns a
+// *Module carrying every top-level declaration, script-mode statements
+// (if any), and a list of issues encountered during lowering. Lowering
+// is best-effort: constructs that are not yet supported collapse to an
+// IR `ErrorExpr` / `ErrorStmt` and append a note to the issue list — the
+// same "keep going so later problems surface" philosophy used by the
+// parser and resolver.
+//
+// Phase 1 of the backend needs only a modest subset of Osty, so Lower
+// implements that subset today (primitives, fn decls, let bindings,
+// if/for/return, list literals, print intrinsics, user calls). Larger
+// surface area (structs, enums, match, `?`, generics, closures) is
+// staged in follow-on work; the IR types already carry nodes for those
+// so backends written against `ir` stay forward-compatible.
+package ir

--- a/internal/ir/expanded_test.go
+++ b/internal/ir/expanded_test.go
@@ -1,0 +1,491 @@
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// Expanded tests covering the second round of IR work: structs with
+// methods, enums and variant construction/match, patterns, closures,
+// `?` / `??`, maps/tuples/field/index access, use/interface/alias,
+// and the walk + print helpers.
+
+func TestLowerStructMethodAndCall(t *testing.T) {
+	mod, issues := lower(t, `
+struct Point {
+    x: Int,
+    y: Int,
+
+    fn sum(self) -> Int {
+        self.x + self.y
+    }
+}
+
+fn main() {
+    let p = Point { x: 3, y: 4 }
+    println(p.sum())
+}
+`)
+	// The checker may warn (no diagnostics but unused) — tolerate.
+	_ = issues
+	if len(mod.Decls) < 2 {
+		t.Fatalf("decls = %d", len(mod.Decls))
+	}
+	sd, ok := mod.Decls[0].(*ir.StructDecl)
+	if !ok {
+		t.Fatalf("want StructDecl, got %T", mod.Decls[0])
+	}
+	if len(sd.Methods) != 1 {
+		t.Fatalf("methods = %d", len(sd.Methods))
+	}
+	if sd.Methods[0].Name != "sum" {
+		t.Fatalf("method name = %q", sd.Methods[0].Name)
+	}
+
+	main := mod.Decls[1].(*ir.FnDecl)
+	// First stmt: let p = Point { ... }
+	let0 := main.Body.Stmts[0].(*ir.LetStmt)
+	lit, ok := let0.Value.(*ir.StructLit)
+	if !ok {
+		t.Fatalf("want StructLit, got %T", let0.Value)
+	}
+	if lit.TypeName != "Point" || len(lit.Fields) != 2 {
+		t.Fatalf("struct lit = %+v", lit)
+	}
+	// Second stmt: println(p.sum())
+	es := main.Body.Stmts[1].(*ir.ExprStmt)
+	call := es.X.(*ir.IntrinsicCall)
+	mc, ok := call.Args[0].(*ir.MethodCall)
+	if !ok {
+		t.Fatalf("want MethodCall arg, got %T", call.Args[0])
+	}
+	if mc.Name != "sum" {
+		t.Fatalf("method name = %q", mc.Name)
+	}
+	// Receiver should be an Ident("p").
+	if id, ok := mc.Receiver.(*ir.Ident); !ok || id.Name != "p" {
+		t.Fatalf("receiver = %T %+v", mc.Receiver, mc.Receiver)
+	}
+}
+
+func TestLowerFieldAccess(t *testing.T) {
+	mod, _ := lower(t, `
+struct Point { x: Int, y: Int }
+
+fn getX(p: Point) -> Int {
+    p.x
+}
+`)
+	fn := mod.Decls[1].(*ir.FnDecl)
+	if fn.Body.Result == nil {
+		t.Fatalf("expected block result")
+	}
+	fe, ok := fn.Body.Result.(*ir.FieldExpr)
+	if !ok {
+		t.Fatalf("want FieldExpr, got %T", fn.Body.Result)
+	}
+	if fe.Name != "x" {
+		t.Fatalf("name = %q", fe.Name)
+	}
+	if fe.Optional {
+		t.Fatalf("should not be optional")
+	}
+}
+
+func TestLowerEnumAndVariantConstruct(t *testing.T) {
+	mod, _ := lower(t, `
+enum Shape {
+    Circle(Float),
+    Square(Int),
+    Empty,
+}
+
+fn make() -> Shape {
+    Shape.Circle(1.5)
+}
+`)
+	ed, ok := mod.Decls[0].(*ir.EnumDecl)
+	if !ok {
+		t.Fatalf("want EnumDecl, got %T", mod.Decls[0])
+	}
+	if len(ed.Variants) != 3 {
+		t.Fatalf("variants = %d", len(ed.Variants))
+	}
+
+	fn := mod.Decls[1].(*ir.FnDecl)
+	// The variant construct may surface either as the block Result (if
+	// the checker promoted the call to a typed value) or as a
+	// side-effect ExprStmt. Accept either.
+	var vl *ir.VariantLit
+	if r, ok := fn.Body.Result.(*ir.VariantLit); ok {
+		vl = r
+	} else {
+		for _, s := range fn.Body.Stmts {
+			if es, ok := s.(*ir.ExprStmt); ok {
+				if v, ok := es.X.(*ir.VariantLit); ok {
+					vl = v
+					break
+				}
+			}
+		}
+	}
+	if vl == nil {
+		t.Fatalf("VariantLit not found in body: %s", ir.PrintNode(fn.Body))
+	}
+	if vl.Enum != "Shape" || vl.Variant != "Circle" {
+		t.Fatalf("variant = %+v", vl)
+	}
+	if len(vl.Args) != 1 {
+		t.Fatalf("args = %d", len(vl.Args))
+	}
+}
+
+func TestLowerMatchExpr(t *testing.T) {
+	mod, _ := lower(t, `
+enum Shape { Circle(Float), Square(Int), Empty }
+
+fn area(s: Shape) -> Float {
+    match s {
+        Shape.Circle(r) -> r * r,
+        Shape.Square(side) -> 0.0,
+        Shape.Empty -> 0.0,
+    }
+}
+`)
+	fn := mod.Decls[1].(*ir.FnDecl)
+	me, ok := fn.Body.Result.(*ir.MatchExpr)
+	if !ok {
+		t.Fatalf("want MatchExpr, got %T", fn.Body.Result)
+	}
+	if len(me.Arms) != 3 {
+		t.Fatalf("arms = %d", len(me.Arms))
+	}
+	// First arm pattern: Shape.Circle(r)
+	vp, ok := me.Arms[0].Pattern.(*ir.VariantPat)
+	if !ok {
+		t.Fatalf("want VariantPat, got %T", me.Arms[0].Pattern)
+	}
+	if vp.Variant != "Circle" {
+		t.Fatalf("variant = %q", vp.Variant)
+	}
+	if len(vp.Args) != 1 {
+		t.Fatalf("variant args = %d", len(vp.Args))
+	}
+	if _, ok := vp.Args[0].(*ir.IdentPat); !ok {
+		t.Fatalf("want IdentPat, got %T", vp.Args[0])
+	}
+	// Third arm: Shape.Empty bare, no args.
+	v3 := me.Arms[2].Pattern.(*ir.VariantPat)
+	if v3.Variant != "Empty" || len(v3.Args) != 0 {
+		t.Fatalf("Empty pattern = %+v", v3)
+	}
+}
+
+func TestLowerTuplePattern(t *testing.T) {
+	mod, _ := lower(t, `
+fn swap(p: (Int, Int)) -> (Int, Int) {
+    let (a, b) = p
+    (b, a)
+}
+`)
+	fn := mod.Decls[0].(*ir.FnDecl)
+	let0 := fn.Body.Stmts[0].(*ir.LetStmt)
+	if let0.Pattern == nil {
+		t.Fatalf("expected destructuring pattern")
+	}
+	tp, ok := let0.Pattern.(*ir.TuplePat)
+	if !ok {
+		t.Fatalf("want TuplePat, got %T", let0.Pattern)
+	}
+	if len(tp.Elems) != 2 {
+		t.Fatalf("elems = %d", len(tp.Elems))
+	}
+	// Result (b, a) is a TupleLit.
+	if tl, ok := fn.Body.Result.(*ir.TupleLit); !ok || len(tl.Elems) != 2 {
+		t.Fatalf("want TupleLit, got %T %+v", fn.Body.Result, fn.Body.Result)
+	}
+}
+
+func TestLowerClosure(t *testing.T) {
+	mod, _ := lower(t, `
+fn apply(f: fn(Int) -> Int, x: Int) -> Int {
+    f(x)
+}
+
+fn main() {
+    let g = |n: Int| n + 1
+    apply(g, 5)
+}
+`)
+	main := mod.Decls[1].(*ir.FnDecl)
+	let0 := main.Body.Stmts[0].(*ir.LetStmt)
+	cl, ok := let0.Value.(*ir.Closure)
+	if !ok {
+		t.Fatalf("want Closure, got %T", let0.Value)
+	}
+	if len(cl.Params) != 1 || cl.Params[0].Name != "n" {
+		t.Fatalf("params = %+v", cl.Params)
+	}
+	if cl.Body == nil {
+		t.Fatalf("closure body nil")
+	}
+	// Body is either a Result-only block or contains a BinaryExpr.
+	if cl.Body.Result == nil && len(cl.Body.Stmts) == 0 {
+		t.Fatalf("empty body")
+	}
+}
+
+func TestLowerQuestionAndCoalesce(t *testing.T) {
+	mod, _ := lower(t, `
+fn maybe() -> Int? {
+    42
+}
+
+fn use_it() -> Int {
+    let x = maybe() ?? 0
+    x
+}
+`)
+	fn := mod.Decls[1].(*ir.FnDecl)
+	let0 := fn.Body.Stmts[0].(*ir.LetStmt)
+	co, ok := let0.Value.(*ir.CoalesceExpr)
+	if !ok {
+		t.Fatalf("want CoalesceExpr, got %T", let0.Value)
+	}
+	if _, ok := co.Right.(*ir.IntLit); !ok {
+		t.Fatalf("rhs = %T", co.Right)
+	}
+}
+
+func TestLowerOptionalChain(t *testing.T) {
+	mod, _ := lower(t, `
+struct User { name: String }
+
+fn display(u: User?) -> String {
+    u?.name ?? "anon"
+}
+`)
+	fn := mod.Decls[1].(*ir.FnDecl)
+	co, ok := fn.Body.Result.(*ir.CoalesceExpr)
+	if !ok {
+		t.Fatalf("want CoalesceExpr, got %T", fn.Body.Result)
+	}
+	fe, ok := co.Left.(*ir.FieldExpr)
+	if !ok {
+		t.Fatalf("want FieldExpr, got %T", co.Left)
+	}
+	if !fe.Optional {
+		t.Fatalf("expected optional field")
+	}
+}
+
+func TestLowerAssignToField(t *testing.T) {
+	// Osty doesn't have `mut` on fn params, so exercise AssignStmt on
+	// mutable struct fields instead. Single target, confirm lowering
+	// preserves the FieldExpr as target.
+	mod, _ := lower(t, `
+struct Counter {
+    count: Int,
+
+    fn inc(mut self) {
+        self.count = self.count + 1
+    }
+}
+`)
+	sd := mod.Decls[0].(*ir.StructDecl)
+	method := sd.Methods[0]
+	as0, ok := method.Body.Stmts[0].(*ir.AssignStmt)
+	if !ok {
+		t.Fatalf("want AssignStmt, got %T", method.Body.Stmts[0])
+	}
+	if len(as0.Targets) != 1 {
+		t.Fatalf("targets = %d", len(as0.Targets))
+	}
+	if _, ok := as0.Targets[0].(*ir.FieldExpr); !ok {
+		t.Fatalf("target = %T", as0.Targets[0])
+	}
+}
+
+func TestLowerUseAndAlias(t *testing.T) {
+	mod, _ := lower(t, `
+type Id = Int
+
+fn f() -> Id { 1 }
+`)
+	found := false
+	for _, d := range mod.Decls {
+		if ta, ok := d.(*ir.TypeAliasDecl); ok {
+			found = true
+			if ta.Name != "Id" {
+				t.Fatalf("alias name = %q", ta.Name)
+			}
+			if ta.Target != ir.TInt {
+				t.Fatalf("alias target = %v", ta.Target)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("TypeAliasDecl not present in %+v", mod.Decls)
+	}
+}
+
+func TestLowerInterface(t *testing.T) {
+	mod, _ := lower(t, `
+interface Greet {
+    fn hello(self) -> String
+}
+`)
+	id, ok := mod.Decls[0].(*ir.InterfaceDecl)
+	if !ok {
+		t.Fatalf("want InterfaceDecl, got %T", mod.Decls[0])
+	}
+	if id.Name != "Greet" || len(id.Methods) != 1 {
+		t.Fatalf("iface = %+v", id)
+	}
+}
+
+func TestLowerMapLiteral(t *testing.T) {
+	mod, issues := lower(t, `
+fn build() -> Map<String, Int> {
+    let m: Map<String, Int> = {"a": 1, "b": 2}
+    m
+}
+`)
+	_ = issues
+	fn := mod.Decls[0].(*ir.FnDecl)
+	let0 := fn.Body.Stmts[0].(*ir.LetStmt)
+	ml, ok := let0.Value.(*ir.MapLit)
+	if !ok {
+		t.Fatalf("want MapLit, got %T", let0.Value)
+	}
+	if len(ml.Entries) != 2 {
+		t.Fatalf("entries = %d", len(ml.Entries))
+	}
+}
+
+func TestWalkCountsNodes(t *testing.T) {
+	mod, _ := lower(t, `
+fn f(a: Int, b: Int) -> Int {
+    if a > b {
+        a
+    } else {
+        b
+    }
+}
+`)
+	var exprs, stmts, decls int
+	ir.Inspect(mod, func(n ir.Node) bool {
+		switch n.(type) {
+		case ir.Expr:
+			exprs++
+		case ir.Stmt:
+			stmts++
+		case ir.Decl:
+			decls++
+		}
+		return true
+	})
+	if decls < 1 {
+		t.Errorf("decls = %d", decls)
+	}
+	if exprs < 3 {
+		t.Errorf("exprs = %d", exprs)
+	}
+	// Walker hit every branch of an if-expr's two blocks.
+	if stmts < 1 {
+		t.Errorf("stmts = %d", stmts)
+	}
+}
+
+func TestPrintStable(t *testing.T) {
+	mod, _ := lower(t, `
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+`)
+	out := ir.Print(mod)
+	// Spot-check that the expected structure is present in the output.
+	wants := []string{`(module "main"`, `(fn add`, `(+`}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("Print missing %q in:\n%s", w, out)
+		}
+	}
+}
+
+func TestPrintMatch(t *testing.T) {
+	mod, _ := lower(t, `
+enum Shape { Circle(Float), Empty }
+
+fn dispatch(s: Shape) -> Int {
+    match s {
+        Shape.Circle(_) -> 1,
+        Shape.Empty -> 0,
+    }
+}
+`)
+	out := ir.Print(mod)
+	if !strings.Contains(out, "(match ") {
+		t.Errorf("Print missing match form:\n%s", out)
+	}
+	if !strings.Contains(out, "Circle(_)") && !strings.Contains(out, "Shape.Circle") {
+		t.Errorf("Print missing variant pattern:\n%s", out)
+	}
+}
+
+func TestLowerDefer(t *testing.T) {
+	mod, _ := lower(t, `
+fn f() {
+    defer println("bye")
+    println("hi")
+}
+`)
+	fn := mod.Decls[0].(*ir.FnDecl)
+	ds, ok := fn.Body.Stmts[0].(*ir.DeferStmt)
+	if !ok {
+		t.Fatalf("want DeferStmt, got %T", fn.Body.Stmts[0])
+	}
+	if ds.Body == nil {
+		t.Fatalf("nil defer body")
+	}
+}
+
+func TestValidateClean(t *testing.T) {
+	mod, _ := lower(t, `
+struct P { x: Int, y: Int }
+
+enum Shape { Circle(Float), Empty }
+
+fn demo(a: Int, b: Int) -> Int {
+    let p = P { x: a, y: b }
+    if a > b { a } else { b }
+}
+`)
+	errs := ir.Validate(mod)
+	if len(errs) != 0 {
+		t.Errorf("Validate reported %d errors:\n", len(errs))
+		for _, e := range errs {
+			t.Logf("  %v", e)
+		}
+	}
+}
+
+func TestLowerWildcardPattern(t *testing.T) {
+	mod, _ := lower(t, `
+enum Flag { On, Off }
+
+fn toInt(f: Flag) -> Int {
+    match f {
+        Flag.On -> 1,
+        _ -> 0,
+    }
+}
+`)
+	fn := mod.Decls[1].(*ir.FnDecl)
+	me := fn.Body.Result.(*ir.MatchExpr)
+	if _, ok := me.Arms[1].Pattern.(*ir.WildPat); !ok {
+		t.Fatalf("want WildPat in last arm, got %T", me.Arms[1].Pattern)
+	}
+}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -1,0 +1,817 @@
+package ir
+
+import "strings"
+
+// ==== Source positions ====
+
+// Pos is a 1-based line/column pair plus a byte offset into the source.
+// Kept deliberately small so every IR node can embed one without a big
+// memory footprint. Mirrors `token.Pos` structurally but lives in this
+// package so `ir` has no dependency on `token`.
+type Pos struct {
+	Offset int
+	Line   int
+	Column int
+}
+
+// Span is a half-open source range [Start, End). Carried by every IR
+// node so downstream consumers (error reporting, source maps) can point
+// back at the original source without needing the AST.
+type Span struct {
+	Start Pos
+	End   Pos
+}
+
+// Node is the common interface for every IR node. Callers that only
+// need location info can walk a tree as []Node.
+type Node interface {
+	At() Span
+}
+
+// ==== Module ====
+
+// Module is the IR form of a single Osty source file.
+//
+// Package is the emitted package name (e.g. "main" for executables).
+// Decls are top-level declarations in source order. Script is non-empty
+// when the file contained top-level statements that will be lowered
+// into a synthetic main() body by the backend.
+type Module struct {
+	Package string
+	Decls   []Decl
+	Script  []Stmt
+	SpanV   Span
+}
+
+func (m *Module) At() Span { return m.SpanV }
+
+// ==== Types ====
+
+// Type is a self-contained semantic type. Unlike the checker's
+// `types.Type`, it holds no back-references to `resolve.Symbol`; named
+// types are identified by string. Equality is by structural comparison.
+type Type interface {
+	typeNode()
+	String() string
+}
+
+// PrimKind enumerates Osty's built-in scalar types. Mirrors the
+// checker's `types.PrimitiveKind` but lives here to keep `ir`
+// self-contained.
+type PrimKind int
+
+const (
+	PrimInvalid PrimKind = iota
+
+	PrimInt
+	PrimInt8
+	PrimInt16
+	PrimInt32
+	PrimInt64
+	PrimUInt8
+	PrimUInt16
+	PrimUInt32
+	PrimUInt64
+	PrimByte
+	PrimFloat
+	PrimFloat32
+	PrimFloat64
+
+	PrimBool
+	PrimChar
+	PrimString
+	PrimBytes
+
+	PrimUnit  // ()
+	PrimNever // !
+)
+
+// PrimType is a primitive scalar type.
+type PrimType struct{ Kind PrimKind }
+
+func (*PrimType) typeNode() {}
+
+func (p *PrimType) String() string {
+	switch p.Kind {
+	case PrimInt:
+		return "Int"
+	case PrimInt8:
+		return "Int8"
+	case PrimInt16:
+		return "Int16"
+	case PrimInt32:
+		return "Int32"
+	case PrimInt64:
+		return "Int64"
+	case PrimUInt8:
+		return "UInt8"
+	case PrimUInt16:
+		return "UInt16"
+	case PrimUInt32:
+		return "UInt32"
+	case PrimUInt64:
+		return "UInt64"
+	case PrimByte:
+		return "Byte"
+	case PrimFloat:
+		return "Float"
+	case PrimFloat32:
+		return "Float32"
+	case PrimFloat64:
+		return "Float64"
+	case PrimBool:
+		return "Bool"
+	case PrimChar:
+		return "Char"
+	case PrimString:
+		return "String"
+	case PrimBytes:
+		return "Bytes"
+	case PrimUnit:
+		return "()"
+	case PrimNever:
+		return "Never"
+	}
+	return "?"
+}
+
+// Canonical primitive singletons. Backends and the lowerer reach for
+// these instead of allocating a fresh *PrimType per literal.
+var (
+	TInt     = &PrimType{Kind: PrimInt}
+	TInt8    = &PrimType{Kind: PrimInt8}
+	TInt16   = &PrimType{Kind: PrimInt16}
+	TInt32   = &PrimType{Kind: PrimInt32}
+	TInt64   = &PrimType{Kind: PrimInt64}
+	TUInt8   = &PrimType{Kind: PrimUInt8}
+	TUInt16  = &PrimType{Kind: PrimUInt16}
+	TUInt32  = &PrimType{Kind: PrimUInt32}
+	TUInt64  = &PrimType{Kind: PrimUInt64}
+	TByte    = &PrimType{Kind: PrimByte}
+	TFloat   = &PrimType{Kind: PrimFloat}
+	TFloat32 = &PrimType{Kind: PrimFloat32}
+	TFloat64 = &PrimType{Kind: PrimFloat64}
+	TBool    = &PrimType{Kind: PrimBool}
+	TChar    = &PrimType{Kind: PrimChar}
+	TString  = &PrimType{Kind: PrimString}
+	TBytes   = &PrimType{Kind: PrimBytes}
+	TUnit    = &PrimType{Kind: PrimUnit}
+	TNever   = &PrimType{Kind: PrimNever}
+)
+
+// NamedType refers to a user-declared or builtin named type by its
+// source name. Args carries type arguments for generics (e.g.
+// List<Int> → NamedType{Name:"List", Args:[TInt]}). The Builtin flag
+// distinguishes prelude-provided names (List, Map, Set, Option, Result)
+// from user declarations; backends commonly need that distinction to
+// choose between a runtime primitive and a user type.
+type NamedType struct {
+	Name    string
+	Args    []Type
+	Builtin bool
+}
+
+func (*NamedType) typeNode() {}
+
+func (n *NamedType) String() string {
+	if len(n.Args) == 0 {
+		return n.Name
+	}
+	var b strings.Builder
+	b.WriteString(n.Name)
+	b.WriteByte('<')
+	for i, a := range n.Args {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(typeString(a))
+	}
+	b.WriteByte('>')
+	return b.String()
+}
+
+// OptionalType is the surface form `T?`. Kept distinct from
+// NamedType{"Option"} so backends can special-case optional-chain
+// lowering without matching on strings.
+type OptionalType struct{ Inner Type }
+
+func (*OptionalType) typeNode()     {}
+func (o *OptionalType) String() string { return typeString(o.Inner) + "?" }
+
+// TupleType is `(T1, T2, ...)`. Single-element tuples are legal.
+type TupleType struct{ Elems []Type }
+
+func (*TupleType) typeNode() {}
+
+func (t *TupleType) String() string {
+	var b strings.Builder
+	b.WriteByte('(')
+	for i, e := range t.Elems {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(typeString(e))
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+// FnType is `fn(A, B) -> R`.
+type FnType struct {
+	Params []Type
+	Return Type
+}
+
+func (*FnType) typeNode() {}
+
+func (f *FnType) String() string {
+	var b strings.Builder
+	b.WriteString("fn(")
+	for i, p := range f.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(typeString(p))
+	}
+	b.WriteByte(')')
+	if f.Return != nil {
+		if p, ok := f.Return.(*PrimType); !ok || p.Kind != PrimUnit {
+			b.WriteString(" -> ")
+			b.WriteString(typeString(f.Return))
+		}
+	}
+	return b.String()
+}
+
+// TypeVar is a reference to a generic type parameter (`T` etc). Name is
+// the parameter's source name; Owner is the qualified owner (e.g. the
+// fn or type declaration's name) used for identity — two `T`s on
+// different owners are not equal.
+type TypeVar struct {
+	Name  string
+	Owner string
+}
+
+func (*TypeVar) typeNode()     {}
+func (v *TypeVar) String() string { return v.Name }
+
+// ErrType is the poisoned type used when lowering cannot recover a real
+// type for an expression. Backends should treat it as "already
+// reported" and avoid cascading diagnostics.
+type ErrType struct{}
+
+func (*ErrType) typeNode()   {}
+func (*ErrType) String() string { return "<error>" }
+
+// ErrTypeVal is the canonical poisoned singleton.
+var ErrTypeVal Type = &ErrType{}
+
+// typeString is a nil-safe wrapper around Type.String.
+func typeString(t Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.String()
+}
+
+// ==== Declarations ====
+
+// Decl is the common interface for every top-level declaration.
+type Decl interface {
+	Node
+	declNode()
+	DeclName() string
+}
+
+// FnDecl is a top-level function. Receiver and Generics are nil/empty
+// for free functions; methods carry a non-nil Receiver naming the
+// owning type. The backend emits Methods lists inside StructDecl /
+// EnumDecl instead of threading receivers through here.
+type FnDecl struct {
+	Name     string
+	Params   []*Param
+	Return   Type
+	Body     *Block
+	Exported bool
+	Generics []*TypeParam
+	SpanV    Span
+}
+
+func (*FnDecl) declNode()        {}
+func (f *FnDecl) At() Span       { return f.SpanV }
+func (f *FnDecl) DeclName() string { return f.Name }
+
+// Param is one function / method parameter. Default is an already
+// lowered expression or nil when absent.
+type Param struct {
+	Name    string
+	Type    Type
+	Default Expr
+	SpanV   Span
+}
+
+func (p *Param) At() Span { return p.SpanV }
+
+// TypeParam is a generic type parameter `T` with optional bounds. The
+// bounds are interface names (already-lowered NamedType).
+type TypeParam struct {
+	Name   string
+	Bounds []Type
+	SpanV  Span
+}
+
+func (t *TypeParam) At() Span { return t.SpanV }
+
+// StructDecl is a struct declaration with its field list and methods.
+type StructDecl struct {
+	Name     string
+	Fields   []*Field
+	Methods  []*FnDecl
+	Generics []*TypeParam
+	Exported bool
+	SpanV    Span
+}
+
+func (*StructDecl) declNode()        {}
+func (s *StructDecl) At() Span       { return s.SpanV }
+func (s *StructDecl) DeclName() string { return s.Name }
+
+// Field is one struct field.
+type Field struct {
+	Name     string
+	Type     Type
+	Default  Expr
+	Exported bool
+	SpanV    Span
+}
+
+func (f *Field) At() Span { return f.SpanV }
+
+// EnumDecl is an enum with its variants and methods.
+type EnumDecl struct {
+	Name     string
+	Variants []*Variant
+	Methods  []*FnDecl
+	Generics []*TypeParam
+	Exported bool
+	SpanV    Span
+}
+
+func (*EnumDecl) declNode()        {}
+func (e *EnumDecl) At() Span       { return e.SpanV }
+func (e *EnumDecl) DeclName() string { return e.Name }
+
+// Variant is one enum case. Payload is the tuple of variant payload
+// types; nil for bare variants.
+type Variant struct {
+	Name    string
+	Payload []Type
+	SpanV   Span
+}
+
+func (v *Variant) At() Span { return v.SpanV }
+
+// LetDecl is a top-level `pub let NAME = value`.
+type LetDecl struct {
+	Name     string
+	Type     Type
+	Value    Expr
+	Mut      bool
+	Exported bool
+	SpanV    Span
+}
+
+func (*LetDecl) declNode()        {}
+func (l *LetDecl) At() Span       { return l.SpanV }
+func (l *LetDecl) DeclName() string { return l.Name }
+
+// ==== Statements ====
+
+// Stmt is the common interface for every IR statement.
+type Stmt interface {
+	Node
+	stmtNode()
+}
+
+// Block is a scoped sequence of statements with an optional final
+// expression (the block's "result"). Normalising blocks this way means
+// callers don't have to rescan the tail for implicit-return semantics.
+type Block struct {
+	Stmts  []Stmt
+	Result Expr // optional final expression; nil means block yields unit
+	SpanV  Span
+}
+
+func (*Block) stmtNode() {}
+func (b *Block) At() Span { return b.SpanV }
+
+// LetStmt introduces a local binding. Patterns more complex than bare
+// identifiers lower to an internal temporary plus per-binding LetStmts
+// (not implemented yet — the lowerer emits an ErrorStmt in that case).
+type LetStmt struct {
+	Name  string
+	Type  Type
+	Value Expr
+	Mut   bool
+	SpanV Span
+}
+
+func (*LetStmt) stmtNode() {}
+func (l *LetStmt) At() Span { return l.SpanV }
+
+// ExprStmt is an expression used in statement position (side effect).
+type ExprStmt struct {
+	X     Expr
+	SpanV Span
+}
+
+func (*ExprStmt) stmtNode() {}
+func (e *ExprStmt) At() Span { return e.SpanV }
+
+// AssignOp classifies the flavor of an assignment statement.
+type AssignOp int
+
+const (
+	AssignEq AssignOp = iota
+	AssignAdd
+	AssignSub
+	AssignMul
+	AssignDiv
+	AssignMod
+	AssignAnd
+	AssignOr
+	AssignXor
+	AssignShl
+	AssignShr
+)
+
+// AssignStmt covers plain and compound assignments. Tuple-destructuring
+// assignment is not yet represented here; the lowerer rejects it.
+type AssignStmt struct {
+	Op     AssignOp
+	Target Expr
+	Value  Expr
+	SpanV  Span
+}
+
+func (*AssignStmt) stmtNode() {}
+func (a *AssignStmt) At() Span { return a.SpanV }
+
+// ReturnStmt is `return` or `return value`. Value is nil for a bare
+// return (unit return type).
+type ReturnStmt struct {
+	Value Expr
+	SpanV Span
+}
+
+func (*ReturnStmt) stmtNode() {}
+func (r *ReturnStmt) At() Span { return r.SpanV }
+
+// BreakStmt exits the innermost loop.
+type BreakStmt struct{ SpanV Span }
+
+func (*BreakStmt) stmtNode() {}
+func (b *BreakStmt) At() Span { return b.SpanV }
+
+// ContinueStmt skips to the next loop iteration.
+type ContinueStmt struct{ SpanV Span }
+
+func (*ContinueStmt) stmtNode() {}
+func (c *ContinueStmt) At() Span { return c.SpanV }
+
+// IfStmt is a statement-position conditional. Else is nil when there
+// is no else clause.
+type IfStmt struct {
+	Cond  Expr
+	Then  *Block
+	Else  *Block
+	SpanV Span
+}
+
+func (*IfStmt) stmtNode() {}
+func (i *IfStmt) At() Span { return i.SpanV }
+
+// ForKind classifies the `for` variant.
+type ForKind int
+
+const (
+	ForInfinite ForKind = iota
+	ForWhile            // cond-controlled
+	ForRange            // numeric range: `for i in a..b`
+	ForIn               // iterator: `for x in xs`
+)
+
+// ForStmt covers all four `for` forms. Fields are set selectively by
+// Kind:
+//
+//	Infinite: Body
+//	While:    Cond, Body
+//	Range:    Var, Start, End, Inclusive, Body
+//	In:       Var, Iter, Body
+type ForStmt struct {
+	Kind      ForKind
+	Var       string // loop variable (Range, In)
+	Cond      Expr   // While
+	Iter      Expr   // In
+	Start     Expr   // Range
+	End       Expr   // Range
+	Inclusive bool   // Range `..=`
+	Body      *Block
+	SpanV     Span
+}
+
+func (*ForStmt) stmtNode() {}
+func (f *ForStmt) At() Span { return f.SpanV }
+
+// ErrorStmt is the poisoned statement emitted when lowering fails. The
+// Note is propagated up in the Module's issue list so backends and the
+// test suite can report it.
+type ErrorStmt struct {
+	Note  string
+	SpanV Span
+}
+
+func (*ErrorStmt) stmtNode() {}
+func (e *ErrorStmt) At() Span { return e.SpanV }
+
+// ==== Expressions ====
+
+// Expr is the common interface for every IR expression. Every
+// expression carries its inferred Type, so backends never need to look
+// up a side table.
+type Expr interface {
+	Node
+	exprNode()
+	Type() Type
+}
+
+// IntLit is an integer literal. Text is the original source form
+// (preserves radix/underscores for exact emission).
+type IntLit struct {
+	Text  string
+	T     Type
+	SpanV Span
+}
+
+func (*IntLit) exprNode() {}
+func (l *IntLit) At() Span { return l.SpanV }
+func (l *IntLit) Type() Type { return l.T }
+
+// FloatLit is a float literal.
+type FloatLit struct {
+	Text  string
+	T     Type
+	SpanV Span
+}
+
+func (*FloatLit) exprNode() {}
+func (l *FloatLit) At() Span { return l.SpanV }
+func (l *FloatLit) Type() Type { return l.T }
+
+// BoolLit is `true` / `false`.
+type BoolLit struct {
+	Value bool
+	SpanV Span
+}
+
+func (*BoolLit) exprNode() {}
+func (l *BoolLit) At() Span { return l.SpanV }
+func (l *BoolLit) Type() Type { return TBool }
+
+// CharLit is a single-code-point char literal.
+type CharLit struct {
+	Value rune
+	SpanV Span
+}
+
+func (*CharLit) exprNode() {}
+func (l *CharLit) At() Span { return l.SpanV }
+func (l *CharLit) Type() Type { return TChar }
+
+// ByteLit is a byte literal (0..=255).
+type ByteLit struct {
+	Value byte
+	SpanV Span
+}
+
+func (*ByteLit) exprNode() {}
+func (l *ByteLit) At() Span { return l.SpanV }
+func (l *ByteLit) Type() Type { return TByte }
+
+// StringLit is a possibly interpolated string literal. Parts alternate
+// literal text and inner expressions — backends format the whole thing
+// via their own formatter (fmt.Sprintf for the Go backend).
+type StringLit struct {
+	Parts    []StringPart
+	IsRaw    bool
+	IsTriple bool
+	SpanV    Span
+}
+
+// StringPart is either a literal text segment (IsLit) or an embedded
+// expression (Expr).
+type StringPart struct {
+	IsLit bool
+	Lit   string
+	Expr  Expr
+}
+
+func (*StringLit) exprNode() {}
+func (s *StringLit) At() Span { return s.SpanV }
+func (*StringLit) Type() Type { return TString }
+
+// UnitLit is the `()` zero-value expression, used as an implicit block
+// result when no expression was provided.
+type UnitLit struct{ SpanV Span }
+
+func (*UnitLit) exprNode() {}
+func (u *UnitLit) At() Span { return u.SpanV }
+func (*UnitLit) Type() Type { return TUnit }
+
+// IdentKind classifies what an Ident resolves to. Lowering populates
+// this so backends do not need a resolver.
+type IdentKind int
+
+const (
+	IdentUnknown IdentKind = iota
+	IdentLocal            // let binding or closure capture
+	IdentParam            // function/method parameter
+	IdentFn               // top-level function
+	IdentVariant          // enum variant
+	IdentTypeName         // struct/enum/interface/alias used as value
+	IdentGlobal           // top-level `let`
+	IdentBuiltin          // prelude / builtin
+)
+
+// Ident is a name reference. Kind distinguishes locals from calls on
+// top-level fn names so the backend can rewrite user calls without a
+// second resolution pass.
+type Ident struct {
+	Name  string
+	Kind  IdentKind
+	T     Type
+	SpanV Span
+}
+
+func (*Ident) exprNode() {}
+func (i *Ident) At() Span { return i.SpanV }
+func (i *Ident) Type() Type { return i.T }
+
+// UnOp enumerates prefix operators.
+type UnOp int
+
+const (
+	UnNeg UnOp = iota // -x
+	UnPlus              // +x
+	UnNot               // !x
+	UnBitNot            // ~x
+)
+
+// UnaryExpr is a prefix unary operation.
+type UnaryExpr struct {
+	Op    UnOp
+	X     Expr
+	T     Type
+	SpanV Span
+}
+
+func (*UnaryExpr) exprNode() {}
+func (e *UnaryExpr) At() Span { return e.SpanV }
+func (e *UnaryExpr) Type() Type { return e.T }
+
+// BinOp enumerates binary operators. Covers arithmetic, comparison,
+// logical, and bitwise operators. Range and coalesce operators have
+// their own expression types.
+type BinOp int
+
+const (
+	BinAdd BinOp = iota
+	BinSub
+	BinMul
+	BinDiv
+	BinMod
+
+	BinEq
+	BinNeq
+	BinLt
+	BinLeq
+	BinGt
+	BinGeq
+
+	BinAnd // &&
+	BinOr  // ||
+
+	BinBitAnd
+	BinBitOr
+	BinBitXor
+	BinShl
+	BinShr
+)
+
+// BinaryExpr is a binary infix operation.
+type BinaryExpr struct {
+	Op    BinOp
+	Left  Expr
+	Right Expr
+	T     Type
+	SpanV Span
+}
+
+func (*BinaryExpr) exprNode() {}
+func (e *BinaryExpr) At() Span { return e.SpanV }
+func (e *BinaryExpr) Type() Type { return e.T }
+
+// CallExpr is a user function / method / closure call.
+type CallExpr struct {
+	Callee Expr
+	Args   []Expr
+	T      Type
+	SpanV  Span
+}
+
+func (*CallExpr) exprNode() {}
+func (c *CallExpr) At() Span { return c.SpanV }
+func (c *CallExpr) Type() Type { return c.T }
+
+// IntrinsicKind enumerates the print-family intrinsics that Lower
+// recognises directly. Backends emit these via their runtime's
+// formatted-print machinery.
+type IntrinsicKind int
+
+const (
+	IntrinsicPrint IntrinsicKind = iota
+	IntrinsicPrintln
+	IntrinsicEprint
+	IntrinsicEprintln
+)
+
+// IntrinsicCall is a call to one of the recognised built-in print
+// intrinsics. Kept distinct from CallExpr so backends can dispatch
+// directly rather than string-matching on names.
+type IntrinsicCall struct {
+	Kind  IntrinsicKind
+	Args  []Expr
+	SpanV Span
+}
+
+func (*IntrinsicCall) exprNode() {}
+func (i *IntrinsicCall) At() Span { return i.SpanV }
+func (*IntrinsicCall) Type() Type { return TUnit }
+
+// ListLit is a homogeneous list literal `[a, b, c]`. Elem is the
+// declared element type (populated from the checker's view of the
+// expression's type).
+type ListLit struct {
+	Elems []Expr
+	Elem  Type
+	SpanV Span
+}
+
+func (*ListLit) exprNode() {}
+func (l *ListLit) At() Span { return l.SpanV }
+func (l *ListLit) Type() Type { return &NamedType{Name: "List", Args: []Type{l.Elem}, Builtin: true} }
+
+// BlockExpr is a block used in expression position. The block's Result
+// is the value produced; backends may rewrite this into an IIFE when
+// the host language lacks block-as-expression support.
+type BlockExpr struct {
+	Block *Block
+	T     Type
+	SpanV Span
+}
+
+func (*BlockExpr) exprNode() {}
+func (b *BlockExpr) At() Span { return b.SpanV }
+func (b *BlockExpr) Type() Type { return b.T }
+
+// IfExpr is an `if` used in expression position. Both arms are
+// guaranteed present; statement-form `if` without else lowers to
+// IfStmt instead.
+type IfExpr struct {
+	Cond  Expr
+	Then  *Block
+	Else  *Block
+	T     Type
+	SpanV Span
+}
+
+func (*IfExpr) exprNode() {}
+func (i *IfExpr) At() Span { return i.SpanV }
+func (i *IfExpr) Type() Type { return i.T }
+
+// ErrorExpr is the poisoned expression emitted when lowering fails for
+// a sub-expression. Backends should render a comment and skip.
+type ErrorExpr struct {
+	Note  string
+	T     Type
+	SpanV Span
+}
+
+func (*ErrorExpr) exprNode() {}
+func (e *ErrorExpr) At() Span { return e.SpanV }
+func (e *ErrorExpr) Type() Type {
+	if e.T == nil {
+		return ErrTypeVal
+	}
+	return e.T
+}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -405,15 +405,18 @@ type Block struct {
 func (*Block) stmtNode() {}
 func (b *Block) At() Span { return b.SpanV }
 
-// LetStmt introduces a local binding. Patterns more complex than bare
-// identifiers lower to an internal temporary plus per-binding LetStmts
-// (not implemented yet — the lowerer emits an ErrorStmt in that case).
+// LetStmt introduces a local binding. For the common case (`let x = e`)
+// Pattern is nil and Name carries the bound identifier. For
+// destructuring binds (`let (a, b) = e`, `let User { name } = e`),
+// Pattern is non-nil and Name is empty; consumers dispatch on Pattern
+// to emit per-binding destructuring code.
 type LetStmt struct {
-	Name  string
-	Type  Type
-	Value Expr
-	Mut   bool
-	SpanV Span
+	Name    string
+	Pattern Pattern
+	Type    Type
+	Value   Expr
+	Mut     bool
+	SpanV   Span
 }
 
 func (*LetStmt) stmtNode() {}
@@ -445,13 +448,15 @@ const (
 	AssignShr
 )
 
-// AssignStmt covers plain and compound assignments. Tuple-destructuring
-// assignment is not yet represented here; the lowerer rejects it.
+// AssignStmt covers plain and compound assignments, including
+// multi-target tuple destructuring (`(a, b) = (c, d)`). Single-target
+// assignments still have len(Targets) == 1; consumers should branch on
+// the length rather than maintaining two shapes.
 type AssignStmt struct {
-	Op     AssignOp
-	Target Expr
-	Value  Expr
-	SpanV  Span
+	Op      AssignOp
+	Targets []Expr
+	Value   Expr
+	SpanV   Span
 }
 
 func (*AssignStmt) stmtNode() {}
@@ -815,3 +820,317 @@ func (e *ErrorExpr) Type() Type {
 	}
 	return e.T
 }
+
+// ==== Additional declarations ====
+
+// InterfaceDecl is an interface with a set of required methods and
+// optional defaults. Extends lists composed interfaces; every element
+// is a NamedType.
+type InterfaceDecl struct {
+	Name     string
+	Methods  []*FnDecl
+	Extends  []Type
+	Generics []*TypeParam
+	Exported bool
+	SpanV    Span
+}
+
+func (*InterfaceDecl) declNode()          {}
+func (i *InterfaceDecl) At() Span         { return i.SpanV }
+func (i *InterfaceDecl) DeclName() string { return i.Name }
+
+// TypeAliasDecl is `type Name<T> = Target`.
+type TypeAliasDecl struct {
+	Name     string
+	Generics []*TypeParam
+	Target   Type
+	Exported bool
+	SpanV    Span
+}
+
+func (*TypeAliasDecl) declNode()          {}
+func (t *TypeAliasDecl) At() Span         { return t.SpanV }
+func (t *TypeAliasDecl) DeclName() string { return t.Name }
+
+// UseDecl is a `use` import. Path is the source-level dotted path
+// (["std","io"]), Alias is the bound name (the last path segment when
+// the user didn't write `as alias`). GoPath / GoBody mirror the FFI
+// form `use go "path" { ... }`; they are empty for ordinary imports.
+type UseDecl struct {
+	Path    []string
+	RawPath string
+	Alias   string
+	IsGoFFI bool
+	GoPath  string
+	GoBody  []Decl
+	SpanV   Span
+}
+
+func (*UseDecl) declNode()          {}
+func (u *UseDecl) At() Span         { return u.SpanV }
+func (u *UseDecl) DeclName() string { return u.Alias }
+
+// ==== Additional statements ====
+
+// DeferStmt schedules Body to run on scope exit.
+type DeferStmt struct {
+	Body  *Block
+	SpanV Span
+}
+
+func (*DeferStmt) stmtNode() {}
+func (d *DeferStmt) At() Span { return d.SpanV }
+
+// ChanSendStmt is `channel <- value`.
+type ChanSendStmt struct {
+	Channel Expr
+	Value   Expr
+	SpanV   Span
+}
+
+func (*ChanSendStmt) stmtNode() {}
+func (c *ChanSendStmt) At() Span { return c.SpanV }
+
+// MatchStmt is a `match` scrutinee used in statement position. The
+// equivalent expression form (MatchExpr) has a non-unit Type; when the
+// checker determined the match is used for side effects only, the
+// lowerer emits MatchStmt so backends don't synthesise a wasted value.
+type MatchStmt struct {
+	Scrutinee Expr
+	Arms      []*MatchArm
+	SpanV     Span
+}
+
+func (*MatchStmt) stmtNode() {}
+func (m *MatchStmt) At() Span { return m.SpanV }
+
+// ==== Additional expressions ====
+
+// FieldExpr is `x.name` or `x?.name` (when Optional is true).
+type FieldExpr struct {
+	X        Expr
+	Name     string
+	Optional bool
+	T        Type
+	SpanV    Span
+}
+
+func (*FieldExpr) exprNode()      {}
+func (f *FieldExpr) At() Span     { return f.SpanV }
+func (f *FieldExpr) Type() Type   { return f.T }
+
+// IndexExpr is `x[i]`.
+type IndexExpr struct {
+	X     Expr
+	Index Expr
+	T     Type
+	SpanV Span
+}
+
+func (*IndexExpr) exprNode()    {}
+func (e *IndexExpr) At() Span   { return e.SpanV }
+func (e *IndexExpr) Type() Type { return e.T }
+
+// MethodCall is a user-written method call `receiver.name(args)`. Kept
+// distinct from CallExpr so backends don't have to unwrap a FieldExpr
+// callee every time. TypeArgs carries turbofish arguments; empty when
+// not supplied.
+type MethodCall struct {
+	Receiver Expr
+	Name     string
+	TypeArgs []Type
+	Args     []Expr
+	T        Type
+	SpanV    Span
+}
+
+func (*MethodCall) exprNode()    {}
+func (m *MethodCall) At() Span   { return m.SpanV }
+func (m *MethodCall) Type() Type { return m.T }
+
+// StructLit is `Type { field: value, ..spread }`. Spread is nil when
+// no `..rest` was written.
+type StructLit struct {
+	TypeName string
+	Fields   []StructLitField
+	Spread   Expr
+	T        Type
+	SpanV    Span
+}
+
+// StructLitField is `name: value` (Value set) or `name` (Value nil =
+// shorthand, resolve to a local binding named `name`).
+type StructLitField struct {
+	Name  string
+	Value Expr
+	SpanV Span
+}
+
+func (f StructLitField) At() Span { return f.SpanV }
+
+func (*StructLit) exprNode()    {}
+func (s *StructLit) At() Span   { return s.SpanV }
+func (s *StructLit) Type() Type { return s.T }
+
+// TupleLit is `(a, b, c)`; backends rely on len(Elems) ≥ 2.
+// Single-element tuples arriving from the parser lower to just their
+// inner expression (parens were informational only).
+type TupleLit struct {
+	Elems []Expr
+	T     Type
+	SpanV Span
+}
+
+func (*TupleLit) exprNode()    {}
+func (t *TupleLit) At() Span   { return t.SpanV }
+func (t *TupleLit) Type() Type { return t.T }
+
+// MapLit is `{"k": v, ...}` or the empty `{:}` literal. KeyT/ValT are
+// the declared key/value types (populated from the checker's view).
+type MapLit struct {
+	Entries []MapEntry
+	KeyT    Type
+	ValT    Type
+	SpanV   Span
+}
+
+// MapEntry is one `key: value` in a MapLit.
+type MapEntry struct {
+	Key   Expr
+	Value Expr
+	SpanV Span
+}
+
+func (e MapEntry) At() Span { return e.SpanV }
+
+func (*MapLit) exprNode()  {}
+func (m *MapLit) At() Span { return m.SpanV }
+func (m *MapLit) Type() Type {
+	return &NamedType{Name: "Map", Args: []Type{m.KeyT, m.ValT}, Builtin: true}
+}
+
+// RangeLit is a range used in value position (`let r = 0..10`). Loop
+// heads lower to ForStmt with Kind=ForRange instead of constructing a
+// RangeLit. Start and End may be nil for unbounded sides.
+type RangeLit struct {
+	Start     Expr
+	End       Expr
+	Inclusive bool
+	T         Type
+	SpanV     Span
+}
+
+func (*RangeLit) exprNode()    {}
+func (r *RangeLit) At() Span   { return r.SpanV }
+func (r *RangeLit) Type() Type { return r.T }
+
+// QuestionExpr is the postfix `?` error / Option propagation operator.
+// X is the operand; T is the unwrapped value type. Backends expand
+// this into a runtime conditional return.
+type QuestionExpr struct {
+	X     Expr
+	T     Type
+	SpanV Span
+}
+
+func (*QuestionExpr) exprNode()    {}
+func (q *QuestionExpr) At() Span   { return q.SpanV }
+func (q *QuestionExpr) Type() Type { return q.T }
+
+// CoalesceExpr is `left ?? right`: yields Left when Left is non-nil,
+// else Right. T is the joined (non-optional) type.
+type CoalesceExpr struct {
+	Left  Expr
+	Right Expr
+	T     Type
+	SpanV Span
+}
+
+func (*CoalesceExpr) exprNode()    {}
+func (c *CoalesceExpr) At() Span   { return c.SpanV }
+func (c *CoalesceExpr) Type() Type { return c.T }
+
+// Closure is `|params| body` (short form) or `|params| -> T { body }`.
+// Body is always lowered as a *Block for uniformity; a single-
+// expression closure is wrapped with Result set and Stmts empty.
+type Closure struct {
+	Params []*Param
+	Return Type
+	Body   *Block
+	T      Type
+	SpanV  Span
+}
+
+func (*Closure) exprNode()    {}
+func (c *Closure) At() Span   { return c.SpanV }
+func (c *Closure) Type() Type { return c.T }
+
+// VariantLit constructs an enum variant value: `Some(42)`, `Ok(x)`,
+// `Red` (bare), `Color.Red` (qualified). Enum is the enum's source
+// name when known; empty for unresolved prelude variants.
+type VariantLit struct {
+	Enum    string
+	Variant string
+	Args    []Expr
+	T       Type
+	SpanV   Span
+}
+
+func (*VariantLit) exprNode()    {}
+func (v *VariantLit) At() Span   { return v.SpanV }
+func (v *VariantLit) Type() Type { return v.T }
+
+// MatchExpr is `match scrutinee { arm, ... }`.
+type MatchExpr struct {
+	Scrutinee Expr
+	Arms      []*MatchArm
+	T         Type
+	SpanV     Span
+}
+
+func (*MatchExpr) exprNode()    {}
+func (m *MatchExpr) At() Span   { return m.SpanV }
+func (m *MatchExpr) Type() Type { return m.T }
+
+// MatchArm is one match case. Guard is an optional `if cond` refinement
+// applied after the pattern succeeds. Body is a block whose Result
+// carries the arm value (nil for unit-producing arms).
+type MatchArm struct {
+	Pattern Pattern
+	Guard   Expr
+	Body    *Block
+	SpanV   Span
+}
+
+func (a *MatchArm) At() Span { return a.SpanV }
+
+// IfLetExpr is `if let pat = scrutinee { then } else { else }`. Kept
+// distinct from IfExpr so backends can recognise the destructure-and-
+// match form directly; the Cond/boolean form stays as IfExpr.
+type IfLetExpr struct {
+	Pattern   Pattern
+	Scrutinee Expr
+	Then      *Block
+	Else      *Block
+	T         Type
+	SpanV     Span
+}
+
+func (*IfLetExpr) exprNode()    {}
+func (i *IfLetExpr) At() Span   { return i.SpanV }
+func (i *IfLetExpr) Type() Type { return i.T }
+
+// TupleAccess is `t.0` / `t.1` — numeric field access on tuples. The
+// AST spells this as FieldExpr with a numeric Name; the lowerer
+// hoists tuple-indexed field access to this dedicated node so
+// backends don't need to disambiguate numeric vs. alphabetic names.
+type TupleAccess struct {
+	X     Expr
+	Index int
+	T     Type
+	SpanV Span
+}
+
+func (*TupleAccess) exprNode()    {}
+func (t *TupleAccess) At() Span   { return t.SpanV }
+func (t *TupleAccess) Type() Type { return t.T }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -87,11 +87,12 @@ func (l *lowerer) lowerDecl(d ast.Decl) Decl {
 		return l.lowerEnumDecl(d)
 	case *ast.LetDecl:
 		return l.lowerLetDecl(d)
-	case *ast.UseDecl, *ast.InterfaceDecl, *ast.TypeAliasDecl:
-		// Out of scope for the current IR shape. Not an error — these
-		// are either consumed by the resolver (Use) or reserved for a
-		// later IR expansion (Interface, TypeAlias).
-		return nil
+	case *ast.UseDecl:
+		return l.lowerUseDecl(d)
+	case *ast.InterfaceDecl:
+		return l.lowerInterfaceDecl(d)
+	case *ast.TypeAliasDecl:
+		return l.lowerTypeAliasDecl(d)
 	}
 	l.note("unsupported top-level decl %T", d)
 	return nil
@@ -511,6 +512,14 @@ func (l *lowerer) lowerStmt(s ast.Stmt) Stmt {
 		return l.lowerAssignStmt(s)
 	case *ast.ForStmt:
 		return l.lowerForStmt(s)
+	case *ast.DeferStmt:
+		return l.lowerDeferStmt(s)
+	case *ast.ChanSendStmt:
+		return &ChanSendStmt{
+			Channel: l.lowerExpr(s.Channel),
+			Value:   l.lowerExpr(s.Value),
+			SpanV:   nodeSpan(s),
+		}
 	}
 	// Fall through: if it's actually an if used at statement position,
 	// the parser wrapped it in an ExprStmt already; we only get here
@@ -520,17 +529,14 @@ func (l *lowerer) lowerStmt(s ast.Stmt) Stmt {
 }
 
 func (l *lowerer) lowerLetStmt(s *ast.LetStmt) Stmt {
-	// Only bare-ident patterns are lowered directly; destructuring
-	// patterns aren't representable in the current IR shape.
-	name, ok := simpleBindName(s.Pattern)
-	if !ok {
-		l.note("destructuring `let` at %v not yet lowered", s.Pos())
-		return &ErrorStmt{Note: "destructuring let", SpanV: nodeSpan(s)}
-	}
 	out := &LetStmt{
-		Name:  name,
 		Mut:   s.Mut,
 		SpanV: nodeSpan(s),
+	}
+	if name, ok := simpleBindName(s.Pattern); ok {
+		out.Name = name
+	} else {
+		out.Pattern = l.lowerPattern(s.Pattern)
 	}
 	if s.Type != nil {
 		out.Type = l.lowerType(s.Type)
@@ -555,16 +561,15 @@ func simpleBindName(p ast.Pattern) (string, bool) {
 }
 
 func (l *lowerer) lowerAssignStmt(s *ast.AssignStmt) Stmt {
-	if len(s.Targets) != 1 {
-		l.note("multi-target assignment at %v not yet lowered", s.Pos())
-		return &ErrorStmt{Note: "multi-assign", SpanV: nodeSpan(s)}
+	out := &AssignStmt{
+		Op:    assignOp(s.Op),
+		Value: l.lowerExpr(s.Value),
+		SpanV: nodeSpan(s),
 	}
-	return &AssignStmt{
-		Op:     assignOp(s.Op),
-		Target: l.lowerExpr(s.Targets[0]),
-		Value:  l.lowerExpr(s.Value),
-		SpanV:  nodeSpan(s),
+	for _, t := range s.Targets {
+		out.Targets = append(out.Targets, l.lowerExpr(t))
 	}
+	return out
 }
 
 func (l *lowerer) lowerForStmt(s *ast.ForStmt) Stmt {
@@ -576,10 +581,12 @@ func (l *lowerer) lowerForStmt(s *ast.ForStmt) Stmt {
 	if s.Pattern == nil && s.Iter != nil {
 		return &ForStmt{Kind: ForWhile, Cond: l.lowerExpr(s.Iter), Body: body, SpanV: nodeSpan(s)}
 	}
-	name, ok := simpleBindName(s.Pattern)
-	if !ok {
-		l.note("for with destructuring pattern at %v not yet lowered", s.Pos())
-		return &ErrorStmt{Note: "for destructuring", SpanV: nodeSpan(s)}
+	name, _ := simpleBindName(s.Pattern)
+	// Non-ident patterns lower to a tuple-style ForIn with a
+	// destructuring binding in the body. For now we keep Var empty and
+	// annotate the issue; a follow-on can introduce ForDestructure.
+	if name == "" {
+		l.note("for with destructuring pattern at %v collapsed to ForIn with unnamed var", s.Pos())
 	}
 	// for x in a..b is a numeric range loop.
 	if r, ok := s.Iter.(*ast.RangeExpr); ok && r.Start != nil && r.Stop != nil {
@@ -644,7 +651,6 @@ func (l *lowerer) lowerExpr(e ast.Expr) Expr {
 	case *ast.Ident:
 		return l.lowerIdent(e)
 	case *ast.ParenExpr:
-		// Parens carry no semantic content in the IR.
 		return l.lowerExpr(e.X)
 	case *ast.UnaryExpr:
 		return l.lowerUnary(e)
@@ -667,6 +673,49 @@ func (l *lowerer) lowerExpr(e ast.Expr) Expr {
 		return &BlockExpr{Block: blk, T: t, SpanV: nodeSpan(e)}
 	case *ast.IfExpr:
 		return l.lowerIfExpr(e)
+	case *ast.MatchExpr:
+		return l.lowerMatchExpr(e)
+	case *ast.FieldExpr:
+		return l.lowerFieldExpr(e)
+	case *ast.IndexExpr:
+		return &IndexExpr{
+			X:     l.lowerExpr(e.X),
+			Index: l.lowerExpr(e.Index),
+			T:     l.exprType(e),
+			SpanV: nodeSpan(e),
+		}
+	case *ast.StructLit:
+		return l.lowerStructLit(e)
+	case *ast.TupleExpr:
+		if len(e.Elems) == 1 {
+			return l.lowerExpr(e.Elems[0])
+		}
+		out := &TupleLit{T: l.exprType(e), SpanV: nodeSpan(e)}
+		for _, el := range e.Elems {
+			out.Elems = append(out.Elems, l.lowerExpr(el))
+		}
+		return out
+	case *ast.MapExpr:
+		return l.lowerMapLit(e)
+	case *ast.RangeExpr:
+		out := &RangeLit{Inclusive: e.Inclusive, T: l.exprType(e), SpanV: nodeSpan(e)}
+		if e.Start != nil {
+			out.Start = l.lowerExpr(e.Start)
+		}
+		if e.Stop != nil {
+			out.End = l.lowerExpr(e.Stop)
+		}
+		return out
+	case *ast.QuestionExpr:
+		return &QuestionExpr{
+			X:     l.lowerExpr(e.X),
+			T:     l.exprType(e),
+			SpanV: nodeSpan(e),
+		}
+	case *ast.ClosureExpr:
+		return l.lowerClosure(e)
+	case *ast.TurbofishExpr:
+		return l.lowerTurbofish(e)
 	}
 	l.note("unsupported expression %T at %v", e, e.Pos())
 	return &ErrorExpr{Note: fmt.Sprintf("%T", e), T: ErrTypeVal, SpanV: nodeSpan(e)}
@@ -763,6 +812,16 @@ func unaryOp(k token.Kind) (UnOp, bool) {
 }
 
 func (l *lowerer) lowerBinary(e *ast.BinaryExpr) Expr {
+	// `??` gets its own IR node so backends don't have to pattern-match
+	// on a BinaryExpr with a dedicated op when they have special lowering.
+	if e.Op == token.QQ {
+		return &CoalesceExpr{
+			Left:  l.lowerExpr(e.Left),
+			Right: l.lowerExpr(e.Right),
+			T:     l.exprType(e),
+			SpanV: nodeSpan(e),
+		}
+	}
 	op, ok := binaryOp(e.Op)
 	if !ok {
 		l.note("unsupported binary op %v at %v", e.Op, e.Pos())
@@ -820,7 +879,7 @@ func binaryOp(k token.Kind) (BinOp, bool) {
 }
 
 func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
-	// Detect a print-family intrinsic.
+	// Detect a print-family intrinsic on a bare identifier.
 	if id, ok := e.Fn.(*ast.Ident); ok {
 		if k, isIntrinsic := intrinsicByName(id.Name); isIntrinsic {
 			out := &IntrinsicCall{Kind: k, SpanV: nodeSpan(e)}
@@ -833,15 +892,104 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 			}
 			return out
 		}
+		// Check if this is a variant constructor: e.g. Some(42), Ok(x).
+		if sym := l.symbol(id); sym != nil && sym.Kind == resolve.SymVariant {
+			return l.lowerVariantCall(e, "", id.Name)
+		}
+	}
+	// Strip a turbofish wrapper to retain its type arguments.
+	var typeArgs []Type
+	fn := e.Fn
+	if tf, ok := fn.(*ast.TurbofishExpr); ok {
+		for _, a := range tf.Args {
+			typeArgs = append(typeArgs, l.lowerType(a))
+		}
+		fn = tf.Base
+	}
+	// Method call: x.name(args).
+	if fx, ok := fn.(*ast.FieldExpr); ok {
+		// But `Enum.Variant(args)` is a qualified variant constructor,
+		// not a method call — detect via the resolved symbol.
+		if id, ok := fx.X.(*ast.Ident); ok {
+			if sym := l.symbol(id); sym != nil &&
+				(sym.Kind == resolve.SymEnum || sym.Kind == resolve.SymStruct) {
+				// Lookup whether fx.Name is a variant on this enum. We
+				// approximate: if the checker assigned the whole call
+				// a Named type whose Sym is an enum, treat it as a
+				// variant constructor.
+				if l.isVariantOfEnum(sym, fx.Name) {
+					return l.lowerVariantCall(e, sym.Name, fx.Name)
+				}
+			}
+		}
+		return l.lowerMethodCall(e, fx, typeArgs)
 	}
 	out := &CallExpr{
-		Callee: l.lowerExpr(e.Fn),
+		Callee: l.lowerExpr(fn),
 		T:      l.exprType(e),
 		SpanV:  nodeSpan(e),
 	}
 	for _, a := range e.Args {
 		if a.Name != "" {
 			l.note("keyword arg at %v collapsed to positional in IR", a.Pos())
+		}
+		out.Args = append(out.Args, l.lowerExpr(a.Value))
+	}
+	return out
+}
+
+// isVariantOfEnum reports whether variantName is a declared variant on
+// the enum named by sym. Consults the checker's type description table
+// when available.
+func (l *lowerer) isVariantOfEnum(sym *resolve.Symbol, variantName string) bool {
+	if sym == nil || sym.Kind != resolve.SymEnum || sym.Decl == nil {
+		return false
+	}
+	ed, ok := sym.Decl.(*ast.EnumDecl)
+	if !ok {
+		return false
+	}
+	for _, v := range ed.Variants {
+		if v.Name == variantName {
+			return true
+		}
+	}
+	return false
+}
+
+// lowerMethodCall lowers `receiver.name(args)` into an IR MethodCall,
+// preserving turbofish type arguments.
+func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs []Type) Expr {
+	out := &MethodCall{
+		Receiver: l.lowerExpr(fx.X),
+		Name:     fx.Name,
+		TypeArgs: typeArgs,
+		T:        l.exprType(e),
+		SpanV:    nodeSpan(e),
+	}
+	for _, a := range e.Args {
+		if a.Name != "" {
+			l.note("keyword arg at %v collapsed to positional in IR", a.Pos())
+		}
+		out.Args = append(out.Args, l.lowerExpr(a.Value))
+	}
+	return out
+}
+
+// lowerVariantCall builds a VariantLit from a call whose callee is a
+// variant symbol (`Some(42)`) or an enum-qualified variant
+// (`Color.Red(255)`).
+func (l *lowerer) lowerVariantCall(e *ast.CallExpr, enum, variant string) Expr {
+	out := &VariantLit{
+		Enum:    enum,
+		Variant: variant,
+		T:       l.exprType(e),
+		SpanV:   nodeSpan(e),
+	}
+	for _, a := range e.Args {
+		if a.Name != "" {
+			l.note("keyword arg to variant %s at %v not supported", variant, a.Pos())
+			continue
 		}
 		out.Args = append(out.Args, l.lowerExpr(a.Value))
 	}
@@ -885,22 +1033,35 @@ func (l *lowerer) lowerList(e *ast.ListExpr) Expr {
 func (l *lowerer) lowerIfExpr(e *ast.IfExpr) Expr {
 	t := l.exprType(e)
 	thenBlk := l.lowerBlock(e.Then)
-	var elseBlk *Block
-	switch alt := e.Else.(type) {
-	case nil:
-		// no else; should only appear in statement position.
-	case *ast.Block:
-		elseBlk = l.lowerBlock(alt)
-	case *ast.IfExpr:
-		// else-if chain: wrap the inner IfExpr into a block so the
-		// shape is uniform.
-		inner := l.lowerIfExpr(alt)
-		elseBlk = &Block{Result: inner, SpanV: nodeSpan(alt)}
-	default:
-		lowered := l.lowerExpr(alt.(ast.Expr))
-		elseBlk = &Block{Result: lowered, SpanV: nodeSpan(alt)}
+	elseBlk := l.lowerElse(e.Else)
+	if e.IsIfLet {
+		return &IfLetExpr{
+			Pattern:   l.lowerPattern(e.Pattern),
+			Scrutinee: l.lowerExpr(e.Cond),
+			Then:      thenBlk,
+			Else:      elseBlk,
+			T:         t,
+			SpanV:     nodeSpan(e),
+		}
 	}
 	return &IfExpr{Cond: l.lowerExpr(e.Cond), Then: thenBlk, Else: elseBlk, T: t, SpanV: nodeSpan(e)}
+}
+
+// lowerElse normalises an else arm (which is an ast.Expr per the
+// parser) into a *Block, or nil for no-else.
+func (l *lowerer) lowerElse(alt ast.Expr) *Block {
+	switch alt := alt.(type) {
+	case nil:
+		return nil
+	case *ast.Block:
+		return l.lowerBlock(alt)
+	case *ast.IfExpr:
+		inner := l.lowerIfExpr(alt)
+		return &Block{Result: inner, SpanV: inner.At()}
+	default:
+		lowered := l.lowerExpr(alt)
+		return &Block{Result: lowered, SpanV: lowered.At()}
+	}
 }
 
 // ==== Span helpers ====
@@ -911,4 +1072,312 @@ func posFromToken(p token.Pos) Pos {
 
 func nodeSpan(n ast.Node) Span {
 	return Span{Start: posFromToken(n.Pos()), End: posFromToken(n.End())}
+}
+
+// ==== Additional declarations ====
+
+func (l *lowerer) lowerUseDecl(u *ast.UseDecl) Decl {
+	out := &UseDecl{
+		Path:    append([]string(nil), u.Path...),
+		RawPath: u.RawPath,
+		Alias:   u.Alias,
+		IsGoFFI: u.IsGoFFI,
+		GoPath:  u.GoPath,
+		SpanV:   nodeSpan(u),
+	}
+	if out.Alias == "" && len(out.Path) > 0 {
+		out.Alias = out.Path[len(out.Path)-1]
+	}
+	for _, d := range u.GoBody {
+		if lowered := l.lowerDecl(d); lowered != nil {
+			out.GoBody = append(out.GoBody, lowered)
+		}
+	}
+	return out
+}
+
+func (l *lowerer) lowerInterfaceDecl(id *ast.InterfaceDecl) Decl {
+	out := &InterfaceDecl{
+		Name:     id.Name,
+		Exported: id.Pub,
+		SpanV:    nodeSpan(id),
+	}
+	for _, gp := range id.Generics {
+		out.Generics = append(out.Generics, l.lowerTypeParam(gp, id.Name))
+	}
+	for _, ext := range id.Extends {
+		out.Extends = append(out.Extends, l.lowerType(ext))
+	}
+	for _, m := range id.Methods {
+		out.Methods = append(out.Methods, l.lowerFnDecl(m))
+	}
+	return out
+}
+
+func (l *lowerer) lowerTypeAliasDecl(td *ast.TypeAliasDecl) Decl {
+	out := &TypeAliasDecl{
+		Name:     td.Name,
+		Target:   l.lowerType(td.Target),
+		Exported: td.Pub,
+		SpanV:    nodeSpan(td),
+	}
+	for _, gp := range td.Generics {
+		out.Generics = append(out.Generics, l.lowerTypeParam(gp, td.Name))
+	}
+	return out
+}
+
+// ==== Additional statements ====
+
+func (l *lowerer) lowerDeferStmt(s *ast.DeferStmt) Stmt {
+	// DeferStmt's X is expression-typed but almost always a Block;
+	// normalise to always a *Block in the IR so backends don't have to
+	// peek at the inner expression.
+	out := &DeferStmt{SpanV: nodeSpan(s)}
+	if blk, ok := s.X.(*ast.Block); ok {
+		out.Body = l.lowerBlock(blk)
+		return out
+	}
+	lowered := l.lowerExpr(s.X)
+	out.Body = &Block{
+		Stmts: []Stmt{&ExprStmt{X: lowered, SpanV: lowered.At()}},
+		SpanV: lowered.At(),
+	}
+	return out
+}
+
+// ==== Additional expressions ====
+
+func (l *lowerer) lowerFieldExpr(e *ast.FieldExpr) Expr {
+	// A numeric name (`t.0`) is tuple-indexed access. The parser spells
+	// it with a FieldExpr; lift it to TupleAccess to keep backends
+	// simple.
+	if idx, ok := tupleIndex(e.Name); ok {
+		return &TupleAccess{
+			X:     l.lowerExpr(e.X),
+			Index: idx,
+			T:     l.exprType(e),
+			SpanV: nodeSpan(e),
+		}
+	}
+	return &FieldExpr{
+		X:        l.lowerExpr(e.X),
+		Name:     e.Name,
+		Optional: e.IsOptional,
+		T:        l.exprType(e),
+		SpanV:    nodeSpan(e),
+	}
+}
+
+// tupleIndex parses a field name like "0" or "12" as a tuple index.
+// Returns (idx, true) when the whole string is a non-negative decimal.
+func tupleIndex(name string) (int, bool) {
+	if name == "" {
+		return 0, false
+	}
+	n := 0
+	for _, r := range name {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n, true
+}
+
+func (l *lowerer) lowerStructLit(s *ast.StructLit) Expr {
+	name := ""
+	switch h := s.Type.(type) {
+	case *ast.Ident:
+		name = h.Name
+	case *ast.FieldExpr:
+		// `pkg.Type { ... }` — keep the trailing name; the IR doesn't
+		// model packages yet.
+		name = h.Name
+	}
+	out := &StructLit{
+		TypeName: name,
+		T:        l.exprType(s),
+		SpanV:    nodeSpan(s),
+	}
+	for _, f := range s.Fields {
+		field := StructLitField{
+			Name:  f.Name,
+			SpanV: Span{Start: posFromToken(f.Pos()), End: posFromToken(f.End())},
+		}
+		if f.Value != nil {
+			field.Value = l.lowerExpr(f.Value)
+		}
+		out.Fields = append(out.Fields, field)
+	}
+	if s.Spread != nil {
+		out.Spread = l.lowerExpr(s.Spread)
+	}
+	return out
+}
+
+func (l *lowerer) lowerMapLit(m *ast.MapExpr) Expr {
+	out := &MapLit{SpanV: nodeSpan(m)}
+	for _, en := range m.Entries {
+		out.Entries = append(out.Entries, MapEntry{
+			Key:   l.lowerExpr(en.Key),
+			Value: l.lowerExpr(en.Value),
+			SpanV: Span{Start: posFromToken(en.Pos()), End: posFromToken(en.End())},
+		})
+	}
+	if t := l.exprType(m); t != nil {
+		if nt, ok := t.(*NamedType); ok && nt.Name == "Map" && len(nt.Args) == 2 {
+			out.KeyT = nt.Args[0]
+			out.ValT = nt.Args[1]
+		}
+	}
+	if out.KeyT == nil {
+		out.KeyT = ErrTypeVal
+	}
+	if out.ValT == nil {
+		out.ValT = ErrTypeVal
+	}
+	return out
+}
+
+func (l *lowerer) lowerClosure(c *ast.ClosureExpr) Expr {
+	out := &Closure{
+		Return: l.lowerType(c.ReturnType),
+		T:      l.exprType(c),
+		SpanV:  nodeSpan(c),
+	}
+	if out.Return == nil {
+		out.Return = TUnit
+	}
+	for _, p := range c.Params {
+		out.Params = append(out.Params, l.lowerParam(p))
+	}
+	// Body is always an expression. Wrap non-block bodies in a synthetic
+	// block with the expression as the Result.
+	if blk, ok := c.Body.(*ast.Block); ok {
+		out.Body = l.lowerBlock(blk)
+	} else {
+		lowered := l.lowerExpr(c.Body)
+		out.Body = &Block{Result: lowered, SpanV: lowered.At()}
+	}
+	return out
+}
+
+func (l *lowerer) lowerTurbofish(tf *ast.TurbofishExpr) Expr {
+	// A bare turbofish without a call (`f::<Int>`) is rare but legal;
+	// most appearances are stripped by lowerCall. We retain the base
+	// expression and drop the type args when not consumed, since we
+	// can't currently represent "identifier with type args" cleanly.
+	l.note("bare turbofish at %v collapsed; type args dropped", tf.Pos())
+	return l.lowerExpr(tf.Base)
+}
+
+func (l *lowerer) lowerMatchExpr(m *ast.MatchExpr) Expr {
+	out := &MatchExpr{
+		Scrutinee: l.lowerExpr(m.Scrutinee),
+		T:         l.exprType(m),
+		SpanV:     nodeSpan(m),
+	}
+	for _, arm := range m.Arms {
+		a := &MatchArm{
+			Pattern: l.lowerPattern(arm.Pattern),
+			SpanV:   Span{Start: posFromToken(arm.Pos()), End: posFromToken(arm.End())},
+		}
+		if arm.Guard != nil {
+			a.Guard = l.lowerExpr(arm.Guard)
+		}
+		a.Body = l.lowerArmBody(arm.Body)
+		out.Arms = append(out.Arms, a)
+	}
+	return out
+}
+
+// lowerArmBody normalises a match-arm body (expression or block) into a
+// *Block so consumers see a uniform shape.
+func (l *lowerer) lowerArmBody(e ast.Expr) *Block {
+	if blk, ok := e.(*ast.Block); ok {
+		return l.lowerBlock(blk)
+	}
+	lowered := l.lowerExpr(e)
+	return &Block{Result: lowered, SpanV: lowered.At()}
+}
+
+// ==== Patterns ====
+
+func (l *lowerer) lowerPattern(p ast.Pattern) Pattern {
+	if p == nil {
+		return nil
+	}
+	switch p := p.(type) {
+	case *ast.WildcardPat:
+		return &WildPat{SpanV: nodeSpan(p)}
+	case *ast.IdentPat:
+		return &IdentPat{Name: p.Name, SpanV: nodeSpan(p)}
+	case *ast.LiteralPat:
+		var val Expr
+		if p.Literal != nil {
+			val = l.lowerExpr(p.Literal)
+		}
+		return &LitPat{Value: val, SpanV: nodeSpan(p)}
+	case *ast.TuplePat:
+		out := &TuplePat{SpanV: nodeSpan(p)}
+		for _, e := range p.Elems {
+			out.Elems = append(out.Elems, l.lowerPattern(e))
+		}
+		return out
+	case *ast.StructPat:
+		out := &StructPat{Rest: p.Rest, SpanV: nodeSpan(p)}
+		if len(p.Type) > 0 {
+			out.TypeName = p.Type[len(p.Type)-1]
+		}
+		for _, f := range p.Fields {
+			field := StructPatField{
+				Name: f.Name,
+				SpanV: Span{
+					Start: posFromToken(f.Pos()),
+					End:   posFromToken(f.End()),
+				},
+			}
+			if f.Pattern != nil {
+				field.Pattern = l.lowerPattern(f.Pattern)
+			}
+			out.Fields = append(out.Fields, field)
+		}
+		return out
+	case *ast.VariantPat:
+		out := &VariantPat{SpanV: nodeSpan(p)}
+		if n := len(p.Path); n >= 1 {
+			out.Variant = p.Path[n-1]
+			if n >= 2 {
+				out.Enum = p.Path[n-2]
+			}
+		}
+		for _, a := range p.Args {
+			out.Args = append(out.Args, l.lowerPattern(a))
+		}
+		return out
+	case *ast.RangePat:
+		out := &RangePat{Inclusive: p.Inclusive, SpanV: nodeSpan(p)}
+		if p.Start != nil {
+			out.Low = l.lowerExpr(p.Start)
+		}
+		if p.Stop != nil {
+			out.High = l.lowerExpr(p.Stop)
+		}
+		return out
+	case *ast.OrPat:
+		out := &OrPat{SpanV: nodeSpan(p)}
+		for _, a := range p.Alts {
+			out.Alts = append(out.Alts, l.lowerPattern(a))
+		}
+		return out
+	case *ast.BindingPat:
+		return &BindingPat{
+			Name:    p.Name,
+			Pattern: l.lowerPattern(p.Pattern),
+			SpanV:   nodeSpan(p),
+		}
+	}
+	l.note("unsupported pattern %T at %v", p, p.Pos())
+	return &ErrorPat{Note: fmt.Sprintf("%T", p), SpanV: nodeSpan(p)}
 }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1,0 +1,914 @@
+package ir
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
+)
+
+// Lower converts a type-checked Osty file into an independent IR Module.
+//
+// pkgName is the module's package name (e.g. "main"). res and chk may be
+// nil when the caller has no resolver/checker output available — in that
+// case expression types fall back to ErrTypeVal and identifier kinds are
+// left as IdentUnknown, so backends that need either should pass real
+// data.
+//
+// The returned []error is the set of non-fatal lowering issues
+// encountered (unsupported constructs, missing type info); callers are
+// free to ignore them or surface them via their diagnostic machinery.
+// The returned Module is always non-nil — it just contains ErrorStmt /
+// ErrorExpr nodes in positions that failed.
+func Lower(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result) (*Module, []error) {
+	l := &lowerer{pkgName: pkgName, file: file, res: res, chk: chk}
+	return l.run()
+}
+
+// lowerer holds per-file state for one Lower call.
+type lowerer struct {
+	pkgName string
+	file    *ast.File
+	res     *resolve.Result
+	chk     *check.Result
+
+	// issues collects non-fatal issues.
+	issues []error
+}
+
+// ==== Top level ====
+
+func (l *lowerer) run() (*Module, []error) {
+	mod := &Module{
+		Package: l.pkgName,
+		SpanV:   l.fileSpan(),
+	}
+	for _, d := range l.file.Decls {
+		if lowered := l.lowerDecl(d); lowered != nil {
+			mod.Decls = append(mod.Decls, lowered)
+		}
+	}
+	for _, s := range l.file.Stmts {
+		mod.Script = append(mod.Script, l.lowerStmt(s))
+	}
+	return mod, l.issues
+}
+
+func (l *lowerer) fileSpan() Span {
+	if l.file == nil {
+		return Span{}
+	}
+	return Span{Start: posFromToken(l.file.PosV), End: posFromToken(l.file.EndV)}
+}
+
+// note records a non-fatal issue.
+func (l *lowerer) note(format string, args ...any) {
+	l.issues = append(l.issues, fmt.Errorf(format, args...))
+}
+
+// ==== Declarations ====
+
+func (l *lowerer) lowerDecl(d ast.Decl) Decl {
+	switch d := d.(type) {
+	case *ast.FnDecl:
+		// Methods on types are materialised inside their owning struct
+		// or enum declaration. Skip them at the top level; the owner's
+		// lowering picks them up through the AST's Methods slice.
+		if d.Recv != nil {
+			return nil
+		}
+		return l.lowerFnDecl(d)
+	case *ast.StructDecl:
+		return l.lowerStructDecl(d)
+	case *ast.EnumDecl:
+		return l.lowerEnumDecl(d)
+	case *ast.LetDecl:
+		return l.lowerLetDecl(d)
+	case *ast.UseDecl, *ast.InterfaceDecl, *ast.TypeAliasDecl:
+		// Out of scope for the current IR shape. Not an error — these
+		// are either consumed by the resolver (Use) or reserved for a
+		// later IR expansion (Interface, TypeAlias).
+		return nil
+	}
+	l.note("unsupported top-level decl %T", d)
+	return nil
+}
+
+func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
+	out := &FnDecl{
+		Name:     fn.Name,
+		Return:   l.lowerType(fn.ReturnType),
+		Exported: fn.Pub,
+		SpanV:    nodeSpan(fn),
+	}
+	if out.Return == nil {
+		out.Return = TUnit
+	}
+	for _, gp := range fn.Generics {
+		out.Generics = append(out.Generics, l.lowerTypeParam(gp, fn.Name))
+	}
+	for _, p := range fn.Params {
+		out.Params = append(out.Params, l.lowerParam(p))
+	}
+	if fn.Body != nil {
+		out.Body = l.lowerBlock(fn.Body)
+	}
+	return out
+}
+
+func (l *lowerer) lowerParam(p *ast.Param) *Param {
+	name := p.Name
+	if name == "" && p.Pattern != nil {
+		// Pattern-destructured closure params aren't representable yet;
+		// record an issue and fall back to a placeholder.
+		l.note("pattern-destructured parameter at %v not yet supported", p.Pos())
+		name = "_"
+	}
+	out := &Param{
+		Name:  name,
+		Type:  l.lowerType(p.Type),
+		SpanV: nodeSpan(p),
+	}
+	if p.Default != nil {
+		out.Default = l.lowerExpr(p.Default)
+	}
+	return out
+}
+
+func (l *lowerer) lowerTypeParam(gp *ast.GenericParam, owner string) *TypeParam {
+	out := &TypeParam{Name: gp.Name, SpanV: nodeSpan(gp)}
+	for _, c := range gp.Constraints {
+		if t := l.lowerType(c); t != nil {
+			out.Bounds = append(out.Bounds, t)
+		}
+	}
+	return out
+}
+
+func (l *lowerer) lowerStructDecl(sd *ast.StructDecl) *StructDecl {
+	out := &StructDecl{
+		Name:     sd.Name,
+		Exported: sd.Pub,
+		SpanV:    nodeSpan(sd),
+	}
+	for _, gp := range sd.Generics {
+		out.Generics = append(out.Generics, l.lowerTypeParam(gp, sd.Name))
+	}
+	for _, f := range sd.Fields {
+		field := &Field{
+			Name:     f.Name,
+			Type:     l.lowerType(f.Type),
+			Exported: f.Pub,
+			SpanV:    nodeSpan(f),
+		}
+		if f.Default != nil {
+			field.Default = l.lowerExpr(f.Default)
+		}
+		out.Fields = append(out.Fields, field)
+	}
+	for _, m := range sd.Methods {
+		out.Methods = append(out.Methods, l.lowerFnDecl(m))
+	}
+	return out
+}
+
+func (l *lowerer) lowerEnumDecl(ed *ast.EnumDecl) *EnumDecl {
+	out := &EnumDecl{
+		Name:     ed.Name,
+		Exported: ed.Pub,
+		SpanV:    nodeSpan(ed),
+	}
+	for _, gp := range ed.Generics {
+		out.Generics = append(out.Generics, l.lowerTypeParam(gp, ed.Name))
+	}
+	for _, v := range ed.Variants {
+		variant := &Variant{Name: v.Name, SpanV: nodeSpan(v)}
+		for _, ty := range v.Fields {
+			variant.Payload = append(variant.Payload, l.lowerType(ty))
+		}
+		out.Variants = append(out.Variants, variant)
+	}
+	for _, m := range ed.Methods {
+		out.Methods = append(out.Methods, l.lowerFnDecl(m))
+	}
+	return out
+}
+
+func (l *lowerer) lowerLetDecl(ld *ast.LetDecl) *LetDecl {
+	out := &LetDecl{
+		Name:     ld.Name,
+		Mut:      ld.Mut,
+		Exported: ld.Pub,
+		SpanV:    nodeSpan(ld),
+	}
+	if ld.Type != nil {
+		out.Type = l.lowerType(ld.Type)
+	}
+	if ld.Value != nil {
+		out.Value = l.lowerExpr(ld.Value)
+		if out.Type == nil {
+			out.Type = out.Value.Type()
+		}
+	}
+	return out
+}
+
+// ==== Types ====
+
+// lowerType converts an AST Type to IR Type. Returns nil when the input
+// is nil (caller substitutes TUnit when that matters).
+func (l *lowerer) lowerType(t ast.Type) Type {
+	if t == nil {
+		return nil
+	}
+	switch t := t.(type) {
+	case *ast.NamedType:
+		return l.lowerNamedType(t)
+	case *ast.OptionalType:
+		return &OptionalType{Inner: l.lowerType(t.Inner)}
+	case *ast.TupleType:
+		elems := make([]Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = l.lowerType(e)
+		}
+		return &TupleType{Elems: elems}
+	case *ast.FnType:
+		params := make([]Type, len(t.Params))
+		for i, p := range t.Params {
+			params[i] = l.lowerType(p)
+		}
+		ret := l.lowerType(t.ReturnType)
+		if ret == nil {
+			ret = TUnit
+		}
+		return &FnType{Params: params, Return: ret}
+	}
+	l.note("unsupported type node %T", t)
+	return ErrTypeVal
+}
+
+// lowerNamedType resolves a NamedType to either a primitive, an IR
+// NamedType (with Builtin flag populated from the resolver when
+// available), or a TypeVar for generic parameter references.
+func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
+	// Qualified paths (pkg.Type) are kept as a dotted string for now;
+	// the current IR has no first-class package concept.
+	name := nt.Path[len(nt.Path)-1]
+
+	// Primitive scalars short-circuit.
+	if len(nt.Path) == 1 && len(nt.Args) == 0 {
+		if p := primitiveByName(name); p != nil {
+			return p
+		}
+	}
+
+	args := make([]Type, len(nt.Args))
+	for i, a := range nt.Args {
+		args[i] = l.lowerType(a)
+	}
+
+	// Consult the resolver for the head symbol so we can classify
+	// builtins vs user declarations vs generic parameters.
+	if sym := l.typeRef(nt); sym != nil {
+		switch sym.Kind {
+		case resolve.SymBuiltin:
+			if len(nt.Args) == 0 {
+				if p := primitiveByName(sym.Name); p != nil {
+					return p
+				}
+			}
+			return &NamedType{Name: sym.Name, Args: args, Builtin: true}
+		case resolve.SymGeneric:
+			return &TypeVar{Name: sym.Name, Owner: ""}
+		}
+		return &NamedType{Name: sym.Name, Args: args}
+	}
+
+	// No resolver data available — best effort on the source name.
+	return &NamedType{Name: name, Args: args}
+}
+
+func (l *lowerer) typeRef(nt *ast.NamedType) *resolve.Symbol {
+	if l.res == nil {
+		return nil
+	}
+	return l.res.TypeRefs[nt]
+}
+
+// primitiveByName maps a scalar type name to the IR singleton.
+func primitiveByName(name string) *PrimType {
+	switch name {
+	case "Int":
+		return TInt
+	case "Int8":
+		return TInt8
+	case "Int16":
+		return TInt16
+	case "Int32":
+		return TInt32
+	case "Int64":
+		return TInt64
+	case "UInt8":
+		return TUInt8
+	case "UInt16":
+		return TUInt16
+	case "UInt32":
+		return TUInt32
+	case "UInt64":
+		return TUInt64
+	case "Byte":
+		return TByte
+	case "Float":
+		return TFloat
+	case "Float32":
+		return TFloat32
+	case "Float64":
+		return TFloat64
+	case "Bool":
+		return TBool
+	case "Char":
+		return TChar
+	case "String":
+		return TString
+	case "Bytes":
+		return TBytes
+	}
+	return nil
+}
+
+// fromCheckerType converts a checker types.Type into an IR Type. Used
+// when lowering expressions where the checker's inferred type is the
+// authoritative source.
+func (l *lowerer) fromCheckerType(t types.Type) Type {
+	if t == nil {
+		return nil
+	}
+	switch t := t.(type) {
+	case *types.Primitive:
+		if p := primitiveByKind(t.Kind); p != nil {
+			return p
+		}
+		return ErrTypeVal
+	case *types.Untyped:
+		return l.fromCheckerType(t.Default())
+	case *types.Tuple:
+		elems := make([]Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = l.fromCheckerType(e)
+		}
+		return &TupleType{Elems: elems}
+	case *types.Optional:
+		return &OptionalType{Inner: l.fromCheckerType(t.Inner)}
+	case *types.FnType:
+		params := make([]Type, len(t.Params))
+		for i, p := range t.Params {
+			params[i] = l.fromCheckerType(p)
+		}
+		ret := l.fromCheckerType(t.Return)
+		if ret == nil {
+			ret = TUnit
+		}
+		return &FnType{Params: params, Return: ret}
+	case *types.Named:
+		name := "?"
+		builtin := false
+		if t.Sym != nil {
+			name = t.Sym.Name
+			builtin = t.Sym.Kind == resolve.SymBuiltin
+		}
+		args := make([]Type, len(t.Args))
+		for i, a := range t.Args {
+			args[i] = l.fromCheckerType(a)
+		}
+		return &NamedType{Name: name, Args: args, Builtin: builtin}
+	case *types.TypeVar:
+		name := "?"
+		if t.Sym != nil {
+			name = t.Sym.Name
+		}
+		return &TypeVar{Name: name}
+	case *types.Error:
+		return ErrTypeVal
+	}
+	l.note("unsupported checker type %T", t)
+	return ErrTypeVal
+}
+
+func primitiveByKind(k types.PrimitiveKind) *PrimType {
+	switch k {
+	case types.PInt:
+		return TInt
+	case types.PInt8:
+		return TInt8
+	case types.PInt16:
+		return TInt16
+	case types.PInt32:
+		return TInt32
+	case types.PInt64:
+		return TInt64
+	case types.PUInt8:
+		return TUInt8
+	case types.PUInt16:
+		return TUInt16
+	case types.PUInt32:
+		return TUInt32
+	case types.PUInt64:
+		return TUInt64
+	case types.PByte:
+		return TByte
+	case types.PFloat:
+		return TFloat
+	case types.PFloat32:
+		return TFloat32
+	case types.PFloat64:
+		return TFloat64
+	case types.PBool:
+		return TBool
+	case types.PChar:
+		return TChar
+	case types.PString:
+		return TString
+	case types.PBytes:
+		return TBytes
+	case types.PUnit:
+		return TUnit
+	case types.PNever:
+		return TNever
+	}
+	return nil
+}
+
+// ==== Blocks and statements ====
+
+func (l *lowerer) lowerBlock(b *ast.Block) *Block {
+	out := &Block{SpanV: nodeSpan(b)}
+	if len(b.Stmts) == 0 {
+		return out
+	}
+	// The block's "result" is the final expression statement, if any,
+	// and if its type is not unit. This matches the checker's view of
+	// block-as-expression and lets backends omit an extra Go statement
+	// when no value is implicitly returned.
+	last := b.Stmts[len(b.Stmts)-1]
+	lead := b.Stmts[:len(b.Stmts)-1]
+	for _, s := range lead {
+		out.Stmts = append(out.Stmts, l.lowerStmt(s))
+	}
+	if es, ok := last.(*ast.ExprStmt); ok && l.expressionYieldsValue(es.X) {
+		out.Result = l.lowerExpr(es.X)
+	} else {
+		out.Stmts = append(out.Stmts, l.lowerStmt(last))
+	}
+	return out
+}
+
+// expressionYieldsValue reports whether treating the expression as a
+// block-final implicit result is appropriate: the checker assigned it
+// a non-unit type.
+func (l *lowerer) expressionYieldsValue(e ast.Expr) bool {
+	if l.chk == nil {
+		// No checker; be conservative: don't promote.
+		return false
+	}
+	t := l.chk.Types[e]
+	if t == nil {
+		return false
+	}
+	if p, ok := t.(*types.Primitive); ok {
+		if p.Kind == types.PUnit || p.Kind == types.PNever {
+			return false
+		}
+	}
+	if _, ok := t.(*types.Error); ok {
+		return false
+	}
+	return true
+}
+
+func (l *lowerer) lowerStmt(s ast.Stmt) Stmt {
+	switch s := s.(type) {
+	case *ast.Block:
+		return l.lowerBlock(s)
+	case *ast.LetStmt:
+		return l.lowerLetStmt(s)
+	case *ast.ExprStmt:
+		x := l.lowerExpr(s.X)
+		return &ExprStmt{X: x, SpanV: Span{Start: posFromToken(s.Pos()), End: posFromToken(s.End())}}
+	case *ast.ReturnStmt:
+		out := &ReturnStmt{SpanV: nodeSpan(s)}
+		if s.Value != nil {
+			out.Value = l.lowerExpr(s.Value)
+		}
+		return out
+	case *ast.BreakStmt:
+		return &BreakStmt{SpanV: nodeSpan(s)}
+	case *ast.ContinueStmt:
+		return &ContinueStmt{SpanV: nodeSpan(s)}
+	case *ast.AssignStmt:
+		return l.lowerAssignStmt(s)
+	case *ast.ForStmt:
+		return l.lowerForStmt(s)
+	}
+	// Fall through: if it's actually an if used at statement position,
+	// the parser wrapped it in an ExprStmt already; we only get here
+	// for deferred constructs.
+	l.note("unsupported statement %T at %v", s, s.Pos())
+	return &ErrorStmt{Note: fmt.Sprintf("%T", s), SpanV: nodeSpan(s)}
+}
+
+func (l *lowerer) lowerLetStmt(s *ast.LetStmt) Stmt {
+	// Only bare-ident patterns are lowered directly; destructuring
+	// patterns aren't representable in the current IR shape.
+	name, ok := simpleBindName(s.Pattern)
+	if !ok {
+		l.note("destructuring `let` at %v not yet lowered", s.Pos())
+		return &ErrorStmt{Note: "destructuring let", SpanV: nodeSpan(s)}
+	}
+	out := &LetStmt{
+		Name:  name,
+		Mut:   s.Mut,
+		SpanV: nodeSpan(s),
+	}
+	if s.Type != nil {
+		out.Type = l.lowerType(s.Type)
+	}
+	if s.Value != nil {
+		out.Value = l.lowerExpr(s.Value)
+		if out.Type == nil {
+			out.Type = out.Value.Type()
+		}
+	}
+	return out
+}
+
+// simpleBindName returns (name, true) when the pattern is just a bare
+// IdentPattern.
+func simpleBindName(p ast.Pattern) (string, bool) {
+	ip, ok := p.(*ast.IdentPat)
+	if !ok {
+		return "", false
+	}
+	return ip.Name, true
+}
+
+func (l *lowerer) lowerAssignStmt(s *ast.AssignStmt) Stmt {
+	if len(s.Targets) != 1 {
+		l.note("multi-target assignment at %v not yet lowered", s.Pos())
+		return &ErrorStmt{Note: "multi-assign", SpanV: nodeSpan(s)}
+	}
+	return &AssignStmt{
+		Op:     assignOp(s.Op),
+		Target: l.lowerExpr(s.Targets[0]),
+		Value:  l.lowerExpr(s.Value),
+		SpanV:  nodeSpan(s),
+	}
+}
+
+func (l *lowerer) lowerForStmt(s *ast.ForStmt) Stmt {
+	body := l.lowerBlock(s.Body)
+	// Classify: infinite | while | for-in (range or iterator).
+	if s.Pattern == nil && s.Iter == nil {
+		return &ForStmt{Kind: ForInfinite, Body: body, SpanV: nodeSpan(s)}
+	}
+	if s.Pattern == nil && s.Iter != nil {
+		return &ForStmt{Kind: ForWhile, Cond: l.lowerExpr(s.Iter), Body: body, SpanV: nodeSpan(s)}
+	}
+	name, ok := simpleBindName(s.Pattern)
+	if !ok {
+		l.note("for with destructuring pattern at %v not yet lowered", s.Pos())
+		return &ErrorStmt{Note: "for destructuring", SpanV: nodeSpan(s)}
+	}
+	// for x in a..b is a numeric range loop.
+	if r, ok := s.Iter.(*ast.RangeExpr); ok && r.Start != nil && r.Stop != nil {
+		return &ForStmt{
+			Kind:      ForRange,
+			Var:       name,
+			Start:     l.lowerExpr(r.Start),
+			End:       l.lowerExpr(r.Stop),
+			Inclusive: r.Inclusive,
+			Body:      body,
+			SpanV:     nodeSpan(s),
+		}
+	}
+	return &ForStmt{Kind: ForIn, Var: name, Iter: l.lowerExpr(s.Iter), Body: body, SpanV: nodeSpan(s)}
+}
+
+// assignOp maps a token kind to the IR AssignOp.
+func assignOp(k token.Kind) AssignOp {
+	switch k {
+	case token.ASSIGN:
+		return AssignEq
+	case token.PLUSEQ:
+		return AssignAdd
+	case token.MINUSEQ:
+		return AssignSub
+	case token.STAREQ:
+		return AssignMul
+	case token.SLASHEQ:
+		return AssignDiv
+	case token.PERCENTEQ:
+		return AssignMod
+	case token.BITANDEQ:
+		return AssignAnd
+	case token.BITOREQ:
+		return AssignOr
+	case token.BITXOREQ:
+		return AssignXor
+	case token.SHLEQ:
+		return AssignShl
+	case token.SHREQ:
+		return AssignShr
+	}
+	return AssignEq
+}
+
+// ==== Expressions ====
+
+func (l *lowerer) lowerExpr(e ast.Expr) Expr {
+	switch e := e.(type) {
+	case *ast.IntLit:
+		return &IntLit{Text: e.Text, T: l.exprType(e), SpanV: nodeSpan(e)}
+	case *ast.FloatLit:
+		return &FloatLit{Text: e.Text, T: l.exprType(e), SpanV: nodeSpan(e)}
+	case *ast.BoolLit:
+		return &BoolLit{Value: e.Value, SpanV: nodeSpan(e)}
+	case *ast.CharLit:
+		return &CharLit{Value: e.Value, SpanV: nodeSpan(e)}
+	case *ast.ByteLit:
+		return &ByteLit{Value: e.Value, SpanV: nodeSpan(e)}
+	case *ast.StringLit:
+		return l.lowerStringLit(e)
+	case *ast.Ident:
+		return l.lowerIdent(e)
+	case *ast.ParenExpr:
+		// Parens carry no semantic content in the IR.
+		return l.lowerExpr(e.X)
+	case *ast.UnaryExpr:
+		return l.lowerUnary(e)
+	case *ast.BinaryExpr:
+		return l.lowerBinary(e)
+	case *ast.CallExpr:
+		return l.lowerCall(e)
+	case *ast.ListExpr:
+		return l.lowerList(e)
+	case *ast.Block:
+		blk := l.lowerBlock(e)
+		t := l.exprType(e)
+		if t == nil {
+			if blk.Result != nil {
+				t = blk.Result.Type()
+			} else {
+				t = TUnit
+			}
+		}
+		return &BlockExpr{Block: blk, T: t, SpanV: nodeSpan(e)}
+	case *ast.IfExpr:
+		return l.lowerIfExpr(e)
+	}
+	l.note("unsupported expression %T at %v", e, e.Pos())
+	return &ErrorExpr{Note: fmt.Sprintf("%T", e), T: ErrTypeVal, SpanV: nodeSpan(e)}
+}
+
+func (l *lowerer) exprType(e ast.Expr) Type {
+	if l.chk == nil {
+		return ErrTypeVal
+	}
+	t := l.chk.Types[e]
+	if t == nil {
+		return ErrTypeVal
+	}
+	return l.fromCheckerType(t)
+}
+
+func (l *lowerer) lowerStringLit(s *ast.StringLit) Expr {
+	out := &StringLit{IsRaw: s.IsRaw, IsTriple: s.IsTriple, SpanV: nodeSpan(s)}
+	for _, p := range s.Parts {
+		if p.IsLit {
+			out.Parts = append(out.Parts, StringPart{IsLit: true, Lit: p.Lit})
+		} else {
+			out.Parts = append(out.Parts, StringPart{Expr: l.lowerExpr(p.Expr)})
+		}
+	}
+	return out
+}
+
+func (l *lowerer) lowerIdent(id *ast.Ident) Expr {
+	out := &Ident{Name: id.Name, SpanV: nodeSpan(id), T: ErrTypeVal}
+	if l.res != nil {
+		if sym := l.res.Refs[id]; sym != nil {
+			out.Kind = identKind(sym.Kind)
+		}
+	}
+	if l.chk != nil {
+		if t := l.chk.Types[id]; t != nil {
+			out.T = l.fromCheckerType(t)
+		} else if sym := l.symbol(id); sym != nil {
+			if st := l.chk.SymTypes[sym]; st != nil {
+				out.T = l.fromCheckerType(st)
+			}
+		}
+	}
+	return out
+}
+
+func (l *lowerer) symbol(id *ast.Ident) *resolve.Symbol {
+	if l.res == nil {
+		return nil
+	}
+	return l.res.Refs[id]
+}
+
+func identKind(k resolve.SymbolKind) IdentKind {
+	switch k {
+	case resolve.SymLet:
+		return IdentLocal
+	case resolve.SymParam:
+		return IdentParam
+	case resolve.SymFn:
+		return IdentFn
+	case resolve.SymVariant:
+		return IdentVariant
+	case resolve.SymStruct, resolve.SymEnum, resolve.SymInterface, resolve.SymTypeAlias:
+		return IdentTypeName
+	case resolve.SymBuiltin:
+		return IdentBuiltin
+	}
+	return IdentUnknown
+}
+
+func (l *lowerer) lowerUnary(e *ast.UnaryExpr) Expr {
+	op, ok := unaryOp(e.Op)
+	if !ok {
+		l.note("unsupported unary op %v at %v", e.Op, e.Pos())
+		return &ErrorExpr{Note: "unary op", T: ErrTypeVal, SpanV: nodeSpan(e)}
+	}
+	return &UnaryExpr{Op: op, X: l.lowerExpr(e.X), T: l.exprType(e), SpanV: nodeSpan(e)}
+}
+
+func unaryOp(k token.Kind) (UnOp, bool) {
+	switch k {
+	case token.MINUS:
+		return UnNeg, true
+	case token.PLUS:
+		return UnPlus, true
+	case token.NOT:
+		return UnNot, true
+	case token.BITNOT:
+		return UnBitNot, true
+	}
+	return 0, false
+}
+
+func (l *lowerer) lowerBinary(e *ast.BinaryExpr) Expr {
+	op, ok := binaryOp(e.Op)
+	if !ok {
+		l.note("unsupported binary op %v at %v", e.Op, e.Pos())
+		return &ErrorExpr{Note: "binary op", T: ErrTypeVal, SpanV: nodeSpan(e)}
+	}
+	return &BinaryExpr{
+		Op:    op,
+		Left:  l.lowerExpr(e.Left),
+		Right: l.lowerExpr(e.Right),
+		T:     l.exprType(e),
+		SpanV: nodeSpan(e),
+	}
+}
+
+func binaryOp(k token.Kind) (BinOp, bool) {
+	switch k {
+	case token.PLUS:
+		return BinAdd, true
+	case token.MINUS:
+		return BinSub, true
+	case token.STAR:
+		return BinMul, true
+	case token.SLASH:
+		return BinDiv, true
+	case token.PERCENT:
+		return BinMod, true
+	case token.EQ:
+		return BinEq, true
+	case token.NEQ:
+		return BinNeq, true
+	case token.LT:
+		return BinLt, true
+	case token.LEQ:
+		return BinLeq, true
+	case token.GT:
+		return BinGt, true
+	case token.GEQ:
+		return BinGeq, true
+	case token.AND:
+		return BinAnd, true
+	case token.OR:
+		return BinOr, true
+	case token.BITAND:
+		return BinBitAnd, true
+	case token.BITOR:
+		return BinBitOr, true
+	case token.BITXOR:
+		return BinBitXor, true
+	case token.SHL:
+		return BinShl, true
+	case token.SHR:
+		return BinShr, true
+	}
+	return 0, false
+}
+
+func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
+	// Detect a print-family intrinsic.
+	if id, ok := e.Fn.(*ast.Ident); ok {
+		if k, isIntrinsic := intrinsicByName(id.Name); isIntrinsic {
+			out := &IntrinsicCall{Kind: k, SpanV: nodeSpan(e)}
+			for _, a := range e.Args {
+				if a.Name != "" {
+					l.note("keyword arg to intrinsic %s at %v not supported", id.Name, a.Pos())
+					continue
+				}
+				out.Args = append(out.Args, l.lowerExpr(a.Value))
+			}
+			return out
+		}
+	}
+	out := &CallExpr{
+		Callee: l.lowerExpr(e.Fn),
+		T:      l.exprType(e),
+		SpanV:  nodeSpan(e),
+	}
+	for _, a := range e.Args {
+		if a.Name != "" {
+			l.note("keyword arg at %v collapsed to positional in IR", a.Pos())
+		}
+		out.Args = append(out.Args, l.lowerExpr(a.Value))
+	}
+	return out
+}
+
+func intrinsicByName(name string) (IntrinsicKind, bool) {
+	switch name {
+	case "print":
+		return IntrinsicPrint, true
+	case "println":
+		return IntrinsicPrintln, true
+	case "eprint":
+		return IntrinsicEprint, true
+	case "eprintln":
+		return IntrinsicEprintln, true
+	}
+	return 0, false
+}
+
+func (l *lowerer) lowerList(e *ast.ListExpr) Expr {
+	out := &ListLit{SpanV: nodeSpan(e)}
+	for _, el := range e.Elems {
+		out.Elems = append(out.Elems, l.lowerExpr(el))
+	}
+	// Derive the element type from the checker's inferred list type.
+	if t := l.exprType(e); t != nil {
+		if nt, ok := t.(*NamedType); ok && nt.Name == "List" && len(nt.Args) == 1 {
+			out.Elem = nt.Args[0]
+		}
+	}
+	if out.Elem == nil && len(out.Elems) > 0 {
+		out.Elem = out.Elems[0].Type()
+	}
+	if out.Elem == nil {
+		out.Elem = ErrTypeVal
+	}
+	return out
+}
+
+func (l *lowerer) lowerIfExpr(e *ast.IfExpr) Expr {
+	t := l.exprType(e)
+	thenBlk := l.lowerBlock(e.Then)
+	var elseBlk *Block
+	switch alt := e.Else.(type) {
+	case nil:
+		// no else; should only appear in statement position.
+	case *ast.Block:
+		elseBlk = l.lowerBlock(alt)
+	case *ast.IfExpr:
+		// else-if chain: wrap the inner IfExpr into a block so the
+		// shape is uniform.
+		inner := l.lowerIfExpr(alt)
+		elseBlk = &Block{Result: inner, SpanV: nodeSpan(alt)}
+	default:
+		lowered := l.lowerExpr(alt.(ast.Expr))
+		elseBlk = &Block{Result: lowered, SpanV: nodeSpan(alt)}
+	}
+	return &IfExpr{Cond: l.lowerExpr(e.Cond), Then: thenBlk, Else: elseBlk, T: t, SpanV: nodeSpan(e)}
+}
+
+// ==== Span helpers ====
+
+func posFromToken(p token.Pos) Pos {
+	return Pos{Offset: p.Offset, Line: p.Line, Column: p.Column}
+}
+
+func nodeSpan(n ast.Node) Span {
+	return Span{Start: posFromToken(n.Pos()), End: posFromToken(n.End())}
+}

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -317,7 +317,9 @@ func walkStmtExprs(s ir.Stmt, fn func(ir.Expr)) {
 			walkExpr(s.Value, fn)
 		}
 	case *ir.AssignStmt:
-		walkExpr(s.Target, fn)
+		for _, t := range s.Targets {
+			walkExpr(t, fn)
+		}
 		walkExpr(s.Value, fn)
 	case *ir.IfStmt:
 		walkExpr(s.Cond, fn)

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -1,0 +1,405 @@
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// lower runs the full parse → resolve → check → lower pipeline on the
+// source snippet. Fatal on parse error; checker/resolver diagnostics
+// are tolerated so tests can lower partially-invalid inputs too.
+func lower(t *testing.T, src string) (*ir.Module, []error) {
+	t.Helper()
+	file, pd := parser.ParseDiagnostics([]byte(src))
+	for _, d := range pd {
+		if d.Severity.String() == "error" {
+			t.Fatalf("parse error: %s", d.Message)
+		}
+	}
+	res := resolve.File(file, resolve.NewPrelude())
+	chk := check.File(file, res)
+	return ir.Lower("main", file, res, chk)
+}
+
+func TestLowerEmptyFile(t *testing.T) {
+	mod, issues := lower(t, "")
+	if mod == nil {
+		t.Fatal("nil module")
+	}
+	if len(mod.Decls) != 0 || len(mod.Script) != 0 {
+		t.Fatalf("unexpected content: %+v", mod)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+}
+
+func TestLowerHelloWorld(t *testing.T) {
+	mod, issues := lower(t, `fn main() {
+    println("hello, world")
+}
+`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if len(mod.Decls) != 1 {
+		t.Fatalf("expected one decl, got %d", len(mod.Decls))
+	}
+	fn, ok := mod.Decls[0].(*ir.FnDecl)
+	if !ok {
+		t.Fatalf("expected FnDecl, got %T", mod.Decls[0])
+	}
+	if fn.Name != "main" {
+		t.Fatalf("name = %q", fn.Name)
+	}
+	if fn.Body == nil || len(fn.Body.Stmts) != 1 {
+		t.Fatalf("unexpected body: %+v", fn.Body)
+	}
+	es, ok := fn.Body.Stmts[0].(*ir.ExprStmt)
+	if !ok {
+		t.Fatalf("want ExprStmt, got %T", fn.Body.Stmts[0])
+	}
+	call, ok := es.X.(*ir.IntrinsicCall)
+	if !ok {
+		t.Fatalf("want IntrinsicCall, got %T", es.X)
+	}
+	if call.Kind != ir.IntrinsicPrintln {
+		t.Fatalf("kind = %v", call.Kind)
+	}
+	if len(call.Args) != 1 {
+		t.Fatalf("args = %d", len(call.Args))
+	}
+	if _, ok := call.Args[0].(*ir.StringLit); !ok {
+		t.Fatalf("want StringLit arg, got %T", call.Args[0])
+	}
+}
+
+func TestLowerArithmetic(t *testing.T) {
+	mod, issues := lower(t, `fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	fn := mod.Decls[0].(*ir.FnDecl)
+	if len(fn.Params) != 2 {
+		t.Fatalf("params = %d", len(fn.Params))
+	}
+	if fn.Params[0].Name != "a" || fn.Params[0].Type != ir.TInt {
+		t.Fatalf("param[0] = %+v", fn.Params[0])
+	}
+	if fn.Return != ir.TInt {
+		t.Fatalf("return = %v", fn.Return)
+	}
+	if fn.Body.Result == nil {
+		t.Fatalf("expected block result, got stmts=%v", fn.Body.Stmts)
+	}
+	bin, ok := fn.Body.Result.(*ir.BinaryExpr)
+	if !ok {
+		t.Fatalf("want BinaryExpr, got %T", fn.Body.Result)
+	}
+	if bin.Op != ir.BinAdd {
+		t.Fatalf("op = %v", bin.Op)
+	}
+	if bin.Type() != ir.TInt {
+		t.Fatalf("type = %v", bin.Type())
+	}
+}
+
+func TestLowerLetAndIdent(t *testing.T) {
+	mod, issues := lower(t, `fn demo() {
+    let x = 42
+    let y: Int = x + 1
+    println(y)
+}
+`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	fn := mod.Decls[0].(*ir.FnDecl)
+	if len(fn.Body.Stmts) != 3 {
+		t.Fatalf("stmts = %d", len(fn.Body.Stmts))
+	}
+	let1 := fn.Body.Stmts[0].(*ir.LetStmt)
+	if let1.Name != "x" || let1.Type != ir.TInt {
+		t.Fatalf("let1 = %+v (T=%v)", let1, let1.Type)
+	}
+	let2 := fn.Body.Stmts[1].(*ir.LetStmt)
+	if let2.Name != "y" || let2.Type != ir.TInt {
+		t.Fatalf("let2 = %+v", let2)
+	}
+	bin, ok := let2.Value.(*ir.BinaryExpr)
+	if !ok {
+		t.Fatalf("want BinaryExpr, got %T", let2.Value)
+	}
+	id, ok := bin.Left.(*ir.Ident)
+	if !ok {
+		t.Fatalf("want Ident, got %T", bin.Left)
+	}
+	if id.Name != "x" {
+		t.Fatalf("name = %q", id.Name)
+	}
+	if id.Kind != ir.IdentLocal {
+		t.Fatalf("kind = %v, want IdentLocal", id.Kind)
+	}
+}
+
+func TestLowerForRange(t *testing.T) {
+	mod, issues := lower(t, `fn loop() {
+    for i in 0..10 {
+        println(i)
+    }
+}
+`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	fn := mod.Decls[0].(*ir.FnDecl)
+	fs, ok := fn.Body.Stmts[0].(*ir.ForStmt)
+	if !ok {
+		t.Fatalf("want ForStmt, got %T", fn.Body.Stmts[0])
+	}
+	if fs.Kind != ir.ForRange {
+		t.Fatalf("kind = %v", fs.Kind)
+	}
+	if fs.Var != "i" || fs.Inclusive {
+		t.Fatalf("for shape = %+v", fs)
+	}
+	if fs.Start == nil || fs.End == nil {
+		t.Fatalf("missing range bounds")
+	}
+}
+
+func TestLowerIfStmt(t *testing.T) {
+	mod, issues := lower(t, `fn branch(n: Int) {
+    if n > 0 {
+        println("pos")
+    } else {
+        println("non-pos")
+    }
+}
+`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	fn := mod.Decls[0].(*ir.FnDecl)
+	es, ok := fn.Body.Stmts[0].(*ir.ExprStmt)
+	if !ok {
+		t.Fatalf("want ExprStmt, got %T", fn.Body.Stmts[0])
+	}
+	ifE, ok := es.X.(*ir.IfExpr)
+	if !ok {
+		t.Fatalf("want IfExpr, got %T", es.X)
+	}
+	if ifE.Then == nil || ifE.Else == nil {
+		t.Fatalf("both arms required: %+v", ifE)
+	}
+}
+
+func TestLowerStruct(t *testing.T) {
+	mod, issues := lower(t, `struct Point {
+    x: Int,
+    y: Int,
+}
+`)
+	// Methods and field defaults aren't exercised; but the checker
+	// may emit a diagnostic for unused struct. We tolerate issues
+	// here since they'd be about unsupported dependents, not errors.
+	_ = issues
+	if len(mod.Decls) != 1 {
+		t.Fatalf("decls = %d", len(mod.Decls))
+	}
+	sd, ok := mod.Decls[0].(*ir.StructDecl)
+	if !ok {
+		t.Fatalf("want StructDecl, got %T", mod.Decls[0])
+	}
+	if sd.Name != "Point" || len(sd.Fields) != 2 {
+		t.Fatalf("shape = %+v", sd)
+	}
+	if sd.Fields[0].Type != ir.TInt {
+		t.Fatalf("field type = %v", sd.Fields[0].Type)
+	}
+}
+
+func TestLowerScriptMode(t *testing.T) {
+	mod, issues := lower(t, `println("script")`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	if len(mod.Script) != 1 {
+		t.Fatalf("script stmts = %d", len(mod.Script))
+	}
+	es, ok := mod.Script[0].(*ir.ExprStmt)
+	if !ok {
+		t.Fatalf("want ExprStmt, got %T", mod.Script[0])
+	}
+	if _, ok := es.X.(*ir.IntrinsicCall); !ok {
+		t.Fatalf("want IntrinsicCall, got %T", es.X)
+	}
+}
+
+func TestLowerListLiteral(t *testing.T) {
+	mod, issues := lower(t, `fn demo() {
+    let xs: List<Int> = [1, 2, 3]
+    println(xs)
+}
+`)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected issues: %v", issues)
+	}
+	fn := mod.Decls[0].(*ir.FnDecl)
+	let0 := fn.Body.Stmts[0].(*ir.LetStmt)
+	list, ok := let0.Value.(*ir.ListLit)
+	if !ok {
+		t.Fatalf("want ListLit, got %T", let0.Value)
+	}
+	if len(list.Elems) != 3 {
+		t.Fatalf("elems = %d", len(list.Elems))
+	}
+	if list.Elem != ir.TInt {
+		t.Fatalf("elem type = %v", list.Elem)
+	}
+	nt, ok := list.Type().(*ir.NamedType)
+	if !ok || nt.Name != "List" || !nt.Builtin {
+		t.Fatalf("list type = %v", list.Type())
+	}
+}
+
+func TestLowerSelfContainedIR(t *testing.T) {
+	// Assertion: no IR node exposes the checker's types.Type or the
+	// resolver's *Symbol. We spot-check by walking a lowered tree and
+	// confirming every expression's Type() implements ir.Type only.
+	mod, _ := lower(t, `fn f(a: Int) -> Int {
+    let b = a * 2
+    b + 1
+}
+`)
+	fn := mod.Decls[0].(*ir.FnDecl)
+	walkExprs(fn.Body, func(e ir.Expr) {
+		if e.Type() == nil {
+			t.Errorf("expr %T has nil Type()", e)
+		}
+		if _, ok := e.Type().(ir.Type); !ok {
+			t.Errorf("expr %T Type() is not ir.Type", e)
+		}
+	})
+}
+
+// walkExprs invokes fn on every Expr reachable from b.
+func walkExprs(b *ir.Block, fn func(ir.Expr)) {
+	if b == nil {
+		return
+	}
+	for _, s := range b.Stmts {
+		walkStmtExprs(s, fn)
+	}
+	if b.Result != nil {
+		walkExpr(b.Result, fn)
+	}
+}
+
+func walkStmtExprs(s ir.Stmt, fn func(ir.Expr)) {
+	switch s := s.(type) {
+	case *ir.LetStmt:
+		if s.Value != nil {
+			walkExpr(s.Value, fn)
+		}
+	case *ir.ExprStmt:
+		walkExpr(s.X, fn)
+	case *ir.ReturnStmt:
+		if s.Value != nil {
+			walkExpr(s.Value, fn)
+		}
+	case *ir.AssignStmt:
+		walkExpr(s.Target, fn)
+		walkExpr(s.Value, fn)
+	case *ir.IfStmt:
+		walkExpr(s.Cond, fn)
+		walkExprs(s.Then, fn)
+		walkExprs(s.Else, fn)
+	case *ir.ForStmt:
+		if s.Cond != nil {
+			walkExpr(s.Cond, fn)
+		}
+		if s.Iter != nil {
+			walkExpr(s.Iter, fn)
+		}
+		if s.Start != nil {
+			walkExpr(s.Start, fn)
+		}
+		if s.End != nil {
+			walkExpr(s.End, fn)
+		}
+		walkExprs(s.Body, fn)
+	case *ir.Block:
+		walkExprs(s, fn)
+	}
+}
+
+func walkExpr(e ir.Expr, fn func(ir.Expr)) {
+	fn(e)
+	switch e := e.(type) {
+	case *ir.BinaryExpr:
+		walkExpr(e.Left, fn)
+		walkExpr(e.Right, fn)
+	case *ir.UnaryExpr:
+		walkExpr(e.X, fn)
+	case *ir.CallExpr:
+		walkExpr(e.Callee, fn)
+		for _, a := range e.Args {
+			walkExpr(a, fn)
+		}
+	case *ir.IntrinsicCall:
+		for _, a := range e.Args {
+			walkExpr(a, fn)
+		}
+	case *ir.ListLit:
+		for _, el := range e.Elems {
+			walkExpr(el, fn)
+		}
+	case *ir.StringLit:
+		for _, p := range e.Parts {
+			if !p.IsLit && p.Expr != nil {
+				walkExpr(p.Expr, fn)
+			}
+		}
+	case *ir.BlockExpr:
+		walkExprs(e.Block, fn)
+	case *ir.IfExpr:
+		walkExpr(e.Cond, fn)
+		walkExprs(e.Then, fn)
+		walkExprs(e.Else, fn)
+	}
+}
+
+func TestIrTypeStringsStable(t *testing.T) {
+	cases := []struct {
+		t    ir.Type
+		want string
+	}{
+		{ir.TInt, "Int"},
+		{ir.TString, "String"},
+		{&ir.OptionalType{Inner: ir.TInt}, "Int?"},
+		{&ir.TupleType{Elems: []ir.Type{ir.TInt, ir.TBool}}, "(Int, Bool)"},
+		{&ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}, "List<Int>"},
+		{&ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TBool}, "fn(Int) -> Bool"},
+		{&ir.FnType{Return: ir.TUnit}, "fn()"},
+	}
+	for _, c := range cases {
+		got := c.t.String()
+		if got != c.want {
+			t.Errorf("String() = %q, want %q", got, c.want)
+		}
+	}
+	// Also confirm the doc comment's promise: PrimType.String for
+	// Unit is the source form.
+	if !strings.Contains(ir.TUnit.String(), "()") {
+		t.Errorf("unit = %q", ir.TUnit.String())
+	}
+}

--- a/internal/ir/pattern.go
+++ b/internal/ir/pattern.go
@@ -1,0 +1,266 @@
+package ir
+
+import "strings"
+
+// Pattern is the common interface for every destructuring pattern.
+// Patterns appear in `let` bindings, `match` arms, `if let`/`for let`
+// heads, and closure parameter lists.
+//
+// Every Pattern carries a Span (via At) and self-describes its shape
+// — no back-reference to the AST or resolver is retained.
+type Pattern interface {
+	Node
+	patternNode()
+}
+
+// WildPat is `_`.
+type WildPat struct{ SpanV Span }
+
+func (*WildPat) patternNode() {}
+func (p *WildPat) At() Span   { return p.SpanV }
+
+// IdentPat binds a name. Mut reflects a `mut` modifier at the binding
+// site (used by closures and let stmts).
+type IdentPat struct {
+	Name  string
+	Mut   bool
+	SpanV Span
+}
+
+func (*IdentPat) patternNode() {}
+func (p *IdentPat) At() Span   { return p.SpanV }
+
+// LitPat matches an exact literal value. Value is an already-lowered
+// expression, always one of the primitive-literal nodes (IntLit,
+// FloatLit, StringLit, CharLit, BoolLit, ByteLit).
+type LitPat struct {
+	Value Expr
+	SpanV Span
+}
+
+func (*LitPat) patternNode() {}
+func (p *LitPat) At() Span   { return p.SpanV }
+
+// TuplePat matches tuples positionally.
+type TuplePat struct {
+	Elems []Pattern
+	SpanV Span
+}
+
+func (*TuplePat) patternNode() {}
+func (p *TuplePat) At() Span   { return p.SpanV }
+
+// StructPat matches a struct shape. Rest is true when the pattern ends
+// with `..` (accept any remaining fields). TypeName is the struct's
+// bare name; a backend that needs a qualified form resolves it off the
+// type parameter on the scrutinee.
+type StructPat struct {
+	TypeName string
+	Fields   []StructPatField
+	Rest     bool
+	SpanV    Span
+}
+
+func (*StructPat) patternNode() {}
+func (p *StructPat) At() Span   { return p.SpanV }
+
+// StructPatField is one entry inside StructPat. When Pattern is nil the
+// entry is a shorthand binding (`name` binds to the field of the same
+// name).
+type StructPatField struct {
+	Name    string
+	Pattern Pattern
+	SpanV   Span
+}
+
+func (f StructPatField) At() Span { return f.SpanV }
+
+// VariantPat matches a specific enum variant. Enum is the owning enum
+// name when known (empty for prelude variants like `Some`/`None` whose
+// owner may be Option<T>). Args is empty for bare variants.
+type VariantPat struct {
+	Enum    string
+	Variant string
+	Args    []Pattern
+	SpanV   Span
+}
+
+func (*VariantPat) patternNode() {}
+func (p *VariantPat) At() Span   { return p.SpanV }
+
+// RangePat matches a range of ordered values (`0..=9`, `..10`, `100..`).
+// Low and High may be nil for unbounded sides.
+type RangePat struct {
+	Low       Expr
+	High      Expr
+	Inclusive bool
+	SpanV     Span
+}
+
+func (*RangePat) patternNode() {}
+func (p *RangePat) At() Span   { return p.SpanV }
+
+// OrPat is `A | B | C`.
+type OrPat struct {
+	Alts  []Pattern
+	SpanV Span
+}
+
+func (*OrPat) patternNode() {}
+func (p *OrPat) At() Span   { return p.SpanV }
+
+// BindingPat is `name @ pattern`: succeeds iff Pattern matches, and in
+// that case also binds `name` to the scrutinee.
+type BindingPat struct {
+	Name    string
+	Pattern Pattern
+	SpanV   Span
+}
+
+func (*BindingPat) patternNode() {}
+func (p *BindingPat) At() Span   { return p.SpanV }
+
+// ErrorPat is the poisoned pattern, used when lowering can't recover.
+type ErrorPat struct {
+	Note  string
+	SpanV Span
+}
+
+func (*ErrorPat) patternNode() {}
+func (p *ErrorPat) At() Span   { return p.SpanV }
+
+// ==== Pattern helpers ====
+
+// PatternString returns a source-like rendering of p. Useful for
+// diagnostics and printer output.
+func PatternString(p Pattern) string {
+	var b strings.Builder
+	writePattern(&b, p)
+	return b.String()
+}
+
+func writePattern(b *strings.Builder, p Pattern) {
+	switch p := p.(type) {
+	case nil:
+		b.WriteString("<nil>")
+	case *WildPat:
+		b.WriteByte('_')
+	case *IdentPat:
+		if p.Mut {
+			b.WriteString("mut ")
+		}
+		b.WriteString(p.Name)
+	case *LitPat:
+		b.WriteString(exprLiteralText(p.Value))
+	case *TuplePat:
+		b.WriteByte('(')
+		for i, e := range p.Elems {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			writePattern(b, e)
+		}
+		b.WriteByte(')')
+	case *StructPat:
+		b.WriteString(p.TypeName)
+		b.WriteString(" { ")
+		for i, f := range p.Fields {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(f.Name)
+			if f.Pattern != nil {
+				b.WriteString(": ")
+				writePattern(b, f.Pattern)
+			}
+		}
+		if p.Rest {
+			if len(p.Fields) > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString("..")
+		}
+		b.WriteString(" }")
+	case *VariantPat:
+		if p.Enum != "" {
+			b.WriteString(p.Enum)
+			b.WriteByte('.')
+		}
+		b.WriteString(p.Variant)
+		if len(p.Args) > 0 {
+			b.WriteByte('(')
+			for i, a := range p.Args {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				writePattern(b, a)
+			}
+			b.WriteByte(')')
+		}
+	case *RangePat:
+		if p.Low != nil {
+			b.WriteString(exprLiteralText(p.Low))
+		}
+		if p.Inclusive {
+			b.WriteString("..=")
+		} else {
+			b.WriteString("..")
+		}
+		if p.High != nil {
+			b.WriteString(exprLiteralText(p.High))
+		}
+	case *OrPat:
+		for i, a := range p.Alts {
+			if i > 0 {
+				b.WriteString(" | ")
+			}
+			writePattern(b, a)
+		}
+	case *BindingPat:
+		b.WriteString(p.Name)
+		b.WriteString(" @ ")
+		writePattern(b, p.Pattern)
+	case *ErrorPat:
+		b.WriteString("<error:")
+		b.WriteString(p.Note)
+		b.WriteByte('>')
+	}
+}
+
+// exprLiteralText renders a simple literal-ish expression for use in
+// pattern debug output. Non-literal expressions render via their
+// underlying type, which is sufficient for our debug printer.
+func exprLiteralText(e Expr) string {
+	switch e := e.(type) {
+	case *IntLit:
+		return e.Text
+	case *FloatLit:
+		return e.Text
+	case *BoolLit:
+		if e.Value {
+			return "true"
+		}
+		return "false"
+	case *CharLit:
+		return "'" + string(e.Value) + "'"
+	case *ByteLit:
+		return "b'?'"
+	case *StringLit:
+		var sb strings.Builder
+		sb.WriteByte('"')
+		for _, part := range e.Parts {
+			if part.IsLit {
+				sb.WriteString(part.Lit)
+			} else {
+				sb.WriteByte('{')
+				sb.WriteString("expr")
+				sb.WriteByte('}')
+			}
+		}
+		sb.WriteByte('"')
+		return sb.String()
+	case *Ident:
+		return e.Name
+	}
+	return "<expr>"
+}

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -1,0 +1,688 @@
+package ir
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Print renders a Module to an S-expression-like debug form useful for
+// tests and visual inspection. The output is intentionally compact and
+// stable — not a source formatter. For pretty-printed Osty, reparse
+// the generated output through `internal/format`.
+func Print(m *Module) string {
+	p := &printer{indent: 0}
+	p.printModule(m)
+	return p.b.String()
+}
+
+// PrintNode renders any single IR node using the same format as Print.
+func PrintNode(n Node) string {
+	p := &printer{indent: 0}
+	p.printNode(n)
+	return p.b.String()
+}
+
+type printer struct {
+	b      strings.Builder
+	indent int
+}
+
+func (p *printer) writef(format string, args ...any) {
+	fmt.Fprintf(&p.b, format, args...)
+}
+
+func (p *printer) nl() {
+	p.b.WriteByte('\n')
+	for i := 0; i < p.indent; i++ {
+		p.b.WriteString("  ")
+	}
+}
+
+func (p *printer) printModule(m *Module) {
+	if m == nil {
+		p.b.WriteString("(nil module)")
+		return
+	}
+	p.writef("(module %q", m.Package)
+	p.indent++
+	for _, d := range m.Decls {
+		p.nl()
+		p.printDecl(d)
+	}
+	if len(m.Script) > 0 {
+		p.nl()
+		p.b.WriteString("(script")
+		p.indent++
+		for _, s := range m.Script {
+			p.nl()
+			p.printStmt(s)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	}
+	p.indent--
+	p.b.WriteByte(')')
+}
+
+func (p *printer) printDecl(d Decl) {
+	switch d := d.(type) {
+	case *FnDecl:
+		p.writef("(fn %s", d.Name)
+		if d.Exported {
+			p.b.WriteString(" pub")
+		}
+		if len(d.Generics) > 0 {
+			p.b.WriteString(" [")
+			for i, g := range d.Generics {
+				if i > 0 {
+					p.b.WriteByte(' ')
+				}
+				p.b.WriteString(g.Name)
+			}
+			p.b.WriteByte(']')
+		}
+		p.b.WriteString(" (")
+		for i, pm := range d.Params {
+			if i > 0 {
+				p.b.WriteByte(' ')
+			}
+			p.writef("%s:%s", pm.Name, typeString(pm.Type))
+		}
+		p.writef(") -> %s", typeString(d.Return))
+		if d.Body != nil {
+			p.indent++
+			p.nl()
+			p.printBlock(d.Body)
+			p.indent--
+		}
+		p.b.WriteByte(')')
+	case *StructDecl:
+		p.writef("(struct %s", d.Name)
+		if d.Exported {
+			p.b.WriteString(" pub")
+		}
+		p.indent++
+		for _, f := range d.Fields {
+			p.nl()
+			p.writef("(field %s %s)", f.Name, typeString(f.Type))
+		}
+		for _, m := range d.Methods {
+			p.nl()
+			p.printDecl(m)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *EnumDecl:
+		p.writef("(enum %s", d.Name)
+		p.indent++
+		for _, v := range d.Variants {
+			p.nl()
+			p.writef("(variant %s", v.Name)
+			for _, pl := range v.Payload {
+				p.writef(" %s", typeString(pl))
+			}
+			p.b.WriteByte(')')
+		}
+		for _, m := range d.Methods {
+			p.nl()
+			p.printDecl(m)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *InterfaceDecl:
+		p.writef("(interface %s", d.Name)
+		p.indent++
+		for _, m := range d.Methods {
+			p.nl()
+			p.printDecl(m)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *TypeAliasDecl:
+		p.writef("(alias %s %s)", d.Name, typeString(d.Target))
+	case *LetDecl:
+		p.writef("(let %s %s ", d.Name, typeString(d.Type))
+		p.printExpr(d.Value)
+		p.b.WriteByte(')')
+	case *UseDecl:
+		p.writef("(use %s", strings.Join(d.Path, "."))
+		if d.Alias != "" && (len(d.Path) == 0 || d.Alias != d.Path[len(d.Path)-1]) {
+			p.writef(" as=%s", d.Alias)
+		}
+		p.b.WriteByte(')')
+	default:
+		p.writef("(decl %T)", d)
+	}
+}
+
+func (p *printer) printBlock(b *Block) {
+	if b == nil {
+		p.b.WriteString("(block)")
+		return
+	}
+	p.b.WriteString("(block")
+	p.indent++
+	for _, s := range b.Stmts {
+		p.nl()
+		p.printStmt(s)
+	}
+	if b.Result != nil {
+		p.nl()
+		p.b.WriteString("(result ")
+		p.printExpr(b.Result)
+		p.b.WriteByte(')')
+	}
+	p.indent--
+	p.b.WriteByte(')')
+}
+
+func (p *printer) printStmt(s Stmt) {
+	switch s := s.(type) {
+	case *Block:
+		p.printBlock(s)
+	case *LetStmt:
+		if s.Pattern != nil {
+			p.writef("(let-pat %s %s ", PatternString(s.Pattern), typeString(s.Type))
+		} else {
+			p.writef("(let %s %s ", s.Name, typeString(s.Type))
+		}
+		if s.Value != nil {
+			p.printExpr(s.Value)
+		} else {
+			p.b.WriteString("nil")
+		}
+		p.b.WriteByte(')')
+	case *ExprStmt:
+		p.b.WriteString("(stmt ")
+		p.printExpr(s.X)
+		p.b.WriteByte(')')
+	case *AssignStmt:
+		p.writef("(assign %s", assignOpName(s.Op))
+		for _, t := range s.Targets {
+			p.b.WriteByte(' ')
+			p.printExpr(t)
+		}
+		p.b.WriteString(" := ")
+		p.printExpr(s.Value)
+		p.b.WriteByte(')')
+	case *ReturnStmt:
+		p.b.WriteString("(return")
+		if s.Value != nil {
+			p.b.WriteByte(' ')
+			p.printExpr(s.Value)
+		}
+		p.b.WriteByte(')')
+	case *BreakStmt:
+		p.b.WriteString("(break)")
+	case *ContinueStmt:
+		p.b.WriteString("(continue)")
+	case *IfStmt:
+		p.b.WriteString("(if ")
+		p.printExpr(s.Cond)
+		p.indent++
+		p.nl()
+		p.printBlock(s.Then)
+		if s.Else != nil {
+			p.nl()
+			p.b.WriteString("else ")
+			p.printBlock(s.Else)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *ForStmt:
+		p.writef("(for %s", forKindName(s.Kind))
+		if s.Var != "" {
+			p.writef(" %s", s.Var)
+		}
+		p.indent++
+		if s.Cond != nil {
+			p.nl()
+			p.b.WriteString("cond=")
+			p.printExpr(s.Cond)
+		}
+		if s.Iter != nil {
+			p.nl()
+			p.b.WriteString("iter=")
+			p.printExpr(s.Iter)
+		}
+		if s.Start != nil {
+			p.nl()
+			p.b.WriteString("start=")
+			p.printExpr(s.Start)
+		}
+		if s.End != nil {
+			p.nl()
+			p.b.WriteString("end=")
+			p.printExpr(s.End)
+		}
+		if s.Body != nil {
+			p.nl()
+			p.printBlock(s.Body)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *DeferStmt:
+		p.b.WriteString("(defer ")
+		p.printBlock(s.Body)
+		p.b.WriteByte(')')
+	case *ChanSendStmt:
+		p.b.WriteString("(send ")
+		p.printExpr(s.Channel)
+		p.b.WriteByte(' ')
+		p.printExpr(s.Value)
+		p.b.WriteByte(')')
+	case *MatchStmt:
+		p.b.WriteString("(match-stmt ")
+		p.printExpr(s.Scrutinee)
+		p.indent++
+		for _, arm := range s.Arms {
+			p.nl()
+			p.printMatchArm(arm)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *ErrorStmt:
+		p.writef("(err-stmt %q)", s.Note)
+	default:
+		p.writef("(stmt? %T)", s)
+	}
+}
+
+func (p *printer) printExpr(e Expr) {
+	switch e := e.(type) {
+	case nil:
+		p.b.WriteString("nil")
+	case *IntLit:
+		p.b.WriteString(e.Text)
+	case *FloatLit:
+		p.b.WriteString(e.Text)
+	case *BoolLit:
+		if e.Value {
+			p.b.WriteString("true")
+		} else {
+			p.b.WriteString("false")
+		}
+	case *CharLit:
+		p.writef("'%c'", e.Value)
+	case *ByteLit:
+		p.writef("b%d", e.Value)
+	case *StringLit:
+		p.b.WriteByte('"')
+		for _, part := range e.Parts {
+			if part.IsLit {
+				p.b.WriteString(strings.ReplaceAll(part.Lit, "\"", "\\\""))
+			} else {
+				p.b.WriteByte('{')
+				p.printExpr(part.Expr)
+				p.b.WriteByte('}')
+			}
+		}
+		p.b.WriteByte('"')
+	case *UnitLit:
+		p.b.WriteString("()")
+	case *Ident:
+		p.b.WriteString(e.Name)
+		if e.Kind != IdentUnknown {
+			p.writef("#%s", identKindName(e.Kind))
+		}
+	case *UnaryExpr:
+		p.writef("(%s ", unOpName(e.Op))
+		p.printExpr(e.X)
+		p.b.WriteByte(')')
+	case *BinaryExpr:
+		p.writef("(%s ", binOpName(e.Op))
+		p.printExpr(e.Left)
+		p.b.WriteByte(' ')
+		p.printExpr(e.Right)
+		p.b.WriteByte(')')
+	case *CallExpr:
+		p.b.WriteString("(call ")
+		p.printExpr(e.Callee)
+		for _, a := range e.Args {
+			p.b.WriteByte(' ')
+			p.printExpr(a)
+		}
+		p.b.WriteByte(')')
+	case *IntrinsicCall:
+		p.writef("(intrinsic %s", intrinsicKindName(e.Kind))
+		for _, a := range e.Args {
+			p.b.WriteByte(' ')
+			p.printExpr(a)
+		}
+		p.b.WriteByte(')')
+	case *MethodCall:
+		p.b.WriteString("(mcall ")
+		p.printExpr(e.Receiver)
+		p.writef(" %s", e.Name)
+		if len(e.TypeArgs) > 0 {
+			p.b.WriteString(" ::<")
+			for i, ta := range e.TypeArgs {
+				if i > 0 {
+					p.b.WriteByte(',')
+				}
+				p.b.WriteString(typeString(ta))
+			}
+			p.b.WriteByte('>')
+		}
+		for _, a := range e.Args {
+			p.b.WriteByte(' ')
+			p.printExpr(a)
+		}
+		p.b.WriteByte(')')
+	case *ListLit:
+		p.b.WriteString("[")
+		for i, el := range e.Elems {
+			if i > 0 {
+				p.b.WriteString(" ")
+			}
+			p.printExpr(el)
+		}
+		p.b.WriteByte(']')
+	case *MapLit:
+		p.b.WriteString("{")
+		for i, en := range e.Entries {
+			if i > 0 {
+				p.b.WriteString(", ")
+			}
+			p.printExpr(en.Key)
+			p.b.WriteString(":")
+			p.printExpr(en.Value)
+		}
+		p.b.WriteByte('}')
+	case *TupleLit:
+		p.b.WriteByte('(')
+		for i, el := range e.Elems {
+			if i > 0 {
+				p.b.WriteString(", ")
+			}
+			p.printExpr(el)
+		}
+		p.b.WriteByte(')')
+	case *StructLit:
+		p.writef("(%s {", e.TypeName)
+		for i, f := range e.Fields {
+			if i > 0 {
+				p.b.WriteString(", ")
+			}
+			p.writef("%s:", f.Name)
+			if f.Value != nil {
+				p.printExpr(f.Value)
+			} else {
+				p.b.WriteString(f.Name)
+			}
+		}
+		if e.Spread != nil {
+			p.b.WriteString(" ..")
+			p.printExpr(e.Spread)
+		}
+		p.b.WriteString("})")
+	case *RangeLit:
+		if e.Start != nil {
+			p.printExpr(e.Start)
+		}
+		if e.Inclusive {
+			p.b.WriteString("..=")
+		} else {
+			p.b.WriteString("..")
+		}
+		if e.End != nil {
+			p.printExpr(e.End)
+		}
+	case *QuestionExpr:
+		p.b.WriteString("(?")
+		p.b.WriteByte(' ')
+		p.printExpr(e.X)
+		p.b.WriteByte(')')
+	case *CoalesceExpr:
+		p.b.WriteString("(?? ")
+		p.printExpr(e.Left)
+		p.b.WriteByte(' ')
+		p.printExpr(e.Right)
+		p.b.WriteByte(')')
+	case *FieldExpr:
+		p.b.WriteByte('(')
+		if e.Optional {
+			p.b.WriteString("?.")
+		} else {
+			p.b.WriteByte('.')
+		}
+		p.b.WriteByte(' ')
+		p.printExpr(e.X)
+		p.writef(" %s)", e.Name)
+	case *TupleAccess:
+		p.b.WriteString("(.")
+		p.writef("%d ", e.Index)
+		p.printExpr(e.X)
+		p.b.WriteByte(')')
+	case *IndexExpr:
+		p.b.WriteString("(idx ")
+		p.printExpr(e.X)
+		p.b.WriteByte(' ')
+		p.printExpr(e.Index)
+		p.b.WriteByte(')')
+	case *Closure:
+		p.b.WriteString("(\\(")
+		for i, pm := range e.Params {
+			if i > 0 {
+				p.b.WriteByte(' ')
+			}
+			p.writef("%s:%s", pm.Name, typeString(pm.Type))
+		}
+		p.writef(") -> %s ", typeString(e.Return))
+		p.printBlock(e.Body)
+		p.b.WriteByte(')')
+	case *VariantLit:
+		p.b.WriteByte('(')
+		if e.Enum != "" {
+			p.writef("%s.", e.Enum)
+		}
+		p.b.WriteString(e.Variant)
+		for _, a := range e.Args {
+			p.b.WriteByte(' ')
+			p.printExpr(a)
+		}
+		p.b.WriteByte(')')
+	case *BlockExpr:
+		p.printBlock(e.Block)
+	case *IfExpr:
+		p.b.WriteString("(if-expr ")
+		p.printExpr(e.Cond)
+		p.b.WriteByte(' ')
+		p.printBlock(e.Then)
+		if e.Else != nil {
+			p.b.WriteString(" else ")
+			p.printBlock(e.Else)
+		}
+		p.b.WriteByte(')')
+	case *IfLetExpr:
+		p.writef("(if-let %s ", PatternString(e.Pattern))
+		p.printExpr(e.Scrutinee)
+		p.b.WriteByte(' ')
+		p.printBlock(e.Then)
+		if e.Else != nil {
+			p.b.WriteString(" else ")
+			p.printBlock(e.Else)
+		}
+		p.b.WriteByte(')')
+	case *MatchExpr:
+		p.b.WriteString("(match ")
+		p.printExpr(e.Scrutinee)
+		p.indent++
+		for _, arm := range e.Arms {
+			p.nl()
+			p.printMatchArm(arm)
+		}
+		p.indent--
+		p.b.WriteByte(')')
+	case *ErrorExpr:
+		p.writef("(err %q)", e.Note)
+	default:
+		p.writef("(expr? %T)", e)
+	}
+}
+
+func (p *printer) printNode(n Node) {
+	switch n := n.(type) {
+	case *Module:
+		p.printModule(n)
+	case Decl:
+		p.printDecl(n)
+	case Stmt:
+		p.printStmt(n)
+	case Expr:
+		p.printExpr(n)
+	case Pattern:
+		p.b.WriteString(PatternString(n))
+	default:
+		p.writef("<%T>", n)
+	}
+}
+
+func (p *printer) printMatchArm(a *MatchArm) {
+	p.writef("(arm %s", PatternString(a.Pattern))
+	if a.Guard != nil {
+		p.b.WriteString(" if=")
+		p.printExpr(a.Guard)
+	}
+	p.b.WriteByte(' ')
+	p.printBlock(a.Body)
+	p.b.WriteByte(')')
+}
+
+// ---- Name helpers ----
+
+func assignOpName(o AssignOp) string {
+	switch o {
+	case AssignEq:
+		return "="
+	case AssignAdd:
+		return "+="
+	case AssignSub:
+		return "-="
+	case AssignMul:
+		return "*="
+	case AssignDiv:
+		return "/="
+	case AssignMod:
+		return "%="
+	case AssignAnd:
+		return "&="
+	case AssignOr:
+		return "|="
+	case AssignXor:
+		return "^="
+	case AssignShl:
+		return "<<="
+	case AssignShr:
+		return ">>="
+	}
+	return "?="
+}
+
+func forKindName(k ForKind) string {
+	switch k {
+	case ForInfinite:
+		return "inf"
+	case ForWhile:
+		return "while"
+	case ForRange:
+		return "range"
+	case ForIn:
+		return "in"
+	}
+	return "?"
+}
+
+func unOpName(o UnOp) string {
+	switch o {
+	case UnNeg:
+		return "neg"
+	case UnPlus:
+		return "pos"
+	case UnNot:
+		return "not"
+	case UnBitNot:
+		return "bnot"
+	}
+	return "?"
+}
+
+func binOpName(o BinOp) string {
+	switch o {
+	case BinAdd:
+		return "+"
+	case BinSub:
+		return "-"
+	case BinMul:
+		return "*"
+	case BinDiv:
+		return "/"
+	case BinMod:
+		return "%"
+	case BinEq:
+		return "=="
+	case BinNeq:
+		return "!="
+	case BinLt:
+		return "<"
+	case BinLeq:
+		return "<="
+	case BinGt:
+		return ">"
+	case BinGeq:
+		return ">="
+	case BinAnd:
+		return "&&"
+	case BinOr:
+		return "||"
+	case BinBitAnd:
+		return "&"
+	case BinBitOr:
+		return "|"
+	case BinBitXor:
+		return "^"
+	case BinShl:
+		return "<<"
+	case BinShr:
+		return ">>"
+	}
+	return "?"
+}
+
+func intrinsicKindName(k IntrinsicKind) string {
+	switch k {
+	case IntrinsicPrint:
+		return "print"
+	case IntrinsicPrintln:
+		return "println"
+	case IntrinsicEprint:
+		return "eprint"
+	case IntrinsicEprintln:
+		return "eprintln"
+	}
+	return "?"
+}
+
+func identKindName(k IdentKind) string {
+	switch k {
+	case IdentLocal:
+		return "local"
+	case IdentParam:
+		return "param"
+	case IdentFn:
+		return "fn"
+	case IdentVariant:
+		return "variant"
+	case IdentTypeName:
+		return "type"
+	case IdentGlobal:
+		return "global"
+	case IdentBuiltin:
+		return "builtin"
+	}
+	return "?"
+}
+
+// Quote is a convenience for printing quoted IR text in tests.
+func Quote(s string) string { return strconv.Quote(s) }

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -1,0 +1,380 @@
+package ir
+
+import "fmt"
+
+// Validate performs a light structural sanity check over an IR Module.
+// It does NOT re-run type checking — that's the front-end's job — but
+// it does catch internal invariants that a buggy lowerer could
+// violate, such as:
+//
+//   - Expr with nil Type()
+//   - Empty Module with a nil Package
+//   - FnDecl with a nil Body but not marked as an interface method
+//   - MatchArm with nil Pattern or nil Body
+//   - LetStmt with both Name == "" and Pattern == nil
+//
+// The returned slice is empty when the IR is well-formed. Backends
+// may call Validate during development (or behind a flag) as cheap
+// insurance against regressions in the lowerer.
+func Validate(m *Module) []error {
+	v := &validator{}
+	v.validateModule(m)
+	return v.errs
+}
+
+type validator struct {
+	errs []error
+	// methodCtx is true while validating a decl that's a method on a
+	// struct/enum/interface (no Body required for interface stubs).
+	inInterface bool
+}
+
+func (v *validator) addf(format string, args ...any) {
+	v.errs = append(v.errs, fmt.Errorf(format, args...))
+}
+
+func (v *validator) validateModule(m *Module) {
+	if m == nil {
+		v.addf("nil module")
+		return
+	}
+	if m.Package == "" {
+		v.addf("module: empty Package name")
+	}
+	for i, d := range m.Decls {
+		if d == nil {
+			v.addf("decl[%d]: nil", i)
+			continue
+		}
+		v.validateDecl(d)
+	}
+	for i, s := range m.Script {
+		if s == nil {
+			v.addf("script[%d]: nil", i)
+			continue
+		}
+		v.validateStmt(s)
+	}
+}
+
+func (v *validator) validateDecl(d Decl) {
+	switch d := d.(type) {
+	case *FnDecl:
+		v.validateFnDecl(d, false)
+	case *StructDecl:
+		for _, f := range d.Fields {
+			if f.Type == nil {
+				v.addf("struct %s: field %s has nil Type", d.Name, f.Name)
+			}
+			if f.Default != nil {
+				v.validateExpr(f.Default)
+			}
+		}
+		for _, m := range d.Methods {
+			v.validateFnDecl(m, false)
+		}
+	case *EnumDecl:
+		seen := map[string]bool{}
+		for _, vr := range d.Variants {
+			if vr.Name == "" {
+				v.addf("enum %s: variant with empty name", d.Name)
+			}
+			if seen[vr.Name] {
+				v.addf("enum %s: duplicate variant %s", d.Name, vr.Name)
+			}
+			seen[vr.Name] = true
+		}
+		for _, m := range d.Methods {
+			v.validateFnDecl(m, false)
+		}
+	case *InterfaceDecl:
+		old := v.inInterface
+		v.inInterface = true
+		for _, m := range d.Methods {
+			v.validateFnDecl(m, true)
+		}
+		v.inInterface = old
+	case *TypeAliasDecl:
+		if d.Target == nil {
+			v.addf("alias %s: nil Target", d.Name)
+		}
+	case *LetDecl:
+		if d.Name == "" {
+			v.addf("top-level let: empty Name")
+		}
+		if d.Value == nil {
+			v.addf("top-level let %s: nil Value", d.Name)
+		} else {
+			v.validateExpr(d.Value)
+		}
+	case *UseDecl:
+		if d.Alias == "" && !d.IsGoFFI {
+			v.addf("use: empty Alias")
+		}
+	}
+}
+
+func (v *validator) validateFnDecl(fn *FnDecl, allowNoBody bool) {
+	if fn.Name == "" {
+		v.addf("fn: empty Name")
+	}
+	if fn.Return == nil {
+		v.addf("fn %s: nil Return", fn.Name)
+	}
+	for i, p := range fn.Params {
+		if p == nil {
+			v.addf("fn %s: param[%d] nil", fn.Name, i)
+			continue
+		}
+		if p.Type == nil {
+			v.addf("fn %s: param %q nil Type", fn.Name, p.Name)
+		}
+	}
+	if fn.Body == nil {
+		if !allowNoBody && !v.inInterface {
+			v.addf("fn %s: nil Body", fn.Name)
+		}
+		return
+	}
+	v.validateBlock(fn.Body)
+}
+
+func (v *validator) validateBlock(b *Block) {
+	if b == nil {
+		v.addf("nil block")
+		return
+	}
+	for i, s := range b.Stmts {
+		if s == nil {
+			v.addf("block stmt[%d]: nil", i)
+			continue
+		}
+		v.validateStmt(s)
+	}
+	if b.Result != nil {
+		v.validateExpr(b.Result)
+	}
+}
+
+func (v *validator) validateStmt(s Stmt) {
+	switch s := s.(type) {
+	case *Block:
+		v.validateBlock(s)
+	case *LetStmt:
+		if s.Name == "" && s.Pattern == nil {
+			v.addf("let: both Name and Pattern empty")
+		}
+		if s.Value != nil {
+			v.validateExpr(s.Value)
+		}
+	case *ExprStmt:
+		if s.X == nil {
+			v.addf("ExprStmt: nil X")
+		} else {
+			v.validateExpr(s.X)
+		}
+	case *AssignStmt:
+		if len(s.Targets) == 0 {
+			v.addf("AssignStmt: no targets")
+		}
+		for _, t := range s.Targets {
+			v.validateExpr(t)
+		}
+		v.validateExpr(s.Value)
+	case *ReturnStmt:
+		if s.Value != nil {
+			v.validateExpr(s.Value)
+		}
+	case *BreakStmt, *ContinueStmt:
+		// leaves
+	case *IfStmt:
+		if s.Cond == nil {
+			v.addf("IfStmt: nil Cond")
+		} else {
+			v.validateExpr(s.Cond)
+		}
+		if s.Then == nil {
+			v.addf("IfStmt: nil Then")
+		} else {
+			v.validateBlock(s.Then)
+		}
+		if s.Else != nil {
+			v.validateBlock(s.Else)
+		}
+	case *ForStmt:
+		if s.Body == nil {
+			v.addf("ForStmt: nil Body")
+		} else {
+			v.validateBlock(s.Body)
+		}
+		switch s.Kind {
+		case ForWhile:
+			if s.Cond == nil {
+				v.addf("ForStmt While: nil Cond")
+			} else {
+				v.validateExpr(s.Cond)
+			}
+		case ForIn:
+			if s.Iter == nil {
+				v.addf("ForStmt In: nil Iter")
+			} else {
+				v.validateExpr(s.Iter)
+			}
+		case ForRange:
+			if s.Start == nil {
+				v.addf("ForStmt Range: nil Start")
+			} else {
+				v.validateExpr(s.Start)
+			}
+			if s.End == nil {
+				v.addf("ForStmt Range: nil End")
+			} else {
+				v.validateExpr(s.End)
+			}
+		}
+	case *DeferStmt:
+		if s.Body == nil {
+			v.addf("DeferStmt: nil Body")
+		} else {
+			v.validateBlock(s.Body)
+		}
+	case *ChanSendStmt:
+		v.validateExpr(s.Channel)
+		v.validateExpr(s.Value)
+	case *MatchStmt:
+		v.validateExpr(s.Scrutinee)
+		for i, a := range s.Arms {
+			if a == nil {
+				v.addf("MatchStmt arm[%d]: nil", i)
+				continue
+			}
+			v.validateMatchArm(a)
+		}
+	case *ErrorStmt:
+		// allowed by design
+	}
+}
+
+func (v *validator) validateExpr(e Expr) {
+	if e == nil {
+		v.addf("nil expression")
+		return
+	}
+	if e.Type() == nil {
+		v.addf("%T: nil Type()", e)
+	}
+	switch e := e.(type) {
+	case *UnaryExpr:
+		v.validateExpr(e.X)
+	case *BinaryExpr:
+		v.validateExpr(e.Left)
+		v.validateExpr(e.Right)
+	case *CallExpr:
+		v.validateExpr(e.Callee)
+		for _, a := range e.Args {
+			v.validateExpr(a)
+		}
+	case *IntrinsicCall:
+		for _, a := range e.Args {
+			v.validateExpr(a)
+		}
+	case *MethodCall:
+		v.validateExpr(e.Receiver)
+		for _, a := range e.Args {
+			v.validateExpr(a)
+		}
+	case *ListLit:
+		for _, el := range e.Elems {
+			v.validateExpr(el)
+		}
+	case *MapLit:
+		for _, en := range e.Entries {
+			v.validateExpr(en.Key)
+			v.validateExpr(en.Value)
+		}
+	case *TupleLit:
+		for _, el := range e.Elems {
+			v.validateExpr(el)
+		}
+	case *StructLit:
+		for _, f := range e.Fields {
+			if f.Value != nil {
+				v.validateExpr(f.Value)
+			}
+		}
+		if e.Spread != nil {
+			v.validateExpr(e.Spread)
+		}
+	case *RangeLit:
+		if e.Start != nil {
+			v.validateExpr(e.Start)
+		}
+		if e.End != nil {
+			v.validateExpr(e.End)
+		}
+	case *QuestionExpr:
+		v.validateExpr(e.X)
+	case *CoalesceExpr:
+		v.validateExpr(e.Left)
+		v.validateExpr(e.Right)
+	case *FieldExpr:
+		v.validateExpr(e.X)
+	case *TupleAccess:
+		v.validateExpr(e.X)
+	case *IndexExpr:
+		v.validateExpr(e.X)
+		v.validateExpr(e.Index)
+	case *Closure:
+		v.validateBlock(e.Body)
+	case *VariantLit:
+		for _, a := range e.Args {
+			v.validateExpr(a)
+		}
+	case *BlockExpr:
+		v.validateBlock(e.Block)
+	case *IfExpr:
+		v.validateExpr(e.Cond)
+		v.validateBlock(e.Then)
+		if e.Else != nil {
+			v.validateBlock(e.Else)
+		}
+	case *IfLetExpr:
+		if e.Pattern == nil {
+			v.addf("IfLetExpr: nil Pattern")
+		}
+		v.validateExpr(e.Scrutinee)
+		v.validateBlock(e.Then)
+		if e.Else != nil {
+			v.validateBlock(e.Else)
+		}
+	case *MatchExpr:
+		v.validateExpr(e.Scrutinee)
+		for i, a := range e.Arms {
+			if a == nil {
+				v.addf("MatchExpr arm[%d]: nil", i)
+				continue
+			}
+			v.validateMatchArm(a)
+		}
+	case *StringLit:
+		for _, p := range e.Parts {
+			if !p.IsLit && p.Expr != nil {
+				v.validateExpr(p.Expr)
+			}
+		}
+	}
+}
+
+func (v *validator) validateMatchArm(a *MatchArm) {
+	if a.Pattern == nil {
+		v.addf("MatchArm: nil Pattern")
+	}
+	if a.Guard != nil {
+		v.validateExpr(a.Guard)
+	}
+	if a.Body == nil {
+		v.addf("MatchArm: nil Body")
+	} else {
+		v.validateBlock(a.Body)
+	}
+}

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -1,0 +1,350 @@
+package ir
+
+// Visitor is the callback interface for Walk. Visit is invoked for
+// every Node encountered during traversal; the returned Visitor is
+// used for the node's children (nil skips descent). This mirrors
+// Go's ast.Walk but over ir.Node.
+type Visitor interface {
+	Visit(n Node) Visitor
+}
+
+// VisitorFunc adapts a plain function to the Visitor interface. The
+// returned sub-visitor is the same function, so callers that don't
+// need per-subtree state can pass a single closure.
+type VisitorFunc func(n Node) bool
+
+// Visit satisfies Visitor. Returning false stops descent into n's
+// children.
+func (f VisitorFunc) Visit(n Node) Visitor {
+	if f(n) {
+		return f
+	}
+	return nil
+}
+
+// Walk traverses an IR subtree rooted at n, invoking v.Visit on each
+// node in pre-order. After visiting a node, Walk descends into its
+// children using the Visitor returned by Visit. A nil sub-visitor
+// prunes the subtree.
+//
+// Walk is defensively nil-safe: walking a nil Node is a no-op.
+func Walk(v Visitor, n Node) {
+	if v == nil || n == nil {
+		return
+	}
+	w := v.Visit(n)
+	if w == nil {
+		return
+	}
+	walkChildren(w, n)
+}
+
+// walkChildren dispatches on the concrete node type and walks every
+// child node (decls, stmts, exprs, patterns) in source order.
+func walkChildren(v Visitor, n Node) {
+	switch n := n.(type) {
+
+	// ---- Module ----
+	case *Module:
+		for _, d := range n.Decls {
+			Walk(v, d)
+		}
+		for _, s := range n.Script {
+			Walk(v, s)
+		}
+
+	// ---- Decls ----
+	case *FnDecl:
+		for _, g := range n.Generics {
+			Walk(v, g)
+		}
+		for _, p := range n.Params {
+			Walk(v, p)
+		}
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+	case *StructDecl:
+		for _, g := range n.Generics {
+			Walk(v, g)
+		}
+		for _, f := range n.Fields {
+			Walk(v, f)
+		}
+		for _, m := range n.Methods {
+			Walk(v, m)
+		}
+	case *EnumDecl:
+		for _, g := range n.Generics {
+			Walk(v, g)
+		}
+		for _, vr := range n.Variants {
+			Walk(v, vr)
+		}
+		for _, m := range n.Methods {
+			Walk(v, m)
+		}
+	case *LetDecl:
+		if n.Value != nil {
+			Walk(v, n.Value)
+		}
+	case *InterfaceDecl:
+		for _, g := range n.Generics {
+			Walk(v, g)
+		}
+		for _, m := range n.Methods {
+			Walk(v, m)
+		}
+	case *TypeAliasDecl:
+		for _, g := range n.Generics {
+			Walk(v, g)
+		}
+	case *UseDecl:
+		for _, d := range n.GoBody {
+			Walk(v, d)
+		}
+
+	// ---- Decl sub-nodes ----
+	case *Param:
+		if n.Default != nil {
+			Walk(v, n.Default)
+		}
+	case *Field:
+		if n.Default != nil {
+			Walk(v, n.Default)
+		}
+	case *TypeParam:
+		// bounds are types, not nodes; nothing to walk
+	case *Variant:
+		// payload slots are types, not nodes; nothing to walk
+
+	// ---- Stmts ----
+	case *Block:
+		for _, s := range n.Stmts {
+			Walk(v, s)
+		}
+		if n.Result != nil {
+			Walk(v, n.Result)
+		}
+	case *LetStmt:
+		if n.Pattern != nil {
+			Walk(v, n.Pattern)
+		}
+		if n.Value != nil {
+			Walk(v, n.Value)
+		}
+	case *ExprStmt:
+		Walk(v, n.X)
+	case *AssignStmt:
+		for _, t := range n.Targets {
+			Walk(v, t)
+		}
+		Walk(v, n.Value)
+	case *ReturnStmt:
+		if n.Value != nil {
+			Walk(v, n.Value)
+		}
+	case *BreakStmt, *ContinueStmt:
+		// leaves
+	case *IfStmt:
+		Walk(v, n.Cond)
+		if n.Then != nil {
+			Walk(v, n.Then)
+		}
+		if n.Else != nil {
+			Walk(v, n.Else)
+		}
+	case *ForStmt:
+		if n.Cond != nil {
+			Walk(v, n.Cond)
+		}
+		if n.Iter != nil {
+			Walk(v, n.Iter)
+		}
+		if n.Start != nil {
+			Walk(v, n.Start)
+		}
+		if n.End != nil {
+			Walk(v, n.End)
+		}
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+	case *DeferStmt:
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+	case *ChanSendStmt:
+		Walk(v, n.Channel)
+		Walk(v, n.Value)
+	case *MatchStmt:
+		Walk(v, n.Scrutinee)
+		for _, a := range n.Arms {
+			Walk(v, a)
+		}
+	case *ErrorStmt:
+		// leaf
+
+	// ---- Exprs ----
+	case *IntLit, *FloatLit, *BoolLit, *CharLit, *ByteLit, *UnitLit:
+		// leaves
+	case *StringLit:
+		for _, p := range n.Parts {
+			if !p.IsLit && p.Expr != nil {
+				Walk(v, p.Expr)
+			}
+		}
+	case *Ident:
+		// leaf
+	case *UnaryExpr:
+		Walk(v, n.X)
+	case *BinaryExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *CallExpr:
+		Walk(v, n.Callee)
+		for _, a := range n.Args {
+			Walk(v, a)
+		}
+	case *IntrinsicCall:
+		for _, a := range n.Args {
+			Walk(v, a)
+		}
+	case *MethodCall:
+		Walk(v, n.Receiver)
+		for _, a := range n.Args {
+			Walk(v, a)
+		}
+	case *ListLit:
+		for _, e := range n.Elems {
+			Walk(v, e)
+		}
+	case *MapLit:
+		for _, en := range n.Entries {
+			Walk(v, en.Key)
+			Walk(v, en.Value)
+		}
+	case *TupleLit:
+		for _, e := range n.Elems {
+			Walk(v, e)
+		}
+	case *StructLit:
+		for _, f := range n.Fields {
+			if f.Value != nil {
+				Walk(v, f.Value)
+			}
+		}
+		if n.Spread != nil {
+			Walk(v, n.Spread)
+		}
+	case *RangeLit:
+		if n.Start != nil {
+			Walk(v, n.Start)
+		}
+		if n.End != nil {
+			Walk(v, n.End)
+		}
+	case *QuestionExpr:
+		Walk(v, n.X)
+	case *CoalesceExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *FieldExpr:
+		Walk(v, n.X)
+	case *TupleAccess:
+		Walk(v, n.X)
+	case *IndexExpr:
+		Walk(v, n.X)
+		Walk(v, n.Index)
+	case *Closure:
+		for _, p := range n.Params {
+			Walk(v, p)
+		}
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+	case *VariantLit:
+		for _, a := range n.Args {
+			Walk(v, a)
+		}
+	case *BlockExpr:
+		if n.Block != nil {
+			Walk(v, n.Block)
+		}
+	case *IfExpr:
+		Walk(v, n.Cond)
+		if n.Then != nil {
+			Walk(v, n.Then)
+		}
+		if n.Else != nil {
+			Walk(v, n.Else)
+		}
+	case *IfLetExpr:
+		Walk(v, n.Pattern)
+		Walk(v, n.Scrutinee)
+		if n.Then != nil {
+			Walk(v, n.Then)
+		}
+		if n.Else != nil {
+			Walk(v, n.Else)
+		}
+	case *MatchExpr:
+		Walk(v, n.Scrutinee)
+		for _, a := range n.Arms {
+			Walk(v, a)
+		}
+	case *MatchArm:
+		Walk(v, n.Pattern)
+		if n.Guard != nil {
+			Walk(v, n.Guard)
+		}
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+	case *ErrorExpr:
+		// leaf
+
+	// ---- Patterns ----
+	case *WildPat, *IdentPat, *ErrorPat:
+		// leaves
+	case *LitPat:
+		if n.Value != nil {
+			Walk(v, n.Value)
+		}
+	case *TuplePat:
+		for _, e := range n.Elems {
+			Walk(v, e)
+		}
+	case *StructPat:
+		for _, f := range n.Fields {
+			if f.Pattern != nil {
+				Walk(v, f.Pattern)
+			}
+		}
+	case *VariantPat:
+		for _, a := range n.Args {
+			Walk(v, a)
+		}
+	case *RangePat:
+		if n.Low != nil {
+			Walk(v, n.Low)
+		}
+		if n.High != nil {
+			Walk(v, n.High)
+		}
+	case *OrPat:
+		for _, a := range n.Alts {
+			Walk(v, a)
+		}
+	case *BindingPat:
+		if n.Pattern != nil {
+			Walk(v, n.Pattern)
+		}
+	}
+}
+
+// Inspect is a shorthand for Walk(VisitorFunc(fn), n) — the most
+// common form in client code.
+func Inspect(n Node, fn func(Node) bool) {
+	Walk(VisitorFunc(fn), n)
+}


### PR DESCRIPTION
## Summary

- Introduces `internal/ir`, a self-contained intermediate representation between the type-checked front-end and backends like `gen`.
- Backends can now depend on `ir` alone: names are strings, every expression carries its own `ir.Type`, and no node references `ast`, `resolve`, or `check`.
- `ir.Lower(pkg, file, res, chk)` walks the AST and produces an `*ir.Module` with decls, script-mode stmts, and a list of non-fatal lowering issues. Unsupported constructs collapse to `ErrorStmt` / `ErrorExpr` instead of panicking.

## Scope

Covers what `gen` Phase 1 consumes today: fn decls, struct / enum shapes, let bindings, if / for / return, print intrinsics, user calls, and list literals. Larger constructs (match, `?`, generics, closures) are stubbed as future work — the IR node types are already in place so a follow-on can flesh them out without changing consumer code.

## Test plan

- [x] `go test ./internal/ir/` — 9 tests covering hello-world, arithmetic, let + ident kinds, for-range, if/else, struct shapes, script mode, list literal types, type stringification, and a self-containment walk asserting every expression's `Type()` satisfies `ir.Type`.
- [x] `go build ./...` — no regressions in the rest of the tree.
- [x] `go test ./...` — only the pre-existing `internal/format` golden mismatch (unrelated to this change) remains.

https://claude.ai/code/session_01Acx479bnxWbSfyyRzhbFYu