### PR TITLE
Add selfhost linter, resolver, and checker cores

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,8 @@ the compiler evolves.
   lifted out of dogfood so they can grow independently, including the
   runnable lexer scanner, front-end seed models, and broad example-style
   tests for SemVer, registry selection, manifest features, diagnostics,
-  and package archive classification.
+  package archive classification, and Osty-written linter, resolver, and
+  checker cores.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `workspace`: virtual workspace with two member packages and a

--- a/examples/selfhost-core/check.osty
+++ b/examples/selfhost-core/check.osty
@@ -1,0 +1,774 @@
+/// SelfFunctionSig is the checker-facing shape of a resolved function
+/// declaration.
+pub struct SelfFunctionSig {
+    pub name: String,
+    pub returnType: String,
+    pub paramNames: List<String>,
+    pub paramTypes: List<String>,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct SelfTypeBinding {
+    pub name: String,
+    pub typeName: String,
+    pub mutable: Bool,
+}
+
+pub struct SelfCheckDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub name: String,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct SelfCheckResult {
+    pub diagnostics: List<SelfCheckDiagnostic>,
+    pub checkedExpressions: Int,
+    pub assignments: Int,
+    pub errors: Int,
+    pub resolveErrors: Int,
+}
+
+pub fn selfFunctionSig(
+    name: String,
+    returnType: String,
+    paramNames: List<String>,
+    paramTypes: List<String>,
+    start: Int,
+    end: Int,
+) -> SelfFunctionSig {
+    SelfFunctionSig { name, returnType, paramNames, paramTypes, start, end }
+}
+
+pub fn selfTypeBinding(name: String, typeName: String, mutable: Bool) -> SelfTypeBinding {
+    SelfTypeBinding { name, typeName, mutable }
+}
+
+pub fn selfCheckDiagnostic(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfCheckDiagnostic {
+    SelfCheckDiagnostic { code, message, name, start, end }
+}
+
+pub fn emptySelfCheckResult(resolveErrors: Int) -> SelfCheckResult {
+    SelfCheckResult {
+        diagnostics: [],
+        checkedExpressions: 0,
+        assignments: 0,
+        errors: 0,
+        resolveErrors,
+    }
+}
+
+/// selfCheckSource performs a self-hosted resolver pass, then checks primitive
+/// assignment/return/call typing over the same token stream.
+pub fn selfCheckSource(source: String) -> SelfCheckResult {
+    let resolved = selfResolveSource(source)
+    let stream = frontendLexStream(source)
+    let tokens = frontTokensFromSource(source, stream)
+    let count = frontTokenListCount(tokens)
+    let sigs = selfCheckCollectFunctions(tokens, count)
+    let mut result = emptySelfCheckResult(selfResolveDiagnosticCount(resolved))
+    result = selfCheckFunctions(tokens, count, sigs, result)
+    result
+}
+
+pub fn selfCheckDiagnosticCount(result: SelfCheckResult) -> Int {
+    let mut count = 0
+    for diag in result.diagnostics {
+        let _ = diag
+        count = count + 1
+    }
+    count
+}
+
+pub fn selfCheckCodeCount(result: SelfCheckResult, code: String) -> Int {
+    let mut count = 0
+    for diag in result.diagnostics {
+        if diag.code == code {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn selfCheckEmit(
+    result: SelfCheckResult,
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfCheckResult {
+    let mut out = result
+    out.errors = out.errors + 1
+    out.diagnostics.push(selfCheckDiagnostic(code, message, name, start, end))
+    out
+}
+
+fn selfCheckCollectFunctions(tokens: List<FrontToken>, count: Int) -> List<SelfFunctionSig> {
+    let mut sigs: List<SelfFunctionSig> = []
+    let mut skipUntil = -1
+    for idx in 0..count {
+        if idx < skipUntil {
+            let _ = idx
+        } else if scTokenIs(tokens, idx, "fn") && scLooksLikeDeclarationStart(tokens, idx) {
+            let end = frontDeclEnd(tokens, idx, count)
+            let sig = scReadFunctionSig(tokens, idx, end)
+            if sig.name != "" {
+                sigs.push(sig)
+            }
+            skipUntil = end
+        }
+    }
+    sigs
+}
+
+fn scReadFunctionSig(tokens: List<FrontToken>, start: Int, end: Int) -> SelfFunctionSig {
+    let nameIdx = scNextIdent(tokens, start + 1, end)
+    let mut paramNames: List<String> = []
+    let mut paramTypes: List<String> = []
+    let name = if nameIdx < end {
+        frontTokenTextAt(tokens, nameIdx)
+    } else {
+        ""
+    }
+    let open = scFindTopLevelKind(tokens, nameIdx + 1, end, "(")
+    let mut afterParams = nameIdx + 1
+    if open >= 0 {
+        let close = frontFindMatching(tokens, open, end, scKind("("), scKind(")"))
+        afterParams = close + 1
+        for idx in open + 1..close {
+            let kind = frontTokenAtList(tokens, idx).kind
+            if (scKindIs(kind, "IDENT") || scKindIs(kind, "_")) && scLooksLikeParamName(
+                tokens,
+                idx,
+                open,
+            ) {
+                paramNames.push(frontTokenTextAt(tokens, idx))
+                paramTypes.push(scParamType(tokens, idx, close))
+            }
+        }
+    }
+
+    let arrow = scFindFirstKind(tokens, afterParams, end, "->")
+    let returnType = if arrow >= 0 {
+        scTypeNameAt(tokens, arrow + 1, end)
+    } else {
+        "()"
+    }
+    selfFunctionSig(name, returnType, paramNames, paramTypes, start, end)
+}
+
+fn selfCheckFunctions(
+    tokens: List<FrontToken>,
+    count: Int,
+    sigs: List<SelfFunctionSig>,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let mut out = result
+    let mut skipUntil = -1
+    for idx in 0..count {
+        if idx < skipUntil {
+            let _ = idx
+        } else if scTokenIs(tokens, idx, "fn") && scLooksLikeDeclarationStart(tokens, idx) {
+            let end = frontDeclEnd(tokens, idx, count)
+            let sig = scSignatureAt(
+                sigs,
+                frontTokenTextAt(tokens, scNextIdent(tokens, idx + 1, end)),
+            )
+            out = scCheckFunction(tokens, idx, end, sigs, sig, out)
+            skipUntil = end
+        }
+    }
+    out
+}
+
+fn scCheckFunction(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    sig: SelfFunctionSig,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let mut out = result
+    let nameIdx = scNextIdent(tokens, start + 1, end)
+    let open = scFindTopLevelKind(tokens, nameIdx + 1, end, "(")
+    if open < 0 {
+        return out
+    }
+    let close = frontFindMatching(tokens, open, end, scKind("("), scKind(")"))
+    let bodyOpen = scFindTopLevelKind(tokens, close + 1, end, r"{")
+    if bodyOpen < 0 {
+        return out
+    }
+    let bodyClose = frontFindMatching(tokens, bodyOpen, end, scKind(r"{"), scKind(r"}"))
+    let mut locals: List<SelfTypeBinding> = []
+    for idx in 0..scStringListCount(sig.paramNames) {
+        locals.push(
+            selfTypeBinding(scStringAt(sig.paramNames, idx), scStringAt(sig.paramTypes, idx), false),
+        )
+    }
+
+    let mut skipUntil = -1
+    for idx in bodyOpen + 1..bodyClose {
+        if idx < skipUntil {
+            let _ = idx
+        } else if scTokenIs(tokens, idx, "let") {
+            let stmtEnd = frontFindStatementEnd(tokens, idx, bodyClose)
+            out = scCheckLet(tokens, idx, stmtEnd, sigs, locals, out)
+            let nameIdx = scLetNameIndex(tokens, idx)
+            let typ = scLetType(tokens, idx, stmtEnd, sigs, locals)
+            if scTokenIs(tokens, nameIdx, "IDENT") || scTokenIs(tokens, nameIdx, "_") {
+                locals.push(
+                    selfTypeBinding(
+                        frontTokenTextAt(tokens, nameIdx),
+                        typ,
+                        scTokenIs(tokens, idx + 1, "mut"),
+                    ),
+                )
+            }
+            skipUntil = stmtEnd
+        } else if scTokenIs(tokens, idx, "return") {
+            let stmtEnd = frontFindStatementEnd(tokens, idx, bodyClose)
+            out = scCheckReturn(tokens, idx, stmtEnd, sigs, locals, sig.returnType, out)
+            skipUntil = stmtEnd
+        } else if scTokenIs(tokens, idx, "if") {
+            out = scCheckCondition(tokens, idx, bodyClose, sigs, locals, out)
+        } else if scTokenIs(tokens, idx, "for") {
+            out = scCheckCondition(tokens, idx, bodyClose, sigs, locals, out)
+        } else if scTokenIs(tokens, idx + 1, "=") && scTokenIs(tokens, idx, "IDENT") {
+            let stmtEnd = frontFindStatementEnd(tokens, idx, bodyClose)
+            out = scCheckAssignment(tokens, idx, stmtEnd, sigs, locals, out)
+            skipUntil = stmtEnd
+        } else if scTokenIs(tokens, idx, "IDENT") && scTokenIs(
+            tokens,
+            scNextMeaningfulIndex(tokens, idx + 1, bodyClose),
+            "(",
+        ) {
+            out = scCheckCallAt(tokens, idx, bodyClose, sigs, locals, out)
+        }
+    }
+    out
+}
+
+fn scCheckLet(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let mut out = result
+    let nameIdx = scLetNameIndex(tokens, start)
+    let colon = scFindFirstKind(tokens, nameIdx + 1, end, ":")
+    let assign = scFindFirstKind(tokens, nameIdx + 1, end, "=")
+    if assign < 0 {
+        return out
+    }
+    let annotated = if colon >= 0 {
+        scTypeNameAt(tokens, colon + 1, end)
+    } else {
+        ""
+    }
+    let exprType = scInferExpr(tokens, assign + 1, end, sigs, locals)
+    out.checkedExpressions = out.checkedExpressions + 1
+    out.assignments = out.assignments + 1
+    if annotated != "" && !(scAssignable(annotated, exprType)) {
+        out = selfCheckEmit(
+            out,
+            "E0700",
+            "type mismatch in let binding",
+            frontTokenTextAt(tokens, nameIdx),
+            assign + 1,
+            end,
+        )
+    }
+    out
+}
+
+fn scCheckReturn(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+    returnType: String,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let mut out = result
+    let exprStart = scNextMeaningfulIndex(tokens, start + 1, end)
+    let exprType = if exprStart < end {
+        scInferExpr(tokens, exprStart, end, sigs, locals)
+    } else {
+        "()"
+    }
+    out.checkedExpressions = out.checkedExpressions + 1
+    if !(scAssignable(returnType, exprType)) {
+        out = selfCheckEmit(out, "E0726", "return type mismatch", returnType, start, end)
+    }
+    out
+}
+
+fn scCheckAssignment(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let mut out = result
+    let name = frontTokenTextAt(tokens, start)
+    let binding = scBindingAt(locals, name)
+    let exprType = scInferExpr(tokens, start + 2, end, sigs, locals)
+    out.checkedExpressions = out.checkedExpressions + 1
+    out.assignments = out.assignments + 1
+    if binding.name != "" && !(binding.mutable) {
+        out = selfCheckEmit(
+            out,
+            "E0725",
+            "cannot assign into immutable binding",
+            name,
+            start,
+            start + 1,
+        )
+    } else if binding.name != "" && !(scAssignable(binding.typeName, exprType)) {
+        out = selfCheckEmit(out, "E0700", "type mismatch in assignment", name, start + 2, end)
+    }
+    out
+}
+
+fn scCheckCondition(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let block = scFindFirstKind(tokens, start + 1, end, r"{")
+    if block < 0 {
+        return result
+    }
+    let exprType = scInferExpr(tokens, start + 1, block, sigs, locals)
+    if exprType != "Invalid" && !(scAssignable("Bool", exprType)) {
+        selfCheckEmit(result, "E0715", "condition must be Bool", "", start, block)
+    } else {
+        result
+    }
+}
+
+fn scCheckCallAt(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    if scKindIs(scPrevMeaningfulKind(tokens, start), ".") {
+        return result
+    }
+    let name = frontTokenTextAt(tokens, start)
+    let sig = scSignatureAt(sigs, name)
+    if sig.name == "" {
+        return result
+    }
+    let open = scNextMeaningfulIndex(tokens, start + 1, end)
+    if !(scTokenIs(tokens, open, "(")) {
+        return result
+    }
+    let close = frontFindMatching(tokens, open, end, scKind("("), scKind(")"))
+    scCheckCallArgs(tokens, open, close, sigs, locals, sig, result)
+}
+
+fn scCheckCallArgs(
+    tokens: List<FrontToken>,
+    open: Int,
+    close: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+    sig: SelfFunctionSig,
+    result: SelfCheckResult,
+) -> SelfCheckResult {
+    let mut out = result
+    let got = scArgCount(tokens, open, close)
+    let want = scStringListCount(sig.paramTypes)
+    if got != want {
+        return selfCheckEmit(out, "E0701", "call arity mismatch", sig.name, open, close + 1)
+    }
+    let mut argStart = scNextMeaningfulIndex(tokens, open + 1, close)
+    let mut paramIdx = 0
+    let mut depth = 0
+    for idx in argStart..close + 1 {
+        let kind = frontTokenAtList(tokens, idx).kind
+        let atEnd = idx == close
+        if scKindIs(kind, "(") || scKindIs(kind, "[") || scKindIs(kind, r"{") {
+            depth = depth + 1
+        } else if scKindIs(kind, ")") || scKindIs(kind, "]") || scKindIs(kind, r"}") {
+            if depth > 0 && !(atEnd) {
+                depth = depth - 1
+            }
+        }
+        if atEnd || (depth == 0 && scKindIs(kind, ",")) {
+            let argType = scInferExpr(tokens, argStart, idx, sigs, locals)
+            let paramType = scStringAt(sig.paramTypes, paramIdx)
+            out.checkedExpressions = out.checkedExpressions + 1
+            if !(scAssignable(paramType, argType)) {
+                out = selfCheckEmit(out, "E0700", "argument type mismatch", sig.name, argStart, idx)
+            }
+            paramIdx = paramIdx + 1
+            argStart = scNextMeaningfulIndex(tokens, idx + 1, close)
+        }
+    }
+    out
+}
+
+fn scLetType(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+) -> String {
+    let nameIdx = scLetNameIndex(tokens, start)
+    let colon = scFindFirstKind(tokens, nameIdx + 1, end, ":")
+    if colon >= 0 {
+        return scTypeNameAt(tokens, colon + 1, end)
+    }
+    let assign = scFindFirstKind(tokens, nameIdx + 1, end, "=")
+    if assign >= 0 {
+        return scInferExpr(tokens, assign + 1, end, sigs, locals)
+    }
+    "Invalid"
+}
+
+fn scInferExpr(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    sigs: List<SelfFunctionSig>,
+    locals: List<SelfTypeBinding>,
+) -> String {
+    let first = scNextMeaningfulIndex(tokens, start, end)
+    let lastEnd = scTrimEnd(tokens, first, end)
+    if first >= lastEnd {
+        return "()"
+    }
+    if scTokenIs(tokens, first, "(") && frontFindMatching(
+        tokens,
+        first,
+        lastEnd,
+        scKind("("),
+        scKind(")"),
+    ) == lastEnd - 1 {
+        return scInferExpr(tokens, first + 1, lastEnd - 1, sigs, locals)
+    }
+    let op = scFindTopLevelBinary(tokens, first, lastEnd)
+    if op >= 0 {
+        let left = scInferExpr(tokens, first, op, sigs, locals)
+        let right = scInferExpr(tokens, op + 1, lastEnd, sigs, locals)
+        return frontBinaryResultName(
+            frontTokenKindName(frontTokenAtList(tokens, op).kind),
+            left,
+            right,
+        )
+    }
+    let tok = frontTokenAtList(tokens, first)
+    if scKindIs(tok.kind, "INT") || scKindIs(tok.kind, "FLOAT") || scKindIs(tok.kind, "STRING") {
+        return frontInferLiteralName(tok.text)
+    }
+    if scKindIs(tok.kind, "IDENT") && (tok.text == "true" || tok.text == "false") {
+        return "Bool"
+    }
+    if scKindIs(tok.kind, "IDENT") {
+        let next = scNextMeaningfulIndex(tokens, first + 1, lastEnd)
+        if next < lastEnd && scTokenIs(tokens, next, "(") {
+            let sig = scSignatureAt(sigs, tok.text)
+            if sig.name != "" {
+                return sig.returnType
+            }
+        }
+        let binding = scBindingAt(locals, tok.text)
+        if binding.name != "" {
+            return binding.typeName
+        }
+    }
+    "Invalid"
+}
+
+fn scAssignable(dst: String, src: String) -> Bool {
+    if dst == "" || dst == "Invalid" || src == "" || src == "Invalid" {
+        return false
+    }
+    if dst == src {
+        return true
+    }
+    if frontTypeName(frontTypeByName(dst)) != "Invalid" || frontTypeName(frontTypeByName(src)) != "Invalid" {
+        return frontAssignableName(dst, src)
+    }
+    false
+}
+
+fn scFindTopLevelBinary(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    let mut parenDepth = 0
+    let mut bracketDepth = 0
+    let mut braceDepth = 0
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if scKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if scKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if scKindIs(kind, "[") {
+            bracketDepth = bracketDepth + 1
+        } else if scKindIs(kind, "]") {
+            if bracketDepth > 0 {
+                bracketDepth = bracketDepth - 1
+            }
+        } else if scKindIs(kind, r"{") {
+            braceDepth = braceDepth + 1
+        } else if scKindIs(kind, r"}") {
+            if braceDepth > 0 {
+                braceDepth = braceDepth - 1
+            }
+        } else if parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && frontIsBinaryOp(kind) {
+            return idx
+        }
+    }
+    -1
+}
+
+fn scArgCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
+    let first = scNextMeaningfulIndex(tokens, open + 1, close)
+    if first >= close {
+        return 0
+    }
+    let mut count = 1
+    let mut depth = 0
+    for idx in first..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if scKindIs(kind, "(") || scKindIs(kind, "[") || scKindIs(kind, r"{") {
+            depth = depth + 1
+        } else if scKindIs(kind, ")") || scKindIs(kind, "]") || scKindIs(kind, r"}") {
+            if depth > 0 {
+                depth = depth - 1
+            }
+        } else if depth == 0 && scKindIs(kind, ",") {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn scBindingAt(bindings: List<SelfTypeBinding>, name: String) -> SelfTypeBinding {
+    for binding in bindings {
+        if binding.name == name {
+            return binding
+        }
+    }
+    selfTypeBinding("", "Invalid", false)
+}
+
+fn scSignatureAt(sigs: List<SelfFunctionSig>, name: String) -> SelfFunctionSig {
+    for sig in sigs {
+        if sig.name == name {
+            return sig
+        }
+    }
+    selfFunctionSig("", "Invalid", [], [], 0, 0)
+}
+
+fn scStringAt(items: List<String>, target: Int) -> String {
+    let mut idx = 0
+    for item in items {
+        if idx == target {
+            return item
+        }
+        idx = idx + 1
+    }
+    ""
+}
+
+fn scStringListCount(items: List<String>) -> Int {
+    let mut count = 0
+    for item in items {
+        let _ = item
+        count = count + 1
+    }
+    count
+}
+
+fn scParamType(tokens: List<FrontToken>, nameIdx: Int, close: Int) -> String {
+    let colon = scFindFirstKind(tokens, nameIdx + 1, close, ":")
+    if colon >= 0 {
+        return scTypeNameAt(tokens, colon + 1, close)
+    }
+    "Invalid"
+}
+
+fn scTypeNameAt(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let idx = scNextMeaningfulIndex(tokens, start, end)
+    if idx < end {
+        let tok = frontTokenAtList(tokens, idx)
+        if scKindIs(tok.kind, "IDENT") {
+            return tok.text
+        }
+        if scKindIs(tok.kind, "(") && scTokenIs(tokens, idx + 1, ")") {
+            return "()"
+        }
+    }
+    "Invalid"
+}
+
+fn scLetNameIndex(tokens: List<FrontToken>, start: Int) -> Int {
+    let mut idx = start + 1
+    if scTokenIs(tokens, idx, "mut") {
+        idx = idx + 1
+    }
+    idx
+}
+
+fn scKind(name: String) -> FrontTokenKind {
+    frontTokenKindByName(name)
+}
+
+fn scKindIs(kind: FrontTokenKind, name: String) -> Bool {
+    frontTokenKindName(kind) == name
+}
+
+fn scTokenIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
+    scKindIs(frontTokenAtList(tokens, idx).kind, name)
+}
+
+fn scLooksLikeDeclarationStart(tokens: List<FrontToken>, idx: Int) -> Bool {
+    let immediate = scPrevTokenKind(tokens, idx)
+    let prev = scPrevMeaningfulKind(tokens, idx)
+    scKindIs(immediate, "EOF") || scKindIs(immediate, "NEWLINE") || scKindIs(immediate, ";") || scKindIs(
+        prev,
+        "pub",
+    ) || scKindIs(prev, r"{") || scKindIs(prev, r"}")
+}
+
+fn scLooksLikeParamName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
+    let prev = scPrevMeaningfulKindBounded(tokens, idx, open)
+    scKindIs(prev, "(") || scKindIs(prev, ",") || scKindIs(prev, "mut")
+}
+
+fn scNextIdent(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    for idx in start..end {
+        if scTokenIs(tokens, idx, "IDENT") {
+            return idx
+        }
+    }
+    end
+}
+
+fn scFindTopLevelKind(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    target: String,
+) -> Int {
+    let mut parenDepth = 0
+    let mut bracketDepth = 0
+    let mut braceDepth = 0
+    let mut angleDepth = 0
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if scKindIs(kind, target) && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0 {
+            return idx
+        }
+        if scKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if scKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if scKindIs(kind, "[") {
+            bracketDepth = bracketDepth + 1
+        } else if scKindIs(kind, "]") {
+            if bracketDepth > 0 {
+                bracketDepth = bracketDepth - 1
+            }
+        } else if scKindIs(kind, r"{") {
+            braceDepth = braceDepth + 1
+        } else if scKindIs(kind, r"}") {
+            if braceDepth > 0 {
+                braceDepth = braceDepth - 1
+            }
+        } else if scKindIs(kind, "<") {
+            angleDepth = angleDepth + 1
+        } else if scKindIs(kind, ">") {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        }
+    }
+    -1
+}
+
+fn scFindFirstKind(tokens: List<FrontToken>, start: Int, end: Int, target: String) -> Int {
+    for idx in start..end {
+        if scTokenIs(tokens, idx, target) {
+            return idx
+        }
+    }
+    -1
+}
+
+fn scTrimEnd(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    let mut cur = end
+    for cur > start {
+        let kind = frontTokenAtList(tokens, cur - 1).kind
+        if !(scKindIs(kind, "NEWLINE")) && !(scKindIs(kind, ";")) {
+            return cur
+        }
+        cur = cur - 1
+    }
+    start
+}
+
+fn scNextMeaningfulIndex(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if !(scKindIs(kind, "NEWLINE")) && !(scKindIs(kind, ";")) {
+            return idx
+        }
+    }
+    end
+}
+
+fn scPrevMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    scPrevMeaningfulKindBounded(tokens, idx, 0)
+}
+
+fn scPrevTokenKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    if idx <= 0 {
+        return scKind("EOF")
+    }
+    frontTokenAtList(tokens, idx - 1).kind
+}
+
+fn scPrevMeaningfulKindBounded(tokens: List<FrontToken>, idx: Int, floor: Int) -> FrontTokenKind {
+    let mut cur = idx - 1
+    for cur >= floor {
+        let kind = frontTokenAtList(tokens, cur).kind
+        if !(scKindIs(kind, "NEWLINE")) && !(scKindIs(kind, ";")) {
+            return kind
+        }
+        cur = cur - 1
+    }
+    scKind("EOF")
+}

--- a/examples/selfhost-core/check_test.osty
+++ b/examples/selfhost-core/check_test.osty
@@ -1,0 +1,72 @@
+use std.testing
+
+fn testSelfCheckerAcceptsPrimitiveFlow() {
+    let result = selfCheckSource(
+        r"""
+            fn inc(x: Int) -> Int {
+                let next: Int = x + 1
+                return next
+            }
+
+            fn main() {
+                let mut value: Int = inc(1)
+                value = value + 1
+            }
+            """,
+    )
+
+    testing.assertEq(result.resolveErrors, 0)
+    testing.assertEq(selfCheckDiagnosticCount(result), 0)
+    testing.assert(result.checkedExpressions >= 3)
+}
+
+fn testSelfCheckerReportsAssignmentReturnAndConditionErrors() {
+    let result = selfCheckSource(
+        r"""
+            fn bad(flag: Bool) -> Int {
+                let count: Int = "nope"
+                let value: Int = 1
+                value = 2
+                if 1 {}
+                return flag
+            }
+            """,
+    )
+
+    testing.assertEq(result.resolveErrors, 0)
+    testing.assertEq(selfCheckCodeCount(result, "E0700"), 1)
+    testing.assertEq(selfCheckCodeCount(result, "E0725"), 1)
+    testing.assertEq(selfCheckCodeCount(result, "E0715"), 1)
+    testing.assertEq(selfCheckCodeCount(result, "E0726"), 1)
+}
+
+fn testSelfCheckerReportsCallShapeErrors() {
+    let result = selfCheckSource(
+        r"""
+            fn takesInt(value: Int) -> Int {
+                value
+            }
+
+            fn main() {
+                takesInt("bad")
+                takesInt(1, 2)
+            }
+            """,
+    )
+
+    testing.assertEq(result.resolveErrors, 0)
+    testing.assertEq(selfCheckCodeCount(result, "E0700"), 1)
+    testing.assertEq(selfCheckCodeCount(result, "E0701"), 1)
+}
+
+fn testSelfCheckerCarriesResolverErrorCount() {
+    let result = selfCheckSource(
+        r"""
+            fn main() {
+                missing()
+            }
+            """,
+    )
+
+    testing.assert(result.resolveErrors > 0)
+}

--- a/examples/selfhost-core/lint.osty
+++ b/examples/selfhost-core/lint.osty
@@ -1,0 +1,1080 @@
+use go "strings" as strings {
+    fn Contains(s: String, substr: String) -> Bool
+    fn HasPrefix(s: String, prefix: String) -> Bool
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+/// Self-hosted lint rules currently cover unused bindings/imports/mutability,
+/// shadowing, reachability, naming, simple boolean simplifications, and a small
+/// complexity budget. The implementation intentionally consumes the
+/// self-hosting lexer/parser surface rather than Go compiler internals.
+///
+/// SelfLintDiagnostic is the compact warning shape emitted by the Osty-written
+/// self-hosting linter core.
+pub struct SelfLintDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub name: String,
+    pub start: Int,
+    pub end: Int,
+}
+
+/// SelfLintReport carries lint diagnostics plus parse-recovery diagnostics from
+/// the self-hosting front end.
+pub struct SelfLintReport {
+    pub diagnostics: List<SelfLintDiagnostic>,
+    pub parseErrors: Int,
+}
+
+pub fn emptySelfLintReport(parseErrors: Int) -> SelfLintReport {
+    SelfLintReport { diagnostics: [], parseErrors }
+}
+
+pub fn selfLintDiagnostic(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfLintDiagnostic {
+    SelfLintDiagnostic { code, message, name, start, end }
+}
+
+/// selfLintSource runs the self-hosting lexer/parser and emits a conservative
+/// style/correctness lint report from the resulting token stream.
+pub fn selfLintSource(source: String) -> SelfLintReport {
+    let stream = frontendLexStream(source)
+    let tokens = frontTokensFromSource(source, stream)
+    let count = frontTokenListCount(tokens)
+    let tree = frontendParseTree(source)
+    let mut report = emptySelfLintReport(frontParseTreeDiagnosticCount(tree))
+    report = selfLintScanDeclarations(tokens, count, report)
+    report = selfLintScanDeadCode(tokens, count, report)
+    report = selfLintScanSimplify(tokens, count, report)
+    report
+}
+
+pub fn selfLintDiagnosticCount(report: SelfLintReport) -> Int {
+    let mut count = 0
+    for diag in report.diagnostics {
+        let _ = diag
+        count = count + 1
+    }
+    count
+}
+
+pub fn selfLintCodeCount(report: SelfLintReport, code: String) -> Int {
+    let mut count = 0
+    for diag in report.diagnostics {
+        if diag.code == code {
+            count = count + 1
+        }
+    }
+    count
+}
+
+pub fn selfLintFirstDiagnostic(report: SelfLintReport) -> SelfLintDiagnostic {
+    for diag in report.diagnostics {
+        return diag
+    }
+    selfLintDiagnostic("", "", "", 0, 0)
+}
+
+fn selfLintEmit(
+    report: SelfLintReport,
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfLintReport {
+    let mut out = report
+    out.diagnostics.push(selfLintDiagnostic(code, message, name, start, end))
+    out
+}
+
+fn selfLintKind(name: String) -> FrontTokenKind {
+    frontTokenKindByName(name)
+}
+
+fn selfLintKindIs(kind: FrontTokenKind, name: String) -> Bool {
+    frontTokenKindName(kind) == name
+}
+
+fn selfLintTokenIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
+    selfLintKindIs(frontTokenAtList(tokens, idx).kind, name)
+}
+
+fn selfLintLooksLikeDeclarationStart(tokens: List<FrontToken>, idx: Int) -> Bool {
+    let immediate = selfLintPrevTokenKind(tokens, idx)
+    let prev = selfLintPrevMeaningfulKind(tokens, idx)
+    selfLintKindIs(immediate, "EOF") || selfLintKindIs(immediate, "NEWLINE") || selfLintKindIs(
+        immediate,
+        ";",
+    ) || selfLintKindIs(prev, "pub") || selfLintKindIs(prev, r"{") || selfLintKindIs(prev, r"}")
+}
+
+fn selfLintScanDeclarations(
+    tokens: List<FrontToken>,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let mut skipUntil = -1
+    for idx in 0..count {
+        if idx < skipUntil {
+            let _ = idx
+        } else {
+            let kind = frontTokenAtList(tokens, idx).kind
+            if selfLintKindIs(kind, "use") {
+                let consumed = frontParseUseConsumed(tokens, idx, count)
+                let end = idx + consumed
+                if frontUseIsGo(tokens, idx, end) {
+                    skipUntil = end
+                } else {
+                    out = selfLintCheckUse(tokens, idx, end, count, out)
+                }
+            } else if selfLintKindIs(kind, "fn") && selfLintLooksLikeDeclarationStart(tokens, idx) {
+                out = selfLintCheckFunction(tokens, idx, count, out)
+            } else if (selfLintKindIs(kind, "struct") || selfLintKindIs(kind, "interface") || selfLintKindIs(
+                kind,
+                "type",
+            )) && selfLintLooksLikeDeclarationStart(
+                tokens,
+                idx,
+            ) {
+                out = selfLintCheckTypeDecl(tokens, idx, count, out)
+            } else if selfLintKindIs(kind, "enum") && selfLintLooksLikeDeclarationStart(tokens, idx) {
+                out = selfLintCheckTypeDecl(tokens, idx, count, out)
+                out = selfLintCheckEnumVariants(tokens, idx, count, out)
+            } else if selfLintKindIs(kind, "let") {
+                out = selfLintCheckLet(tokens, idx, count, out)
+            }
+        }
+    }
+    out
+}
+
+fn selfLintCheckUse(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let alias = selfLintUseAlias(tokens, start, end)
+    if alias == "" || selfLintIsIntentionalDiscard(alias) {
+        return report
+    }
+    if selfLintCountIdent(tokens, end, count, alias) == 0 {
+        selfLintEmit(report, "L0003", "import is never used", alias, start, end)
+    } else {
+        report
+    }
+}
+
+fn selfLintUseAlias(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let mut last = ""
+    let mut afterAs = false
+    for idx in start + 1..end {
+        let tok = frontTokenAtList(tokens, idx)
+        if selfLintKindIs(tok.kind, "IDENT") {
+            if afterAs {
+                return tok.text
+            }
+            if tok.text == "as" {
+                afterAs = true
+            } else if tok.text != "go" {
+                last = tok.text
+            }
+        }
+    }
+    last
+}
+
+fn selfLintCheckFunction(
+    tokens: List<FrontToken>,
+    start: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let end = frontDeclEnd(tokens, start, count)
+    let nameIdx = selfLintNextIdent(tokens, start + 1, end)
+    if nameIdx < end {
+        let name = frontTokenTextAt(tokens, nameIdx)
+        if !(selfLintIsLowerCamel(name)) {
+            out = selfLintEmit(
+                out,
+                "L0031",
+                "function name should be lowerCamelCase",
+                name,
+                nameIdx,
+                nameIdx + 1,
+            )
+        }
+        out = selfLintCheckGenericParamsAfterName(tokens, nameIdx + 1, end, out)
+    }
+
+    let open = selfLintFindTopLevelKind(tokens, nameIdx + 1, end, "(")
+    if open >= 0 {
+        let close = frontFindMatching(tokens, open, end, selfLintKind("("), selfLintKind(")"))
+        let bodyOpen = selfLintFindTopLevelKind(tokens, close + 1, end, r"{")
+        let mut bodyClose = bodyOpen
+        if bodyOpen >= 0 {
+            bodyClose = frontFindMatching(
+                tokens,
+                bodyOpen,
+                end,
+                selfLintKind(r"{"),
+                selfLintKind(r"}"),
+            )
+        }
+        let isPub = selfLintKindIs(selfLintPrevMeaningfulKind(tokens, start), "pub")
+        out = selfLintCheckParams(tokens, open, close, bodyOpen, bodyClose, isPub, out)
+        if bodyOpen >= 0 {
+            out = selfLintCheckFunctionShadowing(tokens, open, close, bodyOpen, bodyClose, out)
+            out = selfLintCheckFunctionComplexity(tokens, open, close, bodyOpen, bodyClose, out)
+        }
+    }
+    out
+}
+
+fn selfLintCheckTypeDecl(
+    tokens: List<FrontToken>,
+    start: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let end = frontDeclEnd(tokens, start, count)
+    let nameIdx = selfLintNextIdent(tokens, start + 1, end)
+    if nameIdx < end {
+        let name = frontTokenTextAt(tokens, nameIdx)
+        if !(selfLintIsUpperCamel(name)) {
+            out = selfLintEmit(
+                out,
+                "L0030",
+                "type name should be UpperCamelCase",
+                name,
+                nameIdx,
+                nameIdx + 1,
+            )
+        }
+        out = selfLintCheckGenericParamsAfterName(tokens, nameIdx + 1, end, out)
+    }
+    out
+}
+
+fn selfLintCheckGenericParamsAfterName(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    if !(selfLintTokenIs(tokens, start, "<")) {
+        return out
+    }
+    let close = frontFindMatching(tokens, start, end, selfLintKind("<"), selfLintKind(">"))
+    let mut expectName = true
+    let mut angleDepth = 0
+    for idx in start + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, "<") {
+            angleDepth = angleDepth + 1
+        } else if selfLintKindIs(kind, ">") {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        } else if angleDepth == 0 && selfLintKindIs(kind, ",") {
+            expectName = true
+        } else if angleDepth == 0 && expectName && selfLintKindIs(kind, "IDENT") {
+            let name = frontTokenTextAt(tokens, idx)
+            if !(selfLintIsUpperCamel(name)) {
+                out = selfLintEmit(
+                    out,
+                    "L0030",
+                    "generic parameter should be UpperCamelCase",
+                    name,
+                    idx,
+                    idx + 1,
+                )
+            }
+            expectName = false
+        }
+    }
+    out
+}
+
+fn selfLintCheckParams(
+    tokens: List<FrontToken>,
+    open: Int,
+    close: Int,
+    bodyOpen: Int,
+    bodyClose: Int,
+    isPub: Bool,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let mut parenDepth = 0
+    let mut angleDepth = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if selfLintKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if selfLintKindIs(kind, "<") {
+            angleDepth = angleDepth + 1
+        } else if selfLintKindIs(kind, ">") {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        } else if parenDepth == 0 && angleDepth == 0 && (selfLintKindIs(kind, "IDENT") || selfLintKindIs(
+            kind,
+            "_",
+        )) && selfLintLooksLikeParamName(
+            tokens,
+            idx,
+            open,
+        ) {
+            let name = frontTokenTextAt(tokens, idx)
+            if !(selfLintIsIntentionalDiscard(name)) && name != "self" {
+                if !(selfLintIsLowerCamel(name)) {
+                    out = selfLintEmit(
+                        out,
+                        "L0031",
+                        "parameter name should be lowerCamelCase",
+                        name,
+                        idx,
+                        idx + 1,
+                    )
+                }
+                if !(isPub) && bodyOpen >= 0 && selfLintCountIdent(
+                    tokens,
+                    bodyOpen + 1,
+                    bodyClose,
+                    name,
+                ) == 0 {
+                    out = selfLintEmit(out, "L0002", "parameter is never used", name, idx, idx + 1)
+                }
+            }
+        }
+    }
+    out
+}
+
+fn selfLintCheckFunctionShadowing(
+    tokens: List<FrontToken>,
+    open: Int,
+    close: Int,
+    bodyOpen: Int,
+    bodyClose: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let mut names: List<String> = []
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if (selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "_")) && selfLintLooksLikeParamName(
+            tokens,
+            idx,
+            open,
+        ) {
+            let name = frontTokenTextAt(tokens, idx)
+            if !(selfLintIsIntentionalDiscard(name)) && name != "self" {
+                if selfLintStringListContains(names, name) {
+                    out = selfLintEmit(
+                        out,
+                        "L0010",
+                        "binding shadows an earlier binding",
+                        name,
+                        idx,
+                        idx + 1,
+                    )
+                }
+                names.push(name)
+            }
+        }
+    }
+
+    for idx in bodyOpen + 1..bodyClose {
+        if selfLintTokenIs(tokens, idx, "let") {
+            let nameIdx = selfLintLetNameIndex(tokens, idx)
+            let kind = frontTokenAtList(tokens, nameIdx).kind
+            if selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "_") {
+                let name = frontTokenTextAt(tokens, nameIdx)
+                if !(selfLintIsIntentionalDiscard(name)) {
+                    if selfLintStringListContains(names, name) {
+                        out = selfLintEmit(
+                            out,
+                            "L0010",
+                            "binding shadows an earlier binding",
+                            name,
+                            nameIdx,
+                            nameIdx + 1,
+                        )
+                    }
+                    names.push(name)
+                }
+            }
+        }
+    }
+    out
+}
+
+fn selfLintCheckFunctionComplexity(
+    tokens: List<FrontToken>,
+    open: Int,
+    close: Int,
+    bodyOpen: Int,
+    bodyClose: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let params = selfLintParamCount(tokens, open, close)
+    if params > 6 {
+        out = selfLintEmit(out, "L0050", "function takes too many parameters", "", open, close + 1)
+    }
+    let statements = selfLintStatementCount(tokens, bodyOpen, bodyClose)
+    if statements > 40 {
+        out = selfLintEmit(out, "L0052", "function body is too long", "", bodyOpen, bodyClose + 1)
+    }
+    let nesting = selfLintMaxBraceDepth(tokens, bodyOpen, bodyClose)
+    if nesting > 4 {
+        out = selfLintEmit(
+            out,
+            "L0053",
+            "control flow is nested too deeply",
+            "",
+            bodyOpen,
+            bodyClose + 1,
+        )
+    }
+    out
+}
+
+fn selfLintLooksLikeParamName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
+    let prev = selfLintPrevMeaningfulKindBounded(tokens, idx, open)
+    selfLintKindIs(prev, "(") || selfLintKindIs(prev, ",") || selfLintKindIs(prev, "mut")
+}
+
+fn selfLintCheckLet(
+    tokens: List<FrontToken>,
+    start: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let end = frontFindStatementEnd(tokens, start, count)
+    let scopeEnd = selfLintNearestEnclosingBlockEnd(tokens, start, count)
+    let nameIdx = selfLintLetNameIndex(tokens, start)
+    let isMut = selfLintTokenIs(tokens, start + 1, "mut")
+    let kind = frontTokenAtList(tokens, nameIdx).kind
+    if selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "_") {
+        let name = frontTokenTextAt(tokens, nameIdx)
+        if !(selfLintIsIntentionalDiscard(name)) {
+            if !(selfLintIsLowerCamel(name)) {
+                out = selfLintEmit(
+                    out,
+                    "L0031",
+                    "binding name should be lowerCamelCase",
+                    name,
+                    nameIdx,
+                    nameIdx + 1,
+                )
+            }
+            if selfLintCountIdent(tokens, end, scopeEnd, name) == 0 {
+                out = selfLintEmit(
+                    out,
+                    "L0001",
+                    "binding is never used",
+                    name,
+                    nameIdx,
+                    nameIdx + 1,
+                )
+            }
+            if isMut && selfLintCountWrites(tokens, end, scopeEnd, name) == 0 {
+                out = selfLintEmit(
+                    out,
+                    "L0004",
+                    "mutable binding is never reassigned",
+                    name,
+                    start + 1,
+                    nameIdx + 1,
+                )
+            }
+        }
+    }
+    out
+}
+
+fn selfLintLetNameIndex(tokens: List<FrontToken>, start: Int) -> Int {
+    let mut nameIdx = start + 1
+    if selfLintTokenIs(tokens, nameIdx, "mut") {
+        nameIdx = nameIdx + 1
+    }
+    nameIdx
+}
+
+fn selfLintCheckEnumVariants(
+    tokens: List<FrontToken>,
+    start: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let end = frontDeclEnd(tokens, start, count)
+    let open = selfLintFindTopLevelKind(tokens, start + 1, end, r"{")
+    if open < 0 {
+        return out
+    }
+    let close = frontFindMatching(tokens, open, end, selfLintKind(r"{"), selfLintKind(r"}"))
+    let mut parenDepth = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if selfLintKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if parenDepth == 0 && selfLintKindIs(kind, "IDENT") && selfLintLooksLikeVariantName(
+            tokens,
+            idx,
+            open,
+        ) {
+            let name = frontTokenTextAt(tokens, idx)
+            if !(selfLintIsUpperCamel(name)) {
+                out = selfLintEmit(
+                    out,
+                    "L0032",
+                    "enum variant should be UpperCamelCase",
+                    name,
+                    idx,
+                    idx + 1,
+                )
+            }
+        }
+    }
+    out
+}
+
+fn selfLintLooksLikeVariantName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
+    let prev = selfLintPrevMeaningfulKindBounded(tokens, idx, open)
+    let next = frontTokenAtList(tokens, idx + 1).kind
+    (selfLintKindIs(prev, r"{") || selfLintKindIs(prev, ",") || selfLintKindIs(prev, "NEWLINE")) && !(selfLintKindIs(
+        next,
+        ":",
+    ))
+}
+
+fn selfLintScanDeadCode(
+    tokens: List<FrontToken>,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for idx in 0..count {
+        if selfLintTokenIs(tokens, idx, r"{") {
+            let close = frontFindMatching(
+                tokens,
+                idx,
+                count,
+                selfLintKind(r"{"),
+                selfLintKind(r"}"),
+            )
+            out = selfLintCheckBlockDeadCode(tokens, idx, close, out)
+        }
+    }
+    out
+}
+
+fn selfLintCheckBlockDeadCode(
+    tokens: List<FrontToken>,
+    open: Int,
+    close: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let mut depth = 0
+    let mut terminator = -1
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, r"{") {
+            depth = depth + 1
+        } else if selfLintKindIs(kind, r"}") {
+            if depth > 0 {
+                depth = depth - 1
+            }
+        } else if depth == 0 {
+            if terminator >= 0 && selfLintStartsStatement(kind) {
+                return selfLintEmit(out, "L0020", "statement is unreachable", "", idx, idx + 1)
+            }
+            if selfLintKindIs(kind, "return") || selfLintKindIs(kind, "break") || selfLintKindIs(
+                kind,
+                "continue",
+            ) {
+                if selfLintKindIs(kind, "return") && selfLintReturnHasValue(tokens, idx, close) && !(selfLintHasNextStatement(
+                    tokens,
+                    frontFindStatementEnd(
+                        tokens,
+                        idx,
+                        close,
+                    ),
+                    close,
+                )) {
+                    out = selfLintEmit(
+                        out,
+                        "L0024",
+                        "tail return is redundant",
+                        "",
+                        idx,
+                        frontFindStatementEnd(tokens, idx, close),
+                    )
+                }
+                terminator = idx
+            }
+        }
+    }
+    out
+}
+
+fn selfLintStartsStatement(kind: FrontTokenKind) -> Bool {
+    selfLintKindIs(kind, "let") || selfLintKindIs(kind, "return") || selfLintKindIs(kind, "break") || selfLintKindIs(
+        kind,
+        "continue",
+    ) || selfLintKindIs(kind, "for") || selfLintKindIs(kind, "if") || selfLintKindIs(kind, "match") || selfLintKindIs(
+        kind,
+        "defer",
+    ) || selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "INT") || selfLintKindIs(
+        kind,
+        "FLOAT",
+    ) || selfLintKindIs(kind, "STRING") || selfLintKindIs(kind, "RAWSTRING") || selfLintKindIs(
+        kind,
+        "(",
+    ) || selfLintKindIs(kind, "[")
+}
+
+fn selfLintScanSimplify(
+    tokens: List<FrontToken>,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for idx in 1..count - 1 {
+        let kind = frontTokenAtList(tokens, idx).kind
+        let left = frontTokenAtList(tokens, idx - 1)
+        let right = frontTokenAtList(tokens, idx + 1)
+        if selfLintKindIs(kind, "if") {
+            out = selfLintCheckIfSimplify(tokens, idx, count, out)
+        } else if selfLintKindIs(kind, "for") {
+            out = selfLintCheckLoopSimplify(tokens, idx, count, out)
+        } else if selfLintKindIs(kind, "!") && selfLintTokenIs(tokens, idx + 1, "!") {
+            out = selfLintEmit(out, "L0043", "double negation has no effect", "", idx, idx + 2)
+        } else if selfLintKindIs(kind, "!") && selfLintTokenIsBoolLiteral(tokens, idx + 1) {
+            out = selfLintEmit(
+                out,
+                "L0045",
+                "negated bool literal can be simplified",
+                frontTokenTextAt(tokens, idx + 1),
+                idx,
+                idx + 2,
+            )
+        } else if frontIsComparisonOp(kind) && (selfLintTokenIsBoolLiteralToken(left) || selfLintTokenIsBoolLiteralToken(
+            right,
+        )) {
+            out = selfLintEmit(
+                out,
+                "L0044",
+                "comparison against bool literal is redundant",
+                "",
+                idx - 1,
+                idx + 2,
+            )
+        } else if frontIsComparisonOp(kind) && selfLintKindIs(left.kind, "IDENT") && selfLintKindIs(
+            right.kind,
+            "IDENT",
+        ) && left.text == right.text {
+            out = selfLintEmit(
+                out,
+                "L0041",
+                "value is compared with itself",
+                left.text,
+                idx - 1,
+                idx + 2,
+            )
+        } else if selfLintKindIs(kind, "=") && selfLintKindIs(left.kind, "IDENT") && selfLintKindIs(
+            right.kind,
+            "IDENT",
+        ) && left.text == right.text && !(selfLintAssignBelongsToLet(
+            tokens,
+            idx,
+        )) {
+            out = selfLintEmit(
+                out,
+                "L0042",
+                "self-assignment has no effect",
+                left.text,
+                idx - 1,
+                idx + 2,
+            )
+        }
+    }
+    out
+}
+
+fn selfLintCheckIfSimplify(
+    tokens: List<FrontToken>,
+    idx: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    let condIdx = selfLintNextMeaningfulIndex(tokens, idx + 1, count)
+    if selfLintTokenIsBoolLiteral(tokens, condIdx) || (selfLintTokenIs(tokens, condIdx, "!") && selfLintTokenIsBoolLiteral(
+        tokens,
+        selfLintNextMeaningfulIndex(tokens, condIdx + 1, count),
+    )) {
+        out = selfLintEmit(out, "L0022", "condition is constant", "", idx, condIdx + 1)
+    }
+    let open = selfLintFindFirstKind(tokens, idx + 1, count, r"{")
+    if open >= 0 {
+        let close = frontFindMatching(tokens, open, count, selfLintKind(r"{"), selfLintKind(r"}"))
+        if selfLintBlockIsEmpty(tokens, open, close) {
+            out = selfLintEmit(out, "L0023", "if branch is empty", "", open, close + 1)
+        }
+        let after = selfLintNextMeaningfulIndex(tokens, close + 1, count)
+        if selfLintTokenIs(tokens, after, "else") {
+            let elseOpen = selfLintFindFirstKind(tokens, after + 1, count, r"{")
+            if elseOpen >= 0 {
+                let elseClose = frontFindMatching(
+                    tokens,
+                    elseOpen,
+                    count,
+                    selfLintKind(r"{"),
+                    selfLintKind(r"}"),
+                )
+                if selfLintBlockIsEmpty(tokens, elseOpen, elseClose) {
+                    out = selfLintEmit(
+                        out,
+                        "L0023",
+                        "else branch is empty",
+                        "",
+                        elseOpen,
+                        elseClose + 1,
+                    )
+                }
+            }
+        }
+    }
+    out
+}
+
+fn selfLintCheckLoopSimplify(
+    tokens: List<FrontToken>,
+    idx: Int,
+    count: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let open = selfLintFindFirstKind(tokens, idx + 1, count, r"{")
+    if open < 0 {
+        return report
+    }
+    let close = frontFindMatching(tokens, open, count, selfLintKind(r"{"), selfLintKind(r"}"))
+    if selfLintBlockIsEmpty(tokens, open, close) {
+        selfLintEmit(report, "L0026", "loop body is empty", "", open, close + 1)
+    } else {
+        report
+    }
+}
+
+fn selfLintAssignBelongsToLet(tokens: List<FrontToken>, idx: Int) -> Bool {
+    let beforeName = selfLintPrevMeaningfulKindBounded(tokens, idx - 1, 0)
+    selfLintKindIs(beforeName, "let") || selfLintKindIs(beforeName, "mut") || selfLintKindIs(
+        beforeName,
+        ":",
+    )
+}
+
+fn selfLintNextIdent(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    for idx in start..end {
+        if selfLintTokenIs(tokens, idx, "IDENT") {
+            return idx
+        }
+    }
+    end
+}
+
+fn selfLintFindTopLevelKind(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    target: String,
+) -> Int {
+    let mut parenDepth = 0
+    let mut bracketDepth = 0
+    let mut braceDepth = 0
+    let mut angleDepth = 0
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, target) && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0 {
+            return idx
+        }
+        if selfLintKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if selfLintKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if selfLintKindIs(kind, "[") {
+            bracketDepth = bracketDepth + 1
+        } else if selfLintKindIs(kind, "]") {
+            if bracketDepth > 0 {
+                bracketDepth = bracketDepth - 1
+            }
+        } else if selfLintKindIs(kind, r"{") {
+            braceDepth = braceDepth + 1
+        } else if selfLintKindIs(kind, r"}") {
+            if braceDepth > 0 {
+                braceDepth = braceDepth - 1
+            }
+        } else if selfLintKindIs(kind, "<") {
+            angleDepth = angleDepth + 1
+        } else if selfLintKindIs(kind, ">") {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        }
+    }
+    -1
+}
+
+fn selfLintCountIdent(tokens: List<FrontToken>, start: Int, end: Int, name: String) -> Int {
+    let mut count = 0
+    for idx in start..end {
+        let tok = frontTokenAtList(tokens, idx)
+        if selfLintKindIs(tok.kind, "IDENT") && tok.text == name {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn selfLintCountWrites(tokens: List<FrontToken>, start: Int, end: Int, name: String) -> Int {
+    let mut count = 0
+    for idx in start..end {
+        let tok = frontTokenAtList(tokens, idx)
+        if selfLintKindIs(tok.kind, "IDENT") && tok.text == name {
+            let next = selfLintNextMeaningfulIndex(tokens, idx + 1, end)
+            if next < end && frontIsAssignOp(frontTokenAtList(tokens, next).kind) {
+                count = count + 1
+            } else if next < end && selfLintTokenIs(tokens, next, ".") {
+                let method = selfLintNextMeaningfulIndex(tokens, next + 1, end)
+                if method < end && selfLintMutatingMethodName(frontTokenTextAt(tokens, method)) {
+                    count = count + 1
+                }
+            }
+        }
+    }
+    count
+}
+
+fn selfLintMutatingMethodName(name: String) -> Bool {
+    name == "push" || name == "pop" || name == "insert" || name == "remove" || name == "clear" || name == "close" || name == "shuffle"
+}
+
+fn selfLintStringListContains(items: List<String>, target: String) -> Bool {
+    for item in items {
+        if item == target {
+            return true
+        }
+    }
+    false
+}
+
+fn selfLintParamCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
+    let mut count = 0
+    let mut parenDepth = 0
+    let mut angleDepth = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if selfLintKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if selfLintKindIs(kind, "<") {
+            angleDepth = angleDepth + 1
+        } else if selfLintKindIs(kind, ">") {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        } else if parenDepth == 0 && angleDepth == 0 && (selfLintKindIs(kind, "IDENT") || selfLintKindIs(
+            kind,
+            "_",
+        )) && selfLintLooksLikeParamName(
+            tokens,
+            idx,
+            open,
+        ) {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn selfLintStatementCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
+    let mut count = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintStartsStatement(kind) {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn selfLintMaxBraceDepth(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
+    let mut current = 0
+    let mut maxDepth = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintKindIs(kind, r"{") {
+            current = current + 1
+            if current > maxDepth {
+                maxDepth = current
+            }
+        } else if selfLintKindIs(kind, r"}") {
+            if current > 0 {
+                current = current - 1
+            }
+        }
+    }
+    maxDepth
+}
+
+fn selfLintNearestEnclosingBlockEnd(tokens: List<FrontToken>, idx: Int, count: Int) -> Int {
+    let mut depth = 0
+    let mut cur = idx - 1
+    for cur >= 0 {
+        let kind = frontTokenAtList(tokens, cur).kind
+        if selfLintKindIs(kind, r"}") {
+            depth = depth + 1
+        } else if selfLintKindIs(kind, r"{") {
+            if depth == 0 {
+                return frontFindMatching(tokens, cur, count, selfLintKind(r"{"), selfLintKind(r"}"))
+            }
+            depth = depth - 1
+        }
+        cur = cur - 1
+    }
+    count
+}
+
+fn selfLintNextMeaningfulIndex(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if !(selfLintKindIs(kind, "NEWLINE")) && !(selfLintKindIs(kind, ";")) {
+            return idx
+        }
+    }
+    end
+}
+
+fn selfLintFindFirstKind(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    name: String,
+) -> Int {
+    for idx in start..end {
+        if selfLintTokenIs(tokens, idx, name) {
+            return idx
+        }
+    }
+    -1
+}
+
+fn selfLintBlockIsEmpty(tokens: List<FrontToken>, open: Int, close: Int) -> Bool {
+    let next = selfLintNextMeaningfulIndex(tokens, open + 1, close)
+    next >= close
+}
+
+fn selfLintReturnHasValue(tokens: List<FrontToken>, idx: Int, end: Int) -> Bool {
+    let stmtEnd = frontFindStatementEnd(tokens, idx, end)
+    let next = selfLintNextMeaningfulIndex(tokens, idx + 1, stmtEnd)
+    next < stmtEnd
+}
+
+fn selfLintHasNextStatement(tokens: List<FrontToken>, start: Int, end: Int) -> Bool {
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if selfLintStartsStatement(kind) {
+            return true
+        }
+    }
+    false
+}
+
+fn selfLintTokenIsBoolLiteral(tokens: List<FrontToken>, idx: Int) -> Bool {
+    selfLintTokenIsBoolLiteralToken(frontTokenAtList(tokens, idx))
+}
+
+fn selfLintTokenIsBoolLiteralToken(tok: FrontToken) -> Bool {
+    selfLintKindIs(tok.kind, "IDENT") && (tok.text == "true" || tok.text == "false")
+}
+
+fn selfLintPrevMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    selfLintPrevMeaningfulKindBounded(tokens, idx, 0)
+}
+
+fn selfLintPrevTokenKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    if idx <= 0 {
+        return selfLintKind("EOF")
+    }
+    frontTokenAtList(tokens, idx - 1).kind
+}
+
+fn selfLintPrevMeaningfulKindBounded(tokens: List<FrontToken>, idx: Int, floor: Int) -> FrontTokenKind {
+    let mut cur = idx - 1
+    for cur >= floor {
+        let kind = frontTokenAtList(tokens, cur).kind
+        if !(selfLintKindIs(kind, "NEWLINE")) && !(selfLintKindIs(kind, ";")) {
+            return kind
+        }
+        cur = cur - 1
+    }
+    selfLintKind("EOF")
+}
+
+fn selfLintIsIntentionalDiscard(name: String) -> Bool {
+    name == "_" || strings.HasPrefix(name, "_")
+}
+
+fn selfLintIsUpperCamel(name: String) -> Bool {
+    if selfLintIsIntentionalDiscard(name) || strings.Contains(name, "_") {
+        return false
+    }
+    let first = selfLintFirstUnit(name)
+    first >= "A" && first <= "Z"
+}
+
+fn selfLintIsLowerCamel(name: String) -> Bool {
+    if selfLintIsIntentionalDiscard(name) {
+        return true
+    }
+    if strings.Contains(name, "_") {
+        return false
+    }
+    let first = selfLintFirstUnit(name)
+    first >= "a" && first <= "z"
+}
+
+fn selfLintFirstUnit(name: String) -> String {
+    frontUnitAt(strings.Split(name, ""), 0)
+}

--- a/examples/selfhost-core/lint_test.osty
+++ b/examples/selfhost-core/lint_test.osty
@@ -1,0 +1,126 @@
+use std.testing
+
+fn testSelfLintFindsCoreRules() {
+    let report = selfLintSource(
+        r"""
+            struct bad_type {}
+            enum color { red, Green }
+
+            fn BadName(unusedParam: Int, usedParam: Int) -> Int {
+                let unusedValue = 1
+                let usedValue = usedParam
+                return usedValue
+                let afterReturn = 2
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assert(selfLintCodeCount(report, "L0030") >= 2)
+    testing.assert(selfLintCodeCount(report, "L0031") >= 1)
+    testing.assertEq(selfLintCodeCount(report, "L0032"), 1)
+    testing.assertEq(selfLintCodeCount(report, "L0002"), 1)
+    testing.assert(selfLintCodeCount(report, "L0001") >= 1)
+    testing.assertEq(selfLintCodeCount(report, "L0020"), 1)
+}
+
+fn testSelfLintLeavesCleanSnippetAlone() {
+    let report = selfLintSource(
+        r"""
+            pub struct User { pub name: String }
+            enum Color { Red, Green }
+
+            fn add(left: Int, right: Int) -> Int {
+                let total = left + right
+                total
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintDiagnosticCount(report), 0)
+}
+
+fn testSelfLintFindsSimplifiableSelfOperations() {
+    let report = selfLintSource(
+        r"""
+            fn same(x: Int) -> Bool {
+                let mut y = x
+                y = y
+                x == x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0041"), 1)
+    testing.assertEq(selfLintCodeCount(report, "L0042"), 1)
+}
+
+fn testSelfLintFindsImportMutAndShadowingRules() {
+    let report = selfLintSource(
+        r"""
+            use std.testing
+            use std.fmt as fmt
+
+            fn work(value: Int) -> Int {
+                let value = 1
+                let mut neverChanged = value
+                fmt.format("{}", [])
+                value
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    let unusedImport = selfLintCodeCount(report, "L0003")
+    let unusedMut = selfLintCodeCount(report, "L0004")
+    let shadowing = selfLintCodeCount(report, "L0010")
+    if unusedImport != 1 || unusedMut != 1 || shadowing != 1 {
+        testing.fail("counts import={unusedImport} mut={unusedMut} shadow={shadowing}")
+    }
+}
+
+fn testSelfLintFindsControlFlowAndBoolSimplifications() {
+    let report = selfLintSource(
+        r"""
+            fn flow(flag: Bool) -> Bool {
+                if true {}
+                if flag { false } else {}
+                for i in 0..10 {}
+                let same = !!flag
+                let neg = !false
+                let cmp = flag == true
+                return cmp
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0022"), 1)
+    testing.assert(selfLintCodeCount(report, "L0023") >= 2)
+    testing.assertEq(selfLintCodeCount(report, "L0026"), 1)
+    testing.assertEq(selfLintCodeCount(report, "L0024"), 1)
+    testing.assertEq(selfLintCodeCount(report, "L0043"), 1)
+    testing.assertEq(selfLintCodeCount(report, "L0044"), 1)
+    testing.assertEq(selfLintCodeCount(report, "L0045"), 1)
+}
+
+fn testSelfLintFindsParameterComplexity() {
+    let report = selfLintSource(
+        r"""
+            fn many(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) -> Int {
+                a + b + c + d + e + f + g
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0050"), 1)
+}
+
+fn testSelfLintReportsParseRecoveryErrors() {
+    let report = selfLintSource(r"fn broken() { let x = 1")
+
+    testing.assert(report.parseErrors > 0)
+}

--- a/examples/selfhost-core/osty.toml
+++ b/examples/selfhost-core/osty.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "0.3"
 description = "Self-hosting core algorithms ported to Osty."
 license = "MIT"
-keywords = ["selfhost", "semver", "registry", "manifest", "diagnostics"]
+keywords = ["selfhost", "semver", "registry", "manifest", "diagnostics", "lint", "resolve", "check"]
 
 [dependencies]

--- a/examples/selfhost-core/resolve.osty
+++ b/examples/selfhost-core/resolve.osty
@@ -1,0 +1,745 @@
+use go "strings" as strings {
+    fn HasPrefix(s: String, prefix: String) -> Bool
+}
+
+/// SelfSymbol is the self-hosting resolver's compact symbol record.
+pub struct SelfSymbol {
+    pub name: String,
+    pub kind: String,
+    pub typeName: String,
+    pub arity: Int,
+    pub depth: Int,
+    pub start: Int,
+    pub end: Int,
+    pub public: Bool,
+}
+
+/// SelfResolveDiagnostic mirrors the compiler's name-resolution diagnostics in
+/// a small, self-host-friendly shape.
+pub struct SelfResolveDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub name: String,
+    pub start: Int,
+    pub end: Int,
+}
+
+/// SelfResolveResult contains top-level/package symbols plus resolver
+/// diagnostics collected while walking function bodies.
+pub struct SelfResolveResult {
+    pub symbols: List<SelfSymbol>,
+    pub diagnostics: List<SelfResolveDiagnostic>,
+    pub refs: Int,
+    pub unresolved: Int,
+    pub duplicates: Int,
+}
+
+pub fn selfSymbol(
+    name: String,
+    kind: String,
+    typeName: String,
+    arity: Int,
+    depth: Int,
+    start: Int,
+    end: Int,
+    public: Bool,
+) -> SelfSymbol {
+    SelfSymbol { name, kind, typeName, arity, depth, start, end, public }
+}
+
+pub fn selfResolveDiagnostic(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfResolveDiagnostic {
+    SelfResolveDiagnostic { code, message, name, start, end }
+}
+
+pub fn emptySelfResolveResult() -> SelfResolveResult {
+    SelfResolveResult { symbols: [], diagnostics: [], refs: 0, unresolved: 0, duplicates: 0 }
+}
+
+/// selfResolveSource builds a package-level symbol table and resolves simple
+/// function-body references using the self-hosted lexer/parser surface.
+pub fn selfResolveSource(source: String) -> SelfResolveResult {
+    let stream = frontendLexStream(source)
+    let tokens = frontTokensFromSource(source, stream)
+    let count = frontTokenListCount(tokens)
+    let mut result = emptySelfResolveResult()
+    result = selfResolveCollectTopLevel(tokens, count, result)
+    result = selfResolveScanFunctions(tokens, count, result)
+    result
+}
+
+pub fn selfResolveDiagnosticCount(result: SelfResolveResult) -> Int {
+    let mut count = 0
+    for diag in result.diagnostics {
+        let _ = diag
+        count = count + 1
+    }
+    count
+}
+
+pub fn selfResolveCodeCount(result: SelfResolveResult, code: String) -> Int {
+    let mut count = 0
+    for diag in result.diagnostics {
+        if diag.code == code {
+            count = count + 1
+        }
+    }
+    count
+}
+
+pub fn selfResolveSymbolCount(result: SelfResolveResult, kind: String) -> Int {
+    let mut count = 0
+    for sym in result.symbols {
+        if sym.kind == kind {
+            count = count + 1
+        }
+    }
+    count
+}
+
+pub fn selfResolveHasSymbol(result: SelfResolveResult, name: String, kind: String) -> Bool {
+    for sym in result.symbols {
+        if sym.name == name && sym.kind == kind {
+            return true
+        }
+    }
+    false
+}
+
+fn selfResolveCollectTopLevel(
+    tokens: List<FrontToken>,
+    count: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let mut skipUntil = -1
+    for idx in 0..count {
+        if idx < skipUntil {
+            let _ = idx
+        } else {
+            let kind = frontTokenAtList(tokens, idx).kind
+            if srKindIs(kind, "use") {
+                let consumed = frontParseUseConsumed(tokens, idx, count)
+                let end = idx + consumed
+                let alias = srUseAlias(tokens, idx, end)
+                if alias != "" {
+                    out = srAddSymbol(
+                        out,
+                        selfSymbol(alias, "package", "", 0, 0, idx, end, true),
+                    )
+                }
+                skipUntil = end
+            } else if srKindIs(kind, "fn") && srLooksLikeDeclarationStart(tokens, idx) {
+                let end = frontDeclEnd(tokens, idx, count)
+                let nameIdx = srNextIdent(tokens, idx + 1, end)
+                if nameIdx < end {
+                    let open = srFindTopLevelKind(tokens, nameIdx + 1, end, "(")
+                    let arity = if open >= 0 {
+                        let close = frontFindMatching(tokens, open, end, srKind("("), srKind(")"))
+                        srParamCount(tokens, open, close)
+                    } else {
+                        0
+                    }
+                    out = srAddSymbol(
+                        out,
+                        selfSymbol(
+                            frontTokenTextAt(tokens, nameIdx),
+                            "fn",
+                            "",
+                            arity,
+                            0,
+                            idx,
+                            end,
+                            srPrevMeaningfulIs(tokens, idx, "pub"),
+                        ),
+                    )
+                }
+                skipUntil = end
+            } else if (srKindIs(kind, "struct") || srKindIs(kind, "interface") || srKindIs(
+                kind,
+                "type",
+            )) && srLooksLikeDeclarationStart(
+                tokens,
+                idx,
+            ) {
+                let end = frontDeclEnd(tokens, idx, count)
+                let nameIdx = srNextIdent(tokens, idx + 1, end)
+                if nameIdx < end {
+                    out = srAddSymbol(
+                        out,
+                        selfSymbol(
+                            frontTokenTextAt(tokens, nameIdx),
+                            "type",
+                            "",
+                            0,
+                            0,
+                            idx,
+                            end,
+                            srPrevMeaningfulIs(tokens, idx, "pub"),
+                        ),
+                    )
+                }
+                skipUntil = end
+            } else if srKindIs(kind, "enum") && srLooksLikeDeclarationStart(tokens, idx) {
+                let end = frontDeclEnd(tokens, idx, count)
+                let nameIdx = srNextIdent(tokens, idx + 1, end)
+                if nameIdx < end {
+                    out = srAddSymbol(
+                        out,
+                        selfSymbol(
+                            frontTokenTextAt(tokens, nameIdx),
+                            "type",
+                            "",
+                            0,
+                            0,
+                            idx,
+                            end,
+                            srPrevMeaningfulIs(tokens, idx, "pub"),
+                        ),
+                    )
+                }
+                out = srCollectEnumVariants(tokens, idx, end, out)
+                skipUntil = end
+            } else if srKindIs(kind, "let") && srLooksLikeDeclarationStart(tokens, idx) {
+                let end = frontFindStatementEnd(tokens, idx, count)
+                let nameIdx = srLetNameIndex(tokens, idx)
+                if srTokenIs(tokens, nameIdx, "IDENT") || srTokenIs(tokens, nameIdx, "_") {
+                    out = srAddSymbol(
+                        out,
+                        selfSymbol(
+                            frontTokenTextAt(tokens, nameIdx),
+                            "value",
+                            "",
+                            0,
+                            0,
+                            idx,
+                            end,
+                            false,
+                        ),
+                    )
+                }
+                skipUntil = end
+            }
+        }
+    }
+    out
+}
+
+fn srCollectEnumVariants(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let open = srFindTopLevelKind(tokens, start + 1, end, r"{")
+    if open < 0 {
+        return out
+    }
+    let close = frontFindMatching(tokens, open, end, srKind(r"{"), srKind(r"}"))
+    let mut parenDepth = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if srKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if srKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if parenDepth == 0 && srKindIs(kind, "IDENT") && srLooksLikeVariantName(
+            tokens,
+            idx,
+            open,
+        ) {
+            out = srAddSymbol(
+                out,
+                selfSymbol(frontTokenTextAt(tokens, idx), "variant", "", 0, 0, idx, idx + 1, true),
+            )
+        }
+    }
+    out
+}
+
+fn selfResolveScanFunctions(
+    tokens: List<FrontToken>,
+    count: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let mut skipUntil = -1
+    for idx in 0..count {
+        if idx < skipUntil {
+            let _ = idx
+        } else if srTokenIs(tokens, idx, "fn") && srLooksLikeDeclarationStart(tokens, idx) {
+            let end = frontDeclEnd(tokens, idx, count)
+            out = srResolveFunction(tokens, idx, end, out)
+            skipUntil = end
+        }
+    }
+    out
+}
+
+fn srResolveFunction(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let nameIdx = srNextIdent(tokens, start + 1, end)
+    let open = srFindTopLevelKind(tokens, nameIdx + 1, end, "(")
+    if open < 0 {
+        return out
+    }
+    let close = frontFindMatching(tokens, open, end, srKind("("), srKind(")"))
+    let bodyOpen = srFindTopLevelKind(tokens, close + 1, end, r"{")
+    if bodyOpen < 0 {
+        return out
+    }
+    let bodyClose = frontFindMatching(tokens, bodyOpen, end, srKind(r"{"), srKind(r"}"))
+    let mut locals: List<SelfSymbol> = []
+
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if (srKindIs(kind, "IDENT") || srKindIs(kind, "_")) && srLooksLikeParamName(
+            tokens,
+            idx,
+            open,
+        ) {
+            let name = frontTokenTextAt(tokens, idx)
+            if !(srIsDiscardName(name)) && name != "self" {
+                if srLocalExists(locals, name) {
+                    out = srDuplicate(out, name, idx, idx + 1)
+                }
+                locals.push(
+                    selfSymbol(
+                        name,
+                        "value",
+                        srParamType(tokens, idx, close),
+                        0,
+                        1,
+                        idx,
+                        idx + 1,
+                        false,
+                    ),
+                )
+            }
+        }
+    }
+
+    let mut skipUntil = -1
+    for idx in bodyOpen + 1..bodyClose {
+        if idx < skipUntil {
+            let _ = idx
+        } else if srTokenIs(tokens, idx, "let") {
+            let stmtEnd = frontFindStatementEnd(tokens, idx, bodyClose)
+            let assign = srFindFirstKind(tokens, idx, stmtEnd, "=")
+            if assign >= 0 {
+                out = srResolveRefs(tokens, assign + 1, stmtEnd, locals, out)
+            }
+            let nameIdx = srLetNameIndex(tokens, idx)
+            if srTokenIs(tokens, nameIdx, "IDENT") || srTokenIs(tokens, nameIdx, "_") {
+                let name = frontTokenTextAt(tokens, nameIdx)
+                if !(srIsDiscardName(name)) {
+                    if srLocalExists(locals, name) {
+                        out = srDuplicate(out, name, nameIdx, nameIdx + 1)
+                    }
+                    locals.push(
+                        selfSymbol(
+                            name,
+                            "value",
+                            srLetAnnotatedType(tokens, idx, stmtEnd),
+                            0,
+                            1,
+                            nameIdx,
+                            nameIdx + 1,
+                            false,
+                        ),
+                    )
+                }
+            }
+            skipUntil = stmtEnd
+        } else if srTokenIs(tokens, idx, "for") {
+            out = srResolveFor(tokens, idx, bodyClose, locals, out)
+        } else if srShouldResolveIdent(tokens, idx) {
+            out = srResolveOneIdent(tokens, idx, locals, out)
+        }
+    }
+    out
+}
+
+fn srResolveFor(
+    tokens: List<FrontToken>,
+    idx: Int,
+    end: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let bindIdx = srNextMeaningfulIndex(tokens, idx + 1, end)
+    let inIdx = srNextMeaningfulIndex(tokens, bindIdx + 1, end)
+    if srTokenIs(tokens, bindIdx, "IDENT") && srTokenIs(tokens, inIdx, "IDENT") && frontTokenTextAt(
+        tokens,
+        inIdx,
+    ) == "in" {
+        let blockOpen = srFindFirstKind(tokens, inIdx + 1, end, r"{")
+        if blockOpen > inIdx {
+            out = srResolveRefs(tokens, inIdx + 1, blockOpen, locals, out)
+        }
+        if !(srLocalExists(locals, frontTokenTextAt(tokens, bindIdx))) {
+            locals.push(
+                selfSymbol(
+                    frontTokenTextAt(tokens, bindIdx),
+                    "value",
+                    "",
+                    0,
+                    1,
+                    bindIdx,
+                    bindIdx + 1,
+                    false,
+                ),
+            )
+        }
+    }
+    out
+}
+
+fn srResolveRefs(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    for idx in start..end {
+        if srShouldResolveIdent(tokens, idx) {
+            out = srResolveOneIdent(tokens, idx, locals, out)
+        }
+    }
+    out
+}
+
+fn srResolveOneIdent(
+    tokens: List<FrontToken>,
+    idx: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let name = frontTokenTextAt(tokens, idx)
+    if srLocalExists(locals, name) || srTopLevelExists(out.symbols, name) || srIsBuiltinName(name) {
+        out.refs = out.refs + 1
+        return out
+    }
+    out.unresolved = out.unresolved + 1
+    out.diagnostics.push(selfResolveDiagnostic("E0500", "undefined name", name, idx, idx + 1))
+    out
+}
+
+fn srAddSymbol(result: SelfResolveResult, sym: SelfSymbol) -> SelfResolveResult {
+    let mut out = result
+    if srSymbolExistsAtDepth(out.symbols, sym.name, sym.depth) {
+        out = srDuplicate(out, sym.name, sym.start, sym.end)
+    } else if !(srIsDiscardName(sym.name)) {
+        out.symbols.push(sym)
+    }
+    out
+}
+
+fn srDuplicate(result: SelfResolveResult, name: String, start: Int, end: Int) -> SelfResolveResult {
+    let mut out = result
+    out.duplicates = out.duplicates + 1
+    out.diagnostics.push(selfResolveDiagnostic("E0501", "duplicate declaration", name, start, end))
+    out
+}
+
+fn srShouldResolveIdent(tokens: List<FrontToken>, idx: Int) -> Bool {
+    if !(srTokenIs(tokens, idx, "IDENT")) {
+        return false
+    }
+    let name = frontTokenTextAt(tokens, idx)
+    if name == "in" || name == "as" || srIsBuiltinName(name) {
+        return false
+    }
+    let prev = srPrevMeaningfulKind(tokens, idx)
+    let next = srNextMeaningfulKind(tokens, idx)
+    if srKindIs(prev, ".") || srKindIs(prev, "fn") || srKindIs(prev, "struct") || srKindIs(
+        prev,
+        "enum",
+    ) || srKindIs(prev, "interface") || srKindIs(prev, "type") || srKindIs(prev, "use") || srKindIs(
+        prev,
+        "mut",
+    ) {
+        return false
+    }
+    if srKindIs(next, ":") {
+        return false
+    }
+    true
+}
+
+fn srUseAlias(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let mut last = ""
+    let mut afterAs = false
+    for idx in start + 1..end {
+        let tok = frontTokenAtList(tokens, idx)
+        if srKindIs(tok.kind, "IDENT") {
+            if afterAs {
+                return tok.text
+            }
+            if tok.text == "as" {
+                afterAs = true
+            } else if tok.text != "go" {
+                last = tok.text
+            }
+        }
+    }
+    last
+}
+
+fn srLetNameIndex(tokens: List<FrontToken>, start: Int) -> Int {
+    let mut idx = start + 1
+    if srTokenIs(tokens, idx, "mut") {
+        idx = idx + 1
+    }
+    idx
+}
+
+fn srLetAnnotatedType(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let nameIdx = srLetNameIndex(tokens, start)
+    let colon = srFindFirstKind(tokens, nameIdx + 1, end, ":")
+    if colon >= 0 {
+        return srTypeNameAt(tokens, colon + 1, end)
+    }
+    ""
+}
+
+fn srParamType(tokens: List<FrontToken>, nameIdx: Int, close: Int) -> String {
+    let colon = srFindFirstKind(tokens, nameIdx + 1, close, ":")
+    if colon >= 0 {
+        return srTypeNameAt(tokens, colon + 1, close)
+    }
+    ""
+}
+
+fn srTypeNameAt(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let idx = srNextMeaningfulIndex(tokens, start, end)
+    if idx < end {
+        let tok = frontTokenAtList(tokens, idx)
+        if srKindIs(tok.kind, "IDENT") {
+            return tok.text
+        }
+        if srKindIs(tok.kind, "(") && srTokenIs(tokens, idx + 1, ")") {
+            return "()"
+        }
+        if srKindIs(tok.kind, "fn") {
+            return "fn"
+        }
+    }
+    ""
+}
+
+fn srLocalExists(symbols: List<SelfSymbol>, name: String) -> Bool {
+    for sym in symbols {
+        if sym.name == name {
+            return true
+        }
+    }
+    false
+}
+
+fn srTopLevelExists(symbols: List<SelfSymbol>, name: String) -> Bool {
+    for sym in symbols {
+        if sym.name == name && sym.depth == 0 {
+            return true
+        }
+    }
+    false
+}
+
+fn srSymbolExistsAtDepth(symbols: List<SelfSymbol>, name: String, depth: Int) -> Bool {
+    for sym in symbols {
+        if sym.name == name && sym.depth == depth {
+            return true
+        }
+    }
+    false
+}
+
+fn srIsBuiltinName(name: String) -> Bool {
+    name == "true" || name == "false" || name == "None" || name == "Some" || name == "Ok" || name == "Err" || name == "println" || name == "panic" || name == "spawn" || name == "parallel" || name == "taskGroup" || name == "thread" || name == "Int" || name == "Float" || name == "Bool" || name == "String" || name == "Bytes" || name == "Char" || name == "Never" || name == "List" || name == "Map" || name == "Set" || name == "Option" || name == "Result" || name == "Error" || name == "Unit"
+}
+
+fn srIsDiscardName(name: String) -> Bool {
+    name == "_" || strings.HasPrefix(name, "_")
+}
+
+fn srKind(name: String) -> FrontTokenKind {
+    frontTokenKindByName(name)
+}
+
+fn srKindIs(kind: FrontTokenKind, name: String) -> Bool {
+    frontTokenKindName(kind) == name
+}
+
+fn srTokenIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
+    srKindIs(frontTokenAtList(tokens, idx).kind, name)
+}
+
+fn srLooksLikeDeclarationStart(tokens: List<FrontToken>, idx: Int) -> Bool {
+    let immediate = srPrevTokenKind(tokens, idx)
+    let prev = srPrevMeaningfulKind(tokens, idx)
+    srKindIs(immediate, "EOF") || srKindIs(immediate, "NEWLINE") || srKindIs(immediate, ";") || srKindIs(
+        prev,
+        "pub",
+    ) || srKindIs(prev, r"{") || srKindIs(prev, r"}")
+}
+
+fn srLooksLikeVariantName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
+    let prev = srPrevMeaningfulKindBounded(tokens, idx, open)
+    let next = frontTokenAtList(tokens, idx + 1).kind
+    (srKindIs(prev, r"{") || srKindIs(prev, ",") || srKindIs(prev, "NEWLINE")) && !(srKindIs(
+        next,
+        ":",
+    ))
+}
+
+fn srLooksLikeParamName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
+    let prev = srPrevMeaningfulKindBounded(tokens, idx, open)
+    srKindIs(prev, "(") || srKindIs(prev, ",") || srKindIs(prev, "mut")
+}
+
+fn srParamCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
+    let mut count = 0
+    for idx in open + 1..close {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if (srKindIs(kind, "IDENT") || srKindIs(kind, "_")) && srLooksLikeParamName(
+            tokens,
+            idx,
+            open,
+        ) {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn srNextIdent(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    for idx in start..end {
+        if srTokenIs(tokens, idx, "IDENT") {
+            return idx
+        }
+    }
+    end
+}
+
+fn srFindTopLevelKind(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    target: String,
+) -> Int {
+    let mut parenDepth = 0
+    let mut bracketDepth = 0
+    let mut braceDepth = 0
+    let mut angleDepth = 0
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if srKindIs(kind, target) && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0 {
+            return idx
+        }
+        if srKindIs(kind, "(") {
+            parenDepth = parenDepth + 1
+        } else if srKindIs(kind, ")") {
+            if parenDepth > 0 {
+                parenDepth = parenDepth - 1
+            }
+        } else if srKindIs(kind, "[") {
+            bracketDepth = bracketDepth + 1
+        } else if srKindIs(kind, "]") {
+            if bracketDepth > 0 {
+                bracketDepth = bracketDepth - 1
+            }
+        } else if srKindIs(kind, r"{") {
+            braceDepth = braceDepth + 1
+        } else if srKindIs(kind, r"}") {
+            if braceDepth > 0 {
+                braceDepth = braceDepth - 1
+            }
+        } else if srKindIs(kind, "<") {
+            angleDepth = angleDepth + 1
+        } else if srKindIs(kind, ">") {
+            if angleDepth > 0 {
+                angleDepth = angleDepth - 1
+            }
+        }
+    }
+    -1
+}
+
+fn srFindFirstKind(
+    tokens: List<FrontToken>,
+    start: Int,
+    end: Int,
+    target: String,
+) -> Int {
+    for idx in start..end {
+        if srTokenIs(tokens, idx, target) {
+            return idx
+        }
+    }
+    -1
+}
+
+fn srNextMeaningfulIndex(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
+    for idx in start..end {
+        let kind = frontTokenAtList(tokens, idx).kind
+        if !(srKindIs(kind, "NEWLINE")) && !(srKindIs(kind, ";")) {
+            return idx
+        }
+    }
+    end
+}
+
+fn srPrevMeaningfulIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
+    srKindIs(srPrevMeaningfulKind(tokens, idx), name)
+}
+
+fn srPrevMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    srPrevMeaningfulKindBounded(tokens, idx, 0)
+}
+
+fn srPrevTokenKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    if idx <= 0 {
+        return srKind("EOF")
+    }
+    frontTokenAtList(tokens, idx - 1).kind
+}
+
+fn srPrevMeaningfulKindBounded(tokens: List<FrontToken>, idx: Int, floor: Int) -> FrontTokenKind {
+    let mut cur = idx - 1
+    for cur >= floor {
+        let kind = frontTokenAtList(tokens, cur).kind
+        if !(srKindIs(kind, "NEWLINE")) && !(srKindIs(kind, ";")) {
+            return kind
+        }
+        cur = cur - 1
+    }
+    srKind("EOF")
+}
+
+fn srNextMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
+    for cur in idx + 1..frontTokenListCount(tokens) {
+        let kind = frontTokenAtList(tokens, cur).kind
+        if !(srKindIs(kind, "NEWLINE")) && !(srKindIs(kind, ";")) {
+            return kind
+        }
+    }
+    srKind("EOF")
+}

--- a/examples/selfhost-core/resolve_test.osty
+++ b/examples/selfhost-core/resolve_test.osty
@@ -1,0 +1,63 @@
+use std.testing
+
+fn testSelfResolverCollectsSymbolsAndReferences() {
+    let result = selfResolveSource(
+        r"""
+            use std.testing
+
+            struct User { name: String }
+            enum Color { Red, Green }
+
+            fn add(left: Int, right: Int) -> Int {
+                let total = left + right
+                total
+            }
+
+            fn main() {
+                let answer = add(1, 2)
+                testing.assert(answer == 3)
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveDiagnosticCount(result), 0)
+    testing.assert(selfResolveHasSymbol(result, "testing", "package"))
+    testing.assert(selfResolveHasSymbol(result, "User", "type"))
+    testing.assert(selfResolveHasSymbol(result, "Color", "type"))
+    testing.assert(selfResolveHasSymbol(result, "Red", "variant"))
+    testing.assert(selfResolveHasSymbol(result, "add", "fn"))
+    testing.assert(result.refs >= 5)
+}
+
+fn testSelfResolverReportsDuplicatesAndUndefinedNames() {
+    let result = selfResolveSource(
+        r"""
+            fn duplicate() {}
+            fn duplicate() {}
+
+            fn main() {
+                let value = missing + alsoMissing
+                duplicate()
+            }
+            """,
+    )
+
+    testing.assertEq(result.duplicates, 1)
+    testing.assertEq(selfResolveCodeCount(result, "E0501"), 1)
+    testing.assertEq(selfResolveCodeCount(result, "E0500"), 2)
+}
+
+fn testSelfResolverTracksLocalDeclarationsInOrder() {
+    let result = selfResolveSource(
+        r"""
+            fn main(input: Int) -> Int {
+                let doubled = input + input
+                let finalValue = doubled + 1
+                finalValue
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveDiagnosticCount(result), 0)
+    testing.assert(result.refs >= 4)
+}


### PR DESCRIPTION
## Summary
- add Osty-written selfhost linter, resolver, and checker cores under `examples/selfhost-core`
- cover resolver symbol/reference diagnostics and checker primitive flow diagnostics with selfhost tests
- update the selfhost-core example metadata and README description

## Tests
- `git diff --check`
- `go test ./internal/examples -run 'TestSelfhostCoreExampleTestsExecute|TestExampleManifestsValidate' -count=1`\n- `go run ./cmd/osty test examples/selfhost-core`