### PR TITLE
[codex] document stdlib stub gen boundary

### DIFF
--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -401,11 +401,13 @@ func (g *gen) emitUseDecl(u *ast.UseDecl) {
 		}
 		return
 	}
-	// Regular `use pkg.path [as alias]` — Osty module system, not yet
-	// backed by a loader. For well-known stdlib shims (std.testing,
-	// std.thread) we emit a mock struct so spec fixtures that *call*
-	// those helpers compile. Real stdlib usage bridges through Go's
-	// own packages; see stdlibBridge for the mapping.
+	// Regular `use pkg.path [as alias]` — Osty module system. The
+	// embedded stdlib is a resolved signature surface, not a runtime
+	// implementation, so general gen may still emit `std.*` package
+	// stubs. A few modules have temporary Go bridges for fixture
+	// compatibility; well-known shims (std.testing, std.thread) get
+	// mock structs when they need a callable shape. The test harness
+	// separately replaces the std.testing stub with a real runtime.
 	alias := u.Alias
 	if alias == "" && len(u.Path) > 0 {
 		alias = u.Path[len(u.Path)-1]
@@ -599,9 +601,10 @@ func (g *gen) exprUsesAliasSelector(e ast.Expr, alias string) bool {
 	return false
 }
 
-// stdlibBridge maps an Osty stdlib module path to a Go package whose
-// exported surface matches closely enough for typical spec use. Returns
-// "" when no bridge is available (caller falls back to a mock stub).
+// stdlibBridge maps a small subset of Osty stdlib module paths to Go
+// packages for fixture compatibility. This is not the stdlib runtime;
+// the embedded stdlib under internal/stdlib is a signature-stub surface.
+// Returns "" when no bridge is available (caller falls back to a stub).
 func stdlibBridge(path []string) string {
 	if len(path) < 2 || path[0] != "std" {
 		return ""

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -46,6 +46,53 @@ func runGo(t *testing.T, src []byte) string {
 	return string(out)
 }
 
+func TestStdlibUsesRemainGeneralGenStubs(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "fs",
+			src:  "use std.fs\n",
+			want: "var fs = struct{}{} // stub for `use std.fs`",
+		},
+		{
+			name: "thread",
+			src: `use std.thread
+
+fn main() {
+    let cancelled = thread.isCancelled()
+    println("{cancelled}")
+}
+`,
+			want: "var thread = struct {",
+		},
+		{
+			name: "testing",
+			src: `use std.testing
+
+fn testTruth() {
+    testing.assert(true)
+}
+`,
+			want: "var testing = struct {",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			goSrc, err := transpile(t, c.src)
+			if err != nil {
+				t.Fatalf("transpile: %v\n%s", err, goSrc)
+			}
+			if !strings.Contains(string(goSrc), c.want) {
+				t.Fatalf("generated Go missing stdlib stub %q:\n%s", c.want, goSrc)
+			}
+		})
+	}
+}
+
 func TestHelloWorld(t *testing.T) {
 	src := `fn main() {
     println("hello, world")


### PR DESCRIPTION
## Summary

- Clarify in generator comments that embedded stdlib modules provide a resolved signature-stub surface, not a runtime implementation.
- Reframe temporary stdlib Go bridges as fixture compatibility shims.
- Add a regression test that general gen output may still contain stubs for `std.fs`, `std.thread`, and `std.testing`.

## Validation

- `go test ./internal/gen ./internal/testgen ./internal/stdlib`