### PR TITLE
llvm: encode escaped string println constants

### DIFF
--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -280,6 +280,10 @@ The initial helper package for this plan is `internal/backend`.
     constant and `printf(ptr @.strN)` call, and the executable smoke corpus now
     includes `string_print.osty`. The Go bridge only filters literals to the
     current conservative subset before calling generated Osty helpers.
+25. Add escaped ASCII String constants through the self-hosted core. Done in
+    Phase 24: `examples/selfhost-core/llvmgen.osty` owns newline, tab,
+    carriage-return, quote, and backslash encoding for LLVM C strings, and the
+    smoke corpus now includes `string_escape_print.osty`.
 
 The backend subdirectory change should land before the LLVM backend writes any
 files, so LLVM never shares the old Go-only output location.

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -48,9 +48,10 @@ Each fixture should be independently checkable as a single file and avoid:
 | `testdata/backend/llvm_smoke/control_flow.osty` | `15\n` | Phase 14 LLVM IR: mutable local, inclusive range loop, accumulator update |
 | `testdata/backend/llvm_smoke/booleans.osty` | `7\n` | Phase 15 LLVM IR: Bool comparison, logical not/and, value-position if/else, phi |
 | `testdata/backend/llvm_smoke/string_print.osty` | `hello, osty\n` | Phase 23 LLVM IR: plain printable-ASCII `String` literal through `println` and module string constants |
+| `testdata/backend/llvm_smoke/string_escape_print.osty` | `line one\nquote " slash \\\n` | Phase 24 LLVM IR: escaped ASCII `String` literal through Osty-owned LLVM C-string encoding |
 
-The Phase 10 skeleton behavior and the Phase 12-15 plus Phase 23 lowering behavior are
-mirrored in
+The Phase 10 skeleton behavior and the Phase 12-15 plus Phase 23-24 lowering
+behavior are mirrored in
 `examples/selfhost-core/llvmgen.osty` so the LLVM backend logic is authored in
 Osty first. The Go `internal/llvmgen` package includes generated bridge code
 from that Osty source for module/function/skeleton rendering. A backend test
@@ -97,6 +98,12 @@ constant shape, newline terminator, `printf(ptr @.strN)` call, and the string
 smoke fixture entry. The Go bridge only classifies the AST literal as the
 current conservative subset: non-raw, non-triple, non-interpolated printable
 ASCII without quotes, backslashes, or control characters.
+
+Phase 24 expands that path to escaped ASCII strings while keeping the LLVM
+constant encoding self-hosted. `examples/selfhost-core/llvmgen.osty` now maps
+newline, tab, carriage return, quote, and backslash into LLVM C-string escapes
+before appending the `println` newline and NUL terminator. The Go bridge still
+only rejects source outside the currently supported ASCII subset.
 
 ## Promotion Rules
 

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -22,12 +22,12 @@
 - Multi-file package, vendored dependency, workspace build의 실제 code emission은
   아직 제한이 있다. LLVM 전환 전에 package 단위 emit/link 모델을 분명히 해야
   한다.
-- 현재 Phase 23까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
+- 현재 Phase 24까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
   쪽으로 옮겨지고 있다. 여기에는 smoke IR builder, skeleton renderer,
   toolchain command plan, executable parity corpus, go-only diagnostic, 그리고
   unsupported source-shape taxonomy가 포함된다. 성공 경로의 scalar instruction
-  strings, temp/label naming, 그리고 첫 plain `String` `println` module constant
-  shape도 같은 selfhost-core에서 생성한다.
+  strings, temp/label naming, plain/escaped ASCII `String` `println` module
+  constant shape도 같은 selfhost-core에서 생성한다.
 
 ## 이주 원칙
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ newline-separated `else`.
 - `-o PATH` / `--out PATH` — write Go source to `PATH` instead of stdout
 - `--package NAME` — Go package clause for the emitted file (default: `main`)
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
-  `llvm` emits textual `.ll` for the early scalar/control-flow/plain-string
+  `llvm` emits textual `.ll` for the early scalar/control-flow/plain/escaped-string
   subset and falls back to an inspectable skeleton for unsupported shapes with
   Osty-authored instruction builders and category diagnostics)
 - `--emit MODE` — requested text artifact. `go` emits Go source for the Go
@@ -291,7 +291,7 @@ creating a new one.
 `build` / `run` / `test` backend flags (after the subcommand):
 
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
-  `llvm` can write textual IR for the early scalar/control-flow/plain-string
+  `llvm` can write textual IR for the early scalar/control-flow/plain/escaped-string
   subset and, when `clang` is available, drive object/binary emission for
   supported programs; unsupported shapes still prepare skeleton artifacts and report the
   missing lowering through categorized diagnostics generated from the Osty

--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -33,6 +33,11 @@ pub struct LlvmStringGlobal {
     pub byteLen: Int,
 }
 
+pub struct LlvmCString {
+    pub encoded: String,
+    pub byteLen: Int,
+}
+
 pub struct LlvmEmitter {
     pub temp: Int,
     pub label: Int,
@@ -223,10 +228,37 @@ pub fn llvmPrintlnI64(emitter: LlvmEmitter, value: LlvmValue) {
 pub fn llvmStringLiteralLine(emitter: LlvmEmitter, text: String) -> LlvmValue {
     let name = "@.str{emitter.stringId}"
     emitter.stringId = emitter.stringId + 1
-    let encoded = "{text}\\0A\\00"
-    let byteLen = llvmStrings.Split(text, "").len() + 2
-    emitter.stringGlobals.push(LlvmStringGlobal { name, encoded, byteLen })
+    let cstring = llvmCStringLine(text)
+    emitter.stringGlobals.push(
+        LlvmStringGlobal { name, encoded: cstring.encoded, byteLen: cstring.byteLen },
+    )
     LlvmValue { typ: "ptr", name, pointer: false }
+}
+
+pub fn llvmCStringLine(text: String) -> LlvmCString {
+    let encoded = "{llvmCStringEscape(text)}\\0A\\00"
+    let byteLen = llvmStrings.Split(text, "").len() + 2
+    LlvmCString { encoded, byteLen }
+}
+
+pub fn llvmCStringEscape(text: String) -> String {
+    let mut encoded = ""
+    for unit in llvmStrings.Split(text, "") {
+        if unit == "\n" {
+            encoded = "{encoded}\\0A"
+        } else if unit == "\t" {
+            encoded = "{encoded}\\09"
+        } else if unit == "\r" {
+            encoded = "{encoded}\\0D"
+        } else if unit == "\"" {
+            encoded = "{encoded}\\22"
+        } else if unit == "\\" {
+            encoded = "{encoded}\\5C"
+        } else {
+            encoded = "{encoded}{unit}"
+        }
+    }
+    encoded
 }
 
 pub fn llvmPrintlnString(emitter: LlvmEmitter, value: LlvmValue) {
@@ -637,6 +669,11 @@ pub fn llvmSmokeExecutableCorpus() -> List<LlvmSmokeExecutableCase> {
             fixture: "string_print.osty",
             stdout: "hello, osty\n",
         },
+        LlvmSmokeExecutableCase {
+            name: "string-escape",
+            fixture: "string_escape_print.osty",
+            stdout: "line one\nquote \" slash \\\n",
+        },
     ]
 }
 
@@ -756,6 +793,22 @@ pub fn llvmSmokeBooleansIR(sourcePath: String) -> String {
 pub fn llvmSmokeStringPrintIR(sourcePath: String) -> String {
     let main = llvmEmitter()
     let line = llvmStringLiteralLine(main, "hello, osty")
+    llvmPrintlnString(main, line)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobals(
+        sourcePath,
+        "",
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStringEscapeIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let line = llvmStringLiteralLine(main, "line one\nquote \" slash \\")
     llvmPrintlnString(main, line)
     llvmReturnI32Zero(main)
 

--- a/examples/selfhost-core/llvmgen_test.osty
+++ b/examples/selfhost-core/llvmgen_test.osty
@@ -81,7 +81,7 @@ fn testLlvmToolchainPlanIsOstyOwned() {
 fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     let cases = llvmSmokeExecutableCorpus()
 
-    testing.assert(cases.len() == 5)
+    testing.assert(cases.len() == 6)
     testing.assert(cases[0].name == "minimal")
     testing.assert(cases[0].fixture == "minimal_print.osty")
     testing.assert(cases[0].stdout == "42\n")
@@ -97,6 +97,9 @@ fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     testing.assert(cases[4].name == "string")
     testing.assert(cases[4].fixture == "string_print.osty")
     testing.assert(cases[4].stdout == "hello, osty\n")
+    testing.assert(cases[5].name == "string-escape")
+    testing.assert(cases[5].fixture == "string_escape_print.osty")
+    testing.assert(cases[5].stdout == "line one\nquote \" slash \\\n")
 }
 
 fn testLlvmUnsupportedDiagnosticPolicyIsOstyOwned() {
@@ -205,6 +208,15 @@ fn testLlvmSmokeStringPrintIsOstyOwned() {
     let ir = llvmSmokeStringPrintIR("/tmp/string_print.osty")
 
     assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [13 x i8] c\"hello, osty\\0A\\00\"")
+    assertLlvmContains(ir, "define i32 @main() \{")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.str0)")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmSmokeStringEscapeIsOstyOwned() {
+    let ir = llvmSmokeStringEscapeIR("/tmp/string_escape_print.osty")
+
+    assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [26 x i8] c\"line one\\0Aquote \\22 slash \\5C\\0A\\00\"")
     assertLlvmContains(ir, "define i32 @main() \{")
     assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.str0)")
     assertLlvmContains(ir, "ret i32 0")

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -5,7 +5,7 @@
 // the same artifact/cache layout contract. LLVM lowering is still small, but it
 // can produce textual IR and drive a host clang toolchain for supported
 // object/binary artifacts. LLVM backend meaning, including scalar instruction
-// builders, plain string constants, and unsupported-source diagnostic
-// categories, is authored in Osty selfhost-core; this package remains the
-// bootstrap host shim for file I/O and process execution.
+// builders, plain/escaped ASCII string constants, and unsupported-source
+// diagnostic categories, is authored in Osty selfhost-core; this package
+// remains the bootstrap host shim for file I/O and process execution.
 package backend

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -1,11 +1,11 @@
 // Package llvmgen emits textual LLVM IR for the native backend.
 //
 // The first implementation is deliberately small: it supports no-arg main
-// functions or script files, integer println expressions, plain printable-ASCII
-// string println literals, immutable scalar lets, mutable scalar locals, simple
-// Int/Bool helper functions, statement-position if/else, value-position
-// if/else, simple Bool logical operators, and inclusive/exclusive Int range
-// loops.
+// functions or script files, integer println expressions, plain ASCII string
+// println literals with simple escapes, immutable scalar lets, mutable scalar
+// locals, simple Int/Bool helper functions, statement-position if/else,
+// value-position if/else, simple Bool logical operators, and inclusive/exclusive
+// Int range loops.
 // Unsupported shapes return ErrUnsupported so callers can fall back to
 // inspectable skeleton IR while the backend grows. The module/function/skeleton
 // renderers, scalar/string instruction builders, LLVM toolchain command plans,

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -658,8 +658,8 @@ func (g *generator) emitPrintlnString(lit *ast.StringLit) error {
 	if !ok {
 		return unsupported("expression", "interpolated String literals are not supported by LLVM println")
 	}
-	if !isLLVMPlainCStringText(text) {
-		return unsupported("type-system", "plain String literals currently require printable ASCII without quotes, backslashes, or control characters")
+	if !isLLVMASCIIStringText(text) {
+		return unsupported("type-system", "plain String literals currently require ASCII text with printable bytes or newline, tab, and carriage-return escapes")
 	}
 	emitter := g.toOstyEmitter()
 	line := llvmStringLiteralLine(emitter, text)
@@ -1002,10 +1002,14 @@ func plainStringLiteral(lit *ast.StringLit) (string, bool) {
 	return b.String(), true
 }
 
-func isLLVMPlainCStringText(text string) bool {
+func isLLVMASCIIStringText(text string) bool {
 	for i := 0; i < len(text); i++ {
 		ch := text[i]
-		if ch < 0x20 || ch > 0x7e || ch == '"' || ch == '\\' {
+		switch ch {
+		case '\n', '\t', '\r':
+			continue
+		}
+		if ch < 0x20 || ch > 0x7e {
 			return false
 		}
 	}

--- a/internal/llvmgen/osty_generated.go
+++ b/internal/llvmgen/osty_generated.go
@@ -55,6 +55,12 @@ type LlvmStringGlobal struct {
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:36:5
+type LlvmCString struct {
+	encoded string
+	byteLen int
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:41:5
 type LlvmEmitter struct {
 	temp          int
 	label         int
@@ -64,14 +70,14 @@ type LlvmEmitter struct {
 	stringGlobals []*LlvmStringGlobal
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:45:5
+// Osty: examples/selfhost-core/llvmgen.osty:50:5
 type LlvmIfLabels struct {
 	thenLabel string
 	elseLabel string
 	endLabel  string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:51:5
+// Osty: examples/selfhost-core/llvmgen.osty:56:5
 type LlvmRangeLoop struct {
 	condLabel string
 	bodyLabel string
@@ -80,14 +86,14 @@ type LlvmRangeLoop struct {
 	current   string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:59:5
+// Osty: examples/selfhost-core/llvmgen.osty:64:5
 type LlvmSmokeExecutableCase struct {
 	name    string
 	fixture string
 	stdout  string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:65:5
+// Osty: examples/selfhost-core/llvmgen.osty:70:5
 type LlvmUnsupportedDiagnostic struct {
 	code    string
 	kind    string
@@ -95,80 +101,80 @@ type LlvmUnsupportedDiagnostic struct {
 	hint    string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:72:5
+// Osty: examples/selfhost-core/llvmgen.osty:77:5
 func llvmEmitter() *LlvmEmitter {
 	return &LlvmEmitter{temp: 0, label: 0, stringId: 0, body: make([]string, 0, 1), locals: make([]*LlvmBinding, 0, 1), stringGlobals: make([]*LlvmStringGlobal, 0, 1)}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:83:5
+// Osty: examples/selfhost-core/llvmgen.osty:88:5
 func llvmI64(name string) *LlvmValue {
 	return &LlvmValue{typ: "i64", name: name, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:87:5
+// Osty: examples/selfhost-core/llvmgen.osty:92:5
 func llvmI1(name string) *LlvmValue {
 	return &LlvmValue{typ: "i1", name: name, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:91:5
+// Osty: examples/selfhost-core/llvmgen.osty:96:5
 func llvmIntLiteral(value int) *LlvmValue {
 	return llvmI64(fmt.Sprintf("%s", ostyToString(value)))
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:95:5
+// Osty: examples/selfhost-core/llvmgen.osty:100:5
 func llvmParam(name string, typ string) *LlvmParam {
 	return &LlvmParam{name: name, typ: typ}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:99:5
+// Osty: examples/selfhost-core/llvmgen.osty:104:5
 func llvmBind(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:100:5
+	// Osty: examples/selfhost-core/llvmgen.osty:105:5
 	func() struct{} {
 		emitter.locals = append(emitter.locals, &LlvmBinding{name: name, value: value})
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:103:5
+// Osty: examples/selfhost-core/llvmgen.osty:108:5
 func llvmLookup(emitter *LlvmEmitter, name string) *LlvmLookup {
-	// Osty: examples/selfhost-core/llvmgen.osty:104:5
+	// Osty: examples/selfhost-core/llvmgen.osty:109:5
 	out := &LlvmLookup{found: false, value: llvmI64("0")}
 	_ = out
-	// Osty: examples/selfhost-core/llvmgen.osty:105:5
+	// Osty: examples/selfhost-core/llvmgen.osty:110:5
 	for _, binding := range emitter.locals {
-		// Osty: examples/selfhost-core/llvmgen.osty:106:9
+		// Osty: examples/selfhost-core/llvmgen.osty:111:9
 		if binding.name == name {
-			// Osty: examples/selfhost-core/llvmgen.osty:107:17
+			// Osty: examples/selfhost-core/llvmgen.osty:112:17
 			out = &LlvmLookup{found: true, value: binding.value}
 		}
 	}
 	return out
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:113:5
+// Osty: examples/selfhost-core/llvmgen.osty:118:5
 func llvmIdent(emitter *LlvmEmitter, name string) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:114:5
+	// Osty: examples/selfhost-core/llvmgen.osty:119:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: examples/selfhost-core/llvmgen.osty:115:5
+	// Osty: examples/selfhost-core/llvmgen.osty:120:5
 	if !(lookup.found) {
-		// Osty: examples/selfhost-core/llvmgen.osty:116:9
+		// Osty: examples/selfhost-core/llvmgen.osty:121:9
 		return llvmI64("0")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:118:5
+	// Osty: examples/selfhost-core/llvmgen.osty:123:5
 	if lookup.value.pointer {
-		// Osty: examples/selfhost-core/llvmgen.osty:119:9
+		// Osty: examples/selfhost-core/llvmgen.osty:124:9
 		return llvmLoad(emitter, lookup.value)
 	}
 	return lookup.value
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:124:5
+// Osty: examples/selfhost-core/llvmgen.osty:129:5
 func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:125:5
+	// Osty: examples/selfhost-core/llvmgen.osty:130:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:126:5
+	// Osty: examples/selfhost-core/llvmgen.osty:131:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(slot.typ), ostyToString(slot.name)))
 		return struct{}{}
@@ -176,72 +182,72 @@ func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
 	return &LlvmValue{typ: slot.typ, name: tmp, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:130:5
+// Osty: examples/selfhost-core/llvmgen.osty:135:5
 func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:135:5
+	// Osty: examples/selfhost-core/llvmgen.osty:140:5
 	ptr := llvmNextTemp(emitter)
 	_ = ptr
-	// Osty: examples/selfhost-core/llvmgen.osty:136:5
+	// Osty: examples/selfhost-core/llvmgen.osty:141:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(ptr), ostyToString(initial.typ)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:137:5
+	// Osty: examples/selfhost-core/llvmgen.osty:142:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(initial.typ), ostyToString(initial.name), ostyToString(ptr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:138:5
+	// Osty: examples/selfhost-core/llvmgen.osty:143:5
 	slot := &LlvmValue{typ: initial.typ, name: ptr, pointer: true}
 	_ = slot
-	// Osty: examples/selfhost-core/llvmgen.osty:139:5
+	// Osty: examples/selfhost-core/llvmgen.osty:144:5
 	llvmBind(emitter, name, slot)
 	return slot
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:143:5
+// Osty: examples/selfhost-core/llvmgen.osty:148:5
 func llvmMutableLet(emitter *LlvmEmitter, name string, initial *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:144:5
+	// Osty: examples/selfhost-core/llvmgen.osty:149:5
 	_slot := llvmMutableLetSlot(emitter, name, initial)
 	_ = _slot
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:147:5
+// Osty: examples/selfhost-core/llvmgen.osty:152:5
 func llvmStore(emitter *LlvmEmitter, slot *LlvmValue, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:148:5
+	// Osty: examples/selfhost-core/llvmgen.osty:153:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(slot.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:151:5
+// Osty: examples/selfhost-core/llvmgen.osty:156:5
 func llvmAssign(emitter *LlvmEmitter, name string, value *LlvmValue) bool {
-	// Osty: examples/selfhost-core/llvmgen.osty:152:5
+	// Osty: examples/selfhost-core/llvmgen.osty:157:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: examples/selfhost-core/llvmgen.osty:153:5
+	// Osty: examples/selfhost-core/llvmgen.osty:158:5
 	if !(lookup.found) || !(lookup.value.pointer) || lookup.value.typ != value.typ {
-		// Osty: examples/selfhost-core/llvmgen.osty:154:9
+		// Osty: examples/selfhost-core/llvmgen.osty:159:9
 		return false
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:156:5
+	// Osty: examples/selfhost-core/llvmgen.osty:161:5
 	llvmStore(emitter, lookup.value, value)
 	return true
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:160:5
+// Osty: examples/selfhost-core/llvmgen.osty:165:5
 func llvmImmutableLet(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:161:5
+	// Osty: examples/selfhost-core/llvmgen.osty:166:5
 	llvmBind(emitter, name, value)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:168:5
+// Osty: examples/selfhost-core/llvmgen.osty:173:5
 func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:174:5
+	// Osty: examples/selfhost-core/llvmgen.osty:179:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:175:5
+	// Osty: examples/selfhost-core/llvmgen.osty:180:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i64 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -249,12 +255,12 @@ func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI64(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:179:5
+// Osty: examples/selfhost-core/llvmgen.osty:184:5
 func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:185:5
+	// Osty: examples/selfhost-core/llvmgen.osty:190:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:186:5
+	// Osty: examples/selfhost-core/llvmgen.osty:191:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s %s %s, %s", ostyToString(tmp), ostyToString(pred), ostyToString(left.typ), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -262,12 +268,12 @@ func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:190:5
+// Osty: examples/selfhost-core/llvmgen.osty:195:5
 func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:191:5
+	// Osty: examples/selfhost-core/llvmgen.osty:196:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:192:5
+	// Osty: examples/selfhost-core/llvmgen.osty:197:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = xor i1 %s, true", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
@@ -275,12 +281,12 @@ func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmI1(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:196:5
+// Osty: examples/selfhost-core/llvmgen.osty:201:5
 func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:202:5
+	// Osty: examples/selfhost-core/llvmgen.osty:207:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:203:5
+	// Osty: examples/selfhost-core/llvmgen.osty:208:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i1 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -288,12 +294,12 @@ func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:207:5
+// Osty: examples/selfhost-core/llvmgen.osty:212:5
 func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:213:5
+	// Osty: examples/selfhost-core/llvmgen.osty:218:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:214:5
+	// Osty: examples/selfhost-core/llvmgen.osty:219:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s @%s(%s)", ostyToString(tmp), ostyToString(ret), ostyToString(name), ostyToString(llvmCallArgs(args))))
 		return struct{}{}
@@ -301,62 +307,101 @@ func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) 
 	return &LlvmValue{typ: ret, name: tmp, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:218:5
+// Osty: examples/selfhost-core/llvmgen.osty:223:5
 func llvmPrintlnI64(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:219:5
+	// Osty: examples/selfhost-core/llvmgen.osty:224:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:220:5
+	// Osty: examples/selfhost-core/llvmgen.osty:225:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:223:5
+// Osty: examples/selfhost-core/llvmgen.osty:228:5
 func llvmStringLiteralLine(emitter *LlvmEmitter, text string) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:224:5
+	// Osty: examples/selfhost-core/llvmgen.osty:229:5
 	name := fmt.Sprintf("@.str%s", ostyToString(emitter.stringId))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:225:22
+	// Osty: examples/selfhost-core/llvmgen.osty:230:22
 	emitter.stringId = emitter.stringId + 1
-	// Osty: examples/selfhost-core/llvmgen.osty:226:5
-	encoded := fmt.Sprintf("%s\\0A\\00", ostyToString(text))
-	_ = encoded
-	// Osty: examples/selfhost-core/llvmgen.osty:227:5
-	byteLen := len(llvmStrings.Split(text, "")) + 2
-	_ = byteLen
-	// Osty: examples/selfhost-core/llvmgen.osty:228:5
+	// Osty: examples/selfhost-core/llvmgen.osty:231:5
+	cstring := llvmCStringLine(text)
+	_ = cstring
+	// Osty: examples/selfhost-core/llvmgen.osty:232:5
 	func() struct{} {
-		emitter.stringGlobals = append(emitter.stringGlobals, &LlvmStringGlobal{name: name, encoded: encoded, byteLen: byteLen})
+		emitter.stringGlobals = append(emitter.stringGlobals, &LlvmStringGlobal{name: name, encoded: cstring.encoded, byteLen: cstring.byteLen})
 		return struct{}{}
 	}()
 	return &LlvmValue{typ: "ptr", name: name, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:232:5
+// Osty: examples/selfhost-core/llvmgen.osty:238:5
+func llvmCStringLine(text string) *LlvmCString {
+	// Osty: examples/selfhost-core/llvmgen.osty:239:5
+	encoded := fmt.Sprintf("%s\\0A\\00", ostyToString(llvmCStringEscape(text)))
+	_ = encoded
+	// Osty: examples/selfhost-core/llvmgen.osty:240:5
+	byteLen := len(llvmStrings.Split(text, "")) + 2
+	_ = byteLen
+	return &LlvmCString{encoded: encoded, byteLen: byteLen}
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:244:5
+func llvmCStringEscape(text string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:245:5
+	encoded := ""
+	_ = encoded
+	// Osty: examples/selfhost-core/llvmgen.osty:246:5
+	for _, unit := range llvmStrings.Split(text, "") {
+		// Osty: examples/selfhost-core/llvmgen.osty:247:9
+		if unit == "\n" {
+			// Osty: examples/selfhost-core/llvmgen.osty:248:21
+			encoded = fmt.Sprintf("%s\\0A", ostyToString(encoded))
+		} else if unit == "\t" {
+			// Osty: examples/selfhost-core/llvmgen.osty:250:21
+			encoded = fmt.Sprintf("%s\\09", ostyToString(encoded))
+		} else if unit == "\r" {
+			// Osty: examples/selfhost-core/llvmgen.osty:252:21
+			encoded = fmt.Sprintf("%s\\0D", ostyToString(encoded))
+		} else if unit == "\"" {
+			// Osty: examples/selfhost-core/llvmgen.osty:254:21
+			encoded = fmt.Sprintf("%s\\22", ostyToString(encoded))
+		} else if unit == "\\" {
+			// Osty: examples/selfhost-core/llvmgen.osty:256:21
+			encoded = fmt.Sprintf("%s\\5C", ostyToString(encoded))
+		} else {
+			// Osty: examples/selfhost-core/llvmgen.osty:258:21
+			encoded = fmt.Sprintf("%s%s", ostyToString(encoded), ostyToString(unit))
+		}
+	}
+	return encoded
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:264:5
 func llvmPrintlnString(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:233:5
+	// Osty: examples/selfhost-core/llvmgen.osty:265:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:234:5
+	// Osty: examples/selfhost-core/llvmgen.osty:266:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:237:5
+// Osty: examples/selfhost-core/llvmgen.osty:269:5
 func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: examples/selfhost-core/llvmgen.osty:238:5
+	// Osty: examples/selfhost-core/llvmgen.osty:270:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.then"), elseLabel: llvmNextLabel(emitter, "if.else"), endLabel: llvmNextLabel(emitter, "if.end")}
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:243:5
+	// Osty: examples/selfhost-core/llvmgen.osty:275:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:244:5
+	// Osty: examples/selfhost-core/llvmgen.osty:276:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -364,68 +409,8 @@ func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:248:5
+// Osty: examples/selfhost-core/llvmgen.osty:280:5
 func llvmIfElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: examples/selfhost-core/llvmgen.osty:249:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
-		return struct{}{}
-	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:250:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
-		return struct{}{}
-	}()
-}
-
-// Osty: examples/selfhost-core/llvmgen.osty:253:5
-func llvmIfEnd(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: examples/selfhost-core/llvmgen.osty:254:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
-		return struct{}{}
-	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:255:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
-		return struct{}{}
-	}()
-}
-
-// Osty: examples/selfhost-core/llvmgen.osty:258:5
-func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: examples/selfhost-core/llvmgen.osty:259:5
-	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.expr.then"), elseLabel: llvmNextLabel(emitter, "if.expr.else"), endLabel: llvmNextLabel(emitter, "if.expr.end")}
-	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:264:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
-		return struct{}{}
-	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:265:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
-		return struct{}{}
-	}()
-	return labels
-}
-
-// Osty: examples/selfhost-core/llvmgen.osty:269:5
-func llvmIfExprElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: examples/selfhost-core/llvmgen.osty:270:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
-		return struct{}{}
-	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:271:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
-		return struct{}{}
-	}()
-}
-
-// Osty: examples/selfhost-core/llvmgen.osty:274:5
-func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseValue *LlvmValue, labels *LlvmIfLabels) *LlvmValue {
 	// Osty: examples/selfhost-core/llvmgen.osty:281:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
@@ -433,13 +418,73 @@ func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseV
 	}()
 	// Osty: examples/selfhost-core/llvmgen.osty:282:5
 	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
+		return struct{}{}
+	}()
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:285:5
+func llvmIfEnd(emitter *LlvmEmitter, labels *LlvmIfLabels) {
+	// Osty: examples/selfhost-core/llvmgen.osty:286:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
+		return struct{}{}
+	}()
+	// Osty: examples/selfhost-core/llvmgen.osty:287:5
+	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:283:5
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:290:5
+func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
+	// Osty: examples/selfhost-core/llvmgen.osty:291:5
+	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.expr.then"), elseLabel: llvmNextLabel(emitter, "if.expr.else"), endLabel: llvmNextLabel(emitter, "if.expr.end")}
+	_ = labels
+	// Osty: examples/selfhost-core/llvmgen.osty:296:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
+		return struct{}{}
+	}()
+	// Osty: examples/selfhost-core/llvmgen.osty:297:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
+		return struct{}{}
+	}()
+	return labels
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:301:5
+func llvmIfExprElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
+	// Osty: examples/selfhost-core/llvmgen.osty:302:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
+		return struct{}{}
+	}()
+	// Osty: examples/selfhost-core/llvmgen.osty:303:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
+		return struct{}{}
+	}()
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:306:5
+func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseValue *LlvmValue, labels *LlvmIfLabels) *LlvmValue {
+	// Osty: examples/selfhost-core/llvmgen.osty:313:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
+		return struct{}{}
+	}()
+	// Osty: examples/selfhost-core/llvmgen.osty:314:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
+		return struct{}{}
+	}()
+	// Osty: examples/selfhost-core/llvmgen.osty:315:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:284:5
+	// Osty: examples/selfhost-core/llvmgen.osty:316:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]", ostyToString(tmp), ostyToString(typ), ostyToString(thenValue.name), ostyToString(labels.thenLabel), ostyToString(elseValue.name), ostyToString(labels.elseLabel)))
 		return struct{}{}
@@ -447,222 +492,222 @@ func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseV
 	return &LlvmValue{typ: typ, name: tmp, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:290:5
+// Osty: examples/selfhost-core/llvmgen.osty:322:5
 func llvmInclusiveRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue) *LlvmRangeLoop {
 	return llvmRangeStart(emitter, iterName, start, stop, true)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:299:5
+// Osty: examples/selfhost-core/llvmgen.osty:331:5
 func llvmRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue, inclusive bool) *LlvmRangeLoop {
-	// Osty: examples/selfhost-core/llvmgen.osty:306:5
+	// Osty: examples/selfhost-core/llvmgen.osty:338:5
 	iterPtr := llvmNextTemp(emitter)
 	_ = iterPtr
-	// Osty: examples/selfhost-core/llvmgen.osty:307:5
+	// Osty: examples/selfhost-core/llvmgen.osty:339:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:308:5
+	// Osty: examples/selfhost-core/llvmgen.osty:340:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(start.name), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:310:5
+	// Osty: examples/selfhost-core/llvmgen.osty:342:5
 	loop := &LlvmRangeLoop{condLabel: llvmNextLabel(emitter, "for.cond"), bodyLabel: llvmNextLabel(emitter, "for.body"), endLabel: llvmNextLabel(emitter, "for.end"), iterPtr: iterPtr, current: ""}
 	_ = loop
-	// Osty: examples/selfhost-core/llvmgen.osty:317:5
+	// Osty: examples/selfhost-core/llvmgen.osty:349:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:318:5
+	// Osty: examples/selfhost-core/llvmgen.osty:350:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:320:5
+	// Osty: examples/selfhost-core/llvmgen.osty:352:5
 	current := llvmNextTemp(emitter)
 	_ = current
-	// Osty: examples/selfhost-core/llvmgen.osty:321:5
+	// Osty: examples/selfhost-core/llvmgen.osty:353:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", ostyToString(current), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:322:5
+	// Osty: examples/selfhost-core/llvmgen.osty:354:5
 	cmp := llvmNextTemp(emitter)
 	_ = cmp
-	// Osty: examples/selfhost-core/llvmgen.osty:323:5
+	// Osty: examples/selfhost-core/llvmgen.osty:355:5
 	pred := "slt"
 	_ = pred
-	// Osty: examples/selfhost-core/llvmgen.osty:324:5
+	// Osty: examples/selfhost-core/llvmgen.osty:356:5
 	if inclusive {
-		// Osty: examples/selfhost-core/llvmgen.osty:325:14
+		// Osty: examples/selfhost-core/llvmgen.osty:357:14
 		pred = "sle"
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:327:5
+	// Osty: examples/selfhost-core/llvmgen.osty:359:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s i64 %s, %s", ostyToString(cmp), ostyToString(pred), ostyToString(current), ostyToString(stop.name)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:328:5
+	// Osty: examples/selfhost-core/llvmgen.osty:360:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cmp), ostyToString(loop.bodyLabel), ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:329:5
+	// Osty: examples/selfhost-core/llvmgen.osty:361:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.bodyLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:330:5
+	// Osty: examples/selfhost-core/llvmgen.osty:362:5
 	llvmBind(emitter, iterName, llvmI64(current))
 	return &LlvmRangeLoop{condLabel: loop.condLabel, bodyLabel: loop.bodyLabel, endLabel: loop.endLabel, iterPtr: loop.iterPtr, current: current}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:341:5
+// Osty: examples/selfhost-core/llvmgen.osty:373:5
 func llvmRangeEnd(emitter *LlvmEmitter, loop *LlvmRangeLoop) {
-	// Osty: examples/selfhost-core/llvmgen.osty:342:5
+	// Osty: examples/selfhost-core/llvmgen.osty:374:5
 	next := llvmNextTemp(emitter)
 	_ = next
-	// Osty: examples/selfhost-core/llvmgen.osty:343:5
+	// Osty: examples/selfhost-core/llvmgen.osty:375:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", ostyToString(next), ostyToString(loop.current)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:344:5
+	// Osty: examples/selfhost-core/llvmgen.osty:376:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(next), ostyToString(loop.iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:345:5
+	// Osty: examples/selfhost-core/llvmgen.osty:377:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:346:5
+	// Osty: examples/selfhost-core/llvmgen.osty:378:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:349:5
+// Osty: examples/selfhost-core/llvmgen.osty:381:5
 func llvmReturn(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:350:5
+	// Osty: examples/selfhost-core/llvmgen.osty:382:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  ret %s %s", ostyToString(value.typ), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:353:5
+// Osty: examples/selfhost-core/llvmgen.osty:385:5
 func llvmReturnI32Zero(emitter *LlvmEmitter) {
-	// Osty: examples/selfhost-core/llvmgen.osty:354:5
+	// Osty: examples/selfhost-core/llvmgen.osty:386:5
 	func() struct{} { emitter.body = append(emitter.body, "  ret i32 0"); return struct{}{} }()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:357:5
+// Osty: examples/selfhost-core/llvmgen.osty:389:5
 func llvmRenderModule(sourcePath string, target string, definitions []string) string {
 	return llvmRenderModuleWithGlobals(sourcePath, target, make([]*LlvmStringGlobal, 0, 1), definitions)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:361:5
+// Osty: examples/selfhost-core/llvmgen.osty:393:5
 func llvmRenderModuleWithGlobals(sourcePath string, target string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:367:5
+	// Osty: examples/selfhost-core/llvmgen.osty:399:5
 	lines := []string{"; Code generated by osty LLVM backend. DO NOT EDIT.", fmt.Sprintf("; Osty: %s", ostyToString(sourcePath)), fmt.Sprintf("source_filename = \"%s\"", ostyToString(sourcePath))}
 	_ = lines
-	// Osty: examples/selfhost-core/llvmgen.osty:372:5
+	// Osty: examples/selfhost-core/llvmgen.osty:404:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:373:9
+		// Osty: examples/selfhost-core/llvmgen.osty:405:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("target triple = \"%s\"", ostyToString(target)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:375:5
+	// Osty: examples/selfhost-core/llvmgen.osty:407:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:376:5
+	// Osty: examples/selfhost-core/llvmgen.osty:408:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_i64 = private unnamed_addr constant [5 x i8] c\"%ld\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:377:5
+	// Osty: examples/selfhost-core/llvmgen.osty:409:5
 	for _, global := range stringGlobals {
-		// Osty: examples/selfhost-core/llvmgen.osty:378:9
+		// Osty: examples/selfhost-core/llvmgen.osty:410:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("%s = private unnamed_addr constant [%s x i8] c\"%s\"", ostyToString(global.name), ostyToString(global.byteLen), ostyToString(global.encoded)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:380:5
+	// Osty: examples/selfhost-core/llvmgen.osty:412:5
 	func() struct{} { lines = append(lines, "declare i32 @printf(ptr, ...)"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:381:5
+	// Osty: examples/selfhost-core/llvmgen.osty:413:5
 	firstDefinition := true
 	_ = firstDefinition
-	// Osty: examples/selfhost-core/llvmgen.osty:382:5
+	// Osty: examples/selfhost-core/llvmgen.osty:414:5
 	for _, definition := range definitions {
-		// Osty: examples/selfhost-core/llvmgen.osty:383:9
+		// Osty: examples/selfhost-core/llvmgen.osty:415:9
 		if firstDefinition {
-			// Osty: examples/selfhost-core/llvmgen.osty:384:13
+			// Osty: examples/selfhost-core/llvmgen.osty:416:13
 			func() struct{} { lines = append(lines, ""); return struct{}{} }()
-			// Osty: examples/selfhost-core/llvmgen.osty:385:29
+			// Osty: examples/selfhost-core/llvmgen.osty:417:29
 			firstDefinition = false
 		}
-		// Osty: examples/selfhost-core/llvmgen.osty:387:9
+		// Osty: examples/selfhost-core/llvmgen.osty:419:9
 		func() struct{} { lines = append(lines, definition); return struct{}{} }()
 	}
 	return llvmStrings.Join(lines, "\n")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:392:5
+// Osty: examples/selfhost-core/llvmgen.osty:424:5
 func llvmRenderSkeleton(packageName string, sourcePath string, emit string, target string, unsupported string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:399:5
+	// Osty: examples/selfhost-core/llvmgen.osty:431:5
 	pkg := packageName
 	_ = pkg
-	// Osty: examples/selfhost-core/llvmgen.osty:400:5
+	// Osty: examples/selfhost-core/llvmgen.osty:432:5
 	if pkg == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:401:13
+		// Osty: examples/selfhost-core/llvmgen.osty:433:13
 		pkg = "main"
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:403:5
+	// Osty: examples/selfhost-core/llvmgen.osty:435:5
 	source := sourcePath
 	_ = source
-	// Osty: examples/selfhost-core/llvmgen.osty:404:5
+	// Osty: examples/selfhost-core/llvmgen.osty:436:5
 	if source == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:405:16
+		// Osty: examples/selfhost-core/llvmgen.osty:437:16
 		source = "<unknown>"
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:408:5
+	// Osty: examples/selfhost-core/llvmgen.osty:440:5
 	lines := []string{"; Osty LLVM backend skeleton", fmt.Sprintf("; package: %s", ostyToString(pkg)), fmt.Sprintf("; source: %s", ostyToString(source)), fmt.Sprintf("; emit: %s", ostyToString(emit))}
 	_ = lines
-	// Osty: examples/selfhost-core/llvmgen.osty:414:5
+	// Osty: examples/selfhost-core/llvmgen.osty:446:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:415:9
+		// Osty: examples/selfhost-core/llvmgen.osty:447:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; target: %s", ostyToString(target)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:417:5
+	// Osty: examples/selfhost-core/llvmgen.osty:449:5
 	if unsupported != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:418:9
+		// Osty: examples/selfhost-core/llvmgen.osty:450:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; unsupported: %s", ostyToString(unsupported)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:420:5
+	// Osty: examples/selfhost-core/llvmgen.osty:452:5
 	func() struct{} { lines = append(lines, "; code generation is not implemented yet"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:421:5
+	// Osty: examples/selfhost-core/llvmgen.osty:453:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:422:5
+	// Osty: examples/selfhost-core/llvmgen.osty:454:5
 	func() struct{} {
 		lines = append(lines, fmt.Sprintf("source_filename = \"%s\"", ostyToString(source)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:423:5
+	// Osty: examples/selfhost-core/llvmgen.osty:455:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:424:9
+		// Osty: examples/selfhost-core/llvmgen.osty:456:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("target triple = \"%s\"", ostyToString(target)))
 			return struct{}{}
@@ -671,347 +716,362 @@ func llvmRenderSkeleton(packageName string, sourcePath string, emit string, targ
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:429:5
+// Osty: examples/selfhost-core/llvmgen.osty:461:5
 func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:435:5
+	// Osty: examples/selfhost-core/llvmgen.osty:467:5
 	lines := []string{fmt.Sprintf("define %s @%s(%s) {", ostyToString(ret), ostyToString(name), ostyToString(llvmParams(params))), "entry:"}
 	_ = lines
-	// Osty: examples/selfhost-core/llvmgen.osty:436:5
+	// Osty: examples/selfhost-core/llvmgen.osty:468:5
 	for _, line := range body {
-		// Osty: examples/selfhost-core/llvmgen.osty:437:9
+		// Osty: examples/selfhost-core/llvmgen.osty:469:9
 		func() struct{} { lines = append(lines, line); return struct{}{} }()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:439:5
+	// Osty: examples/selfhost-core/llvmgen.osty:471:5
 	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:443:5
+// Osty: examples/selfhost-core/llvmgen.osty:475:5
 func llvmNeedsObjectArtifact(emit string) bool {
 	return emit == "object" || emit == "binary"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:447:5
+// Osty: examples/selfhost-core/llvmgen.osty:479:5
 func llvmNeedsBinaryArtifact(emit string) bool {
 	return emit == "binary"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:451:5
+// Osty: examples/selfhost-core/llvmgen.osty:483:5
 func llvmClangCompileObjectArgs(target string, irPath string, objectPath string) []string {
-	// Osty: examples/selfhost-core/llvmgen.osty:456:5
+	// Osty: examples/selfhost-core/llvmgen.osty:488:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: examples/selfhost-core/llvmgen.osty:457:5
+	// Osty: examples/selfhost-core/llvmgen.osty:489:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:458:9
+		// Osty: examples/selfhost-core/llvmgen.osty:490:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: examples/selfhost-core/llvmgen.osty:459:9
+		// Osty: examples/selfhost-core/llvmgen.osty:491:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:461:5
+	// Osty: examples/selfhost-core/llvmgen.osty:493:5
 	func() struct{} { args = append(args, "-c"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:462:5
+	// Osty: examples/selfhost-core/llvmgen.osty:494:5
 	func() struct{} { args = append(args, irPath); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:463:5
+	// Osty: examples/selfhost-core/llvmgen.osty:495:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:464:5
+	// Osty: examples/selfhost-core/llvmgen.osty:496:5
 	func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	return args
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:468:5
+// Osty: examples/selfhost-core/llvmgen.osty:500:5
 func llvmClangLinkBinaryArgs(target string, objectPath string, binaryPath string) []string {
-	// Osty: examples/selfhost-core/llvmgen.osty:473:5
+	// Osty: examples/selfhost-core/llvmgen.osty:505:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: examples/selfhost-core/llvmgen.osty:474:5
+	// Osty: examples/selfhost-core/llvmgen.osty:506:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:475:9
+		// Osty: examples/selfhost-core/llvmgen.osty:507:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: examples/selfhost-core/llvmgen.osty:476:9
+		// Osty: examples/selfhost-core/llvmgen.osty:508:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:478:5
+	// Osty: examples/selfhost-core/llvmgen.osty:510:5
 	func() struct{} { args = append(args, objectPath); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:479:5
+	// Osty: examples/selfhost-core/llvmgen.osty:511:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:480:5
+	// Osty: examples/selfhost-core/llvmgen.osty:512:5
 	func() struct{} { args = append(args, binaryPath); return struct{}{} }()
 	return args
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:484:5
+// Osty: examples/selfhost-core/llvmgen.osty:516:5
 func llvmMissingClangMessage() string {
 	return "llvm backend: clang not found on PATH; install clang or use --emit=llvm-ir"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:488:5
+// Osty: examples/selfhost-core/llvmgen.osty:520:5
 func llvmMissingBinaryArtifactMessage() string {
 	return "llvm backend: missing binary artifact path"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:492:5
+// Osty: examples/selfhost-core/llvmgen.osty:524:5
 func llvmClangFailureMessage(action string, command string, output string) string {
 	return fmt.Sprintf("llvm backend: clang %s failed\ncommand: %s\n%s", ostyToString(action), ostyToString(command), ostyToString(output))
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:496:5
+// Osty: examples/selfhost-core/llvmgen.osty:528:5
 func llvmUnsupportedBackendErrorMessage() string {
 	return "llvm backend: code generation is not implemented yet"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:500:5
+// Osty: examples/selfhost-core/llvmgen.osty:532:5
 func llvmUnsupportedDiagnostic(kind string, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: examples/selfhost-core/llvmgen.osty:501:5
+	// Osty: examples/selfhost-core/llvmgen.osty:533:5
 	if kind == "go-ffi" {
-		// Osty: examples/selfhost-core/llvmgen.osty:502:9
+		// Osty: examples/selfhost-core/llvmgen.osty:534:9
 		target := detail
 		_ = target
-		// Osty: examples/selfhost-core/llvmgen.osty:503:9
+		// Osty: examples/selfhost-core/llvmgen.osty:535:9
 		if target == "" {
-			// Osty: examples/selfhost-core/llvmgen.osty:504:20
+			// Osty: examples/selfhost-core/llvmgen.osty:536:20
 			target = "<unknown>"
 		}
-		// Osty: examples/selfhost-core/llvmgen.osty:506:9
+		// Osty: examples/selfhost-core/llvmgen.osty:538:9
 		return &LlvmUnsupportedDiagnostic{code: "LLVM001", kind: "go-only", message: fmt.Sprintf("use go \"%s\" is only supported by the Go backend", ostyToString(target)), hint: "use --backend=go or replace it with a native/runtime binding before using --backend=llvm"}
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:514:5
+	// Osty: examples/selfhost-core/llvmgen.osty:546:5
 	if kind == "source-layout" {
-		// Osty: examples/selfhost-core/llvmgen.osty:515:9
+		// Osty: examples/selfhost-core/llvmgen.osty:547:9
 		return llvmUnsupportedDiagnosticWith("LLVM010", kind, detail, "reshape the file around the current LLVM subset: script statements or a simple main function")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:522:5
+	// Osty: examples/selfhost-core/llvmgen.osty:554:5
 	if kind == "type-system" {
-		// Osty: examples/selfhost-core/llvmgen.osty:523:9
+		// Osty: examples/selfhost-core/llvmgen.osty:555:9
 		return llvmUnsupportedDiagnosticWith("LLVM011", kind, detail, "use Int or Bool values until the LLVM runtime type surface grows")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:530:5
+	// Osty: examples/selfhost-core/llvmgen.osty:562:5
 	if kind == "statement" {
-		// Osty: examples/selfhost-core/llvmgen.osty:531:9
+		// Osty: examples/selfhost-core/llvmgen.osty:563:9
 		return llvmUnsupportedDiagnosticWith("LLVM012", kind, detail, "reduce the statement to let, assignment, if, range-for, return, or println")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:538:5
+	// Osty: examples/selfhost-core/llvmgen.osty:570:5
 	if kind == "expression" {
-		// Osty: examples/selfhost-core/llvmgen.osty:539:9
+		// Osty: examples/selfhost-core/llvmgen.osty:571:9
 		return llvmUnsupportedDiagnosticWith("LLVM013", kind, detail, "reduce the expression to Int, Bool, arithmetic, comparison, call, or value-if forms")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:546:5
+	// Osty: examples/selfhost-core/llvmgen.osty:578:5
 	if kind == "control-flow" {
-		// Osty: examples/selfhost-core/llvmgen.osty:547:9
+		// Osty: examples/selfhost-core/llvmgen.osty:579:9
 		return llvmUnsupportedDiagnosticWith("LLVM014", kind, detail, "use plain if/else or closed Int range loops for the current LLVM backend")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:554:5
+	// Osty: examples/selfhost-core/llvmgen.osty:586:5
 	if kind == "call" {
-		// Osty: examples/selfhost-core/llvmgen.osty:555:9
+		// Osty: examples/selfhost-core/llvmgen.osty:587:9
 		return llvmUnsupportedDiagnosticWith("LLVM015", kind, detail, "call an Osty function with positional Int/Bool arguments or use println as a statement")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:562:5
+	// Osty: examples/selfhost-core/llvmgen.osty:594:5
 	if kind == "name" {
-		// Osty: examples/selfhost-core/llvmgen.osty:563:9
+		// Osty: examples/selfhost-core/llvmgen.osty:595:9
 		return llvmUnsupportedDiagnosticWith("LLVM016", kind, detail, "use simple ASCII identifiers that the LLVM bridge can map directly")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:570:5
+	// Osty: examples/selfhost-core/llvmgen.osty:602:5
 	if kind == "function-signature" {
-		// Osty: examples/selfhost-core/llvmgen.osty:571:9
+		// Osty: examples/selfhost-core/llvmgen.osty:603:9
 		return llvmUnsupportedDiagnosticWith("LLVM017", kind, detail, "use non-generic functions with identifier parameters and Int/Bool types")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:579:5
+	// Osty: examples/selfhost-core/llvmgen.osty:611:5
 	reason := detail
 	_ = reason
-	// Osty: examples/selfhost-core/llvmgen.osty:580:5
+	// Osty: examples/selfhost-core/llvmgen.osty:612:5
 	if reason == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:581:16
+		// Osty: examples/selfhost-core/llvmgen.osty:613:16
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: "LLVM000", kind: "unsupported-source", message: reason, hint: "reduce the program to the LLVM smoke subset or keep using --backend=go for this source"}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:591:5
+// Osty: examples/selfhost-core/llvmgen.osty:623:5
 func llvmUnsupportedDiagnosticWith(code string, kind string, detail string, hint string) *LlvmUnsupportedDiagnostic {
-	// Osty: examples/selfhost-core/llvmgen.osty:597:5
+	// Osty: examples/selfhost-core/llvmgen.osty:629:5
 	reason := detail
 	_ = reason
-	// Osty: examples/selfhost-core/llvmgen.osty:598:5
+	// Osty: examples/selfhost-core/llvmgen.osty:630:5
 	if reason == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:599:16
+		// Osty: examples/selfhost-core/llvmgen.osty:631:16
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: code, kind: kind, message: reason, hint: hint}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:609:5
+// Osty: examples/selfhost-core/llvmgen.osty:641:5
 func llvmUnsupportedSummary(diag *LlvmUnsupportedDiagnostic) string {
 	return fmt.Sprintf("%s %s: %s; hint: %s", ostyToString(diag.code), ostyToString(diag.kind), ostyToString(diag.message), ostyToString(diag.hint))
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:613:5
+// Osty: examples/selfhost-core/llvmgen.osty:645:5
 func llvmSmokeExecutableCorpus() []*LlvmSmokeExecutableCase {
-	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}}
+	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:643:5
+// Osty: examples/selfhost-core/llvmgen.osty:680:5
 func llvmSmokeMinimalPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:644:5
+	// Osty: examples/selfhost-core/llvmgen.osty:681:5
 	emitter := llvmEmitter()
 	_ = emitter
-	// Osty: examples/selfhost-core/llvmgen.osty:645:5
+	// Osty: examples/selfhost-core/llvmgen.osty:682:5
 	value := llvmBinaryI64(emitter, "add", llvmIntLiteral(40), llvmIntLiteral(2))
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:646:5
+	// Osty: examples/selfhost-core/llvmgen.osty:683:5
 	llvmPrintlnI64(emitter, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:647:5
+	// Osty: examples/selfhost-core/llvmgen.osty:684:5
 	llvmReturnI32Zero(emitter)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), emitter.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:657:5
+// Osty: examples/selfhost-core/llvmgen.osty:694:5
 func llvmSmokeScalarArithmeticIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:658:5
+	// Osty: examples/selfhost-core/llvmgen.osty:695:5
 	add := llvmEmitter()
 	_ = add
-	// Osty: examples/selfhost-core/llvmgen.osty:659:5
+	// Osty: examples/selfhost-core/llvmgen.osty:696:5
 	llvmBind(add, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:660:5
+	// Osty: examples/selfhost-core/llvmgen.osty:697:5
 	llvmBind(add, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:661:5
+	// Osty: examples/selfhost-core/llvmgen.osty:698:5
 	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
 	_ = sum
-	// Osty: examples/selfhost-core/llvmgen.osty:662:5
+	// Osty: examples/selfhost-core/llvmgen.osty:699:5
 	llvmReturn(add, sum)
-	// Osty: examples/selfhost-core/llvmgen.osty:664:5
+	// Osty: examples/selfhost-core/llvmgen.osty:701:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:665:5
+	// Osty: examples/selfhost-core/llvmgen.osty:702:5
 	value := llvmCall(main, "i64", "add", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:666:5
+	// Osty: examples/selfhost-core/llvmgen.osty:703:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: examples/selfhost-core/llvmgen.osty:667:5
+	// Osty: examples/selfhost-core/llvmgen.osty:704:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "value"), llvmIntLiteral(42))
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:668:5
+	// Osty: examples/selfhost-core/llvmgen.osty:705:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:669:5
+	// Osty: examples/selfhost-core/llvmgen.osty:706:5
 	llvmPrintlnI64(main, llvmIdent(main, "value"))
-	// Osty: examples/selfhost-core/llvmgen.osty:670:5
+	// Osty: examples/selfhost-core/llvmgen.osty:707:5
 	llvmIfElse(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:671:5
+	// Osty: examples/selfhost-core/llvmgen.osty:708:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:672:5
+	// Osty: examples/selfhost-core/llvmgen.osty:709:5
 	llvmIfEnd(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:673:5
+	// Osty: examples/selfhost-core/llvmgen.osty:710:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "add", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, add.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:693:5
+// Osty: examples/selfhost-core/llvmgen.osty:730:5
 func llvmSmokeControlFlowIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:694:5
+	// Osty: examples/selfhost-core/llvmgen.osty:731:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: examples/selfhost-core/llvmgen.osty:695:5
+	// Osty: examples/selfhost-core/llvmgen.osty:732:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: examples/selfhost-core/llvmgen.osty:696:5
+	// Osty: examples/selfhost-core/llvmgen.osty:733:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:697:5
+	// Osty: examples/selfhost-core/llvmgen.osty:734:5
 	loop := llvmInclusiveRangeStart(sumTo, "i", llvmIntLiteral(1), llvmIdent(sumTo, "n"))
 	_ = loop
-	// Osty: examples/selfhost-core/llvmgen.osty:698:5
+	// Osty: examples/selfhost-core/llvmgen.osty:735:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: examples/selfhost-core/llvmgen.osty:699:5
+	// Osty: examples/selfhost-core/llvmgen.osty:736:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: examples/selfhost-core/llvmgen.osty:700:5
+	// Osty: examples/selfhost-core/llvmgen.osty:737:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: examples/selfhost-core/llvmgen.osty:701:5
+	// Osty: examples/selfhost-core/llvmgen.osty:738:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: examples/selfhost-core/llvmgen.osty:703:5
+	// Osty: examples/selfhost-core/llvmgen.osty:740:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:704:5
+	// Osty: examples/selfhost-core/llvmgen.osty:741:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(5)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:705:5
+	// Osty: examples/selfhost-core/llvmgen.osty:742:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:706:5
+	// Osty: examples/selfhost-core/llvmgen.osty:743:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:718:5
+// Osty: examples/selfhost-core/llvmgen.osty:755:5
 func llvmSmokeBooleansIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:719:5
+	// Osty: examples/selfhost-core/llvmgen.osty:756:5
 	choose := llvmEmitter()
 	_ = choose
-	// Osty: examples/selfhost-core/llvmgen.osty:720:5
+	// Osty: examples/selfhost-core/llvmgen.osty:757:5
 	llvmBind(choose, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:721:5
+	// Osty: examples/selfhost-core/llvmgen.osty:758:5
 	llvmBind(choose, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:722:5
+	// Osty: examples/selfhost-core/llvmgen.osty:759:5
 	lt := llvmCompare(choose, "slt", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = lt
-	// Osty: examples/selfhost-core/llvmgen.osty:723:5
+	// Osty: examples/selfhost-core/llvmgen.osty:760:5
 	eqZero := llvmCompare(choose, "eq", llvmIdent(choose, "a"), llvmIntLiteral(0))
 	_ = eqZero
-	// Osty: examples/selfhost-core/llvmgen.osty:724:5
+	// Osty: examples/selfhost-core/llvmgen.osty:761:5
 	nonZero := llvmNotI1(choose, eqZero)
 	_ = nonZero
-	// Osty: examples/selfhost-core/llvmgen.osty:725:5
+	// Osty: examples/selfhost-core/llvmgen.osty:762:5
 	cond := llvmLogicalI1(choose, "and", lt, nonZero)
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:726:5
+	// Osty: examples/selfhost-core/llvmgen.osty:763:5
 	labels := llvmIfExprStart(choose, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:727:5
+	// Osty: examples/selfhost-core/llvmgen.osty:764:5
 	thenValue := llvmBinaryI64(choose, "sub", llvmIdent(choose, "b"), llvmIdent(choose, "a"))
 	_ = thenValue
-	// Osty: examples/selfhost-core/llvmgen.osty:728:5
+	// Osty: examples/selfhost-core/llvmgen.osty:765:5
 	llvmIfExprElse(choose, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:729:5
+	// Osty: examples/selfhost-core/llvmgen.osty:766:5
 	elseValue := llvmBinaryI64(choose, "add", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = elseValue
-	// Osty: examples/selfhost-core/llvmgen.osty:730:5
+	// Osty: examples/selfhost-core/llvmgen.osty:767:5
 	result := llvmIfExprEnd(choose, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: examples/selfhost-core/llvmgen.osty:731:5
+	// Osty: examples/selfhost-core/llvmgen.osty:768:5
 	llvmReturn(choose, result)
-	// Osty: examples/selfhost-core/llvmgen.osty:733:5
+	// Osty: examples/selfhost-core/llvmgen.osty:770:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:734:5
+	// Osty: examples/selfhost-core/llvmgen.osty:771:5
 	value := llvmCall(main, "i64", "choose", []*LlvmValue{llvmIntLiteral(3), llvmIntLiteral(10)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:735:5
+	// Osty: examples/selfhost-core/llvmgen.osty:772:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:736:5
+	// Osty: examples/selfhost-core/llvmgen.osty:773:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "choose", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, choose.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:756:5
+// Osty: examples/selfhost-core/llvmgen.osty:793:5
 func llvmSmokeStringPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:757:5
+	// Osty: examples/selfhost-core/llvmgen.osty:794:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:758:5
+	// Osty: examples/selfhost-core/llvmgen.osty:795:5
 	line := llvmStringLiteralLine(main, "hello, osty")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:759:5
+	// Osty: examples/selfhost-core/llvmgen.osty:796:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:760:5
+	// Osty: examples/selfhost-core/llvmgen.osty:797:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:772:1
+// Osty: examples/selfhost-core/llvmgen.osty:809:5
+func llvmSmokeStringEscapeIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:810:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:811:5
+	line := llvmStringLiteralLine(main, "line one\nquote \" slash \\")
+	_ = line
+	// Osty: examples/selfhost-core/llvmgen.osty:812:5
+	llvmPrintlnString(main, line)
+	// Osty: examples/selfhost-core/llvmgen.osty:813:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:825:1
 func llvmCallArgs(args []*LlvmValue) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:773:5
+	// Osty: examples/selfhost-core/llvmgen.osty:826:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:774:5
+	// Osty: examples/selfhost-core/llvmgen.osty:827:5
 	for _, arg := range args {
-		// Osty: examples/selfhost-core/llvmgen.osty:775:9
+		// Osty: examples/selfhost-core/llvmgen.osty:828:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %s", ostyToString(arg.typ), ostyToString(arg.name)))
 			return struct{}{}
@@ -1020,14 +1080,14 @@ func llvmCallArgs(args []*LlvmValue) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:780:1
+// Osty: examples/selfhost-core/llvmgen.osty:833:1
 func llvmParams(params []*LlvmParam) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:781:5
+	// Osty: examples/selfhost-core/llvmgen.osty:834:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:782:5
+	// Osty: examples/selfhost-core/llvmgen.osty:835:5
 	for _, param := range params {
-		// Osty: examples/selfhost-core/llvmgen.osty:783:9
+		// Osty: examples/selfhost-core/llvmgen.osty:836:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %%%s", ostyToString(param.typ), ostyToString(param.name)))
 			return struct{}{}
@@ -1036,22 +1096,22 @@ func llvmParams(params []*LlvmParam) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:788:1
+// Osty: examples/selfhost-core/llvmgen.osty:841:1
 func llvmNextTemp(emitter *LlvmEmitter) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:789:5
+	// Osty: examples/selfhost-core/llvmgen.osty:842:5
 	name := fmt.Sprintf("%%t%s", ostyToString(emitter.temp))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:790:18
+	// Osty: examples/selfhost-core/llvmgen.osty:843:18
 	emitter.temp = emitter.temp + 1
 	return name
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:794:1
+// Osty: examples/selfhost-core/llvmgen.osty:847:1
 func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:795:5
+	// Osty: examples/selfhost-core/llvmgen.osty:848:5
 	name := fmt.Sprintf("%s%s", ostyToString(prefix), ostyToString(emitter.label))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:796:19
+	// Osty: examples/selfhost-core/llvmgen.osty:849:19
 	emitter.label = emitter.label + 1
 	return name
 }

--- a/testdata/backend/llvm_smoke/string_escape_print.osty
+++ b/testdata/backend/llvm_smoke/string_escape_print.osty
@@ -1,0 +1,3 @@
+fn main() {
+    println("line one\nquote \" slash \\")
+}


### PR DESCRIPTION
## Summary
- add selfhost-owned LLVM C-string escaping for `println` string constants
- support newline, tab, carriage return, quote, and backslash in ASCII string literals
- add `string_escape_print.osty` to the LLVM smoke corpus and update Phase 24 docs

## Verification
- `go test -count=1 ./internal/profile ./internal/llvmgen ./internal/backend ./internal/pipeline ./cmd/osty`
- `go run ./cmd/osty gen --backend llvm --emit llvm-ir testdata/backend/llvm_smoke/string_escape_print.osty`
- actual LLVM run smoke prints the escaped-string output
- `git diff --check`

Note: `go run ./cmd/osty test examples/selfhost-core/llvmgen_test.osty` reports the llvmgen test file itself as ok with 12 tests, then still exits 1 in the current selfhost-wide checker/generated Go path (`check.osty`/`ir.osty`).