### PR TITLE
Harden GC negative-path coverage

### DIFF
--- a/examples/gc/DESIGN.md
+++ b/examples/gc/DESIGN.md
@@ -1746,14 +1746,24 @@ Osty language spec은 OOM을 recoverable error로 보지 않는다. 이 library�
 ### Phase 41: Barrier Failure Paths and Bridge Accounting Integrity
 
 - Status: done for the executable prototype.
-- `barrierAudit()`의 failure path를 lowered slot/owner ref mismatch와 remembered bookkeeping
-  mismatch 테스트로 직접 잠근다.
+- `barrierAudit()`의 failure path를 lowered slot/owner ref mismatch, invalid lowered reference,
+  remembered bookkeeping mismatch 테스트로 직접 잠근다.
 - `hardeningReport()`가 heap invalid + barrier audit failure를 동시에 surface하는지 regression으로
   고정한다.
 - LLVM bridge trace의 handle/root/runtime-root accounting이 실제 table/set state와 어긋나면
   `validateHeap()`가 즉시 실패하도록 한다.
 - Acceptance criteria: audit/hardening drift와 bridge counter corruption이 런타임 연동 전에
   executable model에서 먼저 드러난다.
+
+### Phase 42: Performance Gate and Allocator Corruption Negatives
+
+- Status: done for the executable prototype.
+- `hardeningReport()`의 performance failure path를 threshold underflow 케이스로 regression에
+  고정한다.
+- Tenured free-list corruption이 live object와 겹칠 때 `validateHeap()`가 즉시 실패하는
+  negative path를 추가한다.
+- Acceptance criteria: hardening gate가 success path뿐 아니라 budget/free-list corruption도
+  실행 가능한 테스트로 드러낸다.
 ## Open Questions
 
 - Generational policy를 two-generation으로 고정할지, nursery plus aging tenured buckets로 확장할지.
@@ -1826,6 +1836,8 @@ allocation, root bind/release, post-write barrier call을 Osty-owned helper로 �
   regression test로 잠가 LLVM bridge state transition을 더 엄격하게 만든다.
 - Phase 41은 barrier audit failure path와 llvm bridge accounting mismatch를 hardening gate로
   묶어 negative-path coverage를 높인다.
+- Phase 42는 performance gate 실패와 allocator free-list corruption을 validator regression으로
+  잠가 production hardening surface를 더 촘촘하게 만든다.
 
 ## Future Native Runtime Path
 

--- a/examples/gc/lib_test.osty
+++ b/examples/gc/lib_test.osty
@@ -441,6 +441,21 @@ fn testLargeTenuredAllocationRoutesToHumongousSpace() {
     testing.assertEq(heap.humongousBytes(), 64)
 }
 
+fn testValidateHeapRejectsTenuredFreeBlockOverlappingLiveObject() {
+    let mut heap = newGcHeap(testGcConfig())
+    let old = heap.allocateTenured(GcRecord, 16)
+    assertValid(heap)
+
+    heap.tenured.freeList.push(
+        GcFreeBlock {
+            address: intOr(heap.addressOf(old), -1),
+            size: 8,
+        },
+    )
+
+    let _ = testing.expectError(heap.validateHeap())
+}
+
 fn testMajorCollectionReclaimsCycles() {
     let mut heap = newGcHeap(testGcConfig())
     assertValid(heap)
@@ -1279,6 +1294,44 @@ fn testHardeningReportFailsOnLoweredSlotMismatch() {
     testing.assert(report.validationMessage != "")
 }
 
+fn testHardeningReportFailsOnInvalidLoweredObjectReference() {
+    let mut heap = newGcHeap(testGcConfig())
+    let parent = heap.allocate(GcRecord, 16)
+    let child = heap.allocate(GcArray, 16)
+    testing.assert(heap.addRoot(parent))
+    match heap.lowerStructFieldStore(parent, 0, "child", child) {
+        Some(_) -> {},
+        None -> testing.fail("lowered field store failed"),
+    }
+    assertValid(heap)
+
+    let key = "struct.field:{parent}:0"
+    if heap.loweredPointerSlots.containsKey(key) {
+        let entry = heap.loweredPointerSlots[key]
+        let mut next = entry
+        next.objectId = 999
+        heap.loweredPointerSlots.insert(key, next)
+    } else {
+        testing.fail("missing lowered pointer slot")
+    }
+
+    let audit = heap.barrierAudit()
+    testing.assertEq(audit.loweredSlots, 1)
+    testing.assertEq(audit.invalidObjectReferences, 1)
+    testing.assertEq(audit.missingOwnerRefs, 0)
+    testing.assertEq(audit.rememberedMismatches, 0)
+    testing.assert(!(audit.passed))
+
+    let thresholds = gcPerformanceThresholdsForProfile(GcThroughputFirstProfile)
+    let report = heap.hardeningReport(thresholds)
+    testing.assert(!(report.passed))
+    testing.assert(!(report.heapValid))
+    testing.assert(!(report.barrierAuditPassed))
+    testing.assert(report.performancePassed)
+    testing.assertEq(report.loweredSlots, 1)
+    testing.assert(report.validationMessage != "")
+}
+
 fn testBarrierAuditDetectsRememberedMismatch() {
     let mut heap = newGcHeap(testGcConfig())
     let old = heap.allocateTenured(GcRecord, 16)
@@ -1310,6 +1363,38 @@ fn testBarrierAuditDetectsRememberedMismatch() {
     testing.assert(report.performancePassed)
 }
 
+fn testHardeningReportFailsPerformanceThresholds() {
+    let mut heap = newGcHeap(testGcConfig())
+    let parent = heap.allocate(GcRecord, 16)
+    let child = heap.allocate(GcArray, 16)
+    testing.assert(heap.addRoot(parent))
+    match heap.lowerStructFieldStore(parent, 0, "child", child) {
+        Some(_) -> {},
+        None -> testing.fail("lowered field store failed"),
+    }
+    let _ = heap.majorCollect()
+    assertValid(heap)
+
+    let baseline = heap.performanceReport(gcPerformanceThresholdsForProfile(GcThroughputFirstProfile))
+    testing.assert(baseline.liveBytes > 0)
+    let thresholds = GcPerformanceThresholds {
+        maxPauseUnits: baseline.pauseUnits,
+        maxFragmentedBytes: 1024,
+        maxLiveBytes: baseline.liveBytes - 1,
+        maxRememberedObjects: 64,
+        maxDirtyCards: 64,
+    }
+
+    let performance = heap.performanceReport(thresholds)
+    testing.assertEq(performance.pauseUnits, baseline.pauseUnits)
+    testing.assert(!(performance.passed))
+
+    let report = heap.hardeningReport(thresholds)
+    testing.assert(!(report.passed))
+    testing.assert(report.heapValid)
+    testing.assert(report.barrierAuditPassed)
+    testing.assert(!(report.performancePassed))
+}
 fn testLlvmHandleTablePreservesIdentityAcrossCompaction() {
     let mut heap = newGcHeap(testGcConfig())
     let dead = heap.allocate(GcBytes, 16)


### PR DESCRIPTION
## Summary
- harden `validateHeap()` with llvm bridge accounting invariants for handle/root/runtime-root table state
- add negative-path regression coverage for barrier audit invalid refs, remembered mismatches, performance gate failure, and tenured free-list corruption
- document the new GC hardening steps as Phase 41 and Phase 42 in the GC design notes

## Verification
- attempted `go test ./cmd/osty ./internal/ast ./internal/parser ./internal/llvmgen` but latest `main` is currently broken by unrelated in-progress selfhost removal work in `internal/selfhost`, `internal/llvmgen`, and `internal/manifest`
- attempted `go run -tags selfhostgen ./cmd/osty test --backend go examples/gc` but it is blocked by the same unrelated breakage on latest `main`
