### PR TITLE
[codex] fix offline registry cache resolution

### DIFF
--- a/internal/pkgmgr/source_registry.go
+++ b/internal/pkgmgr/source_registry.go
@@ -59,9 +59,6 @@ func (s *registrySource) candidateRegistryVersions(ctx context.Context, env *Env
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if env.Offline {
-		return nil, fmt.Errorf("registry dependency %s: offline mode forbids registry access", s.name)
-	}
 	regURL, ok := env.Registries[s.registryName]
 	if !ok || regURL == "" {
 		return nil, fmt.Errorf("registry %q not configured", s.registryName)
@@ -77,9 +74,17 @@ func (s *registrySource) candidateRegistryVersions(ctx context.Context, env *Env
 	// fast and let an offline machine fall back to the last known
 	// view of the registry.
 	client.Cache = registry.NewDirIndexCache(filepath.Join(env.CacheDir, "registry-index", sanitizeURL(regURL)))
-	versions, err := client.Versions(ctx, s.packageName)
-	if err != nil {
-		return nil, fmt.Errorf("registry dependency %s: %w", s.name, err)
+	var versions []registry.Version
+	if env.Offline {
+		versions, err = client.CachedVersions(s.packageName)
+		if err != nil {
+			return nil, fmt.Errorf("registry dependency %s: offline mode requires cached registry index: %w", s.name, err)
+		}
+	} else {
+		versions, err = client.Versions(ctx, s.packageName)
+		if err != nil {
+			return nil, fmt.Errorf("registry dependency %s: %w", s.name, err)
+		}
 	}
 	var candidates []registryCandidate
 	for _, v := range versions {
@@ -123,13 +128,27 @@ func (s *registrySource) fetchRegistryCandidate(ctx context.Context, env *Env, c
 
 	// Download + verify the tarball.
 	cacheRoot := filepath.Join(env.CacheDir, "registry", sanitizeURL(regURL), s.packageName, best)
-	if err := ensureDir(cacheRoot); err != nil {
-		return nil, err
+	if env.Offline {
+		if _, err := os.Stat(cacheRoot); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("registry dependency %s@%s: offline mode requires cached registry tarball at %s",
+					s.name, best, filepath.Join(cacheRoot, "package.tgz"))
+			}
+			return nil, err
+		}
+	} else {
+		if err := ensureDir(cacheRoot); err != nil {
+			return nil, err
+		}
 	}
 	tarPath := filepath.Join(cacheRoot, "package.tgz")
 	if _, err := os.Stat(tarPath); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
+		}
+		if env.Offline {
+			return nil, fmt.Errorf("registry dependency %s@%s: offline mode requires cached registry tarball at %s",
+				s.name, best, tarPath)
 		}
 		if err := client.DownloadTarball(ctx, s.packageName, best, tarPath); err != nil {
 			return nil, fmt.Errorf("registry dependency %s: download: %w", s.name, err)

--- a/internal/pkgmgr/source_registry_test.go
+++ b/internal/pkgmgr/source_registry_test.go
@@ -1,0 +1,130 @@
+package pkgmgr
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/osty/osty/internal/manifest"
+	"github.com/osty/osty/internal/registry"
+)
+
+func TestRegistryFetchOfflineUsesCachedIndexAndTarball(t *testing.T) {
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, "cache")
+
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, "offline fetch must not contact registry", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	checksum := seedRegistryTarball(t, cacheDir, server.URL, "lib", "1.2.3")
+	seedRegistryIndex(t, cacheDir, server.URL, "lib", registry.Version{
+		Version:  "1.2.3",
+		Checksum: checksum,
+	})
+
+	src := &registrySource{name: "lib", packageName: "lib", versionReq: "^1.0.0"}
+	env := &Env{
+		CacheDir:   cacheDir,
+		Registries: map[string]string{"": server.URL},
+		Offline:    true,
+	}
+
+	fetched, err := src.Fetch(context.Background(), env)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("offline fetch contacted registry %d time(s)", got)
+	}
+	if fetched.Version != "1.2.3" {
+		t.Fatalf("version: got %q, want 1.2.3", fetched.Version)
+	}
+	if fetched.Checksum != checksum {
+		t.Fatalf("checksum: got %q, want %q", fetched.Checksum, checksum)
+	}
+	if fetched.Manifest.Package.Name != "lib" {
+		t.Fatalf("manifest package: got %q, want lib", fetched.Manifest.Package.Name)
+	}
+	if _, err := os.Stat(filepath.Join(fetched.LocalDir, manifest.ManifestFile)); err != nil {
+		t.Fatalf("unpacked manifest missing: %v", err)
+	}
+}
+
+func TestRegistryFetchOfflineFailsWhenTarballCacheIsMissing(t *testing.T) {
+	tmp := t.TempDir()
+	cacheDir := filepath.Join(tmp, "cache")
+
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, "offline fetch must not contact registry", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	seedRegistryIndex(t, cacheDir, server.URL, "lib", registry.Version{
+		Version:  "1.2.3",
+		Checksum: HashBytes([]byte("not-present")),
+	})
+
+	src := &registrySource{name: "lib", packageName: "lib", versionReq: "^1.0.0"}
+	env := &Env{
+		CacheDir:   cacheDir,
+		Registries: map[string]string{"": server.URL},
+		Offline:    true,
+	}
+
+	_, err := src.Fetch(context.Background(), env)
+	if err == nil {
+		t.Fatal("Fetch should fail without a cached tarball")
+	}
+	if !strings.Contains(err.Error(), "offline mode requires cached registry tarball") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("offline fetch contacted registry %d time(s)", got)
+	}
+}
+
+func seedRegistryIndex(t *testing.T, cacheDir, registryURL, name string, version registry.Version) {
+	t.Helper()
+
+	indexCache := registry.NewDirIndexCache(filepath.Join(cacheDir, "registry-index", sanitizeURL(registryURL)))
+	must(t, indexCache.Store(name, &registry.IndexEntry{
+		Name:     name,
+		Versions: []registry.Version{version},
+	}, "test-etag"))
+}
+
+func seedRegistryTarball(t *testing.T, cacheDir, registryURL, name, version string) string {
+	t.Helper()
+
+	srcDir := filepath.Join(t.TempDir(), name)
+	must(t, os.MkdirAll(srcDir, 0o755))
+	must(t, manifest.Write(filepath.Join(srcDir, manifest.ManifestFile), &manifest.Manifest{
+		Package: manifest.Package{Name: name, Version: version},
+	}))
+	must(t, os.WriteFile(filepath.Join(srcDir, name+".osty"), []byte("pub fn ping() {}\n"), 0o644))
+
+	cacheRoot := filepath.Join(cacheDir, "registry", sanitizeURL(registryURL), name, version)
+	must(t, os.MkdirAll(cacheRoot, 0o755))
+	tarPath := filepath.Join(cacheRoot, "package.tgz")
+	f, err := os.Create(tarPath)
+	must(t, err)
+	if err := CreateTarGz(srcDir, f); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	must(t, f.Close())
+	checksum, err := hashFile(tarPath)
+	must(t, err)
+	return checksum
+}

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -77,10 +77,10 @@ type IndexEntry struct {
 // fields here are enough for semver resolution, checksum verification,
 // and dependency graph construction.
 type Version struct {
-	Version      string             `json:"version"`
-	Checksum     string             `json:"checksum"`
-	PublishedAt  time.Time          `json:"published_at"`
-	Yanked       bool               `json:"yanked"`
+	Version      string              `json:"version"`
+	Checksum     string              `json:"checksum"`
+	PublishedAt  time.Time           `json:"published_at"`
+	Yanked       bool                `json:"yanked"`
 	Dependencies []VersionDependency `json:"dependencies"`
 	Features     map[string][]string `json:"features,omitempty"`
 }
@@ -167,6 +167,22 @@ func (c *Client) Versions(ctx context.Context, name string) ([]Version, error) {
 		_ = c.Cache.Store(name, &out, resp.Header.Get("ETag"))
 	}
 	return filterYanked(out.Versions), nil
+}
+
+// CachedVersions returns every non-yanked version of `name` from the
+// configured index cache without contacting the registry.
+func (c *Client) CachedVersions(name string) ([]Version, error) {
+	if c.Cache == nil {
+		return nil, fmt.Errorf("registry index cache is not configured")
+	}
+	entry, _, err := c.Cache.Load(name)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("registry index cache missing entry for %s", name)
+	}
+	return filterYanked(entry.Versions), nil
 }
 
 // filterYanked drops yanked entries from a version list. Centralized


### PR DESCRIPTION
## Summary
- allow offline registry dependency resolution to read the cached registry index instead of failing before cache lookup
- keep offline mode from downloading missing tarballs, returning a clear cache-missing error instead
- add regression coverage for cached offline success and missing-tarball failure without contacting the registry

## Root Cause
`registrySource.Fetch` returned immediately when `env.Offline` was set, so cached registry metadata and tarballs could never satisfy registry dependencies despite the helper comment promising that cached downloads still work.

## Validation
- `go test ./...`
- `go test ./...` on the conflict-resolved merge candidate based on commit `2fadc08b6ae8642751b120a76af609c853de4592`