### PR TITLE
Add embedded native checker fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,16 +142,18 @@ go build -o osty ./cmd/osty
 
 ## Native Checker
 
-`internal/check` now targets an external checker executable boundary. By
-default the CLI manages a versioned checker artifact under
-`.osty/toolchain/<tool-version>/osty-native-checker` and builds it on demand.
-`OSTY_NATIVE_CHECKER_BIN` is still supported as an override/debug escape hatch.
+`internal/check` prefers an external checker executable boundary when one is
+available. By default the CLI manages a versioned checker artifact under
+`.osty/toolchain/<tool-version>/osty-native-checker` and builds it on demand,
+but falls back to the embedded selfhost checker when that binary is unavailable.
+`OSTY_NATIVE_CHECKER_BIN` is still supported as a strict override/debug escape
+hatch.
 
 This repository also ships a repo-local wrapper at
 [`scripts/osty-native-checker`](./scripts/osty-native-checker), backed by
 [`cmd/osty-native-checker/`](./cmd/osty-native-checker/).
 
-Normal use no longer needs any env var:
+Normal use no longer needs any env var or prebuilt checker binary:
 
 ```sh
 go run ./cmd/osty check examples/calc

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/toolchain"
 	"github.com/osty/osty/internal/types"
@@ -21,9 +22,9 @@ import (
 
 const nativeCheckerEnv = "OSTY_NATIVE_CHECKER_BIN"
 
-// The checker now targets an Osty-native executable boundary instead of the
-// deleted generated Go bridge. The external tool is expected to read one JSON
-// request from stdin and emit one JSON response to stdout.
+// The checker targets an Osty-native request/response boundary. The preferred
+// path uses an external executable, and the default host implementation falls
+// back to the embedded selfhost checker when that binary is unavailable.
 type nativeChecker interface {
 	CheckSourceStructured([]byte) (nativeCheckResult, error)
 }
@@ -109,6 +110,68 @@ func (e nativeCheckerExec) CheckSourceStructured(src []byte) (nativeCheckResult,
 	return checked, nil
 }
 
+type embeddedNativeChecker struct{}
+
+func (embeddedNativeChecker) CheckSourceStructured(src []byte) (nativeCheckResult, error) {
+	checked := selfhost.CheckSourceStructured(src)
+	return adaptEmbeddedCheckResult(checked), nil
+}
+
+func adaptEmbeddedCheckResult(checked selfhost.CheckResult) nativeCheckResult {
+	result := nativeCheckResult{
+		Summary: nativeCheckSummary{
+			Assignments: checked.Summary.Assignments,
+			Accepted:    checked.Summary.Accepted,
+			Errors:      checked.Summary.Errors,
+		},
+		TypedNodes:     make([]nativeCheckedNode, 0, len(checked.TypedNodes)),
+		Bindings:       make([]nativeCheckedBinding, 0, len(checked.Bindings)),
+		Symbols:        make([]nativeCheckedSymbol, 0, len(checked.Symbols)),
+		Instantiations: make([]nativeCheckInstantiation, 0, len(checked.Instantiations)),
+	}
+	for _, node := range checked.TypedNodes {
+		result.TypedNodes = append(result.TypedNodes, nativeCheckedNode{
+			Node:     node.Node,
+			Kind:     node.Kind,
+			TypeName: node.TypeName,
+			Start:    node.Start,
+			End:      node.End,
+		})
+	}
+	for _, binding := range checked.Bindings {
+		result.Bindings = append(result.Bindings, nativeCheckedBinding{
+			Node:     binding.Node,
+			Name:     binding.Name,
+			TypeName: binding.TypeName,
+			Mutable:  binding.Mutable,
+			Start:    binding.Start,
+			End:      binding.End,
+		})
+	}
+	for _, symbol := range checked.Symbols {
+		result.Symbols = append(result.Symbols, nativeCheckedSymbol{
+			Node:     symbol.Node,
+			Kind:     symbol.Kind,
+			Name:     symbol.Name,
+			Owner:    symbol.Owner,
+			TypeName: symbol.TypeName,
+			Start:    symbol.Start,
+			End:      symbol.End,
+		})
+	}
+	for _, inst := range checked.Instantiations {
+		result.Instantiations = append(result.Instantiations, nativeCheckInstantiation{
+			Node:       inst.Node,
+			Callee:     inst.Callee,
+			TypeArgs:   append([]string(nil), inst.TypeArgs...),
+			ResultType: inst.ResultType,
+			Start:      inst.Start,
+			End:        inst.End,
+		})
+	}
+	return result
+}
+
 var nativeCheckerFactory = defaultNativeChecker
 var ensureManagedNativeChecker = func() (string, error) {
 	return toolchain.EnsureNativeChecker(".")
@@ -125,8 +188,8 @@ func defaultNativeChecker() (nativeChecker, string) {
 	}
 	managedPath, err := ensureManagedNativeChecker()
 	if err != nil {
-		return nil, fmt.Sprintf(
-			"%s is not set and the managed toolchain checker could not be prepared: %v",
+		return embeddedNativeChecker{}, fmt.Sprintf(
+			"%s is not set and the managed toolchain checker could not be prepared: %v; falling back to the embedded checker",
 			nativeCheckerEnv,
 			err,
 		)

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -136,6 +137,42 @@ fn main() {}
 	}
 	if got := chk.LookupSymType(paramSym); got == nil || got.String() != "Int" {
 		t.Fatalf("unused param type = %v, want Int", got)
+	}
+}
+
+func TestFileFallsBackToEmbeddedCheckerWhenManagedArtifactUnavailable(t *testing.T) {
+	src := []byte(`fn id<T>(value: T) -> T { value }
+
+fn main() {
+    let answer = id::<Int>(1)
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	mainDecl := file.Decls[1].(*ast.FnDecl)
+	letStmt := mainDecl.Body.Stmts[0].(*ast.LetStmt)
+	call := letStmt.Value.(*ast.CallExpr)
+
+	t.Setenv(nativeCheckerEnv, "")
+
+	oldEnsure := ensureManagedNativeChecker
+	ensureManagedNativeChecker = func() (string, error) {
+		return "", fmt.Errorf("boom")
+	}
+	t.Cleanup(func() { ensureManagedNativeChecker = oldEnsure })
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	if got := chk.LookupType(call); got == nil || got.String() != "Int" {
+		t.Fatalf("call type = %v, want Int", got)
+	}
+	if got := chk.LetTypes[letStmt]; got == nil || got.String() != "Int" {
+		t.Fatalf("binding type = %v, want Int", got)
 	}
 }
 

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +59,34 @@ func TestDefaultNativeCheckerUsesManagedArtifactWhenEnvUnset(t *testing.T) {
 	runner, note := defaultNativeChecker()
 	if runner == nil {
 		t.Fatalf("defaultNativeChecker returned nil runner: %s", note)
+	}
+	checked, err := runner.CheckSourceStructured([]byte("fn main() { let answer = 1 }\n"))
+	if err != nil {
+		t.Fatalf("CheckSourceStructured error: %v", err)
+	}
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0", checked.Summary.Errors)
+	}
+	if len(checked.TypedNodes) == 0 {
+		t.Fatalf("typed nodes = %#v, want non-empty result", checked.TypedNodes)
+	}
+}
+
+func TestDefaultNativeCheckerFallsBackToEmbeddedCheckerWhenManagedArtifactUnavailable(t *testing.T) {
+	t.Setenv(nativeCheckerEnv, "")
+
+	oldEnsure := ensureManagedNativeChecker
+	ensureManagedNativeChecker = func() (string, error) {
+		return "", fmt.Errorf("boom")
+	}
+	t.Cleanup(func() { ensureManagedNativeChecker = oldEnsure })
+
+	runner, note := defaultNativeChecker()
+	if runner == nil {
+		t.Fatalf("defaultNativeChecker returned nil runner: %s", note)
+	}
+	if note == "" || note == "boom" {
+		t.Fatalf("fallback note = %q, want fallback explanation", note)
 	}
 	checked, err := runner.CheckSourceStructured([]byte("fn main() { let answer = 1 }\n"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- add an embedded selfhost checker fallback when the managed native checker binary is unavailable
- preserve strict OSTY_NATIVE_CHECKER_BIN override behavior while keeping file/package checking working without a binary
- cover the fallback with regression tests and document the updated behavior

## Testing
- go test ./internal/check ./cmd/osty