### PR TITLE
Implement independent IR in Osty

### DIFF
--- a/examples/dogfood/ir.osty
+++ b/examples/dogfood/ir.osty
@@ -1,0 +1,559 @@
+pub enum IrNodeKind {
+    IrNodeModule,
+    IrNodeAnnotation,
+    IrNodeUseDecl,
+    IrNodeGoUseDecl,
+    IrNodeFnDecl,
+    IrNodeStructDecl,
+    IrNodeEnumDecl,
+    IrNodeInterfaceDecl,
+    IrNodeTypeAliasDecl,
+    IrNodeLetDecl,
+    IrNodeGenericParams,
+    IrNodeParamList,
+    IrNodeParam,
+    IrNodeType,
+    IrNodeBlock,
+    IrNodeLetStmt,
+    IrNodeReturnStmt,
+    IrNodeBreakStmt,
+    IrNodeContinueStmt,
+    IrNodeForStmt,
+    IrNodeDeferStmt,
+    IrNodeAssignStmt,
+    IrNodeChannelSendStmt,
+    IrNodeIfExpr,
+    IrNodeMatchExpr,
+    IrNodeMatchArm,
+    IrNodeCallExpr,
+    IrNodeIndexExpr,
+    IrNodeSelectorExpr,
+    IrNodeTurbofishExpr,
+    IrNodeClosureExpr,
+    IrNodeListExpr,
+    IrNodeMapExpr,
+    IrNodeTupleExpr,
+    IrNodeStructExpr,
+    IrNodeRangeExpr,
+    IrNodeBinaryExpr,
+    IrNodeUnaryExpr,
+    IrNodeQuestionExpr,
+    IrNodePattern,
+    IrNodeField,
+    IrNodeVariant,
+    IrNodeRecovery,
+    IrNodeError,
+}
+
+pub enum IrDiagnosticKind {
+    IrDiagUnexpectedToken,
+    IrDiagMissingName,
+    IrDiagMissingDelimiter,
+    IrDiagUnmatchedDelimiter,
+    IrDiagNonAssociativeOperator,
+    IrDiagTrailingSelector,
+    IrDiagLexerError,
+}
+
+pub struct IrNode {
+    pub kind: IrNodeKind,
+    pub start: Int,
+    pub end: Int,
+    pub depth: Int,
+    pub flags: Int,
+    pub parent: Int,
+    pub children: List<Int>,
+}
+
+pub struct IrDiagnostic {
+    pub kind: IrDiagnosticKind,
+    pub start: Int,
+    pub end: Int,
+    pub expected: String,
+    pub found: String,
+}
+
+pub struct IrArena {
+    pub nodes: List<IrNode>,
+}
+
+pub struct IrModule {
+    pub packageName: String,
+    pub arena: IrArena,
+    pub root: Int,
+    pub decls: List<Int>,
+    pub script: List<Int>,
+    pub diagnostics: List<IrDiagnostic>,
+    pub sourceTokens: Int,
+    pub coveredTokens: Int,
+    pub maxDepth: Int,
+    pub recovered: Int,
+}
+
+pub struct IrSummary {
+    pub nodes: Int,
+    pub decls: Int,
+    pub funcs: Int,
+    pub structs: Int,
+    pub enums: Int,
+    pub interfaces: Int,
+    pub aliases: Int,
+    pub uses: Int,
+    pub lets: Int,
+    pub stmts: Int,
+    pub exprs: Int,
+    pub patterns: Int,
+    pub types: Int,
+    pub diagnostics: Int,
+    pub invalidParents: Int,
+    pub maxDepth: Int,
+}
+
+pub fn emptyIrNode(kind: IrNodeKind) -> IrNode {
+    IrNode {
+        kind,
+        start: 0,
+        end: 0,
+        depth: 0,
+        flags: 0,
+        parent: -1,
+        children: [],
+    }
+}
+
+pub fn emptyIrArena() -> IrArena {
+    IrArena { nodes: [] }
+}
+
+pub fn emptyIrModule(packageName: String) -> IrModule {
+    IrModule {
+        packageName,
+        arena: emptyIrArena(),
+        root: -1,
+        decls: [],
+        script: [],
+        diagnostics: [],
+        sourceTokens: 0,
+        coveredTokens: 0,
+        maxDepth: 0,
+        recovered: 0,
+    }
+}
+
+pub fn emptyIrSummary() -> IrSummary {
+    IrSummary {
+        nodes: 0,
+        decls: 0,
+        funcs: 0,
+        structs: 0,
+        enums: 0,
+        interfaces: 0,
+        aliases: 0,
+        uses: 0,
+        lets: 0,
+        stmts: 0,
+        exprs: 0,
+        patterns: 0,
+        types: 0,
+        diagnostics: 0,
+        invalidParents: 0,
+        maxDepth: 0,
+    }
+}
+
+pub fn irArenaAdd(arena: IrArena, node: IrNode) -> Int {
+    let idx = irArenaNodeCount(arena)
+    arena.nodes.push(node)
+    idx
+}
+
+pub fn irArenaNodeCount(arena: IrArena) -> Int {
+    let mut count = 0
+    for node in arena.nodes {
+        let _ = node
+        count = count + 1
+    }
+    count
+}
+
+pub fn irArenaNodeAt(arena: IrArena, idx: Int) -> IrNode {
+    let mut i = 0
+    for node in arena.nodes {
+        if i == idx {
+            return node
+        }
+        i = i + 1
+    }
+    emptyIrNode(IrNodeError)
+}
+
+pub fn irLowerSource(packageName: String, source: String) -> IrModule {
+    irLowerParseTree(packageName, frontendParseTree(source))
+}
+
+pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
+    let mut module = emptyIrModule(packageName)
+    module.sourceTokens = tree.tokens
+    module.coveredTokens = tree.coveredTokens
+    module.maxDepth = tree.maxDepth
+    module.recovered = tree.recovered
+
+    let mut stack: List<Int> = []
+    for frontNode in tree.nodes {
+        for irStackCount(stack) > frontNode.depth {
+            stack.pop()
+        }
+
+        let mut node = emptyIrNode(irKindFromFront(frontNode.kind))
+        node.start = frontNode.start
+        node.end = frontNode.end
+        node.depth = frontNode.depth
+        node.flags = frontNode.flags
+        node.parent = irParentForDepth(stack, frontNode.depth)
+
+        let idx = irArenaAdd(module.arena, node)
+        if node.parent >= 0 {
+            irAttachChild(module.arena, node.parent, idx)
+        }
+        if frontNode.depth == 0 && module.root < 0 {
+            module.root = idx
+        }
+        if frontNode.depth == 1 && irKindIsDecl(node.kind) {
+            module.decls.push(idx)
+        }
+        if frontNode.depth == 1 && !(irKindIsDecl(node.kind)) && node.kind != IrNodeRecovery {
+            module.script.push(idx)
+        }
+        stack.push(idx)
+    }
+
+    for diag in tree.diagnostics {
+        module.diagnostics.push(
+            IrDiagnostic {
+                kind: irDiagnosticKindFromFront(diag.kind),
+                start: diag.start,
+                end: diag.end,
+                expected: frontTokenKindName(diag.expected),
+                found: frontTokenKindName(diag.found),
+            },
+        )
+    }
+
+    module
+}
+
+fn irAttachChild(arena: IrArena, parent: Int, child: Int) {
+    if parent < 0 {
+        return
+    }
+    let mut node = irArenaNodeAt(arena, parent)
+    node.children.push(child)
+    arena.nodes[parent] = node
+}
+
+fn irParentForDepth(stack: List<Int>, depth: Int) -> Int {
+    if depth <= 0 {
+        return -1
+    }
+    if irStackCount(stack) < depth {
+        return -1
+    }
+    stack[depth - 1]
+}
+
+fn irStackCount(stack: List<Int>) -> Int {
+    let mut count = 0
+    for item in stack {
+        let _ = item
+        count = count + 1
+    }
+    count
+}
+
+pub fn irSummarize(module: IrModule) -> IrSummary {
+    let mut summary = emptyIrSummary()
+    summary.nodes = irArenaNodeCount(module.arena)
+    summary.decls = irListCount(module.decls)
+    summary.diagnostics = irDiagnosticCount(module)
+    summary.maxDepth = module.maxDepth
+    summary.invalidParents = irInvalidParentCount(module)
+
+    for node in module.arena.nodes {
+        if node.kind == IrNodeFnDecl {
+            summary.funcs = summary.funcs + 1
+        } else if node.kind == IrNodeStructDecl {
+            summary.structs = summary.structs + 1
+        } else if node.kind == IrNodeEnumDecl {
+            summary.enums = summary.enums + 1
+        } else if node.kind == IrNodeInterfaceDecl {
+            summary.interfaces = summary.interfaces + 1
+        } else if node.kind == IrNodeTypeAliasDecl {
+            summary.aliases = summary.aliases + 1
+        } else if node.kind == IrNodeUseDecl || node.kind == IrNodeGoUseDecl {
+            summary.uses = summary.uses + 1
+        } else if node.kind == IrNodeLetDecl {
+            summary.lets = summary.lets + 1
+        }
+        if irKindIsStmt(node.kind) {
+            summary.stmts = summary.stmts + 1
+        }
+        if irKindIsExpr(node.kind) {
+            summary.exprs = summary.exprs + 1
+        }
+        if node.kind == IrNodePattern {
+            summary.patterns = summary.patterns + 1
+        }
+        if node.kind == IrNodeType {
+            summary.types = summary.types + 1
+        }
+    }
+
+    summary
+}
+
+pub fn irDiagnosticCount(module: IrModule) -> Int {
+    let mut count = 0
+    for diag in module.diagnostics {
+        let _ = diag
+        count = count + 1
+    }
+    count
+}
+
+pub fn irChildCount(module: IrModule, idx: Int) -> Int {
+    irListCount(irArenaNodeAt(module.arena, idx).children)
+}
+
+pub fn irDeclCount(module: IrModule) -> Int {
+    irListCount(module.decls)
+}
+
+pub fn irListCount(items: List<Int>) -> Int {
+    let mut count = 0
+    for item in items {
+        let _ = item
+        count = count + 1
+    }
+    count
+}
+
+pub fn irInvalidParentCount(module: IrModule) -> Int {
+    let mut count = 0
+    let total = irArenaNodeCount(module.arena)
+    let mut idx = 0
+    for node in module.arena.nodes {
+        if idx == module.root {
+            if node.parent != -1 {
+                count = count + 1
+            }
+        } else if node.parent < 0 || node.parent >= total {
+            count = count + 1
+        }
+        idx = idx + 1
+    }
+    count
+}
+
+pub fn irKindIsDecl(kind: IrNodeKind) -> Bool {
+    match kind {
+        IrNodeUseDecl -> true,
+        IrNodeGoUseDecl -> true,
+        IrNodeFnDecl -> true,
+        IrNodeStructDecl -> true,
+        IrNodeEnumDecl -> true,
+        IrNodeInterfaceDecl -> true,
+        IrNodeTypeAliasDecl -> true,
+        IrNodeLetDecl -> true,
+        _ -> false,
+    }
+}
+
+pub fn irKindIsStmt(kind: IrNodeKind) -> Bool {
+    kind == IrNodeLetStmt || kind == IrNodeReturnStmt || kind == IrNodeBreakStmt || kind == IrNodeContinueStmt || kind == IrNodeForStmt || kind == IrNodeDeferStmt || kind == IrNodeAssignStmt || kind == IrNodeChannelSendStmt
+}
+
+pub fn irKindIsExpr(kind: IrNodeKind) -> Bool {
+    kind == IrNodeCallExpr || kind == IrNodeIndexExpr || kind == IrNodeSelectorExpr || kind == IrNodeTurbofishExpr || kind == IrNodeClosureExpr || kind == IrNodeListExpr || kind == IrNodeMapExpr || kind == IrNodeTupleExpr || kind == IrNodeStructExpr || kind == IrNodeRangeExpr || kind == IrNodeBinaryExpr || kind == IrNodeUnaryExpr || kind == IrNodeQuestionExpr || kind == IrNodeIfExpr || kind == IrNodeMatchExpr
+}
+
+pub fn irKindFromFront(kind: FrontNodeKind) -> IrNodeKind {
+    if kind == frontNodeKindByName("file") {
+        IrNodeModule
+    } else if kind == frontNodeKindByName("annotation") {
+        IrNodeAnnotation
+    } else if kind == frontNodeKindByName("use") {
+        IrNodeUseDecl
+    } else if kind == frontNodeKindByName("goUse") {
+        IrNodeGoUseDecl
+    } else if kind == frontNodeKindByName("fn") {
+        IrNodeFnDecl
+    } else if kind == frontNodeKindByName("struct") {
+        IrNodeStructDecl
+    } else if kind == frontNodeKindByName("enum") {
+        IrNodeEnumDecl
+    } else if kind == frontNodeKindByName("interface") {
+        IrNodeInterfaceDecl
+    } else if kind == frontNodeKindByName("typeAlias") {
+        IrNodeTypeAliasDecl
+    } else if kind == frontNodeKindByName("letDecl") {
+        IrNodeLetDecl
+    } else if kind == frontNodeKindByName("genericParams") {
+        IrNodeGenericParams
+    } else if kind == frontNodeKindByName("paramList") {
+        IrNodeParamList
+    } else if kind == frontNodeKindByName("param") {
+        IrNodeParam
+    } else if kind == frontNodeKindByName("type") {
+        IrNodeType
+    } else if kind == frontNodeKindByName("block") {
+        IrNodeBlock
+    } else if kind == frontNodeKindByName("letStmt") {
+        IrNodeLetStmt
+    } else if kind == frontNodeKindByName("return") {
+        IrNodeReturnStmt
+    } else if kind == frontNodeKindByName("break") {
+        IrNodeBreakStmt
+    } else if kind == frontNodeKindByName("continue") {
+        IrNodeContinueStmt
+    } else if kind == frontNodeKindByName("for") {
+        IrNodeForStmt
+    } else if kind == frontNodeKindByName("defer") {
+        IrNodeDeferStmt
+    } else if kind == frontNodeKindByName("assign") {
+        IrNodeAssignStmt
+    } else if kind == frontNodeKindByName("channelSend") {
+        IrNodeChannelSendStmt
+    } else if kind == frontNodeKindByName("if") {
+        IrNodeIfExpr
+    } else if kind == frontNodeKindByName("match") {
+        IrNodeMatchExpr
+    } else if kind == frontNodeKindByName("matchArm") {
+        IrNodeMatchArm
+    } else if kind == frontNodeKindByName("call") {
+        IrNodeCallExpr
+    } else if kind == frontNodeKindByName("index") {
+        IrNodeIndexExpr
+    } else if kind == frontNodeKindByName("selector") {
+        IrNodeSelectorExpr
+    } else if kind == frontNodeKindByName("turbofish") {
+        IrNodeTurbofishExpr
+    } else if kind == frontNodeKindByName("closure") {
+        IrNodeClosureExpr
+    } else if kind == frontNodeKindByName("list") {
+        IrNodeListExpr
+    } else if kind == frontNodeKindByName("map") {
+        IrNodeMapExpr
+    } else if kind == frontNodeKindByName("tuple") {
+        IrNodeTupleExpr
+    } else if kind == frontNodeKindByName("structExpr") {
+        IrNodeStructExpr
+    } else if kind == frontNodeKindByName("range") {
+        IrNodeRangeExpr
+    } else if kind == frontNodeKindByName("binary") {
+        IrNodeBinaryExpr
+    } else if kind == frontNodeKindByName("unary") {
+        IrNodeUnaryExpr
+    } else if kind == frontNodeKindByName("question") {
+        IrNodeQuestionExpr
+    } else if kind == frontNodeKindByName("pattern") {
+        IrNodePattern
+    } else if kind == frontNodeKindByName("field") {
+        IrNodeField
+    } else if kind == frontNodeKindByName("variant") {
+        IrNodeVariant
+    } else {
+        IrNodeRecovery
+    }
+}
+
+pub fn irDiagnosticKindFromFront(kind: FrontParseDiagnosticKind) -> IrDiagnosticKind {
+    if kind == frontParseDiagnosticKindByName("unexpected") {
+        IrDiagUnexpectedToken
+    } else if kind == frontParseDiagnosticKindByName("missingName") {
+        IrDiagMissingName
+    } else if kind == frontParseDiagnosticKindByName("missingDelimiter") {
+        IrDiagMissingDelimiter
+    } else if kind == frontParseDiagnosticKindByName("unmatchedDelimiter") {
+        IrDiagUnmatchedDelimiter
+    } else if kind == frontParseDiagnosticKindByName("nonAssoc") {
+        IrDiagNonAssociativeOperator
+    } else if kind == frontParseDiagnosticKindByName("trailingSelector") {
+        IrDiagTrailingSelector
+    } else {
+        IrDiagLexerError
+    }
+}
+
+pub fn irNodeKindName(kind: IrNodeKind) -> String {
+    match kind {
+        IrNodeModule -> "module",
+        IrNodeAnnotation -> "annotation",
+        IrNodeUseDecl -> "use",
+        IrNodeGoUseDecl -> "goUse",
+        IrNodeFnDecl -> "fn",
+        IrNodeStructDecl -> "struct",
+        IrNodeEnumDecl -> "enum",
+        IrNodeInterfaceDecl -> "interface",
+        IrNodeTypeAliasDecl -> "typeAlias",
+        IrNodeLetDecl -> "letDecl",
+        IrNodeGenericParams -> "genericParams",
+        IrNodeParamList -> "paramList",
+        IrNodeParam -> "param",
+        IrNodeType -> "type",
+        IrNodeBlock -> "block",
+        IrNodeLetStmt -> "letStmt",
+        IrNodeReturnStmt -> "return",
+        IrNodeBreakStmt -> "break",
+        IrNodeContinueStmt -> "continue",
+        IrNodeForStmt -> "for",
+        IrNodeDeferStmt -> "defer",
+        IrNodeAssignStmt -> "assign",
+        IrNodeChannelSendStmt -> "channelSend",
+        IrNodeIfExpr -> "if",
+        IrNodeMatchExpr -> "match",
+        IrNodeMatchArm -> "matchArm",
+        IrNodeCallExpr -> "call",
+        IrNodeIndexExpr -> "index",
+        IrNodeSelectorExpr -> "selector",
+        IrNodeTurbofishExpr -> "turbofish",
+        IrNodeClosureExpr -> "closure",
+        IrNodeListExpr -> "list",
+        IrNodeMapExpr -> "map",
+        IrNodeTupleExpr -> "tuple",
+        IrNodeStructExpr -> "structExpr",
+        IrNodeRangeExpr -> "range",
+        IrNodeBinaryExpr -> "binary",
+        IrNodeUnaryExpr -> "unary",
+        IrNodeQuestionExpr -> "question",
+        IrNodePattern -> "pattern",
+        IrNodeField -> "field",
+        IrNodeVariant -> "variant",
+        IrNodeRecovery -> "recovery",
+        IrNodeError -> "error",
+    }
+}
+
+pub fn irDiagnosticKindName(kind: IrDiagnosticKind) -> String {
+    match kind {
+        IrDiagUnexpectedToken -> "unexpectedToken",
+        IrDiagMissingName -> "missingName",
+        IrDiagMissingDelimiter -> "missingDelimiter",
+        IrDiagUnmatchedDelimiter -> "unmatchedDelimiter",
+        IrDiagNonAssociativeOperator -> "nonAssociativeOperator",
+        IrDiagTrailingSelector -> "trailingSelector",
+        IrDiagLexerError -> "lexerError",
+    }
+}
+
+pub fn irFnDeclKind() -> IrNodeKind {
+    IrNodeFnDecl
+}
+pub fn irMatchExprKind() -> IrNodeKind {
+    IrNodeMatchExpr
+}
+pub fn irPatternKind() -> IrNodeKind {
+    IrNodePattern
+}
+pub fn irTrailingSelectorDiagKind() -> IrDiagnosticKind {
+    IrDiagTrailingSelector
+}

--- a/examples/dogfood/ir_test.osty
+++ b/examples/dogfood/ir_test.osty
@@ -1,0 +1,66 @@
+use std.testing
+
+fn testIrLowersParseTreeIntoIndependentModule() {
+    let source = r"""
+        use std.testing
+        pub struct Box<T> { value: T }
+        enum Maybe<T> { Some(T), None }
+        fn main(xs: List<Int>) -> Int {
+            let mut total = 0
+            for x in xs { total = total + x }
+            match Some(total) {
+                Some(v) if v > 0 -> v,
+                None -> 0,
+            }
+        }
+        """
+    let module = irLowerSource("main", source)
+    let summary = irSummarize(module)
+
+    testing.assertEq(module.packageName, "main")
+    testing.assertEq(summary.decls, 4)
+    testing.assertEq(summary.uses, 1)
+    testing.assertEq(summary.structs, 1)
+    testing.assertEq(summary.enums, 1)
+    testing.assertEq(summary.funcs, 1)
+    testing.assert(summary.stmts >= 2)
+    testing.assert(summary.exprs >= 3)
+    testing.assert(summary.patterns >= 2)
+    testing.assertEq(summary.diagnostics, 0)
+    testing.assertEq(summary.invalidParents, 0)
+}
+
+fn testIrKeepsParentChildShape() {
+    let module = irLowerSource("main", r"fn f() { if true { return } else { return } }")
+    let root = irArenaNodeAt(module.arena, module.root)
+    let summary = irSummarize(module)
+
+    testing.assertEq(irNodeKindName(root.kind), "module")
+    testing.assertEq(root.parent, -1)
+    testing.assert(irChildCount(module, module.root) >= 1)
+    testing.assert(summary.maxDepth >= 2)
+    testing.assertEq(summary.invalidParents, 0)
+}
+
+fn testIrSurfacesDiagnosticsWithoutFrontendEnums() {
+    let module = irLowerSource("main", r"fn broken( {")
+    let summary = irSummarize(module)
+
+    testing.assert(summary.diagnostics >= 1)
+    testing.assertEq(irDiagnosticKindName(module.diagnostics[0].kind), "missingDelimiter")
+    testing.assert(module.diagnostics[0].expected != "")
+}
+
+fn testIrKindNamesAreStable() {
+    testing.assertEq(irNodeKindName(irFnDeclKind()), "fn")
+    testing.assertEq(irNodeKindName(irMatchExprKind()), "match")
+    testing.assertEq(irNodeKindName(irPatternKind()), "pattern")
+    testing.assertEq(irDiagnosticKindName(irTrailingSelectorDiagKind()), "trailingSelector")
+    testing.assertEq(irNodeKindName(irKindFromFront(frontNodeKindByName("fn"))), "fn")
+    testing.assertEq(
+        irDiagnosticKindName(
+            irDiagnosticKindFromFront(frontParseDiagnosticKindByName("missingName")),
+        ),
+        "missingName",
+    )
+}

--- a/examples/selfhost-core/ir.osty
+++ b/examples/selfhost-core/ir.osty
@@ -1,0 +1,559 @@
+pub enum IrNodeKind {
+    IrNodeModule,
+    IrNodeAnnotation,
+    IrNodeUseDecl,
+    IrNodeGoUseDecl,
+    IrNodeFnDecl,
+    IrNodeStructDecl,
+    IrNodeEnumDecl,
+    IrNodeInterfaceDecl,
+    IrNodeTypeAliasDecl,
+    IrNodeLetDecl,
+    IrNodeGenericParams,
+    IrNodeParamList,
+    IrNodeParam,
+    IrNodeType,
+    IrNodeBlock,
+    IrNodeLetStmt,
+    IrNodeReturnStmt,
+    IrNodeBreakStmt,
+    IrNodeContinueStmt,
+    IrNodeForStmt,
+    IrNodeDeferStmt,
+    IrNodeAssignStmt,
+    IrNodeChannelSendStmt,
+    IrNodeIfExpr,
+    IrNodeMatchExpr,
+    IrNodeMatchArm,
+    IrNodeCallExpr,
+    IrNodeIndexExpr,
+    IrNodeSelectorExpr,
+    IrNodeTurbofishExpr,
+    IrNodeClosureExpr,
+    IrNodeListExpr,
+    IrNodeMapExpr,
+    IrNodeTupleExpr,
+    IrNodeStructExpr,
+    IrNodeRangeExpr,
+    IrNodeBinaryExpr,
+    IrNodeUnaryExpr,
+    IrNodeQuestionExpr,
+    IrNodePattern,
+    IrNodeField,
+    IrNodeVariant,
+    IrNodeRecovery,
+    IrNodeError,
+}
+
+pub enum IrDiagnosticKind {
+    IrDiagUnexpectedToken,
+    IrDiagMissingName,
+    IrDiagMissingDelimiter,
+    IrDiagUnmatchedDelimiter,
+    IrDiagNonAssociativeOperator,
+    IrDiagTrailingSelector,
+    IrDiagLexerError,
+}
+
+pub struct IrNode {
+    pub kind: IrNodeKind,
+    pub start: Int,
+    pub end: Int,
+    pub depth: Int,
+    pub flags: Int,
+    pub parent: Int,
+    pub children: List<Int>,
+}
+
+pub struct IrDiagnostic {
+    pub kind: IrDiagnosticKind,
+    pub start: Int,
+    pub end: Int,
+    pub expected: String,
+    pub found: String,
+}
+
+pub struct IrArena {
+    pub nodes: List<IrNode>,
+}
+
+pub struct IrModule {
+    pub packageName: String,
+    pub arena: IrArena,
+    pub root: Int,
+    pub decls: List<Int>,
+    pub script: List<Int>,
+    pub diagnostics: List<IrDiagnostic>,
+    pub sourceTokens: Int,
+    pub coveredTokens: Int,
+    pub maxDepth: Int,
+    pub recovered: Int,
+}
+
+pub struct IrSummary {
+    pub nodes: Int,
+    pub decls: Int,
+    pub funcs: Int,
+    pub structs: Int,
+    pub enums: Int,
+    pub interfaces: Int,
+    pub aliases: Int,
+    pub uses: Int,
+    pub lets: Int,
+    pub stmts: Int,
+    pub exprs: Int,
+    pub patterns: Int,
+    pub types: Int,
+    pub diagnostics: Int,
+    pub invalidParents: Int,
+    pub maxDepth: Int,
+}
+
+pub fn emptyIrNode(kind: IrNodeKind) -> IrNode {
+    IrNode {
+        kind,
+        start: 0,
+        end: 0,
+        depth: 0,
+        flags: 0,
+        parent: -1,
+        children: [],
+    }
+}
+
+pub fn emptyIrArena() -> IrArena {
+    IrArena { nodes: [] }
+}
+
+pub fn emptyIrModule(packageName: String) -> IrModule {
+    IrModule {
+        packageName,
+        arena: emptyIrArena(),
+        root: -1,
+        decls: [],
+        script: [],
+        diagnostics: [],
+        sourceTokens: 0,
+        coveredTokens: 0,
+        maxDepth: 0,
+        recovered: 0,
+    }
+}
+
+pub fn emptyIrSummary() -> IrSummary {
+    IrSummary {
+        nodes: 0,
+        decls: 0,
+        funcs: 0,
+        structs: 0,
+        enums: 0,
+        interfaces: 0,
+        aliases: 0,
+        uses: 0,
+        lets: 0,
+        stmts: 0,
+        exprs: 0,
+        patterns: 0,
+        types: 0,
+        diagnostics: 0,
+        invalidParents: 0,
+        maxDepth: 0,
+    }
+}
+
+pub fn irArenaAdd(arena: IrArena, node: IrNode) -> Int {
+    let idx = irArenaNodeCount(arena)
+    arena.nodes.push(node)
+    idx
+}
+
+pub fn irArenaNodeCount(arena: IrArena) -> Int {
+    let mut count = 0
+    for node in arena.nodes {
+        let _ = node
+        count = count + 1
+    }
+    count
+}
+
+pub fn irArenaNodeAt(arena: IrArena, idx: Int) -> IrNode {
+    let mut i = 0
+    for node in arena.nodes {
+        if i == idx {
+            return node
+        }
+        i = i + 1
+    }
+    emptyIrNode(IrNodeError)
+}
+
+pub fn irLowerSource(packageName: String, source: String) -> IrModule {
+    irLowerParseTree(packageName, frontendParseTree(source))
+}
+
+pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
+    let mut module = emptyIrModule(packageName)
+    module.sourceTokens = tree.tokens
+    module.coveredTokens = tree.coveredTokens
+    module.maxDepth = tree.maxDepth
+    module.recovered = tree.recovered
+
+    let mut stack: List<Int> = []
+    for frontNode in tree.nodes {
+        for irStackCount(stack) > frontNode.depth {
+            stack.pop()
+        }
+
+        let mut node = emptyIrNode(irKindFromFront(frontNode.kind))
+        node.start = frontNode.start
+        node.end = frontNode.end
+        node.depth = frontNode.depth
+        node.flags = frontNode.flags
+        node.parent = irParentForDepth(stack, frontNode.depth)
+
+        let idx = irArenaAdd(module.arena, node)
+        if node.parent >= 0 {
+            irAttachChild(module.arena, node.parent, idx)
+        }
+        if frontNode.depth == 0 && module.root < 0 {
+            module.root = idx
+        }
+        if frontNode.depth == 1 && irKindIsDecl(node.kind) {
+            module.decls.push(idx)
+        }
+        if frontNode.depth == 1 && !(irKindIsDecl(node.kind)) && node.kind != IrNodeRecovery {
+            module.script.push(idx)
+        }
+        stack.push(idx)
+    }
+
+    for diag in tree.diagnostics {
+        module.diagnostics.push(
+            IrDiagnostic {
+                kind: irDiagnosticKindFromFront(diag.kind),
+                start: diag.start,
+                end: diag.end,
+                expected: frontTokenKindName(diag.expected),
+                found: frontTokenKindName(diag.found),
+            },
+        )
+    }
+
+    module
+}
+
+fn irAttachChild(arena: IrArena, parent: Int, child: Int) {
+    if parent < 0 {
+        return
+    }
+    let mut node = irArenaNodeAt(arena, parent)
+    node.children.push(child)
+    arena.nodes[parent] = node
+}
+
+fn irParentForDepth(stack: List<Int>, depth: Int) -> Int {
+    if depth <= 0 {
+        return -1
+    }
+    if irStackCount(stack) < depth {
+        return -1
+    }
+    stack[depth - 1]
+}
+
+fn irStackCount(stack: List<Int>) -> Int {
+    let mut count = 0
+    for item in stack {
+        let _ = item
+        count = count + 1
+    }
+    count
+}
+
+pub fn irSummarize(module: IrModule) -> IrSummary {
+    let mut summary = emptyIrSummary()
+    summary.nodes = irArenaNodeCount(module.arena)
+    summary.decls = irListCount(module.decls)
+    summary.diagnostics = irDiagnosticCount(module)
+    summary.maxDepth = module.maxDepth
+    summary.invalidParents = irInvalidParentCount(module)
+
+    for node in module.arena.nodes {
+        if node.kind == IrNodeFnDecl {
+            summary.funcs = summary.funcs + 1
+        } else if node.kind == IrNodeStructDecl {
+            summary.structs = summary.structs + 1
+        } else if node.kind == IrNodeEnumDecl {
+            summary.enums = summary.enums + 1
+        } else if node.kind == IrNodeInterfaceDecl {
+            summary.interfaces = summary.interfaces + 1
+        } else if node.kind == IrNodeTypeAliasDecl {
+            summary.aliases = summary.aliases + 1
+        } else if node.kind == IrNodeUseDecl || node.kind == IrNodeGoUseDecl {
+            summary.uses = summary.uses + 1
+        } else if node.kind == IrNodeLetDecl {
+            summary.lets = summary.lets + 1
+        }
+        if irKindIsStmt(node.kind) {
+            summary.stmts = summary.stmts + 1
+        }
+        if irKindIsExpr(node.kind) {
+            summary.exprs = summary.exprs + 1
+        }
+        if node.kind == IrNodePattern {
+            summary.patterns = summary.patterns + 1
+        }
+        if node.kind == IrNodeType {
+            summary.types = summary.types + 1
+        }
+    }
+
+    summary
+}
+
+pub fn irDiagnosticCount(module: IrModule) -> Int {
+    let mut count = 0
+    for diag in module.diagnostics {
+        let _ = diag
+        count = count + 1
+    }
+    count
+}
+
+pub fn irChildCount(module: IrModule, idx: Int) -> Int {
+    irListCount(irArenaNodeAt(module.arena, idx).children)
+}
+
+pub fn irDeclCount(module: IrModule) -> Int {
+    irListCount(module.decls)
+}
+
+pub fn irListCount(items: List<Int>) -> Int {
+    let mut count = 0
+    for item in items {
+        let _ = item
+        count = count + 1
+    }
+    count
+}
+
+pub fn irInvalidParentCount(module: IrModule) -> Int {
+    let mut count = 0
+    let total = irArenaNodeCount(module.arena)
+    let mut idx = 0
+    for node in module.arena.nodes {
+        if idx == module.root {
+            if node.parent != -1 {
+                count = count + 1
+            }
+        } else if node.parent < 0 || node.parent >= total {
+            count = count + 1
+        }
+        idx = idx + 1
+    }
+    count
+}
+
+pub fn irKindIsDecl(kind: IrNodeKind) -> Bool {
+    match kind {
+        IrNodeUseDecl -> true,
+        IrNodeGoUseDecl -> true,
+        IrNodeFnDecl -> true,
+        IrNodeStructDecl -> true,
+        IrNodeEnumDecl -> true,
+        IrNodeInterfaceDecl -> true,
+        IrNodeTypeAliasDecl -> true,
+        IrNodeLetDecl -> true,
+        _ -> false,
+    }
+}
+
+pub fn irKindIsStmt(kind: IrNodeKind) -> Bool {
+    kind == IrNodeLetStmt || kind == IrNodeReturnStmt || kind == IrNodeBreakStmt || kind == IrNodeContinueStmt || kind == IrNodeForStmt || kind == IrNodeDeferStmt || kind == IrNodeAssignStmt || kind == IrNodeChannelSendStmt
+}
+
+pub fn irKindIsExpr(kind: IrNodeKind) -> Bool {
+    kind == IrNodeCallExpr || kind == IrNodeIndexExpr || kind == IrNodeSelectorExpr || kind == IrNodeTurbofishExpr || kind == IrNodeClosureExpr || kind == IrNodeListExpr || kind == IrNodeMapExpr || kind == IrNodeTupleExpr || kind == IrNodeStructExpr || kind == IrNodeRangeExpr || kind == IrNodeBinaryExpr || kind == IrNodeUnaryExpr || kind == IrNodeQuestionExpr || kind == IrNodeIfExpr || kind == IrNodeMatchExpr
+}
+
+pub fn irKindFromFront(kind: FrontNodeKind) -> IrNodeKind {
+    if kind == frontNodeKindByName("file") {
+        IrNodeModule
+    } else if kind == frontNodeKindByName("annotation") {
+        IrNodeAnnotation
+    } else if kind == frontNodeKindByName("use") {
+        IrNodeUseDecl
+    } else if kind == frontNodeKindByName("goUse") {
+        IrNodeGoUseDecl
+    } else if kind == frontNodeKindByName("fn") {
+        IrNodeFnDecl
+    } else if kind == frontNodeKindByName("struct") {
+        IrNodeStructDecl
+    } else if kind == frontNodeKindByName("enum") {
+        IrNodeEnumDecl
+    } else if kind == frontNodeKindByName("interface") {
+        IrNodeInterfaceDecl
+    } else if kind == frontNodeKindByName("typeAlias") {
+        IrNodeTypeAliasDecl
+    } else if kind == frontNodeKindByName("letDecl") {
+        IrNodeLetDecl
+    } else if kind == frontNodeKindByName("genericParams") {
+        IrNodeGenericParams
+    } else if kind == frontNodeKindByName("paramList") {
+        IrNodeParamList
+    } else if kind == frontNodeKindByName("param") {
+        IrNodeParam
+    } else if kind == frontNodeKindByName("type") {
+        IrNodeType
+    } else if kind == frontNodeKindByName("block") {
+        IrNodeBlock
+    } else if kind == frontNodeKindByName("letStmt") {
+        IrNodeLetStmt
+    } else if kind == frontNodeKindByName("return") {
+        IrNodeReturnStmt
+    } else if kind == frontNodeKindByName("break") {
+        IrNodeBreakStmt
+    } else if kind == frontNodeKindByName("continue") {
+        IrNodeContinueStmt
+    } else if kind == frontNodeKindByName("for") {
+        IrNodeForStmt
+    } else if kind == frontNodeKindByName("defer") {
+        IrNodeDeferStmt
+    } else if kind == frontNodeKindByName("assign") {
+        IrNodeAssignStmt
+    } else if kind == frontNodeKindByName("channelSend") {
+        IrNodeChannelSendStmt
+    } else if kind == frontNodeKindByName("if") {
+        IrNodeIfExpr
+    } else if kind == frontNodeKindByName("match") {
+        IrNodeMatchExpr
+    } else if kind == frontNodeKindByName("matchArm") {
+        IrNodeMatchArm
+    } else if kind == frontNodeKindByName("call") {
+        IrNodeCallExpr
+    } else if kind == frontNodeKindByName("index") {
+        IrNodeIndexExpr
+    } else if kind == frontNodeKindByName("selector") {
+        IrNodeSelectorExpr
+    } else if kind == frontNodeKindByName("turbofish") {
+        IrNodeTurbofishExpr
+    } else if kind == frontNodeKindByName("closure") {
+        IrNodeClosureExpr
+    } else if kind == frontNodeKindByName("list") {
+        IrNodeListExpr
+    } else if kind == frontNodeKindByName("map") {
+        IrNodeMapExpr
+    } else if kind == frontNodeKindByName("tuple") {
+        IrNodeTupleExpr
+    } else if kind == frontNodeKindByName("structExpr") {
+        IrNodeStructExpr
+    } else if kind == frontNodeKindByName("range") {
+        IrNodeRangeExpr
+    } else if kind == frontNodeKindByName("binary") {
+        IrNodeBinaryExpr
+    } else if kind == frontNodeKindByName("unary") {
+        IrNodeUnaryExpr
+    } else if kind == frontNodeKindByName("question") {
+        IrNodeQuestionExpr
+    } else if kind == frontNodeKindByName("pattern") {
+        IrNodePattern
+    } else if kind == frontNodeKindByName("field") {
+        IrNodeField
+    } else if kind == frontNodeKindByName("variant") {
+        IrNodeVariant
+    } else {
+        IrNodeRecovery
+    }
+}
+
+pub fn irDiagnosticKindFromFront(kind: FrontParseDiagnosticKind) -> IrDiagnosticKind {
+    if kind == frontParseDiagnosticKindByName("unexpected") {
+        IrDiagUnexpectedToken
+    } else if kind == frontParseDiagnosticKindByName("missingName") {
+        IrDiagMissingName
+    } else if kind == frontParseDiagnosticKindByName("missingDelimiter") {
+        IrDiagMissingDelimiter
+    } else if kind == frontParseDiagnosticKindByName("unmatchedDelimiter") {
+        IrDiagUnmatchedDelimiter
+    } else if kind == frontParseDiagnosticKindByName("nonAssoc") {
+        IrDiagNonAssociativeOperator
+    } else if kind == frontParseDiagnosticKindByName("trailingSelector") {
+        IrDiagTrailingSelector
+    } else {
+        IrDiagLexerError
+    }
+}
+
+pub fn irNodeKindName(kind: IrNodeKind) -> String {
+    match kind {
+        IrNodeModule -> "module",
+        IrNodeAnnotation -> "annotation",
+        IrNodeUseDecl -> "use",
+        IrNodeGoUseDecl -> "goUse",
+        IrNodeFnDecl -> "fn",
+        IrNodeStructDecl -> "struct",
+        IrNodeEnumDecl -> "enum",
+        IrNodeInterfaceDecl -> "interface",
+        IrNodeTypeAliasDecl -> "typeAlias",
+        IrNodeLetDecl -> "letDecl",
+        IrNodeGenericParams -> "genericParams",
+        IrNodeParamList -> "paramList",
+        IrNodeParam -> "param",
+        IrNodeType -> "type",
+        IrNodeBlock -> "block",
+        IrNodeLetStmt -> "letStmt",
+        IrNodeReturnStmt -> "return",
+        IrNodeBreakStmt -> "break",
+        IrNodeContinueStmt -> "continue",
+        IrNodeForStmt -> "for",
+        IrNodeDeferStmt -> "defer",
+        IrNodeAssignStmt -> "assign",
+        IrNodeChannelSendStmt -> "channelSend",
+        IrNodeIfExpr -> "if",
+        IrNodeMatchExpr -> "match",
+        IrNodeMatchArm -> "matchArm",
+        IrNodeCallExpr -> "call",
+        IrNodeIndexExpr -> "index",
+        IrNodeSelectorExpr -> "selector",
+        IrNodeTurbofishExpr -> "turbofish",
+        IrNodeClosureExpr -> "closure",
+        IrNodeListExpr -> "list",
+        IrNodeMapExpr -> "map",
+        IrNodeTupleExpr -> "tuple",
+        IrNodeStructExpr -> "structExpr",
+        IrNodeRangeExpr -> "range",
+        IrNodeBinaryExpr -> "binary",
+        IrNodeUnaryExpr -> "unary",
+        IrNodeQuestionExpr -> "question",
+        IrNodePattern -> "pattern",
+        IrNodeField -> "field",
+        IrNodeVariant -> "variant",
+        IrNodeRecovery -> "recovery",
+        IrNodeError -> "error",
+    }
+}
+
+pub fn irDiagnosticKindName(kind: IrDiagnosticKind) -> String {
+    match kind {
+        IrDiagUnexpectedToken -> "unexpectedToken",
+        IrDiagMissingName -> "missingName",
+        IrDiagMissingDelimiter -> "missingDelimiter",
+        IrDiagUnmatchedDelimiter -> "unmatchedDelimiter",
+        IrDiagNonAssociativeOperator -> "nonAssociativeOperator",
+        IrDiagTrailingSelector -> "trailingSelector",
+        IrDiagLexerError -> "lexerError",
+    }
+}
+
+pub fn irFnDeclKind() -> IrNodeKind {
+    IrNodeFnDecl
+}
+pub fn irMatchExprKind() -> IrNodeKind {
+    IrNodeMatchExpr
+}
+pub fn irPatternKind() -> IrNodeKind {
+    IrNodePattern
+}
+pub fn irTrailingSelectorDiagKind() -> IrDiagnosticKind {
+    IrDiagTrailingSelector
+}

--- a/examples/selfhost-core/ir_test.osty
+++ b/examples/selfhost-core/ir_test.osty
@@ -1,0 +1,66 @@
+use std.testing
+
+fn testIrLowersParseTreeIntoIndependentModule() {
+    let source = r"""
+        use std.testing
+        pub struct Box<T> { value: T }
+        enum Maybe<T> { Some(T), None }
+        fn main(xs: List<Int>) -> Int {
+            let mut total = 0
+            for x in xs { total = total + x }
+            match Some(total) {
+                Some(v) if v > 0 -> v,
+                None -> 0,
+            }
+        }
+        """
+    let module = irLowerSource("main", source)
+    let summary = irSummarize(module)
+
+    testing.assertEq(module.packageName, "main")
+    testing.assertEq(summary.decls, 4)
+    testing.assertEq(summary.uses, 1)
+    testing.assertEq(summary.structs, 1)
+    testing.assertEq(summary.enums, 1)
+    testing.assertEq(summary.funcs, 1)
+    testing.assert(summary.stmts >= 2)
+    testing.assert(summary.exprs >= 3)
+    testing.assert(summary.patterns >= 2)
+    testing.assertEq(summary.diagnostics, 0)
+    testing.assertEq(summary.invalidParents, 0)
+}
+
+fn testIrKeepsParentChildShape() {
+    let module = irLowerSource("main", r"fn f() { if true { return } else { return } }")
+    let root = irArenaNodeAt(module.arena, module.root)
+    let summary = irSummarize(module)
+
+    testing.assertEq(irNodeKindName(root.kind), "module")
+    testing.assertEq(root.parent, -1)
+    testing.assert(irChildCount(module, module.root) >= 1)
+    testing.assert(summary.maxDepth >= 2)
+    testing.assertEq(summary.invalidParents, 0)
+}
+
+fn testIrSurfacesDiagnosticsWithoutFrontendEnums() {
+    let module = irLowerSource("main", r"fn broken( {")
+    let summary = irSummarize(module)
+
+    testing.assert(summary.diagnostics >= 1)
+    testing.assertEq(irDiagnosticKindName(module.diagnostics[0].kind), "missingDelimiter")
+    testing.assert(module.diagnostics[0].expected != "")
+}
+
+fn testIrKindNamesAreStable() {
+    testing.assertEq(irNodeKindName(irFnDeclKind()), "fn")
+    testing.assertEq(irNodeKindName(irMatchExprKind()), "match")
+    testing.assertEq(irNodeKindName(irPatternKind()), "pattern")
+    testing.assertEq(irDiagnosticKindName(irTrailingSelectorDiagKind()), "trailingSelector")
+    testing.assertEq(irNodeKindName(irKindFromFront(frontNodeKindByName("fn"))), "fn")
+    testing.assertEq(
+        irDiagnosticKindName(
+            irDiagnosticKindFromFront(frontParseDiagnosticKindByName("missingName")),
+        ),
+        "missingName",
+    )
+}

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -2224,7 +2224,7 @@ func (g *gen) emitCollectionLess(left, right string, t types.Type) {
 }
 
 func (g *gen) collectionListElemGo(t types.Type, fallback string) string {
-	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && (n.Sym.Name == "List" || n.Sym.Name == "Iter") && len(n.Args) == 1 {
 		return g.goType(n.Args[0])
 	}
 	return strings.TrimPrefix(fallback, "[]")

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -99,11 +99,40 @@ func (g *gen) emitIdent(id *ast.Ident) {
 	// wrapped in the enum interface conversion so type assertions at
 	// use sites work (a bare struct value cannot be the scrutinee of a
 	// `v.(Enum_Variant)` type assertion).
-	if owner, ok := g.variantOwner[id.Name]; ok {
+	if owner, ok := g.variantOwnerForIdent(id); ok {
 		g.body.writef("%s(&%s_%s{})", owner, owner, id.Name)
 		return
 	}
 	g.body.write(mangleIdent(id.Name))
+}
+
+func (g *gen) variantOwnerForIdent(id *ast.Ident) (string, bool) {
+	if id == nil {
+		return "", false
+	}
+	if sym := g.symbolFor(id); sym != nil {
+		if sym.Kind != resolve.SymVariant {
+			return "", false
+		}
+		if owner, ok := g.variantOwnerForSymbol(sym); ok {
+			return owner, true
+		}
+	}
+	if owner, ok := g.variantOwner[id.Name]; ok {
+		return owner, true
+	}
+	return "", false
+}
+
+func (g *gen) variantOwnerForSymbol(sym *resolve.Symbol) (string, bool) {
+	t := g.symTypeOf(sym)
+	if fn, ok := t.(*types.FnType); ok {
+		t = fn.Return
+	}
+	if n, ok := types.AsNamed(t); ok && n.Sym != nil {
+		return n.Sym.Name, true
+	}
+	return "", false
 }
 
 // emitStructLit writes a struct literal. `Self { ... }` is rewritten
@@ -431,7 +460,7 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 			return
 		}
 		// User-defined variant construction: Fn is a bare variant name.
-		if owner, ok := g.variantOwner[id.Name]; ok {
+		if owner, ok := g.variantOwnerForIdent(id); ok {
 			g.emitVariantCtor(owner, id.Name, c.Args)
 			return
 		}

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -321,6 +321,12 @@ func (g *gen) goNamedAST(n *ast.NamedType) string {
 			g.needJSON = true
 			return "Json"
 		}
+		if len(n.Path) == 2 && n.Path[1] == "Iter" && g.isStdlibAliasName(n.Path[0], "iter") {
+			if len(n.Args) == 1 {
+				return "[]" + g.goTypeExpr(n.Args[0])
+			}
+			return "[]any"
+		}
 		if len(n.Path) == 2 && g.isStdlibAliasName(n.Path[0], "error") {
 			switch n.Path[1] {
 			case "Error":

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -141,8 +141,72 @@ type Config struct {
 	RunGen bool
 
 	// GenPackageName is the Go package clause used when RunGen is set.
-	// Defaults to "main".
+	// Single-file mode defaults to "main"; package/workspace mode derives
+	// a valid Go identifier from the Osty package name when this is empty.
 	GenPackageName string
+}
+
+func genPackageName(cfgName, fallback string) string {
+	if cfgName != "" {
+		return sanitizeGoPackageName(cfgName)
+	}
+	if fallback == "" {
+		return "main"
+	}
+	return sanitizeGoPackageName(fallback)
+}
+
+func sanitizeGoPackageName(name string) string {
+	var b strings.Builder
+	for i, r := range name {
+		ok := r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			continue
+		}
+		if i == 0 && r >= '0' && r <= '9' {
+			b.WriteByte('_')
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	out := b.String()
+	if out == "" || strings.Trim(out, "_") == "" {
+		return "main"
+	}
+	if goKeywords[out] {
+		return "_" + out
+	}
+	return out
+}
+
+var goKeywords = map[string]bool{
+	"break":       true,
+	"default":     true,
+	"func":        true,
+	"interface":   true,
+	"select":      true,
+	"case":        true,
+	"defer":       true,
+	"go":          true,
+	"map":         true,
+	"struct":      true,
+	"chan":        true,
+	"else":        true,
+	"goto":        true,
+	"package":     true,
+	"switch":      true,
+	"const":       true,
+	"fallthrough": true,
+	"if":          true,
+	"range":       true,
+	"type":        true,
+	"continue":    true,
+	"for":         true,
+	"import":      true,
+	"return":      true,
+	"var":         true,
 }
 
 // Run executes lex → parse → resolve → check → lint over src with
@@ -287,10 +351,7 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 	// makes the situation obvious.
 	if cfg.RunGen {
 		t0 = time.Now()
-		pkg := cfg.GenPackageName
-		if pkg == "" {
-			pkg = "main"
-		}
+		pkg := genPackageName(cfg.GenPackageName, "main")
 		out, err := gen.Generate(pkg, file, res, chk)
 		r.GenBytes = out
 		r.GenError = err
@@ -456,10 +517,7 @@ func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
 	// still reconstruct per-file boundaries.
 	if cfg.RunGen {
 		t0 = time.Now()
-		pkgName := cfg.GenPackageName
-		if pkgName == "" {
-			pkgName = pkg.Name
-		}
+		pkgName := genPackageName(cfg.GenPackageName, pkg.Name)
 		var genBuf []byte
 		var firstErr error
 		genErrs := 0
@@ -700,9 +758,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 				continue
 			}
 			pkgName := cfg.GenPackageName
-			if pkgName == "" {
-				pkgName = pkg.Name
-			}
+			pkgName = genPackageName(pkgName, pkg.Name)
 			for _, pf := range pkg.Files {
 				if pf.File == nil {
 					continue

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -153,6 +155,52 @@ func TestRunGen(t *testing.T) {
 	}
 	if !strings.Contains(string(r.GenBytes), "package main") {
 		t.Errorf("GenBytes missing 'package main' clause; got: %s", r.GenBytes)
+	}
+}
+
+func TestRunPackageGenSanitizesManifestPackageName(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "selfhost-core")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir package: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(`[package]
+name = "selfhost-core"
+version = "0.1.0"
+edition = "0.3"
+`), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.osty"), []byte(`pub fn answer() -> Int {
+    42
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	r, err := RunPackage(dir, nil, Config{RunGen: true})
+	if err != nil {
+		t.Fatalf("RunPackage: %v", err)
+	}
+	if r.GenError != nil {
+		t.Fatalf("GenError = %v\n--- generated ---\n%s", r.GenError, r.GenBytes)
+	}
+	if !strings.Contains(string(r.GenBytes), "package selfhost_core") {
+		t.Fatalf("generated package name was not sanitized:\n%s", r.GenBytes)
+	}
+}
+
+func TestSanitizeGoPackageName(t *testing.T) {
+	cases := map[string]string{
+		"selfhost-core": "selfhost_core",
+		"123pkg":        "_123pkg",
+		"type":          "_type",
+		"---":           "main",
+		"":              "main",
+	}
+	for in, want := range cases {
+		if got := sanitizeGoPackageName(in); got != want {
+			t.Errorf("sanitizeGoPackageName(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/internal/testgen/testgen_test.go
+++ b/internal/testgen/testgen_test.go
@@ -119,7 +119,7 @@ fn testBoth() {
     testing.assert(sameA())
     testing.assert(sameB())
 }
-`))
+	`))
 	pkg, chk := loadCalc(t, dir)
 
 	srcs, err := GenerateHarness(pkg, chk, nil)
@@ -167,6 +167,75 @@ fn testCrossFileVariant() {
 	}})
 	if err != nil {
 		t.Fatalf("GenerateHarness: %v\n--- main.go ---\n%s", err, srcs.Main)
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go binary not on PATH; skipping end-to-end run")
+	}
+	out := t.TempDir()
+	mustWrite(t, filepath.Join(out, "main.go"), srcs.Main)
+	mustWrite(t, filepath.Join(out, "harness.go"), srcs.Harness)
+	mustWrite(t, filepath.Join(out, "go.mod"), []byte("module ostytest\ngo 1.22\n"))
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = out
+	combined, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("go run failed: %v\n%s\n--- main.go ---\n%s", runErr, combined, srcs.Main)
+	}
+	if want := "1 passed, 0 failed, 1 total"; !strings.Contains(string(combined), want) {
+		t.Fatalf("missing summary %q in:\n%s", want, combined)
+	}
+}
+
+func TestGenerateHarness_CrossFileEnumVariantRefs(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "token.osty"), []byte(`pub enum TokenKind {
+    EOF,
+    Newline,
+    Ident(String),
+}
+`))
+	mustWrite(t, filepath.Join(dir, "parser.osty"), []byte(`pub struct Node {
+    pub kind: TokenKind,
+}
+
+pub fn emptyNode() -> Node {
+    Node { kind: EOF }
+}
+
+pub fn identNode(text: String) -> Node {
+    Node { kind: Ident(text) }
+}
+
+pub fn isEOF(kind: TokenKind) -> Bool {
+    kind == EOF
+}
+
+pub fn isNewline(kind: TokenKind) -> Bool {
+    kind == Newline
+}
+`))
+	mustWrite(t, filepath.Join(dir, "parser_test.osty"), []byte(`fn testCrossFileEnumVariantRefs() {
+    let n = emptyNode()
+    let _ = isEOF(n.kind)
+    let _ = isNewline(Newline)
+    let _ = identNode("x")
+}
+`))
+
+	pkg, err := resolve.LoadPackageWithTests(dir)
+	if err != nil {
+		t.Fatalf("load package: %v", err)
+	}
+	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+	chk := check.Package(pkg, res)
+	srcs, err := GenerateHarness(pkg, chk, []Entry{{
+		Name: "testCrossFileEnumVariantRefs",
+		Kind: KindTest,
+		File: "parser_test.osty",
+		Line: 1,
+	}})
+	if err != nil {
+		t.Fatalf("GenerateHarness: %v", err)
 	}
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go binary not on PATH; skipping end-to-end run")


### PR DESCRIPTION
## Summary
- add an Osty-authored independent IR for selfhost-core and dogfood
- make test harness generation dedupe structural equality runtime helpers
- fix cross-file enum variant codegen and package-name sanitization for generated Go
- unblock dogfood parser checks by discarding statement-only token returns

## Verification
- go run ./cmd/osty test examples/selfhost-core ir_test
- go run ./cmd/osty test examples/dogfood ir_test
- go run ./cmd/osty pipeline --gen examples/selfhost-core
- go run ./cmd/osty pipeline --gen examples/dogfood
- go test ./internal/testgen -count=1
- go test ./internal/pipeline ./cmd/osty ./internal/ir -count=1
- go test ./internal/gen -run "TestEnumBareVariant|TestEnumTupleVariant|TestMatch" -count=1