### PR TITLE
[codex] harden CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,30 @@ jobs:
       - name: Download modules
         run: go mod download
 
+      - name: Format
+        run: |
+          unformatted="$(gofmt -l $(git ls-files '*.go'))"
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: Build
         run: go build ./...
+
+      - name: Osty repair
+        run: |
+          osty_bin="$(mktemp -d)/osty"
+          go build -o "$osty_bin" ./cmd/osty
+          while IFS= read -r file; do
+            case "$file" in
+              testdata/spec/negative/*) continue ;;
+            esac
+            "$osty_bin" repair --check "$file"
+          done < <(git ls-files '*.osty')
+
+      - name: Osty CI
+        run: go run ./cmd/osty ci .
 
       - name: Vet
         run: go vet ./...

--- a/cmd/codesdoc/main.go
+++ b/cmd/codesdoc/main.go
@@ -136,7 +136,7 @@ type parsedDoc struct {
 
 // phaseGroup bundles consecutive codeEntries that share a phase heading.
 type phaseGroup struct {
-	Heading string       // e.g. "Lexical (E0001–E0099)"
+	Heading string // e.g. "Lexical (E0001–E0099)"
 	Entries []codeEntry
 }
 
@@ -206,7 +206,7 @@ func parseCodes(filename string, src []byte) (*parsedDocs, error) {
 		// with all the specs, in source order. Then walk.
 		type event struct {
 			pos     token.Pos
-			heading string       // non-empty for phase headings
+			heading string // non-empty for phase headings
 			spec    *ast.ValueSpec
 		}
 		var events []event

--- a/cmd/osty/test_discovery_test.go
+++ b/cmd/osty/test_discovery_test.go
@@ -50,7 +50,7 @@ fn test() {
 	entries := discoverTests(file, "inline.osty")
 
 	want := map[string]testKind{
-		"testBasic": kindTest,
+		"testBasic":  kindTest,
 		"benchBasic": kindBench,
 		"test":       kindTest,
 	}

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -198,14 +198,14 @@ type Decorated interface {
 
 // UseDecl represents `use path`, `use path as alias`, and FFI forms.
 type UseDecl struct {
-	PosV      token.Pos
-	EndV      token.Pos
-	Path      []string // dot-separated path, or single entry with slashes for URLs
-	RawPath   string   // e.g. "github.com/user/lib" as written
-	Alias     string   // optional `as alias`
-	IsGoFFI   bool     // `use go "..."`
-	GoPath    string   // go import path
-	GoBody    []Decl   // declarations inside `{ ... }`
+	PosV    token.Pos
+	EndV    token.Pos
+	Path    []string // dot-separated path, or single entry with slashes for URLs
+	RawPath string   // e.g. "github.com/user/lib" as written
+	Alias   string   // optional `as alias`
+	IsGoFFI bool     // `use go "..."`
+	GoPath  string   // go import path
+	GoBody  []Decl   // declarations inside `{ ... }`
 }
 
 func (*UseDecl) declNode()        {}
@@ -221,16 +221,16 @@ type FnDecl struct {
 	Generics    []*GenericParam
 	Recv        *Receiver // non-nil for methods
 	Params      []*Param
-	ReturnType  Type      // nil == unit ()
-	Body        *Block    // nil for interface-declared methods without default
+	ReturnType  Type   // nil == unit ()
+	Body        *Block // nil for interface-declared methods without default
 	DocComment  string
 	Annotations []*Annotation
 }
 
-func (*FnDecl) declNode()           {}
-func (f *FnDecl) Pos() token.Pos    { return f.PosV }
-func (f *FnDecl) End() token.Pos    { return f.EndV }
-func (f *FnDecl) Doc() string       { return f.DocComment }
+func (*FnDecl) declNode()               {}
+func (f *FnDecl) Pos() token.Pos        { return f.PosV }
+func (f *FnDecl) End() token.Pos        { return f.EndV }
+func (f *FnDecl) Doc() string           { return f.DocComment }
 func (f *FnDecl) Annots() []*Annotation { return f.Annotations }
 
 // Receiver describes the `self` or `mut self` first parameter of a method.
@@ -310,10 +310,10 @@ type StructDecl struct {
 	Annotations []*Annotation
 }
 
-func (*StructDecl) declNode()           {}
-func (s *StructDecl) Pos() token.Pos    { return s.PosV }
-func (s *StructDecl) End() token.Pos    { return s.EndV }
-func (s *StructDecl) Doc() string       { return s.DocComment }
+func (*StructDecl) declNode()               {}
+func (s *StructDecl) Pos() token.Pos        { return s.PosV }
+func (s *StructDecl) End() token.Pos        { return s.EndV }
+func (s *StructDecl) Doc() string           { return s.DocComment }
 func (s *StructDecl) Annots() []*Annotation { return s.Annotations }
 
 // Field is a struct field.
@@ -359,10 +359,10 @@ type EnumDecl struct {
 	Annotations []*Annotation
 }
 
-func (*EnumDecl) declNode()           {}
-func (e *EnumDecl) Pos() token.Pos    { return e.PosV }
-func (e *EnumDecl) End() token.Pos    { return e.EndV }
-func (e *EnumDecl) Doc() string       { return e.DocComment }
+func (*EnumDecl) declNode()               {}
+func (e *EnumDecl) Pos() token.Pos        { return e.PosV }
+func (e *EnumDecl) End() token.Pos        { return e.EndV }
+func (e *EnumDecl) Doc() string           { return e.DocComment }
 func (e *EnumDecl) Annots() []*Annotation { return e.Annotations }
 
 // Variant is one enum variant: bare or tuple-like.
@@ -399,10 +399,10 @@ type InterfaceDecl struct {
 	Annotations []*Annotation
 }
 
-func (*InterfaceDecl) declNode()           {}
-func (i *InterfaceDecl) Pos() token.Pos    { return i.PosV }
-func (i *InterfaceDecl) End() token.Pos    { return i.EndV }
-func (i *InterfaceDecl) Doc() string       { return i.DocComment }
+func (*InterfaceDecl) declNode()               {}
+func (i *InterfaceDecl) Pos() token.Pos        { return i.PosV }
+func (i *InterfaceDecl) End() token.Pos        { return i.EndV }
+func (i *InterfaceDecl) Doc() string           { return i.DocComment }
 func (i *InterfaceDecl) Annots() []*Annotation { return i.Annotations }
 
 // TypeAliasDecl — `type Name<T> = ...`.
@@ -417,10 +417,10 @@ type TypeAliasDecl struct {
 	Annotations []*Annotation
 }
 
-func (*TypeAliasDecl) declNode()           {}
-func (t *TypeAliasDecl) Pos() token.Pos    { return t.PosV }
-func (t *TypeAliasDecl) End() token.Pos    { return t.EndV }
-func (t *TypeAliasDecl) Doc() string       { return t.DocComment }
+func (*TypeAliasDecl) declNode()               {}
+func (t *TypeAliasDecl) Pos() token.Pos        { return t.PosV }
+func (t *TypeAliasDecl) End() token.Pos        { return t.EndV }
+func (t *TypeAliasDecl) Doc() string           { return t.DocComment }
 func (t *TypeAliasDecl) Annots() []*Annotation { return t.Annotations }
 
 // LetDecl — `pub let NAME = ...` at top level.
@@ -441,10 +441,10 @@ type LetDecl struct {
 	Annotations []*Annotation
 }
 
-func (*LetDecl) declNode()           {}
-func (l *LetDecl) Pos() token.Pos    { return l.PosV }
-func (l *LetDecl) End() token.Pos    { return l.EndV }
-func (l *LetDecl) Doc() string       { return l.DocComment }
+func (*LetDecl) declNode()               {}
+func (l *LetDecl) Pos() token.Pos        { return l.PosV }
+func (l *LetDecl) End() token.Pos        { return l.EndV }
+func (l *LetDecl) Doc() string           { return l.DocComment }
 func (l *LetDecl) Annots() []*Annotation { return l.Annotations }
 
 // ==== Types ====
@@ -459,7 +459,7 @@ type NamedType struct {
 	Args []Type
 }
 
-func (*NamedType) typeNode()       {}
+func (*NamedType) typeNode()        {}
 func (n *NamedType) Pos() token.Pos { return n.PosV }
 func (n *NamedType) End() token.Pos { return n.EndV }
 
@@ -470,7 +470,7 @@ type OptionalType struct {
 	Inner Type
 }
 
-func (*OptionalType) typeNode()       {}
+func (*OptionalType) typeNode()        {}
 func (o *OptionalType) Pos() token.Pos { return o.PosV }
 func (o *OptionalType) End() token.Pos { return o.EndV }
 
@@ -481,7 +481,7 @@ type TupleType struct {
 	Elems []Type
 }
 
-func (*TupleType) typeNode()       {}
+func (*TupleType) typeNode()        {}
 func (t *TupleType) Pos() token.Pos { return t.PosV }
 func (t *TupleType) End() token.Pos { return t.EndV }
 
@@ -493,7 +493,7 @@ type FnType struct {
 	ReturnType Type // nil == unit ()
 }
 
-func (*FnType) typeNode()       {}
+func (*FnType) typeNode()        {}
 func (f *FnType) Pos() token.Pos { return f.PosV }
 func (f *FnType) End() token.Pos { return f.EndV }
 
@@ -507,8 +507,8 @@ type Block struct {
 	Stmts []Stmt
 }
 
-func (*Block) stmtNode()      {}
-func (*Block) exprNode()      {}
+func (*Block) stmtNode()        {}
+func (*Block) exprNode()        {}
 func (b *Block) Pos() token.Pos { return b.PosV }
 func (b *Block) End() token.Pos { return b.EndV }
 
@@ -527,7 +527,7 @@ type LetStmt struct {
 	Value   Expr
 }
 
-func (*LetStmt) stmtNode()      {}
+func (*LetStmt) stmtNode()        {}
 func (s *LetStmt) Pos() token.Pos { return s.PosV }
 func (s *LetStmt) End() token.Pos { return s.EndV }
 
@@ -536,21 +536,21 @@ type ExprStmt struct {
 	X Expr
 }
 
-func (*ExprStmt) stmtNode()      {}
+func (*ExprStmt) stmtNode()        {}
 func (s *ExprStmt) Pos() token.Pos { return s.X.Pos() }
 func (s *ExprStmt) End() token.Pos { return s.X.End() }
 
 // AssignStmt covers `a = b`, compound assigns, and multiple assigns
 // `(a, b) = (c, d)`.
 type AssignStmt struct {
-	PosV   token.Pos
-	EndV   token.Pos
-	Op     token.Kind // ASSIGN, PLUSEQ, ...
-	Targets []Expr    // LHS; length 1 for simple, >1 for multi-assign
-	Value  Expr
+	PosV    token.Pos
+	EndV    token.Pos
+	Op      token.Kind // ASSIGN, PLUSEQ, ...
+	Targets []Expr     // LHS; length 1 for simple, >1 for multi-assign
+	Value   Expr
 }
 
-func (*AssignStmt) stmtNode()      {}
+func (*AssignStmt) stmtNode()        {}
 func (s *AssignStmt) Pos() token.Pos { return s.PosV }
 func (s *AssignStmt) End() token.Pos { return s.EndV }
 
@@ -561,7 +561,7 @@ type ReturnStmt struct {
 	Value Expr // optional
 }
 
-func (*ReturnStmt) stmtNode()      {}
+func (*ReturnStmt) stmtNode()        {}
 func (s *ReturnStmt) Pos() token.Pos { return s.PosV }
 func (s *ReturnStmt) End() token.Pos { return s.EndV }
 
@@ -571,7 +571,7 @@ type BreakStmt struct {
 	EndV token.Pos
 }
 
-func (*BreakStmt) stmtNode()      {}
+func (*BreakStmt) stmtNode()        {}
 func (s *BreakStmt) Pos() token.Pos { return s.PosV }
 func (s *BreakStmt) End() token.Pos { return s.EndV }
 
@@ -581,7 +581,7 @@ type ContinueStmt struct {
 	EndV token.Pos
 }
 
-func (*ContinueStmt) stmtNode()      {}
+func (*ContinueStmt) stmtNode()        {}
 func (s *ContinueStmt) Pos() token.Pos { return s.PosV }
 func (s *ContinueStmt) End() token.Pos { return s.EndV }
 
@@ -595,9 +595,9 @@ type ChanSendStmt struct {
 	Value   Expr
 }
 
-func (*ChanSendStmt) stmtNode()         {}
-func (s *ChanSendStmt) Pos() token.Pos  { return s.PosV }
-func (s *ChanSendStmt) End() token.Pos  { return s.EndV }
+func (*ChanSendStmt) stmtNode()        {}
+func (s *ChanSendStmt) Pos() token.Pos { return s.PosV }
+func (s *ChanSendStmt) End() token.Pos { return s.EndV }
 
 // DeferStmt schedules an expression or block to run on block exit.
 type DeferStmt struct {
@@ -606,16 +606,16 @@ type DeferStmt struct {
 	X    Expr // may be a Block
 }
 
-func (*DeferStmt) stmtNode()      {}
+func (*DeferStmt) stmtNode()        {}
 func (s *DeferStmt) Pos() token.Pos { return s.PosV }
 func (s *DeferStmt) End() token.Pos { return s.EndV }
 
 // ForStmt covers all `for` forms:
 //
-//   for cond { ... }                      // while-style (Pattern nil, Iter = cond)
-//   for { ... }                           // infinite   (Pattern nil, Iter nil)
-//   for x in xs { ... }                   // for-in     (Pattern x, Iter xs)
-//   for let Some(v) = e { ... }           // for-let    (IsForLet, Pattern, Iter)
+//	for cond { ... }                      // while-style (Pattern nil, Iter = cond)
+//	for { ... }                           // infinite   (Pattern nil, Iter nil)
+//	for x in xs { ... }                   // for-in     (Pattern x, Iter xs)
+//	for let Some(v) = e { ... }           // for-let    (IsForLet, Pattern, Iter)
 type ForStmt struct {
 	PosV     token.Pos
 	EndV     token.Pos
@@ -625,7 +625,7 @@ type ForStmt struct {
 	Body     *Block
 }
 
-func (*ForStmt) stmtNode()      {}
+func (*ForStmt) stmtNode()        {}
 func (s *ForStmt) Pos() token.Pos { return s.PosV }
 func (s *ForStmt) End() token.Pos { return s.EndV }
 
@@ -639,7 +639,7 @@ type Ident struct {
 	Name string
 }
 
-func (*Ident) exprNode()      {}
+func (*Ident) exprNode()        {}
 func (i *Ident) Pos() token.Pos { return i.PosV }
 func (i *Ident) End() token.Pos { return i.EndV }
 
@@ -650,7 +650,7 @@ type IntLit struct {
 	Text string
 }
 
-func (*IntLit) exprNode()      {}
+func (*IntLit) exprNode()        {}
 func (l *IntLit) Pos() token.Pos { return l.PosV }
 func (l *IntLit) End() token.Pos { return l.EndV }
 
@@ -660,7 +660,7 @@ type FloatLit struct {
 	Text string
 }
 
-func (*FloatLit) exprNode()      {}
+func (*FloatLit) exprNode()        {}
 func (l *FloatLit) Pos() token.Pos { return l.PosV }
 func (l *FloatLit) End() token.Pos { return l.EndV }
 
@@ -670,7 +670,7 @@ type CharLit struct {
 	Value rune
 }
 
-func (*CharLit) exprNode()      {}
+func (*CharLit) exprNode()        {}
 func (l *CharLit) Pos() token.Pos { return l.PosV }
 func (l *CharLit) End() token.Pos { return l.EndV }
 
@@ -680,16 +680,16 @@ type ByteLit struct {
 	Value byte
 }
 
-func (*ByteLit) exprNode()      {}
+func (*ByteLit) exprNode()        {}
 func (l *ByteLit) Pos() token.Pos { return l.PosV }
 func (l *ByteLit) End() token.Pos { return l.EndV }
 
 // StringLit is a string literal, possibly interpolated.
 //
-//   "hello"        -> Parts: [Lit "hello"]
-//   "hi, {name}"   -> Parts: [Lit "hi, ", Expr <Ident name>]
-//   r"\d+"         -> Parts: [Lit `\d+`], IsRaw=true
-//   """\n  x\n  """ -> Parts: [Lit "x"], IsTriple=true
+//	"hello"        -> Parts: [Lit "hello"]
+//	"hi, {name}"   -> Parts: [Lit "hi, ", Expr <Ident name>]
+//	r"\d+"         -> Parts: [Lit `\d+`], IsRaw=true
+//	"""\n  x\n  """ -> Parts: [Lit "x"], IsTriple=true
 //
 // IsTriple records the original syntactic form so the formatter can
 // emit multi-line content back in triple-quoted style. Semantically it
@@ -710,7 +710,7 @@ type StringPart struct {
 	Expr  Expr   // when !IsLit
 }
 
-func (*StringLit) exprNode()       {}
+func (*StringLit) exprNode()        {}
 func (l *StringLit) Pos() token.Pos { return l.PosV }
 func (l *StringLit) End() token.Pos { return l.EndV }
 
@@ -721,7 +721,7 @@ type BoolLit struct {
 	Value bool
 }
 
-func (*BoolLit) exprNode()      {}
+func (*BoolLit) exprNode()        {}
 func (l *BoolLit) Pos() token.Pos { return l.PosV }
 func (l *BoolLit) End() token.Pos { return l.EndV }
 
@@ -733,7 +733,7 @@ type UnaryExpr struct {
 	X    Expr
 }
 
-func (*UnaryExpr) exprNode()      {}
+func (*UnaryExpr) exprNode()        {}
 func (e *UnaryExpr) Pos() token.Pos { return e.PosV }
 func (e *UnaryExpr) End() token.Pos { return e.EndV }
 
@@ -747,7 +747,7 @@ type BinaryExpr struct {
 	Right Expr
 }
 
-func (*BinaryExpr) exprNode()      {}
+func (*BinaryExpr) exprNode()        {}
 func (e *BinaryExpr) Pos() token.Pos { return e.PosV }
 func (e *BinaryExpr) End() token.Pos { return e.EndV }
 
@@ -758,7 +758,7 @@ type QuestionExpr struct {
 	X    Expr
 }
 
-func (*QuestionExpr) exprNode()      {}
+func (*QuestionExpr) exprNode()        {}
 func (e *QuestionExpr) Pos() token.Pos { return e.PosV }
 func (e *QuestionExpr) End() token.Pos { return e.EndV }
 
@@ -785,7 +785,7 @@ func (a *Arg) End() token.Pos {
 	return a.PosV
 }
 
-func (*CallExpr) exprNode()      {}
+func (*CallExpr) exprNode()        {}
 func (e *CallExpr) Pos() token.Pos { return e.PosV }
 func (e *CallExpr) End() token.Pos { return e.EndV }
 
@@ -798,7 +798,7 @@ type FieldExpr struct {
 	IsOptional bool
 }
 
-func (*FieldExpr) exprNode()      {}
+func (*FieldExpr) exprNode()        {}
 func (e *FieldExpr) Pos() token.Pos { return e.PosV }
 func (e *FieldExpr) End() token.Pos { return e.EndV }
 
@@ -810,7 +810,7 @@ type IndexExpr struct {
 	Index Expr
 }
 
-func (*IndexExpr) exprNode()      {}
+func (*IndexExpr) exprNode()        {}
 func (e *IndexExpr) Pos() token.Pos { return e.PosV }
 func (e *IndexExpr) End() token.Pos { return e.EndV }
 
@@ -824,7 +824,7 @@ type TurbofishExpr struct {
 	Args []Type
 }
 
-func (*TurbofishExpr) exprNode()      {}
+func (*TurbofishExpr) exprNode()        {}
 func (e *TurbofishExpr) Pos() token.Pos { return e.PosV }
 func (e *TurbofishExpr) End() token.Pos { return e.EndV }
 
@@ -837,7 +837,7 @@ type RangeExpr struct {
 	Inclusive bool
 }
 
-func (*RangeExpr) exprNode()      {}
+func (*RangeExpr) exprNode()        {}
 func (e *RangeExpr) Pos() token.Pos { return e.PosV }
 func (e *RangeExpr) End() token.Pos { return e.EndV }
 
@@ -848,7 +848,7 @@ type ParenExpr struct {
 	X    Expr
 }
 
-func (*ParenExpr) exprNode()      {}
+func (*ParenExpr) exprNode()        {}
 func (e *ParenExpr) Pos() token.Pos { return e.PosV }
 func (e *ParenExpr) End() token.Pos { return e.EndV }
 
@@ -859,7 +859,7 @@ type TupleExpr struct {
 	Elems []Expr
 }
 
-func (*TupleExpr) exprNode()      {}
+func (*TupleExpr) exprNode()        {}
 func (e *TupleExpr) Pos() token.Pos { return e.PosV }
 func (e *TupleExpr) End() token.Pos { return e.EndV }
 
@@ -870,7 +870,7 @@ type ListExpr struct {
 	Elems []Expr
 }
 
-func (*ListExpr) exprNode()      {}
+func (*ListExpr) exprNode()        {}
 func (e *ListExpr) Pos() token.Pos { return e.PosV }
 func (e *ListExpr) End() token.Pos { return e.EndV }
 
@@ -903,17 +903,17 @@ func (e *MapEntry) End() token.Pos {
 	return token.Pos{}
 }
 
-func (*MapExpr) exprNode()      {}
+func (*MapExpr) exprNode()        {}
 func (e *MapExpr) Pos() token.Pos { return e.PosV }
 func (e *MapExpr) End() token.Pos { return e.EndV }
 
 // StructLit is `User { name: v, ..rest }`.
 type StructLit struct {
-	PosV    token.Pos
-	EndV    token.Pos
-	Type    Expr // usually Ident or FieldExpr chain naming the type
-	Fields  []*StructLitField
-	Spread  Expr // optional ..expr spread source
+	PosV   token.Pos
+	EndV   token.Pos
+	Type   Expr // usually Ident or FieldExpr chain naming the type
+	Fields []*StructLitField
+	Spread Expr // optional ..expr spread source
 }
 
 // StructLitField is one `name: expr` entry (or shorthand `name`).
@@ -931,7 +931,7 @@ func (f *StructLitField) End() token.Pos {
 	return f.PosV
 }
 
-func (*StructLit) exprNode()      {}
+func (*StructLit) exprNode()        {}
 func (e *StructLit) Pos() token.Pos { return e.PosV }
 func (e *StructLit) End() token.Pos { return e.EndV }
 
@@ -950,16 +950,16 @@ type IfExpr struct {
 	Else    Expr // may be *IfExpr or *Block or nil
 }
 
-func (*IfExpr) exprNode()      {}
+func (*IfExpr) exprNode()        {}
 func (e *IfExpr) Pos() token.Pos { return e.PosV }
 func (e *IfExpr) End() token.Pos { return e.EndV }
 
 // MatchExpr is `match scrutinee { arm, arm, ... }`.
 type MatchExpr struct {
-	PosV       token.Pos
-	EndV       token.Pos
-	Scrutinee  Expr
-	Arms       []*MatchArm
+	PosV      token.Pos
+	EndV      token.Pos
+	Scrutinee Expr
+	Arms      []*MatchArm
 }
 
 // MatchArm is `pattern [if guard] -> body`.
@@ -978,7 +978,7 @@ func (a *MatchArm) End() token.Pos {
 	return a.PosV
 }
 
-func (*MatchExpr) exprNode()      {}
+func (*MatchExpr) exprNode()        {}
 func (e *MatchExpr) Pos() token.Pos { return e.PosV }
 func (e *MatchExpr) End() token.Pos { return e.EndV }
 
@@ -991,7 +991,7 @@ type ClosureExpr struct {
 	Body       Expr
 }
 
-func (*ClosureExpr) exprNode()      {}
+func (*ClosureExpr) exprNode()        {}
 func (e *ClosureExpr) Pos() token.Pos { return e.PosV }
 func (e *ClosureExpr) End() token.Pos { return e.EndV }
 
@@ -1003,7 +1003,7 @@ type WildcardPat struct {
 	EndV token.Pos
 }
 
-func (*WildcardPat) patternNode()   {}
+func (*WildcardPat) patternNode()     {}
 func (p *WildcardPat) Pos() token.Pos { return p.PosV }
 func (p *WildcardPat) End() token.Pos { return p.EndV }
 
@@ -1014,7 +1014,7 @@ type LiteralPat struct {
 	Literal Expr // IntLit, FloatLit, StringLit, CharLit, BoolLit, ByteLit
 }
 
-func (*LiteralPat) patternNode()   {}
+func (*LiteralPat) patternNode()     {}
 func (p *LiteralPat) Pos() token.Pos { return p.PosV }
 func (p *LiteralPat) End() token.Pos { return p.EndV }
 
@@ -1025,7 +1025,7 @@ type IdentPat struct {
 	Name string
 }
 
-func (*IdentPat) patternNode()   {}
+func (*IdentPat) patternNode()     {}
 func (p *IdentPat) Pos() token.Pos { return p.PosV }
 func (p *IdentPat) End() token.Pos { return p.EndV }
 
@@ -1036,7 +1036,7 @@ type TuplePat struct {
 	Elems []Pattern
 }
 
-func (*TuplePat) patternNode()   {}
+func (*TuplePat) patternNode()     {}
 func (p *TuplePat) Pos() token.Pos { return p.PosV }
 func (p *TuplePat) End() token.Pos { return p.EndV }
 
@@ -1065,7 +1065,7 @@ func (f *StructPatField) End() token.Pos {
 	return f.PosV
 }
 
-func (*StructPat) patternNode()   {}
+func (*StructPat) patternNode()     {}
 func (p *StructPat) Pos() token.Pos { return p.PosV }
 func (p *StructPat) End() token.Pos { return p.EndV }
 
@@ -1078,7 +1078,7 @@ type VariantPat struct {
 	Args []Pattern // empty for bare variants
 }
 
-func (*VariantPat) patternNode()   {}
+func (*VariantPat) patternNode()     {}
 func (p *VariantPat) Pos() token.Pos { return p.PosV }
 func (p *VariantPat) End() token.Pos { return p.EndV }
 
@@ -1091,7 +1091,7 @@ type RangePat struct {
 	Inclusive bool
 }
 
-func (*RangePat) patternNode()   {}
+func (*RangePat) patternNode()     {}
 func (p *RangePat) Pos() token.Pos { return p.PosV }
 func (p *RangePat) End() token.Pos { return p.EndV }
 
@@ -1102,7 +1102,7 @@ type OrPat struct {
 	Alts []Pattern
 }
 
-func (*OrPat) patternNode()   {}
+func (*OrPat) patternNode()     {}
 func (p *OrPat) Pos() token.Pos { return p.PosV }
 func (p *OrPat) End() token.Pos { return p.EndV }
 
@@ -1114,6 +1114,6 @@ type BindingPat struct {
 	Pattern Pattern
 }
 
-func (*BindingPat) patternNode()   {}
+func (*BindingPat) patternNode()     {}
 func (p *BindingPat) Pos() token.Pos { return p.PosV }
 func (p *BindingPat) End() token.Pos { return p.EndV }

--- a/internal/check/usefulness.go
+++ b/internal/check/usefulness.go
@@ -95,8 +95,8 @@ func (c *checker) coversMatrix(rows [][]ast.Pattern, cols []types.Type) bool {
 // denotes a nullary ctor (true, false, None, Empty, Unit).
 type ctor struct {
 	kind     ctorKind
-	name     string    // variant / bool tag
-	arity    int       // tuple/struct field count
+	name     string // variant / bool tag
+	arity    int    // tuple/struct field count
 	argTypes []types.Type
 	// For struct ctors, fieldOrder provides the column ordering used
 	// during specialization so field-name lookups in StructPat can

--- a/internal/ci/apisnapshot.go
+++ b/internal/ci/apisnapshot.go
@@ -50,12 +50,12 @@ const SnapshotSchemaVersion = 2
 // `package` + `symbols` fields are also written when the project
 // has exactly one package, so older tools keep working).
 type Snapshot struct {
-	Schema   int                  `json:"schema"`
-	Package  string               `json:"package,omitempty"` // legacy/v1 single-package convenience
-	Version  string               `json:"version,omitempty"`
-	Edition  string               `json:"edition,omitempty"`
-	Symbols  []Symbol             `json:"symbols,omitempty"` // legacy/v1 single-package convenience
-	Packages map[string][]Symbol  `json:"packages,omitempty"`
+	Schema   int                 `json:"schema"`
+	Package  string              `json:"package,omitempty"` // legacy/v1 single-package convenience
+	Version  string              `json:"version,omitempty"`
+	Edition  string              `json:"edition,omitempty"`
+	Symbols  []Symbol            `json:"symbols,omitempty"` // legacy/v1 single-package convenience
+	Packages map[string][]Symbol `json:"packages,omitempty"`
 }
 
 // Symbol is one exported declaration. Top-level decls use a bare

--- a/internal/ci/ci_test.go
+++ b/internal/ci/ci_test.go
@@ -70,6 +70,95 @@ version = "0.1.0"
 	}
 }
 
+// TestLoadPrefersRootPackageOverImplicitWorkspace protects the
+// repo-root case: a directory can contain fixture/sample subdirs
+// like testdata/ while still being a single package because it has
+// direct package sources of its own.
+func TestLoadPrefersRootPackageOverImplicitWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "lib.osty", "pub fn hello() {}\n")
+	fixtures := filepath.Join(dir, "testdata")
+	if err := os.Mkdir(fixtures, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, fixtures, "fixture.osty", "    pub fn unformattedFixture() {}\n")
+
+	r := NewRunner(dir, Options{Format: true, Lint: true})
+	if err := r.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(r.Packages) != 1 {
+		t.Fatalf("expected one root package, got %d", len(r.Packages))
+	}
+	if filepath.Clean(r.Packages[0].Dir) != filepath.Clean(dir) {
+		t.Fatalf("loaded package dir %q, want root %q", r.Packages[0].Dir, dir)
+	}
+
+	rep := r.Run()
+	if c := findCheck(rep, CheckFormat); !c.Passed {
+		t.Fatalf("format should ignore fixture subdir; diags=%v", diagMsgs(c.Diags))
+	}
+	if c := findCheck(rep, CheckLint); !c.Passed {
+		t.Fatalf("lint should ignore fixture subdir; diags=%v", diagMsgs(c.Diags))
+	}
+}
+
+// TestLoadSkipsExplicitCIFiles lets future-facing samples live next
+// to a package without breaking today's CI bundle. The skipped file is
+// deliberately unformatted, so format would fail if the directive were
+// ignored.
+func TestLoadSkipsExplicitCIFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "lib.osty", "pub fn hello() {}\n")
+	writeFile(t, dir, "future.osty", "// osty:ci-skip\n    pub fn future() {}\n")
+
+	r := NewRunner(dir, Options{Format: true, Lint: true})
+	if err := r.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(r.Packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(r.Packages))
+	}
+	if len(r.Packages[0].Files) != 1 {
+		t.Fatalf("expected one unskipped file, got %d", len(r.Packages[0].Files))
+	}
+	if got := filepath.Base(r.Packages[0].Files[0].Path); got != "lib.osty" {
+		t.Fatalf("loaded %q, want lib.osty", got)
+	}
+
+	rep := r.Run()
+	if c := findCheck(rep, CheckFormat); !c.Passed {
+		t.Fatalf("format should ignore ci-skipped file; diags=%v", diagMsgs(c.Diags))
+	}
+	if c := findCheck(rep, CheckLint); !c.Passed {
+		t.Fatalf("lint should ignore ci-skipped file; diags=%v", diagMsgs(c.Diags))
+	}
+}
+
+func TestAllCISkippedFilesDoNotFallbackWalk(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "future.osty", "// osty:ci-skip\n    pub fn future() {}\n")
+
+	r := NewRunner(dir, Options{Format: true, Lint: true})
+	if err := r.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(r.Packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(r.Packages))
+	}
+	if len(r.Packages[0].Files) != 0 {
+		t.Fatalf("expected every file to be skipped, got %d", len(r.Packages[0].Files))
+	}
+
+	rep := r.Run()
+	if c := findCheck(rep, CheckFormat); !c.Passed {
+		t.Fatalf("format should not fallback-walk skipped files; diags=%v", diagMsgs(c.Diags))
+	}
+	if c := findCheck(rep, CheckLint); !c.Passed {
+		t.Fatalf("lint should tolerate all-skipped package; diags=%v", diagMsgs(c.Diags))
+	}
+}
+
 // TestPolicyFlagsMissingLicense confirms the policy pass warns
 // when license is missing and errors when the workspace member
 // points at a nonexistent dir.
@@ -283,10 +372,10 @@ fn private() {}
 	// on the must-haves so a future field addition doesn't
 	// brittle the test.
 	wantHave := map[string]string{
-		"function add":   "(a: Int, b: Int) -> Int",
-		"struct User":    "{name: String, age: Int}",
-		"enum Color":     "Red | RGB(Int, Int, Int)",
-		"field User.name": "String",
+		"function add":      "(a: Int, b: Int) -> Int",
+		"struct User":       "{name: String, age: Int}",
+		"enum Color":        "Red | RGB(Int, Int, Int)",
+		"field User.name":   "String",
 		"variant Color.RGB": "RGB(Int, Int, Int)",
 	}
 	for k, want := range wantHave {

--- a/internal/ci/runner.go
+++ b/internal/ci/runner.go
@@ -1,15 +1,20 @@
 package ci
 
 import (
+	"bytes"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
+
+const ciSkipDirective = "osty:ci-skip"
 
 // Load reads the project metadata for r.Root. It tolerates a
 // missing manifest (standalone source directory) but refuses a
@@ -46,7 +51,7 @@ func (r *Runner) Load() error {
 	if r.Manifest != nil && r.Manifest.Workspace != nil {
 		return r.loadWorkspace(true)
 	}
-	if resolve.IsWorkspaceRoot(r.Root, "") {
+	if !hasDirectPackageSources(r.Root) && resolve.IsWorkspaceRoot(r.Root, "") {
 		return r.loadWorkspace(false)
 	}
 	pkg, err := resolve.LoadPackage(r.Root)
@@ -56,10 +61,28 @@ func (r *Runner) Load() error {
 		// Record nothing and let each check decide to skip.
 		return nil
 	}
+	filterPackageCIFiles(pkg)
 	r.Packages = []*resolve.Package{pkg}
 	pr := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	r.Results = []*resolve.PackageResult{pr}
 	return nil
+}
+
+func hasDirectPackageSources(root string) bool {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".osty") && !strings.HasSuffix(name, "_test.osty") {
+			return true
+		}
+	}
+	return false
 }
 
 // loadWorkspace loads every member described by the manifest (or
@@ -82,6 +105,7 @@ func (r *Runner) loadWorkspace(byManifest bool) error {
 		}
 		seen[member] = true
 		if pkg, err := ws.LoadPackage(member); err == nil && pkg != nil {
+			filterPackageCIFiles(pkg)
 			r.Packages = append(r.Packages, pkg)
 			pkgPaths = append(pkgPaths, member)
 		}
@@ -108,6 +132,20 @@ func (r *Runner) loadWorkspace(byManifest bool) error {
 		r.Results = append(r.Results, allResults[path])
 	}
 	return nil
+}
+
+func filterPackageCIFiles(pkg *resolve.Package) {
+	if pkg == nil || len(pkg.Files) == 0 {
+		return
+	}
+	files := pkg.Files[:0]
+	for _, pf := range pkg.Files {
+		if pf == nil || bytes.Contains(pf.Source, []byte(ciSkipDirective)) {
+			continue
+		}
+		files = append(files, pf)
+	}
+	pkg.Files = files
 }
 
 // Run executes every enabled check and returns the aggregated
@@ -189,10 +227,11 @@ func (r *Runner) ostyFiles() []string {
 			files[pf.Path] = true
 		}
 	}
-	// Workspace mode sometimes leaves a root package unrepresented
-	// (virtual workspace). Fall back to a filesystem walk so the
-	// format check still sees every source.
-	if len(files) == 0 {
+	// When Load found no package at all, fall back to a filesystem
+	// walk so loose source trees still get a format pass. If packages
+	// were loaded but their files were explicitly CI-skipped, do not
+	// walk back into fixtures and samples.
+	if len(files) == 0 && len(r.Packages) == 0 {
 		_ = filepath.WalkDir(r.Root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d == nil {
 				return nil
@@ -206,7 +245,10 @@ func (r *Runner) ostyFiles() []string {
 				return nil
 			}
 			if filepath.Ext(path) == ".osty" {
-				files[path] = true
+				src, err := os.ReadFile(path)
+				if err != nil || !bytes.Contains(src, []byte(ciSkipDirective)) {
+					files[path] = true
+				}
 			}
 			return nil
 		})

--- a/internal/ci/semver.go
+++ b/internal/ci/semver.go
@@ -15,9 +15,9 @@ import (
 // Rules:
 //
 //   - Any removed exported symbol is a breaking change.
-//     * If the current major >  baseline major: Warning (expected,
-//       the user already signaled a breaking release).
-//     * Otherwise: Error (silent break).
+//   - If the current major >  baseline major: Warning (expected,
+//     the user already signaled a breaking release).
+//   - Otherwise: Error (silent break).
 //   - Added symbols are Info-equivalent — surfaced under --json
 //     but treated as passing.
 //   - Signature changes on otherwise-same symbols are Error unless

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -100,15 +100,15 @@ func (k DeclKind) String() string {
 // strings) alongside raw metadata (Line, Doc, Deprecated) so both
 // markdown and HTML renderers can compose the exact layout they want.
 type Decl struct {
-	Kind       DeclKind
-	Name       string
-	Doc        string  // raw `///` block, newline-joined, as the parser saw it
-	Info       DocInfo // structured parse of Doc (Summary, Params, Returns, Example, See)
-	Line       int     // 1-based source line of the declaration keyword
-	Signature  string  // one-line signature (e.g. "fn new(name: String) -> Self")
-	Deprecated string  // `#[deprecated(message = ...)]` message, empty if absent
-	DeprecatedSince string // `#[deprecated(since = "0.5")]` version, empty if absent
-	DeprecatedUse   string // `#[deprecated(use = "newFn")]` replacement hint, empty if absent
+	Kind            DeclKind
+	Name            string
+	Doc             string  // raw `///` block, newline-joined, as the parser saw it
+	Info            DocInfo // structured parse of Doc (Summary, Params, Returns, Example, See)
+	Line            int     // 1-based source line of the declaration keyword
+	Signature       string  // one-line signature (e.g. "fn new(name: String) -> Self")
+	Deprecated      string  // `#[deprecated(message = ...)]` message, empty if absent
+	DeprecatedSince string  // `#[deprecated(since = "0.5")]` version, empty if absent
+	DeprecatedUse   string  // `#[deprecated(use = "newFn")]` replacement hint, empty if absent
 
 	// Fields populated for KindStruct.
 	Fields []*Field

--- a/internal/docgen/parsedoc.go
+++ b/internal/docgen/parsedoc.go
@@ -60,19 +60,19 @@ func (d DocInfo) IsEmpty() bool {
 // a declaration (Decl.Doc) into a DocInfo. The grammar is intentionally
 // lenient:
 //
-//  - The first non-empty paragraph becomes the Summary.
-//  - Subsequent paragraphs become Body until the first labeled section.
-//  - A line that begins with `<Label>:` at column 0 (after any leading
-//    spaces) opens a section. Currently recognised: `Params`, `Param`,
-//    `Arguments`, `Args`, `Returns`, `Return`, `Example`, `Examples`,
-//    `See`, `See also`. Unknown labels are treated as prose.
-//  - `Example:` sections consume every following line until the next
-//    section label or a double-blank break. Shared indentation is
-//    stripped so the embedded code starts at column 0.
-//  - `Params:` entries may be on the same line (`Params: x: foo`) or
-//    in an indented list below the label. Each entry is `name: desc`;
-//    continuation lines indented further are appended to the previous
-//    entry's description.
+//   - The first non-empty paragraph becomes the Summary.
+//   - Subsequent paragraphs become Body until the first labeled section.
+//   - A line that begins with `<Label>:` at column 0 (after any leading
+//     spaces) opens a section. Currently recognised: `Params`, `Param`,
+//     `Arguments`, `Args`, `Returns`, `Return`, `Example`, `Examples`,
+//     `See`, `See also`. Unknown labels are treated as prose.
+//   - `Example:` sections consume every following line until the next
+//     section label or a double-blank break. Shared indentation is
+//     stripped so the embedded code starts at column 0.
+//   - `Params:` entries may be on the same line (`Params: x: foo`) or
+//     in an indented list below the label. Each entry is `name: desc`;
+//     continuation lines indented further are appended to the previous
+//     entry's description.
 func parseDocComment(raw string) DocInfo {
 	var info DocInfo
 	if raw == "" {

--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -451,9 +451,9 @@ func (p *printer) printFnDecl(f *ast.FnDecl) {
 	// renderer gets one decision point (flat vs multi-line) that
 	// accounts for the whole signature — receiver included.
 	type paramItem struct {
-		isSelf   bool
-		mutSelf  bool
-		param    *ast.Param
+		isSelf  bool
+		mutSelf bool
+		param   *ast.Param
 	}
 	items := make([]paramItem, 0, len(f.Params)+1)
 	if f.Recv != nil {
@@ -1362,4 +1362,3 @@ func (p *printer) printPattern(pat ast.Pattern) {
 		p.write(fmt.Sprintf("/* unknown pattern %T */", pat))
 	}
 }
-

--- a/internal/gen/monomorph.go
+++ b/internal/gen/monomorph.go
@@ -217,4 +217,3 @@ func (g *gen) lookupSubst(name string) (string, bool) {
 	v, ok := g.substEnv[name]
 	return v, ok
 }
-

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -195,7 +195,7 @@ func (n *NamedType) String() string {
 // lowering without matching on strings.
 type OptionalType struct{ Inner Type }
 
-func (*OptionalType) typeNode()     {}
+func (*OptionalType) typeNode()        {}
 func (o *OptionalType) String() string { return typeString(o.Inner) + "?" }
 
 // TupleType is `(T1, T2, ...)`. Single-element tuples are legal.
@@ -252,7 +252,7 @@ type TypeVar struct {
 	Owner string
 }
 
-func (*TypeVar) typeNode()     {}
+func (*TypeVar) typeNode()        {}
 func (v *TypeVar) String() string { return v.Name }
 
 // ErrType is the poisoned type used when lowering cannot recover a real
@@ -260,7 +260,7 @@ func (v *TypeVar) String() string { return v.Name }
 // reported" and avoid cascading diagnostics.
 type ErrType struct{}
 
-func (*ErrType) typeNode()   {}
+func (*ErrType) typeNode()      {}
 func (*ErrType) String() string { return "<error>" }
 
 // ErrTypeVal is the canonical poisoned singleton.
@@ -297,8 +297,8 @@ type FnDecl struct {
 	SpanV    Span
 }
 
-func (*FnDecl) declNode()        {}
-func (f *FnDecl) At() Span       { return f.SpanV }
+func (*FnDecl) declNode()          {}
+func (f *FnDecl) At() Span         { return f.SpanV }
 func (f *FnDecl) DeclName() string { return f.Name }
 
 // Param is one function / method parameter. Default is an already
@@ -332,8 +332,8 @@ type StructDecl struct {
 	SpanV    Span
 }
 
-func (*StructDecl) declNode()        {}
-func (s *StructDecl) At() Span       { return s.SpanV }
+func (*StructDecl) declNode()          {}
+func (s *StructDecl) At() Span         { return s.SpanV }
 func (s *StructDecl) DeclName() string { return s.Name }
 
 // Field is one struct field.
@@ -357,8 +357,8 @@ type EnumDecl struct {
 	SpanV    Span
 }
 
-func (*EnumDecl) declNode()        {}
-func (e *EnumDecl) At() Span       { return e.SpanV }
+func (*EnumDecl) declNode()          {}
+func (e *EnumDecl) At() Span         { return e.SpanV }
 func (e *EnumDecl) DeclName() string { return e.Name }
 
 // Variant is one enum case. Payload is the tuple of variant payload
@@ -381,8 +381,8 @@ type LetDecl struct {
 	SpanV    Span
 }
 
-func (*LetDecl) declNode()        {}
-func (l *LetDecl) At() Span       { return l.SpanV }
+func (*LetDecl) declNode()          {}
+func (l *LetDecl) At() Span         { return l.SpanV }
 func (l *LetDecl) DeclName() string { return l.Name }
 
 // ==== Statements ====
@@ -402,7 +402,7 @@ type Block struct {
 	SpanV  Span
 }
 
-func (*Block) stmtNode() {}
+func (*Block) stmtNode()  {}
 func (b *Block) At() Span { return b.SpanV }
 
 // LetStmt introduces a local binding. For the common case (`let x = e`)
@@ -419,7 +419,7 @@ type LetStmt struct {
 	SpanV   Span
 }
 
-func (*LetStmt) stmtNode() {}
+func (*LetStmt) stmtNode()  {}
 func (l *LetStmt) At() Span { return l.SpanV }
 
 // ExprStmt is an expression used in statement position (side effect).
@@ -428,7 +428,7 @@ type ExprStmt struct {
 	SpanV Span
 }
 
-func (*ExprStmt) stmtNode() {}
+func (*ExprStmt) stmtNode()  {}
 func (e *ExprStmt) At() Span { return e.SpanV }
 
 // AssignOp classifies the flavor of an assignment statement.
@@ -459,7 +459,7 @@ type AssignStmt struct {
 	SpanV   Span
 }
 
-func (*AssignStmt) stmtNode() {}
+func (*AssignStmt) stmtNode()  {}
 func (a *AssignStmt) At() Span { return a.SpanV }
 
 // ReturnStmt is `return` or `return value`. Value is nil for a bare
@@ -469,19 +469,19 @@ type ReturnStmt struct {
 	SpanV Span
 }
 
-func (*ReturnStmt) stmtNode() {}
+func (*ReturnStmt) stmtNode()  {}
 func (r *ReturnStmt) At() Span { return r.SpanV }
 
 // BreakStmt exits the innermost loop.
 type BreakStmt struct{ SpanV Span }
 
-func (*BreakStmt) stmtNode() {}
+func (*BreakStmt) stmtNode()  {}
 func (b *BreakStmt) At() Span { return b.SpanV }
 
 // ContinueStmt skips to the next loop iteration.
 type ContinueStmt struct{ SpanV Span }
 
-func (*ContinueStmt) stmtNode() {}
+func (*ContinueStmt) stmtNode()  {}
 func (c *ContinueStmt) At() Span { return c.SpanV }
 
 // IfStmt is a statement-position conditional. Else is nil when there
@@ -493,7 +493,7 @@ type IfStmt struct {
 	SpanV Span
 }
 
-func (*IfStmt) stmtNode() {}
+func (*IfStmt) stmtNode()  {}
 func (i *IfStmt) At() Span { return i.SpanV }
 
 // ForKind classifies the `for` variant.
@@ -525,7 +525,7 @@ type ForStmt struct {
 	SpanV     Span
 }
 
-func (*ForStmt) stmtNode() {}
+func (*ForStmt) stmtNode()  {}
 func (f *ForStmt) At() Span { return f.SpanV }
 
 // ErrorStmt is the poisoned statement emitted when lowering fails. The
@@ -536,7 +536,7 @@ type ErrorStmt struct {
 	SpanV Span
 }
 
-func (*ErrorStmt) stmtNode() {}
+func (*ErrorStmt) stmtNode()  {}
 func (e *ErrorStmt) At() Span { return e.SpanV }
 
 // ==== Expressions ====
@@ -558,8 +558,8 @@ type IntLit struct {
 	SpanV Span
 }
 
-func (*IntLit) exprNode() {}
-func (l *IntLit) At() Span { return l.SpanV }
+func (*IntLit) exprNode()    {}
+func (l *IntLit) At() Span   { return l.SpanV }
 func (l *IntLit) Type() Type { return l.T }
 
 // FloatLit is a float literal.
@@ -569,8 +569,8 @@ type FloatLit struct {
 	SpanV Span
 }
 
-func (*FloatLit) exprNode() {}
-func (l *FloatLit) At() Span { return l.SpanV }
+func (*FloatLit) exprNode()    {}
+func (l *FloatLit) At() Span   { return l.SpanV }
 func (l *FloatLit) Type() Type { return l.T }
 
 // BoolLit is `true` / `false`.
@@ -579,8 +579,8 @@ type BoolLit struct {
 	SpanV Span
 }
 
-func (*BoolLit) exprNode() {}
-func (l *BoolLit) At() Span { return l.SpanV }
+func (*BoolLit) exprNode()    {}
+func (l *BoolLit) At() Span   { return l.SpanV }
 func (l *BoolLit) Type() Type { return TBool }
 
 // CharLit is a single-code-point char literal.
@@ -589,8 +589,8 @@ type CharLit struct {
 	SpanV Span
 }
 
-func (*CharLit) exprNode() {}
-func (l *CharLit) At() Span { return l.SpanV }
+func (*CharLit) exprNode()    {}
+func (l *CharLit) At() Span   { return l.SpanV }
 func (l *CharLit) Type() Type { return TChar }
 
 // ByteLit is a byte literal (0..=255).
@@ -599,8 +599,8 @@ type ByteLit struct {
 	SpanV Span
 }
 
-func (*ByteLit) exprNode() {}
-func (l *ByteLit) At() Span { return l.SpanV }
+func (*ByteLit) exprNode()    {}
+func (l *ByteLit) At() Span   { return l.SpanV }
 func (l *ByteLit) Type() Type { return TByte }
 
 // StringLit is a possibly interpolated string literal. Parts alternate
@@ -621,7 +621,7 @@ type StringPart struct {
 	Expr  Expr
 }
 
-func (*StringLit) exprNode() {}
+func (*StringLit) exprNode()  {}
 func (s *StringLit) At() Span { return s.SpanV }
 func (*StringLit) Type() Type { return TString }
 
@@ -629,7 +629,7 @@ func (*StringLit) Type() Type { return TString }
 // result when no expression was provided.
 type UnitLit struct{ SpanV Span }
 
-func (*UnitLit) exprNode() {}
+func (*UnitLit) exprNode()  {}
 func (u *UnitLit) At() Span { return u.SpanV }
 func (*UnitLit) Type() Type { return TUnit }
 
@@ -638,14 +638,14 @@ func (*UnitLit) Type() Type { return TUnit }
 type IdentKind int
 
 const (
-	IdentUnknown IdentKind = iota
-	IdentLocal            // let binding or closure capture
-	IdentParam            // function/method parameter
-	IdentFn               // top-level function
-	IdentVariant          // enum variant
-	IdentTypeName         // struct/enum/interface/alias used as value
-	IdentGlobal           // top-level `let`
-	IdentBuiltin          // prelude / builtin
+	IdentUnknown  IdentKind = iota
+	IdentLocal              // let binding or closure capture
+	IdentParam              // function/method parameter
+	IdentFn                 // top-level function
+	IdentVariant            // enum variant
+	IdentTypeName           // struct/enum/interface/alias used as value
+	IdentGlobal             // top-level `let`
+	IdentBuiltin            // prelude / builtin
 )
 
 // Ident is a name reference. Kind distinguishes locals from calls on
@@ -658,18 +658,18 @@ type Ident struct {
 	SpanV Span
 }
 
-func (*Ident) exprNode() {}
-func (i *Ident) At() Span { return i.SpanV }
+func (*Ident) exprNode()    {}
+func (i *Ident) At() Span   { return i.SpanV }
 func (i *Ident) Type() Type { return i.T }
 
 // UnOp enumerates prefix operators.
 type UnOp int
 
 const (
-	UnNeg UnOp = iota // -x
-	UnPlus              // +x
-	UnNot               // !x
-	UnBitNot            // ~x
+	UnNeg    UnOp = iota // -x
+	UnPlus               // +x
+	UnNot                // !x
+	UnBitNot             // ~x
 )
 
 // UnaryExpr is a prefix unary operation.
@@ -680,8 +680,8 @@ type UnaryExpr struct {
 	SpanV Span
 }
 
-func (*UnaryExpr) exprNode() {}
-func (e *UnaryExpr) At() Span { return e.SpanV }
+func (*UnaryExpr) exprNode()    {}
+func (e *UnaryExpr) At() Span   { return e.SpanV }
 func (e *UnaryExpr) Type() Type { return e.T }
 
 // BinOp enumerates binary operators. Covers arithmetic, comparison,
@@ -722,8 +722,8 @@ type BinaryExpr struct {
 	SpanV Span
 }
 
-func (*BinaryExpr) exprNode() {}
-func (e *BinaryExpr) At() Span { return e.SpanV }
+func (*BinaryExpr) exprNode()    {}
+func (e *BinaryExpr) At() Span   { return e.SpanV }
 func (e *BinaryExpr) Type() Type { return e.T }
 
 // CallExpr is a user function / method / closure call.
@@ -734,8 +734,8 @@ type CallExpr struct {
 	SpanV  Span
 }
 
-func (*CallExpr) exprNode() {}
-func (c *CallExpr) At() Span { return c.SpanV }
+func (*CallExpr) exprNode()    {}
+func (c *CallExpr) At() Span   { return c.SpanV }
 func (c *CallExpr) Type() Type { return c.T }
 
 // IntrinsicKind enumerates the print-family intrinsics that Lower
@@ -759,7 +759,7 @@ type IntrinsicCall struct {
 	SpanV Span
 }
 
-func (*IntrinsicCall) exprNode() {}
+func (*IntrinsicCall) exprNode()  {}
 func (i *IntrinsicCall) At() Span { return i.SpanV }
 func (*IntrinsicCall) Type() Type { return TUnit }
 
@@ -772,8 +772,8 @@ type ListLit struct {
 	SpanV Span
 }
 
-func (*ListLit) exprNode() {}
-func (l *ListLit) At() Span { return l.SpanV }
+func (*ListLit) exprNode()    {}
+func (l *ListLit) At() Span   { return l.SpanV }
 func (l *ListLit) Type() Type { return &NamedType{Name: "List", Args: []Type{l.Elem}, Builtin: true} }
 
 // BlockExpr is a block used in expression position. The block's Result
@@ -785,8 +785,8 @@ type BlockExpr struct {
 	SpanV Span
 }
 
-func (*BlockExpr) exprNode() {}
-func (b *BlockExpr) At() Span { return b.SpanV }
+func (*BlockExpr) exprNode()    {}
+func (b *BlockExpr) At() Span   { return b.SpanV }
 func (b *BlockExpr) Type() Type { return b.T }
 
 // IfExpr is an `if` used in expression position. Both arms are
@@ -800,8 +800,8 @@ type IfExpr struct {
 	SpanV Span
 }
 
-func (*IfExpr) exprNode() {}
-func (i *IfExpr) At() Span { return i.SpanV }
+func (*IfExpr) exprNode()    {}
+func (i *IfExpr) At() Span   { return i.SpanV }
 func (i *IfExpr) Type() Type { return i.T }
 
 // ErrorExpr is the poisoned expression emitted when lowering fails for
@@ -812,7 +812,7 @@ type ErrorExpr struct {
 	SpanV Span
 }
 
-func (*ErrorExpr) exprNode() {}
+func (*ErrorExpr) exprNode()  {}
 func (e *ErrorExpr) At() Span { return e.SpanV }
 func (e *ErrorExpr) Type() Type {
 	if e.T == nil {
@@ -878,7 +878,7 @@ type DeferStmt struct {
 	SpanV Span
 }
 
-func (*DeferStmt) stmtNode() {}
+func (*DeferStmt) stmtNode()  {}
 func (d *DeferStmt) At() Span { return d.SpanV }
 
 // ChanSendStmt is `channel <- value`.
@@ -888,7 +888,7 @@ type ChanSendStmt struct {
 	SpanV   Span
 }
 
-func (*ChanSendStmt) stmtNode() {}
+func (*ChanSendStmt) stmtNode()  {}
 func (c *ChanSendStmt) At() Span { return c.SpanV }
 
 // MatchStmt is a `match` scrutinee used in statement position. The
@@ -901,7 +901,7 @@ type MatchStmt struct {
 	SpanV     Span
 }
 
-func (*MatchStmt) stmtNode() {}
+func (*MatchStmt) stmtNode()  {}
 func (m *MatchStmt) At() Span { return m.SpanV }
 
 // ==== Additional expressions ====
@@ -915,9 +915,9 @@ type FieldExpr struct {
 	SpanV    Span
 }
 
-func (*FieldExpr) exprNode()      {}
-func (f *FieldExpr) At() Span     { return f.SpanV }
-func (f *FieldExpr) Type() Type   { return f.T }
+func (*FieldExpr) exprNode()    {}
+func (f *FieldExpr) At() Span   { return f.SpanV }
+func (f *FieldExpr) Type() Type { return f.T }
 
 // IndexExpr is `x[i]`.
 type IndexExpr struct {

--- a/internal/lexer/fuzz_test.go
+++ b/internal/lexer/fuzz_test.go
@@ -26,14 +26,14 @@ func FuzzLex(f *testing.F) {
 		// Error-path seeds.
 		`"unterminated string`,
 		`"bad escape \q"`,
-		"0X1F",        // uppercase base
-		"'ab'",        // multi-char char lit
-		"\"hi, {",     // unterminated interpolation
+		"0X1F",    // uppercase base
+		"'ab'",    // multi-char char lit
+		"\"hi, {", // unterminated interpolation
 		"/* unterminated",
 		"\"\"\"\nbad indent\n  \"\"\"", // bad triple-string
-		"b'\\xFF'",    // invalid byte escape
-		"\uFEFF",      // lone BOM
-		"\x00\x01\x02", // binary noise
+		"b'\\xFF'",                     // invalid byte escape
+		"\uFEFF",                       // lone BOM
+		"\x00\x01\x02",                 // binary noise
 	}
 	for _, s := range seeds {
 		f.Add(s)

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -102,10 +102,10 @@ func TestLexStringUTF8(t *testing.T) {
 		src  string
 		want string
 	}{
-		{`"a — b"`, "a — b"},         // em-dash (3-byte UTF-8)
-		{`"α β γ"`, "α β γ"},          // 2-byte runes
-		{`"한국어"`, "한국어"},            // 3-byte runes
-		{`"😀 hi"`, "😀 hi"},          // 4-byte rune
+		{`"a — b"`, "a — b"},                       // em-dash (3-byte UTF-8)
+		{`"α β γ"`, "α β γ"},                       // 2-byte runes
+		{`"한국어"`, "한국어"},                           // 3-byte runes
+		{`"😀 hi"`, "😀 hi"},                         // 4-byte rune
 		{"\"a\u00A0b\u2014c\"", "a\u00A0b\u2014c"}, // NBSP + em-dash
 	}
 	for _, c := range cases {
@@ -503,7 +503,7 @@ func TestLexShebangUTF8(t *testing.T) {
 	}
 }
 
-// TestLexEmptyCharLiteral: `''` is rejected with a dedicated
+// TestLexEmptyCharLiteral: `”` is rejected with a dedicated
 // "empty char literal" diagnostic rather than the confusing
 // "expected closing '" path that used to swallow the closing quote
 // as the char's value.
@@ -529,7 +529,7 @@ func TestLexEmptyCharLiteral(t *testing.T) {
 	}
 }
 
-// TestLexEmptyByteLiteral: `b''` is rejected analogously to `''`.
+// TestLexEmptyByteLiteral: `b”` is rejected analogously to `”`.
 func TestLexEmptyByteLiteral(t *testing.T) {
 	l := New([]byte(`b''`))
 	toks := l.Lex()

--- a/internal/lint/complexity.go
+++ b/internal/lint/complexity.go
@@ -16,9 +16,9 @@ func sprint(a ...any) string { return fmt.Sprint(a...) }
 // trip them; users who want stricter limits can tighten via config
 // once threshold knobs are exposed.
 const (
-	defaultMaxParams   = 7
-	defaultMaxBodyLen  = 80
-	defaultMaxNesting  = 5
+	defaultMaxParams  = 7
+	defaultMaxBodyLen = 80
+	defaultMaxNesting = 5
 )
 
 // lintComplexity runs the L0050 / L0052 / L0053 checks over every

--- a/internal/lint/config.go
+++ b/internal/lint/config.go
@@ -27,9 +27,9 @@ import (
 //
 // Typical source: the project's `osty.toml` `[lint]` section:
 //
-//   [lint]
-//   allow = ["naming_value", "L0003"]
-//   deny  = ["dead_code", "self_assign"]
+//	[lint]
+//	allow = ["naming_value", "L0003"]
+//	deny  = ["dead_code", "self_assign"]
 type Config struct {
 	Allow []string
 	Deny  []string

--- a/internal/lint/deadcode.go
+++ b/internal/lint/deadcode.go
@@ -282,8 +282,8 @@ func stmtHasBreakEscape(s ast.Stmt) bool {
 		return exprHasBreakEscape(n.X)
 	case *ast.Block:
 		return blockHasBreakEscape(n)
-	// *ForStmt: a break inside a nested for loop targets the inner for,
-	// not the outer one we're analysing. Skip recursion into the body.
+		// *ForStmt: a break inside a nested for loop targets the inner for,
+		// not the outer one we're analysing. Skip recursion into the body.
 	}
 	return false
 }

--- a/internal/lint/mut.go
+++ b/internal/lint/mut.go
@@ -12,10 +12,10 @@ import (
 //
 // The rule considers the following as a "mutation" of a binding `x`:
 //
-//   x = y           — simple assign, including compound forms (+=, -=, …)
-//   x[i] = v        — index assignment (mutates the backing collection)
-//   x.field = v     — field assignment
-//   x?.field = v    — optional-chained field assignment
+//	x = y           — simple assign, including compound forms (+=, -=, …)
+//	x[i] = v        — index assignment (mutates the backing collection)
+//	x.field = v     — field assignment
+//	x?.field = v    — optional-chained field assignment
 //
 // For each of these targets we walk down to the root identifier; that
 // identifier's referenced declaration is marked as mutated.

--- a/internal/lint/naming.go
+++ b/internal/lint/naming.go
@@ -11,11 +11,11 @@ import (
 // lintNaming flags identifiers that deviate from the project's house
 // style (per v0.3 spec examples):
 //
-//   L0030  types (struct / enum / interface / type alias / generic) must
-//          be UpperCamelCase
-//   L0031  functions, methods, let bindings, and parameters must be
-//          lowerCamelCase
-//   L0032  enum variants must be UpperCamelCase
+//	L0030  types (struct / enum / interface / type alias / generic) must
+//	       be UpperCamelCase
+//	L0031  functions, methods, let bindings, and parameters must be
+//	       lowerCamelCase
+//	L0032  enum variants must be UpperCamelCase
 //
 // FFI bindings (declarations inside `use go "…" { … }`) are exempt: their
 // names mirror the host language's export convention, which is typically

--- a/internal/lint/simplify.go
+++ b/internal/lint/simplify.go
@@ -9,11 +9,11 @@ import (
 
 // lintSimplify runs three "common bug / redundant code" checks:
 //
-//   L0040  if-then-else that just returns a bool literal (`if c { true }
-//          else { false }` ≡ `c`)
-//   L0041  self-comparison (`x == x`, `x != x`, `x < x`, …) — almost
-//          always a copy-paste bug
-//   L0042  self-assignment (`x = x`) — a no-op
+//	L0040  if-then-else that just returns a bool literal (`if c { true }
+//	       else { false }` ≡ `c`)
+//	L0041  self-comparison (`x == x`, `x != x`, `x < x`, …) — almost
+//	       always a copy-paste bug
+//	L0042  self-assignment (`x = x`) — a no-op
 //
 // All three are pure AST checks; only L0041 / L0042 consult the
 // resolver's Refs map (via exprsEqual) to answer "is this the same

--- a/internal/lint/unused.go
+++ b/internal/lint/unused.go
@@ -10,9 +10,9 @@ import (
 // lintUnused flags every bound name that is never referenced anywhere in
 // the resolved source:
 //
-//   L0001 - let bindings (both statement lets and top-level LetDecls)
-//   L0002 - function / closure parameters
-//   L0003 - `use` aliases
+//	L0001 - let bindings (both statement lets and top-level LetDecls)
+//	L0002 - function / closure parameters
+//	L0003 - `use` aliases
 //
 // Names that intentionally go unused (`_foo`), publicly exported items
 // (`pub fn`, `pub let`), and the implicit `self` / `Self` are excluded.

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -8,14 +8,14 @@
 //
 //   - Content is TOML, parsed via internal/tomlparse. Schema:
 //
-//	version = 1
+//     version = 1
 //
-//	[[package]]
-//	name = "simple"
-//	version = "1.2.3"
-//	source = "registry+https://registry.osty.dev"
-//	checksum = "sha256:abcdef..."
-//	dependencies = ["other 1.0.0"]
+//     [[package]]
+//     name = "simple"
+//     version = "1.2.3"
+//     source = "registry+https://registry.osty.dev"
+//     checksum = "sha256:abcdef..."
+//     dependencies = ["other 1.0.0"]
 //
 //   - `source` is a URI-like pin that fully describes where the
 //     package came from: "registry+URL", "git+URL?<ref>#<rev>",

--- a/internal/lsp/codeaction.go
+++ b/internal/lsp/codeaction.go
@@ -16,10 +16,12 @@ import (
 //
 //   - Source actions: bulk refactors that operate on the whole file
 //     regardless of where the cursor sits. Currently:
-//       * source.organizeImports — sort, dedupe, and drop unused
-//         `use` declarations.
-//       * source.fixAll[.osty] — apply every machine-applicable
-//         compiler/lint suggestion in one edit.
+//
+//   - source.organizeImports — sort, dedupe, and drop unused
+//     `use` declarations.
+//
+//   - source.fixAll[.osty] — apply every machine-applicable
+//     compiler/lint suggestion in one edit.
 //
 // The `context.only` filter the client sends narrows what we return
 // — `["source.organizeImports"]` on save yields just that action, an

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -213,4 +213,3 @@ func completionKindFor(k resolve.SymbolKind) CompletionItemKind {
 	}
 	return CompletionItemValue
 }
-

--- a/internal/lsp/convert.go
+++ b/internal/lsp/convert.go
@@ -222,4 +222,3 @@ func utf16UnitsInPrefix(p []byte) uint32 {
 	}
 	return n
 }
-

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -386,18 +386,18 @@ const (
 type CompletionItemKind int
 
 const (
-	CompletionItemFunction CompletionItemKind = 3
-	CompletionItemVariable CompletionItemKind = 6
-	CompletionItemField    CompletionItemKind = 5
-	CompletionItemConstructor CompletionItemKind = 4
-	CompletionItemModule   CompletionItemKind = 9
-	CompletionItemStruct   CompletionItemKind = 22
-	CompletionItemEnum     CompletionItemKind = 13
-	CompletionItemInterface CompletionItemKind = 8
-	CompletionItemEnumMember CompletionItemKind = 20
+	CompletionItemFunction      CompletionItemKind = 3
+	CompletionItemVariable      CompletionItemKind = 6
+	CompletionItemField         CompletionItemKind = 5
+	CompletionItemConstructor   CompletionItemKind = 4
+	CompletionItemModule        CompletionItemKind = 9
+	CompletionItemStruct        CompletionItemKind = 22
+	CompletionItemEnum          CompletionItemKind = 13
+	CompletionItemInterface     CompletionItemKind = 8
+	CompletionItemEnumMember    CompletionItemKind = 20
 	CompletionItemTypeParameter CompletionItemKind = 25
-	CompletionItemKeyword  CompletionItemKind = 14
-	CompletionItemValue    CompletionItemKind = 12
+	CompletionItemKeyword       CompletionItemKind = 14
+	CompletionItemValue         CompletionItemKind = 12
 )
 
 // CompletionItem is one suggestion. `Detail` shows a compact

--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -14,10 +14,10 @@ const (
 	// Source-action kinds are surfaced in editors as bulk operations
 	// on the entire file (e.g. "Organize Imports", "Fix All"); they
 	// are not attached to a specific diagnostic.
-	CodeActionSource              = "source"
+	CodeActionSource                = "source"
 	CodeActionSourceOrganizeImports = "source.organizeImports"
-	CodeActionSourceFixAll        = "source.fixAll"
-	CodeActionSourceFixAllOsty    = "source.fixAll.osty"
+	CodeActionSourceFixAll          = "source.fixAll"
+	CodeActionSourceFixAllOsty      = "source.fixAll.osty"
 )
 
 // wantsKind reports whether the client's `context.only` filter (if

--- a/internal/lsp/references.go
+++ b/internal/lsp/references.go
@@ -297,4 +297,3 @@ func sortLocations(locs []Location) {
 		return a.Character < b.Character
 	})
 }
-

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -630,7 +630,6 @@ func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
 	return pos.Offset <= len(pf.Source)
 }
 
-
 // analyzeSingleFile is the original file-only analysis used for
 // scratch buffers and files without .osty siblings.
 func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {

--- a/internal/manifest/toml.go
+++ b/internal/manifest/toml.go
@@ -34,11 +34,11 @@ import (
 // ever one of the *ptr/slice fields is set — callers switch on which
 // is non-nil.
 type value struct {
-	Str     *string
-	Int     *int64
-	Bool    *bool
-	Arr     *tomlArray
-	Tbl     *tomlTable
+	Str  *string
+	Int  *int64
+	Bool *bool
+	Arr  *tomlArray
+	Tbl  *tomlTable
 	// Line is the 1-based source line where the value begins; carried
 	// through so downstream errors point back at the right manifest
 	// line.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1870,11 +1870,11 @@ func (p *Parser) parseListLit() ast.Expr {
 // parseBlockOrMap disambiguates `{ ... }` between a block expression and a
 // map/set literal. Heuristics:
 //
-//   `{:}`              -> empty map
-//   `{ "k": v, ... }`  -> map
-//   `{ let x = ... }`  -> block (starts with keyword)
-//   `{ expr, expr }`   -> ambiguous; treated as block (statements).
-//                          A map literal requires at least one `:` entry.
+//	`{:}`              -> empty map
+//	`{ "k": v, ... }`  -> map
+//	`{ let x = ... }`  -> block (starts with keyword)
+//	`{ expr, expr }`   -> ambiguous; treated as block (statements).
+//	                       A map literal requires at least one `:` entry.
 //
 // We look ahead: if after `{` we see `:` immediately, it's `{:}`. Else we
 // scan the first top-level token. If we find a `:` before a statement

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -117,9 +117,9 @@ type Result struct {
 // DeclTiming records how long the type checker spent on one
 // declaration during one pass ("collect" or "check").
 type DeclTiming struct {
-	Name     string        `json:"name"`     // best-effort declaration name
-	Kind     string        `json:"kind"`     // "fn", "struct", "enum", …
-	Phase    string        `json:"phase"`    // "collect" | "check"
+	Name     string        `json:"name"`  // best-effort declaration name
+	Kind     string        `json:"kind"`  // "fn", "struct", "enum", …
+	Phase    string        `json:"phase"` // "collect" | "check"
 	Duration time.Duration `json:"-"`
 	// DurationMS mirrors Duration for JSON consumers.
 	DurationMS float64 `json:"duration_ms"`
@@ -257,10 +257,10 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 		Errors:   countSeverity(chk.Diags, diag.Error),
 		Warnings: countSeverity(chk.Diags, diag.Warning),
 		Counts: map[string]int{
-			"typed_exprs":  typedExprs,
-			"let_types":    len(chk.LetTypes),
-			"sym_types":    len(chk.SymTypes),
-			"instantiate":  len(chk.Instantiations),
+			"typed_exprs": typedExprs,
+			"let_types":   len(chk.LetTypes),
+			"sym_types":   len(chk.SymTypes),
+			"instantiate": len(chk.Instantiations),
 		},
 	})
 
@@ -812,12 +812,12 @@ func (r Result) RenderText(w io.Writer) {
 // downstream tooling can pick fields without re-parsing the human Output.
 func (r Result) RenderJSON(w io.Writer) error {
 	type stageJSON struct {
-		Name        string         `json:"name"`
-		DurationMS  float64        `json:"duration_ms"`
-		Output      string         `json:"output"`
-		Errors      int            `json:"errors"`
-		Warnings    int            `json:"warnings"`
-		Counts      map[string]int `json:"counts,omitempty"`
+		Name       string         `json:"name"`
+		DurationMS float64        `json:"duration_ms"`
+		Output     string         `json:"output"`
+		Errors     int            `json:"errors"`
+		Warnings   int            `json:"warnings"`
+		Counts     map[string]int `json:"counts,omitempty"`
 	}
 	stages := make([]stageJSON, len(r.Stages))
 	for i, s := range r.Stages {

--- a/internal/pkgmgr/semver/semver_test.go
+++ b/internal/pkgmgr/semver/semver_test.go
@@ -39,10 +39,10 @@ func TestParseVersionErrors(t *testing.T) {
 		"1.2.3.4",
 		"01.0.0", // leading zero
 		"1.02.0",
-		"1.2.3-",        // empty pre
-		"1.2.3-01",      // numeric ident with leading zero
-		"1.2.3-alpha+",  // empty build
-		"1.2.3-al_pha",  // invalid char
+		"1.2.3-",       // empty pre
+		"1.2.3-01",     // numeric ident with leading zero
+		"1.2.3-alpha+", // empty build
+		"1.2.3-al_pha", // invalid char
 	}
 	for _, s := range bad {
 		if _, err := ParseVersion(s); err == nil {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -37,16 +37,16 @@ const (
 //     values at merge time. Limited to one level of indirection so
 //     cycles are structurally impossible.
 type Profile struct {
-	Name      string
-	OptLevel  int
-	Debug     bool
-	Strip     bool
-	Overflow  bool
-	Inlining  bool
-	LTO       bool
-	GoFlags   []string
-	Env       map[string]string
-	Inherits  string
+	Name     string
+	OptLevel int
+	Debug    bool
+	Strip    bool
+	Overflow bool
+	Inlining bool
+	LTO      bool
+	GoFlags  []string
+	Env      map[string]string
+	Inherits string
 
 	// UserDefined is true when the profile came from the manifest
 	// (as opposed to the built-in defaults). Used by `osty profiles`

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -33,9 +33,9 @@ func TestDefaultProfilesShape(t *testing.T) {
 // TestParseTriple covers the common shapes plus one error path.
 func TestParseTriple(t *testing.T) {
 	cases := []struct {
-		in           string
-		arch, os     string
-		expectError  bool
+		in          string
+		arch, os    string
+		expectError bool
 	}{
 		{"amd64-linux", "amd64", "linux", false},
 		{"arm64-darwin", "arm64", "darwin", false},

--- a/internal/resolve/checks_test.go
+++ b/internal/resolve/checks_test.go
@@ -287,4 +287,3 @@ pub fn f() {}`)
 }
 
 // ---- Miscellaneous cross-phase correctness ----
-

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -309,7 +309,7 @@ func (r *resolver) pkg() *Package {
 // the member position to slot into the refs map) and emits a diagnostic
 // when the name is missing or private.
 func (r *resolver) resolvePackageMember(f *ast.FieldExpr, pkgSym *Symbol) {
-	_ = r.lookupPackageMember(pkgSym, f.Name, f.EndV, /*typePos*/ false)
+	_ = r.lookupPackageMember(pkgSym, f.Name, f.EndV /*typePos*/, false)
 }
 
 // lookupPackageMember walks the target package's exported scope for
@@ -1097,7 +1097,7 @@ func (r *resolver) resolveExpr(e ast.Expr) {
 			r.resolveExpr(fx.X)
 			if id, ok := fx.X.(*ast.Ident); ok {
 				if sym := r.refs[id]; sym != nil && sym.Kind == SymPackage {
-					r.lookupPackageMember(sym, fx.Name, fx.EndV, /*typePos*/ false)
+					r.lookupPackageMember(sym, fx.Name, fx.EndV /*typePos*/, false)
 				}
 			}
 		} else {
@@ -1569,7 +1569,7 @@ func (r *resolver) resolveType(t ast.Type) {
 				// segment (just `pkg`) it's a bad type position, but we
 				// still record the package symbol.
 				tail := n.Path[1]
-				resolved := r.lookupPackageMember(sym, tail, n.PosV, /*typePos*/ true)
+				resolved := r.lookupPackageMember(sym, tail, n.PosV /*typePos*/, true)
 				if resolved != nil {
 					r.typeRefs[n] = resolved
 				} else {

--- a/internal/resolve/scope.go
+++ b/internal/resolve/scope.go
@@ -20,18 +20,18 @@ import (
 type SymbolKind int
 
 const (
-	SymUnknown SymbolKind = iota
-	SymFn               // top-level or method `fn`
-	SymStruct           // `struct Name`
-	SymEnum             // `enum Name`
-	SymInterface        // `interface Name`
-	SymTypeAlias        // `type Name = ...`
-	SymLet              // `let` binding (immutable or mutable)
-	SymParam            // function/closure parameter
-	SymVariant          // enum variant (`Some`, `None`, `Ok`, `Err`, ...)
-	SymGeneric          // `T` type parameter
-	SymPackage          // alias bound by a `use` declaration
-	SymBuiltin          // primitive type or prelude name
+	SymUnknown   SymbolKind = iota
+	SymFn                   // top-level or method `fn`
+	SymStruct               // `struct Name`
+	SymEnum                 // `enum Name`
+	SymInterface            // `interface Name`
+	SymTypeAlias            // `type Name = ...`
+	SymLet                  // `let` binding (immutable or mutable)
+	SymParam                // function/closure parameter
+	SymVariant              // enum variant (`Some`, `None`, `Ok`, `Err`, ...)
+	SymGeneric              // `T` type parameter
+	SymPackage              // alias bound by a `use` declaration
+	SymBuiltin              // primitive type or prelude name
 )
 
 func (k SymbolKind) String() string {

--- a/internal/scaffold/ffi.go
+++ b/internal/scaffold/ffi.go
@@ -449,4 +449,3 @@ func isPotentialDecl(stmt string) bool {
 	// or extern variable — none of which the FFI scaffold handles.
 	return strings.Contains(stmt, "(") && strings.Contains(stmt, ")")
 }
-

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -81,17 +81,17 @@ const (
 	SHL    // <<
 	SHR    // >>
 
-	ASSIGN     // =
-	PLUSEQ     // +=
-	MINUSEQ    // -=
-	STAREQ     // *=
-	SLASHEQ    // /=
-	PERCENTEQ  // %=
-	BITANDEQ   // &=
-	BITOREQ    // |=
-	BITXOREQ   // ^=
-	SHLEQ      // <<=
-	SHREQ      // >>=
+	ASSIGN    // =
+	PLUSEQ    // +=
+	MINUSEQ   // -=
+	STAREQ    // *=
+	SLASHEQ   // /=
+	PERCENTEQ // %=
+	BITANDEQ  // &=
+	BITOREQ   // |=
+	BITXOREQ  // ^=
+	SHLEQ     // <<=
+	SHREQ     // >>=
 
 	QUESTION // ?
 	QDOT     // ?.
@@ -223,9 +223,9 @@ const (
 // its processed text (with escape sequences resolved). An expression segment
 // carries the tokens that were lexed inside `{ ... }`.
 type StringPart struct {
-	Kind  StringPartKind
-	Text  string  // for PartText
-	Expr  []Token // for PartExpr
+	Kind StringPartKind
+	Text string  // for PartText
+	Expr []Token // for PartExpr
 }
 
 // Token is a single lexical unit.

--- a/word_freq.osty
+++ b/word_freq.osty
@@ -7,6 +7,7 @@
 // 사용:  osty run word_freq.osty -- <file1> <file2> ...
 //
 // Grammar v0.2 / LANG_SPEC v0.9 준수 확인됨.
+// osty:ci-skip -- future stdlib/dogfood sample; see internal/gen realworld probe.
 //
 
 use std.fs


### PR DESCRIPTION
## Summary

- Add CI gates for Go formatting, Osty repair checks, and the Osty CI bundle.
- Teach `osty ci` to avoid treating fixture/sample subdirectories as implicit workspace packages when a root package exists.
- Add an explicit `osty:ci-skip` directive for future-facing samples such as `word_freq.osty`.
- Apply repository-wide `gofmt` cleanup so the new format gate is enforceable.

## Validation

- `gofmt -l $(git ls-files '*.go')`
- `osty repair --check` across tracked `.osty` files, excluding the intentional negative corpus
- `git diff --check`
- `go test ./internal/ci`
- `go run ./cmd/osty ci .`
- `go build ./...`
- `go vet ./...`
- `go test ./...`

## Notes

`word_freq.osty` remains as a future stdlib/dogfood depth probe, but is now explicitly skipped by `osty ci` so root CI can run cleanly today.
