### PR TITLE
Stop selfhost path collecting Go descriptors

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -31,8 +31,8 @@ type Result struct {
 	// for types themselves it is a *Named or *Primitive.
 	SymTypes map[*resolve.Symbol]types.Type
 
-	// Descs maps struct/enum/interface/alias symbols to the collected
-	// declaration shape. Consumed by the Go transpiler to emit code.
+	// Descs maps struct/enum/interface/alias symbols to declaration
+	// shapes used by the legacy Go checker internals.
 	Descs map[*resolve.Symbol]*typeDesc
 
 	// Instantiations records the concrete type-argument list at every
@@ -69,9 +69,9 @@ func (r *Result) LookupType(e ast.Expr) types.Type {
 // Opts matches the legacy no-stdlib behavior.
 type Opts struct {
 	// UseSelfhost makes the bootstrapped Osty checker authoritative for
-	// checker diagnostics and expression/binding instantiation facts. The
-	// Go side only collects declaration shapes still consumed by gen, lint,
-	// and LSP features.
+	// checker diagnostics and expression/binding/instantiation facts. The
+	// Go side only bridges those facts onto resolver symbols and AST nodes
+	// still consumed by gen, lint, and LSP features.
 	UseSelfhost bool
 
 	// Source is the raw source for File when UseSelfhost is enabled.
@@ -149,11 +149,9 @@ func selfhostFile(f *ast.File, rr *resolve.Result, opt Opts) *Result {
 	c.indexPrimitiveMethods(opt.Primitives)
 	c.resultMethods = opt.ResultMethods
 	c.indexSymbolsFrom(rr)
-	for _, d := range f.Decls {
-		c.timedCollect(d)
-	}
 	applySelfhostFileResult(c.result, f, rr, opt.Source, opt.Stdlib)
-	c.recordSelfhostCheckPass(f)
+	c.recordSelfhostDeclPass(f, "collect")
+	c.recordSelfhostDeclPass(f, "check")
 	return c.result
 }
 
@@ -242,16 +240,10 @@ func selfhostPackage(pkg *resolve.Package, pr *resolve.PackageResult, opt Opts) 
 	for _, pf := range pkg.Files {
 		c.indexSymbolsFrom(fileResult(pf))
 	}
-	for _, pf := range pkg.Files {
-		c.file = pf.File
-		c.resolved = fileResult(pf)
-		for _, d := range pf.File.Decls {
-			c.timedCollect(d)
-		}
-	}
 	applySelfhostPackageResult(c.result, pkg, pr, nil, opt.Stdlib)
 	for _, pf := range pkg.Files {
-		c.recordSelfhostCheckPass(pf.File)
+		c.recordSelfhostDeclPass(pf.File, "collect")
+		c.recordSelfhostDeclPass(pf.File, "check")
 	}
 	return c.result
 }
@@ -441,15 +433,6 @@ func selfhostWorkspace(
 			c.indexSymbolsFrom(fileResult(pf))
 		}
 	}
-	for _, e := range walk {
-		for _, pf := range e.pkg.Files {
-			c.file = pf.File
-			c.resolved = fileResult(pf)
-			for _, d := range pf.File.Decls {
-				c.timedCollect(d)
-			}
-		}
-	}
 
 	out := map[string]*Result{}
 	for _, e := range walk {
@@ -464,7 +447,8 @@ func selfhostWorkspace(
 	applySelfhostWorkspaceResults(ws, resolved, out, opt.Stdlib)
 	for _, e := range walk {
 		for _, pf := range e.pkg.Files {
-			c.recordSelfhostCheckPass(pf.File)
+			c.recordSelfhostDeclPass(pf.File, "collect")
+			c.recordSelfhostDeclPass(pf.File, "check")
 		}
 	}
 	return out
@@ -934,12 +918,12 @@ func (c *checker) timedCheckDecl(d ast.Decl) {
 	c.onDecl(d, "check", time.Since(t0))
 }
 
-func (c *checker) recordSelfhostCheckPass(file *ast.File) {
+func (c *checker) recordSelfhostDeclPass(file *ast.File, phase string) {
 	if c.onDecl == nil || file == nil {
 		return
 	}
 	for _, d := range file.Decls {
-		c.onDecl(d, "check", 0)
+		c.onDecl(d, phase, 0)
 	}
 }
 

--- a/internal/check/selfhost_bridge.go
+++ b/internal/check/selfhost_bridge.go
@@ -190,6 +190,8 @@ func buildSelfhostSpanIndex(src selfhostCheckedSource) *selfhostSpanIndex {
 		for _, stmt := range file.file.Stmts {
 			idx.addNode(stmt, file.base, file.scope)
 		}
+		idx.addScopeTreeSymbols(file.scope, file.base)
+		idx.addTopLevelDeclSymbols(file.file, file.scope, file.base)
 		for _, sym := range file.refs {
 			idx.addSymbol(sym, file.base, file.scope)
 		}
@@ -217,6 +219,57 @@ func (idx *selfhostSpanIndex) scopeFor(key selfhostSpanKey) *resolve.Scope {
 		}
 	}
 	return best
+}
+
+func (idx *selfhostSpanIndex) addScopeTreeSymbols(scope *resolve.Scope, base int) {
+	if scope == nil {
+		return
+	}
+	for _, sym := range scope.Symbols() {
+		idx.addSymbol(sym, base, scope)
+	}
+	for _, child := range scope.Children() {
+		idx.addScopeTreeSymbols(child, base)
+	}
+}
+
+func (idx *selfhostSpanIndex) addTopLevelDeclSymbols(file *ast.File, scope *resolve.Scope, base int) {
+	if file == nil || scope == nil {
+		return
+	}
+	for _, decl := range file.Decls {
+		switch n := decl.(type) {
+		case *ast.FnDecl:
+			idx.addVisibleSymbolForNode(scope, n.Name, n, base)
+		case *ast.StructDecl:
+			idx.addVisibleSymbolForNode(scope, n.Name, n, base)
+		case *ast.EnumDecl:
+			idx.addVisibleSymbolForNode(scope, n.Name, n, base)
+			for _, variant := range n.Variants {
+				idx.addVisibleSymbolForNode(scope, variant.Name, variant, base)
+			}
+		case *ast.InterfaceDecl:
+			idx.addVisibleSymbolForNode(scope, n.Name, n, base)
+		case *ast.TypeAliasDecl:
+			idx.addVisibleSymbolForNode(scope, n.Name, n, base)
+		case *ast.LetDecl:
+			idx.addVisibleSymbolForNode(scope, n.Name, n, base)
+		}
+	}
+}
+
+func (idx *selfhostSpanIndex) addVisibleSymbolForNode(scope *resolve.Scope, name string, node ast.Node, base int) {
+	if name == "" || node == nil {
+		return
+	}
+	for cur := scope; cur != nil; cur = cur.Parent() {
+		sym := cur.LookupLocal(name)
+		if sym == nil {
+			continue
+		}
+		idx.addSymbolForNode(sym, node, name, base, scope)
+		return
+	}
 }
 
 func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope) {
@@ -626,11 +679,18 @@ func (idx *selfhostSpanIndex) addSymbol(sym *resolve.Symbol, base int, scope *re
 	if sym == nil || sym.Decl == nil || sym.Name == "" {
 		return
 	}
-	key, ok := spanKeyForNode(sym.Decl, base)
+	idx.addSymbolForNode(sym, sym.Decl, sym.Name, base, scope)
+}
+
+func (idx *selfhostSpanIndex) addSymbolForNode(sym *resolve.Symbol, node ast.Node, name string, base int, scope *resolve.Scope) {
+	if sym == nil || node == nil || name == "" {
+		return
+	}
+	key, ok := spanKeyForNode(node, base)
 	if !ok {
 		return
 	}
-	idx.symbols[selfhostNameSpanKey{selfhostSpanKey: key, name: sym.Name}] = sym
+	idx.symbols[selfhostNameSpanKey{selfhostSpanKey: key, name: name}] = sym
 	if _, ok := idx.scopes[key]; !ok {
 		idx.scopes[key] = scope
 	}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -56,9 +56,23 @@ func (r Result[T, E]) unwrap() T {
 	return r.Value
 }
 
+func (r Result[T, E]) expect(msg string) T {
+	if !r.IsOk {
+		panic(msg)
+	}
+	return r.Value
+}
+
 func (r Result[T, E]) unwrapErr() E {
 	if r.IsOk {
 		panic("called unwrapErr on Ok")
+	}
+	return r.Error
+}
+
+func (r Result[T, E]) expectErr(msg string) E {
+	if r.IsOk {
+		panic(msg)
 	}
 	return r.Error
 }
@@ -68,6 +82,13 @@ func (r Result[T, E]) unwrapOr(fallback T) T {
 		return r.Value
 	}
 	return fallback
+}
+
+func (r Result[T, E]) unwrapOrElse(fallback func(E) T) T {
+	if r.IsOk {
+		return r.Value
+	}
+	return fallback(r.Error)
 }
 
 func (r Result[T, E]) ok() *T {
@@ -89,6 +110,48 @@ func (r Result[T, E]) toString() string {
 		return "Ok(" + ostyToString(r.Value) + ")"
 	}
 	return "Err(" + ostyToString(r.Error) + ")"
+}
+
+func (r Result[T, E]) inspect(f func(T)) Result[T, E] {
+	if r.IsOk {
+		f(r.Value)
+	}
+	return r
+}
+
+func (r Result[T, E]) inspectErr(f func(E)) Result[T, E] {
+	if !r.IsOk {
+		f(r.Error)
+	}
+	return r
+}
+
+func resultAnd[T any, E any, U any](r Result[T, E], other Result[U, E]) Result[U, E] {
+	if r.IsOk {
+		return other
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultAndThen[T any, E any, U any](r Result[T, E], f func(T) Result[U, E]) Result[U, E] {
+	if r.IsOk {
+		return f(r.Value)
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultOr[T any, E any, F any](r Result[T, E], other Result[T, F]) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return other
+}
+
+func resultOrElse[T any, E any, F any](r Result[T, E], f func(E) Result[T, F]) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return f(r.Error)
 }
 
 func resultMap[T any, E any, U any](r Result[T, E], f func(T) U) Result[U, E] {


### PR DESCRIPTION
## Summary
- remove the Go declaration collect pass from UseSelfhost file/package/workspace paths
- index resolver scope and top-level declaration symbols in the selfhost bridge so selfhost CheckedSymbol facts still populate SymTypes
- refresh generated selfhost Result helpers so go generate stays in sync with current stdlib surfaces

## Verification
- gofmt -l $(git ls-files '*.go')
- git diff --check
- go test -vet=off ./...
- go vet ./...
- go generate ./internal/selfhost
- go build -o $(mktemp -d)/osty ./cmd/osty && $(mktemp -d)/osty ci .