### PR TITLE
Generalize LLVM multi-arm enum matches

### DIFF
--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1876,11 +1876,20 @@ func (g *generator) emitTagEnumMatchExprValue(scrutinee value, arms []*ast.Match
 	if len(arms) == 2 {
 		return g.emitTagEnumMatchIfExprValue(scrutinee, arms[0], arms[1])
 	}
+	selectSafe := true
 	for _, arm := range arms {
 		if !matchArmBodyIsSelectSafe(arm.Body) {
-			return value{}, unsupported("expression", "multi-arm match currently requires literal/identifier arm bodies")
+			selectSafe = false
+			break
 		}
 	}
+	if selectSafe {
+		return g.emitTagEnumMatchSelectValue(scrutinee, arms)
+	}
+	return g.emitTagEnumMatchChainValue(scrutinee, arms)
+}
+
+func (g *generator) emitTagEnumMatchSelectValue(scrutinee value, arms []*ast.MatchArm) (value, error) {
 	var current value
 	haveCurrent := false
 	for i := len(arms) - 1; i >= 0; i-- {
@@ -1928,6 +1937,61 @@ func (g *generator) emitTagEnumMatchExprValue(scrutinee value, arms []*ast.Match
 		return value{}, unsupported("expression", "match with no arms")
 	}
 	return current, nil
+}
+
+func (g *generator) emitTagEnumMatchChainValue(scrutinee value, arms []*ast.MatchArm) (value, error) {
+	if len(arms) == 0 {
+		return value{}, unsupported("expression", "match with no arms")
+	}
+	arm := arms[0]
+	if arm == nil {
+		return value{}, unsupported("expression", "nil match arm")
+	}
+	if len(arms) == 1 {
+		if _, catchAll := arm.Pattern.(*ast.WildcardPat); !catchAll {
+			if _, ok, err := g.matchEnumTag(arm.Pattern); err != nil {
+				return value{}, err
+			} else if !ok {
+				return value{}, unsupported("expression", "match arm must be a payload-free enum variant")
+			}
+		}
+		return g.emitMatchArmBodyValue(arm.Body)
+	}
+	if _, catchAll := arm.Pattern.(*ast.WildcardPat); catchAll {
+		return value{}, unsupported("expression", "wildcard match arm must be last")
+	}
+	tag, ok, err := g.matchEnumTag(arm.Pattern)
+	if err != nil {
+		return value{}, err
+	}
+	if !ok {
+		return value{}, unsupported("expression", "match arm must be a payload-free enum variant")
+	}
+	emitter := g.toOstyEmitter()
+	cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(value{typ: "i64", ref: strconv.Itoa(tag)}))
+	labels := llvmIfExprStart(emitter, cond)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	thenValue, err := g.emitMatchArmBodyValue(arm.Body)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	elseValue, err := g.emitTagEnumMatchChainValue(scrutinee, arms[1:])
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+	if thenValue.typ != elseValue.typ {
+		return value{}, unsupportedf("type-system", "match arm types %s/%s", thenValue.typ, elseValue.typ)
+	}
+	return g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
 }
 
 func (g *generator) emitGuardedMatchExprValue(scrutinee value, arms []*ast.MatchArm) (value, error) {

--- a/internal/llvmgen/multi_arm_match_test.go
+++ b/internal/llvmgen/multi_arm_match_test.go
@@ -1,0 +1,97 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateTagEnumMultiArmMatchWithBlockBodies(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Kind {
+    Ready,
+    Waiting,
+    Done,
+}
+
+fn score(kind: Kind) -> Int {
+    match kind {
+        Ready -> {
+            let base = 40
+            base + 2
+        },
+        Waiting -> {
+            let base = 20
+            base + 1
+        },
+        Done -> 0,
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/multi_arm_block_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @score(i64 %kind)",
+		"if.expr.then",
+		"if.expr.else",
+		"phi i64",
+		"add i64 40, 2",
+		"add i64 20, 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateTagEnumMultiArmMatchWithCalls(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Kind {
+    Ready,
+    Waiting,
+    Done,
+}
+
+fn ready() -> Int {
+    42
+}
+
+fn waiting() -> Int {
+    21
+}
+
+fn score(kind: Kind) -> Int {
+    match kind {
+        Ready -> ready(),
+        Waiting -> waiting(),
+        _ -> 0,
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/multi_arm_call_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @ready()",
+		"define i64 @waiting()",
+		"call i64 @ready()",
+		"call i64 @waiting()",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- keep select fast-path for simple match arms
- add branch-and-phi lowering for non-trivial multi-arm payload-free enum matches
- cover block-bodied and call-bodied multi-arm matches with llvmgen tests

## Test
- go test ./internal/llvmgen ./internal/backend ./cmd/osty