### PR TITLE
lsp: add source.organizeImports and source.fixAll code actions

### DIFF
--- a/internal/lsp/codeaction.go
+++ b/internal/lsp/codeaction.go
@@ -7,13 +7,25 @@ import (
 	"github.com/osty/osty/internal/lexer"
 )
 
-// handleCodeAction answers `textDocument/codeAction`. We examine the
-// diagnostics the editor attached to the request (those it has cached
-// for the current cursor range) and emit quick fixes for the subset
-// whose code we know how to patch.
+// handleCodeAction answers `textDocument/codeAction`. It produces two
+// families of results:
 //
-// Today we cover:
+//   - Diagnostic-attached quick fixes: one fix per problem the editor
+//     attached to the request (those it has cached for the current
+//     cursor range) whose code we know how to patch.
 //
+//   - Source actions: bulk refactors that operate on the whole file
+//     regardless of where the cursor sits. Currently:
+//       * source.organizeImports — sort, dedupe, and drop unused
+//         `use` declarations.
+//       * source.fixAll[.osty] — apply every machine-applicable
+//         compiler/lint suggestion in one edit.
+//
+// The `context.only` filter the client sends narrows what we return
+// — `["source.organizeImports"]` on save yields just that action, an
+// empty filter yields everything applicable.
+//
+// Quick-fix coverage:
 //   - E0500 (undefined name): suggest rename-to-nearest-match using
 //     the resolver's own scope+Levenshtein logic, so the fixes line
 //     up with the hints the compiler emitted in the first place.
@@ -31,15 +43,31 @@ func (s *Server) handleCodeAction(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, []CodeAction{})
 		return
 	}
+	only := params.Context.Only
 	var actions []CodeAction
-	for _, d := range params.Context.Diagnostics {
-		switch d.Code {
-		case diag.CodeUndefinedName:
-			actions = append(actions, undefinedNameFixes(doc, d)...)
-		case diag.CodeUnusedLet, diag.CodeUnusedParam:
-			actions = append(actions, prefixUnderscoreFix(doc, d))
-		case diag.CodeUnusedImport:
-			actions = append(actions, removeLineFix(doc, d))
+	// Diagnostic-attached quick fixes (kind = quickfix).
+	if wantsKind(only, CodeActionQuickFix) {
+		for _, d := range params.Context.Diagnostics {
+			switch d.Code {
+			case diag.CodeUndefinedName:
+				actions = append(actions, undefinedNameFixes(doc, d)...)
+			case diag.CodeUnusedLet, diag.CodeUnusedParam:
+				actions = append(actions, prefixUnderscoreFix(doc, d))
+			case diag.CodeUnusedImport:
+				actions = append(actions, removeLineFix(doc, d))
+			}
+		}
+	}
+	// Source actions (kind = source.*). These are triggered on save
+	// or via the command palette, independent of the cursor range.
+	if wantsKind(only, CodeActionSourceOrganizeImports) {
+		if a := organizeImportsAction(doc); a != nil {
+			actions = append(actions, *a)
+		}
+	}
+	if wantsKind(only, CodeActionSourceFixAllOsty) || wantsKind(only, CodeActionSourceFixAll) {
+		if a := fixAllAction(doc); a != nil {
+			actions = append(actions, *a)
 		}
 	}
 	replyJSON(s.conn, req.ID, actions)

--- a/internal/lsp/features_test.go
+++ b/internal/lsp/features_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/osty/osty/internal/diag"
 )
@@ -298,6 +299,174 @@ func TestCodeActionRenameUndefined(t *testing.T) {
 	if !found {
 		t.Errorf("expected a rename-to-println quick fix, got %+v", actions)
 	}
+}
+
+// TestLintDiagnosticsPublished verifies that lint warnings (L-codes)
+// now arrive in publishDiagnostics so editors paint squigglies and
+// the per-diagnostic quick-fix handlers actually have something to
+// fire on.
+func TestLintDiagnosticsPublished(t *testing.T) {
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+
+	src := `fn main() {
+    let unused = 1
+    let x = 2
+    println(x)
+}
+`
+	sess.send("", "textDocument/didOpen", DidOpenTextDocumentParams{
+		TextDocument: TextDocumentItem{
+			URI: sampleURI, LanguageID: "osty", Version: 1, Text: src,
+		},
+	})
+	notifs := sess.drainNotifications("textDocument/publishDiagnostics", 2*time.Second)
+	if len(notifs) == 0 {
+		t.Fatal("no diagnostics published")
+	}
+	var pp PublishDiagnosticsParams
+	if err := json.Unmarshal(notifs[len(notifs)-1].Params, &pp); err != nil {
+		t.Fatal(err)
+	}
+	foundL0001 := false
+	for _, d := range pp.Diagnostics {
+		if d.Code == diag.CodeUnusedLet {
+			foundL0001 = true
+			break
+		}
+	}
+	if !foundL0001 {
+		t.Errorf("expected L0001 (unused let) in published diagnostics, got %+v", pp.Diagnostics)
+	}
+}
+
+// TestOrganizeImportsBailsOnComment verifies we refuse to rewrite
+// the use block when a line comment sits between two imports — the
+// AST doesn't track that comment, so rewriting would silently drop
+// it. The action must simply not be offered in that case.
+func TestOrganizeImportsBailsOnComment(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "zeta", "z.osty"),
+		`pub fn zz() {}
+`)
+	writeFile(t, filepath.Join(dir, "alpha", "a.osty"),
+		`pub fn aa() {}
+`)
+	mainPath := filepath.Join(dir, "main.osty")
+	// Out-of-order imports with a comment between them. Without
+	// the comment we'd offer a sort action; with it we must bail.
+	mainSrc := `use zeta
+// important ordering note
+use alpha
+
+fn main() {
+    zeta.zz()
+    alpha.aa()
+}
+`
+	writeFile(t, mainPath, mainSrc)
+
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+	mainURI := fileURI(mainPath)
+	sess.openDoc(mainURI, mainSrc)
+
+	sess.send("oi4", "textDocument/codeAction", CodeActionParams{
+		TextDocument: TextDocumentIdentifier{URI: mainURI},
+		Range:        Range{},
+		Context: CodeActionContext{
+			Only: []string{CodeActionSourceOrganizeImports},
+		},
+	})
+	resp := sess.waitResponse("oi4")
+	if resp.Error != nil {
+		t.Fatalf("codeAction error: %+v", resp.Error)
+	}
+	var actions []CodeAction
+	if err := json.Unmarshal(resp.Result, &actions); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 0 {
+		t.Errorf("expected no organizeImports when comment between uses; got %+v", actions)
+	}
+}
+
+// TestOrganizeImportsPreservesTrailingBlank checks that the rewrite
+// doesn't swallow blank lines the author inserted after the last
+// use — that whitespace belongs to the next declaration and must
+// survive.
+func TestOrganizeImportsPreservesTrailingBlank(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "zeta", "z.osty"),
+		`pub fn zz() {}
+`)
+	writeFile(t, filepath.Join(dir, "alpha", "a.osty"),
+		`pub fn aa() {}
+`)
+	mainPath := filepath.Join(dir, "main.osty")
+	// Out-of-order but clean (no comments).
+	mainSrc := `use zeta
+use alpha
+
+fn main() {
+    zeta.zz()
+    alpha.aa()
+}
+`
+	writeFile(t, mainPath, mainSrc)
+
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+	mainURI := fileURI(mainPath)
+	sess.openDoc(mainURI, mainSrc)
+
+	sess.send("oi5", "textDocument/codeAction", CodeActionParams{
+		TextDocument: TextDocumentIdentifier{URI: mainURI},
+		Range:        Range{},
+		Context: CodeActionContext{
+			Only: []string{CodeActionSourceOrganizeImports},
+		},
+	})
+	resp := sess.waitResponse("oi5")
+	if resp.Error != nil {
+		t.Fatalf("codeAction error: %+v", resp.Error)
+	}
+	var actions []CodeAction
+	if err := json.Unmarshal(resp.Result, &actions); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("expected a sort action")
+	}
+	edits := actions[0].Edit.Changes[mainURI]
+	if len(edits) != 1 {
+		t.Fatalf("expected one edit, got %d", len(edits))
+	}
+	// Simulate applying the edit to the original source and confirm
+	// the blank line before `fn main` survives.
+	li := newLineIndex([]byte(mainSrc))
+	startOff := offsetFromLSP(li, edits[0].Range.Start)
+	endOff := offsetFromLSP(li, edits[0].Range.End)
+	if startOff < 0 || endOff > len(mainSrc) || startOff > endOff {
+		t.Fatalf("bad edit range: %+v", edits[0].Range)
+	}
+	after := mainSrc[:startOff] + edits[0].NewText + mainSrc[endOff:]
+	if !strings.Contains(after, "use alpha\nuse zeta\n\nfn main()") {
+		t.Errorf("trailing blank line lost. Applied result:\n%s", after)
+	}
+}
+
+// offsetFromLSP is a small helper that walks a lineIndex to convert
+// an LSP Position back into a byte offset — used by the organize
+// tests above to simulate applying the returned edits.
+func offsetFromLSP(li *lineIndex, p Position) int {
+	if int(p.Line) >= len(li.lines) {
+		return len(li.src)
+	}
+	return li.lspToOsty(p).Offset
 }
 
 // TestOrganizeImportsDropsUnused opens a file with one used and one

--- a/internal/lsp/features_test.go
+++ b/internal/lsp/features_test.go
@@ -300,6 +300,275 @@ func TestCodeActionRenameUndefined(t *testing.T) {
 	}
 }
 
+// TestOrganizeImportsDropsUnused opens a file with one used and one
+// unused `use` and verifies source.organizeImports returns an edit
+// that rewrites the import block without the dead line.
+func TestOrganizeImportsDropsUnused(t *testing.T) {
+	dir := t.TempDir()
+	// Sibling packages so the `use` decls resolve against a real
+	// workspace — otherwise the resolver may not flag the unused
+	// imports via L0003.
+	writeFile(t, filepath.Join(dir, "auth", "login.osty"),
+		`pub fn login() {}
+`)
+	writeFile(t, filepath.Join(dir, "util", "helper.osty"),
+		`pub fn noop() {}
+`)
+	mainPath := filepath.Join(dir, "main.osty")
+	mainSrc := `use util
+use auth
+
+fn main() {
+    auth.login()
+}
+`
+	writeFile(t, mainPath, mainSrc)
+
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+	mainURI := fileURI(mainPath)
+	sess.openDoc(mainURI, mainSrc)
+
+	sess.send("oi1", "textDocument/codeAction", CodeActionParams{
+		TextDocument: TextDocumentIdentifier{URI: mainURI},
+		Range: Range{
+			Start: Position{Line: 0, Character: 0},
+			End:   Position{Line: 0, Character: 0},
+		},
+		Context: CodeActionContext{
+			Only: []string{CodeActionSourceOrganizeImports},
+		},
+	})
+	resp := sess.waitResponse("oi1")
+	if resp.Error != nil {
+		t.Fatalf("codeAction error: %+v", resp.Error)
+	}
+	var actions []CodeAction
+	if err := json.Unmarshal(resp.Result, &actions); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("expected an organizeImports action")
+	}
+	a := actions[0]
+	if a.Kind != CodeActionSourceOrganizeImports {
+		t.Errorf("kind = %q, want %q", a.Kind, CodeActionSourceOrganizeImports)
+	}
+	if a.Edit == nil || len(a.Edit.Changes[mainURI]) == 0 {
+		t.Fatalf("no edits in action: %+v", a)
+	}
+	newText := a.Edit.Changes[mainURI][0].NewText
+	if strings.Contains(newText, "use util") {
+		t.Errorf("expected `use util` to be removed; got: %q", newText)
+	}
+	if !strings.Contains(newText, "use auth") {
+		t.Errorf("expected `use auth` to survive; got: %q", newText)
+	}
+}
+
+// TestOrganizeImportsSortsAlphabetically verifies a grab-bag of
+// imports comes back in sorted order so the edit is a genuine
+// canonicalization and not just a passthrough.
+func TestOrganizeImportsSortsAlphabetically(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "zeta", "z.osty"),
+		`pub fn zz() {}
+`)
+	writeFile(t, filepath.Join(dir, "alpha", "a.osty"),
+		`pub fn aa() {}
+`)
+	writeFile(t, filepath.Join(dir, "beta", "b.osty"),
+		`pub fn bb() {}
+`)
+	mainPath := filepath.Join(dir, "main.osty")
+	mainSrc := `use zeta
+use alpha
+use beta
+
+fn main() {
+    zeta.zz()
+    alpha.aa()
+    beta.bb()
+}
+`
+	writeFile(t, mainPath, mainSrc)
+
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+	mainURI := fileURI(mainPath)
+	sess.openDoc(mainURI, mainSrc)
+
+	sess.send("oi2", "textDocument/codeAction", CodeActionParams{
+		TextDocument: TextDocumentIdentifier{URI: mainURI},
+		Range:        Range{},
+		Context: CodeActionContext{
+			Only: []string{CodeActionSourceOrganizeImports},
+		},
+	})
+	resp := sess.waitResponse("oi2")
+	if resp.Error != nil {
+		t.Fatalf("codeAction error: %+v", resp.Error)
+	}
+	var actions []CodeAction
+	if err := json.Unmarshal(resp.Result, &actions); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("expected a sort-imports action")
+	}
+	newText := actions[0].Edit.Changes[mainURI][0].NewText
+	// Alpha < beta < zeta — indices must be ascending in the rewrite.
+	ai := strings.Index(newText, "use alpha")
+	bi := strings.Index(newText, "use beta")
+	zi := strings.Index(newText, "use zeta")
+	if ai < 0 || bi < 0 || zi < 0 {
+		t.Fatalf("missing use line in %q", newText)
+	}
+	if !(ai < bi && bi < zi) {
+		t.Errorf("uses not sorted alphabetically: alpha@%d beta@%d zeta@%d\n%s",
+			ai, bi, zi, newText)
+	}
+}
+
+// TestOrganizeImportsNoOpOnCleanFile confirms that a file whose
+// imports are already sorted and used yields no organizeImports
+// action — the lightbulb shouldn't light up on clean code.
+func TestOrganizeImportsNoOpOnCleanFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "alpha", "a.osty"),
+		`pub fn aa() {}
+`)
+	writeFile(t, filepath.Join(dir, "beta", "b.osty"),
+		`pub fn bb() {}
+`)
+	mainPath := filepath.Join(dir, "main.osty")
+	mainSrc := `use alpha
+use beta
+
+fn main() {
+    alpha.aa()
+    beta.bb()
+}
+`
+	writeFile(t, mainPath, mainSrc)
+
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+	mainURI := fileURI(mainPath)
+	sess.openDoc(mainURI, mainSrc)
+
+	sess.send("oi3", "textDocument/codeAction", CodeActionParams{
+		TextDocument: TextDocumentIdentifier{URI: mainURI},
+		Range:        Range{},
+		Context: CodeActionContext{
+			Only: []string{CodeActionSourceOrganizeImports},
+		},
+	})
+	resp := sess.waitResponse("oi3")
+	if resp.Error != nil {
+		t.Fatalf("codeAction error: %+v", resp.Error)
+	}
+	var actions []CodeAction
+	if err := json.Unmarshal(resp.Result, &actions); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 0 {
+		t.Errorf("expected no actions for clean imports, got %+v", actions)
+	}
+}
+
+// TestFixAllBundlesSuggestions verifies source.fixAll.osty rolls
+// multiple machine-applicable lint fixes into one edit.
+func TestFixAllBundlesSuggestions(t *testing.T) {
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+
+	// Two unused bindings — each carries a MachineApplicable
+	// "prefix with _" suggestion.
+	src := `fn main() {
+    let alpha = 1
+    let beta = 2
+}
+`
+	sess.openDoc(sampleURI, src)
+
+	sess.send("fa1", "textDocument/codeAction", CodeActionParams{
+		TextDocument: TextDocumentIdentifier{URI: sampleURI},
+		Range:        Range{},
+		Context: CodeActionContext{
+			Only: []string{CodeActionSourceFixAllOsty},
+		},
+	})
+	resp := sess.waitResponse("fa1")
+	if resp.Error != nil {
+		t.Fatalf("codeAction error: %+v", resp.Error)
+	}
+	var actions []CodeAction
+	if err := json.Unmarshal(resp.Result, &actions); err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("expected a fixAll action")
+	}
+	a := actions[0]
+	if a.Kind != CodeActionSourceFixAllOsty {
+		t.Errorf("kind = %q, want %q", a.Kind, CodeActionSourceFixAllOsty)
+	}
+	if a.Edit == nil {
+		t.Fatal("fixAll action missing edit")
+	}
+	edits := a.Edit.Changes[sampleURI]
+	// Expect at least two fixes — one per unused binding. The exact
+	// number may be higher if the checker also contributes
+	// suggestions for the same diagnostics.
+	if len(edits) < 2 {
+		t.Errorf("expected ≥2 bundled edits, got %d: %+v", len(edits), edits)
+	}
+}
+
+// TestCodeActionCapabilityAdvertisesKinds confirms the Initialize
+// response lists the source-action kinds clients need to see before
+// they'll run them on save.
+func TestCodeActionCapabilityAdvertisesKinds(t *testing.T) {
+	sess := startSession(t)
+	defer sess.stop()
+
+	sess.send("cap", "initialize", InitializeParams{})
+	resp := sess.waitResponse("cap")
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %+v", resp.Error)
+	}
+	var res InitializeResult
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Capabilities.CodeActionProvider == nil {
+		t.Fatal("no codeActionProvider advertised")
+	}
+	kinds := res.Capabilities.CodeActionProvider.CodeActionKinds
+	wants := []string{
+		CodeActionQuickFix,
+		CodeActionSourceOrganizeImports,
+		CodeActionSourceFixAllOsty,
+	}
+	for _, w := range wants {
+		found := false
+		for _, k := range kinds {
+			if k == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("capability missing kind %q; got %v", w, kinds)
+		}
+	}
+}
+
 // TestReferencesAcrossPackages confirms references walk every loaded
 // package rather than stopping at the current file.
 func TestReferencesAcrossPackages(t *testing.T) {

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -46,7 +46,14 @@ func (s *Server) handleInitialize(req *rpcRequest) {
 			RenameProvider:             true,
 			WorkspaceSymbolProvider:    true,
 			InlayHintProvider:          true,
-			CodeActionProvider:         true,
+			CodeActionProvider: &CodeActionOptions{
+				CodeActionKinds: []string{
+					CodeActionQuickFix,
+					CodeActionSourceOrganizeImports,
+					CodeActionSourceFixAllOsty,
+					CodeActionSourceFixAll,
+				},
+			},
 			CompletionProvider: &CompletionOptions{
 				// `.` triggers member completion (pkg.fn, recv.method).
 				TriggerCharacters: []string{"."},

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -164,7 +164,7 @@ type ServerCapabilities struct {
 	WorkspaceSymbolProvider    bool                     `json:"workspaceSymbolProvider,omitempty"`
 	InlayHintProvider          bool                     `json:"inlayHintProvider,omitempty"`
 	SemanticTokensProvider     *SemanticTokensOptions   `json:"semanticTokensProvider,omitempty"`
-	CodeActionProvider         bool                     `json:"codeActionProvider,omitempty"`
+	CodeActionProvider         *CodeActionOptions       `json:"codeActionProvider,omitempty"`
 	PositionEncoding           string                   `json:"positionEncoding,omitempty"`
 }
 
@@ -554,6 +554,16 @@ type SemanticTokensOptions struct {
 }
 
 // ---- Code action ----
+
+// CodeActionOptions advertises which code-action kinds the server
+// can produce. Clients that honor the list (VS Code in particular)
+// filter their "Source Action…" menu and on-save runners by it, so
+// advertising `source.organizeImports` here is what makes
+// `editor.codeActionsOnSave` actually fire for Osty files.
+type CodeActionOptions struct {
+	CodeActionKinds []string `json:"codeActionKinds,omitempty"`
+	ResolveProvider bool     `json:"resolveProvider,omitempty"`
+}
 
 // CodeActionParams is the payload of `textDocument/codeAction`. The
 // Context.Diagnostics slice holds whatever problems the editor has

--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/lint"
 )
 
 // LSP code-action kind strings (LSP 3.17 §codeActionKind). Only the
@@ -64,9 +63,15 @@ func organizeImportsAction(doc *document) *CodeAction {
 		return nil
 	}
 	uses := a.file.Uses
-	// Drop uses whose primary span overlaps a parser error — we don't
-	// trust their offsets enough to rewrite the file. A single bad line
-	// shouldn't void the whole organize operation; just skip that one.
+	// Bail out if any meaningful trivia sits between consecutive use
+	// decls — line comments, doc comments, or annotations that the
+	// AST doesn't attach to the UseDecl itself. Rewriting the block
+	// would silently relocate or delete those bytes. The user can
+	// still delete unused imports via the per-diagnostic quick fix,
+	// so organizing is just unavailable, not broken.
+	if hasTriviaBetweenUses(doc.src, uses) {
+		return nil
+	}
 	unused := unusedUseSet(doc)
 
 	type keyed struct {
@@ -190,8 +195,10 @@ func useSourceText(src []byte, u *ast.UseDecl) string {
 }
 
 // endOfLineOffset advances from `off` over any trailing whitespace
-// plus one line terminator, returning the offset of the first byte of
-// the next line (or len(src) if we hit EOF first).
+// plus exactly one line terminator, returning the offset of the first
+// byte of the next line (or len(src) if we hit EOF first). Trailing
+// blank lines the user inserted between the last `use` and the next
+// decl are preserved — we stop after consuming the first newline.
 func endOfLineOffset(src []byte, off int) int {
 	for off < len(src) && (src[off] == ' ' || src[off] == '\t') {
 		off++
@@ -205,15 +212,48 @@ func endOfLineOffset(src []byte, off int) int {
 	return off
 }
 
-// unusedUseSet runs the single-file lint pass and returns the set of
-// UseDecl nodes flagged L0003 ("unused import"). Reuses lint.File so
-// the organize action stays in lockstep with the standalone `osty
-// lint` CLI — if lint's unused-import logic evolves, the refactor
-// follows automatically.
+// hasTriviaBetweenUses reports whether non-whitespace bytes appear
+// between the end of one UseDecl's line and the start of the next.
+// Osty's parser strips comments before handing the token stream to
+// the AST builder, so a `// ...` line between two `use` decls has no
+// AST node — it only shows up when we scan the raw source. Finding
+// ANY non-whitespace / non-`use` byte in that gap tells us there's
+// trivia we shouldn't stomp.
+//
+// The scan runs from each use's end-of-line to the next use's
+// PosV.Offset. If it sees anything other than ASCII whitespace or a
+// second `use` keyword, we treat the block as too risky to rewrite.
+func hasTriviaBetweenUses(src []byte, uses []*ast.UseDecl) bool {
+	for i := 0; i+1 < len(uses); i++ {
+		if uses[i] == nil || uses[i+1] == nil {
+			continue
+		}
+		gapStart := uses[i].EndV.Offset
+		gapEnd := uses[i+1].PosV.Offset
+		if gapStart < 0 || gapEnd > len(src) || gapStart >= gapEnd {
+			continue
+		}
+		for off := gapStart; off < gapEnd; off++ {
+			b := src[off]
+			if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+				continue
+			}
+			// Any other byte (comment start `/`, `#` annotation,
+			// stray text) means we can't safely rewrite.
+			return true
+		}
+	}
+	return false
+}
+
+// unusedUseSet returns the set of UseDecl nodes flagged L0003
+// ("unused import") by the analysis pipeline's lint pass. Uses the
+// cached result on doc.analysis so organizing imports costs one diag
+// scan, not another full lint walk.
 func unusedUseSet(doc *document) map[*ast.UseDecl]bool {
 	out := map[*ast.UseDecl]bool{}
 	a := doc.analysis
-	if a == nil || a.file == nil {
+	if a == nil || a.file == nil || a.lint == nil {
 		return out
 	}
 	// Build a by-offset index of every use decl so we can map lint
@@ -225,11 +265,7 @@ func unusedUseSet(doc *document) map[*ast.UseDecl]bool {
 			byOffset[u.PosV.Offset] = u
 		}
 	}
-	lr := lint.File(a.file, a.resolve, a.check)
-	if lr == nil {
-		return out
-	}
-	for _, d := range lr.Diags {
+	for _, d := range a.lint.Diags {
 		if d.Code != diag.CodeUnusedImport {
 			continue
 		}
@@ -244,9 +280,9 @@ func unusedUseSet(doc *document) map[*ast.UseDecl]bool {
 
 // ---- Fix All ----
 
-// fixAllAction collects every machine-applicable suggestion the lint
-// pass produced for this file and folds them into a single
-// WorkspaceEdit. The action is offered only when at least one
+// fixAllAction collects every machine-applicable suggestion the
+// analysis pipeline produced for this file and folds them into a
+// single WorkspaceEdit. The action is offered only when at least one
 // applicable fix exists so the lightbulb doesn't light up on clean
 // files.
 //
@@ -262,11 +298,13 @@ func fixAllAction(doc *document) *CodeAction {
 	if len(edits) == 0 {
 		return nil
 	}
-	// Offsets may overlap between competing suggestions for the same
-	// span (two renames of the same ident). applyEditsInReverse keeps
-	// only the first suggestion at each offset so we never produce
-	// overlapping edits, which clients reject outright.
-	edits = dedupeEdits(edits)
+	// Overlapping edits within one WorkspaceEdit are illegal per LSP
+	// 3.17; clients reject the bundle outright when any two ranges
+	// touch. Sort by start + drop any edit whose range intersects
+	// one we've already kept — earlier sources (parse, resolve,
+	// check) win over lint, which matches the "errors first" intent
+	// of fix-all.
+	edits = resolveOverlaps(edits)
 	return &CodeAction{
 		Title: "Fix all auto-fixable problems",
 		Kind:  CodeActionSourceFixAllOsty,
@@ -278,20 +316,16 @@ func fixAllAction(doc *document) *CodeAction {
 	}
 }
 
-// collectMachineApplicable harvests every diagnostic suggestion (from
-// parse, resolve, check, AND an on-demand lint pass) whose
-// MachineApplicable bit is set, converts each into a TextEdit, and
-// returns them in document order. Lint diagnostics are re-run here
-// because the LSP analysis cache currently skips the lint stage.
+// collectMachineApplicable harvests every diagnostic suggestion on
+// the cached analysis whose MachineApplicable bit is set, converts
+// each into a TextEdit, and returns them in the order they appeared.
+// The cache already contains parse + resolve + check + lint diags
+// (see analyzeSingleFile / analysisForFileInPackage), so this is a
+// single pass with no redundant lint work.
 func collectMachineApplicable(doc *document) []TextEdit {
 	a := doc.analysis
-	var sources []*diag.Diagnostic
-	sources = append(sources, a.diags...)
-	if lr := lint.File(a.file, a.resolve, a.check); lr != nil {
-		sources = append(sources, lr.Diags...)
-	}
 	var out []TextEdit
-	for _, d := range sources {
+	for _, d := range a.diags {
 		for _, sg := range d.Suggestions {
 			if !sg.MachineApplicable {
 				continue
@@ -311,31 +345,84 @@ func collectMachineApplicable(doc *document) []TextEdit {
 	return out
 }
 
-// dedupeEdits drops edits whose range duplicates an earlier entry's
-// range. LSP disallows overlapping edits within one WorkspaceEdit —
-// two suggestions for the same ident span would both try to rename
-// it, and the client would reject the bundle. We keep the first
-// suggestion encountered (diagnostics are ordered by severity, so
-// errors win over warnings).
-func dedupeEdits(in []TextEdit) []TextEdit {
+// resolveOverlaps sorts edits by start position (ties broken by end)
+// and drops any whose range intersects an edit already kept. Two
+// ranges overlap when [s1,e1) ∩ [s2,e2) is non-empty. A pure-insert
+// edit at position p (start == end) is treated as a point; two
+// inserts at the same point are considered duplicates so we keep
+// just the first.
+//
+// Input order encodes source priority: parse/resolve/check
+// suggestions come before lint, so when two fixes collide the
+// earlier-sourced (stronger) fix wins. After deduplication the
+// result is in document order, which LSP clients prefer even though
+// the spec doesn't strictly require it.
+func resolveOverlaps(in []TextEdit) []TextEdit {
 	if len(in) <= 1 {
 		return in
 	}
-	type key struct {
-		sLine, sChar, eLine, eChar uint32
+	// Remember original index so the stable-sort preserves source
+	// priority for equal-range edits.
+	type indexed struct {
+		e   TextEdit
+		idx int
 	}
-	seen := make(map[key]bool, len(in))
-	out := in[:0]
-	for _, e := range in {
-		k := key{
-			e.Range.Start.Line, e.Range.Start.Character,
-			e.Range.End.Line, e.Range.End.Character,
+	tagged := make([]indexed, len(in))
+	for i, e := range in {
+		tagged[i] = indexed{e: e, idx: i}
+	}
+	sort.SliceStable(tagged, func(i, j int) bool {
+		a, b := tagged[i].e.Range, tagged[j].e.Range
+		if a.Start.Line != b.Start.Line {
+			return a.Start.Line < b.Start.Line
 		}
-		if seen[k] {
-			continue
+		if a.Start.Character != b.Start.Character {
+			return a.Start.Character < b.Start.Character
 		}
-		seen[k] = true
-		out = append(out, e)
+		// Same start: the earlier-sourced edit wins the tie so the
+		// stable order puts it first.
+		return tagged[i].idx < tagged[j].idx
+	})
+	out := make([]TextEdit, 0, len(tagged))
+	var lastStart, lastEnd Position
+	var have bool
+	for _, t := range tagged {
+		start := t.e.Range.Start
+		end := t.e.Range.End
+		if have {
+			// Strict overlap: this edit begins before the previous
+			// edit ended. Drop it.
+			if posBefore(start, lastEnd) {
+				continue
+			}
+			// Edge-on case: start == lastEnd. This is a valid
+			// adjacency for replacements, but two inserts at the
+			// exact same point (start == end == lastStart ==
+			// lastEnd) would both rewrite "at the caret" and the
+			// client has no way to pick an order. Collapse to the
+			// first.
+			if posEqual(start, lastEnd) && posEqual(start, end) &&
+				posEqual(lastStart, lastEnd) {
+				continue
+			}
+		}
+		out = append(out, t.e)
+		lastStart = start
+		lastEnd = end
+		have = true
 	}
 	return out
+}
+
+// posBefore reports whether a is strictly before b.
+func posBefore(a, b Position) bool {
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	return a.Character < b.Character
+}
+
+// posEqual reports whether two LSP positions are identical.
+func posEqual(a, b Position) bool {
+	return a.Line == b.Line && a.Character == b.Character
 }

--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -1,0 +1,341 @@
+package lsp
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lint"
+)
+
+// LSP code-action kind strings (LSP 3.17 §codeActionKind). Only the
+// kinds the server emits are listed.
+const (
+	// Source-action kinds are surfaced in editors as bulk operations
+	// on the entire file (e.g. "Organize Imports", "Fix All"); they
+	// are not attached to a specific diagnostic.
+	CodeActionSource              = "source"
+	CodeActionSourceOrganizeImports = "source.organizeImports"
+	CodeActionSourceFixAll        = "source.fixAll"
+	CodeActionSourceFixAllOsty    = "source.fixAll.osty"
+)
+
+// wantsKind reports whether the client's `context.only` filter (if
+// any) admits the given action kind. An empty filter means "everything
+// is admissible". A filter entry is treated as a prefix match so that
+// a client asking for `"source"` gets every `source.*` subtype back —
+// this matches how LSP 3.17 defines `CodeActionKind` inheritance.
+func wantsKind(only []string, kind string) bool {
+	if len(only) == 0 {
+		return true
+	}
+	for _, k := range only {
+		if k == kind {
+			return true
+		}
+		// Prefix match (e.g. "source" matches "source.organizeImports").
+		if strings.HasPrefix(kind, k+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// organizeImportsAction builds a `source.organizeImports` action when
+// one would actually change the document. The action:
+//
+//   - Removes `use` declarations that are never referenced (modulo
+//     side-effect imports prefixed with `_`).
+//   - Drops duplicates whose effective alias + target path coincide
+//     — two `use foo` entries collapse to one.
+//   - Groups into: stdlib (`std.*`), external, Go FFI — matching
+//     `osty fmt`'s ordering rules — and sorts alphabetically within
+//     each group by raw path.
+//
+// FFI `use go "..." { ... }` blocks are treated as opaque: we still
+// remove them if unused but don't attempt to rewrite their bodies.
+//
+// Returns nil if no changes would be made so the action isn't offered
+// when the file is already clean.
+func organizeImportsAction(doc *document) *CodeAction {
+	a := doc.analysis
+	if a == nil || a.file == nil || len(a.file.Uses) == 0 {
+		return nil
+	}
+	uses := a.file.Uses
+	// Drop uses whose primary span overlaps a parser error — we don't
+	// trust their offsets enough to rewrite the file. A single bad line
+	// shouldn't void the whole organize operation; just skip that one.
+	unused := unusedUseSet(doc)
+
+	type keyed struct {
+		u     *ast.UseDecl
+		group int
+		key   string
+		text  string
+	}
+	kept := make([]keyed, 0, len(uses))
+	seen := make(map[string]bool, len(uses))
+	for _, u := range uses {
+		if u == nil {
+			continue
+		}
+		if unused[u] {
+			continue
+		}
+		text := useSourceText(doc.src, u)
+		if text == "" {
+			continue
+		}
+		group := useGroup(u)
+		key := useKey(u)
+		// Dedup by (group, key, alias) — two identical `use` lines
+		// collapse to one.
+		dedupKey := keyWithAlias(group, key, u.Alias)
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+		kept = append(kept, keyed{u: u, group: group, key: key, text: text})
+	}
+	sort.SliceStable(kept, func(i, j int) bool {
+		if kept[i].group != kept[j].group {
+			return kept[i].group < kept[j].group
+		}
+		if kept[i].key != kept[j].key {
+			return kept[i].key < kept[j].key
+		}
+		return kept[i].u.Alias < kept[j].u.Alias
+	})
+
+	// Build the replacement block. Separate groups with a blank line so
+	// the output matches what `osty fmt` would emit after the reorder.
+	var b strings.Builder
+	prevGroup := -1
+	for i, k := range kept {
+		if i > 0 && k.group != prevGroup {
+			b.WriteByte('\n')
+		}
+		b.WriteString(k.text)
+		b.WriteByte('\n')
+		prevGroup = k.group
+	}
+	newText := b.String()
+
+	// Replacement range covers the full `use` block: from the first
+	// use's start to just past the last use's terminating newline. We
+	// must NOT swallow a blank line that belongs to the subsequent
+	// decl, so we stop at the newline of the last use's line.
+	startOff := uses[0].PosV.Offset
+	endOff := endOfLineOffset(doc.src, uses[len(uses)-1].EndV.Offset)
+	oldText := string(doc.src[startOff:endOff])
+	if newText == oldText {
+		return nil
+	}
+
+	rng := doc.analysis.lines.rangeFromOffsets(startOff, endOff)
+	return &CodeAction{
+		Title: "Organize imports",
+		Kind:  CodeActionSourceOrganizeImports,
+		Edit: &WorkspaceEdit{
+			Changes: map[string][]TextEdit{
+				doc.uri: {{Range: rng, NewText: newText}},
+			},
+		},
+	}
+}
+
+// useGroup classifies a use decl into the canonical group ordering.
+// Kept in sync with format.useGroupOrder — duplicating instead of
+// importing to avoid pulling the formatter into the lsp package just
+// for a three-way switch.
+func useGroup(u *ast.UseDecl) int {
+	if u.IsGoFFI {
+		return 2
+	}
+	if len(u.Path) > 0 && u.Path[0] == "std" {
+		return 0
+	}
+	return 1
+}
+
+// useKey is the intra-group sort key.
+func useKey(u *ast.UseDecl) string {
+	if u.IsGoFFI {
+		return u.GoPath
+	}
+	if u.RawPath != "" {
+		return u.RawPath
+	}
+	return strings.Join(u.Path, ".")
+}
+
+// keyWithAlias combines the sort key with the alias so `use foo` and
+// `use foo as bar` don't dedupe into one entry.
+func keyWithAlias(group int, key, alias string) string {
+	return string(rune('0'+group)) + "|" + key + "|" + alias
+}
+
+// useSourceText extracts the exact source text of a single-line use
+// decl. Multi-line FFI blocks (whose body spans several lines) are
+// returned verbatim including the `{ ... }` block.
+func useSourceText(src []byte, u *ast.UseDecl) string {
+	start := u.PosV.Offset
+	end := u.EndV.Offset
+	if start < 0 || end > len(src) || start >= end {
+		return ""
+	}
+	return strings.TrimRight(string(src[start:end]), " \t\r\n")
+}
+
+// endOfLineOffset advances from `off` over any trailing whitespace
+// plus one line terminator, returning the offset of the first byte of
+// the next line (or len(src) if we hit EOF first).
+func endOfLineOffset(src []byte, off int) int {
+	for off < len(src) && (src[off] == ' ' || src[off] == '\t') {
+		off++
+	}
+	if off < len(src) && src[off] == '\r' {
+		off++
+	}
+	if off < len(src) && src[off] == '\n' {
+		off++
+	}
+	return off
+}
+
+// unusedUseSet runs the single-file lint pass and returns the set of
+// UseDecl nodes flagged L0003 ("unused import"). Reuses lint.File so
+// the organize action stays in lockstep with the standalone `osty
+// lint` CLI — if lint's unused-import logic evolves, the refactor
+// follows automatically.
+func unusedUseSet(doc *document) map[*ast.UseDecl]bool {
+	out := map[*ast.UseDecl]bool{}
+	a := doc.analysis
+	if a == nil || a.file == nil {
+		return out
+	}
+	// Build a by-offset index of every use decl so we can map lint
+	// diagnostics (which carry positions, not AST pointers) back to
+	// the node they concern.
+	byOffset := make(map[int]*ast.UseDecl, len(a.file.Uses))
+	for _, u := range a.file.Uses {
+		if u != nil {
+			byOffset[u.PosV.Offset] = u
+		}
+	}
+	lr := lint.File(a.file, a.resolve, a.check)
+	if lr == nil {
+		return out
+	}
+	for _, d := range lr.Diags {
+		if d.Code != diag.CodeUnusedImport {
+			continue
+		}
+		for _, sp := range d.Spans {
+			if u := byOffset[sp.Span.Start.Offset]; u != nil {
+				out[u] = true
+			}
+		}
+	}
+	return out
+}
+
+// ---- Fix All ----
+
+// fixAllAction collects every machine-applicable suggestion the lint
+// pass produced for this file and folds them into a single
+// WorkspaceEdit. The action is offered only when at least one
+// applicable fix exists so the lightbulb doesn't light up on clean
+// files.
+//
+// Resolver / checker diagnostics that carry suggestions are pulled
+// in as well; those already feed the per-diagnostic quick fixes, but
+// fix-all rolls them into one bulk edit for a single-click cleanup.
+func fixAllAction(doc *document) *CodeAction {
+	a := doc.analysis
+	if a == nil || a.file == nil {
+		return nil
+	}
+	edits := collectMachineApplicable(doc)
+	if len(edits) == 0 {
+		return nil
+	}
+	// Offsets may overlap between competing suggestions for the same
+	// span (two renames of the same ident). applyEditsInReverse keeps
+	// only the first suggestion at each offset so we never produce
+	// overlapping edits, which clients reject outright.
+	edits = dedupeEdits(edits)
+	return &CodeAction{
+		Title: "Fix all auto-fixable problems",
+		Kind:  CodeActionSourceFixAllOsty,
+		Edit: &WorkspaceEdit{
+			Changes: map[string][]TextEdit{
+				doc.uri: edits,
+			},
+		},
+	}
+}
+
+// collectMachineApplicable harvests every diagnostic suggestion (from
+// parse, resolve, check, AND an on-demand lint pass) whose
+// MachineApplicable bit is set, converts each into a TextEdit, and
+// returns them in document order. Lint diagnostics are re-run here
+// because the LSP analysis cache currently skips the lint stage.
+func collectMachineApplicable(doc *document) []TextEdit {
+	a := doc.analysis
+	var sources []*diag.Diagnostic
+	sources = append(sources, a.diags...)
+	if lr := lint.File(a.file, a.resolve, a.check); lr != nil {
+		sources = append(sources, lr.Diags...)
+	}
+	var out []TextEdit
+	for _, d := range sources {
+		for _, sg := range d.Suggestions {
+			if !sg.MachineApplicable {
+				continue
+			}
+			// Skip suggestions whose span is malformed (zero Start
+			// AND zero End with no insertion hint). These leak in
+			// when a diag was built without pinning a span; applying
+			// them would rewrite the top of the file.
+			if sg.Span.Start.Offset == 0 && sg.Span.End.Offset == 0 &&
+				sg.Span.Start.Line == 0 {
+				continue
+			}
+			rng := a.lines.ostyRange(sg.Span)
+			out = append(out, TextEdit{Range: rng, NewText: sg.Replacement})
+		}
+	}
+	return out
+}
+
+// dedupeEdits drops edits whose range duplicates an earlier entry's
+// range. LSP disallows overlapping edits within one WorkspaceEdit —
+// two suggestions for the same ident span would both try to rename
+// it, and the client would reject the bundle. We keep the first
+// suggestion encountered (diagnostics are ordered by severity, so
+// errors win over warnings).
+func dedupeEdits(in []TextEdit) []TextEdit {
+	if len(in) <= 1 {
+		return in
+	}
+	type key struct {
+		sLine, sChar, eLine, eChar uint32
+	}
+	seen := make(map[key]bool, len(in))
+	out := in[:0]
+	for _, e := range in {
+		k := key{
+			e.Range.Start.Line, e.Range.Start.Character,
+			e.Range.End.Line, e.Range.End.Character,
+		}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	return out
+}

--- a/internal/lsp/refactor_test.go
+++ b/internal/lsp/refactor_test.go
@@ -1,0 +1,70 @@
+package lsp
+
+import "testing"
+
+// TestResolveOverlapsDropsStrictOverlap verifies that an edit whose
+// range starts before a kept edit ended is dropped, while an edit
+// that starts exactly at the previous end is retained (adjacency is
+// legal per LSP 3.17).
+func TestResolveOverlapsDropsStrictOverlap(t *testing.T) {
+	// First edit: replace chars 0-10 on line 0.
+	// Second edit: replace chars 5-8 on line 0 — strict overlap, drop.
+	// Third edit: replace chars 10-15 on line 0 — touches the first
+	//             edit's end, keep.
+	in := []TextEdit{
+		{Range: mkRange(0, 0, 0, 10), NewText: "A"},
+		{Range: mkRange(0, 5, 0, 8), NewText: "B"},
+		{Range: mkRange(0, 10, 0, 15), NewText: "C"},
+	}
+	out := resolveOverlaps(in)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 surviving edits, got %d: %+v", len(out), out)
+	}
+	if out[0].NewText != "A" || out[1].NewText != "C" {
+		t.Errorf("wrong survivors: %+v", out)
+	}
+}
+
+// TestResolveOverlapsPrioritizesFirstSource verifies that when two
+// edits share a start point and one is a pure insert at the same
+// point, the first-inserted (stable-sort) wins. Source ordering
+// encodes severity priority in the real caller.
+func TestResolveOverlapsPrioritizesFirstSource(t *testing.T) {
+	// Two pure inserts at the exact same point — only the first
+	// survives.
+	in := []TextEdit{
+		{Range: mkRange(2, 4, 2, 4), NewText: "first"},
+		{Range: mkRange(2, 4, 2, 4), NewText: "second"},
+	}
+	out := resolveOverlaps(in)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 edit, got %d: %+v", len(out), out)
+	}
+	if out[0].NewText != "first" {
+		t.Errorf("expected 'first' to win; got %q", out[0].NewText)
+	}
+}
+
+// TestResolveOverlapsKeepsDisjointReorder confirms that two edits on
+// the same line at distinct ranges are both kept, and that the output
+// is sorted by start position even when the input was reverse-order.
+func TestResolveOverlapsKeepsDisjointReorder(t *testing.T) {
+	in := []TextEdit{
+		{Range: mkRange(0, 20, 0, 25), NewText: "LATE"},
+		{Range: mkRange(0, 0, 0, 5), NewText: "EARLY"},
+	}
+	out := resolveOverlaps(in)
+	if len(out) != 2 {
+		t.Fatalf("expected both edits, got %+v", out)
+	}
+	if out[0].NewText != "EARLY" || out[1].NewText != "LATE" {
+		t.Errorf("expected sort by start; got %+v", out)
+	}
+}
+
+func mkRange(sLine, sChar, eLine, eChar uint32) Range {
+	return Range{
+		Start: Position{Line: sLine, Character: sChar},
+		End:   Position{Line: eLine, Character: eChar},
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 )
@@ -271,7 +272,12 @@ type docAnalysis struct {
 	file    *ast.File
 	resolve *resolve.Result
 	check   *check.Result
-	diags   []*diag.Diagnostic
+	// lint is the lint pass output (may be nil if the pipeline
+	// skipped linting, e.g. a future mode flag). Downstream handlers
+	// use it for the source.organizeImports / source.fixAll actions
+	// so they don't re-run lint.File on every request.
+	lint  *lint.Result
+	diags []*diag.Diagnostic
 	// packages is every package loaded as part of this analysis.
 	// Empty for scratch/single-file buffers; one entry for package
 	// mode; one per package for workspace mode. Cross-file handlers
@@ -420,7 +426,8 @@ func (s *Server) analyzePackage(pkgDir, path string, src []byte) *docAnalysis {
 	substituteFileSource(pkg, path, src)
 	pr := resolve.ResolvePackage(pkg, s.prelude)
 	chk := check.Package(pkg, pr)
-	a := analysisForFileInPackage(pkg, pr, chk, path, src)
+	lr := lint.Package(pkg, pr, chk)
+	a := analysisForFileInPackage(pkg, pr, chk, lr, path, src)
 	if a != nil {
 		a.packages = []*resolve.Package{pkg}
 	}
@@ -459,10 +466,17 @@ func (s *Server) analyzeWorkspace(root, path string, src []byte) *docAnalysis {
 	for pkgPath, pkg := range ws.Packages {
 		for _, pf := range pkg.Files {
 			if pf.Path == path {
+				// Run lint over this package only — the owner of the
+				// opened file. Sibling packages aren't relevant for
+				// the diagnostics we publish to the editor, and
+				// linting every package in the workspace on every
+				// keystroke is too expensive.
+				lr := lint.Package(pkg, resolved[pkgPath], checks[pkgPath])
 				a := analysisForFileInPackage(
 					pkg,
 					resolved[pkgPath],
 					checks[pkgPath],
+					lr,
 					path, src,
 				)
 				if a != nil {
@@ -510,6 +524,7 @@ func analysisForFileInPackage(
 	pkg *resolve.Package,
 	pr *resolve.PackageResult,
 	chk *check.Result,
+	lr *lint.Result,
 	path string,
 	src []byte,
 ) *docAnalysis {
@@ -528,26 +543,28 @@ func analysisForFileInPackage(
 		TypeRefs:  pf.TypeRefs,
 		FileScope: pf.FileScope,
 	}
-	all := collectDiagsForFile(pr, chk, pf)
+	all := collectDiagsForFile(pr, chk, lr, pf)
 	return &docAnalysis{
 		lines:      newLineIndex(src),
 		file:       pf.File,
 		resolve:    fileRes,
 		check:      chk,
+		lint:       lr,
 		diags:      all,
 		identIndex: buildIdentIndex(fileRes),
 	}
 }
 
-// collectDiagsForFile picks out the parser, resolver, and checker
-// diagnostics that belong to one file. Parser diagnostics are already
-// file-attributed via PackageFile.ParseDiags; resolver and checker
-// diagnostics are filtered by byte-offset containment — positions
-// from different files have disjoint offset ranges because each file
-// was lexed against its own source buffer.
+// collectDiagsForFile picks out the parser, resolver, checker, and
+// lint diagnostics that belong to one file. Parser diagnostics are
+// already file-attributed via PackageFile.ParseDiags; the other three
+// stages are filtered by byte-offset containment — positions from
+// different files have disjoint offset ranges because each file was
+// lexed against its own source buffer.
 func collectDiagsForFile(
 	pr *resolve.PackageResult,
 	chk *check.Result,
+	lr *lint.Result,
 	pf *resolve.PackageFile,
 ) []*diag.Diagnostic {
 	var out []*diag.Diagnostic
@@ -561,6 +578,13 @@ func collectDiagsForFile(
 	}
 	if chk != nil {
 		for _, d := range chk.Diags {
+			if diagBelongsToFile(d, pf) {
+				out = append(out, d)
+			}
+		}
+	}
+	if lr != nil {
+		for _, d := range lr.Diags {
 			if diagBelongsToFile(d, pf) {
 				out = append(out, d)
 			}
@@ -592,15 +616,19 @@ func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
 	file, parseDiags := parser.ParseDiagnostics(src)
 	res := resolve.File(file, s.prelude)
 	chk := check.File(file, res)
-	all := make([]*diag.Diagnostic, 0, len(parseDiags)+len(res.Diags)+len(chk.Diags))
+	lr := lint.File(file, res, chk)
+	all := make([]*diag.Diagnostic, 0,
+		len(parseDiags)+len(res.Diags)+len(chk.Diags)+len(lr.Diags))
 	all = append(all, parseDiags...)
 	all = append(all, res.Diags...)
 	all = append(all, chk.Diags...)
+	all = append(all, lr.Diags...)
 	return &docAnalysis{
 		lines:      newLineIndex(src),
 		file:       file,
 		resolve:    res,
 		check:      chk,
+		lint:       lr,
 		diags:      all,
 		identIndex: buildIdentIndex(res),
 	}


### PR DESCRIPTION
## Summary

Starts building out the "stronger refactoring tools" direction in the LSP. Extends the existing code-action handler (which today only emits per-diagnostic quick fixes) with two file-wide source actions:

- **`source.organizeImports`** – sorts `use` declarations into the canonical group order (std / external / Go FFI), removes duplicates, and drops imports flagged unused by the lint pass (L0003). No-ops on already-clean files.
- **`source.fixAll[.osty]`** – collects every `MachineApplicable` suggestion from parse / resolve / check / lint and folds them into one `WorkspaceEdit`, deduping overlapping ranges so LSP accepts the bundle.

`ServerCapabilities` now advertise both kinds via `CodeActionOptions` so editors that gate source actions on the capability list (VS Code's `editor.codeActionsOnSave` in particular) can invoke them.

## Why this shape

Osty's grammar is narrow and rule-rich, and the LSP already has full resolver/checker/lint infrastructure — so bulk refactors mostly reduce to "walk the structured suggestions the compiler already produces". Both actions reuse existing machinery (`lint.File`, `diag.Suggestion{MachineApplicable}`) rather than introducing a parallel refactoring engine, which keeps behavior in lockstep with the CLI's `osty lint`/auto-fix paths.

Follow-ups from the roadmap not tackled here: extract function / extract variable, inline symbol, dedicated dead-code cleanup action (currently subsumed by `fixAll`). Those need deeper AST-walking helpers that don't exist yet and are easier to land incrementally on top of this.

## Test plan

- [x] `go test ./internal/lsp/...` — new tests:
  - `TestOrganizeImportsDropsUnused` — removes unused `use` in a two-package workspace
  - `TestOrganizeImportsSortsAlphabetically` — asserts alpha < beta < zeta ordering in the rewrite
  - `TestOrganizeImportsNoOpOnCleanFile` — no lightbulb on clean files
  - `TestFixAllBundlesSuggestions` — two unused-binding fixes arrive as one `WorkspaceEdit`
  - `TestCodeActionCapabilityAdvertisesKinds` — `initialize` response lists the new kinds
- [x] `go build ./...` clean
- [x] Existing `TestCodeActionRenameUndefined` still passes — quick fixes unchanged

Note: `internal/format/TestGolden/chains` is failing on `main` unrelated to this change.

https://claude.ai/code/session_01WBh4qMMsu36uEQDEYS7ENc