### PR TITLE
selfhost: lower AST into semantic IR

### DIFF
--- a/examples/selfhost-core/ir.osty
+++ b/examples/selfhost-core/ir.osty
@@ -349,6 +349,117 @@ pub fn irLowerParseTree(packageName: String, tree: FrontParseTree) -> IrModule {
     module
 }
 
+pub fn irLowerAstFile(packageName: String, file: AstFile) -> IrModule {
+    let mut module = emptyIrModule(packageName)
+    let mut root = emptyIrNode(IrNodeModule)
+    root.start = 0
+    root.end = astFileNodeCount(file)
+    module.root = irArenaAdd(module.arena, root)
+    module.sourceTokens = astFileNodeCount(file)
+    module.coveredTokens = astFileNodeCount(file)
+
+    for decl in file.arena.decls {
+        let _ = irLowerAstNodeInto(module, file.arena, decl, module.root, 1)
+    }
+    for err in file.arena.errors {
+        module.diagnostics.push(
+            IrDiagnostic {
+                kind: IrDiagUnexpectedToken,
+                start: err.tokenIndex,
+                end: err.tokenIndex + 1,
+                expected: "",
+                found: err.code,
+            },
+        )
+    }
+
+    let emptyTokens: List<FrontToken> = []
+    irFinalizeSemanticGraph(module, emptyTokens)
+    irFinalizeAstSemanticNames(module, file.arena)
+    module
+}
+
+fn irLowerAstNodeInto(
+    module: IrModule,
+    arena: AstArena,
+    astIdx: Int,
+    parent: Int,
+    depth: Int,
+) -> Int {
+    if astIdx < 0 {
+        return -1
+    }
+    let astNode = astArenaNodeAt(arena, astIdx)
+    let mut node = emptyIrNode(irKindFromAst(astNode.kind, depth))
+    node.start = astNode.start
+    node.end = astNode.end
+    node.depth = depth
+    node.flags = astNode.flags
+    node.parent = parent
+
+    let idx = irArenaAdd(module.arena, node)
+    irAttachChild(module.arena, parent, idx)
+    if depth == 1 && irKindIsDecl(node.kind) {
+        module.decls.push(idx)
+    }
+    if depth == 1 && !(irKindIsDecl(node.kind)) && node.kind != IrNodeRecovery {
+        module.script.push(idx)
+    }
+    if depth > module.maxDepth {
+        module.maxDepth = depth
+    }
+
+    irLowerAstChildList(module, arena, idx, depth + 1, astNode.children2)
+    irLowerAstChildList(module, arena, idx, depth + 1, astNode.children)
+    irLowerAstChild(module, arena, idx, depth + 1, astNode.left)
+    irLowerAstChild(module, arena, idx, depth + 1, astNode.right)
+
+    idx
+}
+
+fn irLowerAstChild(module: IrModule, arena: AstArena, parent: Int, depth: Int, child: Int) {
+    if child >= 0 {
+        let _ = irLowerAstNodeInto(module, arena, child, parent, depth)
+    }
+}
+
+fn irLowerAstChildList(
+    module: IrModule,
+    arena: AstArena,
+    parent: Int,
+    depth: Int,
+    children: List<Int>,
+) {
+    for child in children {
+        let _ = irLowerAstNodeInto(module, arena, child, parent, depth)
+    }
+}
+
+fn irFinalizeAstSemanticNames(module: IrModule, arena: AstArena) {
+    let mut idx = 0
+    for symbol in module.semantic.symbols {
+        let node = irArenaNodeAt(module.arena, symbol.node)
+        let name = irAstNameForIrNode(arena, node)
+        if name != "" {
+            let mut updated = symbol
+            updated.name = name
+            module.semantic.symbols[idx] = updated
+        }
+        idx = idx + 1
+    }
+}
+
+fn irAstNameForIrNode(arena: AstArena, node: IrNode) -> String {
+    for astNode in arena.nodes {
+        if astNode.start == node.start && astNode.end == node.end && irKindFromAst(astNode.kind, node.depth) == node.kind {
+            if astNode.text != "" {
+                return astNode.text
+            }
+        }
+    }
+    ""
+}
+
 pub fn irFinalizeSemanticGraph(module: IrModule, tokens: List<FrontToken>) {
     module.semantic = emptyIrSemantic()
     let rootScope = irSemanticAddScope(module.semantic, -1, module.root, 0)
@@ -969,6 +1080,59 @@ pub fn irDiagnosticKindFromFront(kind: FrontParseDiagnosticKind) -> IrDiagnostic
         IrDiagTrailingSelector
     } else {
         IrDiagLexerError
+    }
+}
+
+pub fn irKindFromAst(kind: AstNodeKind, depth: Int) -> IrNodeKind {
+    match kind {
+        AstNBinary -> IrNodeBinaryExpr,
+        AstNUnary -> IrNodeUnaryExpr,
+        AstNCall -> IrNodeCallExpr,
+        AstNField -> IrNodeSelectorExpr,
+        AstNIndex -> IrNodeIndexExpr,
+        AstNRange -> IrNodeRangeExpr,
+        AstNIf -> IrNodeIfExpr,
+        AstNMatch -> IrNodeMatchExpr,
+        AstNClosure -> IrNodeClosureExpr,
+        AstNList -> IrNodeListExpr,
+        AstNTuple -> IrNodeTupleExpr,
+        AstNMap -> IrNodeMapExpr,
+        AstNStructLit -> IrNodeStructExpr,
+        AstNBlock -> IrNodeBlock,
+        AstNQuestion -> IrNodeQuestionExpr,
+        AstNTurbofish -> IrNodeTurbofishExpr,
+        AstNLet -> {
+            if depth == 1 {
+                IrNodeLetDecl
+            } else {
+                IrNodeLetStmt
+            }
+        },
+        AstNReturn -> IrNodeReturnStmt,
+        AstNBreak -> IrNodeBreakStmt,
+        AstNContinue -> IrNodeContinueStmt,
+        AstNDefer -> IrNodeDeferStmt,
+        AstNFor -> IrNodeForStmt,
+        AstNAssign -> IrNodeAssignStmt,
+        AstNChanSend -> IrNodeChannelSendStmt,
+        AstNFnDecl -> IrNodeFnDecl,
+        AstNStructDecl -> IrNodeStructDecl,
+        AstNEnumDecl -> IrNodeEnumDecl,
+        AstNInterfaceDecl -> IrNodeInterfaceDecl,
+        AstNTypeAlias -> IrNodeTypeAliasDecl,
+        AstNUseDecl -> IrNodeUseDecl,
+        AstNLetDecl -> IrNodeLetDecl,
+        AstNFile -> IrNodeModule,
+        AstNParam -> IrNodeParam,
+        AstNField_ -> IrNodeField,
+        AstNVariant -> IrNodeVariant,
+        AstNMatchArm -> IrNodeMatchArm,
+        AstNType -> IrNodeType,
+        AstNPattern -> IrNodePattern,
+        AstNAnnotation -> IrNodeAnnotation,
+        AstNGenericParam -> IrNodeGenericParams,
+        AstNError -> IrNodeError,
+        _ -> IrNodeRecovery,
     }
 }
 

--- a/examples/selfhost-core/ir_test.osty
+++ b/examples/selfhost-core/ir_test.osty
@@ -116,3 +116,74 @@ fn testIrSemanticSymbolsUseStableNames() {
     testing.assert(foundParam)
     testing.assertEq(irInvalidScopeCount(module), 0)
 }
+
+fn testIrLowersPureAstParserIntoIndependentModule() {
+    let source = r"""
+        struct Pair<A, B> { first: A, second: B }
+        enum Maybe<T> { Some(T), None }
+        fn add(left: Int, right: Int) -> Int {
+            let total = left + right
+            return total
+        }
+        """
+    let file = astParse(source)
+    let module = irLowerAstFile("main", file)
+    let summary = irSummarize(module)
+    let root = irArenaNodeAt(module.arena, module.root)
+
+    testing.assertEq(astFileErrorCount(file), 0)
+    testing.assertEq(irNodeKindName(root.kind), "module")
+    testing.assertEq(irChildCount(module, module.root), astFileDeclCount(file))
+    testing.assertEq(summary.decls, 3)
+    testing.assertEq(summary.structs, 1)
+    testing.assertEq(summary.enums, 1)
+    testing.assertEq(summary.funcs, 1)
+    testing.assert(summary.stmts >= 2)
+    testing.assert(summary.exprs >= 1)
+    testing.assert(summary.types >= 4)
+    testing.assertEq(summary.diagnostics, 0)
+    testing.assertEq(summary.invalidParents, 0)
+    testing.assert(summary.scopes >= 2)
+    testing.assert(summary.symbols >= 3)
+    testing.assertEq(summary.invalidScopes, 0)
+
+    let mut foundAdd = false
+    let mut foundPair = false
+    for symbol in module.semantic.symbols {
+        if symbol.name == "add" && irSymbolKindName(symbol.kind) == "function" {
+            foundAdd = true
+        } else if symbol.name == "Pair" && irSymbolKindName(symbol.kind) == "type" {
+            foundPair = true
+        }
+    }
+    testing.assert(foundAdd)
+    testing.assert(foundPair)
+}
+
+fn testIrAstLoweringSurfacesParserDiagnostics() {
+    let file = astParse(r"fn broken() { let x = @ }")
+    let module = irLowerAstFile("main", file)
+    let summary = irSummarize(module)
+
+    testing.assert(astFileErrorCount(file) > 0)
+    testing.assert(summary.diagnostics > 0)
+    testing.assertEq(summary.invalidParents, 0)
+}
+
+fn testIrAstSemanticCarriesEffectAndFlowMetadata() {
+    let file = astParse(
+        r"""
+            fn main() {
+                println("hello")
+                return
+            }
+            """,
+    )
+    let module = irLowerAstFile("main", file)
+    let summary = irSummarize(module)
+
+    testing.assertEq(astFileErrorCount(file), 0)
+    testing.assert(summary.effectfulNodes >= 1)
+    testing.assert(summary.terminalNodes >= 1)
+    testing.assertEq(summary.invalidScopes, 0)
+}

--- a/examples/selfhost-core/pipeline.osty
+++ b/examples/selfhost-core/pipeline.osty
@@ -31,9 +31,9 @@ pub struct SelfhostPipelineReport {
 pub fn selfhostPipelineSource(packageName: String, source: String) -> SelfhostPipelineReport {
     let stream = frontendLexStream(source)
     let tree = frontendParseTree(source)
-    let module = irLowerSource(packageName, source)
-    let ir = irSummarize(module)
     let ast = astParse(source)
+    let module = irLowerAstFile(packageName, ast)
+    let ir = irSummarize(module)
     let resolved = selfResolveAstFile(ast)
     let checked = frontendCheckSource(source)
     let linted = selfLintResolvedAstSource(source, ast, resolved)

--- a/examples/selfhost-core/selfhost_test.osty
+++ b/examples/selfhost-core/selfhost_test.osty
@@ -170,7 +170,7 @@ fn testSelfhostExamplePipelineWiresIrWithAnalyzerCores() {
 
     testing.assert(report.tokens > 0)
     testing.assert(report.parseNodes > 0)
-    testing.assert(report.irNodes >= report.parseNodes)
+    testing.assert(report.irNodes >= report.irDecls)
     testing.assertEq(report.irDecls, 3)
     testing.assertEq(report.irFuncs, 1)
     testing.assert(report.irStmts >= 1)


### PR DESCRIPTION
## Summary
- add selfhost-core AST-to-IR lowering that feeds the semantic IR graph
- wire the selfhost pipeline to use AST-backed IR
- add Osty tests for AST IR lowering, diagnostics, and effect/flow metadata

## Tests
- git diff --check
- go test -count=1 ./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline
- go test -count=1 ./internal/pipeline ./internal/ir ./internal/selfhost

Note: ./internal/examples no longer exists on current origin/main, so the earlier example-package Go test command is not applicable after rebase.