### PR TITLE
Refresh selfhost structured symbol docs

### DIFF
--- a/examples/selfhost-core/check_test.osty
+++ b/examples/selfhost-core/check_test.osty
@@ -53,6 +53,10 @@ fn testSelfCheckerEmitsStructuredResult() {
                 value
             }
 
+            fn unused() -> Int {
+                1
+            }
+
             fn main() {
                 let boxed: Box<Int> = Box { value: id::<Int>(1) }
             }
@@ -64,7 +68,20 @@ fn testSelfCheckerEmitsStructuredResult() {
     testing.assertEq(frontCheckResultBindingType(checked, "boxed"), "Box<Int>")
     testing.assert(frontCheckResultSymbolCount(checked, "fn") >= 2)
     testing.assert(frontCheckResultSymbolCount(checked, "struct") >= 1)
+    testing.assertEq(checkResultSymbolType(checked, "struct", "Box", ""), "Box<T>")
+    testing.assertEq(checkResultSymbolType(checked, "fn", "id", ""), "fn(T) -> T")
+    testing.assertEq(checkResultSymbolType(checked, "fn", "unused", ""), "fn() -> Int")
     testing.assert(frontCheckResultInstantiationCount(checked) >= 1)
+}
+
+fn checkResultSymbolType(result: FrontCheckResult, kind: String, name: String, owner: String) -> String {
+    let mut found = ""
+    for symbol in result.symbols {
+        if (kind == "" || symbol.kind == kind) && symbol.name == name && symbol.owner == owner {
+            found = symbol.typeName
+        }
+    }
+    found
 }
 
 fn testSelfCheckerReportsAssignmentReturnAndCallErrors() {

--- a/internal/gen/doc.go
+++ b/internal/gen/doc.go
@@ -5,7 +5,7 @@
 //
 //   - *ast.File — the parsed syntax tree
 //   - *resolve.Result — symbol resolution (Refs, TypeRefs)
-//   - *check.Result — semantic types (Types, LetTypes, SymTypes, Descs)
+//   - *check.Result — semantic types (Types, LetTypes, SymTypes, Instantiations)
 //
 // No AST nodes are mutated; the package is a pure read-side consumer of
 // the front-end. Output is `package main` Go that can be fed directly to

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -31,8 +31,7 @@ The generator merges the selfhost-core sources, emits `generated.go` through
 position lookups linear. Public compiler packages should call
 `internal/lexer` and `internal/parser` for the canonical front end, and
 `internal/check` for type checking. The `internal/check` entrypoints route
-mainstream checker diagnostics through `internal/selfhost.CheckSource` while
-the legacy Go checker continues to populate structural maps for codegen and
-editor features. `internal/selfhost.CheckSourceStructured` exposes typed
-nodes, bindings, symbols, and generic instantiations for replacing those maps
-incrementally. This package is the adaptation boundary for bootstrapped code.
+mainstream checker diagnostics through `internal/selfhost.CheckSourceStructured`
+and bridge its typed nodes, bindings, declaration symbols, and generic
+instantiations onto the resolver symbols and AST nodes consumed by codegen and
+editor features. This package is the adaptation boundary for bootstrapped code.

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -5,9 +5,8 @@ package selfhost
 // CheckSummary is the exported Go shape for the bootstrapped Osty checker.
 //
 // The self-hosted checker is authoritative for mainstream checker diagnostics
-// and supplies structured expression/binding/instantiation facts to the Go
-// check.Result bridge. Declaration shapes are still collected on the Go side
-// until codegen no longer consumes the legacy descriptor structs directly.
+// and supplies structured expression, binding, declaration-symbol, and
+// instantiation facts to the Go check.Result bridge.
 type CheckSummary struct {
 	Assignments int
 	Accepted    int
@@ -69,7 +68,7 @@ func CheckSource(src []byte) CheckSummary {
 }
 
 // CheckSourceStructured runs the bootstrapped Osty checker and returns the
-// structured seed result that can be compared with the canonical Go checker.
+// structured result consumed by the Go check.Result bridge.
 func CheckSourceStructured(src []byte) CheckResult {
 	lexed := ostyLexSource(string(src))
 	checked := frontendCheckLexedSourceStructured(lexed)


### PR DESCRIPTION
Summary:
- assert selfhost structured symbol types for struct, referenced fn, and unused fn declarations
- update selfhost adapter and README language after removing the Go declaration collector from UseSelfhost
- remove stale gen docs mention of Descs as a codegen input

Verification:
- go generate ./internal/selfhost && git diff --exit-code -- internal/selfhost/generated.go internal/selfhost/astbridge/generated.go
- go test -vet=off ./...
- go vet ./...
- git diff --check
- go run ./cmd/osty fmt --check examples/selfhost-core/check_test.osty
- build tmp osty binary and run osty ci .

Note: go run ./cmd/osty test examples/selfhost-core/check_test.osty reports the updated check_test file as ok, then exits non-zero in the existing package Go-build stage around formatter_ast.osty.