### PR TITLE
[codex] implement std.option combinators

### DIFF
--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -1075,6 +1075,33 @@ fn main() {
 	assertOK(t, runCheck(t, src))
 }
 
+func TestCheck_OptionCombinators(t *testing.T) {
+	src := `
+use std.option
+
+fn main() {
+    let x: Int? = Some(5)
+    let qualified: Int? = option.Some(7)
+    let qualifiedNone: Int? = option.None
+    let qualifiedType: option.Option<Int> = option.Some(8)
+    let normalized: Int? = qualifiedType
+    let y: String? = x.map(|n| "{n}")
+    let z: Int? = None
+    let recovered: Int? = z.orElse(|| Some(9))
+    let result: Result<Int, Error> = z.orError("missing")
+    let message: String = result.unwrapErr().message()
+    let messageAgain: String = result.err().unwrap().message()
+    let mapped: Result<String, Error> = result.map(|n| "{n}")
+    let mappedErr: Result<Int, String> = result.mapErr(|e| e.message())
+    let label: String = y.unwrapOr("fallback")
+    let ok: Bool = x.isSome()
+    let missing: Bool = qualifiedNone.isNone()
+    let shown: String = recovered.toString()
+}
+`
+	assertOK(t, runCheckWithStdlib(t, src))
+}
+
 func TestCheck_ResultIsOkReturnsBool(t *testing.T) {
 	// Uses the prelude's builtin Result; no user-defined enum shadow.
 	src := `

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -64,7 +64,7 @@ func (c *checker) exprType(e ast.Expr, hint types.Type, env *env) types.Type {
 	case *ast.CallExpr:
 		return c.callType(x, hint, env)
 	case *ast.FieldExpr:
-		return c.fieldType(x, env)
+		return c.fieldType(x, hint, env)
 	case *ast.IndexExpr:
 		return c.indexType(x, env)
 	case *ast.TurbofishExpr:
@@ -707,6 +707,26 @@ func (c *checker) tryPackageCall(
 		}
 		return types.ErrorType, true
 	}
+	if stdlibPackageModule(pkgSym) == "option" {
+		switch fx.Name {
+		case "Some":
+			if len(e.Args) != 1 {
+				c.errNode(e, diag.CodeWrongArgCount,
+					"`Some` takes exactly 1 argument, got %d", len(e.Args))
+				return types.ErrorType, true
+			}
+			var innerHint types.Type
+			if o, ok := hint.(*types.Optional); ok {
+				innerHint = o.Inner
+			}
+			at := c.checkExpr(e.Args[0].Value, innerHint, env)
+			return &types.Optional{Inner: at}, true
+		case "None":
+			c.errNode(e, diag.CodeWrongArgCount,
+				"`None` is a unit variant — write `None`, not `None()`")
+			return types.ErrorType, true
+		}
+	}
 	t := c.symTypeOrError(tgt)
 	var generics []*types.TypeVar
 	if types.IsError(t) {
@@ -1305,11 +1325,17 @@ func (c *checker) optionalMethod(o *types.Optional, name string) *methodDesc {
 		fn := &types.FnType{Params: nil, Return: opt}
 		return simpleMethod(name, []types.Type{fn}, opt)
 	case "map":
-		// fn(T) -> U — but U is fresh per call. We approximate by
-		// returning Option<?> and let the specific checker path
-		// refine via the callback's inferred return.
-		fn := &types.FnType{Params: []types.Type{t}, Return: types.ErrorType}
-		return simpleMethod(name, []types.Type{fn}, &types.Optional{Inner: types.ErrorType})
+		uSym := &resolve.Symbol{Name: "U", Kind: resolve.SymGeneric}
+		u := &types.TypeVar{Sym: uSym}
+		fn := &types.FnType{Params: []types.Type{t}, Return: u}
+		return &methodDesc{
+			Name:     name,
+			Fn:       &types.FnType{Params: []types.Type{fn}, Return: &types.Optional{Inner: u}},
+			Generics: []*types.TypeVar{u},
+		}
+	case "orError":
+		return simpleMethod(name, []types.Type{types.String},
+			c.resultOf(t, c.namedOf("Error", nil)))
 	case "toString":
 		return simpleMethod(name, nil, types.String)
 	}
@@ -1366,6 +1392,10 @@ func (c *checker) builtinNamedMethod(n *types.Named, name string) *methodDesc {
 		case "isCancelled":
 			return simpleMethod(name, nil, types.Bool)
 		}
+	case "Error":
+		if name == "message" {
+			return simpleMethod(name, nil, types.String)
+		}
 	}
 	return nil
 }
@@ -1388,13 +1418,29 @@ func resultMethod(n *types.Named, name string) *methodDesc {
 	case "err":
 		return simpleMethod(name, nil, &types.Optional{Inner: e})
 	case "map":
-		fn := &types.FnType{Params: []types.Type{t}, Return: types.ErrorType}
-		return simpleMethod(name, []types.Type{fn},
-			&types.Named{Sym: n.Sym, Args: []types.Type{types.ErrorType, e}})
+		uSym := &resolve.Symbol{Name: "U", Kind: resolve.SymGeneric}
+		u := &types.TypeVar{Sym: uSym}
+		fn := &types.FnType{Params: []types.Type{t}, Return: u}
+		return &methodDesc{
+			Name: name,
+			Fn: &types.FnType{
+				Params: []types.Type{fn},
+				Return: &types.Named{Sym: n.Sym, Args: []types.Type{u, e}},
+			},
+			Generics: []*types.TypeVar{u},
+		}
 	case "mapErr":
-		fn := &types.FnType{Params: []types.Type{e}, Return: types.ErrorType}
-		return simpleMethod(name, []types.Type{fn},
-			&types.Named{Sym: n.Sym, Args: []types.Type{t, types.ErrorType}})
+		fSym := &resolve.Symbol{Name: "F", Kind: resolve.SymGeneric}
+		f := &types.TypeVar{Sym: fSym}
+		fn := &types.FnType{Params: []types.Type{e}, Return: f}
+		return &methodDesc{
+			Name: name,
+			Fn: &types.FnType{
+				Params: []types.Type{fn},
+				Return: &types.Named{Sym: n.Sym, Args: []types.Type{t, f}},
+			},
+			Generics: []*types.TypeVar{f},
+		}
 	case "toString":
 		return simpleMethod(name, nil, types.String)
 	}
@@ -1863,6 +1909,28 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 		if vd, ok := desc.Variants[sym.Name]; ok {
 			c.warnIfVariantDeprecated(vd, id.PosV)
 		}
+		if desc.Sym != nil && desc.Sym.Name == "Option" {
+			switch sym.Name {
+			case "Some":
+				if len(e.Args) != 1 {
+					c.errNode(e, diag.CodeWrongArgCount,
+						"`Some` takes exactly 1 argument, got %d", len(e.Args))
+					return types.ErrorType
+				}
+				var innerHint types.Type
+				if o, ok := hint.(*types.Optional); ok {
+					innerHint = o.Inner
+				} else if info != nil && len(info.VariantFields) == 1 {
+					innerHint = info.VariantFields[0]
+				}
+				at := c.checkExpr(e.Args[0].Value, innerHint, env)
+				return &types.Optional{Inner: at}
+			case "None":
+				c.errNode(e, diag.CodeWrongArgCount,
+					"`None` is a unit variant — write `None`, not `None()`")
+				return types.ErrorType
+			}
+		}
 		// Pull type arguments from a matching hint first so the same
 		// enum's variants flow concrete args naturally:
 		//     let r: Result<Int, Error> = Ok(5)   // 5 is Int
@@ -1981,7 +2049,7 @@ func inferFromArg(field, arg types.Type, sub map[*resolve.Symbol]types.Type) {
 
 // ---- Field / index ----
 
-func (c *checker) fieldType(fx *ast.FieldExpr, env *env) types.Type {
+func (c *checker) fieldType(fx *ast.FieldExpr, hint types.Type, env *env) types.Type {
 	recvT := c.checkExpr(fx.X, nil, env)
 	if types.IsError(recvT) {
 		return types.ErrorType
@@ -2010,6 +2078,12 @@ func (c *checker) fieldType(fx *ast.FieldExpr, env *env) types.Type {
 			if tgt == nil {
 				// Resolver already reported E0508.
 				return types.ErrorType
+			}
+			if stdlibPackageModule(s) == "option" && fx.Name == "None" {
+				if o, ok := hint.(*types.Optional); ok {
+					return o
+				}
+				return &types.Optional{Inner: types.ErrorType}
 			}
 			if t := c.symTypeOrError(tgt); !types.IsError(t) {
 				return t
@@ -2101,6 +2175,17 @@ func (c *checker) fieldType(fx *ast.FieldExpr, env *env) types.Type {
 		}
 	}
 	return types.ErrorType
+}
+
+func stdlibPackageModule(sym *resolve.Symbol) string {
+	if sym == nil {
+		return ""
+	}
+	u, ok := sym.Decl.(*ast.UseDecl)
+	if !ok || u.IsGoFFI || len(u.Path) != 2 || u.Path[0] != "std" {
+		return ""
+	}
+	return u.Path[1]
 }
 
 func (c *checker) indexType(e *ast.IndexExpr, env *env) types.Type {

--- a/internal/check/method_candidates.go
+++ b/internal/check/method_candidates.go
@@ -48,7 +48,7 @@ func (c *checker) methodCandidates(t types.Type) []string {
 			add(name)
 		}
 	case *types.Optional:
-		for _, name := range []string{"isSome", "isNone", "unwrap", "unwrapOr", "orElse", "map", "toString"} {
+		for _, name := range []string{"isSome", "isNone", "unwrap", "unwrapOr", "orElse", "map", "orError", "toString"} {
 			add(name)
 		}
 	case *types.TypeVar:

--- a/internal/check/stmt.go
+++ b/internal/check/stmt.go
@@ -85,10 +85,14 @@ func (c *checker) checkFnDecl(n *ast.FnDecl, owner *typeDesc) {
 	if owner != nil && n.Recv != nil {
 		selfSym := c.fnReceiverSymbol(n)
 		if selfSym != nil {
-			c.setSymType(selfSym, &types.Named{
+			selfT := types.Type(&types.Named{
 				Sym:  owner.Sym,
 				Args: argsOfGenerics(owner.Generics),
 			})
+			if owner.Sym != nil && owner.Sym.Name == "Option" && len(owner.Generics) == 1 {
+				selfT = &types.Optional{Inner: owner.Generics[0]}
+			}
+			c.setSymType(selfSym, selfT)
 		}
 	}
 

--- a/internal/check/typeref.go
+++ b/internal/check/typeref.go
@@ -100,6 +100,18 @@ func (c *checker) namedType(n *ast.NamedType) types.Type {
 		args = append(args, c.typeOf(a))
 	}
 
+	// The std.option module declares the canonical Option<T> enum, but
+	// the checker represents all Option<T> spellings as Optional so
+	// `option.Option<Int>` and `Int?` remain fully interchangeable.
+	if sym.Name == "Option" {
+		if len(args) != 1 {
+			c.errNode(n, diag.CodeGenericArgCount,
+				"`Option` expects exactly 1 type argument, got %d", len(args))
+			return types.ErrorType
+		}
+		return &types.Optional{Inner: args[0]}
+	}
+
 	// Expand type aliases transparently (§3.7).
 	if desc, ok := c.result.Descs[sym]; ok && desc.Kind == resolve.SymTypeAlias {
 		if desc.Alias != nil && len(args) == 0 {

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -376,6 +376,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		}
 	}
 	if f, ok := c.Fn.(*ast.FieldExpr); ok {
+		if g.emitQualifiedOptionCall(c, f) {
+			return
+		}
 		if g.emitStdlibEncodingCall(c, f) {
 			return
 		}
@@ -404,6 +407,15 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 			return
 		}
 		if g.emitThreadCall(c, f) {
+			return
+		}
+		if g.emitErrorMethodCall(c, f) {
+			return
+		}
+		if g.emitResultMethodCall(c, f) {
+			return
+		}
+		if g.emitOptionalMethodCall(c, f) {
 			return
 		}
 		if g.emitConcurrencyMethod(c, f) {
@@ -717,6 +729,23 @@ func (g *gen) emitStdlibUUIDCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
 	return true
 }
 
+func (g *gen) emitQualifiedOptionCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "option") {
+		return false
+	}
+	switch f.Name {
+	case "Some":
+		return g.emitBuiltinCall("Some", c.Args, c)
+	case "None":
+		if len(c.Args) == 0 {
+			g.body.write("nil")
+			return true
+		}
+	}
+	return false
+}
+
 func (g *gen) emitStdlibHelperCall(helper string, args []*ast.Arg) {
 	g.body.write(helper)
 	g.body.write("(")
@@ -987,6 +1016,181 @@ func (g *gen) emitConcurrencyMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		}
 	}
 	return false
+}
+
+func (g *gen) emitErrorMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.Name != "message" || len(c.Args) != 0 {
+		return false
+	}
+	n, ok := types.AsNamedByName(g.typeOf(f.X), "Error")
+	if !ok || n.Sym == nil {
+		return false
+	}
+	g.needErrorRuntime = true
+	g.body.write("ostyErrorMessage(")
+	g.emitExpr(f.X)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitResultMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	recv, ok := types.AsNamedByName(g.typeOf(f.X), "Result")
+	if !ok || recv.Sym == nil || len(recv.Args) != 2 {
+		return false
+	}
+	switch f.Name {
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		okGo, errGo := "any", g.goType(recv.Args[1])
+		if out, ok := types.AsNamedByName(g.typeOf(c), "Result"); ok && len(out.Args) == 2 {
+			okGo = g.goType(out.Args[0])
+			errGo = g.goType(out.Args[1])
+		}
+		resultGo := "Result[" + okGo + ", " + errGo + "]"
+		g.body.writef("func() %s { r := ", resultGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; if r.IsOk { return %s{Value: f(r.Value), IsOk: true} }; return %s{Error: r.Error} }()", resultGo, resultGo)
+		return true
+	case "mapErr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		okGo, errGo := g.goType(recv.Args[0]), "any"
+		if out, ok := types.AsNamedByName(g.typeOf(c), "Result"); ok && len(out.Args) == 2 {
+			okGo = g.goType(out.Args[0])
+			errGo = g.goType(out.Args[1])
+		}
+		resultGo := "Result[" + okGo + ", " + errGo + "]"
+		g.body.writef("func() %s { r := ", resultGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; if r.IsOk { return %s{Value: r.Value, IsOk: true} }; return %s{Error: f(r.Error)} }()", resultGo, resultGo)
+		return true
+	}
+	return false
+}
+
+// emitOptionalMethodCall lowers Option<T> methods to pointer checks.
+// Option<T> / T? is represented as *T in generated Go, so these methods
+// cannot be emitted as ordinary selector calls.
+func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.IsOptional {
+		return false
+	}
+	inner, ok := optionInnerType(g.typeOf(f.X))
+	if !ok {
+		return false
+	}
+	innerGo := "any"
+	if inner != nil {
+		innerGo = g.goType(inner)
+	}
+	switch f.Name {
+	case "isSome", "isNone":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(")
+		g.emitExpr(f.X)
+		if f.Name == "isSome" {
+			g.body.write(" != nil)")
+		} else {
+			g.body.write(" == nil)")
+		}
+		return true
+	case "unwrap":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write(`; if opt == nil { panic("called unwrap on None") }; return *opt }()`)
+		return true
+	case "unwrapOr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var fallback %s = ", innerGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return *opt }; return fallback }()")
+		return true
+	case "orElse":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() *%s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; fallback := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return opt }; return fallback() }()")
+		return true
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := "any"
+		if retInner, ok := optionInnerType(g.typeOf(c)); ok && retInner != nil {
+			retGo = g.goType(retInner)
+		} else if fn, ok := g.typeOf(c.Args[0].Value).(*types.FnType); ok && fn.Return != nil {
+			retGo = g.goType(fn.Return)
+		}
+		g.body.writef("func() *%s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { return nil }; var value ")
+		g.body.write(retGo)
+		g.body.write(" = f(*opt); return &value }()")
+		return true
+	case "orError":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		okGo, errGo := innerGo, "any"
+		if n, ok := types.AsNamedByName(g.typeOf(c), "Result"); ok && len(n.Args) == 2 {
+			okGo = g.goType(n.Args[0])
+			errGo = g.goType(n.Args[1])
+		}
+		resultGo := "Result[" + okGo + ", " + errGo + "]"
+		g.body.writef("func() %s { opt := ", resultGo)
+		g.emitExpr(f.X)
+		g.body.write("; var msg string = ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; if opt != nil { return %s{Value: *opt, IsOk: true} }; return %s{Error: msg} }()", resultGo, resultGo)
+		return true
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("fmt")
+		g.body.write("func() string { opt := ")
+		g.emitExpr(f.X)
+		g.body.write(`; if opt == nil { return "None" }; return fmt.Sprintf("Some(%v)", *opt) }()`)
+		return true
+	}
+	return false
+}
+
+func optionInnerType(t types.Type) (types.Type, bool) {
+	switch v := t.(type) {
+	case *types.Optional:
+		return v.Inner, true
+	case *types.Named:
+		if v.Sym != nil && v.Sym.Name == "Option" && len(v.Args) == 1 {
+			return v.Args[0], true
+		}
+	}
+	return nil, false
 }
 
 func (g *gen) emitRandomGenericMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
@@ -1898,6 +2102,9 @@ func (g *gen) emitQuestion(q *ast.QuestionExpr) {
 // Field-type lookup comes from the checker when available.
 func (g *gen) emitField(f *ast.FieldExpr) {
 	if !f.IsOptional {
+		if g.emitQualifiedOptionField(f) {
+			return
+		}
 		if g.emitStdlibMathField(f) {
 			return
 		}
@@ -1934,6 +2141,15 @@ func (g *gen) emitField(f *ast.FieldExpr) {
 	g.body.write(" != nil { v := (*")
 	g.emitExpr(f.X)
 	g.body.writef(").%s; return &v }; return nil }()", mangleIdent(f.Name))
+}
+
+func (g *gen) emitQualifiedOptionField(f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "option") || f.Name != "None" {
+		return false
+	}
+	g.body.write("nil")
+	return true
 }
 
 // emitList writes a list literal. Element type comes from the checker

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -85,6 +85,10 @@ type gen struct {
 	// prompting a runtime type definition at file top.
 	needResult bool
 
+	// needErrorRuntime is set when a value typed as Osty's Error
+	// interface needs dynamic message dispatch at runtime.
+	needErrorRuntime bool
+
 	// needRange is set when a standalone range literal is emitted, so
 	// the runtime Range struct can be injected at the top of the file.
 	needRange bool
@@ -310,6 +314,9 @@ func (g *gen) run() ([]byte, error) {
 		g.useAs("net/url", "neturl")
 		g.use("strconv")
 	}
+	if g.needErrorRuntime {
+		g.use("fmt")
+	}
 	if g.needRegex {
 		g.needResult = true
 		g.use("regexp")
@@ -435,6 +442,48 @@ func (r Result[T, E]) unwrapOr(fallback T) T {
 		return r.Value
 	}
 	return fallback
+}
+
+func (r Result[T, E]) ok() *T {
+	if !r.IsOk {
+		return nil
+	}
+	v := r.Value
+	return &v
+}
+
+func (r Result[T, E]) err() *E {
+	if r.IsOk {
+		return nil
+	}
+	v := r.Error
+	return &v
+}
+
+func (r Result[T, E]) toString() string {
+	if r.IsOk {
+		return "Ok(...)"
+	}
+	return "Err(...)"
+}
+`)
+	}
+	if g.needErrorRuntime {
+		out.WriteString(`
+func ostyErrorMessage(e any) string {
+	if e == nil {
+		return ""
+	}
+	if m, ok := e.(interface{ message() string }); ok {
+		return m.message()
+	}
+	if err, ok := e.(error); ok {
+		return err.Error()
+	}
+	if s, ok := e.(string); ok {
+		return s
+	}
+	return fmt.Sprint(e)
 }
 `)
 	}

--- a/internal/gen/phase4_test.go
+++ b/internal/gen/phase4_test.go
@@ -109,6 +109,55 @@ fn main() {
 	}
 }
 
+// TestOptionMethods verifies the std.option method surface over the
+// backend's pointer representation for Option<T>.
+func TestOptionMethods(t *testing.T) {
+	src := `use std.option
+
+fn fallback() -> Int? {
+    Some(9)
+}
+
+fn main() {
+    let a: Int? = Some(4)
+    let b: Int? = None
+    let c: Int? = option.Some(6)
+    let d: Int? = option.None
+    println("{a.isSome()} {b.isNone()}")
+    println("{a.unwrap()} {b.unwrapOr(7)}")
+    println("{c.unwrap()} {d.unwrapOr(10)}")
+    match b.orElse(fallback) {
+        Some(v) -> println("{v}"),
+        None -> println("none"),
+    }
+    let mapped = a.map(|x| x + 1)
+    println("{mapped.unwrap()}")
+    let result = b.orError("missing")
+    println("{result.isErr()}")
+    println(result.unwrapErr().message())
+    match result.err() {
+        Some(e) -> println(e.message()),
+        None -> println("no error"),
+    }
+    let mappedResult = result.map(|x| "{x}")
+    println("{mappedResult.isErr()}")
+    let mappedErr = result.mapErr(|e| e.message())
+    println(mappedErr.unwrapErr())
+    println(a.toString())
+    println(b.toString())
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	want := "true true\n4 7\n6 10\n9\n5\ntrue\nmissing\nmissing\ntrue\nmissing\nSome(4)\nNone\n"
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+}
+
 // TestDefer verifies `defer expr` runs on function exit.
 func TestDefer(t *testing.T) {
 	src := `fn main() {

--- a/internal/stdlib/modules/option.osty
+++ b/internal/stdlib/modules/option.osty
@@ -1,11 +1,82 @@
-// std.option — signature stub for the Osty standard library.
+// std.option — Option<T> and its core combinators.
 //
-// Canonical definition site of `Option<T>`, `Some`, and `None`.
-// The prelude auto-imports these so user code can write `Some(x)`
-// without an explicit `use`. Combinators (`unwrap`, `map`, etc.) will
-// be added alongside the rest of the stdlib's method bodies.
+// Canonical definition site of `Option<T>`, `Some`, and `None`. The
+// prelude auto-imports these so user code can write `Some(x)` without
+// an explicit `use`.
 
 pub enum Option<T> {
     Some(T),
     None,
+
+    pub fn isSome(self) -> Bool {
+        match self {
+            Some(_) -> true,
+            None -> false,
+        }
+    }
+
+    pub fn isNone(self) -> Bool {
+        match self {
+            Some(_) -> false,
+            None -> true,
+        }
+    }
+
+    pub fn unwrap(self) -> T {
+        match self {
+            Some(value) -> value,
+            None -> __optionAbort("called unwrap on None"),
+        }
+    }
+
+    pub fn unwrapOr(self, fallback: T) -> T {
+        match self {
+            Some(value) -> value,
+            None -> fallback,
+        }
+    }
+
+    pub fn orElse(self, fallback: fn() -> T?) -> T? {
+        match self {
+            Some(value) -> Some(value),
+            None -> fallback(),
+        }
+    }
+
+    pub fn map<U>(self, f: fn(T) -> U) -> U? {
+        match self {
+            Some(value) -> Some(f(value)),
+            None -> None,
+        }
+    }
+
+    pub fn orError(self, msg: String) -> Result<T, Error> {
+        match self {
+            Some(value) -> Ok(value),
+            None -> __optionError::<T>(msg),
+        }
+    }
+
+    pub fn toString(self) -> String {
+        match self {
+            Some(_) -> "Some(...)",
+            None -> "None",
+        }
+    }
+}
+
+struct OptionError {
+    msg: String,
+
+    pub fn message(self) -> String {
+        self.msg
+    }
+}
+
+fn __optionAbort(msg: String) -> Never {
+    __optionAbort(msg)
+}
+
+fn __optionError<T>(msg: String) -> Result<T, Error> {
+    __optionError::<T>(msg)
 }

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
@@ -378,6 +379,37 @@ func TestOptionVariantViaPkgAccess(t *testing.T) {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Errorf("std.option PkgScope missing export %q", name)
+		}
+	}
+}
+
+// TestOptionModuleMethodsResolves pins the public combinator surface on
+// std.option. The methods are authored in the Osty stub, even though the
+// Go backend lowers calls directly because Option<T> is represented as
+// a pointer.
+func TestOptionModuleMethodsResolves(t *testing.T) {
+	mod := Load().Modules["option"]
+	if mod == nil || mod.File == nil {
+		t.Fatal("std.option not loaded")
+	}
+	var methods map[string]bool
+	for _, d := range mod.File.Decls {
+		if ed, ok := d.(*ast.EnumDecl); ok && ed.Name == "Option" {
+			methods = map[string]bool{}
+			for _, m := range ed.Methods {
+				if m.Pub {
+					methods[m.Name] = true
+				}
+			}
+			break
+		}
+	}
+	if methods == nil {
+		t.Fatal("std.option missing Option enum declaration")
+	}
+	for _, name := range []string{"isSome", "isNone", "unwrap", "unwrapOr", "orElse", "map", "orError", "toString"} {
+		if !methods[name] {
+			t.Errorf("std.option Option missing pub method %q", name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Implement `std.option` combinators in the Osty stdlib stub.
- Teach the checker to canonicalize `option.Option<T>` as `T?`, infer `Option.map`, support `Option.orError`, and type-check `Error.message`.
- Add Go lowering for Option method calls, qualified `option.Some` / `option.None`, Result `map` / `mapErr`, Result `ok` / `err`, and Error message dispatch.

## Impact
This makes `Option<T>`, `T?`, and `option.Option<T>` flow through the same type path and lets the implemented option combinators execute through the current Go backend.

## Validation
- `go test ./...`
