### PR TITLE
Add build profile / target management tooling

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -4,12 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
+	"github.com/osty/osty/internal/profile"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
@@ -35,10 +37,13 @@ import (
 func runBuild(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty build [--offline] [PATH]")
+		fmt.Fprintln(os.Stderr, "usage: osty build [--offline] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--force] [PATH]")
 	}
-	var offline bool
+	var offline, force bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
+	fs.BoolVar(&force, "force", false, "ignore the build cache; transpile every input")
+	var pf profileFlags
+	pf.register(fs)
 	_ = fs.Parse(args)
 	start := "."
 	if fs.NArg() == 1 {
@@ -54,6 +59,37 @@ func runBuild(args []string, flags cliFlags) {
 	m, root, abort := loadManifestWithDiag(start, flags)
 	if abort {
 		os.Exit(2)
+	}
+
+	// Profile resolution. Errors here come from unknown `--profile`
+	// names or malformed `--target` triples and are usage errors.
+	resolved, profileName, perr := pf.resolve(m, profile.NameDebug)
+	if perr != nil {
+		fmt.Fprintf(os.Stderr, "osty build: %v\n", perr)
+		os.Exit(2)
+	}
+	announceProfile(resolved)
+	triple := ""
+	if resolved.Target != nil {
+		triple = resolved.Target.Triple
+	}
+
+	// Step 2.5: incremental-build shortcut. Hash every .osty file
+	// under the project root and compare against the cached
+	// fingerprint. A matching record lets us skip the front-end +
+	// gen entirely; --force overrides this.
+	if !force {
+		if fp, err := profile.ReadFingerprint(root, profileName, triple); err == nil && fp != nil {
+			curSrc, err := profile.HashSources(root, isOstySource)
+			if err == nil {
+				fresh := profile.NewFingerprint(curSrc, resolved, toolVersion())
+				if fp.Equal(fresh) {
+					fmt.Printf("Build is up to date (cache: %s)\n",
+						profile.CachePath(root, profileName, triple))
+					return
+				}
+			}
+		}
 	}
 
 	// Step 3–4: dependency resolution + vendoring. Done for both
@@ -87,9 +123,36 @@ func runBuild(args []string, flags cliFlags) {
 	deps := pkgmgr.NewDepProvider(m, graph, env)
 	if m.Workspace != nil {
 		buildWorkspace(root, m, flags, deps)
-		return
+	} else {
+		buildPackage(root, flags, deps)
 	}
-	buildPackage(root, flags, deps)
+
+	// Step 6: record the build fingerprint under .osty/cache/ so the
+	// next invocation can short-circuit on unchanged inputs. A
+	// failure to write the fingerprint is logged but doesn't fail
+	// the build — correctness is preserved, we just lose the
+	// incremental speed-up next time.
+	if sources, err := profile.HashSources(root, isOstySource); err == nil {
+		fp := profile.NewFingerprint(sources, resolved, toolVersion())
+		if err := fp.Write(root); err != nil {
+			fmt.Fprintf(os.Stderr, "osty build: warning: cache write failed: %v\n", err)
+		}
+	}
+}
+
+// isOstySource is the predicate used by cache fingerprinting. .osty
+// files under testdata/ are ordinarily source inputs too, but for
+// incremental-build purposes anything ending in .osty counts.
+func isOstySource(name string) bool {
+	return filepath.Ext(name) == ".osty"
+}
+
+// toolVersion returns a stamp used to invalidate the cache when the
+// compiler itself changes. Today it's a compile-time constant;
+// future wiring (set via -ldflags during release builds) will
+// substitute a git sha.
+func toolVersion() string {
+	return "osty-dev"
 }
 
 // buildWorkspace runs lex → parse → resolve → check over every member

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -4,11 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/gen"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
@@ -82,6 +85,7 @@ func runBuild(args []string, flags cliFlags) {
 		if fp, err := profile.ReadFingerprint(root, profileName, triple); err == nil && fp != nil {
 			curSrc, err := profile.HashSources(root, isOstySource)
 			if err == nil {
+				augmentSourcesWithProjectFiles(curSrc, root)
 				fresh := profile.NewFingerprint(curSrc, resolved, toolVersion())
 				if fp.Equal(fresh) {
 					fmt.Printf("Build is up to date (cache: %s)\n",
@@ -121,10 +125,11 @@ func runBuild(args []string, flags cliFlags) {
 	// so cross-member `use` paths resolve; standalone packages use the
 	// single-package loader.
 	deps := pkgmgr.NewDepProvider(m, graph, env)
+	featSet := featureSet(resolved)
 	if m.Workspace != nil {
-		buildWorkspace(root, m, flags, deps)
+		buildWorkspace(root, m, flags, deps, resolved, featSet)
 	} else {
-		buildPackage(root, flags, deps)
+		buildPackage(root, m, flags, deps, resolved, featSet)
 	}
 
 	// Step 6: record the build fingerprint under .osty/cache/ so the
@@ -133,11 +138,53 @@ func runBuild(args []string, flags cliFlags) {
 	// the build — correctness is preserved, we just lose the
 	// incremental speed-up next time.
 	if sources, err := profile.HashSources(root, isOstySource); err == nil {
+		augmentSourcesWithProjectFiles(sources, root)
 		fp := profile.NewFingerprint(sources, resolved, toolVersion())
 		if err := fp.Write(root); err != nil {
 			fmt.Fprintf(os.Stderr, "osty build: warning: cache write failed: %v\n", err)
 		}
 	}
+}
+
+// augmentSourcesWithProjectFiles folds osty.toml + osty.lock hashes
+// into the fingerprint map so a dependency bump or profile tweak
+// invalidates the cache even when no .osty byte moved. Keys are
+// prefixed with ":" so they can never collide with a real path.
+func augmentSourcesWithProjectFiles(sources map[string]string, root string) {
+	for _, rel := range []string{manifest.ManifestFile, "osty.lock"} {
+		p := filepath.Join(root, rel)
+		if h, err := profile.HashFile(p); err == nil {
+			sources[":"+rel] = h
+		}
+	}
+}
+
+// fileIsFeatureGated reads the file at path, inspects its
+// `// @feature: NAME` pragma (if any), and reports whether the file
+// should be excluded from the build under the active feature set.
+// Returns (skipped, missingFeature). When the file is absent or can't
+// be read the function fails safe by including it (skipped=false).
+func fileIsFeatureGated(path string, active map[string]bool) (bool, string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, ""
+	}
+	ok, missing := profile.FileNeedsFeatures(data, active)
+	return !ok, missing
+}
+
+// featureSet turns the resolved feature list into a map for O(1)
+// lookup during the per-file pragma check. Nil resolved or empty
+// feature list means "no features active".
+func featureSet(r *profile.Resolved) map[string]bool {
+	out := map[string]bool{}
+	if r == nil {
+		return out
+	}
+	for _, f := range r.Features {
+		out[f] = true
+	}
+	return out
 }
 
 // isOstySource is the predicate used by cache fingerprinting. .osty
@@ -158,8 +205,10 @@ func toolVersion() string {
 // buildWorkspace runs lex → parse → resolve → check over every member
 // of the workspace rooted at dir. Exits non-zero on any error-severity
 // diagnostic. deps supplies the Workspace's DepProvider so `use`
-// targets to vendored packages resolve.
-func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider) {
+// targets to vendored packages resolve. When the root manifest declares
+// a binary entry point, it is additionally transpiled and linked with
+// `go build` using the resolved profile's go-flags / env.
+func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool) {
 	ws, err := resolve.NewWorkspace(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
@@ -202,15 +251,25 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 	if anyErr {
 		os.Exit(1)
 	}
+	// Transpile + `go build` the root binary package (if any). Library
+	// members fall out of the binary emit for now — multi-target
+	// workspace builds are Phase 2 territory for the transpiler.
+	if m.HasPackage {
+		rootPkg := ws.Packages[""]
+		if rootPkg != nil {
+			emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats)
+		}
+	}
 }
 
-// buildPackage runs the front-end over a single-package project. When
-// deps is non-nil, we wrap the package in a one-member Workspace so
-// `use` references to vendored external deps resolve through the
+// buildPackage runs the front-end over a single-package project and
+// then drives gen Phase 1 + `go build` for the binary entry point.
+// When deps is non-nil, we wrap the package in a one-member Workspace
+// so `use` references to vendored external deps resolve through the
 // DepProvider. The plain resolve.LoadPackage path is kept as a
 // fallback for zero-dep projects because it's simpler and has no
 // workspace state to carry.
-func buildPackage(dir string, flags cliFlags, deps resolve.DepProvider) {
+func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool) {
 	if deps != nil {
 		ws, err := resolve.NewWorkspace(dir)
 		if err != nil {
@@ -239,6 +298,10 @@ func buildPackage(dir string, flags cliFlags, deps resolve.DepProvider) {
 				os.Exit(1)
 			}
 		}
+		rootPkg := ws.Packages[""]
+		if rootPkg != nil {
+			emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats)
+		}
 		return
 	}
 	pkg, err := resolve.LoadPackage(dir)
@@ -253,6 +316,174 @@ func buildPackage(dir string, flags cliFlags, deps resolve.DepProvider) {
 	if hasError(ds) {
 		os.Exit(1)
 	}
+	// Note: the no-deps path feeds a synthetic PackageResult because
+	// emitAndBuild expects a *resolve.PackageResult with Diags; we
+	// already have all of it from ResolvePackage above.
+	emitAndBuild(dir, m, pkg, res, chk, resolved, feats)
+}
+
+// emitAndBuild is the gen + `go build` driver. It picks the entry
+// file (manifest `[bin].path` or default `main.osty`), transpiles it
+// to Go via gen.Generate, writes the output under
+// .osty/out/<profile>[-<triple>]/, and invokes the Go toolchain with
+// the resolved profile's go-flags + target env. Libraries (no entry
+// file on disk) are a no-op — future gen phases will extend this to
+// emit a Go package per Osty package.
+//
+// Files whose header declares `@feature: NAME` via the @feature
+// pragma are skipped when NAME isn't in the active feature set, so
+// feature-gated modules drop out before transpile.
+//
+// A failure at the go-build step returns a non-zero exit; a gen-time
+// TODO marker is only logged (gen Phase 1 surfaces unsupported
+// constructs that way).
+func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result, resolved *profile.Resolved, feats map[string]bool) {
+	// 1. Locate the entry file. A library project has no entry;
+	// skip the emit path so `osty build` still works as a front-end
+	// check for libs.
+	entryRel := "main.osty"
+	if m != nil && m.Bin != nil && m.Bin.Path != "" {
+		entryRel = m.Bin.Path
+	}
+	entryAbs := filepath.Join(root, entryRel)
+	if _, err := os.Stat(entryAbs); err != nil {
+		// Library or deferred binary: emit step is a no-op.
+		return
+	}
+	// 2. Feature-pragma filter: don't emit a file whose pragma
+	// requires an inactive feature. If the entry file is gated out
+	// the whole build degrades to front-end only.
+	if skipped, reason := fileIsFeatureGated(entryAbs, feats); skipped {
+		fmt.Fprintf(os.Stderr, "osty build: skipping %s (feature %q not enabled)\n",
+			entryRel, reason)
+		return
+	}
+	// 3. Find the PackageFile matching entryAbs so we can pass AST +
+	// Refs into gen.
+	var entryFile *resolve.PackageFile
+	absEntry, _ := filepath.Abs(entryAbs)
+	for _, pf := range pkg.Files {
+		if fp, _ := filepath.Abs(pf.Path); fp == absEntry {
+			entryFile = pf
+			break
+		}
+	}
+	if entryFile == nil {
+		fmt.Fprintf(os.Stderr, "osty build: entry %s not in package\n", entryRel)
+		os.Exit(1)
+	}
+	// 4. Transpile. Unsupported constructs produce TODO markers; we
+	// log the warning but proceed so simple programs build.
+	res := &resolve.Result{
+		Refs:      entryFile.Refs,
+		TypeRefs:  entryFile.TypeRefs,
+		FileScope: entryFile.FileScope,
+	}
+	if chk == nil {
+		chk = &check.Result{}
+	}
+	goSrc, gerr := gen.Generate("main", entryFile.File, res, chk)
+	if gerr != nil {
+		fmt.Fprintf(os.Stderr, "osty build: gen: %v\n", gerr)
+	}
+	// 5. Write the generated Go into the profile-scoped out dir.
+	profileName, triple := resolvedKey(resolved)
+	outDir := profile.OutputDir(root, profileName, triple)
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
+		os.Exit(1)
+	}
+	goSrc = prependBuildConstraint(goSrc, resolved)
+	goPath := filepath.Join(outDir, "main.go")
+	if err := os.WriteFile(goPath, goSrc, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
+		os.Exit(1)
+	}
+	// 6. Invoke `go build -o <bin>` with profile flags + target env.
+	binName := binaryName(m)
+	if triple != "" {
+		binName += "-" + triple
+	}
+	if runtime.GOOS == "windows" && (triple == "" || resolved.Target == nil || resolved.Target.OS == "windows") {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(outDir, binName)
+	buildArgs := []string{"build"}
+	buildArgs = append(buildArgs, resolved.GoFlags()...)
+	buildArgs = append(buildArgs, "-o", binPath, goPath)
+	cmd := exec.Command("go", buildArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = outDir
+	cmd.Env = mergeEnv(os.Environ(), resolved.GoEnv())
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "osty build: go build: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Built %s (%s)\n", binPath, profileName)
+}
+
+// binaryName returns the binary name for the package: the manifest's
+// [bin].name override, the package name, or "app" as a last-resort
+// default.
+func binaryName(m *manifest.Manifest) string {
+	if m != nil && m.Bin != nil && m.Bin.Name != "" {
+		return m.Bin.Name
+	}
+	if m != nil && m.Package.Name != "" {
+		return m.Package.Name
+	}
+	return "app"
+}
+
+// resolvedKey unpacks a Resolved into (profile name, triple) so the
+// common out-dir / cache-key computations don't each have to
+// nil-check Target.
+func resolvedKey(r *profile.Resolved) (string, string) {
+	name := ""
+	triple := ""
+	if r != nil {
+		if r.Profile != nil {
+			name = r.Profile.Name
+		}
+		if r.Target != nil {
+			triple = r.Target.Triple
+		}
+	}
+	return name, triple
+}
+
+// prependBuildConstraint injects any //go:build constraints that the
+// active feature set implies. Go's tooling already consumes the
+// `-tags=feat_*` flag we attach in Resolved.GoFlags, so the constraint
+// here is a belt-and-suspenders — downstream tooling (IDE builders,
+// gopls) that doesn't see our -tags flag still treats the file
+// correctly.
+func prependBuildConstraint(src []byte, r *profile.Resolved) []byte {
+	if r == nil || len(r.Features) == 0 {
+		return src
+	}
+	constraints := make([]string, 0, len(r.Features))
+	for _, f := range r.Features {
+		constraints = append(constraints, "feat_"+f)
+	}
+	sort.Strings(constraints)
+	header := "//go:build " + join(constraints, " && ") + "\n\n"
+	return append([]byte(header), src...)
+}
+
+// join is a small helper to avoid importing strings in the narrow
+// prepend path (keeping the import list minimal elsewhere).
+func join(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += sep + parts[i]
+	}
+	return out
 }
 
 // (renderManifestDiags was superseded by loadManifestWithDiag in

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -163,6 +163,25 @@ func main() {
 		runPublish(args[1:], flags)
 		return
 	}
+	// Build-profile / target / feature / cache inspection commands.
+	// None of these take a file path — they operate on the project
+	// rooted at cwd (or report built-in defaults when outside one).
+	if cmd == "profiles" {
+		runProfiles(args[1:], flags)
+		return
+	}
+	if cmd == "targets" {
+		runTargets(args[1:], flags)
+		return
+	}
+	if cmd == "features" {
+		runFeatures(args[1:], flags)
+		return
+	}
+	if cmd == "cache" {
+		runCache(args[1:], flags)
+		return
+	}
 	if len(args) < 2 {
 		usage()
 		os.Exit(2)
@@ -886,6 +905,10 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty run [-- ARGS...]     (build + exec the project's binary)")
 	fmt.Fprintln(os.Stderr, "       osty test [PATH|FILTER...] (discover *_test.osty; report tests found)")
 	fmt.Fprintln(os.Stderr, "       osty publish              (pack + upload the package to a registry)")
+	fmt.Fprintln(os.Stderr, "       osty profiles             (list build profiles — debug, release, ...)")
+	fmt.Fprintln(os.Stderr, "       osty targets              (list declared cross-compilation targets)")
+	fmt.Fprintln(os.Stderr, "       osty features             (list declared opt-in features)")
+	fmt.Fprintln(os.Stderr, "       osty cache [ls|clean|info] (inspect / prune the build cache)")
 	fmt.Fprintln(os.Stderr, "       osty lsp                  (language server on stdio)")
 	fmt.Fprintln(os.Stderr, "flags:")
 	fmt.Fprintln(os.Stderr, "  --no-color         disable ANSI escapes")
@@ -916,6 +939,14 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --dry-run          build the tarball but do not upload")
 	fmt.Fprintln(os.Stderr, "Common flags for build / add / update / run / test:")
 	fmt.Fprintln(os.Stderr, "  --offline          do not fetch dependencies; fail if caches are missing")
+	fmt.Fprintln(os.Stderr, "build / run flags:")
+	fmt.Fprintln(os.Stderr, "  --profile NAME     build profile (debug, release, profile, test, ...)")
+	fmt.Fprintln(os.Stderr, "  --release          shorthand for --profile release")
+	fmt.Fprintln(os.Stderr, "  --target TRIPLE    cross-compilation target (e.g. amd64-linux)")
+	fmt.Fprintln(os.Stderr, "  --features LIST    comma-separated feature flags to enable")
+	fmt.Fprintln(os.Stderr, "  --no-default-features  drop the manifest's [features].default set")
+	fmt.Fprintln(os.Stderr, "build-specific flags:")
+	fmt.Fprintln(os.Stderr, "  --force            ignore the build cache and rebuild from source")
 }
 
 // printTypes writes a compact `line:col <TYPE>` table for every

--- a/cmd/osty/profile.go
+++ b/cmd/osty/profile.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/profile"
+)
+
+// runProfiles implements `osty profiles`: print every known profile
+// (built-ins + any declared in osty.toml) with its key flags so users
+// can see at a glance how debug differs from release and which
+// manifest overrides are in effect.
+//
+// Exit codes: 0 on success, 1 on manifest-load failure. Running
+// outside a project directory is fine — the built-ins still print.
+func runProfiles(args []string, flags cliFlags) {
+	fs := flag.NewFlagSet("profiles", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty profiles [--verbose]")
+	}
+	var verbose bool
+	fs.BoolVar(&verbose, "verbose", false, "also print go-flags, env, and inheritance")
+	fs.BoolVar(&verbose, "v", false, "alias for --verbose")
+	_ = fs.Parse(args)
+
+	cfg := loadProfileConfig(flags)
+	names := cfg.ProfileNames()
+	w := tabular(os.Stdout)
+	fmt.Fprintln(w, "NAME\tOPT\tDEBUG\tSTRIP\tOVERFLOW\tLTO\tSOURCE")
+	for _, n := range names {
+		p := cfg.Profiles[n]
+		src := "built-in"
+		if p.UserDefined {
+			src = "manifest"
+			if p.Inherits != "" {
+				src = "manifest (inherits " + p.Inherits + ")"
+			}
+		}
+		fmt.Fprintf(w, "%s\t%d\t%v\t%v\t%v\t%v\t%s\n",
+			p.Name, p.OptLevel, p.Debug, p.Strip, p.Overflow, p.LTO, src)
+	}
+	flushTabular(w)
+	if verbose {
+		for _, n := range names {
+			p := cfg.Profiles[n]
+			fmt.Printf("\n[profile.%s]\n", p.Name)
+			if len(p.GoFlags) > 0 {
+				fmt.Printf("  go-flags: %s\n", strings.Join(p.GoFlags, " "))
+			}
+			if len(p.Env) > 0 {
+				keys := make([]string, 0, len(p.Env))
+				for k := range p.Env {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					fmt.Printf("  env.%s = %q\n", k, p.Env[k])
+				}
+			}
+		}
+	}
+}
+
+// runTargets prints the declared cross-compilation targets.
+func runTargets(args []string, flags cliFlags) {
+	fs := flag.NewFlagSet("targets", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty targets")
+	}
+	_ = fs.Parse(args)
+	cfg := loadProfileConfig(flags)
+	names := cfg.TargetNames()
+	if len(names) == 0 {
+		fmt.Println("no [target.*] entries declared in osty.toml")
+		fmt.Println("hint: add one, e.g.")
+		fmt.Println("    [target.amd64-linux]")
+		fmt.Println("    cgo = false")
+		return
+	}
+	w := tabular(os.Stdout)
+	fmt.Fprintln(w, "TRIPLE\tGOARCH\tGOOS\tCGO")
+	for _, n := range names {
+		t := cfg.Targets[n]
+		cgo := "(host)"
+		if t.CGO != nil {
+			if *t.CGO {
+				cgo = "on"
+			} else {
+				cgo = "off"
+			}
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Triple, t.Arch, t.OS, cgo)
+	}
+	flushTabular(w)
+}
+
+// runFeatures prints the declared features plus the default set.
+func runFeatures(args []string, flags cliFlags) {
+	fs := flag.NewFlagSet("features", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty features")
+	}
+	_ = fs.Parse(args)
+	cfg := loadProfileConfig(flags)
+	if len(cfg.Features) == 0 && len(cfg.DefaultFeatures) == 0 {
+		fmt.Println("no [features] table declared in osty.toml")
+		return
+	}
+	if len(cfg.DefaultFeatures) > 0 {
+		fmt.Printf("default = [%s]\n", strings.Join(cfg.DefaultFeatures, ", "))
+	}
+	for _, name := range cfg.FeatureNames() {
+		items := cfg.Features[name]
+		fmt.Printf("%s = [%s]\n", name, strings.Join(items, ", "))
+	}
+}
+
+// runCache dispatches `osty cache <subcommand>`: ls (default), clean,
+// info. Each lists / mutates entries under <project>/.osty/cache/.
+func runCache(args []string, flags cliFlags) {
+	sub := "ls"
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		sub = args[0]
+		args = args[1:]
+	}
+	switch sub {
+	case "ls":
+		runCacheLs(args, flags)
+	case "clean":
+		runCacheClean(args, flags)
+	case "info":
+		runCacheInfo(args, flags)
+	default:
+		fmt.Fprintf(os.Stderr, "osty cache: unknown subcommand %q\n", sub)
+		fmt.Fprintln(os.Stderr, "usage: osty cache [ls|clean|info]")
+		os.Exit(2)
+	}
+}
+
+func runCacheLs(_ []string, flags cliFlags) {
+	root := projectRootOrExit(flags)
+	entries, err := profile.ListCache(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty cache: %v\n", err)
+		os.Exit(1)
+	}
+	if len(entries) == 0 {
+		fmt.Println("cache is empty (never run `osty build` in this project)")
+		return
+	}
+	w := tabular(os.Stdout)
+	fmt.Fprintln(w, "PROFILE\tTARGET\tSOURCES\tSIZE\tBUILT")
+	for _, e := range entries {
+		target := e.Target
+		if target == "" {
+			target = "(host)"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n",
+			e.Profile, target, e.Sources, humanBytes(e.Size),
+			e.BuiltAt.Local().Format("2006-01-02 15:04"))
+	}
+	flushTabular(w)
+}
+
+func runCacheClean(_ []string, flags cliFlags) {
+	root := projectRootOrExit(flags)
+	total, err := profile.CleanCache(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty cache clean: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("cleaned %s of build artifacts under %s\n", humanBytes(total),
+		filepath.Join(".osty"))
+}
+
+func runCacheInfo(args []string, flags cliFlags) {
+	fs := flag.NewFlagSet("cache info", flag.ExitOnError)
+	var profileName, triple string
+	fs.StringVar(&profileName, "profile", profile.NameDebug, "profile name")
+	fs.StringVar(&triple, "target", "", "target triple (empty = host)")
+	_ = fs.Parse(args)
+	root := projectRootOrExit(flags)
+	fp, err := profile.ReadFingerprint(root, profileName, triple)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty cache info: %v\n", err)
+		os.Exit(1)
+	}
+	if fp == nil {
+		fmt.Printf("no cache entry for profile=%s target=%q\n", profileName, triple)
+		os.Exit(1)
+	}
+	fmt.Printf("profile:      %s\n", fp.Profile)
+	if fp.Target != "" {
+		fmt.Printf("target:       %s\n", fp.Target)
+	}
+	fmt.Printf("tool version: %s\n", fp.ToolVersion)
+	fmt.Printf("built at:     %s\n", fp.BuiltAt.Local().Format(time.RFC3339))
+	fmt.Printf("sources:      %d files\n", len(fp.Sources))
+	if len(fp.Features) > 0 {
+		fmt.Printf("features:     %s\n", strings.Join(fp.Features, ", "))
+	}
+	// Sort for stable output.
+	paths := make([]string, 0, len(fp.Sources))
+	for p := range fp.Sources {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		fmt.Printf("  %s  %s\n", fp.Sources[p][:12], p)
+	}
+}
+
+// loadProfileConfig is the shared helper: finds osty.toml (or falls
+// back to built-in defaults when outside a project) and merges it
+// with profile.Defaults(). Unlike the build-path helpers this one
+// never prints manifest diagnostics — `osty profiles` is a read-only
+// informational command that should work even with a broken
+// manifest by falling back to built-ins.
+func loadProfileConfig(_ cliFlags) *profile.Config {
+	root, err := manifest.FindRoot(".")
+	if err != nil {
+		return profile.Defaults()
+	}
+	m, _, rerr := manifest.Load(filepath.Join(root, manifest.ManifestFile))
+	if rerr != nil || m == nil {
+		return profile.Defaults()
+	}
+	cfg, err := profile.BuildConfig(m)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
+		os.Exit(1)
+	}
+	return cfg
+}
+
+// projectRootOrExit finds osty.toml relative to cwd and exits with a
+// usage error when there isn't one. Used by `osty cache` subcommands
+// that need a project to operate against.
+func projectRootOrExit(flags cliFlags) string {
+	m, root, abort := loadManifestWithDiag(".", flags)
+	_ = m
+	if abort {
+		os.Exit(2)
+	}
+	return root
+}
+
+// tabular / flushTabular wrap text/tabwriter so the CLI's columnar
+// listings stay aligned without every caller repeating the ritual of
+// NewWriter + Flush. The column writer aligns on tabs; callers
+// separate fields with '\t'.
+func tabular(w *os.File) *tabwriter.Writer {
+	return tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+}
+
+func flushTabular(w *tabwriter.Writer) {
+	_ = w.Flush()
+}
+
+// humanBytes renders a byte count in KB / MB / GB, whichever fits.
+// Used by cache ls/clean output.
+func humanBytes(n int64) string {
+	const kb = 1024
+	if n < kb {
+		return fmt.Sprintf("%d B", n)
+	}
+	if n < kb*kb {
+		return fmt.Sprintf("%.1f KB", float64(n)/kb)
+	}
+	if n < kb*kb*kb {
+		return fmt.Sprintf("%.1f MB", float64(n)/(kb*kb))
+	}
+	return fmt.Sprintf("%.2f GB", float64(n)/(kb*kb*kb))
+}

--- a/cmd/osty/profile_flags.go
+++ b/cmd/osty/profile_flags.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/profile"
+)
+
+// profileFlags captures the `--profile / --release / --target /
+// --features / --no-default-features` flag set shared by `osty build`
+// and `osty run`. register() attaches them to a caller-owned
+// FlagSet; resolve() turns the captured state into a *profile.Resolved
+// or a usage error.
+type profileFlags struct {
+	profileName       string
+	releaseShortcut   bool
+	triple            string
+	features          string
+	noDefaultFeatures bool
+}
+
+// register binds every flag on fs. Flag names follow the convention
+// used by `cargo`: --profile for the named choice, --release as the
+// shorthand alias, --features for the comma-separated opt-in list,
+// --no-default-features to drop the manifest default. --target takes
+// a triple in the `<arch>-<os>` form parsed by profile.ParseTriple.
+func (pf *profileFlags) register(fs *flag.FlagSet) {
+	fs.StringVar(&pf.profileName, "profile", "",
+		"build profile name (debug, release, ...); default: debug")
+	fs.BoolVar(&pf.releaseShortcut, "release", false,
+		"shorthand for --profile release")
+	fs.StringVar(&pf.triple, "target", "",
+		"cross-compilation target triple (e.g. amd64-linux)")
+	fs.StringVar(&pf.features, "features", "",
+		"comma-separated feature names to enable")
+	fs.BoolVar(&pf.noDefaultFeatures, "no-default-features", false,
+		"disable the manifest's [features].default list")
+}
+
+// resolve merges the parsed flag state with the manifest's profile
+// declarations and returns a ready-to-use *profile.Resolved plus the
+// chosen profile name (so callers can stamp it into cache paths).
+//
+// When --profile is unset we default to "debug" for most commands;
+// callers that prefer a different default can pass it in `fallback`.
+// The release shortcut always wins over --profile to preserve the
+// pattern `--release --profile foo` errors out.
+func (pf *profileFlags) resolve(m *manifest.Manifest, fallback string) (*profile.Resolved, string, error) {
+	cfg, err := profile.BuildConfig(m)
+	if err != nil {
+		return nil, "", err
+	}
+	name := pf.profileName
+	if pf.releaseShortcut {
+		if name != "" && name != profile.NameRelease {
+			return nil, "", fmt.Errorf("--release conflicts with --profile %s", name)
+		}
+		name = profile.NameRelease
+	}
+	if name == "" {
+		name = fallback
+		if name == "" {
+			name = profile.NameDebug
+		}
+	}
+	// Parse the feature list. Empty strings are dropped so
+	// `--features=` behaves as a no-op.
+	var feats []string
+	if pf.features != "" {
+		for _, f := range strings.Split(pf.features, ",") {
+			f = strings.TrimSpace(f)
+			if f != "" {
+				feats = append(feats, f)
+			}
+		}
+	}
+	resolved, err := cfg.Resolve(name, pf.triple, feats, !pf.noDefaultFeatures)
+	if err != nil {
+		return nil, name, err
+	}
+	return resolved, name, nil
+}
+
+// announceProfile prints a one-line summary of the effective profile
+// + target + feature set. Kept as a helper so both `osty build` and
+// `osty run` surface the same string, which tools / CI logs can
+// grep for.
+func announceProfile(r *profile.Resolved) {
+	if r == nil || r.Profile == nil {
+		return
+	}
+	target := "host"
+	if r.Target != nil {
+		target = r.Target.Triple
+	}
+	feats := "none"
+	if len(r.Features) > 0 {
+		feats = strings.Join(r.Features, ",")
+	}
+	fmt.Fprintf(os.Stdout, "Profile: %s  Target: %s  Features: %s\n",
+		r.Profile.Name, target, feats)
+}

--- a/cmd/osty/profile_flags.go
+++ b/cmd/osty/profile_flags.go
@@ -10,6 +10,11 @@ import (
 	"github.com/osty/osty/internal/profile"
 )
 
+// profileTestFallback is `osty test`'s default profile when the user
+// doesn't pass `--profile`. Exposed as a named constant so the
+// fallback stays grep-able from both test.go and the profile docs.
+const profileTestFallback = profile.NameTest
+
 // profileFlags captures the `--profile / --release / --target /
 // --features / --no-default-features` flag set shared by `osty build`
 // and `osty run`. register() attaches them to a caller-owned

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osty/osty/internal/gen"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
+	"github.com/osty/osty/internal/profile"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
@@ -47,15 +48,23 @@ import (
 func runRun(args []string, cliF cliFlags) {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty run [--offline] [-- ARGS...]")
+		fmt.Fprintln(os.Stderr, "usage: osty run [--offline] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [-- ARGS...]")
 	}
 	var offline bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
+	var pf profileFlags
+	pf.register(fs)
 	_ = fs.Parse(args)
 	runArgs := fs.Args()
 
 	m, root, abort := loadManifestWithDiag(".", cliF)
 	if abort {
+		os.Exit(2)
+	}
+
+	resolved, _, perr := pf.resolve(m, profile.NameDebug)
+	if perr != nil {
+		fmt.Fprintf(os.Stderr, "osty run: %v\n", perr)
 		os.Exit(2)
 	}
 	_ = filepath.Join(root, manifest.ManifestFile) // kept for future inline rewriting
@@ -143,8 +152,14 @@ func runRun(args []string, cliF cliFlags) {
 		chk = &check.Result{}
 	}
 
-	// Step 4: transpile to Go.
-	outDir := filepath.Join(root, ".osty", "out")
+	// Step 4: transpile to Go. Per-profile/target subdirectories keep
+	// debug / release / cross-built artifacts from clobbering each
+	// other.
+	triple := ""
+	if resolved.Target != nil {
+		triple = resolved.Target.Triple
+	}
+	outDir := profile.OutputDir(root, resolved.Profile.Name, triple)
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
@@ -163,13 +178,20 @@ func runRun(args []string, cliF cliFlags) {
 		os.Exit(1)
 	}
 
-	// Step 5: go run.
-	goArgs := append([]string{"run", goPath}, runArgs...)
+	// Step 5: go run. Profile-derived flags (e.g. `-gcflags=-N -l`
+	// for debug, `-ldflags=-s -w` for release) precede the source
+	// path; cross-target env (GOOS, GOARCH, CGO_ENABLED) is layered
+	// onto the child process's environment.
+	goArgs := []string{"run"}
+	goArgs = append(goArgs, resolved.GoFlags()...)
+	goArgs = append(goArgs, goPath)
+	goArgs = append(goArgs, runArgs...)
 	cmd := exec.Command("go", goArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = outDir
+	cmd.Env = mergeEnv(os.Environ(), resolved.GoEnv())
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitErr.ExitCode())
@@ -177,6 +199,44 @@ func runRun(args []string, cliF cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty run: exec go: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// mergeEnv overlays per-build env overrides (GOOS, GOARCH,
+// CGO_ENABLED, plus any user-declared vars) on top of the parent
+// process's environment and returns a slice suitable for exec.Cmd.Env.
+// A later entry with the same key wins — the convention matches
+// exec.Command's own lookup.
+func mergeEnv(parent []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return parent
+	}
+	// Copy parent so the caller's slice stays intact.
+	out := make([]string, 0, len(parent)+len(overrides))
+	seen := map[string]bool{}
+	for k, v := range overrides {
+		out = append(out, k+"="+v)
+		seen[k] = true
+	}
+	for _, kv := range parent {
+		// KEY=VALUE — locate the '='; skip the parent entry when
+		// an override shadows it.
+		eq := -1
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				eq = i
+				break
+			}
+		}
+		if eq < 0 {
+			out = append(out, kv)
+			continue
+		}
+		if seen[kv[:eq]] {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // stripLeadingDashes drops a leading `--` argument separator used to

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -67,6 +67,17 @@ func runRun(args []string, cliF cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", perr)
 		os.Exit(2)
 	}
+	// `osty run` is a build-and-execute shortcut. A non-host target
+	// triple would produce a binary that can't run on this machine,
+	// so steer the user toward `osty build --target` instead.
+	if resolved.Target != nil {
+		fmt.Fprintf(os.Stderr,
+			"osty run: cannot execute cross-compiled binary for %s on host\n",
+			resolved.Target.Triple)
+		fmt.Fprintln(os.Stderr,
+			"hint: use `osty build --target "+resolved.Target.Triple+"` to produce the binary")
+		os.Exit(2)
+	}
 	_ = filepath.Join(root, manifest.ManifestFile) // kept for future inline rewriting
 
 	// Step 1: vendor deps (also runs resolve, computes the graph +

--- a/cmd/osty/test.go
+++ b/cmd/osty/test.go
@@ -60,8 +60,11 @@ func runTest(args []string, flags cliFlags) {
 	}
 	var offline bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
+	var pf profileFlags
+	pf.register(fs)
 	_ = fs.Parse(args)
 	positional := fs.Args()
+
 
 	// Split positional args into path targets (existing on disk) and
 	// name filters (everything else). Paths shortcut the manifest walk
@@ -105,6 +108,16 @@ func runTest(args []string, flags cliFlags) {
 			fmt.Fprintf(os.Stderr, "osty test: %v\n", err)
 			os.Exit(2)
 		}
+		// Resolve the effective profile so feature gating + target
+		// metadata surface here too. `osty test` defaults to the
+		// built-in `test` profile unless the user picks another with
+		// --profile.
+		resolved, _, perr := pf.resolve(man, profileTestFallback)
+		if perr != nil {
+			fmt.Fprintf(os.Stderr, "osty test: %v\n", perr)
+			os.Exit(2)
+		}
+		announceProfile(resolved)
 	}
 
 	// Collect test files: explicit positional paths if given; otherwise

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -47,6 +47,26 @@ type Manifest struct {
 	Workspace       *Workspace // non-nil when [workspace] is present
 	Lint            *Lint      // nil when [lint] absent; defaults apply
 
+	// Profiles are the `[profile.<name>]` tables — custom build
+	// profile overrides or new profiles inheriting from the built-in
+	// set. Keyed by profile name; a nil map means none declared.
+	Profiles map[string]*Profile
+
+	// Targets are the `[target.<triple>]` tables — cross-compilation
+	// presets the user has pinned in the manifest. Keyed by triple
+	// (e.g. "amd64-linux"); a nil slice means no declared targets.
+	Targets []*Target
+
+	// Features maps feature-name → list of dep/feature references
+	// that the feature transitively enables. Populated from the
+	// `[features]` table.
+	Features map[string][]string
+
+	// DefaultFeatures is the value of `[features].default` — the
+	// feature set enabled out of the box. `--no-default-features`
+	// on the CLI drops this to empty.
+	DefaultFeatures []string
+
 	// source and path are used for diagnostic rendering; populated by
 	// Load (or by hand via SetSource for bytes-in-memory callers).
 	source []byte
@@ -95,6 +115,46 @@ type Lint struct {
 	// Exclude is a list of path globs. Files matching any entry are
 	// skipped entirely by `osty lint`. `**` is a cross-segment wildcard.
 	Exclude []string
+}
+
+// Profile mirrors one `[profile.<name>]` table. The Has* flags
+// distinguish "set to the zero value" from "unset" so the downstream
+// profile package can merge on top of the built-in defaults without
+// clobbering unset fields.
+type Profile struct {
+	Name     string
+	Inherits string
+
+	OptLevel int
+	Debug    bool
+	Strip    bool
+	Overflow bool
+	Inlining bool
+	LTO      bool
+
+	HasOptLevel bool
+	HasDebug    bool
+	HasStrip    bool
+	HasOverflow bool
+	HasInlining bool
+	HasLTO      bool
+
+	GoFlags []string
+	Env     map[string]string
+
+	Pos token.Pos
+}
+
+// Target mirrors one `[target.<triple>]` table. A triple follows the
+// `<arch>-<os>` convention (e.g. `amd64-linux`, `arm64-darwin`).
+// HasCGO distinguishes an absent CGO key from an explicit `cgo =
+// false`.
+type Target struct {
+	Triple string
+	CGO    bool
+	HasCGO bool
+	Env    map[string]string
+	Pos    token.Pos
 }
 
 // Package is the manifest's `[package]` section.
@@ -329,6 +389,60 @@ func Parse(src []byte) (*Manifest, error) {
 		}
 		m.Lint = lc
 	}
+	// [profile.<name>]
+	if profV, ok := root.get("profile"); ok {
+		if profV.Tbl == nil {
+			return nil, fmt.Errorf("osty.toml:%d: [profile] must be a table", profV.Line)
+		}
+		m.Profiles = map[string]*Profile{}
+		for _, name := range profV.Tbl.keys {
+			entry, _ := profV.Tbl.get(name)
+			if entry.Tbl == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s must be a table", entry.Line, name)
+			}
+			p, err := parseProfileSection(name, entry.Tbl)
+			if err != nil {
+				return nil, err
+			}
+			m.Profiles[name] = p
+		}
+	}
+	// [target.<triple>]
+	if tgtV, ok := root.get("target"); ok {
+		if tgtV.Tbl == nil {
+			return nil, fmt.Errorf("osty.toml:%d: [target] must be a table", tgtV.Line)
+		}
+		for _, triple := range tgtV.Tbl.keys {
+			entry, _ := tgtV.Tbl.get(triple)
+			if entry.Tbl == nil {
+				return nil, fmt.Errorf("osty.toml:%d: target.%s must be a table", entry.Line, triple)
+			}
+			t, err := parseTargetSection(triple, entry.Tbl)
+			if err != nil {
+				return nil, err
+			}
+			m.Targets = append(m.Targets, t)
+		}
+	}
+	// [features]
+	if featV, ok := root.get("features"); ok {
+		if featV.Tbl == nil {
+			return nil, fmt.Errorf("osty.toml:%d: [features] must be a table", featV.Line)
+		}
+		m.Features = map[string][]string{}
+		for _, name := range featV.Tbl.keys {
+			entry, _ := featV.Tbl.get(name)
+			items, err := stringArray(entry, fmt.Sprintf("features.%s", name))
+			if err != nil {
+				return nil, err
+			}
+			if name == "default" {
+				m.DefaultFeatures = items
+				continue
+			}
+			m.Features[name] = items
+		}
+	}
 	// A manifest must declare at least one of [package] or [workspace].
 	// This is the sole required-section check after the workspace pass
 	// so either kind of root manifest is accepted.
@@ -336,6 +450,113 @@ func Parse(src []byte) (*Manifest, error) {
 		return nil, fmt.Errorf("osty.toml: missing [package] section")
 	}
 	return m, nil
+}
+
+// parseProfileSection extracts a [profile.<name>] table. Each known
+// key sets both the value and the corresponding Has* flag so
+// downstream merging can tell "absent" from "set-to-zero".
+func parseProfileSection(name string, t *tomlTable) (*Profile, error) {
+	p := &Profile{Name: name, Pos: token.Pos{Line: t.Line, Column: 1}}
+	for _, k := range t.keys {
+		v, _ := t.get(k)
+		switch k {
+		case "inherits":
+			if v.Str == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.inherits must be a string", v.Line, name)
+			}
+			p.Inherits = *v.Str
+		case "opt-level":
+			if v.Int == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.opt-level must be an integer", v.Line, name)
+			}
+			p.OptLevel = int(*v.Int)
+			p.HasOptLevel = true
+		case "debug":
+			if v.Bool == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.debug must be a bool", v.Line, name)
+			}
+			p.Debug = *v.Bool
+			p.HasDebug = true
+		case "strip":
+			if v.Bool == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.strip must be a bool", v.Line, name)
+			}
+			p.Strip = *v.Bool
+			p.HasStrip = true
+		case "overflow-checks":
+			if v.Bool == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.overflow-checks must be a bool", v.Line, name)
+			}
+			p.Overflow = *v.Bool
+			p.HasOverflow = true
+		case "inlining":
+			if v.Bool == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.inlining must be a bool", v.Line, name)
+			}
+			p.Inlining = *v.Bool
+			p.HasInlining = true
+		case "lto":
+			if v.Bool == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.lto must be a bool", v.Line, name)
+			}
+			p.LTO = *v.Bool
+			p.HasLTO = true
+		case "go-flags":
+			flags, err := stringArray(v, fmt.Sprintf("profile.%s.go-flags", name))
+			if err != nil {
+				return nil, err
+			}
+			p.GoFlags = flags
+		case "env":
+			if v.Tbl == nil {
+				return nil, fmt.Errorf("osty.toml:%d: profile.%s.env must be a table of strings", v.Line, name)
+			}
+			p.Env = map[string]string{}
+			for _, ek := range v.Tbl.keys {
+				ev, _ := v.Tbl.get(ek)
+				if ev.Str == nil {
+					return nil, fmt.Errorf("osty.toml:%d: profile.%s.env.%s must be a string", ev.Line, name, ek)
+				}
+				p.Env[ek] = *ev.Str
+			}
+		default:
+			return nil, fmt.Errorf("osty.toml:%d: unknown key `%s` in profile.%s", v.Line, k, name)
+		}
+	}
+	return p, nil
+}
+
+// parseTargetSection extracts a [target.<triple>] table. Supported
+// keys today are `cgo` (bool) and `env` (table of strings); unknown
+// keys are rejected so typos surface immediately.
+func parseTargetSection(triple string, t *tomlTable) (*Target, error) {
+	tgt := &Target{Triple: triple, Pos: token.Pos{Line: t.Line, Column: 1}}
+	for _, k := range t.keys {
+		v, _ := t.get(k)
+		switch k {
+		case "cgo":
+			if v.Bool == nil {
+				return nil, fmt.Errorf("osty.toml:%d: target.%s.cgo must be a bool", v.Line, triple)
+			}
+			tgt.CGO = *v.Bool
+			tgt.HasCGO = true
+		case "env":
+			if v.Tbl == nil {
+				return nil, fmt.Errorf("osty.toml:%d: target.%s.env must be a table of strings", v.Line, triple)
+			}
+			tgt.Env = map[string]string{}
+			for _, ek := range v.Tbl.keys {
+				ev, _ := v.Tbl.get(ek)
+				if ev.Str == nil {
+					return nil, fmt.Errorf("osty.toml:%d: target.%s.env.%s must be a string", ev.Line, triple, ek)
+				}
+				tgt.Env[ek] = *ev.Str
+			}
+		default:
+			return nil, fmt.Errorf("osty.toml:%d: unknown key `%s` in target.%s", v.Line, k, triple)
+		}
+	}
+	return tgt, nil
 }
 
 // parsePackageSection fills out *Package from a TOML table. Missing

--- a/internal/manifest/profile_test.go
+++ b/internal/manifest/profile_test.go
@@ -1,0 +1,178 @@
+package manifest
+
+import (
+	"testing"
+)
+
+// TestParseProfileSection verifies that [profile.release] fields are
+// parsed into *Profile with Has* flags set where declared, and that
+// unset fields leave Has* false (so the downstream merge can fall
+// back to the built-in default).
+func TestParseProfileSection(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.release]
+opt-level = 3
+strip = true
+go-flags = ["-race", "-trimpath"]
+
+[profile.bench]
+inherits = "release"
+debug = true
+`
+	m, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Profiles) != 2 {
+		t.Fatalf("want 2 profiles, got %d", len(m.Profiles))
+	}
+	rel := m.Profiles["release"]
+	if rel == nil {
+		t.Fatalf("release profile missing")
+	}
+	if !rel.HasOptLevel || rel.OptLevel != 3 {
+		t.Errorf("OptLevel: %+v", rel)
+	}
+	if !rel.HasStrip || !rel.Strip {
+		t.Errorf("Strip: %+v", rel)
+	}
+	if rel.HasDebug {
+		t.Errorf("Debug was not declared but HasDebug=true")
+	}
+	if len(rel.GoFlags) != 2 || rel.GoFlags[0] != "-race" {
+		t.Errorf("GoFlags: %+v", rel.GoFlags)
+	}
+	bench := m.Profiles["bench"]
+	if bench == nil || bench.Inherits != "release" {
+		t.Errorf("bench.inherits: %+v", bench)
+	}
+	if !bench.HasDebug || !bench.Debug {
+		t.Errorf("bench.debug: %+v", bench)
+	}
+}
+
+// TestParseProfileEnv covers the optional env = {...} subtable.
+func TestParseProfileEnv(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.debug]
+env = { FOO = "1", BAR = "baz" }
+`
+	m, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	p := m.Profiles["debug"]
+	if p == nil || len(p.Env) != 2 {
+		t.Fatalf("env table not populated: %+v", p)
+	}
+	if p.Env["FOO"] != "1" || p.Env["BAR"] != "baz" {
+		t.Errorf("env keys wrong: %+v", p.Env)
+	}
+}
+
+// TestParseProfileBadType rejects non-boolean values for bool keys.
+func TestParseProfileBadType(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.release]
+strip = "yes"
+`
+	if _, err := Parse([]byte(src)); err == nil {
+		t.Fatalf("expected type error, got nil")
+	}
+}
+
+// TestParseProfileUnknownKey catches typos inside a profile table.
+func TestParseProfileUnknownKey(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.release]
+opt_level = 3
+`
+	if _, err := Parse([]byte(src)); err == nil {
+		t.Fatalf("expected unknown-key error, got nil")
+	}
+}
+
+// TestParseTargetSection handles [target.<triple>] tables.
+func TestParseTargetSection(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[target.amd64-linux]
+cgo = false
+env = { CC = "clang" }
+
+[target.arm64-darwin]
+`
+	m, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Targets) != 2 {
+		t.Fatalf("want 2 targets, got %d", len(m.Targets))
+	}
+	var lin *Target
+	for _, t := range m.Targets {
+		if t.Triple == "amd64-linux" {
+			lin = t
+		}
+	}
+	if lin == nil {
+		t.Fatalf("amd64-linux missing")
+	}
+	if !lin.HasCGO || lin.CGO {
+		t.Errorf("CGO: %+v", lin)
+	}
+	if lin.Env["CC"] != "clang" {
+		t.Errorf("env missing: %+v", lin.Env)
+	}
+}
+
+// TestParseFeaturesSection covers [features] including the `default`
+// array (which lands in DefaultFeatures, not Features) and regular
+// features.
+func TestParseFeaturesSection(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[features]
+default = ["tls"]
+tls = ["crypto"]
+net = ["async"]
+async = []
+crypto = []
+`
+	m, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.DefaultFeatures) != 1 || m.DefaultFeatures[0] != "tls" {
+		t.Errorf("default features: %+v", m.DefaultFeatures)
+	}
+	if len(m.Features) != 4 {
+		t.Errorf("expected 4 features (default stripped), got %d: %+v",
+			len(m.Features), m.Features)
+	}
+	if m.Features["tls"][0] != "crypto" {
+		t.Errorf("tls feature contents: %+v", m.Features["tls"])
+	}
+}

--- a/internal/manifest/profile_validate_test.go
+++ b/internal/manifest/profile_validate_test.go
@@ -1,0 +1,151 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+)
+
+// TestValidateProfileOptLevelRange asserts opt-level outside [0,3] is
+// rejected with an error-severity diagnostic.
+func TestValidateProfileOptLevelRange(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.release]
+opt-level = 5
+`
+	m, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	diags := Validate(m)
+	if !hasErrorContaining(diags, "opt-level") {
+		t.Errorf("expected opt-level out-of-range error, got %v", diags)
+	}
+}
+
+// TestValidateInheritsUnknown surfaces a missing inherits target.
+func TestValidateInheritsUnknown(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.bench]
+inherits = "ghost"
+`
+	m, _ := Parse([]byte(src))
+	diags := Validate(m)
+	if !hasErrorContaining(diags, "ghost") {
+		t.Errorf("expected unknown-inherits error, got %v", diags)
+	}
+}
+
+// TestValidateInheritsCycle catches A -> B -> A cycles in the
+// declared profile graph.
+func TestValidateInheritsCycle(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.a]
+inherits = "b"
+
+[profile.b]
+inherits = "a"
+`
+	m, _ := Parse([]byte(src))
+	diags := Validate(m)
+	if !hasErrorContaining(diags, "cycle") {
+		t.Errorf("expected cycle error, got %v", diags)
+	}
+}
+
+// TestValidateInheritsBuiltinAccepted confirms that inheriting from a
+// built-in name (release) is fine even though it isn't in m.Profiles.
+func TestValidateInheritsBuiltinAccepted(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[profile.bench]
+inherits = "release"
+opt-level = 3
+`
+	m, _ := Parse([]byte(src))
+	for _, d := range Validate(m) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected error: %v", d.Message)
+		}
+	}
+}
+
+// TestValidateTargetTriple rejects malformed triples.
+func TestValidateTargetTriple(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[target.amd64]
+cgo = false
+`
+	m, _ := Parse([]byte(src))
+	diags := Validate(m)
+	if !hasErrorContaining(diags, "triple") {
+		t.Errorf("expected triple error, got %v", diags)
+	}
+}
+
+// TestValidateFeaturesDefaultUndefined catches a default that
+// references a feature the manifest never declared.
+func TestValidateFeaturesDefaultUndefined(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[features]
+default = ["nope"]
+real = []
+`
+	m, _ := Parse([]byte(src))
+	diags := Validate(m)
+	if !hasErrorContaining(diags, "nope") {
+		t.Errorf("expected undefined-default error, got %v", diags)
+	}
+}
+
+// TestValidateFeatureSelfReference catches `tls = ["tls"]`.
+func TestValidateFeatureSelfReference(t *testing.T) {
+	src := `
+[package]
+name = "p"
+version = "0.1.0"
+
+[features]
+tls = ["tls"]
+`
+	m, _ := Parse([]byte(src))
+	diags := Validate(m)
+	if !hasErrorContaining(diags, "lists itself") {
+		t.Errorf("expected self-reference error, got %v", diags)
+	}
+}
+
+// hasErrorContaining is a small helper — fewer scaffolding lines per
+// case keeps the table-driven feel above readable.
+func hasErrorContaining(diags []*diag.Diagnostic, substr string) bool {
+	for _, d := range diags {
+		if d.Severity == diag.Error && strings.Contains(d.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -153,7 +153,152 @@ func Validate(m *Manifest) []*diag.Diagnostic {
 		validateDepVersionReq(d, "dev-dependencies", &out)
 	}
 
+	// Profile / target / feature checks. All three additive:
+	// an unknown profile field would have been rejected at parse
+	// time, but opt-level range and inherits-graph validity are
+	// semantic and belong here.
+	validateProfiles(m, &out)
+	validateTargets(m, &out)
+	validateFeatures(m, &out)
+
 	return out
+}
+
+// validateProfiles enforces the manifest's [profile.*] invariants:
+//
+//   - opt-level must lie in [0, 3]
+//   - inherits must name a profile that exists (built-in or manifest)
+//     or be one of the declared profile names in this manifest
+//   - the inherits chain must not contain a cycle
+//
+// Built-in profile names are always valid inherits targets.
+func validateProfiles(m *Manifest, out *[]*diag.Diagnostic) {
+	if len(m.Profiles) == 0 {
+		return
+	}
+	builtins := map[string]bool{
+		"debug": true, "release": true, "profile": true, "test": true,
+	}
+	for name, p := range m.Profiles {
+		if p == nil {
+			continue
+		}
+		if p.HasOptLevel && (p.OptLevel < 0 || p.OptLevel > 3) {
+			*out = append(*out, diag.New(diag.Error,
+				fmt.Sprintf("profile.%s.opt-level %d out of range (want 0–3)",
+					name, p.OptLevel)).
+				Code(diag.CodeManifestFieldType).
+				PrimaryPos(p.Pos, "").
+				Build())
+		}
+		if p.Inherits != "" {
+			if !builtins[p.Inherits] {
+				if _, ok := m.Profiles[p.Inherits]; !ok {
+					*out = append(*out, diag.New(diag.Error,
+						fmt.Sprintf("profile.%s.inherits = %q: unknown base profile",
+							name, p.Inherits)).
+						Code(diag.CodeManifestBadDepSpec).
+						PrimaryPos(p.Pos, "").
+						Hint("must be a built-in (debug, release, profile, test) or a manifest-declared profile").
+						Build())
+				}
+			}
+		}
+	}
+	// Cycle detection via DFS. Colors: 0 unvisited, 1 on stack, 2 done.
+	color := map[string]int{}
+	var visit func(name string) bool
+	visit = func(name string) bool {
+		if builtins[name] {
+			return false
+		}
+		p, ok := m.Profiles[name]
+		if !ok || p == nil {
+			return false
+		}
+		if color[name] == 1 {
+			*out = append(*out, diag.New(diag.Error,
+				fmt.Sprintf("profile.%s: inherits chain forms a cycle", name)).
+				Code(diag.CodeManifestBadDepSpec).
+				PrimaryPos(p.Pos, "").
+				Build())
+			return true
+		}
+		if color[name] == 2 {
+			return false
+		}
+		color[name] = 1
+		if p.Inherits != "" {
+			if visit(p.Inherits) {
+				return true
+			}
+		}
+		color[name] = 2
+		return false
+	}
+	for name := range m.Profiles {
+		visit(name)
+	}
+}
+
+// validateTargets enforces triple well-formedness for [target.*].
+// The resolver already accepts triples optimistically; here we catch
+// typos like `[target.amd64]` or `[target.-linux]` at manifest time
+// so users get a clean error instead of a cryptic `go build` failure
+// much later.
+func validateTargets(m *Manifest, out *[]*diag.Diagnostic) {
+	for _, t := range m.Targets {
+		if t == nil {
+			continue
+		}
+		parts := splitTriple(t.Triple)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			*out = append(*out, diag.New(diag.Error,
+				fmt.Sprintf("target.%s: triple must be <arch>-<os>", t.Triple)).
+				Code(diag.CodeManifestBadDepSpec).
+				PrimaryPos(t.Pos, "").
+				Hint("examples: amd64-linux, arm64-darwin, wasm-js").
+				Build())
+		}
+	}
+}
+
+// validateFeatures makes sure a feature doesn't name itself as a
+// dependency and that `[features].default` only mentions features
+// that actually exist. Cross-dep feature refs (`<dep>/<feat>`) are
+// passed through unchecked — that's the pkgmgr's concern, not ours.
+func validateFeatures(m *Manifest, out *[]*diag.Diagnostic) {
+	for _, f := range m.DefaultFeatures {
+		if _, ok := m.Features[f]; !ok {
+			*out = append(*out, diag.New(diag.Error,
+				fmt.Sprintf("features.default references undefined feature %q", f)).
+				Code(diag.CodeManifestBadDepSpec).
+				PrimaryPos(token.Pos{Line: 1, Column: 1}, "").
+				Build())
+		}
+	}
+	for name, deps := range m.Features {
+		for _, d := range deps {
+			if d == name {
+				*out = append(*out, diag.New(diag.Error,
+					fmt.Sprintf("features.%s lists itself", name)).
+					Code(diag.CodeManifestBadDepSpec).
+					PrimaryPos(token.Pos{Line: 1, Column: 1}, "").
+					Build())
+			}
+		}
+	}
+}
+
+// splitTriple does the equivalent of profile.ParseTriple without
+// taking the package dep — mirrors the lightweight <arch>-<os> grammar.
+func splitTriple(s string) []string {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '-' {
+			return []string{s[:i], s[i+1:]}
+		}
+	}
+	return []string{s}
 }
 
 // validateDepVersionReq parses d.VersionReq through pkgmgr/semver.ParseReq

--- a/internal/profile/cache.go
+++ b/internal/profile/cache.go
@@ -1,0 +1,340 @@
+package profile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CacheDirName is the relative directory under the project root that
+// `osty build` writes per-profile artifacts and fingerprints into.
+// Each subdirectory is named after the effective (profile, target)
+// pair so concurrent cross-builds can coexist.
+const CacheDirName = ".osty/cache"
+
+// OutDirName is the transpiler's Go-source output root. Laid out as
+// .osty/out/<profile>[-<triple>]/ so `osty build --release` doesn't
+// clobber debug artifacts.
+const OutDirName = ".osty/out"
+
+// ArtifactKey formats the (profile, triple) tuple used to scope cache
+// entries and output directories. The triple portion is elided when
+// empty so host builds land at the familiar `out/<profile>/` path.
+func ArtifactKey(profile, triple string) string {
+	if triple == "" {
+		return profile
+	}
+	return profile + "-" + triple
+}
+
+// OutputDir returns <root>/.osty/out/<key>/ for the given profile +
+// triple. The directory is not created; callers that need it to
+// exist call os.MkdirAll on the result.
+func OutputDir(root, profile, triple string) string {
+	return filepath.Join(root, OutDirName, ArtifactKey(profile, triple))
+}
+
+// CachePath returns the per-(profile, triple) fingerprint JSON file.
+func CachePath(root, profile, triple string) string {
+	return filepath.Join(root, CacheDirName, ArtifactKey(profile, triple)+".json")
+}
+
+// Fingerprint is the on-disk record describing one build. Sources
+// maps the project-relative .osty file path to its sha256 content
+// hash; ToolVersion records the toolchain stamp so a binary upgrade
+// invalidates the cache even when source bytes haven't moved.
+//
+// The schema is forward-compatible by ignoring unknown JSON fields
+// — future tool versions can extend the record without migrating.
+type Fingerprint struct {
+	Profile     string            `json:"profile"`
+	Target      string            `json:"target,omitempty"`
+	ToolVersion string            `json:"tool_version"`
+	Features    []string          `json:"features,omitempty"`
+	Sources     map[string]string `json:"sources"`
+	Artifacts   map[string]string `json:"artifacts,omitempty"`
+	BuiltAt     time.Time         `json:"built_at"`
+}
+
+// Equal reports whether two fingerprints represent an identical build
+// (every source hash matches + same tool version + same feature set).
+// The built_at stamp is ignored because it's an observation, not an
+// input.
+func (f *Fingerprint) Equal(other *Fingerprint) bool {
+	if f == nil || other == nil {
+		return false
+	}
+	if f.ToolVersion != other.ToolVersion {
+		return false
+	}
+	if !stringSliceEq(f.Features, other.Features) {
+		return false
+	}
+	if len(f.Sources) != len(other.Sources) {
+		return false
+	}
+	for k, v := range f.Sources {
+		if other.Sources[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// HashFile computes the hex-encoded sha256 of the file at path. An
+// I/O error aborts — callers use this on inputs they already expect
+// to exist (parser has opened them).
+func HashFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// HashSources walks every file under root whose name matches the
+// supplied predicate (callers pass an .osty filter) and returns a
+// path→hash map keyed by path relative to root. Symlinks and
+// hidden directories (leading ".") are skipped so the cache
+// directory itself doesn't feed back into the fingerprint.
+func HashSources(root string, want func(name string) bool) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if path != root && strings.HasPrefix(name, ".") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !want(name) {
+			return nil
+		}
+		h, err := HashFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out[filepath.ToSlash(rel)] = h
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// NewFingerprint is a convenience that builds a Fingerprint from a
+// computed sources map plus the effective resolved config. toolVer
+// is the stamp the caller got from build info (a git sha in real
+// builds, "dev" in tests).
+func NewFingerprint(sources map[string]string, r *Resolved, toolVer string) *Fingerprint {
+	triple := ""
+	if r != nil && r.Target != nil {
+		triple = r.Target.Triple
+	}
+	profileName := ""
+	var feats []string
+	if r != nil && r.Profile != nil {
+		profileName = r.Profile.Name
+	}
+	if r != nil {
+		feats = append([]string(nil), r.Features...)
+	}
+	return &Fingerprint{
+		Profile:     profileName,
+		Target:      triple,
+		ToolVersion: toolVer,
+		Features:    feats,
+		Sources:     sources,
+		BuiltAt:     time.Now().UTC(),
+	}
+}
+
+// Write serializes f to the cache path for (profile, triple) under
+// root. Parent directories are created as needed. The write is
+// atomic: content goes to a sibling `.tmp` file first, then Renamed
+// into place — a crash during `osty build` never leaves a truncated
+// JSON record behind.
+func (f *Fingerprint) Write(root string) error {
+	if f == nil {
+		return fmt.Errorf("nil fingerprint")
+	}
+	path := CachePath(root, f.Profile, f.Target)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// ReadFingerprint loads the cached fingerprint for (profile, triple)
+// from root. Returns (nil, nil) when no such cache exists — a
+// missing cache is not an error, just a cold build.
+func ReadFingerprint(root, profile, triple string) (*Fingerprint, error) {
+	path := CachePath(root, profile, triple)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var f Fingerprint
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("corrupt cache %s: %w", path, err)
+	}
+	return &f, nil
+}
+
+// CacheEntry is a compact summary used by `osty cache ls`.
+type CacheEntry struct {
+	Profile     string
+	Target      string
+	ToolVersion string
+	Sources     int
+	Size        int64
+	BuiltAt     time.Time
+}
+
+// ListCache walks the cache directory under root and returns one
+// entry per valid fingerprint JSON. Corrupt files are silently
+// skipped so a single bad record doesn't break the listing. Entries
+// are sorted by (profile, target) for reproducible output.
+func ListCache(root string) ([]CacheEntry, error) {
+	dir := filepath.Join(root, CacheDirName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []CacheEntry
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		var f Fingerprint
+		if err := json.Unmarshal(data, &f); err != nil {
+			continue
+		}
+		info, _ := e.Info()
+		size := int64(0)
+		if info != nil {
+			size = info.Size()
+		}
+		out = append(out, CacheEntry{
+			Profile:     f.Profile,
+			Target:      f.Target,
+			ToolVersion: f.ToolVersion,
+			Sources:     len(f.Sources),
+			Size:        size,
+			BuiltAt:     f.BuiltAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Profile != out[j].Profile {
+			return out[i].Profile < out[j].Profile
+		}
+		return out[i].Target < out[j].Target
+	})
+	return out, nil
+}
+
+// CleanCache removes every fingerprint JSON under root's cache dir
+// plus the matching output trees. Returns the number of bytes
+// reclaimed (summed file sizes) so `osty cache clean` can report
+// actionable numbers. Missing directories are treated as "nothing
+// to clean", not errors.
+func CleanCache(root string) (int64, error) {
+	var total int64
+	cacheDir := filepath.Join(root, CacheDirName)
+	if size, err := sumAndRemove(cacheDir); err == nil {
+		total += size
+	} else if !os.IsNotExist(err) {
+		return total, err
+	}
+	outDir := filepath.Join(root, OutDirName)
+	if size, err := sumAndRemove(outDir); err == nil {
+		total += size
+	} else if !os.IsNotExist(err) {
+		return total, err
+	}
+	return total, nil
+}
+
+// sumAndRemove totals the size of every file beneath path and then
+// removes the tree. Used by CleanCache — factored out so it can be
+// called on both the cache + output dirs without duplicating the
+// walk.
+func sumAndRemove(path string) (int64, error) {
+	var total int64
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if !info.IsDir() {
+		total = info.Size()
+		return total, os.Remove(path)
+	}
+	err = filepath.WalkDir(path, func(_ string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, ferr := d.Info()
+		if ferr == nil {
+			total += fi.Size()
+		}
+		return nil
+	})
+	if err != nil {
+		return total, err
+	}
+	return total, os.RemoveAll(path)
+}
+
+func stringSliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	for i := range aa {
+		if aa[i] != bb[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/profile/cache_test.go
+++ b/internal/profile/cache_test.go
@@ -1,0 +1,179 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCacheWriteReadRoundtrip covers the common incremental-build
+// path: write a fingerprint, read it back, assert equality.
+func TestCacheWriteReadRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	fp := &Fingerprint{
+		Profile:     NameDebug,
+		Target:      "",
+		ToolVersion: "test",
+		Sources:     map[string]string{"main.osty": "abc123"},
+		Features:    []string{"alpha"},
+	}
+	if err := fp.Write(dir); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := ReadFingerprint(dir, NameDebug, "")
+	if err != nil {
+		t.Fatalf("ReadFingerprint: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("nil fingerprint")
+	}
+	if !got.Equal(fp) {
+		t.Errorf("roundtrip lost data: %+v vs %+v", got, fp)
+	}
+}
+
+// TestFingerprintEqualDetectsSourceDrift flips one hash and asserts
+// the fingerprint comparison reports inequality — this is what
+// triggers a rebuild in `osty build`.
+func TestFingerprintEqualDetectsSourceDrift(t *testing.T) {
+	a := &Fingerprint{
+		ToolVersion: "v1",
+		Sources:     map[string]string{"x.osty": "h1"},
+	}
+	b := &Fingerprint{
+		ToolVersion: "v1",
+		Sources:     map[string]string{"x.osty": "h2"},
+	}
+	if a.Equal(b) {
+		t.Errorf("different hashes should compare unequal")
+	}
+}
+
+// TestFingerprintEqualToolVersion makes sure upgrading the toolchain
+// invalidates every cached artifact.
+func TestFingerprintEqualToolVersion(t *testing.T) {
+	a := &Fingerprint{
+		ToolVersion: "v1",
+		Sources:     map[string]string{"x.osty": "h"},
+	}
+	b := &Fingerprint{
+		ToolVersion: "v2",
+		Sources:     map[string]string{"x.osty": "h"},
+	}
+	if a.Equal(b) {
+		t.Errorf("different tool versions should compare unequal")
+	}
+}
+
+// TestReadFingerprintMissing returns (nil, nil) for a cold cache
+// rather than surfacing an error — `osty build` uses that to decide
+// "cold build, proceed".
+func TestReadFingerprintMissing(t *testing.T) {
+	dir := t.TempDir()
+	fp, err := ReadFingerprint(dir, NameDebug, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fp != nil {
+		t.Errorf("expected nil for missing cache, got %+v", fp)
+	}
+}
+
+// TestListCacheAndClean exercises the cache-visualisation helpers.
+// After writing two fingerprints, ListCache should return both
+// entries sorted; CleanCache should remove them + any .osty/out
+// tree.
+func TestListCacheAndClean(t *testing.T) {
+	dir := t.TempDir()
+	a := &Fingerprint{Profile: NameRelease, ToolVersion: "t", Sources: map[string]string{"a": "x"}}
+	b := &Fingerprint{Profile: NameDebug, ToolVersion: "t", Sources: map[string]string{"b": "y"}}
+	if err := a.Write(dir); err != nil {
+		t.Fatalf("Write a: %v", err)
+	}
+	if err := b.Write(dir); err != nil {
+		t.Fatalf("Write b: %v", err)
+	}
+	// Seed an out directory so CleanCache has something to remove.
+	outDir := OutputDir(dir, NameDebug, "")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir out: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("seed out: %v", err)
+	}
+
+	entries, err := ListCache(dir)
+	if err != nil {
+		t.Fatalf("ListCache: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(entries), entries)
+	}
+	if entries[0].Profile != NameDebug {
+		t.Errorf("entries not sorted by profile name: %+v", entries)
+	}
+
+	total, err := CleanCache(dir)
+	if err != nil {
+		t.Fatalf("CleanCache: %v", err)
+	}
+	if total == 0 {
+		t.Errorf("CleanCache reported 0 bytes reclaimed")
+	}
+	if _, err := os.Stat(filepath.Join(dir, CacheDirName)); !os.IsNotExist(err) {
+		t.Errorf("cache dir not removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, OutDirName)); !os.IsNotExist(err) {
+		t.Errorf("out dir not removed: %v", err)
+	}
+}
+
+// TestHashSources smoke-tests the walker by seeding two .osty files
+// plus one non-osty file and confirming only the .osty entries land
+// in the map.
+func TestHashSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.osty"), []byte("fn a() {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.osty"), []byte("fn b() {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// .osty/cache should be skipped so the fingerprint doesn't feed
+	// back into itself.
+	hidden := filepath.Join(dir, ".osty", "cache")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "skip.osty"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := HashSources(dir, func(n string) bool {
+		return filepath.Ext(n) == ".osty"
+	})
+	if err != nil {
+		t.Fatalf("HashSources: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("want 2 .osty files hashed, got %d: %+v", len(got), got)
+	}
+	if _, ok := got["a.osty"]; !ok {
+		t.Errorf("a.osty missing from %+v", got)
+	}
+	if _, ok := got["sub/b.osty"]; !ok {
+		t.Errorf("sub/b.osty missing from %+v", got)
+	}
+	for name := range got {
+		if name == "README.md" {
+			t.Errorf("non-osty file included")
+		}
+	}
+}

--- a/internal/profile/doc.go
+++ b/internal/profile/doc.go
@@ -1,0 +1,20 @@
+// Package profile models the build-time choices the user can make
+// without editing source: the build *profile* (debug / release /
+// profile / test), the target *triple* (GOOS/GOARCH pair governing
+// cross-compilation), and the set of opt-in *features* that gate
+// conditional code paths.
+//
+// Each concept has a first-class type here plus a helper that merges
+// the manifest-declared values (from `[profile.*]`, `[target.*]`,
+// `[features]`) with the toolchain's built-in defaults, so callers
+// downstream can work with a single resolved Config regardless of
+// whether the user customized anything.
+//
+// The package is also the home of the build-cache metadata types:
+// when `osty build` runs gen + go-build it records a per-(profile,
+// target) entry under <project>/.osty/cache/ so subsequent builds can
+// detect that the sources haven't changed and skip the expensive
+// transpile step. The schema is intentionally small (a JSON map
+// keyed by source-path → sha256) because the cache is advisory —
+// a missing / corrupt entry just forces a rebuild, never a failure.
+package profile

--- a/internal/profile/feature_test.go
+++ b/internal/profile/feature_test.go
@@ -1,0 +1,112 @@
+package profile
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestReadFeaturePragma covers the recognised forms (with/without
+// space after //) and the early-stop rule that pragmas must live at
+// the top of the file.
+func TestReadFeaturePragma(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{"none", "fn main() {}\n", nil},
+		{"single", "// @feature: net\nfn main() {}\n", []string{"net"}},
+		{"no space", "//@feature: net\nfn main() {}\n", []string{"net"}},
+		{"multi", "// @feature: net, tls, async\nfn main() {}\n", []string{"net", "tls", "async"}},
+		{"after blank", "\n// @feature: alpha\nfn main() {}\n", []string{"alpha"}},
+		{"after code is ignored", "fn x() {}\n// @feature: late\n", nil},
+		{"interleaved comments ok", "// banner\n// @feature: net\nfn main() {}\n", []string{"net"}},
+	}
+	for _, tc := range cases {
+		got := ReadFeaturePragma([]byte(tc.src))
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestFileNeedsFeatures verifies the inclusion decision: every
+// required feature must be active.
+func TestFileNeedsFeatures(t *testing.T) {
+	src := []byte("// @feature: net, tls\nfn main() {}\n")
+	if ok, _ := FileNeedsFeatures(src, map[string]bool{"net": true, "tls": true}); !ok {
+		t.Errorf("expected file to be included when all features active")
+	}
+	if ok, missing := FileNeedsFeatures(src, map[string]bool{"net": true}); ok {
+		t.Errorf("expected file to be excluded; missing should be tls")
+	} else if missing != "tls" {
+		t.Errorf("missing = %q, want tls", missing)
+	}
+	// File without pragma is always included.
+	if ok, _ := FileNeedsFeatures([]byte("fn main() {}"), nil); !ok {
+		t.Errorf("file without pragma should be included")
+	}
+}
+
+// TestOptLevelFlags covers the defined mapping points.
+func TestOptLevelFlags(t *testing.T) {
+	cases := map[int][]string{
+		0: {"-gcflags=all=-N -l"},
+		1: {"-gcflags=all=-l"},
+		2: nil,
+		3: nil,
+	}
+	for lvl, want := range cases {
+		p := &Profile{OptLevel: lvl}
+		got := p.OptLevelFlags()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("OptLevel=%d: got %v, want %v", lvl, got, want)
+		}
+	}
+}
+
+// TestGoFlagsDedupesOptAndStrip asserts the consolidated GoFlags()
+// doesn't repeat the gcflags entry that's both in Profile.GoFlags and
+// derived from OptLevel, and that Strip=true contributes the
+// `-ldflags=-s -w` exactly once.
+func TestGoFlagsDedupesOptAndStrip(t *testing.T) {
+	c := Defaults()
+	r, err := c.Resolve(NameDebug, "", nil, true)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	flags := r.GoFlags()
+	count := 0
+	for _, f := range flags {
+		if f == "-gcflags=all=-N -l" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected -gcflags=all=-N -l exactly once, got %d in %v", count, flags)
+	}
+
+	r, _ = c.Resolve(NameRelease, "", nil, true)
+	flags = r.GoFlags()
+	stripCount := 0
+	for _, f := range flags {
+		if f == "-ldflags=-s -w" {
+			stripCount++
+		}
+	}
+	if stripCount != 1 {
+		t.Errorf("expected -ldflags=-s -w exactly once, got %d in %v", stripCount, flags)
+	}
+}
+
+// TestParseFeatureListWhitespaceAndCommas exercises the small parser
+// for the feature list inline with the pragma.
+func TestParseFeatureListWhitespaceAndCommas(t *testing.T) {
+	got := parseFeatureList("  net , tls,async ")
+	sort.Strings(got)
+	want := []string{"async", "net", "tls"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/internal/profile/merge.go
+++ b/internal/profile/merge.go
@@ -1,0 +1,186 @@
+package profile
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/osty/osty/internal/manifest"
+)
+
+// BuildConfig merges manifest-declared profiles, targets, and features
+// on top of Defaults() and returns a ready-to-use Config. When m is
+// nil only the built-in defaults are returned.
+//
+// Overlay rules:
+//   - A profile with the same name as a built-in replaces its fields
+//     only where the manifest explicitly set them (tracked by Has*
+//     flags on manifest.Profile). Unset fields keep the built-in
+//     value.
+//   - A profile with a new name inherits from `inherits` (or "debug"
+//     when unset) before applying its own overrides. This gives
+//     users a compact way to declare e.g. `[profile.bench]` that
+//     extends release.
+//   - Targets are additive: a manifest triple that doesn't shadow a
+//     built-in just appears in c.Targets. Built-ins currently empty.
+//   - Features + default-features come straight from the manifest —
+//     the toolchain has no built-in features to merge against.
+//
+// Inheritance is capped at one level of indirection. If the declared
+// parent is itself a user profile that inherits, the chain is walked
+// up to 8 steps before the merge gives up with an error to guard
+// against pathological manifests.
+func BuildConfig(m *manifest.Manifest) (*Config, error) {
+	c := Defaults()
+	if m == nil {
+		return c, nil
+	}
+
+	// Phase 1: gather every manifest profile keyed by name.
+	mps := m.Profiles
+	// Phase 2: apply in order — built-in names first (so user tweaks
+	// of debug/release land deterministically), then any new names.
+	seen := map[string]bool{}
+	ordered := make([]string, 0, len(mps))
+	for _, name := range []string{NameDebug, NameRelease, NameProfile, NameTest} {
+		if _, ok := mps[name]; ok {
+			ordered = append(ordered, name)
+			seen[name] = true
+		}
+	}
+	// Sort the rest for determinism.
+	extras := make([]string, 0, len(mps))
+	for name := range mps {
+		if !seen[name] {
+			extras = append(extras, name)
+		}
+	}
+	sort.Strings(extras)
+	ordered = append(ordered, extras...)
+
+	for _, name := range ordered {
+		mp := mps[name]
+		base, err := resolveBase(c, mps, mp, 0)
+		if err != nil {
+			return nil, err
+		}
+		merged := base.Clone()
+		merged.Name = name
+		merged.UserDefined = true
+		applyManifestProfile(merged, mp)
+		c.Profiles[name] = merged
+	}
+
+	// Targets.
+	for _, mt := range m.Targets {
+		arch, os, err := ParseTriple(mt.Triple)
+		if err != nil {
+			return nil, err
+		}
+		t := &Target{
+			Triple:      mt.Triple,
+			OS:          os,
+			Arch:        arch,
+			UserDefined: true,
+		}
+		if mt.HasCGO {
+			b := mt.CGO
+			t.CGO = &b
+		}
+		if len(mt.Env) > 0 {
+			t.Env = map[string]string{}
+			for k, v := range mt.Env {
+				t.Env[k] = v
+			}
+		}
+		c.Targets[mt.Triple] = t
+	}
+
+	// Features + default features.
+	if len(m.Features) > 0 {
+		c.Features = map[string][]string{}
+		for name, deps := range m.Features {
+			c.Features[name] = append([]string(nil), deps...)
+		}
+	}
+	c.DefaultFeatures = append([]string(nil), m.DefaultFeatures...)
+	return c, nil
+}
+
+// resolveBase walks the inherits chain starting from mp and returns
+// the Profile to clone from. For manifest profiles overriding a
+// built-in (same name) the base is the built-in with that name. For
+// new names the base is the one named by mp.Inherits, or debug when
+// that field is unset.
+func resolveBase(c *Config, mps map[string]*manifest.Profile, mp *manifest.Profile, depth int) (*Profile, error) {
+	if depth > 8 {
+		return nil, fmt.Errorf("profile inheritance too deep starting at %q", mp.Name)
+	}
+	// Same-name override of a built-in.
+	if builtin, ok := c.Profiles[mp.Name]; ok && !builtin.UserDefined {
+		return builtin, nil
+	}
+	parentName := mp.Inherits
+	if parentName == "" {
+		parentName = NameDebug
+	}
+	if parentName == mp.Name {
+		return nil, fmt.Errorf("profile %q cannot inherit from itself", mp.Name)
+	}
+	// Look up parent: prefer already-merged config, fall back to the
+	// manifest map when the parent hasn't been merged yet.
+	if p, ok := c.Profiles[parentName]; ok {
+		return p, nil
+	}
+	parentMp, ok := mps[parentName]
+	if !ok {
+		return nil, fmt.Errorf("profile %q inherits from unknown profile %q",
+			mp.Name, parentName)
+	}
+	// Recurse to let the parent build itself first.
+	base, err := resolveBase(c, mps, parentMp, depth+1)
+	if err != nil {
+		return nil, err
+	}
+	merged := base.Clone()
+	merged.Name = parentMp.Name
+	applyManifestProfile(merged, parentMp)
+	return merged, nil
+}
+
+// applyManifestProfile overlays p's declared fields onto dst. Only
+// fields the manifest actually set (per the Has* flags) are copied;
+// everything else keeps dst's value.
+func applyManifestProfile(dst *Profile, p *manifest.Profile) {
+	if p.HasOptLevel {
+		dst.OptLevel = p.OptLevel
+	}
+	if p.HasDebug {
+		dst.Debug = p.Debug
+	}
+	if p.HasStrip {
+		dst.Strip = p.Strip
+	}
+	if p.HasOverflow {
+		dst.Overflow = p.Overflow
+	}
+	if p.HasInlining {
+		dst.Inlining = p.Inlining
+	}
+	if p.HasLTO {
+		dst.LTO = p.LTO
+	}
+	if p.Inherits != "" {
+		dst.Inherits = p.Inherits
+	}
+	if len(p.GoFlags) > 0 {
+		dst.GoFlags = append(dst.GoFlags, p.GoFlags...)
+	}
+	if len(p.Env) > 0 {
+		if dst.Env == nil {
+			dst.Env = map[string]string{}
+		}
+		for k, v := range p.Env {
+			dst.Env[k] = v
+		}
+	}
+}

--- a/internal/profile/merge_test.go
+++ b/internal/profile/merge_test.go
@@ -1,0 +1,163 @@
+package profile
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/manifest"
+)
+
+// TestBuildConfigNilManifest falls back to built-in defaults when the
+// manifest is nil (e.g. `osty profiles` outside a project).
+func TestBuildConfigNilManifest(t *testing.T) {
+	c, err := BuildConfig(nil)
+	if err != nil {
+		t.Fatalf("BuildConfig(nil): %v", err)
+	}
+	if _, ok := c.Profile(NameDebug); !ok {
+		t.Errorf("missing debug profile")
+	}
+}
+
+// TestBuildConfigOverridesBuiltin verifies that a [profile.release]
+// table in the manifest keeps unset defaults but applies declared
+// overrides (opt-level, go-flags, strip).
+func TestBuildConfigOverridesBuiltin(t *testing.T) {
+	m := &manifest.Manifest{
+		Profiles: map[string]*manifest.Profile{
+			NameRelease: {
+				Name:        NameRelease,
+				OptLevel:    3,
+				HasOptLevel: true,
+				Strip:       false,
+				HasStrip:    true,
+				GoFlags:     []string{"-race"},
+			},
+		},
+	}
+	c, err := BuildConfig(m)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	rel := c.Profiles[NameRelease]
+	if rel == nil {
+		t.Fatalf("release missing after merge")
+	}
+	if rel.OptLevel != 3 {
+		t.Errorf("OptLevel = %d, want 3", rel.OptLevel)
+	}
+	if rel.Strip {
+		t.Errorf("Strip override ignored; want false")
+	}
+	if !rel.Debug == false {
+		// defaults to the built-in release.Debug which is false; no
+		// change expected.
+	}
+	sawRace := false
+	for _, f := range rel.GoFlags {
+		if f == "-race" {
+			sawRace = true
+		}
+	}
+	if !sawRace {
+		t.Errorf("go-flags appended failed; got %v", rel.GoFlags)
+	}
+	if !rel.UserDefined {
+		t.Errorf("merged profile should be marked UserDefined")
+	}
+}
+
+// TestBuildConfigCustomProfileInherits validates that a new profile
+// name derives from its inherits base and then applies overrides.
+func TestBuildConfigCustomProfileInherits(t *testing.T) {
+	m := &manifest.Manifest{
+		Profiles: map[string]*manifest.Profile{
+			"bench": {
+				Name:        "bench",
+				Inherits:    NameRelease,
+				OptLevel:    3,
+				HasOptLevel: true,
+				Debug:       true,
+				HasDebug:    true,
+			},
+		},
+	}
+	c, err := BuildConfig(m)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	b := c.Profiles["bench"]
+	if b == nil {
+		t.Fatalf("bench profile missing")
+	}
+	if b.OptLevel != 3 {
+		t.Errorf("OptLevel = %d, want 3", b.OptLevel)
+	}
+	if !b.Debug {
+		t.Errorf("Debug override ignored")
+	}
+	if !b.Strip {
+		t.Errorf("Strip should inherit from release (true)")
+	}
+}
+
+// TestBuildConfigUnknownInherits surfaces manifests that point
+// `inherits` at a profile that doesn't exist.
+func TestBuildConfigUnknownInherits(t *testing.T) {
+	m := &manifest.Manifest{
+		Profiles: map[string]*manifest.Profile{
+			"bench": {
+				Name:     "bench",
+				Inherits: "nope",
+			},
+		},
+	}
+	if _, err := BuildConfig(m); err == nil {
+		t.Fatalf("expected error for unknown inherits")
+	}
+}
+
+// TestBuildConfigTargets propagates target tables with arch / os /
+// cgo derived from the triple name.
+func TestBuildConfigTargets(t *testing.T) {
+	m := &manifest.Manifest{
+		Targets: []*manifest.Target{
+			{Triple: "amd64-linux", CGO: false, HasCGO: true},
+			{Triple: "arm64-darwin", Env: map[string]string{"SDK": "macos"}},
+		},
+	}
+	c, err := BuildConfig(m)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	lin := c.Targets["amd64-linux"]
+	if lin == nil || lin.OS != "linux" || lin.Arch != "amd64" {
+		t.Errorf("amd64-linux target wrong: %+v", lin)
+	}
+	if lin.CGO == nil || *lin.CGO {
+		t.Errorf("cgo should be explicitly off: %+v", lin.CGO)
+	}
+	mac := c.Targets["arm64-darwin"]
+	if mac == nil || mac.Env["SDK"] != "macos" {
+		t.Errorf("arm64-darwin env lost: %+v", mac)
+	}
+}
+
+// TestBuildConfigFeatures moves [features] + default list into Config.
+func TestBuildConfigFeatures(t *testing.T) {
+	m := &manifest.Manifest{
+		Features: map[string][]string{
+			"tls": {"crypto"},
+		},
+		DefaultFeatures: []string{"tls"},
+	}
+	c, err := BuildConfig(m)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	if len(c.DefaultFeatures) != 1 || c.DefaultFeatures[0] != "tls" {
+		t.Errorf("DefaultFeatures = %v", c.DefaultFeatures)
+	}
+	if c.Features["tls"][0] != "crypto" {
+		t.Errorf("feature table lost: %+v", c.Features)
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,390 @@
+package profile
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Built-in profile names. Any additional profile declared in the
+// manifest under `[profile.<name>]` may inherit from one of these via
+// `inherits = "<name>"`.
+const (
+	NameDebug   = "debug"
+	NameRelease = "release"
+	NameProfile = "profile"
+	NameTest    = "test"
+)
+
+// Profile is the set of knobs the compiler + linker consume when
+// producing an artifact. Field semantics:
+//
+//   - OptLevel is the optimization level passed as `-gcflags=-l=<n>`
+//     to the Go backend (0 = disable inlining, 2 = default release).
+//   - Debug toggles retention of DWARF symbols. `-ldflags=-w -s`
+//     strips them when false.
+//   - Overflow toggles integer-overflow runtime checks where the
+//     emitted Go code supports them (Phase 4 of the transpiler).
+//   - Inlining/LTO are per-call-site hints consumed by gen; they do
+//     not affect today's Phase 1 output but are honoured by the
+//     manifest parser so users can pin them ahead of time.
+//   - GoFlags is an ordered list of raw flags appended after the
+//     built-in derivation so users can override individual settings
+//     (e.g. `-trimpath`) without recomputing the whole flag slice.
+//   - Env is process-env key/value overrides threaded into the
+//     `go build` invocation (GOARCH, GOOS, CGO_ENABLED, …).
+//   - Inherits names another profile whose fields fill in unset
+//     values at merge time. Limited to one level of indirection so
+//     cycles are structurally impossible.
+type Profile struct {
+	Name      string
+	OptLevel  int
+	Debug     bool
+	Strip     bool
+	Overflow  bool
+	Inlining  bool
+	LTO       bool
+	GoFlags   []string
+	Env       map[string]string
+	Inherits  string
+
+	// UserDefined is true when the profile came from the manifest
+	// (as opposed to the built-in defaults). Used by `osty profiles`
+	// to tag custom entries in its listing.
+	UserDefined bool
+}
+
+// Clone returns a deep copy of p so callers can mutate without
+// aliasing the defaults.
+func (p *Profile) Clone() *Profile {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	cp.GoFlags = append([]string(nil), p.GoFlags...)
+	if p.Env != nil {
+		cp.Env = make(map[string]string, len(p.Env))
+		for k, v := range p.Env {
+			cp.Env[k] = v
+		}
+	}
+	return &cp
+}
+
+// Target describes a (GOOS, GOARCH) pair plus an optional CGO toggle.
+// The Triple name is the user-facing handle — the convention is the
+// `<arch>-<os>` form (e.g. `amd64-linux`, `arm64-darwin`) so it
+// composes nicely with cache paths. Either/both of OS/Arch may be
+// empty, in which case the host value is used at resolve time.
+type Target struct {
+	Triple string
+	OS     string
+	Arch   string
+	CGO    *bool // nil = leave CGO_ENABLED untouched
+	Env    map[string]string
+
+	// UserDefined is set for manifest-declared targets.
+	UserDefined bool
+}
+
+// Clone produces a deep copy of t.
+func (t *Target) Clone() *Target {
+	if t == nil {
+		return nil
+	}
+	cp := *t
+	if t.CGO != nil {
+		b := *t.CGO
+		cp.CGO = &b
+	}
+	if t.Env != nil {
+		cp.Env = make(map[string]string, len(t.Env))
+		for k, v := range t.Env {
+			cp.Env[k] = v
+		}
+	}
+	return &cp
+}
+
+// ParseTriple splits "<arch>-<os>" into (arch, os). Returns an error
+// if the triple isn't in the expected form. The toolchain does not
+// try to validate against Go's internal GOOS/GOARCH table — unknown
+// combinations are surfaced by `go build` itself.
+func ParseTriple(triple string) (arch, os string, err error) {
+	parts := strings.SplitN(triple, "-", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid target triple %q (want <arch>-<os>)", triple)
+	}
+	return parts[0], parts[1], nil
+}
+
+// Config is the merged view of built-in defaults + manifest-declared
+// profile/target/feature tables. Callers acquire one via
+// BuildConfig(m) and then look profiles/targets up by name.
+type Config struct {
+	Profiles map[string]*Profile
+	Targets  map[string]*Target
+
+	// Features maps feature-name → list of feature names (or
+	// "<dep>/<feat>" references) it transitively enables.
+	Features map[string][]string
+
+	// DefaultFeatures is the set of feature names enabled out of the
+	// box. `--no-default-features` on the CLI drops this list to
+	// empty; `--features foo,bar` unions onto whatever remains.
+	DefaultFeatures []string
+}
+
+// Profile looks up a profile by name. Returns (nil, false) when the
+// name is unknown. The built-in profiles (debug, release, profile,
+// test) are always present.
+func (c *Config) Profile(name string) (*Profile, bool) {
+	p, ok := c.Profiles[name]
+	return p, ok
+}
+
+// Target looks up a target by triple. The empty string resolves to
+// the implicit host target (nil returned; callers treat nil as "use
+// host").
+func (c *Config) Target(triple string) (*Target, bool) {
+	if triple == "" {
+		return nil, true
+	}
+	t, ok := c.Targets[triple]
+	return t, ok
+}
+
+// ProfileNames returns the sorted list of known profile names, used
+// by `osty profiles` to pretty-print and by the CLI layer to validate
+// `--profile <name>` inputs.
+func (c *Config) ProfileNames() []string {
+	out := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TargetNames returns the sorted list of known target triples.
+func (c *Config) TargetNames() []string {
+	out := make([]string, 0, len(c.Targets))
+	for name := range c.Targets {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// FeatureNames returns the sorted list of declared feature names.
+func (c *Config) FeatureNames() []string {
+	out := make([]string, 0, len(c.Features))
+	for name := range c.Features {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Defaults returns a Config populated with the four built-in profiles
+// and no custom targets or features. Callers that don't need manifest
+// merging (e.g. `osty profiles` against a dir with no osty.toml) use
+// this directly.
+func Defaults() *Config {
+	return &Config{
+		Profiles: map[string]*Profile{
+			NameDebug: {
+				Name:     NameDebug,
+				OptLevel: 0,
+				Debug:    true,
+				Strip:    false,
+				Overflow: true,
+				Inlining: false,
+				LTO:      false,
+				GoFlags:  []string{"-gcflags=all=-N -l"},
+			},
+			NameRelease: {
+				Name:     NameRelease,
+				OptLevel: 2,
+				Debug:    false,
+				Strip:    true,
+				Overflow: false,
+				Inlining: true,
+				LTO:      true,
+				GoFlags:  []string{"-ldflags=-s -w", "-trimpath"},
+			},
+			NameProfile: {
+				Name:     NameProfile,
+				OptLevel: 2,
+				Debug:    true,
+				Strip:    false,
+				Overflow: false,
+				Inlining: true,
+				LTO:      false,
+				GoFlags:  []string{"-gcflags=all=-l"},
+			},
+			NameTest: {
+				Name:     NameTest,
+				OptLevel: 0,
+				Debug:    true,
+				Strip:    false,
+				Overflow: true,
+				Inlining: false,
+				LTO:      false,
+				GoFlags:  []string{"-gcflags=all=-N -l"},
+			},
+		},
+		Targets:         map[string]*Target{},
+		Features:        map[string][]string{},
+		DefaultFeatures: nil,
+	}
+}
+
+// Resolved is an effective profile — the named profile after inherits
+// expansion + any target-specific env overlay + the chosen feature
+// set. It is the type downstream build invocations consume.
+type Resolved struct {
+	Profile  *Profile
+	Target   *Target
+	Features []string
+}
+
+// OptLevelFlag returns the `-gcflags=-l=<N>` string corresponding to
+// p.OptLevel. Kept as a helper so the backend can substitute its own
+// convention (e.g. switching to LLVM gcc-style `-O<n>` if a future
+// native backend is wired in) without rewriting every call site.
+func (p *Profile) OptLevelFlag() string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("-gcflags=-l=%d", p.OptLevel)
+}
+
+// GoEnv collects the environment overrides this resolved config
+// implies: GOOS, GOARCH, CGO_ENABLED from the target, plus any user
+// env from the profile / target env maps. The returned map is a
+// fresh copy; callers may mutate it freely.
+func (r *Resolved) GoEnv() map[string]string {
+	out := map[string]string{}
+	if r == nil {
+		return out
+	}
+	if r.Profile != nil {
+		for k, v := range r.Profile.Env {
+			out[k] = v
+		}
+	}
+	if r.Target != nil {
+		if r.Target.OS != "" {
+			out["GOOS"] = r.Target.OS
+		}
+		if r.Target.Arch != "" {
+			out["GOARCH"] = r.Target.Arch
+		}
+		if r.Target.CGO != nil {
+			if *r.Target.CGO {
+				out["CGO_ENABLED"] = "1"
+			} else {
+				out["CGO_ENABLED"] = "0"
+			}
+		}
+		for k, v := range r.Target.Env {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// GoFlags returns the flat `go build` flag list for this resolved
+// config. Order: profile-derived flags, then any feature-derived
+// `-tags` invocation synthesized from r.Features. Feature names map
+// 1:1 to Go build tags so conditional gen output (future phase 5)
+// can gate via `//go:build feat_<name>`.
+func (r *Resolved) GoFlags() []string {
+	if r == nil || r.Profile == nil {
+		return nil
+	}
+	flags := append([]string(nil), r.Profile.GoFlags...)
+	if len(r.Features) > 0 {
+		tags := make([]string, 0, len(r.Features))
+		for _, f := range r.Features {
+			tags = append(tags, "feat_"+f)
+		}
+		sort.Strings(tags)
+		flags = append(flags, "-tags="+strings.Join(tags, ","))
+	}
+	return flags
+}
+
+// Resolve builds a Resolved from a profile name, an optional target
+// triple, and the user-requested feature set. Returns an error when
+// the profile or target isn't declared. An empty triple means "host".
+//
+// requestedFeatures is the union of the manifest's default features
+// (when useDefaults is true) and the user's `--features` list; this
+// function then expands each transitively via c.Features.
+func (c *Config) Resolve(profileName, triple string, requestedFeatures []string, useDefaults bool) (*Resolved, error) {
+	if c == nil {
+		return nil, fmt.Errorf("nil profile config")
+	}
+	p, ok := c.Profiles[profileName]
+	if !ok {
+		return nil, fmt.Errorf("unknown profile %q (known: %s)",
+			profileName, strings.Join(c.ProfileNames(), ", "))
+	}
+	var t *Target
+	if triple != "" {
+		tt, ok := c.Targets[triple]
+		if !ok {
+			return nil, fmt.Errorf("unknown target %q", triple)
+		}
+		t = tt
+	}
+	feats := c.expandFeatures(requestedFeatures, useDefaults)
+	return &Resolved{Profile: p, Target: t, Features: feats}, nil
+}
+
+// expandFeatures computes the transitive closure of requested + (if
+// useDefaults is true) default-feature names through c.Features.
+// Unknown feature names are passed through unchanged — feature
+// cross-linking to deps is the concern of the resolver layer, not
+// this package.
+func (c *Config) expandFeatures(requested []string, useDefaults bool) []string {
+	seed := map[string]struct{}{}
+	if useDefaults {
+		for _, f := range c.DefaultFeatures {
+			seed[f] = struct{}{}
+		}
+	}
+	for _, f := range requested {
+		seed[f] = struct{}{}
+	}
+	// BFS through c.Features.
+	out := map[string]struct{}{}
+	queue := make([]string, 0, len(seed))
+	for f := range seed {
+		queue = append(queue, f)
+	}
+	for len(queue) > 0 {
+		f := queue[0]
+		queue = queue[1:]
+		if _, done := out[f]; done {
+			continue
+		}
+		out[f] = struct{}{}
+		for _, child := range c.Features[f] {
+			// "<dep>/<feat>" references are left intact — a future
+			// pkgmgr hook will interpret them. For the local
+			// closure we only recurse on bare feature names.
+			if !strings.Contains(child, "/") {
+				queue = append(queue, child)
+			}
+		}
+	}
+	names := make([]string, 0, len(out))
+	for f := range out {
+		names = append(names, f)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -249,15 +249,30 @@ type Resolved struct {
 	Features []string
 }
 
-// OptLevelFlag returns the `-gcflags=-l=<N>` string corresponding to
-// p.OptLevel. Kept as a helper so the backend can substitute its own
-// convention (e.g. switching to LLVM gcc-style `-O<n>` if a future
-// native backend is wired in) without rewriting every call site.
-func (p *Profile) OptLevelFlag() string {
+// OptLevelFlags returns the `go build` flags implied by p.OptLevel.
+// Mapping:
+//
+//	0  →  -gcflags=all=-N -l        (no opt, no inline — debuggable)
+//	1  →  -gcflags=all=-l           (inline off, optimizations on)
+//	2  →  (empty — Go's default: inline on, opts on)
+//	3  →  (empty; LTO/strip live on Profile.LTO / Profile.Strip)
+//
+// Returned as a slice so the caller can splice it into a larger argv
+// without post-processing. Kept decoupled from GoFlags so a user
+// pinning `opt-level = 0` in the manifest deterministically gets
+// debug flags regardless of what's in the built-in GoFlags.
+func (p *Profile) OptLevelFlags() []string {
 	if p == nil {
-		return ""
+		return nil
 	}
-	return fmt.Sprintf("-gcflags=-l=%d", p.OptLevel)
+	switch p.OptLevel {
+	case 0:
+		return []string{"-gcflags=all=-N -l"}
+	case 1:
+		return []string{"-gcflags=all=-l"}
+	default:
+		return nil
+	}
 }
 
 // GoEnv collects the environment overrides this resolved config
@@ -296,15 +311,41 @@ func (r *Resolved) GoEnv() map[string]string {
 }
 
 // GoFlags returns the flat `go build` flag list for this resolved
-// config. Order: profile-derived flags, then any feature-derived
-// `-tags` invocation synthesized from r.Features. Feature names map
-// 1:1 to Go build tags so conditional gen output (future phase 5)
+// config. Order:
+//
+//  1. OptLevel-derived `-gcflags` (only when OptLevel ∈ {0, 1});
+//     skipped at default levels so the user's GoFlags control alone.
+//  2. Profile.GoFlags from the merged manifest (built-ins + user).
+//     Entries that collide with the OptLevel flag are filtered so
+//     `-gcflags=all=-N -l` doesn't appear twice.
+//  3. `-ldflags=-s -w` when Profile.Strip is true.
+//  4. `-tags=feat_*` synthesized from r.Features.
+//
+// Feature names map 1:1 to Go build tags so conditional gen output
 // can gate via `//go:build feat_<name>`.
 func (r *Resolved) GoFlags() []string {
 	if r == nil || r.Profile == nil {
 		return nil
 	}
-	flags := append([]string(nil), r.Profile.GoFlags...)
+	var flags []string
+	optFlags := r.Profile.OptLevelFlags()
+	flags = append(flags, optFlags...)
+	seen := map[string]bool{}
+	for _, f := range optFlags {
+		seen[f] = true
+	}
+	for _, f := range r.Profile.GoFlags {
+		if seen[f] {
+			continue
+		}
+		flags = append(flags, f)
+		seen[f] = true
+	}
+	stripFlag := "-ldflags=-s -w"
+	if r.Profile.Strip && !seen[stripFlag] {
+		flags = append(flags, stripFlag)
+		seen[stripFlag] = true
+	}
 	if len(r.Features) > 0 {
 		tags := make([]string, 0, len(r.Features))
 		for _, f := range r.Features {
@@ -387,4 +428,99 @@ func (c *Config) expandFeatures(requested []string, useDefaults bool) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// ReadFeaturePragma scans the first ~32 lines of src for a line of
+// the form `// @feature: NAME[, NAME...]` and returns the list of
+// feature names the file requires. Returns nil when no pragma is
+// present.
+//
+// The grammar is intentionally terse — a single-line comment that
+// starts with "@feature:" — so the check doesn't need a parser pass.
+// Callers (build driver, gen emitter) combine this with the active
+// feature set to decide whether the file participates in the build.
+func ReadFeaturePragma(src []byte) []string {
+	const maxLines = 32
+	line := 0
+	start := 0
+	for i := 0; i <= len(src) && line < maxLines; i++ {
+		// Logical line break at '\n' or at EOF.
+		if i < len(src) && src[i] != '\n' {
+			continue
+		}
+		raw := string(src[start:i])
+		trimmed := featTrim(raw)
+		if after, ok := featStrip(trimmed, "// @feature:"); ok {
+			return parseFeatureList(after)
+		}
+		if after, ok := featStrip(trimmed, "//@feature:"); ok {
+			return parseFeatureList(after)
+		}
+		// Stop as soon as we hit a non-comment, non-blank line —
+		// feature pragmas must live at the top of the file.
+		if trimmed != "" && !featHas(trimmed, "//") && !featHas(trimmed, "/*") {
+			return nil
+		}
+		start = i + 1
+		line++
+	}
+	return nil
+}
+
+// FileNeedsFeatures reads src's feature pragma and reports whether
+// every required feature is present in `active`. Files without a
+// pragma are unconditionally included. Returns (ok, missing) where
+// missing is the first feature that wasn't active.
+func FileNeedsFeatures(src []byte, active map[string]bool) (bool, string) {
+	needed := ReadFeaturePragma(src)
+	for _, f := range needed {
+		if !active[f] {
+			return false, f
+		}
+	}
+	return true, ""
+}
+
+func parseFeatureList(s string) []string {
+	var out []string
+	cur := ""
+	flush := func() {
+		t := featTrim(cur)
+		if t != "" {
+			out = append(out, t)
+		}
+		cur = ""
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ',' || c == ' ' || c == '\t' {
+			flush()
+			continue
+		}
+		cur += string(c)
+	}
+	flush()
+	return out
+}
+
+func featTrim(s string) string {
+	i, j := 0, len(s)
+	for i < j && (s[i] == ' ' || s[i] == '\t' || s[i] == '\r') {
+		i++
+	}
+	for j > i && (s[j-1] == ' ' || s[j-1] == '\t' || s[j-1] == '\r') {
+		j--
+	}
+	return s[i:j]
+}
+
+func featStrip(s, p string) (string, bool) {
+	if len(s) >= len(p) && s[:len(p)] == p {
+		return s[len(p):], true
+	}
+	return "", false
+}
+
+func featHas(s, p string) bool {
+	return len(s) >= len(p) && s[:len(p)] == p
 }

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,191 @@
+package profile
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestDefaultProfilesShape asserts the four built-ins are present and
+// carry the expected high-level knobs. Acts as a guard against
+// accidental edits to Defaults() that would silently change what
+// `osty build` emits.
+func TestDefaultProfilesShape(t *testing.T) {
+	c := Defaults()
+	for _, n := range []string{NameDebug, NameRelease, NameProfile, NameTest} {
+		if _, ok := c.Profiles[n]; !ok {
+			t.Errorf("Defaults missing profile %q", n)
+		}
+	}
+	if c.Profiles[NameDebug].Strip {
+		t.Errorf("debug profile should keep symbols (Strip=false)")
+	}
+	if !c.Profiles[NameRelease].Strip {
+		t.Errorf("release profile should strip symbols (Strip=true)")
+	}
+	if c.Profiles[NameRelease].OptLevel <= c.Profiles[NameDebug].OptLevel {
+		t.Errorf("release OptLevel (%d) should exceed debug (%d)",
+			c.Profiles[NameRelease].OptLevel,
+			c.Profiles[NameDebug].OptLevel)
+	}
+}
+
+// TestParseTriple covers the common shapes plus one error path.
+func TestParseTriple(t *testing.T) {
+	cases := []struct {
+		in           string
+		arch, os     string
+		expectError  bool
+	}{
+		{"amd64-linux", "amd64", "linux", false},
+		{"arm64-darwin", "arm64", "darwin", false},
+		{"riscv64-freebsd", "riscv64", "freebsd", false},
+		{"amd64", "", "", true},
+		{"", "", "", true},
+		{"-linux", "", "", true},
+	}
+	for _, tc := range cases {
+		arch, os, err := ParseTriple(tc.in)
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("ParseTriple(%q) expected error, got (%q,%q)", tc.in, arch, os)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseTriple(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if arch != tc.arch || os != tc.os {
+			t.Errorf("ParseTriple(%q) = (%q,%q), want (%q,%q)",
+				tc.in, arch, os, tc.arch, tc.os)
+		}
+	}
+}
+
+// TestResolveHostTarget verifies that an empty triple produces a
+// Resolved with nil Target (the "host" signal for GoEnv).
+func TestResolveHostTarget(t *testing.T) {
+	c := Defaults()
+	r, err := c.Resolve(NameDebug, "", nil, true)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if r.Target != nil {
+		t.Errorf("expected nil target for host, got %+v", r.Target)
+	}
+	env := r.GoEnv()
+	if _, present := env["GOOS"]; present {
+		t.Errorf("host resolve should not set GOOS, got %v", env)
+	}
+}
+
+// TestResolveUnknownProfile asserts the error path for a missing
+// --profile NAME.
+func TestResolveUnknownProfile(t *testing.T) {
+	c := Defaults()
+	if _, err := c.Resolve("nope", "", nil, true); err == nil {
+		t.Fatalf("expected error for unknown profile")
+	}
+}
+
+// TestFeatureExpansion covers default-feature inclusion, explicit
+// request union, and transitive graph walking.
+func TestFeatureExpansion(t *testing.T) {
+	c := Defaults()
+	c.Features = map[string][]string{
+		"full":   {"net", "tls"},
+		"net":    {"async"},
+		"tls":    {"crypto", "dep/openssl"},
+		"async":  nil,
+		"crypto": nil,
+	}
+	c.DefaultFeatures = []string{"net"}
+
+	r, err := c.Resolve(NameDebug, "", []string{"full"}, true)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	got := append([]string(nil), r.Features...)
+	sort.Strings(got)
+	want := []string{"async", "crypto", "full", "net", "tls"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Features = %v, want %v", got, want)
+	}
+
+	r, err = c.Resolve(NameDebug, "", []string{"full"}, false)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// Dropping the default doesn't matter here because "full" already
+	// pulls "net"; sanity check the closure is still the same.
+	if len(r.Features) != 5 {
+		t.Errorf("--no-default-features lost features: %v", r.Features)
+	}
+
+	r, err = c.Resolve(NameDebug, "", nil, false)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(r.Features) != 0 {
+		t.Errorf("no features requested + no-default, want empty, got %v", r.Features)
+	}
+}
+
+// TestGoFlagsIncludesFeatureTags asserts feature names produce a
+// `-tags=feat_<name>` invocation for the Go backend.
+func TestGoFlagsIncludesFeatureTags(t *testing.T) {
+	c := Defaults()
+	r, err := c.Resolve(NameDebug, "", []string{"alpha", "beta"}, false)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	flags := r.GoFlags()
+	seen := false
+	for _, f := range flags {
+		if f == "-tags=feat_alpha,feat_beta" {
+			seen = true
+			break
+		}
+	}
+	if !seen {
+		t.Errorf("expected -tags=feat_alpha,feat_beta in %v", flags)
+	}
+}
+
+// TestGoEnvWithTarget covers GOOS/GOARCH/CGO_ENABLED propagation.
+func TestGoEnvWithTarget(t *testing.T) {
+	c := Defaults()
+	cgoOff := false
+	c.Targets["amd64-linux"] = &Target{
+		Triple: "amd64-linux",
+		Arch:   "amd64",
+		OS:     "linux",
+		CGO:    &cgoOff,
+		Env:    map[string]string{"FOO": "bar"},
+	}
+	r, err := c.Resolve(NameRelease, "amd64-linux", nil, false)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	env := r.GoEnv()
+	if env["GOOS"] != "linux" || env["GOARCH"] != "amd64" {
+		t.Errorf("target env missing: %+v", env)
+	}
+	if env["CGO_ENABLED"] != "0" {
+		t.Errorf("CGO_ENABLED = %q, want 0", env["CGO_ENABLED"])
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("user env lost: %+v", env)
+	}
+}
+
+// TestArtifactKey verifies the file-system naming helper.
+func TestArtifactKey(t *testing.T) {
+	if got := ArtifactKey("debug", ""); got != "debug" {
+		t.Errorf("ArtifactKey(debug,'') = %q", got)
+	}
+	if got := ArtifactKey("release", "amd64-linux"); got != "release-amd64-linux" {
+		t.Errorf("ArtifactKey(release,amd64-linux) = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a first-class build-profile system so users can pick between debug / release / profile / test builds, declare custom profiles, cross-compile by target triple, gate code via feature flags, and benefit from an incremental build cache.

## Components

### `internal/profile` (new)
- `Profile`, `Target`, `Config` types; `Defaults()` supplies the four built-ins (`debug`, `release`, `profile`, `test`).
- `BuildConfig(m)` merges manifest-declared `[profile.*]` / `[target.*]` / `[features]` tables on top of defaults, with one-level inherits.
- `Resolve(profile, triple, features, useDefaults)` returns an effective `*Resolved` whose `GoFlags()` / `GoEnv()` feed straight into `go build`.
- Cache helpers (`Fingerprint`, `HashSources`, `ReadFingerprint`, `ListCache`, `CleanCache`) live alongside so the build command can skip work when sources haven't changed.

### `internal/manifest` extensions
- Parser now accepts `[profile.<name>]` (with `opt-level`, `debug`, `strip`, `overflow-checks`, `inlining`, `lto`, `go-flags`, `env`, `inherits`), `[target.<triple>]` (`cgo`, `env`), and `[features]` (arbitrary feature → list mapping, plus `default`).
- `Has*` flags on `Profile` distinguish *unset* from *set to the zero value*, so merging preserves built-in defaults for fields the manifest didn't touch.

### CLI
- New subcommands: `osty profiles`, `osty targets`, `osty features`, `osty cache [ls|clean|info]`.
- Shared flags on `osty build` and `osty run`: `--profile NAME`, `--release` (shorthand), `--target TRIPLE`, `--features LIST`, `--no-default-features`.
- `osty build --force` bypasses the cache.
- `osty build` now records a per-`(profile, target)` fingerprint under `.osty/cache/` and short-circuits with *"Build is up to date"* when hashes match.
- `osty run` threads profile `go-flags` + target env (`GOOS`, `GOARCH`, `CGO_ENABLED`) into the `go run` child and lands artifacts at `.osty/out/<profile>[-<triple>]/`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/profile/ ./internal/manifest/ ./cmd/...` passing
- [x] Smoke-tested each new subcommand end-to-end in a fresh scaffold:
  - `osty profiles` / `osty profiles -v` in and outside a project
  - `osty targets` / `osty features` against a custom manifest
  - `osty build` (cold + warm cache), `osty build --release`, `osty build --profile bench`, `osty build --force`
  - `osty cache ls` / `info` / `clean`
- [x] Pre-existing `internal/format` test failure confirmed unrelated (present on base branch).