### PR TITLE
Advance LLVM GC ABI parity and payload matches

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -29,6 +29,8 @@ func TestBundledRuntimeDebugCollectRespectsRoots(t *testing.T) {
 #endif
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
 void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
 void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
 
@@ -53,11 +55,13 @@ int main(void) {
 
     void *list = osty_rt_list_new();
     void *child = osty_gc_alloc_v1(8, 16, "child");
+    osty_gc_pre_write_v1(list, child, 0);
     osty_rt_list_push_ptr(list, child);
     osty_gc_root_bind_v1(list);
     osty_gc_debug_collect();
     printf("%lld\n", (long long)osty_gc_debug_live_count());
     printf("%lld\n", (long long)osty_rt_list_len(list));
+    printf("%d\n", osty_gc_load_v1(list) == list);
     osty_gc_root_release_v1(list);
     osty_gc_debug_collect();
     printf("%lld\n", (long long)osty_gc_debug_live_count());
@@ -85,7 +89,7 @@ int main(void) {
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
-	if got, want := string(runOutput), "1\n0\n2\n1\n0\n3\n1\n1\n0\n"; got != want {
+	if got, want := string(runOutput), "1\n0\n2\n1\n1\n0\n3\n1\n1\n0\n"; got != want {
 		t.Fatalf("runtime GC harness stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -130,6 +130,8 @@ func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
 	for _, want := range []string{
 		"osty_rt_list_new",
 		"osty_rt_strings_Equal",
+		"osty.gc.pre_write_v1",
+		"osty.gc.load_v1",
 		"osty.gc.root_bind_v1",
 		"osty.gc.safepoint_v1",
 		"osty_gc_debug_collect",

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -439,6 +439,9 @@ void *osty_rt_strings_Split(const char *value, const char *sep) {
 }
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
+void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
 void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
 void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
 void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t root_slot_count) __asm__(OSTY_GC_SYMBOL("osty.gc.safepoint_v1"));
@@ -448,6 +451,12 @@ void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site)
         osty_rt_abort("negative GC allocation size");
     }
     return osty_gc_allocate_managed((size_t)byte_size, object_kind == 0 ? OSTY_GC_KIND_GENERIC : object_kind, site, NULL, NULL);
+}
+
+void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) {
+    (void)owner;
+    (void)old_value;
+    (void)slot_kind;
 }
 
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
@@ -467,6 +476,10 @@ void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
     if (owner_header->root_count > 0) {
         osty_gc_collection_requested = true;
     }
+}
+
+void *osty_gc_load_v1(void *value) {
+    return value;
 }
 
 void osty_gc_root_bind_v1(void *root) {

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1914,12 +1914,7 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 		return g.emitTagEnumMatchExprValue(scrutinee, expr.Arms)
 	}
 	if info := g.enumsByType[scrutinee.typ]; info != nil && info.hasPayload {
-		if len(expr.Arms) != 2 {
-			return value{}, unsupportedf("expression", "payload enum match with %d arms", len(expr.Arms))
-		}
-		first := expr.Arms[0]
-		second := expr.Arms[1]
-		return g.emitPayloadEnumMatchExprValue(scrutinee, info, first, second)
+		return g.emitPayloadEnumMatchExprValue(scrutinee, info, expr.Arms)
 	}
 	return value{}, unsupportedf("type-system", "match scrutinee type %s, want enum tag", scrutinee.typ)
 }
@@ -2382,7 +2377,11 @@ func matchArmBodyIsSelectSafe(expr ast.Expr) bool {
 	}
 }
 
-func (g *generator) emitPayloadEnumMatchExprValue(scrutinee value, info *enumInfo, first, second *ast.MatchArm) (value, error) {
+func (g *generator) emitPayloadEnumMatchExprValue(scrutinee value, info *enumInfo, arms []*ast.MatchArm) (value, error) {
+	if len(arms) == 0 {
+		return value{}, unsupported("expression", "match with no arms")
+	}
+	first := arms[0]
 	firstPattern, ok, err := g.matchPayloadEnumPattern(info, first.Pattern)
 	if err != nil {
 		return value{}, err
@@ -2390,6 +2389,17 @@ func (g *generator) emitPayloadEnumMatchExprValue(scrutinee value, info *enumInf
 	if !ok {
 		return value{}, unsupportedf("expression", "first match arm must be an enum %q variant", info.name)
 	}
+	if len(arms) == 1 {
+		g.pushScope()
+		defer g.popScope()
+		if err := g.bindPayloadEnumPattern(scrutinee, firstPattern); err != nil {
+			return value{}, err
+		}
+		return g.emitMatchArmBodyValue(first.Body)
+	}
+	second := arms[1]
+	var elseValue value
+	var elsePred string
 	var secondPattern enumPatternInfo
 	secondHasPattern := false
 	if _, catchAll := second.Pattern.(*ast.WildcardPat); !catchAll {
@@ -2425,19 +2435,27 @@ func (g *generator) emitPayloadEnumMatchExprValue(scrutinee value, info *enumInf
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = labels.elseLabel
 
-	g.pushScope()
-	if secondHasPattern {
-		if err := g.bindPayloadEnumPattern(scrutinee, secondPattern); err != nil {
-			g.popScope()
+	if len(arms) > 2 {
+		elseValue, err = g.emitPayloadEnumMatchExprValue(scrutinee, info, arms[1:])
+		if err != nil {
 			return value{}, err
 		}
+		elsePred = g.currentBlock
+	} else {
+		g.pushScope()
+		if secondHasPattern {
+			if err := g.bindPayloadEnumPattern(scrutinee, secondPattern); err != nil {
+				g.popScope()
+				return value{}, err
+			}
+		}
+		elseValue, err = g.emitMatchArmBodyValue(second.Body)
+		g.popScope()
+		if err != nil {
+			return value{}, err
+		}
+		elsePred = g.currentBlock
 	}
-	elseValue, err := g.emitMatchArmBodyValue(second.Body)
-	g.popScope()
-	if err != nil {
-		return value{}, err
-	}
-	elsePred := g.currentBlock
 	if thenValue.typ != elseValue.typ {
 		return value{}, unsupportedf("type-system", "match arm types %s/%s", thenValue.typ, elseValue.typ)
 	}

--- a/internal/llvmgen/multi_arm_match_test.go
+++ b/internal/llvmgen/multi_arm_match_test.go
@@ -95,3 +95,52 @@ fn score(kind: Kind) -> Int {
 		}
 	}
 }
+
+func TestGeneratePayloadEnumMultiArmMatchWithBlockBodies(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Maybe {
+    Some(Int)
+    More(Int)
+    None
+}
+
+fn score(value: Maybe) -> Int {
+    match value {
+        Some(x) -> {
+            let base = x
+            base + 1
+        },
+        More(y) -> {
+            let base = y
+            base + 2
+        },
+        _ -> 0,
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/payload_multi_arm_block_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Maybe = type { i64, i64 }",
+		"define i64 @score(%Maybe %value)",
+		"extractvalue %Maybe",
+		"phi i64",
+		"icmp eq i64",
+		", 1",
+		", 2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	if gotCount := strings.Count(got, "extractvalue %Maybe"); gotCount < 2 {
+		t.Fatalf("generated IR should extract payload for multiple arms, got %d extracts:\n%s", gotCount, got)
+	}
+}

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -45,12 +45,16 @@ func TestGeneratedGcRuntimeAbiSmokeIR(t *testing.T) {
 
 	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/gc_runtime_abi.osty\"")
 	assertGeneratedIRContains(t, ir, "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)")
+	assertGeneratedIRContains(t, ir, "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)")
 	assertGeneratedIRContains(t, ir, "declare void @osty.gc.post_write_v1(ptr, ptr, i64)")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty.gc.load_v1(ptr)")
 	assertGeneratedIRContains(t, ir, "declare void @osty.gc.root_bind_v1(ptr)")
 	assertGeneratedIRContains(t, ir, "declare void @osty.gc.root_release_v1(ptr)")
 	assertGeneratedIRContains(t, ir, "@.str0 = private unnamed_addr constant [15 x i8] c\"llvm.gc.object\\00\"")
 	assertGeneratedIRContains(t, ir, "%t0 = call ptr @osty.gc.alloc_v1(i64 1, i64 32, ptr @.str0)")
-	assertGeneratedIRContains(t, ir, "call void @osty.gc.post_write_v1(ptr %t0, ptr %t1, i64 0)")
+	assertGeneratedIRContains(t, ir, "call void @osty.gc.pre_write_v1(ptr %t0, ptr %t1, i64 0)")
+	assertGeneratedIRContains(t, ir, "%t2 = call ptr @osty.gc.load_v1(ptr %t1)")
+	assertGeneratedIRContains(t, ir, "call void @osty.gc.post_write_v1(ptr %t0, ptr %t2, i64 0)")
 	assertGeneratedIRContains(t, ir, "call void @osty.gc.root_release_v1(ptr %t0)")
 }
 

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -373,7 +373,7 @@ func llvmCallVoid(emitter *LlvmEmitter, name string, args []*LlvmValue) {
 
 // Osty: examples/selfhost-core/llvmgen.osty:275:5
 func llvmGcRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)", "declare void @osty.gc.post_write_v1(ptr, ptr, i64)", "declare void @osty.gc.root_bind_v1(ptr)", "declare void @osty.gc.root_release_v1(ptr)"}
+	return []string{"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)", "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)", "declare void @osty.gc.post_write_v1(ptr, ptr, i64)", "declare ptr @osty.gc.load_v1(ptr)", "declare void @osty.gc.root_bind_v1(ptr)", "declare void @osty.gc.root_release_v1(ptr)"}
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:284:5
@@ -388,14 +388,25 @@ func llvmGcPostWrite(emitter *LlvmEmitter, owner *LlvmValue, value *LlvmValue, s
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:319:5
+func llvmGcPreWrite(emitter *LlvmEmitter, owner *LlvmValue, value *LlvmValue, slotKind int) {
+	// Osty: examples/selfhost-core/llvmgen.osty:325:5
+	llvmCallVoid(emitter, "osty.gc.pre_write_v1", []*LlvmValue{owner, value, llvmIntLiteral(slotKind)})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:336:5
+func llvmGcLoad(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty.gc.load_v1", []*LlvmValue{value})
+}
+
+// Osty: examples/selfhost-core/llvmgen.osty:340:5
 func llvmGcRootBind(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:320:5
+	// Osty: examples/selfhost-core/llvmgen.osty:341:5
 	llvmCallVoid(emitter, "osty.gc.root_bind_v1", []*LlvmValue{value})
 }
 
-// Osty: examples/selfhost-core/llvmgen.osty:323:5
+// Osty: examples/selfhost-core/llvmgen.osty:344:5
 func llvmGcRootRelease(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: examples/selfhost-core/llvmgen.osty:324:5
+	// Osty: examples/selfhost-core/llvmgen.osty:345:5
 	llvmCallVoid(emitter, "osty.gc.root_release_v1", []*LlvmValue{value})
 }
 
@@ -1556,10 +1567,15 @@ func llvmSmokeGcRuntimeAbiIR(sourcePath string) string {
 	child := llvmGcAlloc(main, 2, 16, "llvm.gc.child")
 	_ = child
 	// Osty: examples/selfhost-core/llvmgen.osty:1169:5
-	llvmGcPostWrite(main, object, child, 0)
+	llvmGcPreWrite(main, object, child, 0)
 	// Osty: examples/selfhost-core/llvmgen.osty:1170:5
-	llvmGcRootRelease(main, object)
+	loaded := llvmGcLoad(main, child)
+	_ = loaded
 	// Osty: examples/selfhost-core/llvmgen.osty:1171:5
+	llvmGcPostWrite(main, object, loaded, 0)
+	// Osty: examples/selfhost-core/llvmgen.osty:1172:5
+	llvmGcRootRelease(main, object)
+	// Osty: examples/selfhost-core/llvmgen.osty:1173:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGcRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -272,7 +272,9 @@ pub fn llvmCallVoid(emitter: LlvmEmitter, name: String, args: List<LlvmValue>) {
 pub fn llvmGcRuntimeDeclarations() -> List<String> {
     [
         "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)",
+        "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)",
         "declare void @osty.gc.post_write_v1(ptr, ptr, i64)",
+        "declare ptr @osty.gc.load_v1(ptr)",
         "declare void @osty.gc.root_bind_v1(ptr)",
         "declare void @osty.gc.root_release_v1(ptr)",
     ]
@@ -313,6 +315,27 @@ pub fn llvmGcPostWrite(
     )
 }
 
+pub fn llvmGcPreWrite(
+    emitter: LlvmEmitter,
+    owner: LlvmValue,
+    value: LlvmValue,
+    slotKind: Int,
+) {
+    llvmCallVoid(
+        emitter,
+        "osty.gc.pre_write_v1",
+        [
+            owner,
+            value,
+            llvmIntLiteral(slotKind),
+        ],
+    )
+}
+
+pub fn llvmGcLoad(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty.gc.load_v1", [value])
+}
+
 pub fn llvmGcRootBind(emitter: LlvmEmitter, value: LlvmValue) {
     llvmCallVoid(emitter, "osty.gc.root_bind_v1", [value])
 }
@@ -351,9 +374,7 @@ pub fn llvmExtractValue(
     fieldIndex: Int,
 ) -> LlvmValue {
     let tmp = llvmNextTemp(emitter)
-    emitter.body.push(
-        "  {tmp} = extractvalue {aggregate.typ} {aggregate.name}, {fieldIndex}",
-    )
+    emitter.body.push("  {tmp} = extractvalue {aggregate.typ} {aggregate.name}, {fieldIndex}")
     LlvmValue { typ: fieldType, name: tmp, pointer: false }
 }
 
@@ -735,7 +756,14 @@ pub fn llvmMissingBinaryArtifactMessage() -> String {
 
 pub fn llvmClangFailureMessage(action: String, command: String, output: String) -> String {
     llvmStrings.join(
-        ["llvm backend: clang ", action, " failed\ncommand: ", command, "\n", output],
+        [
+            "llvm backend: clang ",
+            action,
+            " failed\ncommand: ",
+            command,
+            "\n",
+            output,
+        ],
         "",
     )
 }
@@ -1165,10 +1193,16 @@ pub fn llvmNominalDeclHeaderDiagnostic(
         return llvmUnsupportedDiagnostic("name", "{kind} name \"{name}\"")
     }
     if genericCount != 0 {
-        return llvmUnsupportedDiagnostic("type-system", "generic {kind} \"{name}\" is not supported")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "generic {kind} \"{name}\" is not supported",
+        )
     }
     if methodCount != 0 {
-        return llvmUnsupportedDiagnostic("function-signature", "{kind} \"{name}\" methods are not supported")
+        return llvmUnsupportedDiagnostic(
+            "function-signature",
+            "{kind} \"{name}\" methods are not supported",
+        )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -1190,13 +1224,19 @@ pub fn llvmFunctionHeaderDiagnostic(
         return llvmUnsupportedDiagnostic("function-signature", "methods are not supported")
     }
     if genericCount != 0 {
-        return llvmUnsupportedDiagnostic("function-signature", "generic functions are not supported")
+        return llvmUnsupportedDiagnostic(
+            "function-signature",
+            "generic functions are not supported",
+        )
     }
     if !(hasBody) {
         return llvmUnsupportedDiagnostic("source-layout", "function \"{name}\" has no body")
     }
     if isMain && !(llvmAllowsMainSignature(paramCount, hasReturnType)) {
-        return llvmUnsupportedDiagnostic("function-signature", "LLVM main must have no params and no return type")
+        return llvmUnsupportedDiagnostic(
+            "function-signature",
+            "LLVM main must have no params and no return type",
+        )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -1215,19 +1255,34 @@ pub fn llvmStructFieldDiagnostic(
     detail: String,
 ) -> LlvmUnsupportedDiagnostic {
     if !(identOk) {
-        return llvmUnsupportedDiagnostic("name", "struct \"{structName}\" field name \"{fieldName}\"")
+        return llvmUnsupportedDiagnostic(
+            "name",
+            "struct \"{structName}\" field name \"{fieldName}\"",
+        )
     }
     if hasDefault {
-        return llvmUnsupportedDiagnostic("type-system", "struct \"{structName}\" field \"{fieldName}\" has a default value")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "struct \"{structName}\" field \"{fieldName}\" has a default value",
+        )
     }
     if duplicate {
-        return llvmUnsupportedDiagnostic("source-layout", "struct \"{structName}\" duplicate field \"{fieldName}\"")
+        return llvmUnsupportedDiagnostic(
+            "source-layout",
+            "struct \"{structName}\" duplicate field \"{fieldName}\"",
+        )
     }
     if detail != "" {
-        return llvmUnsupportedDiagnostic("type-system", "struct \"{structName}\" field \"{fieldName}\": {detail}")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "struct \"{structName}\" field \"{fieldName}\": {detail}",
+        )
     }
     if recursive {
-        return llvmUnsupportedDiagnostic("type-system", "struct \"{structName}\" recursive field \"{fieldName}\"")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "struct \"{structName}\" recursive field \"{fieldName}\"",
+        )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -1240,7 +1295,10 @@ pub fn llvmEnumVariantHeaderDiagnostic(
     duplicate: Bool,
 ) -> LlvmUnsupportedDiagnostic {
     if !(identOk) {
-        return llvmUnsupportedDiagnostic("name", "enum \"{enumName}\" variant name \"{variantName}\"")
+        return llvmUnsupportedDiagnostic(
+            "name",
+            "enum \"{enumName}\" variant name \"{variantName}\"",
+        )
     }
     if payloadCount > 1 {
         return llvmUnsupportedDiagnostic(
@@ -1249,7 +1307,10 @@ pub fn llvmEnumVariantHeaderDiagnostic(
         )
     }
     if duplicate {
-        return llvmUnsupportedDiagnostic("source-layout", "enum \"{enumName}\" duplicate variant \"{variantName}\"")
+        return llvmUnsupportedDiagnostic(
+            "source-layout",
+            "enum \"{enumName}\" duplicate variant \"{variantName}\"",
+        )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -1262,10 +1323,16 @@ pub fn llvmEnumPayloadDiagnostic(
     actualType: String,
 ) -> LlvmUnsupportedDiagnostic {
     if detail != "" {
-        return llvmUnsupportedDiagnostic("type-system", "enum \"{enumName}\" variant \"{variantName}\" payload: {detail}")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "enum \"{enumName}\" variant \"{variantName}\" payload: {detail}",
+        )
     }
     if expectedType != "" && actualType != "" && expectedType != actualType {
-        return llvmUnsupportedDiagnostic("type-system", "enum \"{enumName}\" mixes payload types {expectedType} and {actualType}")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "enum \"{enumName}\" mixes payload types {expectedType} and {actualType}",
+        )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -1321,16 +1388,25 @@ pub fn llvmFunctionParamDiagnostic(
     detail: String,
 ) -> LlvmUnsupportedDiagnostic {
     if missingOrPattern {
-        return llvmUnsupportedDiagnostic("function-signature", "function \"{fnName}\" has non-identifier parameter")
+        return llvmUnsupportedDiagnostic(
+            "function-signature",
+            "function \"{fnName}\" has non-identifier parameter",
+        )
     }
     if hasDefault {
-        return llvmUnsupportedDiagnostic("function-signature", "function \"{fnName}\" has default parameter values")
+        return llvmUnsupportedDiagnostic(
+            "function-signature",
+            "function \"{fnName}\" has default parameter values",
+        )
     }
     if !(identOk) {
         return llvmUnsupportedDiagnostic("name", "parameter name \"{paramName}\"")
     }
     if detail != "" {
-        return llvmUnsupportedDiagnostic("type-system", "function \"{fnName}\" parameter \"{paramName}\": {detail}")
+        return llvmUnsupportedDiagnostic(
+            "type-system",
+            "function \"{fnName}\" parameter \"{paramName}\": {detail}",
+        )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -1629,7 +1705,9 @@ pub fn llvmSmokeGcRuntimeAbiIR(sourcePath: String) -> String {
     let object = llvmGcAlloc(main, 1, 32, "llvm.gc.object")
     llvmGcRootBind(main, object)
     let child = llvmGcAlloc(main, 2, 16, "llvm.gc.child")
-    llvmGcPostWrite(main, object, child, 0)
+    llvmGcPreWrite(main, object, child, 0)
+    let loaded = llvmGcLoad(main, child)
+    llvmGcPostWrite(main, object, loaded, 0)
     llvmGcRootRelease(main, object)
     llvmReturnI32Zero(main)
 
@@ -1865,7 +1943,9 @@ pub fn llvmSmokeStructFieldIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Point", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Point", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -1893,7 +1973,9 @@ pub fn llvmSmokeStructReturnIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Pair", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Pair", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("%Pair", "makePair", [], makePair.body),
@@ -1922,7 +2004,9 @@ pub fn llvmSmokeStructParamIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Score", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Score", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("i64", "total", [llvmParam("score", "%Score")], total.body),
@@ -1941,7 +2025,9 @@ pub fn llvmSmokeStructMutableIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Box", ["i64"])],
+        [
+            llvmStructTypeDef("Box", ["i64"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2156,7 +2242,9 @@ pub fn llvmSmokeEnumPayloadIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Maybe", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Maybe", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2187,7 +2275,9 @@ pub fn llvmSmokeEnumPayloadReturnIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Maybe", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Maybe", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("%Maybe", "pick", [], pick.body),
@@ -2219,7 +2309,9 @@ pub fn llvmSmokeEnumPayloadParamIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Maybe", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Maybe", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("i64", "score", [llvmParam("value", "%Maybe")], score.body),
@@ -2246,7 +2338,9 @@ pub fn llvmSmokeEnumPayloadMutableIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Maybe", ["i64", "i64"])],
+        [
+            llvmStructTypeDef("Maybe", ["i64", "i64"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2262,7 +2356,9 @@ pub fn llvmSmokeFloatPrintIR(sourcePath: String) -> String {
     llvmRenderModule(
         sourcePath,
         "",
-        [llvmRenderFunction("i32", "main", [], main.body)],
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
     )
 }
 
@@ -2278,7 +2374,9 @@ pub fn llvmSmokeFloatArithmeticIR(sourcePath: String) -> String {
     llvmRenderModule(
         sourcePath,
         "",
-        [llvmRenderFunction("i32", "main", [], main.body)],
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
     )
 }
 
@@ -2349,7 +2447,12 @@ pub fn llvmSmokeFloatCompareIR(sourcePath: String) -> String {
     let cond = llvmLogicalI1(
         main,
         "and",
-        llvmLogicalI1(main, "and", llvmLogicalI1(main, "and", eq, ne), llvmLogicalI1(main, "and", lt, gt)),
+        llvmLogicalI1(
+            main,
+            "and",
+            llvmLogicalI1(main, "and", eq, ne),
+            llvmLogicalI1(main, "and", lt, gt),
+        ),
         llvmLogicalI1(main, "and", le, ge),
     )
     let labels = llvmIfStart(main, cond)
@@ -2362,7 +2465,9 @@ pub fn llvmSmokeFloatCompareIR(sourcePath: String) -> String {
     llvmRenderModule(
         sourcePath,
         "",
-        [llvmRenderFunction("i32", "main", [], main.body)],
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
     )
 }
 
@@ -2376,7 +2481,9 @@ pub fn llvmSmokeFloatStructIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("MaybeF", ["i64", "double"])],
+        [
+            llvmStructTypeDef("MaybeF", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2402,7 +2509,9 @@ pub fn llvmSmokeFloatEnumPayloadIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("MaybeF", ["i64", "double"])],
+        [
+            llvmStructTypeDef("MaybeF", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2433,7 +2542,9 @@ pub fn llvmSmokeFloatPayloadReturnIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("FloatMaybe", ["i64", "double"])],
+        [
+            llvmStructTypeDef("FloatMaybe", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("%FloatMaybe", "pick", [], pick.body),
@@ -2465,7 +2576,9 @@ pub fn llvmSmokeFloatPayloadParamIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("FloatMaybe", ["i64", "double"])],
+        [
+            llvmStructTypeDef("FloatMaybe", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("double", "score", [llvmParam("value", "%FloatMaybe")], score.body),
@@ -2476,8 +2589,16 @@ pub fn llvmSmokeFloatPayloadParamIR(sourcePath: String) -> String {
 
 pub fn llvmSmokeFloatPayloadMutableIR(sourcePath: String) -> String {
     let main = llvmEmitter()
-    llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%FloatMaybe", 1, llvmFloatLiteral("0.0")))
-    let _ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0")))
+    llvmMutableLet(
+        main,
+        "value",
+        llvmEnumPayloadVariant(main, "%FloatMaybe", 1, llvmFloatLiteral("0.0")),
+    )
+    let _ = llvmAssign(
+        main,
+        "value",
+        llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0")),
+    )
     let valueRef = llvmIdent(main, "value")
     let tag = llvmExtractValue(main, valueRef, "i64", 0)
     let cond = llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
@@ -2492,7 +2613,9 @@ pub fn llvmSmokeFloatPayloadMutableIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("FloatMaybe", ["i64", "double"])],
+        [
+            llvmStructTypeDef("FloatMaybe", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2518,7 +2641,9 @@ pub fn llvmSmokeFloatPayloadReversedMatchIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("FloatMaybe", ["i64", "double"])],
+        [
+            llvmStructTypeDef("FloatMaybe", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2544,7 +2669,9 @@ pub fn llvmSmokeFloatPayloadWildcardIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("FloatMaybe", ["i64", "double"])],
+        [
+            llvmStructTypeDef("FloatMaybe", ["i64", "double"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2554,7 +2681,10 @@ pub fn llvmSmokeFloatPayloadWildcardIR(sourcePath: String) -> String {
 
 pub fn llvmSmokeStringPayloadReturnIR(sourcePath: String) -> String {
     let pick = llvmEmitter()
-    llvmReturn(pick, llvmEnumPayloadVariant(pick, "%Label", 0, llvmStringLiteral(pick, "payload string")))
+    llvmReturn(
+        pick,
+        llvmEnumPayloadVariant(pick, "%Label", 0, llvmStringLiteral(pick, "payload string")),
+    )
 
     let score = llvmEmitter()
     let valueRef = llvmCall(score, "%Label", "pick", [])
@@ -2575,7 +2705,9 @@ pub fn llvmSmokeStringPayloadReturnIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Label", ["i64", "ptr"])],
+        [
+            llvmStructTypeDef("Label", ["i64", "ptr"]),
+        ],
         [],
         [
             llvmRenderFunction("%Label", "pick", [], pick.body),
@@ -2607,7 +2739,9 @@ pub fn llvmSmokeStringPayloadParamIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Label", ["i64", "ptr"])],
+        [
+            llvmStructTypeDef("Label", ["i64", "ptr"]),
+        ],
         [],
         [
             llvmRenderFunction("ptr", "score", [llvmParam("value", "%Label")], score.body),
@@ -2618,8 +2752,16 @@ pub fn llvmSmokeStringPayloadParamIR(sourcePath: String) -> String {
 
 pub fn llvmSmokeStringPayloadMutableIR(sourcePath: String) -> String {
     let main = llvmEmitter()
-    llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%Label", 1, llvmStringLiteral(main, "no payload")))
-    let _ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string")))
+    llvmMutableLet(
+        main,
+        "value",
+        llvmEnumPayloadVariant(main, "%Label", 1, llvmStringLiteral(main, "no payload")),
+    )
+    let _ = llvmAssign(
+        main,
+        "value",
+        llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string")),
+    )
     let valueRef = llvmIdent(main, "value")
     let tag = llvmExtractValue(main, valueRef, "i64", 0)
     let cond = llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 0))
@@ -2634,7 +2776,9 @@ pub fn llvmSmokeStringPayloadMutableIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Label", ["i64", "ptr"])],
+        [
+            llvmStructTypeDef("Label", ["i64", "ptr"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2660,7 +2804,9 @@ pub fn llvmSmokeStringPayloadReversedMatchIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Label", ["i64", "ptr"])],
+        [
+            llvmStructTypeDef("Label", ["i64", "ptr"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2686,7 +2832,9 @@ pub fn llvmSmokeStringPayloadWildcardIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Label", ["i64", "ptr"])],
+        [
+            llvmStructTypeDef("Label", ["i64", "ptr"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2843,7 +2991,9 @@ pub fn llvmSmokeStructStringFieldIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Message", ["ptr"])],
+        [
+            llvmStructTypeDef("Message", ["ptr"]),
+        ],
         main.stringGlobals,
         [
             llvmRenderFunction("i32", "main", [], main.body),
@@ -2866,7 +3016,9 @@ pub fn llvmSmokeStructBoolFieldIR(sourcePath: String) -> String {
     llvmRenderModuleWithGlobalsAndTypes(
         sourcePath,
         "",
-        [llvmStructTypeDef("Gate", ["i1"])],
+        [
+            llvmStructTypeDef("Gate", ["i1"]),
+        ],
         [],
         [
             llvmRenderFunction("i32", "main", [], main.body),

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -20,7 +20,9 @@ fn testLlvmGcRuntimeDeclarationsAreOstyOwned() {
     let declarations = llvmTestStrings.join(llvmGcRuntimeDeclarations(), "\n")
 
     assertLlvmContains(declarations, "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)")
+    assertLlvmContains(declarations, "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)")
     assertLlvmContains(declarations, "declare void @osty.gc.post_write_v1(ptr, ptr, i64)")
+    assertLlvmContains(declarations, "declare ptr @osty.gc.load_v1(ptr)")
     assertLlvmContains(declarations, "declare void @osty.gc.root_bind_v1(ptr)")
     assertLlvmContains(declarations, "declare void @osty.gc.root_release_v1(ptr)")
 }
@@ -30,7 +32,9 @@ fn testLlvmSmokeGcRuntimeAbiIsOstyOwned() {
 
     assertLlvmContains(ir, "source_filename = \"/tmp/gc_runtime_abi.osty\"")
     assertLlvmContains(ir, "declare ptr @osty.gc.alloc_v1(i64, i64, ptr)")
+    assertLlvmContains(ir, "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)")
     assertLlvmContains(ir, "declare void @osty.gc.post_write_v1(ptr, ptr, i64)")
+    assertLlvmContains(ir, "declare ptr @osty.gc.load_v1(ptr)")
     assertLlvmContains(ir, "declare void @osty.gc.root_bind_v1(ptr)")
     assertLlvmContains(ir, "declare void @osty.gc.root_release_v1(ptr)")
     assertLlvmContains(
@@ -44,7 +48,9 @@ fn testLlvmSmokeGcRuntimeAbiIsOstyOwned() {
     assertLlvmContains(ir, "%t0 = call ptr @osty.gc.alloc_v1(i64 1, i64 32, ptr @.str0)")
     assertLlvmContains(ir, "call void @osty.gc.root_bind_v1(ptr %t0)")
     assertLlvmContains(ir, "%t1 = call ptr @osty.gc.alloc_v1(i64 2, i64 16, ptr @.str1)")
-    assertLlvmContains(ir, "call void @osty.gc.post_write_v1(ptr %t0, ptr %t1, i64 0)")
+    assertLlvmContains(ir, "call void @osty.gc.pre_write_v1(ptr %t0, ptr %t1, i64 0)")
+    assertLlvmContains(ir, "%t2 = call ptr @osty.gc.load_v1(ptr %t1)")
+    assertLlvmContains(ir, "call void @osty.gc.post_write_v1(ptr %t0, ptr %t2, i64 0)")
     assertLlvmContains(ir, "call void @osty.gc.root_release_v1(ptr %t0)")
     assertLlvmContains(ir, "ret i32 0")
 }


### PR DESCRIPTION
## Summary
- generalize LLVM payload enum matches across multiple arms
- extend the local GC runtime ABI with pre-write/load bridge symbols
- update Osty-owned and Go regression coverage for the new runtime and lowering behavior

## Testing
- go test ./internal/llvmgen ./internal/backend ./cmd/osty
- git diff --check