### PR TITLE
Rebind stdlib types to prelude builtins

### DIFF
--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -3,11 +3,9 @@
 // These names are already auto-imported via the prelude, so user code
 // rarely writes `use std.collections`. The module-local structs provide
 // the canonical signature surface for the collection methods in spec
-// §10.6. Runtime lowering is intrinsic because these types map directly
-// to Go slices/maps in the current backend. Some pure bodies seed an
-// output collection from an intrinsic method before rebuilding it; that
-// keeps the placeholder `std.collections` types aligned with the prelude
-// builtin collection types until the prelude rebind lands.
+// §10.6. Runtime lowering still supplies the primitive storage
+// operations, while pure helpers construct and return the prelude-bound
+// collection types directly.
 
 pub struct List<T> {
     pub fn len(self) -> Int
@@ -36,16 +34,14 @@ pub struct List<T> {
     }
 
     pub fn map<R>(self, f: fn(T) -> R) -> List<R> {
-        let mut out = self.map(f)
-        out.clear()
+        let mut out: List<R> = []
         for item in self {
             out.push(f(item))
         }
         out
     }
     pub fn filter(self, pred: fn(T) -> Bool) -> List<T> {
-        let mut out = self.map(|item| item)
-        out.clear()
+        let mut out: List<T> = []
         for item in self {
             if pred(item) {
                 out.push(item)
@@ -62,8 +58,7 @@ pub struct List<T> {
     }
     pub fn sorted(self) -> List<T>
     pub fn sortedBy<K: Ordered>(self, key: fn(T) -> K) -> List<T> {
-        let mut out = self.map(|item| item)
-        out.clear()
+        let mut out: List<T> = []
         for item in self {
             out.push(item)
         }
@@ -88,8 +83,7 @@ pub struct List<T> {
         out
     }
     pub fn reversed(self) -> List<T> {
-        let mut out = self.map(|item| item)
-        out.clear()
+        let mut out: List<T> = []
         let mut i = self.len()
         for i > 0 {
             i = i - 1
@@ -98,13 +92,15 @@ pub struct List<T> {
         out
     }
     pub fn appended(self, item: T) -> List<T> {
-        let mut out = self.map(|value| value)
+        let mut out: List<T> = []
+        for value in self {
+            out.push(value)
+        }
         out.push(item)
         out
     }
     pub fn concat(self, other: List<T>) -> List<T> {
-        let mut out = self.map(|item| item)
-        out.clear()
+        let mut out: List<T> = []
         for item in self {
             out.push(item)
         }
@@ -114,8 +110,7 @@ pub struct List<T> {
         out
     }
     pub fn zip<U>(self, other: List<U>) -> List<(T, U)> {
-        let mut out = self.zip(other)
-        out.clear()
+        let mut out: List<(T, U)> = []
         let limit = if self.len() < other.len() { self.len() } else { other.len() }
         for i in 0..limit {
             out.push((self[i], other[i]))
@@ -123,8 +118,7 @@ pub struct List<T> {
         out
     }
     pub fn enumerate(self) -> List<(Int, T)> {
-        let mut out = self.enumerate()
-        out.clear()
+        let mut out: List<(Int, T)> = []
         let mut i = 0
         for item in self {
             out.push((i, item))
@@ -161,24 +155,21 @@ pub struct Map<K: Hashable, V> {
         self.get(key).isSome()
     }
     pub fn keys(self) -> List<K> {
-        let mut out = self.keys()
-        out.clear()
+        let mut out: List<K> = []
         for (key, unusedValue) in self {
             out.push(key)
         }
         out
     }
     pub fn values(self) -> List<V> {
-        let mut out = self.values()
-        out.clear()
+        let mut out: List<V> = []
         for (unusedKey, value) in self {
             out.push(value)
         }
         out
     }
     pub fn entries(self) -> List<(K, V)> {
-        let mut out = self.entries()
-        out.clear()
+        let mut out: List<(K, V)> = []
         for (key, value) in self {
             out.push((key, value))
         }
@@ -197,8 +188,8 @@ pub struct Set<T: Hashable> {
     }
     pub fn contains(self, item: T) -> Bool
     pub fn union(self, other: Set<T>) -> Set<T> {
-        let mut out = self.union(other)
-        out.clear()
+        let empty: List<T> = []
+        let mut out = empty.toSet()
         for item in self {
             out.insert(item)
         }
@@ -208,8 +199,8 @@ pub struct Set<T: Hashable> {
         out
     }
     pub fn intersect(self, other: Set<T>) -> Set<T> {
-        let mut out = self.union(other)
-        out.clear()
+        let empty: List<T> = []
+        let mut out = empty.toSet()
         for item in self {
             if other.contains(item) {
                 out.insert(item)
@@ -218,8 +209,8 @@ pub struct Set<T: Hashable> {
         out
     }
     pub fn difference(self, other: Set<T>) -> Set<T> {
-        let mut out = self.union(other)
-        out.clear()
+        let empty: List<T> = []
+        let mut out = empty.toSet()
         for item in self {
             if other.contains(item) == false {
                 out.insert(item)

--- a/internal/stdlib/rebind_test.go
+++ b/internal/stdlib/rebind_test.go
@@ -1,0 +1,126 @@
+package stdlib
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestPreludeBuiltinRebindings(t *testing.T) {
+	reg := Load()
+	for _, tc := range []struct {
+		module string
+		names  []string
+	}{
+		{"collections", []string{"List", "Map", "Set"}},
+		{"error", []string{"Error"}},
+		{"option", []string{"Option"}},
+		{"result", []string{"Result"}},
+	} {
+		mod := reg.Modules[tc.module]
+		if mod == nil || mod.Package == nil {
+			t.Fatalf("std.%s not loaded", tc.module)
+		}
+		for _, name := range tc.names {
+			sym := mod.Package.PkgScope.LookupLocal(name)
+			if sym == nil {
+				t.Fatalf("std.%s missing export %s", tc.module, name)
+			}
+			if sym.Kind != resolve.SymBuiltin {
+				t.Fatalf("std.%s.%s kind = %s, want builtin", tc.module, name, sym.Kind)
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		module string
+		names  []string
+	}{
+		{"option", []string{"Some", "None"}},
+		{"result", []string{"Ok", "Err"}},
+	} {
+		mod := reg.Modules[tc.module]
+		for _, name := range tc.names {
+			sym := mod.Package.PkgScope.LookupLocal(name)
+			if sym == nil {
+				t.Fatalf("std.%s missing export %s", tc.module, name)
+			}
+			if sym.Kind != resolve.SymVariant {
+				t.Fatalf("std.%s.%s kind = %s, want variant", tc.module, name, sym.Kind)
+			}
+		}
+	}
+}
+
+func TestQualifiedStdlibTypesSharePreludeIdentity(t *testing.T) {
+	src := []byte(`use std.collections
+use std.option
+use std.result
+use std.error
+
+pub fn collectionsRoundTrip(xs: List<Int>, m: Map<String, Int>, s: Set<Int>) -> Int {
+    let qxs: collections.List<Int> = xs
+    let bxs: List<Int> = qxs
+    let qm: collections.Map<String, Int> = m
+    let bm: Map<String, Int> = qm
+    let qs: collections.Set<Int> = s
+    let bs: Set<Int> = qs
+    bxs.len() + bm.len() + bs.len()
+}
+
+pub fn optionRoundTrip(x: Int?) -> Int? {
+    let q: option.Option<Int> = x
+    let b: Int? = q
+    b
+}
+
+pub fn resultRoundTrip(r: Result<Int, Error>) -> result.Result<Int, error.Error> {
+    let q: result.Result<Int, error.Error> = r
+    let b: Result<Int, Error> = q
+    b
+}
+
+pub fn errorRoundTrip(e: Error) -> error.Error {
+    let q: error.Error = e
+    let b: Error = q
+    b
+}
+`)
+	file, parseDiags := parser.ParseDiagnostics(src)
+	for _, d := range parseDiags {
+		if d.Severity == diag.Error {
+			t.Fatalf("parse: %s", d.Error())
+		}
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+	})
+	for _, d := range append(res.Diags, chk.Diags...) {
+		if d.Severity == diag.Error {
+			t.Fatalf("unexpected diagnostic: %s", d.Error())
+		}
+	}
+}
+
+func TestCollectionsPureBodiesTypeCheckAfterRebind(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["collections"]
+	if mod == nil || mod.Package == nil {
+		t.Fatal("std.collections not loaded")
+	}
+	chk := check.Package(mod.Package, &resolve.PackageResult{PackageScope: mod.Package.PkgScope}, check.Opts{
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+	})
+	for _, d := range chk.Diags {
+		if d.Severity == diag.Error {
+			t.Fatalf("std.collections should type-check: %s", d.Error())
+		}
+	}
+}

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -158,11 +158,13 @@ func loadRegistry() *Registry {
 			r.absorbPrimitiveStub(file, p)
 			continue
 		}
-		if moduleName(p) == "result" {
+		name := moduleName(p)
+		rebindPreludeBuiltinTypes(pkg, prelude, name)
+		if name == "result" {
 			r.absorbResultStub(file)
 		}
-		r.Modules[moduleName(p)] = &Module{
-			Name:    moduleName(p),
+		r.Modules[name] = &Module{
+			Name:    name,
 			Path:    p,
 			Source:  src,
 			File:    file,
@@ -196,6 +198,54 @@ func cloneRegistry(r *Registry) *Registry {
 		out.ResultMethods[k] = v
 	}
 	return out
+}
+
+var preludeBuiltinRebinds = map[string][]string{
+	"collections": {"List", "Map", "Set"},
+	"error":       {"Error"},
+	"option":      {"Option"},
+	"result":      {"Result"},
+}
+
+// rebindPreludeBuiltinTypes makes stdlib module exports that mirror
+// prelude types share the prelude symbol identity. The module AST keeps
+// the source declarations so method surfaces and future source emission
+// can still inspect them, but user-facing qualified references such as
+// `collections.List<T>` and `result.Result<T, E>` resolve to the same
+// semantic type as bare `List<T>` / `Result<T, E>`.
+func rebindPreludeBuiltinTypes(pkg *resolve.Package, prelude *resolve.Scope, module string) {
+	if pkg == nil || pkg.PkgScope == nil || prelude == nil {
+		return
+	}
+	names := preludeBuiltinRebinds[module]
+	if len(names) == 0 {
+		return
+	}
+	builtins := map[string]*resolve.Symbol{}
+	for _, name := range names {
+		sym := prelude.LookupLocal(name)
+		if sym == nil || sym.Kind != resolve.SymBuiltin {
+			continue
+		}
+		builtins[name] = sym
+		pkg.PkgScope.DefineForce(sym)
+	}
+	if len(builtins) == 0 {
+		return
+	}
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		for nt, sym := range pf.TypeRefs {
+			if nt == nil || sym == nil {
+				continue
+			}
+			if builtin := builtins[sym.Name]; builtin != nil {
+				pf.TypeRefs[nt] = builtin
+			}
+		}
+	}
 }
 
 func promoteTopLevelLets(file *ast.File) {


### PR DESCRIPTION
## Summary
- Rebind std.collections List/Map/Set, std.option Option, std.result Result, and std.error Error exports to their prelude builtin symbols while preserving stdlib source declarations.
- Patch resolved stdlib TypeRefs so stdlib bodies and future source emission see the canonical prelude type identity.
- Replace collection helper seed/clear workarounds with direct Osty collection construction and add focused rebinding/typecheck coverage.

## Tests
- go test ./...
