### PR TITLE
Port primitive collection option result stdlib surfaces

### DIFF
--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -1231,6 +1231,46 @@ fn main() {
 	}
 }
 
+func TestCheck_IntShiftMethodsTakeIntCount(t *testing.T) {
+	src := `
+fn main() {
+    let x: Int8 = 5
+    let n: Int = 2
+    let a: Int8 = x.wrappingShl(n)
+    let b: Int8? = x.checkedShr(n)
+}
+`
+	got := runCheckWithStdlib(t, src)
+	if len(got) > 0 {
+		lines := make([]string, 0, len(got))
+		for _, d := range got {
+			lines = append(lines, d.Code+": "+d.Message)
+		}
+		t.Fatalf("expected no errors, got: %s", strings.Join(lines, ", "))
+	}
+}
+
+func TestCheck_FloatExplicitIntConversions(t *testing.T) {
+	src := `
+fn main() {
+    let f: Float = 2.5
+    let a: Result<Int, Error> = f.toIntTrunc()
+    let b: Result<Int, Error> = f.toIntRound()
+    let c: Result<Int, Error> = f.toIntFloor()
+    let d: Result<Int, Error> = f.toIntCeil()
+    let s: String = f.toFixed(2)
+}
+`
+	got := runCheckWithStdlib(t, src)
+	if len(got) > 0 {
+		lines := make([]string, 0, len(got))
+		for _, d := range got {
+			lines = append(lines, d.Code+": "+d.Message)
+		}
+		t.Fatalf("expected no errors, got: %s", strings.Join(lines, ", "))
+	}
+}
+
 func TestCheck_IntToInt32ReturnsResult(t *testing.T) {
 	// Narrowing conversion returns Result; using ? propagates the err.
 	src := `
@@ -1280,7 +1320,16 @@ fn main() {
     let y: String? = x.map(|n| "{n}")
     let z: Int? = None
     let recovered: Int? = z.orElse(|| Some(9))
+    let expected: Int = x.expect("present")
+    let lazy: Int = z.unwrapOrElse(|| 9)
+    let chained: String? = x.andThen(|n| Some("{n}"))
+    let dropped: String? = z.and(Some("unused"))
+    let kept: Int? = z.or(Some(10))
+    let xored: Int? = x.xor(None)
+    let filtered: Int? = x.filter(|n| n > 0)
+    let inspected: Int? = x.inspect(|n| println(n))
     let result: Result<Int, Error> = z.orError("missing")
+    let resultAlias: Result<Int, Error> = z.okOr("missing")
     let message: String = result.unwrapErr().message()
     let messageAgain: String = result.err().unwrap().message()
     let mapped: Result<String, Error> = result.map(|n| "{n}")
@@ -1311,6 +1360,14 @@ fn parse() -> Result<Int, String> { Ok(1) }
 fn test() {
     let mapped: Result<String, String> = parse().map(|n| "value={n}")
     let mappedErr: Result<Int, Int> = parse().mapErr(|e| e.len())
+    let expected: Int = parse().expect("present")
+    let fallback: Int = parse().unwrapOrElse(|e| e.len())
+    let anded: Result<String, String> = parse().and(Ok("next"))
+    let chained: Result<String, String> = parse().andThen(|n| Ok("value={n}"))
+    let fallbackErr: Result<Int, Int> = Err(0)
+    let recovered: Result<Int, Int> = parse().or(fallbackErr)
+    let recoveredElse: Result<Int, Int> = parse().orElse(|e| Err(e.len()))
+    let inspected: Result<Int, String> = parse().inspect(|n| println(n)).inspectErr(|e| println(e))
     let okValue: Int? = parse().ok()
     let errValue: String? = parse().err()
 }

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -1836,10 +1836,40 @@ func (c *checker) optionalMethod(o *types.Optional, name string) *methodDesc {
 		return simpleMethod(name, nil, types.Bool)
 	case "unwrap":
 		return simpleMethod(name, nil, t)
+	case "expect":
+		return simpleMethod(name, []types.Type{types.String}, t)
 	case "unwrapOr":
 		return simpleMethod(name, []types.Type{t}, t)
+	case "unwrapOrElse":
+		fn := &types.FnType{Params: nil, Return: t}
+		return simpleMethod(name, []types.Type{fn}, t)
+	case "and":
+		uSym := &resolve.Symbol{Name: "U", Kind: resolve.SymGeneric}
+		u := &types.TypeVar{Sym: uSym}
+		return &methodDesc{
+			Name:     name,
+			Fn:       &types.FnType{Params: []types.Type{&types.Optional{Inner: u}}, Return: &types.Optional{Inner: u}},
+			Generics: []*types.TypeVar{u},
+		}
+	case "andThen":
+		uSym := &resolve.Symbol{Name: "U", Kind: resolve.SymGeneric}
+		u := &types.TypeVar{Sym: uSym}
+		fn := &types.FnType{Params: []types.Type{t}, Return: &types.Optional{Inner: u}}
+		return &methodDesc{
+			Name:     name,
+			Fn:       &types.FnType{Params: []types.Type{fn}, Return: &types.Optional{Inner: u}},
+			Generics: []*types.TypeVar{u},
+		}
+	case "or", "xor":
+		return simpleMethod(name, []types.Type{opt}, opt)
 	case "orElse":
 		fn := &types.FnType{Params: nil, Return: opt}
+		return simpleMethod(name, []types.Type{fn}, opt)
+	case "filter":
+		fn := &types.FnType{Params: []types.Type{t}, Return: types.Bool}
+		return simpleMethod(name, []types.Type{fn}, opt)
+	case "inspect":
+		fn := &types.FnType{Params: []types.Type{t}, Return: types.Unit}
 		return simpleMethod(name, []types.Type{fn}, opt)
 	case "map":
 		uSym := &resolve.Symbol{Name: "U", Kind: resolve.SymGeneric}
@@ -1851,6 +1881,9 @@ func (c *checker) optionalMethod(o *types.Optional, name string) *methodDesc {
 			Generics: []*types.TypeVar{u},
 		}
 	case "orError":
+		return simpleMethod(name, []types.Type{types.String},
+			c.resultOf(t, c.namedOf("Error", nil)))
+	case "okOr":
 		return simpleMethod(name, []types.Type{types.String},
 			c.resultOf(t, c.namedOf("Error", nil)))
 	case "toString":
@@ -1932,14 +1965,45 @@ func resultMethod(n *types.Named, name string) *methodDesc {
 		return simpleMethod(name, nil, types.Bool)
 	case "unwrap":
 		return simpleMethod(name, nil, t)
+	case "expect":
+		return simpleMethod(name, []types.Type{types.String}, t)
 	case "unwrapErr":
 		return simpleMethod(name, nil, e)
+	case "expectErr":
+		return simpleMethod(name, []types.Type{types.String}, e)
 	case "unwrapOr":
 		return simpleMethod(name, []types.Type{t}, t)
+	case "unwrapOrElse":
+		fn := &types.FnType{Params: []types.Type{e}, Return: t}
+		return simpleMethod(name, []types.Type{fn}, t)
 	case "ok":
 		return simpleMethod(name, nil, &types.Optional{Inner: t})
 	case "err":
 		return simpleMethod(name, nil, &types.Optional{Inner: e})
+	case "and":
+		u := resultMethodTypeVar("U")
+		return genericMethod(name, []types.Type{&types.Named{Sym: n.Sym, Args: []types.Type{u, e}}},
+			&types.Named{Sym: n.Sym, Args: []types.Type{u, e}}, u)
+	case "andThen":
+		u := resultMethodTypeVar("U")
+		fn := &types.FnType{Params: []types.Type{t}, Return: &types.Named{Sym: n.Sym, Args: []types.Type{u, e}}}
+		return genericMethod(name, []types.Type{fn},
+			&types.Named{Sym: n.Sym, Args: []types.Type{u, e}}, u)
+	case "or":
+		f := resultMethodTypeVar("F")
+		return genericMethod(name, []types.Type{&types.Named{Sym: n.Sym, Args: []types.Type{t, f}}},
+			&types.Named{Sym: n.Sym, Args: []types.Type{t, f}}, f)
+	case "orElse":
+		f := resultMethodTypeVar("F")
+		fn := &types.FnType{Params: []types.Type{e}, Return: &types.Named{Sym: n.Sym, Args: []types.Type{t, f}}}
+		return genericMethod(name, []types.Type{fn},
+			&types.Named{Sym: n.Sym, Args: []types.Type{t, f}}, f)
+	case "inspect":
+		fn := &types.FnType{Params: []types.Type{t}, Return: types.Unit}
+		return simpleMethod(name, []types.Type{fn}, n)
+	case "inspectErr":
+		fn := &types.FnType{Params: []types.Type{e}, Return: types.Unit}
+		return simpleMethod(name, []types.Type{fn}, n)
 	case "map":
 		u := resultMethodTypeVar("U")
 		fn := &types.FnType{Params: []types.Type{t}, Return: u}
@@ -2395,7 +2459,8 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 				errHint = types.ErrorType
 			}
 			okOut := at
-			if okHint != nil && !types.IsError(okHint) && c.accepts(okHint, at, e.Args[0].Value) {
+			_, okHintIsTypeVar := okHint.(*types.TypeVar)
+			if okHint != nil && !okHintIsTypeVar && !types.IsError(okHint) && c.accepts(okHint, at, e.Args[0].Value) {
 				okOut = okHint
 			}
 			return &types.Named{Sym: resSym, Args: []types.Type{okOut, errHint}}
@@ -2419,7 +2484,8 @@ func (c *checker) tryVariantCall(id *ast.Ident, e *ast.CallExpr, hint types.Type
 				okHint = types.ErrorType
 			}
 			errOut := at
-			if errHint != nil && !types.IsError(errHint) && c.accepts(errHint, at, e.Args[0].Value) {
+			_, errHintIsTypeVar := errHint.(*types.TypeVar)
+			if errHint != nil && !errHintIsTypeVar && !types.IsError(errHint) && c.accepts(errHint, at, e.Args[0].Value) {
 				errOut = errHint
 			}
 			return &types.Named{Sym: resSym, Args: []types.Type{okHint, errOut}}

--- a/internal/check/method_candidates.go
+++ b/internal/check/method_candidates.go
@@ -56,7 +56,10 @@ func (c *checker) methodCandidates(t types.Type) []string {
 						add(name)
 					}
 				} else {
-					for _, name := range []string{"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr", "ok", "err", "map", "mapErr", "toString"} {
+					for _, name := range []string{
+						"isOk", "isErr", "unwrap", "expect", "unwrapErr", "expectErr", "unwrapOr", "unwrapOrElse",
+						"ok", "err", "and", "andThen", "or", "orElse", "inspect", "inspectErr", "map", "mapErr", "toString",
+					} {
 						add(name)
 					}
 				}
@@ -77,7 +80,10 @@ func (c *checker) methodCandidates(t types.Type) []string {
 			add(name)
 		}
 	case *types.Optional:
-		for _, name := range []string{"isSome", "isNone", "unwrap", "unwrapOr", "orElse", "map", "orError", "toString"} {
+		for _, name := range []string{
+			"isSome", "isNone", "unwrap", "expect", "unwrapOr", "unwrapOrElse",
+			"and", "andThen", "or", "orElse", "xor", "filter", "inspect", "map", "orError", "okOr", "toString",
+		} {
 			add(name)
 		}
 	case *types.TypeVar:

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -1609,6 +1609,16 @@ func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		g.emitExpr(f.X)
 		g.body.write(`; if opt == nil { panic("called unwrap on None") }; return *opt }()`)
 		return true
+	case "expect":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; var msg string = ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { panic(msg) }; return *opt }()")
+		return true
 	case "unwrapOr":
 		if len(c.Args) != 1 {
 			return false
@@ -1619,6 +1629,49 @@ func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		g.emitExpr(c.Args[0].Value)
 		g.body.write("; if opt != nil { return *opt }; return fallback }()")
 		return true
+	case "unwrapOrElse":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; fallback := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return *opt }; return fallback() }()")
+		return true
+	case "and":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var other %s = ", retGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return other }; return nil }()")
+		return true
+	case "andThen":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { return nil }; return f(*opt) }()")
+		return true
+	case "or":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var other %s = ", retGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return opt }; return other }()")
+		return true
 	case "orElse":
 		if len(c.Args) != 1 {
 			return false
@@ -1628,6 +1681,37 @@ func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		g.body.write("; fallback := ")
 		g.emitExpr(c.Args[0].Value)
 		g.body.write("; if opt != nil { return opt }; return fallback() }()")
+		return true
+	case "xor":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var other %s = ", retGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { if other == nil { return opt }; return nil }; return other }()")
+		return true
+	case "filter":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() *%s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; pred := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { return nil }; if pred(*opt) { return opt }; return nil }()")
+		return true
+	case "inspect":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() *%s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { f(*opt) }; return opt }()")
 		return true
 	case "map":
 		if len(c.Args) != 1 {
@@ -1647,7 +1731,7 @@ func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		g.body.write(retGo)
 		g.body.write(" = f(*opt); return &value }()")
 		return true
-	case "orError":
+	case "orError", "okOr":
 		if len(c.Args) != 1 {
 			return false
 		}
@@ -1662,7 +1746,8 @@ func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		g.emitExpr(f.X)
 		g.body.write("; var msg string = ")
 		g.emitExpr(c.Args[0].Value)
-		g.body.writef("; if opt != nil { return %s{Value: *opt, IsOk: true} }; return %s{Error: msg} }()", resultGo, resultGo)
+		g.body.writef("; if opt != nil { return resultOk[%s, %s](*opt) }; return resultErr[%s, %s](msg) }()",
+			okGo, errGo, okGo, errGo)
 		return true
 	case "toString":
 		if len(c.Args) != 0 {
@@ -2731,6 +2816,50 @@ func (g *gen) emitResultMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
 		return false
 	}
 	switch f.Name {
+	case "and":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultAnd(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "andThen":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultAndThen(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "or":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultOr(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "orElse":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultOrElse(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
 	case "map":
 		if len(c.Args) != 1 {
 			return false

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -611,9 +611,23 @@ func (r Result[T, E]) unwrap() T {
 	return r.Value
 }
 
+func (r Result[T, E]) expect(msg string) T {
+	if !r.IsOk {
+		panic(msg)
+	}
+	return r.Value
+}
+
 func (r Result[T, E]) unwrapErr() E {
 	if r.IsOk {
 		panic("called unwrapErr on Ok")
+	}
+	return r.Error
+}
+
+func (r Result[T, E]) expectErr(msg string) E {
+	if r.IsOk {
+		panic(msg)
 	}
 	return r.Error
 }
@@ -623,6 +637,13 @@ func (r Result[T, E]) unwrapOr(fallback T) T {
 		return r.Value
 	}
 	return fallback
+}
+
+func (r Result[T, E]) unwrapOrElse(fallback func(E) T) T {
+	if r.IsOk {
+		return r.Value
+	}
+	return fallback(r.Error)
 }
 
 func (r Result[T, E]) ok() *T {
@@ -644,6 +665,48 @@ func (r Result[T, E]) toString() string {
 		return "Ok(" + ostyToString(r.Value) + ")"
 	}
 	return "Err(" + ostyToString(r.Error) + ")"
+}
+
+func (r Result[T, E]) inspect(f func(T)) Result[T, E] {
+	if r.IsOk {
+		f(r.Value)
+	}
+	return r
+}
+
+func (r Result[T, E]) inspectErr(f func(E)) Result[T, E] {
+	if !r.IsOk {
+		f(r.Error)
+	}
+	return r
+}
+
+func resultAnd[T any, E any, U any](r Result[T, E], other Result[U, E]) Result[U, E] {
+	if r.IsOk {
+		return other
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultAndThen[T any, E any, U any](r Result[T, E], f func(T) Result[U, E]) Result[U, E] {
+	if r.IsOk {
+		return f(r.Value)
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultOr[T any, E any, F any](r Result[T, E], other Result[T, F]) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return other
+}
+
+func resultOrElse[T any, E any, F any](r Result[T, E], f func(E) Result[T, F]) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return f(r.Error)
 }
 
 func resultMap[T any, E any, U any](r Result[T, E], f func(T) U) Result[U, E] {

--- a/internal/gen/phase4_test.go
+++ b/internal/gen/phase4_test.go
@@ -132,6 +132,23 @@ fn main() {
     }
     let mapped = a.map(|x| x + 1)
     println("{mapped.unwrap()}")
+    println("{a.expect("present")} {b.unwrapOrElse(|| 8)}")
+    let chained = a.andThen(|x| Some("n={x}"))
+    println(chained.unwrap())
+    let anded = a.and(Some("and"))
+    let noneAnd = b.and(Some("skip"))
+    println("{anded.unwrap()} {noneAnd.isNone()}")
+    let ored = b.or(Some(12))
+    let kept = a.or(Some(99))
+    println("{ored.unwrap()} {kept.unwrap()}")
+    let xored = a.xor(None)
+    let xoredNone = a.xor(Some(5))
+    println("{xored.unwrap()} {xoredNone.isNone()}")
+    let filtered = a.filter(|x| x > 3)
+    let filteredOut = a.filter(|x| x < 0)
+    println("{filtered.unwrap()} {filteredOut.isNone()}")
+    let inspected = a.inspect(|x| println("inspect {x}"))
+    println(inspected.unwrap())
     let result = b.orError("missing")
     println("{result.isErr()}")
     println(result.unwrapErr().message())
@@ -143,6 +160,8 @@ fn main() {
     println("{mappedResult.isErr()}")
     let mappedErr = result.mapErr(|e| e.message())
     println(mappedErr.unwrapErr())
+    let alias = b.okOr("alias")
+    println(alias.unwrapErr().message())
     println(a.toString())
     println(b.toString())
 }
@@ -152,7 +171,7 @@ fn main() {
 		t.Fatalf("transpile: %v\n%s", err, goSrc)
 	}
 	out := runGo(t, goSrc)
-	want := "true true\n4 7\n6 10\n9\n5\ntrue\nmissing\nmissing\ntrue\nmissing\nSome(4)\nNone\n"
+	want := "true true\n4 7\n6 10\n9\n5\n4 8\nn=4\nand true\n12 4\n4 true\n4 true\ninspect 4\n4\ntrue\nmissing\nmissing\ntrue\nmissing\nalias\nSome(4)\nNone\n"
 	if out != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
 	}

--- a/internal/gen/primitive_methods.go
+++ b/internal/gen/primitive_methods.go
@@ -651,13 +651,12 @@ func (g *gen) emitWrappingIntShift(name string, f *ast.FieldExpr, arg ast.Expr, 
 	}
 	g.emitPrimitiveIIFE(goT, f.X, func(v string) {
 		rhs := g.freshVar("_rhs")
-		g.body.writef("var %s %s = ", rhs, goT)
+		g.body.writef("var %s int = ", rhs)
 		g.emitExpr(arg)
 		g.body.nl()
-		g.body.writef("shift := int(%s %% %s(%s))\n", rhs, goT, info.bits)
-		if recv.IsSignedInt() {
-			g.body.writef("if shift < 0 { shift += %s }\n", info.bits)
-		}
+		g.body.writef("bitWidth := int(%s)\n", info.bits)
+		g.body.writef("shift := %s %% bitWidth\n", rhs)
+		g.body.writeln("if shift < 0 { shift += bitWidth }")
 		g.body.writef("return %s %s uint(shift)\n", v, op)
 	})
 }
@@ -708,14 +707,11 @@ func (g *gen) emitCheckedIntShift(name string, f *ast.FieldExpr, arg ast.Expr, r
 	}
 	g.emitPrimitiveIIFE("*"+goT, f.X, func(v string) {
 		rhs := g.freshVar("_rhs")
-		g.body.writef("var %s %s = ", rhs, goT)
+		g.body.writef("var %s int = ", rhs)
 		g.emitExpr(arg)
 		g.body.nl()
-		if info.signed {
-			g.body.writef("if %s < 0 || %s >= %s(%s) { return nil }\n", rhs, rhs, goT, info.bits)
-		} else {
-			g.body.writef("if %s >= %s(%s) { return nil }\n", rhs, goT, info.bits)
-		}
+		g.body.writef("bitWidth := int(%s)\n", info.bits)
+		g.body.writef("if %s < 0 || %s >= bitWidth { return nil }\n", rhs, rhs)
 		g.body.writef("out := %s %s uint(%s)\n", v, op, rhs)
 		g.body.writeln("return &out")
 	})
@@ -863,7 +859,7 @@ func (g *gen) emitFloatMethod(c *ast.CallExpr, f *ast.FieldExpr, recv types.Prim
 			"abs":   "Abs",
 			"floor": "Floor",
 			"ceil":  "Ceil",
-			"round": "Round",
+			"round": "RoundToEven",
 			"trunc": "Trunc",
 			"sqrt":  "Sqrt",
 			"cbrt":  "Cbrt",
@@ -985,6 +981,24 @@ func (g *gen) emitFloatMethod(c *ast.CallExpr, f *ast.FieldExpr, recv types.Prim
 			g.emitExpr(f.X)
 			g.body.write("))")
 		}
+	case "toFixed":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strconv")
+		g.emitPrimitiveIIFE("string", f.X, func(v string) {
+			precision := g.freshVar("_precision")
+			g.body.writef("var %s int = ", precision)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 { %s = 0 }\n", precision, precision)
+			g.body.writef("return strconv.FormatFloat(float64(%s), 'f', %s, %s)\n", v, precision, bits)
+		})
+	case "toIntTrunc", "toIntRound", "toIntFloor", "toIntCeil":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitFloatToIntResult(f)
 	case "toInt", "toInt32", "toInt64", "toFloat", "toFloat32", "toFloat64":
 		if len(c.Args) != 0 {
 			return false
@@ -1015,6 +1029,28 @@ func (g *gen) emitFloatMethod(c *ast.CallExpr, f *ast.FieldExpr, recv types.Prim
 		return false
 	}
 	return true
+}
+
+func (g *gen) emitFloatToIntResult(f *ast.FieldExpr) {
+	g.needResult = true
+	g.use("math")
+	g.use("strconv")
+	fn := map[string]string{
+		"toIntTrunc": "Trunc",
+		"toIntRound": "RoundToEven",
+		"toIntFloor": "Floor",
+		"toIntCeil":  "Ceil",
+	}[f.Name]
+	g.emitPrimitiveIIFE("Result[int, any]", f.X, func(v string) {
+		rounded := g.freshVar("_rounded")
+		g.body.writef("%s := math.%s(float64(%s))\n", rounded, fn, v)
+		g.body.writeln("lo := -9223372036854775808.0")
+		g.body.writeln("hi := 9223372036854775808.0")
+		g.body.writeln("if strconv.IntSize == 32 { lo = -2147483648.0; hi = 2147483648.0 }")
+		g.body.writef("if math.IsNaN(%s) || math.IsInf(%s, 0) || %s < lo || %s >= hi { return resultErr[int, any](%q) }\n",
+			rounded, rounded, rounded, rounded, f.Name+" out of Int range")
+		g.body.writef("return resultOk[int, any](int(%s))\n", rounded)
+	})
 }
 
 func (g *gen) emitIntConversionResult(f *ast.FieldExpr, recv types.PrimitiveKind) bool {

--- a/internal/gen/primitive_methods_test.go
+++ b/internal/gen/primitive_methods_test.go
@@ -14,7 +14,7 @@ func TestPrimitiveMethodsCompileAndRun(t *testing.T) {
     println("{n.abs()} {n.min(3)} {n.max(3)} {n.clamp(-5, 5)} {n.signum()} {n.pow(2)} {narrowed} {checked} {missing} {n.toString()}")
 
     let f: Float = 9.25
-    println("{f.sqrt().round().toString()} {f.floor().toInt()} {f.fract().toString()} {f.isFinite()}")
+    println("{f.sqrt().round().toString()} {f.floor().toIntFloor().unwrap()} {f.fract().toString()} {f.isFinite()} {f.toFixed(1)}")
     let i8: Int8 = 5
     let f32: Float32 = 4.0
     println("{i8.checkedAdd(1).unwrap().toInt()} {i8.min(3).toInt()} {i8.clamp(0, 4).toInt()} {f32.max(5.0).toFloat().toString()}")
@@ -35,7 +35,7 @@ func TestPrimitiveMethodsCompileAndRun(t *testing.T) {
         Err(_) -> println("bad int"),
     }
     match "2.5".toFloat() {
-        Ok(v) -> println(v.toInt()),
+        Ok(v) -> println(v.toIntTrunc().unwrap()),
         Err(_) -> println("bad float"),
     }
 }
@@ -46,7 +46,7 @@ func TestPrimitiveMethodsCompileAndRun(t *testing.T) {
 	out := strings.TrimSpace(runGo(t, goSrc))
 	want := strings.Join([]string{
 		"7 -7 3 -5 -1 49 7 3 true -7",
-		"3 9 0.25 true",
+		"3 9 0.25 true 9.2",
 		"6 3 4 5",
 		"A true false 97",
 		"OSTY LANG true true true",
@@ -72,7 +72,7 @@ fn main() {
     println("{max.checkedAdd(1).isNone()} {max.saturatingAdd(1).toInt()} {min.checkedSub(1).isNone()} {min.saturatingSub(1).toInt()}")
     println("{min.checkedAbs().isNone()} {min.wrappingAbs().toInt()} {min.checkedNeg().isNone()}")
     println("{min.checkedDiv(-1).isNone()} {min.saturatingDiv(-1).toInt()} {min.wrappingDiv(-1).toInt()} {min.wrappingMod(-1).toInt()}")
-    println("{ten.checkedMul(13).isNone()} {ten.saturatingMul(13).toInt()} {ten.checkedShl(8).isNone()} {ten.wrappingShl(8).toInt()}")
+    println("{ten.checkedMul(13).isNone()} {ten.saturatingMul(13).toInt()} {ten.checkedShl(8).isNone()} {ten.wrappingShl(8).toInt()} {ten.checkedShl(-1).isNone()} {ten.wrappingShl(-1).toInt()}")
     println("{u.checkedAdd(10).isNone()} {u.saturatingAdd(10).toInt()} {u.checkedSub(251).isNone()} {u.saturatingSub(251).toInt()} {u.checkedMul(2).isNone()} {u.saturatingMul(2).toInt()}")
 
     let accent = "e\u{0301}"
@@ -82,6 +82,12 @@ fn main() {
 
     let bad = bytes.fromHex("ff").unwrap()
     println("{bad.toString().isErr()} {bytes.toString(bad).isErr()}")
+
+    let half: Float = 2.5
+    let neg: Float = -2.5
+    println("{half.round().toString()} {neg.round().toString()} {half.toIntTrunc().unwrap()} {half.toIntRound().unwrap()} {neg.toIntFloor().unwrap()} {neg.toIntCeil().unwrap()} {half.toFixed(2)} {half.toFixed(-1)}")
+    let zero = 0.0
+    println("{(1.0 / zero).toIntTrunc().isErr()}")
 }
 `)
 	if err != nil {
@@ -92,10 +98,12 @@ fn main() {
 		"true 127 true -128",
 		"true -128 true",
 		"true 127 -128 0",
-		"true 127 true 10",
+		"true 127 true 10 true 0",
 		"true 255 true 0 true 255",
 		"2 1 1 1",
 		"true true",
+		"2 -2 2 2 -3 -2 2.50 2",
+		"true",
 	}, "\n")
 	if out != want {
 		t.Fatalf("stdout = %q, want %q\n--- source ---\n%s", out, want, goSrc)

--- a/internal/gen/result_test.go
+++ b/internal/gen/result_test.go
@@ -108,8 +108,10 @@ func TestResultIntrinsicMethodsRuntime(t *testing.T) {
     println(ok.isOk())
     println(ok.isErr())
     println(ok.unwrap())
+    println(ok.expect("ok expected"))
     println(ok.unwrapOr(9))
     println(ok.toString())
+    ok.inspect(|n| println("seen ok {n}"))
     let nested: Result<Result<Int, String>, String> = Ok(ok)
     println(nested.toString())
     println("{nested}")
@@ -122,8 +124,11 @@ func TestResultIntrinsicMethodsRuntime(t *testing.T) {
     println(err.isOk())
     println(err.isErr())
     println(err.unwrapOr(9))
+    println(err.unwrapOrElse(|e| e.len()))
     println(err.unwrapErr())
+    println(err.expectErr("err expected"))
     println(err.toString())
+    err.inspectErr(|e| println("seen err {e}"))
     match err.err() {
         Some(e) -> println("err value: {e}"),
         None -> println("missing"),
@@ -135,7 +140,7 @@ func TestResultIntrinsicMethodsRuntime(t *testing.T) {
 		t.Fatalf("transpile: %v\n%s", err, goSrc)
 	}
 	out := runGo(t, goSrc)
-	want := "true\nfalse\n5\n5\nOk(5)\nOk(Ok(5))\nOk(Ok(5))\nok value: 5\nfalse\ntrue\n9\nbad\nErr(bad)\nerr value: bad\n"
+	want := "true\nfalse\n5\n5\n5\nOk(5)\nseen ok 5\nOk(Ok(5))\nOk(Ok(5))\nok value: 5\nfalse\ntrue\n9\n3\nbad\nbad\nErr(bad)\nseen err bad\nerr value: bad\n"
 	if out != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
 	}
@@ -164,6 +169,44 @@ fn main() {
         Ok(n) -> println("ok {n}"),
         Err(e) -> println("mapped err {e}"),
     }
+
+    let next: Result<String, Int> = Ok("next")
+    let anded = parse("ok").and(next)
+    match anded {
+        Ok(s) -> println("and {s}"),
+        Err(e) -> println("and err {e}"),
+    }
+
+    let nextErr: Result<String, Int> = Ok("skip")
+    let stopped = parse("bad").and(nextErr)
+    match stopped {
+        Ok(s) -> println("and {s}"),
+        Err(e) -> println("and err {e}"),
+    }
+
+    let chained = parse("ok").andThen(|n| Ok("n={n}"))
+    match chained {
+        Ok(s) -> println("chain {s}"),
+        Err(e) -> println("chain err {e}"),
+    }
+
+    let fallback: Result<Int, String> = Ok(7)
+    let recovered = parse("bad").or(fallback)
+    match recovered {
+        Ok(n) -> println("or {n}"),
+        Err(e) -> println("or err {e}"),
+    }
+
+    let changedErr = parse("bad").orElse(|e| Err("e={e}"))
+    match changedErr {
+        Ok(n) -> println("orElse ok {n}"),
+        Err(e) -> println("orElse err {e}"),
+    }
+
+    let inspected = parse("ok").inspect(|n| println("inspect {n}"))
+    println(inspected.unwrap())
+    let inspectedErr = parse("bad").inspectErr(|e| println("inspect err {e}"))
+    println(inspectedErr.unwrapErr())
 }
 `
 	goSrc, err := transpile(t, src)
@@ -171,7 +214,7 @@ fn main() {
 		t.Fatalf("transpile: %v\n%s", err, goSrc)
 	}
 	out := runGo(t, goSrc)
-	want := "mapped v=2\nstill err 40\nmapped err e=40\n"
+	want := "mapped v=2\nstill err 40\nmapped err e=40\nand next\nand err 40\nchain n=2\nor 7\norElse err e=40\ninspect 2\n2\ninspect err 40\n40\n"
 	if out != want {
 		t.Errorf("got %q, want %q\n--- src ---\n%s", out, want, goSrc)
 	}

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -4,7 +4,10 @@
 // rarely writes `use std.collections`. The module-local structs provide
 // the canonical signature surface for the collection methods in spec
 // §10.6. Runtime lowering is intrinsic because these types map directly
-// to Go slices/maps in the current backend.
+// to Go slices/maps in the current backend. Some pure bodies seed an
+// output collection from an intrinsic method before rebuilding it; that
+// keeps the placeholder `std.collections` types aligned with the prelude
+// builtin collection types until the prelude rebind lands.
 
 pub struct List<T> {
     pub fn len(self) -> Int
@@ -32,8 +35,24 @@ pub struct List<T> {
         None
     }
 
-    pub fn map<R>(self, f: fn(T) -> R) -> List<R>
-    pub fn filter(self, pred: fn(T) -> Bool) -> List<T>
+    pub fn map<R>(self, f: fn(T) -> R) -> List<R> {
+        let mut out = self.map(f)
+        out.clear()
+        for item in self {
+            out.push(f(item))
+        }
+        out
+    }
+    pub fn filter(self, pred: fn(T) -> Bool) -> List<T> {
+        let mut out = self.map(|item| item)
+        out.clear()
+        for item in self {
+            if pred(item) {
+                out.push(item)
+            }
+        }
+        out
+    }
     pub fn fold<A>(self, init: A, f: fn(A, T) -> A) -> A {
         let mut acc = init
         for item in self {
@@ -42,20 +61,94 @@ pub struct List<T> {
         acc
     }
     pub fn sorted(self) -> List<T>
-    pub fn sortedBy<K>(self, key: fn(T) -> K) -> List<T>
-    pub fn reversed(self) -> List<T>
-    pub fn appended(self, item: T) -> List<T>
-    pub fn concat(self, other: List<T>) -> List<T>
-    pub fn zip<U>(self, other: List<U>) -> List<(T, U)>
-    pub fn enumerate(self) -> List<(Int, T)>
+    pub fn sortedBy<K: Ordered>(self, key: fn(T) -> K) -> List<T> {
+        let mut out = self.map(|item| item)
+        out.clear()
+        for item in self {
+            out.push(item)
+        }
+
+        let mut i = 0
+        for i < out.len() {
+            let mut best = i
+            let mut j = i + 1
+            for j < out.len() {
+                if key(out[j]) < key(out[best]) {
+                    best = j
+                }
+                j = j + 1
+            }
+            if best != i {
+                let tmp = out[i]
+                out[i] = out[best]
+                out[best] = tmp
+            }
+            i = i + 1
+        }
+        out
+    }
+    pub fn reversed(self) -> List<T> {
+        let mut out = self.map(|item| item)
+        out.clear()
+        let mut i = self.len()
+        for i > 0 {
+            i = i - 1
+            out.push(self[i])
+        }
+        out
+    }
+    pub fn appended(self, item: T) -> List<T> {
+        let mut out = self.map(|value| value)
+        out.push(item)
+        out
+    }
+    pub fn concat(self, other: List<T>) -> List<T> {
+        let mut out = self.map(|item| item)
+        out.clear()
+        for item in self {
+            out.push(item)
+        }
+        for item in other {
+            out.push(item)
+        }
+        out
+    }
+    pub fn zip<U>(self, other: List<U>) -> List<(T, U)> {
+        let mut out = self.zip(other)
+        out.clear()
+        let limit = if self.len() < other.len() { self.len() } else { other.len() }
+        for i in 0..limit {
+            out.push((self[i], other[i]))
+        }
+        out
+    }
+    pub fn enumerate(self) -> List<(Int, T)> {
+        let mut out = self.enumerate()
+        out.clear()
+        let mut i = 0
+        for item in self {
+            out.push((i, item))
+            i = i + 1
+        }
+        out
+    }
 
     pub fn push(mut self, item: T)
-    pub fn pop(mut self) -> T?
+    pub fn pop(mut self) -> T? {
+        if self.isEmpty() {
+            return None
+        }
+        Some(self.removeAt(self.len() - 1))
+    }
     pub fn insert(mut self, index: Int, item: T)
     pub fn removeAt(mut self, index: Int) -> T
     pub fn sort(mut self)
     pub fn reverse(mut self)
-    pub fn clear(mut self)
+    pub fn clear(mut self) {
+        for self.len() > 0 {
+            self.removeAt(self.len() - 1)
+        }
+    }
 }
 
 pub struct Map<K: Hashable, V> {
@@ -67,9 +160,30 @@ pub struct Map<K: Hashable, V> {
     pub fn containsKey(self, key: K) -> Bool {
         self.get(key).isSome()
     }
-    pub fn keys(self) -> List<K>
-    pub fn values(self) -> List<V>
-    pub fn entries(self) -> List<(K, V)>
+    pub fn keys(self) -> List<K> {
+        let mut out = self.keys()
+        out.clear()
+        for (key, unusedValue) in self {
+            out.push(key)
+        }
+        out
+    }
+    pub fn values(self) -> List<V> {
+        let mut out = self.values()
+        out.clear()
+        for (unusedKey, value) in self {
+            out.push(value)
+        }
+        out
+    }
+    pub fn entries(self) -> List<(K, V)> {
+        let mut out = self.entries()
+        out.clear()
+        for (key, value) in self {
+            out.push((key, value))
+        }
+        out
+    }
 
     pub fn insert(mut self, key: K, value: V)
     pub fn remove(mut self, key: K) -> V?
@@ -82,9 +196,37 @@ pub struct Set<T: Hashable> {
         self.len() == 0
     }
     pub fn contains(self, item: T) -> Bool
-    pub fn union(self, other: Set<T>) -> Set<T>
-    pub fn intersect(self, other: Set<T>) -> Set<T>
-    pub fn difference(self, other: Set<T>) -> Set<T>
+    pub fn union(self, other: Set<T>) -> Set<T> {
+        let mut out = self.union(other)
+        out.clear()
+        for item in self {
+            out.insert(item)
+        }
+        for item in other {
+            out.insert(item)
+        }
+        out
+    }
+    pub fn intersect(self, other: Set<T>) -> Set<T> {
+        let mut out = self.union(other)
+        out.clear()
+        for item in self {
+            if other.contains(item) {
+                out.insert(item)
+            }
+        }
+        out
+    }
+    pub fn difference(self, other: Set<T>) -> Set<T> {
+        let mut out = self.union(other)
+        out.clear()
+        for item in self {
+            if other.contains(item) == false {
+                out.insert(item)
+            }
+        }
+        out
+    }
 
     pub fn insert(mut self, item: T)
     pub fn remove(mut self, item: T) -> Bool

--- a/internal/stdlib/modules/fmt.osty
+++ b/internal/stdlib/modules/fmt.osty
@@ -180,7 +180,7 @@ pub fn fixed(f: Float, decimals: Int) -> String {
     }
     let negative = f < 0.0 || isNegZero(f)
     if decimals <= 0 {
-        let s = f.abs().round().toInt().toString()
+        let s = f.abs().toIntRound().unwrap().toString()
         if negative {
             return "-{s}"
         }
@@ -196,9 +196,10 @@ pub fn fixed(f: Float, decimals: Int) -> String {
         i = i + 1
     }
 
-    let shifted = (abs * power + 0.5).floor().toInt()
-    let intPart = shifted / power.toInt()
-    let fracPart = shifted % power.toInt()
+    let shifted = (abs * power + 0.5).floor().toIntTrunc().unwrap()
+    let powerInt = power.toIntTrunc().unwrap()
+    let intPart = shifted / powerInt
+    let fracPart = shifted % powerInt
 
     let fracStr = fracPart.toString()
     let padded = padLeft(fracStr, clampedDec, '0')

--- a/internal/stdlib/modules/option.osty
+++ b/internal/stdlib/modules/option.osty
@@ -29,6 +29,13 @@ pub enum Option<T> {
         }
     }
 
+    pub fn expect(self, msg: String) -> T {
+        match self {
+            Some(value) -> value,
+            None -> __optionAbort(msg),
+        }
+    }
+
     pub fn unwrapOr(self, fallback: T) -> T {
         match self {
             Some(value) -> value,
@@ -36,10 +43,65 @@ pub enum Option<T> {
         }
     }
 
+    pub fn unwrapOrElse(self, fallback: fn() -> T) -> T {
+        match self {
+            Some(value) -> value,
+            None -> fallback(),
+        }
+    }
+
+    pub fn and<U>(self, other: U?) -> U? {
+        match self {
+            Some(_) -> other,
+            None -> None,
+        }
+    }
+
+    pub fn andThen<U>(self, f: fn(T) -> U?) -> U? {
+        match self {
+            Some(value) -> f(value),
+            None -> None,
+        }
+    }
+
+    pub fn or(self, other: T?) -> T? {
+        match self {
+            Some(value) -> Some(value),
+            None -> other,
+        }
+    }
+
     pub fn orElse(self, fallback: fn() -> T?) -> T? {
         match self {
             Some(value) -> Some(value),
             None -> fallback(),
+        }
+    }
+
+    pub fn xor(self, other: T?) -> T? {
+        match self {
+            Some(value) -> match other {
+                Some(_) -> None,
+                None -> Some(value),
+            },
+            None -> other,
+        }
+    }
+
+    pub fn filter(self, pred: fn(T) -> Bool) -> T? {
+        match self {
+            Some(value) -> if pred(value) { Some(value) } else { None },
+            None -> None,
+        }
+    }
+
+    pub fn inspect(self, f: fn(T) -> ()) -> T? {
+        match self {
+            Some(value) -> {
+                f(value)
+                Some(value)
+            },
+            None -> None,
         }
     }
 
@@ -55,6 +117,10 @@ pub enum Option<T> {
             Some(value) -> Ok(value),
             None -> __optionError::<T>(msg),
         }
+    }
+
+    pub fn okOr(self, msg: String) -> Result<T, Error> {
+        self.orError(msg)
     }
 
     pub fn toString(self) -> String {

--- a/internal/stdlib/modules/result.osty
+++ b/internal/stdlib/modules/result.osty
@@ -30,9 +30,23 @@ pub enum Result<T, E> {
         }
     }
 
+    pub fn expect(self, msg: String) -> T {
+        match self {
+            Ok(value) -> value,
+            Err(_) -> __resultAbort(msg),
+        }
+    }
+
     pub fn unwrapErr(self) -> E {
         match self {
             Ok(_) -> __resultAbort("called unwrapErr on Ok"),
+            Err(error) -> error,
+        }
+    }
+
+    pub fn expectErr(self, msg: String) -> E {
+        match self {
+            Ok(_) -> __resultAbort(msg),
             Err(error) -> error,
         }
     }
@@ -41,6 +55,13 @@ pub enum Result<T, E> {
         match self {
             Ok(value) -> value,
             Err(_) -> fallback,
+        }
+    }
+
+    pub fn unwrapOrElse(self, fallback: fn(E) -> T) -> T {
+        match self {
+            Ok(value) -> value,
+            Err(error) -> fallback(error),
         }
     }
 
@@ -55,6 +76,54 @@ pub enum Result<T, E> {
         match self {
             Ok(_) -> None,
             Err(error) -> Some(error),
+        }
+    }
+
+    pub fn and<U>(self, other: Result<U, E>) -> Result<U, E> {
+        match self {
+            Ok(_) -> other,
+            Err(error) -> Err(error),
+        }
+    }
+
+    pub fn andThen<U>(self, f: fn(T) -> Result<U, E>) -> Result<U, E> {
+        match self {
+            Ok(value) -> f(value),
+            Err(error) -> Err(error),
+        }
+    }
+
+    pub fn or<F>(self, other: Result<T, F>) -> Result<T, F> {
+        match self {
+            Ok(value) -> Ok(value),
+            Err(_) -> other,
+        }
+    }
+
+    pub fn orElse<F>(self, f: fn(E) -> Result<T, F>) -> Result<T, F> {
+        match self {
+            Ok(value) -> Ok(value),
+            Err(error) -> f(error),
+        }
+    }
+
+    pub fn inspect(self, f: fn(T) -> ()) -> Result<T, E> {
+        match self {
+            Ok(value) -> {
+                f(value)
+                Ok(value)
+            },
+            Err(error) -> Err(error),
+        }
+    }
+
+    pub fn inspectErr(self, f: fn(E) -> ()) -> Result<T, E> {
+        match self {
+            Ok(value) -> Ok(value),
+            Err(error) -> {
+                f(error)
+                Err(error)
+            },
         }
     }
 

--- a/internal/stdlib/primitives/float.osty
+++ b/internal/stdlib/primitives/float.osty
@@ -34,11 +34,16 @@ pub struct __FloatMethods {
     pub fn isInfinite(self) -> Bool { false }
     pub fn isFinite(self) -> Bool { false }
     pub fn toBits(self) -> UInt64 { 0 }
+    pub fn toFixed(self, n: Int) -> String { "" }
 
-    // Conversions to integer types. Per §2.3 overflow aborts; no
-    // Result wrapping on the lossy path. The toInt family here
-    // mirrors Int's outward-facing conversions but loses the
-    // fractional part.
+    // Explicit conversions to Int. The mode is named at the call site
+    // and failures stay in the value channel.
+    pub fn toIntTrunc(self) -> Result<Int, Error> { Ok(0) }
+    pub fn toIntRound(self) -> Result<Int, Error> { Ok(0) }
+    pub fn toIntFloor(self) -> Result<Int, Error> { Ok(0) }
+    pub fn toIntCeil(self) -> Result<Int, Error> { Ok(0) }
+
+    // Legacy lossy conversions kept for source compatibility.
     pub fn toInt(self) -> Int { 0 }
     pub fn toInt32(self) -> Int32 { 0 }
     pub fn toInt64(self) -> Int64 { 0 }

--- a/internal/stdlib/primitives/int.osty
+++ b/internal/stdlib/primitives/int.osty
@@ -24,8 +24,8 @@ pub struct __IntMethods {
     pub fn wrappingMul(self, other: Self) -> Self { self }
     pub fn wrappingDiv(self, other: Self) -> Self { self }
     pub fn wrappingMod(self, other: Self) -> Self { self }
-    pub fn wrappingShl(self, b: Self) -> Self { self }
-    pub fn wrappingShr(self, b: Self) -> Self { self }
+    pub fn wrappingShl(self, b: Int) -> Self { self }
+    pub fn wrappingShr(self, b: Int) -> Self { self }
     pub fn wrappingAbs(self) -> Self { self }
     pub fn wrappingNeg(self) -> Self { self }
 
@@ -34,8 +34,8 @@ pub struct __IntMethods {
     pub fn checkedMul(self, other: Self) -> Self? { None }
     pub fn checkedDiv(self, other: Self) -> Self? { None }
     pub fn checkedMod(self, other: Self) -> Self? { None }
-    pub fn checkedShl(self, b: Self) -> Self? { None }
-    pub fn checkedShr(self, b: Self) -> Self? { None }
+    pub fn checkedShl(self, b: Int) -> Self? { None }
+    pub fn checkedShr(self, b: Int) -> Self? { None }
     pub fn checkedAbs(self) -> Self? { None }
     pub fn checkedNeg(self) -> Self? { None }
 

--- a/internal/stdlib/stdlib_test.go
+++ b/internal/stdlib/stdlib_test.go
@@ -211,8 +211,8 @@ func TestResultModuleMethods(t *testing.T) {
 		hasBody[method.Name] = method.Body != nil
 	}
 	for _, name := range []string{
-		"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr",
-		"ok", "err", "map", "mapErr", "toString",
+		"isOk", "isErr", "unwrap", "expect", "unwrapErr", "expectErr", "unwrapOr", "unwrapOrElse",
+		"ok", "err", "and", "andThen", "or", "orElse", "inspect", "inspectErr", "map", "mapErr", "toString",
 	} {
 		if !got[name] {
 			t.Errorf("Result missing method %q", name)
@@ -221,7 +221,10 @@ func TestResultModuleMethods(t *testing.T) {
 			t.Errorf("Registry.ResultMethods missing method %q", name)
 		}
 	}
-	for _, name := range []string{"isOk", "isErr", "unwrap", "unwrapErr", "unwrapOr", "ok", "err", "map", "mapErr", "toString"} {
+	for _, name := range []string{
+		"isOk", "isErr", "unwrap", "expect", "unwrapErr", "expectErr", "unwrapOr", "unwrapOrElse",
+		"ok", "err", "and", "andThen", "or", "orElse", "inspect", "inspectErr", "map", "mapErr", "toString",
+	} {
 		if !hasBody[name] {
 			t.Errorf("Result.%s should have an Osty body", name)
 		}
@@ -534,13 +537,13 @@ func TestOptionModuleMethodsResolves(t *testing.T) {
 	if mod == nil || mod.File == nil {
 		t.Fatal("std.option not loaded")
 	}
-	var methods map[string]bool
+	var methods map[string]*ast.FnDecl
 	for _, d := range mod.File.Decls {
 		if ed, ok := d.(*ast.EnumDecl); ok && ed.Name == "Option" {
-			methods = map[string]bool{}
+			methods = map[string]*ast.FnDecl{}
 			for _, m := range ed.Methods {
 				if m.Pub {
-					methods[m.Name] = true
+					methods[m.Name] = m
 				}
 			}
 			break
@@ -549,9 +552,17 @@ func TestOptionModuleMethodsResolves(t *testing.T) {
 	if methods == nil {
 		t.Fatal("std.option missing Option enum declaration")
 	}
-	for _, name := range []string{"isSome", "isNone", "unwrap", "unwrapOr", "orElse", "map", "orError", "toString"} {
-		if !methods[name] {
+	for _, name := range []string{
+		"isSome", "isNone", "unwrap", "expect", "unwrapOr", "unwrapOrElse",
+		"and", "andThen", "or", "orElse", "xor", "filter", "inspect", "map", "orError", "okOr", "toString",
+	} {
+		method := methods[name]
+		if method == nil {
 			t.Errorf("std.option Option missing pub method %q", name)
+			continue
+		}
+		if method.Body == nil {
+			t.Errorf("std.option Option.%s should have an Osty body", name)
 		}
 	}
 }
@@ -645,6 +656,44 @@ func TestCollectionsModuleResolves(t *testing.T) {
 		for _, name := range methods {
 			if !have[name] {
 				t.Errorf("std.collections %s missing method %q", typ, name)
+			}
+		}
+	}
+}
+
+func TestCollectionsPureOstyBodies(t *testing.T) {
+	mod := Load().Modules["collections"]
+	if mod == nil {
+		t.Fatal("std.collections not loaded")
+	}
+	decls := map[string]*ast.StructDecl{}
+	for _, d := range mod.File.Decls {
+		if sd, ok := d.(*ast.StructDecl); ok {
+			decls[sd.Name] = sd
+		}
+	}
+	wantBodies := map[string][]string{
+		"List": {"isEmpty", "first", "last", "contains", "find", "map", "filter", "fold", "sortedBy", "reversed", "appended", "concat", "zip", "enumerate", "pop", "clear"},
+		"Map":  {"isEmpty", "containsKey", "keys", "values", "entries"},
+		"Set":  {"isEmpty", "union", "intersect", "difference"},
+	}
+	for typ, names := range wantBodies {
+		sd := decls[typ]
+		if sd == nil {
+			t.Fatalf("std.collections missing struct %s", typ)
+		}
+		methods := map[string]*ast.FnDecl{}
+		for _, m := range sd.Methods {
+			methods[m.Name] = m
+		}
+		for _, name := range names {
+			method := methods[name]
+			if method == nil {
+				t.Errorf("std.collections %s missing method %q", typ, name)
+				continue
+			}
+			if method.Body == nil {
+				t.Errorf("std.collections %s.%s should have an Osty body", typ, name)
 			}
 		}
 	}
@@ -1385,7 +1434,7 @@ func TestPrimitivesIntMethods(t *testing.T) {
 			t.Errorf("primitive kind %v has no method table", k)
 			continue
 		}
-		for _, m := range []string{"abs", "min", "max"} {
+		for _, m := range []string{"abs", "min", "max", "wrappingShl", "checkedShl", "pow", "toInt32"} {
 			if _, ok := methods[m]; !ok {
 				t.Errorf("primitive kind %v missing method %q", k, m)
 			}
@@ -1481,7 +1530,7 @@ func TestPrimitivesFloatMethods(t *testing.T) {
 			t.Errorf("primitive kind %v has no method table", k)
 			continue
 		}
-		for _, m := range []string{"abs", "sqrt", "isNaN"} {
+		for _, m := range []string{"abs", "sqrt", "isNaN", "toFixed", "toIntTrunc", "toIntRound", "toIntFloor", "toIntCeil"} {
 			if _, ok := methods[m]; !ok {
 				t.Errorf("primitive kind %v missing method %q", k, m)
 			}


### PR DESCRIPTION
## Summary
- add explicit primitive shift/float conversion surfaces and Go lowering
- fill pure Osty collection, option, and result method bodies where possible
- extend checker/gen/stdlib coverage for the new surfaces

## Tests
- go test ./internal/stdlib ./internal/gen ./internal/check ./internal/resolve ./internal/lint ./internal/parser ./internal/selfhost -count=1
- git diff --check