### PR TITLE
Wire selfhost diagnostics into pipeline reports

### DIFF
--- a/cmd/osty/ci_integration_test.go
+++ b/cmd/osty/ci_integration_test.go
@@ -256,6 +256,31 @@ func TestFmtNoRepairLeavesParserStrict(t *testing.T) {
 	}
 }
 
+func TestPipelineDiagnosticsFlagRendersFormattedDiagnostics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI integration test (slow)")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte("fn main() {\n    missing()\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runOsty(t, dir, "pipeline", "--diagnostics", path)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d. output:\n%s", code, out)
+	}
+	if !strings.Contains(out, "diagnostics by code:") {
+		t.Fatalf("missing pipeline report histogram:\n%s", out)
+	}
+	if !strings.Contains(out, "error[E0500]") {
+		t.Fatalf("missing formatted diagnostic code:\n%s", out)
+	}
+	if !strings.Contains(out, "-->") || !strings.Contains(out, "main.osty:2:5") {
+		t.Fatalf("missing formatted source location:\n%s", out)
+	}
+}
+
 func mustWrite(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 
+	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/pipeline"
 	"github.com/osty/osty/internal/resolve"
 )
@@ -14,6 +15,7 @@ import (
 // runPipeline implements
 //
 //	osty pipeline [--json] [--trace] [--per-decl] [--gen]
+//	              [--diagnostics]
 //	              [--cpuprofile PATH] [--memprofile PATH]
 //	              FILE-OR-DIR
 //
@@ -37,23 +39,25 @@ func runPipeline(args []string) {
 	fs := flag.NewFlagSet("pipeline", flag.ExitOnError)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr,
-			"usage: osty pipeline [--json] [--trace] [--per-decl] [--gen]")
+			"usage: osty pipeline [--json] [--trace] [--per-decl] [--gen] [--diagnostics]")
 		fmt.Fprintln(os.Stderr,
 			"                     [--cpuprofile PATH] [--memprofile PATH] FILE-OR-DIR")
 	}
 	var (
-		jsonOut    bool
-		trace      bool
-		perDecl    bool
-		runGen     bool
-		cpuProfile string
-		memProfile string
-		baseline   string
+		jsonOut         bool
+		trace           bool
+		perDecl         bool
+		runGen          bool
+		showDiagnostics bool
+		cpuProfile      string
+		memProfile      string
+		baseline        string
 	)
 	fs.BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the text table")
 	fs.BoolVar(&trace, "trace", false, "stream a trace line to stderr as each phase completes")
 	fs.BoolVar(&perDecl, "per-decl", false, "report per-declaration check timing in the output")
 	fs.BoolVar(&runGen, "gen", false, "also run the Go transpiler as a final pipeline phase (file mode)")
+	fs.BoolVar(&showDiagnostics, "diagnostics", false, "render full diagnostics after the pipeline report")
 	fs.StringVar(&cpuProfile, "cpuprofile", "", "write a CPU pprof profile to this path")
 	fs.StringVar(&memProfile, "memprofile", "", "write a memory pprof profile to this path after the pipeline")
 	fs.StringVar(&baseline, "baseline", "", "compare against a previous --json snapshot at this path")
@@ -96,6 +100,8 @@ func runPipeline(args []string) {
 	}
 
 	var r pipeline.Result
+	var sourceForDiagnostics []byte
+	diagnosticFilename := target
 	if info.IsDir() {
 		// Workspace vs single-package detection mirrors what `osty
 		// check DIR` does: a workspace root has no top-level .osty
@@ -116,6 +122,7 @@ func runPipeline(args []string) {
 			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
 			os.Exit(1)
 		}
+		sourceForDiagnostics = src
 		r = pipeline.RunWithConfig(src, stream, cfg)
 	}
 
@@ -154,6 +161,12 @@ func runPipeline(args []string) {
 		}
 	} else {
 		r.RenderText(os.Stdout)
+	}
+
+	if showDiagnostics && len(r.AllDiags) > 0 {
+		formatter := &diag.Formatter{Filename: diagnosticFilename, Source: sourceForDiagnostics}
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, formatter.FormatAll(r.AllDiags))
 	}
 
 	// Memory profile after the pipeline finishes. Force a GC first so

--- a/examples/selfhost-core/diagnostic.osty
+++ b/examples/selfhost-core/diagnostic.osty
@@ -1,3 +1,7 @@
+use go "strings" as strings {
+    fn Join(elems: List<String>, sep: String) -> String
+}
+
 /// DiagnosticSeverity is the stable user-facing diagnostic bucket.
 pub enum DiagnosticSeverity {
     SeverityError,
@@ -102,4 +106,115 @@ pub fn diagnosticIsCompilerError(code: String) -> Bool {
         SeverityError -> true,
         _ -> false,
     }
+}
+
+/// DiagnosticLocation maps analyzer token spans back to lexer source positions.
+pub struct DiagnosticLocation {
+    pub line: Int,
+    pub column: Int,
+    pub endLine: Int,
+    pub endColumn: Int,
+    pub token: Int,
+    pub endToken: Int,
+}
+
+pub fn diagnosticLocation(
+    line: Int,
+    column: Int,
+    endLine: Int,
+    endColumn: Int,
+    token: Int,
+    endToken: Int,
+) -> DiagnosticLocation {
+    DiagnosticLocation { line, column, endLine, endColumn, token, endToken }
+}
+
+fn diagnosticClampTokenIndex(index: Int, count: Int) -> Int {
+    if count <= 0 {
+        return 0
+    }
+    if index < 0 {
+        return 0
+    }
+    if index >= count {
+        return count - 1
+    }
+    index
+}
+
+fn diagnosticLocationFromStream(stream: FrontLexStream, start: Int, end: Int) -> DiagnosticLocation {
+    let count = frontLexTokenCount(stream)
+    let startToken = diagnosticClampTokenIndex(start, count)
+    let mut lastToken = startToken
+    if end > start {
+        lastToken = diagnosticClampTokenIndex(end - 1, count)
+    }
+    let first = frontLexTokenAt(stream, startToken)
+    let last = frontLexTokenAt(stream, lastToken)
+    diagnosticLocation(
+        first.start.line,
+        first.start.column,
+        last.end.line,
+        last.end.column,
+        startToken,
+        lastToken,
+    )
+}
+
+/// diagnosticSourceLocation returns the source position for a parser/analyzer
+/// token span.
+pub fn diagnosticSourceLocation(source: String, start: Int, end: Int) -> DiagnosticLocation {
+    diagnosticLocationFromStream(frontendLexStream(source), start, end)
+}
+
+fn diagnosticSubject(name: String) -> String {
+    if name == "" {
+        ""
+    } else {
+        " `{name}`"
+    }
+}
+
+fn diagnosticFormatOne(
+    source: String,
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> String {
+    let loc = diagnosticSourceLocation(source, start, end)
+    let severity = diagnosticSeverityName(diagnosticSeverity(code))
+    let family = diagnosticFamilyName(diagnosticFamily(code))
+    "{severity}[{code}] {family} at {loc.line}:{loc.column}: {message}{diagnosticSubject(name)}"
+}
+
+pub fn diagnosticFormatSelfResolveDiagnostic(
+    source: String,
+    diag: SelfResolveDiagnostic,
+) -> String {
+    diagnosticFormatOne(source, diag.code, diag.message, diag.name, diag.start, diag.end)
+}
+
+pub fn diagnosticFormatSelfResolveDiagnostics(
+    source: String,
+    result: SelfResolveResult,
+) -> String {
+    let mut lines: List<String> = []
+    for diag in result.diagnostics {
+        lines.push(diagnosticFormatSelfResolveDiagnostic(source, diag))
+    }
+    strings.Join(lines, "\n")
+}
+
+pub fn diagnosticFormatSelfLintDiagnostic(source: String, diag: SelfLintDiagnostic) -> String {
+    diagnosticFormatOne(source, diag.code, diag.message, diag.name, diag.start, diag.end)
+}
+
+pub fn diagnosticFormatSelfLintDiagnostics(source: String, report: SelfLintReport) -> String {
+    let mut lines: List<String> = []
+    for diag in report.diagnostics {
+        lines.push(diagnosticFormatSelfLintDiagnostic(source, diag))
+    }
+    strings.Join(lines, "\n")
 }

--- a/examples/selfhost-core/diagnostic_test.osty
+++ b/examples/selfhost-core/diagnostic_test.osty
@@ -1,11 +1,21 @@
 use std.testing
 
+use go "strings" as diagStrings {
+    fn Contains(s: String, substr: String) -> Bool
+}
+
 fn assertDiagnosticSeverity(code: String, want: String) {
     testing.assertEq(diagnosticSeverityName(diagnosticSeverity(code)), want)
 }
 
 fn assertDiagnosticFamily(code: String, want: String) {
     testing.assertEq(diagnosticFamilyName(diagnosticFamily(code)), want)
+}
+
+fn assertDiagnosticTextContains(output: String, text: String) {
+    if !(diagStrings.Contains(output, text)) {
+        testing.fail("missing {text} in {output}")
+    }
 }
 
 fn testDiagnosticExamplesClassifySeverityPrefixes() {
@@ -57,4 +67,38 @@ fn testDiagnosticExamplesIdentifyCompilationBlockers() {
     testing.assert(!(diagnosticIsCompilerError("W0001")))
     testing.assert(!(diagnosticIsCompilerError("L0001")))
     testing.assert(!(diagnosticIsCompilerError("Z0000")))
+}
+
+fn testDiagnosticSourceLocationUsesAnalyzerTokenSpans() {
+    let source = "fn main() \{\n    missing()\n\}\n"
+    let result = selfResolveSource(source)
+    let diag = result.diagnostics[0]
+    let loc = diagnosticSourceLocation(source, diag.start, diag.end)
+
+    testing.assertEq(loc.line, 2)
+    testing.assertEq(loc.column, 5)
+    testing.assert(loc.endColumn > loc.column)
+    testing.assert(loc.token <= loc.endToken)
+}
+
+fn testDiagnosticFormatsResolveDiagnosticsWithLocations() {
+    let source = "fn main() \{\n    missing()\n\}\n"
+    let result = selfResolveSource(source)
+    let output = diagnosticFormatSelfResolveDiagnostics(source, result)
+
+    assertDiagnosticTextContains(output, "error[E0500]")
+    assertDiagnosticTextContains(output, "resolution")
+    assertDiagnosticTextContains(output, "at 2:5")
+    assertDiagnosticTextContains(output, "undefined name `missing`")
+}
+
+fn testDiagnosticFormatsLintDiagnosticsWithLocations() {
+    let source = "fn same(x: Int) -> Bool \{\n    x == (x)\n\}\n"
+    let report = selfLintSource(source)
+    let output = diagnosticFormatSelfLintDiagnostics(source, report)
+
+    assertDiagnosticTextContains(output, "lint[L0041]")
+    assertDiagnosticTextContains(output, "lint")
+    assertDiagnosticTextContains(output, "at 2:5")
+    assertDiagnosticTextContains(output, "value is compared with itself `x`")
 }

--- a/examples/selfhost-core/lint.osty
+++ b/examples/selfhost-core/lint.osty
@@ -17,17 +17,19 @@ pub struct SelfLintDiagnostic {
     pub name: String,
     pub start: Int,
     pub end: Int,
+    pub node: Int,
 }
 
-/// SelfLintReport carries lint diagnostics plus parse-recovery diagnostics from
-/// the self-hosting front end.
+/// SelfLintReport carries lint diagnostics plus parse and resolver diagnostics
+/// from the self-hosting front end.
 pub struct SelfLintReport {
     pub diagnostics: List<SelfLintDiagnostic>,
     pub parseErrors: Int,
+    pub resolveErrors: Int,
 }
 
 pub fn emptySelfLintReport(parseErrors: Int) -> SelfLintReport {
-    SelfLintReport { diagnostics: [], parseErrors }
+    SelfLintReport { diagnostics: [], parseErrors, resolveErrors: 0 }
 }
 
 pub fn selfLintDiagnostic(
@@ -37,21 +39,40 @@ pub fn selfLintDiagnostic(
     start: Int,
     end: Int,
 ) -> SelfLintDiagnostic {
-    SelfLintDiagnostic { code, message, name, start, end }
+    selfLintDiagnosticAtNode(code, message, name, start, end, -1)
+}
+
+fn selfLintDiagnosticAtNode(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfLintDiagnostic {
+    SelfLintDiagnostic { code, message, name, start, end, node }
 }
 
 /// selfLintSource runs the self-hosting lexer/parser and emits a conservative
-/// style/correctness lint report from the resulting token stream.
+/// style/correctness lint report from the parsed AST plus resolver references.
 pub fn selfLintSource(source: String) -> SelfLintReport {
+    selfLintAstSource(source, astParse(source))
+}
+
+pub fn selfLintAstSource(source: String, file: AstFile) -> SelfLintReport {
+    let resolved = selfResolveAstFile(file)
+    selfLintResolvedAstSource(source, file, resolved)
+}
+
+pub fn selfLintResolvedAstSource(
+    source: String,
+    file: AstFile,
+    resolved: SelfResolveResult,
+) -> SelfLintReport {
     let stream = frontendLexStream(source)
-    let tokens = frontTokensFromSource(source, stream)
-    let count = frontTokenListCount(tokens)
-    let tree = frontendParseTree(source)
-    let mut report = emptySelfLintReport(frontParseTreeDiagnosticCount(tree))
-    report = selfLintScanDeclarations(tokens, count, report)
-    report = selfLintScanDeadCode(tokens, count, report)
-    report = selfLintScanSimplify(tokens, count, report)
-    report
+    let mut report = emptySelfLintReport(frontLexDiagnosticCount(stream) + astFileErrorCount(file))
+    report.resolveErrors = selfResolveDiagnosticCount(resolved)
+    selfLintAstFile(file, resolved, report)
 }
 
 pub fn selfLintDiagnosticCount(report: SelfLintReport) -> Int {
@@ -88,799 +109,1134 @@ fn selfLintEmit(
     start: Int,
     end: Int,
 ) -> SelfLintReport {
+    selfLintEmitAtNode(report, code, message, name, start, end, -1)
+}
+
+fn selfLintEmitAtNode(
+    report: SelfLintReport,
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfLintReport {
     let mut out = report
-    out.diagnostics.push(selfLintDiagnostic(code, message, name, start, end))
+    out.diagnostics.push(selfLintDiagnosticAtNode(code, message, name, start, end, node))
     out
 }
 
-fn selfLintKind(name: String) -> FrontTokenKind {
-    frontTokenKindByName(name)
+struct SelfLintName {
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
 }
 
-fn selfLintKindIs(kind: FrontTokenKind, name: String) -> Bool {
-    frontTokenKindName(kind) == name
+fn selfLintName(name: String, start: Int, end: Int) -> SelfLintName {
+    selfLintNameAtNode(name, start, end, -1)
 }
 
-fn selfLintTokenIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
-    selfLintKindIs(frontTokenAtList(tokens, idx).kind, name)
+fn selfLintNameAtNode(name: String, start: Int, end: Int, node: Int) -> SelfLintName {
+    SelfLintName { name, start, end, node }
 }
 
-fn selfLintLooksLikeDeclarationStart(tokens: List<FrontToken>, idx: Int) -> Bool {
-    let immediate = selfLintPrevTokenKind(tokens, idx)
-    let prev = selfLintPrevMeaningfulKind(tokens, idx)
-    selfLintKindIs(immediate, "EOF") || selfLintKindIs(immediate, "NEWLINE") || selfLintKindIs(
-        immediate,
-        ";",
-    ) || selfLintKindIs(prev, "pub") || selfLintKindIs(prev, r"{") || selfLintKindIs(prev, r"}")
-}
-
-fn selfLintScanDeclarations(
-    tokens: List<FrontToken>,
-    count: Int,
+fn selfLintAstFile(
+    file: AstFile,
+    resolved: SelfResolveResult,
     report: SelfLintReport,
 ) -> SelfLintReport {
     let mut out = report
-    let mut skipUntil = -1
-    for idx in 0..count {
-        if idx < skipUntil {
-            let _ = idx
-        } else {
-            let kind = frontTokenAtList(tokens, idx).kind
-            if selfLintKindIs(kind, "use") {
-                let consumed = frontParseUseConsumed(tokens, idx, count)
-                let end = idx + consumed
-                if frontUseIsGo(tokens, idx, end) {
-                    skipUntil = end
-                } else {
-                    out = selfLintCheckUse(tokens, idx, end, count, out)
-                }
-            } else if selfLintKindIs(kind, "fn") && selfLintLooksLikeDeclarationStart(tokens, idx) {
-                out = selfLintCheckFunction(tokens, idx, count, out)
-            } else if (selfLintKindIs(kind, "struct") || selfLintKindIs(kind, "interface") || selfLintKindIs(
-                kind,
-                "type",
-            )) && selfLintLooksLikeDeclarationStart(
-                tokens,
-                idx,
-            ) {
-                out = selfLintCheckTypeDecl(tokens, idx, count, out)
-            } else if selfLintKindIs(kind, "enum") && selfLintLooksLikeDeclarationStart(tokens, idx) {
-                out = selfLintCheckTypeDecl(tokens, idx, count, out)
-                out = selfLintCheckEnumVariants(tokens, idx, count, out)
-            } else if selfLintKindIs(kind, "let") {
-                out = selfLintCheckLet(tokens, idx, count, out)
-            }
-        }
+    for declIdx in file.arena.decls {
+        out = selfLintAstDecl(file, declIdx, resolved, out)
     }
     out
 }
 
-fn selfLintCheckUse(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    count: Int,
+fn selfLintAstDecl(
+    file: AstFile,
+    idx: Int,
+    resolved: SelfResolveResult,
     report: SelfLintReport,
 ) -> SelfLintReport {
-    let alias = selfLintUseAlias(tokens, start, end)
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNUseDecl {
+        return selfLintAstCheckUse(file, idx, node, resolved, out)
+    }
+    if node.kind == AstNFnDecl {
+        return selfLintAstCheckFunction(file, idx, node, out)
+    }
+    if node.kind == AstNStructDecl || node.kind == AstNInterfaceDecl || node.kind == AstNTypeAlias {
+        out = selfLintAstCheckTypeDecl(file, idx, node, out)
+        out = selfLintAstCheckMemberFunctions(file, node.children, out)
+        return out
+    }
+    if node.kind == AstNEnumDecl {
+        out = selfLintAstCheckTypeDecl(file, idx, node, out)
+        out = selfLintAstCheckEnumMembers(file, node.children, out)
+        return out
+    }
+    if node.kind == AstNLet {
+        out = selfLintAstCheckLetNames(file, node, out)
+        if node.right >= 0 {
+            out = selfLintAstCheckSimplifyNode(file, node.right, out)
+        }
+        return out
+    }
+    out
+}
+
+fn selfLintAstNode(file: AstFile, idx: Int) -> AstNode {
+    astArenaNodeAt(file.arena, idx)
+}
+
+fn selfLintAstCheckUse(
+    file: AstFile,
+    idx: Int,
+    node: AstNode,
+    resolved: SelfResolveResult,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if node.flags == 1 {
+        return report
+    }
+    let alias = selfLintAstUseAlias(file, node)
     if alias == "" || selfLintIsIntentionalDiscard(alias) {
         return report
     }
-    if selfLintCountIdent(tokens, end, count, alias) == 0 {
-        selfLintEmit(report, "L0003", "import is never used", alias, start, end)
-    } else {
-        report
+    let used = selfResolveHasRef(resolved, alias)
+    if !(used) {
+        return selfLintEmitAtNode(
+            report,
+            "L0003",
+            "import is never used",
+            alias,
+            node.start,
+            node.end,
+            idx,
+        )
     }
+    report
 }
 
-fn selfLintUseAlias(tokens: List<FrontToken>, start: Int, end: Int) -> String {
+fn selfLintAstUseAlias(file: AstFile, node: AstNode) -> String {
+    let aliasIdx = selfLintAstChildAt(node.children2, 0)
+    if aliasIdx >= 0 {
+        let alias = selfLintAstNode(file, aliasIdx)
+        if alias.text != "" {
+            return alias.text
+        }
+    }
+    selfLintLastPathSegment(node.text)
+}
+
+fn selfLintLastPathSegment(path: String) -> String {
     let mut last = ""
-    let mut afterAs = false
-    for idx in start + 1..end {
-        let tok = frontTokenAtList(tokens, idx)
-        if selfLintKindIs(tok.kind, "IDENT") {
-            if afterAs {
-                return tok.text
-            }
-            if tok.text == "as" {
-                afterAs = true
-            } else if tok.text != "go" {
-                last = tok.text
-            }
+    for part in strings.Split(path, ".") {
+        if part != "" {
+            last = part
         }
     }
     last
 }
 
-fn selfLintCheckFunction(
-    tokens: List<FrontToken>,
-    start: Int,
-    count: Int,
+fn selfLintAstCheckTypeDecl(
+    file: AstFile,
+    idx: Int,
+    node: AstNode,
     report: SelfLintReport,
 ) -> SelfLintReport {
     let mut out = report
-    let end = frontDeclEnd(tokens, start, count)
-    let nameIdx = selfLintNextIdent(tokens, start + 1, end)
-    if nameIdx < end {
-        let name = frontTokenTextAt(tokens, nameIdx)
-        if !(selfLintIsLowerCamel(name)) {
-            out = selfLintEmit(
-                out,
-                "L0031",
-                "function name should be lowerCamelCase",
-                name,
-                nameIdx,
-                nameIdx + 1,
-            )
-        }
-        out = selfLintCheckGenericParamsAfterName(tokens, nameIdx + 1, end, out)
-    }
-
-    let open = selfLintFindTopLevelKind(tokens, nameIdx + 1, end, "(")
-    if open >= 0 {
-        let close = frontFindMatching(tokens, open, end, selfLintKind("("), selfLintKind(")"))
-        let bodyOpen = selfLintFindTopLevelKind(tokens, close + 1, end, r"{")
-        let mut bodyClose = bodyOpen
-        if bodyOpen >= 0 {
-            bodyClose = frontFindMatching(
-                tokens,
-                bodyOpen,
-                end,
-                selfLintKind(r"{"),
-                selfLintKind(r"}"),
-            )
-        }
-        let isPub = selfLintKindIs(selfLintPrevMeaningfulKind(tokens, start), "pub")
-        out = selfLintCheckParams(tokens, open, close, bodyOpen, bodyClose, isPub, out)
-        if bodyOpen >= 0 {
-            out = selfLintCheckFunctionShadowing(tokens, open, close, bodyOpen, bodyClose, out)
-            out = selfLintCheckFunctionComplexity(tokens, open, close, bodyOpen, bodyClose, out)
-        }
-    }
-    out
-}
-
-fn selfLintCheckTypeDecl(
-    tokens: List<FrontToken>,
-    start: Int,
-    count: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    let end = frontDeclEnd(tokens, start, count)
-    let nameIdx = selfLintNextIdent(tokens, start + 1, end)
-    if nameIdx < end {
-        let name = frontTokenTextAt(tokens, nameIdx)
-        if !(selfLintIsUpperCamel(name)) {
-            out = selfLintEmit(
-                out,
-                "L0030",
-                "type name should be UpperCamelCase",
-                name,
-                nameIdx,
-                nameIdx + 1,
-            )
-        }
-        out = selfLintCheckGenericParamsAfterName(tokens, nameIdx + 1, end, out)
-    }
-    out
-}
-
-fn selfLintCheckGenericParamsAfterName(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    if !(selfLintTokenIs(tokens, start, "<")) {
-        return out
-    }
-    let close = frontFindMatching(tokens, start, end, selfLintKind("<"), selfLintKind(">"))
-    let mut expectName = true
-    let mut angleDepth = 0
-    for idx in start + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, "<") {
-            angleDepth = angleDepth + 1
-        } else if selfLintKindIs(kind, ">") {
-            if angleDepth > 0 {
-                angleDepth = angleDepth - 1
-            }
-        } else if angleDepth == 0 && selfLintKindIs(kind, ",") {
-            expectName = true
-        } else if angleDepth == 0 && expectName && selfLintKindIs(kind, "IDENT") {
-            let name = frontTokenTextAt(tokens, idx)
-            if !(selfLintIsUpperCamel(name)) {
-                out = selfLintEmit(
-                    out,
-                    "L0030",
-                    "generic parameter should be UpperCamelCase",
-                    name,
-                    idx,
-                    idx + 1,
-                )
-            }
-            expectName = false
-        }
-    }
-    out
-}
-
-fn selfLintCheckParams(
-    tokens: List<FrontToken>,
-    open: Int,
-    close: Int,
-    bodyOpen: Int,
-    bodyClose: Int,
-    isPub: Bool,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    let mut parenDepth = 0
-    let mut angleDepth = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, "(") {
-            parenDepth = parenDepth + 1
-        } else if selfLintKindIs(kind, ")") {
-            if parenDepth > 0 {
-                parenDepth = parenDepth - 1
-            }
-        } else if selfLintKindIs(kind, "<") {
-            angleDepth = angleDepth + 1
-        } else if selfLintKindIs(kind, ">") {
-            if angleDepth > 0 {
-                angleDepth = angleDepth - 1
-            }
-        } else if parenDepth == 0 && angleDepth == 0 && (selfLintKindIs(kind, "IDENT") || selfLintKindIs(
-            kind,
-            "_",
-        )) && selfLintLooksLikeParamName(
-            tokens,
-            idx,
-            open,
-        ) {
-            let name = frontTokenTextAt(tokens, idx)
-            if !(selfLintIsIntentionalDiscard(name)) && name != "self" {
-                if !(selfLintIsLowerCamel(name)) {
-                    out = selfLintEmit(
-                        out,
-                        "L0031",
-                        "parameter name should be lowerCamelCase",
-                        name,
-                        idx,
-                        idx + 1,
-                    )
-                }
-                if !(isPub) && bodyOpen >= 0 && selfLintCountIdent(
-                    tokens,
-                    bodyOpen + 1,
-                    bodyClose,
-                    name,
-                ) == 0 {
-                    out = selfLintEmit(out, "L0002", "parameter is never used", name, idx, idx + 1)
-                }
-            }
-        }
-    }
-    out
-}
-
-fn selfLintCheckFunctionShadowing(
-    tokens: List<FrontToken>,
-    open: Int,
-    close: Int,
-    bodyOpen: Int,
-    bodyClose: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    let mut names: List<String> = []
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if (selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "_")) && selfLintLooksLikeParamName(
-            tokens,
-            idx,
-            open,
-        ) {
-            let name = frontTokenTextAt(tokens, idx)
-            if !(selfLintIsIntentionalDiscard(name)) && name != "self" {
-                if selfLintStringListContains(names, name) {
-                    out = selfLintEmit(
-                        out,
-                        "L0010",
-                        "binding shadows an earlier binding",
-                        name,
-                        idx,
-                        idx + 1,
-                    )
-                }
-                names.push(name)
-            }
-        }
-    }
-
-    for idx in bodyOpen + 1..bodyClose {
-        if selfLintTokenIs(tokens, idx, "let") {
-            let nameIdx = selfLintLetNameIndex(tokens, idx)
-            let kind = frontTokenAtList(tokens, nameIdx).kind
-            if selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "_") {
-                let name = frontTokenTextAt(tokens, nameIdx)
-                if !(selfLintIsIntentionalDiscard(name)) {
-                    if selfLintStringListContains(names, name) {
-                        out = selfLintEmit(
-                            out,
-                            "L0010",
-                            "binding shadows an earlier binding",
-                            name,
-                            nameIdx,
-                            nameIdx + 1,
-                        )
-                    }
-                    names.push(name)
-                }
-            }
-        }
-    }
-    out
-}
-
-fn selfLintCheckFunctionComplexity(
-    tokens: List<FrontToken>,
-    open: Int,
-    close: Int,
-    bodyOpen: Int,
-    bodyClose: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    let params = selfLintParamCount(tokens, open, close)
-    if params > 6 {
-        out = selfLintEmit(out, "L0050", "function takes too many parameters", "", open, close + 1)
-    }
-    let statements = selfLintStatementCount(tokens, bodyOpen, bodyClose)
-    if statements > 40 {
-        out = selfLintEmit(out, "L0052", "function body is too long", "", bodyOpen, bodyClose + 1)
-    }
-    let nesting = selfLintMaxBraceDepth(tokens, bodyOpen, bodyClose)
-    if nesting > 4 {
-        out = selfLintEmit(
+    if !(selfLintIsUpperCamel(node.text)) {
+        out = selfLintEmitAtNode(
             out,
-            "L0053",
-            "control flow is nested too deeply",
-            "",
-            bodyOpen,
-            bodyClose + 1,
+            "L0030",
+            "type name should be UpperCamelCase",
+            node.text,
+            node.start + 1,
+            node.start + 2,
+            idx,
         )
     }
-    out
+    selfLintAstCheckGenericParams(file, node.children2, out)
 }
 
-fn selfLintLooksLikeParamName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
-    let prev = selfLintPrevMeaningfulKindBounded(tokens, idx, open)
-    selfLintKindIs(prev, "(") || selfLintKindIs(prev, ",") || selfLintKindIs(prev, "mut")
-}
-
-fn selfLintCheckLet(
-    tokens: List<FrontToken>,
-    start: Int,
-    count: Int,
+fn selfLintAstCheckGenericParams(
+    file: AstFile,
+    params: List<Int>,
     report: SelfLintReport,
 ) -> SelfLintReport {
     let mut out = report
-    let end = frontFindStatementEnd(tokens, start, count)
-    let scopeEnd = selfLintNearestEnclosingBlockEnd(tokens, start, count)
-    let nameIdx = selfLintLetNameIndex(tokens, start)
-    let isMut = selfLintTokenIs(tokens, start + 1, "mut")
-    let kind = frontTokenAtList(tokens, nameIdx).kind
-    if selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "_") {
-        let name = frontTokenTextAt(tokens, nameIdx)
-        if !(selfLintIsIntentionalDiscard(name)) {
-            if !(selfLintIsLowerCamel(name)) {
-                out = selfLintEmit(
-                    out,
-                    "L0031",
-                    "binding name should be lowerCamelCase",
-                    name,
-                    nameIdx,
-                    nameIdx + 1,
-                )
-            }
-            if selfLintCountIdent(tokens, end, scopeEnd, name) == 0 {
-                out = selfLintEmit(
-                    out,
-                    "L0001",
-                    "binding is never used",
-                    name,
-                    nameIdx,
-                    nameIdx + 1,
-                )
-            }
-            if isMut && selfLintCountWrites(tokens, end, scopeEnd, name) == 0 {
-                out = selfLintEmit(
-                    out,
-                    "L0004",
-                    "mutable binding is never reassigned",
-                    name,
-                    start + 1,
-                    nameIdx + 1,
-                )
-            }
+    for paramIdx in params {
+        let param = selfLintAstNode(file, paramIdx)
+        if !(selfLintIsUpperCamel(param.text)) {
+            out = selfLintEmitAtNode(
+                out,
+                "L0030",
+                "generic parameter should be UpperCamelCase",
+                param.text,
+                param.start,
+                param.end,
+                paramIdx,
+            )
         }
     }
     out
 }
 
-fn selfLintLetNameIndex(tokens: List<FrontToken>, start: Int) -> Int {
-    let mut nameIdx = start + 1
-    if selfLintTokenIs(tokens, nameIdx, "mut") {
-        nameIdx = nameIdx + 1
-    }
-    nameIdx
-}
-
-fn selfLintCheckEnumVariants(
-    tokens: List<FrontToken>,
-    start: Int,
-    count: Int,
+fn selfLintAstCheckMemberFunctions(
+    file: AstFile,
+    members: List<Int>,
     report: SelfLintReport,
 ) -> SelfLintReport {
     let mut out = report
-    let end = frontDeclEnd(tokens, start, count)
-    let open = selfLintFindTopLevelKind(tokens, start + 1, end, r"{")
-    if open < 0 {
-        return out
+    for memberIdx in members {
+        let member = selfLintAstNode(file, memberIdx)
+        if member.kind == AstNFnDecl {
+            out = selfLintAstCheckFunction(file, memberIdx, member, out)
+        }
     }
-    let close = frontFindMatching(tokens, open, end, selfLintKind(r"{"), selfLintKind(r"}"))
-    let mut parenDepth = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, "(") {
-            parenDepth = parenDepth + 1
-        } else if selfLintKindIs(kind, ")") {
-            if parenDepth > 0 {
-                parenDepth = parenDepth - 1
-            }
-        } else if parenDepth == 0 && selfLintKindIs(kind, "IDENT") && selfLintLooksLikeVariantName(
-            tokens,
-            idx,
-            open,
-        ) {
-            let name = frontTokenTextAt(tokens, idx)
-            if !(selfLintIsUpperCamel(name)) {
-                out = selfLintEmit(
+    out
+}
+
+fn selfLintAstCheckEnumMembers(
+    file: AstFile,
+    members: List<Int>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for memberIdx in members {
+        let member = selfLintAstNode(file, memberIdx)
+        if member.kind == AstNVariant {
+            if !(selfLintIsUpperCamel(member.text)) {
+                out = selfLintEmitAtNode(
                     out,
                     "L0032",
                     "enum variant should be UpperCamelCase",
-                    name,
-                    idx,
-                    idx + 1,
+                    member.text,
+                    member.start,
+                    member.end,
+                    memberIdx,
+                )
+            }
+        } else if member.kind == AstNFnDecl {
+            out = selfLintAstCheckFunction(file, memberIdx, member, out)
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckFunction(
+    file: AstFile,
+    idx: Int,
+    node: AstNode,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    if !(selfLintIsLowerCamel(node.text)) {
+        out = selfLintEmitAtNode(
+            out,
+            "L0031",
+            "function name should be lowerCamelCase",
+            node.text,
+            node.start + 1,
+            node.start + 2,
+            idx,
+        )
+    }
+    out = selfLintAstCheckGenericParams(file, node.children2, out)
+    out = selfLintAstCheckFunctionParams(file, node, out)
+    if selfLintAstListCount(node.children) > 6 {
+        out = selfLintEmitAtNode(
+            out,
+            "L0050",
+            "function takes too many parameters",
+            "",
+            node.start,
+            node.end,
+            idx,
+        )
+    }
+    if node.right >= 0 {
+        out = selfLintAstCheckFunctionScopes(file, node, out)
+        out = selfLintAstCheckBlockUsage(file, node.right, out)
+        out = selfLintAstCheckDeadCode(file, node.right, out)
+        out = selfLintAstCheckFlow(file, node.right, out)
+        out = selfLintAstCheckSimplifyNode(file, node.right, out)
+        let statements = selfLintAstStatementCount(file, node.right)
+        if statements > 40 {
+            out = selfLintEmitAtNode(
+                out,
+                "L0052",
+                "function body is too long",
+                "",
+                node.start,
+                node.end,
+                idx,
+            )
+        }
+        let nesting = selfLintAstMaxNesting(file, node.right, -1)
+        if nesting > 4 {
+            out = selfLintEmitAtNode(
+                out,
+                "L0053",
+                "control flow is nested too deeply",
+                "",
+                node.start,
+                node.end,
+                idx,
+            )
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckFunctionParams(
+    file: AstFile,
+    fnNode: AstNode,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for paramIdx in fnNode.children {
+        let param = selfLintAstNode(file, paramIdx)
+        let names = selfLintAstParamNames(file, param)
+        for item in names {
+            if !(selfLintIsIntentionalDiscard(item.name)) && item.name != "self" {
+                if !(selfLintIsLowerCamel(item.name)) {
+                    out = selfLintEmitAtNode(
+                        out,
+                        "L0031",
+                        "parameter name should be lowerCamelCase",
+                        item.name,
+                        item.start,
+                        item.end,
+                        item.node,
+                    )
+                }
+                if fnNode.flags != 1 && fnNode.right >= 0 && selfLintAstCountIdentInNode(
+                    file,
+                    fnNode.right,
+                    item.name,
+                ) == 0 {
+                    out = selfLintEmitAtNode(
+                        out,
+                        "L0002",
+                        "parameter is never used",
+                        item.name,
+                        item.start,
+                        item.end,
+                        item.node,
+                    )
+                }
+            }
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckFunctionScopes(
+    file: AstFile,
+    fnNode: AstNode,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut names: List<String> = []
+    let mut out = report
+    for paramIdx in fnNode.children {
+        let param = selfLintAstNode(file, paramIdx)
+        let paramNames = selfLintAstParamNames(file, param)
+        for item in paramNames {
+            if !(selfLintIsIntentionalDiscard(item.name)) && item.name != "self" {
+                if selfLintStringListContains(names, item.name) {
+                    out = selfLintEmitAtNode(
+                        out,
+                        "L0010",
+                        "binding shadows an earlier binding",
+                        item.name,
+                        item.start,
+                        item.end,
+                        item.node,
+                    )
+                }
+                names.push(item.name)
+            }
+        }
+    }
+    selfLintAstCheckBlockScopes(file, fnNode.right, names, out)
+}
+
+fn selfLintAstCheckBlockScopes(
+    file: AstFile,
+    blockIdx: Int,
+    visible: List<String>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if blockIdx < 0 {
+        return report
+    }
+    let block = selfLintAstNode(file, blockIdx)
+    if block.kind != AstNBlock {
+        return report
+    }
+    let mut out = report
+    let mut local = selfLintStringListCopy(visible)
+    for stmtIdx in block.children {
+        let stmt = selfLintAstNode(file, stmtIdx)
+        if stmt.kind == AstNLet {
+            out = selfLintAstCheckPatternShadowing(file, stmt.left, local, out)
+            local = selfLintAstAppendPatternNames(file, stmt.left, local)
+            if stmt.right >= 0 {
+                out = selfLintAstCheckExprScopes(file, stmt.right, local, out)
+            }
+        } else {
+            out = selfLintAstCheckStmtScopes(file, stmtIdx, local, out)
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckStmtScopes(
+    file: AstFile,
+    idx: Int,
+    visible: List<String>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNFor {
+        let mut loopNames = selfLintStringListCopy(visible)
+        let patIdx = selfLintAstChildAt(node.children, 0)
+        out = selfLintAstCheckPatternShadowing(file, patIdx, loopNames, out)
+        loopNames = selfLintAstAppendPatternNames(file, patIdx, loopNames)
+        out = selfLintAstCheckBlockScopes(file, node.right, loopNames, out)
+        if node.left >= 0 {
+            out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+        }
+        let iterIdx = selfLintAstChildAt(node.children, 1)
+        if iterIdx >= 0 {
+            out = selfLintAstCheckExprScopes(file, iterIdx, visible, out)
+        }
+    } else if node.kind == AstNExprStmt {
+        out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+    } else if node.kind == AstNReturn || node.kind == AstNDefer {
+        out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+    } else if node.kind == AstNAssign || node.kind == AstNChanSend {
+        out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+        out = selfLintAstCheckExprScopes(file, node.right, visible, out)
+    } else {
+        out = selfLintAstCheckExprScopes(file, idx, visible, out)
+    }
+    out
+}
+
+fn selfLintAstCheckExprScopes(
+    file: AstFile,
+    idx: Int,
+    visible: List<String>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNBlock {
+        return selfLintAstCheckBlockScopes(file, idx, visible, out)
+    }
+    if node.kind == AstNIf {
+        out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+        out = selfLintAstCheckBlockScopes(file, node.right, visible, out)
+        let elseIdx = selfLintAstChildAt(node.children, 0)
+        if elseIdx >= 0 {
+            out = selfLintAstCheckExprScopes(file, elseIdx, visible, out)
+        }
+        return out
+    }
+    if node.kind == AstNMatch {
+        out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+        for armIdx in node.children {
+            let arm = selfLintAstNode(file, armIdx)
+            let mut armNames = selfLintStringListCopy(visible)
+            out = selfLintAstCheckPatternShadowing(file, arm.left, armNames, out)
+            armNames = selfLintAstAppendPatternNames(file, arm.left, armNames)
+            out = selfLintAstCheckExprScopes(file, arm.right, armNames, out)
+            let guard = selfLintAstChildAt(arm.children, 0)
+            if guard >= 0 {
+                out = selfLintAstCheckExprScopes(file, guard, armNames, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNClosure {
+        let mut closureNames = selfLintStringListCopy(visible)
+        for paramIdx in node.children {
+            let param = selfLintAstNode(file, paramIdx)
+            let paramNames = selfLintAstParamNames(file, param)
+            for item in paramNames {
+                if !(selfLintIsIntentionalDiscard(item.name)) {
+                    if selfLintStringListContains(closureNames, item.name) {
+                        out = selfLintEmitAtNode(
+                            out,
+                            "L0010",
+                            "binding shadows an earlier binding",
+                            item.name,
+                            item.start,
+                            item.end,
+                            item.node,
+                        )
+                    }
+                    closureNames.push(item.name)
+                }
+            }
+        }
+        return selfLintAstCheckExprScopes(file, node.left, closureNames, out)
+    }
+    out = selfLintAstCheckExprScopes(file, node.left, visible, out)
+    out = selfLintAstCheckExprScopes(file, node.right, visible, out)
+    for child in node.children {
+        out = selfLintAstCheckExprScopes(file, child, visible, out)
+    }
+    for child in node.children2 {
+        out = selfLintAstCheckExprScopes(file, child, visible, out)
+    }
+    out
+}
+
+fn selfLintAstCheckPatternShadowing(
+    file: AstFile,
+    patternIdx: Int,
+    visible: List<String>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let names = selfLintAstPatternNames(file, patternIdx, [])
+    let mut out = report
+    let mut local = selfLintStringListCopy(visible)
+    for item in names {
+        if !(selfLintIsIntentionalDiscard(item.name)) {
+            if selfLintStringListContains(local, item.name) {
+                out = selfLintEmitAtNode(
+                    out,
+                    "L0010",
+                    "binding shadows an earlier binding",
+                    item.name,
+                    item.start,
+                    item.end,
+                    item.node,
+                )
+            }
+            local.push(item.name)
+        }
+    }
+    out
+}
+
+fn selfLintAstAppendPatternNames(
+    file: AstFile,
+    patternIdx: Int,
+    visible: List<String>,
+) -> List<String> {
+    let names = selfLintAstPatternNames(file, patternIdx, [])
+    let mut out = selfLintStringListCopy(visible)
+    for item in names {
+        if !(selfLintIsIntentionalDiscard(item.name)) {
+            out.push(item.name)
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckBlockUsage(
+    file: AstFile,
+    blockIdx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if blockIdx < 0 {
+        return report
+    }
+    let block = selfLintAstNode(file, blockIdx)
+    if block.kind != AstNBlock {
+        return report
+    }
+    let mut out = report
+    let mut ordinal = 0
+    for stmtIdx in block.children {
+        let stmt = selfLintAstNode(file, stmtIdx)
+        if stmt.kind == AstNLet {
+            out = selfLintAstCheckLetNames(file, stmt, out)
+            let names = selfLintAstPatternNames(file, stmt.left, [])
+            for item in names {
+                if !(selfLintIsIntentionalDiscard(item.name)) {
+                    if selfLintAstCountIdentAfter(file, block.children, ordinal, item.name) == 0 {
+                        out = selfLintEmitAtNode(
+                            out,
+                            "L0001",
+                            "binding is never used",
+                            item.name,
+                            item.start,
+                            item.end,
+                            item.node,
+                        )
+                    }
+                    if stmt.flags == 1 && selfLintAstCountWritesAfter(
+                        file,
+                        block.children,
+                        ordinal,
+                        item.name,
+                    ) == 0 {
+                        out = selfLintEmitAtNode(
+                            out,
+                            "L0004",
+                            "mutable binding is never reassigned",
+                            item.name,
+                            stmt.start,
+                            item.end,
+                            item.node,
+                        )
+                    }
+                }
+            }
+            if stmt.right >= 0 {
+                out = selfLintAstCheckUsageInNode(file, stmt.right, out)
+            }
+        } else {
+            out = selfLintAstCheckUsageInNode(file, stmtIdx, out)
+        }
+        ordinal = ordinal + 1
+    }
+    out
+}
+
+fn selfLintAstCheckUsageInNode(file: AstFile, idx: Int, report: SelfLintReport) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNBlock {
+        return selfLintAstCheckBlockUsage(file, idx, out)
+    }
+    if node.kind == AstNIf {
+        out = selfLintAstCheckUsageInNode(file, node.left, out)
+        out = selfLintAstCheckBlockUsage(file, node.right, out)
+        let elseIdx = selfLintAstChildAt(node.children, 0)
+        if elseIdx >= 0 {
+            out = selfLintAstCheckUsageInNode(file, elseIdx, out)
+        }
+        return out
+    }
+    if node.kind == AstNFor {
+        out = selfLintAstCheckUsageInNode(file, node.left, out)
+        out = selfLintAstCheckUsageInNode(file, node.right, out)
+        let iterIdx = selfLintAstChildAt(node.children, 1)
+        if iterIdx >= 0 {
+            out = selfLintAstCheckUsageInNode(file, iterIdx, out)
+        }
+        return out
+    }
+    if node.kind == AstNMatch {
+        out = selfLintAstCheckUsageInNode(file, node.left, out)
+        for armIdx in node.children {
+            let arm = selfLintAstNode(file, armIdx)
+            out = selfLintAstCheckUsageInNode(file, arm.right, out)
+            let guard = selfLintAstChildAt(arm.children, 0)
+            if guard >= 0 {
+                out = selfLintAstCheckUsageInNode(file, guard, out)
+            }
+        }
+        return out
+    }
+    out = selfLintAstCheckUsageInNode(file, node.left, out)
+    out = selfLintAstCheckUsageInNode(file, node.right, out)
+    for child in node.children {
+        out = selfLintAstCheckUsageInNode(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintAstCheckUsageInNode(file, child, out)
+    }
+    out
+}
+
+fn selfLintAstCheckLetNames(file: AstFile, node: AstNode, report: SelfLintReport) -> SelfLintReport {
+    let mut out = report
+    let names = selfLintAstPatternNames(file, node.left, [])
+    for item in names {
+        if !(selfLintIsIntentionalDiscard(item.name)) && !(selfLintIsLowerCamel(item.name)) {
+            out = selfLintEmitAtNode(
+                out,
+                "L0031",
+                "binding name should be lowerCamelCase",
+                item.name,
+                item.start,
+                item.end,
+                item.node,
+            )
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckDeadCode(file: AstFile, idx: Int, report: SelfLintReport) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNBlock {
+        out = selfLintAstCheckBlockDeadCode(file, idx, out)
+    }
+    out = selfLintAstCheckDeadCode(file, node.left, out)
+    out = selfLintAstCheckDeadCode(file, node.right, out)
+    for child in node.children {
+        out = selfLintAstCheckDeadCode(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintAstCheckDeadCode(file, child, out)
+    }
+    out
+}
+
+fn selfLintAstCheckBlockDeadCode(
+    file: AstFile,
+    blockIdx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let block = selfLintAstNode(file, blockIdx)
+    let mut out = report
+    let mut terminated = false
+    for stmtIdx in block.children {
+        let stmt = selfLintAstNode(file, stmtIdx)
+        if terminated {
+            return selfLintEmitAtNode(out, "L0020", "statement is unreachable", "", stmt.start, stmt.end, stmtIdx)
+        }
+        if selfLintAstIsTerminator(stmt) {
+            terminated = true
+        }
+    }
+    let lastIdx = selfLintAstLastChild(block.children)
+    if lastIdx >= 0 {
+        let last = selfLintAstNode(file, lastIdx)
+        if last.kind == AstNReturn && last.left >= 0 {
+            out = selfLintEmitAtNode(out, "L0024", "tail return is redundant", "", last.start, last.end, lastIdx)
+        }
+    }
+    out
+}
+
+fn selfLintAstCheckFlow(file: AstFile, idx: Int, report: SelfLintReport) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNIf {
+        if selfLintAstIsConstantBoolCondition(file, node.left) {
+            out = selfLintEmitAtNode(out, "L0022", "condition is constant", "", node.start, node.start + 1, node.left)
+        }
+        if selfLintAstBlockIsEmpty(file, node.right) {
+            out = selfLintEmitAtNode(out, "L0023", "if branch is empty", "", node.start, node.end, node.right)
+        }
+        let elseIdx = selfLintAstChildAt(node.children, 0)
+        if elseIdx >= 0 {
+            let elseNode = selfLintAstNode(file, elseIdx)
+            if elseNode.kind == AstNBlock && selfLintAstBlockIsEmpty(file, elseIdx) {
+                out = selfLintEmitAtNode(
+                    out,
+                    "L0023",
+                    "else branch is empty",
+                    "",
+                    elseNode.start,
+                    elseNode.end,
+                    elseIdx,
                 )
             }
         }
-    }
-    out
-}
-
-fn selfLintLooksLikeVariantName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
-    let prev = selfLintPrevMeaningfulKindBounded(tokens, idx, open)
-    let next = frontTokenAtList(tokens, idx + 1).kind
-    (selfLintKindIs(prev, r"{") || selfLintKindIs(prev, ",") || selfLintKindIs(prev, "NEWLINE")) && !(selfLintKindIs(
-        next,
-        ":",
-    ))
-}
-
-fn selfLintScanDeadCode(
-    tokens: List<FrontToken>,
-    count: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    for idx in 0..count {
-        if selfLintTokenIs(tokens, idx, r"{") {
-            let close = frontFindMatching(
-                tokens,
-                idx,
-                count,
-                selfLintKind(r"{"),
-                selfLintKind(r"}"),
-            )
-            out = selfLintCheckBlockDeadCode(tokens, idx, close, out)
+    } else if node.kind == AstNFor {
+        if selfLintAstBlockIsEmpty(file, node.right) {
+            out = selfLintEmitAtNode(out, "L0026", "loop body is empty", "", node.start, node.end, node.right)
         }
     }
-    out
-}
-
-fn selfLintCheckBlockDeadCode(
-    tokens: List<FrontToken>,
-    open: Int,
-    close: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    let mut depth = 0
-    let mut terminator = -1
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, r"{") {
-            depth = depth + 1
-        } else if selfLintKindIs(kind, r"}") {
-            if depth > 0 {
-                depth = depth - 1
-            }
-        } else if depth == 0 {
-            if terminator >= 0 && selfLintStartsStatement(kind) {
-                return selfLintEmit(out, "L0020", "statement is unreachable", "", idx, idx + 1)
-            }
-            if selfLintKindIs(kind, "return") || selfLintKindIs(kind, "break") || selfLintKindIs(
-                kind,
-                "continue",
-            ) {
-                if selfLintKindIs(kind, "return") && selfLintReturnHasValue(tokens, idx, close) && !(selfLintHasNextStatement(
-                    tokens,
-                    frontFindStatementEnd(
-                        tokens,
-                        idx,
-                        close,
-                    ),
-                    close,
-                )) {
-                    out = selfLintEmit(
-                        out,
-                        "L0024",
-                        "tail return is redundant",
-                        "",
-                        idx,
-                        frontFindStatementEnd(tokens, idx, close),
-                    )
-                }
-                terminator = idx
-            }
-        }
+    out = selfLintAstCheckFlow(file, node.left, out)
+    out = selfLintAstCheckFlow(file, node.right, out)
+    for child in node.children {
+        out = selfLintAstCheckFlow(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintAstCheckFlow(file, child, out)
     }
     out
 }
 
-fn selfLintStartsStatement(kind: FrontTokenKind) -> Bool {
-    selfLintKindIs(kind, "let") || selfLintKindIs(kind, "return") || selfLintKindIs(kind, "break") || selfLintKindIs(
-        kind,
-        "continue",
-    ) || selfLintKindIs(kind, "for") || selfLintKindIs(kind, "if") || selfLintKindIs(kind, "match") || selfLintKindIs(
-        kind,
-        "defer",
-    ) || selfLintKindIs(kind, "IDENT") || selfLintKindIs(kind, "INT") || selfLintKindIs(
-        kind,
-        "FLOAT",
-    ) || selfLintKindIs(kind, "STRING") || selfLintKindIs(kind, "RAWSTRING") || selfLintKindIs(
-        kind,
-        "(",
-    ) || selfLintKindIs(kind, "[")
-}
-
-fn selfLintScanSimplify(
-    tokens: List<FrontToken>,
-    count: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
+fn selfLintAstCheckSimplifyNode(file: AstFile, idx: Int, report: SelfLintReport) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
     let mut out = report
-    for idx in 1..count - 1 {
-        let kind = frontTokenAtList(tokens, idx).kind
-        let left = frontTokenAtList(tokens, idx - 1)
-        let right = frontTokenAtList(tokens, idx + 1)
-        if selfLintKindIs(kind, "if") {
-            out = selfLintCheckIfSimplify(tokens, idx, count, out)
-        } else if selfLintKindIs(kind, "for") {
-            out = selfLintCheckLoopSimplify(tokens, idx, count, out)
-        } else if selfLintKindIs(kind, "!") && selfLintTokenIs(tokens, idx + 1, "!") {
-            out = selfLintEmit(out, "L0043", "double negation has no effect", "", idx, idx + 2)
-        } else if selfLintKindIs(kind, "!") && selfLintTokenIsBoolLiteral(tokens, idx + 1) {
-            out = selfLintEmit(
+    if node.kind == AstNUnary && node.op == FrontNot {
+        let inner = selfLintAstNode(file, node.left)
+        if inner.kind == AstNUnary && inner.op == FrontNot {
+            out = selfLintEmitAtNode(out, "L0043", "double negation has no effect", "", node.start, node.end, idx)
+        } else if inner.kind == AstNBoolLit {
+            out = selfLintEmitAtNode(
                 out,
                 "L0045",
                 "negated bool literal can be simplified",
-                frontTokenTextAt(tokens, idx + 1),
+                inner.text,
+                node.start,
+                node.end,
                 idx,
-                idx + 2,
             )
-        } else if frontIsComparisonOp(kind) && (selfLintTokenIsBoolLiteralToken(left) || selfLintTokenIsBoolLiteralToken(
-            right,
-        )) {
-            out = selfLintEmit(
+        }
+    } else if node.kind == AstNBinary && frontIsComparisonOp(node.op) {
+        if selfLintAstIsBoolLiteral(file, node.left) || selfLintAstIsBoolLiteral(file, node.right) {
+            out = selfLintEmitAtNode(
                 out,
                 "L0044",
                 "comparison against bool literal is redundant",
                 "",
-                idx - 1,
-                idx + 2,
+                node.start,
+                node.end,
+                idx,
             )
-        } else if frontIsComparisonOp(kind) && selfLintKindIs(left.kind, "IDENT") && selfLintKindIs(
-            right.kind,
-            "IDENT",
-        ) && left.text == right.text {
-            out = selfLintEmit(
-                out,
-                "L0041",
-                "value is compared with itself",
-                left.text,
-                idx - 1,
-                idx + 2,
-            )
-        } else if selfLintKindIs(kind, "=") && selfLintKindIs(left.kind, "IDENT") && selfLintKindIs(
-            right.kind,
-            "IDENT",
-        ) && left.text == right.text && !(selfLintAssignBelongsToLet(
-            tokens,
-            idx,
-        )) {
-            out = selfLintEmit(
+        } else {
+            let left = selfLintAstIdentName(file, node.left)
+            let right = selfLintAstIdentName(file, node.right)
+            if left != "" && left == right {
+                out = selfLintEmitAtNode(
+                    out,
+                    "L0041",
+                    "value is compared with itself",
+                    left,
+                    node.start,
+                    node.end,
+                    idx,
+                )
+            }
+        }
+    } else if node.kind == AstNAssign && node.op == FrontAssign {
+        let left = selfLintAstIdentName(file, node.left)
+        let right = selfLintAstIdentName(file, node.right)
+        if left != "" && left == right {
+            out = selfLintEmitAtNode(
                 out,
                 "L0042",
                 "self-assignment has no effect",
-                left.text,
-                idx - 1,
-                idx + 2,
+                left,
+                node.start,
+                node.end,
+                idx,
             )
         }
     }
-    out
-}
-
-fn selfLintCheckIfSimplify(
-    tokens: List<FrontToken>,
-    idx: Int,
-    count: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let mut out = report
-    let condIdx = selfLintNextMeaningfulIndex(tokens, idx + 1, count)
-    if selfLintTokenIsBoolLiteral(tokens, condIdx) || (selfLintTokenIs(tokens, condIdx, "!") && selfLintTokenIsBoolLiteral(
-        tokens,
-        selfLintNextMeaningfulIndex(tokens, condIdx + 1, count),
-    )) {
-        out = selfLintEmit(out, "L0022", "condition is constant", "", idx, condIdx + 1)
+    out = selfLintAstCheckSimplifyNode(file, node.left, out)
+    out = selfLintAstCheckSimplifyNode(file, node.right, out)
+    for child in node.children {
+        out = selfLintAstCheckSimplifyNode(file, child, out)
     }
-    let open = selfLintFindFirstKind(tokens, idx + 1, count, r"{")
-    if open >= 0 {
-        let close = frontFindMatching(tokens, open, count, selfLintKind(r"{"), selfLintKind(r"}"))
-        if selfLintBlockIsEmpty(tokens, open, close) {
-            out = selfLintEmit(out, "L0023", "if branch is empty", "", open, close + 1)
-        }
-        let after = selfLintNextMeaningfulIndex(tokens, close + 1, count)
-        if selfLintTokenIs(tokens, after, "else") {
-            let elseOpen = selfLintFindFirstKind(tokens, after + 1, count, r"{")
-            if elseOpen >= 0 {
-                let elseClose = frontFindMatching(
-                    tokens,
-                    elseOpen,
-                    count,
-                    selfLintKind(r"{"),
-                    selfLintKind(r"}"),
-                )
-                if selfLintBlockIsEmpty(tokens, elseOpen, elseClose) {
-                    out = selfLintEmit(
-                        out,
-                        "L0023",
-                        "else branch is empty",
-                        "",
-                        elseOpen,
-                        elseClose + 1,
-                    )
-                }
-            }
-        }
+    for child in node.children2 {
+        out = selfLintAstCheckSimplifyNode(file, child, out)
     }
     out
 }
 
-fn selfLintCheckLoopSimplify(
-    tokens: List<FrontToken>,
-    idx: Int,
-    count: Int,
-    report: SelfLintReport,
-) -> SelfLintReport {
-    let open = selfLintFindFirstKind(tokens, idx + 1, count, r"{")
-    if open < 0 {
-        return report
+fn selfLintAstParamNames(file: AstFile, param: AstNode) -> List<SelfLintName> {
+    let mut names: List<SelfLintName> = []
+    if param.text != "" {
+        names.push(selfLintName(param.text, param.start, param.end))
+        return names
     }
-    let close = frontFindMatching(tokens, open, count, selfLintKind(r"{"), selfLintKind(r"}"))
-    if selfLintBlockIsEmpty(tokens, open, close) {
-        selfLintEmit(report, "L0026", "loop body is empty", "", open, close + 1)
+    selfLintAstPatternNames(file, param.left, names)
+}
+
+fn selfLintAstPatternNames(
+    file: AstFile,
+    idx: Int,
+    names: List<SelfLintName>,
+) -> List<SelfLintName> {
+    if idx < 0 {
+        return names
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = names
+    if node.kind == AstNIdent {
+        out.push(selfLintNameAtNode(node.text, node.start, node.end, idx))
+        return out
+    }
+    if node.kind != AstNPattern {
+        return out
+    }
+    if node.extra == astPatternIdentKind() {
+        out.push(selfLintNameAtNode(node.text, node.start, node.end, idx))
+    } else if node.extra == astPatternBindingKind() {
+        out.push(selfLintNameAtNode(node.text, node.start, node.start + 1, idx))
+        out = selfLintAstPatternNames(file, node.left, out)
+    } else if node.extra == astPatternFieldKind() {
+        if node.left >= 0 {
+            out = selfLintAstPatternNames(file, node.left, out)
+        } else {
+            out.push(selfLintNameAtNode(node.text, node.start, node.end, idx))
+        }
     } else {
-        report
-    }
-}
-
-fn selfLintAssignBelongsToLet(tokens: List<FrontToken>, idx: Int) -> Bool {
-    let beforeName = selfLintPrevMeaningfulKindBounded(tokens, idx - 1, 0)
-    selfLintKindIs(beforeName, "let") || selfLintKindIs(beforeName, "mut") || selfLintKindIs(
-        beforeName,
-        ":",
-    )
-}
-
-fn selfLintNextIdent(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
-    for idx in start..end {
-        if selfLintTokenIs(tokens, idx, "IDENT") {
-            return idx
+        out = selfLintAstPatternNames(file, node.left, out)
+        out = selfLintAstPatternNames(file, node.right, out)
+        for child in node.children {
+            out = selfLintAstPatternNames(file, child, out)
         }
     }
-    end
+    out
 }
 
-fn selfLintFindTopLevelKind(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    target: String,
+fn selfLintAstCountIdentAfter(
+    file: AstFile,
+    stmts: List<Int>,
+    ordinal: Int,
+    name: String,
 ) -> Int {
-    let mut parenDepth = 0
-    let mut bracketDepth = 0
-    let mut braceDepth = 0
-    let mut angleDepth = 0
-    for idx in start..end {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, target) && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0 {
-            return idx
+    let mut count = 0
+    let mut idx = 0
+    for stmtIdx in stmts {
+        if idx > ordinal {
+            count = count + selfLintAstCountIdentInNode(file, stmtIdx, name)
         }
-        if selfLintKindIs(kind, "(") {
-            parenDepth = parenDepth + 1
-        } else if selfLintKindIs(kind, ")") {
-            if parenDepth > 0 {
-                parenDepth = parenDepth - 1
-            }
-        } else if selfLintKindIs(kind, "[") {
-            bracketDepth = bracketDepth + 1
-        } else if selfLintKindIs(kind, "]") {
-            if bracketDepth > 0 {
-                bracketDepth = bracketDepth - 1
-            }
-        } else if selfLintKindIs(kind, r"{") {
-            braceDepth = braceDepth + 1
-        } else if selfLintKindIs(kind, r"}") {
-            if braceDepth > 0 {
-                braceDepth = braceDepth - 1
-            }
-        } else if selfLintKindIs(kind, "<") {
-            angleDepth = angleDepth + 1
-        } else if selfLintKindIs(kind, ">") {
-            if angleDepth > 0 {
-                angleDepth = angleDepth - 1
-            }
+        idx = idx + 1
+    }
+    count
+}
+
+fn selfLintAstCountWritesAfter(
+    file: AstFile,
+    stmts: List<Int>,
+    ordinal: Int,
+    name: String,
+) -> Int {
+    let mut count = 0
+    let mut idx = 0
+    for stmtIdx in stmts {
+        if idx > ordinal {
+            count = count + selfLintAstCountWritesInNode(file, stmtIdx, name)
         }
+        idx = idx + 1
+    }
+    count
+}
+
+fn selfLintAstCountIdentInNode(file: AstFile, idx: Int, name: String) -> Int {
+    if idx < 0 {
+        return 0
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut count = 0
+    if node.kind == AstNIdent && node.text == name {
+        count = count + 1
+    }
+    count = count + selfLintAstCountIdentInNode(file, node.left, name)
+    count = count + selfLintAstCountIdentInNode(file, node.right, name)
+    for child in node.children {
+        count = count + selfLintAstCountIdentInNode(file, child, name)
+    }
+    for child in node.children2 {
+        count = count + selfLintAstCountIdentInNode(file, child, name)
+    }
+    count
+}
+
+fn selfLintAstCountWritesInNode(file: AstFile, idx: Int, name: String) -> Int {
+    if idx < 0 {
+        return 0
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut count = 0
+    if node.kind == AstNAssign && selfLintAstWriteTargetMatches(file, node.left, name) {
+        count = count + 1
+    }
+    if node.kind == AstNCall && selfLintAstMutatingCallMatches(file, node, name) {
+        count = count + 1
+    }
+    count = count + selfLintAstCountWritesInNode(file, node.left, name)
+    count = count + selfLintAstCountWritesInNode(file, node.right, name)
+    for child in node.children {
+        count = count + selfLintAstCountWritesInNode(file, child, name)
+    }
+    for child in node.children2 {
+        count = count + selfLintAstCountWritesInNode(file, child, name)
+    }
+    count
+}
+
+fn selfLintAstWriteTargetMatches(file: AstFile, idx: Int, name: String) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNIdent {
+        return node.text == name
+    }
+    if node.kind == AstNField || node.kind == AstNIndex || node.kind == AstNQuestion {
+        return selfLintAstWriteTargetMatches(file, node.left, name)
+    }
+    false
+}
+
+fn selfLintAstMutatingCallMatches(file: AstFile, node: AstNode, name: String) -> Bool {
+    let callee = selfLintAstNode(file, node.left)
+    if callee.kind == AstNField && selfLintMutatingMethodName(callee.text) {
+        return selfLintAstWriteTargetMatches(file, callee.left, name)
+    }
+    false
+}
+
+fn selfLintAstIsTerminator(node: AstNode) -> Bool {
+    node.kind == AstNReturn || node.kind == AstNBreak || node.kind == AstNContinue
+}
+
+fn selfLintAstIsConstantBoolCondition(file: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNBoolLit {
+        return true
+    }
+    if node.kind == AstNUnary && node.op == FrontNot {
+        return selfLintAstIsBoolLiteral(file, node.left)
+    }
+    false
+}
+
+fn selfLintAstIsBoolLiteral(file: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNBoolLit {
+        return true
+    }
+    if node.kind == AstNParen {
+        return selfLintAstIsBoolLiteral(file, node.left)
+    }
+    false
+}
+
+fn selfLintAstIdentName(file: AstFile, idx: Int) -> String {
+    if idx < 0 {
+        return ""
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNIdent {
+        return node.text
+    }
+    if node.kind == AstNParen {
+        return selfLintAstIdentName(file, node.left)
+    }
+    ""
+}
+
+fn selfLintAstBlockIsEmpty(file: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    node.kind == AstNBlock && selfLintAstListCount(node.children) == 0
+}
+
+fn selfLintAstStatementCount(file: AstFile, idx: Int) -> Int {
+    if idx < 0 {
+        return 0
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut count = 0
+    if selfLintAstIsStatementNode(node) {
+        count = count + 1
+    }
+    count = count + selfLintAstStatementCount(file, node.left)
+    count = count + selfLintAstStatementCount(file, node.right)
+    for child in node.children {
+        count = count + selfLintAstStatementCount(file, child)
+    }
+    for child in node.children2 {
+        count = count + selfLintAstStatementCount(file, child)
+    }
+    count
+}
+
+fn selfLintAstIsStatementNode(node: AstNode) -> Bool {
+    node.kind == AstNLet || node.kind == AstNReturn || node.kind == AstNBreak || node.kind == AstNContinue || node.kind == AstNFor || node.kind == AstNDefer || node.kind == AstNAssign || node.kind == AstNChanSend || node.kind == AstNExprStmt
+}
+
+fn selfLintAstMaxNesting(file: AstFile, idx: Int, depth: Int) -> Int {
+    if idx < 0 {
+        return depth
+    }
+    let node = selfLintAstNode(file, idx)
+    let childDepth = if node.kind == AstNBlock || node.kind == AstNIf || node.kind == AstNFor || node.kind == AstNMatch {
+        depth + 1
+    } else {
+        depth
+    }
+    let mut maxDepth = childDepth
+    let left = selfLintAstMaxNesting(file, node.left, childDepth)
+    if left > maxDepth {
+        maxDepth = left
+    }
+    let right = selfLintAstMaxNesting(file, node.right, childDepth)
+    if right > maxDepth {
+        maxDepth = right
+    }
+    for child in node.children {
+        let nested = selfLintAstMaxNesting(file, child, childDepth)
+        if nested > maxDepth {
+            maxDepth = nested
+        }
+    }
+    for child in node.children2 {
+        let nested = selfLintAstMaxNesting(file, child, childDepth)
+        if nested > maxDepth {
+            maxDepth = nested
+        }
+    }
+    maxDepth
+}
+
+fn selfLintAstChildAt(children: List<Int>, target: Int) -> Int {
+    let mut idx = 0
+    for child in children {
+        if idx == target {
+            return child
+        }
+        idx = idx + 1
     }
     -1
 }
 
-fn selfLintCountIdent(tokens: List<FrontToken>, start: Int, end: Int, name: String) -> Int {
+fn selfLintAstLastChild(children: List<Int>) -> Int {
+    let mut last = -1
+    for child in children {
+        last = child
+    }
+    last
+}
+
+fn selfLintAstListCount(items: List<Int>) -> Int {
     let mut count = 0
-    for idx in start..end {
-        let tok = frontTokenAtList(tokens, idx)
-        if selfLintKindIs(tok.kind, "IDENT") && tok.text == name {
-            count = count + 1
-        }
+    for item in items {
+        let _ = item
+        count = count + 1
     }
     count
 }
 
-fn selfLintCountWrites(tokens: List<FrontToken>, start: Int, end: Int, name: String) -> Int {
-    let mut count = 0
-    for idx in start..end {
-        let tok = frontTokenAtList(tokens, idx)
-        if selfLintKindIs(tok.kind, "IDENT") && tok.text == name {
-            let next = selfLintNextMeaningfulIndex(tokens, idx + 1, end)
-            if next < end && frontIsAssignOp(frontTokenAtList(tokens, next).kind) {
-                count = count + 1
-            } else if next < end && selfLintTokenIs(tokens, next, ".") {
-                let method = selfLintNextMeaningfulIndex(tokens, next + 1, end)
-                if method < end && selfLintMutatingMethodName(frontTokenTextAt(tokens, method)) {
-                    count = count + 1
-                }
-            }
-        }
+fn selfLintStringListCopy(items: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for item in items {
+        out.push(item)
     }
-    count
+    out
 }
 
 fn selfLintMutatingMethodName(name: String) -> Bool {
@@ -894,162 +1250,6 @@ fn selfLintStringListContains(items: List<String>, target: String) -> Bool {
         }
     }
     false
-}
-
-fn selfLintParamCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
-    let mut count = 0
-    let mut parenDepth = 0
-    let mut angleDepth = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, "(") {
-            parenDepth = parenDepth + 1
-        } else if selfLintKindIs(kind, ")") {
-            if parenDepth > 0 {
-                parenDepth = parenDepth - 1
-            }
-        } else if selfLintKindIs(kind, "<") {
-            angleDepth = angleDepth + 1
-        } else if selfLintKindIs(kind, ">") {
-            if angleDepth > 0 {
-                angleDepth = angleDepth - 1
-            }
-        } else if parenDepth == 0 && angleDepth == 0 && (selfLintKindIs(kind, "IDENT") || selfLintKindIs(
-            kind,
-            "_",
-        )) && selfLintLooksLikeParamName(
-            tokens,
-            idx,
-            open,
-        ) {
-            count = count + 1
-        }
-    }
-    count
-}
-
-fn selfLintStatementCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
-    let mut count = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintStartsStatement(kind) {
-            count = count + 1
-        }
-    }
-    count
-}
-
-fn selfLintMaxBraceDepth(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
-    let mut current = 0
-    let mut maxDepth = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintKindIs(kind, r"{") {
-            current = current + 1
-            if current > maxDepth {
-                maxDepth = current
-            }
-        } else if selfLintKindIs(kind, r"}") {
-            if current > 0 {
-                current = current - 1
-            }
-        }
-    }
-    maxDepth
-}
-
-fn selfLintNearestEnclosingBlockEnd(tokens: List<FrontToken>, idx: Int, count: Int) -> Int {
-    let mut depth = 0
-    let mut cur = idx - 1
-    for cur >= 0 {
-        let kind = frontTokenAtList(tokens, cur).kind
-        if selfLintKindIs(kind, r"}") {
-            depth = depth + 1
-        } else if selfLintKindIs(kind, r"{") {
-            if depth == 0 {
-                return frontFindMatching(tokens, cur, count, selfLintKind(r"{"), selfLintKind(r"}"))
-            }
-            depth = depth - 1
-        }
-        cur = cur - 1
-    }
-    count
-}
-
-fn selfLintNextMeaningfulIndex(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
-    for idx in start..end {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if !(selfLintKindIs(kind, "NEWLINE")) && !(selfLintKindIs(kind, ";")) {
-            return idx
-        }
-    }
-    end
-}
-
-fn selfLintFindFirstKind(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    name: String,
-) -> Int {
-    for idx in start..end {
-        if selfLintTokenIs(tokens, idx, name) {
-            return idx
-        }
-    }
-    -1
-}
-
-fn selfLintBlockIsEmpty(tokens: List<FrontToken>, open: Int, close: Int) -> Bool {
-    let next = selfLintNextMeaningfulIndex(tokens, open + 1, close)
-    next >= close
-}
-
-fn selfLintReturnHasValue(tokens: List<FrontToken>, idx: Int, end: Int) -> Bool {
-    let stmtEnd = frontFindStatementEnd(tokens, idx, end)
-    let next = selfLintNextMeaningfulIndex(tokens, idx + 1, stmtEnd)
-    next < stmtEnd
-}
-
-fn selfLintHasNextStatement(tokens: List<FrontToken>, start: Int, end: Int) -> Bool {
-    for idx in start..end {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if selfLintStartsStatement(kind) {
-            return true
-        }
-    }
-    false
-}
-
-fn selfLintTokenIsBoolLiteral(tokens: List<FrontToken>, idx: Int) -> Bool {
-    selfLintTokenIsBoolLiteralToken(frontTokenAtList(tokens, idx))
-}
-
-fn selfLintTokenIsBoolLiteralToken(tok: FrontToken) -> Bool {
-    selfLintKindIs(tok.kind, "IDENT") && (tok.text == "true" || tok.text == "false")
-}
-
-fn selfLintPrevMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
-    selfLintPrevMeaningfulKindBounded(tokens, idx, 0)
-}
-
-fn selfLintPrevTokenKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
-    if idx <= 0 {
-        return selfLintKind("EOF")
-    }
-    frontTokenAtList(tokens, idx - 1).kind
-}
-
-fn selfLintPrevMeaningfulKindBounded(tokens: List<FrontToken>, idx: Int, floor: Int) -> FrontTokenKind {
-    let mut cur = idx - 1
-    for cur >= floor {
-        let kind = frontTokenAtList(tokens, cur).kind
-        if !(selfLintKindIs(kind, "NEWLINE")) && !(selfLintKindIs(kind, ";")) {
-            return kind
-        }
-        cur = cur - 1
-    }
-    selfLintKind("EOF")
 }
 
 fn selfLintIsIntentionalDiscard(name: String) -> Bool {

--- a/examples/selfhost-core/lint_test.osty
+++ b/examples/selfhost-core/lint_test.osty
@@ -47,7 +47,7 @@ fn testSelfLintFindsSimplifiableSelfOperations() {
             fn same(x: Int) -> Bool {
                 let mut y = x
                 y = y
-                x == x
+                x == (x)
             }
             """,
     )
@@ -55,6 +55,73 @@ fn testSelfLintFindsSimplifiableSelfOperations() {
     testing.assertEq(report.parseErrors, 0)
     testing.assertEq(selfLintCodeCount(report, "L0041"), 1)
     testing.assertEq(selfLintCodeCount(report, "L0042"), 1)
+    let mut nodeBackedSimplifications = 0
+    for diag in report.diagnostics {
+        if (diag.code == "L0041" || diag.code == "L0042") && diag.node >= 0 {
+            nodeBackedSimplifications = nodeBackedSimplifications + 1
+        }
+    }
+    testing.assertEq(nodeBackedSimplifications, 2)
+}
+
+fn testSelfLintAstDoesNotCountFieldNamesAsReads() {
+    let report = selfLintSource(
+        r"""
+            fn build() -> User {
+                let name = 1
+                let user = User { name: "Ada" }
+                user
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0001"), 1)
+}
+
+fn testSelfLintParserStoresUseAliasInAst() {
+    let file = astParse("use std.testing as t\n")
+    let decl = astFileDeclAt(file, 0)
+    let mut aliasIdx = -1
+    for child in decl.children2 {
+        aliasIdx = child
+    }
+    let alias = astArenaNodeAt(file.arena, aliasIdx)
+
+    testing.assertEq(astFileErrorCount(file), 0)
+    testing.assertEq(alias.text, "t")
+}
+
+fn testSelfLintUsesResolvedRefsForImportAliases() {
+    let source = r"""
+            use std.fmt as fmt
+
+            fn main() {
+                fmt.format("{}", [])
+            }
+            """
+    let file = astParse(source)
+    let resolved = selfResolveAstFile(file)
+    let report = selfLintResolvedAstSource(source, file, resolved)
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(report.resolveErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0003"), 0)
+}
+
+fn testSelfLintKeepsImportRefsWhenResolverHasOtherErrors() {
+    let source = r"""
+            use std.fmt as fmt
+
+            fn main() {
+                fmt.format("{}", [])
+                missing()
+            }
+            """
+    let report = selfLintSource(source)
+
+    testing.assert(report.resolveErrors >= 1)
+    testing.assertEq(selfLintCodeCount(report, "L0003"), 0)
 }
 
 fn testSelfLintFindsImportMutAndShadowingRules() {

--- a/examples/selfhost-core/parser.osty
+++ b/examples/selfhost-core/parser.osty
@@ -404,10 +404,12 @@ fn opParseExprBP(p: OstyParser, minBP: Int) -> Int {
             if op.kind == FrontDotDot || op.kind == FrontDotDotEq {
                 let mut rhsIdx = -1
                 if astStartsExpr(opPeek(p).kind) { rhsIdx = opParseExprBP(p, rbp) }
+                let leftNode = astArenaNodeAt(p.arena, left)
                 let mut rangeNode = emptyAstNode(AstNRange)
                 rangeNode.left = left
                 rangeNode.right = rhsIdx
-                rangeNode.start = p.pos
+                rangeNode.start = leftNode.start
+                rangeNode.end = p.pos
                 if op.kind == FrontDotDotEq { rangeNode.flags = 1 }
                 left = opAddNode(p, rangeNode)
                 if astIsNonAssocOp(opPeek(p).kind) && astSameLevel(op.kind, opPeek(p).kind) {
@@ -416,11 +418,13 @@ fn opParseExprBP(p: OstyParser, minBP: Int) -> Int {
                 }
             } else {
                 let rhs = opParseExprBP(p, rbp)
+                let leftNode = astArenaNodeAt(p.arena, left)
                 let mut binNode = emptyAstNode(AstNBinary)
                 binNode.op = op.kind
                 binNode.left = left
                 binNode.right = rhs
-                binNode.start = p.pos
+                binNode.start = leftNode.start
+                binNode.end = p.pos
                 left = opAddNode(p, binNode)
                 if astIsNonAssocOp(op.kind) && astIsNonAssocOp(opPeek(p).kind) && astSameLevel(op.kind, opPeek(p).kind) {
                     opErrorFull(p, "chained comparison operators require parentheses", "", "v0.2 R1: comparison operators are non-associative", "E0200")
@@ -966,28 +970,31 @@ fn opParseStmt(p: OstyParser) -> Int {
     if tok.kind == FrontFor { return opParseForStmt(p) }
     let expr = opParseExpr(p)
     let next = opPeek(p)
-    if next.kind == FrontChanArrow { let s = p.pos
+    if next.kind == FrontChanArrow {
     let _ = opAdvance(p)
     let v = opParseExpr(p)
+    let leftNode = astArenaNodeAt(p.arena, expr)
     let mut n = emptyAstNode(AstNChanSend)
     n.left = expr
     n.right = v
-    n.start = s
+    n.start = leftNode.start
     n.end = p.pos
     return opAddNode(p, n) }
-    if frontIsAssignOp(next.kind) { let s = p.pos
+    if frontIsAssignOp(next.kind) {
     let _ = opAdvance(p)
     let v = opParseExpr(p)
+    let leftNode = astArenaNodeAt(p.arena, expr)
     let mut n = emptyAstNode(AstNAssign)
     n.left = expr
     n.right = v
     n.op = next.kind
-    n.start = s
+    n.start = leftNode.start
     n.end = p.pos
     return opAddNode(p, n) }
+    let exprNode = astArenaNodeAt(p.arena, expr)
     let mut n = emptyAstNode(AstNExprStmt)
     n.left = expr
-    n.start = p.pos
+    n.start = exprNode.start
     n.end = p.pos
     opAddNode(p, n)
 }
@@ -1662,6 +1669,7 @@ fn opParseUseDecl(p: OstyParser) -> Int {
     let mut path: List<String> = []
     let mut isGo = false
     let mut alias = ""
+    let mut aliasStart = -1
     if opAt(p, FrontIdent) && opPeek(p).text == "go" {
         isGo = true
         let _ = opAdvance(p)
@@ -1670,6 +1678,7 @@ fn opParseUseDecl(p: OstyParser) -> Int {
     if !(opEat(p, FrontDot)) { break } } }
     if opAt(p, FrontIdent) && opPeek(p).text == "as" {
         let _ = opAdvance(p)
+        aliasStart = p.pos
         alias = opExpect(p, FrontIdent).text
     }
     let mut goItems: List<Int> = []
@@ -1691,7 +1700,14 @@ fn opParseUseDecl(p: OstyParser) -> Int {
     n.start = start
     n.end = p.pos
     if isGo { n.flags = 1 }
-    if alias != "" { n.op = FrontIdent }
+    if alias != "" {
+        n.op = FrontIdent
+        let mut aliasNode = emptyAstNode(AstNIdent)
+        aliasNode.text = alias
+        aliasNode.start = aliasStart
+        aliasNode.end = aliasStart + 1
+        n.children2 = [opAddNode(p, aliasNode)]
+    }
     opAddNode(p, n)
 }
 

--- a/examples/selfhost-core/pipeline.osty
+++ b/examples/selfhost-core/pipeline.osty
@@ -1,3 +1,7 @@
+use go "strings" as strings {
+    fn Join(elems: List<String>, sep: String) -> String
+}
+
 pub struct SelfhostPipelineReport {
     pub tokens: Int,
     pub parseNodes: Int,
@@ -21,6 +25,7 @@ pub struct SelfhostPipelineReport {
     pub checkedExpressions: Int,
     pub lintDiagnostics: Int,
     pub lintParseErrors: Int,
+    pub diagnostics: String,
 }
 
 pub fn selfhostPipelineSource(packageName: String, source: String) -> SelfhostPipelineReport {
@@ -28,9 +33,10 @@ pub fn selfhostPipelineSource(packageName: String, source: String) -> SelfhostPi
     let tree = frontendParseTree(source)
     let module = irLowerSource(packageName, source)
     let ir = irSummarize(module)
-    let resolved = selfResolveSource(source)
+    let ast = astParse(source)
+    let resolved = selfResolveAstFile(ast)
     let checked = frontendCheckSource(source)
-    let linted = selfLintSource(source)
+    let linted = selfLintResolvedAstSource(source, ast, resolved)
 
     SelfhostPipelineReport {
         tokens: frontLexTokenCount(stream),
@@ -55,6 +61,7 @@ pub fn selfhostPipelineSource(packageName: String, source: String) -> SelfhostPi
         checkedExpressions: checked.accepted,
         lintDiagnostics: selfLintDiagnosticCount(linted),
         lintParseErrors: linted.parseErrors,
+        diagnostics: selfhostPipelineDiagnosticOutput(source, resolved, linted),
     }
 }
 
@@ -69,4 +76,21 @@ fn selfhostPipelineSymbolCount(result: SelfResolveResult) -> Int {
         count = count + 1
     }
     count
+}
+
+fn selfhostPipelineDiagnosticOutput(
+    source: String,
+    resolved: SelfResolveResult,
+    linted: SelfLintReport,
+) -> String {
+    let mut lines: List<String> = []
+    let resolveText = diagnosticFormatSelfResolveDiagnostics(source, resolved)
+    if resolveText != "" {
+        lines.push(resolveText)
+    }
+    let lintText = diagnosticFormatSelfLintDiagnostics(source, linted)
+    if lintText != "" {
+        lines.push(lintText)
+    }
+    strings.Join(lines, "\n")
 }

--- a/examples/selfhost-core/resolve.osty
+++ b/examples/selfhost-core/resolve.osty
@@ -1,5 +1,6 @@
 use go "strings" as strings {
     fn HasPrefix(s: String, prefix: String) -> Bool
+    fn Split(s: String, sep: String) -> List<String>
 }
 
 /// SelfSymbol is the self-hosting resolver's compact symbol record.
@@ -12,6 +13,7 @@ pub struct SelfSymbol {
     pub start: Int,
     pub end: Int,
     pub public: Bool,
+    pub node: Int,
 }
 
 /// SelfResolveDiagnostic mirrors the compiler's name-resolution diagnostics in
@@ -22,6 +24,7 @@ pub struct SelfResolveDiagnostic {
     pub name: String,
     pub start: Int,
     pub end: Int,
+    pub node: Int,
 }
 
 /// SelfResolveResult contains top-level/package symbols plus resolver
@@ -30,6 +33,8 @@ pub struct SelfResolveResult {
     pub symbols: List<SelfSymbol>,
     pub diagnostics: List<SelfResolveDiagnostic>,
     pub refs: Int,
+    pub refNames: List<String>,
+    pub refNodes: List<Int>,
     pub unresolved: Int,
     pub duplicates: Int,
 }
@@ -44,7 +49,21 @@ pub fn selfSymbol(
     end: Int,
     public: Bool,
 ) -> SelfSymbol {
-    SelfSymbol { name, kind, typeName, arity, depth, start, end, public }
+    SelfSymbol { name, kind, typeName, arity, depth, start, end, public, node: -1 }
+}
+
+fn selfSymbolAtNode(
+    name: String,
+    kind: String,
+    typeName: String,
+    arity: Int,
+    depth: Int,
+    start: Int,
+    end: Int,
+    public: Bool,
+    node: Int,
+) -> SelfSymbol {
+    SelfSymbol { name, kind, typeName, arity, depth, start, end, public, node }
 }
 
 pub fn selfResolveDiagnostic(
@@ -54,22 +73,42 @@ pub fn selfResolveDiagnostic(
     start: Int,
     end: Int,
 ) -> SelfResolveDiagnostic {
-    SelfResolveDiagnostic { code, message, name, start, end }
+    selfResolveDiagnosticAtNode(code, message, name, start, end, -1)
+}
+
+fn selfResolveDiagnosticAtNode(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfResolveDiagnostic {
+    SelfResolveDiagnostic { code, message, name, start, end, node }
 }
 
 pub fn emptySelfResolveResult() -> SelfResolveResult {
-    SelfResolveResult { symbols: [], diagnostics: [], refs: 0, unresolved: 0, duplicates: 0 }
+    SelfResolveResult {
+        symbols: [],
+        diagnostics: [],
+        refs: 0,
+        refNames: [],
+        refNodes: [],
+        unresolved: 0,
+        duplicates: 0,
+    }
 }
 
 /// selfResolveSource builds a package-level symbol table and resolves simple
-/// function-body references using the self-hosted lexer/parser surface.
+/// function-body references using the self-hosted AST surface.
 pub fn selfResolveSource(source: String) -> SelfResolveResult {
-    let stream = frontendLexStream(source)
-    let tokens = frontTokensFromSource(source, stream)
-    let count = frontTokenListCount(tokens)
+    selfResolveAstFile(astParse(source))
+}
+
+pub fn selfResolveAstFile(file: AstFile) -> SelfResolveResult {
     let mut result = emptySelfResolveResult()
-    result = selfResolveCollectTopLevel(tokens, count, result)
-    result = selfResolveScanFunctions(tokens, count, result)
+    result = selfResolveAstCollectTopLevel(file, result)
+    result = selfResolveAstScanFunctions(file, result)
     result
 }
 
@@ -111,341 +150,606 @@ pub fn selfResolveHasSymbol(result: SelfResolveResult, name: String, kind: Strin
     false
 }
 
-fn selfResolveCollectTopLevel(
-    tokens: List<FrontToken>,
-    count: Int,
-    result: SelfResolveResult,
-) -> SelfResolveResult {
-    let mut out = result
-    let mut skipUntil = -1
-    for idx in 0..count {
-        if idx < skipUntil {
-            let _ = idx
-        } else {
-            let kind = frontTokenAtList(tokens, idx).kind
-            if srKindIs(kind, "use") {
-                let consumed = frontParseUseConsumed(tokens, idx, count)
-                let end = idx + consumed
-                let alias = srUseAlias(tokens, idx, end)
-                if alias != "" {
-                    out = srAddSymbol(
-                        out,
-                        selfSymbol(alias, "package", "", 0, 0, idx, end, true),
-                    )
-                }
-                skipUntil = end
-            } else if srKindIs(kind, "fn") && srLooksLikeDeclarationStart(tokens, idx) {
-                let end = frontDeclEnd(tokens, idx, count)
-                let nameIdx = srNextIdent(tokens, idx + 1, end)
-                if nameIdx < end {
-                    let open = srFindTopLevelKind(tokens, nameIdx + 1, end, "(")
-                    let arity = if open >= 0 {
-                        let close = frontFindMatching(tokens, open, end, srKind("("), srKind(")"))
-                        srParamCount(tokens, open, close)
-                    } else {
-                        0
-                    }
-                    out = srAddSymbol(
-                        out,
-                        selfSymbol(
-                            frontTokenTextAt(tokens, nameIdx),
-                            "fn",
-                            "",
-                            arity,
-                            0,
-                            idx,
-                            end,
-                            srPrevMeaningfulIs(tokens, idx, "pub"),
-                        ),
-                    )
-                }
-                skipUntil = end
-            } else if (srKindIs(kind, "struct") || srKindIs(kind, "interface") || srKindIs(
-                kind,
-                "type",
-            )) && srLooksLikeDeclarationStart(
-                tokens,
-                idx,
-            ) {
-                let end = frontDeclEnd(tokens, idx, count)
-                let nameIdx = srNextIdent(tokens, idx + 1, end)
-                if nameIdx < end {
-                    out = srAddSymbol(
-                        out,
-                        selfSymbol(
-                            frontTokenTextAt(tokens, nameIdx),
-                            "type",
-                            "",
-                            0,
-                            0,
-                            idx,
-                            end,
-                            srPrevMeaningfulIs(tokens, idx, "pub"),
-                        ),
-                    )
-                }
-                skipUntil = end
-            } else if srKindIs(kind, "enum") && srLooksLikeDeclarationStart(tokens, idx) {
-                let end = frontDeclEnd(tokens, idx, count)
-                let nameIdx = srNextIdent(tokens, idx + 1, end)
-                if nameIdx < end {
-                    out = srAddSymbol(
-                        out,
-                        selfSymbol(
-                            frontTokenTextAt(tokens, nameIdx),
-                            "type",
-                            "",
-                            0,
-                            0,
-                            idx,
-                            end,
-                            srPrevMeaningfulIs(tokens, idx, "pub"),
-                        ),
-                    )
-                }
-                out = srCollectEnumVariants(tokens, idx, end, out)
-                skipUntil = end
-            } else if srKindIs(kind, "let") && srLooksLikeDeclarationStart(tokens, idx) {
-                let end = frontFindStatementEnd(tokens, idx, count)
-                let nameIdx = srLetNameIndex(tokens, idx)
-                if srTokenIs(tokens, nameIdx, "IDENT") || srTokenIs(tokens, nameIdx, "_") {
-                    out = srAddSymbol(
-                        out,
-                        selfSymbol(
-                            frontTokenTextAt(tokens, nameIdx),
-                            "value",
-                            "",
-                            0,
-                            0,
-                            idx,
-                            end,
-                            false,
-                        ),
-                    )
-                }
-                skipUntil = end
-            }
+pub fn selfResolveHasRef(result: SelfResolveResult, name: String) -> Bool {
+    for refName in result.refNames {
+        if refName == name {
+            return true
         }
+    }
+    false
+}
+
+pub fn selfResolveHasRefNode(result: SelfResolveResult, node: Int) -> Bool {
+    for refNode in result.refNodes {
+        if refNode == node {
+            return true
+        }
+    }
+    false
+}
+
+struct SelfResolveName {
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+}
+
+fn selfResolveName(name: String, start: Int, end: Int, node: Int) -> SelfResolveName {
+    SelfResolveName { name, start, end, node }
+}
+
+fn selfResolveAstCollectTopLevel(file: AstFile, result: SelfResolveResult) -> SelfResolveResult {
+    let mut out = result
+    for declIdx in file.arena.decls {
+        out = srAstCollectDecl(file, declIdx, out)
     }
     out
 }
 
-fn srCollectEnumVariants(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    result: SelfResolveResult,
-) -> SelfResolveResult {
-    let mut out = result
-    let open = srFindTopLevelKind(tokens, start + 1, end, r"{")
-    if open < 0 {
-        return out
+fn srAstCollectDecl(file: AstFile, idx: Int, result: SelfResolveResult) -> SelfResolveResult {
+    if idx < 0 {
+        return result
     }
-    let close = frontFindMatching(tokens, open, end, srKind(r"{"), srKind(r"}"))
-    let mut parenDepth = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if srKindIs(kind, "(") {
-            parenDepth = parenDepth + 1
-        } else if srKindIs(kind, ")") {
-            if parenDepth > 0 {
-                parenDepth = parenDepth - 1
-            }
-        } else if parenDepth == 0 && srKindIs(kind, "IDENT") && srLooksLikeVariantName(
-            tokens,
-            idx,
-            open,
-        ) {
+    let node = srAstNode(file, idx)
+    let mut out = result
+    if node.kind == AstNUseDecl {
+        let alias = srAstUseAlias(file, node)
+        if alias != "" {
             out = srAddSymbol(
                 out,
-                selfSymbol(frontTokenTextAt(tokens, idx), "variant", "", 0, 0, idx, idx + 1, true),
+                selfSymbolAtNode(alias, "package", "", 0, 0, node.start, node.end, true, idx),
+            )
+        }
+    } else if node.kind == AstNFnDecl {
+        out = srAstAddFunctionSymbol(file, idx, out)
+    } else if node.kind == AstNStructDecl || node.kind == AstNInterfaceDecl || node.kind == AstNTypeAlias {
+        out = srAddSymbol(
+            out,
+            selfSymbolAtNode(node.text, "type", "", 0, 0, node.start, node.end, node.flags == 1, idx),
+        )
+        out = srAstCollectMemberFunctions(file, node.children, out)
+    } else if node.kind == AstNEnumDecl {
+        out = srAddSymbol(
+            out,
+            selfSymbolAtNode(node.text, "type", "", 0, 0, node.start, node.end, node.flags == 1, idx),
+        )
+        for memberIdx in node.children {
+            let member = srAstNode(file, memberIdx)
+            if member.kind == AstNVariant {
+                out = srAddSymbol(
+                    out,
+                    selfSymbolAtNode(
+                        member.text,
+                        "variant",
+                        "",
+                        0,
+                        0,
+                        member.start,
+                        member.end,
+                        true,
+                        memberIdx,
+                    ),
+                )
+            }
+        }
+        out = srAstCollectMemberFunctions(file, node.children, out)
+    } else if node.kind == AstNLet {
+        let names = srAstPatternNames(file, node.left, [])
+        for item in names {
+            out = srAddSymbol(
+                out,
+                selfSymbolAtNode(item.name, "value", srAstLetTypeName(file, node), 0, 0, item.start, item.end, false, item.node),
             )
         }
     }
     out
 }
 
-fn selfResolveScanFunctions(
-    tokens: List<FrontToken>,
-    count: Int,
+fn srAstCollectMemberFunctions(
+    file: AstFile,
+    members: List<Int>,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    let mut skipUntil = -1
-    for idx in 0..count {
-        if idx < skipUntil {
-            let _ = idx
-        } else if srTokenIs(tokens, idx, "fn") && srLooksLikeDeclarationStart(tokens, idx) {
-            let end = frontDeclEnd(tokens, idx, count)
-            out = srResolveFunction(tokens, idx, end, out)
-            skipUntil = end
+    for memberIdx in members {
+        let member = srAstNode(file, memberIdx)
+        if member.kind == AstNFnDecl {
+            out = srAstAddFunctionSymbol(file, memberIdx, out)
         }
     }
     out
 }
 
-fn srResolveFunction(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
+fn srAstAddFunctionSymbol(
+    file: AstFile,
+    idx: Int,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
-    let mut out = result
-    let nameIdx = srNextIdent(tokens, start + 1, end)
-    let open = srFindTopLevelKind(tokens, nameIdx + 1, end, "(")
-    if open < 0 {
-        return out
-    }
-    let close = frontFindMatching(tokens, open, end, srKind("("), srKind(")"))
-    let bodyOpen = srFindTopLevelKind(tokens, close + 1, end, r"{")
-    if bodyOpen < 0 {
-        return out
-    }
-    let bodyClose = frontFindMatching(tokens, bodyOpen, end, srKind(r"{"), srKind(r"}"))
-    let mut locals: List<SelfSymbol> = []
-
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if (srKindIs(kind, "IDENT") || srKindIs(kind, "_")) && srLooksLikeParamName(
-            tokens,
+    let node = srAstNode(file, idx)
+    srAddSymbol(
+        result,
+        selfSymbolAtNode(
+            node.text,
+            "fn",
+            "",
+            srAstListCount(node.children),
+            0,
+            node.start,
+            node.end,
+            node.flags == 1,
             idx,
-            open,
-        ) {
-            let name = frontTokenTextAt(tokens, idx)
-            if !(srIsDiscardName(name)) && name != "self" {
-                if srLocalExists(locals, name) {
-                    out = srDuplicate(out, name, idx, idx + 1)
+        ),
+    )
+}
+
+fn selfResolveAstScanFunctions(file: AstFile, result: SelfResolveResult) -> SelfResolveResult {
+    let mut out = result
+    for declIdx in file.arena.decls {
+        out = srAstScanFunctionsInDecl(file, declIdx, out)
+    }
+    out
+}
+
+fn srAstScanFunctionsInDecl(
+    file: AstFile,
+    idx: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if idx < 0 {
+        return result
+    }
+    let node = srAstNode(file, idx)
+    let mut out = result
+    if node.kind == AstNFnDecl {
+        return srAstResolveFunction(file, idx, out)
+    }
+    if node.kind == AstNStructDecl || node.kind == AstNEnumDecl || node.kind == AstNInterfaceDecl {
+        for memberIdx in node.children {
+            let member = srAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl {
+                out = srAstResolveFunction(file, memberIdx, out)
+            }
+        }
+    }
+    out
+}
+
+fn srAstResolveFunction(
+    file: AstFile,
+    idx: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let node = srAstNode(file, idx)
+    let mut out = result
+    let mut locals: List<SelfSymbol> = []
+    for paramIdx in node.children {
+        let param = srAstNode(file, paramIdx)
+        if param.left >= 0 && param.text != "" {
+            out = srAstResolveExpr(file, param.left, locals, out)
+        }
+        let names = srAstParamNames(file, param)
+        for item in names {
+            if !(srIsDiscardName(item.name)) && item.name != "self" {
+                if srLocalExists(locals, item.name) {
+                    out = srDuplicateAtNode(out, item.name, item.start, item.end, item.node)
                 }
                 locals.push(
-                    selfSymbol(
-                        name,
+                    selfSymbolAtNode(
+                        item.name,
                         "value",
-                        srParamType(tokens, idx, close),
+                        srAstTypeName(file, param.right),
                         0,
                         1,
-                        idx,
-                        idx + 1,
+                        item.start,
+                        item.end,
                         false,
+                        item.node,
                     ),
                 )
             }
         }
     }
+    srAstResolveBlock(file, node.right, locals, out)
+}
 
-    let mut skipUntil = -1
-    for idx in bodyOpen + 1..bodyClose {
-        if idx < skipUntil {
-            let _ = idx
-        } else if srTokenIs(tokens, idx, "let") {
-            let stmtEnd = frontFindStatementEnd(tokens, idx, bodyClose)
-            let assign = srFindFirstKind(tokens, idx, stmtEnd, "=")
-            if assign >= 0 {
-                out = srResolveRefs(tokens, assign + 1, stmtEnd, locals, out)
+fn srAstResolveBlock(
+    file: AstFile,
+    idx: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if idx < 0 {
+        return result
+    }
+    let node = srAstNode(file, idx)
+    if node.kind != AstNBlock {
+        return srAstResolveExpr(file, idx, locals, result)
+    }
+    let mut out = result
+    for stmtIdx in node.children {
+        let stmt = srAstNode(file, stmtIdx)
+        if stmt.kind == AstNLet {
+            if stmt.right >= 0 {
+                out = srAstResolveExpr(file, stmt.right, locals, out)
             }
-            let nameIdx = srLetNameIndex(tokens, idx)
-            if srTokenIs(tokens, nameIdx, "IDENT") || srTokenIs(tokens, nameIdx, "_") {
-                let name = frontTokenTextAt(tokens, nameIdx)
-                if !(srIsDiscardName(name)) {
-                    if srLocalExists(locals, name) {
-                        out = srDuplicate(out, name, nameIdx, nameIdx + 1)
+            let names = srAstPatternNames(file, stmt.left, [])
+            for item in names {
+                if !(srIsDiscardName(item.name)) {
+                    if srLocalExists(locals, item.name) {
+                        out = srDuplicateAtNode(out, item.name, item.start, item.end, item.node)
                     }
-                    locals.push(
-                        selfSymbol(
-                            name,
-                            "value",
-                            srLetAnnotatedType(tokens, idx, stmtEnd),
-                            0,
-                            1,
-                            nameIdx,
-                            nameIdx + 1,
-                            false,
-                        ),
-                    )
+                    locals.push(srAstLocalSymbol(file, stmt, item))
                 }
             }
-            skipUntil = stmtEnd
-        } else if srTokenIs(tokens, idx, "for") {
-            out = srResolveFor(tokens, idx, bodyClose, locals, out)
-        } else if srShouldResolveIdent(tokens, idx) {
-            out = srResolveOneIdent(tokens, idx, locals, out)
+        } else {
+            out = srAstResolveStmt(file, stmtIdx, locals, out)
         }
     }
     out
 }
 
-fn srResolveFor(
-    tokens: List<FrontToken>,
+fn srAstResolveStmt(
+    file: AstFile,
     idx: Int,
-    end: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if idx < 0 {
+        return result
+    }
+    let node = srAstNode(file, idx)
+    let mut out = result
+    if node.kind == AstNFor {
+        return srAstResolveFor(file, node, locals, out)
+    }
+    if node.kind == AstNReturn || node.kind == AstNDefer || node.kind == AstNExprStmt {
+        return srAstResolveExpr(file, node.left, locals, out)
+    }
+    if node.kind == AstNAssign || node.kind == AstNChanSend {
+        out = srAstResolveExpr(file, node.left, locals, out)
+        return srAstResolveExpr(file, node.right, locals, out)
+    }
+    srAstResolveExpr(file, idx, locals, out)
+}
+
+fn srAstResolveFor(
+    file: AstFile,
+    node: AstNode,
     locals: List<SelfSymbol>,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    let bindIdx = srNextMeaningfulIndex(tokens, idx + 1, end)
-    let inIdx = srNextMeaningfulIndex(tokens, bindIdx + 1, end)
-    if srTokenIs(tokens, bindIdx, "IDENT") && srTokenIs(tokens, inIdx, "IDENT") && frontTokenTextAt(
-        tokens,
-        inIdx,
-    ) == "in" {
-        let blockOpen = srFindFirstKind(tokens, inIdx + 1, end, r"{")
-        if blockOpen > inIdx {
-            out = srResolveRefs(tokens, inIdx + 1, blockOpen, locals, out)
+    out = srAstResolveExpr(file, node.left, locals, out)
+    let iterIdx = srAstChildAt(node.children, 1)
+    out = srAstResolveExpr(file, iterIdx, locals, out)
+    let mut loopLocals = srSymbolListCopy(locals)
+    let patIdx = srAstChildAt(node.children, 0)
+    let names = srAstPatternNames(file, patIdx, [])
+    for item in names {
+        if !(srIsDiscardName(item.name)) {
+            if srLocalExists(loopLocals, item.name) {
+                out = srDuplicateAtNode(out, item.name, item.start, item.end, item.node)
+            }
+            loopLocals.push(srAstLocalSymbol(file, node, item))
         }
-        if !(srLocalExists(locals, frontTokenTextAt(tokens, bindIdx))) {
-            locals.push(
-                selfSymbol(
-                    frontTokenTextAt(tokens, bindIdx),
-                    "value",
-                    "",
-                    0,
-                    1,
-                    bindIdx,
-                    bindIdx + 1,
-                    false,
-                ),
-            )
+    }
+    srAstResolveBlock(file, node.right, loopLocals, out)
+}
+
+fn srAstResolveExpr(
+    file: AstFile,
+    idx: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if idx < 0 {
+        return result
+    }
+    let node = srAstNode(file, idx)
+    let mut out = result
+    if node.kind == AstNIdent {
+        return srResolveOneAstIdent(node.text, node.start, node.end, idx, locals, out)
+    }
+    if node.kind == AstNField {
+        return srAstResolveExpr(file, node.left, locals, out)
+    }
+    if node.kind == AstNStructLit {
+        out = srAstResolveExpr(file, node.left, locals, out)
+        for fieldIdx in node.children {
+            out = srAstResolveStructField(file, fieldIdx, locals, out)
         }
+        return srAstResolveExpr(file, node.right, locals, out)
+    }
+    if node.kind == AstNIf {
+        return srAstResolveIf(file, node, locals, out)
+    }
+    if node.kind == AstNMatch {
+        return srAstResolveMatch(file, node, locals, out)
+    }
+    if node.kind == AstNClosure {
+        return srAstResolveClosure(file, node, locals, out)
+    }
+    if node.kind == AstNBlock {
+        let mut blockLocals = srSymbolListCopy(locals)
+        return srAstResolveBlock(file, idx, blockLocals, out)
+    }
+    if node.kind == AstNType || node.kind == AstNPattern || node.kind == AstNParam || node.kind == AstNGenericParam {
+        return out
+    }
+    out = srAstResolveExpr(file, node.left, locals, out)
+    out = srAstResolveExpr(file, node.right, locals, out)
+    for child in node.children {
+        out = srAstResolveExpr(file, child, locals, out)
+    }
+    for child in node.children2 {
+        out = srAstResolveExpr(file, child, locals, out)
     }
     out
 }
 
-fn srResolveRefs(
-    tokens: List<FrontToken>,
+fn srAstResolveStructField(
+    file: AstFile,
+    idx: Int,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if idx < 0 {
+        return result
+    }
+    let node = srAstNode(file, idx)
+    if node.kind != AstNField_ {
+        return srAstResolveExpr(file, idx, locals, result)
+    }
+    if node.left >= 0 {
+        return srAstResolveExpr(file, node.left, locals, result)
+    }
+    srResolveOneAstIdent(node.text, node.start, node.end, idx, locals, result)
+}
+
+fn srAstResolveIf(
+    file: AstFile,
+    node: AstNode,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = srAstResolveExpr(file, node.left, locals, result)
+    let mut thenLocals = srSymbolListCopy(locals)
+    if node.flags == 1 {
+        let patIdx = srAstChildAt(node.children, 1)
+        let names = srAstPatternNames(file, patIdx, [])
+        for item in names {
+            if !(srIsDiscardName(item.name)) {
+                if srLocalExists(thenLocals, item.name) {
+                    out = srDuplicateAtNode(out, item.name, item.start, item.end, item.node)
+                }
+                thenLocals.push(srAstLocalSymbol(file, node, item))
+            }
+        }
+    }
+    out = srAstResolveBlock(file, node.right, thenLocals, out)
+    let elseIdx = srAstChildAt(node.children, 0)
+    let mut elseLocals = srSymbolListCopy(locals)
+    srAstResolveExpr(file, elseIdx, elseLocals, out)
+}
+
+fn srAstResolveMatch(
+    file: AstFile,
+    node: AstNode,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = srAstResolveExpr(file, node.left, locals, result)
+    for armIdx in node.children {
+        let arm = srAstNode(file, armIdx)
+        let mut armLocals = srSymbolListCopy(locals)
+        let names = srAstPatternNames(file, arm.left, [])
+        for item in names {
+            if !(srIsDiscardName(item.name)) {
+                if srLocalExists(armLocals, item.name) {
+                    out = srDuplicateAtNode(out, item.name, item.start, item.end, item.node)
+                }
+                armLocals.push(srAstLocalSymbol(file, arm, item))
+            }
+        }
+        let guardIdx = srAstChildAt(arm.children, 0)
+        out = srAstResolveExpr(file, guardIdx, armLocals, out)
+        out = srAstResolveExpr(file, arm.right, armLocals, out)
+    }
+    out
+}
+
+fn srAstResolveClosure(
+    file: AstFile,
+    node: AstNode,
+    locals: List<SelfSymbol>,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let mut closureLocals = srSymbolListCopy(locals)
+    for paramIdx in node.children {
+        let param = srAstNode(file, paramIdx)
+        let names = srAstParamNames(file, param)
+        for item in names {
+            if !(srIsDiscardName(item.name)) {
+                if srLocalExists(closureLocals, item.name) {
+                    out = srDuplicateAtNode(out, item.name, item.start, item.end, item.node)
+                }
+                closureLocals.push(srAstLocalSymbol(file, param, item))
+            }
+        }
+    }
+    srAstResolveExpr(file, node.left, closureLocals, out)
+}
+
+fn srAstLocalSymbol(
+    file: AstFile,
+    owner: AstNode,
+    item: SelfResolveName,
+) -> SelfSymbol {
+    selfSymbolAtNode(
+        item.name,
+        "value",
+        srAstLetTypeNameFromOwner(file, owner),
+        0,
+        1,
+        item.start,
+        item.end,
+        false,
+        item.node,
+    )
+}
+
+fn srResolveOneAstIdent(
+    name: String,
     start: Int,
     end: Int,
+    node: Int,
     locals: List<SelfSymbol>,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    for idx in start..end {
-        if srShouldResolveIdent(tokens, idx) {
-            out = srResolveOneIdent(tokens, idx, locals, out)
-        }
+    if srIsBuiltinName(name) {
+        return out
     }
-    out
-}
-
-fn srResolveOneIdent(
-    tokens: List<FrontToken>,
-    idx: Int,
-    locals: List<SelfSymbol>,
-    result: SelfResolveResult,
-) -> SelfResolveResult {
-    let mut out = result
-    let name = frontTokenTextAt(tokens, idx)
-    if srLocalExists(locals, name) || srTopLevelExists(out.symbols, name) || srIsBuiltinName(name) {
+    if srLocalExists(locals, name) || srTopLevelExists(out.symbols, name) {
         out.refs = out.refs + 1
+        out.refNames.push(name)
+        out.refNodes.push(node)
         return out
     }
     out.unresolved = out.unresolved + 1
-    out.diagnostics.push(selfResolveDiagnostic("E0500", "undefined name", name, idx, idx + 1))
+    out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
+    out
+}
+
+fn srAstParamNames(file: AstFile, param: AstNode) -> List<SelfResolveName> {
+    let mut names: List<SelfResolveName> = []
+    if param.text != "" {
+        names.push(selfResolveName(param.text, param.start, param.end, -1))
+        return names
+    }
+    srAstPatternNames(file, param.left, names)
+}
+
+fn srAstPatternNames(
+    file: AstFile,
+    idx: Int,
+    names: List<SelfResolveName>,
+) -> List<SelfResolveName> {
+    if idx < 0 {
+        return names
+    }
+    let node = srAstNode(file, idx)
+    let mut out = names
+    if node.kind == AstNIdent {
+        out.push(selfResolveName(node.text, node.start, node.end, idx))
+        return out
+    }
+    if node.kind != AstNPattern {
+        return out
+    }
+    if node.extra == astPatternIdentKind() {
+        out.push(selfResolveName(node.text, node.start, node.end, idx))
+    } else if node.extra == astPatternBindingKind() {
+        out.push(selfResolveName(node.text, node.start, node.start + 1, idx))
+        out = srAstPatternNames(file, node.left, out)
+    } else if node.extra == astPatternFieldKind() {
+        if node.left >= 0 {
+            out = srAstPatternNames(file, node.left, out)
+        } else {
+            out.push(selfResolveName(node.text, node.start, node.end, idx))
+        }
+    } else {
+        out = srAstPatternNames(file, node.left, out)
+        out = srAstPatternNames(file, node.right, out)
+        for child in node.children {
+            out = srAstPatternNames(file, child, out)
+        }
+    }
+    out
+}
+
+fn srAstLetTypeName(file: AstFile, node: AstNode) -> String {
+    srAstTypeName(file, srAstChildAt(node.children, 0))
+}
+
+fn srAstLetTypeNameFromOwner(file: AstFile, owner: AstNode) -> String {
+    if owner.kind == AstNLet {
+        return srAstLetTypeName(file, owner)
+    }
+    ""
+}
+
+fn srAstTypeName(file: AstFile, idx: Int) -> String {
+    if idx < 0 {
+        return ""
+    }
+    let node = srAstNode(file, idx)
+    if node.kind == AstNType {
+        return node.text
+    }
+    ""
+}
+
+fn srAstUseAlias(file: AstFile, node: AstNode) -> String {
+    let aliasIdx = srAstChildAt(node.children2, 0)
+    if aliasIdx >= 0 {
+        let alias = srAstNode(file, aliasIdx)
+        if alias.text != "" {
+            return alias.text
+        }
+    }
+    srPathLastSegment(node.text)
+}
+
+fn srPathLastSegment(path: String) -> String {
+    let parts = strings.Split(path, ".")
+    let mut last = ""
+    for part in parts {
+        if part != "" {
+            last = part
+        }
+    }
+    last
+}
+
+fn srAstNode(file: AstFile, idx: Int) -> AstNode {
+    astArenaNodeAt(file.arena, idx)
+}
+
+fn srAstChildAt(children: List<Int>, target: Int) -> Int {
+    let mut idx = 0
+    for child in children {
+        if idx == target {
+            return child
+        }
+        idx = idx + 1
+    }
+    -1
+}
+
+fn srAstListCount(items: List<Int>) -> Int {
+    let mut count = 0
+    for item in items {
+        let _ = item
+        count = count + 1
+    }
+    count
+}
+
+fn srSymbolListCopy(items: List<SelfSymbol>) -> List<SelfSymbol> {
+    let mut out: List<SelfSymbol> = []
+    for item in items {
+        out.push(item)
+    }
     out
 }
 
 fn srAddSymbol(result: SelfResolveResult, sym: SelfSymbol) -> SelfResolveResult {
     let mut out = result
     if srSymbolExistsAtDepth(out.symbols, sym.name, sym.depth) {
-        out = srDuplicate(out, sym.name, sym.start, sym.end)
+        out = srDuplicateAtNode(out, sym.name, sym.start, sym.end, sym.node)
     } else if !(srIsDiscardName(sym.name)) {
         out.symbols.push(sym)
     }
@@ -453,96 +757,22 @@ fn srAddSymbol(result: SelfResolveResult, sym: SelfSymbol) -> SelfResolveResult 
 }
 
 fn srDuplicate(result: SelfResolveResult, name: String, start: Int, end: Int) -> SelfResolveResult {
+    srDuplicateAtNode(result, name, start, end, -1)
+}
+
+fn srDuplicateAtNode(
+    result: SelfResolveResult,
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfResolveResult {
     let mut out = result
     out.duplicates = out.duplicates + 1
-    out.diagnostics.push(selfResolveDiagnostic("E0501", "duplicate declaration", name, start, end))
+    out.diagnostics.push(
+        selfResolveDiagnosticAtNode("E0501", "duplicate declaration", name, start, end, node),
+    )
     out
-}
-
-fn srShouldResolveIdent(tokens: List<FrontToken>, idx: Int) -> Bool {
-    if !(srTokenIs(tokens, idx, "IDENT")) {
-        return false
-    }
-    let name = frontTokenTextAt(tokens, idx)
-    if name == "in" || name == "as" || srIsBuiltinName(name) {
-        return false
-    }
-    let prev = srPrevMeaningfulKind(tokens, idx)
-    let next = srNextMeaningfulKind(tokens, idx)
-    if srKindIs(prev, ".") || srKindIs(prev, "fn") || srKindIs(prev, "struct") || srKindIs(
-        prev,
-        "enum",
-    ) || srKindIs(prev, "interface") || srKindIs(prev, "type") || srKindIs(prev, "use") || srKindIs(
-        prev,
-        "mut",
-    ) {
-        return false
-    }
-    if srKindIs(next, ":") {
-        return false
-    }
-    true
-}
-
-fn srUseAlias(tokens: List<FrontToken>, start: Int, end: Int) -> String {
-    let mut last = ""
-    let mut afterAs = false
-    for idx in start + 1..end {
-        let tok = frontTokenAtList(tokens, idx)
-        if srKindIs(tok.kind, "IDENT") {
-            if afterAs {
-                return tok.text
-            }
-            if tok.text == "as" {
-                afterAs = true
-            } else if tok.text != "go" {
-                last = tok.text
-            }
-        }
-    }
-    last
-}
-
-fn srLetNameIndex(tokens: List<FrontToken>, start: Int) -> Int {
-    let mut idx = start + 1
-    if srTokenIs(tokens, idx, "mut") {
-        idx = idx + 1
-    }
-    idx
-}
-
-fn srLetAnnotatedType(tokens: List<FrontToken>, start: Int, end: Int) -> String {
-    let nameIdx = srLetNameIndex(tokens, start)
-    let colon = srFindFirstKind(tokens, nameIdx + 1, end, ":")
-    if colon >= 0 {
-        return srTypeNameAt(tokens, colon + 1, end)
-    }
-    ""
-}
-
-fn srParamType(tokens: List<FrontToken>, nameIdx: Int, close: Int) -> String {
-    let colon = srFindFirstKind(tokens, nameIdx + 1, close, ":")
-    if colon >= 0 {
-        return srTypeNameAt(tokens, colon + 1, close)
-    }
-    ""
-}
-
-fn srTypeNameAt(tokens: List<FrontToken>, start: Int, end: Int) -> String {
-    let idx = srNextMeaningfulIndex(tokens, start, end)
-    if idx < end {
-        let tok = frontTokenAtList(tokens, idx)
-        if srKindIs(tok.kind, "IDENT") {
-            return tok.text
-        }
-        if srKindIs(tok.kind, "(") && srTokenIs(tokens, idx + 1, ")") {
-            return "()"
-        }
-        if srKindIs(tok.kind, "fn") {
-            return "fn"
-        }
-    }
-    ""
 }
 
 fn srLocalExists(symbols: List<SelfSymbol>, name: String) -> Bool {
@@ -578,168 +808,4 @@ fn srIsBuiltinName(name: String) -> Bool {
 
 fn srIsDiscardName(name: String) -> Bool {
     name == "_" || strings.HasPrefix(name, "_")
-}
-
-fn srKind(name: String) -> FrontTokenKind {
-    frontTokenKindByName(name)
-}
-
-fn srKindIs(kind: FrontTokenKind, name: String) -> Bool {
-    frontTokenKindName(kind) == name
-}
-
-fn srTokenIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
-    srKindIs(frontTokenAtList(tokens, idx).kind, name)
-}
-
-fn srLooksLikeDeclarationStart(tokens: List<FrontToken>, idx: Int) -> Bool {
-    let immediate = srPrevTokenKind(tokens, idx)
-    let prev = srPrevMeaningfulKind(tokens, idx)
-    srKindIs(immediate, "EOF") || srKindIs(immediate, "NEWLINE") || srKindIs(immediate, ";") || srKindIs(
-        prev,
-        "pub",
-    ) || srKindIs(prev, r"{") || srKindIs(prev, r"}")
-}
-
-fn srLooksLikeVariantName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
-    let prev = srPrevMeaningfulKindBounded(tokens, idx, open)
-    let next = frontTokenAtList(tokens, idx + 1).kind
-    (srKindIs(prev, r"{") || srKindIs(prev, ",") || srKindIs(prev, "NEWLINE")) && !(srKindIs(
-        next,
-        ":",
-    ))
-}
-
-fn srLooksLikeParamName(tokens: List<FrontToken>, idx: Int, open: Int) -> Bool {
-    let prev = srPrevMeaningfulKindBounded(tokens, idx, open)
-    srKindIs(prev, "(") || srKindIs(prev, ",") || srKindIs(prev, "mut")
-}
-
-fn srParamCount(tokens: List<FrontToken>, open: Int, close: Int) -> Int {
-    let mut count = 0
-    for idx in open + 1..close {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if (srKindIs(kind, "IDENT") || srKindIs(kind, "_")) && srLooksLikeParamName(
-            tokens,
-            idx,
-            open,
-        ) {
-            count = count + 1
-        }
-    }
-    count
-}
-
-fn srNextIdent(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
-    for idx in start..end {
-        if srTokenIs(tokens, idx, "IDENT") {
-            return idx
-        }
-    }
-    end
-}
-
-fn srFindTopLevelKind(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    target: String,
-) -> Int {
-    let mut parenDepth = 0
-    let mut bracketDepth = 0
-    let mut braceDepth = 0
-    let mut angleDepth = 0
-    for idx in start..end {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if srKindIs(kind, target) && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && angleDepth == 0 {
-            return idx
-        }
-        if srKindIs(kind, "(") {
-            parenDepth = parenDepth + 1
-        } else if srKindIs(kind, ")") {
-            if parenDepth > 0 {
-                parenDepth = parenDepth - 1
-            }
-        } else if srKindIs(kind, "[") {
-            bracketDepth = bracketDepth + 1
-        } else if srKindIs(kind, "]") {
-            if bracketDepth > 0 {
-                bracketDepth = bracketDepth - 1
-            }
-        } else if srKindIs(kind, r"{") {
-            braceDepth = braceDepth + 1
-        } else if srKindIs(kind, r"}") {
-            if braceDepth > 0 {
-                braceDepth = braceDepth - 1
-            }
-        } else if srKindIs(kind, "<") {
-            angleDepth = angleDepth + 1
-        } else if srKindIs(kind, ">") {
-            if angleDepth > 0 {
-                angleDepth = angleDepth - 1
-            }
-        }
-    }
-    -1
-}
-
-fn srFindFirstKind(
-    tokens: List<FrontToken>,
-    start: Int,
-    end: Int,
-    target: String,
-) -> Int {
-    for idx in start..end {
-        if srTokenIs(tokens, idx, target) {
-            return idx
-        }
-    }
-    -1
-}
-
-fn srNextMeaningfulIndex(tokens: List<FrontToken>, start: Int, end: Int) -> Int {
-    for idx in start..end {
-        let kind = frontTokenAtList(tokens, idx).kind
-        if !(srKindIs(kind, "NEWLINE")) && !(srKindIs(kind, ";")) {
-            return idx
-        }
-    }
-    end
-}
-
-fn srPrevMeaningfulIs(tokens: List<FrontToken>, idx: Int, name: String) -> Bool {
-    srKindIs(srPrevMeaningfulKind(tokens, idx), name)
-}
-
-fn srPrevMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
-    srPrevMeaningfulKindBounded(tokens, idx, 0)
-}
-
-fn srPrevTokenKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
-    if idx <= 0 {
-        return srKind("EOF")
-    }
-    frontTokenAtList(tokens, idx - 1).kind
-}
-
-fn srPrevMeaningfulKindBounded(tokens: List<FrontToken>, idx: Int, floor: Int) -> FrontTokenKind {
-    let mut cur = idx - 1
-    for cur >= floor {
-        let kind = frontTokenAtList(tokens, cur).kind
-        if !(srKindIs(kind, "NEWLINE")) && !(srKindIs(kind, ";")) {
-            return kind
-        }
-        cur = cur - 1
-    }
-    srKind("EOF")
-}
-
-fn srNextMeaningfulKind(tokens: List<FrontToken>, idx: Int) -> FrontTokenKind {
-    for cur in idx + 1..frontTokenListCount(tokens) {
-        let kind = frontTokenAtList(tokens, cur).kind
-        if !(srKindIs(kind, "NEWLINE")) && !(srKindIs(kind, ";")) {
-            return kind
-        }
-    }
-    srKind("EOF")
 }

--- a/examples/selfhost-core/resolve_test.osty
+++ b/examples/selfhost-core/resolve_test.osty
@@ -29,6 +29,30 @@ fn testSelfResolverCollectsSymbolsAndReferences() {
     testing.assert(result.refs >= 5)
 }
 
+fn testSelfResolverTracksReferenceNames() {
+    let source = r"""
+            use std.fmt as fmt
+
+            fn main() {
+                fmt.format("{}", [])
+            }
+            """
+    let file = astParse(source)
+    let result = selfResolveSource(source)
+    let mut fmtNode = -1
+    let mut nodeIdx = 0
+    for node in file.arena.nodes {
+        if node.kind == AstNIdent && node.text == "fmt" {
+            fmtNode = nodeIdx
+        }
+        nodeIdx = nodeIdx + 1
+    }
+
+    testing.assertEq(selfResolveDiagnosticCount(result), 0)
+    testing.assert(selfResolveHasRef(result, "fmt"))
+    testing.assert(selfResolveHasRefNode(result, fmtNode))
+}
+
 fn testSelfResolverReportsDuplicatesAndUndefinedNames() {
     let result = selfResolveSource(
         r"""
@@ -45,6 +69,18 @@ fn testSelfResolverReportsDuplicatesAndUndefinedNames() {
     testing.assertEq(result.duplicates, 1)
     testing.assertEq(selfResolveCodeCount(result, "E0501"), 1)
     testing.assertEq(selfResolveCodeCount(result, "E0500"), 2)
+    let mut sawNodeBackedUndefined = false
+    let mut sawNodeBackedDuplicate = false
+    for diag in result.diagnostics {
+        if diag.code == "E0500" && diag.node >= 0 {
+            sawNodeBackedUndefined = true
+        }
+        if diag.code == "E0501" && diag.node >= 0 {
+            sawNodeBackedDuplicate = true
+        }
+    }
+    testing.assert(sawNodeBackedUndefined)
+    testing.assert(sawNodeBackedDuplicate)
 }
 
 fn testSelfResolverTracksLocalDeclarationsInOrder() {

--- a/examples/selfhost-core/selfhost_test.osty
+++ b/examples/selfhost-core/selfhost_test.osty
@@ -1,5 +1,9 @@
 use std.testing
 
+use go "strings" as strings {
+    fn Contains(s: String, substr: String) -> Bool
+}
+
 fn testSemverRequirementMatching() {
     let req = caretReq(stableVersion(1, 2, 3))
     testing.assert(semReqMatches(req, stableVersion(1, 2, 3)))
@@ -188,4 +192,18 @@ fn testSelfhostExamplePipelineCarriesRecoveryIntoIr() {
     testing.assert(report.parseDiagnostics > 0)
     testing.assert(report.irDiagnostics > 0)
     testing.assert(report.lintParseErrors > 0)
+}
+
+fn testSelfhostExamplePipelineRendersAnalyzerDiagnostics() {
+    let source = "fn main() \{\n    let unusedValue = 1\n    missing()\n\}\n"
+    let report = selfhostPipelineSource("main", source)
+
+    testing.assert(report.resolveDiagnostics > 0)
+    testing.assert(report.lintDiagnostics > 0)
+    testing.assert(report.diagnostics != "")
+    testing.assert(selfhostPipelineBlockingErrorCount(report) >= report.resolveDiagnostics)
+    testing.assert(strings.Contains(report.diagnostics, "error[E0500]"))
+    testing.assert(strings.Contains(report.diagnostics, "resolution"))
+    testing.assert(strings.Contains(report.diagnostics, "undefined name `missing`"))
+    testing.assert(strings.Contains(report.diagnostics, "lint[L0001]"))
 }


### PR DESCRIPTION
## Summary
- Move selfhost resolve/lint diagnostics onto AST/resolved spans with source-location formatting
- Add selfhost pipeline diagnostic report output
- Add `osty pipeline --diagnostics` to render full CLI diagnostics after the pipeline report

## Tests
- `go test -count=1 ./cmd/osty`
- `go test -count=1 ./internal/pipeline`
- `go test -count=1 ./internal/examples -run TestSelfhostCoreExampleTestsExecute -v`
- `go test -count=1 ./internal/examples`
- `git diff --check`