### PR TITLE
[codex] Align spec checker and generator

### DIFF
--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -1094,6 +1094,44 @@ fn main() {
 	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
 }
 
+func TestCheck_StdlibEnumerateTuplePattern(t *testing.T) {
+	src := `
+fn main() {
+    let pairs = [(1, 2), (3, 4)]
+    for (i, (a, b)) in pairs.enumerate() {
+        let total: Int = i + a + b
+    }
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_ParallelMapForm(t *testing.T) {
+	src := `
+fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    let rs: List<Result<Int, Error>> = parallel(xs, 2, |x| Ok(x * 2))
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_QuestionUsesClosureReturnType(t *testing.T) {
+	src := `
+fn parse() -> Result<Int, String> {
+    Ok(1)
+}
+
+fn main() {
+    let f: fn() -> Result<Int, String> = || {
+        let x = parse()?
+        Ok(x)
+    }
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
 func TestCheck_IteratorProtocolUserDefined(t *testing.T) {
 	// A type with `iter(self) -> I` where `I` has `next(mut self) -> T?`
 	// should iterate over T in `for`.

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -679,6 +679,12 @@ func (c *checker) tryPackageCall(
 		return types.ErrorType, true
 	}
 	t := c.symTypeOrError(tgt)
+	var generics []*types.TypeVar
+	if types.IsError(t) {
+		if fnDecl, ok := tgt.Decl.(*ast.FnDecl); ok {
+			t = c.externalFnType(fnDecl)
+		}
+	}
 	fn, isFn := types.AsFn(t)
 	if !isFn {
 		if types.IsError(t) {
@@ -696,8 +702,7 @@ func (c *checker) tryPackageCall(
 	}
 	c.recordExpr(e.Fn, t)
 	info := c.info(tgt)
-	var generics []*types.TypeVar
-	if info != nil {
+	if info != nil && len(generics) == 0 {
 		generics = info.Generics
 	}
 	return c.applyGenericCall(e, fn, generics, hint, env), true
@@ -812,19 +817,20 @@ var stdlibMethods = map[string]types.Type{
 	"toInt64":  types.Int64,
 	"toFloat":  types.Float,
 	// Receiver-dependent — nil means "dispatch by name".
-	"get":     nil,
-	"push":    nil,
-	"map":     nil,
-	"filter":  nil,
-	"iter":    nil,
-	"entries": nil,
-	"keys":    nil,
-	"values":  nil,
-	"toList":  nil,
-	"toSet":   nil,
-	"toMap":   nil,
-	"chars":   nil,
-	"take":    nil,
+	"get":       nil,
+	"push":      nil,
+	"map":       nil,
+	"filter":    nil,
+	"iter":      nil,
+	"entries":   nil,
+	"enumerate": nil,
+	"keys":      nil,
+	"values":    nil,
+	"toList":    nil,
+	"toSet":     nil,
+	"toMap":     nil,
+	"chars":     nil,
+	"take":      nil,
 }
 
 // stdlibCallReturn synthesizes a return type for an escape-hatch stdlib
@@ -892,6 +898,9 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 		c.checkExactArity(e, 0)
 		ret = c.listOf(iterElem(recvT))
 	case "entries", "keys", "values":
+		c.checkExactArity(e, 0)
+		ret = c.stdlibChainReturn(fx.Name, recvT)
+	case "enumerate":
 		c.checkExactArity(e, 0)
 		ret = c.stdlibChainReturn(fx.Name, recvT)
 	case "toSet":
@@ -1034,6 +1043,8 @@ func (c *checker) stdlibChainReturn(name string, recvT types.Type) types.Type {
 			return c.listOf(tup)
 		}
 		return list
+	case "enumerate":
+		return c.listOf(&types.Tuple{Elems: []types.Type{types.Int, elem}})
 	case "keys":
 		if n, ok := recvT.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Map" && len(n.Args) == 2 {
 			return c.listOf(n.Args[0])
@@ -1151,6 +1162,22 @@ func (c *checker) iteratorElement(t types.Type) types.Type {
 
 func (c *checker) listOf(elem types.Type) types.Type {
 	return c.namedOf("List", []types.Type{elem})
+}
+
+func (c *checker) resultOf(ok, err types.Type) types.Type {
+	return c.namedOf("Result", []types.Type{ok, err})
+}
+
+func (c *checker) externalFnType(fn *ast.FnDecl) *types.FnType {
+	params := make([]types.Type, 0, len(fn.Params))
+	for _, p := range fn.Params {
+		params = append(params, c.ffiType(p.Type))
+	}
+	var ret types.Type = types.Unit
+	if fn.ReturnType != nil {
+		ret = c.ffiType(fn.ReturnType)
+	}
+	return &types.FnType{Params: params, Return: ret}
 }
 
 func (c *checker) namedOf(name string, args []types.Type) types.Type {
@@ -1383,6 +1410,31 @@ func (c *checker) tryBuiltinCall(name string, e *ast.CallExpr, hint types.Type, 
 		}
 		return types.ErrorType
 	case "parallel":
+		// §8.3 production form:
+		//
+		//   parallel(items, concurrency, |x| work(x))
+		//
+		// maps a List<T> through a Result-returning callback and returns
+		// List<Result<R, Error>>. Keep the earlier variadic-closure form
+		// below for existing tests and simple concurrency expressions.
+		if len(e.Args) == 3 {
+			itemsT := c.checkExpr(e.Args[0].Value, nil, env)
+			if n, ok := types.AsNamed(itemsT); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
+				c.checkExpr(e.Args[1].Value, types.Int, env)
+				mapperRet := c.resultOf(types.ErrorType, c.namedOf("Error", nil))
+				if hn, ok := types.AsNamed(hint); ok && hn.Sym != nil && hn.Sym.Name == "List" && len(hn.Args) == 1 {
+					if rn, ok := types.AsNamed(hn.Args[0]); ok && rn.Sym != nil && rn.Sym.Name == "Result" && len(rn.Args) == 2 {
+						mapperRet = hn.Args[0]
+					}
+				}
+				mapperHint := &types.FnType{Params: []types.Type{n.Args[0]}, Return: mapperRet}
+				got := c.checkExpr(e.Args[2].Value, mapperHint, env)
+				if fn, ok := types.AsFn(got); ok && fn.Return != nil {
+					return c.listOf(fn.Return)
+				}
+				return c.listOf(mapperRet)
+			}
+		}
 		// §8.3: parallel(|| a, || b, ...) runs every closure concurrently
 		// and returns a List<T> in source order. All closures must
 		// agree on their return type.
@@ -1557,6 +1609,16 @@ func (c *checker) ffiType(n ast.Type) types.Type {
 			elems[i] = c.ffiType(e)
 		}
 		return &types.Tuple{Elems: elems}
+	case *ast.FnType:
+		params := make([]types.Type, len(x.Params))
+		for i, p := range x.Params {
+			params[i] = c.ffiType(p)
+		}
+		var ret types.Type = types.Unit
+		if x.ReturnType != nil {
+			ret = c.ffiType(x.ReturnType)
+		}
+		return &types.FnType{Params: params, Return: ret}
 	}
 	return types.ErrorType
 }
@@ -2237,7 +2299,7 @@ func (c *checker) matchType(e *ast.MatchExpr, hint types.Type, env *env) types.T
 	return resultT
 }
 
-func (c *checker) closureType(e *ast.ClosureExpr, hint types.Type, env *env) types.Type {
+func (c *checker) closureType(e *ast.ClosureExpr, hint types.Type, parent *env) types.Type {
 	// If hint is a FnType, use its param types for closure params that
 	// lack annotations.
 	var hintFn *types.FnType
@@ -2265,7 +2327,15 @@ func (c *checker) closureType(e *ast.ClosureExpr, hint types.Type, env *env) typ
 	} else if hintFn != nil && hintFn.Return != nil {
 		retT = hintFn.Return
 	}
-	bodyT := c.checkExpr(e.Body, retT, env)
+	bodyEnv := &env{retType: retT}
+	if rn, ok := types.AsNamedByName(retT, "Result"); ok && len(rn.Args) == 2 {
+		bodyEnv.retIsResult = true
+		bodyEnv.retResultErr = rn.Args[1]
+	}
+	if _, ok := retT.(*types.Optional); ok {
+		bodyEnv.retIsOption = true
+	}
+	bodyT := c.checkExpr(e.Body, retT, bodyEnv)
 	if e.ReturnType != nil && !types.Assignable(retT, bodyT) {
 		c.errMismatch(e.Body, retT, bodyT)
 	}

--- a/internal/gen/audit_test.go
+++ b/internal/gen/audit_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 // TestSpecCorpusAudit runs every positive spec fixture through the
-// full pipeline (parse → resolve → check → transpile → `go build`) and
-// reports which ones survive. This is NOT an assertion — a hard fail
-// would block iteration — but it's tracked so we can see progress.
+// full pipeline (parse → resolve → check → transpile → `go vet`).
+// Check diagnostics are logged because the single-file fixture harness
+// still treats some imported stdlib/package surfaces as opaque; gen
+// must nevertheless lower every positive fixture to Go that type-checks.
 //
 // Run explicitly:
 //
@@ -42,28 +43,29 @@ func TestSpecCorpusAudit(t *testing.T) {
 		}
 		file, parseDiags := parser.ParseDiagnostics(src)
 		if hasErr(parseDiags) {
-			t.Logf("SKIP %s: parse errors", name)
+			t.Errorf("FAIL(parse) %s: parse errors (%d)", name, countErrs(parseDiags))
 			continue
 		}
 		res := resolve.File(file, resolve.NewPrelude())
 		if hasErr(res.Diags) {
-			t.Logf("SKIP %s: resolve errors (%d)", name, countErrs(res.Diags))
+			t.Errorf("FAIL(resolve) %s: resolve errors (%d)", name, countErrs(res.Diags))
 			continue
 		}
 		chk := check.File(file, res)
-		// We don't skip on check errors — the transpiler is still
-		// expected to produce SOMETHING for incomplete programs.
+		if hasErr(chk.Diags) {
+			t.Logf("WARN(check) %s: check errors (%d)", name, countErrs(chk.Diags))
+		}
 
 		goSrc, gerr := gen.Generate("main", file, res, chk)
 		if gerr != nil {
-			t.Logf("FAIL(gen) %s: %v", name, gerr)
+			t.Errorf("FAIL(gen) %s: %v", name, gerr)
 			continue
 		}
 
 		dir := t.TempDir()
 		outPath := filepath.Join(dir, "out.go")
 		if err := os.WriteFile(outPath, goSrc, 0o644); err != nil {
-			t.Logf("FAIL(write) %s: %v", name, err)
+			t.Errorf("FAIL(write) %s: %v", name, err)
 			continue
 		}
 		// `go vet` type-checks without requiring a main function, so
@@ -86,7 +88,7 @@ func TestSpecCorpusAudit(t *testing.T) {
 				msg = l
 				break
 			}
-			t.Logf("FAIL(compile) %s: %s", name, msg)
+			t.Errorf("FAIL(compile) %s: %s", name, msg)
 			continue
 		}
 		t.Logf("OK   %s (%d bytes)", name, len(goSrc))

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -89,8 +89,16 @@ func (g *gen) emitFnDeclBody(fn *ast.FnDecl, name string) {
 	g.body.write(" ")
 
 	prevRet := g.currentRetType
+	prevRetGo := g.currentRetGo
 	g.currentRetType = fn.ReturnType
-	defer func() { g.currentRetType = prevRet }()
+	g.currentRetGo = ""
+	if fn.ReturnType != nil {
+		g.currentRetGo = g.goTypeExpr(fn.ReturnType)
+	}
+	defer func() {
+		g.currentRetType = prevRet
+		g.currentRetGo = prevRetGo
+	}()
 
 	g.emitBlockAsReturn(fn.Body, fn.ReturnType != nil)
 	g.body.nl()
@@ -281,10 +289,16 @@ func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
 	prev := g.selfType
 	g.selfType = typeName
 	prevRet := g.currentRetType
+	prevRetGo := g.currentRetGo
 	g.currentRetType = m.ReturnType
+	g.currentRetGo = ""
+	if m.ReturnType != nil {
+		g.currentRetGo = g.resolveSelfType(m.ReturnType, typeName)
+	}
 	defer func() {
 		g.selfType = prev
 		g.currentRetType = prevRet
+		g.currentRetGo = prevRetGo
 	}()
 
 	if m.Body == nil {
@@ -369,6 +383,10 @@ func (g *gen) emitUseDecl(u *ast.UseDecl) {
 		if alias == "" {
 			alias = defaultAlias
 		}
+		if !g.aliasUsedAsSelector(alias) {
+			g.emitUseStub(alias, "struct{}{}", u.GoPath)
+			return
+		}
 		if alias == defaultAlias {
 			g.use(u.GoPath)
 		} else {
@@ -389,7 +407,7 @@ func (g *gen) emitUseDecl(u *ast.UseDecl) {
 		return
 	}
 	full := strings.Join(u.Path, ".")
-	if bridge := stdlibBridge(u.Path); bridge != "" {
+	if bridge := stdlibBridge(u.Path); bridge != "" && g.aliasUsedAsSelector(alias) {
 		g.use(bridge)
 		// When the Go bridge's package name already matches the
 		// Osty alias, no rebinding is needed.
@@ -403,8 +421,175 @@ func (g *gen) emitUseDecl(u *ast.UseDecl) {
 	if stub == "" {
 		stub = "struct{}{}"
 	}
+	g.emitUseStub(alias, stub, full)
+}
+
+func (g *gen) emitUseStub(alias, stub, full string) {
 	g.body.writef("\nvar %s = %s // stub for `use %s`\n",
 		mangleIdent(alias), stub, full)
+}
+
+func (g *gen) aliasUsedAsSelector(alias string) bool {
+	for _, d := range g.file.Decls {
+		if g.declUsesAliasSelector(d, alias) {
+			return true
+		}
+	}
+	for _, s := range g.file.Stmts {
+		if g.stmtUsesAliasSelector(s, alias) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *gen) declUsesAliasSelector(d ast.Decl, alias string) bool {
+	switch d := d.(type) {
+	case *ast.FnDecl:
+		return d.Body != nil && g.stmtUsesAliasSelector(d.Body, alias)
+	case *ast.LetDecl:
+		return g.exprUsesAliasSelector(d.Value, alias)
+	case *ast.StructDecl:
+		for _, m := range d.Methods {
+			if m.Body != nil && g.stmtUsesAliasSelector(m.Body, alias) {
+				return true
+			}
+		}
+	case *ast.EnumDecl:
+		for _, m := range d.Methods {
+			if m.Body != nil && g.stmtUsesAliasSelector(m.Body, alias) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *gen) stmtUsesAliasSelector(s ast.Stmt, alias string) bool {
+	switch s := s.(type) {
+	case *ast.Block:
+		for _, st := range s.Stmts {
+			if g.stmtUsesAliasSelector(st, alias) {
+				return true
+			}
+		}
+	case *ast.LetStmt:
+		return g.exprUsesAliasSelector(s.Value, alias)
+	case *ast.ExprStmt:
+		return g.exprUsesAliasSelector(s.X, alias)
+	case *ast.AssignStmt:
+		if g.exprUsesAliasSelector(s.Value, alias) {
+			return true
+		}
+		for _, t := range s.Targets {
+			if g.exprUsesAliasSelector(t, alias) {
+				return true
+			}
+		}
+	case *ast.ReturnStmt:
+		return g.exprUsesAliasSelector(s.Value, alias)
+	case *ast.ForStmt:
+		return g.exprUsesAliasSelector(s.Iter, alias) ||
+			(s.Body != nil && g.stmtUsesAliasSelector(s.Body, alias))
+	case *ast.DeferStmt:
+		return g.exprUsesAliasSelector(s.X, alias)
+	case *ast.ChanSendStmt:
+		return g.exprUsesAliasSelector(s.Channel, alias) ||
+			g.exprUsesAliasSelector(s.Value, alias)
+	}
+	return false
+}
+
+func (g *gen) exprUsesAliasSelector(e ast.Expr, alias string) bool {
+	switch e := e.(type) {
+	case nil:
+		return false
+	case *ast.FieldExpr:
+		if id, ok := e.X.(*ast.Ident); ok && id.Name == alias {
+			return true
+		}
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.CallExpr:
+		if g.exprUsesAliasSelector(e.Fn, alias) {
+			return true
+		}
+		for _, a := range e.Args {
+			if g.exprUsesAliasSelector(a.Value, alias) {
+				return true
+			}
+		}
+	case *ast.StringLit:
+		for _, p := range e.Parts {
+			if !p.IsLit && g.exprUsesAliasSelector(p.Expr, alias) {
+				return true
+			}
+		}
+	case *ast.ParenExpr:
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.UnaryExpr:
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.BinaryExpr:
+		return g.exprUsesAliasSelector(e.Left, alias) ||
+			g.exprUsesAliasSelector(e.Right, alias)
+	case *ast.QuestionExpr:
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.IndexExpr:
+		return g.exprUsesAliasSelector(e.X, alias) ||
+			g.exprUsesAliasSelector(e.Index, alias)
+	case *ast.TurbofishExpr:
+		return g.exprUsesAliasSelector(e.Base, alias)
+	case *ast.RangeExpr:
+		return g.exprUsesAliasSelector(e.Start, alias) ||
+			g.exprUsesAliasSelector(e.Stop, alias)
+	case *ast.TupleExpr:
+		for _, x := range e.Elems {
+			if g.exprUsesAliasSelector(x, alias) {
+				return true
+			}
+		}
+	case *ast.ListExpr:
+		for _, x := range e.Elems {
+			if g.exprUsesAliasSelector(x, alias) {
+				return true
+			}
+		}
+	case *ast.MapExpr:
+		for _, ent := range e.Entries {
+			if g.exprUsesAliasSelector(ent.Key, alias) ||
+				g.exprUsesAliasSelector(ent.Value, alias) {
+				return true
+			}
+		}
+	case *ast.StructLit:
+		if g.exprUsesAliasSelector(e.Type, alias) ||
+			g.exprUsesAliasSelector(e.Spread, alias) {
+			return true
+		}
+		for _, f := range e.Fields {
+			if g.exprUsesAliasSelector(f.Value, alias) {
+				return true
+			}
+		}
+	case *ast.IfExpr:
+		return g.exprUsesAliasSelector(e.Cond, alias) ||
+			(e.Then != nil && g.stmtUsesAliasSelector(e.Then, alias)) ||
+			g.exprUsesAliasSelector(e.Else, alias)
+	case *ast.MatchExpr:
+		if g.exprUsesAliasSelector(e.Scrutinee, alias) {
+			return true
+		}
+		for _, a := range e.Arms {
+			if g.exprUsesAliasSelector(a.Guard, alias) ||
+				g.exprUsesAliasSelector(a.Body, alias) {
+				return true
+			}
+		}
+	case *ast.ClosureExpr:
+		return g.exprUsesAliasSelector(e.Body, alias)
+	case *ast.Block:
+		return g.stmtUsesAliasSelector(e, alias)
+	}
+	return false
 }
 
 // stdlibBridge maps an Osty stdlib module path to a Go package whose
@@ -447,11 +632,13 @@ func knownStdlibStub(path []string) string {
 			assertEq  func(...any)
 			context   func(...any)
 			benchmark func(...any)
+			snapshot  func(...any)
 		}{
 			assert:    func(...any) {},
 			assertEq:  func(...any) {},
 			context:   func(...any) {},
 			benchmark: func(...any) {},
+			snapshot:  func(...any) {},
 		}`
 	case "thread":
 		return `struct {
@@ -459,11 +646,13 @@ func knownStdlibStub(path []string) string {
 			race       func(...any) any
 			chan_      func(...any) any
 			select_    func(...any) any
+			isCancelled func() bool
 		}{
 			collectAll: func(...any) any { return nil },
 			race:       func(...any) any { return nil },
 			chan_:      func(...any) any { return nil },
 			select_:    func(...any) any { return nil },
+			isCancelled: func() bool { return false },
 		}`
 	}
 	return ""
@@ -593,6 +782,14 @@ func (g *gen) isVoidExpr(e ast.Expr) bool {
 	}
 	if t := g.typeOf(call); t != nil && types.IsUnit(t) {
 		return true
+	}
+	if f, ok := call.Fn.(*ast.FieldExpr); ok {
+		if id, ok := f.X.(*ast.Ident); ok && id.Name == "testing" {
+			switch f.Name {
+			case "assert", "assertEq", "assertNe", "context", "benchmark", "snapshot":
+				return true
+			}
+		}
 	}
 	// Callee introspection: walk Fn → find the referenced FnDecl, check
 	// that it has no declared return type.

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -540,6 +540,19 @@ func (g *gen) emitThreadCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		return false
 	}
 	switch f.Name {
+	case "collectAll":
+		if g.emitThreadCollectAll(c) {
+			return true
+		}
+	case "race":
+		if g.emitThreadRace(c) {
+			return true
+		}
+	case "isCancelled":
+		if len(c.Args) == 0 {
+			g.body.write("false")
+			return true
+		}
 	case "sleep":
 		// thread.sleep(dur) → time.Sleep(dur)
 		if len(c.Args) != 1 {
@@ -557,6 +570,137 @@ func (g *gen) emitThreadCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		return true
 	}
 	return false
+}
+
+func (g *gen) emitThreadCollectAll(c *ast.CallExpr) bool {
+	param, spawns, ok := g.threadGroupSpawnCalls(c)
+	if !ok || len(spawns) == 0 {
+		return false
+	}
+	g.needTaskGroup = true
+	g.needHandle = true
+	inner := g.spawnCallInnerGo(spawns[0])
+	ret := g.listReturnGo(c, inner)
+	g.body.writef("runTaskGroup[%s](func(%s *TaskGroup) %s {\n", ret, param, ret)
+	g.body.indent()
+	handles := make([]string, len(spawns))
+	for i, sp := range spawns {
+		h := g.freshVar("_h")
+		handles[i] = h
+		g.body.writef("%s := spawnInGroup[%s](%s, ", h, inner, param)
+		g.emitSpawnClosure(sp.Args[0].Value, types.IsUnit(g.closureReturnType(sp.Args[0].Value)))
+		g.body.writeln(")")
+	}
+	g.body.writef("return %s{", ret)
+	for i, h := range handles {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.writef("%s.Join()", h)
+	}
+	g.body.writeln("}")
+	g.body.dedent()
+	g.body.write("})")
+	return true
+}
+
+func (g *gen) emitThreadRace(c *ast.CallExpr) bool {
+	param, spawns, ok := g.threadGroupSpawnCalls(c)
+	if !ok || len(spawns) == 0 {
+		return false
+	}
+	g.needTaskGroup = true
+	g.needHandle = true
+	inner := g.spawnCallInnerGo(spawns[0])
+	g.body.writef("runTaskGroup[%s](func(%s *TaskGroup) %s {\n", inner, param, inner)
+	g.body.indent()
+	handles := make([]string, len(spawns))
+	for i, sp := range spawns {
+		h := g.freshVar("_h")
+		handles[i] = h
+		g.body.writef("%s := spawnInGroup[%s](%s, ", h, inner, param)
+		g.emitSpawnClosure(sp.Args[0].Value, types.IsUnit(g.closureReturnType(sp.Args[0].Value)))
+		g.body.writeln(")")
+	}
+	g.body.writeln("select {")
+	g.body.indent()
+	for _, h := range handles {
+		g.body.writef("case v := <-%s.result:\n", h)
+		g.body.indent()
+		g.body.writeln("return v")
+		g.body.dedent()
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.dedent()
+	g.body.write("})")
+	return true
+}
+
+func (g *gen) threadGroupSpawnCalls(c *ast.CallExpr) (string, []*ast.CallExpr, bool) {
+	if c == nil || len(c.Args) != 1 {
+		return "", nil, false
+	}
+	cl, ok := c.Args[0].Value.(*ast.ClosureExpr)
+	if !ok || len(cl.Params) == 0 {
+		return "", nil, false
+	}
+	param := "g"
+	if cl.Params[0].Name != "" {
+		param = mangleIdent(cl.Params[0].Name)
+	}
+	list, ok := cl.Body.(*ast.ListExpr)
+	if !ok {
+		return "", nil, false
+	}
+	spawns := make([]*ast.CallExpr, 0, len(list.Elems))
+	for _, e := range list.Elems {
+		call, ok := e.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return "", nil, false
+		}
+		fx, ok := call.Fn.(*ast.FieldExpr)
+		if !ok || fx.Name != "spawn" {
+			return "", nil, false
+		}
+		if id, ok := fx.X.(*ast.Ident); !ok || mangleIdent(id.Name) != param {
+			return "", nil, false
+		}
+		spawns = append(spawns, call)
+	}
+	return param, spawns, true
+}
+
+func (g *gen) spawnCallInnerGo(call *ast.CallExpr) string {
+	if call == nil || len(call.Args) != 1 {
+		return "any"
+	}
+	t := g.closureReturnType(call.Args[0].Value)
+	if t == nil || types.IsError(t) {
+		return "any"
+	}
+	if types.IsUnit(t) {
+		return "struct{}"
+	}
+	return g.goType(t)
+}
+
+func (g *gen) closureReturnType(e ast.Expr) types.Type {
+	if t := g.typeOf(e); t != nil {
+		if fn, ok := t.(*types.FnType); ok {
+			return fn.Return
+		}
+	}
+	return nil
+}
+
+func (g *gen) listReturnGo(call *ast.CallExpr, elemGo string) string {
+	if t := g.typeOf(call); t != nil {
+		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
+			return g.goType(t)
+		}
+	}
+	return "[]" + elemGo
 }
 
 // emitVariantCtor writes `Shape(Shape_Circle{F0: a0, F1: a1})` for
@@ -747,6 +891,19 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 			return true
 		}
 	case "parallel":
+		if len(args) == 3 {
+			if itemGo, resultGo, ok := g.parallelMapTypes(call); ok {
+				g.needTaskGroup = true
+				g.body.writef("runParallelMap[%s, %s](", itemGo, resultGo)
+				g.emitExpr(args[0].Value)
+				g.body.write(", ")
+				g.emitExpr(args[1].Value)
+				g.body.write(", ")
+				g.emitExpr(args[2].Value)
+				g.body.write(")")
+				return true
+			}
+		}
 		// §8.3: parallel(|| a, || b, ...) → runParallel[T](bodies...).
 		// Every closure must return the same T; we pull T from the
 		// first argument's inferred FnType return.
@@ -828,6 +985,25 @@ func (g *gen) emitCallArgList(args []*ast.Arg) {
 		}
 		g.emitExpr(a.Value)
 	}
+}
+
+func (g *gen) parallelMapTypes(call *ast.CallExpr) (itemGo, resultGo string, ok bool) {
+	if call == nil || len(call.Args) != 3 {
+		return "", "", false
+	}
+	itemsT := g.typeOf(call.Args[0].Value)
+	n, ok := itemsT.(*types.Named)
+	if !ok || n.Sym == nil || n.Sym.Name != "List" || len(n.Args) != 1 {
+		return "", "", false
+	}
+	itemGo = g.goType(n.Args[0])
+	resultGo = "any"
+	if t := g.typeOf(call); t != nil {
+		if ln, ok := t.(*types.Named); ok && ln.Sym != nil && ln.Sym.Name == "List" && len(ln.Args) == 1 {
+			resultGo = g.goType(ln.Args[0])
+		}
+	}
+	return itemGo, resultGo, true
 }
 
 // handleInnerTypeFromCall inspects a spawn/spawn-like call's inferred
@@ -1559,6 +1735,21 @@ func (g *gen) emitClosure(c *ast.ClosureExpr) {
 		// rest of Osty's untyped-numeric default (§2.2).
 		g.body.write("int ")
 	}
+	closureRetGo := ""
+	if c.ReturnType != nil {
+		closureRetGo = g.goTypeExpr(c.ReturnType)
+	} else if inferred != nil && inferred.Return != nil &&
+		!types.IsUnit(inferred.Return) && !types.IsError(inferred.Return) {
+		closureRetGo = g.goType(inferred.Return)
+	}
+	prevRetType := g.currentRetType
+	prevRetGo := g.currentRetGo
+	g.currentRetType = c.ReturnType
+	g.currentRetGo = closureRetGo
+	defer func() {
+		g.currentRetType = prevRetType
+		g.currentRetGo = prevRetGo
+	}()
 	// Body may be a Block (return needs to come from its final expr)
 	// or a single expression (wrap in { return <expr> }). In either
 	// case, emit destructure bindings first.

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -95,6 +95,11 @@ type gen struct {
 	// correct type parameters when the operand's T differs.
 	currentRetType ast.Type
 
+	// currentRetGo is the same contract after semantic inference. It is
+	// needed for closures, whose return type often comes from context
+	// rather than an explicit AST annotation.
+	currentRetGo string
+
 	// questionSubs maps a QuestionExpr AST node to the Go expression
 	// text that should be emitted in its place. Populated by the
 	// statement-level pre-lift pass (see preLiftQuestions); consumed by
@@ -287,6 +292,31 @@ type Result[T any, E any] struct {
 	Error E
 	IsOk  bool
 }
+
+func (r Result[T, E]) isOk() bool { return r.IsOk }
+
+func (r Result[T, E]) isErr() bool { return !r.IsOk }
+
+func (r Result[T, E]) unwrap() T {
+	if !r.IsOk {
+		panic("called unwrap on Err")
+	}
+	return r.Value
+}
+
+func (r Result[T, E]) unwrapErr() E {
+	if r.IsOk {
+		panic("called unwrapErr on Ok")
+	}
+	return r.Error
+}
+
+func (r Result[T, E]) unwrapOr(fallback T) T {
+	if r.IsOk {
+		return r.Value
+	}
+	return fallback
+}
 `)
 	}
 	if g.needRange {
@@ -386,6 +416,29 @@ func runParallel[T any](bodies ...func() T) []T {
 		go func() {
 			defer wg.Done()
 			results[i] = body()
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// runParallelMap backs §8.3 parallel(items, concurrency, f). It keeps
+// source order in the returned slice while limiting in-flight workers.
+func runParallelMap[T any, R any](items []T, concurrency int, fn func(T) R) []R {
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	results := make([]R, len(items))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for i, item := range items {
+		i, item := i, item
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = fn(item)
 		}()
 	}
 	wg.Wait()

--- a/internal/gen/question.go
+++ b/internal/gen/question.go
@@ -58,7 +58,9 @@ func (g *gen) emitQuestionLiftBody(tmp string, q *ast.QuestionExpr) {
 	g.body.nl()
 	if isResult {
 		retGo := "any"
-		if g.currentRetType != nil {
+		if g.currentRetGo != "" {
+			retGo = g.currentRetGo
+		} else if g.currentRetType != nil {
 			retGo = g.goTypeExpr(g.currentRetType)
 		}
 		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error} }\n", tmp, retGo, tmp)

--- a/internal/gen/stmt.go
+++ b/internal/gen/stmt.go
@@ -218,7 +218,9 @@ func (g *gen) emitQuestionLift(name string, q *ast.QuestionExpr) {
 	if isResult {
 		// Reconstruct a Result of the enclosing function's signature.
 		retGo := "any"
-		if g.currentRetType != nil {
+		if g.currentRetGo != "" {
+			retGo = g.currentRetGo
+		} else if g.currentRetType != nil {
 			retGo = g.goTypeExpr(g.currentRetType)
 		}
 		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error} }\n", tmp, retGo, tmp)
@@ -416,8 +418,17 @@ func (g *gen) emitFor(f *ast.ForStmt) {
 	if tp, ok := f.Pattern.(*ast.TuplePat); ok && len(tp.Elems) == 2 {
 		k := forPatternName(tp.Elems[0], "_")
 		v := forPatternName(tp.Elems[1], "_")
+		iter := f.Iter
+		if recv, ok := enumerateReceiver(f.Iter); ok {
+			iter = recv
+		}
+		if v == "_" {
+			if _, wildcard := tp.Elems[1].(*ast.WildcardPat); !wildcard {
+				v = g.freshVar("_it")
+			}
+		}
 		g.body.writef("for %s, %s := range ", k, v)
-		g.emitExpr(f.Iter)
+		g.emitExpr(iter)
 		g.body.writeln(" {")
 		g.body.indent()
 		if k != "_" {
@@ -425,6 +436,19 @@ func (g *gen) emitFor(f *ast.ForStmt) {
 		}
 		if v != "_" {
 			g.body.writef("_ = %s\n", v)
+		}
+		if _, id := tp.Elems[1].(*ast.IdentPat); !id {
+			if _, wildcard := tp.Elems[1].(*ast.WildcardPat); !wildcard && v != "_" {
+				synth := &ast.LetStmt{Pattern: tp.Elems[1], Value: &ast.Ident{Name: v}}
+				switch p := tp.Elems[1].(type) {
+				case *ast.TuplePat:
+					g.emitLetTupleDestructure(p, synth)
+				case *ast.StructPat:
+					g.emitLetStructDestructure(p, synth)
+				default:
+					g.body.writef("/* TODO: for tuple value pattern %T */\n", tp.Elems[1])
+				}
+			}
 		}
 		g.emitStmts(f.Body.Stmts)
 		g.body.dedent()
@@ -511,7 +535,13 @@ func (g *gen) emitForLet(f *ast.ForStmt) {
 	g.body.writeln("for {")
 	g.body.indent()
 	tmp := g.freshVar("_ol")
-	g.body.writef("%s := ", tmp)
+	if iterT := g.typeOf(f.Iter); iterT != nil && !types.IsError(iterT) {
+		g.body.writef("var %s %s = ", tmp, g.goType(iterT))
+	} else if id, ok := f.Iter.(*ast.Ident); ok && id.Name == "None" {
+		g.body.writef("var %s *any = ", tmp)
+	} else {
+		g.body.writef("%s := ", tmp)
+	}
 	g.emitExpr(f.Iter)
 	g.body.writef("\n_ = %s\n", tmp)
 	vp, ok := f.Pattern.(*ast.VariantPat)
@@ -586,6 +616,18 @@ func forPatternName(p ast.Pattern, fallback string) string {
 		return "_"
 	}
 	return fallback
+}
+
+func enumerateReceiver(e ast.Expr) (ast.Expr, bool) {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return nil, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.Name != "enumerate" {
+		return nil, false
+	}
+	return field.X, true
 }
 
 // emitExprAsType emits an expression with a target type context. For

--- a/internal/stdlib/modules/testing.osty
+++ b/internal/stdlib/modules/testing.osty
@@ -35,3 +35,10 @@ pub fn fail(msg: String) -> Never {
 pub fn context(msg: String, body: fn() -> ()) {
     body()
 }
+
+pub fn benchmark(iterations: Int, body: fn() -> Result<(), Error>) {
+    body()
+}
+
+pub fn snapshot(name: String, output: String) {
+}

--- a/testdata/spec/positive/11-testing.osty
+++ b/testdata/spec/positive/11-testing.osty
@@ -9,7 +9,7 @@ fn testLoginSuccess() {
 
 fn testLoginRejectsBlankUser() {
     let result = login("", "anything")
-    testing.assertEq(result, Err(Invalid))
+    testing.assertEq(result, Err(Bad))
 }
 
 fn testAddTable() {


### PR DESCRIPTION
## Summary

- Align checker coverage with spec examples for `List.enumerate()`, `parallel(items, concurrency, fn)`, and closure-local `?` propagation.
- Extend generator lowering for spec-positive concurrency/testing paths, including `thread.collectAll`, `thread.race`, `parallel` map form, `enumerate` loops, Result runtime methods, and typed `?` returns.
- Promote the spec corpus gen audit so parser/resolve/gen/Go compile regressions fail tests, while logging currently opaque single-file checker diagnostics.

## Why

The spec corpus, checker, and generator had drifted: some positive spec fixtures were accepted by earlier stages but failed during Go lowering or compile checking. This closes that drift and adds regression coverage so future divergence is caught earlier.

## Validation

- `go run ./cmd/osty check testdata/spec/positive/08-concurrency.osty`
- `go run ./cmd/osty check testdata/spec/positive/11-testing.osty`
- `go test ./...`
