### PR TITLE
Add LLVM runtime collection containers

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -129,6 +129,8 @@ func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
 	}
 	for _, want := range []string{
 		"osty_rt_list_new",
+		"osty_rt_map_new",
+		"osty_rt_set_new",
 		"osty_rt_strings_Equal",
 		"osty.gc.pre_write_v1",
 		"osty.gc.load_v1",
@@ -411,6 +413,104 @@ fn main() {
 		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
 	}
 	if got, want := string(output), "3\n3\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryCollectionsUseRuntimeContainers(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `struct Pair {
+    left: Int
+    right: Int
+}
+
+fn main() {
+    let mut pairs: Map<Int, Pair> = {:}
+    pairs.insert(1, Pair { left: 2, right: 3 })
+    if pairs.containsKey(1) {
+        println(1)
+    } else {
+        println(0)
+    }
+    let pair = pairs[1]
+    println(pair.left + pair.right)
+
+    let keys = pairs.keys().sorted()
+    println(keys[0])
+
+    let mut values: List<Pair> = []
+    values.push(Pair { left: 4, right: 6 })
+    let value = values[0]
+    println(value.left + value.right)
+
+    let mut nums: List<Int> = [1]
+    nums[0] = 9
+    println(nums[0])
+
+    let empty: List<Int> = []
+    let mut seen = empty.toSet()
+    seen.insert(7)
+    seen.insert(7)
+    println(seen.len())
+    let ids = seen.toList()
+    println(ids[0])
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n5\n1\n10\n9\n1\n7\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryManagedAggregateContainersSurvivePressureGC(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `struct Bucket {
+    ids: List<Int>
+}
+
+fn main() {
+    let ids: List<Int> = [7]
+    let mut buckets: Map<String, Bucket> = {:}
+    buckets.insert("root", Bucket { ids: ids })
+    let bucket = buckets["root"]
+
+    let empty: List<Int> = []
+    let mut seen = empty.toSet()
+    seen.insert(7)
+
+    println(bucket.ids[0])
+    println(seen.len())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	cmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "7\n1\n"; got != want {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -8,6 +8,7 @@
 
 typedef void (*osty_gc_trace_fn)(void *payload);
 typedef void (*osty_gc_destroy_fn)(void *payload);
+typedef void (*osty_rt_trace_slot_fn)(void *slot_addr);
 
 typedef struct osty_gc_header {
     struct osty_gc_header *next;
@@ -26,9 +27,27 @@ typedef struct osty_rt_list {
     int64_t len;
     int64_t cap;
     size_t elem_size;
-    bool pointer_elems;
+    osty_rt_trace_slot_fn trace_elem;
     unsigned char *data;
 } osty_rt_list;
+
+typedef struct osty_rt_map {
+    int64_t len;
+    int64_t cap;
+    int64_t key_kind;
+    int64_t value_kind;
+    size_t value_size;
+    osty_rt_trace_slot_fn value_trace;
+    unsigned char *keys;
+    unsigned char *values;
+} osty_rt_map;
+
+typedef struct osty_rt_set {
+    int64_t len;
+    int64_t cap;
+    int64_t elem_kind;
+    unsigned char *items;
+} osty_rt_set;
 
 #if defined(__APPLE__)
 #define OSTY_GC_SYMBOL(name) "_" name
@@ -40,6 +59,17 @@ enum {
     OSTY_GC_KIND_GENERIC = 1,
     OSTY_GC_KIND_LIST = 1024,
     OSTY_GC_KIND_STRING = 1025,
+    OSTY_GC_KIND_MAP = 1026,
+    OSTY_GC_KIND_SET = 1027,
+};
+
+enum {
+    OSTY_RT_ABI_I64 = 1,
+    OSTY_RT_ABI_I1 = 2,
+    OSTY_RT_ABI_F64 = 3,
+    OSTY_RT_ABI_PTR = 4,
+    OSTY_RT_ABI_STRING = 5,
+    OSTY_RT_ABI_INLINE = 6,
 };
 
 static osty_gc_header *osty_gc_objects = NULL;
@@ -61,6 +91,7 @@ static int64_t osty_gc_load_managed_count = 0;
 
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
 void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+void osty_gc_mark_slot_v1(void *slot_addr) __asm__(OSTY_GC_SYMBOL("osty.gc.mark_slot_v1"));
 
 static void osty_rt_abort(const char *message) {
     fprintf(stderr, "osty llvm runtime: %s\n", message);
@@ -166,20 +197,18 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
 }
 
 static void osty_gc_mark_payload(void *payload);
+bool osty_rt_strings_Equal(const char *left, const char *right);
+bool osty_rt_set_insert_i64(void *raw_set, int64_t item);
 
 static void osty_rt_list_trace(void *payload) {
     osty_rt_list *list = (osty_rt_list *)payload;
     int64_t i;
 
-    if (list == NULL || !list->pointer_elems || list->data == NULL) {
+    if (list == NULL || list->trace_elem == NULL || list->data == NULL) {
         return;
     }
     for (i = 0; i < list->len; i++) {
-        void *child = NULL;
-        memcpy(&child, list->data + ((size_t)i * list->elem_size), sizeof(child));
-        if (child != NULL) {
-            osty_gc_mark_payload(child);
-        }
+        list->trace_elem((void *)(list->data + ((size_t)i * list->elem_size)));
     }
 }
 
@@ -187,6 +216,83 @@ static void osty_rt_list_destroy(void *payload) {
     osty_rt_list *list = (osty_rt_list *)payload;
     if (list != NULL) {
         free(list->data);
+    }
+}
+
+static bool osty_rt_value_equals(const void *left, const void *right, size_t size, int64_t kind) {
+    if (kind == OSTY_RT_ABI_STRING) {
+        const char *left_value = NULL;
+        const char *right_value = NULL;
+        memcpy(&left_value, left, sizeof(left_value));
+        memcpy(&right_value, right, sizeof(right_value));
+        return osty_rt_strings_Equal(left_value, right_value);
+    }
+    return memcmp(left, right, size) == 0;
+}
+
+static size_t osty_rt_kind_size(int64_t kind) {
+    switch (kind) {
+    case OSTY_RT_ABI_I64:
+    case OSTY_RT_ABI_F64:
+        return sizeof(int64_t);
+    case OSTY_RT_ABI_PTR:
+    case OSTY_RT_ABI_STRING:
+        return sizeof(void *);
+    case OSTY_RT_ABI_I1:
+        return sizeof(bool);
+    default:
+        osty_rt_abort("unsupported runtime ABI kind");
+        return 0;
+    }
+}
+
+static void osty_rt_map_trace(void *payload) {
+    osty_rt_map *map = (osty_rt_map *)payload;
+    int64_t i;
+
+    if (map == NULL) {
+        return;
+    }
+    for (i = 0; i < map->len; i++) {
+        unsigned char *key_slot = map->keys + ((size_t)i * osty_rt_kind_size(map->key_kind));
+        unsigned char *value_slot = map->values + ((size_t)i * map->value_size);
+        if (map->key_kind == OSTY_RT_ABI_STRING || map->key_kind == OSTY_RT_ABI_PTR) {
+            osty_gc_mark_slot_v1((void *)key_slot);
+        }
+        if (map->value_kind == OSTY_RT_ABI_STRING || map->value_kind == OSTY_RT_ABI_PTR) {
+            osty_gc_mark_slot_v1((void *)value_slot);
+        } else if (map->value_trace != NULL) {
+            map->value_trace((void *)value_slot);
+        }
+    }
+}
+
+static void osty_rt_map_destroy(void *payload) {
+    osty_rt_map *map = (osty_rt_map *)payload;
+    if (map != NULL) {
+        free(map->keys);
+        free(map->values);
+    }
+}
+
+static void osty_rt_set_trace(void *payload) {
+    osty_rt_set *set = (osty_rt_set *)payload;
+    int64_t i;
+    size_t elem_size;
+
+    if (set == NULL || (set->elem_kind != OSTY_RT_ABI_STRING && set->elem_kind != OSTY_RT_ABI_PTR)) {
+        return;
+    }
+    elem_size = osty_rt_kind_size(set->elem_kind);
+    for (i = 0; i < set->len; i++) {
+        osty_gc_mark_slot_v1((void *)(set->items + ((size_t)i * elem_size)));
+    }
+}
+
+static void osty_rt_set_destroy(void *payload) {
+    osty_rt_set *set = (osty_rt_set *)payload;
+    if (set != NULL) {
+        free(set->items);
     }
 }
 
@@ -280,17 +386,17 @@ static osty_rt_list *osty_rt_list_cast(void *raw_list) {
     return (osty_rt_list *)raw_list;
 }
 
-static void osty_rt_list_ensure_layout(osty_rt_list *list, size_t elem_size, bool pointer_elems) {
+static void osty_rt_list_ensure_layout(osty_rt_list *list, size_t elem_size, osty_rt_trace_slot_fn trace_elem) {
     if (list->elem_size == 0) {
         list->elem_size = elem_size;
-        list->pointer_elems = pointer_elems;
+        list->trace_elem = trace_elem;
         return;
     }
     if (list->elem_size != elem_size) {
         osty_rt_abort("list element size mismatch");
     }
-    if (list->pointer_elems != pointer_elems) {
-        osty_rt_abort("list element pointer-kind mismatch");
+    if (list->trace_elem != trace_elem) {
+        osty_rt_abort("list element trace-kind mismatch");
     }
 }
 
@@ -327,21 +433,26 @@ static void osty_rt_list_reserve(osty_rt_list *list, int64_t min_cap) {
     list->cap = next_cap;
 }
 
-static void osty_rt_list_push_bytes(void *raw_list, const void *value, size_t elem_size, bool pointer_elems) {
+static void osty_rt_list_push_raw(void *raw_list, const void *value, size_t elem_size, osty_rt_trace_slot_fn trace_elem) {
     osty_rt_list *list = osty_rt_list_cast(raw_list);
-    osty_rt_list_ensure_layout(list, elem_size, pointer_elems);
+    osty_rt_list_ensure_layout(list, elem_size, trace_elem);
     osty_rt_list_reserve(list, list->len + 1);
     memcpy(list->data + ((size_t)list->len * list->elem_size), value, elem_size);
     list->len += 1;
 }
 
-static void *osty_rt_list_get_bytes(void *raw_list, int64_t index, size_t elem_size, bool pointer_elems) {
+static void *osty_rt_list_get_raw(void *raw_list, int64_t index, size_t elem_size, osty_rt_trace_slot_fn trace_elem) {
     osty_rt_list *list = osty_rt_list_cast(raw_list);
     if (index < 0 || index >= list->len) {
         osty_rt_abort("list index out of range");
     }
-    osty_rt_list_ensure_layout(list, elem_size, pointer_elems);
+    osty_rt_list_ensure_layout(list, elem_size, trace_elem);
     return list->data + ((size_t)index * list->elem_size);
+}
+
+static void osty_rt_list_set_raw(void *raw_list, int64_t index, const void *value, size_t elem_size, osty_rt_trace_slot_fn trace_elem) {
+    void *slot = osty_rt_list_get_raw(raw_list, index, elem_size, trace_elem);
+    memcpy(slot, value, elem_size);
 }
 
 static char *osty_rt_string_dup_range(const char *start, size_t len) {
@@ -363,44 +474,108 @@ int64_t osty_rt_list_len(void *raw_list) {
 }
 
 void osty_rt_list_push_i64(void *raw_list, int64_t value) {
-    osty_rt_list_push_bytes(raw_list, &value, sizeof(value), false);
+    osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }
 
 void osty_rt_list_push_i1(void *raw_list, bool value) {
-    osty_rt_list_push_bytes(raw_list, &value, sizeof(value), false);
+    osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }
 
 void osty_rt_list_push_f64(void *raw_list, double value) {
-    osty_rt_list_push_bytes(raw_list, &value, sizeof(value), false);
+    osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }
 
 void osty_rt_list_push_ptr(void *raw_list, void *value) {
-    osty_rt_list_push_bytes(raw_list, &value, sizeof(value), true);
+    osty_rt_list_push_raw(raw_list, &value, sizeof(value), osty_gc_mark_slot_v1);
     osty_gc_post_write_v1(raw_list, value, OSTY_GC_KIND_LIST);
+}
+
+void osty_rt_list_push_bytes(void *raw_list, const void *value, int64_t elem_size, osty_rt_trace_slot_fn trace_elem) {
+    if (elem_size < 0) {
+        osty_rt_abort("negative list element size");
+    }
+    osty_rt_list_push_raw(raw_list, value, (size_t)elem_size, trace_elem);
 }
 
 int64_t osty_rt_list_get_i64(void *raw_list, int64_t index) {
     int64_t value;
-    memcpy(&value, osty_rt_list_get_bytes(raw_list, index, sizeof(value), false), sizeof(value));
+    memcpy(&value, osty_rt_list_get_raw(raw_list, index, sizeof(value), NULL), sizeof(value));
     return value;
 }
 
 bool osty_rt_list_get_i1(void *raw_list, int64_t index) {
     bool value;
-    memcpy(&value, osty_rt_list_get_bytes(raw_list, index, sizeof(value), false), sizeof(value));
+    memcpy(&value, osty_rt_list_get_raw(raw_list, index, sizeof(value), NULL), sizeof(value));
     return value;
 }
 
 double osty_rt_list_get_f64(void *raw_list, int64_t index) {
     double value;
-    memcpy(&value, osty_rt_list_get_bytes(raw_list, index, sizeof(value), false), sizeof(value));
+    memcpy(&value, osty_rt_list_get_raw(raw_list, index, sizeof(value), NULL), sizeof(value));
     return value;
 }
 
 void *osty_rt_list_get_ptr(void *raw_list, int64_t index) {
     void *value;
-    memcpy(&value, osty_rt_list_get_bytes(raw_list, index, sizeof(value), true), sizeof(value));
+    memcpy(&value, osty_rt_list_get_raw(raw_list, index, sizeof(value), osty_gc_mark_slot_v1), sizeof(value));
     return osty_gc_load_v1(value);
+}
+
+void osty_rt_list_get_bytes(void *raw_list, int64_t index, void *out_value, int64_t elem_size, osty_rt_trace_slot_fn trace_elem) {
+    if (out_value == NULL || elem_size < 0) {
+        osty_rt_abort("invalid list get_bytes call");
+    }
+    memcpy(out_value, osty_rt_list_get_raw(raw_list, index, (size_t)elem_size, trace_elem), (size_t)elem_size);
+}
+
+void osty_rt_list_set_i64(void *raw_list, int64_t index, int64_t value) {
+    osty_rt_list_set_raw(raw_list, index, &value, sizeof(value), NULL);
+}
+
+void osty_rt_list_set_i1(void *raw_list, int64_t index, bool value) {
+    osty_rt_list_set_raw(raw_list, index, &value, sizeof(value), NULL);
+}
+
+void osty_rt_list_set_f64(void *raw_list, int64_t index, double value) {
+    osty_rt_list_set_raw(raw_list, index, &value, sizeof(value), NULL);
+}
+
+void osty_rt_list_set_ptr(void *raw_list, int64_t index, void *value) {
+    osty_rt_list_set_raw(raw_list, index, &value, sizeof(value), osty_gc_mark_slot_v1);
+    osty_gc_post_write_v1(raw_list, value, OSTY_GC_KIND_LIST);
+}
+
+void osty_rt_list_set_bytes(void *raw_list, int64_t index, const void *value, int64_t elem_size, osty_rt_trace_slot_fn trace_elem) {
+    if (value == NULL || elem_size < 0) {
+        osty_rt_abort("invalid list set_bytes call");
+    }
+    osty_rt_list_set_raw(raw_list, index, value, (size_t)elem_size, trace_elem);
+}
+
+static int osty_rt_compare_i64_ascending(const void *left, const void *right) {
+    const int64_t left_value = *(const int64_t *)left;
+    const int64_t right_value = *(const int64_t *)right;
+    if (left_value < right_value) {
+        return -1;
+    }
+    if (left_value > right_value) {
+        return 1;
+    }
+    return 0;
+}
+
+void *osty_rt_list_sorted_i64(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    void *out = osty_rt_list_new();
+    int64_t i;
+
+    osty_rt_list_ensure_layout(list, sizeof(int64_t), NULL);
+    for (i = 0; i < list->len; i++) {
+        int64_t value = osty_rt_list_get_i64(raw_list, i);
+        osty_rt_list_push_i64(out, value);
+    }
+    qsort(osty_rt_list_cast(out)->data, (size_t)osty_rt_list_cast(out)->len, sizeof(int64_t), osty_rt_compare_i64_ascending);
+    return out;
 }
 
 bool osty_rt_strings_Equal(const char *left, const char *right) {
@@ -446,6 +621,324 @@ void *osty_rt_strings_Split(const char *value, const char *sep) {
     osty_rt_list_push_ptr(out, osty_rt_string_dup_range(cursor, strlen(cursor)));
     return out;
 }
+
+static void *osty_rt_map_value_slot(osty_rt_map *map, int64_t index) {
+    return (void *)(map->values + ((size_t)index * map->value_size));
+}
+
+static void *osty_rt_map_key_slot(osty_rt_map *map, int64_t index) {
+    return (void *)(map->keys + ((size_t)index * osty_rt_kind_size(map->key_kind)));
+}
+
+static void osty_rt_map_reserve(osty_rt_map *map, int64_t min_cap) {
+    int64_t next_cap = map->cap;
+    size_t key_bytes;
+    size_t value_bytes;
+
+    if (min_cap <= map->cap) {
+        return;
+    }
+    if (next_cap < 4) {
+        next_cap = 4;
+    }
+    while (next_cap < min_cap) {
+        if (next_cap > INT64_MAX / 2) {
+            next_cap = min_cap;
+            break;
+        }
+        next_cap *= 2;
+    }
+    key_bytes = (size_t)next_cap * osty_rt_kind_size(map->key_kind);
+    value_bytes = (size_t)next_cap * map->value_size;
+    map->keys = (unsigned char *)realloc(map->keys, key_bytes);
+    map->values = (unsigned char *)realloc(map->values, value_bytes);
+    if (map->keys == NULL || map->values == NULL) {
+        osty_rt_abort("out of memory");
+    }
+    map->cap = next_cap;
+}
+
+static int64_t osty_rt_map_find_index(osty_rt_map *map, const void *key) {
+    int64_t i;
+    size_t key_size = osty_rt_kind_size(map->key_kind);
+    for (i = 0; i < map->len; i++) {
+        if (osty_rt_value_equals(osty_rt_map_key_slot(map, i), key, key_size, map->key_kind)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, osty_rt_trace_slot_fn value_trace) {
+    osty_rt_map *map;
+    if (value_size <= 0) {
+        osty_rt_abort("invalid map value size");
+    }
+    if (key_kind != OSTY_RT_ABI_I64 && key_kind != OSTY_RT_ABI_I1 && key_kind != OSTY_RT_ABI_F64 && key_kind != OSTY_RT_ABI_PTR && key_kind != OSTY_RT_ABI_STRING) {
+        osty_rt_abort("unsupported map key kind");
+    }
+    map = (osty_rt_map *)osty_gc_allocate_managed(sizeof(osty_rt_map), OSTY_GC_KIND_MAP, "runtime.map", osty_rt_map_trace, osty_rt_map_destroy);
+    map->key_kind = key_kind;
+    map->value_kind = value_kind;
+    map->value_size = (size_t)value_size;
+    map->value_trace = value_trace;
+    return map;
+}
+
+static bool osty_rt_map_contains_raw(void *raw_map, const void *key) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    return map != NULL && osty_rt_map_find_index(map, key) >= 0;
+}
+
+static void osty_rt_map_insert_raw(void *raw_map, const void *key, const void *value) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    int64_t index;
+    size_t key_size;
+    if (map == NULL || key == NULL || value == NULL) {
+        osty_rt_abort("invalid map insert");
+    }
+    key_size = osty_rt_kind_size(map->key_kind);
+    index = osty_rt_map_find_index(map, key);
+    if (index < 0) {
+        osty_rt_map_reserve(map, map->len + 1);
+        index = map->len;
+        map->len += 1;
+    }
+    memcpy(osty_rt_map_key_slot(map, index), key, key_size);
+    memcpy(osty_rt_map_value_slot(map, index), value, map->value_size);
+}
+
+static bool osty_rt_map_remove_raw(void *raw_map, const void *key) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    int64_t index;
+    size_t key_size;
+    size_t value_size;
+    if (map == NULL || key == NULL) {
+        osty_rt_abort("invalid map remove");
+    }
+    index = osty_rt_map_find_index(map, key);
+    if (index < 0) {
+        return false;
+    }
+    key_size = osty_rt_kind_size(map->key_kind);
+    value_size = map->value_size;
+    if (index + 1 < map->len) {
+        memmove(osty_rt_map_key_slot(map, index), osty_rt_map_key_slot(map, index + 1), (size_t)(map->len - index - 1) * key_size);
+        memmove(osty_rt_map_value_slot(map, index), osty_rt_map_value_slot(map, index + 1), (size_t)(map->len - index - 1) * value_size);
+    }
+    map->len -= 1;
+    return true;
+}
+
+static void osty_rt_map_get_or_abort_raw(void *raw_map, const void *key, void *out_value) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    int64_t index;
+    if (map == NULL || key == NULL || out_value == NULL) {
+        osty_rt_abort("invalid map get");
+    }
+    index = osty_rt_map_find_index(map, key);
+    if (index < 0) {
+        osty_rt_abort("map key not found");
+    }
+    memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
+}
+
+void *osty_rt_map_keys(void *raw_map) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    void *out = osty_rt_list_new();
+    int64_t i;
+    if (map == NULL) {
+        osty_rt_abort("map is null");
+    }
+    for (i = 0; i < map->len; i++) {
+        switch (map->key_kind) {
+        case OSTY_RT_ABI_I64: {
+            int64_t value = 0;
+            memcpy(&value, osty_rt_map_key_slot(map, i), sizeof(value));
+            osty_rt_list_push_i64(out, value);
+            break;
+        }
+        case OSTY_RT_ABI_I1: {
+            bool value = false;
+            memcpy(&value, osty_rt_map_key_slot(map, i), sizeof(value));
+            osty_rt_list_push_i1(out, value);
+            break;
+        }
+        case OSTY_RT_ABI_F64: {
+            double value = 0.0;
+            memcpy(&value, osty_rt_map_key_slot(map, i), sizeof(value));
+            osty_rt_list_push_f64(out, value);
+            break;
+        }
+        case OSTY_RT_ABI_PTR:
+        case OSTY_RT_ABI_STRING: {
+            void *value = NULL;
+            memcpy(&value, osty_rt_map_key_slot(map, i), sizeof(value));
+            osty_rt_list_push_ptr(out, value);
+            break;
+        }
+        default:
+            osty_rt_abort("unsupported map key list kind");
+        }
+    }
+    return out;
+}
+
+#define OSTY_RT_DEFINE_MAP_KEY_OPS(suffix, ctype) \
+bool osty_rt_map_contains_##suffix(void *raw_map, ctype key) { return osty_rt_map_contains_raw(raw_map, &key); } \
+void osty_rt_map_insert_##suffix(void *raw_map, ctype key, const void *value) { osty_rt_map_insert_raw(raw_map, &key, value); } \
+bool osty_rt_map_remove_##suffix(void *raw_map, ctype key) { return osty_rt_map_remove_raw(raw_map, &key); } \
+void osty_rt_map_get_or_abort_##suffix(void *raw_map, ctype key, void *out_value) { osty_rt_map_get_or_abort_raw(raw_map, &key, out_value); }
+
+OSTY_RT_DEFINE_MAP_KEY_OPS(i64, int64_t)
+OSTY_RT_DEFINE_MAP_KEY_OPS(i1, bool)
+OSTY_RT_DEFINE_MAP_KEY_OPS(f64, double)
+OSTY_RT_DEFINE_MAP_KEY_OPS(ptr, void *)
+OSTY_RT_DEFINE_MAP_KEY_OPS(string, const char *)
+
+static void osty_rt_set_reserve(osty_rt_set *set, int64_t min_cap) {
+    int64_t next_cap = set->cap;
+    size_t bytes;
+    if (min_cap <= set->cap) {
+        return;
+    }
+    if (next_cap < 4) {
+        next_cap = 4;
+    }
+    while (next_cap < min_cap) {
+        if (next_cap > INT64_MAX / 2) {
+            next_cap = min_cap;
+            break;
+        }
+        next_cap *= 2;
+    }
+    bytes = (size_t)next_cap * osty_rt_kind_size(set->elem_kind);
+    set->items = (unsigned char *)realloc(set->items, bytes);
+    if (set->items == NULL) {
+        osty_rt_abort("out of memory");
+    }
+    set->cap = next_cap;
+}
+
+static int64_t osty_rt_set_find_index(osty_rt_set *set, const void *item) {
+    int64_t i;
+    size_t elem_size = osty_rt_kind_size(set->elem_kind);
+    for (i = 0; i < set->len; i++) {
+        if (osty_rt_value_equals(set->items + ((size_t)i * elem_size), item, elem_size, set->elem_kind)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void *osty_rt_set_new(int64_t elem_kind) {
+    osty_rt_set *set;
+    if (elem_kind != OSTY_RT_ABI_I64 && elem_kind != OSTY_RT_ABI_I1 && elem_kind != OSTY_RT_ABI_F64 && elem_kind != OSTY_RT_ABI_PTR && elem_kind != OSTY_RT_ABI_STRING) {
+        osty_rt_abort("unsupported set element kind");
+    }
+    set = (osty_rt_set *)osty_gc_allocate_managed(sizeof(osty_rt_set), OSTY_GC_KIND_SET, "runtime.set", osty_rt_set_trace, osty_rt_set_destroy);
+    set->elem_kind = elem_kind;
+    return set;
+}
+
+int64_t osty_rt_set_len(void *raw_set) {
+    osty_rt_set *set = (osty_rt_set *)raw_set;
+    if (set == NULL) {
+        osty_rt_abort("set is null");
+    }
+    return set->len;
+}
+
+void *osty_rt_set_to_list(void *raw_set) {
+    osty_rt_set *set = (osty_rt_set *)raw_set;
+    void *out = osty_rt_list_new();
+    int64_t i;
+    if (set == NULL) {
+        osty_rt_abort("set is null");
+    }
+    for (i = 0; i < set->len; i++) {
+        switch (set->elem_kind) {
+        case OSTY_RT_ABI_I64: {
+            int64_t value = 0;
+            memcpy(&value, set->items + ((size_t)i * sizeof(value)), sizeof(value));
+            osty_rt_list_push_i64(out, value);
+            break;
+        }
+        case OSTY_RT_ABI_I1: {
+            bool value = false;
+            memcpy(&value, set->items + ((size_t)i * sizeof(value)), sizeof(value));
+            osty_rt_list_push_i1(out, value);
+            break;
+        }
+        case OSTY_RT_ABI_F64: {
+            double value = 0.0;
+            memcpy(&value, set->items + ((size_t)i * sizeof(value)), sizeof(value));
+            osty_rt_list_push_f64(out, value);
+            break;
+        }
+        case OSTY_RT_ABI_PTR:
+        case OSTY_RT_ABI_STRING: {
+            void *value = NULL;
+            memcpy(&value, set->items + ((size_t)i * sizeof(value)), sizeof(value));
+            osty_rt_list_push_ptr(out, value);
+            break;
+        }
+        default:
+            osty_rt_abort("unsupported set element list kind");
+        }
+    }
+    return out;
+}
+
+void *osty_rt_list_to_set_i64(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    void *set = osty_rt_set_new(OSTY_RT_ABI_I64);
+    int64_t i;
+
+    osty_rt_list_ensure_layout(list, sizeof(int64_t), NULL);
+    for (i = 0; i < list->len; i++) {
+        int64_t value = osty_rt_list_get_i64(raw_list, i);
+        osty_rt_set_insert_i64(set, value);
+    }
+    return set;
+}
+
+#define OSTY_RT_DEFINE_SET_KEY_OPS(suffix, ctype) \
+bool osty_rt_set_contains_##suffix(void *raw_set, ctype item) { \
+    osty_rt_set *set = (osty_rt_set *)raw_set; \
+    return set != NULL && osty_rt_set_find_index(set, &item) >= 0; \
+} \
+bool osty_rt_set_insert_##suffix(void *raw_set, ctype item) { \
+    osty_rt_set *set = (osty_rt_set *)raw_set; \
+    size_t elem_size; \
+    if (set == NULL) { osty_rt_abort("set is null"); } \
+    if (osty_rt_set_find_index(set, &item) >= 0) { return false; } \
+    elem_size = osty_rt_kind_size(set->elem_kind); \
+    osty_rt_set_reserve(set, set->len + 1); \
+    memcpy(set->items + ((size_t)set->len * elem_size), &item, elem_size); \
+    set->len += 1; \
+    return true; \
+} \
+bool osty_rt_set_remove_##suffix(void *raw_set, ctype item) { \
+    osty_rt_set *set = (osty_rt_set *)raw_set; \
+    int64_t index; \
+    size_t elem_size; \
+    if (set == NULL) { osty_rt_abort("set is null"); } \
+    index = osty_rt_set_find_index(set, &item); \
+    if (index < 0) { return false; } \
+    elem_size = osty_rt_kind_size(set->elem_kind); \
+    if (index + 1 < set->len) { \
+        memmove(set->items + ((size_t)index * elem_size), set->items + ((size_t)(index + 1) * elem_size), (size_t)(set->len - index - 1) * elem_size); \
+    } \
+    set->len -= 1; \
+    return true; \
+}
+
+OSTY_RT_DEFINE_SET_KEY_OPS(i64, int64_t)
+OSTY_RT_DEFINE_SET_KEY_OPS(i1, bool)
+OSTY_RT_DEFINE_SET_KEY_OPS(f64, double)
+OSTY_RT_DEFINE_SET_KEY_OPS(ptr, void *)
+OSTY_RT_DEFINE_SET_KEY_OPS(string, const char *)
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
 void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
@@ -507,6 +1000,10 @@ void *osty_gc_load_v1(void *value) {
         osty_gc_load_managed_count += 1;
     }
     return value;
+}
+
+void osty_gc_mark_slot_v1(void *slot_addr) {
+    osty_gc_mark_root_slot(slot_addr);
 }
 
 void osty_gc_root_bind_v1(void *root) {

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -196,6 +196,7 @@ func Generate(file *ast.File, opts Options) ([]byte, error) {
 		runtimeFFI:      map[string]map[string]*runtimeFFIFunction{},
 		runtimeFFIPaths: map[string]string{},
 		runtimeDecls:    map[string]runtimeDecl{},
+		traceHelpers:    map[string]string{},
 	}
 	if len(file.Stmts) > 0 {
 		if len(file.Decls) > 0 {
@@ -279,6 +280,8 @@ type generator struct {
 	testingAliases   map[string]bool
 	runtimeDecls     map[string]runtimeDecl
 	runtimeDeclOrder []string
+	traceHelpers     map[string]string
+	traceHelperDefs  []string
 
 	temp             int
 	label            int
@@ -329,6 +332,12 @@ type fnSig struct {
 	receiverMut    bool
 	ret            string
 	retListElemTyp string
+	retListString  bool
+	retMapKeyTyp   string
+	retMapValueTyp string
+	retMapKeyString bool
+	retSetElemTyp  string
+	retSetElemString bool
 	params         []paramInfo
 	decl           *ast.FnDecl
 }
@@ -338,6 +347,12 @@ type paramInfo struct {
 	typ         string
 	irTyp       string
 	listElemTyp string
+	listElemString bool
+	mapKeyTyp   string
+	mapValueTyp string
+	mapKeyString bool
+	setElemTyp  string
+	setElemString bool
 	mutable     bool
 	byRef       bool
 }
@@ -355,6 +370,12 @@ type fieldInfo struct {
 	typ         string
 	index       int
 	listElemTyp string
+	listElemString bool
+	mapKeyTyp   string
+	mapValueTyp string
+	mapKeyString bool
+	setElemTyp  string
+	setElemString bool
 }
 
 type enumInfo struct {
@@ -393,6 +414,12 @@ type value struct {
 	mutable     bool
 	gcManaged   bool
 	listElemTyp string
+	listElemString bool
+	mapKeyTyp   string
+	mapValueTyp string
+	mapKeyString bool
+	setElemTyp  string
+	setElemString bool
 	rootPaths   [][]int
 }
 
@@ -691,6 +718,53 @@ func llvmListElementType(t ast.Type, structs map[string]*structInfo, enums map[s
 	return elemTyp, true, nil
 }
 
+func llvmListElementInfo(t ast.Type, structs map[string]*structInfo, enums map[string]*enumInfo) (string, bool, bool, error) {
+	elemTyp, ok, err := llvmListElementType(t, structs, enums)
+	if err != nil || !ok {
+		return elemTyp, false, ok, err
+	}
+	return elemTyp, llvmNamedTypeIsString(t.(*ast.NamedType).Args[0]), true, nil
+}
+
+func llvmMapTypes(t ast.Type, structs map[string]*structInfo, enums map[string]*enumInfo) (string, string, bool, bool, error) {
+	named, ok := t.(*ast.NamedType)
+	if !ok {
+		return "", "", false, false, nil
+	}
+	if len(named.Path) != 1 || named.Path[0] != "Map" || len(named.Args) != 2 {
+		return "", "", false, false, nil
+	}
+	keyTyp, err := llvmRuntimeABIType(named.Args[0], structs, enums)
+	if err != nil {
+		return "", "", false, true, err
+	}
+	valueTyp, err := llvmRuntimeABIType(named.Args[1], structs, enums)
+	if err != nil {
+		return "", "", false, true, err
+	}
+	return keyTyp, valueTyp, llvmNamedTypeIsString(named.Args[0]), true, nil
+}
+
+func llvmSetElementType(t ast.Type, structs map[string]*structInfo, enums map[string]*enumInfo) (string, bool, bool, error) {
+	named, ok := t.(*ast.NamedType)
+	if !ok {
+		return "", false, false, nil
+	}
+	if len(named.Path) != 1 || named.Path[0] != "Set" || len(named.Args) != 1 {
+		return "", false, false, nil
+	}
+	elemTyp, err := llvmRuntimeABIType(named.Args[0], structs, enums)
+	if err != nil {
+		return "", false, true, err
+	}
+	return elemTyp, llvmNamedTypeIsString(named.Args[0]), true, nil
+}
+
+func llvmNamedTypeIsString(t ast.Type) bool {
+	named, ok := t.(*ast.NamedType)
+	return ok && len(named.Path) == 1 && named.Path[0] == "String" && len(named.Args) == 0
+}
+
 func collectStructShell(decl *ast.StructDecl) (*structInfo, error) {
 	if decl == nil {
 		return nil, unsupported("source-layout", "nil struct")
@@ -731,11 +805,27 @@ func collectStructFields(info *structInfo, structs map[string]*structInfo, enums
 			return unsupported(diag.kind, diag.message)
 		}
 		fieldInfo := fieldInfo{name: field.Name, typ: typ, index: i}
-		if listElemTyp, ok, err := llvmListElementType(field.Type, structs, enums); err != nil {
+		if listElemTyp, listElemString, ok, err := llvmListElementInfo(field.Type, structs, enums); err != nil {
 			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
 			return unsupported(diag.kind, diag.message)
 		} else if ok {
 			fieldInfo.listElemTyp = listElemTyp
+			fieldInfo.listElemString = listElemString
+		}
+		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(field.Type, structs, enums); err != nil {
+			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
+			return unsupported(diag.kind, diag.message)
+		} else if ok {
+			fieldInfo.mapKeyTyp = mapKeyTyp
+			fieldInfo.mapValueTyp = mapValueTyp
+			fieldInfo.mapKeyString = mapKeyString
+		}
+		if setElemTyp, setElemString, ok, err := llvmSetElementType(field.Type, structs, enums); err != nil {
+			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
+			return unsupported(diag.kind, diag.message)
+		} else if ok {
+			fieldInfo.setElemTyp = setElemTyp
+			fieldInfo.setElemString = setElemString
 		}
 		info.fields = append(info.fields, fieldInfo)
 		info.byName[field.Name] = fieldInfo
@@ -880,18 +970,48 @@ func signatureOf(fn *ast.FnDecl, ownerName string, structs map[string]*structInf
 			return nil, unsupported(diag.kind, diag.message)
 		}
 		info := paramInfo{name: p.Name, typ: typ}
-		if listElemTyp, ok, err := llvmListElementType(p.Type, structs, enums); err != nil {
+		if listElemTyp, listElemString, ok, err := llvmListElementInfo(p.Type, structs, enums); err != nil {
 			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
 			return nil, unsupported(diag.kind, diag.message)
 		} else if ok {
 			info.listElemTyp = listElemTyp
+			info.listElemString = listElemString
+		}
+		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(p.Type, structs, enums); err != nil {
+			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
+			return nil, unsupported(diag.kind, diag.message)
+		} else if ok {
+			info.mapKeyTyp = mapKeyTyp
+			info.mapValueTyp = mapValueTyp
+			info.mapKeyString = mapKeyString
+		}
+		if setElemTyp, setElemString, ok, err := llvmSetElementType(p.Type, structs, enums); err != nil {
+			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
+			return nil, unsupported(diag.kind, diag.message)
+		} else if ok {
+			info.setElemTyp = setElemTyp
+			info.setElemString = setElemString
 		}
 		sig.params = append(sig.params, info)
 	}
-	if listElemTyp, ok, err := llvmListElementType(fn.ReturnType, structs, enums); err != nil {
+	if listElemTyp, listElemString, ok, err := llvmListElementInfo(fn.ReturnType, structs, enums); err != nil {
 		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
 	} else if ok {
 		sig.retListElemTyp = listElemTyp
+		sig.retListString = listElemString
+	}
+	if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(fn.ReturnType, structs, enums); err != nil {
+		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
+	} else if ok {
+		sig.retMapKeyTyp = mapKeyTyp
+		sig.retMapValueTyp = mapValueTyp
+		sig.retMapKeyString = mapKeyString
+	}
+	if setElemTyp, setElemString, ok, err := llvmSetElementType(fn.ReturnType, structs, enums); err != nil {
+		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
+	} else if ok {
+		sig.retSetElemTyp = setElemTyp
+		sig.retSetElemString = setElemString
 	}
 	return sig, nil
 }
@@ -924,10 +1044,18 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 	g.beginFunction()
 	g.returnType = sig.ret
 	for _, p := range sig.params {
-		v := value{typ: p.typ, ref: "%" + p.name, listElemTyp: p.listElemTyp}
-		if p.listElemTyp != "" {
-			v.gcManaged = true
+		v := value{
+			typ:           p.typ,
+			ref:           "%" + p.name,
+			listElemTyp:   p.listElemTyp,
+			listElemString: p.listElemString,
+			mapKeyTyp:     p.mapKeyTyp,
+			mapValueTyp:   p.mapValueTyp,
+			mapKeyString:  p.mapKeyString,
+			setElemTyp:    p.setElemTyp,
+			setElemString: p.setElemString,
 		}
+		v.gcManaged = valueNeedsManagedRoot(v)
 		v.rootPaths = g.rootPathsForType(p.typ)
 		if p.byRef {
 			v.ptr = true
@@ -946,7 +1074,7 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 		emitter.body = append(emitter.body, "  ret void")
 		g.takeOstyEmitter(emitter)
 	} else {
-		if err := g.emitReturningBlock(sig.decl.Body.Stmts, sig.ret, sig.retListElemTyp); err != nil {
+		if err := g.emitReturningBlock(sig.decl.Body.Stmts, sig.ret, sig.retListElemTyp, sig.retMapKeyTyp, sig.retMapValueTyp, sig.retSetElemTyp); err != nil {
 			return "", err
 		}
 	}
@@ -1024,7 +1152,7 @@ func (g *generator) emitGCSafepoint(emitter *LlvmEmitter) {
 	g.needsGCRuntime = true
 }
 
-func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp string) error {
+func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp string, retMapKeyTyp string, retMapValueTyp string, retSetElemTyp string) error {
 	if len(stmts) == 0 {
 		return unsupported("function-signature", "function body has no return value")
 	}
@@ -1040,7 +1168,7 @@ func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp
 			if s.Value == nil {
 				return unsupported("function-signature", "bare return in value-returning function")
 			}
-			v, err := g.emitExprWithListHint(s.Value, retListElemTyp)
+			v, err := g.emitExprWithHint(s.Value, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
 			if err != nil {
 				return err
 			}
@@ -1053,7 +1181,7 @@ func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp
 			g.takeOstyEmitter(emitter)
 			return nil
 		case *ast.ExprStmt:
-			v, err := g.emitExprWithListHint(s.X, retListElemTyp)
+			v, err := g.emitExprWithHint(s.X, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
 			if err != nil {
 				return err
 			}
@@ -1120,14 +1248,34 @@ func (g *generator) emitLet(stmt *ast.LetStmt) error {
 		return unsupportedf("statement", "let %q has no value", name)
 	}
 	hintedListElemTyp := ""
+	hintedListElemString := false
+	hintedMapKeyTyp := ""
+	hintedMapValueTyp := ""
+	hintedMapKeyString := false
+	hintedSetElemTyp := ""
+	hintedSetElemString := false
 	if stmt.Type != nil {
-		if listElemTyp, ok, err := llvmListElementType(stmt.Type, g.structsByName, g.enumsByName); err != nil {
+		if listElemTyp, listElemString, ok, err := llvmListElementInfo(stmt.Type, g.structsByName, g.enumsByName); err != nil {
 			return err
 		} else if ok {
 			hintedListElemTyp = listElemTyp
+			hintedListElemString = listElemString
+		}
+		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(stmt.Type, g.structsByName, g.enumsByName); err != nil {
+			return err
+		} else if ok {
+			hintedMapKeyTyp = mapKeyTyp
+			hintedMapValueTyp = mapValueTyp
+			hintedMapKeyString = mapKeyString
+		}
+		if setElemTyp, setElemString, ok, err := llvmSetElementType(stmt.Type, g.structsByName, g.enumsByName); err != nil {
+			return err
+		} else if ok {
+			hintedSetElemTyp = setElemTyp
+			hintedSetElemString = setElemString
 		}
 	}
-	v, err := g.emitExprWithListHint(stmt.Value, hintedListElemTyp)
+	v, err := g.emitExprWithHint(stmt.Value, hintedListElemTyp, hintedListElemString, hintedMapKeyTyp, hintedMapValueTyp, hintedMapKeyString, hintedSetElemTyp, hintedSetElemString)
 	if err != nil {
 		return err
 	}
@@ -1160,7 +1308,7 @@ func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
 		if !slot.mutable {
 			return unsupportedf("statement", "assignment to immutable identifier %q", target.Name)
 		}
-		v, err := g.emitExprWithListHint(stmt.Value, slot.listElemTyp)
+		v, err := g.emitExprWithHint(stmt.Value, slot.listElemTyp, slot.listElemString, slot.mapKeyTyp, slot.mapValueTyp, slot.mapKeyString, slot.setElemTyp, slot.setElemString)
 		if err != nil {
 			return err
 		}
@@ -1174,6 +1322,11 @@ func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
 		return nil
 	}
 	field, ok := stmt.Targets[0].(*ast.FieldExpr)
+	if !ok {
+		if index, ok := stmt.Targets[0].(*ast.IndexExpr); ok {
+			return g.emitIndexAssign(index, stmt.Value)
+		}
+	}
 	if !ok {
 		return unsupportedf("statement", "assignment target %T", stmt.Targets[0])
 	}
@@ -1206,7 +1359,7 @@ func (g *generator) emitFieldAssign(target *ast.FieldExpr, rhs ast.Expr) error {
 	if !ok {
 		return unsupportedf("expression", "struct %q has no field %q", info.name, target.Name)
 	}
-	v, err := g.emitExprWithListHint(rhs, field.listElemTyp)
+	v, err := g.emitExprWithHint(rhs, field.listElemTyp, field.listElemString, field.mapKeyTyp, field.mapValueTyp, field.mapKeyString, field.setElemTyp, field.setElemString)
 	if err != nil {
 		return err
 	}
@@ -1233,6 +1386,59 @@ func (g *generator) emitFieldAssign(target *ast.FieldExpr, rhs ast.Expr) error {
 	return nil
 }
 
+func (g *generator) emitIndexAssign(target *ast.IndexExpr, rhs ast.Expr) error {
+	if target == nil {
+		return unsupported("statement", "nil index assignment target")
+	}
+	base, err := g.emitExpr(target.X)
+	if err != nil {
+		return err
+	}
+	if base.listElemTyp == "" {
+		return unsupported("statement", "index assignment currently supports lists only")
+	}
+	index, err := g.emitExpr(target.Index)
+	if err != nil {
+		return err
+	}
+	if index.typ != "i64" {
+		return unsupportedf("type-system", "list index type %s, want i64", index.typ)
+	}
+	v, err := g.emitExprWithHint(rhs, "", false, "", "", false, "", false)
+	if err != nil {
+		return err
+	}
+	if v.typ != base.listElemTyp {
+		return unsupportedf("type-system", "list assignment value type %s, want %s", v.typ, base.listElemTyp)
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return err
+	}
+	emitter := g.toOstyEmitter()
+	if listUsesTypedRuntime(base.listElemTyp) {
+		symbol := listRuntimeSetSymbol(base.listElemTyp)
+		g.declareRuntimeSymbol(symbol, "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: base.listElemTyp}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			symbol,
+			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), toOstyValue(loaded)}),
+		))
+	} else {
+		traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
+		addr := g.spillValueAddress(emitter, "list.set", loaded)
+		sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
+		g.declareRuntimeSymbol(listRuntimeSetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimeSetBytesSymbol(),
+				llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), {typ: "ptr", name: addr}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
+		))
+	}
+	g.takeOstyEmitter(emitter)
+	return nil
+}
+
 func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	if stmt.IsForLet {
 		return g.emitForLet(stmt)
@@ -1247,8 +1453,8 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	if err != nil {
 		return err
 	}
-	if iterTyp, elemTyp, ok := g.staticExprType(stmt.Iter); ok && iterTyp == "ptr" && elemTyp != "" {
-		return g.emitListFor(stmt, iterName, elemTyp)
+	if iterInfo, ok := g.staticExprInfo(stmt.Iter); ok && iterInfo.typ == "ptr" && iterInfo.listElemTyp != "" {
+		return g.emitListFor(stmt, iterName, iterInfo.listElemTyp)
 	}
 	rng, ok := stmt.Iter.(*ast.RangeExpr)
 	if !ok {
@@ -1461,6 +1667,12 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 		return err
 	}
 	if emitted, err := g.emitListMethodCallStmt(call); emitted || err != nil {
+		return err
+	}
+	if emitted, err := g.emitMapMethodCallStmt(call); emitted || err != nil {
+		return err
+	}
+	if emitted, err := g.emitSetMethodCallStmt(call); emitted || err != nil {
 		return err
 	}
 	if emitted, err := g.emitRuntimeFFICallStmt(call); emitted || err != nil {
@@ -1859,8 +2071,12 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 		return g.emitCall(e)
 	case *ast.FieldExpr:
 		return g.emitFieldExpr(e)
+	case *ast.IndexExpr:
+		return g.emitIndexExpr(e)
 	case *ast.ListExpr:
 		return g.emitListExprWithHint(e, "")
+	case *ast.MapExpr:
+		return g.emitMapExprWithHint(e, "", "", false)
 	case *ast.StructLit:
 		return g.emitStructLit(e)
 	case *ast.IfExpr:
@@ -1890,8 +2106,7 @@ func (g *generator) loadIfPointer(v value) (value, error) {
 	out := llvmLoad(emitter, toOstyValue(v))
 	g.takeOstyEmitter(emitter)
 	loaded := fromOstyValue(out)
-	loaded.gcManaged = v.gcManaged
-	loaded.listElemTyp = v.listElemTyp
+	copyContainerMetadata(&loaded, v)
 	loaded.rootPaths = cloneRootPaths(v.rootPaths)
 	return loaded, nil
 }
@@ -1935,7 +2150,7 @@ func (g *generator) emitStructLit(lit *ast.StructLit) (value, error) {
 		if litField.Value == nil {
 			v, err = g.emitIdent(litField.Name)
 		} else {
-			v, err = g.emitExprWithListHint(litField.Value, field.listElemTyp)
+			v, err = g.emitExprWithHint(litField.Value, field.listElemTyp, field.listElemString, field.mapKeyTyp, field.mapValueTyp, field.mapKeyString, field.setElemTyp, field.setElemString)
 		}
 		if err != nil {
 			return value{}, err
@@ -1977,9 +2192,86 @@ func (g *generator) emitFieldExpr(expr *ast.FieldExpr) (value, error) {
 	g.takeOstyEmitter(emitter)
 	loaded := fromOstyValue(out)
 	loaded.listElemTyp = field.listElemTyp
-	loaded.gcManaged = field.listElemTyp != ""
+	loaded.listElemString = field.listElemString
+	loaded.mapKeyTyp = field.mapKeyTyp
+	loaded.mapValueTyp = field.mapValueTyp
+	loaded.mapKeyString = field.mapKeyString
+	loaded.setElemTyp = field.setElemTyp
+	loaded.setElemString = field.setElemString
+	loaded.gcManaged = valueNeedsManagedRoot(loaded)
 	loaded.rootPaths = g.rootPathsForType(field.typ)
 	return loaded, nil
+}
+
+func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
+	if expr == nil {
+		return value{}, unsupported("expression", "nil index expression")
+	}
+	base, err := g.emitExpr(expr.X)
+	if err != nil {
+		return value{}, err
+	}
+	index, err := g.emitExpr(expr.Index)
+	if err != nil {
+		return value{}, err
+	}
+	switch {
+	case base.listElemTyp != "":
+		if index.typ != "i64" {
+			return value{}, unsupportedf("type-system", "list index type %s, want i64", index.typ)
+		}
+		if listUsesTypedRuntime(base.listElemTyp) {
+			symbol := listRuntimeGetSymbol(base.listElemTyp)
+			g.declareRuntimeSymbol(symbol, base.listElemTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+			emitter := g.toOstyEmitter()
+			out := llvmCall(emitter, base.listElemTyp, symbol, []*LlvmValue{toOstyValue(base), toOstyValue(index)})
+			g.takeOstyEmitter(emitter)
+			v := fromOstyValue(out)
+			v.gcManaged = base.listElemTyp == "ptr"
+			v.rootPaths = g.rootPathsForType(base.listElemTyp)
+			return v, nil
+		}
+		traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
+		emitter := g.toOstyEmitter()
+		slot := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, base.listElemTyp))
+		sizeValue := g.emitTypeSize(emitter, base.listElemTyp)
+		g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimeGetBytesSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(index), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
+		))
+		loaded := g.loadValueFromAddress(emitter, base.listElemTyp, slot)
+		g.takeOstyEmitter(emitter)
+		loaded.rootPaths = g.rootPathsForType(base.listElemTyp)
+		return loaded, nil
+	case base.mapKeyTyp != "":
+		if index.typ != base.mapKeyTyp {
+			return value{}, unsupportedf("type-system", "map index type %s, want %s", index.typ, base.mapKeyTyp)
+		}
+		loadedKey, err := g.loadIfPointer(index)
+		if err != nil {
+			return value{}, err
+		}
+		symbol := mapRuntimeGetOrAbortSymbol(base.mapKeyTyp, base.mapKeyString)
+		g.declareRuntimeSymbol(symbol, "void", []paramInfo{{typ: "ptr"}, {typ: base.mapKeyTyp}, {typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		slot := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, base.mapValueTyp))
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			symbol,
+			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(loadedKey), {typ: "ptr", name: slot}}),
+		))
+		out := g.loadValueFromAddress(emitter, base.mapValueTyp, slot)
+		g.takeOstyEmitter(emitter)
+		out.gcManaged = base.mapValueTyp == "ptr"
+		out.rootPaths = g.rootPathsForType(base.mapValueTyp)
+		return out, nil
+	default:
+		return value{}, unsupportedf("expression", "index expression on %s", base.typ)
+	}
 }
 
 func (g *generator) enumVariantValue(expr *ast.FieldExpr) (value, bool, error) {
@@ -2313,10 +2605,7 @@ func (g *generator) emitIfExprPhi(labels *LlvmIfLabels, thenPred, elsePred strin
 	g.takeOstyEmitter(emitter)
 	g.currentBlock = labels.endLabel
 	out := value{typ: thenValue.typ, ref: tmp}
-	if thenValue.listElemTyp != "" && thenValue.listElemTyp == elseValue.listElemTyp {
-		out.listElemTyp = thenValue.listElemTyp
-		out.gcManaged = thenValue.gcManaged || elseValue.gcManaged
-	}
+	mergeContainerMetadata(&out, thenValue, elseValue)
 	out.rootPaths = g.rootPathsForType(out.typ)
 	return out, nil
 }
@@ -2672,17 +2961,17 @@ func (g *generator) emitSelectValue(cond *LlvmValue, thenValue, elseValue value)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, %s %s, %s %s", tmp, cond.name, thenValue.typ, thenValue.ref, elseValue.typ, elseValue.ref))
 	g.takeOstyEmitter(emitter)
 	out := value{typ: thenValue.typ, ref: tmp}
-	if thenValue.listElemTyp != "" && thenValue.listElemTyp == elseValue.listElemTyp {
-		out.listElemTyp = thenValue.listElemTyp
-		out.gcManaged = thenValue.gcManaged || elseValue.gcManaged
-	}
+	mergeContainerMetadata(&out, thenValue, elseValue)
 	out.rootPaths = g.rootPathsForType(out.typ)
 	return out, nil
 }
 
-func (g *generator) emitExprWithListHint(expr ast.Expr, listElemTyp string) (value, error) {
+func (g *generator) emitExprWithHint(expr ast.Expr, listElemTyp string, listElemString bool, mapKeyTyp string, mapValueTyp string, mapKeyString bool, setElemTyp string, setElemString bool) (value, error) {
 	if list, ok := expr.(*ast.ListExpr); ok {
 		return g.emitListExprWithHint(list, listElemTyp)
+	}
+	if m, ok := expr.(*ast.MapExpr); ok {
+		return g.emitMapExprWithHint(m, mapKeyTyp, mapValueTyp, mapKeyString)
 	}
 	return g.emitExpr(expr)
 }
@@ -2721,34 +3010,135 @@ func (g *generator) emitListExprWithHint(expr *ast.ListExpr, hintedElemTyp strin
 	if len(emittedElems) == 0 {
 		return listValue, nil
 	}
-	pushSymbol := listRuntimePushSymbol(elemTyp)
-	g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
+	traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
 	for _, elem := range emittedElems {
 		loaded, err := g.loadIfPointer(elem)
 		if err != nil {
 			return value{}, err
 		}
 		emitter = g.toOstyEmitter()
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @%s(%s)",
-			pushSymbol,
-			llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(loaded)}),
-		))
+		if listUsesTypedRuntime(elemTyp) {
+			pushSymbol := listRuntimePushSymbol(elemTyp)
+			g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
+			emitter.body = append(emitter.body, fmt.Sprintf(
+				"  call void @%s(%s)",
+				pushSymbol,
+				llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(loaded)}),
+			))
+		} else {
+			addr := g.spillValueAddress(emitter, "list.elem", loaded)
+			sizeValue := g.emitTypeSize(emitter, elemTyp)
+			g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+			emitter.body = append(emitter.body, fmt.Sprintf(
+				"  call void @%s(%s)",
+				listRuntimePushBytesSymbol(),
+				llvmCallArgs([]*LlvmValue{
+					toOstyValue(listValue),
+					{typ: "ptr", name: addr},
+					sizeValue,
+					{typ: "ptr", name: llvmPointerOperand(traceSymbol)},
+				}),
+			))
+		}
 		g.takeOstyEmitter(emitter)
 	}
 	return listValue, nil
+}
+
+func (g *generator) emitMapExprWithHint(expr *ast.MapExpr, hintedKeyTyp, hintedValueTyp string, hintedKeyString bool) (value, error) {
+	if expr == nil {
+		return value{}, unsupported("expression", "nil map literal")
+	}
+	keyTyp := hintedKeyTyp
+	valueTyp := hintedValueTyp
+	keyIsString := hintedKeyString
+	g.pushScope()
+	defer g.popScope()
+	type entryPair struct {
+		key   value
+		value value
+	}
+	entries := make([]entryPair, 0, len(expr.Entries))
+	for _, entry := range expr.Entries {
+		if entry == nil {
+			return value{}, unsupported("expression", "nil map entry")
+		}
+		key, err := g.emitExpr(entry.Key)
+		if err != nil {
+			return value{}, err
+		}
+		val, err := g.emitExpr(entry.Value)
+		if err != nil {
+			return value{}, err
+		}
+		if keyTyp == "" {
+			keyTyp = key.typ
+			keyIsString = key.typ == "ptr"
+		}
+		if valueTyp == "" {
+			valueTyp = val.typ
+		}
+		if key.typ != keyTyp || val.typ != valueTyp {
+			return value{}, unsupportedf("type-system", "map literal entry types %s/%s, want %s/%s", key.typ, val.typ, keyTyp, valueTyp)
+		}
+		entries = append(entries, entryPair{
+			key:   g.protectManagedTemporary("map.key", key),
+			value: g.protectManagedTemporary("map.value", val),
+		})
+	}
+	if keyTyp == "" || valueTyp == "" {
+		return value{}, unsupported("expression", "empty map literal requires an explicit Map<K, V> type")
+	}
+	traceSymbol := g.traceCallbackSymbol(valueTyp, g.rootPathsForType(valueTyp))
+	g.declareRuntimeSymbol(mapRuntimeNewSymbol(), "ptr", []paramInfo{{typ: "i64"}, {typ: "i64"}, {typ: "i64"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	valueSize := g.emitTypeSize(emitter, valueTyp)
+	out := llvmCall(emitter, "ptr", mapRuntimeNewSymbol(), []*LlvmValue{
+		llvmI64(strconv.Itoa(containerAbiKind(keyTyp, keyIsString))),
+		llvmI64(strconv.Itoa(containerAbiKind(valueTyp, false))),
+		valueSize,
+		{typ: "ptr", name: llvmPointerOperand(traceSymbol)},
+	})
+	g.takeOstyEmitter(emitter)
+	mapValue := fromOstyValue(out)
+	mapValue.gcManaged = true
+	mapValue.mapKeyTyp = keyTyp
+	mapValue.mapValueTyp = valueTyp
+	mapValue.mapKeyString = keyIsString
+	for _, entry := range entries {
+		if err := g.emitMapInsert(mapValue, entry.key, entry.value); err != nil {
+			return value{}, err
+		}
+	}
+	return mapValue, nil
+}
+
+func (g *generator) emitMapInsert(base, key, val value) error {
+	insertSymbol := mapRuntimeInsertSymbol(base.mapKeyTyp, base.mapKeyString)
+	keyLoaded, err := g.loadIfPointer(key)
+	if err != nil {
+		return err
+	}
+	valLoaded, err := g.loadIfPointer(val)
+	if err != nil {
+		return err
+	}
+	emitter := g.toOstyEmitter()
+	valAddr := g.spillValueAddress(emitter, "map.insert.value", valLoaded)
+	g.declareRuntimeSymbol(insertSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: base.mapKeyTyp}, {typ: "ptr"}})
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  call void @%s(%s)",
+		insertSymbol,
+		llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(keyLoaded), {typ: "ptr", name: valAddr}}),
+	))
+	g.takeOstyEmitter(emitter)
+	return nil
 }
 
 func (g *generator) emitListMethodCall(call *ast.CallExpr) (value, bool, error) {
 	field, elemTyp, found := g.listMethodInfo(call)
 	if !found {
 		return value{}, false, nil
-	}
-	if field.Name != "len" {
-		return value{}, false, nil
-	}
-	if len(call.Args) != 0 {
-		return value{}, true, unsupported("call", "list.len requires no arguments")
 	}
 	base, err := g.emitExpr(field.X)
 	if err != nil {
@@ -2757,11 +3147,43 @@ func (g *generator) emitListMethodCall(call *ast.CallExpr) (value, bool, error) 
 	if base.typ != "ptr" || elemTyp == "" {
 		return value{}, true, unsupportedf("type-system", "list receiver type %s", base.typ)
 	}
-	g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
-	emitter := g.toOstyEmitter()
-	out := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
-	g.takeOstyEmitter(emitter)
-	return fromOstyValue(out), true, nil
+	switch field.Name {
+	case "len":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "list.len requires no arguments")
+		}
+		g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "sorted":
+		if len(call.Args) != 0 || elemTyp != "i64" {
+			return value{}, true, unsupported("call", "list.sorted currently supports List<Int> with no arguments")
+		}
+		g.declareRuntimeSymbol(listRuntimeSortedI64Symbol(), "ptr", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "ptr", listRuntimeSortedI64Symbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.listElemTyp = "i64"
+		return v, true, nil
+	case "toSet":
+		if len(call.Args) != 0 || elemTyp != "i64" {
+			return value{}, true, unsupported("call", "list.toSet currently supports List<Int> with no arguments")
+		}
+		g.declareRuntimeSymbol(listRuntimeToSetI64Symbol(), "ptr", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "ptr", listRuntimeToSetI64Symbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.setElemTyp = "i64"
+		return v, true, nil
+	default:
+		return value{}, false, nil
+	}
 }
 
 func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
@@ -2796,7 +3218,6 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		return true, unsupportedf("type-system", "list.push arg type %s, want %s", arg.typ, elemTyp)
 	}
 	pushSymbol := listRuntimePushSymbol(elemTyp)
-	g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
 	baseValue, err := g.loadIfPointer(base)
 	if err != nil {
 		return true, err
@@ -2806,11 +3227,237 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		return true, err
 	}
 	emitter = g.toOstyEmitter()
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  call void @%s(%s)",
-		pushSymbol,
-		llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), toOstyValue(argValue)}),
-	))
+	if listUsesTypedRuntime(elemTyp) {
+		g.declareRuntimeSymbol(pushSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			pushSymbol,
+			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), toOstyValue(argValue)}),
+		))
+	} else {
+		traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
+		addr := g.spillValueAddress(emitter, "list.push", argValue)
+		sizeValue := g.emitTypeSize(emitter, elemTyp)
+		g.declareRuntimeSymbol(listRuntimePushBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimePushBytesSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), {typ: "ptr", name: addr}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
+		))
+	}
+	g.takeOstyEmitter(emitter)
+	return true, nil
+}
+
+func (g *generator) emitMapMethodCall(call *ast.CallExpr) (value, bool, error) {
+	field, keyTyp, _, keyString, found := g.mapMethodInfo(call)
+	if !found {
+		return value{}, false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	switch field.Name {
+	case "containsKey":
+		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "map.containsKey requires one positional argument")
+		}
+		key, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		if key.typ != keyTyp {
+			return value{}, true, unsupportedf("type-system", "map.containsKey key type %s, want %s", key.typ, keyTyp)
+		}
+		loaded, err := g.loadIfPointer(key)
+		if err != nil {
+			return value{}, true, err
+		}
+		symbol := mapRuntimeContainsSymbol(keyTyp, keyString)
+		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}, {typ: keyTyp}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(loaded)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "keys":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "map.keys requires no arguments")
+		}
+		g.declareRuntimeSymbol(mapRuntimeKeysSymbol(), "ptr", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "ptr", mapRuntimeKeysSymbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.listElemTyp = keyTyp
+		v.listElemString = keyString
+		return v, true, nil
+	case "remove":
+		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "map.remove requires one positional argument")
+		}
+		key, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		if key.typ != keyTyp {
+			return value{}, true, unsupportedf("type-system", "map.remove key type %s, want %s", key.typ, keyTyp)
+		}
+		loaded, err := g.loadIfPointer(key)
+		if err != nil {
+			return value{}, true, err
+		}
+		symbol := mapRuntimeRemoveSymbol(keyTyp, keyString)
+		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}, {typ: keyTyp}})
+		emitter := g.toOstyEmitter()
+		llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(loaded)})
+		g.takeOstyEmitter(emitter)
+		return value{typ: "ptr", ref: "null"}, true, nil
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
+	field, keyTyp, _, keyString, found := g.mapMethodInfo(call)
+	if !found {
+		return false, nil
+	}
+	if field.Name != "insert" && field.Name != "remove" {
+		return false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return true, err
+	}
+	if field.Name == "insert" {
+		if len(call.Args) != 2 || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return true, unsupported("call", "map.insert requires two positional arguments")
+		}
+		key, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return true, err
+		}
+		val, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return true, err
+		}
+		if key.typ != keyTyp || val.typ != base.mapValueTyp {
+			return true, unsupportedf("type-system", "map.insert types %s/%s, want %s/%s", key.typ, val.typ, keyTyp, base.mapValueTyp)
+		}
+		return true, g.emitMapInsert(base, key, val)
+	}
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return true, unsupported("call", "map.remove requires one positional argument")
+	}
+	key, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return true, err
+	}
+	if key.typ != keyTyp {
+		return true, unsupportedf("type-system", "map.remove key type %s, want %s", key.typ, keyTyp)
+	}
+	loaded, err := g.loadIfPointer(key)
+	if err != nil {
+		return true, err
+	}
+	symbol := mapRuntimeRemoveSymbol(keyTyp, keyString)
+	g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}, {typ: keyTyp}})
+	emitter := g.toOstyEmitter()
+	llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(loaded)})
+	g.takeOstyEmitter(emitter)
+	return true, nil
+}
+
+func (g *generator) emitSetMethodCall(call *ast.CallExpr) (value, bool, error) {
+	field, elemTyp, elemString, found := g.setMethodInfo(call)
+	if !found {
+		return value{}, false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	switch field.Name {
+	case "len":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "set.len requires no arguments")
+		}
+		g.declareRuntimeSymbol(setRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i64", setRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "contains", "remove":
+		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupportedf("call", "set.%s requires one positional argument", field.Name)
+		}
+		item, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		if item.typ != elemTyp {
+			return value{}, true, unsupportedf("type-system", "set.%s item type %s, want %s", field.Name, item.typ, elemTyp)
+		}
+		loaded, err := g.loadIfPointer(item)
+		if err != nil {
+			return value{}, true, err
+		}
+		symbol := setRuntimeContainsSymbol(elemTyp, elemString)
+		if field.Name == "remove" {
+			symbol = setRuntimeRemoveSymbol(elemTyp, elemString)
+		}
+		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(loaded)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "toList":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "set.toList requires no arguments")
+		}
+		g.declareRuntimeSymbol(setRuntimeToListSymbol(), "ptr", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "ptr", setRuntimeToListSymbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.listElemTyp = elemTyp
+		v.listElemString = elemString
+		return v, true, nil
+	default:
+		return value{}, false, nil
+	}
+}
+
+func (g *generator) emitSetMethodCallStmt(call *ast.CallExpr) (bool, error) {
+	field, elemTyp, elemString, found := g.setMethodInfo(call)
+	if !found || field.Name != "insert" {
+		return false, nil
+	}
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return true, unsupported("call", "set.insert requires one positional argument")
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return true, err
+	}
+	item, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return true, err
+	}
+	if item.typ != elemTyp {
+		return true, unsupportedf("type-system", "set.insert item type %s, want %s", item.typ, elemTyp)
+	}
+	loaded, err := g.loadIfPointer(item)
+	if err != nil {
+		return true, err
+	}
+	symbol := setRuntimeInsertSymbol(elemTyp, elemString)
+	g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}, {typ: elemTyp}})
+	emitter := g.toOstyEmitter()
+	llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(loaded)})
 	g.takeOstyEmitter(emitter)
 	return true, nil
 }
@@ -2827,8 +3474,6 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 	}
 	iterable = g.protectManagedTemporary("for.iter", iterable)
 	g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
-	getSymbol := listRuntimeGetSymbol(elemTyp)
-	g.declareRuntimeSymbol(getSymbol, elemTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
 	iterableValue, err := g.loadIfPointer(iterable)
 	if err != nil {
 		return err
@@ -2855,9 +3500,31 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		return err
 	}
 	emitter = g.toOstyEmitter()
-	item := llvmCall(emitter, elemTyp, getSymbol, []*LlvmValue{toOstyValue(iterableValue), llvmI64(loop.current)})
+	var iterValue value
+	if listUsesTypedRuntime(elemTyp) {
+		getSymbol := listRuntimeGetSymbol(elemTyp)
+		g.declareRuntimeSymbol(getSymbol, elemTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+		item := llvmCall(emitter, elemTyp, getSymbol, []*LlvmValue{toOstyValue(iterableValue), llvmI64(loop.current)})
+		iterValue = fromOstyValue(item)
+		if elemTyp == "ptr" {
+			iterValue.gcManaged = true
+		}
+	} else {
+		traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
+		slot := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, elemTyp))
+		sizeValue := g.emitTypeSize(emitter, elemTyp)
+		g.declareRuntimeSymbol(listRuntimeGetBytesSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimeGetBytesSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(iterableValue), llvmI64(loop.current), {typ: "ptr", name: slot}, sizeValue, {typ: "ptr", name: llvmPointerOperand(traceSymbol)}}),
+		))
+		iterValue = g.loadValueFromAddress(emitter, elemTyp, slot)
+		iterValue.rootPaths = g.rootPathsForType(elemTyp)
+	}
 	g.takeOstyEmitter(emitter)
-	g.bindLocal(iterName, fromOstyValue(item))
+	g.bindLocal(iterName, iterValue)
 	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
 		if len(g.locals) > scopeDepth {
 			g.popScope()
@@ -3105,6 +3772,12 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitListMethodCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitMapMethodCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitSetMethodCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitRuntimeFFICall(call); found || err != nil {
 		return v, err
 	}
@@ -3139,7 +3812,13 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	g.popScope()
 	ret := fromOstyValue(out)
 	ret.listElemTyp = sig.retListElemTyp
-	ret.gcManaged = sig.retListElemTyp != ""
+	ret.listElemString = sig.retListString
+	ret.mapKeyTyp = sig.retMapKeyTyp
+	ret.mapValueTyp = sig.retMapValueTyp
+	ret.mapKeyString = sig.retMapKeyString
+	ret.setElemTyp = sig.retSetElemTyp
+	ret.setElemString = sig.retSetElemString
+	ret.gcManaged = valueNeedsManagedRoot(ret)
 	ret.rootPaths = g.rootPathsForType(sig.ret)
 	return ret, nil
 }
@@ -3252,7 +3931,7 @@ func (g *generator) userCallArgs(sig *fnSig, receiverExpr ast.Expr, call *ast.Ca
 			return nil, unsupportedf("call", "function %q requires positional arguments", sig.name)
 		}
 		param := sig.params[paramIndex+i]
-		v, err := g.emitExprWithListHint(arg.Value, param.listElemTyp)
+		v, err := g.emitExprWithHint(arg.Value, param.listElemTyp, param.listElemString, param.mapKeyTyp, param.mapValueTyp, param.mapKeyString, param.setElemTyp, param.setElemString)
 		if err != nil {
 			return nil, err
 		}
@@ -3316,11 +3995,11 @@ func (g *generator) userCallTarget(call *ast.CallExpr) (*fnSig, ast.Expr, bool, 
 		if fn.IsOptional {
 			return nil, nil, false, unsupported("call", "optional method calls are not supported")
 		}
-		baseTyp, _, ok := g.staticExprType(fn.X)
+		baseInfo, ok := g.staticExprInfo(fn.X)
 		if !ok {
 			return nil, nil, false, nil
 		}
-		methods := g.methods[baseTyp]
+		methods := g.methods[baseInfo.typ]
 		if methods == nil {
 			return nil, nil, false, nil
 		}
@@ -3374,7 +4053,7 @@ func (g *generator) runtimeFFICallArgs(fn *runtimeFFIFunction, callArgs []*ast.A
 			return nil, unsupportedf("call", "runtime FFI %s.%s requires positional arguments", fn.path, fn.sourceName)
 		}
 		param := fn.params[i]
-		v, err := g.emitExprWithListHint(arg.Value, param.listElemTyp)
+		v, err := g.emitExprWithHint(arg.Value, param.listElemTyp, false, "", "", false, "", false)
 		if err != nil {
 			return nil, err
 		}
@@ -3475,6 +4154,9 @@ func (g *generator) render(defs []string) []byte {
 	runtimeDecls := g.runtimeDeclarationIR()
 	if g.needsGCRuntime {
 		runtimeDecls = append(llvmGcRuntimeDeclarations(), runtimeDecls...)
+	}
+	if len(g.traceHelperDefs) != 0 {
+		defs = append(append([]string(nil), g.traceHelperDefs...), defs...)
 	}
 	if len(runtimeDecls) > 0 {
 		return []byte(llvmRenderModuleWithRuntimeDeclarations(g.sourcePath, g.target, typeDefs, g.stringDefs, runtimeDecls, defs))
@@ -3648,12 +4330,11 @@ func (g *generator) popScope() {
 }
 
 func (g *generator) bindNamedLocal(name string, v value, mutable bool) {
-	if mutable || (v.typ == "ptr" && v.gcManaged) || len(v.rootPaths) != 0 {
+	if mutable || (v.typ == "ptr" && valueNeedsManagedRoot(v)) || len(v.rootPaths) != 0 {
 		emitter := g.toOstyEmitter()
 		slot := llvmMutableLetSlot(emitter, name, toOstyValue(v))
 		slotValue := fromOstyValue(slot)
-		slotValue.gcManaged = v.gcManaged
-		slotValue.listElemTyp = v.listElemTyp
+		copyContainerMetadata(&slotValue, v)
 		slotValue.mutable = mutable
 		slotValue.rootPaths = cloneRootPaths(v.rootPaths)
 		g.bindGCRootIfManagedPointer(emitter, slotValue)
@@ -3663,6 +4344,38 @@ func (g *generator) bindNamedLocal(name string, v value, mutable bool) {
 	}
 	v.mutable = false
 	g.bindLocal(name, v)
+}
+
+func valueNeedsManagedRoot(v value) bool {
+	return v.gcManaged || v.listElemTyp != "" || v.mapKeyTyp != "" || v.setElemTyp != ""
+}
+
+func copyContainerMetadata(dst *value, src value) {
+	dst.listElemTyp = src.listElemTyp
+	dst.listElemString = src.listElemString
+	dst.mapKeyTyp = src.mapKeyTyp
+	dst.mapValueTyp = src.mapValueTyp
+	dst.mapKeyString = src.mapKeyString
+	dst.setElemTyp = src.setElemTyp
+	dst.setElemString = src.setElemString
+	dst.gcManaged = valueNeedsManagedRoot(*dst)
+}
+
+func mergeContainerMetadata(dst *value, left, right value) {
+	if left.listElemTyp != "" && left.listElemTyp == right.listElemTyp {
+		dst.listElemTyp = left.listElemTyp
+		dst.listElemString = left.listElemString && right.listElemString
+	}
+	if left.mapKeyTyp != "" && left.mapKeyTyp == right.mapKeyTyp && left.mapValueTyp == right.mapValueTyp {
+		dst.mapKeyTyp = left.mapKeyTyp
+		dst.mapValueTyp = left.mapValueTyp
+		dst.mapKeyString = left.mapKeyString && right.mapKeyString
+	}
+	if left.setElemTyp != "" && left.setElemTyp == right.setElemTyp {
+		dst.setElemTyp = left.setElemTyp
+		dst.setElemString = left.setElemString && right.setElemString
+	}
+	dst.gcManaged = valueNeedsManagedRoot(*dst)
 }
 
 type gcSafepointRoot struct {
@@ -3696,6 +4409,13 @@ func prependRootIndex(index int, paths [][]int) [][]int {
 	return out
 }
 
+func llvmPointerOperand(name string) string {
+	if name == "" || name == "null" || strings.HasPrefix(name, "@") || strings.HasPrefix(name, "%") {
+		return name
+	}
+	return "@" + name
+}
+
 func (g *generator) rootPathsForType(typ string) [][]int {
 	return g.rootPathsForTypeSeen(typ, map[string]bool{})
 }
@@ -3711,7 +4431,7 @@ func (g *generator) rootPathsForTypeSeen(typ string, seen map[string]bool) [][]i
 		seen[typ] = true
 		var out [][]int
 		for _, field := range info.fields {
-			if field.listElemTyp != "" {
+			if field.listElemTyp != "" || field.mapKeyTyp != "" || field.setElemTyp != "" {
 				out = append(out, []int{field.index})
 				continue
 			}
@@ -3808,6 +4528,84 @@ func (g *generator) aggregateFieldType(typ string, index int) (string, bool) {
 	return "", false
 }
 
+func (g *generator) traceCallbackSymbol(typ string, rootPaths [][]int) string {
+	if typ == "" {
+		return "null"
+	}
+	if typ == "ptr" {
+		g.declareRuntimeSymbol("osty.gc.mark_slot_v1", "void", []paramInfo{{typ: "ptr"}})
+		g.needsGCRuntime = true
+		return "osty.gc.mark_slot_v1"
+	}
+	if len(rootPaths) == 0 {
+		return "null"
+	}
+	key := typ + ":" + fmt.Sprint(rootPaths)
+	if name, ok := g.traceHelpers[key]; ok {
+		return name
+	}
+	name := fmt.Sprintf("osty_rt_trace_%d", len(g.traceHelpers))
+	g.traceHelpers[key] = name
+	g.declareRuntimeSymbol("osty.gc.mark_slot_v1", "void", []paramInfo{{typ: "ptr"}})
+	g.needsGCRuntime = true
+	body := []string{}
+	currentType := ""
+	for _, path := range rootPaths {
+		addr := "%value.addr"
+		currentType = typ
+		for _, index := range path {
+			fieldPtr := fmt.Sprintf("%%trace.field.%d.%d", len(body), index)
+			body = append(body, fmt.Sprintf(
+				"  %s = getelementptr inbounds %s, ptr %s, i32 0, i32 %d",
+				fieldPtr,
+				currentType,
+				addr,
+				index,
+			))
+			nextType, ok := g.aggregateFieldType(currentType, index)
+			if !ok {
+				currentType = ""
+				break
+			}
+			addr = fieldPtr
+			currentType = nextType
+		}
+		if currentType == "" {
+			continue
+		}
+		body = append(body, fmt.Sprintf("  call void @osty.gc.mark_slot_v1(ptr %s)", addr))
+	}
+	body = append(body, "  ret void")
+	g.traceHelperDefs = append(g.traceHelperDefs, llvmRenderFunction("void", name, []*LlvmParam{llvmParam("value.addr", "ptr")}, body))
+	return name
+}
+
+func (g *generator) spillValueAddress(emitter *LlvmEmitter, prefix string, v value) string {
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, v.typ))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", v.typ, v.ref, slot))
+	return slot
+}
+
+func (g *generator) loadValueFromAddress(emitter *LlvmEmitter, typ, addr string) value {
+	loaded := fromOstyValue(llvmLoad(emitter, &LlvmValue{typ: typ, name: addr, pointer: true}))
+	return loaded
+}
+
+func (g *generator) emitTypeSize(emitter *LlvmEmitter, typ string) *LlvmValue {
+	switch typ {
+	case "i64", "double", "ptr":
+		return llvmI64("8")
+	case "i1":
+		return llvmI64("1")
+	}
+	ptr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", ptr, typ))
+	out := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", out, ptr))
+	return llvmI64(out)
+}
+
 func (g *generator) bindLocal(name string, v value) {
 	g.locals[len(g.locals)-1][name] = v
 }
@@ -3902,92 +4700,161 @@ func identPatternName(p ast.Pattern) (string, error) {
 	return id.Name, nil
 }
 
-func (g *generator) staticExprType(expr ast.Expr) (string, string, bool) {
+func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 	switch e := expr.(type) {
 	case *ast.IntLit:
-		return "i64", "", true
+		return value{typ: "i64"}, true
 	case *ast.FloatLit:
-		return "double", "", true
+		return value{typ: "double"}, true
 	case *ast.BoolLit:
-		return "i1", "", true
+		return value{typ: "i1"}, true
 	case *ast.StringLit:
-		return "ptr", "", true
+		return value{typ: "ptr"}, true
 	case *ast.Ident:
 		if v, ok := g.lookupLocal(e.Name); ok {
-			return v.typ, v.listElemTyp, true
+			return v, true
 		}
 	case *ast.ParenExpr:
-		return g.staticExprType(e.X)
+		return g.staticExprInfo(e.X)
 	case *ast.ListExpr:
 		if elemTyp, ok := g.staticListLiteralElementType(e); ok {
-			return "ptr", elemTyp, true
+			return value{typ: "ptr", gcManaged: true, listElemTyp: elemTyp}, true
 		}
+	case *ast.MapExpr:
+		return value{}, false
 	case *ast.CallExpr:
-		if retTyp, found, ok := g.staticListMethodResult(e); found {
-			return retTyp, "", ok
+		if out, found, ok := g.staticCollectionMethodResult(e); found {
+			return out, ok
 		}
 		if id, ok := e.Fn.(*ast.Ident); ok {
 			if sig := g.functions[id.Name]; sig != nil && sig.ret != "" && sig.ret != "void" {
-				return sig.ret, sig.retListElemTyp, true
+				return value{
+					typ:            sig.ret,
+					listElemTyp:    sig.retListElemTyp,
+					listElemString: sig.retListString,
+					mapKeyTyp:      sig.retMapKeyTyp,
+					mapValueTyp:    sig.retMapValueTyp,
+					mapKeyString:   sig.retMapKeyString,
+					setElemTyp:     sig.retSetElemTyp,
+					setElemString:  sig.retSetElemString,
+					gcManaged:      sig.retListElemTyp != "" || sig.retMapKeyTyp != "" || sig.retSetElemTyp != "",
+				}, true
 			}
 		}
 		if field, ok := e.Fn.(*ast.FieldExpr); ok && !field.IsOptional {
-			if baseTyp, _, ok := g.staticExprType(field.X); ok {
-				if methods := g.methods[baseTyp]; methods != nil {
+			if baseInfo, ok := g.staticExprInfo(field.X); ok {
+				if methods := g.methods[baseInfo.typ]; methods != nil {
 					if sig := methods[field.Name]; sig != nil && sig.ret != "" && sig.ret != "void" {
-						return sig.ret, sig.retListElemTyp, true
+						return value{
+							typ:            sig.ret,
+							listElemTyp:    sig.retListElemTyp,
+							listElemString: sig.retListString,
+							mapKeyTyp:      sig.retMapKeyTyp,
+							mapValueTyp:    sig.retMapValueTyp,
+							mapKeyString:   sig.retMapKeyString,
+							setElemTyp:     sig.retSetElemTyp,
+							setElemString:  sig.retSetElemString,
+							gcManaged:      sig.retListElemTyp != "" || sig.retMapKeyTyp != "" || sig.retSetElemTyp != "",
+						}, true
 					}
 				}
 			}
 		}
 		if fn, found, err := g.runtimeFFICallTarget(e); found && err == nil && fn.ret != "" && fn.ret != "void" {
-			return fn.ret, fn.listElemTyp, true
+			return value{typ: fn.ret, listElemTyp: fn.listElemTyp, gcManaged: fn.listElemTyp != ""}, true
 		}
 	case *ast.FieldExpr:
 		if e.IsOptional {
-			return "", "", false
+			return value{}, false
 		}
-		baseTyp, _, ok := g.staticExprType(e.X)
+		baseInfo, ok := g.staticExprInfo(e.X)
 		if !ok {
-			return "", "", false
+			return value{}, false
 		}
-		if info := g.structsByType[baseTyp]; info != nil {
+		if info := g.structsByType[baseInfo.typ]; info != nil {
 			if field, ok := info.byName[e.Name]; ok {
-				return field.typ, field.listElemTyp, true
+				return value{
+					typ:            field.typ,
+					listElemTyp:    field.listElemTyp,
+					listElemString: field.listElemString,
+					mapKeyTyp:      field.mapKeyTyp,
+					mapValueTyp:    field.mapValueTyp,
+					mapKeyString:   field.mapKeyString,
+					setElemTyp:     field.setElemTyp,
+					setElemString:  field.setElemString,
+					gcManaged:      field.listElemTyp != "" || field.mapKeyTyp != "" || field.setElemTyp != "",
+				}, true
+			}
+		}
+	case *ast.IndexExpr:
+		if baseInfo, ok := g.staticExprInfo(e.X); ok {
+			switch {
+			case baseInfo.listElemTyp != "":
+				return value{typ: baseInfo.listElemTyp, gcManaged: baseInfo.listElemTyp == "ptr", rootPaths: g.rootPathsForType(baseInfo.listElemTyp)}, true
+			case baseInfo.mapKeyTyp != "":
+				return value{typ: baseInfo.mapValueTyp, gcManaged: baseInfo.mapValueTyp == "ptr", rootPaths: g.rootPathsForType(baseInfo.mapValueTyp)}, true
 			}
 		}
 	}
-	return "", "", false
+	return value{}, false
 }
 
 func (g *generator) staticListLiteralElementType(expr *ast.ListExpr) (string, bool) {
 	if expr == nil || len(expr.Elems) == 0 {
 		return "", false
 	}
-	elemTyp, _, ok := g.staticExprType(expr.Elems[0])
+	elemInfo, ok := g.staticExprInfo(expr.Elems[0])
 	if !ok {
 		return "", false
 	}
+	elemTyp := elemInfo.typ
 	for _, elem := range expr.Elems[1:] {
-		typ, _, ok := g.staticExprType(elem)
-		if !ok || typ != elemTyp {
+		info, ok := g.staticExprInfo(elem)
+		if !ok || info.typ != elemTyp {
 			return "", false
 		}
 	}
 	return elemTyp, true
 }
 
-func (g *generator) staticListMethodResult(call *ast.CallExpr) (string, bool, bool) {
-	field, _, found := g.listMethodInfo(call)
-	if !found {
-		return "", false, false
+func (g *generator) staticCollectionMethodResult(call *ast.CallExpr) (value, bool, bool) {
+	if field, elemTyp, found := g.listMethodInfo(call); found {
+		switch field.Name {
+		case "len":
+			return value{typ: "i64"}, true, true
+		case "sorted":
+			return value{typ: "ptr", gcManaged: true, listElemTyp: elemTyp}, true, true
+		case "toSet":
+			return value{typ: "ptr", gcManaged: true, setElemTyp: elemTyp}, true, true
+		default:
+			return value{}, true, false
+		}
 	}
-	switch field.Name {
-	case "len":
-		return "i64", true, true
-	default:
-		return "", true, false
+	if _, keyTyp, _, keyString, found := g.mapMethodInfo(call); found {
+		switch field := call.Fn.(*ast.FieldExpr); field.Name {
+		case "containsKey":
+			return value{typ: "i1"}, true, true
+		case "keys":
+			return value{typ: "ptr", gcManaged: true, listElemTyp: keyTyp, listElemString: keyString}, true, true
+		case "remove":
+			return value{typ: "ptr"}, true, true
+		default:
+			return value{}, true, false
+		}
 	}
+	if _, elemTyp, elemString, found := g.setMethodInfo(call); found {
+		switch field := call.Fn.(*ast.FieldExpr); field.Name {
+		case "len":
+			return value{typ: "i64"}, true, true
+		case "contains", "remove":
+			return value{typ: "i1"}, true, true
+		case "toList":
+			return value{typ: "ptr", gcManaged: true, listElemTyp: elemTyp, listElemString: elemString}, true, true
+		default:
+			return value{}, true, false
+		}
+	}
+	return value{}, false, false
 }
 
 func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool) {
@@ -3999,19 +4866,71 @@ func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, 
 		return nil, "", false
 	}
 	switch field.Name {
-	case "len", "push":
+	case "len", "push", "sorted", "toSet":
 	default:
 		return nil, "", false
 	}
-	baseTyp, elemTyp, ok := g.staticExprType(field.X)
-	if !ok || baseTyp != "ptr" || elemTyp == "" {
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok || baseInfo.typ != "ptr" || baseInfo.listElemTyp == "" {
 		return nil, "", false
 	}
-	return field, elemTyp, true
+	return field, baseInfo.listElemTyp, true
+}
+
+func (g *generator) mapMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, string, bool, bool) {
+	if call == nil {
+		return nil, "", "", false, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional {
+		return nil, "", "", false, false
+	}
+	switch field.Name {
+	case "containsKey", "insert", "remove", "keys":
+	default:
+		return nil, "", "", false, false
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok || baseInfo.typ != "ptr" || baseInfo.mapKeyTyp == "" || baseInfo.mapValueTyp == "" {
+		return nil, "", "", false, false
+	}
+	return field, baseInfo.mapKeyTyp, baseInfo.mapValueTyp, baseInfo.mapKeyString, true
+}
+
+func (g *generator) setMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool, bool) {
+	if call == nil {
+		return nil, "", false, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional {
+		return nil, "", false, false
+	}
+	switch field.Name {
+	case "len", "contains", "insert", "remove", "toList":
+	default:
+		return nil, "", false, false
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok || baseInfo.typ != "ptr" || baseInfo.setElemTyp == "" {
+		return nil, "", false, false
+	}
+	return field, baseInfo.setElemTyp, baseInfo.setElemString, true
 }
 
 func listRuntimeNewSymbol() string {
 	return "osty_rt_list_new"
+}
+
+func listRuntimePushBytesSymbol() string {
+	return "osty_rt_list_push_bytes"
+}
+
+func listRuntimeGetBytesSymbol() string {
+	return "osty_rt_list_get_bytes"
+}
+
+func listRuntimeSetBytesSymbol() string {
+	return "osty_rt_list_set_bytes"
 }
 
 func listRuntimeLenSymbol() string {
@@ -4024,6 +4943,111 @@ func listRuntimePushSymbol(elemTyp string) string {
 
 func listRuntimeGetSymbol(elemTyp string) string {
 	return "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemTyp)
+}
+
+func listRuntimeSetSymbol(elemTyp string) string {
+	return "osty_rt_list_set_" + listRuntimeSymbolSuffix(elemTyp)
+}
+
+func listRuntimeSortedI64Symbol() string {
+	return "osty_rt_list_sorted_i64"
+}
+
+func listRuntimeToSetI64Symbol() string {
+	return "osty_rt_list_to_set_i64"
+}
+
+func mapRuntimeNewSymbol() string {
+	return "osty_rt_map_new"
+}
+
+func mapRuntimeContainsSymbol(keyTyp string, keyString bool) string {
+	return "osty_rt_map_contains_" + mapSetKeySuffix(keyTyp, keyString)
+}
+
+func mapRuntimeInsertSymbol(keyTyp string, keyString bool) string {
+	return "osty_rt_map_insert_" + mapSetKeySuffix(keyTyp, keyString)
+}
+
+func mapRuntimeRemoveSymbol(keyTyp string, keyString bool) string {
+	return "osty_rt_map_remove_" + mapSetKeySuffix(keyTyp, keyString)
+}
+
+func mapRuntimeGetOrAbortSymbol(keyTyp string, keyString bool) string {
+	return "osty_rt_map_get_or_abort_" + mapSetKeySuffix(keyTyp, keyString)
+}
+
+func mapRuntimeKeysSymbol() string {
+	return "osty_rt_map_keys"
+}
+
+func setRuntimeNewSymbol() string {
+	return "osty_rt_set_new"
+}
+
+func setRuntimeLenSymbol() string {
+	return "osty_rt_set_len"
+}
+
+func setRuntimeContainsSymbol(elemTyp string, elemString bool) string {
+	return "osty_rt_set_contains_" + mapSetKeySuffix(elemTyp, elemString)
+}
+
+func setRuntimeInsertSymbol(elemTyp string, elemString bool) string {
+	return "osty_rt_set_insert_" + mapSetKeySuffix(elemTyp, elemString)
+}
+
+func setRuntimeRemoveSymbol(elemTyp string, elemString bool) string {
+	return "osty_rt_set_remove_" + mapSetKeySuffix(elemTyp, elemString)
+}
+
+func setRuntimeToListSymbol() string {
+	return "osty_rt_set_to_list"
+}
+
+func containerAbiKind(typ string, isString bool) int {
+	if isString {
+		return 5
+	}
+	switch typ {
+	case "i64":
+		return 1
+	case "i1":
+		return 2
+	case "double":
+		return 3
+	case "ptr":
+		return 4
+	default:
+		return 6
+	}
+}
+
+func mapSetKeySuffix(typ string, isString bool) string {
+	if isString {
+		return "string"
+	}
+	switch typ {
+	case "i64":
+		return "i64"
+	case "i1":
+		return "i1"
+	case "double":
+		return "f64"
+	case "ptr":
+		return "ptr"
+	default:
+		return "bytes"
+	}
+}
+
+func listUsesTypedRuntime(elemTyp string) bool {
+	switch elemTyp {
+	case "i64", "i1", "double", "ptr":
+		return true
+	default:
+		return false
+	}
 }
 
 func listRuntimeSymbolSuffix(typ string) string {

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -445,3 +445,92 @@ fn main() {
 		}
 	}
 }
+
+func TestGenerateCollectionsUseManagedRuntimeABI(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Pair {
+    left: Int
+    right: Int
+}
+
+fn main() {
+    let mut pairs: Map<Int, Pair> = {:}
+    pairs.insert(1, Pair { left: 2, right: 3 })
+    let pair = pairs[1]
+    let keys = pairs.keys().sorted()
+
+    let mut values: List<Pair> = []
+    values.push(Pair { left: pair.left, right: pair.right })
+    let first = values[0]
+
+    let empty: List<Int> = []
+    let mut seen = empty.toSet()
+    seen.insert(keys[0])
+    let ids = seen.toList()
+
+    println(first.left + first.right + ids[0])
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/collections_runtime.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_map_new",
+		"call void @osty_rt_map_insert_i64",
+		"call void @osty_rt_map_get_or_abort_i64",
+		"call ptr @osty_rt_map_keys",
+		"call ptr @osty_rt_list_sorted_i64",
+		"call void @osty_rt_list_push_bytes",
+		"call void @osty_rt_list_get_bytes",
+		"call ptr @osty_rt_list_to_set_i64",
+		"call i1 @osty_rt_set_insert_i64",
+		"call ptr @osty_rt_set_to_list",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateCollectionsEmitTraceHelpersForManagedAggregateValues(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Bucket {
+    ids: List<Int>
+}
+
+fn main() {
+    let ids: List<Int> = [7]
+    let mut buckets: Map<String, Bucket> = {:}
+    buckets.insert("root", Bucket { ids: ids })
+    let bucket = buckets["root"]
+    println(bucket.ids[0])
+}
+`)
+
+	ir, err := Generate(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/collections_trace_runtime.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_map_new",
+		"call void @osty_rt_map_insert_string",
+		"call void @osty_rt_map_get_or_abort_string",
+		"ptr @osty_rt_trace_",
+		"define void @osty_rt_trace_",
+		"call i64 @osty_rt_list_get_i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- lower Map/Set literals, index expressions, and collection methods to the bundled LLVM runtime ABI
- extend the bundled runtime with managed map/set/list-bytes support and trace callbacks for aggregate values
- cover the new surface with LLVM IR and clang-backed binary tests, including managed aggregate survival under GC pressure

## Testing
- go test ./internal/llvmgen ./internal/backend
- OSTY_NATIVE_CHECKER_BIN=/tmp/osty-native-checker-dev go run ./cmd/osty build --backend llvm --emit llvm-ir examples/gc