### PR TITLE
Speed up local development loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,17 @@ go test -fuzz=FuzzLex   -fuzztime=30s ./internal/lexer/
 go test -fuzz=FuzzParse -fuzztime=30s ./internal/parser/
 ```
 
+Fast local loops are captured in the `justfile`:
+
+```sh
+just front                 # uncached front-end packages, usually a few seconds
+just short                 # skips generated-Go/runtime-heavy integration paths
+just gen TestQuestionOp    # one gen test or regex
+just lsp TestCompletion    # one LSP test or regex
+just pipe examples/calc    # front-end timing for an Osty package
+just pipe-gen path/file.osty
+```
+
 The **spec corpus** lives under `testdata/spec/`:
 
 - `positive/NN-<chapter>.osty` — one fixture per spec chapter;

--- a/cmd/osty/ci_integration_test.go
+++ b/cmd/osty/ci_integration_test.go
@@ -10,19 +10,13 @@ import (
 	"testing"
 )
 
-// runOsty invokes the cmd/osty binary via `go run` with the
-// given args. Returning combined stdout+stderr keeps the test
-// terse — every assertion in this file checks substring
-// presence, not stream-of-origin.
-//
-// `go run` is slow (a fresh build per call) but the test only
-// runs three times, so the cost is acceptable for CLI-surface
-// coverage we can't get any other way.
+// runOsty invokes the shared cmd/osty test binary with the given args.
+// Returning combined stdout+stderr keeps the test terse — every assertion
+// in this file checks substring presence, not stream-of-origin.
 func runOsty(t *testing.T, dir string, args ...string) (combined string, exitCode int) {
 	t.Helper()
-	full := append([]string{"run", "."}, args...)
-	cmd := exec.Command("go", full...)
-	cmd.Dir = repoRoot(t)
+	cmd := exec.Command(buildOstyBinary(t), args...)
+	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GOFLAGS=") // ensure -mod is unset
 	var buf bytes.Buffer
 	cmd.Stdout = &buf

--- a/cmd/osty/run_integration_test.go
+++ b/cmd/osty/run_integration_test.go
@@ -7,10 +7,27 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/osty/osty/internal/profile"
 )
+
+var (
+	ostyBinOnce   sync.Once
+	ostyBinDir    string
+	ostyBinPath   string
+	ostyBinErr    error
+	ostyBinOutput string
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if ostyBinDir != "" {
+		_ = os.RemoveAll(ostyBinDir)
+	}
+	os.Exit(code)
+}
 
 func TestRunStdFSUsesInvocationCwd(t *testing.T) {
 	if testing.Short() {
@@ -103,21 +120,29 @@ fn main() {
 
 func buildOstyBinary(t *testing.T) string {
 	t.Helper()
-	name := "osty"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
+	ostyBinOnce.Do(func() {
+		name := "osty"
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		ostyBinDir, ostyBinErr = os.MkdirTemp("", "osty-test-bin-*")
+		if ostyBinErr != nil {
+			return
+		}
+		ostyBinPath = filepath.Join(ostyBinDir, name)
+		cmd := exec.Command("go", "build", "-o", ostyBinPath, ".")
+		cmd.Dir = repoRoot(t)
+		cmd.Env = append(os.Environ(), "GOFLAGS=")
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		ostyBinErr = cmd.Run()
+		ostyBinOutput = buf.String()
+	})
+	if ostyBinErr != nil {
+		t.Fatalf("go build osty: %v\n%s", ostyBinErr, ostyBinOutput)
 	}
-	bin := filepath.Join(t.TempDir(), name)
-	cmd := exec.Command("go", "build", "-o", bin, ".")
-	cmd.Dir = repoRoot(t)
-	cmd.Env = append(os.Environ(), "GOFLAGS=")
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("go build osty: %v\n%s", err, buf.String())
-	}
-	return bin
+	return ostyBinPath
 }
 
 func runBuiltOsty(t *testing.T, bin, dir string, args ...string) (combined string, exitCode int) {

--- a/internal/examples/examples_test.go
+++ b/internal/examples/examples_test.go
@@ -55,6 +55,9 @@ func TestExampleManifestsValidate(t *testing.T) {
 }
 
 func TestRunnableExamplesGenerateAndExecute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("example generated-Go execution test (slow)")
+	}
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go binary not on PATH")
 	}
@@ -105,6 +108,10 @@ func executeExampleTests(t *testing.T, name string) {
 	}
 	assertParsesAsGo(t, "main.go", srcs.Main)
 	assertParsesAsGo(t, "harness.go", srcs.Harness)
+	if testing.Short() {
+		t.Log("skipping generated Go execution in short mode")
+		return
+	}
 
 	out := runGoPackage(t, map[string][]byte{
 		"main.go":    srcs.Main,

--- a/internal/gen/audit_test.go
+++ b/internal/gen/audit_test.go
@@ -24,6 +24,9 @@ import (
 //
 //	go test ./internal/gen/ -run TestSpecCorpusAudit -v
 func TestSpecCorpusAudit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spec corpus Go vet audit (slow)")
+	}
 	fixtures, err := filepath.Glob("../../testdata/spec/positive/*.osty")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -47,6 +47,12 @@ func transpileWithStdlib(t *testing.T, src string) ([]byte, error) {
 // `go run`, and returns the captured stdout.
 func runGo(t *testing.T, src []byte) string {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("generated Go execution test (slow)")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go binary not on PATH; skipping generated Go execution")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.go")
 	if err := os.WriteFile(path, src, 0o644); err != nil {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -247,14 +247,19 @@ func (s *session) initialize() {
 	s.send("", "initialized", map[string]any{})
 }
 
-// openDoc sends didOpen for uri/text and drains the first
-// publishDiagnostics so subsequent waitResponse calls won't pick it up.
+const (
+	notificationOpenWait    = 20 * time.Millisecond
+	notificationQuietPeriod = 5 * time.Millisecond
+)
+
+// openDoc sends didOpen for uri/text and briefly drains any immediate
+// publishDiagnostics so subsequent waitResponse calls usually don't pick it up.
 func (s *session) openDoc(uri, text string) {
 	s.t.Helper()
 	s.send("", "textDocument/didOpen", DidOpenTextDocumentParams{
 		TextDocument: TextDocumentItem{URI: uri, LanguageID: "osty", Version: 1, Text: text},
 	})
-	_ = s.drainNotifications("textDocument/publishDiagnostics", 1*time.Second)
+	_ = s.drainNotifications("textDocument/publishDiagnostics", notificationOpenWait)
 }
 
 // stop closes the client side and waits for Run to return.
@@ -344,10 +349,10 @@ func (s *session) waitResponse(id string) rpcResponse {
 	}
 }
 
-// drainNotifications collects every stashed-or-incoming notification
-// matching `method` within `timeout`. Useful for reading
-// textDocument/publishDiagnostics that arrives asynchronously after
-// didOpen / didChange.
+// drainNotifications waits until at least one matching notification arrives,
+// then drains any immediately-following matches. The old helper waited for
+// the whole timeout even after success, which made the LSP suite spend most
+// of its time sleeping.
 func (s *session) drainNotifications(method string, timeout time.Duration) []rpcRequest {
 	s.t.Helper()
 	var out []rpcRequest
@@ -363,7 +368,13 @@ func (s *session) drainNotifications(method string, timeout time.Duration) []rpc
 	}
 	s.pending = keep
 	s.pendMu.Unlock()
-	// Then read more until the timeout elapses with no new match.
+
+	if len(out) > 0 {
+		return s.drainReadyNotifications(method, out)
+	}
+
+	// Then wait for the first match. Once one arrives, return after a
+	// short quiet period instead of burning the caller's full timeout.
 	deadline := time.After(timeout)
 	for {
 		select {
@@ -388,9 +399,46 @@ func (s *session) drainNotifications(method string, timeout time.Duration) []rpc
 			}
 			if n.Method == method {
 				out = append(out, n)
-				// Give the server a tick to emit more of the
-				// same kind of notification (e.g. a follow-up
-				// publishDiagnostics after didChange).
+				return s.drainReadyNotifications(method, out)
+			}
+			s.pendMu.Lock()
+			s.pending = append(s.pending, n)
+			s.pendMu.Unlock()
+		}
+	}
+}
+
+func (s *session) drainReadyNotifications(method string, out []rpcRequest) []rpcRequest {
+	quiet := time.NewTimer(notificationQuietPeriod)
+	defer quiet.Stop()
+	for {
+		select {
+		case <-quiet.C:
+			return out
+		case body, ok := <-s.frames:
+			if !ok {
+				return out
+			}
+			var probe map[string]json.RawMessage
+			if err := json.Unmarshal(body, &probe); err != nil {
+				continue
+			}
+			if _, isResp := probe["id"]; isResp {
+				continue
+			}
+			var n rpcRequest
+			if err := json.Unmarshal(body, &n); err != nil {
+				continue
+			}
+			if n.Method == method {
+				out = append(out, n)
+				if !quiet.Stop() {
+					select {
+					case <-quiet.C:
+					default:
+					}
+				}
+				quiet.Reset(notificationQuietPeriod)
 				continue
 			}
 			s.pendMu.Lock()

--- a/internal/testgen/testgen_test.go
+++ b/internal/testgen/testgen_test.go
@@ -60,6 +60,10 @@ func TestGenerateHarness_CalcExample(t *testing.T) {
 	// End-to-end smoke: write both files into a scratch dir with a
 	// minimal go.mod and confirm `go run .` exits 0 and prints the
 	// expected summary. Skips automatically if `go` isn't on PATH.
+	if testing.Short() {
+		t.Log("skipping generated harness execution in short mode")
+		return
+	}
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go binary not on PATH; skipping end-to-end run")
 	}
@@ -168,6 +172,10 @@ fn testCrossFileVariant() {
 	if err != nil {
 		t.Fatalf("GenerateHarness: %v\n--- main.go ---\n%s", err, srcs.Main)
 	}
+	if testing.Short() {
+		t.Log("skipping generated harness execution in short mode")
+		return
+	}
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go binary not on PATH; skipping end-to-end run")
 	}
@@ -236,6 +244,10 @@ pub fn isNewline(kind: TokenKind) -> Bool {
 	}})
 	if err != nil {
 		t.Fatalf("GenerateHarness: %v", err)
+	}
+	if testing.Short() {
+		t.Log("skipping generated harness execution in short mode")
+		return
 	}
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go binary not on PATH; skipping end-to-end run")
@@ -309,6 +321,10 @@ func TestGenerateHarness_RenamesBinaryMain(t *testing.T) {
 	}
 	if !strings.Contains(main, "\t_ostyProgramMain()\n") {
 		t.Fatalf("test call to main() was not rewritten to _ostyProgramMain():\n%s", main)
+	}
+	if testing.Short() {
+		t.Log("skipping generated harness execution in short mode")
+		return
 	}
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go binary not on PATH; skipping end-to-end run")

--- a/justfile
+++ b/justfile
@@ -1,0 +1,54 @@
+set shell := ["bash", "-cu"]
+
+bin := ".bin/osty"
+front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline"
+
+default:
+    just front
+
+build:
+    mkdir -p .bin
+    go build -o {{bin}} ./cmd/osty
+
+front:
+    go test -count=1 {{front_packages}}
+
+short:
+    go test -short ./...
+
+full:
+    go test ./...
+
+gen test=".":
+    go test -count=1 ./internal/gen -run '{{test}}' -v
+
+lsp test=".":
+    go test -count=1 ./internal/lsp -run '{{test}}' -v
+
+cmd test=".":
+    go test -count=1 ./cmd/osty -run '{{test}}' -v
+
+pipe target:
+    test -x {{bin}} || just build
+    {{bin}} pipeline --per-decl {{target}}
+
+pipe-gen target:
+    test -x {{bin}} || just build
+    {{bin}} pipeline --per-decl --gen {{target}}
+
+profile target:
+    test -x {{bin}} || just build
+    mkdir -p .profiles
+    {{bin}} pipeline --per-decl --cpuprofile .profiles/cpu.pprof --memprofile .profiles/mem.pprof {{target}}
+
+watch-front:
+    watchexec -e go,osty,md -- just front
+
+watch-gen test=".":
+    watchexec -e go,osty -- just gen '{{test}}'
+
+watch-pipe target:
+    watchexec -e go,osty -- just pipe {{target}}
+
+sum:
+    gotestsum -- ./...


### PR DESCRIPTION
## Summary
- add a justfile with fast front-end, short, targeted gen/LSP, and pipeline loops
- make LSP notification draining return after the first matching publish instead of sleeping through full timeouts
- skip generated-Go/runtime-heavy execution paths in short mode and reuse one CLI test binary

## Tests
- go test -count=1 ./internal/lsp
- go test -short -count=1 ./...
- go test -count=1 ./cmd/osty
- go test -count=1 ./...

Note: just is not installed in this environment, so just --list could not be run locally.