### PR TITLE
Add native LLVM test harness

### DIFF
--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -1,15 +1,37 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/resolve"
 )
 
+type nativeTestCase struct {
+	Name string
+	Path string
+}
+
 func runTest(args []string, flags cliFlags) {
-	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	os.Exit(runTestMain(args, flags, os.Stdout, os.Stderr))
+}
+
+func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [PATH|FILTER...]")
+		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [PATH|FILTER...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
@@ -21,14 +43,278 @@ func runTest(args []string, flags cliFlags) {
 	fs.StringVar(&emitName, "emit", "", "artifact mode to execute (binary)")
 	var pf profileFlags
 	pf.register(fs)
-	_ = fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
 	_ = flags
 	_ = offline
 	_ = locked
 	_ = frozen
 	_ = pf
 
-	_, _ = resolveBackendAndEmitFlags("test", backendName, emitName)
-	fmt.Fprintln(os.Stderr, "osty test: native backend test harness is not implemented yet")
-	os.Exit(2)
+	backendID, emitMode := resolveBackendAndEmitFlags("test", backendName, emitName)
+	pkgDir, filters, err := resolveTestTarget(fs.Args())
+	if err != nil {
+		fmt.Fprintf(stderr, "osty test: %v\n", err)
+		return 2
+	}
+
+	pkg, err := resolve.LoadPackageWithTests(pkgDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "osty test: %v\n", err)
+		return 1
+	}
+	parseDiags := packageParseDiags(pkg)
+	if hasError(parseDiags) {
+		printPackageDiags(pkg, parseDiags, flags)
+		fmt.Fprintf(stderr, "osty test: parse errors in %s\n", pkgDir)
+		return 1
+	}
+
+	tests, err := discoverNativeTests(pkg, filters)
+	if err != nil {
+		fmt.Fprintf(stderr, "osty test: %v\n", err)
+		return 1
+	}
+	if len(tests) == 0 {
+		fmt.Fprintln(stdout, "running 0 tests")
+		return 0
+	}
+
+	b, err := backend.New(backendID)
+	if err != nil {
+		fmt.Fprintf(stderr, "osty test: %v\n", err)
+		return 2
+	}
+	tmpRoot, err := os.MkdirTemp("", "osty-test-*")
+	if err != nil {
+		fmt.Fprintf(stderr, "osty test: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(tmpRoot)
+
+	fmt.Fprintf(stdout, "running %d tests\n", len(tests))
+	failures := 0
+	for _, tc := range tests {
+		run, err := compileAndRunNativeTest(context.Background(), b, emitMode, tmpRoot, pkg, tc)
+		if err != nil {
+			failures++
+			fmt.Fprintf(stdout, "FAIL\t%s\n", tc.Name)
+			fmt.Fprintf(stderr, "osty test: %s: %v\n", tc.Name, err)
+			if strings.TrimSpace(run.Stdout) != "" {
+				fmt.Fprintf(stdout, "%s", run.Stdout)
+				if !strings.HasSuffix(run.Stdout, "\n") {
+					fmt.Fprintln(stdout)
+				}
+			}
+			if strings.TrimSpace(run.Stderr) != "" {
+				fmt.Fprintf(stderr, "%s", run.Stderr)
+				if !strings.HasSuffix(run.Stderr, "\n") {
+					fmt.Fprintln(stderr)
+				}
+			}
+			continue
+		}
+		fmt.Fprintf(stdout, "ok\t%s\n", tc.Name)
+	}
+	if failures > 0 {
+		fmt.Fprintf(stdout, "FAIL\t%d/%d tests failed\n", failures, len(tests))
+		return 1
+	}
+	fmt.Fprintf(stdout, "ok\t%d tests passed\n", len(tests))
+	return 0
+}
+
+func resolveTestTarget(args []string) (string, []string, error) {
+	if len(args) == 0 {
+		return ".", nil, nil
+	}
+	first := args[0]
+	if info, err := os.Stat(first); err == nil {
+		if info.IsDir() {
+			return first, args[1:], nil
+		}
+		return filepath.Dir(first), args[1:], nil
+	}
+	return ".", args, nil
+}
+
+func packageParseDiags(pkg *resolve.Package) []*diag.Diagnostic {
+	var out []*diag.Diagnostic
+	if pkg == nil {
+		return out
+	}
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		out = append(out, pf.ParseDiags...)
+	}
+	return out
+}
+
+func discoverNativeTests(pkg *resolve.Package, filters []string) ([]nativeTestCase, error) {
+	if pkg == nil {
+		return nil, fmt.Errorf("missing package for test discovery")
+	}
+	seen := map[string]string{}
+	var tests []nativeTestCase
+	for _, pf := range pkg.Files {
+		if pf == nil || pf.File == nil {
+			continue
+		}
+		for _, decl := range pf.File.Decls {
+			fn, ok := decl.(*ast.FnDecl)
+			if !ok || fn == nil {
+				continue
+			}
+			if fn.Recv != nil || len(fn.Generics) != 0 {
+				continue
+			}
+			if fn.Name == "main" {
+				return nil, fmt.Errorf("package %s already defines main; native test runner currently requires a library-style package", pkg.Dir)
+			}
+			if !strings.HasPrefix(fn.Name, "test") || fn.Name == "testing" {
+				continue
+			}
+			if len(fn.Params) != 0 || fn.ReturnType != nil || fn.Body == nil {
+				continue
+			}
+			if !matchesTestFilters(fn.Name, filters) {
+				continue
+			}
+			if prev, exists := seen[fn.Name]; exists {
+				return nil, fmt.Errorf("duplicate test function %q in %s and %s", fn.Name, prev, pf.Path)
+			}
+			seen[fn.Name] = pf.Path
+			tests = append(tests, nativeTestCase{Name: fn.Name, Path: pf.Path})
+		}
+	}
+	sort.Slice(tests, func(i, j int) bool {
+		if tests[i].Path != tests[j].Path {
+			return tests[i].Path < tests[j].Path
+		}
+		return tests[i].Name < tests[j].Name
+	})
+	return tests, nil
+}
+
+func matchesTestFilters(name string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for _, filter := range filters {
+		if filter == "" {
+			continue
+		}
+		if strings.Contains(name, filter) {
+			return true
+		}
+	}
+	return false
+}
+
+type nativeTestRun struct {
+	Stdout string
+	Stderr string
+}
+
+func compileAndRunNativeTest(ctx context.Context, b backend.Backend, emitMode backend.EmitMode, tmpRoot string, pkg *resolve.Package, tc nativeTestCase) (nativeTestRun, error) {
+	file, sourcePath, err := parseNativeTestEntry(pkg, tc)
+	if err != nil {
+		return nativeTestRun{}, err
+	}
+	name := sanitizeNativeTestName(tc.Name)
+	layoutRoot := filepath.Join(tmpRoot, name)
+	req := backend.Request{
+		Layout: backend.Layout{
+			Root:    layoutRoot,
+			Profile: "test",
+		},
+		Emit: emitMode,
+		Entry: backend.Entry{
+			PackageName: "main",
+			SourcePath:  sourcePath,
+			File:        file,
+		},
+		BinaryName: name,
+	}
+	result, err := b.Emit(ctx, req)
+	if err != nil {
+		return nativeTestRun{}, err
+	}
+	return runNativeTestBinary(result.Artifacts.Binary)
+}
+
+func parseNativeTestEntry(pkg *resolve.Package, tc nativeTestCase) (*ast.File, string, error) {
+	if pkg == nil {
+		return nil, "", fmt.Errorf("missing package")
+	}
+	runnerPath := filepath.Join(pkg.Dir, "__osty_test_runner__.osty")
+	runner := []byte(fmt.Sprintf("fn main() {\n    %s()\n}\n", tc.Name))
+	testPkg := &resolve.Package{
+		Dir:  pkg.Dir,
+		Name: pkg.Name,
+	}
+	testPkg.Files = append(testPkg.Files, pkg.Files...)
+	testPkg.Files = append(testPkg.Files, &resolve.PackageFile{
+		Path:   runnerPath,
+		Source: runner,
+	})
+	file, _, err := parseGenEmitFile(testPkg)
+	if err != nil {
+		return nil, "", err
+	}
+	sourcePath := tc.Path
+	if sourcePath == "" {
+		sourcePath = runnerPath
+	}
+	return file, sourcePath, nil
+}
+
+func sanitizeNativeTestName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "osty_test"
+	}
+	return b.String()
+}
+
+func runNativeTestBinary(binPath string) (nativeTestRun, error) {
+	if binPath == "" {
+		return nativeTestRun{}, fmt.Errorf("native backend did not produce a binary")
+	}
+	absBin, err := filepath.Abs(binPath)
+	if err != nil {
+		return nativeTestRun{}, err
+	}
+	cmd := exec.Command(absBin)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	run := nativeTestRun{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if err == nil {
+		return run, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return run, fmt.Errorf("exit status %d", exitErr.ExitCode())
+	}
+	return run, err
 }

--- a/cmd/osty/test_native_test.go
+++ b/cmd/osty/test_native_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunTestMainPassesNativeLLVMTest(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib.osty", `pub fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+`)
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing as t
+
+fn testAdd() {
+    t.context("simple", || {
+        t.assertEq(add(1, 2), 3)
+    })
+}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTestMain() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "ok\ttestAdd") || !strings.Contains(got, "ok\t1 tests passed") {
+		t.Fatalf("stdout = %q, want passing test summary", got)
+	}
+	if got := stderr.String(); strings.TrimSpace(got) != "" {
+		t.Fatalf("stderr = %q, want empty stderr", got)
+	}
+}
+
+func TestRunTestMainReportsNativeLLVMFailure(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib.osty", `pub fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+`)
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing
+
+fn testAddFails() {
+    testing.assertEq(add(1, 2), 4)
+}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runTestMain() exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "FAIL\ttestAddFails") || !strings.Contains(got, "testing.assertEq failed at") {
+		t.Fatalf("stdout = %q, want failing assertion output", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "osty test: testAddFails: exit status 1") {
+		t.Fatalf("stderr = %q, want native failure summary", got)
+	}
+}
+
+func requireClangForNativeTest(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skipf("clang not available: %v", err)
+	}
+}
+
+func writeNativeTestFile(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -37,6 +37,12 @@ void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_re
 void osty_gc_debug_collect(void);
 int64_t osty_gc_debug_live_count(void);
 int64_t osty_gc_debug_collection_count(void);
+int64_t osty_gc_debug_pre_write_count(void);
+int64_t osty_gc_debug_pre_write_managed_count(void);
+int64_t osty_gc_debug_post_write_count(void);
+int64_t osty_gc_debug_post_write_managed_count(void);
+int64_t osty_gc_debug_load_count(void);
+int64_t osty_gc_debug_load_managed_count(void);
 void *osty_rt_list_new(void);
 void osty_rt_list_push_ptr(void *list, void *value);
 int64_t osty_rt_list_len(void *list);
@@ -62,6 +68,12 @@ int main(void) {
     printf("%lld\n", (long long)osty_gc_debug_live_count());
     printf("%lld\n", (long long)osty_rt_list_len(list));
     printf("%d\n", osty_gc_load_v1(list) == list);
+    printf("%lld\n", (long long)osty_gc_debug_pre_write_count());
+    printf("%lld\n", (long long)osty_gc_debug_pre_write_managed_count());
+    printf("%lld\n", (long long)osty_gc_debug_post_write_count());
+    printf("%lld\n", (long long)osty_gc_debug_post_write_managed_count());
+    printf("%lld\n", (long long)osty_gc_debug_load_count());
+    printf("%lld\n", (long long)osty_gc_debug_load_managed_count());
     osty_gc_root_release_v1(list);
     osty_gc_debug_collect();
     printf("%lld\n", (long long)osty_gc_debug_live_count());
@@ -72,6 +84,8 @@ int main(void) {
     printf("%lld\n", (long long)osty_gc_debug_live_count());
     printf("%d\n", osty_rt_strings_Equal((const char *)osty_rt_list_get_ptr(list, 0), "gc"));
     printf("%d\n", osty_rt_strings_Equal((const char *)osty_rt_list_get_ptr(list, 1), "llvm"));
+    printf("%lld\n", (long long)osty_gc_debug_load_count());
+    printf("%lld\n", (long long)osty_gc_debug_load_managed_count());
     osty_gc_root_release_v1(list);
     osty_gc_debug_collect();
     printf("%lld\n", (long long)osty_gc_debug_live_count());
@@ -89,7 +103,7 @@ int main(void) {
 	if err != nil {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
-	if got, want := string(runOutput), "1\n0\n2\n1\n1\n0\n3\n1\n1\n0\n"; got != want {
+	if got, want := string(runOutput), "1\n0\n2\n1\n1\n1\n1\n1\n1\n1\n1\n0\n3\n1\n1\n3\n3\n0\n"; got != want {
 		t.Fatalf("runtime GC harness stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -52,8 +52,15 @@ static bool osty_gc_safepoint_stress_enabled = false;
 static bool osty_gc_pressure_limit_loaded = false;
 static int64_t osty_gc_pressure_limit_bytes = 32768;
 static bool osty_gc_collection_requested = false;
+static int64_t osty_gc_pre_write_count = 0;
+static int64_t osty_gc_pre_write_managed_count = 0;
+static int64_t osty_gc_post_write_count = 0;
+static int64_t osty_gc_post_write_managed_count = 0;
+static int64_t osty_gc_load_count = 0;
+static int64_t osty_gc_load_managed_count = 0;
 
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
 
 static void osty_rt_abort(const char *message) {
     fprintf(stderr, "osty llvm runtime: %s\n", message);
@@ -393,7 +400,7 @@ double osty_rt_list_get_f64(void *raw_list, int64_t index) {
 void *osty_rt_list_get_ptr(void *raw_list, int64_t index) {
     void *value;
     memcpy(&value, osty_rt_list_get_bytes(raw_list, index, sizeof(value), true), sizeof(value));
-    return value;
+    return osty_gc_load_v1(value);
 }
 
 bool osty_rt_strings_Equal(const char *left, const char *right) {
@@ -456,14 +463,27 @@ void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site)
 }
 
 void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) {
-    (void)owner;
-    (void)old_value;
+    osty_gc_header *owner_header;
+
+    osty_gc_pre_write_count += 1;
     (void)slot_kind;
+    if (old_value == NULL) {
+        return;
+    }
+    if (osty_gc_find_header(old_value) == NULL) {
+        return;
+    }
+    osty_gc_pre_write_managed_count += 1;
+    owner_header = osty_gc_find_header(owner);
+    if (owner_header != NULL && owner_header->root_count > 0) {
+        osty_gc_collection_requested = true;
+    }
 }
 
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
     osty_gc_header *owner_header;
 
+    osty_gc_post_write_count += 1;
     (void)slot_kind;
     if (owner == NULL || value == NULL) {
         return;
@@ -475,12 +495,17 @@ void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
     if (osty_gc_find_header(value) == NULL) {
         return;
     }
+    osty_gc_post_write_managed_count += 1;
     if (owner_header->root_count > 0) {
         osty_gc_collection_requested = true;
     }
 }
 
 void *osty_gc_load_v1(void *value) {
+    osty_gc_load_count += 1;
+    if (osty_gc_find_header(value) != NULL) {
+        osty_gc_load_managed_count += 1;
+    }
     return value;
 }
 
@@ -531,4 +556,28 @@ int64_t osty_gc_debug_collection_count(void) {
 
 int64_t osty_gc_debug_live_bytes(void) {
     return osty_gc_live_bytes;
+}
+
+int64_t osty_gc_debug_pre_write_count(void) {
+    return osty_gc_pre_write_count;
+}
+
+int64_t osty_gc_debug_pre_write_managed_count(void) {
+    return osty_gc_pre_write_managed_count;
+}
+
+int64_t osty_gc_debug_post_write_count(void) {
+    return osty_gc_post_write_count;
+}
+
+int64_t osty_gc_debug_post_write_managed_count(void) {
+    return osty_gc_post_write_managed_count;
+}
+
+int64_t osty_gc_debug_load_count(void) {
+    return osty_gc_load_count;
+}
+
+int64_t osty_gc_debug_load_managed_count(void) {
+    return osty_gc_load_managed_count;
 }

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -203,6 +203,7 @@ func Generate(file *ast.File, opts Options) ([]byte, error) {
 		}
 		g.runtimeFFI = collectRuntimeFFI(file, nil, nil)
 		g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
+		g.testingAliases = collectStdTestingAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -222,6 +223,7 @@ func Generate(file *ast.File, opts Options) ([]byte, error) {
 	g.enumsByType = decls.enumsByType
 	g.runtimeFFI = collectRuntimeFFI(file, decls.structsByName, decls.enumsByName)
 	g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
+	g.testingAliases = collectStdTestingAliases(file)
 	var defs []string
 	for _, sig := range decls.functionsOrdered {
 		if sig.name == "main" {
@@ -272,6 +274,7 @@ type generator struct {
 	enumsByType      map[string]*enumInfo
 	runtimeFFI       map[string]map[string]*runtimeFFIFunction
 	runtimeFFIPaths  map[string]string
+	testingAliases   map[string]bool
 	runtimeDecls     map[string]runtimeDecl
 	runtimeDeclOrder []string
 
@@ -494,6 +497,26 @@ func collectRuntimeFFIPaths(file *ast.File) map[string]string {
 		}
 		if alias := runtimeFFIAlias(use); alias != "" {
 			out[alias] = use.RuntimePath
+		}
+	}
+	return out
+}
+
+func collectStdTestingAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "testing" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "testing"
+		}
+		if alias != "" {
+			out[alias] = true
 		}
 	}
 	return out
@@ -1171,6 +1194,9 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 	if !ok {
 		return unsupported("statement", "only println calls are supported as expression statements")
 	}
+	if emitted, err := g.emitTestingCallStmt(call); emitted || err != nil {
+		return err
+	}
 	if emitted, err := g.emitListMethodCallStmt(call); emitted || err != nil {
 		return err
 	}
@@ -1181,6 +1207,150 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 		return err
 	}
 	return g.emitPrintln(call)
+}
+
+func (g *generator) emitTestingCallStmt(call *ast.CallExpr) (bool, error) {
+	method, ok := g.testingCallMethod(call)
+	if !ok {
+		return false, nil
+	}
+	switch method {
+	case "assert":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return true, unsupported("call", "testing.assert requires one positional argument")
+		}
+		cond, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return true, err
+		}
+		return true, g.emitTestingAssertion(cond, g.testingFailureMessage(call, "assert"))
+	case "assertEq":
+		return true, g.emitTestingCompare(call, token.EQ, "assertEq")
+	case "assertNe":
+		return true, g.emitTestingCompare(call, token.NEQ, "assertNe")
+	case "fail":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return true, unsupported("call", "testing.fail requires one positional argument")
+		}
+		g.emitTestingAbort(g.testingFailureMessage(call, "fail"))
+		return true, nil
+	case "context":
+		return true, g.emitTestingContextStmt(call)
+	default:
+		return true, unsupportedf("call", "testing.%s is not supported by LLVM yet", method)
+	}
+}
+
+func (g *generator) testingCallMethod(call *ast.CallExpr) (string, bool) {
+	if call == nil {
+		return "", false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional {
+		return "", false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || alias == nil || !g.testingAliases[alias.Name] {
+		return "", false
+	}
+	return field.Name, true
+}
+
+func (g *generator) emitTestingCompare(call *ast.CallExpr, op token.Kind, name string) error {
+	if len(call.Args) != 2 {
+		return unsupportedf("call", "testing.%s requires two positional arguments", name)
+	}
+	for _, arg := range call.Args {
+		if arg == nil || arg.Name != "" || arg.Value == nil {
+			return unsupportedf("call", "testing.%s requires positional arguments", name)
+		}
+	}
+	left, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return err
+	}
+	right, err := g.emitExpr(call.Args[1].Value)
+	if err != nil {
+		return err
+	}
+	cond, err := g.emitCompare(op, left, right)
+	if err != nil {
+		return err
+	}
+	return g.emitTestingAssertion(cond, g.testingFailureMessage(call, name))
+}
+
+func (g *generator) emitTestingContextStmt(call *ast.CallExpr) error {
+	if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[1].Value == nil {
+		return unsupported("call", "testing.context requires a message and a zero-arg closure")
+	}
+	closure, ok := call.Args[1].Value.(*ast.ClosureExpr)
+	if !ok {
+		return unsupported("call", "testing.context requires a closure body")
+	}
+	if len(closure.Params) != 0 || closure.ReturnType != nil || closure.Body == nil {
+		return unsupported("call", "testing.context requires a zero-arg closure with inferred unit return")
+	}
+	g.pushScope()
+	defer g.popScope()
+	return g.emitTestingClosureBody(closure.Body)
+}
+
+func (g *generator) emitTestingClosureBody(body ast.Expr) error {
+	switch expr := body.(type) {
+	case *ast.Block:
+		return g.emitBlock(expr.Stmts)
+	case *ast.IfExpr:
+		return g.emitIfStmt(expr)
+	default:
+		return g.emitExprStmt(expr)
+	}
+}
+
+func (g *generator) emitTestingAssertion(cond value, message string) error {
+	if cond.typ != "i1" {
+		return unsupportedf("type-system", "testing assertion condition type %s, want i1", cond.typ)
+	}
+	emitter := g.toOstyEmitter()
+	okLabel := llvmNextLabel(emitter, "test.ok")
+	failLabel := llvmNextLabel(emitter, "test.fail")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.ref, okLabel, failLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", failLabel))
+	g.emitTestingAbortWithEmitter(emitter, message, okLabel)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = okLabel
+	return nil
+}
+
+func (g *generator) emitTestingAbort(message string) {
+	emitter := g.toOstyEmitter()
+	deadLabel := llvmNextLabel(emitter, "test.dead")
+	g.emitTestingAbortWithEmitter(emitter, message, deadLabel)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = deadLabel
+}
+
+func (g *generator) emitTestingAbortWithEmitter(emitter *LlvmEmitter, message string, nextLabel string) {
+	text := llvmStringLiteral(emitter, message)
+	llvmPrintlnString(emitter, text)
+	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
+	emitter.body = append(emitter.body, "  call void @exit(i32 1)")
+	emitter.body = append(emitter.body, "  unreachable")
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+}
+
+func (g *generator) testingFailureMessage(call *ast.CallExpr, name string) string {
+	source := g.sourcePath
+	if source == "" {
+		source = "<test>"
+	} else if abs, err := filepath.Abs(source); err == nil {
+		source = abs
+	}
+	line := 0
+	if call != nil {
+		line = call.Pos().Line
+	}
+	return fmt.Sprintf("testing.%s failed at %s:%d", name, source, line)
 }
 
 func (g *generator) emitIfStmt(expr *ast.IfExpr) error {


### PR DESCRIPTION
## Summary
- add a minimal `osty test` native LLVM harness that discovers `test*` functions and runs them one-by-one
- lower `std.testing` assert/assertEq/assertNe/fail/context calls in the LLVM backend
- keep the local GC runtime barrier counter instrumentation covered by backend tests

## Verification
- go test ./cmd/osty -run 'TestRunTestMain(PassesNativeLLVMTest|ReportsNativeLLVMFailure)' -count=1\n- go test ./cmd/osty ./internal/llvmgen ./internal/backend -count=1\n- git diff --check\n\n## Notes\n- this opens the native test path itself, but real packages using `Ok`/`Err` still need dedicated LLVM lowering