### PR TITLE
Add LLVM backend migration plumbing

### DIFF
--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -1,0 +1,214 @@
+# LLVM Artifact Layout
+
+이 문서는 LLVM 이주 25-step Phase 4의 산출물이다. 목적은 Go backend와 LLVM
+backend가 같은 project/profile/target에서 동시에 동작해도 생성물이 서로
+덮어쓰지 않도록 artifact layout을 확정하는 것이다.
+
+## Legacy Layout
+
+Phase 6 이전 구현은 Go backend 단일 경로를 전제로 했다.
+
+| Surface | Current path shape | Source |
+|---|---|---|
+| `osty build` generated Go | `<root>/.osty/out/<profile>[-<target>]/main.go` | `profile.OutputDir`, `cmd/osty/build.go` |
+| `osty build` binary | `<root>/.osty/out/<profile>[-<target>]/<bin>[-<target>]` | `cmd/osty/build.go` |
+| `osty run` generated Go | `<root>/.osty/out/<profile>[-<target>]/main.go` | `cmd/osty/run.go` |
+| build fingerprint | `<root>/.osty/cache/<profile>[-<target>].json` | `profile.CachePath` |
+| `osty test` generated harness | `$TMPDIR/osty-test-<pkg-hash>/main.go`, `harness.go` | `cmd/osty/test.go` |
+| `osty test` cached binary | `$TMPDIR/osty-test-<pkg-hash>/osty-test-bin-<hash>` | `cmd/osty/test.go` |
+| publish tarball | `<root>/.osty/publish/<name>-<version>.tgz` | `cmd/osty/publish.go` |
+
+This layout works for one active backend, but LLVM would collide with Go for
+`main.go`, binary names, and cache fingerprints if it reused the same directory.
+
+Phase 6 moved `osty build` and `osty run` Go source/binary artifacts to the
+backend-aware `go/` output directory. The legacy cache path remains in use until
+the cache migration step lands.
+
+## Target Layout
+
+Backend-aware artifacts should use this shape:
+
+```text
+<root>/.osty/out/<profile>[-<target>]/
+  go/
+    main.go
+    <binary>
+  llvm/
+    main.ll
+    main.o
+    <binary>
+    runtime/
+      libosty_runtime.a
+      include/
+```
+
+The profile/target key remains unchanged:
+
+```text
+<profile>
+<profile>-<target-triple>
+```
+
+Examples:
+
+```text
+.osty/out/debug/go/main.go
+.osty/out/debug/go/myapp
+.osty/out/debug/llvm/main.ll
+.osty/out/debug/llvm/main.o
+.osty/out/debug/llvm/myapp
+.osty/out/release-amd64-linux/go/main.go
+.osty/out/release-amd64-linux/llvm/main.ll
+```
+
+## Backend Names
+
+Backend directory names are stable API for tooling.
+
+| Backend | Directory | Notes |
+|---|---|---|
+| Go transpiler | `go` | Existing backend, still default during migration |
+| LLVM native | `llvm` | New backend; textual `.ll` first, then object/binary |
+
+Do not encode implementation detail in the backend directory name. For example,
+use `llvm`, not `clang`, `llc`, `capi`, or `llvm-ir`.
+
+## Emit Modes
+
+`--emit` controls which artifacts are requested, not where they live.
+
+| Backend | Emit mode | Required artifacts |
+|---|---|---|
+| `go` | `go` | `go/main.go` |
+| `go` | `binary` | `go/main.go`, `go/<binary>` |
+| `llvm` | `llvm-ir` | `llvm/main.ll` |
+| `llvm` | `object` | `llvm/main.ll`, `llvm/main.o` |
+| `llvm` | `binary` | `llvm/main.ll`, `llvm/main.o`, `llvm/<binary>` |
+
+For `osty run --backend=llvm`, the effective emit mode is `binary` because the
+command must execute a host binary.
+
+## Cache Layout
+
+Build fingerprints must include backend identity.
+
+Recommended cache shape:
+
+```text
+<root>/.osty/cache/<profile>[-<target>]/
+  go.json
+  llvm.json
+```
+
+During the migration, the existing cache path:
+
+```text
+<root>/.osty/cache/<profile>[-<target>].json
+```
+
+may remain as the legacy Go backend fingerprint. Once `internal/backend` owns
+cache keys, move Go to the backend-aware shape and treat the legacy JSON as
+stale if both exist.
+
+Fingerprint fields should include:
+
+- `backend`: `go` or `llvm`
+- `emit`: requested emit mode
+- `tool_version`: Osty compiler version
+- backend toolchain identity
+  - Go: `go version`, `go` executable path/modtime
+  - LLVM: `clang --version` or `llc --version`, linker path, runtime ABI version
+- source hashes
+- manifest/profile/target/features
+- produced artifact paths relative to project root
+
+## Test Artifact Layout
+
+Current `osty test` uses `$TMPDIR/osty-test-<pkg-hash>/` with generated Go files
+and a cached Go test binary. Backend-aware tests should add a backend level:
+
+```text
+$TMPDIR/osty-test-<pkg-hash>/
+  go/
+    main.go
+    harness.go
+    go.mod
+    osty-test-bin-<hash>
+  llvm/
+    main.ll
+    harness.ll
+    runtime/
+    osty-test-bin-<hash>
+```
+
+The test binary hash should include backend, emit mode, toolchain identity, and
+runtime ABI version. Go and LLVM test binaries must never share a cache key.
+
+## Source Maps and Debug Files
+
+Generated-source artifacts must stay inspectable after failures.
+
+Go:
+
+- `go/main.go` keeps existing `// Osty: path:line:column` comments.
+
+LLVM:
+
+- `llvm/main.ll` should initially keep readable source comments or metadata
+  anchors near emitted functions/basic blocks.
+- Later DWARF metadata may be added, but textual anchors are required first so
+  failure reporting works before full debug-info support.
+
+Failure reports should always include:
+
+- backend name
+- generated artifact path
+- work directory
+- rerunnable command
+- nearest Osty source location when available
+
+## Cleanup Semantics
+
+`osty cache clean` currently removes `.osty/cache` and `.osty/out`. That remains
+valid. Backend-aware subdirectories should not require a new cleanup command.
+
+Rules:
+
+- `osty cache clean` removes all backend artifacts.
+- Future selective cleanup may accept backend filters, but that is not required
+  for the LLVM migration's first implementation.
+- Publish artifacts under `.osty/publish` are unrelated to backend build
+  outputs and should remain unchanged.
+
+## Migration Plan
+
+The initial helper package for this plan is `internal/backend`.
+
+1. Add backend-aware helpers without changing the default Go output path. Done
+   in Phase 5.
+2. Switch Go backend writes from `.osty/out/<key>/main.go` to
+   `.osty/out/<key>/go/main.go`. Done for `osty build` and `osty run` in
+   Phase 6.
+3. Add `--backend=go|llvm` CLI plumbing. Done for `gen`, `build`, `run`, and
+   `test` in Phase 7; `llvm` currently reports a not-implemented error.
+4. Add `--emit=go|llvm-ir|object|binary` CLI plumbing. Done for `gen`,
+   `build`, `run`, and `test` in Phase 8. `build --emit=go` writes Go source
+   without linking; `run` and `test` require `binary`.
+5. Update failure reporting tests to accept the new generated path.
+6. Move cache fingerprints from `.osty/cache/<key>.json` to
+   `.osty/cache/<key>/go.json`.
+7. Add LLVM artifacts under `.osty/out/<key>/llvm/`.
+8. Add LLVM cache fingerprints under `.osty/cache/<key>/llvm.json`.
+9. Keep a compatibility note for existing ignored `.osty/out/<key>/main.go`
+   files; they can be deleted by `osty cache clean`.
+
+The backend subdirectory change should land before the LLVM backend writes any
+files, so LLVM never shares the old Go-only output location.
+
+## Phase 4 Done Criteria
+
+- The current artifact layout is documented.
+- The target backend-aware layout is documented.
+- Cache and test artifact separation rules are documented.
+- The migration order avoids Go/LLVM clobbering.

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -1,0 +1,78 @@
+# LLVM Backend Corpus
+
+이 문서는 LLVM 이주 Phase 2의 산출물이다. 목적은 backend parity에 사용할
+fixture를 명시적으로 분류해서, Go backend의 현재 동작과 LLVM backend의 목표
+범위를 섞지 않도록 하는 것이다.
+
+## Classification
+
+| Class | Meaning | LLVM gate usage |
+|---|---|---|
+| `exec` | 현재 Go backend로 실행 가능한 기준 프로그램 | LLVM이 같은 stdout/exit code를 내야 하는 parity gate |
+| `front-end-only` | parse/resolve/check 기준선으로만 쓰는 fixture | LLVM codegen gate로 쓰지 않음 |
+| `go-only` | Go backend 전용 기능에 의존 | LLVM은 명확한 unsupported diagnostic을 내야 함 |
+| `future-runtime` | runtime/stdlib/concurrency port 이후에야 의미 있는 fixture | 초기 LLVM gate에서 제외 |
+| `llvm-smoke` | LLVM 첫 세로 경로를 위해 새로 만든 작은 fixture | `.osty -> IR -> .ll -> binary` 초기 gate |
+
+## Current Repository Fixtures
+
+| Path | Class | Current status | Rationale |
+|---|---|---|---|
+| `examples/concurrency` | `future-runtime` | Go `run`/`build` pass | Channel, spawn, `parallel`, `taskGroup` runtime parity가 필요하다. |
+| `examples/ffi` | `go-only` | Go `run`/`build` pass | `use go "strings"`는 native LLVM backend에서 그대로 지원할 수 없다. |
+| `examples/calc` | `front-end-only` | `check` pass, `test` fail | Package front-end baseline으로만 사용한다. 현재 `osty test`는 `expectError` error type mismatch로 실패한다. |
+| `examples/workspace` | `front-end-only` | `check` pass, root `build` pass | Workspace resolution/orchestration baseline이다. Root binary는 없다. |
+| `examples/stdlib-tour` | `future-runtime` | Not sampled in Phase 1 | stdlib runtime coverage가 늘어난 뒤 module별로 승격한다. |
+| `examples/dogfood` | `front-end-only` | Not sampled in Phase 1 | Self-host/dogfood scale fixture. LLVM 초기 executable gate로는 너무 크다. |
+| `examples/selfhost-core` | `front-end-only` | Not sampled in Phase 1 | Front-end/dogfood baseline. LLVM 초기 executable gate에서 제외한다. |
+| `word_freq.osty` | `future-runtime` | Not sampled in Phase 1 | Real-world candidate. Regex/fs/json/parallel 등 runtime dependency가 크다. |
+| `testdata/spec/positive/*.osty` | `front-end-only` | Existing spec corpus | Spec coverage용이다. 일부 파일은 library-shaped라 실행 gate로 쓰지 않는다. |
+| `testdata/spec/negative/reject.osty` | `front-end-only` | Existing reject corpus | Diagnostic reject 기준이다. Backend gate로 쓰지 않는다. |
+
+## Initial LLVM Smoke Corpus
+
+The initial LLVM smoke corpus lives under `testdata/backend/llvm_smoke/`.
+Each fixture should be independently checkable as a single file and avoid:
+
+- package/workspace dependencies
+- `use go`
+- heap-heavy stdlib modules
+- channels/concurrency
+- test harness APIs
+- generic/interface lowering requirements
+
+| Path | Expected stdout | Coverage |
+|---|---|---|
+| `testdata/backend/llvm_smoke/scalar_arithmetic.osty` | `42\n` | primitive integers, function call, arithmetic, if/else |
+| `testdata/backend/llvm_smoke/control_flow.osty` | `15\n` | mutable locals, inclusive range loop, accumulator update |
+| `testdata/backend/llvm_smoke/booleans.osty` | `7\n` | bool expressions, comparison, logical operators, conditional return |
+
+These fixtures are deliberately smaller than the current examples. They are
+the first target for proving the thin vertical path:
+
+```text
+Osty source -> front-end -> internal/ir -> LLVM IR -> native binary
+```
+
+## Promotion Rules
+
+A fixture may move to a stronger class only when the required runtime and
+backend features are available.
+
+- `llvm-smoke -> exec`: once LLVM can compile and run it in CI.
+- `front-end-only -> exec`: once package emission and runtime dependencies are
+  implemented.
+- `future-runtime -> exec`: once the relevant stdlib/runtime module is ported.
+- `go-only -> exec`: only if a native equivalent feature exists. Otherwise keep
+  it Go-only and require an unsupported diagnostic in LLVM mode.
+
+## Phase 2 Done Criteria
+
+- The corpus classes above are documented.
+- The first LLVM smoke fixtures exist in the repository.
+- The smoke fixtures pass current front-end checks individually.
+- Later backend work can refer to this document instead of guessing which
+  examples are parity gates.
+
+The follow-up Go transpiler TODO audit is tracked in
+[`LLVM_GEN_TODO_AUDIT.md`](./LLVM_GEN_TODO_AUDIT.md).

--- a/LLVM_GEN_TODO_AUDIT.md
+++ b/LLVM_GEN_TODO_AUDIT.md
@@ -1,0 +1,131 @@
+# LLVM Gen TODO Audit
+
+이 문서는 LLVM 이주 25-step Phase 3의 산출물이다. 목적은 현재 Go transpiler
+(`internal/gen`)의 TODO/unsupported marker를 감사해서, LLVM 1차 backend 범위가
+기존 Go backend coverage gap과 섞이지 않도록 하는 것이다.
+
+## Static Marker Summary
+
+Static scan command:
+
+```sh
+rg -n "TODO|unsupported" internal/gen --glob '*.go'
+```
+
+Observed output-producing marker sites:
+
+| Site | Marker | Meaning | LLVM initial action |
+|---|---|---|---|
+| `internal/gen/decl.go` | `// unsupported decl: %T` | Defensive fallback for unknown/future AST declaration nodes. Current known decl kinds are dispatched explicitly. | Exclude unknown declaration forms; add an explicit LLVM unsupported diagnostic if reached. |
+| `internal/gen/expr.go` | `/* TODO: expr %T */` | Defensive fallback for unknown/future AST expression nodes. Current known expression kinds are dispatched explicitly. | Exclude unknown expression forms; add an explicit LLVM unsupported diagnostic if reached. |
+| `internal/gen/stmt.go` | `/* TODO: stmt %T */` | Defensive fallback for unknown/future AST statement nodes. Current known statement kinds are dispatched explicitly. | Exclude unknown statement forms; add an explicit LLVM unsupported diagnostic if reached. |
+| `internal/gen/match.go` | `true /* TODO: pattern %T */` | Defensive fallback for unknown/future pattern nodes in match tests. Current AST pattern kinds are covered. | LLVM smoke excludes match lowering; later match support should reject unknown patterns explicitly. |
+| `internal/gen/expr.go` | `TODO(phase3): ..spread on qualified type` | Real edge-case gap for struct spread when the struct type is package-qualified and gen cannot safely name the emitted Go type. | Exclude qualified struct spread from LLVM initial scope; classify under package/qualified type parity. |
+| `internal/gen/gen.go` | `g.todo(...)` helper | Non-fatal TODO helper for unsupported constructs. Static scan found no current call sites. | No direct LLVM scope impact today. Keep equivalent helper only if diagnostics are explicit. |
+
+Related non-output comments:
+
+- `internal/gen/typ.go` notes that qualified `pkg.Type` currently falls back to
+  `strings.Join(n.Path, ".")`.
+- `internal/gen/expr.go` notes qualified struct literals and numeric duration
+  shorthand as Phase 5/module-stdlib territory.
+- `internal/gen/realworld_test.go` documents `word_freq.osty` as a depth probe
+  because it depends on regex, json, fs, and parallel runtime coverage.
+
+## Dynamic Probe Results
+
+### LLVM smoke corpus
+
+Command shape:
+
+```sh
+for f in testdata/backend/llvm_smoke/*.osty; do
+  go run ./cmd/osty gen -o /tmp/out.go "$f"
+  rg -n "TODO|unsupported" /tmp/out.go
+done
+```
+
+Result:
+
+- `testdata/backend/llvm_smoke/scalar_arithmetic.osty`: no generated
+  TODO/unsupported markers
+- `testdata/backend/llvm_smoke/control_flow.osty`: no generated
+  TODO/unsupported markers
+- `testdata/backend/llvm_smoke/booleans.osty`: no generated
+  TODO/unsupported markers
+
+### Phase 1 executable examples
+
+Result:
+
+- `examples/concurrency/main.osty`: no generated TODO/unsupported markers
+- `examples/ffi/main.osty`: no generated TODO/unsupported markers
+
+This means the currently selected LLVM smoke files do not rely on known Go gen
+TODO fallbacks.
+
+### Spec corpus audit
+
+Command:
+
+```sh
+go test ./internal/gen -run TestSpecCorpusAudit -count=1 -v
+```
+
+Observed result:
+
+- Fails overall because `testdata/spec/positive/05-modules.osty` has an existing
+  resolve error in the single-file audit harness.
+- 8 of 9 positive fixtures reached Go vet successfully.
+- `07-errors.osty` and `11-testing.osty` logged checker warnings/errors but still
+  generated vet-clean Go.
+
+Implication:
+
+- The spec corpus is useful as a broad Go-gen health probe.
+- It is not a clean LLVM executable parity gate.
+- LLVM should initially use the smaller smoke corpus, then graduate selected
+  spec fixtures only after module/package/runtime support exists.
+
+## LLVM Initial Exclusions
+
+The first LLVM backend vertical slice should explicitly exclude these areas:
+
+| Area | Why excluded initially | Later phase |
+|---|---|---|
+| Unknown/future AST node fallbacks | These are defensive Go-gen guards, not meaningful language support targets. | Add explicit unsupported diagnostics in backend facade. |
+| Match lowering and complex patterns | Requires enum/tag representation and pattern binding layout. | Runtime/heap values and enum parity. |
+| Struct/enum/user aggregate layout | Requires stable runtime/value ABI and source-compatible layout choices. | Runtime ABI phase. |
+| Qualified package types and package-member codegen | Current Go path still has package/workspace emission limits. | Package/workspace parity phase. |
+| Qualified struct spread | Known Go-gen edge case. Needs qualified type naming and field layout. | Package/aggregate parity phase. |
+| Generic monomorphization | Needs IR to carry `check.Result.Instantiations`. | IR contract phase. |
+| Closures with captures/destructuring | Needs closure environment layout and lifetime/ownership policy. | Runtime ABI plus generics/closures phase. |
+| Interfaces/vtables | Needs fat pointer/vtable representation. | Interface parity phase. |
+| Go FFI (`use go`) | Native backend cannot call Go packages directly. | Native FFI design; Go-only diagnostic until then. |
+| Stdlib runtime bridges | Current Go backend lowers many stdlib calls to Go helpers/imports. | Module-by-module stdlib runtime port. |
+| Channels and structured concurrency | Requires scheduler/channel/task runtime ABI. | Concurrency runtime phase. |
+| Test harness execution | `osty test` currently has baseline fixture issues and uses generated Go harness behavior. | LLVM test harness phase. |
+
+## LLVM Phase 3 Conclusion
+
+The Go transpiler has only a small number of explicit emitted TODO fallback
+sites, and the new LLVM smoke corpus avoids them. The important migration
+decision is therefore not "match every Go-gen fallback immediately"; it is:
+
+1. Keep the first LLVM backend scope narrow: scalar values, simple functions,
+   branches, loops, and integer `println`.
+2. Emit explicit unsupported diagnostics for excluded constructs rather than
+   producing placeholder LLVM.
+3. Promote excluded areas only when the relevant IR metadata and runtime ABI
+   are in place.
+
+## Phase 3 Done Criteria
+
+- Static TODO/unsupported marker sites are documented.
+- Dynamic probes confirm LLVM smoke fixtures generate without Go TODO markers.
+- The initial LLVM exclusion list is explicit.
+- Later implementation phases can decide whether a construct is in scope
+  without re-auditing `internal/gen` from scratch.
+
+The follow-up backend-aware artifact layout policy is tracked in
+[`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYOUT.md).

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -1,0 +1,379 @@
+# LLVM Migration Plan
+
+이 문서는 Osty의 실행 백엔드를 현재 Go transpiler 중심 구조에서 LLVM 기반
+네이티브 백엔드로 옮기기 위한 이주 계획이다. 목표는 기존 Go 백엔드를 즉시
+제거하는 것이 아니라, front-end 안정성을 유지한 채 LLVM 백엔드를 병렬로
+도입하고 충분한 parity가 확보된 뒤 기본 경로를 전환하는 것이다.
+
+## 현재 상태
+
+- Front-end는 `lexer -> parser -> resolve -> check`까지 안정적으로 분리되어
+  있고, diagnostics/source position 모델도 CLI와 테스트에 이미 공유된다.
+- 실행 경로는 `internal/gen` Go transpiler가 담당한다. `osty gen`, `osty build`,
+  `osty run`, `osty test`는 Go source를 만들고 `go build` 또는 `go run`으로
+  이어진다.
+- `internal/ir`는 backend-agnostic IR로 이미 존재하지만, 현재 Go transpiler는
+  AST와 `resolve/check` 결과를 직접 소비한다.
+- Runtime helper는 Go 출력물 안에 조건부로 주입되는 구조다. LLVM으로 가려면
+  ABI가 고정된 별도 runtime surface가 필요하다.
+- Manifest profile/target은 Go toolchain 플래그와 `GOOS/GOARCH/CGO_ENABLED`
+  중심이다. LLVM target triple, linker, sysroot, runtime artifact 위치를
+  표현할 수 있도록 확장해야 한다.
+- Multi-file package, vendored dependency, workspace build의 실제 code emission은
+  아직 제한이 있다. LLVM 전환 전에 package 단위 emit/link 모델을 분명히 해야
+  한다.
+
+## 이주 원칙
+
+1. Go 백엔드는 migration 기간 동안 안정 백엔드로 유지한다.
+2. LLVM 백엔드는 AST가 아니라 `internal/ir`를 입력으로 삼는다.
+3. 초기 LLVM 출력은 pure Go textual LLVM IR emitter로 시작한다. C API/cgo
+   binding은 toolchain coupling이 커서 1차 목표에서 제외한다.
+4. Runtime ABI를 먼저 문서화하고, helper를 backend별로 흩뿌리지 않는다.
+5. CLI는 `--backend=go|llvm` 또는 동등한 선택지를 제공하고, 기본값 전환은
+   parity gate를 통과한 뒤 별도 릴리스에서 한다.
+6. 각 단계는 기존 테스트를 깨지 않는 additive change로 들어간다.
+
+## 목표 범위
+
+LLVM 백엔드는 다음 결과물을 지원해야 한다.
+
+- `osty build --backend=llvm`로 실행 파일 생성
+- `osty run --backend=llvm`로 host target 실행
+- `osty test --backend=llvm`로 테스트 harness 실행
+- `osty gen --backend=llvm --emit=llvm-ir` 또는 별도 명령으로 inspectable `.ll`
+  출력
+- profile/target/feature에 따른 artifact 디렉터리 분리
+- Go 백엔드와 같은 source mapping 품질을 갖춘 build failure 리포트
+
+초기 non-goal은 다음과 같다.
+
+- JIT 실행
+- LLVM optimizer pass 튜닝 자동화
+- 모든 stdlib/concurrency parity를 1차 milestone에서 달성
+- Go runtime과 ABI 호환
+- LLVM C API 또는 MLIR 기반 재작성
+
+## 단계별 계획
+
+### Phase 0. 기준선 고정
+
+목표: 마이그레이션 중 회귀를 판별할 수 있는 현재 동작 기준을 만든다.
+현재 측정된 25-step Phase 1 기준선은 [`LLVM_PHASE1_BASELINE.md`](./LLVM_PHASE1_BASELINE.md)에
+기록한다. Backend parity fixture 분류와 초기 LLVM smoke set은
+[`LLVM_BACKEND_CORPUS.md`](./LLVM_BACKEND_CORPUS.md)에 기록한다. Go transpiler
+TODO/unsupported marker 감사와 LLVM 1차 제외 목록은
+[`LLVM_GEN_TODO_AUDIT.md`](./LLVM_GEN_TODO_AUDIT.md)에 기록한다. Backend-aware
+artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYOUT.md)에
+기록한다.
+
+작업:
+
+- Go 백엔드 parity corpus를 정리한다.
+  - `examples/calc`, `examples/concurrency`, `examples/ffi`, `examples/workspace`,
+    `examples/stdlib-tour`, `word_freq.osty` 중 backend가 실제 실행해야 하는
+    범위를 표시한다.
+  - 실행이 아직 불가능한 fixture는 front-end-only, Go-only, future-runtime으로
+    라벨링한다.
+- `internal/gen` TODO marker 목록을 audit하고 LLVM의 1차 parity 범위에서
+  제외할 항목을 명시한다.
+- `osty pipeline --gen` 결과와 현재 `go build/go run` 실패 리포트 형식을
+  snapshot으로 묶는다.
+- release/debug/profile/test profile별 기대 artifact layout을 문서화한다.
+
+완료 조건:
+
+- 현재 short-suite 상태가 통과 또는 기존 실패 목록으로 명시되어 있다.
+- backend parity fixture 목록이 문서화되어 있다.
+- LLVM 1차 milestone에서 반드시 통과해야 할 smoke programs가 정해져 있다.
+
+### Phase 1. Backend 인터페이스와 CLI 선택지
+
+목표: Go backend와 LLVM backend를 CLI에서 같은 추상화로 호출할 수 있게 한다.
+
+작업:
+
+- `internal/backend` 패키지를 추가한다.
+  - 입력: package/workspace front-end 결과, selected profile, target, features.
+  - 출력: generated artifacts, executable path, diagnostics/warnings, source map.
+- 기존 Go 경로를 backend interface 뒤로 얇게 감싼다.
+- CLI에 backend 선택지를 추가한다.
+  - 예: `--backend=go|llvm`
+  - 예: `--emit=go|llvm-ir|object|binary`
+- build/run/test의 artifact layout을 backend별로 분리한다.
+  - 예: `.osty/out/<profile>[-<target>]/go/main.go`
+  - 예: `.osty/out/<profile>[-<target>]/llvm/main.ll`
+- Go 실패 리포트에 묶여 있던 debug mapping 로직을 backend-neutral 형태로
+  분리한다.
+
+완료 조건:
+
+- `--backend=go`가 기존 동작과 동일하다.
+- `--backend=llvm`는 아직 unsupported여도 CLI, profile, artifact path plumbing이
+  테스트된다.
+- build/run/test integration test가 backend 선택지 파싱을 검증한다.
+
+### Phase 2. IR를 실제 backend 계약으로 승격
+
+목표: LLVM backend가 `internal/ir`만 보고 codegen할 수 있도록 gap을 닫는다.
+
+작업:
+
+- `internal/ir`에 backend가 필요한 metadata를 보강한다.
+  - package/member identity
+  - qualified symbol name
+  - generic instantiation records
+  - callable default/keyword lowering 결과
+  - source map anchor
+  - capture layout
+  - interface/vtable 필요 정보
+- `check.Result.Instantiations`를 IR lowering에 반영한다.
+- pattern destructuring, for destructuring, qualified type/call, stdlib intrinsic을
+  backend-friendly node로 정규화한다.
+- `ir.Validate`를 backend preflight gate로 강화한다.
+- IR golden tests를 추가해 AST 변화와 backend 계약 변화를 분리한다.
+
+완료 조건:
+
+- smoke corpus가 `lexer -> parser -> resolve -> check -> ir.Validate`를 통과한다.
+- LLVM backend prototype이 AST/resolve/check 패키지에 직접 의존하지 않는다.
+- IR printer snapshot으로 주요 언어 construct가 고정된다.
+
+### Phase 3. Minimal LLVM IR backend
+
+목표: 작은 Osty 프로그램을 `.ll`로 emit하고 host에서 실행 가능한 바이너리로
+링크한다.
+
+초기 지원 범위:
+
+- scalar primitive: `Int`, fixed-width int, `Float`, `Bool`, `Char`, `Byte`
+- local `let`, assignment, return
+- function declaration/call
+- block, if/else, while-style/infinite/range for
+- arithmetic/comparison/logical operators
+- simple string literal 출력은 runtime call 또는 임시 host libc bridge로 제한
+- script-mode synthetic `main`
+
+작업:
+
+- `internal/llvmgen` 패키지를 추가한다.
+- textual `.ll` emitter를 작성한다.
+  - deterministic name mangling
+  - explicit basic block builder
+  - SSA temp allocator
+  - type lowering table
+  - source comment 또는 metadata anchor
+- host compile driver를 추가한다.
+  - `.ll -> .o -> binary`
+  - 초기는 external `clang`/`llc`를 사용하고, tool discovery/error를 친절하게
+    보고한다.
+- `osty gen --backend=llvm --emit=llvm-ir`로 `.ll` 출력이 가능하게 한다.
+- generated IR golden tests와 small executable tests를 만든다.
+
+완료 조건:
+
+- `fn main() { println(1 + 2) }` 수준의 프로그램이 LLVM backend로 실행된다.
+- scalar/control-flow fixture가 Go backend와 같은 stdout/exit code를 낸다.
+- LLVM toolchain이 없을 때 test는 명확히 skip되거나 actionable error를 낸다.
+
+### Phase 4. Runtime ABI와 heap values
+
+목표: Osty 값 모델을 LLVM에서 안정적으로 표현한다.
+
+작업:
+
+- Runtime ABI 문서를 추가한다.
+  - value ownership
+  - allocation/free 정책
+  - string/bytes layout
+  - list/map/set layout
+  - option/result representation
+  - struct/enum layout
+  - closure environment layout
+  - interface/vtable representation
+  - panic/error/reporting ABI
+- `runtime/` 또는 `internal/runtime` 하위에 C/Rust/Zig 중 하나로 구현할
+  portable runtime을 둔다. 1차 권장안은 C ABI를 노출하는 small C runtime이다.
+- Go backend에 흩어진 helper 의미를 runtime ABI로 옮긴다.
+  - string formatting/interpolation
+  - structural equality
+  - range/list/map helpers
+  - Option/Result helpers
+  - error/toString bridge
+- LLVM backend가 runtime symbols를 declare/call하도록 한다.
+- Runtime object/library를 build artifact에 포함하고 linker step에 연결한다.
+
+완료 조건:
+
+- struct/enum/match/list/string/Option/Result smoke tests가 LLVM backend에서 돈다.
+- runtime ABI가 문서와 테스트로 고정된다.
+- Go backend helper와 LLVM runtime 사이의 semantic drift를 잡는 shared tests가
+  있다.
+
+### Phase 5. Package, workspace, generics, FFI
+
+목표: 단일 entry file을 넘어 package 단위 native build를 지원한다.
+
+작업:
+
+- package-per-package emission 모델을 확정한다.
+  - one module per package 또는 one linked module per binary 중 선택
+  - exported symbol mangling
+  - duplicate runtime/helper emission 제거
+- generic monomorphization 결과를 LLVM symbol로 materialize한다.
+- workspace/dependency graph를 codegen/link order로 변환한다.
+- `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
+  정한다.
+  - native backend 전용 `use c` 또는 external symbol declaration
+  - Go FFI는 Go backend-only diagnostic으로 제한
+  - manifest target별 linker flags/sysroot 추가
+- CLI failure report가 object/link 단계의 에러를 Osty source로 최대한 연결하게
+  한다.
+
+완료 조건:
+
+- multi-file package와 workspace example이 LLVM backend로 build된다.
+- generic functions, generic structs, closures가 LLVM smoke corpus를 통과한다.
+- FFI 정책이 diagnostic과 문서에 반영된다.
+
+### Phase 6. Stdlib와 concurrency parity
+
+목표: 사용자 관점에서 Go backend와 LLVM backend의 표준 라이브러리 의미를 맞춘다.
+
+작업:
+
+- stdlib module별 backend support matrix를 만든다.
+  - pure Osty로 실행 가능한 모듈
+  - runtime intrinsic이 필요한 모듈
+  - OS/platform binding이 필요한 모듈
+  - Go backend-only로 남길 모듈
+- `std.io`, `std.fs`, `std.env`, `std.time`, `std.random`, `std.json`,
+  `std.regex`, `std.net`, `std.thread` 순서로 porting한다.
+- concurrency runtime을 설계한다.
+  - task handle layout
+  - task group cancellation
+  - channel close/drain semantics
+  - scheduler/threading primitive
+- `osty test --backend=llvm` harness를 구현한다.
+
+완료 조건:
+
+- stdlib-tour의 지정 subset이 LLVM backend로 통과한다.
+- concurrency example이 LLVM backend로 통과한다.
+- backend support matrix가 문서와 CI에 반영된다.
+
+### Phase 7. 기본 백엔드 전환
+
+목표: LLVM을 기본 build backend로 전환할 수 있는 품질 기준을 충족한다.
+
+작업:
+
+- release note와 migration guide를 작성한다.
+- backend selection default를 edition/profile/feature flag로 점진 전환한다.
+  - 예: 현 edition은 Go default 유지, 다음 edition에서 LLVM default
+  - 또는 `OSTY_BACKEND=llvm`/manifest setting으로 opt-in 기간 운영
+- CI matrix에 host LLVM build를 추가한다.
+- Go backend는 최소 한 릴리스 이상 fallback으로 유지한다.
+- performance, binary size, compile time baseline을 기록한다.
+
+완료 조건:
+
+- 정해진 parity corpus가 LLVM backend로 모두 통과한다.
+- 알려진 Go-only 기능이 명확한 diagnostic을 낸다.
+- 새 프로젝트 scaffold가 LLVM default에서 정상 build/run/test된다.
+
+## 타입/값 lowering 초안
+
+| Osty | LLVM 표현 초안 | 비고 |
+|---|---|---|
+| `Int` | target word 또는 고정 `i64` 중 결정 필요 | 현재 Go `int` 의미와 cross-target 안정성 중 선택 |
+| `Int8..UInt64` | `i8..i64` | signedness는 operation에서 표현 |
+| `Bool` | `i1` in SSA, ABI는 `i8` 가능 | runtime ABI에서 고정 |
+| `Char` | `i32` | Unicode scalar value |
+| `Byte` | `i8` | `UInt8`과 alias 여부 명시 필요 |
+| `Float/Float32/Float64` | `double/float/double` | `Float` width 정책 결정 |
+| `String` | `%osty.string` | pointer+len 또는 fat value |
+| `Bytes` | `%osty.bytes` | pointer+len+cap 또는 runtime-owned buffer |
+| `List<T>` | `%osty.list` + element descriptor | monomorphized typed list와 erased list 중 선택 |
+| `Option<T>` | tagged payload | nullable pointer optimization은 후순위 |
+| `Result<T,E>` | tagged payload | Go backend의 `Value/Error/IsOk`와 semantic parity |
+| `struct` | named LLVM struct 또는 opaque handle | layout stability 필요 |
+| `enum` | tag + max payload storage | niche optimization은 후순위 |
+| closure | fn pointer + env pointer | capture lifetime/ownership 필요 |
+| interface | data pointer + vtable pointer | vtable generation은 Phase 5+ |
+
+## Toolchain 전략
+
+초기 전략:
+
+- LLVM IR은 텍스트로 emit한다.
+- Build driver는 외부 `clang`/`llc`를 찾고, 없으면 actionable error를 낸다.
+- CI에서는 LLVM toolchain 설치가 가능한 job만 LLVM executable tests를 켠다.
+- 로컬 개발자는 `osty gen --backend=llvm --emit=llvm-ir`만으로도 backend를
+  디버그할 수 있다.
+
+후속 전략:
+
+- 필요하면 `.bc` bitcode 출력과 optimizer pass pipeline을 추가한다.
+- 안정성이 충분해지면 target별 linker/sysroot discovery를 manifest target에
+  통합한다.
+- C API/cgo binding은 incremental compile, object cache, debug metadata 품질이
+  textual IR 방식의 한계에 닿았을 때만 재검토한다.
+
+## 테스트 전략
+
+- Unit:
+  - `internal/ir` lowering/validation snapshot
+  - `internal/llvmgen` type lowering, block builder, name mangling
+  - runtime ABI header/layout tests
+- Golden:
+  - `.osty -> .ll` deterministic output
+  - source map metadata/comment anchors
+- Execution:
+  - scalar/control-flow smoke tests
+  - structs/enums/match tests
+  - generics/closures tests
+  - stdlib/runtime tests
+  - concurrency tests
+- CLI:
+  - backend flag parsing
+  - artifact path layout
+  - missing LLVM toolchain diagnostics
+  - compile/link/runtime failure reporting
+- Parity:
+  - same program run through Go and LLVM backends, compare stdout/stderr/exit code
+  - known divergence list checked into tests, not hidden in comments
+
+## 리스크와 대응
+
+| 리스크 | 영향 | 대응 |
+|---|---|---|
+| IR가 backend 계약으로 부족함 | LLVM backend가 AST/checker에 다시 결합 | Phase 2에서 IR gap을 먼저 닫고 `llvmgen` dependency를 제한 |
+| Runtime ABI가 늦게 정해짐 | helper가 backend별로 갈라짐 | Phase 4 전에 string/list/result 최소 ABI부터 문서화 |
+| Go FFI와 native FFI 의미 차이 | 사용자 코드가 backend별로 다르게 동작 | Go FFI는 backend capability로 진단하고 native FFI를 별도 설계 |
+| target triple/profile 모델 충돌 | cross compile UX 혼란 | Go target과 LLVM target을 manifest에서 분리하거나 명시 mapping |
+| source mapping 품질 저하 | LLVM 에러 디버깅 어려움 | 초기부터 source anchor를 IR/LLVM에 싣고 CLI report를 backend-neutral화 |
+| stdlib porting 범위 과대 | migration이 끝나지 않음 | module별 support matrix와 staged parity gate 운영 |
+| CI 시간이 증가 | PR feedback 저하 | LLVM job은 smoke부터 시작하고 full parity는 nightly/manual로 분리 |
+
+## 의사결정이 필요한 항목
+
+- `Int`와 `Float`의 정확한 native width 정책
+- Memory model: manual/free, arena, refcount, GC 중 1차 선택
+- Runtime implementation language
+- LLVM target triple을 manifest `[target.*]`에 통합할지 별도 키로 둘지
+- `use go`를 LLVM backend에서 어떻게 진단할지
+- Debug info를 주석/source map으로 시작할지, DWARF metadata까지 1차에 넣을지
+- Default backend 전환을 edition과 묶을지, manifest setting과 묶을지
+
+## 추천 첫 PR 순서
+
+1. `internal/backend` facade 추가, Go backend를 기존 동작 그대로 감싸기
+2. `--backend`/`--emit` CLI plumbing과 artifact layout 테스트 추가
+3. `internal/ir` metadata gap 목록을 테스트 기반으로 보강
+4. `internal/llvmgen` skeleton과 `.ll` golden smoke test 추가
+5. LLVM toolchain discovery와 missing-tool diagnostic 추가
+6. scalar/control-flow LLVM executable smoke test 추가
+
+이 순서의 장점은 첫 PR부터 사용자 동작을 바꾸지 않으면서도, 이후 LLVM 작업이
+작고 독립적인 리뷰 단위로 쌓인다는 점이다.

--- a/LLVM_PHASE1_BASELINE.md
+++ b/LLVM_PHASE1_BASELINE.md
@@ -1,0 +1,142 @@
+# LLVM Phase 1 Baseline
+
+기준일: 2026-04-16 Asia/Seoul
+기준 commit: `0eb6ea1`
+목적: LLVM backend 이주 전에 현재 Go backend와 관련 CLI 경로의 실제 동작을
+고정한다. 이 문서는 이후 LLVM parity 작업에서 "현재 구현이 이미 하던 것"과
+"현재 구현도 아직 못 하던 것"을 구분하기 위한 기준선이다.
+
+## Scope
+
+이번 기준선은 25단계 LLVM 이주 로드맵의 Phase 1, "현재 Go 백엔드 기준선
+고정"에 해당한다.
+
+확인한 표면은 다음과 같다.
+
+- `osty gen`: Go source emission
+- `osty build`: manifest/profile-aware Go build path
+- `osty run`: generated Go execution path
+- `osty test`: test harness path
+- `osty check`: front-end package/workspace validation
+- `go test -short ./...`: repository test-suite health signal
+
+## Command Results
+
+| Area | Command | Result | Notes |
+|---|---|---|---|
+| CLI build | `go build -o .bin/osty ./cmd/osty` | pass | Baseline CLI built successfully. Temporary `.bin/` was removed after checks. |
+| calc front-end | `osty check examples/calc` | pass | No diagnostics. |
+| calc tests | `osty test examples/calc` | fail | Fails in type-checking before execution. See failure details below. |
+| concurrency gen | `osty gen -o /tmp/osty-phase1-baseline/concurrency.go examples/concurrency/main.osty` | pass | Generated 209 lines of Go. |
+| concurrency run | `osty run` from `examples/concurrency` | pass | stdout matched expected sample output. |
+| concurrency build | `osty build examples/concurrency` | pass | Built `examples/concurrency/.osty/out/debug/concurrency-demo`. |
+| FFI run | `osty run` from `examples/ffi` | pass | Go FFI example executed successfully. |
+| FFI build | `osty build examples/ffi` | pass | Built `examples/ffi/.osty/out/debug/ffi-demo`. |
+| workspace build | `osty build examples/workspace` | pass | Virtual workspace root completed successfully; no root binary emitted. |
+| workspace check | `osty check examples/workspace` | pass | No diagnostics. |
+| repository short tests | `go test -short ./...` | fail/interrupted | Multiple failing packages were observed; command was stopped after long-running packages continued. See below. |
+
+## Observed Runtime Output
+
+`examples/concurrency`:
+
+```text
+sum=39
+grouped=61
+```
+
+`examples/ffi`:
+
+```text
+OSTYOSTY
+ffi ok
+```
+
+## Known Failing Baseline Items
+
+### `osty test examples/calc`
+
+Current result:
+
+```text
+error[E0700]: type mismatch: expected `Result<Int, ()>`, got `Result<Int, CalcError>`
+ --> examples/calc/lib_test.osty:54:25
+```
+
+Impact:
+
+- The calc package itself front-end checks cleanly.
+- The test harness path is not a clean Go-backend parity gate today.
+- Do not use `examples/calc` as an LLVM `osty test` parity gate until this
+  checker/testgen expectation is fixed or the fixture is reclassified.
+
+### `go test -short ./...`
+
+The command was run to sample repository health. It was not a clean baseline.
+Observed failures before interruption:
+
+- `internal/check`
+  - `TestCheck_DefaultArgMustBeLiteral`: expected `E0762`, got `E0106`
+  - `TestCheck_KeywordArgOK`: keyword/default argument path emitted `E0732` and
+    `E0701` diagnostics where the test expected none
+- `internal/docgen`
+  - `TestFnSignature`: default argument value was missing from rendered
+    signature
+- `internal/lint`
+  - `TestLint_UnusedMutHasFix`
+  - `TestLint_UnusedMutTopLevelHasFix`
+  - `TestLint_Fixes_RoundTripThroughParser/unused_mut_stmt`
+
+Observed passing packages before interruption included:
+
+- `cmd/codesdoc`
+- `cmd/osty`
+- `internal/ci`
+- `internal/diag`
+- `internal/examples`
+- `internal/format`
+- `internal/gen`
+- `internal/ir`
+- `internal/lexer`
+- `internal/lockfile`
+
+Impact:
+
+- LLVM migration work should not assume the full short suite is green.
+- Phase 2+ changes should avoid hiding these existing failures.
+- If CI requires a clean short suite, fix or explicitly quarantine these
+  failures before using it as an LLVM gate.
+
+## Fixture Classification
+
+| Fixture | Current Go backend status | LLVM migration classification |
+|---|---|---|
+| `examples/concurrency` | `run` and `build` pass | Go backend executable baseline; LLVM parity later, after runtime/concurrency work |
+| `examples/ffi` | `run` and `build` pass | Go backend executable baseline; LLVM should treat `use go` as Go-only until native FFI exists |
+| `examples/calc` | `check` passes, `test` fails | Front-end baseline only for now; not a test-runner parity gate |
+| `examples/workspace` | `check` and root `build` pass | Workspace front-end/orchestration baseline; no root binary emitted |
+| `word_freq.osty` | not exercised in this pass | Candidate for later real-world corpus once stdlib/runtime parity is clearer |
+
+## Phase 1 Conclusions
+
+- The current Go backend can successfully execute and build the concurrency and
+  Go FFI examples.
+- The front-end path is clean for `examples/calc` and `examples/workspace`.
+- The current test-runner fixture `examples/calc` is not usable as a clean
+  backend parity gate without follow-up work.
+- The repository short test suite is currently not green, independent of LLVM
+  work.
+- LLVM's first executable smoke tests should be new or carefully selected
+  scalar/control-flow fixtures rather than examples that require Go FFI,
+  testgen, or concurrency runtime parity.
+
+## Next Phase
+
+Phase 2 is now tracked in [`LLVM_BACKEND_CORPUS.md`](./LLVM_BACKEND_CORPUS.md).
+It covers:
+
+1. Create the backend parity corpus file/list.
+2. Mark each fixture as `exec`, `front-end-only`, `go-only`, or
+   `future-runtime`.
+3. Add the first minimal LLVM smoke candidates that avoid stdlib, Go FFI, and
+   concurrency.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ osty/
 ├── LANG_SPEC_v0.4/          # Current language spec (prose + examples)
 ├── OSTY_GRAMMAR_v0.4.md     # Current EBNF grammar + decision log
 ├── SPEC_GAPS.md             # Resolved-gap archive (no open items in v0.4)
+├── LLVM_MIGRATION_PLAN.md   # Planned migration from Go gen to LLVM backend
+├── LLVM_PHASE1_BASELINE.md  # Current Go-backend baseline for LLVM migration
+├── LLVM_BACKEND_CORPUS.md   # Backend parity fixture classes and smoke set
+├── LLVM_GEN_TODO_AUDIT.md   # Go-gen TODO audit and LLVM initial exclusions
+├── LLVM_ARTIFACT_LAYOUT.md  # Backend-aware output/cache layout policy
 ├── cmd/
 │   ├── osty/                # Main CLI (`osty` binary)
 │   └── codesdoc/            # Regenerates ERROR_CODES.md from codes.go
@@ -115,6 +120,7 @@ osty/
 │   ├── lint/                # Style/correctness lint rules (L0xxx codes)
 │   ├── format/              # Canonical-style formatter
 │   ├── ir/                  # Independent intermediate representation
+│   ├── backend/             # Backend names, emit modes, artifact layout
 │   ├── gen/                 # Go transpiler (Phases 1–6; `osty gen FILE`)
 │   ├── testgen/             # Test runner harness (drives `osty test`)
 │   ├── docgen/              # API doc generator (HTML + markdown; `osty doc`)
@@ -127,7 +133,7 @@ osty/
 │   ├── lockfile/            # osty.lock read/write
 │   ├── registry/            # Package registry client + file-backed HTTP server
 │   └── pkgmgr/semver/       # SemVer parse, compare, constraint match
-└── testdata/                # .osty fixtures used by tests
+└── testdata/                # .osty fixtures used by tests and backend corpus
 ```
 
 ## Building
@@ -213,6 +219,10 @@ newline-separated `else`.
 
 - `-o PATH` / `--out PATH` — write Go source to `PATH` instead of stdout
 - `--package NAME` — Go package clause for the emitted file (default: `main`)
+- `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
+  `llvm` is currently parsed but not implemented)
+- `--emit MODE` — requested text artifact. `go` emits Go source for the Go
+  backend; `llvm-ir` is reserved for the LLVM backend.
 
 ### Debugging build / run / test failures
 
@@ -264,13 +274,21 @@ creating a new one.
   requires `osty.lock` to already exist. Catches "fresh checkout, no
   lockfile" mistakes before any download starts.
 
+`build` / `run` / `test` backend flags (after the subcommand):
+
+- `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
+  `llvm` is currently parsed but not implemented)
+- `--emit MODE` — requested artifact mode (`go`, `llvm-ir`, `object`, or
+  `binary`). `build --emit go` writes inspectable Go without linking a binary;
+  `run` and `test` require `binary` because they execute the result.
+
 `osty build` loads `osty.toml` starting at the given path (or the cwd),
 resolves dependencies against `osty.lock` (regenerated if stale),
 vendors deps into `<project>/.osty/deps/`, and runs the front-end
 (parse → resolve → check → lint) plus gen across every package
-the manifest names. Future iterations will invoke `go build` on the
-emitted source; today step emits the Go into `<project>/.osty/out/`
-and reports diagnostics.
+the manifest names. For binary packages it emits Go into
+`<project>/.osty/out/<profile>[-<target>]/go/`, invokes `go build`, and
+reports diagnostics with generated-source mapping.
 
 `add`-specific flags (after the subcommand):
 

--- a/cmd/osty/backend_helpers.go
+++ b/cmd/osty/backend_helpers.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/backend"
+)
+
+func firstBackendWarning(r *backend.Result) error {
+	if r == nil || len(r.Warnings) == 0 {
+		return nil
+	}
+	return r.Warnings[0]
+}
+
+func defaultBackendName() string {
+	return backend.NameGo.String()
+}
+
+func defaultEmitMode(tool string, name backend.Name) backend.EmitMode {
+	if tool == "gen" {
+		if name == backend.NameLLVM {
+			return backend.EmitLLVMIR
+		}
+		return backend.EmitGoSource
+	}
+	return backend.EmitBinary
+}
+
+func parseCLIBackend(raw string) (backend.Name, error) {
+	name, err := backend.ParseName(raw)
+	if err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+func parseCLIEmitMode(raw string) (backend.EmitMode, error) {
+	mode, err := backend.ParseEmitMode(raw)
+	if err != nil {
+		return "", err
+	}
+	return mode, nil
+}
+
+func requireImplementedBackend(name backend.Name) error {
+	if name != backend.NameGo {
+		return fmt.Errorf("backend %q is not implemented yet", name)
+	}
+	return nil
+}
+
+func validateCLIEmit(tool string, name backend.Name, mode backend.EmitMode) error {
+	switch tool {
+	case "gen":
+		switch name {
+		case backend.NameGo:
+			if mode != backend.EmitGoSource {
+				return fmt.Errorf("gen with backend %q cannot emit %q (want %q)", name, mode, backend.EmitGoSource)
+			}
+		case backend.NameLLVM:
+			if mode != backend.EmitLLVMIR {
+				return fmt.Errorf("gen with backend %q cannot emit %q (want %q)", name, mode, backend.EmitLLVMIR)
+			}
+		}
+	case "run", "test":
+		if mode != backend.EmitBinary {
+			return fmt.Errorf("%s requires --emit=%q", tool, backend.EmitBinary)
+		}
+	}
+	return backend.ValidateEmit(name, mode)
+}
+
+func resolveBackendAndEmitFlags(tool, backendRaw, emitRaw string) (backend.Name, backend.EmitMode) {
+	name, err := parseCLIBackend(backendRaw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
+		os.Exit(2)
+	}
+	if emitRaw == "" {
+		emitRaw = defaultEmitMode(tool, name).String()
+	}
+	mode, err := parseCLIEmitMode(emitRaw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
+		os.Exit(2)
+	}
+	if err := validateCLIEmit(tool, name, mode); err != nil {
+		fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
+		os.Exit(2)
+	}
+	if err := requireImplementedBackend(name); err != nil {
+		fmt.Fprintf(os.Stderr, "osty %s: %v\n", tool, err)
+		os.Exit(2)
+	}
+	return name, mode
+}
+
+func resolveBackendFlag(tool, raw string) backend.Name {
+	name, _ := resolveBackendAndEmitFlags(tool, raw, "")
+	return name
+}

--- a/cmd/osty/backend_helpers_test.go
+++ b/cmd/osty/backend_helpers_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/backend"
+)
+
+func TestParseCLIBackend(t *testing.T) {
+	got, err := parseCLIBackend("go")
+	if err != nil {
+		t.Fatalf("parseCLIBackend(go): %v", err)
+	}
+	if got != backend.NameGo {
+		t.Fatalf("parseCLIBackend(go) = %q, want go", got)
+	}
+	got, err = parseCLIBackend("llvm")
+	if err != nil {
+		t.Fatalf("parseCLIBackend(llvm): %v", err)
+	}
+	if got != backend.NameLLVM {
+		t.Fatalf("parseCLIBackend(llvm) = %q, want llvm", got)
+	}
+	if _, err := parseCLIBackend("wasm"); err == nil {
+		t.Fatal("parseCLIBackend(wasm) succeeded; want error")
+	}
+}
+
+func TestDefaultEmitMode(t *testing.T) {
+	if got := defaultEmitMode("gen", backend.NameGo); got != backend.EmitGoSource {
+		t.Fatalf("gen/go default emit = %q, want %q", got, backend.EmitGoSource)
+	}
+	if got := defaultEmitMode("gen", backend.NameLLVM); got != backend.EmitLLVMIR {
+		t.Fatalf("gen/llvm default emit = %q, want %q", got, backend.EmitLLVMIR)
+	}
+	if got := defaultEmitMode("build", backend.NameGo); got != backend.EmitBinary {
+		t.Fatalf("build/go default emit = %q, want %q", got, backend.EmitBinary)
+	}
+}
+
+func TestParseCLIEmitMode(t *testing.T) {
+	got, err := parseCLIEmitMode("go")
+	if err != nil {
+		t.Fatalf("parseCLIEmitMode(go): %v", err)
+	}
+	if got != backend.EmitGoSource {
+		t.Fatalf("parseCLIEmitMode(go) = %q, want go", got)
+	}
+	got, err = parseCLIEmitMode("llvm-ir")
+	if err != nil {
+		t.Fatalf("parseCLIEmitMode(llvm-ir): %v", err)
+	}
+	if got != backend.EmitLLVMIR {
+		t.Fatalf("parseCLIEmitMode(llvm-ir) = %q, want llvm-ir", got)
+	}
+	if _, err := parseCLIEmitMode("wasm"); err == nil {
+		t.Fatal("parseCLIEmitMode(wasm) succeeded; want error")
+	}
+}
+
+func TestValidateCLIEmit(t *testing.T) {
+	valid := []struct {
+		tool string
+		name backend.Name
+		mode backend.EmitMode
+	}{
+		{"gen", backend.NameGo, backend.EmitGoSource},
+		{"gen", backend.NameLLVM, backend.EmitLLVMIR},
+		{"build", backend.NameGo, backend.EmitGoSource},
+		{"build", backend.NameGo, backend.EmitBinary},
+		{"build", backend.NameLLVM, backend.EmitObject},
+		{"run", backend.NameGo, backend.EmitBinary},
+		{"test", backend.NameGo, backend.EmitBinary},
+	}
+	for _, tc := range valid {
+		if err := validateCLIEmit(tc.tool, tc.name, tc.mode); err != nil {
+			t.Fatalf("validateCLIEmit(%q, %q, %q): %v", tc.tool, tc.name, tc.mode, err)
+		}
+	}
+
+	invalid := []struct {
+		tool string
+		name backend.Name
+		mode backend.EmitMode
+		want string
+	}{
+		{"gen", backend.NameGo, backend.EmitBinary, "cannot emit"},
+		{"gen", backend.NameLLVM, backend.EmitObject, "cannot emit"},
+		{"build", backend.NameGo, backend.EmitObject, "cannot emit"},
+		{"run", backend.NameGo, backend.EmitGoSource, "requires --emit"},
+		{"test", backend.NameLLVM, backend.EmitLLVMIR, "requires --emit"},
+	}
+	for _, tc := range invalid {
+		err := validateCLIEmit(tc.tool, tc.name, tc.mode)
+		if err == nil {
+			t.Fatalf("validateCLIEmit(%q, %q, %q) succeeded; want error", tc.tool, tc.name, tc.mode)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("validateCLIEmit(%q, %q, %q) = %v, want substring %q", tc.tool, tc.name, tc.mode, err, tc.want)
+		}
+	}
+}
+
+func TestRequireImplementedBackend(t *testing.T) {
+	if err := requireImplementedBackend(backend.NameGo); err != nil {
+		t.Fatalf("go backend rejected: %v", err)
+	}
+	err := requireImplementedBackend(backend.NameLLVM)
+	if err == nil {
+		t.Fatal("llvm backend accepted; want not-implemented error")
+	}
+	if !strings.Contains(err.Error(), "not implemented yet") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -11,9 +12,9 @@ import (
 	"runtime"
 	"sort"
 
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/gen"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
@@ -42,16 +43,21 @@ import (
 func runBuild(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty build [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--force] [PATH]")
+		fmt.Fprintln(os.Stderr, "usage: osty build [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [--force] [PATH]")
 	}
 	var offline, force, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
 	fs.BoolVar(&locked, "locked", false, "fail if osty.lock would change")
 	fs.BoolVar(&frozen, "frozen", false, "imply --locked --offline; require an existing osty.lock")
 	fs.BoolVar(&force, "force", false, "ignore the build cache; transpile every input")
+	var backendName string
+	var emitName string
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (go or llvm)")
+	fs.StringVar(&emitName, "emit", "", "artifact mode (go, llvm-ir, object, or binary)")
 	var pf profileFlags
 	pf.register(fs)
 	_ = fs.Parse(args)
+	_, emitMode := resolveBackendAndEmitFlags("build", backendName, emitName)
 	start := "."
 	if fs.NArg() == 1 {
 		start = fs.Arg(0)
@@ -85,7 +91,7 @@ func runBuild(args []string, flags cliFlags) {
 	// under the project root and compare against the cached
 	// fingerprint. A matching record lets us skip the front-end +
 	// gen entirely; --force overrides this.
-	if !force {
+	if !force && emitMode == backend.EmitBinary {
 		if fp, err := profile.ReadFingerprint(root, profileName, triple); err == nil && fp != nil {
 			curSrc, err := profile.HashSources(root, isOstySource)
 			if err == nil {
@@ -133,9 +139,9 @@ func runBuild(args []string, flags cliFlags) {
 	deps := pkgmgr.NewDepProvider(m, graph, env)
 	featSet := featureSet(resolved)
 	if m.Workspace != nil {
-		buildWorkspace(root, m, flags, deps, resolved, featSet)
+		buildWorkspace(root, m, flags, deps, resolved, featSet, emitMode)
 	} else {
-		buildPackage(root, m, flags, deps, resolved, featSet)
+		buildPackage(root, m, flags, deps, resolved, featSet, emitMode)
 	}
 
 	// Step 6: record the build fingerprint under .osty/cache/ so the
@@ -143,11 +149,13 @@ func runBuild(args []string, flags cliFlags) {
 	// failure to write the fingerprint is logged but doesn't fail
 	// the build — correctness is preserved, we just lose the
 	// incremental speed-up next time.
-	if sources, err := profile.HashSources(root, isOstySource); err == nil {
-		augmentSourcesWithProjectFiles(sources, root)
-		fp := profile.NewFingerprint(sources, resolved, toolVersion())
-		if err := fp.Write(root); err != nil {
-			fmt.Fprintf(os.Stderr, "osty build: warning: cache write failed: %v\n", err)
+	if emitMode == backend.EmitBinary {
+		if sources, err := profile.HashSources(root, isOstySource); err == nil {
+			augmentSourcesWithProjectFiles(sources, root)
+			fp := profile.NewFingerprint(sources, resolved, toolVersion())
+			if err := fp.Write(root); err != nil {
+				fmt.Fprintf(os.Stderr, "osty build: warning: cache write failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -214,7 +222,7 @@ func toolVersion() string {
 // targets to vendored packages resolve. When the root manifest declares
 // a binary entry point, it is additionally transpiled and linked with
 // `go build` using the resolved profile's go-flags / env.
-func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool) {
+func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, emitMode backend.EmitMode) {
 	ws, err := resolve.NewWorkspace(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
@@ -263,7 +271,7 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 	if m.HasPackage {
 		rootPkg := ws.Packages[""]
 		if rootPkg != nil {
-			emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats)
+			emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats, emitMode)
 		}
 	}
 }
@@ -275,7 +283,7 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 // DepProvider. The plain resolve.LoadPackage path is kept as a
 // fallback for zero-dep projects because it's simpler and has no
 // workspace state to carry.
-func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool) {
+func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve.DepProvider, resolved *profile.Resolved, feats map[string]bool, emitMode backend.EmitMode) {
 	if deps != nil {
 		ws, err := resolve.NewWorkspace(dir)
 		if err != nil {
@@ -306,7 +314,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 		}
 		rootPkg := ws.Packages[""]
 		if rootPkg != nil {
-			emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats)
+			emitAndBuild(dir, m, rootPkg, results[""], checks[""], resolved, feats, emitMode)
 		}
 		return
 	}
@@ -325,16 +333,16 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 	// Note: the no-deps path feeds a synthetic PackageResult because
 	// emitAndBuild expects a *resolve.PackageResult with Diags; we
 	// already have all of it from ResolvePackage above.
-	emitAndBuild(dir, m, pkg, res, chk, resolved, feats)
+	emitAndBuild(dir, m, pkg, res, chk, resolved, feats, emitMode)
 }
 
-// emitAndBuild is the gen + `go build` driver. It picks the entry
+// emitAndBuild is the Go backend + `go build` driver. It picks the entry
 // file (manifest `[bin].path` or default `main.osty`), transpiles it
-// to Go via gen.Generate, writes the output under
-// .osty/out/<profile>[-<triple>]/, and invokes the Go toolchain with
-// the resolved profile's go-flags + target env. Libraries (no entry
-// file on disk) are a no-op until the emitter grows package-per-package
-// output.
+// through internal/backend, writes the output under
+// .osty/out/<profile>[-<triple>]/go/, and invokes the Go toolchain
+// with the resolved profile's go-flags + target env. Libraries (no
+// entry file on disk) are a no-op until the emitter grows
+// package-per-package output.
 //
 // Files whose header declares `@feature: NAME` via the @feature
 // pragma are skipped when NAME isn't in the active feature set, so
@@ -342,7 +350,7 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 //
 // A failure at the go-build step returns a non-zero exit; a gen-time
 // TODO marker is only logged so the clean portion remains inspectable.
-func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result, resolved *profile.Resolved, feats map[string]bool) {
+func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *resolve.PackageResult, chk *check.Result, resolved *profile.Resolved, feats map[string]bool, emitMode backend.EmitMode) {
 	// 1. Locate the entry file. A library project has no entry;
 	// skip the emit path so `osty build` still works as a front-end
 	// check for libs.
@@ -387,30 +395,47 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 	if chk == nil {
 		chk = &check.Result{}
 	}
-	goSrc, gerr := gen.GenerateMapped("main", entryFile.File, res, chk, entryAbs)
-	// 5. Write the generated Go into the profile-scoped out dir.
 	profileName, triple := resolvedKey(resolved)
-	outDir := profile.OutputDir(root, profileName, triple)
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
+	binName := ""
+	if emitMode == backend.EmitBinary {
+		binName = binaryName(m)
+		if triple != "" {
+			binName += "-" + triple
+		}
+		if runtime.GOOS == "windows" && (triple == "" || resolved.Target == nil || resolved.Target.OS == "windows") {
+			binName += ".exe"
+		}
+	}
+	goResult, err := backend.GoBackend{}.Emit(context.Background(), backend.Request{
+		Layout: backend.Layout{
+			Root:    root,
+			Profile: profileName,
+			Target:  triple,
+		},
+		Emit: emitMode,
+		Entry: backend.Entry{
+			PackageName: "main",
+			SourcePath:  entryAbs,
+			File:        entryFile.File,
+			Resolve:     res,
+			Check:       chk,
+		},
+		BinaryName: binName,
+		Features:   resolved.Features,
+	})
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}
-	goSrc = prependBuildConstraint(goSrc, resolved)
-	goPath := filepath.Join(outDir, "main.go")
-	if err := os.WriteFile(goPath, goSrc, 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
-		os.Exit(1)
+	goPath := goResult.Artifacts.GoSource
+	outDir := goResult.Artifacts.OutputDir
+	reportTranspileWarning("osty build", entryAbs, goPath, firstBackendWarning(goResult))
+	if emitMode == backend.EmitGoSource {
+		fmt.Printf("Generated %s (%s)\n", goPath, profileName)
+		return
 	}
-	reportTranspileWarning("osty build", entryAbs, goPath, gerr)
-	// 6. Invoke `go build -o <bin>` with profile flags + target env.
-	binName := binaryName(m)
-	if triple != "" {
-		binName += "-" + triple
-	}
-	if runtime.GOOS == "windows" && (triple == "" || resolved.Target == nil || resolved.Target.OS == "windows") {
-		binName += ".exe"
-	}
-	binPath := filepath.Join(outDir, binName)
+	// 5. Invoke `go build -o <bin>` with profile flags + target env.
+	binPath := goResult.Artifacts.Binary
 	buildArgs := []string{"build"}
 	buildArgs = append(buildArgs, resolved.GoFlags()...)
 	buildArgs = append(buildArgs, "-o", binPath, goPath)
@@ -466,38 +491,6 @@ func resolvedKey(r *profile.Resolved) (string, string) {
 		}
 	}
 	return name, triple
-}
-
-// prependBuildConstraint injects any //go:build constraints that the
-// active feature set implies. Go's tooling already consumes the
-// `-tags=feat_*` flag we attach in Resolved.GoFlags, so the constraint
-// here is a belt-and-suspenders — downstream tooling (IDE builders,
-// gopls) that doesn't see our -tags flag still treats the file
-// correctly.
-func prependBuildConstraint(src []byte, r *profile.Resolved) []byte {
-	if r == nil || len(r.Features) == 0 {
-		return src
-	}
-	constraints := make([]string, 0, len(r.Features))
-	for _, f := range r.Features {
-		constraints = append(constraints, "feat_"+f)
-	}
-	sort.Strings(constraints)
-	header := "//go:build " + join(constraints, " && ") + "\n\n"
-	return append([]byte(header), src...)
-}
-
-// join is a small helper to avoid importing strings in the narrow
-// prepend path (keeping the import list minimal elsewhere).
-func join(parts []string, sep string) string {
-	if len(parts) == 0 {
-		return ""
-	}
-	out := parts[0]
-	for i := 1; i < len(parts); i++ {
-		out += sep + parts[i]
-	}
-	return out
 }
 
 // (renderManifestDiags was superseded by loadManifestWithDiag in

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1132,6 +1132,8 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "gen-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  -o PATH            write Go source to PATH instead of stdout")
 	fmt.Fprintln(os.Stderr, "  --package NAME     Go package clause (default: main)")
+	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (go or llvm; default go)")
+	fmt.Fprintln(os.Stderr, "  --emit MODE        artifact mode (go or llvm-ir; default follows backend)")
 	fmt.Fprintln(os.Stderr, "new-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --lib              scaffold a library project (lib.osty, no main)")
 	fmt.Fprintln(os.Stderr, "  --bin              scaffold a binary project (main.osty) [default]")
@@ -1148,12 +1150,14 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --dry-run          build the tarball but do not upload")
 	fmt.Fprintln(os.Stderr, "Common flags for build / add / update / run / test:")
 	fmt.Fprintln(os.Stderr, "  --offline          do not fetch dependencies; fail if caches are missing")
-	fmt.Fprintln(os.Stderr, "build / run flags:")
+	fmt.Fprintln(os.Stderr, "build / run / test flags:")
 	fmt.Fprintln(os.Stderr, "  --profile NAME     build profile (debug, release, profile, test, ...)")
 	fmt.Fprintln(os.Stderr, "  --release          shorthand for --profile release")
 	fmt.Fprintln(os.Stderr, "  --target TRIPLE    cross-compilation target (e.g. amd64-linux)")
 	fmt.Fprintln(os.Stderr, "  --features LIST    comma-separated feature flags to enable")
 	fmt.Fprintln(os.Stderr, "  --no-default-features  drop the manifest's [features].default set")
+	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (go or llvm; default go)")
+	fmt.Fprintln(os.Stderr, "  --emit MODE        artifact mode (go, llvm-ir, object, or binary)")
 	fmt.Fprintln(os.Stderr, "build-specific flags:")
 	fmt.Fprintln(os.Stderr, "  --force            ignore the build cache and rebuild from source")
 }
@@ -1290,14 +1294,19 @@ func runFmt(args []string) {
 func runGen(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("gen", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty gen [-o OUT.go] FILE.osty")
+		fmt.Fprintln(os.Stderr, "usage: osty gen [--backend NAME] [--emit MODE] [-o OUT] FILE.osty")
 	}
 	var outPath string
 	var pkgName string
+	var backendName string
+	var emitName string
 	fs.StringVar(&outPath, "o", "", "write Go source to this file instead of stdout")
 	fs.StringVar(&outPath, "out", "", "alias for -o")
 	fs.StringVar(&pkgName, "package", "main", "Go package clause (default: main)")
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (go or llvm)")
+	fs.StringVar(&emitName, "emit", "", "artifact mode (go or llvm-ir; default follows backend)")
 	_ = fs.Parse(args)
+	_, _ = resolveBackendAndEmitFlags("gen", backendName, emitName)
 	if fs.NArg() != 1 {
 		fs.Usage()
 		os.Exit(2)

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -10,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
-	"github.com/osty/osty/internal/gen"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
@@ -28,7 +29,7 @@ import (
 //  2. Resolve the project as a package; confirm we have an entry
 //     point (manifest Bin target or default main.osty with fn main).
 //  3. Run the front-end (parse + resolve + type check).
-//  4. Transpile the entry file via internal/gen into a temp directory.
+//  4. Transpile the entry file via internal/backend into .osty/out.
 //  5. `go run` the generated Go source, passing through the
 //     user-supplied arguments after `--`.
 //
@@ -48,15 +49,20 @@ import (
 func runRun(args []string, cliF cliFlags) {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty run [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [-- ARGS...]")
+		fmt.Fprintln(os.Stderr, "usage: osty run [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [-- ARGS...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
 	fs.BoolVar(&locked, "locked", false, "fail if osty.lock would change")
 	fs.BoolVar(&frozen, "frozen", false, "imply --locked --offline; require an existing osty.lock")
+	var backendName string
+	var emitName string
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (go or llvm)")
+	fs.StringVar(&emitName, "emit", "", "artifact mode to execute (binary)")
 	var pf profileFlags
 	pf.register(fs)
 	_ = fs.Parse(args)
+	_, emitMode := resolveBackendAndEmitFlags("run", backendName, emitName)
 	runArgs := fs.Args()
 
 	runDir, err := os.Getwd()
@@ -173,27 +179,37 @@ func runRun(args []string, cliF cliFlags) {
 		chk = &check.Result{}
 	}
 
-	// Step 4: transpile to Go. Per-profile/target subdirectories keep
-	// debug / release / cross-built artifacts from clobbering each
-	// other.
+	// Step 4: transpile to Go. Per-profile/target/backend
+	// subdirectories keep debug / release / cross-built artifacts from
+	// clobbering each other.
 	triple := ""
 	if resolved.Target != nil {
 		triple = resolved.Target.Triple
 	}
-	outDir := profile.OutputDir(root, resolved.Profile.Name, triple)
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
-		os.Exit(1)
-	}
-	goSrc, gerr := gen.GenerateMapped("main", file, res, chk, entryAbs)
-	goPath := filepath.Join(outDir, "main.go")
-	if err := os.WriteFile(goPath, goSrc, 0o644); err != nil {
+	goResult, err := backend.GoBackend{}.Emit(context.Background(), backend.Request{
+		Layout: backend.Layout{
+			Root:    root,
+			Profile: resolved.Profile.Name,
+			Target:  triple,
+		},
+		Emit: emitMode,
+		Entry: backend.Entry{
+			PackageName: "main",
+			SourcePath:  entryAbs,
+			File:        file,
+			Resolve:     res,
+			Check:       chk,
+		},
+		Features: resolved.Features,
+	})
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
 	}
 	// Gen returns warnings for unsupported lowering shapes; we still
 	// try to run the output because the clean portion may compile.
-	reportTranspileWarning("osty run", entryAbs, goPath, gerr)
+	goPath := goResult.Artifacts.GoSource
+	reportTranspileWarning("osty run", entryAbs, goPath, firstBackendWarning(goResult))
 
 	// Step 5: go run. Profile-derived flags (e.g. `-gcflags=-N -l`
 	// for debug, `-ldflags=-s -w` for release) precede the source

--- a/cmd/osty/run_integration_test.go
+++ b/cmd/osty/run_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/profile"
 )
 
@@ -72,7 +73,10 @@ func TestBuildStdFSBinary(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		exeName += ".exe"
 	}
-	exe := filepath.Join(profile.OutputDir(dir, profile.NameDebug, ""), exeName)
+	exe := backend.Layout{
+		Root:    dir,
+		Profile: profile.NameDebug,
+	}.Artifacts(backend.NameGo, exeName).Binary
 	cmd := exec.Command(exe)
 	cmd.Dir = dir
 	var buf bytes.Buffer

--- a/cmd/osty/test.go
+++ b/cmd/osty/test.go
@@ -66,15 +66,20 @@ import (
 func runTest(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("test", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty test [--offline | --locked | --frozen] [PATH|FILTER...]")
+		fmt.Fprintln(os.Stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [PATH|FILTER...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
 	fs.BoolVar(&locked, "locked", false, "fail if osty.lock would change")
 	fs.BoolVar(&frozen, "frozen", false, "imply --locked --offline; require an existing osty.lock")
+	var backendName string
+	var emitName string
+	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (go or llvm)")
+	fs.StringVar(&emitName, "emit", "", "artifact mode to execute (binary)")
 	var pf profileFlags
 	pf.register(fs)
 	_ = fs.Parse(args)
+	_, _ = resolveBackendAndEmitFlags("test", backendName, emitName)
 	positional := fs.Args()
 
 	// Split positional args into path targets (existing on disk) and

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -1,0 +1,151 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// Name is the stable user/tooling identifier for a code-generation backend.
+// It is also the backend artifact directory name under .osty/out/<key>/.
+type Name string
+
+const (
+	NameGo   Name = "go"
+	NameLLVM Name = "llvm"
+)
+
+// ParseName converts a CLI/config backend name into a Name.
+func ParseName(s string) (Name, error) {
+	switch Name(s) {
+	case NameGo:
+		return NameGo, nil
+	case NameLLVM:
+		return NameLLVM, nil
+	default:
+		return "", fmt.Errorf("unknown backend %q (want go or llvm)", s)
+	}
+}
+
+func (n Name) String() string { return string(n) }
+
+// Valid reports whether n is a known backend name.
+func (n Name) Valid() bool {
+	switch n {
+	case NameGo, NameLLVM:
+		return true
+	default:
+		return false
+	}
+}
+
+// EmitMode describes how far a backend should drive code generation.
+type EmitMode string
+
+const (
+	EmitGoSource EmitMode = "go"
+	EmitLLVMIR   EmitMode = "llvm-ir"
+	EmitObject   EmitMode = "object"
+	EmitBinary   EmitMode = "binary"
+)
+
+// ParseEmitMode converts a CLI/config emit mode into an EmitMode.
+func ParseEmitMode(s string) (EmitMode, error) {
+	switch EmitMode(s) {
+	case EmitGoSource:
+		return EmitGoSource, nil
+	case EmitLLVMIR:
+		return EmitLLVMIR, nil
+	case EmitObject:
+		return EmitObject, nil
+	case EmitBinary:
+		return EmitBinary, nil
+	default:
+		return "", fmt.Errorf("unknown emit mode %q (want go, llvm-ir, object, or binary)", s)
+	}
+}
+
+func (m EmitMode) String() string { return string(m) }
+
+// Valid reports whether m is a known emit mode.
+func (m EmitMode) Valid() bool {
+	switch m {
+	case EmitGoSource, EmitLLVMIR, EmitObject, EmitBinary:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidFor reports whether backend n can produce emit mode m.
+func (m EmitMode) ValidFor(n Name) bool {
+	switch n {
+	case NameGo:
+		return m == EmitGoSource || m == EmitBinary
+	case NameLLVM:
+		return m == EmitLLVMIR || m == EmitObject || m == EmitBinary
+	default:
+		return false
+	}
+}
+
+// ValidateEmit returns an error when emit mode m is not meaningful for backend
+// n. CLI plumbing should call this before dispatching to a concrete backend.
+func ValidateEmit(n Name, m EmitMode) error {
+	if !n.Valid() {
+		return fmt.Errorf("unknown backend %q", n)
+	}
+	if !m.Valid() {
+		return fmt.Errorf("unknown emit mode %q", m)
+	}
+	if !m.ValidFor(n) {
+		return fmt.Errorf("backend %q cannot emit %q", n, m)
+	}
+	return nil
+}
+
+// Backend is implemented by concrete code-generation backends.
+//
+// Phase 5 only defines the interface. Later phases will wrap the existing Go
+// transpiler behind it and add the LLVM implementation.
+type Backend interface {
+	Name() Name
+	Emit(context.Context, Request) (*Result, error)
+}
+
+// Entry is the type-checked source unit a backend should emit. It mirrors the
+// current Go transpiler inputs while keeping them grouped under one contract.
+type Entry struct {
+	PackageName string
+	SourcePath  string
+	File        *ast.File
+	Resolve     *resolve.Result
+	Check       *check.Result
+}
+
+// Request is the backend-neutral build request shared by gen/build/run/test
+// orchestration.
+type Request struct {
+	Layout     Layout
+	Emit       EmitMode
+	Entry      Entry
+	BinaryName string
+	Features   []string
+}
+
+// Artifacts returns the conventional artifact paths for backend n.
+func (r Request) Artifacts(n Name) Artifacts {
+	return r.Layout.Artifacts(n, r.BinaryName)
+}
+
+// Result is the backend-neutral execution result returned by concrete
+// backends. Warnings are non-fatal lowering/runtime/toolchain observations.
+type Result struct {
+	Backend   Name
+	Emit      EmitMode
+	Artifacts Artifacts
+	Warnings  []error
+}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,0 +1,182 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestParseName(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want Name
+	}{
+		{"go", NameGo},
+		{"llvm", NameLLVM},
+	} {
+		got, err := ParseName(tc.in)
+		if err != nil {
+			t.Fatalf("ParseName(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	if _, err := ParseName("wasm"); err == nil {
+		t.Fatal("ParseName(wasm) succeeded; want error")
+	}
+}
+
+func TestValidateEmit(t *testing.T) {
+	valid := []struct {
+		name Name
+		mode EmitMode
+	}{
+		{NameGo, EmitGoSource},
+		{NameGo, EmitBinary},
+		{NameLLVM, EmitLLVMIR},
+		{NameLLVM, EmitObject},
+		{NameLLVM, EmitBinary},
+	}
+	for _, tc := range valid {
+		if err := ValidateEmit(tc.name, tc.mode); err != nil {
+			t.Fatalf("ValidateEmit(%q, %q): %v", tc.name, tc.mode, err)
+		}
+	}
+	invalid := []struct {
+		name Name
+		mode EmitMode
+	}{
+		{NameGo, EmitLLVMIR},
+		{NameGo, EmitObject},
+		{NameLLVM, EmitGoSource},
+		{Name("bad"), EmitBinary},
+		{NameGo, EmitMode("bad")},
+	}
+	for _, tc := range invalid {
+		if err := ValidateEmit(tc.name, tc.mode); err == nil {
+			t.Fatalf("ValidateEmit(%q, %q) succeeded; want error", tc.name, tc.mode)
+		}
+	}
+}
+
+func TestLayoutPaths(t *testing.T) {
+	root := filepath.Join("tmp", "project")
+	l := Layout{Root: root, Profile: "debug"}
+
+	if got, want := l.Key(), "debug"; got != want {
+		t.Fatalf("Key() = %q, want %q", got, want)
+	}
+	if got, want := l.OutputRoot(), filepath.Join(root, ".osty", "out", "debug"); got != want {
+		t.Fatalf("OutputRoot() = %q, want %q", got, want)
+	}
+	if got, want := l.OutputDir(NameGo), filepath.Join(root, ".osty", "out", "debug", "go"); got != want {
+		t.Fatalf("OutputDir(go) = %q, want %q", got, want)
+	}
+	if got, want := l.CachePath(NameLLVM), filepath.Join(root, ".osty", "cache", "debug", "llvm.json"); got != want {
+		t.Fatalf("CachePath(llvm) = %q, want %q", got, want)
+	}
+	if got, want := l.LegacyCachePath(), filepath.Join(root, ".osty", "cache", "debug.json"); got != want {
+		t.Fatalf("LegacyCachePath() = %q, want %q", got, want)
+	}
+}
+
+func TestLayoutTargetPaths(t *testing.T) {
+	root := filepath.Join("tmp", "project")
+	l := Layout{Root: root, Profile: "release", Target: "amd64-linux"}
+
+	if got, want := l.Key(), "release-amd64-linux"; got != want {
+		t.Fatalf("Key() = %q, want %q", got, want)
+	}
+	if got, want := l.OutputDir(NameLLVM), filepath.Join(root, ".osty", "out", "release-amd64-linux", "llvm"); got != want {
+		t.Fatalf("OutputDir(llvm) = %q, want %q", got, want)
+	}
+	if got, want := l.CachePath(NameGo), filepath.Join(root, ".osty", "cache", "release-amd64-linux", "go.json"); got != want {
+		t.Fatalf("CachePath(go) = %q, want %q", got, want)
+	}
+}
+
+func TestArtifacts(t *testing.T) {
+	root := filepath.Join("tmp", "project")
+	l := Layout{Root: root, Profile: "debug"}
+
+	goArtifacts := l.Artifacts(NameGo, "app")
+	if got, want := goArtifacts.GoSource, filepath.Join(root, ".osty", "out", "debug", "go", "main.go"); got != want {
+		t.Fatalf("GoSource = %q, want %q", got, want)
+	}
+	if goArtifacts.LLVMIR != "" || goArtifacts.Object != "" || goArtifacts.RuntimeDir != "" {
+		t.Fatalf("Go artifacts populated LLVM fields: %+v", goArtifacts)
+	}
+	if got, want := goArtifacts.Binary, filepath.Join(root, ".osty", "out", "debug", "go", "app"); got != want {
+		t.Fatalf("Go Binary = %q, want %q", got, want)
+	}
+
+	llvmArtifacts := l.Artifacts(NameLLVM, "app")
+	if got, want := llvmArtifacts.LLVMIR, filepath.Join(root, ".osty", "out", "debug", "llvm", "main.ll"); got != want {
+		t.Fatalf("LLVMIR = %q, want %q", got, want)
+	}
+	if got, want := llvmArtifacts.Object, filepath.Join(root, ".osty", "out", "debug", "llvm", "main.o"); got != want {
+		t.Fatalf("Object = %q, want %q", got, want)
+	}
+	if got, want := llvmArtifacts.RuntimeDir, filepath.Join(root, ".osty", "out", "debug", "llvm", "runtime"); got != want {
+		t.Fatalf("RuntimeDir = %q, want %q", got, want)
+	}
+	if llvmArtifacts.GoSource != "" {
+		t.Fatalf("LLVM artifacts populated GoSource: %+v", llvmArtifacts)
+	}
+}
+
+func TestGoBackendEmitWritesSource(t *testing.T) {
+	src := []byte(`fn main() {
+    println(42)
+}
+`)
+	file, diags := parser.ParseDiagnostics(src)
+	if len(diags) != 0 {
+		t.Fatalf("parse diagnostics: %v", diags)
+	}
+	res := resolve.File(file, resolve.NewPrelude())
+	chk := check.File(file, res)
+
+	root := t.TempDir()
+	req := Request{
+		Layout: Layout{Root: root, Profile: "debug"},
+		Emit:   EmitGoSource,
+		Entry: Entry{
+			PackageName: "main",
+			SourcePath:  filepath.Join(root, "main.osty"),
+			File:        file,
+			Resolve:     res,
+			Check:       chk,
+		},
+		Features: []string{"alpha"},
+	}
+	result, err := GoBackend{}.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	wantPath := filepath.Join(root, ".osty", "out", "debug", "go", "main.go")
+	if result.Artifacts.GoSource != wantPath {
+		t.Fatalf("GoSource = %q, want %q", result.Artifacts.GoSource, wantPath)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read emitted source: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"//go:build feat_alpha",
+		"package main",
+		"// Osty: " + filepath.Join(root, "main.osty") + ":1:1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("emitted source missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -1,0 +1,8 @@
+// Package backend defines the small contract shared by concrete Osty
+// code-generation backends.
+//
+// The current CLI still calls the Go transpiler directly. This package is the
+// migration point for making that path backend-aware before adding LLVM output:
+// it owns stable backend names, emit modes, artifact/cache layout helpers, and
+// the minimal interface concrete backends will implement.
+package backend

--- a/internal/backend/go.go
+++ b/internal/backend/go.go
@@ -1,0 +1,107 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/gen"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// GoBackend wraps the existing Go transpiler behind the backend contract.
+type GoBackend struct{}
+
+func (GoBackend) Name() Name { return NameGo }
+
+// Emit writes generated Go source to the backend-aware artifact path. For
+// EmitBinary, callers still invoke `go build` themselves; this method prepares
+// the source artifact and reports the conventional binary path.
+func (GoBackend) Emit(ctx context.Context, req Request) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := ValidateEmit(NameGo, req.Emit); err != nil {
+		return nil, err
+	}
+	if req.Entry.File == nil {
+		return nil, fmt.Errorf("go backend: nil entry file")
+	}
+	pkgName := req.Entry.PackageName
+	if pkgName == "" {
+		pkgName = "main"
+	}
+	res := req.Entry.Resolve
+	if res == nil {
+		res = &resolve.Result{}
+	}
+	chk := req.Entry.Check
+	if chk == nil {
+		chk = &check.Result{}
+	}
+
+	artifacts := req.Artifacts(NameGo)
+	if err := os.MkdirAll(artifacts.OutputDir, 0o755); err != nil {
+		return nil, err
+	}
+	src, genErr := gen.GenerateMapped(pkgName, req.Entry.File, res, chk, req.Entry.SourcePath)
+	src = prependGoBuildConstraints(src, req.Features)
+	if err := os.WriteFile(artifacts.GoSource, src, 0o644); err != nil {
+		return nil, err
+	}
+
+	out := &Result{
+		Backend:   NameGo,
+		Emit:      req.Emit,
+		Artifacts: artifacts,
+	}
+	if genErr != nil {
+		out.Warnings = append(out.Warnings, genErr)
+	}
+	return out, nil
+}
+
+func prependGoBuildConstraints(src []byte, features []string) []byte {
+	if len(features) == 0 {
+		return src
+	}
+	constraints := make([]string, 0, len(features))
+	for _, f := range features {
+		if f == "" {
+			continue
+		}
+		constraints = append(constraints, "feat_"+f)
+	}
+	if len(constraints) == 0 {
+		return src
+	}
+	sort.Strings(constraints)
+	header := "//go:build " + join(constraints, " && ") + "\n\n"
+	return append([]byte(header), src...)
+}
+
+func join(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += sep + parts[i]
+	}
+	return out
+}
+
+// SourcePath returns a clean source path for diagnostics. Kept as a helper so
+// callers do not need to know the artifact struct's field names.
+func (a Artifacts) SourcePath() string {
+	if a.GoSource != "" {
+		return filepath.Clean(a.GoSource)
+	}
+	if a.LLVMIR != "" {
+		return filepath.Clean(a.LLVMIR)
+	}
+	return ""
+}

--- a/internal/backend/layout.go
+++ b/internal/backend/layout.go
@@ -1,0 +1,85 @@
+package backend
+
+import (
+	"path/filepath"
+
+	"github.com/osty/osty/internal/profile"
+)
+
+// Layout identifies the project/profile/target namespace for backend
+// artifacts. It preserves the existing profile.ArtifactKey convention and adds
+// a backend subdirectory underneath it.
+type Layout struct {
+	Root    string
+	Profile string
+	Target  string
+}
+
+// Key returns the profile/target artifact key, e.g. "debug" or
+// "release-amd64-linux".
+func (l Layout) Key() string {
+	return profile.ArtifactKey(l.Profile, l.Target)
+}
+
+// OutputRoot returns <root>/.osty/out/<key>.
+func (l Layout) OutputRoot() string {
+	return profile.OutputDir(l.Root, l.Profile, l.Target)
+}
+
+// OutputDir returns <root>/.osty/out/<key>/<backend>.
+func (l Layout) OutputDir(n Name) string {
+	return filepath.Join(l.OutputRoot(), n.String())
+}
+
+// CacheRoot returns <root>/.osty/cache/<key>.
+func (l Layout) CacheRoot() string {
+	return filepath.Join(l.Root, profile.CacheDirName, l.Key())
+}
+
+// CachePath returns <root>/.osty/cache/<key>/<backend>.json.
+func (l Layout) CachePath(n Name) string {
+	return filepath.Join(l.CacheRoot(), n.String()+".json")
+}
+
+// LegacyCachePath returns the current Go-only fingerprint path. It exists so
+// the migration can read or retire old cache files deliberately.
+func (l Layout) LegacyCachePath() string {
+	return profile.CachePath(l.Root, l.Profile, l.Target)
+}
+
+// Artifacts is the conventional set of paths a backend may write. Not every
+// field is populated by every backend or emit mode.
+type Artifacts struct {
+	Key       string
+	OutputDir string
+	CachePath string
+
+	GoSource string
+	LLVMIR   string
+	Object   string
+	Binary   string
+
+	RuntimeDir string
+}
+
+// Artifacts returns conventional artifact paths for backend n. binaryName may
+// be empty when the caller only needs source/IR/object paths.
+func (l Layout) Artifacts(n Name, binaryName string) Artifacts {
+	out := Artifacts{
+		Key:       l.Key(),
+		OutputDir: l.OutputDir(n),
+		CachePath: l.CachePath(n),
+	}
+	switch n {
+	case NameGo:
+		out.GoSource = filepath.Join(out.OutputDir, "main.go")
+	case NameLLVM:
+		out.LLVMIR = filepath.Join(out.OutputDir, "main.ll")
+		out.Object = filepath.Join(out.OutputDir, "main.o")
+		out.RuntimeDir = filepath.Join(out.OutputDir, "runtime")
+	}
+	if binaryName != "" {
+		out.Binary = filepath.Join(out.OutputDir, binaryName)
+	}
+	return out
+}

--- a/testdata/backend/llvm_smoke/booleans.osty
+++ b/testdata/backend/llvm_smoke/booleans.osty
@@ -1,0 +1,11 @@
+fn choose(a: Int, b: Int) -> Int {
+    if a < b && !(a == 0) {
+        b - a
+    } else {
+        a + b
+    }
+}
+
+fn main() {
+    println(choose(3, 10))
+}

--- a/testdata/backend/llvm_smoke/control_flow.osty
+++ b/testdata/backend/llvm_smoke/control_flow.osty
@@ -1,0 +1,11 @@
+fn sumTo(n: Int) -> Int {
+    let mut total = 0
+    for i in 1..=n {
+        total = total + i
+    }
+    total
+}
+
+fn main() {
+    println(sumTo(5))
+}

--- a/testdata/backend/llvm_smoke/scalar_arithmetic.osty
+++ b/testdata/backend/llvm_smoke/scalar_arithmetic.osty
@@ -1,0 +1,12 @@
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+
+fn main() {
+    let value = add(40, 2)
+    if value == 42 {
+        println(value)
+    } else {
+        println(0)
+    }
+}


### PR DESCRIPTION
## Summary
- document the LLVM migration plan, baseline, corpus, TODO audit, and backend-aware artifact layout
- add internal/backend with backend names, emit modes, artifact layout helpers, and a Go backend facade
- wire --backend and --emit through gen/build/run/test while keeping Go as the default and guarding LLVM as not implemented

## Tests
- go test -count=1 ./cmd/osty ./internal/backend ./internal/profile
- git diff --check
- smoke: gen/build/run emit/backend combinations for Go and LLVM guardrails