### PR TITLE
Add pressure-driven LLVM runtime GC

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -34,6 +34,7 @@ void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_re
 
 void osty_gc_debug_collect(void);
 int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_collection_count(void);
 void *osty_rt_list_new(void);
 void osty_rt_list_push_ptr(void *list, void *value);
 int64_t osty_rt_list_len(void *list);
@@ -156,5 +157,140 @@ int main(void) {
 	}
 	if got, want := string(runOutput), "1\n0\n2\n1\n0\n"; got != want {
 		t.Fatalf("runtime safepoint harness stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBundledRuntimeAutoCollectsAtPressureSafepoints(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_pressure_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_pressure_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t root_slot_count) __asm__(OSTY_GC_SYMBOL("osty.gc.safepoint_v1"));
+
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_collection_count(void);
+
+int main(void) {
+    void *root = osty_gc_alloc_v1(7, 32, "root");
+    void *leaf = osty_gc_alloc_v1(8, 16, "leaf");
+    (void)leaf;
+    osty_gc_root_bind_v1(root);
+    osty_gc_safepoint_v1(1, NULL, 0);
+    printf("%lld\n", (long long)osty_gc_debug_collection_count());
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+    osty_gc_root_release_v1(root);
+    leaf = osty_gc_alloc_v1(9, 8, "late");
+    (void)leaf;
+    osty_gc_safepoint_v1(2, NULL, 0);
+    printf("%lld\n", (long long)osty_gc_debug_collection_count());
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "1\n1\n2\n0\n"; got != want {
+		t.Fatalf("runtime pressure harness stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBundledRuntimePressureKeepsRootedListChildrenAlive(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_pressure_list_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_pressure_list_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t root_slot_count) __asm__(OSTY_GC_SYMBOL("osty.gc.safepoint_v1"));
+
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_collection_count(void);
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+void *osty_rt_list_get_ptr(void *list, int64_t index);
+
+int main(void) {
+    void *list = osty_rt_list_new();
+    void *child = osty_gc_alloc_v1(8, 16, "child");
+    void *saved_child = child;
+    osty_rt_list_push_ptr(list, child);
+    osty_gc_root_bind_v1(list);
+    child = osty_gc_alloc_v1(9, 8, "garbage");
+    (void)child;
+    osty_gc_safepoint_v1(1, NULL, 0);
+    printf("%lld\n", (long long)osty_gc_debug_collection_count());
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+    printf("%d\n", osty_rt_list_get_ptr(list, 0) == saved_child);
+    osty_gc_root_release_v1(list);
+    child = osty_gc_alloc_v1(10, 8, "late");
+    (void)child;
+    osty_gc_safepoint_v1(2, NULL, 0);
+    printf("%lld\n", (long long)osty_gc_debug_collection_count());
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "1\n2\n1\n2\n0\n"; got != want {
+		t.Fatalf("runtime pressure list harness stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -264,3 +264,41 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryAutoCollectsOnPressure(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+fn touch() {}
+
+fn localCount() -> Int {
+    let parts = strings.Split("gc,llvm", ",")
+    touch()
+    parts.len()
+}
+
+fn main() {
+    println(localCount())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "2\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -42,9 +42,16 @@ enum {
 
 static osty_gc_header *osty_gc_objects = NULL;
 static int64_t osty_gc_live_count = 0;
+static int64_t osty_gc_live_bytes = 0;
 static int64_t osty_gc_collection_count = 0;
+static int64_t osty_gc_allocated_since_collect = 0;
 static bool osty_gc_safepoint_stress_loaded = false;
 static bool osty_gc_safepoint_stress_enabled = false;
+static bool osty_gc_pressure_limit_loaded = false;
+static int64_t osty_gc_pressure_limit_bytes = 32768;
+static bool osty_gc_collection_requested = false;
+
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
 
 static void osty_rt_abort(const char *message) {
     fprintf(stderr, "osty llvm runtime: %s\n", message);
@@ -59,6 +66,7 @@ static void osty_gc_link(osty_gc_header *header) {
     }
     osty_gc_objects = header;
     osty_gc_live_count += 1;
+    osty_gc_live_bytes += header->byte_size;
 }
 
 static void osty_gc_unlink(osty_gc_header *header) {
@@ -71,6 +79,43 @@ static void osty_gc_unlink(osty_gc_header *header) {
         header->next->prev = header->prev;
     }
     osty_gc_live_count -= 1;
+    osty_gc_live_bytes -= header->byte_size;
+}
+
+static int64_t osty_gc_pressure_limit_now(void) {
+    const char *value;
+    char *end = NULL;
+    long long parsed;
+
+    if (osty_gc_pressure_limit_loaded) {
+        return osty_gc_pressure_limit_bytes;
+    }
+    osty_gc_pressure_limit_loaded = true;
+    value = getenv("OSTY_GC_THRESHOLD_BYTES");
+    if (value == NULL || value[0] == '\0') {
+        return osty_gc_pressure_limit_bytes;
+    }
+    parsed = strtoll(value, &end, 10);
+    if (end == value || (end != NULL && *end != '\0') || parsed < 0) {
+        osty_rt_abort("invalid OSTY_GC_THRESHOLD_BYTES");
+    }
+    osty_gc_pressure_limit_bytes = (int64_t)parsed;
+    return osty_gc_pressure_limit_bytes;
+}
+
+static void osty_gc_note_allocation(size_t payload_size) {
+    int64_t pressure_limit = osty_gc_pressure_limit_now();
+
+    if (payload_size > (size_t)INT64_MAX) {
+        osty_rt_abort("GC payload size overflow");
+    }
+    osty_gc_allocated_since_collect += (int64_t)payload_size;
+    if (pressure_limit <= 0) {
+        return;
+    }
+    if (osty_gc_live_bytes >= pressure_limit || osty_gc_allocated_since_collect >= pressure_limit) {
+        osty_gc_collection_requested = true;
+    }
 }
 
 static osty_gc_header *osty_gc_find_header(void *payload) {
@@ -107,6 +152,7 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
     header->site = site;
     header->payload = (void *)(header + 1);
     osty_gc_link(header);
+    osty_gc_note_allocation(payload_size);
     return header->payload;
 }
 
@@ -194,6 +240,8 @@ static void osty_gc_collect_now_with_stack_roots(void *const *root_slots, int64_
         header = next;
     }
     osty_gc_collection_count += 1;
+    osty_gc_allocated_since_collect = 0;
+    osty_gc_collection_requested = false;
 }
 
 static void osty_gc_collect_now(void) {
@@ -319,6 +367,7 @@ void osty_rt_list_push_f64(void *raw_list, double value) {
 
 void osty_rt_list_push_ptr(void *raw_list, void *value) {
     osty_rt_list_push_bytes(raw_list, &value, sizeof(value), true);
+    osty_gc_post_write_v1(raw_list, value, OSTY_GC_KIND_LIST);
 }
 
 int64_t osty_rt_list_get_i64(void *raw_list, int64_t index) {
@@ -390,7 +439,6 @@ void *osty_rt_strings_Split(const char *value, const char *sep) {
 }
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
-void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
 void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
 void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
 void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t root_slot_count) __asm__(OSTY_GC_SYMBOL("osty.gc.safepoint_v1"));
@@ -403,9 +451,22 @@ void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site)
 }
 
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
-    (void)owner;
-    (void)value;
+    osty_gc_header *owner_header;
+
     (void)slot_kind;
+    if (owner == NULL || value == NULL) {
+        return;
+    }
+    owner_header = osty_gc_find_header(owner);
+    if (owner_header == NULL) {
+        return;
+    }
+    if (osty_gc_find_header(value) == NULL) {
+        return;
+    }
+    if (owner_header->root_count > 0) {
+        osty_gc_collection_requested = true;
+    }
 }
 
 void osty_gc_root_bind_v1(void *root) {
@@ -435,7 +496,7 @@ void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t
     if (root_slot_count < 0) {
         osty_rt_abort("negative safepoint root slot count");
     }
-    if (!osty_gc_safepoint_stress_enabled_now()) {
+    if (!osty_gc_safepoint_stress_enabled_now() && !osty_gc_collection_requested) {
         return;
     }
     osty_gc_collect_now_with_stack_roots(root_slots, root_slot_count);
@@ -451,4 +512,8 @@ int64_t osty_gc_debug_live_count(void) {
 
 int64_t osty_gc_debug_collection_count(void) {
     return osty_gc_collection_count;
+}
+
+int64_t osty_gc_debug_live_bytes(void) {
+    return osty_gc_live_bytes;
 }

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -2306,6 +2306,9 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 		return true, unsupported("call", "list.push requires one positional argument")
 	}
+	emitter := g.toOstyEmitter()
+	g.emitGCSafepoint(emitter)
+	g.takeOstyEmitter(emitter)
 	base, err := g.emitExpr(field.X)
 	if err != nil {
 		return true, err
@@ -2322,7 +2325,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	}
 	pushSymbol := listRuntimePushSymbol(elemTyp)
 	g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
-	emitter := g.toOstyEmitter()
+	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf(
 		"  call void @%s(%s)",
 		pushSymbol,

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -322,6 +322,32 @@ func TestGenerateListPushStmtUsesRuntimeABI(t *testing.T) {
 	}
 }
 
+func TestGenerateManagedListPushStmtUsesSafepoint(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn append(mut values: List<String>, item: String) {
+    values.push(item)
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/list_push_managed.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare void @osty.gc.safepoint_v1(i64, ptr, i64)",
+		"call void @osty.gc.safepoint_v1(",
+		"call void @osty_rt_list_push_ptr(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestGenerateForInOverListStringUsesRuntimeABI(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn visit(items: List<String>) {
     for item in items {


### PR DESCRIPTION
## Summary
- request GC collection from runtime allocation pressure and fulfill it at LLVM safepoints
- make pointer list mutation participate in runtime GC bookkeeping and treat list.push as a safepoint-capable operation
- add runtime harness and clang-backed backend coverage for pressure-driven collection preserving managed roots

## Testing
- go test ./cmd/osty ./internal/llvmgen ./internal/backend