### PR TITLE
[codex] strengthen checker static guarantees

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,16 +167,19 @@ bodies producing per-expression types in `Result.Types` plus
 per-symbol types in `Result.SymTypes`. Entry points mirror
 `resolve`: `File`, `Package`, `Workspace`.
 
-Known gaps (hooks reserved but not yet wired) live in a package doc
-comment at `env.go`:
+The main static guarantee hooks are wired here:
 
-- generic monomorphization,
-- interface-satisfaction validation,
-- match-exhaustiveness (`E0731` reserved in `diag/codes.go`),
-- builder auto-derivation (§3.4).
-
-Method references (`obj.method` as a value) are also deferred —
-`expr.go:1106` returns `ErrorType` with a TODO comment.
+- generic call sites are recorded in `Result.Instantiations` for
+  demand-driven monomorphization in `internal/gen`,
+- structural interface satisfaction checks composed interfaces,
+  `Self`-typed signatures, generic receiver substitution, and generic
+  bounds,
+- match exhaustiveness emits `E0731` and synthesizes witnesses for
+  closed product/sum shapes,
+- auto-derived `default()`, `builder()`, `toBuilder()`, setter chains,
+  and `build()` obligations are checked in `builder.go`,
+- method references (`obj.method` as a value) lower to receiver-free
+  function types.
 
 ### `internal/stdlib`
 Built-in prelude symbols injected into every file before resolution.
@@ -342,11 +345,11 @@ Cross-file resolution used to live here as a gap; it's now done via
 One resolver-level test is still pending: cross-file partial-method
 name-collision detection (`resolve/package_test.go:243`, skipped).
 
-The checker still defers four items (see `internal/check/env.go`):
-generic monomorphization, interface-satisfaction validation, match
-exhaustiveness (`E0731`), and builder auto-derivation. The
-transpiler's Phase 2+ is the other large remaining surface — see
-`internal/gen/doc.go` for the scoping.
+The checker is still intentionally conservative in a few places:
+built-in marker-interface derivation outside primitives is broad,
+open scalar match domains require a catch-all, and type-level generic
+specialization is less precise than function-call monomorphization.
+See `internal/gen/doc.go` for the transpiler's remaining scoping.
 
 Spec-level open items are tracked in `SPEC_GAPS.md` (currently: zero
 open gaps for v0.3).

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ orchestrator (`osty build`) that reads `osty.toml` / `osty.lock`
 and threads the front-end + gen across the declared packages, a
 working test runner (`osty test`), API documentation generation
 (`osty doc`), and CI quality tooling (`osty ci`). The remaining
-pieces are four deferred type-checker hooks (generic
-monomorphization, interface-satisfaction, match exhaustiveness,
-`#[derive(Builder)]`), Tier 2+ of the standard library, and the
-real package-registry backend behind `osty add` / `osty update` /
-`osty publish`.
+pieces are Tier 2+ of the standard library and the real
+package-registry backend behind `osty add` / `osty update` /
+`osty publish`; the checker now records generic call
+instantiations, validates structural interface satisfaction, emits
+match exhaustiveness diagnostics, and wires the auto-derived
+builder/default protocol.
 transpiler whose Phase 1 (primitives, fns, control flow) is
 working, project scaffolding (`osty new` / `osty init`), a
 manifest-driven build orchestrator (`osty build`) that reads
@@ -75,20 +76,17 @@ fixture that triggers the expected `Exxxx` diagnostic. See
 
 The checker covers the common path (literals, operators, collections,
 functions, patterns, control flow, field access, method dispatch,
-Option/Result, closures, type aliases) but has four consciously-deferred
-hooks documented at `internal/check/env.go`:
+Option/Result, closures, type aliases) and now closes the major static
+guarantee hooks: generic call instantiation records for the transpiler,
+structural interface satisfaction including composed interfaces, match
+exhaustiveness (`E0731`) with witnesses for closed shapes, method
+references as values, and auto-derived `default()` / builder flows.
 
-- **Generic monomorphization** — generic fns aren't specialized per call site.
-- **Interface-satisfaction validation** — structs aren't checked to actually
-  implement their declared interfaces.
-- **Match exhaustiveness (`E0731`)** — code reserved in `diag/codes.go`
-  but not yet emitted.
-- **Builder auto-derivation** (§3.4) — `#[derive(Builder)]` not supported.
-
-Minor deferred items: method references as values (`obj.method` without
-a call) at `internal/check/expr.go:1106`, and cross-file partial-method
-name-collision detection (test skipped at
-`internal/resolve/package_test.go:243`).
+Minor deferred items are deliberately conservative rather than absent:
+some built-in marker-interface derivations are accepted optimistically
+outside primitives, open scalar match domains still require a catch-all,
+and type-level generic specialization remains less precise than
+function-call monomorphization.
 
 ### Transpiler phases
 

--- a/internal/check/builder.go
+++ b/internal/check/builder.go
@@ -184,16 +184,26 @@ func (c *checker) builderSet(b *types.Builder, fx *ast.FieldExpr, e *ast.CallExp
 			fx.Name, len(e.Args))
 		return b
 	}
-	// Apply any receiver-side generic substitution.
-	ft := target.Type
-	if sub := types.BindArgs(desc.Generics, b.Struct.Args); len(sub) > 0 {
-		ft = types.Substitute(ft, sub)
-	}
+	// Apply receiver-side generic substitution, but leave still-symbolic
+	// builder args open so this setter can infer them:
+	// `Box.builder().value(1).build()` narrows Builder<Box<T>> to
+	// Builder<Box<Int>> at the setter call.
+	sub := openBuilderSub(desc.Generics, b.Struct.Args)
+	ft := types.Substitute(target.Type, sub)
 	at := c.checkExpr(e.Args[0].Value, ft, env)
-	if !types.Assignable(ft, at) {
+	inferFromArg(target.Type, at, sub)
+	nextArgs := materializeBuilderArgs(desc.Generics, b.Struct.Args, sub)
+	if len(nextArgs) > 0 {
+		ft = types.Substitute(target.Type, types.BindArgs(desc.Generics, nextArgs))
+	}
+	if !c.accepts(ft, at, e.Args[0].Value) {
 		c.errMismatch(e.Args[0].Value, ft, at)
 	}
-	return b.WithField(fx.Name)
+	next := b.WithField(fx.Name)
+	if len(nextArgs) > 0 {
+		next.Struct = &types.Named{Sym: b.Struct.Sym, Args: nextArgs}
+	}
+	return next
 }
 
 // builderBuild validates a `.build()` terminal call: every required
@@ -254,4 +264,53 @@ func hasZeroValue(t types.Type) bool {
 		}
 	}
 	return false
+}
+
+func openBuilderSub(generics []*types.TypeVar, args []types.Type) map[*resolve.Symbol]types.Type {
+	if len(generics) == 0 || len(args) == 0 {
+		return map[*resolve.Symbol]types.Type{}
+	}
+	sub := make(map[*resolve.Symbol]types.Type, len(generics))
+	for i, g := range generics {
+		if i >= len(args) || g == nil || g.Sym == nil {
+			break
+		}
+		if tv, ok := args[i].(*types.TypeVar); ok && tv.Sym == g.Sym {
+			continue
+		}
+		sub[g.Sym] = args[i]
+	}
+	return sub
+}
+
+func materializeBuilderArgs(
+	generics []*types.TypeVar,
+	current []types.Type,
+	sub map[*resolve.Symbol]types.Type,
+) []types.Type {
+	if len(generics) == 0 {
+		return nil
+	}
+	out := make([]types.Type, len(generics))
+	for i, g := range generics {
+		if g != nil && g.Sym != nil {
+			if t, ok := sub[g.Sym]; ok && t != nil {
+				out[i] = defaultUntyped(t)
+				continue
+			}
+		}
+		if i < len(current) && current[i] != nil {
+			out[i] = defaultUntyped(current[i])
+			continue
+		}
+		out[i] = g
+	}
+	return out
+}
+
+func defaultUntyped(t types.Type) types.Type {
+	if u, ok := t.(*types.Untyped); ok {
+		return u.Default()
+	}
+	return t
 }

--- a/internal/check/callargs.go
+++ b/internal/check/callargs.go
@@ -24,10 +24,17 @@ func (c *checker) applyDeclaredCall(
 	e *ast.CallExpr, fn *types.FnType, generics []*types.TypeVar,
 	params []*ast.Param, hint types.Type, env *env,
 ) types.Type {
+	return c.applyDeclaredCallWithExplicit(e, fn, generics, params, nil, hint, env)
+}
+
+func (c *checker) applyDeclaredCallWithExplicit(
+	e *ast.CallExpr, fn *types.FnType, generics []*types.TypeVar,
+	params []*ast.Param, explicit []types.Type, hint types.Type, env *env,
+) types.Type {
 	// Fast path: no param metadata → fall back to the positional-only
 	// generic-aware path.
 	if len(params) == 0 {
-		return c.applyGenericCall(e, fn, generics, hint, env)
+		return c.applyGenericCallWithArgs(e, fn, generics, explicit, hint, env)
 	}
 
 	// Walk the surface-call arguments once to classify positional vs
@@ -82,7 +89,7 @@ func (c *checker) applyDeclaredCall(
 	// Now drive the generic-aware positional check using `resolved` as
 	// the effective argument list. Missing slots (defaults) are filled
 	// with nil and skipped.
-	return c.applyGenericCallResolved(e, fn, generics, params, resolved, hint, env)
+	return c.applyGenericCallResolved(e, fn, generics, params, resolved, explicit, hint, env)
 }
 
 // applyGenericCallResolved mirrors applyGenericCallWithArgs but pulls
@@ -92,8 +99,9 @@ func (c *checker) applyDeclaredCall(
 // type still participates in return-type inference.
 func (c *checker) applyGenericCallResolved(
 	e *ast.CallExpr, fn *types.FnType, generics []*types.TypeVar,
-	params []*ast.Param, resolved []*ast.Arg, hint types.Type, env *env,
+	params []*ast.Param, resolved []*ast.Arg, explicit []types.Type, hint types.Type, env *env,
 ) types.Type {
+	c.checkExplicitGenericArity(e, len(generics), len(explicit))
 	if len(generics) == 0 {
 		// Simple type-check loop without substitution work.
 		for i, a := range resolved {
@@ -102,7 +110,7 @@ func (c *checker) applyGenericCallResolved(
 			}
 			pt := fn.Params[i]
 			at := c.checkExpr(a.Value, pt, env)
-			if pt != nil && !types.IsError(pt) && !types.Assignable(pt, at) {
+			if pt != nil && !types.IsError(pt) && !c.accepts(pt, at, a.Value) {
 				c.errMismatch(a.Value, pt, at)
 			}
 		}
@@ -110,6 +118,11 @@ func (c *checker) applyGenericCallResolved(
 	}
 
 	sub := make(map[*resolve.Symbol]types.Type, len(generics))
+	for i, g := range generics {
+		if i < len(explicit) {
+			sub[g.Sym] = explicit[i]
+		}
+	}
 	if hint != nil && !types.IsError(hint) {
 		inferFromArg(fn.Return, hint, sub)
 	}
@@ -140,7 +153,7 @@ func (c *checker) applyGenericCallResolved(
 		}
 		pt := types.Substitute(fn.Params[i], sub)
 		at := c.result.Types[a.Value]
-		if pt != nil && !types.IsError(pt) && at != nil && !types.Assignable(pt, at) {
+		if pt != nil && !types.IsError(pt) && at != nil && !c.accepts(pt, at, a.Value) {
 			c.errMismatch(a.Value, pt, at)
 		}
 	}

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -475,6 +475,182 @@ fn main() {
 	assertOK(t, runCheck(t, src))
 }
 
+func TestCheck_InterfaceValueExposesRequiredMethods(t *testing.T) {
+	src := `
+pub interface Printable {
+    fn show(self) -> String
+}
+
+fn render(p: Printable) -> String {
+    p.show()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_InterfaceBoundExposesRequiredMethods(t *testing.T) {
+	src := `
+pub interface Printable {
+    fn show(self) -> String
+}
+
+fn render<T: Printable>(p: T) -> String {
+    p.show()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_InterfaceReturnRequiresGenericBound(t *testing.T) {
+	src := `
+pub interface Printable {
+    fn show(self) -> String
+}
+
+fn render<T>(p: T) -> Printable {
+    p
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_InterfaceReturnAcceptsGenericBound(t *testing.T) {
+	src := `
+pub interface Printable {
+    fn show(self) -> String
+}
+
+fn render<T: Printable>(p: T) -> Printable {
+    p
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_InterfaceReturnRejectsDifferentBoundSignature(t *testing.T) {
+	src := `
+pub interface IntBox {
+    fn get(self) -> Int
+}
+
+pub interface StringBox {
+    fn get(self) -> String
+}
+
+fn render<T: IntBox>(p: T) -> StringBox {
+    p
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_InterfaceCompositionSatisfiedStructurally(t *testing.T) {
+	src := `
+pub interface Named {
+    fn name(self) -> String
+}
+
+pub interface Printable {
+    fn show(self) -> String
+}
+
+pub interface DisplayNamed {
+    Named
+    Printable
+}
+
+pub struct User {
+    pub label: String,
+
+    pub fn name(self) -> String { self.label }
+    pub fn show(self) -> String { self.label }
+}
+
+fn render<T: DisplayNamed>(x: T) -> String {
+    let n = x.name()
+    x.show()
+}
+
+fn main() {
+    let u = User { label: "ada" }
+    render(u)
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_InterfaceCompositionMissingInheritedMethod(t *testing.T) {
+	src := `
+pub interface Named {
+    fn name(self) -> String
+}
+
+pub interface Printable {
+    fn show(self) -> String
+}
+
+pub interface DisplayNamed {
+    Named
+    Printable
+}
+
+pub struct OnlyNamed {
+    pub label: String,
+
+    pub fn name(self) -> String { self.label }
+}
+
+fn render<T: DisplayNamed>(x: T) {}
+
+fn main() {
+    render(OnlyNamed { label: "ada" })
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_InterfaceSelfSignatureMatchesConcreteSelf(t *testing.T) {
+	src := `
+pub interface Same {
+    fn same(self, other: Self) -> Bool
+}
+
+pub struct Point {
+    pub x: Int,
+
+    pub fn same(self, other: Point) -> Bool { true }
+}
+
+fn require<T: Same>(x: T) {}
+
+fn main() {
+    require(Point { x: 1 })
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_InterfaceSatisfactionSubstitutesGenericReceiver(t *testing.T) {
+	src := `
+pub interface IntBox {
+    fn get(self) -> Int
+}
+
+pub struct Box<T> {
+    pub value: T,
+
+    pub fn get(self) -> T { self.value }
+}
+
+fn require<T: IntBox>(x: T) {}
+
+fn main() {
+    require(Box.builder().value(1).build())
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
 // runCheckWithStdlib parses + resolves + type-checks with the primitive
 // method table from the embedded stdlib. Only required by tests that
 // exercise intrinsic primitive methods (`Int.abs`, `Float.sqrt`, ...).
@@ -1675,6 +1851,19 @@ fn main() {
 	assertOK(t, runCheck(t, src))
 }
 
+func TestCheck_GenericBuilderInfersTypeArgsFromSetter(t *testing.T) {
+	src := `
+pub struct Box<T> {
+    pub value: T,
+}
+
+fn main() {
+    let b: Box<Int> = Box.builder().value(1).build()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
 func TestCheck_StructDefaultAllFieldsHaveDefaults(t *testing.T) {
 	src := `
 pub struct Settings {
@@ -1741,6 +1930,17 @@ fn describe(u: Int?) -> String {
 }
 `
 	assertCodes(t, runCheck(t, src), diag.CodeNonExhaustiveMatch)
+}
+
+func TestCheck_MatchOptionOrPatternExhaustive(t *testing.T) {
+	src := `
+fn describe(b: Bool?) -> Int {
+    match b {
+        Some(_) | _ -> 0,
+    }
+}
+`
+	assertOK(t, runCheck(t, src))
 }
 
 func TestCheck_MatchGuardsRequireCatchAll(t *testing.T) {
@@ -1812,6 +2012,17 @@ fn main() {
 	if !seen["Int"] || !seen["String"] {
 		t.Fatalf("expected instantiations for Int and String, got %v", seen)
 	}
+}
+
+func TestCheck_TurbofishWrongTypeArgCount(t *testing.T) {
+	src := `
+fn identity<T>(x: T) -> T { x }
+
+fn main() {
+    let x = identity::<Int, String>(1)
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeGenericArgCount)
 }
 
 // TestCheck_MatchEnumVariantPayloadGap verifies that even when every

--- a/internal/check/collect.go
+++ b/internal/check/collect.go
@@ -243,6 +243,11 @@ func (c *checker) collectInterface(n *ast.InterfaceDecl) {
 	selfT := &types.Named{Sym: sym, Args: argsOfGenerics(desc.Generics)}
 	c.setSymType(sym, selfT)
 
+	for _, ext := range n.Extends {
+		if t := c.typeOf(ext); t != nil {
+			desc.InterfaceExtends = append(desc.InterfaceExtends, t)
+		}
+	}
 	for _, m := range n.Methods {
 		md := c.methodDescOf(m, desc)
 		desc.InterfaceMethods[m.Name] = md
@@ -322,6 +327,7 @@ func (c *checker) methodDescOf(n *ast.FnDecl, owner *typeDesc) *methodDesc {
 		HasBody:       n.Body != nil,
 		Params:        n.Params,
 		Decl:          n,
+		Owner:         owner,
 		Generics:      ownGenerics,
 		OwnerGenerics: ownerGenerics,
 	}

--- a/internal/check/env.go
+++ b/internal/check/env.go
@@ -4,9 +4,9 @@
 // *Result (per-expression types + per-symbol types + collected struct /
 // enum / interface / alias shapes) plus diagnostics.
 //
-// Known gaps (each has a hook where the real implementation will land):
-// full generic monomorphization, interface-satisfaction validation,
-// match-exhaustiveness (E0731), and builder auto-derivation (§3.4).
+// The checker also records the static evidence downstream phases need
+// for monomorphized generic calls, interface satisfaction, match
+// exhaustiveness, and auto-derived builder/default members.
 package check
 
 import (
@@ -36,12 +36,13 @@ type typeDesc struct {
 	Sym              *resolve.Symbol
 	Kind             resolve.SymbolKind
 	Generics         []*types.TypeVar
-	Fields           []*fieldDesc                 // struct only
+	Fields           []*fieldDesc // struct only
 	Methods          map[string]*methodDesc
-	Variants         map[string]*variantDesc      // enum only
-	VariantOrder     []string                     // enum variant source order
-	InterfaceMethods map[string]*methodDesc       // interface signatures
-	Alias            types.Type                   // type alias target
+	Variants         map[string]*variantDesc // enum only
+	VariantOrder     []string                // enum variant source order
+	InterfaceMethods map[string]*methodDesc  // interface signatures
+	InterfaceExtends []types.Type            // interface composition clauses
+	Alias            types.Type              // type alias target
 }
 
 type fieldDesc struct {
@@ -60,6 +61,7 @@ type methodDesc struct {
 	HasBody       bool
 	Params        []*ast.Param
 	Decl          *ast.FnDecl
+	Owner         *typeDesc        // enclosing type/interface, if any
 	Generics      []*types.TypeVar // method's own type parameters (e.g. <U>)
 	OwnerGenerics []*types.TypeVar // enclosing type's generics
 }

--- a/internal/check/exhaust.go
+++ b/internal/check/exhaust.go
@@ -152,11 +152,11 @@ func (c *checker) checkVariantReachability(m *ast.MatchExpr, arms []armHead) {
 // match anything (wildcards or plain ident bindings), which signals
 // that the arm fully covers its variant.
 type armHead struct {
-	guarded          bool
-	variant          string   // "" when no top-level variant (tuple/struct/literal)
-	orAlts           []string // alternatives in an or-pattern
-	catchAllPayload  bool     // variant arm whose payload is all catch-all
-	pattern          ast.Pattern
+	guarded         bool
+	variant         string   // "" when no top-level variant (tuple/struct/literal)
+	orAlts          []string // alternatives in an or-pattern
+	catchAllPayload bool     // variant arm whose payload is all catch-all
+	pattern         ast.Pattern
 }
 
 func classifyArmPattern(p ast.Pattern, guarded bool) armHead {
@@ -323,12 +323,19 @@ func (c *checker) verifyOptionCoverage(m *ast.MatchExpr, scrutT, innerT types.Ty
 		if arm.Guard != nil {
 			continue
 		}
-		head := variantHeadName(arm.Pattern)
-		switch head {
-		case "Some":
+		heads, catchAll := variantHeadCoverage(arm.Pattern)
+		if catchAll {
 			someCovered = true
-		case "None":
 			noneCovered = true
+			continue
+		}
+		for _, head := range heads {
+			switch head {
+			case "Some":
+				someCovered = true
+			case "None":
+				noneCovered = true
+			}
 		}
 	}
 	var missing []string
@@ -356,11 +363,19 @@ func (c *checker) verifyResultCoverage(m *ast.MatchExpr, scrutT types.Type) {
 		if arm.Guard != nil {
 			continue
 		}
-		switch variantHeadName(arm.Pattern) {
-		case "Ok":
+		heads, catchAll := variantHeadCoverage(arm.Pattern)
+		if catchAll {
 			okCovered = true
-		case "Err":
 			errCovered = true
+			continue
+		}
+		for _, head := range heads {
+			switch head {
+			case "Ok":
+				okCovered = true
+			case "Err":
+				errCovered = true
+			}
 		}
 	}
 	var missing []string
@@ -398,3 +413,23 @@ func variantHeadName(p ast.Pattern) string {
 	return ""
 }
 
+func variantHeadCoverage(p ast.Pattern) ([]string, bool) {
+	if op, ok := p.(*ast.OrPat); ok {
+		var out []string
+		for _, alt := range op.Alts {
+			heads, catchAll := variantHeadCoverage(alt)
+			if catchAll {
+				return nil, true
+			}
+			out = append(out, heads...)
+		}
+		return out, false
+	}
+	if patternIsCatchAll(p) {
+		return nil, true
+	}
+	if h := variantHeadName(p); h != "" {
+		return []string{h}, false
+	}
+	return nil, false
+}

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -449,7 +449,8 @@ func (c *checker) callType(e *ast.CallExpr, hint types.Type, env *env) types.Typ
 					for _, a := range tf.Args {
 						explicit = append(explicit, c.typeOf(a))
 					}
-					return c.applyGenericCallWithArgs(e, fn, generics, explicit, hint, env)
+					params := fnDeclParams(sym)
+					return c.applyDeclaredCallWithExplicit(e, fn, generics, params, explicit, hint, env)
 				}
 			}
 		}
@@ -503,7 +504,7 @@ func (c *checker) applyFnTo(call ast.Node, args []*ast.Arg, fn *types.FnType, en
 			c.satisfies(at, ifaceN, a.Value)
 			continue
 		}
-		if !types.Assignable(pt, at) {
+		if !c.accepts(pt, at, a.Value) {
 			c.errMismatch(a.Value, pt, at)
 		}
 	}
@@ -542,6 +543,7 @@ func (c *checker) applyGenericCall(e *ast.CallExpr, fn *types.FnType, generics [
 // applyGenericCallWithArgs is applyGenericCall with an optional explicit
 // type-argument list from a turbofish.
 func (c *checker) applyGenericCallWithArgs(e *ast.CallExpr, fn *types.FnType, generics []*types.TypeVar, explicit []types.Type, hint types.Type, env *env) types.Type {
+	c.checkExplicitGenericArity(e, len(generics), len(explicit))
 	if len(generics) == 0 {
 		// Non-generic fn — arity and types only.
 		return c.applyFnTo(e, e.Args, fn, env)
@@ -597,7 +599,7 @@ func (c *checker) applyGenericCallWithArgs(e *ast.CallExpr, fn *types.FnType, ge
 		}
 		pt := types.Substitute(fn.Params[i], sub)
 		at := c.result.Types[a.Value]
-		if pt != nil && !types.IsError(pt) && at != nil && !types.Assignable(pt, at) {
+		if pt != nil && !types.IsError(pt) && at != nil && !c.accepts(pt, at, a.Value) {
 			c.errMismatch(a.Value, pt, at)
 		}
 	}
@@ -620,6 +622,14 @@ func (c *checker) applyGenericCallWithArgs(e *ast.CallExpr, fn *types.FnType, ge
 	}
 
 	return types.Substitute(fn.Return, sub)
+}
+
+func (c *checker) checkExplicitGenericArity(e *ast.CallExpr, want, got int) {
+	if got == 0 || want == got {
+		return
+	}
+	c.errNode(e, diag.CodeGenericArgCount,
+		"generic call expects %d type argument(s), got %d", want, got)
 }
 
 // methodCallType resolves `recv.method(args)` by looking up the method
@@ -859,7 +869,7 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 		} else {
 			elem := stdlibElement(recvT)
 			at := c.checkExpr(e.Args[0].Value, elem, env)
-			if elem != nil && !types.IsError(elem) && !types.Assignable(elem, at) {
+			if elem != nil && !types.IsError(elem) && !c.accepts(elem, at, e.Args[0].Value) {
 				c.errMismatch(e.Args[0].Value, elem, at)
 			}
 		}
@@ -869,7 +879,7 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 		if len(e.Args) == 1 {
 			keyT := stdlibKeyOrIndex(recvT)
 			at := c.checkExpr(e.Args[0].Value, keyT, env)
-			if keyT != nil && !types.IsError(keyT) && !types.Assignable(keyT, at) {
+			if keyT != nil && !types.IsError(keyT) && !c.accepts(keyT, at, e.Args[0].Value) {
 				c.errMismatch(e.Args[0].Value, keyT, at)
 			}
 		}
@@ -879,7 +889,7 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 		if len(e.Args) == 1 {
 			elem := stdlibElement(recvT)
 			at := c.checkExpr(e.Args[0].Value, elem, env)
-			if elem != nil && !types.IsError(elem) && !types.Assignable(elem, at) {
+			if elem != nil && !types.IsError(elem) && !c.accepts(elem, at, e.Args[0].Value) {
 				c.errMismatch(e.Args[0].Value, elem, at)
 			}
 		}
@@ -1198,6 +1208,11 @@ func (c *checker) lookupMethod(recvT types.Type, name string) (*methodDesc, map[
 				sub := bindArgs(desc.Generics, v.Args)
 				return md, sub
 			}
+			if desc.Kind == resolve.SymInterface {
+				if md, ok := c.interfaceMethodSet(v)[name]; ok {
+					return md, nil
+				}
+			}
 		}
 		// Builtin compound types carry synthetic method tables.
 		if v.Sym != nil && v.Sym.Kind == resolve.SymBuiltin {
@@ -1217,6 +1232,16 @@ func (c *checker) lookupMethod(recvT types.Type, name string) (*methodDesc, map[
 	case *types.Optional:
 		if md := c.optionalMethod(v, name); md != nil {
 			return md, nil
+		}
+	case *types.TypeVar:
+		for _, b := range v.Bounds {
+			n, ok := b.(*types.Named)
+			if !ok {
+				continue
+			}
+			if md, ok := c.interfaceMethodSet(n)[name]; ok {
+				return md, nil
+			}
 		}
 	}
 	return nil, nil
@@ -1763,7 +1788,7 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 			if i < len(fields) {
 				inferFromArg(fields[i], at, sub)
 			}
-			if ft != nil && !types.IsError(ft) && !types.Assignable(ft, at) {
+			if ft != nil && !types.IsError(ft) && !c.accepts(ft, at, a.Value) {
 				c.errMismatch(a.Value, ft, at)
 			}
 		}
@@ -1925,8 +1950,12 @@ func (c *checker) fieldType(fx *ast.FieldExpr, env *env) types.Type {
 				}
 				c.errFieldNotFound(fx, n.Sym.Name, fx.Name, cand)
 			} else {
-				cand := make([]string, 0, len(desc.Methods))
+				methods := c.interfaceMethodSet(n)
+				cand := make([]string, 0, len(desc.Methods)+len(methods))
 				for name := range desc.Methods {
+					cand = append(cand, name)
+				}
+				for name := range methods {
 					cand = append(cand, name)
 				}
 				c.errMethodNotFound(fx, fmt.Sprintf("type `%s`", recvT), fx.Name, cand)
@@ -2199,7 +2228,7 @@ func (c *checker) structLitType(e *ast.StructLit, env *env) types.Type {
 			id := &ast.Ident{PosV: f.PosV, EndV: f.PosV, Name: f.Name}
 			vt = c.checkExpr(id, fd.Type, env)
 		}
-		if !types.Assignable(fd.Type, vt) {
+		if !c.accepts(fd.Type, vt, f) {
 			c.errMismatch(f, fd.Type, vt)
 		}
 	}
@@ -2336,7 +2365,7 @@ func (c *checker) closureType(e *ast.ClosureExpr, hint types.Type, parent *env) 
 		bodyEnv.retIsOption = true
 	}
 	bodyT := c.checkExpr(e.Body, retT, bodyEnv)
-	if e.ReturnType != nil && !types.Assignable(retT, bodyT) {
+	if e.ReturnType != nil && !c.accepts(retT, bodyT, e.Body) {
 		c.errMismatch(e.Body, retT, bodyT)
 	}
 	if e.ReturnType == nil {

--- a/internal/check/iface.go
+++ b/internal/check/iface.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"sort"
+
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
@@ -46,11 +48,13 @@ func (c *checker) satisfies(concrete types.Type, iface *types.Named, pos ast.Nod
 	if types.IsError(concrete) {
 		return true // suppressed
 	}
-	// Unconstrained TypeVars and still-symbolic generics trivially match
-	// — the call-site couldn't infer a concrete type, so complaining
-	// about the bound would be noise on top of the root cause.
-	if _, ok := concrete.(*types.TypeVar); ok {
-		return true
+	if tv, ok := concrete.(*types.TypeVar); ok {
+		if c.typeVarKnownSatisfies(tv, iface) {
+			return true
+		}
+		c.errNode(pos, diag.CodeTypeMismatch,
+			"type parameter `%s` is not known to implement `%s`", tv, iface.Sym.Name)
+		return false
 	}
 
 	// Built-in marker interfaces first — they have semantic rules that
@@ -76,15 +80,15 @@ func (c *checker) satisfies(concrete types.Type, iface *types.Named, pos ast.Nod
 		return true
 	}
 
+	methods := c.interfaceMethodSet(iface)
 	missing := []string{}
-	for name := range ifDesc.InterfaceMethods {
-		wantMd := ifDesc.InterfaceMethods[name]
+	for name, wantMd := range methods {
 		gotMd, sub := c.lookupMethod(concrete, name)
 		if gotMd == nil {
 			missing = append(missing, name)
 			continue
 		}
-		if !methodSignaturesMatch(wantMd.Fn, gotMd.Fn, sub) {
+		if !methodSignaturesMatch(wantMd, gotMd, concrete, sub) {
 			c.errNode(pos, diag.CodeTypeMismatch,
 				"type `%s` does not satisfy `%s`: method `%s` has a different signature",
 				concrete, iface.Sym.Name, name)
@@ -92,6 +96,7 @@ func (c *checker) satisfies(concrete types.Type, iface *types.Named, pos ast.Nod
 		}
 	}
 	if len(missing) > 0 {
+		sort.Strings(missing)
 		c.errNode(pos, diag.CodeTypeMismatch,
 			"type `%s` does not implement `%s`: missing method(s): %s",
 			concrete, iface.Sym.Name, joinMethods(missing))
@@ -100,34 +105,190 @@ func (c *checker) satisfies(concrete types.Type, iface *types.Named, pos ast.Nod
 	return true
 }
 
+func (c *checker) typeVarKnownSatisfies(tv *types.TypeVar, iface *types.Named) bool {
+	if tv == nil || iface == nil || iface.Sym == nil {
+		return true
+	}
+	for _, b := range tv.Bounds {
+		n, ok := b.(*types.Named)
+		if !ok || n.Sym == nil {
+			continue
+		}
+		if c.interfaceImplies(n, iface) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *checker) interfaceImplies(have, want *types.Named) bool {
+	if have == nil || want == nil || have.Sym == nil || want.Sym == nil {
+		return false
+	}
+	if types.Identical(have, want) {
+		return true
+	}
+	if want.Sym.Name == "Equal" && (have.Sym.Name == "Ordered" || have.Sym.Name == "Hashable") {
+		return true
+	}
+	haveMethods := c.interfaceMethodSet(have)
+	wantMethods := c.interfaceMethodSet(want)
+	if len(wantMethods) == 0 {
+		return false
+	}
+	for name, wantMd := range wantMethods {
+		haveMd, ok := haveMethods[name]
+		if !ok {
+			return false
+		}
+		if !methodSignaturesMatch(wantMd, haveMd, have, nil) {
+			return false
+		}
+	}
+	return true
+}
+
+// interfaceMethodSet returns every method required by iface, including
+// methods inherited through interface composition. Generic arguments on
+// composed interfaces are substituted before the method is exposed.
+func (c *checker) interfaceMethodSet(iface *types.Named) map[string]*methodDesc {
+	out := map[string]*methodDesc{}
+	c.interfaceMethodsInto(iface, out, map[*resolve.Symbol]bool{})
+	return out
+}
+
+func (c *checker) interfaceMethodsInto(
+	iface *types.Named,
+	out map[string]*methodDesc,
+	visiting map[*resolve.Symbol]bool,
+) {
+	if iface == nil || iface.Sym == nil {
+		return
+	}
+	if visiting[iface.Sym] {
+		return
+	}
+	desc, ok := c.result.Descs[iface.Sym]
+	if !ok || desc.Kind != resolve.SymInterface {
+		return
+	}
+	visiting[iface.Sym] = true
+	defer delete(visiting, iface.Sym)
+
+	sub := types.BindArgs(desc.Generics, iface.Args)
+	for _, ext := range desc.InterfaceExtends {
+		extT := types.Substitute(ext, sub)
+		if extN, ok := types.AsNamed(extT); ok {
+			c.interfaceMethodsInto(extN, out, visiting)
+		}
+	}
+	for name, md := range desc.InterfaceMethods {
+		out[name] = specializeMethodDesc(md, sub)
+	}
+}
+
+func specializeMethodDesc(md *methodDesc, sub map[*resolve.Symbol]types.Type) *methodDesc {
+	if md == nil || len(sub) == 0 || md.Fn == nil {
+		return md
+	}
+	fn := &types.FnType{
+		Params: make([]types.Type, len(md.Fn.Params)),
+		Return: types.Substitute(md.Fn.Return, sub),
+	}
+	for i, p := range md.Fn.Params {
+		fn.Params[i] = types.Substitute(p, sub)
+	}
+	cp := *md
+	cp.Fn = fn
+	return &cp
+}
+
 // methodSignaturesMatch compares the declared interface signature with
-// a concrete method signature after receiver-generic substitution.
-// Both signatures exclude `self`, so it is a straight parameter-list +
-// return comparison.
-func methodSignaturesMatch(want, got *types.FnType, sub map[*resolve.Symbol]types.Type) bool {
+// a concrete method signature after two substitutions:
+//   - interface `Self` becomes the concrete receiver type;
+//   - concrete receiver generics become the receiver's actual args.
+//
+// Both signatures exclude `self`, so the final comparison is a straight
+// parameter-list + return comparison.
+func methodSignaturesMatch(
+	wantMd, gotMd *methodDesc,
+	concrete types.Type,
+	gotSub map[*resolve.Symbol]types.Type,
+) bool {
+	if wantMd == nil || gotMd == nil {
+		return wantMd == gotMd
+	}
+	want := wantMd.Fn
+	got := gotMd.Fn
 	if want == nil || got == nil {
 		return want == got
 	}
-	wantParams := want.Params
-	if len(sub) > 0 {
-		wantParams = make([]types.Type, len(want.Params))
-		for i, p := range want.Params {
-			wantParams[i] = types.Substitute(p, sub)
+	if wantMd.Owner != nil && wantMd.Owner.Sym != nil {
+		want = substituteSelfInFn(want, wantMd.Owner.Sym, concrete)
+	}
+	if len(gotSub) > 0 {
+		got = &types.FnType{
+			Params: make([]types.Type, len(got.Params)),
+			Return: types.Substitute(got.Return, gotSub),
+		}
+		for i, p := range gotMd.Fn.Params {
+			got.Params[i] = types.Substitute(p, gotSub)
 		}
 	}
-	if len(wantParams) != len(got.Params) {
+	if len(want.Params) != len(got.Params) {
 		return false
 	}
-	for i, p := range wantParams {
+	for i, p := range want.Params {
 		if !types.Identical(p, got.Params[i]) {
 			return false
 		}
 	}
-	wantRet := want.Return
-	if len(sub) > 0 {
-		wantRet = types.Substitute(wantRet, sub)
+	return types.Identical(want.Return, got.Return)
+}
+
+func substituteSelfInFn(fn *types.FnType, selfSym *resolve.Symbol, concrete types.Type) *types.FnType {
+	if fn == nil {
+		return nil
 	}
-	return types.Identical(wantRet, got.Return)
+	out := &types.FnType{
+		Params: make([]types.Type, len(fn.Params)),
+		Return: substituteSelfType(fn.Return, selfSym, concrete),
+	}
+	for i, p := range fn.Params {
+		out.Params[i] = substituteSelfType(p, selfSym, concrete)
+	}
+	return out
+}
+
+func substituteSelfType(t types.Type, selfSym *resolve.Symbol, concrete types.Type) types.Type {
+	if t == nil || selfSym == nil || concrete == nil {
+		return t
+	}
+	switch x := t.(type) {
+	case *types.Named:
+		if x.Sym == selfSym {
+			return concrete
+		}
+		if len(x.Args) == 0 {
+			return x
+		}
+		args := make([]types.Type, len(x.Args))
+		for i, a := range x.Args {
+			args[i] = substituteSelfType(a, selfSym, concrete)
+		}
+		return &types.Named{Sym: x.Sym, Args: args}
+	case *types.Optional:
+		return &types.Optional{Inner: substituteSelfType(x.Inner, selfSym, concrete)}
+	case *types.Tuple:
+		elems := make([]types.Type, len(x.Elems))
+		for i, e := range x.Elems {
+			elems[i] = substituteSelfType(e, selfSym, concrete)
+		}
+		return &types.Tuple{Elems: elems}
+	case *types.FnType:
+		return substituteSelfInFn(x, selfSym, concrete)
+	}
+	return t
 }
 
 func joinMethods(names []string) string {
@@ -156,6 +317,16 @@ func (c *checker) checkBounds(g *types.TypeVar, arg types.Type, pos ast.Node) {
 		}
 		c.satisfies(arg, n, pos)
 	}
+}
+
+// accepts is the checker-level assignment relation. It extends the
+// pure types.Assignable relation with structural interface satisfaction
+// because only the checker has access to method descriptors.
+func (c *checker) accepts(dst, src types.Type, pos ast.Node) bool {
+	if ifaceN, isIface := interfaceNamed(c, dst); isIface {
+		return c.satisfies(src, ifaceN, pos)
+	}
+	return types.Assignable(dst, src)
 }
 
 // hasToString reports whether a type implements the §17 display

--- a/internal/check/method_candidates.go
+++ b/internal/check/method_candidates.go
@@ -1,8 +1,69 @@
 package check
 
-import "github.com/osty/osty/internal/types"
+import (
+	"sort"
+
+	"github.com/osty/osty/internal/types"
+)
 
 // methodCandidates returns a list of nearby method names on a type,
-// used for typo suggestions in "unknown method" diagnostics. Stubbed
-// while the real type-aware analysis is being reworked.
-func (c *checker) methodCandidates(_ types.Type) []string { return nil }
+// used for typo suggestions in "unknown method" diagnostics.
+func (c *checker) methodCandidates(t types.Type) []string {
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name != "" {
+			seen[name] = true
+		}
+	}
+	switch v := t.(type) {
+	case *types.Named:
+		if desc, ok := c.result.Descs[v.Sym]; ok {
+			for name := range desc.Methods {
+				add(name)
+			}
+			for name := range c.interfaceMethodSet(v) {
+				add(name)
+			}
+		}
+		if v.Sym != nil {
+			switch v.Sym.Name {
+			case "Result":
+				for _, name := range []string{"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr", "ok", "err", "map", "mapErr", "toString"} {
+					add(name)
+				}
+			case "Chan", "Channel":
+				for _, name := range []string{"recv", "send", "close"} {
+					add(name)
+				}
+			case "Handle":
+				add("join")
+			case "TaskGroup":
+				for _, name := range []string{"spawn", "cancel", "isCancelled"} {
+					add(name)
+				}
+			}
+		}
+	case *types.Primitive:
+		for name := range c.primMethods[v.Kind] {
+			add(name)
+		}
+	case *types.Optional:
+		for _, name := range []string{"isSome", "isNone", "unwrap", "unwrapOr", "orElse", "map", "toString"} {
+			add(name)
+		}
+	case *types.TypeVar:
+		for _, b := range v.Bounds {
+			if n, ok := b.(*types.Named); ok {
+				for name := range c.interfaceMethodSet(n) {
+					add(name)
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/check/package_test.go
+++ b/internal/check/package_test.go
@@ -119,6 +119,34 @@ func TestPackageCrossFileEnumMatch(t *testing.T) {
 	}
 }
 
+func TestPackageCrossFileInterfaceComposition(t *testing.T) {
+	a := `pub interface Named {
+    fn name(self) -> String
+}`
+	b := `pub interface DisplayNamed {
+    Named
+}`
+	csrc := `pub struct User {
+    pub label: String,
+
+    pub fn name(self) -> String { self.label }
+}
+
+fn useIt<T: DisplayNamed>(x: T) -> String {
+    x.name()
+}
+
+fn main() {
+    useIt(User { label: "ada" })
+}`
+	r := mkPkg(t, a, b, csrc)
+	for _, d := range r.Diags {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected error: %s", d.Error())
+		}
+	}
+}
+
 // TestPackageCrossFileFieldTypeMismatch verifies the checker catches a
 // wrong-type literal in a cross-file struct constructor.
 func TestPackageCrossFileFieldTypeMismatch(t *testing.T) {

--- a/internal/check/stmt.go
+++ b/internal/check/stmt.go
@@ -111,7 +111,7 @@ func (c *checker) checkFnDecl(n *ast.FnDecl, owner *typeDesc) {
 
 	// Body block: the final expression's value is the implicit return.
 	bodyT := c.blockAsExprType(n.Body, ret, e)
-	if !types.IsUnit(ret) && !types.IsError(ret) && !types.Assignable(ret, bodyT) {
+	if !types.IsUnit(ret) && !types.IsError(ret) && !c.accepts(ret, bodyT, n.Body) {
 		// Suppress the error when the body ends in an explicit `return`
 		// or when the whole body is `Never` (diverges).
 		if !blockEndsInReturn(n.Body) && !types.IsNever(bodyT) {
@@ -171,7 +171,7 @@ func (c *checker) checkTopLet(n *ast.LetDecl) {
 	}
 	e := &env{retType: types.Unit}
 	got := c.checkExpr(n.Value, want, e)
-	if want != nil && !types.Assignable(want, got) {
+	if want != nil && !c.accepts(want, got, n.Value) {
 		c.errMismatch(n.Value, want, got)
 	}
 	final := want
@@ -230,7 +230,7 @@ func (c *checker) checkLetStmt(n *ast.LetStmt, env *env) {
 	if n.Value != nil {
 		got = c.checkExpr(n.Value, want, env)
 	}
-	if want != nil && got != nil && !types.Assignable(want, got) {
+	if want != nil && got != nil && !c.accepts(want, got, n.Value) {
 		if n.Type != nil {
 			c.errMismatchWithSource(n.Value, n.Type, want, got,
 				"expected because of this annotation")
@@ -305,7 +305,7 @@ func (c *checker) checkAssignTarget(tgt ast.Expr, vt types.Type, env *env) {
 			return
 		}
 		want := c.symTypeOrError(sym)
-		if want != nil && !types.IsError(want) && !types.Assignable(want, vt) {
+		if want != nil && !types.IsError(want) && !c.accepts(want, vt, tgt) {
 			c.errMismatch(tgt, want, vt)
 		}
 	case *ast.FieldExpr:
@@ -313,12 +313,12 @@ func (c *checker) checkAssignTarget(tgt ast.Expr, vt types.Type, env *env) {
 		// check origin ownership precisely here, but we DO check that
 		// the field type accepts the value.
 		ft := c.checkExpr(x, nil, env)
-		if !types.Assignable(ft, vt) {
+		if !c.accepts(ft, vt, tgt) {
 			c.errMismatch(tgt, ft, vt)
 		}
 	case *ast.IndexExpr:
 		it := c.checkExpr(x, nil, env)
-		if !types.Assignable(it, vt) {
+		if !c.accepts(it, vt, tgt) {
 			c.errMismatch(tgt, it, vt)
 		}
 	default:
@@ -336,7 +336,7 @@ func (c *checker) checkReturnStmt(n *ast.ReturnStmt, env *env) {
 		return
 	}
 	got := c.checkExpr(n.Value, env.retType, env)
-	if !types.Assignable(env.retType, got) {
+	if !c.accepts(env.retType, got, n.Value) {
 		c.errMismatch(n.Value, env.retType, got)
 	}
 }
@@ -362,7 +362,7 @@ func (c *checker) checkChanSend(n *ast.ChanSendStmt, env *env) {
 		elem = named.Args[0]
 	}
 	vt := c.checkExpr(n.Value, elem, env)
-	if elem != nil && !types.IsError(elem) && !types.Assignable(elem, vt) {
+	if elem != nil && !types.IsError(elem) && !c.accepts(elem, vt, n.Value) {
 		c.errNode(n.Value, diag.CodeChannelWrongValue,
 			"cannot send `%s` on `%s`", vt, chT)
 	}
@@ -409,7 +409,7 @@ func (c *checker) bindPatternTypes(p ast.Pattern, t types.Type, env *env) {
 		// nothing to bind
 	case *ast.LiteralPat:
 		lt := c.checkExpr(x.Literal, t, env)
-		if !types.Assignable(t, lt) && !types.IsError(t) && !types.IsError(lt) {
+		if !c.accepts(t, lt, x) && !types.IsError(t) && !types.IsError(lt) {
 			c.errNode(x, diag.CodeLitPatternMismatch,
 				"literal pattern `%s` does not match scrutinee of type `%s`",
 				lt, t)


### PR DESCRIPTION
## Summary
- Strengthen structural interface satisfaction, including composed interfaces, `Self` signatures, generic receiver substitution, and generic bounds.
- Tighten checker assignment/call paths to validate interface destinations structurally.
- Improve builder generic inference, turbofish arity checking, Option/Result exhaustiveness coverage, and method suggestions.
- Refresh checker status docs in README and ARCHITECTURE.

## Validation
- `go test ./...`
- `git diff --check`