### PR TITLE
[codex] add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GOFLAGS: -mod=readonly
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary

- Add a GitHub Actions CI workflow for pushes and pull requests.
- Use the Go version from `go.mod` with module caching enabled.
- Run module download, build, vet, and the full Go test suite.

## Validation

- `git diff --check`
- `go build ./...`
- `go vet ./...`
- `go test ./...`

## Notes

`osty ci .` is not included yet because the repository root currently includes spec and sample `.osty` files that make that command fail when run over the whole tree.
