### PR TITLE
Preserve native checker types for unreferenced symbols

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -371,6 +371,7 @@ func buildSelfhostSpanIndex(src selfhostCheckedSource) *selfhostSpanIndex {
 		for _, stmt := range file.file.Stmts {
 			idx.addNode(stmt, file.base, file.scope)
 		}
+		idx.addScopeSubtree(file.scope, file.base)
 		for _, sym := range file.refs {
 			idx.addSymbol(sym, file.base, file.scope)
 		}
@@ -409,6 +410,7 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 		if _, ok := idx.scopes[key]; !ok {
 			idx.scopes[key] = scope
 		}
+		idx.addDeclaredSymbol(n, key, scope)
 		if e, ok := n.(ast.Expr); ok {
 			if _, have := idx.exprs[key]; !have {
 				idx.exprs[key] = e
@@ -674,6 +676,68 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 		}
 		idx.addNode(v.Pattern, base, scope)
 	}
+}
+
+func (idx *selfhostSpanIndex) addScopeSubtree(scope *resolve.Scope, base int) {
+	if scope == nil {
+		return
+	}
+	for _, sym := range scope.Symbols() {
+		idx.addSymbol(sym, base, scope)
+	}
+	for _, child := range scope.Children() {
+		idx.addScopeSubtree(child, base)
+	}
+}
+
+func (idx *selfhostSpanIndex) addDeclaredSymbol(n ast.Node, key selfhostSpanKey, scope *resolve.Scope) {
+	sym := declaredSymbolForNode(n, scope)
+	if sym == nil {
+		return
+	}
+	idx.symbols[selfhostNameSpanKey{selfhostSpanKey: key, name: sym.Name}] = sym
+}
+
+func declaredSymbolForNode(n ast.Node, scope *resolve.Scope) *resolve.Symbol {
+	if scope == nil {
+		return nil
+	}
+	pkgScope := scope.Parent()
+	if pkgScope == nil {
+		pkgScope = scope
+	}
+	switch v := n.(type) {
+	case *ast.FnDecl:
+		if v.Recv != nil || v.Name == "" {
+			return nil
+		}
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	case *ast.StructDecl:
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	case *ast.EnumDecl:
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	case *ast.InterfaceDecl:
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	case *ast.TypeAliasDecl:
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	case *ast.LetDecl:
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	case *ast.Variant:
+		return lookupLocalDeclSymbol(pkgScope, v.Name, v)
+	default:
+		return nil
+	}
+}
+
+func lookupLocalDeclSymbol(scope *resolve.Scope, name string, decl ast.Node) *resolve.Symbol {
+	if scope == nil || name == "" || decl == nil {
+		return nil
+	}
+	sym := scope.LookupLocal(name)
+	if sym == nil || sym.Decl != decl {
+		return nil
+	}
+	return sym
 }
 
 func (idx *selfhostSpanIndex) lookupExpr(key selfhostSpanKey, kind string) ast.Expr {

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -98,6 +98,62 @@ func TestNativeBoundaryReportsMissingExecutable(t *testing.T) {
 	}
 }
 
+func TestNativeBoundaryPreservesUnreferencedSymbolTypes(t *testing.T) {
+	src := []byte(`fn unused(value: Int) -> Int {
+    0
+}
+
+fn main() {}
+`)
+	file, res := parseResolvedFile(t, src)
+	unusedDecl := file.Decls[0].(*ast.FnDecl)
+	param := unusedDecl.Params[0]
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return fakeNativeChecker{result: nativeCheckResult{
+			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			Bindings: []nativeCheckedBinding{
+				{Name: "value", TypeName: "Int", Start: param.Pos().Offset, End: param.End().Offset},
+			},
+			Symbols: []nativeCheckedSymbol{
+				{Name: "unused", Kind: "fn", TypeName: "fn(Int) -> Int", Start: unusedDecl.Pos().Offset, End: unusedDecl.End().Offset},
+			},
+		}}, ""
+	}
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	if got := chk.LookupSymType(res.FileScope.Lookup("unused")); got == nil || got.String() != "fn(Int) -> Int" {
+		t.Fatalf("unused fn type = %v, want fn(Int) -> Int", got)
+	}
+	paramSym := lookupChildScopeSymbol(res.FileScope, "fn:unused", "value")
+	if paramSym == nil {
+		t.Fatal("expected resolver symbol for unused parameter")
+	}
+	if got := chk.LookupSymType(paramSym); got == nil || got.String() != "Int" {
+		t.Fatalf("unused param type = %v, want Int", got)
+	}
+}
+
+func lookupChildScopeSymbol(root *resolve.Scope, kind, name string) *resolve.Symbol {
+	if root == nil {
+		return nil
+	}
+	for _, child := range root.Children() {
+		if child.Kind() == kind {
+			return child.LookupLocal(name)
+		}
+		if sym := lookupChildScopeSymbol(child, kind, name); sym != nil {
+			return sym
+		}
+	}
+	return nil
+}
+
 func parseResolvedFile(t *testing.T, src []byte) (*ast.File, *resolve.Result) {
 	t.Helper()
 	file, diags := parser.ParseDiagnostics(src)

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -71,6 +71,31 @@ func TestDefaultNativeCheckerUsesManagedArtifactWhenEnvUnset(t *testing.T) {
 	}
 }
 
+func TestNativeBoundaryExecKeepsUnusedDeclarationTypes(t *testing.T) {
+	src := []byte(`fn unused(value: Int) -> Int {
+    0
+}
+
+fn main() {}
+`)
+	file, res := parseResolvedFile(t, src)
+
+	bin := buildRepoNativeChecker(t)
+	t.Setenv(nativeCheckerEnv, bin)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	if got := chk.LookupSymType(res.FileScope.Lookup("unused")); got == nil || got.String() != "fn(Int) -> Int" {
+		t.Fatalf("unused fn type = %v, want fn(Int) -> Int", got)
+	}
+}
+
 func buildRepoNativeChecker(t *testing.T) string {
 	t.Helper()
 	cwd, err := os.Getwd()


### PR DESCRIPTION
## Summary
- index declaration and nested scope symbols when overlaying native checker results
- preserve `SymTypes` for unreferenced functions and parameters
- add regression coverage for fake and executable native checker paths

## Testing
- go test ./internal/check/...
- go test ./internal/lsp/...
- go test ./...