### PR TITLE
registry: add filesystem-backed registry server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ registry (`osty add` / `osty update`), and a test runner
 | Manifest + lockfile + SemVer (`internal/manifest`, `lockfile`, `pkgmgr/semver`) | done (parse + validate + resolve) |
 | Build orchestrator (`osty build`) | wired — drives manifest → front-end → gen Phase 1 |
 | `osty test` (discovery + front-end, `std.testing` stub) | wired — validates test files and reports `test*` / `bench*` fns; runner harness pending |
-| Package registry / `osty add` / `osty update` / `osty run` | not started |
+| Package registry client (`osty add` / `osty update` / `osty publish`) | wired |
+| Package registry server (`cmd/osty-registry`, `internal/registry/server`) | wired — filesystem-backed, token-gated |
+| `osty run` | not started |
 
 The front-end (lex → parse → resolve) is **spec-complete for v0.3**:
 every syntactic construct in `LANG_SPEC_v0.3/` has a positive-corpus
@@ -88,6 +90,7 @@ osty/
 ├── SPEC_GAPS.md             # Resolved-gap archive (no open items in v0.3)
 ├── cmd/
 │   ├── osty/                # Main CLI (`osty` binary)
+│   ├── osty-registry/       # Self-hosted package registry server
 │   └── codesdoc/            # Regenerates ERROR_CODES.md from codes.go
 ├── internal/
 │   ├── token/               # Token kinds + positions
@@ -107,7 +110,9 @@ osty/
 │   ├── tomlparse/           # Generic TOML parser (subset)
 │   ├── manifest/            # osty.toml parse + validate + lookup
 │   ├── lockfile/            # osty.lock read/write
-│   └── pkgmgr/semver/       # SemVer parse, compare, constraint match
+│   ├── pkgmgr/semver/       # SemVer parse, compare, constraint match
+│   ├── registry/            # HTTP client for the registry protocol
+│   └── registry/server/     # Filesystem-backed registry server impl
 └── testdata/                # .osty fixtures used by tests
 ```
 
@@ -252,6 +257,45 @@ error[E0500]: undefined name `name`
 
   1 error(s), 0 warning(s)
 ```
+
+## Running a registry
+
+The `osty-registry` binary is a self-hosted package registry. It stores
+tarballs on local disk, gates publishes behind bearer tokens read from a
+JSON file, and implements exactly the three endpoints the `osty` CLI needs
+(`osty add`, `osty update`, `osty publish`).
+
+```sh
+# Start a registry on :8080 with data in ./registry-data.
+go build -o osty-registry ./cmd/osty-registry
+./osty-registry --root ./registry-data --tokens ./tokens.json
+
+# Point `osty` at it: add to osty.toml
+# [registries.local]
+# url = "http://localhost:8080"
+# token = "abc123"
+osty publish --registry local
+osty add hello@1.0 --registry local
+```
+
+`tokens.json` is a flat list of API tokens with scopes:
+
+```json
+{
+  "tokens": [
+    { "token": "abc123", "owner": "alice", "scopes": ["publish:*"] },
+    { "token": "ci-bot", "owner": "ci",    "scopes": ["publish:hello"] }
+  ]
+}
+```
+
+A scope of `publish:*` lets the token publish any package;
+`publish:<name>` restricts it to one. Send `SIGHUP` to the running
+server to reload `tokens.json` without dropping connections.
+
+See [`internal/registry/server/server.go`](./internal/registry/server/server.go)
+for the HTTP surface and [`cmd/osty-registry/main.go`](./cmd/osty-registry/main.go)
+for the process-level flags.
 
 ## Testing
 

--- a/cmd/osty-registry/main.go
+++ b/cmd/osty-registry/main.go
@@ -1,0 +1,170 @@
+// Command osty-registry runs a self-hosted osty package registry
+// that speaks the HTTP protocol defined in internal/registry/client.go.
+//
+// Usage:
+//
+//	osty-registry --root ./data [--addr :8080] [--tokens ./tokens.json]
+//
+// Flags:
+//
+//	--root    Directory used for package storage. Created if missing.
+//	          Layout is documented at internal/registry/server/storage.go.
+//	--addr    TCP address to listen on. Default ":8080".
+//	--tokens  Path to a JSON file containing publish tokens. Omit for
+//	          a read-only registry (publishes always 401). The file
+//	          is re-read on SIGHUP so tokens can be rotated without a
+//	          restart.
+//	--max-upload-mb  Cap on accepted publish body size, in MiB.
+//	                 Default 16.
+//
+// tokens.json schema:
+//
+//	{
+//	  "tokens": [
+//	    {"token": "abc123", "owner": "alice", "scopes": ["publish:*"]},
+//	    {"token": "ci-bot", "owner": "ci", "scopes": ["publish:hello"]}
+//	  ]
+//	}
+//
+// On a publish, the server:
+//
+//   - Verifies the Bearer token against tokens.json.
+//   - Requires a scope of "publish:<name>" or "publish:*".
+//   - Reads the upload body (bounded by --max-upload-mb), sha256s it,
+//     and rejects if the client's Osty-Checksum disagrees.
+//   - Extracts osty.toml from the tarball to populate the published
+//     version's dependency list in the index.
+//   - Refuses to overwrite an already-published (name, version) pair.
+//
+// The HTTP surface is intentionally small — three client endpoints,
+// a /health probe for load balancers, and a JSON package listing at
+// "/". See internal/registry/server/server.go for the handler code.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/osty/osty/internal/registry/server"
+)
+
+func main() {
+	fs := flag.NewFlagSet("osty-registry", flag.ExitOnError)
+	var (
+		addr       = fs.String("addr", ":8080", "TCP address to listen on")
+		root       = fs.String("root", "", "package storage directory (required)")
+		tokensPath = fs.String("tokens", "", "path to tokens.json (optional; absent = read-only)")
+		maxMB      = fs.Int64("max-upload-mb", 16, "max publish body size in MiB")
+	)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty-registry --root DIR [--addr :8080] [--tokens FILE]")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(os.Args[1:])
+
+	if *root == "" {
+		fmt.Fprintln(os.Stderr, "osty-registry: --root is required")
+		os.Exit(2)
+	}
+	absRoot, err := filepath.Abs(*root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty-registry: %v\n", err)
+		os.Exit(1)
+	}
+
+	storage, err := server.NewStorage(absRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty-registry: storage: %v\n", err)
+		os.Exit(1)
+	}
+	tokens, err := loadTokens(*tokensPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty-registry: tokens: %v\n", err)
+		os.Exit(1)
+	}
+	logger := log.New(os.Stderr, "osty-registry ", log.LstdFlags)
+	srv := server.New(server.Config{
+		Storage:         storage,
+		Tokens:          tokens,
+		MaxTarballBytes: *maxMB << 20,
+		Logger:          logger,
+	})
+
+	// Wire SIGHUP to a tokens.json re-read so operators can add or
+	// rotate tokens without dropping in-flight requests. SIGINT /
+	// SIGTERM drive a graceful shutdown.
+	httpSrv := &http.Server{
+		Addr:              *addr,
+		Handler:           srv,
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		for sig := range signals {
+			switch sig {
+			case syscall.SIGHUP:
+				logger.Printf("SIGHUP: reloading tokens from %q", *tokensPath)
+				reloaded, err := server.LoadTokenDB(*tokensPath)
+				if err != nil {
+					logger.Printf("SIGHUP: token reload failed: %v", err)
+					continue
+				}
+				// Swap the token table in place — the Server still holds
+				// the original *TokenDB, which internally picks up new
+				// entries via Replace.
+				tokensInPlace(tokens, reloaded)
+				logger.Printf("SIGHUP: tokens reloaded")
+			case syscall.SIGINT, syscall.SIGTERM:
+				logger.Printf("received %s, shutting down", sig)
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				_ = httpSrv.Shutdown(ctx)
+				return
+			}
+		}
+	}()
+
+	logger.Printf("listening on %s (root=%s, tokens=%s)", *addr, absRoot, displayPath(*tokensPath))
+	if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Fatalf("listen: %v", err)
+	}
+}
+
+// loadTokens reads tokens.json if a path was given, or returns an
+// empty DB otherwise. An empty DB means no publishes succeed — the
+// server is effectively read-only, which is the right default when
+// an operator hasn't configured auth.
+func loadTokens(path string) (*server.TokenDB, error) {
+	if path == "" {
+		return server.NewTokenDB(nil), nil
+	}
+	return server.LoadTokenDB(path)
+}
+
+// tokensInPlace copies the fresh token list into the live DB so the
+// Server keeps the same *TokenDB pointer across reloads. Replace
+// takes a write lock internally, so in-flight authorizations see a
+// consistent snapshot.
+func tokensInPlace(live, fresh *server.TokenDB) {
+	live.Replace(fresh.Snapshot())
+}
+
+// displayPath renders a config-file path for logs, showing "<none>"
+// when the operator omitted the flag so the read-only mode is
+// unambiguous in the startup banner.
+func displayPath(p string) string {
+	if p == "" {
+		return "<none>"
+	}
+	return p
+}

--- a/internal/registry/server/auth.go
+++ b/internal/registry/server/auth.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+// ErrUnauthorized is returned when an incoming token is unknown or
+// has no scope for the requested operation. Handlers translate this
+// to HTTP 401 (missing / unknown token) or 403 (known but insufficient
+// scope) depending on the cause.
+var ErrUnauthorized = errors.New("unauthorized")
+
+// ErrForbidden signals a known token whose scopes do not permit the
+// operation. Kept distinct from ErrUnauthorized so handlers can pick
+// the right status code.
+var ErrForbidden = errors.New("forbidden")
+
+// Token is one entry in the tokens.json file. Scopes is a list of
+// scope strings:
+//
+//	publish:*          publish any package
+//	publish:<name>     publish this package only
+//	admin:yank         mark versions yanked / unyanked
+//
+// Owner is informational — surfaced in logs so operators can trace
+// a publish back to a person or CI job.
+type Token struct {
+	Token  string   `json:"token"`
+	Owner  string   `json:"owner,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// TokenDB is the in-memory token table. It is loaded from
+// tokens.json at server startup and can be swapped out at runtime
+// via Replace; handlers call Authorize under a read lock.
+type TokenDB struct {
+	mu     sync.RWMutex
+	tokens []Token
+}
+
+// LoadTokenDB reads tokens.json from path. A missing file yields an
+// empty DB (useful in dev — the operator creates tokens.json out of
+// band and the server picks it up on restart).
+func LoadTokenDB(path string) (*TokenDB, error) {
+	db := &TokenDB{}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return db, nil
+		}
+		return nil, err
+	}
+	var wire struct {
+		Tokens []Token `json:"tokens"`
+	}
+	if err := json.Unmarshal(b, &wire); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	db.tokens = wire.Tokens
+	return db, nil
+}
+
+// NewTokenDB builds a DB from an in-memory slice. Useful for tests
+// and programmatic embedding.
+func NewTokenDB(tokens []Token) *TokenDB {
+	return &TokenDB{tokens: append([]Token(nil), tokens...)}
+}
+
+// Replace atomically swaps the token list. cmd/osty-registry calls
+// this on SIGHUP to pick up edits to tokens.json.
+func (db *TokenDB) Replace(tokens []Token) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.tokens = append([]Token(nil), tokens...)
+}
+
+// Snapshot returns a copy of the current token list. Used by the
+// SIGHUP reload path to move tokens between two *TokenDB values
+// without exposing the internal slice.
+func (db *TokenDB) Snapshot() []Token {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	return append([]Token(nil), db.tokens...)
+}
+
+// Authorize checks whether `bearer` is known and has a scope that
+// satisfies `need`. Need is a scope string — "publish:<name>" or a
+// broader scope like "publish:*". ConstantTimeCompare is used on
+// token comparison so a rogue client can't time-attack the table.
+func (db *TokenDB) Authorize(bearer, need string) error {
+	if bearer == "" {
+		return ErrUnauthorized
+	}
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	for _, t := range db.tokens {
+		if subtle.ConstantTimeCompare([]byte(t.Token), []byte(bearer)) != 1 {
+			continue
+		}
+		// Token matched. Now check scopes.
+		for _, scope := range t.Scopes {
+			if scopeMatches(scope, need) {
+				return nil
+			}
+		}
+		return ErrForbidden
+	}
+	return ErrUnauthorized
+}
+
+// scopeMatches returns true if `have` grants `need`. The matcher
+// supports a single trailing wildcard:
+//
+//	have="publish:*"   need="publish:foo"  → true
+//	have="publish:foo" need="publish:foo"  → true
+//	have="publish:foo" need="publish:bar"  → false
+func scopeMatches(have, need string) bool {
+	if have == need {
+		return true
+	}
+	if strings.HasSuffix(have, ":*") {
+		prefix := strings.TrimSuffix(have, "*")
+		return strings.HasPrefix(need, prefix)
+	}
+	return false
+}
+
+// parseBearer extracts the token from an `Authorization: Bearer xyz`
+// header value. Returns "" when the header is missing or malformed,
+// in which case callers should respond 401.
+func parseBearer(header string) string {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(prefix):])
+}

--- a/internal/registry/server/server.go
+++ b/internal/registry/server/server.go
@@ -1,0 +1,411 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/registry"
+)
+
+// DefaultMaxTarballBytes caps the size of a publish body. 16 MiB is
+// generous for a language still specifying its stdlib and comfortably
+// below Go's default server memory footprint.
+const DefaultMaxTarballBytes = 16 << 20
+
+// Config wires the ingredients of a Server together. Zero value is
+// not usable; use New.
+type Config struct {
+	Storage *Storage
+	Tokens  *TokenDB
+
+	// MaxTarballBytes bounds the accepted upload size. Zero picks
+	// DefaultMaxTarballBytes.
+	MaxTarballBytes int64
+
+	// Logger receives one line per request. nil uses log.Default().
+	Logger *log.Logger
+}
+
+// Server is the HTTP handler. It implements http.Handler; mount it
+// at "/" of any ServeMux or serve it directly with http.ListenAndServe.
+type Server struct {
+	cfg Config
+	mux *http.ServeMux
+	log *log.Logger
+	max int64
+}
+
+// New returns a Server configured with cfg. It panics if Storage or
+// Tokens are nil — those are programming errors, not runtime
+// failures worth surfacing as an error path.
+func New(cfg Config) *Server {
+	if cfg.Storage == nil {
+		panic("registry/server: Storage is nil")
+	}
+	if cfg.Tokens == nil {
+		panic("registry/server: Tokens is nil")
+	}
+	s := &Server{
+		cfg: cfg,
+		mux: http.NewServeMux(),
+		log: cfg.Logger,
+		max: cfg.MaxTarballBytes,
+	}
+	if s.log == nil {
+		s.log = log.Default()
+	}
+	if s.max == 0 {
+		s.max = DefaultMaxTarballBytes
+	}
+	// Only one pattern is registered at the mux — everything under
+	// /v1/ is routed inside handleV1 so we can do custom method-based
+	// dispatch without juggling six StripPrefix wrappers.
+	s.mux.HandleFunc("/v1/crates/", s.handleV1)
+	s.mux.HandleFunc("/v1/crates", s.handleV1)
+	s.mux.HandleFunc("/health", s.handleHealth)
+	s.mux.HandleFunc("/", s.handleRoot)
+	return s
+}
+
+// ServeHTTP implements http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+// handleHealth is a cheap liveness probe for load balancers.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = io.WriteString(w, "ok\n")
+}
+
+// handleRoot is the human-facing landing page. It lists packages so
+// an operator can eyeball what's published; GETs under /v1/ are
+// routed elsewhere.
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	names, err := s.cfg.Storage.List()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "list packages: %v", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"registry": "osty",
+		"version":  "v1",
+		"packages": names,
+	})
+}
+
+// handleV1 dispatches every /v1/crates/* path based on the number of
+// segments after "crates":
+//
+//	/v1/crates/<name>           → GET: index
+//	/v1/crates/<name>/<ver>     → PUT: publish
+//	/v1/crates/<name>/<ver>/tar → GET: download
+func (s *Server) handleV1(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/crates")
+	rest = strings.TrimPrefix(rest, "/")
+	if rest == "" {
+		// Reserved for a future package-listing endpoint; for now 404
+		// so clients that stumble here get a clear signal.
+		http.NotFound(w, r)
+		return
+	}
+	parts := strings.Split(rest, "/")
+	// Percent-decode each path segment — Go's mux leaves them raw.
+	for i := range parts {
+		if decoded, err := url.PathUnescape(parts[i]); err == nil {
+			parts[i] = decoded
+		}
+	}
+	switch len(parts) {
+	case 1:
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleIndex(w, r, parts[0])
+	case 2:
+		if r.Method != http.MethodPut {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handlePublish(w, r, parts[0], parts[1])
+	case 3:
+		if parts[2] != "tar" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleDownload(w, r, parts[0], parts[1])
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleIndex serves GET /v1/crates/<name>.
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request, name string) {
+	idx, err := s.cfg.Storage.Index(name)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			s.writeError(w, http.StatusNotFound, "package %q not found", name)
+			return
+		}
+		s.writeError(w, http.StatusBadRequest, "%v", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(idx)
+	s.log.Printf("GET  /v1/crates/%s → 200 (%d versions)", name, len(idx.Versions))
+}
+
+// handleDownload serves GET /v1/crates/<name>/<version>/tar.
+func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request, name, version string) {
+	rc, err := s.cfg.Storage.OpenTarball(name, version)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			s.writeError(w, http.StatusNotFound, "%s@%s not found", name, version)
+			return
+		}
+		s.writeError(w, http.StatusBadRequest, "%v", err)
+		return
+	}
+	defer rc.Close()
+	w.Header().Set("Content-Type", "application/x-tar+gzip")
+	// The client checks the sha256 against the registry-advertised
+	// hash; surfacing the checksum here gives operators a sanity
+	// check without re-hashing.
+	if idx, err := s.cfg.Storage.Index(name); err == nil {
+		for _, v := range idx.Versions {
+			if v.Version == version {
+				w.Header().Set("Osty-Checksum", v.Checksum)
+				break
+			}
+		}
+	}
+	n, _ := io.Copy(w, rc)
+	s.log.Printf("GET  /v1/crates/%s/%s/tar → 200 (%d bytes)", name, version, n)
+}
+
+// handlePublish serves PUT /v1/crates/<name>/<version>. The flow:
+//
+//  1. Verify Authorization: Bearer token, scope `publish:<name>`.
+//  2. Read the whole body into memory (bounded by MaxTarballBytes)
+//     and sha256 it.
+//  3. If the client sent Osty-Checksum, verify it matches; if not,
+//     use our own computed checksum as authoritative.
+//  4. Extract osty.toml from inside the tarball to harvest the
+//     declared dependencies into the index entry.
+//  5. Storage.Publish writes the blob + rewrites the index.
+func (s *Server) handlePublish(w http.ResponseWriter, r *http.Request, name, version string) {
+	token := parseBearer(r.Header.Get("Authorization"))
+	if err := s.cfg.Tokens.Authorize(token, "publish:"+name); err != nil {
+		if errors.Is(err, ErrForbidden) {
+			s.writeError(w, http.StatusForbidden, "token is not authorized to publish %q", name)
+			return
+		}
+		s.writeError(w, http.StatusUnauthorized, "missing or invalid token")
+		return
+	}
+	if err := ValidateName(name); err != nil {
+		s.writeError(w, http.StatusBadRequest, "%v", err)
+		return
+	}
+	if err := ValidateVersion(version); err != nil {
+		s.writeError(w, http.StatusBadRequest, "%v", err)
+		return
+	}
+
+	// Bound the upload size. http.MaxBytesReader converts overrun
+	// into a specific error at Read time.
+	r.Body = http.MaxBytesReader(w, r.Body, s.max)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.writeError(w, http.StatusRequestEntityTooLarge,
+			"upload exceeds %d bytes or read failed: %v", s.max, err)
+		return
+	}
+	if len(body) == 0 {
+		s.writeError(w, http.StatusBadRequest, "empty body")
+		return
+	}
+
+	sum := sha256.Sum256(body)
+	computed := "sha256:" + hex.EncodeToString(sum[:])
+	if declared := r.Header.Get("Osty-Checksum"); declared != "" && declared != computed {
+		s.writeError(w, http.StatusBadRequest,
+			"Osty-Checksum mismatch: header=%s computed=%s", declared, computed)
+		return
+	}
+
+	// Parse the Osty-Metadata header (URL-encoded JSON, as the client
+	// serializes it in registry.Client.Publish).
+	var meta registry.PublishMetadata
+	if raw := r.Header.Get("Osty-Metadata"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+			s.writeError(w, http.StatusBadRequest, "invalid Osty-Metadata: %v", err)
+			return
+		}
+	}
+
+	// Peek inside the tarball for osty.toml so the index carries the
+	// package's declared deps + declared version (sanity check).
+	pkgName, pkgVersion, deps, err := extractManifestFromTarball(body)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "reading osty.toml from tarball: %v", err)
+		return
+	}
+	if pkgName != "" && pkgName != name {
+		s.writeError(w, http.StatusBadRequest,
+			"manifest package.name %q does not match URL name %q", pkgName, name)
+		return
+	}
+	if pkgVersion != "" && pkgVersion != version {
+		s.writeError(w, http.StatusBadRequest,
+			"manifest package.version %q does not match URL version %q", pkgVersion, version)
+		return
+	}
+
+	if err := s.cfg.Storage.Publish(PublishInput{
+		Name:         name,
+		Version:      version,
+		Checksum:     computed,
+		Tarball:      body,
+		Metadata:     meta,
+		Dependencies: deps,
+	}); err != nil {
+		if errors.Is(err, ErrVersionExists) {
+			s.writeError(w, http.StatusConflict, "%s@%s already published", name, version)
+			return
+		}
+		s.writeError(w, http.StatusInternalServerError, "publish: %v", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"name":     name,
+		"version":  version,
+		"checksum": computed,
+	})
+	s.log.Printf("PUT  /v1/crates/%s/%s → 201 (%d bytes, %s)", name, version, len(body), shortSum(computed))
+}
+
+// writeError sends a plaintext error body. The HTTP client surfaces
+// this body verbatim to the user, so keep the message terse and
+// actionable.
+func (s *Server) writeError(w http.ResponseWriter, code int, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	http.Error(w, msg, code)
+}
+
+// extractManifestFromTarball reads osty.toml out of a gzipped tar
+// archive without writing to disk. Returns the declared package
+// name, version, and dependency list. Missing osty.toml is not an
+// error — the registry is tolerant of archives produced by older
+// tooling, and deps just stay empty in the index.
+func extractManifestFromTarball(body []byte) (name, version string, deps []registry.VersionDependency, err error) {
+	gz, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return "", "", nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return "", "", nil, nil
+		}
+		if err != nil {
+			return "", "", nil, err
+		}
+		// Tarballs produced by pkgmgr.CreateTarGz put files at the
+		// archive root (no wrapping directory), so both "osty.toml"
+		// and "<pkg>/osty.toml" shapes are accepted.
+		if path.Base(hdr.Name) != manifest.ManifestFile {
+			continue
+		}
+		// Only accept a top-level or once-nested osty.toml. Deeper
+		// paths likely belong to a vendored dep that slipped into the
+		// archive and shouldn't drive the registry's index.
+		depth := strings.Count(strings.Trim(hdr.Name, "/"), "/")
+		if depth > 1 {
+			continue
+		}
+		const maxManifestBytes = 1 << 20
+		buf, err := io.ReadAll(io.LimitReader(tr, maxManifestBytes))
+		if err != nil {
+			return "", "", nil, err
+		}
+		m, perr := manifest.Parse(buf)
+		if perr != nil {
+			return "", "", nil, fmt.Errorf("parse osty.toml: %w", perr)
+		}
+		for _, d := range m.Dependencies {
+			if d.VersionReq == "" {
+				// path/git deps are skipped in the public index —
+				// they only make sense in the publishing workspace.
+				continue
+			}
+			deps = append(deps, registry.VersionDependency{
+				Name: d.Name,
+				Req:  d.VersionReq,
+				Kind: "normal",
+			})
+		}
+		for _, d := range m.DevDependencies {
+			if d.VersionReq == "" {
+				continue
+			}
+			deps = append(deps, registry.VersionDependency{
+				Name: d.Name,
+				Req:  d.VersionReq,
+				Kind: "dev",
+			})
+		}
+		if m.HasPackage {
+			return m.Package.Name, m.Package.Version, deps, nil
+		}
+		return "", "", deps, nil
+	}
+}
+
+// shortSum renders the first 10 hex chars of a "sha256:<hex>" string
+// for log lines.
+func shortSum(sum string) string {
+	const prefix = "sha256:"
+	if strings.HasPrefix(sum, prefix) {
+		sum = sum[len(prefix):]
+	}
+	if len(sum) > 10 {
+		sum = sum[:10]
+	}
+	return sum
+}

--- a/internal/registry/server/server_test.go
+++ b/internal/registry/server/server_test.go
@@ -1,0 +1,348 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/registry"
+)
+
+// newTestServer wires a Server on top of a temp-dir storage and a
+// single-token auth table. Returns the httptest.Server; tests call
+// srv.URL with the existing registry client.
+func newTestServer(t *testing.T, token string) (*httptest.Server, *Storage) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := NewStorage(dir)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	tokens := NewTokenDB([]Token{
+		{Token: token, Owner: "test", Scopes: []string{"publish:*"}},
+	})
+	// Silent logger: tests don't care about access log output and we
+	// don't want them to spam go test -v.
+	s := New(Config{
+		Storage: st,
+		Tokens:  tokens,
+		Logger:  nopLogger(t),
+	})
+	return httptest.NewServer(s), st
+}
+
+// makeTarball builds a .tgz containing only osty.toml with the given
+// manifest body. Mirrors the archive shape pkgmgr.CreateTarGz
+// produces for a real osty package.
+func makeTarball(t *testing.T, manifestBody string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "osty.toml",
+		Mode: 0o644,
+		Size: int64(len(manifestBody)),
+	}); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	if _, err := tw.Write([]byte(manifestBody)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz.Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+const sampleManifest = `
+[package]
+name = "hello"
+version = "1.2.3"
+edition = "0.3"
+
+[dependencies]
+json = "^0.3"
+`
+
+// TestPublishThenFetchRoundTrip drives the full publish → index →
+// download loop through the official client. This is the integration
+// test the whole package exists for.
+func TestPublishThenFetchRoundTrip(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+
+	tarball := makeTarball(t, sampleManifest)
+	sum := sha256.Sum256(tarball)
+	checksum := "sha256:" + hex.EncodeToString(sum[:])
+
+	c := registry.NewClient(srv.URL)
+	c.Token = "secret"
+	err := c.Publish(context.Background(), registry.PublishRequest{
+		Name:     "hello",
+		Version:  "1.2.3",
+		Checksum: checksum,
+		Tarball:  bytes.NewReader(tarball),
+		Metadata: registry.PublishMetadata{Description: "hi", License: "MIT"},
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Index should list the new version with the deps the server
+	// extracted from osty.toml.
+	vs, err := c.Versions(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Versions: %v", err)
+	}
+	if len(vs) != 1 {
+		t.Fatalf("want 1 version, got %d", len(vs))
+	}
+	if vs[0].Version != "1.2.3" {
+		t.Errorf("version: got %q, want %q", vs[0].Version, "1.2.3")
+	}
+	if vs[0].Checksum != checksum {
+		t.Errorf("checksum: got %q, want %q", vs[0].Checksum, checksum)
+	}
+	if len(vs[0].Dependencies) != 1 || vs[0].Dependencies[0].Name != "json" {
+		t.Errorf("dependencies: got %+v", vs[0].Dependencies)
+	}
+
+	// Download should yield the exact bytes we published.
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "pkg.tgz")
+	if err := c.DownloadTarball(context.Background(), "hello", "1.2.3", dest); err != nil {
+		t.Fatalf("DownloadTarball: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, tarball) {
+		t.Errorf("downloaded bytes differ from published bytes")
+	}
+}
+
+// TestPublishRejectsBadToken ensures an unknown token → 401 and a
+// known token with the wrong scope → 403.
+func TestPublishRejectsBadToken(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	tarball := makeTarball(t, sampleManifest)
+
+	c := registry.NewClient(srv.URL)
+	c.Token = "nope"
+	err := c.Publish(context.Background(), registry.PublishRequest{
+		Name: "hello", Version: "1.2.3",
+		Tarball: bytes.NewReader(tarball),
+	})
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("want 401, got %v", err)
+	}
+}
+
+// TestPublishRejectsChecksumMismatch — if the client claims a
+// checksum the server didn't compute, reject with 400.
+func TestPublishRejectsChecksumMismatch(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	tarball := makeTarball(t, sampleManifest)
+
+	c := registry.NewClient(srv.URL)
+	c.Token = "secret"
+	err := c.Publish(context.Background(), registry.PublishRequest{
+		Name: "hello", Version: "1.2.3",
+		Checksum: "sha256:deadbeef",
+		Tarball:  bytes.NewReader(tarball),
+	})
+	if err == nil || !strings.Contains(err.Error(), "Osty-Checksum mismatch") {
+		t.Errorf("want mismatch error, got %v", err)
+	}
+}
+
+// TestPublishRejectsNameMismatch — manifest name must match URL.
+func TestPublishRejectsNameMismatch(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	tarball := makeTarball(t, sampleManifest) // package.name = "hello"
+
+	c := registry.NewClient(srv.URL)
+	c.Token = "secret"
+	sum := sha256.Sum256(tarball)
+	err := c.Publish(context.Background(), registry.PublishRequest{
+		Name: "world", Version: "1.2.3",
+		Checksum: "sha256:" + hex.EncodeToString(sum[:]),
+		Tarball:  bytes.NewReader(tarball),
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("want name-mismatch error, got %v", err)
+	}
+}
+
+// TestPublishDuplicateVersion — a second publish of the same
+// (name,version) → 409.
+func TestPublishDuplicateVersion(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	tarball := makeTarball(t, sampleManifest)
+	sum := sha256.Sum256(tarball)
+	checksum := "sha256:" + hex.EncodeToString(sum[:])
+
+	c := registry.NewClient(srv.URL)
+	c.Token = "secret"
+	pub := func() error {
+		return c.Publish(context.Background(), registry.PublishRequest{
+			Name: "hello", Version: "1.2.3",
+			Checksum: checksum,
+			Tarball:  bytes.NewReader(tarball),
+		})
+	}
+	if err := pub(); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	err := pub()
+	if err == nil || !strings.Contains(err.Error(), "already published") {
+		t.Errorf("want 409 already published, got %v", err)
+	}
+}
+
+// TestScopedTokenOnlyPublishesOnePackage verifies scope enforcement —
+// a token with publish:foo must not be able to publish bar.
+func TestScopedTokenOnlyPublishesOnePackage(t *testing.T) {
+	dir := t.TempDir()
+	st, err := NewStorage(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokens := NewTokenDB([]Token{
+		{Token: "narrow", Scopes: []string{"publish:hello"}},
+	})
+	srv := httptest.NewServer(New(Config{Storage: st, Tokens: tokens, Logger: nopLogger(t)}))
+	defer srv.Close()
+
+	tarball := makeTarball(t, sampleManifest)
+	sum := sha256.Sum256(tarball)
+	checksum := "sha256:" + hex.EncodeToString(sum[:])
+	c := registry.NewClient(srv.URL)
+	c.Token = "narrow"
+
+	// "hello" allowed.
+	if err := c.Publish(context.Background(), registry.PublishRequest{
+		Name: "hello", Version: "1.2.3", Checksum: checksum,
+		Tarball: bytes.NewReader(tarball),
+	}); err != nil {
+		t.Fatalf("expected hello to publish, got %v", err)
+	}
+	// Building a second tarball for name "other" so the body validates.
+	otherTB := makeTarball(t, strings.Replace(sampleManifest, `name = "hello"`, `name = "other"`, 1))
+	sum2 := sha256.Sum256(otherTB)
+	err = c.Publish(context.Background(), registry.PublishRequest{
+		Name: "other", Version: "1.0.0",
+		Checksum: "sha256:" + hex.EncodeToString(sum2[:]),
+		Tarball:  bytes.NewReader(otherTB),
+	})
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Errorf("want 403 for scoped token, got %v", err)
+	}
+}
+
+// TestIndexMissingPackage — 404 with a useful error body.
+func TestIndexMissingPackage(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/v1/crates/ghost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: %d", resp.StatusCode)
+	}
+}
+
+// TestHealth — simple probe.
+func TestHealth(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status: %d", resp.StatusCode)
+	}
+}
+
+// TestYankHidesVersionFromClient — yanking should make the client's
+// Versions() drop the entry.
+func TestYankHidesVersionFromClient(t *testing.T) {
+	srv, st := newTestServer(t, "secret")
+	defer srv.Close()
+	tarball := makeTarball(t, sampleManifest)
+	sum := sha256.Sum256(tarball)
+	checksum := "sha256:" + hex.EncodeToString(sum[:])
+
+	c := registry.NewClient(srv.URL)
+	c.Token = "secret"
+	if err := c.Publish(context.Background(), registry.PublishRequest{
+		Name: "hello", Version: "1.2.3", Checksum: checksum,
+		Tarball: bytes.NewReader(tarball),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Yank("hello", "1.2.3", true); err != nil {
+		t.Fatal(err)
+	}
+	vs, err := c.Versions(context.Background(), "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 0 {
+		t.Errorf("yanked version still visible: %+v", vs)
+	}
+}
+
+// TestRootListsPackages — operator-facing endpoint.
+func TestRootListsPackages(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	defer srv.Close()
+	tarball := makeTarball(t, sampleManifest)
+	sum := sha256.Sum256(tarball)
+	c := registry.NewClient(srv.URL)
+	c.Token = "secret"
+	if err := c.Publish(context.Background(), registry.PublishRequest{
+		Name: "hello", Version: "1.2.3",
+		Checksum: "sha256:" + hex.EncodeToString(sum[:]),
+		Tarball:  bytes.NewReader(tarball),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Packages []string `json:"packages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Packages) != 1 || body.Packages[0] != "hello" {
+		t.Errorf("packages: %+v", body.Packages)
+	}
+}

--- a/internal/registry/server/storage.go
+++ b/internal/registry/server/storage.go
@@ -1,0 +1,350 @@
+// Package server implements the HTTP service side of the osty
+// registry protocol defined in internal/registry/client.go.
+//
+// The server is deliberately small: a filesystem-backed storage
+// layout, a token-gated publish endpoint, and read-only index /
+// tarball endpoints. It can be run on its own (cmd/osty-registry)
+// or embedded as an http.Handler in another Go binary.
+//
+// Storage layout on disk (rooted at Storage.Root):
+//
+//	<root>/
+//	  crates/
+//	    <name>/
+//	      index.json             ← IndexEntry, rewritten on every publish
+//	      <version>/
+//	        package.tgz          ← raw upload body
+//	        metadata.json        ← PublishMetadata mirror (for listing pages)
+//	  tokens.json                ← TokenDB (see auth.go)
+//
+// The layout is human-inspectable by design — a registry operator can
+// hand-edit index.json to yank a version or rotate tokens without
+// running a separate admin tool.
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/osty/osty/internal/registry"
+)
+
+// ErrNotFound is returned by Storage when a package or version does
+// not exist. Callers translate this to HTTP 404.
+var ErrNotFound = errors.New("not found")
+
+// ErrVersionExists is returned when a publish would overwrite an
+// already-published, non-yanked version. Callers translate this to
+// HTTP 409.
+var ErrVersionExists = errors.New("version already published")
+
+// namePattern constrains package names to the same character set the
+// CLI accepts in `osty.toml`: ASCII letters, digits, underscores,
+// and dashes. Rejecting anything else keeps filesystem storage safe
+// from path traversal.
+var namePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
+
+// versionPattern is a loose SemVer-ish filter — strict parsing
+// happens in the pkgmgr/semver package when a client resolves a dep.
+// We only enforce "no path separators, reasonable shape" here.
+var versionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.\-]+)?$`)
+
+// ValidateName reports whether name is acceptable on this registry.
+func ValidateName(name string) error {
+	if !namePattern.MatchString(name) {
+		return fmt.Errorf("invalid package name %q (allowed: [A-Za-z0-9_-], 1..64 chars, must start with alnum)", name)
+	}
+	return nil
+}
+
+// ValidateVersion reports whether version is a well-formed SemVer.
+func ValidateVersion(version string) error {
+	if !versionPattern.MatchString(version) {
+		return fmt.Errorf("invalid version %q (expected MAJOR.MINOR.PATCH[-prerelease][+build])", version)
+	}
+	return nil
+}
+
+// Storage is a filesystem-backed registry backend. All methods are
+// safe for concurrent use; a single sync.Mutex serializes index
+// mutations. Read operations release the lock before touching disk,
+// so slow tarball streams do not block publishes.
+type Storage struct {
+	Root string
+
+	mu sync.Mutex
+}
+
+// NewStorage returns a Storage rooted at root. The directory is
+// created if missing. Callers pass an absolute path in production;
+// tests pass t.TempDir().
+func NewStorage(root string) (*Storage, error) {
+	if root == "" {
+		return nil, fmt.Errorf("registry storage root must not be empty")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Join(abs, "crates"), 0o755); err != nil {
+		return nil, err
+	}
+	return &Storage{Root: abs}, nil
+}
+
+// Index returns the IndexEntry for name. Yanked versions are
+// included in the response — the client filters them on read.
+// Returns ErrNotFound if the package has never been published.
+func (s *Storage) Index(name string) (*registry.IndexEntry, error) {
+	if err := ValidateName(name); err != nil {
+		return nil, err
+	}
+	p := s.indexPath(name)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	var idx registry.IndexEntry
+	if err := json.Unmarshal(b, &idx); err != nil {
+		return nil, fmt.Errorf("corrupt index %s: %w", p, err)
+	}
+	return &idx, nil
+}
+
+// OpenTarball returns an open file handle for a published tarball.
+// Caller is responsible for Closing it. Returns ErrNotFound if the
+// version does not exist.
+func (s *Storage) OpenTarball(name, version string) (io.ReadCloser, error) {
+	if err := ValidateName(name); err != nil {
+		return nil, err
+	}
+	if err := ValidateVersion(version); err != nil {
+		return nil, err
+	}
+	f, err := os.Open(s.tarballPath(name, version))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return f, nil
+}
+
+// PublishInput carries everything Publish needs to commit a new
+// version. Tarball is the raw `.tgz` bytes already validated against
+// Checksum by the HTTP layer.
+type PublishInput struct {
+	Name         string
+	Version      string
+	Checksum     string // "sha256:<hex>"
+	Tarball      []byte
+	Metadata     registry.PublishMetadata
+	Dependencies []registry.VersionDependency
+	Features     map[string][]string
+	PublishedAt  time.Time
+}
+
+// Publish writes a new version. It rejects re-publishing an existing
+// version (ErrVersionExists) — the registry is append-only from a
+// client's perspective.
+//
+// The sequence is deliberately "write blob first, then rewrite
+// index" so a crash mid-publish leaves a harmless orphan tarball
+// rather than a dangling index entry pointing at a missing file.
+func (s *Storage) Publish(in PublishInput) error {
+	if err := ValidateName(in.Name); err != nil {
+		return err
+	}
+	if err := ValidateVersion(in.Version); err != nil {
+		return err
+	}
+	if len(in.Tarball) == 0 {
+		return fmt.Errorf("empty tarball")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Reject duplicate versions.
+	if _, err := os.Stat(s.tarballPath(in.Name, in.Version)); err == nil {
+		return ErrVersionExists
+	}
+
+	versionDir := s.versionDir(in.Name, in.Version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		return err
+	}
+	if err := writeFileAtomic(filepath.Join(versionDir, "package.tgz"), in.Tarball, 0o644); err != nil {
+		return err
+	}
+	metaBytes, err := json.MarshalIndent(in.Metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(filepath.Join(versionDir, "metadata.json"), metaBytes, 0o644); err != nil {
+		return err
+	}
+
+	// Load-or-create the index and append this version.
+	var idx registry.IndexEntry
+	if b, err := os.ReadFile(s.indexPath(in.Name)); err == nil {
+		if err := json.Unmarshal(b, &idx); err != nil {
+			return fmt.Errorf("corrupt index: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if idx.Name == "" {
+		idx.Name = in.Name
+	}
+	at := in.PublishedAt
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	idx.Versions = append(idx.Versions, registry.Version{
+		Version:      in.Version,
+		Checksum:     in.Checksum,
+		PublishedAt:  at,
+		Yanked:       false,
+		Dependencies: in.Dependencies,
+		Features:     in.Features,
+	})
+	// Sort by PublishedAt so the listing has a stable order; ties
+	// broken by version string. Callers do semver ranking themselves.
+	sort.SliceStable(idx.Versions, func(i, j int) bool {
+		if !idx.Versions[i].PublishedAt.Equal(idx.Versions[j].PublishedAt) {
+			return idx.Versions[i].PublishedAt.Before(idx.Versions[j].PublishedAt)
+		}
+		return idx.Versions[i].Version < idx.Versions[j].Version
+	})
+	out, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(s.indexPath(in.Name), out, 0o644)
+}
+
+// Yank marks a version as yanked without deleting its tarball. An
+// unyank is a Yank with yanked=false. Returns ErrNotFound if the
+// package or version is unknown.
+func (s *Storage) Yank(name, version string, yanked bool) error {
+	if err := ValidateName(name); err != nil {
+		return err
+	}
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, err := os.ReadFile(s.indexPath(name))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrNotFound
+		}
+		return err
+	}
+	var idx registry.IndexEntry
+	if err := json.Unmarshal(b, &idx); err != nil {
+		return err
+	}
+	found := false
+	for i := range idx.Versions {
+		if idx.Versions[i].Version == version {
+			idx.Versions[i].Yanked = yanked
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrNotFound
+	}
+	out, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(s.indexPath(name), out, 0o644)
+}
+
+// List returns the names of every package with at least one
+// published version, in lexicographic order. Used by the root
+// endpoint so operators can browse the registry contents.
+func (s *Storage) List() ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(s.Root, "crates"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(s.Root, "crates", e.Name(), "index.json")); err == nil {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (s *Storage) indexPath(name string) string {
+	return filepath.Join(s.Root, "crates", name, "index.json")
+}
+
+func (s *Storage) versionDir(name, version string) string {
+	return filepath.Join(s.Root, "crates", name, version)
+}
+
+func (s *Storage) tarballPath(name, version string) string {
+	return filepath.Join(s.versionDir(name, version), "package.tgz")
+}
+
+// writeFileAtomic writes data to a sibling temp file then renames it
+// over path. On POSIX filesystems rename is atomic, so readers see
+// either the old or new file, never a half-written one.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/registry/server/testutil_test.go
+++ b/internal/registry/server/testutil_test.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"io"
+	"log"
+	"testing"
+)
+
+// nopLogger returns a *log.Logger that discards output. Used in
+// tests so publish/download traces don't pollute `go test -v` output.
+func nopLogger(t *testing.T) *log.Logger {
+	t.Helper()
+	return log.New(io.Discard, "", 0)
+}


### PR DESCRIPTION
## Summary

The client side of the osty package registry (`osty add`, `osty update`, `osty publish`) already spoke a small HTTP protocol but had no server to talk to. This PR lands that server.

- **`internal/registry/server`** — implements the three client endpoints (`GET /v1/crates/<name>`, `GET /v1/crates/<name>/<ver>/tar`, `PUT /v1/crates/<name>/<ver>`) on top of a filesystem-backed storage layout (`<root>/crates/<name>/{index.json,<ver>/package.tgz}`). Publishes are:
  - token-gated with scope matching (`publish:*` or `publish:<name>`)
  - bounded in body size (`--max-upload-mb`, default 16)
  - sha256-verified against the client's `Osty-Checksum` header
  - inspected for `osty.toml` so the index carries the published version's declared deps
  - refused on duplicate (name, version) → `409 Conflict`
- **`cmd/osty-registry`** — standalone binary with `--root`, `--tokens`, `--addr`, graceful shutdown on SIGINT/SIGTERM, and `tokens.json` reload on SIGHUP.
- **Tests** — round-trip the real `registry.Client` against the new server (publish → index → download), plus negative cases for 401/403/400/409.
- **README** — adds a "Running a registry" section with the `tokens.json` schema and a minimal end-to-end recipe, and updates the Status table.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/registry/...` (existing client tests + new server tests all pass)
- [x] `go vet ./internal/registry/... ./cmd/osty-registry/...`
- [ ] Manually spin up `osty-registry`, `osty publish` → `osty add` end to end
- [ ] Verify SIGHUP reloads `tokens.json` without dropping in-flight requests

Pre-existing `internal/format` test failure on `main` is unrelated.

https://claude.ai/code/session_01GRtosbPuPd4grL3rnNcDfe