### PR TITLE
[codex] add automatic Osty source repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ osty resolve FILE|DIR  # name resolution; directory = package mode (--scopes for
 osty check FILE|DIR    # lex + parse + resolve + type-check (diagnostics only)
 osty typecheck FILE    # same as check, plus a per-expression type dump
 osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
-osty fmt FILE          # format to canonical style (see --check, --write)
+osty fmt FILE          # repair + format to canonical style (see --check, --write)
+osty repair FILE       # auto-fix common AI-authored syntax/idiom slips
 osty gen FILE          # transpile to Go source (see -o, --package)
 osty doc PATH          # generate API documentation (HTML + markdown)
 osty ci                # run CI quality checks (signatures, coverage, snapshots)
@@ -194,8 +195,22 @@ Global flags (precede the subcommand):
 
 `fmt`-specific flags (after the subcommand):
 
+`osty fmt` runs the same automatic source repair pass before formatting by
+default, so AI-authored syntax slips are normalized in one command.
+
 - `--check` — exit 1 if the file is not already formatted; show diff
 - `--write` — rewrite the file in place instead of printing
+- `--no-repair` — disable the default automatic source repair pass
+
+`repair`-specific flags (after the subcommand):
+
+- `--check` — exit 1 if the file contains repairable syntax slips
+- `--write` — rewrite the file in place instead of printing
+
+Repairs include common foreign-language carryovers such as `func`/`def`,
+`var`/`const`, `while`, `switch`/`case`, `nil`/`null`, Python word
+operators, JS `console.log`, semicolons, `=>`, trailing chain dots, and
+newline-separated `else`.
 
 `gen`-specific flags (after the subcommand):
 

--- a/cmd/osty/ci_integration_test.go
+++ b/cmd/osty/ci_integration_test.go
@@ -159,6 +159,46 @@ license = "MIT"
 	}
 }
 
+func TestFmtAutoRepairWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte("function main(){ console.log(null); }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runOsty(t, dir, "fmt", "--write", path)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d. output:\n%s", code, out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "fn main() {\n    println(None)\n}\n"
+	if string(got) != want {
+		t.Fatalf("formatted repair mismatch:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFmtNoRepairLeavesParserStrict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte("function main(){ console.log(null); }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runOsty(t, dir, "fmt", "--no-repair", "--write", path)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit without repair. output:\n%s", out)
+	}
+}
+
 func mustWrite(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -9,7 +9,8 @@
 //	osty check <file.osty>     Lex+parse+resolve+type-check diagnostics only.
 //	osty typecheck <file.osty> Alias of `check` that also prints the inferred
 //	                           type of each expression (debugging aid).
-//	osty fmt <file.osty>       Format source to canonical style; see -check/-write.
+//	osty fmt <file.osty>       Repair then format source; see -check/-write/-no-repair.
+//	osty repair <file.osty>    Fix common AI-authored syntax slips; see -check/-write.
 //	osty gen <file.osty>       Transpile to Go (prints to stdout; -o writes to file).
 //	osty doc <path>            Emit markdown API docs for a file or package.
 //	osty lsp                   Run the Language Server Protocol server on stdio.
@@ -26,6 +27,7 @@
 // `fmt` subcommand flags (after the subcommand name):
 //
 //	--check        exit 1 if the file is not already formatted; print diff to stderr
+//	--no-repair    disable the default pre-format source repair pass
 //	--write        overwrite the file in place instead of printing to stdout
 package main
 
@@ -50,6 +52,7 @@ import (
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/pipeline"
+	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/scaffold"
 	"github.com/osty/osty/internal/stdlib"
@@ -81,10 +84,16 @@ func main() {
 	}
 	cmd := args[0]
 	// fmt has its own flag parser because --check/--write only make
-	// sense in that subcommand. Every other subcommand takes exactly
-	// one file path as its second positional arg.
+	// sense in that subcommand. Most front-end subcommands take exactly
+	// one file path as their second positional arg.
 	if cmd == "fmt" {
 		runFmt(args[1:])
+		return
+	}
+	// repair has its own flag parser for --check/--write. It runs before
+	// parse so it can fix syntax slips that would otherwise block fmt/lint.
+	if cmd == "repair" {
+		runRepair(args[1:])
 		return
 	}
 	// gen also has its own flag parser for --out/-o.
@@ -1075,7 +1084,7 @@ func printScopeNode(s *resolve.Scope, depth int) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: osty [flags] (parse|tokens|resolve|check|typecheck|lint|fmt|gen) FILE")
+	fmt.Fprintln(os.Stderr, "usage: osty [flags] (parse|tokens|resolve|check|typecheck|lint|fmt|repair|gen) FILE")
 	fmt.Fprintln(os.Stderr, "       osty new [--lib] NAME     (scaffold a new project)")
 	fmt.Fprintln(os.Stderr, "       osty init [--lib]         (scaffold into the current directory)")
 	fmt.Fprintln(os.Stderr, "       osty build [DIR]          (manifest-driven front end over a project)")
@@ -1114,6 +1123,10 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --explain          append `osty explain CODE` text after each diagnostic block")
 	fmt.Fprintln(os.Stderr, "fmt-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --check            exit 1 if FILE is not already formatted")
+	fmt.Fprintln(os.Stderr, "  --write            overwrite FILE in place")
+	fmt.Fprintln(os.Stderr, "  --no-repair        disable the default pre-format source repair pass")
+	fmt.Fprintln(os.Stderr, "repair-specific flags (after the subcommand):")
+	fmt.Fprintln(os.Stderr, "  --check            exit 1 if FILE would be repaired")
 	fmt.Fprintln(os.Stderr, "  --write            overwrite FILE in place")
 	fmt.Fprintln(os.Stderr, "gen-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  -o PATH            write Go source to PATH instead of stdout")
@@ -1179,7 +1192,7 @@ func printTypes(r *check.Result) {
 
 // runFmt implements the `osty fmt` subcommand. The args slice holds
 // everything on the command line following `fmt` — zero or more of
-// --check/--write, then exactly one file path.
+// --check/--write/--no-repair, then exactly one file path.
 //
 // Exit codes match gofmt conventions:
 //
@@ -1189,14 +1202,20 @@ func printTypes(r *check.Result) {
 func runFmt(args []string) {
 	fs := flag.NewFlagSet("fmt", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty fmt [--check] [--write] FILE")
+		fmt.Fprintln(os.Stderr, "usage: osty fmt [--check] [--write] [--no-repair] FILE")
 	}
-	var checkMode, writeMode bool
+	var checkMode, writeMode, noRepair bool
+	repairMode := true
 	fs.BoolVar(&checkMode, "check", false, "exit 1 if FILE is not already formatted")
 	fs.BoolVar(&checkMode, "c", false, "alias for --check")
 	fs.BoolVar(&writeMode, "write", false, "overwrite FILE in place")
 	fs.BoolVar(&writeMode, "w", false, "alias for --write")
+	fs.BoolVar(&repairMode, "repair", true, "enable automatic source repair before formatting")
+	fs.BoolVar(&noRepair, "no-repair", false, "disable automatic source repair before formatting")
 	_ = fs.Parse(args)
+	if noRepair {
+		repairMode = false
+	}
 	if fs.NArg() != 1 {
 		fs.Usage()
 		os.Exit(2)
@@ -1212,10 +1231,16 @@ func runFmt(args []string) {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	out, diags, ferr := format.Source(src)
+	formatSrc := src
+	var repairs repair.Result
+	if repairMode {
+		repairs = repair.Source(src)
+		formatSrc = repairs.Source
+	}
+	out, diags, ferr := format.Source(formatSrc)
 	if ferr != nil {
 		// Render parse diagnostics so the user can fix them.
-		formatter := &diag.Formatter{Filename: path, Source: src}
+		formatter := &diag.Formatter{Filename: path, Source: formatSrc}
 		if len(diags) > 0 {
 			fmt.Fprintln(os.Stderr, formatter.FormatAll(diags))
 		}
@@ -1225,7 +1250,10 @@ func runFmt(args []string) {
 
 	if checkMode {
 		if !bytes.Equal(src, out) {
-			fmt.Fprintf(os.Stderr, "%s: not formatted\n", path)
+			if repairMode && (len(repairs.Changes) > 0 || repairs.Skipped > 0) {
+				reportRepairSummary(path, repairs)
+			}
+			fmt.Fprintf(os.Stderr, "%s: not repaired/formatted\n", path)
 			os.Exit(1)
 		}
 		return

--- a/cmd/osty/repair.go
+++ b/cmd/osty/repair.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/repair"
+)
+
+// runRepair implements `osty repair`: a small pre-parser source fixer for
+// common AI-authored Osty mistakes.
+func runRepair(args []string) {
+	fs := flag.NewFlagSet("repair", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: osty repair [--check] [--write] FILE")
+	}
+	var checkMode, writeMode bool
+	fs.BoolVar(&checkMode, "check", false, "exit 1 if FILE would be repaired")
+	fs.BoolVar(&checkMode, "c", false, "alias for --check")
+	fs.BoolVar(&writeMode, "write", false, "overwrite FILE in place")
+	fs.BoolVar(&writeMode, "w", false, "alias for --write")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	if checkMode && writeMode {
+		fmt.Fprintln(os.Stderr, "osty repair: --check and --write are mutually exclusive")
+		os.Exit(2)
+	}
+
+	path := fs.Arg(0)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty repair: %v\n", err)
+		os.Exit(1)
+	}
+	res := repair.Source(src)
+	changed := !bytes.Equal(src, res.Source)
+
+	if checkMode {
+		if changed {
+			reportRepairSummary(path, res)
+			os.Exit(1)
+		}
+		return
+	}
+	if writeMode {
+		if changed {
+			if err := os.WriteFile(path, res.Source, 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "osty repair: %v\n", err)
+				os.Exit(1)
+			}
+		}
+		reportRepairSummary(path, res)
+		return
+	}
+
+	if _, err := os.Stdout.Write(res.Source); err != nil {
+		fmt.Fprintf(os.Stderr, "osty repair: %v\n", err)
+		os.Exit(1)
+	}
+	reportRepairSummary(path, res)
+}
+
+func reportRepairSummary(path string, res repair.Result) {
+	for _, c := range res.Changes {
+		fmt.Fprintf(os.Stderr, "%s:%d:%d: repair %s: %s\n",
+			path, c.Pos.Line, c.Pos.Column, c.Kind, c.Message)
+	}
+	if len(res.Changes) == 0 && res.Skipped == 0 {
+		fmt.Fprintf(os.Stderr, "osty repair: %s already clean\n", path)
+		return
+	}
+	if res.Skipped > 0 {
+		fmt.Fprintf(os.Stderr, "osty repair: applied %d repair(s), skipped %d overlapping edit(s)\n",
+			len(res.Changes), res.Skipped)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "osty repair: applied %d repair(s)\n", len(res.Changes))
+}

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/format"
+	"github.com/osty/osty/internal/repair"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
@@ -419,11 +420,11 @@ func (s *Server) handleDefinition(req *rpcRequest) {
 
 // ---- Formatting ----
 
-// handleFormatting runs the same pipeline as `osty fmt` and returns
-// a single TextEdit that replaces the whole document. If the source
-// has parse errors the formatter refuses to produce output; we
-// reply with an empty edit list so the client doesn't rewrite the
-// buffer with `null`.
+// handleFormatting runs the same repair+format pipeline as `osty fmt` and
+// returns a single TextEdit that replaces the whole document. If the source
+// still has parse errors after repair, the formatter refuses to produce
+// output; we reply with an empty edit list so the client doesn't rewrite
+// the buffer with `null`.
 func (s *Server) handleFormatting(req *rpcRequest) {
 	var params DocumentFormattingParams
 	if err := unmarshalParams(req, &params); err != nil {
@@ -435,7 +436,8 @@ func (s *Server) handleFormatting(req *rpcRequest) {
 		replyJSON(s.conn, req.ID, []TextEdit{})
 		return
 	}
-	out, _, err := format.Source(doc.src)
+	repaired := repair.Source(doc.src)
+	out, _, err := format.Source(repaired.Source)
 	if err != nil {
 		replyJSON(s.conn, req.ID, []TextEdit{})
 		return

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -647,6 +647,33 @@ func TestFormattingProducesEdit(t *testing.T) {
 	}
 }
 
+func TestFormattingAutoRepairs(t *testing.T) {
+	sess := startSession(t)
+	defer sess.stop()
+	sess.initialize()
+	sess.openDoc(sampleURI, "function main(){ console.log(null); }\n")
+
+	sess.send("2", "textDocument/formatting", DocumentFormattingParams{
+		TextDocument: TextDocumentIdentifier{URI: sampleURI},
+		Options:      FormattingOptions{TabSize: 4, InsertSpaces: true},
+	})
+	resp := sess.waitResponse("2")
+	if resp.Error != nil {
+		t.Fatalf("formatting error: %+v", resp.Error)
+	}
+	var edits []TextEdit
+	if err := json.Unmarshal(resp.Result, &edits); err != nil {
+		t.Fatalf("decode edits: %v", err)
+	}
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(edits))
+	}
+	want := "fn main() {\n    println(None)\n}\n"
+	if edits[0].NewText != want {
+		t.Fatalf("formatting repair mismatch:\nwant:\n%s\ngot:\n%s", want, edits[0].NewText)
+	}
+}
+
 func TestMethodNotFound(t *testing.T) {
 	sess := startSession(t)
 	defer sess.stop()

--- a/internal/repair/repair.go
+++ b/internal/repair/repair.go
@@ -1,0 +1,633 @@
+// Package repair applies conservative source-level rewrites for common
+// Osty mistakes that prevent parsing.
+package repair
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/osty/osty/internal/lexer"
+	"github.com/osty/osty/internal/token"
+)
+
+// Change describes one user-facing repair. A change may expand to more
+// than one textual edit; for example, moving a trailing method-chain dot
+// deletes it at the old line and inserts it at the continuation line.
+type Change struct {
+	Kind    string
+	Message string
+	Pos     token.Pos
+}
+
+// Result is the output of applying source repairs.
+type Result struct {
+	Source  []byte
+	Changes []Change
+	Skipped int
+}
+
+type edit struct {
+	start int
+	end   int
+	text  string
+}
+
+// Source returns src with every safe, machine-applicable repair applied.
+//
+// The rewrites intentionally cover only syntax that has an unambiguous
+// Osty equivalent:
+//
+//   - match-style fat arrows: `=>` -> `->`
+//   - uppercase base prefixes: `0X` / `0B` / `0O` -> lowercase
+//   - Rust-style member separators: `foo::bar` -> `foo.bar`
+//   - Go/Python/JS-style declaration keywords in declaration shape:
+//     `func` / `function` / `def` -> `fn`, `const` -> `let`,
+//     `var` -> `let mut`, `public` -> `pub`, `private` removed
+//   - Python/JS control-flow spelling: `elif` / `elseif` -> `else if`,
+//     `while` -> `for`, `switch` -> `match`, `case x:` -> `x ->`,
+//     `default:` -> `_ ->`
+//   - Python/JS value and operator spelling: `nil` / `null` -> `None`,
+//     `True` / `False` -> `true` / `false`, `and` / `or` / `not` /
+//     `is` / `is not` -> Osty operators
+//   - Go short declarations: `x := value` -> `let x = value`
+//   - JS logging: `console.log(x)` -> `println(x)`
+//   - statement semicolons: removed or split into newlines
+//   - `}` newline `else`: collapsed to `} else`
+//   - trailing method-chain `.` / `?.`: moved to the continuation line
+func Source(src []byte) Result {
+	normalizedLineEndings := bytes.ContainsRune(src, '\r')
+	src = normalizeNewlines(src)
+	toks := lexer.New(src).Lex()
+
+	var edits []edit
+	var changes []Change
+	if normalizedLineEndings {
+		changes = append(changes, Change{
+			Kind:    "line_endings",
+			Message: "normalize CRLF/CR line endings to LF",
+			Pos:     token.Pos{Line: 1, Column: 1},
+		})
+	}
+	add := func(t token.Token, kind, msg string, editsForChange ...edit) {
+		edits = append(edits, editsForChange...)
+		changes = append(changes, Change{Kind: kind, Message: msg, Pos: t.Pos})
+	}
+
+	for i, t := range toks {
+		switch t.Kind {
+		case token.ILLEGAL:
+			if t.Value == "=>" {
+				add(t, "fat_arrow", "replace `=>` with `->`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "->"})
+			}
+		case token.INT:
+			if prefix := uppercaseBasePrefix(t.Value); prefix != "" && t.Pos.Offset+2 <= len(src) {
+				add(t, "uppercase_base_prefix", "lowercase numeric base prefix",
+					edit{start: t.Pos.Offset + 1, end: t.Pos.Offset + 2, text: prefix})
+			}
+		case token.COLONCOLON:
+			if next := nextSignificant(toks, i+1); next.Kind == token.IDENT {
+				add(t, "member_separator", "replace Rust-style `::` member access with `.`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "."})
+			}
+		case token.IDENT:
+			if colon, assign, ok := shortVarDecl(toks, i); ok {
+				add(t, "short_var_decl", "replace Go-style `:=` declaration with `let ... =`",
+					edit{start: t.Pos.Offset, end: t.Pos.Offset, text: "let "},
+					edit{start: colon.Pos.Offset, end: assign.End.Offset, text: "="})
+			}
+			if repl, ok := declarationKeywordReplacement(t.Value); ok && looksLikeFnDecl(toks, i) {
+				add(t, "function_keyword", "replace function declaration keyword with `fn`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: repl})
+			}
+			if t.Value == "const" && looksLikeLetDecl(toks, i) {
+				add(t, "const_keyword", "replace `const` declaration with `let`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "let"})
+			}
+			if t.Value == "var" && looksLikeLetDecl(toks, i) {
+				add(t, "var_keyword", "replace `var` declaration with `let mut`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "let mut"})
+			}
+			if t.Value == "public" && looksLikeVisibilityDecl(toks, i) {
+				add(t, "visibility_keyword", "replace `public` with `pub`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "pub"})
+			}
+			if t.Value == "private" {
+				if next, ok := nextSignificantIndex(toks, i+1); ok && looksLikeVisibilityTarget(toks[next]) {
+					add(t, "visibility_keyword", "remove redundant `private` keyword",
+						edit{start: t.Pos.Offset, end: toks[next].Pos.Offset})
+				}
+			}
+			if (t.Value == "elif" || t.Value == "elseif") && looksLikeElseIf(toks, i) {
+				add(t, "else_if_keyword", "replace alternate else-if spelling with `else if`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "else if"})
+			}
+			if t.Value == "while" && looksLikeBlockHead(toks, i) {
+				add(t, "while_keyword", "replace `while` with Osty's condition loop `for`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "for"})
+			}
+			if t.Value == "switch" && looksLikeBlockHead(toks, i) {
+				add(t, "switch_keyword", "replace `switch` with `match`",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: "match"})
+			}
+			if t.Value == "case" {
+				if next, colon, ok := caseArmColon(toks, i); ok {
+					add(t, "case_arm", "replace `case` arm syntax with Osty match arm syntax",
+						edit{start: t.Pos.Offset, end: toks[next].Pos.Offset},
+						edit{start: colon.Pos.Offset, end: colon.End.Offset, text: " ->"})
+				}
+			}
+			if t.Value == "default" {
+				if colon, ok := defaultArmColon(toks, i); ok {
+					add(t, "default_arm", "replace `default` arm with `_ ->`",
+						edit{start: t.Pos.Offset, end: t.End.Offset, text: "_"},
+						edit{start: colon.Pos.Offset, end: colon.End.Offset, text: " ->"})
+				}
+			}
+			if repl, ok := valueIdentifierReplacement(t.Value); ok && looksLikeValueUse(toks, i) {
+				add(t, "value_spelling", "replace foreign literal spelling with Osty spelling",
+					edit{start: t.Pos.Offset, end: t.End.Offset, text: repl})
+			}
+			if repl, ok := wordOperatorReplacement(toks, i); ok {
+				add(t, "word_operator", "replace word operator with Osty operator",
+					edit{start: t.Pos.Offset, end: wordOperatorEnd(toks, i), text: repl})
+			}
+			if logTok, ok := consoleLogCall(toks, i); ok {
+				add(t, "console_log", "replace `console.log` with `println`",
+					edit{start: t.Pos.Offset, end: logTok.End.Offset, text: "println"})
+			}
+		case token.SEMICOLON:
+			add(t, "semicolon", "repair statement semicolon",
+				semicolonEdit(src, toks, i))
+		case token.RBRACE:
+			if elseTok, ok := newlineSeparatedElse(src, toks, i); ok {
+				add(elseTok, "else_newline", "move `else` onto the closing-brace line",
+					edit{start: t.End.Offset, end: elseTok.Pos.Offset, text: " "})
+			}
+		case token.DOT, token.QDOT:
+			if next := nextSignificant(toks, i+1); canMoveTrailingChainDot(src, t, next) {
+				text := "."
+				if t.Kind == token.QDOT {
+					text = "?."
+				}
+				add(t, "trailing_chain_dot", "move method-chain dot to the continuation line",
+					edit{start: t.Pos.Offset, end: t.End.Offset},
+					edit{start: next.Pos.Offset, end: next.Pos.Offset, text: text})
+			}
+		}
+	}
+
+	out, skipped := apply(src, edits)
+	return Result{Source: out, Changes: changes, Skipped: skipped}
+}
+
+func uppercaseBasePrefix(value string) string {
+	if len(value) < 2 || value[0] != '0' {
+		return ""
+	}
+	switch value[1] {
+	case 'X':
+		return "x"
+	case 'B':
+		return "b"
+	case 'O':
+		return "o"
+	default:
+		return ""
+	}
+}
+
+func declarationKeywordReplacement(value string) (string, bool) {
+	switch value {
+	case "func", "function", "def":
+		return "fn", true
+	default:
+		return "", false
+	}
+}
+
+func looksLikeFnDecl(toks []token.Token, i int) bool {
+	next := nextSignificant(toks, i+1)
+	if next.Kind != token.IDENT {
+		return false
+	}
+	afterName := nextSignificantFromToken(toks, next, i+2)
+	if afterName.Kind != token.LPAREN {
+		return false
+	}
+	prev := prevSignificant(toks, i-1)
+	return prev.Kind != token.DOT && prev.Kind != token.QDOT
+}
+
+func looksLikeLetDecl(toks []token.Token, i int) bool {
+	next := nextSignificant(toks, i+1)
+	if next.Kind != token.IDENT {
+		return false
+	}
+	for j := i + 2; j < len(toks); j++ {
+		switch toks[j].Kind {
+		case token.NEWLINE, token.EOF, token.RBRACE:
+			return false
+		case token.ASSIGN:
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeVisibilityDecl(toks []token.Token, i int) bool {
+	next := nextSignificant(toks, i+1)
+	return looksLikeVisibilityTarget(next)
+}
+
+func looksLikeVisibilityTarget(t token.Token) bool {
+	switch t.Kind {
+	case token.FN, token.STRUCT, token.ENUM, token.INTERFACE, token.TYPE, token.LET:
+		return true
+	case token.IDENT:
+		_, isFn := declarationKeywordReplacement(t.Value)
+		return isFn || t.Value == "const" || t.Value == "var"
+	default:
+		return false
+	}
+}
+
+func looksLikeElseIf(toks []token.Token, i int) bool {
+	next := nextSignificant(toks, i+1)
+	return startsExpr(next.Kind)
+}
+
+func looksLikeBlockHead(toks []token.Token, i int) bool {
+	next := nextSignificant(toks, i+1)
+	if !startsExpr(next.Kind) {
+		return false
+	}
+	depth := 0
+	for j := i + 1; j < len(toks); j++ {
+		switch toks[j].Kind {
+		case token.LPAREN, token.LBRACKET:
+			depth++
+		case token.RPAREN, token.RBRACKET:
+			if depth > 0 {
+				depth--
+			}
+		case token.LBRACE:
+			return depth == 0
+		case token.NEWLINE, token.EOF:
+			return false
+		}
+	}
+	return false
+}
+
+func shortVarDecl(toks []token.Token, i int) (token.Token, token.Token, bool) {
+	if !atStatementStart(toks, i) {
+		return token.Token{}, token.Token{}, false
+	}
+	colonIdx, ok := nextSignificantIndex(toks, i+1)
+	if !ok || toks[colonIdx].Kind != token.COLON {
+		return token.Token{}, token.Token{}, false
+	}
+	assignIdx, ok := nextSignificantIndex(toks, colonIdx+1)
+	if !ok || toks[assignIdx].Kind != token.ASSIGN {
+		return token.Token{}, token.Token{}, false
+	}
+	return toks[colonIdx], toks[assignIdx], true
+}
+
+func atStatementStart(toks []token.Token, i int) bool {
+	prev := prevSignificant(toks, i-1)
+	switch prev.Kind {
+	case token.EOF, token.NEWLINE, token.LBRACE, token.RBRACE:
+		return true
+	default:
+		return false
+	}
+}
+
+func valueIdentifierReplacement(value string) (string, bool) {
+	switch value {
+	case "nil", "null":
+		return "None", true
+	case "True":
+		return "true", true
+	case "False":
+		return "false", true
+	default:
+		return "", false
+	}
+}
+
+func looksLikeValueUse(toks []token.Token, i int) bool {
+	next := nextSignificant(toks, i+1)
+	prev := prevSignificant(toks, i-1)
+	if next.Kind == token.COLON && !(prev.Kind == token.IDENT && prev.Value == "case") {
+		return false
+	}
+	if next.Kind == token.ASSIGN {
+		return false
+	}
+	if prev.Kind == token.LET || prev.Kind == token.FN || prev.Kind == token.MUT ||
+		prev.Kind == token.PUB || prev.Kind == token.DOT || prev.Kind == token.QDOT {
+		return false
+	}
+	return true
+}
+
+func wordOperatorReplacement(toks []token.Token, i int) (string, bool) {
+	t := toks[i]
+	prev := prevSignificant(toks, i-1)
+	next := nextSignificant(toks, i+1)
+	switch t.Value {
+	case "and":
+		if tokenEndsExpr(prev) && tokenStartsExpr(next) {
+			return "&&", true
+		}
+	case "or":
+		if tokenEndsExpr(prev) && tokenStartsExpr(next) {
+			return "||", true
+		}
+	case "not":
+		if prev.Kind == token.IDENT && prev.Value == "is" {
+			return "", false
+		}
+		if tokenStartsExpr(next) && !tokenEndsExpr(prev) {
+			return "!", true
+		}
+	case "is":
+		if !tokenEndsExpr(prev) {
+			return "", false
+		}
+		if next.Kind == token.IDENT && next.Value == "not" {
+			afterNot := nextSignificantFromToken(toks, next, i+2)
+			if tokenStartsExpr(afterNot) {
+				return "!=", true
+			}
+		}
+		if tokenStartsExpr(next) {
+			return "==", true
+		}
+	}
+	return "", false
+}
+
+func wordOperatorEnd(toks []token.Token, i int) int {
+	if toks[i].Value != "is" {
+		return toks[i].End.Offset
+	}
+	next := nextSignificant(toks, i+1)
+	if next.Kind == token.IDENT && next.Value == "not" {
+		return next.End.Offset
+	}
+	return toks[i].End.Offset
+}
+
+func consoleLogCall(toks []token.Token, i int) (token.Token, bool) {
+	if toks[i].Value != "console" {
+		return token.Token{}, false
+	}
+	dotIdx, ok := nextSignificantIndex(toks, i+1)
+	if !ok || toks[dotIdx].Kind != token.DOT {
+		return token.Token{}, false
+	}
+	logIdx, ok := nextSignificantIndex(toks, dotIdx+1)
+	if !ok || toks[logIdx].Kind != token.IDENT || toks[logIdx].Value != "log" {
+		return token.Token{}, false
+	}
+	callIdx, ok := nextSignificantIndex(toks, logIdx+1)
+	if !ok || toks[callIdx].Kind != token.LPAREN {
+		return token.Token{}, false
+	}
+	return toks[logIdx], true
+}
+
+func caseArmColon(toks []token.Token, i int) (nextIdx int, colon token.Token, ok bool) {
+	nextIdx, ok = nextSignificantIndex(toks, i+1)
+	if !ok || toks[nextIdx].Kind == token.COLON || toks[nextIdx].Kind == token.NEWLINE {
+		return 0, token.Token{}, false
+	}
+	colon, ok = findArmColon(toks, nextIdx)
+	return nextIdx, colon, ok
+}
+
+func defaultArmColon(toks []token.Token, i int) (token.Token, bool) {
+	next := nextSignificant(toks, i+1)
+	if next.Kind == token.COLON {
+		return next, true
+	}
+	return token.Token{}, false
+}
+
+func findArmColon(toks []token.Token, start int) (token.Token, bool) {
+	depth := 0
+	for j := start; j < len(toks); j++ {
+		switch toks[j].Kind {
+		case token.LPAREN, token.LBRACKET, token.LBRACE:
+			depth++
+		case token.RPAREN, token.RBRACKET, token.RBRACE:
+			if depth == 0 {
+				return token.Token{}, false
+			}
+			depth--
+		case token.COLON:
+			if depth == 0 {
+				return toks[j], true
+			}
+		case token.ARROW:
+			return token.Token{}, false
+		case token.NEWLINE, token.EOF:
+			return token.Token{}, false
+		}
+	}
+	return token.Token{}, false
+}
+
+func semicolonEdit(src []byte, toks []token.Token, i int) edit {
+	next := nextSignificant(toks, i+1)
+	if next.Kind != token.EOF && next.Kind != token.RBRACE && next.Pos.Line == toks[i].Pos.Line {
+		return edit{
+			start: toks[i].Pos.Offset,
+			end:   next.Pos.Offset,
+			text:  "\n" + lineIndent(src, toks[i].Pos.Offset),
+		}
+	}
+	return edit{start: toks[i].Pos.Offset, end: toks[i].End.Offset}
+}
+
+func lineIndent(src []byte, offset int) string {
+	start := offset
+	for start > 0 && src[start-1] != '\n' {
+		start--
+	}
+	end := start
+	for end < len(src) {
+		switch src[end] {
+		case ' ', '\t':
+			end++
+		default:
+			return string(src[start:end])
+		}
+	}
+	return string(src[start:end])
+}
+
+func nextSignificant(toks []token.Token, start int) token.Token {
+	if i, ok := nextSignificantIndex(toks, start); ok {
+		return toks[i]
+	}
+	return token.Token{Kind: token.EOF}
+}
+
+func nextSignificantIndex(toks []token.Token, start int) (int, bool) {
+	for i := start; i < len(toks); i++ {
+		if toks[i].Kind != token.NEWLINE {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func nextSignificantFromToken(toks []token.Token, tok token.Token, fallback int) token.Token {
+	for i := fallback; i < len(toks); i++ {
+		if toks[i].Pos.Offset < tok.End.Offset {
+			continue
+		}
+		if toks[i].Kind != token.NEWLINE {
+			return toks[i]
+		}
+	}
+	return token.Token{Kind: token.EOF}
+}
+
+func startsExpr(k token.Kind) bool {
+	switch k {
+	case token.IDENT, token.INT, token.FLOAT, token.STRING, token.RAWSTRING,
+		token.CHAR, token.BYTE, token.LPAREN, token.LBRACKET, token.LBRACE,
+		token.IF, token.MATCH, token.BITOR, token.OR, token.MINUS,
+		token.NOT, token.BITNOT, token.DOTDOT, token.DOTDOTEQ:
+		return true
+	default:
+		return false
+	}
+}
+
+func tokenStartsExpr(t token.Token) bool {
+	if t.Kind == token.IDENT {
+		switch t.Value {
+		case "and", "or", "is", "case", "default", "elif", "elseif":
+			return false
+		}
+	}
+	return startsExpr(t.Kind)
+}
+
+func endsExpr(k token.Kind) bool {
+	switch k {
+	case token.IDENT, token.INT, token.FLOAT, token.STRING, token.RAWSTRING,
+		token.CHAR, token.BYTE, token.RPAREN, token.RBRACKET, token.RBRACE,
+		token.QUESTION:
+		return true
+	default:
+		return false
+	}
+}
+
+func tokenEndsExpr(t token.Token) bool {
+	if t.Kind == token.IDENT {
+		switch t.Value {
+		case "and", "or", "not", "is", "case", "default", "elif", "elseif":
+			return false
+		}
+	}
+	return endsExpr(t.Kind)
+}
+
+func prevSignificant(toks []token.Token, start int) token.Token {
+	for i := start; i >= 0; i-- {
+		if toks[i].Kind != token.NEWLINE {
+			return toks[i]
+		}
+	}
+	return token.Token{Kind: token.EOF}
+}
+
+func newlineSeparatedElse(src []byte, toks []token.Token, i int) (token.Token, bool) {
+	j := i + 1
+	sawNewline := false
+	for j < len(toks) && toks[j].Kind == token.NEWLINE {
+		sawNewline = true
+		j++
+	}
+	if !sawNewline || j >= len(toks) || toks[j].Kind != token.ELSE {
+		return token.Token{}, false
+	}
+	if !allWhitespace(src[toks[i].End.Offset:toks[j].Pos.Offset]) {
+		return token.Token{}, false
+	}
+	return toks[j], true
+}
+
+func canMoveTrailingChainDot(src []byte, dot token.Token, next token.Token) bool {
+	if next.Kind != token.IDENT {
+		return false
+	}
+	if dot.End.Offset > next.Pos.Offset {
+		return false
+	}
+	gap := src[dot.End.Offset:next.Pos.Offset]
+	return bytes.ContainsRune(gap, '\n') && allWhitespace(gap)
+}
+
+func allWhitespace(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r', '\v', '\f':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func apply(src []byte, edits []edit) ([]byte, int) {
+	if len(edits) == 0 {
+		return src, 0
+	}
+	sort.SliceStable(edits, func(i, j int) bool {
+		if edits[i].start != edits[j].start {
+			return edits[i].start > edits[j].start
+		}
+		return edits[i].end > edits[j].end
+	})
+	out := append([]byte(nil), src...)
+	lastStart := len(src) + 1
+	skipped := 0
+	for _, e := range edits {
+		if e.start < 0 || e.end < e.start || e.end > len(src) || e.end > lastStart {
+			skipped++
+			continue
+		}
+		out = append(append([]byte(nil), out[:e.start]...), append([]byte(e.text), out[e.end:]...)...)
+		lastStart = e.start
+	}
+	return out, skipped
+}
+
+func normalizeNewlines(src []byte) []byte {
+	if !bytes.ContainsRune(src, '\r') {
+		return src
+	}
+	out := make([]byte, 0, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] == '\r' {
+			if i+1 < len(src) && src[i+1] == '\n' {
+				continue
+			}
+			out = append(out, '\n')
+			continue
+		}
+		out = append(out, src[i])
+	}
+	return out
+}

--- a/internal/repair/repair_test.go
+++ b/internal/repair/repair_test.go
@@ -1,0 +1,155 @@
+package repair_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/repair"
+)
+
+func TestSourceRepairsCommonAIMistakes(t *testing.T) {
+	src := []byte(`function main() {
+    let n = 0X1F;
+    let x = foo::bar();
+    match n {
+        1 => "one"
+        _ => "other"
+    }
+    if ok {
+        println("yes")
+    }
+    else {
+        println("no")
+    }
+    xs.
+        map(|x| x)
+    opt?.
+        value()
+}
+`)
+	got := string(repair.Source(src).Source)
+	want := `fn main() {
+    let n = 0x1F
+    let x = foo.bar()
+    match n {
+        1 -> "one"
+        _ -> "other"
+    }
+    if ok {
+        println("yes")
+    } else {
+        println("no")
+    }
+    xs
+        .map(|x| x)
+    opt
+        ?.value()
+}
+`
+	if got != want {
+		t.Fatalf("repair mismatch:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestSourceLeavesStringsCommentsAndTurbofishAlone(t *testing.T) {
+	src := []byte(`fn main() {
+    let s = "=> 0X1F foo::bar();"
+    // => 0X1F foo::bar();
+    let n = parse::<Int>("42")
+}
+`)
+	res := repair.Source(src)
+	got := string(res.Source)
+	if got != string(src) {
+		t.Fatalf("unexpected repair:\n%s", got)
+	}
+	if len(res.Changes) != 0 {
+		t.Fatalf("expected no changes, got %d", len(res.Changes))
+	}
+}
+
+func TestSourceRepairsFuncKeywordInDeclarationShape(t *testing.T) {
+	src := []byte("pub func greet(name: String) { println(name) }\n")
+	got := string(repair.Source(src).Source)
+	if want := "pub fn greet(name: String) { println(name) }\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestSourceIsIdempotent(t *testing.T) {
+	src := []byte(`func main() {
+    let n = 0B1010;
+    if ok {
+        println("ok")
+    }
+    else {
+        println("no")
+    }
+}
+`)
+	once := repair.Source(src).Source
+	twice := repair.Source(once).Source
+	if string(once) != string(twice) {
+		t.Fatalf("not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+	if strings.Contains(string(once), "0B") || strings.Contains(string(once), ";") {
+		t.Fatalf("repair missed obvious syntax: %s", once)
+	}
+}
+
+func TestSourceRepairsForeignControlFlowAndOperators(t *testing.T) {
+	src := []byte(`public def main() {
+    var keepGoing = True; const fallback = null
+    while keepGoing and not done {
+        if current is not nil {
+            console.log(current);
+        } elif fallback is None {
+            console.log("fallback")
+        }
+    }
+}
+`)
+	got := string(repair.Source(src).Source)
+	want := `pub fn main() {
+    let mut keepGoing = true
+    let fallback = None
+    for keepGoing && ! done {
+        if current != None {
+            println(current)
+        } else if fallback == None {
+            println("fallback")
+        }
+    }
+}
+`
+	if got != want {
+		t.Fatalf("repair mismatch:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestSourceRepairsSwitchCaseAndShortVar(t *testing.T) {
+	src := []byte(`fn main() {
+    value := read()
+    switch value {
+        case null:
+            println("one")
+        default:
+            println("other")
+    }
+}
+`)
+	got := string(repair.Source(src).Source)
+	want := `fn main() {
+    let value = read()
+    match value {
+        None ->
+            println("one")
+        _ ->
+            println("other")
+    }
+}
+`
+	if got != want {
+		t.Fatalf("repair mismatch:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add a token-based source repair pass for common AI-authored Osty syntax and idiom slips.
- Add `osty repair` as an explicit command and run the same repair pass automatically before `osty fmt`.
- Apply repair before LSP formatting so editor formatting matches CLI behavior.

## Impact

Users can paste AI-authored or foreign-language-flavored Osty and run `osty fmt --write` without remembering a separate repair flag. Strict formatter behavior remains available via `osty fmt --no-repair`.

## Validation

- `go test ./cmd/osty ./internal/repair ./internal/lsp`
- `go test ./...`
- Manual `go run ./cmd/osty fmt --write` check for `function main(){ console.log(null); }`
- Manual `go run ./cmd/osty fmt --no-repair --write` check for strict parse failure
