### PR TITLE
Implement pure Osty AST dogfood parser

### DIFF
--- a/examples/dogfood/parser.osty
+++ b/examples/dogfood/parser.osty
@@ -254,8 +254,10 @@ fn opErrorCount(p: OstyParser) -> Int {
 
 fn opTruncateErrors(p: OstyParser, target: Int) {
     let mut cur = opErrorCount(p)
-    for cur > target { p.arena.errors.pop()
-    cur = cur - 1 }
+    for cur > target {
+        let _ = p.arena.errors.pop()
+        cur = cur - 1
+    }
 }
 
 // ===================================================================
@@ -628,7 +630,11 @@ fn opParseIfExpr(p: OstyParser) -> Int {
     let thenBlock = opParseBlock(p)
     let mut elseIdx = -1
     if opEat(p, FrontElse) {
-        if opAt(p, FrontIf) { elseIdx = opParseIfExpr(p) } else { elseIdx = opParseBlock(p) }
+        if opAt(p, FrontIf) {
+            elseIdx = opParseIfExpr(p)
+        } else {
+            elseIdx = opParseBlock(p)
+        }
     } else if opPeekPastNewlines(p).kind == FrontElse {
         opErrorFull(p, "`else` must be on the same line as `\}`", "move `else` to the same line: `\} else \{`", "v0.2 O2: `\} else` must sit on the same line", "E0201")
     }
@@ -644,7 +650,7 @@ fn opParseIfExpr(p: OstyParser) -> Int {
 
 fn opParseMatchExpr(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let prevNoSL = p.noStructLit
     p.noStructLit = true
     let scrutinee = opParseExpr(p)
@@ -656,12 +662,14 @@ fn opParseMatchExpr(p: OstyParser) -> Int {
         let armStart = p.pos
         let pat = opParsePattern(p)
         let mut guard = -1
-        if opAt(p, FrontIf) { opAdvance(p)
-        let pv = p.noStructLit
-        p.noStructLit = true
-        guard = opParseExpr(p)
-        p.noStructLit = pv }
-        opExpect(p, FrontArrow)
+        if opAt(p, FrontIf) {
+            let _ = opAdvance(p)
+            let pv = p.noStructLit
+            p.noStructLit = true
+            guard = opParseExpr(p)
+            p.noStructLit = pv
+        }
+        let _ = opExpect(p, FrontArrow)
         let body = opParseExpr(p)
         let mut armNode = emptyAstNode(AstNMatchArm)
         armNode.left = pat
@@ -685,12 +693,14 @@ fn opParseMatchExpr(p: OstyParser) -> Int {
 
 fn opParseClosure(p: OstyParser) -> Int {
     let start = p.pos
-    if opEat(p, FrontOr) { let body = opParseClosureBody(p, false)
-    let mut n = emptyAstNode(AstNClosure)
-    n.left = body
-    n.start = start
-    n.end = p.pos
-    return opAddNode(p, n) }
+    if opEat(p, FrontOr) {
+        let body = opParseClosureBody(p, false)
+        let mut n = emptyAstNode(AstNClosure)
+        n.left = body
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
     let _ = opExpect(p, FrontBitOr)
     let mut params: List<Int> = []
     for !(opAt(p, FrontBitOr)) && !(opAt(p, FrontEOF)) {
@@ -735,37 +745,42 @@ fn opParseClosureBody(p: OstyParser, requireBlock: Bool) -> Int {
 
 fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
     let tok = opPeek(p)
-    if tok.kind == FrontDot { let s = p.pos
-    let _ = opAdvance(p)
-    let nm = opAdvance(p).text
-    let mut n = emptyAstNode(AstNField)
-    n.left = lhs
-    n.text = nm
-    n.start = s
-    n.end = p.pos
-    return opAddNode(p, n) }
-    if tok.kind == FrontQDot { let s = p.pos
-    let _ = opAdvance(p)
-    let nm = opAdvance(p).text
-    let mut n = emptyAstNode(AstNField)
-    n.left = lhs
-    n.text = nm
-    n.flags = 1
-    n.start = s
-    n.end = p.pos
-    return opAddNode(p, n) }
+    if tok.kind == FrontDot {
+        let s = p.pos
+        let _ = opAdvance(p)
+        let nm = opAdvance(p).text
+        let mut n = emptyAstNode(AstNField)
+        n.left = lhs
+        n.text = nm
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontQDot {
+        let s = p.pos
+        let _ = opAdvance(p)
+        let nm = opAdvance(p).text
+        let mut n = emptyAstNode(AstNField)
+        n.left = lhs
+        n.text = nm
+        n.flags = 1
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
     if tok.kind == FrontLParen { return opParseCallArgs(p, lhs) }
     if tok.kind == FrontLBracket { return opParseIndex(p, lhs) }
-    if tok.kind == FrontQuestion { let s = p.pos
-    let _ = opAdvance(p)
-    let mut n = emptyAstNode(AstNQuestion)
-    n.left = lhs
-    n.start = s
-    n.end = p.pos
-    return opAddNode(p, n) }
+    if tok.kind == FrontQuestion {
+        let s = p.pos
+        let _ = opAdvance(p)
+        let mut n = emptyAstNode(AstNQuestion)
+        n.left = lhs
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
     if tok.kind == FrontColonColon && opPeekAt(p, 1).kind == FrontLt { return opParseTurbofish(p, lhs) }
-    let canStructLit = tok.kind == FrontLBrace && !(p.noStructLit)
-    if canStructLit {
+    if tok.kind == FrontLBrace && !(p.noStructLit) && lhs >= 0 {
         let leftNode = astArenaNodeAt(p.arena, lhs)
         if leftNode.kind == AstNIdent && astIsUpperName(leftNode.text) { return opParseStructLit(p, lhs) }
     }
@@ -774,7 +789,7 @@ fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
 
 fn opParseCallArgs(p: OstyParser, callee: Int) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut args: List<Int> = []
     opSkipNewlines(p)
     for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
@@ -798,9 +813,9 @@ fn opParseCallArgs(p: OstyParser, callee: Int) -> Int {
 
 fn opParseIndex(p: OstyParser, object: Int) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let index = opParseExpr(p)
-    opExpect(p, FrontRBracket)
+    let _ = opExpect(p, FrontRBracket)
     let mut n = emptyAstNode(AstNIndex)
     n.left = object
     n.right = index
@@ -811,12 +826,12 @@ fn opParseIndex(p: OstyParser, object: Int) -> Int {
 
 fn opParseTurbofish(p: OstyParser, callee: Int) -> Int {
     let start = p.pos
-    opAdvance(p)
-    opAdvance(p)
+    let _ = opAdvance(p)
+    let _ = opAdvance(p)
     let mut typeArgs: List<Int> = []
     for !(opAt(p, FrontGt)) && !(opAt(p, FrontEOF)) { typeArgs.push(opParseType(p))
     if !(opEat(p, FrontComma)) { break } }
-    opExpect(p, FrontGt)
+    let _ = opExpect(p, FrontGt)
     let mut n = emptyAstNode(AstNTurbofish)
     n.left = callee
     n.children = typeArgs
@@ -827,16 +842,18 @@ fn opParseTurbofish(p: OstyParser, callee: Int) -> Int {
 
 fn opParseStructLit(p: OstyParser, name: Int) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut fields: List<Int> = []
     let mut spreadIdx = -1
     opSkipNewlines(p)
     for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
-        if opAt(p, FrontDotDot) { opAdvance(p)
-        spreadIdx = opParseExpr(p)
-        opSkipNewlines(p)
-        opEat(p, FrontComma)
-        break }
+        if opAt(p, FrontDotDot) {
+            let _ = opAdvance(p)
+            spreadIdx = opParseExpr(p)
+            opSkipNewlines(p)
+            let _ = opEat(p, FrontComma)
+            break
+        }
         let fs = p.pos
         let fn_ = opAdvance(p).text
         let mut valIdx = -1
@@ -851,7 +868,7 @@ fn opParseStructLit(p: OstyParser, name: Int) -> Int {
         if !(opEat(p, FrontComma)) { break }
         opSkipNewlines(p)
     }
-    opExpect(p, FrontRBrace)
+    let _ = opExpect(p, FrontRBrace)
     let mut n = emptyAstNode(AstNStructLit)
     n.left = name
     n.right = spreadIdx
@@ -877,7 +894,7 @@ fn opParseStmt(p: OstyParser) -> Int {
     if tok.kind == FrontReturn { return opParseReturnStmt(p) }
     if tok.kind == FrontBreak {
         let s = p.pos
-        opAdvance(p)
+        let _ = opAdvance(p)
         if !(p.inLoop) { opErrorFull(p, "`break` outside of loop", "move inside a `for` loop", "", "E0100") }
         let mut n = emptyAstNode(AstNBreak)
         n.start = s
@@ -886,7 +903,7 @@ fn opParseStmt(p: OstyParser) -> Int {
     }
     if tok.kind == FrontContinue {
         let s = p.pos
-        opAdvance(p)
+        let _ = opAdvance(p)
         if !(p.inLoop) { opErrorFull(p, "`continue` outside of loop", "move inside a `for` loop", "", "E0101") }
         let mut n = emptyAstNode(AstNContinue)
         n.start = s
@@ -898,7 +915,7 @@ fn opParseStmt(p: OstyParser) -> Int {
     let expr = opParseExpr(p)
     let next = opPeek(p)
     if next.kind == FrontChanArrow { let s = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let v = opParseExpr(p)
     let mut n = emptyAstNode(AstNChanSend)
     n.left = expr
@@ -907,7 +924,7 @@ fn opParseStmt(p: OstyParser) -> Int {
     n.end = p.pos
     return opAddNode(p, n) }
     if frontIsAssignOp(next.kind) { let s = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let v = opParseExpr(p)
     let mut n = emptyAstNode(AstNAssign)
     n.left = expr
@@ -925,7 +942,7 @@ fn opParseStmt(p: OstyParser) -> Int {
 
 fn opParseLetStmt(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut isMut = false
     if opEat(p, FrontMut) { isMut = true }
     let pat = opParsePattern(p)
@@ -945,7 +962,7 @@ fn opParseLetStmt(p: OstyParser) -> Int {
 
 fn opParseReturnStmt(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut valueIdx = -1
     if !(opAt(p, FrontNewline)) && !(opAt(p, FrontEOF)) && !(opAt(p, FrontRBrace)) { valueIdx = opParseExpr(p) }
     let mut n = emptyAstNode(AstNReturn)
@@ -957,7 +974,7 @@ fn opParseReturnStmt(p: OstyParser) -> Int {
 
 fn opParseDeferStmt(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let expr = opParseExpr(p)
     let mut n = emptyAstNode(AstNDefer)
     n.left = expr
@@ -968,7 +985,7 @@ fn opParseDeferStmt(p: OstyParser) -> Int {
 
 fn opParseForStmt(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let prevInLoop = p.inLoop
     p.inLoop = true
     let mut kind = "infinite"
@@ -977,9 +994,9 @@ fn opParseForStmt(p: OstyParser) -> Int {
     let mut iterIdx = -1
     if opAt(p, FrontLBrace) { kind = "infinite" } else if opAt(p, FrontLet) {
         kind = "forlet"
-        opAdvance(p)
+        let _ = opAdvance(p)
         patIdx = opParsePattern(p)
-        opExpect(p, FrontAssign)
+        let _ = opExpect(p, FrontAssign)
         let pv = p.noStructLit
         p.noStructLit = true
         condIdx = opParseExpr(p)
@@ -990,7 +1007,7 @@ fn opParseForStmt(p: OstyParser) -> Int {
         let expr = opParseExpr(p)
         p.noStructLit = pv
         if opAt(p, FrontIdent) && opPeek(p).text == "in" {
-            opAdvance(p)
+            let _ = opAdvance(p)
             kind = "forin"
             patIdx = expr
             let pv2 = p.noStructLit
@@ -1359,10 +1376,10 @@ fn opParseFnDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
 
 fn opParseStructDecl(p: OstyParser, isPub: Bool) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let name = opExpect(p, FrontIdent).text
     let genericParams = opParseGenericParams(p)
-    opExpect(p, FrontLBrace)
+    let _ = opExpect(p, FrontLBrace)
     let mut members: List<Int> = []
     opSkipNewlines(p)
     for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
@@ -1390,10 +1407,10 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool) -> Int {
             let _ = opAdvance(p)
         }
         opSkipNewlines(p)
-        opEat(p, FrontComma)
+        let _ = opEat(p, FrontComma)
         opSkipNewlines(p)
     }
-    opExpect(p, FrontRBrace)
+    let _ = opExpect(p, FrontRBrace)
     let mut n = emptyAstNode(AstNStructDecl)
     n.text = name
     n.children = members
@@ -1406,10 +1423,10 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool) -> Int {
 
 fn opParseEnumDecl(p: OstyParser, isPub: Bool) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let name = opExpect(p, FrontIdent).text
     let genericParams = opParseGenericParams(p)
-    opExpect(p, FrontLBrace)
+    let _ = opExpect(p, FrontLBrace)
     let mut members: List<Int> = []
     opSkipNewlines(p)
     for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
@@ -1436,10 +1453,10 @@ fn opParseEnumDecl(p: OstyParser, isPub: Bool) -> Int {
             let _ = opAdvance(p)
         }
         opSkipNewlines(p)
-        opEat(p, FrontComma)
+        let _ = opEat(p, FrontComma)
         opSkipNewlines(p)
     }
-    opExpect(p, FrontRBrace)
+    let _ = opExpect(p, FrontRBrace)
     let mut n = emptyAstNode(AstNEnumDecl)
     n.text = name
     n.children = members
@@ -1452,12 +1469,12 @@ fn opParseEnumDecl(p: OstyParser, isPub: Bool) -> Int {
 
 fn opParseInterfaceDecl(p: OstyParser, isPub: Bool) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let name = opExpect(p, FrontIdent).text
     let mut supers: List<Int> = []
     if opEat(p, FrontColon) { for { supers.push(opParseType(p))
     if !(opEat(p, FrontComma)) && !(opEat(p, FrontPlus)) { break } } }
-    opExpect(p, FrontLBrace)
+    let _ = opExpect(p, FrontLBrace)
     let mut members: List<Int> = []
     opSkipNewlines(p)
     for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
@@ -1485,10 +1502,10 @@ fn opParseInterfaceDecl(p: OstyParser, isPub: Bool) -> Int {
 
 fn opParseTypeAliasDecl(p: OstyParser, isPub: Bool) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let name = opExpect(p, FrontIdent).text
     let genericParams = opParseGenericParams(p)
-    opExpect(p, FrontAssign)
+    let _ = opExpect(p, FrontAssign)
     let typeIdx = opParseType(p)
     let mut n = emptyAstNode(AstNTypeAlias)
     n.text = name
@@ -1502,7 +1519,7 @@ fn opParseTypeAliasDecl(p: OstyParser, isPub: Bool) -> Int {
 
 fn opParseUseDecl(p: OstyParser) -> Int {
     let start = p.pos
-    opAdvance(p)
+    let _ = opAdvance(p)
     let mut path: List<String> = []
     let mut isGo = false
     let mut alias = ""

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -2508,6 +2508,29 @@ fn name(c: Color) -> String {
 	assertOK(t, runCheck(t, src))
 }
 
+func TestCheck_QualifiedEnumVariants(t *testing.T) {
+	src := `
+pub enum Jsonish {
+    Null,
+    String(String),
+}
+
+fn main() {
+    let a: Jsonish = Jsonish.String("osty")
+    let b: Jsonish = Jsonish.Null
+    let shown: String = match a {
+        Jsonish.String(s) -> s,
+        Jsonish.Null -> "null",
+    }
+    let empty: Bool = match b {
+        Jsonish.Null -> true,
+        Jsonish.String(_) -> false,
+    }
+}
+`
+	assertOK(t, runCheck(t, src))
+}
+
 func TestCheck_MatchNonExhaustiveEnum(t *testing.T) {
 	src := `
 pub enum Color { Red, Green, Blue }

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -403,6 +403,11 @@ func (c *checker) callType(e *ast.CallExpr, hint types.Type, env *env) types.Typ
 			return t
 		}
 	}
+	if fx, ok := e.Fn.(*ast.FieldExpr); ok {
+		if t, handled := c.tryEnumVariantCall(fx, e, hint, env); handled {
+			return t
+		}
+	}
 	// Concurrency intrinsics: `thread.chan::<T>(cap)` → Channel<T>,
 	// `thread.spawn(f)` → Handle<T>. The generator lowers these to Go
 	// primitives; here we only need the checker to agree on the type so
@@ -2453,78 +2458,105 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 				return types.ErrorType
 			}
 		}
-		// Pull type arguments from a matching hint first so the same
-		// enum's variants flow concrete args naturally:
-		//     let r: Result<Int, Error> = Ok(5)   // 5 is Int
-		var tArgs []types.Type
-		if n, ok := types.AsNamed(hint); ok && n.Sym == desc.Sym && len(n.Args) == len(desc.Generics) {
-			tArgs = n.Args
-		} else {
-			// Fresh argument slot per generic; we'll refine while
-			// checking each payload arg.
-			tArgs = make([]types.Type, len(desc.Generics))
-			for i := range tArgs {
-				tArgs[i] = nil
-			}
-		}
-
-		// Check argument count.
-		fields := info.VariantFields
-		if len(e.Args) != len(fields) {
-			c.errNode(e, diag.CodeVariantShape,
-				"variant `%s` takes %d payload value(s), got %d",
-				sym.Name, len(fields), len(e.Args))
-		}
-		// Check each argument. If the field type is a TypeVar, try to
-		// infer it from the argument's actual type.
-		sub := map[*resolve.Symbol]types.Type{}
-		for i, g := range desc.Generics {
-			if i < len(tArgs) && tArgs[i] != nil {
-				sub[g.Sym] = tArgs[i]
-			}
-		}
-		for i, a := range e.Args {
-			var ft types.Type
-			if i < len(fields) {
-				ft = fields[i]
-				if len(sub) > 0 {
-					ft = substituteTypeVars(ft, sub)
-				}
-			}
-			at := c.checkExpr(a.Value, ft, env)
-			if i < len(fields) {
-				inferFromArg(fields[i], at, sub)
-			}
-			if ft != nil && !types.IsError(ft) && !c.accepts(ft, at, a.Value) {
-				c.errMismatch(a.Value, ft, at)
-			}
-		}
-		// Materialize the concrete type-argument list: hint wins, then
-		// inferred; generics we couldn't pin stay as TypeVars to avoid
-		// synthesizing wrong concrete types.
-		finalArgs := make([]types.Type, len(desc.Generics))
-		for i, g := range desc.Generics {
-			if t, ok := sub[g.Sym]; ok && t != nil {
-				finalArgs[i] = t
-				continue
-			}
-			if i < len(tArgs) && tArgs[i] != nil {
-				finalArgs[i] = tArgs[i]
-				continue
-			}
-			finalArgs[i] = g
-		}
-		// Untyped fallbacks: if we inferred an untyped int/float for a
-		// generic, default it rather than leaking the Untyped marker.
-		for i, t := range finalArgs {
-			if u, ok := t.(*types.Untyped); ok {
-				finalArgs[i] = u.Default()
-			}
-		}
-		return &types.Named{Sym: desc.Sym, Args: finalArgs}
+		return c.variantCtorType(desc, sym.Name, info.VariantFields, e, hint, env)
 	}
 
 	return nil
+}
+
+func (c *checker) tryEnumVariantCall(fx *ast.FieldExpr, e *ast.CallExpr, hint types.Type, env *env) (types.Type, bool) {
+	desc, vd, ok := c.enumVariantField(fx)
+	if !ok {
+		return nil, false
+	}
+	if vd.Sym != nil {
+		c.warnIfDeprecated(vd.Sym, fx.PosV)
+	}
+	c.warnIfVariantDeprecated(vd, fx.PosV)
+	return c.variantCtorType(desc, vd.Name, vd.Fields, e, hint, env), true
+}
+
+func (c *checker) enumVariantField(fx *ast.FieldExpr) (*typeDesc, *variantDesc, bool) {
+	id, ok := fx.X.(*ast.Ident)
+	if !ok {
+		return nil, nil, false
+	}
+	sym := c.symbol(id)
+	if sym == nil || sym.Kind != resolve.SymEnum {
+		return nil, nil, false
+	}
+	desc, ok := c.result.Descs[sym]
+	if !ok || desc == nil || desc.Kind != resolve.SymEnum {
+		return nil, nil, false
+	}
+	vd, ok := desc.Variants[fx.Name]
+	if !ok {
+		return nil, nil, false
+	}
+	return desc, vd, true
+}
+
+func (c *checker) variantCtorType(desc *typeDesc, name string, fields []types.Type, e *ast.CallExpr, hint types.Type, env *env) types.Type {
+	// Pull type arguments from a matching hint first so the same enum's
+	// variants flow concrete args naturally:
+	//     let r: Result<Int, Error> = Ok(5)   // 5 is Int
+	var tArgs []types.Type
+	if n, ok := types.AsNamed(hint); ok && n.Sym == desc.Sym && len(n.Args) == len(desc.Generics) {
+		tArgs = n.Args
+	} else {
+		// Fresh argument slot per generic; we'll refine while checking
+		// each payload arg.
+		tArgs = make([]types.Type, len(desc.Generics))
+		for i := range tArgs {
+			tArgs[i] = nil
+		}
+	}
+
+	if len(e.Args) != len(fields) {
+		c.errNode(e, diag.CodeVariantShape,
+			"variant `%s` takes %d payload value(s), got %d",
+			name, len(fields), len(e.Args))
+	}
+	sub := map[*resolve.Symbol]types.Type{}
+	for i, g := range desc.Generics {
+		if i < len(tArgs) && tArgs[i] != nil {
+			sub[g.Sym] = tArgs[i]
+		}
+	}
+	for i, a := range e.Args {
+		var ft types.Type
+		if i < len(fields) {
+			ft = fields[i]
+			if len(sub) > 0 {
+				ft = substituteTypeVars(ft, sub)
+			}
+		}
+		at := c.checkExpr(a.Value, ft, env)
+		if i < len(fields) {
+			inferFromArg(fields[i], at, sub)
+		}
+		if ft != nil && !types.IsError(ft) && !c.accepts(ft, at, a.Value) {
+			c.errMismatch(a.Value, ft, at)
+		}
+	}
+	finalArgs := make([]types.Type, len(desc.Generics))
+	for i, g := range desc.Generics {
+		if t, ok := sub[g.Sym]; ok && t != nil {
+			finalArgs[i] = t
+			continue
+		}
+		if i < len(tArgs) && tArgs[i] != nil {
+			finalArgs[i] = tArgs[i]
+			continue
+		}
+		finalArgs[i] = g
+	}
+	for i, t := range finalArgs {
+		if u, ok := t.(*types.Untyped); ok {
+			finalArgs[i] = u.Default()
+		}
+	}
+	return &types.Named{Sym: desc.Sym, Args: finalArgs}
 }
 
 // inferFromArg populates `sub` when `field` is a TypeVar and `arg` is
@@ -2572,6 +2604,9 @@ func inferFromArg(field, arg types.Type, sub map[*resolve.Symbol]types.Type) {
 // ---- Field / index ----
 
 func (c *checker) fieldType(fx *ast.FieldExpr, hint types.Type, env *env) types.Type {
+	if _, vd, ok := c.enumVariantField(fx); ok && vd.Sym != nil {
+		return c.symTypeOrError(vd.Sym)
+	}
 	recvT := c.checkExpr(fx.X, nil, env)
 	if types.IsError(recvT) {
 		return types.ErrorType

--- a/internal/check/stmt.go
+++ b/internal/check/stmt.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"strings"
+
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
@@ -657,16 +659,30 @@ func (c *checker) bindVariantPattern(p *ast.VariantPat, t types.Type, env *env) 
 	// falling back to scope lookup for bare names like `Red`.
 	var varSym *resolve.Symbol
 	var enumDesc *typeDesc
-	if n, ok := types.AsNamed(t); ok {
-		if desc, ok := c.result.Descs[n.Sym]; ok && desc.Kind == resolve.SymEnum {
-			if v, found := desc.Variants[head]; found {
-				enumDesc = desc
-				varSym = v.Sym
+	variantName := head
+	if len(p.Path) >= 2 {
+		if sym := c.topLevelSym(p.Path[len(p.Path)-2]); sym != nil && sym.Kind == resolve.SymEnum {
+			if desc, ok := c.result.Descs[sym]; ok && desc != nil && desc.Kind == resolve.SymEnum {
+				if vd, found := desc.Variants[p.Path[len(p.Path)-1]]; found {
+					enumDesc = desc
+					variantName = vd.Name
+					varSym = vd.Sym
+				}
 			}
 		}
 	}
 	if varSym == nil {
-		if sym := c.topLevelSym(head); sym != nil && sym.Kind == resolve.SymVariant {
+		if n, ok := types.AsNamed(t); ok {
+			if desc, ok := c.result.Descs[n.Sym]; ok && desc.Kind == resolve.SymEnum {
+				if v, found := desc.Variants[variantName]; found {
+					enumDesc = desc
+					varSym = v.Sym
+				}
+			}
+		}
+	}
+	if varSym == nil {
+		if sym := c.topLevelSym(variantName); sym != nil && sym.Kind == resolve.SymVariant {
 			varSym = sym
 			if info := c.info(sym); info != nil {
 				enumDesc = info.Enum
@@ -679,7 +695,7 @@ func (c *checker) bindVariantPattern(p *ast.VariantPat, t types.Type, env *env) 
 		// overrides). At this point we couldn't resolve it; emit a
 		// diagnostic only when the scrutinee isn't already Error.
 		if !types.IsError(t) {
-			c.errNode(p, diag.CodeUnknownVariant, "unknown variant `%s`", head)
+			c.errNode(p, diag.CodeUnknownVariant, "unknown variant `%s`", strings.Join(p.Path, "."))
 		}
 		for _, a := range p.Args {
 			c.bindPatternTypes(a, types.ErrorType, env)
@@ -695,13 +711,13 @@ func (c *checker) bindVariantPattern(p *ast.VariantPat, t types.Type, env *env) 
 		if n.Sym != enumDesc.Sym && !types.IsError(t) {
 			c.errNode(p, diag.CodeTypeMismatch,
 				"variant `%s` belongs to enum `%s`, not `%s`",
-				head, enumDesc.Sym.Name, n.Sym.Name)
+				variantName, enumDesc.Sym.Name, n.Sym.Name)
 		}
 	}
 	if len(p.Args) != len(info.VariantFields) {
 		c.errNode(p, diag.CodeVariantShape,
 			"variant `%s` takes %d payload pattern(s), got %d",
-			head, len(info.VariantFields), len(p.Args))
+			variantName, len(info.VariantFields), len(p.Args))
 		return
 	}
 	// Apply scrutinee's type-arg substitutions to variant fields.

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -666,8 +666,8 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 				v := b[i]
 				return &v
 			},
-			equal:       stdbytes.Equal,
-			contains:    stdbytes.Contains,
+			equal:       bytesEqual,
+			contains:    bytesContains,
 			startsWith:  stdbytes.HasPrefix,
 			endsWith:    stdbytes.HasSuffix,
 			indexOf: func(b []byte, sub []byte) *int {
@@ -694,16 +694,10 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			trimRight:  func(b []byte, strip []byte) []byte { return stdbytes.TrimRight(b, string(strip)) },
 			trim:       func(b []byte, strip []byte) []byte { return stdbytes.Trim(b, string(strip)) },
 			trimSpace:  stdbytes.TrimSpace,
-			toUpper:    stdbytes.ToUpper,
+			toUpper:    bytesToUpper,
 			toLower:    stdbytes.ToLower,
 			toHex:      _ostybyteshex.EncodeToString,
-			fromHex: func(s string) Result[[]byte, any] {
-				b, err := _ostybyteshex.DecodeString(s)
-				if err != nil {
-					return resultErr[[]byte, any](err)
-				}
-				return resultOk[[]byte, any](b)
-			},
+			fromHex: bytesFromHex,
 		}`, full)
 		return true
 	case "csv":

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -439,7 +439,14 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 	if g.emitStdlibJSONCall(c) {
 		return
 	}
+	if g.emitStdlibIterCall(c) {
+		return
+	}
 	if f, ok := c.Fn.(*ast.FieldExpr); ok {
+		if owner, variant, ok := g.qualifiedVariant(f); ok {
+			g.emitVariantCtor(owner, variant, c.Args)
+			return
+		}
 		if g.emitQualifiedOptionCall(c, f) {
 			return
 		}
@@ -450,6 +457,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 			return
 		}
 		if g.emitStdlibRefCall(c, f) {
+			return
+		}
+		if g.emitStdlibRegexCall(c, f) {
 			return
 		}
 		if g.emitStdlibEncodingCall(c, f) {
@@ -1038,6 +1048,77 @@ func (g *gen) emitStdlibHelperCall(helper string, args []*ast.Arg) {
 	g.body.write(")")
 }
 
+func (g *gen) emitStdlibRegexCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "regex") || f.Name != "compile" {
+		return false
+	}
+	if len(c.Args) != 1 {
+		return false
+	}
+	g.needRegex = true
+	g.needResult = true
+	g.body.write("regexCompile(")
+	g.emitExpr(c.Args[0].Value)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitStdlibIterCall(c *ast.CallExpr) bool {
+	base := c.Fn
+	var explicit []ast.Type
+	if tf, ok := base.(*ast.TurbofishExpr); ok {
+		base = tf.Base
+		explicit = tf.Args
+	}
+	id, parts, ok := stdlibFieldChain(base)
+	if !ok || id == nil || len(parts) != 1 || !g.isStdlibPackageAlias(id, "iter") {
+		return false
+	}
+	switch parts[0] {
+	case "range":
+		if len(c.Args) != 2 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]int")
+		g.body.writef("func() %s { ", retGo)
+		start := g.freshVar("_start")
+		stop := g.freshVar("_stop")
+		g.body.writef("%s := ", start)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; %s := ", stop)
+		g.emitExpr(c.Args[1].Value)
+		g.body.writef("; out := make(%s, 0); for i := %s; i < %s; i++ { out = append(out, i) }; return out }()", retGo, start, stop)
+		return true
+	case "from":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]any")
+		g.emitCollectionIIFE(retGo, c.Args[0].Value, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.writeln("return out")
+		})
+		return true
+	case "empty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, iterExplicitListGo(g, explicit))
+		g.body.writef("make(%s, 0)", retGo)
+		return true
+	}
+	return false
+}
+
+func iterExplicitListGo(g *gen, explicit []ast.Type) string {
+	if len(explicit) == 1 {
+		return "[]" + g.goTypeExpr(explicit[0])
+	}
+	return "[]any"
+}
+
 func (g *gen) stdlibCallPath(c *ast.CallExpr, module string) ([]string, bool) {
 	id, parts, ok := stdlibFieldChain(c.Fn)
 	if !ok || id == nil || len(parts) == 0 {
@@ -1448,7 +1529,7 @@ func (g *gen) emitCollectionMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		return false
 	}
 	switch n.Sym.Name {
-	case "List":
+	case "List", "Iter":
 		return g.emitListMethod(c, f, n)
 	case "Map":
 		return g.emitMapMethod(c, f, n)
@@ -1480,6 +1561,13 @@ func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) 
 		g.body.write("(len(")
 		g.emitExpr(f.X)
 		g.body.write(") == 0)")
+	case "count":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
 	case "iter":
 		if len(c.Args) != 0 {
 			return false
@@ -1726,6 +1814,32 @@ func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) 
 			g.body.writef("out := make(%s, %s)\n", retGo, limit)
 			g.body.writef("copy(out, %s[:%s])\n", xs, limit)
 			g.body.writeln("return out")
+		})
+	case "takeWhile":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			pred := g.freshVar("_pred")
+			g.body.writef("%s := ", pred)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, xs)
+			g.body.writef("for _, v := range %s { if !%s(v) { break }; out = append(out, v) }\n", xs, pred)
+			g.body.writeln("return out")
+		})
+	case "forEach":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("struct{}", f.X, func(xs string) {
+			fn := g.freshVar("_fn")
+			g.body.writef("%s := ", fn)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { %s(v) }\n", xs, fn)
+			g.body.writeln("return struct{}{}")
 		})
 	case "toSet":
 		if len(c.Args) != 0 {
@@ -2321,6 +2435,24 @@ func (g *gen) emitVariantCtor(owner, name string, args []*ast.Arg) {
 	g.body.write("})")
 }
 
+func (g *gen) qualifiedVariant(f *ast.FieldExpr) (owner, variant string, ok bool) {
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+	owner = id.Name
+	if owner == "Self" {
+		owner = g.selfType
+	}
+	if owner == "" || !g.enumTypes[owner] {
+		return "", "", false
+	}
+	if got, found := g.variantOwner[f.Name]; !found || got != owner {
+		return "", "", false
+	}
+	return owner, f.Name, true
+}
+
 // emitStaticCall rewrites `TypeName.fnName(args)` as `TypeName_fnName(args)`
 // when TypeName is a struct or enum declared in this file. `Self.new(...)`
 // inside a method body also flows here. Returns false when the head does
@@ -2446,29 +2578,6 @@ func (g *gen) resultTypeArgsAt(callType types.Type, payloadType types.Type, isEr
 
 // emitBuiltinCall handles prelude intrinsics. Returns true when it
 // produced output; false lets the generic path take over.
-// isBytesType reports whether t is the Bytes builtin type.
-func isBytesType(t types.Type) bool {
-	n, ok := t.(*types.Named)
-	return ok && n.Sym != nil && n.Sym.Kind == resolve.SymBuiltin && n.Sym.Name == "Bytes"
-}
-
-// emitPrintArgList emits arguments for print/println, wrapping Bytes values
-// with string(...) so they display as text rather than raw byte slices.
-func (g *gen) emitPrintArgList(args []*ast.Arg) {
-	for i, a := range args {
-		if i > 0 {
-			g.body.write(", ")
-		}
-		if isBytesType(g.typeOf(a.Value)) {
-			g.body.write("string(")
-			g.emitExpr(a.Value)
-			g.body.write(")")
-		} else {
-			g.emitExpr(a.Value)
-		}
-	}
-}
-
 func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) bool {
 	switch name {
 	case "println":
@@ -2486,15 +2595,21 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 	case "eprintln":
 		g.use("fmt")
 		g.use("os")
-		g.body.write("fmt.Fprintln(os.Stderr, ")
-		g.emitPrintArgList(args)
+		g.body.write("fmt.Fprintln(os.Stderr")
+		if len(args) > 0 {
+			g.body.write(", ")
+			g.emitPrintArgList(args)
+		}
 		g.body.write(")")
 		return true
 	case "eprint":
 		g.use("fmt")
 		g.use("os")
-		g.body.write("fmt.Fprint(os.Stderr, ")
-		g.emitCallArgList(args)
+		g.body.write("fmt.Fprint(os.Stderr")
+		if len(args) > 0 {
+			g.body.write(", ")
+			g.emitPrintArgList(args)
+		}
 		g.body.write(")")
 		return true
 	case "dbg":
@@ -2641,6 +2756,20 @@ func (g *gen) emitCallArgList(args []*ast.Arg) {
 			g.body.write(", ")
 		}
 		g.emitExpr(a.Value)
+	}
+}
+
+func (g *gen) emitPrintArgList(args []*ast.Arg) {
+	if len(args) > 0 {
+		g.needStringRuntime = true
+	}
+	for i, a := range args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.write("ostyToString(")
+		g.emitExpr(a.Value)
+		g.body.write(")")
 	}
 }
 
@@ -3020,6 +3149,10 @@ func (g *gen) emitQuestion(q *ast.QuestionExpr) {
 // Field-type lookup comes from the checker when available.
 func (g *gen) emitField(f *ast.FieldExpr) {
 	if !f.IsOptional {
+		if owner, variant, ok := g.qualifiedVariant(f); ok {
+			g.body.writef("%s(&%s_%s{})", owner, owner, variant)
+			return
+		}
 		if g.emitQualifiedOptionField(f) {
 			return
 		}

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -39,6 +39,28 @@ func GenerateMapped(pkgName string, file *ast.File, res *resolve.Result, chk *ch
 	return g.run()
 }
 
+// PackageIndex supplements file-local codegen knowledge with declarations
+// from sibling files in the same Osty package. Most callers generate one
+// source file in isolation and should use Generate/GenerateMapped; package
+// harnesses that merge several generated files can pass this index so
+// cross-file enum variants and methods lower the same way as local ones.
+type PackageIndex struct {
+	VariantOwner map[string]string
+	EnumTypes    map[string]bool
+	StructTypes  map[string]bool
+	MethodNames  map[string]map[string]bool
+}
+
+// GenerateMappedWithIndex is GenerateMapped with package-local declaration
+// metadata supplied by the caller. The index must contain only declarations
+// from the package being generated, not imported stdlib/workspace packages.
+func GenerateMappedWithIndex(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result, sourcePath string, idx PackageIndex) ([]byte, error) {
+	g := newGen(pkgName, file, res, chk)
+	g.sourcePath = sourcePath
+	g.applyPackageIndex(idx)
+	return g.run()
+}
+
 // gen is the transpiler state for one file.
 type gen struct {
 	pkgName string
@@ -286,6 +308,28 @@ func (g *gen) indexStructDecl(s *ast.StructDecl) {
 	}
 }
 
+func (g *gen) applyPackageIndex(idx PackageIndex) {
+	for name, owner := range idx.VariantOwner {
+		if _, ok := g.variantOwner[name]; !ok {
+			g.variantOwner[name] = owner
+		}
+	}
+	for name := range idx.EnumTypes {
+		g.enumTypes[name] = true
+	}
+	for name := range idx.StructTypes {
+		g.structTypes[name] = true
+	}
+	for typeName, methods := range idx.MethodNames {
+		if g.methodNames[typeName] == nil {
+			g.methodNames[typeName] = map[string]bool{}
+		}
+		for methodName := range methods {
+			g.methodNames[typeName][methodName] = true
+		}
+	}
+}
+
 // use records a Go import with no alias (bare `import "path"`). A
 // subsequent useAs for the same path overrides with an alias; a
 // bare use after an alias leaves the alias intact.
@@ -385,6 +429,7 @@ func (g *gen) run() ([]byte, error) {
 	}
 	if g.needRegex {
 		g.needResult = true
+		g.use("fmt")
 		g.useAs("unicode/utf8", "utf8")
 	}
 	if g.needEncoding {
@@ -832,6 +877,129 @@ func jsonParseValue(data []byte) (Json, error) {
 	return value, nil
 }
 
+func jsonStringifyValue(value Json) string { return jsonEncode(value) }
+
+func jsonParseValueResult(text string) Result[Json, any] {
+	value, err := jsonParseValue([]byte(text))
+	if err != nil {
+		return resultErr[Json, any](err)
+	}
+	return resultOk[Json, any](value)
+}
+
+func jsonIsNullVal(value Json) bool { return value == nil }
+
+func jsonIsBoolVal(value Json) bool {
+	_, ok := value.(bool)
+	return ok
+}
+
+func jsonIsNumberVal(value Json) bool {
+	switch value.(type) {
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return true
+	default:
+		return false
+	}
+}
+
+func jsonIsStringVal(value Json) bool {
+	_, ok := value.(string)
+	return ok
+}
+
+func jsonIsArrayVal(value Json) bool {
+	_, ok := value.([]Json)
+	return ok
+}
+
+func jsonIsObjectVal(value Json) bool {
+	_, ok := value.(map[string]Json)
+	return ok
+}
+
+func jsonAsBoolResult(value Json) Result[bool, any] {
+	if v, ok := value.(bool); ok {
+		return resultOk[bool, any](v)
+	}
+	return resultErr[bool, any](fmt.Sprintf("std.json: expected Bool, got %T", value))
+}
+
+func jsonAsNumberResult(value Json) Result[float64, any] {
+	switch v := value.(type) {
+	case float64:
+		return resultOk[float64, any](v)
+	case float32:
+		return resultOk[float64, any](float64(v))
+	case int:
+		return resultOk[float64, any](float64(v))
+	case int8:
+		return resultOk[float64, any](float64(v))
+	case int16:
+		return resultOk[float64, any](float64(v))
+	case int32:
+		return resultOk[float64, any](float64(v))
+	case int64:
+		return resultOk[float64, any](float64(v))
+	case uint:
+		return resultOk[float64, any](float64(v))
+	case uint8:
+		return resultOk[float64, any](float64(v))
+	case uint16:
+		return resultOk[float64, any](float64(v))
+	case uint32:
+		return resultOk[float64, any](float64(v))
+	case uint64:
+		return resultOk[float64, any](float64(v))
+	default:
+		return resultErr[float64, any](fmt.Sprintf("std.json: expected Number, got %T", value))
+	}
+}
+
+func jsonAsStringResult(value Json) Result[string, any] {
+	if v, ok := value.(string); ok {
+		return resultOk[string, any](v)
+	}
+	return resultErr[string, any](fmt.Sprintf("std.json: expected String, got %T", value))
+}
+
+func jsonAsArrayResult(value Json) Result[[]Json, any] {
+	if v, ok := value.([]Json); ok {
+		return resultOk[[]Json, any](v)
+	}
+	return resultErr[[]Json, any](fmt.Sprintf("std.json: expected Array, got %T", value))
+}
+
+func jsonAsObjectResult(value Json) Result[map[string]Json, any] {
+	if v, ok := value.(map[string]Json); ok {
+		return resultOk[map[string]Json, any](v)
+	}
+	return resultErr[map[string]Json, any](fmt.Sprintf("std.json: expected Object, got %T", value))
+}
+
+func jsonGetFieldResult(value Json, key string) Result[Json, any] {
+	obj, ok := value.(map[string]Json)
+	if !ok {
+		return resultErr[Json, any](fmt.Sprintf("std.json: expected Object, got %T", value))
+	}
+	field, ok := obj[key]
+	if !ok {
+		return resultErr[Json, any](fmt.Sprintf("std.json: missing field %q", key))
+	}
+	return resultOk[Json, any](field)
+}
+
+func jsonGetIndexResult(value Json, index int) Result[Json, any] {
+	arr, ok := value.([]Json)
+	if !ok {
+		return resultErr[Json, any](fmt.Sprintf("std.json: expected Array, got %T", value))
+	}
+	if index < 0 || index >= len(arr) {
+		return resultErr[Json, any](fmt.Sprintf("std.json: index %d out of bounds", index))
+	}
+	return resultOk[Json, any](arr[index])
+}
+
 func jsonAsError(value any) error {
 	if err, ok := value.(error); ok {
 		return err
@@ -1123,6 +1291,23 @@ func refInterfaceData(v any) unsafe.Pointer {
 }
 `)
 	}
+	if g.needBytesRuntime {
+		out.WriteString(`
+func bytesEqual(a, b []byte) bool { return stdbytes.Equal(a, b) }
+
+func bytesContains(b, sub []byte) bool { return stdbytes.Contains(b, sub) }
+
+func bytesToUpper(b []byte) []byte { return stdbytes.ToUpper(b) }
+
+func bytesFromHex(s string) Result[[]byte, any] {
+	b, err := _ostybyteshex.DecodeString(s)
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	return resultOk[[]byte, any](b)
+}
+`)
+	}
 	if g.needRandomRuntime {
 		out.WriteString(`
 // Rng is the runtime representation of std.random.Rng.
@@ -1312,7 +1497,7 @@ func (u Url) queryValues(key string) []string {
 `)
 	}
 	if g.needRegex {
-		// TODO: regexRuntime placeholder
+		out.WriteString(regexRuntime)
 	}
 	if g.needEncoding {
 		out.WriteString(`

--- a/internal/gen/phase2_test.go
+++ b/internal/gen/phase2_test.go
@@ -169,6 +169,36 @@ fn main() {
 	}
 }
 
+func TestEnumQualifiedVariant(t *testing.T) {
+	src := `enum Shape {
+    Circle(Int),
+    Empty,
+}
+
+fn main() {
+    let c: Shape = Shape.Circle(3)
+    let e: Shape = Shape.Empty
+    let n = match c {
+        Shape.Circle(v) -> v,
+        Shape.Empty -> 0,
+    }
+    let ok = match e {
+        Shape.Empty -> true,
+        Shape.Circle(_) -> false,
+    }
+    println("{n} {ok}")
+}
+`
+	goSrc, err := transpile(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := runGo(t, goSrc)
+	if strings.TrimSpace(out) != "3 true" {
+		t.Errorf("unexpected output: %q\n--- src ---\n%s", out, goSrc)
+	}
+}
+
 // TestMatchGuard verifies `if guard` on a match arm.
 func TestMatchGuard(t *testing.T) {
 	src := `fn classify(n: Int) -> String {

--- a/internal/gen/regex_runtime.go
+++ b/internal/gen/regex_runtime.go
@@ -664,7 +664,8 @@ func (re Regex) findAll(text string) []RegexMatch {
 	for from := 0; from <= len(chars); {
 		sl, ok := re.runAt(chars, boff, from)
 		if !ok {
-			break
+			from++
+			continue
 		}
 		out = append(out, RegexMatch{text: text[sl[0]:sl[1]], start: sl[0], end: sl[1]})
 		ec := rxByteToChar(boff, sl[1])
@@ -693,7 +694,8 @@ func (re Regex) capturesAll(text string) []Captures {
 	for from := 0; from <= len(chars); {
 		sl, ok := re.runAt(chars, boff, from)
 		if !ok {
-			break
+			from++
+			continue
 		}
 		out = append(out, Captures{slots: sl, text: text, names: re.names})
 		ec := rxByteToChar(boff, sl[1])
@@ -786,7 +788,8 @@ func (re Regex) replaceAll(text, replacement string) string {
 	for from := 0; from <= len(chars); {
 		sl, ok := re.runAt(chars, boff, from)
 		if !ok {
-			break
+			from++
+			continue
 		}
 		out = append(out, text[lastEnd:sl[0]]...)
 		out = append(out, rxApplyRepl(replacement, sl, text, re.names)...)

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -24,7 +24,7 @@ func itoa(n int) string { return strconv.Itoa(n) }
 //	()                          → struct{}
 //	Never                       → struct{} (unreachable placeholder)
 //	T?                          → *T
-//	List<T>                     → []T
+//	List<T>, Iter<T>            → []T
 //	Map<K, V>                   → map[K]V
 //	User-defined Named          → its name verbatim
 //	TypeVar T                   → T
@@ -151,7 +151,7 @@ func (g *gen) goNamedType(n *types.Named) string {
 		return "any"
 	}
 	switch n.Sym.Name {
-	case "List":
+	case "List", "Iter":
 		if len(n.Args) == 1 {
 			return "[]" + g.goType(n.Args[0])
 		}
@@ -351,7 +351,7 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 		return gt
 	}
 	switch name {
-	case "List":
+	case "List", "Iter":
 		if len(n.Args) == 1 {
 			return "[]" + g.goTypeExpr(n.Args[0])
 		}

--- a/internal/stdlib/modules/bytes.osty
+++ b/internal/stdlib/modules/bytes.osty
@@ -88,6 +88,10 @@ pub fn fromString(s: String) -> Bytes {
     fromString(s)
 }
 
+pub fn from(list: List<Byte>) -> Bytes {
+    from(list)
+}
+
 pub fn toString(b: Bytes) -> Result<String, Error> {
     b.toString()
 }

--- a/internal/stdlib/modules/json.osty
+++ b/internal/stdlib/modules/json.osty
@@ -8,6 +8,7 @@
 // real implementation is lowered by the codegen layer via Go's
 // encoding/json package; the value-level stringifyValue/parseValue
 // pair is fully implemented here as a spec-checked reference.
+use std.bytes
 use std.error
 
 // ---------------------------------------------------------------------------
@@ -101,9 +102,9 @@ fn stringifyObject(obj: JsonObject) -> String {
     let entries = obj.entries()
     let len = entries.len()
     if len == 0 {
-        return "{}"
+        return "\{\}"
     }
-    let mut out = "{"
+    let mut out = "\{"
     let mut i = 0
     for i < len {
         let (key, val) = entries[i]
@@ -113,7 +114,7 @@ fn stringifyObject(obj: JsonObject) -> String {
         out = "{out}{escapeJsonString(key)}:{stringifyValue(val)}"
         i = i + 1
     }
-    "{out}}"
+    "{out}\}"
 }
 
 fn escapeJsonString(s: String) -> String {
@@ -150,7 +151,7 @@ fn escapeJsonString(s: String) -> String {
 
 fn hexNibble(n: Int) -> Char {
     let lut = "0123456789abcdef"
-    lut[n & 0x0F]
+    lut[n & 0x0F].toChar()
 }
 
 fn formatJsonNumber(n: Float) -> String {
@@ -246,7 +247,7 @@ fn parseStr(bs: List<Byte>, pos: Int, len: Int) -> Result<(String, Int), Error> 
         let b = bs[i].toInt()
         if b == 0x22 {
             // closing "
-            let result = Bytes.from(buf).toString()?
+            let result = bytes.from(buf).toString()?
             return Ok((result, i + 1))
         }
         if b == 0x5C {
@@ -321,12 +322,13 @@ fn parseHex4(bs: List<Byte>, pos: Int) -> Result<Int, Error> {
     let mut i = 0
     for i < 4 {
         let b = bs[pos + i].toInt()
-        let v = if b >= 0x30 && b <= 0x39 {
-            b - 0x30
+        let mut v = 0
+        if b >= 0x30 && b <= 0x39 {
+            v = b - 0x30
         } else if b >= 0x41 && b <= 0x46 {
-            b - 0x41 + 10
+            v = b - 0x41 + 10
         } else if b >= 0x61 && b <= 0x66 {
-            b - 0x61 + 10
+            v = b - 0x61 + 10
         } else {
             return Err(error.new("json: invalid hex digit in unicode escape"))
         }
@@ -338,19 +340,19 @@ fn parseHex4(bs: List<Byte>, pos: Int) -> Result<Int, Error> {
 
 fn encodeUtf8(buf: List<Byte>, cp: Int) {
     if cp < 0x80 {
-        buf.push(cp)
+        buf.push(cp.toByte().unwrap())
     } else if cp < 0x800 {
-        buf.push(0xC0 | (cp >> 6))
-        buf.push(0x80 | (cp & 0x3F))
+        buf.push((0xC0 | (cp >> 6)).toByte().unwrap())
+        buf.push((0x80 | (cp & 0x3F)).toByte().unwrap())
     } else if cp < 0x10000 {
-        buf.push(0xE0 | (cp >> 12))
-        buf.push(0x80 | ((cp >> 6) & 0x3F))
-        buf.push(0x80 | (cp & 0x3F))
+        buf.push((0xE0 | (cp >> 12)).toByte().unwrap())
+        buf.push((0x80 | ((cp >> 6) & 0x3F)).toByte().unwrap())
+        buf.push((0x80 | (cp & 0x3F)).toByte().unwrap())
     } else {
-        buf.push(0xF0 | (cp >> 18))
-        buf.push(0x80 | ((cp >> 12) & 0x3F))
-        buf.push(0x80 | ((cp >> 6) & 0x3F))
-        buf.push(0x80 | (cp & 0x3F))
+        buf.push((0xF0 | (cp >> 18)).toByte().unwrap())
+        buf.push((0x80 | ((cp >> 12) & 0x3F)).toByte().unwrap())
+        buf.push((0x80 | ((cp >> 6) & 0x3F)).toByte().unwrap())
+        buf.push((0x80 | (cp & 0x3F)).toByte().unwrap())
     }
 }
 
@@ -407,7 +409,7 @@ fn parseNum(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
         numBuf.push(bs[j])
         j = j + 1
     }
-    let numStr = Bytes.from(numBuf).toString()?
+    let numStr = bytes.from(numBuf).toString()?
     let n = numStr.toFloat()?
     Ok((Json.Number(n), i))
 }
@@ -446,7 +448,7 @@ fn parseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
 
 fn parseObj(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
     let mut i = skipWs(bs, pos + 1, len)
-    let mut entries: Map<String, Json> = {}
+    let mut entries: Map<String, Json> = {:}
     if i < len && bs[i].toInt() == 0x7D {
         return Ok((Json.Object(entries), i + 1))
     }
@@ -543,38 +545,38 @@ pub fn isObject(value: Json) -> Bool {
 // Narrowing accessors
 // ---------------------------------------------------------------------------
 
-pub fn asBool(value: Json) -> Bool? {
+pub fn asBool(value: Json) -> Result<Bool, Error> {
     match value {
-        Json.Bool(b) -> Some(b),
-        _ -> None,
+        Json.Bool(b) -> Ok(b),
+        _ -> Err(error.new("json: expected Bool")),
     }
 }
 
-pub fn asNumber(value: Json) -> Float? {
+pub fn asNumber(value: Json) -> Result<Float, Error> {
     match value {
-        Json.Number(n) -> Some(n),
-        _ -> None,
+        Json.Number(n) -> Ok(n),
+        _ -> Err(error.new("json: expected Number")),
     }
 }
 
-pub fn asString(value: Json) -> String? {
+pub fn asString(value: Json) -> Result<String, Error> {
     match value {
-        Json.String(s) -> Some(s),
-        _ -> None,
+        Json.String(s) -> Ok(s),
+        _ -> Err(error.new("json: expected String")),
     }
 }
 
-pub fn asArray(value: Json) -> JsonArray? {
+pub fn asArray(value: Json) -> Result<JsonArray, Error> {
     match value {
-        Json.Array(a) -> Some(a),
-        _ -> None,
+        Json.Array(a) -> Ok(a),
+        _ -> Err(error.new("json: expected Array")),
     }
 }
 
-pub fn asObject(value: Json) -> JsonObject? {
+pub fn asObject(value: Json) -> Result<JsonObject, Error> {
     match value {
-        Json.Object(o) -> Some(o),
-        _ -> None,
+        Json.Object(o) -> Ok(o),
+        _ -> Err(error.new("json: expected Object")),
     }
 }
 
@@ -582,16 +584,16 @@ pub fn asObject(value: Json) -> JsonObject? {
 // Indexed access
 // ---------------------------------------------------------------------------
 
-pub fn getField(obj: Json, key: String) -> Json? {
+pub fn getField(obj: Json, key: String) -> Result<Json, Error> {
     match obj {
-        Json.Object(o) -> o.get(key)?.let(|v| Some(v)),
-        _ -> None,
+        Json.Object(o) -> o.get(key).orError("json: missing field"),
+        _ -> Err(error.new("json: expected Object")),
     }
 }
 
-pub fn getIndex(arr: Json, index: Int) -> Json? {
+pub fn getIndex(arr: Json, index: Int) -> Result<Json, Error> {
     match arr {
-        Json.Array(a) -> a.get(index)?.let(|v| Some(v)),
-        _ -> None,
+        Json.Array(a) -> a.get(index).orError("json: index out of bounds"),
+        _ -> Err(error.new("json: expected Array")),
     }
 }

--- a/internal/stdlib/primitives/int.osty
+++ b/internal/stdlib/primitives/int.osty
@@ -55,6 +55,7 @@ pub struct __IntMethods {
     pub fn toInt32(self) -> Result<Int32, Error> { Ok(0) }
     pub fn toInt64(self) -> Int64 { 0 }
     pub fn toUInt8(self) -> Result<UInt8, Error> { Ok(0) }
+    pub fn toByte(self) -> Result<Byte, Error> { Ok(0) }
     pub fn toUInt16(self) -> Result<UInt16, Error> { Ok(0) }
     pub fn toUInt32(self) -> Result<UInt32, Error> { Ok(0) }
     pub fn toUInt64(self) -> Result<UInt64, Error> { Ok(0) }

--- a/internal/testgen/testgen.go
+++ b/internal/testgen/testgen.go
@@ -89,6 +89,44 @@ type Sources struct {
 	Harness []byte
 }
 
+func genPackageIndex(pkg *resolve.Package) gen.PackageIndex {
+	idx := gen.PackageIndex{
+		VariantOwner: map[string]string{},
+		EnumTypes:    map[string]bool{},
+		StructTypes:  map[string]bool{},
+		MethodNames:  map[string]map[string]bool{},
+	}
+	for _, pf := range pkg.Files {
+		if pf == nil || pf.File == nil {
+			continue
+		}
+		for _, d := range pf.File.Decls {
+			switch d := d.(type) {
+			case *ostyast.EnumDecl:
+				idx.EnumTypes[d.Name] = true
+				if idx.MethodNames[d.Name] == nil {
+					idx.MethodNames[d.Name] = map[string]bool{}
+				}
+				for _, v := range d.Variants {
+					idx.VariantOwner[v.Name] = d.Name
+				}
+				for _, m := range d.Methods {
+					idx.MethodNames[d.Name][m.Name] = true
+				}
+			case *ostyast.StructDecl:
+				idx.StructTypes[d.Name] = true
+				if idx.MethodNames[d.Name] == nil {
+					idx.MethodNames[d.Name] = map[string]bool{}
+				}
+				for _, m := range d.Methods {
+					idx.MethodNames[d.Name][m.Name] = true
+				}
+			}
+		}
+	}
+	return idx
+}
+
 // GenerateHarness produces a Sources bundle for pkg. chk is the
 // per-package check result; entries is the flat list of discovered
 // tests and benchmarks (in declaration order across files).
@@ -122,6 +160,7 @@ func GenerateHarness(pkg *resolve.Package, chk *check.Result, entries []Entry) (
 	seenOstyEqualRuntime := map[string]bool{}
 	var firstGenErr error
 	hasProgramMain := packageHasProgramMain(pkg)
+	pkgIndex := genPackageIndex(pkg)
 
 	for _, pf := range files {
 		if pf.File == nil {
@@ -132,7 +171,7 @@ func GenerateHarness(pkg *resolve.Package, chk *check.Result, entries []Entry) (
 			TypeRefs:  pf.TypeRefs,
 			FileScope: pf.FileScope,
 		}
-		src, gerr := gen.GenerateMapped("main", pf.File, res, chk, pf.Path)
+		src, gerr := gen.GenerateMappedWithIndex("main", pf.File, res, chk, pf.Path, pkgIndex)
 		if gerr != nil && firstGenErr == nil {
 			// Non-fatal: gen returns warnings alongside formatted
 			// source. Remember the first one so the CLI can surface

--- a/internal/testgen/testgen_test.go
+++ b/internal/testgen/testgen_test.go
@@ -103,6 +103,89 @@ func TestGenerateHarness_DedupesResultRuntime(t *testing.T) {
 	}
 }
 
+func TestGenerateHarness_DedupesEqualRuntime(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "a.osty"), []byte(`fn sameA() -> Bool {
+    [1] == [1]
+}
+`))
+	mustWrite(t, filepath.Join(dir, "b.osty"), []byte(`fn sameB() -> Bool {
+    [2] == [2]
+}
+`))
+	mustWrite(t, filepath.Join(dir, "main_test.osty"), []byte(`use std.testing
+
+fn testBoth() {
+    testing.assert(sameA())
+    testing.assert(sameB())
+}
+`))
+	pkg, chk := loadCalc(t, dir)
+
+	srcs, err := GenerateHarness(pkg, chk, nil)
+	if err != nil {
+		t.Fatalf("GenerateHarness: %v", err)
+	}
+	main := string(srcs.Main)
+	for _, needle := range []string{
+		"func ostyEqual(a, b any) bool",
+		"type ostyEqualVisit struct",
+		"func ostyEqualValue(a, b reflect.Value, seen map[ostyEqualVisit]bool) bool",
+		"func ostyIsNilValue(v reflect.Value) bool",
+	} {
+		if count := strings.Count(main, needle); count != 1 {
+			t.Fatalf("expected exactly 1 %q helper, got %d\n%s", needle, count, main)
+		}
+	}
+}
+
+func TestGenerateHarness_CrossFileEnumVariantIndex(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "kind.osty"), []byte(`enum Item {
+    Boxed(Int),
+    Empty,
+}
+`))
+	mustWrite(t, filepath.Join(dir, "use.osty"), []byte(`fn makeItem() -> Item {
+    Boxed(3)
+}
+`))
+	mustWrite(t, filepath.Join(dir, "main_test.osty"), []byte(`use std.testing
+
+fn testCrossFileVariant() {
+    let _ = makeItem()
+    testing.assert(true)
+}
+`))
+	pkg, chk := loadCalc(t, dir)
+
+	srcs, err := GenerateHarness(pkg, chk, []Entry{{
+		Name: "testCrossFileVariant",
+		Kind: KindTest,
+		File: "main_test.osty",
+		Line: 3,
+	}})
+	if err != nil {
+		t.Fatalf("GenerateHarness: %v\n--- main.go ---\n%s", err, srcs.Main)
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go binary not on PATH; skipping end-to-end run")
+	}
+	out := t.TempDir()
+	mustWrite(t, filepath.Join(out, "main.go"), srcs.Main)
+	mustWrite(t, filepath.Join(out, "harness.go"), srcs.Harness)
+	mustWrite(t, filepath.Join(out, "go.mod"), []byte("module ostytest\ngo 1.22\n"))
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = out
+	combined, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("go run failed: %v\n%s\n--- main.go ---\n%s", runErr, combined, srcs.Main)
+	}
+	if want := "1 passed, 0 failed, 1 total"; !strings.Contains(string(combined), want) {
+		t.Fatalf("missing summary %q in:\n%s", want, combined)
+	}
+}
+
 // TestGenerateHarness_StripsTestingStub checks that the no-op `var
 // testing = struct{…}{…}` gen emits for `use std.testing` is removed
 // from the merged output — the runtime in harness.go owns that name


### PR DESCRIPTION
## Summary
- make the pure Osty dogfood AST parser compile and run cleanly
- add package-aware codegen metadata for test harness cross-file enum variants
- fill stdlib bridge gaps for regex/json/iter/bytes uncovered by full gen tests

## Verification
- go test ./...
- go run ./cmd/osty check examples/dogfood
- go run ./cmd/osty test examples/dogfood
- git diff --check