### PR TITLE
llvm: add aggregate and enum smoke paths

### DIFF
--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -299,6 +299,27 @@ The initial helper package for this plan is `internal/backend`.
 30. Add mutable String locals. Done in Phase 29: mutable `String` slots use
     `alloca ptr`, `store ptr`, and `load ptr` through the existing Osty-owned
     mutable local helpers.
+31. Add named struct type definitions and field reads. Done in Phase 30:
+    non-generic struct declarations emit `%Name = type { ... }`, struct
+    literals use the Osty-owned `insertvalue` builder, and field reads use the
+    Osty-owned `extractvalue` builder.
+32. Add struct return values. Done in Phase 31: simple aggregate struct values
+    can be returned from helper functions and read in `main`.
+33. Add struct parameters. Done in Phase 32: simple aggregate struct values can
+    be passed to helper functions and field-read inside the callee.
+34. Add mutable struct locals. Done in Phase 33: mutable struct slots reuse the
+    generic Osty-owned alloca/store/load helpers for whole-value assignment and
+    later field extraction.
+35. Add payload-free enum variant values. Done in Phase 34: bare variants lower
+    to Osty-owned `i64` tag values and can participate in equality/if smoke
+    paths.
+36. Add enum return values. Done in Phase 35: payload-free enum tag values can
+    cross helper return boundaries.
+37. Add enum parameters. Done in Phase 36: payload-free enum tag values can
+    cross helper parameter boundaries.
+38. Add mutable enum locals. Done in Phase 37: enum tag values reuse the generic
+    Osty-owned alloca/store/load helpers for whole-value assignment and later
+    comparison.
 
 The backend subdirectory change should land before the LLVM backend writes any
 files, so LLVM never shares the old Go-only output location.

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -52,14 +52,22 @@ Each fixture should be independently checkable as a single file and avoid:
 | `testdata/backend/llvm_smoke/string_return_print.osty` | `from function\n` | Phase 27 LLVM IR: `String` return type lowered to `ptr` and printed from a function call |
 | `testdata/backend/llvm_smoke/string_param_print.osty` | `param string\n` | Phase 28 LLVM IR: `String` parameter and argument passing through helper calls |
 | `testdata/backend/llvm_smoke/string_mut_print.osty` | `after\n` | Phase 29 LLVM IR: mutable local `String` slot, assignment, load, and print |
+| `testdata/backend/llvm_smoke/struct_field_print.osty` | `42\n` | Phase 30 LLVM IR: named struct type definition, aggregate literal via `insertvalue`, and field reads via `extractvalue` |
+| `testdata/backend/llvm_smoke/struct_return_print.osty` | `42\n` | Phase 31 LLVM IR: simple struct value returned from a helper function and read in `main` |
+| `testdata/backend/llvm_smoke/struct_param_print.osty` | `42\n` | Phase 32 LLVM IR: simple struct value passed as a function parameter |
+| `testdata/backend/llvm_smoke/struct_mut_print.osty` | `42\n` | Phase 33 LLVM IR: mutable struct local slot, whole-value assignment, load, and field read |
+| `testdata/backend/llvm_smoke/enum_variant_print.osty` | `42\n` | Phase 34 LLVM IR: payload-free enum variants lower to Osty-owned `i64` tag values and compare in an `if` |
+| `testdata/backend/llvm_smoke/enum_return_print.osty` | `42\n` | Phase 35 LLVM IR: payload-free enum tag values cross function return boundaries |
+| `testdata/backend/llvm_smoke/enum_param_print.osty` | `42\n` | Phase 36 LLVM IR: payload-free enum tag values cross function parameter boundaries |
+| `testdata/backend/llvm_smoke/enum_mut_print.osty` | `42\n` | Phase 37 LLVM IR: mutable enum local slot, whole-value assignment, load, and comparison |
 
-The Phase 10 skeleton behavior and the Phase 12-15 plus Phase 23-24 lowering
+The Phase 10 skeleton behavior and the Phase 12-15 plus Phase 23-37 lowering
 behavior are mirrored in
 `examples/selfhost-core/llvmgen.osty` so the LLVM backend logic is authored in
 Osty first. The Go `internal/llvmgen` package includes generated bridge code
 from that Osty source for module/function/skeleton rendering. A backend test
 transpiles the Osty emitter again and compares its
-minimal/scalar/control-flow/booleans/string and skeleton output byte-for-byte
+minimal/scalar/control-flow/booleans/string/struct/enum and skeleton output byte-for-byte
 against the production bridge.
 
 These fixtures are deliberately smaller than the current examples. They are
@@ -123,6 +131,20 @@ boundaries and mutable locals. The bridge now lowers the `String` type to
 `ptr`, so String-returning functions, String parameters, and mutable String
 slots can reuse the existing self-hosted call, return, load, store, and print
 builders.
+
+Phases 30-33 add the first value-aggregate struct path. Top-level non-generic
+struct declarations lower to named LLVM types, struct literals are assembled
+with the Osty-owned `insertvalue` builder, field reads use the Osty-owned
+`extractvalue` builder, and simple struct values can cross return/parameter
+boundaries or live in mutable local slots. The Go bridge still only collects
+declaration field order and source expression shape before calling generated
+self-hosted helpers.
+
+Phases 34-37 add the first payload-free enum path. Bare variants lower to
+Osty-owned `i64` tag values, so equality, if branches, function return/parameter
+boundaries, and mutable local slots can execute before the later tagged-payload
+ABI and match lowering work. The initial smoke fixtures use unqualified variant
+names because the self-hosted checker already supports that form.
 
 ## Promotion Rules
 

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -22,14 +22,16 @@
 - Multi-file package, vendored dependency, workspace build의 실제 code emission은
   아직 제한이 있다. LLVM 전환 전에 package 단위 emit/link 모델을 분명히 해야
   한다.
-- 현재 Phase 29까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
+- 현재 Phase 37까지의 LLVM backend 의미는 `examples/selfhost-core/llvmgen.osty`
   쪽으로 옮겨지고 있다. 여기에는 smoke IR builder, skeleton renderer,
   toolchain command plan, executable parity corpus, go-only diagnostic, 그리고
   unsupported source-shape taxonomy가 포함된다. 성공 경로의 scalar instruction
   strings, temp/label naming, plain/escaped ASCII `String` `println` module
   constant/formatting shape, immutable/mutable local String value paths, and
-  simple String function return/parameter paths도 같은 selfhost-core에서
-  생성한다.
+  simple String function return/parameter paths, simple named struct type
+  definitions, struct literals, field reads, struct function boundaries, and
+  mutable struct locals, plus bare enum tag values across simple function and
+  mutable-local paths도 같은 selfhost-core에서 생성한다.
 
 ## 이주 원칙
 
@@ -326,8 +328,8 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
 | `List<T>` | `%osty.list` + element descriptor | monomorphized typed list와 erased list 중 선택 |
 | `Option<T>` | tagged payload | nullable pointer optimization은 후순위 |
 | `Result<T,E>` | tagged payload | Go backend의 `Value/Error/IsOk`와 semantic parity |
-| `struct` | named LLVM struct 또는 opaque handle | layout stability 필요 |
-| `enum` | tag + max payload storage | niche optimization은 후순위 |
+| `struct` | named LLVM struct | Phase 30-33 smoke subset uses value aggregates; full ABI/layout stability remains runtime work |
+| `enum` | `i64` tag for bare variants, tagged payload storage later | Phase 34-37 smoke subset covers payload-free variants; niche optimization is later |
 | closure | fn pointer + env pointer | capture lifetime/ownership 필요 |
 | interface | data pointer + vtable pointer | vtable generation은 Phase 5+ |
 

--- a/README.md
+++ b/README.md
@@ -239,8 +239,9 @@ newline-separated `else`.
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` emits textual `.ll` for the early scalar/control-flow/plain/escaped
   string subset, including immutable/mutable string locals and simple String
-  function boundaries, and falls back to an inspectable skeleton for unsupported
-  shapes with Osty-authored instruction builders and category diagnostics)
+  function boundaries plus simple struct aggregate values and payload-free enum
+  tags, and falls back to an inspectable skeleton for unsupported shapes with
+  Osty-authored instruction builders and category diagnostics)
 - `--emit MODE` — requested text artifact. `go` emits Go source for the Go
   backend; `llvm-ir` is reserved for the LLVM backend.
 
@@ -304,8 +305,9 @@ creating a new one.
 - `--backend NAME` — code generation backend (`go` or `llvm`; default: `go`;
   `llvm` can write textual IR for the early scalar/control-flow/plain/escaped
   string subset, including immutable/mutable string locals and simple String
-  function boundaries, and when `clang` is available, drive object/binary
-  emission for supported programs; unsupported shapes still prepare skeleton
+  function boundaries plus simple struct aggregate values and payload-free enum
+  tags, and when `clang` is available, drive object/binary emission for
+  supported programs; unsupported shapes still prepare skeleton
   artifacts and report the missing lowering through categorized diagnostics
   generated from the Osty selfhost-core backend policy; supported scalar
   instruction strings are generated from that same backend core)

--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -33,6 +33,10 @@ pub struct LlvmStringGlobal {
     pub byteLen: Int,
 }
 
+pub struct LlvmStructField {
+    pub typ: String,
+}
+
 pub struct LlvmCString {
     pub encoded: String,
     pub byteLen: Int,
@@ -95,6 +99,11 @@ pub fn llvmI1(name: String) -> LlvmValue {
 
 pub fn llvmIntLiteral(value: Int) -> LlvmValue {
     llvmI64("{value}")
+}
+
+pub fn llvmEnumVariant(enumName: String, tag: Int) -> LlvmValue {
+    let _ = enumName
+    llvmI64("{tag}")
 }
 
 pub fn llvmParam(name: String, typ: String) -> LlvmParam {
@@ -218,6 +227,42 @@ pub fn llvmCall(
     let tmp = llvmNextTemp(emitter)
     emitter.body.push("  {tmp} = call {ret} @{name}({llvmCallArgs(args)})")
     LlvmValue { typ: ret, name: tmp, pointer: false }
+}
+
+pub fn llvmStructTypeDef(name: String, fieldTypes: List<String>) -> String {
+    let fields = llvmStrings.Join(fieldTypes, ", ")
+    "%{name} = type \{ {fields} \}"
+}
+
+pub fn llvmStructLiteral(
+    emitter: LlvmEmitter,
+    typ: String,
+    fields: List<LlvmValue>,
+) -> LlvmValue {
+    let mut current = "undef"
+    let mut fieldIndex = 0
+    for field in fields {
+        let tmp = llvmNextTemp(emitter)
+        emitter.body.push(
+            "  {tmp} = insertvalue {typ} {current}, {field.typ} {field.name}, {fieldIndex}",
+        )
+        current = tmp
+        fieldIndex = fieldIndex + 1
+    }
+    LlvmValue { typ, name: current, pointer: false }
+}
+
+pub fn llvmExtractValue(
+    emitter: LlvmEmitter,
+    aggregate: LlvmValue,
+    fieldType: String,
+    fieldIndex: Int,
+) -> LlvmValue {
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push(
+        "  {tmp} = extractvalue {aggregate.typ} {aggregate.name}, {fieldIndex}",
+    )
+    LlvmValue { typ: fieldType, name: tmp, pointer: false }
 }
 
 pub fn llvmPrintlnI64(emitter: LlvmEmitter, value: LlvmValue) {
@@ -387,12 +432,22 @@ pub fn llvmReturnI32Zero(emitter: LlvmEmitter) {
 }
 
 pub fn llvmRenderModule(sourcePath: String, target: String, definitions: List<String>) -> String {
-    llvmRenderModuleWithGlobals(sourcePath, target, [], definitions)
+    llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, [], [], definitions)
 }
 
 pub fn llvmRenderModuleWithGlobals(
     sourcePath: String,
     target: String,
+    stringGlobals: List<LlvmStringGlobal>,
+    definitions: List<String>,
+) -> String {
+    llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, [], stringGlobals, definitions)
+}
+
+pub fn llvmRenderModuleWithGlobalsAndTypes(
+    sourcePath: String,
+    target: String,
+    typeDefs: List<String>,
     stringGlobals: List<LlvmStringGlobal>,
     definitions: List<String>,
 ) -> String {
@@ -405,6 +460,12 @@ pub fn llvmRenderModuleWithGlobals(
         lines.push("target triple = \"{target}\"")
     }
     lines.push("")
+    for typeDef in typeDefs {
+        lines.push(typeDef)
+    }
+    if typeDefs.len() > 0 {
+        lines.push("")
+    }
     lines.push("@.fmt_i64 = private unnamed_addr constant [5 x i8] c\"%ld\\0A\\00\"")
     lines.push("@.fmt_str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"")
     for global in stringGlobals {
@@ -695,6 +756,46 @@ pub fn llvmSmokeExecutableCorpus() -> List<LlvmSmokeExecutableCase> {
             fixture: "string_mut_print.osty",
             stdout: "after\n",
         },
+        LlvmSmokeExecutableCase {
+            name: "struct-field",
+            fixture: "struct_field_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "struct-return",
+            fixture: "struct_return_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "struct-param",
+            fixture: "struct_param_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "struct-mut",
+            fixture: "struct_mut_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "enum-variant",
+            fixture: "enum_variant_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "enum-return",
+            fixture: "enum_return_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "enum-param",
+            fixture: "enum_param_print.osty",
+            stdout: "42\n",
+        },
+        LlvmSmokeExecutableCase {
+            name: "enum-mut",
+            fixture: "enum_mut_print.osty",
+            stdout: "42\n",
+        },
     ]
 }
 
@@ -911,6 +1012,197 @@ pub fn llvmSmokeStringMutableIR(sourcePath: String) -> String {
         sourcePath,
         "",
         main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStructFieldIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let point = llvmStructLiteral(main, "%Point", [llvmIntLiteral(40), llvmIntLiteral(2)])
+    llvmImmutableLet(main, "point", point)
+    let sum = llvmBinaryI64(
+        main,
+        "add",
+        llvmExtractValue(main, llvmIdent(main, "point"), "i64", 0),
+        llvmExtractValue(main, llvmIdent(main, "point"), "i64", 1),
+    )
+    llvmPrintlnI64(main, sum)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobalsAndTypes(
+        sourcePath,
+        "",
+        [llvmStructTypeDef("Point", ["i64", "i64"])],
+        [],
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStructReturnIR(sourcePath: String) -> String {
+    let makePair = llvmEmitter()
+    let pair = llvmStructLiteral(makePair, "%Pair", [llvmIntLiteral(10), llvmIntLiteral(32)])
+    llvmReturn(makePair, pair)
+
+    let main = llvmEmitter()
+    let returned = llvmCall(main, "%Pair", "makePair", [])
+    llvmImmutableLet(main, "pair", returned)
+    let sum = llvmBinaryI64(
+        main,
+        "add",
+        llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 0),
+        llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 1),
+    )
+    llvmPrintlnI64(main, sum)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobalsAndTypes(
+        sourcePath,
+        "",
+        [llvmStructTypeDef("Pair", ["i64", "i64"])],
+        [],
+        [
+            llvmRenderFunction("%Pair", "makePair", [], makePair.body),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStructParamIR(sourcePath: String) -> String {
+    let total = llvmEmitter()
+    llvmBind(total, "score", LlvmValue { typ: "%Score", name: "%score", pointer: false })
+    let sum = llvmBinaryI64(
+        total,
+        "add",
+        llvmExtractValue(total, llvmIdent(total, "score"), "i64", 0),
+        llvmExtractValue(total, llvmIdent(total, "score"), "i64", 1),
+    )
+    llvmReturn(total, sum)
+
+    let main = llvmEmitter()
+    let score = llvmStructLiteral(main, "%Score", [llvmIntLiteral(40), llvmIntLiteral(2)])
+    let out = llvmCall(main, "i64", "total", [score])
+    llvmPrintlnI64(main, out)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobalsAndTypes(
+        sourcePath,
+        "",
+        [llvmStructTypeDef("Score", ["i64", "i64"])],
+        [],
+        [
+            llvmRenderFunction("i64", "total", [llvmParam("score", "%Score")], total.body),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeStructMutableIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    llvmMutableLet(main, "box", llvmStructLiteral(main, "%Box", [llvmIntLiteral(1)]))
+    let _ = llvmAssign(main, "box", llvmStructLiteral(main, "%Box", [llvmIntLiteral(42)]))
+    llvmPrintlnI64(main, llvmExtractValue(main, llvmIdent(main, "box"), "i64", 0))
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobalsAndTypes(
+        sourcePath,
+        "",
+        [llvmStructTypeDef("Box", ["i64"])],
+        [],
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeEnumVariantIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    llvmImmutableLet(main, "light", llvmEnumVariant("Light", 1))
+    let cond = llvmCompare(main, "eq", llvmIdent(main, "light"), llvmEnumVariant("Light", 1))
+    let labels = llvmIfStart(main, cond)
+    llvmPrintlnI64(main, llvmIntLiteral(42))
+    llvmIfElse(main, labels)
+    llvmPrintlnI64(main, llvmIntLiteral(0))
+    llvmIfEnd(main, labels)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModule(
+        sourcePath,
+        "",
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeEnumReturnIR(sourcePath: String) -> String {
+    let pick = llvmEmitter()
+    llvmReturn(pick, llvmEnumVariant("Switch", 1))
+
+    let main = llvmEmitter()
+    let state = llvmCall(main, "i64", "pick", [])
+    let cond = llvmCompare(main, "eq", state, llvmEnumVariant("Switch", 1))
+    let labels = llvmIfStart(main, cond)
+    llvmPrintlnI64(main, llvmIntLiteral(42))
+    llvmIfElse(main, labels)
+    llvmPrintlnI64(main, llvmIntLiteral(0))
+    llvmIfEnd(main, labels)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModule(
+        sourcePath,
+        "",
+        [
+            llvmRenderFunction("i64", "pick", [], pick.body),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeEnumParamIR(sourcePath: String) -> String {
+    let score = llvmEmitter()
+    llvmBind(score, "state", llvmI64("%state"))
+    let cond = llvmCompare(score, "eq", llvmIdent(score, "state"), llvmEnumVariant("Switch", 1))
+    let labels = llvmIfExprStart(score, cond)
+    let thenValue = llvmIntLiteral(42)
+    llvmIfExprElse(score, labels)
+    let elseValue = llvmIntLiteral(0)
+    let out = llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
+    llvmReturn(score, out)
+
+    let main = llvmEmitter()
+    let result = llvmCall(main, "i64", "score", [llvmEnumVariant("Switch", 1)])
+    llvmPrintlnI64(main, result)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModule(
+        sourcePath,
+        "",
+        [
+            llvmRenderFunction("i64", "score", [llvmParam("state", "i64")], score.body),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+pub fn llvmSmokeEnumMutableIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    llvmMutableLet(main, "state", llvmEnumVariant("Switch", 0))
+    let _ = llvmAssign(main, "state", llvmEnumVariant("Switch", 1))
+    let cond = llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
+    let labels = llvmIfStart(main, cond)
+    llvmPrintlnI64(main, llvmIntLiteral(42))
+    llvmIfElse(main, labels)
+    llvmPrintlnI64(main, llvmIntLiteral(0))
+    llvmIfEnd(main, labels)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModule(
+        sourcePath,
+        "",
         [
             llvmRenderFunction("i32", "main", [], main.body),
         ],

--- a/examples/selfhost-core/llvmgen_test.osty
+++ b/examples/selfhost-core/llvmgen_test.osty
@@ -81,7 +81,7 @@ fn testLlvmToolchainPlanIsOstyOwned() {
 fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     let cases = llvmSmokeExecutableCorpus()
 
-    testing.assert(cases.len() == 10)
+    testing.assert(cases.len() == 18)
     testing.assert(cases[0].name == "minimal")
     testing.assert(cases[0].fixture == "minimal_print.osty")
     testing.assert(cases[0].stdout == "42\n")
@@ -112,6 +112,30 @@ fn testLlvmExecutableCorpusPlanIsOstyOwned() {
     testing.assert(cases[9].name == "string-mut")
     testing.assert(cases[9].fixture == "string_mut_print.osty")
     testing.assert(cases[9].stdout == "after\n")
+    testing.assert(cases[10].name == "struct-field")
+    testing.assert(cases[10].fixture == "struct_field_print.osty")
+    testing.assert(cases[10].stdout == "42\n")
+    testing.assert(cases[11].name == "struct-return")
+    testing.assert(cases[11].fixture == "struct_return_print.osty")
+    testing.assert(cases[11].stdout == "42\n")
+    testing.assert(cases[12].name == "struct-param")
+    testing.assert(cases[12].fixture == "struct_param_print.osty")
+    testing.assert(cases[12].stdout == "42\n")
+    testing.assert(cases[13].name == "struct-mut")
+    testing.assert(cases[13].fixture == "struct_mut_print.osty")
+    testing.assert(cases[13].stdout == "42\n")
+    testing.assert(cases[14].name == "enum-variant")
+    testing.assert(cases[14].fixture == "enum_variant_print.osty")
+    testing.assert(cases[14].stdout == "42\n")
+    testing.assert(cases[15].name == "enum-return")
+    testing.assert(cases[15].fixture == "enum_return_print.osty")
+    testing.assert(cases[15].stdout == "42\n")
+    testing.assert(cases[16].name == "enum-param")
+    testing.assert(cases[16].fixture == "enum_param_print.osty")
+    testing.assert(cases[16].stdout == "42\n")
+    testing.assert(cases[17].name == "enum-mut")
+    testing.assert(cases[17].fixture == "enum_mut_print.osty")
+    testing.assert(cases[17].stdout == "42\n")
 }
 
 fn testLlvmUnsupportedDiagnosticPolicyIsOstyOwned() {
@@ -273,4 +297,79 @@ fn testLlvmSmokeStringMutableIsOstyOwned() {
     assertLlvmContains(ir, "store ptr @.str1")
     assertLlvmContains(ir, "load ptr")
     assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str")
+}
+
+fn testLlvmSmokeStructFieldIsOstyOwned() {
+    let ir = llvmSmokeStructFieldIR("/tmp/struct_field_print.osty")
+
+    assertLlvmContains(ir, "%Point = type \{ i64, i64 \}")
+    assertLlvmContains(ir, "insertvalue %Point undef, i64 40, 0")
+    assertLlvmContains(ir, "insertvalue %Point %t0, i64 2, 1")
+    assertLlvmContains(ir, "extractvalue %Point")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64")
+}
+
+fn testLlvmSmokeStructReturnIsOstyOwned() {
+    let ir = llvmSmokeStructReturnIR("/tmp/struct_return_print.osty")
+
+    assertLlvmContains(ir, "%Pair = type \{ i64, i64 \}")
+    assertLlvmContains(ir, "define %Pair @makePair() \{")
+    assertLlvmContains(ir, "ret %Pair")
+    assertLlvmContains(ir, "call %Pair @makePair()")
+    assertLlvmContains(ir, "extractvalue %Pair")
+}
+
+fn testLlvmSmokeStructParamIsOstyOwned() {
+    let ir = llvmSmokeStructParamIR("/tmp/struct_param_print.osty")
+
+    assertLlvmContains(ir, "%Score = type \{ i64, i64 \}")
+    assertLlvmContains(ir, "define i64 @total(%Score %score) \{")
+    assertLlvmContains(ir, "extractvalue %Score %score, 0")
+    assertLlvmContains(ir, "call i64 @total(%Score")
+}
+
+fn testLlvmSmokeStructMutableIsOstyOwned() {
+    let ir = llvmSmokeStructMutableIR("/tmp/struct_mut_print.osty")
+
+    assertLlvmContains(ir, "%Box = type \{ i64 \}")
+    assertLlvmContains(ir, "alloca %Box")
+    assertLlvmContains(ir, "store %Box")
+    assertLlvmContains(ir, "load %Box")
+    assertLlvmContains(ir, "extractvalue %Box")
+}
+
+fn testLlvmSmokeEnumVariantIsOstyOwned() {
+    let ir = llvmSmokeEnumVariantIR("/tmp/enum_variant_print.osty")
+
+    assertLlvmContains(ir, "icmp eq i64 1, 1")
+    assertLlvmContains(ir, "br i1")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 42)")
+}
+
+fn testLlvmSmokeEnumReturnIsOstyOwned() {
+    let ir = llvmSmokeEnumReturnIR("/tmp/enum_return_print.osty")
+
+    assertLlvmContains(ir, "define i64 @pick() \{")
+    assertLlvmContains(ir, "ret i64 1")
+    assertLlvmContains(ir, "call i64 @pick()")
+    assertLlvmContains(ir, "icmp eq i64")
+}
+
+fn testLlvmSmokeEnumParamIsOstyOwned() {
+    let ir = llvmSmokeEnumParamIR("/tmp/enum_param_print.osty")
+
+    assertLlvmContains(ir, "define i64 @score(i64 %state) \{")
+    assertLlvmContains(ir, "icmp eq i64 %state, 1")
+    assertLlvmContains(ir, "phi i64")
+    assertLlvmContains(ir, "call i64 @score(i64 1)")
+}
+
+fn testLlvmSmokeEnumMutableIsOstyOwned() {
+    let ir = llvmSmokeEnumMutableIR("/tmp/enum_mut_print.osty")
+
+    assertLlvmContains(ir, "alloca i64")
+    assertLlvmContains(ir, "store i64 0")
+    assertLlvmContains(ir, "store i64 1")
+    assertLlvmContains(ir, "load i64")
+    assertLlvmContains(ir, "icmp eq i64")
 }

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -6,7 +6,8 @@
 // can produce textual IR and drive a host clang toolchain for supported
 // object/binary artifacts. LLVM backend meaning, including scalar instruction
 // builders, plain/escaped ASCII string constants/local values/function values,
-// and unsupported-source diagnostic categories, is authored in Osty
+// simple struct aggregate values, payload-free enum tag values, and
+// unsupported-source diagnostic categories, is authored in Osty
 // selfhost-core; this package remains the bootstrap host shim for file I/O and
 // process execution.
 package backend

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -3,14 +3,15 @@
 // The first implementation is deliberately small: it supports no-arg main
 // functions or script files, integer println expressions, plain ASCII string
 // println literals, local string values with simple escapes, simple String
-// returns/parameters, immutable scalar lets, mutable scalar locals, simple
-// Int/Bool helper functions, statement-position if/else, value-position
-// if/else, simple Bool logical operators, and inclusive/exclusive Int range
-// loops.
+// returns/parameters, simple value-aggregate structs, payload-free enum tags,
+// immutable scalar lets, mutable scalar locals, simple Int/Bool helper
+// functions, statement-position if/else, value-position if/else, simple Bool
+// logical operators, and inclusive/exclusive Int range loops.
 // Unsupported shapes return ErrUnsupported so callers can fall back to
 // inspectable skeleton IR while the backend grows. The module/function/skeleton
-// renderers, scalar/string instruction builders, LLVM toolchain command plans,
-// executable parity plans, and categorized unsupported/backend-capability
-// diagnostics are generated from examples/selfhost-core/llvmgen.osty so the
-// backend meaning is owned by Osty source.
+// renderers, scalar/string/struct/enum instruction builders, LLVM toolchain
+// command plans, executable parity plans, and categorized
+// unsupported/backend-capability diagnostics are generated from
+// examples/selfhost-core/llvmgen.osty so the backend meaning is owned by Osty
+// source.
 package llvmgen

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -203,13 +203,17 @@ func Generate(file *ast.File, opts Options) ([]byte, error) {
 		}
 		return g.render([]string{mainIR}), nil
 	}
-	decls, err := collectFunctions(file)
+	decls, err := collectDeclarations(file)
 	if err != nil {
 		return nil, err
 	}
-	g.functions = decls.byName
+	g.functions = decls.functionsByName
+	g.structs = decls.structsOrdered
+	g.structsByName = decls.structsByName
+	g.structsByType = decls.structsByType
+	g.enumsByName = decls.enumsByName
 	var defs []string
-	for _, sig := range decls.ordered {
+	for _, sig := range decls.functionsOrdered {
 		if sig.name == "main" {
 			continue
 		}
@@ -219,7 +223,7 @@ func Generate(file *ast.File, opts Options) ([]byte, error) {
 		}
 		defs = append(defs, def)
 	}
-	mainSig := decls.byName["main"]
+	mainSig := decls.functionsByName["main"]
 	if mainSig == nil {
 		return nil, unsupported("source-layout", "missing main function or script statements")
 	}
@@ -241,9 +245,13 @@ func fileUnsupportedDiagnostic(file *ast.File) (UnsupportedDiagnostic, bool) {
 }
 
 type generator struct {
-	sourcePath string
-	target     string
-	functions  map[string]*fnSig
+	sourcePath    string
+	target        string
+	functions     map[string]*fnSig
+	structs       []*structInfo
+	structsByName map[string]*structInfo
+	structsByType map[string]*structInfo
+	enumsByName   map[string]*enumInfo
 
 	temp       int
 	label      int
@@ -254,9 +262,14 @@ type generator struct {
 	returnType string
 }
 
-type fnDecls struct {
-	ordered []*fnSig
-	byName  map[string]*fnSig
+type declarations struct {
+	functionsOrdered []*fnSig
+	functionsByName  map[string]*fnSig
+	structsOrdered   []*structInfo
+	structsByName    map[string]*structInfo
+	structsByType    map[string]*structInfo
+	enumsOrdered     []*enumInfo
+	enumsByName      map[string]*enumInfo
 }
 
 type fnSig struct {
@@ -271,33 +284,186 @@ type paramInfo struct {
 	typ  string
 }
 
+type structInfo struct {
+	name   string
+	typ    string
+	decl   *ast.StructDecl
+	fields []fieldInfo
+	byName map[string]fieldInfo
+}
+
+type fieldInfo struct {
+	name  string
+	typ   string
+	index int
+}
+
+type enumInfo struct {
+	name     string
+	decl     *ast.EnumDecl
+	variants map[string]variantInfo
+}
+
+type variantInfo struct {
+	name string
+	tag  int
+}
+
 type value struct {
 	typ string
 	ref string
 	ptr bool
 }
 
-func collectFunctions(file *ast.File) (*fnDecls, error) {
-	out := &fnDecls{byName: map[string]*fnSig{}}
+func collectDeclarations(file *ast.File) (*declarations, error) {
+	out := &declarations{
+		functionsByName: map[string]*fnSig{},
+		structsByName:   map[string]*structInfo{},
+		structsByType:   map[string]*structInfo{},
+		enumsByName:     map[string]*enumInfo{},
+	}
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.StructDecl:
+			info, err := collectStructShell(d)
+			if err != nil {
+				return nil, err
+			}
+			if _, exists := out.structsByName[info.name]; exists {
+				return nil, unsupportedf("source-layout", "duplicate struct %q", info.name)
+			}
+			out.structsOrdered = append(out.structsOrdered, info)
+			out.structsByName[info.name] = info
+			out.structsByType[info.typ] = info
+		case *ast.EnumDecl:
+			info, err := collectEnum(d)
+			if err != nil {
+				return nil, err
+			}
+			if _, exists := out.enumsByName[info.name]; exists {
+				return nil, unsupportedf("source-layout", "duplicate enum %q", info.name)
+			}
+			out.enumsOrdered = append(out.enumsOrdered, info)
+			out.enumsByName[info.name] = info
+		case *ast.FnDecl:
+			// Function signatures are collected after struct shells so named
+			// struct types can appear in parameters and returns.
+		default:
+			return nil, unsupportedf("source-layout", "top-level declaration %T", decl)
+		}
+	}
+	for _, info := range out.structsOrdered {
+		if err := collectStructFields(info, out.structsByName); err != nil {
+			return nil, err
+		}
+	}
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FnDecl)
 		if !ok {
-			return nil, unsupportedf("source-layout", "top-level declaration %T", decl)
+			continue
 		}
-		sig, err := signatureOf(fn)
+		sig, err := signatureOf(fn, out.structsByName, out.enumsByName)
 		if err != nil {
 			return nil, err
 		}
-		if _, exists := out.byName[sig.name]; exists {
+		if _, exists := out.functionsByName[sig.name]; exists {
 			return nil, unsupportedf("source-layout", "duplicate function %q", sig.name)
 		}
-		out.ordered = append(out.ordered, sig)
-		out.byName[sig.name] = sig
+		out.functionsOrdered = append(out.functionsOrdered, sig)
+		out.functionsByName[sig.name] = sig
 	}
 	return out, nil
 }
 
-func signatureOf(fn *ast.FnDecl) (*fnSig, error) {
+func collectStructShell(decl *ast.StructDecl) (*structInfo, error) {
+	if decl == nil {
+		return nil, unsupported("source-layout", "nil struct")
+	}
+	if !isLLVMIdent(decl.Name) {
+		return nil, unsupportedf("name", "struct name %q", decl.Name)
+	}
+	if len(decl.Generics) != 0 {
+		return nil, unsupportedf("type-system", "generic struct %q is not supported", decl.Name)
+	}
+	if len(decl.Methods) != 0 {
+		return nil, unsupportedf("function-signature", "struct %q methods are not supported", decl.Name)
+	}
+	return &structInfo{
+		name:   decl.Name,
+		typ:    "%" + decl.Name,
+		decl:   decl,
+		byName: map[string]fieldInfo{},
+	}, nil
+}
+
+func collectStructFields(info *structInfo, structs map[string]*structInfo) error {
+	if info == nil || info.decl == nil {
+		return unsupported("source-layout", "nil struct")
+	}
+	for i, field := range info.decl.Fields {
+		if field == nil {
+			return unsupportedf("source-layout", "struct %q has nil field", info.name)
+		}
+		if !isLLVMIdent(field.Name) {
+			return unsupportedf("name", "struct %q field name %q", info.name, field.Name)
+		}
+		if field.Default != nil {
+			return unsupportedf("type-system", "struct %q field %q has a default value", info.name, field.Name)
+		}
+		if _, exists := info.byName[field.Name]; exists {
+			return unsupportedf("source-layout", "struct %q duplicate field %q", info.name, field.Name)
+		}
+		typ, err := llvmType(field.Type, structs, nil)
+		if err != nil {
+			return unsupportedf("type-system", "struct %q field %q: %s", info.name, field.Name, unsupportedMessage(err))
+		}
+		if typ == info.typ {
+			return unsupportedf("type-system", "struct %q recursive field %q", info.name, field.Name)
+		}
+		fieldInfo := fieldInfo{name: field.Name, typ: typ, index: i}
+		info.fields = append(info.fields, fieldInfo)
+		info.byName[field.Name] = fieldInfo
+	}
+	return nil
+}
+
+func collectEnum(decl *ast.EnumDecl) (*enumInfo, error) {
+	if decl == nil {
+		return nil, unsupported("source-layout", "nil enum")
+	}
+	if !isLLVMIdent(decl.Name) {
+		return nil, unsupportedf("name", "enum name %q", decl.Name)
+	}
+	if len(decl.Generics) != 0 {
+		return nil, unsupportedf("type-system", "generic enum %q is not supported", decl.Name)
+	}
+	if len(decl.Methods) != 0 {
+		return nil, unsupportedf("function-signature", "enum %q methods are not supported", decl.Name)
+	}
+	info := &enumInfo{
+		name:     decl.Name,
+		decl:     decl,
+		variants: map[string]variantInfo{},
+	}
+	for i, variant := range decl.Variants {
+		if variant == nil {
+			return nil, unsupportedf("source-layout", "enum %q has nil variant", decl.Name)
+		}
+		if !isLLVMIdent(variant.Name) {
+			return nil, unsupportedf("name", "enum %q variant name %q", decl.Name, variant.Name)
+		}
+		if len(variant.Fields) != 0 {
+			return nil, unsupportedf("type-system", "enum %q variant %q payloads are not supported", decl.Name, variant.Name)
+		}
+		if _, exists := info.variants[variant.Name]; exists {
+			return nil, unsupportedf("source-layout", "enum %q duplicate variant %q", decl.Name, variant.Name)
+		}
+		info.variants[variant.Name] = variantInfo{name: variant.Name, tag: i}
+	}
+	return info, nil
+}
+
+func signatureOf(fn *ast.FnDecl, structs map[string]*structInfo, enums map[string]*enumInfo) (*fnSig, error) {
 	if fn == nil {
 		return nil, unsupported("source-layout", "nil function")
 	}
@@ -320,7 +486,7 @@ func signatureOf(fn *ast.FnDecl) (*fnSig, error) {
 		}
 		return sig, nil
 	}
-	ret, err := llvmType(fn.ReturnType)
+	ret, err := llvmType(fn.ReturnType, structs, enums)
 	if err != nil {
 		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
 	}
@@ -335,7 +501,7 @@ func signatureOf(fn *ast.FnDecl) (*fnSig, error) {
 		if !isLLVMIdent(p.Name) {
 			return nil, unsupportedf("name", "parameter name %q", p.Name)
 		}
-		typ, err := llvmType(p.Type)
+		typ, err := llvmType(p.Type, structs, enums)
 		if err != nil {
 			return nil, unsupportedf("type-system", "function %q parameter %q: %s", fn.Name, p.Name, unsupportedMessage(err))
 		}
@@ -476,7 +642,7 @@ func (g *generator) emitLet(stmt *ast.LetStmt) error {
 		return err
 	}
 	if stmt.Type != nil {
-		typ, err := llvmType(stmt.Type)
+		typ, err := llvmType(stmt.Type, g.structsByName, g.enumsByName)
 		if err != nil {
 			return err
 		}
@@ -686,16 +852,7 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 	case *ast.StringLit:
 		return g.emitStringLiteral(e)
 	case *ast.Ident:
-		if v, ok := g.lookupLocal(e.Name); ok {
-			if v.ptr {
-				emitter := g.toOstyEmitter()
-				out := llvmLoad(emitter, toOstyValue(v))
-				g.takeOstyEmitter(emitter)
-				return fromOstyValue(out), nil
-			}
-			return v, nil
-		}
-		return value{}, unsupportedf("name", "unknown identifier %q", e.Name)
+		return g.emitIdent(e.Name)
 	case *ast.ParenExpr:
 		return g.emitExpr(e.X)
 	case *ast.UnaryExpr:
@@ -704,11 +861,153 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 		return g.emitBinary(e)
 	case *ast.CallExpr:
 		return g.emitCall(e)
+	case *ast.FieldExpr:
+		return g.emitFieldExpr(e)
+	case *ast.StructLit:
+		return g.emitStructLit(e)
 	case *ast.IfExpr:
 		return g.emitIfExprValue(e)
 	default:
 		return value{}, unsupportedf("expression", "expression %T", expr)
 	}
+}
+
+func (g *generator) emitIdent(name string) (value, error) {
+	if v, ok := g.lookupLocal(name); ok {
+		return g.loadIfPointer(v)
+	}
+	if v, found, err := g.enumVariantIdent(name); found || err != nil {
+		return v, err
+	}
+	return value{}, unsupportedf("name", "unknown identifier %q", name)
+}
+
+func (g *generator) loadIfPointer(v value) (value, error) {
+	if !v.ptr {
+		return v, nil
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmLoad(emitter, toOstyValue(v))
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), nil
+}
+
+func (g *generator) emitStructLit(lit *ast.StructLit) (value, error) {
+	typeName, ok := structTypeExprName(lit.Type)
+	if !ok {
+		return value{}, unsupportedf("type-system", "struct literal type %T", lit.Type)
+	}
+	info := g.structsByName[typeName]
+	if info == nil {
+		return value{}, unsupportedf("type-system", "unknown struct %q", typeName)
+	}
+	if lit.Spread != nil {
+		return value{}, unsupportedf("expression", "struct %q spread literal", typeName)
+	}
+	fields := map[string]*ast.StructLitField{}
+	for _, field := range lit.Fields {
+		if field == nil {
+			return value{}, unsupportedf("expression", "struct %q has nil literal field", typeName)
+		}
+		if !isLLVMIdent(field.Name) {
+			return value{}, unsupportedf("name", "struct %q literal field name %q", typeName, field.Name)
+		}
+		if _, exists := fields[field.Name]; exists {
+			return value{}, unsupportedf("expression", "struct %q duplicate literal field %q", typeName, field.Name)
+		}
+		if _, exists := info.byName[field.Name]; !exists {
+			return value{}, unsupportedf("expression", "struct %q unknown literal field %q", typeName, field.Name)
+		}
+		fields[field.Name] = field
+	}
+	values := make([]*LlvmValue, 0, len(info.fields))
+	for _, field := range info.fields {
+		litField := fields[field.name]
+		if litField == nil {
+			return value{}, unsupportedf("expression", "struct %q missing literal field %q", typeName, field.name)
+		}
+		var v value
+		var err error
+		if litField.Value == nil {
+			v, err = g.emitIdent(litField.Name)
+		} else {
+			v, err = g.emitExpr(litField.Value)
+		}
+		if err != nil {
+			return value{}, err
+		}
+		if v.typ != field.typ {
+			return value{}, unsupportedf("type-system", "struct %q field %q type %s, value %s", typeName, field.name, field.typ, v.typ)
+		}
+		values = append(values, toOstyValue(v))
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmStructLiteral(emitter, info.typ, values)
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), nil
+}
+
+func (g *generator) emitFieldExpr(expr *ast.FieldExpr) (value, error) {
+	if expr.IsOptional {
+		return value{}, unsupported("expression", "optional field access is not supported")
+	}
+	if v, ok := g.enumVariantValue(expr); ok {
+		return v, nil
+	}
+	base, err := g.emitExpr(expr.X)
+	if err != nil {
+		return value{}, err
+	}
+	info := g.structsByType[base.typ]
+	if info == nil {
+		return value{}, unsupportedf("type-system", "field access on %s", base.typ)
+	}
+	field, ok := info.byName[expr.Name]
+	if !ok {
+		return value{}, unsupportedf("expression", "struct %q has no field %q", info.name, expr.Name)
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmExtractValue(emitter, toOstyValue(base), field.typ, field.index)
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), nil
+}
+
+func (g *generator) enumVariantValue(expr *ast.FieldExpr) (value, bool) {
+	base, ok := expr.X.(*ast.Ident)
+	if !ok {
+		return value{}, false
+	}
+	info := g.enumsByName[base.Name]
+	if info == nil {
+		return value{}, false
+	}
+	variant, ok := info.variants[expr.Name]
+	if !ok {
+		return value{}, false
+	}
+	out := llvmEnumVariant(info.name, variant.tag)
+	return fromOstyValue(out), true
+}
+
+func (g *generator) enumVariantIdent(name string) (value, bool, error) {
+	var foundEnum string
+	var found variantInfo
+	count := 0
+	for _, info := range g.enumsByName {
+		if variant, ok := info.variants[name]; ok {
+			foundEnum = info.name
+			found = variant
+			count++
+		}
+	}
+	if count == 0 {
+		return value{}, false, nil
+	}
+	if count > 1 {
+		return value{}, true, unsupportedf("name", "ambiguous enum variant %q", name)
+	}
+	out := llvmEnumVariant(foundEnum, found.tag)
+	return fromOstyValue(out), true, nil
 }
 
 func (g *generator) emitUnary(e *ast.UnaryExpr) (value, error) {
@@ -950,7 +1249,15 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 }
 
 func (g *generator) render(defs []string) []byte {
-	return []byte(llvmRenderModuleWithGlobals(g.sourcePath, g.target, g.stringDefs, defs))
+	typeDefs := make([]string, 0, len(g.structs))
+	for _, info := range g.structs {
+		fieldTypes := make([]string, 0, len(info.fields))
+		for _, field := range info.fields {
+			fieldTypes = append(fieldTypes, field.typ)
+		}
+		typeDefs = append(typeDefs, llvmStructTypeDef(info.name, fieldTypes))
+	}
+	return []byte(llvmRenderModuleWithGlobalsAndTypes(g.sourcePath, g.target, typeDefs, g.stringDefs, defs))
 }
 
 func (g *generator) renderFunction(ret, name string, params []paramInfo) string {
@@ -1003,6 +1310,14 @@ func plainStringLiteral(lit *ast.StringLit) (string, bool) {
 		b.WriteString(part.Lit)
 	}
 	return b.String(), true
+}
+
+func structTypeExprName(expr ast.Expr) (string, bool) {
+	id, ok := expr.(*ast.Ident)
+	if !ok || id.Name == "" {
+		return "", false
+	}
+	return id.Name, true
 }
 
 func isLLVMASCIIStringText(text string) bool {
@@ -1059,7 +1374,7 @@ func identPatternName(p ast.Pattern) (string, error) {
 	return id.Name, nil
 }
 
-func llvmType(t ast.Type) (string, error) {
+func llvmType(t ast.Type, structs map[string]*structInfo, enums map[string]*enumInfo) (string, error) {
 	named, ok := t.(*ast.NamedType)
 	if !ok {
 		return "", unsupportedf("type-system", "type %T", t)
@@ -1075,6 +1390,13 @@ func llvmType(t ast.Type) (string, error) {
 	case "String":
 		return "ptr", nil
 	default:
+		if info := structs[named.Path[0]]; info != nil {
+			return info.typ, nil
+		}
+		if info := enums[named.Path[0]]; info != nil {
+			_ = info
+			return "i64", nil
+		}
 		return "", unsupportedf("type-system", "type %q", strings.Join(named.Path, "."))
 	}
 }

--- a/internal/llvmgen/osty_generated.go
+++ b/internal/llvmgen/osty_generated.go
@@ -5,6 +5,7 @@ package llvmgen
 
 import (
 	"fmt"
+	"math"
 	llvmStrings "strings"
 )
 
@@ -55,12 +56,17 @@ type LlvmStringGlobal struct {
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:36:5
+type LlvmStructField struct {
+	typ string
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:40:5
 type LlvmCString struct {
 	encoded string
 	byteLen int
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:41:5
+// Osty: examples/selfhost-core/llvmgen.osty:45:5
 type LlvmEmitter struct {
 	temp          int
 	label         int
@@ -70,14 +76,14 @@ type LlvmEmitter struct {
 	stringGlobals []*LlvmStringGlobal
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:50:5
+// Osty: examples/selfhost-core/llvmgen.osty:54:5
 type LlvmIfLabels struct {
 	thenLabel string
 	elseLabel string
 	endLabel  string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:56:5
+// Osty: examples/selfhost-core/llvmgen.osty:60:5
 type LlvmRangeLoop struct {
 	condLabel string
 	bodyLabel string
@@ -86,14 +92,14 @@ type LlvmRangeLoop struct {
 	current   string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:64:5
+// Osty: examples/selfhost-core/llvmgen.osty:68:5
 type LlvmSmokeExecutableCase struct {
 	name    string
 	fixture string
 	stdout  string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:70:5
+// Osty: examples/selfhost-core/llvmgen.osty:74:5
 type LlvmUnsupportedDiagnostic struct {
 	code    string
 	kind    string
@@ -101,80 +107,87 @@ type LlvmUnsupportedDiagnostic struct {
 	hint    string
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:77:5
+// Osty: examples/selfhost-core/llvmgen.osty:81:5
 func llvmEmitter() *LlvmEmitter {
 	return &LlvmEmitter{temp: 0, label: 0, stringId: 0, body: make([]string, 0, 1), locals: make([]*LlvmBinding, 0, 1), stringGlobals: make([]*LlvmStringGlobal, 0, 1)}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:88:5
+// Osty: examples/selfhost-core/llvmgen.osty:92:5
 func llvmI64(name string) *LlvmValue {
 	return &LlvmValue{typ: "i64", name: name, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:92:5
+// Osty: examples/selfhost-core/llvmgen.osty:96:5
 func llvmI1(name string) *LlvmValue {
 	return &LlvmValue{typ: "i1", name: name, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:96:5
+// Osty: examples/selfhost-core/llvmgen.osty:100:5
 func llvmIntLiteral(value int) *LlvmValue {
 	return llvmI64(fmt.Sprintf("%s", ostyToString(value)))
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:100:5
+// Osty: examples/selfhost-core/llvmgen.osty:104:5
+func llvmEnumVariant(enumName string, tag int) *LlvmValue {
+	// Osty: examples/selfhost-core/llvmgen.osty:105:5
+	_ = enumName
+	return llvmI64(fmt.Sprintf("%s", ostyToString(tag)))
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:109:5
 func llvmParam(name string, typ string) *LlvmParam {
 	return &LlvmParam{name: name, typ: typ}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:104:5
+// Osty: examples/selfhost-core/llvmgen.osty:113:5
 func llvmBind(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:105:5
+	// Osty: examples/selfhost-core/llvmgen.osty:114:5
 	func() struct{} {
 		emitter.locals = append(emitter.locals, &LlvmBinding{name: name, value: value})
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:108:5
+// Osty: examples/selfhost-core/llvmgen.osty:117:5
 func llvmLookup(emitter *LlvmEmitter, name string) *LlvmLookup {
-	// Osty: examples/selfhost-core/llvmgen.osty:109:5
+	// Osty: examples/selfhost-core/llvmgen.osty:118:5
 	out := &LlvmLookup{found: false, value: llvmI64("0")}
 	_ = out
-	// Osty: examples/selfhost-core/llvmgen.osty:110:5
+	// Osty: examples/selfhost-core/llvmgen.osty:119:5
 	for _, binding := range emitter.locals {
-		// Osty: examples/selfhost-core/llvmgen.osty:111:9
+		// Osty: examples/selfhost-core/llvmgen.osty:120:9
 		if binding.name == name {
-			// Osty: examples/selfhost-core/llvmgen.osty:112:17
+			// Osty: examples/selfhost-core/llvmgen.osty:121:13
 			out = &LlvmLookup{found: true, value: binding.value}
 		}
 	}
 	return out
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:118:5
+// Osty: examples/selfhost-core/llvmgen.osty:127:5
 func llvmIdent(emitter *LlvmEmitter, name string) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:119:5
+	// Osty: examples/selfhost-core/llvmgen.osty:128:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: examples/selfhost-core/llvmgen.osty:120:5
+	// Osty: examples/selfhost-core/llvmgen.osty:129:5
 	if !(lookup.found) {
-		// Osty: examples/selfhost-core/llvmgen.osty:121:9
+		// Osty: examples/selfhost-core/llvmgen.osty:130:9
 		return llvmI64("0")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:123:5
+	// Osty: examples/selfhost-core/llvmgen.osty:132:5
 	if lookup.value.pointer {
-		// Osty: examples/selfhost-core/llvmgen.osty:124:9
+		// Osty: examples/selfhost-core/llvmgen.osty:133:9
 		return llvmLoad(emitter, lookup.value)
 	}
 	return lookup.value
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:129:5
+// Osty: examples/selfhost-core/llvmgen.osty:138:5
 func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:130:5
+	// Osty: examples/selfhost-core/llvmgen.osty:139:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:131:5
+	// Osty: examples/selfhost-core/llvmgen.osty:140:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(slot.typ), ostyToString(slot.name)))
 		return struct{}{}
@@ -182,72 +195,72 @@ func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
 	return &LlvmValue{typ: slot.typ, name: tmp, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:135:5
+// Osty: examples/selfhost-core/llvmgen.osty:144:5
 func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:140:5
+	// Osty: examples/selfhost-core/llvmgen.osty:149:5
 	ptr := llvmNextTemp(emitter)
 	_ = ptr
-	// Osty: examples/selfhost-core/llvmgen.osty:141:5
+	// Osty: examples/selfhost-core/llvmgen.osty:150:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(ptr), ostyToString(initial.typ)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:142:5
+	// Osty: examples/selfhost-core/llvmgen.osty:151:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(initial.typ), ostyToString(initial.name), ostyToString(ptr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:143:5
+	// Osty: examples/selfhost-core/llvmgen.osty:152:5
 	slot := &LlvmValue{typ: initial.typ, name: ptr, pointer: true}
 	_ = slot
-	// Osty: examples/selfhost-core/llvmgen.osty:144:5
+	// Osty: examples/selfhost-core/llvmgen.osty:153:5
 	llvmBind(emitter, name, slot)
 	return slot
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:148:5
+// Osty: examples/selfhost-core/llvmgen.osty:157:5
 func llvmMutableLet(emitter *LlvmEmitter, name string, initial *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:149:5
+	// Osty: examples/selfhost-core/llvmgen.osty:158:5
 	_slot := llvmMutableLetSlot(emitter, name, initial)
 	_ = _slot
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:152:5
+// Osty: examples/selfhost-core/llvmgen.osty:161:5
 func llvmStore(emitter *LlvmEmitter, slot *LlvmValue, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:153:5
+	// Osty: examples/selfhost-core/llvmgen.osty:162:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(slot.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:156:5
+// Osty: examples/selfhost-core/llvmgen.osty:165:5
 func llvmAssign(emitter *LlvmEmitter, name string, value *LlvmValue) bool {
-	// Osty: examples/selfhost-core/llvmgen.osty:157:5
+	// Osty: examples/selfhost-core/llvmgen.osty:166:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: examples/selfhost-core/llvmgen.osty:158:5
+	// Osty: examples/selfhost-core/llvmgen.osty:167:5
 	if !(lookup.found) || !(lookup.value.pointer) || lookup.value.typ != value.typ {
-		// Osty: examples/selfhost-core/llvmgen.osty:159:9
+		// Osty: examples/selfhost-core/llvmgen.osty:168:9
 		return false
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:161:5
+	// Osty: examples/selfhost-core/llvmgen.osty:170:5
 	llvmStore(emitter, lookup.value, value)
 	return true
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:165:5
+// Osty: examples/selfhost-core/llvmgen.osty:174:5
 func llvmImmutableLet(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:166:5
+	// Osty: examples/selfhost-core/llvmgen.osty:175:5
 	llvmBind(emitter, name, value)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:173:5
+// Osty: examples/selfhost-core/llvmgen.osty:182:5
 func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:179:5
+	// Osty: examples/selfhost-core/llvmgen.osty:188:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:180:5
+	// Osty: examples/selfhost-core/llvmgen.osty:189:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i64 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -255,12 +268,12 @@ func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI64(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:184:5
+// Osty: examples/selfhost-core/llvmgen.osty:193:5
 func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:190:5
+	// Osty: examples/selfhost-core/llvmgen.osty:199:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:191:5
+	// Osty: examples/selfhost-core/llvmgen.osty:200:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s %s %s, %s", ostyToString(tmp), ostyToString(pred), ostyToString(left.typ), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -268,12 +281,12 @@ func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:195:5
+// Osty: examples/selfhost-core/llvmgen.osty:204:5
 func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:196:5
+	// Osty: examples/selfhost-core/llvmgen.osty:205:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:197:5
+	// Osty: examples/selfhost-core/llvmgen.osty:206:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = xor i1 %s, true", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
@@ -281,12 +294,12 @@ func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmI1(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:201:5
+// Osty: examples/selfhost-core/llvmgen.osty:210:5
 func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:207:5
+	// Osty: examples/selfhost-core/llvmgen.osty:216:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:208:5
+	// Osty: examples/selfhost-core/llvmgen.osty:217:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i1 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -294,12 +307,12 @@ func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:212:5
+// Osty: examples/selfhost-core/llvmgen.osty:221:5
 func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:218:5
+	// Osty: examples/selfhost-core/llvmgen.osty:227:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:219:5
+	// Osty: examples/selfhost-core/llvmgen.osty:228:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s @%s(%s)", ostyToString(tmp), ostyToString(ret), ostyToString(name), ostyToString(llvmCallArgs(args))))
 		return struct{}{}
@@ -307,29 +320,96 @@ func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) 
 	return &LlvmValue{typ: ret, name: tmp, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:223:5
-func llvmPrintlnI64(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:224:5
+// Osty: examples/selfhost-core/llvmgen.osty:232:5
+func llvmStructTypeDef(name string, fieldTypes []string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:233:5
+	fields := llvmStrings.Join(fieldTypes, ", ")
+	_ = fields
+	return fmt.Sprintf("%%%s = type { %s }", ostyToString(name), ostyToString(fields))
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:237:5
+func llvmStructLiteral(emitter *LlvmEmitter, typ string, fields []*LlvmValue) *LlvmValue {
+	// Osty: examples/selfhost-core/llvmgen.osty:242:5
+	current := "undef"
+	_ = current
+	// Osty: examples/selfhost-core/llvmgen.osty:243:5
+	fieldIndex := 0
+	_ = fieldIndex
+	// Osty: examples/selfhost-core/llvmgen.osty:244:5
+	for _, field := range fields {
+		// Osty: examples/selfhost-core/llvmgen.osty:245:9
+		tmp := llvmNextTemp(emitter)
+		_ = tmp
+		// Osty: examples/selfhost-core/llvmgen.osty:246:9
+		func() struct{} {
+			emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %s %s, %s %s, %s", ostyToString(tmp), ostyToString(typ), ostyToString(current), ostyToString(field.typ), ostyToString(field.name), ostyToString(fieldIndex)))
+			return struct{}{}
+		}()
+		// Osty: examples/selfhost-core/llvmgen.osty:249:9
+		current = tmp
+		// Osty: examples/selfhost-core/llvmgen.osty:250:9
+		func() {
+			var _cur1 int = fieldIndex
+			var _rhs2 int = 1
+			if _rhs2 > 0 && _cur1 > math.MaxInt-_rhs2 {
+				panic("integer overflow")
+			}
+			if _rhs2 < 0 && _cur1 < math.MinInt-_rhs2 {
+				panic("integer overflow")
+			}
+			fieldIndex = _cur1 + _rhs2
+		}()
+	}
+	return &LlvmValue{typ: typ, name: current, pointer: false}
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:255:5
+func llvmExtractValue(emitter *LlvmEmitter, aggregate *LlvmValue, fieldType string, fieldIndex int) *LlvmValue {
+	// Osty: examples/selfhost-core/llvmgen.osty:261:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:225:5
+	// Osty: examples/selfhost-core/llvmgen.osty:262:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %s %s, %s", ostyToString(tmp), ostyToString(aggregate.typ), ostyToString(aggregate.name), ostyToString(fieldIndex)))
+		return struct{}{}
+	}()
+	return &LlvmValue{typ: fieldType, name: tmp, pointer: false}
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:268:5
+func llvmPrintlnI64(emitter *LlvmEmitter, value *LlvmValue) {
+	// Osty: examples/selfhost-core/llvmgen.osty:269:5
+	tmp := llvmNextTemp(emitter)
+	_ = tmp
+	// Osty: examples/selfhost-core/llvmgen.osty:270:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:228:5
+// Osty: examples/selfhost-core/llvmgen.osty:273:5
 func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:229:5
+	// Osty: examples/selfhost-core/llvmgen.osty:274:5
 	name := fmt.Sprintf("@.str%s", ostyToString(emitter.stringId))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:230:22
-	emitter.stringId = emitter.stringId + 1
-	// Osty: examples/selfhost-core/llvmgen.osty:231:5
+	// Osty: examples/selfhost-core/llvmgen.osty:275:12
+	emitter.stringId = func() int {
+		var _p3 int = emitter.stringId
+		var _rhs4 int = 1
+		if _rhs4 > 0 && _p3 > math.MaxInt-_rhs4 {
+			panic("integer overflow")
+		}
+		if _rhs4 < 0 && _p3 < math.MinInt-_rhs4 {
+			panic("integer overflow")
+		}
+		return _p3 + _rhs4
+	}()
+	// Osty: examples/selfhost-core/llvmgen.osty:276:5
 	cstring := llvmCString(text)
 	_ = cstring
-	// Osty: examples/selfhost-core/llvmgen.osty:232:5
+	// Osty: examples/selfhost-core/llvmgen.osty:277:5
 	func() struct{} {
 		emitter.stringGlobals = append(emitter.stringGlobals, &LlvmStringGlobal{name: name, encoded: cstring.encoded, byteLen: cstring.byteLen})
 		return struct{}{}
@@ -337,71 +417,71 @@ func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
 	return &LlvmValue{typ: "ptr", name: name, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:238:5
+// Osty: examples/selfhost-core/llvmgen.osty:283:5
 func llvmCString(text string) *LlvmCString {
-	// Osty: examples/selfhost-core/llvmgen.osty:239:5
+	// Osty: examples/selfhost-core/llvmgen.osty:284:5
 	encoded := fmt.Sprintf("%s\\00", ostyToString(llvmCStringEscape(text)))
 	_ = encoded
-	// Osty: examples/selfhost-core/llvmgen.osty:240:5
+	// Osty: examples/selfhost-core/llvmgen.osty:285:5
 	byteLen := len(llvmStrings.Split(text, "")) + 1
 	_ = byteLen
 	return &LlvmCString{encoded: encoded, byteLen: byteLen}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:244:5
+// Osty: examples/selfhost-core/llvmgen.osty:289:5
 func llvmCStringEscape(text string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:245:5
+	// Osty: examples/selfhost-core/llvmgen.osty:290:5
 	encoded := ""
 	_ = encoded
-	// Osty: examples/selfhost-core/llvmgen.osty:246:5
+	// Osty: examples/selfhost-core/llvmgen.osty:291:5
 	for _, unit := range llvmStrings.Split(text, "") {
-		// Osty: examples/selfhost-core/llvmgen.osty:247:9
+		// Osty: examples/selfhost-core/llvmgen.osty:292:9
 		if unit == "\n" {
-			// Osty: examples/selfhost-core/llvmgen.osty:248:21
+			// Osty: examples/selfhost-core/llvmgen.osty:293:13
 			encoded = fmt.Sprintf("%s\\0A", ostyToString(encoded))
 		} else if unit == "\t" {
-			// Osty: examples/selfhost-core/llvmgen.osty:250:21
+			// Osty: examples/selfhost-core/llvmgen.osty:295:13
 			encoded = fmt.Sprintf("%s\\09", ostyToString(encoded))
 		} else if unit == "\r" {
-			// Osty: examples/selfhost-core/llvmgen.osty:252:21
+			// Osty: examples/selfhost-core/llvmgen.osty:297:13
 			encoded = fmt.Sprintf("%s\\0D", ostyToString(encoded))
 		} else if unit == "\"" {
-			// Osty: examples/selfhost-core/llvmgen.osty:254:21
+			// Osty: examples/selfhost-core/llvmgen.osty:299:13
 			encoded = fmt.Sprintf("%s\\22", ostyToString(encoded))
 		} else if unit == "\\" {
-			// Osty: examples/selfhost-core/llvmgen.osty:256:21
+			// Osty: examples/selfhost-core/llvmgen.osty:301:13
 			encoded = fmt.Sprintf("%s\\5C", ostyToString(encoded))
 		} else {
-			// Osty: examples/selfhost-core/llvmgen.osty:258:21
+			// Osty: examples/selfhost-core/llvmgen.osty:303:13
 			encoded = fmt.Sprintf("%s%s", ostyToString(encoded), ostyToString(unit))
 		}
 	}
 	return encoded
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:264:5
+// Osty: examples/selfhost-core/llvmgen.osty:309:5
 func llvmPrintlnString(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:265:5
+	// Osty: examples/selfhost-core/llvmgen.osty:310:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:266:5
+	// Osty: examples/selfhost-core/llvmgen.osty:311:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:269:5
+// Osty: examples/selfhost-core/llvmgen.osty:314:5
 func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: examples/selfhost-core/llvmgen.osty:270:5
+	// Osty: examples/selfhost-core/llvmgen.osty:315:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.then"), elseLabel: llvmNextLabel(emitter, "if.else"), endLabel: llvmNextLabel(emitter, "if.end")}
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:275:5
+	// Osty: examples/selfhost-core/llvmgen.osty:320:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:276:5
+	// Osty: examples/selfhost-core/llvmgen.osty:321:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -409,45 +489,45 @@ func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:280:5
+// Osty: examples/selfhost-core/llvmgen.osty:325:5
 func llvmIfElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: examples/selfhost-core/llvmgen.osty:281:5
+	// Osty: examples/selfhost-core/llvmgen.osty:326:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:282:5
+	// Osty: examples/selfhost-core/llvmgen.osty:327:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:285:5
+// Osty: examples/selfhost-core/llvmgen.osty:330:5
 func llvmIfEnd(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: examples/selfhost-core/llvmgen.osty:286:5
+	// Osty: examples/selfhost-core/llvmgen.osty:331:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:287:5
+	// Osty: examples/selfhost-core/llvmgen.osty:332:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:290:5
+// Osty: examples/selfhost-core/llvmgen.osty:335:5
 func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: examples/selfhost-core/llvmgen.osty:291:5
+	// Osty: examples/selfhost-core/llvmgen.osty:336:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.expr.then"), elseLabel: llvmNextLabel(emitter, "if.expr.else"), endLabel: llvmNextLabel(emitter, "if.expr.end")}
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:296:5
+	// Osty: examples/selfhost-core/llvmgen.osty:341:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:297:5
+	// Osty: examples/selfhost-core/llvmgen.osty:342:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -455,36 +535,36 @@ func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:301:5
+// Osty: examples/selfhost-core/llvmgen.osty:346:5
 func llvmIfExprElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: examples/selfhost-core/llvmgen.osty:302:5
+	// Osty: examples/selfhost-core/llvmgen.osty:347:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:303:5
+	// Osty: examples/selfhost-core/llvmgen.osty:348:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:306:5
+// Osty: examples/selfhost-core/llvmgen.osty:351:5
 func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseValue *LlvmValue, labels *LlvmIfLabels) *LlvmValue {
-	// Osty: examples/selfhost-core/llvmgen.osty:313:5
+	// Osty: examples/selfhost-core/llvmgen.osty:358:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:314:5
+	// Osty: examples/selfhost-core/llvmgen.osty:359:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:315:5
+	// Osty: examples/selfhost-core/llvmgen.osty:360:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: examples/selfhost-core/llvmgen.osty:316:5
+	// Osty: examples/selfhost-core/llvmgen.osty:361:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]", ostyToString(tmp), ostyToString(typ), ostyToString(thenValue.name), ostyToString(labels.thenLabel), ostyToString(elseValue.name), ostyToString(labels.elseLabel)))
 		return struct{}{}
@@ -492,227 +572,242 @@ func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseV
 	return &LlvmValue{typ: typ, name: tmp, pointer: false}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:322:5
+// Osty: examples/selfhost-core/llvmgen.osty:367:5
 func llvmInclusiveRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue) *LlvmRangeLoop {
 	return llvmRangeStart(emitter, iterName, start, stop, true)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:331:5
+// Osty: examples/selfhost-core/llvmgen.osty:376:5
 func llvmRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue, inclusive bool) *LlvmRangeLoop {
-	// Osty: examples/selfhost-core/llvmgen.osty:338:5
+	// Osty: examples/selfhost-core/llvmgen.osty:383:5
 	iterPtr := llvmNextTemp(emitter)
 	_ = iterPtr
-	// Osty: examples/selfhost-core/llvmgen.osty:339:5
+	// Osty: examples/selfhost-core/llvmgen.osty:384:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:340:5
+	// Osty: examples/selfhost-core/llvmgen.osty:385:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(start.name), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:342:5
+	// Osty: examples/selfhost-core/llvmgen.osty:387:5
 	loop := &LlvmRangeLoop{condLabel: llvmNextLabel(emitter, "for.cond"), bodyLabel: llvmNextLabel(emitter, "for.body"), endLabel: llvmNextLabel(emitter, "for.end"), iterPtr: iterPtr, current: ""}
 	_ = loop
-	// Osty: examples/selfhost-core/llvmgen.osty:349:5
+	// Osty: examples/selfhost-core/llvmgen.osty:394:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:350:5
+	// Osty: examples/selfhost-core/llvmgen.osty:395:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:352:5
+	// Osty: examples/selfhost-core/llvmgen.osty:397:5
 	current := llvmNextTemp(emitter)
 	_ = current
-	// Osty: examples/selfhost-core/llvmgen.osty:353:5
+	// Osty: examples/selfhost-core/llvmgen.osty:398:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", ostyToString(current), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:354:5
+	// Osty: examples/selfhost-core/llvmgen.osty:399:5
 	cmp := llvmNextTemp(emitter)
 	_ = cmp
-	// Osty: examples/selfhost-core/llvmgen.osty:355:5
+	// Osty: examples/selfhost-core/llvmgen.osty:400:5
 	pred := "slt"
 	_ = pred
-	// Osty: examples/selfhost-core/llvmgen.osty:356:5
+	// Osty: examples/selfhost-core/llvmgen.osty:401:5
 	if inclusive {
-		// Osty: examples/selfhost-core/llvmgen.osty:357:14
+		// Osty: examples/selfhost-core/llvmgen.osty:402:9
 		pred = "sle"
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:359:5
+	// Osty: examples/selfhost-core/llvmgen.osty:404:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s i64 %s, %s", ostyToString(cmp), ostyToString(pred), ostyToString(current), ostyToString(stop.name)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:360:5
+	// Osty: examples/selfhost-core/llvmgen.osty:405:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cmp), ostyToString(loop.bodyLabel), ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:361:5
+	// Osty: examples/selfhost-core/llvmgen.osty:406:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.bodyLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:362:5
+	// Osty: examples/selfhost-core/llvmgen.osty:407:5
 	llvmBind(emitter, iterName, llvmI64(current))
 	return &LlvmRangeLoop{condLabel: loop.condLabel, bodyLabel: loop.bodyLabel, endLabel: loop.endLabel, iterPtr: loop.iterPtr, current: current}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:373:5
+// Osty: examples/selfhost-core/llvmgen.osty:418:5
 func llvmRangeEnd(emitter *LlvmEmitter, loop *LlvmRangeLoop) {
-	// Osty: examples/selfhost-core/llvmgen.osty:374:5
+	// Osty: examples/selfhost-core/llvmgen.osty:419:5
 	next := llvmNextTemp(emitter)
 	_ = next
-	// Osty: examples/selfhost-core/llvmgen.osty:375:5
+	// Osty: examples/selfhost-core/llvmgen.osty:420:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", ostyToString(next), ostyToString(loop.current)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:376:5
+	// Osty: examples/selfhost-core/llvmgen.osty:421:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(next), ostyToString(loop.iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:377:5
+	// Osty: examples/selfhost-core/llvmgen.osty:422:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:378:5
+	// Osty: examples/selfhost-core/llvmgen.osty:423:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:381:5
+// Osty: examples/selfhost-core/llvmgen.osty:426:5
 func llvmReturn(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:382:5
+	// Osty: examples/selfhost-core/llvmgen.osty:427:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  ret %s %s", ostyToString(value.typ), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:385:5
+// Osty: examples/selfhost-core/llvmgen.osty:430:5
 func llvmReturnI32Zero(emitter *LlvmEmitter) {
-	// Osty: examples/selfhost-core/llvmgen.osty:386:5
+	// Osty: examples/selfhost-core/llvmgen.osty:431:5
 	func() struct{} { emitter.body = append(emitter.body, "  ret i32 0"); return struct{}{} }()
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:389:5
+// Osty: examples/selfhost-core/llvmgen.osty:434:5
 func llvmRenderModule(sourcePath string, target string, definitions []string) string {
-	return llvmRenderModuleWithGlobals(sourcePath, target, make([]*LlvmStringGlobal, 0, 1), definitions)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, make([]string, 0, 1), make([]*LlvmStringGlobal, 0, 1), definitions)
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:393:5
+// Osty: examples/selfhost-core/llvmgen.osty:438:5
 func llvmRenderModuleWithGlobals(sourcePath string, target string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:399:5
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, make([]string, 0, 1), stringGlobals, definitions)
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:447:5
+func llvmRenderModuleWithGlobalsAndTypes(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:454:5
 	lines := []string{"; Code generated by osty LLVM backend. DO NOT EDIT.", fmt.Sprintf("; Osty: %s", ostyToString(sourcePath)), fmt.Sprintf("source_filename = \"%s\"", ostyToString(sourcePath))}
 	_ = lines
-	// Osty: examples/selfhost-core/llvmgen.osty:404:5
+	// Osty: examples/selfhost-core/llvmgen.osty:459:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:405:9
+		// Osty: examples/selfhost-core/llvmgen.osty:460:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("target triple = \"%s\"", ostyToString(target)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:407:5
+	// Osty: examples/selfhost-core/llvmgen.osty:462:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:408:5
+	// Osty: examples/selfhost-core/llvmgen.osty:463:5
+	for _, typeDef := range typeDefs {
+		// Osty: examples/selfhost-core/llvmgen.osty:464:9
+		func() struct{} { lines = append(lines, typeDef); return struct{}{} }()
+	}
+	// Osty: examples/selfhost-core/llvmgen.osty:466:5
+	if len(typeDefs) > 0 {
+		// Osty: examples/selfhost-core/llvmgen.osty:467:9
+		func() struct{} { lines = append(lines, ""); return struct{}{} }()
+	}
+	// Osty: examples/selfhost-core/llvmgen.osty:469:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_i64 = private unnamed_addr constant [5 x i8] c\"%ld\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:409:5
+	// Osty: examples/selfhost-core/llvmgen.osty:470:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:410:5
+	// Osty: examples/selfhost-core/llvmgen.osty:471:5
 	for _, global := range stringGlobals {
-		// Osty: examples/selfhost-core/llvmgen.osty:411:9
+		// Osty: examples/selfhost-core/llvmgen.osty:472:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("%s = private unnamed_addr constant [%s x i8] c\"%s\"", ostyToString(global.name), ostyToString(global.byteLen), ostyToString(global.encoded)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:413:5
+	// Osty: examples/selfhost-core/llvmgen.osty:474:5
 	func() struct{} { lines = append(lines, "declare i32 @printf(ptr, ...)"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:414:5
+	// Osty: examples/selfhost-core/llvmgen.osty:475:5
 	firstDefinition := true
 	_ = firstDefinition
-	// Osty: examples/selfhost-core/llvmgen.osty:415:5
+	// Osty: examples/selfhost-core/llvmgen.osty:476:5
 	for _, definition := range definitions {
-		// Osty: examples/selfhost-core/llvmgen.osty:416:9
+		// Osty: examples/selfhost-core/llvmgen.osty:477:9
 		if firstDefinition {
-			// Osty: examples/selfhost-core/llvmgen.osty:417:13
+			// Osty: examples/selfhost-core/llvmgen.osty:478:13
 			func() struct{} { lines = append(lines, ""); return struct{}{} }()
-			// Osty: examples/selfhost-core/llvmgen.osty:418:29
+			// Osty: examples/selfhost-core/llvmgen.osty:479:13
 			firstDefinition = false
 		}
-		// Osty: examples/selfhost-core/llvmgen.osty:420:9
+		// Osty: examples/selfhost-core/llvmgen.osty:481:9
 		func() struct{} { lines = append(lines, definition); return struct{}{} }()
 	}
 	return llvmStrings.Join(lines, "\n")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:425:5
+// Osty: examples/selfhost-core/llvmgen.osty:486:5
 func llvmRenderSkeleton(packageName string, sourcePath string, emit string, target string, unsupported string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:432:5
+	// Osty: examples/selfhost-core/llvmgen.osty:493:5
 	pkg := packageName
 	_ = pkg
-	// Osty: examples/selfhost-core/llvmgen.osty:433:5
+	// Osty: examples/selfhost-core/llvmgen.osty:494:5
 	if pkg == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:434:13
+		// Osty: examples/selfhost-core/llvmgen.osty:495:9
 		pkg = "main"
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:436:5
+	// Osty: examples/selfhost-core/llvmgen.osty:497:5
 	source := sourcePath
 	_ = source
-	// Osty: examples/selfhost-core/llvmgen.osty:437:5
+	// Osty: examples/selfhost-core/llvmgen.osty:498:5
 	if source == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:438:16
+		// Osty: examples/selfhost-core/llvmgen.osty:499:9
 		source = "<unknown>"
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:441:5
+	// Osty: examples/selfhost-core/llvmgen.osty:502:5
 	lines := []string{"; Osty LLVM backend skeleton", fmt.Sprintf("; package: %s", ostyToString(pkg)), fmt.Sprintf("; source: %s", ostyToString(source)), fmt.Sprintf("; emit: %s", ostyToString(emit))}
 	_ = lines
-	// Osty: examples/selfhost-core/llvmgen.osty:447:5
+	// Osty: examples/selfhost-core/llvmgen.osty:508:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:448:9
+		// Osty: examples/selfhost-core/llvmgen.osty:509:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; target: %s", ostyToString(target)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:450:5
+	// Osty: examples/selfhost-core/llvmgen.osty:511:5
 	if unsupported != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:451:9
+		// Osty: examples/selfhost-core/llvmgen.osty:512:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; unsupported: %s", ostyToString(unsupported)))
 			return struct{}{}
 		}()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:453:5
+	// Osty: examples/selfhost-core/llvmgen.osty:514:5
 	func() struct{} { lines = append(lines, "; code generation is not implemented yet"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:454:5
+	// Osty: examples/selfhost-core/llvmgen.osty:515:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:455:5
+	// Osty: examples/selfhost-core/llvmgen.osty:516:5
 	func() struct{} {
 		lines = append(lines, fmt.Sprintf("source_filename = \"%s\"", ostyToString(source)))
 		return struct{}{}
 	}()
-	// Osty: examples/selfhost-core/llvmgen.osty:456:5
+	// Osty: examples/selfhost-core/llvmgen.osty:517:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:457:9
+		// Osty: examples/selfhost-core/llvmgen.osty:518:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("target triple = \"%s\"", ostyToString(target)))
 			return struct{}{}
@@ -721,434 +816,651 @@ func llvmRenderSkeleton(packageName string, sourcePath string, emit string, targ
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:462:5
+// Osty: examples/selfhost-core/llvmgen.osty:523:5
 func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:468:5
+	// Osty: examples/selfhost-core/llvmgen.osty:529:5
 	lines := []string{fmt.Sprintf("define %s @%s(%s) {", ostyToString(ret), ostyToString(name), ostyToString(llvmParams(params))), "entry:"}
 	_ = lines
-	// Osty: examples/selfhost-core/llvmgen.osty:469:5
+	// Osty: examples/selfhost-core/llvmgen.osty:530:5
 	for _, line := range body {
-		// Osty: examples/selfhost-core/llvmgen.osty:470:9
+		// Osty: examples/selfhost-core/llvmgen.osty:531:9
 		func() struct{} { lines = append(lines, line); return struct{}{} }()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:472:5
+	// Osty: examples/selfhost-core/llvmgen.osty:533:5
 	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:476:5
+// Osty: examples/selfhost-core/llvmgen.osty:537:5
 func llvmNeedsObjectArtifact(emit string) bool {
 	return emit == "object" || emit == "binary"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:480:5
+// Osty: examples/selfhost-core/llvmgen.osty:541:5
 func llvmNeedsBinaryArtifact(emit string) bool {
 	return emit == "binary"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:484:5
+// Osty: examples/selfhost-core/llvmgen.osty:545:5
 func llvmClangCompileObjectArgs(target string, irPath string, objectPath string) []string {
-	// Osty: examples/selfhost-core/llvmgen.osty:489:5
+	// Osty: examples/selfhost-core/llvmgen.osty:550:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: examples/selfhost-core/llvmgen.osty:490:5
+	// Osty: examples/selfhost-core/llvmgen.osty:551:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:491:9
+		// Osty: examples/selfhost-core/llvmgen.osty:552:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: examples/selfhost-core/llvmgen.osty:492:9
+		// Osty: examples/selfhost-core/llvmgen.osty:553:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:494:5
+	// Osty: examples/selfhost-core/llvmgen.osty:555:5
 	func() struct{} { args = append(args, "-c"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:495:5
+	// Osty: examples/selfhost-core/llvmgen.osty:556:5
 	func() struct{} { args = append(args, irPath); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:496:5
+	// Osty: examples/selfhost-core/llvmgen.osty:557:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:497:5
+	// Osty: examples/selfhost-core/llvmgen.osty:558:5
 	func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	return args
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:501:5
+// Osty: examples/selfhost-core/llvmgen.osty:562:5
 func llvmClangLinkBinaryArgs(target string, objectPath string, binaryPath string) []string {
-	// Osty: examples/selfhost-core/llvmgen.osty:506:5
+	// Osty: examples/selfhost-core/llvmgen.osty:567:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: examples/selfhost-core/llvmgen.osty:507:5
+	// Osty: examples/selfhost-core/llvmgen.osty:568:5
 	if target != "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:508:9
+		// Osty: examples/selfhost-core/llvmgen.osty:569:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: examples/selfhost-core/llvmgen.osty:509:9
+		// Osty: examples/selfhost-core/llvmgen.osty:570:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:511:5
+	// Osty: examples/selfhost-core/llvmgen.osty:572:5
 	func() struct{} { args = append(args, objectPath); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:512:5
+	// Osty: examples/selfhost-core/llvmgen.osty:573:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: examples/selfhost-core/llvmgen.osty:513:5
+	// Osty: examples/selfhost-core/llvmgen.osty:574:5
 	func() struct{} { args = append(args, binaryPath); return struct{}{} }()
 	return args
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:517:5
+// Osty: examples/selfhost-core/llvmgen.osty:578:5
 func llvmMissingClangMessage() string {
 	return "llvm backend: clang not found on PATH; install clang or use --emit=llvm-ir"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:521:5
+// Osty: examples/selfhost-core/llvmgen.osty:582:5
 func llvmMissingBinaryArtifactMessage() string {
 	return "llvm backend: missing binary artifact path"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:525:5
+// Osty: examples/selfhost-core/llvmgen.osty:586:5
 func llvmClangFailureMessage(action string, command string, output string) string {
 	return fmt.Sprintf("llvm backend: clang %s failed\ncommand: %s\n%s", ostyToString(action), ostyToString(command), ostyToString(output))
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:529:5
+// Osty: examples/selfhost-core/llvmgen.osty:590:5
 func llvmUnsupportedBackendErrorMessage() string {
 	return "llvm backend: code generation is not implemented yet"
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:533:5
+// Osty: examples/selfhost-core/llvmgen.osty:594:5
 func llvmUnsupportedDiagnostic(kind string, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: examples/selfhost-core/llvmgen.osty:534:5
+	// Osty: examples/selfhost-core/llvmgen.osty:595:5
 	if kind == "go-ffi" {
-		// Osty: examples/selfhost-core/llvmgen.osty:535:9
+		// Osty: examples/selfhost-core/llvmgen.osty:596:9
 		target := detail
 		_ = target
-		// Osty: examples/selfhost-core/llvmgen.osty:536:9
+		// Osty: examples/selfhost-core/llvmgen.osty:597:9
 		if target == "" {
-			// Osty: examples/selfhost-core/llvmgen.osty:537:20
+			// Osty: examples/selfhost-core/llvmgen.osty:598:13
 			target = "<unknown>"
 		}
-		// Osty: examples/selfhost-core/llvmgen.osty:539:9
+		// Osty: examples/selfhost-core/llvmgen.osty:600:9
 		return &LlvmUnsupportedDiagnostic{code: "LLVM001", kind: "go-only", message: fmt.Sprintf("use go \"%s\" is only supported by the Go backend", ostyToString(target)), hint: "use --backend=go or replace it with a native/runtime binding before using --backend=llvm"}
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:547:5
+	// Osty: examples/selfhost-core/llvmgen.osty:608:5
 	if kind == "source-layout" {
-		// Osty: examples/selfhost-core/llvmgen.osty:548:9
+		// Osty: examples/selfhost-core/llvmgen.osty:609:9
 		return llvmUnsupportedDiagnosticWith("LLVM010", kind, detail, "reshape the file around the current LLVM subset: script statements or a simple main function")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:555:5
+	// Osty: examples/selfhost-core/llvmgen.osty:616:5
 	if kind == "type-system" {
-		// Osty: examples/selfhost-core/llvmgen.osty:556:9
+		// Osty: examples/selfhost-core/llvmgen.osty:617:9
 		return llvmUnsupportedDiagnosticWith("LLVM011", kind, detail, "use Int or Bool values until the LLVM runtime type surface grows")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:563:5
+	// Osty: examples/selfhost-core/llvmgen.osty:624:5
 	if kind == "statement" {
-		// Osty: examples/selfhost-core/llvmgen.osty:564:9
+		// Osty: examples/selfhost-core/llvmgen.osty:625:9
 		return llvmUnsupportedDiagnosticWith("LLVM012", kind, detail, "reduce the statement to let, assignment, if, range-for, return, or println")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:571:5
+	// Osty: examples/selfhost-core/llvmgen.osty:632:5
 	if kind == "expression" {
-		// Osty: examples/selfhost-core/llvmgen.osty:572:9
+		// Osty: examples/selfhost-core/llvmgen.osty:633:9
 		return llvmUnsupportedDiagnosticWith("LLVM013", kind, detail, "reduce the expression to Int, Bool, arithmetic, comparison, call, or value-if forms")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:579:5
+	// Osty: examples/selfhost-core/llvmgen.osty:640:5
 	if kind == "control-flow" {
-		// Osty: examples/selfhost-core/llvmgen.osty:580:9
+		// Osty: examples/selfhost-core/llvmgen.osty:641:9
 		return llvmUnsupportedDiagnosticWith("LLVM014", kind, detail, "use plain if/else or closed Int range loops for the current LLVM backend")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:587:5
+	// Osty: examples/selfhost-core/llvmgen.osty:648:5
 	if kind == "call" {
-		// Osty: examples/selfhost-core/llvmgen.osty:588:9
+		// Osty: examples/selfhost-core/llvmgen.osty:649:9
 		return llvmUnsupportedDiagnosticWith("LLVM015", kind, detail, "call an Osty function with positional Int/Bool arguments or use println as a statement")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:595:5
+	// Osty: examples/selfhost-core/llvmgen.osty:656:5
 	if kind == "name" {
-		// Osty: examples/selfhost-core/llvmgen.osty:596:9
+		// Osty: examples/selfhost-core/llvmgen.osty:657:9
 		return llvmUnsupportedDiagnosticWith("LLVM016", kind, detail, "use simple ASCII identifiers that the LLVM bridge can map directly")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:603:5
+	// Osty: examples/selfhost-core/llvmgen.osty:664:5
 	if kind == "function-signature" {
-		// Osty: examples/selfhost-core/llvmgen.osty:604:9
+		// Osty: examples/selfhost-core/llvmgen.osty:665:9
 		return llvmUnsupportedDiagnosticWith("LLVM017", kind, detail, "use non-generic functions with identifier parameters and Int/Bool types")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:612:5
+	// Osty: examples/selfhost-core/llvmgen.osty:673:5
 	reason := detail
 	_ = reason
-	// Osty: examples/selfhost-core/llvmgen.osty:613:5
+	// Osty: examples/selfhost-core/llvmgen.osty:674:5
 	if reason == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:614:16
+		// Osty: examples/selfhost-core/llvmgen.osty:675:9
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: "LLVM000", kind: "unsupported-source", message: reason, hint: "reduce the program to the LLVM smoke subset or keep using --backend=go for this source"}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:624:5
+// Osty: examples/selfhost-core/llvmgen.osty:685:5
 func llvmUnsupportedDiagnosticWith(code string, kind string, detail string, hint string) *LlvmUnsupportedDiagnostic {
-	// Osty: examples/selfhost-core/llvmgen.osty:630:5
+	// Osty: examples/selfhost-core/llvmgen.osty:691:5
 	reason := detail
 	_ = reason
-	// Osty: examples/selfhost-core/llvmgen.osty:631:5
+	// Osty: examples/selfhost-core/llvmgen.osty:692:5
 	if reason == "" {
-		// Osty: examples/selfhost-core/llvmgen.osty:632:16
+		// Osty: examples/selfhost-core/llvmgen.osty:693:9
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: code, kind: kind, message: reason, hint: hint}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:642:5
+// Osty: examples/selfhost-core/llvmgen.osty:703:5
 func llvmUnsupportedSummary(diag *LlvmUnsupportedDiagnostic) string {
 	return fmt.Sprintf("%s %s: %s; hint: %s", ostyToString(diag.code), ostyToString(diag.kind), ostyToString(diag.message), ostyToString(diag.hint))
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:646:5
+// Osty: examples/selfhost-core/llvmgen.osty:707:5
 func llvmSmokeExecutableCorpus() []*LlvmSmokeExecutableCase {
-	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}, &LlvmSmokeExecutableCase{name: "string-return", fixture: "string_return_print.osty", stdout: "from function\n"}, &LlvmSmokeExecutableCase{name: "string-param", fixture: "string_param_print.osty", stdout: "param string\n"}, &LlvmSmokeExecutableCase{name: "string-mut", fixture: "string_mut_print.osty", stdout: "after\n"}}
+	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}, &LlvmSmokeExecutableCase{name: "string-return", fixture: "string_return_print.osty", stdout: "from function\n"}, &LlvmSmokeExecutableCase{name: "string-param", fixture: "string_param_print.osty", stdout: "param string\n"}, &LlvmSmokeExecutableCase{name: "string-mut", fixture: "string_mut_print.osty", stdout: "after\n"}, &LlvmSmokeExecutableCase{name: "struct-field", fixture: "struct_field_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-return", fixture: "struct_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-param", fixture: "struct_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-mut", fixture: "struct_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-variant", fixture: "enum_variant_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-return", fixture: "enum_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-param", fixture: "enum_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-mut", fixture: "enum_mut_print.osty", stdout: "42\n"}}
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:701:5
+// Osty: examples/selfhost-core/llvmgen.osty:802:5
 func llvmSmokeMinimalPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:702:5
+	// Osty: examples/selfhost-core/llvmgen.osty:803:5
 	emitter := llvmEmitter()
 	_ = emitter
-	// Osty: examples/selfhost-core/llvmgen.osty:703:5
+	// Osty: examples/selfhost-core/llvmgen.osty:804:5
 	value := llvmBinaryI64(emitter, "add", llvmIntLiteral(40), llvmIntLiteral(2))
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:704:5
+	// Osty: examples/selfhost-core/llvmgen.osty:805:5
 	llvmPrintlnI64(emitter, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:705:5
+	// Osty: examples/selfhost-core/llvmgen.osty:806:5
 	llvmReturnI32Zero(emitter)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), emitter.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:715:5
+// Osty: examples/selfhost-core/llvmgen.osty:816:5
 func llvmSmokeScalarArithmeticIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:716:5
+	// Osty: examples/selfhost-core/llvmgen.osty:817:5
 	add := llvmEmitter()
 	_ = add
-	// Osty: examples/selfhost-core/llvmgen.osty:717:5
+	// Osty: examples/selfhost-core/llvmgen.osty:818:5
 	llvmBind(add, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:718:5
+	// Osty: examples/selfhost-core/llvmgen.osty:819:5
 	llvmBind(add, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:719:5
+	// Osty: examples/selfhost-core/llvmgen.osty:820:5
 	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
 	_ = sum
-	// Osty: examples/selfhost-core/llvmgen.osty:720:5
+	// Osty: examples/selfhost-core/llvmgen.osty:821:5
 	llvmReturn(add, sum)
-	// Osty: examples/selfhost-core/llvmgen.osty:722:5
+	// Osty: examples/selfhost-core/llvmgen.osty:823:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:723:5
+	// Osty: examples/selfhost-core/llvmgen.osty:824:5
 	value := llvmCall(main, "i64", "add", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:724:5
+	// Osty: examples/selfhost-core/llvmgen.osty:825:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: examples/selfhost-core/llvmgen.osty:725:5
+	// Osty: examples/selfhost-core/llvmgen.osty:826:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "value"), llvmIntLiteral(42))
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:726:5
+	// Osty: examples/selfhost-core/llvmgen.osty:827:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:727:5
+	// Osty: examples/selfhost-core/llvmgen.osty:828:5
 	llvmPrintlnI64(main, llvmIdent(main, "value"))
-	// Osty: examples/selfhost-core/llvmgen.osty:728:5
+	// Osty: examples/selfhost-core/llvmgen.osty:829:5
 	llvmIfElse(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:729:5
+	// Osty: examples/selfhost-core/llvmgen.osty:830:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:730:5
+	// Osty: examples/selfhost-core/llvmgen.osty:831:5
 	llvmIfEnd(main, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:731:5
+	// Osty: examples/selfhost-core/llvmgen.osty:832:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "add", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, add.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:751:5
+// Osty: examples/selfhost-core/llvmgen.osty:852:5
 func llvmSmokeControlFlowIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:752:5
+	// Osty: examples/selfhost-core/llvmgen.osty:853:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: examples/selfhost-core/llvmgen.osty:753:5
+	// Osty: examples/selfhost-core/llvmgen.osty:854:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: examples/selfhost-core/llvmgen.osty:754:5
+	// Osty: examples/selfhost-core/llvmgen.osty:855:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: examples/selfhost-core/llvmgen.osty:755:5
+	// Osty: examples/selfhost-core/llvmgen.osty:856:5
 	loop := llvmInclusiveRangeStart(sumTo, "i", llvmIntLiteral(1), llvmIdent(sumTo, "n"))
 	_ = loop
-	// Osty: examples/selfhost-core/llvmgen.osty:756:5
+	// Osty: examples/selfhost-core/llvmgen.osty:857:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: examples/selfhost-core/llvmgen.osty:757:5
+	// Osty: examples/selfhost-core/llvmgen.osty:858:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: examples/selfhost-core/llvmgen.osty:758:5
+	// Osty: examples/selfhost-core/llvmgen.osty:859:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: examples/selfhost-core/llvmgen.osty:759:5
+	// Osty: examples/selfhost-core/llvmgen.osty:860:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: examples/selfhost-core/llvmgen.osty:761:5
+	// Osty: examples/selfhost-core/llvmgen.osty:862:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:762:5
+	// Osty: examples/selfhost-core/llvmgen.osty:863:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(5)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:763:5
+	// Osty: examples/selfhost-core/llvmgen.osty:864:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:764:5
+	// Osty: examples/selfhost-core/llvmgen.osty:865:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:776:5
+// Osty: examples/selfhost-core/llvmgen.osty:877:5
 func llvmSmokeBooleansIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:777:5
+	// Osty: examples/selfhost-core/llvmgen.osty:878:5
 	choose := llvmEmitter()
 	_ = choose
-	// Osty: examples/selfhost-core/llvmgen.osty:778:5
+	// Osty: examples/selfhost-core/llvmgen.osty:879:5
 	llvmBind(choose, "a", llvmI64("%a"))
-	// Osty: examples/selfhost-core/llvmgen.osty:779:5
+	// Osty: examples/selfhost-core/llvmgen.osty:880:5
 	llvmBind(choose, "b", llvmI64("%b"))
-	// Osty: examples/selfhost-core/llvmgen.osty:780:5
+	// Osty: examples/selfhost-core/llvmgen.osty:881:5
 	lt := llvmCompare(choose, "slt", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = lt
-	// Osty: examples/selfhost-core/llvmgen.osty:781:5
+	// Osty: examples/selfhost-core/llvmgen.osty:882:5
 	eqZero := llvmCompare(choose, "eq", llvmIdent(choose, "a"), llvmIntLiteral(0))
 	_ = eqZero
-	// Osty: examples/selfhost-core/llvmgen.osty:782:5
+	// Osty: examples/selfhost-core/llvmgen.osty:883:5
 	nonZero := llvmNotI1(choose, eqZero)
 	_ = nonZero
-	// Osty: examples/selfhost-core/llvmgen.osty:783:5
+	// Osty: examples/selfhost-core/llvmgen.osty:884:5
 	cond := llvmLogicalI1(choose, "and", lt, nonZero)
 	_ = cond
-	// Osty: examples/selfhost-core/llvmgen.osty:784:5
+	// Osty: examples/selfhost-core/llvmgen.osty:885:5
 	labels := llvmIfExprStart(choose, cond)
 	_ = labels
-	// Osty: examples/selfhost-core/llvmgen.osty:785:5
+	// Osty: examples/selfhost-core/llvmgen.osty:886:5
 	thenValue := llvmBinaryI64(choose, "sub", llvmIdent(choose, "b"), llvmIdent(choose, "a"))
 	_ = thenValue
-	// Osty: examples/selfhost-core/llvmgen.osty:786:5
+	// Osty: examples/selfhost-core/llvmgen.osty:887:5
 	llvmIfExprElse(choose, labels)
-	// Osty: examples/selfhost-core/llvmgen.osty:787:5
+	// Osty: examples/selfhost-core/llvmgen.osty:888:5
 	elseValue := llvmBinaryI64(choose, "add", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = elseValue
-	// Osty: examples/selfhost-core/llvmgen.osty:788:5
+	// Osty: examples/selfhost-core/llvmgen.osty:889:5
 	result := llvmIfExprEnd(choose, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: examples/selfhost-core/llvmgen.osty:789:5
+	// Osty: examples/selfhost-core/llvmgen.osty:890:5
 	llvmReturn(choose, result)
-	// Osty: examples/selfhost-core/llvmgen.osty:791:5
+	// Osty: examples/selfhost-core/llvmgen.osty:892:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:792:5
+	// Osty: examples/selfhost-core/llvmgen.osty:893:5
 	value := llvmCall(main, "i64", "choose", []*LlvmValue{llvmIntLiteral(3), llvmIntLiteral(10)})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:793:5
+	// Osty: examples/selfhost-core/llvmgen.osty:894:5
 	llvmPrintlnI64(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:794:5
+	// Osty: examples/selfhost-core/llvmgen.osty:895:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "choose", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, choose.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:814:5
+// Osty: examples/selfhost-core/llvmgen.osty:915:5
 func llvmSmokeStringPrintIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:815:5
+	// Osty: examples/selfhost-core/llvmgen.osty:916:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:816:5
+	// Osty: examples/selfhost-core/llvmgen.osty:917:5
 	line := llvmStringLiteral(main, "hello, osty")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:817:5
+	// Osty: examples/selfhost-core/llvmgen.osty:918:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:818:5
+	// Osty: examples/selfhost-core/llvmgen.osty:919:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:830:5
+// Osty: examples/selfhost-core/llvmgen.osty:931:5
 func llvmSmokeStringEscapeIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:831:5
+	// Osty: examples/selfhost-core/llvmgen.osty:932:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:832:5
+	// Osty: examples/selfhost-core/llvmgen.osty:933:5
 	line := llvmStringLiteral(main, "line one\nquote \" slash \\")
 	_ = line
-	// Osty: examples/selfhost-core/llvmgen.osty:833:5
+	// Osty: examples/selfhost-core/llvmgen.osty:934:5
 	llvmPrintlnString(main, line)
-	// Osty: examples/selfhost-core/llvmgen.osty:834:5
+	// Osty: examples/selfhost-core/llvmgen.osty:935:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:846:5
+// Osty: examples/selfhost-core/llvmgen.osty:947:5
 func llvmSmokeStringLetIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:847:5
+	// Osty: examples/selfhost-core/llvmgen.osty:948:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:848:5
+	// Osty: examples/selfhost-core/llvmgen.osty:949:5
 	msg := llvmStringLiteral(main, "stored string")
 	_ = msg
-	// Osty: examples/selfhost-core/llvmgen.osty:849:5
+	// Osty: examples/selfhost-core/llvmgen.osty:950:5
 	llvmImmutableLet(main, "msg", msg)
-	// Osty: examples/selfhost-core/llvmgen.osty:850:5
+	// Osty: examples/selfhost-core/llvmgen.osty:951:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: examples/selfhost-core/llvmgen.osty:851:5
+	// Osty: examples/selfhost-core/llvmgen.osty:952:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:863:5
+// Osty: examples/selfhost-core/llvmgen.osty:964:5
 func llvmSmokeStringReturnIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:864:5
+	// Osty: examples/selfhost-core/llvmgen.osty:965:5
 	greet := llvmEmitter()
 	_ = greet
-	// Osty: examples/selfhost-core/llvmgen.osty:865:5
+	// Osty: examples/selfhost-core/llvmgen.osty:966:5
 	llvmReturn(greet, llvmStringLiteral(greet, "from function"))
-	// Osty: examples/selfhost-core/llvmgen.osty:867:5
+	// Osty: examples/selfhost-core/llvmgen.osty:968:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:868:5
+	// Osty: examples/selfhost-core/llvmgen.osty:969:5
 	llvmPrintlnString(main, llvmCall(main, "ptr", "greet", make([]*LlvmValue, 0, 1)))
-	// Osty: examples/selfhost-core/llvmgen.osty:869:5
+	// Osty: examples/selfhost-core/llvmgen.osty:970:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", greet.stringGlobals, []string{llvmRenderFunction("ptr", "greet", make([]*LlvmParam, 0, 1), greet.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:882:5
+// Osty: examples/selfhost-core/llvmgen.osty:983:5
 func llvmSmokeStringParamIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:883:5
+	// Osty: examples/selfhost-core/llvmgen.osty:984:5
 	echo := llvmEmitter()
 	_ = echo
-	// Osty: examples/selfhost-core/llvmgen.osty:884:5
+	// Osty: examples/selfhost-core/llvmgen.osty:985:5
 	llvmBind(echo, "msg", &LlvmValue{typ: "ptr", name: "%msg", pointer: false})
-	// Osty: examples/selfhost-core/llvmgen.osty:885:5
+	// Osty: examples/selfhost-core/llvmgen.osty:986:5
 	llvmReturn(echo, llvmIdent(echo, "msg"))
-	// Osty: examples/selfhost-core/llvmgen.osty:887:5
+	// Osty: examples/selfhost-core/llvmgen.osty:988:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:888:5
+	// Osty: examples/selfhost-core/llvmgen.osty:989:5
 	value := llvmCall(main, "ptr", "echo", []*LlvmValue{llvmStringLiteral(main, "param string")})
 	_ = value
-	// Osty: examples/selfhost-core/llvmgen.osty:889:5
+	// Osty: examples/selfhost-core/llvmgen.osty:990:5
 	llvmPrintlnString(main, value)
-	// Osty: examples/selfhost-core/llvmgen.osty:890:5
+	// Osty: examples/selfhost-core/llvmgen.osty:991:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("ptr", "echo", []*LlvmParam{llvmParam("msg", "ptr")}, echo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:903:5
+// Osty: examples/selfhost-core/llvmgen.osty:1004:5
 func llvmSmokeStringMutableIR(sourcePath string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:904:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1005:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: examples/selfhost-core/llvmgen.osty:905:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1006:5
 	llvmMutableLet(main, "msg", llvmStringLiteral(main, "before"))
-	// Osty: examples/selfhost-core/llvmgen.osty:906:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1007:5
 	_ = llvmAssign(main, "msg", llvmStringLiteral(main, "after"))
-	// Osty: examples/selfhost-core/llvmgen.osty:907:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1008:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: examples/selfhost-core/llvmgen.osty:908:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1009:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:920:1
+// Osty: examples/selfhost-core/llvmgen.osty:1021:5
+func llvmSmokeStructFieldIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1022:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1023:5
+	point := llvmStructLiteral(main, "%Point", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
+	_ = point
+	// Osty: examples/selfhost-core/llvmgen.osty:1024:5
+	llvmImmutableLet(main, "point", point)
+	// Osty: examples/selfhost-core/llvmgen.osty:1025:5
+	sum := llvmBinaryI64(main, "add", llvmExtractValue(main, llvmIdent(main, "point"), "i64", 0), llvmExtractValue(main, llvmIdent(main, "point"), "i64", 1))
+	_ = sum
+	// Osty: examples/selfhost-core/llvmgen.osty:1031:5
+	llvmPrintlnI64(main, sum)
+	// Osty: examples/selfhost-core/llvmgen.osty:1032:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Point", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1045:5
+func llvmSmokeStructReturnIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1046:5
+	makePair := llvmEmitter()
+	_ = makePair
+	// Osty: examples/selfhost-core/llvmgen.osty:1047:5
+	pair := llvmStructLiteral(makePair, "%Pair", []*LlvmValue{llvmIntLiteral(10), llvmIntLiteral(32)})
+	_ = pair
+	// Osty: examples/selfhost-core/llvmgen.osty:1048:5
+	llvmReturn(makePair, pair)
+	// Osty: examples/selfhost-core/llvmgen.osty:1050:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1051:5
+	returned := llvmCall(main, "%Pair", "makePair", make([]*LlvmValue, 0, 1))
+	_ = returned
+	// Osty: examples/selfhost-core/llvmgen.osty:1052:5
+	llvmImmutableLet(main, "pair", returned)
+	// Osty: examples/selfhost-core/llvmgen.osty:1053:5
+	sum := llvmBinaryI64(main, "add", llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 0), llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 1))
+	_ = sum
+	// Osty: examples/selfhost-core/llvmgen.osty:1059:5
+	llvmPrintlnI64(main, sum)
+	// Osty: examples/selfhost-core/llvmgen.osty:1060:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Pair", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Pair", "makePair", make([]*LlvmParam, 0, 1), makePair.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1074:5
+func llvmSmokeStructParamIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1075:5
+	total := llvmEmitter()
+	_ = total
+	// Osty: examples/selfhost-core/llvmgen.osty:1076:5
+	llvmBind(total, "score", &LlvmValue{typ: "%Score", name: "%score", pointer: false})
+	// Osty: examples/selfhost-core/llvmgen.osty:1077:5
+	sum := llvmBinaryI64(total, "add", llvmExtractValue(total, llvmIdent(total, "score"), "i64", 0), llvmExtractValue(total, llvmIdent(total, "score"), "i64", 1))
+	_ = sum
+	// Osty: examples/selfhost-core/llvmgen.osty:1083:5
+	llvmReturn(total, sum)
+	// Osty: examples/selfhost-core/llvmgen.osty:1085:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1086:5
+	score := llvmStructLiteral(main, "%Score", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
+	_ = score
+	// Osty: examples/selfhost-core/llvmgen.osty:1087:5
+	out := llvmCall(main, "i64", "total", []*LlvmValue{score})
+	_ = out
+	// Osty: examples/selfhost-core/llvmgen.osty:1088:5
+	llvmPrintlnI64(main, out)
+	// Osty: examples/selfhost-core/llvmgen.osty:1089:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Score", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i64", "total", []*LlvmParam{llvmParam("score", "%Score")}, total.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1103:5
+func llvmSmokeStructMutableIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1104:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1105:5
+	llvmMutableLet(main, "box", llvmStructLiteral(main, "%Box", []*LlvmValue{llvmIntLiteral(1)}))
+	// Osty: examples/selfhost-core/llvmgen.osty:1106:5
+	_ = llvmAssign(main, "box", llvmStructLiteral(main, "%Box", []*LlvmValue{llvmIntLiteral(42)}))
+	// Osty: examples/selfhost-core/llvmgen.osty:1107:5
+	llvmPrintlnI64(main, llvmExtractValue(main, llvmIdent(main, "box"), "i64", 0))
+	// Osty: examples/selfhost-core/llvmgen.osty:1108:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Box", []string{"i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1121:5
+func llvmSmokeEnumVariantIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1122:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1123:5
+	llvmImmutableLet(main, "light", llvmEnumVariant("Light", 1))
+	// Osty: examples/selfhost-core/llvmgen.osty:1124:5
+	cond := llvmCompare(main, "eq", llvmIdent(main, "light"), llvmEnumVariant("Light", 1))
+	_ = cond
+	// Osty: examples/selfhost-core/llvmgen.osty:1125:5
+	labels := llvmIfStart(main, cond)
+	_ = labels
+	// Osty: examples/selfhost-core/llvmgen.osty:1126:5
+	llvmPrintlnI64(main, llvmIntLiteral(42))
+	// Osty: examples/selfhost-core/llvmgen.osty:1127:5
+	llvmIfElse(main, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1128:5
+	llvmPrintlnI64(main, llvmIntLiteral(0))
+	// Osty: examples/selfhost-core/llvmgen.osty:1129:5
+	llvmIfEnd(main, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1130:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1141:5
+func llvmSmokeEnumReturnIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1142:5
+	pick := llvmEmitter()
+	_ = pick
+	// Osty: examples/selfhost-core/llvmgen.osty:1143:5
+	llvmReturn(pick, llvmEnumVariant("Switch", 1))
+	// Osty: examples/selfhost-core/llvmgen.osty:1145:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1146:5
+	state := llvmCall(main, "i64", "pick", make([]*LlvmValue, 0, 1))
+	_ = state
+	// Osty: examples/selfhost-core/llvmgen.osty:1147:5
+	cond := llvmCompare(main, "eq", state, llvmEnumVariant("Switch", 1))
+	_ = cond
+	// Osty: examples/selfhost-core/llvmgen.osty:1148:5
+	labels := llvmIfStart(main, cond)
+	_ = labels
+	// Osty: examples/selfhost-core/llvmgen.osty:1149:5
+	llvmPrintlnI64(main, llvmIntLiteral(42))
+	// Osty: examples/selfhost-core/llvmgen.osty:1150:5
+	llvmIfElse(main, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1151:5
+	llvmPrintlnI64(main, llvmIntLiteral(0))
+	// Osty: examples/selfhost-core/llvmgen.osty:1152:5
+	llvmIfEnd(main, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1153:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1165:5
+func llvmSmokeEnumParamIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1166:5
+	score := llvmEmitter()
+	_ = score
+	// Osty: examples/selfhost-core/llvmgen.osty:1167:5
+	llvmBind(score, "state", llvmI64("%state"))
+	// Osty: examples/selfhost-core/llvmgen.osty:1168:5
+	cond := llvmCompare(score, "eq", llvmIdent(score, "state"), llvmEnumVariant("Switch", 1))
+	_ = cond
+	// Osty: examples/selfhost-core/llvmgen.osty:1169:5
+	labels := llvmIfExprStart(score, cond)
+	_ = labels
+	// Osty: examples/selfhost-core/llvmgen.osty:1170:5
+	thenValue := llvmIntLiteral(42)
+	_ = thenValue
+	// Osty: examples/selfhost-core/llvmgen.osty:1171:5
+	llvmIfExprElse(score, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1172:5
+	elseValue := llvmIntLiteral(0)
+	_ = elseValue
+	// Osty: examples/selfhost-core/llvmgen.osty:1173:5
+	out := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
+	_ = out
+	// Osty: examples/selfhost-core/llvmgen.osty:1174:5
+	llvmReturn(score, out)
+	// Osty: examples/selfhost-core/llvmgen.osty:1176:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1177:5
+	result := llvmCall(main, "i64", "score", []*LlvmValue{llvmEnumVariant("Switch", 1)})
+	_ = result
+	// Osty: examples/selfhost-core/llvmgen.osty:1178:5
+	llvmPrintlnI64(main, result)
+	// Osty: examples/selfhost-core/llvmgen.osty:1179:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("state", "i64")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1191:5
+func llvmSmokeEnumMutableIR(sourcePath string) string {
+	// Osty: examples/selfhost-core/llvmgen.osty:1192:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: examples/selfhost-core/llvmgen.osty:1193:5
+	llvmMutableLet(main, "state", llvmEnumVariant("Switch", 0))
+	// Osty: examples/selfhost-core/llvmgen.osty:1194:5
+	_ = llvmAssign(main, "state", llvmEnumVariant("Switch", 1))
+	// Osty: examples/selfhost-core/llvmgen.osty:1195:5
+	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
+	_ = cond
+	// Osty: examples/selfhost-core/llvmgen.osty:1196:5
+	labels := llvmIfStart(main, cond)
+	_ = labels
+	// Osty: examples/selfhost-core/llvmgen.osty:1197:5
+	llvmPrintlnI64(main, llvmIntLiteral(42))
+	// Osty: examples/selfhost-core/llvmgen.osty:1198:5
+	llvmIfElse(main, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1199:5
+	llvmPrintlnI64(main, llvmIntLiteral(0))
+	// Osty: examples/selfhost-core/llvmgen.osty:1200:5
+	llvmIfEnd(main, labels)
+	// Osty: examples/selfhost-core/llvmgen.osty:1201:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:1212:1
 func llvmCallArgs(args []*LlvmValue) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:921:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1213:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:922:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1214:5
 	for _, arg := range args {
-		// Osty: examples/selfhost-core/llvmgen.osty:923:9
+		// Osty: examples/selfhost-core/llvmgen.osty:1215:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %s", ostyToString(arg.typ), ostyToString(arg.name)))
 			return struct{}{}
@@ -1157,14 +1469,14 @@ func llvmCallArgs(args []*LlvmValue) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:928:1
+// Osty: examples/selfhost-core/llvmgen.osty:1220:1
 func llvmParams(params []*LlvmParam) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:929:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1221:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: examples/selfhost-core/llvmgen.osty:930:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1222:5
 	for _, param := range params {
-		// Osty: examples/selfhost-core/llvmgen.osty:931:9
+		// Osty: examples/selfhost-core/llvmgen.osty:1223:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %%%s", ostyToString(param.typ), ostyToString(param.name)))
 			return struct{}{}
@@ -1173,22 +1485,42 @@ func llvmParams(params []*LlvmParam) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:936:1
+// Osty: examples/selfhost-core/llvmgen.osty:1228:1
 func llvmNextTemp(emitter *LlvmEmitter) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:937:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1229:5
 	name := fmt.Sprintf("%%t%s", ostyToString(emitter.temp))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:938:18
-	emitter.temp = emitter.temp + 1
+	// Osty: examples/selfhost-core/llvmgen.osty:1230:12
+	emitter.temp = func() int {
+		var _p5 int = emitter.temp
+		var _rhs6 int = 1
+		if _rhs6 > 0 && _p5 > math.MaxInt-_rhs6 {
+			panic("integer overflow")
+		}
+		if _rhs6 < 0 && _p5 < math.MinInt-_rhs6 {
+			panic("integer overflow")
+		}
+		return _p5 + _rhs6
+	}()
 	return name
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:942:1
+// Osty: examples/selfhost-core/llvmgen.osty:1234:1
 func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:943:5
+	// Osty: examples/selfhost-core/llvmgen.osty:1235:5
 	name := fmt.Sprintf("%s%s", ostyToString(prefix), ostyToString(emitter.label))
 	_ = name
-	// Osty: examples/selfhost-core/llvmgen.osty:944:19
-	emitter.label = emitter.label + 1
+	// Osty: examples/selfhost-core/llvmgen.osty:1236:12
+	emitter.label = func() int {
+		var _p7 int = emitter.label
+		var _rhs8 int = 1
+		if _rhs8 > 0 && _p7 > math.MaxInt-_rhs8 {
+			panic("integer overflow")
+		}
+		if _rhs8 < 0 && _p7 < math.MinInt-_rhs8 {
+			panic("integer overflow")
+		}
+		return _p7 + _rhs8
+	}()
 	return name
 }

--- a/testdata/backend/llvm_smoke/enum_mut_print.osty
+++ b/testdata/backend/llvm_smoke/enum_mut_print.osty
@@ -1,0 +1,14 @@
+enum Switch {
+    Off
+    On
+}
+
+fn main() {
+    let mut state: Switch = Off
+    state = On
+    if state == On {
+        println(42)
+    } else {
+        println(0)
+    }
+}

--- a/testdata/backend/llvm_smoke/enum_param_print.osty
+++ b/testdata/backend/llvm_smoke/enum_param_print.osty
@@ -1,0 +1,16 @@
+enum Switch {
+    Off
+    On
+}
+
+fn score(state: Switch) -> Int {
+    if state == On {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    println(score(On))
+}

--- a/testdata/backend/llvm_smoke/enum_return_print.osty
+++ b/testdata/backend/llvm_smoke/enum_return_print.osty
@@ -1,0 +1,16 @@
+enum Switch {
+    Off
+    On
+}
+
+fn pick() -> Switch {
+    On
+}
+
+fn main() {
+    if pick() == On {
+        println(42)
+    } else {
+        println(0)
+    }
+}

--- a/testdata/backend/llvm_smoke/enum_variant_print.osty
+++ b/testdata/backend/llvm_smoke/enum_variant_print.osty
@@ -1,0 +1,13 @@
+enum Light {
+    Red
+    Green
+}
+
+fn main() {
+    let light: Light = Green
+    if light == Green {
+        println(42)
+    } else {
+        println(0)
+    }
+}

--- a/testdata/backend/llvm_smoke/struct_field_print.osty
+++ b/testdata/backend/llvm_smoke/struct_field_print.osty
@@ -1,0 +1,9 @@
+struct Point {
+    x: Int
+    y: Int
+}
+
+fn main() {
+    let point = Point { x: 40, y: 2 }
+    println(point.x + point.y)
+}

--- a/testdata/backend/llvm_smoke/struct_mut_print.osty
+++ b/testdata/backend/llvm_smoke/struct_mut_print.osty
@@ -1,0 +1,9 @@
+struct Box {
+    value: Int
+}
+
+fn main() {
+    let mut box = Box { value: 1 }
+    box = Box { value: 42 }
+    println(box.value)
+}

--- a/testdata/backend/llvm_smoke/struct_param_print.osty
+++ b/testdata/backend/llvm_smoke/struct_param_print.osty
@@ -1,0 +1,12 @@
+struct Score {
+    base: Int
+    bonus: Int
+}
+
+fn total(score: Score) -> Int {
+    score.base + score.bonus
+}
+
+fn main() {
+    println(total(Score { base: 40, bonus: 2 }))
+}

--- a/testdata/backend/llvm_smoke/struct_return_print.osty
+++ b/testdata/backend/llvm_smoke/struct_return_print.osty
@@ -1,0 +1,13 @@
+struct Pair {
+    left: Int
+    right: Int
+}
+
+fn makePair() -> Pair {
+    Pair { left: 10, right: 32 }
+}
+
+fn main() {
+    let pair = makePair()
+    println(pair.left + pair.right)
+}


### PR DESCRIPTION
## Summary
- add struct aggregate LLVM smoke paths for type definitions, field reads, returns, params, and mutable locals
- add payload-free enum tag smoke paths for variants, returns, params, and mutable locals
- keep new LLVM instruction builders in examples/selfhost-core/llvmgen.osty and update Phase 30-37 docs/corpus

## Verification
- `go test -count=1 ./internal/profile ./internal/llvmgen ./internal/backend ./internal/pipeline ./cmd/osty`
- after rebase: `go test -count=1 ./internal/llvmgen ./internal/backend ./cmd/osty`
- individual clang smoke runs for struct_field_print, struct_return_print, struct_param_print, struct_mut_print
- individual clang smoke runs for enum_variant_print, enum_return_print, enum_param_print, enum_mut_print
- `git diff --check`

Note: skipped the long selfhost-wide test wait per request. The known `go run ./cmd/osty test examples/selfhost-core/llvmgen_test.osty` path still reports the llvmgen test file itself as ok, then exits through the existing selfhost-wide checker/generated-Go failure.