### PR TITLE
Add LLVM lowering for bitwise Int ops

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -374,3 +374,30 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryRunsBitwiseIntOps(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    println(~-43)
+    println((1 << 5) | (1 << 3) | 2)
+    println((255 >> 2) ^ 21)
+    println(58 & 43)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "42\n42\n42\n42\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/bitwise_test.go
+++ b/internal/llvmgen/bitwise_test.go
@@ -1,0 +1,37 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateBitwiseIntOps(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    println(~-43)
+    println((1 << 5) | (1 << 3) | 2)
+    println((255 >> 2) ^ 21)
+    println(58 & 43)
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/bitwise_int_ops.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"xor i64",
+		"shl i64",
+		"or i64",
+		"ashr i64",
+		"and i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1795,6 +1795,14 @@ func (g *generator) emitUnary(e *ast.UnaryExpr) (value, error) {
 		out := llvmNotI1(emitter, toOstyValue(v))
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), nil
+	case token.BITNOT:
+		if v.typ != "i64" {
+			return value{}, unsupportedf("type-system", "bitwise not on %s", v.typ)
+		}
+		emitter := g.toOstyEmitter()
+		out := llvmBinaryI64(emitter, "xor", toOstyValue(v), llvmIntLiteral(-1))
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), nil
 	default:
 		return value{}, unsupportedf("expression", "unary operator %q", e.Op)
 	}

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -83,6 +83,21 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if got, want := llvmIntBinaryInstruction("%"), "srem"; got != want {
 		t.Fatalf("llvmIntBinaryInstruction(%q) = %q, want %q", "%", got, want)
 	}
+	if got, want := llvmIntBinaryInstruction("&"), "and"; got != want {
+		t.Fatalf("llvmIntBinaryInstruction(%q) = %q, want %q", "&", got, want)
+	}
+	if got, want := llvmIntBinaryInstruction("|"), "or"; got != want {
+		t.Fatalf("llvmIntBinaryInstruction(%q) = %q, want %q", "|", got, want)
+	}
+	if got, want := llvmIntBinaryInstruction("^"), "xor"; got != want {
+		t.Fatalf("llvmIntBinaryInstruction(%q) = %q, want %q", "^", got, want)
+	}
+	if got, want := llvmIntBinaryInstruction("<<"), "shl"; got != want {
+		t.Fatalf("llvmIntBinaryInstruction(%q) = %q, want %q", "<<", got, want)
+	}
+	if got, want := llvmIntBinaryInstruction(">>"), "ashr"; got != want {
+		t.Fatalf("llvmIntBinaryInstruction(%q) = %q, want %q", ">>", got, want)
+	}
 	if got, want := llvmFloatBinaryInstruction("/"), "fdiv"; got != want {
 		t.Fatalf("llvmFloatBinaryInstruction(%q) = %q, want %q", "/", got, want)
 	}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1191,6 +1191,16 @@ func llvmIntBinaryInstruction(op string) string {
 		return "sdiv"
 	case "%":
 		return "srem"
+	case "&":
+		return "and"
+	case "|":
+		return "or"
+	case "^":
+		return "xor"
+	case "<<":
+		return "shl"
+	case ">>":
+		return "ashr"
 	default:
 		return ""
 	}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -961,6 +961,21 @@ pub fn llvmIntBinaryInstruction(op: String) -> String {
     if op == "%" {
         return "srem"
     }
+    if op == "&" {
+        return "and"
+    }
+    if op == "|" {
+        return "or"
+    }
+    if op == "^" {
+        return "xor"
+    }
+    if op == "<<" {
+        return "shl"
+    }
+    if op == ">>" {
+        return "ashr"
+    }
     ""
 }
 


### PR DESCRIPTION
## Summary
- add LLVM lowering for Int bitwise operators `&`, `|`, `^`, `<<`, and `>>`
- lower unary bitwise not `~` through the existing LLVM integer instruction path
- add IR and native backend tests covering bitwise expressions end-to-end

## Testing
- go test ./internal/llvmgen/...
- go test ./internal/backend/...