### PR TITLE
gen: monomorphize generic functions per §2.7.3

### DIFF
--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -35,6 +35,14 @@ func (g *gen) emitDecl(d ast.Decl) {
 // Methods (with a receiver) are emitted in Phase 2 alongside their
 // struct/enum; a standalone FnDecl with a non-nil Recv here would be
 // a parser accident, so we skip it with a TODO.
+//
+// Generic functions with recorded instantiations are monomorphized
+// (§2.7.3): instead of emitting a single Go-generic definition, we
+// emit one specialized copy per distinct type-argument list collected
+// by the checker. A generic fn with no observed instantiations emits
+// nothing — its body becomes live only when a downstream package
+// references it with a concrete type tuple. Non-generic fns take the
+// standard single-emission path.
 func (g *gen) emitFnDecl(fn *ast.FnDecl) {
 	if fn.Recv != nil {
 		// Methods are emitted by their enclosing type in Phase 2.
@@ -42,22 +50,34 @@ func (g *gen) emitFnDecl(fn *ast.FnDecl) {
 		// for the owner; skip here.
 		return
 	}
-	g.body.nl()
-	g.body.write("func ")
-	g.body.write(fn.Name)
 
 	if len(fn.Generics) > 0 {
-		g.body.write("[")
-		for i, gp := range fn.Generics {
-			if i > 0 {
-				g.body.write(", ")
-			}
-			g.body.write(gp.Name)
-			g.body.write(" ")
-			g.body.write(g.goConstraint(gp.Constraints))
+		sym := g.res.FileScope.Lookup(fn.Name)
+		recs := g.genericInstances[sym]
+		if len(recs) == 0 {
+			// No instantiations: emit nothing. Monomorphization is a
+			// demand-driven transform — a generic body with no call
+			// sites has no lowered form in the Go output.
+			return
 		}
-		g.body.write("]")
+		g.emitMonomorphizedFn(fn, recs)
+		return
 	}
+
+	g.emitFnDeclBody(fn, fn.Name)
+}
+
+// emitFnDeclBody writes a single function definition under `name`. It
+// is the shared emission path used by both the non-generic fast path
+// and the per-instantiation loop over a monomorphized generic. Generic
+// type parameters are never emitted as Go `[T any]` brackets here —
+// when we reach this function for a generic source fn, the caller has
+// already pushed a substitution env so every type-param reference
+// resolves to a concrete Go type.
+func (g *gen) emitFnDeclBody(fn *ast.FnDecl, name string) {
+	g.body.nl()
+	g.body.write("func ")
+	g.body.write(name)
 
 	g.emitParamList(fn.Params)
 
@@ -67,7 +87,6 @@ func (g *gen) emitFnDecl(fn *ast.FnDecl) {
 	}
 
 	if fn.Body == nil {
-		// Signature-only (shouldn't happen at top level, but be safe).
 		g.body.writeln(" {}")
 		return
 	}

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -52,15 +52,10 @@ func (g *gen) emitFnDecl(fn *ast.FnDecl) {
 	}
 
 	if len(fn.Generics) > 0 {
-		sym := g.res.FileScope.Lookup(fn.Name)
-		recs := g.genericInstances[sym]
-		if len(recs) == 0 {
-			// No instantiations: emit nothing. Monomorphization is a
-			// demand-driven transform — a generic body with no call
-			// sites has no lowered form in the Go output.
-			return
-		}
-		g.emitMonomorphizedFn(fn, recs)
+		// Demand-driven: generic fns never emit inline. A call site
+		// (possibly inside another generic body being specialized)
+		// requests an instantiation via requestInstance, and the
+		// post-pass drainInstances materializes it.
 		return
 	}
 

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -301,6 +301,26 @@ func (g *gen) emitCoalesce(b *ast.BinaryExpr) {
 // (`shape.area()` → `Shape_area(shape)`), and static/associated
 // function calls (`User.new("a")` → `User_new("a")`).
 func (g *gen) emitCall(c *ast.CallExpr) {
+	// Monomorphized generic-fn call: the callee was specialized to a
+	// mangled name during buildInstances. Rewrite before any of the
+	// construct-specific paths so the mangled name wins even when the
+	// source-level identifier happens to collide with, say, a variant
+	// constructor in a different scope.
+	if mangled, ok := g.callMono[c]; ok {
+		g.body.write(mangled)
+		g.body.write("(")
+		for i, a := range c.Args {
+			if i > 0 {
+				g.body.write(", ")
+			}
+			if a.Name != "" {
+				g.body.writef("/* %s = */ ", a.Name)
+			}
+			g.emitExpr(a.Value)
+		}
+		g.body.write(")")
+		return
+	}
 	if id, ok := c.Fn.(*ast.Ident); ok {
 		if g.emitBuiltinCall(id.Name, c.Args, c) {
 			return

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -301,12 +301,14 @@ func (g *gen) emitCoalesce(b *ast.BinaryExpr) {
 // (`shape.area()` → `Shape_area(shape)`), and static/associated
 // function calls (`User.new("a")` → `User_new("a")`).
 func (g *gen) emitCall(c *ast.CallExpr) {
-	// Monomorphized generic-fn call: the callee was specialized to a
-	// mangled name during buildInstances. Rewrite before any of the
-	// construct-specific paths so the mangled name wins even when the
-	// source-level identifier happens to collide with, say, a variant
-	// constructor in a different scope.
-	if mangled, ok := g.callMono[c]; ok {
+	// Monomorphized generic-fn call. callMonoName consults the current
+	// substEnv so an inner call inside a generic body (e.g. `id(y)`
+	// appearing in `wrap<U>`) resolves transitively to the concrete
+	// type of the enclosing monomorph (`id_int` when emitting
+	// wrap_int). The rewrite runs before the construct-specific paths
+	// so the mangled name wins over any source-level collision with
+	// a variant constructor etc.
+	if mangled := g.callMonoName(c); mangled != "" {
 		g.body.write(mangled)
 		g.body.write("(")
 		for i, a := range c.Args {

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -101,16 +101,19 @@ type gen struct {
 	// emitQuestion. Nil when no lift is in progress.
 	questionSubs map[*ast.QuestionExpr]string
 
-	// genericInstances groups the distinct instantiations recorded for
-	// each user-defined generic function. Populated by buildInstances
-	// before declaration emission; consumed by emitFnDecl to produce
-	// one specialized copy per entry (§2.7.3).
-	genericInstances map[*resolve.Symbol][]instRecord
+	// instQueue is the pending list of generic-fn monomorphizations
+	// that still need to be emitted. emitCall appends to this queue
+	// each time it encounters a generic call site whose (sym, type
+	// tuple) pair hasn't yet been emitted; drainInstances walks the
+	// queue to a fixed point after the normal decl pass so transitive
+	// instantiations (a generic body calling another generic fn) are
+	// materialized (§2.7.3).
+	instQueue []instRecord
 
-	// callMono maps each generic CallExpr to the mangled name its
-	// callee is emitted under. Consumed by emitCall so the argument
-	// list lands in front of the specialized function.
-	callMono map[*ast.CallExpr]string
+	// instByKey dedupes the queue — maps (sym, goTypes) key to the
+	// mangled name already assigned. Read by callers that need the
+	// mangled name without re-enqueueing.
+	instByKey map[string]string
 
 	// substEnv is the current generic-parameter → Go-type substitution
 	// environment. Non-empty only while we emit inside a monomorphized
@@ -132,7 +135,7 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 		methodNames:  map[string]map[string]bool{},
 	}
 	g.indexTypes()
-	g.buildInstances()
+	g.initInstances()
 	return g
 }
 
@@ -198,10 +201,20 @@ func (g *gen) run() ([]byte, error) {
 		g.emitUseDecl(u)
 	}
 
-	// 1b. Emit every declaration in source order.
+	// 1b. Emit every declaration in source order. Generic fns are
+	//     skipped inline — their specializations are materialized
+	//     by drainInstances once every reachable (fn × type-tuple)
+	//     pair has been requested by a call site.
 	for _, d := range g.file.Decls {
 		g.emitDecl(d)
 	}
+
+	// 1c. Fixed-point drain of queued monomorphizations. Emitting one
+	//     specialization may discover further generic calls in its
+	//     body (transitive instantiation); drainInstances walks the
+	//     queue with an index-based loop so append-during-iteration
+	//     works as expected.
+	g.drainInstances()
 
 	// 2. Script-mode: if the file has top-level statements, wrap them
 	//    into a synthetic `main` function. A file with neither a

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -100,6 +100,23 @@ type gen struct {
 	// statement-level pre-lift pass (see preLiftQuestions); consumed by
 	// emitQuestion. Nil when no lift is in progress.
 	questionSubs map[*ast.QuestionExpr]string
+
+	// genericInstances groups the distinct instantiations recorded for
+	// each user-defined generic function. Populated by buildInstances
+	// before declaration emission; consumed by emitFnDecl to produce
+	// one specialized copy per entry (§2.7.3).
+	genericInstances map[*resolve.Symbol][]instRecord
+
+	// callMono maps each generic CallExpr to the mangled name its
+	// callee is emitted under. Consumed by emitCall so the argument
+	// list lands in front of the specialized function.
+	callMono map[*ast.CallExpr]string
+
+	// substEnv is the current generic-parameter → Go-type substitution
+	// environment. Non-empty only while we emit inside a monomorphized
+	// body; goTypeExpr and goType consult it so every reference to `T`
+	// in the source surfaces as the concrete Go type in the output.
+	substEnv map[string]string
 }
 
 func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result) *gen {
@@ -115,6 +132,7 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 		methodNames:  map[string]map[string]bool{},
 	}
 	g.indexTypes()
+	g.buildInstances()
 	return g
 }
 

--- a/internal/gen/monomorph.go
+++ b/internal/gen/monomorph.go
@@ -1,7 +1,6 @@
 package gen
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -11,102 +10,79 @@ import (
 // Generic monomorphization (§2.7.3).
 //
 // The checker records every generic call site's concrete type-argument
-// list on Result.Instantiations. This file consumes that map to emit
-// one specialized copy of each generic function definition per distinct
-// instantiation. Name mangling follows `fn_T1_T2` where each Ti is the
-// Go type rendering with identifier-unsafe characters flattened.
+// list on Result.Instantiations. This file drives the lowering: for
+// each reachable (generic fn × concrete type tuple) pair we emit one
+// specialized copy, rewriting its body's generic calls recursively so
+// the transform reaches transitive instantiations as well. A generic
+// fn with no reachable instantiations emits nothing — matching the
+// spec's "header-like" demand-driven framing.
 //
-// Scope (Phase-bounded): top-level fn declarations only. Generic
-// struct / enum types and generic methods still round-trip through
-// the Go-native generics path — the spec permits this because
-// monomorphization is observable only via emitted binary size, not
-// behavior, and tightening those cases is a separate, larger refactor.
+// Scope (out of scope here): generic struct / enum / alias types and
+// methods on generic types still flow through the Go-native generics
+// path. Tightening those is a separate, larger refactor.
 
-// instKey is the canonical textual key for one instantiation — a
-// tab-joined concatenation of the Go type strings. Using a tab avoids
-// clashing with the `_` used by the mangled name.
-type instKey string
-
-// instRecord captures one specialized instantiation of a generic fn.
+// instRecord is one specialized instantiation of a generic fn — the
+// concrete Go type rendering of each type argument plus the mangled
+// Go name the specialization is emitted under.
 type instRecord struct {
-	// Key is the canonical instKey — identifies the instantiation in
-	// the genericInstances map.
-	Key instKey
-	// GoTypes is the Go rendering of each type argument, used both to
-	// mangle the specialized name and to populate the substitution
-	// environment when emitting the body.
+	Fn      *ast.FnDecl
+	Sym     *resolve.Symbol
 	GoTypes []string
-	// Mangled is the Go function name the specialized copy is emitted
-	// under, and the name every call site rewrites to.
 	Mangled string
 }
 
-// buildInstances scans chk.Instantiations and groups the concrete
-// type-argument lists by the generic fn symbol they instantiate. The
-// result map is keyed by the fn's resolver Symbol; each value is a
-// deterministically-ordered slice of unique instantiations.
-//
-// Call sites that don't resolve to a user-defined fn symbol (variant
-// constructors, method calls through a value, builtins, etc.) are
-// skipped — those either have no generic body to specialize or ride
-// through a separate lowering path.
-func (g *gen) buildInstances() {
-	g.genericInstances = map[*resolve.Symbol][]instRecord{}
-	g.callMono = map[*ast.CallExpr]string{}
-	if g.chk == nil || g.res == nil {
-		return
+// requestInstance records that `(sym, goTypes)` is reachable and must
+// be emitted. Returns the mangled name the caller should emit at the
+// call site. Idempotent: repeated requests for the same (sym, tuple)
+// dedupe to the same name without re-enqueueing.
+func (g *gen) requestInstance(sym *resolve.Symbol, goTypes []string) string {
+	fn, ok := sym.Decl.(*ast.FnDecl)
+	if !ok || fn == nil {
+		return ""
 	}
-
-	for call, args := range g.chk.Instantiations {
-		sym := g.calleeSymbol(call.Fn)
-		if sym == nil || sym.Kind != resolve.SymFn {
-			continue
-		}
-		fn, ok := sym.Decl.(*ast.FnDecl)
-		if !ok || fn == nil || len(fn.Generics) == 0 {
-			continue
-		}
-		if len(args) != len(fn.Generics) {
-			// Checker produced a shape that doesn't line up with the
-			// declaration — skip rather than emit broken code.
-			continue
-		}
-
-		goTypes := make([]string, len(args))
-		parts := make([]string, len(args))
-		for i, a := range args {
-			goTypes[i] = g.goType(a)
-			parts[i] = goTypes[i]
-		}
-		key := instKey(strings.Join(parts, "\t"))
-
-		rec := instRecord{
-			Key:     key,
-			GoTypes: goTypes,
-			Mangled: mangleInst(fn.Name, goTypes),
-		}
-
-		existing := g.genericInstances[sym]
-		found := false
-		for _, r := range existing {
-			if r.Key == key {
-				rec.Mangled = r.Mangled
-				found = true
-				break
-			}
-		}
-		if !found {
-			g.genericInstances[sym] = append(existing, rec)
-		}
-		g.callMono[call] = rec.Mangled
+	key := instDedupeKey(sym, goTypes)
+	if name, ok := g.instByKey[key]; ok {
+		return name
 	}
+	mangled := mangleInst(fn.Name, goTypes)
+	rec := instRecord{Fn: fn, Sym: sym, GoTypes: goTypes, Mangled: mangled}
+	g.instByKey[key] = mangled
+	g.instQueue = append(g.instQueue, rec)
+	return mangled
+}
 
-	// Stable output order so repeated runs produce identical source.
-	for sym, recs := range g.genericInstances {
-		sort.SliceStable(recs, func(i, j int) bool {
-			return recs[i].Mangled < recs[j].Mangled
-		})
-		g.genericInstances[sym] = recs
+// instDedupeKey builds a map key that identifies a (symbol, type-tuple)
+// pair. Uses a unit-separator byte between the pointer repr and each
+// type fragment so `id_int` vs `id_int*` can't collide.
+func instDedupeKey(sym *resolve.Symbol, goTypes []string) string {
+	var b strings.Builder
+	b.WriteString(sym.Name)
+	b.WriteByte(0x1f)
+	b.WriteString(sym.Pos.String())
+	for _, t := range goTypes {
+		b.WriteByte(0x1f)
+		b.WriteString(t)
+	}
+	return b.String()
+}
+
+// initInstances resets the per-file monomorphization state. Called
+// once per gen.run() before any decl is visited.
+func (g *gen) initInstances() {
+	g.instByKey = map[string]string{}
+	g.instQueue = nil
+}
+
+// drainInstances emits every queued specialization and every further
+// specialization triggered by their bodies. Runs to a fixed point;
+// bounded by the call graph which is finite for any well-typed input.
+func (g *gen) drainInstances() {
+	// Index-based loop so appends during emission are picked up.
+	for i := 0; i < len(g.instQueue); i++ {
+		rec := g.instQueue[i]
+		cleanup := g.pushSubst(rec.Fn.Generics, rec.GoTypes)
+		g.emitFnDeclBody(rec.Fn, rec.Mangled)
+		cleanup()
 	}
 }
 
@@ -125,11 +101,57 @@ func (g *gen) calleeSymbol(fn ast.Expr) *resolve.Symbol {
 	return nil
 }
 
+// callMonoName returns the mangled specialization name for a generic
+// call site, or "" when the call isn't a generic fn call (or the
+// callee isn't a user-defined fn). Records the instantiation on the
+// pending queue as a side effect so downstream emission picks it up.
+//
+// The current substEnv is implicitly consumed: g.goType on a TypeVar
+// whose name is in substEnv substitutes its concrete Go type, so a
+// call `id(y)` inside `wrap<U>` being monomorphized at U=Int yields
+// goTypes=["int"] here. This is how transitive instantiation works —
+// a generic fn's body is visited once per outer monomorph, and each
+// inner generic call is re-specialized under that monomorph's subst.
+func (g *gen) callMonoName(c *ast.CallExpr) string {
+	if g.chk == nil {
+		return ""
+	}
+	args, ok := g.chk.Instantiations[c]
+	if !ok || len(args) == 0 {
+		return ""
+	}
+	sym := g.calleeSymbol(c.Fn)
+	if sym == nil || sym.Kind != resolve.SymFn {
+		return ""
+	}
+	fn, ok := sym.Decl.(*ast.FnDecl)
+	if !ok || fn == nil || len(fn.Generics) == 0 {
+		return ""
+	}
+	if len(args) != len(fn.Generics) {
+		return ""
+	}
+	goTypes := make([]string, len(args))
+	for i, a := range args {
+		goTypes[i] = g.goType(a)
+	}
+	// If any arg resolved to a symbolic name still (unhandled TypeVar)
+	// we bail — the call can't be safely monomorphized, fall through
+	// to the generic path. This catches bugs rather than emitting
+	// invalid Go silently.
+	for _, t := range goTypes {
+		if t == "" {
+			return ""
+		}
+	}
+	return g.requestInstance(sym, goTypes)
+}
+
 // mangleInst builds the specialized fn name. Illegal identifier
 // characters in a Go type rendering (`[`, `]`, `.`, space, `*`) are
-// flattened so `id[[]int]` becomes `id_SliceInt`-ish — we keep it simple
-// and replace with `_` / drop — the goal is only uniqueness per type
-// tuple within one file, not human readability.
+// flattened so e.g. `[]int` → `Ofint` — uniqueness within the set of
+// types Osty currently emits is preserved; human readability is a
+// non-goal here.
 func mangleInst(name string, goTypes []string) string {
 	var b strings.Builder
 	b.WriteString(name)
@@ -141,12 +163,10 @@ func mangleInst(name string, goTypes []string) string {
 }
 
 // sanitizeTypeName collapses a Go type string into a conservative
-// identifier fragment. The resulting fragment loses structural
-// information (we can't distinguish `[]int` from `[]int8` … wait, we
-// keep digits, just drop brackets). Distinctness is preserved because
-// mapping is injective within the set of types Osty currently emits:
-// brackets → `Of`, `*` → `Ptr`, `.` → `_`, space → ``, anything else
-// non-alphanumeric → `_`.
+// identifier fragment. `[` / `]` become `Of`, `*` → `Ptr`, spaces
+// dropped, anything else non-alphanumeric → `_`. The mapping is
+// injective over the set of Go type strings Osty currently emits,
+// which is what monomorphization-name distinctness requires.
 func sanitizeTypeName(t string) string {
 	var b strings.Builder
 	for _, r := range t {
@@ -196,27 +216,5 @@ func (g *gen) lookupSubst(name string) (string, bool) {
 	}
 	v, ok := g.substEnv[name]
 	return v, ok
-}
-
-// isGenericFnSym reports whether `sym` is a user-declared generic
-// function — the set whose calls need name rewriting.
-func (g *gen) isGenericFnSym(sym *resolve.Symbol) bool {
-	if sym == nil || sym.Kind != resolve.SymFn {
-		return false
-	}
-	fn, ok := sym.Decl.(*ast.FnDecl)
-	return ok && fn != nil && len(fn.Generics) > 0
-}
-
-// emitMonomorphizedFn emits every specialized copy of a generic fn.
-// Each copy substitutes the generic parameters with their concrete
-// types via the pushed substEnv — the rest of the emit path is
-// unchanged because goTypeExpr / goType now consult substEnv.
-func (g *gen) emitMonomorphizedFn(fn *ast.FnDecl, recs []instRecord) {
-	for _, rec := range recs {
-		cleanup := g.pushSubst(fn.Generics, rec.GoTypes)
-		g.emitFnDeclBody(fn, rec.Mangled)
-		cleanup()
-	}
 }
 

--- a/internal/gen/monomorph.go
+++ b/internal/gen/monomorph.go
@@ -1,0 +1,222 @@
+package gen
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// Generic monomorphization (§2.7.3).
+//
+// The checker records every generic call site's concrete type-argument
+// list on Result.Instantiations. This file consumes that map to emit
+// one specialized copy of each generic function definition per distinct
+// instantiation. Name mangling follows `fn_T1_T2` where each Ti is the
+// Go type rendering with identifier-unsafe characters flattened.
+//
+// Scope (Phase-bounded): top-level fn declarations only. Generic
+// struct / enum types and generic methods still round-trip through
+// the Go-native generics path — the spec permits this because
+// monomorphization is observable only via emitted binary size, not
+// behavior, and tightening those cases is a separate, larger refactor.
+
+// instKey is the canonical textual key for one instantiation — a
+// tab-joined concatenation of the Go type strings. Using a tab avoids
+// clashing with the `_` used by the mangled name.
+type instKey string
+
+// instRecord captures one specialized instantiation of a generic fn.
+type instRecord struct {
+	// Key is the canonical instKey — identifies the instantiation in
+	// the genericInstances map.
+	Key instKey
+	// GoTypes is the Go rendering of each type argument, used both to
+	// mangle the specialized name and to populate the substitution
+	// environment when emitting the body.
+	GoTypes []string
+	// Mangled is the Go function name the specialized copy is emitted
+	// under, and the name every call site rewrites to.
+	Mangled string
+}
+
+// buildInstances scans chk.Instantiations and groups the concrete
+// type-argument lists by the generic fn symbol they instantiate. The
+// result map is keyed by the fn's resolver Symbol; each value is a
+// deterministically-ordered slice of unique instantiations.
+//
+// Call sites that don't resolve to a user-defined fn symbol (variant
+// constructors, method calls through a value, builtins, etc.) are
+// skipped — those either have no generic body to specialize or ride
+// through a separate lowering path.
+func (g *gen) buildInstances() {
+	g.genericInstances = map[*resolve.Symbol][]instRecord{}
+	g.callMono = map[*ast.CallExpr]string{}
+	if g.chk == nil || g.res == nil {
+		return
+	}
+
+	for call, args := range g.chk.Instantiations {
+		sym := g.calleeSymbol(call.Fn)
+		if sym == nil || sym.Kind != resolve.SymFn {
+			continue
+		}
+		fn, ok := sym.Decl.(*ast.FnDecl)
+		if !ok || fn == nil || len(fn.Generics) == 0 {
+			continue
+		}
+		if len(args) != len(fn.Generics) {
+			// Checker produced a shape that doesn't line up with the
+			// declaration — skip rather than emit broken code.
+			continue
+		}
+
+		goTypes := make([]string, len(args))
+		parts := make([]string, len(args))
+		for i, a := range args {
+			goTypes[i] = g.goType(a)
+			parts[i] = goTypes[i]
+		}
+		key := instKey(strings.Join(parts, "\t"))
+
+		rec := instRecord{
+			Key:     key,
+			GoTypes: goTypes,
+			Mangled: mangleInst(fn.Name, goTypes),
+		}
+
+		existing := g.genericInstances[sym]
+		found := false
+		for _, r := range existing {
+			if r.Key == key {
+				rec.Mangled = r.Mangled
+				found = true
+				break
+			}
+		}
+		if !found {
+			g.genericInstances[sym] = append(existing, rec)
+		}
+		g.callMono[call] = rec.Mangled
+	}
+
+	// Stable output order so repeated runs produce identical source.
+	for sym, recs := range g.genericInstances {
+		sort.SliceStable(recs, func(i, j int) bool {
+			return recs[i].Mangled < recs[j].Mangled
+		})
+		g.genericInstances[sym] = recs
+	}
+}
+
+// calleeSymbol resolves the function expression of a CallExpr to its
+// declaring Symbol, or nil when the callee isn't a direct user-defined
+// function reference (variable holding a closure, method call, etc.).
+func (g *gen) calleeSymbol(fn ast.Expr) *resolve.Symbol {
+	switch e := fn.(type) {
+	case *ast.Ident:
+		return g.symbolFor(e)
+	case *ast.TurbofishExpr:
+		if id, ok := e.Base.(*ast.Ident); ok {
+			return g.symbolFor(id)
+		}
+	}
+	return nil
+}
+
+// mangleInst builds the specialized fn name. Illegal identifier
+// characters in a Go type rendering (`[`, `]`, `.`, space, `*`) are
+// flattened so `id[[]int]` becomes `id_SliceInt`-ish — we keep it simple
+// and replace with `_` / drop — the goal is only uniqueness per type
+// tuple within one file, not human readability.
+func mangleInst(name string, goTypes []string) string {
+	var b strings.Builder
+	b.WriteString(name)
+	for _, t := range goTypes {
+		b.WriteByte('_')
+		b.WriteString(sanitizeTypeName(t))
+	}
+	return b.String()
+}
+
+// sanitizeTypeName collapses a Go type string into a conservative
+// identifier fragment. The resulting fragment loses structural
+// information (we can't distinguish `[]int` from `[]int8` … wait, we
+// keep digits, just drop brackets). Distinctness is preserved because
+// mapping is injective within the set of types Osty currently emits:
+// brackets → `Of`, `*` → `Ptr`, `.` → `_`, space → ``, anything else
+// non-alphanumeric → `_`.
+func sanitizeTypeName(t string) string {
+	var b strings.Builder
+	for _, r := range t {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '[' || r == ']':
+			b.WriteString("Of")
+		case r == '*':
+			b.WriteString("Ptr")
+		case r == ' ':
+			// drop
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "T"
+	}
+	return b.String()
+}
+
+// pushSubst binds each generic parameter name to its Go rendering for
+// the duration of a monomorphized emission. The returned cleanup
+// restores the previous env; call it with `defer`.
+func (g *gen) pushSubst(params []*ast.GenericParam, goTypes []string) func() {
+	prev := g.substEnv
+	next := map[string]string{}
+	for k, v := range prev {
+		next[k] = v
+	}
+	for i, p := range params {
+		if i >= len(goTypes) {
+			break
+		}
+		next[p.Name] = goTypes[i]
+	}
+	g.substEnv = next
+	return func() { g.substEnv = prev }
+}
+
+// lookupSubst reports whether `name` is a generic type-parameter
+// currently in scope and returns its concrete Go rendering if so.
+func (g *gen) lookupSubst(name string) (string, bool) {
+	if g.substEnv == nil {
+		return "", false
+	}
+	v, ok := g.substEnv[name]
+	return v, ok
+}
+
+// isGenericFnSym reports whether `sym` is a user-declared generic
+// function — the set whose calls need name rewriting.
+func (g *gen) isGenericFnSym(sym *resolve.Symbol) bool {
+	if sym == nil || sym.Kind != resolve.SymFn {
+		return false
+	}
+	fn, ok := sym.Decl.(*ast.FnDecl)
+	return ok && fn != nil && len(fn.Generics) > 0
+}
+
+// emitMonomorphizedFn emits every specialized copy of a generic fn.
+// Each copy substitutes the generic parameters with their concrete
+// types via the pushed substEnv — the rest of the emit path is
+// unchanged because goTypeExpr / goType now consult substEnv.
+func (g *gen) emitMonomorphizedFn(fn *ast.FnDecl, recs []instRecord) {
+	for _, rec := range recs {
+		cleanup := g.pushSubst(fn.Generics, rec.GoTypes)
+		g.emitFnDeclBody(fn, rec.Mangled)
+		cleanup()
+	}
+}
+

--- a/internal/gen/monomorph_depth_test.go
+++ b/internal/gen/monomorph_depth_test.go
@@ -1,0 +1,90 @@
+package gen_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMonomorph_TransitiveChain drives a three-level generic call
+// chain (outer<T> → middle<U> → inner<V>) with the concrete type
+// only pinned at the outermost boundary. Every intermediate
+// specialization must pick up the concrete type as the outer
+// monomorph substitutes downward.
+func TestMonomorph_TransitiveChain(t *testing.T) {
+	src := `fn inner<V>(x: V) -> V { x }
+fn middle<U>(x: U) -> U { inner(x) }
+fn outer<T>(x: T) -> T { middle(x) }
+
+fn main() {
+    let a: Int = outer(7)
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	for _, want := range []string{"func outer_int(", "func middle_int(", "func inner_int("} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "7" {
+		t.Errorf("runtime output = %q; want %q", got, "7")
+	}
+}
+
+// TestMonomorph_MultiTypeParam exercises a fn with two type
+// parameters, verifying the mangled name combines both and a single
+// call site produces a single specialization.
+func TestMonomorph_MultiTypeParam(t *testing.T) {
+	src := `fn pairFirst<A, B>(a: A, b: B) -> A { a }
+
+fn main() {
+    let x = pairFirst(1, "two")
+    println("{x}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if !strings.Contains(out, "func pairFirst_int_string(") {
+		t.Errorf("expected `pairFirst_int_string` specialization:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "1" {
+		t.Errorf("runtime output = %q; want %q", got, "1")
+	}
+}
+
+// TestMonomorph_NestedGeneric stresses transitive instantiation: a
+// generic fn whose body calls another generic fn with the enclosing
+// type-parameter as argument. A complete monomorphizer must propagate
+// the outer instantiation inward and emit `id_int` (not `id_U`) for
+// the inner call when `wrap<U=Int>` is requested.
+func TestMonomorph_NestedGeneric(t *testing.T) {
+	src := `fn id<T>(x: T) -> T { x }
+fn wrap<U>(y: U) -> U { id(y) }
+
+fn main() {
+    let a: Int = wrap(5)
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if strings.Contains(out, "id_U(") || strings.Contains(out, "func id_U(") {
+		t.Errorf("id specialized on a type variable U (should be int):\n%s", out)
+	}
+	if !strings.Contains(out, "func id_int(") {
+		t.Errorf("expected transitive `id_int` specialization:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "5" {
+		t.Errorf("runtime output = %q; want %q", got, "5")
+	}
+}

--- a/internal/gen/monomorph_edge_test.go
+++ b/internal/gen/monomorph_edge_test.go
@@ -1,0 +1,242 @@
+package gen_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMonomorph_RecursiveGeneric covers a generic fn that calls
+// itself. The self-call's instantiation args record [T] — under the
+// current monomorph's substEnv this must resolve to the same
+// specialization already being emitted (the worklist entry is seeded
+// before its body is visited, so requestInstance dedupes to the
+// in-flight mangled name rather than re-enqueueing).
+func TestMonomorph_RecursiveGeneric(t *testing.T) {
+	src := `fn countDown<T>(x: Int, seed: T) -> T {
+    if x <= 0 {
+        return seed
+    }
+    countDown(x - 1, seed)
+}
+
+fn main() {
+    let a = countDown(3, 42)
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	// Exactly one specialization, not two.
+	if n := strings.Count(out, "func countDown_int("); n != 1 {
+		t.Errorf("expected exactly 1 `countDown_int` definition, got %d:\n%s", n, out)
+	}
+	// The recursive call must land on the same mangled name.
+	if strings.Count(out, "countDown_int(") < 2 {
+		t.Errorf("expected recursive call site to also use mangled name:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "42" {
+		t.Errorf("runtime output = %q; want %q", got, "42")
+	}
+}
+
+// TestMonomorph_MutualRecursion covers a pair of generic fns that
+// call each other. Both halves of the cycle must reach a fixed point
+// — requestInstance must handle the second fn's entry being added
+// while the first is still mid-emission.
+func TestMonomorph_MutualRecursion(t *testing.T) {
+	src := `fn pingGeneric<T>(n: Int, tag: T) -> T {
+    if n <= 0 { return tag }
+    pongGeneric(n - 1, tag)
+}
+fn pongGeneric<T>(n: Int, tag: T) -> T {
+    if n <= 0 { return tag }
+    pingGeneric(n - 1, tag)
+}
+
+fn main() {
+    let a = pingGeneric(3, "hi")
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	for _, want := range []string{"func pingGeneric_string(", "func pongGeneric_string("} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "hi" {
+		t.Errorf("runtime output = %q; want %q", got, "hi")
+	}
+}
+
+// TestMonomorph_GenericInMethodBody covers a non-generic struct
+// method whose body happens to call a generic fn. The enclosing
+// context has no substEnv, but the checker still records the
+// instantiation on the inner call — which must materialize as a
+// normal root specialization.
+func TestMonomorph_GenericInMethodBody(t *testing.T) {
+	src := `fn id<T>(x: T) -> T { x }
+
+struct Holder {
+    value: Int,
+
+    fn doubled(self) -> Int {
+        id(self.value) * 2
+    }
+}
+
+fn main() {
+    let h = Holder { value: 21 }
+    println("{h.doubled()}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if !strings.Contains(out, "func id_int(") {
+		t.Errorf("expected `id_int` specialization reached through method body:\n%s", out)
+	}
+	if strings.Contains(out, "id(self") && !strings.Contains(out, "id_int(self") {
+		t.Errorf("call site in method wasn't rewritten:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "42" {
+		t.Errorf("runtime output = %q; want %q", got, "42")
+	}
+}
+
+// TestMonomorph_Turbofish covers an explicit type-argument call
+// `f::<Int>(x)`. The checker takes the explicit path which populates
+// Instantiations identically; the calleeSymbol resolver must
+// unwrap the TurbofishExpr.
+func TestMonomorph_Turbofish(t *testing.T) {
+	src := `fn id<T>(x: T) -> T { x }
+
+fn main() {
+    let a = id::<Int>(99)
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if !strings.Contains(out, "func id_int(") {
+		t.Errorf("turbofish call didn't produce `id_int` specialization:\n%s", out)
+	}
+	if !strings.Contains(out, "id_int(99)") {
+		t.Errorf("turbofish call site not rewritten:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "99" {
+		t.Errorf("runtime output = %q; want %q", got, "99")
+	}
+}
+
+// TestMonomorph_FnParamInGeneric covers a generic fn whose parameter
+// list itself mentions the type variable inside a function type —
+// `fn apply<T>(f: fn(T) -> T, x: T) -> T`. Every occurrence of T in
+// the nested fn-type must be substituted when emitting the body.
+func TestMonomorph_FnParamInGeneric(t *testing.T) {
+	src := `fn apply<T>(f: fn(T) -> T, x: T) -> T {
+    f(x)
+}
+
+fn main() {
+    let inc = |n: Int| -> Int { n + 1 }
+    let a = apply(inc, 41)
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if !strings.Contains(out, "func apply_int(") {
+		t.Errorf("expected `apply_int` specialization:\n%s", out)
+	}
+	// The closure-parameter type inside the fn signature must itself
+	// be `func(int) int`, not `func(T) T`.
+	if !strings.Contains(out, "func(int) int") {
+		t.Errorf("expected substituted closure param type `func(int) int`:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "42" {
+		t.Errorf("runtime output = %q; want %q", got, "42")
+	}
+}
+
+// TestMonomorph_OptionalReturn verifies an Optional type-var return
+// (`T?`) substitutes into the correct Go shape (`*int`). Optional
+// is pure sugar in Osty but it flows through a separate AST node
+// from Named, so the substEnv lookup must kick in through the nested
+// `Optional.Inner` path too.
+func TestMonomorph_OptionalReturn(t *testing.T) {
+	src := `fn wrapOpt<T>(x: T) -> T? {
+    Some(x)
+}
+
+fn main() {
+    match wrapOpt(7) {
+        Some(x) -> println("{x}"),
+        None -> println("empty"),
+    }
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if !strings.Contains(out, "func wrapOpt_int(") {
+		t.Errorf("expected `wrapOpt_int` specialization:\n%s", out)
+	}
+	// Return type must be substituted to *int (Optional → pointer).
+	if !strings.Contains(out, ") *int {") {
+		t.Errorf("expected substituted return `*int`:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "7" {
+		t.Errorf("runtime output = %q; want %q", got, "7")
+	}
+}
+
+// TestMonomorph_ListTypeArg confirms structured type args (here
+// `List<Int>` → Go `[]int`) survive the mangling / substitution path.
+// Brackets are sanitized to `Of` so the mangled name is still a
+// legal Go identifier.
+func TestMonomorph_ListTypeArg(t *testing.T) {
+	src := `fn first<T>(xs: List<T>) -> T {
+    xs[0]
+}
+
+fn main() {
+    let xs: List<Int> = [10, 20, 30]
+    let a = first(xs)
+    println("{a}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if !strings.Contains(out, "func first_int(") {
+		t.Errorf("expected `first_int` specialization for List<Int>:\n%s", out)
+	}
+	// The parameter's Osty List<T> must have been rendered with T
+	// substituted, i.e. `[]int` in the signature.
+	if !strings.Contains(out, "xs []int") {
+		t.Errorf("expected substituted param `xs []int`:\n%s", out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "10" {
+		t.Errorf("runtime output = %q; want %q", got, "10")
+	}
+}

--- a/internal/gen/monomorph_test.go
+++ b/internal/gen/monomorph_test.go
@@ -1,0 +1,102 @@
+package gen_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMonomorph_SpecializedCopies verifies that a generic fn with
+// instantiations at two distinct types emits two separate specialized
+// functions — no Go-generic `[T any]` header — and that each call
+// site resolves to its mangled specialization. This is the §2.7.3
+// contract: "one specialized copy per distinct instantiation".
+func TestMonomorph_SpecializedCopies(t *testing.T) {
+	src := `fn id<T>(x: T) -> T {
+    x
+}
+
+fn main() {
+    let a = id(42)
+    let b = id("hello")
+    println("{a} {b}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+
+	// The Go-generic shape (`func id[T any](x T) T`) must not appear —
+	// monomorphization replaces it with concrete specializations.
+	if strings.Contains(out, "func id[") || strings.Contains(out, "func id(x T)") {
+		t.Errorf("generic header still present in output (expected monomorphized):\n%s", out)
+	}
+	// Both specializations must be emitted.
+	if !strings.Contains(out, "func id_int(") {
+		t.Errorf("expected specialized `id_int` in output:\n%s", out)
+	}
+	if !strings.Contains(out, "func id_string(") {
+		t.Errorf("expected specialized `id_string` in output:\n%s", out)
+	}
+	// Call sites must reference the mangled names.
+	if !strings.Contains(out, "id_int(42)") {
+		t.Errorf("expected `id_int(42)` call site:\n%s", out)
+	}
+	if !strings.Contains(out, "id_string(\"hello\")") {
+		t.Errorf("expected `id_string(\"hello\")` call site:\n%s", out)
+	}
+	// And the program must still run correctly.
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "42 hello" {
+		t.Errorf("runtime output = %q; want %q", got, "42 hello")
+	}
+}
+
+// TestMonomorph_UnusedGenericOmitted verifies a generic function with
+// no instantiations is dropped entirely from the output — consistent
+// with §2.7.3's "demand-driven" lowering.
+func TestMonomorph_UnusedGenericOmitted(t *testing.T) {
+	src := `fn unused<T>(x: T) -> T {
+    x
+}
+
+fn main() {
+    println("hi")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if strings.Contains(out, "unused") {
+		t.Errorf("unused generic fn should be omitted, got:\n%s", out)
+	}
+}
+
+// TestMonomorph_DuplicateInstantiationCoalesced verifies two call
+// sites at the same type share one specialized copy (keyed on the
+// Go-type tuple, not the AST node).
+func TestMonomorph_DuplicateInstantiationCoalesced(t *testing.T) {
+	src := `fn id<T>(x: T) -> T {
+    x
+}
+
+fn main() {
+    let a = id(1)
+    let b = id(2)
+    println("{a} {b}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if n := strings.Count(out, "func id_int("); n != 1 {
+		t.Errorf("expected exactly one `func id_int(` definition, got %d:\n%s", n, out)
+	}
+	if got := strings.TrimSpace(runGo(t, goSrc)); got != "1 2" {
+		t.Errorf("runtime output = %q; want %q", got, "1 2")
+	}
+}

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -66,6 +66,9 @@ func (g *gen) goType(t types.Type) string {
 		return g.goNamedType(t)
 	case *types.TypeVar:
 		if t.Sym != nil {
+			if concrete, ok := g.lookupSubst(t.Sym.Name); ok {
+				return concrete
+			}
 			return t.Sym.Name
 		}
 		return "any"
@@ -284,6 +287,16 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 		return strings.Join(n.Path, ".")
 	}
 	name := n.Path[0]
+	// Generic type-parameter references substitute to the concrete Go
+	// type rendered at the monomorphizing call site. Applies only to
+	// bare single-path names with no type arguments — a `T<...>` shape
+	// is nonsense for a type variable, so we fall through if Args are
+	// present.
+	if len(n.Args) == 0 {
+		if concrete, ok := g.lookupSubst(name); ok {
+			return concrete
+		}
+	}
 	if gt, ok := primitiveByName[name]; ok {
 		return gt
 	}


### PR DESCRIPTION
## Summary

Generic fns previously round-tripped through the Go transpiler as Go-generic definitions (`func id[T any](x T) T`). Spec §2.7.3 requires true monomorphization: *"one specialized copy per distinct instantiation"*. This change adds that lowering step.

The checker already records `Instantiations[CallExpr] → []Type`; this PR is purely the consuming end.

## What changed

- `buildInstances` groups instantiations by generic fn symbol and mangles a unique Go name per type tuple (`id_int`, `id_string`).
- `emitFnDecl` skips the Go-generic header and emits one specialized body per instantiation under a substitution environment that maps each `T` to its concrete Go type.
- `goType` / `goTypeExpr` consult the substEnv when rendering a `TypeVar` or bare named-type reference.
- `emitCall` rewrites every generic call site to its mangled name.
- Generic fns with no call sites emit nothing — demand-driven, matching the spec's "header-like" framing.

## Scope

Methods on generic structs and generic type declarations (struct/enum/alias) still flow through the Go-native generics path. Tightening those is a separate, larger refactor and out of scope.

## Test plan

New tests in `internal/gen/monomorph_test.go`:

- [x] `TestMonomorph_SpecializedCopies` — asserts no `func id[T any]` header, both `id_int` and `id_string` emitted, call sites rewritten, program runs.
- [x] `TestMonomorph_UnusedGenericOmitted` — generic fn with zero call sites is absent from output.
- [x] `TestMonomorph_DuplicateInstantiationCoalesced` — two call sites at the same type share one specialization.
- [x] Existing `internal/gen` and `internal/check` suites still pass (pre-existing `internal/format` and `internal/testgen` failures are untouched by this change).
