### PR TITLE
[codex] Expand dogfood examples and coverage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Osty Examples
+
+These examples are part of the dogfood corpus. They are intentionally
+kept under `go test` coverage so syntax, name resolution, type checking,
+code generation, and the test harness keep exercising real programs as
+the compiler evolves.
+
+## Packages
+
+- `calc`: small library used by the `osty test` harness smoke test.
+- `dogfood`: self-dogfooding library that summarizes Osty source text,
+  runs std.testing tests, calls Go FFI, and uses concurrency primitives.
+- `ffi`: runnable Go FFI example using the Go `strings` package.
+- `concurrency`: runnable example covering channels, `spawn`,
+  `parallel`, and `taskGroup`.
+- `stdlib-tour`: front-end checked package that demonstrates Tier 1
+  standard-library imports and Result-style error flow.
+- `workspace`: virtual workspace with two member packages and a
+  cross-package call from `cli` to `core`.

--- a/examples/concurrency/main.osty
+++ b/examples/concurrency/main.osty
@@ -1,0 +1,38 @@
+fn square(n: Int) -> Int {
+    n * n
+}
+
+fn producer(ch: Channel<Int>) {
+    for i in 1..=4 {
+        ch <- i
+    }
+    ch.close()
+}
+
+fn main() {
+    let ch = thread.chan::<Int>(0)
+    let h = spawn(|| producer(ch))
+    let mut sum = 0
+    for x in ch {
+        sum = sum + x
+    }
+    h.join()
+
+    let squares = parallel(
+        || square(2),
+        || square(3),
+        || square(4),
+    )
+    for n in squares {
+        sum = sum + n
+    }
+
+    let grouped = taskGroup(|g| {
+        let a = g.spawn(|| square(5))
+        let b = g.spawn(|| square(6))
+        a.join() + b.join()
+    })
+
+    println("sum={sum}")
+    println("grouped={grouped}")
+}

--- a/examples/concurrency/osty.toml
+++ b/examples/concurrency/osty.toml
@@ -1,0 +1,9 @@
+[package]
+name = "concurrency-demo"
+version = "0.1.0"
+edition = "0.3"
+description = "Runnable channel and structured concurrency example."
+license = "MIT"
+keywords = ["concurrency", "channels"]
+
+[dependencies]

--- a/examples/dogfood/osty.toml
+++ b/examples/dogfood/osty.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dogfood"
+version = "0.1.0"
+edition = "0.3"
+description = "Self-dogfooding source summarizer used by the Osty example corpus."
+license = "MIT"
+keywords = ["dogfood", "examples", "testing"]
+
+[dependencies]

--- a/examples/dogfood/source.osty
+++ b/examples/dogfood/source.osty
@@ -1,0 +1,127 @@
+use go "strings" as strings {
+    fn Contains(s: String, substr: String) -> Bool
+    fn Count(s: String, substr: String) -> Int
+    fn HasSuffix(s: String, suffix: String) -> Bool
+    fn TrimSpace(s: String) -> String
+}
+
+/// SourceFile is the small unit of Osty source inspected by the dogfood analyzer.
+pub struct SourceFile {
+    pub path: String,
+    pub text: String,
+}
+
+/// Summary records the signals this example cares about for one or more files.
+pub struct Summary {
+    pub files: Int,
+    pub functions: Int,
+    pub tests: Int,
+    pub imports: Int,
+    pub lines: Int,
+    pub hasFFI: Bool,
+    pub hasConcurrency: Bool,
+}
+
+/// source builds a SourceFile value for tests and examples.
+pub fn source(path: String, text: String) -> SourceFile {
+    SourceFile { path, text }
+}
+
+/// emptySummary returns the identity value used when merging summaries.
+pub fn emptySummary() -> Summary {
+    Summary {
+        files: 0,
+        functions: 0,
+        tests: 0,
+        imports: 0,
+        lines: 0,
+        hasFFI: false,
+        hasConcurrency: false,
+    }
+}
+
+/// lineCount counts non-empty source lines after trimming surrounding whitespace.
+pub fn lineCount(text: String) -> Int {
+    let trimmed = strings.TrimSpace(text)
+    if trimmed == "" {
+        0
+    } else {
+        strings.Count(trimmed, "\n") + 1
+    }
+}
+
+/// summarize extracts simple dogfood signals from one Osty source file.
+pub fn summarize(file: SourceFile) -> Summary {
+    Summary {
+        files: 1,
+        functions: strings.Count(file.text, "fn "),
+        tests: strings.Count(file.text, "fn test"),
+        imports: strings.Count(file.text, "use "),
+        lines: lineCount(file.text),
+        hasFFI: strings.Contains(file.text, "use go "),
+        hasConcurrency: strings.Contains(file.text, "spawn(") ||
+            strings.Contains(file.text, "thread.") ||
+            strings.Contains(file.text, "taskGroup"),
+    }
+}
+
+/// mergeSummary combines two Summary values.
+pub fn mergeSummary(a: Summary, b: Summary) -> Summary {
+    Summary {
+        files: a.files + b.files,
+        functions: a.functions + b.functions,
+        tests: a.tests + b.tests,
+        imports: a.imports + b.imports,
+        lines: a.lines + b.lines,
+        hasFFI: a.hasFFI || b.hasFFI,
+        hasConcurrency: a.hasConcurrency || b.hasConcurrency,
+    }
+}
+
+/// isTestFile reports whether a source path follows the Osty test-file convention.
+pub fn isTestFile(file: SourceFile) -> Bool {
+    strings.HasSuffix(file.path, "_test.osty")
+}
+
+/// readinessScore gives heavier weight to tests, FFI, and concurrency coverage.
+pub fn readinessScore(summary: Summary) -> Int {
+    let mut score = summary.functions * 2 + summary.tests * 3 + summary.imports
+    if summary.hasFFI {
+        score = score + 5
+    }
+    if summary.hasConcurrency {
+        score = score + 5
+    }
+    score
+}
+
+/// summarizeBatch summarizes three files concurrently with the prelude parallel helper.
+pub fn summarizeBatch(a: SourceFile, b: SourceFile, c: SourceFile) -> Summary {
+    let parts = parallel(
+        || summarize(a),
+        || summarize(b),
+        || summarize(c),
+    )
+    let mut out = emptySummary()
+    for part in parts {
+        out = mergeSummary(out, part)
+    }
+    out
+}
+
+/// streamLineTotal sends per-file line counts over a channel and totals them.
+pub fn streamLineTotal(files: List<SourceFile>) -> Int {
+    let ch = thread.chan::<Int>(0)
+    let h = spawn(|| {
+        for file in files {
+            ch <- lineCount(file.text)
+        }
+        ch.close()
+    })
+    let mut total = 0
+    for n in ch {
+        total = total + n
+    }
+    h.join()
+    total
+}

--- a/examples/dogfood/source_test.osty
+++ b/examples/dogfood/source_test.osty
@@ -1,0 +1,65 @@
+use std.testing
+
+fn sampleLib() -> SourceFile {
+    let text = r"""
+        use std.testing
+        use go strings
+        fn parse() {}
+        fn render() {}
+        """
+    source("lib.osty", text)
+}
+
+fn sampleTest() -> SourceFile {
+    let text = r"""
+        use std.testing
+        fn testParse() {}
+        fn testRender() {}
+        """
+    source("lib_test.osty", text)
+}
+
+fn sampleConcurrent() -> SourceFile {
+    let text = r"""
+        fn worker() { spawn(|| println("work")) }
+        fn fanout() { thread.yield() }
+        """
+    source("worker.osty", text)
+}
+
+fn testSummarizesOneSourceFile() {
+    let summary = summarize(sampleLib())
+    testing.assertEq(summary.files, 1)
+    testing.assertEq(summary.functions, 2)
+    testing.assertEq(summary.tests, 0)
+    testing.assertEq(summary.imports, 2)
+    testing.assert(summary.hasFFI)
+    testing.assert(!(summary.hasConcurrency))
+}
+
+fn testDetectsTestFileShape() {
+    testing.assert(isTestFile(sampleTest()))
+    testing.assert(!(isTestFile(sampleLib())))
+
+    let summary = summarize(sampleTest())
+    testing.assertEq(summary.tests, 2)
+    testing.assertEq(readinessScore(summary), 11)
+}
+
+fn testBatchSummaryUsesParallelWorkers() {
+    let summary = summarizeBatch(sampleLib(), sampleTest(), sampleConcurrent())
+    testing.assertEq(summary.files, 3)
+    testing.assertEq(summary.functions, 6)
+    testing.assertEq(summary.tests, 2)
+    testing.assert(summary.hasFFI)
+    testing.assert(summary.hasConcurrency)
+}
+
+fn testStreamLineTotalUsesChannels() {
+    let total = streamLineTotal([sampleLib(), sampleTest(), sampleConcurrent()])
+    testing.assertEq(total, 9)
+}
+
+fn benchSummarizeDogfoodSnippet() {
+    let _ = summarize(sampleConcurrent())
+}

--- a/examples/ffi/main.osty
+++ b/examples/ffi/main.osty
@@ -1,0 +1,17 @@
+use go "strings" as strings {
+    fn Contains(s: String, substr: String) -> Bool
+    fn Repeat(s: String, count: Int) -> String
+    fn ToUpper(s: String) -> String
+}
+
+fn banner(name: String) -> String {
+    strings.ToUpper(strings.Repeat(name, 2))
+}
+
+fn main() {
+    let msg = banner("osty")
+    println(msg)
+    if strings.Contains(msg, "OSTY") {
+        println("ffi ok")
+    }
+}

--- a/examples/ffi/osty.toml
+++ b/examples/ffi/osty.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ffi-demo"
+version = "0.1.0"
+edition = "0.3"
+description = "Runnable Go FFI example."
+license = "MIT"
+keywords = ["ffi", "go"]
+
+[dependencies]

--- a/examples/stdlib-tour/lib.osty
+++ b/examples/stdlib-tour/lib.osty
@@ -1,0 +1,45 @@
+use std.debug
+use std.fs
+use std.strings
+
+/// Document is a tiny value loaded through the std.fs and std.strings examples.
+pub struct Document {
+    pub path: String,
+    pub title: String,
+    pub body: String,
+}
+
+/// normalizedTitle trims surrounding whitespace and lowercases a title.
+pub fn normalizedTitle(raw: String) -> String {
+    strings.toLower(strings.trim(raw))
+}
+
+/// loadDocument reads a file and packages its path, normalized title, and body.
+pub fn loadDocument(path: String) -> Result<Document, Error> {
+    let text = fs.readToString(path)?
+    Ok(Document {
+        path,
+        title: normalizedTitle(path),
+        body: text,
+    })
+}
+
+/// containsNeedle performs a case-insensitive body search.
+pub fn containsNeedle(doc: Document, needle: String) -> Bool {
+    strings.contains(strings.toLower(doc.body), strings.toLower(needle))
+}
+
+/// removeIfPresent removes a path only when std.fs reports that it exists.
+pub fn removeIfPresent(path: String) -> Result<Bool, Error> {
+    if fs.exists(path) {
+        let _ = fs.remove(path)?
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// debugSize routes through std.debug and returns the original value.
+pub fn debugSize(n: Int) -> Int {
+    debug.dbg(n)
+}

--- a/examples/stdlib-tour/osty.toml
+++ b/examples/stdlib-tour/osty.toml
@@ -1,0 +1,9 @@
+[package]
+name = "stdlib-tour"
+version = "0.1.0"
+edition = "0.3"
+description = "Tier 1 standard-library usage tour."
+license = "MIT"
+keywords = ["stdlib", "examples"]
+
+[dependencies]

--- a/examples/workspace/cli/main.osty
+++ b/examples/workspace/cli/main.osty
@@ -1,0 +1,6 @@
+use core
+
+fn main() {
+    let signal = core.makeSignal("dogfood", 6, 5)
+    println(core.badge(signal))
+}

--- a/examples/workspace/cli/osty.toml
+++ b/examples/workspace/cli/osty.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cli"
+version = "0.1.0"
+edition = "0.3"
+description = "Binary member for the workspace example."
+license = "MIT"
+
+[dependencies]

--- a/examples/workspace/core/lib.osty
+++ b/examples/workspace/core/lib.osty
@@ -1,0 +1,24 @@
+/// BuildSignal is the shared value passed between workspace members.
+pub struct BuildSignal {
+    pub name: String,
+    pub score: Int,
+    pub runnable: Bool,
+}
+
+/// makeSignal computes a readiness score from test and example counts.
+pub fn makeSignal(name: String, tests: Int, examples: Int) -> BuildSignal {
+    BuildSignal {
+        name,
+        score: tests * 3 + examples * 2,
+        runnable: tests > 0 && examples > 0,
+    }
+}
+
+/// badge renders a compact status string for CLI-style output.
+pub fn badge(signal: BuildSignal) -> String {
+    if signal.runnable {
+        "{signal.name}:{signal.score}:ready"
+    } else {
+        "{signal.name}:{signal.score}:draft"
+    }
+}

--- a/examples/workspace/core/osty.toml
+++ b/examples/workspace/core/osty.toml
@@ -1,0 +1,8 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "0.3"
+description = "Shared library member for the workspace example."
+license = "MIT"
+
+[dependencies]

--- a/examples/workspace/osty.toml
+++ b/examples/workspace/osty.toml
@@ -1,0 +1,4 @@
+# Virtual workspace root used by the dogfood example tests.
+
+[workspace]
+members = ["core", "cli"]

--- a/internal/examples/examples_test.go
+++ b/internal/examples/examples_test.go
@@ -1,0 +1,360 @@
+package examples_test
+
+import (
+	"bytes"
+	"fmt"
+	goparser "go/parser"
+	gotoken "go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/gen"
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+	"github.com/osty/osty/internal/testgen"
+)
+
+func TestExampleManifestsValidate(t *testing.T) {
+	root := repoRoot(t)
+	examples := filepath.Join(root, "examples")
+	err := filepath.WalkDir(examples, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != manifest.ManifestFile {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		m, err := manifest.Parse(src)
+		if err != nil {
+			t.Errorf("%s: parse manifest: %v", rel(root, path), err)
+			return nil
+		}
+		for _, d := range manifest.Validate(m) {
+			if d.Severity == diag.Error {
+				t.Errorf("%s: manifest diagnostic: %s", rel(root, path), d.Error())
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk examples: %v", err)
+	}
+}
+
+func TestRunnableExamplesGenerateAndExecute(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go binary not on PATH")
+	}
+	root := repoRoot(t)
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"examples/ffi/main.osty", "OSTYOSTY\nffi ok\n"},
+		{"examples/concurrency/main.osty", "sum=39\ngrouped=61\n"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.path, func(t *testing.T) {
+			goSrc := transpileFile(t, filepath.Join(root, c.path))
+			got := runGo(t, goSrc)
+			if got != c.want {
+				t.Fatalf("output mismatch for %s\ngot:\n%q\nwant:\n%q\n--- go ---\n%s",
+					c.path, got, c.want, goSrc)
+			}
+		})
+	}
+}
+
+func TestDogfoodExampleTestsExecute(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go binary not on PATH")
+	}
+	root := repoRoot(t)
+	dir := filepath.Join(root, "examples", "dogfood")
+	pkg, chk := checkPackageDir(t, dir, true)
+	entries := discoverEntries(pkg)
+	if len(entries) == 0 {
+		t.Fatal("dogfood example exposed no test or benchmark entries")
+	}
+	srcs, err := testgen.GenerateHarness(pkg, chk, entries)
+	if err != nil {
+		t.Fatalf("GenerateHarness: %v", err)
+	}
+	assertParsesAsGo(t, "main.go", srcs.Main)
+	assertParsesAsGo(t, "harness.go", srcs.Harness)
+
+	out := runGoPackage(t, map[string][]byte{
+		"main.go":    srcs.Main,
+		"harness.go": srcs.Harness,
+	})
+	want := fmt.Sprintf("%d passed, 0 failed, %d total", len(entries), len(entries))
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing dogfood test summary %q in:\n%s", want, out)
+	}
+}
+
+func TestStdlibTourExampleChecks(t *testing.T) {
+	root := repoRoot(t)
+	checkPackageDir(t, filepath.Join(root, "examples", "stdlib-tour"), false)
+}
+
+func TestWorkspaceExampleChecks(t *testing.T) {
+	root := repoRoot(t)
+	dir := filepath.Join(root, "examples", "workspace")
+	raw, err := os.ReadFile(filepath.Join(dir, manifest.ManifestFile))
+	if err != nil {
+		t.Fatalf("read workspace manifest: %v", err)
+	}
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse workspace manifest: %v", err)
+	}
+	failOnErrors(t, "workspace manifest", manifest.Validate(m))
+	if m.Workspace == nil {
+		t.Fatal("workspace example has no [workspace] table")
+	}
+
+	ws, err := resolve.NewWorkspace(dir)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	ws.Stdlib = stdlib.LoadCached()
+	for _, member := range m.Workspace.Members {
+		if _, err := ws.LoadPackage(member); err != nil {
+			t.Fatalf("load workspace member %s: %v", member, err)
+		}
+	}
+	results := ws.ResolveAll()
+	checks := check.Workspace(ws, results, check.Opts{Primitives: stdlib.LoadCached().Primitives})
+	paths := make([]string, 0, len(ws.Packages))
+	for p := range ws.Packages {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		pkg := ws.Packages[p]
+		if pkg == nil {
+			continue
+		}
+		var parseDiags []*diag.Diagnostic
+		for _, pf := range pkg.Files {
+			parseDiags = append(parseDiags, pf.ParseDiags...)
+		}
+		failOnErrors(t, "workspace "+p+" parse", parseDiags)
+		if r := results[p]; r != nil {
+			failOnErrors(t, "workspace "+p+" resolve", r.Diags)
+		}
+		if c := checks[p]; c != nil {
+			failOnErrors(t, "workspace "+p+" check", c.Diags)
+		}
+	}
+}
+
+func checkPackageDir(t *testing.T, dir string, includeTests bool) (*resolve.Package, *check.Result) {
+	t.Helper()
+	var (
+		pkg *resolve.Package
+		err error
+	)
+	if includeTests {
+		pkg, err = resolve.LoadPackageWithTests(dir)
+	} else {
+		pkg, err = resolve.LoadPackage(dir)
+	}
+	if err != nil {
+		t.Fatalf("load package %s: %v", dir, err)
+	}
+	var parseDiags []*diag.Diagnostic
+	for _, pf := range pkg.Files {
+		parseDiags = append(parseDiags, pf.ParseDiags...)
+	}
+	failOnErrors(t, rel(repoRoot(t), dir)+" parse", parseDiags)
+
+	ws, err := resolve.NewWorkspace(dir)
+	if err != nil {
+		t.Fatalf("workspace %s: %v", dir, err)
+	}
+	ws.Stdlib = stdlib.LoadCached()
+	ws.Packages[""] = pkg
+	pkg.Name = filepath.Base(dir)
+	preloadPackageUses(ws, pkg)
+	results := ws.ResolveAll()
+	pr := results[""]
+	if pr == nil {
+		t.Fatalf("missing root package result for %s", dir)
+	}
+	failOnErrors(t, rel(repoRoot(t), dir)+" resolve", pr.Diags)
+	chk := check.Package(pkg, pr, check.Opts{Primitives: stdlib.LoadCached().Primitives})
+	failOnErrors(t, rel(repoRoot(t), dir)+" check", chk.Diags)
+	return pkg, chk
+}
+
+func preloadPackageUses(ws *resolve.Workspace, pkg *resolve.Package) {
+	for _, pf := range pkg.Files {
+		if pf.File == nil {
+			continue
+		}
+		for _, u := range pf.File.Uses {
+			if u.IsGoFFI {
+				continue
+			}
+			target := strings.Join(u.Path, ".")
+			if target == "" {
+				continue
+			}
+			if _, ok := ws.Packages[target]; ok {
+				continue
+			}
+			_, _ = ws.LoadPackage(target)
+		}
+	}
+}
+
+func transpileFile(t *testing.T, path string) []byte {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	file, parseDiags := parser.ParseDiagnostics(src)
+	failOnErrors(t, rel(repoRoot(t), path)+" parse", parseDiags)
+	reg := stdlib.LoadCached()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	failOnErrors(t, rel(repoRoot(t), path)+" resolve", res.Diags)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	failOnErrors(t, rel(repoRoot(t), path)+" check", chk.Diags)
+	goSrc, err := gen.Generate("main", file, res, chk)
+	if err != nil {
+		t.Fatalf("gen %s: %v\n%s", rel(repoRoot(t), path), err, goSrc)
+	}
+	assertParsesAsGo(t, filepath.Base(path)+".go", goSrc)
+	return goSrc
+}
+
+func discoverEntries(pkg *resolve.Package) []testgen.Entry {
+	files := append([]*resolve.PackageFile(nil), pkg.Files...)
+	sort.SliceStable(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	var out []testgen.Entry
+	for _, pf := range files {
+		if pf.File == nil {
+			continue
+		}
+		for _, d := range pf.File.Decls {
+			fn, ok := d.(*ast.FnDecl)
+			if !ok || !isDiscoverable(fn) {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(fn.Name, "test"):
+				out = append(out, testgen.Entry{
+					Name: fn.Name,
+					Kind: testgen.KindTest,
+					File: filepath.Base(pf.Path),
+					Line: fn.PosV.Line,
+				})
+			case strings.HasPrefix(fn.Name, "bench"):
+				out = append(out, testgen.Entry{
+					Name: fn.Name,
+					Kind: testgen.KindBench,
+					File: filepath.Base(pf.Path),
+					Line: fn.PosV.Line,
+				})
+			}
+		}
+	}
+	return out
+}
+
+func isDiscoverable(fn *ast.FnDecl) bool {
+	return fn.Recv == nil &&
+		len(fn.Params) == 0 &&
+		len(fn.Generics) == 0 &&
+		fn.ReturnType == nil
+}
+
+func failOnErrors(t *testing.T, label string, diags []*diag.Diagnostic) {
+	t.Helper()
+	for _, d := range diags {
+		if d.Severity == diag.Error {
+			t.Errorf("%s: %s", label, d.Error())
+		}
+	}
+}
+
+func assertParsesAsGo(t *testing.T, name string, src []byte) {
+	t.Helper()
+	if _, err := goparser.ParseFile(gotoken.NewFileSet(), name, src, 0); err != nil {
+		t.Fatalf("%s does not parse as Go: %v\n%s", name, err, src)
+	}
+}
+
+func runGo(t *testing.T, src []byte) string {
+	t.Helper()
+	return runGoPackage(t, map[string][]byte{"main.go": src})
+}
+
+func runGoPackage(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, src := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), src, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if _, ok := files["go.mod"]; !ok {
+		if err := os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module example\n\ngo 1.22\n"), 0o644); err != nil {
+			t.Fatalf("write go.mod: %v", err)
+		}
+	}
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = dir
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go run failed: %v\n%s", err, out.String())
+	}
+	return out.String()
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func rel(root, path string) string {
+	if r, err := filepath.Rel(root, path); err == nil {
+		return r
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- Add larger Osty example programs for self-dogfooding, standard library usage, Go FFI, concurrency, and workspace/package flows.
- Add `internal/examples` regression coverage that validates manifests, checks example packages/workspaces, runs generated Go for runnable examples, and executes the dogfood `std.testing` harness.
- Document the example corpus in `examples/README.md` so the examples are easier to discover and maintain.

## Impact

This turns the examples into a living dogfood corpus instead of standalone sample files. Future parser, resolver, checker, generator, stdlib, or test harness regressions should be caught by `go test ./...`.

## Validation

- `go test ./internal/examples`
- `go test ./...`
- `go run ./cmd/osty test examples/dogfood`
- `go run ./cmd/osty pipeline examples/workspace`