### PR TITLE
Add broader selfhost example coverage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,13 +13,16 @@ the compiler evolves.
   and string parsing, ports requirement matching, filters registry
   candidates, classifies diagnostics, validates manifest feature graphs,
   ports a runnable lexer scanner and parser/type-checker seed models,
-  runs std.testing tests, calls Go FFI, and uses concurrency primitives.
+  mirrors the selfhost-core example-style tests, runs std.testing tests,
+  calls Go FFI, and uses concurrency primitives.
 - `ffi`: runnable Go FFI example using the Go `strings` package.
 - `concurrency`: runnable example covering channels, `spawn`,
   `parallel`, and `taskGroup`.
 - `selfhost-core`: standalone package for the self-hosting algorithms
   lifted out of dogfood so they can grow independently, including the
-  runnable lexer scanner and front-end seed models.
+  runnable lexer scanner, front-end seed models, and broad example-style
+  tests for SemVer, registry selection, manifest features, diagnostics,
+  and package archive classification.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `workspace`: virtual workspace with two member packages and a

--- a/examples/dogfood/diagnostic_test.osty
+++ b/examples/dogfood/diagnostic_test.osty
@@ -1,0 +1,60 @@
+use std.testing
+
+fn assertDiagnosticSeverity(code: String, want: String) {
+    testing.assertEq(diagnosticSeverityName(diagnosticSeverity(code)), want)
+}
+
+fn assertDiagnosticFamily(code: String, want: String) {
+    testing.assertEq(diagnosticFamilyName(diagnosticFamily(code)), want)
+}
+
+fn testDiagnosticExamplesClassifySeverityPrefixes() {
+    assertDiagnosticSeverity("E0001", "error")
+    assertDiagnosticSeverity("E9999", "error")
+    assertDiagnosticSeverity("W0000", "warning")
+    assertDiagnosticSeverity("W9999", "warning")
+    assertDiagnosticSeverity("L0000", "lint")
+    assertDiagnosticSeverity("L9999", "lint")
+    assertDiagnosticSeverity("X0001", "unknown")
+    assertDiagnosticSeverity("", "unknown")
+}
+
+fn testDiagnosticExamplesClassifyCompilerFamilies() {
+    assertDiagnosticFamily("E0001", "lexical")
+    assertDiagnosticFamily("E0007", "lexical")
+    assertDiagnosticFamily("E0100", "declaration")
+    assertDiagnosticFamily("E0106", "declaration")
+    assertDiagnosticFamily("E0204", "expression")
+    assertDiagnosticFamily("E0301", "type-pattern")
+    assertDiagnosticFamily("E0400", "annotation")
+    assertDiagnosticFamily("E0509", "resolution")
+    assertDiagnosticFamily("E0609", "control-flow")
+    assertDiagnosticFamily("E0762", "type-checking")
+    assertDiagnosticFamily("E2000", "manifest")
+    assertDiagnosticFamily("E2032", "manifest")
+    assertDiagnosticFamily("E2050", "scaffold")
+    assertDiagnosticFamily("E2052", "scaffold")
+}
+
+fn testDiagnosticExamplesClassifyToolFamilies() {
+    assertDiagnosticFamily("L0001", "lint")
+    assertDiagnosticFamily("L0041", "lint")
+    assertDiagnosticFamily("W0000", "warning")
+    assertDiagnosticFamily("W0750", "warning")
+}
+
+fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
+    assertDiagnosticFamily("E0000", "unknown")
+    assertDiagnosticFamily("E0099", "unknown")
+    assertDiagnosticFamily("E2040", "unknown")
+    assertDiagnosticFamily("L0000", "unknown")
+    assertDiagnosticFamily("Z0000", "unknown")
+}
+
+fn testDiagnosticExamplesIdentifyCompilationBlockers() {
+    testing.assert(diagnosticIsCompilerError("E0500"))
+    testing.assert(diagnosticIsCompilerError("E2017"))
+    testing.assert(!(diagnosticIsCompilerError("W0001")))
+    testing.assert(!(diagnosticIsCompilerError("L0001")))
+    testing.assert(!(diagnosticIsCompilerError("Z0000")))
+}

--- a/examples/dogfood/manifest_features_test.osty
+++ b/examples/dogfood/manifest_features_test.osty
@@ -1,0 +1,55 @@
+use std.testing
+
+fn testManifestFeatureExamplesFindDeclaredFeatures() {
+    let features = [
+        featureSpec("default", ["serde", "cli"]),
+        featureSpec("serde", []),
+        featureSpec("cli", ["serde"]),
+    ]
+
+    testing.assert(featureExists("default", features))
+    testing.assert(featureExists("serde", features))
+    testing.assert(!(featureExists("missing", features)))
+}
+
+fn testManifestFeatureExamplesValidateEmptyGraph() {
+    let result = validateFeatureGraph([], [])
+
+    testing.assertEq(result.undefinedDefault, 0)
+    testing.assertEq(result.selfReferences, 0)
+}
+
+fn testManifestFeatureExamplesCountMissingDefaults() {
+    let features = [
+        featureSpec("cli", []),
+        featureSpec("serde", []),
+    ]
+    let result = validateFeatureGraph(["default", "full", "cli"], features)
+
+    testing.assertEq(result.undefinedDefault, 2)
+    testing.assertEq(result.selfReferences, 0)
+}
+
+fn testManifestFeatureExamplesCountSelfReferences() {
+    let features = [
+        featureSpec("default", ["serde"]),
+        featureSpec("serde", ["serde"]),
+        featureSpec("cli", ["serde", "cli"]),
+        featureSpec("docs", ["cli"]),
+    ]
+    let result = validateFeatureGraph(["default", "cli"], features)
+
+    testing.assertEq(result.undefinedDefault, 0)
+    testing.assertEq(result.selfReferences, 2)
+}
+
+fn testManifestFeatureExamplesReportIndependentProblems() {
+    let features = [
+        featureSpec("default", ["default"]),
+        featureSpec("serde", []),
+    ]
+    let result = validateFeatureGraph(["default", "missing"], features)
+
+    testing.assertEq(result.undefinedDefault, 1)
+    testing.assertEq(result.selfReferences, 1)
+}

--- a/examples/dogfood/package_entry_test.osty
+++ b/examples/dogfood/package_entry_test.osty
@@ -1,0 +1,60 @@
+use std.testing
+
+fn assertPackageEntryKind(path: String, want: String) {
+    testing.assertEq(packageEntryKindName(packageEntryKind(path)), want)
+}
+
+fn testPackageEntryExamplesClassifyRootFiles() {
+    assertPackageEntryKind("osty.toml", "manifest")
+    assertPackageEntryKind("osty.lock", "lockfile")
+    assertPackageEntryKind("lib.osty", "source")
+    assertPackageEntryKind("README.md", "support")
+}
+
+fn testPackageEntryExamplesClassifyNestedFilesByBaseName() {
+    assertPackageEntryKind("src/main.osty", "source")
+    assertPackageEntryKind("tests/parser_test.osty", "source")
+    assertPackageEntryKind("fixtures/osty.toml", "manifest")
+    assertPackageEntryKind("fixtures/osty.lock", "lockfile")
+    assertPackageEntryKind("docs/tutorial.txt", "support")
+}
+
+fn testPackageEntryExamplesIgnoreLocalMetadataDirs() {
+    assertPackageEntryKind(".osty", "ignored")
+    assertPackageEntryKind(".git", "ignored")
+    assertPackageEntryKind(".hg", "ignored")
+    assertPackageEntryKind(".svn", "ignored")
+    assertPackageEntryKind("src/.DS_Store", "ignored")
+}
+
+fn testPackageEntryExamplesHashPolicy() {
+    let paths = [
+        "osty.toml",
+        "osty.lock",
+        "src/lib.osty",
+        "README.md",
+        ".osty",
+        ".git",
+    ]
+    let mut hashed = 0
+    let mut ignored = 0
+    for path in paths {
+        if shouldHashPackageEntry(path) {
+            hashed = hashed + 1
+        } else {
+            ignored = ignored + 1
+        }
+    }
+
+    testing.assertEq(hashed, 4)
+    testing.assertEq(ignored, 2)
+}
+
+fn testPackageEntryExamplesSourceDetection() {
+    testing.assert(isOstySourceEntry("src/lib.osty"))
+    testing.assert(isOstySourceEntry("lib_test.osty"))
+    testing.assert(!(isOstySourceEntry("osty.toml")))
+    testing.assert(!(isOstySourceEntry("osty.lock")))
+    testing.assert(!(isOstySourceEntry("README.md")))
+    testing.assert(!(isOstySourceEntry(".osty")))
+}

--- a/examples/dogfood/parser.osty
+++ b/examples/dogfood/parser.osty
@@ -186,8 +186,10 @@ fn opAdvance(p: OstyParser) -> FrontToken {
 }
 
 fn opEat(p: OstyParser, kind: FrontTokenKind) -> Bool {
-    if opAt(p, kind) { opAdvance(p)
-    return true }
+    if opAt(p, kind) {
+        let _ = opAdvance(p)
+        return true
+    }
     false
 }
 
@@ -200,7 +202,11 @@ fn opExpect(p: OstyParser, kind: FrontTokenKind) -> FrontToken {
     tok
 }
 
-fn opSkipNewlines(p: OstyParser) { for opAt(p, FrontNewline) { opAdvance(p) } }
+fn opSkipNewlines(p: OstyParser) {
+    for opAt(p, FrontNewline) {
+        let _ = opAdvance(p)
+    }
+}
 
 // ===================================================================
 // DIAGNOSTICS
@@ -222,18 +228,20 @@ fn opSyncDecl(p: OstyParser) {
     for !(opAt(p, FrontEOF)) {
         let kind = opPeek(p).kind
         if kind == FrontFn || kind == FrontStruct || kind == FrontEnum || kind == FrontInterface || kind == FrontType || kind == FrontUse || kind == FrontPub || kind == FrontHash { return }
-        opAdvance(p)
+        let _ = opAdvance(p)
     }
 }
 
 fn opSyncStmt(p: OstyParser) {
     for !(opAt(p, FrontEOF)) {
         let kind = opPeek(p).kind
-        if kind == FrontNewline { opAdvance(p)
-        return }
+        if kind == FrontNewline {
+            let _ = opAdvance(p)
+            return
+        }
         if kind == FrontRBrace { return }
         if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || kind == FrontFor || kind == FrontIf || kind == FrontMatch { return }
-        opAdvance(p)
+        let _ = opAdvance(p)
     }
 }
 
@@ -323,7 +331,7 @@ fn opParseGenericParams(p: OstyParser) -> List<Int> {
             params.push(opAddNode(p, gNode))
             if !(opEat(p, FrontComma)) { break }
         }
-        opExpect(p, FrontGt)
+        let _ = opExpect(p, FrontGt)
     }
     params
 }
@@ -604,13 +612,15 @@ fn opParseBlock(p: OstyParser) -> Int {
 
 fn opParseIfExpr(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut patIdx = -1
     let mut isIfLet = false
-    if opAt(p, FrontLet) { opAdvance(p)
-    isIfLet = true
-    patIdx = opParsePattern(p)
-    opExpect(p, FrontAssign) }
+    if opAt(p, FrontLet) {
+        let _ = opAdvance(p)
+        isIfLet = true
+        patIdx = opParsePattern(p)
+        let _ = opExpect(p, FrontAssign)
+    }
     let prevNoSL = p.noStructLit
     p.noStructLit = true
     let cond = opParseExpr(p)
@@ -681,20 +691,26 @@ fn opParseClosure(p: OstyParser) -> Int {
     n.start = start
     n.end = p.pos
     return opAddNode(p, n) }
-    opExpect(p, FrontBitOr)
+    let _ = opExpect(p, FrontBitOr)
     let mut params: List<Int> = []
     for !(opAt(p, FrontBitOr)) && !(opAt(p, FrontEOF)) {
         let paramStart = p.pos
         let mut paramNode = emptyAstNode(AstNParam)
-        if opAt(p, FrontLParen) || opAt(p, FrontUnderscore) { paramNode.left = opParsePattern(p) } else if opAt(p, FrontIdent) { paramNode.text = opAdvance(p).text } else { opError(p, "expected closure parameter")
-        opAdvance(p) }
+        if opAt(p, FrontLParen) || opAt(p, FrontUnderscore) {
+            paramNode.left = opParsePattern(p)
+        } else if opAt(p, FrontIdent) {
+            paramNode.text = opAdvance(p).text
+        } else {
+            opError(p, "expected closure parameter")
+            let _ = opAdvance(p)
+        }
         if opEat(p, FrontColon) { paramNode.right = opParseType(p) }
         paramNode.start = paramStart
         paramNode.end = p.pos
         params.push(opAddNode(p, paramNode))
         if !(opEat(p, FrontComma)) { break }
     }
-    opExpect(p, FrontBitOr)
+    let _ = opExpect(p, FrontBitOr)
     let mut retTypeIdx = -1
     if opEat(p, FrontArrow) { retTypeIdx = opParseType(p) }
     let body = opParseClosureBody(p, retTypeIdx >= 0)
@@ -717,42 +733,43 @@ fn opParseClosureBody(p: OstyParser, requireBlock: Bool) -> Int {
 // POSTFIX
 // ===================================================================
 
-fn opTryParsePostfix(p: OstyParser, left: Int) -> Int {
+fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
     let tok = opPeek(p)
     if tok.kind == FrontDot { let s = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let nm = opAdvance(p).text
     let mut n = emptyAstNode(AstNField)
-    n.left = left
+    n.left = lhs
     n.text = nm
     n.start = s
     n.end = p.pos
     return opAddNode(p, n) }
     if tok.kind == FrontQDot { let s = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let nm = opAdvance(p).text
     let mut n = emptyAstNode(AstNField)
-    n.left = left
+    n.left = lhs
     n.text = nm
     n.flags = 1
     n.start = s
     n.end = p.pos
     return opAddNode(p, n) }
-    if tok.kind == FrontLParen { return opParseCallArgs(p, left) }
-    if tok.kind == FrontLBracket { return opParseIndex(p, left) }
+    if tok.kind == FrontLParen { return opParseCallArgs(p, lhs) }
+    if tok.kind == FrontLBracket { return opParseIndex(p, lhs) }
     if tok.kind == FrontQuestion { let s = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut n = emptyAstNode(AstNQuestion)
-    n.left = left
+    n.left = lhs
     n.start = s
     n.end = p.pos
     return opAddNode(p, n) }
-    if tok.kind == FrontColonColon && opPeekAt(p, 1).kind == FrontLt { return opParseTurbofish(p, left) }
-    if tok.kind == FrontLBrace && !(p.noStructLit) && left >= 0 {
-        let leftNode = astArenaNodeAt(p.arena, left)
-        if leftNode.kind == AstNIdent && astIsUpperName(leftNode.text) { return opParseStructLit(p, left) }
+    if tok.kind == FrontColonColon && opPeekAt(p, 1).kind == FrontLt { return opParseTurbofish(p, lhs) }
+    let canStructLit = tok.kind == FrontLBrace && !(p.noStructLit)
+    if canStructLit {
+        let leftNode = astArenaNodeAt(p.arena, lhs)
+        if leftNode.kind == AstNIdent && astIsUpperName(leftNode.text) { return opParseStructLit(p, lhs) }
     }
-    -1
+    return 0 - 1
 }
 
 fn opParseCallArgs(p: OstyParser, callee: Int) -> Int {
@@ -761,8 +778,10 @@ fn opParseCallArgs(p: OstyParser, callee: Int) -> Int {
     let mut args: List<Int> = []
     opSkipNewlines(p)
     for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
-        if opAt(p, FrontIdent) && opPeekAt(p, 1).kind == FrontColon { let _ = opAdvance(p)
-        opAdvance(p) }
+        if opAt(p, FrontIdent) && opPeekAt(p, 1).kind == FrontColon {
+            let _ = opAdvance(p)
+            let _ = opAdvance(p)
+        }
         args.push(opParseExpr(p))
         opSkipNewlines(p)
         if !(opEat(p, FrontComma)) { break }
@@ -1247,19 +1266,21 @@ fn opParseAnnotations(p: OstyParser) -> List<Int> {
     let mut anns: List<Int> = []
     for opAt(p, FrontHash) && opPeekAt(p, 1).kind == FrontLBracket {
         let start = p.pos
-        opAdvance(p)
-        opAdvance(p)
+        let _ = opAdvance(p)
+        let _ = opAdvance(p)
         let mut annName = ""
         if opAt(p, FrontIdent) { annName = opAdvance(p).text }
         let mut annArgs: List<Int> = []
         if opEat(p, FrontLParen) {
             for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { annArgs.push(opParseExpr(p))
             if !(opEat(p, FrontComma)) { break } }
-            opExpect(p, FrontRParen)
+            let _ = opExpect(p, FrontRParen)
         }
-        if opAt(p, FrontAssign) { opAdvance(p)
-        annArgs.push(opParseExpr(p)) }
-        opExpect(p, FrontRBracket)
+        if opAt(p, FrontAssign) {
+            let _ = opAdvance(p)
+            annArgs.push(opParseExpr(p))
+        }
+        let _ = opExpect(p, FrontRBracket)
         let mut n = emptyAstNode(AstNAnnotation)
         n.text = annName
         n.children = annArgs
@@ -1352,7 +1373,7 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool) -> Int {
         if opAt(p, FrontFn) { members.push(opParseFnDecl(p, memberPub, [])) } else if opAt(p, FrontIdent) {
             let fs = p.pos
             let fn_ = opAdvance(p).text
-            opExpect(p, FrontColon)
+            let _ = opExpect(p, FrontColon)
             let ft = opParseType(p)
             let mut defIdx = -1
             if opEat(p, FrontAssign) { defIdx = opParseExpr(p) }
@@ -1364,8 +1385,10 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool) -> Int {
             fNode.end = p.pos
             if memberPub { fNode.flags = 1 }
             members.push(opAddNode(p, fNode))
-        } else { opError(p, "expected field or method in struct")
-        opAdvance(p) }
+        } else {
+            opError(p, "expected field or method in struct")
+            let _ = opAdvance(p)
+        }
         opSkipNewlines(p)
         opEat(p, FrontComma)
         opSkipNewlines(p)
@@ -1400,7 +1423,7 @@ fn opParseEnumDecl(p: OstyParser, isPub: Bool) -> Int {
             if opEat(p, FrontLParen) {
                 for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { vFields.push(opParseType(p))
                 if !(opEat(p, FrontComma)) { break } }
-                opExpect(p, FrontRParen)
+                let _ = opExpect(p, FrontRParen)
             }
             let mut vNode = emptyAstNode(AstNVariant)
             vNode.text = vn
@@ -1408,8 +1431,10 @@ fn opParseEnumDecl(p: OstyParser, isPub: Bool) -> Int {
             vNode.start = vs
             vNode.end = p.pos
             members.push(opAddNode(p, vNode))
-        } else { opError(p, "expected variant or method in enum")
-        opAdvance(p) }
+        } else {
+            opError(p, "expected variant or method in enum")
+            let _ = opAdvance(p)
+        }
         opSkipNewlines(p)
         opEat(p, FrontComma)
         opSkipNewlines(p)
@@ -1436,12 +1461,18 @@ fn opParseInterfaceDecl(p: OstyParser, isPub: Bool) -> Int {
     let mut members: List<Int> = []
     opSkipNewlines(p)
     for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
-        if opAt(p, FrontFn) || (opAt(p, FrontPub) && opPeekAt(p, 1).kind == FrontFn) { let fnPub = opEat(p, FrontPub)
-        members.push(opParseFnDecl(p, fnPub, [])) } else if opAt(p, FrontIdent) { members.push(opParseType(p)) } else { opError(p, "expected method or type in interface")
-        opAdvance(p) }
+        if opAt(p, FrontFn) || (opAt(p, FrontPub) && opPeekAt(p, 1).kind == FrontFn) {
+            let fnPub = opEat(p, FrontPub)
+            members.push(opParseFnDecl(p, fnPub, []))
+        } else if opAt(p, FrontIdent) {
+            members.push(opParseType(p))
+        } else {
+            opError(p, "expected method or type in interface")
+            let _ = opAdvance(p)
+        }
         opSkipNewlines(p)
     }
-    opExpect(p, FrontRBrace)
+    let _ = opExpect(p, FrontRBrace)
     let mut n = emptyAstNode(AstNInterfaceDecl)
     n.text = name
     n.children = members
@@ -1477,20 +1508,26 @@ fn opParseUseDecl(p: OstyParser) -> Int {
     let mut alias = ""
     if opAt(p, FrontIdent) && opPeek(p).text == "go" {
         isGo = true
-        opAdvance(p)
+        let _ = opAdvance(p)
         if opAt(p, FrontString) || opAt(p, FrontRawString) { path.push(opAdvance(p).text) }
     } else { for opAt(p, FrontIdent) { path.push(opAdvance(p).text)
     if !(opEat(p, FrontDot)) { break } } }
-    if opAt(p, FrontIdent) && opPeek(p).text == "as" { opAdvance(p)
-    alias = opExpect(p, FrontIdent).text }
+    if opAt(p, FrontIdent) && opPeek(p).text == "as" {
+        let _ = opAdvance(p)
+        alias = opExpect(p, FrontIdent).text
+    }
     let mut goItems: List<Int> = []
     if opEat(p, FrontLBrace) {
         opSkipNewlines(p)
         for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
-            if opAt(p, FrontFn) || opAt(p, FrontStruct) || opAt(p, FrontType) { goItems.push(opParseFnDecl(p, false, [])) } else { opAdvance(p) }
+            if opAt(p, FrontFn) || opAt(p, FrontStruct) || opAt(p, FrontType) {
+                goItems.push(opParseFnDecl(p, false, []))
+            } else {
+                let _ = opAdvance(p)
+            }
             opSkipNewlines(p)
         }
-        opExpect(p, FrontRBrace)
+        let _ = opExpect(p, FrontRBrace)
     }
     let mut n = emptyAstNode(AstNUseDecl)
     n.text = strings.Join(path, ".")
@@ -1519,20 +1556,33 @@ fn opParseFile(p: OstyParser) {
 
 pub fn astPrettyPrint(file: AstFile) -> String {
     let mut lines: List<String> = []
-    for d in file.arena.decls { astPPNode(file.arena, d, 0, lines) }
+    for d in file.arena.decls {
+        lines = astPPNode(file.arena, d, 0, lines)
+    }
     strings.Join(lines, "\n")
 }
 
-fn astPPNode(arena: AstArena, idx: Int, depth: Int, lines: List<String>) {
-    if idx < 0 { return }
+fn astPPNode(arena: AstArena, idx: Int, depth: Int, lines: List<String>) -> List<String> {
+    if idx < 0 {
+        return lines
+    }
     let node = astArenaNodeAt(arena, idx)
     let indent = strings.Repeat("  ", depth)
     let kindName = astNodeKindName(node.kind)
     if node.text != "" { lines.push("{indent}{kindName} \"{node.text}\"") } else { lines.push("{indent}{kindName}") }
-    if node.left >= 0 { astPPNode(arena, node.left, depth + 1, lines) }
-    if node.right >= 0 { astPPNode(arena, node.right, depth + 1, lines) }
-    for child in node.children { astPPNode(arena, child, depth + 1, lines) }
-    for child in node.children2 { astPPNode(arena, child, depth + 1, lines) }
+    if node.left >= 0 {
+        lines = astPPNode(arena, node.left, depth + 1, lines)
+    }
+    if node.right >= 0 {
+        lines = astPPNode(arena, node.right, depth + 1, lines)
+    }
+    for child in node.children {
+        lines = astPPNode(arena, child, depth + 1, lines)
+    }
+    for child in node.children2 {
+        lines = astPPNode(arena, child, depth + 1, lines)
+    }
+    lines
 }
 
 pub fn astNodeKindName(kind: AstNodeKind) -> String {

--- a/examples/dogfood/registry_test.osty
+++ b/examples/dogfood/registry_test.osty
@@ -1,0 +1,66 @@
+use std.testing
+
+fn assertRegistryBest(req: SemReq, versions: List<RegistryVersion>, want: SemVersion) {
+    let best = bestRegistryVersion(req, versions)
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, want), 0)
+}
+
+fn testRegistryExamplesSelectHighestVisibleMatch() {
+    let versions = [
+        registryVersion(stableVersion(1, 0, 0), false),
+        registryVersion(stableVersion(1, 4, 0), false),
+        registryVersion(stableVersion(1, 5, 0), true),
+        registryVersion(stableVersion(2, 0, 0), false),
+    ]
+
+    testing.assertEq(visibleRegistryCount(versions), 3)
+    assertRegistryBest(wildcardMajorReq(1), versions, stableVersion(1, 4, 0))
+}
+
+fn testRegistryExamplesReportNoMatchWhenOnlyCandidateIsYanked() {
+    let versions = [
+        registryVersion(stableVersion(1, 2, 0), true),
+        registryVersion(stableVersion(2, 0, 0), false),
+    ]
+    let best = bestRegistryVersion(wildcardMinorReq(1, 2), versions)
+
+    testing.assert(!(best.found))
+    testing.assertEq(compareSemVersion(best.version, stableVersion(0, 0, 0)), 0)
+}
+
+fn testRegistryExamplesHonorPrereleasePolicy() {
+    let alpha = prerelease1(1, 1, 0, preText("alpha"))
+    let versions = [
+        registryVersion(alpha, false),
+        registryVersion(stableVersion(1, 0, 0), false),
+    ]
+
+    assertRegistryBest(wildcardMajorReq(1), versions, stableVersion(1, 0, 0))
+    assertRegistryBest(exactReq(alpha), versions, alpha)
+}
+
+fn testRegistryExamplesHandleUnsortedIndexes() {
+    let versions = [
+        registryVersion(stableVersion(1, 9, 0), false),
+        registryVersion(stableVersion(1, 7, 0), false),
+        registryVersion(stableVersion(1, 8, 5), false),
+        registryVersion(stableVersion(1, 10, 0), true),
+    ]
+
+    assertRegistryBest(wildcardMajorReq(1), versions, stableVersion(1, 9, 0))
+}
+
+fn testRegistryExamplesCountVisibleVersionsSeparatelyFromMatching() {
+    let versions = [
+        registryVersion(stableVersion(0, 9, 0), false),
+        registryVersion(stableVersion(1, 0, 0), true),
+        registryVersion(stableVersion(1, 1, 0), false),
+        registryVersion(stableVersion(2, 0, 0), false),
+    ]
+    let best = bestRegistryVersion(wildcardMajorReq(1), versions)
+
+    testing.assertEq(visibleRegistryCount(versions), 3)
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, stableVersion(1, 1, 0)), 0)
+}

--- a/examples/dogfood/selfhost_test.osty
+++ b/examples/dogfood/selfhost_test.osty
@@ -77,3 +77,77 @@ fn testManifestFeatureValidation() {
     testing.assertEq(bad.undefinedDefault, 1)
     testing.assertEq(bad.selfReferences, 1)
 }
+
+fn parsedSelfhostVersion(text: String) -> SemVersion {
+    let mut out = stableVersion(0, 0, 0)
+    match parseSemVersionText(text) {
+        Ok(version) -> {
+            out = version
+        },
+        Err(e) -> testing.fail(e),
+    }
+    out
+}
+
+fn testSelfhostExampleDependencyResolutionScenario() {
+    let versions = [
+        registryVersion(parsedSelfhostVersion("1.4.0"), false),
+        registryVersion(parsedSelfhostVersion("1.4.1"), false),
+        registryVersion(parsedSelfhostVersion("1.5.0"), true),
+        registryVersion(parsedSelfhostVersion("1.5.1-alpha"), false),
+        registryVersion(parsedSelfhostVersion("2.0.0"), false),
+    ]
+    let best = bestRegistryVersion(caretReq(parsedSelfhostVersion("1.4.0")), versions)
+
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, parsedSelfhostVersion("1.4.1")), 0)
+}
+
+fn testSelfhostExamplePackageArchiveScenario() {
+    let paths = [
+        "osty.toml",
+        "osty.lock",
+        "src/lib.osty",
+        "src/parser_test.osty",
+        "README.md",
+        ".osty",
+        ".git",
+    ]
+    let mut sources = 0
+    let mut hashed = 0
+    let mut ignored = 0
+    for path in paths {
+        if isOstySourceEntry(path) {
+            sources = sources + 1
+        }
+        if shouldHashPackageEntry(path) {
+            hashed = hashed + 1
+        } else {
+            ignored = ignored + 1
+        }
+    }
+
+    testing.assertEq(sources, 2)
+    testing.assertEq(hashed, 5)
+    testing.assertEq(ignored, 2)
+}
+
+fn testSelfhostExampleFrontEndPipelineScenario() {
+    let source = r"""
+        /// Adds two integers.
+        pub fn add(a: Int, b: Int) -> Int {
+            let sum = a + b
+            return sum
+        }
+        """
+    let lexed = frontendLexStream(source)
+    let tree = frontendParseTree(source)
+
+    testing.assert(frontLexTokenCount(lexed) > 0)
+    testing.assertEq(frontLexDiagnosticCount(lexed), 0)
+    testing.assertEq(frontLeadingDocAttachmentCount(lexed), 1)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeNodeNameCount(tree, "fn"), 1)
+    testing.assert(frontParseTreeNodeNameCount(tree, "param") >= 2)
+    testing.assert(frontParseTreeNodeNameCount(tree, "return") >= 1)
+}

--- a/examples/dogfood/semver_parse_test.osty
+++ b/examples/dogfood/semver_parse_test.osty
@@ -14,6 +14,34 @@ fn assertParseVersionFails(text: String) {
     }
 }
 
+fn assertParsedNumber(text: String, want: Int) {
+    match parseSemNumber(text) {
+        Ok(got) -> testing.assertEq(got, want),
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn assertParseNumberFails(text: String) {
+    match parseSemNumber(text) {
+        Ok(_) -> testing.fail("expected number parse failure"),
+        Err(_) -> testing.assert(true),
+    }
+}
+
+fn assertPreNumber(text: String, want: Int) {
+    match parseSemPreIdent(text) {
+        Ok(got) -> testing.assertEq(comparePreIdent(got, preNumber(want)), 0),
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn assertPreText(text: String, want: String) {
+    match parseSemPreIdent(text) {
+        Ok(got) -> testing.assertEq(comparePreIdent(got, preText(want)), 0),
+        Err(e) -> testing.fail(e),
+    }
+}
+
 fn testParseSemverCoreAndBuild() {
     assertParsedVersion("1.2.3", stableVersion(1, 2, 3))
     assertParsedVersion("v1.2.3", stableVersion(1, 2, 3))
@@ -45,4 +73,80 @@ fn testParseSemverRejectsInvalidForms() {
     assertParseVersionFails("1.2.3-01")
     assertParseVersionFails("1.2.3-alpha+")
     assertParseVersionFails("1.2.3-al_pha")
+}
+
+fn testParseSemverSplitSummaryExamples() {
+    let one = splitSummary(["core"])
+    testing.assertEq(one.count, 1)
+    testing.assertEq(one.first, "core")
+    testing.assertEq(one.second, "")
+
+    let many = splitSummary(["major", "minor", "patch", "ignored"])
+    testing.assertEq(many.count, 4)
+    testing.assertEq(many.first, "major")
+    testing.assertEq(many.second, "minor")
+    testing.assertEq(many.third, "patch")
+}
+
+fn testParseSemverNumberExamples() {
+    assertParsedNumber("0", 0)
+    assertParsedNumber("7", 7)
+    assertParsedNumber("123", 123)
+
+    assertParseNumberFails("")
+    assertParseNumberFails("00")
+    assertParseNumberFails("01")
+    assertParseNumberFails("4a")
+}
+
+fn testParseSemverIdentifierExamples() {
+    testing.assert(allAsciiDigits("12345"))
+    testing.assert(!(allAsciiDigits("")))
+    testing.assert(!(allAsciiDigits("12a")))
+
+    testing.assert(identifierTextValid("rc-1"))
+    testing.assert(identifierTextValid("BUILD"))
+    testing.assert(!(identifierTextValid("")))
+    testing.assert(!(identifierTextValid("rc.1")))
+
+    testing.assert(buildIdentifiersValid("meta.7.sha"))
+    testing.assert(!(buildIdentifiersValid("")))
+    testing.assert(!(buildIdentifiersValid("meta..sha")))
+}
+
+fn testParseSemverPreIdentifierExamples() {
+    assertPreNumber("9", 9)
+    assertPreText("alpha", "alpha")
+    assertPreText("rc-1", "rc-1")
+
+    match parseSemPreIdent("01") {
+        Ok(_) -> testing.fail("expected leading-zero pre-release failure"),
+        Err(e) -> testing.assertEq(e, "number has leading zero"),
+    }
+    match parseSemPreIdent("bad_name") {
+        Ok(_) -> testing.fail("expected invalid pre-release failure"),
+        Err(e) -> testing.assertEq(e, "invalid pre-release identifier"),
+    }
+}
+
+fn testParseSemverPreservesPrereleaseAndBuildFields() {
+    match parseSemVersionText("2.3.4-beta.7.sha+build.11") {
+        Ok(got) -> {
+            testing.assertEq(got.major, 2)
+            testing.assertEq(got.minor, 3)
+            testing.assertEq(got.patch, 4)
+            testing.assertEq(got.build, "build.11")
+            testing.assertEq(comparePreIdent(got.pre1, preText("beta")), 0)
+            testing.assertEq(comparePreIdent(got.pre2, preNumber(7)), 0)
+            testing.assertEq(comparePreIdent(got.pre3, preText("sha")), 0)
+        },
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn testParseSemverRejectsExtraPrereleaseAndBadBuildExamples() {
+    assertParseVersionFails("1.2.3-a.b.c.d")
+    assertParseVersionFails("1.2.3+build..1")
+    assertParseVersionFails("1.2.3+bad_meta")
+    assertParseVersionFails("1.2.3-rc+bad_meta")
 }

--- a/examples/dogfood/semver_req_test.osty
+++ b/examples/dogfood/semver_req_test.osty
@@ -69,3 +69,55 @@ fn testSemverReqPrereleaseGoldenCases() {
     let preRange = caretReq(prerelease1(1, 2, 3, preText("alpha")))
     assertReqMatch(preRange, prerelease2(1, 2, 3, preText("alpha"), preNumber(1)))
 }
+
+fn testSemverReqAnyMatchesStableOnly() {
+    let any = anySemReq()
+    assertReqMatch(any, stableVersion(0, 0, 0))
+    assertReqMatch(any, stableVersion(99, 1, 2))
+    assertReqMiss(any, prerelease1(1, 0, 0, preText("alpha")))
+}
+
+fn testSemverReqBoundedConjunctionExamples() {
+    let req = boundedReq(stableVersion(1, 4, 0), stableVersion(1, 6, 0))
+
+    assertReqMiss(req, stableVersion(1, 3, 9))
+    assertReqMatch(req, stableVersion(1, 4, 0))
+    assertReqMatch(req, stableVersion(1, 5, 9))
+    assertReqMiss(req, stableVersion(1, 6, 0))
+}
+
+fn testSemverReqMaxMatchingSkipsPrereleasesByDefault() {
+    let versions = [
+        prerelease1(2, 0, 0, preText("alpha")),
+        stableVersion(1, 9, 9),
+        stableVersion(1, 8, 0),
+    ]
+    let best = maxMatchingVersion(atLeastReq(stableVersion(1, 0, 0)), versions)
+
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, stableVersion(1, 9, 9)), 0)
+}
+
+fn testSemverReqMaxMatchingCanSelectPrereleaseWhenRequested() {
+    let req = exactReq(prerelease1(2, 0, 0, preText("alpha")))
+    let versions = [
+        stableVersion(1, 9, 9),
+        prerelease1(2, 0, 0, preText("alpha")),
+        prerelease1(2, 0, 0, preText("beta")),
+    ]
+    let best = maxMatchingVersion(req, versions)
+
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, prerelease1(2, 0, 0, preText("alpha"))), 0)
+}
+
+fn testSemverReqMaxMatchingReportsNoMatch() {
+    let versions = [
+        stableVersion(0, 9, 0),
+        stableVersion(2, 0, 0),
+    ]
+    let best = maxMatchingVersion(wildcardMinorReq(1, 4), versions)
+
+    testing.assert(!(best.found))
+    testing.assertEq(compareSemVersion(best.version, stableVersion(0, 0, 0)), 0)
+}

--- a/examples/dogfood/semver_test.osty
+++ b/examples/dogfood/semver_test.osty
@@ -39,3 +39,51 @@ fn testSemverIgnoresBuildMetadata() {
     let b = versionWithBuild(1, 0, 0, "build.2")
     testing.assertEq(compareSemVersion(a, b), 0)
 }
+
+fn testSemverConstructorsExposePrereleaseSlots() {
+    let v = semVersion(
+        2,
+        3,
+        4,
+        preText("rc"),
+        preNumber(2),
+        preText("hotfix"),
+        "build.9",
+    )
+
+    testing.assertEq(v.major, 2)
+    testing.assertEq(v.minor, 3)
+    testing.assertEq(v.patch, 4)
+    testing.assertEq(v.build, "build.9")
+    testing.assert(isSemPrerelease(v))
+    testing.assertEq(comparePreIdent(v.pre1, preText("rc")), 0)
+    testing.assertEq(comparePreIdent(v.pre2, preNumber(2)), 0)
+    testing.assertEq(comparePreIdent(v.pre3, preText("hotfix")), 0)
+}
+
+fn testSemverOrdersShorterPrereleaseBeforeLongerPrefix() {
+    let alpha = prerelease1(1, 0, 0, preText("alpha"))
+    let alpha0 = prerelease2(1, 0, 0, preText("alpha"), preNumber(0))
+    let alpha0Build = semVersion(1, 0, 0, preText("alpha"), preNumber(0), preText("build"), "")
+
+    testing.assertEq(compareSemVersion(alpha, alpha0), -1)
+    testing.assertEq(compareSemVersion(alpha0, alpha0Build), -1)
+    testing.assertEq(comparePreIdent(preNone(), preNumber(1)), -1)
+}
+
+fn testSemverOrdersNumericPrereleaseBeforeText() {
+    testing.assertEq(comparePreIdent(preNumber(10), preText("alpha")), -1)
+    testing.assertEq(comparePreIdent(preText("alpha"), preNumber(10)), 1)
+    testing.assertEq(comparePreIdent(preText("alpha"), preText("beta")), -1)
+    testing.assertEq(comparePreIdent(preText("rc"), preText("rc")), 0)
+}
+
+fn testSemverComparisonHelpersAreThreeWay() {
+    testing.assertEq(signInt(1, 2), -1)
+    testing.assertEq(signInt(2, 1), 1)
+    testing.assertEq(signInt(2, 2), 0)
+
+    testing.assertEq(signString("alpha", "beta"), -1)
+    testing.assertEq(signString("beta", "alpha"), 1)
+    testing.assertEq(signString("rc", "rc"), 0)
+}

--- a/examples/selfhost-core/diagnostic_test.osty
+++ b/examples/selfhost-core/diagnostic_test.osty
@@ -1,0 +1,60 @@
+use std.testing
+
+fn assertDiagnosticSeverity(code: String, want: String) {
+    testing.assertEq(diagnosticSeverityName(diagnosticSeverity(code)), want)
+}
+
+fn assertDiagnosticFamily(code: String, want: String) {
+    testing.assertEq(diagnosticFamilyName(diagnosticFamily(code)), want)
+}
+
+fn testDiagnosticExamplesClassifySeverityPrefixes() {
+    assertDiagnosticSeverity("E0001", "error")
+    assertDiagnosticSeverity("E9999", "error")
+    assertDiagnosticSeverity("W0000", "warning")
+    assertDiagnosticSeverity("W9999", "warning")
+    assertDiagnosticSeverity("L0000", "lint")
+    assertDiagnosticSeverity("L9999", "lint")
+    assertDiagnosticSeverity("X0001", "unknown")
+    assertDiagnosticSeverity("", "unknown")
+}
+
+fn testDiagnosticExamplesClassifyCompilerFamilies() {
+    assertDiagnosticFamily("E0001", "lexical")
+    assertDiagnosticFamily("E0007", "lexical")
+    assertDiagnosticFamily("E0100", "declaration")
+    assertDiagnosticFamily("E0106", "declaration")
+    assertDiagnosticFamily("E0204", "expression")
+    assertDiagnosticFamily("E0301", "type-pattern")
+    assertDiagnosticFamily("E0400", "annotation")
+    assertDiagnosticFamily("E0509", "resolution")
+    assertDiagnosticFamily("E0609", "control-flow")
+    assertDiagnosticFamily("E0762", "type-checking")
+    assertDiagnosticFamily("E2000", "manifest")
+    assertDiagnosticFamily("E2032", "manifest")
+    assertDiagnosticFamily("E2050", "scaffold")
+    assertDiagnosticFamily("E2052", "scaffold")
+}
+
+fn testDiagnosticExamplesClassifyToolFamilies() {
+    assertDiagnosticFamily("L0001", "lint")
+    assertDiagnosticFamily("L0041", "lint")
+    assertDiagnosticFamily("W0000", "warning")
+    assertDiagnosticFamily("W0750", "warning")
+}
+
+fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
+    assertDiagnosticFamily("E0000", "unknown")
+    assertDiagnosticFamily("E0099", "unknown")
+    assertDiagnosticFamily("E2040", "unknown")
+    assertDiagnosticFamily("L0000", "unknown")
+    assertDiagnosticFamily("Z0000", "unknown")
+}
+
+fn testDiagnosticExamplesIdentifyCompilationBlockers() {
+    testing.assert(diagnosticIsCompilerError("E0500"))
+    testing.assert(diagnosticIsCompilerError("E2017"))
+    testing.assert(!(diagnosticIsCompilerError("W0001")))
+    testing.assert(!(diagnosticIsCompilerError("L0001")))
+    testing.assert(!(diagnosticIsCompilerError("Z0000")))
+}

--- a/examples/selfhost-core/manifest_features_test.osty
+++ b/examples/selfhost-core/manifest_features_test.osty
@@ -1,0 +1,55 @@
+use std.testing
+
+fn testManifestFeatureExamplesFindDeclaredFeatures() {
+    let features = [
+        featureSpec("default", ["serde", "cli"]),
+        featureSpec("serde", []),
+        featureSpec("cli", ["serde"]),
+    ]
+
+    testing.assert(featureExists("default", features))
+    testing.assert(featureExists("serde", features))
+    testing.assert(!(featureExists("missing", features)))
+}
+
+fn testManifestFeatureExamplesValidateEmptyGraph() {
+    let result = validateFeatureGraph([], [])
+
+    testing.assertEq(result.undefinedDefault, 0)
+    testing.assertEq(result.selfReferences, 0)
+}
+
+fn testManifestFeatureExamplesCountMissingDefaults() {
+    let features = [
+        featureSpec("cli", []),
+        featureSpec("serde", []),
+    ]
+    let result = validateFeatureGraph(["default", "full", "cli"], features)
+
+    testing.assertEq(result.undefinedDefault, 2)
+    testing.assertEq(result.selfReferences, 0)
+}
+
+fn testManifestFeatureExamplesCountSelfReferences() {
+    let features = [
+        featureSpec("default", ["serde"]),
+        featureSpec("serde", ["serde"]),
+        featureSpec("cli", ["serde", "cli"]),
+        featureSpec("docs", ["cli"]),
+    ]
+    let result = validateFeatureGraph(["default", "cli"], features)
+
+    testing.assertEq(result.undefinedDefault, 0)
+    testing.assertEq(result.selfReferences, 2)
+}
+
+fn testManifestFeatureExamplesReportIndependentProblems() {
+    let features = [
+        featureSpec("default", ["default"]),
+        featureSpec("serde", []),
+    ]
+    let result = validateFeatureGraph(["default", "missing"], features)
+
+    testing.assertEq(result.undefinedDefault, 1)
+    testing.assertEq(result.selfReferences, 1)
+}

--- a/examples/selfhost-core/package_entry_test.osty
+++ b/examples/selfhost-core/package_entry_test.osty
@@ -1,0 +1,60 @@
+use std.testing
+
+fn assertPackageEntryKind(path: String, want: String) {
+    testing.assertEq(packageEntryKindName(packageEntryKind(path)), want)
+}
+
+fn testPackageEntryExamplesClassifyRootFiles() {
+    assertPackageEntryKind("osty.toml", "manifest")
+    assertPackageEntryKind("osty.lock", "lockfile")
+    assertPackageEntryKind("lib.osty", "source")
+    assertPackageEntryKind("README.md", "support")
+}
+
+fn testPackageEntryExamplesClassifyNestedFilesByBaseName() {
+    assertPackageEntryKind("src/main.osty", "source")
+    assertPackageEntryKind("tests/parser_test.osty", "source")
+    assertPackageEntryKind("fixtures/osty.toml", "manifest")
+    assertPackageEntryKind("fixtures/osty.lock", "lockfile")
+    assertPackageEntryKind("docs/tutorial.txt", "support")
+}
+
+fn testPackageEntryExamplesIgnoreLocalMetadataDirs() {
+    assertPackageEntryKind(".osty", "ignored")
+    assertPackageEntryKind(".git", "ignored")
+    assertPackageEntryKind(".hg", "ignored")
+    assertPackageEntryKind(".svn", "ignored")
+    assertPackageEntryKind("src/.DS_Store", "ignored")
+}
+
+fn testPackageEntryExamplesHashPolicy() {
+    let paths = [
+        "osty.toml",
+        "osty.lock",
+        "src/lib.osty",
+        "README.md",
+        ".osty",
+        ".git",
+    ]
+    let mut hashed = 0
+    let mut ignored = 0
+    for path in paths {
+        if shouldHashPackageEntry(path) {
+            hashed = hashed + 1
+        } else {
+            ignored = ignored + 1
+        }
+    }
+
+    testing.assertEq(hashed, 4)
+    testing.assertEq(ignored, 2)
+}
+
+fn testPackageEntryExamplesSourceDetection() {
+    testing.assert(isOstySourceEntry("src/lib.osty"))
+    testing.assert(isOstySourceEntry("lib_test.osty"))
+    testing.assert(!(isOstySourceEntry("osty.toml")))
+    testing.assert(!(isOstySourceEntry("osty.lock")))
+    testing.assert(!(isOstySourceEntry("README.md")))
+    testing.assert(!(isOstySourceEntry(".osty")))
+}

--- a/examples/selfhost-core/registry_test.osty
+++ b/examples/selfhost-core/registry_test.osty
@@ -1,0 +1,66 @@
+use std.testing
+
+fn assertRegistryBest(req: SemReq, versions: List<RegistryVersion>, want: SemVersion) {
+    let best = bestRegistryVersion(req, versions)
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, want), 0)
+}
+
+fn testRegistryExamplesSelectHighestVisibleMatch() {
+    let versions = [
+        registryVersion(stableVersion(1, 0, 0), false),
+        registryVersion(stableVersion(1, 4, 0), false),
+        registryVersion(stableVersion(1, 5, 0), true),
+        registryVersion(stableVersion(2, 0, 0), false),
+    ]
+
+    testing.assertEq(visibleRegistryCount(versions), 3)
+    assertRegistryBest(wildcardMajorReq(1), versions, stableVersion(1, 4, 0))
+}
+
+fn testRegistryExamplesReportNoMatchWhenOnlyCandidateIsYanked() {
+    let versions = [
+        registryVersion(stableVersion(1, 2, 0), true),
+        registryVersion(stableVersion(2, 0, 0), false),
+    ]
+    let best = bestRegistryVersion(wildcardMinorReq(1, 2), versions)
+
+    testing.assert(!(best.found))
+    testing.assertEq(compareSemVersion(best.version, stableVersion(0, 0, 0)), 0)
+}
+
+fn testRegistryExamplesHonorPrereleasePolicy() {
+    let alpha = prerelease1(1, 1, 0, preText("alpha"))
+    let versions = [
+        registryVersion(alpha, false),
+        registryVersion(stableVersion(1, 0, 0), false),
+    ]
+
+    assertRegistryBest(wildcardMajorReq(1), versions, stableVersion(1, 0, 0))
+    assertRegistryBest(exactReq(alpha), versions, alpha)
+}
+
+fn testRegistryExamplesHandleUnsortedIndexes() {
+    let versions = [
+        registryVersion(stableVersion(1, 9, 0), false),
+        registryVersion(stableVersion(1, 7, 0), false),
+        registryVersion(stableVersion(1, 8, 5), false),
+        registryVersion(stableVersion(1, 10, 0), true),
+    ]
+
+    assertRegistryBest(wildcardMajorReq(1), versions, stableVersion(1, 9, 0))
+}
+
+fn testRegistryExamplesCountVisibleVersionsSeparatelyFromMatching() {
+    let versions = [
+        registryVersion(stableVersion(0, 9, 0), false),
+        registryVersion(stableVersion(1, 0, 0), true),
+        registryVersion(stableVersion(1, 1, 0), false),
+        registryVersion(stableVersion(2, 0, 0), false),
+    ]
+    let best = bestRegistryVersion(wildcardMajorReq(1), versions)
+
+    testing.assertEq(visibleRegistryCount(versions), 3)
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, stableVersion(1, 1, 0)), 0)
+}

--- a/examples/selfhost-core/selfhost_test.osty
+++ b/examples/selfhost-core/selfhost_test.osty
@@ -77,3 +77,77 @@ fn testManifestFeatureValidation() {
     testing.assertEq(bad.undefinedDefault, 1)
     testing.assertEq(bad.selfReferences, 1)
 }
+
+fn parsedSelfhostVersion(text: String) -> SemVersion {
+    let mut out = stableVersion(0, 0, 0)
+    match parseSemVersionText(text) {
+        Ok(version) -> {
+            out = version
+        },
+        Err(e) -> testing.fail(e),
+    }
+    out
+}
+
+fn testSelfhostExampleDependencyResolutionScenario() {
+    let versions = [
+        registryVersion(parsedSelfhostVersion("1.4.0"), false),
+        registryVersion(parsedSelfhostVersion("1.4.1"), false),
+        registryVersion(parsedSelfhostVersion("1.5.0"), true),
+        registryVersion(parsedSelfhostVersion("1.5.1-alpha"), false),
+        registryVersion(parsedSelfhostVersion("2.0.0"), false),
+    ]
+    let best = bestRegistryVersion(caretReq(parsedSelfhostVersion("1.4.0")), versions)
+
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, parsedSelfhostVersion("1.4.1")), 0)
+}
+
+fn testSelfhostExamplePackageArchiveScenario() {
+    let paths = [
+        "osty.toml",
+        "osty.lock",
+        "src/lib.osty",
+        "src/parser_test.osty",
+        "README.md",
+        ".osty",
+        ".git",
+    ]
+    let mut sources = 0
+    let mut hashed = 0
+    let mut ignored = 0
+    for path in paths {
+        if isOstySourceEntry(path) {
+            sources = sources + 1
+        }
+        if shouldHashPackageEntry(path) {
+            hashed = hashed + 1
+        } else {
+            ignored = ignored + 1
+        }
+    }
+
+    testing.assertEq(sources, 2)
+    testing.assertEq(hashed, 5)
+    testing.assertEq(ignored, 2)
+}
+
+fn testSelfhostExampleFrontEndPipelineScenario() {
+    let source = r"""
+        /// Adds two integers.
+        pub fn add(a: Int, b: Int) -> Int {
+            let sum = a + b
+            return sum
+        }
+        """
+    let lexed = frontendLexStream(source)
+    let tree = frontendParseTree(source)
+
+    testing.assert(frontLexTokenCount(lexed) > 0)
+    testing.assertEq(frontLexDiagnosticCount(lexed), 0)
+    testing.assertEq(frontLeadingDocAttachmentCount(lexed), 1)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeNodeNameCount(tree, "fn"), 1)
+    testing.assert(frontParseTreeNodeNameCount(tree, "param") >= 2)
+    testing.assert(frontParseTreeNodeNameCount(tree, "return") >= 1)
+}

--- a/examples/selfhost-core/semver_parse_test.osty
+++ b/examples/selfhost-core/semver_parse_test.osty
@@ -14,6 +14,34 @@ fn assertParseVersionFails(text: String) {
     }
 }
 
+fn assertParsedNumber(text: String, want: Int) {
+    match parseSemNumber(text) {
+        Ok(got) -> testing.assertEq(got, want),
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn assertParseNumberFails(text: String) {
+    match parseSemNumber(text) {
+        Ok(_) -> testing.fail("expected number parse failure"),
+        Err(_) -> testing.assert(true),
+    }
+}
+
+fn assertPreNumber(text: String, want: Int) {
+    match parseSemPreIdent(text) {
+        Ok(got) -> testing.assertEq(comparePreIdent(got, preNumber(want)), 0),
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn assertPreText(text: String, want: String) {
+    match parseSemPreIdent(text) {
+        Ok(got) -> testing.assertEq(comparePreIdent(got, preText(want)), 0),
+        Err(e) -> testing.fail(e),
+    }
+}
+
 fn testParseSemverCoreAndBuild() {
     assertParsedVersion("1.2.3", stableVersion(1, 2, 3))
     assertParsedVersion("v1.2.3", stableVersion(1, 2, 3))
@@ -45,4 +73,80 @@ fn testParseSemverRejectsInvalidForms() {
     assertParseVersionFails("1.2.3-01")
     assertParseVersionFails("1.2.3-alpha+")
     assertParseVersionFails("1.2.3-al_pha")
+}
+
+fn testParseSemverSplitSummaryExamples() {
+    let one = splitSummary(["core"])
+    testing.assertEq(one.count, 1)
+    testing.assertEq(one.first, "core")
+    testing.assertEq(one.second, "")
+
+    let many = splitSummary(["major", "minor", "patch", "ignored"])
+    testing.assertEq(many.count, 4)
+    testing.assertEq(many.first, "major")
+    testing.assertEq(many.second, "minor")
+    testing.assertEq(many.third, "patch")
+}
+
+fn testParseSemverNumberExamples() {
+    assertParsedNumber("0", 0)
+    assertParsedNumber("7", 7)
+    assertParsedNumber("123", 123)
+
+    assertParseNumberFails("")
+    assertParseNumberFails("00")
+    assertParseNumberFails("01")
+    assertParseNumberFails("4a")
+}
+
+fn testParseSemverIdentifierExamples() {
+    testing.assert(allAsciiDigits("12345"))
+    testing.assert(!(allAsciiDigits("")))
+    testing.assert(!(allAsciiDigits("12a")))
+
+    testing.assert(identifierTextValid("rc-1"))
+    testing.assert(identifierTextValid("BUILD"))
+    testing.assert(!(identifierTextValid("")))
+    testing.assert(!(identifierTextValid("rc.1")))
+
+    testing.assert(buildIdentifiersValid("meta.7.sha"))
+    testing.assert(!(buildIdentifiersValid("")))
+    testing.assert(!(buildIdentifiersValid("meta..sha")))
+}
+
+fn testParseSemverPreIdentifierExamples() {
+    assertPreNumber("9", 9)
+    assertPreText("alpha", "alpha")
+    assertPreText("rc-1", "rc-1")
+
+    match parseSemPreIdent("01") {
+        Ok(_) -> testing.fail("expected leading-zero pre-release failure"),
+        Err(e) -> testing.assertEq(e, "number has leading zero"),
+    }
+    match parseSemPreIdent("bad_name") {
+        Ok(_) -> testing.fail("expected invalid pre-release failure"),
+        Err(e) -> testing.assertEq(e, "invalid pre-release identifier"),
+    }
+}
+
+fn testParseSemverPreservesPrereleaseAndBuildFields() {
+    match parseSemVersionText("2.3.4-beta.7.sha+build.11") {
+        Ok(got) -> {
+            testing.assertEq(got.major, 2)
+            testing.assertEq(got.minor, 3)
+            testing.assertEq(got.patch, 4)
+            testing.assertEq(got.build, "build.11")
+            testing.assertEq(comparePreIdent(got.pre1, preText("beta")), 0)
+            testing.assertEq(comparePreIdent(got.pre2, preNumber(7)), 0)
+            testing.assertEq(comparePreIdent(got.pre3, preText("sha")), 0)
+        },
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn testParseSemverRejectsExtraPrereleaseAndBadBuildExamples() {
+    assertParseVersionFails("1.2.3-a.b.c.d")
+    assertParseVersionFails("1.2.3+build..1")
+    assertParseVersionFails("1.2.3+bad_meta")
+    assertParseVersionFails("1.2.3-rc+bad_meta")
 }

--- a/examples/selfhost-core/semver_req_test.osty
+++ b/examples/selfhost-core/semver_req_test.osty
@@ -69,3 +69,55 @@ fn testSemverReqPrereleaseGoldenCases() {
     let preRange = caretReq(prerelease1(1, 2, 3, preText("alpha")))
     assertReqMatch(preRange, prerelease2(1, 2, 3, preText("alpha"), preNumber(1)))
 }
+
+fn testSemverReqAnyMatchesStableOnly() {
+    let any = anySemReq()
+    assertReqMatch(any, stableVersion(0, 0, 0))
+    assertReqMatch(any, stableVersion(99, 1, 2))
+    assertReqMiss(any, prerelease1(1, 0, 0, preText("alpha")))
+}
+
+fn testSemverReqBoundedConjunctionExamples() {
+    let req = boundedReq(stableVersion(1, 4, 0), stableVersion(1, 6, 0))
+
+    assertReqMiss(req, stableVersion(1, 3, 9))
+    assertReqMatch(req, stableVersion(1, 4, 0))
+    assertReqMatch(req, stableVersion(1, 5, 9))
+    assertReqMiss(req, stableVersion(1, 6, 0))
+}
+
+fn testSemverReqMaxMatchingSkipsPrereleasesByDefault() {
+    let versions = [
+        prerelease1(2, 0, 0, preText("alpha")),
+        stableVersion(1, 9, 9),
+        stableVersion(1, 8, 0),
+    ]
+    let best = maxMatchingVersion(atLeastReq(stableVersion(1, 0, 0)), versions)
+
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, stableVersion(1, 9, 9)), 0)
+}
+
+fn testSemverReqMaxMatchingCanSelectPrereleaseWhenRequested() {
+    let req = exactReq(prerelease1(2, 0, 0, preText("alpha")))
+    let versions = [
+        stableVersion(1, 9, 9),
+        prerelease1(2, 0, 0, preText("alpha")),
+        prerelease1(2, 0, 0, preText("beta")),
+    ]
+    let best = maxMatchingVersion(req, versions)
+
+    testing.assert(best.found)
+    testing.assertEq(compareSemVersion(best.version, prerelease1(2, 0, 0, preText("alpha"))), 0)
+}
+
+fn testSemverReqMaxMatchingReportsNoMatch() {
+    let versions = [
+        stableVersion(0, 9, 0),
+        stableVersion(2, 0, 0),
+    ]
+    let best = maxMatchingVersion(wildcardMinorReq(1, 4), versions)
+
+    testing.assert(!(best.found))
+    testing.assertEq(compareSemVersion(best.version, stableVersion(0, 0, 0)), 0)
+}

--- a/examples/selfhost-core/semver_test.osty
+++ b/examples/selfhost-core/semver_test.osty
@@ -39,3 +39,51 @@ fn testSemverIgnoresBuildMetadata() {
     let b = versionWithBuild(1, 0, 0, "build.2")
     testing.assertEq(compareSemVersion(a, b), 0)
 }
+
+fn testSemverConstructorsExposePrereleaseSlots() {
+    let v = semVersion(
+        2,
+        3,
+        4,
+        preText("rc"),
+        preNumber(2),
+        preText("hotfix"),
+        "build.9",
+    )
+
+    testing.assertEq(v.major, 2)
+    testing.assertEq(v.minor, 3)
+    testing.assertEq(v.patch, 4)
+    testing.assertEq(v.build, "build.9")
+    testing.assert(isSemPrerelease(v))
+    testing.assertEq(comparePreIdent(v.pre1, preText("rc")), 0)
+    testing.assertEq(comparePreIdent(v.pre2, preNumber(2)), 0)
+    testing.assertEq(comparePreIdent(v.pre3, preText("hotfix")), 0)
+}
+
+fn testSemverOrdersShorterPrereleaseBeforeLongerPrefix() {
+    let alpha = prerelease1(1, 0, 0, preText("alpha"))
+    let alpha0 = prerelease2(1, 0, 0, preText("alpha"), preNumber(0))
+    let alpha0Build = semVersion(1, 0, 0, preText("alpha"), preNumber(0), preText("build"), "")
+
+    testing.assertEq(compareSemVersion(alpha, alpha0), -1)
+    testing.assertEq(compareSemVersion(alpha0, alpha0Build), -1)
+    testing.assertEq(comparePreIdent(preNone(), preNumber(1)), -1)
+}
+
+fn testSemverOrdersNumericPrereleaseBeforeText() {
+    testing.assertEq(comparePreIdent(preNumber(10), preText("alpha")), -1)
+    testing.assertEq(comparePreIdent(preText("alpha"), preNumber(10)), 1)
+    testing.assertEq(comparePreIdent(preText("alpha"), preText("beta")), -1)
+    testing.assertEq(comparePreIdent(preText("rc"), preText("rc")), 0)
+}
+
+fn testSemverComparisonHelpersAreThreeWay() {
+    testing.assertEq(signInt(1, 2), -1)
+    testing.assertEq(signInt(2, 1), 1)
+    testing.assertEq(signInt(2, 2), 0)
+
+    testing.assertEq(signString("alpha", "beta"), -1)
+    testing.assertEq(signString("beta", "alpha"), 1)
+    testing.assertEq(signString("rc", "rc"), 0)
+}

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -232,28 +232,57 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 // owner / enum-type / method-name maps. Keeps the emit path branch-free
 // by having direct lookups available.
 func (g *gen) indexTypes() {
+	g.indexScopeTypes()
 	for _, d := range g.file.Decls {
 		switch d := d.(type) {
 		case *ast.EnumDecl:
-			g.enumTypes[d.Name] = true
-			for _, v := range d.Variants {
-				g.variantOwner[v.Name] = d.Name
-			}
-			if g.methodNames[d.Name] == nil {
-				g.methodNames[d.Name] = map[string]bool{}
-			}
-			for _, m := range d.Methods {
-				g.methodNames[d.Name][m.Name] = true
-			}
+			g.indexEnumDecl(d)
 		case *ast.StructDecl:
-			g.structTypes[d.Name] = true
-			if g.methodNames[d.Name] == nil {
-				g.methodNames[d.Name] = map[string]bool{}
-			}
-			for _, m := range d.Methods {
-				g.methodNames[d.Name][m.Name] = true
+			g.indexStructDecl(d)
+		}
+	}
+}
+
+func (g *gen) indexScopeTypes() {
+	if g.res == nil || g.res.FileScope == nil {
+		return
+	}
+	for scope := g.res.FileScope; scope != nil; scope = scope.Parent() {
+		for _, sym := range scope.Symbols() {
+			switch sym.Kind {
+			case resolve.SymEnum:
+				if decl, ok := sym.Decl.(*ast.EnumDecl); ok {
+					g.indexEnumDecl(decl)
+				}
+			case resolve.SymStruct:
+				if decl, ok := sym.Decl.(*ast.StructDecl); ok {
+					g.indexStructDecl(decl)
+				}
 			}
 		}
+	}
+}
+
+func (g *gen) indexEnumDecl(e *ast.EnumDecl) {
+	g.enumTypes[e.Name] = true
+	for _, v := range e.Variants {
+		g.variantOwner[v.Name] = e.Name
+	}
+	if g.methodNames[e.Name] == nil {
+		g.methodNames[e.Name] = map[string]bool{}
+	}
+	for _, m := range e.Methods {
+		g.methodNames[e.Name][m.Name] = true
+	}
+}
+
+func (g *gen) indexStructDecl(s *ast.StructDecl) {
+	g.structTypes[s.Name] = true
+	if g.methodNames[s.Name] == nil {
+		g.methodNames[s.Name] = map[string]bool{}
+	}
+	for _, m := range s.Methods {
+		g.methodNames[s.Name][m.Name] = true
 	}
 }
 

--- a/internal/testgen/testgen.go
+++ b/internal/testgen/testgen.go
@@ -119,6 +119,7 @@ func GenerateHarness(pkg *resolve.Package, chk *check.Result, entries []Entry) (
 	seenRange := false
 	seenOstyStringer := false
 	seenOstyToString := false
+	seenOstyEqualRuntime := map[string]bool{}
 	var firstGenErr error
 	hasProgramMain := packageHasProgramMain(pkg)
 
@@ -188,6 +189,12 @@ func GenerateHarness(pkg *resolve.Package, chk *check.Result, entries []Entry) (
 				}
 				seenOstyToString = true
 			}
+			if name := ostyEqualRuntimeName(d); name != "" {
+				if seenOstyEqualRuntime[name] {
+					continue
+				}
+				seenOstyEqualRuntime[name] = true
+			}
 			if isTestingStub(d) {
 				// Dropped — replaced by the runtime in harness.go.
 				continue
@@ -256,6 +263,28 @@ func isOstyStringerRuntime(d goast.Decl) bool {
 func isOstyToStringRuntime(d goast.Decl) bool {
 	fn, ok := d.(*goast.FuncDecl)
 	return ok && fn.Recv == nil && fn.Name != nil && fn.Name.Name == "ostyToString"
+}
+
+func ostyEqualRuntimeName(d goast.Decl) string {
+	switch d := d.(type) {
+	case *goast.FuncDecl:
+		if d.Recv != nil || d.Name == nil {
+			return ""
+		}
+		switch d.Name.Name {
+		case "ostyEqual", "ostyEqualValue", "ostyIsNilValue":
+			return d.Name.Name
+		}
+	case *goast.GenDecl:
+		if d.Tok != gotoken.TYPE || len(d.Specs) != 1 {
+			return ""
+		}
+		ts, ok := d.Specs[0].(*goast.TypeSpec)
+		if ok && ts.Name != nil && ts.Name.Name == "ostyEqualVisit" {
+			return ts.Name.Name
+		}
+	}
+	return ""
 }
 
 // isRangeRuntime reports whether d is the Range struct gen emits


### PR DESCRIPTION
## Summary
- add broad example-style tests to selfhost-core and mirror them in dogfood
- fix dogfood parser example issues surfaced by the expanded harness
- teach gen/testgen to handle cross-file enum variants and dedupe equality runtime helpers

## Tests
- go test -count=1 ./internal/examples
- go test -count=1 ./internal/testgen
- go test -count=1 ./internal/gen -run 'TestEnumBareVariant|TestEnumTupleVariant|TestCLIResultViaCheck'\n- ./osty fmt --check on added/updated example test files\n- git diff --check