### PR TITLE
docs: refresh tooling and backend status

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -42,7 +42,7 @@ let s = "hello
 
 Base prefixes must be lowercase.
 
-Spec: v0.2 R11 / v0.3 §1.6.1
+Spec: v0.2 R11 / v0.4 §1.6.1
 
 ```osty
 let n = 0X1F  // rejected
@@ -56,7 +56,7 @@ The escape sequence is unknown or references an invalid Unicode scalar value.
 
 Most commonly a surrogate code point.
 
-Spec: v0.3 §2.1
+Spec: v0.4 §2.1
 
 ```osty
 let c = '\u{D800}'  // rejected
@@ -88,7 +88,7 @@ Triple-quoted string violates the indent rules.
 
 The opening `"""` must be followed by a newline, every content line must begin with the closing-line's whitespace prefix, and the closing `"""` must be on its own line.
 
-Spec: v0.3 §1.6.3
+Spec: v0.4 §1.6.3
 
 **Fix**: realign the content and closing delimiter per §1.6.3.
 
@@ -98,7 +98,7 @@ The `=>` (fat-arrow) token was removed from the grammar.
 
 `match` arms and every other arrow position use `->` instead. Any occurrence of `=>` in source is a lex error (O7, §1.7).
 
-Spec: v0.3 §1.7, OSTY_GRAMMAR_v0.3 O7
+Spec: v0.4 §1.7, OSTY_GRAMMAR_v0.4 O7
 
 ```osty
 match x { 0 => "zero", _ => "other" }  // rejected
@@ -122,7 +122,7 @@ Functions declared inside `use go "..."` must not have a body.
 
 They forward to the imported Go function.
 
-Spec: v0.3 R17
+Spec: v0.4 R17
 
 ```osty
 use go "net/http" {
@@ -138,7 +138,7 @@ Structs inside `use go { ... }` blocks mirror Go field layout only.
 
 Methods live on the Go side.
 
-Spec: v0.3 R16
+Spec: v0.4 R16
 
 **Fix**: move the method definition to the Go file that owns the type.
 
@@ -156,7 +156,7 @@ A `use` path mixes dotted and urlish forms.
 
 A path is either dotted (`std.fs`) OR urlish (`github.com/x/y`) — the two cannot mix.
 
-Spec: v0.3 R15
+Spec: v0.4 R15
 
 **Fix**: choose one form for the whole path.
 
@@ -166,7 +166,7 @@ Spec: v0.3 R15
 
 It must sit on the same line as the closing `}` of the `if` body.
 
-Spec: v0.3 O2
+Spec: v0.4 O2
 
 ```osty
 if cond {
@@ -185,7 +185,7 @@ Parameter or field default is not a literal.
 
 Defaults must be restricted literal forms (literal, `-` numeric, `None`, `Ok(lit)`, `Err(lit)`, `[]`, `{:}`, `()`).
 
-Spec: v0.3 R18
+Spec: v0.4 R18
 
 ```osty
 fn connect(t: Int = computeTimeout()) {}  // rejected
@@ -201,7 +201,7 @@ fn connect(t: Int = computeTimeout()) {}  // rejected
 
 Comparison or range operators are non-associative.
 
-Spec: v0.3 R1
+Spec: v0.4 R1
 
 ```osty
 a < b < c      // rejected
@@ -214,7 +214,7 @@ a < b < c      // rejected
 
 `::` is reserved for turbofish and must be followed by `<`.
 
-Spec: v0.3 O6
+Spec: v0.4 O6
 
 ```osty
 foo::bar()     // rejected — did you mean `foo.bar()`?
@@ -228,7 +228,7 @@ Method chains must continue with a leading dot on the next line.
 
 A trailing `.` then newline is a syntax error.
 
-Spec: v0.3 O3
+Spec: v0.4 O3
 
 **Fix**: move the `.` to the start of the continuation line.
 
@@ -236,7 +236,7 @@ Spec: v0.3 O3
 
 A closure with an explicit return type must have a block body.
 
-Spec: v0.3 R25
+Spec: v0.4 R25
 
 ```osty
 let f = |x: Int| -> Int x * 2       // rejected
@@ -277,7 +277,7 @@ The annotation name is not recognized.
 
 Only `#[json(...)]` and `#[deprecated(...)]` are defined today.
 
-Spec: v0.3 R26
+Spec: v0.4 R26
 
 **Fix**: remove the annotation or use one of the recognized names.
 
@@ -325,7 +325,7 @@ For example, a function name used where a type is expected.
 
 The referenced package cannot be found.
 
-Spec: v0.3 §5
+Spec: v0.4 §5
 
 **Fix**: check the `use` path and verify the package is on disk or in the manifest.
 
@@ -335,7 +335,7 @@ A `use` graph contains a cycle.
 
 Package A imports B which eventually imports A. The resolver breaks the cycle and reports the first edge that closes it.
 
-Spec: v0.3 §5.3
+Spec: v0.4 §5.3
 
 **Fix**: extract shared declarations into a third package that both sides import.
 
@@ -345,7 +345,7 @@ A cross-package reference targets a non-`pub` item.
 
 Private items are visible only to other files in the same package.
 
-Spec: v0.3 §5.2
+Spec: v0.4 §5.2
 
 **Fix**: add `pub` to the declaration, or move the caller into the same package.
 
@@ -355,7 +355,7 @@ Package member access names an item that isn't exported.
 
 The member might be private, misspelled, or from a different package.
 
-Spec: v0.3 §5.2
+Spec: v0.4 §5.2
 
 **Fix**: verify the name is `pub` and matches the exported spelling.
 
@@ -411,7 +411,7 @@ let x = _  // rejected
 
 Every alternative of an or-pattern must bind the same names.
 
-Spec: v0.3 §4.3.1
+Spec: v0.4 §4.3.1
 
 ```osty
 match e {
@@ -427,7 +427,7 @@ An interface default method may not access fields on `self`.
 
 The interface has no view of the implementing type's layout.
 
-Spec: v0.3 §2.6.2
+Spec: v0.4 §2.6.2
 
 **Fix**: call other interface methods instead of reading fields directly.
 
@@ -437,7 +437,7 @@ The annotation's target is not in its permitted set.
 
 `#[json]` only attaches to struct fields; `#[deprecated]` to top-level declarations and methods; neither attaches to `use`.
 
-Spec: v0.3 §18.1
+Spec: v0.4 §18.1
 
 **Fix**: move the annotation to a permitted target.
 
@@ -445,7 +445,7 @@ Spec: v0.3 §18.1
 
 Bare `defer` at the top level of a script is rejected.
 
-Spec: v0.3 §6 / §18.3
+Spec: v0.4 §6 / §18.3
 
 **Fix**: wrap the cleanup in an explicit `fn` or move it inside an existing function body.
 
@@ -453,7 +453,7 @@ Spec: v0.3 §6 / §18.3
 
 The same annotation name may not appear twice on a single target.
 
-Spec: v0.3 §18.1
+Spec: v0.4 §18.1
 
 ```osty
 #[deprecated]
@@ -763,7 +763,7 @@ Use site references an item marked `#[deprecated]`.
 
 Emitted as a `diag.Warning`. Tooling can promote it to error via build configuration.
 
-Spec: v0.3 §3.8.2
+Spec: v0.4 §3.8.2
 
 **Fix**: migrate to the replacement noted in the `#[deprecated]` annotation.
 
@@ -773,7 +773,7 @@ Control flow diagnostics (E0760-E0769).
 
 CodeUnreachableCode: a statement appears after a divergent construct (return, break, continue, or an expression of type Never) and therefore can never execute.
 
-Spec: v0.3 §4 control flow, §2.1 Never
+Spec: v0.4 §4 control flow, §2.1 Never
 
 **Fix**: delete the dead statement or move it above the divergent one.
 
@@ -783,7 +783,7 @@ CodeMissingReturn: a non-unit function's body could reach its end without produc
 
 function's result.
 
-Spec: v0.3 §3.1
+Spec: v0.4 §3.1
 
 **Fix**: add an explicit `return` or make the final expression the
 

--- a/LANG_SPEC_v0.4/13-tooling.md
+++ b/LANG_SPEC_v0.4/13-tooling.md
@@ -7,17 +7,45 @@ osty new <name>           Scaffold a new project directory
                           (--lib | --bin | --workspace)
 osty init                 Scaffold into the current directory in place
                           (--lib | --bin | --workspace)
-osty build [PATH]         Manifest-driven front-end + dependency resolution
-osty run                  Build and run (or execute a script)
-osty test                 Run tests (--bench, --serial, --update-snapshots)
+osty build [PATH]         Manifest + deps + front-end + backend emit/build
+osty run [-- ARGS...]     Build and execute the root binary on the host
+osty test [PATH|FILTER...] Discover, build, and run *_test.osty tests
 osty fmt FILE             Format source files (--check, --write)
+osty repair FILE          Repair common syntax/idiom slips before parsing
 osty check FILE|DIR       Type-check without building
 osty lint FILE|DIR        Style + correctness lint (--strict for CI)
-osty gen FILE             Transpile a single file to Go (debug aid)
+osty gen FILE             Emit a single file through go or llvm backend
+osty doc PATH             Generate API docs (markdown or html)
+osty ci [PATH]            Run format/lint/policy/lockfile/API checks
+osty ci snapshot [PATH]   Capture the exported API baseline
 osty add <pkg>            Add a dependency to osty.toml + osty.lock
 osty update [NAMES...]    Refresh dependencies (lockfile re-resolve)
+osty remove <name>...     Remove dependencies from osty.toml (alias: rm)
+osty fetch                Resolve and vendor without building
+osty publish              Pack and upload the package to a registry
+osty search QUERY         Search a registry
+osty info PKG             Show registry metadata
+osty yank / unyank        Mark or clear a yanked package version
+osty login / logout       Manage registry credentials
+osty registry serve       Run a file-backed package registry
+osty profiles             List build profiles
+osty targets              List cross-compilation targets
+osty features             List declared feature flags
+osty cache [ls|clean|info] Inspect or prune backend build caches
+osty pipeline FILE|DIR    Run each front-end phase; --gen emits artifacts
 osty lsp                  Run the language server on stdio
+osty explain [CODE]       Explain compiler or lint diagnostics
 ```
+
+`build`, `run`, and `test` accept profile/target/feature flags:
+`--profile`, `--release`, `--target`, `--features`, and
+`--no-default-features`. `build`, `run`, `test`, `add`, `update`, and
+`fetch` accept dependency-resolution guards: `--offline`, `--locked`,
+and `--frozen`. Backend-producing commands accept `--backend go|llvm`
+and `--emit go|llvm-ir|object|binary`; the Go backend remains the
+default. `run` requires a host binary and rejects cross-target
+execution. The `test` harness is currently Go-backed; `--backend llvm`
+is reserved for backend-aware test generation.
 
 ### 13.2 Manifest
 
@@ -25,9 +53,10 @@ A project is described by `osty.toml` at its root. `osty.lock` records
 exact resolved versions and content hashes.
 
 **Schema (v0.4).** The following TOML shape is accepted by the v0.4
-toolchain. Unknown keys inside known tables are rejected
-(`E2012`) so typos surface early; unknown top-level tables are
-ignored for forward-compatibility with future additions.
+toolchain. Stable configuration tables such as dependencies, lint,
+profiles, and targets reject unknown keys (`E2012`) so typos surface
+early; unknown top-level tables and extra `[package]` metadata are
+tolerated for forward-compatibility with future additions.
 
 ```toml
 [package]                        # required unless [workspace] is present
@@ -48,6 +77,9 @@ git-dep   = { git = "https://github.com/x/y", tag = "v1" }
 # { git = "...", branch = "main" } and { git = "...", rev = "sha" }
 # are also accepted; at most one of tag/branch/rev may be set.
 renamed   = { version = "1", package = "upstream-name" }
+full      = { version = "^1.2", registry = "custom",
+              optional = true, features = ["json"],
+              default-features = false }
 
 [dev-dependencies]               # optional; only visible to `osty test`
 test-helper = "0.4"
@@ -61,6 +93,7 @@ path = "src/lib.osty"
 
 [registries.custom]              # optional; non-default registries
 url = "https://custom.example"
+token = "..."                    # optional; credentials may also live in ~/.osty
 
 [workspace]                      # optional; defines a virtual workspace
 members = ["packages/core", "packages/util"]
@@ -68,6 +101,31 @@ members = ["packages/core", "packages/util"]
 [lint]                           # optional; project-wide lint policy
 allow = ["L0004"]                # suppress these codes for the whole project
 deny  = ["L0003"]                # elevate these codes to error (CI-failing)
+exclude = ["vendor/**"]          # skip matching files during `osty lint`
+
+[profile.release]                # optional; override a built-in profile
+opt-level = 3                    # valid range: 0..3
+debug = false
+strip = true
+overflow-checks = false
+inlining = true
+lto = true
+go-flags = ["-trimpath"]
+env = { CGO_ENABLED = "0" }
+
+[profile.bench]                  # optional; define a custom profile
+inherits = "release"             # built-ins: debug, release, profile, test
+debug = true
+
+[target.amd64-linux]             # optional; <arch>-<os> target triple
+cgo = false
+env = { GOAMD64 = "v3" }
+
+[features]                       # optional; local feature closure
+default = ["cli"]
+cli = []
+tls = ["crypto"]
+full = ["cli", "tls", "dep/feature"]
 ```
 
 **Coexistence of `[package]` and `[workspace]`.** A manifest may
@@ -100,6 +158,37 @@ applies its policy after running the default lint pass — `allow`
 drops matching diagnostics entirely, `deny` converts matching
 warnings to errors. `osty lint --strict` still elevates everything
 to error on top of these per-project settings.
+
+**Profiles and targets.** Four profiles are built in: `debug`,
+`release`, `profile`, and `test`. A manifest may override any of
+them or define a new profile that inherits from a built-in or another
+manifest profile. `--profile NAME` selects one explicitly;
+`--release` is shorthand for `--profile release`. Targets are named
+by `<arch>-<os>` triples such as `amd64-linux` or `arm64-darwin`.
+When selected with `--target`, target values populate the backend
+environment (`GOARCH`, `GOOS`, optional `CGO_ENABLED`, and any
+target-specific `env` entries). `osty run` refuses non-host targets
+because it must execute the produced binary locally.
+
+**Features.** `[features]` declares local feature names and their
+transitive closure. `default` names features enabled unless
+`--no-default-features` is present; `--features a,b` unions additional
+feature names. Cross-dependency references use `dep/feature` and are
+preserved for the dependency resolver. A source file may require
+features with a top-of-file pragma:
+
+```osty
+// @feature: tls
+```
+
+Files whose required features are inactive are skipped by the build
+driver before backend emission.
+
+**Artifacts and cache.** Backend outputs live under
+`.osty/out/<profile>[-<target>]/{go,llvm}/`; fingerprints live under
+`.osty/cache/<profile>[-<target>]/{go,llvm}.json`. `osty cache ls`
+lists those records, `osty cache info` prints one fingerprint, and
+`osty cache clean` removes `.osty/cache/` plus `.osty/out/`.
 
 ### 13.3 Formatter
 

--- a/README.md
+++ b/README.md
@@ -5,22 +5,25 @@ general-purpose, statically-typed, GC'd language specified in
 [`LANG_SPEC_v0.4/`](./LANG_SPEC_v0.4/README.md) with grammar fixed in
 [`OSTY_GRAMMAR_v0.4.md`](./OSTY_GRAMMAR_v0.4.md).
 
-The target is transpilation to Go. Current scope: front-end
-(lex → parse → resolve → type-check), multi-file packages and
-workspaces, formatter, linter, a JSON-RPC LSP server, a Go
-transpiler with **Phases 1–6 wired end-to-end** (primitives,
-control flow, structs/enums/match, generics/closures,
-Option/Result/`?`, `use`/FFI, channels/concurrency), project
-scaffolding (`osty new` / `osty init`), a manifest-driven build
-orchestrator (`osty build`) that reads `osty.toml` / `osty.lock`
-and threads the front-end + gen across the declared packages, a
-working test runner (`osty test`), API documentation generation
-(`osty doc`), CI quality tooling (`osty ci`), and a package manager
-(`osty add` / `osty update` / `osty publish`) backed by a
-file-backed HTTP registry server for local/private registries. The next
-language baseline is v0.4: the grammar is frozen, the remaining
-semantic corners are closed, and the next work is implementation/runtime
-coverage rather than language-decision churn.
+The default production backend transpiles to Go, and an early LLVM
+backend now shares the same artifact/cache layout for native IR,
+object, and binary experiments. Current scope: front-end (lex → parse
+→ resolve → type-check), multi-file packages and workspaces, formatter,
+linter, a JSON-RPC LSP server, a Go transpiler with **Phases 1–6 wired
+end-to-end** (primitives, control flow, structs/enums/match,
+generics/closures, Option/Result/`?`, `use`/FFI, channels/concurrency),
+an LLVM backend slice for scalar/control-flow/Bool/String smoke
+programs, project scaffolding (`osty new` / `osty init`), a
+manifest-driven build orchestrator (`osty build`) that reads
+`osty.toml` / `osty.lock` and threads the front-end + selected backend
+across the declared packages, a working test runner (`osty test`), API
+documentation generation (`osty doc`), CI quality tooling (`osty ci`),
+profile/target/feature/cache inspection commands, and a package manager
+(`osty add` / `osty update` / `osty publish`) backed by a file-backed
+HTTP registry server for local/private registries. The current language
+baseline is v0.4: the grammar is frozen, the remaining semantic corners
+are closed, and the next work is implementation/runtime coverage rather
+than language-decision churn.
 
 ## Status
 
@@ -40,16 +43,18 @@ coverage rather than language-decision churn.
 | Independent IR (`internal/ir`) | done — patterns, match, closures, struct/field/method |
 | Project scaffolding (`internal/scaffold`, `osty new` / `osty init`) | done — `--bin`, `--lib`, `--workspace`, `--cli`, `--service` |
 | Manifest + lockfile + SemVer (`internal/manifest`, `lockfile`, `pkgmgr/semver`) | done (parse + validate + resolve) |
-| Build orchestrator (`osty build`) | done — manifest → front-end → gen, profile/target/feature wiring |
+| Build orchestrator (`osty build`) | done — manifest → front-end → backend emit/build, profile/target/feature wiring, backend-aware artifact/cache paths |
 | Test runner harness (`internal/testgen`) | done — merges per-file gen output, injects a real std.testing runtime + main(), runs via `go run` |
 | `osty test` (discovery + front-end + execution) | done — validates and **runs** discovered `test*` / `bench*` fns; failures and pass/fail totals report inline |
 | API doc generator (`internal/docgen`, `osty doc`) | done — HTML + markdown, field docs, cross-refs, workspace mode |
 | CI quality tooling (`internal/ci`, `osty ci`) | done — signature-aware snapshots, workspace coverage, JSON reports |
 | Pipeline visualizer (`osty pipeline`) | done — per-stage timing, workspace mode, backend-aware gen, baseline diff, LSP trace, `--explain` |
+| Profiles / targets / features / cache (`internal/profile`, `osty profiles` / `targets` / `features` / `cache`) | done — built-in and manifest profiles, cross-target env, feature closure + file pragmas, backend-aware fingerprints |
+| LLVM backend (`internal/backend`, `internal/llvmgen`, `--backend llvm`) | early executable slice — textual IR/object/binary for scalar/control-flow/Bool/String smoke programs, host `clang` driver, inspectable skeleton + categorized diagnostics for unsupported source shapes |
 | Package registry backend / `osty registry serve` | done — file-backed HTTP server for index/search/download/publish/yank, with ETag index responses and bearer-token write auth |
 | Package registry / `osty add` / `osty update` / `osty run` | done (resolve + vendor + lockfile-honoring re-resolves, ETag-cached registry index, copy fallback for symlink-less filesystems; CLI: `add`, `remove`/`rm`, `update`, `run`, `fetch`, `publish`, `search`, `info`, `yank`/`unyank`, `login`/`logout`; `--locked` / `--frozen` CI guards) |
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
-| `osty run` (build + exec through gen) | wired — resolves manifest, vendors deps, transpiles entry, `go run`s the output with profile/target-aware flags |
+| `osty run` (build + exec through selected backend) | wired — resolves manifest, vendors deps, emits the entry artifact, executes host Go/LLVM binaries with profile/feature flags, and rejects cross-target execution |
 | `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
 
 The front-end (lex → parse → resolve → type-check) is **coverage-complete
@@ -152,12 +157,12 @@ go build -o osty ./cmd/osty
 ```sh
 osty new NAME          # scaffold a new project directory (--lib, --workspace)
 osty init              # scaffold into the current directory (same flags as new)
-osty build [DIR]       # manifest-driven: manifest → deps → front-end
+osty build [DIR]       # manifest-driven: manifest → deps → front-end → backend
 osty add PKG           # append a dependency to osty.toml and re-resolve
 osty remove NAME...    # drop dependencies from osty.toml and re-resolve (alias: rm)
 osty update [NAMES...] # refresh the lockfile (selective or full)
-osty run [-- ARGS...]  # build and exec the binary through gen
-osty test [PATH|FILTERS...] # discover & validate *_test.osty; list test + bench fns
+osty run [-- ARGS...]  # build and exec the binary through the selected backend
+osty test [PATH|FILTERS...] # discover, build, and run *_test.osty tests/benches
 osty publish           # pack the project and upload to a registry
 osty search QUERY      # full-text search the registry (--registry, --limit)
 osty info PKG          # show registry metadata for a package (--all-versions)
@@ -175,9 +180,14 @@ osty typecheck FILE    # same as check, plus a per-expression type dump
 osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
 osty fmt FILE          # repair + format to canonical style (see --check, --write, --engine)
 osty repair FILE       # auto-fix common AI-authored syntax/idiom slips
-osty gen FILE          # transpile to Go source (see -o, --package)
+osty gen FILE          # emit one file through a backend (see -o, --package)
 osty doc PATH          # generate API documentation (HTML + markdown)
 osty ci                # run CI quality checks (signatures, coverage, snapshots)
+osty ci snapshot       # capture the exported API baseline
+osty profiles          # list build profiles (debug, release, profile, test, ...)
+osty targets           # list declared cross-compilation targets
+osty features          # list declared opt-in features
+osty cache [ls|clean|info] # inspect or prune backend build caches
 osty scaffold          # generators (fixture / schema / ffi)
 osty lsp               # run the language server on stdio
 osty explain [CODE]    # describe a diagnostic (Exxxx/Wxxxx/Lxxxx); no arg lists every code
@@ -224,7 +234,7 @@ newline-separated `else`.
 
 `gen`-specific flags (after the subcommand):
 
-- `-o PATH` / `--out PATH` — write Go source to `PATH` instead of stdout
+- `-o PATH` / `--out PATH` — write the emitted artifact to `PATH` instead of stdout
 - `--package NAME` — Go package clause for the emitted file (default: `main`)
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` emits textual `.ll` for the early scalar/control-flow/plain/escaped
@@ -241,21 +251,21 @@ pipeline is otherwise front-end only.
 
 ### Debugging build / run / test failures
 
-`osty gen`, `osty build`, `osty run`, and `osty test` keep the generated
-Go inspectable. Emitted Go now includes comments like:
+`osty gen`, `osty build`, `osty run`, and `osty test` keep generated
+artifacts inspectable. Emitted Go includes comments like:
 
 ```go
 // Osty: /path/to/main.osty:12:5
 ```
 
-When `go build`, `go run`, or the test harness fails after the Osty
-front-end has succeeded, the CLI prints a short post-mortem:
+When `go build`, `go run`, the LLVM toolchain, or the test harness fails
+after the Osty front-end has succeeded, the CLI prints a short post-mortem:
 
-- the generated Go file or scratch directory to inspect;
+- the generated Go/LLVM artifact or scratch directory to inspect;
 - the nearest Osty source marker for Go compile errors and panic stack traces;
 - a category for common Go-side failures such as `package/import`,
   `transpile output`, `generated Go type/check`, or `runtime panic`;
-- the exact Go command to rerun from the generated output directory.
+- the exact Go or `clang` command to rerun from the generated output directory.
 
 For package/import errors, start with the reported `use go "..."` path
 or project dependency configuration. For runtime panics, read the Go
@@ -301,14 +311,27 @@ creating a new one.
   instruction strings are generated from that same backend core)
 - `--emit MODE` — requested artifact mode (`go`, `llvm-ir`, `object`, or
   `binary`). `build --emit go` writes inspectable Go without linking a binary;
-  `build --backend llvm --emit object|binary` uses `clang`; `run` and `test`
-  require `binary` because they execute the result.
+  `build --backend llvm --emit object|binary` uses `clang`; `run` requires
+  `binary` because it executes the result. `test` still uses the Go harness;
+  `--backend llvm` is reserved for backend-aware test generation.
+
+`profiles` / `targets` / `features` / `cache` commands:
+
+- `osty profiles [--verbose]` — list built-in and manifest-defined profiles,
+  including `debug`, `release`, `profile`, and `test`.
+- `osty targets` — list manifest `[target.<arch-os>]` cross-compilation
+  presets.
+- `osty features` — list manifest `[features]` entries and the default set.
+- `osty cache ls` — show backend-aware build fingerprints under `.osty/cache/`.
+- `osty cache info [--profile NAME] [--target TRIPLE] [--backend NAME]` —
+  inspect one cached fingerprint.
+- `osty cache clean` — remove `.osty/cache/` and `.osty/out/` build artifacts.
 
 `osty build` loads `osty.toml` starting at the given path (or the cwd),
 resolves dependencies against `osty.lock` (regenerated if stale),
 vendors deps into `<project>/.osty/deps/`, and runs the front-end
-(parse → resolve → check → lint) plus gen across every package
-the manifest names. For binary packages it emits backend artifacts into
+(parse → resolve → check → lint) plus selected backend emission across every
+package the manifest names. For binary packages it emits backend artifacts into
 `<project>/.osty/out/<profile>[-<target>]/{go,llvm}/`, invokes the selected
 toolchain, and reports diagnostics with generated-source mapping.
 

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -23,19 +23,23 @@ import (
 )
 
 // runBuild implements the `osty build` subcommand: the manifest-aware
-// front-end pipeline end-to-end.
+// project pipeline end-to-end.
 //
 //  1. Locate osty.toml (walking up from PATH, default cwd).
 //  2. Load + validate the manifest, rendering any E2xxx diagnostics.
 //  3. Resolve dependencies (osty.lock is read; regenerated if stale).
 //  4. Vendor deps into <project>/.osty/deps/<name>/.
-//  5. Run the front-end (parse + resolve + type-check) across the
-//     project sources — as a workspace when [workspace] is present,
+//  5. Run the front-end (parse + resolve + type-check + lint) across
+//     the project sources — as a workspace when [workspace] is present,
 //     as a single package otherwise.
+//  6. Emit the selected backend artifact (Go source/binary or LLVM
+//     IR/object/binary) under .osty/out/<profile>[-<target>]/<backend>/.
+//  7. Record a backend-aware fingerprint under .osty/cache/ so an
+//     unchanged build can skip the front-end and backend work.
 //
 // Exit codes:
 //
-//	0   manifest + every package is clean
+//	0   manifest + every package is clean and requested artifacts were produced
 //	1   I/O failure, vendor / lockfile write error, or at least one
 //	    package emitted an error-severity diagnostic
 //	2   usage error or manifest validation failure

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -2,20 +2,24 @@
 //
 // Subcommands:
 //
-//	osty new <name>            Scaffold a new project directory (spec §13.1).
-//	osty parse <file.osty>     Parse a file and print the AST as JSON.
-//	osty tokens <file.osty>    Lex a file and print the token stream.
-//	osty resolve <file.osty>   Lex+parse+name-resolve; print resolved refs.
-//	osty check <file.osty>     Lex+parse+resolve+type-check diagnostics only.
-//	osty typecheck <file.osty> Alias of `check` that also prints the inferred
-//	                           type of each expression (debugging aid).
-//	osty fmt <file.osty>       Repair then format source; see -check/-write/-no-repair.
-//	osty repair <file.osty>    Fix common AI-authored syntax slips; see -check/-write.
-//	osty gen <file.osty>       Transpile to Go (prints to stdout; -o writes to file).
-//	osty doc <path>            Emit markdown API docs for a file or package.
-//	osty lsp                   Run the Language Server Protocol server on stdio.
-//	osty explain [CODE]        Describe a diagnostic code; with no arg, list every code.
-//	osty pipeline <file.osty>  Run every front-end phase and print per-stage timing.
+//	osty new <name>              Scaffold a new project directory (spec §13.1).
+//	osty init                    Scaffold into the current directory.
+//	osty build [dir]             Resolve deps, run the front-end, emit/build artifacts.
+//	osty run [-- args...]        Build and execute the host binary.
+//	osty test [path|filter...]   Discover, build, and run *_test.osty tests.
+//	osty add/update/remove/fetch Manage manifest deps, vendoring, and osty.lock.
+//	osty publish/search/info     Interact with package registries.
+//	osty registry serve          Run a file-backed registry for local/private use.
+//	osty doc <path>              Emit markdown or HTML API docs.
+//	osty ci [path]               Run quality checks; `ci snapshot` captures API.
+//	osty profiles/targets/features/cache
+//	                             Inspect build profiles, target presets, features, cache.
+//	osty parse/tokens/resolve/check/typecheck/lint/fmt/repair
+//	                             Single-file/package front-end and source tools.
+//	osty gen <file.osty>         Emit a single file through go or llvm backend.
+//	osty lsp                     Run the Language Server Protocol server on stdio.
+//	osty explain [CODE]          Describe a diagnostic code; with no arg, list every code.
+//	osty pipeline <file|dir>     Run every front-end phase and print per-stage timing.
 //
 // Global flags (may precede the subcommand):
 //
@@ -132,9 +136,9 @@ func main() {
 		runScaffold(args[1:])
 		return
 	}
-	// build is the manifest-driven front-end over a directory. When
-	// passed a directory it loads osty.toml, validates, and runs
-	// check + lint across the package(s) the manifest describes.
+	// build is the manifest-driven project pipeline: load osty.toml,
+	// resolve deps, run the front-end, and ask the selected backend to
+	// emit/build artifacts under the profile/target output tree.
 	if cmd == "build" {
 		runBuild(args[1:], flags)
 		return
@@ -178,9 +182,9 @@ func main() {
 		runUpdate(args[1:], flags)
 		return
 	}
-	// run builds the project (via gen Phase 1) and executes the
-	// produced Go program; test walks *_test.osty files; publish packs
-	// a tarball and uploads it to a configured registry.
+	// run builds the project through the selected backend and executes
+	// the host binary; test walks *_test.osty files and runs the Go
+	// harness; publish packs a tarball and uploads it to a registry.
 	if cmd == "run" {
 		runRun(args[1:], flags)
 		return
@@ -1096,11 +1100,11 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "usage: osty [flags] (parse|tokens|resolve|check|typecheck|lint|fmt|repair|gen) FILE")
 	fmt.Fprintln(os.Stderr, "       osty new [--lib] NAME     (scaffold a new project)")
 	fmt.Fprintln(os.Stderr, "       osty init [--lib]         (scaffold into the current directory)")
-	fmt.Fprintln(os.Stderr, "       osty build [DIR]          (manifest-driven front end over a project)")
+	fmt.Fprintln(os.Stderr, "       osty build [DIR]          (manifest + deps + front end + backend artifacts)")
 	fmt.Fprintln(os.Stderr, "       osty add NAME[@VER]       (add a dependency; also --path, --git)")
 	fmt.Fprintln(os.Stderr, "       osty update [NAME...]     (refresh osty.lock)")
 	fmt.Fprintln(os.Stderr, "       osty run [-- ARGS...]     (build + exec the project's binary)")
-	fmt.Fprintln(os.Stderr, "       osty test [PATH|FILTER...] (discover *_test.osty; report tests found)")
+	fmt.Fprintln(os.Stderr, "       osty test [PATH|FILTER...] (discover, build, and run *_test.osty)")
 	fmt.Fprintln(os.Stderr, "       osty publish              (pack + upload the package to a registry)")
 	fmt.Fprintln(os.Stderr, "       osty search QUERY         (search the registry for packages)")
 	fmt.Fprintln(os.Stderr, "       osty yank --version V [PKG]   (mark a published version as yanked)")
@@ -1139,7 +1143,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --check            exit 1 if FILE would be repaired")
 	fmt.Fprintln(os.Stderr, "  --write            overwrite FILE in place")
 	fmt.Fprintln(os.Stderr, "gen-specific flags (after the subcommand):")
-	fmt.Fprintln(os.Stderr, "  -o PATH            write Go source to PATH instead of stdout")
+	fmt.Fprintln(os.Stderr, "  -o PATH            write emitted artifact to PATH instead of stdout")
 	fmt.Fprintln(os.Stderr, "  --package NAME     Go package clause (default: main)")
 	fmt.Fprintln(os.Stderr, "  --backend NAME     code generation backend (go or llvm; default go)")
 	fmt.Fprintln(os.Stderr, "  --emit MODE        artifact mode (go or llvm-ir; default follows backend)")
@@ -1304,9 +1308,9 @@ func runFmt(args []string) {
 	}
 }
 
-// runGen implements the `osty gen` subcommand: transpile a single
-// .osty file to Go and either print the result to stdout or write it
-// to the path given by --out/-o.
+// runGen implements the `osty gen` subcommand: emit a single .osty
+// file through the selected backend and either print the requested
+// text artifact to stdout or write it to the path given by --out/-o.
 //
 // Exit codes:
 //
@@ -1314,7 +1318,7 @@ func runFmt(args []string) {
 //	1   unrecoverable I/O error, or transpile returned an error even
 //	    after partial output
 //	2   usage error (missing path, unknown flag), or parse/resolve/check
-//	    failures that would produce garbage Go
+//	    failures that would produce garbage backend output
 func runGen(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("gen", flag.ExitOnError)
 	fs.Usage = func() {
@@ -1324,7 +1328,7 @@ func runGen(args []string, flags cliFlags) {
 	var pkgName string
 	var backendName string
 	var emitName string
-	fs.StringVar(&outPath, "o", "", "write Go source to this file instead of stdout")
+	fs.StringVar(&outPath, "o", "", "write the emitted artifact to this file instead of stdout")
 	fs.StringVar(&outPath, "out", "", "alias for -o")
 	fs.StringVar(&pkgName, "package", "main", "Go package clause (default: main)")
 	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (go or llvm)")

--- a/cmd/osty/profile_flags.go
+++ b/cmd/osty/profile_flags.go
@@ -16,8 +16,8 @@ import (
 const profileTestFallback = profile.NameTest
 
 // profileFlags captures the `--profile / --release / --target /
-// --features / --no-default-features` flag set shared by `osty build`
-// and `osty run`. register() attaches them to a caller-owned
+// --features / --no-default-features` flag set shared by `osty build`,
+// `osty run`, and `osty test`. register() attaches them to a caller-owned
 // FlagSet; resolve() turns the captured state into a *profile.Resolved
 // or a usage error.
 type profileFlags struct {

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -29,17 +29,18 @@ import (
 //  2. Resolve the project as a package; confirm we have an entry
 //     point (manifest Bin target or default main.osty with fn main).
 //  3. Run the front-end (parse + resolve + type check).
-//  4. Transpile the entry file via internal/backend into .osty/out.
-//  5. `go run` the generated Go source, passing through the
-//     user-supplied arguments after `--`.
+//  4. Emit the entry file via internal/backend into .osty/out.
+//  5. Execute the host artifact, passing through the user-supplied
+//     arguments after `--` (`go run` for the Go backend, a native
+//     binary for the LLVM backend).
 //
 // Limitations (current emitter):
 //
 //   - Multi-file packages aren't fully emitted by gen yet; run executes
 //     the selected entry file. Complex unsupported lowering shapes may
-//     still emit TODO markers and fail to compile as Go.
+//     still emit TODO markers/skeletons and fail to compile or link.
 //
-//   - Registry / git dep code is vendored but NOT yet transpiled
+//   - Registry / git dep code is vendored but NOT yet emitted
 //     together with the entry file — the Workspace loader sees them
 //     for resolution, but package-per-package emission still needs to
 //     land before they contribute Go code.

--- a/cmd/osty/test.go
+++ b/cmd/osty/test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // runTest implements `osty test [--offline] [PATH|FILTER...]` per
-// LANG_SPEC_v0.3 §11.
+// LANG_SPEC_v0.4 §11.
 //
 // Two invocation shapes are supported:
 //
@@ -32,8 +32,8 @@ import (
 //     project tree for `*_test.osty` files, groups them by containing
 //     directory, runs the full front-end pipeline per package (with
 //     test files included so they can reference sibling non-test
-//     declarations, per §11), and reports discovered `test*` /
-//     `bench*` functions per file.
+//     declarations, per §11), emits a Go harness, and executes the
+//     discovered `test*` / `bench*` functions per file.
 //
 //   - `osty test PATH` where PATH is a single `.osty` file or a bare
 //     directory (no manifest required): runs the same pipeline but

--- a/internal/check/defaults.go
+++ b/internal/check/defaults.go
@@ -4,7 +4,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 )
 
-// isAllowedDefaultExpr enforces v0.3 §3.1's rule that default
+// isAllowedDefaultExpr enforces v0.4 §3.1's rule that default
 // arguments must be simple literals. Allowed shapes:
 //
 //   - Numeric / string / char / byte / bool literals

--- a/internal/check/expr.go
+++ b/internal/check/expr.go
@@ -235,7 +235,7 @@ func (c *checker) binaryType(e *ast.BinaryExpr, env *env) types.Type {
 }
 
 // binaryOpResult validates an operator against its operands and returns
-// the result type. The error messages try to match v0.3 §2.2 phrasing.
+// the result type. The error messages try to match v0.4 §2.2 phrasing.
 func (c *checker) binaryOpResult(e *ast.BinaryExpr, op token.Kind, lt, rt types.Type) types.Type {
 	switch op {
 	// Arithmetic

--- a/internal/check/iface.go
+++ b/internal/check/iface.go
@@ -10,7 +10,7 @@ import (
 )
 
 // builtinSatisfies reports whether a primitive type satisfies one of the
-// built-in marker interfaces per v0.3 §2.6.5. Returns (matched, ok):
+// built-in marker interfaces per v0.4 §2.6.5. Returns (matched, ok):
 // matched=true means the interface name was recognized as built-in;
 // ok=true means the primitive satisfies it.
 func builtinSatisfies(iface string, t types.Type) (matched, ok bool) {

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -18,7 +18,7 @@ const (
 
 	// Base prefixes must be lowercase.
 	//
-	// Spec: v0.2 R11 / v0.3 §1.6.1
+	// Spec: v0.2 R11 / v0.4 §1.6.1
 	// Example:
 	//   let n = 0X1F  // rejected
 	// Fix: use `0x1F` / `0b1010` / `0o777`.
@@ -28,7 +28,7 @@ const (
 	//
 	// Most commonly a surrogate code point.
 	//
-	// Spec: v0.3 §2.1
+	// Spec: v0.4 §2.1
 	// Example:
 	//   let c = '\u{D800}'  // rejected
 	// Fix: use a non-surrogate scalar (U+0..U+D7FF or U+E000..U+10FFFF).
@@ -54,7 +54,7 @@ const (
 	// must begin with the closing-line's whitespace prefix, and the
 	// closing `"""` must be on its own line.
 	//
-	// Spec: v0.3 §1.6.3
+	// Spec: v0.4 §1.6.3
 	// Fix: realign the content and closing delimiter per §1.6.3.
 	CodeBadTripleString = "E0006"
 
@@ -63,7 +63,7 @@ const (
 	// `match` arms and every other arrow position use `->` instead.
 	// Any occurrence of `=>` in source is a lex error (O7, §1.7).
 	//
-	// Spec: v0.3 §1.7, OSTY_GRAMMAR_v0.3 O7
+	// Spec: v0.4 §1.7, OSTY_GRAMMAR_v0.4 O7
 	// Example:
 	//   match x { 0 => "zero", _ => "other" }  // rejected
 	// Fix: replace `=>` with `->`.
@@ -80,7 +80,7 @@ const (
 	//
 	// They forward to the imported Go function.
 	//
-	// Spec: v0.3 R17
+	// Spec: v0.4 R17
 	// Example:
 	//   use go "net/http" {
 	//       fn Get(url: String) -> String { "x" }  // rejected
@@ -92,7 +92,7 @@ const (
 	//
 	// Methods live on the Go side.
 	//
-	// Spec: v0.3 R16
+	// Spec: v0.4 R16
 	// Fix: move the method definition to the Go file that owns the type.
 	CodeUseGoStructHasMethod = "E0102"
 
@@ -109,7 +109,7 @@ const (
 	// A path is either dotted (`std.fs`) OR urlish (`github.com/x/y`) —
 	// the two cannot mix.
 	//
-	// Spec: v0.3 R15
+	// Spec: v0.4 R15
 	// Fix: choose one form for the whole path.
 	CodeUsePathMixed = "E0104"
 
@@ -117,7 +117,7 @@ const (
 	//
 	// It must sit on the same line as the closing `}` of the `if` body.
 	//
-	// Spec: v0.3 O2
+	// Spec: v0.4 O2
 	// Example:
 	//   if cond {
 	//       ...
@@ -133,7 +133,7 @@ const (
 	// Defaults must be restricted literal forms (literal, `-` numeric,
 	// `None`, `Ok(lit)`, `Err(lit)`, `[]`, `{:}`, `()`).
 	//
-	// Spec: v0.3 R18
+	// Spec: v0.4 R18
 	// Example:
 	//   fn connect(t: Int = computeTimeout()) {}  // rejected
 	// Fix: use a literal default, or move the computation into the body.
@@ -143,7 +143,7 @@ const (
 
 	// Comparison or range operators are non-associative.
 	//
-	// Spec: v0.3 R1
+	// Spec: v0.4 R1
 	// Example:
 	//   a < b < c      // rejected
 	//   0..10..20      // rejected
@@ -152,7 +152,7 @@ const (
 
 	// `::` is reserved for turbofish and must be followed by `<`.
 	//
-	// Spec: v0.3 O6
+	// Spec: v0.4 O6
 	// Example:
 	//   foo::bar()     // rejected — did you mean `foo.bar()`?
 	// Fix: use `.` for member access or `::<T>` for type application.
@@ -162,13 +162,13 @@ const (
 	//
 	// A trailing `.` then newline is a syntax error.
 	//
-	// Spec: v0.3 O3
+	// Spec: v0.4 O3
 	// Fix: move the `.` to the start of the continuation line.
 	CodeTrailingDot = "E0202"
 
 	// A closure with an explicit return type must have a block body.
 	//
-	// Spec: v0.3 R25
+	// Spec: v0.4 R25
 	// Example:
 	//   let f = |x: Int| -> Int x * 2       // rejected
 	//   let f = |x: Int| -> Int { x * 2 }   // ok
@@ -198,7 +198,7 @@ const (
 	//
 	// Only `#[json(...)]` and `#[deprecated(...)]` are defined today.
 	//
-	// Spec: v0.3 R26
+	// Spec: v0.4 R26
 	// Fix: remove the annotation or use one of the recognized names.
 	CodeUnknownAnnotation = "E0400"
 
@@ -239,7 +239,7 @@ const (
 
 	// The referenced package cannot be found.
 	//
-	// Spec: v0.3 §5
+	// Spec: v0.4 §5
 	// Fix: check the `use` path and verify the package is on disk or in the manifest.
 	CodeUnknownPackage = "E0505"
 
@@ -248,7 +248,7 @@ const (
 	// Package A imports B which eventually imports A. The resolver
 	// breaks the cycle and reports the first edge that closes it.
 	//
-	// Spec: v0.3 §5.3
+	// Spec: v0.4 §5.3
 	// Fix: extract shared declarations into a third package that both sides import.
 	CodeCyclicImport = "E0506"
 
@@ -256,7 +256,7 @@ const (
 	//
 	// Private items are visible only to other files in the same package.
 	//
-	// Spec: v0.3 §5.2
+	// Spec: v0.4 §5.2
 	// Fix: add `pub` to the declaration, or move the caller into the same package.
 	CodePrivateAcrossPackages = "E0507"
 
@@ -264,7 +264,7 @@ const (
 	//
 	// The member might be private, misspelled, or from a different package.
 	//
-	// Spec: v0.3 §5.2
+	// Spec: v0.4 §5.2
 	// Fix: verify the name is `pub` and matches the exported spelling.
 	CodeUnknownExportedMember = "E0508"
 
@@ -310,7 +310,7 @@ const (
 
 	// Every alternative of an or-pattern must bind the same names.
 	//
-	// Spec: v0.3 §4.3.1
+	// Spec: v0.4 §4.3.1
 	// Example:
 	//   match e {
 	//       A(x) | B(x, y) -> ...   // rejected: `y` not bound by A
@@ -322,7 +322,7 @@ const (
 	//
 	// The interface has no view of the implementing type's layout.
 	//
-	// Spec: v0.3 §2.6.2
+	// Spec: v0.4 §2.6.2
 	// Fix: call other interface methods instead of reading fields directly.
 	CodeInterfaceDefaultField = "E0606"
 
@@ -331,19 +331,19 @@ const (
 	// `#[json]` only attaches to struct fields; `#[deprecated]` to
 	// top-level declarations and methods; neither attaches to `use`.
 	//
-	// Spec: v0.3 §18.1
+	// Spec: v0.4 §18.1
 	// Fix: move the annotation to a permitted target.
 	CodeAnnotationBadTarget = "E0607"
 
 	// Bare `defer` at the top level of a script is rejected.
 	//
-	// Spec: v0.3 §6 / §18.3
+	// Spec: v0.4 §6 / §18.3
 	// Fix: wrap the cleanup in an explicit `fn` or move it inside an existing function body.
 	CodeDeferAtScriptTop = "E0608"
 
 	// The same annotation name may not appear twice on a single target.
 	//
-	// Spec: v0.3 §18.1
+	// Spec: v0.4 §18.1
 	// Example:
 	//   #[deprecated]
 	//   #[deprecated]           // rejected
@@ -605,7 +605,7 @@ const (
 	// Emitted as a `diag.Warning`. Tooling can promote it to error via
 	// build configuration.
 	//
-	// Spec: v0.3 §3.8.2
+	// Spec: v0.4 §3.8.2
 	// Fix: migrate to the replacement noted in the `#[deprecated]` annotation.
 	CodeDeprecatedUse = "W0750"
 
@@ -614,13 +614,13 @@ const (
 	// CodeUnreachableCode: a statement appears after a divergent
 	// construct (return, break, continue, or an expression of type
 	// Never) and therefore can never execute.
-	// Spec: v0.3 §4 control flow, §2.1 Never
+	// Spec: v0.4 §4 control flow, §2.1 Never
 	// Fix: delete the dead statement or move it above the divergent one.
 	CodeUnreachableCode = "E0760"
 
 	// CodeMissingReturn: a non-unit function's body could reach its
 	// end without producing a value matching the return type.
-	// Spec: v0.3 §3.1
+	// Spec: v0.4 §3.1
 	// Fix: add an explicit `return` or make the final expression the
 	//      function's result.
 	CodeMissingReturn = "E0761"

--- a/internal/lint/naming.go
+++ b/internal/lint/naming.go
@@ -9,7 +9,7 @@ import (
 )
 
 // lintNaming flags identifiers that deviate from the project's house
-// style (per v0.3 spec examples):
+// style (per v0.4 spec examples):
 //
 //	L0030  types (struct / enum / interface / type alias / generic) must
 //	       be UpperCamelCase

--- a/internal/lint/registry.go
+++ b/internal/lint/registry.go
@@ -157,13 +157,13 @@ var allRules = []Rule{
 		Code: diag.CodeNamingType, Name: "naming_type",
 		Category: CategoryNaming, DefaultSeverity: diag.Warning,
 		Summary:     "type name is not UpperCamelCase",
-		Description: "Types (struct, enum, interface, type alias, generic parameter) should be UpperCamelCase per the v0.3 spec examples.",
+		Description: "Types (struct, enum, interface, type alias, generic parameter) should be UpperCamelCase per the v0.4 spec examples.",
 	},
 	{
 		Code: diag.CodeNamingValue, Name: "naming_value",
 		Category: CategoryNaming, DefaultSeverity: diag.Warning,
 		Summary:     "value name is not lowerCamelCase",
-		Description: "Functions, methods, `let` bindings, and parameters should be lowerCamelCase per the v0.3 spec examples.",
+		Description: "Functions, methods, `let` bindings, and parameters should be lowerCamelCase per the v0.4 spec examples.",
 	},
 	{
 		Code: diag.CodeNamingVariant, Name: "naming_variant",

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -12,7 +12,7 @@ import (
 
 // LoadPackage discovers and parses every `.osty` file directly under
 // dir (non-recursive) and returns them as a single Package ready for
-// ResolvePackage. Test files (`*_test.osty`) are excluded per v0.3 §11
+// ResolvePackage. Test files (`*_test.osty`) are excluded per v0.4 §11
 // so production builds don't drag test-only declarations into scope.
 //
 // The returned Package has Files sorted lexicographically by path for

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -165,7 +165,7 @@ func (r *resolver) bodyPass(pkg *Package) {
 						"`defer` is not allowed at the top level of a script").
 						Code(diag.CodeDeferAtScriptTop).
 						PrimaryPos(ds.PosV, "top-level defer").
-						Note("v0.3 §6 / §18.3: `defer` must appear inside an explicit `fn` body; the implicit main of a script does not accept it").
+						Note("v0.4 §6 / §18.3: `defer` must appear inside an explicit `fn` body; the implicit main of a script does not accept it").
 						Hint("wrap the deferred cleanup in an `fn` you invoke from the script body").
 						Build())
 					continue
@@ -442,7 +442,7 @@ func topLevelAnnotations(d ast.Decl) []*ast.Annotation {
 }
 
 // checkAnnotations validates the annotations on a declaration against
-// v0.2 R26 and v0.3 §18.1:
+// v0.2 R26 and v0.4 §18.1:
 //
 //   - unknown names are flagged by the parser (E0400) and skipped here;
 //   - the annotation's target kind must be permitted (E0607);
@@ -474,7 +474,7 @@ func (r *resolver) checkAnnotations(annots []*ast.Annotation, target ast.Annotat
 					"duplicate annotation here").
 				Secondary(diag.Span{Start: prev.PosV, End: prev.EndV},
 					"first occurrence here").
-				Note("v0.3 §18.1: the same annotation name may not appear more than once on a single target").
+				Note("v0.4 §18.1: the same annotation name may not appear more than once on a single target").
 				Build())
 			continue
 		}

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -539,7 +539,7 @@ func (w *Workspace) ResolveUseTarget(dotPath string, usePos token.Pos) (*Package
 		fmt.Sprintf("package `%s` not found in this workspace", dotPath)).
 		Code(diag.CodeUnknownPackage).
 		PrimaryPos(usePos, "unknown package").
-		Note("v0.3 §5.2: imports resolve to subdirectories of the project root")
+		Note("v0.4 §5.2: imports resolve to subdirectories of the project root")
 	if err != nil {
 		d.Note(err.Error())
 	}

--- a/internal/testgen/testgen.go
+++ b/internal/testgen/testgen.go
@@ -57,7 +57,7 @@ const programMainName = "_ostyProgramMain"
 // EntryKind identifies how the harness should invoke an entry — as a
 // regular test (recorded in pass/fail totals) or as a benchmark
 // (currently only invoked once; iteration counts and timing are
-// future work, per LANG_SPEC_v0.3 §11.4).
+// future work, per LANG_SPEC_v0.4 §11.4).
 type EntryKind int
 
 const (

--- a/internal/types/compat.go
+++ b/internal/types/compat.go
@@ -104,7 +104,7 @@ func sameNamedSymbol(a, b *resolve.Symbol) bool {
 }
 
 // Assignable reports whether a value of type `src` can be assigned to a
-// destination of type `dst`. The rules track v0.3:
+// destination of type `dst`. The rules track v0.4:
 //
 //   - Identical types are assignable.
 //   - Never is assignable to any type (bottom).
@@ -158,7 +158,7 @@ func Assignable(dst, src Type) bool {
 	}
 	// A concrete value flows into an Optional: `let x: Int? = 5_i32` if
 	// the int type matches inner. This is the implicit `Some(v)` wrap
-	// that v0.3 semantically supports via inference at the literal level.
+	// that v0.4 semantically supports via inference at the literal level.
 	if o, ok := dst.(*Optional); ok {
 		if Identical(o.Inner, src) {
 			return true

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -37,7 +37,7 @@ type Type interface {
 
 // ==== Primitive ====
 
-// PrimitiveKind enumerates the built-in scalar types of v0.3 §2.1 plus
+// PrimitiveKind enumerates the built-in scalar types of v0.4 §2.1 plus
 // the synthetic Unit and Never tags.
 type PrimitiveKind int
 
@@ -102,7 +102,7 @@ func (k PrimitiveKind) IsFloat() bool {
 func (k PrimitiveKind) IsNumeric() bool { return k.IsInteger() || k.IsFloat() }
 
 // IsOrdered reports whether the primitive has a built-in total order
-// (v0.3 §2.6.5).
+// (v0.4 §2.6.5).
 func (k PrimitiveKind) IsOrdered() bool {
 	switch k {
 	case PBool, PChar, PString, PBytes:


### PR DESCRIPTION
## Summary
- Refresh README status and CLI docs for backend selection, LLVM artifacts, profiles, targets, features, and cache commands.
- Update v0.4 tooling spec manifest/CLI documentation to match current implementation.
- Align user-facing CLI/GoDoc comments and regenerated diagnostic spec references with v0.4.

## Tests
- go test ./cmd/osty ./internal/diag ./internal/profile ./internal/manifest
- go run ./cmd/codesdoc -in internal/diag/codes.go -check ERROR_CODES.md
- git diff --check