### PR TITLE
dogfood: elevate pure Osty IR to semantic HIR

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,9 @@ the compiler evolves.
   and string parsing, ports requirement matching, filters registry
   candidates, classifies diagnostics, validates manifest feature graphs,
   ports a runnable lexer scanner and parser/type-checker seed models,
-  mirrors the selfhost-core example-style tests, runs std.testing tests,
+  lowers both front-end and pure-AST parser output into the Osty-written
+  semantic IR with scope/symbol/type/effect metadata, mirrors the
+  selfhost-core example-style tests, runs std.testing tests,
   calls Go FFI, and uses concurrency primitives.
 - `ffi`: runnable Go FFI example using the Go `strings` package.
 - `concurrency`: runnable example covering channels, `spawn`,
@@ -22,8 +24,9 @@ the compiler evolves.
   lifted out of dogfood so they can grow independently, including the
   runnable lexer scanner, front-end seed models, and broad example-style
   tests for SemVer, registry selection, manifest features, diagnostics,
-  package archive classification, and Osty-written linter, resolver, and
-  checker cores, plus the pure Osty formatter.
+  package archive classification, a pure Osty semantic IR bridge,
+  Osty-written linter, resolver, and checker cores, plus the pure Osty
+  formatter.
 - `stdlib-tour`: front-end checked package that demonstrates Tier 1
   standard-library imports and Result-style error flow.
 - `workspace`: virtual workspace with two member packages and a

--- a/examples/dogfood/ir.osty
+++ b/examples/dogfood/ir.osty
@@ -55,6 +55,36 @@ pub enum IrDiagnosticKind {
     IrDiagLexerError,
 }
 
+pub enum IrSymbolKind {
+    IrSymNone,
+    IrSymPackage,
+    IrSymFunction,
+    IrSymType,
+    IrSymVariant,
+    IrSymField,
+    IrSymParameter,
+    IrSymLocal,
+    IrSymGeneric,
+}
+
+pub enum IrValueKind {
+    IrValueNone,
+    IrValueType,
+    IrValueFunction,
+    IrValuePlace,
+    IrValueRValue,
+    IrValuePattern,
+}
+
+pub enum IrFlowKind {
+    IrFlowFallthrough,
+    IrFlowReturns,
+    IrFlowBreaks,
+    IrFlowContinues,
+    IrFlowDiverges,
+    IrFlowMixed,
+}
+
 pub struct IrNode {
     pub kind: IrNodeKind,
     pub start: Int,
@@ -63,6 +93,12 @@ pub struct IrNode {
     pub flags: Int,
     pub parent: Int,
     pub children: List<Int>,
+    pub scope: Int,
+    pub symbol: Int,
+    pub typeName: String,
+    pub value: IrValueKind,
+    pub flow: IrFlowKind,
+    pub effects: Int,
 }
 
 pub struct IrDiagnostic {
@@ -77,6 +113,36 @@ pub struct IrArena {
     pub nodes: List<IrNode>,
 }
 
+pub struct IrScope {
+    pub id: Int,
+    pub parent: Int,
+    pub owner: Int,
+    pub depth: Int,
+    pub symbols: List<Int>,
+}
+
+pub struct IrSymbol {
+    pub id: Int,
+    pub name: String,
+    pub kind: IrSymbolKind,
+    pub typeName: String,
+    pub scope: Int,
+    pub node: Int,
+    pub parent: Int,
+    pub public: Bool,
+    pub mutable: Bool,
+}
+
+pub struct IrSemantic {
+    pub scopes: List<IrScope>,
+    pub symbols: List<IrSymbol>,
+    pub typedNodes: Int,
+    pub effectfulNodes: Int,
+    pub terminalNodes: Int,
+    pub invalidScopes: Int,
+    pub unresolvedRefs: Int,
+}
+
 pub struct IrModule {
     pub packageName: String,
     pub arena: IrArena,
@@ -84,6 +150,7 @@ pub struct IrModule {
     pub decls: List<Int>,
     pub script: List<Int>,
     pub diagnostics: List<IrDiagnostic>,
+    pub semantic: IrSemantic,
     pub sourceTokens: Int,
     pub coveredTokens: Int,
     pub maxDepth: Int,
@@ -106,6 +173,13 @@ pub struct IrSummary {
     pub types: Int,
     pub diagnostics: Int,
     pub invalidParents: Int,
+    pub scopes: Int,
+    pub symbols: Int,
+    pub typedNodes: Int,
+    pub effectfulNodes: Int,
+    pub terminalNodes: Int,
+    pub invalidScopes: Int,
+    pub unresolvedRefs: Int,
     pub maxDepth: Int,
 }
 
@@ -118,11 +192,29 @@ pub fn emptyIrNode(kind: IrNodeKind) -> IrNode {
         flags: 0,
         parent: -1,
         children: [],
+        scope: -1,
+        symbol: -1,
+        typeName: "",
+        value: IrValueNone,
+        flow: IrFlowFallthrough,
+        effects: 0,
     }
 }
 
 pub fn emptyIrArena() -> IrArena {
     IrArena { nodes: [] }
+}
+
+pub fn emptyIrSemantic() -> IrSemantic {
+    IrSemantic {
+        scopes: [],
+        symbols: [],
+        typedNodes: 0,
+        effectfulNodes: 0,
+        terminalNodes: 0,
+        invalidScopes: 0,
+        unresolvedRefs: 0,
+    }
 }
 
 pub fn emptyIrModule(packageName: String) -> IrModule {
@@ -133,6 +225,7 @@ pub fn emptyIrModule(packageName: String) -> IrModule {
         decls: [],
         script: [],
         diagnostics: [],
+        semantic: emptyIrSemantic(),
         sourceTokens: 0,
         coveredTokens: 0,
         maxDepth: 0,
@@ -157,6 +250,13 @@ pub fn emptyIrSummary() -> IrSummary {
         types: 0,
         diagnostics: 0,
         invalidParents: 0,
+        scopes: 0,
+        symbols: 0,
+        typedNodes: 0,
+        effectfulNodes: 0,
+        terminalNodes: 0,
+        invalidScopes: 0,
+        unresolvedRefs: 0,
         maxDepth: 0,
     }
 }
@@ -188,7 +288,12 @@ pub fn irArenaNodeAt(arena: IrArena, idx: Int) -> IrNode {
 }
 
 pub fn irLowerSource(packageName: String, source: String) -> IrModule {
-    irLowerParseTree(packageName, frontendParseTree(source))
+    let stream = frontendLexStream(source)
+    let tokens = frontTokensFromSource(source, stream)
+    let tree = frontendParseTree(source)
+    let mut module = irLowerParseTree(packageName, tree)
+    irFinalizeSemanticGraph(module, tokens)
+    module
 }
 
 pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
@@ -239,7 +344,441 @@ pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
         )
     }
 
+    let emptyTokens: List<FrontToken> = []
+    irFinalizeSemanticGraph(module, emptyTokens)
     module
+}
+
+pub fn irLowerAstFile(packageName: String, file: AstFile) -> IrModule {
+    let mut module = emptyIrModule(packageName)
+    let mut root = emptyIrNode(IrNodeModule)
+    root.start = 0
+    root.end = astFileNodeCount(file)
+    module.root = irArenaAdd(module.arena, root)
+    module.sourceTokens = astFileNodeCount(file)
+    module.coveredTokens = astFileNodeCount(file)
+
+    for decl in file.arena.decls {
+        let _ = irLowerAstNodeInto(module, file.arena, decl, module.root, 1)
+    }
+    for err in file.arena.errors {
+        module.diagnostics.push(
+            IrDiagnostic {
+                kind: IrDiagUnexpectedToken,
+                start: err.tokenIndex,
+                end: err.tokenIndex + 1,
+                expected: "",
+                found: err.code,
+            },
+        )
+    }
+
+    let emptyTokens: List<FrontToken> = []
+    irFinalizeSemanticGraph(module, emptyTokens)
+    irFinalizeAstSemanticNames(module, file.arena)
+    module
+}
+
+fn irLowerAstNodeInto(
+    module: IrModule,
+    arena: AstArena,
+    astIdx: Int,
+    parent: Int,
+    depth: Int,
+) -> Int {
+    if astIdx < 0 {
+        return -1
+    }
+    let astNode = astArenaNodeAt(arena, astIdx)
+    let mut node = emptyIrNode(irKindFromAst(astNode.kind, depth))
+    node.start = astNode.start
+    node.end = astNode.end
+    node.depth = depth
+    node.flags = astNode.flags
+    node.parent = parent
+
+    let idx = irArenaAdd(module.arena, node)
+    irAttachChild(module.arena, parent, idx)
+    if depth == 1 && irKindIsDecl(node.kind) {
+        module.decls.push(idx)
+    }
+    if depth == 1 && !(irKindIsDecl(node.kind)) && node.kind != IrNodeRecovery {
+        module.script.push(idx)
+    }
+    if depth > module.maxDepth {
+        module.maxDepth = depth
+    }
+
+    irLowerAstChildList(module, arena, idx, depth + 1, astNode.children2)
+    irLowerAstChildList(module, arena, idx, depth + 1, astNode.children)
+    irLowerAstChild(module, arena, idx, depth + 1, astNode.left)
+    irLowerAstChild(module, arena, idx, depth + 1, astNode.right)
+    irLowerAstChild(module, arena, idx, depth + 1, astNode.extra)
+
+    idx
+}
+
+fn irLowerAstChild(module: IrModule, arena: AstArena, parent: Int, depth: Int, child: Int) {
+    if child >= 0 {
+        let _ = irLowerAstNodeInto(module, arena, child, parent, depth)
+    }
+}
+
+fn irLowerAstChildList(
+    module: IrModule,
+    arena: AstArena,
+    parent: Int,
+    depth: Int,
+    children: List<Int>,
+) {
+    for child in children {
+        let _ = irLowerAstNodeInto(module, arena, child, parent, depth)
+    }
+}
+
+fn irFinalizeAstSemanticNames(module: IrModule, arena: AstArena) {
+    let mut idx = 0
+    for symbol in module.semantic.symbols {
+        let node = irArenaNodeAt(module.arena, symbol.node)
+        let name = irAstNameForIrNode(arena, node)
+        if name != "" {
+            let mut updated = symbol
+            updated.name = name
+            module.semantic.symbols[idx] = updated
+        }
+        idx = idx + 1
+    }
+}
+
+fn irAstNameForIrNode(arena: AstArena, node: IrNode) -> String {
+    for astNode in arena.nodes {
+        if astNode.start == node.start && astNode.end == node.end && irKindFromAst(astNode.kind, node.depth) == node.kind {
+            if astNode.text != "" {
+                return astNode.text
+            }
+        }
+    }
+    ""
+}
+
+pub fn irFinalizeSemanticGraph(module: IrModule, tokens: List<FrontToken>) {
+    module.semantic = emptyIrSemantic()
+    let rootScope = irSemanticAddScope(module.semantic, -1, module.root, 0)
+    let total = irArenaNodeCount(module.arena)
+    let mut idx = 0
+    for current in module.arena.nodes {
+        let mut node = current
+        let parentScope = if idx == module.root {
+            rootScope
+        } else if node.parent >= 0 && node.parent < total {
+            irArenaNodeAt(module.arena, node.parent).scope
+        } else {
+            -1
+        }
+        if idx == module.root {
+            node.scope = rootScope
+        } else if irKindCreatesScope(node.kind) {
+            node.scope = irSemanticAddScope(module.semantic, parentScope, idx, node.depth)
+        } else {
+            node.scope = parentScope
+        }
+        node.value = irValueKindForNode(node.kind)
+        node.flow = irFlowKindForNode(node.kind)
+        node.effects = irEffectsForNode(node.kind)
+        node.typeName = irSemanticTypeName(tokens, node)
+
+        let symKind = irSymbolKindForNode(node.kind, node.depth)
+        if symKind != IrSymNone {
+            let symID = irSemanticAddSymbol(
+                module.semantic,
+                IrSymbol {
+                    id: -1,
+                    name: irSemanticName(tokens, node, idx),
+                    kind: symKind,
+                    typeName: node.typeName,
+                    scope: node.scope,
+                    node: idx,
+                    parent: -1,
+                    public: node.flags > 0,
+                    mutable: node.kind == IrNodeLetStmt && node.flags > 0,
+                },
+            )
+            node.symbol = symID
+            irSemanticScopeAddSymbol(module.semantic, node.scope, symID)
+        }
+
+        module.arena.nodes[idx] = node
+        idx = idx + 1
+    }
+    module.semantic.invalidScopes = irInvalidScopeCount(module)
+    module.semantic.unresolvedRefs = irUnresolvedReferenceCount(module)
+    irRefreshSemanticCounters(module)
+}
+
+fn irSemanticAddScope(semantic: IrSemantic, parent: Int, owner: Int, depth: Int) -> Int {
+    let id = irScopeCount(semantic)
+    semantic.scopes.push(IrScope { id, parent, owner, depth, symbols: [] })
+    id
+}
+
+fn irSemanticAddSymbol(semantic: IrSemantic, symbol: IrSymbol) -> Int {
+    let id = irSymbolCount(semantic)
+    let mut s = symbol
+    s.id = id
+    semantic.symbols.push(s)
+    id
+}
+
+fn irSemanticScopeAddSymbol(semantic: IrSemantic, scopeID: Int, symbolID: Int) {
+    let mut idx = 0
+    for scope in semantic.scopes {
+        if scope.id == scopeID {
+            let mut updated = scope
+            updated.symbols.push(symbolID)
+            semantic.scopes[idx] = updated
+            return
+        }
+        idx = idx + 1
+    }
+}
+
+fn irRefreshSemanticCounters(module: IrModule) {
+    let mut typed = 0
+    let mut effectful = 0
+    let mut terminal = 0
+    for node in module.arena.nodes {
+        if node.typeName != "" && node.typeName != "Unknown" {
+            typed = typed + 1
+        }
+        if node.effects != 0 {
+            effectful = effectful + 1
+        }
+        if node.flow != IrFlowFallthrough {
+            terminal = terminal + 1
+        }
+    }
+    module.semantic.typedNodes = typed
+    module.semantic.effectfulNodes = effectful
+    module.semantic.terminalNodes = terminal
+}
+
+pub fn irScopeCount(semantic: IrSemantic) -> Int {
+    let mut count = 0
+    for scope in semantic.scopes {
+        let _ = scope
+        count = count + 1
+    }
+    count
+}
+
+pub fn irSymbolCount(semantic: IrSemantic) -> Int {
+    let mut count = 0
+    for symbol in semantic.symbols {
+        let _ = symbol
+        count = count + 1
+    }
+    count
+}
+
+pub fn irSymbolAt(semantic: IrSemantic, id: Int) -> IrSymbol {
+    for symbol in semantic.symbols {
+        if symbol.id == id {
+            return symbol
+        }
+    }
+    IrSymbol {
+        id: -1,
+        name: "",
+        kind: IrSymNone,
+        typeName: "",
+        scope: -1,
+        node: -1,
+        parent: -1,
+        public: false,
+        mutable: false,
+    }
+}
+
+pub fn irScopeAt(semantic: IrSemantic, id: Int) -> IrScope {
+    for scope in semantic.scopes {
+        if scope.id == id {
+            return scope
+        }
+    }
+    IrScope { id: -1, parent: -1, owner: -1, depth: 0, symbols: [] }
+}
+
+pub fn irSemanticName(tokens: List<FrontToken>, node: IrNode, fallback: Int) -> String {
+    let count = frontTokenListCount(tokens)
+    if count == 0 {
+        return "{irNodeKindName(node.kind)}#{fallback}"
+    }
+    if node.kind == IrNodeUseDecl || node.kind == IrNodeGoUseDecl {
+        let alias = irUseAliasFromTokens(tokens, node.start, node.end)
+        if alias != "" {
+            return alias
+        }
+    }
+    let name = irFirstIdentText(tokens, node.start, node.end)
+    if name != "" {
+        return name
+    }
+    "{irNodeKindName(node.kind)}#{fallback}"
+}
+
+fn irSemanticTypeName(tokens: List<FrontToken>, node: IrNode) -> String {
+    if node.kind == IrNodeType {
+        let name = irFirstIdentText(tokens, node.start, node.end)
+        if name != "" {
+            return name
+        }
+        return "Type"
+    }
+    if node.kind == IrNodeFnDecl {
+        return "fn"
+    }
+    if node.kind == IrNodeStructDecl || node.kind == IrNodeEnumDecl || node.kind == IrNodeInterfaceDecl || node.kind == IrNodeTypeAliasDecl {
+        return "Type"
+    }
+    if node.kind == IrNodeUseDecl || node.kind == IrNodeGoUseDecl {
+        return "Package"
+    }
+    if node.kind == IrNodeReturnStmt || node.kind == IrNodeBreakStmt || node.kind == IrNodeContinueStmt {
+        return "Never"
+    }
+    if node.kind == IrNodeLetStmt || node.kind == IrNodeLetDecl || node.kind == IrNodeParam || node.kind == IrNodeField || node.kind == IrNodeVariant || node.kind == IrNodePattern {
+        return "Unknown"
+    }
+    if irKindIsExpr(node.kind) {
+        return "Unknown"
+    }
+    ""
+}
+
+fn irFirstIdentText(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let count = frontTokenListCount(tokens)
+    let stop = if end < count { end } else { count }
+    let mut idx = start
+    for idx < stop {
+        let tok = frontTokenAtList(tokens, idx)
+        if tok.kind == FrontIdent {
+            return tok.text
+        }
+        idx = idx + 1
+    }
+    ""
+}
+
+fn irUseAliasFromTokens(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let count = frontTokenListCount(tokens)
+    let stop = if end < count { end } else { count }
+    let mut idx = start
+    let mut last = ""
+    let mut afterAs = false
+    for idx < stop {
+        let tok = frontTokenAtList(tokens, idx)
+        if tok.kind == FrontIdent {
+            if afterAs {
+                return tok.text
+            }
+            if tok.text == "as" {
+                afterAs = true
+            } else if tok.text != "go" {
+                last = tok.text
+            }
+        }
+        idx = idx + 1
+    }
+    last
+}
+
+fn irKindCreatesScope(kind: IrNodeKind) -> Bool {
+    kind == IrNodeFnDecl || kind == IrNodeBlock || kind == IrNodeClosureExpr || kind == IrNodeMatchArm
+}
+
+fn irSymbolKindForNode(kind: IrNodeKind, depth: Int) -> IrSymbolKind {
+    if kind == IrNodeUseDecl || kind == IrNodeGoUseDecl {
+        return IrSymPackage
+    }
+    if kind == IrNodeFnDecl {
+        return IrSymFunction
+    }
+    if kind == IrNodeStructDecl || kind == IrNodeEnumDecl || kind == IrNodeInterfaceDecl || kind == IrNodeTypeAliasDecl {
+        return IrSymType
+    }
+    if kind == IrNodeVariant {
+        return IrSymVariant
+    }
+    if kind == IrNodeField {
+        return IrSymField
+    }
+    if kind == IrNodeParam {
+        return IrSymParameter
+    }
+    if kind == IrNodeLetDecl || kind == IrNodeLetStmt {
+        return IrSymLocal
+    }
+    if kind == IrNodeGenericParams {
+        return IrSymGeneric
+    }
+    if depth < 0 {
+        return IrSymNone
+    }
+    IrSymNone
+}
+
+fn irValueKindForNode(kind: IrNodeKind) -> IrValueKind {
+    if kind == IrNodeFnDecl {
+        return IrValueFunction
+    }
+    if kind == IrNodeStructDecl || kind == IrNodeEnumDecl || kind == IrNodeInterfaceDecl || kind == IrNodeTypeAliasDecl || kind == IrNodeType {
+        return IrValueType
+    }
+    if kind == IrNodeLetDecl || kind == IrNodeLetStmt || kind == IrNodeParam || kind == IrNodeField {
+        return IrValuePlace
+    }
+    if kind == IrNodePattern {
+        return IrValuePattern
+    }
+    if irKindIsExpr(kind) {
+        return IrValueRValue
+    }
+    IrValueNone
+}
+
+fn irFlowKindForNode(kind: IrNodeKind) -> IrFlowKind {
+    if kind == IrNodeReturnStmt {
+        return IrFlowReturns
+    }
+    if kind == IrNodeBreakStmt {
+        return IrFlowBreaks
+    }
+    if kind == IrNodeContinueStmt {
+        return IrFlowContinues
+    }
+    if kind == IrNodeError {
+        return IrFlowDiverges
+    }
+    IrFlowFallthrough
+}
+
+fn irEffectsForNode(kind: IrNodeKind) -> Int {
+    if kind == IrNodeCallExpr {
+        return 1
+    }
+    if kind == IrNodeAssignStmt {
+        return 2
+    }
+    if kind == IrNodeChannelSendStmt {
+        return 4
+    }
+    if kind == IrNodeDeferStmt {
+        return 8
+    }
+    if kind == IrNodeQuestionExpr {
+        return 16
+    }
+    0
 }
 
 fn irAttachChild(arena: IrArena, parent: Int, child: Int) {
@@ -277,6 +816,13 @@ pub fn irSummarize(module: IrModule) -> IrSummary {
     summary.diagnostics = irDiagnosticCount(module)
     summary.maxDepth = module.maxDepth
     summary.invalidParents = irInvalidParentCount(module)
+    summary.scopes = irScopeCount(module.semantic)
+    summary.symbols = irSymbolCount(module.semantic)
+    summary.typedNodes = module.semantic.typedNodes
+    summary.effectfulNodes = module.semantic.effectfulNodes
+    summary.terminalNodes = module.semantic.terminalNodes
+    summary.invalidScopes = module.semantic.invalidScopes
+    summary.unresolvedRefs = module.semantic.unresolvedRefs
 
     for node in module.arena.nodes {
         if node.kind == IrNodeFnDecl {
@@ -352,6 +898,60 @@ pub fn irInvalidParentCount(module: IrModule) -> Int {
         idx = idx + 1
     }
     count
+}
+
+pub fn irInvalidScopeCount(module: IrModule) -> Int {
+    let mut count = 0
+    let totalScopes = irScopeCount(module.semantic)
+    let totalNodes = irArenaNodeCount(module.arena)
+    for node in module.arena.nodes {
+        if node.scope < 0 || node.scope >= totalScopes {
+            count = count + 1
+        }
+        if node.symbol >= 0 {
+            let sym = irSymbolAt(module.semantic, node.symbol)
+            if sym.id < 0 || sym.node < 0 || sym.node >= totalNodes {
+                count = count + 1
+            }
+        }
+    }
+    for scope in module.semantic.scopes {
+        if scope.parent >= totalScopes {
+            count = count + 1
+        }
+        if scope.owner >= totalNodes {
+            count = count + 1
+        }
+        for symbolID in scope.symbols {
+            let sym = irSymbolAt(module.semantic, symbolID)
+            if sym.id < 0 || sym.scope != scope.id {
+                count = count + 1
+            }
+        }
+    }
+    for symbol in module.semantic.symbols {
+        if symbol.scope < 0 || symbol.scope >= totalScopes || symbol.node < 0 || symbol.node >= totalNodes {
+            count = count + 1
+        }
+    }
+    count
+}
+
+pub fn irUnresolvedReferenceCount(module: IrModule) -> Int {
+    let mut count = 0
+    let totalSymbols = irSymbolCount(module.semantic)
+    for node in module.arena.nodes {
+        if irKindDeclaresSymbol(node.kind) {
+            let _ = node
+        } else if (node.kind == IrNodeSelectorExpr || node.kind == IrNodeCallExpr || node.kind == IrNodeIndexExpr) && node.symbol >= totalSymbols {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn irKindDeclaresSymbol(kind: IrNodeKind) -> Bool {
+    irSymbolKindForNode(kind, 0) != IrSymNone
 }
 
 pub fn irKindIsDecl(kind: IrNodeKind) -> Bool {
@@ -484,6 +1084,59 @@ pub fn irDiagnosticKindFromFront(kind: FrontParseDiagnosticKind) -> IrDiagnostic
     }
 }
 
+pub fn irKindFromAst(kind: AstNodeKind, depth: Int) -> IrNodeKind {
+    match kind {
+        AstNBinary -> IrNodeBinaryExpr,
+        AstNUnary -> IrNodeUnaryExpr,
+        AstNCall -> IrNodeCallExpr,
+        AstNField -> IrNodeSelectorExpr,
+        AstNIndex -> IrNodeIndexExpr,
+        AstNRange -> IrNodeRangeExpr,
+        AstNIf -> IrNodeIfExpr,
+        AstNMatch -> IrNodeMatchExpr,
+        AstNClosure -> IrNodeClosureExpr,
+        AstNList -> IrNodeListExpr,
+        AstNTuple -> IrNodeTupleExpr,
+        AstNMap -> IrNodeMapExpr,
+        AstNStructLit -> IrNodeStructExpr,
+        AstNBlock -> IrNodeBlock,
+        AstNQuestion -> IrNodeQuestionExpr,
+        AstNTurbofish -> IrNodeTurbofishExpr,
+        AstNLet -> {
+            if depth == 1 {
+                IrNodeLetDecl
+            } else {
+                IrNodeLetStmt
+            }
+        },
+        AstNReturn -> IrNodeReturnStmt,
+        AstNBreak -> IrNodeBreakStmt,
+        AstNContinue -> IrNodeContinueStmt,
+        AstNDefer -> IrNodeDeferStmt,
+        AstNFor -> IrNodeForStmt,
+        AstNAssign -> IrNodeAssignStmt,
+        AstNChanSend -> IrNodeChannelSendStmt,
+        AstNFnDecl -> IrNodeFnDecl,
+        AstNStructDecl -> IrNodeStructDecl,
+        AstNEnumDecl -> IrNodeEnumDecl,
+        AstNInterfaceDecl -> IrNodeInterfaceDecl,
+        AstNTypeAlias -> IrNodeTypeAliasDecl,
+        AstNUseDecl -> IrNodeUseDecl,
+        AstNLetDecl -> IrNodeLetDecl,
+        AstNFile -> IrNodeModule,
+        AstNParam -> IrNodeParam,
+        AstNField_ -> IrNodeField,
+        AstNVariant -> IrNodeVariant,
+        AstNMatchArm -> IrNodeMatchArm,
+        AstNType -> IrNodeType,
+        AstNPattern -> IrNodePattern,
+        AstNAnnotation -> IrNodeAnnotation,
+        AstNGenericParam -> IrNodeGenericParams,
+        AstNError -> IrNodeError,
+        _ -> IrNodeRecovery,
+    }
+}
+
 pub fn irNodeKindName(kind: IrNodeKind) -> String {
     match kind {
         IrNodeModule -> "module",
@@ -542,6 +1195,42 @@ pub fn irDiagnosticKindName(kind: IrDiagnosticKind) -> String {
         IrDiagNonAssociativeOperator -> "nonAssociativeOperator",
         IrDiagTrailingSelector -> "trailingSelector",
         IrDiagLexerError -> "lexerError",
+    }
+}
+
+pub fn irSymbolKindName(kind: IrSymbolKind) -> String {
+    match kind {
+        IrSymNone -> "none",
+        IrSymPackage -> "package",
+        IrSymFunction -> "function",
+        IrSymType -> "type",
+        IrSymVariant -> "variant",
+        IrSymField -> "field",
+        IrSymParameter -> "parameter",
+        IrSymLocal -> "local",
+        IrSymGeneric -> "generic",
+    }
+}
+
+pub fn irValueKindName(kind: IrValueKind) -> String {
+    match kind {
+        IrValueNone -> "none",
+        IrValueType -> "type",
+        IrValueFunction -> "function",
+        IrValuePlace -> "place",
+        IrValueRValue -> "rvalue",
+        IrValuePattern -> "pattern",
+    }
+}
+
+pub fn irFlowKindName(kind: IrFlowKind) -> String {
+    match kind {
+        IrFlowFallthrough -> "fallthrough",
+        IrFlowReturns -> "returns",
+        IrFlowBreaks -> "breaks",
+        IrFlowContinues -> "continues",
+        IrFlowDiverges -> "diverges",
+        IrFlowMixed -> "mixed",
     }
 }
 

--- a/examples/dogfood/ir_test.osty
+++ b/examples/dogfood/ir_test.osty
@@ -64,3 +64,107 @@ fn testIrKindNamesAreStable() {
         "missingName",
     )
 }
+
+fn testIrCarriesSemanticGraph() {
+    let module = irLowerSource(
+        "main",
+        r"""
+            use std.testing
+            pub struct Box<T> { value: T }
+            fn add(left: Int, right: Int) -> Int {
+                let total = left + right
+                return total
+            }
+            """,
+    )
+    let summary = irSummarize(module)
+    let root = irArenaNodeAt(module.arena, module.root)
+
+    testing.assert(root.scope >= 0)
+    testing.assert(summary.scopes >= 2)
+    testing.assert(summary.symbols >= 6)
+    testing.assert(summary.typedNodes >= 3)
+    testing.assert(summary.terminalNodes >= 1)
+    testing.assertEq(summary.invalidScopes, 0)
+    testing.assertEq(summary.unresolvedRefs, 0)
+}
+
+fn testIrSemanticSymbolsUseStableNames() {
+    let module = irLowerSource(
+        "main",
+        r"""
+            use std.testing as t
+            fn add(left: Int) -> Int { left }
+            """,
+    )
+    let mut foundUse = false
+    let mut foundFn = false
+    let mut foundParam = false
+    for symbol in module.semantic.symbols {
+        if symbol.name == "t" && irSymbolKindName(symbol.kind) == "package" {
+            foundUse = true
+        } else if symbol.name == "add" && irSymbolKindName(symbol.kind) == "function" {
+            foundFn = true
+        } else if symbol.name == "left" && irSymbolKindName(symbol.kind) == "parameter" {
+            foundParam = true
+        }
+    }
+
+    testing.assert(foundUse)
+    testing.assert(foundFn)
+    testing.assert(foundParam)
+    testing.assertEq(irInvalidScopeCount(module), 0)
+}
+
+fn testIrLowersPureAstParserIntoIndependentModule() {
+    let source = r"""
+        struct Pair<A, B> { first: A, second: B }
+        enum Maybe<T> { Some(T), None }
+        fn add(left: Int, right: Int) -> Int {
+            let total = left + right
+            return total
+        }
+        """
+    let file = astParse(source)
+    let module = irLowerAstFile("main", file)
+    let summary = irSummarize(module)
+    let root = irArenaNodeAt(module.arena, module.root)
+
+    testing.assertEq(astFileErrorCount(file), 0)
+    testing.assertEq(irNodeKindName(root.kind), "module")
+    testing.assertEq(irChildCount(module, module.root), astFileDeclCount(file))
+    testing.assertEq(summary.decls, 3)
+    testing.assertEq(summary.structs, 1)
+    testing.assertEq(summary.enums, 1)
+    testing.assertEq(summary.funcs, 1)
+    testing.assert(summary.stmts >= 2)
+    testing.assert(summary.exprs >= 1)
+    testing.assert(summary.types >= 4)
+    testing.assertEq(summary.diagnostics, 0)
+    testing.assertEq(summary.invalidParents, 0)
+    testing.assert(summary.scopes >= 2)
+    testing.assert(summary.symbols >= 3)
+    testing.assertEq(summary.invalidScopes, 0)
+
+    let mut foundAdd = false
+    let mut foundPair = false
+    for symbol in module.semantic.symbols {
+        if symbol.name == "add" && irSymbolKindName(symbol.kind) == "function" {
+            foundAdd = true
+        } else if symbol.name == "Pair" && irSymbolKindName(symbol.kind) == "type" {
+            foundPair = true
+        }
+    }
+    testing.assert(foundAdd)
+    testing.assert(foundPair)
+}
+
+fn testIrAstLoweringSurfacesParserDiagnostics() {
+    let file = astParse(r"fn broken() { let x = @ }")
+    let module = irLowerAstFile("main", file)
+    let summary = irSummarize(module)
+
+    testing.assert(astFileErrorCount(file) > 0)
+    testing.assert(summary.diagnostics > 0)
+    testing.assertEq(summary.invalidParents, 0)
+}

--- a/examples/selfhost-core/ir.osty
+++ b/examples/selfhost-core/ir.osty
@@ -55,6 +55,36 @@ pub enum IrDiagnosticKind {
     IrDiagLexerError,
 }
 
+pub enum IrSymbolKind {
+    IrSymNone,
+    IrSymPackage,
+    IrSymFunction,
+    IrSymType,
+    IrSymVariant,
+    IrSymField,
+    IrSymParameter,
+    IrSymLocal,
+    IrSymGeneric,
+}
+
+pub enum IrValueKind {
+    IrValueNone,
+    IrValueType,
+    IrValueFunction,
+    IrValuePlace,
+    IrValueRValue,
+    IrValuePattern,
+}
+
+pub enum IrFlowKind {
+    IrFlowFallthrough,
+    IrFlowReturns,
+    IrFlowBreaks,
+    IrFlowContinues,
+    IrFlowDiverges,
+    IrFlowMixed,
+}
+
 pub struct IrNode {
     pub kind: IrNodeKind,
     pub start: Int,
@@ -63,6 +93,12 @@ pub struct IrNode {
     pub flags: Int,
     pub parent: Int,
     pub children: List<Int>,
+    pub scope: Int,
+    pub symbol: Int,
+    pub typeName: String,
+    pub value: IrValueKind,
+    pub flow: IrFlowKind,
+    pub effects: Int,
 }
 
 pub struct IrDiagnostic {
@@ -77,6 +113,36 @@ pub struct IrArena {
     pub nodes: List<IrNode>,
 }
 
+pub struct IrScope {
+    pub id: Int,
+    pub parent: Int,
+    pub owner: Int,
+    pub depth: Int,
+    pub symbols: List<Int>,
+}
+
+pub struct IrSymbol {
+    pub id: Int,
+    pub name: String,
+    pub kind: IrSymbolKind,
+    pub typeName: String,
+    pub scope: Int,
+    pub node: Int,
+    pub parent: Int,
+    pub public: Bool,
+    pub mutable: Bool,
+}
+
+pub struct IrSemantic {
+    pub scopes: List<IrScope>,
+    pub symbols: List<IrSymbol>,
+    pub typedNodes: Int,
+    pub effectfulNodes: Int,
+    pub terminalNodes: Int,
+    pub invalidScopes: Int,
+    pub unresolvedRefs: Int,
+}
+
 pub struct IrModule {
     pub packageName: String,
     pub arena: IrArena,
@@ -84,6 +150,7 @@ pub struct IrModule {
     pub decls: List<Int>,
     pub script: List<Int>,
     pub diagnostics: List<IrDiagnostic>,
+    pub semantic: IrSemantic,
     pub sourceTokens: Int,
     pub coveredTokens: Int,
     pub maxDepth: Int,
@@ -106,6 +173,13 @@ pub struct IrSummary {
     pub types: Int,
     pub diagnostics: Int,
     pub invalidParents: Int,
+    pub scopes: Int,
+    pub symbols: Int,
+    pub typedNodes: Int,
+    pub effectfulNodes: Int,
+    pub terminalNodes: Int,
+    pub invalidScopes: Int,
+    pub unresolvedRefs: Int,
     pub maxDepth: Int,
 }
 
@@ -118,11 +192,29 @@ pub fn emptyIrNode(kind: IrNodeKind) -> IrNode {
         flags: 0,
         parent: -1,
         children: [],
+        scope: -1,
+        symbol: -1,
+        typeName: "",
+        value: IrValueNone,
+        flow: IrFlowFallthrough,
+        effects: 0,
     }
 }
 
 pub fn emptyIrArena() -> IrArena {
     IrArena { nodes: [] }
+}
+
+pub fn emptyIrSemantic() -> IrSemantic {
+    IrSemantic {
+        scopes: [],
+        symbols: [],
+        typedNodes: 0,
+        effectfulNodes: 0,
+        terminalNodes: 0,
+        invalidScopes: 0,
+        unresolvedRefs: 0,
+    }
 }
 
 pub fn emptyIrModule(packageName: String) -> IrModule {
@@ -133,6 +225,7 @@ pub fn emptyIrModule(packageName: String) -> IrModule {
         decls: [],
         script: [],
         diagnostics: [],
+        semantic: emptyIrSemantic(),
         sourceTokens: 0,
         coveredTokens: 0,
         maxDepth: 0,
@@ -157,6 +250,13 @@ pub fn emptyIrSummary() -> IrSummary {
         types: 0,
         diagnostics: 0,
         invalidParents: 0,
+        scopes: 0,
+        symbols: 0,
+        typedNodes: 0,
+        effectfulNodes: 0,
+        terminalNodes: 0,
+        invalidScopes: 0,
+        unresolvedRefs: 0,
         maxDepth: 0,
     }
 }
@@ -188,7 +288,12 @@ pub fn irArenaNodeAt(arena: IrArena, idx: Int) -> IrNode {
 }
 
 pub fn irLowerSource(packageName: String, source: String) -> IrModule {
-    irLowerParseTree(packageName, frontendParseTree(source))
+    let stream = frontendLexStream(source)
+    let tokens = frontTokensFromSource(source, stream)
+    let tree = frontendParseTree(source)
+    let mut module = irLowerParseTree(packageName, tree)
+    irFinalizeSemanticGraph(module, tokens)
+    module
 }
 
 pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
@@ -239,7 +344,329 @@ pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
         )
     }
 
+    let emptyTokens: List<FrontToken> = []
+    irFinalizeSemanticGraph(module, emptyTokens)
     module
+}
+
+pub fn irFinalizeSemanticGraph(module: IrModule, tokens: List<FrontToken>) {
+    module.semantic = emptyIrSemantic()
+    let rootScope = irSemanticAddScope(module.semantic, -1, module.root, 0)
+    let total = irArenaNodeCount(module.arena)
+    let mut idx = 0
+    for current in module.arena.nodes {
+        let mut node = current
+        let parentScope = if idx == module.root {
+            rootScope
+        } else if node.parent >= 0 && node.parent < total {
+            irArenaNodeAt(module.arena, node.parent).scope
+        } else {
+            -1
+        }
+        if idx == module.root {
+            node.scope = rootScope
+        } else if irKindCreatesScope(node.kind) {
+            node.scope = irSemanticAddScope(module.semantic, parentScope, idx, node.depth)
+        } else {
+            node.scope = parentScope
+        }
+        node.value = irValueKindForNode(node.kind)
+        node.flow = irFlowKindForNode(node.kind)
+        node.effects = irEffectsForNode(node.kind)
+        node.typeName = irSemanticTypeName(tokens, node)
+
+        let symKind = irSymbolKindForNode(node.kind, node.depth)
+        if symKind != IrSymNone {
+            let symID = irSemanticAddSymbol(
+                module.semantic,
+                IrSymbol {
+                    id: -1,
+                    name: irSemanticName(tokens, node, idx),
+                    kind: symKind,
+                    typeName: node.typeName,
+                    scope: node.scope,
+                    node: idx,
+                    parent: -1,
+                    public: node.flags > 0,
+                    mutable: node.kind == IrNodeLetStmt && node.flags > 0,
+                },
+            )
+            node.symbol = symID
+            irSemanticScopeAddSymbol(module.semantic, node.scope, symID)
+        }
+
+        module.arena.nodes[idx] = node
+        idx = idx + 1
+    }
+    module.semantic.invalidScopes = irInvalidScopeCount(module)
+    module.semantic.unresolvedRefs = irUnresolvedReferenceCount(module)
+    irRefreshSemanticCounters(module)
+}
+
+fn irSemanticAddScope(semantic: IrSemantic, parent: Int, owner: Int, depth: Int) -> Int {
+    let id = irScopeCount(semantic)
+    semantic.scopes.push(IrScope { id, parent, owner, depth, symbols: [] })
+    id
+}
+
+fn irSemanticAddSymbol(semantic: IrSemantic, symbol: IrSymbol) -> Int {
+    let id = irSymbolCount(semantic)
+    let mut s = symbol
+    s.id = id
+    semantic.symbols.push(s)
+    id
+}
+
+fn irSemanticScopeAddSymbol(semantic: IrSemantic, scopeID: Int, symbolID: Int) {
+    let mut idx = 0
+    for scope in semantic.scopes {
+        if scope.id == scopeID {
+            let mut updated = scope
+            updated.symbols.push(symbolID)
+            semantic.scopes[idx] = updated
+            return
+        }
+        idx = idx + 1
+    }
+}
+
+fn irRefreshSemanticCounters(module: IrModule) {
+    let mut typed = 0
+    let mut effectful = 0
+    let mut terminal = 0
+    for node in module.arena.nodes {
+        if node.typeName != "" && node.typeName != "Unknown" {
+            typed = typed + 1
+        }
+        if node.effects != 0 {
+            effectful = effectful + 1
+        }
+        if node.flow != IrFlowFallthrough {
+            terminal = terminal + 1
+        }
+    }
+    module.semantic.typedNodes = typed
+    module.semantic.effectfulNodes = effectful
+    module.semantic.terminalNodes = terminal
+}
+
+pub fn irScopeCount(semantic: IrSemantic) -> Int {
+    let mut count = 0
+    for scope in semantic.scopes {
+        let _ = scope
+        count = count + 1
+    }
+    count
+}
+
+pub fn irSymbolCount(semantic: IrSemantic) -> Int {
+    let mut count = 0
+    for symbol in semantic.symbols {
+        let _ = symbol
+        count = count + 1
+    }
+    count
+}
+
+pub fn irSymbolAt(semantic: IrSemantic, id: Int) -> IrSymbol {
+    for symbol in semantic.symbols {
+        if symbol.id == id {
+            return symbol
+        }
+    }
+    IrSymbol {
+        id: -1,
+        name: "",
+        kind: IrSymNone,
+        typeName: "",
+        scope: -1,
+        node: -1,
+        parent: -1,
+        public: false,
+        mutable: false,
+    }
+}
+
+pub fn irScopeAt(semantic: IrSemantic, id: Int) -> IrScope {
+    for scope in semantic.scopes {
+        if scope.id == id {
+            return scope
+        }
+    }
+    IrScope { id: -1, parent: -1, owner: -1, depth: 0, symbols: [] }
+}
+
+pub fn irSemanticName(tokens: List<FrontToken>, node: IrNode, fallback: Int) -> String {
+    let count = frontTokenListCount(tokens)
+    if count == 0 {
+        return "{irNodeKindName(node.kind)}#{fallback}"
+    }
+    if node.kind == IrNodeUseDecl || node.kind == IrNodeGoUseDecl {
+        let alias = irUseAliasFromTokens(tokens, node.start, node.end)
+        if alias != "" {
+            return alias
+        }
+    }
+    let name = irFirstIdentText(tokens, node.start, node.end)
+    if name != "" {
+        return name
+    }
+    "{irNodeKindName(node.kind)}#{fallback}"
+}
+
+fn irSemanticTypeName(tokens: List<FrontToken>, node: IrNode) -> String {
+    if node.kind == IrNodeType {
+        let name = irFirstIdentText(tokens, node.start, node.end)
+        if name != "" {
+            return name
+        }
+        return "Type"
+    }
+    if node.kind == IrNodeFnDecl {
+        return "fn"
+    }
+    if node.kind == IrNodeStructDecl || node.kind == IrNodeEnumDecl || node.kind == IrNodeInterfaceDecl || node.kind == IrNodeTypeAliasDecl {
+        return "Type"
+    }
+    if node.kind == IrNodeUseDecl || node.kind == IrNodeGoUseDecl {
+        return "Package"
+    }
+    if node.kind == IrNodeReturnStmt || node.kind == IrNodeBreakStmt || node.kind == IrNodeContinueStmt {
+        return "Never"
+    }
+    if node.kind == IrNodeLetStmt || node.kind == IrNodeLetDecl || node.kind == IrNodeParam || node.kind == IrNodeField || node.kind == IrNodeVariant || node.kind == IrNodePattern {
+        return "Unknown"
+    }
+    if irKindIsExpr(node.kind) {
+        return "Unknown"
+    }
+    ""
+}
+
+fn irFirstIdentText(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let count = frontTokenListCount(tokens)
+    let stop = if end < count { end } else { count }
+    let mut idx = start
+    for idx < stop {
+        let tok = frontTokenAtList(tokens, idx)
+        if tok.kind == FrontIdent {
+            return tok.text
+        }
+        idx = idx + 1
+    }
+    ""
+}
+
+fn irUseAliasFromTokens(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+    let count = frontTokenListCount(tokens)
+    let stop = if end < count { end } else { count }
+    let mut idx = start
+    let mut last = ""
+    let mut afterAs = false
+    for idx < stop {
+        let tok = frontTokenAtList(tokens, idx)
+        if tok.kind == FrontIdent {
+            if afterAs {
+                return tok.text
+            }
+            if tok.text == "as" {
+                afterAs = true
+            } else if tok.text != "go" {
+                last = tok.text
+            }
+        }
+        idx = idx + 1
+    }
+    last
+}
+
+fn irKindCreatesScope(kind: IrNodeKind) -> Bool {
+    kind == IrNodeFnDecl || kind == IrNodeBlock || kind == IrNodeClosureExpr || kind == IrNodeMatchArm
+}
+
+fn irSymbolKindForNode(kind: IrNodeKind, depth: Int) -> IrSymbolKind {
+    if kind == IrNodeUseDecl || kind == IrNodeGoUseDecl {
+        return IrSymPackage
+    }
+    if kind == IrNodeFnDecl {
+        return IrSymFunction
+    }
+    if kind == IrNodeStructDecl || kind == IrNodeEnumDecl || kind == IrNodeInterfaceDecl || kind == IrNodeTypeAliasDecl {
+        return IrSymType
+    }
+    if kind == IrNodeVariant {
+        return IrSymVariant
+    }
+    if kind == IrNodeField {
+        return IrSymField
+    }
+    if kind == IrNodeParam {
+        return IrSymParameter
+    }
+    if kind == IrNodeLetDecl || kind == IrNodeLetStmt {
+        return IrSymLocal
+    }
+    if kind == IrNodeGenericParams {
+        return IrSymGeneric
+    }
+    if depth < 0 {
+        return IrSymNone
+    }
+    IrSymNone
+}
+
+fn irValueKindForNode(kind: IrNodeKind) -> IrValueKind {
+    if kind == IrNodeFnDecl {
+        return IrValueFunction
+    }
+    if kind == IrNodeStructDecl || kind == IrNodeEnumDecl || kind == IrNodeInterfaceDecl || kind == IrNodeTypeAliasDecl || kind == IrNodeType {
+        return IrValueType
+    }
+    if kind == IrNodeLetDecl || kind == IrNodeLetStmt || kind == IrNodeParam || kind == IrNodeField {
+        return IrValuePlace
+    }
+    if kind == IrNodePattern {
+        return IrValuePattern
+    }
+    if irKindIsExpr(kind) {
+        return IrValueRValue
+    }
+    IrValueNone
+}
+
+fn irFlowKindForNode(kind: IrNodeKind) -> IrFlowKind {
+    if kind == IrNodeReturnStmt {
+        return IrFlowReturns
+    }
+    if kind == IrNodeBreakStmt {
+        return IrFlowBreaks
+    }
+    if kind == IrNodeContinueStmt {
+        return IrFlowContinues
+    }
+    if kind == IrNodeError {
+        return IrFlowDiverges
+    }
+    IrFlowFallthrough
+}
+
+fn irEffectsForNode(kind: IrNodeKind) -> Int {
+    if kind == IrNodeCallExpr {
+        return 1
+    }
+    if kind == IrNodeAssignStmt {
+        return 2
+    }
+    if kind == IrNodeChannelSendStmt {
+        return 4
+    }
+    if kind == IrNodeDeferStmt {
+        return 8
+    }
+    if kind == IrNodeQuestionExpr {
+        return 16
+    }
+    0
 }
 
 fn irAttachChild(arena: IrArena, parent: Int, child: Int) {
@@ -277,6 +704,13 @@ pub fn irSummarize(module: IrModule) -> IrSummary {
     summary.diagnostics = irDiagnosticCount(module)
     summary.maxDepth = module.maxDepth
     summary.invalidParents = irInvalidParentCount(module)
+    summary.scopes = irScopeCount(module.semantic)
+    summary.symbols = irSymbolCount(module.semantic)
+    summary.typedNodes = module.semantic.typedNodes
+    summary.effectfulNodes = module.semantic.effectfulNodes
+    summary.terminalNodes = module.semantic.terminalNodes
+    summary.invalidScopes = module.semantic.invalidScopes
+    summary.unresolvedRefs = module.semantic.unresolvedRefs
 
     for node in module.arena.nodes {
         if node.kind == IrNodeFnDecl {
@@ -352,6 +786,60 @@ pub fn irInvalidParentCount(module: IrModule) -> Int {
         idx = idx + 1
     }
     count
+}
+
+pub fn irInvalidScopeCount(module: IrModule) -> Int {
+    let mut count = 0
+    let totalScopes = irScopeCount(module.semantic)
+    let totalNodes = irArenaNodeCount(module.arena)
+    for node in module.arena.nodes {
+        if node.scope < 0 || node.scope >= totalScopes {
+            count = count + 1
+        }
+        if node.symbol >= 0 {
+            let sym = irSymbolAt(module.semantic, node.symbol)
+            if sym.id < 0 || sym.node < 0 || sym.node >= totalNodes {
+                count = count + 1
+            }
+        }
+    }
+    for scope in module.semantic.scopes {
+        if scope.parent >= totalScopes {
+            count = count + 1
+        }
+        if scope.owner >= totalNodes {
+            count = count + 1
+        }
+        for symbolID in scope.symbols {
+            let sym = irSymbolAt(module.semantic, symbolID)
+            if sym.id < 0 || sym.scope != scope.id {
+                count = count + 1
+            }
+        }
+    }
+    for symbol in module.semantic.symbols {
+        if symbol.scope < 0 || symbol.scope >= totalScopes || symbol.node < 0 || symbol.node >= totalNodes {
+            count = count + 1
+        }
+    }
+    count
+}
+
+pub fn irUnresolvedReferenceCount(module: IrModule) -> Int {
+    let mut count = 0
+    let totalSymbols = irSymbolCount(module.semantic)
+    for node in module.arena.nodes {
+        if irKindDeclaresSymbol(node.kind) {
+            let _ = node
+        } else if (node.kind == IrNodeSelectorExpr || node.kind == IrNodeCallExpr || node.kind == IrNodeIndexExpr) && node.symbol >= totalSymbols {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn irKindDeclaresSymbol(kind: IrNodeKind) -> Bool {
+    irSymbolKindForNode(kind, 0) != IrSymNone
 }
 
 pub fn irKindIsDecl(kind: IrNodeKind) -> Bool {
@@ -542,6 +1030,42 @@ pub fn irDiagnosticKindName(kind: IrDiagnosticKind) -> String {
         IrDiagNonAssociativeOperator -> "nonAssociativeOperator",
         IrDiagTrailingSelector -> "trailingSelector",
         IrDiagLexerError -> "lexerError",
+    }
+}
+
+pub fn irSymbolKindName(kind: IrSymbolKind) -> String {
+    match kind {
+        IrSymNone -> "none",
+        IrSymPackage -> "package",
+        IrSymFunction -> "function",
+        IrSymType -> "type",
+        IrSymVariant -> "variant",
+        IrSymField -> "field",
+        IrSymParameter -> "parameter",
+        IrSymLocal -> "local",
+        IrSymGeneric -> "generic",
+    }
+}
+
+pub fn irValueKindName(kind: IrValueKind) -> String {
+    match kind {
+        IrValueNone -> "none",
+        IrValueType -> "type",
+        IrValueFunction -> "function",
+        IrValuePlace -> "place",
+        IrValueRValue -> "rvalue",
+        IrValuePattern -> "pattern",
+    }
+}
+
+pub fn irFlowKindName(kind: IrFlowKind) -> String {
+    match kind {
+        IrFlowFallthrough -> "fallthrough",
+        IrFlowReturns -> "returns",
+        IrFlowBreaks -> "breaks",
+        IrFlowContinues -> "continues",
+        IrFlowDiverges -> "diverges",
+        IrFlowMixed -> "mixed",
     }
 }
 

--- a/examples/selfhost-core/ir_test.osty
+++ b/examples/selfhost-core/ir_test.osty
@@ -64,3 +64,55 @@ fn testIrKindNamesAreStable() {
         "missingName",
     )
 }
+
+fn testIrCarriesSemanticGraph() {
+    let module = irLowerSource(
+        "main",
+        r"""
+            use std.testing
+            pub struct Box<T> { value: T }
+            fn add(left: Int, right: Int) -> Int {
+                let total = left + right
+                return total
+            }
+            """,
+    )
+    let summary = irSummarize(module)
+    let root = irArenaNodeAt(module.arena, module.root)
+
+    testing.assert(root.scope >= 0)
+    testing.assert(summary.scopes >= 2)
+    testing.assert(summary.symbols >= 6)
+    testing.assert(summary.typedNodes >= 3)
+    testing.assert(summary.effectfulNodes == 0)
+    testing.assert(summary.terminalNodes >= 1)
+    testing.assertEq(summary.invalidScopes, 0)
+    testing.assertEq(summary.unresolvedRefs, 0)
+}
+
+fn testIrSemanticSymbolsUseStableNames() {
+    let module = irLowerSource(
+        "main",
+        r"""
+            use std.testing as t
+            fn add(left: Int) -> Int { left }
+            """,
+    )
+    let mut foundUse = false
+    let mut foundFn = false
+    let mut foundParam = false
+    for symbol in module.semantic.symbols {
+        if symbol.name == "t" && irSymbolKindName(symbol.kind) == "package" {
+            foundUse = true
+        } else if symbol.name == "add" && irSymbolKindName(symbol.kind) == "function" {
+            foundFn = true
+        } else if symbol.name == "left" && irSymbolKindName(symbol.kind) == "parameter" {
+            foundParam = true
+        }
+    }
+
+    testing.assert(foundUse)
+    testing.assert(foundFn)
+    testing.assert(foundParam)
+    testing.assertEq(irInvalidScopeCount(module), 0)
+}

--- a/examples/selfhost-core/osty.toml
+++ b/examples/selfhost-core/osty.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "0.3"
 description = "Self-hosting core algorithms ported to Osty."
 license = "MIT"
-keywords = ["selfhost", "semver", "registry", "manifest", "diagnostics", "lint", "resolve", "check"]
+keywords = ["selfhost", "semver", "registry", "manifest", "diagnostics", "ir", "lint", "resolve", "check"]
 
 [dependencies]

--- a/examples/selfhost-core/pipeline.osty
+++ b/examples/selfhost-core/pipeline.osty
@@ -1,0 +1,72 @@
+pub struct SelfhostPipelineReport {
+    pub tokens: Int,
+    pub parseNodes: Int,
+    pub parseDiagnostics: Int,
+    pub irNodes: Int,
+    pub irDecls: Int,
+    pub irFuncs: Int,
+    pub irStmts: Int,
+    pub irExprs: Int,
+    pub irDiagnostics: Int,
+    pub irInvalidParents: Int,
+    pub irScopes: Int,
+    pub irSymbols: Int,
+    pub irTypedNodes: Int,
+    pub irEffectfulNodes: Int,
+    pub irTerminalNodes: Int,
+    pub irInvalidScopes: Int,
+    pub resolveSymbols: Int,
+    pub resolveDiagnostics: Int,
+    pub checkDiagnostics: Int,
+    pub checkedExpressions: Int,
+    pub lintDiagnostics: Int,
+    pub lintParseErrors: Int,
+}
+
+pub fn selfhostPipelineSource(packageName: String, source: String) -> SelfhostPipelineReport {
+    let stream = frontendLexStream(source)
+    let tree = frontendParseTree(source)
+    let module = irLowerSource(packageName, source)
+    let ir = irSummarize(module)
+    let resolved = selfResolveSource(source)
+    let checked = selfCheckSource(source)
+    let linted = selfLintSource(source)
+
+    SelfhostPipelineReport {
+        tokens: frontLexTokenCount(stream),
+        parseNodes: frontParseTreeNodeCount(tree),
+        parseDiagnostics: frontParseTreeDiagnosticCount(tree),
+        irNodes: ir.nodes,
+        irDecls: ir.decls,
+        irFuncs: ir.funcs,
+        irStmts: ir.stmts,
+        irExprs: ir.exprs,
+        irDiagnostics: ir.diagnostics,
+        irInvalidParents: ir.invalidParents,
+        irScopes: ir.scopes,
+        irSymbols: ir.symbols,
+        irTypedNodes: ir.typedNodes,
+        irEffectfulNodes: ir.effectfulNodes,
+        irTerminalNodes: ir.terminalNodes,
+        irInvalidScopes: ir.invalidScopes,
+        resolveSymbols: selfhostPipelineSymbolCount(resolved),
+        resolveDiagnostics: selfResolveDiagnosticCount(resolved),
+        checkDiagnostics: selfCheckDiagnosticCount(checked),
+        checkedExpressions: checked.checkedExpressions,
+        lintDiagnostics: selfLintDiagnosticCount(linted),
+        lintParseErrors: linted.parseErrors,
+    }
+}
+
+pub fn selfhostPipelineBlockingErrorCount(report: SelfhostPipelineReport) -> Int {
+    report.parseDiagnostics + report.irDiagnostics + report.irInvalidParents + report.irInvalidScopes + report.resolveDiagnostics + report.checkDiagnostics + report.lintParseErrors
+}
+
+fn selfhostPipelineSymbolCount(result: SelfResolveResult) -> Int {
+    let mut count = 0
+    for symbol in result.symbols {
+        let _ = symbol
+        count = count + 1
+    }
+    count
+}

--- a/examples/selfhost-core/selfhost_test.osty
+++ b/examples/selfhost-core/selfhost_test.osty
@@ -151,3 +151,41 @@ fn testSelfhostExampleFrontEndPipelineScenario() {
     testing.assert(frontParseTreeNodeNameCount(tree, "param") >= 2)
     testing.assert(frontParseTreeNodeNameCount(tree, "return") >= 1)
 }
+
+fn testSelfhostExamplePipelineWiresIrWithAnalyzerCores() {
+    let source = r"""
+        pub struct User { pub name: String }
+        enum Color { Red, Green }
+
+        fn add(left: Int, right: Int) -> Int {
+            let total = left + right
+            total
+        }
+        """
+    let report = selfhostPipelineSource("main", source)
+
+    testing.assert(report.tokens > 0)
+    testing.assert(report.parseNodes > 0)
+    testing.assert(report.irNodes >= report.parseNodes)
+    testing.assertEq(report.irDecls, 3)
+    testing.assertEq(report.irFuncs, 1)
+    testing.assert(report.irStmts >= 1)
+    testing.assert(report.irExprs >= 1)
+    testing.assert(report.irScopes >= 2)
+    testing.assert(report.irSymbols >= 5)
+    testing.assert(report.irTypedNodes >= 3)
+    testing.assert(report.irTerminalNodes == 0)
+    testing.assertEq(report.irInvalidScopes, 0)
+    testing.assert(report.resolveSymbols >= 5)
+    testing.assert(report.checkedExpressions >= 1)
+    testing.assertEq(report.lintDiagnostics, 0)
+    testing.assertEq(selfhostPipelineBlockingErrorCount(report), 0)
+}
+
+fn testSelfhostExamplePipelineCarriesRecoveryIntoIr() {
+    let report = selfhostPipelineSource("main", r"fn broken( {")
+
+    testing.assert(report.parseDiagnostics > 0)
+    testing.assert(report.irDiagnostics > 0)
+    testing.assert(report.lintParseErrors > 0)
+}


### PR DESCRIPTION
## Summary
- add semantic scope/symbol/type/value/flow/effect metadata to the pure Osty IR
- wire selfhost-core through a semantic IR pipeline report
- connect dogfood pure AST lowering to semantic IR names and invariants

## Tests
- go test ./internal/examples -run 'Test(Dogfood|SelfhostCore)ExampleTestsExecute|TestExampleManifestsValidate' -v
- go test ./...
