### PR TITLE
[codex] Implement std.ref identity semantics

### DIFF
--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -222,7 +222,7 @@ func (g *gen) emitEnumDecl(e *ast.EnumDecl) {
 func (g *gen) emitVariant(e *ast.EnumDecl, v *ast.Variant) {
 	name := e.Name + "_" + v.Name
 	if len(v.Fields) == 0 {
-		g.body.writef("type %s struct{}\n", name)
+		g.body.writef("type %s struct{ _ref byte }\n", name)
 	} else {
 		g.body.writef("type %s struct {\n", name)
 		g.body.indent()
@@ -257,12 +257,7 @@ func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
 	if free {
 		g.body.writef("func %s_%s", typeName, m.Name)
 	} else {
-		// Pointer receiver for `mut self`, value for `self`.
-		if m.Recv.Mut {
-			g.body.writef("func (self *%s) %s", typeName, m.Name)
-		} else {
-			g.body.writef("func (self %s) %s", typeName, m.Name)
-		}
+		g.body.writef("func (self *%s) %s", typeName, m.Name)
 	}
 	g.body.write("(")
 	first := true
@@ -324,7 +319,7 @@ func (g *gen) emitEnumVariantMethodWrappers(e *ast.EnumDecl, m *ast.FnDecl) {
 		recvType := e.Name + "_" + v.Name
 		g.body.nl()
 		g.sourceMarker(m)
-		g.body.writef("func (self %s) %s(", recvType, m.Name)
+		g.body.writef("func (self *%s) %s(", recvType, m.Name)
 		paramNames := make([]string, len(m.Params))
 		for i, p := range m.Params {
 			if i > 0 {
@@ -366,7 +361,7 @@ func (g *gen) emitEnumVariantMethodWrappers(e *ast.EnumDecl, m *ast.FnDecl) {
 // enclosing type's name; other type expressions pass through unchanged.
 func (g *gen) resolveSelfType(t ast.Type, typeName string) string {
 	if n, ok := t.(*ast.NamedType); ok && len(n.Path) == 1 && n.Path[0] == "Self" {
-		return typeName
+		return g.goSelfTypeAST(n.Args)
 	}
 	return g.goTypeExpr(t)
 }
@@ -511,34 +506,42 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			writeString  func(path string, contents string) Result[struct{}, any]
 			exists       func(path string) bool
 			remove       func(path string) Result[struct{}, any]
+			}{
+				readToString: func(path string) Result[string, any] {
+					data, err := %[1]s.ReadFile(path)
+					if err != nil {
+						return resultErr[string, any](err)
+					}
+					if !%[2]s.Valid(data) {
+						return resultErr[string, any]("fs.readToString: invalid UTF-8 in " + path)
+					}
+					return resultOk[string, any](string(data))
+				},
+				writeString: func(path string, contents string) Result[struct{}, any] {
+					if err := %[1]s.WriteFile(path, []byte(contents), 0o644); err != nil {
+						return resultErr[struct{}, any](err)
+					}
+					return resultOk[struct{}, any](struct{}{})
+				},
+				exists: func(path string) bool {
+					_, err := %[1]s.Stat(path)
+					return err == nil
+				},
+				remove: func(path string) Result[struct{}, any] {
+					if err := %[1]s.Remove(path); err != nil {
+						return resultErr[struct{}, any](err)
+					}
+					return resultOk[struct{}, any](struct{}{})
+				},
+			}`, osAlias, utf8Alias), full)
+		return true
+	case "ref":
+		g.needRefRuntime = true
+		g.emitUseStub(alias, `struct {
+			same func(any, any) bool
 		}{
-			readToString: func(path string) Result[string, any] {
-				data, err := %[1]s.ReadFile(path)
-				if err != nil {
-					return Result[string, any]{Error: err}
-				}
-				if !%[2]s.Valid(data) {
-					return Result[string, any]{Error: "fs.readToString: invalid UTF-8 in " + path}
-				}
-				return Result[string, any]{Value: string(data), IsOk: true}
-			},
-			writeString: func(path string, contents string) Result[struct{}, any] {
-				if err := %[1]s.WriteFile(path, []byte(contents), 0o644); err != nil {
-					return Result[struct{}, any]{Error: err}
-				}
-				return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
-			},
-			exists: func(path string) bool {
-				_, err := %[1]s.Stat(path)
-				return err == nil
-			},
-			remove: func(path string) Result[struct{}, any] {
-				if err := %[1]s.Remove(path); err != nil {
-					return Result[struct{}, any]{Error: err}
-				}
-				return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
-			},
-		}`, osAlias, utf8Alias), full)
+			same: refSame,
+		}`, full)
 		return true
 	case "json":
 		g.needJSON = true

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -100,7 +100,7 @@ func (g *gen) emitIdent(id *ast.Ident) {
 	// use sites work (a bare struct value cannot be the scrutinee of a
 	// `v.(Enum_Variant)` type assertion).
 	if owner, ok := g.variantOwner[id.Name]; ok {
-		g.body.writef("%s(%s_%s{})", owner, owner, id.Name)
+		g.body.writef("%s(&%s_%s{})", owner, owner, id.Name)
 		return
 	}
 	g.body.write(mangleIdent(id.Name))
@@ -137,11 +137,26 @@ func (g *gen) emitStructLit(s *ast.StructLit) {
 	default:
 		g.emitExpr(s.Type)
 	}
+	refStruct := false
+	if n, ok := g.typeOf(s).(*types.Named); ok && g.isReferenceStructSym(n.Sym) {
+		refStruct = true
+		if got := g.goType(n); strings.HasPrefix(got, "*") {
+			typeName = strings.TrimPrefix(got, "*")
+		}
+	} else if id, ok := s.Type.(*ast.Ident); ok && g.structTypes[id.Name] {
+		refStruct = true
+	}
+	if typeName != "" && g.structTypes[typeName] {
+		refStruct = true
+	}
 	if s.Spread != nil && typeName != "" {
-		g.emitStructSpreadLit(s, typeName)
+		g.emitStructSpreadLit(s, typeName, refStruct)
 		return
 	}
 	if typeName != "" {
+		if refStruct {
+			g.body.write("&")
+		}
 		g.body.write(typeName)
 	}
 	g.body.write("{")
@@ -169,9 +184,16 @@ func (g *gen) emitStructLit(s *ast.StructLit) {
 // emitStructSpreadLit lowers `Type { f: v, ..base }` to an IIFE that
 // copies base then assigns each explicit field, matching Osty's
 // "overrides win" semantics (§3.4).
-func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string) {
+func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string, refStruct bool) {
 	tmp := g.freshVar("_r")
-	g.body.writef("func() %s { %s := ", typeName, tmp)
+	retType := typeName
+	if refStruct {
+		retType = "*" + typeName
+	}
+	g.body.writef("func() %s { %s := ", retType, tmp)
+	if refStruct {
+		g.body.write("*")
+	}
 	g.emitExpr(s.Spread)
 	g.body.write("; ")
 	for _, f := range s.Fields {
@@ -182,6 +204,10 @@ func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string) {
 			g.emitExpr(f.Value)
 		}
 		g.body.write("; ")
+	}
+	if refStruct {
+		g.body.writef("return &%s }()", tmp)
+		return
 	}
 	g.body.writef("return %s }()", tmp)
 }
@@ -266,10 +292,39 @@ func (g *gen) emitBinary(b *ast.BinaryExpr) {
 		g.emitCoalesce(b)
 		return
 	}
+	if (b.Op == token.EQ || b.Op == token.NEQ) && g.needsOstyEqual(b.Left, b.Right) {
+		if b.Op == token.NEQ {
+			g.body.write("!")
+		}
+		g.needEqualRuntime = true
+		g.body.write("ostyEqual(")
+		g.emitExpr(b.Left)
+		g.body.write(", ")
+		g.emitExpr(b.Right)
+		g.body.write(")")
+		return
+	}
 	op := binaryOp(b.Op)
 	g.emitExpr(b.Left)
 	g.body.writef(" %s ", op)
 	g.emitExpr(b.Right)
+}
+
+func (g *gen) needsOstyEqual(left, right ast.Expr) bool {
+	return needsOstyEqualType(g.typeOf(left)) || needsOstyEqualType(g.typeOf(right))
+}
+
+func needsOstyEqualType(t types.Type) bool {
+	switch t := t.(type) {
+	case nil:
+		return false
+	case *types.Primitive:
+		return t.Kind == types.PBytes
+	case *types.Untyped:
+		return false
+	default:
+		return true
+	}
 }
 
 func binaryOp(k token.Kind) string {
@@ -388,6 +443,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 			return
 		}
 		if g.emitErrorMethodCall(c, f) {
+			return
+		}
+		if g.emitStdlibRefCall(c, f) {
 			return
 		}
 		if g.emitStdlibEncodingCall(c, f) {
@@ -607,6 +665,32 @@ func (g *gen) isPreludeErrorTypeExpr(e ast.Expr) bool {
 func isErrorType(t types.Type) bool {
 	n, ok := t.(*types.Named)
 	return ok && n.Sym != nil && n.Sym.Name == "Error"
+}
+
+func (g *gen) emitStdlibRefCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "ref") || f.Name != "same" || len(c.Args) != 2 {
+		return false
+	}
+	if t := g.typeOf(c.Args[0].Value); hasValueSemantics(t) {
+		g.body.write("false")
+		return true
+	}
+	g.needRefRuntime = true
+	g.body.write("refSame(")
+	g.emitExpr(c.Args[0].Value)
+	g.body.write(", ")
+	g.emitExpr(c.Args[1].Value)
+	g.body.write(")")
+	return true
+}
+
+func hasValueSemantics(t types.Type) bool {
+	switch t.(type) {
+	case *types.Primitive, *types.Untyped, *types.Tuple:
+		return true
+	}
+	return false
 }
 
 func (g *gen) emitStdlibEncodingCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
@@ -2178,7 +2262,7 @@ func (g *gen) listReturnGo(call *ast.CallExpr, elemGo string) string {
 // to the enum interface type so downstream type assertions work even
 // when the value flows through a generic position like a `let` short-form.
 func (g *gen) emitVariantCtor(owner, name string, args []*ast.Arg) {
-	g.body.writef("%s(%s_%s{", owner, owner, name)
+	g.body.writef("%s(&%s_%s{", owner, owner, name)
 	for i, a := range args {
 		if i > 0 {
 			g.body.write(", ")
@@ -2456,9 +2540,9 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 				callType = g.typeOf(call)
 			}
 			tArg, tErr := g.resultTypeArgsAt(callType, g.typeOf(args[0].Value), false)
-			g.body.writef("Result[%s, %s]{Value: ", tArg, tErr)
+			g.body.writef("resultOk[%s, %s](", tArg, tErr)
 			g.emitExpr(args[0].Value)
-			g.body.write(", IsOk: true}")
+			g.body.write(")")
 			return true
 		}
 	case "Err":
@@ -2469,9 +2553,9 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 				callType = g.typeOf(call)
 			}
 			tArg, tErr := g.resultTypeArgsAt(callType, g.typeOf(args[0].Value), true)
-			g.body.writef("Result[%s, %s]{Error: ", tArg, tErr)
+			g.body.writef("resultErr[%s, %s](", tArg, tErr)
 			g.emitExpr(args[0].Value)
-			g.body.write("}")
+			g.body.write(")")
 			return true
 		}
 	}
@@ -2923,6 +3007,10 @@ func (g *gen) emitList(l *ast.ListExpr) {
 		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
 			elemType = g.goType(n.Args[0])
 		}
+	}
+	if len(l.Elems) == 0 {
+		g.body.writef("make([]%s, 0, 1)", elemType)
+		return
 	}
 	g.body.writef("[]%s{", elemType)
 	for i, e := range l.Elems {

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -73,6 +73,12 @@ type gen struct {
 	// receivers at emitCall time.
 	enumTypes map[string]bool
 
+	// structTypes is the set of struct names declared in this file.
+	// User structs lower as reference types, so expression emitters need
+	// a quick local-name check even for AST nodes that the resolver does
+	// not record in Refs.
+	structTypes map[string]bool
+
 	// methodNames[typeName] is the set of method names declared on
 	// that type, used at emitCall to distinguish instance-method
 	// invocation from field access to a function-valued field.
@@ -150,6 +156,14 @@ type gen struct {
 	// generation/parsing helpers.
 	needUUID bool
 
+	// needRefRuntime is set when std.ref.same lowers to the runtime
+	// reference-identity helper.
+	needRefRuntime bool
+
+	// needEqualRuntime is set when ==/!= need Osty's structural equality
+	// instead of Go's pointer/interface identity for lowered reference values.
+	needEqualRuntime bool
+
 	// currentRetType tracks the enclosing function's return type so the
 	// `?` lift at let-stmt position can reconstruct the Result with the
 	// correct type parameters when the operand's T differs.
@@ -202,6 +216,7 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 		imports:      map[string]string{},
 		variantOwner: map[string]string{},
 		enumTypes:    map[string]bool{},
+		structTypes:  map[string]bool{},
 		methodNames:  map[string]map[string]bool{},
 	}
 	g.indexTypes()
@@ -227,6 +242,7 @@ func (g *gen) indexTypes() {
 				g.methodNames[d.Name][m.Name] = true
 			}
 		case *ast.StructDecl:
+			g.structTypes[d.Name] = true
 			if g.methodNames[d.Name] == nil {
 				g.methodNames[d.Name] = map[string]bool{}
 			}
@@ -389,6 +405,12 @@ func (g *gen) run() ([]byte, error) {
 	if g.needResult || g.needStringRuntime || g.needErrorRuntime {
 		g.use("fmt")
 	}
+	if g.needRefRuntime || g.needEqualRuntime {
+		g.use("reflect")
+	}
+	if g.needRefRuntime {
+		g.use("unsafe")
+	}
 
 	// 3. Assemble header + body.
 	var out bytes.Buffer
@@ -457,6 +479,17 @@ type Result[T any, E any] struct {
 	Value T
 	Error E
 	IsOk  bool
+	ref   *byte
+}
+
+func resultRef() *byte { return new(byte) }
+
+func resultOk[T any, E any](value T) Result[T, E] {
+	return Result[T, E]{Value: value, IsOk: true, ref: resultRef()}
+}
+
+func resultErr[T any, E any](err E) Result[T, E] {
+	return Result[T, E]{Error: err, ref: resultRef()}
 }
 
 func (r Result[T, E]) isOk() bool { return r.IsOk }
@@ -507,16 +540,16 @@ func (r Result[T, E]) toString() string {
 
 func resultMap[T any, E any, U any](r Result[T, E], f func(T) U) Result[U, E] {
 	if r.IsOk {
-		return Result[U, E]{Value: f(r.Value), IsOk: true}
+		return resultOk[U, E](f(r.Value))
 	}
-	return Result[U, E]{Error: r.Error}
+	return resultErr[U, E](r.Error)
 }
 
 func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F] {
 	if r.IsOk {
-		return Result[T, F]{Value: r.Value, IsOk: true}
+		return resultOk[T, F](r.Value)
 	}
-	return Result[T, F]{Error: f(r.Error)}
+	return resultErr[T, F](f(r.Error))
 }
 `)
 	}
@@ -615,12 +648,12 @@ func jsonStringify(value any) string { return jsonEncode(value) }
 func jsonDecode[T any](text string) Result[T, any] {
 	var out T
 	if err := jsonRejectLoneSurrogates(text); err != nil {
-		return Result[T, any]{Error: err}
+		return resultErr[T, any](err)
 	}
 	if err := jsonUnmarshalInto([]byte(text), &out); err != nil {
-		return Result[T, any]{Error: err}
+		return resultErr[T, any](err)
 	}
-	return Result[T, any]{Value: out, IsOk: true}
+	return resultOk[T, any](out)
 }
 
 func jsonObject(value map[string]Json) Json { return value }
@@ -664,6 +697,14 @@ func jsonUnmarshalReflect(data []byte, target reflect.Type, dest reflect.Value) 
 	}
 	if target.Kind() == reflect.Pointer {
 		if jsonRawIsNull(data) {
+			if target.Implements(reflect.TypeOf((*stdjson.Unmarshaler)(nil)).Elem()) {
+				ptr := reflect.New(target.Elem())
+				if err := stdjson.Unmarshal(data, ptr.Interface()); err != nil {
+					return err
+				}
+				dest.Set(ptr)
+				return nil
+			}
 			dest.SetZero()
 			return nil
 		}
@@ -823,7 +864,6 @@ func jsonIsNil(value any) bool {
 		return false
 	}
 }
-
 func jsonRejectLoneSurrogates(text string) error {
 	inString := false
 	for i := 0; i < len(text); i++ {
@@ -883,6 +923,160 @@ func jsonHex4(s string) (rune, bool) {
 		r = r*16 + rune(v)
 	}
 	return r, true
+}
+`)
+	}
+	if g.needEqualRuntime {
+		out.WriteString(`
+func ostyEqual(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if !av.IsValid() || !bv.IsValid() {
+		return ostyIsNilValue(av) && ostyIsNilValue(bv)
+	}
+	return ostyEqualValue(av, bv, map[ostyEqualVisit]bool{})
+}
+
+type ostyEqualVisit struct {
+	a, b uintptr
+	typ  reflect.Type
+}
+
+func ostyEqualValue(a, b reflect.Value, seen map[ostyEqualVisit]bool) bool {
+	if !a.IsValid() || !b.IsValid() {
+		return ostyIsNilValue(a) && ostyIsNilValue(b)
+	}
+	if a.Type() != b.Type() {
+		return ostyIsNilValue(a) && ostyIsNilValue(b)
+	}
+	switch a.Kind() {
+	case reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		return ostyEqualValue(a.Elem(), b.Elem(), seen)
+	case reflect.Pointer:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		visit := ostyEqualVisit{a: a.Pointer(), b: b.Pointer(), typ: a.Type()}
+		if seen[visit] {
+			return true
+		}
+		seen[visit] = true
+		return ostyEqualValue(a.Elem(), b.Elem(), seen)
+	case reflect.Struct:
+		for i := 0; i < a.NumField(); i++ {
+			if a.Type().Field(i).Name == "ref" {
+				continue
+			}
+			if !ostyEqualValue(a.Field(i), b.Field(i), seen) {
+				return false
+			}
+		}
+		return true
+	case reflect.Array, reflect.Slice:
+		if a.Kind() == reflect.Slice && (a.IsNil() || b.IsNil()) {
+			return a.IsNil() == b.IsNil()
+		}
+		if a.Len() != b.Len() {
+			return false
+		}
+		for i := 0; i < a.Len(); i++ {
+			if !ostyEqualValue(a.Index(i), b.Index(i), seen) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		if a.Len() != b.Len() {
+			return false
+		}
+		for _, key := range a.MapKeys() {
+			bv := b.MapIndex(key)
+			if !bv.IsValid() || !ostyEqualValue(a.MapIndex(key), bv, seen) {
+				return false
+			}
+		}
+		return true
+	case reflect.String:
+		return a.String() == b.String()
+	case reflect.Bool:
+		return a.Bool() == b.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return a.Int() == b.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return a.Uint() == b.Uint()
+	case reflect.Float32, reflect.Float64:
+		return a.Float() == b.Float()
+	case reflect.Complex64, reflect.Complex128:
+		return a.Complex() == b.Complex()
+	case reflect.Func:
+		return a.IsNil() && b.IsNil()
+	case reflect.Chan, reflect.UnsafePointer:
+		return a.Pointer() == b.Pointer()
+	default:
+		if a.CanInterface() && b.CanInterface() {
+			return reflect.DeepEqual(a.Interface(), b.Interface())
+		}
+		return false
+	}
+}
+
+func ostyIsNilValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+`)
+	}
+	if g.needRefRuntime {
+		out.WriteString(`
+func refSame(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if !av.IsValid() || !bv.IsValid() || av.Type() != bv.Type() {
+		return false
+	}
+	switch av.Kind() {
+	case reflect.Func:
+		ap := refInterfaceData(a)
+		return ap != nil && ap == refInterfaceData(b)
+	case reflect.Slice:
+		ap := av.Pointer()
+		return ap != 0 && ap == bv.Pointer()
+	case reflect.Chan, reflect.Map, reflect.Pointer, reflect.UnsafePointer:
+		ap := av.Pointer()
+		return ap != 0 && ap == bv.Pointer()
+	case reflect.Struct:
+		af := av.FieldByName("ref")
+		bf := bv.FieldByName("ref")
+		if af.IsValid() && bf.IsValid() && af.Kind() == reflect.Pointer && bf.Kind() == reflect.Pointer {
+			ap := af.Pointer()
+			return ap != 0 && ap == bf.Pointer()
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+type refInterfaceHeader struct {
+	typ  unsafe.Pointer
+	data unsafe.Pointer
+}
+
+func refInterfaceData(v any) unsafe.Pointer {
+	return (*refInterfaceHeader)(unsafe.Pointer(&v)).data
 }
 `)
 	}
@@ -986,13 +1180,13 @@ type Url struct {
 func urlParse(text string) Result[Url, any] {
 	parsed, err := neturl.Parse(text)
 	if err != nil {
-		return Result[Url, any]{Error: err.Error()}
+		return resultErr[Url, any](err.Error())
 	}
 	var port *int
 	if raw := parsed.Port(); raw != "" {
 		n, err := strconv.Atoi(raw)
 		if err != nil {
-			return Result[Url, any]{Error: err.Error()}
+			return resultErr[Url, any](err.Error())
 		}
 		port = &n
 	}
@@ -1012,30 +1206,27 @@ func urlParse(text string) Result[Url, any] {
 			query[key] = values[0]
 		}
 	}
-	return Result[Url, any]{
-		Value: Url{
-			scheme:   parsed.Scheme,
-			host:     parsed.Hostname(),
-			port:     port,
-			path:     parsed.Path,
-			query:    query,
-			queryAll: queryAll,
-			fragment: fragment,
-		},
-		IsOk: true,
-	}
+	return resultOk[Url, any](Url{
+		scheme:   parsed.Scheme,
+		host:     parsed.Hostname(),
+		port:     port,
+		path:     parsed.Path,
+		query:    query,
+		queryAll: queryAll,
+		fragment: fragment,
+	})
 }
 
 func urlJoin(base, relative string) Result[string, any] {
 	b, err := neturl.Parse(base)
 	if err != nil {
-		return Result[string, any]{Error: err.Error()}
+		return resultErr[string, any](err.Error())
 	}
 	r, err := neturl.Parse(relative)
 	if err != nil {
-		return Result[string, any]{Error: err.Error()}
+		return resultErr[string, any](err.Error())
 	}
-	return Result[string, any]{Value: b.ResolveReference(r).String(), IsOk: true}
+	return resultOk[string, any](b.ResolveReference(r).String())
 }
 
 func (u Url) toString() string {
@@ -1096,9 +1287,9 @@ type Captures struct {
 func regexCompile(pattern string) Result[Regex, error] {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return Result[Regex, error]{Error: err}
+		return resultErr[Regex, error](err)
 	}
-	return Result[Regex, error]{Value: Regex{re: re}, IsOk: true}
+	return resultOk[Regex, error](Regex{re: re})
 }
 
 func (r Regex) matches(text string) bool { return r.re.MatchString(text) }
@@ -1198,9 +1389,9 @@ func encodingBase64Encode(data []byte) string {
 func encodingBase64Decode(text string) Result[[]byte, any] {
 	data, err := stdbase64.StdEncoding.DecodeString(text)
 	if err != nil {
-		return Result[[]byte, any]{Error: err}
+		return resultErr[[]byte, any](err)
 	}
-	return Result[[]byte, any]{Value: data, IsOk: true}
+	return resultOk[[]byte, any](data)
 }
 
 func encodingBase64URLEncode(data []byte) string {
@@ -1210,9 +1401,9 @@ func encodingBase64URLEncode(data []byte) string {
 func encodingBase64URLDecode(text string) Result[[]byte, any] {
 	data, err := stdbase64.URLEncoding.DecodeString(text)
 	if err != nil {
-		return Result[[]byte, any]{Error: err}
+		return resultErr[[]byte, any](err)
 	}
-	return Result[[]byte, any]{Value: data, IsOk: true}
+	return resultOk[[]byte, any](data)
 }
 
 func encodingHexEncode(data []byte) string {
@@ -1222,9 +1413,9 @@ func encodingHexEncode(data []byte) string {
 func encodingHexDecode(text string) Result[[]byte, any] {
 	data, err := stdhex.DecodeString(text)
 	if err != nil {
-		return Result[[]byte, any]{Error: err}
+		return resultErr[[]byte, any](err)
 	}
-	return Result[[]byte, any]{Value: data, IsOk: true}
+	return resultOk[[]byte, any](data)
 }
 
 func encodingURLEncode(text string) string {
@@ -1234,9 +1425,9 @@ func encodingURLEncode(text string) string {
 func encodingURLDecode(text string) Result[string, any] {
 	text, err := neturl.QueryUnescape(text)
 	if err != nil {
-		return Result[string, any]{Error: err}
+		return resultErr[string, any](err)
 	}
-	return Result[string, any]{Value: text, IsOk: true}
+	return resultOk[string, any](text)
 }
 `)
 	}
@@ -1259,23 +1450,23 @@ func envGet(name string) *string {
 func envRequire(name string) Result[string, any] {
 	value, ok := os.LookupEnv(name)
 	if !ok {
-		return Result[string, any]{Error: fmt.Errorf("environment variable %s is not set", name)}
+		return resultErr[string, any](fmt.Errorf("environment variable %s is not set", name))
 	}
-	return Result[string, any]{Value: value, IsOk: true}
+	return resultOk[string, any](value)
 }
 
 func envSet(name, value string) Result[struct{}, any] {
 	if err := os.Setenv(name, value); err != nil {
-		return Result[struct{}, any]{Error: err}
+		return resultErr[struct{}, any](err)
 	}
-	return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+	return resultOk[struct{}, any](struct{}{})
 }
 
 func envUnset(name string) Result[struct{}, any] {
 	if err := os.Unsetenv(name); err != nil {
-		return Result[struct{}, any]{Error: err}
+		return resultErr[struct{}, any](err)
 	}
-	return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+	return resultOk[struct{}, any](struct{}{})
 }
 
 func envVars() map[string]string {
@@ -1291,16 +1482,16 @@ func envVars() map[string]string {
 func envCurrentDir() Result[string, any] {
 	dir, err := os.Getwd()
 	if err != nil {
-		return Result[string, any]{Error: err}
+		return resultErr[string, any](err)
 	}
-	return Result[string, any]{Value: dir, IsOk: true}
+	return resultOk[string, any](dir)
 }
 
 func envSetCurrentDir(path string) Result[struct{}, any] {
 	if err := os.Chdir(path); err != nil {
-		return Result[struct{}, any]{Error: err}
+		return resultErr[struct{}, any](err)
 	}
-	return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+	return resultOk[struct{}, any](struct{}{})
 }
 `)
 	}
@@ -1385,9 +1576,9 @@ func csvDecodeWith(text string, options CsvOptions) Result[[][]string, any] {
 	if options.quote != '"' {
 		rows, err := csvDecodeCustom(text, options)
 		if err != nil {
-			return Result[[][]string, any]{Error: err}
+			return resultErr[[][]string, any](err)
 		}
-		return Result[[][]string, any]{Value: rows, IsOk: true}
+		return resultOk[[][]string, any](rows)
 	}
 	r := stdcsv.NewReader(stdstrings.NewReader(text))
 	r.Comma = options.delimiter
@@ -1395,9 +1586,9 @@ func csvDecodeWith(text string, options CsvOptions) Result[[][]string, any] {
 	r.FieldsPerRecord = -1
 	rows, err := r.ReadAll()
 	if err != nil {
-		return Result[[][]string, any]{Error: err}
+		return resultErr[[][]string, any](err)
 	}
-	return Result[[][]string, any]{Value: rows, IsOk: true}
+	return resultOk[[][]string, any](rows)
 }
 
 func csvDecodeCustom(text string, options CsvOptions) ([][]string, error) {
@@ -1474,11 +1665,11 @@ func csvDecodeCustom(text string, options CsvOptions) ([][]string, error) {
 func csvDecodeHeaders(text string) Result[[]map[string]string, any] {
 	rowsRes := csvDecode(text)
 	if !rowsRes.IsOk {
-		return Result[[]map[string]string, any]{Error: rowsRes.Error}
+		return resultErr[[]map[string]string, any](rowsRes.Error)
 	}
 	rows := rowsRes.Value
 	if len(rows) == 0 {
-		return Result[[]map[string]string, any]{Value: []map[string]string{}, IsOk: true}
+		return resultOk[[]map[string]string, any]([]map[string]string{})
 	}
 	headers := rows[0]
 	out := make([]map[string]string, 0, len(rows)-1)
@@ -1493,7 +1684,7 @@ func csvDecodeHeaders(text string) Result[[]map[string]string, any] {
 		}
 		out = append(out, record)
 	}
-	return Result[[]map[string]string, any]{Value: out, IsOk: true}
+	return resultOk[[]map[string]string, any](out)
 }
 `)
 	}
@@ -1514,17 +1705,17 @@ func compressGzipEncode(data []byte) []byte {
 func compressGzipDecode(data []byte) Result[[]byte, any] {
 	r, err := stdgzip.NewReader(stdbytes.NewReader(data))
 	if err != nil {
-		return Result[[]byte, any]{Error: err}
+		return resultErr[[]byte, any](err)
 	}
 	out, readErr := stdio.ReadAll(r)
 	closeErr := r.Close()
 	if readErr != nil {
-		return Result[[]byte, any]{Error: readErr}
+		return resultErr[[]byte, any](readErr)
 	}
 	if closeErr != nil {
-		return Result[[]byte, any]{Error: closeErr}
+		return resultErr[[]byte, any](closeErr)
 	}
-	return Result[[]byte, any]{Value: out, IsOk: true}
+	return resultOk[[]byte, any](out)
 }
 `)
 	}
@@ -1615,17 +1806,17 @@ func uuidParse(text string) Result[Uuid, any] {
 		compact = text
 	case 36:
 		if text[8] != '-' || text[13] != '-' || text[18] != '-' || text[23] != '-' {
-			return Result[Uuid, any]{Error: fmt.Errorf("invalid UUID %q", text)}
+			return resultErr[Uuid, any](fmt.Errorf("invalid UUID %q", text))
 		}
 		compact = stdstrings.ReplaceAll(text, "-", "")
 	default:
-		return Result[Uuid, any]{Error: fmt.Errorf("invalid UUID %q", text)}
+		return resultErr[Uuid, any](fmt.Errorf("invalid UUID %q", text))
 	}
 	var u Uuid
 	if _, err := stdhex.Decode(u[:], []byte(compact)); err != nil {
-		return Result[Uuid, any]{Error: err}
+		return resultErr[Uuid, any](err)
 	}
-	return Result[Uuid, any]{Value: u, IsOk: true}
+	return resultOk[Uuid, any](u)
 }
 
 func uuidNil() Uuid { return Uuid{} }

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -449,7 +449,7 @@ fn main() {
 	if out != want {
 		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
 	}
-	for _, want := range []string{"stdjson.Marshal", "func (self Payload) MarshalJSON", "func (self *Payload) UnmarshalJSON", "jsonDecode[Payload]", "jsonUnmarshalShape"} {
+	for _, want := range []string{"stdjson.Marshal", "func (self Payload) MarshalJSON", "func (self *Payload) UnmarshalJSON", "jsonDecode[*Payload]", "jsonUnmarshalShape"} {
 		if !strings.Contains(string(goSrc), want) {
 			t.Errorf("generated std.json bridge missing %s:\n%s", want, goSrc)
 		}

--- a/internal/gen/json.go
+++ b/internal/gen/json.go
@@ -71,7 +71,9 @@ func (g *gen) emitStructJSONUnmarshal(s *ast.StructDecl) {
 		g.body.writeln("return jsonAsError(result.Error)")
 		g.body.dedent()
 		g.body.writeln("}")
-		g.body.writeln("*self = result.Value")
+		g.body.writef("if result.Value == nil { return fmt.Errorf(%q) }\n",
+			fmt.Sprintf("std.json: %s.fromJson returned nil", s.Name))
+		g.body.writeln("*self = *result.Value")
 		g.body.writeln("return nil")
 		g.body.dedent()
 		g.body.writeln("}")
@@ -172,7 +174,7 @@ func (g *gen) emitEnumJSONDecoder(e *ast.EnumDecl) {
 		g.body.indent()
 		switch len(v.Fields) {
 		case 0:
-			g.body.writef("return %s(%s{}), nil\n", e.Name, goName)
+			g.body.writef("return %s(&%s{}), nil\n", e.Name, goName)
 		case 1:
 			fieldType := g.goTypeExpr(v.Fields[0])
 			missing := fmt.Sprintf("std.json: %s missing value", label)
@@ -180,7 +182,7 @@ func (g *gen) emitEnumJSONDecoder(e *ast.EnumDecl) {
 			g.body.writef("if len(head.Value) == 0 { return nil, fmt.Errorf(%q) }\n", missing)
 			g.body.writef("var f0 %s\n", fieldType)
 			g.body.writef("if err := jsonUnmarshalInto(head.Value, &f0); err != nil { return nil, fmt.Errorf(%q, err) }\n", msg)
-			g.body.writef("return %s(%s{F0: f0}), nil\n", e.Name, goName)
+			g.body.writef("return %s(&%s{F0: f0}), nil\n", e.Name, goName)
 		default:
 			g.body.writef("values, err := jsonUnmarshalArray(head.Value, %d, %q)\n", len(v.Fields), label)
 			g.body.writeln("if err != nil {")
@@ -193,7 +195,7 @@ func (g *gen) emitEnumJSONDecoder(e *ast.EnumDecl) {
 				g.body.writef("var f%d %s\n", i, g.goTypeExpr(f))
 				g.body.writef("if err := jsonUnmarshalInto(values[%d], &f%d); err != nil { return nil, fmt.Errorf(%q, err) }\n", i, i, msg)
 			}
-			g.body.writef("return %s(%s{", e.Name, goName)
+			g.body.writef("return %s(&%s{", e.Name, goName)
 			for i := range v.Fields {
 				if i > 0 {
 					g.body.write(", ")

--- a/internal/gen/match.go
+++ b/internal/gen/match.go
@@ -204,7 +204,7 @@ func (g *gen) emitPatternTest(scrut string, scrutType types.Type, p ast.Pattern)
 		// name matches a declared (or prelude) enum variant. The
 		// resolver treats it as a variant in that case; we mirror.
 		if owner, ok := g.variantOwner[p.Name]; ok {
-			g.body.writef("func() bool { _, ok := %s.(%s_%s); return ok }()",
+			g.body.writef("func() bool { _, ok := %s.(*%s_%s); return ok }()",
 				scrut, owner, p.Name)
 			return
 		}
@@ -254,7 +254,7 @@ func (g *gen) emitPatternTest(scrut string, scrutType types.Type, p ast.Pattern)
 			return
 		}
 		owner := g.enumOwnerForPath(scrutType, p.Path)
-		g.body.writef("func() bool { _, ok := %s.(%s_%s); return ok }()",
+		g.body.writef("func() bool { _, ok := %s.(*%s_%s); return ok }()",
 			scrut, owner, vname)
 	case *ast.RangePat:
 		g.emitRangeTest(scrut, p)
@@ -433,7 +433,7 @@ func (g *gen) emitPatternBindings(scrut string, scrutType types.Type, p ast.Patt
 		owner := g.enumOwnerForPath(scrutType, p.Path)
 		// Reconstruct via type assertion + per-arg Fi access.
 		tmp := g.freshVar("_v")
-		g.body.writef("%s := %s.(%s_%s); _ = %s\n", tmp, scrut, owner, vname, tmp)
+		g.body.writef("%s := %s.(*%s_%s); _ = %s\n", tmp, scrut, owner, vname, tmp)
 		for i, a := range p.Args {
 			if _, ok := a.(*ast.WildcardPat); ok {
 				continue

--- a/internal/gen/question.go
+++ b/internal/gen/question.go
@@ -63,7 +63,7 @@ func (g *gen) emitQuestionLiftBody(tmp string, q *ast.QuestionExpr) {
 		} else if g.currentRetType != nil {
 			retGo = g.goTypeExpr(g.currentRetType)
 		}
-		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error} }\n", tmp, retGo, tmp)
+		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error, ref: resultRef()} }\n", tmp, retGo, tmp)
 		return
 	}
 	g.body.writef("if %s == nil { return nil }\n", tmp)

--- a/internal/gen/stdlib_runtime_test.go
+++ b/internal/gen/stdlib_runtime_test.go
@@ -108,7 +108,7 @@ fn main() {
 	if out != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
 	}
-	for _, want := range []string{"ostyErrorDowncast[FsError]", "func (self FsError_NotFound) message() string"} {
+	for _, want := range []string{"ostyErrorDowncast[FsError]", "func (self *FsError_NotFound) message() string"} {
 		if !strings.Contains(string(goSrc), want) {
 			t.Errorf("generated std.error downcast bridge missing %s:\n%s", want, goSrc)
 		}
@@ -158,6 +158,132 @@ fn main() {
 	want := "https example.com 8080 /path top https://example.com:8080/path?q=1#top"
 	if strings.TrimSpace(out) != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", strings.TrimSpace(out), want, goSrc)
+	}
+}
+
+func TestStdRefSameRuntimeBridge(t *testing.T) {
+	src := `use std.ref
+
+struct Box {
+    value: Int,
+
+    fn sameAs(self, other: Self) -> Bool {
+        ref.same(self, other)
+    }
+}
+
+enum Token {
+    Word(String),
+    End,
+}
+
+fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    let alias = xs
+    let other: List<Int> = [1, 2, 3]
+    let empty: List<Int> = []
+    let sameEmpty = empty
+    let otherEmpty: List<Int> = []
+
+    let names: Map<String, Int> = {"a": 1}
+    let sameNames = names
+    let otherNames: Map<String, Int> = {"a": 1}
+
+    let box = Box { value: 7 }
+    let sameBox = box
+    let otherBox = Box { value: 7 }
+    let spreadBox = Box { value: 8, ..box }
+
+    let tok = Word("osty")
+    let sameTok = tok
+    let otherTok = Word("osty")
+    let end = End
+    let sameEnd = end
+    let otherEnd = End
+
+    let fnA = || 1
+    let fnAlias = fnA
+    let fnOther = || 1
+
+    let ok: Result<Int, String> = Ok(1)
+    let sameOk = ok
+    let otherOk: Result<Int, String> = Ok(1)
+    let err: Result<Int, String> = Err("bad")
+    let sameErr = err
+    let otherErr: Result<Int, String> = Err("bad")
+
+    println("{ref.same(xs, alias)}")
+    println("{ref.same(xs, other)}")
+    println("{ref.same(empty, sameEmpty)}")
+    println("{ref.same(empty, otherEmpty)}")
+    println("{ref.same(names, sameNames)}")
+    println("{ref.same(names, otherNames)}")
+    println("{ref.same(box, sameBox)}")
+    println("{ref.same(box, otherBox)}")
+    println("{ref.same(box, spreadBox)}")
+    println("{box.sameAs(sameBox)}")
+    println("{ref.same(tok, sameTok)}")
+    println("{ref.same(tok, otherTok)}")
+    println("{ref.same(end, sameEnd)}")
+    println("{ref.same(end, otherEnd)}")
+    println("{ref.same(fnA, fnAlias)}")
+    println("{ref.same(fnA, fnOther)}")
+    println("{ref.same(ok, sameOk)}")
+    println("{ref.same(ok, otherOk)}")
+    println("{ref.same(err, sameErr)}")
+	println("{ref.same(err, otherErr)}")
+	println("{ref.same(1, 1)}")
+	println("{ref.same("osty", "osty")}")
+	println("{box == otherBox}")
+	println("{box != spreadBox}")
+	println("{tok == otherTok}")
+	println("{end == otherEnd}")
+	println("{ok == otherOk}")
+	println("{err == otherErr}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"true",
+		"false",
+		"true",
+		"false",
+		"true",
+		"false",
+		"true",
+		"false",
+		"false",
+		"true",
+		"true",
+		"false",
+		"true",
+		"false",
+		"true",
+		"false",
+		"true",
+		"false",
+		"true",
+		"false",
+		"false",
+		"false",
+		"true",
+		"true",
+		"true",
+		"true",
+		"true",
+		"true",
+	}, "\n")
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"func refSame", "reflect.ValueOf"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.ref bridge missing %s:\n%s", want, goSrc)
+		}
 	}
 }
 

--- a/internal/gen/stmt.go
+++ b/internal/gen/stmt.go
@@ -212,7 +212,7 @@ func (g *gen) emitQuestionLift(name string, q *ast.QuestionExpr) {
 		} else if g.currentRetType != nil {
 			retGo = g.goTypeExpr(g.currentRetType)
 		}
-		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error} }\n", tmp, retGo, tmp)
+		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error, ref: resultRef()} }\n", tmp, retGo, tmp)
 		if name != "_" {
 			g.body.writef("%s := %s.Value\n_ = %s\n", name, tmp, name)
 		} else {

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -233,15 +233,25 @@ func (g *gen) goNamedType(n *types.Named) string {
 		g.needUUID = true
 		return "Uuid"
 	}
-	// User-defined: bare name + optional type args.
-	if len(n.Args) == 0 {
-		return n.Sym.Name
+	// User-defined structs have reference semantics (§2.8), so values
+	// flow as pointers to the emitted Go struct. Enums stay as their Go
+	// interface type; their variants carry identity by storing pointers
+	// to the concrete variant structs in that interface.
+	name := g.goUserNamed(n.Sym.Name, n.Args)
+	if g.isReferenceStructSym(n.Sym) || g.structTypes[n.Sym.Name] {
+		return "*" + name
 	}
-	// Generic user type — emit with Go type arg brackets.
+	return name
+}
+
+func (g *gen) goUserNamed(name string, args []types.Type) string {
+	if len(args) == 0 {
+		return name
+	}
 	var b strings.Builder
-	b.WriteString(n.Sym.Name)
+	b.WriteString(name)
 	b.WriteByte('[')
-	for i, a := range n.Args {
+	for i, a := range args {
 		if i > 0 {
 			b.WriteString(", ")
 		}
@@ -249,6 +259,20 @@ func (g *gen) goNamedType(n *types.Named) string {
 	}
 	b.WriteByte(']')
 	return b.String()
+}
+
+func (g *gen) isReferenceStructSym(sym *resolve.Symbol) bool {
+	if sym == nil || sym.Kind != resolve.SymStruct {
+		return false
+	}
+	if g.structTypes[sym.Name] {
+		return true
+	}
+	switch sym.Name {
+	case "CsvOptions":
+		return false
+	}
+	return true
 }
 
 // goTypeExpr translates an AST type node to its Go type string. Used
@@ -328,20 +352,7 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 	}
 	name := n.Path[0]
 	if name == "Self" && g.selfType != "" {
-		if len(n.Args) == 0 {
-			return g.selfType
-		}
-		var b strings.Builder
-		b.WriteString(g.selfType)
-		b.WriteByte('[')
-		for i, a := range n.Args {
-			if i > 0 {
-				b.WriteString(", ")
-			}
-			b.WriteString(g.goTypeExpr(a))
-		}
-		b.WriteByte(']')
-		return b.String()
+		return g.goSelfTypeAST(n.Args)
 	}
 	// Generic type-parameter references substitute to the concrete Go
 	// type rendered at the monomorphizing call site. Applies only to
@@ -417,20 +428,52 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 		g.needUUID = true
 		return "Uuid"
 	}
-	if len(n.Args) == 0 {
-		return name
-	}
-	var b strings.Builder
-	b.WriteString(name)
-	b.WriteByte('[')
-	for i, a := range n.Args {
-		if i > 0 {
-			b.WriteString(", ")
+	out := name
+	if len(n.Args) > 0 {
+		var b strings.Builder
+		b.WriteString(name)
+		b.WriteByte('[')
+		for i, a := range n.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(g.goTypeExpr(a))
 		}
-		b.WriteString(g.goTypeExpr(a))
+		b.WriteByte(']')
+		out = b.String()
 	}
-	b.WriteByte(']')
-	return b.String()
+	if sym := g.typeRefSym(n); g.isReferenceStructSym(sym) || g.structTypes[name] {
+		return "*" + out
+	}
+	return out
+}
+
+func (g *gen) goSelfTypeAST(args []ast.Type) string {
+	out := g.selfType
+	if len(args) > 0 {
+		var b strings.Builder
+		b.WriteString(g.selfType)
+		b.WriteByte('[')
+		for i, a := range args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(g.goTypeExpr(a))
+		}
+		b.WriteByte(']')
+		out = b.String()
+	}
+	if !g.enumTypes[g.selfType] {
+		return "*" + out
+	}
+	return out
+}
+
+func (g *gen) typeRefSym(n *ast.NamedType) *resolve.Symbol {
+	if g.res == nil || n == nil {
+		return nil
+	}
+	return g.res.TypeRefs[n]
 }
 
 func (g *gen) goFnTypeAST(f *ast.FnType) string {


### PR DESCRIPTION
## Summary

- Implemented `std.ref.same` lowering and runtime identity comparison.
- Aligned generated reference semantics for user structs, enum variants, closures, lists, and `Result` wrappers.
- Added regression coverage for alias vs fresh allocation behavior across reference and value categories.

## Why

`std.ref.same` previously had only a signature stub and no faithful runtime behavior. The generator also lowered several reference-semantics values as plain Go values, which made identity impossible to observe correctly.

## Validation

- `go test ./internal/gen -run 'TestStdRefSameRuntimeBridge|TestStdURLRuntimeBridge|TestStdRegexBridge|TestStdEncodingBridge|TestStdEnvBridge|TestStdCSVBridge|TestStdCompressBridge|TestStdUUIDBridge'`
- `go test ./internal/gen`
- `go test ./...`
