### PR TITLE
Add pure Osty AST formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ osty resolve FILE|DIR  # name resolution; directory = package mode (--scopes for
 osty check FILE|DIR    # lex + parse + resolve + type-check (diagnostics only)
 osty typecheck FILE    # same as check, plus a per-expression type dump
 osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
-osty fmt FILE          # repair + format to canonical style (see --check, --write)
+osty fmt FILE          # repair + format to canonical style (see --check, --write, --engine)
 osty repair FILE       # auto-fix common AI-authored syntax/idiom slips
 osty gen FILE          # transpile to Go source (see -o, --package)
 osty doc PATH          # generate API documentation (HTML + markdown)
@@ -198,6 +198,10 @@ default, so AI-authored syntax slips are normalized in one command.
 - `--check` — exit 1 if the file is not already formatted; show diff
 - `--write` — rewrite the file in place instead of printing
 - `--no-repair` — disable the default automatic source repair pass
+- `--engine go|osty` — choose the formatter engine. `go` is the default
+  AST formatter; `osty` is a compatibility entry point that now shares the
+  same AST-backed formatting contract instead of maintaining a separate
+  token-heuristic printer.
 
 `repair`-specific flags (after the subcommand):
 

--- a/cmd/osty/ci_integration_test.go
+++ b/cmd/osty/ci_integration_test.go
@@ -177,6 +177,69 @@ func TestFmtAutoRepairWrite(t *testing.T) {
 	}
 }
 
+func TestFmtOstyEngineWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte("fn add(a:Int,b:Int)->Int{return a+b}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runOsty(t, dir, "fmt", "--engine=osty", "--no-repair", "--write", path)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d. output:\n%s", code, out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "fn add(a: Int, b: Int) -> Int {\n    return a + b\n}\n"
+	if string(got) != want {
+		t.Fatalf("osty engine formatted mismatch:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFmtOstyEngineMatchesDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	src := []byte(`struct User{name:Int}
+fn f(ok:Bool,x:Int)->Bool{return if ok{1}else{2}< -x}
+fn g(u:User)->Int{if let User{name}=u{return name}else{return 0}}
+`)
+	goPath := filepath.Join(dir, "go.osty")
+	ostyPath := filepath.Join(dir, "osty.osty")
+	if err := os.WriteFile(goPath, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ostyPath, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runOsty(t, dir, "fmt", "--no-repair", "--write", goPath)
+	if code != 0 {
+		t.Fatalf("default engine exit %d. output:\n%s", code, out)
+	}
+	out, code = runOsty(t, dir, "fmt", "--engine=osty", "--no-repair", "--write", ostyPath)
+	if code != 0 {
+		t.Fatalf("osty engine exit %d. output:\n%s", code, out)
+	}
+	goOut, err := os.ReadFile(goPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ostyOut, err := os.ReadFile(ostyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(ostyOut, goOut) {
+		t.Fatalf("osty engine diverged from default:\n--- osty ---\n%s--- default ---\n%s", ostyOut, goOut)
+	}
+}
+
 func TestFmtNoRepairLeavesParserStrict(t *testing.T) {
 	if testing.Short() {
 		t.Skip("CLI integration test (slow)")

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -27,6 +27,7 @@
 // `fmt` subcommand flags (after the subcommand name):
 //
 //	--check        exit 1 if the file is not already formatted; print diff to stderr
+//	--engine NAME  formatter engine: go (default) or osty
 //	--no-repair    disable the default pre-format source repair pass
 //	--write        overwrite the file in place instead of printing to stdout
 package main
@@ -1124,6 +1125,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --explain          append `osty explain CODE` text after each diagnostic block")
 	fmt.Fprintln(os.Stderr, "fmt-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --check            exit 1 if FILE is not already formatted")
+	fmt.Fprintln(os.Stderr, "  --engine NAME      formatter engine: go (default) or osty")
 	fmt.Fprintln(os.Stderr, "  --write            overwrite FILE in place")
 	fmt.Fprintln(os.Stderr, "  --no-repair        disable the default pre-format source repair pass")
 	fmt.Fprintln(os.Stderr, "repair-specific flags (after the subcommand):")
@@ -1193,7 +1195,7 @@ func printTypes(r *check.Result) {
 
 // runFmt implements the `osty fmt` subcommand. The args slice holds
 // everything on the command line following `fmt` — zero or more of
-// --check/--write/--no-repair, then exactly one file path.
+// --check/--write/--no-repair/--engine, then exactly one file path.
 //
 // Exit codes match gofmt conventions:
 //
@@ -1203,9 +1205,10 @@ func printTypes(r *check.Result) {
 func runFmt(args []string) {
 	fs := flag.NewFlagSet("fmt", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty fmt [--check] [--write] [--no-repair] FILE")
+		fmt.Fprintln(os.Stderr, "usage: osty fmt [--check] [--write] [--no-repair] [--engine go|osty] FILE")
 	}
 	var checkMode, writeMode, noRepair bool
+	engine := "go"
 	repairMode := true
 	fs.BoolVar(&checkMode, "check", false, "exit 1 if FILE is not already formatted")
 	fs.BoolVar(&checkMode, "c", false, "alias for --check")
@@ -1213,6 +1216,7 @@ func runFmt(args []string) {
 	fs.BoolVar(&writeMode, "w", false, "alias for --write")
 	fs.BoolVar(&repairMode, "repair", true, "enable automatic source repair before formatting")
 	fs.BoolVar(&noRepair, "no-repair", false, "disable automatic source repair before formatting")
+	fs.StringVar(&engine, "engine", engine, "formatter engine (go|osty)")
 	_ = fs.Parse(args)
 	if noRepair {
 		repairMode = false
@@ -1238,7 +1242,20 @@ func runFmt(args []string) {
 		repairs = repair.Source(src)
 		formatSrc = repairs.Source
 	}
-	out, diags, ferr := format.Source(formatSrc)
+	var (
+		out   []byte
+		diags []*diag.Diagnostic
+		ferr  error
+	)
+	switch engine {
+	case "", "go", "ast":
+		out, diags, ferr = format.Source(formatSrc)
+	case "osty":
+		out, diags, ferr = format.OstySource(formatSrc)
+	default:
+		fmt.Fprintf(os.Stderr, "osty fmt: unknown engine %q (want go or osty)\n", engine)
+		os.Exit(2)
+	}
 	if ferr != nil {
 		// Render parse diagnostics so the user can fix them.
 		formatter := &diag.Formatter{Filename: path, Source: formatSrc}

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ the compiler evolves.
   runnable lexer scanner, front-end seed models, and broad example-style
   tests for SemVer, registry selection, manifest features, diagnostics,
   package archive classification, and Osty-written linter, resolver, and
-  checker cores.
+  checker cores, plus the pure Osty formatter.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `workspace`: virtual workspace with two member packages and a

--- a/examples/selfhost-core/formatter_ast.osty
+++ b/examples/selfhost-core/formatter_ast.osty
@@ -1,0 +1,749 @@
+use go "strings" as strings {
+    fn Join(elems: List<String>, sep: String) -> String
+    fn Repeat(s: String, count: Int) -> String
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+struct OstyAstFormatter {
+    arena: AstArena,
+    tokens: List<FrontToken>,
+    stream: FrontLexStream,
+    units: List<String>,
+    parts: List<String>,
+    indent: Int,
+    commentIdx: Int,
+    leadingIdx: Int,
+}
+
+fn ostyAstFormatter(
+    arena: AstArena,
+    tokens: List<FrontToken>,
+    stream: FrontLexStream,
+    units: List<String>,
+) -> OstyAstFormatter {
+    OstyAstFormatter {
+        arena,
+        tokens,
+        stream,
+        units,
+        parts: [],
+        indent: 0,
+        commentIdx: 0,
+        leadingIdx: 0,
+    }
+}
+
+fn ostyAstOk(output: String) -> OstyFormatResult {
+    OstyFormatResult { ok: true, output, message: "" }
+}
+
+fn ostyAstErr(message: String) -> OstyFormatResult {
+    OstyFormatResult { ok: false, output: "", message }
+}
+
+fn ostyAstDiagnosticText(stream: FrontLexStream) -> String {
+    let mut lines: List<String> = []
+    for diag in stream.diagnostics {
+        lines.push(
+            "{frontLexDiagnosticCodeName(diag.code)} at {diag.start.line}:{diag.start.column}",
+        )
+    }
+    strings.Join(lines, "\n")
+}
+
+fn ostyAstNode(f: OstyAstFormatter, idx: Int) -> AstNode {
+    astArenaNodeAt(f.arena, idx)
+}
+
+fn ostyAstChildAt(node: AstNode, target: Int) -> Int {
+    let mut idx = 0
+    for child in node.children {
+        if idx == target {
+            return child
+        }
+        idx = idx + 1
+    }
+    -1
+}
+
+fn ostyAstIndent(level: Int) -> String {
+    if level <= 0 {
+        return ""
+    }
+    strings.Repeat("    ", level)
+}
+
+fn ostyAstPush(f: OstyAstFormatter, text: String) {
+    if text != "" {
+        f.parts.push(text)
+    }
+}
+
+fn ostyAstPushLine(f: OstyAstFormatter, text: String) {
+    ostyAstPush(f, text)
+    f.parts.push("\n")
+}
+
+fn ostyAstFinish(f: OstyAstFormatter) -> String {
+    strings.Join(f.parts, "")
+}
+
+fn ostyAstRawTokenRange(f: OstyAstFormatter, start: Int, end: Int) -> String {
+    if start < 0 || end <= start {
+        return ""
+    }
+    let first = frontLexTokenAt(f.stream, start)
+    let last = frontLexTokenAt(f.stream, end - 1)
+    frontLexemeFromUnits(f.units, first.start.offset, last.end.offset - first.start.offset)
+}
+
+fn ostyAstCommentText(f: OstyAstFormatter, comment: FrontComment) -> String {
+    frontLexemeFromUnits(
+        f.units,
+        comment.start.offset,
+        comment.end.offset - comment.start.offset,
+    )
+}
+
+fn ostyAstEmitLeading(f: OstyAstFormatter, tokenStart: Int) {
+    if tokenStart < 0 {
+        return
+    }
+    let startTok = frontLexTokenAt(f.stream, tokenStart)
+    let commentCount = frontCommentCount(f.stream)
+    for f.commentIdx < commentCount {
+        let comment = frontCommentAt(f.stream, f.commentIdx)
+        if comment.end.offset > startTok.start.offset {
+            break
+        }
+        ostyAstPushLine(f, ostyAstCommentText(f, comment))
+        f.commentIdx = f.commentIdx + 1
+    }
+
+    let mut idx = f.leadingIdx
+    for idx < tokenStart {
+        let tok = frontTokenAtList(f.tokens, idx)
+        if tok.kind == FrontHash && frontTokenAtList(f.tokens, idx + 1).kind == FrontLBracket {
+            let close = frontFindMatching(
+                f.tokens,
+                idx + 1,
+                tokenStart,
+                FrontLBracket,
+                FrontRBracket,
+            )
+            ostyAstPushLine(f, ostyAstRawTokenRange(f, idx, close + 1))
+            idx = close + 1
+        } else {
+            idx = idx + 1
+        }
+    }
+    f.leadingIdx = tokenStart
+}
+
+pub fn ostyAstFormatSource(source: String) -> OstyFormatResult {
+    let stream = frontendLexStream(source)
+    if frontLexDiagnosticCount(stream) > 0 {
+        return ostyAstErr(ostyAstDiagnosticText(stream))
+    }
+    let file = astParse(source)
+    if astFileErrorCount(file) > 0 {
+        return ostyAstErr(astFormatErrors(file))
+    }
+
+    let tokens = frontTokensFromSource(source, stream)
+    let units = strings.Split(source, "")
+    let mut f = ostyAstFormatter(file.arena, tokens, stream, units)
+    for decl in file.arena.decls {
+        let node = ostyAstNode(f, decl)
+        ostyAstEmitLeading(f, node.start)
+        ostyAstPushLine(f, ostyAstDecl(f, decl))
+        f.leadingIdx = node.end
+    }
+    ostyAstOk(ostyAstFinish(f))
+}
+
+fn ostyAstDecl(f: OstyAstFormatter, idx: Int) -> String {
+    let node = ostyAstNode(f, idx)
+    match node.kind {
+        AstNFnDecl -> ostyAstFnDecl(f, node),
+        AstNStructDecl -> ostyAstAggregateDecl(f, node, "struct"),
+        AstNEnumDecl -> ostyAstAggregateDecl(f, node, "enum"),
+        AstNInterfaceDecl -> ostyAstInterfaceDecl(f, node),
+        AstNTypeAlias -> ostyAstTypeAliasDecl(f, node),
+        AstNUseDecl -> ostyAstRawTokenRange(f, node.start, node.end),
+        AstNLet -> ostyAstStmt(f, idx),
+        _ -> ostyAstRawTokenRange(f, node.start, node.end),
+    }
+}
+
+fn ostyAstVisibility(node: AstNode) -> String {
+    if node.flags == 1 {
+        return "pub "
+    }
+    ""
+}
+
+fn ostyAstGenericParams(f: OstyAstFormatter, params: List<Int>) -> String {
+    let mut parts: List<String> = []
+    for paramIdx in params {
+        let param = ostyAstNode(f, paramIdx)
+        let mut text = param.text
+        if param.children.len() > 0 {
+            text = strings.Join([text, ": ", ostyAstTypeList(f, param.children, " + ")], "")
+        }
+        parts.push(text)
+    }
+    if parts.len() == 0 {
+        return ""
+    }
+    strings.Join(["<", strings.Join(parts, ", "), ">"], "")
+}
+
+fn ostyAstFnDecl(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut head = strings.Join(
+        [
+            ostyAstVisibility(node),
+            "fn ",
+            node.text,
+            ostyAstGenericParams(f, node.children2),
+            "(",
+            ostyAstParamList(f, node.children),
+            ")",
+        ],
+        "",
+    )
+    if node.left >= 0 {
+        head = strings.Join([head, " -> ", ostyAstType(f, node.left)], "")
+    }
+    if node.right >= 0 {
+        return strings.Join([head, " ", ostyAstBlock(f, node.right)], "")
+    }
+    head
+}
+
+fn ostyAstParamList(f: OstyAstFormatter, params: List<Int>) -> String {
+    let mut parts: List<String> = []
+    for paramIdx in params {
+        parts.push(ostyAstParam(f, paramIdx))
+    }
+    strings.Join(parts, ", ")
+}
+
+fn ostyAstParam(f: OstyAstFormatter, idx: Int) -> String {
+    let node = ostyAstNode(f, idx)
+    let mut text = ""
+    if node.flags == 1 {
+        text = "mut "
+    }
+    if node.left >= 0 {
+        text = strings.Join([text, ostyAstPattern(f, node.left)], "")
+    } else {
+        text = strings.Join([text, node.text], "")
+    }
+    if node.right >= 0 {
+        text = strings.Join([text, ": ", ostyAstType(f, node.right)], "")
+    }
+    text
+}
+
+fn ostyAstAggregateDecl(f: OstyAstFormatter, node: AstNode, keyword: String) -> String {
+    let mut lines: List<String> = []
+    lines.push(
+        strings.Join(
+            [
+                ostyAstVisibility(node),
+                keyword,
+                " ",
+                node.text,
+                ostyAstGenericParams(f, node.children2),
+                " ",
+                r"{",
+            ],
+            "",
+        ),
+    )
+    let saved = f.indent
+    f.indent = 1
+    for memberIdx in node.children {
+        let member = ostyAstNode(f, memberIdx)
+        let mut line = ""
+        if member.kind == AstNFnDecl {
+            line = ostyAstDecl(f, memberIdx)
+        } else if member.kind == AstNField_ {
+            line = ostyAstFieldMember(f, member)
+        } else if member.kind == AstNVariant {
+            line = ostyAstVariant(f, member)
+        } else {
+            line = ostyAstRawTokenRange(f, member.start, member.end)
+        }
+        lines.push(strings.Join([ostyAstIndent(1), line], ""))
+    }
+    f.indent = saved
+    lines.push(r"}")
+    strings.Join(lines, "\n")
+}
+
+fn ostyAstFieldMember(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut text = strings.Join([ostyAstVisibility(node), node.text, ": ", ostyAstType(f, node.right)], "")
+    if node.left >= 0 {
+        text = strings.Join([text, " = ", ostyAstExpr(f, node.left)], "")
+    }
+    strings.Join([text, ","], "")
+}
+
+fn ostyAstVariant(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut text = node.text
+    if node.children.len() > 0 {
+        text = strings.Join([text, "(", ostyAstTypeList(f, node.children, ", "), ")"], "")
+    }
+    strings.Join([text, ","], "")
+}
+
+fn ostyAstInterfaceDecl(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut head = strings.Join([ostyAstVisibility(node), "interface ", node.text], "")
+    if node.children2.len() > 0 {
+        head = strings.Join([head, ": ", ostyAstTypeList(f, node.children2, " + ")], "")
+    }
+    let mut lines: List<String> = [strings.Join([head, " ", r"{"], "")]
+    let saved = f.indent
+    f.indent = 1
+    for memberIdx in node.children {
+        lines.push(strings.Join([ostyAstIndent(1), ostyAstDecl(f, memberIdx)], ""))
+    }
+    f.indent = saved
+    lines.push(r"}")
+    strings.Join(lines, "\n")
+}
+
+fn ostyAstTypeAliasDecl(f: OstyAstFormatter, node: AstNode) -> String {
+    strings.Join(
+        [
+            ostyAstVisibility(node),
+            "type ",
+            node.text,
+            ostyAstGenericParams(f, node.children),
+            " = ",
+            ostyAstType(f, node.left),
+        ],
+        "",
+    )
+}
+
+fn ostyAstBlock(f: OstyAstFormatter, idx: Int) -> String {
+    ostyAstBlockFromNode(f, ostyAstNode(f, idx))
+}
+
+fn ostyAstBlockFromNode(f: OstyAstFormatter, node: AstNode) -> String {
+    let base = f.indent
+    let mut lines: List<String> = [r"{"]
+    let saved = f.indent
+    f.indent = base + 1
+    for stmtIdx in node.children {
+        lines.push(strings.Join([ostyAstIndent(base + 1), ostyAstStmt(f, stmtIdx)], ""))
+    }
+    f.indent = saved
+    lines.push(strings.Join([ostyAstIndent(base), r"}"], ""))
+    strings.Join(lines, "\n")
+}
+
+fn ostyAstStmt(f: OstyAstFormatter, idx: Int) -> String {
+    let node = ostyAstNode(f, idx)
+    match node.kind {
+        AstNLet -> ostyAstLetStmt(f, node),
+        AstNReturn -> {
+            if node.left >= 0 {
+                strings.Join(["return ", ostyAstExpr(f, node.left)], "")
+            } else {
+                "return"
+            }
+        },
+        AstNBreak -> "break",
+        AstNContinue -> "continue",
+        AstNDefer -> strings.Join(["defer ", ostyAstExpr(f, node.left)], ""),
+        AstNFor -> ostyAstForStmt(f, node),
+        AstNAssign -> strings.Join(
+            [ostyAstExpr(f, node.left), " ", frontTokenKindName(node.op), " ", ostyAstExpr(f, node.right)],
+            "",
+        ),
+        AstNChanSend -> strings.Join([ostyAstExpr(f, node.left), " <- ", ostyAstExpr(f, node.right)], ""),
+        AstNExprStmt -> ostyAstExpr(f, node.left),
+        _ -> ostyAstExpr(f, idx),
+    }
+}
+
+fn ostyAstLetStmt(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut text = "let "
+    if node.flags == 1 {
+        text = "let mut "
+    }
+    text = strings.Join([text, ostyAstPattern(f, node.left)], "")
+    let typeIdx = ostyAstChildAt(node, 0)
+    if typeIdx >= 0 {
+        text = strings.Join([text, ": ", ostyAstType(f, typeIdx)], "")
+    }
+    if node.right >= 0 {
+        text = strings.Join([text, " = ", ostyAstExpr(f, node.right)], "")
+    }
+    text
+}
+
+fn ostyAstForStmt(f: OstyAstFormatter, node: AstNode) -> String {
+    if node.text == "infinite" {
+        return strings.Join(["for ", ostyAstBlock(f, node.right)], "")
+    }
+    if node.text == "forlet" {
+        return strings.Join(
+            [
+                "for let ",
+                ostyAstPattern(f, ostyAstChildAt(node, 0)),
+                " = ",
+                ostyAstExpr(f, node.left),
+                " ",
+                ostyAstBlock(f, node.right),
+            ],
+            "",
+        )
+    }
+    if node.text == "forin" {
+        return strings.Join(
+            [
+                "for ",
+                ostyAstPattern(f, ostyAstChildAt(node, 0)),
+                " in ",
+                ostyAstExpr(f, ostyAstChildAt(node, 1)),
+                " ",
+                ostyAstBlock(f, node.right),
+            ],
+            "",
+        )
+    }
+    strings.Join(["for ", ostyAstExpr(f, node.left), " ", ostyAstBlock(f, node.right)], "")
+}
+
+fn ostyAstTypeList(f: OstyAstFormatter, nodes: List<Int>, sep: String) -> String {
+    let mut parts: List<String> = []
+    for idx in nodes {
+        parts.push(ostyAstType(f, idx))
+    }
+    strings.Join(parts, sep)
+}
+
+fn ostyAstType(f: OstyAstFormatter, idx: Int) -> String {
+    if idx < 0 {
+        return "()"
+    }
+    let node = ostyAstNode(f, idx)
+    if node.text == "optional" {
+        return strings.Join([ostyAstType(f, node.left), "?"], "")
+    }
+    if node.text == "fn" {
+        let mut text = strings.Join(["fn(", ostyAstTypeList(f, node.children, ", "), ")"], "")
+        if node.right >= 0 {
+            text = strings.Join([text, " -> ", ostyAstType(f, node.right)], "")
+        }
+        return text
+    }
+    if node.text == "tuple" {
+        return strings.Join(["(", ostyAstTypeList(f, node.children, ", "), ")"], "")
+    }
+    let mut text = node.text
+    if node.children.len() > 0 {
+        text = strings.Join([text, "<", ostyAstTypeList(f, node.children, ", "), ">"], "")
+    }
+    text
+}
+
+fn ostyAstPattern(f: OstyAstFormatter, idx: Int) -> String {
+    if idx < 0 {
+        return ""
+    }
+    let node = ostyAstNode(f, idx)
+    if node.extra == astPatternWildcardKind() {
+        return "_"
+    }
+    if node.extra == astPatternLiteralKind() {
+        if node.left >= 0 {
+            return strings.Join([node.text, ostyAstPattern(f, node.left)], "")
+        }
+        return node.text
+    }
+    if node.extra == astPatternIdentKind() {
+        return node.text
+    }
+    if node.extra == astPatternTupleKind() {
+        return strings.Join(["(", ostyAstPatternList(f, node.children), ")"], "")
+    }
+    if node.extra == astPatternStructKind() {
+        return ostyAstStructPattern(f, node)
+    }
+    if node.extra == astPatternVariantKind() {
+        if node.children.len() == 0 {
+            return node.text
+        }
+        return strings.Join([node.text, "(", ostyAstPatternList(f, node.children), ")"], "")
+    }
+    if node.extra == astPatternRangeKind() {
+        return ostyAstRangePattern(f, node)
+    }
+    if node.extra == astPatternOrKind() {
+        return strings.Join([ostyAstPattern(f, node.left), " | ", ostyAstPattern(f, node.right)], "")
+    }
+    if node.extra == astPatternBindingKind() {
+        return strings.Join([node.text, " @ ", ostyAstPattern(f, node.left)], "")
+    }
+    if node.extra == astPatternFieldKind() {
+        return ostyAstStructPatternField(f, node)
+    }
+    node.text
+}
+
+fn ostyAstPatternList(f: OstyAstFormatter, nodes: List<Int>) -> String {
+    let mut parts: List<String> = []
+    for idx in nodes {
+        parts.push(ostyAstPattern(f, idx))
+    }
+    strings.Join(parts, ", ")
+}
+
+fn ostyAstStructPattern(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut fields: List<String> = []
+    for fieldIdx in node.children {
+        let field = ostyAstNode(f, fieldIdx)
+        if field.extra == astPatternFieldKind() {
+            fields.push(ostyAstStructPatternField(f, field))
+        } else {
+            fields.push(ostyAstPattern(f, fieldIdx))
+        }
+    }
+    if node.flags == 1 {
+        fields.push("..")
+    }
+    if fields.len() == 0 {
+        return strings.Join([node.text, " ", r"{}"], "")
+    }
+    strings.Join([node.text, " ", r"{", " ", strings.Join(fields, ", "), " ", r"}"], "")
+}
+
+fn ostyAstStructPatternField(f: OstyAstFormatter, node: AstNode) -> String {
+    if node.left >= 0 {
+        return strings.Join([node.text, ": ", ostyAstPattern(f, node.left)], "")
+    }
+    node.text
+}
+
+fn ostyAstRangePattern(f: OstyAstFormatter, node: AstNode) -> String {
+    let op = if node.flags == 1 { "..=" } else { ".." }
+    strings.Join([ostyAstPattern(f, node.left), op, ostyAstPattern(f, node.right)], "")
+}
+
+fn ostyAstExpr(f: OstyAstFormatter, idx: Int) -> String {
+    ostyAstExprPrec(f, idx, 0)
+}
+
+fn ostyAstExprPrec(f: OstyAstFormatter, idx: Int, parentPrec: Int) -> String {
+    if idx < 0 {
+        return ""
+    }
+    let node = ostyAstNode(f, idx)
+    let prec = ostyAstExprPrecValue(node)
+    let mut text = ostyAstExprBare(f, node)
+    if parentPrec > 0 && prec > 0 && prec < parentPrec {
+        text = strings.Join(["(", text, ")"], "")
+    }
+    text
+}
+
+fn ostyAstExprPrecValue(node: AstNode) -> Int {
+    if node.kind == AstNBinary {
+        return astInfixLBP(node.op)
+    }
+    if node.kind == AstNRange {
+        return 6
+    }
+    if node.kind == AstNUnary {
+        return 13
+    }
+    15
+}
+
+fn ostyAstExprBare(f: OstyAstFormatter, node: AstNode) -> String {
+    match node.kind {
+        AstNIdent -> node.text,
+        AstNIntLit -> node.text,
+        AstNFloatLit -> node.text,
+        AstNStringLit -> node.text,
+        AstNBoolLit -> node.text,
+        AstNCharLit -> node.text,
+        AstNByteLit -> node.text,
+        AstNUnary -> strings.Join([frontTokenKindName(node.op), ostyAstExprPrec(f, node.left, 13)], ""),
+        AstNBinary -> ostyAstBinaryExpr(f, node),
+        AstNRange -> ostyAstRangeExpr(f, node),
+        AstNCall -> strings.Join([ostyAstExprPrec(f, node.left, 15), "(", ostyAstExprList(f, node.children), ")"], ""),
+        AstNField -> ostyAstFieldExpr(f, node),
+        AstNIndex -> strings.Join([ostyAstExprPrec(f, node.left, 15), "[", ostyAstExpr(f, node.right), "]"], ""),
+        AstNQuestion -> strings.Join([ostyAstExprPrec(f, node.left, 15), "?"], ""),
+        AstNTurbofish -> strings.Join(
+            [ostyAstExprPrec(f, node.left, 15), "::<", ostyAstTypeList(f, node.children, ", "), ">"],
+            "",
+        ),
+        AstNList -> strings.Join(["[", ostyAstExprList(f, node.children), "]"], ""),
+        AstNTuple -> strings.Join(["(", ostyAstExprList(f, node.children), ")"], ""),
+        AstNMap -> ostyAstMapExpr(f, node),
+        AstNStructLit -> ostyAstStructLitExpr(f, node),
+        AstNParen -> strings.Join(["(", ostyAstExpr(f, node.left), ")"], ""),
+        AstNIf -> ostyAstIfExpr(f, node),
+        AstNMatch -> ostyAstMatchExpr(f, node),
+        AstNClosure -> ostyAstClosureExpr(f, node),
+        AstNBlock -> ostyAstBlockFromNode(f, node),
+        AstNExprStmt -> ostyAstExpr(f, node.left),
+        _ -> ostyAstRawTokenRange(f, node.start, node.end),
+    }
+}
+
+fn ostyAstBinaryExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let prec = astInfixLBP(node.op)
+    strings.Join(
+        [
+            ostyAstExprPrec(f, node.left, prec),
+            " ",
+            frontTokenKindName(node.op),
+            " ",
+            ostyAstExprPrec(f, node.right, prec + 1),
+        ],
+        "",
+    )
+}
+
+fn ostyAstFieldExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let op = if node.flags == 1 { "?." } else { "." }
+    strings.Join([ostyAstExprPrec(f, node.left, 15), op, node.text], "")
+}
+
+fn ostyAstExprList(f: OstyAstFormatter, nodes: List<Int>) -> String {
+    let mut parts: List<String> = []
+    for idx in nodes {
+        parts.push(ostyAstExpr(f, idx))
+    }
+    strings.Join(parts, ", ")
+}
+
+fn ostyAstRangeExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let op = if node.flags == 1 { "..=" } else { ".." }
+    let mut left = ""
+    if node.left >= 0 {
+        left = ostyAstExprPrec(f, node.left, 6)
+    }
+    let mut right = ""
+    if node.right >= 0 {
+        right = ostyAstExprPrec(f, node.right, 7)
+    }
+    strings.Join([left, op, right], "")
+}
+
+fn ostyAstMapExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    if node.flags == 1 {
+        return r"{:}"
+    }
+    let mut parts: List<String> = []
+    let mut idx = 0
+    for key in node.children {
+        let value = ostyAstChildAtVals(node.children2, idx)
+        parts.push(strings.Join([ostyAstExpr(f, key), ": ", ostyAstExpr(f, value)], ""))
+        idx = idx + 1
+    }
+    strings.Join([r"{", strings.Join(parts, ", "), r"}"], "")
+}
+
+fn ostyAstChildAtVals(values: List<Int>, target: Int) -> Int {
+    let mut idx = 0
+    for value in values {
+        if idx == target {
+            return value
+        }
+        idx = idx + 1
+    }
+    -1
+}
+
+fn ostyAstStructLitExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut fields: List<String> = []
+    for fieldIdx in node.children {
+        let field = ostyAstNode(f, fieldIdx)
+        if field.left >= 0 {
+            fields.push(strings.Join([field.text, ": ", ostyAstExpr(f, field.left)], ""))
+        } else {
+            fields.push(field.text)
+        }
+    }
+    if node.right >= 0 {
+        fields.push(strings.Join(["..", ostyAstExpr(f, node.right)], ""))
+    }
+    strings.Join([ostyAstExpr(f, node.left), " ", r"{", strings.Join(fields, ", "), r"}"], "")
+}
+
+fn ostyAstIfExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut head = "if "
+    if node.flags == 1 {
+        head = strings.Join(
+            [
+                head,
+                "let ",
+                ostyAstPattern(f, ostyAstChildAt(node, 1)),
+                " = ",
+                ostyAstExpr(f, node.left),
+            ],
+            "",
+        )
+    } else {
+        head = strings.Join([head, ostyAstExpr(f, node.left)], "")
+    }
+    let mut text = strings.Join([head, " ", ostyAstBlock(f, node.right)], "")
+    let elseIdx = ostyAstChildAt(node, 0)
+    if elseIdx >= 0 {
+        let elseNode = ostyAstNode(f, elseIdx)
+        if elseNode.kind == AstNIf {
+            text = strings.Join([text, " else ", ostyAstIfExpr(f, elseNode)], "")
+        } else {
+            text = strings.Join([text, " else ", ostyAstBlock(f, elseIdx)], "")
+        }
+    }
+    text
+}
+
+fn ostyAstMatchExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let base = f.indent
+    let saved = f.indent
+    let mut lines: List<String> = [
+        strings.Join(["match ", ostyAstExpr(f, node.left), " ", r"{"], ""),
+    ]
+    f.indent = base + 1
+    for armIdx in node.children {
+        lines.push(strings.Join([ostyAstIndent(base + 1), ostyAstMatchArm(f, armIdx), ","], ""))
+    }
+    f.indent = saved
+    lines.push(strings.Join([ostyAstIndent(base), r"}"], ""))
+    strings.Join(lines, "\n")
+}
+
+fn ostyAstMatchArm(f: OstyAstFormatter, idx: Int) -> String {
+    let node = ostyAstNode(f, idx)
+    let mut text = ostyAstPattern(f, node.left)
+    let guard = ostyAstChildAt(node, 0)
+    if guard >= 0 {
+        text = strings.Join([text, " if ", ostyAstExpr(f, guard)], "")
+    }
+    strings.Join([text, " -> ", ostyAstExpr(f, node.right)], "")
+}
+
+fn ostyAstClosureExpr(f: OstyAstFormatter, node: AstNode) -> String {
+    let mut text = ""
+    if node.children.len() == 0 {
+        text = "||"
+    } else {
+        text = strings.Join(["|", ostyAstParamList(f, node.children), "|"], "")
+    }
+    if node.right >= 0 {
+        text = strings.Join([text, " -> ", ostyAstType(f, node.right)], "")
+    }
+    strings.Join([text, " ", ostyAstExpr(f, node.left)], "")
+}

--- a/examples/selfhost-core/formatter_test.osty
+++ b/examples/selfhost-core/formatter_test.osty
@@ -1,0 +1,238 @@
+use std.testing
+
+use go "strings" as fmtStrings {
+    fn Contains(s: String, substr: String) -> Bool
+}
+
+fn assertFormatterContains(output: String, text: String) {
+    testing.assert(fmtStrings.Contains(output, text))
+}
+
+fn testPureFormatterCompactsFunctionSpacing() {
+    let formatted = ostyFormatSource(r"fn add(a:Int,b:Int)->Int{return a+b}")
+    testing.assert(formatted.ok)
+    testing.assertEq(
+        formatted.output,
+        "fn add(a: Int, b: Int) -> Int \{\n    return a + b\n\}\n",
+    )
+}
+
+fn testPureFormatterIsIdempotentForFormattedSubset() {
+    let source = "fn add(a: Int, b: Int) -> Int \{\n    return a + b\n\}\n"
+    let once = ostyFormatSource(source)
+    testing.assert(once.ok)
+    let twice = ostyFormatSource(once.output)
+    testing.assert(twice.ok)
+    testing.assertEq(once.output, twice.output)
+}
+
+fn testPureFormatterCheckReportsCleanAndDirty() {
+    let dirty = ostyFormatCheck(r"fn add(a:Int)->Int{return a}")
+    testing.assert(dirty.ok)
+    testing.assert(dirty.changed)
+    let clean = ostyFormatCheck(dirty.output)
+    testing.assert(clean.ok)
+    testing.assert(!(clean.changed))
+}
+
+fn testPureFormatterOutputFeedsFrontParser() {
+    let formatted = ostyFormatSource(r"fn add(a:Int,b:Int)->Int{return a+b}")
+    testing.assert(formatted.ok)
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterFormatsTypesAndLists() {
+    let formatted = ostyFormatSource(
+        r"fn first(xs:List<Int>)->Int{let ys=[1,2,3] return xs[0]??ys[0]}",
+    )
+    testing.assert(formatted.ok)
+    testing.assertEq(
+        formatted.output,
+        "fn first(xs: List<Int>) -> Int \{\n    let ys = [1, 2, 3]\n    return xs[0] ?? ys[0]\n\}\n",
+    )
+}
+
+fn testPureFormatterPreservesLeadingLineComment() {
+    let formatted = ostyFormatSource("// hello\nfn f()\{return 1\}")
+    testing.assert(formatted.ok)
+    testing.assertEq(
+        formatted.output,
+        "// hello\nfn f() \{\n    return 1\n\}\n",
+    )
+}
+
+fn testPureFormatterAngleDepthTorture() {
+    let formatted = ostyFormatSource(
+        "fn max<T: Ordered + Hashable>(a:T,b:T)->T\{if a>b\{return a\}else\{return b\}\}\ntype Handler = fn(List<Int>, Map<String,List<Int>>) -> Result<(), Error?>\nfn load(json:Json,text:String)->Result<Config,Error>\{let cfg=json.parse::<Config>(text)? return Ok(cfg)\}\nfn splitClose()->Int\{let xs:List<Int>=[] let m:Map<Int,List<Int>>=m return 0\}\nfn compare(a:Int,b:Int)->Bool\{return a < b\}",
+    )
+    testing.assert(formatted.ok)
+    testing.assertEq(
+        formatted.output,
+        "fn max<T: Ordered + Hashable>(a: T, b: T) -> T \{\n    if a > b \{\n        return a\n    \} else \{\n        return b\n    \}\n\}\ntype Handler = fn(List<Int>, Map<String, List<Int>>) -> Result<(), Error?>\nfn load(json: Json, text: String) -> Result<Config, Error> \{\n    let cfg = json.parse::<Config>(text)?\n    return Ok(cfg)\n\}\nfn splitClose() -> Int \{\n    let xs: List<Int> = []\n    let m: Map<Int, List<Int>> = m\n    return 0\n\}\nfn compare(a: Int, b: Int) -> Bool \{\n    return a < b\n\}\n",
+    )
+}
+
+fn testPureFormatterClosureAndAnnotationDepth() {
+    let formatted = ostyFormatSource(
+        "#[deprecated(message = \"old\")]\nfn f(xs:List<Int>)->List<Int>\{return xs.map(|x:Int|x+1).filter(|x|x>1)\}\nfn g()->fn(Int)->Int\{return || 1\}",
+    )
+    testing.assert(formatted.ok)
+    testing.assertEq(
+        formatted.output,
+        "#[deprecated(message = \"old\")]\nfn f(xs: List<Int>) -> List<Int> \{\n    return xs.map(|x: Int| x + 1).filter(|x| x > 1)\n\}\nfn g() -> fn(Int) -> Int \{\n    return || 1\n\}\n",
+    )
+}
+
+fn testPureFormatterTypeContextDepth() {
+    let formatted = ostyFormatSource(
+        "enum Wire<T>\{Packet(Result<List<T>,Error>),Fn(fn(Result<T,Error>,Map<String,List<T>>)->Result<(),Error>)\}\nfn tuple()->(Result<Int,Error>,fn(List<Int>,Result<String,Error>)->Map<String,Int>)\{return make()\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "Packet(Result<List<T>, Error>)")
+    assertFormatterContains(
+        formatted.output,
+        "Fn(fn(Result<T, Error>, Map<String, List<T>>) -> Result<(), Error>)",
+    )
+    assertFormatterContains(
+        formatted.output,
+        "fn tuple() -> (Result<Int, Error>, fn(List<Int>, Result<String, Error>) -> Map<String, Int>)",
+    )
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterBracePostfixAndEmptyMapDepth() {
+    let formatted = ostyFormatSource(
+        "fn f()->String\{return User\{name:\"Ada\",meta:\{:\}\}.name\}\nfn g()->Int\{return makeMap()[\"answer\"]\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "meta: \{:\}")
+    assertFormatterContains(formatted.output, "\}.name")
+    assertFormatterContains(formatted.output, "return makeMap()[\"answer\"]")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterPatternBraceDepth() {
+    let formatted = ostyFormatSource(
+        "struct User\{name:Int\}\nfn score(u:User)->Int\{return match u \{ User\{name\} if name > 0 -> name, User\{name\} -> name, _ -> 0 \}\}\nfn names(xs:List<User>)->List<Int>\{return xs.map(|User\{name\}|name)\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "\} if name > 0 -> name")
+    assertFormatterContains(formatted.output, "\} -> name")
+    assertFormatterContains(formatted.output, "\}| name")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterKeywordExpressionDepth() {
+    let formatted = ostyFormatSource(
+        "enum Maybe\{Some(Int),None\}\nfn f(opt:Maybe,ok:Bool)->Int\{if let Some(x)=opt\{return x\}else\{return 0\} for let Some(y)=opt\{return y\} return if ok\{1\}else\{2\}\}\nfn g(opt:Maybe)->Int\{return match opt \{ Some(v) if v > 0 -> v, Some(v) -> v, _ -> 0 \}\}\nfn h(opt:Maybe)->Int\{return if let Some(z)=opt\{z\}else\{0\}\}\nfn i(opt:Maybe)->Int\{if match opt \{ Some(v) -> v > 0, _ -> false \} \{ return 1 \} else \{ return 0 \}\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "if let Some(x) = opt \{")
+    assertFormatterContains(formatted.output, "for let Some(y) = opt \{")
+    assertFormatterContains(formatted.output, "return if ok \{")
+    assertFormatterContains(formatted.output, "return match opt \{")
+    assertFormatterContains(formatted.output, "Some(v) if v > 0 -> v")
+    assertFormatterContains(formatted.output, "return if let Some(z) = opt \{")
+    assertFormatterContains(formatted.output, "if match opt \{")
+    assertFormatterContains(formatted.output, "\} \{")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterPatternContinuationDepth() {
+    let formatted = ostyFormatSource(
+        "struct User\{name:Int\}\nfn f(u:User)->Int\{let User\{name\}=u let User\{name\}:User=u return name\}\nfn g(u:User)->Int\{if let User\{name\}=u\{return name\}else\{return 0\}\}\nfn h(users:List<User>)->Int\{for User\{name\} in users\{return name\} return 0\}\nfn k(xs:List<User>)->List<Int>\{return xs.map(|User\{name\}:User|name)\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "\} = u")
+    assertFormatterContains(formatted.output, "\}: User = u")
+    assertFormatterContains(formatted.output, "\} in users \{")
+    assertFormatterContains(formatted.output, "\}: User| name")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterPatternsUseAstLeaves() {
+    let formatted = ostyFormatSource(
+        "enum Maybe\{Some(Int),None\}\nstruct User\{name:Int,age:Int\}\nfn f(v:Maybe,u:User)->Int\{let User\{name:n,age,..\}=u return match v \{ Some( 1..= 3 ) | None -> 0, x @ Some( _ ) -> 1, _ -> n \}\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "let User \{ name: n, age, .. \} = u")
+    assertFormatterContains(formatted.output, "Some(1..=3) | None -> 0")
+    assertFormatterContains(formatted.output, "x @ Some(_) -> 1")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterRightBraceInfixContinuationDepth() {
+    let formatted = ostyFormatSource(
+        "fn f(ok:Bool,x:Int)->Int\{return if ok\{1\}else\{2\}+x\}\nfn g(x:Int)->Int\{return match x \{ 0 -> 1, _ -> 2 \} ?? 0\}\nfn h(x:Int)->Bool\{return Box\{value:x\}==Box\{value:0\}\}\nfn r(ok:Bool)->Range\{return if ok\{0\}else\{1\}..10\}\nfn lt(ok:Bool,x:Int)->Bool\{return if ok\{1\}else\{2\}<x\}\nfn gt(ok:Bool,x:Int)->Bool\{return if ok\{1\}else\{2\}>x\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "\} + x")
+    assertFormatterContains(formatted.output, "\} ?? 0")
+    assertFormatterContains(formatted.output, "\} == Box")
+    assertFormatterContains(formatted.output, "\}..10")
+    assertFormatterContains(formatted.output, "\} < x")
+    assertFormatterContains(formatted.output, "\} > x")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterPrefixOperatorDepth() {
+    let formatted = ostyFormatSource(
+        "fn neg(n:Int)->Int\{return -n\}\nfn not(ok:Bool)->Bool\{return !ok\}\nfn flip(n:Int)->Int\{return ~n\}\nfn cmp(a:Int,b:Int)->Bool\{return a < -b && a > -b\}\nfn expr(ok:Bool,x:Int)->Bool\{return if ok\{1\}else\{2\}< -x\}\nfn loop(done:Bool)\{for !done\{return\}\}\nfn scrutinee(ok:Bool)->Int\{return match !ok \{ true -> 1, _ -> 0 \}\}\nfn later(ok:Bool)\{defer !ok\}",
+    )
+    if !(formatted.ok) {
+        testing.fail(formatted.message)
+    }
+    assertFormatterContains(formatted.output, "return -n")
+    assertFormatterContains(formatted.output, "return !ok")
+    assertFormatterContains(formatted.output, "return ~n")
+    assertFormatterContains(formatted.output, "return a < -b && a > -b")
+    assertFormatterContains(formatted.output, "\} < -x")
+    assertFormatterContains(formatted.output, "for !done \{")
+    assertFormatterContains(formatted.output, "return match !ok \{")
+    assertFormatterContains(formatted.output, "defer !ok")
+    let tree = frontendParseTree(formatted.output)
+    testing.assertEq(frontParseTreeDiagnosticCount(tree), 0)
+    testing.assertEq(frontParseTreeInvalidSpanCount(tree), 0)
+}
+
+fn testPureFormatterRejectsLexErrors() {
+    let formatted = ostyFormatSource("\"unterminated")
+    testing.assert(!(formatted.ok))
+    testing.assert(formatted.message != "")
+}
+
+fn testPureFormatterRejectsParseErrors() {
+    let formatted = ostyFormatSource("fn f()\{a < b < c\}")
+    testing.assert(!(formatted.ok))
+    testing.assert(formatted.message != "")
+}

--- a/examples/selfhost-core/frontend.osty
+++ b/examples/selfhost-core/frontend.osty
@@ -5569,3 +5569,52 @@ pub fn frontendCheckAssignments(assignments: List<FrontAssignment>) -> FrontChec
     }
     summary
 }
+
+// ===================================================================
+// PURE OSTY FORMATTER
+// ===================================================================
+
+/// OstyFormatResult is the pure-Osty formatter result surface.
+pub struct OstyFormatResult {
+    pub ok: Bool,
+    pub output: String,
+    pub message: String,
+}
+
+/// OstyFormatCheckResult reports whether a source string is already in the
+/// formatter's canonical form.
+pub struct OstyFormatCheckResult {
+    pub ok: Bool,
+    pub changed: Bool,
+    pub output: String,
+    pub message: String,
+}
+
+/// ostyFormatSource formats Osty source without calling the Go formatter.
+///
+/// The public formatter routes through the self-hosted AST parser and printer.
+/// Comments and annotations are recovered as trivia from the lexer, but
+/// declarations, statements, expressions, patterns, and types are printed from
+/// AST node roles rather than token-depth heuristics.
+pub fn ostyFormatSource(source: String) -> OstyFormatResult {
+    ostyAstFormatSource(source)
+}
+
+/// ostyFormatCheck formats source and marks whether the result differs.
+pub fn ostyFormatCheck(source: String) -> OstyFormatCheckResult {
+    let formatted = ostyFormatSource(source)
+    if !(formatted.ok) {
+        return OstyFormatCheckResult {
+            ok: false,
+            changed: false,
+            output: "",
+            message: formatted.message,
+        }
+    }
+    OstyFormatCheckResult {
+        ok: true,
+        changed: formatted.output != source,
+        output: formatted.output,
+        message: "",
+    }
+}

--- a/examples/selfhost-core/parser.osty
+++ b/examples/selfhost-core/parser.osty
@@ -1,0 +1,1881 @@
+use go "strings" as strings {
+    fn Join(elems: List<String>, sep: String) -> String
+    fn Split(s: String, sep: String) -> List<String>
+    fn Repeat(s: String, count: Int) -> String
+    fn HasPrefix(s: String, prefix: String) -> Bool
+}
+
+// ===================================================================
+// AST NODE KINDS
+// ===================================================================
+
+pub enum AstNodeKind {
+    AstNIdent,
+    AstNIntLit,
+    AstNFloatLit,
+    AstNStringLit,
+    AstNBoolLit,
+    AstNCharLit,
+    AstNByteLit,
+    AstNBinary,
+    AstNUnary,
+    AstNCall,
+    AstNField,
+    AstNIndex,
+    AstNRange,
+    AstNIf,
+    AstNMatch,
+    AstNClosure,
+    AstNList,
+    AstNTuple,
+    AstNMap,
+    AstNStructLit,
+    AstNBlock,
+    AstNParen,
+    AstNQuestion,
+    AstNTurbofish,
+    AstNLet,
+    AstNReturn,
+    AstNBreak,
+    AstNContinue,
+    AstNDefer,
+    AstNFor,
+    AstNAssign,
+    AstNChanSend,
+    AstNExprStmt,
+    AstNFnDecl,
+    AstNStructDecl,
+    AstNEnumDecl,
+    AstNInterfaceDecl,
+    AstNTypeAlias,
+    AstNUseDecl,
+    AstNLetDecl,
+    AstNFile,
+    AstNParam,
+    AstNField_,
+    AstNVariant,
+    AstNMatchArm,
+    AstNType,
+    AstNPattern,
+    AstNAnnotation,
+    AstNGenericParam,
+    AstNError,
+}
+
+// ===================================================================
+// AST NODE + ARENA
+// ===================================================================
+
+pub struct AstNode {
+    pub kind: AstNodeKind,
+    pub start: Int,
+    pub end: Int,
+    pub text: String,
+    pub op: FrontTokenKind,
+    pub left: Int,
+    pub right: Int,
+    pub extra: Int,
+    pub children: List<Int>,
+    pub children2: List<Int>,
+    pub flags: Int,
+}
+
+pub struct AstParseError {
+    pub message: String,
+    pub tokenIndex: Int,
+    pub hint: String,
+    pub note: String,
+    pub code: String,
+}
+
+pub struct AstArena {
+    pub nodes: List<AstNode>,
+    pub decls: List<Int>,
+    pub errors: List<AstParseError>,
+}
+
+pub fn emptyAstNode(kind: AstNodeKind) -> AstNode {
+    AstNode {
+        kind, start: 0, end: 0, text: "", op: FrontEOF,
+        left: -1, right: -1, extra: -1,
+        children: [], children2: [], flags: 0,
+    }
+}
+
+pub fn emptyAstArena() -> AstArena {
+    AstArena { nodes: [], decls: [], errors: [] }
+}
+
+pub fn astPatternWildcardKind() -> Int { 1 }
+pub fn astPatternLiteralKind() -> Int { 2 }
+pub fn astPatternIdentKind() -> Int { 3 }
+pub fn astPatternTupleKind() -> Int { 4 }
+pub fn astPatternStructKind() -> Int { 5 }
+pub fn astPatternVariantKind() -> Int { 6 }
+pub fn astPatternRangeKind() -> Int { 7 }
+pub fn astPatternOrKind() -> Int { 8 }
+pub fn astPatternBindingKind() -> Int { 9 }
+pub fn astPatternFieldKind() -> Int { 10 }
+pub fn astPatternErrorKind() -> Int { 11 }
+
+pub fn astArenaAdd(arena: AstArena, node: AstNode) -> Int {
+    let idx = astArenaNodeCount(arena)
+    arena.nodes.push(node)
+    idx
+}
+
+pub fn astArenaNodeCount(arena: AstArena) -> Int {
+    let mut count = 0
+    for n in arena.nodes {
+        let _ = n
+        count = count + 1
+    }
+    count
+}
+
+pub fn astArenaNodeAt(arena: AstArena, idx: Int) -> AstNode {
+    let mut i = 0
+    for n in arena.nodes {
+        if i == idx {
+            return n
+        }
+        i = i + 1
+    }
+    emptyAstNode(AstNError)
+}
+
+// ===================================================================
+// PARSER STATE
+// ===================================================================
+
+pub struct OstyParser {
+    pub tokens: List<FrontToken>,
+    pub count: Int,
+    pub pos: Int,
+    pub arena: AstArena,
+    pub noStructLit: Bool,
+    pub inLoop: Bool,
+    pub typeGtDebt: Int,
+    pub pendingAssign: Bool,
+}
+
+pub fn newOstyParser(tokens: List<FrontToken>) -> OstyParser {
+    OstyParser {
+        tokens, count: frontTokenListCount(tokens), pos: 0,
+        arena: emptyAstArena(), noStructLit: false, inLoop: false,
+        typeGtDebt: 0, pendingAssign: false,
+    }
+}
+
+// ===================================================================
+// TOKEN PRIMITIVES
+// ===================================================================
+
+fn opPeek(p: OstyParser) -> FrontToken {
+    if p.typeGtDebt > 0 {
+        return FrontToken { kind: FrontGt, text: ">" }
+    }
+    if p.pendingAssign {
+        return FrontToken { kind: FrontAssign, text: "=" }
+    }
+    if p.pos >= p.count { return frontEOF() }
+    frontTokenAtList(p.tokens, p.pos)
+}
+
+fn opPeekAt(p: OstyParser, n: Int) -> FrontToken {
+    if n == 0 {
+        return opPeek(p)
+    }
+    let mut offset = n
+    if p.typeGtDebt > 0 {
+        if offset < p.typeGtDebt {
+            return FrontToken { kind: FrontGt, text: ">" }
+        }
+        offset = offset - p.typeGtDebt
+    }
+    if p.pendingAssign {
+        if offset == 0 {
+            return FrontToken { kind: FrontAssign, text: "=" }
+        }
+        offset = offset - 1
+    }
+    let idx = p.pos + offset
+    if idx >= p.count { return frontEOF() }
+    frontTokenAtList(p.tokens, idx)
+}
+
+fn opPeekPastNewlines(p: OstyParser) -> FrontToken {
+    let mut i = p.pos
+    for i < p.count {
+        let tok = frontTokenAtList(p.tokens, i)
+        if tok.kind != FrontNewline { return tok }
+        i = i + 1
+    }
+    frontEOF()
+}
+
+fn opAt(p: OstyParser, kind: FrontTokenKind) -> Bool { opPeek(p).kind == kind }
+
+fn opAdvance(p: OstyParser) -> FrontToken {
+    if p.typeGtDebt > 0 {
+        p.typeGtDebt = p.typeGtDebt - 1
+        return FrontToken { kind: FrontGt, text: ">" }
+    }
+    if p.pendingAssign {
+        p.pendingAssign = false
+        return FrontToken { kind: FrontAssign, text: "=" }
+    }
+    let tok = opPeek(p)
+    if tok.kind != FrontEOF { p.pos = p.pos + 1 }
+    tok
+}
+
+fn opEat(p: OstyParser, kind: FrontTokenKind) -> Bool {
+    if opAt(p, kind) {
+        let _ = opAdvance(p)
+        return true
+    }
+    false
+}
+
+fn opExpect(p: OstyParser, kind: FrontTokenKind) -> FrontToken {
+    if opAt(p, kind) { return opAdvance(p) }
+    let tok = opPeek(p)
+    let expectedName = frontTokenKindName(kind)
+    let gotName = frontTokenKindName(tok.kind)
+    opErrorFull(p, "expected {expectedName}, got {gotName}", "", "", "E0001")
+    tok
+}
+
+fn opSkipNewlines(p: OstyParser) {
+    for opAt(p, FrontNewline) {
+        let _ = opAdvance(p)
+    }
+}
+
+// ===================================================================
+// DIAGNOSTICS
+// ===================================================================
+
+fn opErrorFull(p: OstyParser, msg: String, hint: String, note: String, code: String) {
+    p.arena.errors.push(AstParseError { message: msg, tokenIndex: p.pos, hint, note, code })
+}
+
+fn opError(p: OstyParser, msg: String) { opErrorFull(p, msg, "", "", "") }
+
+fn opAddNode(p: OstyParser, node: AstNode) -> Int { astArenaAdd(p.arena, node) }
+
+// ===================================================================
+// ERROR RECOVERY
+// ===================================================================
+
+fn opSyncDecl(p: OstyParser) {
+    for !(opAt(p, FrontEOF)) {
+        let kind = opPeek(p).kind
+        if kind == FrontFn || kind == FrontStruct || kind == FrontEnum || kind == FrontInterface || kind == FrontType || kind == FrontUse || kind == FrontPub || kind == FrontHash { return }
+        let _ = opAdvance(p)
+    }
+}
+
+fn opSyncStmt(p: OstyParser) {
+    for !(opAt(p, FrontEOF)) {
+        let kind = opPeek(p).kind
+        if kind == FrontNewline {
+            let _ = opAdvance(p)
+            return
+        }
+        if kind == FrontRBrace { return }
+        if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || kind == FrontFor || kind == FrontIf || kind == FrontMatch { return }
+        let _ = opAdvance(p)
+    }
+}
+
+fn opErrorCount(p: OstyParser) -> Int {
+    let mut c = 0
+    for e in p.arena.errors { let _ = e
+    c = c + 1 }
+    c
+}
+
+fn opTruncateErrors(p: OstyParser, target: Int) {
+    let mut cur = opErrorCount(p)
+    for cur > target {
+        let _ = p.arena.errors.pop()
+        cur = cur - 1
+    }
+}
+
+// ===================================================================
+// OPERATOR HELPERS
+// ===================================================================
+
+fn astIsNonAssocOp(kind: FrontTokenKind) -> Bool {
+    kind == FrontEq || kind == FrontNeq || kind == FrontLt || kind == FrontGt || kind == FrontLeq || kind == FrontGeq || kind == FrontDotDot || kind == FrontDotDotEq
+}
+
+fn astSameLevel(a: FrontTokenKind, b: FrontTokenKind) -> Bool {
+    let ac = a == FrontEq || a == FrontNeq || a == FrontLt || a == FrontGt || a == FrontLeq || a == FrontGeq
+    let bc = b == FrontEq || b == FrontNeq || b == FrontLt || b == FrontGt || b == FrontLeq || b == FrontGeq
+    let ar = a == FrontDotDot || a == FrontDotDotEq
+    let br = b == FrontDotDot || b == FrontDotDotEq
+    (ac && bc) || (ar && br)
+}
+
+pub fn astInfixLBP(kind: FrontTokenKind) -> Int {
+    if kind == FrontQQ { return 2 }
+    if kind == FrontOr { return 3 }
+    if kind == FrontAnd { return 4 }
+    if kind == FrontEq || kind == FrontNeq || kind == FrontLt || kind == FrontGt || kind == FrontLeq || kind == FrontGeq { return 5 }
+    if kind == FrontDotDot || kind == FrontDotDotEq { return 6 }
+    if kind == FrontBitOr { return 7 }
+    if kind == FrontBitXor { return 8 }
+    if kind == FrontBitAnd { return 9 }
+    if kind == FrontShl || kind == FrontShr { return 10 }
+    if kind == FrontPlus || kind == FrontMinus { return 11 }
+    if kind == FrontStar || kind == FrontSlash || kind == FrontPercent { return 12 }
+    0
+}
+
+pub fn astInfixRBP(kind: FrontTokenKind) -> Int {
+    if kind == FrontQQ { return 2 }
+    if kind == FrontOr { return 4 }
+    if kind == FrontAnd { return 5 }
+    if kind == FrontEq || kind == FrontNeq || kind == FrontLt || kind == FrontGt || kind == FrontLeq || kind == FrontGeq { return 6 }
+    if kind == FrontDotDot || kind == FrontDotDotEq { return 7 }
+    if kind == FrontBitOr { return 8 }
+    if kind == FrontBitXor { return 9 }
+    if kind == FrontBitAnd { return 10 }
+    if kind == FrontShl || kind == FrontShr { return 11 }
+    if kind == FrontPlus || kind == FrontMinus { return 12 }
+    if kind == FrontStar || kind == FrontSlash || kind == FrontPercent { return 13 }
+    0
+}
+
+fn astStartsExpr(kind: FrontTokenKind) -> Bool {
+    kind == FrontIdent || kind == FrontInt || kind == FrontFloat || kind == FrontString || kind == FrontRawString || kind == FrontChar || kind == FrontByte || kind == FrontLParen || kind == FrontLBracket || kind == FrontLBrace || kind == FrontMinus || kind == FrontNot || kind == FrontBitNot || kind == FrontIf || kind == FrontMatch || kind == FrontBitOr || kind == FrontOr || kind == FrontUnderscore
+}
+
+// ===================================================================
+// GENERIC PARAMETER PARSING (shared)
+// ===================================================================
+
+fn opParseGenericParams(p: OstyParser) -> List<Int> {
+    let mut params: List<Int> = []
+    if opEat(p, FrontLt) {
+        for !(opAt(p, FrontGt)) && !(opAt(p, FrontEOF)) {
+            let start = p.pos
+            let gName = opExpect(p, FrontIdent).text
+            let mut bounds: List<Int> = []
+            if opEat(p, FrontColon) {
+                bounds.push(opParseType(p))
+                for opEat(p, FrontPlus) { bounds.push(opParseType(p)) }
+            }
+            let mut gNode = emptyAstNode(AstNGenericParam)
+            gNode.text = gName
+            gNode.children = bounds
+            gNode.start = start
+            gNode.end = p.pos
+            params.push(opAddNode(p, gNode))
+            if !(opEat(p, FrontComma)) { break }
+        }
+        let _ = opExpect(p, FrontGt)
+    }
+    params
+}
+
+// ===================================================================
+// EXPRESSION PARSING
+// ===================================================================
+
+fn opParseExpr(p: OstyParser) -> Int { opParseExprBP(p, 0) }
+
+fn opParseExprBP(p: OstyParser, minBP: Int) -> Int {
+    let mut left = opParsePrefix(p)
+    for {
+        let postfix = opTryParsePostfix(p, left)
+        if postfix >= 0 {
+            left = postfix
+        } else {
+            let op = opPeek(p)
+            let lbp = astInfixLBP(op.kind)
+            if lbp == 0 || lbp < minBP { break }
+            opAdvance(p)
+            let rbp = astInfixRBP(op.kind)
+            if op.kind == FrontDotDot || op.kind == FrontDotDotEq {
+                let mut rhsIdx = -1
+                if astStartsExpr(opPeek(p).kind) { rhsIdx = opParseExprBP(p, rbp) }
+                let mut rangeNode = emptyAstNode(AstNRange)
+                rangeNode.left = left
+                rangeNode.right = rhsIdx
+                rangeNode.start = p.pos
+                if op.kind == FrontDotDotEq { rangeNode.flags = 1 }
+                left = opAddNode(p, rangeNode)
+                if astIsNonAssocOp(opPeek(p).kind) && astSameLevel(op.kind, opPeek(p).kind) {
+                    opErrorFull(p, "chained range operators require parentheses", "", "v0.2 R1: range operators are non-associative", "E0200")
+                    break
+                }
+            } else {
+                let rhs = opParseExprBP(p, rbp)
+                let mut binNode = emptyAstNode(AstNBinary)
+                binNode.op = op.kind
+                binNode.left = left
+                binNode.right = rhs
+                binNode.start = p.pos
+                left = opAddNode(p, binNode)
+                if astIsNonAssocOp(op.kind) && astIsNonAssocOp(opPeek(p).kind) && astSameLevel(op.kind, opPeek(p).kind) {
+                    opErrorFull(p, "chained comparison operators require parentheses", "", "v0.2 R1: comparison operators are non-associative", "E0200")
+                    break
+                }
+            }
+        }
+    }
+    left
+}
+
+fn opParsePrefix(p: OstyParser) -> Int {
+    let tok = opPeek(p)
+    if tok.kind == FrontMinus || tok.kind == FrontNot || tok.kind == FrontBitNot {
+        let start = p.pos
+        opAdvance(p)
+        let x = opParsePrefix(p)
+        let mut node = emptyAstNode(AstNUnary)
+        node.op = tok.kind
+        node.left = x
+        node.start = start
+        node.end = p.pos
+        return opAddNode(p, node)
+    }
+    if tok.kind == FrontDotDot || tok.kind == FrontDotDotEq {
+        let start = p.pos
+        opAdvance(p)
+        let mut rhsIdx = -1
+        if astStartsExpr(opPeek(p).kind) { rhsIdx = opParseExprBP(p, 100) }
+        let mut rangeNode = emptyAstNode(AstNRange)
+        rangeNode.left = -1
+        rangeNode.right = rhsIdx
+        rangeNode.start = start
+        rangeNode.end = p.pos
+        if tok.kind == FrontDotDotEq { rangeNode.flags = 1 }
+        return opAddNode(p, rangeNode)
+    }
+    opParsePrimary(p)
+}
+
+fn opParsePrimary(p: OstyParser) -> Int {
+    let tok = opPeek(p)
+    let start = p.pos
+    if tok.kind == FrontInt { opAdvance(p)
+    let mut n = emptyAstNode(AstNIntLit)
+    n.text = tok.text
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if tok.kind == FrontFloat { opAdvance(p)
+    let mut n = emptyAstNode(AstNFloatLit)
+    n.text = tok.text
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if tok.kind == FrontString || tok.kind == FrontRawString { opAdvance(p)
+    let mut n = emptyAstNode(AstNStringLit)
+    n.text = tok.text
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if tok.kind == FrontChar { opAdvance(p)
+    let mut n = emptyAstNode(AstNCharLit)
+    n.text = tok.text
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if tok.kind == FrontByte { opAdvance(p)
+    let mut n = emptyAstNode(AstNByteLit)
+    n.text = tok.text
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if tok.kind == FrontIdent {
+        opAdvance(p)
+        if tok.text == "true" || tok.text == "false" {
+            let mut n = emptyAstNode(AstNBoolLit)
+            n.text = tok.text
+            if tok.text == "true" { n.flags = 1 }
+            n.start = start
+            n.end = p.pos
+            return opAddNode(p, n)
+        }
+        let mut n = emptyAstNode(AstNIdent)
+        n.text = tok.text
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontLParen { return opParseParenOrTuple(p) }
+    if tok.kind == FrontLBracket { return opParseListLit(p) }
+    if tok.kind == FrontLBrace { return opParseBlockOrMap(p) }
+    if tok.kind == FrontIf { return opParseIfExpr(p) }
+    if tok.kind == FrontMatch { return opParseMatchExpr(p) }
+    if tok.kind == FrontBitOr || tok.kind == FrontOr { return opParseClosure(p) }
+    if tok.kind == FrontUnderscore { opAdvance(p)
+    let mut n = emptyAstNode(AstNIdent)
+    n.text = "_"
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    let errKindName = frontTokenKindName(tok.kind)
+    opErrorFull(p, "unexpected {errKindName} in expression", "an expression starts with a literal, identifier, `(`, `[`, `if`, `match`, or a closure", "", "E0010")
+    opAdvance(p)
+    let mut errNode = emptyAstNode(AstNError)
+    errNode.start = p.pos - 1
+    errNode.end = p.pos
+    opAddNode(p, errNode)
+}
+
+fn opParseParenOrTuple(p: OstyParser) -> Int {
+    let start = p.pos
+    opAdvance(p)
+    let prevNoSL = p.noStructLit
+    p.noStructLit = false
+    opSkipNewlines(p)
+    if opEat(p, FrontRParen) { p.noStructLit = prevNoSL
+    let mut n = emptyAstNode(AstNTuple)
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    let first = opParseExpr(p)
+    opSkipNewlines(p)
+    if opAt(p, FrontRParen) { opAdvance(p)
+    p.noStructLit = prevNoSL
+    let mut n = emptyAstNode(AstNParen)
+    n.left = first
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    let mut elems: List<Int> = [first]
+    for opEat(p, FrontComma) { opSkipNewlines(p)
+    if opAt(p, FrontRParen) { break }
+    elems.push(opParseExpr(p))
+    opSkipNewlines(p) }
+    opExpect(p, FrontRParen)
+    p.noStructLit = prevNoSL
+    let mut n = emptyAstNode(AstNTuple)
+    n.children = elems
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseListLit(p: OstyParser) -> Int {
+    let start = p.pos
+    opAdvance(p)
+    let mut elems: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBracket)) && !(opAt(p, FrontEOF)) { elems.push(opParseExpr(p))
+    opSkipNewlines(p)
+    if !(opEat(p, FrontComma)) { break }
+    opSkipNewlines(p) }
+    opExpect(p, FrontRBracket)
+    let mut n = emptyAstNode(AstNList)
+    n.children = elems
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseBlockOrMap(p: OstyParser) -> Int {
+    if opPeekAt(p, 1).kind == FrontColon && opPeekAt(p, 2).kind == FrontRBrace {
+        let start = p.pos
+        opAdvance(p)
+        opAdvance(p)
+        opAdvance(p)
+        let mut n = emptyAstNode(AstNMap)
+        n.start = start
+        n.end = p.pos
+        n.flags = 1
+        return opAddNode(p, n)
+    }
+    if opLooksLikeMap(p) { return opParseMapLit(p) }
+    opParseBlock(p)
+}
+
+fn opLooksLikeMap(p: OstyParser) -> Bool {
+    let save = p.pos
+    let saveErr = opErrorCount(p)
+    opAdvance(p)
+    opSkipNewlines(p)
+    if opAt(p, FrontRBrace) { p.pos = save
+    return false }
+    let kind = opPeek(p).kind
+    if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || kind == FrontFor { p.pos = save
+    return false }
+    opParseExpr(p)
+    let result = opAt(p, FrontColon) && opPeekAt(p, 1).kind != FrontColon
+    p.pos = save
+    opTruncateErrors(p, saveErr)
+    result
+}
+
+fn opParseMapLit(p: OstyParser) -> Int {
+    let start = p.pos
+    opAdvance(p)
+    let mut keys: List<Int> = []
+    let mut vals: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        keys.push(opParseExpr(p))
+        opExpect(p, FrontColon)
+        vals.push(opParseExpr(p))
+        opSkipNewlines(p)
+        if !(opEat(p, FrontComma)) { break }
+        opSkipNewlines(p)
+    }
+    opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNMap)
+    n.children = keys
+    n.children2 = vals
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseBlock(p: OstyParser) -> Int {
+    let start = p.pos
+    opExpect(p, FrontLBrace)
+    let mut stmts: List<Int> = []
+    opSkipNewlines(p)
+    let errsBefore = opErrorCount(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        stmts.push(opParseStmt(p))
+        if opErrorCount(p) > errsBefore { opSyncStmt(p) }
+        opSkipNewlines(p)
+    }
+    opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNBlock)
+    n.children = stmts
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseIfExpr(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let mut patIdx = -1
+    let mut isIfLet = false
+    if opAt(p, FrontLet) {
+        let _ = opAdvance(p)
+        isIfLet = true
+        patIdx = opParsePattern(p)
+        let _ = opExpect(p, FrontAssign)
+    }
+    let prevNoSL = p.noStructLit
+    p.noStructLit = true
+    let cond = opParseExpr(p)
+    p.noStructLit = prevNoSL
+    let thenBlock = opParseBlock(p)
+    let mut elseIdx = -1
+    if opEat(p, FrontElse) {
+        if opAt(p, FrontIf) {
+            elseIdx = opParseIfExpr(p)
+        } else {
+            elseIdx = opParseBlock(p)
+        }
+    } else if opPeekPastNewlines(p).kind == FrontElse {
+        opErrorFull(p, "`else` must be on the same line as `\}`", "move `else` to the same line: `\} else \{`", "v0.2 O2: `\} else` must sit on the same line", "E0201")
+    }
+    let mut n = emptyAstNode(AstNIf)
+    n.left = cond
+    n.right = thenBlock
+    n.children = [elseIdx, patIdx]
+    n.start = start
+    n.end = p.pos
+    if isIfLet { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseMatchExpr(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let prevNoSL = p.noStructLit
+    p.noStructLit = true
+    let scrutinee = opParseExpr(p)
+    p.noStructLit = prevNoSL
+    opExpect(p, FrontLBrace)
+    let mut arms: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        let armStart = p.pos
+        let pat = opParsePattern(p)
+        let mut guard = -1
+        if opAt(p, FrontIf) {
+            let _ = opAdvance(p)
+            let pv = p.noStructLit
+            p.noStructLit = true
+            guard = opParseExpr(p)
+            p.noStructLit = pv
+        }
+        let _ = opExpect(p, FrontArrow)
+        let body = opParseExpr(p)
+        let mut armNode = emptyAstNode(AstNMatchArm)
+        armNode.left = pat
+        armNode.right = body
+        armNode.children = [guard]
+        armNode.start = armStart
+        armNode.end = p.pos
+        arms.push(opAddNode(p, armNode))
+        opSkipNewlines(p)
+        if !(opEat(p, FrontComma)) { break }
+        opSkipNewlines(p)
+    }
+    opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNMatch)
+    n.left = scrutinee
+    n.children = arms
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseClosure(p: OstyParser) -> Int {
+    let start = p.pos
+    if opEat(p, FrontOr) {
+        let body = opParseClosureBody(p, false)
+        let mut n = emptyAstNode(AstNClosure)
+        n.left = body
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    let _ = opExpect(p, FrontBitOr)
+    let mut params: List<Int> = []
+    for !(opAt(p, FrontBitOr)) && !(opAt(p, FrontEOF)) {
+        let paramStart = p.pos
+        let mut paramNode = emptyAstNode(AstNParam)
+        if opAt(p, FrontLParen) || opAt(p, FrontUnderscore) {
+            paramNode.left = opParsePatternOneAlt(p)
+        } else if opAt(p, FrontIdent) {
+            let name = opPeek(p).text
+            if astIsUpperName(name) && (opPeekAt(p, 1).kind == FrontLParen || opPeekAt(p, 1).kind == FrontLBrace) {
+                paramNode.left = opParsePatternOneAlt(p)
+            } else {
+                paramNode.text = opAdvance(p).text
+            }
+        } else {
+            opError(p, "expected closure parameter")
+            let _ = opAdvance(p)
+        }
+        if opEat(p, FrontColon) { paramNode.right = opParseType(p) }
+        paramNode.start = paramStart
+        paramNode.end = p.pos
+        params.push(opAddNode(p, paramNode))
+        if !(opEat(p, FrontComma)) { break }
+    }
+    let _ = opExpect(p, FrontBitOr)
+    let mut retTypeIdx = -1
+    if opEat(p, FrontArrow) { retTypeIdx = opParseType(p) }
+    let body = opParseClosureBody(p, retTypeIdx >= 0)
+    let mut n = emptyAstNode(AstNClosure)
+    n.left = body
+    n.right = retTypeIdx
+    n.children = params
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseClosureBody(p: OstyParser, requireBlock: Bool) -> Int {
+    if opAt(p, FrontLBrace) { return opParseBlock(p) }
+    if requireBlock { opErrorFull(p, "closure with return type requires block body", "add `\{ ... \}`", "", "E0011") }
+    opParseExpr(p)
+}
+
+// ===================================================================
+// POSTFIX
+// ===================================================================
+
+fn opTryParsePostfix(p: OstyParser, lhs: Int) -> Int {
+    let tok = opPeek(p)
+    if tok.kind == FrontDot {
+        let s = p.pos
+        let _ = opAdvance(p)
+        let nm = opAdvance(p).text
+        let mut n = emptyAstNode(AstNField)
+        n.left = lhs
+        n.text = nm
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontQDot {
+        let s = p.pos
+        let _ = opAdvance(p)
+        let nm = opAdvance(p).text
+        let mut n = emptyAstNode(AstNField)
+        n.left = lhs
+        n.text = nm
+        n.flags = 1
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontLParen { return opParseCallArgs(p, lhs) }
+    if tok.kind == FrontLBracket { return opParseIndex(p, lhs) }
+    if tok.kind == FrontQuestion {
+        let s = p.pos
+        let _ = opAdvance(p)
+        let mut n = emptyAstNode(AstNQuestion)
+        n.left = lhs
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontColonColon && opPeekAt(p, 1).kind == FrontLt { return opParseTurbofish(p, lhs) }
+    if tok.kind == FrontLBrace && !(p.noStructLit) && lhs >= 0 {
+        let leftNode = astArenaNodeAt(p.arena, lhs)
+        if leftNode.kind == AstNIdent && astIsUpperName(leftNode.text) { return opParseStructLit(p, lhs) }
+    }
+    return 0 - 1
+}
+
+fn opParseCallArgs(p: OstyParser, callee: Int) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let mut args: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
+        if opAt(p, FrontIdent) && opPeekAt(p, 1).kind == FrontColon {
+            let _ = opAdvance(p)
+            let _ = opAdvance(p)
+        }
+        args.push(opParseExpr(p))
+        opSkipNewlines(p)
+        if !(opEat(p, FrontComma)) { break }
+        opSkipNewlines(p)
+    }
+    opExpect(p, FrontRParen)
+    let mut n = emptyAstNode(AstNCall)
+    n.left = callee
+    n.children = args
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseIndex(p: OstyParser, object: Int) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let index = opParseExpr(p)
+    let _ = opExpect(p, FrontRBracket)
+    let mut n = emptyAstNode(AstNIndex)
+    n.left = object
+    n.right = index
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseTurbofish(p: OstyParser, callee: Int) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let _ = opAdvance(p)
+    let mut typeArgs: List<Int> = []
+    for !(opAt(p, FrontGt)) && !(opAt(p, FrontEOF)) { typeArgs.push(opParseType(p))
+    if !(opEat(p, FrontComma)) { break } }
+    let _ = opExpect(p, FrontGt)
+    let mut n = emptyAstNode(AstNTurbofish)
+    n.left = callee
+    n.children = typeArgs
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseStructLit(p: OstyParser, name: Int) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let mut fields: List<Int> = []
+    let mut spreadIdx = -1
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        if opAt(p, FrontDotDot) {
+            let _ = opAdvance(p)
+            spreadIdx = opParseExpr(p)
+            opSkipNewlines(p)
+            let _ = opEat(p, FrontComma)
+            break
+        }
+        let fs = p.pos
+        let fn_ = opAdvance(p).text
+        let mut valIdx = -1
+        if opEat(p, FrontColon) { valIdx = opParseExpr(p) }
+        let mut fNode = emptyAstNode(AstNField_)
+        fNode.text = fn_
+        fNode.left = valIdx
+        fNode.start = fs
+        fNode.end = p.pos
+        fields.push(opAddNode(p, fNode))
+        opSkipNewlines(p)
+        if !(opEat(p, FrontComma)) { break }
+        opSkipNewlines(p)
+    }
+    let _ = opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNStructLit)
+    n.left = name
+    n.right = spreadIdx
+    n.children = fields
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn astIsUpperName(text: String) -> Bool {
+    let units = strings.Split(text, "")
+    let first = frontUnitAt(units, 0)
+    first >= "A" && first <= "Z"
+}
+
+// ===================================================================
+// STATEMENT PARSING
+// ===================================================================
+
+fn opParseStmt(p: OstyParser) -> Int {
+    let tok = opPeek(p)
+    if tok.kind == FrontLet { return opParseLetStmt(p) }
+    if tok.kind == FrontReturn { return opParseReturnStmt(p) }
+    if tok.kind == FrontBreak {
+        let s = p.pos
+        let _ = opAdvance(p)
+        if !(p.inLoop) { opErrorFull(p, "`break` outside of loop", "move inside a `for` loop", "", "E0100") }
+        let mut n = emptyAstNode(AstNBreak)
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontContinue {
+        let s = p.pos
+        let _ = opAdvance(p)
+        if !(p.inLoop) { opErrorFull(p, "`continue` outside of loop", "move inside a `for` loop", "", "E0101") }
+        let mut n = emptyAstNode(AstNContinue)
+        n.start = s
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontDefer { return opParseDeferStmt(p) }
+    if tok.kind == FrontFor { return opParseForStmt(p) }
+    let expr = opParseExpr(p)
+    let next = opPeek(p)
+    if next.kind == FrontChanArrow { let s = p.pos
+    let _ = opAdvance(p)
+    let v = opParseExpr(p)
+    let mut n = emptyAstNode(AstNChanSend)
+    n.left = expr
+    n.right = v
+    n.start = s
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if frontIsAssignOp(next.kind) { let s = p.pos
+    let _ = opAdvance(p)
+    let v = opParseExpr(p)
+    let mut n = emptyAstNode(AstNAssign)
+    n.left = expr
+    n.right = v
+    n.op = next.kind
+    n.start = s
+    n.end = p.pos
+    return opAddNode(p, n) }
+    let mut n = emptyAstNode(AstNExprStmt)
+    n.left = expr
+    n.start = p.pos
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseLetStmt(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let mut isMut = false
+    if opEat(p, FrontMut) { isMut = true }
+    let pat = opParsePattern(p)
+    let mut typeIdx = -1
+    if opEat(p, FrontColon) { typeIdx = opParseType(p) }
+    let mut valueIdx = -1
+    if opEat(p, FrontAssign) { valueIdx = opParseExpr(p) }
+    let mut n = emptyAstNode(AstNLet)
+    n.left = pat
+    n.right = valueIdx
+    n.children = [typeIdx]
+    n.start = start
+    n.end = p.pos
+    if isMut { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseReturnStmt(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let mut valueIdx = -1
+    if !(opAt(p, FrontNewline)) && !(opAt(p, FrontEOF)) && !(opAt(p, FrontRBrace)) { valueIdx = opParseExpr(p) }
+    let mut n = emptyAstNode(AstNReturn)
+    n.left = valueIdx
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseDeferStmt(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let expr = opParseExpr(p)
+    let mut n = emptyAstNode(AstNDefer)
+    n.left = expr
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseForStmt(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let prevInLoop = p.inLoop
+    p.inLoop = true
+    let mut kind = "infinite"
+    let mut patIdx = -1
+    let mut condIdx = -1
+    let mut iterIdx = -1
+    if opAt(p, FrontLBrace) { kind = "infinite" } else if opAt(p, FrontLet) {
+        kind = "forlet"
+        let _ = opAdvance(p)
+        patIdx = opParsePattern(p)
+        let _ = opExpect(p, FrontAssign)
+        let pv = p.noStructLit
+        p.noStructLit = true
+        condIdx = opParseExpr(p)
+        p.noStructLit = pv
+    } else if opAt(p, FrontIdent) && astIsUpperName(opPeek(p).text) && (opPeekAt(p, 1).kind == FrontLParen || opPeekAt(p, 1).kind == FrontLBrace) {
+        patIdx = opParsePatternOneAlt(p)
+        if opAt(p, FrontIdent) && opPeek(p).text == "in" {
+            let _ = opAdvance(p)
+            kind = "forin"
+            let pv = p.noStructLit
+            p.noStructLit = true
+            iterIdx = opParseExpr(p)
+            p.noStructLit = pv
+        } else {
+            kind = "cond"
+            condIdx = patIdx
+            patIdx = -1
+        }
+    } else {
+        let pv = p.noStructLit
+        p.noStructLit = true
+        let expr = opParseExpr(p)
+        p.noStructLit = pv
+        if opAt(p, FrontIdent) && opPeek(p).text == "in" {
+            let _ = opAdvance(p)
+            kind = "forin"
+            patIdx = expr
+            let pv2 = p.noStructLit
+            p.noStructLit = true
+            iterIdx = opParseExpr(p)
+            p.noStructLit = pv2
+        } else { kind = "cond"
+        condIdx = expr }
+    }
+    let body = opParseBlock(p)
+    p.inLoop = prevInLoop
+    let mut n = emptyAstNode(AstNFor)
+    n.text = kind
+    n.left = condIdx
+    n.right = body
+    n.children = [patIdx, iterIdx]
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+// ===================================================================
+// PATTERN PARSING
+// ===================================================================
+
+fn opParsePattern(p: OstyParser) -> Int {
+    let mut left = opParsePatternOneAlt(p)
+    for opAt(p, FrontBitOr) { opAdvance(p)
+    let right = opParsePatternOneAlt(p)
+    let mut n = emptyAstNode(AstNPattern)
+    n.extra = astPatternOrKind()
+    n.left = left
+    n.right = right
+    n.start = astArenaNodeAt(p.arena, left).start
+    n.end = p.pos
+    left = opAddNode(p, n) }
+    left
+}
+
+fn opPatternAtEnd(p: OstyParser) -> Bool {
+    opAt(p, FrontArrow) || opAt(p, FrontComma) || opAt(p, FrontRBrace) || opAt(p, FrontRParen) || opAt(
+        p,
+        FrontBitOr,
+    ) || opAt(p, FrontIf) || opAt(p, FrontEOF)
+}
+
+fn opParsePatternRangeTail(p: OstyParser, start: Int, left: Int) -> Int {
+    if !(opAt(p, FrontDotDot)) && !(opAt(p, FrontDotDotEq)) {
+        return left
+    }
+    let inclusive = opAt(p, FrontDotDotEq)
+    opAdvance(p)
+    let mut rhsIdx = -1
+    if !(opPatternAtEnd(p)) {
+        rhsIdx = opParsePatternOneAlt(p)
+    }
+    let mut rn = emptyAstNode(AstNPattern)
+    rn.extra = astPatternRangeKind()
+    rn.left = left
+    rn.right = rhsIdx
+    rn.start = start
+    rn.end = p.pos
+    if inclusive {
+        rn.flags = 1
+    }
+    opAddNode(p, rn)
+}
+
+fn opParsePatternOneAlt(p: OstyParser) -> Int {
+    let tok = opPeek(p)
+    let start = p.pos
+    if tok.kind == FrontDotDot || tok.kind == FrontDotDotEq {
+        let inclusive = tok.kind == FrontDotDotEq
+        opAdvance(p)
+        let mut rhsIdx = -1
+        if !(opPatternAtEnd(p)) {
+            rhsIdx = opParsePatternOneAlt(p)
+        }
+        let mut n = emptyAstNode(AstNPattern)
+        n.extra = astPatternRangeKind()
+        n.right = rhsIdx
+        n.start = start
+        n.end = p.pos
+        if inclusive {
+            n.flags = 1
+        }
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontUnderscore { opAdvance(p)
+    let mut n = emptyAstNode(AstNPattern)
+    n.extra = astPatternWildcardKind()
+    n.text = "_"
+    n.start = start
+    n.end = p.pos
+    return opAddNode(p, n) }
+    if tok.kind == FrontInt || tok.kind == FrontFloat || tok.kind == FrontString || tok.kind == FrontRawString || tok.kind == FrontChar || tok.kind == FrontByte {
+        opAdvance(p)
+        let mut n = emptyAstNode(AstNPattern)
+        n.extra = astPatternLiteralKind()
+        n.text = tok.text
+        n.op = tok.kind
+        n.start = start
+        n.end = p.pos
+        let patIdx = opAddNode(p, n)
+        return opParsePatternRangeTail(p, start, patIdx)
+    }
+    if tok.kind == FrontMinus { opAdvance(p)
+    let inner = opParsePatternOneAlt(p)
+    let mut n = emptyAstNode(AstNPattern)
+    n.extra = astPatternLiteralKind()
+    n.text = "-"
+    n.left = inner
+    n.start = start
+    n.end = p.pos
+    return opParsePatternRangeTail(p, start, opAddNode(p, n)) }
+    if tok.kind == FrontLParen {
+        opAdvance(p)
+        let mut elems: List<Int> = []
+        opSkipNewlines(p)
+        for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { elems.push(opParsePattern(p))
+        if !(opEat(p, FrontComma)) { break }
+        opSkipNewlines(p) }
+        opExpect(p, FrontRParen)
+        let mut n = emptyAstNode(AstNPattern)
+        n.extra = astPatternTupleKind()
+        n.children = elems
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    if tok.kind == FrontIdent {
+        let head = tok.text
+        let mut path: List<String> = [head]
+        opAdvance(p)
+        for opAt(p, FrontDot) && opPeekAt(p, 1).kind == FrontIdent {
+            opAdvance(p)
+            path.push(opAdvance(p).text)
+        }
+        let name = strings.Join(path, ".")
+        if path.len() == 1 && (head == "true" || head == "false") { let mut n = emptyAstNode(AstNPattern)
+        n.extra = astPatternLiteralKind()
+        n.text = head
+        n.op = FrontIdent
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n) }
+        if opAt(p, FrontLParen) {
+            opAdvance(p)
+            let mut fields: List<Int> = []
+            for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { fields.push(opParsePattern(p))
+            if !(opEat(p, FrontComma)) { break } }
+            opExpect(p, FrontRParen)
+            let mut n = emptyAstNode(AstNPattern)
+            n.extra = astPatternVariantKind()
+            n.text = name
+            n.op = FrontIdent
+            n.children = fields
+            n.start = start
+            n.end = p.pos
+            return opAddNode(p, n)
+        }
+        if opAt(p, FrontLBrace) {
+            opAdvance(p)
+            let mut fields: List<Int> = []
+            let mut hasRest = false
+            opSkipNewlines(p)
+            for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+                if opAt(p, FrontDotDot) { opAdvance(p)
+                hasRest = true
+                break }
+                if opAt(p, FrontIdent) {
+                    let fs = p.pos
+                    let fn_ = opAdvance(p).text
+                    let mut fNode = emptyAstNode(AstNPattern)
+                    fNode.extra = astPatternFieldKind()
+                    fNode.text = fn_
+                    if opEat(p, FrontColon) {
+                        fNode.left = opParsePattern(p)
+                    }
+                    fNode.start = fs
+                    fNode.end = p.pos
+                    fields.push(opAddNode(p, fNode))
+                } else {
+                    fields.push(opParsePattern(p))
+                }
+                if !(opEat(p, FrontComma)) { break }
+                opSkipNewlines(p)
+            }
+            opExpect(p, FrontRBrace)
+            let mut n = emptyAstNode(AstNPattern)
+            n.extra = astPatternStructKind()
+            n.text = name
+            n.children = fields
+            n.start = start
+            n.end = p.pos
+            if hasRest { n.flags = 1 }
+            return opAddNode(p, n)
+        }
+        if path.len() == 1 && opAt(p, FrontAt) { opAdvance(p)
+        let inner = opParsePatternOneAlt(p)
+        let mut n = emptyAstNode(AstNPattern)
+        n.extra = astPatternBindingKind()
+        n.text = head
+        n.left = inner
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n) }
+        if path.len() > 1 {
+            let mut n = emptyAstNode(AstNPattern)
+            n.extra = astPatternVariantKind()
+            n.text = name
+            n.op = FrontIdent
+            n.start = start
+            n.end = p.pos
+            return opAddNode(p, n)
+        }
+        let mut n = emptyAstNode(AstNPattern)
+        n.extra = astPatternIdentKind()
+        n.text = head
+        n.op = FrontIdent
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    opError(p, "expected pattern")
+    opAdvance(p)
+    let mut n = emptyAstNode(AstNPattern)
+    n.extra = astPatternErrorKind()
+    n.start = p.pos
+    opAddNode(p, n)
+}
+
+// ===================================================================
+// TYPE PARSING
+// ===================================================================
+
+fn opParseType(p: OstyParser) -> Int {
+    let mut ty = opParseTypeAtom(p)
+    for opAt(p, FrontQuestion) { let s = p.pos
+    opAdvance(p)
+    let mut n = emptyAstNode(AstNType)
+    n.text = "optional"
+    n.left = ty
+    n.start = s
+    n.end = p.pos
+    ty = opAddNode(p, n) }
+    ty
+}
+
+fn opParseTypeAtom(p: OstyParser) -> Int {
+    let tok = opPeek(p)
+    if tok.kind == FrontFn { return opParseFnType(p) }
+    if tok.kind == FrontLParen { return opParseTupleType(p) }
+    if tok.kind == FrontIdent {
+        let start = p.pos
+        let name = tok.text
+        opAdvance(p)
+        let mut typeArgs: List<Int> = []
+        if opEat(p, FrontLt) {
+            for !(opAt(p, FrontGt)) && !(opAt(p, FrontShr)) && !(opAt(p, FrontGeq)) && !(opAt(p, FrontShrEq)) && !(opAt(p, FrontEOF)) { typeArgs.push(opParseType(p))
+            if !(opEat(p, FrontComma)) { break } }
+            opExpectTypeGT(p)
+        }
+        let mut n = emptyAstNode(AstNType)
+        n.text = name
+        n.children = typeArgs
+        n.start = start
+        n.end = p.pos
+        return opAddNode(p, n)
+    }
+    opErrorFull(p, "expected type", "a type is `Int`, `String`, `List<T>`, `fn(T) -> R`, or `(T, U)`", "", "E0020")
+    opAdvance(p)
+    let mut n = emptyAstNode(AstNType)
+    n.text = "error"
+    n.start = p.pos
+    opAddNode(p, n)
+}
+
+fn opExpectTypeGT(p: OstyParser) {
+    if opAt(p, FrontGt) { opAdvance(p)
+    return }
+    if opAt(p, FrontShr) {
+        let _ = opAdvance(p)
+        p.typeGtDebt = p.typeGtDebt + 1
+        return
+    }
+    if opAt(p, FrontGeq) {
+        let _ = opAdvance(p)
+        p.pendingAssign = true
+        return
+    }
+    if opAt(p, FrontShrEq) {
+        let _ = opAdvance(p)
+        p.typeGtDebt = p.typeGtDebt + 1
+        p.pendingAssign = true
+        return
+    }
+    opExpect(p, FrontGt)
+}
+
+fn opParseFnType(p: OstyParser) -> Int {
+    let start = p.pos
+    opAdvance(p)
+    opExpect(p, FrontLParen)
+    let mut params: List<Int> = []
+    for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { params.push(opParseType(p))
+    if !(opEat(p, FrontComma)) { break } }
+    opExpect(p, FrontRParen)
+    let mut retIdx = -1
+    if opEat(p, FrontArrow) { retIdx = opParseType(p) }
+    let mut n = emptyAstNode(AstNType)
+    n.text = "fn"
+    n.children = params
+    n.right = retIdx
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseTupleType(p: OstyParser) -> Int {
+    let start = p.pos
+    opAdvance(p)
+    let mut elems: List<Int> = []
+    for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { elems.push(opParseType(p))
+    if !(opEat(p, FrontComma)) { break } }
+    opExpect(p, FrontRParen)
+    let mut n = emptyAstNode(AstNType)
+    n.text = "tuple"
+    n.children = elems
+    n.start = start
+    n.end = p.pos
+    opAddNode(p, n)
+}
+
+// ===================================================================
+// ANNOTATION PARSING
+// ===================================================================
+
+fn opParseAnnotations(p: OstyParser) -> List<Int> {
+    let mut anns: List<Int> = []
+    for opAt(p, FrontHash) && opPeekAt(p, 1).kind == FrontLBracket {
+        let start = p.pos
+        let _ = opAdvance(p)
+        let _ = opAdvance(p)
+        let mut annName = ""
+        if opAt(p, FrontIdent) { annName = opAdvance(p).text }
+        let mut annArgs: List<Int> = []
+        if opEat(p, FrontLParen) {
+            for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
+                if opAt(p, FrontIdent) && opPeekAt(p, 1).kind == FrontAssign {
+                    let _ = opAdvance(p)
+                    let _ = opAdvance(p)
+                }
+                annArgs.push(opParseExpr(p))
+                if !(opEat(p, FrontComma)) { break }
+            }
+            let _ = opExpect(p, FrontRParen)
+        }
+        if opAt(p, FrontAssign) {
+            let _ = opAdvance(p)
+            annArgs.push(opParseExpr(p))
+        }
+        let _ = opExpect(p, FrontRBracket)
+        let mut n = emptyAstNode(AstNAnnotation)
+        n.text = annName
+        n.children = annArgs
+        n.start = start
+        n.end = p.pos
+        anns.push(opAddNode(p, n))
+        opSkipNewlines(p)
+    }
+    anns
+}
+
+// ===================================================================
+// DECLARATION PARSING
+// ===================================================================
+
+fn opParseDecl(p: OstyParser) -> Int {
+    opSkipNewlines(p)
+    let anns = opParseAnnotations(p)
+    let mut isPub = false
+    if opEat(p, FrontPub) { isPub = true }
+    let tok = opPeek(p)
+    if tok.kind == FrontFn { return opParseFnDecl(p, isPub, anns) }
+    if tok.kind == FrontStruct { return opParseStructDecl(p, isPub) }
+    if tok.kind == FrontEnum { return opParseEnumDecl(p, isPub) }
+    if tok.kind == FrontInterface { return opParseInterfaceDecl(p, isPub) }
+    if tok.kind == FrontType { return opParseTypeAliasDecl(p, isPub) }
+    if tok.kind == FrontUse { return opParseUseDecl(p) }
+    if tok.kind == FrontLet { return opParseLetStmt(p) }
+    let errKindName = frontTokenKindName(tok.kind)
+    opErrorFull(p, "expected declaration, got {errKindName}", "a declaration starts with `fn`, `struct`, `enum`, `interface`, `type`, `use`, or `let`", "", "E0030")
+    opSyncDecl(p)
+    let mut n = emptyAstNode(AstNError)
+    n.start = p.pos
+    opAddNode(p, n)
+}
+
+fn opParseFnDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
+    let start = p.pos
+    opAdvance(p)
+    let name = opExpect(p, FrontIdent).text
+    let genericParams = opParseGenericParams(p)
+    opExpect(p, FrontLParen)
+    let mut params: List<Int> = []
+    for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) {
+        let ps = p.pos
+        let mut paramNode = emptyAstNode(AstNParam)
+        if opAt(p, FrontMut) { opAdvance(p)
+        paramNode.flags = 1 }
+        if opAt(p, FrontIdent) && opPeek(p).text == "self" { paramNode.text = opAdvance(p).text } else {
+            paramNode.text = opExpect(p, FrontIdent).text
+            if opEat(p, FrontColon) { paramNode.right = opParseType(p) }
+            if opEat(p, FrontAssign) { paramNode.left = opParseExpr(p) }
+        }
+        paramNode.start = ps
+        paramNode.end = p.pos
+        params.push(opAddNode(p, paramNode))
+        if !(opEat(p, FrontComma)) { break }
+        opSkipNewlines(p)
+    }
+    opExpect(p, FrontRParen)
+    let mut retTypeIdx = -1
+    if opEat(p, FrontArrow) { retTypeIdx = opParseType(p) }
+    let mut bodyIdx = -1
+    if opAt(p, FrontLBrace) { bodyIdx = opParseBlock(p) }
+    let mut n = emptyAstNode(AstNFnDecl)
+    n.text = name
+    n.left = retTypeIdx
+    n.right = bodyIdx
+    n.children = params
+    n.children2 = genericParams
+    n.start = start
+    n.end = p.pos
+    if isPub { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseStructDecl(p: OstyParser, isPub: Bool) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let name = opExpect(p, FrontIdent).text
+    let genericParams = opParseGenericParams(p)
+    let _ = opExpect(p, FrontLBrace)
+    let mut members: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        let memberAnns = opParseAnnotations(p)
+        let _ = memberAnns
+        let mut memberPub = false
+        if opEat(p, FrontPub) { memberPub = true }
+        if opAt(p, FrontFn) { members.push(opParseFnDecl(p, memberPub, [])) } else if opAt(p, FrontIdent) {
+            let fs = p.pos
+            let fn_ = opAdvance(p).text
+            let _ = opExpect(p, FrontColon)
+            let ft = opParseType(p)
+            let mut defIdx = -1
+            if opEat(p, FrontAssign) { defIdx = opParseExpr(p) }
+            let mut fNode = emptyAstNode(AstNField_)
+            fNode.text = fn_
+            fNode.right = ft
+            fNode.left = defIdx
+            fNode.start = fs
+            fNode.end = p.pos
+            if memberPub { fNode.flags = 1 }
+            members.push(opAddNode(p, fNode))
+        } else {
+            opError(p, "expected field or method in struct")
+            let _ = opAdvance(p)
+        }
+        opSkipNewlines(p)
+        let _ = opEat(p, FrontComma)
+        opSkipNewlines(p)
+    }
+    let _ = opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNStructDecl)
+    n.text = name
+    n.children = members
+    n.children2 = genericParams
+    n.start = start
+    n.end = p.pos
+    if isPub { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseEnumDecl(p: OstyParser, isPub: Bool) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let name = opExpect(p, FrontIdent).text
+    let genericParams = opParseGenericParams(p)
+    let _ = opExpect(p, FrontLBrace)
+    let mut members: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        if opAt(p, FrontFn) || (opAt(p, FrontPub) && opPeekAt(p, 1).kind == FrontFn) {
+            let fnPub = opEat(p, FrontPub)
+            members.push(opParseFnDecl(p, fnPub, []))
+        } else if opAt(p, FrontIdent) {
+            let vs = p.pos
+            let vn = opAdvance(p).text
+            let mut vFields: List<Int> = []
+            if opEat(p, FrontLParen) {
+                for !(opAt(p, FrontRParen)) && !(opAt(p, FrontEOF)) { vFields.push(opParseType(p))
+                if !(opEat(p, FrontComma)) { break } }
+                let _ = opExpect(p, FrontRParen)
+            }
+            let mut vNode = emptyAstNode(AstNVariant)
+            vNode.text = vn
+            vNode.children = vFields
+            vNode.start = vs
+            vNode.end = p.pos
+            members.push(opAddNode(p, vNode))
+        } else {
+            opError(p, "expected variant or method in enum")
+            let _ = opAdvance(p)
+        }
+        opSkipNewlines(p)
+        let _ = opEat(p, FrontComma)
+        opSkipNewlines(p)
+    }
+    let _ = opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNEnumDecl)
+    n.text = name
+    n.children = members
+    n.children2 = genericParams
+    n.start = start
+    n.end = p.pos
+    if isPub { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseInterfaceDecl(p: OstyParser, isPub: Bool) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let name = opExpect(p, FrontIdent).text
+    let mut supers: List<Int> = []
+    if opEat(p, FrontColon) { for { supers.push(opParseType(p))
+    if !(opEat(p, FrontComma)) && !(opEat(p, FrontPlus)) { break } } }
+    let _ = opExpect(p, FrontLBrace)
+    let mut members: List<Int> = []
+    opSkipNewlines(p)
+    for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+        if opAt(p, FrontFn) || (opAt(p, FrontPub) && opPeekAt(p, 1).kind == FrontFn) {
+            let fnPub = opEat(p, FrontPub)
+            members.push(opParseFnDecl(p, fnPub, []))
+        } else if opAt(p, FrontIdent) {
+            members.push(opParseType(p))
+        } else {
+            opError(p, "expected method or type in interface")
+            let _ = opAdvance(p)
+        }
+        opSkipNewlines(p)
+    }
+    let _ = opExpect(p, FrontRBrace)
+    let mut n = emptyAstNode(AstNInterfaceDecl)
+    n.text = name
+    n.children = members
+    n.children2 = supers
+    n.start = start
+    n.end = p.pos
+    if isPub { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseTypeAliasDecl(p: OstyParser, isPub: Bool) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let name = opExpect(p, FrontIdent).text
+    let genericParams = opParseGenericParams(p)
+    let _ = opExpect(p, FrontAssign)
+    let typeIdx = opParseType(p)
+    let mut n = emptyAstNode(AstNTypeAlias)
+    n.text = name
+    n.left = typeIdx
+    n.children = genericParams
+    n.start = start
+    n.end = p.pos
+    if isPub { n.flags = 1 }
+    opAddNode(p, n)
+}
+
+fn opParseUseDecl(p: OstyParser) -> Int {
+    let start = p.pos
+    let _ = opAdvance(p)
+    let mut path: List<String> = []
+    let mut isGo = false
+    let mut alias = ""
+    if opAt(p, FrontIdent) && opPeek(p).text == "go" {
+        isGo = true
+        let _ = opAdvance(p)
+        if opAt(p, FrontString) || opAt(p, FrontRawString) { path.push(opAdvance(p).text) }
+    } else { for opAt(p, FrontIdent) { path.push(opAdvance(p).text)
+    if !(opEat(p, FrontDot)) { break } } }
+    if opAt(p, FrontIdent) && opPeek(p).text == "as" {
+        let _ = opAdvance(p)
+        alias = opExpect(p, FrontIdent).text
+    }
+    let mut goItems: List<Int> = []
+    if opEat(p, FrontLBrace) {
+        opSkipNewlines(p)
+        for !(opAt(p, FrontRBrace)) && !(opAt(p, FrontEOF)) {
+            if opAt(p, FrontFn) || opAt(p, FrontStruct) || opAt(p, FrontType) {
+                goItems.push(opParseFnDecl(p, false, []))
+            } else {
+                let _ = opAdvance(p)
+            }
+            opSkipNewlines(p)
+        }
+        let _ = opExpect(p, FrontRBrace)
+    }
+    let mut n = emptyAstNode(AstNUseDecl)
+    n.text = strings.Join(path, ".")
+    n.children = goItems
+    n.start = start
+    n.end = p.pos
+    if isGo { n.flags = 1 }
+    if alias != "" { n.op = FrontIdent }
+    opAddNode(p, n)
+}
+
+// ===================================================================
+// FILE PARSING
+// ===================================================================
+
+fn opParseFile(p: OstyParser) {
+    opSkipNewlines(p)
+    for !(opAt(p, FrontEOF)) { let declIdx = opParseDecl(p)
+    p.arena.decls.push(declIdx)
+    opSkipNewlines(p) }
+}
+
+// ===================================================================
+// AST PRETTY PRINTER
+// ===================================================================
+
+pub fn astPrettyPrint(file: AstFile) -> String {
+    let mut lines: List<String> = []
+    for d in file.arena.decls {
+        lines = astPPNode(file.arena, d, 0, lines)
+    }
+    strings.Join(lines, "\n")
+}
+
+fn astPPNode(arena: AstArena, idx: Int, depth: Int, lines: List<String>) -> List<String> {
+    if idx < 0 {
+        return lines
+    }
+    let node = astArenaNodeAt(arena, idx)
+    let indent = strings.Repeat("  ", depth)
+    let kindName = astNodeKindName(node.kind)
+    if node.text != "" { lines.push("{indent}{kindName} \"{node.text}\"") } else { lines.push("{indent}{kindName}") }
+    if node.left >= 0 {
+        lines = astPPNode(arena, node.left, depth + 1, lines)
+    }
+    if node.right >= 0 {
+        lines = astPPNode(arena, node.right, depth + 1, lines)
+    }
+    for child in node.children {
+        lines = astPPNode(arena, child, depth + 1, lines)
+    }
+    for child in node.children2 {
+        lines = astPPNode(arena, child, depth + 1, lines)
+    }
+    lines
+}
+
+pub fn astNodeKindName(kind: AstNodeKind) -> String {
+    match kind {
+        AstNIdent -> "Ident", AstNIntLit -> "IntLit", AstNFloatLit -> "FloatLit", AstNStringLit -> "StringLit",
+        AstNBoolLit -> "BoolLit", AstNCharLit -> "CharLit", AstNByteLit -> "ByteLit", AstNBinary -> "Binary",
+        AstNUnary -> "Unary", AstNCall -> "Call", AstNField -> "Field", AstNIndex -> "Index", AstNRange -> "Range",
+        AstNIf -> "If", AstNMatch -> "Match", AstNClosure -> "Closure", AstNList -> "List", AstNTuple -> "Tuple",
+        AstNMap -> "Map", AstNStructLit -> "StructLit", AstNBlock -> "Block", AstNParen -> "Paren",
+        AstNQuestion -> "Question", AstNTurbofish -> "Turbofish", AstNLet -> "Let", AstNReturn -> "Return",
+        AstNBreak -> "Break", AstNContinue -> "Continue", AstNDefer -> "Defer", AstNFor -> "For",
+        AstNAssign -> "Assign", AstNChanSend -> "ChanSend", AstNExprStmt -> "ExprStmt", AstNFnDecl -> "FnDecl",
+        AstNStructDecl -> "StructDecl", AstNEnumDecl -> "EnumDecl", AstNInterfaceDecl -> "InterfaceDecl",
+        AstNTypeAlias -> "TypeAlias", AstNUseDecl -> "UseDecl", AstNLetDecl -> "LetDecl", AstNFile -> "File",
+        AstNParam -> "Param", AstNField_ -> "Field_", AstNVariant -> "Variant", AstNMatchArm -> "MatchArm",
+        AstNType -> "Type", AstNPattern -> "Pattern", AstNAnnotation -> "Annotation",
+        AstNGenericParam -> "GenericParam", AstNError -> "Error",
+    }
+}
+
+pub fn astFormatErrors(file: AstFile) -> String {
+    let mut lines: List<String> = []
+    for e in file.arena.errors {
+        if e.code != "" { lines.push("error[{e.code}]: {e.message} (at token {e.tokenIndex})") } else { lines.push("error: {e.message} (at token {e.tokenIndex})") }
+        if e.note != "" { lines.push("  = note: {e.note}") }
+        if e.hint != "" { lines.push("  = hint: {e.hint}") }
+    }
+    strings.Join(lines, "\n")
+}
+
+// ===================================================================
+// PUBLIC API
+// ===================================================================
+
+pub struct AstFile { pub arena: AstArena }
+
+pub fn astParse(source: String) -> AstFile {
+    let stream = frontendLexStream(source)
+    let tokens = frontTokensFromSource(source, stream)
+    let mut p = newOstyParser(tokens)
+    opParseFile(p)
+    AstFile { arena: p.arena }
+}
+
+pub fn astParseSummary(source: String) -> FrontParseSummary { let file = astParse(source)
+astCountSummary(file) }
+
+pub fn astFileDeclCount(file: AstFile) -> Int { let mut c = 0
+for d in file.arena.decls { let _ = d
+c = c + 1 }
+c }
+pub fn astFileNodeCount(file: AstFile) -> Int { astArenaNodeCount(file.arena) }
+pub fn astFileErrorCount(file: AstFile) -> Int { let mut c = 0
+for e in file.arena.errors { let _ = e
+c = c + 1 }
+c }
+
+pub fn astFileDeclAt(file: AstFile, idx: Int) -> AstNode {
+    let mut i = 0
+    for d in file.arena.decls { if i == idx { return astArenaNodeAt(file.arena, d) }
+    i = i + 1 }
+    emptyAstNode(AstNError)
+}
+
+pub fn astFileErrorAt(file: AstFile, idx: Int) -> AstParseError {
+    let mut i = 0
+    for e in file.arena.errors { if i == idx { return e }
+    i = i + 1 }
+    AstParseError { message: "", tokenIndex: 0, hint: "", note: "", code: "" }
+}
+
+pub fn astCountNodeKind(file: AstFile, kind: AstNodeKind) -> Int { let mut c = 0
+for n in file.arena.nodes { if n.kind == kind { c = c + 1 } }
+c }
+
+// ===================================================================
+// SUMMARY BRIDGE
+// ===================================================================
+
+pub fn astCountSummary(file: AstFile) -> FrontParseSummary {
+    let mut s = emptyFrontParseSummary()
+    for n in file.arena.nodes {
+        match n.kind {
+            AstNFnDecl -> { s.funcs = s.funcs + 1
+            if n.flags == 1 { s.publicDecls = s.publicDecls + 1 } },
+            AstNStructDecl -> { s.structs = s.structs + 1
+            if n.flags == 1 { s.publicDecls = s.publicDecls + 1 } },
+            AstNEnumDecl -> { s.enums = s.enums + 1
+            if n.flags == 1 { s.publicDecls = s.publicDecls + 1 } },
+            AstNInterfaceDecl -> { s.interfaces = s.interfaces + 1
+            if n.flags == 1 { s.publicDecls = s.publicDecls + 1 } },
+            AstNTypeAlias -> { s.aliases = s.aliases + 1
+            if n.flags == 1 { s.publicDecls = s.publicDecls + 1 } },
+            AstNUseDecl -> { s.uses = s.uses + 1
+            if n.flags == 1 { s.goUses = s.goUses + 1 } },
+            AstNBlock -> { s.blocks = s.blocks + 1 },
+            AstNLet -> { s.lets = s.lets + 1
+            s.statements = s.statements + 1
+            if n.flags == 1 { s.mutableBindings = s.mutableBindings + 1 } },
+            AstNReturn -> { s.returns = s.returns + 1
+            s.statements = s.statements + 1 },
+            AstNBreak -> { s.breaks = s.breaks + 1
+            s.statements = s.statements + 1 },
+            AstNContinue -> { s.continues = s.continues + 1
+            s.statements = s.statements + 1 },
+            AstNFor -> { s.fors = s.fors + 1
+            s.statements = s.statements + 1 },
+            AstNDefer -> { s.defers = s.defers + 1
+            s.statements = s.statements + 1 },
+            AstNIf -> { s.ifs = s.ifs + 1
+            if n.flags == 1 { s.ifLets = s.ifLets + 1 } },
+            AstNMatch -> { s.matches = s.matches + 1 },
+            AstNMatchArm -> { s.matchArms = s.matchArms + 1 },
+            AstNCall -> { s.calls = s.calls + 1 },
+            AstNIndex -> { s.indexes = s.indexes + 1 },
+            AstNField -> { s.selectors = s.selectors + 1 },
+            AstNBinary -> { s.binaryOps = s.binaryOps + 1 },
+            AstNUnary -> { s.unaryOps = s.unaryOps + 1 },
+            AstNAssign -> { s.assignments = s.assignments + 1 },
+            AstNClosure -> { s.closures = s.closures + 1 },
+            AstNTurbofish -> { s.turbofish = s.turbofish + 1 },
+            AstNList -> { s.listLits = s.listLits + 1 },
+            AstNTuple -> { s.tupleLits = s.tupleLits + 1 },
+            AstNMap -> { s.mapLits = s.mapLits + 1 },
+            AstNStructLit -> { s.structLits = s.structLits + 1 },
+            AstNRange -> { s.ranges = s.ranges + 1 },
+            AstNChanSend -> { s.channelSends = s.channelSends + 1 },
+            AstNQuestion -> { s.questionOps = s.questionOps + 1 },
+            AstNParam -> { s.params = s.params + 1 },
+            AstNIntLit -> { s.literals = s.literals + 1 },
+            AstNFloatLit -> { s.literals = s.literals + 1 },
+            AstNStringLit -> { s.literals = s.literals + 1 },
+            AstNBoolLit -> { s.literals = s.literals + 1 },
+            AstNCharLit -> { s.literals = s.literals + 1 },
+            AstNByteLit -> { s.literals = s.literals + 1 },
+            AstNError -> { s.errors = s.errors + 1 },
+            _ -> { let _ = n },
+        }
+    }
+    s.decls = astFileDeclCount(file)
+    s
+}

--- a/internal/format/osty.go
+++ b/internal/format/osty.go
@@ -1,0 +1,46 @@
+package format
+
+import (
+	"bytes"
+
+	"github.com/osty/osty/internal/diag"
+)
+
+// OstySource formats src through the same AST-backed printer as Source.
+//
+// The first token-stream implementation of the "osty" engine deliberately
+// tried to mirror the self-hosting formatter. That kept the implementation
+// small, but it also meant every ambiguous token shape (`{}` as block vs
+// pattern, `<` as generic vs comparison, keyword expressions, prefix ops)
+// needed another heuristic. The highest-quality design is to make the
+// formatter role-aware by construction: parse once, print declarations,
+// statements, expressions, types, and patterns from the AST, and keep comments
+// as trivia.
+//
+// This function is intentionally a thin named entry point over Source so the
+// CLI can still expose --engine=osty while sharing one canonical formatting
+// contract. The pure Osty formatter in examples/selfhost-core is tested
+// separately as a self-hosting exercise; the CLI engine should not diverge
+// from the production AST printer.
+func OstySource(src []byte) ([]byte, []*diag.Diagnostic, error) {
+	return Source(normalizeOstyFormatterInput(src))
+}
+
+func normalizeOstyFormatterInput(src []byte) []byte {
+	src = bytes.TrimPrefix(src, []byte{0xEF, 0xBB, 0xBF})
+	if !bytes.Contains(src, []byte{'\r'}) {
+		return src
+	}
+	out := make([]byte, 0, len(src))
+	for idx := 0; idx < len(src); idx++ {
+		if src[idx] != '\r' {
+			out = append(out, src[idx])
+			continue
+		}
+		if idx+1 < len(src) && src[idx+1] == '\n' {
+			continue
+		}
+		out = append(out, '\n')
+	}
+	return out
+}

--- a/internal/format/osty_test.go
+++ b/internal/format/osty_test.go
@@ -1,0 +1,469 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+func TestOstySourceMatchesCanonicalFixtures(t *testing.T) {
+	for _, name := range fixtureNames(t) {
+		t.Run(name, func(t *testing.T) {
+			src := readFixture(t, name)
+			want, wantDiags, wantErr := Source(normalizeOstyFormatterInput(src))
+			got, gotDiags, gotErr := OstySource(src)
+			if (gotErr != nil) != (wantErr != nil) {
+				t.Fatalf("error mismatch: OstySource=%v Source=%v", gotErr, wantErr)
+			}
+			if len(gotDiags) != len(wantDiags) {
+				t.Fatalf("diagnostic count mismatch: OstySource=%d Source=%d", len(gotDiags), len(wantDiags))
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("output mismatch:\n--- osty ---\n%s--- source ---\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestOstySourceMatchesCanonicalTortureCases(t *testing.T) {
+	cases := map[string]string{
+		"angles": `fn max<T: Ordered + Hashable>(a:T,b:T)->T{if a>b{return a}else{return b}}
+type Handler = fn(List<Int>, Map<String,List<Int>>) -> Result<(), Error?>
+fn load(json:Json,text:String)->Result<Config,Error>{let cfg=json.parse::<Config>(text)? return Ok(cfg)}
+fn splitClose()->Int{let xs:List<Int>=[] let m:Map<Int,List<Int>>=m return 0}
+fn compare(a:Int,b:Int)->Bool{return a < b}
+`,
+		"patterns": `struct User{name:Int}
+fn f(u:User)->Int{let User{name}=u let User{name}:User=u return name}
+fn g(u:User)->Int{if let User{name}=u{return name}else{return 0}}
+fn h(users:List<User>)->Int{for User{name} in users{return name} return 0}
+fn k(xs:List<User>)->List<Int>{return xs.map(|User{name}:User|name)}
+`,
+		"keyword-exprs": `enum Maybe{Some(Int),None}
+fn f(opt:Maybe,ok:Bool)->Int{if let Some(x)=opt{return x}else{return 0} for let Some(y)=opt{return y} return if ok{1}else{2}}
+fn g(opt:Maybe)->Int{return match opt { Some(v) if v > 0 -> v, Some(v) -> v, _ -> 0 }}
+fn h(opt:Maybe)->Int{return if let Some(z)=opt{z}else{0}}
+fn i(opt:Maybe)->Int{if match opt { Some(v) -> v > 0, _ -> false } { return 1 } else { return 0 }}
+`,
+		"operators": `fn f(ok:Bool,x:Int)->Int{return if ok{1}else{2}+x}
+fn g(x:Int)->Int{return match x { 0 -> 1, _ -> 2 } ?? 0}
+fn h(x:Int)->Bool{return Box{value:x}==Box{value:0}}
+fn r(ok:Bool)->Range{return if ok{0}else{1}..10}
+fn lt(ok:Bool,x:Int)->Bool{return if ok{1}else{2}<x}
+fn gt(ok:Bool,x:Int)->Bool{return if ok{1}else{2}>x}
+fn neg(n:Int)->Int{return -n}
+fn not(ok:Bool)->Bool{return !ok}
+fn flip(n:Int)->Int{return ~n}
+fn cmp(a:Int,b:Int)->Bool{return a < -b && a > -b}
+fn loop(done:Bool){for !done{return}}
+fn scrutinee(ok:Bool)->Int{return match !ok { true -> 1, _ -> 0 }}
+fn later(ok:Bool){defer !ok}
+`,
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			want, wantDiags, wantErr := Source([]byte(src))
+			got, gotDiags, gotErr := OstySource([]byte(src))
+			if (gotErr != nil) != (wantErr != nil) {
+				t.Fatalf("error mismatch: OstySource=%v Source=%v", gotErr, wantErr)
+			}
+			if len(gotDiags) != len(wantDiags) {
+				t.Fatalf("diagnostic count mismatch: OstySource=%d Source=%d", len(gotDiags), len(wantDiags))
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("output mismatch:\n--- osty ---\n%s--- source ---\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestOstySourceFormatsFunctionSpacing(t *testing.T) {
+	src := []byte("fn add(a:Int,b:Int)->Int{return a+b}\n")
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("OstySource: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	want := "fn add(a: Int, b: Int) -> Int {\n    return a + b\n}\n"
+	if string(out) != want {
+		t.Fatalf("formatted mismatch:\nwant:\n%s\ngot:\n%s", want, out)
+	}
+}
+
+func TestOstySourceIdempotentForFormattedSubset(t *testing.T) {
+	src := []byte("fn add(a: Int, b: Int) -> Int {\n    return a + b\n}\n")
+	once, _, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("first format: %v", err)
+	}
+	twice, _, err := OstySource(once)
+	if err != nil {
+		t.Fatalf("second format: %v", err)
+	}
+	if !bytes.Equal(once, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", once, twice)
+	}
+}
+
+func TestOstySourceOutputParses(t *testing.T) {
+	out, diags, err := OstySource([]byte("struct Box<T>{value:T}\nfn get<T>(b:Box<T>)->T{return b.value}\n"))
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("unexpected lex diagnostics: %v", diags)
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+}
+
+func TestOstySourceAngleDepthTorture(t *testing.T) {
+	src := []byte(`fn max<T: Ordered + Hashable>(a:T,b:T)->T{if a>b{return a}else{return b}}
+type Handler = fn(List<Int>, Map<String,List<Int>>) -> Result<(), Error?>
+fn load(json:Json,text:String)->Result<Config,Error>{let cfg=json.parse::<Config>(text)? return Ok(cfg)}
+fn splitClose()->Int{let xs:List<Int>=[] let m:Map<Int,List<Int>>=m return 0}
+fn compare(a:Int,b:Int)->Bool{return a < b}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"fn max<T: Ordered + Hashable>(a: T, b: T) -> T {",
+		"type Handler = fn(List<Int>, Map<String, List<Int>>) -> Result<(), Error?>",
+		"let cfg = json.parse::<Config>(text)?",
+		"let xs: List<Int> = []",
+		"let m: Map<Int, List<Int>> = m",
+		"return a < b",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	once := out
+	twice, _, err := OstySource(once)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, once)
+	}
+	if !bytes.Equal(once, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", once, twice)
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+}
+
+func TestOstySourceClosureAndAnnotationDepth(t *testing.T) {
+	src := []byte(`#[deprecated(message = "old")]
+fn f(xs:List<Int>)->List<Int>{return xs.map(|x:Int|x+1).filter(|x|x>1)}
+fn g()->fn(Int)->Int{return || 1}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"#[deprecated(message = \"old\")]",
+		"xs.map(|x: Int| x + 1).filter(|x| x > 1)",
+		"return || 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestOstySourceTypeContextDepth(t *testing.T) {
+	src := []byte(`enum Wire<T>{Packet(Result<List<T>,Error>),Fn(fn(Result<T,Error>,Map<String,List<T>>)->Result<(),Error>)}
+fn tuple()->(Result<Int,Error>,fn(List<Int>,Result<String,Error>)->Map<String,Int>){return make()}
+fn expr(a:Int,b:Int,c:Int,d:Int)->Bool{return call(a, b < c, d > a)}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"Packet(Result<List<T>, Error>)",
+		"Fn(fn(Result<T, Error>, Map<String, List<T>>) -> Result<(), Error>)",
+		"fn tuple() -> (Result<Int, Error>, fn(List<Int>, Result<String, Error>) -> Map<String, Int>)",
+		"return call(a, b < c, d > a)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourceBracePostfixAndEmptyMapDepth(t *testing.T) {
+	src := []byte(`fn f()->String{return User{name:"Ada",meta:{:}}.name}
+fn g()->Int{return makeMap()["answer"]}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"meta: {:}",
+		"}.name",
+		`return makeMap()["answer"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourcePatternBraceDepth(t *testing.T) {
+	src := []byte(`struct User{name:Int}
+fn score(u:User)->Int{return match u { User{name} if name > 0 -> name, User{name} -> name, _ -> 0 }}
+fn names(xs:List<User>)->List<Int>{return xs.map(|User{name}|name)}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"} if name > 0 -> name",
+		"} -> name",
+		"}| name",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourceKeywordExpressionDepth(t *testing.T) {
+	src := []byte(`enum Maybe{Some(Int),None}
+fn f(opt:Maybe,ok:Bool)->Int{if let Some(x)=opt{return x}else{return 0} for let Some(y)=opt{return y} return if ok{1}else{2}}
+fn g(opt:Maybe)->Int{return match opt { Some(v) if v > 0 -> v, Some(v) -> v, _ -> 0 }}
+fn h(opt:Maybe)->Int{return if let Some(z)=opt{z}else{0}}
+fn i(opt:Maybe)->Int{if match opt { Some(v) -> v > 0, _ -> false } { return 1 } else { return 0 }}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"if let Some(x) = opt {",
+		"for let Some(y) = opt {",
+		"return if ok {",
+		"return match opt {",
+		"Some(v) if v > 0 -> v",
+		"return if let Some(z) = opt {",
+		"if match opt {",
+		"} {",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourcePatternContinuationDepth(t *testing.T) {
+	src := []byte(`struct User{name:Int}
+fn f(u:User)->Int{let User{name}=u let User{name}:User=u return name}
+fn g(u:User)->Int{if let User{name}=u{return name}else{return 0}}
+fn h(users:List<User>)->Int{for User{name} in users{return name} return 0}
+fn k(xs:List<User>)->List<Int>{return xs.map(|User{name}:User|name)}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"} = u",
+		"}: User = u",
+		"} in users {",
+		"}: User| name",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourceRightBraceInfixContinuationDepth(t *testing.T) {
+	src := []byte(`fn f(ok:Bool,x:Int)->Int{return if ok{1}else{2}+x}
+fn g(x:Int)->Int{return match x { 0 -> 1, _ -> 2 } ?? 0}
+fn h(x:Int)->Bool{return Box{value:x}==Box{value:0}}
+fn r(ok:Bool)->Range{return if ok{0}else{1}..10}
+fn lt(ok:Bool,x:Int)->Bool{return if ok{1}else{2}<x}
+fn gt(ok:Bool,x:Int)->Bool{return if ok{1}else{2}>x}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"} + x",
+		"} ?? 0",
+		"} == Box",
+		"}..10",
+		"} < x",
+		"} > x",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourcePrefixOperatorDepth(t *testing.T) {
+	src := []byte(`fn neg(n:Int)->Int{return -n}
+fn not(ok:Bool)->Bool{return !ok}
+fn flip(n:Int)->Int{return ~n}
+fn cmp(a:Int,b:Int)->Bool{return a < -b && a > -b}
+fn expr(ok:Bool,x:Int)->Bool{return if ok{1}else{2}< -x}
+fn loop(done:Bool){for !done{return}}
+fn scrutinee(ok:Bool)->Int{return match !ok { true -> 1, _ -> 0 }}
+fn later(ok:Bool){defer !ok}
+`)
+	out, diags, err := OstySource(src)
+	if err != nil {
+		t.Fatalf("format: %v\ndiags=%v", err, diags)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"return -n",
+		"return !ok",
+		"return ~n",
+		"return a < -b && a > -b",
+		"} < -x",
+		"for !done {",
+		"return match !ok {",
+		"defer !ok",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+	if _, parseDiags := parser.ParseDiagnostics(out); len(parseDiags) != 0 {
+		t.Fatalf("formatted output parse diagnostics: %v\n%s", parseDiags, out)
+	}
+	twice, _, err := OstySource(out)
+	if err != nil {
+		t.Fatalf("reformat: %v\n%s", err, out)
+	}
+	if !bytes.Equal(out, twice) {
+		t.Fatalf("not idempotent:\n--- once ---\n%s--- twice ---\n%s", out, twice)
+	}
+}
+
+func TestOstySourcePreservesLeadingLineComment(t *testing.T) {
+	out, _, err := OstySource([]byte("// hello\nfn main(){return}\n"))
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	got := string(out)
+	if !strings.HasPrefix(got, "// hello\nfn main()") {
+		t.Fatalf("leading comment not preserved:\n%s", got)
+	}
+}
+
+func TestOstySourcePreservesLiteralLexemes(t *testing.T) {
+	out, _, err := OstySource([]byte("fn f(){let c='한' let s=\"hi\"}\n"))
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "let c = '한'") {
+		t.Fatalf("char literal lexeme not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "let s = \"hi\"") {
+		t.Fatalf("string literal lexeme not preserved:\n%s", got)
+	}
+}
+
+func TestOstySourceRejectsLexErrors(t *testing.T) {
+	_, diags, err := OstySource([]byte("fn main(){ let s = \"unterminated }\n"))
+	if err == nil {
+		t.Fatalf("expected lexical error")
+	}
+	if len(diags) == 0 {
+		t.Fatalf("expected diagnostics")
+	}
+}
+
+func TestOstySourceRejectsParseErrors(t *testing.T) {
+	_, diags, err := OstySource([]byte("fn f(){let x = }\n"))
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+	if len(diags) == 0 {
+		t.Fatalf("expected diagnostics")
+	}
+}


### PR DESCRIPTION
## Summary
- add an AST-backed pure Osty formatter in selfhost-core
- route the public pure formatter surface through astParse -> AST printer
- add CLI engine selection and regression coverage for formatter depth cases

## Verification
- git diff --check
- go test ./internal/examples -run TestSelfhostCoreExampleTestsExecute -count=1 -v
- go test ./internal/examples ./internal/format ./cmd/osty -count=1
- go test ./... -count=1