### PR TITLE
Add LLVM method lowering for GC model

### DIFF
--- a/examples/selfhost-core/check.osty
+++ b/examples/selfhost-core/check.osty
@@ -1588,7 +1588,7 @@ fn frontCheckFor(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
 
 fn frontCheckIterableElement(typeName: String) -> String {
     let head = frontCheckTypeHead(typeName)
-    if head == "List" || head == "Range" || head == "Option" {
+    if head == "List" || head == "Range" || head == "Option" || head == "Set" {
         return frontCheckGenericArgAt(typeName, 0)
     }
     if head == "Map" {
@@ -3398,16 +3398,7 @@ fn frontCheckPatternIrrefutable(file: AstFile, patIdx: Int) -> Bool {
         return true
     }
     let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return true
-    }
-    if frontCheckPatternKind(pat) == "wildcard" {
-        return true
-    }
-    if frontCheckPatternIsBindingIdent(pat) {
-        return true
-    }
-    if frontCheckPatternKind(pat) == "tuple" {
+    if pat.kind == AstNTuple {
         for child in pat.children {
             if !(frontCheckPatternIrrefutable(file, child)) {
                 return false
@@ -3415,7 +3406,25 @@ fn frontCheckPatternIrrefutable(file: AstFile, patIdx: Int) -> Bool {
         }
         return true
     }
-    if frontCheckPatternKind(pat) == "struct" {
+    let kind = frontCheckPatternKind(pat)
+    if kind == "" {
+        return true
+    }
+    if kind == "wildcard" {
+        return true
+    }
+    if frontCheckPatternIsBindingIdent(pat) {
+        return true
+    }
+    if kind == "tuple" {
+        for child in pat.children {
+            if !(frontCheckPatternIrrefutable(file, child)) {
+                return false
+            }
+        }
+        return true
+    }
+    if kind == "struct" {
         for fieldIdx in pat.children {
             let fieldPat = astArenaNodeAt(file.arena, fieldIdx)
             if !(frontCheckPatternIrrefutable(file, fieldPat.left)) {
@@ -3441,14 +3450,24 @@ fn frontCheckBindPattern(file: AstFile, env: FrontCheckEnv, patIdx: Int, typeNam
         }
         return
     }
-    if pat.kind != AstNPattern {
+    if pat.kind == AstNTuple {
+        let elems = frontCheckTupleElems(typeName)
+        let mut i = 0
+        for child in pat.children {
+            frontCheckBindPattern(file, env, child, frontCheckStringAt(elems, i), mutable)
+            i = i + 1
+        }
+        return
+    }
+    let kind = frontCheckPatternKind(pat)
+    if kind == "" {
         return
     }
     if frontCheckPatternIsBindingIdent(pat) {
         frontCheckBindNode(env, frontCheckPatternName(pat), typeName, mutable, patIdx, pat.start, pat.end)
         return
     }
-    if frontCheckPatternKind(pat) == "tuple" {
+    if kind == "tuple" {
         let elems = frontCheckTupleElems(typeName)
         let mut i = 0
         for child in pat.children {
@@ -3477,25 +3496,39 @@ fn frontCheckPatternCompatible(file: AstFile, env: FrontCheckEnv, patIdx: Int, s
         return
     }
     let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
+    if pat.kind == AstNTuple {
+        let scrutineeResolved = frontCheckResolveAliasesDeep(env, scrutineeType)
+        let elems = frontCheckTupleElems(scrutineeResolved)
+        if frontCheckStringCount(elems) != frontCheckIntCount(pat.children) {
+            env.errors = env.errors + 1
+        }
+        let mut i = 0
+        for child in pat.children {
+            frontCheckPatternCompatible(file, env, child, frontCheckStringAt(elems, i))
+            i = i + 1
+        }
+        return
+    }
+    let kind = frontCheckPatternKind(pat)
+    if kind == "" {
         return
     }
     let scrutineeResolved = frontCheckResolveAliasesDeep(env, scrutineeType)
-    if frontCheckPatternKind(pat) == "wildcard" {
+    if kind == "wildcard" {
         return
     }
     if frontCheckPatternIsBindingIdent(pat) {
         frontCheckBind(env, frontCheckPatternName(pat), scrutineeResolved, false)
         return
     }
-    if frontCheckPatternKind(pat) == "literal" {
+    if kind == "literal" {
         let litType = frontCheckPatternLiteralType(pat)
         if !(frontCheckIsAssignable(env, scrutineeResolved, litType)) && !(frontCheckIsAssignable(env, litType, scrutineeResolved)) {
             env.errors = env.errors + 1
         }
         return
     }
-    if frontCheckPatternKind(pat) == "negLiteral" {
+    if kind == "negLiteral" {
         let inner = astArenaNodeAt(file.arena, pat.left)
         let litType = frontCheckPatternLiteralType(inner)
         if !(frontCheckIsNumeric(litType)) {
@@ -3507,7 +3540,7 @@ fn frontCheckPatternCompatible(file: AstFile, env: FrontCheckEnv, patIdx: Int, s
         }
         return
     }
-    if frontCheckPatternKind(pat) == "range" {
+    if kind == "range" {
         if !(frontCheckIsOrdered(scrutineeResolved)) {
             env.errors = env.errors + 1
             return
@@ -3518,7 +3551,7 @@ fn frontCheckPatternCompatible(file: AstFile, env: FrontCheckEnv, patIdx: Int, s
         }
         return
     }
-    if frontCheckPatternKind(pat) == "tuple" {
+    if kind == "tuple" {
         let elems = frontCheckTupleElems(scrutineeResolved)
         if frontCheckStringCount(elems) != frontCheckIntCount(pat.children) {
             env.errors = env.errors + 1
@@ -3544,7 +3577,7 @@ fn frontCheckPatternCompatible(file: AstFile, env: FrontCheckEnv, patIdx: Int, s
         }
         return
     }
-    if frontCheckPatternKind(pat) == "struct" {
+    if kind == "struct" {
         let structName = frontCheckPatternName(pat)
         if frontCheckTypeHead(scrutineeResolved) != structName {
             env.errors = env.errors + 1
@@ -3567,7 +3600,7 @@ fn frontCheckPatternCompatible(file: AstFile, env: FrontCheckEnv, patIdx: Int, s
         frontCheckPatternCompatible(file, env, pat.left, scrutineeResolved)
         return
     }
-    if frontCheckPatternKind(pat) == "or" {
+    if kind == "or" {
         let mark = frontCheckBindingCount(env.bindings)
         frontCheckPatternCompatible(file, env, pat.left, scrutineeResolved)
         let leftBindings = frontCheckBindingsFrom(env, mark)
@@ -3778,6 +3811,9 @@ fn frontCheckStdMethodCall(file: AstFile, env: FrontCheckEnv, callee: AstNode, r
     if head == "Map" {
         return frontCheckMapMethod(file, env, receiver, name, args)
     }
+    if head == "Set" {
+        return frontCheckSetMethod(file, env, receiver, name, args)
+    }
     if head == "Option" {
         return frontCheckOptionMethod(file, env, receiver, name, args)
     }
@@ -3852,6 +3888,18 @@ fn frontCheckListMethod(file: AstFile, env: FrontCheckEnv, callee: AstNode, recv
         let _ = frontCheckClosureArg(file, env, frontCheckIntAt(args, 1), [acc, elem], acc)
         return acc
     }
+    if name == "sorted" {
+        frontCheckExpectArgCount(env, args, 0)
+        return recvType
+    }
+    if name == "toSet" {
+        frontCheckExpectArgCount(env, args, 0)
+        return frontCheckOneArgType("Set", elem)
+    }
+    if name == "clear" {
+        frontCheckExpectArgCount(env, args, 0)
+        return "()"
+    }
     "Invalid"
 }
 
@@ -3889,6 +3937,46 @@ fn frontCheckMapMethod(file: AstFile, env: FrontCheckEnv, recvType: String, name
     if name == "values" {
         frontCheckExpectArgCount(env, args, 0)
         return frontCheckOneArgType("List", val)
+    }
+    if name == "clear" {
+        frontCheckExpectArgCount(env, args, 0)
+        return "()"
+    }
+    "Invalid"
+}
+
+fn frontCheckSetMethod(file: AstFile, env: FrontCheckEnv, recvType: String, name: String, args: List<Int>) -> String {
+    let elem = frontCheckGenericArgAt(recvType, 0)
+    if name == "len" {
+        frontCheckExpectArgCount(env, args, 0)
+        return "Int"
+    }
+    if name == "isEmpty" {
+        frontCheckExpectArgCount(env, args, 0)
+        return "Bool"
+    }
+    if name == "contains" {
+        frontCheckExpectArgCount(env, args, 1)
+        frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
+        return "Bool"
+    }
+    if name == "insert" {
+        frontCheckExpectArgCount(env, args, 1)
+        frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
+        return "()"
+    }
+    if name == "remove" {
+        frontCheckExpectArgCount(env, args, 1)
+        frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
+        return "Bool"
+    }
+    if name == "toList" {
+        frontCheckExpectArgCount(env, args, 0)
+        return frontCheckOneArgType("List", elem)
+    }
+    if name == "clear" {
+        frontCheckExpectArgCount(env, args, 0)
+        return "()"
     }
     "Invalid"
 }

--- a/examples/selfhost-core/check_test.osty
+++ b/examples/selfhost-core/check_test.osty
@@ -192,6 +192,53 @@ fn testSelfCheckerAcceptsConcurrencyPreludeSurface() {
     testing.assertEq(checked.errors, 0)
 }
 
+fn testSelfCheckerAcceptsCollectionMethodSurfaceUsedByGcModel() {
+    let checked = frontendCheckSource(
+        r"""
+            fn snapshot(objects: Map<Int, String>, roots: Set<Int>) -> List<Int> {
+                let rootList: List<Int> = roots.toList()
+                let sortedIds: List<Int> = objects.keys().sorted()
+                let rebuilt: Set<Int> = rootList.toSet()
+                let hasRoot: Bool = rebuilt.contains(1)
+                let rootCount: Int = rebuilt.len()
+                let empty: Bool = rebuilt.isEmpty()
+                rebuilt.insert(rootCount)
+                let removed: Bool = rebuilt.remove(0)
+                if hasRoot && removed == false && empty == false {
+                    return sortedIds
+                }
+                sortedIds
+            }
+            """,
+    )
+
+    testing.assertEq(checked.errors, 0)
+}
+
+fn testSelfCheckerBindsTuplePatternsWhenIteratingMaps() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct Obj {
+                generation: Int,
+            }
+
+            fn total(objects: Map<Int, Obj>) -> Int {
+                let mut sum = 0
+                for (id, obj) in objects {
+                    if obj.generation > 0 {
+                        sum = sum + id
+                    }
+                }
+                sum
+            }
+            """,
+    )
+
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "id"), "Int")
+    testing.assertEq(frontCheckResultBindingType(checked, "obj"), "Obj")
+}
+
 fn testSelfCheckerChecksMatchExhaustivenessAndPatterns() {
     let nonExhaustive = frontendCheckSource(
         r"""

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -374,3 +374,43 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryMutReceiverMethodWritesBackToCaller(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `struct Counter {
+    value: Int,
+
+    fn add(mut self, delta: Int) -> Int {
+        self.value = self.value + delta
+        self.value
+    }
+
+    fn get(self) -> Int {
+        self.value
+    }
+}
+
+fn main() {
+    let mut counter = Counter { value: 1 }
+    println(counter.add(2))
+    println(counter.get())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "3\n3\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/gc_integration_test.go
+++ b/internal/llvmgen/gc_integration_test.go
@@ -84,3 +84,90 @@ fn main() {
 		}
 	}
 }
+
+func TestGenerateMutReceiverMethodsLowerToReceiverSlots(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Counter {
+    value: Int,
+
+    fn add(mut self, delta: Int) -> Int {
+        self.value = self.value + delta
+        self.value
+    }
+
+    fn get(self) -> Int {
+        self.value
+    }
+}
+
+fn main() {
+    let mut counter = Counter { value: 1 }
+    println(counter.add(2))
+    println(counter.get())
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/method_receivers.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @Counter__add(ptr %self, i64 %delta)",
+		"define i64 @Counter__get(%Counter %self)",
+		"call i64 @Counter__add(ptr %t",
+		"call i64 @Counter__get(%Counter",
+		"insertvalue %Counter",
+		"alloca %Counter",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateStructFieldsCanUseEnumTypes(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Kind {
+    Ready,
+    Done,
+}
+
+struct Box {
+    kind: Kind,
+}
+
+fn tag(box: Box) -> Int {
+    match box.kind {
+        Ready -> 1,
+        Done -> 2,
+    }
+}
+
+fn main() {
+    let box = Box { kind: Ready }
+    println(tag(box))
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_struct_field.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Box = type { i64 }",
+		"insertvalue %Box undef, i64 0, 0",
+		"extractvalue %Box",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -214,6 +214,7 @@ func Generate(file *ast.File, opts Options) ([]byte, error) {
 		return nil, err
 	}
 	g.functions = decls.functionsByName
+	g.methods = decls.methodsByType
 	g.structs = decls.structsOrdered
 	g.structsByName = decls.structsByName
 	g.structsByType = decls.structsByType
@@ -264,6 +265,7 @@ type generator struct {
 	sourcePath       string
 	target           string
 	functions        map[string]*fnSig
+	methods          map[string]map[string]*fnSig
 	structs          []*structInfo
 	structsByName    map[string]*structInfo
 	structsByType    map[string]*structInfo
@@ -294,6 +296,7 @@ type generator struct {
 type declarations struct {
 	functionsOrdered []*fnSig
 	functionsByName  map[string]*fnSig
+	methodsByType    map[string]map[string]*fnSig
 	structsOrdered   []*structInfo
 	structsByName    map[string]*structInfo
 	structsByType    map[string]*structInfo
@@ -304,6 +307,9 @@ type declarations struct {
 
 type fnSig struct {
 	name           string
+	irName         string
+	receiverType   string
+	receiverMut    bool
 	ret            string
 	retListElemTyp string
 	params         []paramInfo
@@ -313,7 +319,10 @@ type fnSig struct {
 type paramInfo struct {
 	name        string
 	typ         string
+	irTyp       string
 	listElemTyp string
+	mutable     bool
+	byRef       bool
 }
 
 type structInfo struct {
@@ -393,6 +402,7 @@ type runtimeDecl struct {
 func collectDeclarations(file *ast.File) (*declarations, error) {
 	out := &declarations{
 		functionsByName: map[string]*fnSig{},
+		methodsByType:   map[string]map[string]*fnSig{},
 		structsByName:   map[string]*structInfo{},
 		structsByType:   map[string]*structInfo{},
 		enumsByName:     map[string]*enumInfo{},
@@ -432,7 +442,7 @@ func collectDeclarations(file *ast.File) (*declarations, error) {
 		}
 	}
 	for _, info := range out.structsOrdered {
-		if err := collectStructFields(info, out.structsByName); err != nil {
+		if err := collectStructFields(info, out.structsByName, out.enumsByName); err != nil {
 			return nil, err
 		}
 	}
@@ -441,7 +451,7 @@ func collectDeclarations(file *ast.File) (*declarations, error) {
 		if !ok {
 			continue
 		}
-		sig, err := signatureOf(fn, out.structsByName, out.enumsByName)
+		sig, err := signatureOf(fn, "", out.structsByName, out.enumsByName)
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +461,40 @@ func collectDeclarations(file *ast.File) (*declarations, error) {
 		out.functionsOrdered = append(out.functionsOrdered, sig)
 		out.functionsByName[sig.name] = sig
 	}
+	for _, info := range out.structsOrdered {
+		if err := collectMethodDeclarations(out, info.name, info.typ, info.decl.Methods, out.structsByName, out.enumsByName); err != nil {
+			return nil, err
+		}
+	}
+	for _, info := range out.enumsOrdered {
+		if err := collectMethodDeclarations(out, info.name, info.typ, info.decl.Methods, out.structsByName, out.enumsByName); err != nil {
+			return nil, err
+		}
+	}
 	return out, nil
+}
+
+func collectMethodDeclarations(out *declarations, ownerName, ownerType string, methods []*ast.FnDecl, structs map[string]*structInfo, enums map[string]*enumInfo) error {
+	if out == nil {
+		return unsupported("source-layout", "nil declarations")
+	}
+	for _, fn := range methods {
+		sig, err := signatureOf(fn, ownerName, structs, enums)
+		if err != nil {
+			return err
+		}
+		methodsByName := out.methodsByType[ownerType]
+		if methodsByName == nil {
+			methodsByName = map[string]*fnSig{}
+			out.methodsByType[ownerType] = methodsByName
+		}
+		if _, exists := methodsByName[sig.name]; exists {
+			return unsupportedf("source-layout", "duplicate method %q on %q", sig.name, ownerName)
+		}
+		out.functionsOrdered = append(out.functionsOrdered, sig)
+		methodsByName[sig.name] = sig
+	}
+	return nil
 }
 
 func collectRuntimeFFI(file *ast.File, structs map[string]*structInfo, enums map[string]*enumInfo) map[string]map[string]*runtimeFFIFunction {
@@ -626,7 +669,7 @@ func collectStructShell(decl *ast.StructDecl) (*structInfo, error) {
 	}, nil
 }
 
-func collectStructFields(info *structInfo, structs map[string]*structInfo) error {
+func collectStructFields(info *structInfo, structs map[string]*structInfo, enums map[string]*enumInfo) error {
 	if info == nil || info.decl == nil {
 		return unsupported("source-layout", "nil struct")
 	}
@@ -641,7 +684,7 @@ func collectStructFields(info *structInfo, structs map[string]*structInfo) error
 			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, true, false, "")
 			return unsupported(diag.kind, diag.message)
 		}
-		typ, err := llvmType(field.Type, structs, nil)
+		typ, err := llvmType(field.Type, structs, enums)
 		if err != nil {
 			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
 			return unsupported(diag.kind, diag.message)
@@ -651,7 +694,7 @@ func collectStructFields(info *structInfo, structs map[string]*structInfo) error
 			return unsupported(diag.kind, diag.message)
 		}
 		fieldInfo := fieldInfo{name: field.Name, typ: typ, index: i}
-		if listElemTyp, ok, err := llvmListElementType(field.Type, structs, nil); err != nil {
+		if listElemTyp, ok, err := llvmListElementType(field.Type, structs, enums); err != nil {
 			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
 			return unsupported(diag.kind, diag.message)
 		} else if ok {
@@ -736,14 +779,14 @@ func llvmEnumPayloadType(t ast.Type) (string, error) {
 	return "", unsupported("type-system", "LLVM enum payloads currently support Int, Float, or String only")
 }
 
-func signatureOf(fn *ast.FnDecl, structs map[string]*structInfo, enums map[string]*enumInfo) (*fnSig, error) {
+func signatureOf(fn *ast.FnDecl, ownerName string, structs map[string]*structInfo, enums map[string]*enumInfo) (*fnSig, error) {
 	if fn == nil {
 		return nil, unsupported("source-layout", "nil function")
 	}
 	if diag := llvmFunctionHeaderDiagnostic(
 		fn.Name,
 		llvmIsIdent(fn.Name),
-		fn.Recv != nil,
+		false,
 		len(fn.Generics),
 		fn.Body != nil,
 		fn.Name == "main",
@@ -752,7 +795,23 @@ func signatureOf(fn *ast.FnDecl, structs map[string]*structInfo, enums map[strin
 	); diag.kind != "" {
 		return nil, unsupported(diag.kind, diag.message)
 	}
-	sig := &fnSig{name: fn.Name, decl: fn}
+	sig := &fnSig{name: fn.Name, irName: fn.Name, decl: fn}
+	if fn.Recv != nil {
+		ownerType, ok := llvmMethodOwnerType(ownerName, structs, enums)
+		if !ok {
+			return nil, unsupportedf("type-system", "unknown method receiver owner %q", ownerName)
+		}
+		sig.irName = llvmMethodIRName(ownerName, fn.Name)
+		sig.receiverType = ownerType
+		sig.receiverMut = fn.Recv.Mut
+		sig.params = append(sig.params, paramInfo{
+			name:    "self",
+			typ:     ownerType,
+			irTyp:   llvmMethodReceiverIRType(ownerType, fn.Recv.Mut),
+			mutable: fn.Recv.Mut,
+			byRef:   fn.Recv.Mut,
+		})
+	}
 	if fn.Name == "main" {
 		return sig, nil
 	}
@@ -833,7 +892,13 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 			v.gcManaged = true
 		}
 		v.rootPaths = g.rootPathsForType(p.typ)
-		g.bindNamedLocal(p.name, v, false)
+		if p.byRef {
+			v.ptr = true
+			v.mutable = p.mutable
+			g.bindLocal(p.name, v)
+			continue
+		}
+		g.bindNamedLocal(p.name, v, p.mutable)
 	}
 	if sig.ret == "void" {
 		if err := g.emitBlock(sig.decl.Body.Stmts); err != nil {
@@ -848,7 +913,7 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 			return "", err
 		}
 	}
-	return g.renderFunction(sig.ret, sig.name, sig.params), nil
+	return g.renderFunction(sig.ret, sig.irName, sig.params), nil
 }
 
 func (g *generator) beginFunction() {
@@ -1040,26 +1105,83 @@ func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
 		return unsupported("statement", "multi-target assignment")
 	}
 	target, ok := stmt.Targets[0].(*ast.Ident)
+	if ok {
+		slot, ok := g.lookupLocal(target.Name)
+		if !ok {
+			return unsupportedf("name", "assignment to unknown identifier %q", target.Name)
+		}
+		if !slot.mutable {
+			return unsupportedf("statement", "assignment to immutable identifier %q", target.Name)
+		}
+		v, err := g.emitExprWithListHint(stmt.Value, slot.listElemTyp)
+		if err != nil {
+			return err
+		}
+		if v.typ != slot.typ {
+			return unsupportedf("type-system", "assignment to %q type %s, value %s", target.Name, slot.typ, v.typ)
+		}
+		emitter := g.toOstyEmitter()
+		llvmStore(emitter, toOstyValue(slot), toOstyValue(v))
+		g.postGCWriteIfPointer(emitter, slot, v)
+		g.takeOstyEmitter(emitter)
+		return nil
+	}
+	field, ok := stmt.Targets[0].(*ast.FieldExpr)
 	if !ok {
 		return unsupportedf("statement", "assignment target %T", stmt.Targets[0])
 	}
-	slot, ok := g.lookupLocal(target.Name)
+	return g.emitFieldAssign(field, stmt.Value)
+}
+
+func (g *generator) emitFieldAssign(target *ast.FieldExpr, rhs ast.Expr) error {
+	if target == nil {
+		return unsupported("statement", "nil field assignment target")
+	}
+	if target.IsOptional {
+		return unsupported("statement", "optional field assignment is not supported")
+	}
+	baseIdent, ok := target.X.(*ast.Ident)
 	if !ok {
-		return unsupportedf("name", "assignment to unknown identifier %q", target.Name)
+		return unsupportedf("statement", "field assignment base %T", target.X)
 	}
-	if !slot.mutable {
-		return unsupportedf("statement", "assignment to immutable identifier %q", target.Name)
+	slot, ok := g.lookupLocal(baseIdent.Name)
+	if !ok {
+		return unsupportedf("name", "assignment to unknown identifier %q", baseIdent.Name)
 	}
-	v, err := g.emitExprWithListHint(stmt.Value, slot.listElemTyp)
+	if !slot.ptr || !slot.mutable {
+		return unsupportedf("statement", "assignment to immutable field %q.%s", baseIdent.Name, target.Name)
+	}
+	info := g.structsByType[slot.typ]
+	if info == nil {
+		return unsupportedf("type-system", "field assignment on %s", slot.typ)
+	}
+	field, ok := info.byName[target.Name]
+	if !ok {
+		return unsupportedf("expression", "struct %q has no field %q", info.name, target.Name)
+	}
+	v, err := g.emitExprWithListHint(rhs, field.listElemTyp)
 	if err != nil {
 		return err
 	}
-	if v.typ != slot.typ {
-		return unsupportedf("type-system", "assignment to %q type %s, value %s", target.Name, slot.typ, v.typ)
+	if v.typ != field.typ {
+		return unsupportedf("type-system", "field assignment %q.%s type %s, value %s", baseIdent.Name, target.Name, field.typ, v.typ)
+	}
+	current, err := g.loadIfPointer(slot)
+	if err != nil {
+		return err
 	}
 	emitter := g.toOstyEmitter()
-	llvmStore(emitter, toOstyValue(slot), toOstyValue(v))
-	g.postGCWriteIfPointer(emitter, slot, v)
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  %s = insertvalue %s %s, %s %s, %d",
+		tmp,
+		current.typ,
+		current.ref,
+		v.typ,
+		v.ref,
+		field.index,
+	))
+	llvmStore(emitter, toOstyValue(slot), toOstyValue(value{typ: current.typ, ref: tmp}))
 	g.takeOstyEmitter(emitter)
 	return nil
 }
@@ -2621,34 +2743,33 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitRuntimeFFICall(call); found || err != nil {
 		return v, err
 	}
-	id, ok := call.Fn.(*ast.Ident)
-	if !ok {
+	sig, receiverExpr, found, err := g.userCallTarget(call)
+	if err != nil {
+		return value{}, err
+	}
+	if !found {
+		if id, ok := call.Fn.(*ast.Ident); ok && id.Name == "println" {
+			return value{}, unsupported("call", "println is only supported as a statement")
+		}
 		return value{}, unsupportedf("call", "call target %T", call.Fn)
 	}
-	if id.Name == "println" {
-		return value{}, unsupported("call", "println is only supported as a statement")
-	}
-	sig := g.functions[id.Name]
-	if sig == nil {
-		return value{}, unsupportedf("name", "unknown function %q", id.Name)
-	}
 	if sig.ret == "" {
-		return value{}, unsupportedf("call", "function %q has no return value", id.Name)
+		return value{}, unsupportedf("call", "function %q has no return value", sig.name)
 	}
 	if sig.ret == "void" {
-		return value{}, unsupportedf("call", "function %q has no return value", id.Name)
+		return value{}, unsupportedf("call", "function %q has no return value", sig.name)
 	}
 	emitter := g.toOstyEmitter()
 	g.emitGCSafepoint(emitter)
 	g.takeOstyEmitter(emitter)
 	g.pushScope()
-	args, err := g.userCallArgs(sig, call)
+	args, err := g.userCallArgs(sig, receiverExpr, call)
 	if err != nil {
 		g.popScope()
 		return value{}, err
 	}
 	emitter = g.toOstyEmitter()
-	out := llvmCall(emitter, sig.ret, sig.name, args)
+	out := llvmCall(emitter, sig.ret, sig.irName, args)
 	g.takeOstyEmitter(emitter)
 	g.popScope()
 	ret := fromOstyValue(out)
@@ -2715,44 +2836,57 @@ func (g *generator) emitRuntimeFFICallStmt(call *ast.CallExpr) (bool, error) {
 }
 
 func (g *generator) emitUserCallStmt(call *ast.CallExpr) (bool, error) {
-	id, ok := call.Fn.(*ast.Ident)
-	if !ok {
-		return false, nil
+	sig, receiverExpr, found, err := g.userCallTarget(call)
+	if err != nil {
+		return true, err
 	}
-	sig := g.functions[id.Name]
-	if sig == nil {
+	if !found {
 		return false, nil
 	}
 	emitter := g.toOstyEmitter()
 	g.emitGCSafepoint(emitter)
 	g.takeOstyEmitter(emitter)
 	g.pushScope()
-	args, err := g.userCallArgs(sig, call)
+	args, err := g.userCallArgs(sig, receiverExpr, call)
 	if err != nil {
 		g.popScope()
 		return true, err
 	}
 	emitter = g.toOstyEmitter()
 	if sig.ret == "void" {
-		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", sig.name, llvmCallArgs(args)))
+		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", sig.irName, llvmCallArgs(args)))
 	} else {
-		llvmCall(emitter, sig.ret, sig.name, args)
+		llvmCall(emitter, sig.ret, sig.irName, args)
 	}
 	g.takeOstyEmitter(emitter)
 	g.popScope()
 	return true, nil
 }
 
-func (g *generator) userCallArgs(sig *fnSig, call *ast.CallExpr) ([]*LlvmValue, error) {
-	if len(call.Args) != len(sig.params) {
+func (g *generator) userCallArgs(sig *fnSig, receiverExpr ast.Expr, call *ast.CallExpr) ([]*LlvmValue, error) {
+	expectedArgs := len(sig.params)
+	if receiverExpr != nil {
+		expectedArgs--
+	}
+	if len(call.Args) != expectedArgs {
 		return nil, unsupportedf("call", "function %q argument count", sig.name)
+	}
+	args := make([]*LlvmValue, 0, len(sig.params))
+	paramIndex := 0
+	if receiverExpr != nil {
+		receiver, err := g.userCallReceiverArg(sig, sig.params[0], receiverExpr)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, receiver)
+		paramIndex = 1
 	}
 	values := make([]value, 0, len(call.Args))
 	for i, arg := range call.Args {
 		if arg.Name != "" || arg.Value == nil {
 			return nil, unsupportedf("call", "function %q requires positional arguments", sig.name)
 		}
-		param := sig.params[i]
+		param := sig.params[paramIndex+i]
 		v, err := g.emitExprWithListHint(arg.Value, param.listElemTyp)
 		if err != nil {
 			return nil, err
@@ -2762,7 +2896,6 @@ func (g *generator) userCallArgs(sig *fnSig, call *ast.CallExpr) ([]*LlvmValue, 
 		}
 		values = append(values, g.protectManagedTemporary(sig.name+".arg", v))
 	}
-	args := make([]*LlvmValue, 0, len(values))
 	for _, v := range values {
 		loaded, err := g.loadIfPointer(v)
 		if err != nil {
@@ -2771,6 +2904,69 @@ func (g *generator) userCallArgs(sig *fnSig, call *ast.CallExpr) ([]*LlvmValue, 
 		args = append(args, toOstyValue(loaded))
 	}
 	return args, nil
+}
+
+func (g *generator) userCallReceiverArg(sig *fnSig, param paramInfo, receiverExpr ast.Expr) (*LlvmValue, error) {
+	if param.byRef {
+		id, ok := receiverExpr.(*ast.Ident)
+		if !ok {
+			return nil, unsupportedf("call", "mut receiver for %q must be a local binding", sig.name)
+		}
+		slot, ok := g.lookupLocal(id.Name)
+		if !ok {
+			return nil, unsupportedf("name", "unknown receiver binding %q", id.Name)
+		}
+		if !slot.ptr || slot.typ != param.typ {
+			return nil, unsupportedf("type-system", "receiver for %q must be mutable %s", sig.name, param.typ)
+		}
+		return &LlvmValue{typ: "ptr", name: slot.ref}, nil
+	}
+	v, err := g.emitExpr(receiverExpr)
+	if err != nil {
+		return nil, err
+	}
+	if v.typ != param.typ {
+		return nil, unsupportedf("type-system", "receiver for %q type %s, want %s", sig.name, v.typ, param.typ)
+	}
+	protected := g.protectManagedTemporary(sig.name+".self", v)
+	loaded, err := g.loadIfPointer(protected)
+	if err != nil {
+		return nil, err
+	}
+	return toOstyValue(loaded), nil
+}
+
+func (g *generator) userCallTarget(call *ast.CallExpr) (*fnSig, ast.Expr, bool, error) {
+	if call == nil {
+		return nil, nil, false, nil
+	}
+	switch fn := call.Fn.(type) {
+	case *ast.Ident:
+		sig := g.functions[fn.Name]
+		if sig == nil {
+			return nil, nil, false, nil
+		}
+		return sig, nil, true, nil
+	case *ast.FieldExpr:
+		if fn.IsOptional {
+			return nil, nil, false, unsupported("call", "optional method calls are not supported")
+		}
+		baseTyp, _, ok := g.staticExprType(fn.X)
+		if !ok {
+			return nil, nil, false, nil
+		}
+		methods := g.methods[baseTyp]
+		if methods == nil {
+			return nil, nil, false, nil
+		}
+		sig := methods[fn.Name]
+		if sig == nil {
+			return nil, nil, false, nil
+		}
+		return sig, fn.X, true, nil
+	default:
+		return nil, nil, false, nil
+	}
 }
 
 func (g *generator) runtimeFFICallTarget(call *ast.CallExpr) (*runtimeFFIFunction, bool, error) {
@@ -3003,7 +3199,7 @@ func structTypeExprName(expr ast.Expr) (string, bool) {
 func toLLVMParams(params []paramInfo) []*LlvmParam {
 	out := make([]*LlvmParam, 0, len(params))
 	for _, p := range params {
-		out = append(out, llvmParam(p.name, p.typ))
+		out = append(out, llvmParam(p.name, llvmParamIRType(p)))
 	}
 	return out
 }
@@ -3270,6 +3466,15 @@ func (g *generator) staticExprType(expr ast.Expr) (string, string, bool) {
 				return sig.ret, sig.retListElemTyp, true
 			}
 		}
+		if field, ok := e.Fn.(*ast.FieldExpr); ok && !field.IsOptional {
+			if baseTyp, _, ok := g.staticExprType(field.X); ok {
+				if methods := g.methods[baseTyp]; methods != nil {
+					if sig := methods[field.Name]; sig != nil && sig.ret != "" && sig.ret != "void" {
+						return sig.ret, sig.retListElemTyp, true
+					}
+				}
+			}
+		}
 		if fn, found, err := g.runtimeFFICallTarget(e); found && err == nil && fn.ret != "" && fn.ret != "void" {
 			return fn.ret, fn.listElemTyp, true
 		}
@@ -3402,4 +3607,55 @@ func llvmType(t ast.Type, structs map[string]*structInfo, enums map[string]*enum
 	default:
 		return "", unsupportedf("type-system", "type %T", t)
 	}
+}
+
+func llvmMethodOwnerType(ownerName string, structs map[string]*structInfo, enums map[string]*enumInfo) (string, bool) {
+	if info := structs[ownerName]; info != nil {
+		return info.typ, true
+	}
+	if info := enums[ownerName]; info != nil {
+		return info.typ, true
+	}
+	return "", false
+}
+
+func llvmMethodIRName(ownerName, methodName string) string {
+	return sanitizeLLVMName(ownerName) + "__" + sanitizeLLVMName(methodName)
+}
+
+func llvmMethodReceiverIRType(ownerType string, mutable bool) string {
+	if mutable {
+		return "ptr"
+	}
+	return ownerType
+}
+
+func llvmParamIRType(param paramInfo) string {
+	if param.irTyp != "" {
+		return param.irTyp
+	}
+	return param.typ
+}
+
+func sanitizeLLVMName(name string) string {
+	if name == "" {
+		return "anon"
+	}
+	var b strings.Builder
+	for i, c := range name {
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || (i > 0 && '0' <= c && c <= '9') {
+			b.WriteRune(c)
+			continue
+		}
+		if i == 0 && '0' <= c && c <= '9' {
+			b.WriteByte('_')
+			b.WriteRune(c)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	if b.Len() == 0 {
+		return "anon"
+	}
+	return b.String()
 }

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -209,8 +209,8 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if got := llvmFunctionHeaderDiagnostic("main", true, false, 0, true, true, 0, false); got.kind != "" {
 		t.Fatalf("llvmFunctionHeaderDiagnostic(%q, true, false, 0, true, true, 0, false).kind = %q, want empty", "main", got.kind)
 	}
-	if got, want := llvmFunctionHeaderDiagnostic("methodish", true, true, 0, true, false, 0, false).message, "methods are not supported"; got != want {
-		t.Fatalf("llvmFunctionHeaderDiagnostic(%q, true, true, 0, true, false, 0, false).message = %q, want %q", "methodish", got, want)
+	if got := llvmFunctionHeaderDiagnostic("methodish", true, true, 0, true, false, 0, false); got.kind != "" {
+		t.Fatalf("llvmFunctionHeaderDiagnostic(%q, true, true, 0, true, false, 0, false).kind = %q, want empty", "methodish", got.kind)
 	}
 	if got, want := llvmFunctionHeaderDiagnostic("main", true, false, 0, true, true, 1, false).message, "LLVM main must have no params and no return type"; got != want {
 		t.Fatalf("llvmFunctionHeaderDiagnostic(%q, true, false, 0, true, true, 1, false).message = %q, want %q", "main", got, want)

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1409,18 +1409,12 @@ func llvmNominalDeclHeaderDiagnostic(kind string, name string, identOk bool, gen
 	if genericCount != 0 {
 		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("generic %s %q is not supported", kind, name))
 	}
-	if methodCount != 0 {
-		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("%s %q methods are not supported", kind, name))
-	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
 func llvmFunctionHeaderDiagnostic(name string, identOk bool, hasRecv bool, genericCount int, hasBody bool, isMain bool, paramCount int, hasReturnType bool) *LlvmUnsupportedDiagnostic {
 	if !identOk {
 		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("function name %q", name))
-	}
-	if hasRecv {
-		return llvmUnsupportedDiagnostic("function-signature", "methods are not supported")
 	}
 	if genericCount != 0 {
 		return llvmUnsupportedDiagnostic("function-signature", "generic functions are not supported")

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -28000,7 +28000,7 @@ func frontCheckIterableElement(typeName string) string {
 	head := frontCheckTypeHead(typeName)
 	_ = head
 	// Osty: /tmp/selfhost_merged.osty:10927:5
-	if head == "List" || head == "Range" || head == "Option" {
+	if head == "List" || head == "Range" || head == "Option" || head == "Set" {
 		// Osty: /tmp/selfhost_merged.osty:10928:9
 		return frontCheckGenericArgAt(typeName, 0)
 	}
@@ -31984,13 +31984,24 @@ func frontCheckPatternIrrefutable(file *AstFile, patIdx int) bool {
 	// Osty: /tmp/selfhost_merged.osty:12736:5
 	pat := astArenaNodeAt(file.arena, patIdx)
 	_ = pat
+	if ostyEqual(pat.kind, AstNodeKind(&AstNodeKind_AstNTuple{})) {
+		for _, child := range pat.children {
+			if !(frontCheckPatternIrrefutable(file, child)) {
+				return false
+			}
+		}
+		return true
+	}
 	// Osty: /tmp/selfhost_merged.osty:12737:5
-	if !ostyEqual(pat.kind, AstNodeKind(&AstNodeKind_AstNPattern{})) {
+	kind := frontCheckPatternKind(pat)
+	_ = kind
+	// Osty: /tmp/selfhost_merged.osty:12738:5
+	if kind == "" {
 		// Osty: /tmp/selfhost_merged.osty:12738:9
 		return true
 	}
 	// Osty: /tmp/selfhost_merged.osty:12740:5
-	if frontCheckPatternKind(pat) == "wildcard" {
+	if kind == "wildcard" {
 		// Osty: /tmp/selfhost_merged.osty:12741:9
 		return true
 	}
@@ -32000,7 +32011,7 @@ func frontCheckPatternIrrefutable(file *AstFile, patIdx int) bool {
 		return true
 	}
 	// Osty: /tmp/selfhost_merged.osty:12746:5
-	if frontCheckPatternKind(pat) == "tuple" {
+	if kind == "tuple" {
 		// Osty: /tmp/selfhost_merged.osty:12747:9
 		for _, child := range pat.children {
 			// Osty: /tmp/selfhost_merged.osty:12748:13
@@ -32013,7 +32024,7 @@ func frontCheckPatternIrrefutable(file *AstFile, patIdx int) bool {
 		return true
 	}
 	// Osty: /tmp/selfhost_merged.osty:12754:5
-	if frontCheckPatternKind(pat) == "struct" {
+	if kind == "struct" {
 		// Osty: /tmp/selfhost_merged.osty:12755:9
 		for _, fieldIdx := range pat.children {
 			// Osty: /tmp/selfhost_merged.osty:12756:13
@@ -32056,8 +32067,32 @@ func frontCheckBindPattern(file *AstFile, env *FrontCheckEnv, patIdx int, typeNa
 		// Osty: /tmp/selfhost_merged.osty:12778:9
 		return
 	}
+	if ostyEqual(pat.kind, AstNodeKind(&AstNodeKind_AstNTuple{})) {
+		elems := frontCheckTupleElems(typeName)
+		_ = elems
+		i := 0
+		_ = i
+		for _, child := range pat.children {
+			frontCheckBindPattern(file, env, child, frontCheckStringAt(elems, i), mutable)
+			func() {
+				var _cur2196 int = i
+				var _rhs2197 int = 1
+				if _rhs2197 > 0 && _cur2196 > math.MaxInt-_rhs2197 {
+					panic("integer overflow")
+				}
+				if _rhs2197 < 0 && _cur2196 < math.MinInt-_rhs2197 {
+					panic("integer overflow")
+				}
+				i = _cur2196 + _rhs2197
+			}()
+		}
+		return
+	}
 	// Osty: /tmp/selfhost_merged.osty:12780:5
-	if !ostyEqual(pat.kind, AstNodeKind(&AstNodeKind_AstNPattern{})) {
+	kind := frontCheckPatternKind(pat)
+	_ = kind
+	// Osty: /tmp/selfhost_merged.osty:12781:5
+	if kind == "" {
 		// Osty: /tmp/selfhost_merged.osty:12781:9
 		return
 	}
@@ -32069,7 +32104,7 @@ func frontCheckBindPattern(file *AstFile, env *FrontCheckEnv, patIdx int, typeNa
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12787:5
-	if frontCheckPatternKind(pat) == "tuple" {
+	if kind == "tuple" {
 		// Osty: /tmp/selfhost_merged.osty:12788:9
 		elems := frontCheckTupleElems(typeName)
 		_ = elems
@@ -32143,8 +32178,47 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 	// Osty: /tmp/selfhost_merged.osty:12815:5
 	pat := astArenaNodeAt(file.arena, patIdx)
 	_ = pat
+	if ostyEqual(pat.kind, AstNodeKind(&AstNodeKind_AstNTuple{})) {
+		scrutineeResolved := frontCheckResolveAliasesDeep(env, scrutineeType)
+		_ = scrutineeResolved
+		elems := frontCheckTupleElems(scrutineeResolved)
+		_ = elems
+		if frontCheckStringCount(elems) != frontCheckIntCount(pat.children) {
+			env.errors = func() int {
+				var _p2208 int = env.errors
+				var _rhs2209 int = 1
+				if _rhs2209 > 0 && _p2208 > math.MaxInt-_rhs2209 {
+					panic("integer overflow")
+				}
+				if _rhs2209 < 0 && _p2208 < math.MinInt-_rhs2209 {
+					panic("integer overflow")
+				}
+				return _p2208 + _rhs2209
+			}()
+		}
+		i := 0
+		_ = i
+		for _, child := range pat.children {
+			frontCheckPatternCompatible(file, env, child, frontCheckStringAt(elems, i))
+			func() {
+				var _cur2210 int = i
+				var _rhs2211 int = 1
+				if _rhs2211 > 0 && _cur2210 > math.MaxInt-_rhs2211 {
+					panic("integer overflow")
+				}
+				if _rhs2211 < 0 && _cur2210 < math.MinInt-_rhs2211 {
+					panic("integer overflow")
+				}
+				i = _cur2210 + _rhs2211
+			}()
+		}
+		return
+	}
 	// Osty: /tmp/selfhost_merged.osty:12816:5
-	if !ostyEqual(pat.kind, AstNodeKind(&AstNodeKind_AstNPattern{})) {
+	kind := frontCheckPatternKind(pat)
+	_ = kind
+	// Osty: /tmp/selfhost_merged.osty:12817:5
+	if kind == "" {
 		// Osty: /tmp/selfhost_merged.osty:12817:9
 		return
 	}
@@ -32152,7 +32226,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 	scrutineeResolved := frontCheckResolveAliasesDeep(env, scrutineeType)
 	_ = scrutineeResolved
 	// Osty: /tmp/selfhost_merged.osty:12820:5
-	if frontCheckPatternKind(pat) == "wildcard" {
+	if kind == "wildcard" {
 		// Osty: /tmp/selfhost_merged.osty:12821:9
 		return
 	}
@@ -32164,7 +32238,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12827:5
-	if frontCheckPatternKind(pat) == "literal" {
+	if kind == "literal" {
 		// Osty: /tmp/selfhost_merged.osty:12828:9
 		litType := frontCheckPatternLiteralType(pat)
 		_ = litType
@@ -32187,7 +32261,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12834:5
-	if frontCheckPatternKind(pat) == "negLiteral" {
+	if kind == "negLiteral" {
 		// Osty: /tmp/selfhost_merged.osty:12835:9
 		inner := astArenaNodeAt(file.arena, pat.left)
 		_ = inner
@@ -32230,7 +32304,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12846:5
-	if frontCheckPatternKind(pat) == "range" {
+	if kind == "range" {
 		// Osty: /tmp/selfhost_merged.osty:12847:9
 		if !(frontCheckIsOrdered(scrutineeResolved)) {
 			// Osty: /tmp/selfhost_merged.osty:12848:16
@@ -32259,7 +32333,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12857:5
-	if frontCheckPatternKind(pat) == "tuple" {
+	if kind == "tuple" {
 		// Osty: /tmp/selfhost_merged.osty:12858:9
 		elems := frontCheckTupleElems(scrutineeResolved)
 		_ = elems
@@ -32350,7 +32424,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12883:5
-	if frontCheckPatternKind(pat) == "struct" {
+	if kind == "struct" {
 		// Osty: /tmp/selfhost_merged.osty:12884:9
 		structName := frontCheckPatternName(pat)
 		_ = structName
@@ -32414,7 +32488,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		return
 	}
 	// Osty: /tmp/selfhost_merged.osty:12906:5
-	if frontCheckPatternKind(pat) == "or" {
+	if kind == "or" {
 		// Osty: /tmp/selfhost_merged.osty:12907:9
 		mark := frontCheckBindingCount(env.bindings)
 		_ = mark
@@ -32918,13 +32992,18 @@ func frontCheckStdMethodCall(file *AstFile, env *FrontCheckEnv, callee *AstNode,
 		return frontCheckMapMethod(file, env, receiver, name, args)
 	}
 	// Osty: /tmp/selfhost_merged.osty:13117:5
-	if head == "Option" {
+	if head == "Set" {
 		// Osty: /tmp/selfhost_merged.osty:13118:9
-		return frontCheckOptionMethod(file, env, receiver, name, args)
+		return frontCheckSetMethod(file, env, receiver, name, args)
 	}
 	// Osty: /tmp/selfhost_merged.osty:13120:5
-	if head == "Result" {
+	if head == "Option" {
 		// Osty: /tmp/selfhost_merged.osty:13121:9
+		return frontCheckOptionMethod(file, env, receiver, name, args)
+	}
+	// Osty: /tmp/selfhost_merged.osty:13123:5
+	if head == "Result" {
+		// Osty: /tmp/selfhost_merged.osty:13124:9
 		return frontCheckResultMethod(file, env, receiver, name, args)
 	}
 	// Osty: /tmp/selfhost_merged.osty:13123:5
@@ -33049,10 +33128,28 @@ func frontCheckListMethod(file *AstFile, env *FrontCheckEnv, callee *AstNode, re
 		// Osty: /tmp/selfhost_merged.osty:13189:9
 		return acc
 	}
+	// Osty: /tmp/selfhost_merged.osty:13191:5
+	if name == "sorted" {
+		// Osty: /tmp/selfhost_merged.osty:13192:9
+		frontCheckExpectArgCount(env, args, 0)
+		// Osty: /tmp/selfhost_merged.osty:13193:9
+		return recvType
+	}
+	// Osty: /tmp/selfhost_merged.osty:13195:5
+	if name == "toSet" {
+		// Osty: /tmp/selfhost_merged.osty:13196:9
+		frontCheckExpectArgCount(env, args, 0)
+		// Osty: /tmp/selfhost_merged.osty:13197:9
+		return frontCheckOneArgType("Set", elem)
+	}
+	if name == "clear" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "()"
+	}
 	return "Invalid"
 }
 
-// Osty: /tmp/selfhost_merged.osty:13194:1
+// Osty: /tmp/selfhost_merged.osty:13201:1
 func frontCheckMapMethod(file *AstFile, env *FrontCheckEnv, recvType string, name string, args []int) string {
 	// Osty: /tmp/selfhost_merged.osty:13195:5
 	key := frontCheckGenericArgAt(recvType, 0)
@@ -33117,10 +33214,74 @@ func frontCheckMapMethod(file *AstFile, env *FrontCheckEnv, recvType string, nam
 		// Osty: /tmp/selfhost_merged.osty:13227:9
 		return frontCheckOneArgType("List", val)
 	}
+	if name == "clear" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "()"
+	}
 	return "Invalid"
 }
 
-// Osty: /tmp/selfhost_merged.osty:13232:1
+// Osty: /tmp/selfhost_merged.osty:13239:1
+func frontCheckSetMethod(file *AstFile, env *FrontCheckEnv, recvType string, name string, args []int) string {
+	// Osty: /tmp/selfhost_merged.osty:13240:5
+	elem := frontCheckGenericArgAt(recvType, 0)
+	_ = elem
+	// Osty: /tmp/selfhost_merged.osty:13241:5
+	if name == "len" {
+		// Osty: /tmp/selfhost_merged.osty:13242:9
+		frontCheckExpectArgCount(env, args, 0)
+		// Osty: /tmp/selfhost_merged.osty:13243:9
+		return "Int"
+	}
+	// Osty: /tmp/selfhost_merged.osty:13245:5
+	if name == "isEmpty" {
+		// Osty: /tmp/selfhost_merged.osty:13246:9
+		frontCheckExpectArgCount(env, args, 0)
+		// Osty: /tmp/selfhost_merged.osty:13247:9
+		return "Bool"
+	}
+	// Osty: /tmp/selfhost_merged.osty:13249:5
+	if name == "contains" {
+		// Osty: /tmp/selfhost_merged.osty:13250:9
+		frontCheckExpectArgCount(env, args, 1)
+		// Osty: /tmp/selfhost_merged.osty:13251:9
+		frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
+		// Osty: /tmp/selfhost_merged.osty:13252:9
+		return "Bool"
+	}
+	// Osty: /tmp/selfhost_merged.osty:13254:5
+	if name == "insert" {
+		// Osty: /tmp/selfhost_merged.osty:13255:9
+		frontCheckExpectArgCount(env, args, 1)
+		// Osty: /tmp/selfhost_merged.osty:13256:9
+		frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
+		// Osty: /tmp/selfhost_merged.osty:13257:9
+		return "()"
+	}
+	// Osty: /tmp/selfhost_merged.osty:13259:5
+	if name == "remove" {
+		// Osty: /tmp/selfhost_merged.osty:13260:9
+		frontCheckExpectArgCount(env, args, 1)
+		// Osty: /tmp/selfhost_merged.osty:13261:9
+		frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
+		// Osty: /tmp/selfhost_merged.osty:13262:9
+		return "Bool"
+	}
+	// Osty: /tmp/selfhost_merged.osty:13264:5
+	if name == "toList" {
+		// Osty: /tmp/selfhost_merged.osty:13265:9
+		frontCheckExpectArgCount(env, args, 0)
+		// Osty: /tmp/selfhost_merged.osty:13266:9
+		return frontCheckOneArgType("List", elem)
+	}
+	if name == "clear" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "()"
+	}
+	return "Invalid"
+}
+
+// Osty: /tmp/selfhost_merged.osty:13271:1
 func frontCheckOptionMethod(file *AstFile, env *FrontCheckEnv, recvType string, name string, args []int) string {
 	// Osty: /tmp/selfhost_merged.osty:13233:5
 	elem := frontCheckGenericArgAt(recvType, 0)


### PR DESCRIPTION
## Summary
- teach the selfhost checker enough collection and tuple-pattern surface for examples/gc to pass native checking
- lower struct receiver methods in llvmgen, including mut-self writeback via receiver slots and direct field assignment
- add llvmgen and clang-backed backend tests for receiver methods and enum-typed struct fields

## Verification
- go test ./internal/check ./cmd/osty-native-checker ./internal/llvmgen ./internal/backend
- OSTY_NATIVE_CHECKER_BIN=/tmp/osty-native-checker-dev go run ./cmd/osty gen --backend llvm --emit llvm-ir examples/gc/lib.osty
  - now advances past method rejection and stops at MapExpr lowering
