### PR TITLE
[codex] add stdlib bridge modules

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -289,6 +289,7 @@ func newChecker() *checker {
 		syms:              map[*resolve.Symbol]*symInfo{},
 		declToSym:         map[ast.Node]*resolve.Symbol{},
 		externalCollected: map[*resolve.Package]bool{},
+		externalPkgs:      map[*resolve.Symbol]*resolve.Package{},
 	}
 }
 
@@ -376,6 +377,12 @@ type checker struct {
 	// packages, but package calls like `random.seeded()` still need the
 	// callee return type and the returned struct's methods.
 	externalCollected map[*resolve.Package]bool
+
+	// externalPkgs remembers which loaded package introduced a Named
+	// type discovered through a package call. Stdlib modules are
+	// resolved but not collected by the user's checker pass; this lets
+	// later field/method lookups walk their AST signatures.
+	externalPkgs map[*resolve.Symbol]*resolve.Package
 }
 
 func (c *checker) ensurePackageCollected(pkg *resolve.Package) {

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -693,7 +693,7 @@ func (c *checker) tryPackageCall(
 	var generics []*types.TypeVar
 	if types.IsError(t) {
 		if fnDecl, ok := tgt.Decl.(*ast.FnDecl); ok {
-			t = c.externalFnType(fnDecl)
+			t = c.externalFnType(fnDecl, pkgSym.Package)
 		}
 	}
 	fn, isFn := types.AsFn(t)
@@ -1179,14 +1179,14 @@ func (c *checker) resultOf(ok, err types.Type) types.Type {
 	return c.namedOf("Result", []types.Type{ok, err})
 }
 
-func (c *checker) externalFnType(fn *ast.FnDecl) *types.FnType {
+func (c *checker) externalFnType(fn *ast.FnDecl, pkg *resolve.Package) *types.FnType {
 	params := make([]types.Type, 0, len(fn.Params))
 	for _, p := range fn.Params {
-		params = append(params, c.ffiType(p.Type))
+		params = append(params, c.externalType(p.Type, pkg))
 	}
 	var ret types.Type = types.Unit
 	if fn.ReturnType != nil {
-		ret = c.ffiType(fn.ReturnType)
+		ret = c.externalType(fn.ReturnType, pkg)
 	}
 	return &types.FnType{Params: params, Return: ret}
 }
@@ -1213,6 +1213,11 @@ func (c *checker) lookupMethod(recvT types.Type, name string) (*methodDesc, map[
 				if md, ok := c.interfaceMethodSet(v)[name]; ok {
 					return md, nil
 				}
+			}
+		}
+		if pkg := c.externalPkgs[v.Sym]; pkg != nil {
+			if md := c.externalMethod(v.Sym, pkg, name); md != nil {
+				return md, nil
 			}
 		}
 		// Builtin compound types carry synthetic method tables.
@@ -1582,15 +1587,7 @@ func (c *checker) tryFFICall(u *ast.UseDecl, fx *ast.FieldExpr, e *ast.CallExpr,
 	if fn == nil {
 		return nil
 	}
-	params := make([]types.Type, 0, len(fn.Params))
-	for _, p := range fn.Params {
-		params = append(params, c.ffiType(p.Type))
-	}
-	var ret types.Type = types.Unit
-	if fn.ReturnType != nil {
-		ret = c.ffiType(fn.ReturnType)
-	}
-	ft := &types.FnType{Params: params, Return: ret}
+	ft := c.externalFnType(fn, nil)
 	c.recordExpr(e.Fn, ft)
 	return c.applyFnTo(e, e.Args, ft, env)
 }
@@ -1600,6 +1597,10 @@ func (c *checker) tryFFICall(u *ast.UseDecl, fx *ast.FieldExpr, e *ast.CallExpr,
 // table — the FFI body isn't walked by the resolver, so type refs there
 // have no recorded symbol.
 func (c *checker) ffiType(n ast.Type) types.Type {
+	return c.externalType(n, nil)
+}
+
+func (c *checker) externalType(n ast.Type, pkg *resolve.Package) types.Type {
 	if n == nil {
 		return types.Unit
 	}
@@ -1612,41 +1613,96 @@ func (c *checker) ffiType(n ast.Type) types.Type {
 		if t, ok := c.builtinScalarType(name); ok {
 			return t
 		}
+		args := make([]types.Type, 0, len(x.Args))
+		for _, a := range x.Args {
+			args = append(args, c.externalType(a, pkg))
+		}
 		// Generic prelude types (List<T>, Option<T>, Result<T, E>, Channel<T>).
 		if sym := c.topLevelSym(name); sym != nil {
-			args := make([]types.Type, 0, len(x.Args))
-			for _, a := range x.Args {
-				args = append(args, c.ffiType(a))
-			}
 			if name == "Option" && len(args) == 1 {
 				return &types.Optional{Inner: args[0]}
 			}
 			return &types.Named{Sym: sym, Args: args}
 		}
+		if pkg != nil && pkg.PkgScope != nil {
+			if sym := pkg.PkgScope.LookupLocal(name); sym != nil {
+				c.externalPkgs[sym] = pkg
+				return &types.Named{Sym: sym, Args: args}
+			}
+		}
 		return types.ErrorType
 	case *ast.OptionalType:
-		return &types.Optional{Inner: c.ffiType(x.Inner)}
+		return &types.Optional{Inner: c.externalType(x.Inner, pkg)}
 	case *ast.TupleType:
 		if len(x.Elems) == 0 {
 			return types.Unit
 		}
 		elems := make([]types.Type, len(x.Elems))
 		for i, e := range x.Elems {
-			elems[i] = c.ffiType(e)
+			elems[i] = c.externalType(e, pkg)
 		}
 		return &types.Tuple{Elems: elems}
 	case *ast.FnType:
 		params := make([]types.Type, len(x.Params))
 		for i, p := range x.Params {
-			params[i] = c.ffiType(p)
+			params[i] = c.externalType(p, pkg)
 		}
 		var ret types.Type = types.Unit
 		if x.ReturnType != nil {
-			ret = c.ffiType(x.ReturnType)
+			ret = c.externalType(x.ReturnType, pkg)
 		}
 		return &types.FnType{Params: params, Return: ret}
 	}
 	return types.ErrorType
+}
+
+func (c *checker) externalMethod(sym *resolve.Symbol, pkg *resolve.Package, name string) *methodDesc {
+	switch d := sym.Decl.(type) {
+	case *ast.StructDecl:
+		for _, m := range d.Methods {
+			if m.Name == name && m.Pub {
+				return c.externalMethodDesc(m, pkg)
+			}
+		}
+	case *ast.EnumDecl:
+		for _, m := range d.Methods {
+			if m.Name == name && m.Pub {
+				return c.externalMethodDesc(m, pkg)
+			}
+		}
+	case *ast.InterfaceDecl:
+		for _, m := range d.Methods {
+			if m.Name == name && m.Pub {
+				return c.externalMethodDesc(m, pkg)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *checker) externalMethodDesc(fn *ast.FnDecl, pkg *resolve.Package) *methodDesc {
+	return &methodDesc{
+		Name:    fn.Name,
+		Pub:     fn.Pub,
+		Recv:    fn.Recv,
+		Fn:      c.externalFnType(fn, pkg),
+		HasBody: fn.Body != nil,
+		Params:  fn.Params,
+		Decl:    fn,
+	}
+}
+
+func (c *checker) externalField(sym *resolve.Symbol, pkg *resolve.Package, name string) (types.Type, bool) {
+	sd, ok := sym.Decl.(*ast.StructDecl)
+	if !ok {
+		return nil, false
+	}
+	for _, f := range sd.Fields {
+		if f.Name == name && f.Pub {
+			return c.externalType(f.Type, pkg), true
+		}
+	}
+	return nil, false
 }
 
 // channelOf builds a Channel<T> Named type bound to the prelude's
@@ -1895,10 +1951,24 @@ func (c *checker) fieldType(fx *ast.FieldExpr, env *env) types.Type {
 				// Resolver already reported E0508.
 				return types.ErrorType
 			}
-			return c.symTypeOrError(tgt)
+			if t := c.symTypeOrError(tgt); !types.IsError(t) {
+				return t
+			}
+			if ld, ok := tgt.Decl.(*ast.LetDecl); ok && ld.Type != nil {
+				return c.externalType(ld.Type, s.Package)
+			}
+			return types.ErrorType
 		}
 	}
 	if n, ok := types.AsNamed(recvT); ok {
+		if pkg := c.externalPkgs[n.Sym]; pkg != nil {
+			if t, ok := c.externalField(n.Sym, pkg, fx.Name); ok {
+				if wasOpt && fx.IsOptional {
+					return &types.Optional{Inner: t}
+				}
+				return t
+			}
+		}
 		if desc, ok := c.result.Descs[n.Sym]; ok {
 			// Field access on a struct — take precedence over method
 			// lookup so `foo.bar` reads the field even when a method
@@ -2167,7 +2237,15 @@ func (c *checker) structLitType(e *ast.StructLit, env *env) types.Type {
 		return types.ErrorType
 	}
 	desc, ok := c.result.Descs[typeSym]
-	if !ok || desc.Kind != resolve.SymStruct {
+	if !ok {
+		if pkg := c.externalPkgs[typeSym]; pkg != nil {
+			return c.externalStructLitType(e, typeSym, pkg, env)
+		}
+		c.errNode(e, diag.CodeNotAStruct,
+			"`%s` is not a struct", typeSym.Name)
+		return types.ErrorType
+	}
+	if desc.Kind != resolve.SymStruct {
 		c.errNode(e, diag.CodeNotAStruct,
 			"`%s` is not a struct", typeSym.Name)
 		return types.ErrorType
@@ -2253,6 +2331,85 @@ func (c *checker) structLitType(e *ast.StructLit, env *env) types.Type {
 	return selfT
 }
 
+func (c *checker) externalStructLitType(e *ast.StructLit, typeSym *resolve.Symbol, pkg *resolve.Package, env *env) types.Type {
+	sd, ok := typeSym.Decl.(*ast.StructDecl)
+	if !ok {
+		c.errNode(e, diag.CodeNotAStruct,
+			"`%s` is not a struct", typeSym.Name)
+		return types.ErrorType
+	}
+	selfT := &types.Named{Sym: typeSym}
+	want := map[string]*fieldDesc{}
+	fieldNames := make([]string, 0, len(sd.Fields))
+	for _, f := range sd.Fields {
+		fd := &fieldDesc{
+			Name:   f.Name,
+			Type:   c.externalType(f.Type, pkg),
+			Pub:    f.Pub,
+			HasDef: f.Default != nil,
+			Decl:   f,
+		}
+		want[f.Name] = fd
+		fieldNames = append(fieldNames, f.Name)
+	}
+
+	spreadCoversAll := false
+	if e.Spread != nil {
+		spreadT := c.checkExpr(e.Spread, selfT, env)
+		if spreadT != nil && !types.IsError(spreadT) {
+			n, ok := types.AsNamed(spreadT)
+			if !ok || n.Sym != typeSym {
+				c.errNode(e.Spread, diag.CodeTypeMismatch,
+					"spread source must be a `%s` value, got `%s`",
+					typeSym.Name, spreadT)
+			} else {
+				spreadCoversAll = true
+			}
+		}
+	}
+
+	provided := map[string]bool{}
+	for _, f := range e.Fields {
+		fd, ok := want[f.Name]
+		if !ok {
+			b := diag.New(diag.Error,
+				fmt.Sprintf("no field `%s` on struct `%s`", f.Name, typeSym.Name)).
+				Code(diag.CodeUnknownStructField).
+				Primary(diag.Span{Start: f.Pos(), End: f.End()}, "no such field")
+			if s := suggestFrom(f.Name, fieldNames); s != "" {
+				b.Hint(fmt.Sprintf("did you mean `%s`?", s))
+			}
+			c.emit(b.Build())
+			if f.Value != nil {
+				c.checkExpr(f.Value, nil, env)
+			}
+			continue
+		}
+		provided[f.Name] = true
+		var vt types.Type
+		if f.Value != nil {
+			vt = c.checkExpr(f.Value, fd.Type, env)
+		} else {
+			id := &ast.Ident{PosV: f.PosV, EndV: f.PosV, Name: f.Name}
+			vt = c.checkExpr(id, fd.Type, env)
+		}
+		if !types.Assignable(fd.Type, vt) {
+			c.errMismatch(f, fd.Type, vt)
+		}
+	}
+	if !spreadCoversAll {
+		for name, fd := range want {
+			if provided[name] || fd.HasDef {
+				continue
+			}
+			c.errNode(e, diag.CodeMissingStructField,
+				"struct literal for `%s` is missing field `%s`",
+				typeSym.Name, name)
+		}
+	}
+	return selfT
+}
+
 // structLitSym walks a StructLit's Type expr to recover the struct's
 // Symbol. Handles bare Ident and pkg.Type FieldExpr chains.
 func (c *checker) structLitSym(e ast.Expr) *resolve.Symbol {
@@ -2260,6 +2417,16 @@ func (c *checker) structLitSym(e ast.Expr) *resolve.Symbol {
 	case *ast.Ident:
 		return c.symbol(x)
 	case *ast.FieldExpr:
+		if id, ok := x.X.(*ast.Ident); ok {
+			if pkgSym := c.symbol(id); pkgSym != nil && pkgSym.Kind == resolve.SymPackage {
+				if pkgSym.Package != nil && pkgSym.Package.PkgScope != nil {
+					if sym := pkgSym.Package.PkgScope.LookupLocal(x.Name); sym != nil {
+						c.externalPkgs[sym] = pkgSym.Package
+						return sym
+					}
+				}
+			}
+		}
 		return c.structLitSym(x.X) // MVP: only validate the head
 	}
 	return nil

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -128,8 +128,12 @@ func (g *gen) emitStructLit(s *ast.StructLit) {
 			typeName = t.Name
 		}
 	case *ast.FieldExpr:
-		// Qualified type (pkg.Type) — Phase 5.
-		g.emitExpr(s.Type)
+		if name, ok := g.stdlibStructLitType(t); ok {
+			typeName = name
+		} else {
+			// Qualified type (pkg.Type) — Phase 5.
+			g.emitExpr(s.Type)
+		}
 	default:
 		g.emitExpr(s.Type)
 	}
@@ -372,6 +376,30 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		}
 	}
 	if f, ok := c.Fn.(*ast.FieldExpr); ok {
+		if g.emitStdlibEncodingCall(c, f) {
+			return
+		}
+		if g.emitStdlibEnvCall(c, f) {
+			return
+		}
+		if g.emitStdlibCSVCall(c, f) {
+			return
+		}
+		if g.emitStdlibCompressCall(c, f) {
+			return
+		}
+		if g.emitStdlibCryptoCall(c, f) {
+			return
+		}
+		if g.emitStdlibUUIDCall(c, f) {
+			return
+		}
+		if g.emitStdlibRegexCall(c, f) {
+			return
+		}
+		if g.emitStdlibMathCall(c, f) {
+			return
+		}
 		if g.emitThreadSelect(c, f) {
 			return
 		}
@@ -411,6 +439,455 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		g.emitExpr(a.Value)
 	}
 	g.body.write(")")
+}
+
+func (g *gen) emitStdlibEncodingCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "encoding")
+	if !ok {
+		return false
+	}
+	var helper string
+	switch strings.Join(parts, ".") {
+	case "base64.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64Encode"
+		}
+	case "base64.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64Decode"
+		}
+	case "base64.url.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64URLEncode"
+		}
+	case "base64.url.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64URLDecode"
+		}
+	case "hex.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingHexEncode"
+		}
+	case "hex.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingHexDecode"
+		}
+	case "url.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingURLEncode"
+		}
+	case "url.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingURLDecode"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needEncoding = true
+	if strings.HasSuffix(helper, "Decode") {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibEnvCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "env")
+	if !ok || len(parts) != 1 {
+		return false
+	}
+	var helper string
+	switch parts[0] {
+	case "args":
+		if len(c.Args) == 0 {
+			helper = "envArgs"
+		}
+	case "get":
+		if len(c.Args) == 1 {
+			helper = "envGet"
+		}
+	case "require":
+		if len(c.Args) == 1 {
+			helper = "envRequire"
+		}
+	case "set":
+		if len(c.Args) == 2 {
+			helper = "envSet"
+		}
+	case "unset":
+		if len(c.Args) == 1 {
+			helper = "envUnset"
+		}
+	case "vars":
+		if len(c.Args) == 0 {
+			helper = "envVars"
+		}
+	case "currentDir":
+		if len(c.Args) == 0 {
+			helper = "envCurrentDir"
+		}
+	case "setCurrentDir":
+		if len(c.Args) == 1 {
+			helper = "envSetCurrentDir"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needEnv = true
+	switch helper {
+	case "envRequire", "envSet", "envUnset", "envCurrentDir", "envSetCurrentDir":
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibCSVCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "csv")
+	if !ok || len(parts) != 1 {
+		return false
+	}
+	var helper string
+	switch parts[0] {
+	case "encode":
+		if len(c.Args) == 1 {
+			helper = "csvEncode"
+		}
+	case "encodeWith":
+		if len(c.Args) == 2 {
+			helper = "csvEncodeWith"
+		}
+	case "decode":
+		if len(c.Args) == 1 {
+			helper = "csvDecode"
+		}
+	case "decodeHeaders":
+		if len(c.Args) == 1 {
+			helper = "csvDecodeHeaders"
+		}
+	case "decodeWith":
+		if len(c.Args) == 2 {
+			helper = "csvDecodeWith"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needCSV = true
+	if strings.HasPrefix(helper, "csvDecode") {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibCompressCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "compress")
+	if !ok {
+		return false
+	}
+	var helper string
+	switch strings.Join(parts, ".") {
+	case "gzip.encode":
+		if len(c.Args) == 1 {
+			helper = "compressGzipEncode"
+		}
+	case "gzip.decode":
+		if len(c.Args) == 1 {
+			helper = "compressGzipDecode"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needCompress = true
+	if helper == "compressGzipDecode" {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibCryptoCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "crypto")
+	if !ok {
+		return false
+	}
+	var helper string
+	switch strings.Join(parts, ".") {
+	case "sha256":
+		if len(c.Args) == 1 {
+			helper = "cryptoSHA256"
+		}
+	case "sha512":
+		if len(c.Args) == 1 {
+			helper = "cryptoSHA512"
+		}
+	case "sha1":
+		if len(c.Args) == 1 {
+			helper = "cryptoSHA1"
+		}
+	case "md5":
+		if len(c.Args) == 1 {
+			helper = "cryptoMD5"
+		}
+	case "hmac.sha256":
+		if len(c.Args) == 2 {
+			helper = "cryptoHMACSHA256"
+		}
+	case "hmac.sha512":
+		if len(c.Args) == 2 {
+			helper = "cryptoHMACSHA512"
+		}
+	case "randomBytes":
+		if len(c.Args) == 1 {
+			helper = "cryptoRandomBytes"
+		}
+	case "constantTimeEq":
+		if len(c.Args) == 2 {
+			helper = "cryptoConstantTimeEq"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needCrypto = true
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibUUIDCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "uuid")
+	if !ok || len(parts) != 1 {
+		return false
+	}
+	var helper string
+	switch parts[0] {
+	case "v4":
+		if len(c.Args) == 0 {
+			helper = "uuidV4"
+		}
+	case "v7":
+		if len(c.Args) == 0 {
+			helper = "uuidV7"
+		}
+	case "parse":
+		if len(c.Args) == 1 {
+			helper = "uuidParse"
+		}
+	case "nil":
+		if len(c.Args) == 0 {
+			helper = "uuidNil"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needUUID = true
+	if helper == "uuidParse" {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibHelperCall(helper string, args []*ast.Arg) {
+	g.body.write(helper)
+	g.body.write("(")
+	for i, a := range args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+}
+
+func (g *gen) emitStdlibRegexCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "regex") || f.Name != "compile" {
+		return false
+	}
+	if len(c.Args) != 1 {
+		return false
+	}
+	g.needRegex = true
+	g.needResult = true
+	g.body.write("regexCompile(")
+	g.emitExpr(c.Args[0].Value)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) stdlibCallPath(c *ast.CallExpr, module string) ([]string, bool) {
+	id, parts, ok := stdlibFieldChain(c.Fn)
+	if !ok || id == nil || len(parts) == 0 {
+		return nil, false
+	}
+	if !g.isStdlibPackageAlias(id, module) {
+		return nil, false
+	}
+	return parts, true
+}
+
+func stdlibFieldChain(e ast.Expr) (*ast.Ident, []string, bool) {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x, nil, true
+	case *ast.FieldExpr:
+		id, parts, ok := stdlibFieldChain(x.X)
+		if !ok {
+			return nil, nil, false
+		}
+		return id, append(parts, x.Name), true
+	}
+	return nil, nil, false
+}
+
+func (g *gen) stdlibStructLitType(e ast.Expr) (string, bool) {
+	f, ok := e.(*ast.FieldExpr)
+	if !ok {
+		return "", false
+	}
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	if g.isStdlibPackageAlias(id, "csv") && f.Name == "CsvOptions" {
+		g.needCSV = true
+		return "CsvOptions", true
+	}
+	return "", false
+}
+
+func (g *gen) emitStdlibMathCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "math") {
+		return false
+	}
+	alias := g.useStdlibMath(id.Name)
+	if f.Name == "log" {
+		switch len(c.Args) {
+		case 1:
+			g.body.writef("%s.Log(", alias)
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(")")
+			return true
+		case 2:
+			g.body.write("(")
+			g.body.writef("%s.Log(", alias)
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(") / ")
+			g.body.writef("%s.Log(", alias)
+			g.emitExpr(c.Args[1].Value)
+			g.body.write("))")
+			return true
+		}
+		return false
+	}
+	name, ok := stdlibMathFuncs[f.Name]
+	if !ok {
+		return false
+	}
+	g.body.writef("%s.%s(", alias, name)
+	for i, a := range c.Args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitStdlibMathField(f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "math") {
+		return false
+	}
+	alias := g.useStdlibMath(id.Name)
+	switch f.Name {
+	case "PI":
+		g.body.writef("%s.Pi", alias)
+	case "E":
+		g.body.writef("%s.E", alias)
+	case "TAU":
+		g.body.writef("(2 * %s.Pi)", alias)
+	case "INFINITY":
+		g.body.writef("%s.Inf(1)", alias)
+	case "NAN":
+		g.body.writef("%s.NaN()", alias)
+	default:
+		return false
+	}
+	return true
+}
+
+var stdlibMathFuncs = map[string]string{
+	"sin":   "Sin",
+	"cos":   "Cos",
+	"tan":   "Tan",
+	"asin":  "Asin",
+	"acos":  "Acos",
+	"atan":  "Atan",
+	"atan2": "Atan2",
+	"sinh":  "Sinh",
+	"cosh":  "Cosh",
+	"tanh":  "Tanh",
+	"exp":   "Exp",
+	"log2":  "Log2",
+	"log10": "Log10",
+	"sqrt":  "Sqrt",
+	"cbrt":  "Cbrt",
+	"pow":   "Pow",
+	"floor": "Floor",
+	"ceil":  "Ceil",
+	"round": "Round",
+	"trunc": "Trunc",
+	"abs":   "Abs",
+	"min":   "Min",
+	"max":   "Max",
+	"hypot": "Hypot",
+}
+
+func (g *gen) useStdlibMath(alias string) string {
+	goAlias := mangleIdent(alias)
+	if goAlias == "math" {
+		g.use("math")
+	} else {
+		g.useAs("math", goAlias)
+	}
+	return goAlias
+}
+
+func (g *gen) isStdlibPackageAlias(id *ast.Ident, module string) bool {
+	if sym := g.symbolFor(id); sym != nil && sym.Kind == resolve.SymPackage {
+		if u, ok := sym.Decl.(*ast.UseDecl); ok {
+			return stdlibUseMatchesAlias(u, id.Name, module)
+		}
+	}
+	if g.res != nil {
+		return false
+	}
+	for _, u := range g.file.Uses {
+		if stdlibUseMatchesAlias(u, id.Name, module) {
+			return true
+		}
+	}
+	return false
+}
+
+func stdlibUseMatchesAlias(u *ast.UseDecl, alias, module string) bool {
+	if u == nil || u.IsGoFFI || len(u.Path) != 2 || u.Path[0] != "std" || u.Path[1] != module {
+		return false
+	}
+	name := u.Alias
+	if name == "" {
+		name = u.Path[len(u.Path)-1]
+	}
+	return name == alias
 }
 
 // emitConcurrencyMethod recognizes the small set of channel / handle
@@ -1397,6 +1874,9 @@ func (g *gen) emitQuestion(q *ast.QuestionExpr) {
 // Field-type lookup comes from the checker when available.
 func (g *gen) emitField(f *ast.FieldExpr) {
 	if !f.IsOptional {
+		if g.emitStdlibMathField(f) {
+			return
+		}
 		// Numeric literals need parens to disambiguate from float
 		// literals: `5.s` would be lexed as `5.` + `s` by Go. The
 		// Osty spec uses `5.s` for duration-literal shorthand

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -108,6 +108,32 @@ type gen struct {
 	needRandomRuntime bool
 	needURLRuntime    bool
 
+	// needRegex is set when std.regex lowers to Go's regexp package,
+	// pulling in Regex/Match/Captures runtime wrappers.
+	needRegex bool
+
+	// needEncoding is set when std.encoding lowers to Go's encoding
+	// packages, pulling in base64/hex/url helper functions.
+	needEncoding bool
+
+	// needEnv is set when std.env lowers to os-backed helper functions.
+	needEnv bool
+
+	// needCSV is set when std.csv lowers to encoding/csv helper
+	// functions and the CsvOptions runtime struct.
+	needCSV bool
+
+	// needCompress is set when std.compress lowers to gzip helpers.
+	needCompress bool
+
+	// needCrypto is set when std.crypto lowers to hashing/HMAC/CSPRNG
+	// helper functions.
+	needCrypto bool
+
+	// needUUID is set when std.uuid lowers to the runtime Uuid type and
+	// generation/parsing helpers.
+	needUUID bool
+
 	// currentRetType tracks the enclosing function's return type so the
 	// `?` lift at let-stmt position can reconstruct the Result with the
 	// correct type parameters when the operand's T differs.
@@ -283,6 +309,52 @@ func (g *gen) run() ([]byte, error) {
 		g.needResult = true
 		g.useAs("net/url", "neturl")
 		g.use("strconv")
+	}
+	if g.needRegex {
+		g.needResult = true
+		g.use("regexp")
+	}
+	if g.needEncoding {
+		g.needResult = true
+		g.useAs("encoding/base64", "stdbase64")
+		g.useAs("encoding/hex", "stdhex")
+		g.useAs("net/url", "neturl")
+		g.useAs("strings", "stdstrings")
+	}
+	if g.needEnv {
+		g.needResult = true
+		g.use("fmt")
+		g.use("os")
+		g.useAs("strings", "stdstrings")
+	}
+	if g.needCSV {
+		g.needResult = true
+		g.useAs("encoding/csv", "stdcsv")
+		g.use("fmt")
+		g.useAs("strings", "stdstrings")
+	}
+	if g.needCompress {
+		g.needResult = true
+		g.useAs("bytes", "stdbytes")
+		g.useAs("compress/gzip", "stdgzip")
+		g.useAs("io", "stdio")
+	}
+	if g.needCrypto {
+		g.useAs("crypto/hmac", "stdhmac")
+		g.useAs("crypto/md5", "stdmd5")
+		g.useAs("crypto/rand", "stdrand")
+		g.useAs("crypto/sha1", "stdsha1")
+		g.useAs("crypto/sha256", "stdsha256")
+		g.useAs("crypto/sha512", "stdsha512")
+		g.useAs("crypto/subtle", "stdsubtle")
+	}
+	if g.needUUID {
+		g.needResult = true
+		g.useAs("crypto/rand", "stdrand")
+		g.useAs("encoding/hex", "stdhex")
+		g.use("fmt")
+		g.useAs("strings", "stdstrings")
+		g.use("time")
 	}
 
 	// 3. Assemble header + body.
@@ -564,6 +636,584 @@ func (u Url) queryValues(key string) []string {
 		return []string{value}
 	}
 	return []string{}
+}
+`)
+	}
+	if g.needRegex {
+		out.WriteString(`
+type Regex struct {
+	re *regexp.Regexp
+}
+
+type RegexMatch struct {
+	text       string
+	start, end int
+}
+
+type Captures struct {
+	values []*string
+	names  map[string]int
+}
+
+func regexCompile(pattern string) Result[Regex, error] {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return Result[Regex, error]{Error: err}
+	}
+	return Result[Regex, error]{Value: Regex{re: re}, IsOk: true}
+}
+
+func (r Regex) matches(text string) bool { return r.re.MatchString(text) }
+
+func (r Regex) find(text string) *RegexMatch {
+	loc := r.re.FindStringIndex(text)
+	if loc == nil {
+		return nil
+	}
+	m := RegexMatch{text: text[loc[0]:loc[1]], start: loc[0], end: loc[1]}
+	return &m
+}
+
+func (r Regex) findAll(text string) []RegexMatch {
+	locs := r.re.FindAllStringIndex(text, -1)
+	out := make([]RegexMatch, 0, len(locs))
+	for _, loc := range locs {
+		out = append(out, RegexMatch{text: text[loc[0]:loc[1]], start: loc[0], end: loc[1]})
+	}
+	return out
+}
+
+func (r Regex) captures(text string) *Captures {
+	idx := r.re.FindStringSubmatchIndex(text)
+	if idx == nil {
+		return nil
+	}
+	c := regexCaptures(r.re, text, idx)
+	return &c
+}
+
+func (r Regex) capturesAll(text string) []Captures {
+	idxs := r.re.FindAllStringSubmatchIndex(text, -1)
+	out := make([]Captures, 0, len(idxs))
+	for _, idx := range idxs {
+		out = append(out, regexCaptures(r.re, text, idx))
+	}
+	return out
+}
+
+func (r Regex) replace(text, replacement string) string {
+	idx := r.re.FindStringSubmatchIndex(text)
+	if idx == nil {
+		return text
+	}
+	dst := make([]byte, 0, len(text)+len(replacement))
+	dst = append(dst, text[:idx[0]]...)
+	dst = r.re.ExpandString(dst, replacement, text, idx)
+	dst = append(dst, text[idx[1]:]...)
+	return string(dst)
+}
+
+func (r Regex) replaceAll(text, replacement string) string {
+	return r.re.ReplaceAllString(text, replacement)
+}
+
+func (r Regex) split(text string) []string { return r.re.Split(text, -1) }
+
+func regexCaptures(re *regexp.Regexp, text string, idx []int) Captures {
+	names := re.SubexpNames()
+	c := Captures{values: make([]*string, len(idx)/2), names: map[string]int{}}
+	for i := range c.values {
+		start, end := idx[2*i], idx[2*i+1]
+		if start >= 0 && end >= 0 {
+			v := text[start:end]
+			c.values[i] = &v
+		}
+		if i < len(names) && names[i] != "" {
+			c.names[names[i]] = i
+		}
+	}
+	return c
+}
+
+func (c Captures) get(i int) *string {
+	if i < 0 || i >= len(c.values) {
+		return nil
+	}
+	return c.values[i]
+}
+
+func (c Captures) named(name string) *string {
+	i, ok := c.names[name]
+	if !ok {
+		return nil
+	}
+	return c.get(i)
+}
+`)
+	}
+	if g.needEncoding {
+		out.WriteString(`
+func encodingBase64Encode(data []byte) string {
+	return stdbase64.StdEncoding.EncodeToString(data)
+}
+
+func encodingBase64Decode(text string) Result[[]byte, any] {
+	data, err := stdbase64.StdEncoding.DecodeString(text)
+	if err != nil {
+		return Result[[]byte, any]{Error: err}
+	}
+	return Result[[]byte, any]{Value: data, IsOk: true}
+}
+
+func encodingBase64URLEncode(data []byte) string {
+	return stdbase64.URLEncoding.EncodeToString(data)
+}
+
+func encodingBase64URLDecode(text string) Result[[]byte, any] {
+	data, err := stdbase64.URLEncoding.DecodeString(text)
+	if err != nil {
+		return Result[[]byte, any]{Error: err}
+	}
+	return Result[[]byte, any]{Value: data, IsOk: true}
+}
+
+func encodingHexEncode(data []byte) string {
+	return stdhex.EncodeToString(data)
+}
+
+func encodingHexDecode(text string) Result[[]byte, any] {
+	data, err := stdhex.DecodeString(text)
+	if err != nil {
+		return Result[[]byte, any]{Error: err}
+	}
+	return Result[[]byte, any]{Value: data, IsOk: true}
+}
+
+func encodingURLEncode(text string) string {
+	return stdstrings.ReplaceAll(neturl.QueryEscape(text), "+", "%20")
+}
+
+func encodingURLDecode(text string) Result[string, any] {
+	text, err := neturl.QueryUnescape(text)
+	if err != nil {
+		return Result[string, any]{Error: err}
+	}
+	return Result[string, any]{Value: text, IsOk: true}
+}
+`)
+	}
+	if g.needEnv {
+		out.WriteString(`
+func envArgs() []string {
+	args := make([]string, len(os.Args)-1)
+	copy(args, os.Args[1:])
+	return args
+}
+
+func envGet(name string) *string {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func envRequire(name string) Result[string, any] {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return Result[string, any]{Error: fmt.Errorf("environment variable %s is not set", name)}
+	}
+	return Result[string, any]{Value: value, IsOk: true}
+}
+
+func envSet(name, value string) Result[struct{}, any] {
+	if err := os.Setenv(name, value); err != nil {
+		return Result[struct{}, any]{Error: err}
+	}
+	return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+}
+
+func envUnset(name string) Result[struct{}, any] {
+	if err := os.Unsetenv(name); err != nil {
+		return Result[struct{}, any]{Error: err}
+	}
+	return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+}
+
+func envVars() map[string]string {
+	out := map[string]string{}
+	for _, pair := range os.Environ() {
+		if key, value, ok := stdstrings.Cut(pair, "="); ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func envCurrentDir() Result[string, any] {
+	dir, err := os.Getwd()
+	if err != nil {
+		return Result[string, any]{Error: err}
+	}
+	return Result[string, any]{Value: dir, IsOk: true}
+}
+
+func envSetCurrentDir(path string) Result[struct{}, any] {
+	if err := os.Chdir(path); err != nil {
+		return Result[struct{}, any]{Error: err}
+	}
+	return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+}
+`)
+	}
+	if g.needCSV {
+		out.WriteString(`
+type CsvOptions struct {
+	delimiter rune
+	quote     rune
+	trimSpace bool
+}
+
+func csvDefaultOptions() CsvOptions {
+	return CsvOptions{delimiter: ',', quote: '"'}
+}
+
+func csvNormalizeOptions(options CsvOptions) CsvOptions {
+	if options.delimiter == 0 {
+		options.delimiter = ','
+	}
+	if options.quote == 0 {
+		options.quote = '"'
+	}
+	return options
+}
+
+func csvEncode(rows [][]string) string {
+	return csvEncodeWith(rows, csvDefaultOptions())
+}
+
+func csvEncodeWith(rows [][]string, options CsvOptions) string {
+	options = csvNormalizeOptions(options)
+	if options.quote != '"' {
+		return csvEncodeCustom(rows, options)
+	}
+	var b stdstrings.Builder
+	w := stdcsv.NewWriter(&b)
+	w.Comma = options.delimiter
+	_ = w.WriteAll(rows)
+	return b.String()
+}
+
+func csvEncodeCustom(rows [][]string, options CsvOptions) string {
+	var b stdstrings.Builder
+	for _, row := range rows {
+		for i, field := range row {
+			if i > 0 {
+				b.WriteRune(options.delimiter)
+			}
+			csvWriteCustomField(&b, field, options)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func csvWriteCustomField(b *stdstrings.Builder, field string, options CsvOptions) {
+	needsQuote := field == "" ||
+		stdstrings.ContainsRune(field, options.delimiter) ||
+		stdstrings.ContainsRune(field, options.quote) ||
+		stdstrings.ContainsAny(field, "\r\n") ||
+		field != stdstrings.TrimSpace(field)
+	if !needsQuote {
+		b.WriteString(field)
+		return
+	}
+	b.WriteRune(options.quote)
+	for _, r := range field {
+		if r == options.quote {
+			b.WriteRune(options.quote)
+		}
+		b.WriteRune(r)
+	}
+	b.WriteRune(options.quote)
+}
+
+func csvDecode(text string) Result[[][]string, any] {
+	return csvDecodeWith(text, csvDefaultOptions())
+}
+
+func csvDecodeWith(text string, options CsvOptions) Result[[][]string, any] {
+	options = csvNormalizeOptions(options)
+	if options.quote != '"' {
+		rows, err := csvDecodeCustom(text, options)
+		if err != nil {
+			return Result[[][]string, any]{Error: err}
+		}
+		return Result[[][]string, any]{Value: rows, IsOk: true}
+	}
+	r := stdcsv.NewReader(stdstrings.NewReader(text))
+	r.Comma = options.delimiter
+	r.TrimLeadingSpace = options.trimSpace
+	r.FieldsPerRecord = -1
+	rows, err := r.ReadAll()
+	if err != nil {
+		return Result[[][]string, any]{Error: err}
+	}
+	return Result[[][]string, any]{Value: rows, IsOk: true}
+}
+
+func csvDecodeCustom(text string, options CsvOptions) ([][]string, error) {
+	var rows [][]string
+	var row []string
+	var field stdstrings.Builder
+	var inQuote, quoted, sawAny, endedRecord bool
+	appendField := func() {
+		value := field.String()
+		if options.trimSpace && !quoted {
+			value = stdstrings.TrimSpace(value)
+		}
+		row = append(row, value)
+		field.Reset()
+		quoted = false
+	}
+	appendRecord := func() {
+		appendField()
+		rows = append(rows, row)
+		row = nil
+		endedRecord = true
+	}
+	runes := []rune(text)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		sawAny = true
+		if inQuote {
+			if r == options.quote {
+				if i+1 < len(runes) && runes[i+1] == options.quote {
+					field.WriteRune(options.quote)
+					i++
+				} else {
+					inQuote = false
+					quoted = true
+				}
+			} else {
+				field.WriteRune(r)
+			}
+			endedRecord = false
+			continue
+		}
+		switch r {
+		case options.quote:
+			if field.Len() == 0 {
+				inQuote = true
+			} else {
+				field.WriteRune(r)
+			}
+			endedRecord = false
+		case options.delimiter:
+			appendField()
+			endedRecord = false
+		case '\r':
+			if i+1 < len(runes) && runes[i+1] == '\n' {
+				i++
+			}
+			appendRecord()
+		case '\n':
+			appendRecord()
+		default:
+			field.WriteRune(r)
+			endedRecord = false
+		}
+	}
+	if inQuote {
+		return nil, fmt.Errorf("csv: unterminated quoted field")
+	}
+	if sawAny && !endedRecord {
+		appendRecord()
+	}
+	return rows, nil
+}
+
+func csvDecodeHeaders(text string) Result[[]map[string]string, any] {
+	rowsRes := csvDecode(text)
+	if !rowsRes.IsOk {
+		return Result[[]map[string]string, any]{Error: rowsRes.Error}
+	}
+	rows := rowsRes.Value
+	if len(rows) == 0 {
+		return Result[[]map[string]string, any]{Value: []map[string]string{}, IsOk: true}
+	}
+	headers := rows[0]
+	out := make([]map[string]string, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		record := map[string]string{}
+		for i, header := range headers {
+			if i < len(row) {
+				record[header] = row[i]
+			} else {
+				record[header] = ""
+			}
+		}
+		out = append(out, record)
+	}
+	return Result[[]map[string]string, any]{Value: out, IsOk: true}
+}
+`)
+	}
+	if g.needCompress {
+		out.WriteString(`
+func compressGzipEncode(data []byte) []byte {
+	var b stdbytes.Buffer
+	w := stdgzip.NewWriter(&b)
+	if _, err := w.Write(data); err != nil {
+		panic(err)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+	return b.Bytes()
+}
+
+func compressGzipDecode(data []byte) Result[[]byte, any] {
+	r, err := stdgzip.NewReader(stdbytes.NewReader(data))
+	if err != nil {
+		return Result[[]byte, any]{Error: err}
+	}
+	out, readErr := stdio.ReadAll(r)
+	closeErr := r.Close()
+	if readErr != nil {
+		return Result[[]byte, any]{Error: readErr}
+	}
+	if closeErr != nil {
+		return Result[[]byte, any]{Error: closeErr}
+	}
+	return Result[[]byte, any]{Value: out, IsOk: true}
+}
+`)
+	}
+	if g.needCrypto {
+		out.WriteString(`
+func cryptoSHA256(data []byte) []byte {
+	sum := stdsha256.Sum256(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoSHA512(data []byte) []byte {
+	sum := stdsha512.Sum512(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoSHA1(data []byte) []byte {
+	sum := stdsha1.Sum(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoMD5(data []byte) []byte {
+	sum := stdmd5.Sum(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoHMACSHA256(key, message []byte) []byte {
+	mac := stdhmac.New(stdsha256.New, key)
+	_, _ = mac.Write(message)
+	return mac.Sum(nil)
+}
+
+func cryptoHMACSHA512(key, message []byte) []byte {
+	mac := stdhmac.New(stdsha512.New, key)
+	_, _ = mac.Write(message)
+	return mac.Sum(nil)
+}
+
+func cryptoRandomBytes(n int) []byte {
+	if n < 0 {
+		panic("crypto.randomBytes called with a negative length")
+	}
+	out := make([]byte, n)
+	if _, err := stdrand.Read(out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func cryptoConstantTimeEq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return stdsubtle.ConstantTimeCompare(a, b) == 1
+}
+`)
+	}
+	if g.needUUID {
+		out.WriteString(`
+type Uuid [16]byte
+
+func uuidV4() Uuid {
+	var u Uuid
+	uuidFillRandom(u[:])
+	u[6] = (u[6] & 0x0f) | 0x40
+	u[8] = (u[8] & 0x3f) | 0x80
+	return u
+}
+
+func uuidV7() Uuid {
+	var u Uuid
+	uuidFillRandom(u[:])
+	ms := uint64(time.Now().UnixMilli())
+	u[0] = byte(ms >> 40)
+	u[1] = byte(ms >> 32)
+	u[2] = byte(ms >> 24)
+	u[3] = byte(ms >> 16)
+	u[4] = byte(ms >> 8)
+	u[5] = byte(ms)
+	u[6] = (u[6] & 0x0f) | 0x70
+	u[8] = (u[8] & 0x3f) | 0x80
+	return u
+}
+
+func uuidParse(text string) Result[Uuid, any] {
+	var compact string
+	switch len(text) {
+	case 32:
+		compact = text
+	case 36:
+		if text[8] != '-' || text[13] != '-' || text[18] != '-' || text[23] != '-' {
+			return Result[Uuid, any]{Error: fmt.Errorf("invalid UUID %q", text)}
+		}
+		compact = stdstrings.ReplaceAll(text, "-", "")
+	default:
+		return Result[Uuid, any]{Error: fmt.Errorf("invalid UUID %q", text)}
+	}
+	var u Uuid
+	if _, err := stdhex.Decode(u[:], []byte(compact)); err != nil {
+		return Result[Uuid, any]{Error: err}
+	}
+	return Result[Uuid, any]{Value: u, IsOk: true}
+}
+
+func uuidNil() Uuid { return Uuid{} }
+
+func uuidFillRandom(dst []byte) {
+	if _, err := stdrand.Read(dst); err != nil {
+		panic(err)
+	}
+}
+
+func (u Uuid) toString() string {
+	var out [36]byte
+	stdhex.Encode(out[0:8], u[0:4])
+	out[8] = '-'
+	stdhex.Encode(out[9:13], u[4:6])
+	out[13] = '-'
+	stdhex.Encode(out[14:18], u[6:8])
+	out[18] = '-'
+	stdhex.Encode(out[19:23], u[8:10])
+	out[23] = '-'
+	stdhex.Encode(out[24:36], u[10:16])
+	return string(out[:])
+}
+
+func (u Uuid) toBytes() []byte {
+	return append([]byte(nil), u[:]...)
 }
 `)
 	}

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -108,6 +108,291 @@ fn testTruth() {
 	}
 }
 
+func TestStdMathBridge(t *testing.T) {
+	goSrc, err := transpile(t, `use std.math
+
+fn main() {
+    let x = math.sin(math.PI / 2.0)
+    let y = math.log(100.0, 10.0)
+    let z = math.sqrt(81.0)
+    println("{math.round(x + y + z)}")
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	if out != "12" {
+		t.Fatalf("stdout = %q, want 12\n--- source ---\n%s", out, goSrc)
+	}
+	for _, want := range []string{"math.Sin", "math.Log", "math.Sqrt", "math.Round", "math.Pi"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.math bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdRegexBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.regex
+
+fn main() {
+    let re = regex.compile("(?P<word>[a-z][a-z][a-z])-([0-9]+)").unwrap()
+    println("{re.matches("abc-123")}")
+    match re.find("xxabc-123yy") {
+        Some(m) -> println("{m.text}:{m.start}:{m.end}"),
+        None -> println("no match"),
+    }
+    let captured = match re.captures("abc-123") {
+        Some(caps) -> match caps.named("word") {
+            Some(word) -> word,
+            None -> "no word",
+        },
+        None -> "no caps",
+    }
+    println(captured)
+    println(re.replace("abc-123 abc-456", "X"))
+    println(re.replaceAll("abc-123 abc-456", "X"))
+    let parts = re.split("oneabc-123twoabc-456three")
+    println(parts[1])
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"true",
+		"abc-123:2:9",
+		"abc",
+		"X abc-456",
+		"X X",
+		"two",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"regexp.Compile", "regexCompile", "type Regex struct", "type Captures struct"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.regex bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdEncodingBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.encoding
+
+fn main() {
+    let raw = encoding.hex.decode("68656c6c6f3f").unwrap()
+    let b64 = encoding.base64.encode(raw)
+    println(b64)
+    println(encoding.hex.encode(encoding.base64.decode(b64).unwrap()))
+    let safe = encoding.url.encode("hello world&foo=bar")
+    println(safe)
+    println(encoding.url.decode(safe).unwrap())
+    let urlB64 = encoding.base64.url.encode(raw)
+    println(urlB64)
+    println(encoding.hex.encode(encoding.base64.url.decode(urlB64).unwrap()))
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"aGVsbG8/",
+		"68656c6c6f3f",
+		"hello%20world%26foo%3Dbar",
+		"hello world&foo=bar",
+		"aGVsbG8_",
+		"68656c6c6f3f",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"stdbase64.StdEncoding", "stdhex.DecodeString", "neturl.QueryEscape"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.encoding bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdEnvBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.env
+
+fn main() {
+    env.set("OSTY_STD_ENV_TEST", "ready").unwrap()
+    match env.get("OSTY_STD_ENV_TEST") {
+        Some(v) -> println(v),
+        None -> println("missing"),
+    }
+    println(env.require("OSTY_STD_ENV_TEST").unwrap())
+    let all = env.vars()
+    println(all["OSTY_STD_ENV_TEST"])
+    env.unset("OSTY_STD_ENV_TEST").unwrap()
+    match env.get("OSTY_STD_ENV_TEST") {
+        Some(v) -> println(v),
+        None -> println("gone"),
+    }
+    println(env.currentDir().unwrap() != "")
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"ready",
+		"ready",
+		"ready",
+		"gone",
+		"true",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"envGet", "envVars", "os.Setenv"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.env bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdCSVBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.csv
+
+fn main() {
+    let rows = [["name", "age"], ["alice", "30"], ["bob", "25"]]
+    let text = csv.encode(rows)
+    let decoded = csv.decode(text).unwrap()
+    println(decoded[1][0])
+    let records = csv.decodeHeaders(text).unwrap()
+    println(records[1]["age"])
+    let opts = csv.CsvOptions { delimiter: ';', quote: '|', trimSpace: true }
+    let semi = csv.encodeWith([["left;side", "right"], ["up", "down"]], opts)
+    let again = csv.decodeWith(semi, opts).unwrap()
+    println(again[0][0])
+    println(again[1][1])
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{"alice", "25", "left;side", "down"}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"stdcsv.NewWriter", "stdcsv.NewReader", "type CsvOptions struct"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.csv bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdCompressBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.compress
+use std.encoding
+
+fn main() {
+    let raw = encoding.hex.decode("68656c6c6f206f737479").unwrap()
+    let zipped = compress.gzip.encode(raw)
+    let round = compress.gzip.decode(zipped).unwrap()
+    println(encoding.hex.encode(round))
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	if out != "68656c6c6f206f737479" {
+		t.Fatalf("stdout = %q, want hex round-trip\n--- source ---\n%s", out, goSrc)
+	}
+	for _, want := range []string{"stdgzip.NewWriter", "stdgzip.NewReader", "compressGzipDecode"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.compress bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdCryptoBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.crypto
+use std.encoding
+
+fn main() {
+    let data = encoding.hex.decode("68656c6c6f").unwrap()
+    let key = encoding.hex.decode("6b6579").unwrap()
+    println(encoding.hex.encode(crypto.sha256(data)))
+    println(encoding.hex.encode(crypto.sha512(data)))
+    println(encoding.hex.encode(crypto.sha1(data)))
+    println(encoding.hex.encode(crypto.md5(data)))
+    println(encoding.hex.encode(crypto.hmac.sha256(key, data)))
+    println(encoding.hex.encode(crypto.hmac.sha512(key, data)))
+    println(crypto.constantTimeEq(crypto.sha256(data), crypto.sha256(data)))
+    let secret = crypto.randomBytes(4)
+    println(crypto.constantTimeEq(secret, secret))
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		"9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+		"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d",
+		"5d41402abc4b2a76b9719d911017c592",
+		"9307b3b915efb5171ff14d8cb55fbcc798c6c0ef1456d66ded1a6aa723a58b7b",
+		"ff06ab36757777815c008d32c8e14a705b4e7bf310351a06a23b612dc4c7433e7757d20525a5593b71020ea2ee162d2311b247e9855862b270122419652c0c92",
+		"true",
+		"true",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"stdsha256.Sum256", "stdhmac.New", "stdrand.Read", "stdsubtle.ConstantTimeCompare"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.crypto bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdUUIDBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.uuid
+use std.encoding
+
+fn main() {
+    let zero = uuid.nil()
+    println(zero.toString())
+    let parsed = uuid.parse("00112233-4455-6677-8899-aabbccddeeff").unwrap()
+    println(parsed.toString())
+    println(encoding.hex.encode(parsed.toBytes()))
+    let id = uuid.v4()
+    let text = id.toString()
+    println(uuid.parse(text).unwrap().toString() == text)
+    println(uuid.v7().toString() != "")
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"00000000-0000-0000-0000-000000000000",
+		"00112233-4455-6677-8899-aabbccddeeff",
+		"00112233445566778899aabbccddeeff",
+		"true",
+		"true",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"type Uuid [16]byte", "uuidV4", "uuidV7", "uuidParse"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.uuid bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
 func TestHelloWorld(t *testing.T) {
 	src := `fn main() {
     println("hello, world")

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -205,6 +205,24 @@ func (g *gen) goNamedType(n *types.Named) string {
 		// runTaskGroup's Wait call.
 		g.needTaskGroup = true
 		return "*TaskGroup"
+	case "Regex":
+		g.needRegex = true
+		return "Regex"
+	case "Match":
+		g.needRegex = true
+		return "RegexMatch"
+	case "Captures":
+		g.needRegex = true
+		return "Captures"
+	case "RegexError":
+		g.needRegex = true
+		return "error"
+	case "CsvOptions":
+		g.needCSV = true
+		return "CsvOptions"
+	case "Uuid":
+		g.needUUID = true
+		return "Uuid"
 	}
 	// User-defined: bare name + optional type args.
 	if len(n.Args) == 0 {
@@ -339,6 +357,24 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 	case "TaskGroup":
 		g.needTaskGroup = true
 		return "*TaskGroup"
+	case "Regex":
+		g.needRegex = true
+		return "Regex"
+	case "Match":
+		g.needRegex = true
+		return "RegexMatch"
+	case "Captures":
+		g.needRegex = true
+		return "Captures"
+	case "RegexError":
+		g.needRegex = true
+		return "error"
+	case "CsvOptions":
+		g.needCSV = true
+		return "CsvOptions"
+	case "Uuid":
+		g.needUUID = true
+		return "Uuid"
 	}
 	if len(n.Args) == 0 {
 		return name

--- a/internal/stdlib/modules/compress.osty
+++ b/internal/stdlib/modules/compress.osty
@@ -1,0 +1,13 @@
+// std.compress — compression codecs.
+
+pub struct Gzip {
+    pub fn encode(self, data: Bytes) -> Bytes {
+        data
+    }
+
+    pub fn decode(self, data: Bytes) -> Result<Bytes, Error> {
+        Ok(data)
+    }
+}
+
+pub let gzip: Gzip = Gzip {}

--- a/internal/stdlib/modules/crypto.osty
+++ b/internal/stdlib/modules/crypto.osty
@@ -1,0 +1,37 @@
+// std.crypto — hashes, HMAC, and secure random bytes.
+
+pub struct Hmac {
+    pub fn sha256(self, key: Bytes, message: Bytes) -> Bytes {
+        message
+    }
+
+    pub fn sha512(self, key: Bytes, message: Bytes) -> Bytes {
+        message
+    }
+}
+
+pub let hmac: Hmac = Hmac {}
+
+pub fn sha256(data: Bytes) -> Bytes {
+    data
+}
+
+pub fn sha512(data: Bytes) -> Bytes {
+    data
+}
+
+pub fn sha1(data: Bytes) -> Bytes {
+    data
+}
+
+pub fn md5(data: Bytes) -> Bytes {
+    data
+}
+
+pub fn randomBytes(n: Int) -> Bytes {
+    []
+}
+
+pub fn constantTimeEq(a: Bytes, b: Bytes) -> Bool {
+    false
+}

--- a/internal/stdlib/modules/csv.osty
+++ b/internal/stdlib/modules/csv.osty
@@ -1,0 +1,27 @@
+// std.csv — RFC 4180 CSV read/write.
+
+pub struct CsvOptions {
+    pub delimiter: Char = ',',
+    pub quote: Char = '"',
+    pub trimSpace: Bool = false,
+}
+
+pub fn encode(rows: List<List<String>>) -> String {
+    ""
+}
+
+pub fn encodeWith(rows: List<List<String>>, options: CsvOptions) -> String {
+    ""
+}
+
+pub fn decode(text: String) -> Result<List<List<String>>, Error> {
+    Ok([])
+}
+
+pub fn decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
+    Ok([])
+}
+
+pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>>, Error> {
+    Ok([])
+}

--- a/internal/stdlib/modules/encoding.osty
+++ b/internal/stdlib/modules/encoding.osty
@@ -1,0 +1,47 @@
+// std.encoding — binary-to-text encodings.
+
+pub struct Base64Url {
+    pub fn encode(self, data: Bytes) -> String {
+        ""
+    }
+
+    pub fn decode(self, text: String) -> Result<Bytes, Error> {
+        Ok([])
+    }
+}
+
+pub struct Base64 {
+    pub url: Base64Url
+
+    pub fn encode(self, data: Bytes) -> String {
+        ""
+    }
+
+    pub fn decode(self, text: String) -> Result<Bytes, Error> {
+        Ok([])
+    }
+}
+
+pub struct Hex {
+    pub fn encode(self, data: Bytes) -> String {
+        ""
+    }
+
+    pub fn decode(self, text: String) -> Result<Bytes, Error> {
+        Ok([])
+    }
+}
+
+pub struct UrlEncoding {
+    pub fn encode(self, text: String) -> String {
+        text
+    }
+
+    pub fn decode(self, text: String) -> Result<String, Error> {
+        Ok(text)
+    }
+}
+
+pub let base64: Base64 = Base64 { url: Base64Url {} }
+pub let hex: Hex = Hex {}
+pub let url: UrlEncoding = UrlEncoding {}

--- a/internal/stdlib/modules/env.osty
+++ b/internal/stdlib/modules/env.osty
@@ -1,0 +1,33 @@
+// std.env — process environment and command-line arguments.
+
+pub fn args() -> List<String> {
+    []
+}
+
+pub fn get(name: String) -> String? {
+    None
+}
+
+pub fn require(name: String) -> Result<String, Error> {
+    Ok("")
+}
+
+pub fn set(name: String, value: String) -> Result<(), Error> {
+    Ok(())
+}
+
+pub fn unset(name: String) -> Result<(), Error> {
+    Ok(())
+}
+
+pub fn vars() -> Map<String, String> {
+    {:}
+}
+
+pub fn currentDir() -> Result<String, Error> {
+    Ok("")
+}
+
+pub fn setCurrentDir(path: String) -> Result<(), Error> {
+    Ok(())
+}

--- a/internal/stdlib/modules/math.osty
+++ b/internal/stdlib/modules/math.osty
@@ -1,0 +1,39 @@
+// std.math — mathematical constants and Float functions.
+
+pub let PI: Float = 3.141592653589793
+pub let E: Float = 2.718281828459045
+pub let TAU: Float = 6.283185307179586
+pub let INFINITY: Float = 1.0 / 0.0
+pub let NAN: Float = 0.0 / 0.0
+
+pub fn sin(x: Float) -> Float { x }
+pub fn cos(x: Float) -> Float { x }
+pub fn tan(x: Float) -> Float { x }
+
+pub fn asin(x: Float) -> Float { x }
+pub fn acos(x: Float) -> Float { x }
+pub fn atan(x: Float) -> Float { x }
+pub fn atan2(y: Float, x: Float) -> Float { y }
+
+pub fn sinh(x: Float) -> Float { x }
+pub fn cosh(x: Float) -> Float { x }
+pub fn tanh(x: Float) -> Float { x }
+
+pub fn exp(x: Float) -> Float { x }
+pub fn log(x: Float, base: Float = 0.0) -> Float { x }
+pub fn log2(x: Float) -> Float { x }
+pub fn log10(x: Float) -> Float { x }
+
+pub fn sqrt(x: Float) -> Float { x }
+pub fn cbrt(x: Float) -> Float { x }
+pub fn pow(x: Float, y: Float) -> Float { x }
+
+pub fn floor(x: Float) -> Float { x }
+pub fn ceil(x: Float) -> Float { x }
+pub fn round(x: Float) -> Float { x }
+pub fn trunc(x: Float) -> Float { x }
+
+pub fn abs(x: Float) -> Float { x }
+pub fn min(a: Float, b: Float) -> Float { a }
+pub fn max(a: Float, b: Float) -> Float { a }
+pub fn hypot(a: Float, b: Float) -> Float { a }

--- a/internal/stdlib/modules/regex.osty
+++ b/internal/stdlib/modules/regex.osty
@@ -1,0 +1,59 @@
+// std.regex — RE2 regular expressions.
+
+pub struct Regex {
+    pub fn matches(self, text: String) -> Bool {
+        false
+    }
+
+    pub fn find(self, text: String) -> Match? {
+        None
+    }
+
+    pub fn findAll(self, text: String) -> List<Match> {
+        []
+    }
+
+    pub fn captures(self, text: String) -> Captures? {
+        None
+    }
+
+    pub fn capturesAll(self, text: String) -> List<Captures> {
+        []
+    }
+
+    pub fn replace(self, text: String, replacement: String) -> String {
+        text
+    }
+
+    pub fn replaceAll(self, text: String, replacement: String) -> String {
+        text
+    }
+
+    pub fn split(self, text: String) -> List<String> {
+        []
+    }
+}
+
+pub struct RegexError {
+    pub message: String
+}
+
+pub struct Match {
+    pub text: String,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct Captures {
+    pub fn get(self, i: Int) -> String? {
+        None
+    }
+
+    pub fn named(self, name: String) -> String? {
+        None
+    }
+}
+
+pub fn compile(pattern: String) -> Result<Regex, RegexError> {
+    Ok(Regex {})
+}

--- a/internal/stdlib/modules/uuid.osty
+++ b/internal/stdlib/modules/uuid.osty
@@ -1,0 +1,27 @@
+// std.uuid — UUID generation and parsing.
+
+pub struct Uuid {
+    pub fn toString(self) -> String {
+        ""
+    }
+
+    pub fn toBytes(self) -> Bytes {
+        []
+    }
+}
+
+pub fn v4() -> Uuid {
+    Uuid {}
+}
+
+pub fn v7() -> Uuid {
+    Uuid {}
+}
+
+pub fn parse(text: String) -> Result<Uuid, Error> {
+    Ok(Uuid {})
+}
+
+pub fn nil() -> Uuid {
+    Uuid {}
+}

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -457,6 +457,405 @@ func TestRandomAndURLModulesResolve(t *testing.T) {
 	}
 }
 
+// TestMathModuleCoverage pins the std.math Tier 2 surface from spec
+// §10.17: constants plus the Float-valued function set. The stdlib
+// loader only needs signatures here; the transpiler owns the Go math
+// lowering for executable code.
+func TestMathModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["math"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.math not loaded")
+	}
+	for _, name := range []string{
+		"PI", "E", "TAU", "INFINITY", "NAN",
+		"sin", "cos", "tan", "asin", "acos", "atan", "atan2",
+		"sinh", "cosh", "tanh", "exp", "log", "log2", "log10",
+		"sqrt", "cbrt", "pow", "floor", "ceil", "round", "trunc",
+		"abs", "min", "max", "hypot",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.math missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.math export %q is not pub", name)
+		}
+	}
+}
+
+// TestMathPackageTypeChecks covers the user-facing front-end path:
+// importing std.math, reading constants, and calling functions should
+// produce concrete Float types instead of opaque package-member errors.
+func TestMathPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.math
+
+pub fn score(r: Float) -> Float {
+    let circle: Float = math.PI * r * r
+    let angle: Float = math.sin(math.PI / 4.0)
+    let scaled: Float = math.log(100.0, 10.0)
+    math.max(circle, angle) + scaled
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.math diagnostic: %s", d.Error())
+		}
+	}
+}
+
+// TestRegexModuleCoverage pins the std.regex surface from spec §10.9:
+// compile, Regex methods, Match fields, and Captures accessors.
+func TestRegexModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["regex"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.regex not loaded")
+	}
+	for _, name := range []string{"Regex", "RegexError", "Match", "Captures", "compile"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.regex missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.regex export %q is not pub", name)
+		}
+	}
+}
+
+func TestRegexPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.regex
+
+pub fn hasWord(text: String) -> Bool {
+    let re = regex.compile("[a-z]+").unwrap()
+    re.matches(text)
+}
+
+pub fn firstWord(text: String) -> String {
+    let re = regex.compile("[a-z]+").unwrap()
+    match re.find(text) {
+        Some(m) -> m.text,
+        None -> "",
+    }
+}
+
+pub fn namedWord(text: String) -> String {
+    let re = regex.compile("(?P<word>[a-z]+)").unwrap()
+    match re.captures(text) {
+        Some(caps) -> match caps.named("word") {
+            Some(word) -> word,
+            None -> "",
+        },
+        None -> "",
+    }
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.regex diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestEncodingModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["encoding"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.encoding not loaded")
+	}
+	for _, name := range []string{"Base64Url", "Base64", "Hex", "UrlEncoding", "base64", "hex", "url"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.encoding missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.encoding export %q is not pub", name)
+		}
+	}
+}
+
+func TestEncodingPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.encoding
+
+pub fn roundTrip(text: String) -> Bool {
+    let raw: Bytes = encoding.hex.decode("6869").unwrap()
+    let b64: String = encoding.base64.encode(raw)
+    let decoded: Bytes = encoding.base64.decode(b64).unwrap()
+    let urlB64: String = encoding.base64.url.encode(decoded)
+    let urlDecoded: Bytes = encoding.base64.url.decode(urlB64).unwrap()
+    let safe: String = encoding.url.encode(text)
+    let back: String = encoding.url.decode(safe).unwrap()
+    back == text
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.encoding diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestEnvModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["env"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.env not loaded")
+	}
+	for _, name := range []string{"args", "get", "require", "set", "unset", "vars", "currentDir", "setCurrentDir"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.env missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.env export %q is not pub", name)
+		}
+	}
+}
+
+func TestEnvPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.env
+
+pub fn smoke(name: String) -> Result<String, Error> {
+    let args: List<String> = env.args()
+    let maybe: String? = env.get(name)
+    env.set(name, "x")?
+    let required: String = env.require(name)?
+    let all: Map<String, String> = env.vars()
+    env.unset(name)?
+    let cwd: String = env.currentDir()?
+    env.setCurrentDir(cwd)?
+    Ok(required)
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.env diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestCSVModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["csv"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.csv not loaded")
+	}
+	for _, name := range []string{"CsvOptions", "encode", "encodeWith", "decode", "decodeHeaders", "decodeWith"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.csv missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.csv export %q is not pub", name)
+		}
+	}
+}
+
+func TestCSVPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.csv
+
+pub fn smoke(text: String) -> Result<String, Error> {
+    let rows: List<List<String>> = csv.decode(text)?
+    let records: List<Map<String, String>> = csv.decodeHeaders(text)?
+    let opts = csv.CsvOptions { delimiter: ';', quote: '"', trimSpace: true }
+    let out: String = csv.encodeWith(rows, opts)
+    let again: List<List<String>> = csv.decodeWith(out, opts)?
+    Ok(csv.encode(again))
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.csv diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestCompressModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["compress"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.compress not loaded")
+	}
+	for _, name := range []string{"Gzip", "gzip"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.compress missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.compress export %q is not pub", name)
+		}
+	}
+}
+
+func TestCompressPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.compress
+
+pub fn roundTrip(data: Bytes) -> Bytes {
+    let zipped: Bytes = compress.gzip.encode(data)
+    compress.gzip.decode(zipped).unwrap()
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.compress diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestCryptoModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["crypto"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.crypto not loaded")
+	}
+	for _, name := range []string{
+		"Hmac", "hmac",
+		"sha256", "sha512", "sha1", "md5",
+		"randomBytes", "constantTimeEq",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.crypto missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.crypto export %q is not pub", name)
+		}
+	}
+}
+
+func TestCryptoPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.crypto
+
+pub fn digest(data: Bytes, key: Bytes) -> Bool {
+    let sha: Bytes = crypto.sha256(data)
+    let mac: Bytes = crypto.hmac.sha256(key, data)
+    let secret: Bytes = crypto.randomBytes(8)
+    crypto.constantTimeEq(sha, crypto.sha256(data)) && secret.len() == 8 && mac.len() == 32
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.crypto diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestUUIDModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["uuid"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.uuid not loaded")
+	}
+	for _, name := range []string{"Uuid", "v4", "v7", "parse", "nil"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.uuid missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.uuid export %q is not pub", name)
+		}
+	}
+}
+
+func TestUUIDPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.uuid
+
+pub fn smoke() -> Bool {
+    let id = uuid.v4()
+    let text: String = id.toString()
+    let parsed = uuid.parse(text).unwrap()
+    let sortable = uuid.v7()
+    let zero = uuid.nil()
+    parsed.toBytes().len() == 16 && sortable.toBytes().len() == 16 && zero.toString() == "00000000-0000-0000-0000-000000000000"
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.uuid diagnostic: %s", d.Error())
+		}
+	}
+}
+
 // TestPrimitivesNotExposedAsModule pins that the `primitives/` stubs
 // populate the Primitives table only — they must not leak as if they
 // were `std.int` or `std.float` modules addressable from user code.


### PR DESCRIPTION
## Summary

Adds several standard library module surfaces and Go bridges:

- `std.math` and `std.regex`
- `std.encoding`, `std.env`, and `std.csv`
- `std.compress`, `std.crypto`, and `std.uuid`

The checker now handles stdlib package-local types and external struct literals used by these modules, while the generator lowers their public APIs to Go runtime helpers.

## Impact

Osty programs can now type-check and execute a much larger Tier 2 stdlib surface, including nested module-like calls such as `encoding.base64.url.decode`, `compress.gzip.decode`, and `crypto.hmac.sha256`.

## Validation

- `go test ./...`
