### PR TITLE
stdlib: implement std.math / std.env / std.strings / std.fs end-to-end

### DIFF
--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -374,6 +374,14 @@ func (g *gen) emitUseDecl(u *ast.UseDecl) {
 		return
 	}
 	full := strings.Join(u.Path, ".")
+	if mod := stdModuleWithRewrites(u.Path); mod != "" {
+		// std.math / std.env / std.strings / std.fs: their call sites
+		// are rewritten into Go stdlib calls by the per-module emitters
+		// (see stdlib_calls.go). No Go import is emitted here — each
+		// rewrite requests the Go package it needs via g.use().
+		g.stdAliases[alias] = mod
+		return
+	}
 	if bridge := stdlibBridge(u.Path); bridge != "" {
 		g.use(bridge)
 		// When the Go bridge's package name already matches the

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -321,6 +321,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		if g.emitConcurrencyMethod(c, f) {
 			return
 		}
+		if g.emitStdlibCall(c, f) {
+			return
+		}
 		if g.emitStaticCall(f, c.Args) {
 			return
 		}
@@ -593,6 +596,23 @@ func (g *gen) resultTypeArgsAt(callType types.Type, payloadType types.Type, isEr
 	if n, ok := callType.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" && len(n.Args) == 2 {
 		tArg = g.goType(n.Args[0])
 		tErr = g.goType(n.Args[1])
+		if tArg != "any" || tErr != "any" {
+			return tArg, tErr
+		}
+		// Both args were "any" — probably because the checker couldn't
+		// propagate types through the enclosing expression. Prefer the
+		// function's declared return type over this information-free
+		// guess so tail-position `Ok(x)` aligns with the signature.
+	}
+	// Fall back to the enclosing function's return type when the checker
+	// didn't pin one on this specific call. This lets `Ok(x)` in tail
+	// position align with the signature's Result<T, E> even when the
+	// checker hasn't propagated call-level types (e.g. stdlib calls via
+	// the registry).
+	if nt, ok := g.currentRetType.(*ast.NamedType); ok && len(nt.Path) > 0 &&
+		nt.Path[len(nt.Path)-1] == "Result" && len(nt.Args) == 2 {
+		tArg = g.goTypeExpr(nt.Args[0])
+		tErr = g.goTypeExpr(nt.Args[1])
 		return tArg, tErr
 	}
 	// Fallback to payload type on the known side.
@@ -1126,6 +1146,9 @@ func (g *gen) emitQuestion(q *ast.QuestionExpr) {
 //
 // Field-type lookup comes from the checker when available.
 func (g *gen) emitField(f *ast.FieldExpr) {
+	if !f.IsOptional && g.emitStdlibField(f) {
+		return
+	}
 	if !f.IsOptional {
 		// Numeric literals need parens to disambiguate from float
 		// literals: `5.s` would be lexed as `5.` + `s` by Go. The

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -100,6 +100,13 @@ type gen struct {
 	// statement-level pre-lift pass (see preLiftQuestions); consumed by
 	// emitQuestion. Nil when no lift is in progress.
 	questionSubs map[*ast.QuestionExpr]string
+
+	// stdAliases maps a user-visible alias to the stdlib module name
+	// (e.g. "math", "strings", "fs", "env") whose free functions the
+	// gen rewrites into Go stdlib calls. Populated by emitUseDecl when
+	// it recognises a `use std.<mod>` whose call/field surface has a
+	// dedicated per-module rewriter.
+	stdAliases map[string]string
 }
 
 func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result) *gen {
@@ -113,6 +120,7 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 		variantOwner: map[string]string{},
 		enumTypes:    map[string]bool{},
 		methodNames:  map[string]map[string]bool{},
+		stdAliases:   map[string]string{},
 	}
 	g.indexTypes()
 	return g

--- a/internal/gen/question.go
+++ b/internal/gen/question.go
@@ -38,8 +38,7 @@ func (g *gen) preLiftQuestions(e ast.Expr) {
 		}
 		tmp := g.freshVar("_q")
 		g.emitQuestionLiftBody(tmp, q)
-		operandT := g.typeOf(q.X)
-		if isResultOperand(operandT) {
+		if g.isResultOperand(q.X) {
 			g.questionSubs[q] = tmp + ".Value"
 		} else {
 			g.questionSubs[q] = "*" + tmp
@@ -51,8 +50,7 @@ func (g *gen) preLiftQuestions(e ast.Expr) {
 // prelude for one lifted `?` occurrence. Shared by the let-stmt fast
 // path, the return-stmt lift, and preLiftQuestions.
 func (g *gen) emitQuestionLiftBody(tmp string, q *ast.QuestionExpr) {
-	operandT := g.typeOf(q.X)
-	isResult := isResultOperand(operandT)
+	isResult := g.isResultOperand(q.X)
 	g.body.writef("%s := ", tmp)
 	g.emitExpr(q.X)
 	g.body.nl()
@@ -67,13 +65,46 @@ func (g *gen) emitQuestionLiftBody(tmp string, q *ast.QuestionExpr) {
 	g.body.writef("if %s == nil { return nil }\n", tmp)
 }
 
-// isResultOperand reports whether the operand type of a `?` is
-// Result<T, E>. Any other type (Optional, bare named, or nil) is
-// treated as Option for lift purposes — which matches Osty's spec:
-// only Result and Option support `?`.
-func isResultOperand(t types.Type) bool {
-	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" {
-		return true
+// isResultOperand reports whether the operand of a `?` yields a
+// Result<T, E>. Prefers the checker-inferred type; falls back to an
+// AST shape check for stdlib calls the checker hasn't typed (e.g.
+// `fs.readToString(p)?` inside a registry-less transpile pass).
+func (g *gen) isResultOperand(e ast.Expr) bool {
+	if t := g.typeOf(e); t != nil {
+		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" {
+			return true
+		}
+	}
+	return g.astShapeIsResult(e)
+}
+
+// astShapeIsResult inspects the AST of an expression whose checker type
+// is missing to decide whether it returns a Result. Currently recognises
+// stdlib fs calls that are declared with a Result return type; this is
+// the set of calls the pre-lift might otherwise miss when the checker
+// didn't propagate the stub's signature to the call expression.
+func (g *gen) astShapeIsResult(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	f, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return false
+	}
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	mod, ok := g.stdAliases[id.Name]
+	if !ok {
+		return false
+	}
+	if mod == "fs" {
+		switch f.Name {
+		case "readToString", "writeString", "remove":
+			return true
+		}
 	}
 	return false
 }

--- a/internal/gen/stdlib_calls.go
+++ b/internal/gen/stdlib_calls.go
@@ -1,0 +1,275 @@
+package gen
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/types"
+)
+
+// stdModuleWithRewrites reports whether a `use std.<mod>` path refers
+// to a module whose call and field surface is lowered by the
+// per-module rewriters in this file. Returns the bare module name
+// ("math", "env", "strings", "fs") or "" when no rewriter applies —
+// the caller then falls back to the generic stdlibBridge path.
+func stdModuleWithRewrites(path []string) string {
+	if len(path) < 2 || path[0] != "std" {
+		return ""
+	}
+	switch path[1] {
+	case "math", "env", "strings", "fs":
+		return path[1]
+	}
+	return ""
+}
+
+// emitStdlibCall intercepts `<alias>.<fn>(args)` when <alias> was bound
+// by a `use std.math/env/strings/fs` declaration and rewrites it to the
+// equivalent Go stdlib call. Returns false when the call shape doesn't
+// match, letting the generic emitter take over.
+func (g *gen) emitStdlibCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	mod, ok := g.stdAliases[id.Name]
+	if !ok {
+		return false
+	}
+	switch mod {
+	case "math":
+		return g.emitMathCall(c, f.Name)
+	case "env":
+		return g.emitEnvCall(c, f.Name)
+	case "strings":
+		return g.emitStringsCall(c, f.Name)
+	case "fs":
+		return g.emitFsCall(c, f.Name)
+	}
+	return false
+}
+
+// emitStdlibField intercepts `<alias>.<const>` accesses (no call) for
+// stdlib aliases that expose constants — currently only std.math. The
+// constants lower to their Go `math.*` equivalents.
+func (g *gen) emitStdlibField(f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	mod, ok := g.stdAliases[id.Name]
+	if !ok {
+		return false
+	}
+	if mod != "math" {
+		return false
+	}
+	switch f.Name {
+	case "PI":
+		g.use("math")
+		g.body.write("math.Pi")
+		return true
+	case "E":
+		g.use("math")
+		g.body.write("math.E")
+		return true
+	case "TAU":
+		g.use("math")
+		g.body.write("(2 * math.Pi)")
+		return true
+	case "INFINITY":
+		g.use("math")
+		g.body.write("math.Inf(1)")
+		return true
+	case "NAN":
+		g.use("math")
+		g.body.write("math.NaN()")
+		return true
+	}
+	return false
+}
+
+// emitMathCall lowers `math.<fn>(args)` to the equivalent `math.<Fn>`
+// call. Every function in std.math maps to a single Go math-package
+// function except `log`, whose two-argument form divides natural logs
+// to synthesize an arbitrary base.
+func (g *gen) emitMathCall(c *ast.CallExpr, name string) bool {
+	simple := map[string]string{
+		"sin": "Sin", "cos": "Cos", "tan": "Tan",
+		"asin": "Asin", "acos": "Acos", "atan": "Atan",
+		"atan2": "Atan2",
+		"sinh":  "Sinh", "cosh": "Cosh", "tanh": "Tanh",
+		"exp":  "Exp",
+		"log2": "Log2", "log10": "Log10",
+		"sqrt": "Sqrt", "cbrt": "Cbrt",
+		"pow":   "Pow",
+		"floor": "Floor", "ceil": "Ceil", "round": "Round", "trunc": "Trunc",
+		"abs": "Abs",
+		"min": "Min", "max": "Max",
+		"hypot": "Hypot",
+	}
+	if goName, ok := simple[name]; ok {
+		g.use("math")
+		g.body.writef("math.%s(", goName)
+		g.emitCallArgList(c.Args)
+		g.body.write(")")
+		return true
+	}
+	if name == "log" {
+		g.use("math")
+		switch len(c.Args) {
+		case 1:
+			g.body.write("math.Log(")
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(")")
+			return true
+		case 2:
+			// log(x, base) = ln(x) / ln(base)
+			g.body.write("(math.Log(")
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(") / math.Log(")
+			g.emitExpr(c.Args[1].Value)
+			g.body.write("))")
+			return true
+		}
+	}
+	return false
+}
+
+// emitEnvCall lowers `env.args/get/set` to their os-package analogues.
+func (g *gen) emitEnvCall(c *ast.CallExpr, name string) bool {
+	switch name {
+	case "args":
+		g.use("os")
+		g.body.write("os.Args")
+		return true
+	case "get":
+		if len(c.Args) == 1 {
+			g.use("os")
+			g.body.write("os.Getenv(")
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(")")
+			return true
+		}
+	case "set":
+		if len(c.Args) == 2 {
+			g.use("os")
+			// os.Setenv returns an error. std.env.set returns Unit, so we
+			// discard the error via a blank assignment inside an IIFE to
+			// preserve expression position. At statement position the
+			// IIFE collapses into a no-op call after gofmt.
+			g.body.write("func() { _ = os.Setenv(")
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(", ")
+			g.emitExpr(c.Args[1].Value)
+			g.body.write(") }()")
+			return true
+		}
+	}
+	return false
+}
+
+// emitStringsCall lowers `strings.<fn>` to `strings.<Fn>` with a handful
+// of name remappings for the non-obvious cases.
+func (g *gen) emitStringsCall(c *ast.CallExpr, name string) bool {
+	g.use("strings")
+	switch name {
+	case "split":
+		g.body.write("strings.Split(")
+	case "join":
+		g.body.write("strings.Join(")
+	case "contains":
+		g.body.write("strings.Contains(")
+	case "startsWith":
+		g.body.write("strings.HasPrefix(")
+	case "endsWith":
+		g.body.write("strings.HasSuffix(")
+	case "trim":
+		g.body.write("strings.TrimSpace(")
+	case "trimStart":
+		g.body.write("strings.TrimLeft(")
+	case "trimEnd":
+		g.body.write("strings.TrimRight(")
+	case "toUpper":
+		g.body.write("strings.ToUpper(")
+	case "toLower":
+		g.body.write("strings.ToLower(")
+	case "repeat":
+		g.body.write("strings.Repeat(")
+	case "replace":
+		g.body.write("strings.ReplaceAll(")
+	default:
+		return false
+	}
+	g.emitCallArgList(c.Args)
+	// trimStart / trimEnd take a cutset as second arg in Go's API; the
+	// Osty surface takes just the string, so we append a standard
+	// whitespace cutset to keep the call total-function.
+	if name == "trimStart" || name == "trimEnd" {
+		g.body.write(", \" \\t\\n\\r\\v\\f\"")
+	}
+	g.body.write(")")
+	return true
+}
+
+// emitFsCall lowers `fs.<fn>` calls to the corresponding os package
+// call, wrapping failures into Osty's Result[T, E] runtime where the
+// signature demands it.
+func (g *gen) emitFsCall(c *ast.CallExpr, name string) bool {
+	switch name {
+	case "exists":
+		if len(c.Args) == 1 {
+			g.use("os")
+			g.body.write("func() bool { _, err := os.Stat(")
+			g.emitExpr(c.Args[0].Value)
+			g.body.write("); return err == nil }()")
+			return true
+		}
+	case "readToString":
+		if len(c.Args) == 1 {
+			g.use("os")
+			g.needResult = true
+			tArg, tErr := g.fsResultTypeArgs(c, "string")
+			g.body.writef("func() Result[%s, %s] { b, err := os.ReadFile(", tArg, tErr)
+			g.emitExpr(c.Args[0].Value)
+			g.body.writef("); if err != nil { return Result[%s, %s]{Error: err} }; ", tArg, tErr)
+			g.body.writef("return Result[%s, %s]{Value: string(b), IsOk: true} }()", tArg, tErr)
+			return true
+		}
+	case "writeString":
+		if len(c.Args) == 2 {
+			g.use("os")
+			g.needResult = true
+			tArg, tErr := g.fsResultTypeArgs(c, "struct{}")
+			g.body.writef("func() Result[%s, %s] { err := os.WriteFile(", tArg, tErr)
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(", []byte(")
+			g.emitExpr(c.Args[1].Value)
+			g.body.writef("), 0o644); if err != nil { return Result[%s, %s]{Error: err} }; ", tArg, tErr)
+			g.body.writef("return Result[%s, %s]{IsOk: true} }()", tArg, tErr)
+			return true
+		}
+	case "remove":
+		if len(c.Args) == 1 {
+			g.use("os")
+			g.needResult = true
+			tArg, tErr := g.fsResultTypeArgs(c, "struct{}")
+			g.body.writef("func() Result[%s, %s] { err := os.Remove(", tArg, tErr)
+			g.emitExpr(c.Args[0].Value)
+			g.body.writef("); if err != nil { return Result[%s, %s]{Error: err} }; ", tArg, tErr)
+			g.body.writef("return Result[%s, %s]{IsOk: true} }()", tArg, tErr)
+			return true
+		}
+	}
+	return false
+}
+
+// fsResultTypeArgs picks the Go (T, E) type arguments for an fs call's
+// Result wrapper. Prefers the checker's inferred Result<T, E>; falls
+// back to (defaultT, any) when the call's type is missing.
+func (g *gen) fsResultTypeArgs(c *ast.CallExpr, defaultT string) (string, string) {
+	if t := g.typeOf(c); t != nil {
+		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" && len(n.Args) == 2 {
+			return g.goType(n.Args[0]), g.goType(n.Args[1])
+		}
+	}
+	return defaultT, "any"
+}

--- a/internal/gen/stdlib_calls_test.go
+++ b/internal/gen/stdlib_calls_test.go
@@ -1,0 +1,185 @@
+package gen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/gen"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// transpileWithStdlib runs the pipeline with the stdlib registry attached
+// so `use std.math` et al. resolve to real module signatures.
+func transpileWithStdlib(t *testing.T, src string) ([]byte, error) {
+	t.Helper()
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	for _, d := range parseDiags {
+		if d.Severity.String() == "error" {
+			t.Fatalf("parse error: %s", d.Message)
+		}
+	}
+	reg := stdlib.LoadCached()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	return gen.Generate("main", file, res, chk)
+}
+
+// TestStdMathBasic exercises the std.math call-site rewrites: simple
+// trig, sqrt, and the constant PI all route to Go's math package with
+// capitalised function names and math.Pi for the constant.
+func TestStdMathBasic(t *testing.T) {
+	src := `use std.math
+
+fn main() {
+    let s = math.sqrt(16.0)
+    let two = math.cos(0.0) + math.sin(0.0)
+    let pi = math.PI
+    println("{s} {two} {pi}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	str := string(goSrc)
+	for _, want := range []string{"math.Sqrt(", "math.Cos(", "math.Sin(", "math.Pi"} {
+		if !strings.Contains(str, want) {
+			t.Errorf("output missing %q:\n%s", want, str)
+		}
+	}
+	out := runGo(t, goSrc)
+	if !strings.HasPrefix(strings.TrimSpace(out), "4 1 3.14159") {
+		t.Errorf("unexpected output: %q\n--- src ---\n%s", out, goSrc)
+	}
+}
+
+// TestStdMathLog covers the two-argument `log(x, base)` that divides
+// natural logs.
+func TestStdMathLog(t *testing.T) {
+	src := `use std.math
+
+fn main() {
+    let a = math.log(100.0, 10.0)
+    let b = math.log(2.718281828459045)
+    println("{a} {b}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	parts := strings.Fields(strings.TrimSpace(out))
+	if len(parts) != 2 {
+		t.Fatalf("expected two numbers, got %q", out)
+	}
+	if !strings.HasPrefix(parts[0], "2") {
+		t.Errorf("log(100,10) = %q, want ~2", parts[0])
+	}
+	if !strings.HasPrefix(parts[1], "1") {
+		t.Errorf("log(e) = %q, want ~1", parts[1])
+	}
+}
+
+// TestStdEnv covers env.get / env.args rewrites.
+func TestStdEnv(t *testing.T) {
+	src := `use std.env
+
+fn main() {
+    let args = env.args()
+    env.set("OSTY_GEN_TEST_VAR", "hello")
+    let v = env.get("OSTY_GEN_TEST_VAR")
+    println("{v}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	str := string(goSrc)
+	for _, want := range []string{"os.Args", "os.Setenv(", "os.Getenv("} {
+		if !strings.Contains(str, want) {
+			t.Errorf("output missing %q:\n%s", want, str)
+		}
+	}
+	out := runGo(t, goSrc)
+	if strings.TrimSpace(out) != "hello" {
+		t.Errorf("unexpected output: %q\n--- src ---\n%s", out, goSrc)
+	}
+}
+
+// TestStdStrings exercises the strings.* rewrites — every function in
+// the Tier 1 stub gets one call site so a regression in any entry
+// surfaces here.
+func TestStdStrings(t *testing.T) {
+	src := `use std.strings
+
+fn main() {
+    let parts = strings.split("a,b,c", ",")
+    let joined = strings.join(parts, "-")
+    let up = strings.toUpper("hi")
+    let down = strings.toLower("HI")
+    let trimmed = strings.trim("  padded  ")
+    let ls = strings.trimStart("  left")
+    let rs = strings.trimEnd("right  ")
+    let has = strings.contains("foobar", "oba")
+    let sw = strings.startsWith("foobar", "foo")
+    let ew = strings.endsWith("foobar", "bar")
+    let rep = strings.repeat("ab", 3)
+    let replaced = strings.replace("a-b-c", "-", "_")
+    println("{joined} {up} {down} {trimmed}|{ls}|{rs}| {has} {sw} {ew} {rep} {replaced}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	want := "a-b-c HI hi padded|left|right| true true true ababab a_b_c"
+	if strings.TrimSpace(out) != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}
+
+// TestStdFsRoundTrip covers the fs.writeString → fs.readToString →
+// fs.exists → fs.remove cycle end-to-end, including `?` propagation
+// through a Result-returning helper.
+func TestStdFsRoundTrip(t *testing.T) {
+	src := `use std.fs
+
+fn run(path: String) -> Result<String, Error> {
+    fs.writeString(path, "payload")?
+    let data = fs.readToString(path)?
+    Ok(data)
+}
+
+fn main() {
+    let path = "/tmp/osty_std_fs_test.txt"
+    let r = run(path)
+    match r {
+        Ok(s) -> println("read={s}"),
+        Err(_) -> println("err"),
+    }
+    let present = fs.exists(path)
+    println("exists={present}")
+    match fs.remove(path) {
+        Ok(_) -> println("removed"),
+        Err(_) -> println("remove-err"),
+    }
+    let stillThere = fs.exists(path)
+    println("exists={stillThere}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	want := "read=payload\nexists=true\nremoved\nexists=false\n"
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}

--- a/internal/gen/stmt.go
+++ b/internal/gen/stmt.go
@@ -207,11 +207,7 @@ func identPatternName(p ast.Pattern) string {
 // discarded.
 func (g *gen) emitQuestionLift(name string, q *ast.QuestionExpr) {
 	tmp := g.freshVar("_q")
-	operandT := g.typeOf(q.X)
-	isResult := false
-	if n, ok := operandT.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" {
-		isResult = true
-	}
+	isResult := g.isResultOperand(q.X)
 	g.body.writef("%s := ", tmp)
 	g.emitExpr(q.X)
 	g.body.nl()

--- a/internal/stdlib/modules/env.osty
+++ b/internal/stdlib/modules/env.osty
@@ -1,0 +1,13 @@
+// std.env — command-line arguments and environment variables.
+//
+// Tier 2 module (spec §10.2). Bridged to Go's `os` package in the
+// transpiler: `env.args()` → `os.Args`, `env.get`/`env.set` →
+// `os.Getenv`/`os.Setenv`. Missing variables return the empty string;
+// callers who need present/absent discrimination should check for
+// that explicitly.
+
+pub fn args() -> List<String> { [] }
+
+pub fn get(key: String) -> String { "" }
+
+pub fn set(key: String, value: String) {}

--- a/internal/stdlib/modules/math.osty
+++ b/internal/stdlib/modules/math.osty
@@ -1,0 +1,43 @@
+// std.math — mathematical functions and constants.
+//
+// Every function operates on `Float` and maps 1:1 to Go's `math`
+// package in the transpiler. Constants are lowered to their `math.*`
+// equivalents at use site.
+
+pub let PI: Float = 3.141592653589793
+pub let E: Float = 2.718281828459045
+pub let TAU: Float = 6.283185307179586
+pub let INFINITY: Float = 0.0
+pub let NAN: Float = 0.0
+
+pub fn sin(x: Float) -> Float { x }
+pub fn cos(x: Float) -> Float { x }
+pub fn tan(x: Float) -> Float { x }
+
+pub fn asin(x: Float) -> Float { x }
+pub fn acos(x: Float) -> Float { x }
+pub fn atan(x: Float) -> Float { x }
+pub fn atan2(y: Float, x: Float) -> Float { y }
+
+pub fn sinh(x: Float) -> Float { x }
+pub fn cosh(x: Float) -> Float { x }
+pub fn tanh(x: Float) -> Float { x }
+
+pub fn exp(x: Float) -> Float { x }
+pub fn log(x: Float) -> Float { x }
+pub fn log2(x: Float) -> Float { x }
+pub fn log10(x: Float) -> Float { x }
+
+pub fn sqrt(x: Float) -> Float { x }
+pub fn cbrt(x: Float) -> Float { x }
+pub fn pow(x: Float, y: Float) -> Float { x }
+
+pub fn floor(x: Float) -> Float { x }
+pub fn ceil(x: Float) -> Float { x }
+pub fn round(x: Float) -> Float { x }
+pub fn trunc(x: Float) -> Float { x }
+pub fn abs(x: Float) -> Float { x }
+
+pub fn min(a: Float, b: Float) -> Float { a }
+pub fn max(a: Float, b: Float) -> Float { a }
+pub fn hypot(a: Float, b: Float) -> Float { a }

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -412,6 +412,16 @@ func TestTier1ModuleCoverage(t *testing.T) {
 		{"ref", []string{"same"}},
 		{"process", []string{"abort", "unreachable", "todo", "ignoreError", "logError"}},
 		{"debug", []string{"dbg"}},
+		{"math", []string{
+			"PI", "E", "TAU", "INFINITY", "NAN",
+			"sin", "cos", "tan", "asin", "acos", "atan", "atan2",
+			"sinh", "cosh", "tanh",
+			"exp", "log", "log2", "log10",
+			"sqrt", "cbrt", "pow",
+			"floor", "ceil", "round", "trunc", "abs",
+			"min", "max", "hypot",
+		}},
+		{"env", []string{"args", "get", "set"}},
 	}
 	for _, c := range cases {
 		mod := reg.Modules[c.module]


### PR DESCRIPTION
## Summary

Fills in the four Tier 1/2 stdlib modules whose signatures were placeholders by wiring their call sites through the code generator to Go's stdlib — in the order requested: `std.math`, `std.env`, `std.strings`, `std.fs`.

- **std.math** — new module stub; every function lowers 1:1 to `math.Xxx` in Go. Constants (`PI`, `E`, `TAU`, `INFINITY`, `NAN`) are rewritten at field-access. `math.log(x, base)` lowers to natural-log division.
- **std.env** — new module stub; `args/get/set` route to `os.Args`, `os.Getenv`, `os.Setenv`.
- **std.strings** — existing stub; calls remapped to Go names (`split→Split`, `startsWith→HasPrefix`, `trimStart→TrimLeft` with a whitespace cutset, etc.).
- **std.fs** — existing stub; `readToString`, `writeString`, `remove` wrap Go's `os.ReadFile/WriteFile/Remove` in the runtime `Result[T, E]`; `exists` uses `os.Stat`.

### Supporting gen fixes

- `emitStdlibCall` / `emitStdlibField` dispatch on a new `gen.stdAliases` map populated by `emitUseDecl`. The generic `stdlibBridge` is skipped for these modules so we don't emit an unused Go import.
- `isResultOperand` becomes a `gen` method with an AST-shape fallback so `?` on a stdlib fs call unwraps a `Result` when the checker hasn't typed the call expression.
- `resultTypeArgsAt` prefers the enclosing function's declared `Result<T, E>` when the checker's inferred call type is `Result[any, any]`, so tail-position `Ok(x)` matches the signature.

## Test plan

- [x] `go test ./internal/stdlib/...` — `TestTier1ModuleCoverage` extended to cover `math` / `env`.
- [x] `go test ./internal/gen/...` — new `TestStd{Math,MathLog,Env,Strings,FsRoundTrip}` run the full parse→resolve→check→gen→`go run` pipeline and assert stdout.
- [x] `go test ./...` — only pre-existing failures remain (`internal/format` golden, `internal/testgen` calc harness; both fail on `main` too).