### PR TITLE
[codex] implement std.collections

### DIFF
--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -738,6 +738,80 @@ fn main() {
 	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
 }
 
+func TestCheck_MapKeyRequiresHashableTypeArg(t *testing.T) {
+	src := `
+fn main() {
+    let m: Map<Float, Int> = {:}
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_MapLiteralKeyRequiresHashable(t *testing.T) {
+	src := `
+fn main() {
+    let m = {1.5: "nope"}
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_MapKeyRejectsNonHashableComposite(t *testing.T) {
+	src := `
+fn main() {
+    let m: Map<List<Int>, Int> = {:}
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_MapKeyAcceptsHashableGenericBound(t *testing.T) {
+	src := `
+fn make<T: Hashable>() -> Map<T, Int> {
+    {:}
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
+func TestCheck_SetElementRequiresHashableTypeArg(t *testing.T) {
+	src := `
+fn main() {
+    let s: Set<Float> = [1.5].toSet()
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_ToSetElementRequiresHashable(t *testing.T) {
+	src := `
+fn collect<T>(xs: List<T>) -> List<T> {
+    let s = xs.toSet()
+    xs
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_ToSetRejectsNonHashableCompositeElement(t *testing.T) {
+	src := `
+fn main() {
+    let xs = [[1], [2]]
+    let s = xs.toSet()
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_ToSetAcceptsHashableGenericBound(t *testing.T) {
+	src := `
+fn collect<T: Hashable>(xs: List<T>) -> Set<T> {
+    xs.toSet()
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
 func TestCheck_InterfaceMethodMissing(t *testing.T) {
 	// Empty struct has no `message` method → doesn't satisfy Error.
 	// Note: Error is a BUILTIN marker interface in this MVP; the
@@ -1678,6 +1752,27 @@ fn main() {
 }
 `
 	assertCodes(t, runCheck(t, src), diag.CodeTypeMismatch)
+}
+
+func TestCheck_StdlibMutatingCollectionNeedsMutBinding(t *testing.T) {
+	src := `
+fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    xs.push(4)
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeMutabilityMismatch)
+}
+
+func TestCheck_StdlibMutatingCollectionNeedsAssignableReceiver(t *testing.T) {
+	src := `
+fn make() -> List<Int> { [] }
+
+fn main() {
+    make().push(1)
+}
+`
+	assertCodes(t, runCheck(t, src), diag.CodeAssignTarget)
 }
 
 func TestCheck_StdlibEnumerateTuplePattern(t *testing.T) {

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -799,6 +799,17 @@ func (c *checker) methodCallType(fx *ast.FieldExpr, e *ast.CallExpr, explicit []
 	if md == nil {
 		if _, known := stdlibMethods[fx.Name]; known {
 			c.checkExplicitGenericArity(e, 0, explicit)
+			if !stdlibMethodAllowed(fx.Name, recvT) {
+				c.errMethodNotFound(fx, fmt.Sprintf("type `%s`", recvT),
+					fx.Name, c.methodCandidates(recvT))
+				for _, a := range e.Args {
+					c.checkExpr(a.Value, nil, env)
+				}
+				if wasOptional && fx.IsOptional {
+					return &types.Optional{Inner: types.ErrorType}
+				}
+				return types.ErrorType
+			}
 			// Well-known stdlib / builtin method — accept any arguments
 			// and produce an approximate return type (escape hatch until
 			// the stdlib is modelled in full).
@@ -845,29 +856,125 @@ func (c *checker) methodCallType(fx *ast.FieldExpr, e *ast.CallExpr, explicit []
 // receiver (`get`, `map`, `filter`, …) have a nil entry and go through
 // the per-name switch below.
 var stdlibMethods = map[string]types.Type{
-	"len":      types.Int,
-	"isEmpty":  types.Bool,
-	"contains": types.Bool,
-	"toString": types.String,
-	"toInt":    types.Int,
-	"toInt32":  types.Int32,
-	"toInt64":  types.Int64,
-	"toFloat":  types.Float,
+	"len":         types.Int,
+	"isEmpty":     types.Bool,
+	"contains":    types.Bool,
+	"containsKey": types.Bool,
+	"toString":    types.String,
+	"toInt":       types.Int,
+	"toInt32":     types.Int32,
+	"toInt64":     types.Int64,
+	"toFloat":     types.Float,
 	// Receiver-dependent — nil means "dispatch by name".
-	"get":       nil,
-	"push":      nil,
-	"map":       nil,
-	"filter":    nil,
-	"iter":      nil,
-	"entries":   nil,
-	"enumerate": nil,
-	"keys":      nil,
-	"values":    nil,
-	"toList":    nil,
-	"toSet":     nil,
-	"toMap":     nil,
-	"chars":     nil,
-	"take":      nil,
+	"get":        nil,
+	"first":      nil,
+	"last":       nil,
+	"indexOf":    nil,
+	"find":       nil,
+	"push":       nil,
+	"pop":        nil,
+	"insert":     nil,
+	"remove":     nil,
+	"removeAt":   nil,
+	"clear":      nil,
+	"sort":       nil,
+	"reverse":    nil,
+	"fold":       nil,
+	"map":        nil,
+	"filter":     nil,
+	"sorted":     nil,
+	"sortedBy":   nil,
+	"reversed":   nil,
+	"appended":   nil,
+	"concat":     nil,
+	"zip":        nil,
+	"iter":       nil,
+	"entries":    nil,
+	"enumerate":  nil,
+	"keys":       nil,
+	"values":     nil,
+	"toList":     nil,
+	"toSet":      nil,
+	"toMap":      nil,
+	"union":      nil,
+	"intersect":  nil,
+	"difference": nil,
+	"chars":      nil,
+	"take":       nil,
+}
+
+func stdlibMethodAllowed(name string, recvT types.Type) bool {
+	kind := ""
+	if n, ok := recvT.(*types.Named); ok && n.Sym != nil {
+		kind = n.Sym.Name
+	}
+	switch name {
+	case "first", "last", "indexOf", "find", "fold", "sorted", "sortedBy",
+		"reversed", "appended", "concat", "zip", "push", "pop", "removeAt",
+		"sort", "reverse":
+		return kind == "List"
+	case "containsKey", "keys", "values", "entries":
+		return kind == "Map"
+	case "union", "intersect", "difference":
+		return kind == "Set"
+	case "insert", "clear":
+		return kind == "List" || kind == "Map" || kind == "Set"
+	case "remove":
+		return kind == "Map" || kind == "Set"
+	}
+	return true
+}
+
+func stdlibMutatesReceiver(name string, recvT types.Type) bool {
+	kind := ""
+	if n, ok := recvT.(*types.Named); ok && n.Sym != nil {
+		kind = n.Sym.Name
+	}
+	switch name {
+	case "push", "pop", "removeAt", "sort", "reverse":
+		return kind == "List"
+	case "insert", "clear":
+		return kind == "List" || kind == "Map" || kind == "Set"
+	case "remove":
+		return kind == "Map" || kind == "Set"
+	}
+	return false
+}
+
+func (c *checker) checkStdlibMutReceiver(fx *ast.FieldExpr, recvT types.Type) {
+	if !stdlibMutatesReceiver(fx.Name, recvT) {
+		return
+	}
+	root := rootIdent(fx.X)
+	if root == nil {
+		c.errNode(fx.X, diag.CodeAssignTarget,
+			"`%s` requires a mutable collection receiver", fx.Name)
+		return
+	}
+	sym := c.symbol(root)
+	if sym == nil {
+		return
+	}
+	info := c.info(sym)
+	if sym.Kind == resolve.SymLet && info != nil && !info.Mut {
+		c.errNode(fx.X, diag.CodeMutabilityMismatch,
+			"`%s` requires mutable binding `%s`", fx.Name, sym.Name)
+	}
+}
+
+func rootIdent(e ast.Expr) *ast.Ident {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x
+	case *ast.FieldExpr:
+		return rootIdent(x.X)
+	case *ast.IndexExpr:
+		return rootIdent(x.X)
+	case *ast.ParenExpr:
+		return rootIdent(x.X)
+	default:
+		return nil
+	}
 }
 
 // stdlibCallReturn synthesizes a return type for an escape-hatch stdlib
@@ -875,6 +982,7 @@ var stdlibMethods = map[string]types.Type{
 // map, filter, push, get — arguments are type-checked against the
 // expected signature; other names accept any arguments permissively.
 func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.CallExpr, env *env, optChain bool) types.Type {
+	c.checkStdlibMutReceiver(fx, recvT)
 	var ret types.Type
 	switch fx.Name {
 	case "len", "isEmpty":
@@ -887,19 +995,10 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 		c.checkExactArity(e, 0)
 		ret = stdlibMethods[fx.Name]
 	case "contains":
-		if len(e.Args) != 1 {
-			c.errNode(e, diag.CodeWrongArgCount,
-				"`contains` takes 1 argument, got %d", len(e.Args))
-			for _, a := range e.Args {
-				c.checkExpr(a.Value, nil, env)
-			}
-		} else {
-			elem := stdlibElement(recvT)
-			at := c.checkExpr(e.Args[0].Value, elem, env)
-			if elem != nil && !types.IsError(elem) && !c.accepts(elem, at, e.Args[0].Value) {
-				c.errMismatch(e.Args[0].Value, elem, at)
-			}
-		}
+		c.checkStdlibArg(e, "contains", 0, stdlibKeyOrElem(recvT), env)
+		ret = types.Bool
+	case "containsKey":
+		c.checkStdlibArg(e, "containsKey", 0, stdlibKeyOrIndex(recvT), env)
 		ret = types.Bool
 	case "get":
 		c.checkExactArity(e, 1)
@@ -911,20 +1010,63 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 			}
 		}
 		ret = stdlibGetReturn(recvT)
+	case "first", "last", "pop":
+		c.checkExactArity(e, 0)
+		ret = stdlibGetReturn(recvT)
+	case "indexOf":
+		c.checkStdlibArg(e, "indexOf", 0, stdlibElement(recvT), env)
+		ret = &types.Optional{Inner: types.Int}
+	case "find":
+		ret = c.stdlibFind(e, recvT, env)
 	case "push":
+		c.checkStdlibArg(e, "push", 0, stdlibElement(recvT), env)
+		ret = types.Unit
+	case "insert":
+		ret = c.stdlibInsert(e, recvT, env)
+	case "remove":
+		ret = c.stdlibRemove(e, recvT, env)
+	case "removeAt":
 		c.checkExactArity(e, 1)
 		if len(e.Args) == 1 {
-			elem := stdlibElement(recvT)
-			at := c.checkExpr(e.Args[0].Value, elem, env)
-			if elem != nil && !types.IsError(elem) && !c.accepts(elem, at, e.Args[0].Value) {
-				c.errMismatch(e.Args[0].Value, elem, at)
-			}
+			c.checkExpr(e.Args[0].Value, types.Int, env)
+		}
+		ret = iterElem(recvT)
+	case "clear", "reverse":
+		c.checkExactArity(e, 0)
+		ret = types.Unit
+	case "sort":
+		c.checkExactArity(e, 0)
+		if elem := iterElem(recvT); !types.IsOrdered(elem) && !types.IsError(elem) {
+			c.errNode(e, diag.CodeTypeNotOrdered,
+				"`sort` requires elements that implement `Ordered`, got `%s`", elem)
 		}
 		ret = types.Unit
 	case "map":
 		ret = c.stdlibMap(e, recvT, env)
 	case "filter":
 		ret = c.stdlibFilter(e, recvT, env)
+	case "fold":
+		ret = c.stdlibFold(e, recvT, env)
+	case "sorted":
+		c.checkExactArity(e, 0)
+		if elem := iterElem(recvT); !types.IsOrdered(elem) && !types.IsError(elem) {
+			c.errNode(e, diag.CodeTypeNotOrdered,
+				"`sorted` requires elements that implement `Ordered`, got `%s`", elem)
+		}
+		ret = c.listOf(iterElem(recvT))
+	case "reversed":
+		c.checkExactArity(e, 0)
+		ret = c.listOf(iterElem(recvT))
+	case "sortedBy":
+		ret = c.stdlibSortedBy(e, recvT, env)
+	case "appended":
+		c.checkStdlibArg(e, "appended", 0, iterElem(recvT), env)
+		ret = c.listOf(iterElem(recvT))
+	case "concat":
+		c.checkStdlibArg(e, "concat", 0, c.listOf(iterElem(recvT)), env)
+		ret = c.listOf(iterElem(recvT))
+	case "zip":
+		ret = c.stdlibZip(e, recvT, env)
 	case "take":
 		c.checkExactArity(e, 1)
 		if len(e.Args) == 1 {
@@ -942,9 +1084,14 @@ func (c *checker) stdlibCallReturn(fx *ast.FieldExpr, recvT types.Type, e *ast.C
 		ret = c.stdlibChainReturn(fx.Name, recvT)
 	case "toSet":
 		c.checkExactArity(e, 0)
-		ret = c.namedOf("Set", []types.Type{iterElem(recvT)})
+		elem := iterElem(recvT)
+		c.requireHashable(elem, e, "Set element")
+		ret = c.namedOf("Set", []types.Type{elem})
 	case "toMap":
 		c.checkExactArity(e, 0)
+		ret = recvT
+	case "union", "intersect", "difference":
+		c.checkStdlibArg(e, fx.Name, 0, recvT, env)
 		ret = recvT
 	case "chars":
 		c.checkExactArity(e, 0)
@@ -973,11 +1120,49 @@ func (c *checker) checkExactArity(e *ast.CallExpr, want int) {
 		"expected %d argument(s), got %d", want, len(e.Args))
 }
 
+func (c *checker) checkStdlibArgCount(e *ast.CallExpr, name string, want int, env *env) bool {
+	if len(e.Args) == want {
+		return true
+	}
+	c.errNode(e, diag.CodeWrongArgCount,
+		"`%s` takes %d argument(s), got %d", name, want, len(e.Args))
+	for _, a := range e.Args {
+		c.checkExpr(a.Value, nil, env)
+	}
+	return false
+}
+
+func (c *checker) checkStdlibArg(e *ast.CallExpr, name string, index int, want types.Type, env *env) {
+	if !c.checkStdlibArgCount(e, name, index+1, env) {
+		return
+	}
+	at := c.checkExpr(e.Args[index].Value, want, env)
+	if want != nil && !types.IsError(want) && !c.accepts(want, at, e.Args[index].Value) {
+		c.errMismatch(e.Args[index].Value, want, at)
+	}
+}
+
 // stdlibElement returns the element type for an iterable receiver.
 // For List<T>/Set<T>/Chan<T> that's T; for Map<K,V> it's (K, V). For
 // non-iterable receivers returns ErrorType so the caller can skip
 // callback shape checks without emitting a type mismatch.
 func stdlibElement(recvT types.Type) types.Type {
+	return iterElem(recvT)
+}
+
+func stdlibKeyOrElem(recvT types.Type) types.Type {
+	if n, ok := recvT.(*types.Named); ok && n.Sym != nil {
+		switch n.Sym.Name {
+		case "Set":
+			if len(n.Args) == 1 {
+				return n.Args[0]
+			}
+		case "Map":
+			if len(n.Args) == 2 {
+				return &types.Tuple{Elems: []types.Type{n.Args[0], n.Args[1]}}
+			}
+		}
+	}
 	return iterElem(recvT)
 }
 
@@ -1053,6 +1238,154 @@ func (c *checker) stdlibFilter(e *ast.CallExpr, recvT types.Type, env *env) type
 		}
 	}
 	return c.listOf(elem)
+}
+
+func (c *checker) stdlibFind(e *ast.CallExpr, recvT types.Type, env *env) types.Type {
+	if len(e.Args) != 1 {
+		c.errNode(e, diag.CodeWrongArgCount,
+			"`find` takes 1 callback argument, got %d", len(e.Args))
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+		return &types.Optional{Inner: iterElem(recvT)}
+	}
+	elem := iterElem(recvT)
+	hint := &types.FnType{Params: []types.Type{elem}, Return: types.Bool}
+	got := c.checkExpr(e.Args[0].Value, hint, env)
+	if fn, ok := types.AsFn(got); ok {
+		if !types.IsBool(fn.Return) && !types.IsError(fn.Return) {
+			c.errNode(e.Args[0].Value, diag.CodeTypeMismatch,
+				"`find` callback must return `Bool`, got `%s`", fn.Return)
+		}
+	}
+	return &types.Optional{Inner: elem}
+}
+
+func (c *checker) stdlibFold(e *ast.CallExpr, recvT types.Type, env *env) types.Type {
+	if len(e.Args) != 2 {
+		c.errNode(e, diag.CodeWrongArgCount,
+			"`fold` takes an initial value and callback, got %d argument(s)", len(e.Args))
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+		return types.ErrorType
+	}
+	acc := c.checkExpr(e.Args[0].Value, nil, env)
+	if u, ok := acc.(*types.Untyped); ok {
+		acc = u.Default()
+	}
+	elem := iterElem(recvT)
+	hint := &types.FnType{Params: []types.Type{acc, elem}, Return: acc}
+	got := c.checkExpr(e.Args[1].Value, hint, env)
+	if fn, ok := types.AsFn(got); ok {
+		if !types.IsError(acc) && !c.accepts(acc, fn.Return, e.Args[1].Value) {
+			c.errNode(e.Args[1].Value, diag.CodeTypeMismatch,
+				"`fold` callback must return `%s`, got `%s`", acc, fn.Return)
+		}
+	}
+	return acc
+}
+
+func (c *checker) stdlibSortedBy(e *ast.CallExpr, recvT types.Type, env *env) types.Type {
+	if len(e.Args) != 1 {
+		c.errNode(e, diag.CodeWrongArgCount,
+			"`sortedBy` takes 1 callback argument, got %d", len(e.Args))
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+		return c.listOf(iterElem(recvT))
+	}
+	elem := iterElem(recvT)
+	hint := &types.FnType{Params: []types.Type{elem}, Return: nil}
+	got := c.checkExpr(e.Args[0].Value, hint, env)
+	if fn, ok := types.AsFn(got); ok {
+		if !types.IsOrdered(fn.Return) && !types.IsError(fn.Return) {
+			c.errNode(e.Args[0].Value, diag.CodeTypeNotOrdered,
+				"`sortedBy` key must implement `Ordered`, got `%s`", fn.Return)
+		}
+	}
+	return c.listOf(elem)
+}
+
+func (c *checker) stdlibZip(e *ast.CallExpr, recvT types.Type, env *env) types.Type {
+	elem := iterElem(recvT)
+	if !c.checkStdlibArgCount(e, "zip", 1, env) {
+		return c.listOf(&types.Tuple{Elems: []types.Type{elem, types.ErrorType}})
+	}
+	at := c.checkExpr(e.Args[0].Value, nil, env)
+	if n, ok := at.(*types.Named); !ok || n.Sym == nil || n.Sym.Name != "List" || len(n.Args) != 1 {
+		if !types.IsError(at) {
+			c.errNode(e.Args[0].Value, diag.CodeTypeMismatch,
+				"`zip` expects a `List`, got `%s`", at)
+		}
+		return c.listOf(&types.Tuple{Elems: []types.Type{elem, types.ErrorType}})
+	}
+	otherElem := iterElem(at)
+	return c.listOf(&types.Tuple{Elems: []types.Type{elem, otherElem}})
+}
+
+func (c *checker) stdlibInsert(e *ast.CallExpr, recvT types.Type, env *env) types.Type {
+	n, _ := recvT.(*types.Named)
+	if n == nil || n.Sym == nil {
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+		return types.Unit
+	}
+	switch n.Sym.Name {
+	case "List":
+		if !c.checkStdlibArgCount(e, "insert", 2, env) {
+			return types.Unit
+		}
+		c.checkExpr(e.Args[0].Value, types.Int, env)
+		elem := iterElem(recvT)
+		at := c.checkExpr(e.Args[1].Value, elem, env)
+		if !types.IsError(elem) && !c.accepts(elem, at, e.Args[1].Value) {
+			c.errMismatch(e.Args[1].Value, elem, at)
+		}
+	case "Map":
+		if len(n.Args) == 2 && c.checkStdlibArgCount(e, "insert", 2, env) {
+			k := c.checkExpr(e.Args[0].Value, n.Args[0], env)
+			if !c.accepts(n.Args[0], k, e.Args[0].Value) {
+				c.errMismatch(e.Args[0].Value, n.Args[0], k)
+			}
+			v := c.checkExpr(e.Args[1].Value, n.Args[1], env)
+			if !c.accepts(n.Args[1], v, e.Args[1].Value) {
+				c.errMismatch(e.Args[1].Value, n.Args[1], v)
+			}
+		}
+	case "Set":
+		c.checkStdlibArg(e, "insert", 0, iterElem(recvT), env)
+	default:
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+	}
+	return types.Unit
+}
+
+func (c *checker) stdlibRemove(e *ast.CallExpr, recvT types.Type, env *env) types.Type {
+	n, _ := recvT.(*types.Named)
+	if n == nil || n.Sym == nil {
+		for _, a := range e.Args {
+			c.checkExpr(a.Value, nil, env)
+		}
+		return types.ErrorType
+	}
+	switch n.Sym.Name {
+	case "Map":
+		if len(n.Args) == 2 {
+			c.checkStdlibArg(e, "remove", 0, n.Args[0], env)
+			return &types.Optional{Inner: n.Args[1]}
+		}
+	case "Set":
+		c.checkStdlibArg(e, "remove", 0, iterElem(recvT), env)
+		return types.Bool
+	}
+	for _, a := range e.Args {
+		c.checkExpr(a.Value, nil, env)
+	}
+	return types.ErrorType
 }
 
 // stdlibGetReturn returns `T?` for List<T>.get / Set<T>.get, `V?` for
@@ -2272,6 +2605,7 @@ func (c *checker) mapType(e *ast.MapExpr, hint types.Type, env *env) types.Type 
 		if kHint != nil && vHint != nil {
 			c.rejectCapabilityEscape(e, kHint, "be stored as a map key")
 			c.rejectCapabilityEscape(e, vHint, "be stored in a map value")
+			c.requireHashable(kHint, e, "Map key")
 			return c.namedOf("Map", []types.Type{kHint, vHint})
 		}
 		return c.namedOf("Map", []types.Type{types.ErrorType, types.ErrorType})
@@ -2303,6 +2637,7 @@ func (c *checker) mapType(e *ast.MapExpr, hint types.Type, env *env) types.Type 
 	if u, ok := vT.(*types.Untyped); ok {
 		vT = u.Default()
 	}
+	c.requireHashable(kT, e, "Map key")
 	return c.namedOf("Map", []types.Type{kT, vT})
 }
 

--- a/internal/check/iface.go
+++ b/internal/check/iface.go
@@ -48,6 +48,19 @@ func (c *checker) satisfies(concrete types.Type, iface *types.Named, pos ast.Nod
 	if types.IsError(concrete) {
 		return true // suppressed
 	}
+	if iface.Sym.Name == "Hashable" {
+		if c.typeIsHashable(concrete) {
+			return true
+		}
+		if tv, ok := concrete.(*types.TypeVar); ok {
+			c.errNode(pos, diag.CodeTypeMismatch,
+				"type parameter `%s` is not known to implement `Hashable`", tv)
+			return false
+		}
+		c.errNode(pos, diag.CodeTypeMismatch,
+			"type `%s` does not implement `Hashable`", concrete)
+		return false
+	}
 	if tv, ok := concrete.(*types.TypeVar); ok {
 		if c.typeVarKnownSatisfies(tv, iface) {
 			return true
@@ -119,6 +132,85 @@ func (c *checker) typeVarKnownSatisfies(tv *types.TypeVar, iface *types.Named) b
 		}
 	}
 	return false
+}
+
+func (c *checker) typeIsHashable(t types.Type) bool {
+	switch v := t.(type) {
+	case *types.Primitive:
+		return v.Kind.IsEqual() && !v.Kind.IsFloat()
+	case *types.Untyped:
+		return c.typeIsHashable(v.Default())
+	case *types.Optional:
+		return c.typeIsHashable(v.Inner)
+	case *types.Tuple:
+		for _, e := range v.Elems {
+			if !c.typeIsHashable(e) {
+				return false
+			}
+		}
+		return true
+	case *types.TypeVar:
+		return c.typeVarKnownSatisfies(v, c.hashableInterface())
+	case *types.Named:
+		if v.Sym == nil {
+			return false
+		}
+		switch v.Sym.Name {
+		case "List", "Map", "Set", "Result", "Chan", "Channel":
+			return false
+		case "Hashable":
+			return true
+		}
+		if desc, ok := c.result.Descs[v.Sym]; ok {
+			if desc.Kind == resolve.SymTypeAlias && desc.Alias != nil {
+				return c.typeIsHashable(types.Substitute(desc.Alias, bindArgs(desc.Generics, v.Args)))
+			}
+			if desc.Kind == resolve.SymInterface {
+				return c.interfaceImplies(v, c.hashableInterface())
+			}
+		}
+		return c.hasHashableMethods(v)
+	}
+	return false
+}
+
+func (c *checker) hashableInterface() *types.Named {
+	if sym := c.lookupBuiltin("Hashable"); sym != nil {
+		return &types.Named{Sym: sym}
+	}
+	return nil
+}
+
+func (c *checker) hasHashableMethods(t types.Type) bool {
+	hash, hashSub := c.lookupMethod(t, "hash")
+	if hash == nil || hash.Fn == nil {
+		return false
+	}
+	hashFn := specializeMethodDesc(hash, hashSub).Fn
+	if len(hashFn.Params) != 0 || !types.Identical(hashFn.Return, types.Int) {
+		return false
+	}
+	eq, eqSub := c.lookupMethod(t, "eq")
+	if eq == nil || eq.Fn == nil {
+		return false
+	}
+	eqFn := specializeMethodDesc(eq, eqSub).Fn
+	return len(eqFn.Params) == 1 &&
+		types.Identical(eqFn.Params[0], t) &&
+		types.Identical(eqFn.Return, types.Bool)
+}
+
+func (c *checker) requireHashable(t types.Type, pos ast.Node, role string) {
+	if t == nil || types.IsError(t) || c.typeIsHashable(t) {
+		return
+	}
+	if tv, ok := t.(*types.TypeVar); ok {
+		c.errNode(pos, diag.CodeTypeMismatch,
+			"%s type parameter `%s` is not known to implement `Hashable`", role, tv)
+		return
+	}
+	c.errNode(pos, diag.CodeTypeMismatch,
+		"%s type `%s` must implement `Hashable`", role, t)
 }
 
 func (c *checker) interfaceImplies(have, want *types.Named) bool {

--- a/internal/check/method_candidates.go
+++ b/internal/check/method_candidates.go
@@ -27,6 +27,29 @@ func (c *checker) methodCandidates(t types.Type) []string {
 		}
 		if v.Sym != nil {
 			switch v.Sym.Name {
+			case "List":
+				for _, name := range []string{
+					"len", "isEmpty", "first", "last", "get", "contains", "indexOf", "find",
+					"map", "filter", "fold", "sorted", "sortedBy", "reversed", "appended",
+					"concat", "zip", "enumerate", "push", "pop", "insert", "removeAt",
+					"sort", "reverse", "clear",
+				} {
+					add(name)
+				}
+			case "Map":
+				for _, name := range []string{
+					"len", "isEmpty", "get", "containsKey", "keys", "values", "entries",
+					"insert", "remove", "clear",
+				} {
+					add(name)
+				}
+			case "Set":
+				for _, name := range []string{
+					"len", "isEmpty", "contains", "union", "intersect", "difference",
+					"insert", "remove", "clear",
+				} {
+					add(name)
+				}
 			case "Result":
 				if len(c.resultMethods) > 0 {
 					for name := range c.resultMethods {

--- a/internal/check/typeref.go
+++ b/internal/check/typeref.go
@@ -119,6 +119,7 @@ func (c *checker) namedType(n *ast.NamedType) types.Type {
 				sym.Name, want, got)
 		}
 	}
+	c.checkCollectionHashableArgs(n, sym.Name, args)
 	return &types.Named{Sym: sym, Args: args}
 }
 
@@ -172,7 +173,30 @@ func (c *checker) builtinGenericType(n *ast.NamedType, sym *resolve.Symbol) type
 	if sym.Name == "Option" {
 		return &types.Optional{Inner: args[0]}
 	}
+
+	c.checkCollectionHashableArgs(n, sym.Name, args)
 	return &types.Named{Sym: sym, Args: args}
+}
+
+func (c *checker) checkCollectionHashableArgs(n *ast.NamedType, name string, args []types.Type) {
+	switch name {
+	case "Map":
+		if len(args) >= 1 {
+			pos := ast.Node(n)
+			if len(n.Args) >= 1 {
+				pos = n.Args[0]
+			}
+			c.requireHashable(args[0], pos, "Map key")
+		}
+	case "Set":
+		if len(args) >= 1 {
+			pos := ast.Node(n)
+			if len(n.Args) >= 1 {
+				pos = n.Args[0]
+			}
+			c.requireHashable(args[0], pos, "Set element")
+		}
+	}
 }
 
 // bindArgs / substituteTypeVars are aliases so the checker reads

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -420,6 +420,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		if g.emitResultMethodCall(c, f) {
 			return
 		}
+		if g.emitCollectionMethod(c, f) {
+			return
+		}
 		if g.emitStaticCall(f, c.Args) {
 			return
 		}
@@ -1023,6 +1026,651 @@ func (g *gen) emitRandomGenericMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 	g.emitExpr(c.Args[0].Value)
 	g.body.write(")")
 	return true
+}
+
+func (g *gen) emitCollectionMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	n, ok := g.typeOf(f.X).(*types.Named)
+	if !ok || n.Sym == nil {
+		return false
+	}
+	switch n.Sym.Name {
+	case "List":
+		return g.emitListMethod(c, f, n)
+	case "Map":
+		return g.emitMapMethod(c, f, n)
+	case "Set":
+		return g.emitSetMethod(c, f, n)
+	}
+	return false
+}
+
+func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
+	if len(n.Args) != 1 {
+		return false
+	}
+	elemGo := g.goType(n.Args[0])
+	listGo := g.goType(n)
+	target := g.renderExpr(f.X)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "iter":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitExpr(f.X)
+	case "toList":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.writeln("return out")
+		})
+	case "first":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			g.body.writef("if len(%s) == 0 { return nil }\n", xs)
+			g.body.writef("v := %s[0]\n", xs)
+			g.body.writeln("return &v")
+		})
+	case "last":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			g.body.writef("if len(%s) == 0 { return nil }\n", xs)
+			g.body.writef("v := %s[len(%s)-1]\n", xs, xs)
+			g.body.writeln("return &v")
+		})
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			idx := g.freshVar("_idx")
+			g.body.writef("%s := ", idx)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 || %s >= len(%s) { return nil }\n", idx, idx, xs)
+			g.body.writef("v := %s[%s]\n", xs, idx)
+			g.body.writeln("return &v")
+		})
+	case "contains":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("reflect")
+		g.emitCollectionIIFE("bool", f.X, func(xs string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { if reflect.DeepEqual(v, %s) { return true } }\n", xs, item)
+			g.body.writeln("return false")
+		})
+	case "indexOf":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("reflect")
+		g.emitCollectionIIFE("*int", f.X, func(xs string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for i, v := range %s { if reflect.DeepEqual(v, %s) { idx := i; return &idx } }\n", xs, item)
+			g.body.writeln("return nil")
+		})
+	case "find":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			pred := g.freshVar("_pred")
+			g.body.writef("%s := ", pred)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { if %s(v) { found := v; return &found } }\n", xs, pred)
+			g.body.writeln("return nil")
+		})
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]any")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			fn := g.freshVar("_fn")
+			g.body.writef("%s := ", fn)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("for i, v := range %s { out[i] = %s(v) }\n", xs, fn)
+			g.body.writeln("return out")
+		})
+	case "filter":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			pred := g.freshVar("_pred")
+			g.body.writef("%s := ", pred)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, xs)
+			g.body.writef("for _, v := range %s { if %s(v) { out = append(out, v) } }\n", xs, pred)
+			g.body.writeln("return out")
+		})
+	case "fold":
+		if len(c.Args) != 2 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "any")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			acc := g.freshVar("_acc")
+			fn := g.freshVar("_fn")
+			g.body.writef("%s := ", acc)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("%s := ", fn)
+			g.emitExpr(c.Args[1].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { %s = %s(%s, v) }\n", xs, acc, fn, acc)
+			g.body.writef("return %s\n", acc)
+		})
+	case "sorted":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("sort")
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.write("sort.Slice(out, func(i, j int) bool { return ")
+			g.emitCollectionLess("out[i]", "out[j]", n.Args[0])
+			g.body.writeln(" })")
+			g.body.writeln("return out")
+		})
+	case "sortedBy":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("sort")
+		retGo := g.callReturnGo(c, listGo)
+		keyRet := g.collectionCallbackReturnType(c)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			key := g.freshVar("_key")
+			g.body.writef("%s := ", key)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.write("sort.Slice(out, func(i, j int) bool { return ")
+			g.emitCollectionLess(key+"(out[i])", key+"(out[j])", keyRet)
+			g.body.writeln(" })")
+			g.body.writeln("return out")
+		})
+	case "reversed":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.writeln("for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 { out[i], out[j] = out[j], out[i] }")
+			g.body.writeln("return out")
+		})
+	case "appended":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+1)\n", retGo, xs)
+			g.body.writef("out = append(out, %s...)\n", xs)
+			g.body.writef("out = append(out, %s)\n", item)
+			g.body.writeln("return out")
+		})
+	case "concat":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+len(%s))\n", retGo, xs, other)
+			g.body.writef("out = append(out, %s...)\n", xs)
+			g.body.writef("out = append(out, %s...)\n", other)
+			g.body.writeln("return out")
+		})
+	case "zip":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]struct{F0 any; F1 any}")
+		elemRetGo := g.collectionListElemGo(g.typeOf(c), "struct{F0 any; F1 any}")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("n := len(%s)\n", xs)
+			g.body.writef("if len(%s) < n { n = len(%s) }\n", other, other)
+			g.body.writef("out := make(%s, n)\n", retGo)
+			g.body.writef("for i := 0; i < n; i++ { out[i] = %s{F0: %s[i], F1: %s[i]} }\n", elemRetGo, xs, other)
+			g.body.writeln("return out")
+		})
+	case "enumerate":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]struct{F0 int; F1 "+elemGo+"}")
+		elemRetGo := g.collectionListElemGo(g.typeOf(c), "struct{F0 int; F1 "+elemGo+"}")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("for i, v := range %s { out[i] = %s{F0: i, F1: v} }\n", xs, elemRetGo)
+			g.body.writeln("return out")
+		})
+	case "take":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			limit := g.freshVar("_n")
+			g.body.writef("%s := ", limit)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 { %s = 0 }\n", limit, limit)
+			g.body.writef("if %s > len(%s) { %s = len(%s) }\n", limit, xs, limit, xs)
+			g.body.writef("out := make(%s, %s)\n", retGo, limit)
+			g.body.writef("copy(out, %s[:%s])\n", xs, limit)
+			g.body.writeln("return out")
+		})
+	case "toSet":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "map["+elemGo+"]struct{}")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("for _, v := range %s { out[v] = struct{}{} }\n", xs)
+			g.body.writeln("return out")
+		})
+	case "push":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.write("func() { ")
+		g.body.write(target)
+		g.body.write(" = append(")
+		g.body.write(target)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(") }()")
+	case "pop":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() *%s { if len(%s) == 0 { return nil }; v := %s[len(%s)-1]; var zero %s; %s[len(%s)-1] = zero; %s = %s[:len(%s)-1]; return &v }()",
+			elemGo, target, target, target, elemGo, target, target, target, target, target)
+	case "insert":
+		if len(c.Args) != 2 {
+			return false
+		}
+		idx := g.freshVar("_idx")
+		item := g.freshVar("_item")
+		g.body.writef("func() { %s := ", idx)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; %s := ", item)
+		g.emitExpr(c.Args[1].Value)
+		g.body.writef("; if %s < 0 || %s > len(%s) { panic(\"List.insert index out of range\") }; var zero %s; %s = append(%s, zero); copy(%s[%s+1:], %s[%s:]); %s[%s] = %s }()",
+			idx, idx, target, elemGo, target, target, target, idx, target, idx, target, idx, item)
+	case "removeAt":
+		if len(c.Args) != 1 {
+			return false
+		}
+		idx := g.freshVar("_idx")
+		g.body.writef("func() %s { %s := ", elemGo, idx)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; v := %s[%s]; copy(%s[%s:], %s[%s+1:]); var zero %s; %s[len(%s)-1] = zero; %s = %s[:len(%s)-1]; return v }()",
+			target, idx, target, idx, target, idx, elemGo, target, target, target, target, target)
+	case "sort":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("sort")
+		g.body.writef("func() { xs := %s; sort.Slice(xs, func(i, j int) bool { return ", target)
+		g.emitCollectionLess("xs[i]", "xs[j]", n.Args[0])
+		g.body.write(" }) }()")
+	case "reverse":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { xs := %s; for i, j := 0, len(xs)-1; i < j; i, j = i+1, j-1 { xs[i], xs[j] = xs[j], xs[i] } }()", target)
+	case "clear":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { %s = %s[:0] }()", target, target)
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitMapMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
+	if len(n.Args) != 2 {
+		return false
+	}
+	keyGo := g.goType(n.Args[0])
+	valGo := g.goType(n.Args[1])
+	mapGo := g.goType(n)
+	target := g.renderExpr(f.X)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+valGo, f.X, func(m string) {
+			key := g.freshVar("_key")
+			g.body.writef("%s := ", key)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("v, ok := %s[%s]\n", m, key)
+			g.body.writeln("if !ok { return nil }")
+			g.body.writeln("return &v")
+		})
+	case "containsKey":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("bool", f.X, func(m string) {
+			key := g.freshVar("_key")
+			g.body.writef("%s := ", key)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("_, ok := %s[%s]\n", m, key)
+			g.body.writeln("return ok")
+		})
+	case "keys":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]"+keyGo)
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, m)
+			g.body.writef("for k := range %s { out = append(out, k) }\n", m)
+			g.body.writeln("return out")
+		})
+	case "values":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]"+valGo)
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, m)
+			g.body.writef("for _, v := range %s { out = append(out, v) }\n", m)
+			g.body.writeln("return out")
+		})
+	case "entries", "iter", "toList":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]struct{F0 "+keyGo+"; F1 "+valGo+"}")
+		elemRetGo := g.collectionListElemGo(g.typeOf(c), "struct{F0 "+keyGo+"; F1 "+valGo+"}")
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, m)
+			g.body.writef("for k, v := range %s { out = append(out, %s{F0: k, F1: v}) }\n", m, elemRetGo)
+			g.body.writeln("return out")
+		})
+	case "insert":
+		if len(c.Args) != 2 {
+			return false
+		}
+		key := g.freshVar("_key")
+		val := g.freshVar("_val")
+		g.body.writef("func() { if %s == nil { %s = %s{} }; %s := ", target, target, mapGo, key)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; %s := ", val)
+		g.emitExpr(c.Args[1].Value)
+		g.body.writef("; %s[%s] = %s }()", target, key, val)
+	case "remove":
+		if len(c.Args) != 1 {
+			return false
+		}
+		key := g.freshVar("_key")
+		g.body.writef("func() *%s { %s := ", valGo, key)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; v, ok := %s[%s]; if !ok { return nil }; delete(%s, %s); return &v }()", target, key, target, key)
+	case "clear":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { clear(%s) }()", target)
+	case "toMap":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, mapGo)
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, m)
+			g.body.writef("for k, v := range %s { out[k] = v }\n", m)
+			g.body.writeln("return out")
+		})
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitSetMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
+	if len(n.Args) != 1 {
+		return false
+	}
+	elemGo := g.goType(n.Args[0])
+	setGo := g.goType(n)
+	target := g.renderExpr(f.X)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "contains":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("bool", f.X, func(s string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("_, ok := %s[%s]\n", s, item)
+			g.body.writeln("return ok")
+		})
+	case "union", "intersect", "difference":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, setGo)
+		g.emitCollectionIIFE(retGo, f.X, func(s string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			switch f.Name {
+			case "union":
+				g.body.writef("out := make(%s, len(%s)+len(%s))\n", retGo, s, other)
+				g.body.writef("for v := range %s { out[v] = struct{}{} }\n", s)
+				g.body.writef("for v := range %s { out[v] = struct{}{} }\n", other)
+			case "intersect":
+				g.body.writef("out := make(%s)\n", retGo)
+				g.body.writef("for v := range %s { if _, ok := %s[v]; ok { out[v] = struct{}{} } }\n", s, other)
+			case "difference":
+				g.body.writef("out := make(%s)\n", retGo)
+				g.body.writef("for v := range %s { if _, ok := %s[v]; !ok { out[v] = struct{}{} } }\n", s, other)
+			}
+			g.body.writeln("return out")
+		})
+	case "insert":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() { if %s == nil { %s = %s{} }; %s[", target, target, setGo, target)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("] = struct{}{} }()")
+	case "remove":
+		if len(c.Args) != 1 {
+			return false
+		}
+		item := g.freshVar("_item")
+		g.body.writef("func() bool { %s := ", item)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; _, ok := %s[%s]; if ok { delete(%s, %s) }; return ok }()", target, item, target, item)
+	case "clear":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { clear(%s) }()", target)
+	case "iter", "toList":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]"+elemGo)
+		g.emitCollectionIIFE(retGo, f.X, func(s string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, s)
+			g.body.writef("for v := range %s { out = append(out, v) }\n", s)
+			g.body.writeln("return out")
+		})
+	case "toSet":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, setGo)
+		g.emitCollectionIIFE(retGo, f.X, func(s string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, s)
+			g.body.writef("for v := range %s { out[v] = struct{}{} }\n", s)
+			g.body.writeln("return out")
+		})
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitCollectionIIFE(retGo string, recv ast.Expr, body func(recvVar string)) {
+	recvVar := g.freshVar("_col")
+	g.body.write("func()")
+	if retGo != "" {
+		g.body.write(" ")
+		g.body.write(retGo)
+	}
+	g.body.writeln(" {")
+	g.body.indent()
+	g.body.writef("%s := ", recvVar)
+	g.emitExpr(recv)
+	g.body.nl()
+	body(recvVar)
+	g.body.dedent()
+	g.body.write("}()")
+}
+
+func (g *gen) renderExpr(e ast.Expr) string {
+	old := g.body
+	w := newWriter()
+	g.body = w
+	defer func() { g.body = old }()
+	g.emitExpr(e)
+	return string(w.bytes())
+}
+
+func (g *gen) callReturnGo(c *ast.CallExpr, fallback string) string {
+	if t := g.typeOf(c); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		return g.goType(t)
+	}
+	return fallback
+}
+
+func (g *gen) collectionCallbackReturnType(c *ast.CallExpr) types.Type {
+	if len(c.Args) != 1 {
+		return nil
+	}
+	if fn, ok := types.AsFn(g.typeOf(c.Args[0].Value)); ok {
+		return fn.Return
+	}
+	return nil
+}
+
+func (g *gen) emitCollectionLess(left, right string, t types.Type) {
+	if p, ok := t.(*types.Primitive); ok {
+		switch p.Kind {
+		case types.PBool:
+			g.body.writef("(!%s && %s)", left, right)
+			return
+		case types.PBytes:
+			g.use("bytes")
+			g.body.writef("bytes.Compare(%s, %s) < 0", left, right)
+			return
+		}
+	}
+	g.body.writef("%s < %s", left, right)
+}
+
+func (g *gen) collectionListElemGo(t types.Type, fallback string) string {
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
+		return g.goType(n.Args[0])
+	}
+	return strings.TrimPrefix(fallback, "[]")
 }
 
 // emitTurbofishCall handles the two concurrency intrinsics that use the

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -132,6 +132,77 @@ fn main() {
 	}
 }
 
+func TestCollectionMethodsCompileAndRun(t *testing.T) {
+	goSrc, err := transpile(t, `
+fn main() {
+    let mut xs = [3, 1, 2]
+    xs.push(4)
+    xs.insert(1, 9)
+    let removed = xs.removeAt(1)
+    let popped = xs.pop() ?? 0
+    let mapped = xs.map(|x| x * 2).filter(|x| x > 2).reversed()
+    let sorted = xs.sorted()
+    let sum = xs.fold(0, |acc, x| acc + x)
+    println("{xs.len()} {removed} {popped} {mapped.get(0) ?? 0} {sorted.get(0) ?? 0} {sum} {xs.contains(3)} {xs.indexOf(2) ?? -1}")
+    let snap = xs.toList()
+    xs.clear()
+    println("{xs.isEmpty()} {snap.len()} {snap.first() ?? 0} {snap.last() ?? 0} {snap.find(|x| x == 1) ?? 0}")
+    let mut combo = snap.appended(7).concat([8])
+    let zipped = combo.zip(["a", "b"])
+    let taken = combo.take(2)
+    combo.reverse()
+    combo.sort()
+    println("{combo.get(0) ?? 0} {combo.get(combo.len() - 1) ?? 0} {zipped.len()} {taken.last() ?? 0}")
+
+    let nested = [[1, 2], [3]]
+    let mut flags = [true, false]
+    flags.sort()
+    let sortedFlags = flags.sorted()
+    println("{nested.contains([1, 2])} {nested.indexOf([3]) ?? -1} {flags.get(0) ?? true} {sortedFlags.last() ?? false}")
+
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 1)
+    m.insert("b", 2)
+    let old = m.remove("a") ?? 0
+    let hasB = m.containsKey("b")
+    let gotB = m.get("b") ?? 0
+    let copied = m.toMap()
+    println("{hasB} {old} {m.len()} {m.keys().len()} {m.values().len()} {m.entries().len()}")
+    m.clear()
+    println("{gotB} {m.isEmpty()} {copied.len()}")
+
+    let s = snap.toSet()
+    let mut t = [2].toSet()
+    t.insert(5)
+    let u = s.union(t)
+    let i = s.intersect(t)
+    let d = u.difference(i)
+    println("{s.contains(3)} {u.contains(5)} {i.contains(2)} {d.contains(5)}")
+    let removedTwo = t.remove(2)
+    let tItems = t.toList()
+    t.clear()
+    println("{removedTwo} {t.isEmpty()} {tItems.len()}")
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"3 9 4 4 1 6 true 2",
+		"true 3 3 2 1",
+		"1 8 2 1",
+		"true 1 false true",
+		"true 1 1 1 1 1",
+		"2 true 1",
+		"true true true true",
+		"true true 1",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+}
+
 func TestStdRegexBridge(t *testing.T) {
 	goSrc, err := transpileWithStdlib(t, `use std.regex
 

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -1,14 +1,65 @@
 // std.collections — List<T>, Map<K, V>, Set<T>.
 //
 // These names are already auto-imported via the prelude, so user code
-// rarely writes `use std.collections`. The module-local structs are
-// the landing pad for the eventual prelude rebind, at which point the
-// prelude's built-in `List`/`Map`/`Set` symbols will point here.
-// Method signatures from spec §10.6 will be added alongside the rest
-// of the stdlib's method bodies.
+// rarely writes `use std.collections`. The module-local structs provide
+// the canonical signature surface for the collection methods in spec
+// §10.6. Runtime lowering is intrinsic because these types map directly
+// to Go slices/maps in the current backend.
 
-pub struct List<T> {}
+pub struct List<T> {
+    pub fn len(self) -> Int
+    pub fn isEmpty(self) -> Bool
+    pub fn first(self) -> T?
+    pub fn last(self) -> T?
+    pub fn get(self, index: Int) -> T?
 
-pub struct Map<K, V> {}
+    pub fn contains(self, item: T) -> Bool
+    pub fn indexOf(self, item: T) -> Int?
+    pub fn find(self, pred: fn(T) -> Bool) -> T?
 
-pub struct Set<T> {}
+    pub fn map<R>(self, f: fn(T) -> R) -> List<R>
+    pub fn filter(self, pred: fn(T) -> Bool) -> List<T>
+    pub fn fold<A>(self, init: A, f: fn(A, T) -> A) -> A
+    pub fn sorted(self) -> List<T>
+    pub fn sortedBy<K>(self, key: fn(T) -> K) -> List<T>
+    pub fn reversed(self) -> List<T>
+    pub fn appended(self, item: T) -> List<T>
+    pub fn concat(self, other: List<T>) -> List<T>
+    pub fn zip<U>(self, other: List<U>) -> List<(T, U)>
+    pub fn enumerate(self) -> List<(Int, T)>
+
+    pub fn push(mut self, item: T)
+    pub fn pop(mut self) -> T?
+    pub fn insert(mut self, index: Int, item: T)
+    pub fn removeAt(mut self, index: Int) -> T
+    pub fn sort(mut self)
+    pub fn reverse(mut self)
+    pub fn clear(mut self)
+}
+
+pub struct Map<K: Hashable, V> {
+    pub fn len(self) -> Int
+    pub fn isEmpty(self) -> Bool
+    pub fn get(self, key: K) -> V?
+    pub fn containsKey(self, key: K) -> Bool
+    pub fn keys(self) -> List<K>
+    pub fn values(self) -> List<V>
+    pub fn entries(self) -> List<(K, V)>
+
+    pub fn insert(mut self, key: K, value: V)
+    pub fn remove(mut self, key: K) -> V?
+    pub fn clear(mut self)
+}
+
+pub struct Set<T: Hashable> {
+    pub fn len(self) -> Int
+    pub fn isEmpty(self) -> Bool
+    pub fn contains(self, item: T) -> Bool
+    pub fn union(self, other: Set<T>) -> Set<T>
+    pub fn intersect(self, other: Set<T>) -> Set<T>
+    pub fn difference(self, other: Set<T>) -> Set<T>
+
+    pub fn insert(mut self, item: T)
+    pub fn remove(mut self, item: T) -> Bool
+    pub fn clear(mut self)
+}

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -511,6 +511,32 @@ func TestCollectionsModuleResolves(t *testing.T) {
 			t.Errorf("export %q has kind %s; want struct", name, sym.Kind)
 		}
 	}
+	wantMethods := map[string][]string{
+		"List": {"len", "isEmpty", "first", "last", "get", "contains", "indexOf", "find", "map", "filter", "fold", "sorted", "sortedBy", "reversed", "appended", "concat", "zip", "enumerate", "push", "pop", "insert", "removeAt", "sort", "reverse", "clear"},
+		"Map":  {"len", "isEmpty", "get", "containsKey", "keys", "values", "entries", "insert", "remove", "clear"},
+		"Set":  {"len", "isEmpty", "contains", "union", "intersect", "difference", "insert", "remove", "clear"},
+	}
+	decls := map[string]*ast.StructDecl{}
+	for _, d := range mod.File.Decls {
+		if sd, ok := d.(*ast.StructDecl); ok {
+			decls[sd.Name] = sd
+		}
+	}
+	for typ, methods := range wantMethods {
+		sd := decls[typ]
+		if sd == nil {
+			t.Fatalf("std.collections missing struct %s", typ)
+		}
+		have := map[string]bool{}
+		for _, m := range sd.Methods {
+			have[m.Name] = true
+		}
+		for _, name := range methods {
+			if !have[name] {
+				t.Errorf("std.collections %s missing method %q", typ, name)
+			}
+		}
+	}
 }
 
 // TestCollectionsViaPkgAccess verifies the user-visible shape: a file
@@ -527,6 +553,32 @@ pub fn take(xs: collections.List<Int>) -> collections.List<Int> {
 	for _, d := range res.Diags {
 		if d.Severity == diag.Error {
 			t.Errorf("unexpected diag on std.collections reference: %s", d.Error())
+		}
+	}
+}
+
+func TestCollectionsViaPkgMethodsTypeCheck(t *testing.T) {
+	src := []byte(`use std.collections
+
+pub fn describe(xs: collections.List<Int>, m: collections.Map<String, Int>, s: collections.Set<Int>) -> Int {
+    let a = xs.first() ?? 0
+    let b = m.get("fallback") ?? 0
+    let c = if s.contains(1) { 1 } else { 0 }
+    a + b + c
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.collections method diagnostic: %s", d.Error())
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fill out std.collections List/Map/Set method signatures.
- Add checker support for collection method arity, return types, callbacks, mutability, and Hashable constraints.
- Lower List/Map/Set operations to Go slices/maps in the generator.
- Add regression coverage for collection runtime behavior, stdlib resolution, and Hashable enforcement.

## Validation
- go test ./internal/check -run 'Hashable|MapKey|MapLiteralKey|SetElement|ToSet|Stdlib.*Collection|StdlibPush|StdlibEnumerate' -count=1
- go test ./internal/gen -run TestCollectionMethodsCompileAndRun -count=1
- go test ./...