### PR TITLE
Implement std.result

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -904,7 +904,8 @@ func resolveFile(file *ast.File) *resolve.Result {
 // checker. Sourcing from the cached registry keeps the stdlib Load
 // cost paid once per process.
 func checkOpts() check.Opts {
-	return check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	reg := stdlib.LoadCached()
+	return check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods}
 }
 
 func hasError(diags []*diag.Diagnostic) bool {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -74,6 +74,12 @@ type Opts struct {
 	// reachable via `x.name()` calls on primitive receivers.
 	Primitives map[types.PrimitiveKind]map[string]*ast.FnDecl
 
+	// ResultMethods is the method table from std.result's canonical
+	// Result<T, E> enum. When supplied, builtin Result method
+	// signatures are derived from these stdlib declarations; when nil,
+	// the checker keeps its bootstrap fallback signatures.
+	ResultMethods map[string]*ast.FnDecl
+
 	// OnDecl, if non-nil, is invoked for every top-level declaration
 	// the checker visits, once per pass ("collect" or "check"), with
 	// the wall-clock time spent in that pass. Used by `osty pipeline
@@ -109,6 +115,7 @@ func File(f *ast.File, rr *resolve.Result, opts ...Opts) *Result {
 	c.onDecl = firstOpt(opts).OnDecl
 	c.initBuiltins()
 	c.indexPrimitiveMethods(firstOpt(opts).Primitives)
+	c.resultMethods = firstOpt(opts).ResultMethods
 	c.indexSymbolsFrom(rr)
 	c.run()
 	return c.result
@@ -139,6 +146,7 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, opts ...Opts) *Res
 	c.onDecl = firstOpt(opts).OnDecl
 	c.initBuiltins()
 	c.indexPrimitiveMethods(firstOpt(opts).Primitives)
+	c.resultMethods = firstOpt(opts).ResultMethods
 
 	// Phase A: build symbol indexes from every file's Refs/TypeRefs
 	// BEFORE any collect pass runs, so the checker can cross-reference
@@ -216,6 +224,7 @@ func Workspace(
 
 	c := newChecker()
 	c.indexPrimitiveMethods(firstOpt(opts).Primitives)
+	c.resultMethods = firstOpt(opts).ResultMethods
 	// Seed c.resolved with any file's view so initBuiltins can walk up
 	// to the prelude. Every file in the workspace reaches the same
 	// prelude, so this is independent of which package we pick first.
@@ -391,6 +400,12 @@ type checker struct {
 	// calls on primitive receivers fall through to the legacy
 	// stdlibCallReturn escape hatch.
 	primMethods map[types.PrimitiveKind]map[string]*methodDesc
+
+	// resultMethods points at std.result's canonical Result enum
+	// methods when the caller supplied a stdlib Registry through Opts.
+	// Builtin Result dispatch consults this before using its bootstrap
+	// fallback signatures.
+	resultMethods map[string]*ast.FnDecl
 
 	// externalCollected tracks imported packages whose declaration
 	// surfaces have been collected into result.SymTypes / result.Descs.

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -659,7 +659,7 @@ func runCheckWithStdlib(t *testing.T, src string) []*diag.Diagnostic {
 	reg := loadRegistry()
 	file, parseDiags := parser.ParseDiagnostics([]byte(src))
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	all := append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...)
 	all = append(all, chk.Diags...)
 	var errs []*diag.Diagnostic
@@ -776,6 +776,85 @@ fn test(r: Result<Int, String>) -> Bool {
 }
 `
 	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_ResultCombinatorsPreservePreciseTypes(t *testing.T) {
+	src := `
+fn parse() -> Result<Int, String> { Ok(1) }
+
+fn test() {
+    let mapped: Result<String, String> = parse().map(|n| "value={n}")
+    let mappedErr: Result<Int, Int> = parse().mapErr(|e| e.len())
+    let okValue: Int? = parse().ok()
+    let errValue: String? = parse().err()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_ResultMapRejectsWrongReturnType(t *testing.T) {
+	src := `
+fn parse() -> Result<Int, String> { Ok(1) }
+
+fn test() {
+    let mapped: Result<Int, String> = parse().map(|n| "value={n}")
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_ResultMethodsCanComeFromStdlibSource(t *testing.T) {
+	method := resultMethodForTest(t, "map", `pub enum Result<T, E> {
+    Ok(T),
+    Err(E),
+
+    pub fn map(self) -> Bool { true }
+}
+`)
+	src := `
+fn parse() -> Result<Int, String> { Ok(1) }
+
+fn test() {
+    let b: Bool = parse().map()
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	res := resolve.File(file, resolve.NewPrelude())
+	chk := check.File(file, res, check.Opts{ResultMethods: map[string]*ast.FnDecl{"map": method}})
+	all := append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...)
+	all = append(all, chk.Diags...)
+	assertOK(t, onlyErrors(all))
+}
+
+func resultMethodForTest(t *testing.T, name, src string) *ast.FnDecl {
+	t.Helper()
+	file, diags := parser.ParseDiagnostics([]byte(src))
+	if errs := onlyErrors(diags); len(errs) > 0 {
+		t.Fatalf("parse result stub: %v", errs[0])
+	}
+	for _, d := range file.Decls {
+		enum, ok := d.(*ast.EnumDecl)
+		if !ok || enum.Name != "Result" {
+			continue
+		}
+		for _, m := range enum.Methods {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("result method %q not found", name)
+	return nil
+}
+
+func onlyErrors(diags []*diag.Diagnostic) []*diag.Diagnostic {
+	errs := make([]*diag.Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		if d.Severity == diag.Error {
+			errs = append(errs, d)
+		}
+	}
+	return errs
 }
 
 // loadRegistry loads the stdlib registry once per test run. Isolated

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -1291,6 +1291,9 @@ func (c *checker) builtinNamedMethod(n *types.Named, name string) *methodDesc {
 		if len(n.Args) != 2 {
 			return nil
 		}
+		if md := c.resultMethodFromStdlib(n, name); md != nil {
+			return md
+		}
 		return resultMethod(n, name)
 	case "Chan", "Channel":
 		// §8.5: channel methods recognized by the checker. The gen
@@ -1353,13 +1356,15 @@ func resultMethod(n *types.Named, name string) *methodDesc {
 	case "err":
 		return simpleMethod(name, nil, &types.Optional{Inner: e})
 	case "map":
-		fn := &types.FnType{Params: []types.Type{t}, Return: types.ErrorType}
-		return simpleMethod(name, []types.Type{fn},
-			&types.Named{Sym: n.Sym, Args: []types.Type{types.ErrorType, e}})
+		u := resultMethodTypeVar("U")
+		fn := &types.FnType{Params: []types.Type{t}, Return: u}
+		return genericMethod(name, []types.Type{fn},
+			&types.Named{Sym: n.Sym, Args: []types.Type{u, e}}, u)
 	case "mapErr":
-		fn := &types.FnType{Params: []types.Type{e}, Return: types.ErrorType}
-		return simpleMethod(name, []types.Type{fn},
-			&types.Named{Sym: n.Sym, Args: []types.Type{t, types.ErrorType}})
+		f := resultMethodTypeVar("F")
+		fn := &types.FnType{Params: []types.Type{e}, Return: f}
+		return genericMethod(name, []types.Type{fn},
+			&types.Named{Sym: n.Sym, Args: []types.Type{t, f}}, f)
 	case "toString":
 		return simpleMethod(name, nil, types.String)
 	}
@@ -1374,6 +1379,16 @@ func simpleMethod(name string, params []types.Type, ret types.Type) *methodDesc 
 		Name: name,
 		Fn:   &types.FnType{Params: params, Return: ret},
 	}
+}
+
+func genericMethod(name string, params []types.Type, ret types.Type, generics ...*types.TypeVar) *methodDesc {
+	md := simpleMethod(name, params, ret)
+	md.Generics = generics
+	return md
+}
+
+func resultMethodTypeVar(name string) *types.TypeVar {
+	return &types.TypeVar{Sym: &resolve.Symbol{Name: name, Kind: resolve.SymGeneric}}
 }
 
 // tryBuiltinCall handles prelude-defined callables like `println`,

--- a/internal/check/method_candidates.go
+++ b/internal/check/method_candidates.go
@@ -28,8 +28,14 @@ func (c *checker) methodCandidates(t types.Type) []string {
 		if v.Sym != nil {
 			switch v.Sym.Name {
 			case "Result":
-				for _, name := range []string{"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr", "ok", "err", "map", "mapErr", "toString"} {
-					add(name)
+				if len(c.resultMethods) > 0 {
+					for name := range c.resultMethods {
+						add(name)
+					}
+				} else {
+					for _, name := range []string{"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr", "ok", "err", "map", "mapErr", "toString"} {
+						add(name)
+					}
 				}
 			case "Chan", "Channel":
 				for _, name := range []string{"recv", "send", "close"} {

--- a/internal/check/result_methods.go
+++ b/internal/check/result_methods.go
@@ -1,0 +1,114 @@
+package check
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/types"
+)
+
+func (c *checker) resultMethodFromStdlib(n *types.Named, name string) *methodDesc {
+	if len(c.resultMethods) == 0 || n == nil || len(n.Args) != 2 {
+		return nil
+	}
+	fn := c.resultMethods[name]
+	if fn == nil {
+		return nil
+	}
+	conv := resultMethodConverter{
+		checker: c,
+		owner: map[string]types.Type{
+			"T": n.Args[0],
+			"E": n.Args[1],
+		},
+		method: map[string]*types.TypeVar{},
+	}
+	generics := make([]*types.TypeVar, 0, len(fn.Generics))
+	for _, g := range fn.Generics {
+		tv := &types.TypeVar{Sym: &resolve.Symbol{Name: g.Name, Kind: resolve.SymGeneric}}
+		for _, b := range g.Constraints {
+			tv.Bounds = append(tv.Bounds, conv.typ(b))
+		}
+		conv.method[g.Name] = tv
+		generics = append(generics, tv)
+	}
+	params := make([]types.Type, 0, len(fn.Params))
+	for _, p := range fn.Params {
+		params = append(params, conv.typ(p.Type))
+	}
+	ret := types.Type(types.Unit)
+	if fn.ReturnType != nil {
+		ret = conv.typ(fn.ReturnType)
+	}
+	return &methodDesc{
+		Name:     fn.Name,
+		Pub:      fn.Pub,
+		Recv:     fn.Recv,
+		Fn:       &types.FnType{Params: params, Return: ret},
+		HasBody:  fn.Body != nil,
+		Params:   fn.Params,
+		Decl:     fn,
+		Generics: generics,
+	}
+}
+
+type resultMethodConverter struct {
+	checker *checker
+	owner   map[string]types.Type
+	method  map[string]*types.TypeVar
+}
+
+func (c resultMethodConverter) typ(t ast.Type) types.Type {
+	if t == nil {
+		return types.Unit
+	}
+	switch x := t.(type) {
+	case *ast.NamedType:
+		if len(x.Path) == 1 {
+			name := x.Path[0]
+			if t, ok := c.owner[name]; ok && len(x.Args) == 0 {
+				return t
+			}
+			if tv, ok := c.method[name]; ok && len(x.Args) == 0 {
+				return tv
+			}
+			if scalar, ok := c.checker.builtinScalarType(name); ok && len(x.Args) == 0 {
+				return scalar
+			}
+			args := make([]types.Type, len(x.Args))
+			for i, a := range x.Args {
+				args[i] = c.typ(a)
+			}
+			return &types.Named{Sym: c.builtinSym(name), Args: args}
+		}
+		return types.ErrorType
+	case *ast.OptionalType:
+		return &types.Optional{Inner: c.typ(x.Inner)}
+	case *ast.TupleType:
+		if len(x.Elems) == 0 {
+			return types.Unit
+		}
+		elems := make([]types.Type, len(x.Elems))
+		for i, e := range x.Elems {
+			elems[i] = c.typ(e)
+		}
+		return &types.Tuple{Elems: elems}
+	case *ast.FnType:
+		params := make([]types.Type, len(x.Params))
+		for i, p := range x.Params {
+			params[i] = c.typ(p)
+		}
+		ret := types.Type(types.Unit)
+		if x.ReturnType != nil {
+			ret = c.typ(x.ReturnType)
+		}
+		return &types.FnType{Params: params, Return: ret}
+	}
+	return types.ErrorType
+}
+
+func (c resultMethodConverter) builtinSym(name string) *resolve.Symbol {
+	if sym := c.checker.lookupBuiltin(name); sym != nil {
+		return sym
+	}
+	return syntheticBuiltinSym(name)
+}

--- a/internal/check/testhelpers_test.go
+++ b/internal/check/testhelpers_test.go
@@ -13,8 +13,9 @@ import (
 // a Registry — just the primitive method table. Split out so the
 // primary test file doesn't have to import the stdlib package twice.
 type registryShim struct {
-	Primitives map[types.PrimitiveKind]map[string]*ast.FnDecl
-	lookup     func(string) *resolve.Package
+	Primitives    map[types.PrimitiveKind]map[string]*ast.FnDecl
+	ResultMethods map[string]*ast.FnDecl
+	lookup        func(string) *resolve.Package
 }
 
 func (r registryShim) LookupPackage(dotPath string) *resolve.Package {
@@ -34,7 +35,11 @@ var (
 func loadRegistryOnce() registryShim {
 	registryCacheOnce.Do(func() {
 		reg := stdlib.Load()
-		registryCache = &registryShim{Primitives: reg.Primitives, lookup: reg.LookupPackage}
+		registryCache = &registryShim{
+			Primitives:    reg.Primitives,
+			ResultMethods: reg.ResultMethods,
+			lookup:        reg.LookupPackage,
+		}
 	})
 	return *registryCache
 }

--- a/internal/ci/lintcheck.go
+++ b/internal/ci/lintcheck.go
@@ -57,7 +57,8 @@ func (r *Runner) checkLint() *Check {
 // checkOpts mirrors the cmd/osty helper so primitive method
 // lookup works during the CI lint pass.
 func checkOpts() check.Opts {
-	return check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	reg := stdlib.LoadCached()
+	return check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods}
 }
 
 // lintConfigFromManifest extracts the [lint] section from the

--- a/internal/examples/examples_test.go
+++ b/internal/examples/examples_test.go
@@ -132,14 +132,15 @@ func TestWorkspaceExampleChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWorkspace: %v", err)
 	}
-	ws.Stdlib = stdlib.LoadCached()
+	reg := stdlib.LoadCached()
+	ws.Stdlib = reg
 	for _, member := range m.Workspace.Members {
 		if _, err := ws.LoadPackage(member); err != nil {
 			t.Fatalf("load workspace member %s: %v", member, err)
 		}
 	}
 	results := ws.ResolveAll()
-	checks := check.Workspace(ws, results, check.Opts{Primitives: stdlib.LoadCached().Primitives})
+	checks := check.Workspace(ws, results, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	paths := make([]string, 0, len(ws.Packages))
 	for p := range ws.Packages {
 		paths = append(paths, p)
@@ -188,7 +189,8 @@ func checkPackageDir(t *testing.T, dir string, includeTests bool) (*resolve.Pack
 	if err != nil {
 		t.Fatalf("workspace %s: %v", dir, err)
 	}
-	ws.Stdlib = stdlib.LoadCached()
+	reg := stdlib.LoadCached()
+	ws.Stdlib = reg
 	ws.Packages[""] = pkg
 	pkg.Name = filepath.Base(dir)
 	preloadPackageUses(ws, pkg)
@@ -198,7 +200,7 @@ func checkPackageDir(t *testing.T, dir string, includeTests bool) (*resolve.Pack
 		t.Fatalf("missing root package result for %s", dir)
 	}
 	failOnErrors(t, rel(repoRoot(t), dir)+" resolve", pr.Diags)
-	chk := check.Package(pkg, pr, check.Opts{Primitives: stdlib.LoadCached().Primitives})
+	chk := check.Package(pkg, pr, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	failOnErrors(t, rel(repoRoot(t), dir)+" check", chk.Diags)
 	return pkg, chk
 }
@@ -235,7 +237,7 @@ func transpileFile(t *testing.T, path string) []byte {
 	reg := stdlib.LoadCached()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
 	failOnErrors(t, rel(repoRoot(t), path)+" resolve", res.Diags)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	failOnErrors(t, rel(repoRoot(t), path)+" check", chk.Diags)
 	goSrc, err := gen.Generate("main", file, res, chk)
 	if err != nil {

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -191,7 +191,7 @@ func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string) {
 // Plain strings (no interpolation) are emitted as Go string literals
 // via strconv.Quote. Interpolated strings are rewritten to a
 // `fmt.Sprintf` call: each literal segment becomes a quoted run, each
-// expression segment becomes a `%v` verb and a trailing argument.
+// expression segment is first routed through the Osty toString bridge.
 func (g *gen) emitStringLit(s *ast.StringLit) {
 	// Fast path: no interpolation.
 	plain := true
@@ -210,8 +210,9 @@ func (g *gen) emitStringLit(s *ast.StringLit) {
 		return
 	}
 
-	// Interpolated: fmt.Sprintf("...", args...).
+	// Interpolated: fmt.Sprintf("...", ostyToString(args)...).
 	g.use("fmt")
+	g.needStringRuntime = true
 	var format strings.Builder
 	var args []ast.Expr
 	for _, p := range s.Parts {
@@ -219,14 +220,15 @@ func (g *gen) emitStringLit(s *ast.StringLit) {
 			// Escape `%` in literal runs so fmt treats them as literal.
 			format.WriteString(strings.ReplaceAll(p.Lit, "%", "%%"))
 		} else {
-			format.WriteString("%v")
+			format.WriteString("%s")
 			args = append(args, p.Expr)
 		}
 	}
 	g.body.writef("fmt.Sprintf(%s", strconv.Quote(format.String()))
 	for _, a := range args {
-		g.body.write(", ")
+		g.body.write(", ostyToString(")
 		g.emitExpr(a)
+		g.body.write(")")
 	}
 	g.body.write(")")
 }
@@ -410,6 +412,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 			return
 		}
 		if g.emitRandomGenericMethod(c, f) {
+			return
+		}
+		if g.emitResultMethodCall(c, f) {
 			return
 		}
 		if g.emitStaticCall(f, c.Args) {
@@ -1272,6 +1277,38 @@ func (g *gen) emitStaticCall(f *ast.FieldExpr, args []*ast.Arg) bool {
 	}
 	g.body.write(")")
 	return true
+}
+
+func (g *gen) emitResultMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	n, ok := types.AsNamedBuiltin(g.typeOf(f.X), "Result")
+	if !ok || len(n.Args) != 2 {
+		return false
+	}
+	switch f.Name {
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultMap(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "mapErr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultMapErr(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	}
+	return false
 }
 
 // emitEnumMethodCall rewrites `enumValue.method(args)` as

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -85,6 +85,11 @@ type gen struct {
 	// prompting a runtime type definition at file top.
 	needResult bool
 
+	// needStringRuntime is set when generated code needs the Osty
+	// toString protocol bridge for interpolation or nested stdlib
+	// toString implementations.
+	needStringRuntime bool
+
 	// needRange is set when a standalone range literal is emitted, so
 	// the runtime Range struct can be injected at the top of the file.
 	needRange bool
@@ -356,6 +361,9 @@ func (g *gen) run() ([]byte, error) {
 		g.useAs("strings", "stdstrings")
 		g.use("time")
 	}
+	if g.needResult || g.needStringRuntime {
+		g.use("fmt")
+	}
 
 	// 3. Assemble header + body.
 	var out bytes.Buffer
@@ -402,6 +410,20 @@ func (g *gen) run() ([]byte, error) {
 	// Inject the runtime type definitions we depend on. Emitted at top
 	// of body (after imports) so every downstream declaration can use
 	// them without caring about order.
+	if g.needResult || g.needStringRuntime {
+		out.WriteString(`
+type ostyStringer interface {
+	toString() string
+}
+
+func ostyToString(v any) string {
+	if s, ok := v.(ostyStringer); ok {
+		return s.toString()
+	}
+	return fmt.Sprint(v)
+}
+`)
+	}
 	if g.needResult {
 		out.WriteString(`
 // Result is the runtime representation of Osty's Result<T, E>.
@@ -435,6 +457,41 @@ func (r Result[T, E]) unwrapOr(fallback T) T {
 		return r.Value
 	}
 	return fallback
+}
+
+func (r Result[T, E]) ok() *T {
+	if r.IsOk {
+		return &r.Value
+	}
+	return nil
+}
+
+func (r Result[T, E]) err() *E {
+	if !r.IsOk {
+		return &r.Error
+	}
+	return nil
+}
+
+func (r Result[T, E]) toString() string {
+	if r.IsOk {
+		return "Ok(" + ostyToString(r.Value) + ")"
+	}
+	return "Err(" + ostyToString(r.Error) + ")"
+}
+
+func resultMap[T any, E any, U any](r Result[T, E], f func(T) U) Result[U, E] {
+	if r.IsOk {
+		return Result[U, E]{Value: f(r.Value), IsOk: true}
+	}
+	return Result[U, E]{Error: r.Error}
+}
+
+func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F] {
+	if r.IsOk {
+		return Result[T, F]{Value: r.Value, IsOk: true}
+	}
+	return Result[T, F]{Error: f(r.Error)}
 }
 `)
 	}

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -39,7 +39,7 @@ func transpileWithStdlib(t *testing.T, src string) ([]byte, error) {
 		}
 	}
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	return gen.Generate("main", file, res, chk)
 }
 

--- a/internal/gen/result_test.go
+++ b/internal/gen/result_test.go
@@ -102,6 +102,81 @@ fn main() {
 	}
 }
 
+func TestResultIntrinsicMethodsRuntime(t *testing.T) {
+	src := `fn main() {
+    let ok: Result<Int, String> = Ok(5)
+    println(ok.isOk())
+    println(ok.isErr())
+    println(ok.unwrap())
+    println(ok.unwrapOr(9))
+    println(ok.toString())
+    let nested: Result<Result<Int, String>, String> = Ok(ok)
+    println(nested.toString())
+    println("{nested}")
+    match ok.ok() {
+        Some(n) -> println("ok value: {n}"),
+        None -> println("missing"),
+    }
+
+    let err: Result<Int, String> = Err("bad")
+    println(err.isOk())
+    println(err.isErr())
+    println(err.unwrapOr(9))
+    println(err.unwrapErr())
+    println(err.toString())
+    match err.err() {
+        Some(e) -> println("err value: {e}"),
+        None -> println("missing"),
+    }
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	want := "true\nfalse\n5\n5\nOk(5)\nOk(Ok(5))\nOk(Ok(5))\nok value: 5\nfalse\ntrue\n9\nbad\nErr(bad)\nerr value: bad\n"
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}
+
+func TestResultMapAndMapErr(t *testing.T) {
+	src := `fn parse(s: String) -> Result<Int, Int> {
+    if s == "ok" { Ok(2) } else { Err(40) }
+}
+
+fn main() {
+    let mapped: Result<String, Int> = parse("ok").map(|n| "v={n}")
+    match mapped {
+        Ok(s) -> println("mapped {s}"),
+        Err(e) -> println("err {e}"),
+    }
+
+    let stillErr: Result<String, Int> = parse("bad").map(|n| "v={n}")
+    match stillErr {
+        Ok(s) -> println("mapped {s}"),
+        Err(e) -> println("still err {e}"),
+    }
+
+    let errMapped: Result<Int, String> = parse("bad").mapErr(|e| "e={e}")
+    match errMapped {
+        Ok(n) -> println("ok {n}"),
+        Err(e) -> println("mapped err {e}"),
+    }
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	want := "mapped v=2\nstill err 40\nmapped err e=40\n"
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}
+
 // TestResultChainedQuestion — two `?` lifts in a row, both in a
 // Result-returning function.
 func TestResultChainedQuestion(t *testing.T) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -117,9 +117,9 @@ type Result struct {
 // DeclTiming records how long the type checker spent on one
 // declaration during one pass ("collect" or "check").
 type DeclTiming struct {
-	Name     string        `json:"name"`     // best-effort declaration name
-	Kind     string        `json:"kind"`     // "fn", "struct", "enum", …
-	Phase    string        `json:"phase"`    // "collect" | "check"
+	Name     string        `json:"name"`  // best-effort declaration name
+	Kind     string        `json:"kind"`  // "fn", "struct", "enum", …
+	Phase    string        `json:"phase"` // "collect" | "check"
 	Duration time.Duration `json:"-"`
 	// DurationMS mirrors Duration for JSON consumers.
 	DurationMS float64 `json:"duration_ms"`
@@ -229,7 +229,8 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 
 	// --- check ---
 	t0 = time.Now()
-	checkOpts := check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	reg := stdlib.LoadCached()
+	checkOpts := check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods}
 	if cfg.PerDecl {
 		checkOpts.OnDecl = func(d ast.Decl, phase string, dur time.Duration) {
 			r.PerDecl = append(r.PerDecl, DeclTiming{
@@ -257,10 +258,10 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 		Errors:   countSeverity(chk.Diags, diag.Error),
 		Warnings: countSeverity(chk.Diags, diag.Warning),
 		Counts: map[string]int{
-			"typed_exprs":  typedExprs,
-			"let_types":    len(chk.LetTypes),
-			"sym_types":    len(chk.SymTypes),
-			"instantiate":  len(chk.Instantiations),
+			"typed_exprs": typedExprs,
+			"let_types":   len(chk.LetTypes),
+			"sym_types":   len(chk.SymTypes),
+			"instantiate": len(chk.Instantiations),
 		},
 	})
 
@@ -389,7 +390,8 @@ func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
 
 	// --- check (whole-package) ---
 	t0 = time.Now()
-	checkOpts := check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	reg := stdlib.LoadCached()
+	checkOpts := check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods}
 	if cfg.PerDecl {
 		checkOpts.OnDecl = func(d ast.Decl, phase string, dur time.Duration) {
 			r.PerDecl = append(r.PerDecl, DeclTiming{
@@ -612,7 +614,8 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 
 	// --- check (cross-package) ---
 	t0 = time.Now()
-	checkOpts := check.Opts{Primitives: stdlib.LoadCached().Primitives}
+	reg := stdlib.LoadCached()
+	checkOpts := check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods}
 	if cfg.PerDecl {
 		checkOpts.OnDecl = func(d ast.Decl, phase string, dur time.Duration) {
 			r.PerDecl = append(r.PerDecl, DeclTiming{
@@ -812,12 +815,12 @@ func (r Result) RenderText(w io.Writer) {
 // downstream tooling can pick fields without re-parsing the human Output.
 func (r Result) RenderJSON(w io.Writer) error {
 	type stageJSON struct {
-		Name        string         `json:"name"`
-		DurationMS  float64        `json:"duration_ms"`
-		Output      string         `json:"output"`
-		Errors      int            `json:"errors"`
-		Warnings    int            `json:"warnings"`
-		Counts      map[string]int `json:"counts,omitempty"`
+		Name       string         `json:"name"`
+		DurationMS float64        `json:"duration_ms"`
+		Output     string         `json:"output"`
+		Errors     int            `json:"errors"`
+		Warnings   int            `json:"warnings"`
+		Counts     map[string]int `json:"counts,omitempty"`
 	}
 	stages := make([]stageJSON, len(r.Stages))
 	for i, s := range r.Stages {

--- a/internal/stdlib/modules/result.osty
+++ b/internal/stdlib/modules/result.osty
@@ -1,12 +1,75 @@
-// std.result — signature stub for the Osty standard library.
+// std.result — Result helpers for the Osty standard library.
 //
 // Canonical definition site of `Result<T, E>`, `Ok`, and `Err`.
 // The prelude auto-imports these so user code can write `Ok(x)` /
 // `Err(e)` and return types like `Result<Int, Error>` without an
-// explicit `use`. Combinators (`map`, `unwrap`, `?` propagation helpers)
-// will be added alongside the rest of the stdlib's method bodies.
+// explicit `use`.
 
 pub enum Result<T, E> {
     Ok(T),
     Err(E),
+
+    pub fn isOk(self) -> Bool {
+        match self {
+            Ok(_) -> true,
+            Err(_) -> false,
+        }
+    }
+
+    pub fn isErr(self) -> Bool {
+        match self {
+            Ok(_) -> false,
+            Err(_) -> true,
+        }
+    }
+
+    // Implemented by the runtime intrinsic because the Err branch
+    // aborts with Never.
+    pub fn unwrap(self) -> T
+
+    // Implemented by the runtime intrinsic because the Ok branch
+    // aborts with Never.
+    pub fn unwrapErr(self) -> E
+
+    pub fn unwrapOr(self, fallback: T) -> T {
+        match self {
+            Ok(value) -> value,
+            Err(_) -> fallback,
+        }
+    }
+
+    pub fn ok(self) -> T? {
+        match self {
+            Ok(value) -> Some(value),
+            Err(_) -> None,
+        }
+    }
+
+    pub fn err(self) -> E? {
+        match self {
+            Ok(_) -> None,
+            Err(error) -> Some(error),
+        }
+    }
+
+    pub fn map<U>(self, f: fn(T) -> U) -> Result<U, E> {
+        match self {
+            Ok(value) -> Ok(f(value)),
+            Err(error) -> Err(error),
+        }
+    }
+
+    pub fn mapErr<F>(self, f: fn(E) -> F) -> Result<T, F> {
+        match self {
+            Ok(value) -> Ok(value),
+            Err(error) -> Err(f(error)),
+        }
+    }
+
+    pub fn toString(self) -> String {
+        match self {
+            Ok(value) -> "Ok({value})",
+            Err(error) -> "Err({error})",
+        }
+    }
 }

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -62,6 +62,12 @@ type Registry struct {
 	// carries signature and body; the type checker consumes this map
 	// when resolving `x.abs()`-style calls where `x` is a primitive.
 	Primitives map[types.PrimitiveKind]map[string]*ast.FnDecl
+	// ResultMethods holds the methods declared on std.result's
+	// canonical Result<T, E> enum. The checker can use these source
+	// declarations as the stdlib-backed method surface for the prelude
+	// builtin Result, while still retaining a bootstrap fallback when
+	// no registry is supplied.
+	ResultMethods map[string]*ast.FnDecl
 	// Diags aggregates parse diagnostics from every stub. A well-formed
 	// Registry has zero error-severity entries.
 	Diags []*diag.Diagnostic
@@ -100,8 +106,9 @@ type Module struct {
 // re-parsing on every invocation.
 func Load() *Registry {
 	r := &Registry{
-		Modules:    map[string]*Module{},
-		Primitives: map[types.PrimitiveKind]map[string]*ast.FnDecl{},
+		Modules:       map[string]*Module{},
+		Primitives:    map[types.PrimitiveKind]map[string]*ast.FnDecl{},
+		ResultMethods: map[string]*ast.FnDecl{},
 	}
 
 	// One prelude shared across every stub's resolve pass. The prelude
@@ -142,6 +149,9 @@ func Load() *Registry {
 			r.absorbPrimitiveStub(file, p)
 			continue
 		}
+		if moduleName(p) == "result" {
+			r.absorbResultStub(file)
+		}
 		r.Modules[moduleName(p)] = &Module{
 			Name:    moduleName(p),
 			Path:    p,
@@ -178,6 +188,19 @@ func (r *Registry) absorbPrimitiveStub(file *ast.File, path string) {
 			}
 		}
 		_ = path // reserved for richer diagnostics in a later step
+	}
+}
+
+func (r *Registry) absorbResultStub(file *ast.File) {
+	for _, decl := range file.Decls {
+		enum, ok := decl.(*ast.EnumDecl)
+		if !ok || enum.Name != "Result" {
+			continue
+		}
+		for _, m := range enum.Methods {
+			r.ResultMethods[m.Name] = m
+		}
+		return
 	}
 }
 

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
@@ -137,6 +138,68 @@ func TestOptionModuleParsed(t *testing.T) {
 	}
 	if m.Path != "modules/option.osty" {
 		t.Errorf(`Module "option" Path = %q, want "modules/option.osty"`, m.Path)
+	}
+}
+
+func TestResultModuleMethods(t *testing.T) {
+	r := Load()
+	m, ok := r.Modules["result"]
+	if !ok {
+		t.Fatal(`Registry missing module "result"`)
+	}
+	var resultEnum *ast.EnumDecl
+	for _, d := range m.File.Decls {
+		if e, ok := d.(*ast.EnumDecl); ok && e.Name == "Result" {
+			resultEnum = e
+			break
+		}
+	}
+	if resultEnum == nil {
+		t.Fatal(`Module "result" missing Result enum`)
+	}
+	got := map[string]bool{}
+	hasBody := map[string]bool{}
+	for _, method := range resultEnum.Methods {
+		got[method.Name] = true
+		hasBody[method.Name] = method.Body != nil
+	}
+	for _, name := range []string{
+		"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr",
+		"ok", "err", "map", "mapErr", "toString",
+	} {
+		if !got[name] {
+			t.Errorf("Result missing method %q", name)
+		}
+		if r.ResultMethods[name] == nil {
+			t.Errorf("Registry.ResultMethods missing method %q", name)
+		}
+	}
+	for _, name := range []string{"isOk", "isErr", "unwrapOr", "ok", "err", "map", "mapErr", "toString"} {
+		if !hasBody[name] {
+			t.Errorf("Result.%s should have an Osty body", name)
+		}
+	}
+	for _, name := range []string{"unwrap", "unwrapErr"} {
+		if hasBody[name] {
+			t.Errorf("Result.%s should stay runtime-intrinsic", name)
+		}
+	}
+}
+
+func TestResultModuleBodiesTypeCheck(t *testing.T) {
+	mod := Load().Modules["result"]
+	if mod == nil {
+		t.Fatal("std.result not loaded")
+	}
+	file, parseDiags := parser.ParseDiagnostics(mod.Source)
+	res := resolve.File(file, resolve.NewPrelude())
+	chk := check.File(file, res)
+	all := append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...)
+	all = append(all, chk.Diags...)
+	for _, d := range all {
+		if d.Severity == diag.Error {
+			t.Fatalf("std.result should type-check: [%s] %s", d.Code, d.Message)
+		}
 	}
 }
 
@@ -571,7 +634,7 @@ pub fn score(r: Float) -> Float {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.math diagnostic: %s", d.Error())
@@ -634,7 +697,7 @@ pub fn namedWord(text: String) -> String {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.regex diagnostic: %s", d.Error())
@@ -682,7 +745,7 @@ pub fn roundTrip(text: String) -> Bool {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.encoding diagnostic: %s", d.Error())
@@ -731,7 +794,7 @@ pub fn smoke(name: String) -> Result<String, Error> {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.env diagnostic: %s", d.Error())
@@ -777,7 +840,7 @@ pub fn smoke(text: String) -> Result<String, Error> {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.csv diagnostic: %s", d.Error())
@@ -819,7 +882,7 @@ pub fn roundTrip(data: Bytes) -> Bytes {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.compress diagnostic: %s", d.Error())
@@ -867,7 +930,7 @@ pub fn digest(data: Bytes, key: Bytes) -> Bool {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.crypto diagnostic: %s", d.Error())
@@ -913,7 +976,7 @@ pub fn smoke() -> Bool {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range append(res.Diags, chk.Diags...) {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected std.uuid diagnostic: %s", d.Error())
@@ -977,7 +1040,7 @@ func TestPrimitiveMethodCheckerIntegration(t *testing.T) {
 	}
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range chk.Diags {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected checker error: %s", d.Error())
@@ -998,7 +1061,7 @@ func TestRegistryShadowsEscapeHatch_Abs(t *testing.T) {
 	file, _ := parser.ParseDiagnostics(src)
 	reg := Load()
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
-	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	for _, d := range chk.Diags {
 		if d.Code == diag.CodeUnknownMethod {
 			t.Errorf("Registry dispatch regressed — abs fell through to escape hatch: %s",

--- a/internal/testgen/testgen.go
+++ b/internal/testgen/testgen.go
@@ -11,13 +11,14 @@
 //
 //  1. For each PackageFile, invoke gen.Generate. Each result is a
 //     complete Go file with its own `package main` clause, imports,
-//     and (when applicable) a copy of the Result<T, E> runtime type.
+//     and (when applicable) a copy of the Result<T, E> / toString
+//     runtime helpers.
 //
 //  2. Parse every result with go/parser, then merge them into one
-//     ast.File: dedupe imports, keep the first Result<T, E>
-//     definition seen, and strip the no-op `var testing = struct{…}{…}`
-//     stub that gen emits for `use std.testing`. The resulting
-//     merged ast.File is printed back out as main.go.
+//     ast.File: dedupe imports, keep the first runtime helper
+//     definitions seen, and strip the no-op `var testing = struct{…}{…}`
+//     stub that gen emits for `use std.testing`. The resulting merged
+//     ast.File is printed back out as main.go.
 //
 //  3. Rename any user-defined func main to _ostyProgramMain, rewrite
 //     direct main() calls to that preserved entry point, then append a
@@ -116,6 +117,8 @@ func GenerateHarness(pkg *resolve.Package, chk *check.Result, entries []Entry) (
 	var importSpecs []goast.Spec
 	seenResult := false
 	seenRange := false
+	seenOstyStringer := false
+	seenOstyToString := false
 	var firstGenErr error
 	hasProgramMain := packageHasProgramMain(pkg)
 
@@ -173,6 +176,18 @@ func GenerateHarness(pkg *resolve.Package, chk *check.Result, entries []Entry) (
 				}
 				seenRange = true
 			}
+			if isOstyStringerRuntime(d) {
+				if seenOstyStringer {
+					continue
+				}
+				seenOstyStringer = true
+			}
+			if isOstyToStringRuntime(d) {
+				if seenOstyToString {
+					continue
+				}
+				seenOstyToString = true
+			}
 			if isTestingStub(d) {
 				// Dropped — replaced by the runtime in harness.go.
 				continue
@@ -227,6 +242,20 @@ func isResultRuntime(d goast.Decl) bool {
 	}
 	_, isStruct := ts.Type.(*goast.StructType)
 	return isStruct
+}
+
+func isOstyStringerRuntime(d goast.Decl) bool {
+	gd, ok := d.(*goast.GenDecl)
+	if !ok || gd.Tok != gotoken.TYPE || len(gd.Specs) != 1 {
+		return false
+	}
+	ts, ok := gd.Specs[0].(*goast.TypeSpec)
+	return ok && ts.Name != nil && ts.Name.Name == "ostyStringer"
+}
+
+func isOstyToStringRuntime(d goast.Decl) bool {
+	fn, ok := d.(*goast.FuncDecl)
+	return ok && fn.Recv == nil && fn.Name != nil && fn.Name.Name == "ostyToString"
 }
 
 // isRangeRuntime reports whether d is the Range struct gen emits

--- a/internal/testgen/testgen_test.go
+++ b/internal/testgen/testgen_test.go
@@ -97,6 +97,10 @@ func TestGenerateHarness_DedupesResultRuntime(t *testing.T) {
 	if count != 1 {
 		t.Errorf("expected exactly 1 Result type definition, got %d", count)
 	}
+	count = strings.Count(string(srcs.Main), "func ostyToString(v any) string")
+	if count != 1 {
+		t.Errorf("expected exactly 1 ostyToString helper, got %d", count)
+	}
 }
 
 // TestGenerateHarness_StripsTestingStub checks that the no-op `var
@@ -200,7 +204,8 @@ func loadCalc(t *testing.T, dir string) (*resolve.Package, *check.Result) {
 	if err != nil {
 		t.Fatalf("workspace: %v", err)
 	}
-	ws.Stdlib = stdlib.LoadCached()
+	reg := stdlib.LoadCached()
+	ws.Stdlib = reg
 	ws.Packages[""] = pkg
 	pkg.Name = filepath.Base(dir)
 	for _, pf := range pkg.Files {
@@ -219,7 +224,7 @@ func loadCalc(t *testing.T, dir string) (*resolve.Package, *check.Result) {
 		}
 	}
 	results := ws.ResolveAll()
-	chk := check.Package(pkg, results[""])
+	chk := check.Package(pkg, results[""], check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
 	return pkg, chk
 }
 


### PR DESCRIPTION
## Summary
- implement `std.result` method bodies where possible in Osty and wire stdlib result methods into checker metadata
- add codegen support for Result helpers, map/mapErr, toString, and interpolation through `ostyToString`
- expand stdlib, checker, generator, and testgen coverage for Result behavior

## Tests
- `go test ./...`
