### PR TITLE
Clarify legacy Go transpiler surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,8 +169,10 @@ per-symbol types in `Result.SymTypes`. Entry points mirror
 
 The main v0.4 front-end static guarantee hooks are wired here:
 
-- generic call sites are recorded in `Result.Instantiations` for
-  demand-driven monomorphization in `internal/gen`,
+- generic call sites are recorded in `Result.Instantiations`; this
+  originally fed demand-driven monomorphization in `internal/gen` and
+  remains available as front-end metadata while that legacy path is
+  retired,
 - structural interface satisfaction checks composed interfaces,
   `Self`-typed signatures, generic receiver substitution, params, and
   generic bounds,
@@ -228,23 +230,12 @@ Wired as `osty lint` with `--strict` (CI mode: exit 1 on any
 warning).
 
 ### `internal/gen`
-Go transpiler. Pure read-side consumer of the front-end: takes
-`*ast.File` + `*resolve.Result` + `*check.Result` and emits
-gofmt-formatted Go source. Phases 1–6 are wired end-to-end:
-primitive/control-flow code, structs/enums/match, generics/closures,
-Option/Result/`?`, `use`/FFI, and channels/concurrency. Phases are
-enumerated in the package doc comment at `doc.go`.
-
-Wired as `osty gen FILE` (with `-o OUT.go` / `--package NAME`): runs
-the front-end, aborts on errors, then transpiles to gofmt-formatted Go
-on stdout or at the given path.
-
-CLI-facing generation uses `GenerateMapped`, which emits `// Osty:
-path:line:column` comments before generated declarations and
-statements. `osty build`, `osty run`, and `osty test` use those markers
-when Go compilation or runtime execution fails so users can move from a
-generated `main.go:line` or panic stack frame back to the closest Osty
-source construct.
+Legacy Go transpiler retained only as migration residue while its
+removal lands. Historically it consumed `*ast.File` +
+`*resolve.Result` + `*check.Result` and emitted mapped Go source for
+early bootstrap flows. New backend work should target
+`internal/backend` / `internal/llvmgen` instead of extending this
+path.
 
 ### `internal/lsp`
 JSON-RPC language server on stdio. Lifecycle (`initialize` / `shutdown`

--- a/LANG_SPEC_v0.4/13-tooling.md
+++ b/LANG_SPEC_v0.4/13-tooling.md
@@ -14,7 +14,7 @@ osty fmt FILE             Format source files (--check, --write)
 osty repair FILE          Repair common syntax/idiom slips before parsing
 osty check FILE|DIR       Type-check without building
 osty lint FILE|DIR        Style + correctness lint (--strict for CI)
-osty gen FILE             Emit a single file through go or llvm backend
+osty gen FILE             Emit a single file through the native backend
 osty doc PATH             Generate API docs (markdown or html)
 osty ci [PATH]            Run format/lint/policy/lockfile/API checks
 osty ci snapshot [PATH]   Capture the exported API baseline
@@ -41,11 +41,11 @@ osty explain [CODE]       Explain compiler or lint diagnostics
 `--profile`, `--release`, `--target`, `--features`, and
 `--no-default-features`. `build`, `run`, `test`, `add`, `update`, and
 `fetch` accept dependency-resolution guards: `--offline`, `--locked`,
-and `--frozen`. Backend-producing commands accept `--backend go|llvm`
-and `--emit go|llvm-ir|object|binary`; the Go backend remains the
-default. `run` requires a host binary and rejects cross-target
-execution. The `test` harness is currently Go-backed; `--backend llvm`
-is reserved for backend-aware test generation.
+and `--frozen`. Public backend-producing commands accept `--backend llvm`
+and `--emit llvm-ir|object|binary`. Historical Go-backend/bootstrap
+switches are not part of the public CLI contract. `run` requires a host
+binary and rejects cross-target execution. Native `osty test`
+execution is still pending.
 
 ### 13.2 Manifest
 

--- a/LLVM_ARTIFACT_LAYOUT.md
+++ b/LLVM_ARTIFACT_LAYOUT.md
@@ -69,7 +69,7 @@ Backend directory names are stable API for tooling.
 
 | Backend | Directory | Notes |
 |---|---|---|
-| Go transpiler | `go` | Existing backend, still default during migration |
+| Go transpiler | `go` | Historical bootstrap path; kept here only as migration context while removal lands |
 | LLVM native | `llvm` | New backend; textual `.ll` first, then object/binary |
 
 Do not encode implementation detail in the backend directory name. For example,

--- a/LLVM_BACKEND_CORPUS.md
+++ b/LLVM_BACKEND_CORPUS.md
@@ -237,5 +237,5 @@ backend features are available.
 - Later backend work can refer to this document instead of guessing which
   examples are parity gates.
 
-The follow-up Go transpiler TODO audit is tracked in
+The historical Go transpiler TODO audit is tracked in
 [`LLVM_GEN_TODO_AUDIT.md`](./LLVM_GEN_TODO_AUDIT.md).

--- a/LLVM_GEN_TODO_AUDIT.md
+++ b/LLVM_GEN_TODO_AUDIT.md
@@ -1,8 +1,9 @@
 # LLVM Gen TODO Audit
 
-이 문서는 LLVM 이주 25-step Phase 3의 산출물이다. 목적은 현재 Go transpiler
+이 문서는 LLVM 이주 25-step Phase 3의 산출물이다. 목적은 당시 Go transpiler
 (`internal/gen`)의 TODO/unsupported marker를 감사해서, LLVM 1차 backend 범위가
-기존 Go backend coverage gap과 섞이지 않도록 하는 것이다.
+기존 Go backend coverage gap과 섞이지 않도록 하는 것이었다. 현재는 역사 기록이며,
+새 작업의 기준 문서로 취급하지 않는다.
 
 ## Static Marker Summary
 

--- a/LLVM_PHASE1_BASELINE.md
+++ b/LLVM_PHASE1_BASELINE.md
@@ -2,9 +2,10 @@
 
 기준일: 2026-04-16 Asia/Seoul
 기준 commit: `0eb6ea1`
-목적: LLVM backend 이주 전에 현재 Go backend와 관련 CLI 경로의 실제 동작을
-고정한다. 이 문서는 이후 LLVM parity 작업에서 "현재 구현이 이미 하던 것"과
-"현재 구현도 아직 못 하던 것"을 구분하기 위한 기준선이다.
+목적: LLVM backend 이주 초기에 기록한 historical baseline 이다. 당시 Go
+backend와 관련 CLI 경로의 실제 동작을 고정해 두었고, 이후 LLVM parity 작업에서
+"그 시점 구현이 이미 하던 것"과 "그 시점 구현도 아직 못 하던 것"을 구분하기 위한
+기준선으로 사용했다.
 
 ## Scope
 

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -76,7 +76,7 @@ front-end 에서 finite 하게 잡을 수 있을 것, 에러 메시지가 안정
 | 항목 | 분류 | 처리 |
 |---|---|---|
 | generic type parameter defaults (`struct Pair<T, U = T>`) | excluded feature | v0.4 grammar freeze 에서 제외. 나중에 넣으려면 새 edition 제안으로 재오픈. |
-| Go transpiler TODO markers / unsupported lowering forms | backend parity | 언어 스펙 미정이 아니라 gen coverage 문제. `internal/gen/doc.go` 와 tests 로 관리. |
+| Historical Go transpiler TODO audit / unsupported lowering forms | backend archive | 언어 스펙 미정이 아니라 retired backend parity 문맥이다. `LLVM_GEN_TODO_AUDIT.md` 는 역사 기록으로만 유지한다. |
 | IR가 아직 gen 의 입력이 아님 | backend architecture | `internal/ir/doc.go` 의 follow-on work. 언어 결정 아님. |
 | package-manager SAT solver, multi-binary manifests, build artifact convention | tooling/product backlog | manifest/pkgmgr/build 문서나 이슈로 관리. 언어 의미론 아님. |
 | LSP incremental sync, richer doc/comment transport | tooling backlog | LSP/editor 품질 항목. 언어 의미론 아님. |

--- a/examples/gc/DESIGN.md
+++ b/examples/gc/DESIGN.md
@@ -1,8 +1,9 @@
 # Osty Independent GC Design
 
 이 문서는 `examples/gc` 패키지의 설계 기준이다. 목표는 Osty 언어로
-작성된 독립 GC 코어를 만드는 것이다. 현재 Go transpiler 위에서 실행되지만,
-구조는 미래의 native Osty 런타임이 그대로 가져갈 수 있는 형태를 지향한다.
+작성된 독립 GC 코어를 만드는 것이다. 현재 구현 세부는 과도기적일 수
+있지만, 구조는 미래의 native Osty 런타임이 그대로 가져갈 수 있는 형태를
+지향한다.
 
 ## 큰 그림
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -512,7 +512,7 @@ func RenderWorkspaceManifest(name, edition, member string) string {
 }
 
 func renderManifest(name, edition string, k Kind) string {
-	header := "# Binary project; `osty gen main.osty` emits LLVM IR for the entry point."
+	header := "# Binary project; `osty gen main.osty` uses the native LLVM backend and emits LLVM IR for the entry point."
 	switch k {
 	case KindLib:
 		header = "# Library project; exposes a public API via `pub` declarations."

--- a/justfile
+++ b/justfile
@@ -19,9 +19,6 @@ short:
 full:
     go test ./...
 
-gen test=".":
-    go test -count=1 ./internal/gen -run '{{test}}' -v
-
 lsp test=".":
     go test -count=1 ./internal/lsp -run '{{test}}' -v
 
@@ -43,9 +40,6 @@ profile target:
 
 watch-front:
     watchexec -e go,osty,md -- just front
-
-watch-gen test=".":
-    watchexec -e go,osty -- just gen '{{test}}'
 
 watch-pipe target:
     watchexec -e go,osty -- just pipe {{target}}

--- a/word_freq.osty
+++ b/word_freq.osty
@@ -7,7 +7,7 @@
 // 사용:  osty run word_freq.osty -- <file1> <file2> ...
 //
 // Grammar v0.2 / LANG_SPEC v0.9 준수 확인됨.
-// osty:ci-skip -- future stdlib sample; see internal/gen realworld probe.
+// osty:ci-skip -- future stdlib sample; see the historical internal/gen realworld probe.
 //
 
 use std.fs


### PR DESCRIPTION
## Summary
- clarify docs and scaffolding text so the repo reads as native-only after Go transpiler removal
- remove justfile and reference wording that still pointed people at legacy Go transpiler flows
- keep this PR low-conflict by avoiding core backend/transpiler code while the larger deletion work lands

## Testing
- go test ./internal/scaffold ./cmd/osty