### PR TITLE
[codex] Implement std.json encode and decode

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -91,7 +91,7 @@ const (
 // annotationRules lists the v0.9 permitted annotations (R26) and the
 // targets each applies to.
 var annotationRules = map[string]AnnotationTarget{
-	"json":       TargetStructField,
+	"json":       TargetStructField | TargetVariant,
 	"deprecated": TargetTopLevelDecl | TargetMethod,
 	// `allow` suppresses lint warnings for the annotated declaration
 	// (and its descendants). Broad target set: any place a lint rule

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -2096,7 +2096,7 @@ pub struct User {
     pub name: String,
 }
 `
-	assertCodes(t, runCheck(t, src), diag.CodeUnknownAnnotation)
+	assertCodes(t, runCheck(t, src), diag.CodeAnnotationBadArg)
 }
 
 func TestCheck_AnnotationJSONUnknownArg(t *testing.T) {
@@ -2107,6 +2107,16 @@ pub struct User {
 }
 `
 	assertCodes(t, runCheck(t, src), diag.CodeUnknownAnnotation)
+}
+
+func TestCheck_AnnotationJSONOptionalRequiresOptionalField(t *testing.T) {
+	src := `
+pub struct User {
+    #[json(optional)]
+    pub name: String,
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeAnnotationBadArg)
 }
 
 func TestCheck_MethodReferenceHasFnType(t *testing.T) {

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -60,7 +60,7 @@ func (c *checker) exprType(e ast.Expr, hint types.Type, env *env) types.Type {
 	case *ast.BinaryExpr:
 		return c.binaryType(x, env)
 	case *ast.QuestionExpr:
-		return c.questionType(x, env)
+		return c.questionType(x, hint, env)
 	case *ast.CallExpr:
 		return c.callType(x, hint, env)
 	case *ast.FieldExpr:
@@ -334,8 +334,20 @@ func (c *checker) binaryOpResult(e *ast.BinaryExpr, op token.Kind, lt, rt types.
 
 // ---- Error propagation (?) ----
 
-func (c *checker) questionType(e *ast.QuestionExpr, env *env) types.Type {
-	t := c.checkExpr(e.X, nil, env)
+func (c *checker) questionType(e *ast.QuestionExpr, hint types.Type, env *env) types.Type {
+	var operandHint types.Type
+	if hint != nil && !types.IsError(hint) {
+		if env.retIsResult {
+			errT := env.retResultErr
+			if errT == nil {
+				errT = c.namedOf("Error", nil)
+			}
+			operandHint = c.resultOf(hint, errT)
+		} else if env.retIsOption {
+			operandHint = &types.Optional{Inner: hint}
+		}
+	}
+	t := c.checkExpr(e.X, operandHint, env)
 	if types.IsError(t) {
 		return types.ErrorType
 	}
@@ -397,6 +409,18 @@ func (c *checker) callType(e *ast.CallExpr, hint types.Type, env *env) types.Typ
 	// downstream method calls (`ch.recv()`, `h.join()`) resolve.
 	if t := c.tryThreadCall(e, env); t != nil {
 		return t
+	}
+
+	if tf, ok := e.Fn.(*ast.TurbofishExpr); ok {
+		if fx, fxOK := tf.Base.(*ast.FieldExpr); fxOK {
+			explicit := make([]types.Type, 0, len(tf.Args))
+			for _, a := range tf.Args {
+				explicit = append(explicit, c.typeOf(a))
+			}
+			if t, handled := c.tryPackageCallWithExplicit(fx, e, hint, env, explicit); handled {
+				return t
+			}
+		}
 	}
 
 	// Method call via field: `recv.method(args)`.
@@ -662,6 +686,12 @@ func (c *checker) checkExplicitGenericArity(e *ast.CallExpr, want int, explicit 
 // caller fall through to method-call handling for instance receivers.
 func (c *checker) tryPackageCall(
 	fx *ast.FieldExpr, e *ast.CallExpr, explicit []types.Type, hint types.Type, env *env,
+) (types.Type, bool) {
+	return c.tryPackageCallWithExplicit(fx, e, hint, env, nil)
+}
+
+func (c *checker) tryPackageCallWithExplicit(
+	fx *ast.FieldExpr, e *ast.CallExpr, hint types.Type, env *env, explicit []types.Type,
 ) (types.Type, bool) {
 	id, ok := fx.X.(*ast.Ident)
 	if !ok {

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -183,6 +183,8 @@ func (g *gen) emitStructDecl(s *ast.StructDecl) {
 	for _, m := range s.Methods {
 		g.emitMethod(s.Name, m, false)
 	}
+	g.emitStructJSONMarshal(s)
+	g.emitStructJSONUnmarshal(s)
 }
 
 // emitEnumDecl writes an enum as an interface plus one struct per
@@ -210,6 +212,7 @@ func (g *gen) emitEnumDecl(e *ast.EnumDecl) {
 	for _, m := range e.Methods {
 		g.emitMethod(e.Name, m, true)
 	}
+	g.emitEnumJSONDecoder(e)
 }
 
 // emitVariant writes the struct + marker-method for one enum variant.
@@ -227,6 +230,7 @@ func (g *gen) emitVariant(e *ast.EnumDecl, v *ast.Variant) {
 		g.body.writeln("}")
 	}
 	g.body.writef("func (%s) _is%s() {}\n", name, e.Name)
+	g.emitVariantJSONMarshal(e, v, name)
 }
 
 // emitMethod writes a single method.
@@ -241,6 +245,9 @@ func (g *gen) emitVariant(e *ast.EnumDecl, v *ast.Variant) {
 func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
 	g.body.nl()
 	g.sourceMarker(m)
+
+	prevSelf := g.selfType
+	g.selfType = typeName
 
 	free := m.Recv == nil || enumMethod
 
@@ -284,8 +291,6 @@ func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
 		g.body.write(g.resolveSelfType(m.ReturnType, typeName))
 	}
 
-	prev := g.selfType
-	g.selfType = typeName
 	prevRet := g.currentRetType
 	prevRetGo := g.currentRetGo
 	g.currentRetType = m.ReturnType
@@ -294,7 +299,7 @@ func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
 		g.currentRetGo = g.resolveSelfType(m.ReturnType, typeName)
 	}
 	defer func() {
-		g.selfType = prev
+		g.selfType = prevSelf
 		g.currentRetType = prevRet
 		g.currentRetGo = prevRetGo
 	}()
@@ -485,6 +490,28 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 				return Result[struct{}, any]{Value: struct{}{}, IsOk: true}
 			},
 		}`, osAlias, utf8Alias), full)
+		return true
+	case "json":
+		g.needJSON = true
+		g.emitUseStub(alias, `struct {
+			encode    func(value any) string
+			stringify func(value any) string
+			Object    func(value map[string]Json) Json
+			Array     func(value []Json) Json
+			String    func(value string) Json
+			Number    func(value float64) Json
+			Bool      func(value bool) Json
+			Null      Json
+		}{
+			encode:    jsonEncode,
+			stringify: jsonStringify,
+			Object:    jsonObject,
+			Array:     jsonArray,
+			String:    jsonString,
+			Number:    jsonNumber,
+			Bool:      jsonBool,
+			Null:      nil,
+		}`, full)
 		return true
 	case "random":
 		g.needRandomRuntime = true

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -377,6 +377,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 			return
 		}
 	}
+	if g.emitStdlibJSONCall(c) {
+		return
+	}
 	if f, ok := c.Fn.(*ast.FieldExpr); ok {
 		if g.emitStdlibEncodingCall(c, f) {
 			return
@@ -468,6 +471,50 @@ func (g *gen) emitListPushCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 	g.emitExprAsType(c.Args[0].Value, n.Args[0])
 	g.body.write("); return struct{}{} }()")
 	return true
+}
+
+func (g *gen) emitStdlibJSONCall(c *ast.CallExpr) bool {
+	base := c.Fn
+	var explicit []ast.Type
+	if tf, ok := base.(*ast.TurbofishExpr); ok {
+		base = tf.Base
+		explicit = tf.Args
+	}
+	id, parts, ok := stdlibFieldChain(base)
+	if !ok || id == nil || len(parts) != 1 || !g.isStdlibPackageAlias(id, "json") {
+		return false
+	}
+	if len(c.Args) != 1 {
+		return false
+	}
+	switch parts[0] {
+	case "encode":
+		g.body.write("jsonEncode(")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "stringify":
+		g.body.write("jsonStringify(")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "decode", "parse":
+		g.body.writef("jsonDecode[%s](", g.jsonDecodeTargetGo(c, explicit))
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
+func (g *gen) jsonDecodeTargetGo(c *ast.CallExpr, explicit []ast.Type) string {
+	if len(explicit) == 1 {
+		return g.goTypeExpr(explicit[0])
+	}
+	if n, ok := types.AsNamedByName(g.typeOf(c), "Result"); ok && len(n.Args) == 2 {
+		return g.goType(n.Args[0])
+	}
+	return "any"
 }
 
 func (g *gen) emitStdlibEncodingCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
@@ -902,6 +949,15 @@ func (g *gen) isStdlibPackageAlias(id *ast.Ident, module string) bool {
 	}
 	for _, u := range g.file.Uses {
 		if stdlibUseMatchesAlias(u, id.Name, module) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *gen) isStdlibAliasName(alias, module string) bool {
+	for _, u := range g.file.Uses {
+		if stdlibUseMatchesAlias(u, alias, module) {
 			return true
 		}
 	}

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -132,6 +132,9 @@ type gen struct {
 	// functions and the CsvOptions runtime struct.
 	needCSV bool
 
+	// needJSON is set when std.json lowers to encoding/json helpers.
+	needJSON bool
+
 	// needCompress is set when std.compress lowers to gzip helpers.
 	needCompress bool
 
@@ -347,6 +350,12 @@ func (g *gen) run() ([]byte, error) {
 		g.use("fmt")
 		g.useAs("strings", "stdstrings")
 	}
+	if g.needJSON {
+		g.needResult = true
+		g.useAs("encoding/json", "stdjson")
+		g.use("fmt")
+		g.use("reflect")
+	}
 	if g.needCompress {
 		g.needResult = true
 		g.useAs("bytes", "stdbytes")
@@ -511,6 +520,313 @@ func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F]
 type Range struct {
 	Start, Stop                  int
 	HasStart, HasStop, Inclusive bool
+}
+`)
+	}
+	if g.needJSON {
+		out.WriteString(`
+// Json is the runtime representation of std.json.Json.
+type Json = any
+
+type jsonEncoder interface {
+	toJson() Json
+}
+
+type jsonDecoderFunc func([]byte) (any, error)
+
+type jsonField struct {
+	Name    string
+	Value   any
+	OmitNil bool
+}
+
+var jsonDecoders = map[reflect.Type]jsonDecoderFunc{}
+
+func jsonRegisterDecoder(t reflect.Type, fn jsonDecoderFunc) {
+	jsonDecoders[t] = fn
+}
+
+func jsonEncode(value any) string {
+	data, err := jsonMarshalAny(value)
+	if err != nil {
+		panic(fmt.Sprintf("std.json.encode: %v", err))
+	}
+	return string(data)
+}
+
+func jsonStringify(value any) string { return jsonEncode(value) }
+
+func jsonDecode[T any](text string) Result[T, any] {
+	var out T
+	if err := jsonRejectLoneSurrogates(text); err != nil {
+		return Result[T, any]{Error: err}
+	}
+	if err := jsonUnmarshalInto([]byte(text), &out); err != nil {
+		return Result[T, any]{Error: err}
+	}
+	return Result[T, any]{Value: out, IsOk: true}
+}
+
+func jsonObject(value map[string]Json) Json { return value }
+
+func jsonArray(value []Json) Json { return value }
+
+func jsonString(value string) Json { return value }
+
+func jsonNumber(value float64) Json { return value }
+
+func jsonBool(value bool) Json { return value }
+
+func jsonMarshalAny(value any) ([]byte, error) {
+	if enc, ok := value.(jsonEncoder); ok {
+		return jsonMarshalAny(enc.toJson())
+	}
+	return stdjson.Marshal(value)
+}
+
+func jsonUnmarshalInto[T any](data []byte, out *T) error {
+	target := reflect.TypeOf((*T)(nil)).Elem()
+	return jsonUnmarshalReflect(data, target, reflect.ValueOf(out).Elem())
+}
+
+func jsonUnmarshalReflect(data []byte, target reflect.Type, dest reflect.Value) error {
+	if dec := jsonDecoders[target]; dec != nil {
+		value, err := dec(data)
+		if err != nil {
+			return err
+		}
+		rv := reflect.ValueOf(value)
+		if !rv.Type().AssignableTo(target) {
+			if rv.Type().ConvertibleTo(target) {
+				rv = rv.Convert(target)
+			} else {
+				return fmt.Errorf("std.json: decoded %T cannot be assigned to %v", value, target)
+			}
+		}
+		dest.Set(rv)
+		return nil
+	}
+	if target.Kind() == reflect.Pointer {
+		if jsonRawIsNull(data) {
+			dest.SetZero()
+			return nil
+		}
+		ptr := reflect.New(target.Elem())
+		if err := jsonUnmarshalReflect(data, target.Elem(), ptr.Elem()); err != nil {
+			return err
+		}
+		dest.Set(ptr)
+		return nil
+	}
+	if jsonRawIsNull(data) && target.Kind() != reflect.Interface {
+		if dest.CanAddr() && reflect.PointerTo(target).Implements(reflect.TypeOf((*stdjson.Unmarshaler)(nil)).Elem()) {
+			return stdjson.Unmarshal(data, dest.Addr().Interface())
+		}
+		return fmt.Errorf("std.json: null cannot be decoded into %v", target)
+	}
+	switch target.Kind() {
+	case reflect.Slice:
+		var raw []stdjson.RawMessage
+		if err := stdjson.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+		out := reflect.MakeSlice(target, len(raw), len(raw))
+		for i := range raw {
+			if err := jsonUnmarshalReflect(raw[i], target.Elem(), out.Index(i)); err != nil {
+				return fmt.Errorf("std.json: array[%d]: %w", i, err)
+			}
+		}
+		dest.Set(out)
+		return nil
+	case reflect.Array:
+		var raw []stdjson.RawMessage
+		if err := stdjson.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+		if len(raw) != target.Len() {
+			return fmt.Errorf("std.json: array expected %d values, got %d", target.Len(), len(raw))
+		}
+		for i := range raw {
+			if err := jsonUnmarshalReflect(raw[i], target.Elem(), dest.Index(i)); err != nil {
+				return fmt.Errorf("std.json: array[%d]: %w", i, err)
+			}
+		}
+		return nil
+	case reflect.Map:
+		if target.Key().Kind() == reflect.String {
+			var raw map[string]stdjson.RawMessage
+			if err := stdjson.Unmarshal(data, &raw); err != nil {
+				return err
+			}
+			out := reflect.MakeMapWithSize(target, len(raw))
+			for key, value := range raw {
+				elem := reflect.New(target.Elem()).Elem()
+				if err := jsonUnmarshalReflect(value, target.Elem(), elem); err != nil {
+					return fmt.Errorf("std.json: object[%q]: %w", key, err)
+				}
+				out.SetMapIndex(reflect.ValueOf(key).Convert(target.Key()), elem)
+			}
+			dest.Set(out)
+			return nil
+		}
+	}
+	if dest.CanAddr() {
+		return stdjson.Unmarshal(data, dest.Addr().Interface())
+	}
+	ptr := reflect.New(target)
+	if err := stdjson.Unmarshal(data, ptr.Interface()); err != nil {
+		return err
+	}
+	dest.Set(ptr.Elem())
+	return nil
+}
+
+func jsonParseValue(data []byte) (Json, error) {
+	if err := jsonRejectLoneSurrogates(string(data)); err != nil {
+		return nil, err
+	}
+	var value Json
+	if err := stdjson.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func jsonAsError(value any) error {
+	if err, ok := value.(error); ok {
+		return err
+	}
+	return fmt.Errorf("%v", value)
+}
+
+func jsonMarshalObject(fields []jsonField) ([]byte, error) {
+	out := make(map[string]stdjson.RawMessage, len(fields))
+	for _, field := range fields {
+		if field.OmitNil && jsonIsNil(field.Value) {
+			continue
+		}
+		data, err := jsonMarshalAny(field.Value)
+		if err != nil {
+			return nil, err
+		}
+		out[field.Name] = stdjson.RawMessage(data)
+	}
+	return stdjson.Marshal(out)
+}
+
+func jsonMarshalEnum(tag string, values ...any) ([]byte, error) {
+	fields := []jsonField{{Name: "tag", Value: tag}}
+	switch len(values) {
+	case 0:
+	case 1:
+		fields = append(fields, jsonField{Name: "value", Value: values[0]})
+	default:
+		fields = append(fields, jsonField{Name: "value", Value: values})
+	}
+	return jsonMarshalObject(fields)
+}
+
+func jsonSkippedVariant(enumName, variantName string) ([]byte, error) {
+	return nil, fmt.Errorf("std.json: %s.%s is marked #[json(skip)]", enumName, variantName)
+}
+
+func jsonUnmarshalArray(data []byte, want int, label string) ([]stdjson.RawMessage, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("std.json: %s missing value", label)
+	}
+	var values []stdjson.RawMessage
+	if err := stdjson.Unmarshal(data, &values); err != nil {
+		return nil, fmt.Errorf("std.json: %s value: %w", label, err)
+	}
+	if len(values) != want {
+		return nil, fmt.Errorf("std.json: %s expected %d values, got %d", label, want, len(values))
+	}
+	return values, nil
+}
+
+func jsonRawIsNull(data []byte) bool {
+	start, end := 0, len(data)
+	for start < end && data[start] <= ' ' {
+		start++
+	}
+	for end > start && data[end-1] <= ' ' {
+		end--
+	}
+	return end-start == 4 && string(data[start:end]) == "null"
+}
+
+func jsonIsNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+func jsonRejectLoneSurrogates(text string) error {
+	inString := false
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || i+1 >= len(text) {
+				continue
+			}
+			if text[i+1] != 'u' {
+				i++
+				continue
+			}
+			r, ok := jsonHex4(text[i+2:])
+			if !ok {
+				continue
+			}
+			if r >= 0xD800 && r <= 0xDBFF {
+				low, lowOK := rune(0), false
+				if i+12 <= len(text) && text[i+6] == '\\' && text[i+7] == 'u' {
+					low, lowOK = jsonHex4(text[i+8:])
+				}
+				if !lowOK || low < 0xDC00 || low > 0xDFFF {
+					return fmt.Errorf("std.json.decode: lone surrogate escape \\u%04X", r)
+				}
+				i += 11
+				continue
+			}
+			if r >= 0xDC00 && r <= 0xDFFF {
+				return fmt.Errorf("std.json.decode: lone surrogate escape \\u%04X", r)
+			}
+			i += 5
+		}
+	}
+	return nil
+}
+
+func jsonHex4(s string) (rune, bool) {
+	if len(s) < 4 {
+		return 0, false
+	}
+	var r rune
+	for i := 0; i < 4; i++ {
+		c := s[i]
+		var v byte
+		switch {
+		case c >= '0' && c <= '9':
+			v = c - '0'
+		case c >= 'a' && c <= 'f':
+			v = c - 'a' + 10
+		case c >= 'A' && c <= 'F':
+			v = c - 'A' + 10
+		default:
+			return 0, false
+		}
+		r = r*16 + rune(v)
+	}
+	return r, true
 }
 `)
 	}

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -289,6 +289,102 @@ fn main() {
 	}
 }
 
+func TestStdJSONBridge(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.json
+
+pub struct Payload {
+    #[json(key = "user_id")]
+    pub userId: Int,
+
+    #[json(optional)]
+    pub nickname: String?,
+
+    #[json(skip)]
+    pub cache: Int,
+}
+
+pub enum Shape {
+    #[json(key = "circle")]
+    Circle(Float),
+    Empty,
+}
+
+pub struct Secret {
+    pub raw: String,
+
+    pub fn toJson(self) -> json.Json {
+        json.String("redacted")
+    }
+}
+
+pub struct FromCustom {
+    pub value: Int,
+
+    pub fn fromJson(value: json.Json) -> Result<Self, Error> {
+        Ok(Self { value: 42 })
+    }
+}
+
+fn loadPayload(text: String) -> Result<Payload, Error> {
+    let cfg: Payload = json.decode(text)?
+    Ok(cfg)
+}
+
+fn main() {
+    let missing = Payload { userId: 7, nickname: None, cache: 99 }
+    println(json.encode(missing))
+    let nick = "neo"
+    let present = Payload { userId: 8, nickname: Some(nick), cache: 0 }
+    println(json.stringify(present))
+    println(json.encode(Circle(2.5)))
+    let raw: json.Json = json.Object({"ok": json.Bool(true), "name": json.String("osty"), "none": json.Null})
+    println(json.stringify(raw))
+    let decoded: Payload = json.decode::<Payload>("\{\"user_id\":9,\"nickname\":null,\"cache\":123,\"extra\":true\}").unwrap()
+    println(json.encode(decoded))
+    let parsed: Payload = json.parse::<Payload>("\{\"user_id\":10,\"nickname\":\"trinity\"\}").unwrap()
+    println(json.encode(parsed))
+    let roundShape: Shape = json.decode::<Shape>("\{\"tag\":\"circle\",\"value\":3.5\}").unwrap()
+    println(json.encode(roundShape))
+    let shapes: List<Shape> = json.decode::<List<Shape>>("[\{\"tag\":\"circle\",\"value\":1.25\},\{\"tag\":\"Empty\"\}]").unwrap()
+    println(json.encode(shapes))
+    let shapeMap: Map<String, Shape> = json.decode::<Map<String, Shape>>("\{\"a\":\{\"tag\":\"circle\",\"value\":4.5\}\}").unwrap()
+    println(json.encode(shapeMap["a"]))
+    let loaded = loadPayload("\{\"user_id\":11\}").unwrap()
+    println(json.encode(loaded))
+    println(json.decode::<String>("\"\\uD800\"").isErr())
+    println(json.encode(Secret { raw: "top" }))
+    println(json.decode::<FromCustom>("null").unwrap().value)
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		`{"user_id":7}`,
+		`{"nickname":"neo","user_id":8}`,
+		`{"tag":"circle","value":2.5}`,
+		`{"name":"osty","none":null,"ok":true}`,
+		`{"user_id":9}`,
+		`{"nickname":"trinity","user_id":10}`,
+		`{"tag":"circle","value":3.5}`,
+		`[{"tag":"circle","value":1.25},{"tag":"Empty"}]`,
+		`{"tag":"circle","value":4.5}`,
+		`{"user_id":11}`,
+		`true`,
+		`"redacted"`,
+		`42`,
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"stdjson.Marshal", "func (self Payload) MarshalJSON", "func (self *Payload) UnmarshalJSON", "jsonDecode[Payload]", "jsonUnmarshalShape"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.json bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
 func TestStdCompressBridge(t *testing.T) {
 	goSrc, err := transpileWithStdlib(t, `use std.compress
 use std.encoding

--- a/internal/gen/json.go
+++ b/internal/gen/json.go
@@ -1,0 +1,340 @@
+package gen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+type jsonAnnotationOptions struct {
+	name     string
+	skip     bool
+	optional bool
+}
+
+func (g *gen) emitStructJSONMarshal(s *ast.StructDecl) {
+	if !g.needJSON || hasMethodNamed(s.Methods, "MarshalJSON") {
+		return
+	}
+	recv := genericReceiverName(s.Name, s.Generics)
+	g.body.nl()
+	g.body.writef("func (self %s) MarshalJSON() ([]byte, error) {\n", recv)
+	g.body.indent()
+	if m := receiverMethodNamed(s.Methods, "toJson"); m != nil {
+		call := "self.toJson()"
+		if m.Recv != nil && m.Recv.Mut {
+			call = "(&self).toJson()"
+		}
+		g.body.writef("return jsonMarshalAny(%s)\n", call)
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+	g.body.writeln("return jsonMarshalObject([]jsonField{")
+	g.body.indent()
+	for _, f := range s.Fields {
+		opts := jsonOptions(f.Annotations, f.Name)
+		if opts.skip {
+			continue
+		}
+		g.body.writef("{Name: %q, Value: self.%s", opts.name, mangleIdent(f.Name))
+		if opts.optional {
+			g.body.write(", OmitNil: true")
+		}
+		g.body.writeln("},")
+	}
+	g.body.dedent()
+	g.body.writeln("})")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitStructJSONUnmarshal(s *ast.StructDecl) {
+	if !g.needJSON || hasMethodNamed(s.Methods, "UnmarshalJSON") {
+		return
+	}
+	recv := genericReceiverName(s.Name, s.Generics)
+	g.body.nl()
+	g.body.writef("func (self *%s) UnmarshalJSON(data []byte) error {\n", recv)
+	g.body.indent()
+	if len(s.Generics) == 0 && associatedMethodNamed(s.Methods, "fromJson") != nil {
+		g.body.writeln("value, err := jsonParseValue(data)")
+		g.body.writeln("if err != nil {")
+		g.body.indent()
+		g.body.writeln("return err")
+		g.body.dedent()
+		g.body.writeln("}")
+		g.body.writef("result := %s_fromJson(value)\n", s.Name)
+		g.body.writeln("if !result.IsOk {")
+		g.body.indent()
+		g.body.writeln("return jsonAsError(result.Error)")
+		g.body.dedent()
+		g.body.writeln("}")
+		g.body.writeln("*self = result.Value")
+		g.body.writeln("return nil")
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+	g.body.writeln("var raw map[string]stdjson.RawMessage")
+	g.body.writeln("if err := stdjson.Unmarshal(data, &raw); err != nil {")
+	g.body.indent()
+	g.body.writeln("return err")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writef("if raw == nil && jsonRawIsNull(data) { return fmt.Errorf(%q) }\n",
+		fmt.Sprintf("std.json: %s expects object, got null", s.Name))
+	for _, f := range s.Fields {
+		opts := jsonOptions(f.Annotations, f.Name)
+		if opts.skip {
+			continue
+		}
+		g.body.writef("if value, ok := raw[%q]; ok {\n", opts.name)
+		g.body.indent()
+		if !g.jsonTypeAllowsNull(f.Type) {
+			msg := fmt.Sprintf("std.json: %s.%s is null", s.Name, opts.name)
+			g.body.writef("if jsonRawIsNull(value) { return fmt.Errorf(%q) }\n", msg)
+		}
+		msg := fmt.Sprintf("std.json: %s.%s: %%w", s.Name, opts.name)
+		g.body.writef("if err := jsonUnmarshalInto(value, &self.%s); err != nil { return fmt.Errorf(%q, err) }\n",
+			mangleIdent(f.Name), msg)
+		g.body.dedent()
+		g.body.writeln("}")
+	}
+	g.body.writeln("return nil")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitVariantJSONMarshal(e *ast.EnumDecl, v *ast.Variant, goName string) {
+	if !g.needJSON {
+		return
+	}
+	if receiverMethodNamed(e.Methods, "toJson") != nil {
+		g.body.writef("func (self %s) MarshalJSON() ([]byte, error) { ", goName)
+		g.body.writef("return jsonMarshalAny(%s_toJson(%s(self)))", e.Name, e.Name)
+		g.body.writeln(" }")
+		return
+	}
+	opts := jsonOptions(v.Annotations, v.Name)
+	g.body.writef("func (self %s) MarshalJSON() ([]byte, error) { ", goName)
+	if opts.skip {
+		g.body.writef("return jsonSkippedVariant(%q, %q)", e.Name, v.Name)
+		g.body.writeln(" }")
+		return
+	}
+	g.body.writef("return jsonMarshalEnum(%q", opts.name)
+	for i := range v.Fields {
+		g.body.writef(", self.F%d", i)
+	}
+	g.body.writeln(") }")
+}
+
+func (g *gen) emitEnumJSONDecoder(e *ast.EnumDecl) {
+	if !g.needJSON {
+		return
+	}
+	if associatedMethodNamed(e.Methods, "fromJson") != nil {
+		g.emitEnumJSONCustomDecoder(e)
+		return
+	}
+	g.body.nl()
+	g.body.writeln("func init() {")
+	g.body.indent()
+	g.body.writef("jsonRegisterDecoder(reflect.TypeOf((*%s)(nil)).Elem(), func(data []byte) (any, error) { return jsonUnmarshal%s(data) })\n", e.Name, e.Name)
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.nl()
+	g.body.writef("func jsonUnmarshal%s(data []byte) (%s, error) {\n", e.Name, e.Name)
+	g.body.indent()
+	g.body.writeln("var head struct {")
+	g.body.indent()
+	g.body.writeln("Tag string `json:\"tag\"`")
+	g.body.writeln("Value stdjson.RawMessage `json:\"value\"`")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writeln("if err := stdjson.Unmarshal(data, &head); err != nil {")
+	g.body.indent()
+	g.body.writeln("return nil, err")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writeln("switch head.Tag {")
+	g.body.indent()
+	for _, v := range e.Variants {
+		opts := jsonOptions(v.Annotations, v.Name)
+		if opts.skip {
+			continue
+		}
+		goName := e.Name + "_" + v.Name
+		label := e.Name + "." + v.Name
+		g.body.writef("case %q:\n", opts.name)
+		g.body.indent()
+		switch len(v.Fields) {
+		case 0:
+			g.body.writef("return %s(%s{}), nil\n", e.Name, goName)
+		case 1:
+			fieldType := g.goTypeExpr(v.Fields[0])
+			missing := fmt.Sprintf("std.json: %s missing value", label)
+			msg := fmt.Sprintf("std.json: %s value: %%w", label)
+			g.body.writef("if len(head.Value) == 0 { return nil, fmt.Errorf(%q) }\n", missing)
+			g.body.writef("var f0 %s\n", fieldType)
+			g.body.writef("if err := jsonUnmarshalInto(head.Value, &f0); err != nil { return nil, fmt.Errorf(%q, err) }\n", msg)
+			g.body.writef("return %s(%s{F0: f0}), nil\n", e.Name, goName)
+		default:
+			g.body.writef("values, err := jsonUnmarshalArray(head.Value, %d, %q)\n", len(v.Fields), label)
+			g.body.writeln("if err != nil {")
+			g.body.indent()
+			g.body.writeln("return nil, err")
+			g.body.dedent()
+			g.body.writeln("}")
+			for i, f := range v.Fields {
+				msg := fmt.Sprintf("std.json: %s value[%d]: %%w", label, i)
+				g.body.writef("var f%d %s\n", i, g.goTypeExpr(f))
+				g.body.writef("if err := jsonUnmarshalInto(values[%d], &f%d); err != nil { return nil, fmt.Errorf(%q, err) }\n", i, i, msg)
+			}
+			g.body.writef("return %s(%s{", e.Name, goName)
+			for i := range v.Fields {
+				if i > 0 {
+					g.body.write(", ")
+				}
+				g.body.writef("F%d: f%d", i, i)
+			}
+			g.body.writeln("}), nil")
+		}
+		g.body.dedent()
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writef("return nil, fmt.Errorf(\"std.json: unknown %s tag %%q\", head.Tag)\n", e.Name)
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitEnumJSONCustomDecoder(e *ast.EnumDecl) {
+	g.body.nl()
+	g.body.writeln("func init() {")
+	g.body.indent()
+	g.body.writef("jsonRegisterDecoder(reflect.TypeOf((*%s)(nil)).Elem(), func(data []byte) (any, error) {\n", e.Name)
+	g.body.indent()
+	g.body.writeln("value, err := jsonParseValue(data)")
+	g.body.writeln("if err != nil {")
+	g.body.indent()
+	g.body.writeln("return nil, err")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writef("result := %s_fromJson(value)\n", e.Name)
+	g.body.writeln("if !result.IsOk {")
+	g.body.indent()
+	g.body.writeln("return nil, jsonAsError(result.Error)")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writeln("return result.Value, nil")
+	g.body.dedent()
+	g.body.writeln("})")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func hasMethodNamed(methods []*ast.FnDecl, name string) bool {
+	return methodNamed(methods, name) != nil
+}
+
+func methodNamed(methods []*ast.FnDecl, name string) *ast.FnDecl {
+	for _, m := range methods {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}
+
+func receiverMethodNamed(methods []*ast.FnDecl, name string) *ast.FnDecl {
+	for _, m := range methods {
+		if m.Name == name && m.Recv != nil {
+			return m
+		}
+	}
+	return nil
+}
+
+func associatedMethodNamed(methods []*ast.FnDecl, name string) *ast.FnDecl {
+	for _, m := range methods {
+		if m.Name == name && m.Recv == nil {
+			return m
+		}
+	}
+	return nil
+}
+
+func genericReceiverName(name string, generics []*ast.GenericParam) string {
+	if len(generics) == 0 {
+		return name
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteByte('[')
+	for i, p := range generics {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(p.Name)
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+func (g *gen) jsonTypeAllowsNull(t ast.Type) bool {
+	switch t := t.(type) {
+	case *ast.OptionalType:
+		return true
+	case *ast.NamedType:
+		if len(t.Path) == 1 {
+			switch t.Path[0] {
+			case "Option", "Json":
+				return true
+			}
+		}
+		if len(t.Path) == 2 && t.Path[1] == "Json" && g.isStdlibAliasName(t.Path[0], "json") {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonOptions(annots []*ast.Annotation, fallback string) jsonAnnotationOptions {
+	opts := jsonAnnotationOptions{name: fallback}
+	for _, ann := range annots {
+		if ann.Name != "json" {
+			continue
+		}
+		for _, arg := range ann.Args {
+			switch arg.Key {
+			case "key":
+				if s, ok := annotationString(arg.Value); ok {
+					opts.name = s
+				}
+			case "skip":
+				opts.skip = true
+			case "optional":
+				opts.optional = true
+			}
+		}
+	}
+	return opts
+}
+
+func annotationString(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.StringLit)
+	if !ok {
+		return "", false
+	}
+	var b strings.Builder
+	for _, p := range lit.Parts {
+		if !p.IsLit {
+			return "", false
+		}
+		b.WriteString(p.Lit)
+	}
+	return b.String(), true
+}

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -220,6 +220,9 @@ func (g *gen) goNamedType(n *types.Named) string {
 	case "CsvOptions":
 		g.needCSV = true
 		return "CsvOptions"
+	case "Json":
+		g.needJSON = true
+		return "Json"
 	case "Uuid":
 		g.needUUID = true
 		return "Uuid"
@@ -301,10 +304,30 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 		return "any"
 	}
 	if len(n.Path) > 1 {
+		if len(n.Path) == 2 && n.Path[1] == "Json" && g.isStdlibAliasName(n.Path[0], "json") {
+			g.needJSON = true
+			return "Json"
+		}
 		// Qualified (pkg.Type). Phase 5 adds proper module handling.
 		return strings.Join(n.Path, ".")
 	}
 	name := n.Path[0]
+	if name == "Self" && g.selfType != "" {
+		if len(n.Args) == 0 {
+			return g.selfType
+		}
+		var b strings.Builder
+		b.WriteString(g.selfType)
+		b.WriteByte('[')
+		for i, a := range n.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(g.goTypeExpr(a))
+		}
+		b.WriteByte(']')
+		return b.String()
+	}
 	// Generic type-parameter references substitute to the concrete Go
 	// type rendered at the monomorphizing call site. Applies only to
 	// bare single-path names with no type arguments — a `T<...>` shape
@@ -372,6 +395,9 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 	case "CsvOptions":
 		g.needCSV = true
 		return "CsvOptions"
+	case "Json":
+		g.needJSON = true
+		return "Json"
 	case "Uuid":
 		g.needUUID = true
 		return "Uuid"

--- a/internal/resolve/checks_test.go
+++ b/internal/resolve/checks_test.go
@@ -126,6 +126,15 @@ func TestDuplicateVariant(t *testing.T) {
 }`, diag.CodeDuplicateDecl)
 }
 
+func TestDuplicateVariantJSONTag(t *testing.T) {
+	expectCode(t, `pub enum E {
+    #[json(key = "same")]
+    A,
+    #[json(key = "same")]
+    B,
+}`, diag.CodeDuplicateDecl)
+}
+
 func TestDuplicateEnumMethod(t *testing.T) {
 	expectCode(t, `pub enum E {
     A,

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -527,17 +527,17 @@ func (r *resolver) checkAnnotations(annots []*ast.Annotation, target ast.Annotat
 			continue
 		}
 		seen[a.Name] = a
-		r.checkAnnotationArgs(a)
+		r.checkAnnotationArgs(a, target)
 	}
 }
 
 // checkAnnotationArgs validates each `#[name(arg = value)]` argument
 // against the fixed signature for that annotation (§3.8). Unknown keys
 // and wrong-typed values are both reported here.
-func (r *resolver) checkAnnotationArgs(a *ast.Annotation) {
+func (r *resolver) checkAnnotationArgs(a *ast.Annotation, target ast.AnnotationTarget) {
 	switch a.Name {
 	case "json":
-		r.checkJSONArgs(a)
+		r.checkJSONArgs(a, target)
 	case "deprecated":
 		r.checkDeprecatedArgs(a)
 	}
@@ -551,7 +551,7 @@ func (r *resolver) checkAnnotationArgs(a *ast.Annotation) {
 //
 // The combined-argument constraints (skip mutually excludes key /
 // optional) are enforced here too.
-func (r *resolver) checkJSONArgs(a *ast.Annotation) {
+func (r *resolver) checkJSONArgs(a *ast.Annotation, target ast.AnnotationTarget) {
 	var hasKey, hasSkip, hasOptional bool
 	for _, arg := range a.Args {
 		switch arg.Key {
@@ -560,7 +560,7 @@ func (r *resolver) checkJSONArgs(a *ast.Annotation) {
 			if _, ok := stringArg(arg.Value); !ok {
 				r.emit(diag.New(diag.Error,
 					"`#[json(key = ...)]` requires a string literal").
-					Code(diag.CodeUnknownAnnotation).
+					Code(diag.CodeAnnotationBadArg).
 					PrimaryPos(arg.PosV, "expected string literal here").
 					Build())
 			}
@@ -569,16 +569,23 @@ func (r *resolver) checkJSONArgs(a *ast.Annotation) {
 			if !isFlagOrTrue(arg) {
 				r.emit(diag.New(diag.Error,
 					"`#[json(skip)]` takes no value or `skip = true`").
-					Code(diag.CodeUnknownAnnotation).
+					Code(diag.CodeAnnotationBadArg).
 					PrimaryPos(arg.PosV, "unexpected value").
 					Build())
 			}
 		case "optional":
 			hasOptional = true
+			if target != ast.TargetStructField {
+				r.emit(diag.New(diag.Error,
+					"`#[json(optional)]` is only valid on struct fields").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "not a struct field option").
+					Build())
+			}
 			if !isFlagOrTrue(arg) {
 				r.emit(diag.New(diag.Error,
 					"`#[json(optional)]` takes no value or `optional = true`").
-					Code(diag.CodeUnknownAnnotation).
+					Code(diag.CodeAnnotationBadArg).
 					PrimaryPos(arg.PosV, "unexpected value").
 					Build())
 			}
@@ -594,7 +601,7 @@ func (r *resolver) checkJSONArgs(a *ast.Annotation) {
 	if hasSkip && (hasKey || hasOptional) {
 		r.emit(diag.New(diag.Error,
 			"`skip` is mutually exclusive with `key` and `optional`").
-			Code(diag.CodeUnknownAnnotation).
+			Code(diag.CodeAnnotationBadArg).
 			PrimaryPos(a.PosV, "remove `skip` or the other argument").
 			Build())
 	}
@@ -822,6 +829,7 @@ func (r *resolver) resolveStructDecl(s *ast.StructDecl) {
 		r.checkDuplicateMethods(s.Methods)
 		for _, fld := range s.Fields {
 			r.checkAnnotations(fld.Annotations, ast.TargetStructField)
+			r.checkJSONFieldArgs(fld)
 			r.resolveType(fld.Type)
 			if fld.Default != nil {
 				r.resolveExpr(fld.Default)
@@ -837,6 +845,7 @@ func (r *resolver) resolveStructDecl(s *ast.StructDecl) {
 func (r *resolver) resolveEnumDecl(e *ast.EnumDecl) {
 	r.resolveTypeBody(e.Name, "enum", e.PosV, e, e.Generics, func(selfSym *Symbol) {
 		r.checkDuplicateVariants(e.Variants)
+		r.checkDuplicateVariantJSONTags(e)
 		r.checkDuplicateMethods(e.Methods)
 		// Variant annotations were already validated in declareTopLevel;
 		// only resolve variant-field types here.
@@ -879,6 +888,83 @@ func (r *resolver) checkDuplicateFields(fields []*ast.Field) {
 
 func (r *resolver) checkDuplicateVariants(variants []*ast.Variant) {
 	checkDuplicateNamed(r, variants, "variant", "")
+}
+
+func (r *resolver) checkDuplicateVariantJSONTags(e *ast.EnumDecl) {
+	type record struct {
+		variant *ast.Variant
+		tag     string
+	}
+	seen := map[string]record{}
+	for _, v := range e.Variants {
+		tag, skipped := jsonVariantTag(v)
+		if skipped {
+			continue
+		}
+		if prev, ok := seen[tag]; ok {
+			r.emit(diag.New(diag.Error,
+				fmt.Sprintf("enum `%s` has duplicate JSON tag `%s`", e.Name, tag)).
+				Code(diag.CodeDuplicateDecl).
+				Primary(diag.Span{Start: v.Pos(), End: v.End()},
+					"duplicate JSON tag here").
+				Secondary(diag.Span{Start: prev.variant.Pos(), End: prev.variant.End()},
+					"previous JSON tag here").
+				Build())
+			continue
+		}
+		seen[tag] = record{variant: v, tag: tag}
+	}
+}
+
+func (r *resolver) checkJSONFieldArgs(f *ast.Field) {
+	for _, ann := range f.Annotations {
+		if ann.Name != "json" {
+			continue
+		}
+		for _, arg := range ann.Args {
+			if arg.Key != "optional" {
+				continue
+			}
+			if !jsonFieldTypeAllowsOptional(f.Type) {
+				r.emit(diag.New(diag.Error,
+					"`#[json(optional)]` requires an optional field type").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "field type is not optional").
+					Build())
+			}
+		}
+	}
+}
+
+func jsonVariantTag(v *ast.Variant) (string, bool) {
+	tag := v.Name
+	for _, ann := range v.Annotations {
+		if ann.Name != "json" {
+			continue
+		}
+		for _, arg := range ann.Args {
+			switch arg.Key {
+			case "key":
+				if s, ok := stringArg(arg.Value); ok {
+					tag = s
+				}
+			case "skip":
+				return tag, true
+			}
+		}
+	}
+	return tag, false
+}
+
+func jsonFieldTypeAllowsOptional(t ast.Type) bool {
+	switch t := t.(type) {
+	case *ast.OptionalType:
+		return true
+	case *ast.NamedType:
+		return len(t.Path) == 1 && t.Path[0] == "Option"
+	default:
+		return false
+	}
 }
 
 func (r *resolver) checkDuplicateMethods(methods []*ast.FnDecl) {
@@ -1555,14 +1641,16 @@ func (r *resolver) resolveType(t ast.Type) {
 				r.typeRefs[n] = r.methodCtx.selfType
 			}
 		default:
-			sym := r.current.LookupType(first)
+			sym, shadow := r.current.LookupTypeHead(first)
 			switch {
 			case sym == nil:
-				r.errorf(n.PosV, diag.CodeUndefinedName,
-					"undefined type `%s`", first)
-			case !sym.Kind.IsType() && sym.Kind != SymPackage:
-				r.errorf(n.PosV, diag.CodeWrongSymbolKind,
-					"`%s` is a %s, not a type", first, sym.Kind)
+				if shadow != nil {
+					r.errorf(n.PosV, diag.CodeWrongSymbolKind,
+						"`%s` is a %s, not a type", first, shadow.Kind)
+				} else {
+					r.errorf(n.PosV, diag.CodeUndefinedName,
+						"undefined type `%s`", first)
+				}
 			case sym.Kind == SymPackage && len(n.Path) >= 2:
 				// `pkg.Type` — look the tail up in the target package's
 				// exported scope and attach that symbol. With only one

--- a/internal/resolve/scope.go
+++ b/internal/resolve/scope.go
@@ -71,6 +71,13 @@ func (k SymbolKind) IsType() bool {
 	return false
 }
 
+// IsTypeHead reports whether the symbol can appear as the first segment
+// of a type reference. Packages are accepted here only so `pkg.Type`
+// can resolve the tail in the package's exported scope.
+func (k SymbolKind) IsTypeHead() bool {
+	return k.IsType() || k == SymPackage
+}
+
 // IsValue reports whether the symbol can appear in an expression position
 // (function call target, variable reference, variant constructor).
 func (k SymbolKind) IsValue() bool {
@@ -242,6 +249,25 @@ func (s *Scope) LookupType(name string) *Symbol {
 		}
 	}
 	return nil
+}
+
+// LookupTypeHead resolves a name in type position. Osty keeps type and
+// value lookup separate enough that a local value or variant named
+// `String` should not prevent the builtin type `String` from being used
+// in a field or annotation. The returned shadow is the first non-type
+// symbol seen; callers use it only when no type head exists anywhere.
+func (s *Scope) LookupTypeHead(name string) (typ *Symbol, shadow *Symbol) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if sym, ok := cur.syms[name]; ok {
+			if sym.Kind.IsTypeHead() {
+				return sym, shadow
+			}
+			if shadow == nil {
+				shadow = sym
+			}
+		}
+	}
+	return nil, shadow
 }
 
 // LookupLocal returns a symbol only if it is defined in THIS scope (not

--- a/internal/stdlib/modules/json.osty
+++ b/internal/stdlib/modules/json.osty
@@ -1,6 +1,4 @@
-// std.json — JSON value model and codec protocol surface.
-
-use std.strings
+// std.json - JSON value model and codec protocol surface.
 
 pub type JsonObject = Map<String, Json>
 pub type JsonArray = List<Json>
@@ -25,22 +23,18 @@ pub interface Decode {
     fn fromJson(value: Json) -> Result<Self, Error>
 }
 
-fn quote(text: String) -> String {
-    text
+pub fn encode<T>(value: T) -> String {
+    ""
 }
 
-pub fn encode<T: Encode>(value: T) -> String {
-    stringify(value.toJson())
+pub fn stringify<T>(value: T) -> String {
+    encode(value)
 }
 
 pub fn decode<T>(text: String) -> Result<T, Error> {
     decode::<T>(text)
 }
 
-pub fn parse(text: String) -> Result<Json, Error> {
-    Ok(Null)
-}
-
-pub fn stringify(value: Json) -> String {
-    ""
+pub fn parse<T>(text: String) -> Result<T, Error> {
+    decode(text)
 }

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -902,6 +902,62 @@ pub fn smoke(text: String) -> Result<String, Error> {
 	}
 }
 
+func TestJSONModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["json"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.json not loaded")
+	}
+	for _, name := range []string{"Json", "Encode", "Decode", "encode", "stringify", "decode", "parse"} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.json missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.json export %q is not pub", name)
+		}
+	}
+}
+
+func TestJSONPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.json
+
+pub struct User {
+    #[json(key = "user_id")]
+    pub userId: Int,
+
+    #[json(optional)]
+    pub nickname: String?,
+
+    #[json(skip)]
+    pub cache: Int,
+}
+
+pub fn smoke(user: User) -> String {
+    let encoded: String = json.encode(user)
+    let decoded: Result<User, Error> = json.decode(encoded)
+    let parsed: Result<User, Error> = json.parse(encoded)
+    let value: json.Json = json.Object({"ok": json.Bool(true), "name": json.String("osty"), "none": json.Null})
+    json.stringify(value)
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.json diagnostic: %s", d.Error())
+		}
+	}
+}
+
 func TestCompressModuleCoverage(t *testing.T) {
 	reg := Load()
 	mod := reg.Modules["compress"]


### PR DESCRIPTION
## Summary

Implements the `std.json` module surface and generator/runtime support for JSON encode/decode.

## Changes

- Added `std.json` exports for `Json`, `Encode`, `Decode`, `encode`, `stringify`, `decode`, and `parse`.
- Generated JSON marshal/unmarshal support for structs and tagged enums, including `#[json(key)]`, `#[json(skip)]`, and `#[json(optional)]`.
- Added custom `toJson` and `fromJson` hooks, recursive decode support for nested enum values in lists/maps, and strict decode handling for lone surrogate escapes and nullability.
- Improved package turbofish calls and `?` hint propagation so `json.decode(text)?` can infer the expected result type.
- Added resolver diagnostics for duplicate enum JSON tags and invalid JSON annotation usage.

## Validation

- `go test ./...`