### PR TITLE
llvm: extend string values through functions

### DIFF
--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -291,6 +291,14 @@ The initial helper package for this plan is `internal/backend`.
 27. Split String value constants from `println` formatting. Done in Phase 26:
     string literals now emit NUL-terminated value constants, while
     `llvmPrintlnString` owns the `@.fmt_str` newline formatting call.
+28. Add String return values. Done in Phase 27: `String` lowers to `ptr` in
+    function signatures, so String literals can be returned and printed from a
+    function call.
+29. Add String parameters. Done in Phase 28: `String` arguments and parameters
+    use the same `ptr` value path through generated self-hosted call builders.
+30. Add mutable String locals. Done in Phase 29: mutable `String` slots use
+    `alloca ptr`, `store ptr`, and `load ptr` through the existing Osty-owned
+    mutable local helpers.
 
 The backend subdirectory change should land before the LLVM backend writes any
 files, so LLVM never shares the old Go-only output location.

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -49,6 +49,9 @@ Each fixture should be independently checkable as a single file and avoid:
 | `testdata/backend/llvm_smoke/string_print.osty` | `hello, osty\n` | Phase 23 LLVM IR: plain printable-ASCII `String` literal through `println` and module string constants |
 | `testdata/backend/llvm_smoke/string_escape_print.osty` | `line one\nquote " slash \\\n` | Phase 24 LLVM IR: escaped ASCII `String` literal through Osty-owned LLVM C-string encoding |
 | `testdata/backend/llvm_smoke/string_let_print.osty` | `stored string\n` | Phase 25 LLVM IR: immutable local `String` value bound from a literal and printed through an identifier |
+| `testdata/backend/llvm_smoke/string_return_print.osty` | `from function\n` | Phase 27 LLVM IR: `String` return type lowered to `ptr` and printed from a function call |
+| `testdata/backend/llvm_smoke/string_param_print.osty` | `param string\n` | Phase 28 LLVM IR: `String` parameter and argument passing through helper calls |
+| `testdata/backend/llvm_smoke/string_mut_print.osty` | `after\n` | Phase 29 LLVM IR: mutable local `String` slot, assignment, load, and print |
 
 The Phase 10 skeleton behavior and the Phase 12-15 plus Phase 23-24 lowering
 behavior are mirrored in
@@ -114,6 +117,12 @@ produce NUL-terminated constants without a baked-in newline, and
 `llvmPrintlnString` uses the Osty-owned `@.fmt_str` format constant to add the
 line ending at print time. This keeps local String values usable for later
 non-print lowering phases.
+
+Phases 27-29 expand that corrected String value shape across simple function
+boundaries and mutable locals. The bridge now lowers the `String` type to
+`ptr`, so String-returning functions, String parameters, and mutable String
+slots can reuse the existing self-hosted call, return, load, store, and print
+builders.
 
 ## Promotion Rules
 

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -22,13 +22,14 @@
 - Multi-file package, vendored dependency, workspace build의 실제 code emission은
   아직 제한이 있다. LLVM 전환 전에 package 단위 emit/link 모델을 분명히 해야
   한다.
-- 현재 Phase 26까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
+- 현재 Phase 29까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
   쪽으로 옮겨지고 있다. 여기에는 smoke IR builder, skeleton renderer,
   toolchain command plan, executable parity corpus, go-only diagnostic, 그리고
   unsupported source-shape taxonomy가 포함된다. 성공 경로의 scalar instruction
   strings, temp/label naming, plain/escaped ASCII `String` `println` module
-  constant/formatting shape, 그리고 첫 immutable local String value path도 같은
-  selfhost-core에서 생성한다.
+  constant/formatting shape, immutable/mutable local String value paths, and
+  simple String function return/parameter paths도 같은 selfhost-core에서
+  생성한다.
 
 ## 이주 원칙
 

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ newline-separated `else`.
 - `--package NAME` — Go package clause for the emitted file (default: `main`)
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` emits textual `.ll` for the early scalar/control-flow/plain/escaped
-  string subset, including immutable string locals, and falls back to an
-  inspectable skeleton for unsupported shapes with Osty-authored instruction
-  builders and category diagnostics)
+  string subset, including immutable/mutable string locals and simple String
+  function boundaries, and falls back to an inspectable skeleton for unsupported
+  shapes with Osty-authored instruction builders and category diagnostics)
 - `--emit MODE` — requested text artifact. `go` emits Go source for the Go
   backend; `llvm-ir` is reserved for the LLVM backend.
 
@@ -293,12 +293,12 @@ creating a new one.
 
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` can write textual IR for the early scalar/control-flow/plain/escaped
-  string subset, including immutable string locals, and when `clang` is
-  available, drive object/binary emission for supported programs; unsupported
-  shapes still prepare skeleton artifacts and report the missing lowering
-  through categorized diagnostics generated from the Osty selfhost-core backend
-  policy; supported scalar instruction strings are generated from that same
-  backend core)
+  string subset, including immutable/mutable string locals and simple String
+  function boundaries, and when `clang` is available, drive object/binary
+  emission for supported programs; unsupported shapes still prepare skeleton
+  artifacts and report the missing lowering through categorized diagnostics
+  generated from the Osty selfhost-core backend policy; supported scalar
+  instruction strings are generated from that same backend core)
 - `--emit MODE` — requested artifact mode (`go`, `llvm-ir`, `object`, or
   `binary`). `build --emit go` writes inspectable Go without linking a binary;
   `build --backend llvm --emit object|binary` uses `clang`; `run` and `test`

--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -680,6 +680,21 @@ pub fn llvmSmokeExecutableCorpus() -> List<LlvmSmokeExecutableCase> {
             fixture: "string_let_print.osty",
             stdout: "stored string\n",
         },
+        LlvmSmokeExecutableCase {
+            name: "string-return",
+            fixture: "string_return_print.osty",
+            stdout: "from function\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "string-param",
+            fixture: "string_param_print.osty",
+            stdout: "param string\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "string-mut",
+            fixture: "string_mut_print.osty",
+            stdout: "after\n",
+        },
     ]
 }
 
@@ -832,6 +847,63 @@ pub fn llvmSmokeStringLetIR(sourcePath: String) -> String {
     let main = llvmEmitter()
     let msg = llvmStringLiteral(main, "stored string")
     llvmImmutableLet(main, "msg", msg)
+    llvmPrintlnString(main, llvmIdent(main, "msg"))
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobals(
+        sourcePath,
+        "",
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStringReturnIR(sourcePath: String) -> String {
+    let greet = llvmEmitter()
+    llvmReturn(greet, llvmStringLiteral(greet, "from function"))
+
+    let main = llvmEmitter()
+    llvmPrintlnString(main, llvmCall(main, "ptr", "greet", []))
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobals(
+        sourcePath,
+        "",
+        greet.stringGlobals,
+        [
+            llvmRenderFunction("ptr", "greet", [], greet.body),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStringParamIR(sourcePath: String) -> String {
+    let echo = llvmEmitter()
+    llvmBind(echo, "msg", LlvmValue { typ: "ptr", name: "%msg", pointer: false })
+    llvmReturn(echo, llvmIdent(echo, "msg"))
+
+    let main = llvmEmitter()
+    let value = llvmCall(main, "ptr", "echo", [llvmStringLiteral(main, "param string")])
+    llvmPrintlnString(main, value)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobals(
+        sourcePath,
+        "",
+        main.stringGlobals,
+        [
+            llvmRenderFunction("ptr", "echo", [llvmParam("msg", "ptr")], echo.body),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStringMutableIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    llvmMutableLet(main, "msg", llvmStringLiteral(main, "before"))
+    let _ = llvmAssign(main, "msg", llvmStringLiteral(main, "after"))
     llvmPrintlnString(main, llvmIdent(main, "msg"))
     llvmReturnI32Zero(main)
 

--- a/examples/selfhost-core/llvmgen_test.osty
+++ b/examples/selfhost-core/llvmgen_test.osty
@@ -81,7 +81,7 @@ fn testLlvmToolchainPlanIsOstyOwned() {
 fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     let cases = llvmSmokeExecutableCorpus()
 
-    testing.assert(cases.len() == 7)
+    testing.assert(cases.len() == 10)
     testing.assert(cases[0].name == "minimal")
     testing.assert(cases[0].fixture == "minimal_print.osty")
     testing.assert(cases[0].stdout == "42\n")
@@ -103,6 +103,15 @@ fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     testing.assert(cases[6].name == "string-let")
     testing.assert(cases[6].fixture == "string_let_print.osty")
     testing.assert(cases[6].stdout == "stored string\n")
+    testing.assert(cases[7].name == "string-return")
+    testing.assert(cases[7].fixture == "string_return_print.osty")
+    testing.assert(cases[7].stdout == "from function\n")
+    testing.assert(cases[8].name == "string-param")
+    testing.assert(cases[8].fixture == "string_param_print.osty")
+    testing.assert(cases[8].stdout == "param string\n")
+    testing.assert(cases[9].name == "string-mut")
+    testing.assert(cases[9].fixture == "string_mut_print.osty")
+    testing.assert(cases[9].stdout == "after\n")
 }
 
 fn testLlvmUnsupportedDiagnosticPolicyIsOstyOwned() {
@@ -233,4 +242,35 @@ fn testLlvmSmokeStringLetIsOstyOwned() {
     assertLlvmContains(ir, "define i32 @main() \{")
     assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr @.str0)")
     assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmSmokeStringReturnIsOstyOwned() {
+    let ir = llvmSmokeStringReturnIR("/tmp/string_return_print.osty")
+
+    assertLlvmContains(ir, "define ptr @greet() \{")
+    assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [14 x i8] c\"from function\\00\"")
+    assertLlvmContains(ir, "ret ptr @.str0")
+    assertLlvmContains(ir, "%t0 = call ptr @greet()")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %t0)")
+}
+
+fn testLlvmSmokeStringParamIsOstyOwned() {
+    let ir = llvmSmokeStringParamIR("/tmp/string_param_print.osty")
+
+    assertLlvmContains(ir, "define ptr @echo(ptr %msg) \{")
+    assertLlvmContains(ir, "ret ptr %msg")
+    assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [13 x i8] c\"param string\\00\"")
+    assertLlvmContains(ir, "%t0 = call ptr @echo(ptr @.str0)")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %t0)")
+}
+
+fn testLlvmSmokeStringMutableIsOstyOwned() {
+    let ir = llvmSmokeStringMutableIR("/tmp/string_mut_print.osty")
+
+    assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [7 x i8] c\"before\\00\"")
+    assertLlvmContains(ir, "@.str1 = private unnamed_addr constant [6 x i8] c\"after\\00\"")
+    assertLlvmContains(ir, "alloca ptr")
+    assertLlvmContains(ir, "store ptr @.str1")
+    assertLlvmContains(ir, "load ptr")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str")
 }

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -5,8 +5,8 @@
 // the same artifact/cache layout contract. LLVM lowering is still small, but it
 // can produce textual IR and drive a host clang toolchain for supported
 // object/binary artifacts. LLVM backend meaning, including scalar instruction
-// builders, plain/escaped ASCII string constants and local values, and
-// unsupported-source diagnostic categories, is authored in Osty selfhost-core;
-// this package remains the bootstrap host shim for file I/O and process
-// execution.
+// builders, plain/escaped ASCII string constants/local values/function values,
+// and unsupported-source diagnostic categories, is authored in Osty
+// selfhost-core; this package remains the bootstrap host shim for file I/O and
+// process execution.
 package backend

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -2,10 +2,11 @@
 //
 // The first implementation is deliberately small: it supports no-arg main
 // functions or script files, integer println expressions, plain ASCII string
-// println literals and local string values with simple escapes, immutable
-// scalar lets, mutable scalar locals, simple Int/Bool helper functions,
-// statement-position if/else, value-position if/else, simple Bool logical
-// operators, and inclusive/exclusive Int range loops.
+// println literals, local string values with simple escapes, simple String
+// returns/parameters, immutable scalar lets, mutable scalar locals, simple
+// Int/Bool helper functions, statement-position if/else, value-position
+// if/else, simple Bool logical operators, and inclusive/exclusive Int range
+// loops.
 // Unsupported shapes return ErrUnsupported so callers can fall back to
 // inspectable skeleton IR while the backend grows. The module/function/skeleton
 // renderers, scalar/string instruction builders, LLVM toolchain command plans,

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1072,6 +1072,8 @@ func llvmType(t ast.Type) (string, error) {
 		return "i64", nil
 	case "Bool":
 		return "i1", nil
+	case "String":
+		return "ptr", nil
 	default:
 		return "", unsupportedf("type-system", "type %q", strings.Join(named.Path, "."))
 	}

--- a/internal/llvmgen/osty_generated.go
+++ b/internal/llvmgen/osty_generated.go
@@ -896,204 +896,259 @@ func llvmUnsupportedSummary(diag *LlvmUnsupportedDiagnostic) string {
 
 // Osty: examples/selfhost-core/llvmgen.osty:646:5
 func llvmSmokeExecutableCorpus() []*LlvmSmokeExecutableCase {
-	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}}
+	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}, &LlvmSmokeExecutableCase{name: "string-return", fixture: "string_return_print.osty", stdout: "from function\n"}, &LlvmSmokeExecutableCase{name: "string-param", fixture: "string_param_print.osty", stdout: "param string\n"}, &LlvmSmokeExecutableCase{name: "string-mut", fixture: "string_mut_print.osty", stdout: "after\n"}}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:686:5
+// Osty: examples/selfhost-core/llvmgen.osty:701:5
 func llvmSmokeMinimalPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:687:5
+	// Osty: examples/selfhost-core/llvmgen.osty:702:5
 	emitter := llvmEmitter()
 	_ = emitter
-	// Osty: examples/selfhost-core/llvmgen.osty:688:5
+	// Osty: examples/selfhost-core/llvmgen.osty:703:5
 	value := llvmBinaryI64(emitter, "add", llvmIntLiteral(40), llvmIntLiteral(2))
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:689:5
+	// Osty: examples/selfhost-core/llvmgen.osty:704:5
 	llvmPrintlnI64(emitter, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:690:5
+	// Osty: examples/selfhost-core/llvmgen.osty:705:5
 	llvmReturnI32Zero(emitter)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), emitter.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:700:5
+// Osty: examples/selfhost-core/llvmgen.osty:715:5
 func llvmSmokeScalarArithmeticIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:701:5
+	// Osty: examples/selfhost-core/llvmgen.osty:716:5
 	add := llvmEmitter()
 	_ = add
-	// Osty: examples/selfhost-core/llvmgen.osty:702:5
+	// Osty: examples/selfhost-core/llvmgen.osty:717:5
 	llvmBind(add, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:703:5
+	// Osty: examples/selfhost-core/llvmgen.osty:718:5
 	llvmBind(add, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:704:5
+	// Osty: examples/selfhost-core/llvmgen.osty:719:5
 	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
 	_ = sum
-	// Osty: examples/selfhost-core/llvmgen.osty:705:5
+	// Osty: examples/selfhost-core/llvmgen.osty:720:5
 	llvmReturn(add, sum)
-	// Osty: examples/selfhost-core/llvmgen.osty:707:5
+	// Osty: examples/selfhost-core/llvmgen.osty:722:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:708:5
+	// Osty: examples/selfhost-core/llvmgen.osty:723:5
 	value := llvmCall(main, "i64", "add", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:709:5
+	// Osty: examples/selfhost-core/llvmgen.osty:724:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: examples/selfhost-core/llvmgen.osty:710:5
+	// Osty: examples/selfhost-core/llvmgen.osty:725:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "value"), llvmIntLiteral(42))
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:711:5
+	// Osty: examples/selfhost-core/llvmgen.osty:726:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:712:5
+	// Osty: examples/selfhost-core/llvmgen.osty:727:5
 	llvmPrintlnI64(main, llvmIdent(main, "value"))
-	// Osty: examples/selfhost-core/llvmgen.osty:713:5
+	// Osty: examples/selfhost-core/llvmgen.osty:728:5
 	llvmIfElse(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:714:5
+	// Osty: examples/selfhost-core/llvmgen.osty:729:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:715:5
+	// Osty: examples/selfhost-core/llvmgen.osty:730:5
 	llvmIfEnd(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:716:5
+	// Osty: examples/selfhost-core/llvmgen.osty:731:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "add", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, add.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:736:5
+// Osty: examples/selfhost-core/llvmgen.osty:751:5
 func llvmSmokeControlFlowIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:737:5
+	// Osty: examples/selfhost-core/llvmgen.osty:752:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: examples/selfhost-core/llvmgen.osty:738:5
+	// Osty: examples/selfhost-core/llvmgen.osty:753:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: examples/selfhost-core/llvmgen.osty:739:5
+	// Osty: examples/selfhost-core/llvmgen.osty:754:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:740:5
+	// Osty: examples/selfhost-core/llvmgen.osty:755:5
 	loop := llvmInclusiveRangeStart(sumTo, "i", llvmIntLiteral(1), llvmIdent(sumTo, "n"))
 	_ = loop
-	// Osty: examples/selfhost-core/llvmgen.osty:741:5
+	// Osty: examples/selfhost-core/llvmgen.osty:756:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: examples/selfhost-core/llvmgen.osty:742:5
+	// Osty: examples/selfhost-core/llvmgen.osty:757:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: examples/selfhost-core/llvmgen.osty:743:5
+	// Osty: examples/selfhost-core/llvmgen.osty:758:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: examples/selfhost-core/llvmgen.osty:744:5
+	// Osty: examples/selfhost-core/llvmgen.osty:759:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: examples/selfhost-core/llvmgen.osty:746:5
+	// Osty: examples/selfhost-core/llvmgen.osty:761:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:747:5
+	// Osty: examples/selfhost-core/llvmgen.osty:762:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(5)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:748:5
+	// Osty: examples/selfhost-core/llvmgen.osty:763:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:749:5
+	// Osty: examples/selfhost-core/llvmgen.osty:764:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:761:5
+// Osty: examples/selfhost-core/llvmgen.osty:776:5
 func llvmSmokeBooleansIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:762:5
+	// Osty: examples/selfhost-core/llvmgen.osty:777:5
 	choose := llvmEmitter()
 	_ = choose
-	// Osty: examples/selfhost-core/llvmgen.osty:763:5
+	// Osty: examples/selfhost-core/llvmgen.osty:778:5
 	llvmBind(choose, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:764:5
+	// Osty: examples/selfhost-core/llvmgen.osty:779:5
 	llvmBind(choose, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:765:5
+	// Osty: examples/selfhost-core/llvmgen.osty:780:5
 	lt := llvmCompare(choose, "slt", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = lt
-	// Osty: examples/selfhost-core/llvmgen.osty:766:5
+	// Osty: examples/selfhost-core/llvmgen.osty:781:5
 	eqZero := llvmCompare(choose, "eq", llvmIdent(choose, "a"), llvmIntLiteral(0))
 	_ = eqZero
-	// Osty: examples/selfhost-core/llvmgen.osty:767:5
+	// Osty: examples/selfhost-core/llvmgen.osty:782:5
 	nonZero := llvmNotI1(choose, eqZero)
 	_ = nonZero
-	// Osty: examples/selfhost-core/llvmgen.osty:768:5
+	// Osty: examples/selfhost-core/llvmgen.osty:783:5
 	cond := llvmLogicalI1(choose, "and", lt, nonZero)
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:769:5
+	// Osty: examples/selfhost-core/llvmgen.osty:784:5
 	labels := llvmIfExprStart(choose, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:770:5
+	// Osty: examples/selfhost-core/llvmgen.osty:785:5
 	thenValue := llvmBinaryI64(choose, "sub", llvmIdent(choose, "b"), llvmIdent(choose, "a"))
 	_ = thenValue
-	// Osty: examples/selfhost-core/llvmgen.osty:771:5
+	// Osty: examples/selfhost-core/llvmgen.osty:786:5
 	llvmIfExprElse(choose, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:772:5
+	// Osty: examples/selfhost-core/llvmgen.osty:787:5
 	elseValue := llvmBinaryI64(choose, "add", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = elseValue
-	// Osty: examples/selfhost-core/llvmgen.osty:773:5
+	// Osty: examples/selfhost-core/llvmgen.osty:788:5
 	result := llvmIfExprEnd(choose, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: examples/selfhost-core/llvmgen.osty:774:5
+	// Osty: examples/selfhost-core/llvmgen.osty:789:5
 	llvmReturn(choose, result)
-	// Osty: examples/selfhost-core/llvmgen.osty:776:5
+	// Osty: examples/selfhost-core/llvmgen.osty:791:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:777:5
+	// Osty: examples/selfhost-core/llvmgen.osty:792:5
 	value := llvmCall(main, "i64", "choose", []*LlvmValue{llvmIntLiteral(3), llvmIntLiteral(10)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:778:5
+	// Osty: examples/selfhost-core/llvmgen.osty:793:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:779:5
+	// Osty: examples/selfhost-core/llvmgen.osty:794:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "choose", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, choose.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:799:5
+// Osty: examples/selfhost-core/llvmgen.osty:814:5
 func llvmSmokeStringPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:800:5
+	// Osty: examples/selfhost-core/llvmgen.osty:815:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:801:5
+	// Osty: examples/selfhost-core/llvmgen.osty:816:5
 	line := llvmStringLiteral(main, "hello, osty")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:802:5
+	// Osty: examples/selfhost-core/llvmgen.osty:817:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:803:5
+	// Osty: examples/selfhost-core/llvmgen.osty:818:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:815:5
+// Osty: examples/selfhost-core/llvmgen.osty:830:5
 func llvmSmokeStringEscapeIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:816:5
+	// Osty: examples/selfhost-core/llvmgen.osty:831:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:817:5
+	// Osty: examples/selfhost-core/llvmgen.osty:832:5
 	line := llvmStringLiteral(main, "line one\nquote \" slash \\")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:818:5
+	// Osty: examples/selfhost-core/llvmgen.osty:833:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:819:5
+	// Osty: examples/selfhost-core/llvmgen.osty:834:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:831:5
+// Osty: examples/selfhost-core/llvmgen.osty:846:5
 func llvmSmokeStringLetIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:832:5
+	// Osty: examples/selfhost-core/llvmgen.osty:847:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:833:5
+	// Osty: examples/selfhost-core/llvmgen.osty:848:5
 	msg := llvmStringLiteral(main, "stored string")
 	_ = msg
-	// Osty: examples/selfhost-core/llvmgen.osty:834:5
+	// Osty: examples/selfhost-core/llvmgen.osty:849:5
 	llvmImmutableLet(main, "msg", msg)
-	// Osty: examples/selfhost-core/llvmgen.osty:835:5
+	// Osty: examples/selfhost-core/llvmgen.osty:850:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: examples/selfhost-core/llvmgen.osty:836:5
+	// Osty: examples/selfhost-core/llvmgen.osty:851:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:848:1
+// Osty: examples/selfhost-core/llvmgen.osty:863:5
+func llvmSmokeStringReturnIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:864:5
+	greet := llvmEmitter()
+	_ = greet
+	// Osty: examples/selfhost-core/llvmgen.osty:865:5
+	llvmReturn(greet, llvmStringLiteral(greet, "from function"))
+	// Osty: examples/selfhost-core/llvmgen.osty:867:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:868:5
+	llvmPrintlnString(main, llvmCall(main, "ptr", "greet", make([]*LlvmValue, 0, 1)))
+	// Osty: examples/selfhost-core/llvmgen.osty:869:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobals(sourcePath, "", greet.stringGlobals, []string{llvmRenderFunction("ptr", "greet", make([]*LlvmParam, 0, 1), greet.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:882:5
+func llvmSmokeStringParamIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:883:5
+	echo := llvmEmitter()
+	_ = echo
+	// Osty: examples/selfhost-core/llvmgen.osty:884:5
+	llvmBind(echo, "msg", &LlvmValue{typ: "ptr", name: "%msg", pointer: false})
+	// Osty: examples/selfhost-core/llvmgen.osty:885:5
+	llvmReturn(echo, llvmIdent(echo, "msg"))
+	// Osty: examples/selfhost-core/llvmgen.osty:887:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:888:5
+	value := llvmCall(main, "ptr", "echo", []*LlvmValue{llvmStringLiteral(main, "param string")})
+	_ = value
+	// Osty: examples/selfhost-core/llvmgen.osty:889:5
+	llvmPrintlnString(main, value)
+	// Osty: examples/selfhost-core/llvmgen.osty:890:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("ptr", "echo", []*LlvmParam{llvmParam("msg", "ptr")}, echo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:903:5
+func llvmSmokeStringMutableIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:904:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:905:5
+	llvmMutableLet(main, "msg", llvmStringLiteral(main, "before"))
+	// Osty: examples/selfhost-core/llvmgen.osty:906:5
+	_ = llvmAssign(main, "msg", llvmStringLiteral(main, "after"))
+	// Osty: examples/selfhost-core/llvmgen.osty:907:5
+	llvmPrintlnString(main, llvmIdent(main, "msg"))
+	// Osty: examples/selfhost-core/llvmgen.osty:908:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:920:1
 func llvmCallArgs(args []*LlvmValue) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:849:5
+	// Osty: examples/selfhost-core/llvmgen.osty:921:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:850:5
+	// Osty: examples/selfhost-core/llvmgen.osty:922:5
 	for _, arg := range args {
-		// Osty: examples/selfhost-core/llvmgen.osty:851:9
+		// Osty: examples/selfhost-core/llvmgen.osty:923:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %s", ostyToString(arg.typ), ostyToString(arg.name)))
 			return struct{}{}
@@ -1102,14 +1157,14 @@ func llvmCallArgs(args []*LlvmValue) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:856:1
+// Osty: examples/selfhost-core/llvmgen.osty:928:1
 func llvmParams(params []*LlvmParam) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:857:5
+	// Osty: examples/selfhost-core/llvmgen.osty:929:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:858:5
+	// Osty: examples/selfhost-core/llvmgen.osty:930:5
 	for _, param := range params {
-		// Osty: examples/selfhost-core/llvmgen.osty:859:9
+		// Osty: examples/selfhost-core/llvmgen.osty:931:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %%%s", ostyToString(param.typ), ostyToString(param.name)))
 			return struct{}{}
@@ -1118,22 +1173,22 @@ func llvmParams(params []*LlvmParam) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:864:1
+// Osty: examples/selfhost-core/llvmgen.osty:936:1
 func llvmNextTemp(emitter *LlvmEmitter) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:865:5
+	// Osty: examples/selfhost-core/llvmgen.osty:937:5
 	name := fmt.Sprintf("%%t%s", ostyToString(emitter.temp))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:866:18
+	// Osty: examples/selfhost-core/llvmgen.osty:938:18
 	emitter.temp = emitter.temp + 1
 	return name
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:870:1
+// Osty: examples/selfhost-core/llvmgen.osty:942:1
 func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:871:5
+	// Osty: examples/selfhost-core/llvmgen.osty:943:5
 	name := fmt.Sprintf("%s%s", ostyToString(prefix), ostyToString(emitter.label))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:872:19
+	// Osty: examples/selfhost-core/llvmgen.osty:944:19
 	emitter.label = emitter.label + 1
 	return name
 }

--- a/testdata/backend/llvm_smoke/string_mut_print.osty
+++ b/testdata/backend/llvm_smoke/string_mut_print.osty
@@ -1,0 +1,5 @@
+fn main() {
+    let mut msg = "before"
+    msg = "after"
+    println(msg)
+}

--- a/testdata/backend/llvm_smoke/string_param_print.osty
+++ b/testdata/backend/llvm_smoke/string_param_print.osty
@@ -1,0 +1,7 @@
+fn echo(msg: String) -> String {
+    msg
+}
+
+fn main() {
+    println(echo("param string"))
+}

--- a/testdata/backend/llvm_smoke/string_return_print.osty
+++ b/testdata/backend/llvm_smoke/string_return_print.osty
@@ -1,0 +1,7 @@
+fn greet() -> String {
+    "from function"
+}
+
+fn main() {
+    println(greet())
+}


### PR DESCRIPTION
## Summary
- lower `String` types to LLVM `ptr` in the bootstrap bridge
- add String-return, String-parameter, and mutable String-local smoke paths
- keep instruction/string rendering in `examples/selfhost-core/llvmgen.osty` and update Phase 27-29 docs

## Verification
- `go test -count=1 ./internal/profile ./internal/llvmgen ./internal/backend ./internal/pipeline ./cmd/osty`
- generated LLVM IR for `string_return_print`, `string_param_print`, and `string_mut_print`
- actual LLVM run smoke for all three new string fixtures
- `git diff --check`

Note: `go run ./cmd/osty test examples/selfhost-core/llvmgen_test.osty` reports the llvmgen test file itself as ok with 16 tests, then still exits 1 in the current selfhost-wide checker/generated Go path.