### PR TITLE
Add LLVM for-let enum lowering

### DIFF
--- a/internal/llvmgen/for_let_test.go
+++ b/internal/llvmgen/for_let_test.go
@@ -1,0 +1,80 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateForLetPayloadEnumLoop(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Maybe {
+    Some(Int)
+    None
+}
+
+fn main() {
+    let mut value: Maybe = Some(42)
+    for let Some(x) = value {
+        println(x)
+        value = None
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/for_let_payload_loop.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Maybe = type { i64, i64 }",
+		"for.cond",
+		"for.body",
+		"for.end",
+		"extractvalue %Maybe",
+		"store %Maybe",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateForLetQualifiedVariantLoop(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Maybe {
+    Some(Int)
+    None
+}
+
+fn main() {
+    let mut value: Maybe = Maybe.Some(42)
+    for let Maybe.Some(x) = value {
+        println(x)
+        value = Maybe.None
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/for_let_qualified_loop.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Maybe = type { i64, i64 }",
+		"insertvalue %Maybe",
+		"extractvalue %Maybe",
+		"br i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1020,7 +1020,7 @@ func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
 
 func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	if stmt.IsForLet {
-		return unsupported("control-flow", "for-let is not supported")
+		return g.emitForLet(stmt)
 	}
 	if stmt.Body == nil {
 		return unsupported("control-flow", "for has no body")
@@ -1063,6 +1063,59 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	emitter = g.toOstyEmitter()
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
+	return nil
+}
+
+func (g *generator) emitForLet(stmt *ast.ForStmt) error {
+	if stmt.Body == nil {
+		return unsupported("control-flow", "for has no body")
+	}
+	if stmt.Pattern == nil {
+		return unsupported("control-flow", "for-let requires a pattern")
+	}
+	if stmt.Iter == nil {
+		return unsupported("control-flow", "for-let requires an iterator expression")
+	}
+	emitter := g.toOstyEmitter()
+	condLabel := llvmNextLabel(emitter, "for.cond")
+	bodyLabel := llvmNextLabel(emitter, "for.body")
+	endLabel := llvmNextLabel(emitter, "for.end")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", condLabel))
+	g.takeOstyEmitter(emitter)
+
+	scrutinee, err := g.emitExpr(stmt.Iter)
+	if err != nil {
+		return err
+	}
+	cond, bind, err := g.ifLetCondition(stmt.Pattern, scrutinee)
+	if err != nil {
+		return err
+	}
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, bodyLabel, endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = bodyLabel
+
+	g.pushScope()
+	if bind != nil {
+		if err := bind(); err != nil {
+			g.popScope()
+			return err
+		}
+	}
+	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
+		g.popScope()
+		return err
+	}
+	g.popScope()
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = endLabel
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add LLVM lowering for enum-based for-let loops
- reuse if-let enum pattern matching and payload binding in loop form
- cover payload and qualified variant loop forms with llvmgen tests

## Test
- go test ./internal/llvmgen -run 'TestGenerateForLet' -count=1
- go test ./internal/llvmgen ./internal/backend ./cmd/osty