### PR TITLE
[codex] implement std.error runtime

### DIFF
--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -856,6 +856,60 @@ fn main() {
 	assertOK(t, runCheck(t, src))
 }
 
+func TestCheck_ErrorNewAndInterfaceMethods(t *testing.T) {
+	src := `
+pub struct MyError {
+    pub msg: String,
+
+    pub fn message(self) -> String { self.msg }
+}
+
+fn main() {
+    let e = Error.new("boom")
+    let msg: String = e.message()
+    let cause: Error? = e.source()
+    let concrete: MyError? = e.downcast::<MyError>()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_StdErrorQualifiedConstructorOnOpaqueImport(t *testing.T) {
+	src := `
+use std.error as err
+
+fn main() {
+    let e: Error = err.Error.new("boom")
+    let msg: String = e.message()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_ErrorDowncastRejectsInterfaceTarget(t *testing.T) {
+	src := `
+fn main() {
+    let e = Error.new("boom")
+    let concrete = e.downcast::<Error>()
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_ErrorDowncastRejectsNonErrorTarget(t *testing.T) {
+	src := `
+pub struct Plain {
+    pub msg: String,
+}
+
+fn main() {
+    let e = Error.new("boom")
+    let concrete = e.downcast::<Plain>()
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
 func TestCheck_InterfaceValueExposesRequiredMethods(t *testing.T) {
 	src := `
 pub interface Printable {
@@ -1006,6 +1060,25 @@ fn require<T: Same>(x: T) {}
 
 fn main() {
     require(Point { x: 1 })
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_InterfaceNamedReferenceIsNotSelf(t *testing.T) {
+	src := `
+pub interface Cause {
+    fn source(self) -> Cause?
+}
+
+pub struct Leaf {
+    pub fn source(self) -> Cause? { None }
+}
+
+fn require<T: Cause>(x: T) {}
+
+fn main() {
+    require(Leaf {})
 }
 `
 	assertOK(t, runCheck(t, src))

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -410,6 +410,11 @@ func (c *checker) callType(e *ast.CallExpr, hint types.Type, env *env) types.Typ
 	if t := c.tryThreadCall(e, env); t != nil {
 		return t
 	}
+	if tf, ok := e.Fn.(*ast.TurbofishExpr); ok {
+		if t, handled := c.tryErrorDowncastCall(tf, e, env); handled {
+			return t
+		}
+	}
 
 	if tf, ok := e.Fn.(*ast.TurbofishExpr); ok {
 		if fx, fxOK := tf.Base.(*ast.FieldExpr); fxOK {
@@ -788,6 +793,22 @@ func (c *checker) tryPackageCallWithExplicit(
 }
 
 func (c *checker) methodCallType(fx *ast.FieldExpr, e *ast.CallExpr, explicit []types.Type, env *env) types.Type {
+	if fx.Name == "new" && c.isErrorTypeExpr(fx.X) {
+		c.checkExplicitGenericArity(e, 0, explicit)
+		c.checkExactArity(e, 1)
+		if len(e.Args) == 1 {
+			at := c.checkExpr(e.Args[0].Value, types.String, env)
+			if !c.accepts(types.String, at, e.Args[0].Value) {
+				c.errMismatch(e.Args[0].Value, types.String, at)
+			}
+		} else {
+			for _, a := range e.Args {
+				c.checkExpr(a.Value, nil, env)
+			}
+		}
+		return c.namedOf("Error", nil)
+	}
+
 	// Builder protocol (§3.4) takes priority over regular method lookup
 	// — Type.builder() / value.toBuilder() / chain setters / .build().
 	// tryBuilderCall handles argument type-checking on its own paths.
@@ -895,6 +916,134 @@ func (c *checker) methodCallType(fx *ast.FieldExpr, e *ast.CallExpr, explicit []
 		return &types.Optional{Inner: ret}
 	}
 	return ret
+}
+
+func (c *checker) isErrorTypeExpr(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		sym := c.symbol(x)
+		return sym != nil && sym.Name == "Error" &&
+			(sym.Kind == resolve.SymBuiltin || sym.Kind == resolve.SymInterface)
+	case *ast.FieldExpr:
+		if x.Name != "Error" {
+			return false
+		}
+		id, ok := x.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		pkgSym := c.symbol(id)
+		if pkgSym == nil || pkgSym.Kind != resolve.SymPackage ||
+			!isStdlibErrorUse(pkgSym, id.Name) &&
+				(pkgSym.Package == nil || pkgSym.Package.PkgScope == nil) {
+			return false
+		}
+		if isStdlibErrorUse(pkgSym, id.Name) {
+			return true
+		}
+		sym := pkgSym.Package.PkgScope.LookupLocal("Error")
+		return sym != nil && sym.Kind == resolve.SymInterface
+	}
+	return false
+}
+
+func isStdlibErrorUse(sym *resolve.Symbol, alias string) bool {
+	if sym == nil || sym.Kind != resolve.SymPackage {
+		return false
+	}
+	u, ok := sym.Decl.(*ast.UseDecl)
+	if !ok || u.IsGoFFI || len(u.Path) != 2 || u.Path[0] != "std" || u.Path[1] != "error" {
+		return false
+	}
+	name := u.Alias
+	if name == "" {
+		name = u.Path[len(u.Path)-1]
+	}
+	return name == alias
+}
+
+func (c *checker) tryErrorDowncastCall(tf *ast.TurbofishExpr, e *ast.CallExpr, env *env) (types.Type, bool) {
+	fx, ok := tf.Base.(*ast.FieldExpr)
+	if !ok || fx.Name != "downcast" {
+		return nil, false
+	}
+	recvT := c.checkExpr(fx.X, nil, env)
+	if !isErrorNamedType(recvT) && !types.IsError(recvT) {
+		c.errMethodNotFound(fx, fmt.Sprintf("type `%s`", recvT),
+			fx.Name, c.methodCandidates(recvT))
+	}
+	explicit := make([]types.Type, 0, len(tf.Args))
+	for _, a := range tf.Args {
+		explicit = append(explicit, c.typeOf(a))
+	}
+	c.checkExplicitGenericArity(e, 1, explicit)
+	if len(e.Args) != 0 {
+		c.errNode(e, diag.CodeWrongArgCount,
+			"`Error.downcast` takes no arguments, got %d", len(e.Args))
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+	}
+	if len(tf.Args) != 1 {
+		return types.ErrorType, true
+	}
+	target := explicit[0]
+	if !c.validErrorDowncastTarget(target) && !types.IsError(target) {
+		c.errNode(tf.Args[0], diag.CodeTypeMismatch,
+			"`Error.downcast` target must be a concrete Osty error type, got `%s`", target)
+	}
+	return &types.Optional{Inner: target}, true
+}
+
+func isErrorNamedType(t types.Type) bool {
+	n, ok := types.AsNamed(t)
+	return ok && n.Sym != nil && n.Sym.Name == "Error"
+}
+
+func (c *checker) validErrorDowncastTarget(t types.Type) bool {
+	n, ok := types.AsNamed(t)
+	if !ok || n.Sym == nil {
+		return false
+	}
+	switch n.Sym.Kind {
+	case resolve.SymStruct, resolve.SymEnum:
+		return c.hasErrorMessageMethod(t)
+	}
+	return false
+}
+
+func (c *checker) hasErrorMessageMethod(t types.Type) bool {
+	if md, _ := c.lookupMethod(t, "message"); methodReturnsString(md) {
+		return true
+	}
+	n, ok := types.AsNamed(t)
+	if !ok || n.Sym == nil {
+		return false
+	}
+	switch decl := n.Sym.Decl.(type) {
+	case *ast.StructDecl:
+		return c.declaresErrorMessageMethod(decl.Methods)
+	case *ast.EnumDecl:
+		return c.declaresErrorMessageMethod(decl.Methods)
+	}
+	return false
+}
+
+func (c *checker) declaresErrorMessageMethod(methods []*ast.FnDecl) bool {
+	for _, m := range methods {
+		if m.Name != "message" {
+			continue
+		}
+		return methodReturnsString(c.externalMethodDesc(m, nil))
+	}
+	return false
+}
+
+func methodReturnsString(md *methodDesc) bool {
+	return md != nil &&
+		md.Fn != nil &&
+		len(md.Fn.Params) == 0 &&
+		types.Identical(md.Fn.Return, types.String)
 }
 
 // stdlibMethods is the set of well-known method names for which the
@@ -1639,7 +1788,7 @@ func (c *checker) lookupMethod(recvT types.Type, name string) (*methodDesc, map[
 			}
 		}
 		// Builtin compound types carry synthetic method tables.
-		if v.Sym != nil && v.Sym.Kind == resolve.SymBuiltin {
+		if v.Sym != nil && (v.Sym.Kind == resolve.SymBuiltin || v.Sym.Name == "Error") {
 			if md := c.builtinNamedMethod(v, name); md != nil {
 				return md, nil
 			}
@@ -1711,6 +1860,13 @@ func (c *checker) optionalMethod(o *types.Optional, name string) *methodDesc {
 // stdlibCallReturn but whose core methods deserve typed signatures.
 func (c *checker) builtinNamedMethod(n *types.Named, name string) *methodDesc {
 	switch n.Sym.Name {
+	case "Error":
+		switch name {
+		case "message":
+			return simpleMethod(name, nil, types.String)
+		case "source":
+			return simpleMethod(name, nil, &types.Optional{Inner: n})
+		}
 	case "Result":
 		if len(n.Args) != 2 {
 			return nil
@@ -1757,10 +1913,6 @@ func (c *checker) builtinNamedMethod(n *types.Named, name string) *methodDesc {
 			return simpleMethod(name, nil, types.Unit)
 		case "isCancelled":
 			return simpleMethod(name, nil, types.Bool)
-		}
-	case "Error":
-		if name == "message" {
-			return simpleMethod(name, nil, types.String)
 		}
 	}
 	return nil
@@ -2237,7 +2389,11 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 			if errHint == nil {
 				errHint = types.ErrorType
 			}
-			return &types.Named{Sym: resSym, Args: []types.Type{at, errHint}}
+			okOut := at
+			if okHint != nil && !types.IsError(okHint) && c.accepts(okHint, at, e.Args[0].Value) {
+				okOut = okHint
+			}
+			return &types.Named{Sym: resSym, Args: []types.Type{okOut, errHint}}
 		case "Err":
 			if len(e.Args) != 1 {
 				c.errNode(e, diag.CodeWrongArgCount,
@@ -2257,7 +2413,11 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 			if okHint == nil {
 				okHint = types.ErrorType
 			}
-			return &types.Named{Sym: resSym, Args: []types.Type{okHint, at}}
+			errOut := at
+			if errHint != nil && !types.IsError(errHint) && c.accepts(errHint, at, e.Args[0].Value) {
+				errOut = errHint
+			}
+			return &types.Named{Sym: resSym, Args: []types.Type{okHint, errOut}}
 		}
 	}
 

--- a/internal/check/iface.go
+++ b/internal/check/iface.go
@@ -316,7 +316,7 @@ func methodSignaturesMatch(
 		return want == got
 	}
 	if wantMd.Owner != nil && wantMd.Owner.Sym != nil {
-		want = substituteSelfInFn(want, wantMd.Owner.Sym, concrete)
+		want = substituteSelfInMethodFn(wantMd, concrete)
 	}
 	if len(gotSub) > 0 {
 		got = &types.FnType{
@@ -338,6 +338,31 @@ func methodSignaturesMatch(
 	return types.Identical(want.Return, got.Return)
 }
 
+func substituteSelfInMethodFn(md *methodDesc, concrete types.Type) *types.FnType {
+	if md == nil || md.Fn == nil || md.Owner == nil || md.Owner.Sym == nil {
+		if md != nil {
+			return md.Fn
+		}
+		return nil
+	}
+	decl := md.Decl
+	if decl == nil {
+		return substituteSelfInFn(md.Fn, md.Owner.Sym, concrete)
+	}
+	out := &types.FnType{
+		Params: make([]types.Type, len(md.Fn.Params)),
+		Return: substituteSelfTypeByAST(md.Fn.Return, decl.ReturnType, md.Owner.Sym, concrete),
+	}
+	for i, p := range md.Fn.Params {
+		var astT ast.Type
+		if i < len(decl.Params) {
+			astT = decl.Params[i].Type
+		}
+		out.Params[i] = substituteSelfTypeByAST(p, astT, md.Owner.Sym, concrete)
+	}
+	return out
+}
+
 func substituteSelfInFn(fn *types.FnType, selfSym *resolve.Symbol, concrete types.Type) *types.FnType {
 	if fn == nil {
 		return nil
@@ -350,6 +375,61 @@ func substituteSelfInFn(fn *types.FnType, selfSym *resolve.Symbol, concrete type
 		out.Params[i] = substituteSelfType(p, selfSym, concrete)
 	}
 	return out
+}
+
+func substituteSelfTypeByAST(t types.Type, astT ast.Type, selfSym *resolve.Symbol, concrete types.Type) types.Type {
+	if t == nil || astT == nil || selfSym == nil || concrete == nil {
+		return t
+	}
+	switch a := astT.(type) {
+	case *ast.NamedType:
+		if len(a.Path) == 1 && a.Path[0] == "Self" {
+			return substituteSelfType(t, selfSym, concrete)
+		}
+		n, ok := t.(*types.Named)
+		if !ok || len(a.Args) == 0 || len(a.Args) != len(n.Args) {
+			return t
+		}
+		args := make([]types.Type, len(n.Args))
+		for i, arg := range n.Args {
+			args[i] = substituteSelfTypeByAST(arg, a.Args[i], selfSym, concrete)
+		}
+		return &types.Named{Sym: n.Sym, Args: args}
+	case *ast.OptionalType:
+		o, ok := t.(*types.Optional)
+		if !ok {
+			return t
+		}
+		return &types.Optional{Inner: substituteSelfTypeByAST(o.Inner, a.Inner, selfSym, concrete)}
+	case *ast.TupleType:
+		tup, ok := t.(*types.Tuple)
+		if !ok || len(a.Elems) != len(tup.Elems) {
+			return t
+		}
+		elems := make([]types.Type, len(tup.Elems))
+		for i, elem := range tup.Elems {
+			elems[i] = substituteSelfTypeByAST(elem, a.Elems[i], selfSym, concrete)
+		}
+		return &types.Tuple{Elems: elems}
+	case *ast.FnType:
+		fn, ok := t.(*types.FnType)
+		if !ok {
+			return t
+		}
+		out := &types.FnType{
+			Params: make([]types.Type, len(fn.Params)),
+			Return: substituteSelfTypeByAST(fn.Return, a.ReturnType, selfSym, concrete),
+		}
+		for i, p := range fn.Params {
+			var astP ast.Type
+			if i < len(a.Params) {
+				astP = a.Params[i]
+			}
+			out.Params[i] = substituteSelfTypeByAST(p, astP, selfSym, concrete)
+		}
+		return out
+	}
+	return t
 }
 
 func substituteSelfType(t types.Type, selfSym *resolve.Symbol, concrete types.Type) types.Type {

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -213,6 +213,9 @@ func (g *gen) emitEnumDecl(e *ast.EnumDecl) {
 		g.emitMethod(e.Name, m, true)
 	}
 	g.emitEnumJSONDecoder(e)
+	for _, m := range e.Methods {
+		g.emitEnumVariantMethodWrappers(e, m)
+	}
 }
 
 // emitVariant writes the struct + marker-method for one enum variant.
@@ -311,6 +314,52 @@ func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
 	g.body.write(" ")
 	g.emitBlockAsReturn(m.Body, m.ReturnType != nil)
 	g.body.nl()
+}
+
+func (g *gen) emitEnumVariantMethodWrappers(e *ast.EnumDecl, m *ast.FnDecl) {
+	if m.Recv == nil || len(m.Generics) != 0 {
+		return
+	}
+	for _, v := range e.Variants {
+		recvType := e.Name + "_" + v.Name
+		g.body.nl()
+		g.sourceMarker(m)
+		g.body.writef("func (self %s) %s(", recvType, m.Name)
+		paramNames := make([]string, len(m.Params))
+		for i, p := range m.Params {
+			if i > 0 {
+				g.body.write(", ")
+			}
+			name := p.Name
+			if name == "" {
+				name = "_p" + itoa(i)
+			}
+			paramNames[i] = mangleIdent(name)
+			g.body.write(paramNames[i])
+			if p.Type != nil {
+				g.body.write(" ")
+				g.body.write(g.resolveSelfType(p.Type, e.Name))
+			} else {
+				g.body.write(" any")
+			}
+		}
+		g.body.write(")")
+		hasReturn := m.ReturnType != nil && !isUnitAST(m.ReturnType)
+		if hasReturn {
+			g.body.write(" ")
+			g.body.write(g.resolveSelfType(m.ReturnType, e.Name))
+		}
+		g.body.write(" { ")
+		if hasReturn {
+			g.body.write("return ")
+		}
+		g.body.writef("%s_%s(%s(self)", e.Name, m.Name, e.Name)
+		for _, name := range paramNames {
+			g.body.write(", ")
+			g.body.write(name)
+		}
+		g.body.writeln(") }")
+	}
 }
 
 // resolveSelfType rewrites a bare `Self` type annotation to the
@@ -512,6 +561,12 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			Bool:      jsonBool,
 			Null:      nil,
 		}`, full)
+		return true
+	case "error":
+		// std.error calls and qualified literals are lowered directly by
+		// expr.go; no package-shaped Go value is needed here. Avoid
+		// emitting `var error ...`, which would shadow Go's predeclared
+		// error type for any runtime helper that still uses it.
 		return true
 	case "random":
 		g.needRandomRuntime = true

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -149,11 +149,11 @@ func (g *gen) emitStructLit(s *ast.StructLit) {
 		if i > 0 {
 			g.body.write(", ")
 		}
-		name := mangleIdent(f.Name)
+		name := structLitFieldName(typeName, f.Name)
 		g.body.writef("%s: ", name)
 		if f.Value == nil {
 			// Shorthand `Point { name }` → `Point{name: name}`.
-			g.body.write(name)
+			g.body.write(mangleIdent(f.Name))
 		} else {
 			g.emitExpr(f.Value)
 		}
@@ -175,7 +175,7 @@ func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string) {
 	g.emitExpr(s.Spread)
 	g.body.write("; ")
 	for _, f := range s.Fields {
-		g.body.writef("%s.%s = ", tmp, mangleIdent(f.Name))
+		g.body.writef("%s.%s = ", tmp, structLitFieldName(typeName, f.Name))
 		if f.Value == nil {
 			g.body.write(mangleIdent(f.Name))
 		} else {
@@ -384,6 +384,12 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		if g.emitQualifiedOptionCall(c, f) {
 			return
 		}
+		if g.emitStdlibErrorCall(c, f) {
+			return
+		}
+		if g.emitErrorMethodCall(c, f) {
+			return
+		}
 		if g.emitStdlibEncodingCall(c, f) {
 			return
 		}
@@ -443,6 +449,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		}
 	}
 	if tf, ok := c.Fn.(*ast.TurbofishExpr); ok {
+		if g.emitErrorDowncastCall(c, tf) {
+			return
+		}
 		if g.emitTurbofishCall(c, tf) {
 			return
 		}
@@ -527,6 +536,77 @@ func (g *gen) jsonDecodeTargetGo(c *ast.CallExpr, explicit []ast.Type) string {
 		return g.goType(n.Args[0])
 	}
 	return "any"
+}
+
+func (g *gen) emitStdlibErrorCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.Name == "new" && g.isPreludeErrorTypeExpr(f.X) && len(c.Args) == 1 {
+		g.emitErrorNew(c.Args)
+		return true
+	}
+	parts, ok := g.stdlibCallPath(c, "error")
+	if !ok || len(c.Args) != 1 {
+		return false
+	}
+	switch strings.Join(parts, ".") {
+	case "new", "Error.new":
+		g.emitErrorNew(c.Args)
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitErrorNew(args []*ast.Arg) {
+	g.needErrorRuntime = true
+	g.body.write("ostyErrorNew(")
+	g.emitExpr(args[0].Value)
+	g.body.write(")")
+}
+
+func (g *gen) emitErrorMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if len(c.Args) != 0 || !isErrorType(g.typeOf(f.X)) {
+		return false
+	}
+	switch f.Name {
+	case "message":
+		g.needErrorRuntime = true
+		g.body.write("ostyErrorMessage(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	case "source":
+		g.needErrorRuntime = true
+		g.body.write("ostyErrorSource(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitErrorDowncastCall(c *ast.CallExpr, tf *ast.TurbofishExpr) bool {
+	f, ok := tf.Base.(*ast.FieldExpr)
+	if !ok || f.Name != "downcast" || len(tf.Args) != 1 || len(c.Args) != 0 || !isErrorType(g.typeOf(f.X)) {
+		return false
+	}
+	g.needErrorRuntime = true
+	g.body.writef("ostyErrorDowncast[%s](", g.goTypeExpr(tf.Args[0]))
+	g.emitExpr(f.X)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) isPreludeErrorTypeExpr(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	if !ok || id.Name != "Error" {
+		return false
+	}
+	sym := g.symbolFor(id)
+	return sym != nil && sym.Kind == resolve.SymBuiltin && sym.Name == "Error"
+}
+
+func isErrorType(t types.Type) bool {
+	n, ok := t.(*types.Named)
+	return ok && n.Sym != nil && n.Sym.Name == "Error"
 }
 
 func (g *gen) emitStdlibEncodingCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
@@ -864,6 +944,10 @@ func (g *gen) stdlibStructLitType(e ast.Expr) (string, bool) {
 		g.needCSV = true
 		return "CsvOptions", true
 	}
+	if g.isStdlibPackageAlias(id, "error") && f.Name == "BasicError" {
+		g.needErrorRuntime = true
+		return "ostyBasicError", true
+	}
 	return "", false
 }
 
@@ -1077,21 +1161,6 @@ func (g *gen) emitConcurrencyMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		}
 	}
 	return false
-}
-
-func (g *gen) emitErrorMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
-	if f.Name != "message" || len(c.Args) != 0 {
-		return false
-	}
-	n, ok := types.AsNamedByName(g.typeOf(f.X), "Error")
-	if !ok || n.Sym == nil {
-		return false
-	}
-	g.needErrorRuntime = true
-	g.body.write("ostyErrorMessage(")
-	g.emitExpr(f.X)
-	g.body.write(")")
-	return true
 }
 
 // emitOptionalMethodCall lowers Option<T> methods to pointer checks.
@@ -2900,6 +2969,13 @@ func (g *gen) emitIfLetExpr(ie *ast.IfExpr) {
 	g.emitIfLetInner(ie, true)
 	g.body.dedent()
 	g.body.write("}()")
+}
+
+func structLitFieldName(typeName, field string) string {
+	if typeName == "ostyBasicError" && field == "message" {
+		return "messageText"
+	}
+	return mangleIdent(field)
 }
 
 // emitIfLetStmt lowers `if let ... = ... { ... } else { ... }` at

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -386,7 +386,7 @@ func (g *gen) run() ([]byte, error) {
 		g.useAs("strings", "stdstrings")
 		g.use("time")
 	}
-	if g.needResult || g.needStringRuntime {
+	if g.needResult || g.needStringRuntime || g.needErrorRuntime {
 		g.use("fmt")
 	}
 
@@ -522,6 +522,26 @@ func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F]
 	}
 	if g.needErrorRuntime {
 		out.WriteString(`
+type ostyBasicError struct {
+	messageText string
+}
+
+func ostyErrorNew(message string) any {
+	return ostyBasicError{messageText: message}
+}
+
+func (e ostyBasicError) message() string { return e.messageText }
+
+func (e ostyBasicError) source() *any { return nil }
+
+func ostyErrorDowncast[T any](err any) *T {
+	v, ok := err.(T)
+	if !ok {
+		return nil
+	}
+	return &v
+}
+
 func ostyErrorMessage(e any) string {
 	if e == nil {
 		return ""
@@ -536,6 +556,16 @@ func ostyErrorMessage(e any) string {
 		return s
 	}
 	return fmt.Sprint(e)
+}
+
+func ostyErrorSource(err any) *any {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(interface{ source() *any }); ok {
+		return e.source()
+	}
+	return nil
 }
 `)
 	}

--- a/internal/gen/stdlib_runtime_test.go
+++ b/internal/gen/stdlib_runtime_test.go
@@ -8,6 +8,113 @@ import (
 	"testing"
 )
 
+func TestStdErrorRuntimeBridge(t *testing.T) {
+	src := `use std.error
+
+fn fail() -> Result<Int, Error> {
+    Err(error.new("boom"))
+}
+
+fn main() {
+	let direct = Error.new("direct")
+	println(direct.message())
+	let qualified = error.Error.new("qualified")
+	println(qualified.message())
+	match fail() {
+		Ok(n) -> println("ok {n}"),
+		Err(e) -> println(e.message()),
+	}
+    let literal = error.BasicError { message: "literal" }
+    println(literal.message())
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{"direct", "qualified", "boom", "literal"}, "\n")
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"ostyErrorNew", "ostyErrorMessage", "type ostyBasicError struct"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.error bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
+func TestStdErrorDowncastRuntimeBridge(t *testing.T) {
+	src := `use std.error
+
+pub enum FsError {
+    NotFound(String),
+    PermissionDenied(String),
+
+    pub fn message(self) -> String {
+        match self {
+            NotFound(p) -> "not found: {p}",
+            PermissionDenied(p) -> "permission denied: {p}",
+        }
+    }
+}
+
+fn read() -> Result<Int, FsError> {
+    Err(NotFound("cfg"))
+}
+
+fn load() -> Result<Int, Error> {
+    let value = read()?
+    Ok(value)
+}
+
+fn direct() -> Result<Int, Error> {
+    Err(NotFound("direct"))
+}
+
+fn main() {
+    match load() {
+        Ok(_) -> println("ok"),
+        Err(e) -> {
+            println(e.message())
+            match e.downcast::<FsError>() {
+                Some(fe) -> println(fe.message()),
+                None -> println("missing"),
+            }
+        },
+    }
+    match direct() {
+        Ok(_) -> println("direct ok"),
+        Err(e) -> println(e.message()),
+    }
+    let basic = Error.new("basic")
+    match basic.downcast::<error.BasicError>() {
+        Some(be) -> println(be.message()),
+        None -> println("missing basic"),
+    }
+}
+`
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"not found: cfg",
+		"not found: cfg",
+		"not found: direct",
+		"basic",
+	}, "\n")
+	if out != want {
+		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
+	}
+	for _, want := range []string{"ostyErrorDowncast[FsError]", "func (self FsError_NotFound) message() string"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("generated std.error downcast bridge missing %s:\n%s", want, goSrc)
+		}
+	}
+}
+
 func TestStdRandomRuntimeBridge(t *testing.T) {
 	src := `use std.random
 

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/types"
 )
 
@@ -184,6 +185,11 @@ func (g *gen) goNamedType(n *types.Named) string {
 		// cost of losing Go's error-interface polymorphism; a full
 		// fix would generate an .Error() shim per type.
 		return "any"
+	case "BasicError":
+		if isStdlibBasicError(n) {
+			g.needErrorRuntime = true
+			return "ostyBasicError"
+		}
 	case "Chan", "Channel":
 		// §8.5: channel types lower to Go's built-in chan T.
 		if len(n.Args) == 1 {
@@ -307,6 +313,15 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 		if len(n.Path) == 2 && n.Path[1] == "Json" && g.isStdlibAliasName(n.Path[0], "json") {
 			g.needJSON = true
 			return "Json"
+		}
+		if len(n.Path) == 2 && g.isStdlibAliasName(n.Path[0], "error") {
+			switch n.Path[1] {
+			case "Error":
+				return "any"
+			case "BasicError":
+				g.needErrorRuntime = true
+				return "ostyBasicError"
+			}
 		}
 		// Qualified (pkg.Type). Phase 5 adds proper module handling.
 		return strings.Join(n.Path, ".")
@@ -438,6 +453,27 @@ func (g *gen) goFnTypeAST(f *ast.FnType) string {
 		b.WriteString(g.goTypeExpr(f.ReturnType))
 	}
 	return b.String()
+}
+
+func isStdlibBasicError(n *types.Named) bool {
+	if n == nil || n.Sym == nil || n.Sym.Name != "BasicError" || n.Sym.Kind != resolve.SymStruct {
+		return false
+	}
+	decl, ok := n.Sym.Decl.(*ast.StructDecl)
+	return ok &&
+		len(decl.Fields) == 1 &&
+		decl.Fields[0].Name == "message" &&
+		hasStructMethod(decl, "message") &&
+		hasStructMethod(decl, "source")
+}
+
+func hasStructMethod(decl *ast.StructDecl, name string) bool {
+	for _, m := range decl.Methods {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // isUnitAST reports whether t is the AST representation of the Osty

--- a/internal/stdlib/modules/error.osty
+++ b/internal/stdlib/modules/error.osty
@@ -2,13 +2,24 @@
 //
 // Defines the auto-imported `Error` interface and the concrete
 // `BasicError` struct that most callers use for ad-hoc error values.
-// The `Error.new` constructor will be added alongside the rest of the
-// stdlib's body-carrying functions.
 
 pub interface Error {
     fn message(self) -> String
+    fn source(self) -> Error? { None }
 }
 
 pub struct BasicError {
-    pub message: String
+    pub message: String,
+
+    pub fn message(self) -> String {
+        self.message
+    }
+
+    pub fn source(self) -> Error? {
+        None
+    }
+}
+
+pub fn new(message: String) -> Error {
+    BasicError { message }
 }

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -273,7 +273,7 @@ func TestErrorModuleResolves(t *testing.T) {
 	if mod.Package.PkgScope == nil {
 		t.Fatal(`Module "error" has nil PkgScope — resolve did not populate it`)
 	}
-	for _, name := range []string{"Error", "BasicError"} {
+	for _, name := range []string{"Error", "BasicError", "new"} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Errorf("PkgScope missing expected export %q", name)
@@ -283,6 +283,42 @@ func TestErrorModuleResolves(t *testing.T) {
 			t.Errorf("export %q is not pub", name)
 		}
 	}
+}
+
+func TestErrorModuleSurface(t *testing.T) {
+	mod := Load().Modules["error"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.error not loaded")
+	}
+	errSym := mod.Package.PkgScope.LookupLocal("Error")
+	errDecl, ok := errSym.Decl.(*ast.InterfaceDecl)
+	if !ok {
+		t.Fatalf("Error decl = %T, want interface", errSym.Decl)
+	}
+	for _, name := range []string{"message", "source"} {
+		if !hasMethod(errDecl.Methods, name) {
+			t.Errorf("Error missing method %q", name)
+		}
+	}
+	basicSym := mod.Package.PkgScope.LookupLocal("BasicError")
+	basicDecl, ok := basicSym.Decl.(*ast.StructDecl)
+	if !ok {
+		t.Fatalf("BasicError decl = %T, want struct", basicSym.Decl)
+	}
+	for _, name := range []string{"message", "source"} {
+		if !hasMethod(basicDecl.Methods, name) {
+			t.Errorf("BasicError missing method %q", name)
+		}
+	}
+}
+
+func hasMethod(methods []*ast.FnDecl, name string) bool {
+	for _, m := range methods {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // TestLookupPackageReturnsResolvedPackage exercises the StdlibProvider
@@ -340,6 +376,31 @@ pub fn describe(e: error.Nope) -> String {
 	if !found {
 		t.Errorf("expected CodeUnknownExportedMember for error.Nope; got %d diags: %v",
 			len(res.Diags), diagCodes(res.Diags))
+	}
+}
+
+func TestErrorModuleConstructorTypeChecks(t *testing.T) {
+	src := `use std.error
+
+pub fn describe() -> String {
+    let a = error.new("bad")
+    let b = error.Error.new("worse")
+    "{a.message()} {b.message()}"
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Fatalf("unexpected diagnostic: %s", d.Error())
+		}
 	}
 }
 
@@ -676,6 +737,7 @@ func TestTier1ModuleCoverage(t *testing.T) {
 		{"iter", []string{"Iter", "from", "empty", "range"}},
 		{"thread", []string{"Group", "Select", "spawn", "collectAll", "race", "chan", "sleep", "yield", "isCancelled", "checkCancelled", "select"}},
 		{"os", []string{"path", "Path", "Output", "Signal", "exec", "execShell", "exit", "pid", "hostname", "onSignal"}},
+		{"error", []string{"Error", "BasicError", "new"}},
 		{"ref", []string{"same"}},
 		{"process", []string{"abort", "unreachable", "todo", "ignoreError", "logError"}},
 		{"debug", []string{"dbg"}},

--- a/testdata/spec/positive/07-errors.osty
+++ b/testdata/spec/positive/07-errors.osty
@@ -1,5 +1,7 @@
 // §7 The Error Interface — custom error types, `?` propagation.
 
+use std.error
+
 pub enum FsError {
     NotFound(String),
     PermissionDenied(String),
@@ -42,4 +44,29 @@ fn checkExists(path: String) -> Result<Bool, FsError> {
 fn loadConfig(path: String) -> Result<String, Error> {
     let text = readFile(path)?
     Ok(text)
+}
+
+// std.error constructors and methods. This doubles as a language-level
+// fixture for the public API surface that codegen lowers through the
+// std.error runtime bridge.
+fn stdErrorConstructors() -> Result<String, Error> {
+    let direct: Error = Error.new("direct")
+    let qualified: Error = error.Error.new("qualified")
+    let literal = error.BasicError { message: "literal" }
+    let _ = direct.source()
+    let _ = qualified.message()
+    let _ = literal.message()
+    Err(literal)
+}
+
+// Concrete Osty errors can still be recovered after widening to Error.
+fn describeError(err: Error) -> String {
+    match err.downcast::<FsError>() {
+        Some(fs) -> fs.message(),
+        None -> err.message(),
+    }
+}
+
+fn directWidening() -> Result<String, Error> {
+    Err(NotFound("settings.osty"))
 }


### PR DESCRIPTION
## Summary

- Implement the `std.error` surface with `Error`, `BasicError`, and `new`.
- Add checker support for `Error.new`, `error.Error.new`, `message`, `source`, `downcast::<T>()`, and `Result<_, Error>` widening.
- Add Go runtime/codegen bridge support for erased `Error` values, `BasicError`, downcast, enum error wrappers, and `std.error` import handling.
- Add language-level positive fixture coverage for the public `std.error` API.
- Tighten interface `Self` substitution so syntactic `Self` is substituted without rewriting explicit interface-name references like `Error?`.

## Validation

- `go test ./internal/check -run 'TestCheck_Interface(SelfSignatureMatchesConcreteSelf|NamedReferenceIsNotSelf)|TestCheck_(ErrorNewAndInterfaceMethods|StdErrorQualifiedConstructorOnOpaqueImport)' -v`\n- `go test ./internal/stdlib -run 'TestAllSignatureStubsCheck|TestErrorModuleSurface|TestErrorModuleConstructorTypeChecks|TestTier1ModuleCoverage' -v`\n- `go test ./...`