### PR TITLE
[codex] fix gen TODO fallbacks

### DIFF
--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -158,18 +158,10 @@ func (g *gen) emitLetDecl(l *ast.LetDecl) {
 func (g *gen) emitStructDecl(s *ast.StructDecl) {
 	g.body.nl()
 	g.sourceMarker(s)
-	// Generic type parameters land in Phase 3; for now we still emit
-	// the bracket block with `any` constraints so downstream code at
-	// least type-checks syntactically.
 	if len(s.Generics) > 0 {
-		g.body.writef("type %s[", s.Name)
-		for i, gp := range s.Generics {
-			if i > 0 {
-				g.body.write(", ")
-			}
-			g.body.writef("%s any", gp.Name)
-		}
-		g.body.write("] struct {")
+		g.body.writef("type %s", s.Name)
+		g.emitGenericParamList(s.Generics)
+		g.body.write(" struct {")
 	} else {
 		g.body.writef("type %s struct {", s.Name)
 	}
@@ -359,17 +351,29 @@ func (g *gen) emitInterfaceDecl(i *ast.InterfaceDecl) {
 	g.body.writeln("}")
 }
 
-// emitTypeAliasDecl writes `type Name = Target` (Go type alias) for
-// non-generic aliases. Generic aliases require Go 1.24+ features
-// and are Phase 3 work; for now we emit a commented note.
+// emitTypeAliasDecl writes a Go type alias. Generic aliases are emitted
+// with Go type parameters; constraints currently lower to `any`, matching
+// the existing generic struct/function backend surface.
 func (g *gen) emitTypeAliasDecl(a *ast.TypeAliasDecl) {
 	g.body.nl()
 	g.sourceMarker(a)
-	if len(a.Generics) > 0 {
-		g.body.writef("// TODO(phase3): generic type alias %s\n", a.Name)
+	g.body.writef("type %s", a.Name)
+	g.emitGenericParamList(a.Generics)
+	g.body.writef(" = %s\n", g.goTypeExpr(a.Target))
+}
+
+func (g *gen) emitGenericParamList(params []*ast.GenericParam) {
+	if len(params) == 0 {
 		return
 	}
-	g.body.writef("type %s = %s\n", a.Name, g.goTypeExpr(a.Target))
+	g.body.write("[")
+	for i, p := range params {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.writef("%s any", p.Name)
+	}
+	g.body.write("]")
 }
 
 func (g *gen) emitUseDecl(u *ast.UseDecl) {

--- a/internal/gen/phase3_test.go
+++ b/internal/gen/phase3_test.go
@@ -70,6 +70,33 @@ fn main() {
 	}
 }
 
+// TestGenericTypeAlias verifies generic aliases emit real Go aliases,
+// not TODO comments, and remain usable in annotations.
+func TestGenericTypeAlias(t *testing.T) {
+	src := `type Pair<T> = (T, T)
+
+fn main() {
+    let p: Pair<Int> = (3, 4)
+    println("{p.F0} {p.F1}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := string(goSrc)
+	if strings.Contains(out, "TODO(phase3): generic type alias") {
+		t.Errorf("generic alias TODO leaked into output:\n%s", out)
+	}
+	if !strings.Contains(out, "type Pair[T any] =") {
+		t.Errorf("expected generic type alias in output:\n%s", out)
+	}
+	got := runGo(t, goSrc)
+	if strings.TrimSpace(got) != "3 4" {
+		t.Errorf("unexpected output: %q\n--- src ---\n%s", got, goSrc)
+	}
+}
+
 // TestMapIteration verifies `for (k, v) in m` pattern.
 func TestMapIteration(t *testing.T) {
 	src := `fn main() {

--- a/internal/gen/transpiler_completion_test.go
+++ b/internal/gen/transpiler_completion_test.go
@@ -191,6 +191,36 @@ fn main() {
 	}
 }
 
+// TestForLetNestedDestructure verifies for-let binds nested payload
+// patterns after the match succeeds.
+func TestForLetNestedDestructure(t *testing.T) {
+	src := `fn maybePair(n: Int) -> (Int, Int)? {
+    if n < 1 { Some((2, 3)) } else { None }
+}
+
+fn main() {
+    let mut n = 0
+    let mut total = 0
+    for let Some((a, b)) = maybePair(n) {
+        total = total + a + b
+        n = n + 1
+    }
+    println("{total}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	if strings.Contains(string(goSrc), "TODO: for-let") {
+		t.Errorf("for-let TODO marker still present:\n%s", goSrc)
+	}
+	out := runGo(t, goSrc)
+	if strings.TrimSpace(out) != "5" {
+		t.Errorf("for-let nested destructure: got %q\n--- go ---\n%s", out, goSrc)
+	}
+}
+
 // TestMatchTuplePattern verifies tuple patterns in match arms generate
 // a conjunction of per-element tests (previously hardcoded `true`).
 func TestMatchTuplePattern(t *testing.T) {


### PR DESCRIPTION
## Summary

- Emit generic type aliases as real Go generic aliases instead of leaking the phase3 TODO comment.
- Add regression coverage for generic alias output and nested for-let destructuring on the current pattern-lowering backend.

## Why

The compiler backend still emitted a TODO comment for valid generic type aliases even though the repository targets a Go version with generic alias support. Recent main already contains the recursive pattern-binding path for nested destructuring, so this PR preserves that path with additional coverage while fixing the remaining alias emission gap.

## Validation

- go test ./internal/gen
- go test ./...