### PR TITLE
Implement LLVM loop control-flow lowering

### DIFF
--- a/internal/backend/llvm_break_continue_test.go
+++ b/internal/backend/llvm_break_continue_test.go
@@ -1,0 +1,89 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestLLVMBackendBinaryRunsBreakAndContinueLoops(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut i = 0
+    for i < 6 {
+        i = i + 1
+        if i == 2 {
+            continue
+        }
+        if i == 5 {
+            break
+        }
+        println(i)
+    }
+
+    for j in 0..6 {
+        if j == 1 {
+            continue
+        }
+        if j == 4 {
+            break
+        }
+        println(j)
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n3\n4\n0\n2\n3\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryManagedListLoopBreakAndContinueSurvivePressure(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+fn main() {
+    for item in strings.Split("a,b,c", ",") {
+        if item == "a" {
+            continue
+        }
+        println(item)
+        break
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "b\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/llvm_while_test.go
+++ b/internal/backend/llvm_while_test.go
@@ -1,0 +1,38 @@
+package backend
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestLLVMBackendBinaryRunsWhileStyleForLoop(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 4 {
+        sum = sum + i
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "6\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/break_continue_test.go
+++ b/internal/llvmgen/break_continue_test.go
@@ -1,0 +1,80 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateRangeLoopBreakAndContinue(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    for i in 0..6 {
+        if i == 1 {
+            continue
+        }
+        if i == 4 {
+            break
+        }
+        println(i)
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/range_break_continue.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"for.cont",
+		"for.end",
+		"br label %for.cont",
+		"br label %for.end",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateWhileLoopBreakAndContinue(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut i = 0
+    for i < 6 {
+        i = i + 1
+        if i == 2 {
+            continue
+        }
+        if i == 5 {
+            break
+        }
+        println(i)
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/while_break_continue.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"for.cond",
+		"for.cont",
+		"for.end",
+		"br label %for.cont",
+		"br label %for.end",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -275,20 +275,34 @@ type generator struct {
 	runtimeDecls     map[string]runtimeDecl
 	runtimeDeclOrder []string
 
-	temp         int
-	label        int
-	stringID     int
-	stringDefs   []*LlvmStringGlobal
-	body         []string
-	locals       []map[string]value
-	returnType   string
-	currentBlock string
+	temp             int
+	label            int
+	stringID         int
+	stringDefs       []*LlvmStringGlobal
+	body             []string
+	locals           []map[string]value
+	returnType       string
+	currentBlock     string
+	currentReachable bool
 
 	needsGCRuntime bool
 	gcRootSlots    []value
 	gcRootMarks    []int
 	nextSafepoint  int
 	hiddenLocalID  int
+	loopStack      []loopContext
+}
+
+type loopContext struct {
+	continueLabel string
+	breakLabel    string
+	scopeDepth    int
+}
+
+type scopeState struct {
+	locals      []map[string]value
+	gcRootSlots []value
+	gcRootMarks []int
 }
 
 type declarations struct {
@@ -862,6 +876,8 @@ func (g *generator) beginFunction() {
 	g.nextSafepoint = 1
 	g.hiddenLocalID = 0
 	g.currentBlock = "entry"
+	g.currentReachable = true
+	g.loopStack = nil
 }
 
 func (g *generator) bindGCRootIfManagedPointer(emitter *LlvmEmitter, slot value) {
@@ -973,22 +989,30 @@ func (g *generator) emitBlock(stmts []ast.Stmt) error {
 		if err := g.emitStmt(stmt); err != nil {
 			return err
 		}
+		if !g.currentReachable {
+			break
+		}
 	}
 	return nil
 }
 
 func (g *generator) emitStmt(stmt ast.Stmt) error {
+	if !g.currentReachable {
+		return nil
+	}
 	switch s := stmt.(type) {
 	case *ast.Block:
-		g.pushScope()
-		defer g.popScope()
-		return g.emitBlock(s.Stmts)
+		return g.emitScopedStmtBlock(s.Stmts)
 	case *ast.LetStmt:
 		return g.emitLet(s)
 	case *ast.AssignStmt:
 		return g.emitAssign(s)
 	case *ast.ForStmt:
 		return g.emitFor(s)
+	case *ast.BreakStmt:
+		return g.emitBreak()
+	case *ast.ContinueStmt:
+		return g.emitContinue()
 	case *ast.ExprStmt:
 		if ifExpr, ok := s.X.(*ast.IfExpr); ok {
 			return g.emitIfStmt(ifExpr)
@@ -1071,6 +1095,9 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	if stmt.Body == nil {
 		return unsupported("control-flow", "for has no body")
 	}
+	if stmt.Pattern == nil {
+		return g.emitWhileFor(stmt)
+	}
 	iterName, err := identPatternName(stmt.Pattern)
 	if err != nil {
 		return err
@@ -1099,17 +1126,107 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	emitter := g.toOstyEmitter()
 	loop := llvmRangeStart(emitter, iterName, toOstyValue(start), toOstyValue(stop), rng.Inclusive)
 	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.bodyLabel)
+	continueLabel := g.nextNamedLabel("for.cont")
+	g.pushLoop(loopContext{
+		continueLabel: continueLabel,
+		breakLabel:    loop.endLabel,
+		scopeDepth:    len(g.locals),
+	})
+	scopeDepth := len(g.locals)
 	g.pushScope()
 	g.bindLocal(iterName, value{typ: "i64", ref: loop.current})
 	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
-		g.popScope()
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
 		return err
 	}
-	g.popScope()
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(continueLabel)
+	}
 	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
 	g.emitGCSafepoint(emitter)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.endLabel)
+	return nil
+}
+
+func (g *generator) emitWhileFor(stmt *ast.ForStmt) error {
+	emitter := g.toOstyEmitter()
+	condLabel := llvmNextLabel(emitter, "for.cond")
+	bodyLabel := llvmNextLabel(emitter, "for.body")
+	continueLabel := llvmNextLabel(emitter, "for.cont")
+	endLabel := llvmNextLabel(emitter, "for.end")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", condLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(condLabel)
+
+	if stmt.Iter == nil {
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", bodyLabel))
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+		g.takeOstyEmitter(emitter)
+	} else {
+		cond, err := g.emitExpr(stmt.Iter)
+		if err != nil {
+			return err
+		}
+		if cond.typ != "i1" {
+			return unsupportedf("type-system", "for condition type %s, want i1", cond.typ)
+		}
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  br i1 %s, label %%%s, label %%%s",
+			toOstyValue(cond).name,
+			bodyLabel,
+			endLabel,
+		))
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
+		g.takeOstyEmitter(emitter)
+	}
+	g.enterBlock(bodyLabel)
+
+	g.pushLoop(loopContext{
+		continueLabel: continueLabel,
+		breakLabel:    endLabel,
+		scopeDepth:    len(g.locals),
+	})
+	scopeDepth := len(g.locals)
+	g.pushScope()
+	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
+		return err
+	}
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(continueLabel)
+	}
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(continueLabel)
+	emitter = g.toOstyEmitter()
+	g.emitGCSafepoint(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
 	return nil
 }
 
@@ -1126,6 +1243,7 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 	emitter := g.toOstyEmitter()
 	condLabel := llvmNextLabel(emitter, "for.cond")
 	bodyLabel := llvmNextLabel(emitter, "for.body")
+	continueLabel := llvmNextLabel(emitter, "for.cont")
 	endLabel := llvmNextLabel(emitter, "for.end")
 	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", condLabel))
@@ -1143,26 +1261,49 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", cond.name, bodyLabel, endLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", bodyLabel))
 	g.takeOstyEmitter(emitter)
-	g.currentBlock = bodyLabel
+	g.enterBlock(bodyLabel)
 
+	g.pushLoop(loopContext{
+		continueLabel: continueLabel,
+		breakLabel:    endLabel,
+		scopeDepth:    len(g.locals),
+	})
+	scopeDepth := len(g.locals)
 	g.pushScope()
 	if bind != nil {
 		if err := bind(); err != nil {
-			g.popScope()
+			if len(g.locals) > scopeDepth {
+				g.popScope()
+			}
+			g.popLoop()
 			return err
 		}
 	}
 	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
-		g.popScope()
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
 		return err
 	}
-	g.popScope()
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(continueLabel)
+	}
 
 	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(continueLabel)
+	emitter = g.toOstyEmitter()
+	g.emitGCSafepoint(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
 	g.takeOstyEmitter(emitter)
-	g.currentBlock = endLabel
+	g.enterBlock(endLabel)
 	return nil
 }
 
@@ -1200,26 +1341,38 @@ func (g *generator) emitIfStmt(expr *ast.IfExpr) error {
 	emitter := g.toOstyEmitter()
 	labels := llvmIfStart(emitter, toOstyValue(cond))
 	g.takeOstyEmitter(emitter)
-	g.currentBlock = labels.thenLabel
-	g.pushScope()
-	if err := g.emitBlock(expr.Then.Stmts); err != nil {
-		g.popScope()
+	g.enterBlock(labels.thenLabel)
+	baseState := g.captureScopeState()
+	if err := g.emitScopedStmtBlock(expr.Then.Stmts); err != nil {
 		return err
 	}
-	g.popScope()
+	thenReachable := g.currentReachable
+	if thenReachable {
+		g.branchTo(labels.endLabel)
+	}
+	g.restoreScopeState(baseState)
 	emitter = g.toOstyEmitter()
-	llvmIfElse(emitter, labels)
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.elseLabel))
 	g.takeOstyEmitter(emitter)
-	g.currentBlock = labels.elseLabel
+	g.enterBlock(labels.elseLabel)
 	if expr.Else != nil {
 		if err := g.emitElse(expr.Else); err != nil {
 			return err
 		}
 	}
-	emitter = g.toOstyEmitter()
-	llvmIfEnd(emitter, labels)
-	g.takeOstyEmitter(emitter)
-	g.currentBlock = labels.endLabel
+	elseReachable := g.currentReachable
+	if elseReachable {
+		g.branchTo(labels.endLabel)
+	}
+	g.restoreScopeState(baseState)
+	if thenReachable || elseReachable {
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(labels.endLabel)
+		return nil
+	}
+	g.leaveBlock()
 	return nil
 }
 
@@ -1238,32 +1391,54 @@ func (g *generator) emitIfLetStmt(expr *ast.IfExpr) error {
 	emitter := g.toOstyEmitter()
 	labels := llvmIfStart(emitter, cond)
 	g.takeOstyEmitter(emitter)
-	g.currentBlock = labels.thenLabel
+	g.enterBlock(labels.thenLabel)
+	baseState := g.captureScopeState()
+	scopeDepth := len(g.locals)
 	g.pushScope()
 	if bind != nil {
 		if err := bind(); err != nil {
-			g.popScope()
+			if len(g.locals) > scopeDepth {
+				g.popScope()
+			}
 			return err
 		}
 	}
 	if err := g.emitBlock(expr.Then.Stmts); err != nil {
-		g.popScope()
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
 		return err
 	}
-	g.popScope()
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	thenReachable := g.currentReachable
+	if thenReachable {
+		g.branchTo(labels.endLabel)
+	}
+	g.restoreScopeState(baseState)
 	emitter = g.toOstyEmitter()
-	llvmIfElse(emitter, labels)
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.elseLabel))
 	g.takeOstyEmitter(emitter)
-	g.currentBlock = labels.elseLabel
+	g.enterBlock(labels.elseLabel)
 	if expr.Else != nil {
 		if err := g.emitElse(expr.Else); err != nil {
 			return err
 		}
 	}
-	emitter = g.toOstyEmitter()
-	llvmIfEnd(emitter, labels)
-	g.takeOstyEmitter(emitter)
-	g.currentBlock = labels.endLabel
+	elseReachable := g.currentReachable
+	if elseReachable {
+		g.branchTo(labels.endLabel)
+	}
+	g.restoreScopeState(baseState)
+	if thenReachable || elseReachable {
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(labels.endLabel)
+		return nil
+	}
+	g.leaveBlock()
 	return nil
 }
 
@@ -1306,9 +1481,7 @@ func (g *generator) ifLetCondition(pattern ast.Pattern, scrutinee value) (*LlvmV
 func (g *generator) emitElse(expr ast.Expr) error {
 	switch e := expr.(type) {
 	case *ast.Block:
-		g.pushScope()
-		defer g.popScope()
-		return g.emitBlock(e.Stmts)
+		return g.emitScopedStmtBlock(e.Stmts)
 	case *ast.IfExpr:
 		return g.emitIfStmt(e)
 	default:
@@ -2372,10 +2545,21 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 	lenValue := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(iterableValue)})
 	loop := llvmRangeStart(emitter, iterName+"_idx", llvmIntLiteral(0), lenValue, false)
 	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.bodyLabel)
+	continueLabel := g.nextNamedLabel("for.cont")
+	g.pushLoop(loopContext{
+		continueLabel: continueLabel,
+		breakLabel:    loop.endLabel,
+		scopeDepth:    len(g.locals),
+	})
+	scopeDepth := len(g.locals)
 	g.pushScope()
 	iterableValue, err = g.loadIfPointer(iterable)
 	if err != nil {
-		g.popScope()
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
 		return err
 	}
 	emitter = g.toOstyEmitter()
@@ -2383,14 +2567,25 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 	g.takeOstyEmitter(emitter)
 	g.bindLocal(iterName, fromOstyValue(item))
 	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
-		g.popScope()
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
 		return err
 	}
-	g.popScope()
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(continueLabel)
+	}
 	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
 	g.emitGCSafepoint(emitter)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.endLabel)
 	return nil
 }
 
@@ -3008,6 +3203,62 @@ func toLLVMParams(params []paramInfo) []*LlvmParam {
 	return out
 }
 
+func (g *generator) enterBlock(label string) {
+	g.currentBlock = label
+	g.currentReachable = true
+}
+
+func (g *generator) leaveBlock() {
+	g.currentBlock = ""
+	g.currentReachable = false
+}
+
+func (g *generator) branchTo(label string) {
+	emitter := g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", label))
+	g.takeOstyEmitter(emitter)
+	g.leaveBlock()
+}
+
+func (g *generator) nextNamedLabel(prefix string) string {
+	emitter := g.toOstyEmitter()
+	label := llvmNextLabel(emitter, prefix)
+	g.takeOstyEmitter(emitter)
+	return label
+}
+
+func (g *generator) emitScopedStmtBlock(stmts []ast.Stmt) error {
+	scopeDepth := len(g.locals)
+	g.pushScope()
+	if err := g.emitBlock(stmts); err != nil {
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		return err
+	}
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	return nil
+}
+
+func (g *generator) captureScopeState() scopeState {
+	locals := append([]map[string]value(nil), g.locals...)
+	gcRootSlots := append([]value(nil), g.gcRootSlots...)
+	gcRootMarks := append([]int(nil), g.gcRootMarks...)
+	return scopeState{
+		locals:      locals,
+		gcRootSlots: gcRootSlots,
+		gcRootMarks: gcRootMarks,
+	}
+}
+
+func (g *generator) restoreScopeState(state scopeState) {
+	g.locals = append([]map[string]value(nil), state.locals...)
+	g.gcRootSlots = append([]value(nil), state.gcRootSlots...)
+	g.gcRootMarks = append([]int(nil), state.gcRootMarks...)
+}
+
 func (g *generator) pushScope() {
 	g.locals = append(g.locals, map[string]value{})
 	g.gcRootMarks = append(g.gcRootMarks, len(g.gcRootSlots))
@@ -3193,6 +3444,50 @@ func (g *generator) aggregateFieldType(typ string, index int) (string, bool) {
 
 func (g *generator) bindLocal(name string, v value) {
 	g.locals[len(g.locals)-1][name] = v
+}
+
+func (g *generator) pushLoop(loop loopContext) {
+	g.loopStack = append(g.loopStack, loop)
+}
+
+func (g *generator) popLoop() {
+	if len(g.loopStack) == 0 {
+		return
+	}
+	g.loopStack = g.loopStack[:len(g.loopStack)-1]
+}
+
+func (g *generator) currentLoop() (loopContext, bool) {
+	if len(g.loopStack) == 0 {
+		return loopContext{}, false
+	}
+	return g.loopStack[len(g.loopStack)-1], true
+}
+
+func (g *generator) unwindScopesTo(scopeDepth int) {
+	for len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+}
+
+func (g *generator) emitBreak() error {
+	loop, ok := g.currentLoop()
+	if !ok {
+		return unsupported("control-flow", "break outside of loop")
+	}
+	g.unwindScopesTo(loop.scopeDepth)
+	g.branchTo(loop.breakLabel)
+	return nil
+}
+
+func (g *generator) emitContinue() error {
+	loop, ok := g.currentLoop()
+	if !ok {
+		return unsupported("control-flow", "continue outside of loop")
+	}
+	g.unwindScopesTo(loop.scopeDepth)
+	g.branchTo(loop.continueLabel)
+	return nil
 }
 
 func (g *generator) nextHiddenLocalName(prefix string) string {

--- a/internal/llvmgen/while_for_test.go
+++ b/internal/llvmgen/while_for_test.go
@@ -1,0 +1,72 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateWhileStyleForLoop(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 4 {
+        sum = sum + i
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/while_for.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"for.cond",
+		"for.body",
+		"for.end",
+		"icmp slt i64",
+		"br i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateBareForLoop(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut count = 0
+    for {
+        count = count + 1
+        println(count)
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/bare_for.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"for.cond",
+		"for.body",
+		"for.end",
+		"br label %for.body",
+		"br label %for.cond",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add LLVM lowering for while-style and bare `for` loops
- implement `break` and `continue` lowering with loop-aware scope unwinding
- add IR and executable coverage for loop control-flow, including managed list loops under GC pressure

## Testing
- `go test ./internal/llvmgen ./internal/backend`