### PR TITLE
Remove unused regex runtime and restore encoding imports

### DIFF
--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -127,10 +127,6 @@ type gen struct {
 	needRandomRuntime bool
 	needURLRuntime    bool
 
-	// needRegex is set when std.regex lowers to Go's regexp package,
-	// pulling in Regex/Match/Captures runtime wrappers.
-	needRegex bool
-
 	// needEncoding is set when std.encoding lowers to Go's encoding
 	// packages, pulling in base64/hex/url helper functions.
 	needEncoding bool
@@ -354,13 +350,13 @@ func (g *gen) run() ([]byte, error) {
 	if g.needErrorRuntime {
 		g.use("fmt")
 	}
-	if g.needRegex {
-		g.needResult = true
-		g.use("regexp")
-	}
 	if g.needEncoding {
 		g.needResult = true
 		g.use("fmt")
+		g.useAs("encoding/base64", "stdbase64")
+		g.useAs("encoding/hex", "stdhex")
+		g.useAs("net/url", "neturl")
+		g.useAs("strings", "stdstrings")
 		g.useAs("unicode/utf8", "utf8")
 	}
 	if g.needEnv {
@@ -1272,118 +1268,6 @@ func (u Url) queryValues(key string) []string {
 		return []string{value}
 	}
 	return []string{}
-}
-`)
-	}
-	if g.needRegex {
-		out.WriteString(`
-type Regex struct {
-	re *regexp.Regexp
-}
-
-type RegexMatch struct {
-	text       string
-	start, end int
-}
-
-type Captures struct {
-	values []*string
-	names  map[string]int
-}
-
-func regexCompile(pattern string) Result[Regex, error] {
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return resultErr[Regex, error](err)
-	}
-	return resultOk[Regex, error](Regex{re: re})
-}
-
-func (r Regex) matches(text string) bool { return r.re.MatchString(text) }
-
-func (r Regex) find(text string) *RegexMatch {
-	loc := r.re.FindStringIndex(text)
-	if loc == nil {
-		return nil
-	}
-	m := RegexMatch{text: text[loc[0]:loc[1]], start: loc[0], end: loc[1]}
-	return &m
-}
-
-func (r Regex) findAll(text string) []RegexMatch {
-	locs := r.re.FindAllStringIndex(text, -1)
-	out := make([]RegexMatch, 0, len(locs))
-	for _, loc := range locs {
-		out = append(out, RegexMatch{text: text[loc[0]:loc[1]], start: loc[0], end: loc[1]})
-	}
-	return out
-}
-
-func (r Regex) captures(text string) *Captures {
-	idx := r.re.FindStringSubmatchIndex(text)
-	if idx == nil {
-		return nil
-	}
-	c := regexCaptures(r.re, text, idx)
-	return &c
-}
-
-func (r Regex) capturesAll(text string) []Captures {
-	idxs := r.re.FindAllStringSubmatchIndex(text, -1)
-	out := make([]Captures, 0, len(idxs))
-	for _, idx := range idxs {
-		out = append(out, regexCaptures(r.re, text, idx))
-	}
-	return out
-}
-
-func (r Regex) replace(text, replacement string) string {
-	idx := r.re.FindStringSubmatchIndex(text)
-	if idx == nil {
-		return text
-	}
-	dst := make([]byte, 0, len(text)+len(replacement))
-	dst = append(dst, text[:idx[0]]...)
-	dst = r.re.ExpandString(dst, replacement, text, idx)
-	dst = append(dst, text[idx[1]:]...)
-	return string(dst)
-}
-
-func (r Regex) replaceAll(text, replacement string) string {
-	return r.re.ReplaceAllString(text, replacement)
-}
-
-func (r Regex) split(text string) []string { return r.re.Split(text, -1) }
-
-func regexCaptures(re *regexp.Regexp, text string, idx []int) Captures {
-	names := re.SubexpNames()
-	c := Captures{values: make([]*string, len(idx)/2), names: map[string]int{}}
-	for i := range c.values {
-		start, end := idx[2*i], idx[2*i+1]
-		if start >= 0 && end >= 0 {
-			v := text[start:end]
-			c.values[i] = &v
-		}
-		if i < len(names) && names[i] != "" {
-			c.names[names[i]] = i
-		}
-	}
-	return c
-}
-
-func (c Captures) get(i int) *string {
-	if i < 0 || i >= len(c.values) {
-		return nil
-	}
-	return c.values[i]
-}
-
-func (c Captures) named(name string) *string {
-	i, ok := c.names[name]
-	if !ok {
-		return nil
-	}
-	return c.get(i)
 }
 `)
 	}

--- a/internal/gen/iter_bridge_test.go
+++ b/internal/gen/iter_bridge_test.go
@@ -1,0 +1,41 @@
+package gen_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIterTranspile(t *testing.T) {
+	src := "use std.iter\n\nfn main() {\n" +
+		"    let xs = iter.range(0, 5)\n" +
+		"    let doubled = xs.map(|x| x * 2)\n" +
+		"    let big = doubled.filter(|x| x > 4)\n" +
+		"    let first3 = big.takeWhile(|x| x < 100)\n" +
+		"    let total = first3.fold(0, |acc, x| acc + x)\n" +
+		"    println(\"{total}\")\n}\n"
+
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile range/map/filter/takeWhile/fold: %v\n%s", err, goSrc)
+	}
+
+	src2 := "use std.iter\n\nfn main() {\n" +
+		"    let xs: List<Int> = [1, 2, 3]\n" +
+		"    let it = iter.from(xs)\n" +
+		"    let empty = iter.empty::<Int>()\n" +
+		"    println(\"{it.count()}\")\n" +
+		"    println(\"{empty.count()}\")\n}\n"
+
+	goSrc2, err2 := transpileWithStdlib(t, src2)
+	if err2 != nil {
+		t.Fatalf("transpile from/empty: %v\n%s", err2, goSrc2)
+	}
+
+	for _, want := range []string{"make([]int", "for"} {
+		if !strings.Contains(string(goSrc), want) {
+			t.Errorf("expected %q in generated Go:\n%s", want, goSrc)
+		}
+	}
+	t.Logf("range output:\n%s", goSrc)
+	t.Logf("from/empty output:\n%s", goSrc2)
+}


### PR DESCRIPTION
## Summary
- Remove the unused `needRegex` field and its associated `Regex`/`Match`/`Captures` runtime block that was no longer referenced after the regex bridge was removed
- Restore `encoding/base64`, `encoding/hex`, `net/url`, and `strings` imports alongside `unicode/utf8` so the encoding bridge compiles correctly
- Add `iter_bridge_test.go` for iterator bridge coverage

## Test plan
- [ ] Verify `go build ./internal/gen/` succeeds
- [ ] Run `go test ./internal/gen/ -run TestStdEncodingBridge` to confirm encoding round-trips
- [ ] Run full test suite `go test ./...`


Made with [Cursor](https://cursor.com)