### PR TITLE
[codex] stabilize package dependency workflow

### DIFF
--- a/internal/manifest/io.go
+++ b/internal/manifest/io.go
@@ -22,6 +22,7 @@ func Read(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
+	m.SetSource(src, path)
 	return m, nil
 }
 

--- a/internal/pkgmgr/depprovider.go
+++ b/internal/pkgmgr/depprovider.go
@@ -2,6 +2,7 @@ package pkgmgr
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/osty/osty/internal/manifest"
@@ -14,16 +15,21 @@ import (
 //
 // Mapping rules (first match wins):
 //
-//  1. rawPath equals a top-level [dependencies] alias  → vendor dir.
+//  1. rawPath equals a resolved graph alias or top-level
+//     [dependencies] alias  → vendor dir.
+//     Graph aliases include transitive deps discovered while walking
+//     fetched package manifests.
 //     Matches bare-name imports like `use fastjson` against a
 //     `fastjson = { git = "..." }` entry.
 //
-//  2. rawPath is a URL that matches a dep's git URL  → vendor dir.
+//  2. rawPath is a URL that matches a graph/source git URL  →
+//     vendor dir.
 //     Matches `use github.com/user/fastjson` against the same
 //     `fastjson = { git = "github.com/user/fastjson" }`. Trailing
 //     `.git` and scheme are tolerated in either direction.
 //
-//  3. rawPath's last segment equals a dep alias  → vendor dir.
+//  3. rawPath's last segment equals a graph or manifest alias  →
+//     vendor dir.
 //     Fallback for `use github.com/user/lib` when the alias is just
 //     `lib` — the spec says `lib` is the default alias and the source
 //     form still resolves.
@@ -45,11 +51,17 @@ func (p *depProvider) LookupDep(rawPath string) (string, bool) {
 		return "", false
 	}
 	// Rule 1: direct alias match.
+	if p.hasGraphNode(rawPath) {
+		return filepath.Join(p.env.VendorDir, rawPath), true
+	}
 	if dep, ok := findDepByAlias(p.m, rawPath); ok {
 		return filepath.Join(p.env.VendorDir, dep.Name), true
 	}
 	// Rule 2: git URL match.
 	if strings.ContainsAny(rawPath, "/") {
+		if name, ok := p.findGraphNodeByGitURL(rawPath); ok {
+			return filepath.Join(p.env.VendorDir, name), true
+		}
 		if dep, ok := findDepByGitURL(p.m, rawPath); ok {
 			return filepath.Join(p.env.VendorDir, dep.Name), true
 		}
@@ -57,11 +69,58 @@ func (p *depProvider) LookupDep(rawPath string) (string, bool) {
 	// Rule 3: last-segment alias match.
 	if i := strings.LastIndex(rawPath, "/"); i >= 0 {
 		lastSeg := rawPath[i+1:]
+		if p.hasGraphNode(lastSeg) {
+			return filepath.Join(p.env.VendorDir, lastSeg), true
+		}
 		if dep, ok := findDepByAlias(p.m, lastSeg); ok {
 			return filepath.Join(p.env.VendorDir, dep.Name), true
 		}
 	}
 	return "", false
+}
+
+func (p *depProvider) hasGraphNode(alias string) bool {
+	if p == nil || p.graph == nil || p.graph.Nodes == nil {
+		return false
+	}
+	_, ok := p.graph.Nodes[alias]
+	return ok
+}
+
+func (p *depProvider) findGraphNodeByGitURL(rawPath string) (string, bool) {
+	if p == nil || p.graph == nil {
+		return "", false
+	}
+	needle := normalizeGitURL(rawPath)
+	for _, name := range p.graphNodeNames() {
+		n := p.graph.Nodes[name]
+		if n == nil {
+			continue
+		}
+		gs, ok := n.Source.(*gitSource)
+		if !ok {
+			continue
+		}
+		if normalizeGitURL(gs.url) == needle {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func (p *depProvider) graphNodeNames() []string {
+	if p == nil || p.graph == nil {
+		return nil
+	}
+	if len(p.graph.Order) > 0 {
+		return append([]string(nil), p.graph.Order...)
+	}
+	names := make([]string, 0, len(p.graph.Nodes))
+	for name := range p.graph.Nodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // findDepByAlias walks both dependency tables and returns the entry

--- a/internal/pkgmgr/resolve.go
+++ b/internal/pkgmgr/resolve.go
@@ -36,9 +36,9 @@ type Graph struct {
 // declared origin; Fetched is populated once Fetch succeeds and
 // captures everything the lockfile needs to record.
 type ResolvedNode struct {
-	Name     string
-	Source   Source
-	Fetched  *FetchedPackage
+	Name    string
+	Source  Source
+	Fetched *FetchedPackage
 	// Deps is the set of *local* names this node depends on
 	// (transitive edges). Populated during graph construction.
 	Deps []string
@@ -69,13 +69,14 @@ func Resolve(ctx context.Context, root *manifest.Manifest, env *Env) (*Graph, er
 		graph:    &Graph{Root: root, Nodes: map[string]*ResolvedNode{}},
 		inflight: map[string]bool{},
 	}
+	rootDir := manifestBaseDir(root, env.ProjectRoot)
 	for _, d := range root.Dependencies {
-		if _, err := r.resolveDep(ctx, d); err != nil {
+		if _, err := r.resolveDep(ctx, d, rootDir); err != nil {
 			return nil, err
 		}
 	}
 	for _, d := range root.DevDependencies {
-		if _, err := r.resolveDep(ctx, d); err != nil {
+		if _, err := r.resolveDep(ctx, d, rootDir); err != nil {
 			return nil, err
 		}
 	}
@@ -94,19 +95,11 @@ type resolver struct {
 // resolveDep fetches dep, records it in the graph, then recurses
 // into its own dependencies. Returns an error on cycle detection,
 // fetch failure, or conflicting versions.
-func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency) (*ResolvedNode, error) {
-	if existing, ok := r.graph.Nodes[d.Name]; ok {
-		// Already resolved under this local name. A conflicting
-		// second Dependency spec with the same name is rejected here.
-		return existing, nil
-	}
+func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency, baseDir string) (*ResolvedNode, error) {
 	if r.inflight[d.Name] {
 		return nil, fmt.Errorf("cyclic dependency through %q", d.Name)
 	}
-	r.inflight[d.Name] = true
-	defer delete(r.inflight, d.Name)
-
-	src, err := NewSource(d)
+	src, err := newSourceFromDir(d, baseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +110,15 @@ func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency) (*Reso
 	// resolve. `osty update` clears the pin before calling Resolve, so
 	// honoring it here doesn't block intended upgrades.
 	applyLockPin(src, d, r.lock)
+	if existing, ok := r.graph.Nodes[d.Name]; ok {
+		if err := r.ensureCompatible(existing, src, d); err != nil {
+			return nil, err
+		}
+		return existing, nil
+	}
+	r.inflight[d.Name] = true
+	defer delete(r.inflight, d.Name)
+
 	fetched, err := src.Fetch(ctx, r.env)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: %w", d.Name, err)
@@ -131,14 +133,71 @@ func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency) (*Reso
 	// Recurse into the fetched package's own deps. Dev-deps are NOT
 	// followed for transitive packages — only the root's dev-deps
 	// matter.
+	childBase := manifestBaseDir(fetched.Manifest, fetched.LocalDir)
 	for _, sub := range fetched.Manifest.Dependencies {
-		child, err := r.resolveDep(ctx, sub)
+		child, err := r.resolveDep(ctx, sub, childBase)
 		if err != nil {
 			return nil, err
 		}
 		node.Deps = append(node.Deps, child.Name)
 	}
 	return node, nil
+}
+
+func manifestBaseDir(m *manifest.Manifest, fallback string) string {
+	if m != nil && m.Path() != "" {
+		return filepath.Dir(m.Path())
+	}
+	return fallback
+}
+
+func (r *resolver) ensureCompatible(existing *ResolvedNode, candidate Source, d manifest.Dependency) error {
+	if existing == nil || existing.Source == nil || existing.Fetched == nil {
+		return fmt.Errorf("dependency %q already exists in graph but is incomplete", d.Name)
+	}
+	if existing.Source.Kind() != candidate.Kind() {
+		return fmt.Errorf("dependency %q resolved from %s, but another dependency requires %s",
+			d.Name, existing.Source.URI(), candidate.URI())
+	}
+	switch ex := existing.Source.(type) {
+	case *registrySource:
+		cand, ok := candidate.(*registrySource)
+		if !ok {
+			break
+		}
+		if ex.registryName != cand.registryName || ex.packageName != cand.packageName {
+			return fmt.Errorf("dependency %q resolved from %s package %q, but another dependency requires %s package %q",
+				d.Name, ex.URI(), ex.packageName, cand.URI(), cand.packageName)
+		}
+		req, err := semver.ParseReq(cand.versionReq)
+		if err != nil {
+			return fmt.Errorf("dependency %q: invalid version req %q: %w", d.Name, cand.versionReq, err)
+		}
+		picked, err := semver.ParseVersion(existing.Fetched.Version)
+		if err != nil {
+			return fmt.Errorf("dependency %q: resolved version %q is invalid: %w", d.Name, existing.Fetched.Version, err)
+		}
+		if !req.Match(picked) {
+			return fmt.Errorf("dependency %q already resolved to %s, which does not satisfy %q",
+				d.Name, existing.Fetched.Version, cand.versionReq)
+		}
+		return nil
+	case *pathSource:
+		cand, ok := candidate.(*pathSource)
+		if !ok {
+			break
+		}
+		if ex.absPath(r.env) == cand.absPath(r.env) {
+			return nil
+		}
+		return fmt.Errorf("dependency %q resolved from %s, but another dependency requires %s",
+			d.Name, ex.absPath(r.env), cand.absPath(r.env))
+	}
+	if existing.Source.URI() != candidate.URI() {
+		return fmt.Errorf("dependency %q resolved from %s, but another dependency requires %s",
+			d.Name, existing.Source.URI(), candidate.URI())
+	}
+	return nil
 }
 
 // topoOrder returns node names in a stable, leaves-first order.
@@ -493,10 +552,24 @@ func applyLockPin(src Source, d manifest.Dependency, lock *lockfile.Lock) {
 	if len(pinned) == 0 {
 		return
 	}
-	// Take the first pinned version (we don't admit multiple per name
-	// in the simple resolver). Verify it still satisfies the declared
-	// req before narrowing — a manifest edit may have invalidated it.
-	pin := pinned[0]
+	// Take the first matching-source pinned version (we don't admit
+	// multiple per name in the simple resolver). Verify it still
+	// satisfies the declared req before narrowing — a manifest edit may
+	// have invalidated it. Also require the source URI to match so an
+	// old path/git pin with the same alias does not accidentally
+	// constrain a registry dep.
+	var pin lockfile.Package
+	found := false
+	for _, p := range pinned {
+		if p.Source == "" || p.Source == rs.URI() {
+			pin = p
+			found = true
+			break
+		}
+	}
+	if !found {
+		return
+	}
 	pv, err := semver.ParseVersion(pin.Version)
 	if err != nil {
 		return

--- a/internal/pkgmgr/resolve_test.go
+++ b/internal/pkgmgr/resolve_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lockfile"
 	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/resolve"
 )
 
 // TestResolvePathDep wires up a project with a single local-path
@@ -60,13 +63,98 @@ func TestResolvePathDep(t *testing.T) {
 	}
 }
 
+func TestResolveTransitivePathDepsAreRelativeToParentManifest(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	parent := filepath.Join(tmp, "deps", "parent")
+	child := filepath.Join(tmp, "deps", "child")
+	for _, d := range []string{proj, parent, child} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	must(t, manifest.Write(filepath.Join(child, manifest.ManifestFile),
+		&manifest.Manifest{Package: manifest.Package{Name: "child", Version: "0.1.0"}}))
+	must(t, manifest.Write(filepath.Join(parent, manifest.ManifestFile), &manifest.Manifest{
+		Package: manifest.Package{Name: "parent", Version: "0.1.0"},
+		Dependencies: []manifest.Dependency{
+			{Name: "child", Path: "../child", DefaultFeats: true},
+		},
+	}))
+
+	env := &Env{
+		CacheDir:    filepath.Join(tmp, "cache"),
+		VendorDir:   filepath.Join(proj, ".osty", "deps"),
+		ProjectRoot: proj,
+		Registries:  map[string]string{},
+	}
+	graph, err := Resolve(context.Background(), &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "parent", Path: "../deps/parent", DefaultFeats: true},
+		},
+	}, env)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := graph.Nodes["child"].Fetched.LocalDir; filepath.Clean(got) != filepath.Clean(child) {
+		t.Fatalf("child LocalDir: got %q, want %q", got, child)
+	}
+}
+
+func TestResolveRejectsConflictingTransitivePathAlias(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	libA := filepath.Join(tmp, "deps", "a")
+	libB := filepath.Join(tmp, "deps", "b")
+	utilA := filepath.Join(tmp, "deps", "util-a")
+	utilB := filepath.Join(tmp, "deps", "util-b")
+	for _, d := range []string{proj, libA, libB, utilA, utilB} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	must(t, manifest.Write(filepath.Join(utilA, manifest.ManifestFile),
+		&manifest.Manifest{Package: manifest.Package{Name: "util", Version: "1.0.0"}}))
+	must(t, manifest.Write(filepath.Join(utilB, manifest.ManifestFile),
+		&manifest.Manifest{Package: manifest.Package{Name: "util", Version: "2.0.0"}}))
+	must(t, manifest.Write(filepath.Join(libA, manifest.ManifestFile), &manifest.Manifest{
+		Package: manifest.Package{Name: "a", Version: "0.1.0"},
+		Dependencies: []manifest.Dependency{
+			{Name: "util", Path: "../util-a", DefaultFeats: true},
+		},
+	}))
+	must(t, manifest.Write(filepath.Join(libB, manifest.ManifestFile), &manifest.Manifest{
+		Package: manifest.Package{Name: "b", Version: "0.1.0"},
+		Dependencies: []manifest.Dependency{
+			{Name: "util", Path: "../util-b", DefaultFeats: true},
+		},
+	}))
+
+	env := &Env{
+		CacheDir:    filepath.Join(tmp, "cache"),
+		VendorDir:   filepath.Join(proj, ".osty", "deps"),
+		ProjectRoot: proj,
+		Registries:  map[string]string{},
+	}
+	_, err := Resolve(context.Background(), &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "a", Path: "../deps/a", DefaultFeats: true},
+			{Name: "b", Path: "../deps/b", DefaultFeats: true},
+		},
+	}, env)
+	if err == nil {
+		t.Fatal("Resolve should reject same alias pointing at different path deps")
+	}
+	if !strings.Contains(err.Error(), `dependency "util" resolved from`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // TestResolveTransitive confirms transitive path deps are followed
 // and returned in topological order (leaves first).
 func TestResolveTransitive(t *testing.T) {
 	tmp := t.TempDir()
 	proj := filepath.Join(tmp, "app")
-	libA := filepath.Join(tmp, "libA")
-	libB := filepath.Join(tmp, "libB")
+	libA := filepath.Join(tmp, "packages", "libA")
+	libB := filepath.Join(tmp, "packages", "libB")
 	for _, d := range []string{proj, libA, libB} {
 		must(t, os.MkdirAll(d, 0o755))
 	}
@@ -84,7 +172,7 @@ func TestResolveTransitive(t *testing.T) {
 	appMani := &manifest.Manifest{
 		Package: manifest.Package{Name: "app", Version: "0.0.1"},
 		Dependencies: []manifest.Dependency{
-			{Name: "libA", Path: "../libA", DefaultFeats: true},
+			{Name: "libA", Path: "../packages/libA", DefaultFeats: true},
 		},
 	}
 	env := &Env{
@@ -101,16 +189,6 @@ func TestResolveTransitive(t *testing.T) {
 		t.Fatalf("nodes: got %d, want 2", len(graph.Nodes))
 	}
 	// Order must have libB (leaf) before libA (parent).
-	// Note: the test needs to handle the fact that libA's Path is
-	// "../libB" which is resolved against libA's directory, but our
-	// resolver resolves paths against env.ProjectRoot. This test
-	// succeeds only if the resolver correctly resolves relative path
-	// deps against the PARENT package's root, not the project root.
-	// The current implementation uses env.ProjectRoot uniformly — which
-	// is wrong for transitive deps, but that's a known limitation.
-	// Adjust test: libA declares Path "../libB" which, relative to proj,
-	// points to tmp/libB — exactly what we want. So we've arranged the
-	// layout to make this pass under current resolver behavior.
 	order := graph.Order
 	idxA, idxB := -1, -1
 	for i, n := range order {
@@ -331,6 +409,21 @@ func TestApplyLockPinIgnoresMismatchedReq(t *testing.T) {
 	}
 }
 
+func TestApplyLockPinIgnoresMismatchedSource(t *testing.T) {
+	rs := &registrySource{name: "x", packageName: "x", versionReq: "^1.0.0"}
+	dep := manifest.Dependency{Name: "x", PackageName: "x", VersionReq: "^1.0.0"}
+	lock := &lockfile.Lock{
+		Version: lockfile.SchemaVersion,
+		Packages: []lockfile.Package{
+			{Name: "x", Version: "1.2.3", Source: "path+../x"},
+		},
+	}
+	applyLockPin(rs, dep, lock)
+	if rs.versionReq != "^1.0.0" {
+		t.Errorf("versionReq: got %q, want ^1.0.0 (unchanged)", rs.versionReq)
+	}
+}
+
 // TestApplyLockPinSkipsPathSources: path / git sources don't get
 // rewritten; their identity comes from the manifest, not the lock.
 func TestApplyLockPinSkipsPathSources(t *testing.T) {
@@ -407,6 +500,109 @@ func TestDiffLockNilInputs(t *testing.T) {
 	}
 	if changes := DiffLock(nil, nil); len(changes) != 0 {
 		t.Errorf("nil-both: %+v", changes)
+	}
+}
+
+func TestDepProviderFindsTransitiveGraphAlias(t *testing.T) {
+	tmp := t.TempDir()
+	env := &Env{VendorDir: filepath.Join(tmp, ".osty", "deps")}
+	graph := &Graph{
+		Nodes: map[string]*ResolvedNode{
+			"leaf": &ResolvedNode{Name: "leaf"},
+		},
+		Order: []string{"leaf"},
+	}
+	provider := NewDepProvider(&manifest.Manifest{}, graph, env)
+	dir, ok := provider.LookupDep("leaf")
+	if !ok {
+		t.Fatal("LookupDep should find transitive graph alias")
+	}
+	if want := filepath.Join(env.VendorDir, "leaf"); dir != want {
+		t.Fatalf("dir: got %q, want %q", dir, want)
+	}
+}
+
+func TestDepProviderFindsTransitiveGraphGitURL(t *testing.T) {
+	tmp := t.TempDir()
+	env := &Env{VendorDir: filepath.Join(tmp, ".osty", "deps")}
+	graph := &Graph{
+		Nodes: map[string]*ResolvedNode{
+			"json": &ResolvedNode{
+				Name:   "json",
+				Source: &gitSource{name: "json", url: "https://github.com/acme/json.git"},
+			},
+		},
+		Order: []string{"json"},
+	}
+	provider := NewDepProvider(&manifest.Manifest{}, graph, env)
+	dir, ok := provider.LookupDep("github.com/acme/json")
+	if !ok {
+		t.Fatal("LookupDep should find transitive graph git URL")
+	}
+	if want := filepath.Join(env.VendorDir, "json"); dir != want {
+		t.Fatalf("dir: got %q, want %q", dir, want)
+	}
+}
+
+func TestWorkspaceCanImportTransitiveVendoredDependency(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "app")
+	vendor := filepath.Join(root, ".osty", "deps")
+	parentDir := filepath.Join(vendor, "parent")
+	leafDir := filepath.Join(vendor, "leaf")
+	for _, d := range []string{root, parentDir, leafDir} {
+		must(t, os.MkdirAll(d, 0o755))
+	}
+	must(t, os.WriteFile(filepath.Join(root, "main.osty"), []byte(`
+use parent
+
+fn main() {
+    parent.ping()
+}
+`), 0o644))
+	must(t, os.WriteFile(filepath.Join(parentDir, "parent.osty"), []byte(`
+use leaf
+
+pub fn ping() {
+    leaf.pong()
+}
+`), 0o644))
+	must(t, os.WriteFile(filepath.Join(leafDir, "leaf.osty"), []byte(`
+pub fn pong() {}
+`), 0o644))
+
+	m := &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "parent", Path: "../parent", DefaultFeats: true},
+		},
+	}
+	graph := &Graph{
+		Nodes: map[string]*ResolvedNode{
+			"parent": &ResolvedNode{Name: "parent"},
+			"leaf":   &ResolvedNode{Name: "leaf"},
+		},
+		Order: []string{"leaf", "parent"},
+	}
+	env := &Env{VendorDir: vendor}
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	ws.Deps = NewDepProvider(m, graph, env)
+	if _, err := ws.LoadPackage(""); err != nil {
+		t.Fatalf("LoadPackage: %v", err)
+	}
+	results := ws.ResolveAll()
+	for key, res := range results {
+		for _, d := range res.Diags {
+			if d.Severity == diag.Error {
+				t.Fatalf("%s: unexpected diagnostic: %s", key, d.Message)
+			}
+		}
+	}
+	if _, ok := ws.Packages["leaf"]; !ok {
+		t.Fatalf("transitive leaf package was not loaded: %v", ws.Packages)
 	}
 }
 

--- a/internal/pkgmgr/source.go
+++ b/internal/pkgmgr/source.go
@@ -9,7 +9,7 @@
 //     returns a ResolvedGraph. Uses osty.lock when present; writes
 //     one back when the graph changes.
 //  3. pkgmgr.Vendor() materializes every node of the graph into
-//     `<project>/.osty/deps/<name>-<version>/` so the workspace
+//     `<project>/.osty/deps/<name>/` so the workspace
 //     loader can find them by directory.
 //  4. The caller builds a resolve.Workspace over the project root
 //     plus the vendored deps and proceeds with the normal front-end
@@ -170,9 +170,17 @@ var DefaultRegistryURL = "https://registry.osty.dev"
 // Exactly one of Path / Git / VersionReq must be set; NewSource
 // assumes the manifest parser enforced that.
 func NewSource(d manifest.Dependency) (Source, error) {
+	return newSourceFromDir(d, "")
+}
+
+// newSourceFromDir is the resolver's internal constructor. baseDir is
+// the directory containing the manifest that declared d, so transitive
+// path dependencies resolve relative to their own package instead of
+// the root project.
+func newSourceFromDir(d manifest.Dependency, baseDir string) (Source, error) {
 	switch {
 	case d.Path != "":
-		return &pathSource{name: d.Name, path: d.Path}, nil
+		return &pathSource{name: d.Name, path: d.Path, baseDir: baseDir}, nil
 	case d.Git != nil:
 		return &gitSource{
 			name:   d.Name,

--- a/internal/pkgmgr/source_path.go
+++ b/internal/pkgmgr/source_path.go
@@ -15,8 +15,9 @@ import (
 // trusts the filesystem here — changes to the source directory
 // automatically flow into the next resolve + build.
 type pathSource struct {
-	name string
-	path string // as written in the manifest, possibly relative
+	name    string
+	path    string // as written in the manifest, possibly relative
+	baseDir string // directory containing the manifest that declared path
 }
 
 func (s *pathSource) Kind() SourceKind { return SourcePath }
@@ -30,6 +31,18 @@ func (s *pathSource) URI() string {
 	return "path+" + filepath.ToSlash(s.path)
 }
 
+func (s *pathSource) absPath(env *Env) string {
+	abs := s.path
+	if filepath.IsAbs(abs) {
+		return filepath.Clean(abs)
+	}
+	base := s.baseDir
+	if base == "" && env != nil {
+		base = env.ProjectRoot
+	}
+	return filepath.Clean(filepath.Join(base, abs))
+}
+
 // Fetch reads the dependency's osty.toml to discover its version and
 // its own declared deps. The returned LocalDir is the absolute
 // directory on disk.
@@ -39,10 +52,7 @@ func (s *pathSource) Fetch(ctx context.Context, env *Env) (*FetchedPackage, erro
 			return nil, err
 		}
 	}
-	abs := s.path
-	if !filepath.IsAbs(abs) {
-		abs = filepath.Join(env.ProjectRoot, abs)
-	}
+	abs := s.absPath(env)
 	info, err := os.Stat(abs)
 	if err != nil {
 		return nil, fmt.Errorf("path dependency %s: %w", s.name, err)


### PR DESCRIPTION
## Summary

Stabilizes the package/dependency workflow around transitive package resolution, lockfile pinning, and vendored import lookup.

## What changed

- Resolve transitive path dependencies relative to the manifest that declares them, not always the root project.
- Reject conflicting repeated dependency aliases when they point at different sources or incompatible registry requirements.
- Only apply registry lockfile pins when the pinned source matches the requested source.
- Allow the dependency provider to resolve imports from the full resolved graph, including transitive vendored packages.
- Add focused tests for transitive path resolution, alias conflict detection, source-aware lock pins, graph-backed import lookup, and workspace imports of transitive vendored dependencies.

## Validation

- `go test ./internal/pkgmgr`
- `go test ./...`
- `git diff --check`