### PR TITLE
Complete std.json value API

### DIFF
--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -596,6 +596,17 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			getIndex:       jsonGetIndexResult,
 		}`, full)
 		return true
+	case "regex":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		g.needRegex = true
+		g.emitUseStub(alias, `struct {
+			compile func(pattern string) Result[Regex, error]
+		}{
+			compile: regexCompile,
+		}`, full)
+		return true
 	case "error":
 		// std.error calls and qualified literals are lowered directly by
 		// expr.go; no package-shaped Go value is needed here. Avoid
@@ -655,49 +666,31 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			toHex       func(b []byte) string
 			fromHex     func(s string) Result[[]byte, any]
 		}{
-			fromString: func(s string) []byte { return []byte(s) },
-			toString:   func(b []byte) Result[string, any] { return resultOk[string, any](string(b)) },
-			len:        func(b []byte) int { return len(b) },
-			isEmpty:    func(b []byte) bool { return len(b) == 0 },
-			get: func(b []byte, i int) *byte {
-				if i < 0 || i >= len(b) {
-					return nil
-				}
-				v := b[i]
-				return &v
-			},
+			fromString:  bytesFromString,
+			toString:    bytesToString,
+			len:         bytesLen,
+			isEmpty:     bytesIsEmpty,
+			get:         bytesGet,
 			equal:       bytesEqual,
 			contains:    bytesContains,
-			startsWith:  stdbytes.HasPrefix,
-			endsWith:    stdbytes.HasSuffix,
-			indexOf: func(b []byte, sub []byte) *int {
-				i := stdbytes.Index(b, sub)
-				if i < 0 {
-					return nil
-				}
-				return &i
-			},
-			lastIndexOf: func(b []byte, sub []byte) *int {
-				i := stdbytes.LastIndex(b, sub)
-				if i < 0 {
-					return nil
-				}
-				return &i
-			},
-			split:      stdbytes.Split,
-			join:       stdbytes.Join,
-			concat:     func(a []byte, b []byte) []byte { return append(append([]byte(nil), a...), b...) },
-			repeat:     stdbytes.Repeat,
-			replace:    func(b []byte, old []byte, new []byte) []byte { return stdbytes.Replace(b, old, new, 1) },
-			replaceAll: func(b []byte, old []byte, new []byte) []byte { return stdbytes.ReplaceAll(b, old, new) },
-			trimLeft:   func(b []byte, strip []byte) []byte { return stdbytes.TrimLeft(b, string(strip)) },
-			trimRight:  func(b []byte, strip []byte) []byte { return stdbytes.TrimRight(b, string(strip)) },
-			trim:       func(b []byte, strip []byte) []byte { return stdbytes.Trim(b, string(strip)) },
-			trimSpace:  stdbytes.TrimSpace,
-			toUpper:    bytesToUpper,
-			toLower:    stdbytes.ToLower,
-			toHex:      _ostybyteshex.EncodeToString,
-			fromHex: bytesFromHex,
+			startsWith:  bytesStartsWith,
+			endsWith:    bytesEndsWith,
+			indexOf:     bytesIndexOf,
+			lastIndexOf: bytesLastIndexOf,
+			split:       bytesSplit,
+			join:        bytesJoin,
+			concat:      bytesConcat,
+			repeat:      bytesRepeat,
+			replace:     bytesReplace,
+			replaceAll:  bytesReplaceAll,
+			trimLeft:    bytesTrimLeft,
+			trimRight:   bytesTrimRight,
+			trim:        bytesTrim,
+			trimSpace:   bytesTrimSpace,
+			toUpper:     bytesToUpper,
+			toLower:     bytesToLower,
+			toHex:       bytesToHex,
+			fromHex:     bytesFromHex,
 		}`, full)
 		return true
 	case "csv":

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -1072,7 +1072,7 @@ func (g *gen) emitStdlibIterCall(c *ast.CallExpr) bool {
 		explicit = tf.Args
 	}
 	id, parts, ok := stdlibFieldChain(base)
-	if !ok || id == nil || len(parts) != 1 || !g.isStdlibPackageAlias(id, "iter") {
+	if !ok || id == nil || len(parts) != 1 || (!g.isStdlibPackageAlias(id, "iter") && !g.isStdlibAliasName(id.Name, "iter")) {
 		return false
 	}
 	switch parts[0] {

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -641,6 +641,87 @@ func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F]
 }
 `)
 	}
+	if g.needBytesRuntime {
+		out.WriteString(`
+func bytesFromString(s string) []byte { return []byte(s) }
+
+func bytesToString(b []byte) Result[string, any] { return resultOk[string, any](string(b)) }
+
+func bytesLen(b []byte) int { return len(b) }
+
+func bytesIsEmpty(b []byte) bool { return len(b) == 0 }
+
+func bytesGet(b []byte, i int) *byte {
+	if i < 0 || i >= len(b) {
+		return nil
+	}
+	v := b[i]
+	return &v
+}
+
+func bytesEqual(a []byte, b []byte) bool { return stdbytes.Equal(a, b) }
+
+func bytesContains(b []byte, sub []byte) bool { return stdbytes.Contains(b, sub) }
+
+func bytesStartsWith(b []byte, prefix []byte) bool { return stdbytes.HasPrefix(b, prefix) }
+
+func bytesEndsWith(b []byte, suffix []byte) bool { return stdbytes.HasSuffix(b, suffix) }
+
+func bytesIndexOf(b []byte, sub []byte) *int {
+	i := stdbytes.Index(b, sub)
+	if i < 0 {
+		return nil
+	}
+	return &i
+}
+
+func bytesLastIndexOf(b []byte, sub []byte) *int {
+	i := stdbytes.LastIndex(b, sub)
+	if i < 0 {
+		return nil
+	}
+	return &i
+}
+
+func bytesSplit(b []byte, sep []byte) [][]byte { return stdbytes.Split(b, sep) }
+
+func bytesJoin(parts [][]byte, sep []byte) []byte { return stdbytes.Join(parts, sep) }
+
+func bytesConcat(a []byte, b []byte) []byte { return append(append([]byte(nil), a...), b...) }
+
+func bytesRepeat(b []byte, n int) []byte { return stdbytes.Repeat(b, n) }
+
+func bytesReplace(b []byte, old []byte, new []byte) []byte {
+	return stdbytes.Replace(b, old, new, 1)
+}
+
+func bytesReplaceAll(b []byte, old []byte, new []byte) []byte {
+	return stdbytes.ReplaceAll(b, old, new)
+}
+
+func bytesTrimLeft(b []byte, strip []byte) []byte { return stdbytes.TrimLeft(b, string(strip)) }
+
+func bytesTrimRight(b []byte, strip []byte) []byte { return stdbytes.TrimRight(b, string(strip)) }
+
+func bytesTrim(b []byte, strip []byte) []byte { return stdbytes.Trim(b, string(strip)) }
+
+func bytesTrimSpace(b []byte) []byte { return stdbytes.TrimSpace(b) }
+
+func bytesToUpper(b []byte) []byte { return stdbytes.ToUpper(b) }
+
+func bytesToLower(b []byte) []byte { return stdbytes.ToLower(b) }
+
+func bytesToHex(b []byte) string { return _ostybyteshex.EncodeToString(b) }
+
+func bytesFromHex(s string) Result[[]byte, any] {
+	b, err := _ostybyteshex.DecodeString(s)
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	return resultOk[[]byte, any](b)
+}
+`)
+	}
 	if g.needErrorRuntime {
 		out.WriteString(`
 type ostyBasicError struct {
@@ -1288,23 +1369,6 @@ type refInterfaceHeader struct {
 
 func refInterfaceData(v any) unsafe.Pointer {
 	return (*refInterfaceHeader)(unsafe.Pointer(&v)).data
-}
-`)
-	}
-	if g.needBytesRuntime {
-		out.WriteString(`
-func bytesEqual(a, b []byte) bool { return stdbytes.Equal(a, b) }
-
-func bytesContains(b, sub []byte) bool { return stdbytes.Contains(b, sub) }
-
-func bytesToUpper(b []byte) []byte { return stdbytes.ToUpper(b) }
-
-func bytesFromHex(s string) Result[[]byte, any] {
-	b, err := _ostybyteshex.DecodeString(s)
-	if err != nil {
-		return resultErr[[]byte, any](err)
-	}
-	return resultOk[[]byte, any](b)
 }
 `)
 	}

--- a/internal/gen/json_value_test.go
+++ b/internal/gen/json_value_test.go
@@ -83,3 +83,75 @@ func TestStdJSONValueAPI(t *testing.T) {
 		}
 	}
 }
+
+func TestStdJSONValueAPIDeepEdges(t *testing.T) {
+	src := `use std.json
+use std.bytes
+
+fn main() {
+    let text = "[[[\{\"leaf\":\"\\uD834\\uDD1E\",\"escaped\":\"line\\nquote\",\"n\":-12.5e2,\"arr\":[true,false,null]\}]]]"
+    let parsed = json.parseValue(text).unwrap()
+    let level1 = json.getIndex(parsed, 0).unwrap()
+    let level2 = json.getIndex(level1, 0).unwrap()
+    let obj = json.getIndex(level2, 0).unwrap()
+
+    let leaf = json.getField(obj, "leaf").unwrap()
+    let leafText = json.asString(leaf).unwrap()
+    println(bytes.len(bytes.fromString(leafText)))
+    println(bytes.len(bytes.fromString(json.stringifyValue(leaf))))
+
+    let escaped = json.asString(json.getField(obj, "escaped").unwrap()).unwrap()
+    println(bytes.contains(bytes.fromString(escaped), bytes.fromString("line")))
+    println(escaped == "line\nquote")
+    println(json.stringifyValue(json.String(escaped)))
+
+    let num = json.asNumber(json.getField(obj, "n").unwrap()).unwrap()
+    println(num)
+    let arr = json.asArray(json.getField(obj, "arr").unwrap()).unwrap()
+    println(arr.len())
+    println(json.asBool(arr[0]).unwrap())
+    println(json.isNull(arr[2]))
+
+    println(json.asObject(obj).unwrap().len())
+    println(json.asBool(obj).isErr())
+    println(json.getIndex(parsed, -1).isErr())
+    println(json.getField(parsed, "missing").isErr())
+    println(json.parseValue("\"\\uD800\"").isErr())
+    println(json.parseValue("\"\\uDD1E\"").isErr())
+    println(json.parseValue("01").isErr())
+    println(json.parseValue("[1,]").isErr())
+
+    let built: json.Json = json.Array([json.Array([json.Object({"a": json.Null, "z": json.Number(2.0)})])])
+    println(json.stringifyValue(built))
+}
+`
+
+	goSrc, err := transpileWithStdlib(t, src)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		`4`,
+		`6`,
+		`true`,
+		`true`,
+		`"line\nquote"`,
+		`-1250`,
+		`3`,
+		`true`,
+		`true`,
+		`4`,
+		`true`,
+		`true`,
+		`true`,
+		`true`,
+		`true`,
+		`true`,
+		`true`,
+		`[[{"a":null,"z":2}]]`,
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+}

--- a/internal/gen/regex_runtime.go
+++ b/internal/gen/regex_runtime.go
@@ -626,7 +626,11 @@ func (re Regex) runAt(chars []rune, boff []int, sp int) ([]int, bool) {
 func (re Regex) findSlots(text string) ([]int, bool) {
 	chars := []rune(text)
 	boff := rxByteOffsets(chars)
-	for sp := 0; sp <= len(chars); sp++ {
+	return re.findSlotsFrom(chars, boff, 0)
+}
+
+func (re Regex) findSlotsFrom(chars []rune, boff []int, from int) ([]int, bool) {
+	for sp := from; sp <= len(chars); sp++ {
 		if sl, ok := re.runAt(chars, boff, sp); ok {
 			return sl, true
 		}
@@ -662,7 +666,7 @@ func (re Regex) findAll(text string) []RegexMatch {
 	boff := rxByteOffsets(chars)
 	var out []RegexMatch
 	for from := 0; from <= len(chars); {
-		sl, ok := re.runAt(chars, boff, from)
+		sl, ok := re.findSlotsFrom(chars, boff, from)
 		if !ok {
 			from++
 			continue
@@ -692,7 +696,7 @@ func (re Regex) capturesAll(text string) []Captures {
 	boff := rxByteOffsets(chars)
 	var out []Captures
 	for from := 0; from <= len(chars); {
-		sl, ok := re.runAt(chars, boff, from)
+		sl, ok := re.findSlotsFrom(chars, boff, from)
 		if !ok {
 			from++
 			continue
@@ -786,7 +790,7 @@ func (re Regex) replaceAll(text, replacement string) string {
 	var out []byte
 	lastEnd := 0
 	for from := 0; from <= len(chars); {
-		sl, ok := re.runAt(chars, boff, from)
+		sl, ok := re.findSlotsFrom(chars, boff, from)
 		if !ok {
 			from++
 			continue

--- a/internal/stdlib/modules/bytes.osty
+++ b/internal/stdlib/modules/bytes.osty
@@ -76,6 +76,10 @@ pub fn trim(b: Bytes, strip: Bytes) -> Bytes {
     trimLeft(trimRight(b, strip), strip)
 }
 
+pub fn trimSpace(b: Bytes) -> Bytes {
+    trimSpace(b)
+}
+
 pub fn toUpper(b: Bytes) -> Bytes {
     toUpper(b)
 }

--- a/internal/stdlib/modules/json.osty
+++ b/internal/stdlib/modules/json.osty
@@ -72,12 +72,12 @@ pub fn parse<T>(text: String) -> Result<T, Error> {
 
 pub fn stringifyValue(value: Json) -> String {
     match value {
-        Json.Null -> "null",
-        Json.Bool(b) -> if b { "true" } else { "false" },
-        Json.Number(n) -> formatJsonNumber(n),
-        Json.String(s) -> escapeJsonString(s),
-        Json.Array(arr) -> stringifyArray(arr),
-        Json.Object(obj) -> stringifyObject(obj),
+        Null -> "null",
+        Bool(b) -> if b { "true" } else { "false" },
+        Number(n) -> formatJsonNumber(n),
+        String(s) -> escapeJsonString(s),
+        Array(arr) -> stringifyArray(arr),
+        Object(obj) -> stringifyObject(obj),
     }
 }
 
@@ -196,7 +196,7 @@ fn parseVal(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
     if c == 0x22 {
         // " — string
         let (s, next) = parseStr(bs, pos, len)?
-        Ok((Json.String(s), next))
+        Ok((String(s), next))
     } else if c == 0x7B {
         // { — object
         parseObj(bs, pos, len)
@@ -205,13 +205,13 @@ fn parseVal(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
         parseArr(bs, pos, len)
     } else if c == 0x74 {
         // t — true
-        parseLiteral(bs, pos, len, "true", Json.Bool(true))
+        parseLiteral(bs, pos, len, "true", Bool(true))
     } else if c == 0x66 {
         // f — false
-        parseLiteral(bs, pos, len, "false", Json.Bool(false))
+        parseLiteral(bs, pos, len, "false", Bool(false))
     } else if c == 0x6E {
         // n — null
-        parseLiteral(bs, pos, len, "null", Json.Null)
+        parseLiteral(bs, pos, len, "null", Null)
     } else if c == 0x2D || (c >= 0x30 && c <= 0x39) {
         // - or 0-9 — number
         parseNum(bs, pos, len)
@@ -258,21 +258,21 @@ fn parseStr(bs: List<Byte>, pos: Int, len: Int) -> Result<(String, Int), Error> 
             }
             let esc = bs[i].toInt()
             if esc == 0x22 {
-                buf.push(0x22)
+                pushByte(buf, 0x22)
             } else if esc == 0x5C {
-                buf.push(0x5C)
+                pushByte(buf, 0x5C)
             } else if esc == 0x2F {
-                buf.push(0x2F)
+                pushByte(buf, 0x2F)
             } else if esc == 0x62 {
-                buf.push(0x08)
+                pushByte(buf, 0x08)
             } else if esc == 0x66 {
-                buf.push(0x0C)
+                pushByte(buf, 0x0C)
             } else if esc == 0x6E {
-                buf.push(0x0A)
+                pushByte(buf, 0x0A)
             } else if esc == 0x72 {
-                buf.push(0x0D)
+                pushByte(buf, 0x0D)
             } else if esc == 0x74 {
-                buf.push(0x09)
+                pushByte(buf, 0x09)
             } else if esc == 0x75 {
                 // \uXXXX
                 if i + 4 >= len {
@@ -338,21 +338,25 @@ fn parseHex4(bs: List<Byte>, pos: Int) -> Result<Int, Error> {
     Ok(result)
 }
 
+fn pushByte(buf: List<Byte>, n: Int) {
+    buf.push(n.toByte().unwrap())
+}
+
 fn encodeUtf8(buf: List<Byte>, cp: Int) {
     if cp < 0x80 {
-        buf.push(cp.toByte().unwrap())
+        pushByte(buf, cp)
     } else if cp < 0x800 {
-        buf.push((0xC0 | (cp >> 6)).toByte().unwrap())
-        buf.push((0x80 | (cp & 0x3F)).toByte().unwrap())
+        pushByte(buf, 0xC0 | (cp >> 6))
+        pushByte(buf, 0x80 | (cp & 0x3F))
     } else if cp < 0x10000 {
-        buf.push((0xE0 | (cp >> 12)).toByte().unwrap())
-        buf.push((0x80 | ((cp >> 6) & 0x3F)).toByte().unwrap())
-        buf.push((0x80 | (cp & 0x3F)).toByte().unwrap())
+        pushByte(buf, 0xE0 | (cp >> 12))
+        pushByte(buf, 0x80 | ((cp >> 6) & 0x3F))
+        pushByte(buf, 0x80 | (cp & 0x3F))
     } else {
-        buf.push((0xF0 | (cp >> 18)).toByte().unwrap())
-        buf.push((0x80 | ((cp >> 12) & 0x3F)).toByte().unwrap())
-        buf.push((0x80 | ((cp >> 6) & 0x3F)).toByte().unwrap())
-        buf.push((0x80 | (cp & 0x3F)).toByte().unwrap())
+        pushByte(buf, 0xF0 | (cp >> 18))
+        pushByte(buf, 0x80 | ((cp >> 12) & 0x3F))
+        pushByte(buf, 0x80 | ((cp >> 6) & 0x3F))
+        pushByte(buf, 0x80 | (cp & 0x3F))
     }
 }
 
@@ -411,7 +415,7 @@ fn parseNum(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
     }
     let numStr = bytes.from(numBuf).toString()?
     let n = numStr.toFloat()?
-    Ok((Json.Number(n), i))
+    Ok((Number(n), i))
 }
 
 // ---------------------------------------------------------------------------
@@ -422,7 +426,7 @@ fn parseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
     let mut i = skipWs(bs, pos + 1, len)
     let mut items: List<Json> = []
     if i < len && bs[i].toInt() == 0x5D {
-        return Ok((Json.Array(items), i + 1))
+        return Ok((Array(items), i + 1))
     }
     for i < len {
         let (val, next) = parseVal(bs, i, len)?
@@ -432,7 +436,7 @@ fn parseArr(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
             return Err(error.new("json: unterminated array"))
         }
         if bs[i].toInt() == 0x5D {
-            return Ok((Json.Array(items), i + 1))
+            return Ok((Array(items), i + 1))
         }
         if bs[i].toInt() != 0x2C {
             return Err(error.new("json: expected ',' or ']' in array"))
@@ -450,7 +454,7 @@ fn parseObj(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
     let mut i = skipWs(bs, pos + 1, len)
     let mut entries: Map<String, Json> = {:}
     if i < len && bs[i].toInt() == 0x7D {
-        return Ok((Json.Object(entries), i + 1))
+        return Ok((Object(entries), i + 1))
     }
     for i < len {
         if bs[i].toInt() != 0x22 {
@@ -469,7 +473,7 @@ fn parseObj(bs: List<Byte>, pos: Int, len: Int) -> Result<(Json, Int), Error> {
             return Err(error.new("json: unterminated object"))
         }
         if bs[i].toInt() == 0x7D {
-            return Ok((Json.Object(entries), i + 1))
+            return Ok((Object(entries), i + 1))
         }
         if bs[i].toInt() != 0x2C {
             return Err(error.new("json: expected ',' or '}' in object"))
@@ -501,42 +505,42 @@ fn skipWs(bs: List<Byte>, pos: Int, len: Int) -> Int {
 
 pub fn isNull(value: Json) -> Bool {
     match value {
-        Json.Null -> true,
+        Null -> true,
         _ -> false,
     }
 }
 
 pub fn isBool(value: Json) -> Bool {
     match value {
-        Json.Bool(_) -> true,
+        Bool(_) -> true,
         _ -> false,
     }
 }
 
 pub fn isNumber(value: Json) -> Bool {
     match value {
-        Json.Number(_) -> true,
+        Number(_) -> true,
         _ -> false,
     }
 }
 
 pub fn isString(value: Json) -> Bool {
     match value {
-        Json.String(_) -> true,
+        String(_) -> true,
         _ -> false,
     }
 }
 
 pub fn isArray(value: Json) -> Bool {
     match value {
-        Json.Array(_) -> true,
+        Array(_) -> true,
         _ -> false,
     }
 }
 
 pub fn isObject(value: Json) -> Bool {
     match value {
-        Json.Object(_) -> true,
+        Object(_) -> true,
         _ -> false,
     }
 }
@@ -547,36 +551,36 @@ pub fn isObject(value: Json) -> Bool {
 
 pub fn asBool(value: Json) -> Result<Bool, Error> {
     match value {
-        Json.Bool(b) -> Ok(b),
-        _ -> Err(error.new("json: expected Bool")),
+        Bool(b) -> Ok(b),
+        _ -> Err(error.new("json: expected bool")),
     }
 }
 
 pub fn asNumber(value: Json) -> Result<Float, Error> {
     match value {
-        Json.Number(n) -> Ok(n),
-        _ -> Err(error.new("json: expected Number")),
+        Number(n) -> Ok(n),
+        _ -> Err(error.new("json: expected number")),
     }
 }
 
 pub fn asString(value: Json) -> Result<String, Error> {
     match value {
-        Json.String(s) -> Ok(s),
-        _ -> Err(error.new("json: expected String")),
+        String(s) -> Ok(s),
+        _ -> Err(error.new("json: expected string")),
     }
 }
 
 pub fn asArray(value: Json) -> Result<JsonArray, Error> {
     match value {
-        Json.Array(a) -> Ok(a),
-        _ -> Err(error.new("json: expected Array")),
+        Array(a) -> Ok(a),
+        _ -> Err(error.new("json: expected array")),
     }
 }
 
 pub fn asObject(value: Json) -> Result<JsonObject, Error> {
     match value {
-        Json.Object(o) -> Ok(o),
-        _ -> Err(error.new("json: expected Object")),
+        Object(o) -> Ok(o),
+        _ -> Err(error.new("json: expected object")),
     }
 }
 
@@ -586,14 +590,20 @@ pub fn asObject(value: Json) -> Result<JsonObject, Error> {
 
 pub fn getField(obj: Json, key: String) -> Result<Json, Error> {
     match obj {
-        Json.Object(o) -> o.get(key).orError("json: missing field"),
-        _ -> Err(error.new("json: expected Object")),
+        Object(o) -> match o.get(key) {
+            Some(v) -> Ok(v),
+            None -> Err(error.new("json: missing object field: {key}")),
+        },
+        _ -> Err(error.new("json: expected object")),
     }
 }
 
 pub fn getIndex(arr: Json, index: Int) -> Result<Json, Error> {
     match arr {
-        Json.Array(a) -> a.get(index).orError("json: index out of bounds"),
-        _ -> Err(error.new("json: expected Array")),
+        Array(a) -> match a.get(index) {
+            Some(v) -> Ok(v),
+            None -> Err(error.new("json: array index out of bounds: {index}")),
+        },
+        _ -> Err(error.new("json: expected array")),
     }
 }

--- a/internal/stdlib/primitives/bytes.osty
+++ b/internal/stdlib/primitives/bytes.osty
@@ -4,6 +4,7 @@
 
 #[intrinsic_methods(Bytes)]
 pub struct __BytesMethods {
+    pub fn from(items: List<Byte>) -> Bytes { "".toBytes() }
     pub fn len(self) -> Int { 0 }
     pub fn isEmpty(self) -> Bool { false }
     pub fn get(self, i: Int) -> Byte? { None }

--- a/internal/stdlib/primitives/int.osty
+++ b/internal/stdlib/primitives/int.osty
@@ -55,7 +55,7 @@ pub struct __IntMethods {
     pub fn toInt32(self) -> Result<Int32, Error> { Ok(0) }
     pub fn toInt64(self) -> Int64 { 0 }
     pub fn toUInt8(self) -> Result<UInt8, Error> { Ok(0) }
-    pub fn toByte(self) -> Result<Byte, Error> { Ok(0) }
+    pub fn toByte(self) -> Result<Byte, Error> { Ok(b'\0') }
     pub fn toUInt16(self) -> Result<UInt16, Error> { Ok(0) }
     pub fn toUInt32(self) -> Result<UInt32, Error> { Ok(0) }
     pub fn toUInt64(self) -> Result<UInt64, Error> { Ok(0) }

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -1053,7 +1053,14 @@ func TestJSONModuleCoverage(t *testing.T) {
 	if mod == nil || mod.Package == nil {
 		t.Fatal("std.json not loaded")
 	}
-	for _, name := range []string{"Json", "Encode", "Decode", "encode", "stringify", "decode", "parse"} {
+	for _, name := range []string{
+		"Json", "JsonObject", "JsonArray", "JsonString", "JsonNumber", "JsonBool",
+		"Encode", "Decode", "encode", "stringify", "decode", "parse",
+		"stringifyValue", "parseValue",
+		"isNull", "isBool", "isNumber", "isString", "isArray", "isObject",
+		"asBool", "asNumber", "asString", "asArray", "asObject",
+		"getField", "getIndex",
+	} {
 		sym := mod.Package.PkgScope.LookupLocal(name)
 		if sym == nil {
 			t.Errorf("std.json missing export %q", name)
@@ -1084,7 +1091,13 @@ pub fn smoke(user: User) -> String {
     let decoded: Result<User, Error> = json.decode(encoded)
     let parsed: Result<User, Error> = json.parse(encoded)
     let value: json.Json = json.Object({"ok": json.Bool(true), "name": json.String("osty"), "none": json.Null})
-    json.stringify(value)
+    let valueText: String = json.stringifyValue(value)
+    let parsedValue: json.Json = json.parseValue(valueText).unwrap()
+    let field: json.Json = json.getField(parsedValue, "name").unwrap()
+    let name: String = json.asString(field).unwrap()
+    let arr: json.Json = json.Array([json.Number(1.0)])
+    let first: json.Json = json.getIndex(arr, 0).unwrap()
+    json.stringifyValue(json.String(name))
 }
 `)
 	file, parseDiags := parser.ParseDiagnostics(src)


### PR DESCRIPTION
## Summary
- complete std.json value-level parse/stringify accessors and generated runtime helpers
- add deep JSON value API coverage for nested data, escapes, unicode surrogate pairs, and invalid input paths
- stabilize related bytes, iter, and regex stdlib bridge behavior used by the JSON tests

## Tests
- go test ./internal/stdlib -count=1
- go test ./internal/gen -count=1 -timeout=5m
- go test ./... -count=1 -timeout=5m