### PR TITLE
Add GC runtime foundation example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,9 @@ the compiler evolves.
   mirrors the selfhost-core example-style tests, runs std.testing tests,
   calls Go FFI, and uses concurrency primitives.
 - `ffi`: runnable Go FFI example using the Go `strings` package.
+- `gc`: independent garbage-collector core written in Osty, covering
+  generational collection, remembered-set barriers, incremental marking,
+  cycle reclamation, compaction, pinning, and allocation telemetry.
 - `concurrency`: runnable example covering channels, `spawn`,
   `parallel`, and `taskGroup`.
 - `selfhost-core`: standalone package for the self-hosting algorithms

--- a/examples/gc/DESIGN.md
+++ b/examples/gc/DESIGN.md
@@ -1,0 +1,1261 @@
+# Osty Independent GC Design
+
+이 문서는 `examples/gc` 패키지의 설계 기준이다. 목표는 Osty 언어로
+작성된 독립 GC 코어를 만드는 것이다. 현재 Go transpiler 위에서 실행되지만,
+구조는 미래의 native Osty 런타임이 그대로 가져갈 수 있는 형태를 지향한다.
+
+## 큰 그림
+
+Osty의 언어 스펙은 "GC가 있다"는 observable contract만 고정한다. 어떤 알고리즘을
+쓰는지, 언제 멈추는지, 어떤 tuning knob을 제공하는지는 implementation detail이다.
+따라서 이 설계의 핵심은 "지금 당장 Go 위에서 도는 예제"가 아니라, 나중에 Osty
+native runtime이 가져야 할 책임 경계를 먼저 세우는 것이다.
+
+GC runtime은 크게 네 가지 계약을 제공해야 한다.
+
+1. Allocation contract: 객체를 만들고, 실패하면 명확한 failure path를 제공한다.
+2. Reachability contract: stack, global, closure, thread-local root에서 닿는 객체는 살아남는다.
+3. Movement contract: compaction으로 객체 위치가 바뀌어도 language-level reference는 깨지지 않는다.
+4. Scheduling contract: collector가 언제, 얼마나, 어떤 pause budget으로 실행되는지 runtime이 제어한다.
+
+현재 `examples/gc` 구현은 이 네 계약을 직접 OS 메모리로 수행하지 않고, Osty data
+structure로 시뮬레이션한다. 하지만 API와 invariant는 실제 runtime으로 이동 가능한
+형태로 둔다. 다시 말해 `Map<Int, GcObject>`는 미래의 arena/page allocator로,
+`refs: List<Int>`는 compiler-generated pointer map으로, `roots: Set<Int>`는 stack
+map과 global table로 바뀔 수 있다.
+
+## 설계 철학
+
+- Correctness first: leak보다 worse인 use-after-free, lost root, missed barrier를 먼저 막는다.
+- Explicit metadata: 처음에는 metadata를 객체 안에 명확히 둔다. 나중에 성능을 위해 side table로 뺄 수 있다.
+- Stable handle boundary: public API는 object ID를 본다. 내부 address는 움직일 수 있다.
+- Barriers are visible: write barrier는 `link`에 숨어 있지만 개념적으로 public mutation path의 일부다.
+- Deterministic tests: 현재 구현은 object ID 순서 compaction처럼 재현 가능한 동작을 선호한다.
+- Telemetry by default: collector는 "무엇을 회수했는가"뿐 아니라 "왜 실행됐고 얼마나 이동했는가"를 말해야 한다.
+- Runtime migration path: 모든 자료구조는 나중에 더 낮은 수준의 allocator, card table, stack map으로 대체 가능해야 한다.
+
+## 최종 목표 아키텍처
+
+처음부터 목표를 높게 잡는다. 최종 GC는 단순 mark-sweep이 아니라,
+**precise, generational, regional, mostly-concurrent, incremental, compacting
+collector**를 목표로 한다.
+
+구체적으로는 다음 성질을 갖는다.
+
+- Precise: stack, object field, closure capture, collection storage에서 pointer slot을 정확히 안다.
+- Generational: young object는 nursery에서 빠르게 할당하고 minor collection으로 자주 수집한다.
+- Regional: heap을 fixed-size region들로 나눠 evacuation, compaction, large object, pinned object 정책을 분리한다.
+- Mostly-concurrent: root snapshot과 짧은 final synchronization만 stop-the-world로 두고 mark/evacuation work는 가능한 한 mutator와 병행한다.
+- Incremental: pause budget을 넘기지 않도록 mark, remap, sweep work를 작은 step으로 나눈다.
+- Compacting: fragmentation을 방치하지 않고 region evacuation으로 live object를 모은다.
+- Moving-safe: object movement 후에도 language-level reference와 `std.ref.same` identity가 유지된다.
+- Barrier-backed: compiler가 모든 heap mutation에 barrier를 삽입해 collector invariant를 유지한다.
+- Profile-aware: latency-first, throughput-first, memory-tight profile이 collector policy를 바꿀 수 있다.
+
+현재 `examples/gc` 구현은 이 최종 아키텍처의 작은 executable model이다. 즉,
+prototype이 목표를 결정하는 것이 아니라 목표 아키텍처가 prototype의 모양을
+결정한다.
+
+## 되돌리기 어려운 결정
+
+나중에 판갈이를 피하려면 초기에 다음 결정을 고정해야 한다.
+
+### 1. Conservative GC는 쓰지 않는다
+
+Osty는 statically typed language다. 따라서 GC는 precise 해야 한다. Conservative
+stack scan은 처음에는 쉬워 보여도 moving compaction, pointer compression, FFI
+pinning, `std.ref.same` semantics와 계속 충돌한다.
+
+결정:
+
+- Compiler는 safepoint별 stack map을 생성한다.
+- Type descriptor는 object layout의 pointer map을 제공한다.
+- Unknown word를 pointer처럼 취급하는 fallback은 production path에 넣지 않는다.
+
+### 2. Object identity와 physical address를 분리한다
+
+Moving collector를 제대로 하려면 "같은 객체인가"와 "지금 어디에 있는가"를 분리해야 한다.
+
+결정:
+
+- Language-level identity는 object header identity 또는 stable object ID로 정의한다.
+- Physical address는 evacuation/compaction 중 바뀔 수 있다.
+- `std.ref.same(a, b)`는 physical address 비교가 아니라 logical identity 비교다.
+
+현재 prototype은 stable `id`와 movable `address`로 이 결정을 모델링한다.
+
+### 3. Heap은 처음부터 region 기반으로 간다
+
+단일 contiguous heap은 구현은 쉽지만, compaction과 large/pinned object 정책이
+커질수록 발목을 잡는다.
+
+결정:
+
+- Heap은 region들의 집합이다.
+- Region은 young, survivor, old, humongous, pinned, free 상태를 가진다.
+- Collection은 whole-heap sweep보다 region selection과 evacuation을 중심으로 설계한다.
+- Fragmentation은 object-level metric뿐 아니라 region-level metric으로 추적한다.
+
+### 4. Allocation fast path는 thread-local이다
+
+멀티스레드 runtime을 나중에 붙일 생각이라면 allocation fast path가 global lock에
+의존하면 안 된다.
+
+결정:
+
+- 각 thread/task worker는 TLAB(thread-local allocation buffer)을 가진다.
+- TLAB refill이 allocation slow path이며 GC trigger와 연결된다.
+- Large object와 pinned object는 TLAB을 우회한다.
+
+### 5. Barrier ABI를 compiler-runtime 계약으로 고정한다
+
+Write barrier를 나중에 "필요한 곳에 적당히 추가"하면 반드시 빠지는 경로가 생긴다.
+
+결정:
+
+- 모든 heap pointer store는 compiler lowering 단계에서 barrier ABI를 호출한다.
+- Field store, array/list store, map insert/update, closure environment update,
+  runtime frame update가 모두 barrier 대상이다.
+- Barrier ABI는 collector algorithm이 바뀌어도 compiler surface를 크게 바꾸지 않도록
+  안정적인 함수/inline hook 형태로 둔다.
+
+### 6. Safepoint와 stack map은 IR 단계에서 설계한다
+
+GC는 backend 뒷단에서만 붙일 수 없다. 어떤 local이 live pointer인지 알려면 IR이
+그 정보를 보존해야 한다.
+
+결정:
+
+- IR는 safepoint 후보를 명시한다.
+- 각 safepoint는 live pointer slot metadata를 가진다.
+- Optimizer가 local을 제거하거나 이동해도 stack map이 같이 갱신되어야 한다.
+
+## 목표
+
+- Osty 코드만으로 관리 힙과 객체 그래프를 모델링한다.
+- reference cycle을 반드시 회수한다.
+- nursery와 tenured generation을 분리해 짧게 사는 객체를 싸게 수집한다.
+- old-to-young reference를 remembered set으로 추적한다.
+- incremental tri-color mark를 제공하고 write barrier로 black-to-white 누락을 막는다.
+- major collection 후 compaction으로 hole을 줄인다.
+- pinned object를 지원해 FFI, IO buffer, stack map 등 움직이면 안 되는 객체를 표현한다.
+- OOM은 `Result` API로 안전하게 보고하고, 편의 API는 `unwrap` 기반으로 단순하게 둔다.
+- 모든 collection은 telemetry를 남겨 테스트와 튜닝이 가능해야 한다.
+
+## 비목표
+
+- 실제 OS 메모리 allocator를 대체하지 않는다.
+- Go runtime GC를 끄거나 우회하지 않는다.
+- thread-safe concurrent collector까지 구현하지 않는다.
+- finalizer, weak reference, destructor는 제공하지 않는다. Osty v0.4 memory spec과 맞춘다.
+
+## Production Runtime Shape
+
+이 섹션은 최종 runtime이 가져야 할 구체적인 내부 모양이다. 현재 prototype은 이 모양을
+단순화해서 Osty data structure로 표현한다.
+
+### Object Header
+
+모든 heap object는 header를 가진다.
+
+필수 field:
+
+- type descriptor pointer
+- logical identity 또는 identity hash seed
+- size class 또는 object size
+- mark state
+- generation / age bits
+- forwarding state
+- pinned bit
+- remembered/card dirty hint
+
+Header는 작아야 한다. 자주 읽는 bit는 header에 두고, 드문 metadata는 side table로
+분리한다. 예를 들어 profiling allocation site, debug owner, extended pin reason은
+side table이 더 적합하다.
+
+### Type Descriptor
+
+Type descriptor는 GC가 object body를 scan하는 방법을 알려준다.
+
+필수 정보:
+
+- object kind
+- total size 또는 dynamic size function
+- pointer bitmap 또는 pointer offset list
+- array element trace descriptor
+- enum variant payload descriptor
+- finalizer 없음
+- optional debug type name
+
+Generic type은 monomorphized layout이면 descriptor도 concrete하게 만든다. Erased
+generic layout이면 descriptor가 runtime type argument descriptor를 가진다.
+
+### Region Table
+
+Heap은 region table을 가진다.
+
+Region metadata:
+
+- base address
+- size
+- used bytes
+- live bytes after last mark
+- region kind: free, eden, survivor, old, humongous, pinned
+- remembered/card bitmap
+- evacuation candidate score
+- allocation epoch
+
+Region 설계의 장점:
+
+- Minor collection은 eden/survivor region만 대상으로 삼을 수 있다.
+- Old compaction은 fragmentation이 높은 region만 고를 수 있다.
+- Pinned object가 있는 region은 evacuation에서 제외하거나 부분 evacuation 정책을 쓸 수 있다.
+- Large object는 humongous region으로 분리해 copying cost를 피할 수 있다.
+
+### Reference Representation
+
+최종 runtime은 두 representation 중 하나를 선택해야 한다.
+
+1. Direct pointer + forwarding/load barrier
+2. Compressed handle/object ID + handle table
+
+초기 production target은 direct pointer를 기본으로 둔다. 이유는 일반 object access의
+비용을 낮추기 위해서다. 다만 prototype은 stable `Int` ID를 사용한다. 이 차이를
+흡수하기 위해 public design은 "identity와 address 분리"를 고정하고, concrete
+representation은 backend 결정으로 둔다.
+
+Direct pointer 방식을 택하면 moving 중 다음 중 하나가 필요하다.
+
+- Stop-the-world evacuation 후 모든 root/object slot을 갱신한다.
+- Concurrent evacuation을 위해 load/read barrier를 둔다.
+
+초기 native runtime은 stop-the-world evacuation으로 시작하고, 최종 목표는 selected
+old-region concurrent evacuation까지 열어둔다.
+
+### Collection Pipeline
+
+최종 major cycle은 다음 pipeline을 가진다.
+
+1. Initial safepoint: thread roots를 안정화한다.
+2. Root snapshot: stack/global/thread-local/FFI roots를 수집한다.
+3. Concurrent or incremental mark: grey work queue를 처리한다.
+4. Remark safepoint: barrier buffer와 dirty cards를 drain한다.
+5. Region selection: evacuation candidate를 고른다.
+6. Evacuation/relocation: selected region의 live object를 새 region으로 옮긴다.
+7. Remap: roots와 object fields를 forwarding destination으로 갱신한다.
+8. Reclaim: empty/free region을 free list로 돌린다.
+9. Telemetry publish: stats와 pause profile을 기록한다.
+
+Minor cycle은 더 짧다.
+
+1. Eden allocation pressure trigger
+2. Root and remembered/card scan
+3. Young mark/copy
+4. Survivor aging or promotion
+5. Eden reset
+
+### Barrier Set
+
+최종 collector는 barrier set을 명시적으로 가진다.
+
+- Pre-write barrier: SATB 정책을 선택할 때 old value를 mark queue에 보존한다.
+- Post-write barrier: generational remembered/card dirtying을 수행한다.
+- Load/read barrier: concurrent relocation을 선택할 때 forwarding을 따라간다.
+- Allocation barrier: newly allocated object의 color/generation을 현재 phase에 맞춘다.
+
+현재 prototype은 `link` 안에 post-write barrier와 insertion barrier를 넣었다. 고급
+runtime에서는 barrier set을 collector policy별로 교체 가능한 ABI로 만든다.
+
+### Threading Model
+
+최종 runtime은 mutator thread와 collector worker를 분리할 수 있어야 한다.
+
+- Mutator thread는 TLAB에서 allocate한다.
+- Collector worker는 mark queue와 evacuation work queue를 처리한다.
+- Safepoint coordinator는 thread를 짧게 멈춰 root snapshot과 remark를 수행한다.
+- Barrier buffers는 per-thread로 두고 remark에서 flush한다.
+
+처음 native backend는 single-threaded stop-the-world로 시작할 수 있지만, API는
+multi-threaded collector로 확장 가능한 형태여야 한다.
+
+### Policy Layer
+
+Mechanism과 policy를 분리한다.
+
+Mechanism:
+
+- mark
+- sweep
+- evacuate
+- remap
+- remembered/card scan
+- root scan
+
+Policy:
+
+- 언제 minor를 실행할지
+- 어떤 old region을 compact할지
+- promotion threshold를 얼마로 둘지
+- incremental budget을 얼마로 둘지
+- pinned/humongous region을 언제 회수할지
+
+이 분리는 중요하다. Mechanism이 깨지면 correctness bug지만, policy는 profile과
+workload에 따라 바뀔 수 있다.
+
+## Phase 1-4 Foundation Decisions
+
+Phase 1-4는 구현 편의를 위한 TODO가 아니라, 나중에 전체 runtime을 갈아엎지 않기
+위한 foundation이다. 이 구간에서 결정하는 내용은 compiler IR, generated code,
+runtime ABI, profiler output까지 번진다.
+
+### Phase 1 Detail: GC RFC 고정
+
+Phase 1의 산출물은 "Osty GC는 어떤 계열의 collector인가"를 한 문장으로 말할 수
+있게 만드는 것이다.
+
+고정할 collector family:
+
+- precise, not conservative
+- moving-capable, not address-stable-only
+- generational, with nursery as the default allocation target
+- regional, with collection and evacuation candidate selection at region granularity
+- incremental by construction
+- mostly-concurrent as a target, even if the first backend is stop-the-world
+- barrier-backed, with compiler lowering participating in GC correctness
+
+명시적으로 금지되는 후퇴:
+
+- "일단 conservative stack scan으로 시작하자"
+- "object address를 identity로 영구 고정하자"
+- "single contiguous heap으로 충분할 때까지 버티자"
+- "write barrier는 나중에 필요한 store에만 붙이자"
+- "safepoint metadata는 backend가 알아서 복원하자"
+
+Phase 1 완료 조건:
+
+- GC family가 문서에 명확히 고정되어 있다.
+- language-visible behavior와 runtime implementation detail의 경계가 적혀 있다.
+- compiler, runtime, stdlib, tooling owner가 각자의 책임을 분리할 수 있다.
+- prototype이 최종 설계를 제한하지 않고, 최종 설계가 prototype을 설명한다.
+
+### Phase 2 Detail: Object Header 설계
+
+Object header는 모든 heap object의 최소 공통 ABI다. 너무 가볍게 잡으면 나중에
+moving collection, profiling, pinning, type-directed scan을 붙일 때 계속 깨진다.
+
+초기 logical header는 두 machine word 이상을 전제로 한다.
+
+```text
+word 0: type descriptor pointer
+word 1: packed metadata
+```
+
+`word 1`의 logical fields:
+
+- mark epoch or mark color
+- generation bits
+- age bits
+- pinned bit
+- remembered/card hint bit
+- forwarding state bit
+- size class or small object size
+- identity hash state
+
+큰 객체나 debug/profile metadata는 header에 직접 넣지 않는다. 다음 정보는 side
+table 후보로 둔다.
+
+- allocation site
+- extended object size
+- pin reason
+- owner thread/region debug info
+- profiling counters
+- forwarding target for evacuation
+
+Forwarding 정책:
+
+- 초기 backend는 forwarding side table을 기본으로 한다.
+- Header에는 forwarding state bit만 둔다.
+- Evacuation 중 forwarding target은 region-local forwarding table에서 찾는다.
+- 미래 concurrent relocation에서는 load barrier가 forwarding target을 따라간다.
+
+이 선택은 type descriptor pointer를 header에서 안정적으로 유지한다. 객체 body를
+forwarding pointer로 덮어쓰는 방식은 간단하지만, descriptor-based scan과 debug
+tooling을 복잡하게 만든다.
+
+Phase 2 완료 조건:
+
+- Header가 scan, mark, pin, generation, forwarding 여부를 표현한다.
+- Side table로 빠질 metadata와 header에 남을 metadata가 구분되어 있다.
+- Header layout이 object kind와 무관하게 공통 ABI로 쓸 수 있다.
+- Prototype의 `GcObject` field들이 native header/side table 중 어디로 갈지 매핑되어 있다.
+
+Prototype mapping:
+
+- `kind` -> type descriptor
+- `size` -> size class or side table exact size
+- `address` -> region base + object offset
+- `generation`, `age`, `color`, `marked`, `pinned`, `large` -> packed metadata
+- `region` -> region table membership cache
+- `remembered` -> card/remembered hint
+- `allocatedCycle` -> debug/profiling side table
+
+### Phase 3 Detail: Type Descriptor 설계
+
+Type descriptor는 precise GC의 중심이다. Collector는 source-level type checker가 아니라
+runtime layout만 본다. 따라서 descriptor는 "어디가 pointer slot인가"를 빠르게 말해야 한다.
+
+Descriptor 공통 field:
+
+- runtime kind: record, enum, tuple, closure, array, bytes, string, runtime frame
+- object size or dynamic size function
+- pointer map encoding
+- optional element descriptor
+- optional enum variant table
+- optional closure environment table
+- debug type name
+
+Pointer map encoding 기본 정책:
+
+- 작은 고정 크기 object는 inline bitmap을 쓴다.
+- 큰 고정 크기 object는 pointer offset list를 쓴다.
+- Array/list는 element descriptor와 length로 scan한다.
+- Pointer-free object는 `noPointers` fast path를 가진다.
+- Closure는 capture slot descriptor를 가진다.
+- Enum은 active variant tag로 payload descriptor를 고른다.
+
+Generic policy:
+
+- Monomorphized generic layout은 concrete descriptor를 생성한다.
+- Erased layout이 필요한 경우 descriptor가 runtime type argument descriptor를 보유한다.
+- `List<T>`, `Map<K, V>`, `Set<T>`는 element/key/value pointer-bearing 여부를 descriptor에 반영한다.
+
+Descriptor가 책임지지 않는 것:
+
+- liveness: stack map/safepoint가 책임진다.
+- ownership: language type system이 책임진다.
+- cleanup: Osty는 finalizer가 없으므로 descriptor가 destructor를 들지 않는다.
+
+Phase 3 완료 조건:
+
+- 모든 heap-allocated Osty value category가 descriptor를 가진다.
+- Pointer-bearing 여부를 runtime이 source AST 없이 판단할 수 있다.
+- Descriptor만으로 object scan loop를 작성할 수 있다.
+- Descriptor format이 monomorphized generics와 runtime-erased generics를 모두 설명한다.
+
+Prototype mapping:
+
+- `ObjectKind` -> descriptor runtime kind
+- `refs: List<Int>` -> descriptor-guided pointer slots
+- `GcBytes` -> `noPointers`
+- `GcClosure` -> closure capture descriptor
+- `GcRuntimeFrame` -> stack/runtime frame descriptor
+
+### Phase 4 Detail: Region Heap 설계
+
+Region heap은 처음에는 무거워 보여도, moving/compacting collector를 고급으로 가져가려면
+초기부터 맞는 선택이다. Region은 allocation, collection, evacuation, telemetry의
+공통 단위다.
+
+Region 종류:
+
+- `free`: allocation 가능
+- `eden`: fresh young allocation
+- `survivor`: minor collection에서 살아남은 young object
+- `old`: promoted or long-lived object
+- `humongous`: region 하나 이상을 차지하는 large object
+- `pinned`: moving 불가 object가 있어 evacuation에서 제외되는 region
+
+Region metadata:
+
+- base address
+- region size
+- used bytes
+- live bytes after mark
+- remembered/card bitmap
+- object start bitmap or line table
+- evacuation candidate score
+- allocation epoch
+- owner thread or shared state
+
+Region state transitions:
+
+```text
+free -> eden -> survivor -> old
+free -> humongous -> free
+free -> pinned -> old/free
+old -> evacuation-source -> free
+old -> old
+```
+
+Collection policy hooks:
+
+- Minor GC scans eden/survivor plus remembered cards from old.
+- Major GC marks all regions but evacuates only selected candidates.
+- Humongous regions are reclaimed when unreachable but usually not copied.
+- Pinned regions are either skipped or partially compacted around pinned objects.
+
+Phase 4 완료 조건:
+
+- Heap 전체를 한 덩어리로 보는 code path가 core design에 남아 있지 않다.
+- Minor, major, compaction, humongous, pinned policy가 region metadata로 설명된다.
+- Fragmentation metric이 object-level이 아니라 region-level로도 정의된다.
+- Prototype의 logical address model이 region base + offset model로 확장 가능하다.
+
+Prototype mapping:
+
+- `address` -> synthetic region offset
+- `fragmentedBytes()` -> future region fragmentation metric의 object-level approximation
+- `pinned` -> pinned object or pinned region policy seed
+- `large` -> humongous object policy seed
+- `region` -> eden/survivor/old/humongous/pinned membership
+- `generation` -> eden/survivor/old region membership
+
+## Phase 9 Compiler Contract Decisions
+
+Phase 9의 핵심은 "collector가 멈출 수 있는 지점"과 "그 지점에서 live pointer가
+어디 있는지"를 IR에서 잃지 않는 것이다. 이 정보가 사라지면 나중에 backend가 아무리
+좋아도 precise moving GC를 만들 수 없다.
+
+Safepoint kind:
+
+- `call`: Osty function call, runtime call, FFI wrapper call
+- `allocation`: allocation slow path, TLAB refill, heap-limit check
+- `loopBackedge`: 긴 loop에서 incremental GC work를 나눠 실행할 수 있는 지점
+- `asyncYield`: task suspension, await/yield, scheduler handoff
+
+Safepoint metadata:
+
+- stable safepoint id
+- source IR node id
+- backend instruction offset 또는 pseudo offset
+- `mayCollect`: collector work가 실행될 수 있는지
+- `mayAllocate`: allocation slow path나 allocating call인지
+- `maySuspend`: async frame으로 보존될 수 있는지
+- `requiresStackMap`: live pointer root map이 반드시 필요한지
+- `liveRoots`: 해당 safepoint에서 live인 pointer slot 목록
+
+Live root slot metadata:
+
+- frame/register/spill slot index
+- slot kind: local, temporary, register, spill, closure, derived
+- debug name
+- nullable 여부
+- derived root인 경우 base root slot
+
+Derived root는 slice data pointer, interior array pointer, field address처럼 object 내부를
+가리키는 값이다. Moving GC에서는 derived pointer만으로 object를 remap할 수 없으므로,
+base object root가 같은 safepoint에서 live여야 한다.
+
+Validator rules:
+
+- Safepoint id는 function 안에서 unique해야 한다.
+- 모든 safepoint는 `mayCollect=true`이고 `requiresStackMap=true`여야 한다.
+- Allocation safepoint는 `mayAllocate=true`여야 한다.
+- Async yield safepoint는 `maySuspend=true`여야 한다.
+- Root slot index는 frame slot 범위 안에 있어야 한다.
+- 한 safepoint 안에서 같은 root slot이 두 번 나오면 안 된다.
+- Derived root는 자기 자신이 아닌 live base root를 가져야 한다.
+
+Phase 10은 이 contract를 실제 bitmap/stack-map binary format으로 낮추는 단계다.
+Phase 9는 format을 고정하지 않고, IR과 optimizer가 보존해야 할 semantic contract만
+고정한다.
+
+Prototype mapping:
+
+- `GcSafepointKind` -> IR safepoint classification
+- `GcLiveRootSlot` -> future stack-map live pointer entry
+- `GcSafepoint` -> function-local safepoint record
+- `GcSafepointPlan` -> backend가 stack map을 만들기 전 semantic input
+- `validateSafepointPlan()` -> lowering/optimizer contract checker
+
+## Phase 10 Stack Map Format Decisions
+
+Phase 10은 Phase 9 contract를 실제 runtime이 빠르게 읽을 수 있는 stack-map shape로
+낮춘다. 아직 platform ABI나 binary section format을 확정하지는 않지만, backend가
+반드시 만들 수 있어야 하는 정보와 validator rule은 실행 가능한 모델로 고정한다.
+
+Frame layout entry:
+
+- frame slot index
+- frame slot kind: local, temporary, register spill, closure capture, tuple field, defer,
+  question, return
+- debug name
+- byte offset
+- pointer 여부
+- derived slot인 경우 base slot
+- defer, `?`, early return path에서 보존되어야 하는지
+
+Stack map entry:
+
+- safepoint id
+- instruction offset
+- live pointer count
+- inline bitmap slot count
+- bitmap words
+- overflow pointer slot list
+- derived-root to base-root map
+
+Encoding policy:
+
+- 작은 frame과 hot slot은 bitmap으로 인코딩한다.
+- bitmap이 덮지 않는 큰 slot 번호는 overflow slot list로 둔다.
+- derived root는 bitmap/list에 live pointer로 표시하면서 별도 base mapping도 가진다.
+- pointer-free frame slot은 stack map에 live root로 등장할 수 없다.
+- frame slot kind와 root slot kind가 맞지 않으면 stack map build를 거부한다.
+
+Control-flow preservation:
+
+- `defer` path에서 필요한 root는 defer-running safepoint마다 live여야 한다.
+- `?` early-exit path에서 필요한 root는 question-exit safepoint마다 live여야 한다.
+- explicit early return path에서 필요한 root는 return safepoint마다 live여야 한다.
+
+Prototype mapping:
+
+- `GcFrameSlot` -> backend frame-layout table entry
+- `GcStackMapEntry` -> per-safepoint encoded pointer map
+- `bitmapWords` -> inline pointer bitmap
+- `overflowSlots` -> large/sparse frame fallback list
+- `GcDerivedRootMap` -> derived pointer remapping input
+- `buildGcStackMap()` -> semantic stack map builder/validator
+
+## 현재 구현된 범위
+
+현재 패키지는 다음을 구현한다.
+
+- `GcHeap`: 독립 heap instance
+- `GcObject`: object metadata와 outgoing reference list
+- `tryAllocate` / `allocate`: allocation pressure에 따라 minor, major collection을 시도
+- `largeObjectThreshold`: nursery를 우회하는 humongous allocation policy seed
+- `addRoot` / `removeRoot`: explicit root management
+- `link` / `unlink`: object graph mutation과 write barrier
+- `minorCollect`: nursery-only tracing collection
+- `majorCollect`: full tracing collection과 cycle reclamation
+- `startIncrementalMajor` / `stepIncremental` / `finishIncremental`: incremental major marking
+- `compactLive`: stable ID 기반 logical compaction
+- `pin` / `unpin`: compaction exclusion과 pinned region metadata
+- `regionOf` / `isLarge`: object의 region/humongous 상태 introspection
+- `validateHeap`: debug-time invariant checker
+- `GcStats`: trigger, allocation debt, logical pause units, fragmentation, survival telemetry
+- `lastCollectionStats`: pressure-triggered collection telemetry lookup
+- deterministic graph stress tests: seed 기반 graph mutation과 reference reachability 비교
+- `GcSafepointPlan`: IR safepoint와 live pointer root contract model
+- `validateSafepointPlan`: backend stack map 입력의 semantic validator
+- `GcFrameSlot`: backend frame layout model
+- `GcStackMap`: bitmap + overflow-list stack-map prototype
+- `buildGcStackMap`: stack map builder와 frame/root preservation validator
+
+현재 구현은 "runtime algorithm prototype"이다. 아직 실제 compiler-emitted stack map,
+real allocator, host FFI pointer pinning, thread safepoint와 연결되어 있지는 않다.
+
+## Architecture Layers
+
+### Layer 1: Object Model
+
+Object layer는 "무엇이 heap object인가"를 정의한다. 현재는 `ObjectKind`로 record,
+array, closure, bytes, runtime frame을 구분한다.
+
+실제 runtime에서는 kind별로 trace strategy가 달라진다.
+
+- Record: compiler가 field pointer bitmap을 제공한다.
+- Array: element type이 pointer-bearing인지에 따라 scan 여부가 달라진다.
+- Closure: captured environment slots를 scan한다.
+- Bytes: pointer-free object이므로 scan하지 않는다.
+- Runtime frame: stack root snapshot이나 coroutine frame을 나타낸다.
+
+현재 `refs: List<Int>`는 모든 pointer-bearing field를 한곳에 모은 단순 모델이다.
+native runtime에서는 object header와 type descriptor가 이 역할을 나눠 가진다.
+
+### Layer 2: Allocation
+
+Allocation layer는 nursery allocation fast path와 slow path를 나눈다.
+
+- Fast path: nursery에 충분한 공간이 있으면 bump allocation한다.
+- Slow path: nursery pressure가 넘으면 minor collection을 실행한다.
+- Full slow path: heap limit까지 넘으면 major collection을 실행한다.
+- Large object path: threshold 이상 object는 nursery를 우회해 humongous region에 둔다.
+- Failure path: collection 이후에도 공간이 부족하면 OOM으로 실패한다.
+
+Incremental marking 중에는 nested minor collection을 실행하지 않는다. Young mark
+state와 major mark state가 같은 prototype metadata를 공유하기 때문이다. 실제 runtime은
+phase별 mark bitmap을 분리하거나 safepoint에서 incremental cycle을 끝낸 뒤 nursery
+collection을 실행해야 한다.
+
+현재는 `nextAddress`와 `liveBytes`로 logical allocation만 한다. 다음 단계에서는
+size class, page, arena, large object space를 도입해야 한다. Phase 7 prototype은
+`largeObjectThreshold`와 `GcHumongousRegion`으로 이 정책의 API/invariant를 먼저
+고정한다.
+
+### Layer 3: Root Discovery
+
+Root discovery는 collector의 정확성을 좌우한다. 현재는 `addRoot`로 explicit root를
+넣는다. 실제 runtime은 다음 root source를 자동으로 제공해야 한다.
+
+- active stack frames
+- suspended async frames
+- globals and constants containing references
+- closure environments
+- thread-local runtime state
+- FFI handles and pinned host objects
+
+정확한 GC를 하려면 compiler가 safepoint마다 stack map을 내보내야 한다. Stack slot이
+integer인지 pointer인지 모르면 conservative GC가 되며, compaction과 충돌한다.
+Phase 9 prototype은 `GcSafepointPlan`으로 이 contract를 executable model로 고정한다.
+
+### Layer 4: Barriers
+
+Barrier layer는 mutator가 heap graph를 바꿀 때 collector invariant를 유지한다.
+
+현재 `link`는 두 barrier를 수행한다.
+
+- Generational barrier: tenured object가 nursery object를 가리키면 remembered set에 넣는다.
+- Incremental barrier: marking 중 black object가 white object를 새로 가리키면 child를 shade한다.
+
+실제 runtime에서는 모든 field store, array store, closure capture update, map entry
+write가 barrier를 호출해야 한다. Compiler lowering에서 store instruction이 barrier
+hook을 빠뜨리면 collector correctness가 깨진다.
+
+### Layer 5: Collection Algorithms
+
+Collection layer는 minor, major, incremental phase를 제공한다.
+
+- Minor: young generation만 trace한다.
+- Major: full heap을 trace하고 unreachable cycle을 회수한다.
+- Incremental: mark work를 작은 step으로 나눠 pause를 줄인다.
+- Compact: fragmentation을 줄이고 cache locality를 높인다.
+
+현재 compaction은 logical address만 바꾼다. 실제 moving collector에서는 모든 root와
+object field를 forwarding pointer를 통해 갱신해야 한다.
+
+### Layer 6: Scheduler Integration
+
+Scheduler integration은 collection work를 언제 실행할지 결정한다.
+
+- Allocation pressure가 limit을 넘으면 collector를 깨운다.
+- Safepoint에서 incremental step을 실행한다.
+- Latency-sensitive profile에서는 작은 budget을 자주 쓴다.
+- Batch profile에서는 더 큰 major collection을 허용한다.
+
+현재 `stepIncremental`은 caller가 직접 호출한다. native runtime에서는 function prologue,
+loop backedge, allocation slow path, async yield 같은 safepoint와 연결해야 한다.
+Phase 9에서는 이 safepoint 종류를 `call`, `allocation`, `loopBackedge`, `asyncYield`로
+분류하고, 각 지점이 live root metadata를 반드시 보존하도록 한다.
+
+### Layer 7: Observability
+
+Observability layer는 GC가 runtime black box가 되지 않도록 한다.
+
+현재 `GcStats`는 다음 정보를 제공한다.
+
+- collection kind and cycle
+- trigger reason
+- object count before and after
+- bytes before and after
+- reclaimed objects and bytes
+- promoted objects
+- compacted objects
+- remembered set scan count
+- mark step count
+- logical pause units
+- allocation bytes since the previous completed collection
+- fragmentation before and after
+- heap survival and promotion percentages
+
+추가로 필요한 정보는 wall-clock pause time, mutator utilization, allocation rate,
+card dirtying rate, pinned bytes, large object bytes다.
+
+## 핵심 모델
+
+### Object ID와 address
+
+객체는 외부에 `Int` ID로 노출된다. ID는 안정적이다. Compaction은 객체의
+논리 address만 바꾸고 ID는 바꾸지 않는다.
+
+이 선택은 세 가지 장점이 있다.
+
+- 외부 handle이 compaction 때문에 무효화되지 않는다.
+- 테스트가 안정적인 ID를 기준으로 객체 생존 여부를 확인할 수 있다.
+- 미래 backend에서는 ID를 handle table index, address를 실제 heap pointer로 치환할 수 있다.
+
+### 객체 메타데이터
+
+`GcObject`는 다음 정보를 가진다.
+
+- `id`: 안정적인 object handle
+- `kind`: record, array, closure, bytes, runtime frame
+- `size`: allocator accounting에 쓰는 logical byte size
+- `address`: compaction 대상 logical address
+- `generation`: `0`은 nursery, `1`은 tenured
+- `age`: minor collection 생존 횟수
+- `color`: tri-color mark state
+- `marked`: sweep fast path용 mark bit
+- `pinned`: compaction 금지
+- `large`: nursery 우회와 humongous region 배치 여부
+- `region`: eden, survivor, old, humongous, pinned 중 현재 membership
+- `refs`: outgoing object references
+- `remembered`: old-to-young edge 보유 여부
+- `allocatedCycle`: allocation이 일어난 collection cycle
+
+### Heap 상태
+
+`GcHeap`은 다음 상태를 소유한다.
+
+- `objects: Map<Int, GcObject>`
+- `roots: Set<Int>`
+- `remembered: Set<Int>`
+- `grey: List<Int>`
+- `phase: TracePhase`
+- `liveBytes`, `nextId`, `nextAddress`
+- collection counters and config
+
+이 구조는 전역 상태 없이 heap instance를 여러 개 만들 수 있게 한다. 테스트나
+미래 isolate runtime에서 중요하다.
+
+## Public API
+
+### Construction
+
+```osty
+let mut heap = newGcHeap(productionGcConfig())
+```
+
+`productionGcConfig`는 보수적인 기본값이고, `testGcConfig`는 작은 limit와
+작은 incremental budget으로 edge case를 쉽게 만든다.
+
+### Allocation
+
+```osty
+let id = heap.allocate(GcRecord, 64)
+let maybe = heap.tryAllocate(GcArray, 1024)
+```
+
+`tryAllocate`가 기본 primitive다. 필요하면 minor collection, major collection을
+순서대로 시도한 뒤에도 limit을 넘으면 `Err(String)`을 반환한다.
+
+`allocate`는 편의 API다. `tryAllocate(...).unwrap()`과 같은 정책이다.
+
+### Roots
+
+```osty
+heap.addRoot(id)
+heap.removeRoot(id)
+```
+
+Root는 collector의 시작점이다. Incremental marking 중 새 root가 추가되면
+즉시 shade되어 snapshot invariant를 유지한다.
+
+### Edges
+
+```osty
+heap.link(parent, child)
+heap.unlink(parent, child)
+```
+
+`link`는 두 barrier를 수행한다.
+
+- Generational barrier: old object가 young object를 가리키면 parent를 remembered set에 넣는다.
+- Incremental barrier: marking 중 black object가 white object를 새로 가리키면 child를 grey로 shade한다.
+
+`unlink`는 edge를 제거한 뒤 remembered set을 재구성한다. 구현은 단순하지만
+정확성을 우선한다.
+
+### Collection
+
+```osty
+let minor = heap.minorCollect()
+let major = heap.majorCollect()
+
+heap.startIncrementalMajor()
+let step = heap.stepIncremental()
+let done = heap.finishIncremental()
+```
+
+모든 collection은 `GcStats`를 반환한다.
+
+## Algorithms
+
+### Minor collection
+
+Minor collection은 nursery만 대상으로 한다.
+
+1. Young object mark state를 초기화한다.
+2. Young root를 grey로 shade한다.
+3. Old root와 remembered old object의 young children을 shade한다.
+4. Grey queue를 young-only로 drain한다.
+5. Unmarked young object를 sweep한다.
+6. Surviving young object는 age를 올리고, threshold에 도달하면 tenured로 promote한다.
+7. Remembered set을 재구성한다.
+
+이 방식은 old generation 전체를 trace하지 않으면서 old-to-young reference의
+정확성을 보존한다.
+
+### Major collection
+
+Major collection은 전체 힙을 대상으로 한다.
+
+1. 모든 object mark state를 초기화한다.
+2. Root set에서 tri-color mark를 시작한다.
+3. Grey queue가 빌 때까지 full graph를 trace한다.
+4. Unmarked object를 sweep한다. Cycle도 여기서 회수된다.
+5. Live object를 tenured로 정규화한다.
+6. Movable object를 compact한다. Pinned/humongous object는 address를 유지한다.
+7. Remembered set을 재구성한다.
+
+Cycle collection은 별도 refcount cycle detector가 아니라 tracing으로 해결한다.
+Root에서 닿지 않는 strongly connected component는 mark되지 않으므로 sweep된다.
+
+### Incremental marking
+
+Incremental major collection은 major mark phase를 step 단위로 나눈다.
+
+1. `startIncrementalMajor`가 모든 mark state를 초기화하고 roots를 shade한다.
+2. `stepIncremental`은 `incrementalBudget`만큼 grey object를 blacken한다.
+3. Grey queue가 남아 있으면 phase는 `GcMarking`으로 유지된다.
+4. Grey queue가 비면 sweep, compact, remembered rebuild를 수행하고 `GcIdle`로 돌아간다.
+
+Write barrier는 Dijkstra-style insertion barrier다. Marking 중 black object가
+white object를 새로 참조하면 child를 grey로 바꾼다. 따라서 black object가
+white object를 숨기는 상황이 생기지 않는다.
+
+Allocation slow path는 incremental marking 중 nested minor collection을 만들지 않는다.
+이 제약은 Phase 8 stress에서 고정됐다. Mark bitmap을 세대별로 분리하기 전까지는
+major marking과 young-only marking을 같은 heap에서 동시에 실행하지 않는다.
+
+### Compaction
+
+Compaction은 stable ID를 유지하면서 logical address만 재배치한다.
+
+- Live movable object는 낮은 address부터 packed된다.
+- Pinned object는 address가 유지된다.
+- Pinned object 뒤의 cursor는 overlap을 피하도록 pinned end 이후로 이동한다.
+- Humongous object도 기본적으로 움직이지 않으며, cursor는 humongous end 이후로 이동한다.
+- `fragmentedBytes`는 heap span과 live bytes 차이로 계산한다.
+
+현재 구현은 deterministic testability를 위해 object ID 순서로 compact한다. 실제
+native backend에서는 allocation address order나 size class order를 선택할 수 있다.
+
+## Invariants
+
+다음 조건은 항상 유지되어야 한다.
+
+- `liveBytes`는 `objects`에 남아 있는 object size 합과 같다.
+- `roots`에는 live object ID만 남아야 한다.
+- `remembered`에는 old object만 들어간다.
+- `remembered` object는 적어도 하나의 live young child를 가진다.
+- Marking 중 black object는 white child를 직접 새로 숨길 수 없다.
+- Major collection 뒤 movable live objects는 가능한 낮은 address로 이동한다.
+- Non-pinned `large` object는 tenured이고 `GcHumongousRegion`에 속한다.
+- `pinned` object는 `GcPinnedRegion`에 속하고 compaction에서 address가 유지된다.
+- Non-large movable object의 region은 generation/age에서 결정된다.
+- `allocate`가 반환한 ID는 object가 sweep되기 전까지 안정적이다.
+
+## Failure Policy
+
+Osty language spec은 OOM을 recoverable error로 보지 않는다. 이 library는 두 층을 둔다.
+
+- `tryAllocate`: `Result<Int, String>`으로 OOM을 보고한다.
+- `allocate`: 편의 API이며 OOM이면 `unwrap` panic으로 실패한다.
+
+미래 runtime integration에서는 `tryAllocate`의 error branch를 `std.process.abort`
+또는 runtime trap으로 연결할 수 있다.
+
+## Test Strategy
+
+필수 테스트는 다음을 포함한다.
+
+- Root에서 끊어진 cycle이 major collection에서 회수되는지
+- Old-to-young edge가 remembered set을 통해 minor collection에서 보존되는지
+- Minor survival 후 promotion이 이루어지는지
+- Nursery cycle이 root 없으면 minor collection에서 회수되는지
+- Incremental marking 중 black-to-white edge가 barrier로 보존되는지
+- Major compaction이 hole을 닫고 fragmentation을 0으로 줄이는지
+- Heap limit 초과 allocation이 full collection 이후에도 불가능하면 `Err`를 반환하는지
+- Large object가 nursery pressure를 유발하지 않고 humongous region에 들어가는지
+- Pinned object가 compaction hole을 남기고, unpin 후 다시 compact되는지
+- Seed 기반 random graph가 major collection 뒤 reference reachability와 일치하는지
+- Incremental marking 중 black-to-white insertion barrier가 stress graph에서도 보존되는지
+- Safepoint plan이 call/allocation/loop/async yield별 live root contract를 보존하는지
+- Duplicate root slot, missing stack map, dangling derived root를 validator가 거부하는지
+- Stack map이 live pointer bitmap, overflow slot list, derived-root mapping을 생성하는지
+- Stack map builder가 scalar slot root, missing frame slot, cleanup path root loss를 거부하는지
+
+## 해야 할 일
+
+이 섹션은 "현재 예제 패키지"에서 "진짜 Osty runtime GC"로 가기 위한 작업 목록이다.
+순서는 대략적인 의존성을 따른다.
+
+### Phase 1: GC RFC 고정
+
+- 최종 collector 목표를 precise, generational, regional, incremental, compacting으로 고정한다.
+- Conservative GC를 production path에서 배제한다.
+- Identity와 physical address 분리 원칙을 language/runtime contract로 적는다.
+- Detailed baseline은 `Phase 1 Detail: GC RFC 고정`을 따른다.
+- Acceptance criteria: 나중에 mark-sweep-only, conservative, non-moving design으로 후퇴하지 않도록 문서가 명확해야 한다.
+
+### Phase 2: Object Header 설계
+
+- Type descriptor pointer, mark state, generation bits, pinned bit, forwarding state를 header layout에 배치한다.
+- Header와 side table에 들어갈 metadata를 분리한다.
+- Alignment, size class, identity hash seed 정책을 정한다.
+- Detailed baseline은 `Phase 2 Detail: Object Header 설계`를 따른다.
+- Acceptance criteria: object header만 보고 scan, mark, move 가능 여부를 판단할 수 있어야 한다.
+
+### Phase 3: Type Descriptor 설계
+
+- Struct, enum, tuple, closure, array, string/bytes descriptor shape를 정의한다.
+- Pointer bitmap과 pointer offset list 중 기본 representation을 정한다.
+- Generic instantiation descriptor 생성 정책을 정한다.
+- Detailed baseline은 `Phase 3 Detail: Type Descriptor 설계`를 따른다.
+- Acceptance criteria: 모든 Osty value layout이 정확한 trace descriptor를 가진다.
+
+### Phase 4: Region Heap 설계
+
+- Region kind를 free, eden, survivor, old, humongous, pinned으로 정의한다.
+- Region table metadata와 region state transition을 문서화한다.
+- Region selection score를 live bytes, fragmentation, pin density 기준으로 설계한다.
+- Detailed baseline은 `Phase 4 Detail: Region Heap 설계`를 따른다.
+- Acceptance criteria: 단일 heap sweep 없이 region 단위 collection/evacuation을 설명할 수 있어야 한다.
+
+### Phase 5: Prototype Invariant Checker
+
+- Status: done for the executable prototype.
+- `validateHeap()`를 추가한다.
+- `liveBytes`, remembered set, roots, mark colors, generation invariants를 검사한다.
+- 모든 collection 테스트 뒤 invariant check를 호출한다.
+- Acceptance criteria: prototype 내부 상태가 깨지면 테스트가 즉시 실패한다.
+
+### Phase 6: Prototype Telemetry 확장
+
+- Status: done for the executable prototype.
+- `GcStats`에 trigger reason, logical pause units, allocation bytes since last GC를 추가한다.
+- Promotion rate, survival rate, fragmentation before/after를 기록한다.
+- Golden telemetry tests를 추가한다.
+- Acceptance criteria: collection이 왜 발생했고 어떤 비용/효과가 있었는지 stats로 설명된다.
+
+### Phase 7: Large Object와 Pinned Prototype
+
+- Status: done for the executable prototype.
+- Nursery를 우회하는 large object path를 prototype에 추가한다.
+- Pinned object가 compaction hole을 만드는 케이스를 테스트한다.
+- Pinned region 개념을 prototype model에 반영한다.
+- Acceptance criteria: movable object와 non-movable object 정책이 명확히 갈라진다.
+
+### Phase 8: Random Graph Stress Prototype
+
+- Status: done for the executable prototype.
+- Random object graph 생성기를 만든다.
+- Link/unlink/root add/remove/collection interleaving을 fuzz-like로 검증한다.
+- Reference model과 GC 결과를 비교한다.
+- Acceptance criteria: cycle, remembered edge, incremental barrier가 무작위 그래프에서도 깨지지 않는다.
+
+### Phase 9: IR Safepoint Contract
+
+- Status: done for the executable prototype.
+- IR에 safepoint 후보를 표현하는 방식을 설계한다.
+- Function call, allocation slow path, loop backedge, async yield를 safepoint로 분류한다.
+- Safepoint별 live pointer slot metadata contract를 정의한다.
+- Acceptance criteria: backend가 stack map을 만들 수 있는 정보가 IR에서 사라지지 않는다.
+
+### Phase 10: Stack Map Format
+
+- Status: done for the executable prototype.
+- Stack frame layout과 live pointer bitmap format을 정의한다.
+- Register spill, temporary, closure capture, tuple destructuring local을 다룬다.
+- `defer`, `?`, early return path의 live root 보존 규칙을 정한다.
+- Acceptance criteria: 어느 safepoint에서 major GC가 떠도 live local reference가 보존된다.
+
+### Phase 11: Global and Static Roots
+
+- Top-level `let`, constants, package globals의 root table을 설계한다.
+- Module initialization 중 partially initialized global을 다루는 규칙을 정한다.
+- Cross-package global references를 root graph에 포함한다.
+- Acceptance criteria: global object가 collection timing에 따라 사라지지 않는다.
+
+### Phase 12: Closure and Async Frame Roots
+
+- Closure environment descriptor를 정의한다.
+- Captured mutable binding과 boxed capture의 trace 규칙을 정한다.
+- Suspended async/task frame root scan을 설계한다.
+- Acceptance criteria: closure와 task suspension이 root liveness를 잃지 않는다.
+
+### Phase 13: TLAB Allocation Fast Path
+
+- Thread-local allocation buffer 구조를 설계한다.
+- Bump pointer fast path와 refill slow path를 나눈다.
+- TLAB waste accounting과 refill trigger를 정한다.
+- Acceptance criteria: common allocation이 global lock 없이 실행될 수 있다.
+
+### Phase 14: Nursery and Survivor Spaces
+
+- Eden, survivor aging, promotion threshold를 설계한다.
+- Minor GC에서 copy/promotion target region을 선택하는 정책을 정한다.
+- Survivor overflow 시 promotion fallback을 정의한다.
+- Acceptance criteria: short-lived object는 싸게 죽고, long-lived object는 안정적으로 old로 이동한다.
+
+### Phase 15: Tenured Allocation Backend
+
+- Old generation allocation policy를 정한다.
+- Free list, segregated size class, region bump allocation 중 초기 방식을 선택한다.
+- Fragmentation accounting을 region metadata에 연결한다.
+- Acceptance criteria: promoted object와 long-lived allocation이 nursery 정책과 분리된다.
+
+### Phase 16: Humongous Object Space
+
+- Large string, bytes, large array threshold를 정의한다.
+- Humongous region allocation/reclaim 정책을 만든다.
+- Humongous object compaction 여부와 pinning interaction을 정한다.
+- Acceptance criteria: 큰 객체가 nursery/evacuation cost를 망치지 않는다.
+
+### Phase 17: Barrier ABI v1
+
+- Runtime barrier function signatures를 고정한다.
+- Post-write barrier, pre-write barrier, load barrier hook을 분리한다.
+- Compiler가 호출할 stable ABI와 runtime이 inline할 fast path를 나눈다.
+- Acceptance criteria: collector policy가 바뀌어도 compiler call surface는 안정적이다.
+
+### Phase 18: Store Lowering Integration
+
+- Struct field store가 barrier를 호출하게 한다.
+- Tuple/enum payload update가 있다면 barrier 대상에 포함한다.
+- Self/method receiver mutation path를 검토한다.
+- Acceptance criteria: user-defined object field update에서 barrier 누락이 없다.
+
+### Phase 19: Collection Store Barrier
+
+- List/array element write barrier를 붙인다.
+- Map key/value insert/update barrier를 붙인다.
+- Set 내부 key store가 pointer-bearing type일 때의 규칙을 정한다.
+- Acceptance criteria: std collection 내부 mutation이 GC graph를 숨기지 않는다.
+
+### Phase 20: Closure and Runtime Frame Barrier
+
+- Closure capture update barrier를 붙인다.
+- Async frame, task handle, channel buffer, runtime frame mutation barrier를 설계한다.
+- Compiler-generated temporary heap object update path를 점검한다.
+- Acceptance criteria: compiler-generated heap mutation도 user field store와 같은 barrier discipline을 따른다.
+
+### Phase 21: Card Table and Remembered Set
+
+- Region/card size를 정한다.
+- Card dirtying, card scan, card clearing 정책을 만든다.
+- Prototype의 `Set<Int>` remembered set을 native card table 설계로 매핑한다.
+- Acceptance criteria: minor GC가 old generation 전체 scan 없이 old-to-young edges를 찾는다.
+
+### Phase 22: Minor Collector Backend
+
+- Root scan + remembered/card scan + young copy/promotion pipeline을 구현한다.
+- Eden reset과 survivor swap을 구현한다.
+- Minor collection telemetry를 연결한다.
+- Acceptance criteria: nursery pressure만으로 young collection이 정확히 실행된다.
+
+### Phase 23: Full Mark Collector Backend
+
+- Mark work queue를 구현한다.
+- Type descriptor 기반 object scan을 구현한다.
+- Full heap mark/sweep을 region table과 연결한다.
+- Acceptance criteria: root-unreachable cycle과 old garbage가 회수된다.
+
+### Phase 24: Evacuation and Forwarding
+
+- Forwarding pointer/table을 구현한다.
+- Selected region live object를 evacuation target으로 복사한다.
+- Object header forwarding state와 remap phase를 연결한다.
+- Acceptance criteria: evacuated object의 모든 reference가 새 location으로 갱신된다.
+
+### Phase 25: Root and Object Remapping
+
+- Stack roots, globals, closure env, object fields를 forwarding destination으로 갱신한다.
+- Remap 중 pinned/humongous object를 건너뛰는 규칙을 구현한다.
+- Remap verification pass를 추가한다.
+- Acceptance criteria: compaction 후 stale pointer가 남지 않는다.
+
+### Phase 26: Incremental Marking Scheduler
+
+- Incremental budget accounting을 구현한다.
+- Allocation slow path와 loop/call safepoint에서 mark step을 실행한다.
+- Mutator assist policy를 도입한다.
+- Acceptance criteria: configured budget을 넘기지 않고 mark progress가 보장된다.
+
+### Phase 27: Mostly-Concurrent Marking
+
+- Concurrent marker worker와 mark queue synchronization을 설계한다.
+- Barrier buffer flush와 remark safepoint를 구현한다.
+- Memory ordering과 data race 규칙을 문서화한다.
+- Acceptance criteria: concurrent mark가 mutator mutation과 race 없이 정확성을 유지한다.
+
+### Phase 28: Policy and Profiles
+
+- Latency-first, throughput-first, memory-tight profile을 정의한다.
+- Nursery size, promotion age, region evacuation threshold, incremental budget을 profile별로 조정한다.
+- Runtime config와 `osty run/build` profile config를 연결한다.
+- Acceptance criteria: collector mechanism은 그대로 두고 policy만 바꿀 수 있다.
+
+### Phase 29: Diagnostics, Stress, and Tooling
+
+- GC stats snapshot을 runtime diagnostics에 노출한다.
+- GC stress mode를 추가한다. 예: every allocation minor, frequent full GC, no compaction, always compact.
+- Heap dump와 object graph debug output을 설계한다.
+- Acceptance criteria: GC bug를 재현하고 telemetry로 원인을 좁힐 수 있다.
+
+### Phase 30: Spec and Production Hardening
+
+- OOM, `abort`, `defer`, FFI pinning, `std.ref.same`의 spec alignment를 완료한다.
+- Long-running stress, randomized graph, generated-code barrier audit를 CI에 넣는다.
+- Performance baseline과 regression thresholds를 만든다.
+- Acceptance criteria: GC implementation detail이 language behavior로 새지 않고, production runtime으로 켤 수 있다.
+
+## Open Questions
+
+- Generational policy를 two-generation으로 고정할지, nursery plus aging tenured buckets로 확장할지.
+- Large object threshold를 byte size만으로 정할지, pointer density도 고려할지.
+- Closure environment를 일반 record로 볼지, 별도 object kind로 최적화할지.
+- Strings and bytes를 moving heap에 둘지, 별도 immutable/pointer-free arena에 둘지.
+- Incremental barrier를 insertion barrier로 계속 갈지, SATB barrier로 바꿀지.
+- Compaction을 항상 major collection에 붙일지, fragmentation threshold 기반으로 분리할지.
+- Multi-threaded runtime에서 per-thread nursery를 둘지, shared nursery를 lock-free로 만들지.
+- FFI pinned object가 많을 때 fallback policy를 어떻게 둘지.
+
+## Milestones
+
+### M1: Executable Prototype
+
+현재 상태다. Osty code로 GC core가 동작하고, 주요 correctness test가 통과한다.
+대략 Phase 1-8에 해당한다.
+
+### M2: Verified Prototype
+
+Heap invariant checker, random graph stress test, pinning/fragmentation tests를 추가한다.
+대략 Phase 5-8을 production-grade prototype 품질로 끌어올리는 구간이다.
+
+### M3: Metadata Prototype
+
+IR 또는 generator layer에서 type descriptor와 pointer map을 실험적으로 생성한다.
+대략 Phase 9-12에 해당한다.
+
+### M4: Runtime Backend Spike
+
+Toy native allocator 또는 Go-emitted runtime helper에서 실제 object header와 arena를 사용한다.
+대략 Phase 13-17에 해당한다.
+
+### M5: Compiler Integration
+
+Generated code의 allocations, field stores, stack maps, safepoints가 GC runtime contract를 따른다.
+대략 Phase 18-25에 해당한다.
+
+### M6: Production Hardening
+
+Stress mode, telemetry, profile knobs, FFI pinning, incremental scheduling을 갖춘다.
+대략 Phase 26-30에 해당한다.
+
+## Future Native Runtime Path
+
+이 Osty implementation을 실제 runtime으로 승격할 때의 순서는 다음과 같다.
+
+1. `GcObject.refs`를 compiler-generated pointer bitmap 또는 stack map으로 대체한다.
+2. `address`를 real heap pointer 또는 arena offset으로 대체한다.
+3. `roots`를 stack roots, globals, thread locals, closure captures에서 자동 생성한다.
+4. `remembered`를 card table 또는 page-level remembered bitmap으로 낮춘다.
+5. `stepIncremental`을 scheduler safepoint와 연결한다.
+6. `pinned`를 FFI buffer, syscall buffer, host interop object에 연결한다.
+7. `GcStats`를 profiler event stream으로 노출한다.
+
+이 설계의 핵심은 API와 invariants를 먼저 고정하고, storage backend만 교체하는 것이다.

--- a/examples/gc/lib.osty
+++ b/examples/gc/lib.osty
@@ -1,0 +1,1585 @@
+// gc - a high-grade independent garbage-collector core written in Osty.
+//
+// This package models the runtime pieces a native Osty backend would need:
+// a managed object graph, explicit roots, a nursery and tenured generation,
+// old-to-young remembered-set write barriers, incremental tri-color marking,
+// cycle collection, compaction, pinning, allocation pressure triggers, and
+// telemetry for every collection.
+
+pub enum ObjectKind {
+    GcRecord,
+    GcArray,
+    GcClosure,
+    GcBytes,
+    GcRuntimeFrame,
+}
+
+pub enum MarkColor {
+    GcWhite,
+    GcGrey,
+    GcBlack,
+}
+
+pub enum GcRegionKind {
+    GcEdenRegion,
+    GcSurvivorRegion,
+    GcOldRegion,
+    GcHumongousRegion,
+    GcPinnedRegion,
+}
+
+pub enum TracePhase {
+    GcIdle,
+    GcMarking,
+    GcSweeping,
+}
+
+pub struct GcConfig {
+    pub nurseryLimit: Int,
+    pub heapLimit: Int,
+    pub promotionAge: Int,
+    pub incrementalBudget: Int,
+    pub largeObjectThreshold: Int,
+}
+
+pub struct GcStats {
+    pub kind: String,
+    pub trigger: String,
+    pub cycle: Int,
+    pub beforeObjects: Int,
+    pub afterObjects: Int,
+    pub reclaimedObjects: Int,
+    pub beforeBytes: Int,
+    pub afterBytes: Int,
+    pub reclaimedBytes: Int,
+    pub promotedObjects: Int,
+    pub compactedObjects: Int,
+    pub rememberedScanned: Int,
+    pub markSteps: Int,
+    pub pauseUnits: Int,
+    pub allocationBytesSinceLastGC: Int,
+    pub beforeFragmentedBytes: Int,
+    pub afterFragmentedBytes: Int,
+    pub fragmentedBytes: Int,
+    pub survivalPercent: Int,
+    pub promotionPercent: Int,
+}
+
+pub struct GcObject {
+    pub id: Int,
+    pub kind: ObjectKind,
+    pub size: Int,
+    pub address: Int,
+    pub generation: Int,
+    pub age: Int,
+    pub color: MarkColor,
+    pub marked: Bool,
+    pub pinned: Bool,
+    pub large: Bool,
+    pub region: GcRegionKind,
+    pub refs: List<Int>,
+    pub remembered: Bool,
+    pub allocatedCycle: Int,
+}
+
+pub enum GcSafepointKind {
+    GcCallSafepoint,
+    GcAllocationSafepoint,
+    GcLoopBackedgeSafepoint,
+    GcAsyncYieldSafepoint,
+}
+
+pub enum GcRootSlotKind {
+    GcLocalRootSlot,
+    GcTemporaryRootSlot,
+    GcRegisterRootSlot,
+    GcSpillRootSlot,
+    GcClosureRootSlot,
+    GcDerivedRootSlot,
+}
+
+pub enum GcFrameSlotKind {
+    GcFrameLocalSlot,
+    GcFrameTemporarySlot,
+    GcFrameRegisterSpillSlot,
+    GcFrameClosureCaptureSlot,
+    GcFrameTupleFieldSlot,
+    GcFrameDeferSlot,
+    GcFrameQuestionSlot,
+    GcFrameReturnSlot,
+}
+
+pub struct GcLiveRootSlot {
+    pub slot: Int,
+    pub kind: GcRootSlotKind,
+    pub name: String,
+    pub derivedFrom: Int,
+    pub nullable: Bool,
+}
+
+pub struct GcSafepoint {
+    pub id: Int,
+    pub kind: GcSafepointKind,
+    pub irNode: Int,
+    pub instructionOffset: Int,
+    pub mayCollect: Bool,
+    pub mayAllocate: Bool,
+    pub maySuspend: Bool,
+    pub requiresStackMap: Bool,
+    pub runsDefer: Bool,
+    pub questionExit: Bool,
+    pub earlyReturn: Bool,
+    pub liveRoots: List<GcLiveRootSlot>,
+}
+
+pub struct GcSafepointPlan {
+    pub functionName: String,
+    pub frameSlots: Int,
+    pub safepoints: List<GcSafepoint>,
+}
+
+pub struct GcFrameSlot {
+    pub slot: Int,
+    pub kind: GcFrameSlotKind,
+    pub name: String,
+    pub byteOffset: Int,
+    pub pointer: Bool,
+    pub derivedFrom: Int,
+    pub preserveForDefer: Bool,
+    pub preserveForQuestion: Bool,
+    pub preserveForReturn: Bool,
+}
+
+pub struct GcDerivedRootMap {
+    pub derivedSlot: Int,
+    pub baseSlot: Int,
+}
+
+pub struct GcStackMapEntry {
+    pub safepointId: Int,
+    pub instructionOffset: Int,
+    pub liveCount: Int,
+    pub inlineSlots: Int,
+    pub bitmapWords: List<Int>,
+    pub overflowSlots: List<Int>,
+    pub derivedRoots: List<GcDerivedRootMap>,
+}
+
+pub struct GcStackMap {
+    pub functionName: String,
+    pub frameSlots: Int,
+    pub pointerSize: Int,
+    pub inlineSlots: Int,
+    pub frameLayout: List<GcFrameSlot>,
+    pub entries: List<GcStackMapEntry>,
+}
+
+pub struct GcHeap {
+    pub config: GcConfig,
+    nextId: Int,
+    nextAddress: Int,
+    liveBytes: Int,
+    cycle: Int,
+    minorCollections: Int,
+    majorCollections: Int,
+    phase: TracePhase,
+    objects: Map<Int, GcObject>,
+    roots: Set<Int>,
+    remembered: Set<Int>,
+    grey: List<Int>,
+    allocatedSinceLastGC: Int,
+    lastStats: GcStats?,
+
+    pub fn tryAllocate(mut self, kind: ObjectKind, size: Int) -> Result<Int, String> {
+        let normalized = normalizeSize(size)
+        let large = self.isLargeSize(normalized)
+
+        if !(large) && self.phase == GcIdle && self.config.nurseryLimit > 0 && self.nurseryBytes() + normalized > self.config.nurseryLimit {
+            let _ = self.minorCollectFor("nursery-pressure")
+        }
+
+        if self.config.heapLimit > 0 && self.liveBytes + normalized > self.config.heapLimit {
+            let _ = self.majorCollectFor("heap-pressure")
+        }
+
+        if self.config.heapLimit > 0 && self.liveBytes + normalized > self.config.heapLimit {
+            Err("gc heap exhausted: requested {normalized} bytes with {self.liveBytes} live bytes")
+        } else {
+            Ok(self.allocateRaw(kind, normalized))
+        }
+    }
+
+    pub fn allocate(mut self, kind: ObjectKind, size: Int) -> Int {
+        self.tryAllocate(kind, size).unwrap()
+    }
+
+    pub fn addRoot(mut self, id: Int) -> Bool {
+        if !(self.objects.containsKey(id)) {
+            return false
+        }
+        self.roots.insert(id)
+        if self.phase == GcMarking {
+            self.shade(id)
+        }
+        true
+    }
+
+    pub fn removeRoot(mut self, id: Int) -> Bool {
+        self.roots.remove(id)
+    }
+
+    pub fn pin(mut self, id: Int) -> Bool {
+        if !(self.objects.containsKey(id)) {
+            return false
+        }
+        let mut next = self.objects[id]
+        next.pinned = true
+        next.region = regionForObject(next)
+        self.objects.insert(id, next)
+        true
+    }
+
+    pub fn unpin(mut self, id: Int) -> Bool {
+        if !(self.objects.containsKey(id)) {
+            return false
+        }
+        let mut next = self.objects[id]
+        next.pinned = false
+        next.region = regionForObject(next)
+        self.objects.insert(id, next)
+        true
+    }
+
+    pub fn link(mut self, from: Int, to: Int) -> Bool {
+        if !(self.objects.containsKey(from)) {
+            return false
+        }
+        if !(self.objects.containsKey(to)) {
+            return false
+        }
+
+        let child = self.objects[to]
+        let mut next = self.objects[from]
+        if !(next.refs.contains(to)) {
+            next.refs.push(to)
+        }
+        if next.generation > child.generation {
+            next.remembered = true
+            self.remembered.insert(from)
+        }
+        self.objects.insert(from, next)
+        if self.phase == GcMarking && next.color == GcBlack && child.color == GcWhite {
+            self.shade(to)
+        }
+        true
+    }
+
+    pub fn unlink(mut self, from: Int, to: Int) -> Bool {
+        if !(self.objects.containsKey(from)) {
+            return false
+        }
+        let mut next = self.objects[from]
+        let before = next.refs.len()
+        next.refs = next.refs.filter(|id| id != to)
+        self.objects.insert(from, next)
+        if before != next.refs.len() {
+            self.rebuildRemembered()
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn minorCollect(mut self) -> GcStats {
+        self.minorCollectFor("manual")
+    }
+
+    pub fn majorCollect(mut self) -> GcStats {
+        self.majorCollectFor("manual")
+    }
+
+    pub fn startIncrementalMajor(mut self) {
+        self.cycle = self.cycle + 1
+        self.phase = GcMarking
+        self.clearAllMarks()
+        for id in self.roots.toList() {
+            self.shade(id)
+        }
+    }
+
+    pub fn stepIncremental(mut self) -> GcStats {
+        if self.phase == GcIdle {
+            self.startIncrementalMajor()
+        }
+
+        let beforeObjects = self.objectCount()
+        let beforeBytes = self.liveBytes
+        let beforeFragmentedBytes = self.fragmentedBytes()
+        let allocationBytesSinceLastGC = self.allocatedSinceLastGC
+
+        if self.phase == GcMarking {
+            let markSteps = self.drainGrey(self.config.incrementalBudget, false)
+            if self.grey.len() > 0 {
+                let stats = GcStats {
+                    kind: "incremental-mark",
+                    trigger: "incremental-budget",
+                    cycle: self.cycle,
+                    beforeObjects,
+                    afterObjects: self.objectCount(),
+                    reclaimedObjects: 0,
+                    beforeBytes,
+                    afterBytes: self.liveBytes,
+                    reclaimedBytes: 0,
+                    promotedObjects: 0,
+                    compactedObjects: 0,
+                    rememberedScanned: 0,
+                    markSteps,
+                    pauseUnits: telemetryPauseUnits(markSteps, 0, 0, 0, 0),
+                    allocationBytesSinceLastGC,
+                    beforeFragmentedBytes,
+                    afterFragmentedBytes: self.fragmentedBytes(),
+                    fragmentedBytes: self.fragmentedBytes(),
+                    survivalPercent: percent(self.objectCount(), beforeObjects),
+                    promotionPercent: 0,
+                }
+                self.lastStats = Some(stats)
+                return stats
+            }
+
+            self.phase = GcSweeping
+            let (reclaimedObjects, reclaimedBytes) = self.sweepAll()
+            let compactedObjects = self.compactLive()
+            self.rebuildRemembered()
+            self.majorCollections = self.majorCollections + 1
+            self.phase = GcIdle
+            self.allocatedSinceLastGC = 0
+
+            let stats = GcStats {
+                kind: "incremental-sweep",
+                trigger: "incremental-budget",
+                cycle: self.cycle,
+                beforeObjects,
+                afterObjects: self.objectCount(),
+                reclaimedObjects,
+                beforeBytes,
+                afterBytes: self.liveBytes,
+                reclaimedBytes,
+                promotedObjects: 0,
+                compactedObjects,
+                rememberedScanned: 0,
+                markSteps,
+                pauseUnits: telemetryPauseUnits(markSteps, reclaimedObjects, 0, compactedObjects, 0),
+                allocationBytesSinceLastGC,
+                beforeFragmentedBytes,
+                afterFragmentedBytes: self.fragmentedBytes(),
+                fragmentedBytes: self.fragmentedBytes(),
+                survivalPercent: percent(self.objectCount(), beforeObjects),
+                promotionPercent: 0,
+            }
+            self.lastStats = Some(stats)
+            return stats
+        }
+
+        self.majorCollectFor("manual")
+    }
+
+    pub fn finishIncremental(mut self) -> GcStats {
+        let mut last = emptyStats("incremental-idle", self)
+        for self.phase != GcIdle {
+            last = self.stepIncremental()
+        }
+        last
+    }
+
+    pub fn lastCollectionStats(self) -> GcStats? {
+        self.lastStats
+    }
+
+    fn minorCollectFor(mut self, trigger: String) -> GcStats {
+        self.cycle = self.cycle + 1
+        let beforeObjects = self.objectCount()
+        let beforeBytes = self.liveBytes
+        let beforeFragmentedBytes = self.fragmentedBytes()
+        let rememberedScanned = self.remembered.len()
+        let allocationBytesSinceLastGC = self.allocatedSinceLastGC
+
+        self.clearYoungMarks()
+        self.markYoungRoots()
+        let markSteps = self.drainGrey(0, true)
+        let (reclaimedObjects, reclaimedBytes, promotedObjects) = self.sweepYoung()
+        self.rebuildRemembered()
+        self.minorCollections = self.minorCollections + 1
+        self.allocatedSinceLastGC = 0
+
+        let stats = GcStats {
+            kind: "minor",
+            trigger,
+            cycle: self.cycle,
+            beforeObjects,
+            afterObjects: self.objectCount(),
+            reclaimedObjects,
+            beforeBytes,
+            afterBytes: self.liveBytes,
+            reclaimedBytes,
+            promotedObjects,
+            compactedObjects: 0,
+            rememberedScanned,
+            markSteps,
+            pauseUnits: telemetryPauseUnits(
+                markSteps,
+                reclaimedObjects,
+                promotedObjects,
+                0,
+                rememberedScanned,
+            ),
+            allocationBytesSinceLastGC,
+            beforeFragmentedBytes,
+            afterFragmentedBytes: self.fragmentedBytes(),
+            fragmentedBytes: self.fragmentedBytes(),
+            survivalPercent: percent(self.objectCount(), beforeObjects),
+            promotionPercent: percent(promotedObjects, beforeObjects),
+        }
+        self.lastStats = Some(stats)
+        stats
+    }
+
+    fn majorCollectFor(mut self, trigger: String) -> GcStats {
+        self.cycle = self.cycle + 1
+        let beforeObjects = self.objectCount()
+        let beforeBytes = self.liveBytes
+        let beforeFragmentedBytes = self.fragmentedBytes()
+        let allocationBytesSinceLastGC = self.allocatedSinceLastGC
+
+        self.phase = GcMarking
+        self.clearAllMarks()
+        for id in self.roots.toList() {
+            self.shade(id)
+        }
+        let markSteps = self.drainGrey(0, false)
+
+        self.phase = GcSweeping
+        let (reclaimedObjects, reclaimedBytes) = self.sweepAll()
+        let compactedObjects = self.compactLive()
+        self.rebuildRemembered()
+        self.majorCollections = self.majorCollections + 1
+        self.phase = GcIdle
+        self.allocatedSinceLastGC = 0
+
+        let stats = GcStats {
+            kind: "major",
+            trigger,
+            cycle: self.cycle,
+            beforeObjects,
+            afterObjects: self.objectCount(),
+            reclaimedObjects,
+            beforeBytes,
+            afterBytes: self.liveBytes,
+            reclaimedBytes,
+            promotedObjects: 0,
+            compactedObjects,
+            rememberedScanned: 0,
+            markSteps,
+            pauseUnits: telemetryPauseUnits(markSteps, reclaimedObjects, 0, compactedObjects, 0),
+            allocationBytesSinceLastGC,
+            beforeFragmentedBytes,
+            afterFragmentedBytes: self.fragmentedBytes(),
+            fragmentedBytes: self.fragmentedBytes(),
+            survivalPercent: percent(self.objectCount(), beforeObjects),
+            promotionPercent: 0,
+        }
+        self.lastStats = Some(stats)
+        stats
+    }
+
+    pub fn contains(self, id: Int) -> Bool {
+        self.objects.containsKey(id)
+    }
+
+    pub fn objectCount(self) -> Int {
+        self.objects.len()
+    }
+
+    pub fn rootCount(self) -> Int {
+        self.roots.len()
+    }
+
+    pub fn rememberedCount(self) -> Int {
+        self.remembered.len()
+    }
+
+    pub fn nurseryBytes(self) -> Int {
+        let mut total = 0
+        for (_, obj) in self.objects {
+            if obj.generation == 0 {
+                total = total + obj.size
+            }
+        }
+        total
+    }
+
+    pub fn totalLiveBytes(self) -> Int {
+        self.liveBytes
+    }
+
+    pub fn fragmentedBytes(self) -> Int {
+        let span = self.heapSpan()
+        if span > self.liveBytes {
+            span - self.liveBytes
+        } else {
+            0
+        }
+    }
+
+    pub fn phaseNow(self) -> TracePhase {
+        self.phase
+    }
+
+    pub fn minorCount(self) -> Int {
+        self.minorCollections
+    }
+
+    pub fn majorCount(self) -> Int {
+        self.majorCollections
+    }
+
+    pub fn generationOf(self, id: Int) -> Int? {
+        if self.objects.containsKey(id) {
+            Some(self.objects[id].generation)
+        } else {
+            None
+        }
+    }
+
+    pub fn addressOf(self, id: Int) -> Int? {
+        if self.objects.containsKey(id) {
+            Some(self.objects[id].address)
+        } else {
+            None
+        }
+    }
+
+    pub fn refCount(self, id: Int) -> Int? {
+        if self.objects.containsKey(id) {
+            Some(self.objects[id].refs.len())
+        } else {
+            None
+        }
+    }
+
+    pub fn isLarge(self, id: Int) -> Bool? {
+        if self.objects.containsKey(id) {
+            Some(self.objects[id].large)
+        } else {
+            None
+        }
+    }
+
+    pub fn regionOf(self, id: Int) -> GcRegionKind? {
+        if self.objects.containsKey(id) {
+            Some(self.objects[id].region)
+        } else {
+            None
+        }
+    }
+
+    pub fn largeObjectCount(self) -> Int {
+        let mut total = 0
+        for (_, obj) in self.objects {
+            if obj.large {
+                total = total + 1
+            }
+        }
+        total
+    }
+
+    pub fn pinnedObjectCount(self) -> Int {
+        let mut total = 0
+        for (_, obj) in self.objects {
+            if obj.pinned {
+                total = total + 1
+            }
+        }
+        total
+    }
+
+    pub fn validateHeap(self) -> Result<(), String> {
+        let mut byteSum = 0
+        let mut maxEnd = 0
+
+        for (id, obj) in self.objects {
+            if obj.id != id {
+                return Err("heap object key/id mismatch: key={id}, object={obj.id}")
+            }
+            if id <= 0 {
+                return Err("heap object id must be positive: {id}")
+            }
+            if id >= self.nextId {
+                return Err("heap object id {id} is outside nextId {self.nextId}")
+            }
+            if obj.size <= 0 {
+                return Err("object {id} has non-positive size {obj.size}")
+            }
+            if obj.address < 0 {
+                return Err("object {id} has negative address {obj.address}")
+            }
+            if obj.generation != 0 && obj.generation != 1 {
+                return Err("object {id} has invalid generation {obj.generation}")
+            }
+            if obj.age < 0 {
+                return Err("object {id} has negative age {obj.age}")
+            }
+            if obj.large && obj.generation != 1 {
+                return Err("large object {id} is not tenured")
+            }
+            if obj.region != regionForObject(obj) {
+                return Err("object {id} has stale region metadata")
+            }
+            if obj.color == GcWhite && obj.marked {
+                return Err("object {id} is white but marked")
+            }
+            if obj.color != GcWhite && !(obj.marked) {
+                return Err("object {id} is non-white but unmarked")
+            }
+
+            for childId in obj.refs {
+                if !(self.objects.containsKey(childId)) {
+                    return Err("object {id} references missing object {childId}")
+                }
+            }
+
+            let expectedRemembered = obj.generation > 0 && self.hasYoungRef(obj)
+            if obj.remembered != expectedRemembered {
+                return Err("object {id} remembered flag is stale")
+            }
+            if expectedRemembered && !(self.remembered.contains(id)) {
+                return Err("old object {id} has a young edge but is not remembered")
+            }
+            if !(expectedRemembered) && self.remembered.contains(id) {
+                return Err("object {id} is remembered without an old-to-young edge")
+            }
+
+            byteSum = byteSum + obj.size
+            let end = obj.address + obj.size
+            if end > maxEnd {
+                maxEnd = end
+            }
+        }
+
+        if byteSum != self.liveBytes {
+            return Err("liveBytes mismatch: field={self.liveBytes}, actual={byteSum}")
+        }
+        if maxEnd > self.nextAddress {
+            return Err("nextAddress {self.nextAddress} is before heap span {maxEnd}")
+        }
+        if self.allocatedSinceLastGC < 0 {
+            return Err("allocatedSinceLastGC is negative: {self.allocatedSinceLastGC}")
+        }
+
+        for rootId in self.roots.toList() {
+            if !(self.objects.containsKey(rootId)) {
+                return Err("root references missing object {rootId}")
+            }
+        }
+
+        for id in self.remembered.toList() {
+            if !(self.objects.containsKey(id)) {
+                return Err("remembered set references missing object {id}")
+            }
+            let obj = self.objects[id]
+            if obj.generation == 0 {
+                return Err("young object {id} is present in remembered set")
+            }
+            if !(obj.remembered) {
+                return Err("remembered object {id} has remembered=false")
+            }
+            if !(self.hasYoungRef(obj)) {
+                return Err("remembered object {id} has no young reference")
+            }
+        }
+
+        if self.phase != GcMarking && self.grey.len() > 0 {
+            return Err("grey queue is non-empty outside marking phase")
+        }
+        for id in self.grey {
+            if !(self.objects.containsKey(id)) {
+                return Err("grey queue references missing object {id}")
+            }
+            let obj = self.objects[id]
+            if obj.color != GcGrey {
+                return Err("grey queue object {id} is not grey")
+            }
+            if !(obj.marked) {
+                return Err("grey queue object {id} is unmarked")
+            }
+        }
+
+        Ok(())
+    }
+
+    fn allocateRaw(mut self, kind: ObjectKind, size: Int) -> Int {
+        let id = self.nextId
+        let address = self.nextAddress
+        let large = self.isLargeSize(size)
+        self.nextId = self.nextId + 1
+        self.nextAddress = self.nextAddress + size
+        self.liveBytes = self.liveBytes + size
+        self.allocatedSinceLastGC = self.allocatedSinceLastGC + size
+        self.objects.insert(id, newGcObject(id, kind, size, address, self.cycle, large))
+        id
+    }
+
+    fn isLargeSize(self, size: Int) -> Bool {
+        self.config.largeObjectThreshold > 0 && size >= self.config.largeObjectThreshold
+    }
+
+    fn clearAllMarks(mut self) {
+        self.grey.clear()
+        let ids = self.objects.keys()
+        for id in ids {
+            if self.objects.containsKey(id) {
+                let mut next = self.objects[id]
+                next.marked = false
+                next.color = GcWhite
+                self.objects.insert(id, next)
+            }
+        }
+    }
+
+    fn clearYoungMarks(mut self) {
+        self.grey.clear()
+        let ids = self.objects.keys()
+        for id in ids {
+            if self.objects.containsKey(id) {
+                let obj = self.objects[id]
+                if obj.generation == 0 {
+                    let mut next = obj
+                    next.marked = false
+                    next.color = GcWhite
+                    self.objects.insert(id, next)
+                }
+            }
+        }
+    }
+
+    fn shade(mut self, id: Int) {
+        if self.objects.containsKey(id) {
+            let obj = self.objects[id]
+            if obj.color == GcWhite {
+                let mut next = obj
+                next.color = GcGrey
+                next.marked = true
+                self.objects.insert(id, next)
+                self.grey.push(id)
+            }
+        }
+    }
+
+    fn shadeYoung(mut self, id: Int) {
+        if self.objects.containsKey(id) {
+            let obj = self.objects[id]
+            if obj.generation == 0 && obj.color == GcWhite {
+                let mut next = obj
+                next.color = GcGrey
+                next.marked = true
+                self.objects.insert(id, next)
+                self.grey.push(id)
+            }
+        }
+    }
+
+    fn markYoungRoots(mut self) {
+        for id in self.roots.toList() {
+            if self.objects.containsKey(id) {
+                let obj = self.objects[id]
+                if obj.generation == 0 {
+                    self.shadeYoung(id)
+                } else {
+                    self.shadeYoungChildren(obj)
+                }
+            }
+        }
+
+        for id in self.remembered.toList() {
+            if self.objects.containsKey(id) {
+                self.shadeYoungChildren(self.objects[id])
+            }
+        }
+    }
+
+    fn shadeYoungChildren(mut self, obj: GcObject) {
+        for childId in obj.refs {
+            self.shadeYoung(childId)
+        }
+    }
+
+    fn drainGrey(mut self, budget: Int, youngOnly: Bool) -> Int {
+        let unlimited = budget <= 0
+        let mut steps = 0
+        for self.grey.len() > 0 && (unlimited || steps < budget) {
+            let id = self.grey.pop() ?? -1
+            if id >= 0 {
+                if youngOnly {
+                    self.blackenYoung(id)
+                } else {
+                    self.blacken(id)
+                }
+                steps = steps + 1
+            }
+        }
+        steps
+    }
+
+    fn blacken(mut self, id: Int) {
+        if self.objects.containsKey(id) {
+            let obj = self.objects[id]
+            if obj.color == GcGrey {
+                let refs = obj.refs
+                let mut next = obj
+                next.color = GcBlack
+                next.marked = true
+                self.objects.insert(id, next)
+                for childId in refs {
+                    self.shade(childId)
+                }
+            }
+        }
+    }
+
+    fn blackenYoung(mut self, id: Int) {
+        if self.objects.containsKey(id) {
+            let obj = self.objects[id]
+            if obj.generation == 0 && obj.color == GcGrey {
+                let refs = obj.refs
+                let mut next = obj
+                next.color = GcBlack
+                next.marked = true
+                self.objects.insert(id, next)
+                for childId in refs {
+                    self.shadeYoung(childId)
+                }
+            }
+        }
+    }
+
+    fn sweepYoung(mut self) -> (Int, Int, Int) {
+        let mut reclaimedObjects = 0
+        let mut reclaimedBytes = 0
+        let mut promotedObjects = 0
+        let ids = self.objects.keys()
+
+        for id in ids {
+            if self.objects.containsKey(id) {
+                let obj = self.objects[id]
+                if obj.generation == 0 {
+                    if obj.marked {
+                        let mut next = obj
+                        next.age = next.age + 1
+                        if next.age >= self.config.promotionAge || next.pinned {
+                            next.generation = 1
+                            promotedObjects = promotedObjects + 1
+                        }
+                        next.region = regionForObject(next)
+                        next.marked = false
+                        next.color = GcWhite
+                        self.objects.insert(id, next)
+                    } else {
+                        let _ = self.objects.remove(id)
+                        self.liveBytes = self.liveBytes - obj.size
+                        reclaimedObjects = reclaimedObjects + 1
+                        reclaimedBytes = reclaimedBytes + obj.size
+                    }
+                }
+            }
+        }
+
+        (reclaimedObjects, reclaimedBytes, promotedObjects)
+    }
+
+    fn sweepAll(mut self) -> (Int, Int) {
+        let mut reclaimedObjects = 0
+        let mut reclaimedBytes = 0
+        let ids = self.objects.keys()
+
+        for id in ids {
+            if self.objects.containsKey(id) {
+                let obj = self.objects[id]
+                if obj.marked {
+                    let mut next = obj
+                    next.generation = 1
+                    if next.age < self.config.promotionAge {
+                        next.age = self.config.promotionAge
+                    }
+                    next.region = regionForObject(next)
+                    next.marked = false
+                    next.color = GcWhite
+                    self.objects.insert(id, next)
+                } else {
+                    let _ = self.objects.remove(id)
+                    self.liveBytes = self.liveBytes - obj.size
+                    reclaimedObjects = reclaimedObjects + 1
+                    reclaimedBytes = reclaimedBytes + obj.size
+                }
+            }
+        }
+
+        (reclaimedObjects, reclaimedBytes)
+    }
+
+    fn compactLive(mut self) -> Int {
+        let ids = self.objects.keys().sorted()
+        let mut cursor = 0
+        let mut moved = 0
+
+        for id in ids {
+            if self.objects.containsKey(id) {
+                let mut next = self.objects[id]
+                if next.pinned || next.large {
+                    let end = next.address + next.size
+                    if end > cursor {
+                        cursor = end
+                    }
+                } else {
+                    if next.address != cursor {
+                        moved = moved + 1
+                    }
+                    next.address = cursor
+                    cursor = cursor + next.size
+                }
+                self.objects.insert(id, next)
+            }
+        }
+
+        self.nextAddress = cursor
+        moved
+    }
+
+    fn rebuildRemembered(mut self) {
+        self.remembered.clear()
+        let ids = self.objects.keys()
+        for id in ids {
+            if self.objects.containsKey(id) {
+                let mut next = self.objects[id]
+                next.remembered = next.generation > 0 && self.hasYoungRef(next)
+                if next.remembered {
+                    self.remembered.insert(id)
+                }
+                self.objects.insert(id, next)
+            }
+        }
+    }
+
+    fn hasYoungRef(self, obj: GcObject) -> Bool {
+        for childId in obj.refs {
+            if self.objects.containsKey(childId) {
+                let child = self.objects[childId]
+                if child.generation == 0 {
+                    return true
+                }
+            }
+        }
+        false
+    }
+
+    fn heapSpan(self) -> Int {
+        let mut span = 0
+        for (_, obj) in self.objects {
+            let end = obj.address + obj.size
+            if end > span {
+                span = end
+            }
+        }
+        span
+    }
+}
+
+pub fn productionGcConfig() -> GcConfig {
+    GcConfig {
+        nurseryLimit: 64 * 1024,
+        heapLimit: 16 * 1024 * 1024,
+        promotionAge: 2,
+        incrementalBudget: 64,
+        largeObjectThreshold: 128 * 1024,
+    }
+}
+
+pub fn testGcConfig() -> GcConfig {
+    GcConfig {
+        nurseryLimit: 256,
+        heapLimit: 4096,
+        promotionAge: 1,
+        incrementalBudget: 1,
+        largeObjectThreshold: 512,
+    }
+}
+
+pub fn newGcHeap(config: GcConfig) -> GcHeap {
+    let objects: Map<Int, GcObject> = {:}
+    let emptyRoots: List<Int> = []
+    let emptyRemembered: List<Int> = []
+    let grey: List<Int> = []
+
+    GcHeap {
+        config,
+        nextId: 1,
+        nextAddress: 0,
+        liveBytes: 0,
+        cycle: 0,
+        minorCollections: 0,
+        majorCollections: 0,
+        phase: GcIdle,
+        objects,
+        roots: emptyRoots.toSet(),
+        remembered: emptyRemembered.toSet(),
+        grey,
+        allocatedSinceLastGC: 0,
+        lastStats: None,
+    }
+}
+
+pub fn gcRootSlot(slot: Int, kind: GcRootSlotKind, name: String) -> GcLiveRootSlot {
+    GcLiveRootSlot {
+        slot,
+        kind,
+        name,
+        derivedFrom: -1,
+        nullable: true,
+    }
+}
+
+pub fn gcDerivedRootSlot(slot: Int, name: String, derivedFrom: Int) -> GcLiveRootSlot {
+    GcLiveRootSlot {
+        slot,
+        kind: GcDerivedRootSlot,
+        name,
+        derivedFrom,
+        nullable: false,
+    }
+}
+
+pub fn gcSafepoint(
+    id: Int,
+    kind: GcSafepointKind,
+    irNode: Int,
+    instructionOffset: Int,
+    liveRoots: List<GcLiveRootSlot>,
+) -> GcSafepoint {
+    GcSafepoint {
+        id,
+        kind,
+        irNode,
+        instructionOffset,
+        mayCollect: true,
+        mayAllocate: safepointMayAllocate(kind),
+        maySuspend: kind == GcAsyncYieldSafepoint,
+        requiresStackMap: true,
+        runsDefer: false,
+        questionExit: false,
+        earlyReturn: false,
+        liveRoots,
+    }
+}
+
+pub fn gcSafepointPlan(functionName: String, frameSlots: Int, safepoints: List<GcSafepoint>) -> GcSafepointPlan {
+    GcSafepointPlan {
+        functionName,
+        frameSlots,
+        safepoints,
+    }
+}
+
+pub fn validateSafepointPlan(plan: GcSafepointPlan) -> Result<(), String> {
+    if plan.functionName == "" {
+        return Err("safepoint plan requires a function name")
+    }
+    if plan.frameSlots < 0 {
+        return Err("safepoint plan has negative frame slot count")
+    }
+
+    let empty: List<Int> = []
+    let mut seenIds = empty.toSet()
+    for point in plan.safepoints {
+        if point.id <= 0 {
+            return Err("safepoint id must be positive")
+        }
+        if seenIds.contains(point.id) {
+            return Err("duplicate safepoint id {point.id}")
+        }
+        seenIds.insert(point.id)
+
+        match validateSafepoint(plan, point) {
+            Ok(_) -> {},
+            Err(e) -> {
+                return Err(e)
+            },
+        }
+    }
+
+    Ok(())
+}
+
+pub fn gcFrameSlot(
+    slot: Int,
+    kind: GcFrameSlotKind,
+    name: String,
+    byteOffset: Int,
+    pointer: Bool,
+) -> GcFrameSlot {
+    GcFrameSlot {
+        slot,
+        kind,
+        name,
+        byteOffset,
+        pointer,
+        derivedFrom: -1,
+        preserveForDefer: false,
+        preserveForQuestion: false,
+        preserveForReturn: false,
+    }
+}
+
+pub fn gcPreservedFrameSlot(
+    slot: Int,
+    kind: GcFrameSlotKind,
+    name: String,
+    byteOffset: Int,
+    pointer: Bool,
+    preserveForDefer: Bool,
+    preserveForQuestion: Bool,
+    preserveForReturn: Bool,
+) -> GcFrameSlot {
+    GcFrameSlot {
+        slot,
+        kind,
+        name,
+        byteOffset,
+        pointer,
+        derivedFrom: -1,
+        preserveForDefer,
+        preserveForQuestion,
+        preserveForReturn,
+    }
+}
+
+pub fn gcDerivedFrameSlot(
+    slot: Int,
+    kind: GcFrameSlotKind,
+    name: String,
+    byteOffset: Int,
+    derivedFrom: Int,
+) -> GcFrameSlot {
+    GcFrameSlot {
+        slot,
+        kind,
+        name,
+        byteOffset,
+        pointer: true,
+        derivedFrom,
+        preserveForDefer: false,
+        preserveForQuestion: false,
+        preserveForReturn: false,
+    }
+}
+
+pub fn buildGcStackMap(
+    plan: GcSafepointPlan,
+    frameLayout: List<GcFrameSlot>,
+    inlineSlots: Int,
+) -> Result<GcStackMap, String> {
+    match validateSafepointPlan(plan) {
+        Ok(_) -> {},
+        Err(e) -> {
+            return Err(e)
+        },
+    }
+
+    match validateFrameLayout(plan, frameLayout) {
+        Ok(_) -> {},
+        Err(e) -> {
+            return Err(e)
+        },
+    }
+
+    let inline = normalizeInlineSlots(inlineSlots, plan.frameSlots)
+    let mut entries: List<GcStackMapEntry> = []
+    for point in plan.safepoints {
+        match validateSafepointAgainstFrameLayout(point, frameLayout) {
+            Ok(_) -> {},
+            Err(e) -> {
+                return Err(e)
+            },
+        }
+        entries.push(buildStackMapEntry(point, inline))
+    }
+
+    Ok(
+        GcStackMap {
+            functionName: plan.functionName,
+            frameSlots: plan.frameSlots,
+            pointerSize: 8,
+            inlineSlots: inline,
+            frameLayout,
+            entries,
+        },
+    )
+}
+
+pub fn stackMapEntryFor(map: GcStackMap, safepointId: Int) -> GcStackMapEntry? {
+    for entry in map.entries {
+        if entry.safepointId == safepointId {
+            return Some(entry)
+        }
+    }
+    None
+}
+
+pub fn stackMapHasPointer(entry: GcStackMapEntry, slot: Int) -> Bool {
+    if slot < 0 {
+        return false
+    }
+    if slot < entry.inlineSlots {
+        let word = slot / 32
+        if word < 0 || word >= entry.bitmapWords.len() {
+            return false
+        }
+        let mask = 1 << (slot % 32)
+        return (entry.bitmapWords[word] & mask) != 0
+    }
+
+    entry.overflowSlots.contains(slot)
+}
+
+fn newGcObject(id: Int, kind: ObjectKind, size: Int, address: Int, cycle: Int, large: Bool) -> GcObject {
+    let refs: List<Int> = []
+    let generation = if large {
+        1
+    } else {
+        0
+    }
+    let region = if large {
+        GcHumongousRegion
+    } else {
+        GcEdenRegion
+    }
+    GcObject {
+        id,
+        kind,
+        size,
+        address,
+        generation,
+        age: 0,
+        color: GcWhite,
+        marked: false,
+        pinned: false,
+        large,
+        region,
+        refs,
+        remembered: false,
+        allocatedCycle: cycle,
+    }
+}
+
+fn validateSafepoint(plan: GcSafepointPlan, point: GcSafepoint) -> Result<(), String> {
+    if point.irNode < 0 {
+        return Err("safepoint {point.id} has negative IR node")
+    }
+    if point.instructionOffset < 0 {
+        return Err("safepoint {point.id} has negative instruction offset")
+    }
+    if !(point.mayCollect) {
+        return Err("safepoint {point.id} cannot run collector work")
+    }
+    if !(point.requiresStackMap) {
+        return Err("safepoint {point.id} is missing required stack map")
+    }
+    if point.kind == GcAllocationSafepoint && !(point.mayAllocate) {
+        return Err("allocation safepoint {point.id} must be marked mayAllocate")
+    }
+    if point.kind == GcAsyncYieldSafepoint && !(point.maySuspend) {
+        return Err("async yield safepoint {point.id} must be marked maySuspend")
+    }
+
+    let empty: List<Int> = []
+    let mut seenSlots = empty.toSet()
+    for root in point.liveRoots {
+        if root.slot < 0 || root.slot >= plan.frameSlots {
+            return Err("safepoint {point.id} root slot {root.slot} is outside frame")
+        }
+        if root.name == "" {
+            return Err("safepoint {point.id} root slot {root.slot} is unnamed")
+        }
+        if seenSlots.contains(root.slot) {
+            return Err("safepoint {point.id} has duplicate root slot {root.slot}")
+        }
+        seenSlots.insert(root.slot)
+
+        if root.kind == GcDerivedRootSlot {
+            if root.derivedFrom < 0 {
+                return Err("derived root slot {root.slot} has no base slot")
+            }
+            if root.derivedFrom == root.slot {
+                return Err("derived root slot {root.slot} cannot derive from itself")
+            }
+            if !(safepointHasRootSlot(point.liveRoots, root.derivedFrom)) {
+                return Err(
+                    "derived root slot {root.slot} references missing base slot {root.derivedFrom}",
+                )
+            }
+        } else if root.derivedFrom >= 0 {
+            return Err("non-derived root slot {root.slot} has derivedFrom metadata")
+        }
+    }
+
+    Ok(())
+}
+
+fn safepointHasRootSlot(roots: List<GcLiveRootSlot>, slot: Int) -> Bool {
+    for root in roots {
+        if root.slot == slot {
+            return true
+        }
+    }
+    false
+}
+
+fn safepointMayAllocate(kind: GcSafepointKind) -> Bool {
+    kind == GcCallSafepoint || kind == GcAllocationSafepoint
+}
+
+fn validateFrameLayout(plan: GcSafepointPlan, frameLayout: List<GcFrameSlot>) -> Result<(), String> {
+    let empty: List<Int> = []
+    let mut seenSlots = empty.toSet()
+
+    for slot in frameLayout {
+        if slot.slot < 0 || slot.slot >= plan.frameSlots {
+            return Err("frame slot {slot.slot} is outside frame")
+        }
+        if seenSlots.contains(slot.slot) {
+            return Err("duplicate frame slot {slot.slot}")
+        }
+        seenSlots.insert(slot.slot)
+        if slot.name == "" {
+            return Err("frame slot {slot.slot} is unnamed")
+        }
+        if slot.byteOffset < 0 {
+            return Err("frame slot {slot.slot} has negative byte offset")
+        }
+        if slot.derivedFrom >= 0 {
+            if !(slot.pointer) {
+                return Err("derived frame slot {slot.slot} must be a pointer")
+            }
+            if slot.derivedFrom == slot.slot {
+                return Err("derived frame slot {slot.slot} cannot derive from itself")
+            }
+            if !(frameLayoutHasPointerSlot(frameLayout, slot.derivedFrom)) {
+                return Err(
+                    "derived frame slot {slot.slot} references missing pointer base {slot.derivedFrom}",
+                )
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validateSafepointAgainstFrameLayout(point: GcSafepoint, frameLayout: List<GcFrameSlot>) -> Result<(), String> {
+    for root in point.liveRoots {
+        let frame = frameLayoutSlot(frameLayout, root.slot)
+        match frame {
+            Some(slot) -> {
+                if !(slot.pointer) {
+                    return Err("safepoint {point.id} marks non-pointer frame slot {root.slot} live")
+                }
+                if !(rootKindMatchesFrameSlot(root.kind, slot.kind)) {
+                    return Err(
+                        "safepoint {point.id} root slot {root.slot} has incompatible frame slot kind",
+                    )
+                }
+                if root.kind == GcDerivedRootSlot && slot.derivedFrom >= 0 && slot.derivedFrom != root.derivedFrom {
+                    return Err("derived root slot {root.slot} disagrees with frame layout base")
+                }
+            },
+            None -> {
+                return Err("safepoint {point.id} references missing frame slot {root.slot}")
+            },
+        }
+    }
+
+    for slot in frameLayout {
+        if point.runsDefer && slot.pointer && slot.preserveForDefer && !(safepointHasRootSlot(
+            point.liveRoots,
+            slot.slot,
+        )) {
+            return Err("safepoint {point.id} drops defer-preserved root slot {slot.slot}")
+        }
+        if point.questionExit && slot.pointer && slot.preserveForQuestion && !(safepointHasRootSlot(
+            point.liveRoots,
+            slot.slot,
+        )) {
+            return Err("safepoint {point.id} drops question-preserved root slot {slot.slot}")
+        }
+        if point.earlyReturn && slot.pointer && slot.preserveForReturn && !(safepointHasRootSlot(
+            point.liveRoots,
+            slot.slot,
+        )) {
+            return Err("safepoint {point.id} drops return-preserved root slot {slot.slot}")
+        }
+    }
+
+    Ok(())
+}
+
+fn buildStackMapEntry(point: GcSafepoint, inlineSlots: Int) -> GcStackMapEntry {
+    let mut bitmapWords = zeroBitmapWords(inlineSlots)
+    let mut overflowSlots: List<Int> = []
+    let mut derivedRoots: List<GcDerivedRootMap> = []
+
+    for root in point.liveRoots {
+        if root.slot < inlineSlots {
+            let word = root.slot / 32
+            let mask = 1 << (root.slot % 32)
+            bitmapWords[word] = bitmapWords[word] | mask
+        } else {
+            overflowSlots.push(root.slot)
+        }
+        if root.kind == GcDerivedRootSlot {
+            derivedRoots.push(
+                GcDerivedRootMap {
+                    derivedSlot: root.slot,
+                    baseSlot: root.derivedFrom,
+                },
+            )
+        }
+    }
+
+    GcStackMapEntry {
+        safepointId: point.id,
+        instructionOffset: point.instructionOffset,
+        liveCount: point.liveRoots.len(),
+        inlineSlots,
+        bitmapWords,
+        overflowSlots,
+        derivedRoots,
+    }
+}
+
+fn zeroBitmapWords(inlineSlots: Int) -> List<Int> {
+    let mut words: List<Int> = []
+    for idx in 0..bitmapWordCount(inlineSlots) {
+        let _ = idx
+        words.push(0)
+    }
+    words
+}
+
+fn bitmapWordCount(inlineSlots: Int) -> Int {
+    if inlineSlots <= 0 {
+        0
+    } else {
+        (inlineSlots + 31) / 32
+    }
+}
+
+fn normalizeInlineSlots(inlineSlots: Int, frameSlots: Int) -> Int {
+    if inlineSlots <= 0 {
+        frameSlots
+    } else if inlineSlots > frameSlots {
+        frameSlots
+    } else {
+        inlineSlots
+    }
+}
+
+fn frameLayoutSlot(frameLayout: List<GcFrameSlot>, slotId: Int) -> GcFrameSlot? {
+    for slot in frameLayout {
+        if slot.slot == slotId {
+            return Some(slot)
+        }
+    }
+    None
+}
+
+fn frameLayoutHasPointerSlot(frameLayout: List<GcFrameSlot>, slotId: Int) -> Bool {
+    match frameLayoutSlot(frameLayout, slotId) {
+        Some(slot) -> slot.pointer,
+        None -> false,
+    }
+}
+
+fn rootKindMatchesFrameSlot(rootKind: GcRootSlotKind, frameKind: GcFrameSlotKind) -> Bool {
+    match rootKind {
+        GcRegisterRootSlot -> frameKind == GcFrameRegisterSpillSlot,
+        GcSpillRootSlot -> frameKind == GcFrameRegisterSpillSlot,
+        GcTemporaryRootSlot -> frameKind == GcFrameTemporarySlot,
+        GcClosureRootSlot -> frameKind == GcFrameClosureCaptureSlot,
+        GcDerivedRootSlot -> true,
+        GcLocalRootSlot -> frameKind == GcFrameLocalSlot || frameKind == GcFrameTupleFieldSlot || frameKind == GcFrameDeferSlot || frameKind == GcFrameQuestionSlot || frameKind == GcFrameReturnSlot,
+    }
+}
+
+fn normalizeSize(size: Int) -> Int {
+    if size <= 0 {
+        1
+    } else {
+        size
+    }
+}
+
+fn regionForObject(obj: GcObject) -> GcRegionKind {
+    if obj.pinned {
+        GcPinnedRegion
+    } else if obj.large {
+        GcHumongousRegion
+    } else if obj.generation == 0 {
+        if obj.age > 0 {
+            GcSurvivorRegion
+        } else {
+            GcEdenRegion
+        }
+    } else {
+        GcOldRegion
+    }
+}
+
+fn percent(part: Int, whole: Int) -> Int {
+    if whole <= 0 {
+        0
+    } else {
+        part * 100 / whole
+    }
+}
+
+fn telemetryPauseUnits(
+    markSteps: Int,
+    reclaimedObjects: Int,
+    promotedObjects: Int,
+    compactedObjects: Int,
+    rememberedScanned: Int,
+) -> Int {
+    markSteps + reclaimedObjects + promotedObjects + compactedObjects + rememberedScanned
+}
+
+fn emptyStats(kind: String, heap: GcHeap) -> GcStats {
+    let fragmented = heap.fragmentedBytes()
+    GcStats {
+        kind,
+        trigger: "idle",
+        cycle: heap.cycle,
+        beforeObjects: heap.objectCount(),
+        afterObjects: heap.objectCount(),
+        reclaimedObjects: 0,
+        beforeBytes: heap.totalLiveBytes(),
+        afterBytes: heap.totalLiveBytes(),
+        reclaimedBytes: 0,
+        promotedObjects: 0,
+        compactedObjects: 0,
+        rememberedScanned: 0,
+        markSteps: 0,
+        pauseUnits: 0,
+        allocationBytesSinceLastGC: heap.allocatedSinceLastGC,
+        beforeFragmentedBytes: fragmented,
+        afterFragmentedBytes: fragmented,
+        fragmentedBytes: heap.fragmentedBytes(),
+        survivalPercent: percent(heap.objectCount(), heap.objectCount()),
+        promotionPercent: 0,
+    }
+}

--- a/examples/gc/lib_test.osty
+++ b/examples/gc/lib_test.osty
@@ -1,0 +1,804 @@
+use std.testing
+
+fn assertValid(heap: GcHeap) {
+    match heap.validateHeap() {
+        Ok(_) -> {},
+        Err(e) -> testing.fail(e),
+    }
+}
+
+fn emptyTestStackMap() -> GcStackMap {
+    let frameLayout: List<GcFrameSlot> = []
+    let entries: List<GcStackMapEntry> = []
+    GcStackMap {
+        functionName: "",
+        frameSlots: 0,
+        pointerSize: 0,
+        inlineSlots: 0,
+        frameLayout,
+        entries,
+    }
+}
+
+fn emptyTestStackMapEntry() -> GcStackMapEntry {
+    let bitmapWords: List<Int> = []
+    let overflowSlots: List<Int> = []
+    let derivedRoots: List<GcDerivedRootMap> = []
+    GcStackMapEntry {
+        safepointId: 0,
+        instructionOffset: 0,
+        liveCount: 0,
+        inlineSlots: 0,
+        bitmapWords,
+        overflowSlots,
+        derivedRoots,
+    }
+}
+
+fn testValidateHeapRejectsLiveByteMismatch() {
+    let refs: List<Int> = []
+    let mut objects: Map<Int, GcObject> = {:}
+    objects.insert(
+        1,
+        GcObject {
+            id: 1,
+            kind: GcRecord,
+            size: 16,
+            address: 0,
+            generation: 0,
+            age: 0,
+            color: GcWhite,
+            marked: false,
+            pinned: false,
+            large: false,
+            region: GcEdenRegion,
+            refs,
+            remembered: false,
+            allocatedCycle: 0,
+        },
+    )
+    let empty: List<Int> = []
+    let heap = GcHeap {
+        config: testGcConfig(),
+        nextId: 2,
+        nextAddress: 16,
+        liveBytes: 15,
+        cycle: 0,
+        minorCollections: 0,
+        majorCollections: 0,
+        phase: GcIdle,
+        objects,
+        roots: empty.toSet(),
+        remembered: empty.toSet(),
+        grey: [],
+        allocatedSinceLastGC: 16,
+        lastStats: None,
+    }
+
+    let _ = testing.expectError(heap.validateHeap())
+}
+
+fn testValidateHeapRejectsMissingRememberedEdge() {
+    let refs: List<Int> = [2]
+    let mut objects: Map<Int, GcObject> = {:}
+    objects.insert(
+        1,
+        GcObject {
+            id: 1,
+            kind: GcRecord,
+            size: 16,
+            address: 0,
+            generation: 1,
+            age: 1,
+            color: GcWhite,
+            marked: false,
+            pinned: false,
+            large: false,
+            region: GcOldRegion,
+            refs,
+            remembered: false,
+            allocatedCycle: 0,
+        },
+    )
+    objects.insert(
+        2,
+        GcObject {
+            id: 2,
+            kind: GcArray,
+            size: 16,
+            address: 16,
+            generation: 0,
+            age: 0,
+            color: GcWhite,
+            marked: false,
+            pinned: false,
+            large: false,
+            region: GcEdenRegion,
+            refs: [],
+            remembered: false,
+            allocatedCycle: 0,
+        },
+    )
+    let empty: List<Int> = []
+    let heap = GcHeap {
+        config: testGcConfig(),
+        nextId: 3,
+        nextAddress: 32,
+        liveBytes: 32,
+        cycle: 0,
+        minorCollections: 0,
+        majorCollections: 0,
+        phase: GcIdle,
+        objects,
+        roots: empty.toSet(),
+        remembered: empty.toSet(),
+        grey: [],
+        allocatedSinceLastGC: 32,
+        lastStats: None,
+    }
+
+    let _ = testing.expectError(heap.validateHeap())
+}
+
+fn testTelemetryRecordsManualMajorWork() {
+    let mut heap = newGcHeap(testGcConfig())
+    let first = heap.allocate(GcRecord, 10)
+    let dead = heap.allocate(GcBytes, 20)
+    let last = heap.allocate(GcRecord, 30)
+    testing.assert(heap.addRoot(first))
+    testing.assert(heap.addRoot(last))
+    assertValid(heap)
+
+    let stats = heap.majorCollect()
+    assertValid(heap)
+
+    testing.assert(!(heap.contains(dead)))
+    testing.assertEq(stats.kind, "major")
+    testing.assertEq(stats.trigger, "manual")
+    testing.assertEq(stats.allocationBytesSinceLastGC, 60)
+    testing.assertEq(stats.beforeFragmentedBytes, 0)
+    testing.assertEq(stats.afterFragmentedBytes, 0)
+    testing.assertEq(stats.survivalPercent, 66)
+    testing.assert(stats.pauseUnits > 0)
+}
+
+fn testTelemetryRecordsNurseryPressureTrigger() {
+    let mut heap = newGcHeap(
+        GcConfig {
+            nurseryLimit: 24,
+            heapLimit: 4096,
+            promotionAge: 1,
+            incrementalBudget: 1,
+            largeObjectThreshold: 512,
+        },
+    )
+    let first = heap.allocate(GcRecord, 16)
+    assertValid(heap)
+
+    let mut second = 0
+    match heap.tryAllocate(GcArray, 16) {
+        Ok(id) -> {
+            second = id
+        },
+        Err(e) -> testing.fail(e),
+    }
+    assertValid(heap)
+
+    testing.assert(!(heap.contains(first)))
+    testing.assert(heap.contains(second))
+    match heap.lastCollectionStats() {
+        Some(stats) -> {
+            testing.assertEq(stats.kind, "minor")
+            testing.assertEq(stats.trigger, "nursery-pressure")
+            testing.assertEq(stats.allocationBytesSinceLastGC, 16)
+            testing.assertEq(stats.survivalPercent, 0)
+            testing.assert(stats.pauseUnits > 0)
+        },
+        None -> testing.fail("missing last collection stats"),
+    }
+}
+
+fn testLargeObjectBypassesNurseryAndStartsHumongous() {
+    let mut heap = newGcHeap(
+        GcConfig {
+            nurseryLimit: 24,
+            heapLimit: 4096,
+            promotionAge: 1,
+            incrementalBudget: 1,
+            largeObjectThreshold: 32,
+        },
+    )
+    let small = heap.allocate(GcRecord, 16)
+    assertValid(heap)
+
+    let large = heap.allocate(GcBytes, 64)
+    assertValid(heap)
+
+    testing.assert(heap.contains(small))
+    testing.assert(heap.contains(large))
+    testing.assert(heap.isLarge(large) ?? false)
+    testing.assertEq(heap.regionOf(large) ?? GcEdenRegion, GcHumongousRegion)
+    testing.assertEq(heap.generationOf(large) ?? -1, 1)
+    testing.assertEq(heap.nurseryBytes(), 16)
+    testing.assertEq(heap.largeObjectCount(), 1)
+    match heap.lastCollectionStats() {
+        Some(_) -> testing.fail("large allocation unexpectedly triggered collection"),
+        None -> {},
+    }
+
+    testing.assert(heap.addRoot(large))
+    let stats = heap.majorCollect()
+    assertValid(heap)
+
+    testing.assert(!(heap.contains(small)))
+    testing.assertEq(heap.addressOf(large) ?? -1, 16)
+    testing.assertEq(stats.afterFragmentedBytes, 16)
+}
+
+fn testMajorCollectionReclaimsCycles() {
+    let mut heap = newGcHeap(testGcConfig())
+    assertValid(heap)
+
+    let anchor = heap.allocate(GcRecord, 16)
+    let left = heap.allocate(GcRecord, 24)
+    let right = heap.allocate(GcRecord, 24)
+    assertValid(heap)
+
+    testing.assert(heap.addRoot(anchor))
+    testing.assert(heap.link(anchor, left))
+    testing.assert(heap.link(left, right))
+    testing.assert(heap.link(right, left))
+    assertValid(heap)
+
+    testing.assert(heap.unlink(anchor, left))
+    let stats = heap.majorCollect()
+    assertValid(heap)
+
+    testing.assert(heap.contains(anchor))
+    testing.assert(!(heap.contains(left)))
+    testing.assert(!(heap.contains(right)))
+    testing.assertEq(stats.reclaimedObjects, 2)
+    testing.assertEq(stats.reclaimedBytes, 48)
+}
+
+fn testMinorCollectionUsesRememberedSetAndPromotes() {
+    let mut heap = newGcHeap(testGcConfig())
+    let parent = heap.allocate(GcRecord, 16)
+    testing.assert(heap.addRoot(parent))
+    assertValid(heap)
+
+    let _ = heap.majorCollect()
+    assertValid(heap)
+    testing.assertEq(heap.generationOf(parent) ?? -1, 1)
+
+    let child = heap.allocate(GcArray, 32)
+    testing.assert(heap.link(parent, child))
+    assertValid(heap)
+    testing.assertEq(heap.rememberedCount(), 1)
+
+    let stats = heap.minorCollect()
+    assertValid(heap)
+    testing.assert(heap.contains(child))
+    testing.assertEq(heap.generationOf(child) ?? -1, 1)
+    testing.assertEq(stats.promotedObjects, 1)
+    testing.assertEq(stats.rememberedScanned, 1)
+    testing.assertEq(heap.rememberedCount(), 0)
+}
+
+fn testNurseryCycleDiesWithoutRoots() {
+    let mut heap = newGcHeap(testGcConfig())
+    let left = heap.allocate(GcRecord, 16)
+    let right = heap.allocate(GcRecord, 16)
+    assertValid(heap)
+
+    testing.assert(heap.link(left, right))
+    testing.assert(heap.link(right, left))
+    assertValid(heap)
+
+    let stats = heap.minorCollect()
+    assertValid(heap)
+    testing.assert(!(heap.contains(left)))
+    testing.assert(!(heap.contains(right)))
+    testing.assertEq(stats.reclaimedObjects, 2)
+}
+
+fn testIncrementalWriteBarrierKeepsNewBlackToWhiteEdge() {
+    let mut heap = newGcHeap(testGcConfig())
+    let root = heap.allocate(GcRecord, 16)
+    let existing = heap.allocate(GcRecord, 16)
+    let late = heap.allocate(GcClosure, 16)
+
+    testing.assert(heap.addRoot(root))
+    testing.assert(heap.link(root, existing))
+    assertValid(heap)
+
+    heap.startIncrementalMajor()
+    assertValid(heap)
+    let markStats = heap.stepIncremental()
+    assertValid(heap)
+    testing.assertEq(markStats.kind, "incremental-mark")
+    testing.assertEq(heap.phaseNow(), GcMarking)
+
+    testing.assert(heap.link(root, late))
+    assertValid(heap)
+    let done = heap.finishIncremental()
+    assertValid(heap)
+
+    testing.assertEq(done.kind, "incremental-sweep")
+    testing.assert(heap.contains(root))
+    testing.assert(heap.contains(existing))
+    testing.assert(heap.contains(late))
+    testing.assertEq(heap.phaseNow(), GcIdle)
+}
+
+fn testMajorCompactionClosesHoles() {
+    let mut heap = newGcHeap(testGcConfig())
+    let first = heap.allocate(GcRecord, 10)
+    let dead = heap.allocate(GcBytes, 20)
+    let last = heap.allocate(GcRecord, 30)
+
+    testing.assert(heap.addRoot(first))
+    testing.assert(heap.addRoot(last))
+    assertValid(heap)
+    let beforeLast = heap.addressOf(last) ?? -1
+
+    let stats = heap.majorCollect()
+    assertValid(heap)
+    let afterLast = heap.addressOf(last) ?? -1
+
+    testing.assert(!(heap.contains(dead)))
+    testing.assert(afterLast < beforeLast)
+    testing.assertEq(afterLast, 10)
+    testing.assertEq(stats.reclaimedObjects, 1)
+    testing.assertEq(stats.compactedObjects, 1)
+    testing.assertEq(heap.fragmentedBytes(), 0)
+}
+
+fn testPinnedObjectLeavesCompactionHoleUntilUnpinned() {
+    let mut heap = newGcHeap(testGcConfig())
+    let dead = heap.allocate(GcBytes, 20)
+    let pinned = heap.allocate(GcRecord, 20)
+    let tail = heap.allocate(GcArray, 10)
+
+    testing.assert(heap.addRoot(pinned))
+    testing.assert(heap.addRoot(tail))
+    testing.assert(heap.pin(pinned))
+    assertValid(heap)
+
+    let first = heap.majorCollect()
+    assertValid(heap)
+
+    testing.assert(!(heap.contains(dead)))
+    testing.assertEq(heap.addressOf(pinned) ?? -1, 20)
+    testing.assertEq(heap.addressOf(tail) ?? -1, 40)
+    testing.assertEq(heap.regionOf(pinned) ?? GcEdenRegion, GcPinnedRegion)
+    testing.assertEq(heap.pinnedObjectCount(), 1)
+    testing.assertEq(first.reclaimedObjects, 1)
+    testing.assertEq(first.afterFragmentedBytes, 20)
+    testing.assertEq(heap.fragmentedBytes(), 20)
+
+    testing.assert(heap.unpin(pinned))
+    assertValid(heap)
+    let second = heap.majorCollect()
+    assertValid(heap)
+
+    testing.assertEq(heap.regionOf(pinned) ?? GcEdenRegion, GcOldRegion)
+    testing.assertEq(heap.addressOf(pinned) ?? -1, 0)
+    testing.assertEq(heap.addressOf(tail) ?? -1, 20)
+    testing.assertEq(heap.pinnedObjectCount(), 0)
+    testing.assertEq(second.afterFragmentedBytes, 0)
+    testing.assertEq(second.compactedObjects, 2)
+    testing.assertEq(heap.fragmentedBytes(), 0)
+}
+
+fn testTryAllocateReportsOutOfMemoryAfterFullCollection() {
+    let mut heap = newGcHeap(
+        GcConfig {
+            nurseryLimit: 64,
+            heapLimit: 40,
+            promotionAge: 1,
+            incrementalBudget: 4,
+            largeObjectThreshold: 512,
+        },
+    )
+    let rooted = heap.allocate(GcRecord, 32)
+    testing.assert(heap.addRoot(rooted))
+    assertValid(heap)
+
+    let out = heap.tryAllocate(GcArray, 16)
+    assertValid(heap)
+    testing.expectError(out)
+    match heap.lastCollectionStats() {
+        Some(stats) -> {
+            testing.assertEq(stats.kind, "major")
+            testing.assertEq(stats.trigger, "heap-pressure")
+            testing.assertEq(stats.allocationBytesSinceLastGC, 32)
+        },
+        None -> testing.fail("missing heap-pressure stats"),
+    }
+    testing.assert(heap.contains(rooted))
+    testing.assertEq(heap.totalLiveBytes(), 32)
+}
+
+fn testSafepointPlanValidatesPreciseLiveRoots() {
+    let callRoots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "payload"),
+        gcRootSlot(1, GcSpillRootSlot, "env"),
+    ]
+    let allocRoots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "payload"),
+        gcRootSlot(3, GcTemporaryRootSlot, "pending"),
+    ]
+    let loopRoots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "payload"),
+        gcDerivedRootSlot(2, "payload.field", 0),
+    ]
+    let asyncRoots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "payload"),
+        gcRootSlot(4, GcClosureRootSlot, "task.frame"),
+    ]
+    let safepoints: List<GcSafepoint> = [
+        gcSafepoint(1, GcCallSafepoint, 10, 32, callRoots),
+        gcSafepoint(2, GcAllocationSafepoint, 14, 48, allocRoots),
+        gcSafepoint(3, GcLoopBackedgeSafepoint, 21, 80, loopRoots),
+        gcSafepoint(4, GcAsyncYieldSafepoint, 30, 120, asyncRoots),
+    ]
+    let plan = gcSafepointPlan("renderFrame", 6, safepoints)
+
+    match validateSafepointPlan(plan) {
+        Ok(_) -> {},
+        Err(e) -> testing.fail(e),
+    }
+
+    testing.assert(plan.safepoints[0].mayAllocate)
+    testing.assert(plan.safepoints[1].mayAllocate)
+    testing.assert(!(plan.safepoints[2].mayAllocate))
+    testing.assert(plan.safepoints[3].maySuspend)
+}
+
+fn testSafepointPlanRejectsMissingStackMap() {
+    let roots: List<GcLiveRootSlot> = [gcRootSlot(0, GcLocalRootSlot, "value")]
+    let mut point = gcSafepoint(1, GcAllocationSafepoint, 4, 12, roots)
+    point.requiresStackMap = false
+    let safepoints: List<GcSafepoint> = [point]
+    let plan = gcSafepointPlan("badAlloc", 2, safepoints)
+
+    let _ = testing.expectError(validateSafepointPlan(plan))
+}
+
+fn testSafepointPlanRejectsDuplicateRootSlots() {
+    let roots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "left"),
+        gcRootSlot(0, GcSpillRootSlot, "right"),
+    ]
+    let safepoints: List<GcSafepoint> = [gcSafepoint(1, GcCallSafepoint, 7, 24, roots)]
+    let plan = gcSafepointPlan("badDuplicate", 2, safepoints)
+
+    let _ = testing.expectError(validateSafepointPlan(plan))
+}
+
+fn testSafepointPlanRejectsDanglingDerivedRoot() {
+    let roots: List<GcLiveRootSlot> = [gcDerivedRootSlot(2, "slice.data", 0)]
+    let safepoints: List<GcSafepoint> = [gcSafepoint(1, GcLoopBackedgeSafepoint, 9, 28, roots)]
+    let plan = gcSafepointPlan("badDerived", 4, safepoints)
+
+    let _ = testing.expectError(validateSafepointPlan(plan))
+}
+
+fn testStackMapBuildsBitmapOverflowAndDerivedRoots() {
+    let roots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "payload"),
+        gcRootSlot(1, GcSpillRootSlot, "saved.r1"),
+        gcRootSlot(3, GcClosureRootSlot, "env.capture"),
+        gcDerivedRootSlot(4, "payload.field", 0),
+        gcRootSlot(9, GcTemporaryRootSlot, "scratch"),
+    ]
+    let safepoints: List<GcSafepoint> = [gcSafepoint(1, GcCallSafepoint, 11, 64, roots)]
+    let plan = gcSafepointPlan("stacky", 12, safepoints)
+    let layout: List<GcFrameSlot> = [
+        gcFrameSlot(0, GcFrameLocalSlot, "payload", 0, true),
+        gcFrameSlot(1, GcFrameRegisterSpillSlot, "saved.r1", 8, true),
+        gcFrameSlot(2, GcFrameTemporarySlot, "unused.temp", 16, true),
+        gcFrameSlot(3, GcFrameClosureCaptureSlot, "env.capture", 24, true),
+        gcDerivedFrameSlot(4, GcFrameTupleFieldSlot, "payload.field", 32, 0),
+        gcFrameSlot(5, GcFrameLocalSlot, "scalar", 40, false),
+        gcFrameSlot(9, GcFrameTemporarySlot, "scratch", 72, true),
+    ]
+
+    let mut map = emptyTestStackMap()
+    match buildGcStackMap(plan, layout, 8) {
+        Ok(next) -> {
+            map = next
+        },
+        Err(e) -> testing.fail(e),
+    }
+
+    let mut entry = emptyTestStackMapEntry()
+    match stackMapEntryFor(map, 1) {
+        Some(next) -> {
+            entry = next
+        },
+        None -> testing.fail("missing stack map entry"),
+    }
+
+    testing.assertEq(map.functionName, "stacky")
+    testing.assertEq(map.pointerSize, 8)
+    testing.assertEq(map.inlineSlots, 8)
+    testing.assertEq(entry.liveCount, 5)
+    testing.assertEq(entry.bitmapWords[0], 27)
+    testing.assertEq(entry.overflowSlots.len(), 1)
+    testing.assertEq(entry.overflowSlots[0], 9)
+    testing.assertEq(entry.derivedRoots.len(), 1)
+    testing.assertEq(entry.derivedRoots[0].derivedSlot, 4)
+    testing.assertEq(entry.derivedRoots[0].baseSlot, 0)
+    testing.assert(stackMapHasPointer(entry, 0))
+    testing.assert(!(stackMapHasPointer(entry, 2)))
+    testing.assert(!(stackMapHasPointer(entry, 5)))
+    testing.assert(stackMapHasPointer(entry, 9))
+}
+
+fn testStackMapRejectsMissingOrScalarRootSlots() {
+    let scalarRoots: List<GcLiveRootSlot> = [gcRootSlot(1, GcLocalRootSlot, "scalar")]
+    let scalarPoints: List<GcSafepoint> = [gcSafepoint(1, GcCallSafepoint, 5, 16, scalarRoots)]
+    let scalarPlan = gcSafepointPlan("badScalar", 3, scalarPoints)
+    let scalarLayout: List<GcFrameSlot> = [
+        gcFrameSlot(0, GcFrameLocalSlot, "payload", 0, true),
+        gcFrameSlot(1, GcFrameLocalSlot, "scalar", 8, false),
+    ]
+    let _ = testing.expectError(buildGcStackMap(scalarPlan, scalarLayout, 8))
+
+    let missingRoots: List<GcLiveRootSlot> = [gcRootSlot(2, GcLocalRootSlot, "missing")]
+    let missingPoints: List<GcSafepoint> = [gcSafepoint(1, GcCallSafepoint, 6, 20, missingRoots)]
+    let missingPlan = gcSafepointPlan("badMissing", 3, missingPoints)
+    let missingLayout: List<GcFrameSlot> = [gcFrameSlot(0, GcFrameLocalSlot, "payload", 0, true)]
+    let _ = testing.expectError(buildGcStackMap(missingPlan, missingLayout, 8))
+}
+
+fn testStackMapPreservesDeferQuestionAndEarlyReturnRoots() {
+    let roots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "defer.env"),
+        gcRootSlot(1, GcLocalRootSlot, "question.value"),
+        gcRootSlot(2, GcLocalRootSlot, "return.value"),
+    ]
+    let mut point = gcSafepoint(1, GcCallSafepoint, 12, 44, roots)
+    point.runsDefer = true
+    point.questionExit = true
+    point.earlyReturn = true
+    let safepoints: List<GcSafepoint> = [point]
+    let plan = gcSafepointPlan("cleanupPaths", 4, safepoints)
+    let layout: List<GcFrameSlot> = [
+        gcPreservedFrameSlot(0, GcFrameDeferSlot, "defer.env", 0, true, true, false, false),
+        gcPreservedFrameSlot(1, GcFrameQuestionSlot, "question.value", 8, true, false, true, false),
+        gcPreservedFrameSlot(2, GcFrameReturnSlot, "return.value", 16, true, false, false, true),
+    ]
+
+    let mut map = emptyTestStackMap()
+    match buildGcStackMap(plan, layout, 4) {
+        Ok(next) -> {
+            map = next
+        },
+        Err(e) -> testing.fail(e),
+    }
+
+    let entry = stackMapEntryFor(map, 1) ?? emptyTestStackMapEntry()
+    testing.assertEq(entry.bitmapWords[0], 7)
+
+    let badRoots: List<GcLiveRootSlot> = [
+        gcRootSlot(0, GcLocalRootSlot, "defer.env"),
+        gcRootSlot(2, GcLocalRootSlot, "return.value"),
+    ]
+    let mut badPoint = gcSafepoint(1, GcCallSafepoint, 12, 44, badRoots)
+    badPoint.runsDefer = true
+    badPoint.questionExit = true
+    badPoint.earlyReturn = true
+    let badPoints: List<GcSafepoint> = [badPoint]
+    let badPlan = gcSafepointPlan("cleanupPathsBad", 4, badPoints)
+    let badLayout: List<GcFrameSlot> = [
+        gcPreservedFrameSlot(0, GcFrameDeferSlot, "defer.env", 0, true, true, false, false),
+        gcPreservedFrameSlot(1, GcFrameQuestionSlot, "question.value", 8, true, false, true, false),
+        gcPreservedFrameSlot(2, GcFrameReturnSlot, "return.value", 16, true, false, false, true),
+    ]
+    let _ = testing.expectError(buildGcStackMap(badPlan, badLayout, 4))
+}
+
+fn testRandomGraphStressMatchesReferenceModel() {
+    let mut heap = newGcHeap(stressGcConfig())
+    let mut ids: List<Int> = []
+
+    for idx in 0..18 {
+        let id = heap.allocate(stressKind(idx), stressSize(idx * 17))
+        ids.push(id)
+        if idx % 4 == 0 {
+            testing.assert(heap.addRoot(id))
+        }
+        if idx > 0 {
+            let previous = ids[idx - 1]
+            testing.assert(heap.link(previous, id))
+        }
+    }
+
+    assertValid(heap)
+    heap = stressMajorAndCompare(heap, ids)
+
+    for step in 0..120 {
+        let op = stressRand(137, step, 0) % 10
+        if op == 0 {
+            let id = heap.allocate(
+                stressKind(stressRand(137, step, 1)),
+                stressSize(stressRand(137, step, 2)),
+            )
+            ids.push(id)
+            if stressRand(137, step, 3) % 3 == 0 {
+                testing.assert(heap.addRoot(id))
+            }
+        } else if op == 1 {
+            let from = stressIdAt(ids, stressRand(137, step, 4))
+            let to = stressIdAt(ids, stressRand(137, step, 5))
+            let _ = heap.link(from, to)
+        } else if op == 2 {
+            let from = stressIdAt(ids, stressRand(137, step, 6))
+            let to = stressIdAt(ids, stressRand(137, step, 7))
+            let _ = heap.unlink(from, to)
+        } else if op == 3 {
+            let id = stressIdAt(ids, stressRand(137, step, 8))
+            let _ = heap.addRoot(id)
+        } else if op == 4 {
+            let id = stressIdAt(ids, stressRand(137, step, 9))
+            let _ = heap.removeRoot(id)
+        } else if op == 5 {
+            let _ = heap.minorCollect()
+        } else if op == 6 {
+            heap = stressMajorAndCompare(heap, ids)
+        } else if op == 7 {
+            let id = stressIdAt(ids, stressRand(137, step, 10))
+            let _ = heap.pin(id)
+        } else if op == 8 {
+            let id = stressIdAt(ids, stressRand(137, step, 11))
+            let _ = heap.unpin(id)
+        } else {
+            heap = stressIncrementalAndCompare(heap, ids)
+        }
+        assertValid(heap)
+    }
+
+    heap = stressMajorAndCompare(heap, ids)
+    testing.assert(heap.majorCount() > 0)
+    testing.assert(heap.minorCount() > 0)
+}
+
+fn testRandomGraphIncrementalInsertionBarrierStress() {
+    let mut heap = newGcHeap(stressGcConfig())
+    let mut ids: List<Int> = []
+
+    let root = heap.allocate(GcRecord, 16)
+    ids.push(root)
+    testing.assert(heap.addRoot(root))
+
+    for idx in 0..10 {
+        let id = heap.allocate(stressKind(idx), stressSize(idx * 29))
+        ids.push(id)
+        if idx < 5 {
+            testing.assert(heap.link(root, id))
+        } else {
+            let parent = ids[(idx % 5) + 1]
+            testing.assert(heap.link(parent, id))
+        }
+    }
+    assertValid(heap)
+
+    heap.startIncrementalMajor()
+    assertValid(heap)
+    let _ = heap.stepIncremental()
+    assertValid(heap)
+
+    let lateA = heap.allocate(GcClosure, 24)
+    let lateB = heap.allocate(GcArray, 88)
+    ids.push(lateA)
+    ids.push(lateB)
+    testing.assert(heap.link(root, lateA))
+    testing.assert(heap.link(lateA, lateB))
+
+    let expected = stressReachableFromRoots(heap)
+    let _ = heap.finishIncremental()
+    assertValid(heap)
+
+    stressAssertMatchesReachability(heap, ids, expected)
+    testing.assert(heap.contains(lateA))
+    testing.assert(heap.contains(lateB))
+    testing.assertEq(heap.phaseNow(), GcIdle)
+}
+
+fn stressGcConfig() -> GcConfig {
+    GcConfig {
+        nurseryLimit: 96,
+        heapLimit: 32768,
+        promotionAge: 2,
+        incrementalBudget: 3,
+        largeObjectThreshold: 80,
+    }
+}
+
+fn stressRand(seed: Int, step: Int, salt: Int) -> Int {
+    let mut value = (seed + 11) * (step + 3) + salt * 97
+    value = (value * 73 + 41) % 9973
+    if value < 0 {
+        -value
+    } else {
+        value
+    }
+}
+
+fn stressSize(raw: Int) -> Int {
+    8 + raw % 104
+}
+
+fn stressKind(raw: Int) -> ObjectKind {
+    match raw % 5 {
+        0 -> GcRecord,
+        1 -> GcArray,
+        2 -> GcClosure,
+        3 -> GcBytes,
+        _ -> GcRuntimeFrame,
+    }
+}
+
+fn stressIdAt(ids: List<Int>, raw: Int) -> Int {
+    if ids.len() == 0 {
+        -1
+    } else {
+        ids[raw % ids.len()]
+    }
+}
+
+fn stressMajorAndCompare(heap: GcHeap, ids: List<Int>) -> GcHeap {
+    let mut next = heap
+    let expected = stressReachableFromRoots(next)
+    let _ = next.majorCollect()
+    assertValid(next)
+    stressAssertMatchesReachability(next, ids, expected)
+    next
+}
+
+fn stressIncrementalAndCompare(heap: GcHeap, ids: List<Int>) -> GcHeap {
+    let mut next = heap
+    let expected = stressReachableFromRoots(next)
+    next.startIncrementalMajor()
+    let _ = next.finishIncremental()
+    assertValid(next)
+    stressAssertMatchesReachability(next, ids, expected)
+    next
+}
+
+fn stressReachableFromRoots(heap: GcHeap) -> Set<Int> {
+    let empty: List<Int> = []
+    let mut seen = empty.toSet()
+    let mut work: List<Int> = []
+
+    for rootId in heap.roots.toList() {
+        if heap.objects.containsKey(rootId) && !(seen.contains(rootId)) {
+            seen.insert(rootId)
+            work.push(rootId)
+        }
+    }
+
+    for work.len() > 0 {
+        let id = work.pop() ?? -1
+        if id >= 0 && heap.objects.containsKey(id) {
+            let obj = heap.objects[id]
+            for childId in obj.refs {
+                if heap.objects.containsKey(childId) && !(seen.contains(childId)) {
+                    seen.insert(childId)
+                    work.push(childId)
+                }
+            }
+        }
+    }
+
+    seen
+}
+
+fn stressAssertMatchesReachability(heap: GcHeap, ids: List<Int>, expected: Set<Int>) {
+    for id in ids {
+        testing.assertEq(heap.contains(id), expected.contains(id))
+    }
+}

--- a/examples/gc/osty.toml
+++ b/examples/gc/osty.toml
@@ -1,0 +1,13 @@
+# gc - independent garbage-collector core written in Osty.
+#
+# Run from this directory:
+#
+#     osty test
+#     osty check
+
+[package]
+name = "gc"
+version = "0.1.0"
+edition = "0.4"
+
+[dependencies]


### PR DESCRIPTION
## Summary
- add a new `examples/gc` Osty package with a design document and executable GC runtime prototype
- model generational collection, remembered-set barriers, incremental marking, compaction, pinning, large objects, safepoint contracts, and stack maps
- add stress and invariant tests for GC graph correctness and stack-map validation

## Verification
- `go run ./cmd/osty fmt --check examples/gc/lib.osty`
- `go run ./cmd/osty fmt --check examples/gc/lib_test.osty`
- `go run ./cmd/osty check examples/gc`
- `go run ./cmd/osty test examples/gc`
- `go test ./internal/examples`