### PR TITLE
Move LLVM backend entrypoint to lowered IR

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -455,20 +455,19 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 		}
 	}
 	selectedBackend := backendFromCLI("build", backendID)
+	entry, err := backend.PrepareEntry("main", entryAbs, entryFile.File, res, chk)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
+		os.Exit(1)
+	}
 	emitResult, err := selectedBackend.Emit(context.Background(), backend.Request{
 		Layout: backend.Layout{
 			Root:    root,
 			Profile: profileName,
 			Target:  triple,
 		},
-		Emit: emitMode,
-		Entry: backend.Entry{
-			PackageName: "main",
-			SourcePath:  entryAbs,
-			File:        entryFile.File,
-			Resolve:     res,
-			Check:       chk,
-		},
+		Emit:       emitMode,
+		Entry:      entry,
 		BinaryName: binName,
 		Features:   resolved.Features,
 	})

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1466,20 +1466,18 @@ func emitGenArtifact(name backend.Name, mode backend.EmitMode, pkgName, sourcePa
 		return nil, nil, err
 	}
 	defer os.RemoveAll(tmpRoot)
+	entry, err := backend.PrepareEntry(pkgName, sourcePath, file, res, chk)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	result, emitErr := b.Emit(context.Background(), backend.Request{
 		Layout: backend.Layout{
 			Root:    tmpRoot,
 			Profile: "gen",
 		},
-		Emit: mode,
-		Entry: backend.Entry{
-			PackageName: pkgName,
-			SourcePath:  sourcePath,
-			File:        file,
-			Resolve:     res,
-			Check:       chk,
-		},
+		Emit:  mode,
+		Entry: entry,
 	})
 	if result == nil {
 		return nil, nil, emitErr

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -190,20 +190,19 @@ func runRun(args []string, cliF cliFlags) {
 		binName += ".exe"
 	}
 	selectedBackend := backendFromCLI("run", backendID)
+	backendEntry, err := backend.PrepareEntry("main", entryAbs, file, res, chk)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
+		os.Exit(1)
+	}
 	emitResult, err := selectedBackend.Emit(context.Background(), backend.Request{
 		Layout: backend.Layout{
 			Root:    root,
 			Profile: resolved.Profile.Name,
 			Target:  triple,
 		},
-		Emit: emitMode,
-		Entry: backend.Entry{
-			PackageName: "main",
-			SourcePath:  entryAbs,
-			File:        file,
-			Resolve:     res,
-			Check:       chk,
-		},
+		Emit:       emitMode,
+		Entry:      backendEntry,
 		BinaryName: binName,
 		Features:   resolved.Features,
 	})

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
 )
@@ -220,23 +221,25 @@ type nativeTestRun struct {
 }
 
 func compileAndRunNativeTest(ctx context.Context, b backend.Backend, emitMode backend.EmitMode, tmpRoot string, pkg *resolve.Package, tc nativeTestCase) (nativeTestRun, error) {
-	file, sourcePath, err := parseNativeTestEntry(pkg, tc)
+	file, src, sourcePath, err := parseNativeTestEntry(pkg, tc)
 	if err != nil {
 		return nativeTestRun{}, err
 	}
 	name := sanitizeNativeTestName(tc.Name)
 	layoutRoot := filepath.Join(tmpRoot, name)
+	res := resolveFile(file)
+	chk := check.File(file, res, checkOptsForSource(src))
+	entry, err := backend.PrepareEntry("main", sourcePath, file, res, chk)
+	if err != nil {
+		return nativeTestRun{}, err
+	}
 	req := backend.Request{
 		Layout: backend.Layout{
 			Root:    layoutRoot,
 			Profile: "test",
 		},
-		Emit: emitMode,
-		Entry: backend.Entry{
-			PackageName: "main",
-			SourcePath:  sourcePath,
-			File:        file,
-		},
+		Emit:       emitMode,
+		Entry:      entry,
 		BinaryName: name,
 	}
 	result, err := b.Emit(ctx, req)
@@ -246,9 +249,9 @@ func compileAndRunNativeTest(ctx context.Context, b backend.Backend, emitMode ba
 	return runNativeTestBinary(result.Artifacts.Binary)
 }
 
-func parseNativeTestEntry(pkg *resolve.Package, tc nativeTestCase) (*ast.File, string, error) {
+func parseNativeTestEntry(pkg *resolve.Package, tc nativeTestCase) (*ast.File, []byte, string, error) {
 	if pkg == nil {
-		return nil, "", fmt.Errorf("missing package")
+		return nil, nil, "", fmt.Errorf("missing package")
 	}
 	runnerPath := filepath.Join(pkg.Dir, "__osty_test_runner__.osty")
 	runner := []byte(fmt.Sprintf("fn main() {\n    %s()\n}\n", tc.Name))
@@ -261,15 +264,15 @@ func parseNativeTestEntry(pkg *resolve.Package, tc nativeTestCase) (*ast.File, s
 		Path:   runnerPath,
 		Source: runner,
 	})
-	file, _, err := parseGenEmitFile(testPkg)
+	file, src, err := parseGenEmitFile(testPkg)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", err
 	}
 	sourcePath := tc.Path
 	if sourcePath == "" {
 		sourcePath = runnerPath
 	}
-	return file, sourcePath, nil
+	return file, src, sourcePath, nil
 }
 
 func sanitizeNativeTestName(name string) string {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/resolve"
 )
 
@@ -117,6 +118,8 @@ type Entry struct {
 	File        *ast.File
 	Resolve     *resolve.Result
 	Check       *check.Result
+	IR          *ir.Module
+	IRIssues    []error
 }
 
 // Request is the backend-neutral build request shared by gen/build/run/test

--- a/internal/backend/backend_selfhostgen.go
+++ b/internal/backend/backend_selfhostgen.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/resolve"
 )
 
@@ -121,6 +122,8 @@ type Entry struct {
 	File        *ast.File
 	Resolve     *resolve.Result
 	Check       *check.Result
+	IR          *ir.Module
+	IRIssues    []error
 }
 
 // Request is the backend-neutral build request shared by gen/build/run/test

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -1,0 +1,35 @@
+package backend
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// PrepareEntry lowers a checked front-end source unit into the backend-neutral
+// IR contract. Validation failures are returned as an error because they
+// indicate a broken lowering contract rather than a user-visible backend gap.
+func PrepareEntry(packageName, sourcePath string, file *ast.File, res *resolve.Result, chk *check.Result) (Entry, error) {
+	entry := Entry{
+		PackageName: packageName,
+		SourcePath:  sourcePath,
+		File:        file,
+		Resolve:     res,
+		Check:       chk,
+	}
+	if file == nil {
+		return entry, fmt.Errorf("backend: nil source file")
+	}
+	mod, issues := ir.Lower(packageName, file, res, chk)
+	entry.IR = mod
+	entry.IRIssues = append(entry.IRIssues, issues...)
+	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
+		entry.IRIssues = append(entry.IRIssues, validateErrs...)
+		return entry, errors.Join(validateErrs...)
+	}
+	return entry, nil
+}

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -49,19 +49,36 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if artifacts.LLVMIR == "" {
 		return nil, fmt.Errorf("llvm backend: missing LLVM IR artifact path")
 	}
-	ir, genErr := llvmgen.Generate(req.Entry.File, llvmgen.Options{
+	if req.Entry.IR == nil {
+		return nil, fmt.Errorf("llvm backend: missing lowered IR entry")
+	}
+	opts := llvmgen.Options{
 		PackageName: req.Entry.PackageName,
 		SourcePath:  req.Entry.SourcePath,
 		Target:      req.Layout.Target,
-	})
+	}
+	irOut, genErr := llvmgen.GenerateModule(req.Entry.IR, opts)
+	var fallbackWarning error
+	if genErr != nil && req.Entry.File != nil && errors.Is(genErr, llvmgen.ErrUnsupported) {
+		bridgeErr := genErr
+		irOut, genErr = llvmgen.Generate(req.Entry.File, opts)
+		if genErr == nil {
+			fallbackWarning = fmt.Errorf("llvm backend: fell back to legacy AST bridge after IR lowering gap: %w", bridgeErr)
+		}
+	}
 	if genErr == nil {
-		if err := os.WriteFile(artifacts.LLVMIR, ir, 0o644); err != nil {
+		if err := os.WriteFile(artifacts.LLVMIR, irOut, 0o644); err != nil {
 			return nil, err
+		}
+		warnings := append([]error(nil), req.Entry.IRIssues...)
+		if fallbackWarning != nil {
+			warnings = append(warnings, fallbackWarning)
 		}
 		out := &Result{
 			Backend:   NameLLVM,
 			Emit:      req.Emit,
 			Artifacts: artifacts,
+			Warnings:  warnings,
 		}
 		if !llvmgen.NeedsObjectArtifact(req.Emit.String()) {
 			return out, nil
@@ -105,7 +122,11 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 		Backend:   NameLLVM,
 		Emit:      req.Emit,
 		Artifacts: artifacts,
-		Warnings:  []error{errors.New(llvmgen.UnsupportedSummary(diag)), ErrLLVMNotImplemented},
+		Warnings: append(
+			append([]error(nil), req.Entry.IRIssues...),
+			errors.New(llvmgen.UnsupportedSummary(diag)),
+			ErrLLVMNotImplemented,
+		),
 	}, ErrLLVMNotImplemented
 }
 

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 type compileCall struct {
@@ -57,7 +60,7 @@ func (f *fakeLLVMToolchain) LinkBinary(_ context.Context, objectPaths []string, 
 	return nil
 }
 
-func parseBackendFile(t *testing.T, src string) *ast.File {
+func parseBackendFile(t *testing.T, src string) (*ast.File, *resolve.Result, *check.Result) {
 	t.Helper()
 
 	file, diags := parser.ParseDiagnostics([]byte(src))
@@ -67,24 +70,40 @@ func parseBackendFile(t *testing.T, src string) *ast.File {
 	if file == nil {
 		t.Fatal("ParseDiagnostics returned nil file")
 	}
-	return file
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	return file, res, chk
 }
 
 func newBackendRequest(t *testing.T, emit EmitMode, src string) Request {
 	t.Helper()
 
 	root := t.TempDir()
+	file, res, chk := parseBackendFile(t, src)
+	entry, err := PrepareEntry(
+		"main",
+		filepath.Join(root, "main.osty"),
+		file,
+		res,
+		chk,
+	)
+	if err != nil {
+		t.Fatalf("PrepareEntry returned error: %v", err)
+	}
 	return Request{
 		Layout: Layout{
 			Root:    root,
 			Profile: "debug",
 		},
-		Emit: emit,
-		Entry: Entry{
-			PackageName: "main",
-			SourcePath:  filepath.Join(root, "main.osty"),
-			File:        parseBackendFile(t, src),
-		},
+		Emit:       emit,
+		Entry:      entry,
 		BinaryName: "app",
 	}
 }
@@ -180,6 +199,37 @@ func TestLLVMBackendEmitLLVMIRSkipsToolchain(t *testing.T) {
 	}
 	if _, err := os.Stat(result.Artifacts.RuntimeDir); err != nil {
 		t.Fatalf("runtime dir %q missing: %v", result.Artifacts.RuntimeDir, err)
+	}
+}
+
+func TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback(t *testing.T) {
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    let mut i = 0
+    for i < 2 {
+        println(i)
+        i = i + 1
+    }
+}
+`)
+	req.Entry.File = nil
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error with IR-only entry: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Emit returned nil result")
+	}
+	data, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	for _, want := range []string{"for.cond", "@printf"} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("IR-only backend output missing %q:\n%s", want, data)
+		}
 	}
 }
 

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -1,0 +1,1430 @@
+package llvmgen
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	ostyir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/token"
+)
+
+// GenerateModule is the IR-first LLVM entry point used by the production
+// backend path. During migration it reifies the backend-owned IR into the
+// legacy AST bridge so the rest of the emitter can stay stable while the
+// direct AST boundary is removed from backend call sites.
+func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
+	if mod == nil {
+		return nil, unsupported("source-layout", "nil module")
+	}
+	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
+		return nil, &UnsupportedError{Diagnostic: diag}
+	}
+	file, err := legacyFileFromModule(mod)
+	if err != nil {
+		return nil, err
+	}
+	return generateASTFile(file, opts)
+}
+
+func moduleUnsupportedDiagnostic(mod *ostyir.Module) (UnsupportedDiagnostic, bool) {
+	if mod == nil {
+		return UnsupportedDiagnostic{}, false
+	}
+	for _, decl := range mod.Decls {
+		use, ok := decl.(*ostyir.UseDecl)
+		if !ok || use == nil {
+			continue
+		}
+		if use.IsGoFFI {
+			return UnsupportedDiagnosticFor("go-ffi", use.GoPath), true
+		}
+		if use.IsRuntimeFFI && !llvmIsKnownRuntimeFfiPath(use.RuntimePath) {
+			return UnsupportedDiagnosticFor("runtime-ffi", use.RuntimePath), true
+		}
+	}
+	return UnsupportedDiagnostic{}, false
+}
+
+func legacyFileFromModule(mod *ostyir.Module) (*ast.File, error) {
+	start, end := legacySpan(mod.At())
+	file := &ast.File{PosV: start, EndV: end}
+	for _, decl := range mod.Decls {
+		legacyDecl, err := legacyDeclFromIR(decl)
+		if err != nil {
+			return nil, err
+		}
+		if legacyDecl == nil {
+			continue
+		}
+		if use, ok := legacyDecl.(*ast.UseDecl); ok {
+			file.Uses = append(file.Uses, use)
+			continue
+		}
+		file.Decls = append(file.Decls, legacyDecl)
+	}
+	for _, stmt := range mod.Script {
+		legacyStmt, err := legacyStmtFromIR(stmt)
+		if err != nil {
+			return nil, err
+		}
+		if legacyStmt != nil {
+			file.Stmts = append(file.Stmts, legacyStmt)
+		}
+	}
+	return file, nil
+}
+
+func legacyDeclFromIR(decl ostyir.Decl) (ast.Decl, error) {
+	switch d := decl.(type) {
+	case nil:
+		return nil, nil
+	case *ostyir.UseDecl:
+		return legacyUseDeclFromIR(d)
+	case *ostyir.FnDecl:
+		return legacyFnDeclFromIR(d, false)
+	case *ostyir.StructDecl:
+		return legacyStructDeclFromIR(d)
+	case *ostyir.EnumDecl:
+		return legacyEnumDeclFromIR(d)
+	case *ostyir.InterfaceDecl:
+		return legacyInterfaceDeclFromIR(d)
+	case *ostyir.TypeAliasDecl:
+		return legacyTypeAliasDeclFromIR(d)
+	case *ostyir.LetDecl:
+		return legacyLetDeclFromIR(d)
+	default:
+		return nil, unsupportedf("source-layout", "IR declaration %T", decl)
+	}
+}
+
+func legacyUseDeclFromIR(d *ostyir.UseDecl) (ast.Decl, error) {
+	if d == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(d.At())
+	out := &ast.UseDecl{
+		PosV:         start,
+		EndV:         end,
+		Path:         append([]string(nil), d.Path...),
+		RawPath:      d.RawPath,
+		Alias:        d.Alias,
+		IsGoFFI:      d.IsGoFFI,
+		IsRuntimeFFI: d.IsRuntimeFFI,
+		GoPath:       d.GoPath,
+		RuntimePath:  d.RuntimePath,
+	}
+	for _, inner := range d.GoBody {
+		legacyInner, err := legacyDeclFromIR(inner)
+		if err != nil {
+			return nil, err
+		}
+		if legacyInner != nil {
+			out.GoBody = append(out.GoBody, legacyInner)
+		}
+	}
+	return out, nil
+}
+
+func legacyFnDeclFromIR(fn *ostyir.FnDecl, asMethod bool) (*ast.FnDecl, error) {
+	if fn == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(fn.At())
+	out := &ast.FnDecl{
+		PosV:       start,
+		EndV:       end,
+		Pub:        fn.Exported,
+		Name:       fn.Name,
+		ReturnType: legacyTypeFromIR(fn.Return),
+	}
+	if asMethod {
+		out.Recv = &ast.Receiver{PosV: start, EndV: start}
+	}
+	for _, gp := range fn.Generics {
+		out.Generics = append(out.Generics, legacyTypeParamFromIR(gp))
+	}
+	for _, param := range fn.Params {
+		legacyParam, err := legacyParamFromIR(param)
+		if err != nil {
+			return nil, err
+		}
+		out.Params = append(out.Params, legacyParam)
+	}
+	if fn.Body != nil {
+		body, err := legacyBlockFromIR(fn.Body)
+		if err != nil {
+			return nil, err
+		}
+		out.Body = body
+	}
+	return out, nil
+}
+
+func legacyTypeParamFromIR(tp *ostyir.TypeParam) *ast.GenericParam {
+	if tp == nil {
+		return nil
+	}
+	start, end := legacySpan(tp.At())
+	out := &ast.GenericParam{PosV: start, EndV: end, Name: tp.Name}
+	for _, bound := range tp.Bounds {
+		out.Constraints = append(out.Constraints, legacyTypeFromIR(bound))
+	}
+	return out
+}
+
+func legacyParamFromIR(param *ostyir.Param) (*ast.Param, error) {
+	if param == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(param.At())
+	out := &ast.Param{
+		PosV: start,
+		EndV: end,
+		Name: param.Name,
+		Type: legacyTypeFromIR(param.Type),
+	}
+	if param.Default != nil {
+		value, err := legacyExprFromIR(param.Default)
+		if err != nil {
+			return nil, err
+		}
+		out.Default = value
+	}
+	return out, nil
+}
+
+func legacyStructDeclFromIR(sd *ostyir.StructDecl) (*ast.StructDecl, error) {
+	if sd == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(sd.At())
+	out := &ast.StructDecl{
+		PosV: start,
+		EndV: end,
+		Pub:  sd.Exported,
+		Name: sd.Name,
+	}
+	for _, gp := range sd.Generics {
+		out.Generics = append(out.Generics, legacyTypeParamFromIR(gp))
+	}
+	for _, field := range sd.Fields {
+		legacyField, err := legacyFieldFromIR(field)
+		if err != nil {
+			return nil, err
+		}
+		out.Fields = append(out.Fields, legacyField)
+	}
+	for _, method := range sd.Methods {
+		legacyMethod, err := legacyFnDeclFromIR(method, true)
+		if err != nil {
+			return nil, err
+		}
+		out.Methods = append(out.Methods, legacyMethod)
+	}
+	return out, nil
+}
+
+func legacyFieldFromIR(field *ostyir.Field) (*ast.Field, error) {
+	if field == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(field.At())
+	out := &ast.Field{
+		PosV: start,
+		EndV: end,
+		Pub:  field.Exported,
+		Name: field.Name,
+		Type: legacyTypeFromIR(field.Type),
+	}
+	if field.Default != nil {
+		value, err := legacyExprFromIR(field.Default)
+		if err != nil {
+			return nil, err
+		}
+		out.Default = value
+	}
+	return out, nil
+}
+
+func legacyEnumDeclFromIR(ed *ostyir.EnumDecl) (*ast.EnumDecl, error) {
+	if ed == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(ed.At())
+	out := &ast.EnumDecl{
+		PosV: start,
+		EndV: end,
+		Pub:  ed.Exported,
+		Name: ed.Name,
+	}
+	for _, gp := range ed.Generics {
+		out.Generics = append(out.Generics, legacyTypeParamFromIR(gp))
+	}
+	for _, variant := range ed.Variants {
+		legacyVariant := legacyVariantFromIR(variant)
+		out.Variants = append(out.Variants, legacyVariant)
+	}
+	for _, method := range ed.Methods {
+		legacyMethod, err := legacyFnDeclFromIR(method, true)
+		if err != nil {
+			return nil, err
+		}
+		out.Methods = append(out.Methods, legacyMethod)
+	}
+	return out, nil
+}
+
+func legacyVariantFromIR(variant *ostyir.Variant) *ast.Variant {
+	if variant == nil {
+		return nil
+	}
+	start, end := legacySpan(variant.At())
+	out := &ast.Variant{
+		PosV: start,
+		EndV: end,
+		Name: variant.Name,
+	}
+	for _, payload := range variant.Payload {
+		out.Fields = append(out.Fields, legacyTypeFromIR(payload))
+	}
+	return out
+}
+
+func legacyInterfaceDeclFromIR(id *ostyir.InterfaceDecl) (*ast.InterfaceDecl, error) {
+	if id == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(id.At())
+	out := &ast.InterfaceDecl{
+		PosV: start,
+		EndV: end,
+		Pub:  id.Exported,
+		Name: id.Name,
+	}
+	for _, gp := range id.Generics {
+		out.Generics = append(out.Generics, legacyTypeParamFromIR(gp))
+	}
+	for _, ext := range id.Extends {
+		out.Extends = append(out.Extends, legacyTypeFromIR(ext))
+	}
+	for _, method := range id.Methods {
+		legacyMethod, err := legacyFnDeclFromIR(method, false)
+		if err != nil {
+			return nil, err
+		}
+		out.Methods = append(out.Methods, legacyMethod)
+	}
+	return out, nil
+}
+
+func legacyTypeAliasDeclFromIR(td *ostyir.TypeAliasDecl) (*ast.TypeAliasDecl, error) {
+	if td == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(td.At())
+	out := &ast.TypeAliasDecl{
+		PosV:   start,
+		EndV:   end,
+		Pub:    td.Exported,
+		Name:   td.Name,
+		Target: legacyTypeFromIR(td.Target),
+	}
+	for _, gp := range td.Generics {
+		out.Generics = append(out.Generics, legacyTypeParamFromIR(gp))
+	}
+	return out, nil
+}
+
+func legacyLetDeclFromIR(ld *ostyir.LetDecl) (*ast.LetDecl, error) {
+	if ld == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(ld.At())
+	out := &ast.LetDecl{
+		PosV: start,
+		EndV: end,
+		Pub:  ld.Exported,
+		Mut:  ld.Mut,
+		Name: ld.Name,
+		Type: legacyTypeFromIR(ld.Type),
+	}
+	if ld.Value != nil {
+		value, err := legacyExprFromIR(ld.Value)
+		if err != nil {
+			return nil, err
+		}
+		out.Value = value
+	}
+	return out, nil
+}
+
+func legacyTypeFromIR(typ ostyir.Type) ast.Type {
+	switch t := typ.(type) {
+	case nil:
+		return nil
+	case *ostyir.PrimType:
+		name := legacyPrimTypeName(t.Kind)
+		if name == "" {
+			return nil
+		}
+		return &ast.NamedType{Path: []string{name}}
+	case *ostyir.NamedType:
+		out := &ast.NamedType{Path: splitQualifiedName(t.Name)}
+		for _, arg := range t.Args {
+			out.Args = append(out.Args, legacyTypeFromIR(arg))
+		}
+		return out
+	case *ostyir.OptionalType:
+		return &ast.OptionalType{Inner: legacyTypeFromIR(t.Inner)}
+	case *ostyir.TupleType:
+		out := &ast.TupleType{}
+		for _, elem := range t.Elems {
+			out.Elems = append(out.Elems, legacyTypeFromIR(elem))
+		}
+		return out
+	case *ostyir.FnType:
+		out := &ast.FnType{ReturnType: legacyTypeFromIR(t.Return)}
+		for _, param := range t.Params {
+			out.Params = append(out.Params, legacyTypeFromIR(param))
+		}
+		return out
+	case *ostyir.TypeVar:
+		return &ast.NamedType{Path: []string{t.Name}}
+	case *ostyir.ErrType:
+		return &ast.NamedType{Path: []string{"<error>"}}
+	default:
+		return nil
+	}
+}
+
+func legacyPrimTypeName(kind ostyir.PrimKind) string {
+	switch kind {
+	case ostyir.PrimInt:
+		return "Int"
+	case ostyir.PrimInt8:
+		return "Int8"
+	case ostyir.PrimInt16:
+		return "Int16"
+	case ostyir.PrimInt32:
+		return "Int32"
+	case ostyir.PrimInt64:
+		return "Int64"
+	case ostyir.PrimUInt8:
+		return "UInt8"
+	case ostyir.PrimUInt16:
+		return "UInt16"
+	case ostyir.PrimUInt32:
+		return "UInt32"
+	case ostyir.PrimUInt64:
+		return "UInt64"
+	case ostyir.PrimByte:
+		return "Byte"
+	case ostyir.PrimFloat:
+		return "Float"
+	case ostyir.PrimFloat32:
+		return "Float32"
+	case ostyir.PrimFloat64:
+		return "Float64"
+	case ostyir.PrimBool:
+		return "Bool"
+	case ostyir.PrimChar:
+		return "Char"
+	case ostyir.PrimString:
+		return "String"
+	case ostyir.PrimBytes:
+		return "Bytes"
+	default:
+		return ""
+	}
+}
+
+func legacyBlockFromIR(block *ostyir.Block) (*ast.Block, error) {
+	if block == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(block.At())
+	out := &ast.Block{PosV: start, EndV: end}
+	for _, stmt := range block.Stmts {
+		legacyStmt, err := legacyStmtFromIR(stmt)
+		if err != nil {
+			return nil, err
+		}
+		if legacyStmt != nil {
+			out.Stmts = append(out.Stmts, legacyStmt)
+		}
+	}
+	if block.Result != nil {
+		resultExpr, err := legacyExprFromIR(block.Result)
+		if err != nil {
+			return nil, err
+		}
+		out.Stmts = append(out.Stmts, &ast.ExprStmt{X: resultExpr})
+	}
+	return out, nil
+}
+
+func legacyStmtFromIR(stmt ostyir.Stmt) (ast.Stmt, error) {
+	switch s := stmt.(type) {
+	case nil:
+		return nil, nil
+	case *ostyir.Block:
+		return legacyBlockFromIR(s)
+	case *ostyir.LetStmt:
+		return legacyLetStmtFromIR(s)
+	case *ostyir.ExprStmt:
+		expr, err := legacyExprFromIR(s.X)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ExprStmt{X: expr}, nil
+	case *ostyir.AssignStmt:
+		return legacyAssignStmtFromIR(s)
+	case *ostyir.ReturnStmt:
+		start, end := legacySpan(s.At())
+		out := &ast.ReturnStmt{PosV: start, EndV: end}
+		if s.Value != nil {
+			value, err := legacyExprFromIR(s.Value)
+			if err != nil {
+				return nil, err
+			}
+			out.Value = value
+		}
+		return out, nil
+	case *ostyir.BreakStmt:
+		start, end := legacySpan(s.At())
+		return &ast.BreakStmt{PosV: start, EndV: end}, nil
+	case *ostyir.ContinueStmt:
+		start, end := legacySpan(s.At())
+		return &ast.ContinueStmt{PosV: start, EndV: end}, nil
+	case *ostyir.IfStmt:
+		return legacyIfStmtFromIR(s)
+	case *ostyir.ForStmt:
+		return legacyForStmtFromIR(s)
+	case *ostyir.DeferStmt:
+		return legacyDeferStmtFromIR(s)
+	case *ostyir.MatchStmt:
+		expr, err := legacyMatchExprFromIR(&ostyir.MatchExpr{
+			Scrutinee: s.Scrutinee,
+			Arms:      s.Arms,
+			SpanV:     s.At(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ExprStmt{X: expr}, nil
+	default:
+		return nil, unsupportedf("statement", "IR statement %T", stmt)
+	}
+}
+
+func legacyLetStmtFromIR(stmt *ostyir.LetStmt) (ast.Stmt, error) {
+	if stmt == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(stmt.At())
+	out := &ast.LetStmt{
+		PosV: start,
+		EndV: end,
+		Mut:  stmt.Mut,
+		Type: legacyTypeFromIR(stmt.Type),
+	}
+	if stmt.Pattern != nil {
+		pat, err := legacyPatternFromIR(stmt.Pattern)
+		if err != nil {
+			return nil, err
+		}
+		out.Pattern = pat
+	} else {
+		out.Pattern = &ast.IdentPat{PosV: start, EndV: end, Name: stmt.Name}
+	}
+	if stmt.Value != nil {
+		value, err := legacyExprFromIR(stmt.Value)
+		if err != nil {
+			return nil, err
+		}
+		out.Value = value
+	}
+	return out, nil
+}
+
+func legacyAssignStmtFromIR(stmt *ostyir.AssignStmt) (ast.Stmt, error) {
+	if stmt == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(stmt.At())
+	out := &ast.AssignStmt{
+		PosV: start,
+		EndV: end,
+		Op:   legacyAssignOp(stmt.Op),
+	}
+	for _, target := range stmt.Targets {
+		legacyTarget, err := legacyExprFromIR(target)
+		if err != nil {
+			return nil, err
+		}
+		out.Targets = append(out.Targets, legacyTarget)
+	}
+	value, err := legacyExprFromIR(stmt.Value)
+	if err != nil {
+		return nil, err
+	}
+	out.Value = value
+	return out, nil
+}
+
+func legacyAssignOp(op ostyir.AssignOp) token.Kind {
+	switch op {
+	case ostyir.AssignEq:
+		return token.ASSIGN
+	case ostyir.AssignAdd:
+		return token.PLUSEQ
+	case ostyir.AssignSub:
+		return token.MINUSEQ
+	case ostyir.AssignMul:
+		return token.STAREQ
+	case ostyir.AssignDiv:
+		return token.SLASHEQ
+	case ostyir.AssignMod:
+		return token.PERCENTEQ
+	case ostyir.AssignAnd:
+		return token.BITANDEQ
+	case ostyir.AssignOr:
+		return token.BITOREQ
+	case ostyir.AssignXor:
+		return token.BITXOREQ
+	case ostyir.AssignShl:
+		return token.SHLEQ
+	case ostyir.AssignShr:
+		return token.SHREQ
+	default:
+		return token.ASSIGN
+	}
+}
+
+func legacyIfStmtFromIR(stmt *ostyir.IfStmt) (ast.Stmt, error) {
+	if stmt == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(stmt.At())
+	cond, err := legacyExprFromIR(stmt.Cond)
+	if err != nil {
+		return nil, err
+	}
+	thenBlock, err := legacyBlockFromIR(stmt.Then)
+	if err != nil {
+		return nil, err
+	}
+	var elseExpr ast.Expr
+	if stmt.Else != nil {
+		elseBlock, err := legacyBlockFromIR(stmt.Else)
+		if err != nil {
+			return nil, err
+		}
+		if elseBlock != nil {
+			elseExpr = elseBlock
+		}
+	}
+	return &ast.ExprStmt{
+		X: &ast.IfExpr{
+			PosV: start,
+			EndV: end,
+			Cond: cond,
+			Then: thenBlock,
+			Else: elseExpr,
+		},
+	}, nil
+}
+
+func legacyForStmtFromIR(stmt *ostyir.ForStmt) (ast.Stmt, error) {
+	if stmt == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(stmt.At())
+	out := &ast.ForStmt{PosV: start, EndV: end}
+	body, err := legacyBlockFromIR(stmt.Body)
+	if err != nil {
+		return nil, err
+	}
+	out.Body = body
+	switch stmt.Kind {
+	case ostyir.ForInfinite:
+		return out, nil
+	case ostyir.ForWhile:
+		iter, err := legacyExprFromIR(stmt.Cond)
+		if err != nil {
+			return nil, err
+		}
+		out.Iter = iter
+		return out, nil
+	case ostyir.ForRange:
+		out.Pattern = &ast.IdentPat{PosV: start, EndV: start, Name: stmt.Var}
+		startExpr, err := legacyExprFromIR(stmt.Start)
+		if err != nil {
+			return nil, err
+		}
+		endExpr, err := legacyExprFromIR(stmt.End)
+		if err != nil {
+			return nil, err
+		}
+		out.Iter = &ast.RangeExpr{
+			PosV:      start,
+			EndV:      end,
+			Start:     startExpr,
+			Stop:      endExpr,
+			Inclusive: stmt.Inclusive,
+		}
+		return out, nil
+	case ostyir.ForIn:
+		out.Pattern = &ast.IdentPat{PosV: start, EndV: start, Name: stmt.Var}
+		iter, err := legacyExprFromIR(stmt.Iter)
+		if err != nil {
+			return nil, err
+		}
+		out.Iter = iter
+		return out, nil
+	default:
+		return nil, unsupportedf("control-flow", "IR for-kind %d", stmt.Kind)
+	}
+}
+
+func legacyDeferStmtFromIR(stmt *ostyir.DeferStmt) (ast.Stmt, error) {
+	if stmt == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(stmt.At())
+	body, err := legacyBlockFromIR(stmt.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.DeferStmt{PosV: start, EndV: end, X: body}, nil
+}
+
+func legacyExprFromIR(expr ostyir.Expr) (ast.Expr, error) {
+	switch e := expr.(type) {
+	case nil:
+		return nil, nil
+	case *ostyir.IntLit:
+		start, end := legacySpan(e.At())
+		return &ast.IntLit{PosV: start, EndV: end, Text: e.Text}, nil
+	case *ostyir.FloatLit:
+		start, end := legacySpan(e.At())
+		return &ast.FloatLit{PosV: start, EndV: end, Text: e.Text}, nil
+	case *ostyir.BoolLit:
+		start, end := legacySpan(e.At())
+		return &ast.BoolLit{PosV: start, EndV: end, Value: e.Value}, nil
+	case *ostyir.CharLit:
+		start, end := legacySpan(e.At())
+		return &ast.CharLit{PosV: start, EndV: end, Value: e.Value}, nil
+	case *ostyir.ByteLit:
+		start, end := legacySpan(e.At())
+		return &ast.ByteLit{PosV: start, EndV: end, Value: e.Value}, nil
+	case *ostyir.StringLit:
+		return legacyStringLitFromIR(e)
+	case *ostyir.UnitLit:
+		return nil, unsupported("expression", "unit literals are not yet supported in the LLVM IR bridge")
+	case *ostyir.Ident:
+		start, end := legacySpan(e.At())
+		return &ast.Ident{PosV: start, EndV: end, Name: e.Name}, nil
+	case *ostyir.UnaryExpr:
+		return legacyUnaryExprFromIR(e)
+	case *ostyir.BinaryExpr:
+		return legacyBinaryExprFromIR(e)
+	case *ostyir.CallExpr:
+		return legacyCallExprFromIR(e)
+	case *ostyir.IntrinsicCall:
+		return legacyIntrinsicCallFromIR(e)
+	case *ostyir.ListLit:
+		return legacyListLitFromIR(e)
+	case *ostyir.BlockExpr:
+		return legacyBlockFromIR(e.Block)
+	case *ostyir.IfExpr:
+		return legacyIfExprFromIR(e)
+	case *ostyir.ErrorExpr:
+		return nil, unsupportedf("expression", "IR error expression: %s", e.Note)
+	case *ostyir.FieldExpr:
+		return legacyFieldExprFromIR(e)
+	case *ostyir.IndexExpr:
+		return legacyIndexExprFromIR(e)
+	case *ostyir.MethodCall:
+		return legacyMethodCallFromIR(e)
+	case *ostyir.StructLit:
+		return legacyStructLitFromIR(e)
+	case *ostyir.TupleLit:
+		return legacyTupleLitFromIR(e)
+	case *ostyir.MapLit:
+		return legacyMapLitFromIR(e)
+	case *ostyir.RangeLit:
+		return legacyRangeLitFromIR(e)
+	case *ostyir.QuestionExpr:
+		return legacyQuestionExprFromIR(e)
+	case *ostyir.CoalesceExpr:
+		return legacyCoalesceExprFromIR(e)
+	case *ostyir.Closure:
+		return legacyClosureFromIR(e)
+	case *ostyir.VariantLit:
+		return legacyVariantLitFromIR(e)
+	case *ostyir.MatchExpr:
+		return legacyMatchExprFromIR(e)
+	case *ostyir.IfLetExpr:
+		return legacyIfLetExprFromIR(e)
+	case *ostyir.TupleAccess:
+		return legacyTupleAccessFromIR(e)
+	default:
+		return nil, unsupportedf("expression", "IR expression %T", expr)
+	}
+}
+
+func legacyStringLitFromIR(lit *ostyir.StringLit) (ast.Expr, error) {
+	if lit == nil {
+		return nil, nil
+	}
+	start, end := legacySpan(lit.At())
+	out := &ast.StringLit{
+		PosV:     start,
+		EndV:     end,
+		IsRaw:    lit.IsRaw,
+		IsTriple: lit.IsTriple,
+	}
+	for _, part := range lit.Parts {
+		entry := ast.StringPart{IsLit: part.IsLit, Lit: part.Lit}
+		if !part.IsLit {
+			expr, err := legacyExprFromIR(part.Expr)
+			if err != nil {
+				return nil, err
+			}
+			entry.Expr = expr
+		}
+		out.Parts = append(out.Parts, entry)
+	}
+	return out, nil
+}
+
+func legacyUnaryExprFromIR(expr *ostyir.UnaryExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	inner, err := legacyExprFromIR(expr.X)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.UnaryExpr{
+		PosV: start,
+		EndV: end,
+		Op:   legacyUnaryOp(expr.Op),
+		X:    inner,
+	}, nil
+}
+
+func legacyBinaryExprFromIR(expr *ostyir.BinaryExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	left, err := legacyExprFromIR(expr.Left)
+	if err != nil {
+		return nil, err
+	}
+	right, err := legacyExprFromIR(expr.Right)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.BinaryExpr{
+		PosV:  start,
+		EndV:  end,
+		Op:    legacyBinaryOp(expr.Op),
+		Left:  left,
+		Right: right,
+	}, nil
+}
+
+func legacyCallExprFromIR(expr *ostyir.CallExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	fn, err := legacyExprFromIR(expr.Callee)
+	if err != nil {
+		return nil, err
+	}
+	out := &ast.CallExpr{PosV: start, EndV: end, Fn: fn}
+	for _, arg := range expr.Args {
+		value, err := legacyExprFromIR(arg)
+		if err != nil {
+			return nil, err
+		}
+		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+	}
+	return out, nil
+}
+
+func legacyIntrinsicCallFromIR(expr *ostyir.IntrinsicCall) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.CallExpr{
+		PosV: start,
+		EndV: end,
+		Fn: &ast.Ident{
+			PosV: start,
+			EndV: start,
+			Name: legacyIntrinsicName(expr.Kind),
+		},
+	}
+	for _, arg := range expr.Args {
+		value, err := legacyExprFromIR(arg)
+		if err != nil {
+			return nil, err
+		}
+		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+	}
+	return out, nil
+}
+
+func legacyListLitFromIR(expr *ostyir.ListLit) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.ListExpr{PosV: start, EndV: end}
+	for _, elem := range expr.Elems {
+		value, err := legacyExprFromIR(elem)
+		if err != nil {
+			return nil, err
+		}
+		out.Elems = append(out.Elems, value)
+	}
+	return out, nil
+}
+
+func legacyIfExprFromIR(expr *ostyir.IfExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	cond, err := legacyExprFromIR(expr.Cond)
+	if err != nil {
+		return nil, err
+	}
+	thenBlock, err := legacyBlockFromIR(expr.Then)
+	if err != nil {
+		return nil, err
+	}
+	elseBlock, err := legacyBlockFromIR(expr.Else)
+	if err != nil {
+		return nil, err
+	}
+	var elseExpr ast.Expr
+	if elseBlock != nil {
+		elseExpr = elseBlock
+	}
+	return &ast.IfExpr{
+		PosV: start,
+		EndV: end,
+		Cond: cond,
+		Then: thenBlock,
+		Else: elseExpr,
+	}, nil
+}
+
+func legacyFieldExprFromIR(expr *ostyir.FieldExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	base, err := legacyExprFromIR(expr.X)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.FieldExpr{
+		PosV:       start,
+		EndV:       end,
+		X:          base,
+		Name:       expr.Name,
+		IsOptional: expr.Optional,
+	}, nil
+}
+
+func legacyIndexExprFromIR(expr *ostyir.IndexExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	base, err := legacyExprFromIR(expr.X)
+	if err != nil {
+		return nil, err
+	}
+	index, err := legacyExprFromIR(expr.Index)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.IndexExpr{
+		PosV:  start,
+		EndV:  end,
+		X:     base,
+		Index: index,
+	}, nil
+}
+
+func legacyMethodCallFromIR(expr *ostyir.MethodCall) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	receiver, err := legacyExprFromIR(expr.Receiver)
+	if err != nil {
+		return nil, err
+	}
+	fn := ast.Expr(&ast.FieldExpr{
+		PosV: start,
+		EndV: end,
+		X:    receiver,
+		Name: expr.Name,
+	})
+	if len(expr.TypeArgs) != 0 {
+		tf := &ast.TurbofishExpr{PosV: start, EndV: end, Base: fn}
+		for _, arg := range expr.TypeArgs {
+			tf.Args = append(tf.Args, legacyTypeFromIR(arg))
+		}
+		fn = tf
+	}
+	out := &ast.CallExpr{PosV: start, EndV: end, Fn: fn}
+	for _, arg := range expr.Args {
+		value, err := legacyExprFromIR(arg)
+		if err != nil {
+			return nil, err
+		}
+		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+	}
+	return out, nil
+}
+
+func legacyStructLitFromIR(expr *ostyir.StructLit) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.StructLit{
+		PosV: start,
+		EndV: end,
+		Type: legacyTypeExpr(expr.TypeName, start, end),
+	}
+	for _, field := range expr.Fields {
+		legacyField := &ast.StructLitField{PosV: legacyPos(field.At().Start), Name: field.Name}
+		if field.Value != nil {
+			value, err := legacyExprFromIR(field.Value)
+			if err != nil {
+				return nil, err
+			}
+			legacyField.Value = value
+		}
+		out.Fields = append(out.Fields, legacyField)
+	}
+	if expr.Spread != nil {
+		spread, err := legacyExprFromIR(expr.Spread)
+		if err != nil {
+			return nil, err
+		}
+		out.Spread = spread
+	}
+	return out, nil
+}
+
+func legacyTupleLitFromIR(expr *ostyir.TupleLit) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.TupleExpr{PosV: start, EndV: end}
+	for _, elem := range expr.Elems {
+		value, err := legacyExprFromIR(elem)
+		if err != nil {
+			return nil, err
+		}
+		out.Elems = append(out.Elems, value)
+	}
+	return out, nil
+}
+
+func legacyMapLitFromIR(expr *ostyir.MapLit) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.MapExpr{PosV: start, EndV: end, Empty: len(expr.Entries) == 0}
+	for _, entry := range expr.Entries {
+		key, err := legacyExprFromIR(entry.Key)
+		if err != nil {
+			return nil, err
+		}
+		value, err := legacyExprFromIR(entry.Value)
+		if err != nil {
+			return nil, err
+		}
+		out.Entries = append(out.Entries, &ast.MapEntry{Key: key, Value: value})
+	}
+	return out, nil
+}
+
+func legacyRangeLitFromIR(expr *ostyir.RangeLit) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.RangeExpr{PosV: start, EndV: end, Inclusive: expr.Inclusive}
+	var err error
+	if expr.Start != nil {
+		out.Start, err = legacyExprFromIR(expr.Start)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if expr.End != nil {
+		out.Stop, err = legacyExprFromIR(expr.End)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func legacyQuestionExprFromIR(expr *ostyir.QuestionExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	inner, err := legacyExprFromIR(expr.X)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.QuestionExpr{PosV: start, EndV: end, X: inner}, nil
+}
+
+func legacyCoalesceExprFromIR(expr *ostyir.CoalesceExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	left, err := legacyExprFromIR(expr.Left)
+	if err != nil {
+		return nil, err
+	}
+	right, err := legacyExprFromIR(expr.Right)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.BinaryExpr{
+		PosV:  start,
+		EndV:  end,
+		Op:    token.QQ,
+		Left:  left,
+		Right: right,
+	}, nil
+}
+
+func legacyClosureFromIR(expr *ostyir.Closure) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	out := &ast.ClosureExpr{
+		PosV:       start,
+		EndV:       end,
+		ReturnType: legacyTypeFromIR(expr.Return),
+	}
+	for _, param := range expr.Params {
+		legacyParam, err := legacyParamFromIR(param)
+		if err != nil {
+			return nil, err
+		}
+		out.Params = append(out.Params, legacyParam)
+	}
+	body, err := legacyBlockFromIR(expr.Body)
+	if err != nil {
+		return nil, err
+	}
+	out.Body = body
+	return out, nil
+}
+
+func legacyVariantLitFromIR(expr *ostyir.VariantLit) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	callee := ast.Expr(&ast.Ident{PosV: start, EndV: end, Name: expr.Variant})
+	if expr.Enum != "" {
+		callee = &ast.FieldExpr{
+			PosV: start,
+			EndV: end,
+			X:    &ast.Ident{PosV: start, EndV: start, Name: expr.Enum},
+			Name: expr.Variant,
+		}
+	}
+	if len(expr.Args) == 0 {
+		return callee, nil
+	}
+	out := &ast.CallExpr{PosV: start, EndV: end, Fn: callee}
+	for _, arg := range expr.Args {
+		value, err := legacyExprFromIR(arg)
+		if err != nil {
+			return nil, err
+		}
+		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+	}
+	return out, nil
+}
+
+func legacyMatchExprFromIR(expr *ostyir.MatchExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	scrutinee, err := legacyExprFromIR(expr.Scrutinee)
+	if err != nil {
+		return nil, err
+	}
+	out := &ast.MatchExpr{PosV: start, EndV: end, Scrutinee: scrutinee}
+	for _, arm := range expr.Arms {
+		legacyArm, err := legacyMatchArmFromIR(arm)
+		if err != nil {
+			return nil, err
+		}
+		out.Arms = append(out.Arms, legacyArm)
+	}
+	return out, nil
+}
+
+func legacyMatchArmFromIR(arm *ostyir.MatchArm) (*ast.MatchArm, error) {
+	if arm == nil {
+		return nil, nil
+	}
+	start, _ := legacySpan(arm.At())
+	pattern, err := legacyPatternFromIR(arm.Pattern)
+	if err != nil {
+		return nil, err
+	}
+	out := &ast.MatchArm{PosV: start, Pattern: pattern}
+	if arm.Guard != nil {
+		guard, err := legacyExprFromIR(arm.Guard)
+		if err != nil {
+			return nil, err
+		}
+		out.Guard = guard
+	}
+	body, err := legacyBlockFromIR(arm.Body)
+	if err != nil {
+		return nil, err
+	}
+	out.Body = body
+	return out, nil
+}
+
+func legacyIfLetExprFromIR(expr *ostyir.IfLetExpr) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	pattern, err := legacyPatternFromIR(expr.Pattern)
+	if err != nil {
+		return nil, err
+	}
+	scrutinee, err := legacyExprFromIR(expr.Scrutinee)
+	if err != nil {
+		return nil, err
+	}
+	thenBlock, err := legacyBlockFromIR(expr.Then)
+	if err != nil {
+		return nil, err
+	}
+	elseBlock, err := legacyBlockFromIR(expr.Else)
+	if err != nil {
+		return nil, err
+	}
+	var elseExpr ast.Expr
+	if elseBlock != nil {
+		elseExpr = elseBlock
+	}
+	return &ast.IfExpr{
+		PosV:    start,
+		EndV:    end,
+		IsIfLet: true,
+		Pattern: pattern,
+		Cond:    scrutinee,
+		Then:    thenBlock,
+		Else:    elseExpr,
+	}, nil
+}
+
+func legacyTupleAccessFromIR(expr *ostyir.TupleAccess) (ast.Expr, error) {
+	start, end := legacySpan(expr.At())
+	base, err := legacyExprFromIR(expr.X)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.FieldExpr{
+		PosV: start,
+		EndV: end,
+		X:    base,
+		Name: strconv.Itoa(expr.Index),
+	}, nil
+}
+
+func legacyPatternFromIR(pattern ostyir.Pattern) (ast.Pattern, error) {
+	switch p := pattern.(type) {
+	case nil:
+		return nil, nil
+	case *ostyir.WildPat:
+		start, end := legacySpan(p.At())
+		return &ast.WildcardPat{PosV: start, EndV: end}, nil
+	case *ostyir.IdentPat:
+		start, end := legacySpan(p.At())
+		return &ast.IdentPat{PosV: start, EndV: end, Name: p.Name}, nil
+	case *ostyir.LitPat:
+		start, end := legacySpan(p.At())
+		lit, err := legacyExprFromIR(p.Value)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.LiteralPat{PosV: start, EndV: end, Literal: lit}, nil
+	case *ostyir.TuplePat:
+		start, end := legacySpan(p.At())
+		out := &ast.TuplePat{PosV: start, EndV: end}
+		for _, elem := range p.Elems {
+			legacyElem, err := legacyPatternFromIR(elem)
+			if err != nil {
+				return nil, err
+			}
+			out.Elems = append(out.Elems, legacyElem)
+		}
+		return out, nil
+	case *ostyir.StructPat:
+		start, end := legacySpan(p.At())
+		out := &ast.StructPat{
+			PosV: start,
+			EndV: end,
+			Type: splitQualifiedName(p.TypeName),
+			Rest: p.Rest,
+		}
+		for _, field := range p.Fields {
+			pat, err := legacyPatternFromIR(field.Pattern)
+			if err != nil {
+				return nil, err
+			}
+			out.Fields = append(out.Fields, &ast.StructPatField{
+				PosV:    legacyPos(field.At().Start),
+				Name:    field.Name,
+				Pattern: pat,
+			})
+		}
+		return out, nil
+	case *ostyir.VariantPat:
+		start, end := legacySpan(p.At())
+		out := &ast.VariantPat{PosV: start, EndV: end}
+		if p.Enum != "" {
+			out.Path = append(out.Path, p.Enum)
+		}
+		out.Path = append(out.Path, p.Variant)
+		for _, arg := range p.Args {
+			legacyArg, err := legacyPatternFromIR(arg)
+			if err != nil {
+				return nil, err
+			}
+			out.Args = append(out.Args, legacyArg)
+		}
+		return out, nil
+	case *ostyir.RangePat:
+		start, end := legacySpan(p.At())
+		out := &ast.RangePat{PosV: start, EndV: end, Inclusive: p.Inclusive}
+		var err error
+		if p.Low != nil {
+			out.Start, err = legacyExprFromIR(p.Low)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if p.High != nil {
+			out.Stop, err = legacyExprFromIR(p.High)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return out, nil
+	case *ostyir.OrPat:
+		start, end := legacySpan(p.At())
+		out := &ast.OrPat{PosV: start, EndV: end}
+		for _, alt := range p.Alts {
+			legacyAlt, err := legacyPatternFromIR(alt)
+			if err != nil {
+				return nil, err
+			}
+			out.Alts = append(out.Alts, legacyAlt)
+		}
+		return out, nil
+	case *ostyir.BindingPat:
+		start, end := legacySpan(p.At())
+		inner, err := legacyPatternFromIR(p.Pattern)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.BindingPat{
+			PosV:    start,
+			EndV:    end,
+			Name:    p.Name,
+			Pattern: inner,
+		}, nil
+	case *ostyir.ErrorPat:
+		return nil, unsupportedf("pattern", "IR error pattern: %s", p.Note)
+	default:
+		return nil, unsupportedf("pattern", "IR pattern %T", pattern)
+	}
+}
+
+func legacyUnaryOp(op ostyir.UnOp) token.Kind {
+	switch op {
+	case ostyir.UnNeg:
+		return token.MINUS
+	case ostyir.UnPlus:
+		return token.PLUS
+	case ostyir.UnNot:
+		return token.NOT
+	case ostyir.UnBitNot:
+		return token.BITNOT
+	default:
+		return token.ILLEGAL
+	}
+}
+
+func legacyBinaryOp(op ostyir.BinOp) token.Kind {
+	switch op {
+	case ostyir.BinAdd:
+		return token.PLUS
+	case ostyir.BinSub:
+		return token.MINUS
+	case ostyir.BinMul:
+		return token.STAR
+	case ostyir.BinDiv:
+		return token.SLASH
+	case ostyir.BinMod:
+		return token.PERCENT
+	case ostyir.BinEq:
+		return token.EQ
+	case ostyir.BinNeq:
+		return token.NEQ
+	case ostyir.BinLt:
+		return token.LT
+	case ostyir.BinLeq:
+		return token.LEQ
+	case ostyir.BinGt:
+		return token.GT
+	case ostyir.BinGeq:
+		return token.GEQ
+	case ostyir.BinAnd:
+		return token.AND
+	case ostyir.BinOr:
+		return token.OR
+	case ostyir.BinBitAnd:
+		return token.BITAND
+	case ostyir.BinBitOr:
+		return token.BITOR
+	case ostyir.BinBitXor:
+		return token.BITXOR
+	case ostyir.BinShl:
+		return token.SHL
+	case ostyir.BinShr:
+		return token.SHR
+	default:
+		return token.ILLEGAL
+	}
+}
+
+func legacyIntrinsicName(kind ostyir.IntrinsicKind) string {
+	switch kind {
+	case ostyir.IntrinsicPrint:
+		return "print"
+	case ostyir.IntrinsicPrintln:
+		return "println"
+	case ostyir.IntrinsicEprint:
+		return "eprint"
+	case ostyir.IntrinsicEprintln:
+		return "eprintln"
+	default:
+		return ""
+	}
+}
+
+func legacyTypeExpr(name string, start, end token.Pos) ast.Expr {
+	parts := splitQualifiedName(name)
+	if len(parts) == 0 {
+		return &ast.Ident{PosV: start, EndV: end, Name: name}
+	}
+	expr := ast.Expr(&ast.Ident{PosV: start, EndV: start, Name: parts[0]})
+	for _, part := range parts[1:] {
+		expr = &ast.FieldExpr{PosV: start, EndV: end, X: expr, Name: part}
+	}
+	return expr
+}
+
+func splitQualifiedName(name string) []string {
+	if name == "" {
+		return nil
+	}
+	return strings.Split(name, ".")
+}
+
+func legacySpan(span ostyir.Span) (token.Pos, token.Pos) {
+	return legacyPos(span.Start), legacyPos(span.End)
+}
+
+func legacyPos(pos ostyir.Pos) token.Pos {
+	return token.Pos{
+		Offset: pos.Offset,
+		Line:   pos.Line,
+		Column: pos.Column,
+	}
+}

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -1,0 +1,67 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestGenerateModuleWhileLoopCompat(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 4 {
+        sum = sum + i
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source: []byte(`fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 4 {
+        sum = sum + i
+        i = i + 1
+    }
+    println(sum)
+}
+`),
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower returned issues: %v", issues)
+	}
+	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
+		t.Fatalf("ir.Validate returned errors: %v", validateErrs)
+	}
+	out, err := GenerateModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/while_loop_ir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"for.cond",
+		"for.body",
+		"@printf",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -184,6 +184,10 @@ func toUnsupportedDiagnostic(diag UnsupportedDiagnostic) *LlvmUnsupportedDiagnos
 
 // Generate emits textual LLVM IR for a minimal, scalar subset.
 func Generate(file *ast.File, opts Options) ([]byte, error) {
+	return generateASTFile(file, opts)
+}
+
+func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	if file == nil {
 		return nil, unsupported("source-layout", "nil file")
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -260,20 +260,18 @@ func emitConfiguredGen(cfg Config, pkgName string, file *ast.File, res *resolve.
 		return nil, err
 	}
 	defer os.RemoveAll(tmpRoot)
+	entry, err := backend.PrepareEntry(pkgName, sourcePath, file, res, chk)
+	if err != nil {
+		return nil, err
+	}
 
 	result, emitErr := b.Emit(context.Background(), backend.Request{
 		Layout: backend.Layout{
 			Root:    tmpRoot,
 			Profile: "pipeline",
 		},
-		Emit: mode,
-		Entry: backend.Entry{
-			PackageName: pkgName,
-			SourcePath:  sourcePath,
-			File:        file,
-			Resolve:     res,
-			Check:       chk,
-		},
+		Emit:  mode,
+		Entry: entry,
 	})
 	if result == nil {
 		return nil, emitErr


### PR DESCRIPTION
## Summary
- lower backend entries to `internal/ir.Module` before dispatch and route the LLVM backend through the lowered IR contract
- add an IR-first `llvmgen.GenerateModule` path plus a migration bridge so supported slices run IR-first while unsupported gaps can still fall back safely
- cover the new boundary with IR-only backend tests and keep native test generation/checking on the lowered path

## Testing
- `go test ./...`