### PR TITLE
llvm: allow string locals in println

### DIFF
--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -284,6 +284,10 @@ The initial helper package for this plan is `internal/backend`.
     Phase 24: `examples/selfhost-core/llvmgen.osty` owns newline, tab,
     carriage-return, quote, and backslash encoding for LLVM C strings, and the
     smoke corpus now includes `string_escape_print.osty`.
+26. Add the first local String value path. Done in Phase 25: String literals
+    lower to self-hosted `ptr` values that can be bound with immutable `let`
+    and later printed through identifiers, with `string_let_print.osty`
+    covering the executable smoke case.
 
 The backend subdirectory change should land before the LLVM backend writes any
 files, so LLVM never shares the old Go-only output location.

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -49,6 +49,7 @@ Each fixture should be independently checkable as a single file and avoid:
 | `testdata/backend/llvm_smoke/booleans.osty` | `7\n` | Phase 15 LLVM IR: Bool comparison, logical not/and, value-position if/else, phi |
 | `testdata/backend/llvm_smoke/string_print.osty` | `hello, osty\n` | Phase 23 LLVM IR: plain printable-ASCII `String` literal through `println` and module string constants |
 | `testdata/backend/llvm_smoke/string_escape_print.osty` | `line one\nquote " slash \\\n` | Phase 24 LLVM IR: escaped ASCII `String` literal through Osty-owned LLVM C-string encoding |
+| `testdata/backend/llvm_smoke/string_let_print.osty` | `stored string\n` | Phase 25 LLVM IR: immutable local `String` value bound from a literal and printed through an identifier |
 
 The Phase 10 skeleton behavior and the Phase 12-15 plus Phase 23-24 lowering
 behavior are mirrored in
@@ -104,6 +105,11 @@ constant encoding self-hosted. `examples/selfhost-core/llvmgen.osty` now maps
 newline, tab, carriage return, quote, and backslash into LLVM C-string escapes
 before appending the `println` newline and NUL terminator. The Go bridge still
 only rejects source outside the currently supported ASCII subset.
+
+Phase 25 promotes those string constants into the first local String value path.
+String literals lower to `ptr` values through generated Osty helpers, so an
+immutable `let msg = "..."` can bind the value and `println(msg)` can print the
+identifier without adding Go-owned LLVM instruction strings.
 
 ## Promotion Rules
 

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -22,12 +22,13 @@
 - Multi-file package, vendored dependency, workspace build의 실제 code emission은
   아직 제한이 있다. LLVM 전환 전에 package 단위 emit/link 모델을 분명히 해야
   한다.
-- 현재 Phase 24까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
+- 현재 Phase 25까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
   쪽으로 옮겨지고 있다. 여기에는 smoke IR builder, skeleton renderer,
   toolchain command plan, executable parity corpus, go-only diagnostic, 그리고
   unsupported source-shape taxonomy가 포함된다. 성공 경로의 scalar instruction
   strings, temp/label naming, plain/escaped ASCII `String` `println` module
-  constant shape도 같은 selfhost-core에서 생성한다.
+  constant shape, 그리고 첫 immutable local String value path도 같은
+  selfhost-core에서 생성한다.
 
 ## 이주 원칙
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ newline-separated `else`.
 - `--package NAME` — Go package clause for the emitted file (default: `main`)
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` emits textual `.ll` for the early scalar/control-flow/plain/escaped-string
-  subset and falls back to an inspectable skeleton for unsupported shapes with
-  Osty-authored instruction builders and category diagnostics)
+  subset, including immutable string locals, and falls back to an inspectable
+  skeleton for unsupported shapes with Osty-authored instruction builders and
+  category diagnostics)
 - `--emit MODE` — requested text artifact. `go` emits Go source for the Go
   backend; `llvm-ir` is reserved for the LLVM backend.
 
@@ -292,8 +293,8 @@ creating a new one.
 
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` can write textual IR for the early scalar/control-flow/plain/escaped-string
-  subset and, when `clang` is available, drive object/binary emission for
-  supported programs; unsupported shapes still prepare skeleton artifacts and report the
+  subset, including immutable string locals, and when `clang` is available,
+  drive object/binary emission for supported programs; unsupported shapes still prepare skeleton artifacts and report the
   missing lowering through categorized diagnostics generated from the Osty
   selfhost-core backend policy; supported scalar instruction strings are
   generated from that same backend core)

--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -674,6 +674,11 @@ pub fn llvmSmokeExecutableCorpus() -> List<LlvmSmokeExecutableCase> {
             fixture: "string_escape_print.osty",
             stdout: "line one\nquote \" slash \\\n",
         },
+        LlvmSmokeExecutableCase {
+            name: "string-let",
+            fixture: "string_let_print.osty",
+            stdout: "stored string\n",
+        },
     ]
 }
 
@@ -810,6 +815,23 @@ pub fn llvmSmokeStringEscapeIR(sourcePath: String) -> String {
     let main = llvmEmitter()
     let line = llvmStringLiteralLine(main, "line one\nquote \" slash \\")
     llvmPrintlnString(main, line)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobals(
+        sourcePath,
+        "",
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStringLetIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let msg = llvmStringLiteralLine(main, "stored string")
+    llvmImmutableLet(main, "msg", msg)
+    llvmPrintlnString(main, llvmIdent(main, "msg"))
     llvmReturnI32Zero(main)
 
     llvmRenderModuleWithGlobals(

--- a/examples/selfhost-core/llvmgen_test.osty
+++ b/examples/selfhost-core/llvmgen_test.osty
@@ -81,7 +81,7 @@ fn testLlvmToolchainPlanIsOstyOwned() {
 fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     let cases = llvmSmokeExecutableCorpus()
 
-    testing.assert(cases.len() == 6)
+    testing.assert(cases.len() == 7)
     testing.assert(cases[0].name == "minimal")
     testing.assert(cases[0].fixture == "minimal_print.osty")
     testing.assert(cases[0].stdout == "42\n")
@@ -100,6 +100,9 @@ fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     testing.assert(cases[5].name == "string-escape")
     testing.assert(cases[5].fixture == "string_escape_print.osty")
     testing.assert(cases[5].stdout == "line one\nquote \" slash \\\n")
+    testing.assert(cases[6].name == "string-let")
+    testing.assert(cases[6].fixture == "string_let_print.osty")
+    testing.assert(cases[6].stdout == "stored string\n")
 }
 
 fn testLlvmUnsupportedDiagnosticPolicyIsOstyOwned() {
@@ -217,6 +220,15 @@ fn testLlvmSmokeStringEscapeIsOstyOwned() {
     let ir = llvmSmokeStringEscapeIR("/tmp/string_escape_print.osty")
 
     assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [26 x i8] c\"line one\\0Aquote \\22 slash \\5C\\0A\\00\"")
+    assertLlvmContains(ir, "define i32 @main() \{")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.str0)")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmSmokeStringLetIsOstyOwned() {
+    let ir = llvmSmokeStringLetIR("/tmp/string_let_print.osty")
+
+    assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [15 x i8] c\"stored string\\0A\\00\"")
     assertLlvmContains(ir, "define i32 @main() \{")
     assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.str0)")
     assertLlvmContains(ir, "ret i32 0")

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -5,7 +5,8 @@
 // the same artifact/cache layout contract. LLVM lowering is still small, but it
 // can produce textual IR and drive a host clang toolchain for supported
 // object/binary artifacts. LLVM backend meaning, including scalar instruction
-// builders, plain/escaped ASCII string constants, and unsupported-source
-// diagnostic categories, is authored in Osty selfhost-core; this package
-// remains the bootstrap host shim for file I/O and process execution.
+// builders, plain/escaped ASCII string constants and local values, and
+// unsupported-source diagnostic categories, is authored in Osty selfhost-core;
+// this package remains the bootstrap host shim for file I/O and process
+// execution.
 package backend

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -2,8 +2,9 @@
 //
 // The first implementation is deliberately small: it supports no-arg main
 // functions or script files, integer println expressions, plain ASCII string
-// println literals with simple escapes, immutable scalar lets, mutable scalar
-// locals, simple Int/Bool helper functions, statement-position if/else,
+// println literals and local string values with simple escapes, immutable
+// scalar lets, mutable scalar locals, simple Int/Bool helper functions,
+// statement-position if/else,
 // value-position if/else, simple Bool logical operators, and inclusive/exclusive
 // Int range loops.
 // Unsupported shapes return ErrUnsupported so callers can fall back to

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -637,35 +637,36 @@ func (g *generator) emitPrintln(call *ast.CallExpr) error {
 	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 		return unsupported("call", "println requires one positional argument")
 	}
-	if lit, ok := call.Args[0].Value.(*ast.StringLit); ok {
-		return g.emitPrintlnString(lit)
-	}
 	v, err := g.emitExpr(call.Args[0].Value)
 	if err != nil {
 		return err
 	}
-	if v.typ != "i64" {
-		return unsupported("type-system", "println currently supports Int expressions and plain String literals only")
-	}
 	emitter := g.toOstyEmitter()
-	llvmPrintlnI64(emitter, toOstyValue(v))
+	switch v.typ {
+	case "i64":
+		llvmPrintlnI64(emitter, toOstyValue(v))
+	case "ptr":
+		llvmPrintlnString(emitter, toOstyValue(v))
+	default:
+		g.takeOstyEmitter(emitter)
+		return unsupported("type-system", "println currently supports Int expressions and plain String values only")
+	}
 	g.takeOstyEmitter(emitter)
 	return nil
 }
 
-func (g *generator) emitPrintlnString(lit *ast.StringLit) error {
+func (g *generator) emitStringLiteral(lit *ast.StringLit) (value, error) {
 	text, ok := plainStringLiteral(lit)
 	if !ok {
-		return unsupported("expression", "interpolated String literals are not supported by LLVM println")
+		return value{}, unsupported("expression", "interpolated String literals are not supported by LLVM")
 	}
 	if !isLLVMASCIIStringText(text) {
-		return unsupported("type-system", "plain String literals currently require ASCII text with printable bytes or newline, tab, and carriage-return escapes")
+		return value{}, unsupported("type-system", "plain String literals currently require ASCII text with printable bytes or newline, tab, and carriage-return escapes")
 	}
 	emitter := g.toOstyEmitter()
 	line := llvmStringLiteralLine(emitter, text)
-	llvmPrintlnString(emitter, line)
 	g.takeOstyEmitter(emitter)
-	return nil
+	return fromOstyValue(line), nil
 }
 
 func (g *generator) emitExpr(expr ast.Expr) (value, error) {
@@ -682,6 +683,8 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 			return value{typ: "i1", ref: "true"}, nil
 		}
 		return value{typ: "i1", ref: "false"}, nil
+	case *ast.StringLit:
+		return g.emitStringLiteral(e)
 	case *ast.Ident:
 		if v, ok := g.lookupLocal(e.Name); ok {
 			if v.ptr {

--- a/internal/llvmgen/osty_generated.go
+++ b/internal/llvmgen/osty_generated.go
@@ -891,187 +891,204 @@ func llvmUnsupportedSummary(diag *LlvmUnsupportedDiagnostic) string {
 
 // Osty: examples/selfhost-core/llvmgen.osty:645:5
 func llvmSmokeExecutableCorpus() []*LlvmSmokeExecutableCase {
-	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}}
+	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:680:5
+// Osty: examples/selfhost-core/llvmgen.osty:685:5
 func llvmSmokeMinimalPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:681:5
+	// Osty: examples/selfhost-core/llvmgen.osty:686:5
 	emitter := llvmEmitter()
 	_ = emitter
-	// Osty: examples/selfhost-core/llvmgen.osty:682:5
+	// Osty: examples/selfhost-core/llvmgen.osty:687:5
 	value := llvmBinaryI64(emitter, "add", llvmIntLiteral(40), llvmIntLiteral(2))
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:683:5
+	// Osty: examples/selfhost-core/llvmgen.osty:688:5
 	llvmPrintlnI64(emitter, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:684:5
+	// Osty: examples/selfhost-core/llvmgen.osty:689:5
 	llvmReturnI32Zero(emitter)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), emitter.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:694:5
+// Osty: examples/selfhost-core/llvmgen.osty:699:5
 func llvmSmokeScalarArithmeticIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:695:5
+	// Osty: examples/selfhost-core/llvmgen.osty:700:5
 	add := llvmEmitter()
 	_ = add
-	// Osty: examples/selfhost-core/llvmgen.osty:696:5
+	// Osty: examples/selfhost-core/llvmgen.osty:701:5
 	llvmBind(add, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:697:5
+	// Osty: examples/selfhost-core/llvmgen.osty:702:5
 	llvmBind(add, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:698:5
+	// Osty: examples/selfhost-core/llvmgen.osty:703:5
 	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
 	_ = sum
-	// Osty: examples/selfhost-core/llvmgen.osty:699:5
+	// Osty: examples/selfhost-core/llvmgen.osty:704:5
 	llvmReturn(add, sum)
-	// Osty: examples/selfhost-core/llvmgen.osty:701:5
+	// Osty: examples/selfhost-core/llvmgen.osty:706:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:702:5
+	// Osty: examples/selfhost-core/llvmgen.osty:707:5
 	value := llvmCall(main, "i64", "add", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:703:5
+	// Osty: examples/selfhost-core/llvmgen.osty:708:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: examples/selfhost-core/llvmgen.osty:704:5
+	// Osty: examples/selfhost-core/llvmgen.osty:709:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "value"), llvmIntLiteral(42))
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:705:5
+	// Osty: examples/selfhost-core/llvmgen.osty:710:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:706:5
+	// Osty: examples/selfhost-core/llvmgen.osty:711:5
 	llvmPrintlnI64(main, llvmIdent(main, "value"))
-	// Osty: examples/selfhost-core/llvmgen.osty:707:5
+	// Osty: examples/selfhost-core/llvmgen.osty:712:5
 	llvmIfElse(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:708:5
+	// Osty: examples/selfhost-core/llvmgen.osty:713:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:709:5
+	// Osty: examples/selfhost-core/llvmgen.osty:714:5
 	llvmIfEnd(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:710:5
+	// Osty: examples/selfhost-core/llvmgen.osty:715:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "add", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, add.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:730:5
+// Osty: examples/selfhost-core/llvmgen.osty:735:5
 func llvmSmokeControlFlowIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:731:5
+	// Osty: examples/selfhost-core/llvmgen.osty:736:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: examples/selfhost-core/llvmgen.osty:732:5
+	// Osty: examples/selfhost-core/llvmgen.osty:737:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: examples/selfhost-core/llvmgen.osty:733:5
+	// Osty: examples/selfhost-core/llvmgen.osty:738:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:734:5
+	// Osty: examples/selfhost-core/llvmgen.osty:739:5
 	loop := llvmInclusiveRangeStart(sumTo, "i", llvmIntLiteral(1), llvmIdent(sumTo, "n"))
 	_ = loop
-	// Osty: examples/selfhost-core/llvmgen.osty:735:5
+	// Osty: examples/selfhost-core/llvmgen.osty:740:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: examples/selfhost-core/llvmgen.osty:736:5
+	// Osty: examples/selfhost-core/llvmgen.osty:741:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: examples/selfhost-core/llvmgen.osty:737:5
+	// Osty: examples/selfhost-core/llvmgen.osty:742:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: examples/selfhost-core/llvmgen.osty:738:5
+	// Osty: examples/selfhost-core/llvmgen.osty:743:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: examples/selfhost-core/llvmgen.osty:740:5
+	// Osty: examples/selfhost-core/llvmgen.osty:745:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:741:5
+	// Osty: examples/selfhost-core/llvmgen.osty:746:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(5)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:742:5
+	// Osty: examples/selfhost-core/llvmgen.osty:747:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:743:5
+	// Osty: examples/selfhost-core/llvmgen.osty:748:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:755:5
+// Osty: examples/selfhost-core/llvmgen.osty:760:5
 func llvmSmokeBooleansIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:756:5
+	// Osty: examples/selfhost-core/llvmgen.osty:761:5
 	choose := llvmEmitter()
 	_ = choose
-	// Osty: examples/selfhost-core/llvmgen.osty:757:5
+	// Osty: examples/selfhost-core/llvmgen.osty:762:5
 	llvmBind(choose, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:758:5
+	// Osty: examples/selfhost-core/llvmgen.osty:763:5
 	llvmBind(choose, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:759:5
+	// Osty: examples/selfhost-core/llvmgen.osty:764:5
 	lt := llvmCompare(choose, "slt", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = lt
-	// Osty: examples/selfhost-core/llvmgen.osty:760:5
+	// Osty: examples/selfhost-core/llvmgen.osty:765:5
 	eqZero := llvmCompare(choose, "eq", llvmIdent(choose, "a"), llvmIntLiteral(0))
 	_ = eqZero
-	// Osty: examples/selfhost-core/llvmgen.osty:761:5
+	// Osty: examples/selfhost-core/llvmgen.osty:766:5
 	nonZero := llvmNotI1(choose, eqZero)
 	_ = nonZero
-	// Osty: examples/selfhost-core/llvmgen.osty:762:5
+	// Osty: examples/selfhost-core/llvmgen.osty:767:5
 	cond := llvmLogicalI1(choose, "and", lt, nonZero)
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:763:5
+	// Osty: examples/selfhost-core/llvmgen.osty:768:5
 	labels := llvmIfExprStart(choose, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:764:5
+	// Osty: examples/selfhost-core/llvmgen.osty:769:5
 	thenValue := llvmBinaryI64(choose, "sub", llvmIdent(choose, "b"), llvmIdent(choose, "a"))
 	_ = thenValue
-	// Osty: examples/selfhost-core/llvmgen.osty:765:5
+	// Osty: examples/selfhost-core/llvmgen.osty:770:5
 	llvmIfExprElse(choose, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:766:5
+	// Osty: examples/selfhost-core/llvmgen.osty:771:5
 	elseValue := llvmBinaryI64(choose, "add", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = elseValue
-	// Osty: examples/selfhost-core/llvmgen.osty:767:5
+	// Osty: examples/selfhost-core/llvmgen.osty:772:5
 	result := llvmIfExprEnd(choose, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: examples/selfhost-core/llvmgen.osty:768:5
+	// Osty: examples/selfhost-core/llvmgen.osty:773:5
 	llvmReturn(choose, result)
-	// Osty: examples/selfhost-core/llvmgen.osty:770:5
+	// Osty: examples/selfhost-core/llvmgen.osty:775:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:771:5
+	// Osty: examples/selfhost-core/llvmgen.osty:776:5
 	value := llvmCall(main, "i64", "choose", []*LlvmValue{llvmIntLiteral(3), llvmIntLiteral(10)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:772:5
+	// Osty: examples/selfhost-core/llvmgen.osty:777:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:773:5
+	// Osty: examples/selfhost-core/llvmgen.osty:778:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "choose", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, choose.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:793:5
+// Osty: examples/selfhost-core/llvmgen.osty:798:5
 func llvmSmokeStringPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:794:5
+	// Osty: examples/selfhost-core/llvmgen.osty:799:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:795:5
+	// Osty: examples/selfhost-core/llvmgen.osty:800:5
 	line := llvmStringLiteralLine(main, "hello, osty")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:796:5
+	// Osty: examples/selfhost-core/llvmgen.osty:801:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:797:5
+	// Osty: examples/selfhost-core/llvmgen.osty:802:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:809:5
+// Osty: examples/selfhost-core/llvmgen.osty:814:5
 func llvmSmokeStringEscapeIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:810:5
+	// Osty: examples/selfhost-core/llvmgen.osty:815:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:811:5
+	// Osty: examples/selfhost-core/llvmgen.osty:816:5
 	line := llvmStringLiteralLine(main, "line one\nquote \" slash \\")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:812:5
+	// Osty: examples/selfhost-core/llvmgen.osty:817:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:813:5
+	// Osty: examples/selfhost-core/llvmgen.osty:818:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:825:1
+// Osty: examples/selfhost-core/llvmgen.osty:830:5
+func llvmSmokeStringLetIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:831:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:832:5
+	msg := llvmStringLiteralLine(main, "stored string")
+	_ = msg
+	// Osty: examples/selfhost-core/llvmgen.osty:833:5
+	llvmImmutableLet(main, "msg", msg)
+	// Osty: examples/selfhost-core/llvmgen.osty:834:5
+	llvmPrintlnString(main, llvmIdent(main, "msg"))
+	// Osty: examples/selfhost-core/llvmgen.osty:835:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:847:1
 func llvmCallArgs(args []*LlvmValue) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:826:5
+	// Osty: examples/selfhost-core/llvmgen.osty:848:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:827:5
+	// Osty: examples/selfhost-core/llvmgen.osty:849:5
 	for _, arg := range args {
-		// Osty: examples/selfhost-core/llvmgen.osty:828:9
+		// Osty: examples/selfhost-core/llvmgen.osty:850:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %s", ostyToString(arg.typ), ostyToString(arg.name)))
 			return struct{}{}
@@ -1080,14 +1097,14 @@ func llvmCallArgs(args []*LlvmValue) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:833:1
+// Osty: examples/selfhost-core/llvmgen.osty:855:1
 func llvmParams(params []*LlvmParam) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:834:5
+	// Osty: examples/selfhost-core/llvmgen.osty:856:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:835:5
+	// Osty: examples/selfhost-core/llvmgen.osty:857:5
 	for _, param := range params {
-		// Osty: examples/selfhost-core/llvmgen.osty:836:9
+		// Osty: examples/selfhost-core/llvmgen.osty:858:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %%%s", ostyToString(param.typ), ostyToString(param.name)))
 			return struct{}{}
@@ -1096,22 +1113,22 @@ func llvmParams(params []*LlvmParam) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:841:1
+// Osty: examples/selfhost-core/llvmgen.osty:863:1
 func llvmNextTemp(emitter *LlvmEmitter) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:842:5
+	// Osty: examples/selfhost-core/llvmgen.osty:864:5
 	name := fmt.Sprintf("%%t%s", ostyToString(emitter.temp))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:843:18
+	// Osty: examples/selfhost-core/llvmgen.osty:865:18
 	emitter.temp = emitter.temp + 1
 	return name
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:847:1
+// Osty: examples/selfhost-core/llvmgen.osty:869:1
 func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:848:5
+	// Osty: examples/selfhost-core/llvmgen.osty:870:5
 	name := fmt.Sprintf("%s%s", ostyToString(prefix), ostyToString(emitter.label))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:849:19
+	// Osty: examples/selfhost-core/llvmgen.osty:871:19
 	emitter.label = emitter.label + 1
 	return name
 }

--- a/testdata/backend/llvm_smoke/string_let_print.osty
+++ b/testdata/backend/llvm_smoke/string_let_print.osty
@@ -1,0 +1,4 @@
+fn main() {
+    let msg = "stored string"
+    println(msg)
+}


### PR DESCRIPTION
## Summary
- lower plain ASCII `String` literals into reusable LLVM ptr values
- allow immutable string locals like `let msg = "..."` to flow into `println(msg)`
- add `string_let_print.osty` to the LLVM smoke corpus and update Phase 25 docs

## Verification
- `go test -count=1 ./internal/profile ./internal/llvmgen ./internal/backend ./internal/pipeline ./cmd/osty`
- `go run ./cmd/osty gen --backend llvm --emit llvm-ir testdata/backend/llvm_smoke/string_let_print.osty`
- actual LLVM run smoke prints `stored string`
- `git diff --check`

Note: `go run ./cmd/osty test examples/selfhost-core/llvmgen_test.osty` reports the llvmgen test file itself as ok with 13 tests, then still exits 1 in the current selfhost-wide checker/generated Go path (`check.osty`/`ir.osty`).