### PR TITLE
Restore selfhost regen path and toolchain file context

### DIFF
--- a/cmd/osty/backend_helpers.go
+++ b/cmd/osty/backend_helpers.go
@@ -41,8 +41,15 @@ func parseCLIEmitMode(raw string) (backend.EmitMode, error) {
 func validateCLIEmit(tool string, name backend.Name, mode backend.EmitMode) error {
 	switch tool {
 	case "gen", "pipeline":
-		if mode != backend.EmitLLVMIR {
-			return fmt.Errorf("%s with backend %q cannot emit %q (want %q)", tool, name, mode, backend.EmitLLVMIR)
+		switch name {
+		case backend.NameGo:
+			if mode != backend.EmitGoSource {
+				return fmt.Errorf("%s with backend %q cannot emit %q (want %q)", tool, name, mode, backend.EmitGoSource)
+			}
+		case backend.NameLLVM:
+			if mode != backend.EmitLLVMIR {
+				return fmt.Errorf("%s with backend %q cannot emit %q (want %q)", tool, name, mode, backend.EmitLLVMIR)
+			}
 		}
 	case "run", "test":
 		if mode != backend.EmitBinary {

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -325,6 +325,53 @@ func main() {
 		}
 	}
 
+	if cmd == "check" || cmd == "typecheck" || cmd == "resolve" {
+		selected, handled, err := loadSelectedPackageEntry(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "osty: %v\n", err)
+			os.Exit(1)
+		}
+		if handled {
+			if flags.trace {
+				pipeline.RunLoadedPackage(selected.pkg, os.Stderr, pipeline.Config{})
+			}
+			switch cmd {
+			case "check":
+				diags := append(append([]*diag.Diagnostic{}, selected.res.Diags...), selected.chk.Diags...)
+				printPackageDiags(selected.pkg, diags, flags)
+				if hasError(diags) {
+					os.Exit(1)
+				}
+				return
+			case "typecheck":
+				diags := append(append([]*diag.Diagnostic{}, selected.res.Diags...), selected.chk.Diags...)
+				printPackageDiags(selected.pkg, diags, flags)
+				printTypes(selected.chk)
+				if hasError(diags) {
+					os.Exit(1)
+				}
+				return
+			case "resolve":
+				printPackageDiags(selected.pkg, selected.res.Diags, flags)
+				if len(selected.file.Refs) > 0 {
+					fmt.Printf("# %s\n", selected.file.Path)
+					printResolutionRefs(selected.file.Refs)
+				}
+				if flags.showScopes {
+					if pkgScope := selected.file.FileScope.Parent(); pkgScope != nil {
+						printScopeTree(pkgScope)
+					} else {
+						printScopeTree(selected.file.FileScope)
+					}
+				}
+				if hasError(selected.res.Diags) {
+					os.Exit(1)
+				}
+				return
+			}
+		}
+	}
+
 	src, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -133,14 +133,23 @@ func runPipeline(args []string) {
 			os.Exit(1)
 		}
 	} else {
-		src, err := os.ReadFile(target)
+		selected, handled, err := loadSelectedPackageEntry(target)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
 			os.Exit(1)
 		}
-		sourceForDiagnostics = src
-		cfg.GenSourcePath = target
-		r = pipeline.RunWithConfig(src, stream, cfg)
+		if handled {
+			r = pipeline.RunLoadedPackage(selected.pkg, stream, cfg)
+		} else {
+			src, err := os.ReadFile(target)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "osty pipeline: %v\n", err)
+				os.Exit(1)
+			}
+			sourceForDiagnostics = src
+			cfg.GenSourcePath = target
+			r = pipeline.RunWithConfig(src, stream, cfg)
+		}
 	}
 
 	// Baseline mode supersedes the regular table: we render the diff

--- a/cmd/osty/toolchain_context.go
+++ b/cmd/osty/toolchain_context.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+type selectedPackageEntry struct {
+	sourcePath string
+	pkg        *resolve.Package
+	res        *resolve.PackageResult
+	chk        *check.Result
+	file       *resolve.PackageFile
+}
+
+func loadSelectedPackageEntry(path string) (*selectedPackageEntry, bool, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, false, err
+	}
+	files := toolchainPackageInputFiles(absPath)
+	if len(files) == 0 {
+		return nil, false, nil
+	}
+	entry, err := loadSelectedPackageFiles(absPath, files)
+	if err != nil {
+		return nil, true, err
+	}
+	return entry, true, nil
+}
+
+func loadSelectedPackageFiles(sourcePath string, files []string) (*selectedPackageEntry, error) {
+	pkg, err := resolve.LoadPackageFiles(files, stdlib.LoadCached())
+	if err != nil {
+		return nil, err
+	}
+	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+	chk := check.Package(pkg, res, checkOpts())
+	var entryFile *resolve.PackageFile
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.Path == sourcePath {
+			entryFile = pf
+			break
+		}
+	}
+	if entryFile == nil {
+		return nil, fmt.Errorf("%s is not part of the selected package slice", sourcePath)
+	}
+	return &selectedPackageEntry{
+		sourcePath: sourcePath,
+		pkg:        pkg,
+		res:        res,
+		chk:        chk,
+		file:       entryFile,
+	}, nil
+}
+
+func toolchainPackageInputFiles(sourcePath string) []string {
+	dir := filepath.Dir(sourcePath)
+	if filepath.Base(dir) != "toolchain" {
+		return nil
+	}
+	base := filepath.Base(sourcePath)
+	if strings.HasSuffix(base, "_test.osty") || base == "ast_lower.osty" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".osty") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.osty") || name == "ast_lower.osty" {
+			continue
+		}
+		files = append(files, filepath.Join(dir, name))
+	}
+	sort.Strings(files)
+	return files
+}
+
+func (e *selectedPackageEntry) fileResult() *resolve.Result {
+	if e == nil || e.file == nil {
+		return nil
+	}
+	return &resolve.Result{
+		Refs:      e.file.Refs,
+		TypeRefs:  e.file.TypeRefs,
+		FileScope: e.file.FileScope,
+	}
+}

--- a/internal/backend/artifacts.go
+++ b/internal/backend/artifacts.go
@@ -5,6 +5,9 @@ import "path/filepath"
 // SourcePath returns a clean source path for diagnostics. Kept as a helper so
 // callers do not need to know the artifact struct's field names.
 func (a Artifacts) SourcePath() string {
+	if a.GoSource != "" {
+		return filepath.Clean(a.GoSource)
+	}
 	if a.LLVMIR != "" {
 		return filepath.Clean(a.LLVMIR)
 	}

--- a/internal/backend/backend_selfhostgen.go
+++ b/internal/backend/backend_selfhostgen.go
@@ -1,4 +1,4 @@
-//go:build !selfhostgen
+//go:build selfhostgen
 
 package backend
 
@@ -22,10 +22,12 @@ const (
 // ParseName converts a CLI/config backend name into a Name.
 func ParseName(s string) (Name, error) {
 	switch Name(s) {
+	case NameGo:
+		return NameGo, nil
 	case NameLLVM:
 		return NameLLVM, nil
 	default:
-		return "", fmt.Errorf("unknown backend %q (want llvm)", s)
+		return "", fmt.Errorf("unknown backend %q (want go or llvm)", s)
 	}
 }
 
@@ -34,7 +36,7 @@ func (n Name) String() string { return string(n) }
 // Valid reports whether n is a known backend name.
 func (n Name) Valid() bool {
 	switch n {
-	case NameLLVM:
+	case NameGo, NameLLVM:
 		return true
 	default:
 		return false
@@ -53,6 +55,8 @@ const (
 // ParseEmitMode converts a CLI/config emit mode into an EmitMode.
 func ParseEmitMode(s string) (EmitMode, error) {
 	switch EmitMode(s) {
+	case EmitGoSource:
+		return EmitGoSource, nil
 	case EmitLLVMIR:
 		return EmitLLVMIR, nil
 	case EmitObject:
@@ -60,7 +64,7 @@ func ParseEmitMode(s string) (EmitMode, error) {
 	case EmitBinary:
 		return EmitBinary, nil
 	default:
-		return "", fmt.Errorf("unknown emit mode %q (want llvm-ir, object, or binary)", s)
+		return "", fmt.Errorf("unknown emit mode %q (want go, llvm-ir, object, or binary)", s)
 	}
 }
 
@@ -69,7 +73,7 @@ func (m EmitMode) String() string { return string(m) }
 // Valid reports whether m is a known emit mode.
 func (m EmitMode) Valid() bool {
 	switch m {
-	case EmitLLVMIR, EmitObject, EmitBinary:
+	case EmitGoSource, EmitLLVMIR, EmitObject, EmitBinary:
 		return true
 	default:
 		return false
@@ -79,6 +83,8 @@ func (m EmitMode) Valid() bool {
 // ValidFor reports whether backend n can produce emit mode m.
 func (m EmitMode) ValidFor(n Name) bool {
 	switch n {
+	case NameGo:
+		return m == EmitGoSource || m == EmitBinary
 	case NameLLVM:
 		return m == EmitLLVMIR || m == EmitObject || m == EmitBinary
 	default:
@@ -102,8 +108,6 @@ func ValidateEmit(n Name, m EmitMode) error {
 }
 
 // Backend is implemented by concrete code-generation backends.
-//
-// The public compiler path is the self-hosted native backend.
 type Backend interface {
 	Name() Name
 	Emit(context.Context, Request) (*Result, error)

--- a/internal/backend/factory_selfhostgen.go
+++ b/internal/backend/factory_selfhostgen.go
@@ -1,4 +1,4 @@
-//go:build !selfhostgen
+//go:build selfhostgen
 
 package backend
 
@@ -7,6 +7,8 @@ import "fmt"
 // New returns the concrete backend implementation for name.
 func New(name Name) (Backend, error) {
 	switch name {
+	case NameGo:
+		return GoBackend{}, nil
 	case NameLLVM:
 		return LLVMBackend{}, nil
 	default:

--- a/internal/backend/go.go
+++ b/internal/backend/go.go
@@ -1,0 +1,97 @@
+//go:build selfhostgen
+
+package backend
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/gen"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// GoBackend wraps the legacy Go transpiler behind the backend contract.
+// It is compiled only for selfhostgen bootstrap runs.
+type GoBackend struct{}
+
+func (GoBackend) Name() Name { return NameGo }
+
+// Emit writes generated Go source to the backend-aware artifact path. For
+// EmitBinary, callers still invoke `go build` themselves; this method prepares
+// the source artifact and reports the conventional binary path.
+func (GoBackend) Emit(ctx context.Context, req Request) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := ValidateEmit(NameGo, req.Emit); err != nil {
+		return nil, err
+	}
+	if req.Entry.File == nil {
+		return nil, fmt.Errorf("go backend: nil entry file")
+	}
+	pkgName := req.Entry.PackageName
+	if pkgName == "" {
+		pkgName = "main"
+	}
+	res := req.Entry.Resolve
+	if res == nil {
+		res = &resolve.Result{}
+	}
+	chk := req.Entry.Check
+	if chk == nil {
+		chk = &check.Result{}
+	}
+
+	artifacts := req.Artifacts(NameGo)
+	if err := os.MkdirAll(artifacts.OutputDir, 0o755); err != nil {
+		return nil, err
+	}
+	src, genErr := gen.GenerateMapped(pkgName, req.Entry.File, res, chk, req.Entry.SourcePath)
+	src = prependGoBuildConstraints(src, req.Features)
+	if err := os.WriteFile(artifacts.GoSource, src, 0o644); err != nil {
+		return nil, err
+	}
+
+	out := &Result{
+		Backend:   NameGo,
+		Emit:      req.Emit,
+		Artifacts: artifacts,
+	}
+	if genErr != nil {
+		out.Warnings = append(out.Warnings, genErr)
+	}
+	return out, nil
+}
+
+func prependGoBuildConstraints(src []byte, features []string) []byte {
+	if len(features) == 0 {
+		return src
+	}
+	constraints := make([]string, 0, len(features))
+	for _, f := range features {
+		if f == "" {
+			continue
+		}
+		constraints = append(constraints, "feat_"+f)
+	}
+	if len(constraints) == 0 {
+		return src
+	}
+	sort.Strings(constraints)
+	header := "//go:build " + join(constraints, " && ") + "\n\n"
+	return append([]byte(header), src...)
+}
+
+func join(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += sep + parts[i]
+	}
+	return out
+}

--- a/internal/backend/go_defs.go
+++ b/internal/backend/go_defs.go
@@ -1,0 +1,9 @@
+package backend
+
+const (
+	NameGo Name = "go"
+)
+
+const (
+	EmitGoSource EmitMode = "go"
+)

--- a/internal/backend/layout.go
+++ b/internal/backend/layout.go
@@ -54,9 +54,10 @@ type Artifacts struct {
 	OutputDir string
 	CachePath string
 
-	LLVMIR string
-	Object string
-	Binary string
+	GoSource string
+	LLVMIR   string
+	Object   string
+	Binary   string
 
 	RuntimeDir string
 }
@@ -70,6 +71,8 @@ func (l Layout) Artifacts(n Name, binaryName string) Artifacts {
 		CachePath: l.CachePath(n),
 	}
 	switch n {
+	case NameGo:
+		out.GoSource = filepath.Join(out.OutputDir, "main.go")
 	case NameLLVM:
 		out.LLVMIR = filepath.Join(out.OutputDir, "main.ll")
 		out.Object = filepath.Join(out.OutputDir, "main.o")

--- a/internal/gen/decl.go
+++ b/internal/gen/decl.go
@@ -1,0 +1,1455 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/types"
+)
+
+// emitDecl dispatches to the per-decl emitter. Phase 1 handles fn and
+// let; struct/enum/interface/type-alias/use are stubbed with TODOs so
+// files that mix supported and unsupported constructs still emit.
+func (g *gen) emitDecl(d ast.Decl) {
+	switch d := d.(type) {
+	case *ast.FnDecl:
+		g.emitFnDecl(d)
+	case *ast.LetDecl:
+		g.emitLetDecl(d)
+	case *ast.StructDecl:
+		g.emitStructDecl(d)
+	case *ast.EnumDecl:
+		g.emitEnumDecl(d)
+	case *ast.InterfaceDecl:
+		g.emitInterfaceDecl(d)
+	case *ast.TypeAliasDecl:
+		g.emitTypeAliasDecl(d)
+	case *ast.UseDecl:
+		g.emitUseDecl(d)
+	default:
+		g.body.writef("// unsupported decl: %T\n", d)
+	}
+}
+
+// emitFnDecl writes a top-level function or method.
+//
+// Methods (with a receiver) are emitted in Phase 2 alongside their
+// struct/enum; a standalone FnDecl with a non-nil Recv here would be
+// a parser accident, so we skip it with a TODO.
+//
+// Generic functions with recorded instantiations are monomorphized
+// (§2.7.3): instead of emitting a single Go-generic definition, we
+// emit one specialized copy per distinct type-argument list collected
+// by the checker. A generic fn with no observed instantiations emits
+// nothing — its body becomes live only when a downstream package
+// references it with a concrete type tuple. Non-generic fns take the
+// standard single-emission path.
+func (g *gen) emitFnDecl(fn *ast.FnDecl) {
+	if fn.Recv != nil {
+		// Methods are emitted by their enclosing type in Phase 2.
+		// A parser FnDecl with Recv at top level is treated as data
+		// for the owner; skip here.
+		return
+	}
+
+	if len(fn.Generics) > 0 {
+		if g.emitGenericFnDecls {
+			g.emitFnDeclBody(fn, g.renamedFnName(fn.Name))
+			return
+		}
+		// Demand-driven: generic fns never emit inline. A call site
+		// (possibly inside another generic body being specialized)
+		// requests an instantiation via requestInstance, and the
+		// post-pass drainInstances materializes it.
+		return
+	}
+
+	g.emitFnDeclBody(fn, g.renamedFnName(fn.Name))
+}
+
+// emitFnDeclBody writes a single function definition under `name`. It
+// is the shared emission path used by both the non-generic fast path
+// and the per-instantiation loop over a monomorphized generic. Generic
+// type parameters are never emitted as Go `[T any]` brackets here —
+// when we reach this function for a generic source fn, the caller has
+// already pushed a substitution env so every type-param reference
+// resolves to a concrete Go type.
+func (g *gen) emitFnDeclBody(fn *ast.FnDecl, name string) {
+	g.body.nl()
+	g.sourceMarker(fn)
+	g.body.write("func ")
+	g.body.write(name)
+	if g.emitGenericFnDecls && len(fn.Generics) > 0 {
+		g.emitGenericParamList(fn.Generics)
+	}
+
+	g.emitParamList(fn.Params)
+
+	if fn.ReturnType != nil {
+		g.body.write(" ")
+		g.body.write(g.goTypeExpr(fn.ReturnType))
+	}
+
+	if fn.Body == nil {
+		g.body.writeln(" {}")
+		return
+	}
+	g.body.write(" ")
+
+	prevRet := g.currentRetType
+	prevRetGo := g.currentRetGo
+	g.currentRetType = fn.ReturnType
+	g.currentRetGo = ""
+	if fn.ReturnType != nil {
+		g.currentRetGo = g.goTypeExpr(fn.ReturnType)
+	}
+	defer func() {
+		g.currentRetType = prevRet
+		g.currentRetGo = prevRetGo
+	}()
+
+	g.emitBlockAsReturn(fn.Body, fn.ReturnType != nil)
+	g.body.nl()
+}
+
+// emitParamList emits `(a type1, b type2, ...)`. Closure params with
+// destructuring aren't reachable here — top-level params always have
+// Name set.
+func (g *gen) emitParamList(params []*ast.Param) {
+	g.body.write("(")
+	for i, p := range params {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		name := p.Name
+		if name == "" {
+			name = "_"
+		}
+		g.body.write(mangleIdent(name))
+		if p.Type != nil {
+			g.body.write(" ")
+			g.body.write(g.goTypeExpr(p.Type))
+		} else {
+			g.body.write(" any")
+		}
+	}
+	g.body.write(")")
+}
+
+// emitLetDecl handles top-level `let` / `pub let`. Osty `let` is
+// immutable-by-default; Go has no equivalent, so we emit `var` and
+// let the type checker police reassignment.
+func (g *gen) emitLetDecl(l *ast.LetDecl) {
+	g.body.nl()
+	g.sourceMarker(l)
+	g.body.write("var ")
+	name := g.renamedFnName(l.Name)
+	if name == l.Name {
+		name = mangleIdent(l.Name)
+	}
+	g.body.write(name)
+	if l.Type != nil {
+		g.body.write(" ")
+		g.body.write(g.goTypeExpr(l.Type))
+	} else if t := g.symTypeOf(g.res.FileScope.Lookup(l.Name)); t != nil {
+		g.body.write(" ")
+		g.body.write(g.goType(t))
+	}
+	if l.Value != nil {
+		g.body.write(" = ")
+		g.emitExpr(l.Value)
+	}
+	g.body.nl()
+}
+
+// emitStructDecl writes `type Name struct { ... }` plus every method
+// declared inside the struct body. Methods with a `self` receiver
+// become Go methods on the struct; associated functions (no receiver)
+// become package-level `TypeName_funcName`.
+func (g *gen) emitStructDecl(s *ast.StructDecl) {
+	g.body.nl()
+	g.sourceMarker(s)
+	if len(s.Generics) > 0 {
+		g.body.writef("type %s", s.Name)
+		g.emitGenericParamList(s.Generics)
+		g.body.write(" struct {")
+	} else {
+		g.body.writef("type %s struct {", s.Name)
+	}
+	if len(s.Fields) == 0 {
+		g.body.writeln("}")
+	} else {
+		g.body.nl()
+		g.body.indent()
+		for _, f := range s.Fields {
+			g.body.writef("%s %s\n", mangleIdent(f.Name), g.goTypeExpr(f.Type))
+		}
+		g.body.dedent()
+		g.body.writeln("}")
+	}
+	// Methods — emitted after the type so Go's "declaration before use"
+	// rule doesn't bite when one method calls another within the same
+	// type (it doesn't, but being explicit about order is cheap).
+	for _, m := range s.Methods {
+		g.emitMethod(s.Name, m, false)
+	}
+	g.emitStructJSONMarshal(s)
+	g.emitStructJSONUnmarshal(s)
+}
+
+// emitEnumDecl writes an enum as an interface plus one struct per
+// variant, wired together with a marker method. Methods on the enum
+// are lowered to free functions `EnumName_methodName(self EnumName, ...)`
+// which every call site rewrites; see emitCall.
+//
+//	enum Shape { Circle(Float), Empty; fn area(self) -> Float { ... } }
+//
+// becomes
+//
+//	type Shape interface { _isShape() }
+//	type Shape_Circle struct { F0 float64 }
+//	func (Shape_Circle) _isShape() {}
+//	type Shape_Empty struct{}
+//	func (Shape_Empty) _isShape() {}
+//	func Shape_area(self Shape) float64 { ... }
+func (g *gen) emitEnumDecl(e *ast.EnumDecl) {
+	g.body.nl()
+	g.sourceMarker(e)
+	g.body.writef("type %s interface{ _is%s() }\n", e.Name, e.Name)
+	for _, v := range e.Variants {
+		g.emitVariant(e, v)
+	}
+	for _, m := range e.Methods {
+		g.emitMethod(e.Name, m, true)
+	}
+	g.emitEnumJSONDecoder(e)
+	for _, m := range e.Methods {
+		g.emitEnumVariantMethodWrappers(e, m)
+	}
+}
+
+// emitVariant writes the struct + marker-method for one enum variant.
+func (g *gen) emitVariant(e *ast.EnumDecl, v *ast.Variant) {
+	name := e.Name + "_" + v.Name
+	if len(v.Fields) == 0 {
+		g.body.writef("type %s struct{ _ref byte }\n", name)
+	} else {
+		g.body.writef("type %s struct {\n", name)
+		g.body.indent()
+		for i, f := range v.Fields {
+			g.body.writef("F%d %s\n", i, g.goTypeExpr(f))
+		}
+		g.body.dedent()
+		g.body.writeln("}")
+	}
+	g.body.writef("func (%s) _is%s() {}\n", name, e.Name)
+	g.emitVariantJSONMarshal(e, v, name)
+}
+
+// emitMethod writes a single method.
+//
+// For structs (enumMethod=false) and a receiver-bearing fn we emit as
+// a Go method on the struct. For enums, Go's interface can't carry a
+// default implementation, so we lower to `TypeName_method(self, ...)`
+// and call sites are rewritten in emitCall.
+//
+// Associated functions (no receiver) always lower to package-level
+// `TypeName_fn(...)`.
+func (g *gen) emitMethod(typeName string, m *ast.FnDecl, enumMethod bool) {
+	g.body.nl()
+	g.sourceMarker(m)
+
+	prevSelf := g.selfType
+	g.selfType = typeName
+
+	free := m.Recv == nil || enumMethod
+
+	if free {
+		g.body.writef("func %s_%s", typeName, m.Name)
+	} else {
+		g.body.writef("func (self *%s) %s", typeName, m.Name)
+	}
+	g.body.write("(")
+	first := true
+	if free && m.Recv != nil {
+		g.body.writef("self %s", typeName)
+		first = false
+	}
+	for _, p := range m.Params {
+		if !first {
+			g.body.write(", ")
+		}
+		first = false
+		name := p.Name
+		if name == "" {
+			name = "_"
+		}
+		g.body.write(mangleIdent(name))
+		if p.Type != nil {
+			g.body.write(" ")
+			g.body.write(g.resolveSelfType(p.Type, typeName))
+		} else {
+			g.body.write(" any")
+		}
+	}
+	g.body.write(")")
+
+	if m.ReturnType != nil {
+		g.body.write(" ")
+		g.body.write(g.resolveSelfType(m.ReturnType, typeName))
+	}
+
+	prevRet := g.currentRetType
+	prevRetGo := g.currentRetGo
+	g.currentRetType = m.ReturnType
+	g.currentRetGo = ""
+	if m.ReturnType != nil {
+		g.currentRetGo = g.resolveSelfType(m.ReturnType, typeName)
+	}
+	defer func() {
+		g.selfType = prevSelf
+		g.currentRetType = prevRet
+		g.currentRetGo = prevRetGo
+	}()
+
+	if m.Body == nil {
+		g.body.writeln(" {}")
+		return
+	}
+	g.body.write(" ")
+	g.emitBlockAsReturn(m.Body, m.ReturnType != nil)
+	g.body.nl()
+}
+
+func (g *gen) emitEnumVariantMethodWrappers(e *ast.EnumDecl, m *ast.FnDecl) {
+	if m.Recv == nil || len(m.Generics) != 0 {
+		return
+	}
+	for _, v := range e.Variants {
+		recvType := e.Name + "_" + v.Name
+		g.body.nl()
+		g.sourceMarker(m)
+		g.body.writef("func (self *%s) %s(", recvType, m.Name)
+		paramNames := make([]string, len(m.Params))
+		for i, p := range m.Params {
+			if i > 0 {
+				g.body.write(", ")
+			}
+			name := p.Name
+			if name == "" {
+				name = "_p" + itoa(i)
+			}
+			paramNames[i] = mangleIdent(name)
+			g.body.write(paramNames[i])
+			if p.Type != nil {
+				g.body.write(" ")
+				g.body.write(g.resolveSelfType(p.Type, e.Name))
+			} else {
+				g.body.write(" any")
+			}
+		}
+		g.body.write(")")
+		hasReturn := m.ReturnType != nil && !isUnitAST(m.ReturnType)
+		if hasReturn {
+			g.body.write(" ")
+			g.body.write(g.resolveSelfType(m.ReturnType, e.Name))
+		}
+		g.body.write(" { ")
+		if hasReturn {
+			g.body.write("return ")
+		}
+		g.body.writef("%s_%s(%s(self)", e.Name, m.Name, e.Name)
+		for _, name := range paramNames {
+			g.body.write(", ")
+			g.body.write(name)
+		}
+		g.body.writeln(") }")
+	}
+}
+
+// resolveSelfType rewrites a bare `Self` type annotation to the
+// enclosing type's name; other type expressions pass through unchanged.
+func (g *gen) resolveSelfType(t ast.Type, typeName string) string {
+	if n, ok := t.(*ast.NamedType); ok && len(n.Path) == 1 && n.Path[0] == "Self" {
+		return g.goSelfTypeAST(n.Args)
+	}
+	return g.goTypeExpr(t)
+}
+
+// emitInterfaceDecl writes a Go interface. Osty allows composed
+// interfaces (`interface ReadWriter { Reader; Writer }`) which map to
+// Go's interface embedding.
+func (g *gen) emitInterfaceDecl(i *ast.InterfaceDecl) {
+	g.body.nl()
+	g.sourceMarker(i)
+	g.body.writef("type %s interface {\n", i.Name)
+	g.body.indent()
+	for _, ext := range i.Extends {
+		g.body.writeln(g.goTypeExpr(ext))
+	}
+	for _, m := range i.Methods {
+		g.body.write(m.Name)
+		g.body.write("(")
+		for j, p := range m.Params {
+			if j > 0 {
+				g.body.write(", ")
+			}
+			name := p.Name
+			if name == "" {
+				name = "_"
+			}
+			g.body.writef("%s %s", mangleIdent(name), g.goTypeExpr(p.Type))
+		}
+		g.body.write(")")
+		if m.ReturnType != nil {
+			g.body.write(" ")
+			g.body.write(g.goTypeExpr(m.ReturnType))
+		}
+		g.body.nl()
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+// emitTypeAliasDecl writes a Go type alias. Generic aliases are emitted
+// with Go type parameters; constraints currently lower to `any`, matching
+// the existing generic struct/function backend surface.
+func (g *gen) emitTypeAliasDecl(a *ast.TypeAliasDecl) {
+	g.body.nl()
+	g.sourceMarker(a)
+	g.body.writef("type %s", a.Name)
+	g.emitGenericParamList(a.Generics)
+	g.body.writef(" = %s\n", g.goTypeExpr(a.Target))
+}
+
+func (g *gen) emitGenericParamList(params []*ast.GenericParam) {
+	if len(params) == 0 {
+		return
+	}
+	g.body.write("[")
+	for i, p := range params {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.writef("%s any", p.Name)
+	}
+	g.body.write("]")
+}
+
+func (g *gen) emitUseDecl(u *ast.UseDecl) {
+	if u.IsFFI() {
+		importPath := u.GoPath
+		if u.IsRuntimeFFI {
+			importPath = runtimeFFIGoImport(u.RuntimePath)
+		}
+		// FFI declarations carry signatures in Osty source. The bootstrap Go
+		// emitter maps runtime FFI paths onto temporary host imports until the
+		// native runtime owns those calls.
+		//
+		// Emit a real Go import. When the Osty alias matches the Go
+		// package's default name (last path component), a bare import
+		// suffices. Otherwise aliased imports use Go's `import alias "path"`
+		// form via the aliased-import map.
+		//
+		// The FFI body is a schema for the checker — it declares the
+		// signatures we expect from the Go package. No code is emitted
+		// for it; call sites like `fmt.Println(x)` resolve to the real
+		// Go symbol via the package import.
+		alias := u.Alias
+		defaultAlias := lastPathComponent(importPath)
+		if alias == "" {
+			alias = defaultAlias
+		}
+		if !g.aliasUsedAsSelector(alias) {
+			g.emitUseStub(alias, "struct{}{}", importPath)
+			return
+		}
+		if alias == defaultAlias {
+			g.use(importPath)
+		} else {
+			g.useAs(importPath, alias)
+		}
+		return
+	}
+	// Regular `use pkg.path [as alias]` — Osty module system. The
+	// embedded stdlib is a resolved signature surface, not a runtime
+	// implementation, so general gen may still emit `std.*` package
+	// stubs. A few modules have temporary Go bridges for fixture
+	// compatibility; well-known shims (std.testing, std.thread) get
+	// mock structs when they need a callable shape. The test harness
+	// separately replaces the std.testing stub with a real runtime.
+	alias := useDeclAlias(u)
+	if alias == "" {
+		return
+	}
+	full := useFullPath(u)
+	if module, ok := stdlibOstyModulePath(u.Path); ok {
+		if g.aliasUsedAsSelector(alias) {
+			g.requestStdlibOsty(module)
+		}
+		return
+	}
+	if g.emitStdlibRuntimeBridge(alias, u.Path, full) {
+		return
+	}
+	if bridge := stdlibBridge(u.Path); bridge != "" && g.aliasUsedAsSelector(alias) {
+		g.use(bridge)
+		// When the Go bridge's package name already matches the
+		// Osty alias, no rebinding is needed.
+		if lastPathComponent(bridge) == alias {
+			return
+		}
+		g.useAs(bridge, alias)
+		return
+	}
+	stub := knownStdlibStub(u.Path)
+	if stub == "" {
+		stub = "struct{}{}"
+	}
+	g.emitUseStub(alias, stub, full)
+}
+
+func (g *gen) emitStdlibRuntimeBridge(alias string, path []string, full string) bool {
+	if len(path) != 2 || path[0] != "std" {
+		return false
+	}
+	switch path[1] {
+	case "fs":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		osAlias, utf8Alias := g.stdFSImportAliases()
+		g.needFS = true
+		g.emitUseStub(alias, fmt.Sprintf(`struct {
+			readToString func(path string) Result[string, any]
+			writeString  func(path string, contents string) Result[struct{}, any]
+			exists       func(path string) bool
+			remove       func(path string) Result[struct{}, any]
+			}{
+				readToString: func(path string) Result[string, any] {
+					data, err := %[1]s.ReadFile(path)
+					if err != nil {
+						return resultErr[string, any](err)
+					}
+					if !%[2]s.Valid(data) {
+						return resultErr[string, any]("fs.readToString: invalid UTF-8 in " + path)
+					}
+					return resultOk[string, any](string(data))
+				},
+				writeString: func(path string, contents string) Result[struct{}, any] {
+					if err := %[1]s.WriteFile(path, []byte(contents), 0o644); err != nil {
+						return resultErr[struct{}, any](err)
+					}
+					return resultOk[struct{}, any](struct{}{})
+				},
+				exists: func(path string) bool {
+					_, err := %[1]s.Stat(path)
+					return err == nil
+				},
+				remove: func(path string) Result[struct{}, any] {
+					if err := %[1]s.Remove(path); err != nil {
+						return resultErr[struct{}, any](err)
+					}
+					return resultOk[struct{}, any](struct{}{})
+				},
+			}`, osAlias, utf8Alias), full)
+		return true
+	case "ref":
+		g.needRefRuntime = true
+		g.emitUseStub(alias, `struct {
+			same func(any, any) bool
+		}{
+			same: refSame,
+		}`, full)
+		return true
+	case "json":
+		g.needJSON = true
+		g.emitUseStub(alias, `struct {
+			encode         func(value any) string
+			stringify      func(value any) string
+			Object         func(value map[string]Json) Json
+			Array          func(value []Json) Json
+			String         func(value string) Json
+			Number         func(value float64) Json
+			Bool           func(value bool) Json
+			Null           Json
+			stringifyValue func(value Json) string
+			parseValue     func(text string) Result[Json, any]
+			isNull         func(value Json) bool
+			isBool         func(value Json) bool
+			isNumber       func(value Json) bool
+			isString       func(value Json) bool
+			isArray        func(value Json) bool
+			isObject       func(value Json) bool
+			asBool         func(value Json) Result[bool, any]
+			asNumber       func(value Json) Result[float64, any]
+			asString       func(value Json) Result[string, any]
+			asArray        func(value Json) Result[[]Json, any]
+			asObject       func(value Json) Result[map[string]Json, any]
+			getField       func(value Json, key string) Result[Json, any]
+			getIndex       func(value Json, index int) Result[Json, any]
+		}{
+			encode:         jsonEncode,
+			stringify:      jsonStringify,
+			Object:         jsonObject,
+			Array:          jsonArray,
+			String:         jsonString,
+			Number:         jsonNumber,
+			Bool:           jsonBool,
+			Null:           nil,
+			stringifyValue: jsonStringifyValue,
+			parseValue:     jsonParseValueResult,
+			isNull:         jsonIsNullVal,
+			isBool:         jsonIsBoolVal,
+			isNumber:       jsonIsNumberVal,
+			isString:       jsonIsStringVal,
+			isArray:        jsonIsArrayVal,
+			isObject:       jsonIsObjectVal,
+			asBool:         jsonAsBoolResult,
+			asNumber:       jsonAsNumberResult,
+			asString:       jsonAsStringResult,
+			asArray:        jsonAsArrayResult,
+			asObject:       jsonAsObjectResult,
+			getField:       jsonGetFieldResult,
+			getIndex:       jsonGetIndexResult,
+		}`, full)
+		return true
+	case "regex":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		g.needRegex = true
+		g.emitUseStub(alias, `struct {
+			compile func(pattern string) Result[Regex, error]
+		}{
+			compile: regexCompile,
+		}`, full)
+		return true
+	case "error":
+		// std.error calls and qualified literals are lowered directly by
+		// expr.go; no package-shaped Go value is needed here. Avoid
+		// emitting `var error ...`, which would shadow Go's predeclared
+		// error type for any runtime helper that still uses it.
+		return true
+	case "random":
+		g.needRandomRuntime = true
+		g.emitUseStub(alias, `struct {
+			default_ func() Rng
+			seeded   func(seed int64) Rng
+		}{
+			default_: randomDefault,
+			seeded:   randomSeeded,
+		}`, full)
+		return true
+	case "url":
+		g.needURLRuntime = true
+		g.emitUseStub(alias, `struct {
+			parse func(text string) Result[Url, any]
+			join  func(base string, relative string) Result[string, any]
+		}{
+			parse: urlParse,
+			join:  urlJoin,
+		}`, full)
+		return true
+	case "encoding":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		g.needEncoding = true
+		g.needResult = true
+		g.emitUseStub(alias, `struct {
+			base64 struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+				url    struct {
+					encode func(data []byte) string
+					decode func(text string) Result[[]byte, any]
+				}
+			}
+			hex struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+			}
+			url struct {
+				encode func(text string) string
+				decode func(text string) Result[string, any]
+			}
+		}{
+			base64: struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+				url    struct {
+					encode func(data []byte) string
+					decode func(text string) Result[[]byte, any]
+				}
+			}{
+				encode: encodingBase64Encode,
+				decode: encodingBase64Decode,
+				url: struct {
+					encode func(data []byte) string
+					decode func(text string) Result[[]byte, any]
+				}{
+					encode: encodingBase64URLEncode,
+					decode: encodingBase64URLDecode,
+				},
+			},
+			hex: struct {
+				encode func(data []byte) string
+				decode func(text string) Result[[]byte, any]
+			}{
+				encode: encodingHexEncode,
+				decode: encodingHexDecode,
+			},
+			url: struct {
+				encode func(text string) string
+				decode func(text string) Result[string, any]
+			}{
+				encode: encodingURLEncode,
+				decode: encodingURLDecode,
+			},
+		}`, full)
+		return true
+	case "bytes":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		g.needBytesRuntime = true
+		g.needResult = true
+		g.emitUseStub(alias, `struct {
+			from        func(items []byte) []byte
+			fromString  func(s string) []byte
+			toString    func(b []byte) Result[string, any]
+			len         func(b []byte) int
+			isEmpty     func(b []byte) bool
+			get         func(b []byte, i int) *byte
+			slice       func(b []byte, start int, end int) []byte
+			equal       func(a []byte, b []byte) bool
+			contains    func(b []byte, sub []byte) bool
+			startsWith  func(b []byte, prefix []byte) bool
+			endsWith    func(b []byte, suffix []byte) bool
+			indexOf     func(b []byte, sub []byte) *int
+			lastIndexOf func(b []byte, sub []byte) *int
+			split       func(b []byte, sep []byte) [][]byte
+			join        func(parts [][]byte, sep []byte) []byte
+			concat      func(a []byte, b []byte) []byte
+			repeat      func(b []byte, n int) []byte
+			replace     func(b []byte, old []byte, new []byte) []byte
+			replaceAll  func(b []byte, old []byte, new []byte) []byte
+			trimLeft    func(b []byte, strip []byte) []byte
+			trimRight   func(b []byte, strip []byte) []byte
+			trim        func(b []byte, strip []byte) []byte
+			trimSpace   func(b []byte) []byte
+			toUpper     func(b []byte) []byte
+			toLower     func(b []byte) []byte
+			toHex       func(b []byte) string
+			fromHex     func(s string) Result[[]byte, any]
+		}{
+			from:        bytesFrom,
+			fromString:  bytesFromString,
+			toString:    bytesToString,
+			len:         bytesLen,
+			isEmpty:     bytesIsEmpty,
+			get:         bytesGet,
+			slice:       bytesSlice,
+			equal:       bytesEqual,
+			contains:    bytesContains,
+			startsWith:  bytesStartsWith,
+			endsWith:    bytesEndsWith,
+			indexOf:     bytesIndexOf,
+			lastIndexOf: bytesLastIndexOf,
+			split:       bytesSplit,
+			join:        bytesJoin,
+			concat:      bytesConcat,
+			repeat:      bytesRepeat,
+			replace:     bytesReplace,
+			replaceAll:  bytesReplaceAll,
+			trimLeft:    bytesTrimLeft,
+			trimRight:   bytesTrimRight,
+			trim:        bytesTrim,
+			trimSpace:   bytesTrimSpace,
+			toUpper:     bytesToUpper,
+			toLower:     bytesToLower,
+			toHex:       bytesToHex,
+			fromHex:     bytesFromHex,
+		}`, full)
+		return true
+	case "csv":
+		if !g.aliasUsedAsSelector(alias) {
+			return false
+		}
+		g.needResult = true
+		g.needCsvRuntime = true
+		g.use("fmt")
+		g.useAs("strings", "_ostyCsvStrings")
+		g.emitUseStub(alias, `struct {
+			CsvOptions    func(_delimiter rune, _quote rune, _trimSpace bool) _ostyCsvOptions
+			encode        func(rows [][]string) string
+			encodeWith    func(rows [][]string, opts _ostyCsvOptions) string
+			decode        func(text string) Result[[][]string, any]
+			decodeHeaders func(text string) Result[[]map[string]string, any]
+			decodeWith    func(text string, opts _ostyCsvOptions) Result[[][]string, any]
+		}{
+			CsvOptions: func(_delimiter rune, _quote rune, _trimSpace bool) _ostyCsvOptions {
+				return _ostyCsvOptions{delimiter: _delimiter, quote: _quote, trimSpace: _trimSpace}
+			},
+			encode: func(rows [][]string) string {
+				return _ostyCsvEncodeWith(rows, _ostyCsvOptions{delimiter: ',', quote: '"', trimSpace: false})
+			},
+			encodeWith: _ostyCsvEncodeWith,
+			decode: func(text string) Result[[][]string, any] {
+				return _ostyCsvDecodeWith(text, _ostyCsvOptions{delimiter: ',', quote: '"', trimSpace: false})
+			},
+			decodeHeaders: _ostyCsvDecodeHeaders,
+			decodeWith:    _ostyCsvDecodeWith,
+		}`, full)
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitCsvRuntime(out *bytes.Buffer) {
+	out.WriteString(`
+type _ostyCsvOptions struct {
+	delimiter rune
+	quote     rune
+	trimSpace bool
+}
+
+func _ostyCsvEncodeField(field string, delimiter rune, quote rune) string {
+	needsQuote := field == "" ||
+		_ostyCsvStrings.ContainsRune(field, delimiter) ||
+		_ostyCsvStrings.ContainsRune(field, quote) ||
+		_ostyCsvStrings.ContainsAny(field, "\r\n") ||
+		field != _ostyCsvStrings.TrimSpace(field)
+	if !needsQuote {
+		return field
+	}
+	var b _ostyCsvStrings.Builder
+	b.WriteRune(quote)
+	for _, r := range field {
+		if r == quote {
+			b.WriteRune(quote)
+		}
+		b.WriteRune(r)
+	}
+	b.WriteRune(quote)
+	return b.String()
+}
+
+func _ostyCsvEncodeWith(rows [][]string, options _ostyCsvOptions) string {
+	var b _ostyCsvStrings.Builder
+	for _, row := range rows {
+		for fi, field := range row {
+			if fi > 0 {
+				b.WriteRune(options.delimiter)
+			}
+			b.WriteString(_ostyCsvEncodeField(field, options.delimiter, options.quote))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func _ostyCsvDecodeWith(text string, options _ostyCsvOptions) Result[[][]string, any] {
+	var rows [][]string
+	var row []string
+	var field _ostyCsvStrings.Builder
+	var inQuote, quoted, sawAny, endedRecord bool
+	chars := []rune(text)
+	length := len(chars)
+	i := 0
+	for i < length {
+		c := chars[i]
+		sawAny = true
+		if inQuote {
+			if c == options.quote {
+				if i+1 < length && chars[i+1] == options.quote {
+					field.WriteRune(options.quote)
+					i++
+				} else {
+					inQuote = false
+					quoted = true
+				}
+			} else {
+				field.WriteRune(c)
+			}
+			endedRecord = false
+			i++
+			continue
+		}
+		if quoted && c != options.delimiter && c != '\r' && c != '\n' {
+			return resultErr[[][]string, any](fmt.Errorf("csv: data after closing quote"))
+		}
+		if c == options.quote {
+			if field.Len() == 0 {
+				inQuote = true
+			} else {
+				return resultErr[[][]string, any](fmt.Errorf("csv: bare quote in unquoted field"))
+			}
+			endedRecord = false
+		} else if c == options.delimiter {
+			value := field.String()
+			if options.trimSpace && !quoted {
+				value = _ostyCsvStrings.TrimSpace(value)
+			}
+			row = append(row, value)
+			field.Reset()
+			quoted = false
+			endedRecord = false
+		} else if c == '\r' {
+			if i+1 < length && chars[i+1] == '\n' {
+				i++
+			}
+			value := field.String()
+			if options.trimSpace && !quoted {
+				value = _ostyCsvStrings.TrimSpace(value)
+			}
+			row = append(row, value)
+			field.Reset()
+			quoted = false
+			rows = append(rows, row)
+			row = nil
+			endedRecord = true
+		} else if c == '\n' {
+			value := field.String()
+			if options.trimSpace && !quoted {
+				value = _ostyCsvStrings.TrimSpace(value)
+			}
+			row = append(row, value)
+			field.Reset()
+			quoted = false
+			rows = append(rows, row)
+			row = nil
+			endedRecord = true
+		} else {
+			field.WriteRune(c)
+			endedRecord = false
+		}
+		i++
+	}
+	if inQuote {
+		return resultErr[[][]string, any](fmt.Errorf("csv: unterminated quoted field"))
+	}
+	if sawAny && !endedRecord {
+		value := field.String()
+		if options.trimSpace && !quoted {
+			value = _ostyCsvStrings.TrimSpace(value)
+		}
+		row = append(row, value)
+		rows = append(rows, row)
+	}
+	return resultOk[[][]string, any](rows)
+}
+
+func _ostyCsvDecodeHeaders(text string) Result[[]map[string]string, any] {
+	rowsRes := _ostyCsvDecodeWith(text, _ostyCsvOptions{delimiter: ',', quote: '"', trimSpace: false})
+	if !rowsRes.IsOk {
+		return resultErr[[]map[string]string, any](rowsRes.Error)
+	}
+	rows := rowsRes.Value
+	if len(rows) == 0 {
+		return resultOk[[]map[string]string, any]([]map[string]string{})
+	}
+	headers := rows[0]
+	out := make([]map[string]string, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		record := map[string]string{}
+		for i, header := range headers {
+			if i < len(row) {
+				record[header] = row[i]
+			} else {
+				record[header] = ""
+			}
+		}
+		out = append(out, record)
+	}
+	return resultOk[[]map[string]string, any](out)
+}
+`)
+}
+
+func (g *gen) stdFSImportAliases() (string, string) {
+	if g.fsOSAlias == "" {
+		g.fsOSAlias = g.freshFileIdent("_ostyStdFSOS")
+	}
+	if g.fsUTF8Alias == "" {
+		g.fsUTF8Alias = g.freshFileIdent("_ostyStdFSUTF8")
+	}
+	return g.fsOSAlias, g.fsUTF8Alias
+}
+
+func (g *gen) freshFileIdent(base string) string {
+	candidate := base
+	for i := 2; g.fileIdentUsed(candidate); i++ {
+		candidate = fmt.Sprintf("%s%d", base, i)
+	}
+	return candidate
+}
+
+func (g *gen) fileIdentUsed(name string) bool {
+	for _, alias := range g.imports {
+		if alias == name {
+			return true
+		}
+	}
+	for _, u := range g.file.Uses {
+		alias := useDeclAlias(u)
+		if mangleIdent(alias) == name {
+			return true
+		}
+	}
+	for _, d := range g.file.Decls {
+		switch d := d.(type) {
+		case *ast.FnDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.LetDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.StructDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.EnumDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.InterfaceDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		case *ast.TypeAliasDecl:
+			if mangleIdent(d.Name) == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *gen) emitUseStub(alias, stub, full string) {
+	g.body.writef("\nvar %s = %s // stub for `use %s`\n",
+		mangleIdent(alias), stub, full)
+}
+
+func (g *gen) aliasUsedAsSelector(alias string) bool {
+	for _, d := range g.file.Decls {
+		if g.declUsesAliasSelector(d, alias) {
+			return true
+		}
+	}
+	for _, s := range g.file.Stmts {
+		if g.stmtUsesAliasSelector(s, alias) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *gen) declUsesAliasSelector(d ast.Decl, alias string) bool {
+	switch d := d.(type) {
+	case *ast.FnDecl:
+		return d.Body != nil && g.stmtUsesAliasSelector(d.Body, alias)
+	case *ast.LetDecl:
+		return g.exprUsesAliasSelector(d.Value, alias)
+	case *ast.StructDecl:
+		for _, m := range d.Methods {
+			if m.Body != nil && g.stmtUsesAliasSelector(m.Body, alias) {
+				return true
+			}
+		}
+	case *ast.EnumDecl:
+		for _, m := range d.Methods {
+			if m.Body != nil && g.stmtUsesAliasSelector(m.Body, alias) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *gen) stmtUsesAliasSelector(s ast.Stmt, alias string) bool {
+	switch s := s.(type) {
+	case *ast.Block:
+		for _, st := range s.Stmts {
+			if g.stmtUsesAliasSelector(st, alias) {
+				return true
+			}
+		}
+	case *ast.LetStmt:
+		return g.exprUsesAliasSelector(s.Value, alias)
+	case *ast.ExprStmt:
+		return g.exprUsesAliasSelector(s.X, alias)
+	case *ast.AssignStmt:
+		if g.exprUsesAliasSelector(s.Value, alias) {
+			return true
+		}
+		for _, t := range s.Targets {
+			if g.exprUsesAliasSelector(t, alias) {
+				return true
+			}
+		}
+	case *ast.ReturnStmt:
+		return g.exprUsesAliasSelector(s.Value, alias)
+	case *ast.ForStmt:
+		return g.exprUsesAliasSelector(s.Iter, alias) ||
+			(s.Body != nil && g.stmtUsesAliasSelector(s.Body, alias))
+	case *ast.DeferStmt:
+		return g.exprUsesAliasSelector(s.X, alias)
+	case *ast.ChanSendStmt:
+		return g.exprUsesAliasSelector(s.Channel, alias) ||
+			g.exprUsesAliasSelector(s.Value, alias)
+	}
+	return false
+}
+
+func (g *gen) exprUsesAliasSelector(e ast.Expr, alias string) bool {
+	switch e := e.(type) {
+	case nil:
+		return false
+	case *ast.FieldExpr:
+		if id, ok := e.X.(*ast.Ident); ok && id.Name == alias {
+			return true
+		}
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.CallExpr:
+		if g.exprUsesAliasSelector(e.Fn, alias) {
+			return true
+		}
+		for _, a := range e.Args {
+			if g.exprUsesAliasSelector(a.Value, alias) {
+				return true
+			}
+		}
+	case *ast.StringLit:
+		for _, p := range e.Parts {
+			if !p.IsLit && g.exprUsesAliasSelector(p.Expr, alias) {
+				return true
+			}
+		}
+	case *ast.ParenExpr:
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.UnaryExpr:
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.BinaryExpr:
+		return g.exprUsesAliasSelector(e.Left, alias) ||
+			g.exprUsesAliasSelector(e.Right, alias)
+	case *ast.QuestionExpr:
+		return g.exprUsesAliasSelector(e.X, alias)
+	case *ast.IndexExpr:
+		return g.exprUsesAliasSelector(e.X, alias) ||
+			g.exprUsesAliasSelector(e.Index, alias)
+	case *ast.TurbofishExpr:
+		return g.exprUsesAliasSelector(e.Base, alias)
+	case *ast.RangeExpr:
+		return g.exprUsesAliasSelector(e.Start, alias) ||
+			g.exprUsesAliasSelector(e.Stop, alias)
+	case *ast.TupleExpr:
+		for _, x := range e.Elems {
+			if g.exprUsesAliasSelector(x, alias) {
+				return true
+			}
+		}
+	case *ast.ListExpr:
+		for _, x := range e.Elems {
+			if g.exprUsesAliasSelector(x, alias) {
+				return true
+			}
+		}
+	case *ast.MapExpr:
+		for _, ent := range e.Entries {
+			if g.exprUsesAliasSelector(ent.Key, alias) ||
+				g.exprUsesAliasSelector(ent.Value, alias) {
+				return true
+			}
+		}
+	case *ast.StructLit:
+		if g.exprUsesAliasSelector(e.Type, alias) ||
+			g.exprUsesAliasSelector(e.Spread, alias) {
+			return true
+		}
+		for _, f := range e.Fields {
+			if g.exprUsesAliasSelector(f.Value, alias) {
+				return true
+			}
+		}
+	case *ast.IfExpr:
+		return g.exprUsesAliasSelector(e.Cond, alias) ||
+			(e.Then != nil && g.stmtUsesAliasSelector(e.Then, alias)) ||
+			g.exprUsesAliasSelector(e.Else, alias)
+	case *ast.MatchExpr:
+		if g.exprUsesAliasSelector(e.Scrutinee, alias) {
+			return true
+		}
+		for _, a := range e.Arms {
+			if g.exprUsesAliasSelector(a.Guard, alias) ||
+				g.exprUsesAliasSelector(a.Body, alias) {
+				return true
+			}
+		}
+	case *ast.ClosureExpr:
+		return g.exprUsesAliasSelector(e.Body, alias)
+	case *ast.Block:
+		return g.stmtUsesAliasSelector(e, alias)
+	}
+	return false
+}
+
+// stdlibBridge maps a small subset of Osty stdlib module paths to Go
+// packages for fixture compatibility. This is not the stdlib runtime;
+// the embedded stdlib under internal/stdlib is a signature-stub surface.
+// Returns "" when no bridge is available (caller falls back to a stub).
+func stdlibBridge(path []string) string {
+	if len(path) < 2 || path[0] != "std" {
+		return ""
+	}
+	switch path[1] {
+	case "os":
+		return "os"
+	case "io":
+		return "io"
+	case "time":
+		return "time"
+	case "math":
+		return "math"
+	case "errors":
+		return "errors"
+	}
+	return ""
+}
+
+// knownStdlibStub returns a Go expression that emulates just enough of
+// a stdlib module's shape for fixtures to compile. Empty string means
+// "use the default empty-struct stub".
+func knownStdlibStub(path []string) string {
+	if len(path) < 2 || path[0] != "std" {
+		return ""
+	}
+	switch path[len(path)-1] {
+	case "testing":
+		return `struct {
+			assert    func(...any)
+			assertEq  func(...any)
+			context   func(...any)
+			benchmark func(...any)
+			snapshot  func(...any)
+		}{
+			assert:    func(...any) {},
+			assertEq:  func(...any) {},
+			context:   func(...any) {},
+			benchmark: func(...any) {},
+			snapshot:  func(...any) {},
+		}`
+	case "thread":
+		return `struct {
+			collectAll func(...any) any
+			race       func(...any) any
+			chan_      func(...any) any
+			select_    func(...any) any
+			isCancelled func() bool
+		}{
+			collectAll: func(...any) any { return nil },
+			race:       func(...any) any { return nil },
+			chan_:      func(...any) any { return nil },
+			select_:    func(...any) any { return nil },
+			isCancelled: func() bool { return false },
+		}`
+	}
+	return ""
+}
+
+// lastPathComponent returns the last slash-delimited segment of a Go
+// import path, used as the default alias when the user didn't spell
+// one out.
+func lastPathComponent(p string) string {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[i+1:]
+	}
+	if i := strings.LastIndexByte(p, '.'); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+func runtimeFFIGoImport(path string) string {
+	switch path {
+	case "runtime.strings":
+		return "strings"
+	case "runtime.path.filepath":
+		return "path/filepath"
+	case "runtime.net.http":
+		return "net/http"
+	case "runtime.selfhost.astbridge":
+		return "github.com/osty/osty/internal/selfhost/astbridge"
+	default:
+		return path
+	}
+}
+
+func useFullPath(u *ast.UseDecl) string {
+	if u == nil {
+		return ""
+	}
+	if u.RawPath != "" {
+		return u.RawPath
+	}
+	return strings.Join(u.Path, ".")
+}
+
+func useDeclAlias(u *ast.UseDecl) string {
+	if u == nil {
+		return ""
+	}
+	if u.Alias != "" {
+		return u.Alias
+	}
+	if u.IsFFI() {
+		return lastPathComponent(u.FFIPath())
+	}
+	if u.RawPath != "" && strings.Contains(u.RawPath, "/") {
+		return lastPathComponent(u.RawPath)
+	}
+	if len(u.Path) > 0 {
+		return lastPathComponent(u.Path[len(u.Path)-1])
+	}
+	return ""
+}
+
+// emitBlockAsReturn writes a block with the final expression optionally
+// lifted into an implicit `return`. Osty allows the last expression of
+// a function body to serve as the return value — Go requires an explicit
+// `return`, so we rewrite when the function has a declared return type.
+//
+// If the final expression contains a `?`, the pre-lift pass runs first
+// so the return expression reduces to a straight substitution on the
+// lifted temps.
+//
+// The closing `}` has no trailing newline; callers add one as needed.
+func (g *gen) emitBlockAsReturn(b *ast.Block, wantReturn bool) {
+	g.body.writeln("{")
+	g.body.indent()
+	stmts := b.Stmts
+	if wantReturn && len(stmts) > 0 {
+		last := stmts[len(stmts)-1]
+		if es, ok := last.(*ast.ExprStmt); ok && !g.isVoidExpr(es.X) {
+			for _, s := range stmts[:len(stmts)-1] {
+				g.emitStmt(s)
+			}
+			g.preLiftQuestions(es.X)
+			g.body.write("return ")
+			g.emitExpr(es.X)
+			g.body.nl()
+			g.resetQuestionSubs()
+			g.body.dedent()
+			g.body.write("}")
+			return
+		}
+	}
+	g.emitStmts(stmts)
+	g.body.dedent()
+	g.body.write("}")
+}
+
+// isVoidCall heuristically reports whether an expression is a
+// call whose result is discarded (e.g. `println(x)`). These should NOT
+// be lifted into a `return` even when they appear last. We can't fully
+// decide this without the type checker, so we treat common void builtins
+// as void and lift everything else.
+func isVoidCall(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	id, ok := call.Fn.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	switch id.Name {
+	case "println", "print", "eprintln", "eprint", "dbg":
+		return true
+	}
+	return false
+}
+
+// isVoidExpr extends isVoidCall with type-checker and resolver
+// awareness. A call is void when any of these hold:
+//
+//   - The checker typed it as Unit (user fn with no return type, or a
+//     stdlib module that was also checked).
+//   - It's `pkg.fn(...)` where `pkg` is a resolved SymPackage and the
+//     target fn's declaration has no return type annotation. This is
+//     the fallback path for stdlib packages that the driver loaded and
+//     resolved but didn't type-check (e.g. `osty test` wires up just
+//     the user package through the checker, leaving `std.testing`
+//     resolved-only — `testing.assertEq` still needs to be recognised
+//     as void so a trailing call in a closure doesn't get wrapped in
+//     an invalid `return`).
+//   - It's a user-declared FnCall (`foo(args)`) whose resolved symbol's
+//     FnDecl has no return type — same problem as above but for in-package
+//     calls.
+func (g *gen) isVoidExpr(e ast.Expr) bool {
+	if isVoidCall(e) {
+		return true
+	}
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	if t := g.typeOf(call); t != nil && types.IsUnit(t) {
+		return true
+	}
+	if f, ok := call.Fn.(*ast.FieldExpr); ok {
+		if id, ok := f.X.(*ast.Ident); ok && id.Name == "testing" {
+			switch f.Name {
+			case "assert", "assertEq", "assertNe", "context", "benchmark", "snapshot":
+				return true
+			}
+		}
+	}
+	// Callee introspection: walk Fn → find the referenced FnDecl, check
+	// that it has no declared return type.
+	fnDecl := g.resolvedCalleeFnDecl(call.Fn)
+	if fnDecl != nil && fnDecl.ReturnType == nil {
+		return true
+	}
+	return false
+}
+
+// resolvedCalleeFnDecl returns the FnDecl that a call expression's Fn
+// resolves to, consulting both the in-package resolver and (for package
+// calls) the imported package's PkgScope. Returns nil when the callee
+// is a closure, a generic turbofish, or otherwise can't be statically
+// attributed to a single FnDecl.
+func (g *gen) resolvedCalleeFnDecl(fn ast.Expr) *ast.FnDecl {
+	switch f := fn.(type) {
+	case *ast.Ident:
+		if sym := g.symbolFor(f); sym != nil {
+			if d, ok := sym.Decl.(*ast.FnDecl); ok {
+				return d
+			}
+		}
+	case *ast.FieldExpr:
+		id, ok := f.X.(*ast.Ident)
+		if !ok {
+			return nil
+		}
+		sym := g.symbolFor(id)
+		if sym == nil || sym.Package == nil || sym.Package.PkgScope == nil {
+			return nil
+		}
+		tgt := sym.Package.PkgScope.LookupLocal(f.Name)
+		if tgt == nil {
+			return nil
+		}
+		if d, ok := tgt.Decl.(*ast.FnDecl); ok {
+			return d
+		}
+	}
+	return nil
+}

--- a/internal/gen/doc.go
+++ b/internal/gen/doc.go
@@ -1,0 +1,63 @@
+//go:build selfhostgen
+
+// Package gen translates a type-checked Osty AST into Go source code for the
+// selfhostgen bootstrap path.
+//
+// The transpiler runs after the front-end pipeline (lex → parse → resolve
+// → check) and consumes:
+//
+//   - *ast.File — the parsed syntax tree
+//   - *resolve.Result — symbol resolution (Refs, TypeRefs)
+//   - *check.Result — semantic types (Types, LetTypes, SymTypes, Instantiations)
+//
+// No AST nodes are mutated; the package is a pure read-side consumer of
+// the front-end. Output is `package main` Go for the bootstrap seed compiler;
+// the public compiler path uses the native LLVM backend instead.
+//
+// Phase 1 coverage (what's implemented):
+//
+//   - top-level fn declarations (params, return type, body)
+//   - script mode (top-level statements wrapped into main())
+//   - primitive types: Int, Int8..Int64, UInt8..UInt64, Byte, Float,
+//     Float32, Float64, Bool, Char, String, Bytes
+//   - primitive literals (int, float, bool, char, byte, string)
+//   - string interpolation via fmt.Sprintf
+//   - let bindings (simple, no destructuring)
+//   - binary/unary expressions (arithmetic, comparison, logical, bitwise)
+//   - if / else (statement form)
+//   - for loops: integer range, while-style, infinite
+//   - return statements (explicit + implicit block-final-expr)
+//   - println / print / eprintln / eprint intrinsics
+//   - user function calls
+//   - list literals over primitive types
+//
+// Phases 2–4 coverage (what's implemented beyond Phase 1):
+//
+//   - structs, enums, interfaces, type aliases (Phase 2)
+//   - match expressions, pattern destructuring (Phase 2)
+//   - generics, closures, collection methods (Phase 3)
+//   - Option / Result and `?` operator, defer (Phase 4)
+//
+// Result is lowered to a parametric Go struct (Value/Error/IsOk) and
+// pattern tests read `IsOk` directly rather than using type assertions
+// (see internal/gen/question.go and the Result helpers in match.go).
+//
+// The `?` operator is lifted out of any direct-evaluation position by
+// preLiftQuestions: a statement that contains one or more `?` gets a
+// prelude of `tmp := operand; if failure { return … }` pairs, and the
+// original expression is rewritten to read `tmp.Value` / `*tmp`. This
+// covers `let x = e?`, `return e?`, `e?` as a discard-statement, and
+// `?` nested in call arguments, binary operators, field chains, and
+// implicit block-final returns. Control-flow boundaries (closures,
+// if/match arms, loop bodies) are *not* crossed by the lift — a `?`
+// inside them binds to its own enclosing return context.
+//
+// Phases 5–6 coverage:
+//
+//   - use declarations and legacy/runtime FFI shims (Phase 5)
+//   - channels and structured-concurrency primitives (Phase 6)
+//
+// Remaining TODO markers in emitted Go are bootstrap-coverage issues for
+// particular AST shapes, not unresolved language semantics. The v0.4
+// language-decision register lives in SPEC_GAPS.md.
+package gen

--- a/internal/gen/expr.go
+++ b/internal/gen/expr.go
@@ -1,0 +1,3986 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
+)
+
+// emitExpr writes an expression inline (no trailing newline).
+func (g *gen) emitExpr(e ast.Expr) {
+	switch e := e.(type) {
+	case *ast.Ident:
+		g.emitIdent(e)
+	case *ast.IntLit:
+		g.body.write(e.Text)
+	case *ast.FloatLit:
+		g.body.write(e.Text)
+	case *ast.BoolLit:
+		if e.Value {
+			g.body.write("true")
+		} else {
+			g.body.write("false")
+		}
+	case *ast.CharLit:
+		g.body.write(strconv.QuoteRune(e.Value))
+	case *ast.ByteLit:
+		g.body.writef("byte(%d)", e.Value)
+	case *ast.StringLit:
+		g.emitStringLit(e)
+	case *ast.ParenExpr:
+		g.body.write("(")
+		g.emitExpr(e.X)
+		g.body.write(")")
+	case *ast.UnaryExpr:
+		g.emitUnary(e)
+	case *ast.BinaryExpr:
+		g.emitBinary(e)
+	case *ast.CallExpr:
+		g.emitCall(e)
+	case *ast.FieldExpr:
+		g.emitField(e)
+	case *ast.IndexExpr:
+		g.emitIndex(e)
+	case *ast.RangeExpr:
+		g.emitRangeExpr(e)
+	case *ast.ListExpr:
+		g.emitList(e)
+	case *ast.MapExpr:
+		g.emitMap(e)
+	case *ast.TupleExpr:
+		g.emitTupleExpr(e)
+	case *ast.IfExpr:
+		g.emitIfExpr(e)
+	case *ast.Block:
+		g.emitBlockAsExpr(e)
+	case *ast.MatchExpr:
+		g.emitMatch(e)
+	case *ast.ClosureExpr:
+		g.emitClosure(e)
+	case *ast.StructLit:
+		g.emitStructLit(e)
+	case *ast.TurbofishExpr:
+		g.emitExpr(e.Base)
+	case *ast.QuestionExpr:
+		g.emitQuestion(e)
+	default:
+		g.body.writef("/* TODO: expr %T */", e)
+	}
+}
+
+// emitIdent writes an identifier reference. Osty prelude builtins with
+// no Go equivalent are rewritten inline (true/false handled by BoolLit;
+// None becomes a typed nil; Some/Ok/Err are emitted as calls at the
+// CallExpr layer). Bare enum variants (no payload) are emitted as
+// zero-value struct literals here; tuple variants flow through
+// emitCall instead.
+func (g *gen) emitIdent(id *ast.Ident) {
+	switch id.Name {
+	case "true", "false":
+		g.body.write(id.Name)
+		return
+	case "None":
+		g.body.write("nil")
+		return
+	case "Self":
+		if g.selfType != "" {
+			g.body.write(g.selfType)
+			return
+		}
+	}
+	// Bare variant reference (no call) — emit a zero-value struct
+	// wrapped in the enum interface conversion so type assertions at
+	// use sites work (a bare struct value cannot be the scrutinee of a
+	// `v.(Enum_Variant)` type assertion).
+	if owner, ok := g.variantOwnerForIdent(id); ok {
+		g.body.writef("%s(&%s_%s{})", owner, owner, id.Name)
+		return
+	}
+	if renamed := g.renamedIdent(id); renamed != "" {
+		g.body.write(renamed)
+		return
+	}
+	g.body.write(mangleIdent(id.Name))
+}
+
+func (g *gen) variantOwnerForIdent(id *ast.Ident) (string, bool) {
+	if id == nil {
+		return "", false
+	}
+	if sym := g.symbolFor(id); sym != nil {
+		if sym.Kind != resolve.SymVariant {
+			return "", false
+		}
+		if owner, ok := g.variantOwnerForSymbol(sym); ok {
+			return owner, true
+		}
+	}
+	if owner, ok := g.variantOwner[id.Name]; ok {
+		return owner, true
+	}
+	return "", false
+}
+
+func (g *gen) variantOwnerForSymbol(sym *resolve.Symbol) (string, bool) {
+	t := g.symTypeOf(sym)
+	if fn, ok := t.(*types.FnType); ok {
+		t = fn.Return
+	}
+	if n, ok := types.AsNamed(t); ok && n.Sym != nil {
+		return n.Sym.Name, true
+	}
+	return "", false
+}
+
+// emitStructLit writes a struct literal. `Self { ... }` is rewritten
+// to the enclosing type while emitting a method body.
+//
+// Functional-update form `Point { x: 1, ..other }` is lowered to an
+// IIFE that seeds a temp from the spread source and overrides the
+// explicit fields, since Go has no direct equivalent:
+//
+//	func() Point { _r := other; _r.x = 1; return _r }()
+//
+// This preserves the Osty semantics (overrides win, untouched fields
+// come from the spread value) without needing the gen to know every
+// field name on the struct type.
+func (g *gen) emitStructLit(s *ast.StructLit) {
+	var typeName string
+	isStdlibLit := false
+	switch t := s.Type.(type) {
+	case *ast.Ident:
+		if t.Name == "Self" && g.selfType != "" {
+			typeName = g.selfType
+		} else {
+			typeName = t.Name
+		}
+	case *ast.FieldExpr:
+		if name, ok := g.stdlibStructLitType(t); ok {
+			typeName = name
+			isStdlibLit = true
+		} else {
+			// Qualified type (pkg.Type) — Phase 5.
+			g.emitExpr(s.Type)
+		}
+	default:
+		g.emitExpr(s.Type)
+	}
+	refStruct := false
+	if !isStdlibLit {
+		if n, ok := g.typeOf(s).(*types.Named); ok && g.isReferenceStructSym(n.Sym) {
+			refStruct = true
+			if got := g.goType(n); strings.HasPrefix(got, "*") {
+				typeName = strings.TrimPrefix(got, "*")
+			}
+		}
+	} else if id, ok := s.Type.(*ast.Ident); ok && g.structTypes[id.Name] {
+		refStruct = true
+	}
+	if typeName != "" && g.structTypes[typeName] {
+		refStruct = true
+	}
+	if s.Spread != nil && typeName != "" {
+		g.emitStructSpreadLit(s, typeName, refStruct)
+		return
+	}
+	if typeName != "" {
+		if refStruct {
+			g.body.write("&")
+		}
+		g.body.write(typeName)
+	}
+	g.body.write("{")
+	for i, f := range s.Fields {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		name := structLitFieldName(typeName, f.Name)
+		g.body.writef("%s: ", name)
+		if f.Value == nil {
+			// Shorthand `Point { name }` → `Point{name: name}`.
+			g.body.write(mangleIdent(f.Name))
+		} else {
+			g.emitExpr(f.Value)
+		}
+	}
+	if s.Spread != nil {
+		// Qualified-type path with a spread is uncommon enough that we
+		// leave a visible TODO rather than guess at the emitted name.
+		g.body.write(" /* TODO(phase3): ..spread on qualified type */ ")
+	}
+	g.body.write("}")
+}
+
+// emitStructSpreadLit lowers `Type { f: v, ..base }` to an IIFE that
+// copies base then assigns each explicit field, matching Osty's
+// "overrides win" semantics (§3.4).
+func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string, refStruct bool) {
+	tmp := g.freshVar("_r")
+	retType := typeName
+	if refStruct {
+		retType = "*" + typeName
+	}
+	g.body.writef("func() %s { %s := ", retType, tmp)
+	if refStruct {
+		g.body.write("*")
+	}
+	g.emitExpr(s.Spread)
+	g.body.write("; ")
+	for _, f := range s.Fields {
+		g.body.writef("%s.%s = ", tmp, structLitFieldName(typeName, f.Name))
+		if f.Value == nil {
+			g.body.write(mangleIdent(f.Name))
+		} else {
+			g.emitExpr(f.Value)
+		}
+		g.body.write("; ")
+	}
+	if refStruct {
+		g.body.writef("return &%s }()", tmp)
+		return
+	}
+	g.body.writef("return %s }()", tmp)
+}
+
+// emitStringLit writes a string literal.
+//
+// Plain strings (no interpolation) are emitted as Go string literals
+// via strconv.Quote. Interpolated strings are rewritten to a
+// `fmt.Sprintf` call: each literal segment becomes a quoted run, each
+// expression segment is first routed through the Osty toString bridge.
+func (g *gen) emitStringLit(s *ast.StringLit) {
+	// Fast path: no interpolation.
+	plain := true
+	for _, p := range s.Parts {
+		if !p.IsLit {
+			plain = false
+			break
+		}
+	}
+	if plain {
+		var b strings.Builder
+		for _, p := range s.Parts {
+			b.WriteString(p.Lit)
+		}
+		g.body.write(strconv.Quote(b.String()))
+		return
+	}
+
+	// Interpolated: fmt.Sprintf("...", ostyToString(args)...).
+	g.use("fmt")
+	g.needStringRuntime = true
+	var format strings.Builder
+	var args []ast.Expr
+	for _, p := range s.Parts {
+		if p.IsLit {
+			// Escape `%` in literal runs so fmt treats them as literal.
+			format.WriteString(strings.ReplaceAll(p.Lit, "%", "%%"))
+		} else {
+			format.WriteString("%s")
+			args = append(args, p.Expr)
+		}
+	}
+	g.body.writef("fmt.Sprintf(%s", strconv.Quote(format.String()))
+	for _, a := range args {
+		g.body.write(", ")
+		g.emitStringInterpArg(a)
+	}
+	g.body.write(")")
+}
+
+func (g *gen) emitStringInterpArg(e ast.Expr) {
+	if p, ok := g.typeOf(e).(*types.Primitive); ok && p.Kind == types.PChar {
+		g.body.write("string(")
+		g.emitExpr(e)
+		g.body.write(")")
+		return
+	}
+	g.body.write("ostyToString(")
+	g.emitExpr(e)
+	g.body.write(")")
+}
+
+func (g *gen) emitIndex(e *ast.IndexExpr) {
+	g.emitExpr(e.X)
+	g.body.write("[")
+	if r, ok := e.Index.(*ast.RangeExpr); ok {
+		if r.Start != nil {
+			g.emitExpr(r.Start)
+		}
+		g.body.write(":")
+		if r.Stop != nil {
+			g.emitExpr(r.Stop)
+		}
+	} else {
+		g.emitExpr(e.Index)
+	}
+	g.body.write("]")
+}
+
+// emitUnary writes `op X`.
+func (g *gen) emitUnary(u *ast.UnaryExpr) {
+	if u.Op == token.MINUS {
+		if _, literal := u.X.(*ast.IntLit); !literal {
+			if k, ok := integerKindOf(g.typeOf(u)); ok {
+				g.emitCheckedIntegerNeg(u.X, k)
+				return
+			}
+		}
+	}
+	g.body.write(unaryOp(u.Op))
+	g.emitExpr(u.X)
+}
+
+func unaryOp(k token.Kind) string {
+	switch k {
+	case token.MINUS:
+		return "-"
+	case token.PLUS:
+		return "+"
+	case token.NOT:
+		return "!"
+	case token.BITNOT:
+		return "^"
+	}
+	return "/*?*/"
+}
+
+// emitBinary writes `a op b` with the Osty operator mapped to Go.
+//
+// The `??` null-coalescing operator has no native Go equivalent; we
+// rewrite it to an IIFE that tests nil and substitutes the default.
+// Since that requires knowing the value type, we emit a conservative
+// pattern that works for pointer operands (which is how Phase 1 models
+// Option<T>).
+func (g *gen) emitBinary(b *ast.BinaryExpr) {
+	// Coalescing is the only special case.
+	if b.Op == token.QQ {
+		g.emitCoalesce(b)
+		return
+	}
+	if (b.Op == token.EQ || b.Op == token.NEQ) && g.needsOstyEqual(b.Left, b.Right) {
+		if b.Op == token.NEQ {
+			g.body.write("!")
+		}
+		g.needEqualRuntime = true
+		g.body.write("ostyEqual(")
+		g.emitExpr(b.Left)
+		g.body.write(", ")
+		g.emitExpr(b.Right)
+		g.body.write(")")
+		return
+	}
+	if g.emitCheckedIntegerBinary(b.Op, b.Left, b.Right, g.typeOf(b), g.typeOf(b.Right)) {
+		return
+	}
+	op := binaryOp(b.Op)
+	g.emitExpr(b.Left)
+	g.body.writef(" %s ", op)
+	g.emitExpr(b.Right)
+}
+
+func (g *gen) emitCheckedIntegerBinary(op token.Kind, left, right ast.Expr, resultT, rightT types.Type) bool {
+	switch op {
+	case token.PLUS, token.MINUS, token.STAR, token.SLASH, token.PERCENT:
+		k, ok := integerKindOf(resultT)
+		if !ok {
+			return false
+		}
+		g.emitCheckedIntegerArithmetic(op, left, right, k)
+		return true
+	case token.SHL, token.SHR:
+		leftK, ok := integerKindOf(resultT)
+		if !ok {
+			return false
+		}
+		rightK, ok := integerKindOf(rightT)
+		if !ok {
+			rightK = leftK
+		}
+		g.emitCheckedIntegerShift(op, left, right, leftK, rightK)
+		return true
+	default:
+		return false
+	}
+}
+
+func integerKindOf(t types.Type) (types.PrimitiveKind, bool) {
+	switch t := t.(type) {
+	case *types.Primitive:
+		if t.Kind.IsInteger() {
+			return t.Kind, true
+		}
+	case *types.Untyped:
+		if p, ok := t.Default().(*types.Primitive); ok && p.Kind.IsInteger() {
+			return p.Kind, true
+		}
+	}
+	return types.PInvalid, false
+}
+
+func (g *gen) emitCheckedIntegerNeg(x ast.Expr, k types.PrimitiveKind) {
+	goT := goPrimitive(k)
+	info := runtimeIntInfo(k)
+	if info.signed {
+		g.use("math")
+	}
+	g.emitPrimitiveTypedIIFE(goT, goT, x, func(v string) {
+		if info.signed {
+			g.body.writef("if %s == %s { panic(%q) }\n", v, info.min, "integer overflow")
+			g.body.writef("return -%s\n", v)
+			return
+		}
+		g.body.writef("if %s != 0 { panic(%q) }\n", v, "integer overflow")
+		g.body.writef("return %s(0)\n", goT)
+	})
+}
+
+func (g *gen) emitCheckedIntegerArithmetic(op token.Kind, left, right ast.Expr, k types.PrimitiveKind) {
+	goT := goPrimitive(k)
+	info := runtimeIntInfo(k)
+	if op == token.PLUS || op == token.MINUS || op == token.STAR || info.signed {
+		g.use("math")
+	}
+	g.emitPrimitiveTypedIIFE(goT, goT, left, func(v string) {
+		rhs := g.freshVar("_rhs")
+		g.body.writef("var %s %s = ", rhs, goT)
+		g.emitExpr(right)
+		g.body.nl()
+		switch op {
+		case token.PLUS:
+			g.emitIntAddOverflowGuard(info, v, rhs, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+			g.body.writef("return %s + %s\n", v, rhs)
+		case token.MINUS:
+			g.emitIntSubOverflowGuard(info, v, rhs, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+			g.body.writef("return %s - %s\n", v, rhs)
+		case token.STAR:
+			g.emitIntMulOverflowGuard(info, goT, v, rhs, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+			g.body.writef("return %s * %s\n", v, rhs)
+		case token.SLASH:
+			g.body.writef("if %s == 0 { panic(%q) }\n", rhs, "integer division by zero")
+			if info.signed {
+				g.body.writef("if %s == %s && %s == %s(-1) { panic(%q) }\n", v, info.min, rhs, goT, "integer overflow")
+			}
+			g.body.writef("return %s / %s\n", v, rhs)
+		case token.PERCENT:
+			g.body.writef("if %s == 0 { panic(%q) }\n", rhs, "integer modulo by zero")
+			if info.signed {
+				g.body.writef("if %s == %s && %s == %s(-1) { panic(%q) }\n", v, info.min, rhs, goT, "integer overflow")
+			}
+			g.body.writef("return %s %% %s\n", v, rhs)
+		}
+	})
+}
+
+func (g *gen) emitCheckedIntegerShift(op token.Kind, left, right ast.Expr, leftK, rightK types.PrimitiveKind) {
+	leftGo := goPrimitive(leftK)
+	rightGo := goPrimitive(rightK)
+	info := runtimeIntInfo(leftK)
+	rightInfo := runtimeIntInfo(rightK)
+	if leftK == types.PInt {
+		g.use("strconv")
+	}
+	shiftOp := "<<"
+	if op == token.SHR {
+		shiftOp = ">>"
+	}
+	g.emitPrimitiveTypedIIFE(leftGo, leftGo, left, func(v string) {
+		rhs := g.freshVar("_rhs")
+		g.body.writef("var %s %s = ", rhs, rightGo)
+		g.emitExpr(right)
+		g.body.nl()
+		if rightInfo.signed {
+			g.body.writef("if %s < 0 || %s >= %s(%s) { panic(%q) }\n", rhs, rhs, rightGo, info.bits, "invalid shift count")
+		} else {
+			g.body.writef("if %s >= %s(%s) { panic(%q) }\n", rhs, rightGo, info.bits, "invalid shift count")
+		}
+		g.body.writef("return %s %s uint(%s)\n", v, shiftOp, rhs)
+	})
+}
+
+func (g *gen) needsOstyEqual(left, right ast.Expr) bool {
+	return needsOstyEqualType(g.typeOf(left)) || needsOstyEqualType(g.typeOf(right))
+}
+
+func needsOstyEqualType(t types.Type) bool {
+	switch t := t.(type) {
+	case nil:
+		return false
+	case *types.Primitive:
+		return t.Kind == types.PBytes
+	case *types.Untyped:
+		return false
+	default:
+		return true
+	}
+}
+
+func binaryOp(k token.Kind) string {
+	switch k {
+	case token.PLUS:
+		return "+"
+	case token.MINUS:
+		return "-"
+	case token.STAR:
+		return "*"
+	case token.SLASH:
+		return "/"
+	case token.PERCENT:
+		return "%"
+	case token.EQ:
+		return "=="
+	case token.NEQ:
+		return "!="
+	case token.LT:
+		return "<"
+	case token.GT:
+		return ">"
+	case token.LEQ:
+		return "<="
+	case token.GEQ:
+		return ">="
+	case token.AND:
+		return "&&"
+	case token.OR:
+		return "||"
+	case token.BITAND:
+		return "&"
+	case token.BITOR:
+		return "|"
+	case token.BITXOR:
+		return "^"
+	case token.SHL:
+		return "<<"
+	case token.SHR:
+		return ">>"
+	}
+	return "/*?*/"
+}
+
+// emitCoalesce lowers `a ?? b`. When the checker tells us `a` is an
+// Optional (*T), we emit a branchy lookup. When the checker lost the
+// type (e.g. calls into unchecked stdlib) we fall back to a runtime
+// nil-probe via reflect-free Go: `func() T { if v := a; v != nil { return *v }; return b }()`.
+// When `a` is not optional, `??` is a no-op — the right operand is
+// unreachable by construction, so we just emit the left.
+func (g *gen) emitCoalesce(b *ast.BinaryExpr) {
+	lt := g.typeOf(b.Left)
+	if opt, ok := lt.(*types.Optional); ok {
+		g.body.write("func() ")
+		inner := g.goType(opt.Inner)
+		g.body.writef("%s { if v := ", inner)
+		g.emitExpr(b.Left)
+		g.body.writef("; v != nil { return *v }; return ")
+		g.emitExpr(b.Right)
+		g.body.write(" }()")
+		return
+	}
+	// Non-optional left: `a ?? b` ≡ `a` (the RHS is dead). The checker
+	// already issued a hint-level diagnostic when this path is reachable
+	// from user source; just emit the LHS.
+	g.emitExpr(b.Left)
+}
+
+// emitCall writes a function call, applying special rewrites for
+// prelude intrinsics (println, print, ...), builtin variant
+// constructors (Some, Ok, Err), user enum variant construction
+// (`Circle(3.14)` → `Shape_Circle{F0: 3.14}`), enum-method dispatch
+// (`shape.area()` → `Shape_area(shape)`), and static/associated
+// function calls (`User.new("a")` → `User_new("a")`).
+func (g *gen) emitCall(c *ast.CallExpr) {
+	// Monomorphized generic-fn call. callMonoName consults the current
+	// substEnv so an inner call inside a generic body (e.g. `id(y)`
+	// appearing in `wrap<U>`) resolves transitively to the concrete
+	// type of the enclosing monomorph (`id_int` when emitting
+	// wrap_int). The rewrite runs before the construct-specific paths
+	// so the mangled name wins over any source-level collision with
+	// a variant constructor etc.
+	if mangled := g.callMonoName(c); mangled != "" {
+		g.body.write(mangled)
+		g.body.write("(")
+		for i, a := range c.Args {
+			if i > 0 {
+				g.body.write(", ")
+			}
+			if a.Name != "" {
+				g.body.writef("/* %s = */ ", a.Name)
+			}
+			g.emitExpr(a.Value)
+		}
+		g.body.write(")")
+		return
+	}
+	if id, ok := c.Fn.(*ast.Ident); ok {
+		if g.emitBuiltinCall(id.Name, c.Args, c) {
+			return
+		}
+		// User-defined variant construction: Fn is a bare variant name.
+		if owner, ok := g.variantOwnerForIdent(id); ok {
+			g.emitVariantCtor(owner, id.Name, c.Args)
+			return
+		}
+	}
+	if g.emitStdlibJSONCall(c) {
+		return
+	}
+	if g.emitStdlibOstyCall(c) {
+		return
+	}
+	if g.emitStdlibIterCall(c) {
+		return
+	}
+	if f, ok := c.Fn.(*ast.FieldExpr); ok {
+		if owner, variant, ok := g.qualifiedVariant(f); ok {
+			g.emitVariantCtor(owner, variant, c.Args)
+			return
+		}
+		if g.emitQualifiedOptionCall(c, f) {
+			return
+		}
+		if g.emitStdlibErrorCall(c, f) {
+			return
+		}
+		if g.emitErrorMethodCall(c, f) {
+			return
+		}
+		if g.emitStdlibRefCall(c, f) {
+			return
+		}
+		if g.emitStdlibRegexCall(c, f) {
+			return
+		}
+		if g.emitStdlibEncodingCall(c, f) {
+			return
+		}
+		if g.emitStdlibEnvCall(c, f) {
+			return
+		}
+		if g.emitStdlibCompressCall(c, f) {
+			return
+		}
+		if g.emitStdlibCryptoCall(c, f) {
+			return
+		}
+		if g.emitStdlibUUIDCall(c, f) {
+			return
+		}
+		if g.emitStdlibMathCall(c, f) {
+			return
+		}
+		if g.emitThreadSelect(c, f) {
+			return
+		}
+		if g.emitThreadCall(c, f) {
+			return
+		}
+		if g.emitPrimitiveMethodCall(c, f) {
+			return
+		}
+		if g.emitErrorMethodCall(c, f) {
+			return
+		}
+		if g.emitResultMethodCall(c, f) {
+			return
+		}
+		if g.emitOptionalMethodCall(c, f) {
+			return
+		}
+		if g.emitPrimitiveMethodCall(c, f) {
+			return
+		}
+		if g.emitConcurrencyMethod(c, f) {
+			return
+		}
+		if g.emitListPushCall(c, f) {
+			return
+		}
+		if g.emitRandomGenericMethod(c, f) {
+			return
+		}
+		if g.emitCollectionMethod(c, f) {
+			return
+		}
+		if g.emitStaticCall(f, c.Args) {
+			return
+		}
+		if g.emitEnumMethodCall(f, c.Args) {
+			return
+		}
+	}
+	if tf, ok := c.Fn.(*ast.TurbofishExpr); ok {
+		if g.emitErrorDowncastCall(c, tf) {
+			return
+		}
+		if g.emitTurbofishCall(c, tf) {
+			return
+		}
+	}
+	g.emitExpr(c.Fn)
+	g.body.write("(")
+	for i, a := range c.Args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		if a.Name != "" {
+			// Keyword arg: Phase 3 will desugar by matching against
+			// the resolved parameter order. For now emit positional
+			// with a comment so the mismatch is visible.
+			g.body.writef("/* %s = */ ", a.Name)
+		}
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+}
+
+// emitListPushCall lowers `xs.push(v)` to an append-backed mutation. The
+// checker already verifies the receiver is List<T> and the argument matches T;
+// this keeps generated Go in sync with that accepted stdlib surface.
+func (g *gen) emitListPushCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.Name != "push" || len(c.Args) != 1 {
+		return false
+	}
+	n, ok := g.typeOf(f.X).(*types.Named)
+	if !ok || n.Sym == nil || n.Sym.Name != "List" || len(n.Args) != 1 {
+		return false
+	}
+	g.body.write("func() struct{} { ")
+	g.emitExpr(f.X)
+	g.body.write(" = append(")
+	g.emitExpr(f.X)
+	g.body.write(", ")
+	g.emitExprAsType(c.Args[0].Value, n.Args[0])
+	g.body.write("); return struct{}{} }()")
+	return true
+}
+
+func (g *gen) emitStdlibJSONCall(c *ast.CallExpr) bool {
+	base := c.Fn
+	var explicit []ast.Type
+	if tf, ok := base.(*ast.TurbofishExpr); ok {
+		base = tf.Base
+		explicit = tf.Args
+	}
+	id, parts, ok := stdlibFieldChain(base)
+	if !ok || id == nil || len(parts) != 1 || !g.isStdlibPackageAlias(id, "json") {
+		return false
+	}
+	nargs := len(c.Args)
+	switch parts[0] {
+	case "encode":
+		if nargs != 1 {
+			return false
+		}
+		g.body.write("jsonEncode(")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "stringify":
+		if nargs != 1 {
+			return false
+		}
+		g.body.write("jsonStringify(")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "decode", "parse":
+		if nargs != 1 {
+			return false
+		}
+		g.body.writef("jsonDecode[%s](", g.jsonDecodeTargetGo(c, explicit))
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "stringifyValue":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonStringifyValue", c.Args)
+		return true
+	case "parseValue":
+		if nargs != 1 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonParseValueResult", c.Args)
+		return true
+	case "isNull":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonIsNullVal", c.Args)
+		return true
+	case "isBool":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonIsBoolVal", c.Args)
+		return true
+	case "isNumber":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonIsNumberVal", c.Args)
+		return true
+	case "isString":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonIsStringVal", c.Args)
+		return true
+	case "isArray":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonIsArrayVal", c.Args)
+		return true
+	case "isObject":
+		if nargs != 1 {
+			return false
+		}
+		g.emitStdlibHelperCall("jsonIsObjectVal", c.Args)
+		return true
+	case "asBool":
+		if nargs != 1 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonAsBoolResult", c.Args)
+		return true
+	case "asNumber":
+		if nargs != 1 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonAsNumberResult", c.Args)
+		return true
+	case "asString":
+		if nargs != 1 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonAsStringResult", c.Args)
+		return true
+	case "asArray":
+		if nargs != 1 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonAsArrayResult", c.Args)
+		return true
+	case "asObject":
+		if nargs != 1 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonAsObjectResult", c.Args)
+		return true
+	case "getField":
+		if nargs != 2 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonGetFieldResult", c.Args)
+		return true
+	case "getIndex":
+		if nargs != 2 {
+			return false
+		}
+		g.needResult = true
+		g.emitStdlibHelperCall("jsonGetIndexResult", c.Args)
+		return true
+	}
+	return false
+}
+
+func (g *gen) jsonDecodeTargetGo(c *ast.CallExpr, explicit []ast.Type) string {
+	if len(explicit) == 1 {
+		return g.goTypeExpr(explicit[0])
+	}
+	if n, ok := types.AsNamedByName(g.typeOf(c), "Result"); ok && len(n.Args) == 2 {
+		return g.goType(n.Args[0])
+	}
+	return "any"
+}
+
+func (g *gen) emitStdlibErrorCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.Name == "new" && g.isPreludeErrorTypeExpr(f.X) && len(c.Args) == 1 {
+		g.emitErrorNew(c.Args)
+		return true
+	}
+	parts, ok := g.stdlibCallPath(c, "error")
+	if !ok || len(c.Args) != 1 {
+		return false
+	}
+	switch strings.Join(parts, ".") {
+	case "new", "Error.new":
+		g.emitErrorNew(c.Args)
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitErrorNew(args []*ast.Arg) {
+	g.needErrorRuntime = true
+	g.body.write("ostyErrorNew(")
+	g.emitExpr(args[0].Value)
+	g.body.write(")")
+}
+
+func (g *gen) emitErrorMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if len(c.Args) != 0 || !isErrorType(g.typeOf(f.X)) {
+		return false
+	}
+	switch f.Name {
+	case "message":
+		g.needErrorRuntime = true
+		g.body.write("ostyErrorMessage(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	case "source":
+		g.needErrorRuntime = true
+		g.body.write("ostyErrorSource(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitErrorDowncastCall(c *ast.CallExpr, tf *ast.TurbofishExpr) bool {
+	f, ok := tf.Base.(*ast.FieldExpr)
+	if !ok || f.Name != "downcast" || len(tf.Args) != 1 || len(c.Args) != 0 || !isErrorType(g.typeOf(f.X)) {
+		return false
+	}
+	g.needErrorRuntime = true
+	g.body.writef("ostyErrorDowncast[%s](", g.goTypeExpr(tf.Args[0]))
+	g.emitExpr(f.X)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) isPreludeErrorTypeExpr(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	if !ok || id.Name != "Error" {
+		return false
+	}
+	sym := g.symbolFor(id)
+	return sym != nil && sym.Kind == resolve.SymBuiltin && sym.Name == "Error"
+}
+
+func isErrorType(t types.Type) bool {
+	n, ok := t.(*types.Named)
+	return ok && n.Sym != nil && n.Sym.Name == "Error"
+}
+
+func (g *gen) emitStdlibRefCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "ref") || f.Name != "same" || len(c.Args) != 2 {
+		return false
+	}
+	if t := g.typeOf(c.Args[0].Value); hasValueSemantics(t) {
+		g.body.write("false")
+		return true
+	}
+	g.needRefRuntime = true
+	g.body.write("refSame(")
+	g.emitExpr(c.Args[0].Value)
+	g.body.write(", ")
+	g.emitExpr(c.Args[1].Value)
+	g.body.write(")")
+	return true
+}
+
+func hasValueSemantics(t types.Type) bool {
+	switch t.(type) {
+	case *types.Primitive, *types.Untyped, *types.Tuple:
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitStdlibEncodingCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "encoding")
+	if !ok {
+		return false
+	}
+	var helper string
+	switch strings.Join(parts, ".") {
+	case "base64.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64Encode"
+		}
+	case "base64.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64Decode"
+		}
+	case "base64.url.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64URLEncode"
+		}
+	case "base64.url.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingBase64URLDecode"
+		}
+	case "hex.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingHexEncode"
+		}
+	case "hex.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingHexDecode"
+		}
+	case "url.encode":
+		if len(c.Args) == 1 {
+			helper = "encodingURLEncode"
+		}
+	case "url.decode":
+		if len(c.Args) == 1 {
+			helper = "encodingURLDecode"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needEncoding = true
+	if strings.HasSuffix(helper, "Decode") {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibEnvCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "env")
+	if !ok || len(parts) != 1 {
+		return false
+	}
+	var helper string
+	switch parts[0] {
+	case "args":
+		if len(c.Args) == 0 {
+			helper = "envArgs"
+		}
+	case "get":
+		if len(c.Args) == 1 {
+			helper = "envGet"
+		}
+	case "require":
+		if len(c.Args) == 1 {
+			helper = "envRequire"
+		}
+	case "set":
+		if len(c.Args) == 2 {
+			helper = "envSet"
+		}
+	case "unset":
+		if len(c.Args) == 1 {
+			helper = "envUnset"
+		}
+	case "vars":
+		if len(c.Args) == 0 {
+			helper = "envVars"
+		}
+	case "currentDir":
+		if len(c.Args) == 0 {
+			helper = "envCurrentDir"
+		}
+	case "setCurrentDir":
+		if len(c.Args) == 1 {
+			helper = "envSetCurrentDir"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needEnv = true
+	switch helper {
+	case "envRequire", "envSet", "envUnset", "envCurrentDir", "envSetCurrentDir":
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibCompressCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "compress")
+	if !ok {
+		return false
+	}
+	var helper string
+	switch strings.Join(parts, ".") {
+	case "gzip.encode":
+		if len(c.Args) == 1 {
+			helper = "compressGzipEncode"
+		}
+	case "gzip.decode":
+		if len(c.Args) == 1 {
+			helper = "compressGzipDecode"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needCompress = true
+	if helper == "compressGzipDecode" {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibCryptoCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "crypto")
+	if !ok {
+		return false
+	}
+	var helper string
+	switch strings.Join(parts, ".") {
+	case "sha256":
+		if len(c.Args) == 1 {
+			helper = "cryptoSHA256"
+		}
+	case "sha512":
+		if len(c.Args) == 1 {
+			helper = "cryptoSHA512"
+		}
+	case "sha1":
+		if len(c.Args) == 1 {
+			helper = "cryptoSHA1"
+		}
+	case "md5":
+		if len(c.Args) == 1 {
+			helper = "cryptoMD5"
+		}
+	case "hmac.sha256":
+		if len(c.Args) == 2 {
+			helper = "cryptoHMACSHA256"
+		}
+	case "hmac.sha512":
+		if len(c.Args) == 2 {
+			helper = "cryptoHMACSHA512"
+		}
+	case "randomBytes":
+		if len(c.Args) == 1 {
+			helper = "cryptoRandomBytes"
+		}
+	case "constantTimeEq":
+		if len(c.Args) == 2 {
+			helper = "cryptoConstantTimeEq"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needCrypto = true
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitStdlibUUIDCall(c *ast.CallExpr, _ *ast.FieldExpr) bool {
+	parts, ok := g.stdlibCallPath(c, "uuid")
+	if !ok || len(parts) != 1 {
+		return false
+	}
+	var helper string
+	switch parts[0] {
+	case "v4":
+		if len(c.Args) == 0 {
+			helper = "uuidV4"
+		}
+	case "v7":
+		if len(c.Args) == 0 {
+			helper = "uuidV7"
+		}
+	case "parse":
+		if len(c.Args) == 1 {
+			helper = "uuidParse"
+		}
+	case "nil":
+		if len(c.Args) == 0 {
+			helper = "uuidNil"
+		}
+	}
+	if helper == "" {
+		return false
+	}
+	g.needUUID = true
+	if helper == "uuidParse" {
+		g.needResult = true
+	}
+	g.emitStdlibHelperCall(helper, c.Args)
+	return true
+}
+
+func (g *gen) emitQualifiedOptionCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "option") {
+		return false
+	}
+	switch f.Name {
+	case "Some":
+		return g.emitBuiltinCall("Some", c.Args, c)
+	case "None":
+		if len(c.Args) == 0 {
+			g.body.write("nil")
+			return true
+		}
+	}
+	return false
+}
+
+func (g *gen) emitStdlibHelperCall(helper string, args []*ast.Arg) {
+	g.body.write(helper)
+	g.body.write("(")
+	for i, a := range args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+}
+
+func (g *gen) emitStdlibRegexCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "regex") || f.Name != "compile" {
+		return false
+	}
+	if len(c.Args) != 1 {
+		return false
+	}
+	g.needRegex = true
+	g.needResult = true
+	g.body.write("regexCompile(")
+	g.emitExpr(c.Args[0].Value)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitStdlibIterCall(c *ast.CallExpr) bool {
+	base := c.Fn
+	var explicit []ast.Type
+	if tf, ok := base.(*ast.TurbofishExpr); ok {
+		base = tf.Base
+		explicit = tf.Args
+	}
+	id, parts, ok := stdlibFieldChain(base)
+	if !ok || id == nil || len(parts) != 1 || (!g.isStdlibPackageAlias(id, "iter") && !g.isStdlibAliasName(id.Name, "iter")) {
+		return false
+	}
+	switch parts[0] {
+	case "range":
+		if len(c.Args) != 2 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]int")
+		g.body.writef("func() %s { ", retGo)
+		start := g.freshVar("_start")
+		stop := g.freshVar("_stop")
+		g.body.writef("%s := ", start)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; %s := ", stop)
+		g.emitExpr(c.Args[1].Value)
+		g.body.writef("; out := make(%s, 0); for i := %s; i < %s; i++ { out = append(out, i) }; return out }()", retGo, start, stop)
+		return true
+	case "from":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]any")
+		g.emitCollectionIIFE(retGo, c.Args[0].Value, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.writeln("return out")
+		})
+		return true
+	case "empty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, iterExplicitListGo(g, explicit))
+		g.body.writef("make(%s, 0)", retGo)
+		return true
+	}
+	return false
+}
+
+func iterExplicitListGo(g *gen, explicit []ast.Type) string {
+	if len(explicit) == 1 {
+		return "[]" + g.goTypeExpr(explicit[0])
+	}
+	return "[]any"
+}
+
+func (g *gen) stdlibCallPath(c *ast.CallExpr, module string) ([]string, bool) {
+	id, parts, ok := stdlibFieldChain(c.Fn)
+	if !ok || id == nil || len(parts) == 0 {
+		return nil, false
+	}
+	if !g.isStdlibPackageAlias(id, module) {
+		return nil, false
+	}
+	return parts, true
+}
+
+func stdlibFieldChain(e ast.Expr) (*ast.Ident, []string, bool) {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x, nil, true
+	case *ast.FieldExpr:
+		id, parts, ok := stdlibFieldChain(x.X)
+		if !ok {
+			return nil, nil, false
+		}
+		return id, append(parts, x.Name), true
+	}
+	return nil, nil, false
+}
+
+func (g *gen) stdlibStructLitType(e ast.Expr) (string, bool) {
+	f, ok := e.(*ast.FieldExpr)
+	if !ok {
+		return "", false
+	}
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	if g.isStdlibPackageAlias(id, "csv") && f.Name == "CsvOptions" {
+		g.needCsvRuntime = true
+		return "_ostyCsvOptions", true
+	}
+	if g.isStdlibPackageAlias(id, "error") && f.Name == "BasicError" {
+		g.needErrorRuntime = true
+		return "ostyBasicError", true
+	}
+	return "", false
+}
+
+func (g *gen) emitStdlibMathCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "math") {
+		return false
+	}
+	alias := g.useStdlibMath(id.Name)
+	if f.Name == "log" {
+		switch len(c.Args) {
+		case 1:
+			g.body.writef("%s.Log(", alias)
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(")")
+			return true
+		case 2:
+			g.body.write("(")
+			g.body.writef("%s.Log(", alias)
+			g.emitExpr(c.Args[0].Value)
+			g.body.write(") / ")
+			g.body.writef("%s.Log(", alias)
+			g.emitExpr(c.Args[1].Value)
+			g.body.write("))")
+			return true
+		}
+		return false
+	}
+	name, ok := stdlibMathFuncs[f.Name]
+	if !ok {
+		return false
+	}
+	g.body.writef("%s.%s(", alias, name)
+	for i, a := range c.Args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitStdlibMathField(f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "math") {
+		return false
+	}
+	alias := g.useStdlibMath(id.Name)
+	switch f.Name {
+	case "PI":
+		g.body.writef("%s.Pi", alias)
+	case "E":
+		g.body.writef("%s.E", alias)
+	case "TAU":
+		g.body.writef("(2 * %s.Pi)", alias)
+	case "INFINITY":
+		g.body.writef("%s.Inf(1)", alias)
+	case "NAN":
+		g.body.writef("%s.NaN()", alias)
+	default:
+		return false
+	}
+	return true
+}
+
+var stdlibMathFuncs = map[string]string{
+	"sin":   "Sin",
+	"cos":   "Cos",
+	"tan":   "Tan",
+	"asin":  "Asin",
+	"acos":  "Acos",
+	"atan":  "Atan",
+	"atan2": "Atan2",
+	"sinh":  "Sinh",
+	"cosh":  "Cosh",
+	"tanh":  "Tanh",
+	"exp":   "Exp",
+	"log2":  "Log2",
+	"log10": "Log10",
+	"sqrt":  "Sqrt",
+	"cbrt":  "Cbrt",
+	"pow":   "Pow",
+	"floor": "Floor",
+	"ceil":  "Ceil",
+	"round": "Round",
+	"trunc": "Trunc",
+	"abs":   "Abs",
+	"min":   "Min",
+	"max":   "Max",
+	"hypot": "Hypot",
+}
+
+func (g *gen) useStdlibMath(alias string) string {
+	goAlias := mangleIdent(alias)
+	if goAlias == "math" {
+		g.use("math")
+	} else {
+		g.useAs("math", goAlias)
+	}
+	return goAlias
+}
+
+func (g *gen) isStdlibPackageAlias(id *ast.Ident, module string) bool {
+	if sym := g.symbolFor(id); sym != nil && sym.Kind == resolve.SymPackage {
+		if u, ok := sym.Decl.(*ast.UseDecl); ok {
+			return stdlibUseMatchesAlias(u, id.Name, module)
+		}
+	}
+	if g.res != nil {
+		return false
+	}
+	for _, u := range g.file.Uses {
+		if stdlibUseMatchesAlias(u, id.Name, module) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *gen) isStdlibAliasName(alias, module string) bool {
+	for _, u := range g.file.Uses {
+		if stdlibUseMatchesAlias(u, alias, module) {
+			return true
+		}
+	}
+	return false
+}
+
+func stdlibUseMatchesAlias(u *ast.UseDecl, alias, module string) bool {
+	if u == nil || u.IsFFI() || len(u.Path) != 2 || u.Path[0] != "std" || u.Path[1] != module {
+		return false
+	}
+	name := u.Alias
+	if name == "" {
+		name = u.Path[len(u.Path)-1]
+	}
+	return name == alias
+}
+
+// emitConcurrencyMethod recognizes the small set of channel / handle
+// method calls from §8 and rewrites them to Go primitives.
+//
+//	ch.recv()     → func() *T { v, ok := <-ch; if !ok { return nil }; return &v }()
+//	ch.close()    → close(ch)
+//	h.join()      → h.Join()
+//
+// The receiver must have a Chan / Channel / Handle named type; when the
+// checker lost that info, we fall through so the generic path takes over.
+func (g *gen) emitConcurrencyMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	recvT := g.typeOf(f.X)
+	n, ok := recvT.(*types.Named)
+	if !ok || n.Sym == nil {
+		return false
+	}
+	switch n.Sym.Name {
+	case "Chan", "Channel":
+		switch f.Name {
+		case "recv":
+			inner := "any"
+			if len(n.Args) == 1 {
+				inner = g.goType(n.Args[0])
+			}
+			g.body.writef("func() *%s { v, ok := <-", inner)
+			g.emitExpr(f.X)
+			g.body.write("; if !ok { return nil }; return &v }()")
+			return true
+		case "close":
+			g.body.write("close(")
+			g.emitExpr(f.X)
+			g.body.write(")")
+			return true
+		case "send":
+			// Defensive: `ch.send(v)` surface form; spec uses `ch <- v`
+			// but a fluent helper is natural to emit through.
+			if len(c.Args) == 1 {
+				g.emitExpr(f.X)
+				g.body.write(" <- ")
+				g.emitExpr(c.Args[0].Value)
+				return true
+			}
+		}
+	case "Handle":
+		if f.Name == "join" {
+			g.emitExpr(f.X)
+			g.body.write(".Join()")
+			return true
+		}
+	case "TaskGroup":
+		switch f.Name {
+		case "spawn":
+			if len(c.Args) == 1 {
+				g.needTaskGroup = true
+				g.needHandle = true
+				inner, isUnit := g.handleInnerTypeFromCall(c)
+				g.body.writef("spawnInGroup[%s](", inner)
+				g.emitExpr(f.X)
+				g.body.write(", ")
+				g.emitSpawnClosure(c.Args[0].Value, isUnit)
+				g.body.write(")")
+				return true
+			}
+		case "cancel":
+			g.emitExpr(f.X)
+			g.body.write(".Cancel()")
+			return true
+		case "isCancelled":
+			g.emitExpr(f.X)
+			g.body.write(".IsCancelled()")
+			return true
+		}
+	}
+	return false
+}
+
+// emitOptionalMethodCall lowers Option<T> methods to pointer checks.
+// Option<T> / T? is represented as *T in generated Go, so these methods
+// cannot be emitted as ordinary selector calls.
+func (g *gen) emitOptionalMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.IsOptional {
+		return false
+	}
+	inner, ok := optionInnerType(g.typeOf(f.X))
+	if !ok {
+		return false
+	}
+	innerGo := "any"
+	if inner != nil {
+		innerGo = g.goType(inner)
+	}
+	switch f.Name {
+	case "isSome", "isNone":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(")
+		g.emitExpr(f.X)
+		if f.Name == "isSome" {
+			g.body.write(" != nil)")
+		} else {
+			g.body.write(" == nil)")
+		}
+		return true
+	case "unwrap":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write(`; if opt == nil { panic("called unwrap on None") }; return *opt }()`)
+		return true
+	case "expect":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; var msg string = ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { panic(msg) }; return *opt }()")
+		return true
+	case "unwrapOr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var fallback %s = ", innerGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return *opt }; return fallback }()")
+		return true
+	case "unwrapOrElse":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() %s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; fallback := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return *opt }; return fallback() }()")
+		return true
+	case "and":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var other %s = ", retGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return other }; return nil }()")
+		return true
+	case "andThen":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { return nil }; return f(*opt) }()")
+		return true
+	case "or":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var other %s = ", retGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return opt }; return other }()")
+		return true
+	case "orElse":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() *%s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; fallback := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { return opt }; return fallback() }()")
+		return true
+	case "xor":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.goType(g.typeOf(c))
+		g.body.writef("func() %s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.writef("; var other %s = ", retGo)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { if other == nil { return opt }; return nil }; return other }()")
+		return true
+	case "filter":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() *%s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; pred := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { return nil }; if pred(*opt) { return opt }; return nil }()")
+		return true
+	case "inspect":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() *%s { opt := ", innerGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt != nil { f(*opt) }; return opt }()")
+		return true
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := "any"
+		if retInner, ok := optionInnerType(g.typeOf(c)); ok && retInner != nil {
+			retGo = g.goType(retInner)
+		} else if fn, ok := g.typeOf(c.Args[0].Value).(*types.FnType); ok && fn.Return != nil {
+			retGo = g.goType(fn.Return)
+		}
+		g.body.writef("func() *%s { opt := ", retGo)
+		g.emitExpr(f.X)
+		g.body.write("; f := ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("; if opt == nil { return nil }; var value ")
+		g.body.write(retGo)
+		g.body.write(" = f(*opt); return &value }()")
+		return true
+	case "orError", "okOr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		okGo, errGo := innerGo, "any"
+		if n, ok := types.AsNamedByName(g.typeOf(c), "Result"); ok && len(n.Args) == 2 {
+			okGo = g.goType(n.Args[0])
+			errGo = g.goType(n.Args[1])
+		}
+		resultGo := "Result[" + okGo + ", " + errGo + "]"
+		g.body.writef("func() %s { opt := ", resultGo)
+		g.emitExpr(f.X)
+		g.body.write("; var msg string = ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; if opt != nil { return resultOk[%s, %s](*opt) }; return resultErr[%s, %s](msg) }()",
+			okGo, errGo, okGo, errGo)
+		return true
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("fmt")
+		g.body.write("func() string { opt := ")
+		g.emitExpr(f.X)
+		g.body.write(`; if opt == nil { return "None" }; return fmt.Sprintf("Some(%v)", *opt) }()`)
+		return true
+	}
+	return false
+}
+
+func optionInnerType(t types.Type) (types.Type, bool) {
+	switch v := t.(type) {
+	case *types.Optional:
+		return v.Inner, true
+	case *types.Named:
+		if v.Sym != nil && v.Sym.Name == "Option" && len(v.Args) == 1 {
+			return v.Args[0], true
+		}
+	}
+	return nil, false
+}
+
+func (g *gen) emitRandomGenericMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.Name != "choice" && f.Name != "shuffle" {
+		return false
+	}
+	recvT := g.typeOf(f.X)
+	n, ok := recvT.(*types.Named)
+	if !ok || n.Sym == nil || n.Sym.Name != "Rng" {
+		return false
+	}
+	if len(c.Args) != 1 {
+		return false
+	}
+	elemGo := "any"
+	if itemsT := g.typeOf(c.Args[0].Value); itemsT != nil {
+		if list, ok := itemsT.(*types.Named); ok && list.Sym != nil && list.Sym.Name == "List" && len(list.Args) == 1 {
+			elemGo = g.goType(list.Args[0])
+		}
+	}
+	switch f.Name {
+	case "choice":
+		g.body.writef("rngChoice[%s](", elemGo)
+	case "shuffle":
+		g.body.writef("rngShuffle[%s](", elemGo)
+	}
+	g.emitExpr(f.X)
+	g.body.write(", ")
+	g.emitExpr(c.Args[0].Value)
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitCollectionMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	n, ok := g.typeOf(f.X).(*types.Named)
+	if !ok || n.Sym == nil {
+		return false
+	}
+	switch n.Sym.Name {
+	case "List", "Iter":
+		return g.emitListMethod(c, f, n)
+	case "Map":
+		return g.emitMapMethod(c, f, n)
+	case "Set":
+		return g.emitSetMethod(c, f, n)
+	}
+	return false
+}
+
+func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
+	if len(n.Args) != 1 {
+		return false
+	}
+	elemGo := g.goType(n.Args[0])
+	listGo := g.goType(n)
+	target := g.renderExpr(f.X)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "count":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "iter":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitExpr(f.X)
+	case "toList":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.writeln("return out")
+		})
+	case "first":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			g.body.writef("if len(%s) == 0 { return nil }\n", xs)
+			g.body.writef("v := %s[0]\n", xs)
+			g.body.writeln("return &v")
+		})
+	case "last":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			g.body.writef("if len(%s) == 0 { return nil }\n", xs)
+			g.body.writef("v := %s[len(%s)-1]\n", xs, xs)
+			g.body.writeln("return &v")
+		})
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			idx := g.freshVar("_idx")
+			g.body.writef("%s := ", idx)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 || %s >= len(%s) { return nil }\n", idx, idx, xs)
+			g.body.writef("v := %s[%s]\n", xs, idx)
+			g.body.writeln("return &v")
+		})
+	case "contains":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("reflect")
+		g.emitCollectionIIFE("bool", f.X, func(xs string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { if reflect.DeepEqual(v, %s) { return true } }\n", xs, item)
+			g.body.writeln("return false")
+		})
+	case "indexOf":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("reflect")
+		g.emitCollectionIIFE("*int", f.X, func(xs string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for i, v := range %s { if reflect.DeepEqual(v, %s) { idx := i; return &idx } }\n", xs, item)
+			g.body.writeln("return nil")
+		})
+	case "find":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+elemGo, f.X, func(xs string) {
+			pred := g.freshVar("_pred")
+			g.body.writef("%s := ", pred)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { if %s(v) { found := v; return &found } }\n", xs, pred)
+			g.body.writeln("return nil")
+		})
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]any")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			fn := g.freshVar("_fn")
+			g.body.writef("%s := ", fn)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("for i, v := range %s { out[i] = %s(v) }\n", xs, fn)
+			g.body.writeln("return out")
+		})
+	case "filter":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			pred := g.freshVar("_pred")
+			g.body.writef("%s := ", pred)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, xs)
+			g.body.writef("for _, v := range %s { if %s(v) { out = append(out, v) } }\n", xs, pred)
+			g.body.writeln("return out")
+		})
+	case "fold":
+		if len(c.Args) != 2 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "any")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			acc := g.freshVar("_acc")
+			fn := g.freshVar("_fn")
+			g.body.writef("%s := ", acc)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("%s := ", fn)
+			g.emitExpr(c.Args[1].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { %s = %s(%s, v) }\n", xs, acc, fn, acc)
+			g.body.writef("return %s\n", acc)
+		})
+	case "sorted":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("sort")
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.write("sort.Slice(out, func(i, j int) bool { return ")
+			g.emitCollectionLess("out[i]", "out[j]", n.Args[0])
+			g.body.writeln(" })")
+			g.body.writeln("return out")
+		})
+	case "sortedBy":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("sort")
+		retGo := g.callReturnGo(c, listGo)
+		keyRet := g.collectionCallbackReturnType(c)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			key := g.freshVar("_key")
+			g.body.writef("%s := ", key)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.write("sort.Slice(out, func(i, j int) bool { return ")
+			g.emitCollectionLess(key+"(out[i])", key+"(out[j])", keyRet)
+			g.body.writeln(" })")
+			g.body.writeln("return out")
+		})
+	case "reversed":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("copy(out, %s)\n", xs)
+			g.body.writeln("for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 { out[i], out[j] = out[j], out[i] }")
+			g.body.writeln("return out")
+		})
+	case "appended":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+1)\n", retGo, xs)
+			g.body.writef("out = append(out, %s...)\n", xs)
+			g.body.writef("out = append(out, %s)\n", item)
+			g.body.writeln("return out")
+		})
+	case "concat":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+len(%s))\n", retGo, xs, other)
+			g.body.writef("out = append(out, %s...)\n", xs)
+			g.body.writef("out = append(out, %s...)\n", other)
+			g.body.writeln("return out")
+		})
+	case "chain":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+len(%s))\n", retGo, xs, other)
+			g.body.writef("out = append(out, %s...)\n", xs)
+			g.body.writef("out = append(out, %s...)\n", other)
+			g.body.writeln("return out")
+		})
+	case "zip":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]struct{F0 any; F1 any}")
+		elemRetGo := g.collectionListElemGo(g.typeOf(c), "struct{F0 any; F1 any}")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("n := len(%s)\n", xs)
+			g.body.writef("if len(%s) < n { n = len(%s) }\n", other, other)
+			g.body.writef("out := make(%s, n)\n", retGo)
+			g.body.writef("for i := 0; i < n; i++ { out[i] = %s{F0: %s[i], F1: %s[i]} }\n", elemRetGo, xs, other)
+			g.body.writeln("return out")
+		})
+	case "enumerate":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]struct{F0 int; F1 "+elemGo+"}")
+		elemRetGo := g.collectionListElemGo(g.typeOf(c), "struct{F0 int; F1 "+elemGo+"}")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("for i, v := range %s { out[i] = %s{F0: i, F1: v} }\n", xs, elemRetGo)
+			g.body.writeln("return out")
+		})
+	case "take":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			limit := g.freshVar("_n")
+			g.body.writef("%s := ", limit)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 { %s = 0 }\n", limit, limit)
+			g.body.writef("if %s > len(%s) { %s = len(%s) }\n", limit, xs, limit, xs)
+			g.body.writef("out := make(%s, %s)\n", retGo, limit)
+			g.body.writef("copy(out, %s[:%s])\n", xs, limit)
+			g.body.writeln("return out")
+		})
+	case "takeWhile":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			pred := g.freshVar("_pred")
+			g.body.writef("%s := ", pred)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, xs)
+			g.body.writef("for _, v := range %s { if !%s(v) { break }; out = append(out, v) }\n", xs, pred)
+			g.body.writeln("return out")
+		})
+	case "skip":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, listGo)
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			start := g.freshVar("_n")
+			g.body.writef("%s := ", start)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 { %s = 0 }\n", start, start)
+			g.body.writef("if %s > len(%s) { %s = len(%s) }\n", start, xs, start, xs)
+			g.body.writef("out := make(%s, len(%s)-%s)\n", retGo, xs, start)
+			g.body.writef("copy(out, %s[%s:])\n", xs, start)
+			g.body.writeln("return out")
+		})
+	case "forEach":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("struct{}", f.X, func(xs string) {
+			fn := g.freshVar("_fn")
+			g.body.writef("%s := ", fn)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("for _, v := range %s { %s(v) }\n", xs, fn)
+			g.body.writeln("return struct{}{}")
+		})
+	case "toSet":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "map["+elemGo+"]struct{}")
+		g.emitCollectionIIFE(retGo, f.X, func(xs string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, xs)
+			g.body.writef("for _, v := range %s { out[v] = struct{}{} }\n", xs)
+			g.body.writeln("return out")
+		})
+	case "push":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.write("func() { ")
+		g.body.write(target)
+		g.body.write(" = append(")
+		g.body.write(target)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(") }()")
+	case "pop":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() *%s { if len(%s) == 0 { return nil }; v := %s[len(%s)-1]; var zero %s; %s[len(%s)-1] = zero; %s = %s[:len(%s)-1]; return &v }()",
+			elemGo, target, target, target, elemGo, target, target, target, target, target)
+	case "insert":
+		if len(c.Args) != 2 {
+			return false
+		}
+		idx := g.freshVar("_idx")
+		item := g.freshVar("_item")
+		g.body.writef("func() { %s := ", idx)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; %s := ", item)
+		g.emitExpr(c.Args[1].Value)
+		g.body.writef("; if %s < 0 || %s > len(%s) { panic(\"List.insert index out of range\") }; var zero %s; %s = append(%s, zero); copy(%s[%s+1:], %s[%s:]); %s[%s] = %s }()",
+			idx, idx, target, elemGo, target, target, target, idx, target, idx, target, idx, item)
+	case "removeAt":
+		if len(c.Args) != 1 {
+			return false
+		}
+		idx := g.freshVar("_idx")
+		g.body.writef("func() %s { %s := ", elemGo, idx)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; v := %s[%s]; copy(%s[%s:], %s[%s+1:]); var zero %s; %s[len(%s)-1] = zero; %s = %s[:len(%s)-1]; return v }()",
+			target, idx, target, idx, target, idx, elemGo, target, target, target, target, target)
+	case "sort":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("sort")
+		g.body.writef("func() { xs := %s; sort.Slice(xs, func(i, j int) bool { return ", target)
+		g.emitCollectionLess("xs[i]", "xs[j]", n.Args[0])
+		g.body.write(" }) }()")
+	case "reverse":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { xs := %s; for i, j := 0, len(xs)-1; i < j; i, j = i+1, j-1 { xs[i], xs[j] = xs[j], xs[i] } }()", target)
+	case "clear":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { %s = %s[:0] }()", target, target)
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitMapMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
+	if len(n.Args) != 2 {
+		return false
+	}
+	keyGo := g.goType(n.Args[0])
+	valGo := g.goType(n.Args[1])
+	mapGo := g.goType(n)
+	target := g.renderExpr(f.X)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("*"+valGo, f.X, func(m string) {
+			key := g.freshVar("_key")
+			g.body.writef("%s := ", key)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("v, ok := %s[%s]\n", m, key)
+			g.body.writeln("if !ok { return nil }")
+			g.body.writeln("return &v")
+		})
+	case "containsKey":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("bool", f.X, func(m string) {
+			key := g.freshVar("_key")
+			g.body.writef("%s := ", key)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("_, ok := %s[%s]\n", m, key)
+			g.body.writeln("return ok")
+		})
+	case "keys":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]"+keyGo)
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, m)
+			g.body.writef("for k := range %s { out = append(out, k) }\n", m)
+			g.body.writeln("return out")
+		})
+	case "values":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]"+valGo)
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, m)
+			g.body.writef("for _, v := range %s { out = append(out, v) }\n", m)
+			g.body.writeln("return out")
+		})
+	case "entries", "iter", "toList":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]struct{F0 "+keyGo+"; F1 "+valGo+"}")
+		elemRetGo := g.collectionListElemGo(g.typeOf(c), "struct{F0 "+keyGo+"; F1 "+valGo+"}")
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, m)
+			g.body.writef("for k, v := range %s { out = append(out, %s{F0: k, F1: v}) }\n", m, elemRetGo)
+			g.body.writeln("return out")
+		})
+	case "insert":
+		if len(c.Args) != 2 {
+			return false
+		}
+		key := g.freshVar("_key")
+		val := g.freshVar("_val")
+		g.body.writef("func() { if %s == nil { %s = %s{} }; %s := ", target, target, mapGo, key)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; %s := ", val)
+		g.emitExpr(c.Args[1].Value)
+		g.body.writef("; %s[%s] = %s }()", target, key, val)
+	case "remove":
+		if len(c.Args) != 1 {
+			return false
+		}
+		key := g.freshVar("_key")
+		g.body.writef("func() *%s { %s := ", valGo, key)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; v, ok := %s[%s]; if !ok { return nil }; delete(%s, %s); return &v }()", target, key, target, key)
+	case "clear":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { clear(%s) }()", target)
+	case "toMap":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, mapGo)
+		g.emitCollectionIIFE(retGo, f.X, func(m string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, m)
+			g.body.writef("for k, v := range %s { out[k] = v }\n", m)
+			g.body.writeln("return out")
+		})
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitSetMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
+	if len(n.Args) != 1 {
+		return false
+	}
+	elemGo := g.goType(n.Args[0])
+	setGo := g.goType(n)
+	target := g.renderExpr(f.X)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "contains":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCollectionIIFE("bool", f.X, func(s string) {
+			item := g.freshVar("_item")
+			g.body.writef("%s := ", item)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("_, ok := %s[%s]\n", s, item)
+			g.body.writeln("return ok")
+		})
+	case "union", "intersect", "difference":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, setGo)
+		g.emitCollectionIIFE(retGo, f.X, func(s string) {
+			other := g.freshVar("_other")
+			g.body.writef("%s := ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			switch f.Name {
+			case "union":
+				g.body.writef("out := make(%s, len(%s)+len(%s))\n", retGo, s, other)
+				g.body.writef("for v := range %s { out[v] = struct{}{} }\n", s)
+				g.body.writef("for v := range %s { out[v] = struct{}{} }\n", other)
+			case "intersect":
+				g.body.writef("out := make(%s)\n", retGo)
+				g.body.writef("for v := range %s { if _, ok := %s[v]; ok { out[v] = struct{}{} } }\n", s, other)
+			case "difference":
+				g.body.writef("out := make(%s)\n", retGo)
+				g.body.writef("for v := range %s { if _, ok := %s[v]; !ok { out[v] = struct{}{} } }\n", s, other)
+			}
+			g.body.writeln("return out")
+		})
+	case "insert":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("func() { if %s == nil { %s = %s{} }; %s[", target, target, setGo, target)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write("] = struct{}{} }()")
+	case "remove":
+		if len(c.Args) != 1 {
+			return false
+		}
+		item := g.freshVar("_item")
+		g.body.writef("func() bool { %s := ", item)
+		g.emitExpr(c.Args[0].Value)
+		g.body.writef("; _, ok := %s[%s]; if ok { delete(%s, %s) }; return ok }()", target, item, target, item)
+	case "clear":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.writef("func() { clear(%s) }()", target)
+	case "iter", "toList":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]"+elemGo)
+		g.emitCollectionIIFE(retGo, f.X, func(s string) {
+			g.body.writef("out := make(%s, 0, len(%s))\n", retGo, s)
+			g.body.writef("for v := range %s { out = append(out, v) }\n", s)
+			g.body.writeln("return out")
+		})
+	case "toSet":
+		if len(c.Args) != 0 {
+			return false
+		}
+		retGo := g.callReturnGo(c, setGo)
+		g.emitCollectionIIFE(retGo, f.X, func(s string) {
+			g.body.writef("out := make(%s, len(%s))\n", retGo, s)
+			g.body.writef("for v := range %s { out[v] = struct{}{} }\n", s)
+			g.body.writeln("return out")
+		})
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitCollectionIIFE(retGo string, recv ast.Expr, body func(recvVar string)) {
+	recvVar := g.freshVar("_col")
+	g.body.write("func()")
+	if retGo != "" {
+		g.body.write(" ")
+		g.body.write(retGo)
+	}
+	g.body.writeln(" {")
+	g.body.indent()
+	g.body.writef("%s := ", recvVar)
+	g.emitExpr(recv)
+	g.body.nl()
+	body(recvVar)
+	g.body.dedent()
+	g.body.write("}()")
+}
+
+func (g *gen) renderExpr(e ast.Expr) string {
+	old := g.body
+	w := newWriter()
+	g.body = w
+	defer func() { g.body = old }()
+	g.emitExpr(e)
+	return string(w.bytes())
+}
+
+func (g *gen) callReturnGo(c *ast.CallExpr, fallback string) string {
+	if t := g.typeOf(c); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		return g.goType(t)
+	}
+	return fallback
+}
+
+func (g *gen) collectionCallbackReturnType(c *ast.CallExpr) types.Type {
+	if len(c.Args) != 1 {
+		return nil
+	}
+	if fn, ok := types.AsFn(g.typeOf(c.Args[0].Value)); ok {
+		return fn.Return
+	}
+	return nil
+}
+
+func (g *gen) emitCollectionLess(left, right string, t types.Type) {
+	if p, ok := t.(*types.Primitive); ok {
+		switch p.Kind {
+		case types.PBool:
+			g.body.writef("(!%s && %s)", left, right)
+			return
+		case types.PBytes:
+			g.use("bytes")
+			g.body.writef("bytes.Compare(%s, %s) < 0", left, right)
+			return
+		}
+	}
+	g.body.writef("%s < %s", left, right)
+}
+
+func (g *gen) collectionListElemGo(t types.Type, fallback string) string {
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && (n.Sym.Name == "List" || n.Sym.Name == "Iter") && len(n.Args) == 1 {
+		return g.goType(n.Args[0])
+	}
+	return strings.TrimPrefix(fallback, "[]")
+}
+
+// emitTurbofishCall handles the two concurrency intrinsics that use the
+// turbofish syntax to pin a type argument:
+//
+//	thread.chan::<T>(cap)  → make(chan T, cap)
+//	thread.spawn::<T>(f)   → spawnHandle[T](f)
+//
+// Returns false when the turbofish base isn't a recognized intrinsic.
+// The base has already been confirmed as the Fn of a CallExpr.
+func (g *gen) emitTurbofishCall(c *ast.CallExpr, tf *ast.TurbofishExpr) bool {
+	fe, ok := tf.Base.(*ast.FieldExpr)
+	if !ok {
+		return false
+	}
+	head, ok := fe.X.(*ast.Ident)
+	if !ok || head.Name != "thread" {
+		return false
+	}
+	switch fe.Name {
+	case "chan":
+		inner := "any"
+		if len(tf.Args) == 1 {
+			inner = g.goTypeExpr(tf.Args[0])
+		}
+		g.body.writef("make(chan %s", inner)
+		if len(c.Args) >= 1 {
+			g.body.write(", ")
+			g.emitExpr(c.Args[0].Value)
+		}
+		g.body.write(")")
+		return true
+	case "spawn":
+		g.needHandle = true
+		inner := "any"
+		if len(tf.Args) == 1 {
+			inner = g.goTypeExpr(tf.Args[0])
+		}
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.body.writef("spawnHandle[%s](", inner)
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
+// emitThreadCall intercepts non-turbofish thread.* helpers like
+// `thread.sleep(dur)` and `thread.yield()`.
+func (g *gen) emitThreadCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	head, ok := f.X.(*ast.Ident)
+	if !ok || head.Name != "thread" {
+		return false
+	}
+	switch f.Name {
+	case "collectAll":
+		if g.emitThreadCollectAll(c) {
+			return true
+		}
+	case "race":
+		if g.emitThreadRace(c) {
+			return true
+		}
+	case "isCancelled":
+		if len(c.Args) == 0 {
+			g.body.write("false")
+			return true
+		}
+	case "sleep":
+		// thread.sleep(dur) → time.Sleep(dur)
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("time")
+		g.body.write("time.Sleep(")
+		g.emitDurationExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "yield":
+		// thread.yield() → runtime.Gosched()
+		g.use("runtime")
+		g.body.write("runtime.Gosched()")
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitThreadCollectAll(c *ast.CallExpr) bool {
+	param, spawns, ok := g.threadGroupSpawnCalls(c)
+	if !ok || len(spawns) == 0 {
+		return false
+	}
+	g.needTaskGroup = true
+	g.needHandle = true
+	inner := g.spawnCallInnerGo(spawns[0])
+	ret := g.listReturnGo(c, inner)
+	g.body.writef("runTaskGroup[%s](func(%s *TaskGroup) %s {\n", ret, param, ret)
+	g.body.indent()
+	handles := make([]string, len(spawns))
+	for i, sp := range spawns {
+		h := g.freshVar("_h")
+		handles[i] = h
+		g.body.writef("%s := spawnInGroup[%s](%s, ", h, inner, param)
+		g.emitSpawnClosure(sp.Args[0].Value, types.IsUnit(g.closureReturnType(sp.Args[0].Value)))
+		g.body.writeln(")")
+	}
+	g.body.writef("return %s{", ret)
+	for i, h := range handles {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.writef("%s.Join()", h)
+	}
+	g.body.writeln("}")
+	g.body.dedent()
+	g.body.write("})")
+	return true
+}
+
+func (g *gen) emitThreadRace(c *ast.CallExpr) bool {
+	param, spawns, ok := g.threadGroupSpawnCalls(c)
+	if !ok || len(spawns) == 0 {
+		return false
+	}
+	g.needTaskGroup = true
+	g.needHandle = true
+	inner := g.spawnCallInnerGo(spawns[0])
+	g.body.writef("runTaskGroup[%s](func(%s *TaskGroup) %s {\n", inner, param, inner)
+	g.body.indent()
+	handles := make([]string, len(spawns))
+	for i, sp := range spawns {
+		h := g.freshVar("_h")
+		handles[i] = h
+		g.body.writef("%s := spawnInGroup[%s](%s, ", h, inner, param)
+		g.emitSpawnClosure(sp.Args[0].Value, types.IsUnit(g.closureReturnType(sp.Args[0].Value)))
+		g.body.writeln(")")
+	}
+	g.body.writeln("select {")
+	g.body.indent()
+	for _, h := range handles {
+		g.body.writef("case v := <-%s.result:\n", h)
+		g.body.indent()
+		g.body.writeln("return v")
+		g.body.dedent()
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.dedent()
+	g.body.write("})")
+	return true
+}
+
+func (g *gen) threadGroupSpawnCalls(c *ast.CallExpr) (string, []*ast.CallExpr, bool) {
+	if c == nil || len(c.Args) != 1 {
+		return "", nil, false
+	}
+	cl, ok := c.Args[0].Value.(*ast.ClosureExpr)
+	if !ok || len(cl.Params) == 0 {
+		return "", nil, false
+	}
+	param := "g"
+	if cl.Params[0].Name != "" {
+		param = mangleIdent(cl.Params[0].Name)
+	}
+	list, ok := cl.Body.(*ast.ListExpr)
+	if !ok {
+		return "", nil, false
+	}
+	spawns := make([]*ast.CallExpr, 0, len(list.Elems))
+	for _, e := range list.Elems {
+		call, ok := e.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return "", nil, false
+		}
+		fx, ok := call.Fn.(*ast.FieldExpr)
+		if !ok || fx.Name != "spawn" {
+			return "", nil, false
+		}
+		if id, ok := fx.X.(*ast.Ident); !ok || mangleIdent(id.Name) != param {
+			return "", nil, false
+		}
+		spawns = append(spawns, call)
+	}
+	return param, spawns, true
+}
+
+func (g *gen) spawnCallInnerGo(call *ast.CallExpr) string {
+	if call == nil || len(call.Args) != 1 {
+		return "any"
+	}
+	t := g.closureReturnType(call.Args[0].Value)
+	if t == nil || types.IsError(t) {
+		return "any"
+	}
+	if types.IsUnit(t) {
+		return "struct{}"
+	}
+	return g.goType(t)
+}
+
+func (g *gen) closureReturnType(e ast.Expr) types.Type {
+	if t := g.typeOf(e); t != nil {
+		if fn, ok := t.(*types.FnType); ok {
+			return fn.Return
+		}
+	}
+	return nil
+}
+
+func (g *gen) listReturnGo(call *ast.CallExpr, elemGo string) string {
+	if t := g.typeOf(call); t != nil {
+		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
+			return g.goType(t)
+		}
+	}
+	return "[]" + elemGo
+}
+
+// emitVariantCtor writes `Shape(Shape_Circle{F0: a0, F1: a1})` for
+// `Circle(a0, a1)`. The outer `Enum(...)` conversion forces the value
+// to the enum interface type so downstream type assertions work even
+// when the value flows through a generic position like a `let` short-form.
+func (g *gen) emitVariantCtor(owner, name string, args []*ast.Arg) {
+	g.body.writef("%s(&%s_%s{", owner, owner, name)
+	for i, a := range args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.writef("F%d: ", i)
+		g.emitExpr(a.Value)
+	}
+	g.body.write("})")
+}
+
+func (g *gen) qualifiedVariant(f *ast.FieldExpr) (owner, variant string, ok bool) {
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+	owner = id.Name
+	if owner == "Self" {
+		owner = g.selfType
+	}
+	if owner == "" || !g.enumTypes[owner] {
+		return "", "", false
+	}
+	if got, found := g.variantOwner[f.Name]; !found || got != owner {
+		return "", "", false
+	}
+	return owner, f.Name, true
+}
+
+// emitStaticCall rewrites `TypeName.fnName(args)` as `TypeName_fnName(args)`
+// when TypeName is a struct or enum declared in this file. `Self.new(...)`
+// inside a method body also flows here. Returns false when the head does
+// not look like a type reference, letting the default path handle it.
+func (g *gen) emitStaticCall(f *ast.FieldExpr, args []*ast.Arg) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	typeName := id.Name
+	if typeName == "Self" {
+		if g.selfType == "" {
+			return false
+		}
+		typeName = g.selfType
+	}
+	methods, known := g.methodNames[typeName]
+	if !known {
+		return false
+	}
+	if !methods[f.Name] {
+		return false
+	}
+	// Is this actually an associated (static) function, or an instance
+	// method being called on an instance? If Ident resolves to a type
+	// symbol it's static; otherwise we fall through.
+	sym := g.symbolFor(id)
+	if sym == nil {
+		return false
+	}
+	if sym.Kind != resolve.SymStruct && sym.Kind != resolve.SymEnum && typeName != g.selfType {
+		return false
+	}
+	g.body.writef("%s_%s(", typeName, f.Name)
+	for i, a := range args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+	return true
+}
+
+func (g *gen) emitResultMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	n, ok := types.AsNamedBuiltin(g.typeOf(f.X), "Result")
+	if !ok || len(n.Args) != 2 {
+		return false
+	}
+	switch f.Name {
+	case "and":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultAnd(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "andThen":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultAndThen(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "or":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultOr(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "orElse":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultOrElse(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "map":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultMap(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	case "mapErr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.needResult = true
+		g.body.write("resultMapErr(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
+// emitEnumMethodCall rewrites `enumValue.method(args)` as
+// `EnumName_method(enumValue, args)` when the value's type is a
+// user-declared enum in this file.
+func (g *gen) emitEnumMethodCall(f *ast.FieldExpr, args []*ast.Arg) bool {
+	t := g.typeOf(f.X)
+	n, ok := t.(*types.Named)
+	if !ok || n.Sym == nil {
+		return false
+	}
+	if !g.enumTypes[n.Sym.Name] {
+		return false
+	}
+	methods := g.methodNames[n.Sym.Name]
+	if methods == nil || !methods[f.Name] {
+		return false
+	}
+	g.body.writef("%s_%s(", n.Sym.Name, f.Name)
+	g.emitExpr(f.X)
+	for _, a := range args {
+		g.body.write(", ")
+		g.emitExpr(a.Value)
+	}
+	g.body.write(")")
+	return true
+}
+
+// resultTypeArgsAt returns the (T, E) Go type strings for the Result
+// that contains expression `at`. Prefers the checker-inferred type of
+// the call expression; falls back to any when no info is available.
+func (g *gen) resultTypeArgsAt(callType types.Type, payloadType types.Type, isErr bool) (string, string) {
+	tArg, tErr := "any", "any"
+	if n, ok := callType.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" && len(n.Args) == 2 {
+		tArg = g.goType(n.Args[0])
+		tErr = g.goType(n.Args[1])
+		return tArg, tErr
+	}
+	// Fallback to payload type on the known side.
+	if payloadType != nil {
+		if isErr {
+			tErr = g.goType(payloadType)
+		} else {
+			tArg = g.goType(payloadType)
+		}
+	}
+	return tArg, tErr
+}
+
+// emitBuiltinCall handles prelude intrinsics. Returns true when it
+// produced output; false lets the generic path take over.
+func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) bool {
+	switch name {
+	case "println":
+		g.use("fmt")
+		g.body.write("fmt.Println(")
+		g.emitPrintArgList(args)
+		g.body.write(")")
+		return true
+	case "print":
+		g.use("fmt")
+		g.body.write("fmt.Print(")
+		g.emitPrintArgList(args)
+		g.body.write(")")
+		return true
+	case "eprintln":
+		g.use("fmt")
+		g.use("os")
+		g.body.write("fmt.Fprintln(os.Stderr")
+		if len(args) > 0 {
+			g.body.write(", ")
+			g.emitPrintArgList(args)
+		}
+		g.body.write(")")
+		return true
+	case "eprint":
+		g.use("fmt")
+		g.use("os")
+		g.body.write("fmt.Fprint(os.Stderr")
+		if len(args) > 0 {
+			g.body.write(", ")
+			g.emitPrintArgList(args)
+		}
+		g.body.write(")")
+		return true
+	case "dbg":
+		// Osty `dbg(x)` prints `[file:line] x = <value>` and returns x.
+		// Phase 1 simplification: route through fmt.Println and return
+		// the argument via an IIFE so it's still usable as an expression.
+		g.use("fmt")
+		g.body.write("func() any { v := ")
+		if len(args) > 0 {
+			g.emitExpr(args[0].Value)
+		} else {
+			g.body.write("nil")
+		}
+		g.body.write("; fmt.Println(\"dbg:\", v); return v }()")
+		return true
+	case "spawn":
+		// §8: spawn(|| body) → spawnHandle[T](body). The checker
+		// inferred the closure's return type; we pull it from the call
+		// expression's Handle<T> type to pin the type parameter.
+		//
+		// Unit-returning closures need a trampoline — Go treats
+		// `func()` and `func() struct{}` as distinct types — so we
+		// wrap with `func() struct{} { <closure>(); return struct{}{} }`
+		// to satisfy spawnHandle's `func() T` signature.
+		if len(args) == 1 {
+			g.needHandle = true
+			inner, isUnit := g.handleInnerTypeFromCall(call)
+			g.body.writef("spawnHandle[%s](", inner)
+			g.emitSpawnClosure(args[0].Value, isUnit)
+			g.body.write(")")
+			return true
+		}
+	case "taskGroup":
+		// §8.1: taskGroup(|g| body) → runTaskGroup[T](body).
+		// The outer call's type is T; the inner closure receives a
+		// *TaskGroup.
+		if len(args) == 1 {
+			g.needTaskGroup = true
+			g.needHandle = true
+			inner := "any"
+			if call != nil {
+				if t := g.typeOf(call); t != nil && !types.IsUnit(t) && !types.IsError(t) {
+					inner = g.goType(t)
+				} else if t != nil && types.IsUnit(t) {
+					inner = "struct{}"
+				}
+			}
+			g.body.writef("runTaskGroup[%s](", inner)
+			g.emitExpr(args[0].Value)
+			g.body.write(")")
+			return true
+		}
+	case "parallel":
+		if len(args) == 3 {
+			if itemGo, resultGo, ok := g.parallelMapTypes(call); ok {
+				g.needTaskGroup = true
+				g.body.writef("runParallelMap[%s, %s](", itemGo, resultGo)
+				g.emitExpr(args[0].Value)
+				g.body.write(", ")
+				g.emitExpr(args[1].Value)
+				g.body.write(", ")
+				g.emitExpr(args[2].Value)
+				g.body.write(")")
+				return true
+			}
+		}
+		// §8.3: parallel(|| a, || b, ...) → runParallel[T](bodies...).
+		// Every closure must return the same T; we pull T from the
+		// first argument's inferred FnType return.
+		if len(args) > 0 {
+			g.needTaskGroup = true
+			g.needHandle = true
+			inner := "any"
+			isUnit := false
+			if t := g.typeOf(args[0].Value); t != nil {
+				if fn, ok := t.(*types.FnType); ok && fn.Return != nil {
+					if types.IsUnit(fn.Return) {
+						inner = "struct{}"
+						isUnit = true
+					} else if !types.IsError(fn.Return) {
+						inner = g.goType(fn.Return)
+					}
+				}
+			}
+			g.body.writef("runParallel[%s](", inner)
+			for i, a := range args {
+				if i > 0 {
+					g.body.write(", ")
+				}
+				g.emitSpawnClosure(a.Value, isUnit)
+			}
+			g.body.write(")")
+			return true
+		}
+	case "Some":
+		if len(args) == 1 {
+			// Some(x) lowers to a typed pointer-to-copy so the result
+			// flows naturally as *T at the use site. The inner type T
+			// comes from the argument's checked type.
+			inner := "any"
+			if t := g.typeOf(args[0].Value); t != nil {
+				inner = g.goType(t)
+			}
+			g.body.writef("func() *%s { v := ", inner)
+			g.emitExpr(args[0].Value)
+			g.body.write("; return &v }()")
+			return true
+		}
+	case "Ok":
+		if len(args) == 1 {
+			g.needResult = true
+			var callType types.Type
+			if call != nil {
+				callType = g.typeOf(call)
+			}
+			tArg, tErr := g.resultTypeArgsAt(callType, g.typeOf(args[0].Value), false)
+			g.body.writef("resultOk[%s, %s](", tArg, tErr)
+			g.emitExpr(args[0].Value)
+			g.body.write(")")
+			return true
+		}
+	case "Err":
+		if len(args) == 1 {
+			g.needResult = true
+			var callType types.Type
+			if call != nil {
+				callType = g.typeOf(call)
+			}
+			tArg, tErr := g.resultTypeArgsAt(callType, g.typeOf(args[0].Value), true)
+			g.body.writef("resultErr[%s, %s](", tArg, tErr)
+			g.emitExpr(args[0].Value)
+			g.body.write(")")
+			return true
+		}
+	}
+	return false
+}
+
+func (g *gen) emitPrintArgList(args []*ast.Arg) {
+	if len(args) > 0 {
+		g.needStringRuntime = true
+	}
+	for i, a := range args {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.write("ostyToString(")
+		g.emitExpr(a.Value)
+		g.body.write(")")
+	}
+}
+
+func (g *gen) parallelMapTypes(call *ast.CallExpr) (itemGo, resultGo string, ok bool) {
+	if call == nil || len(call.Args) != 3 {
+		return "", "", false
+	}
+	itemsT := g.typeOf(call.Args[0].Value)
+	n, ok := itemsT.(*types.Named)
+	if !ok || n.Sym == nil || n.Sym.Name != "List" || len(n.Args) != 1 {
+		return "", "", false
+	}
+	itemGo = g.goType(n.Args[0])
+	resultGo = "any"
+	if t := g.typeOf(call); t != nil {
+		if ln, ok := t.(*types.Named); ok && ln.Sym != nil && ln.Sym.Name == "List" && len(ln.Args) == 1 {
+			resultGo = g.goType(ln.Args[0])
+		}
+	}
+	return itemGo, resultGo, true
+}
+
+// handleInnerTypeFromCall inspects a spawn/spawn-like call's inferred
+// Handle<T> return and returns (goType for T, isUnit). isUnit==true
+// means the caller must wrap the closure in a struct{}-returning
+// trampoline.
+func (g *gen) handleInnerTypeFromCall(call *ast.CallExpr) (string, bool) {
+	if call == nil {
+		return "any", false
+	}
+	t := g.typeOf(call)
+	if t == nil {
+		return "any", false
+	}
+	n, ok := t.(*types.Named)
+	if !ok || n.Sym == nil || n.Sym.Name != "Handle" || len(n.Args) != 1 {
+		return "any", false
+	}
+	if types.IsUnit(n.Args[0]) {
+		return "struct{}", true
+	}
+	return g.goType(n.Args[0]), false
+}
+
+// emitSpawnClosure emits the `body` argument of spawn / parallel,
+// wrapping unit-returning closures in a `func() struct{} { ...(); return struct{}{} }`
+// trampoline so it satisfies the runtime's `func() T` signature.
+func (g *gen) emitSpawnClosure(e ast.Expr, isUnit bool) {
+	if !isUnit {
+		g.emitExpr(e)
+		return
+	}
+	g.body.write("func() struct{} { ")
+	g.emitExpr(e)
+	g.body.write("(); return struct{}{} }")
+}
+
+// emitThreadSelect lowers `thread.select(|s| { ... })` to a Go
+// `select { ... }` statement wrapped in an IIFE.
+//
+// Each statement in the closure body is expected to be a method call
+// on the selector binding (`s.recv`, `s.send`, `s.timeout`, `s.default`).
+// Anything else is preserved verbatim as a Go stmt inside the IIFE,
+// which may or may not be what the author intended — but forbidding
+// it outright would be too strict for a v0 MVP.
+//
+// Returns false when the call shape doesn't match `thread.select(...)`,
+// letting the generic call emitter take over.
+func (g *gen) emitThreadSelect(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	head, ok := f.X.(*ast.Ident)
+	if !ok || head.Name != "thread" || f.Name != "select" {
+		return false
+	}
+	if len(c.Args) != 1 {
+		return false
+	}
+	cl, ok := c.Args[0].Value.(*ast.ClosureExpr)
+	if !ok {
+		return false
+	}
+	blk, ok := cl.Body.(*ast.Block)
+	if !ok {
+		return false
+	}
+	g.body.writeln("func() {")
+	g.body.indent()
+	g.body.writeln("select {")
+	for _, s := range blk.Stmts {
+		g.emitSelectArm(s)
+	}
+	g.body.writeln("}")
+	g.body.dedent()
+	g.body.write("}()")
+	return true
+}
+
+// emitSelectArm translates one `s.<kind>(...)` statement inside a
+// thread.select closure into a `case .../default:` arm.
+func (g *gen) emitSelectArm(s ast.Stmt) {
+	es, ok := s.(*ast.ExprStmt)
+	if !ok {
+		return
+	}
+	call, ok := es.X.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	fx, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return
+	}
+	switch fx.Name {
+	case "recv":
+		// s.recv(ch, |v| body) — case v, ok := <-ch: if ok { body(v) }
+		if len(call.Args) != 2 {
+			return
+		}
+		tmp := g.freshVar("_v")
+		okV := g.freshVar("_ok")
+		g.body.writef("case %s, %s := <-", tmp, okV)
+		g.emitExpr(call.Args[0].Value)
+		g.body.writef(":\n")
+		g.body.indent()
+		g.body.writef("if %s {\n", okV)
+		g.body.indent()
+		g.emitInvokeClosureArg(call.Args[1].Value, tmp)
+		g.body.dedent()
+		g.body.writeln("}")
+		g.body.dedent()
+	case "send":
+		// s.send(ch, val, || body) — case ch <- val: body()
+		if len(call.Args) != 3 {
+			return
+		}
+		g.body.write("case ")
+		g.emitExpr(call.Args[0].Value)
+		g.body.write(" <- ")
+		g.emitExpr(call.Args[1].Value)
+		g.body.writeln(":")
+		g.body.indent()
+		g.emitInvokeClosureArg(call.Args[2].Value)
+		g.body.dedent()
+	case "timeout":
+		// s.timeout(dur, || body) — case <-time.After(dur): body()
+		if len(call.Args) != 2 {
+			return
+		}
+		g.use("time")
+		g.body.write("case <-time.After(")
+		g.emitDurationExpr(call.Args[0].Value)
+		g.body.writeln("):")
+		g.body.indent()
+		g.emitInvokeClosureArg(call.Args[1].Value)
+		g.body.dedent()
+	case "default":
+		// s.default(|| body) — default: body()
+		if len(call.Args) != 1 {
+			return
+		}
+		g.body.writeln("default:")
+		g.body.indent()
+		g.emitInvokeClosureArg(call.Args[0].Value)
+		g.body.dedent()
+	}
+}
+
+// emitInvokeClosureArg emits `(<closure>)(args...)` — synthesising an
+// immediate call of the closure expression passed as an argument.
+// If the closure is a literal (ClosureExpr), its body is inlined
+// directly to avoid a redundant trampoline. Additional arg names are
+// passed positionally.
+func (g *gen) emitInvokeClosureArg(e ast.Expr, argNames ...string) {
+	if cl, ok := e.(*ast.ClosureExpr); ok {
+		// Inline: bind each closure param to the supplied arg name,
+		// then emit the body as statements.
+		for i, p := range cl.Params {
+			if i < len(argNames) && p.Name != "" {
+				g.body.writef("%s := %s\n_ = %s\n",
+					mangleIdent(p.Name), argNames[i], mangleIdent(p.Name))
+			}
+		}
+		if b, ok := cl.Body.(*ast.Block); ok {
+			g.emitStmts(b.Stmts)
+			return
+		}
+		g.emitExpr(cl.Body)
+		g.body.nl()
+		return
+	}
+	// Generic: treat as a callable value.
+	g.body.write("(")
+	g.emitExpr(e)
+	g.body.write(")(")
+	for i, n := range argNames {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.write(n)
+	}
+	g.body.writeln(")")
+}
+
+// emitDurationExpr emits an expression expected to evaluate to a
+// time.Duration. Osty's `N.s` / `N.ms` / `N.us` / `N.ns` duration-
+// literal shorthand is rewritten to `time.Second` / `time.Millisecond`
+// / `time.Microsecond` / `time.Nanosecond` here so the Go code
+// compiles. Everything else passes through verbatim.
+func (g *gen) emitDurationExpr(e ast.Expr) {
+	if f, ok := e.(*ast.FieldExpr); ok {
+		if lit, ok := f.X.(*ast.IntLit); ok {
+			unit := ""
+			switch f.Name {
+			case "s", "sec", "seconds":
+				unit = "time.Second"
+			case "ms", "millis":
+				unit = "time.Millisecond"
+			case "us", "micros":
+				unit = "time.Microsecond"
+			case "ns", "nanos":
+				unit = "time.Nanosecond"
+			case "min", "minutes":
+				unit = "time.Minute"
+			case "h", "hours":
+				unit = "time.Hour"
+			}
+			if unit != "" {
+				g.use("time")
+				g.body.writef("%s*%s", lit.Text, unit)
+				return
+			}
+		}
+	}
+	g.emitExpr(e)
+}
+
+// emitRangeExpr lowers a standalone range literal (`0..10`, `..=N`,
+// `100..`, `..`) to a Range value. The runtime Range type is injected
+// at the top of the file by the gen driver; for-in heads bypass this
+// and lower to C-style loops directly.
+func (g *gen) emitRangeExpr(r *ast.RangeExpr) {
+	g.needRange = true
+	g.body.write("Range{")
+	first := true
+	if r.Start != nil {
+		g.body.write("Start: ")
+		g.emitExpr(r.Start)
+		g.body.write(", HasStart: true")
+		first = false
+	}
+	if r.Stop != nil {
+		if !first {
+			g.body.write(", ")
+		}
+		g.body.write("Stop: ")
+		g.emitExpr(r.Stop)
+		g.body.write(", HasStop: true")
+		first = false
+	}
+	if r.Inclusive {
+		if !first {
+			g.body.write(", ")
+		}
+		g.body.write("Inclusive: true")
+	}
+	g.body.write("}")
+}
+
+// emitTupleExpr lowers `(a, b, c)` to a Go anonymous struct literal
+// `struct{F0 T0; F1 T1; F2 T2}{F0: a, F1: b, F2: c}`. Field access at
+// the tuple type is the checker's job; at the expression level we rely
+// on positional Fi naming, which matches what enum variant structs
+// already use.
+func (g *gen) emitTupleExpr(tup *ast.TupleExpr) {
+	// Prefer element types from the checker, fall back to any.
+	types_ := make([]string, len(tup.Elems))
+	for i, e := range tup.Elems {
+		if t := g.typeOf(e); t != nil {
+			types_[i] = g.goType(t)
+		} else {
+			types_[i] = "any"
+		}
+	}
+	g.body.write("struct{")
+	for i, tp := range types_ {
+		if i > 0 {
+			g.body.write("; ")
+		}
+		g.body.writef("F%d %s", i, tp)
+	}
+	g.body.write("}{")
+	for i, e := range tup.Elems {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.body.writef("F%d: ", i)
+		g.emitExpr(e)
+	}
+	g.body.write("}")
+}
+
+// emitBlockAsExpr lowers a block used in value position (e.g.
+// `let x = { ...; last }`) to an IIFE whose return type follows the
+// checker's inferred type for the block. The final expression of the
+// block becomes the IIFE's return.
+func (g *gen) emitBlockAsExpr(b *ast.Block) {
+	retType := "any"
+	if t := g.typeOf(b); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		retType = g.goType(t)
+	}
+	g.body.writef("func() %s ", retType)
+	g.emitBlockAsReturn(b, true)
+	g.body.write("()")
+}
+
+// closurePatternFallbackType synthesises a Go type for a closure param
+// whose pattern lacks an annotation and the checker couldn't infer. A
+// tuple pattern maps to an anonymous struct of int fields (matches the
+// int-default fallback for scalar closure params); anything else falls
+// back to `int`.
+func closurePatternFallbackType(p ast.Pattern) string {
+	tp, ok := p.(*ast.TuplePat)
+	if !ok {
+		return "int"
+	}
+	var b strings.Builder
+	b.WriteString("struct{")
+	for i := range tp.Elems {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString("F")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(" int")
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// emitQuestion lowers `expr?` used in expression position.
+//
+// When the enclosing statement has run the pre-lift pass, it records
+// a substitution (`tmp.Value` for Result, `*tmp` for Option) in
+// g.questionSubs and we write that directly. Otherwise we fall back
+// to an IIFE that panics on failure — only correct inside a context
+// where the caller has proved the branch is unreachable.
+func (g *gen) emitQuestion(q *ast.QuestionExpr) {
+	if sub, ok := g.questionSubs[q]; ok {
+		g.body.write(sub)
+		return
+	}
+	inner := g.typeOf(q)
+	innerType := "any"
+	if inner != nil {
+		innerType = g.goType(inner)
+	}
+	// Heuristic fallback: the operand is assumed to be an Optional.
+	// This is safe only when caller code has already handled the None
+	// branch (typically via statement-position lifting).
+	g.body.writef("func() %s { r := ", innerType)
+	g.emitExpr(q.X)
+	g.body.writef(`; if r == nil { panic("? propagation at non-lifted position") }; return *r }()`)
+}
+
+// emitField writes `x.Name` or `x?.Name`.
+//
+// Optional chaining (`x?.field`) lowers to a guarded dereference whose
+// result is still an Option. The Go form is:
+//
+//	func() *Field {
+//	    if x != nil {
+//	        v := (*x).field
+//	        return &v
+//	    }
+//	    return nil
+//	}()
+//
+// Field-type lookup comes from the checker when available.
+func (g *gen) emitField(f *ast.FieldExpr) {
+	if !f.IsOptional {
+		if owner, variant, ok := g.qualifiedVariant(f); ok {
+			g.body.writef("%s(&%s_%s{})", owner, owner, variant)
+			return
+		}
+		if g.emitQualifiedOptionField(f) {
+			return
+		}
+		if g.emitStdlibOstyField(f) {
+			return
+		}
+		if g.emitStdlibMathField(f) {
+			return
+		}
+		// Numeric literals need parens to disambiguate from float
+		// literals: `5.s` would be lexed as `5.` + `s` by Go. The
+		// Osty spec uses `5.s` for duration-literal shorthand
+		// (§10.time); the rest of the semantics are Phase 5.
+		needParen := false
+		switch f.X.(type) {
+		case *ast.IntLit, *ast.FloatLit:
+			needParen = true
+		}
+		if needParen {
+			g.body.write("(")
+			g.emitExpr(f.X)
+			g.body.write(")")
+		} else {
+			g.emitExpr(f.X)
+		}
+		g.body.write(".")
+		g.body.write(mangleIdent(f.Name))
+		return
+	}
+	inner := "any"
+	if t := g.typeOf(f); t != nil {
+		if opt, ok := t.(*types.Optional); ok {
+			inner = g.goType(opt.Inner)
+		} else {
+			inner = g.goType(t)
+		}
+	}
+	g.body.writef("func() *%s { if ", inner)
+	g.emitExpr(f.X)
+	g.body.write(" != nil { v := (*")
+	g.emitExpr(f.X)
+	g.body.writef(").%s; return &v }; return nil }()", mangleIdent(f.Name))
+}
+
+func (g *gen) emitQualifiedOptionField(f *ast.FieldExpr) bool {
+	id, ok := f.X.(*ast.Ident)
+	if !ok || !g.isStdlibPackageAlias(id, "option") || f.Name != "None" {
+		return false
+	}
+	g.body.write("nil")
+	return true
+}
+
+// emitList writes a list literal. Element type comes from the checker
+// when available; otherwise we default to `any`.
+func (g *gen) emitList(l *ast.ListExpr) {
+	elemType := "any"
+	if t := g.typeOf(l); t != nil {
+		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "List" && len(n.Args) == 1 {
+			elemType = g.goType(n.Args[0])
+		}
+	}
+	if len(l.Elems) == 0 {
+		g.body.writef("make([]%s, 0, 1)", elemType)
+		return
+	}
+	g.body.writef("[]%s{", elemType)
+	for i, e := range l.Elems {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(e)
+	}
+	g.body.write("}")
+}
+
+// emitMap writes a map literal.
+func (g *gen) emitMap(m *ast.MapExpr) {
+	kType, vType := "any", "any"
+	if t := g.typeOf(m); t != nil {
+		if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Map" && len(n.Args) == 2 {
+			kType = g.goType(n.Args[0])
+			vType = g.goType(n.Args[1])
+		}
+	}
+	g.body.writef("map[%s]%s{", kType, vType)
+	for i, e := range m.Entries {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		g.emitExpr(e.Key)
+		g.body.write(": ")
+		g.emitExpr(e.Value)
+	}
+	g.body.write("}")
+}
+
+// emitIfLetExpr lowers `if let pattern = scrut { then } else { else }`
+// used in expression position. Delegates to the match infrastructure
+// for the pattern test + bindings so every pattern form (Some, Ok,
+// VariantPat, ...) comes for free.
+func (g *gen) emitIfLetExpr(ie *ast.IfExpr) {
+	retType := "any"
+	if t := g.typeOf(ie); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		retType = g.goType(t)
+	}
+	g.body.writef("func() %s {\n", retType)
+	g.body.indent()
+	g.emitIfLetInner(ie, true)
+	g.body.dedent()
+	g.body.write("}()")
+}
+
+func structLitFieldName(typeName, field string) string {
+	if typeName == "ostyBasicError" && field == "message" {
+		return "messageText"
+	}
+	return mangleIdent(field)
+}
+
+// emitIfLetStmt lowers `if let ... = ... { ... } else { ... }` at
+// statement position (no return lift).
+func (g *gen) emitIfLetStmt(ie *ast.IfExpr) {
+	g.emitIfLetInner(ie, false)
+}
+
+// emitIfLetInner writes the `if …; bindings; …` block. When asExpr is
+// true both the then and else branches lift their final expression
+// into `return`.
+func (g *gen) emitIfLetInner(ie *ast.IfExpr, asExpr bool) {
+	tmp := g.freshVar("_il")
+	g.body.writef("%s := ", tmp)
+	g.emitExpr(ie.Cond)
+	g.body.writef("\n_ = %s\n", tmp)
+	scrutT := g.typeOf(ie.Cond)
+	g.body.write("if ")
+	g.emitPatternTest(tmp, scrutT, ie.Pattern)
+	g.body.writeln(" {")
+	g.body.indent()
+	g.emitPatternBindings(tmp, scrutT, ie.Pattern)
+	if asExpr {
+		g.body.write("return ")
+		g.emitArmBody(ie.Then)
+		g.body.nl()
+	} else {
+		for _, s := range ie.Then.Stmts {
+			g.emitStmt(s)
+		}
+	}
+	g.body.dedent()
+	switch els := ie.Else.(type) {
+	case nil:
+		g.body.writeln("}")
+	case *ast.Block:
+		g.body.writeln("} else {")
+		g.body.indent()
+		if asExpr {
+			g.body.write("return ")
+			g.emitArmBody(els)
+			g.body.nl()
+		} else {
+			for _, s := range els.Stmts {
+				g.emitStmt(s)
+			}
+		}
+		g.body.dedent()
+		g.body.writeln("}")
+	case *ast.IfExpr:
+		g.body.writeln("} else {")
+		g.body.indent()
+		g.emitIfLetInner(els, asExpr)
+		g.body.dedent()
+		g.body.writeln("}")
+	default:
+		g.body.writeln("} else {")
+		g.body.indent()
+		if asExpr {
+			g.body.write("return ")
+			g.emitExpr(els)
+			g.body.nl()
+		} else {
+			g.emitExpr(els)
+			g.body.nl()
+		}
+		g.body.dedent()
+		g.body.writeln("}")
+	}
+}
+
+// emitIfExpr lowers an Osty `if` used as an expression. The result is
+// an IIFE whose return type comes from the type checker (or `any` when
+// we have no type info).
+//
+//	if c { 1 } else { 2 }
+//
+// becomes
+//
+//	func() int {
+//	    if c { return 1 }
+//	    return 2
+//	}()
+//
+// Plain `if c { ... }` without `else` in expression position defaults
+// to returning the Go zero value of the inferred type.
+func (g *gen) emitIfExpr(ie *ast.IfExpr) {
+	if ie.IsIfLet {
+		g.emitIfLetExpr(ie)
+		return
+	}
+	retType := "any"
+	if t := g.typeOf(ie); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		retType = g.goType(t)
+	}
+	g.body.writef("func() %s {", retType)
+	g.emitIfChain(ie, true)
+	g.body.write("}()")
+}
+
+// emitIfChain writes an if (possibly with else-if / else branches).
+// When retAsExpr is true, each terminal block's final expression is
+// lifted into `return <expr>`. When false, the block runs as a
+// plain statement group.
+func (g *gen) emitIfChain(ie *ast.IfExpr, retAsExpr bool) {
+	g.body.write(" if ")
+	g.emitExpr(ie.Cond)
+	g.body.write(" ")
+	g.emitBlockMaybeReturn(ie.Then, retAsExpr)
+	switch els := ie.Else.(type) {
+	case nil:
+		// no else
+	case *ast.IfExpr:
+		g.body.write(" else")
+		g.emitIfChain(els, retAsExpr)
+	case *ast.Block:
+		g.body.write(" else ")
+		g.emitBlockMaybeReturn(els, retAsExpr)
+	default:
+		g.body.write(" else { return ")
+		g.emitExpr(els)
+		g.body.write(" }")
+	}
+}
+
+// emitBlockMaybeReturn writes `{ stmts; [return lastExpr] }` without a
+// trailing newline. When retAsExpr is false, the block emits stmts only.
+func (g *gen) emitBlockMaybeReturn(b *ast.Block, retAsExpr bool) {
+	if !retAsExpr {
+		g.emitBlockInline(b)
+		return
+	}
+	g.body.writeln("{")
+	g.body.indent()
+	stmts := b.Stmts
+	if len(stmts) > 0 {
+		last := stmts[len(stmts)-1]
+		if es, ok := last.(*ast.ExprStmt); ok {
+			for _, s := range stmts[:len(stmts)-1] {
+				g.emitStmt(s)
+			}
+			g.preLiftQuestions(es.X)
+			g.body.write("return ")
+			g.emitExpr(es.X)
+			g.body.nl()
+			g.resetQuestionSubs()
+			g.body.dedent()
+			g.body.write("}")
+			return
+		}
+	}
+	g.emitStmts(stmts)
+	g.body.dedent()
+	g.body.write("}")
+}
+
+// emitIfStmt renders an Osty `if` as a Go `if` statement — used when
+// the `if` appears at statement position (its value is discarded).
+func (g *gen) emitIfStmt(ie *ast.IfExpr) {
+	if ie.IsIfLet {
+		g.emitIfLetStmt(ie)
+		return
+	}
+	g.body.write("if ")
+	g.emitExpr(ie.Cond)
+	g.body.write(" ")
+	g.emitBlockInline(ie.Then)
+	switch els := ie.Else.(type) {
+	case nil:
+		g.body.nl()
+	case *ast.IfExpr:
+		g.body.write(" else ")
+		g.emitIfStmt(els)
+	case *ast.Block:
+		g.body.write(" else ")
+		g.emitBlockInline(els)
+		g.body.nl()
+	default:
+		g.body.write(" else { ")
+		g.emitExpr(els)
+		g.body.writeln(" }")
+	}
+}
+
+// emitClosure writes a Go closure. Simple cases map cleanly:
+//
+//	|x| x * 2                → func(x any) any { return x * 2 }
+//	|a: Int, b: Int| a + b   → func(a int, b int) int { return a + b }
+//	|x| { let y = 1; x+y }   → func(x any) any { y := 1; return x+y }
+//
+// Destructuring params (`|(k, v)| k+v`) and inferred parameter types
+// from context are Phase 3 work.
+func (g *gen) emitClosure(c *ast.ClosureExpr) {
+	// Look up the checker's inferred FnType for this closure so
+	// untyped params get a real Go type instead of `any`.
+	var inferred *types.FnType
+	if t := g.typeOf(c); t != nil {
+		if fn, ok := t.(*types.FnType); ok {
+			inferred = fn
+		}
+	}
+
+	// Destructured params get synthetic outer names; bindings for the
+	// pattern elements are emitted as the first statements of the
+	// body. This keeps the Go signature simple and lets pattern
+	// complexity accumulate inside the function.
+	type paramPlan struct {
+		outerName string
+		pattern   ast.Pattern
+		typ       types.Type
+	}
+	plans := make([]paramPlan, len(c.Params))
+
+	g.body.write("func(")
+	for i, p := range c.Params {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		name := p.Name
+		if name == "" && p.Pattern != nil {
+			name = g.freshVar("_tup")
+			plans[i].pattern = p.Pattern
+		}
+		if name == "" {
+			name = "_"
+		}
+		plans[i].outerName = name
+		g.body.write(mangleIdent(name))
+		g.body.write(" ")
+		switch {
+		case p.Type != nil:
+			g.body.write(g.goTypeExpr(p.Type))
+		case inferred != nil && i < len(inferred.Params) && !types.IsError(inferred.Params[i]):
+			plans[i].typ = inferred.Params[i]
+			g.body.write(g.goType(inferred.Params[i]))
+		case plans[i].pattern != nil:
+			// Pattern-without-annotation: synthesise a shape from the
+			// pattern (tuple → struct with int fields as default).
+			g.body.write(closurePatternFallbackType(plans[i].pattern))
+		default:
+			// Checker couldn't pin the param type (no hint, no
+			// annotation). Default to int — matches Osty's untyped-
+			// numeric default and covers the spec's closure examples.
+			// A principled fix would infer from body usage.
+			g.body.write("int")
+		}
+	}
+	_ = plans // used below when emitting body destructure bindings
+	g.body.write(") ")
+	// bodyIsVoid reports whether the closure body's tail expression
+	// resolves to Unit — used when the checker couldn't pin the return
+	// type (e.g. calls into an opaque stdlib package) but the tail is
+	// clearly a void-returning call. Without this, the default fallback
+	// emits `int` on a closure whose body actually returns nothing,
+	// producing invalid Go (`return <void-call>`).
+	bodyIsVoid := false
+	if blk, ok := c.Body.(*ast.Block); ok {
+		if len(blk.Stmts) == 0 {
+			bodyIsVoid = true
+		} else if es, ok := blk.Stmts[len(blk.Stmts)-1].(*ast.ExprStmt); ok {
+			if g.isVoidExpr(es.X) {
+				bodyIsVoid = true
+			}
+		} else {
+			bodyIsVoid = true
+		}
+	}
+	switch {
+	case c.ReturnType != nil:
+		g.body.write(g.goTypeExpr(c.ReturnType))
+		g.body.write(" ")
+	case inferred != nil && inferred.Return != nil && types.IsUnit(inferred.Return):
+		// Unit return — leave the signature as `func(args)`.
+	case inferred != nil && inferred.Return != nil && !types.IsError(inferred.Return):
+		g.body.write(g.goType(inferred.Return))
+		g.body.write(" ")
+	case bodyIsVoid:
+		// Checker lost the return type but the body is void — treat as unit.
+	default:
+		// No inferred type and no annotation — default to int for
+		// arithmetic-shaped closure bodies (`|x| x * 2`). A truly
+		// untyped closure body is a corner case; `int` matches the
+		// rest of Osty's untyped-numeric default (§2.2).
+		g.body.write("int ")
+	}
+	closureRetGo := ""
+	if c.ReturnType != nil {
+		closureRetGo = g.goTypeExpr(c.ReturnType)
+	} else if inferred != nil && inferred.Return != nil &&
+		!types.IsUnit(inferred.Return) && !types.IsError(inferred.Return) {
+		closureRetGo = g.goType(inferred.Return)
+	}
+	prevRetType := g.currentRetType
+	prevRetGo := g.currentRetGo
+	g.currentRetType = c.ReturnType
+	g.currentRetGo = closureRetGo
+	defer func() {
+		g.currentRetType = prevRetType
+		g.currentRetGo = prevRetGo
+	}()
+	// Body may be a Block (return needs to come from its final expr)
+	// or a single expression (wrap in { return <expr> }). In either
+	// case, emit destructure bindings first.
+	hasDestructure := false
+	for _, pl := range plans {
+		if pl.pattern != nil {
+			hasDestructure = true
+			break
+		}
+	}
+	wantReturn := true
+	if c.ReturnType == nil && inferred != nil && inferred.Return != nil &&
+		types.IsUnit(inferred.Return) {
+		wantReturn = false
+	}
+	// When the inferred return type is Error/missing but the body is
+	// clearly void, treat the closure as unit-returning so we don't
+	// wrap the trailing void call in a bogus `return`.
+	if c.ReturnType == nil && bodyIsVoid &&
+		(inferred == nil || inferred.Return == nil || types.IsError(inferred.Return)) {
+		wantReturn = false
+	}
+	if blk, ok := c.Body.(*ast.Block); ok && !hasDestructure {
+		g.emitBlockAsReturn(blk, wantReturn)
+		return
+	}
+	g.body.writeln("{")
+	g.body.indent()
+	for _, pl := range plans {
+		if pl.pattern == nil {
+			continue
+		}
+		g.emitPatternBindings(mangleIdent(pl.outerName), pl.typ, pl.pattern)
+	}
+	if blk, ok := c.Body.(*ast.Block); ok {
+		// Inline the block stmts then return final expr (unless the
+		// inferred return is Unit — then just run the stmts).
+		stmts := blk.Stmts
+		if wantReturn && len(stmts) > 0 {
+			last := stmts[len(stmts)-1]
+			if es, ok := last.(*ast.ExprStmt); ok {
+				for _, s := range stmts[:len(stmts)-1] {
+					g.emitStmt(s)
+				}
+				g.body.write("return ")
+				g.emitExpr(es.X)
+				g.body.nl()
+				g.body.dedent()
+				g.body.write("}")
+				return
+			}
+		}
+		g.emitStmts(stmts)
+		g.body.dedent()
+		g.body.write("}")
+		return
+	}
+	if wantReturn {
+		g.body.write("return ")
+	}
+	g.emitExpr(c.Body)
+	g.body.nl()
+	g.body.dedent()
+	g.body.write("}")
+}

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -1,0 +1,2100 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"sort"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/types"
+)
+
+// Generate translates a type-checked Osty file into Go source bytes.
+//
+// pkgName is the Go package clause to emit ("main" for executables).
+// The returned bytes are gofmt-formatted; a post-process format.Source
+// call both catches syntax bugs in the generator and normalises output.
+//
+// On a generator-internal error (unsupported construct, missing type
+// info) the error is returned; any partial output is still returned so
+// callers can inspect what was produced. On gofmt failure the raw
+// pre-format bytes are returned alongside the error.
+func Generate(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result) ([]byte, error) {
+	g := newGen(pkgName, file, res, chk)
+	return g.run()
+}
+
+// GenerateMapped is Generate with source-origin comments enabled.
+//
+// The generated Go contains `// Osty: path:line:column` markers before
+// emitted declarations and statements. CLI commands use those markers
+// to map a later `go build`, `go run`, or panic stack trace line back
+// to the nearest Osty source construct.
+func GenerateMapped(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result, sourcePath string) ([]byte, error) {
+	g := newGen(pkgName, file, res, chk)
+	g.sourcePath = sourcePath
+	return g.run()
+}
+
+// PackageIndex supplements file-local codegen knowledge with declarations
+// from sibling files in the same Osty package. Most callers generate one
+// source file in isolation and should use Generate/GenerateMapped; package
+// harnesses that merge several generated files can pass this index so
+// cross-file enum variants and methods lower the same way as local ones.
+type PackageIndex struct {
+	VariantOwner map[string]string
+	EnumTypes    map[string]bool
+	StructTypes  map[string]bool
+	MethodNames  map[string]map[string]bool
+}
+
+// GenerateMappedWithIndex is GenerateMapped with package-local declaration
+// metadata supplied by the caller. The index must contain only declarations
+// from the package being generated, not imported stdlib/workspace packages.
+func GenerateMappedWithIndex(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result, sourcePath string, idx PackageIndex) ([]byte, error) {
+	g := newGen(pkgName, file, res, chk)
+	g.sourcePath = sourcePath
+	g.applyPackageIndex(idx)
+	return g.run()
+}
+
+// gen is the transpiler state for one file.
+type gen struct {
+	pkgName string
+	file    *ast.File
+	res     *resolve.Result
+	chk     *check.Result
+
+	body    *writer           // body of the output (decls + main)
+	imports map[string]string // Go import path → alias ("" = no alias)
+
+	// errors accumulates non-fatal issues. The first fatal error
+	// shortcircuits run and is returned; non-fatal issues are reported
+	// with emitComment as `// TODO: ...` lines in the output.
+	errs []error
+
+	// loopDepth tracks nesting so break/continue can be rewritten when
+	// we later support labelled loops. Zero means top level.
+	loopDepth int
+
+	// selfType is the name of the enclosing struct/enum while we emit
+	// a method body; empty at top level. Used to rewrite `Self { ... }`
+	// struct literals and `Self`-typed return annotations.
+	selfType string
+
+	// variantOwner maps an enum variant's name to its owning enum's
+	// name. Built during the first pass so variant-construction calls
+	// can emit `Enum_Variant{...}` without another AST walk.
+	variantOwner map[string]string
+
+	// enumTypes is the set of enum names declared in this file, used
+	// to distinguish method-call rewriting between struct and enum
+	// receivers at emitCall time.
+	enumTypes map[string]bool
+
+	// structTypes is the set of struct names declared in this file.
+	// User structs lower as reference types, so expression emitters need
+	// a quick local-name check even for AST nodes that the resolver does
+	// not record in Refs.
+	structTypes map[string]bool
+
+	// methodNames[typeName] is the set of method names declared on
+	// that type, used at emitCall to distinguish instance-method
+	// invocation from field access to a function-valued field.
+	methodNames map[string]map[string]bool
+
+	// freshCounter backs freshVar for synthesized match / IIFE names.
+	freshCounter int
+
+	// needResult is set when any reference to Result<T, E> is emitted,
+	// prompting a runtime type definition at file top.
+	needResult bool
+
+	// needErrorRuntime is set when a value typed as Osty's Error
+	// interface needs dynamic message dispatch at runtime.
+	needErrorRuntime bool
+
+	// needStringRuntime is set when generated code needs the Osty
+	// toString protocol bridge for interpolation or nested stdlib
+	// toString implementations.
+	needStringRuntime bool
+
+	// needStdlibOsty/emittedStdlibOsty track stdlib modules that should
+	// be lowered from their bundled Osty source into this Go file instead
+	// of going through a Go bridge or an empty package stub.
+	needStdlibOsty    map[string]bool
+	emittedStdlibOsty map[string]bool
+
+	// stdlibInlineModule is non-empty while a bundled stdlib module is
+	// being emitted into another package. Top-level functions are renamed
+	// through stdlibInlineRenames so they cannot collide with user code.
+	stdlibInlineModule  string
+	stdlibInlineRenames map[string]string
+	emitGenericFnDecls  bool
+
+	// needRange is set when a standalone range literal is emitted, so
+	// the runtime Range struct can be injected at the top of the file.
+	needRange bool
+
+	// needHandle is set when a Handle[T] is referenced, pulling in the
+	// runtime struct that backs `taskGroup` / `spawn` results.
+	needHandle bool
+
+	// needTaskGroup is set when `taskGroup(|g| { ... })` or
+	// `parallel(...)` is emitted, pulling in the structured-concurrency
+	// runtime (TaskGroup, spawnInGroup, runTaskGroup, runParallel).
+	needTaskGroup bool
+
+	// needSelect is set when `thread.select(|s| { ... })` is lowered,
+	// pulling in the time import used by `s.timeout(...)` arms.
+	needSelect bool
+
+	// needFS / needRandomRuntime / needURLRuntime are set by stdlib use
+	// bridges whose Osty surface cannot map directly to exported Go
+	// package identifiers (for example `fs.readToString(...)`,
+	// `random.default()` and `rng.int(...)`).
+	needFS            bool
+	fsOSAlias         string
+	fsUTF8Alias       string
+	needRandomRuntime bool
+	needURLRuntime    bool
+
+	// needEncoding is set when std.encoding lowers to Go's encoding
+	// packages, pulling in base64/hex/url helper functions.
+	needEncoding bool
+
+	// needEnv is set when std.env lowers to os-backed helper functions.
+	needEnv bool
+
+	// needCsvRuntime is set when std.csv is used and needs inline
+	// Go runtime helpers (_ostyCsv* functions).
+	needCsvRuntime bool
+
+	// needJSON is set when std.json lowers to encoding/json helpers.
+	needJSON bool
+
+	// needCompress is set when std.compress lowers to gzip helpers.
+	needCompress bool
+
+	// needCrypto is set when std.crypto lowers to hashing/HMAC/CSPRNG
+	// helper functions.
+	needCrypto bool
+
+	// needUUID is set when std.uuid lowers to the runtime Uuid type and
+	// generation/parsing helpers.
+	needUUID bool
+
+	// needBytesRuntime is set when Bytes primitive methods need runtime
+	// helpers backed by Go's bytes package.
+	needBytesRuntime bool
+
+	// needRegex is set when std.regex lowers to the built-in pure-Go
+	// regex engine (no dependency on Go's regexp package).
+	needRegex bool
+
+	// needRefRuntime is set when std.ref.same lowers to the runtime
+	// reference-identity helper.
+	needRefRuntime bool
+
+	// needEqualRuntime is set when ==/!= need Osty's structural equality
+	// instead of Go's pointer/interface identity for lowered reference values.
+	needEqualRuntime bool
+
+	// currentRetType tracks the enclosing function's return type so the
+	// `?` lift at let-stmt position can reconstruct the Result with the
+	// correct type parameters when the operand's T differs.
+	currentRetType ast.Type
+
+	// currentRetGo is the same contract after semantic inference. It is
+	// needed for closures, whose return type often comes from context
+	// rather than an explicit AST annotation.
+	currentRetGo string
+
+	// questionSubs maps a QuestionExpr AST node to the Go expression
+	// text that should be emitted in its place. Populated by the
+	// statement-level pre-lift pass (see preLiftQuestions); consumed by
+	// emitQuestion. Nil when no lift is in progress.
+	questionSubs map[*ast.QuestionExpr]string
+
+	// instQueue is the pending list of generic-fn monomorphizations
+	// that still need to be emitted. emitCall appends to this queue
+	// each time it encounters a generic call site whose (sym, type
+	// tuple) pair hasn't yet been emitted; drainInstances walks the
+	// queue to a fixed point after the normal decl pass so transitive
+	// instantiations (a generic body calling another generic fn) are
+	// materialized (§2.7.3).
+	instQueue []instRecord
+
+	// instByKey dedupes the queue — maps (sym, goTypes) key to the
+	// mangled name already assigned. Read by callers that need the
+	// mangled name without re-enqueueing.
+	instByKey map[string]string
+
+	// substEnv is the current generic-parameter → Go-type substitution
+	// environment. Non-empty only while we emit inside a monomorphized
+	// body; goTypeExpr and goType consult it so every reference to `T`
+	// in the source surfaces as the concrete Go type in the output.
+	substEnv map[string]string
+
+	// sourcePath enables source-origin comments in CLI-generated Go.
+	// Library tests call Generate directly and keep this empty so their
+	// historical source snapshots stay compact.
+	sourcePath string
+}
+
+func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Result) *gen {
+	g := &gen{
+		pkgName:           pkgName,
+		file:              file,
+		res:               res,
+		chk:               chk,
+		body:              newWriter(),
+		imports:           map[string]string{},
+		variantOwner:      map[string]string{},
+		enumTypes:         map[string]bool{},
+		structTypes:       map[string]bool{},
+		methodNames:       map[string]map[string]bool{},
+		needStdlibOsty:    map[string]bool{},
+		emittedStdlibOsty: map[string]bool{},
+	}
+	g.indexTypes()
+	g.initInstances()
+	return g
+}
+
+// indexTypes walks top-level declarations once to build the variant
+// owner / enum-type / method-name maps. Keeps the emit path branch-free
+// by having direct lookups available.
+func (g *gen) indexTypes() {
+	g.indexScopeTypes()
+	for _, d := range g.file.Decls {
+		switch d := d.(type) {
+		case *ast.EnumDecl:
+			g.indexEnumDecl(d)
+		case *ast.StructDecl:
+			g.indexStructDecl(d)
+		}
+	}
+}
+
+func (g *gen) indexScopeTypes() {
+	if g.res == nil || g.res.FileScope == nil {
+		return
+	}
+	for scope := g.res.FileScope; scope != nil; scope = scope.Parent() {
+		for _, sym := range scope.Symbols() {
+			switch sym.Kind {
+			case resolve.SymEnum:
+				if decl, ok := sym.Decl.(*ast.EnumDecl); ok {
+					g.indexEnumDecl(decl)
+				}
+			case resolve.SymStruct:
+				if decl, ok := sym.Decl.(*ast.StructDecl); ok {
+					g.indexStructDecl(decl)
+				}
+			}
+		}
+	}
+}
+
+func (g *gen) indexEnumDecl(e *ast.EnumDecl) {
+	g.enumTypes[e.Name] = true
+	for _, v := range e.Variants {
+		g.variantOwner[v.Name] = e.Name
+	}
+	if g.methodNames[e.Name] == nil {
+		g.methodNames[e.Name] = map[string]bool{}
+	}
+	for _, m := range e.Methods {
+		g.methodNames[e.Name][m.Name] = true
+	}
+}
+
+func (g *gen) indexStructDecl(s *ast.StructDecl) {
+	g.structTypes[s.Name] = true
+	if g.methodNames[s.Name] == nil {
+		g.methodNames[s.Name] = map[string]bool{}
+	}
+	for _, m := range s.Methods {
+		g.methodNames[s.Name][m.Name] = true
+	}
+}
+
+func (g *gen) applyPackageIndex(idx PackageIndex) {
+	for name, owner := range idx.VariantOwner {
+		if _, ok := g.variantOwner[name]; !ok {
+			g.variantOwner[name] = owner
+		}
+	}
+	for name := range idx.EnumTypes {
+		g.enumTypes[name] = true
+	}
+	for name := range idx.StructTypes {
+		g.structTypes[name] = true
+	}
+	for typeName, methods := range idx.MethodNames {
+		if g.methodNames[typeName] == nil {
+			g.methodNames[typeName] = map[string]bool{}
+		}
+		for methodName := range methods {
+			g.methodNames[typeName][methodName] = true
+		}
+	}
+}
+
+// use records a Go import with no alias (bare `import "path"`). A
+// subsequent useAs for the same path overrides with an alias; a
+// bare use after an alias leaves the alias intact.
+func (g *gen) use(path string) {
+	if _, ok := g.imports[path]; !ok {
+		g.imports[path] = ""
+	}
+}
+
+// useAs records a Go import under an alias (`import alias "path"`). Used by
+// bootstrap FFI declarations when the Osty alias differs from the Go package's
+// default name.
+func (g *gen) useAs(path, alias string) {
+	g.imports[path] = alias
+}
+
+func (g *gen) sourceMarker(n ast.Node) {
+	if g.sourcePath == "" || n == nil {
+		return
+	}
+	pos := n.Pos()
+	if pos.Line <= 0 {
+		return
+	}
+	g.body.writef("// Osty: %s:%d:%d\n", g.sourcePath, pos.Line, pos.Column)
+}
+
+// run walks the file and returns the formatted Go source.
+func (g *gen) run() ([]byte, error) {
+	// 1a. Use declarations are stored in File.Uses separately from
+	//     File.Decls. Walk them first so their aliases are in scope
+	//     for the rest of the file (only matters for source order in
+	//     Go, but keeps output tidy).
+	for _, u := range g.file.Uses {
+		g.emitUseDecl(u)
+	}
+
+	// 1b. Emit every declaration in source order. Generic fns are
+	//     skipped inline — their specializations are materialized
+	//     by drainInstances once every reachable (fn × type-tuple)
+	//     pair has been requested by a call site.
+	for _, d := range g.file.Decls {
+		g.emitDecl(d)
+	}
+
+	// 1c. Fixed-point drain of queued monomorphizations. Emitting one
+	//     specialization may discover further generic calls in its
+	//     body (transitive instantiation); drainInstances walks the
+	//     queue with an index-based loop so append-during-iteration
+	//     works as expected.
+	g.drainInstances()
+
+	// 2. Script-mode: if the file has top-level statements, wrap them
+	//    into a synthetic `main` function. A file with neither a
+	//    user-defined `main` nor top-level statements produces a
+	//    library package with no entry point (caller chooses pkgName).
+	if len(g.file.Stmts) > 0 {
+		g.body.nl()
+		g.body.writeln("func main() {")
+		g.body.indent()
+		g.emitStmts(g.file.Stmts)
+		g.body.dedent()
+		g.body.writeln("}")
+	}
+
+	// 2a. Inline selected stdlib modules from their Osty sources once all
+	//     user code has had a chance to mark call-site dependencies.
+	g.emitNeededStdlibOstyModules()
+
+	// 2b. Runtime flags set during body emission may demand additional
+	//     imports. Resolve them before we serialize the import block.
+	if g.needTaskGroup {
+		g.use("sync")
+		g.use("context")
+	}
+	if g.needFS {
+		g.needResult = true
+		g.useAs("os", g.fsOSAlias)
+		g.useAs("unicode/utf8", g.fsUTF8Alias)
+	}
+	if g.needRandomRuntime {
+		g.useAs("math/rand", "mathrand")
+		g.use("sync")
+		g.use("time")
+	}
+	if g.needURLRuntime {
+		g.needResult = true
+		g.useAs("net/url", "neturl")
+		g.use("strconv")
+	}
+	if g.needErrorRuntime {
+		g.use("fmt")
+	}
+	if g.needRegex {
+		g.needResult = true
+		g.use("fmt")
+		g.useAs("unicode/utf8", "utf8")
+	}
+	if g.needEncoding {
+		g.needResult = true
+		g.use("fmt")
+		g.useAs("encoding/base64", "stdbase64")
+		g.useAs("encoding/hex", "stdhex")
+		g.useAs("net/url", "neturl")
+		g.useAs("strings", "stdstrings")
+	}
+	if g.needEnv {
+		g.needResult = true
+		g.use("fmt")
+		g.use("os")
+		g.useAs("strings", "stdstrings")
+	}
+	if g.needCsvRuntime {
+		g.needResult = true
+		g.use("fmt")
+		g.useAs("strings", "_ostyCsvStrings")
+	}
+	if g.needJSON {
+		g.needResult = true
+		g.useAs("encoding/json", "stdjson")
+		g.use("fmt")
+		g.use("reflect")
+	}
+	if g.needBytesRuntime {
+		g.needResult = true
+		g.useAs("bytes", "stdbytes")
+		g.useAs("encoding/hex", "_ostybyteshex")
+		g.useAs("unicode/utf8", "_ostybytesutf8")
+	}
+	if g.needCompress {
+		g.needResult = true
+		if !g.needBytesRuntime {
+			g.useAs("bytes", "stdbytes")
+		}
+		g.useAs("compress/gzip", "stdgzip")
+		g.useAs("io", "stdio")
+	}
+	if g.needCrypto {
+		g.useAs("crypto/hmac", "stdhmac")
+		g.useAs("crypto/md5", "stdmd5")
+		g.useAs("crypto/rand", "stdrand")
+		g.useAs("crypto/sha1", "stdsha1")
+		g.useAs("crypto/sha256", "stdsha256")
+		g.useAs("crypto/sha512", "stdsha512")
+		g.useAs("crypto/subtle", "stdsubtle")
+	}
+	if g.needUUID {
+		g.needResult = true
+		g.useAs("crypto/rand", "stdrand")
+		g.useAs("encoding/hex", "stdhex")
+		g.use("fmt")
+		g.useAs("strings", "stdstrings")
+		g.use("time")
+	}
+	if g.needResult || g.needStringRuntime || g.needErrorRuntime {
+		g.use("fmt")
+	}
+	if g.needRefRuntime || g.needEqualRuntime {
+		g.use("reflect")
+	}
+	if g.needRefRuntime {
+		g.use("unsafe")
+	}
+
+	// 3. Assemble header + body.
+	var out bytes.Buffer
+	fmt.Fprintln(&out, "// Code generated by osty. DO NOT EDIT.")
+	if g.sourcePath != "" {
+		fmt.Fprintf(&out, "// Osty source: %s\n", g.sourcePath)
+	}
+	fmt.Fprintln(&out)
+	fmt.Fprintf(&out, "package %s\n", g.pkgName)
+
+	if len(g.imports) > 0 {
+		out.WriteByte('\n')
+		paths := make([]string, 0, len(g.imports))
+		for p := range g.imports {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		// Aliased imports always use the block form — a single aliased
+		// import is still clearer as `import ( alias "path" )` and gofmt
+		// accepts either.
+		hasAlias := false
+		for _, a := range g.imports {
+			if a != "" {
+				hasAlias = true
+				break
+			}
+		}
+		if len(paths) == 1 && !hasAlias {
+			fmt.Fprintf(&out, "import %q\n", paths[0])
+		} else {
+			out.WriteString("import (\n")
+			for _, p := range paths {
+				if alias := g.imports[p]; alias != "" {
+					fmt.Fprintf(&out, "\t%s %q\n", alias, p)
+				} else {
+					fmt.Fprintf(&out, "\t%q\n", p)
+				}
+			}
+			out.WriteString(")\n")
+		}
+	}
+
+	out.WriteByte('\n')
+	// Inject the runtime type definitions we depend on. Emitted at top
+	// of body (after imports) so every downstream declaration can use
+	// them without caring about order.
+	if g.needResult || g.needStringRuntime {
+		out.WriteString(`
+type ostyStringer interface {
+	toString() string
+}
+
+func ostyToString(v any) string {
+	if s, ok := v.(ostyStringer); ok {
+		return s.toString()
+	}
+	if b, ok := v.([]byte); ok {
+		return string(b)
+	}
+	return fmt.Sprint(v)
+}
+`)
+	}
+	if g.needResult {
+		out.WriteString(`
+// Result is the runtime representation of Osty's Result<T, E>.
+// IsOk distinguishes Ok(Value) from Err(Error).
+type Result[T any, E any] struct {
+	Value T
+	Error E
+	IsOk  bool
+	ref   *byte
+}
+
+func resultRef() *byte { return new(byte) }
+
+func resultOk[T any, E any](value T) Result[T, E] {
+	return Result[T, E]{Value: value, IsOk: true, ref: resultRef()}
+}
+
+func resultErr[T any, E any](err E) Result[T, E] {
+	return Result[T, E]{Error: err, ref: resultRef()}
+}
+
+func (r Result[T, E]) isOk() bool { return r.IsOk }
+
+func (r Result[T, E]) isErr() bool { return !r.IsOk }
+
+func (r Result[T, E]) unwrap() T {
+	if !r.IsOk {
+		panic("called unwrap on Err")
+	}
+	return r.Value
+}
+
+func (r Result[T, E]) expect(msg string) T {
+	if !r.IsOk {
+		panic(msg)
+	}
+	return r.Value
+}
+
+func (r Result[T, E]) unwrapErr() E {
+	if r.IsOk {
+		panic("called unwrapErr on Ok")
+	}
+	return r.Error
+}
+
+func (r Result[T, E]) expectErr(msg string) E {
+	if r.IsOk {
+		panic(msg)
+	}
+	return r.Error
+}
+
+func (r Result[T, E]) unwrapOr(fallback T) T {
+	if r.IsOk {
+		return r.Value
+	}
+	return fallback
+}
+
+func (r Result[T, E]) unwrapOrElse(fallback func(E) T) T {
+	if r.IsOk {
+		return r.Value
+	}
+	return fallback(r.Error)
+}
+
+func (r Result[T, E]) ok() *T {
+	if r.IsOk {
+		return &r.Value
+	}
+	return nil
+}
+
+func (r Result[T, E]) err() *E {
+	if !r.IsOk {
+		return &r.Error
+	}
+	return nil
+}
+
+func (r Result[T, E]) toString() string {
+	if r.IsOk {
+		return "Ok(" + ostyToString(r.Value) + ")"
+	}
+	return "Err(" + ostyToString(r.Error) + ")"
+}
+
+func (r Result[T, E]) inspect(f func(T)) Result[T, E] {
+	if r.IsOk {
+		f(r.Value)
+	}
+	return r
+}
+
+func (r Result[T, E]) inspectErr(f func(E)) Result[T, E] {
+	if !r.IsOk {
+		f(r.Error)
+	}
+	return r
+}
+
+func resultAnd[T any, E any, U any](r Result[T, E], other Result[U, E]) Result[U, E] {
+	if r.IsOk {
+		return other
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultAndThen[T any, E any, U any](r Result[T, E], f func(T) Result[U, E]) Result[U, E] {
+	if r.IsOk {
+		return f(r.Value)
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultOr[T any, E any, F any](r Result[T, E], other Result[T, F]) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return other
+}
+
+func resultOrElse[T any, E any, F any](r Result[T, E], f func(E) Result[T, F]) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return f(r.Error)
+}
+
+func resultMap[T any, E any, U any](r Result[T, E], f func(T) U) Result[U, E] {
+	if r.IsOk {
+		return resultOk[U, E](f(r.Value))
+	}
+	return resultErr[U, E](r.Error)
+}
+
+func resultMapErr[T any, E any, F any](r Result[T, E], f func(E) F) Result[T, F] {
+	if r.IsOk {
+		return resultOk[T, F](r.Value)
+	}
+	return resultErr[T, F](f(r.Error))
+}
+`)
+	}
+	if g.needBytesRuntime {
+		out.WriteString(`
+func bytesClone(b []byte) []byte {
+	return append([]byte(nil), b...)
+}
+
+func bytesFrom(items []byte) []byte { return bytesClone(items) }
+
+func bytesFromString(s string) []byte { return []byte(s) }
+
+func bytesToString(b []byte) Result[string, any] {
+	if !_ostybytesutf8.Valid(b) {
+		return resultErr[string, any](fmt.Errorf("bytes: invalid UTF-8"))
+	}
+	return resultOk[string, any](string(b))
+}
+
+func bytesLen(b []byte) int { return len(b) }
+
+func bytesIsEmpty(b []byte) bool { return len(b) == 0 }
+
+func bytesGet(b []byte, i int) *byte {
+	if i < 0 || i >= len(b) {
+		return nil
+	}
+	v := b[i]
+	return &v
+}
+
+func bytesSlice(b []byte, start int, end int) []byte {
+	if start < 0 || end < start || end > len(b) {
+		panic("bytes.slice index out of range")
+	}
+	return bytesClone(b[start:end])
+}
+
+func bytesEqual(a []byte, b []byte) bool { return stdbytes.Equal(a, b) }
+
+func bytesContains(b []byte, sub []byte) bool { return stdbytes.Contains(b, sub) }
+
+func bytesStartsWith(b []byte, prefix []byte) bool { return stdbytes.HasPrefix(b, prefix) }
+
+func bytesEndsWith(b []byte, suffix []byte) bool { return stdbytes.HasSuffix(b, suffix) }
+
+func bytesIndexOf(b []byte, sub []byte) *int {
+	i := stdbytes.Index(b, sub)
+	if i < 0 {
+		return nil
+	}
+	return &i
+}
+
+func bytesLastIndexOf(b []byte, sub []byte) *int {
+	i := stdbytes.LastIndex(b, sub)
+	if i < 0 {
+		return nil
+	}
+	return &i
+}
+
+func bytesSplit(b []byte, sep []byte) [][]byte {
+	parts := stdbytes.Split(b, sep)
+	out := make([][]byte, len(parts))
+	for i, part := range parts {
+		out[i] = bytesClone(part)
+	}
+	return out
+}
+
+func bytesJoin(parts [][]byte, sep []byte) []byte { return stdbytes.Join(parts, sep) }
+
+func bytesConcat(a []byte, b []byte) []byte { return append(append([]byte(nil), a...), b...) }
+
+func bytesRepeat(b []byte, n int) []byte { return stdbytes.Repeat(b, n) }
+
+func bytesReplace(b []byte, old []byte, new []byte) []byte {
+	return stdbytes.Replace(b, old, new, 1)
+}
+
+func bytesReplaceAll(b []byte, old []byte, new []byte) []byte {
+	return stdbytes.ReplaceAll(b, old, new)
+}
+
+func bytesTrimLeft(b []byte, strip []byte) []byte { return bytesClone(stdbytes.TrimLeft(b, string(strip))) }
+
+func bytesTrimRight(b []byte, strip []byte) []byte { return bytesClone(stdbytes.TrimRight(b, string(strip))) }
+
+func bytesTrim(b []byte, strip []byte) []byte { return bytesClone(stdbytes.Trim(b, string(strip))) }
+
+func bytesTrimSpace(b []byte) []byte { return bytesClone(stdbytes.TrimSpace(b)) }
+
+func bytesToUpper(b []byte) []byte { return stdbytes.ToUpper(b) }
+
+func bytesToLower(b []byte) []byte { return stdbytes.ToLower(b) }
+
+func bytesToHex(b []byte) string { return _ostybyteshex.EncodeToString(b) }
+
+func bytesFromHex(s string) Result[[]byte, any] {
+	b, err := _ostybyteshex.DecodeString(s)
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	return resultOk[[]byte, any](b)
+}
+`)
+	}
+	if g.needErrorRuntime {
+		out.WriteString(`
+type ostyBasicError struct {
+	messageText string
+}
+
+func ostyErrorNew(message string) any {
+	return ostyBasicError{messageText: message}
+}
+
+func (e ostyBasicError) message() string { return e.messageText }
+
+func (e ostyBasicError) source() *any { return nil }
+
+func ostyErrorDowncast[T any](err any) *T {
+	v, ok := err.(T)
+	if !ok {
+		return nil
+	}
+	return &v
+}
+
+func ostyErrorMessage(e any) string {
+	if e == nil {
+		return ""
+	}
+	if m, ok := e.(interface{ message() string }); ok {
+		return m.message()
+	}
+	if err, ok := e.(error); ok {
+		return err.Error()
+	}
+	if s, ok := e.(string); ok {
+		return s
+	}
+	return fmt.Sprint(e)
+}
+
+func ostyErrorSource(err any) *any {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(interface{ source() *any }); ok {
+		return e.source()
+	}
+	return nil
+}
+`)
+	}
+	if g.needRange {
+		out.WriteString(`
+// Range is the runtime representation of an Osty range literal.
+// Used only when a range value is stored (outside a for-in head).
+type Range struct {
+	Start, Stop                  int
+	HasStart, HasStop, Inclusive bool
+}
+`)
+	}
+	if g.needJSON {
+		out.WriteString(`
+// Json is the runtime representation of std.json.Json.
+type Json = any
+
+type jsonEncoder interface {
+	toJson() Json
+}
+
+type jsonDecoderFunc func([]byte) (any, error)
+
+type jsonField struct {
+	Name    string
+	Value   any
+	OmitNil bool
+}
+
+var jsonDecoders = map[reflect.Type]jsonDecoderFunc{}
+
+func jsonRegisterDecoder(t reflect.Type, fn jsonDecoderFunc) {
+	jsonDecoders[t] = fn
+}
+
+func jsonEncode(value any) string {
+	data, err := jsonMarshalAny(value)
+	if err != nil {
+		panic(fmt.Sprintf("std.json.encode: %v", err))
+	}
+	return string(data)
+}
+
+func jsonStringify(value any) string { return jsonEncode(value) }
+
+func jsonDecode[T any](text string) Result[T, any] {
+	var out T
+	if err := jsonRejectLoneSurrogates(text); err != nil {
+		return resultErr[T, any](err)
+	}
+	if err := jsonUnmarshalInto([]byte(text), &out); err != nil {
+		return resultErr[T, any](err)
+	}
+	return resultOk[T, any](out)
+}
+
+func jsonObject(value map[string]Json) Json { return value }
+
+func jsonArray(value []Json) Json { return value }
+
+func jsonString(value string) Json { return value }
+
+func jsonNumber(value float64) Json { return value }
+
+func jsonBool(value bool) Json { return value }
+
+func jsonMarshalAny(value any) ([]byte, error) {
+	if enc, ok := value.(jsonEncoder); ok {
+		return jsonMarshalAny(enc.toJson())
+	}
+	return stdjson.Marshal(value)
+}
+
+func jsonUnmarshalInto[T any](data []byte, out *T) error {
+	target := reflect.TypeOf((*T)(nil)).Elem()
+	return jsonUnmarshalReflect(data, target, reflect.ValueOf(out).Elem())
+}
+
+func jsonUnmarshalReflect(data []byte, target reflect.Type, dest reflect.Value) error {
+	if dec := jsonDecoders[target]; dec != nil {
+		value, err := dec(data)
+		if err != nil {
+			return err
+		}
+		rv := reflect.ValueOf(value)
+		if !rv.Type().AssignableTo(target) {
+			if rv.Type().ConvertibleTo(target) {
+				rv = rv.Convert(target)
+			} else {
+				return fmt.Errorf("std.json: decoded %T cannot be assigned to %v", value, target)
+			}
+		}
+		dest.Set(rv)
+		return nil
+	}
+	if target.Kind() == reflect.Pointer {
+		if jsonRawIsNull(data) {
+			if target.Implements(reflect.TypeOf((*stdjson.Unmarshaler)(nil)).Elem()) {
+				ptr := reflect.New(target.Elem())
+				if err := stdjson.Unmarshal(data, ptr.Interface()); err != nil {
+					return err
+				}
+				dest.Set(ptr)
+				return nil
+			}
+			dest.SetZero()
+			return nil
+		}
+		ptr := reflect.New(target.Elem())
+		if err := jsonUnmarshalReflect(data, target.Elem(), ptr.Elem()); err != nil {
+			return err
+		}
+		dest.Set(ptr)
+		return nil
+	}
+	if jsonRawIsNull(data) && target.Kind() != reflect.Interface {
+		if dest.CanAddr() && reflect.PointerTo(target).Implements(reflect.TypeOf((*stdjson.Unmarshaler)(nil)).Elem()) {
+			return stdjson.Unmarshal(data, dest.Addr().Interface())
+		}
+		return fmt.Errorf("std.json: null cannot be decoded into %v", target)
+	}
+	switch target.Kind() {
+	case reflect.Slice:
+		var raw []stdjson.RawMessage
+		if err := stdjson.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+		out := reflect.MakeSlice(target, len(raw), len(raw))
+		for i := range raw {
+			if err := jsonUnmarshalReflect(raw[i], target.Elem(), out.Index(i)); err != nil {
+				return fmt.Errorf("std.json: array[%d]: %w", i, err)
+			}
+		}
+		dest.Set(out)
+		return nil
+	case reflect.Array:
+		var raw []stdjson.RawMessage
+		if err := stdjson.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+		if len(raw) != target.Len() {
+			return fmt.Errorf("std.json: array expected %d values, got %d", target.Len(), len(raw))
+		}
+		for i := range raw {
+			if err := jsonUnmarshalReflect(raw[i], target.Elem(), dest.Index(i)); err != nil {
+				return fmt.Errorf("std.json: array[%d]: %w", i, err)
+			}
+		}
+		return nil
+	case reflect.Map:
+		if target.Key().Kind() == reflect.String {
+			var raw map[string]stdjson.RawMessage
+			if err := stdjson.Unmarshal(data, &raw); err != nil {
+				return err
+			}
+			out := reflect.MakeMapWithSize(target, len(raw))
+			for key, value := range raw {
+				elem := reflect.New(target.Elem()).Elem()
+				if err := jsonUnmarshalReflect(value, target.Elem(), elem); err != nil {
+					return fmt.Errorf("std.json: object[%q]: %w", key, err)
+				}
+				out.SetMapIndex(reflect.ValueOf(key).Convert(target.Key()), elem)
+			}
+			dest.Set(out)
+			return nil
+		}
+	}
+	if dest.CanAddr() {
+		return stdjson.Unmarshal(data, dest.Addr().Interface())
+	}
+	ptr := reflect.New(target)
+	if err := stdjson.Unmarshal(data, ptr.Interface()); err != nil {
+		return err
+	}
+	dest.Set(ptr.Elem())
+	return nil
+}
+
+func jsonParseValue(data []byte) (Json, error) {
+	if err := jsonRejectLoneSurrogates(string(data)); err != nil {
+		return nil, err
+	}
+	var value Json
+	if err := stdjson.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func jsonStringifyValue(value Json) string { return jsonEncode(value) }
+
+func jsonParseValueResult(text string) Result[Json, any] {
+	value, err := jsonParseValue([]byte(text))
+	if err != nil {
+		return resultErr[Json, any](err)
+	}
+	return resultOk[Json, any](value)
+}
+
+func jsonIsNullVal(value Json) bool { return value == nil }
+
+func jsonIsBoolVal(value Json) bool {
+	_, ok := value.(bool)
+	return ok
+}
+
+func jsonIsNumberVal(value Json) bool {
+	switch value.(type) {
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return true
+	default:
+		return false
+	}
+}
+
+func jsonIsStringVal(value Json) bool {
+	_, ok := value.(string)
+	return ok
+}
+
+func jsonIsArrayVal(value Json) bool {
+	_, ok := value.([]Json)
+	return ok
+}
+
+func jsonIsObjectVal(value Json) bool {
+	_, ok := value.(map[string]Json)
+	return ok
+}
+
+func jsonAsBoolResult(value Json) Result[bool, any] {
+	if v, ok := value.(bool); ok {
+		return resultOk[bool, any](v)
+	}
+	return resultErr[bool, any](fmt.Sprintf("std.json: expected Bool, got %T", value))
+}
+
+func jsonAsNumberResult(value Json) Result[float64, any] {
+	switch v := value.(type) {
+	case float64:
+		return resultOk[float64, any](v)
+	case float32:
+		return resultOk[float64, any](float64(v))
+	case int:
+		return resultOk[float64, any](float64(v))
+	case int8:
+		return resultOk[float64, any](float64(v))
+	case int16:
+		return resultOk[float64, any](float64(v))
+	case int32:
+		return resultOk[float64, any](float64(v))
+	case int64:
+		return resultOk[float64, any](float64(v))
+	case uint:
+		return resultOk[float64, any](float64(v))
+	case uint8:
+		return resultOk[float64, any](float64(v))
+	case uint16:
+		return resultOk[float64, any](float64(v))
+	case uint32:
+		return resultOk[float64, any](float64(v))
+	case uint64:
+		return resultOk[float64, any](float64(v))
+	default:
+		return resultErr[float64, any](fmt.Sprintf("std.json: expected Number, got %T", value))
+	}
+}
+
+func jsonAsStringResult(value Json) Result[string, any] {
+	if v, ok := value.(string); ok {
+		return resultOk[string, any](v)
+	}
+	return resultErr[string, any](fmt.Sprintf("std.json: expected String, got %T", value))
+}
+
+func jsonAsArrayResult(value Json) Result[[]Json, any] {
+	if v, ok := value.([]Json); ok {
+		return resultOk[[]Json, any](v)
+	}
+	return resultErr[[]Json, any](fmt.Sprintf("std.json: expected Array, got %T", value))
+}
+
+func jsonAsObjectResult(value Json) Result[map[string]Json, any] {
+	if v, ok := value.(map[string]Json); ok {
+		return resultOk[map[string]Json, any](v)
+	}
+	return resultErr[map[string]Json, any](fmt.Sprintf("std.json: expected Object, got %T", value))
+}
+
+func jsonGetFieldResult(value Json, key string) Result[Json, any] {
+	obj, ok := value.(map[string]Json)
+	if !ok {
+		return resultErr[Json, any](fmt.Sprintf("std.json: expected Object, got %T", value))
+	}
+	field, ok := obj[key]
+	if !ok {
+		return resultErr[Json, any](fmt.Sprintf("std.json: missing field %q", key))
+	}
+	return resultOk[Json, any](field)
+}
+
+func jsonGetIndexResult(value Json, index int) Result[Json, any] {
+	arr, ok := value.([]Json)
+	if !ok {
+		return resultErr[Json, any](fmt.Sprintf("std.json: expected Array, got %T", value))
+	}
+	if index < 0 || index >= len(arr) {
+		return resultErr[Json, any](fmt.Sprintf("std.json: index %d out of bounds", index))
+	}
+	return resultOk[Json, any](arr[index])
+}
+
+func jsonAsError(value any) error {
+	if err, ok := value.(error); ok {
+		return err
+	}
+	return fmt.Errorf("%v", value)
+}
+
+func jsonMarshalObject(fields []jsonField) ([]byte, error) {
+	out := make(map[string]stdjson.RawMessage, len(fields))
+	for _, field := range fields {
+		if field.OmitNil && jsonIsNil(field.Value) {
+			continue
+		}
+		data, err := jsonMarshalAny(field.Value)
+		if err != nil {
+			return nil, err
+		}
+		out[field.Name] = stdjson.RawMessage(data)
+	}
+	return stdjson.Marshal(out)
+}
+
+func jsonMarshalEnum(tag string, values ...any) ([]byte, error) {
+	fields := []jsonField{{Name: "tag", Value: tag}}
+	switch len(values) {
+	case 0:
+	case 1:
+		fields = append(fields, jsonField{Name: "value", Value: values[0]})
+	default:
+		fields = append(fields, jsonField{Name: "value", Value: values})
+	}
+	return jsonMarshalObject(fields)
+}
+
+func jsonSkippedVariant(enumName, variantName string) ([]byte, error) {
+	return nil, fmt.Errorf("std.json: %s.%s is marked #[json(skip)]", enumName, variantName)
+}
+
+func jsonUnmarshalArray(data []byte, want int, label string) ([]stdjson.RawMessage, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("std.json: %s missing value", label)
+	}
+	var values []stdjson.RawMessage
+	if err := stdjson.Unmarshal(data, &values); err != nil {
+		return nil, fmt.Errorf("std.json: %s value: %w", label, err)
+	}
+	if len(values) != want {
+		return nil, fmt.Errorf("std.json: %s expected %d values, got %d", label, want, len(values))
+	}
+	return values, nil
+}
+
+func jsonRawIsNull(data []byte) bool {
+	start, end := 0, len(data)
+	for start < end && data[start] <= ' ' {
+		start++
+	}
+	for end > start && data[end-1] <= ' ' {
+		end--
+	}
+	return end-start == 4 && string(data[start:end]) == "null"
+}
+
+func jsonIsNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+func jsonRejectLoneSurrogates(text string) error {
+	inString := false
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || i+1 >= len(text) {
+				continue
+			}
+			if text[i+1] != 'u' {
+				i++
+				continue
+			}
+			r, ok := jsonHex4(text[i+2:])
+			if !ok {
+				continue
+			}
+			if r >= 0xD800 && r <= 0xDBFF {
+				low, lowOK := rune(0), false
+				if i+12 <= len(text) && text[i+6] == '\\' && text[i+7] == 'u' {
+					low, lowOK = jsonHex4(text[i+8:])
+				}
+				if !lowOK || low < 0xDC00 || low > 0xDFFF {
+					return fmt.Errorf("std.json.decode: lone surrogate escape \\u%04X", r)
+				}
+				i += 11
+				continue
+			}
+			if r >= 0xDC00 && r <= 0xDFFF {
+				return fmt.Errorf("std.json.decode: lone surrogate escape \\u%04X", r)
+			}
+			i += 5
+		}
+	}
+	return nil
+}
+
+func jsonHex4(s string) (rune, bool) {
+	if len(s) < 4 {
+		return 0, false
+	}
+	var r rune
+	for i := 0; i < 4; i++ {
+		c := s[i]
+		var v byte
+		switch {
+		case c >= '0' && c <= '9':
+			v = c - '0'
+		case c >= 'a' && c <= 'f':
+			v = c - 'a' + 10
+		case c >= 'A' && c <= 'F':
+			v = c - 'A' + 10
+		default:
+			return 0, false
+		}
+		r = r*16 + rune(v)
+	}
+	return r, true
+}
+`)
+	}
+	if g.needEqualRuntime {
+		out.WriteString(`
+func ostyEqual(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if !av.IsValid() || !bv.IsValid() {
+		return ostyIsNilValue(av) && ostyIsNilValue(bv)
+	}
+	return ostyEqualValue(av, bv, map[ostyEqualVisit]bool{})
+}
+
+type ostyEqualVisit struct {
+	a, b uintptr
+	typ  reflect.Type
+}
+
+func ostyEqualValue(a, b reflect.Value, seen map[ostyEqualVisit]bool) bool {
+	if !a.IsValid() || !b.IsValid() {
+		return ostyIsNilValue(a) && ostyIsNilValue(b)
+	}
+	if a.Type() != b.Type() {
+		return ostyIsNilValue(a) && ostyIsNilValue(b)
+	}
+	switch a.Kind() {
+	case reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		return ostyEqualValue(a.Elem(), b.Elem(), seen)
+	case reflect.Pointer:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		visit := ostyEqualVisit{a: a.Pointer(), b: b.Pointer(), typ: a.Type()}
+		if seen[visit] {
+			return true
+		}
+		seen[visit] = true
+		return ostyEqualValue(a.Elem(), b.Elem(), seen)
+	case reflect.Struct:
+		for i := 0; i < a.NumField(); i++ {
+			if a.Type().Field(i).Name == "ref" {
+				continue
+			}
+			if !ostyEqualValue(a.Field(i), b.Field(i), seen) {
+				return false
+			}
+		}
+		return true
+	case reflect.Array, reflect.Slice:
+		if a.Kind() == reflect.Slice && (a.IsNil() || b.IsNil()) {
+			return a.IsNil() == b.IsNil()
+		}
+		if a.Len() != b.Len() {
+			return false
+		}
+		for i := 0; i < a.Len(); i++ {
+			if !ostyEqualValue(a.Index(i), b.Index(i), seen) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		if a.Len() != b.Len() {
+			return false
+		}
+		for _, key := range a.MapKeys() {
+			bv := b.MapIndex(key)
+			if !bv.IsValid() || !ostyEqualValue(a.MapIndex(key), bv, seen) {
+				return false
+			}
+		}
+		return true
+	case reflect.String:
+		return a.String() == b.String()
+	case reflect.Bool:
+		return a.Bool() == b.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return a.Int() == b.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return a.Uint() == b.Uint()
+	case reflect.Float32, reflect.Float64:
+		return a.Float() == b.Float()
+	case reflect.Complex64, reflect.Complex128:
+		return a.Complex() == b.Complex()
+	case reflect.Func:
+		return a.IsNil() && b.IsNil()
+	case reflect.Chan, reflect.UnsafePointer:
+		return a.Pointer() == b.Pointer()
+	default:
+		if a.CanInterface() && b.CanInterface() {
+			return reflect.DeepEqual(a.Interface(), b.Interface())
+		}
+		return false
+	}
+}
+
+func ostyIsNilValue(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+`)
+	}
+	if g.needRefRuntime {
+		out.WriteString(`
+func refSame(a, b any) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if !av.IsValid() || !bv.IsValid() || av.Type() != bv.Type() {
+		return false
+	}
+	switch av.Kind() {
+	case reflect.Func:
+		ap := refInterfaceData(a)
+		return ap != nil && ap == refInterfaceData(b)
+	case reflect.Slice:
+		ap := av.Pointer()
+		return ap != 0 && ap == bv.Pointer()
+	case reflect.Chan, reflect.Map, reflect.Pointer, reflect.UnsafePointer:
+		ap := av.Pointer()
+		return ap != 0 && ap == bv.Pointer()
+	case reflect.Struct:
+		af := av.FieldByName("ref")
+		bf := bv.FieldByName("ref")
+		if af.IsValid() && bf.IsValid() && af.Kind() == reflect.Pointer && bf.Kind() == reflect.Pointer {
+			ap := af.Pointer()
+			return ap != 0 && ap == bf.Pointer()
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+type refInterfaceHeader struct {
+	typ  unsafe.Pointer
+	data unsafe.Pointer
+}
+
+func refInterfaceData(v any) unsafe.Pointer {
+	return (*refInterfaceHeader)(unsafe.Pointer(&v)).data
+}
+`)
+	}
+	if g.needRandomRuntime {
+		out.WriteString(`
+// Rng is the runtime representation of std.random.Rng.
+type Rng struct {
+	mu *sync.Mutex
+	r  *mathrand.Rand
+}
+
+func newRng(seed int64) Rng {
+	return Rng{mu: &sync.Mutex{}, r: mathrand.New(mathrand.NewSource(seed))}
+}
+
+func randomDefault() Rng { return newRng(time.Now().UnixNano()) }
+
+func randomSeeded(seed int64) Rng { return newRng(seed) }
+
+func (r Rng) ready() Rng {
+	if r.r == nil {
+		return randomDefault()
+	}
+	if r.mu == nil {
+		r.mu = &sync.Mutex{}
+	}
+	return r
+}
+
+func (r Rng) int(min, max int) int {
+	if max <= min {
+		panic("std.random.Rng.int requires max > min")
+	}
+	r = r.ready()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return min + r.r.Intn(max-min)
+}
+
+func (r Rng) intInclusive(min, max int) int {
+	if max < min {
+		panic("std.random.Rng.intInclusive requires max >= min")
+	}
+	return r.int(min, max+1)
+}
+
+func (r Rng) float() float64 {
+	r = r.ready()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.r.Float64()
+}
+
+func (r Rng) bool() bool { return r.int(0, 2) == 1 }
+
+func (r Rng) bytes(n int) []byte {
+	if n < 0 {
+		panic("std.random.Rng.bytes requires n >= 0")
+	}
+	r = r.ready()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(r.r.Intn(256))
+	}
+	return out
+}
+
+func rngChoice[T any](r Rng, items []T) *T {
+	if len(items) == 0 {
+		return nil
+	}
+	v := items[r.int(0, len(items))]
+	return &v
+}
+
+func rngShuffle[T any](r Rng, items []T) {
+	r = r.ready()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.r.Shuffle(len(items), func(i, j int) {
+		items[i], items[j] = items[j], items[i]
+	})
+}
+`)
+	}
+	if g.needURLRuntime {
+		out.WriteString(`
+// Url is the runtime representation of std.url.Url.
+type Url struct {
+	scheme   string
+	host     string
+	port     *int
+	path     string
+	query    map[string]string
+	queryAll map[string][]string
+	fragment *string
+}
+
+func urlParse(text string) Result[Url, any] {
+	parsed, err := neturl.Parse(text)
+	if err != nil {
+		return resultErr[Url, any](err.Error())
+	}
+	var port *int
+	if raw := parsed.Port(); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return resultErr[Url, any](err.Error())
+		}
+		port = &n
+	}
+	var fragment *string
+	if parsed.Fragment != "" {
+		v := parsed.Fragment
+		fragment = &v
+	}
+	query := map[string]string{}
+	queryAll := map[string][]string{}
+	for key, values := range parsed.Query() {
+		cp := append([]string(nil), values...)
+		queryAll[key] = cp
+		if len(values) == 0 {
+			query[key] = ""
+		} else {
+			query[key] = values[0]
+		}
+	}
+	return resultOk[Url, any](Url{
+		scheme:   parsed.Scheme,
+		host:     parsed.Hostname(),
+		port:     port,
+		path:     parsed.Path,
+		query:    query,
+		queryAll: queryAll,
+		fragment: fragment,
+	})
+}
+
+func urlJoin(base, relative string) Result[string, any] {
+	b, err := neturl.Parse(base)
+	if err != nil {
+		return resultErr[string, any](err.Error())
+	}
+	r, err := neturl.Parse(relative)
+	if err != nil {
+		return resultErr[string, any](err.Error())
+	}
+	return resultOk[string, any](b.ResolveReference(r).String())
+}
+
+func (u Url) toString() string {
+	out := neturl.URL{
+		Scheme: u.scheme,
+		Host:   u.host,
+		Path:   u.path,
+	}
+	if u.port != nil && u.host != "" {
+		out.Host = u.host + ":" + strconv.Itoa(*u.port)
+	}
+	if u.fragment != nil {
+		out.Fragment = *u.fragment
+	}
+	q := neturl.Values{}
+	if u.queryAll != nil {
+		for key, values := range u.queryAll {
+			for _, value := range values {
+				q.Add(key, value)
+			}
+		}
+	} else {
+		for key, value := range u.query {
+			q.Set(key, value)
+		}
+	}
+	out.RawQuery = q.Encode()
+	return out.String()
+}
+
+func (u Url) queryValues(key string) []string {
+	if u.queryAll != nil {
+		return append([]string(nil), u.queryAll[key]...)
+	}
+	if value, ok := u.query[key]; ok {
+		return []string{value}
+	}
+	return []string{}
+}
+`)
+	}
+	if g.needRegex {
+		out.WriteString(regexRuntime)
+	}
+	if g.needEncoding {
+		out.WriteString(`
+func encodingBase64Encode(data []byte) string {
+	return stdbase64.StdEncoding.EncodeToString(data)
+}
+
+func encodingBase64Decode(text string) Result[[]byte, any] {
+	data, err := stdbase64.StdEncoding.DecodeString(text)
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	return resultOk[[]byte, any](data)
+}
+
+func encodingBase64URLEncode(data []byte) string {
+	return stdbase64.URLEncoding.EncodeToString(data)
+}
+
+func encodingBase64URLDecode(text string) Result[[]byte, any] {
+	data, err := stdbase64.URLEncoding.DecodeString(text)
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	return resultOk[[]byte, any](data)
+}
+
+func encodingHexEncode(data []byte) string {
+	return stdhex.EncodeToString(data)
+}
+
+func encodingHexDecode(text string) Result[[]byte, any] {
+	data, err := stdhex.DecodeString(text)
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	return resultOk[[]byte, any](data)
+}
+
+func encodingURLEncode(text string) string {
+	return stdstrings.ReplaceAll(neturl.QueryEscape(text), "+", "%20")
+}
+
+func encodingURLDecode(text string) Result[string, any] {
+	text, err := neturl.QueryUnescape(text)
+	if err != nil {
+		return resultErr[string, any](err)
+	}
+	return resultOk[string, any](text)
+}
+`)
+	}
+	if g.needEnv {
+		out.WriteString(`
+func envArgs() []string {
+	args := make([]string, len(os.Args)-1)
+	copy(args, os.Args[1:])
+	return args
+}
+
+func envGet(name string) *string {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func envRequire(name string) Result[string, any] {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return resultErr[string, any](fmt.Errorf("environment variable %s is not set", name))
+	}
+	return resultOk[string, any](value)
+}
+
+func envSet(name, value string) Result[struct{}, any] {
+	if err := os.Setenv(name, value); err != nil {
+		return resultErr[struct{}, any](err)
+	}
+	return resultOk[struct{}, any](struct{}{})
+}
+
+func envUnset(name string) Result[struct{}, any] {
+	if err := os.Unsetenv(name); err != nil {
+		return resultErr[struct{}, any](err)
+	}
+	return resultOk[struct{}, any](struct{}{})
+}
+
+func envVars() map[string]string {
+	out := map[string]string{}
+	for _, pair := range os.Environ() {
+		if key, value, ok := stdstrings.Cut(pair, "="); ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func envCurrentDir() Result[string, any] {
+	dir, err := os.Getwd()
+	if err != nil {
+		return resultErr[string, any](err)
+	}
+	return resultOk[string, any](dir)
+}
+
+func envSetCurrentDir(path string) Result[struct{}, any] {
+	if err := os.Chdir(path); err != nil {
+		return resultErr[struct{}, any](err)
+	}
+	return resultOk[struct{}, any](struct{}{})
+}
+`)
+	}
+	if g.needCsvRuntime {
+		g.emitCsvRuntime(&out)
+	}
+	if g.needCompress {
+		out.WriteString(`
+func compressGzipEncode(data []byte) []byte {
+	var b stdbytes.Buffer
+	w := stdgzip.NewWriter(&b)
+	if _, err := w.Write(data); err != nil {
+		panic(err)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+	return b.Bytes()
+}
+
+func compressGzipDecode(data []byte) Result[[]byte, any] {
+	r, err := stdgzip.NewReader(stdbytes.NewReader(data))
+	if err != nil {
+		return resultErr[[]byte, any](err)
+	}
+	out, readErr := stdio.ReadAll(r)
+	closeErr := r.Close()
+	if readErr != nil {
+		return resultErr[[]byte, any](readErr)
+	}
+	if closeErr != nil {
+		return resultErr[[]byte, any](closeErr)
+	}
+	return resultOk[[]byte, any](out)
+}
+`)
+	}
+	if g.needCrypto {
+		out.WriteString(`
+func cryptoSHA256(data []byte) []byte {
+	sum := stdsha256.Sum256(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoSHA512(data []byte) []byte {
+	sum := stdsha512.Sum512(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoSHA1(data []byte) []byte {
+	sum := stdsha1.Sum(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoMD5(data []byte) []byte {
+	sum := stdmd5.Sum(data)
+	return append([]byte(nil), sum[:]...)
+}
+
+func cryptoHMACSHA256(key, message []byte) []byte {
+	mac := stdhmac.New(stdsha256.New, key)
+	_, _ = mac.Write(message)
+	return mac.Sum(nil)
+}
+
+func cryptoHMACSHA512(key, message []byte) []byte {
+	mac := stdhmac.New(stdsha512.New, key)
+	_, _ = mac.Write(message)
+	return mac.Sum(nil)
+}
+
+func cryptoRandomBytes(n int) []byte {
+	if n < 0 {
+		panic("crypto.randomBytes called with a negative length")
+	}
+	out := make([]byte, n)
+	if _, err := stdrand.Read(out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func cryptoConstantTimeEq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return stdsubtle.ConstantTimeCompare(a, b) == 1
+}
+`)
+	}
+	if g.needUUID {
+		out.WriteString(`
+type Uuid [16]byte
+
+func uuidV4() Uuid {
+	var u Uuid
+	uuidFillRandom(u[:])
+	u[6] = (u[6] & 0x0f) | 0x40
+	u[8] = (u[8] & 0x3f) | 0x80
+	return u
+}
+
+func uuidV7() Uuid {
+	var u Uuid
+	uuidFillRandom(u[:])
+	ms := uint64(time.Now().UnixMilli())
+	u[0] = byte(ms >> 40)
+	u[1] = byte(ms >> 32)
+	u[2] = byte(ms >> 24)
+	u[3] = byte(ms >> 16)
+	u[4] = byte(ms >> 8)
+	u[5] = byte(ms)
+	u[6] = (u[6] & 0x0f) | 0x70
+	u[8] = (u[8] & 0x3f) | 0x80
+	return u
+}
+
+func uuidParse(text string) Result[Uuid, any] {
+	var compact string
+	switch len(text) {
+	case 32:
+		compact = text
+	case 36:
+		if text[8] != '-' || text[13] != '-' || text[18] != '-' || text[23] != '-' {
+			return resultErr[Uuid, any](fmt.Errorf("invalid UUID %q", text))
+		}
+		compact = stdstrings.ReplaceAll(text, "-", "")
+	default:
+		return resultErr[Uuid, any](fmt.Errorf("invalid UUID %q", text))
+	}
+	var u Uuid
+	if _, err := stdhex.Decode(u[:], []byte(compact)); err != nil {
+		return resultErr[Uuid, any](err)
+	}
+	return resultOk[Uuid, any](u)
+}
+
+func uuidNil() Uuid { return Uuid{} }
+
+func uuidFillRandom(dst []byte) {
+	if _, err := stdrand.Read(dst); err != nil {
+		panic(err)
+	}
+}
+
+func (u Uuid) toString() string {
+	var out [36]byte
+	stdhex.Encode(out[0:8], u[0:4])
+	out[8] = '-'
+	stdhex.Encode(out[9:13], u[4:6])
+	out[13] = '-'
+	stdhex.Encode(out[14:18], u[6:8])
+	out[18] = '-'
+	stdhex.Encode(out[19:23], u[8:10])
+	out[23] = '-'
+	stdhex.Encode(out[24:36], u[10:16])
+	return string(out[:])
+}
+
+func (u Uuid) toBytes() []byte {
+	return append([]byte(nil), u[:]...)
+}
+`)
+	}
+	if g.needHandle {
+		out.WriteString(`
+// Handle is the runtime representation of a task handle from
+// spawn/taskGroup. Join blocks until the goroutine finishes and
+// returns its result. The result channel is buffered to size 1 so
+// the goroutine never blocks on send when Join hasn't been called.
+type Handle[T any] struct {
+	result chan T
+}
+
+func spawnHandle[T any](body func() T) Handle[T] {
+	h := Handle[T]{result: make(chan T, 1)}
+	go func() {
+		h.result <- body()
+	}()
+	return h
+}
+
+func (h Handle[T]) Join() T { return <-h.result }
+`)
+	}
+	if g.needTaskGroup {
+		out.WriteString(`
+// TaskGroup backs §8 structured concurrency: every task spawned via
+// Spawn must finish before the group exits. A context is carried
+// through so Cancel propagates to cooperating children via
+// IsCancelled / Done. Context-aware stdlib blocking calls (the full
+// spec-mandated cancellation protocol) are not shipped — tasks that
+// don't explicitly check IsCancelled will run to completion.
+type TaskGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func (g *TaskGroup) Done() <-chan struct{} { return g.ctx.Done() }
+
+func (g *TaskGroup) IsCancelled() bool {
+	select {
+	case <-g.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (g *TaskGroup) Cancel() { g.cancel() }
+
+// spawnInGroup is the TaskGroup-aware variant of spawnHandle. The
+// WaitGroup counter increments synchronously so runTaskGroup's Wait
+// sees the task even if the goroutine hasn't started yet.
+func spawnInGroup[T any](g *TaskGroup, body func() T) Handle[T] {
+	g.wg.Add(1)
+	h := Handle[T]{result: make(chan T, 1)}
+	go func() {
+		defer g.wg.Done()
+		h.result <- body()
+	}()
+	return h
+}
+
+// runTaskGroup is the lowering target for ` + "`taskGroup(|g| body)`" + `.
+// The closure runs synchronously; on exit the context is cancelled
+// (so late children observing IsCancelled see the signal) and Wait
+// drains every unfinished spawned task before returning.
+func runTaskGroup[T any](body func(*TaskGroup) T) T {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := &TaskGroup{ctx: ctx, cancel: cancel}
+	defer func() {
+		cancel()
+		g.wg.Wait()
+	}()
+	return body(g)
+}
+
+// runParallel is the lowering target for ` + "`parallel(|| a, || b, ...)`" + `.
+// Every closure runs concurrently; the returned slice preserves the
+// source order so Osty-side destructuring lines up.
+func runParallel[T any](bodies ...func() T) []T {
+	results := make([]T, len(bodies))
+	var wg sync.WaitGroup
+	wg.Add(len(bodies))
+	for i, body := range bodies {
+		i, body := i, body
+		go func() {
+			defer wg.Done()
+			results[i] = body()
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// runParallelMap backs §8.3 parallel(items, concurrency, f). It keeps
+// source order in the returned slice while limiting in-flight workers.
+func runParallelMap[T any, R any](items []T, concurrency int, fn func(T) R) []R {
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	results := make([]R, len(items))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for i, item := range items {
+		i, item := i, item
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = fn(item)
+		}()
+	}
+	wg.Wait()
+	return results
+}
+`)
+	}
+	out.Write(g.body.bytes())
+
+	// 4. Normalise via gofmt. Returns the raw bytes on failure so the
+	//    caller can still inspect the (malformed) output.
+	src := out.Bytes()
+	formatted, err := format.Source(src)
+	if err != nil {
+		return src, fmt.Errorf("gofmt: %w", err)
+	}
+	if len(g.errs) > 0 {
+		return formatted, fmt.Errorf("%d generator issue(s); first: %w",
+			len(g.errs), g.errs[0])
+	}
+	return formatted, nil
+}
+
+// symbolFor returns the resolver Symbol for an Ident, or nil.
+func (g *gen) symbolFor(id *ast.Ident) *resolve.Symbol {
+	if g.res == nil {
+		return nil
+	}
+	return g.res.Refs[id]
+}
+
+// typeOf returns the checked type of an expression, or nil when the
+// checker didn't visit it.
+func (g *gen) typeOf(e ast.Expr) types.Type {
+	if g.chk == nil {
+		return nil
+	}
+	return g.chk.Types[e]
+}
+
+// symTypeOf returns the checked type of a symbol, or nil.
+func (g *gen) symTypeOf(s *resolve.Symbol) types.Type {
+	if g.chk == nil || s == nil {
+		return nil
+	}
+	return g.chk.SymTypes[s]
+}

--- a/internal/gen/ident.go
+++ b/internal/gen/ident.go
@@ -1,0 +1,49 @@
+//go:build selfhostgen
+
+package gen
+
+// goKeywords is the set of Go reserved words that MUST NOT appear as a
+// bare identifier in generated code. Osty identifiers that happen to
+// match one get a trailing underscore.
+//
+// Osty's own keywords (fn, struct, enum, …) cannot be used as idents in
+// the source, so they aren't listed here — the only collisions are Go
+// keywords that happen to be valid Osty identifiers.
+var goKeywords = map[string]struct{}{
+	"break":       {},
+	"case":        {},
+	"chan":        {},
+	"const":       {},
+	"continue":    {},
+	"default":     {},
+	"defer":       {},
+	"else":        {},
+	"fallthrough": {},
+	"for":         {},
+	"func":        {},
+	"go":          {},
+	"goto":        {},
+	"if":          {},
+	"import":      {},
+	"interface":   {},
+	"map":         {},
+	"package":     {},
+	"range":       {},
+	"return":      {},
+	"select":      {},
+	"struct":      {},
+	"switch":      {},
+	"type":        {},
+	"var":         {},
+}
+
+// mangleIdent returns a safe Go identifier for an Osty name: reserved
+// Go words get a trailing underscore, everything else passes through.
+//
+// Osty's self/Self keywords are handled at their call sites, not here.
+func mangleIdent(name string) string {
+	if _, ok := goKeywords[name]; ok {
+		return name + "_"
+	}
+	return name
+}

--- a/internal/gen/json.go
+++ b/internal/gen/json.go
@@ -1,0 +1,344 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+type jsonAnnotationOptions struct {
+	name     string
+	skip     bool
+	optional bool
+}
+
+func (g *gen) emitStructJSONMarshal(s *ast.StructDecl) {
+	if !g.needJSON || hasMethodNamed(s.Methods, "MarshalJSON") {
+		return
+	}
+	recv := genericReceiverName(s.Name, s.Generics)
+	g.body.nl()
+	g.body.writef("func (self %s) MarshalJSON() ([]byte, error) {\n", recv)
+	g.body.indent()
+	if m := receiverMethodNamed(s.Methods, "toJson"); m != nil {
+		call := "self.toJson()"
+		if m.Recv != nil && m.Recv.Mut {
+			call = "(&self).toJson()"
+		}
+		g.body.writef("return jsonMarshalAny(%s)\n", call)
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+	g.body.writeln("return jsonMarshalObject([]jsonField{")
+	g.body.indent()
+	for _, f := range s.Fields {
+		opts := jsonOptions(f.Annotations, f.Name)
+		if opts.skip {
+			continue
+		}
+		g.body.writef("{Name: %q, Value: self.%s", opts.name, mangleIdent(f.Name))
+		if opts.optional {
+			g.body.write(", OmitNil: true")
+		}
+		g.body.writeln("},")
+	}
+	g.body.dedent()
+	g.body.writeln("})")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitStructJSONUnmarshal(s *ast.StructDecl) {
+	if !g.needJSON || hasMethodNamed(s.Methods, "UnmarshalJSON") {
+		return
+	}
+	recv := genericReceiverName(s.Name, s.Generics)
+	g.body.nl()
+	g.body.writef("func (self *%s) UnmarshalJSON(data []byte) error {\n", recv)
+	g.body.indent()
+	if len(s.Generics) == 0 && associatedMethodNamed(s.Methods, "fromJson") != nil {
+		g.body.writeln("value, err := jsonParseValue(data)")
+		g.body.writeln("if err != nil {")
+		g.body.indent()
+		g.body.writeln("return err")
+		g.body.dedent()
+		g.body.writeln("}")
+		g.body.writef("result := %s_fromJson(value)\n", s.Name)
+		g.body.writeln("if !result.IsOk {")
+		g.body.indent()
+		g.body.writeln("return jsonAsError(result.Error)")
+		g.body.dedent()
+		g.body.writeln("}")
+		g.body.writef("if result.Value == nil { return fmt.Errorf(%q) }\n",
+			fmt.Sprintf("std.json: %s.fromJson returned nil", s.Name))
+		g.body.writeln("*self = *result.Value")
+		g.body.writeln("return nil")
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+	g.body.writeln("var raw map[string]stdjson.RawMessage")
+	g.body.writeln("if err := stdjson.Unmarshal(data, &raw); err != nil {")
+	g.body.indent()
+	g.body.writeln("return err")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writef("if raw == nil && jsonRawIsNull(data) { return fmt.Errorf(%q) }\n",
+		fmt.Sprintf("std.json: %s expects object, got null", s.Name))
+	for _, f := range s.Fields {
+		opts := jsonOptions(f.Annotations, f.Name)
+		if opts.skip {
+			continue
+		}
+		g.body.writef("if value, ok := raw[%q]; ok {\n", opts.name)
+		g.body.indent()
+		if !g.jsonTypeAllowsNull(f.Type) {
+			msg := fmt.Sprintf("std.json: %s.%s is null", s.Name, opts.name)
+			g.body.writef("if jsonRawIsNull(value) { return fmt.Errorf(%q) }\n", msg)
+		}
+		msg := fmt.Sprintf("std.json: %s.%s: %%w", s.Name, opts.name)
+		g.body.writef("if err := jsonUnmarshalInto(value, &self.%s); err != nil { return fmt.Errorf(%q, err) }\n",
+			mangleIdent(f.Name), msg)
+		g.body.dedent()
+		g.body.writeln("}")
+	}
+	g.body.writeln("return nil")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitVariantJSONMarshal(e *ast.EnumDecl, v *ast.Variant, goName string) {
+	if !g.needJSON {
+		return
+	}
+	if receiverMethodNamed(e.Methods, "toJson") != nil {
+		g.body.writef("func (self %s) MarshalJSON() ([]byte, error) { ", goName)
+		g.body.writef("return jsonMarshalAny(%s_toJson(%s(self)))", e.Name, e.Name)
+		g.body.writeln(" }")
+		return
+	}
+	opts := jsonOptions(v.Annotations, v.Name)
+	g.body.writef("func (self %s) MarshalJSON() ([]byte, error) { ", goName)
+	if opts.skip {
+		g.body.writef("return jsonSkippedVariant(%q, %q)", e.Name, v.Name)
+		g.body.writeln(" }")
+		return
+	}
+	g.body.writef("return jsonMarshalEnum(%q", opts.name)
+	for i := range v.Fields {
+		g.body.writef(", self.F%d", i)
+	}
+	g.body.writeln(") }")
+}
+
+func (g *gen) emitEnumJSONDecoder(e *ast.EnumDecl) {
+	if !g.needJSON {
+		return
+	}
+	if associatedMethodNamed(e.Methods, "fromJson") != nil {
+		g.emitEnumJSONCustomDecoder(e)
+		return
+	}
+	g.body.nl()
+	g.body.writeln("func init() {")
+	g.body.indent()
+	g.body.writef("jsonRegisterDecoder(reflect.TypeOf((*%s)(nil)).Elem(), func(data []byte) (any, error) { return jsonUnmarshal%s(data) })\n", e.Name, e.Name)
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.nl()
+	g.body.writef("func jsonUnmarshal%s(data []byte) (%s, error) {\n", e.Name, e.Name)
+	g.body.indent()
+	g.body.writeln("var head struct {")
+	g.body.indent()
+	g.body.writeln("Tag string `json:\"tag\"`")
+	g.body.writeln("Value stdjson.RawMessage `json:\"value\"`")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writeln("if err := stdjson.Unmarshal(data, &head); err != nil {")
+	g.body.indent()
+	g.body.writeln("return nil, err")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writeln("switch head.Tag {")
+	g.body.indent()
+	for _, v := range e.Variants {
+		opts := jsonOptions(v.Annotations, v.Name)
+		if opts.skip {
+			continue
+		}
+		goName := e.Name + "_" + v.Name
+		label := e.Name + "." + v.Name
+		g.body.writef("case %q:\n", opts.name)
+		g.body.indent()
+		switch len(v.Fields) {
+		case 0:
+			g.body.writef("return %s(&%s{}), nil\n", e.Name, goName)
+		case 1:
+			fieldType := g.goTypeExpr(v.Fields[0])
+			missing := fmt.Sprintf("std.json: %s missing value", label)
+			msg := fmt.Sprintf("std.json: %s value: %%w", label)
+			g.body.writef("if len(head.Value) == 0 { return nil, fmt.Errorf(%q) }\n", missing)
+			g.body.writef("var f0 %s\n", fieldType)
+			g.body.writef("if err := jsonUnmarshalInto(head.Value, &f0); err != nil { return nil, fmt.Errorf(%q, err) }\n", msg)
+			g.body.writef("return %s(&%s{F0: f0}), nil\n", e.Name, goName)
+		default:
+			g.body.writef("values, err := jsonUnmarshalArray(head.Value, %d, %q)\n", len(v.Fields), label)
+			g.body.writeln("if err != nil {")
+			g.body.indent()
+			g.body.writeln("return nil, err")
+			g.body.dedent()
+			g.body.writeln("}")
+			for i, f := range v.Fields {
+				msg := fmt.Sprintf("std.json: %s value[%d]: %%w", label, i)
+				g.body.writef("var f%d %s\n", i, g.goTypeExpr(f))
+				g.body.writef("if err := jsonUnmarshalInto(values[%d], &f%d); err != nil { return nil, fmt.Errorf(%q, err) }\n", i, i, msg)
+			}
+			g.body.writef("return %s(&%s{", e.Name, goName)
+			for i := range v.Fields {
+				if i > 0 {
+					g.body.write(", ")
+				}
+				g.body.writef("F%d: f%d", i, i)
+			}
+			g.body.writeln("}), nil")
+		}
+		g.body.dedent()
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writef("return nil, fmt.Errorf(\"std.json: unknown %s tag %%q\", head.Tag)\n", e.Name)
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitEnumJSONCustomDecoder(e *ast.EnumDecl) {
+	g.body.nl()
+	g.body.writeln("func init() {")
+	g.body.indent()
+	g.body.writef("jsonRegisterDecoder(reflect.TypeOf((*%s)(nil)).Elem(), func(data []byte) (any, error) {\n", e.Name)
+	g.body.indent()
+	g.body.writeln("value, err := jsonParseValue(data)")
+	g.body.writeln("if err != nil {")
+	g.body.indent()
+	g.body.writeln("return nil, err")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writef("result := %s_fromJson(value)\n", e.Name)
+	g.body.writeln("if !result.IsOk {")
+	g.body.indent()
+	g.body.writeln("return nil, jsonAsError(result.Error)")
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.writeln("return result.Value, nil")
+	g.body.dedent()
+	g.body.writeln("})")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func hasMethodNamed(methods []*ast.FnDecl, name string) bool {
+	return methodNamed(methods, name) != nil
+}
+
+func methodNamed(methods []*ast.FnDecl, name string) *ast.FnDecl {
+	for _, m := range methods {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}
+
+func receiverMethodNamed(methods []*ast.FnDecl, name string) *ast.FnDecl {
+	for _, m := range methods {
+		if m.Name == name && m.Recv != nil {
+			return m
+		}
+	}
+	return nil
+}
+
+func associatedMethodNamed(methods []*ast.FnDecl, name string) *ast.FnDecl {
+	for _, m := range methods {
+		if m.Name == name && m.Recv == nil {
+			return m
+		}
+	}
+	return nil
+}
+
+func genericReceiverName(name string, generics []*ast.GenericParam) string {
+	if len(generics) == 0 {
+		return name
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteByte('[')
+	for i, p := range generics {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(p.Name)
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+func (g *gen) jsonTypeAllowsNull(t ast.Type) bool {
+	switch t := t.(type) {
+	case *ast.OptionalType:
+		return true
+	case *ast.NamedType:
+		if len(t.Path) == 1 {
+			switch t.Path[0] {
+			case "Option", "Json":
+				return true
+			}
+		}
+		if len(t.Path) == 2 && t.Path[1] == "Json" && g.isStdlibAliasName(t.Path[0], "json") {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonOptions(annots []*ast.Annotation, fallback string) jsonAnnotationOptions {
+	opts := jsonAnnotationOptions{name: fallback}
+	for _, ann := range annots {
+		if ann.Name != "json" {
+			continue
+		}
+		for _, arg := range ann.Args {
+			switch arg.Key {
+			case "key":
+				if s, ok := annotationString(arg.Value); ok {
+					opts.name = s
+				}
+			case "skip":
+				opts.skip = true
+			case "optional":
+				opts.optional = true
+			}
+		}
+	}
+	return opts
+}
+
+func annotationString(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.StringLit)
+	if !ok {
+		return "", false
+	}
+	var b strings.Builder
+	for _, p := range lit.Parts {
+		if !p.IsLit {
+			return "", false
+		}
+		b.WriteString(p.Lit)
+	}
+	return b.String(), true
+}

--- a/internal/gen/match.go
+++ b/internal/gen/match.go
@@ -1,0 +1,578 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/types"
+)
+
+// emitMatch lowers a match expression used in value position.
+//
+// The output is an IIFE so match remains usable in expressions
+// (e.g. `let a = match s { ... }`). Each arm lowers to an `if` with a
+// test produced by patternTest and a body that returns the arm expr.
+// Guards apply *after* bindings, so they can reference pattern names.
+//
+// A trailing `panic("unreachable match")` covers the non-exhaustive
+// case. Actual exhaustiveness checking is the type checker's job; the
+// transpiler just runs the generated code honestly.
+func (g *gen) emitMatch(m *ast.MatchExpr) {
+	retType := "any"
+	if t := g.typeOf(m); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		retType = g.goType(t)
+	}
+	name := g.freshVar("_m")
+	g.body.writef("func() %s { %s := ", retType, name)
+	g.emitExpr(m.Scrutinee)
+	g.body.writeln("; _ = " + name)
+	g.body.indent()
+
+	scrutType := g.typeOf(m.Scrutinee)
+	// If the last arm is an unguarded catch-all we know the match is
+	// total — skip the trailing panic (Go flags it as unreachable).
+	totallyCovered := false
+	for i, a := range m.Arms {
+		g.emitMatchArm(name, scrutType, a, true)
+		if i == len(m.Arms)-1 && g.isCatchAll(a.Pattern) && a.Guard == nil {
+			totallyCovered = true
+		}
+	}
+	if !totallyCovered {
+		g.body.writeln(`panic("unreachable match")`)
+	}
+	g.body.dedent()
+	g.body.write("}()")
+}
+
+// emitMatchStmt lowers a match used in statement position, where the
+// arms' return values are discarded. No IIFE wrapper is emitted; the
+// result is a sequence of `if <test> { bindings; body }` blocks.
+func (g *gen) emitMatchStmt(m *ast.MatchExpr) {
+	name := g.freshVar("_m")
+	g.body.writef("{ %s := ", name)
+	g.emitExpr(m.Scrutinee)
+	g.body.writef("; _ = %s\n", name)
+	g.body.indent()
+
+	scrutType := g.typeOf(m.Scrutinee)
+	for _, a := range m.Arms {
+		g.emitMatchArm(name, scrutType, a, false)
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+// emitMatchArm lowers one `pattern [if guard] -> body,` arm.
+//
+// When asExpr is true the body produces a return value; when false it
+// runs purely for its side-effects. In both cases bindings are written
+// before the guard so the guard can reference them.
+func (g *gen) emitMatchArm(scrut string, scrutType types.Type, arm *ast.MatchArm, asExpr bool) {
+	catchAll := g.isCatchAll(arm.Pattern)
+
+	// Fast path: a wildcard / bare-ident catch-all without a guard
+	// always fires, so no outer `if` is needed.
+	if catchAll && arm.Guard == nil {
+		g.body.writeln("{")
+		g.body.indent()
+		g.emitPatternBindings(scrut, scrutType, arm.Pattern)
+		g.emitArmTrailer(arm.Body, asExpr)
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+
+	if !catchAll {
+		g.body.write("if ")
+		g.emitPatternTest(scrut, scrutType, arm.Pattern)
+		g.body.writeln(" {")
+		g.body.indent()
+	} else {
+		// Catch-all with a guard: bindings + guard-test only.
+		g.body.writeln("{")
+		g.body.indent()
+	}
+
+	g.emitPatternBindings(scrut, scrutType, arm.Pattern)
+
+	if arm.Guard != nil {
+		g.body.write("if ")
+		g.emitExpr(arm.Guard)
+		g.body.writeln(" {")
+		g.body.indent()
+		g.emitArmTrailer(arm.Body, asExpr)
+		g.body.dedent()
+		g.body.writeln("}")
+	} else {
+		g.emitArmTrailer(arm.Body, asExpr)
+	}
+
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+// emitArmTrailer writes the body of a match arm, either as a return
+// (expression mode) or as a plain statement followed by `return` from
+// the enclosing IIFE — except in statement mode, where no return is
+// emitted.
+func (g *gen) emitArmTrailer(body ast.Expr, asExpr bool) {
+	if asExpr {
+		g.body.write("return ")
+		g.emitArmBody(body)
+		g.body.nl()
+		return
+	}
+	// Statement mode: run the body for side-effects and fall through.
+	if b, ok := body.(*ast.Block); ok {
+		for _, s := range b.Stmts {
+			g.emitStmt(s)
+		}
+		return
+	}
+	g.emitExpr(body)
+	g.body.nl()
+}
+
+// emitArmBody writes the arm's body expression. A Block body is
+// evaluated via IIFE-free inlining: its final expression becomes the
+// return value.
+func (g *gen) emitArmBody(body ast.Expr) {
+	if b, ok := body.(*ast.Block); ok && len(b.Stmts) > 0 {
+		last := b.Stmts[len(b.Stmts)-1]
+		if es, ok := last.(*ast.ExprStmt); ok {
+			// emit prior stmts inline, then return the last expr.
+			if len(b.Stmts) > 1 {
+				g.body.writeln("")
+				for _, s := range b.Stmts[:len(b.Stmts)-1] {
+					g.emitStmt(s)
+				}
+				g.body.write("return ")
+			}
+			g.emitExpr(es.X)
+			return
+		}
+	}
+	g.emitExpr(body)
+}
+
+// isCatchAll reports whether p matches every value without condition.
+//
+// An IdentPat whose name happens to be a known enum variant is NOT a
+// catch-all — the resolver would have treated it as a variant reference.
+// We detect that case here via the variantOwner map so the match lowers
+// correctly even when the parser reported an IdentPat.
+func (g *gen) isCatchAll(p ast.Pattern) bool {
+	switch p := p.(type) {
+	case *ast.WildcardPat:
+		return true
+	case *ast.IdentPat:
+		if _, isVar := g.variantOwner[p.Name]; isVar {
+			return false
+		}
+		// Prelude variants (None, Some) also aren't catch-alls.
+		switch p.Name {
+		case "None", "Some", "Ok", "Err":
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// isCatchAll is kept as a package function so external callers
+// (if any) keep working; it ignores variant-name shadowing.
+func isCatchAll(p ast.Pattern) bool {
+	switch p.(type) {
+	case *ast.WildcardPat, *ast.IdentPat:
+		return true
+	}
+	return false
+}
+
+// emitPatternTest writes a boolean expression that is true iff the
+// scrutinee matches the pattern.
+//
+// Bindings (IdentPat, BindingPat) don't contribute to the test — they
+// always succeed and only matter for emitPatternBindings.
+func (g *gen) emitPatternTest(scrut string, scrutType types.Type, p ast.Pattern) {
+	switch p := p.(type) {
+	case *ast.WildcardPat:
+		g.body.write("true")
+	case *ast.IdentPat:
+		// IdentPat may actually be a bare variant reference when its
+		// name matches a declared (or prelude) enum variant. The
+		// resolver treats it as a variant in that case; we mirror.
+		if owner, ok := g.variantOwner[p.Name]; ok {
+			g.body.writef("func() bool { _, ok := %s.(*%s_%s); return ok }()",
+				scrut, owner, p.Name)
+			return
+		}
+		switch p.Name {
+		case "None":
+			g.body.writef("%s == nil", scrut)
+			return
+		}
+		g.body.write("true")
+	case *ast.LiteralPat:
+		g.body.writef("%s == ", scrut)
+		g.emitExpr(p.Literal)
+	case *ast.VariantPat:
+		// `Some(...)` / `None` / `Shape.Circle(...)`. Option and Result
+		// are special because they're not interface-backed.
+		//
+		// Option lowers to *T; the test is a nil check.
+		// Result lowers to a struct with an IsOk tag; the test reads it.
+		if len(p.Path) == 0 {
+			g.body.write("false")
+			return
+		}
+		vname := p.Path[len(p.Path)-1]
+		if isOptionScrut(scrutType) || vname == "Some" || vname == "None" {
+			// Avoid routing Ok/Err into the Option path even when the
+			// scrutinee type was lost.
+			if !isResultVariant(vname) {
+				if vname == "Some" {
+					g.body.writef("%s != nil", scrut)
+				} else if vname == "None" {
+					g.body.writef("%s == nil", scrut)
+				} else {
+					g.body.write("false")
+				}
+				return
+			}
+		}
+		if isResultScrut(scrutType) || isResultVariant(vname) {
+			switch vname {
+			case "Ok":
+				g.body.writef("%s.IsOk", scrut)
+			case "Err":
+				g.body.writef("!%s.IsOk", scrut)
+			default:
+				g.body.write("false")
+			}
+			return
+		}
+		owner := g.enumOwnerForPath(scrutType, p.Path)
+		g.body.writef("func() bool { _, ok := %s.(*%s_%s); return ok }()",
+			scrut, owner, vname)
+	case *ast.RangePat:
+		g.emitRangeTest(scrut, p)
+	case *ast.OrPat:
+		g.body.write("(")
+		for i, alt := range p.Alts {
+			if i > 0 {
+				g.body.write(" || ")
+			}
+			g.emitPatternTest(scrut, scrutType, alt)
+		}
+		g.body.write(")")
+	case *ast.BindingPat:
+		// `name @ inner` — binding always succeeds, the test is inner.
+		g.emitPatternTest(scrut, scrutType, p.Pattern)
+	case *ast.TuplePat:
+		g.emitTuplePatTest(scrut, scrutType, p)
+	case *ast.StructPat:
+		g.emitStructPatTest(scrut, scrutType, p)
+	default:
+		g.body.writef("true /* TODO: pattern %T */", p)
+	}
+}
+
+// emitTuplePatTest writes `scrut.F0 matches p0 && scrut.F1 matches p1 && ...`
+// for a tuple pattern. Wildcard / bare-ident sub-patterns always succeed
+// so they're elided from the conjunction, leaving `true` in the
+// degenerate case (pure binding tuple).
+func (g *gen) emitTuplePatTest(scrut string, scrutType types.Type, p *ast.TuplePat) {
+	var elemTypes []types.Type
+	if tup, ok := scrutType.(*types.Tuple); ok {
+		elemTypes = tup.Elems
+	}
+	g.body.write("(")
+	wrote := false
+	for i, elem := range p.Elems {
+		if isCatchAll(elem) {
+			continue
+		}
+		if wrote {
+			g.body.write(" && ")
+		}
+		wrote = true
+		field := scrut + ".F" + itoa(i)
+		var et types.Type
+		if i < len(elemTypes) {
+			et = elemTypes[i]
+		}
+		g.emitPatternTest(field, et, elem)
+	}
+	if !wrote {
+		g.body.write("true")
+	}
+	g.body.write(")")
+}
+
+// emitStructPatTest writes the conjunction of per-field tests for a
+// struct pattern. A rest (`..`) or wildcard sub-pattern is a success by
+// construction and is omitted from the output.
+func (g *gen) emitStructPatTest(scrut string, scrutType types.Type, p *ast.StructPat) {
+	g.body.write("(")
+	wrote := false
+	for _, f := range p.Fields {
+		sub := f.Pattern
+		if sub == nil {
+			// Shorthand `{ name }` — pure binding, always succeeds.
+			continue
+		}
+		if isCatchAll(sub) {
+			continue
+		}
+		if wrote {
+			g.body.write(" && ")
+		}
+		wrote = true
+		field := scrut + "." + mangleIdent(f.Name)
+		g.emitPatternTest(field, nil, sub)
+	}
+	if !wrote {
+		g.body.write("true")
+	}
+	g.body.write(")")
+}
+
+// emitRangeTest writes `scrut >= start && scrut <(=) stop` for a range
+// pattern. Missing bounds become half-open ranges.
+func (g *gen) emitRangeTest(scrut string, p *ast.RangePat) {
+	first := true
+	g.body.write("(")
+	if p.Start != nil {
+		g.body.writef("%s >= ", scrut)
+		g.emitExpr(p.Start)
+		first = false
+	}
+	if p.Stop != nil {
+		if !first {
+			g.body.write(" && ")
+		}
+		cmp := "<"
+		if p.Inclusive {
+			cmp = "<="
+		}
+		g.body.writef("%s %s ", scrut, cmp)
+		g.emitExpr(p.Stop)
+	}
+	if first && p.Stop == nil {
+		// Unbounded both sides — matches everything.
+		g.body.write("true")
+	}
+	g.body.write(")")
+}
+
+// emitPatternBindings writes any variable bindings introduced by the
+// pattern, given that the test already succeeded. Called AFTER the
+// test in the generated if-body.
+func (g *gen) emitPatternBindings(scrut string, scrutType types.Type, p ast.Pattern) {
+	switch p := p.(type) {
+	case *ast.WildcardPat:
+		// nothing
+	case *ast.IdentPat:
+		// Variant-name IdentPat: no binding, just the tag was checked.
+		if _, isVar := g.variantOwner[p.Name]; isVar {
+			return
+		}
+		switch p.Name {
+		case "None", "Some", "Ok", "Err":
+			return
+		}
+		g.body.writef("%s := %s; _ = %s\n", mangleIdent(p.Name), scrut, mangleIdent(p.Name))
+	case *ast.VariantPat:
+		if len(p.Args) == 0 {
+			return
+		}
+		vname := p.Path[len(p.Path)-1]
+		// Option: `Some(n)` binds by dereferencing the pointer.
+		if (isOptionScrut(scrutType) || vname == "Some") && vname == "Some" {
+			if len(p.Args) == 1 {
+				inner := p.Args[0]
+				if id, ok := inner.(*ast.IdentPat); ok {
+					g.body.writef("%s := *%s; _ = %s\n",
+						mangleIdent(id.Name), scrut, mangleIdent(id.Name))
+					return
+				}
+				if _, ok := inner.(*ast.WildcardPat); ok {
+					return
+				}
+				// Nested patterns — bind via the dereferenced value.
+				tmp := g.freshVar("_v")
+				g.body.writef("%s := *%s; _ = %s\n", tmp, scrut, tmp)
+				g.emitPatternBindings(tmp, nil, inner)
+				return
+			}
+		}
+		// Result: `Ok(v)` / `Err(e)` bind from the struct fields.
+		if isResultScrut(scrutType) || isResultVariant(vname) {
+			if len(p.Args) == 1 {
+				inner := p.Args[0]
+				field := "Value"
+				if vname == "Err" {
+					field = "Error"
+				}
+				if id, ok := inner.(*ast.IdentPat); ok {
+					g.body.writef("%s := %s.%s; _ = %s\n",
+						mangleIdent(id.Name), scrut, field, mangleIdent(id.Name))
+					return
+				}
+				if _, ok := inner.(*ast.WildcardPat); ok {
+					return
+				}
+				tmp := g.freshVar("_v")
+				g.body.writef("%s := %s.%s; _ = %s\n", tmp, scrut, field, tmp)
+				g.emitPatternBindings(tmp, nil, inner)
+				return
+			}
+		}
+		owner := g.enumOwnerForPath(scrutType, p.Path)
+		// Reconstruct via type assertion + per-arg Fi access.
+		tmp := g.freshVar("_v")
+		g.body.writef("%s := %s.(*%s_%s); _ = %s\n", tmp, scrut, owner, vname, tmp)
+		for i, a := range p.Args {
+			if _, ok := a.(*ast.WildcardPat); ok {
+				continue
+			}
+			if id, ok := a.(*ast.IdentPat); ok {
+				g.body.writef("%s := %s.F%d; _ = %s\n",
+					mangleIdent(id.Name), tmp, i, mangleIdent(id.Name))
+				continue
+			}
+			// Nested patterns — recurse.
+			nested := g.freshVar("_f")
+			g.body.writef("%s := %s.F%d; _ = %s\n", nested, tmp, i, nested)
+			g.emitPatternBindings(nested, nil, a)
+		}
+	case *ast.BindingPat:
+		g.body.writef("%s := %s; _ = %s\n",
+			mangleIdent(p.Name), scrut, mangleIdent(p.Name))
+		g.emitPatternBindings(scrut, scrutType, p.Pattern)
+	case *ast.OrPat:
+		// Bindings must be consistent across alts by spec; lower by
+		// re-binding from the first alt.
+		if len(p.Alts) > 0 {
+			g.emitPatternBindings(scrut, scrutType, p.Alts[0])
+		}
+	case *ast.TuplePat:
+		// Recurse into each element: `scrut.Fi` is the sub-scrutinee.
+		var elemTypes []types.Type
+		if tup, ok := scrutType.(*types.Tuple); ok {
+			elemTypes = tup.Elems
+		}
+		for i, elem := range p.Elems {
+			if _, ok := elem.(*ast.WildcardPat); ok {
+				continue
+			}
+			field := g.freshVar("_tf")
+			g.body.writef("%s := %s.F%d; _ = %s\n", field, scrut, i, field)
+			var et types.Type
+			if i < len(elemTypes) {
+				et = elemTypes[i]
+			}
+			g.emitPatternBindings(field, et, elem)
+		}
+	case *ast.StructPat:
+		for _, f := range p.Fields {
+			if f.Pattern == nil {
+				// Shorthand `{ name }` — bind the field directly.
+				g.body.writef("%s := %s.%s; _ = %s\n",
+					mangleIdent(f.Name), scrut, mangleIdent(f.Name), mangleIdent(f.Name))
+				continue
+			}
+			if _, ok := f.Pattern.(*ast.WildcardPat); ok {
+				continue
+			}
+			if id, ok := f.Pattern.(*ast.IdentPat); ok {
+				g.body.writef("%s := %s.%s; _ = %s\n",
+					mangleIdent(id.Name), scrut, mangleIdent(f.Name), mangleIdent(id.Name))
+				continue
+			}
+			// Nested pattern: recurse on the field projection.
+			sub := g.freshVar("_sf")
+			g.body.writef("%s := %s.%s; _ = %s\n",
+				sub, scrut, mangleIdent(f.Name), sub)
+			g.emitPatternBindings(sub, nil, f.Pattern)
+		}
+	case *ast.LiteralPat, *ast.RangePat:
+		// Literal / range patterns introduce no bindings.
+	}
+}
+
+// isOptionScrut reports whether the match scrutinee's semantic type is
+// `T?` / `Option<T>` — Optional lowers to *T in Go, which takes the
+// nil-check path rather than the interface-type-assertion path.
+func isOptionScrut(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	if _, ok := t.(*types.Optional); ok {
+		return true
+	}
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Option" {
+		return true
+	}
+	return false
+}
+
+// isResultScrut reports whether the match scrutinee's semantic type is
+// `Result<T, E>`. Result lowers to a Go struct (Value/Error/IsOk), so
+// pattern tests and bindings go through struct field access rather than
+// type assertions. When the checker lost the type we still route
+// Ok/Err patterns through here — the bare variant names are unambiguous
+// in prelude terms.
+func isResultScrut(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" {
+		return true
+	}
+	return false
+}
+
+// isResultVariant reports whether `name` is one of Result's prelude
+// variants. Used to route patterns when the scrutinee type wasn't
+// inferred (e.g., inside a nested match whose scrutinee is itself a
+// pattern binding whose type we lost).
+func isResultVariant(name string) bool {
+	return name == "Ok" || name == "Err"
+}
+
+// enumOwnerForPath returns the owning enum name for a variant pattern,
+// preferring the scrutinee's type when available and falling back to
+// the file-local variant owner index.
+func (g *gen) enumOwnerForPath(scrutType types.Type, path []string) string {
+	if len(path) >= 2 {
+		// Explicit `EnumName.Variant` form.
+		return path[len(path)-2]
+	}
+	name := path[len(path)-1]
+	if owner, ok := g.variantOwner[name]; ok {
+		return owner
+	}
+	// Scrutinee type fallback (e.g., Option<T>).
+	if n, ok := scrutType.(*types.Named); ok && n.Sym != nil {
+		return n.Sym.Name
+	}
+	// Prelude Option variants default to "Option".
+	switch name {
+	case "Some", "None":
+		return "Option"
+	case "Ok", "Err":
+		return "Result"
+	}
+	return "???"
+}
+
+// freshVar returns a unique local name derived from prefix.
+func (g *gen) freshVar(prefix string) string {
+	g.freshCounter++
+	return fmt.Sprintf("%s%d", prefix, g.freshCounter)
+}

--- a/internal/gen/monomorph.go
+++ b/internal/gen/monomorph.go
@@ -1,0 +1,221 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// Generic monomorphization (§2.7.3).
+//
+// The checker records every generic call site's concrete type-argument
+// list on Result.Instantiations. This file drives the lowering: for
+// each reachable (generic fn × concrete type tuple) pair we emit one
+// specialized copy, rewriting its body's generic calls recursively so
+// the transform reaches transitive instantiations as well. A generic
+// fn with no reachable instantiations emits nothing — matching the
+// spec's "header-like" demand-driven framing.
+//
+// Scope (out of scope here): generic struct / enum / alias types and
+// methods on generic types still flow through the Go-native generics
+// path. Tightening those is a separate, larger refactor.
+
+// instRecord is one specialized instantiation of a generic fn — the
+// concrete Go type rendering of each type argument plus the mangled
+// Go name the specialization is emitted under.
+type instRecord struct {
+	Fn      *ast.FnDecl
+	Sym     *resolve.Symbol
+	GoTypes []string
+	Mangled string
+}
+
+// requestInstance records that `(sym, goTypes)` is reachable and must
+// be emitted. Returns the mangled name the caller should emit at the
+// call site. Idempotent: repeated requests for the same (sym, tuple)
+// dedupe to the same name without re-enqueueing.
+func (g *gen) requestInstance(sym *resolve.Symbol, goTypes []string) string {
+	fn, ok := sym.Decl.(*ast.FnDecl)
+	if !ok || fn == nil {
+		return ""
+	}
+	key := instDedupeKey(sym, goTypes)
+	if name, ok := g.instByKey[key]; ok {
+		return name
+	}
+	mangled := mangleInst(fn.Name, goTypes)
+	rec := instRecord{Fn: fn, Sym: sym, GoTypes: goTypes, Mangled: mangled}
+	g.instByKey[key] = mangled
+	g.instQueue = append(g.instQueue, rec)
+	return mangled
+}
+
+// instDedupeKey builds a map key that identifies a (symbol, type-tuple)
+// pair. Uses a unit-separator byte between the pointer repr and each
+// type fragment so `id_int` vs `id_int*` can't collide.
+func instDedupeKey(sym *resolve.Symbol, goTypes []string) string {
+	var b strings.Builder
+	b.WriteString(sym.Name)
+	b.WriteByte(0x1f)
+	b.WriteString(sym.Pos.String())
+	for _, t := range goTypes {
+		b.WriteByte(0x1f)
+		b.WriteString(t)
+	}
+	return b.String()
+}
+
+// initInstances resets the per-file monomorphization state. Called
+// once per gen.run() before any decl is visited.
+func (g *gen) initInstances() {
+	g.instByKey = map[string]string{}
+	g.instQueue = nil
+}
+
+// drainInstances emits every queued specialization and every further
+// specialization triggered by their bodies. Runs to a fixed point;
+// bounded by the call graph which is finite for any well-typed input.
+func (g *gen) drainInstances() {
+	// Index-based loop so appends during emission are picked up.
+	for i := 0; i < len(g.instQueue); i++ {
+		rec := g.instQueue[i]
+		cleanup := g.pushSubst(rec.Fn.Generics, rec.GoTypes)
+		g.emitFnDeclBody(rec.Fn, rec.Mangled)
+		cleanup()
+	}
+}
+
+// calleeSymbol resolves the function expression of a CallExpr to its
+// declaring Symbol, or nil when the callee isn't a direct user-defined
+// function reference (variable holding a closure, method call, etc.).
+func (g *gen) calleeSymbol(fn ast.Expr) *resolve.Symbol {
+	switch e := fn.(type) {
+	case *ast.Ident:
+		return g.symbolFor(e)
+	case *ast.TurbofishExpr:
+		if id, ok := e.Base.(*ast.Ident); ok {
+			return g.symbolFor(id)
+		}
+	}
+	return nil
+}
+
+// callMonoName returns the mangled specialization name for a generic
+// call site, or "" when the call isn't a generic fn call (or the
+// callee isn't a user-defined fn). Records the instantiation on the
+// pending queue as a side effect so downstream emission picks it up.
+//
+// The current substEnv is implicitly consumed: g.goType on a TypeVar
+// whose name is in substEnv substitutes its concrete Go type, so a
+// call `id(y)` inside `wrap<U>` being monomorphized at U=Int yields
+// goTypes=["int"] here. This is how transitive instantiation works —
+// a generic fn's body is visited once per outer monomorph, and each
+// inner generic call is re-specialized under that monomorph's subst.
+func (g *gen) callMonoName(c *ast.CallExpr) string {
+	if g.chk == nil {
+		return ""
+	}
+	args, ok := g.chk.Instantiations[c]
+	if !ok || len(args) == 0 {
+		return ""
+	}
+	sym := g.calleeSymbol(c.Fn)
+	if sym == nil || sym.Kind != resolve.SymFn {
+		return ""
+	}
+	fn, ok := sym.Decl.(*ast.FnDecl)
+	if !ok || fn == nil || len(fn.Generics) == 0 {
+		return ""
+	}
+	if len(args) != len(fn.Generics) {
+		return ""
+	}
+	goTypes := make([]string, len(args))
+	for i, a := range args {
+		goTypes[i] = g.goType(a)
+	}
+	// If any arg resolved to a symbolic name still (unhandled TypeVar)
+	// we bail — the call can't be safely monomorphized, fall through
+	// to the generic path. This catches bugs rather than emitting
+	// invalid Go silently.
+	for _, t := range goTypes {
+		if t == "" {
+			return ""
+		}
+	}
+	return g.requestInstance(sym, goTypes)
+}
+
+// mangleInst builds the specialized fn name. Illegal identifier
+// characters in a Go type rendering (`[`, `]`, `.`, space, `*`) are
+// flattened so e.g. `[]int` → `Ofint` — uniqueness within the set of
+// types Osty currently emits is preserved; human readability is a
+// non-goal here.
+func mangleInst(name string, goTypes []string) string {
+	var b strings.Builder
+	b.WriteString(name)
+	for _, t := range goTypes {
+		b.WriteByte('_')
+		b.WriteString(sanitizeTypeName(t))
+	}
+	return b.String()
+}
+
+// sanitizeTypeName collapses a Go type string into a conservative
+// identifier fragment. `[` / `]` become `Of`, `*` → `Ptr`, spaces
+// dropped, anything else non-alphanumeric → `_`. The mapping is
+// injective over the set of Go type strings Osty currently emits,
+// which is what monomorphization-name distinctness requires.
+func sanitizeTypeName(t string) string {
+	var b strings.Builder
+	for _, r := range t {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '[' || r == ']':
+			b.WriteString("Of")
+		case r == '*':
+			b.WriteString("Ptr")
+		case r == ' ':
+			// drop
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "T"
+	}
+	return b.String()
+}
+
+// pushSubst binds each generic parameter name to its Go rendering for
+// the duration of a monomorphized emission. The returned cleanup
+// restores the previous env; call it with `defer`.
+func (g *gen) pushSubst(params []*ast.GenericParam, goTypes []string) func() {
+	prev := g.substEnv
+	next := map[string]string{}
+	for k, v := range prev {
+		next[k] = v
+	}
+	for i, p := range params {
+		if i >= len(goTypes) {
+			break
+		}
+		next[p.Name] = goTypes[i]
+	}
+	g.substEnv = next
+	return func() { g.substEnv = prev }
+}
+
+// lookupSubst reports whether `name` is a generic type-parameter
+// currently in scope and returns its concrete Go rendering if so.
+func (g *gen) lookupSubst(name string) (string, bool) {
+	if g.substEnv == nil {
+		return "", false
+	}
+	v, ok := g.substEnv[name]
+	return v, ok
+}

--- a/internal/gen/primitive_methods.go
+++ b/internal/gen/primitive_methods.go
@@ -1,0 +1,1156 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/types"
+)
+
+func (g *gen) emitPrimitiveMethodCall(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if f.IsOptional {
+		return false
+	}
+	p, ok := g.primitiveReceiver(f.X)
+	if !ok {
+		return false
+	}
+	switch {
+	case p.Kind == types.PBool:
+		return g.emitBoolMethod(c, f)
+	case p.Kind == types.PChar:
+		return g.emitCharMethod(c, f)
+	case p.Kind == types.PString:
+		return g.emitStringMethod(c, f)
+	case p.Kind == types.PBytes:
+		return g.emitBytesMethod(c, f)
+	case p.Kind.IsInteger():
+		return g.emitIntMethod(c, f, p.Kind)
+	case p.Kind.IsFloat():
+		return g.emitFloatMethod(c, f, p.Kind)
+	}
+	return false
+}
+
+func (g *gen) primitiveReceiver(e ast.Expr) (*types.Primitive, bool) {
+	switch t := g.typeOf(e).(type) {
+	case *types.Primitive:
+		return t, true
+	case *types.Untyped:
+		if p, ok := t.Default().(*types.Primitive); ok {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+func (g *gen) emitBoolMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	switch f.Name {
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strconv")
+		g.body.write("strconv.FormatBool(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "toInt":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("func() int { if ")
+		g.emitExpr(f.X)
+		g.body.write(" { return 1 }; return 0 }()")
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitCharMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	switch f.Name {
+	case "toInt":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("int(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("string(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isDigit", "isAlpha", "isAlphanumeric", "isWhitespace", "isUpper", "isLower":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("unicode")
+		switch f.Name {
+		case "isAlpha":
+			g.body.write("unicode.IsLetter(")
+			g.emitExpr(f.X)
+			g.body.write(")")
+		case "isAlphanumeric":
+			g.body.write("func() bool { c := ")
+			g.emitExpr(f.X)
+			g.body.write("; return unicode.IsLetter(c) || unicode.IsDigit(c) }()")
+		case "isWhitespace":
+			g.body.write("unicode.IsSpace(")
+			g.emitExpr(f.X)
+			g.body.write(")")
+		default:
+			fn := map[string]string{
+				"isDigit": "IsDigit",
+				"isUpper": "IsUpper",
+				"isLower": "IsLower",
+			}[f.Name]
+			g.body.write("unicode.")
+			g.body.write(fn)
+			g.body.write("(")
+			g.emitExpr(f.X)
+			g.body.write(")")
+		}
+	case "toUpper", "toLower":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("unicode")
+		if f.Name == "toUpper" {
+			g.body.write("unicode.ToUpper(")
+		} else {
+			g.body.write("unicode.ToLower(")
+		}
+		g.emitExpr(f.X)
+		g.body.write(")")
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitStringMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "charCount":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len([]rune(")
+		g.emitExpr(f.X)
+		g.body.write("))")
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitPrimitiveIIFE("*byte", f.X, func(s string) {
+			i := g.freshVar("_idx")
+			g.body.writef("%s := ", i)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 || %s >= len(%s) { return nil }\n", i, i, s)
+			g.body.writef("v := %s[%s]\n", s, i)
+			g.body.writeln("return &v")
+		})
+	case "contains", "startsWith", "endsWith":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strings")
+		fn := map[string]string{
+			"contains":   "Contains",
+			"startsWith": "HasPrefix",
+			"endsWith":   "HasSuffix",
+		}[f.Name]
+		g.body.write("strings.")
+		g.body.write(fn)
+		g.body.write("(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+	case "indexOf":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strings")
+		g.emitPrimitiveIIFE("*int", f.X, func(s string) {
+			g.body.write("needle := ")
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("i := strings.Index(%s, needle)\n", s)
+			g.body.writeln("if i < 0 { return nil }")
+			g.body.writeln("return &i")
+		})
+	case "split":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strings")
+		g.body.write("strings.Split(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+	case "lines":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strings")
+		g.body.write(`strings.Split(strings.TrimSuffix(`)
+		g.emitExpr(f.X)
+		g.body.write(`, "\n"), "\n")`)
+	case "join":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strings")
+		g.body.write("strings.Join(")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(", ")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "trim", "trimStart", "trimEnd":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strings")
+		switch f.Name {
+		case "trim":
+			g.body.write("strings.TrimSpace(")
+		case "trimStart":
+			g.body.write("strings.TrimLeftFunc(")
+		case "trimEnd":
+			g.body.write("strings.TrimRightFunc(")
+		}
+		g.emitExpr(f.X)
+		if f.Name == "trim" {
+			g.body.write(")")
+		} else {
+			g.use("unicode")
+			g.body.write(", unicode.IsSpace)")
+		}
+	case "toUpper", "toLower":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strings")
+		if f.Name == "toUpper" {
+			g.body.write("strings.ToUpper(")
+		} else {
+			g.body.write("strings.ToLower(")
+		}
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "replace":
+		if len(c.Args) != 2 {
+			return false
+		}
+		g.use("strings")
+		g.body.write("strings.Replace(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(", ")
+		g.emitExpr(c.Args[1].Value)
+		g.body.write(", 1)")
+	case "repeat":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strings")
+		g.body.write("strings.Repeat(")
+		g.emitExpr(f.X)
+		g.body.write(", ")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")")
+	case "chars":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("[]rune(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "bytes", "toBytes":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("[]byte(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "graphemes":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitStringGraphemes(f.X)
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitExpr(f.X)
+	case "toInt":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strconv")
+		g.needResult = true
+		g.emitPrimitiveIIFE("Result[int, any]", f.X, func(s string) {
+			g.body.writef("v, err := strconv.Atoi(%s)\n", s)
+			g.body.writeln("if err != nil { return resultErr[int, any](err) }")
+			g.body.writeln("return resultOk[int, any](v)")
+		})
+	case "toFloat":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strconv")
+		g.needResult = true
+		g.emitPrimitiveIIFE("Result[float64, any]", f.X, func(s string) {
+			g.body.writef("v, err := strconv.ParseFloat(%s, 64)\n", s)
+			g.body.writeln("if err != nil { return resultErr[float64, any](err) }")
+			g.body.writeln("return resultOk[float64, any](v)")
+		})
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitStringGraphemes(recv ast.Expr) {
+	g.requestStdlibOsty("strings")
+	g.body.write(stdlibOstyFuncName("strings", "graphemes"))
+	g.body.write("(")
+	g.emitExpr(recv)
+	g.body.write(")")
+}
+
+func (g *gen) emitBytesMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+	case "get":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitPrimitiveIIFE("*byte", f.X, func(b string) {
+			i := g.freshVar("_idx")
+			g.body.writef("%s := ", i)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 || %s >= len(%s) { return nil }\n", i, i, b)
+			g.body.writef("v := %s[%s]\n", b, i)
+			g.body.writeln("return &v")
+		})
+	case "concat":
+		if len(c.Args) != 1 {
+			return false
+		}
+		retGo := g.callReturnGo(c, "[]byte")
+		g.emitPrimitiveIIFE(retGo, f.X, func(b string) {
+			other := g.freshVar("_other")
+			g.body.writef("var %s []byte = ", other)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("out := make(%s, 0, len(%s)+len(%s))\n", retGo, b, other)
+			g.body.writef("out = append(out, %s...)\n", b)
+			g.body.writef("out = append(out, %s...)\n", other)
+			g.body.writeln("return out")
+		})
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.needResult = true
+		g.useAs("unicode/utf8", "_ostybytesutf8")
+		g.emitPrimitiveIIFE("Result[string, any]", f.X, func(b string) {
+			g.body.writef("if !_ostybytesutf8.Valid(%s) { return resultErr[string, any](fmt.Errorf(%q)) }\n", b, "invalid UTF-8")
+			g.body.writef("return resultOk[string, any](string(%s))\n", b)
+		})
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitIntMethod(c *ast.CallExpr, f *ast.FieldExpr, recv types.PrimitiveKind) bool {
+	goT := goPrimitive(recv)
+	switch f.Name {
+	case "abs", "wrappingAbs":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitIntAbs(f, recv, goT, f.Name == "wrappingAbs")
+	case "min", "max":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			other := g.freshVar("_other")
+			g.body.writef("var %s %s = ", other, goT)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			op := "<"
+			if f.Name == "max" {
+				op = ">"
+			}
+			g.body.writef("if %s %s %s { return %s }\n", v, op, other, v)
+			g.body.writef("return %s\n", other)
+		})
+	case "clamp":
+		if len(c.Args) != 2 {
+			return false
+		}
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			lo := g.freshVar("_lo")
+			hi := g.freshVar("_hi")
+			g.body.writef("var %s %s = ", lo, goT)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("var %s %s = ", hi, goT)
+			g.emitExpr(c.Args[1].Value)
+			g.body.nl()
+			g.body.writef("if %s < %s { return %s }\n", v, lo, lo)
+			g.body.writef("if %s > %s { return %s }\n", v, hi, hi)
+			g.body.writef("return %s\n", v)
+		})
+	case "signum":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			if recv.IsSignedInt() {
+				g.body.writef("if %s < 0 { return %s(-1) }\n", v, goT)
+			}
+			g.body.writef("if %s > 0 { return %s(1) }\n", v, goT)
+			g.body.writef("return %s(0)\n", goT)
+		})
+	case "wrappingAdd", "wrappingSub", "wrappingMul", "wrappingDiv", "wrappingMod":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitWrappingIntBinary(f.Name, f, c.Args[0].Value, recv, goT)
+	case "wrappingShl", "wrappingShr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitWrappingIntShift(f.Name, f, c.Args[0].Value, recv, goT)
+	case "wrappingNeg":
+		if len(c.Args) != 0 {
+			return false
+		}
+		if recv.IsUnsignedInt() {
+			g.body.write("(")
+			g.body.write(goT)
+			g.body.write("(0) - ")
+			g.emitExpr(f.X)
+			g.body.write(")")
+		} else {
+			g.body.write("(-")
+			g.emitExpr(f.X)
+			g.body.write(")")
+		}
+	case "checkedAdd", "checkedSub", "checkedMul", "checkedDiv", "checkedMod":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCheckedIntBinary(f.Name, f, c.Args[0].Value, recv, goT)
+	case "checkedShl", "checkedShr":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitCheckedIntShift(f.Name, f, c.Args[0].Value, recv, goT)
+	case "checkedAbs":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitCheckedIntAbs(f, recv, goT)
+	case "checkedNeg":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitCheckedIntNeg(f, recv, goT)
+	case "saturatingAdd", "saturatingSub", "saturatingMul", "saturatingDiv":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitSaturatingIntBinary(f.Name, f, c.Args[0].Value, recv, goT)
+	case "pow":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitIntPow(f, c.Args[0].Value, recv, goT)
+	case "toInt", "toInt64", "toFloat", "toFloat32", "toFloat64", "toChar":
+		if len(c.Args) != 0 {
+			return false
+		}
+		if f.Name == "toChar" {
+			g.emitPrimitiveIIFE("rune", f.X, func(v string) {
+				g.body.writef("if %s < 0 || %s > 0x10ffff || (%s >= 0xd800 && %s <= 0xdfff) { panic(%q) }\n",
+					v, v, v, v, "invalid Char code point")
+				g.body.writef("return rune(%s)\n", v)
+			})
+			return true
+		}
+		target := map[string]string{
+			"toInt":     "int",
+			"toInt64":   "int64",
+			"toFloat":   "float64",
+			"toFloat32": "float32",
+			"toFloat64": "float64",
+		}[f.Name]
+		g.body.write(target)
+		g.body.write("(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "toInt8", "toInt16", "toInt32", "toUInt8", "toByte", "toUInt16", "toUInt32", "toUInt64":
+		if len(c.Args) != 0 {
+			return false
+		}
+		return g.emitIntConversionResult(f, recv)
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strconv")
+		if recv.IsUnsignedInt() {
+			g.body.write("strconv.FormatUint(uint64(")
+			g.emitExpr(f.X)
+			g.body.write("), 10)")
+		} else {
+			g.body.write("strconv.FormatInt(int64(")
+			g.emitExpr(f.X)
+			g.body.write("), 10)")
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+type intRuntimeInfo struct {
+	min    string
+	max    string
+	bits   string
+	signed bool
+}
+
+func runtimeIntInfo(k types.PrimitiveKind) intRuntimeInfo {
+	switch k {
+	case types.PInt:
+		return intRuntimeInfo{min: "math.MinInt", max: "math.MaxInt", bits: "strconv.IntSize", signed: true}
+	case types.PInt8:
+		return intRuntimeInfo{min: "math.MinInt8", max: "math.MaxInt8", bits: "8", signed: true}
+	case types.PInt16:
+		return intRuntimeInfo{min: "math.MinInt16", max: "math.MaxInt16", bits: "16", signed: true}
+	case types.PInt32:
+		return intRuntimeInfo{min: "math.MinInt32", max: "math.MaxInt32", bits: "32", signed: true}
+	case types.PInt64:
+		return intRuntimeInfo{min: "math.MinInt64", max: "math.MaxInt64", bits: "64", signed: true}
+	case types.PUInt8, types.PByte:
+		return intRuntimeInfo{min: "0", max: "math.MaxUint8", bits: "8"}
+	case types.PUInt16:
+		return intRuntimeInfo{min: "0", max: "math.MaxUint16", bits: "16"}
+	case types.PUInt32:
+		return intRuntimeInfo{min: "0", max: "math.MaxUint32", bits: "32"}
+	case types.PUInt64:
+		return intRuntimeInfo{min: "0", max: "math.MaxUint64", bits: "64"}
+	default:
+		return intRuntimeInfo{min: "0", max: "0", bits: "0"}
+	}
+}
+
+func (g *gen) emitIntAbs(f *ast.FieldExpr, recv types.PrimitiveKind, goT string, wrapping bool) {
+	if recv.IsUnsignedInt() {
+		g.emitExpr(f.X)
+		return
+	}
+	g.use("math")
+	info := runtimeIntInfo(recv)
+	g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+		if wrapping {
+			g.body.writef("if %s == %s { return %s }\n", v, info.min, v)
+		} else {
+			g.body.writef("if %s == %s { panic(%q) }\n", v, info.min, "integer overflow")
+		}
+		g.body.writef("if %s < 0 { return -%s }\n", v, v)
+		g.body.writef("return %s\n", v)
+	})
+}
+
+func (g *gen) emitWrappingIntBinary(name string, f *ast.FieldExpr, arg ast.Expr, recv types.PrimitiveKind, goT string) {
+	op := map[string]string{
+		"wrappingAdd": "+",
+		"wrappingSub": "-",
+		"wrappingMul": "*",
+		"wrappingDiv": "/",
+		"wrappingMod": "%",
+	}[name]
+	if recv.IsSignedInt() && (name == "wrappingDiv" || name == "wrappingMod") {
+		g.use("math")
+		info := runtimeIntInfo(recv)
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			rhs := g.freshVar("_rhs")
+			g.body.writef("var %s %s = ", rhs, goT)
+			g.emitExpr(arg)
+			g.body.nl()
+			g.body.writef("if %s == %s && %s == %s(-1) {\n", v, info.min, rhs, goT)
+			g.body.indent()
+			if name == "wrappingDiv" {
+				g.body.writef("return %s\n", v)
+			} else {
+				g.body.writef("return %s(0)\n", goT)
+			}
+			g.body.dedent()
+			g.body.writeln("}")
+			g.body.writef("return %s %s %s\n", v, op, rhs)
+		})
+		return
+	}
+	g.body.write("(")
+	g.emitExpr(f.X)
+	g.body.write(" ")
+	g.body.write(op)
+	g.body.write(" ")
+	g.emitExpr(arg)
+	g.body.write(")")
+}
+
+func (g *gen) emitWrappingIntShift(name string, f *ast.FieldExpr, arg ast.Expr, recv types.PrimitiveKind, goT string) {
+	if recv == types.PInt {
+		g.use("strconv")
+	}
+	info := runtimeIntInfo(recv)
+	op := "<<"
+	if name == "wrappingShr" {
+		op = ">>"
+	}
+	g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+		rhs := g.freshVar("_rhs")
+		g.body.writef("var %s int = ", rhs)
+		g.emitExpr(arg)
+		g.body.nl()
+		g.body.writef("bitWidth := int(%s)\n", info.bits)
+		g.body.writef("shift := %s %% bitWidth\n", rhs)
+		g.body.writeln("if shift < 0 { shift += bitWidth }")
+		g.body.writef("return %s %s uint(shift)\n", v, op)
+	})
+}
+
+func (g *gen) emitCheckedIntBinary(name string, f *ast.FieldExpr, arg ast.Expr, recv types.PrimitiveKind, goT string) {
+	info := runtimeIntInfo(recv)
+	if name == "checkedAdd" || name == "checkedSub" || name == "checkedMul" || recv.IsSignedInt() {
+		g.use("math")
+	}
+	op := map[string]string{
+		"checkedAdd": "+",
+		"checkedSub": "-",
+		"checkedMul": "*",
+		"checkedDiv": "/",
+		"checkedMod": "%",
+	}[name]
+	g.emitPrimitiveIIFE("*"+goT, f.X, func(v string) {
+		rhs := g.freshVar("_rhs")
+		g.body.writef("var %s %s = ", rhs, goT)
+		g.emitExpr(arg)
+		g.body.nl()
+		switch name {
+		case "checkedAdd":
+			g.emitIntAddOverflowGuard(info, v, rhs, "return nil", "return nil")
+		case "checkedSub":
+			g.emitIntSubOverflowGuard(info, v, rhs, "return nil", "return nil")
+		case "checkedMul":
+			g.emitIntMulOverflowGuard(info, goT, v, rhs, "return nil", "return nil")
+		case "checkedDiv", "checkedMod":
+			g.body.writef("if %s == 0 { return nil }\n", rhs)
+			if info.signed {
+				g.body.writef("if %s == %s && %s == %s(-1) { return nil }\n", v, info.min, rhs, goT)
+			}
+		}
+		g.body.writef("out := %s %s %s\n", v, op, rhs)
+		g.body.writeln("return &out")
+	})
+}
+
+func (g *gen) emitCheckedIntShift(name string, f *ast.FieldExpr, arg ast.Expr, recv types.PrimitiveKind, goT string) {
+	if recv == types.PInt {
+		g.use("strconv")
+	}
+	info := runtimeIntInfo(recv)
+	op := "<<"
+	if name == "checkedShr" {
+		op = ">>"
+	}
+	g.emitPrimitiveIIFE("*"+goT, f.X, func(v string) {
+		rhs := g.freshVar("_rhs")
+		g.body.writef("var %s int = ", rhs)
+		g.emitExpr(arg)
+		g.body.nl()
+		g.body.writef("bitWidth := int(%s)\n", info.bits)
+		g.body.writef("if %s < 0 || %s >= bitWidth { return nil }\n", rhs, rhs)
+		g.body.writef("out := %s %s uint(%s)\n", v, op, rhs)
+		g.body.writeln("return &out")
+	})
+}
+
+func (g *gen) emitCheckedIntAbs(f *ast.FieldExpr, recv types.PrimitiveKind, goT string) {
+	if recv.IsSignedInt() {
+		g.use("math")
+	}
+	info := runtimeIntInfo(recv)
+	g.emitPrimitiveIIFE("*"+goT, f.X, func(v string) {
+		if info.signed {
+			g.body.writef("if %s == %s { return nil }\n", v, info.min)
+			g.body.writef("if %s < 0 { out := -%s; return &out }\n", v, v)
+		}
+		g.body.writef("out := %s\n", v)
+		g.body.writeln("return &out")
+	})
+}
+
+func (g *gen) emitCheckedIntNeg(f *ast.FieldExpr, recv types.PrimitiveKind, goT string) {
+	if recv.IsSignedInt() {
+		g.use("math")
+	}
+	info := runtimeIntInfo(recv)
+	g.emitPrimitiveIIFE("*"+goT, f.X, func(v string) {
+		if info.signed {
+			g.body.writef("if %s == %s { return nil }\n", v, info.min)
+			g.body.writef("out := -%s\n", v)
+		} else {
+			g.body.writef("if %s != 0 { return nil }\n", v)
+			g.body.writef("out := %s(0)\n", goT)
+		}
+		g.body.writeln("return &out")
+	})
+}
+
+func (g *gen) emitSaturatingIntBinary(name string, f *ast.FieldExpr, arg ast.Expr, recv types.PrimitiveKind, goT string) {
+	info := runtimeIntInfo(recv)
+	if name == "saturatingAdd" || name == "saturatingSub" || name == "saturatingMul" || recv.IsSignedInt() {
+		g.use("math")
+	}
+	op := map[string]string{
+		"saturatingAdd": "+",
+		"saturatingSub": "-",
+		"saturatingMul": "*",
+		"saturatingDiv": "/",
+	}[name]
+	g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+		rhs := g.freshVar("_rhs")
+		g.body.writef("var %s %s = ", rhs, goT)
+		g.emitExpr(arg)
+		g.body.nl()
+		switch name {
+		case "saturatingAdd":
+			g.emitIntAddOverflowGuard(info, v, rhs, "return "+info.min, "return "+info.max)
+		case "saturatingSub":
+			g.emitIntSubOverflowGuard(info, v, rhs, "return "+info.min, "return "+info.max)
+		case "saturatingMul":
+			g.emitIntMulOverflowGuard(info, goT, v, rhs, "return "+info.min, "return "+info.max)
+		case "saturatingDiv":
+			if info.signed {
+				g.body.writef("if %s == %s && %s == %s(-1) { return %s }\n", v, info.min, rhs, goT, info.max)
+			}
+		}
+		g.body.writef("return %s %s %s\n", v, op, rhs)
+	})
+}
+
+func (g *gen) emitIntPow(f *ast.FieldExpr, exp ast.Expr, recv types.PrimitiveKind, goT string) {
+	g.use("math")
+	info := runtimeIntInfo(recv)
+	g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+		expVar := g.freshVar("_exp")
+		g.body.writef("var %s int = ", expVar)
+		g.emitExpr(exp)
+		g.body.nl()
+		g.body.writef("if %s < 0 { panic(%q) }\n", expVar, "negative integer exponent")
+		g.body.writef("out := %s(1)\n", goT)
+		g.body.writef("for i := 0; i < %s; i++ {\n", expVar)
+		g.body.indent()
+		g.emitIntMulOverflowGuard(info, goT, "out", v, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+		g.body.writef("out *= %s\n", v)
+		g.body.dedent()
+		g.body.writeln("}")
+		g.body.writeln("return out")
+	})
+}
+
+func (g *gen) emitIntAddOverflowGuard(info intRuntimeInfo, v, rhs, onLow, onHigh string) {
+	if info.signed {
+		g.body.writef("if %s > 0 && %s > %s-%s { %s }\n", rhs, v, info.max, rhs, onHigh)
+		g.body.writef("if %s < 0 && %s < %s-%s { %s }\n", rhs, v, info.min, rhs, onLow)
+		return
+	}
+	g.body.writef("if %s > %s-%s { %s }\n", v, info.max, rhs, onHigh)
+}
+
+func (g *gen) emitIntSubOverflowGuard(info intRuntimeInfo, v, rhs, onLow, onHigh string) {
+	if info.signed {
+		g.body.writef("if %s < 0 && %s > %s+%s { %s }\n", rhs, v, info.max, rhs, onHigh)
+		g.body.writef("if %s > 0 && %s < %s+%s { %s }\n", rhs, v, info.min, rhs, onLow)
+		return
+	}
+	g.body.writef("if %s < %s { %s }\n", v, rhs, onLow)
+}
+
+func (g *gen) emitIntMulOverflowGuard(info intRuntimeInfo, goT, v, rhs, onLow, onHigh string) {
+	if !info.signed {
+		g.body.writef("if %s != 0 && %s > %s/%s { %s }\n", rhs, v, info.max, rhs, onHigh)
+		return
+	}
+	g.body.writef("if %s != 0 && %s != 0 {\n", v, rhs)
+	g.body.indent()
+	g.body.writef("if %s == %s(-1) && %s == %s { %s }\n", v, goT, rhs, info.min, onHigh)
+	g.body.writef("if %s == %s(-1) && %s == %s { %s }\n", rhs, goT, v, info.min, onHigh)
+	g.body.writef("if %s > 0 {\n", v)
+	g.body.indent()
+	g.body.writef("if %s > 0 && %s > %s/%s { %s }\n", rhs, v, info.max, rhs, onHigh)
+	g.body.writef("if %s < 0 && %s < %s/%s { %s }\n", rhs, rhs, info.min, v, onLow)
+	g.body.dedent()
+	g.body.writeln("} else {")
+	g.body.indent()
+	g.body.writef("if %s > 0 && %s < %s/%s { %s }\n", rhs, v, info.min, rhs, onLow)
+	g.body.writef("if %s < 0 && %s < %s/%s { %s }\n", rhs, v, info.max, rhs, onHigh)
+	g.body.dedent()
+	g.body.writeln("}")
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func (g *gen) emitFloatMethod(c *ast.CallExpr, f *ast.FieldExpr, recv types.PrimitiveKind) bool {
+	goT := goPrimitive(recv)
+	bits := "64"
+	if recv == types.PFloat32 {
+		bits = "32"
+	}
+	switch f.Name {
+	case "abs", "floor", "ceil", "round", "trunc", "sqrt", "cbrt", "ln", "log2", "log10",
+		"exp", "sin", "cos", "tan", "asin", "acos", "atan":
+		if len(c.Args) != 0 {
+			return false
+		}
+		fn := map[string]string{
+			"abs":   "Abs",
+			"floor": "Floor",
+			"ceil":  "Ceil",
+			"round": "RoundToEven",
+			"trunc": "Trunc",
+			"sqrt":  "Sqrt",
+			"cbrt":  "Cbrt",
+			"ln":    "Log",
+			"log2":  "Log2",
+			"log10": "Log10",
+			"exp":   "Exp",
+			"sin":   "Sin",
+			"cos":   "Cos",
+			"tan":   "Tan",
+			"asin":  "Asin",
+			"acos":  "Acos",
+			"atan":  "Atan",
+		}[f.Name]
+		g.use("math")
+		g.body.write(goT)
+		g.body.write("(math.")
+		g.body.write(fn)
+		g.body.write("(float64(")
+		g.emitExpr(f.X)
+		g.body.write(")))")
+	case "min", "max":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			other := g.freshVar("_other")
+			g.body.writef("var %s %s = ", other, goT)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			op := "<"
+			if f.Name == "max" {
+				op = ">"
+			}
+			g.body.writef("if %s %s %s { return %s }\n", v, op, other, v)
+			g.body.writef("return %s\n", other)
+		})
+	case "clamp":
+		if len(c.Args) != 2 {
+			return false
+		}
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			lo := g.freshVar("_lo")
+			hi := g.freshVar("_hi")
+			g.body.writef("var %s %s = ", lo, goT)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("var %s %s = ", hi, goT)
+			g.emitExpr(c.Args[1].Value)
+			g.body.nl()
+			g.body.writef("if %s < %s { return %s }\n", v, lo, lo)
+			g.body.writef("if %s > %s { return %s }\n", v, hi, hi)
+			g.body.writef("return %s\n", v)
+		})
+	case "signum":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			g.body.writef("if %s < 0 { return %s(-1) }\n", v, goT)
+			g.body.writef("if %s > 0 { return %s(1) }\n", v, goT)
+			g.body.writef("return %s(0)\n", goT)
+		})
+	case "fract":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("math")
+		g.emitPrimitiveIIFE(goT, f.X, func(v string) {
+			g.body.writef("return %s - %s(math.Trunc(float64(%s)))\n", v, goT, v)
+		})
+	case "atan2", "pow":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("math")
+		fn := "Atan2"
+		if f.Name == "pow" {
+			fn = "Pow"
+		}
+		g.body.write(goT)
+		g.body.write("(math.")
+		g.body.write(fn)
+		g.body.write("(float64(")
+		g.emitExpr(f.X)
+		g.body.write("), float64(")
+		g.emitExpr(c.Args[0].Value)
+		g.body.write(")))")
+	case "isNaN", "isInfinite", "isFinite":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("math")
+		switch f.Name {
+		case "isNaN":
+			g.body.write("math.IsNaN(float64(")
+			g.emitExpr(f.X)
+			g.body.write("))")
+		case "isInfinite":
+			g.body.write("math.IsInf(float64(")
+			g.emitExpr(f.X)
+			g.body.write("), 0)")
+		case "isFinite":
+			g.body.write("func() bool { v := float64(")
+			g.emitExpr(f.X)
+			g.body.write("); return !math.IsNaN(v) && !math.IsInf(v, 0) }()")
+		}
+	case "toBits":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("math")
+		if recv == types.PFloat32 {
+			g.body.write("uint64(math.Float32bits(")
+			g.emitExpr(f.X)
+			g.body.write("))")
+		} else {
+			g.body.write("math.Float64bits(float64(")
+			g.emitExpr(f.X)
+			g.body.write("))")
+		}
+	case "toFixed":
+		if len(c.Args) != 1 {
+			return false
+		}
+		g.use("strconv")
+		g.emitPrimitiveIIFE("string", f.X, func(v string) {
+			precision := g.freshVar("_precision")
+			g.body.writef("var %s int = ", precision)
+			g.emitExpr(c.Args[0].Value)
+			g.body.nl()
+			g.body.writef("if %s < 0 { %s = 0 }\n", precision, precision)
+			g.body.writef("return strconv.FormatFloat(float64(%s), 'f', %s, %s)\n", v, precision, bits)
+		})
+	case "toIntTrunc", "toIntRound", "toIntFloor", "toIntCeil":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.emitFloatToIntResult(f)
+	case "toInt", "toInt32", "toInt64", "toFloat", "toFloat32", "toFloat64":
+		if len(c.Args) != 0 {
+			return false
+		}
+		target := map[string]string{
+			"toInt":     "int",
+			"toInt32":   "int32",
+			"toInt64":   "int64",
+			"toFloat":   "float64",
+			"toFloat32": "float32",
+			"toFloat64": "float64",
+		}[f.Name]
+		g.body.write(target)
+		g.body.write("(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+	case "toString":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.use("strconv")
+		g.body.write("strconv.FormatFloat(float64(")
+		g.emitExpr(f.X)
+		g.body.write("), 'g', -1, ")
+		g.body.write(bits)
+		g.body.write(")")
+	default:
+		return false
+	}
+	return true
+}
+
+func (g *gen) emitFloatToIntResult(f *ast.FieldExpr) {
+	g.needResult = true
+	g.use("math")
+	g.use("strconv")
+	fn := map[string]string{
+		"toIntTrunc": "Trunc",
+		"toIntRound": "RoundToEven",
+		"toIntFloor": "Floor",
+		"toIntCeil":  "Ceil",
+	}[f.Name]
+	g.emitPrimitiveIIFE("Result[int, any]", f.X, func(v string) {
+		rounded := g.freshVar("_rounded")
+		g.body.writef("%s := math.%s(float64(%s))\n", rounded, fn, v)
+		g.body.writeln("lo := -9223372036854775808.0")
+		g.body.writeln("hi := 9223372036854775808.0")
+		g.body.writeln("if strconv.IntSize == 32 { lo = -2147483648.0; hi = 2147483648.0 }")
+		g.body.writef("if math.IsNaN(%s) || math.IsInf(%s, 0) || %s < lo || %s >= hi { return resultErr[int, any](%q) }\n",
+			rounded, rounded, rounded, rounded, f.Name+" out of Int range")
+		g.body.writef("return resultOk[int, any](int(%s))\n", rounded)
+	})
+}
+
+func (g *gen) emitIntConversionResult(f *ast.FieldExpr, recv types.PrimitiveKind) bool {
+	info, ok := intConversionTarget(f.Name)
+	if !ok {
+		return false
+	}
+	g.needResult = true
+	retGo := "Result[" + info.goType + ", any]"
+	g.emitPrimitiveIIFE(retGo, f.X, func(v string) {
+		for _, cond := range intConversionFailureConds(v, recv, info) {
+			g.body.writef("if %s { return resultErr[%s, any](%q) }\n",
+				cond, info.goType, f.Name+" overflow")
+		}
+		g.body.writef("return resultOk[%s, any](%s(%s))\n", info.goType, info.goType, v)
+	})
+	return true
+}
+
+type intConvTarget struct {
+	goType string
+	min    string
+	max    string
+	signed bool
+}
+
+func intConversionTarget(name string) (intConvTarget, bool) {
+	switch name {
+	case "toInt8":
+		return intConvTarget{goType: "int8", min: "-128", max: "127", signed: true}, true
+	case "toInt16":
+		return intConvTarget{goType: "int16", min: "-32768", max: "32767", signed: true}, true
+	case "toInt32":
+		return intConvTarget{goType: "int32", min: "-2147483648", max: "2147483647", signed: true}, true
+	case "toUInt8", "toByte":
+		if name == "toByte" {
+			return intConvTarget{goType: "byte", min: "0", max: "255"}, true
+		}
+		return intConvTarget{goType: "uint8", min: "0", max: "255"}, true
+	case "toUInt16":
+		return intConvTarget{goType: "uint16", min: "0", max: "65535"}, true
+	case "toUInt32":
+		return intConvTarget{goType: "uint32", min: "0", max: "4294967295"}, true
+	case "toUInt64":
+		return intConvTarget{goType: "uint64", min: "0", max: "18446744073709551615"}, true
+	}
+	return intConvTarget{}, false
+}
+
+func intConversionFailureConds(v string, recv types.PrimitiveKind, target intConvTarget) []string {
+	var conds []string
+	if target.signed {
+		if recv.IsSignedInt() {
+			conds = append(conds, v+" < "+target.min, v+" > "+target.max)
+		} else {
+			conds = append(conds, v+" > "+target.max)
+		}
+		return conds
+	}
+	if recv.IsSignedInt() {
+		conds = append(conds, v+" < 0")
+	}
+	if target.goType != "uint64" {
+		conds = append(conds, v+" > "+target.max)
+	}
+	return conds
+}
+
+func (g *gen) emitPrimitiveIIFE(retGo string, recv ast.Expr, body func(recvVar string)) {
+	recvVar := g.freshVar("_p")
+	g.body.write("func()")
+	if retGo != "" {
+		g.body.write(" ")
+		g.body.write(retGo)
+	}
+	g.body.writeln(" {")
+	g.body.indent()
+	g.body.writef("%s := ", recvVar)
+	g.emitExpr(recv)
+	g.body.nl()
+	body(recvVar)
+	g.body.dedent()
+	g.body.write("}()")
+}
+
+func (g *gen) emitPrimitiveTypedIIFE(retGo, recvGo string, recv ast.Expr, body func(recvVar string)) {
+	recvVar := g.freshVar("_p")
+	g.body.write("func()")
+	if retGo != "" {
+		g.body.write(" ")
+		g.body.write(retGo)
+	}
+	g.body.writeln(" {")
+	g.body.indent()
+	g.body.writef("var %s %s = ", recvVar, recvGo)
+	g.emitExpr(recv)
+	g.body.nl()
+	body(recvVar)
+	g.body.dedent()
+	g.body.write("}()")
+}

--- a/internal/gen/question.go
+++ b/internal/gen/question.go
@@ -1,0 +1,152 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/types"
+)
+
+// preLiftQuestions walks `e` and emits one lift block per `?` operator
+// that appears in a direct-evaluation position (not guarded by a
+// closure, branch, or loop body). Each lifted `?` is recorded in
+// g.questionSubs so the subsequent emitExpr for that node writes the
+// unwrapped temp instead of a panic-IIFE.
+//
+// The walk preserves source order, which matches Go's left-to-right
+// evaluation of the rewritten expression. A `?` nested inside a
+// control-flow expression (closure body, if arm, match arm, loop body)
+// is left alone — it binds to its own lexical return, and lifting it
+// here would both short-circuit prematurely and attempt to return the
+// wrong type.
+//
+// Callers must ensure questionSubs is initialized (or nil, in which
+// case this is a no-op for expressions without `?`).
+func (g *gen) preLiftQuestions(e ast.Expr) {
+	if e == nil {
+		return
+	}
+	var qs []*ast.QuestionExpr
+	g.walkDirectQuestions(e, &qs)
+	if len(qs) == 0 {
+		return
+	}
+	if g.questionSubs == nil {
+		g.questionSubs = map[*ast.QuestionExpr]string{}
+	}
+	for _, q := range qs {
+		if _, already := g.questionSubs[q]; already {
+			continue
+		}
+		tmp := g.freshVar("_q")
+		g.emitQuestionLiftBody(tmp, q)
+		operandT := g.typeOf(q.X)
+		if isResultOperand(operandT) {
+			g.questionSubs[q] = tmp + ".Value"
+		} else {
+			g.questionSubs[q] = "*" + tmp
+		}
+	}
+}
+
+// emitQuestionLiftBody writes the `tmp := <operand>; if <failure> { return <failure> }`
+// prelude for one lifted `?` occurrence. Shared by the let-stmt fast
+// path, the return-stmt lift, and preLiftQuestions.
+func (g *gen) emitQuestionLiftBody(tmp string, q *ast.QuestionExpr) {
+	operandT := g.typeOf(q.X)
+	isResult := isResultOperand(operandT)
+	g.body.writef("%s := ", tmp)
+	g.emitExpr(q.X)
+	g.body.nl()
+	if isResult {
+		retGo := "any"
+		if g.currentRetGo != "" {
+			retGo = g.currentRetGo
+		} else if g.currentRetType != nil {
+			retGo = g.goTypeExpr(g.currentRetType)
+		}
+		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error, ref: resultRef()} }\n", tmp, retGo, tmp)
+		return
+	}
+	g.body.writef("if %s == nil { return nil }\n", tmp)
+}
+
+// isResultOperand reports whether the operand type of a `?` is
+// Result<T, E>. Any other type (Optional, bare named, or nil) is
+// treated as Option for lift purposes — which matches Osty's spec:
+// only Result and Option support `?`.
+func isResultOperand(t types.Type) bool {
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" {
+		return true
+	}
+	return false
+}
+
+// walkDirectQuestions collects QuestionExpr nodes reachable from `e`
+// without crossing a control-flow or closure boundary. The traversal
+// is preorder in source order so lift blocks emit in evaluation order.
+func (g *gen) walkDirectQuestions(e ast.Expr, out *[]*ast.QuestionExpr) {
+	if e == nil {
+		return
+	}
+	switch e := e.(type) {
+	case *ast.QuestionExpr:
+		// First descend into the operand so nested `a??` lifts correctly.
+		g.walkDirectQuestions(e.X, out)
+		*out = append(*out, e)
+	case *ast.ParenExpr:
+		g.walkDirectQuestions(e.X, out)
+	case *ast.UnaryExpr:
+		g.walkDirectQuestions(e.X, out)
+	case *ast.BinaryExpr:
+		g.walkDirectQuestions(e.Left, out)
+		g.walkDirectQuestions(e.Right, out)
+	case *ast.CallExpr:
+		g.walkDirectQuestions(e.Fn, out)
+		for _, a := range e.Args {
+			g.walkDirectQuestions(a.Value, out)
+		}
+	case *ast.FieldExpr:
+		// `.` (and `?.`) access — both evaluate the receiver directly.
+		g.walkDirectQuestions(e.X, out)
+	case *ast.IndexExpr:
+		g.walkDirectQuestions(e.X, out)
+		g.walkDirectQuestions(e.Index, out)
+	case *ast.TurbofishExpr:
+		g.walkDirectQuestions(e.Base, out)
+	case *ast.TupleExpr:
+		for _, x := range e.Elems {
+			g.walkDirectQuestions(x, out)
+		}
+	case *ast.ListExpr:
+		for _, x := range e.Elems {
+			g.walkDirectQuestions(x, out)
+		}
+	case *ast.MapExpr:
+		for _, ent := range e.Entries {
+			g.walkDirectQuestions(ent.Key, out)
+			g.walkDirectQuestions(ent.Value, out)
+		}
+	case *ast.StructLit:
+		for _, f := range e.Fields {
+			if f.Value != nil {
+				g.walkDirectQuestions(f.Value, out)
+			}
+		}
+	case *ast.RangeExpr:
+		g.walkDirectQuestions(e.Start, out)
+		g.walkDirectQuestions(e.Stop, out)
+	// Control-flow / closure boundaries are deliberately not descended:
+	// any `?` inside them targets its own lexical return context.
+	case *ast.IfExpr, *ast.MatchExpr, *ast.ClosureExpr, *ast.Block:
+		// stop
+	}
+}
+
+// resetQuestionSubs clears the lift-substitution map. Called after a
+// statement finishes emitting so subs don't bleed into the next
+// statement (mostly a sanity measure — node keys are unique, but the
+// map can grow without bound otherwise).
+func (g *gen) resetQuestionSubs() {
+	g.questionSubs = nil
+}

--- a/internal/gen/regex_runtime.go
+++ b/internal/gen/regex_runtime.go
@@ -1,0 +1,849 @@
+//go:build selfhostgen
+
+package gen
+
+// regexRuntime is the pure-Go backtracking NFA regex engine emitted when
+// std.regex is used. It does NOT depend on Go's regexp package.
+const regexRuntime = `
+// ── regex runtime: pure backtracking NFA engine ──────────────────
+
+type rxRange struct{ lo, hi rune }
+
+// inst is one NFA bytecode instruction.
+// ops: 0=char 1=any 2=class 3=split 4=jump 5=save 6=match
+//      7=anchorStart 8=anchorEnd 9=wordBound 10=nonWordBound
+type rxInst struct {
+	op      int
+	c       rune
+	ranges  []rxRange
+	negated bool
+	x, y    int
+}
+
+// rnode is a regex AST node.
+// kinds: 0=literal 1=dot 2=anchorS 3=anchorE 4=class 5=concat
+//        6=alt 7=group 8=repeat 9=wb 10=nwb 11=empty
+type rnode struct {
+	kind     int
+	c        rune
+	ranges   []rxRange
+	negated  bool
+	children []*rnode
+	groupID  int
+	name     string
+	rmin     int
+	rmax     int
+	greedy   bool
+}
+
+// ── parser ───────────────────────────────────────────────────────
+
+type rxParser struct {
+	src    []rune
+	pos    int
+	groups int
+	names  map[string]int
+}
+
+func rxParse(pattern string) (*rnode, int, map[string]int, error) {
+	p := &rxParser{src: []rune(pattern), groups: 1, names: map[string]int{}}
+	n, err := p.parseAlt()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	if p.pos < len(p.src) {
+		return nil, 0, nil, fmt.Errorf("unexpected char in pattern")
+	}
+	return n, p.groups, p.names, nil
+}
+
+func (p *rxParser) at(c rune) bool  { return p.pos < len(p.src) && p.src[p.pos] == c }
+func (p *rxParser) done() bool      { return p.pos >= len(p.src) }
+func (p *rxParser) adv() rune       { c := p.src[p.pos]; p.pos++; return c }
+func (p *rxParser) digitHere() bool { return p.pos < len(p.src) && p.src[p.pos] >= '0' && p.src[p.pos] <= '9' }
+
+func (p *rxParser) parseAlt() (*rnode, error) {
+	left, err := p.parseSeq()
+	if err != nil {
+		return nil, err
+	}
+	if p.at('|') {
+		p.adv()
+		right, err := p.parseAlt()
+		if err != nil {
+			return nil, err
+		}
+		return &rnode{kind: 6, children: []*rnode{left, right}}, nil
+	}
+	return left, nil
+}
+
+func (p *rxParser) parseSeq() (*rnode, error) {
+	var items []*rnode
+	for !p.done() && !p.at('|') && !p.at(')') {
+		n, err := p.parseQuant()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, n)
+	}
+	if len(items) == 0 {
+		return &rnode{kind: 11}, nil
+	}
+	if len(items) == 1 {
+		return items[0], nil
+	}
+	return &rnode{kind: 5, children: items}, nil
+}
+
+func (p *rxParser) parseQuant() (*rnode, error) {
+	atom, err := p.parseAtom()
+	if err != nil {
+		return nil, err
+	}
+	if p.done() {
+		return atom, nil
+	}
+	c := p.src[p.pos]
+	rmin, rmax, hasQ := 0, -1, false
+	switch c {
+	case '*':
+		p.adv(); rmin = 0; rmax = -1; hasQ = true
+	case '+':
+		p.adv(); rmin = 1; rmax = -1; hasQ = true
+	case '?':
+		p.adv(); rmin = 0; rmax = 1; hasQ = true
+	case '{':
+		saved := p.pos
+		if mn, mx, ok := p.tryBrace(); ok {
+			rmin = mn; rmax = mx; hasQ = true
+		} else {
+			p.pos = saved
+		}
+	}
+	if !hasQ {
+		return atom, nil
+	}
+	greedy := true
+	if p.at('?') {
+		p.adv(); greedy = false
+	}
+	return &rnode{kind: 8, children: []*rnode{atom}, rmin: rmin, rmax: rmax, greedy: greedy}, nil
+}
+
+func (p *rxParser) tryBrace() (int, int, bool) {
+	p.adv() // skip {
+	if p.done() || !p.digitHere() {
+		return 0, 0, false
+	}
+	n := p.readInt()
+	if p.at('}') {
+		p.adv(); return n, n, true
+	}
+	if p.at(',') {
+		p.adv()
+		if p.at('}') {
+			p.adv(); return n, -1, true
+		}
+		if !p.done() && p.digitHere() {
+			m := p.readInt()
+			if p.at('}') && m >= n {
+				p.adv(); return n, m, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+func (p *rxParser) readInt() int {
+	n := 0
+	for !p.done() && p.digitHere() {
+		n = n*10 + int(p.src[p.pos]-'0'); p.adv()
+	}
+	return n
+}
+
+func (p *rxParser) parseAtom() (*rnode, error) {
+	if p.done() {
+		return nil, fmt.Errorf("unexpected end of pattern")
+	}
+	c := p.src[p.pos]
+	switch {
+	case c == '.':
+		p.adv(); return &rnode{kind: 1}, nil
+	case c == '^':
+		p.adv(); return &rnode{kind: 2}, nil
+	case c == '$':
+		p.adv(); return &rnode{kind: 3}, nil
+	case c == '(':
+		return p.parseGroup()
+	case c == '[':
+		return p.parseClass()
+	case c == '\\':
+		return p.parseEsc()
+	case c == '*' || c == '+' || c == '?':
+		return nil, fmt.Errorf("quantifier without preceding element")
+	default:
+		p.adv(); return &rnode{kind: 0, c: c}, nil
+	}
+}
+
+func (p *rxParser) parseGroup() (*rnode, error) {
+	p.adv() // skip (
+	if p.at('?') {
+		p.adv()
+		if p.at(':') {
+			p.adv()
+			inner, err := p.parseAlt()
+			if err != nil {
+				return nil, err
+			}
+			if !p.at(')') {
+				return nil, fmt.Errorf("expected ')'")
+			}
+			p.adv()
+			return &rnode{kind: 7, children: []*rnode{inner}, groupID: -1}, nil
+		}
+		if p.at('P') || p.at('<') {
+			if p.at('P') {
+				p.adv()
+			}
+			if !p.at('<') {
+				return nil, fmt.Errorf("expected '<' in named group")
+			}
+			p.adv()
+			var name []rune
+			for !p.done() && !p.at('>') {
+				name = append(name, p.adv())
+			}
+			if !p.at('>') {
+				return nil, fmt.Errorf("expected '>'")
+			}
+			p.adv()
+			id := p.groups; p.groups++
+			nm := string(name)
+			p.names[nm] = id
+			inner, err := p.parseAlt()
+			if err != nil {
+				return nil, err
+			}
+			if !p.at(')') {
+				return nil, fmt.Errorf("expected ')'")
+			}
+			p.adv()
+			return &rnode{kind: 7, children: []*rnode{inner}, groupID: id, name: nm}, nil
+		}
+		return nil, fmt.Errorf("unknown group modifier")
+	}
+	id := p.groups; p.groups++
+	inner, err := p.parseAlt()
+	if err != nil {
+		return nil, err
+	}
+	if !p.at(')') {
+		return nil, fmt.Errorf("expected ')'")
+	}
+	p.adv()
+	return &rnode{kind: 7, children: []*rnode{inner}, groupID: id}, nil
+}
+
+func rxDigitRanges() []rxRange { return []rxRange{{'0', '9'}} }
+func rxWordRanges() []rxRange {
+	return []rxRange{{'a', 'z'}, {'A', 'Z'}, {'0', '9'}, {'_', '_'}}
+}
+func rxSpaceRanges() []rxRange {
+	return []rxRange{{' ', ' '}, {'\t', '\t'}, {'\n', '\n'}, {'\r', '\r'}}
+}
+
+func (p *rxParser) parseClass() (*rnode, error) {
+	p.adv() // skip [
+	neg := false
+	if p.at('^') {
+		neg = true; p.adv()
+	}
+	var ranges []rxRange
+	first := true
+	for !p.done() && (first || !p.at(']')) {
+		first = false
+		if p.at('\\') {
+			p.adv()
+			if p.done() {
+				return nil, fmt.Errorf("incomplete escape in class")
+			}
+			ec := p.adv()
+			if ex := rxExpandEsc(ec); len(ex) > 0 {
+				ranges = append(ranges, ex...)
+			} else {
+				lo := rxEscChar(ec)
+				if p.canRange() {
+					p.adv()
+					hi, err := p.classChar()
+					if err != nil {
+						return nil, err
+					}
+					ranges = append(ranges, rxRange{lo, hi})
+				} else {
+					ranges = append(ranges, rxRange{lo, lo})
+				}
+			}
+		} else {
+			lo := p.adv()
+			if p.canRange() {
+				p.adv()
+				hi, err := p.classChar()
+				if err != nil {
+					return nil, err
+				}
+				ranges = append(ranges, rxRange{lo, hi})
+			} else {
+				ranges = append(ranges, rxRange{lo, lo})
+			}
+		}
+	}
+	if !p.at(']') {
+		return nil, fmt.Errorf("unterminated character class")
+	}
+	p.adv()
+	return &rnode{kind: 4, ranges: ranges, negated: neg}, nil
+}
+
+func (p *rxParser) canRange() bool {
+	return p.at('-') && p.pos+1 < len(p.src) && p.src[p.pos+1] != ']'
+}
+
+func (p *rxParser) classChar() (rune, error) {
+	if p.done() {
+		return 0, fmt.Errorf("incomplete class range")
+	}
+	if p.at('\\') {
+		p.adv()
+		if p.done() {
+			return 0, fmt.Errorf("incomplete escape")
+		}
+		return rxEscChar(p.adv()), nil
+	}
+	return p.adv(), nil
+}
+
+func (p *rxParser) parseEsc() (*rnode, error) {
+	p.adv() // skip backslash
+	if p.done() {
+		return nil, fmt.Errorf("trailing backslash")
+	}
+	c := p.adv()
+	switch c {
+	case 'd':
+		return &rnode{kind: 4, ranges: rxDigitRanges()}, nil
+	case 'D':
+		return &rnode{kind: 4, ranges: rxDigitRanges(), negated: true}, nil
+	case 'w':
+		return &rnode{kind: 4, ranges: rxWordRanges()}, nil
+	case 'W':
+		return &rnode{kind: 4, ranges: rxWordRanges(), negated: true}, nil
+	case 's':
+		return &rnode{kind: 4, ranges: rxSpaceRanges()}, nil
+	case 'S':
+		return &rnode{kind: 4, ranges: rxSpaceRanges(), negated: true}, nil
+	case 'b':
+		return &rnode{kind: 9}, nil
+	case 'B':
+		return &rnode{kind: 10}, nil
+	default:
+		return &rnode{kind: 0, c: rxEscChar(c)}, nil
+	}
+}
+
+func rxEscChar(c rune) rune {
+	switch c {
+	case 'n':
+		return '\n'
+	case 'r':
+		return '\r'
+	case 't':
+		return '\t'
+	}
+	return c
+}
+
+func rxExpandEsc(c rune) []rxRange {
+	switch c {
+	case 'd':
+		return rxDigitRanges()
+	case 'w':
+		return rxWordRanges()
+	case 's':
+		return rxSpaceRanges()
+	}
+	return nil
+}
+
+// ── compiler (AST → bytecode) ────────────────────────────────────
+
+type rxCompiler struct{ code []rxInst }
+
+func (cc *rxCompiler) emit(inst rxInst) int {
+	idx := len(cc.code); cc.code = append(cc.code, inst); return idx
+}
+
+func (cc *rxCompiler) gen(n *rnode) {
+	switch n.kind {
+	case 0:
+		cc.emit(rxInst{op: 0, c: n.c})
+	case 1:
+		cc.emit(rxInst{op: 1})
+	case 2:
+		cc.emit(rxInst{op: 7})
+	case 3:
+		cc.emit(rxInst{op: 8})
+	case 4:
+		cc.emit(rxInst{op: 2, ranges: n.ranges, negated: n.negated})
+	case 5:
+		for _, ch := range n.children {
+			cc.gen(ch)
+		}
+	case 6:
+		cc.genAlt(n)
+	case 7:
+		cc.genGroup(n)
+	case 8:
+		cc.genRepeat(n)
+	case 9:
+		cc.emit(rxInst{op: 9})
+	case 10:
+		cc.emit(rxInst{op: 10})
+	case 11:
+		// empty — no code
+	}
+}
+
+func (cc *rxCompiler) genAlt(n *rnode) {
+	spc := cc.emit(rxInst{op: 3})
+	cc.gen(n.children[0])
+	jpc := cc.emit(rxInst{op: 4})
+	rStart := len(cc.code)
+	cc.gen(n.children[1])
+	end := len(cc.code)
+	cc.code[spc] = rxInst{op: 3, x: spc + 1, y: rStart}
+	cc.code[jpc] = rxInst{op: 4, x: end}
+}
+
+func (cc *rxCompiler) genGroup(n *rnode) {
+	if n.groupID >= 0 {
+		cc.emit(rxInst{op: 5, x: n.groupID * 2})
+	}
+	cc.gen(n.children[0])
+	if n.groupID >= 0 {
+		cc.emit(rxInst{op: 5, x: n.groupID*2 + 1})
+	}
+}
+
+func (cc *rxCompiler) genRepeat(n *rnode) {
+	inner := n.children[0]
+	for i := 0; i < n.rmin; i++ {
+		cc.gen(inner)
+	}
+	if n.rmax == -1 {
+		spc := cc.emit(rxInst{op: 3})
+		body := len(cc.code)
+		cc.gen(inner)
+		cc.emit(rxInst{op: 4, x: spc})
+		end := len(cc.code)
+		if n.greedy {
+			cc.code[spc] = rxInst{op: 3, x: body, y: end}
+		} else {
+			cc.code[spc] = rxInst{op: 3, x: end, y: body}
+		}
+	} else if n.rmax > n.rmin {
+		opt := n.rmax - n.rmin
+		splits := make([]int, 0, opt)
+		for j := 0; j < opt; j++ {
+			splits = append(splits, cc.emit(rxInst{op: 3}))
+			cc.gen(inner)
+		}
+		end := len(cc.code)
+		for _, spc := range splits {
+			if n.greedy {
+				cc.code[spc] = rxInst{op: 3, x: spc + 1, y: end}
+			} else {
+				cc.code[spc] = rxInst{op: 3, x: end, y: spc + 1}
+			}
+		}
+	}
+}
+
+// ── VM ───────────────────────────────────────────────────────────
+
+type rxVM struct {
+	code  []rxInst
+	chars []rune
+	boff  []int // byte offset of each char; len = len(chars)+1
+	slots []int
+}
+
+func (vm *rxVM) exec(startPC, startSP int) bool {
+	pc, sp := startPC, startSP
+	for {
+		inst := vm.code[pc]
+		switch inst.op {
+		case 0: // char
+			if sp >= len(vm.chars) || vm.chars[sp] != inst.c {
+				return false
+			}
+			sp++; pc++
+		case 1: // any
+			if sp >= len(vm.chars) || vm.chars[sp] == '\n' {
+				return false
+			}
+			sp++; pc++
+		case 2: // class
+			if sp >= len(vm.chars) {
+				return false
+			}
+			if !rxCharIn(vm.chars[sp], inst.ranges, inst.negated) {
+				return false
+			}
+			sp++; pc++
+		case 3: // split
+			if vm.exec(inst.x, sp) {
+				return true
+			}
+			pc = inst.y
+		case 4: // jump
+			pc = inst.x
+		case 5: // save
+			old := vm.slots[inst.x]
+			vm.slots[inst.x] = vm.boff[sp]
+			if vm.exec(pc+1, sp) {
+				return true
+			}
+			vm.slots[inst.x] = old
+			return false
+		case 6: // match
+			return true
+		case 7: // anchor start
+			if sp != 0 {
+				return false
+			}
+			pc++
+		case 8: // anchor end
+			if sp != len(vm.chars) {
+				return false
+			}
+			pc++
+		case 9: // word boundary
+			if !vm.wordBound(sp) {
+				return false
+			}
+			pc++
+		case 10: // non-word boundary
+			if vm.wordBound(sp) {
+				return false
+			}
+			pc++
+		default:
+			return false
+		}
+	}
+}
+
+func (vm *rxVM) wordBound(sp int) bool {
+	left := sp > 0 && rxIsWord(vm.chars[sp-1])
+	right := sp < len(vm.chars) && rxIsWord(vm.chars[sp])
+	return left != right
+}
+
+func rxIsWord(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+func rxCharIn(c rune, ranges []rxRange, neg bool) bool {
+	for _, r := range ranges {
+		if c >= r.lo && c <= r.hi {
+			return !neg
+		}
+	}
+	return neg
+}
+
+// ── public API ───────────────────────────────────────────────────
+
+type Regex struct {
+	code      []rxInst
+	numGroups int
+	names     map[string]int
+}
+
+type RegexMatch struct {
+	text       string
+	start, end int
+}
+
+type Captures struct {
+	slots []int
+	text  string
+	names map[string]int
+}
+
+func regexCompile(pattern string) Result[Regex, error] {
+	ast, groups, names, err := rxParse(pattern)
+	if err != nil {
+		return resultErr[Regex, error](err)
+	}
+	cc := &rxCompiler{}
+	cc.emit(rxInst{op: 5, x: 0})
+	cc.gen(ast)
+	cc.emit(rxInst{op: 5, x: 1})
+	cc.emit(rxInst{op: 6})
+	return resultOk[Regex, error](Regex{code: cc.code, numGroups: groups, names: names})
+}
+
+func rxByteOffsets(chars []rune) []int {
+	off := make([]int, len(chars)+1)
+	b := 0
+	for i, c := range chars {
+		off[i] = b
+		b += utf8.RuneLen(c)
+	}
+	off[len(chars)] = b
+	return off
+}
+
+func rxInitSlots(n int) []int {
+	s := make([]int, n)
+	for i := range s {
+		s[i] = -1
+	}
+	return s
+}
+
+func (re Regex) runAt(chars []rune, boff []int, sp int) ([]int, bool) {
+	nslots := re.numGroups * 2
+	vm := &rxVM{code: re.code, chars: chars, boff: boff, slots: rxInitSlots(nslots)}
+	if vm.exec(0, sp) {
+		return vm.slots, true
+	}
+	return nil, false
+}
+
+func (re Regex) findSlots(text string) ([]int, bool) {
+	chars := []rune(text)
+	boff := rxByteOffsets(chars)
+	return re.findSlotsFrom(chars, boff, 0)
+}
+
+func (re Regex) findSlotsFrom(chars []rune, boff []int, from int) ([]int, bool) {
+	for sp := from; sp <= len(chars); sp++ {
+		if sl, ok := re.runAt(chars, boff, sp); ok {
+			return sl, true
+		}
+	}
+	return nil, false
+}
+
+func (re Regex) matches(text string) bool {
+	_, ok := re.findSlots(text)
+	return ok
+}
+
+func (re Regex) find(text string) *RegexMatch {
+	sl, ok := re.findSlots(text)
+	if !ok {
+		return nil
+	}
+	m := RegexMatch{text: text[sl[0]:sl[1]], start: sl[0], end: sl[1]}
+	return &m
+}
+
+func rxByteToChar(boff []int, b int) int {
+	for i, o := range boff {
+		if o >= b {
+			return i
+		}
+	}
+	return len(boff) - 1
+}
+
+func (re Regex) findAll(text string) []RegexMatch {
+	chars := []rune(text)
+	boff := rxByteOffsets(chars)
+	var out []RegexMatch
+	for from := 0; from <= len(chars); {
+		sl, ok := re.findSlotsFrom(chars, boff, from)
+		if !ok {
+			from++
+			continue
+		}
+		out = append(out, RegexMatch{text: text[sl[0]:sl[1]], start: sl[0], end: sl[1]})
+		ec := rxByteToChar(boff, sl[1])
+		if ec > from {
+			from = ec
+		} else {
+			from++
+		}
+	}
+	return out
+}
+
+func (re Regex) captures(text string) *Captures {
+	sl, ok := re.findSlots(text)
+	if !ok {
+		return nil
+	}
+	c := Captures{slots: sl, text: text, names: re.names}
+	return &c
+}
+
+func (re Regex) capturesAll(text string) []Captures {
+	chars := []rune(text)
+	boff := rxByteOffsets(chars)
+	var out []Captures
+	for from := 0; from <= len(chars); {
+		sl, ok := re.findSlotsFrom(chars, boff, from)
+		if !ok {
+			from++
+			continue
+		}
+		out = append(out, Captures{slots: sl, text: text, names: re.names})
+		ec := rxByteToChar(boff, sl[1])
+		if ec > from {
+			from = ec
+		} else {
+			from++
+		}
+	}
+	return out
+}
+
+func rxSlotText(slots []int, gid int, text string) string {
+	si := gid * 2
+	if si+1 >= len(slots) {
+		return ""
+	}
+	s, e := slots[si], slots[si+1]
+	if s < 0 || e < 0 {
+		return ""
+	}
+	return text[s:e]
+}
+
+func rxApplyRepl(tmpl string, slots []int, text string, names map[string]int) string {
+	tc := []rune(tmpl)
+	var out []byte
+	for i := 0; i < len(tc); {
+		if tc[i] == '$' {
+			if i+1 < len(tc) && tc[i+1] == '$' {
+				out = append(out, '$')
+				i += 2
+			} else if i+1 < len(tc) && tc[i+1] >= '0' && tc[i+1] <= '9' {
+				j := i + 1
+				n := 0
+				for j < len(tc) && tc[j] >= '0' && tc[j] <= '9' {
+					n = n*10 + int(tc[j]-'0'); j++
+				}
+				out = append(out, rxSlotText(slots, n, text)...)
+				i = j
+			} else if i+1 < len(tc) && tc[i+1] == '{' {
+				j := i + 2
+				var nm []rune
+				for j < len(tc) && tc[j] != '}' {
+					nm = append(nm, tc[j]); j++
+				}
+				if j < len(tc) {
+					j++
+				}
+				key := string(nm)
+				n := 0
+				isNum := true
+				for _, d := range nm {
+					if d < '0' || d > '9' {
+						isNum = false; break
+					}
+					n = n*10 + int(d-'0')
+				}
+				if isNum {
+					out = append(out, rxSlotText(slots, n, text)...)
+				} else if gid, ok := names[key]; ok {
+					out = append(out, rxSlotText(slots, gid, text)...)
+				}
+				i = j
+			} else {
+				out = append(out, '$')
+				i++
+			}
+		} else {
+			out = append(out, string(tc[i])...)
+			i++
+		}
+	}
+	return string(out)
+}
+
+func (re Regex) replace(text, replacement string) string {
+	sl, ok := re.findSlots(text)
+	if !ok {
+		return text
+	}
+	return text[:sl[0]] + rxApplyRepl(replacement, sl, text, re.names) + text[sl[1]:]
+}
+
+func (re Regex) replaceAll(text, replacement string) string {
+	chars := []rune(text)
+	boff := rxByteOffsets(chars)
+	var out []byte
+	lastEnd := 0
+	for from := 0; from <= len(chars); {
+		sl, ok := re.findSlotsFrom(chars, boff, from)
+		if !ok {
+			from++
+			continue
+		}
+		out = append(out, text[lastEnd:sl[0]]...)
+		out = append(out, rxApplyRepl(replacement, sl, text, re.names)...)
+		lastEnd = sl[1]
+		ec := rxByteToChar(boff, sl[1])
+		if ec > from {
+			from = ec
+		} else {
+			from++
+		}
+	}
+	out = append(out, text[lastEnd:]...)
+	return string(out)
+}
+
+func (re Regex) split(text string) []string {
+	all := re.findAll(text)
+	if len(all) == 0 {
+		return []string{text}
+	}
+	var parts []string
+	start := 0
+	for _, m := range all {
+		parts = append(parts, text[start:m.start])
+		start = m.end
+	}
+	parts = append(parts, text[start:])
+	return parts
+}
+
+func (c Captures) get(i int) *string {
+	si := i * 2
+	if si+1 >= len(c.slots) {
+		return nil
+	}
+	s, e := c.slots[si], c.slots[si+1]
+	if s < 0 || e < 0 {
+		return nil
+	}
+	v := c.text[s:e]
+	return &v
+}
+
+func (c Captures) named(name string) *string {
+	gid, ok := c.names[name]
+	if !ok {
+		return nil
+	}
+	return c.get(gid)
+}
+`

--- a/internal/gen/stdlib_inline.go
+++ b/internal/gen/stdlib_inline.go
@@ -1,0 +1,299 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+var stdlibOstyInlineModules = map[string]bool{
+	"strings": true,
+	"fmt":     true,
+}
+
+func stdlibOstyModulePath(path []string) (string, bool) {
+	if len(path) != 2 || path[0] != "std" || !stdlibOstyInlineModules[path[1]] {
+		return "", false
+	}
+	return path[1], true
+}
+
+func (g *gen) requestStdlibOsty(module string) {
+	if stdlibOstyInlineModules[module] {
+		g.needStdlibOsty[module] = true
+	}
+}
+
+func (g *gen) emitNeededStdlibOstyModules() {
+	for {
+		progress := false
+		for _, module := range []string{"strings", "fmt"} {
+			if !g.needStdlibOsty[module] || g.emittedStdlibOsty[module] {
+				continue
+			}
+			g.emittedStdlibOsty[module] = true
+			g.emitStdlibOstyModule(module)
+			progress = true
+		}
+		if !progress {
+			return
+		}
+	}
+}
+
+func (g *gen) emitStdlibOstyModule(module string) {
+	reg := stdlib.LoadCached()
+	mod := reg.Modules[module]
+	if mod == nil || mod.File == nil {
+		g.errs = append(g.errs, fmt.Errorf("gen: std.%s source module not found", module))
+		return
+	}
+
+	res := resolve.FileWithStdlib(mod.File, resolve.NewPrelude(), reg)
+	chk := check.File(mod.File, res, check.Opts{
+		UseSelfhost:   true,
+		Source:        mod.Source,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+	})
+	for _, d := range append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...) {
+		if d.Severity == diag.Error {
+			g.errs = append(g.errs, fmt.Errorf("gen: std.%s inline check: %s", module, d.Error()))
+			return
+		}
+	}
+
+	sub := newGen(g.pkgName, mod.File, res, chk)
+	sub.stdlibInlineModule = module
+	sub.stdlibInlineRenames = collectStdlibInlineRenames(module, mod.File)
+	sub.emitGenericFnDecls = true
+	for _, u := range sub.file.Uses {
+		sub.emitUseDecl(u)
+	}
+	for _, d := range sub.file.Decls {
+		sub.emitDecl(d)
+	}
+	sub.drainInstances()
+
+	g.body.nl()
+	g.body.writef("// std.%s inlined from bundled Osty source.\n", module)
+	g.body.write(string(sub.body.bytes()))
+	g.mergeInlineGen(sub)
+}
+
+func collectStdlibInlineRenames(module string, file *ast.File) map[string]string {
+	out := map[string]string{}
+	if file == nil {
+		return out
+	}
+	for _, d := range file.Decls {
+		switch d := d.(type) {
+		case *ast.FnDecl:
+			if d.Recv != nil {
+				continue
+			}
+			out[d.Name] = stdlibOstyFuncName(module, d.Name)
+		case *ast.LetDecl:
+			out[d.Name] = stdlibOstyFuncName(module, d.Name)
+		}
+	}
+	return out
+}
+
+func stdlibOstyFuncName(module, name string) string {
+	return "_ostyStd" + titleIdent(module) + "_" + mangleIdent(name)
+}
+
+func titleIdent(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func (g *gen) renamedFnName(name string) string {
+	if g.stdlibInlineRenames == nil {
+		return name
+	}
+	if renamed, ok := g.stdlibInlineRenames[name]; ok {
+		return renamed
+	}
+	return name
+}
+
+func (g *gen) renamedIdent(id *ast.Ident) string {
+	if id == nil || g.stdlibInlineRenames == nil {
+		return ""
+	}
+	renamed, ok := g.stdlibInlineRenames[id.Name]
+	if !ok {
+		return ""
+	}
+	if sym := g.symbolFor(id); sym != nil {
+		switch sym.Kind {
+		case resolve.SymFn:
+			fn, ok := sym.Decl.(*ast.FnDecl)
+			if !ok || fn.Recv != nil {
+				return ""
+			}
+		case resolve.SymLet:
+			if _, ok := sym.Decl.(*ast.LetDecl); !ok {
+				return ""
+			}
+		default:
+			return ""
+		}
+	}
+	return renamed
+}
+
+func (g *gen) emitStdlibOstyCall(c *ast.CallExpr) bool {
+	id, parts, ok := stdlibFieldChain(c.Fn)
+	if !ok || id == nil || len(parts) != 1 {
+		return false
+	}
+	for module := range stdlibOstyInlineModules {
+		if !g.isStdlibPackageAlias(id, module) {
+			continue
+		}
+		fn := stdlibOstyFnDecl(module, parts[0])
+		if fn == nil {
+			return false
+		}
+		args := newWriter()
+		prev := g.body
+		g.body = args
+		ok := g.emitArgsForParams(fn.Params, c.Args)
+		g.body = prev
+		if !ok {
+			return false
+		}
+		g.requestStdlibOsty(module)
+		g.body.write(stdlibOstyFuncName(module, parts[0]))
+		g.body.write("(")
+		g.body.write(string(args.bytes()))
+		g.body.write(")")
+		return true
+	}
+	return false
+}
+
+func (g *gen) emitStdlibOstyField(f *ast.FieldExpr) bool {
+	id, parts, ok := stdlibFieldChain(f)
+	if !ok || id == nil || len(parts) != 1 {
+		return false
+	}
+	for module := range stdlibOstyInlineModules {
+		if !g.isStdlibPackageAlias(id, module) {
+			continue
+		}
+		if stdlibOstyFnDecl(module, parts[0]) == nil {
+			return false
+		}
+		g.requestStdlibOsty(module)
+		g.body.write(stdlibOstyFuncName(module, parts[0]))
+		return true
+	}
+	return false
+}
+
+func stdlibOstyFnDecl(module, name string) *ast.FnDecl {
+	reg := stdlib.LoadCached()
+	mod := reg.Modules[module]
+	if mod == nil || mod.File == nil {
+		return nil
+	}
+	for _, d := range mod.File.Decls {
+		if fn, ok := d.(*ast.FnDecl); ok && fn.Recv == nil && fn.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+func (g *gen) emitArgsForParams(params []*ast.Param, args []*ast.Arg) bool {
+	slots := make([]ast.Expr, len(params))
+	paramIndex := map[string]int{}
+	for i, p := range params {
+		paramIndex[p.Name] = i
+	}
+	pos := 0
+	for _, a := range args {
+		if a.Name == "" {
+			if pos >= len(slots) {
+				return false
+			}
+			slots[pos] = a.Value
+			pos++
+			continue
+		}
+		idx, ok := paramIndex[a.Name]
+		if !ok || idx < 0 || idx >= len(slots) || slots[idx] != nil {
+			return false
+		}
+		slots[idx] = a.Value
+	}
+	for i, p := range params {
+		if i > 0 {
+			g.body.write(", ")
+		}
+		arg := slots[i]
+		if arg == nil {
+			arg = p.Default
+		}
+		if arg == nil {
+			return false
+		}
+		g.emitExpr(arg)
+	}
+	return true
+}
+
+func (g *gen) mergeInlineGen(sub *gen) {
+	for path, alias := range sub.imports {
+		if alias != "" {
+			g.useAs(path, alias)
+		} else {
+			g.use(path)
+		}
+	}
+	for module := range sub.needStdlibOsty {
+		g.requestStdlibOsty(module)
+	}
+	g.needResult = g.needResult || sub.needResult
+	g.needErrorRuntime = g.needErrorRuntime || sub.needErrorRuntime
+	g.needStringRuntime = g.needStringRuntime || sub.needStringRuntime
+	g.needRange = g.needRange || sub.needRange
+	g.needHandle = g.needHandle || sub.needHandle
+	g.needTaskGroup = g.needTaskGroup || sub.needTaskGroup
+	g.needSelect = g.needSelect || sub.needSelect
+	g.needFS = g.needFS || sub.needFS
+	g.needRandomRuntime = g.needRandomRuntime || sub.needRandomRuntime
+	g.needURLRuntime = g.needURLRuntime || sub.needURLRuntime
+	g.needEncoding = g.needEncoding || sub.needEncoding
+	g.needEnv = g.needEnv || sub.needEnv
+	g.needCsvRuntime = g.needCsvRuntime || sub.needCsvRuntime
+	g.needJSON = g.needJSON || sub.needJSON
+	g.needCompress = g.needCompress || sub.needCompress
+	g.needCrypto = g.needCrypto || sub.needCrypto
+	g.needUUID = g.needUUID || sub.needUUID
+	g.needBytesRuntime = g.needBytesRuntime || sub.needBytesRuntime
+	g.needRegex = g.needRegex || sub.needRegex
+	g.needRefRuntime = g.needRefRuntime || sub.needRefRuntime
+	g.needEqualRuntime = g.needEqualRuntime || sub.needEqualRuntime
+	if g.fsOSAlias == "" {
+		g.fsOSAlias = sub.fsOSAlias
+	}
+	if g.fsUTF8Alias == "" {
+		g.fsUTF8Alias = sub.fsUTF8Alias
+	}
+	g.errs = append(g.errs, sub.errs...)
+}

--- a/internal/gen/stmt.go
+++ b/internal/gen/stmt.go
@@ -1,0 +1,719 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
+)
+
+// emitStmts writes a series of statements.
+func (g *gen) emitStmts(stmts []ast.Stmt) {
+	for _, s := range stmts {
+		g.emitStmt(s)
+	}
+}
+
+// emitStmt dispatches on statement kind. Each emitter is responsible
+// for writing its own trailing newline.
+//
+// The pre-lift pass for `?` runs inside the per-kind emitters that
+// accept free-form expressions (LetStmt, ReturnStmt, AssignStmt,
+// ExprStmt). It must run before the statement's trailing expression
+// is emitted so the lift blocks land above it; the subs map is
+// cleared after the statement so it doesn't leak into the next.
+func (g *gen) emitStmt(s ast.Stmt) {
+	g.sourceMarker(s)
+	switch s := s.(type) {
+	case *ast.Block:
+		g.emitBlock(s)
+	case *ast.LetStmt:
+		g.emitLetStmt(s)
+	case *ast.ExprStmt:
+		// If / match at statement position lower to Go statements,
+		// not expression-IIFEs. Their value is discarded anyway, so
+		// the IIFE would just allocate a closure for nothing.
+		switch e := s.X.(type) {
+		case *ast.IfExpr:
+			g.emitIfStmt(e)
+			return
+		case *ast.MatchExpr:
+			// Match used only for side effects — lower to a direct
+			// sequence of if blocks, no IIFE wrapper.
+			g.emitMatchStmt(e)
+			return
+		case *ast.QuestionExpr:
+			// A bare `expr?` at statement position is equivalent to
+			// `let _ = expr?` — propagate on failure, discard the
+			// unwrapped value.
+			g.emitQuestionLift("_", e)
+			return
+		}
+		g.preLiftQuestions(s.X)
+		g.emitExpr(s.X)
+		g.body.nl()
+		g.resetQuestionSubs()
+	case *ast.AssignStmt:
+		g.emitAssign(s)
+	case *ast.ReturnStmt:
+		g.emitReturn(s)
+	case *ast.BreakStmt:
+		g.body.writeln("break")
+	case *ast.ContinueStmt:
+		g.body.writeln("continue")
+	case *ast.ForStmt:
+		g.emitFor(s)
+	case *ast.DeferStmt:
+		g.body.write("defer ")
+		// `defer <expr>` in Osty maps to Go's `defer <callish-expr>`;
+		// Go requires a call expression, which Osty-side users already
+		// write (defer close(h)).
+		g.emitExpr(s.X)
+		g.body.nl()
+	case *ast.ChanSendStmt:
+		g.emitExpr(s.Channel)
+		g.body.write(" <- ")
+		g.emitExpr(s.Value)
+		g.body.nl()
+	default:
+		g.body.writef("/* TODO: stmt %T */\n", s)
+	}
+}
+
+// emitBlock writes a brace-delimited block in statement position,
+// including a trailing newline after the closing brace.
+func (g *gen) emitBlock(b *ast.Block) {
+	g.emitBlockInline(b)
+	g.body.nl()
+}
+
+// emitBlockInline writes `{ ... }` without a trailing newline, so that
+// the caller can place `else`, `, ` (closure body), etc. immediately
+// after the closing brace.
+func (g *gen) emitBlockInline(b *ast.Block) {
+	g.body.writeln("{")
+	g.body.indent()
+	g.emitStmts(b.Stmts)
+	g.body.dedent()
+	g.body.write("}")
+}
+
+// emitLetStmt handles `let p = e`.
+//
+// Mutability flag (`let mut`) is discarded: Go variables are always
+// mutable; the type checker already enforced Osty's immutability.
+func (g *gen) emitLetStmt(l *ast.LetStmt) {
+	name := identPatternName(l.Pattern)
+	if name == "" {
+		g.emitLetPatternDestructure(l.Pattern, l.Value)
+		return
+	}
+	safe := mangleIdent(name)
+
+	// `let x = expr?` lifts the `?` into control flow. Two shapes:
+	//
+	//   Option operand: test for nil, return nil on miss, deref.
+	//   Result operand: test IsOk, return the same Result on miss,
+	//                   take Value on success.
+	if q, ok := l.Value.(*ast.QuestionExpr); ok {
+		g.emitQuestionLift(safe, q)
+		return
+	}
+
+	// Any `?` nested inside a compound RHS (e.g. `let x = foo(bar()?)`)
+	// gets hoisted out via preLiftQuestions so the remaining expression
+	// is a straight substitution on the lifted temps.
+	g.preLiftQuestions(l.Value)
+	defer g.resetQuestionSubs()
+
+	// Silence Go's "declared and not used" for the bound name. Go
+	// enforces usage per scope; Osty doesn't. Adding `_ = x` after
+	// every let is the cheapest way to keep the transpiled output
+	// compiling even when the user declares-but-never-reads.
+	defer func() {
+		if safe != "_" {
+			g.body.writef("_ = %s\n", safe)
+		}
+	}()
+
+	// Prefer short form (name := expr) when the checker inferred the
+	// type and no annotation is given. Explicit annotations get the
+	// `var name T = expr` long form so the declared type is preserved
+	// across literal coercion (e.g. `let x: Float32 = 1.5`).
+	if l.Type != nil {
+		g.body.writef("var %s %s", safe, g.goTypeExpr(l.Type))
+		if l.Value != nil {
+			g.body.write(" = ")
+			g.emitExprAsType(l.Value, g.typeOf(l.Value))
+		}
+		g.body.nl()
+		return
+	}
+	if l.Value == nil {
+		// `let x` with no value and no type is unusual; fall back to
+		// `any` so gofmt parses something.
+		g.body.writef("var %s any\n", safe)
+		return
+	}
+	// `let _ = expr`: Go forbids `_ :=`, so emit plain blank-ident
+	// assignment. Keeps side effects of the RHS while explicitly
+	// discarding the value.
+	if safe == "_" {
+		g.body.write("_ = ")
+		g.emitExpr(l.Value)
+		g.body.nl()
+		return
+	}
+	g.body.writef("%s := ", safe)
+	g.emitExpr(l.Value)
+	g.body.nl()
+}
+
+// identPatternName extracts a bare identifier name from a pattern, or
+// "" when the pattern is a destructuring form we haven't yet lowered.
+func identPatternName(p ast.Pattern) string {
+	switch p := p.(type) {
+	case *ast.IdentPat:
+		return p.Name
+	case *ast.WildcardPat:
+		return "_"
+	}
+	return ""
+}
+
+// emitQuestionLift lowers `let <name> = <expr>?` into the pair:
+//
+//	_qN := <expr>
+//	if /* failure test */ { return /* failure value */ }
+//	<name> := /* success value */
+//
+// Dispatch between Option and Result is driven by the operand's
+// checked type. Result's failure-return must be reconstructed with the
+// enclosing function's Result[T, E] signature — Go treats
+// Result[bool, E] and Result[string, E] as unrelated types.
+//
+// A name of "_" skips the user-facing binding — used for the
+// statement-position `expr?` form where the success value is
+// discarded.
+func (g *gen) emitQuestionLift(name string, q *ast.QuestionExpr) {
+	tmp := g.freshVar("_q")
+	operandT := g.typeOf(q.X)
+	isResult := false
+	if n, ok := operandT.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Result" {
+		isResult = true
+	}
+	g.body.writef("%s := ", tmp)
+	g.emitExpr(q.X)
+	g.body.nl()
+	if isResult {
+		// Reconstruct a Result of the enclosing function's signature.
+		retGo := "any"
+		if g.currentRetGo != "" {
+			retGo = g.currentRetGo
+		} else if g.currentRetType != nil {
+			retGo = g.goTypeExpr(g.currentRetType)
+		}
+		g.body.writef("if !%s.IsOk { return %s{Error: %s.Error, ref: resultRef()} }\n", tmp, retGo, tmp)
+		if name != "_" {
+			g.body.writef("%s := %s.Value\n_ = %s\n", name, tmp, name)
+		} else {
+			g.body.writef("_ = %s.Value\n", tmp)
+		}
+		return
+	}
+	g.body.writef("if %s == nil { return nil }\n", tmp)
+	if name != "_" {
+		g.body.writef("%s := *%s\n_ = %s\n", name, tmp, name)
+	} else {
+		g.body.writef("_ = *%s\n", tmp)
+	}
+}
+
+// emitLetPatternDestructure lowers an irrefutable pattern binding by
+// first evaluating the RHS once and then reusing the match binding
+// machinery for tuple / struct / nested subpatterns.
+func (g *gen) emitLetPatternDestructure(p ast.Pattern, value ast.Expr) {
+	tmp := g.freshVar("_p")
+	g.preLiftQuestions(value)
+	defer g.resetQuestionSubs()
+	g.body.writef("%s := ", tmp)
+	g.emitExpr(value)
+	g.body.writef("\n_ = %s\n", tmp)
+	g.emitPatternBindings(tmp, g.typeOf(value), p)
+}
+
+// emitAssign covers `a = b`, compound assigns (`+=`, `-=`, ...) and
+// multi-assign `(a, b) = (c, d)`. Multi-assign with a tuple RHS is
+// rewritten to Go's parallel assignment.
+func (g *gen) emitAssign(a *ast.AssignStmt) {
+	// Pre-lift any `?` in targets or value. Targets rarely contain `?`
+	// in practice, but we walk them for completeness.
+	for _, t := range a.Targets {
+		g.preLiftQuestions(t)
+	}
+	g.preLiftQuestions(a.Value)
+	defer g.resetQuestionSubs()
+
+	op := assignOp(a.Op)
+	if len(a.Targets) > 1 {
+		for i, t := range a.Targets {
+			if i > 0 {
+				g.body.write(", ")
+			}
+			g.emitExpr(t)
+		}
+		g.body.writef(" %s ", op)
+		// Multi-target with tuple RHS: lay out elems side-by-side.
+		if tup, ok := a.Value.(*ast.TupleExpr); ok && len(tup.Elems) == len(a.Targets) {
+			for i, e := range tup.Elems {
+				if i > 0 {
+					g.body.write(", ")
+				}
+				g.emitExpr(e)
+			}
+		} else {
+			g.emitExpr(a.Value)
+		}
+		g.body.nl()
+		return
+	}
+	if a.Op == token.ASSIGN {
+		if g.emitCheckedIntegerSimpleAssign(a.Targets[0], a.Value) {
+			return
+		}
+	}
+	if binOp, ok := compoundBinaryOp(a.Op); ok {
+		if g.emitCheckedIntegerCompoundAssign(a.Targets[0], a.Value, binOp) {
+			return
+		}
+	}
+	g.emitExpr(a.Targets[0])
+	g.body.writef(" %s ", op)
+	g.emitExpr(a.Value)
+	g.body.nl()
+}
+
+func (g *gen) emitCheckedIntegerSimpleAssign(target ast.Expr, value ast.Expr) bool {
+	if _, ok := target.(*ast.Ident); !ok {
+		return false
+	}
+	targetK, ok := integerKindOf(g.typeOf(target))
+	if !ok {
+		return false
+	}
+	bin, ok := value.(*ast.BinaryExpr)
+	if !ok {
+		return false
+	}
+	if _, ok := integerKindOf(g.typeOf(bin)); !ok {
+		return false
+	}
+	switch bin.Op {
+	case token.PLUS, token.MINUS, token.STAR, token.SLASH, token.PERCENT, token.SHL, token.SHR:
+	default:
+		return false
+	}
+	g.body.writeln("func() {")
+	g.body.indent()
+	g.emitCheckedIntegerCompoundAssignBody(bin.Op, bin.Right, targetK, g.typeOf(bin.Right), func() {
+		g.emitExpr(bin.Left)
+	}, func() {
+		g.emitExpr(target)
+	})
+	g.body.dedent()
+	g.body.writeln("}()")
+	return true
+}
+
+func (g *gen) emitCheckedIntegerCompoundAssign(target ast.Expr, value ast.Expr, op token.Kind) bool {
+	targetT := g.typeOf(target)
+	targetK, ok := integerKindOf(targetT)
+	if !ok {
+		return false
+	}
+	g.body.writeln("func() {")
+	g.body.indent()
+	if idx, ok := target.(*ast.IndexExpr); ok && isMapType(g.typeOf(idx.X)) {
+		mapVar := g.freshVar("_map")
+		keyVar := g.freshVar("_key")
+		g.body.writef("%s := ", mapVar)
+		g.emitExpr(idx.X)
+		g.body.nl()
+		g.body.writef("%s := ", keyVar)
+		g.emitExpr(idx.Index)
+		g.body.nl()
+		g.emitCheckedIntegerCompoundAssignBody(op, value, targetK, g.typeOf(value), func() {
+			g.body.writef("%s[%s]", mapVar, keyVar)
+		}, func() {
+			g.body.writef("%s[%s]", mapVar, keyVar)
+		})
+	} else {
+		slotVar := g.freshVar("_slot")
+		g.body.writef("%s := &", slotVar)
+		g.emitExpr(target)
+		g.body.nl()
+		g.emitCheckedIntegerCompoundAssignBody(op, value, targetK, g.typeOf(value), func() {
+			g.body.writef("*%s", slotVar)
+		}, func() {
+			g.body.writef("*%s", slotVar)
+		})
+	}
+	g.body.dedent()
+	g.body.writeln("}()")
+	return true
+}
+
+func (g *gen) emitCheckedIntegerCompoundAssignBody(op token.Kind, value ast.Expr, targetK types.PrimitiveKind, valueT types.Type, emitCurrent, emitDest func()) {
+	goT := goPrimitive(targetK)
+	info := runtimeIntInfo(targetK)
+	cur := g.freshVar("_cur")
+	rhs := g.freshVar("_rhs")
+	g.body.writef("var %s %s = ", cur, goT)
+	emitCurrent()
+	g.body.nl()
+	switch op {
+	case token.PLUS, token.MINUS, token.STAR, token.SLASH, token.PERCENT:
+		if op == token.PLUS || op == token.MINUS || op == token.STAR || info.signed {
+			g.use("math")
+		}
+		g.body.writef("var %s %s = ", rhs, goT)
+		g.emitExpr(value)
+		g.body.nl()
+		switch op {
+		case token.PLUS:
+			g.emitIntAddOverflowGuard(info, cur, rhs, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+			emitDest()
+			g.body.writef(" = %s + %s\n", cur, rhs)
+		case token.MINUS:
+			g.emitIntSubOverflowGuard(info, cur, rhs, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+			emitDest()
+			g.body.writef(" = %s - %s\n", cur, rhs)
+		case token.STAR:
+			g.emitIntMulOverflowGuard(info, goT, cur, rhs, "panic(\"integer overflow\")", "panic(\"integer overflow\")")
+			emitDest()
+			g.body.writef(" = %s * %s\n", cur, rhs)
+		case token.SLASH:
+			g.body.writef("if %s == 0 { panic(%q) }\n", rhs, "integer division by zero")
+			if info.signed {
+				g.body.writef("if %s == %s && %s == %s(-1) { panic(%q) }\n", cur, info.min, rhs, goT, "integer overflow")
+			}
+			emitDest()
+			g.body.writef(" = %s / %s\n", cur, rhs)
+		case token.PERCENT:
+			g.body.writef("if %s == 0 { panic(%q) }\n", rhs, "integer modulo by zero")
+			if info.signed {
+				g.body.writef("if %s == %s && %s == %s(-1) { panic(%q) }\n", cur, info.min, rhs, goT, "integer overflow")
+			}
+			emitDest()
+			g.body.writef(" = %s %% %s\n", cur, rhs)
+		}
+	case token.SHL, token.SHR:
+		rightK, ok := integerKindOf(valueT)
+		if !ok {
+			rightK = targetK
+		}
+		rightGo := goPrimitive(rightK)
+		rightInfo := runtimeIntInfo(rightK)
+		if targetK == types.PInt {
+			g.use("strconv")
+		}
+		g.body.writef("var %s %s = ", rhs, rightGo)
+		g.emitExpr(value)
+		g.body.nl()
+		if rightInfo.signed {
+			g.body.writef("if %s < 0 || %s >= %s(%s) { panic(%q) }\n", rhs, rhs, rightGo, info.bits, "invalid shift count")
+		} else {
+			g.body.writef("if %s >= %s(%s) { panic(%q) }\n", rhs, rightGo, info.bits, "invalid shift count")
+		}
+		emitDest()
+		shiftOp := "<<"
+		if op == token.SHR {
+			shiftOp = ">>"
+		}
+		g.body.writef(" = %s %s uint(%s)\n", cur, shiftOp, rhs)
+	}
+}
+
+func compoundBinaryOp(k token.Kind) (token.Kind, bool) {
+	switch k {
+	case token.PLUSEQ:
+		return token.PLUS, true
+	case token.MINUSEQ:
+		return token.MINUS, true
+	case token.STAREQ:
+		return token.STAR, true
+	case token.SLASHEQ:
+		return token.SLASH, true
+	case token.PERCENTEQ:
+		return token.PERCENT, true
+	case token.SHLEQ:
+		return token.SHL, true
+	case token.SHREQ:
+		return token.SHR, true
+	default:
+		return token.ILLEGAL, false
+	}
+}
+
+// assignOp maps an Osty assignment token to its Go operator string.
+func assignOp(k token.Kind) string {
+	switch k {
+	case token.ASSIGN:
+		return "="
+	case token.PLUSEQ:
+		return "+="
+	case token.MINUSEQ:
+		return "-="
+	case token.STAREQ:
+		return "*="
+	case token.SLASHEQ:
+		return "/="
+	case token.PERCENTEQ:
+		return "%="
+	case token.BITANDEQ:
+		return "&="
+	case token.BITOREQ:
+		return "|="
+	case token.BITXOREQ:
+		return "^="
+	case token.SHLEQ:
+		return "<<="
+	case token.SHREQ:
+		return ">>="
+	}
+	return "="
+}
+
+// emitReturn writes `return` or `return <expr>`.
+//
+// `return expr?` lifts the `?` so the return's expression is the
+// unwrapped success value. Nested `?` inside a compound return
+// expression is handled the same way via preLiftQuestions.
+func (g *gen) emitReturn(r *ast.ReturnStmt) {
+	if r.Value == nil {
+		g.body.writeln("return")
+		return
+	}
+	g.preLiftQuestions(r.Value)
+	defer g.resetQuestionSubs()
+	g.body.write("return ")
+	g.emitExpr(r.Value)
+	g.body.nl()
+}
+
+// emitFor covers all `for` forms.
+//
+//	for cond { ... }        → for cond { ... }
+//	for { ... }             → for { ... }
+//	for i in 0..10 { ... }  → for i := 0; i < 10; i++ { ... }
+//	for i in 0..=10 { ... } → for i := 0; i <= 10; i++ { ... }
+//	for x in xs { ... }     → for _, x := range xs { ... }
+//	for let Some(v) = e {}  → Phase 4 (optional iteration)
+func (g *gen) emitFor(f *ast.ForStmt) {
+	g.loopDepth++
+	defer func() { g.loopDepth-- }()
+
+	if f.IsForLet {
+		g.emitForLet(f)
+		return
+	}
+	// Infinite loop.
+	if f.Iter == nil {
+		g.body.write("for ")
+		g.emitBlock(f.Body)
+		return
+	}
+	// for cond { ... } — Pattern is nil, Iter is the condition.
+	if f.Pattern == nil {
+		g.body.write("for ")
+		g.emitExpr(f.Iter)
+		g.body.write(" ")
+		g.emitBlock(f.Body)
+		return
+	}
+	// Tuple pattern over a Go two-value range source:
+	//
+	//   for (k, v) in map
+	//   for (i, x) in xs.enumerate()
+	//
+	// Plain List<(A, B)> values intentionally skip this path; Go range
+	// yields index + tuple there, so the generic destructuring branch
+	// below must bind the tuple element instead.
+	if tp, ok := f.Pattern.(*ast.TuplePat); ok && len(tp.Elems) == 2 {
+		iter := f.Iter
+		var keyType, valueType types.Type
+		twoValueRange := false
+		if recv, ok := enumerateReceiver(f.Iter); ok {
+			iter = recv
+			keyType = types.Int
+			valueType = iterElementType(g.typeOf(recv))
+			twoValueRange = true
+		} else if isMapType(g.typeOf(f.Iter)) {
+			keyType, valueType = mapElemTypes(g.typeOf(f.Iter))
+			twoValueRange = true
+		}
+		if twoValueRange {
+			k := g.freshVar("_k")
+			v := g.freshVar("_v")
+			g.body.writef("for %s, %s := range ", k, v)
+			g.emitExpr(iter)
+			g.body.writeln(" {")
+			g.body.indent()
+			g.body.writef("_ = %s\n_ = %s\n", k, v)
+			g.emitPatternBindings(k, keyType, tp.Elems[0])
+			g.emitPatternBindings(v, valueType, tp.Elems[1])
+			g.emitStmts(f.Body.Stmts)
+			g.body.dedent()
+			g.body.writeln("}")
+			return
+		}
+	}
+	// for pattern in iter — single binding.
+	name := identPatternName(f.Pattern)
+	if name == "" {
+		// Non-ident pattern: bind each iteration to a fresh temp and
+		// unpack it inside the body through the same recursive pattern
+		// binding path used by match / if-let.
+		tmp := g.freshVar("_it")
+		g.body.writef("for _, %s := range ", tmp)
+		g.emitExpr(f.Iter)
+		g.body.writeln(" {")
+		g.body.indent()
+		g.body.writef("_ = %s\n", tmp)
+		g.emitPatternBindings(tmp, iterElementType(g.typeOf(f.Iter)), f.Pattern)
+		g.emitStmts(f.Body.Stmts)
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+	// Integer range gets a C-style `for i := a; i <op> b; i++`.
+	if r, ok := f.Iter.(*ast.RangeExpr); ok && r.Start != nil && r.Stop != nil {
+		safe := mangleIdent(name)
+		cmp := "<"
+		if r.Inclusive {
+			cmp = "<="
+		}
+		g.body.writef("for %s := ", safe)
+		g.emitExpr(r.Start)
+		g.body.writef("; %s %s ", safe, cmp)
+		g.emitExpr(r.Stop)
+		g.body.writef("; %s++ ", safe)
+		g.emitBlock(f.Body)
+		return
+	}
+	// Channel iteration — Go's `for x := range ch` form (single value).
+	if iterT := g.typeOf(f.Iter); iterT != nil {
+		if n, ok := iterT.(*types.Named); ok && n.Sym != nil &&
+			(n.Sym.Name == "Chan" || n.Sym.Name == "Channel") {
+			safe := mangleIdent(name)
+			g.body.writef("for %s := range ", safe)
+			g.emitExpr(f.Iter)
+			g.body.write(" ")
+			g.emitBlock(f.Body)
+			return
+		}
+	}
+	// Generic: `for _, name := range iter`.
+	safe := mangleIdent(name)
+	g.body.writef("for _, %s := range ", safe)
+	g.emitExpr(f.Iter)
+	g.body.write(" ")
+	g.emitBlock(f.Body)
+}
+
+// emitForLet lowers `for let pat = expr { body }` — iterate while
+// `expr` still matches `pat`. The canonical shape is
+// `for let Some(x) = queue.pop() { ... }`, i.e. pop until the queue
+// runs dry. The lowering is:
+//
+//	for {
+//	    _t := <expr>
+//	    if !matches(_t, pat) { break }
+//	    // bind(s) from the pattern
+//	    <body>
+//	}
+//
+// The pattern test/binding code is shared with match and if-let, so
+// Option, Result, user enums, tuple, struct, range and binding
+// patterns stay in one lowering path.
+func (g *gen) emitForLet(f *ast.ForStmt) {
+	g.body.writeln("for {")
+	g.body.indent()
+	tmp := g.freshVar("_ol")
+	if iterT := g.typeOf(f.Iter); iterT != nil && !types.IsError(iterT) {
+		g.body.writef("var %s %s = ", tmp, g.goType(iterT))
+	} else if id, ok := f.Iter.(*ast.Ident); ok && id.Name == "None" {
+		g.body.writef("var %s *any = ", tmp)
+	} else {
+		g.body.writef("%s := ", tmp)
+	}
+	g.emitExpr(f.Iter)
+	g.body.writef("\n_ = %s\n", tmp)
+	scrutT := g.typeOf(f.Iter)
+	g.body.write("if !(")
+	g.emitPatternTest(tmp, scrutT, f.Pattern)
+	g.body.writeln(") { break }")
+	g.emitPatternBindings(tmp, scrutT, f.Pattern)
+	g.emitStmts(f.Body.Stmts)
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+func isMapType(t types.Type) bool {
+	n, ok := t.(*types.Named)
+	return ok && n.Sym != nil && n.Sym.Name == "Map" && len(n.Args) == 2
+}
+
+func mapElemTypes(t types.Type) (types.Type, types.Type) {
+	if n, ok := t.(*types.Named); ok && n.Sym != nil && n.Sym.Name == "Map" && len(n.Args) == 2 {
+		return n.Args[0], n.Args[1]
+	}
+	return nil, nil
+}
+
+func iterElementType(t types.Type) types.Type {
+	switch n := t.(type) {
+	case *types.Named:
+		if n.Sym == nil {
+			return nil
+		}
+		switch n.Sym.Name {
+		case "List", "Set", "Chan", "Channel":
+			if len(n.Args) == 1 {
+				return n.Args[0]
+			}
+		case "Map":
+			if len(n.Args) == 2 {
+				return &types.Tuple{Elems: []types.Type{n.Args[0], n.Args[1]}}
+			}
+		}
+	case *types.Primitive:
+		if n.Kind == types.PString || n.Kind == types.PBytes {
+			return types.Byte
+		}
+	}
+	return nil
+}
+
+func enumerateReceiver(e ast.Expr) (ast.Expr, bool) {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return nil, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.Name != "enumerate" {
+		return nil, false
+	}
+	return field.X, true
+}
+
+// emitExprAsType emits an expression with a target type context. For
+// numeric literals this rewrites them into the target's Go form so
+// gofmt doesn't complain about untyped constant overflow; for other
+// expressions it falls back to bare emission.
+func (g *gen) emitExprAsType(e ast.Expr, _ types.Type) {
+	// Phase 1: no special handling — the base emitter renders each
+	// literal with its source text which is already Go-compatible.
+	g.emitExpr(e)
+}

--- a/internal/gen/typ.go
+++ b/internal/gen/typ.go
@@ -1,0 +1,505 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/types"
+)
+
+// itoa is a tiny helper so type emission can build fieldX strings
+// without pulling strconv into every caller.
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// goType renders a semantic Type as its Go equivalent.
+//
+// The mapping is fixed for Phase 1:
+//
+//	Int, Int8..Int64            → int, int8..int64
+//	UInt8..UInt64, Byte         → uint8..uint64, byte
+//	Float, Float32, Float64     → float64, float32, float64
+//	Bool, Char, String, Bytes   → bool, rune, string, []byte
+//	()                          → struct{}
+//	Never                       → struct{} (unreachable placeholder)
+//	T?                          → *T
+//	List<T>, Iter<T>            → []T
+//	Map<K, V>                   → map[K]V
+//	User-defined Named          → its name verbatim
+//	TypeVar T                   → T
+//
+// Untyped literals are defaulted per §2.2 (UntypedInt→Int→int,
+// UntypedFloat→Float→float64). An unresolved Error type yields "any"
+// so malformed sources still produce something parseable by gofmt.
+func (g *gen) goType(t types.Type) string {
+	switch t := t.(type) {
+	case nil:
+		return "any"
+	case *types.Primitive:
+		return goPrimitive(t.Kind)
+	case *types.Untyped:
+		if p, ok := t.Default().(*types.Primitive); ok {
+			return goPrimitive(p.Kind)
+		}
+		return "any"
+	case *types.Optional:
+		return "*" + g.goType(t.Inner)
+	case *types.Tuple:
+		// Tuples lower to Go anonymous structs with positional Fi
+		// fields. Matches the shape emitTupleExpr produces.
+		var b strings.Builder
+		b.WriteString("struct{")
+		for i, e := range t.Elems {
+			if i > 0 {
+				b.WriteString("; ")
+			}
+			b.WriteString("F")
+			b.WriteString(itoa(i))
+			b.WriteByte(' ')
+			b.WriteString(g.goType(e))
+		}
+		b.WriteByte('}')
+		return b.String()
+	case *types.FnType:
+		return g.goFnType(t)
+	case *types.Named:
+		return g.goNamedType(t)
+	case *types.TypeVar:
+		if t.Sym != nil {
+			if concrete, ok := g.lookupSubst(t.Sym.Name); ok {
+				return concrete
+			}
+			return t.Sym.Name
+		}
+		return "any"
+	case *types.Error:
+		return "any"
+	}
+	return "any"
+}
+
+// goPrimitive is the fixed primitive→Go identifier table.
+func goPrimitive(k types.PrimitiveKind) string {
+	switch k {
+	case types.PInt:
+		return "int"
+	case types.PInt8:
+		return "int8"
+	case types.PInt16:
+		return "int16"
+	case types.PInt32:
+		return "int32"
+	case types.PInt64:
+		return "int64"
+	case types.PUInt8:
+		return "uint8"
+	case types.PUInt16:
+		return "uint16"
+	case types.PUInt32:
+		return "uint32"
+	case types.PUInt64:
+		return "uint64"
+	case types.PByte:
+		return "byte"
+	case types.PFloat:
+		return "float64"
+	case types.PFloat32:
+		return "float32"
+	case types.PFloat64:
+		return "float64"
+	case types.PBool:
+		return "bool"
+	case types.PChar:
+		return "rune"
+	case types.PString:
+		return "string"
+	case types.PBytes:
+		return "[]byte"
+	case types.PUnit, types.PNever:
+		return "struct{}"
+	}
+	return "any"
+}
+
+// goFnType renders a semantic function type. The return component is
+// omitted when the result is Unit — Go's natural "no result" form.
+func (g *gen) goFnType(f *types.FnType) string {
+	var b strings.Builder
+	b.WriteString("func(")
+	for i, p := range f.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(g.goType(p))
+	}
+	b.WriteByte(')')
+	if f.Return != nil && !types.IsUnit(f.Return) {
+		b.WriteByte(' ')
+		b.WriteString(g.goType(f.Return))
+	}
+	return b.String()
+}
+
+// goNamedType renders a Named type.
+//
+// Built-in compound names (List, Map, Set, Option, Result) get their
+// canonical Go shape: []T, map[K]V, map[T]struct{}, *T, etc. For
+// user-defined types we emit the bare identifier plus type arguments.
+func (g *gen) goNamedType(n *types.Named) string {
+	if n.Sym == nil {
+		return "any"
+	}
+	switch n.Sym.Name {
+	case "List", "Iter":
+		if len(n.Args) == 1 {
+			return "[]" + g.goType(n.Args[0])
+		}
+		return "[]any"
+	case "Map":
+		if len(n.Args) == 2 {
+			return "map[" + g.goType(n.Args[0]) + "]" + g.goType(n.Args[1])
+		}
+		return "map[any]any"
+	case "Set":
+		if len(n.Args) == 1 {
+			return "map[" + g.goType(n.Args[0]) + "]struct{}"
+		}
+		return "map[any]struct{}"
+	case "Option":
+		if len(n.Args) == 1 {
+			return "*" + g.goType(n.Args[0])
+		}
+		return "any"
+	case "Result":
+		g.needResult = true
+		if len(n.Args) == 2 {
+			return "Result[" + g.goType(n.Args[0]) + ", " + g.goType(n.Args[1]) + "]"
+		}
+		return "Result[any, any]"
+	case "Error":
+		// Osty's prelude `Error` is a structural interface (§7.1) with
+		// .message()/.source(). Go's built-in `error` requires
+		// .Error() string, which Osty types don't expose. Mapping to
+		// `any` accepts widening from concrete error enums at the
+		// cost of losing Go's error-interface polymorphism; a full
+		// fix would generate an .Error() shim per type.
+		return "any"
+	case "BasicError":
+		if isStdlibBasicError(n) {
+			g.needErrorRuntime = true
+			return "ostyBasicError"
+		}
+	case "Chan", "Channel":
+		// §8.5: channel types lower to Go's built-in chan T.
+		if len(n.Args) == 1 {
+			return "chan " + g.goType(n.Args[0])
+		}
+		return "chan any"
+	case "Handle":
+		// §8.1: a task handle wraps a future result. We emit a runtime
+		// Handle[T] struct (see needHandle); the mapping here just
+		// requests it.
+		g.needHandle = true
+		if len(n.Args) == 1 {
+			return "Handle[" + g.goType(n.Args[0]) + "]"
+		}
+		return "Handle[any]"
+	case "TaskGroup":
+		// §8.1 structured-concurrency group. Emitted as a pointer so
+		// the same value is seen by the closure body and by
+		// runTaskGroup's Wait call.
+		g.needTaskGroup = true
+		return "*TaskGroup"
+	case "Json":
+		g.needJSON = true
+		return "Json"
+	case "Uuid":
+		g.needUUID = true
+		return "Uuid"
+	}
+	// User-defined structs have reference semantics (§2.8), so values
+	// flow as pointers to the emitted Go struct. Enums stay as their Go
+	// interface type; their variants carry identity by storing pointers
+	// to the concrete variant structs in that interface.
+	name := g.goUserNamed(n.Sym.Name, n.Args)
+	if g.isReferenceStructSym(n.Sym) || g.structTypes[n.Sym.Name] {
+		return "*" + name
+	}
+	return name
+}
+
+func (g *gen) goUserNamed(name string, args []types.Type) string {
+	if len(args) == 0 {
+		return name
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteByte('[')
+	for i, a := range args {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(g.goType(a))
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+func (g *gen) isReferenceStructSym(sym *resolve.Symbol) bool {
+	if sym == nil || sym.Kind != resolve.SymStruct {
+		return false
+	}
+	if g.structTypes[sym.Name] {
+		return true
+	}
+	switch sym.Name {
+	}
+	return true
+}
+
+// goTypeExpr translates an AST type node to its Go type string. Used
+// when no semantic Type is available (parameter declarations before
+// the checker runs, or lost in an unchecked region of the tree).
+func (g *gen) goTypeExpr(t ast.Type) string {
+	switch t := t.(type) {
+	case nil:
+		return ""
+	case *ast.NamedType:
+		return g.goNamedAST(t)
+	case *ast.OptionalType:
+		return "*" + g.goTypeExpr(t.Inner)
+	case *ast.TupleType:
+		var b strings.Builder
+		b.WriteString("struct{")
+		for i, e := range t.Elems {
+			if i > 0 {
+				b.WriteString("; ")
+			}
+			b.WriteString("F")
+			b.WriteString(itoa(i))
+			b.WriteByte(' ')
+			b.WriteString(g.goTypeExpr(e))
+		}
+		b.WriteByte('}')
+		return b.String()
+	case *ast.FnType:
+		return g.goFnTypeAST(t)
+	}
+	return "any"
+}
+
+// primitiveByName is the fallback path when we only have an AST type
+// reference (no resolved Symbol). Mirrors the prelude scalar set.
+var primitiveByName = map[string]string{
+	"Int":     "int",
+	"Int8":    "int8",
+	"Int16":   "int16",
+	"Int32":   "int32",
+	"Int64":   "int64",
+	"UInt8":   "uint8",
+	"UInt16":  "uint16",
+	"UInt32":  "uint32",
+	"UInt64":  "uint64",
+	"Byte":    "byte",
+	"Float":   "float64",
+	"Float32": "float32",
+	"Float64": "float64",
+	"Bool":    "bool",
+	"Char":    "rune",
+	"String":  "string",
+	"Bytes":   "[]byte",
+	"Never":   "struct{}",
+}
+
+func (g *gen) goNamedAST(n *ast.NamedType) string {
+	if len(n.Path) == 0 {
+		return "any"
+	}
+	if len(n.Path) > 1 {
+		if len(n.Path) == 2 && n.Path[1] == "Json" && g.isStdlibAliasName(n.Path[0], "json") {
+			g.needJSON = true
+			return "Json"
+		}
+		if len(n.Path) == 2 && n.Path[1] == "Iter" && g.isStdlibAliasName(n.Path[0], "iter") {
+			if len(n.Args) == 1 {
+				return "[]" + g.goTypeExpr(n.Args[0])
+			}
+			return "[]any"
+		}
+		if len(n.Path) == 2 && g.isStdlibAliasName(n.Path[0], "error") {
+			switch n.Path[1] {
+			case "Error":
+				return "any"
+			case "BasicError":
+				g.needErrorRuntime = true
+				return "ostyBasicError"
+			}
+		}
+		// Qualified (pkg.Type). Phase 5 adds proper module handling.
+		return strings.Join(n.Path, ".")
+	}
+	name := n.Path[0]
+	if name == "Self" && g.selfType != "" {
+		return g.goSelfTypeAST(n.Args)
+	}
+	// Generic type-parameter references substitute to the concrete Go
+	// type rendered at the monomorphizing call site. Applies only to
+	// bare single-path names with no type arguments — a `T<...>` shape
+	// is nonsense for a type variable, so we fall through if Args are
+	// present.
+	if len(n.Args) == 0 {
+		if concrete, ok := g.lookupSubst(name); ok {
+			return concrete
+		}
+	}
+	if gt, ok := primitiveByName[name]; ok {
+		return gt
+	}
+	switch name {
+	case "List", "Iter":
+		if len(n.Args) == 1 {
+			return "[]" + g.goTypeExpr(n.Args[0])
+		}
+	case "Map":
+		if len(n.Args) == 2 {
+			return "map[" + g.goTypeExpr(n.Args[0]) + "]" + g.goTypeExpr(n.Args[1])
+		}
+	case "Set":
+		if len(n.Args) == 1 {
+			return "map[" + g.goTypeExpr(n.Args[0]) + "]struct{}"
+		}
+	case "Option":
+		if len(n.Args) == 1 {
+			return "*" + g.goTypeExpr(n.Args[0])
+		}
+	case "Error":
+		return "any"
+	case "Result":
+		g.needResult = true
+		if len(n.Args) == 2 {
+			return "Result[" + g.goTypeExpr(n.Args[0]) + ", " + g.goTypeExpr(n.Args[1]) + "]"
+		}
+		return "Result[any, any]"
+	case "Chan", "Channel":
+		if len(n.Args) == 1 {
+			return "chan " + g.goTypeExpr(n.Args[0])
+		}
+		return "chan any"
+	case "Handle":
+		g.needHandle = true
+		if len(n.Args) == 1 {
+			return "Handle[" + g.goTypeExpr(n.Args[0]) + "]"
+		}
+		return "Handle[any]"
+	case "TaskGroup":
+		g.needTaskGroup = true
+		return "*TaskGroup"
+	case "Json":
+		g.needJSON = true
+		return "Json"
+	case "Uuid":
+		g.needUUID = true
+		return "Uuid"
+	}
+	out := name
+	if len(n.Args) > 0 {
+		var b strings.Builder
+		b.WriteString(name)
+		b.WriteByte('[')
+		for i, a := range n.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(g.goTypeExpr(a))
+		}
+		b.WriteByte(']')
+		out = b.String()
+	}
+	if sym := g.typeRefSym(n); g.isReferenceStructSym(sym) || g.structTypes[name] {
+		return "*" + out
+	}
+	return out
+}
+
+func (g *gen) goSelfTypeAST(args []ast.Type) string {
+	out := g.selfType
+	if len(args) > 0 {
+		var b strings.Builder
+		b.WriteString(g.selfType)
+		b.WriteByte('[')
+		for i, a := range args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(g.goTypeExpr(a))
+		}
+		b.WriteByte(']')
+		out = b.String()
+	}
+	if !g.enumTypes[g.selfType] {
+		return "*" + out
+	}
+	return out
+}
+
+func (g *gen) typeRefSym(n *ast.NamedType) *resolve.Symbol {
+	if g.res == nil || n == nil {
+		return nil
+	}
+	return g.res.TypeRefs[n]
+}
+
+func (g *gen) goFnTypeAST(f *ast.FnType) string {
+	var b strings.Builder
+	b.WriteString("func(")
+	for i, p := range f.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(g.goTypeExpr(p))
+	}
+	b.WriteByte(')')
+	// Unit return (`-> ()`) maps to no Go return clause — `func()`
+	// rather than `func() struct{}`. The latter is technically a
+	// valid Go type but is incompatible with `func() {…}` literals
+	// the body emitter produces, so closures passed by value would
+	// fail to compile.
+	if f.ReturnType != nil && !isUnitAST(f.ReturnType) {
+		b.WriteByte(' ')
+		b.WriteString(g.goTypeExpr(f.ReturnType))
+	}
+	return b.String()
+}
+
+func isStdlibBasicError(n *types.Named) bool {
+	if n == nil || n.Sym == nil || n.Sym.Name != "BasicError" || n.Sym.Kind != resolve.SymStruct {
+		return false
+	}
+	decl, ok := n.Sym.Decl.(*ast.StructDecl)
+	return ok &&
+		len(decl.Fields) == 1 &&
+		decl.Fields[0].Name == "message" &&
+		hasStructMethod(decl, "message") &&
+		hasStructMethod(decl, "source")
+}
+
+func hasStructMethod(decl *ast.StructDecl, name string) bool {
+	for _, m := range decl.Methods {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// isUnitAST reports whether t is the AST representation of the Osty
+// unit type — a TupleType with no elements (`()`). Function-type
+// returns and parameter types both check this so the synthesized Go
+// signature stays compatible with `func()` closure literals.
+func isUnitAST(t ast.Type) bool {
+	tt, ok := t.(*ast.TupleType)
+	return ok && len(tt.Elems) == 0
+}

--- a/internal/gen/writer.go
+++ b/internal/gen/writer.go
@@ -1,0 +1,61 @@
+//go:build selfhostgen
+
+package gen
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// writer is an indent-aware byte buffer. Writes starting a new line are
+// automatically prefixed with the current indent level (as tabs, so the
+// output is gofmt-ready). Callers use indent()/dedent() to control nesting.
+type writer struct {
+	buf       bytes.Buffer
+	level     int
+	lineStart bool
+}
+
+func newWriter() *writer { return &writer{lineStart: true} }
+
+// write appends s, inserting the current indent at any internal line starts.
+func (w *writer) write(s string) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if w.lineStart && c != '\n' {
+			for j := 0; j < w.level; j++ {
+				w.buf.WriteByte('\t')
+			}
+			w.lineStart = false
+		}
+		w.buf.WriteByte(c)
+		if c == '\n' {
+			w.lineStart = true
+		}
+	}
+}
+
+// writef is write + fmt.Sprintf.
+func (w *writer) writef(format string, args ...any) {
+	w.write(fmt.Sprintf(format, args...))
+}
+
+// writeln writes s followed by a newline.
+func (w *writer) writeln(s string) {
+	w.write(s)
+	w.write("\n")
+}
+
+// nl writes a bare newline.
+func (w *writer) nl() { w.write("\n") }
+
+// indent / dedent adjust the current level.
+func (w *writer) indent() { w.level++ }
+func (w *writer) dedent() {
+	if w.level > 0 {
+		w.level--
+	}
+}
+
+// bytes returns the accumulated output.
+func (w *writer) bytes() []byte { return w.buf.Bytes() }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -480,6 +480,17 @@ func RunWithConfig(src []byte, stream io.Writer, cfg Config) Result {
 // Result has empty Stages and the error is returned to the caller so
 // the CLI can decide whether to abort.
 func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
+	pkg, err := resolve.LoadPackage(dir)
+	if err != nil {
+		return Result{}, err
+	}
+	return RunLoadedPackage(pkg, stream, cfg), nil
+}
+
+// RunLoadedPackage is RunPackage for an already-loaded package. Callers use
+// this when a command wants package-context behavior over a curated file set
+// rather than a directory scan.
+func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result {
 	var r Result
 	emit := func(s Stage) {
 		r.Stages = append(r.Stages, s)
@@ -491,10 +502,6 @@ func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
 
 	// --- load (lex + parse, all files) ---
 	t0 := time.Now()
-	pkg, err := resolve.LoadPackage(dir)
-	if err != nil {
-		return r, err
-	}
 	totalBytes, totalDecls, totalStmts, totalUses := 0, 0, 0, 0
 	var loadDiags []*diag.Diagnostic
 	for _, pf := range pkg.Files {
@@ -659,7 +666,7 @@ func RunPackage(dir string, stream io.Writer, cfg Config) (Result, error) {
 		})
 	}
 
-	return r, nil
+	return r
 }
 
 // RunWorkspace runs the front-end across every package in a workspace

--- a/internal/resolve/load_selected.go
+++ b/internal/resolve/load_selected.go
@@ -1,0 +1,50 @@
+package resolve
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// LoadPackageFiles loads the provided Osty source files as one package while
+// preserving their original paths for diagnostics. Paths may span a synthetic
+// selection rather than a full on-disk directory listing.
+func LoadPackageFiles(paths []string, stdlib StdlibProvider) (*Package, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("load selected package: no files")
+	}
+	absPaths := make([]string, 0, len(paths))
+	for _, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, err
+		}
+		absPaths = append(absPaths, abs)
+	}
+	sort.Strings(absPaths)
+	dir := filepath.Dir(absPaths[0])
+	pkg := &Package{
+		Dir:  dir,
+		Name: filepath.Base(dir),
+	}
+	if stdlib != nil {
+		pkg.workspace = newStdlibOnlyWorkspace(stdlib)
+	}
+	for _, p := range absPaths {
+		src, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		file, parseDiags := parser.ParseDiagnostics(src)
+		pkg.Files = append(pkg.Files, &PackageFile{
+			Path:       p,
+			Source:     src,
+			File:       file,
+			ParseDiags: parseDiags,
+		})
+	}
+	return pkg, nil
+}

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -26,8 +26,6 @@ var sourceFiles = []string{
 	"internal/selfhost/ast_lower.osty",
 }
 
-const mergedPath = "/tmp/selfhost_merged.osty"
-
 const stringsPrelude = `use go "strings" as strings {
     fn Count(s: String, substr: String) -> Int
     fn Fields(s: String) -> List<String>
@@ -56,23 +54,71 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	outPath := filepath.Join(root, "internal/selfhost/generated.go")
+	if upToDate, err := generatedSelfhostUpToDate(root, outPath); err == nil && upToDate {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp("", "osty-selfhostgen-*")
+	if err != nil {
+		return fmt.Errorf("create selfhost temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	merged, err := mergedSource(root)
 	if err != nil {
 		return err
 	}
+	mergedPath := filepath.Join(tmpDir, "selfhost_merged.osty")
 	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
 		return fmt.Errorf("write merged selfhost source: %w", err)
 	}
-	defer os.Remove(mergedPath)
 
-	outPath := filepath.Join(root, "internal/selfhost/generated.go")
-	cmd := exec.Command("go", "run", "-tags", "selfhostgen", "./cmd/osty", "gen", "--package", "selfhost", "-o", outPath, mergedPath)
+	cmd := exec.Command(
+		"go", "run", "-tags", "selfhostgen", "./cmd/osty", "gen",
+		"--backend", "go",
+		"--emit", "go",
+		"--package", "selfhost",
+		"-o", outPath,
+		mergedPath,
+	)
 	cmd.Dir = root
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("generate selfhost parser: %w\n%s", err, bytes.TrimSpace(output))
 	}
 	return patchGenerated(outPath)
+}
+
+func generatedSelfhostUpToDate(root, outPath string) (bool, error) {
+	outInfo, err := os.Stat(outPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat generated selfhost code: %w", err)
+	}
+	newest := outInfo.ModTime()
+	checkPath := func(path string) error {
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+		return nil
+	}
+	if err := checkPath(filepath.Join(root, "internal/selfhost/gen_selfhost.go")); err != nil {
+		return false, fmt.Errorf("stat selfhost generator: %w", err)
+	}
+	for _, rel := range sourceFiles {
+		if err := checkPath(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			return false, fmt.Errorf("stat %s: %w", rel, err)
+		}
+	}
+	return !outInfo.ModTime().Before(newest), nil
 }
 
 func findRepoRoot() (string, error) {
@@ -143,6 +189,7 @@ func patchGenerated(path string) error {
 		return fmt.Errorf("read generated selfhost code: %w", err)
 	}
 	src := string(data)
+	src = normalizeGeneratedSourceComment(src)
 	for _, fn := range []struct {
 		name string
 		body string
@@ -167,6 +214,18 @@ func patchGenerated(path string) error {
 		return fmt.Errorf("write generated selfhost code: %w", err)
 	}
 	return nil
+}
+
+func normalizeGeneratedSourceComment(src string) string {
+	const prefix = "// Osty source: "
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, prefix) && strings.HasSuffix(line, "selfhost_merged.osty") {
+			lines[i] = prefix + "/tmp/selfhost_merged.osty"
+			break
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func replaceGeneratedFunction(src, name, replacement string) (string, error) {


### PR DESCRIPTION
## Summary
- restore the selfhostgen-only Go backend path so `go generate ./internal/selfhost` works again on the current tree
- isolate selfhost merged-source generation and skip regeneration when the checked-in output is already up to date
- load `toolchain/*.osty` single-file `check`/`resolve`/`pipeline` commands with package context so cross-file symbols resolve before reporting real source mismatches

## Testing
- `go generate ./internal/selfhost`
- `go test -tags selfhostgen ./cmd/osty`
- `go test ./...`