### PR TITLE
Trace managed aggregate list elements in LLVM runtime

### DIFF
--- a/cmd/osty/test_native_test.go
+++ b/cmd/osty/test_native_test.go
@@ -178,6 +178,51 @@ fn benchClampHotPath() {
 	}
 }
 
+func TestRunTestMainPassesNativeLLVMManagedAggregateListTests(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib.osty", `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+pub struct Bucket {
+    items: List<String>,
+}
+
+pub fn bucketLen(bucket: Bucket) -> Int {
+    bucket.items.len()
+}
+`)
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing
+use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+fn testManagedAggregateList() {
+    let buckets = [
+        Bucket { items: strings.Split("gc,llvm", ",") },
+    ]
+    for bucket in buckets {
+        testing.assertEq(bucketLen(bucket), 2)
+    }
+}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTestMain() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "ok\ttestManagedAggregateList") || !strings.Contains(got, "ok\t1 tests passed") {
+		t.Fatalf("stdout = %q, want managed-aggregate passing test summary", got)
+	}
+	if got := stderr.String(); strings.TrimSpace(got) != "" {
+		t.Fatalf("stderr = %q, want empty stderr", got)
+	}
+}
+
 func requireClangForNativeTest(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("clang"); err != nil {

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -312,3 +312,74 @@ int main(void) {
 		t.Fatalf("runtime pressure list harness stdout = %q, want %q", got, want)
 	}
 }
+
+func TestBundledRuntimeTracesManagedAggregateListElements(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_aggregate_list_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_aggregate_list_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+typedef struct Box {
+    void *child;
+} Box;
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
+void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
+
+void osty_gc_debug_collect(void);
+int64_t osty_gc_debug_live_count(void);
+void *osty_rt_list_new(void);
+void osty_rt_list_push_bytes_roots_v1(void *list, const void *value, int64_t elem_size, const int64_t *gc_offsets, int64_t gc_offset_count);
+void osty_rt_list_get_bytes_v1(void *list, int64_t index, void *out, int64_t elem_size);
+
+int main(void) {
+    void *list = osty_rt_list_new();
+    void *child = osty_gc_alloc_v1(8, 16, "child");
+    void *saved_child = child;
+    int64_t offsets[1] = { 0 };
+    Box box = { child };
+    Box loaded = { 0 };
+
+    osty_rt_list_push_bytes_roots_v1(list, &box, (int64_t)sizeof(box), offsets, 1);
+    osty_gc_root_bind_v1(list);
+    osty_gc_debug_collect();
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+    osty_rt_list_get_bytes_v1(list, 0, &loaded, (int64_t)sizeof(loaded));
+    printf("%d\n", loaded.child == saved_child);
+    osty_gc_root_release_v1(list);
+    osty_gc_debug_collect();
+    printf("%lld\n", (long long)osty_gc_debug_live_count());
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "2\n1\n0\n"; got != want {
+		t.Fatalf("runtime aggregate list harness stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -130,6 +130,7 @@ func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
 	for _, want := range []string{
 		"osty_rt_list_new",
 		"osty_rt_list_push_bytes_v1",
+		"osty_rt_list_push_bytes_roots_v1",
 		"osty_rt_list_get_bytes_v1",
 		"osty_rt_strings_Equal",
 		"osty.gc.pre_write_v1",

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -27,6 +27,8 @@ typedef struct osty_rt_list {
     int64_t cap;
     size_t elem_size;
     bool pointer_elems;
+    int64_t gc_offset_count;
+    int64_t *gc_offsets;
     unsigned char *data;
 } osty_rt_list;
 
@@ -170,15 +172,32 @@ static void osty_gc_mark_payload(void *payload);
 static void osty_rt_list_trace(void *payload) {
     osty_rt_list *list = (osty_rt_list *)payload;
     int64_t i;
+    int64_t j;
 
-    if (list == NULL || !list->pointer_elems || list->data == NULL) {
+    if (list == NULL || list->data == NULL) {
+        return;
+    }
+    if (list->pointer_elems) {
+        for (i = 0; i < list->len; i++) {
+            void *child = NULL;
+            memcpy(&child, list->data + ((size_t)i * list->elem_size), sizeof(child));
+            if (child != NULL) {
+                osty_gc_mark_payload(child);
+            }
+        }
+        return;
+    }
+    if (list->gc_offset_count <= 0 || list->gc_offsets == NULL) {
         return;
     }
     for (i = 0; i < list->len; i++) {
-        void *child = NULL;
-        memcpy(&child, list->data + ((size_t)i * list->elem_size), sizeof(child));
-        if (child != NULL) {
-            osty_gc_mark_payload(child);
+        unsigned char *elem = list->data + ((size_t)i * list->elem_size);
+        for (j = 0; j < list->gc_offset_count; j++) {
+            void *child = NULL;
+            memcpy(&child, elem + (size_t)list->gc_offsets[j], sizeof(child));
+            if (child != NULL) {
+                osty_gc_mark_payload(child);
+            }
         }
     }
 }
@@ -186,6 +205,7 @@ static void osty_rt_list_trace(void *payload) {
 static void osty_rt_list_destroy(void *payload) {
     osty_rt_list *list = (osty_rt_list *)payload;
     if (list != NULL) {
+        free(list->gc_offsets);
         free(list->data);
     }
 }
@@ -294,6 +314,51 @@ static void osty_rt_list_ensure_layout(osty_rt_list *list, size_t elem_size, boo
     }
 }
 
+static void osty_rt_list_ensure_gc_offsets(osty_rt_list *list, const int64_t *gc_offsets, int64_t gc_offset_count) {
+    int64_t i;
+
+    if (gc_offset_count < 0) {
+        osty_rt_abort("negative list GC offset count");
+    }
+    if (gc_offset_count == 0) {
+        if (list->gc_offset_count != 0) {
+            osty_rt_abort("list GC offset count mismatch");
+        }
+        return;
+    }
+    if (gc_offsets == NULL) {
+        osty_rt_abort("list GC offsets pointer is null");
+    }
+    if (list->pointer_elems) {
+        osty_rt_abort("list pointer elements cannot also use GC offsets");
+    }
+    if (list->elem_size < sizeof(void *)) {
+        osty_rt_abort("list element size too small for GC offsets");
+    }
+    if (list->gc_offset_count == 0) {
+        list->gc_offsets = (int64_t *)malloc((size_t)gc_offset_count * sizeof(int64_t));
+        if (list->gc_offsets == NULL) {
+            osty_rt_abort("out of memory");
+        }
+        for (i = 0; i < gc_offset_count; i++) {
+            if (gc_offsets[i] < 0 || (size_t)gc_offsets[i] > list->elem_size - sizeof(void *)) {
+                osty_rt_abort("list GC offset out of range");
+            }
+            list->gc_offsets[i] = gc_offsets[i];
+        }
+        list->gc_offset_count = gc_offset_count;
+        return;
+    }
+    if (list->gc_offset_count != gc_offset_count) {
+        osty_rt_abort("list GC offset count mismatch");
+    }
+    for (i = 0; i < gc_offset_count; i++) {
+        if (list->gc_offsets[i] != gc_offsets[i]) {
+            osty_rt_abort("list GC offsets mismatch");
+        }
+    }
+}
+
 static void osty_rt_list_reserve(osty_rt_list *list, int64_t min_cap) {
     int64_t next_cap = list->cap;
     void *next_data;
@@ -380,10 +445,35 @@ void osty_rt_list_push_ptr(void *raw_list, void *value) {
 }
 
 void osty_rt_list_push_bytes_v1(void *raw_list, const void *value, int64_t elem_size) {
+    osty_rt_list *list;
+
     if (elem_size < 0) {
         osty_rt_abort("negative list element size");
     }
+    list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, (size_t)elem_size, false);
+    osty_rt_list_ensure_gc_offsets(list, NULL, 0);
     osty_rt_list_push_bytes(raw_list, value, (size_t)elem_size, false);
+}
+
+void osty_rt_list_push_bytes_roots_v1(void *raw_list, const void *value, int64_t elem_size, const int64_t *gc_offsets, int64_t gc_offset_count) {
+    osty_rt_list *list;
+    int64_t i;
+
+    if (elem_size < 0) {
+        osty_rt_abort("negative list element size");
+    }
+    list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, (size_t)elem_size, false);
+    osty_rt_list_ensure_gc_offsets(list, gc_offsets, gc_offset_count);
+    osty_rt_list_push_bytes(raw_list, value, (size_t)elem_size, false);
+    for (i = 0; i < gc_offset_count; i++) {
+        void *child = NULL;
+        memcpy(&child, ((const unsigned char *)value) + (size_t)gc_offsets[i], sizeof(child));
+        if (child != NULL) {
+            osty_gc_post_write_v1(raw_list, child, OSTY_GC_KIND_LIST);
+        }
+    }
 }
 
 int64_t osty_rt_list_get_i64(void *raw_list, int64_t index) {

--- a/internal/llvmgen/gc_integration_test.go
+++ b/internal/llvmgen/gc_integration_test.go
@@ -171,3 +171,43 @@ fn main() {
 		}
 	}
 }
+
+func TestGenerateManagedAggregateListsTraceNestedRoots(t *testing.T) {
+	file := parseLLVMGenFile(t, `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+struct Bucket {
+    items: List<String>
+}
+
+fn main() {
+    let buckets = [
+        Bucket { items: strings.Split("gc,llvm", ",") },
+    ]
+    for bucket in buckets {
+        println(bucket.items.len())
+    }
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/managed_aggregate_list_gc.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare void @osty_rt_list_push_bytes_roots_v1(ptr, ptr, i64, ptr, i64)",
+		"call void @osty_rt_list_push_bytes_roots_v1(",
+		"getelementptr inbounds %Bucket, ptr null, i32 0, i32 0",
+		"call void @osty_rt_list_get_bytes_v1(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -1854,6 +1854,7 @@ func (g *generator) emitTestingExpect(call *ast.CallExpr, wantErr bool) (value, 
 	payload := llvmExtractValue(emitter, toOstyValue(result), payloadType, payloadIndex)
 	g.takeOstyEmitter(emitter)
 	out := fromOstyValue(payload)
+	out.gcManaged = payloadType == "ptr"
 	out.rootPaths = g.rootPathsForType(out.typ)
 	return out, nil
 }
@@ -2339,7 +2340,7 @@ func (g *generator) emitFieldExpr(expr *ast.FieldExpr) (value, error) {
 	g.takeOstyEmitter(emitter)
 	loaded := fromOstyValue(out)
 	loaded.listElemTyp = field.listElemTyp
-	loaded.gcManaged = field.listElemTyp != ""
+	loaded.gcManaged = field.typ == "ptr" || field.listElemTyp != ""
 	loaded.rootPaths = g.rootPathsForType(field.typ)
 	return loaded, nil
 }
@@ -2685,8 +2686,8 @@ func (g *generator) emitIfExprPhi(labels *LlvmIfLabels, thenPred, elsePred strin
 	out := value{typ: thenValue.typ, ref: tmp}
 	if thenValue.listElemTyp != "" && thenValue.listElemTyp == elseValue.listElemTyp {
 		out.listElemTyp = thenValue.listElemTyp
-		out.gcManaged = thenValue.gcManaged || elseValue.gcManaged
 	}
+	out.gcManaged = out.typ == "ptr" || thenValue.gcManaged || elseValue.gcManaged
 	out.rootPaths = g.rootPathsForType(out.typ)
 	return out, nil
 }
@@ -3044,8 +3045,8 @@ func (g *generator) emitSelectValue(cond *LlvmValue, thenValue, elseValue value)
 	out := value{typ: thenValue.typ, ref: tmp}
 	if thenValue.listElemTyp != "" && thenValue.listElemTyp == elseValue.listElemTyp {
 		out.listElemTyp = thenValue.listElemTyp
-		out.gcManaged = thenValue.gcManaged || elseValue.gcManaged
 	}
+	out.gcManaged = out.typ == "ptr" || thenValue.gcManaged || elseValue.gcManaged
 	out.rootPaths = g.rootPathsForType(out.typ)
 	return out, nil
 }
@@ -3062,7 +3063,7 @@ func (g *generator) usesAggregateListABI(elemTyp string) bool {
 	case "", "i64", "i1", "double", "ptr":
 		return false
 	}
-	return len(g.rootPathsForType(elemTyp)) == 0
+	return true
 }
 
 func (g *generator) emitAggregateByteSize(emitter *LlvmEmitter, typ string) value {
@@ -3080,27 +3081,67 @@ func (g *generator) emitAggregateScratchSlot(emitter *LlvmEmitter, typ, initial 
 	return value{typ: typ, ref: slot, ptr: true}
 }
 
-func (g *generator) emitListAggregatePush(listValue, elem value) error {
-	if len(g.rootPathsForType(elem.typ)) != 0 {
-		return unsupportedf("type-system", "list element type %s with managed aggregate fields", elem.typ)
+func (g *generator) emitAggregateRootOffsets(emitter *LlvmEmitter, typ string) (value, int, error) {
+	paths := g.rootPathsForType(typ)
+	if len(paths) == 0 {
+		return value{typ: "ptr", ref: "null"}, 0, nil
 	}
-	g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
+	arrayTyp := fmt.Sprintf("[%d x i64]", len(paths))
+	arrayPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", arrayPtr, arrayTyp))
+	for i, path := range paths {
+		offsetPtr := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  %s = getelementptr inbounds %s, ptr null, %s",
+			offsetPtr,
+			typ,
+			llvmAggregatePathIndices(path),
+		))
+		offsetValue := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", offsetValue, offsetPtr))
+		slotPtr := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d", slotPtr, arrayTyp, arrayPtr, i))
+		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", offsetValue, slotPtr))
+	}
+	firstPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 0", firstPtr, arrayTyp, arrayPtr))
+	return value{typ: "ptr", ref: firstPtr}, len(paths), nil
+}
+
+func (g *generator) emitListAggregatePush(listValue, elem value) error {
 	emitter := g.toOstyEmitter()
 	slot := g.emitAggregateScratchSlot(emitter, elem.typ, elem.ref)
 	size := g.emitAggregateByteSize(emitter, elem.typ)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
-		listRuntimePushBytesSymbol(),
-		llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(value{typ: "ptr", ref: slot.ref}), toOstyValue(size)}),
-	))
+	offsetsPtr, offsetCount, err := g.emitAggregateRootOffsets(emitter, elem.typ)
+	if err != nil {
+		return err
+	}
+	if offsetCount == 0 {
+		g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimePushBytesSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(value{typ: "ptr", ref: slot.ref}), toOstyValue(size)}),
+		))
+	} else {
+		g.declareRuntimeSymbol(listRuntimePushBytesRootsSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimePushBytesRootsSymbol(),
+			llvmCallArgs([]*LlvmValue{
+				toOstyValue(listValue),
+				toOstyValue(value{typ: "ptr", ref: slot.ref}),
+				toOstyValue(size),
+				toOstyValue(offsetsPtr),
+				toOstyValue(value{typ: "i64", ref: strconv.Itoa(offsetCount)}),
+			}),
+		))
+	}
 	g.takeOstyEmitter(emitter)
 	return nil
 }
 
 func (g *generator) emitListAggregateGet(listValue value, index value, elemTyp string) (value, error) {
-	if len(g.rootPathsForType(elemTyp)) != 0 {
-		return value{}, unsupportedf("type-system", "list element type %s with managed aggregate fields", elemTyp)
-	}
 	g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
 	emitter := g.toOstyEmitter()
 	slot := g.emitAggregateScratchSlot(emitter, elemTyp, "zeroinitializer")
@@ -3142,9 +3183,6 @@ func (g *generator) emitListExprWithHint(expr *ast.ListExpr, hintedElemTyp strin
 		return value{}, unsupported("expression", "empty list literal requires an explicit List<T> type")
 	}
 	useAggregateABI := g.usesAggregateListABI(elemTyp)
-	if !useAggregateABI && elemTyp != "ptr" && elemTyp != "i64" && elemTyp != "i1" && elemTyp != "double" {
-		return value{}, unsupportedf("type-system", "list literal element type %s requires scalar tuples or primitive values", elemTyp)
-	}
 	g.declareRuntimeSymbol(listRuntimeNewSymbol(), "ptr", nil)
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", listRuntimeNewSymbol(), nil)
@@ -3249,9 +3287,6 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if g.usesAggregateListABI(elemTyp) {
 		return true, g.emitListAggregatePush(baseValue, argValue)
 	}
-	if elemTyp != "ptr" && elemTyp != "i64" && elemTyp != "i1" && elemTyp != "double" {
-		return true, unsupportedf("type-system", "list.push element type %s requires scalar tuples or primitive values", elemTyp)
-	}
 	pushSymbol := listRuntimePushSymbol(elemTyp)
 	g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
 	emitter = g.toOstyEmitter()
@@ -3275,9 +3310,6 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		return unsupportedf("type-system", "for-in iterable type %s", iterable.typ)
 	}
 	useAggregateABI := g.usesAggregateListABI(elemTyp)
-	if !useAggregateABI && elemTyp != "ptr" && elemTyp != "i64" && elemTyp != "i1" && elemTyp != "double" {
-		return unsupportedf("type-system", "for-in element type %s requires scalar tuples or primitive values", elemTyp)
-	}
 	iterable = g.protectManagedTemporary("for.iter", iterable)
 	g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
 	iterableValue, err := g.loadIfPointer(iterable)
@@ -3455,7 +3487,8 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 	g.takeOstyEmitter(emitter)
 	payloadValue := fromOstyValue(payload)
 	payloadValue.listElemTyp = pattern.payloadListElemTyp
-	payloadValue.gcManaged = pattern.payloadListElemTyp != ""
+	payloadValue.gcManaged = pattern.payloadType == "ptr" || pattern.payloadListElemTyp != ""
+	payloadValue.rootPaths = g.rootPathsForType(pattern.payloadType)
 	g.bindNamedLocal(pattern.payloadName, payloadValue, false)
 	return nil
 }
@@ -3610,7 +3643,7 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	g.popScope()
 	ret := fromOstyValue(out)
 	ret.listElemTyp = sig.retListElemTyp
-	ret.gcManaged = sig.retListElemTyp != ""
+	ret.gcManaged = sig.ret == "ptr" || sig.retListElemTyp != ""
 	ret.rootPaths = g.rootPathsForType(sig.ret)
 	return ret, nil
 }
@@ -3717,7 +3750,7 @@ func (g *generator) emitRuntimeFFICall(call *ast.CallExpr) (value, bool, error) 
 	g.popScope()
 	ret := fromOstyValue(out)
 	ret.listElemTyp = fn.listElemTyp
-	ret.gcManaged = fn.listElemTyp != ""
+	ret.gcManaged = fn.ret == "ptr" || fn.listElemTyp != ""
 	ret.rootPaths = g.rootPathsForType(fn.ret)
 	return ret, true, nil
 }
@@ -4553,8 +4586,8 @@ func (g *generator) extractTupleElement(tuple value, info tupleTypeInfo, index i
 	elem := fromOstyValue(out)
 	if index < len(info.elemListElemTyps) && info.elemListElemTyps[index] != "" {
 		elem.listElemTyp = info.elemListElemTyps[index]
-		elem.gcManaged = true
 	}
+	elem.gcManaged = info.elems[index] == "ptr" || elem.listElemTyp != ""
 	elem.rootPaths = g.rootPathsForType(info.elems[index])
 	return elem, nil
 }
@@ -4700,6 +4733,10 @@ func listRuntimePushBytesSymbol() string {
 	return "osty_rt_list_push_bytes_v1"
 }
 
+func listRuntimePushBytesRootsSymbol() string {
+	return "osty_rt_list_push_bytes_roots_v1"
+}
+
 func listRuntimeGetBytesSymbol() string {
 	return "osty_rt_list_get_bytes_v1"
 }
@@ -4732,6 +4769,15 @@ func listRuntimeSymbolSuffix(typ string) string {
 		return "ptr"
 	}
 	return b.String()
+}
+
+func llvmAggregatePathIndices(path []int) string {
+	parts := make([]string, 0, len(path)+1)
+	parts = append(parts, "i32 0")
+	for _, index := range path {
+		parts = append(parts, fmt.Sprintf("i32 %d", index))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func llvmType(t ast.Type, structs map[string]*structInfo, enums map[string]*enumInfo) (string, error) {


### PR DESCRIPTION
## Summary
- trace managed aggregate list element roots inside the bundled LLVM runtime
- wire llvmgen aggregate-list lowering to pass GC root offsets for nested managed fields
- add llvmgen, runtime harness, and native osty test regressions for managed aggregate lists

## Testing
- go test ./internal/llvmgen ./internal/backend ./cmd/osty -count=1
- go run ./cmd/osty test examples/calc
- git diff --check