### PR TITLE
ci: use self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   go:
     name: Go
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     env:
       GOFLAGS: -mod=readonly


### PR DESCRIPTION
## Summary
- switch the CI workflow runner from GitHub-hosted ubuntu-latest to self-hosted

## Testing
- git diff --check