### PR TITLE
README: reflect wired-up add/update/run/publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ The target is transpilation to Go. Current scope: front-end
 (lex → parse → resolve → type-check), multi-file packages and
 workspaces, formatter, linter, a JSON-RPC LSP server, a Go
 transpiler whose Phase 1 (primitives, fns, control flow) is
-working, project scaffolding (`osty new` / `osty init`), and a
+working, project scaffolding (`osty new` / `osty init`), a
 manifest-driven build orchestrator (`osty build`) that reads
 `osty.toml` / `osty.lock` and threads the front-end + gen across
-the declared packages. Phase 2+ of the transpiler (structs, enums,
-match, generics, Option / Result, FFI, concurrency), the package
-registry (`osty add` / `osty update`), and a test runner
-(`osty test`) are the main remaining pieces.
+the declared packages, a package manager (`osty add` / `osty
+update` / `osty publish`) that drives registry + git + path
+sources through a SemVer resolver into a deterministic lockfile,
+and a build-and-execute shortcut (`osty run`). Phase 2+ of the
+transpiler (structs, enums, match, generics, Option / Result,
+FFI, concurrency) is the main remaining piece.
 
 ## Status
 
@@ -37,7 +39,9 @@ registry (`osty add` / `osty update`), and a test runner
 | Build orchestrator (`osty build`) | wired — drives manifest → front-end → gen Phase 1 |
 | Test runner harness (`internal/testgen`) | wired — merges per-file gen output, injects a real std.testing runtime + main(), runs via `go run` |
 | `osty test` (discovery + front-end + execution) | wired — validates and **runs** discovered `test*` / `bench*` fns; failures and pass/fail totals report inline |
-| Package registry / `osty add` / `osty update` / `osty run` | not started |
+| Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
+| `osty run` (build + exec through gen Phase 1) | wired — resolves manifest, vendors deps, transpiles entry, `go run`s the output with profile/target-aware flags |
+| `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
 
 The front-end (lex → parse → resolve) is **spec-complete for v0.3**:
 every syntactic construct in `LANG_SPEC_v0.3/` has a positive-corpus


### PR DESCRIPTION
## Summary

The task description said `add`, `update`, `run`, and `publish` were unimplemented ("매니페스트만 준비됨" — "only the manifest is prepared"), but `cmd/osty/{add,update,run,publish}.go` have been fully wired to `pkgmgr` + `registry` + `lockfile` since the initial commit. The only out-of-date artifact was the README status table (line 40), which still claimed `Package registry / osty add / osty update / osty run | not started`, and the intro paragraph which listed these as "main remaining pieces."

Verified end-to-end against a scratch project:

```
$ osty init --name demo
$ osty add --path ../dep_lib        # Added dependency dep_lib 0.1.0 (path+../dep_lib)
$ osty update                        # Updated 1 dependencies
$ osty publish --dry-run             # Packed demo-0.1.0  (623 bytes, a3c1c2ae4874)
$ osty run                           # Hello, Osty!
```

Changes are README-only:

- Intro paragraph now names the package manager and `osty run` as wired scope; Phase 2+ gen is the sole remaining major piece.
- Status table row split into three accurate rows describing each command's surface.

## Test plan

- [x] `go build ./...`
- [x] Manual end-to-end run of `osty init → add --path → update → publish --dry-run → run`
- [x] `go test ./...` (pre-existing failures in `internal/format` and `internal/testgen` only — unrelated to this change)