### PR TITLE
Port iter, bytes, encoding, and CSV stdlib bridges

### DIFF
--- a/LANG_SPEC_v0.4/10-standard-library/21-bytes.md
+++ b/LANG_SPEC_v0.4/10-standard-library/21-bytes.md
@@ -29,6 +29,7 @@ bytes.isEmpty(b: Bytes) -> Bool
 bytes.get(b: Bytes, i: Int) -> Byte?
 bytes.slice(b: Bytes, start: Int, end: Int) -> Bytes
 
+bytes.equal(a: Bytes, b: Bytes) -> Bool
 bytes.contains(b: Bytes, sub: Bytes) -> Bool
 bytes.startsWith(b: Bytes, prefix: Bytes) -> Bool
 bytes.endsWith(b: Bytes, suffix: Bytes) -> Bool

--- a/examples/dogfood/parser.osty
+++ b/examples/dogfood/parser.osty
@@ -1031,6 +1031,22 @@ fn opParseDeferStmt(p: OstyParser) -> Int {
     opAddNode(p, n)
 }
 
+fn opAtForInKeyword(p: OstyParser) -> Bool {
+    opAt(p, FrontIdent) && opPeek(p).text == "in"
+}
+
+fn opTryParseForInPattern(p: OstyParser) -> Int {
+    let savedPos = p.pos
+    let savedErrors = opErrorCount(p)
+    let patIdx = opParsePattern(p)
+    if opAtForInKeyword(p) {
+        return patIdx
+    }
+    p.pos = savedPos
+    opTruncateErrors(p, savedErrors)
+    return -1
+}
+
 fn opParseForStmt(p: OstyParser) -> Int {
     let start = p.pos
     let _ = opAdvance(p)
@@ -1050,20 +1066,23 @@ fn opParseForStmt(p: OstyParser) -> Int {
         condIdx = opParseExpr(p)
         p.noStructLit = pv
     } else {
-        let pv = p.noStructLit
-        p.noStructLit = true
-        let expr = opParseExpr(p)
-        p.noStructLit = pv
-        if opAt(p, FrontIdent) && opPeek(p).text == "in" {
+        let forInPat = opTryParseForInPattern(p)
+        if forInPat >= 0 {
             let _ = opAdvance(p)
             kind = "forin"
-            patIdx = expr
+            patIdx = forInPat
             let pv2 = p.noStructLit
             p.noStructLit = true
             iterIdx = opParseExpr(p)
             p.noStructLit = pv2
-        } else { kind = "cond"
-        condIdx = expr }
+        } else {
+            let pv = p.noStructLit
+            p.noStructLit = true
+            let expr = opParseExpr(p)
+            p.noStructLit = pv
+            kind = "cond"
+            condIdx = expr
+        }
     }
     let body = opParseBlock(p)
     p.inLoop = prevInLoop

--- a/internal/gen/audit_test.go
+++ b/internal/gen/audit_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/gen"
@@ -49,9 +50,14 @@ func TestSpecCorpusAudit(t *testing.T) {
 			t.Errorf("FAIL(parse) %s: parse errors (%d)", name, countErrs(parseDiags))
 			continue
 		}
-		res := resolve.File(file, resolve.NewPrelude())
+		file, res, err := resolveAuditFixture(t, src)
+		if err != nil {
+			t.Errorf("FAIL(resolve setup) %s: %v", name, err)
+			continue
+		}
 		if hasErr(res.Diags) {
-			t.Errorf("FAIL(resolve) %s: resolve errors (%d)", name, countErrs(res.Diags))
+			t.Errorf("FAIL(resolve) %s: resolve errors (%d): %s",
+				name, countErrs(res.Diags), firstErr(res.Diags))
 			continue
 		}
 		chk := check.File(file, res)
@@ -117,4 +123,73 @@ func countErrs(ds []*diag.Diagnostic) int {
 		}
 	}
 	return n
+}
+
+func firstErr(ds []*diag.Diagnostic) string {
+	for _, d := range ds {
+		if d.Severity == diag.Error {
+			return d.Error()
+		}
+	}
+	return ""
+}
+
+type auditDepProvider map[string]string
+
+func (p auditDepProvider) LookupDep(rawPath string) (string, bool) {
+	dir, ok := p[rawPath]
+	return dir, ok
+}
+
+func resolveAuditFixture(t *testing.T, src []byte) (*ast.File, *resolve.Result, error) {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.osty"), src, 0o644); err != nil {
+		return nil, nil, err
+	}
+
+	deps, err := writeAuditDeps(t.TempDir())
+	if err != nil {
+		return nil, nil, err
+	}
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	ws.Deps = deps
+	if _, err := ws.LoadPackage(""); err != nil {
+		return nil, nil, err
+	}
+	results := ws.ResolveAll()
+	pkg := ws.Packages[""]
+	if pkg == nil || len(pkg.Files) == 0 {
+		return nil, nil, os.ErrNotExist
+	}
+	pf := pkg.Files[0]
+	pr := results[""]
+	if pr == nil {
+		pr = &resolve.PackageResult{}
+	}
+	return pf.File, &resolve.Result{
+		Refs:      pf.Refs,
+		TypeRefs:  pf.TypeRefs,
+		FileScope: pf.FileScope,
+		Diags:     append(append([]*diag.Diagnostic{}, pf.ParseDiags...), pr.Diags...),
+	}, nil
+}
+
+func writeAuditDeps(root string) (auditDepProvider, error) {
+	provider := auditDepProvider{}
+	for _, key := range []string{"github.com/user/lib", "github.com/user/lib2"} {
+		dir := filepath.Join(root, strings.ReplaceAll(key, "/", "_"))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(filepath.Join(dir, "lib.osty"), []byte("pub fn marker() -> Int { 0 }\n"), 0o644); err != nil {
+			return nil, err
+		}
+		provider[key] = dir
+	}
+	return provider, nil
 }

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -463,10 +463,7 @@ func (g *gen) emitUseDecl(u *ast.UseDecl) {
 	// compatibility; well-known shims (std.testing, std.thread) get
 	// mock structs when they need a callable shape. The test harness
 	// separately replaces the std.testing stub with a real runtime.
-	alias := u.Alias
-	if alias == "" && len(u.Path) > 0 {
-		alias = u.Path[len(u.Path)-1]
-	}
+	alias := useDeclAlias(u)
 	if alias == "" {
 		return
 	}
@@ -633,6 +630,64 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			join:  urlJoin,
 		}`, full)
 		return true
+	case "encoding":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		g.needEncoding = true
+		g.needResult = true
+		g.emitUseStub(alias, `struct {
+			base64 struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+				url    struct {
+					encode func(data []byte) string
+					decode func(text string) Result[[]byte, any]
+				}
+			}
+			hex struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+			}
+			url struct {
+				encode func(text string) string
+				decode func(text string) Result[string, any]
+			}
+		}{
+			base64: struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+				url    struct {
+					encode func(data []byte) string
+					decode func(text string) Result[[]byte, any]
+				}
+			}{
+				encode: encodingBase64Encode,
+				decode: encodingBase64Decode,
+				url: struct {
+					encode func(data []byte) string
+					decode func(text string) Result[[]byte, any]
+				}{
+					encode: encodingBase64URLEncode,
+					decode: encodingBase64URLDecode,
+				},
+			},
+			hex: struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+			}{
+				encode: encodingHexEncode,
+				decode: encodingHexDecode,
+			},
+			url: struct {
+				encode func(text string) string
+				decode func(text string) Result[string, any]
+			}{
+				encode: encodingURLEncode,
+				decode: encodingURLDecode,
+			},
+		}`, full)
+		return true
 	case "bytes":
 		if !g.aliasUsedAsSelector(alias) {
 			return false
@@ -640,11 +695,13 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 		g.needBytesRuntime = true
 		g.needResult = true
 		g.emitUseStub(alias, `struct {
+			from        func(items []byte) []byte
 			fromString  func(s string) []byte
 			toString    func(b []byte) Result[string, any]
 			len         func(b []byte) int
 			isEmpty     func(b []byte) bool
 			get         func(b []byte, i int) *byte
+			slice       func(b []byte, start int, end int) []byte
 			equal       func(a []byte, b []byte) bool
 			contains    func(b []byte, sub []byte) bool
 			startsWith  func(b []byte, prefix []byte) bool
@@ -666,11 +723,13 @@ func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) 
 			toHex       func(b []byte) string
 			fromHex     func(s string) Result[[]byte, any]
 		}{
+			from:        bytesFrom,
 			fromString:  bytesFromString,
 			toString:    bytesToString,
 			len:         bytesLen,
 			isEmpty:     bytesIsEmpty,
 			get:         bytesGet,
+			slice:       bytesSlice,
 			equal:       bytesEqual,
 			contains:    bytesContains,
 			startsWith:  bytesStartsWith,
@@ -797,11 +856,14 @@ func _ostyCsvDecodeWith(text string, options _ostyCsvOptions) Result[[][]string,
 			i++
 			continue
 		}
+		if quoted && c != options.delimiter && c != '\r' && c != '\n' {
+			return resultErr[[][]string, any](fmt.Errorf("csv: data after closing quote"))
+		}
 		if c == options.quote {
 			if field.Len() == 0 {
 				inQuote = true
 			} else {
-				field.WriteRune(c)
+				return resultErr[[][]string, any](fmt.Errorf("csv: bare quote in unquoted field"))
 			}
 			endedRecord = false
 		} else if c == options.delimiter {
@@ -910,14 +972,7 @@ func (g *gen) fileIdentUsed(name string) bool {
 		}
 	}
 	for _, u := range g.file.Uses {
-		alias := u.Alias
-		if alias == "" {
-			if u.IsGoFFI {
-				alias = lastPathComponent(u.GoPath)
-			} else if len(u.Path) > 0 {
-				alias = u.Path[len(u.Path)-1]
-			}
-		}
+		alias := useDeclAlias(u)
 		if mangleIdent(alias) == name {
 			return true
 		}
@@ -1194,6 +1249,25 @@ func lastPathComponent(p string) string {
 		return p[i+1:]
 	}
 	return p
+}
+
+func useDeclAlias(u *ast.UseDecl) string {
+	if u == nil {
+		return ""
+	}
+	if u.Alias != "" {
+		return u.Alias
+	}
+	if u.IsGoFFI {
+		return lastPathComponent(u.GoPath)
+	}
+	if u.RawPath != "" && strings.Contains(u.RawPath, "/") {
+		return lastPathComponent(u.RawPath)
+	}
+	if len(u.Path) > 0 {
+		return lastPathComponent(u.Path[len(u.Path)-1])
+	}
+	return ""
 }
 
 // goConstraint maps a list of Osty generic bounds to a single Go

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -533,6 +533,9 @@ func (g *gen) emitCall(c *ast.CallExpr) {
 		if g.emitRandomGenericMethod(c, f) {
 			return
 		}
+		if g.emitBytesMethod(c, f) {
+			return
+		}
 		if g.emitCollectionMethod(c, f) {
 			return
 		}
@@ -1568,6 +1571,64 @@ func (g *gen) emitCollectionMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 	return false
 }
 
+func (g *gen) emitBytesMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	p, ok := g.typeOf(f.X).(*types.Primitive)
+	if !ok || p.Kind != types.PBytes {
+		return false
+	}
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+		return true
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needBytesRuntime = true
+		g.body.write("bytesGet(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "concat":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needBytesRuntime = true
+		g.body.write("bytesConcat(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.needBytesRuntime = true
+		g.needResult = true
+		g.body.write("bytesToString(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
 func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
 	if len(n.Args) != 1 {
 		return false
@@ -1800,6 +1861,21 @@ func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) 
 			g.body.writef("out = append(out, %s...)\n", other)
 			g.body.writeln("return out")
 		})
+	case "chain":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+len(%s))\n", retGo, xs, other)
+			g.body.writef("out = append(out, %s...)\n", xs)
+			g.body.writef("out = append(out, %s...)\n", other)
+			g.body.writeln("return out")
+		})
 	case "zip":
 		if len(c.Args) != 1 {
 			return false
@@ -1856,6 +1932,22 @@ func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) 
 			g.body.nl()
 			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, xs)
 			g.body.writef("for _, v := range %s { if !%s(v) { break }; out = append(out, v) }\n", xs, pred)
+			g.body.writeln("return out")
+		})
+	case "skip":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			start := g.freshVar("_n")
+			g.body.writef("%s := ", start)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 { %s = 0 }\n", start, start)
+			g.body.writef("if %s > len(%s) { %s = len(%s) }\n", start, xs, start, xs)
+			g.body.writef("out := make(%s, len(%s)-%s)\n", retGo, xs, start)
+			g.body.writef("copy(out, %s[%s:])\n", xs, start)
 			g.body.writeln("return out")
 		})
 	case "forEach":

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -461,6 +461,7 @@ func (g *gen) run() ([]byte, error) {
 		g.needResult = true
 		g.useAs("bytes", "stdbytes")
 		g.useAs("encoding/hex", "_ostybyteshex")
+		g.useAs("unicode/utf8", "_ostybytesutf8")
 	}
 	if g.needCompress {
 		g.needResult = true
@@ -643,9 +644,20 @@ func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F]
 	}
 	if g.needBytesRuntime {
 		out.WriteString(`
+func bytesClone(b []byte) []byte {
+	return append([]byte(nil), b...)
+}
+
+func bytesFrom(items []byte) []byte { return bytesClone(items) }
+
 func bytesFromString(s string) []byte { return []byte(s) }
 
-func bytesToString(b []byte) Result[string, any] { return resultOk[string, any](string(b)) }
+func bytesToString(b []byte) Result[string, any] {
+	if !_ostybytesutf8.Valid(b) {
+		return resultErr[string, any](fmt.Errorf("bytes: invalid UTF-8"))
+	}
+	return resultOk[string, any](string(b))
+}
 
 func bytesLen(b []byte) int { return len(b) }
 
@@ -657,6 +669,13 @@ func bytesGet(b []byte, i int) *byte {
 	}
 	v := b[i]
 	return &v
+}
+
+func bytesSlice(b []byte, start int, end int) []byte {
+	if start < 0 || end < start || end > len(b) {
+		panic("bytes.slice index out of range")
+	}
+	return bytesClone(b[start:end])
 }
 
 func bytesEqual(a []byte, b []byte) bool { return stdbytes.Equal(a, b) }
@@ -683,7 +702,14 @@ func bytesLastIndexOf(b []byte, sub []byte) *int {
 	return &i
 }
 
-func bytesSplit(b []byte, sep []byte) [][]byte { return stdbytes.Split(b, sep) }
+func bytesSplit(b []byte, sep []byte) [][]byte {
+	parts := stdbytes.Split(b, sep)
+	out := make([][]byte, len(parts))
+	for i, part := range parts {
+		out[i] = bytesClone(part)
+	}
+	return out
+}
 
 func bytesJoin(parts [][]byte, sep []byte) []byte { return stdbytes.Join(parts, sep) }
 
@@ -699,13 +725,13 @@ func bytesReplaceAll(b []byte, old []byte, new []byte) []byte {
 	return stdbytes.ReplaceAll(b, old, new)
 }
 
-func bytesTrimLeft(b []byte, strip []byte) []byte { return stdbytes.TrimLeft(b, string(strip)) }
+func bytesTrimLeft(b []byte, strip []byte) []byte { return bytesClone(stdbytes.TrimLeft(b, string(strip))) }
 
-func bytesTrimRight(b []byte, strip []byte) []byte { return stdbytes.TrimRight(b, string(strip)) }
+func bytesTrimRight(b []byte, strip []byte) []byte { return bytesClone(stdbytes.TrimRight(b, string(strip))) }
 
-func bytesTrim(b []byte, strip []byte) []byte { return stdbytes.Trim(b, string(strip)) }
+func bytesTrim(b []byte, strip []byte) []byte { return bytesClone(stdbytes.Trim(b, string(strip))) }
 
-func bytesTrimSpace(b []byte) []byte { return stdbytes.TrimSpace(b) }
+func bytesTrimSpace(b []byte) []byte { return bytesClone(stdbytes.TrimSpace(b)) }
 
 func bytesToUpper(b []byte) []byte { return stdbytes.ToUpper(b) }
 

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -288,6 +288,36 @@ fn main() {
 	}
 }
 
+func TestStdEncodingBridgeValues(t *testing.T) {
+	goSrc, err := transpileWithStdlib(t, `use std.encoding
+
+fn main() {
+    let raw = encoding.hex.decode("6f737479").unwrap()
+    let b64 = encoding.base64
+    let safe64 = encoding.base64.url
+    let hexCodec = encoding.hex
+    let urlCodec = encoding.url
+    println(b64.encode(raw))
+    println(hexCodec.encode(b64.decode("b3N0eQ==").unwrap()))
+    println(safe64.encode(raw))
+    println(urlCodec.decode(urlCodec.encode("a b")).unwrap())
+}
+`)
+	if err != nil {
+		t.Fatalf("transpile: %v\n%s", err, goSrc)
+	}
+	out := strings.TrimSpace(runGo(t, goSrc))
+	want := strings.Join([]string{
+		"b3N0eQ==",
+		"6f737479",
+		"b3N0eQ==",
+		"a b",
+	}, "\n")
+	if out != want {
+		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
+	}
+}
+
 func TestStdEnvBridge(t *testing.T) {
 	goSrc, err := transpileWithStdlib(t, `use std.env
 
@@ -344,13 +374,16 @@ fn main() {
     let again = csv.decodeWith(semi, opts).unwrap()
     println(again[0][0])
     println(again[1][1])
+    let quoted = csv.decode("name,note\nalice,\"hello\nworld\"\n").unwrap()
+    println(quoted[1][1] == "hello\nworld")
+    println(csv.decode("\"bad\"x").isErr())
 }
 `)
 	if err != nil {
 		t.Fatalf("transpile: %v\n%s", err, goSrc)
 	}
 	out := strings.TrimSpace(runGo(t, goSrc))
-	want := strings.Join([]string{"alice", "25", "left;side", "down"}, "\n")
+	want := strings.Join([]string{"alice", "25", "left;side", "down", "true", "true"}, "\n")
 	if out != want {
 		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)
 	}
@@ -588,6 +621,11 @@ fn main() {
     let joined = bytes.join(parts, bytes.fromString("-"))
     println(bytes.toString(joined).unwrap())
     println(bytes.trimSpace(bytes.fromString("  hi  ")))
+    let raw = bytes.from([b'A', b'B', b'C'])
+    println(bytes.toString(bytes.slice(raw, 1, 3)).unwrap())
+    println(raw.len())
+    println((bytes.fromString("x").concat(bytes.fromString("y"))).toString().unwrap())
+    println(bytes.from([255]).toString().isErr())
 }
 `)
 	if err != nil {
@@ -608,11 +646,15 @@ fn main() {
 		"2",
 		"Hello-World!",
 		"hi",
+		"BC",
+		"3",
+		"xy",
+		"true",
 	}, "\n")
 	if out != want {
 		t.Fatalf("stdout = %q, want:\n%s\n--- source ---\n%s", out, want, goSrc)
 	}
-	for _, needle := range []string{"bytesEqual", "bytesContains", "bytesToUpper", "bytesFromHex"} {
+	for _, needle := range []string{"bytesSlice", "bytesFrom", "bytesEqual", "bytesContains", "bytesToUpper", "bytesFromHex"} {
 		if !strings.Contains(string(goSrc), needle) {
 			t.Errorf("generated std.bytes bridge missing %s:\n%s", needle, goSrc)
 		}

--- a/internal/gen/iter_bridge_test.go
+++ b/internal/gen/iter_bridge_test.go
@@ -31,6 +31,21 @@ func TestIterTranspile(t *testing.T) {
 		t.Fatalf("transpile from/empty: %v\n%s", err2, goSrc2)
 	}
 
+	src3 := "use std.iter\n\nfn main() {\n" +
+		"    let left = iter.range(0, 5).skip(2)\n" +
+		"    let right = iter.from([9, 10])\n" +
+		"    let out = left.chain(right).toList()\n" +
+		"    println(\"{out[0]} {out[2]} {out[4]}\")\n}\n"
+
+	goSrc3, err3 := transpileWithStdlib(t, src3)
+	if err3 != nil {
+		t.Fatalf("transpile skip/chain: %v\n%s", err3, goSrc3)
+	}
+	out3 := strings.TrimSpace(runGo(t, goSrc3))
+	if out3 != "2 4 10" {
+		t.Fatalf("skip/chain output = %q\n--- source ---\n%s", out3, goSrc3)
+	}
+
 	for _, want := range []string{"make([]int", "for"} {
 		if !strings.Contains(string(goSrc), want) {
 			t.Errorf("expected %q in generated Go:\n%s", want, goSrc)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -393,6 +393,9 @@ func (s *Server) analyze(uri string, src []byte) *docAnalysis {
 // that file's source before running resolution. That way the LSP
 // reflects the user's in-progress edits — not the saved copy.
 func (s *Server) analyzePackageContaining(path string, src []byte) *docAnalysis {
+	if !isExistingFile(path) {
+		return nil
+	}
 	dir := filepath.Dir(path)
 	// A file qualifies for workspace analysis when EITHER:
 	//   - its own directory holds sibling packages (dir IS the root,
@@ -411,6 +414,14 @@ func (s *Server) analyzePackageContaining(path string, src []byte) *docAnalysis 
 		return s.analyzePackage(dir, path, src)
 	}
 	return nil
+}
+
+func isExistingFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
 }
 
 // dirHasOstySiblings reports whether `dir` contains at least one
@@ -732,6 +743,9 @@ func (s *Server) workspaceRootForAny() string {
 	for uri := range s.docs.m {
 		path, ok := fileURIPath(uri)
 		if !ok {
+			continue
+		}
+		if !isExistingFile(path) {
 			continue
 		}
 		dir := filepath.Dir(path)

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -258,8 +258,10 @@ func (r *resolver) declareUse(u *ast.UseDecl) {
 		// for FFI). Per §5.2 / §12.1.
 		if u.IsGoFFI {
 			name = lastSeg(u.GoPath, '/')
+		} else if u.RawPath != "" && strings.Contains(u.RawPath, "/") {
+			name = lastSeg(u.RawPath, '/')
 		} else if len(u.Path) > 0 {
-			name = u.Path[len(u.Path)-1]
+			name = lastSeg(u.Path[len(u.Path)-1], '/')
 		}
 	}
 	if name == "" {
@@ -1269,9 +1271,16 @@ func (r *resolver) resolveExpr(e ast.Expr) {
 }
 
 func (r *resolver) resolveIdent(id *ast.Ident) {
-	// `_` in expression position has already been reported by the
-	// parser (E0604). Avoid a cascading "undefined name" here.
-	if id.Name == "_" || id.Name == "<error>" {
+	if id.Name == "_" {
+		r.emit(diag.New(diag.Error,
+			"`_` is only valid as a pattern wildcard, not as an expression").
+			Code(diag.CodeWildcardInExpr).
+			PrimaryPos(id.PosV, "wildcard used as a value").
+			Hint("use `let _ = expr` to ignore a value").
+			Build())
+		return
+	}
+	if id.Name == "<error>" {
 		return
 	}
 	// `self` requires special handling: it is not a normal identifier.

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -92,6 +92,17 @@ func TestUndefinedNameSuggestion(t *testing.T) {
 	}
 }
 
+func TestURLUseDefaultAliasUsesLastPathSegment(t *testing.T) {
+	res := resolveSrc(t, `use github.com/user/lib
+
+fn f() {
+    let pkg = lib
+}`)
+	if len(res.Diags) != 0 {
+		t.Fatalf("expected URL-style use to bind alias `lib`, got %v", res.Diags)
+	}
+}
+
 func TestDuplicateTopLevel(t *testing.T) {
 	res := resolveSrc(t, `fn x() {}
 fn x() {}`)

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -145,6 +145,9 @@ func patchGenerated(path string) error {
 			return err
 		}
 	}
+	if strings.Contains(src, "sync.Mutex") && !strings.Contains(src, "\n\t\"sync\"\n") {
+		src = strings.Replace(src, "\n\t\"strings\"\n", "\n\t\"strings\"\n\t\"sync\"\n", 1)
+	}
 	formatted, err := format.Source([]byte(src))
 	if err != nil {
 		return fmt.Errorf("format generated selfhost code: %w", err)
@@ -180,18 +183,55 @@ func replaceGeneratedFunction(src, name, replacement string) (string, error) {
 	return "", fmt.Errorf("generated function %s body is unterminated", name)
 }
 
-const frontPositionAtReplacement = `func frontPositionAt(units []string, target int) *FrontPos {
+const frontPositionAtReplacement = `type frontPositionCacheState struct {
+	units  []string
+	target int
+	offset int
+	line   int
+	column int
+	skipLf bool
+}
+
+var frontPositionCacheMu sync.Mutex
+var frontPositionCache frontPositionCacheState
+
+func frontSameUnits(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return &a[0] == &b[0]
+}
+
+func frontPositionAt(units []string, target int) *FrontPos {
 	if target < 0 {
 		target = 0
 	}
 	if target > len(units) {
 		target = len(units)
 	}
-	offset := 0
-	line := 1
-	column := 1
-	skipLf := false
-	for idx := 0; idx < target; idx++ {
+
+	frontPositionCacheMu.Lock()
+	defer frontPositionCacheMu.Unlock()
+
+	if !frontSameUnits(frontPositionCache.units, units) || target < frontPositionCache.target {
+		frontPositionCache = frontPositionCacheState{
+			units:  units,
+			target: 0,
+			offset: 0,
+			line:   1,
+			column: 1,
+			skipLf: false,
+		}
+	}
+
+	offset := frontPositionCache.offset
+	line := frontPositionCache.line
+	column := frontPositionCache.column
+	skipLf := frontPositionCache.skipLf
+	for idx := frontPositionCache.target; idx < target; idx++ {
 		unit := units[idx]
 		next := ""
 		if idx+1 < len(units) {
@@ -216,6 +256,11 @@ const frontPositionAtReplacement = `func frontPositionAt(units []string, target 
 			offset = offset + 1
 		}
 	}
+	frontPositionCache.target = target
+	frontPositionCache.offset = offset
+	frontPositionCache.line = line
+	frontPositionCache.column = column
+	frontPositionCache.skipLf = skipLf
 	return frontPos(offset, line, column)
 }
 `

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 )
 
 type ostyStringer interface {
@@ -2333,7 +2334,28 @@ func frontLexTokenFromScan(units []string, start int, consumed int, kind FrontTo
 	return frontLexToken(kind, frontPositionAt(units, start), frontPositionAt(units, start+consumed), consumed, leadingDocLines, triple, interpolations, baseLiteral)
 }
 
-// Osty: /tmp/selfhost_merged.osty:1451:5
+type frontPositionCacheState struct {
+	units  []string
+	target int
+	offset int
+	line   int
+	column int
+	skipLf bool
+}
+
+var frontPositionCacheMu sync.Mutex
+var frontPositionCache frontPositionCacheState
+
+func frontSameUnits(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return &a[0] == &b[0]
+}
+
 func frontPositionAt(units []string, target int) *FrontPos {
 	if target < 0 {
 		target = 0
@@ -2341,11 +2363,26 @@ func frontPositionAt(units []string, target int) *FrontPos {
 	if target > len(units) {
 		target = len(units)
 	}
-	offset := 0
-	line := 1
-	column := 1
-	skipLf := false
-	for idx := 0; idx < target; idx++ {
+
+	frontPositionCacheMu.Lock()
+	defer frontPositionCacheMu.Unlock()
+
+	if !frontSameUnits(frontPositionCache.units, units) || target < frontPositionCache.target {
+		frontPositionCache = frontPositionCacheState{
+			units:  units,
+			target: 0,
+			offset: 0,
+			line:   1,
+			column: 1,
+			skipLf: false,
+		}
+	}
+
+	offset := frontPositionCache.offset
+	line := frontPositionCache.line
+	column := frontPositionCache.column
+	skipLf := frontPositionCache.skipLf
+	for idx := frontPositionCache.target; idx < target; idx++ {
 		unit := units[idx]
 		next := ""
 		if idx+1 < len(units) {
@@ -2370,6 +2407,11 @@ func frontPositionAt(units []string, target int) *FrontPos {
 			offset = offset + 1
 		}
 	}
+	frontPositionCache.target = target
+	frontPositionCache.offset = offset
+	frontPositionCache.line = line
+	frontPositionCache.column = column
+	frontPositionCache.skipLf = skipLf
 	return frontPos(offset, line, column)
 }
 
@@ -11038,6 +11080,22 @@ func opParseDeferStmt(p *OstyParser) int {
 	return opAddNode(p, n)
 }
 
+func opAtForInKeyword(p *OstyParser) bool {
+	return opAt(p, FrontTokenKind(&FrontTokenKind_FrontIdent{})) && opPeek(p).text == "in"
+}
+
+func opTryParseForInPattern(p *OstyParser) int {
+	savedPos := p.pos
+	savedErrors := opErrorCount(p)
+	patIdx := opParsePattern(p)
+	if opAtForInKeyword(p) {
+		return patIdx
+	}
+	p.pos = savedPos
+	opTruncateErrors(p, savedErrors)
+	return -1
+}
+
 // Osty: /tmp/selfhost_merged.osty:6994:1
 func opParseForStmt(p *OstyParser) int {
 	// Osty: /tmp/selfhost_merged.osty:6995:5
@@ -11085,24 +11143,14 @@ func opParseForStmt(p *OstyParser) int {
 		// Osty: /tmp/selfhost_merged.osty:7011:23
 		p.noStructLit = pv
 	} else {
-		// Osty: /tmp/selfhost_merged.osty:7013:9
-		pv := p.noStructLit
-		_ = pv
-		// Osty: /tmp/selfhost_merged.osty:7014:23
-		p.noStructLit = true
-		// Osty: /tmp/selfhost_merged.osty:7015:9
-		expr := opParseExpr(p)
-		_ = expr
-		// Osty: /tmp/selfhost_merged.osty:7016:23
-		p.noStructLit = pv
-		// Osty: /tmp/selfhost_merged.osty:7017:9
-		if opAt(p, FrontTokenKind(&FrontTokenKind_FrontIdent{})) && opPeek(p).text == "in" {
+		forInPat := opTryParseForInPattern(p)
+		if forInPat >= 0 {
 			// Osty: /tmp/selfhost_merged.osty:7018:13
 			_ = opAdvance(p)
 			// Osty: /tmp/selfhost_merged.osty:7019:18
 			kind = "forin"
 			// Osty: /tmp/selfhost_merged.osty:7020:20
-			patIdx = expr
+			patIdx = forInPat
 			// Osty: /tmp/selfhost_merged.osty:7021:13
 			pv2 := p.noStructLit
 			_ = pv2
@@ -11113,7 +11161,12 @@ func opParseForStmt(p *OstyParser) int {
 			// Osty: /tmp/selfhost_merged.osty:7024:27
 			p.noStructLit = pv2
 		} else {
-			// Osty: /tmp/selfhost_merged.osty:7025:23
+			pv := p.noStructLit
+			_ = pv
+			p.noStructLit = true
+			expr := opParseExpr(p)
+			_ = expr
+			p.noStructLit = pv
 			kind = "cond"
 			// Osty: /tmp/selfhost_merged.osty:7026:17
 			condIdx = expr

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -2334,6 +2334,7 @@ func frontLexTokenFromScan(units []string, start int, consumed int, kind FrontTo
 	return frontLexToken(kind, frontPositionAt(units, start), frontPositionAt(units, start+consumed), consumed, leadingDocLines, triple, interpolations, baseLiteral)
 }
 
+// Osty: /tmp/selfhost_merged.osty:1452:5
 type frontPositionCacheState struct {
 	units  []string
 	target int

--- a/internal/selfhost/parse_adapter.go
+++ b/internal/selfhost/parse_adapter.go
@@ -149,6 +149,18 @@ func (l astLowerer) doc(idx int) string {
 	return ""
 }
 
+func (l astLowerer) mutPos(n *AstNode) token.Pos {
+	if n == nil || n.flags != 1 {
+		return token.Pos{}
+	}
+	for i := n.start + 1; i < n.end; i++ {
+		if l.tok(i).Kind == token.MUT {
+			return l.pos(i)
+		}
+	}
+	return token.Pos{}
+}
+
 func (l astLowerer) decl(idx int) ast.Decl {
 	n := l.node(idx)
 	if n == nil {
@@ -320,7 +332,7 @@ func (l astLowerer) letDecl(n *AstNode) *ast.LetDecl {
 	if p, ok := l.pattern(n.left).(*ast.IdentPat); ok {
 		name = p.Name
 	}
-	return &ast.LetDecl{PosV: l.nodePos(n), EndV: l.nodeEnd(n), Pub: l.tok(n.start-1).Kind == token.PUB, Mut: n.flags == 1, Name: name, Type: l.childType(n, 0), Value: l.expr(n.right), DocComment: l.doc(n.start), Annotations: l.annotations(n.extra)}
+	return &ast.LetDecl{PosV: l.nodePos(n), EndV: l.nodeEnd(n), Pub: l.tok(n.start-1).Kind == token.PUB, Mut: n.flags == 1, MutPos: l.mutPos(n), Name: name, Type: l.childType(n, 0), Value: l.expr(n.right), DocComment: l.doc(n.start), Annotations: l.annotations(n.extra)}
 }
 
 func (l astLowerer) field(n *AstNode) *ast.Field {
@@ -334,9 +346,13 @@ func (l astLowerer) param(idx int) *ast.Param {
 	}
 	p := &ast.Param{PosV: l.nodePos(n), EndV: l.nodeEnd(n), Name: n.text, Type: l.typ(n.right), Default: l.expr(n.left)}
 	if n.left >= 0 {
-		if pat := l.pattern(n.left); pat != nil {
-			p.Pattern = pat
-			p.Default = nil
+		left := l.node(n.left)
+		if left != nil {
+			if _, ok := left.kind.(*AstNodeKind_AstNPattern); ok {
+				pat := l.pattern(n.left)
+				p.Pattern = pat
+				p.Default = nil
+			}
 		}
 	}
 	return p
@@ -452,7 +468,7 @@ func (l astLowerer) stmt(idx int) ast.Stmt {
 	}
 	switch n.kind.(type) {
 	case *AstNodeKind_AstNLet:
-		return &ast.LetStmt{PosV: l.nodePos(n), EndV: l.nodeEnd(n), Pattern: l.pattern(n.left), Mut: n.flags == 1, Type: l.childType(n, 0), Value: l.expr(n.right)}
+		return &ast.LetStmt{PosV: l.nodePos(n), EndV: l.nodeEnd(n), Pattern: l.pattern(n.left), Mut: n.flags == 1, MutPos: l.mutPos(n), Type: l.childType(n, 0), Value: l.expr(n.right)}
 	case *AstNodeKind_AstNReturn:
 		return &ast.ReturnStmt{PosV: l.nodePos(n), EndV: l.nodeEnd(n), Value: l.expr(n.left)}
 	case *AstNodeKind_AstNBreak:

--- a/internal/stdlib/modules/bytes.osty
+++ b/internal/stdlib/modules/bytes.osty
@@ -20,6 +20,10 @@ pub fn slice(b: Bytes, start: Int, end: Int) -> Bytes {
     slice(b, start, end)
 }
 
+pub fn equal(a: Bytes, b: Bytes) -> Bool {
+    a == b
+}
+
 pub fn contains(b: Bytes, sub: Bytes) -> Bool {
     indexOf(b, sub).isSome()
 }

--- a/internal/stdlib/modules/fmt.osty
+++ b/internal/stdlib/modules/fmt.osty
@@ -369,8 +369,8 @@ pub fn bytes(n: Int) -> String {
 // Callers must use raw strings (r"...") or escape braces (\{ \})
 // to prevent Osty's own interpolation from consuming the placeholders.
 pub fn format(template: String, args: List<String>) -> String {
-    let lbrace: Char = '{'
-    let rbrace: Char = '}'
+    let lbrace: Char = r"{".chars()[0]
+    let rbrace: Char = r"}".chars()[0]
     let chars = template.chars()
     let len = chars.len()
     let mut out = ""
@@ -460,7 +460,7 @@ pub fn numbered(items: List<String>) -> String {
     let mut lines: List<String> = []
     let width = items.len().toString().chars().len()
     for i in 0..items.len() {
-        let num = padLeft((i + 1).toString(), width)
+        let num = padLeft((i + 1).toString(), width, ' ')
         lines.push("{num}. {items[i]}")
     }
     strings.join(lines, "\n")
@@ -491,7 +491,7 @@ pub fn table(headers: List<String>, rows: List<List<String>>, sep: String = " | 
 
     let mut headerCells: List<String> = []
     for ci in 0..cols {
-        headerCells.push(padRight(headers[ci], widths[ci]))
+        headerCells.push(padRight(headers[ci], widths[ci], ' '))
     }
     let headerLine = strings.join(headerCells, sep)
 
@@ -506,7 +506,7 @@ pub fn table(headers: List<String>, rows: List<List<String>>, sep: String = " | 
         let mut cells: List<String> = []
         for ci in 0..cols {
             let cell = if ci < row.len() { row[ci] } else { "" }
-            cells.push(padRight(cell, widths[ci]))
+            cells.push(padRight(cell, widths[ci], ' '))
         }
         lines.push(strings.join(cells, sep))
     }

--- a/internal/stdlib/modules/iter.osty
+++ b/internal/stdlib/modules/iter.osty
@@ -31,7 +31,15 @@ pub struct Iter<T> {
     }
 
     pub fn takeWhile(self, f: fn(T) -> Bool) -> Iter<T> {
-        self.takeWhile(f)
+        let mut out: List<T> = []
+        for item in self.items {
+            if f(item) {
+                out.push(item)
+            } else {
+                break
+            }
+        }
+        Iter { items: out }
     }
 
     pub fn skip(self, n: Int) -> Iter<T> {

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -952,6 +952,63 @@ pub fn roundTrip(text: String) -> Bool {
 	}
 }
 
+func TestBytesModuleCoverage(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["bytes"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.bytes not loaded")
+	}
+	for _, name := range []string{
+		"len", "isEmpty", "get", "slice", "equal", "contains", "startsWith", "endsWith",
+		"indexOf", "lastIndexOf", "split", "join", "concat", "repeat", "replace",
+		"replaceAll", "trimLeft", "trimRight", "trim", "trimSpace", "toUpper",
+		"toLower", "fromString", "from", "toString", "toHex", "fromHex",
+	} {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.bytes missing export %q", name)
+			continue
+		}
+		if !sym.Pub {
+			t.Errorf("std.bytes export %q is not pub", name)
+		}
+	}
+}
+
+func TestBytesPackageTypeChecks(t *testing.T) {
+	src := []byte(`use std.bytes
+
+pub fn smoke(data: Bytes) -> Result<String, Error> {
+    let raw: Bytes = bytes.from([b'a', b'b', b'c'])
+    let tail: Bytes = bytes.slice(raw, 1, 3)
+    let same: Bool = bytes.equal(tail, bytes.fromString("bc"))
+    let idx: Int = bytes.indexOf(data, bytes.fromString("x")) ?? -1
+    let joined: Bytes = bytes.join(bytes.split(data, bytes.fromString(",")), bytes.fromString("|"))
+    let hex: String = bytes.toHex(joined)
+    let decoded: Bytes = bytes.fromHex(hex)?
+    if same && idx >= -1 {
+        decoded.toString()
+    } else {
+        bytes.toString(tail)
+    }
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse error: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{Primitives: reg.Primitives, ResultMethods: reg.ResultMethods})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Errorf("unexpected std.bytes diagnostic: %s", d.Error())
+		}
+	}
+}
+
 func TestEnvModuleCoverage(t *testing.T) {
 	reg := Load()
 	mod := reg.Modules["env"]


### PR DESCRIPTION
## Summary
- add eager Go lowering/runtime bridge coverage for std.iter and std.bytes basics
- add package-shaped std.encoding runtime bridge and strengthen std.csv helper validation
- fix self-host parser/lowering regressions uncovered by full-suite coverage, plus LSP temp-file workspace detection

## Tests
- go test ./... -count=1