### PR TITLE
[codex] Implement std.fs runtime bridge

### DIFF
--- a/LANG_SPEC_v0.3/10-standard-library/01-tier-1-core.md
+++ b/LANG_SPEC_v0.3/10-standard-library/01-tier-1-core.md
@@ -1,7 +1,13 @@
 ### 10.1 Tier 1 (Core)
 
 - `std.io` — `print`, `println`, `eprint`, `eprintln`, `readLine`
-- `std.fs` — file I/O
+- `std.fs` — file I/O:
+  `readToString(path: String) -> Result<String, Error>`,
+  `writeString(path: String, contents: String) -> Result<(), Error>`,
+  `exists(path: String) -> Bool`,
+  `remove(path: String) -> Result<(), Error>`. `readToString` returns
+  `Err` when the file bytes are not valid UTF-8; binary data should flow
+  through `Bytes` APIs when those are available.
 - `std.strings` — string manipulation
 - `std.collections` — `List`, `Map`, `Set`
 - `std.option` — `Option`, `Some`, `None` (auto-imported)

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -59,6 +59,12 @@ func runRun(args []string, cliF cliFlags) {
 	_ = fs.Parse(args)
 	runArgs := fs.Args()
 
+	runDir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty run: get cwd: %v\n", err)
+		os.Exit(1)
+	}
+
 	m, root, abort := loadManifestWithDiag(".", cliF)
 	if abort {
 		os.Exit(2)
@@ -195,14 +201,19 @@ func runRun(args []string, cliF cliFlags) {
 	// onto the child process's environment.
 	goArgs := []string{"run"}
 	goArgs = append(goArgs, resolved.GoFlags()...)
-	goArgs = append(goArgs, goPath)
+	goPathArg, err := filepath.Abs(goPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
+		os.Exit(1)
+	}
+	goArgs = append(goArgs, goPathArg)
 	goArgs = append(goArgs, runArgs...)
 	cmd := exec.Command("go", goArgs...)
 	var stderr bytes.Buffer
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
-	cmd.Dir = outDir
+	cmd.Dir = runDir
 	cmd.Env = mergeEnv(os.Environ(), resolved.GoEnv())
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -210,8 +221,8 @@ func runRun(args []string, cliF cliFlags) {
 				Tool:      "osty run",
 				Action:    "go run",
 				Args:      cmd.Args,
-				WorkDir:   outDir,
-				Generated: []string{goPath},
+				WorkDir:   runDir,
+				Generated: []string{goPathArg},
 				Source:    entryAbs,
 				Stderr:    stderr.String(),
 				Err:       err,

--- a/cmd/osty/run_integration_test.go
+++ b/cmd/osty/run_integration_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/profile"
+)
+
+func TestRunStdFSUsesInvocationCwd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	writeStdFSProject(t, dir, "fsdemo")
+
+	bin := buildOstyBinary(t)
+	out, code := runBuiltOsty(t, bin, dir, "run")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d. output:\n%s", code, out)
+	}
+	want := strings.Join([]string{
+		"false",
+		"true",
+		"roundtrip",
+		"false",
+		"true",
+	}, "\n")
+	if got := strings.TrimSpace(out); got != want {
+		t.Fatalf("stdout = %q, want %q\nfull output:\n%s", got, want, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "data", "payload.txt")); !os.IsNotExist(err) {
+		t.Fatalf("payload should have been removed from invocation cwd, stat err = %v", err)
+	}
+}
+
+func TestBuildStdFSBinary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	writeStdFSProject(t, dir, "fsbuild")
+
+	osty := buildOstyBinary(t)
+	out, code := runBuiltOsty(t, osty, dir, "build")
+	if code != 0 {
+		t.Fatalf("expected build exit 0, got %d. output:\n%s", code, out)
+	}
+	exeName := "fsbuild"
+	if runtime.GOOS == "windows" {
+		exeName += ".exe"
+	}
+	exe := filepath.Join(profile.OutputDir(dir, profile.NameDebug, ""), exeName)
+	cmd := exec.Command(exe)
+	cmd.Dir = dir
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run built binary: %v\n%s", err, buf.String())
+	}
+	want := strings.Join([]string{
+		"false",
+		"true",
+		"roundtrip",
+		"false",
+		"true",
+	}, "\n")
+	if got := strings.TrimSpace(buf.String()); got != want {
+		t.Fatalf("stdout = %q, want %q\nfull output:\n%s", got, want, buf.String())
+	}
+}
+
+func writeStdFSProject(t *testing.T, dir, name string) {
+	t.Helper()
+	mustWrite(t, dir, "osty.toml", `[package]
+name = "`+name+`"
+version = "0.1.0"
+edition = "0.3"
+`)
+	if err := os.Mkdir(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, dir, "main.osty", `use std.fs
+
+fn main() {
+    let p = "data/payload.txt"
+    println("{fs.exists(p)}")
+    fs.writeString(p, "roundtrip").unwrap()
+    println("{fs.exists(p)}")
+    println(fs.readToString(p).unwrap())
+    fs.remove(p).unwrap()
+    println("{fs.exists(p)}")
+    println("{fs.remove(p).isErr()}")
+}
+`)
+}
+
+func buildOstyBinary(t *testing.T) string {
+	t.Helper()
+	name := "osty"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = repoRoot(t)
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go build osty: %v\n%s", err, buf.String())
+	}
+	return bin
+}
+
+func runBuiltOsty(t *testing.T, bin, dir string, args ...string) (combined string, exitCode int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	out := buf.String()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return out, exitErr.ExitCode()
+	}
+	if err != nil {
+		t.Fatalf("run osty binary: %v\n%s", err, out)
+	}
+	return out, 0
+}

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -445,6 +446,46 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 		return false
 	}
 	switch path[1] {
+	case "fs":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		osAlias, utf8Alias := g.stdFSImportAliases()
+		g.needFS = true
+		g.emitUseStub(alias, fmt.Sprintf(`struct {
+			readToString func(path string) Result[string, any]
+			writeString  func(path string, contents string) Result[struct{}, any]
+			exists       func(path string) bool
+			remove       func(path string) Result[struct{}, any]
+		}{
+			readToString: func(path string) Result[string, any] {
+				data, err := %[1]s.ReadFile(path)
+				if err != nil {
+					return Result[string, any]{Error: err}
+				}
+				if !%[2]s.Valid(data) {
+					return Result[string, any]{Error: "fs.readToString: invalid UTF-8 in " + path}
+				}
+				return Result[string, any]{Value: string(data), IsOk: true}
+			},
+			writeString: func(path string, contents string) Result[struct{}, any] {
+				if err := %[1]s.WriteFile(path, []byte(contents), 0o644); err != nil {
+					return Result[struct{}, any]{Error: err}
+				}
+				return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+			},
+			exists: func(path string) bool {
+				_, err := %[1]s.Stat(path)
+				return err == nil
+			},
+			remove: func(path string) Result[struct{}, any] {
+				if err := %[1]s.Remove(path); err != nil {
+					return Result[struct{}, any]{Error: err}
+				}
+				return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
+			},
+		}`, osAlias, utf8Alias), full)
+		return true
 	case "random":
 		g.needRandomRuntime = true
 		g.emitUseStub(alias, `struct {
@@ -465,6 +506,74 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			join:  urlJoin,
 		}`, full)
 		return true
+	}
+	return false
+}
+
+func (g *gen) stdFSImportAliases() (string, string) {
+	if g.fsOSAlias == "" {
+		g.fsOSAlias = g.freshFileIdent("_ostyStdFSOS")
+	}
+	if g.fsUTF8Alias == "" {
+		g.fsUTF8Alias = g.freshFileIdent("_ostyStdFSUTF8")
+	}
+	return g.fsOSAlias, g.fsUTF8Alias
+}
+
+func (g *gen) freshFileIdent(base string) string {
+	candidate := base
+	for i := 2; g.fileIdentUsed(candidate); i++ {
+		candidate = fmt.Sprintf("%s%d", base, i)
+	}
+	return candidate
+}
+
+func (g *gen) fileIdentUsed(name string) bool {
+	for _, alias := range g.imports {
+		if alias == name {
+			return true
+		}
+	}
+	for _, u := range g.file.Uses {
+		alias := u.Alias
+		if alias == "" {
+			if u.IsGoFFI {
+				alias = lastPathComponent(u.GoPath)
+			} else if len(u.Path) > 0 {
+				alias = u.Path[len(u.Path)-1]
+			}
+		}
+		if mangleIdent(alias) == name {
+			return true
+		}
+	}
+	for _, d := range g.file.Decls {
+		switch d := d.(type) {
+		case *ast.FnDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.LetDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.StructDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.EnumDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.InterfaceDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.TypeAliasDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -647,8 +756,6 @@ func stdlibBridge(path []string) string {
 	}
 	switch path[1] {
 	case "os":
-		return "os"
-	case "fs":
 		return "os"
 	case "io":
 		return "io"

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -102,9 +102,13 @@ type gen struct {
 	// pulling in the time import used by `s.timeout(...)` arms.
 	needSelect bool
 
-	// needRandomRuntime / needURLRuntime are set by stdlib use bridges
-	// whose Osty surface cannot map directly to exported Go package
-	// identifiers (for example `random.default()` and `rng.int(...)`).
+	// needFS / needRandomRuntime / needURLRuntime are set by stdlib use
+	// bridges whose Osty surface cannot map directly to exported Go
+	// package identifiers (for example `fs.readToString(...)`,
+	// `random.default()` and `rng.int(...)`).
+	needFS            bool
+	fsOSAlias         string
+	fsUTF8Alias       string
 	needRandomRuntime bool
 	needURLRuntime    bool
 
@@ -299,6 +303,11 @@ func (g *gen) run() ([]byte, error) {
 	if g.needTaskGroup {
 		g.use("sync")
 		g.use("context")
+	}
+	if g.needFS {
+		g.needResult = true
+		g.useAs("os", g.fsOSAlias)
+		g.useAs("unicode/utf8", g.fsUTF8Alias)
 	}
 	if g.needRandomRuntime {
 		g.useAs("math/rand", "mathrand")

--- a/internal/gen/stdlib_runtime_test.go
+++ b/internal/gen/stdlib_runtime_test.go
@@ -1,6 +1,9 @@
 package gen_test
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -48,5 +51,130 @@ fn main() {
 	want := "https example.com 8080 /path top https://example.com:8080/path?q=1#top"
 	if strings.TrimSpace(out) != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", strings.TrimSpace(out), want, goSrc)
+	}
+}
+
+func TestStdFSRuntimeBridge(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "note.txt")
+	src := `use std.fs as os
+
+fn main() {
+    let path = ` + strconv.Quote(path) + `
+    println("{os.exists(path)}")
+    os.writeString(path, "hello osty").unwrap()
+    println("{os.exists(path)}")
+    println(os.readToString(path).unwrap())
+    os.remove(path).unwrap()
+    println("{os.exists(path)}")
+    println("{os.readToString(path).isErr()}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"false",
+		"true",
+		"hello osty",
+		"false",
+		"true",
+	}, "\n")
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"_ostyStdFSOS.ReadFile", "_ostyStdFSOS.WriteFile", "_ostyStdFSOS.Stat", "_ostyStdFSOS.Remove"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.fs bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdFSReadToStringRejectsInvalidUTF8(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.bin")
+	if err := os.WriteFile(path, []byte{0xff, 0xfe, 0xfd}, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	src := `use std.fs
+
+fn main() {
+    let path = ` + strconv.Quote(path) + `
+    println("{fs.readToString(path).isErr()}")
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	if out != "true" {
+		t.Errorf("got %q, want true\n--- src ---\n%s", out, goSrc)
+	}
+	if !strings.Contains(string(goSrc), "_ostyStdFSUTF8.Valid") {
+		t.Errorf("generated std.fs bridge missing UTF-8 validation:\n%s", goSrc)
+	}
+}
+
+func TestStdFSBridgeDoesNotReserveHelperNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "note.txt")
+	src := `use std.fs
+
+fn fsReadToString() -> String { "user-read" }
+fn fsWriteString() -> String { "user-write" }
+fn fsExists() -> String { "user-exists" }
+fn fsRemove() -> String { "user-remove" }
+
+fn main() {
+    let path = ` + strconv.Quote(path) + `
+    fs.writeString(path, fsReadToString()).unwrap()
+    println(fs.readToString(path).unwrap())
+    println(fsWriteString())
+    println(fsExists())
+    fs.remove(path).unwrap()
+    println(fsRemove())
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"user-read",
+		"user-write",
+		"user-exists",
+		"user-remove",
+	}, "\n")
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}
+
+func TestStdFSAvoidsInternalImportAliasCollisions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "note.txt")
+	src := `use std.fs as _ostyStdFSOS
+
+fn _ostyStdFSUTF8() -> String { "user-utf8-name" }
+
+fn main() {
+    let path = ` + strconv.Quote(path) + `
+    _ostyStdFSOS.writeString(path, _ostyStdFSUTF8()).unwrap()
+    println(_ostyStdFSOS.readToString(path).unwrap())
+    _ostyStdFSOS.remove(path).unwrap()
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	if out != "user-utf8-name" {
+		t.Errorf("got %q, want user-utf8-name\n--- src ---\n%s", out, goSrc)
+	}
+	for _, want := range []string{"_ostyStdFSOS2.ReadFile", "_ostyStdFSUTF82.Valid"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.fs bridge did not avoid internal alias collision %s:\n%s", want, goSrc)
+		}
 	}
 }

--- a/internal/stdlib/modules/fs.osty
+++ b/internal/stdlib/modules/fs.osty
@@ -2,20 +2,14 @@
 //
 // The Tier 1 surface is intentionally narrow: read the whole file,
 // write the whole file, check existence, remove. Streaming I/O, file
-// handles, and directory iteration live in higher-tier modules.
+// handles, and directory iteration live in higher-tier modules. The
+// runtime implementation is provided by the generator's std.fs bridge.
+// `readToString` returns Err when the file bytes are not valid UTF-8.
 
-pub fn readToString(path: String) -> Result<String, Error> {
-    Ok("")
-}
+pub fn readToString(path: String) -> Result<String, Error>
 
-pub fn writeString(path: String, contents: String) -> Result<(), Error> {
-    Ok(())
-}
+pub fn writeString(path: String, contents: String) -> Result<(), Error>
 
-pub fn exists(path: String) -> Bool {
-    false
-}
+pub fn exists(path: String) -> Bool
 
-pub fn remove(path: String) -> Result<(), Error> {
-    Ok(())
-}
+pub fn remove(path: String) -> Result<(), Error>


### PR DESCRIPTION
## Summary

Implements the `std.fs` Tier 1 runtime bridge for `readToString`, `writeString`, `exists`, and `remove` instead of leaving those functions as fake-returning stubs.

## Details

- Converts `internal/stdlib/modules/fs.osty` to a signature-only stdlib surface.
- Adds a generator-side `std.fs` bridge backed by Go filesystem calls.
- Validates UTF-8 for `readToString` so Osty `String` semantics are preserved.
- Avoids generated helper-name and import-alias collisions with user code.
- Keeps `osty run` execution rooted at the invocation directory so relative file paths behave like the user expects.
- Adds generator and CLI integration tests covering `osty run`, `osty build`, alias collisions, invalid UTF-8, and helper-name collisions.
- Documents the Tier 1 `std.fs` functions and `readToString` UTF-8 behavior.

## Validation

- `go test ./internal/gen ./internal/stdlib ./cmd/osty`
- `go test ./...`
