### PR TITLE
gen: complete §8 cancellation protocol end-to-end

### DIFF
--- a/internal/gen/concurrency_test.go
+++ b/internal/gen/concurrency_test.go
@@ -3,6 +3,7 @@ package gen_test
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestTaskGroupBasic — taskGroup waits for all spawned tasks and
@@ -219,5 +220,162 @@ fn main() {
 	want := "sum = 20\nerr: bad nope\n"
 	if out != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}
+
+// TestAutoCancelOnError — one spawned task returning Err causes
+// sibling workers that cooperate via isCancelled() to exit early,
+// without explicit g.cancel().
+func TestAutoCancelOnError(t *testing.T) {
+	src := `fn worker(id: Int, g: TaskGroup) -> Result<Int, String> {
+    for i in 0..50 {
+        if g.isCancelled() {
+            return Err("w{id}@{i}")
+        }
+        thread.sleep(5.ms)
+    }
+    Ok(id)
+}
+
+fn failFast() -> Result<Int, String> {
+    thread.sleep(15.ms)
+    Err("fail")
+}
+
+fn main() {
+    taskGroup(|g| {
+        let h1 = g.spawn(|| worker(1, g))
+        let h2 = g.spawn(|| failFast())
+        let h3 = g.spawn(|| worker(3, g))
+        match h1.join() {
+            Ok(v) -> println("w1 done: {v}"),
+            Err(e) -> println("w1: {e}"),
+        }
+        match h2.join() {
+            Ok(v) -> println("w2 done: {v}"),
+            Err(e) -> println("w2: {e}"),
+        }
+        match h3.join() {
+            Ok(v) -> println("w3 done: {v}"),
+            Err(e) -> println("w3: {e}"),
+        }
+    })
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	if strings.Contains(out, "w1 done") || strings.Contains(out, "w3 done") {
+		t.Errorf("workers should have auto-cancelled, got:\n%s\n--- src ---\n%s",
+			out, goSrc)
+	}
+	if !strings.Contains(out, "w1: w1@") || !strings.Contains(out, "w3: w3@") {
+		t.Errorf("expected cancellation traces, got:\n%s", out)
+	}
+	if !strings.Contains(out, "w2: fail") {
+		t.Errorf("w2 should have failed: %s", out)
+	}
+}
+
+// TestNestedCancelChain — cancelling the outer group propagates into
+// a nested taskGroup's context so its workers see IsCancelled.
+func TestNestedCancelChain(t *testing.T) {
+	src := `fn runInner() -> Int {
+    taskGroup(|inner| {
+        let h = inner.spawn(|| {
+            for i in 0..30 {
+                if inner.isCancelled() { return i }
+                thread.sleep(10.ms)
+            }
+            99
+        })
+        h.join()
+    })
+}
+
+fn main() {
+    let got = taskGroup(|outer| {
+        let h = outer.spawn(|| runInner())
+        thread.sleep(30.ms)
+        outer.cancel()
+        h.join()
+    })
+    if got >= 99 {
+        println("inner completed")
+    } else {
+        println("inner cancelled")
+    }
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	if strings.TrimSpace(out) != "inner cancelled" {
+		t.Errorf("got %q\n--- src ---\n%s", out, goSrc)
+	}
+}
+
+// TestRecvCancel — ch.recv() inside a cancelled group returns None
+// instead of blocking forever.
+func TestRecvCancel(t *testing.T) {
+	src := `fn main() {
+    taskGroup(|g| {
+        let ch = thread.chan::<Int>(0)
+        let h = g.spawn(|| {
+            match ch.recv() {
+                Some(v) -> "got {v}",
+                None -> "aborted"
+            }
+        })
+        thread.sleep(20.ms)
+        g.cancel()
+        println(h.join())
+    })
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	if strings.TrimSpace(out) != "aborted" {
+		t.Errorf("got %q\n--- src ---\n%s", out, goSrc)
+	}
+}
+
+// TestSleepCancel — thread.sleep() interrupts on cancel. The body
+// may still complete (signaling requires explicit isCancelled), but
+// the total wall-clock time must be far below the nominal sleep.
+func TestSleepCancel(t *testing.T) {
+	src := `fn main() {
+    taskGroup(|g| {
+        let h = g.spawn(|| {
+            thread.sleep(2000.ms)
+            "ok"
+        })
+        thread.sleep(30.ms)
+        g.cancel()
+        h.join()
+    })
+    println("done")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	t0 := time.Now()
+	out := runGo(t, goSrc)
+	dur := time.Since(t0)
+	if strings.TrimSpace(out) != "done" {
+		t.Errorf("got %q", out)
+	}
+	if dur > 1500*time.Millisecond {
+		t.Errorf("sleep not interrupted: took %v (expected < 1.5s)\n--- src ---\n%s",
+			dur, goSrc)
 	}
 }

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -369,6 +369,17 @@ func (g *gen) emitConcurrencyMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 	case "Chan", "Channel":
 		switch f.Name {
 		case "recv":
+			// When the file uses taskGroup anywhere, recv becomes
+			// cancel-aware via the runtime's recvCancel helper: a
+			// cancelled group returns None even without a sender.
+			// Files without structured concurrency stay on the bare
+			// channel receive — cheaper and equivalent in that case.
+			if g.needTaskGroup {
+				g.body.write("recvCancel(")
+				g.emitExpr(f.X)
+				g.body.write(")")
+				return true
+			}
 			inner := "any"
 			if len(n.Args) == 1 {
 				inner = g.goType(n.Args[0])
@@ -481,9 +492,16 @@ func (g *gen) emitThreadCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 	}
 	switch f.Name {
 	case "sleep":
-		// thread.sleep(dur) → time.Sleep(dur)
+		// thread.sleep(dur) → time.Sleep(dur), or sleepCancel(dur) when
+		// a taskGroup is present so the sleep is interruptible.
 		if len(c.Args) != 1 {
 			return false
+		}
+		if g.needTaskGroup {
+			g.body.write("sleepCancel(")
+			g.emitDurationExpr(c.Args[0].Value)
+			g.body.write(")")
+			return true
 		}
 		g.use("time")
 		g.body.write("time.Sleep(")
@@ -670,19 +688,31 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 		// §8.1: taskGroup(|g| body) → runTaskGroup[T](body).
 		// The outer call's type is T; the inner closure receives a
 		// *TaskGroup.
+		//
+		// A unit-returning closure needs a trampoline so Go's
+		// `func(*TaskGroup)` and `func(*TaskGroup) struct{}` don't
+		// clash at the runTaskGroup[struct{}] call site.
 		if len(args) == 1 {
 			g.needTaskGroup = true
 			g.needHandle = true
 			inner := "any"
+			isUnit := false
 			if call != nil {
-				if t := g.typeOf(call); t != nil && !types.IsUnit(t) && !types.IsError(t) {
-					inner = g.goType(t)
-				} else if t != nil && types.IsUnit(t) {
+				if t := g.typeOf(call); t != nil && types.IsUnit(t) {
 					inner = "struct{}"
+					isUnit = true
+				} else if t != nil && !types.IsError(t) {
+					inner = g.goType(t)
 				}
 			}
 			g.body.writef("runTaskGroup[%s](", inner)
-			g.emitExpr(args[0].Value)
+			if isUnit {
+				g.body.write("func(_g *TaskGroup) struct{} { (")
+				g.emitExpr(args[0].Value)
+				g.body.write(")(_g); return struct{}{} }")
+			} else {
+				g.emitExpr(args[0].Value)
+			}
 			g.body.write(")")
 			return true
 		}

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -115,7 +115,134 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 		methodNames:  map[string]map[string]bool{},
 	}
 	g.indexTypes()
+	// Pre-scan for structured-concurrency callsites so cancel-aware
+	// lowering of `ch.recv()` / `thread.sleep(...)` is decided before
+	// the first expression is emitted. Without this, a recv that
+	// appears lexically before the first `taskGroup(...)` would fall
+	// back to the non-cancel form even in a file that uses groups.
+	g.scanConcurrencyUse()
 	return g
+}
+
+// scanConcurrencyUse walks the file looking for taskGroup / parallel
+// / spawn / g.spawn callsites that would activate the structured
+// concurrency runtime. Sets the needTaskGroup flag when any are
+// present so subsequent emission can decide whether to use the
+// cancel-aware helpers.
+func (g *gen) scanConcurrencyUse() {
+	var hit bool
+	var visit func(n any)
+	visit = func(n any) {
+		if hit || n == nil {
+			return
+		}
+		switch x := n.(type) {
+		case *ast.CallExpr:
+			if id, ok := x.Fn.(*ast.Ident); ok {
+				switch id.Name {
+				case "taskGroup", "parallel", "spawn":
+					hit = true
+					return
+				}
+			}
+			if fx, ok := x.Fn.(*ast.FieldExpr); ok {
+				if fx.Name == "spawn" || fx.Name == "cancel" || fx.Name == "isCancelled" {
+					hit = true
+					return
+				}
+			}
+			visit(x.Fn)
+			for _, a := range x.Args {
+				visit(a.Value)
+			}
+		case *ast.BinaryExpr:
+			visit(x.Left)
+			visit(x.Right)
+		case *ast.UnaryExpr:
+			visit(x.X)
+		case *ast.ParenExpr:
+			visit(x.X)
+		case *ast.FieldExpr:
+			visit(x.X)
+		case *ast.IndexExpr:
+			visit(x.X)
+			visit(x.Index)
+		case *ast.TupleExpr:
+			for _, e := range x.Elems {
+				visit(e)
+			}
+		case *ast.ListExpr:
+			for _, e := range x.Elems {
+				visit(e)
+			}
+		case *ast.StructLit:
+			for _, f := range x.Fields {
+				if f.Value != nil {
+					visit(f.Value)
+				}
+			}
+		case *ast.IfExpr:
+			visit(x.Cond)
+			visit(x.Then)
+			visit(x.Else)
+		case *ast.MatchExpr:
+			visit(x.Scrutinee)
+			for _, a := range x.Arms {
+				visit(a.Body)
+			}
+		case *ast.Block:
+			for _, s := range x.Stmts {
+				visit(s)
+			}
+		case *ast.ClosureExpr:
+			visit(x.Body)
+		case *ast.QuestionExpr:
+			visit(x.X)
+		case *ast.ReturnStmt:
+			visit(x.Value)
+		case *ast.LetStmt:
+			visit(x.Value)
+		case *ast.AssignStmt:
+			visit(x.Value)
+		case *ast.ExprStmt:
+			visit(x.X)
+		case *ast.ForStmt:
+			visit(x.Iter)
+			visit(x.Body)
+		case *ast.DeferStmt:
+			visit(x.X)
+		case *ast.ChanSendStmt:
+			visit(x.Channel)
+			visit(x.Value)
+		case *ast.FnDecl:
+			if x.Body != nil {
+				visit(x.Body)
+			}
+		case *ast.StructDecl:
+			for _, m := range x.Methods {
+				if m.Body != nil {
+					visit(m.Body)
+				}
+			}
+		case *ast.EnumDecl:
+			for _, m := range x.Methods {
+				if m.Body != nil {
+					visit(m.Body)
+				}
+			}
+		case *ast.LetDecl:
+			visit(x.Value)
+		}
+	}
+	for _, d := range g.file.Decls {
+		visit(d)
+	}
+	for _, s := range g.file.Stmts {
+		visit(s)
+	}
+	if hit {
+		g.needTaskGroup = true
+	}
 }
 
 // indexTypes walks top-level declarations once to build the variant
@@ -203,6 +330,13 @@ func (g *gen) run() ([]byte, error) {
 	if g.needTaskGroup {
 		g.use("sync")
 		g.use("context")
+		g.use("runtime")
+		g.use("strconv")
+		g.use("time")
+		// TaskGroup implies Handle (spawn-in-group returns Handle).
+		g.needHandle = true
+		// TaskGroup implies Result for the Err-detection interface.
+		g.needResult = true
 	}
 
 	// 3. Assemble header + body.
@@ -256,6 +390,12 @@ type Result[T any, E any] struct {
 	Error E
 	IsOk  bool
 }
+
+// isErrResult is the private marker consumed by the concurrency
+// runtime's auto-cancel-on-error logic. Named generically so that a
+// file without taskGroup still compiles — the method is always safe
+// to emit because it only exposes existing state.
+func (r Result[T, E]) isErrResult() bool { return !r.IsOk }
 `)
 	}
 	if g.needRange {
@@ -291,12 +431,11 @@ func (h Handle[T]) Join() T { return <-h.result }
 	}
 	if g.needTaskGroup {
 		out.WriteString(`
-// TaskGroup backs §8 structured concurrency: every task spawned via
-// Spawn must finish before the group exits. A context is carried
-// through so Cancel propagates to cooperating children via
-// IsCancelled / Done. Context-aware stdlib blocking calls (the full
-// spec-mandated cancellation protocol) are not shipped — tasks that
-// don't explicitly check IsCancelled will run to completion.
+// TaskGroup backs §8 structured concurrency. Every task spawned via
+// Spawn must finish before the group exits. Cancellation flows
+// through a context: Cancel signals cooperative stop; child groups
+// derive their context from the enclosing one via a goroutine-local
+// registry so a parent's cancel cascades into nested taskGroups.
 type TaskGroup struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -316,31 +455,127 @@ func (g *TaskGroup) IsCancelled() bool {
 
 func (g *TaskGroup) Cancel() { g.cancel() }
 
+// ostyResultErr is the marker interface satisfied by Result[T, E]
+// through its isErrResult method. It lets the runtime detect the
+// Err branch of a spawned task without a concrete type reference,
+// which powers auto-cancel-on-first-error in spawnInGroup.
+type ostyResultErr interface {
+	isErrResult() bool
+}
+
+// goroutineGroup maps each active goroutine ID to its enclosing
+// TaskGroup so nested ` + "`taskGroup`" + ` calls can derive from their parent,
+// and context-aware helpers (recvCancel, sleepCancel) can observe a
+// cancel signal without an explicit handle argument.
+var goroutineGroup sync.Map
+
+// ostyGoid reads the current goroutine's ID from the runtime stack
+// header. Called rarely — at spawn entry and at recv / sleep sites —
+// so the microsecond-scale cost is acceptable.
+func ostyGoid() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	s := buf[:n]
+	const prefix = len("goroutine ")
+	if n <= prefix {
+		return 0
+	}
+	s = s[prefix:]
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	v, _ := strconv.ParseUint(string(s[:i]), 10, 64)
+	return v
+}
+
+// currentGroup returns the TaskGroup the calling goroutine belongs
+// to, or nil when not inside a spawned body.
+func currentGroup() *TaskGroup {
+	if v, ok := goroutineGroup.Load(ostyGoid()); ok {
+		return v.(*TaskGroup)
+	}
+	return nil
+}
+
+// currentGroupCtx returns a context to wait on for cancel-aware
+// helpers. When no group is active, Background's Done channel is
+// nil, so select arms on it never fire — select semantics then
+// match the non-cancel fallback.
+func currentGroupCtx() context.Context {
+	if g := currentGroup(); g != nil {
+		return g.ctx
+	}
+	return context.Background()
+}
+
 // spawnInGroup is the TaskGroup-aware variant of spawnHandle. The
 // WaitGroup counter increments synchronously so runTaskGroup's Wait
-// sees the task even if the goroutine hasn't started yet.
+// sees the task even if the goroutine hasn't started yet. The body's
+// return value is inspected: if it's a Result in its Err branch the
+// enclosing group is cancelled (§8.2 auto-cancel-on-first-error).
 func spawnInGroup[T any](g *TaskGroup, body func() T) Handle[T] {
 	g.wg.Add(1)
 	h := Handle[T]{result: make(chan T, 1)}
 	go func() {
-		defer g.wg.Done()
-		h.result <- body()
+		id := ostyGoid()
+		goroutineGroup.Store(id, g)
+		defer func() {
+			goroutineGroup.Delete(id)
+			g.wg.Done()
+		}()
+		v := body()
+		if r, ok := any(v).(ostyResultErr); ok && r.isErrResult() {
+			g.cancel()
+		}
+		h.result <- v
 	}()
 	return h
 }
 
 // runTaskGroup is the lowering target for ` + "`taskGroup(|g| body)`" + `.
-// The closure runs synchronously; on exit the context is cancelled
-// (so late children observing IsCancelled see the signal) and Wait
-// drains every unfinished spawned task before returning.
+// When called inside another group (detected via the goroutine
+// registry) it derives its context from the parent, so a parent
+// cancel cascades into the child. On exit the context is cancelled
+// and Wait drains every unfinished spawned task.
 func runTaskGroup[T any](body func(*TaskGroup) T) T {
-	ctx, cancel := context.WithCancel(context.Background())
+	parent := currentGroupCtx()
+	ctx, cancel := context.WithCancel(parent)
 	g := &TaskGroup{ctx: ctx, cancel: cancel}
 	defer func() {
 		cancel()
 		g.wg.Wait()
 	}()
 	return body(g)
+}
+
+// recvCancel is the cancel-aware lowering of ` + "`ch.recv()`" + `. When the
+// enclosing TaskGroup is cancelled, it returns nil (mapped to None in
+// Osty) even if the channel has no pending value. Outside a group,
+// behaves identically to a bare channel receive.
+func recvCancel[T any](ch chan T) *T {
+	ctx := currentGroupCtx()
+	select {
+	case v, ok := <-ch:
+		if !ok {
+			return nil
+		}
+		return &v
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+// sleepCancel is the cancel-aware lowering of ` + "`thread.sleep(dur)`" + `.
+// Returns early when the enclosing group is cancelled.
+func sleepCancel(d time.Duration) {
+	ctx := currentGroupCtx()
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
 }
 
 // runParallel is the lowering target for ` + "`parallel(|| a, || b, ...)`" + `.


### PR DESCRIPTION
## Summary
Closes the four §8 spec items previously documented as future work:

1. **Auto-cancel-on-first-error** — a child returning `Err(...)` cancels the enclosing `taskGroup`. Detected via a private `isErrResult()` method on `Result[T, E]` + an `ostyResultErr` marker interface.
2. **Nested cancel-chain** — outer cancel cascades into nested `taskGroup(...)` bodies. Goroutine-local registry (`sync.Map` keyed by `runtime.Stack`-derived goroutine ID) tracks each goroutine's group; nested `runTaskGroup` derives its context from the parent.
3. **Context-aware blocking** — `ch.recv()` → `recvCancel(ch)` (returns None on cancel), `thread.sleep(dur)` → `sleepCancel(dur)` (interrupts), both driven by the same registry.
4. **Select arms** — audited; all spec-specified arms (recv / send / timeout / default + multiple recv) already covered in the prior PR.

## Why
The last PR left these as explicit limitations. They're the difference between "spawn some goroutines and wait" and "actual structured concurrency" — the spec leans heavily on automatic cancel propagation for ergonomics, and without it `taskGroup` is mostly just `sync.WaitGroup` with sugar.

## How
- Runtime (`internal/gen/gen.go`) — adds `goroutineGroup sync.Map`, `ostyGoid()` via `runtime.Stack`, `currentGroup()` / `currentGroupCtx()`, `ostyResultErr` interface + `isErrResult()` on `Result`, `recvCancel[T]` / `sleepCancel` helpers, and reworks `spawnInGroup` / `runTaskGroup` to register-and-derive.
- Pre-scan (`scanConcurrencyUse` in `newGen`) — walks the AST looking for taskGroup / parallel / spawn / group-method usage so `ch.recv()` lowered lexically before the first `taskGroup(...)` still gets the cancel-aware form. Files without concurrency stay on the zero-overhead bare-receive path.
- Unit-closure trampoline for taskGroup — matches the prior fix for spawn/parallel; `func(*TaskGroup)` and `func(*TaskGroup) struct{}` are incompatible in Go, so unit-returning closures get a `func(_g *TaskGroup) struct{} { body(_g); return struct{}{} }` wrapper.

## Test plan
- [ ] `go test ./internal/gen/` still green
- [ ] New tests in `concurrency_test.go`:
  - `TestAutoCancelOnError` — one Err-returning sibling cancels the whole group
  - `TestNestedCancelChain` — outer cancel propagates into nested taskGroup
  - `TestRecvCancel` — blocked `ch.recv()` unblocks to None on cancel
  - `TestSleepCancel` — `thread.sleep(2000.ms)` wall-clock < 1.5s when cancelled at 30ms
- [ ] Hand-run integration: Result-returning workers + blocked-recv + fail-fast trigger — all the cascade-cancel, drop through cleanly in ~500ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)