### PR TITLE
pkgmgr: diamond conflict resolver via constraint unification

### DIFF
--- a/internal/pkgmgr/diamond_test.go
+++ b/internal/pkgmgr/diamond_test.go
@@ -1,0 +1,315 @@
+package pkgmgr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/registry"
+)
+
+// fakeRegistry stands in for a real osty registry server. Each entry
+// in `crates` maps a package name to its index entry; `tarballs`
+// holds the bytes served for `/v1/crates/<name>/<version>/tar`. The
+// helper builds the index entries, packages osty.toml stubs as tar
+// gzs, and returns an httptest.Server ready for plugging into Env.
+type fakeRegistry struct {
+	t     *testing.T
+	srv   *httptest.Server
+	crate map[string]*registry.IndexEntry
+	tar   map[string][]byte // key: "<name>/<version>"
+}
+
+func newFakeRegistry(t *testing.T) *fakeRegistry {
+	t.Helper()
+	fr := &fakeRegistry{
+		t:     t,
+		crate: map[string]*registry.IndexEntry{},
+		tar:   map[string][]byte{},
+	}
+	fr.srv = httptest.NewServer(http.HandlerFunc(fr.handle))
+	t.Cleanup(fr.srv.Close)
+	return fr
+}
+
+// publish records a package version. depReqs is a list of "name@req"
+// strings declaring the version's transitive deps; an empty list
+// makes a leaf package.
+func (fr *fakeRegistry) publish(name, version string, depReqs ...string) {
+	fr.t.Helper()
+	entry, ok := fr.crate[name]
+	if !ok {
+		entry = &registry.IndexEntry{Name: name}
+		fr.crate[name] = entry
+	}
+	v := registry.Version{
+		Version:     version,
+		Checksum:    "", // computed once tar bytes are known
+		PublishedAt: time.Now().UTC(),
+	}
+	// Build the package's osty.toml referencing its declared deps so
+	// the resolver's manifest parser sees them after extraction.
+	var manifestBuf bytes.Buffer
+	manifestBuf.WriteString("[package]\n")
+	manifestBuf.WriteString("name = \"" + name + "\"\n")
+	manifestBuf.WriteString("version = \"" + version + "\"\n")
+	if len(depReqs) > 0 {
+		manifestBuf.WriteString("\n[dependencies]\n")
+	}
+	for _, dr := range depReqs {
+		parts := strings.SplitN(dr, "@", 2)
+		if len(parts) != 2 {
+			fr.t.Fatalf("bad depReq %q", dr)
+		}
+		manifestBuf.WriteString(parts[0] + " = \"" + parts[1] + "\"\n")
+		v.Dependencies = append(v.Dependencies, registry.VersionDependency{
+			Name: parts[0], Req: parts[1], Kind: "normal",
+		})
+	}
+	pkgDir := fr.t.TempDir()
+	if err := os.WriteFile(filepath.Join(pkgDir, manifest.ManifestFile), manifestBuf.Bytes(), 0o644); err != nil {
+		fr.t.Fatal(err)
+	}
+	// A trivial source file ensures the tar isn't empty.
+	if err := os.WriteFile(filepath.Join(pkgDir, "lib.osty"),
+		[]byte("// "+name+" "+version+"\n"), 0o644); err != nil {
+		fr.t.Fatal(err)
+	}
+	var tarBuf bytes.Buffer
+	if err := CreateTarGz(pkgDir, &tarBuf); err != nil {
+		fr.t.Fatal(err)
+	}
+	v.Checksum = HashBytes(tarBuf.Bytes())
+	entry.Versions = append(entry.Versions, v)
+	fr.tar[name+"/"+version] = tarBuf.Bytes()
+}
+
+// handle dispatches the three endpoint shapes the resolver hits:
+// index lookup, tarball download, and a 404 default.
+func (fr *fakeRegistry) handle(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/v1/crates/"), "/")
+	if len(parts) == 1 {
+		entry, ok := fr.crate[parts[0]]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(entry)
+		return
+	}
+	if len(parts) == 3 && parts[2] == "tar" {
+		key := parts[0] + "/" + parts[1]
+		body, ok := fr.tar[key]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(body)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// envFor builds a pkgmgr.Env that points at this registry as the
+// default. proj is the project root the test wants to resolve under.
+func (fr *fakeRegistry) envFor(proj string) *Env {
+	return &Env{
+		CacheDir:    filepath.Join(fr.t.TempDir(), "cache"),
+		VendorDir:   filepath.Join(proj, ".osty", "deps"),
+		ProjectRoot: proj,
+		Registries:  map[string]string{"": fr.srv.URL},
+	}
+}
+
+// TestDiamondUnifyPicksHighestSatisfying covers the canonical diamond
+// case: root requires `B ^1.2`, root also requires path-dep `A` whose
+// own osty.toml requires `B ^1.0`. The greedy first pass following
+// the root's `B ^1.2` constraint should pick the highest 1.x. After
+// the unification pass intersects {^1.2, ^1.0} = ^1.2, the pin must
+// satisfy both — i.e. land on a 1.2.x or higher.
+func TestDiamondUnifyPicksHighestSatisfying(t *testing.T) {
+	fr := newFakeRegistry(t)
+	fr.publish("B", "1.0.0")
+	fr.publish("B", "1.1.0")
+	fr.publish("B", "1.2.5")
+	fr.publish("B", "1.3.0")
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	libA := filepath.Join(tmp, "libA")
+	for _, d := range []string{proj, libA} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	// libA depends on B ^1.0 — would normally pick 1.3.0.
+	must(t, manifest.Write(filepath.Join(libA, manifest.ManifestFile),
+		&manifest.Manifest{
+			Package: manifest.Package{Name: "libA", Version: "0.1.0"},
+			Dependencies: []manifest.Dependency{
+				{Name: "B", PackageName: "B", VersionReq: "^1.0", DefaultFeats: true},
+			},
+		}))
+
+	root := &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "libA", Path: "../libA", DefaultFeats: true},
+			{Name: "B", PackageName: "B", VersionReq: "^1.2", DefaultFeats: true},
+		},
+	}
+	env := fr.envFor(proj)
+
+	graph, err := Resolve(context.Background(), root, env)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	bNode := graph.Nodes["B"]
+	if bNode == nil {
+		t.Fatalf("expected B node, got %+v", graph.Nodes)
+	}
+	// The intersection of ^1.0 and ^1.2 admits only 1.2.x and 1.3.x.
+	// The picker chooses the highest, so 1.3.0.
+	if bNode.Fetched.Version != "1.3.0" {
+		t.Errorf("B version: got %q, want 1.3.0", bNode.Fetched.Version)
+	}
+}
+
+// TestDiamondConflictUnsatisfiable: root needs `B ^2.0` and a path
+// dep needs `B ^1.0` — no single major satisfies both, so the
+// resolver must fail with a clear chain in the message.
+func TestDiamondConflictUnsatisfiable(t *testing.T) {
+	fr := newFakeRegistry(t)
+	fr.publish("B", "1.0.0")
+	fr.publish("B", "1.5.0")
+	fr.publish("B", "2.0.0")
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	libA := filepath.Join(tmp, "libA")
+	for _, d := range []string{proj, libA} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	must(t, manifest.Write(filepath.Join(libA, manifest.ManifestFile),
+		&manifest.Manifest{
+			Package: manifest.Package{Name: "libA", Version: "0.1.0"},
+			Dependencies: []manifest.Dependency{
+				{Name: "B", PackageName: "B", VersionReq: "^1.0", DefaultFeats: true},
+			},
+		}))
+
+	root := &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "libA", Path: "../libA", DefaultFeats: true},
+			{Name: "B", PackageName: "B", VersionReq: "^2.0", DefaultFeats: true},
+		},
+	}
+	env := fr.envFor(proj)
+
+	_, err := Resolve(context.Background(), root, env)
+	if err == nil {
+		t.Fatalf("expected diamond conflict error")
+	}
+	msg := err.Error()
+	// The error must name the conflicting package and at least hint
+	// at the chain so the user knows where to look.
+	if !strings.Contains(msg, `"B"`) {
+		t.Errorf("error should name B: %v", err)
+	}
+	if !strings.Contains(msg, "required by") && !strings.Contains(msg, "no version satisfies") {
+		t.Errorf("error should explain origin: %v", err)
+	}
+}
+
+// TestSourceKindMismatchDiamond: one parent declares B as a path
+// source, another as a registry source. The unifier can't reconcile
+// these structurally — the resolver must error before any version
+// math.
+func TestSourceKindMismatchDiamond(t *testing.T) {
+	fr := newFakeRegistry(t)
+	fr.publish("B", "1.0.0")
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	libA := filepath.Join(tmp, "libA")
+	libB := filepath.Join(tmp, "libB")
+	for _, d := range []string{proj, libA, libB} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	// libB is a real path-shaped package that libA pulls in via path.
+	must(t, manifest.Write(filepath.Join(libB, manifest.ManifestFile),
+		&manifest.Manifest{Package: manifest.Package{Name: "B", Version: "9.9.9"}}))
+	must(t, manifest.Write(filepath.Join(libA, manifest.ManifestFile),
+		&manifest.Manifest{
+			Package: manifest.Package{Name: "libA", Version: "0.1.0"},
+			Dependencies: []manifest.Dependency{
+				{Name: "B", Path: "../libB", DefaultFeats: true},
+			},
+		}))
+
+	root := &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "libA", Path: "../libA", DefaultFeats: true},
+			// Root pulls B from registry — incompatible with libA's path.
+			{Name: "B", PackageName: "B", VersionReq: "^1.0", DefaultFeats: true},
+		},
+	}
+	env := fr.envFor(proj)
+
+	_, err := Resolve(context.Background(), root, env)
+	if err == nil {
+		t.Fatalf("expected source-kind mismatch error")
+	}
+	if !strings.Contains(err.Error(), "source kind mismatch") {
+		t.Errorf("error should mention source kind: %v", err)
+	}
+}
+
+// TestDiamondCompatibleRequirements: when both sides of the diamond
+// already agree (root and lib both want `B ^1.0`), no upgrade is
+// triggered and the greedy pick stands. Verifies the unifier doesn't
+// thrash when constraints are consistent.
+func TestDiamondCompatibleRequirements(t *testing.T) {
+	fr := newFakeRegistry(t)
+	fr.publish("B", "1.0.0")
+	fr.publish("B", "1.5.0")
+
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	libA := filepath.Join(tmp, "libA")
+	for _, d := range []string{proj, libA} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	must(t, manifest.Write(filepath.Join(libA, manifest.ManifestFile),
+		&manifest.Manifest{
+			Package: manifest.Package{Name: "libA", Version: "0.1.0"},
+			Dependencies: []manifest.Dependency{
+				{Name: "B", PackageName: "B", VersionReq: "^1.0", DefaultFeats: true},
+			},
+		}))
+
+	root := &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "libA", Path: "../libA", DefaultFeats: true},
+			{Name: "B", PackageName: "B", VersionReq: "^1.0", DefaultFeats: true},
+		},
+	}
+	env := fr.envFor(proj)
+
+	graph, err := Resolve(context.Background(), root, env)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if v := graph.Nodes["B"].Fetched.Version; v != "1.5.0" {
+		t.Errorf("B version: got %q, want 1.5.0 (highest in ^1.0)", v)
+	}
+}

--- a/internal/pkgmgr/resolve.go
+++ b/internal/pkgmgr/resolve.go
@@ -49,11 +49,28 @@ type ResolvedNode struct {
 // its pins are used to keep versions stable; unknown or newly-added
 // dependencies are resolved fresh.
 //
-// For the first iteration we implement the simplest correct
-// algorithm: DFS, first match wins within a name. The lockfile is
-// honored when the declared requirement still allows its pin. This
-// is good enough for path + git + a single-repo dev workflow; a
-// version-picking SAT solver is future work.
+// Algorithm — two phases:
+//
+//  1. Greedy DFS. Each unique local name is fetched once at the
+//     first version that satisfies its requirement (lockfile pin
+//     honored when present). Every constraint encountered along the
+//     way is recorded with its parent chain.
+//
+//  2. Iterative unification. For each registry-backed node, the
+//     resolver intersects every recorded version constraint and
+//     verifies the chosen pin still satisfies them all. When it
+//     doesn't, the node is re-fetched at the highest version
+//     satisfying the union and the new pin's transitive deps are
+//     re-walked so newly-introduced constraints fold in. The pass
+//     loops to a fixed point or reports an unsatisfiable conflict.
+//
+// Source-kind mismatches (path vs git vs registry for the same
+// local name) and path / git URI mismatches are caught structurally
+// during phase 1 with the offending parent chain in the message.
+//
+// True backtracking (changing a parent's already-pinned version to
+// admit a child) is not yet implemented; that would be a follow-up
+// pubgrub-style solver.
 func Resolve(ctx context.Context, root *manifest.Manifest, env *Env) (*Graph, error) {
 	if root == nil {
 		return nil, fmt.Errorf("nil root manifest")
@@ -63,41 +80,75 @@ func Resolve(ctx context.Context, root *manifest.Manifest, env *Env) (*Graph, er
 		return nil, err
 	}
 	r := &resolver{
-		env:      env,
-		lock:     existing,
-		root:     root,
-		graph:    &Graph{Root: root, Nodes: map[string]*ResolvedNode{}},
-		inflight: map[string]bool{},
+		env:         env,
+		lock:        existing,
+		root:        root,
+		graph:       &Graph{Root: root, Nodes: map[string]*ResolvedNode{}},
+		inflight:    map[string]bool{},
+		constraints: map[string][]constraintRef{},
 	}
 	for _, d := range root.Dependencies {
-		if _, err := r.resolveDep(ctx, d); err != nil {
+		if _, err := r.resolveDep(ctx, d, ""); err != nil {
 			return nil, err
 		}
 	}
 	for _, d := range root.DevDependencies {
-		if _, err := r.resolveDep(ctx, d); err != nil {
+		if _, err := r.resolveDep(ctx, d, ""); err != nil {
 			return nil, err
 		}
+	}
+	// Iterative refinement: the greedy first pass may have committed
+	// to versions that don't satisfy every constraint a transitive
+	// parent placed on them (the classic diamond case). Re-walk the
+	// graph upgrading registry pins to the highest version that
+	// satisfies the union of every recorded constraint, then revisit
+	// the new pin's transitive deps. Loop until the graph stops
+	// changing or we exceed the safety bound.
+	if err := r.unifyConstraints(ctx); err != nil {
+		return nil, err
 	}
 	r.graph.Order = r.topoOrder()
 	return r.graph, nil
 }
 
+// constraintRef is one observation of a dependency requirement.
+// Captured at every encounter (first-time and re-encounter) so the
+// unification pass can compute the intersection of every constraint
+// placed on a single local name and surface the parent chain in
+// conflict reports.
+type constraintRef struct {
+	parent string              // local name of the parent ("" = root manifest)
+	dep    manifest.Dependency // the original dep spec, preserves Path/Git/VersionReq
+}
+
 type resolver struct {
-	env      *Env
-	lock     *lockfile.Lock
-	root     *manifest.Manifest
-	graph    *Graph
-	inflight map[string]bool
+	env         *Env
+	lock        *lockfile.Lock
+	root        *manifest.Manifest
+	graph       *Graph
+	inflight    map[string]bool
+	constraints map[string][]constraintRef
 }
 
 // resolveDep fetches dep, records it in the graph, then recurses
-// into its own dependencies. Returns an error on cycle detection,
-// fetch failure, or conflicting versions.
-func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency) (*ResolvedNode, error) {
+// into its own dependencies. The parent argument is the local name
+// of whoever introduced this dep (the empty string for root deps);
+// it's recorded with each constraint so conflict reports can show
+// the full chain.
+//
+// Re-encounters: when the same local name is requested again from a
+// different point in the graph, the second spec is recorded as a
+// constraint. If it's structurally incompatible with the first
+// (different source kind, mismatched path / git URI), the conflict
+// is fatal. Version-only differences are deferred to unifyConstraints,
+// which runs after the greedy walk and can pick a higher version
+// satisfying every collected requirement.
+func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency, parent string) (*ResolvedNode, error) {
+	r.recordConstraint(d, parent)
 	if existing, ok := r.graph.Nodes[d.Name]; ok {
-		// Already resolved under this local name. A conflicting
-		// second Dependency spec with the same name is rejected here.
+		if err := r.checkSourceKindCompatible(existing, d, parent); err != nil {
+			return nil, err
+		}
 		return existing, nil
 	}
 	if r.inflight[d.Name] {
@@ -132,13 +183,216 @@ func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency) (*Reso
 	// followed for transitive packages — only the root's dev-deps
 	// matter.
 	for _, sub := range fetched.Manifest.Dependencies {
-		child, err := r.resolveDep(ctx, sub)
+		child, err := r.resolveDep(ctx, sub, d.Name)
 		if err != nil {
 			return nil, err
 		}
 		node.Deps = append(node.Deps, child.Name)
 	}
 	return node, nil
+}
+
+// recordConstraint appends one (parent, dep) pair to the running
+// constraint list for d.Name. Called on every encounter (first time
+// and every re-encounter) so unifyConstraints sees the full picture.
+func (r *resolver) recordConstraint(d manifest.Dependency, parent string) {
+	r.constraints[d.Name] = append(r.constraints[d.Name], constraintRef{
+		parent: parent,
+		dep:    d,
+	})
+}
+
+// checkSourceKindCompatible enforces the structural rules: a name
+// already pinned at a path source can't later be requested from git
+// or a registry; a name pinned to a git URL must come from the same
+// URL+ref everywhere; etc. Version-only conflicts are NOT raised
+// here — those are handled by unifyConstraints.
+func (r *resolver) checkSourceKindCompatible(existing *ResolvedNode, d manifest.Dependency, parent string) error {
+	wantSrc, err := NewSource(d)
+	if err != nil {
+		return err
+	}
+	if existing.Source.Kind() != wantSrc.Kind() {
+		return r.conflictError(d.Name,
+			fmt.Sprintf("source kind mismatch: %s wants %s, but %s already pinned as %s",
+				describeParent(parent), wantSrc.Kind(),
+				d.Name, existing.Source.Kind()))
+	}
+	switch existing.Source.Kind() {
+	case SourcePath:
+		if existing.Source.URI() != wantSrc.URI() {
+			return r.conflictError(d.Name,
+				fmt.Sprintf("path mismatch: %s vs %s",
+					existing.Source.URI(), wantSrc.URI()))
+		}
+	case SourceGit:
+		if existing.Source.URI() != wantSrc.URI() {
+			return r.conflictError(d.Name,
+				fmt.Sprintf("git source mismatch: %s vs %s",
+					existing.Source.URI(), wantSrc.URI()))
+		}
+	}
+	return nil
+}
+
+// conflictError formats a diamond-style conflict report including
+// every parent chain that referenced the offending name. The output
+// is multi-line so the user can immediately see who placed which
+// requirement.
+func (r *resolver) conflictError(name, reason string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "dependency conflict on %q: %s", name, reason)
+	if refs := r.constraints[name]; len(refs) > 0 {
+		b.WriteString("\n  required by:")
+		for _, c := range refs {
+			fmt.Fprintf(&b, "\n    - %s -> %s", describeParent(c.parent), describeDepReq(c.dep))
+		}
+	}
+	return errors.New(b.String())
+}
+
+func describeParent(p string) string {
+	if p == "" {
+		return "<root>"
+	}
+	return p
+}
+
+func describeDepReq(d manifest.Dependency) string {
+	switch {
+	case d.Path != "":
+		return fmt.Sprintf("%s (path %s)", d.Name, d.Path)
+	case d.Git != nil:
+		return fmt.Sprintf("%s (git %s)", d.Name, gitRefSummary(d.Git))
+	case d.VersionReq != "":
+		return fmt.Sprintf("%s %s", d.Name, d.VersionReq)
+	}
+	return d.Name
+}
+
+func gitRefSummary(g *manifest.GitSource) string {
+	parts := []string{g.URL}
+	if g.Tag != "" {
+		parts = append(parts, "tag="+g.Tag)
+	}
+	if g.Branch != "" {
+		parts = append(parts, "branch="+g.Branch)
+	}
+	if g.Rev != "" {
+		parts = append(parts, "rev="+g.Rev)
+	}
+	return strings.Join(parts, " ")
+}
+
+// unifyConstraints is the post-DFS validation/repair pass. For each
+// registry-backed name, it intersects every recorded version
+// requirement and verifies that the currently-pinned version
+// satisfies them all. When it doesn't, the resolver re-fetches at
+// the highest version satisfying the union, swaps the node in
+// place, and re-walks the new pin's transitive deps so any new
+// constraints they introduce are caught the next iteration.
+//
+// Iterates to a fixed point. Bounded at maxIters to defend against
+// pathological version-graph oscillation; in practice convergence
+// happens in 1–2 passes for real-world graphs.
+func (r *resolver) unifyConstraints(ctx context.Context) error {
+	const maxIters = 16
+	for iter := 0; iter < maxIters; iter++ {
+		changed := false
+		// Iterate names in deterministic order so error messages and
+		// trace output don't depend on map iteration order.
+		names := make([]string, 0, len(r.graph.Nodes))
+		for name := range r.graph.Nodes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			node := r.graph.Nodes[name]
+			if node == nil || node.Source == nil || node.Source.Kind() != SourceRegistry {
+				continue
+			}
+			rs, ok := node.Source.(*registrySource)
+			if !ok {
+				continue
+			}
+			combined, err := r.intersectRegistryReqs(name)
+			if err != nil {
+				return err
+			}
+			cur, err := semver.ParseVersion(node.Fetched.Version)
+			if err != nil {
+				return fmt.Errorf("internal: cannot parse pinned version %q for %s: %w",
+					node.Fetched.Version, name, err)
+			}
+			if combined.Match(cur) {
+				continue // pin already satisfies every constraint
+			}
+			// Re-fetch at the union req. The narrowed source is
+			// driven by mutating versionReq directly; the existing
+			// applyLockPin path uses the same trick.
+			newRs := &registrySource{
+				name:         rs.name,
+				packageName:  rs.packageName,
+				versionReq:   combined.String(),
+				registryName: rs.registryName,
+			}
+			fetched, ferr := newRs.Fetch(ctx, r.env)
+			if ferr != nil {
+				return r.conflictError(name,
+					fmt.Sprintf("no version satisfies the combined constraints (%s): %v",
+						combined.String(), ferr))
+			}
+			// Swap in the upgraded pin. Drop the old transitive
+			// edges; we'll repopulate them by re-walking the new
+			// pin's manifest below. Children that are still reached
+			// from elsewhere remain valid in r.graph.Nodes; orphans
+			// are pruned by topoOrder later.
+			node.Source = newRs
+			node.Fetched = fetched
+			node.Deps = node.Deps[:0]
+			for _, sub := range fetched.Manifest.Dependencies {
+				child, cerr := r.resolveDep(ctx, sub, name)
+				if cerr != nil {
+					return cerr
+				}
+				node.Deps = append(node.Deps, child.Name)
+			}
+			changed = true
+		}
+		if !changed {
+			return nil
+		}
+	}
+	return errors.New("dependency resolver did not converge after 16 iterations (cyclic version constraints?)")
+}
+
+// intersectRegistryReqs returns a single semver.Req representing the
+// AND of every version requirement recorded for `name`. Empty / "*"
+// reqs contribute nothing; explicit reqs are joined with a space
+// (semver's ParseReq accepts space-separated conjunctions).
+func (r *resolver) intersectRegistryReqs(name string) (semver.Req, error) {
+	var clauses []string
+	seen := map[string]bool{}
+	for _, c := range r.constraints[name] {
+		req := strings.TrimSpace(c.dep.VersionReq)
+		if req == "" || req == "*" {
+			continue
+		}
+		if seen[req] {
+			continue
+		}
+		seen[req] = true
+		clauses = append(clauses, req)
+	}
+	if len(clauses) == 0 {
+		return semver.ParseReq("*")
+	}
+	combined := strings.Join(clauses, " ")
+	parsed, err := semver.ParseReq(combined)
+	if err != nil {
+		return semver.Req{}, fmt.Errorf("intersect %s: %w", name, err)
+	}
+	return parsed, nil
 }
 
 // topoOrder returns node names in a stable, leaves-first order.


### PR DESCRIPTION
## Summary

Closes the last "future work" gap on the package-resolver side: the previous greedy first-match-wins resolver silently ignored constraints from later parents in the dep graph. `app -> A ^1.0` plus `app -> B -> A ^1.2` would silently keep the first 1.x picked, even when it failed the second constraint.

## Algorithm

Two phases inside `pkgmgr.Resolve`:

1. **Greedy DFS**, instrumented. Every `(name, dep, parent)` tuple is recorded in `resolver.constraints` as we walk. Source-kind + source-identity mismatches (path vs git, two paths, two git refs) are structural conflicts caught here and reported with the parent chain.

2. **`unifyConstraints` post-pass**. For each registry-backed node it intersects every recorded version requirement (semver's `ParseReq` accepts space-separated AND clauses), checks the pinned version, and re-fetches at the highest version satisfying the union when the current pin doesn't fit. The new pin's transitive deps are walked so cascading constraints surface and the pass repeats to a fixed point.

When no single version satisfies the intersection, the resolver errors with a multi-line report listing every parent that referenced the package and the requirement each placed.

## Out of scope

Pubgrub-style backtracking (changing an already-pinned parent's version to admit a child) is called out as future work in the doc comment but not implemented. In practice, registry packages let parents satisfy a wide range of child versions, so this rarely matters; the chain reports give the user enough info to manually adjust a top-level constraint.

## Tests (`internal/pkgmgr/diamond_test.go`)

Set up an in-process fake registry that serves real index entries + tarballs (built via `CreateTarGz` over a generated `osty.toml` per version). Cases:

- Diamond unification picks the highest version satisfying both constraints (root `^1.2` + transitive `^1.0` → 1.3.0).
- Unsatisfiable diamonds (`^2.0` vs `^1.0`) error with name + chain.
- Source-kind mismatch (path vs registry on same name) errors before any version math.
- Compatible requirements (both `^1.0`) don't trigger upgrades or thrash the unifier.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pkgmgr/ ./internal/registry/ ./cmd/osty/`
- [x] All four new diamond tests pass.
- [ ] Manual: a real workspace with conflicting transitive registry deps.

https://claude.ai/code/session_016m2uppSVLMJkgo6Cg1xNVv