### PR TITLE
Add LLVM match guard lowering

### DIFF
--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1846,13 +1846,17 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 	if err != nil {
 		return value{}, err
 	}
+	hasGuard := false
 	for _, arm := range expr.Arms {
 		if arm == nil {
 			return value{}, unsupported("expression", "nil match arm")
 		}
 		if arm.Guard != nil {
-			return value{}, unsupported("control-flow", "match guards are not supported")
+			hasGuard = true
 		}
+	}
+	if hasGuard {
+		return g.emitGuardedMatchExprValue(scrutinee, expr.Arms)
 	}
 	if scrutinee.typ == "i64" {
 		return g.emitTagEnumMatchExprValue(scrutinee, expr.Arms)
@@ -1924,6 +1928,118 @@ func (g *generator) emitTagEnumMatchExprValue(scrutinee value, arms []*ast.Match
 		return value{}, unsupported("expression", "match with no arms")
 	}
 	return current, nil
+}
+
+func (g *generator) emitGuardedMatchExprValue(scrutinee value, arms []*ast.MatchArm) (value, error) {
+	if len(arms) == 0 {
+		return value{}, unsupported("expression", "match with no arms")
+	}
+	arm := arms[0]
+	if arm == nil {
+		return value{}, unsupported("expression", "nil match arm")
+	}
+	if len(arms) == 1 {
+		return g.emitFinalMatchArmValue(scrutinee, arm)
+	}
+	if _, catchAll := arm.Pattern.(*ast.WildcardPat); catchAll && arm.Guard == nil {
+		return value{}, unsupported("expression", "wildcard match arm must be last")
+	}
+	cond, bind, err := g.ifLetCondition(arm.Pattern, scrutinee)
+	if err != nil {
+		return value{}, err
+	}
+	emitter := g.toOstyEmitter()
+	labels := llvmIfExprStart(emitter, cond)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	thenValue, err := g.emitGuardedMatchArmThenValue(scrutinee, arm, arms[1:], bind)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	elseValue, err := g.emitGuardedMatchExprValue(scrutinee, arms[1:])
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+	if thenValue.typ != elseValue.typ {
+		return value{}, unsupportedf("type-system", "match arm types %s/%s", thenValue.typ, elseValue.typ)
+	}
+	return g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
+}
+
+func (g *generator) emitGuardedMatchArmThenValue(scrutinee value, arm *ast.MatchArm, rest []*ast.MatchArm, bind func() error) (value, error) {
+	g.pushScope()
+	defer g.popScope()
+	if bind != nil {
+		if err := bind(); err != nil {
+			return value{}, err
+		}
+	}
+	if arm.Guard == nil {
+		return g.emitMatchArmBodyValue(arm.Body)
+	}
+	guard, err := g.emitExpr(arm.Guard)
+	if err != nil {
+		return value{}, err
+	}
+	if guard.typ != "i1" {
+		return value{}, unsupportedf("type-system", "match guard type %s, want i1", guard.typ)
+	}
+	if len(rest) == 0 {
+		return value{}, unsupported("control-flow", "final guarded match arm requires an unguarded fallback arm")
+	}
+	emitter := g.toOstyEmitter()
+	labels := llvmIfExprStart(emitter, toOstyValue(guard))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	thenValue, err := g.emitMatchArmBodyValue(arm.Body)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	elseValue, err := g.emitGuardedMatchExprValue(scrutinee, rest)
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+	if thenValue.typ != elseValue.typ {
+		return value{}, unsupportedf("type-system", "match arm types %s/%s", thenValue.typ, elseValue.typ)
+	}
+	return g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
+}
+
+func (g *generator) emitFinalMatchArmValue(scrutinee value, arm *ast.MatchArm) (value, error) {
+	if arm == nil {
+		return value{}, unsupported("expression", "nil match arm")
+	}
+	if arm.Guard != nil {
+		return value{}, unsupported("control-flow", "final guarded match arm requires an unguarded fallback arm")
+	}
+	_, bind, err := g.ifLetCondition(arm.Pattern, scrutinee)
+	if err != nil {
+		return value{}, err
+	}
+	g.pushScope()
+	defer g.popScope()
+	if bind != nil {
+		if err := bind(); err != nil {
+			return value{}, err
+		}
+	}
+	return g.emitMatchArmBodyValue(arm.Body)
 }
 
 func (g *generator) emitTagEnumMatchIfExprValue(scrutinee value, first, second *ast.MatchArm) (value, error) {

--- a/internal/llvmgen/match_guard_test.go
+++ b/internal/llvmgen/match_guard_test.go
@@ -1,0 +1,83 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGeneratePayloadEnumMatchGuards(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Maybe {
+    Some(Int)
+    None
+}
+
+fn describe(value: Maybe) -> String {
+    match value {
+        Some(v) if v > 0 -> "positive",
+        Some(v) if v < 0 -> "negative",
+        Some(_) -> "zero",
+        None -> "missing",
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/match_guard_payload.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Maybe = type { i64, i64 }",
+		"extractvalue %Maybe",
+		"icmp sgt i64",
+		"icmp slt i64",
+		"phi ptr",
+		"positive",
+		"negative",
+		"zero",
+		"missing",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateTagEnumMatchGuards(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Kind {
+    Ready,
+    Waiting,
+}
+
+fn choose(flag: Bool, kind: Kind) -> Int {
+    match kind {
+        Ready if flag -> 1,
+        Ready -> 2,
+        Waiting -> 3,
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/match_guard_tag.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @choose(i1 %flag, i64 %kind)",
+		"icmp eq i64 %kind, 0",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add LLVM lowering for guarded match arms
- reuse enum/tag payload pattern binding through recursive guarded match lowering
- cover payload and tag enum guarded match forms with llvmgen tests

## Test
- go test ./internal/llvmgen -run 'TestGenerate(PayloadEnumMatchGuards|TagEnumMatchGuards)' -count=1
- go test ./internal/llvmgen ./internal/backend ./cmd/osty