### PR TITLE
[codex] implement pkgmgr resolver backtracking

### DIFF
--- a/internal/pkgmgr/resolve.go
+++ b/internal/pkgmgr/resolve.go
@@ -63,85 +63,259 @@ func Resolve(ctx context.Context, root *manifest.Manifest, env *Env) (*Graph, er
 		return nil, err
 	}
 	r := &resolver{
-		env:      env,
-		lock:     existing,
-		root:     root,
-		graph:    &Graph{Root: root, Nodes: map[string]*ResolvedNode{}},
-		inflight: map[string]bool{},
+		env:   env,
+		lock:  existing,
+		graph: &Graph{Root: root, Nodes: map[string]*ResolvedNode{}},
 	}
 	rootDir := manifestBaseDir(root, env.ProjectRoot)
+	var pending []resolveRequest
 	for _, d := range root.Dependencies {
-		if _, err := r.resolveDep(ctx, d, rootDir); err != nil {
-			return nil, err
-		}
+		pending = append(pending, resolveRequest{dep: d, baseDir: rootDir})
 	}
 	for _, d := range root.DevDependencies {
-		if _, err := r.resolveDep(ctx, d, rootDir); err != nil {
-			return nil, err
-		}
+		pending = append(pending, resolveRequest{dep: d, baseDir: rootDir})
 	}
+	solved, err := r.solve(ctx, &resolveState{
+		graph:   r.graph,
+		pending: pending,
+	})
+	if err != nil {
+		return nil, err
+	}
+	r.graph = solved.graph
 	r.graph.Order = r.topoOrder()
 	return r.graph, nil
 }
 
 type resolver struct {
-	env      *Env
-	lock     *lockfile.Lock
-	root     *manifest.Manifest
-	graph    *Graph
-	inflight map[string]bool
+	env   *Env
+	lock  *lockfile.Lock
+	graph *Graph
 }
 
-// resolveDep fetches dep, records it in the graph, then recurses
-// into its own dependencies. Returns an error on cycle detection,
-// fetch failure, or conflicting versions.
-func (r *resolver) resolveDep(ctx context.Context, d manifest.Dependency, baseDir string) (*ResolvedNode, error) {
-	if r.inflight[d.Name] {
-		return nil, fmt.Errorf("cyclic dependency through %q", d.Name)
+type resolveRequest struct {
+	dep       manifest.Dependency
+	baseDir   string
+	parent    string
+	ancestors map[string]bool
+}
+
+type resolveState struct {
+	graph   *Graph
+	pending []resolveRequest
+}
+
+type resolveCandidate struct {
+	source Source
+	fetch  func(context.Context) (*FetchedPackage, error)
+}
+
+func (r *resolver) solve(ctx context.Context, st *resolveState) (*resolveState, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 	}
-	src, err := newSourceFromDir(d, baseDir)
+	if len(st.pending) == 0 {
+		return st, nil
+	}
+	req := st.pending[0]
+	rest := append([]resolveRequest(nil), st.pending[1:]...)
+	if req.ancestors[req.dep.Name] {
+		return nil, fmt.Errorf("cyclic dependency through %q", req.dep.Name)
+	}
+	src, err := newSourceFromDir(req.dep, req.baseDir)
 	if err != nil {
 		return nil, err
 	}
-	// If the lockfile pins a previously-resolved version that still
-	// satisfies the manifest's requirement, narrow the source so we
-	// fetch exactly that version. This keeps `osty build` reproducible
-	// across runs without forcing a network round-trip on every
-	// resolve. `osty update` clears the pin before calling Resolve, so
-	// honoring it here doesn't block intended upgrades.
-	applyLockPin(src, d, r.lock)
-	if existing, ok := r.graph.Nodes[d.Name]; ok {
-		if err := r.ensureCompatible(existing, src, d); err != nil {
+	if existing, ok := st.graph.Nodes[req.dep.Name]; ok {
+		if err := r.ensureCompatible(existing, src, req.dep); err != nil {
 			return nil, err
 		}
-		return existing, nil
+		next := st.cloneWithPending(rest)
+		addDepEdge(next.graph, req.parent, existing.Name)
+		return r.solve(ctx, next)
 	}
-	r.inflight[d.Name] = true
-	defer delete(r.inflight, d.Name)
 
-	fetched, err := src.Fetch(ctx, r.env)
+	candidates, err := r.resolveCandidates(ctx, src, req.dep)
 	if err != nil {
-		return nil, fmt.Errorf("resolve %s: %w", d.Name, err)
+		return nil, err
 	}
-	node := &ResolvedNode{
-		Name:    d.Name,
-		Source:  src,
-		Fetched: fetched,
-	}
-	r.graph.Nodes[d.Name] = node
-
-	// Recurse into the fetched package's own deps. Dev-deps are NOT
-	// followed for transitive packages — only the root's dev-deps
-	// matter.
-	childBase := manifestBaseDir(fetched.Manifest, fetched.LocalDir)
-	for _, sub := range fetched.Manifest.Dependencies {
-		child, err := r.resolveDep(ctx, sub, childBase)
+	var firstErr error
+	for _, candidate := range candidates {
+		fetched, err := candidate.fetch(ctx)
 		if err != nil {
-			return nil, err
+			if firstErr == nil {
+				firstErr = fmt.Errorf("resolve %s: %w", req.dep.Name, err)
+			}
+			continue
 		}
-		node.Deps = append(node.Deps, child.Name)
+		next := st.cloneWithPending(nil)
+		node := &ResolvedNode{
+			Name:    req.dep.Name,
+			Source:  candidate.source,
+			Fetched: fetched,
+		}
+		next.graph.Nodes[req.dep.Name] = node
+		addDepEdge(next.graph, req.parent, node.Name)
+		children := childRequests(req, node.Name, fetched)
+		next.pending = append(children, rest...)
+		solved, err := r.solve(ctx, next)
+		if err == nil {
+			return solved, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
 	}
-	return node, nil
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return nil, fmt.Errorf("resolve %s: no candidates", req.dep.Name)
+}
+
+func (r *resolver) resolveCandidates(ctx context.Context, src Source, d manifest.Dependency) ([]resolveCandidate, error) {
+	rs, ok := src.(*registrySource)
+	if !ok {
+		return []resolveCandidate{{
+			source: src,
+			fetch: func(ctx context.Context) (*FetchedPackage, error) {
+				return src.Fetch(ctx, r.env)
+			},
+		}}, nil
+	}
+	candidates, err := rs.candidateRegistryVersions(ctx, r.env)
+	if err != nil {
+		return nil, err
+	}
+	candidates = r.prioritizeLockedRegistryCandidate(rs, d, candidates)
+	out := make([]resolveCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		candidate := c
+		exact := &registrySource{
+			name:         rs.name,
+			packageName:  rs.packageName,
+			versionReq:   "=" + candidate.Version.String(),
+			registryName: rs.registryName,
+		}
+		out = append(out, resolveCandidate{
+			source: exact,
+			fetch: func(ctx context.Context) (*FetchedPackage, error) {
+				return exact.fetchRegistryCandidate(ctx, r.env, candidate)
+			},
+		})
+	}
+	return out, nil
+}
+
+func (r *resolver) prioritizeLockedRegistryCandidate(rs *registrySource, d manifest.Dependency, candidates []registryCandidate) []registryCandidate {
+	pinned, ok := r.lockedRegistryVersion(rs, d)
+	if !ok {
+		return candidates
+	}
+	for i, c := range candidates {
+		if semver.Equal(c.Version, pinned) {
+			if i == 0 {
+				return candidates
+			}
+			out := append([]registryCandidate{c}, candidates[:i]...)
+			return append(out, candidates[i+1:]...)
+		}
+	}
+	return candidates
+}
+
+func (r *resolver) lockedRegistryVersion(rs *registrySource, d manifest.Dependency) (semver.Version, bool) {
+	if r.lock == nil {
+		return semver.Version{}, false
+	}
+	req, err := semver.ParseReq(rs.versionReq)
+	if err != nil {
+		return semver.Version{}, false
+	}
+	for _, p := range r.lock.FindByName(d.Name) {
+		if p.Source != "" && p.Source != rs.URI() {
+			continue
+		}
+		pv, err := semver.ParseVersion(p.Version)
+		if err != nil {
+			continue
+		}
+		if req.Match(pv) {
+			return pv, true
+		}
+	}
+	return semver.Version{}, false
+}
+
+func childRequests(parent resolveRequest, parentName string, fetched *FetchedPackage) []resolveRequest {
+	if fetched == nil || fetched.Manifest == nil {
+		return nil
+	}
+	childBase := manifestBaseDir(fetched.Manifest, fetched.LocalDir)
+	ancestors := extendAncestors(parent.ancestors, parentName)
+	out := make([]resolveRequest, 0, len(fetched.Manifest.Dependencies))
+	for _, sub := range fetched.Manifest.Dependencies {
+		out = append(out, resolveRequest{
+			dep:       sub,
+			baseDir:   childBase,
+			parent:    parentName,
+			ancestors: ancestors,
+		})
+	}
+	return out
+}
+
+func extendAncestors(in map[string]bool, name string) map[string]bool {
+	out := make(map[string]bool, len(in)+1)
+	for k, v := range in {
+		out[k] = v
+	}
+	out[name] = true
+	return out
+}
+
+func (st *resolveState) cloneWithPending(pending []resolveRequest) *resolveState {
+	return &resolveState{
+		graph:   cloneGraph(st.graph),
+		pending: append([]resolveRequest(nil), pending...),
+	}
+}
+
+func cloneGraph(g *Graph) *Graph {
+	if g == nil {
+		return &Graph{Nodes: map[string]*ResolvedNode{}}
+	}
+	out := &Graph{
+		Root:  g.Root,
+		Nodes: make(map[string]*ResolvedNode, len(g.Nodes)),
+		Order: append([]string(nil), g.Order...),
+	}
+	for name, node := range g.Nodes {
+		if node == nil {
+			continue
+		}
+		copyNode := *node
+		copyNode.Deps = append([]string(nil), node.Deps...)
+		out.Nodes[name] = &copyNode
+	}
+	return out
+}
+
+func addDepEdge(g *Graph, parent, child string) {
+	if g == nil || parent == "" || child == "" {
+		return
+	}
+	node := g.Nodes[parent]
+	if node == nil {
+		return
+	}
+	for _, dep := range node.Deps {
+		if dep == child {
+			return
+		}
+	}
+	node.Deps = append(node.Deps, child)
 }
 
 func manifestBaseDir(m *manifest.Manifest, fallback string) string {

--- a/internal/pkgmgr/resolve_test.go
+++ b/internal/pkgmgr/resolve_test.go
@@ -1,15 +1,21 @@
 package pkgmgr
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lockfile"
 	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/registry"
 	"github.com/osty/osty/internal/resolve"
 )
 
@@ -145,6 +151,105 @@ func TestResolveRejectsConflictingTransitivePathAlias(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `dependency "util" resolved from`) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveBacktracksRegistryVersionConflicts(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	must(t, os.MkdirAll(proj, 0o755))
+	srv := newTestRegistry(t, map[string]map[string]*manifest.Manifest{
+		"a": {
+			"1.0.0": {
+				Package: manifest.Package{Name: "a", Version: "1.0.0"},
+				Dependencies: []manifest.Dependency{
+					{Name: "util", VersionReq: "^1.0.0", DefaultFeats: true},
+				},
+			},
+			"2.0.0": {
+				Package: manifest.Package{Name: "a", Version: "2.0.0"},
+				Dependencies: []manifest.Dependency{
+					{Name: "util", VersionReq: "^2.0.0", DefaultFeats: true},
+				},
+			},
+		},
+		"b": {
+			"1.0.0": {
+				Package: manifest.Package{Name: "b", Version: "1.0.0"},
+				Dependencies: []manifest.Dependency{
+					{Name: "util", VersionReq: "^1.0.0", DefaultFeats: true},
+				},
+			},
+		},
+		"util": {
+			"1.0.0": {Package: manifest.Package{Name: "util", Version: "1.0.0"}},
+			"2.0.0": {Package: manifest.Package{Name: "util", Version: "2.0.0"}},
+		},
+	})
+	defer srv.Close()
+
+	env := &Env{
+		CacheDir:    filepath.Join(tmp, "cache"),
+		VendorDir:   filepath.Join(proj, ".osty", "deps"),
+		ProjectRoot: proj,
+		Registries:  map[string]string{"": srv.URL},
+	}
+	graph, err := Resolve(context.Background(), &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "a", VersionReq: "*", DefaultFeats: true},
+			{Name: "b", VersionReq: "*", DefaultFeats: true},
+		},
+	}, env)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := graph.Nodes["a"].Fetched.Version; got != "1.0.0" {
+		t.Fatalf("a version: got %q, want 1.0.0", got)
+	}
+	if got := graph.Nodes["util"].Fetched.Version; got != "1.0.0" {
+		t.Fatalf("util version: got %q, want 1.0.0", got)
+	}
+	if !hasDep(graph.Nodes["a"], "util") || !hasDep(graph.Nodes["b"], "util") {
+		t.Fatalf("missing util edges: a=%v b=%v", graph.Nodes["a"].Deps, graph.Nodes["b"].Deps)
+	}
+}
+
+func TestResolvePrioritizesRegistryLockPin(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "app")
+	must(t, os.MkdirAll(proj, 0o755))
+	srv := newTestRegistry(t, map[string]map[string]*manifest.Manifest{
+		"util": {
+			"1.0.0": {Package: manifest.Package{Name: "util", Version: "1.0.0"}},
+			"2.0.0": {Package: manifest.Package{Name: "util", Version: "2.0.0"}},
+		},
+	})
+	defer srv.Close()
+	must(t, lockfile.Write(proj, &lockfile.Lock{
+		Version: lockfile.SchemaVersion,
+		Packages: []lockfile.Package{
+			{Name: "util", Version: "1.0.0", Source: "registry+default"},
+		},
+	}))
+
+	env := &Env{
+		CacheDir:    filepath.Join(tmp, "cache"),
+		VendorDir:   filepath.Join(proj, ".osty", "deps"),
+		ProjectRoot: proj,
+		Registries:  map[string]string{"": srv.URL},
+	}
+	graph, err := Resolve(context.Background(), &manifest.Manifest{
+		Package: manifest.Package{Name: "app", Version: "0.0.1"},
+		Dependencies: []manifest.Dependency{
+			{Name: "util", VersionReq: "*", DefaultFeats: true},
+		},
+	}, env)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := graph.Nodes["util"].Fetched.Version; got != "1.0.0" {
+		t.Fatalf("util version: got %q, want locked 1.0.0", got)
 	}
 }
 
@@ -604,6 +709,82 @@ pub fn pong() {}
 	if _, ok := ws.Packages["leaf"]; !ok {
 		t.Fatalf("transitive leaf package was not loaded: %v", ws.Packages)
 	}
+}
+
+type testRegistryVersion struct {
+	tarball  []byte
+	checksum string
+}
+
+func newTestRegistry(t *testing.T, manifests map[string]map[string]*manifest.Manifest) *httptest.Server {
+	t.Helper()
+	fixtures := map[string]map[string]testRegistryVersion{}
+	for name, versions := range manifests {
+		fixtures[name] = map[string]testRegistryVersion{}
+		for version, mani := range versions {
+			dir := filepath.Join(t.TempDir(), name+"-"+version)
+			must(t, os.MkdirAll(dir, 0o755))
+			must(t, manifest.Write(filepath.Join(dir, manifest.ManifestFile), mani))
+			var buf bytes.Buffer
+			must(t, CreateTarGz(dir, &buf))
+			payload := append([]byte(nil), buf.Bytes()...)
+			fixtures[name][version] = testRegistryVersion{
+				tarball:  payload,
+				checksum: HashBytes(payload),
+			}
+		}
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) == 3 && parts[0] == "v1" && parts[1] == "crates" {
+			versions, ok := fixtures[parts[2]]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			keys := make([]string, 0, len(versions))
+			for version := range versions {
+				keys = append(keys, version)
+			}
+			sort.Strings(keys)
+			entry := registry.IndexEntry{Name: parts[2]}
+			for _, version := range keys {
+				entry.Versions = append(entry.Versions, registry.Version{
+					Version:  version,
+					Checksum: versions[version].checksum,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(entry)
+			return
+		}
+		if len(parts) == 5 && parts[0] == "v1" && parts[1] == "crates" && parts[4] == "tar" {
+			versions, ok := fixtures[parts[2]]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			version, ok := versions[parts[3]]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write(version.tarball)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func hasDep(node *ResolvedNode, dep string) bool {
+	if node == nil {
+		return false
+	}
+	for _, d := range node.Deps {
+		if d == dep {
+			return true
+		}
+	}
+	return false
 }
 
 func must(t *testing.T, err error) {

--- a/internal/pkgmgr/source_registry.go
+++ b/internal/pkgmgr/source_registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr/semver"
@@ -19,6 +20,11 @@ type registrySource struct {
 	packageName  string // the canonical name on the registry; may differ from `name`
 	versionReq   string
 	registryName string // "" = default registry
+}
+
+type registryCandidate struct {
+	Version semver.Version
+	Meta    registry.Version
 }
 
 func (s *registrySource) Kind() SourceKind { return SourceRegistry }
@@ -39,6 +45,14 @@ func (s *registrySource) URI() string {
 // tarball, and unpacks it to the user cache. Returned LocalDir is
 // that unpacked directory.
 func (s *registrySource) Fetch(ctx context.Context, env *Env) (*FetchedPackage, error) {
+	candidates, err := s.candidateRegistryVersions(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	return s.fetchRegistryCandidate(ctx, env, candidates[0])
+}
+
+func (s *registrySource) candidateRegistryVersions(ctx context.Context, env *Env) ([]registryCandidate, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -67,8 +81,7 @@ func (s *registrySource) Fetch(ctx context.Context, env *Env) (*FetchedPackage, 
 	if err != nil {
 		return nil, fmt.Errorf("registry dependency %s: %w", s.name, err)
 	}
-	var parsed []semver.Version
-	versionByString := map[string]registry.Version{}
+	var candidates []registryCandidate
 	for _, v := range versions {
 		sv, err := semver.ParseVersion(v.Version)
 		if err != nil {
@@ -77,18 +90,39 @@ func (s *registrySource) Fetch(ctx context.Context, env *Env) (*FetchedPackage, 
 			// valid resolutions.
 			continue
 		}
-		parsed = append(parsed, sv)
-		versionByString[sv.String()] = v
+		if !req.Match(sv) {
+			continue
+		}
+		candidates = append(candidates, registryCandidate{Version: sv, Meta: v})
 	}
-	best, ok := semver.Max(req, parsed)
-	if !ok {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return semver.Compare(candidates[i].Version, candidates[j].Version) > 0
+	})
+	if len(candidates) == 0 {
 		return nil, fmt.Errorf("registry dependency %s: no version matches %q",
 			s.name, s.versionReq)
 	}
-	picked := versionByString[best.String()]
+	return candidates, nil
+}
+
+func (s *registrySource) fetchRegistryCandidate(ctx context.Context, env *Env, candidate registryCandidate) (*FetchedPackage, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	regURL, ok := env.Registries[s.registryName]
+	if !ok || regURL == "" {
+		return nil, fmt.Errorf("registry %q not configured", s.registryName)
+	}
+	client := registry.NewClient(regURL)
+	client.Cache = registry.NewDirIndexCache(filepath.Join(env.CacheDir, "registry-index", sanitizeURL(regURL)))
+	best := candidate.Version.String()
+	picked := candidate.Meta
 
 	// Download + verify the tarball.
-	cacheRoot := filepath.Join(env.CacheDir, "registry", sanitizeURL(regURL), s.packageName, best.String())
+	cacheRoot := filepath.Join(env.CacheDir, "registry", sanitizeURL(regURL), s.packageName, best)
 	if err := ensureDir(cacheRoot); err != nil {
 		return nil, err
 	}
@@ -97,7 +131,7 @@ func (s *registrySource) Fetch(ctx context.Context, env *Env) (*FetchedPackage, 
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		if err := client.DownloadTarball(ctx, s.packageName, best.String(), tarPath); err != nil {
+		if err := client.DownloadTarball(ctx, s.packageName, best, tarPath); err != nil {
 			return nil, fmt.Errorf("registry dependency %s: download: %w", s.name, err)
 		}
 	}
@@ -133,7 +167,7 @@ func (s *registrySource) Fetch(ctx context.Context, env *Env) (*FetchedPackage, 
 	return &FetchedPackage{
 		LocalDir: unpackDir,
 		Manifest: depManifest,
-		Version:  best.String(),
+		Version:  best,
 		Checksum: picked.Checksum,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Replaces the package manager resolver's simple DFS/first-match path with candidate-based backtracking.
- Splits registry resolution into candidate enumeration and exact candidate fetches so the resolver can try lower compatible versions after conflicts.
- Adds registry-backed tests for transitive version conflict backtracking and lockfile pin priority.

## Why

The old resolver picked the first/highest matching registry version before seeing later transitive constraints. That meant a solvable diamond dependency could fail once another package required a different compatible version range.

## Validation

- `go test ./...`
