### PR TITLE
[codex] add file-backed registry backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -290,8 +290,9 @@ land. Diagnostics use `E2050–E2069`; callers render them through the
 shared `diag.Formatter`.
 
 ### `internal/pkgmgr` & `internal/lockfile` & `internal/registry`
-Dependency resolver, lockfile reader/writer, and (stub) registry
-client. Driven by `osty build` / `osty add` / `osty update`. Out of
+Dependency resolver, lockfile reader/writer, registry HTTP client,
+and file-backed registry server. Driven by `osty build` / `osty add`
+/ `osty update` / `osty publish` / `osty registry serve`. Out of
 scope for this document's front-end focus — see the package-level
 doc comments.
 

--- a/README.md
+++ b/README.md
@@ -15,23 +15,13 @@ scaffolding (`osty new` / `osty init`), a manifest-driven build
 orchestrator (`osty build`) that reads `osty.toml` / `osty.lock`
 and threads the front-end + gen across the declared packages, a
 working test runner (`osty test`), API documentation generation
-(`osty doc`), and CI quality tooling (`osty ci`). The remaining
-pieces are Tier 2+ of the standard library and the real
-package-registry backend behind `osty add` / `osty update` /
-`osty publish`; the checker now records generic call
-instantiations, validates structural interface satisfaction, emits
-match exhaustiveness diagnostics, and wires the auto-derived
-builder/default protocol.
-transpiler whose Phase 1 (primitives, fns, control flow) is
-working, project scaffolding (`osty new` / `osty init`), a
-manifest-driven build orchestrator (`osty build`) that reads
-`osty.toml` / `osty.lock` and threads the front-end + gen across
-the declared packages, a package manager (`osty add` / `osty
-update` / `osty publish`) that drives registry + git + path
-sources through a SemVer resolver into a deterministic lockfile,
-and a build-and-execute shortcut (`osty run`). Phase 2+ of the
-transpiler (structs, enums, match, generics, Option / Result,
-FFI, concurrency) is the main remaining piece.
+(`osty doc`), CI quality tooling (`osty ci`), and a package manager
+(`osty add` / `osty update` / `osty publish`) backed by a
+file-backed HTTP registry server for local/private registries. The
+remaining pieces are Tier 2+ of the standard library; the checker now
+records generic call instantiations, validates structural interface
+satisfaction, emits match exhaustiveness diagnostics, and wires the
+auto-derived builder/default protocol.
 
 ## Status
 
@@ -57,7 +47,7 @@ FFI, concurrency) is the main remaining piece.
 | API doc generator (`internal/docgen`, `osty doc`) | done — HTML + markdown, field docs, cross-refs, workspace mode |
 | CI quality tooling (`internal/ci`, `osty ci`) | done — signature-aware snapshots, workspace coverage, JSON reports |
 | Pipeline visualizer (`osty pipeline`) | done — per-stage timing, workspace mode, package-mode gen, baseline diff, LSP trace, `--explain` |
-| Package registry / `osty add` / `osty update` / `osty run` / `osty publish` | scaffolded — manifest wiring ready; registry backend not yet implemented |
+| Package registry backend / `osty registry serve` | done — file-backed HTTP server for index/search/download/publish/yank, with ETag index responses and bearer-token write auth |
 | Build orchestrator (`osty build`) | wired — drives manifest → front-end → gen Phase 1 |
 | Test runner harness (`internal/testgen`) | wired — merges per-file gen output, injects a real std.testing runtime + main(), runs via `go run` |
 | `osty test` (discovery + front-end + execution) | wired — validates and **runs** discovered `test*` / `bench*` fns; failures and pass/fail totals report inline |
@@ -138,7 +128,7 @@ osty/
 │   ├── tomlparse/           # Generic TOML parser (subset)
 │   ├── manifest/            # osty.toml parse + validate + lookup
 │   ├── lockfile/            # osty.lock read/write
-│   ├── registry/            # Package registry client (stub)
+│   ├── registry/            # Package registry client + file-backed HTTP server
 │   └── pkgmgr/semver/       # SemVer parse, compare, constraint match
 └── testdata/                # .osty fixtures used by tests
 ```
@@ -166,6 +156,7 @@ osty publish           # pack the project and upload to a registry
 osty search QUERY      # full-text search the registry (--registry, --limit)
 osty info PKG          # show registry metadata for a package (--all-versions)
 osty fetch             # resolve + vendor without building (--locked, --frozen)
+osty registry serve    # run a local/private package registry
 osty yank --version V [PKG]   # mark a published version as yanked
 osty unyank --version V [PKG] # un-yank a previously yanked version
 osty login [--registry N]     # store an API token in ~/.osty/credentials.toml
@@ -309,6 +300,17 @@ a different package without leaving its directory.
   default, or the built-in one when run outside a project).
 - `--limit N` — maximum hits to display (default 20; pass 0 for the
   registry's own default page size).
+
+`registry serve`-specific flags (after the subcommand):
+
+- `--addr HOST:PORT` — address to listen on (default `127.0.0.1:7878`).
+- `--root DIR` — package index/tarball storage root (default
+  `.osty/registry`).
+- `--token T` — bearer token required for `publish`, `yank`, and
+  `unyank`; defaults to `$OSTY_REGISTRY_TOKEN`.
+- `--allow-anonymous-writes` — local-test escape hatch when no token
+  should be required.
+- `--max-upload-mb N` — maximum package tarball size.
 
 `login` / `logout`-specific flags (after the subcommand):
 

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -219,6 +219,10 @@ func main() {
 		runInfo(args[1:], flags)
 		return
 	}
+	if cmd == "registry" {
+		runRegistry(args[1:], flags)
+		return
+	}
 	// doc parses a file or directory and emits markdown/HTML API docs.
 	// It has its own flag parser for --out / --title / --format /
 	// --check / --verify-examples.
@@ -1088,6 +1092,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty remove NAME [NAME...] (drop a dep from osty.toml; alias rm)")
 	fmt.Fprintln(os.Stderr, "       osty fetch [--locked|--frozen] (resolve+vendor without building)")
 	fmt.Fprintln(os.Stderr, "       osty info NAME [--all-versions] (show registry metadata for a package)")
+	fmt.Fprintln(os.Stderr, "       osty registry serve [--addr A] [--root DIR] (run a package registry)")
 	fmt.Fprintln(os.Stderr, "       osty doc [--format FMT] [--out PATH] PATH (generate API docs; markdown or html)")
 	fmt.Fprintln(os.Stderr, "       osty ci [flags] [PATH]    (run the CI check bundle: fmt+lint+policy+lockfile)")
 	fmt.Fprintln(os.Stderr, "       osty ci snapshot [-o OUT] (capture the exported API for future semver diffing)")

--- a/cmd/osty/registry.go
+++ b/cmd/osty/registry.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/osty/osty/internal/registry"
+)
+
+func runRegistry(args []string, cliF cliFlags) {
+	if len(args) == 0 || args[0] != "serve" {
+		fmt.Fprintln(os.Stderr, "usage: osty registry serve [--addr HOST:PORT] [--root DIR] [--token T]")
+		os.Exit(2)
+	}
+	runRegistryServe(args[1:], cliF)
+}
+
+func runRegistryServe(args []string, cliF cliFlags) {
+	fs := flag.NewFlagSet("registry serve", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty registry serve [--addr HOST:PORT] [--root DIR] [--token T] [--allow-anonymous-writes]")
+	}
+	var (
+		addr       string
+		root       string
+		token      string
+		allowAnon  bool
+		maxUploadM int
+	)
+	fs.StringVar(&addr, "addr", "127.0.0.1:7878", "address to listen on")
+	fs.StringVar(&root, "root", filepath.Join(".osty", "registry"), "registry data directory")
+	fs.StringVar(&token, "token", os.Getenv("OSTY_REGISTRY_TOKEN"), "bearer token for publish/yank (defaults to $OSTY_REGISTRY_TOKEN)")
+	fs.BoolVar(&allowAnon, "allow-anonymous-writes", false, "accept publish/yank without checking bearer tokens")
+	fs.IntVar(&maxUploadM, "max-upload-mb", int(registry.DefaultMaxUploadBytes>>20), "maximum package upload size in MiB")
+	_ = fs.Parse(args)
+	if fs.NArg() != 0 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	if token == "" && !allowAnon {
+		fmt.Fprintln(os.Stderr, "osty registry serve: pass --token, set $OSTY_REGISTRY_TOKEN, or use --allow-anonymous-writes for local-only testing")
+		os.Exit(2)
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty registry serve: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(absRoot, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "osty registry serve: %v\n", err)
+		os.Exit(1)
+	}
+	handler := registry.NewServer(registry.NewFileStore(absRoot))
+	if !allowAnon {
+		handler.Authorize = registry.BearerTokenAuth(token)
+	}
+	if maxUploadM > 0 {
+		handler.MaxUploadBytes = int64(maxUploadM) << 20
+	}
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	fmt.Printf("Serving osty registry at %s\n", displayRegistryURL(addr))
+	fmt.Printf("Data root: %s\n", absRoot)
+	if allowAnon {
+		fmt.Println("Writes: anonymous")
+	} else {
+		fmt.Println("Writes: bearer token required")
+	}
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		fmt.Fprintf(os.Stderr, "osty registry serve: %v\n", err)
+		os.Exit(1)
+	}
+	_ = cliF
+}
+
+func displayRegistryURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		if strings.HasPrefix(addr, ":") {
+			return "http://127.0.0.1" + addr
+		}
+		return "http://" + addr
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
+}

--- a/internal/registry/server.go
+++ b/internal/registry/server.go
@@ -1,0 +1,900 @@
+package registry
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/pkgmgr/semver"
+)
+
+// DefaultMaxUploadBytes is the default upper bound for one published
+// tarball. Servers can raise it for large private registries.
+const DefaultMaxUploadBytes int64 = 64 << 20
+
+const checksumPrefix = "sha256:"
+
+var (
+	errPackageNotFound = errors.New("registry package not found")
+	errVersionNotFound = errors.New("registry package version not found")
+	errVersionExists   = errors.New("registry package version already exists")
+)
+
+// AuthorizeFunc decides whether a mutating request is allowed. The
+// action is one of "publish", "yank", or "unyank".
+type AuthorizeFunc func(r *http.Request, action, name, version string) bool
+
+// BearerTokenAuth returns an AuthorizeFunc that accepts exactly one
+// bearer token. Empty tokens reject every mutating request.
+func BearerTokenAuth(token string) AuthorizeFunc {
+	token = strings.TrimSpace(token)
+	return func(r *http.Request, action, name, version string) bool {
+		got := strings.TrimSpace(r.Header.Get("Authorization"))
+		if token == "" || !strings.HasPrefix(got, "Bearer ") {
+			return false
+		}
+		return strings.TrimSpace(strings.TrimPrefix(got, "Bearer ")) == token
+	}
+}
+
+// Server exposes the osty registry HTTP protocol backed by a FileStore.
+// The zero-value is not usable; construct it with NewServer.
+type Server struct {
+	Store *FileStore
+
+	// Authorize is consulted for publish/yank/unyank. Nil means writes
+	// are accepted, which is useful for httptest and deliberately local
+	// development servers.
+	Authorize AuthorizeFunc
+
+	// Now supplies PublishedAt timestamps. Defaults to time.Now().UTC.
+	Now func() time.Time
+
+	// MaxUploadBytes caps PUT /v1/crates/<name>/<version> bodies. Zero
+	// selects DefaultMaxUploadBytes.
+	MaxUploadBytes int64
+}
+
+// NewServer constructs a registry HTTP handler over store.
+func NewServer(store *FileStore) *Server {
+	return &Server{Store: store}
+}
+
+// ServeHTTP routes the wire protocol used by Client.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s == nil || s.Store == nil {
+		http.Error(w, "registry server has no store configured", http.StatusInternalServerError)
+		return
+	}
+	segments, err := pathSegments(r.URL.EscapedPath())
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	if len(segments) < 2 || segments[0] != "v1" || segments[1] != "crates" {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodGet && len(segments) == 2:
+		s.handleSearch(w, r)
+	case r.Method == http.MethodGet && len(segments) == 3:
+		s.handleIndex(w, r, segments[2])
+	case r.Method == http.MethodPut && len(segments) == 4:
+		s.handlePublish(w, r, segments[2], segments[3])
+	case r.Method == http.MethodGet && len(segments) == 5 && segments[4] == "tar":
+		s.handleTarball(w, r, segments[2], segments[3])
+	case r.Method == http.MethodDelete && len(segments) == 5 && segments[4] == "yank":
+		s.handleYank(w, r, segments[2], segments[3], true)
+	case r.Method == http.MethodPut && len(segments) == 5 && segments[4] == "unyank":
+		s.handleYank(w, r, segments[2], segments[3], false)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request, name string) {
+	if err := validatePackageName(name); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	entry, err := s.Store.Index(name)
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	data, etag, err := jsonWithETag(entry)
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	w.Header().Set("ETag", etag)
+	if etagMatches(r.Header.Get("If-None-Match"), etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	writeJSONBytes(w, http.StatusOK, data)
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if strings.TrimSpace(q) == "" {
+		writeRegistryError(w, badRequest("registry search query is empty"))
+		return
+	}
+	limit := 0
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			writeRegistryError(w, badRequest("invalid search limit %q", raw))
+			return
+		}
+		limit = n
+	}
+	results, err := s.Store.Search(q, limit)
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, results)
+}
+
+func (s *Server) handlePublish(w http.ResponseWriter, r *http.Request, name, version string) {
+	if err := validatePackageName(name); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	if err := validateVersionString(version); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	if !s.authorized(r, "publish", name, version) {
+		http.Error(w, "registry publish requires a valid bearer token", http.StatusUnauthorized)
+		return
+	}
+	if ct := strings.TrimSpace(r.Header.Get("Content-Type")); ct != "" {
+		base := strings.ToLower(strings.TrimSpace(strings.Split(ct, ";")[0]))
+		if base != "application/x-tar+gzip" {
+			writeRegistryError(w, badRequest("unsupported content type %q", ct))
+			return
+		}
+	}
+	var meta PublishMetadata
+	if raw := strings.TrimSpace(r.Header.Get("Osty-Metadata")); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+			writeRegistryError(w, badRequest("invalid Osty-Metadata header: %v", err))
+			return
+		}
+	}
+
+	tmpPath := ""
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	var gotChecksum string
+	var err error
+	tmpPath, gotChecksum, err = s.writeUploadTemp(r)
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	wantChecksum := strings.TrimSpace(r.Header.Get("Osty-Checksum"))
+	if wantChecksum != "" {
+		if !strings.HasPrefix(wantChecksum, checksumPrefix) {
+			writeRegistryError(w, badRequest("unsupported checksum %q", wantChecksum))
+			return
+		}
+		if wantChecksum != gotChecksum {
+			writeRegistryError(w, badRequest("checksum mismatch: want %s, got %s", wantChecksum, gotChecksum))
+			return
+		}
+	}
+
+	m, err := manifestFromTarball(tmpPath)
+	if err != nil {
+		writeRegistryError(w, badRequest("invalid package tarball: %v", err))
+		return
+	}
+	if !m.HasPackage {
+		writeRegistryError(w, badRequest("package tarball has no [package] table"))
+		return
+	}
+	if m.Package.Name != name || m.Package.Version != version {
+		writeRegistryError(w, badRequest(
+			"package tarball identity mismatch: URL has %s %s, manifest has %s %s",
+			name, version, m.Package.Name, m.Package.Version))
+		return
+	}
+	deps, err := versionDependencies(m)
+	if err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	stored := StoredVersion{
+		Version:      version,
+		Checksum:     gotChecksum,
+		PublishedAt:  s.now(),
+		Dependencies: deps,
+		Features:     copyFeatures(m),
+		Metadata:     meta,
+	}
+	if err := s.Store.Publish(name, stored, tmpPath); err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	tmpPath = ""
+	writeJSON(w, http.StatusCreated, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleTarball(w http.ResponseWriter, r *http.Request, name, version string) {
+	if err := validatePackageName(name); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	if err := validateVersionString(version); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	f, err := s.Store.OpenTarball(name, version)
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	defer f.Close()
+	w.Header().Set("Content-Type", "application/x-tar+gzip")
+	if st, err := f.Stat(); err == nil {
+		w.Header().Set("Content-Length", strconv.FormatInt(st.Size(), 10))
+	}
+	_, _ = io.Copy(w, f)
+}
+
+func (s *Server) handleYank(w http.ResponseWriter, r *http.Request, name, version string, yanked bool) {
+	if err := validatePackageName(name); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	if err := validateVersionString(version); err != nil {
+		writeRegistryError(w, badRequest("%v", err))
+		return
+	}
+	action := "unyank"
+	if yanked {
+		action = "yank"
+	}
+	if !s.authorized(r, action, name, version) {
+		http.Error(w, "registry mutation requires a valid bearer token", http.StatusUnauthorized)
+		return
+	}
+	if err := s.Store.SetYanked(name, version, yanked); err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) authorized(r *http.Request, action, name, version string) bool {
+	return s.Authorize == nil || s.Authorize(r, action, name, version)
+}
+
+func (s *Server) now() time.Time {
+	if s.Now != nil {
+		return s.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (s *Server) maxUploadBytes() int64 {
+	if s.MaxUploadBytes > 0 {
+		return s.MaxUploadBytes
+	}
+	return DefaultMaxUploadBytes
+}
+
+func (s *Server) writeUploadTemp(r *http.Request) (string, string, error) {
+	tmp, err := s.Store.createUploadTemp()
+	if err != nil {
+		return "", "", err
+	}
+	tmpPath := tmp.Name()
+	defer tmp.Close()
+
+	h := sha256.New()
+	limit := s.maxUploadBytes()
+	n, err := io.Copy(tmp, io.TeeReader(io.LimitReader(r.Body, limit+1), h))
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return "", "", err
+	}
+	if n > limit {
+		_ = os.Remove(tmpPath)
+		return "", "", statusError{status: http.StatusRequestEntityTooLarge, msg: fmt.Sprintf("package upload exceeds %d bytes", limit)}
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", "", err
+	}
+	return tmpPath, checksumPrefix + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// StoredVersion is one persisted version record in the file-backed
+// registry. It is intentionally a superset of Version: the public
+// index hides Metadata, while search uses it for useful listings.
+type StoredVersion struct {
+	Version      string              `json:"version"`
+	Checksum     string              `json:"checksum"`
+	PublishedAt  time.Time           `json:"published_at"`
+	Yanked       bool                `json:"yanked"`
+	Dependencies []VersionDependency `json:"dependencies"`
+	Features     map[string][]string `json:"features,omitempty"`
+	Metadata     PublishMetadata     `json:"metadata,omitempty"`
+	Downloads    int64               `json:"downloads,omitempty"`
+}
+
+func (v StoredVersion) indexVersion() Version {
+	return Version{
+		Version:      v.Version,
+		Checksum:     v.Checksum,
+		PublishedAt:  v.PublishedAt,
+		Yanked:       v.Yanked,
+		Dependencies: append([]VersionDependency(nil), v.Dependencies...),
+		Features:     copyStringSliceMap(v.Features),
+	}
+}
+
+// PackageRecord is the on-disk package metadata file.
+type PackageRecord struct {
+	Name     string          `json:"name"`
+	Versions []StoredVersion `json:"versions"`
+}
+
+func (r *PackageRecord) indexEntry() *IndexEntry {
+	out := &IndexEntry{Name: r.Name}
+	for _, v := range r.Versions {
+		out.Versions = append(out.Versions, v.indexVersion())
+	}
+	return out
+}
+
+// FileStore is a small real registry backend rooted on disk.
+//
+// Layout:
+//
+//	<Root>/packages/<name>/package.json
+//	<Root>/packages/<name>/<version>.tgz
+//	<Root>/tmp/upload-*.tgz
+type FileStore struct {
+	Root string
+	mu   sync.Mutex
+}
+
+// NewFileStore returns a file-backed registry store rooted at root.
+func NewFileStore(root string) *FileStore {
+	return &FileStore{Root: root}
+}
+
+// Index returns the public index entry for name.
+func (fs *FileStore) Index(name string) (*IndexEntry, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	rec, err := fs.loadRecordLocked(name)
+	if err != nil {
+		return nil, err
+	}
+	return rec.indexEntry(), nil
+}
+
+// Publish persists one uploaded tarball and adds its metadata to the
+// package index. Duplicate (name, version) publishes are rejected.
+func (fs *FileStore) Publish(name string, version StoredVersion, uploadPath string) error {
+	if err := validatePackageName(name); err != nil {
+		return err
+	}
+	if err := validateVersionString(version.Version); err != nil {
+		return err
+	}
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	rec, err := fs.loadRecordLocked(name)
+	if errors.Is(err, errPackageNotFound) {
+		rec = &PackageRecord{Name: name}
+	} else if err != nil {
+		return err
+	}
+	for _, v := range rec.Versions {
+		if v.Version == version.Version {
+			return errVersionExists
+		}
+	}
+	if err := os.MkdirAll(fs.packageDir(name), 0o755); err != nil {
+		return err
+	}
+	dst := fs.tarballPath(name, version.Version)
+	if _, err := os.Stat(dst); err == nil {
+		return errVersionExists
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(uploadPath, dst); err != nil {
+		return err
+	}
+	rec.Versions = append(rec.Versions, version)
+	if err := fs.saveRecordLocked(rec); err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	return nil
+}
+
+// OpenTarball opens the published tarball and increments the persisted
+// download counter. Yanked versions remain downloadable.
+func (fs *FileStore) OpenTarball(name, version string) (*os.File, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	rec, err := fs.loadRecordLocked(name)
+	if err != nil {
+		return nil, err
+	}
+	idx := -1
+	for i, v := range rec.Versions {
+		if v.Version == version {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, errVersionNotFound
+	}
+	f, err := os.Open(fs.tarballPath(name, version))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errVersionNotFound
+		}
+		return nil, err
+	}
+	rec.Versions[idx].Downloads++
+	if err := fs.saveRecordLocked(rec); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// SetYanked toggles a version's yanked state.
+func (fs *FileStore) SetYanked(name, version string, yanked bool) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	rec, err := fs.loadRecordLocked(name)
+	if err != nil {
+		return err
+	}
+	for i, v := range rec.Versions {
+		if v.Version == version {
+			rec.Versions[i].Yanked = yanked
+			return fs.saveRecordLocked(rec)
+		}
+	}
+	return errVersionNotFound
+}
+
+// Search performs a small case-insensitive name/metadata search.
+// limit <= 0 selects the server default page size.
+func (fs *FileStore) Search(query string, limit int) (*SearchResults, error) {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return nil, fmt.Errorf("registry search query is empty")
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	records, err := fs.loadAllRecordsLocked()
+	if err != nil {
+		return nil, err
+	}
+	type scored struct {
+		hit   SearchHit
+		score int
+	}
+	var hits []scored
+	for _, rec := range records {
+		latest, ok := latestActiveVersion(rec)
+		if !ok {
+			continue
+		}
+		score, ok := searchScore(rec.Name, latest.Metadata, q)
+		if !ok {
+			continue
+		}
+		hits = append(hits, scored{
+			score: score,
+			hit: SearchHit{
+				Name:          rec.Name,
+				LatestVersion: latest.Version,
+				Description:   latest.Metadata.Description,
+				Downloads:     totalDownloads(rec),
+			},
+		})
+	}
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].score != hits[j].score {
+			return hits[i].score < hits[j].score
+		}
+		return hits[i].hit.Name < hits[j].hit.Name
+	})
+	out := &SearchResults{Total: len(hits)}
+	for i, h := range hits {
+		if i >= limit {
+			break
+		}
+		out.Hits = append(out.Hits, h.hit)
+	}
+	return out, nil
+}
+
+func (fs *FileStore) createUploadTemp() (*os.File, error) {
+	if fs == nil || strings.TrimSpace(fs.Root) == "" {
+		return nil, fmt.Errorf("registry store root is empty")
+	}
+	dir := filepath.Join(fs.Root, "tmp")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	return os.CreateTemp(dir, "upload-*.tgz")
+}
+
+func (fs *FileStore) loadAllRecordsLocked() ([]*PackageRecord, error) {
+	root := filepath.Join(fs.Root, "packages")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []*PackageRecord
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(root, ent.Name(), "package.json"))
+		if err != nil {
+			return nil, err
+		}
+		var rec PackageRecord
+		if err := json.Unmarshal(data, &rec); err != nil {
+			return nil, fmt.Errorf("decode package record %s: %w", ent.Name(), err)
+		}
+		out = append(out, &rec)
+	}
+	return out, nil
+}
+
+func (fs *FileStore) loadRecordLocked(name string) (*PackageRecord, error) {
+	data, err := os.ReadFile(fs.recordPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errPackageNotFound
+		}
+		return nil, err
+	}
+	var rec PackageRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("decode package record %s: %w", name, err)
+	}
+	if rec.Name == "" {
+		rec.Name = name
+	}
+	return &rec, nil
+}
+
+func (fs *FileStore) saveRecordLocked(rec *PackageRecord) error {
+	if err := os.MkdirAll(fs.packageDir(rec.Name), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	dst := fs.recordPath(rec.Name)
+	tmp := dst + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, dst)
+}
+
+func (fs *FileStore) packageDir(name string) string {
+	return filepath.Join(fs.Root, "packages", sanitizeIndexName(name))
+}
+
+func (fs *FileStore) recordPath(name string) string {
+	return filepath.Join(fs.packageDir(name), "package.json")
+}
+
+func (fs *FileStore) tarballPath(name, version string) string {
+	return filepath.Join(fs.packageDir(name), sanitizeIndexName(version)+".tgz")
+}
+
+func latestActiveVersion(rec *PackageRecord) (StoredVersion, bool) {
+	var best StoredVersion
+	ok := false
+	for _, v := range rec.Versions {
+		if v.Yanked {
+			continue
+		}
+		if !ok || versionGreater(v.Version, best.Version) {
+			best = v
+			ok = true
+		}
+	}
+	return best, ok
+}
+
+func versionGreater(a, b string) bool {
+	av, aerr := semver.ParseVersion(a)
+	bv, berr := semver.ParseVersion(b)
+	if aerr == nil && berr == nil {
+		return semver.Compare(av, bv) > 0
+	}
+	return a > b
+}
+
+func totalDownloads(rec *PackageRecord) int64 {
+	var n int64
+	for _, v := range rec.Versions {
+		n += v.Downloads
+	}
+	return n
+}
+
+func searchScore(name string, meta PublishMetadata, q string) (int, bool) {
+	lowerName := strings.ToLower(name)
+	switch {
+	case lowerName == q:
+		return 0, true
+	case strings.HasPrefix(lowerName, q):
+		return 1, true
+	case strings.Contains(lowerName, q):
+		return 2, true
+	}
+	if strings.Contains(strings.ToLower(meta.Description), q) {
+		return 3, true
+	}
+	for _, kw := range meta.Keywords {
+		if strings.Contains(strings.ToLower(kw), q) {
+			return 4, true
+		}
+	}
+	return 0, false
+}
+
+func manifestFromTarball(tarPath string) (*manifest.Manifest, error) {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("missing %s", manifest.ManifestFile)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+			continue
+		}
+		name := strings.TrimPrefix(path.Clean(filepath.ToSlash(hdr.Name)), "./")
+		if name != manifest.ManifestFile {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, 1<<20))
+		if err != nil {
+			return nil, err
+		}
+		m, err := manifest.Parse(data)
+		if err != nil {
+			return nil, err
+		}
+		if diags := manifest.Validate(m); len(diags) > 0 {
+			return nil, errors.New(diags[0].Message)
+		}
+		return m, nil
+	}
+}
+
+func versionDependencies(m *manifest.Manifest) ([]VersionDependency, error) {
+	var out []VersionDependency
+	add := func(kind string, deps []manifest.Dependency) error {
+		for _, d := range deps {
+			if d.Path != "" {
+				return fmt.Errorf("dependency %q uses path=%q; path dependencies cannot be published", d.Name, d.Path)
+			}
+			if d.Git != nil {
+				continue
+			}
+			name := d.PackageName
+			if name == "" {
+				name = d.Name
+			}
+			req := d.VersionReq
+			if req == "" {
+				req = "*"
+			}
+			out = append(out, VersionDependency{Name: name, Req: req, Kind: kind})
+		}
+		return nil
+	}
+	if err := add("normal", m.Dependencies); err != nil {
+		return nil, err
+	}
+	if err := add("dev", m.DevDependencies); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func copyFeatures(m *manifest.Manifest) map[string][]string {
+	features := copyStringSliceMap(m.Features)
+	if len(m.DefaultFeatures) > 0 {
+		if features == nil {
+			features = map[string][]string{}
+		}
+		if _, ok := features["default"]; !ok {
+			features["default"] = append([]string(nil), m.DefaultFeatures...)
+		}
+	}
+	return features
+}
+
+func copyStringSliceMap(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+func validatePackageName(name string) error {
+	if name == "" {
+		return fmt.Errorf("package name is empty")
+	}
+	for i, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r == '_':
+			continue
+		case i > 0 && r >= '0' && r <= '9',
+			i > 0 && r == '-':
+			continue
+		default:
+			return fmt.Errorf("invalid package name %q", name)
+		}
+	}
+	return nil
+}
+
+func validateVersionString(version string) error {
+	if _, err := semver.ParseVersion(version); err != nil {
+		return fmt.Errorf("invalid package version %q: %w", version, err)
+	}
+	return nil
+}
+
+type statusError struct {
+	status int
+	msg    string
+}
+
+func (e statusError) Error() string { return e.msg }
+
+func badRequest(format string, args ...any) error {
+	return statusError{status: http.StatusBadRequest, msg: fmt.Sprintf(format, args...)}
+}
+
+func writeRegistryError(w http.ResponseWriter, err error) {
+	var se statusError
+	switch {
+	case errors.As(err, &se):
+		http.Error(w, se.msg, se.status)
+	case errors.Is(err, errPackageNotFound), errors.Is(err, errVersionNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, errVersionExists):
+		http.Error(w, err.Error(), http.StatusConflict)
+	default:
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		writeRegistryError(w, err)
+		return
+	}
+	writeJSONBytes(w, status, data)
+}
+
+func writeJSONBytes(w http.ResponseWriter, status int, data []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}
+
+func jsonWithETag(v any) ([]byte, string, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(data)
+	return data, `"` + checksumPrefix + hex.EncodeToString(sum[:]) + `"`, nil
+}
+
+func etagMatches(header, etag string) bool {
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if part == "*" || part == etag {
+			return true
+		}
+	}
+	return false
+}
+
+func pathSegments(escapedPath string) ([]string, error) {
+	raw := strings.Trim(escapedPath, "/")
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, "/")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return nil, badRequest("empty path segment")
+		}
+		decoded, err := url.PathUnescape(part)
+		if err != nil {
+			return nil, badRequest("invalid path escape %q", part)
+		}
+		if decoded == "" || strings.Contains(decoded, "/") {
+			return nil, badRequest("invalid path segment %q", decoded)
+		}
+		out = append(out, decoded)
+	}
+	return out, nil
+}

--- a/internal/registry/server_test.go
+++ b/internal/registry/server_test.go
@@ -1,0 +1,254 @@
+package registry
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFileServerPublishSearchDownloadAndYank(t *testing.T) {
+	handler := NewServer(NewFileStore(t.TempDir()))
+	handler.Authorize = BearerTokenAuth("tok")
+	handler.Now = func() time.Time {
+		return time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	payload := packageTar(t, "foo", "1.2.3", `
+[dependencies]
+bar = "^1.0.0"
+
+[features]
+default = ["extra"]
+extra = []
+`)
+	client := NewClient(srv.URL)
+	client.Token = "tok"
+	if err := client.Publish(context.Background(), PublishRequest{
+		Name:     "foo",
+		Version:  "1.2.3",
+		Checksum: testChecksum(payload),
+		Tarball:  bytes.NewReader(payload),
+		Metadata: PublishMetadata{
+			Description: "friendly foo package",
+			License:     "MIT",
+			Keywords:    []string{"demo", "foo"},
+		},
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	versions, err := client.Versions(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("Versions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("versions = %+v", versions)
+	}
+	if versions[0].Version != "1.2.3" || versions[0].Checksum != testChecksum(payload) {
+		t.Fatalf("version entry = %+v", versions[0])
+	}
+	if len(versions[0].Dependencies) != 1 || versions[0].Dependencies[0].Name != "bar" {
+		t.Fatalf("dependencies = %+v", versions[0].Dependencies)
+	}
+	if got := versions[0].Features["default"]; len(got) != 1 || got[0] != "extra" {
+		t.Fatalf("features = %+v", versions[0].Features)
+	}
+
+	results, err := client.Search(context.Background(), "friendly", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if results.Total != 1 || len(results.Hits) != 1 {
+		t.Fatalf("search results = %+v", results)
+	}
+	if results.Hits[0].Name != "foo" || results.Hits[0].LatestVersion != "1.2.3" {
+		t.Fatalf("search hit = %+v", results.Hits[0])
+	}
+
+	dest := filepath.Join(t.TempDir(), "foo.tgz")
+	if err := client.DownloadTarball(context.Background(), "foo", "1.2.3", dest); err != nil {
+		t.Fatalf("DownloadTarball: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded bytes differ")
+	}
+
+	results, err = client.Search(context.Background(), "foo", 5)
+	if err != nil {
+		t.Fatalf("Search after download: %v", err)
+	}
+	if results.Hits[0].Downloads != 1 {
+		t.Fatalf("downloads = %d, want 1", results.Hits[0].Downloads)
+	}
+
+	if err := client.Yank(context.Background(), "foo", "1.2.3"); err != nil {
+		t.Fatalf("Yank: %v", err)
+	}
+	versions, err = client.Versions(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("Versions after yank: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("yanked version should be hidden, got %+v", versions)
+	}
+	if err := client.DownloadTarball(context.Background(), "foo", "1.2.3", filepath.Join(t.TempDir(), "yanked.tgz")); err != nil {
+		t.Fatalf("yanked versions should remain downloadable: %v", err)
+	}
+	if err := client.Unyank(context.Background(), "foo", "1.2.3"); err != nil {
+		t.Fatalf("Unyank: %v", err)
+	}
+	versions, err = client.Versions(context.Background(), "foo")
+	if err != nil || len(versions) != 1 {
+		t.Fatalf("Versions after unyank: %v / %+v", err, versions)
+	}
+}
+
+func TestFileServerRejectsBadAuthDuplicateAndChecksum(t *testing.T) {
+	handler := NewServer(NewFileStore(t.TempDir()))
+	handler.Authorize = BearerTokenAuth("good")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	payload := packageTar(t, "authpkg", "0.1.0", "")
+	client := NewClient(srv.URL)
+	client.Token = "bad"
+	err := client.Publish(context.Background(), PublishRequest{
+		Name:     "authpkg",
+		Version:  "0.1.0",
+		Checksum: testChecksum(payload),
+		Tarball:  bytes.NewReader(payload),
+	})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("bad auth error = %v", err)
+	}
+
+	client.Token = "good"
+	err = client.Publish(context.Background(), PublishRequest{
+		Name:     "authpkg",
+		Version:  "0.1.0",
+		Checksum: "sha256:0000",
+		Tarball:  bytes.NewReader(payload),
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("checksum error = %v", err)
+	}
+
+	err = client.Publish(context.Background(), PublishRequest{
+		Name:     "authpkg",
+		Version:  "0.1.0",
+		Checksum: testChecksum(payload),
+		Tarball:  bytes.NewReader(payload),
+	})
+	if err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	err = client.Publish(context.Background(), PublishRequest{
+		Name:     "authpkg",
+		Version:  "0.1.0",
+		Checksum: testChecksum(payload),
+		Tarball:  bytes.NewReader(payload),
+	})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 409") {
+		t.Fatalf("duplicate error = %v", err)
+	}
+}
+
+func TestFileServerIndexETag(t *testing.T) {
+	handler := NewServer(NewFileStore(t.TempDir()))
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	payload := packageTar(t, "etagpkg", "1.0.0", "")
+	client := NewClient(srv.URL)
+	client.Token = "anything"
+	if err := client.Publish(context.Background(), PublishRequest{
+		Name:     "etagpkg",
+		Version:  "1.0.0",
+		Checksum: testChecksum(payload),
+		Tarball:  bytes.NewReader(payload),
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	resp, err := http.Get(srv.URL + "/v1/crates/etagpkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	etag := resp.Header.Get("ETag")
+	if resp.StatusCode != http.StatusOK || etag == "" {
+		t.Fatalf("first index status=%d etag=%q", resp.StatusCode, etag)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/crates/etagpkg", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("If-None-Match", etag)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotModified {
+		t.Fatalf("second index status=%d, want 304", resp.StatusCode)
+	}
+}
+
+func packageTar(t *testing.T, name, version, extraManifest string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	manifest := `[package]
+name = "` + name + `"
+version = "` + version + `"
+edition = "0.3"
+description = "test package"
+license = "MIT"
+` + extraManifest
+	files := map[string]string{
+		"osty.toml": manifest,
+		"lib.osty":  "pub fn value() -> Int { 1 }\n",
+	}
+	for name, body := range files {
+		data := []byte(body)
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func testChecksum(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary

Adds a real file-backed Osty registry backend that implements the existing registry client protocol for local and private package registries.

## What changed

- Added `internal/registry.Server` and `FileStore` for index, search, publish, download, yank, and unyank endpoints.
- Added bearer-token authorization for mutating registry requests and checksum/manifest validation for published tarballs.
- Added `osty registry serve` to run the backend from the CLI.
- Updated README and architecture docs to remove the stale "registry backend not implemented" status.

## Impact

`osty publish`, `osty search`, `osty info`, dependency downloads, and yank/unyank now have a repo-native backend to target instead of only a client protocol.

## Validation

- `go test ./internal/registry ./cmd/osty`
- `go test ./...`
