### PR TITLE
feat: toolchain/check.osty 양방향 elaborator + 타입 박힌 Core IR

### DIFF
--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -1,62 +1,39 @@
+// check.osty — entry point for the toolchain type checker.
+//
+// Phase 10 replaces the 4241-line string-based legacy checker with a
+// thin orchestrator that drives the bidirectional elaborator
+// (`elab.osty`) to completion and serialises the resulting
+// `CoreModule` into the `FrontCheckResult` shape the Go bridge in
+// `internal/selfhost/check_adapter.go:92` already consumes.
+//
+// Pipeline:
+//
+//   source → lexer (ostyLexSource)
+//          → parser (from toolchain/parser.osty)
+//          → elabFile (bidirectional elaboration + Core IR build)
+//          → serialize (CoreModule → FrontCheckResult)
+//
+// The legacy public API names are preserved so existing callers keep
+// compiling:
+//
+//   frontendCheckSource / frontendCheckSourceStructured
+//   frontendCheckLexedSource / frontendCheckLexedSourceStructured
+//   frontendCheckAst / frontendCheckAstStructured
+//
+// All four structured variants now carry the `diagnostics` list
+// populated by `check_diag.osty`; the summary counters are derived
+// values kept in sync for bridge stability.
+
 use std.strings as strings
 
-pub struct FrontCheckBinding {
-    pub name: String,
-    pub typeName: String,
-    pub mutable: Bool,
-}
+// ---------------------------------------------------------------------
+// Bridge record types (preserved for Go host compatibility).
+// ---------------------------------------------------------------------
 
-pub struct FrontFnSig {
-    pub name: String,
-    pub receiverType: String,
-    pub returnType: String,
-    pub paramNames: List<String>,
-    pub paramTypes: List<String>,
-    pub generics: List<String>,
-    pub genericBounds: List<FrontTypeSubst>,
-}
-
-pub struct FrontFieldSig {
-    pub owner: String,
-    pub name: String,
-    pub typeName: String,
-    pub hasDefault: Bool,
-}
-
-pub struct FrontVariantSig {
-    pub owner: String,
-    pub name: String,
-    pub fieldTypes: List<String>,
-    pub generics: List<String>,
-}
-
-pub struct FrontAliasSig {
-    pub name: String,
-    pub typeName: String,
-    pub generics: List<String>,
-}
-
-pub struct FrontTypeSig {
-    pub name: String,
-    pub generics: List<String>,
-}
-
-pub struct FrontTypeSubst {
-    pub name: String,
-    pub typeName: String,
-}
-
-pub struct FrontTypeView {
-    pub kind: String,
-    pub head: String,
-    pub args: List<String>,
-    pub params: List<String>,
-    pub ret: String,
-}
-
-pub struct FrontInterfaceExtSig {
-    pub owner: String,
-    pub typeName: String,
+pub struct FrontCheckSummary {
+    pub assignments: Int,
+    pub accepted: Int,
+    pub errors: Int,
 }
 
 pub struct FrontCheckedNode {
@@ -95,40 +72,26 @@ pub struct FrontCheckInstantiation {
     pub end: Int,
 }
 
-pub struct FrontCheckEnv {
-    pub bindings: List<FrontCheckBinding>,
-    pub fns: List<FrontFnSig>,
-    pub fields: List<FrontFieldSig>,
-    pub variants: List<FrontVariantSig>,
-    pub aliases: List<FrontAliasSig>,
-    pub types: List<FrontTypeSig>,
-    pub interfaces: List<String>,
-    pub interfaceExtends: List<FrontInterfaceExtSig>,
-    pub genericBounds: List<FrontTypeSubst>,
-    pub returnType: String,
-    pub assignments: Int,
-    pub accepted: Int,
-    pub errors: Int,
-    pub typedNodes: List<FrontCheckedNode>,
-    pub checkedBindings: List<FrontCheckedBinding>,
-    pub checkedSymbols: List<FrontCheckedSymbol>,
-    pub instantiations: List<FrontCheckInstantiation>,
-}
-
 pub struct FrontCheckResult {
     pub summary: FrontCheckSummary,
     pub typedNodes: List<FrontCheckedNode>,
     pub bindings: List<FrontCheckedBinding>,
     pub symbols: List<FrontCheckedSymbol>,
     pub instantiations: List<FrontCheckInstantiation>,
+    pub diagnostics: List<CheckDiagnostic>,
 }
+
+// ---------------------------------------------------------------------
+// Public entry points.
+// ---------------------------------------------------------------------
 
 pub fn frontendCheckSource(source: String) -> FrontCheckSummary {
     frontendCheckSourceStructured(source).summary
 }
 
 pub fn frontendCheckSourceStructured(source: String) -> FrontCheckResult {
-    frontendCheckLexedSourceStructured(ostyLexSource(source))
+    let lexed = ostyLexSource(source)
+    frontendCheckLexedSourceStructured(lexed)
 }
 
 pub fn frontendCheckLexedSource(lexed: OstyLexedSource) -> FrontCheckSummary {
@@ -136,7 +99,8 @@ pub fn frontendCheckLexedSource(lexed: OstyLexedSource) -> FrontCheckSummary {
 }
 
 pub fn frontendCheckLexedSourceStructured(lexed: OstyLexedSource) -> FrontCheckResult {
-    frontendCheckAstStructured(astParseLexedSource(lexed))
+    let parsed = ostyParseLexed(lexed)
+    frontendCheckAstStructured(parsed)
 }
 
 pub fn frontendCheckAst(file: AstFile) -> FrontCheckSummary {
@@ -144,757 +108,344 @@ pub fn frontendCheckAst(file: AstFile) -> FrontCheckSummary {
 }
 
 pub fn frontendCheckAstStructured(file: AstFile) -> FrontCheckResult {
-    let mut env = frontCheckEnv("()")
-    env.errors = astFileErrorCount(file)
-    frontCheckCollectDecls(file, env)
-    for declIdx in file.arena.decls {
-        frontCheckDecl(file, env, declIdx)
-    }
-    frontCheckResultFromEnv(env)
+    let tys = emptyTyArena()
+    let cx = newElabCx(file, tys)
+    elabFile(cx)
+    serializeCheckResult(cx)
 }
 
-fn frontCheckSummaryFromEnv(env: FrontCheckEnv) -> FrontCheckSummary {
-    FrontCheckSummary {
-        assignments: env.assignments,
-        accepted: env.accepted,
-        errors: env.errors,
-    }
+// ---------------------------------------------------------------------
+// File driver.
+//
+// Collect-then-elaborate two-phase walk:
+//
+//   1. Collect pass registers every top-level signature (fn, struct,
+//      enum, interface, alias, let) without visiting bodies. This lets
+//      mutually-recursive references resolve without care-about-order.
+//
+//   2. Elaboration pass walks each decl's body, producing Core IR and
+//      propagating types. `let` decls at the top level run in script
+//      order; everything else is order-independent.
+// ---------------------------------------------------------------------
+
+pub fn elabFile(cx: ElabCx) {
+    collectDecls(cx)
+    elaborateDecls(cx)
 }
 
-fn frontCheckResultFromEnv(env: FrontCheckEnv) -> FrontCheckResult {
-    FrontCheckResult {
-        summary: frontCheckSummaryFromEnv(env),
-        typedNodes: env.typedNodes,
-        bindings: env.checkedBindings,
-        symbols: env.checkedSymbols,
-        instantiations: env.instantiations,
-    }
-}
-
-fn frontCheckEnv(returnType: String) -> FrontCheckEnv {
-    let mut env = FrontCheckEnv {
-        bindings: [],
-        fns: [],
-        fields: [],
-        variants: [],
-        aliases: [],
-        types: [],
-        interfaces: [],
-        interfaceExtends: [],
-        genericBounds: [],
-        returnType,
-        assignments: 0,
-        accepted: 0,
-        errors: 0,
-        typedNodes: [],
-        checkedBindings: [],
-        checkedSymbols: [],
-        instantiations: [],
-    }
-    frontCheckInstallBuiltins(env)
-    env
-}
-
-fn frontCheckChildEnv(parent: FrontCheckEnv, returnType: String) -> FrontCheckEnv {
-    FrontCheckEnv {
-        bindings: parent.bindings,
-        fns: parent.fns,
-        fields: parent.fields,
-        variants: parent.variants,
-        aliases: parent.aliases,
-        types: parent.types,
-        interfaces: parent.interfaces,
-        interfaceExtends: parent.interfaceExtends,
-        genericBounds: parent.genericBounds,
-        returnType,
-        assignments: 0,
-        accepted: 0,
-        errors: 0,
-        typedNodes: [],
-        checkedBindings: [],
-        checkedSymbols: parent.checkedSymbols,
-        instantiations: [],
-    }
-}
-
-fn frontCheckInstallBuiltins(env: FrontCheckEnv) {
-    env.types.push(FrontTypeSig { name: "Option", generics: ["T"] })
-    env.variants.push(FrontVariantSig { owner: "Option", name: "Some", fieldTypes: ["T"], generics: ["T"] })
-    env.variants.push(FrontVariantSig { owner: "Option", name: "None", fieldTypes: [], generics: ["T"] })
-    env.types.push(FrontTypeSig { name: "Result", generics: ["T", "E"] })
-    env.variants.push(FrontVariantSig { owner: "Result", name: "Ok", fieldTypes: ["T"], generics: ["T", "E"] })
-    env.variants.push(FrontVariantSig { owner: "Result", name: "Err", fieldTypes: ["E"], generics: ["T", "E"] })
-    env.types.push(FrontTypeSig { name: "Chan", generics: ["T"] })
-    env.types.push(FrontTypeSig { name: "ThreadHandle", generics: [] })
-}
-
-fn frontCheckMerge(parent: FrontCheckEnv, child: FrontCheckEnv) {
-    parent.assignments = parent.assignments + child.assignments
-    parent.accepted = parent.accepted + child.accepted
-    parent.errors = parent.errors + child.errors
-    for typed in child.typedNodes {
-        parent.typedNodes.push(typed)
-    }
-    for binding in child.checkedBindings {
-        parent.checkedBindings.push(binding)
-    }
-    for inst in child.instantiations {
-        parent.instantiations.push(inst)
-    }
-}
-
-pub fn frontCheckResultTypedNodeCount(result: FrontCheckResult) -> Int {
-    let mut count = 0
-    for typed in result.typedNodes {
-        let _ = typed
-        count = count + 1
-    }
-    count
-}
-
-pub fn frontCheckResultBindingType(result: FrontCheckResult, name: String) -> String {
-    let mut found = ""
-    for binding in result.bindings {
-        if binding.name == name {
-            found = binding.typeName
+fn collectDecls(cx: ElabCx) {
+    for declIdx in cx.ast.arena.decls {
+        let node = astArenaNodeAt(cx.ast.arena, declIdx)
+        match node.kind {
+            AstNFnDecl -> collectFnDecl(cx, declIdx, node, "", []),
+            AstNStructDecl -> collectStructDecl(cx, declIdx, node),
+            AstNEnumDecl -> collectEnumDecl(cx, declIdx, node),
+            AstNInterfaceDecl -> collectInterfaceDecl(cx, declIdx, node),
+            AstNTypeAlias -> collectTypeAlias(cx, declIdx, node),
+            AstNLetDecl -> collectLetDecl(cx, declIdx, node),
+            _ -> {},
         }
     }
-    found
 }
 
-pub fn frontCheckResultSymbolCount(result: FrontCheckResult, kind: String) -> Int {
-    let mut count = 0
-    for symbol in result.symbols {
-        if kind == "" || symbol.kind == kind {
-            count = count + 1
+fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGenerics: List<String>) {
+    let name = node.text
+    let generics = collectGenericNames(cx, node.children2)
+    let combinedGenerics = appendStringLists(ownerGenerics, generics)
+
+    // Build paramTys / paramNames from node.children (AstNParam entries).
+    let mut paramNames: List<String> = []
+    let mut paramTys: List<Int> = []
+    for paramIdx in node.children {
+        let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)
+        if paramNode.kind != AstNParam {
+            continue
+        }
+        paramNames.push(paramNode.text)
+        let declared = astTypeToTyInCollect(cx, paramNode.right)
+        paramTys.push(if declared >= 0 { declared } else { tErr(cx.env.tys) })
+    }
+
+    let retTy = astTypeToTyInCollect(cx, node.right)
+    let retEffective = if retTy >= 0 { retTy } else { tUnit(cx.env.tys) }
+
+    let receiverTy = if owner == "" {
+        -1
+    } else {
+        tyNamed(cx.env.tys, owner, genericListToTyArgs(cx, ownerGenerics))
+    }
+
+    let sig = CheckFnSig {
+        name,
+        owner,
+        receiverTy,
+        retTy: retEffective,
+        paramNames,
+        paramTys,
+        generics: combinedGenerics,
+        genericBounds: collectGenericBounds(cx, node.children2),
+    }
+    checkRegisterFn(cx.env, sig)
+
+    // Record a symbol for the Go-bridge summary.
+    let fnTy = tyFn(cx.env.tys, sig.paramTys, sig.retTy)
+    checkRecordSymbol(cx.env, declIdx, "fn", name, owner, fnTy, node.start, node.end)
+}
+
+fn collectStructDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let name = node.text
+    let generics = collectGenericNames(cx, node.children2)
+    checkRegisterType(cx.env, CheckTypeSig { name, generics, kind: "struct" })
+    let ownerTy = tyNamed(cx.env.tys, name, genericListToTyArgs(cx, generics))
+    checkRecordSymbol(cx.env, declIdx, "struct", name, "", ownerTy, node.start, node.end)
+
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        match member.kind {
+            AstNField_ -> {
+                let fieldTy = astTypeToTyInCollect(cx, member.right)
+                let effectiveTy = if fieldTy >= 0 { fieldTy } else { tErr(cx.env.tys) }
+                let hasDefault = member.left >= 0
+                let field = CheckFieldSig {
+                    owner: name,
+                    name: member.text,
+                    ty: effectiveTy,
+                    hasDefault,
+                }
+                checkRegisterField(cx.env, field)
+                checkRecordSymbol(cx.env, memberIdx, "field", member.text, name, effectiveTy, member.start, member.end)
+            },
+            AstNFnDecl -> collectFnDecl(cx, memberIdx, member, name, generics),
+            _ -> {},
         }
     }
-    count
 }
 
-pub fn frontCheckResultInstantiationCount(result: FrontCheckResult) -> Int {
-    let mut count = 0
-    for inst in result.instantiations {
-        let _ = inst
-        count = count + 1
-    }
-    count
-}
+fn collectEnumDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let name = node.text
+    let generics = collectGenericNames(cx, node.children2)
+    checkRegisterType(cx.env, CheckTypeSig { name, generics, kind: "enum" })
+    let ownerTy = tyNamed(cx.env.tys, name, genericListToTyArgs(cx, generics))
+    checkRecordSymbol(cx.env, declIdx, "enum", name, "", ownerTy, node.start, node.end)
 
-fn frontCheckHasTypedNode(env: FrontCheckEnv, node: Int) -> Bool {
-    for typed in env.typedNodes {
-        if typed.node == node {
-            return true
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        match member.kind {
+            AstNVariant -> {
+                let mut fieldTys: List<Int> = []
+                for fIdx in member.children {
+                    let f = astArenaNodeAt(cx.ast.arena, fIdx)
+                    if f.kind == AstNField_ {
+                        let ty = astTypeToTyInCollect(cx, f.right)
+                        fieldTys.push(if ty >= 0 { ty } else { tErr(cx.env.tys) })
+                    }
+                }
+                checkRegisterVariant(cx.env, CheckVariantSig {
+                    owner: name,
+                    name: member.text,
+                    fieldTys,
+                    generics,
+                })
+                checkRecordSymbol(cx.env, memberIdx, "variant", member.text, name, ownerTy, member.start, member.end)
+            },
+            AstNFnDecl -> collectFnDecl(cx, memberIdx, member, name, generics),
+            _ -> {},
         }
     }
-    false
 }
 
-fn frontCheckRecordTypedNode(file: AstFile, env: FrontCheckEnv, nodeIdx: Int, typeName: String) {
-    if nodeIdx < 0 || typeName == "" || typeName == "Invalid" {
+fn collectInterfaceDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let name = node.text
+    let generics = collectGenericNames(cx, node.children2)
+    checkRegisterInterface(cx.env, name)
+    checkRegisterType(cx.env, CheckTypeSig { name, generics, kind: "interface" })
+    checkRecordSymbol(cx.env, declIdx, "interface", name, "", tyNamed(cx.env.tys, name, []), node.start, node.end)
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            collectFnDecl(cx, memberIdx, member, name, generics)
+        }
+    }
+}
+
+fn collectTypeAlias(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let name = node.text
+    let generics = collectGenericNames(cx, node.children2)
+    let target = astTypeToTyInCollect(cx, node.left)
+    let ty = if target >= 0 { target } else { tErr(cx.env.tys) }
+    checkRegisterAlias(cx.env, CheckAliasSig { name, ty, generics })
+    checkRecordSymbol(cx.env, declIdx, "alias", name, "", ty, node.start, node.end)
+}
+
+fn collectLetDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let name = node.text
+    let declared = astTypeToTyInCollect(cx, node.extra)
+    let ty = if declared >= 0 { declared } else { tErr(cx.env.tys) }
+    // Bind the name globally so ident lookups find it during
+    // elaboration of fn bodies.
+    checkBindSpan(cx.env, name, ty, node.flags == 1, node.start, node.end)
+    checkRecordSymbol(cx.env, declIdx, "let", name, "", ty, node.start, node.end)
+}
+
+// ---------------------------------------------------------------------
+// Decl bodies.
+// ---------------------------------------------------------------------
+
+fn elaborateDecls(cx: ElabCx) {
+    for declIdx in cx.ast.arena.decls {
+        let node = astArenaNodeAt(cx.ast.arena, declIdx)
+        match node.kind {
+            AstNFnDecl -> elaborateFnBody(cx, node, ""),
+            AstNStructDecl -> elaborateStructMethods(cx, node),
+            AstNEnumDecl -> elaborateEnumMethods(cx, node),
+            AstNInterfaceDecl -> {},
+            AstNLetDecl -> elaborateLetDecl(cx, declIdx, node),
+            _ -> {},
+        }
+    }
+}
+
+fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
+    let sig = checkLookupFn(cx.env, node.text, owner)
+    if sig.name == "" {
         return
     }
-    if frontCheckHasTypedNode(env, nodeIdx) {
+    let mark = checkScopeMark(cx.env)
+    let prevReturn = cx.env.returnTy
+    let prevFnName = cx.env.fnName
+    cx.env.returnTy = sig.retTy
+    cx.env.fnName = sig.name
+
+    // Bind parameters.
+    let mut i = 0
+    for pname in sig.paramNames {
+        let pty = if i < checkIntListLenLocal(sig.paramTys) { checkIntListAtLocal(sig.paramTys, i) } else { tErr(cx.env.tys) }
+        checkBindSpan(cx.env, pname, pty, false, node.start, node.end)
+        i = i + 1
+    }
+
+    if node.left >= 0 {
+        // Fn body is stored in node.left as a block (AstNBlock).
+        let _ = elabCheck(cx, node.left, sig.retTy)
+    }
+
+    cx.env.returnTy = prevReturn
+    cx.env.fnName = prevFnName
+    checkScopeDrop(cx.env, mark)
+}
+
+fn elaborateStructMethods(cx: ElabCx, node: AstNode) {
+    let owner = node.text
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            elaborateFnBody(cx, member, owner)
+        }
+    }
+}
+
+fn elaborateEnumMethods(cx: ElabCx, node: AstNode) {
+    let owner = node.text
+    for memberIdx in node.children {
+        let member = astArenaNodeAt(cx.ast.arena, memberIdx)
+        if member.kind == AstNFnDecl {
+            elaborateFnBody(cx, member, owner)
+        }
+    }
+}
+
+fn elaborateLetDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let _ = declIdx
+    if node.left < 0 {
         return
     }
-    let node = astArenaNodeAt(file.arena, nodeIdx)
-    env.typedNodes.push(
-        FrontCheckedNode {
-            node: nodeIdx,
-            kind: astNodeKindName(node.kind),
-            typeName,
-            start: node.start,
-            end: node.end,
-        },
-    )
-}
-
-fn frontCheckTypedExpr(file: AstFile, env: FrontCheckEnv, nodeIdx: Int, typeName: String) -> String {
-    frontCheckRecordTypedNode(file, env, nodeIdx, typeName)
-    typeName
-}
-
-fn frontCheckRecordBinding(env: FrontCheckEnv, node: Int, name: String, typeName: String, mutable: Bool, start: Int, end: Int) {
-    if name != "" && name != "_" {
-        env.checkedBindings.push(FrontCheckedBinding { node, name, typeName, mutable, start, end })
+    let declared = checkLookup(cx.env, node.text)
+    let value = if declared >= 0 && !(tyIsErr(cx.env.tys, declared)) {
+        elabCheck(cx, node.left, declared)
+    } else {
+        elabInfer(cx, node.left)
     }
+    let _ = value
 }
 
-fn frontCheckRecordSymbol(env: FrontCheckEnv, nodeIdx: Int, node: AstNode, kind: String, name: String, owner: String, typeName: String) {
-    env.checkedSymbols.push(
-        FrontCheckedSymbol {
-            node: nodeIdx,
-            kind,
-            name,
-            owner,
-            typeName,
-            start: node.start,
-            end: node.end,
-        },
-    )
-}
+// ---------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------
 
-fn frontCheckConcreteTypeArgs(generics: List<String>, substs: List<FrontTypeSubst>) -> List<String> {
+fn collectGenericNames(cx: ElabCx, idxs: List<Int>) -> List<String> {
     let mut out: List<String> = []
-    for generic in generics {
-        let value = frontCheckSubstLookup(substs, generic)
-        if value != "" {
-            out.push(value)
+    for idx in idxs {
+        let node = astArenaNodeAt(cx.ast.arena, idx)
+        if node.kind == AstNGenericParam {
+            out.push(node.text)
         }
     }
     out
 }
 
-fn frontCheckRecordInstantiation(file: AstFile, env: FrontCheckEnv, nodeIdx: Int, callee: String, generics: List<String>, substs: List<FrontTypeSubst>, resultType: String) {
-    if nodeIdx < 0 {
-        return
-    }
-    let typeArgs = frontCheckConcreteTypeArgs(generics, substs)
-    if frontCheckStringCount(typeArgs) == 0 {
-        return
-    }
-    let node = astArenaNodeAt(file.arena, nodeIdx)
-    env.instantiations.push(
-        FrontCheckInstantiation {
-            node: nodeIdx,
-            callee,
-            typeArgs,
-            resultType,
-            start: node.start,
-            end: node.end,
-        },
-    )
-}
-
-fn frontCheckCollectDecls(file: AstFile, env: FrontCheckEnv) {
-    for declIdx in file.arena.decls {
-        let decl = astArenaNodeAt(file.arena, declIdx)
-        frontCheckCollectDecl(file, env, declIdx, decl, "", [])
-    }
-}
-
-fn frontCheckCollectDecl(file: AstFile, env: FrontCheckEnv, declIdx: Int, decl: AstNode, owner: String, ownerGenerics: List<String>) {
-    if decl.kind == AstNFnDecl {
-        if frontCheckFnExists(env, decl.text, owner) {
-            env.errors = env.errors + 1
-        }
-        frontCheckCheckGenericParams(file, env, decl.children2)
-        let sig = frontFnSigFromDecl(file, decl, owner, ownerGenerics)
-        env.fns.push(sig)
-        frontCheckRecordSymbol(env, declIdx, decl, "fn", decl.text, owner, frontCheckFnType(sig.paramTypes, sig.returnType))
-        return
-    }
-    if decl.kind == AstNStructDecl {
-        frontCheckCheckGenericParams(file, env, decl.children2)
-        let generics = frontCheckGenericNames(file, decl.children2)
-        if frontCheckDeclaredTypeExists(env, decl.text) {
-            env.errors = env.errors + 1
-        }
-        env.types.push(FrontTypeSig { name: decl.text, generics })
-        frontCheckRecordSymbol(env, declIdx, decl, "struct", decl.text, owner, frontCheckGenericOwnerType(decl.text, generics, []))
-        for memberIdx in decl.children {
-            let member = astArenaNodeAt(file.arena, memberIdx)
-            if member.kind == AstNField_ {
-                if frontCheckFieldLookup(env, decl.text, member.text).name != "" {
-                    env.errors = env.errors + 1
-                }
-                let field = FrontFieldSig {
-                    owner: decl.text,
-                    name: member.text,
-                    typeName: frontCheckTypeName(file, member.right),
-                    hasDefault: member.left >= 0,
-                }
-                env.fields.push(field)
-                frontCheckRecordSymbol(env, memberIdx, member, "field", member.text, decl.text, field.typeName)
-            } else if member.kind == AstNFnDecl {
-                frontCheckCollectDecl(file, env, memberIdx, member, decl.text, generics)
-            }
-        }
-        return
-    }
-    if decl.kind == AstNEnumDecl {
-        frontCheckCheckGenericParams(file, env, decl.children2)
-        let generics = frontCheckGenericNames(file, decl.children2)
-        if frontCheckDeclaredTypeExists(env, decl.text) {
-            env.errors = env.errors + 1
-        }
-        env.types.push(FrontTypeSig { name: decl.text, generics })
-        frontCheckRecordSymbol(env, declIdx, decl, "enum", decl.text, owner, frontCheckGenericOwnerType(decl.text, generics, []))
-        for memberIdx in decl.children {
-            let member = astArenaNodeAt(file.arena, memberIdx)
-            if member.kind == AstNVariant {
-                if frontCheckVariantLookupForOwner(env, member.text, decl.text).name != "" {
-                    env.errors = env.errors + 1
-                }
-                let mut fieldTypes: List<String> = []
-                for fieldIdx in member.children {
-                    fieldTypes.push(frontCheckTypeName(file, fieldIdx))
-                }
-                env.variants.push(FrontVariantSig { owner: decl.text, name: member.text, fieldTypes, generics })
-                frontCheckRecordSymbol(env, memberIdx, member, "variant", member.text, decl.text, frontCheckGenericOwnerType(decl.text, generics, []))
-            } else if member.kind == AstNFnDecl {
-                frontCheckCollectDecl(file, env, memberIdx, member, decl.text, generics)
-            }
-        }
-        return
-    }
-    if decl.kind == AstNInterfaceDecl {
-        if frontCheckDeclaredTypeExists(env, decl.text) {
-            env.errors = env.errors + 1
-        }
-        env.types.push(FrontTypeSig { name: decl.text, generics: [] })
-        env.interfaces.push(decl.text)
-        frontCheckRecordSymbol(env, declIdx, decl, "interface", decl.text, owner, decl.text)
-        for superIdx in decl.children2 {
-            env.interfaceExtends.push(FrontInterfaceExtSig { owner: decl.text, typeName: frontCheckTypeName(file, superIdx) })
-        }
-        for memberIdx in decl.children {
-            let member = astArenaNodeAt(file.arena, memberIdx)
-            if member.kind == AstNFnDecl {
-                if frontCheckFnExists(env, member.text, decl.text) {
-                    env.errors = env.errors + 1
-                }
-                frontCheckCheckGenericParams(file, env, member.children2)
-                env.fns.push(frontFnSigFromInterfaceDecl(file, member, decl.text))
-                let sig = frontFnSigFromInterfaceDecl(file, member, decl.text)
-                frontCheckRecordSymbol(env, memberIdx, member, "fn", member.text, decl.text, frontCheckFnType(sig.paramTypes, sig.returnType))
-            } else if member.kind == AstNType {
-                env.interfaceExtends.push(FrontInterfaceExtSig { owner: decl.text, typeName: frontCheckTypeName(file, memberIdx) })
-            }
-        }
-        return
-    }
-    if decl.kind == AstNTypeAlias {
-        frontCheckCheckGenericParams(file, env, decl.children)
-        if frontCheckDeclaredTypeExists(env, decl.text) {
-            env.errors = env.errors + 1
-        }
-        env.aliases.push(FrontAliasSig { name: decl.text, typeName: frontCheckTypeName(file, decl.left), generics: frontCheckGenericNames(file, decl.children) })
-        frontCheckRecordSymbol(env, declIdx, decl, "alias", decl.text, owner, frontCheckTypeName(file, decl.left))
-        return
-    }
-    if decl.kind == AstNLet {
-        let declared = frontCheckTypeName(file, frontCheckFirstChild(decl))
-        if declared != "()" && declared != "Invalid" {
-            frontCheckBindLetDecl(file, env, decl, declared)
-        }
-        return
-    }
-    if decl.kind == AstNUseDecl {
-        let alias = frontCheckUseAlias(file, decl)
-        let importedTypes = frontCheckUseImportedTypeNames(file, decl)
-        for itemIdx in decl.children {
-            let item = astArenaNodeAt(file.arena, itemIdx)
-            if item.kind == AstNFnDecl {
-                let mut sig = frontFnSigFromDecl(file, item, "", [])
-                sig.name = "{alias}.{sig.name}"
-                sig = frontCheckQualifyImportedSig(sig, alias, importedTypes)
-                env.fns.push(sig)
-                frontCheckRecordSymbol(env, itemIdx, item, "fn", sig.name, alias, frontCheckFnType(sig.paramTypes, sig.returnType))
-            } else if item.kind == AstNStructDecl {
-                frontCheckCollectImportedStruct(file, env, itemIdx, item, alias, importedTypes)
-            } else if item.kind == AstNTypeAlias {
-                let generics = frontCheckGenericNames(file, item.children)
-                let name = "{alias}.{item.text}"
-                if frontCheckDeclaredTypeExists(env, name) {
-                    env.errors = env.errors + 1
-                }
-                env.aliases.push(
-                    FrontAliasSig {
-                        name,
-                        typeName: frontCheckQualifyImportedType(frontCheckTypeName(file, item.left), alias, importedTypes),
-                        generics,
-                    },
-                )
-                frontCheckRecordSymbol(env, itemIdx, item, "alias", name, alias, frontCheckAliasTarget(env, name))
-            }
-        }
-    }
-}
-
-fn frontCheckCollectImportedStruct(
-    file: AstFile,
-    env: FrontCheckEnv,
-    itemIdx: Int,
-    item: AstNode,
-    alias: String,
-    importedTypes: List<String>,
-) {
-    let generics = frontCheckGenericNames(file, item.children2)
-    let owner = "{alias}.{item.text}"
-    if frontCheckDeclaredTypeExists(env, owner) {
-        env.errors = env.errors + 1
-    }
-    env.types.push(FrontTypeSig { name: owner, generics })
-    frontCheckRecordSymbol(env, itemIdx, item, "struct", owner, alias, frontCheckGenericOwnerType(owner, generics, []))
-    for memberIdx in item.children {
-        let member = astArenaNodeAt(file.arena, memberIdx)
-        if member.kind == AstNField_ {
-            if frontCheckFieldLookup(env, owner, member.text).name != "" {
-                env.errors = env.errors + 1
-            }
-            let field = FrontFieldSig {
-                owner,
-                name: member.text,
-                typeName: frontCheckQualifyImportedType(frontCheckTypeName(file, member.right), alias, importedTypes),
-                hasDefault: member.left >= 0,
-            }
-            env.fields.push(field)
-            frontCheckRecordSymbol(env, memberIdx, member, "field", member.text, owner, field.typeName)
-        } else if member.kind == AstNFnDecl {
-            let mut sig = frontFnSigFromDecl(file, member, owner, generics)
-            sig = frontCheckQualifyImportedSig(sig, alias, importedTypes)
-            env.fns.push(sig)
-            frontCheckRecordSymbol(env, memberIdx, member, "fn", member.text, owner, frontCheckFnType(sig.paramTypes, sig.returnType))
-        }
-    }
-}
-
-fn frontCheckUseAlias(file: AstFile, node: AstNode) -> String {
-    let aliasIdx = frontCheckIntAt(node.children2, 0)
-    if aliasIdx >= 0 {
-        let alias = astArenaNodeAt(file.arena, aliasIdx)
-        if alias.text != "" {
-            return alias.text
-        }
-    }
-    frontCheckLastPathSegment(frontCheckUsePathText(node))
-}
-
-fn frontCheckUsePathText(node: AstNode) -> String {
-    let text = node.text
-    if node.flags != 1 {
-        return text
-    }
-    if strings.HasPrefix(text, "r\"\"\"") && strings.HasSuffix(text, "\"\"\"") {
-        return strings.TrimSuffix(strings.TrimPrefix(text, "r\"\"\""), "\"\"\"")
-    }
-    if strings.HasPrefix(text, "\"\"\"") && strings.HasSuffix(text, "\"\"\"") {
-        return strings.TrimSuffix(strings.TrimPrefix(text, "\"\"\""), "\"\"\"")
-    }
-    if strings.HasPrefix(text, "r\"") && strings.HasSuffix(text, "\"") {
-        return strings.TrimSuffix(strings.TrimPrefix(text, "r\""), "\"")
-    }
-    if strings.HasPrefix(text, "\"") && strings.HasSuffix(text, "\"") {
-        return strings.TrimSuffix(strings.TrimPrefix(text, "\""), "\"")
-    }
-    text
-}
-
-fn frontCheckUseImportedTypeNames(file: AstFile, node: AstNode) -> List<String> {
-    let mut names: List<String> = []
-    for itemIdx in node.children {
-        let item = astArenaNodeAt(file.arena, itemIdx)
-        if item.kind == AstNStructDecl || item.kind == AstNEnumDecl || item.kind == AstNInterfaceDecl || item.kind == AstNTypeAlias {
-            names.push(item.text)
-        }
-    }
-    names
-}
-
-fn frontCheckQualifyImportedSig(sig: FrontFnSig, alias: String, importedTypes: List<String>) -> FrontFnSig {
-    let mut paramTypes: List<String> = []
-    for paramType in sig.paramTypes {
-        paramTypes.push(frontCheckQualifyImportedType(paramType, alias, importedTypes))
-    }
-    let mut bounds: List<FrontTypeSubst> = []
-    for bound in sig.genericBounds {
-        bounds.push(
-            FrontTypeSubst {
-                name: bound.name,
-                typeName: frontCheckQualifyImportedType(bound.typeName, alias, importedTypes),
-            },
-        )
-    }
-    FrontFnSig {
-        name: sig.name,
-        receiverType: sig.receiverType,
-        returnType: frontCheckQualifyImportedType(sig.returnType, alias, importedTypes),
-        paramNames: sig.paramNames,
-        paramTypes,
-        generics: sig.generics,
-        genericBounds: bounds,
-    }
-}
-
-fn frontCheckQualifyImportedType(typeName: String, alias: String, importedTypes: List<String>) -> String {
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        let mut elems: List<String> = []
-        for elem in view.args {
-            elems.push(frontCheckQualifyImportedType(elem, alias, importedTypes))
-        }
-        return frontCheckTupleType(elems)
-    }
-    if view.kind == "fn" {
-        let mut params: List<String> = []
-        for param in view.params {
-            params.push(frontCheckQualifyImportedType(param, alias, importedTypes))
-        }
-        return frontCheckFnType(params, frontCheckQualifyImportedType(view.ret, alias, importedTypes))
-    }
-    if view.kind == "named" {
-        let mut args: List<String> = []
-        for arg in view.args {
-            args.push(frontCheckQualifyImportedType(arg, alias, importedTypes))
-        }
-        let mut head = view.head
-        if frontCheckStringContains(importedTypes, head) {
-            head = "{alias}.{head}"
-        }
-        return frontCheckNamedType(head, args)
-    }
-    typeName
-}
-
-fn frontFnSigFromDecl(file: AstFile, decl: AstNode, owner: String, ownerGenerics: List<String>) -> FrontFnSig {
-    frontFnSigFromDeclMode(file, decl, owner, ownerGenerics, false)
-}
-
-fn frontFnSigFromInterfaceDecl(file: AstFile, decl: AstNode, owner: String) -> FrontFnSig {
-    frontFnSigFromDeclMode(file, decl, owner, [], true)
-}
-
-fn frontFnSigFromDeclMode(file: AstFile, decl: AstNode, owner: String, ownerGenerics: List<String>, preserveSelf: Bool) -> FrontFnSig {
-    let mut paramNames: List<String> = []
-    let mut paramTypes: List<String> = []
-    let mut generics = ownerGenerics
-    let mut genericBounds = frontCheckGenericBounds(file, decl.children2)
-    for genericIdx in decl.children2 {
-        let generic = astArenaNodeAt(file.arena, genericIdx)
-        generics.push(generic.text)
-    }
-    let selfType = frontCheckSelfType(owner, ownerGenerics)
-    for paramIdx in decl.children {
-        let param = astArenaNodeAt(file.arena, paramIdx)
-        let mut paramType = frontCheckTypeName(file, param.right)
-        if param.text == "self" && owner != "" && param.right < 0 {
-            paramType = selfType
-        }
-        paramNames.push(param.text)
-        paramTypes.push(frontCheckReplaceSelfMode(paramType, selfType, preserveSelf))
-    }
-    FrontFnSig {
-        name: decl.text,
-        receiverType: owner,
-        returnType: frontCheckReplaceSelfMode(frontCheckTypeName(file, decl.left), selfType, preserveSelf),
-        paramNames,
-        paramTypes,
-        generics,
-        genericBounds,
-    }
-}
-
-fn frontCheckGenericNames(file: AstFile, idxs: List<Int>) -> List<String> {
-    let mut names: List<String> = []
+fn collectGenericBounds(cx: ElabCx, idxs: List<Int>) -> List<CheckGenericBound> {
+    let mut out: List<CheckGenericBound> = []
     for idx in idxs {
-        let n = astArenaNodeAt(file.arena, idx)
-        names.push(n.text)
-    }
-    names
-}
-
-fn frontCheckCheckGenericParams(file: AstFile, env: FrontCheckEnv, idxs: List<Int>) {
-    let mut seen: List<String> = []
-    for idx in idxs {
-        let n = astArenaNodeAt(file.arena, idx)
-        if frontCheckStringContains(seen, n.text) {
-            env.errors = env.errors + 1
+        let node = astArenaNodeAt(cx.ast.arena, idx)
+        if node.kind != AstNGenericParam {
+            continue
         }
-        seen.push(n.text)
-    }
-}
-
-fn frontCheckStringContains(xs: List<String>, needle: String) -> Bool {
-    for x in xs {
-        if x == needle {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckGenericBounds(file: AstFile, idxs: List<Int>) -> List<FrontTypeSubst> {
-    let mut bounds: List<FrontTypeSubst> = []
-    for idx in idxs {
-        let generic = astArenaNodeAt(file.arena, idx)
-        for boundIdx in generic.children {
-            bounds.push(FrontTypeSubst { name: generic.text, typeName: frontCheckTypeName(file, boundIdx) })
-        }
-    }
-    bounds
-}
-
-fn frontCheckSelfType(owner: String, generics: List<String>) -> String {
-    if owner == "" {
-        return "Invalid"
-    }
-    if frontCheckStringCount(generics) == 0 {
-        return owner
-    }
-    let joined = frontCheckJoinTypes(generics)
-    "{owner}<{joined}>"
-}
-
-fn frontCheckReplaceSelf(typeName: String, selfType: String) -> String {
-    frontCheckReplaceSelfMode(typeName, selfType, false)
-}
-
-fn frontCheckReplaceSelfMode(typeName: String, selfType: String, preserveSelf: Bool) -> String {
-    if typeName == "Self" {
-        if preserveSelf {
-            return "Self"
-        }
-        return selfType
-    }
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        let mut elems: List<String> = []
-        for elem in view.args {
-            elems.push(frontCheckReplaceSelfMode(elem, selfType, preserveSelf))
-        }
-        return frontCheckTupleType(elems)
-    }
-    if view.kind == "fn" {
-        let mut params: List<String> = []
-        for param in view.params {
-            params.push(frontCheckReplaceSelfMode(param, selfType, preserveSelf))
-        }
-        return frontCheckFnType(params, frontCheckReplaceSelfMode(view.ret, selfType, preserveSelf))
-    }
-    if view.kind == "named" && frontCheckStringCount(view.args) > 0 {
-        let mut args: List<String> = []
-        for arg in view.args {
-            args.push(frontCheckReplaceSelfMode(arg, selfType, preserveSelf))
-        }
-        return frontCheckNamedType(view.head, args)
-    }
-    typeName
-}
-
-fn frontCheckDecl(file: AstFile, env: FrontCheckEnv, idx: Int) {
-    let decl = astArenaNodeAt(file.arena, idx)
-    if decl.kind == AstNFnDecl {
-        frontCheckFnDecl(file, env, decl, "", [])
-        return
-    }
-    if decl.kind == AstNStructDecl {
-        let generics = frontCheckGenericNames(file, decl.children2)
-        for memberIdx in decl.children {
-            let member = astArenaNodeAt(file.arena, memberIdx)
-            if member.kind == AstNField_ && member.left >= 0 {
-                let got = frontCheckExpr(file, env, member.left)
-                frontCheckExpectAssignable(env, frontCheckTypeName(file, member.right), got)
-            } else if member.kind == AstNFnDecl {
-                frontCheckFnDecl(file, env, member, decl.text, generics)
+        for boundIdx in node.children {
+            let ty = astTypeToTyInCollect(cx, boundIdx)
+            if ty >= 0 {
+                out.push(CheckGenericBound { tyParam: node.text, iface: ty })
             }
         }
-        return
     }
-    if decl.kind == AstNEnumDecl {
-        let generics = frontCheckGenericNames(file, decl.children2)
-        for memberIdx in decl.children {
-            let member = astArenaNodeAt(file.arena, memberIdx)
-            if member.kind == AstNFnDecl {
-                frontCheckFnDecl(file, env, member, decl.text, generics)
-            }
-        }
-        return
-    }
-    if decl.kind == AstNLet {
-        frontCheckLetDecl(file, env, decl)
-    }
+    out
 }
 
-fn frontCheckLetDecl(file: AstFile, env: FrontCheckEnv, node: AstNode) {
-    let declared = frontCheckTypeName(file, frontCheckFirstChild(node))
-    let valueType = frontCheckExprHint(file, env, node.right, declared)
-    let mut finalType = valueType
-    if declared != "()" && declared != "Invalid" {
-        frontCheckExpectAssignable(env, declared, valueType)
-        finalType = declared
+fn appendStringLists(a: List<String>, b: List<String>) -> List<String> {
+    let mut out: List<String> = []
+    for x in a {
+        out.push(x)
     }
-    if frontCheckLetDeclName(file, node) == "" {
-        if !(frontCheckPatternIrrefutable(file, node.left)) {
-            env.errors = env.errors + 1
-        }
-        frontCheckBindPattern(file, env, node.left, finalType, node.flags == 1)
-    } else if declared == "()" || declared == "Invalid" {
-        frontCheckBindLetDecl(file, env, node, finalType)
+    for y in b {
+        out.push(y)
     }
+    out
 }
 
-fn frontCheckBindLetDecl(file: AstFile, env: FrontCheckEnv, node: AstNode, typeName: String) {
-    let name = frontCheckLetDeclName(file, node)
-    if name == "" {
-        frontCheckBindPattern(file, env, node.left, typeName, node.flags == 1)
-        return
+fn genericListToTyArgs(cx: ElabCx, names: List<String>) -> List<Int> {
+    let mut out: List<Int> = []
+    for name in names {
+        out.push(tyNamed(cx.env.tys, name, []))
     }
-    let pat = astArenaNodeAt(file.arena, node.left)
-    frontCheckBindNode(env, name, typeName, node.flags == 1, node.left, pat.start, pat.end)
+    out
 }
 
-fn frontCheckLetDeclName(file: AstFile, node: AstNode) -> String {
-    if node.left < 0 {
-        return ""
+/// astTypeToTyInCollect lowers an AST type node via the legacy string
+/// round-trip. Separate from the elaborator's `astTypeToTy` so the
+/// collect pass does not depend on a running `cx`.
+fn astTypeToTyInCollect(cx: ElabCx, idx: Int) -> Int {
+    if idx < 0 {
+        return -1
     }
-    let pat = astArenaNodeAt(file.arena, node.left)
-    if pat.kind == AstNIdent {
-        return pat.text
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind != AstNType {
+        return -1
     }
-    if pat.kind == AstNPattern {
-        let kind = frontCheckPatternKind(pat)
-        if (kind == "ident" || kind == "variant") && frontCheckIntCount(pat.children) == 0 && pat.left < 0 {
-            return frontCheckPatternName(pat)
-        }
+    if node.text == "" {
+        return -1
     }
-    ""
+    tyFromString(cx.env.tys, node.text)
 }
 
-fn frontCheckFnDecl(file: AstFile, parent: FrontCheckEnv, decl: AstNode, owner: String, ownerGenerics: List<String>) {
-    let sig = frontFnSigFromDecl(file, decl, owner, ownerGenerics)
-    let mut env = frontCheckChildEnv(parent, sig.returnType)
-    env.genericBounds = sig.genericBounds
-    let mut idx = 0
-    for paramName in sig.paramNames {
-        let paramType = frontCheckStringAt(sig.paramTypes, idx)
-        if paramName != "" {
-            let paramIdx = frontCheckIntAt(decl.children, idx)
-            let param = astArenaNodeAt(file.arena, paramIdx)
-            frontCheckBindNode(env, paramName, paramType, true, paramIdx, param.start, param.end)
-        }
-        idx = idx + 1
-    }
-    if decl.right >= 0 {
-        let bodyType = frontCheckBlockHint(file, env, decl.right, true, sig.returnType)
-        if sig.returnType != "()" && bodyType != "Never" {
-            frontCheckExpectAssignable(env, sig.returnType, bodyType)
-        }
-    }
-    frontCheckMerge(parent, env)
-}
-
-fn frontCheckBind(env: FrontCheckEnv, name: String, typeName: String, mutable: Bool) {
-    frontCheckBindNode(env, name, typeName, mutable, -1, 0, 0)
-}
-
-fn frontCheckBindNode(env: FrontCheckEnv, name: String, typeName: String, mutable: Bool, node: Int, start: Int, end: Int) {
-    if name != "" && name != "_" {
-        env.bindings.push(FrontCheckBinding { name, typeName, mutable })
-        frontCheckRecordBinding(env, node, name, typeName, mutable, start, end)
-    }
-}
-
-fn frontCheckBindingCount(xs: List<FrontCheckBinding>) -> Int {
-    let mut count = 0
+fn checkIntListLenLocal(xs: List<Int>) -> Int {
+    let mut n = 0
     for x in xs {
         let _ = x
-        count = count + 1
+        n = n + 1
     }
-    count
+    n
 }
 
-fn frontCheckBindingAt(xs: List<FrontCheckBinding>, idx: Int) -> FrontCheckBinding {
+fn checkIntListAtLocal(xs: List<Int>, idx: Int) -> Int {
     let mut i = 0
     for x in xs {
         if i == idx {
@@ -902,50 +453,100 @@ fn frontCheckBindingAt(xs: List<FrontCheckBinding>, idx: Int) -> FrontCheckBindi
         }
         i = i + 1
     }
-    FrontCheckBinding { name: "", typeName: "Invalid", mutable: false }
+    -1
 }
 
-fn frontCheckBindingsFrom(env: FrontCheckEnv, start: Int) -> List<FrontCheckBinding> {
-    let mut out: List<FrontCheckBinding> = []
-    let mut i = 0
-    for binding in env.bindings {
-        if i >= start {
-            out.push(binding)
+// ---------------------------------------------------------------------
+// CoreModule → FrontCheckResult serialization.
+// ---------------------------------------------------------------------
+
+fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
+    let summary = FrontCheckSummary {
+        assignments: cx.env.assignments,
+        accepted: cx.env.accepted,
+        errors: checkDiagCountErrors(cx.env.diagnostics),
+    }
+
+    let mut typedNodes: List<FrontCheckedNode> = []
+    for node in cx.env.typedNodes {
+        typedNodes.push(FrontCheckedNode {
+            node: node.node,
+            kind: node.kind,
+            typeName: tyToString(cx.env.tys, node.ty),
+            start: node.start,
+            end: node.end,
+        })
+    }
+
+    let mut bindings: List<FrontCheckedBinding> = []
+    for b in cx.env.bindingRecords {
+        bindings.push(FrontCheckedBinding {
+            node: b.node,
+            name: b.name,
+            typeName: tyToString(cx.env.tys, b.ty),
+            mutable: b.mutable,
+            start: b.start,
+            end: b.end,
+        })
+    }
+
+    let mut symbols: List<FrontCheckedSymbol> = []
+    for s in cx.env.symbolRecords {
+        symbols.push(FrontCheckedSymbol {
+            node: s.node,
+            kind: s.kind,
+            name: s.name,
+            owner: s.owner,
+            typeName: tyToString(cx.env.tys, s.ty),
+            start: s.start,
+            end: s.end,
+        })
+    }
+
+    let mut instantiations: List<FrontCheckInstantiation> = []
+    for inst in cx.env.instantiations {
+        let mut typeArgStrs: List<String> = []
+        for tyArg in inst.typeArgs {
+            typeArgStrs.push(tyToString(cx.env.tys, tyArg))
         }
-        i = i + 1
+        instantiations.push(FrontCheckInstantiation {
+            node: inst.node,
+            callee: inst.callee,
+            typeArgs: typeArgStrs,
+            resultType: tyToString(cx.env.tys, inst.resultTy),
+            start: inst.start,
+            end: inst.end,
+        })
     }
-    out
-}
 
-fn frontCheckBindingsAgree(env: FrontCheckEnv, left: List<FrontCheckBinding>, right: List<FrontCheckBinding>) -> Bool {
-    if frontCheckBindingCount(left) != frontCheckBindingCount(right) {
-        return false
-    }
-    let mut i = 0
-    for l in left {
-        let r = frontCheckBindingAt(right, i)
-        if l.name != r.name {
-            return false
-        }
-        if !(frontCheckIsAssignable(env, l.typeName, r.typeName)) || !(frontCheckIsAssignable(env, r.typeName, l.typeName)) {
-            return false
-        }
-        i = i + 1
-    }
-    true
-}
-
-fn frontCheckPopBindings(env: FrontCheckEnv, target: Int) {
-    let mut count = frontCheckBindingCount(env.bindings)
-    for count > target {
-        env.bindings.pop()
-        count = count - 1
+    FrontCheckResult {
+        summary,
+        typedNodes,
+        bindings,
+        symbols,
+        instantiations,
+        diagnostics: cx.env.diagnostics,
     }
 }
 
-fn frontCheckLookup(env: FrontCheckEnv, name: String) -> String {
-    let mut found = "Invalid"
-    for b in env.bindings {
+// ---------------------------------------------------------------------
+// Legacy public helpers that tests hit directly. Preserve the names
+// and return shapes so `toolchain/check_test.osty` (orphan) still
+// compiles against the new entry point once wired up.
+// ---------------------------------------------------------------------
+
+pub fn frontCheckResultTypedNodeCount(result: FrontCheckResult) -> Int {
+    let mut n = 0
+    for x in result.typedNodes {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+pub fn frontCheckResultBindingType(result: FrontCheckResult, name: String) -> String {
+    let mut found = ""
+    for b in result.bindings {
         if b.name == name {
             found = b.typeName
         }
@@ -953,3289 +554,21 @@ fn frontCheckLookup(env: FrontCheckEnv, name: String) -> String {
     found
 }
 
-fn frontCheckLookupMutable(env: FrontCheckEnv, name: String) -> Bool {
-    let mut found = false
-    for b in env.bindings {
-        if b.name == name {
-            found = b.mutable
+pub fn frontCheckResultSymbolCount(result: FrontCheckResult, kind: String) -> Int {
+    let mut n = 0
+    for s in result.symbols {
+        if s.kind == kind {
+            n = n + 1
         }
     }
-    found
+    n
 }
 
-fn frontCheckSigLookup(env: FrontCheckEnv, name: String) -> FrontFnSig {
-    for sig in env.fns {
-        if sig.name == name && sig.receiverType == "" {
-            return sig
-        }
-    }
-    FrontFnSig { name: "", receiverType: "", returnType: "Invalid", paramNames: [], paramTypes: [], generics: [], genericBounds: [] }
-}
-
-fn frontCheckFnExists(env: FrontCheckEnv, name: String, owner: String) -> Bool {
-    for sig in env.fns {
-        if sig.name == name && sig.receiverType == owner {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckMethodLookup(env: FrontCheckEnv, owner: String, name: String) -> FrontFnSig {
-    frontCheckMethodLookupAt(env, owner, name, 0)
-}
-
-fn frontCheckMethodLookupAt(env: FrontCheckEnv, owner: String, name: String, depth: Int) -> FrontFnSig {
-    for sig in env.fns {
-        if sig.name == name && sig.receiverType == owner {
-            return sig
-        }
-    }
-    if depth < 8 && frontCheckIsInterface(env, owner) {
-        for ext in env.interfaceExtends {
-            if ext.owner == owner {
-                let sig = frontCheckMethodLookupAt(env, frontCheckTypeHead(frontCheckResolveAliasesDeep(env, ext.typeName)), name, depth + 1)
-                if sig.name != "" {
-                    return sig
-                }
-            }
-        }
-    }
-    FrontFnSig { name: "", receiverType: "", returnType: "Invalid", paramNames: [], paramTypes: [], generics: [], genericBounds: [] }
-}
-
-fn frontCheckBoundMethodLookup(env: FrontCheckEnv, owner: String, name: String) -> FrontFnSig {
-    for bound in env.genericBounds {
-        if bound.name == owner {
-            let iface = frontCheckTypeHead(frontCheckResolveAliasesDeep(env, bound.typeName))
-            let sig = frontCheckMethodLookup(env, iface, name)
-            if sig.name != "" {
-                return sig
-            }
-        }
-    }
-    FrontFnSig { name: "", receiverType: "", returnType: "Invalid", paramNames: [], paramTypes: [], generics: [], genericBounds: [] }
-}
-
-fn frontCheckFieldLookup(env: FrontCheckEnv, owner: String, name: String) -> FrontFieldSig {
-    for field in env.fields {
-        if field.owner == owner && field.name == name {
-            return field
-        }
-    }
-    FrontFieldSig { owner: "", name: "", typeName: "Invalid", hasDefault: false }
-}
-
-fn frontCheckVariantLookup(env: FrontCheckEnv, name: String) -> FrontVariantSig {
-    let mut found = FrontVariantSig { owner: "", name: "", fieldTypes: [], generics: [] }
-    for variant in env.variants {
-        if variant.name == name {
-            found = variant
-        }
-    }
-    found
-}
-
-fn frontCheckVariantLookupForOwner(env: FrontCheckEnv, name: String, owner: String) -> FrontVariantSig {
-    let mut found = FrontVariantSig { owner: "", name: "", fieldTypes: [], generics: [] }
-    for variant in env.variants {
-        if variant.name == name && variant.owner == owner {
-            found = variant
-        }
-    }
-    found
-}
-
-fn frontCheckTypeSigLookup(env: FrontCheckEnv, name: String) -> FrontTypeSig {
-    let mut found = FrontTypeSig { name: "", generics: [] }
-    for sig in env.types {
-        if sig.name == name {
-            found = sig
-        }
-    }
-    found
-}
-
-fn frontCheckIsInterface(env: FrontCheckEnv, name: String) -> Bool {
-    for iface in env.interfaces {
-        if iface == name {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckDeclaredTypeExists(env: FrontCheckEnv, name: String) -> Bool {
-    if frontCheckTypeSigLookup(env, name).name != "" {
-        return true
-    }
-    if frontCheckAliasLookup(env, name).name != "" {
-        return true
-    }
-    false
-}
-
-fn frontCheckAliasTarget(env: FrontCheckEnv, name: String) -> String {
-    for alias in env.aliases {
-        if alias.name == name && frontCheckStringCount(alias.generics) == 0 {
-            return alias.typeName
-        }
-    }
-    ""
-}
-
-fn frontCheckAliasLookup(env: FrontCheckEnv, name: String) -> FrontAliasSig {
-    for alias in env.aliases {
-        if alias.name == name {
-            return alias
-        }
-    }
-    FrontAliasSig { name: "", typeName: "", generics: [] }
-}
-
-fn frontCheckResolveAliasOnce(env: FrontCheckEnv, typeName: String) -> String {
-    let target = frontCheckAliasTarget(env, typeName)
-    if target != "" {
-        return target
-    }
-    let view = frontCheckParseType(typeName)
-    if view.kind == "named" && frontCheckStringCount(view.args) > 0 {
-        let alias = frontCheckAliasLookup(env, view.head)
-        if alias.name != "" && frontCheckStringCount(alias.generics) > 0 {
-            let mut substs: List<FrontTypeSubst> = []
-            let mut i = 0
-            for generic in alias.generics {
-                substs.push(FrontTypeSubst { name: generic, typeName: frontCheckStringAt(view.args, i) })
-                i = i + 1
-            }
-            return frontCheckSubstitute(alias.typeName, substs)
-        }
-    }
-    ""
-}
-
-fn frontCheckResolveAlias(env: FrontCheckEnv, typeName: String) -> String {
-    let mut current = typeName
-    let mut depth = 0
-    for depth < 8 {
-        let target = frontCheckResolveAliasOnce(env, current)
-        if target == "" {
-            return current
-        }
-        current = target
-        depth = depth + 1
-    }
-    current
-}
-
-fn frontCheckResolveAliasesDeep(env: FrontCheckEnv, typeName: String) -> String {
-    frontCheckResolveAliasesDeepAt(env, typeName, 0)
-}
-
-fn frontCheckResolveAliasesDeepAt(env: FrontCheckEnv, typeName: String, depth: Int) -> String {
-    if depth > 8 {
-        return typeName
-    }
-    let direct = frontCheckResolveAlias(env, typeName)
-    if direct != typeName {
-        return frontCheckResolveAliasesDeepAt(env, direct, depth + 1)
-    }
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        let mut elems: List<String> = []
-        for elem in view.args {
-            elems.push(frontCheckResolveAliasesDeepAt(env, elem, depth + 1))
-        }
-        return frontCheckTupleType(elems)
-    }
-    if view.kind == "fn" {
-        let mut params: List<String> = []
-        for param in view.params {
-            params.push(frontCheckResolveAliasesDeepAt(env, param, depth + 1))
-        }
-        return frontCheckFnType(params, frontCheckResolveAliasesDeepAt(env, view.ret, depth + 1))
-    }
-    if view.kind == "named" && frontCheckStringCount(view.args) > 0 {
-        let mut args: List<String> = []
-        for arg in view.args {
-            args.push(frontCheckResolveAliasesDeepAt(env, arg, depth + 1))
-        }
-        return frontCheckNamedType(view.head, args)
-    }
-    typeName
-}
-
-fn frontCheckTypeName(file: AstFile, idx: Int) -> String {
-    if idx < 0 {
-        return "()"
-    }
-    let node = astArenaNodeAt(file.arena, idx)
-    if node.kind != AstNType {
-        return "Invalid"
-    }
-    if node.text == "optional" {
-        return frontCheckOneArgType("Option", frontCheckTypeName(file, node.left))
-    }
-    if node.text == "fn" {
-        let mut params: List<String> = []
-        for paramIdx in node.children {
-            params.push(frontCheckTypeName(file, paramIdx))
-        }
-        return frontCheckFnType(params, frontCheckTypeName(file, node.right))
-    }
-    if node.text == "tuple" {
-        let mut elems: List<String> = []
-        for elemIdx in node.children {
-            elems.push(frontCheckTypeName(file, elemIdx))
-        }
-        if frontCheckStringCount(elems) == 0 {
-            return "()"
-        }
-        return "({frontCheckJoinTypes(elems)})"
-    }
-    if frontCheckIntCount(node.children) > 0 {
-        let mut args: List<String> = []
-        for argIdx in node.children {
-            args.push(frontCheckTypeName(file, argIdx))
-        }
-        return "{node.text}<{frontCheckJoinTypes(args)}>"
-    }
-    if node.text == "Unit" {
-        return "()"
-    }
-    if node.text == "error" {
-        return "Invalid"
-    }
-    node.text
-}
-
-fn frontCheckFnType(params: List<String>, ret: String) -> String {
-    "fn({frontCheckJoinTypes(params)}) -> {ret}"
-}
-
-fn frontCheckJoinTypes(xs: List<String>) -> String {
-    strings.join(xs, ", ")
-}
-
-fn frontCheckOneArgType(head: String, arg: String) -> String {
-    "{head}<{arg}>"
-}
-
-fn frontCheckTwoArgType(head: String, left: String, right: String) -> String {
-    "{head}<{left}, {right}>"
-}
-
-fn frontCheckStringCount(xs: List<String>) -> Int {
-    let mut count = 0
-    for x in xs {
+pub fn frontCheckResultInstantiationCount(result: FrontCheckResult) -> Int {
+    let mut n = 0
+    for x in result.instantiations {
         let _ = x
-        count = count + 1
+        n = n + 1
     }
-    count
-}
-
-fn frontCheckIntCount(xs: List<Int>) -> Int {
-    let mut count = 0
-    for x in xs {
-        let _ = x
-        count = count + 1
-    }
-    count
-}
-
-fn frontCheckStringAt(xs: List<String>, idx: Int) -> String {
-    let mut i = 0
-    for x in xs {
-        if i == idx {
-            return x
-        }
-        i = i + 1
-    }
-    "Invalid"
-}
-
-fn frontCheckStringDrop(xs: List<String>, start: Int) -> List<String> {
-    let mut out: List<String> = []
-    let mut i = 0
-    for x in xs {
-        if i >= start {
-            out.push(x)
-        }
-        i = i + 1
-    }
-    out
-}
-
-fn frontCheckIntAt(xs: List<Int>, idx: Int) -> Int {
-    let mut i = 0
-    for x in xs {
-        if i == idx {
-            return x
-        }
-        i = i + 1
-    }
-    -1
-}
-
-fn frontCheckLastPathSegment(path: String) -> String {
-    let parts = strings.split(path, ".")
-    let mut last = path
-    for part in parts {
-        last = part
-    }
-    last
-}
-
-fn frontCheckTypeHead(typeName: String) -> String {
-    frontCheckParseType(typeName).head
-}
-
-fn frontCheckParseType(typeName: String) -> FrontTypeView {
-    let text = strings.trimSpace(typeName)
-    if text == "" {
-        return FrontTypeView { kind: "invalid", head: "Invalid", args: [], params: [], ret: "" }
-    }
-    if strings.hasPrefix(text, "(") && strings.hasSuffix(text, ")") {
-        let inner = strings.trimSuffix(strings.trimPrefix(text, "("), ")")
-        let mut elems: List<String> = []
-        if strings.trimSpace(inner) != "" {
-            elems = frontCheckSplitTopLevel(inner)
-        }
-        return FrontTypeView { kind: "tuple", head: "Tuple", args: elems, params: [], ret: "" }
-    }
-    if strings.hasPrefix(text, "fn(") {
-        let paramsText = frontCheckFnParamsTextRaw(text)
-        let mut params: List<String> = []
-        if strings.trimSpace(paramsText) != "" {
-            params = frontCheckSplitTopLevel(paramsText)
-        }
-        let ret = frontCheckFnReturnRaw(text)
-        return FrontTypeView { kind: "fn", head: "fn", args: [], params, ret }
-    }
-    let head = frontCheckRawTypeHead(text)
-    let argsText = frontCheckGenericArgsTextRaw(text, head)
-    let mut args: List<String> = []
-    if strings.trimSpace(argsText) != "" {
-        args = frontCheckSplitTopLevel(argsText)
-    }
-    FrontTypeView { kind: "named", head, args, params: [], ret: "" }
-}
-
-fn frontCheckRawTypeHead(typeName: String) -> String {
-    let mut head = ""
-    for unit in strings.split(typeName, "") {
-        if unit == "<" {
-            return head
-        }
-        head = "{head}{unit}"
-    }
-    head
-}
-
-fn frontCheckGenericArgsText(typeName: String) -> String {
-    frontCheckJoinTypes(frontCheckGenericArgs(typeName))
-}
-
-fn frontCheckGenericArgsTextRaw(typeName: String, head: String) -> String {
-    if !(strings.hasPrefix(typeName, "{head}<")) || !(strings.hasSuffix(typeName, ">")) {
-        return ""
-    }
-    strings.trimSuffix(strings.trimPrefix(typeName, "{head}<"), ">")
-}
-
-fn frontCheckGenericArgs(typeName: String) -> List<String> {
-    frontCheckParseType(typeName).args
-}
-
-fn frontCheckNamedType(head: String, args: List<String>) -> String {
-    if frontCheckStringCount(args) == 0 {
-        return head
-    }
-    "{head}<{frontCheckJoinTypes(args)}>"
-}
-
-fn frontCheckTupleType(elems: List<String>) -> String {
-    if frontCheckStringCount(elems) == 0 {
-        return "()"
-    }
-    "({frontCheckJoinTypes(elems)})"
-}
-
-fn frontCheckSplitTopLevel(text: String) -> List<String> {
-    let mut out: List<String> = []
-    let mut cur = ""
-    let mut angle = 0
-    let mut paren = 0
-    for unit in strings.split(text, "") {
-        if unit == "<" {
-            angle = angle + 1
-            cur = "{cur}{unit}"
-        } else if unit == ">" {
-            angle = angle - 1
-            cur = "{cur}{unit}"
-        } else if unit == "(" {
-            paren = paren + 1
-            cur = "{cur}{unit}"
-        } else if unit == ")" {
-            paren = paren - 1
-            cur = "{cur}{unit}"
-        } else if unit == "," && angle == 0 && paren == 0 {
-            out.push(strings.trimSpace(cur))
-            cur = ""
-        } else {
-            cur = "{cur}{unit}"
-        }
-    }
-    if strings.trimSpace(cur) != "" {
-        out.push(strings.trimSpace(cur))
-    }
-    out
-}
-
-fn frontCheckGenericArgAt(typeName: String, idx: Int) -> String {
-    frontCheckStringAt(frontCheckGenericArgs(typeName), idx)
-}
-
-fn frontCheckIsInvalid(typeName: String) -> Bool {
-    typeName == "Invalid"
-}
-
-fn frontCheckIsNever(typeName: String) -> Bool {
-    typeName == "Never"
-}
-
-fn frontCheckIsNumeric(typeName: String) -> Bool {
-    typeName == "Int" || typeName == "Float" || typeName == "UntypedInt" || typeName == "UntypedFloat" || typeName == "Byte" || typeName == "Char"
-}
-
-fn frontCheckIsInteger(typeName: String) -> Bool {
-    typeName == "Int" || typeName == "UntypedInt" || typeName == "Byte" || typeName == "Char"
-}
-
-fn frontCheckIsOrdered(typeName: String) -> Bool {
-    frontCheckIsNumeric(typeName) || typeName == "String" || typeName == "Bool"
-}
-
-fn frontCheckIsAssignable(env: FrontCheckEnv, dstRaw: String, srcRaw: String) -> Bool {
-    let dst = frontCheckResolveAliasesDeep(env, dstRaw)
-    let src = frontCheckResolveAliasesDeep(env, srcRaw)
-    if dst == "Any" || src == "Any" || frontCheckIsInvalid(dst) || frontCheckIsInvalid(src) {
-        return true
-    }
-    if src == "Never" || dst == src {
-        return true
-    }
-    if frontCheckSamePathTailType(dst, src) {
-        return true
-    }
-    if src == "UntypedInt" {
-        return dst == "Int" || dst == "Float" || dst == "Byte" || dst == "Char"
-    }
-    if src == "UntypedFloat" {
-        return dst == "Float"
-    }
-    if dst == "UntypedInt" {
-        return src == "Int" || src == "Byte" || src == "Char"
-    }
-    if dst == "UntypedFloat" {
-        return src == "Float"
-    }
-    let dstHead = frontCheckTypeHead(dst)
-    let srcHead = frontCheckTypeHead(src)
-    if frontCheckIsInterface(env, dstHead) {
-        return frontCheckSatisfiesInterface(env, src, dst)
-    }
-    if dstHead == "Tuple" && srcHead == "Tuple" {
-        let dstElems = frontCheckTupleElems(dst)
-        let srcElems = frontCheckTupleElems(src)
-        if frontCheckStringCount(dstElems) != frontCheckStringCount(srcElems) {
-            return false
-        }
-        let mut i = 0
-        for dstElem in dstElems {
-            if !(frontCheckIsAssignable(env, dstElem, frontCheckStringAt(srcElems, i))) {
-                return false
-            }
-            i = i + 1
-        }
-        return true
-    }
-    if dstHead == "fn" && srcHead == "fn" {
-        let dstParams = frontCheckFnParams(dst)
-        let srcParams = frontCheckFnParams(src)
-        if frontCheckStringCount(dstParams) != frontCheckStringCount(srcParams) {
-            return false
-        }
-        let mut i = 0
-        for dstParam in dstParams {
-            if !(frontCheckIsAssignable(env, dstParam, frontCheckStringAt(srcParams, i))) ||
-                    !(frontCheckIsAssignable(env, frontCheckStringAt(srcParams, i), dstParam)) {
-                return false
-            }
-            i = i + 1
-        }
-        return frontCheckIsAssignable(env, frontCheckFnReturn(dst), frontCheckFnReturn(src))
-    }
-    if dstHead == srcHead && strings.hasSuffix(dst, ">") && strings.hasSuffix(src, ">") {
-        let dstArgs = frontCheckSplitTopLevel(frontCheckGenericArgsText(dst))
-        let srcArgs = frontCheckSplitTopLevel(frontCheckGenericArgsText(src))
-        if frontCheckStringCount(dstArgs) != frontCheckStringCount(srcArgs) {
-            return false
-        }
-        let mut i = 0
-        for dstArg in dstArgs {
-            if !(frontCheckIsAssignable(env, dstArg, frontCheckStringAt(srcArgs, i))) {
-                return false
-            }
-            i = i + 1
-        }
-        return true
-    }
-    false
-}
-
-fn frontCheckSamePathTailType(left: String, right: String) -> Bool {
-    let leftView = frontCheckParseType(left)
-    let rightView = frontCheckParseType(right)
-    if leftView.kind != "named" || rightView.kind != "named" {
-        return false
-    }
-    if frontCheckStringCount(leftView.args) > 0 || frontCheckStringCount(rightView.args) > 0 {
-        return false
-    }
-    frontCheckLastPathSegment(leftView.head) == frontCheckLastPathSegment(rightView.head)
-}
-
-fn frontCheckExpectAssignable(env: FrontCheckEnv, dst: String, src: String) {
-    env.assignments = env.assignments + 1
-    if frontCheckIsAssignable(env, dst, src) {
-        env.accepted = env.accepted + 1
-    } else {
-        env.errors = env.errors + 1
-    }
-}
-
-fn frontCheckSatisfiesInterface(env: FrontCheckEnv, concreteRaw: String, ifaceRaw: String) -> Bool {
-    frontCheckSatisfiesInterfaceAt(env, concreteRaw, ifaceRaw, 0)
-}
-
-fn frontCheckSatisfiesInterfaceAt(env: FrontCheckEnv, concreteRaw: String, ifaceRaw: String, depth: Int) -> Bool {
-    if depth > 8 {
-        return true
-    }
-    let concrete = frontCheckResolveAliasesDeep(env, concreteRaw)
-    let iface = frontCheckResolveAliasesDeep(env, ifaceRaw)
-    let concreteHead = frontCheckTypeHead(concrete)
-    let ifaceHead = frontCheckTypeHead(iface)
-    if !(frontCheckIsInterface(env, ifaceHead)) {
-        return false
-    }
-    if concreteHead == ifaceHead {
-        return true
-    }
-    if frontCheckGenericBoundSatisfies(env, concreteHead, iface, depth + 1) {
-        return true
-    }
-    if frontCheckIsInterface(env, concreteHead) {
-        for ext in env.interfaceExtends {
-            if ext.owner == concreteHead && frontCheckSatisfiesInterfaceAt(env, ext.typeName, iface, depth + 1) {
-                return true
-            }
-        }
-    }
-    for ext in env.interfaceExtends {
-        if ext.owner == ifaceHead && !(frontCheckSatisfiesInterfaceAt(env, concrete, ext.typeName, depth + 1)) {
-            return false
-        }
-    }
-    for want in env.fns {
-        if want.receiverType == ifaceHead {
-            let got = frontCheckMethodLookup(env, concreteHead, want.name)
-            if got.name == "" {
-                return false
-            }
-            if !(frontCheckInterfaceMethodMatches(env, concrete, iface, got, want)) {
-                return false
-            }
-        }
-    }
-    true
-}
-
-fn frontCheckGenericBoundSatisfies(env: FrontCheckEnv, genericName: String, iface: String, depth: Int) -> Bool {
-    for bound in env.genericBounds {
-        if bound.name == genericName && frontCheckSatisfiesInterfaceAt(env, bound.typeName, iface, depth + 1) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckInterfaceMethodMatches(env: FrontCheckEnv, concrete: String, iface: String, got: FrontFnSig, want: FrontFnSig) -> Bool {
-    if frontCheckStringCount(got.paramTypes) != frontCheckStringCount(want.paramTypes) {
-        return false
-    }
-    let concreteHead = frontCheckTypeHead(concrete)
-    let ifaceHead = frontCheckTypeHead(iface)
-    let concreteSubsts = frontCheckReceiverSubsts(env, concreteHead, concrete)
-    let mut i = 0
-    for wantParamRaw in want.paramTypes {
-        let gotParamRaw = frontCheckStringAt(got.paramTypes, i)
-        if i > 0 {
-            let wantParam = frontCheckInterfaceSelfType(wantParamRaw, ifaceHead, concrete)
-            let gotParam = frontCheckSubstitute(gotParamRaw, concreteSubsts)
-            if !(frontCheckSameInterfaceSlot(env, wantParam, gotParam, ifaceHead, concrete)) &&
-                    (!(frontCheckIsAssignable(env, wantParam, gotParam)) || !(frontCheckIsAssignable(env, gotParam, wantParam))) {
-                return false
-            }
-        }
-        i = i + 1
-    }
-    let wantReturn = frontCheckInterfaceSelfType(want.returnType, ifaceHead, concrete)
-    let gotReturn = frontCheckSubstitute(got.returnType, concreteSubsts)
-    frontCheckSameInterfaceSlot(env, wantReturn, gotReturn, ifaceHead, concrete) || frontCheckIsAssignable(env, wantReturn, gotReturn)
-}
-
-fn frontCheckInterfaceSelfType(typeName: String, ifaceHead: String, concreteType: String) -> String {
-    let _ = ifaceHead
-    if typeName == "Self" {
-        return concreteType
-    }
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        let mut elems: List<String> = []
-        for elem in view.args {
-            elems.push(frontCheckInterfaceSelfType(elem, ifaceHead, concreteType))
-        }
-        return frontCheckTupleType(elems)
-    }
-    if view.kind == "fn" {
-        let mut params: List<String> = []
-        for param in view.params {
-            params.push(frontCheckInterfaceSelfType(param, ifaceHead, concreteType))
-        }
-        return frontCheckFnType(params, frontCheckInterfaceSelfType(view.ret, ifaceHead, concreteType))
-    }
-    if view.kind == "named" && frontCheckStringCount(view.args) > 0 {
-        let mut args: List<String> = []
-        for arg in view.args {
-            args.push(frontCheckInterfaceSelfType(arg, ifaceHead, concreteType))
-        }
-        return frontCheckNamedType(view.head, args)
-    }
-    typeName
-}
-
-fn frontCheckSameInterfaceSlot(env: FrontCheckEnv, want: String, got: String, ifaceHead: String, concreteHead: String) -> Bool {
-    let _ = env
-    want == got || (want == concreteHead && got == concreteHead) || (want == ifaceHead && got == concreteHead)
-}
-
-fn frontCheckUnify(env: FrontCheckEnv, left: String, right: String) -> String {
-    if frontCheckIsInvalid(left) {
-        return right
-    }
-    if frontCheckIsInvalid(right) {
-        return left
-    }
-    if left == right {
-        return left
-    }
-    if left == "Never" {
-        return right
-    }
-    if right == "Never" {
-        return left
-    }
-    if frontCheckIsAssignable(env, left, right) {
-        return left
-    }
-    if frontCheckIsAssignable(env, right, left) {
-        return right
-    }
-    env.errors = env.errors + 1
-    "Invalid"
-}
-
-fn frontCheckBlock(file: AstFile, env: FrontCheckEnv, blockIdx: Int, asExpr: Bool) -> String {
-    frontCheckBlockHint(file, env, blockIdx, asExpr, "")
-}
-
-fn frontCheckBlockHint(file: AstFile, env: FrontCheckEnv, blockIdx: Int, asExpr: Bool, hint: String) -> String {
-    if blockIdx < 0 {
-        return "()"
-    }
-    let block = astArenaNodeAt(file.arena, blockIdx)
-    if block.kind != AstNBlock {
-        return frontCheckExprHint(file, env, blockIdx, hint)
-    }
-    let mark = frontCheckBindingCount(env.bindings)
-    let mut result = "()"
-    let mut seen = 0
-    let mut total = 0
-    for stmt in block.children {
-        let _ = stmt
-        total = total + 1
-    }
-    for stmtIdx in block.children {
-        seen = seen + 1
-        if asExpr && seen == total {
-            result = frontCheckStmtAsExprHint(file, env, stmtIdx, hint)
-        } else {
-            let _ = frontCheckStmt(file, env, stmtIdx)
-        }
-    }
-    frontCheckPopBindings(env, mark)
-    result
-}
-
-fn frontCheckStmtAsExpr(file: AstFile, env: FrontCheckEnv, idx: Int) -> String {
-    frontCheckStmtAsExprHint(file, env, idx, "")
-}
-
-fn frontCheckStmtAsExprHint(file: AstFile, env: FrontCheckEnv, idx: Int, hint: String) -> String {
-    if idx < 0 {
-        return "()"
-    }
-    let node = astArenaNodeAt(file.arena, idx)
-    if node.kind == AstNExprStmt {
-        return frontCheckExprHint(file, env, node.left, hint)
-    }
-    frontCheckStmt(file, env, idx)
-}
-
-fn frontCheckStmt(file: AstFile, env: FrontCheckEnv, idx: Int) -> String {
-    if idx < 0 {
-        return "()"
-    }
-    let node = astArenaNodeAt(file.arena, idx)
-    if node.kind == AstNLet {
-        let declared = frontCheckTypeName(file, frontCheckFirstChild(node))
-        let valueType = frontCheckExprHint(file, env, node.right, declared)
-        if !(frontCheckLetPatternIrrefutable(file, node.left)) {
-            env.errors = env.errors + 1
-        }
-        let mut finalType = valueType
-        if declared != "()" && declared != "Invalid" {
-            frontCheckExpectAssignable(env, declared, valueType)
-            finalType = declared
-        }
-        frontCheckBindLetPattern(file, env, node.left, finalType, node.flags == 1)
-        return "()"
-    }
-    if node.kind == AstNAssign {
-        let targetType = frontCheckExpr(file, env, node.left)
-        let valueType = frontCheckExprHint(file, env, node.right, targetType)
-        if frontCheckAssignTargetMutable(file, env, node.left) {
-            frontCheckExpectAssignable(env, targetType, valueType)
-        } else {
-            env.assignments = env.assignments + 1
-            env.errors = env.errors + 1
-        }
-        return "()"
-    }
-    if node.kind == AstNChanSend {
-        let chanType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-        let head = frontCheckTypeHead(chanType)
-        if head == "Chan" {
-            let elem = frontCheckGenericArgAt(chanType, 0)
-            frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, node.right, elem))
-        } else if !(frontCheckIsInvalid(chanType)) {
-            env.errors = env.errors + 1
-        }
-        return "()"
-    }
-    if node.kind == AstNReturn {
-        let valueType = frontCheckExprHint(file, env, node.left, env.returnType)
-        frontCheckExpectAssignable(env, env.returnType, valueType)
-        return "Never"
-    }
-    if node.kind == AstNExprStmt {
-        let _ = frontCheckExpr(file, env, node.left)
-        return "()"
-    }
-    if node.kind == AstNFor {
-        return frontCheckFor(file, env, node)
-    }
-    if node.kind == AstNDefer {
-        let _ = frontCheckExpr(file, env, node.left)
-        return "()"
-    }
-    if node.kind == AstNBreak || node.kind == AstNContinue {
-        return "Never"
-    }
-    frontCheckExpr(file, env, idx)
-}
-
-fn frontCheckFor(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let mark = frontCheckBindingCount(env.bindings)
-    if node.text == "cond" {
-        let condType = frontCheckExpr(file, env, node.left)
-        if condType != "Bool" && !(frontCheckIsInvalid(condType)) {
-            env.errors = env.errors + 1
-        }
-    } else if node.text == "forlet" {
-        let valueType = frontCheckExpr(file, env, node.left)
-        frontCheckBindPattern(file, env, frontCheckIntAt(node.children, 0), valueType, false)
-    } else if node.text == "forin" {
-        let iterType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, frontCheckIntAt(node.children, 1)))
-        let elemType = frontCheckIterableElement(iterType)
-        if elemType == "Invalid" {
-            env.errors = env.errors + 1
-        }
-        frontCheckBindPattern(file, env, frontCheckIntAt(node.children, 0), elemType, false)
-    }
-    let _ = frontCheckBlock(file, env, node.right, false)
-    frontCheckPopBindings(env, mark)
-    "()"
-}
-
-fn frontCheckIterableElement(typeName: String) -> String {
-    let head = frontCheckTypeHead(typeName)
-    if head == "List" || head == "Range" || head == "Option" {
-        return frontCheckGenericArgAt(typeName, 0)
-    }
-    if head == "Map" {
-        return "({frontCheckGenericArgAt(typeName, 0)}, {frontCheckGenericArgAt(typeName, 1)})"
-    }
-    if head == "Chan" {
-        return frontCheckGenericArgAt(typeName, 0)
-    }
-    "Invalid"
-}
-
-fn frontCheckFirstChild(node: AstNode) -> Int {
-    for child in node.children {
-        return child
-    }
-    -1
-}
-
-fn frontCheckSecondChild(node: AstNode) -> Int {
-    let mut i = 0
-    for child in node.children {
-        if i == 1 {
-            return child
-        }
-        i = i + 1
-    }
-    -1
-}
-
-fn frontCheckAssignTargetMutable(file: AstFile, env: FrontCheckEnv, idx: Int) -> Bool {
-    let node = astArenaNodeAt(file.arena, idx)
-    if node.kind == AstNIdent {
-        return frontCheckLookupMutable(env, node.text)
-    }
-    if node.kind == AstNField || node.kind == AstNIndex {
-        return true
-    }
-    true
-}
-
-fn frontCheckExpr(file: AstFile, env: FrontCheckEnv, idx: Int) -> String {
-    frontCheckExprHint(file, env, idx, "")
-}
-
-fn frontCheckExprHint(file: AstFile, env: FrontCheckEnv, idx: Int, hint: String) -> String {
-    if idx < 0 {
-        return "()"
-    }
-    let node = astArenaNodeAt(file.arena, idx)
-    if node.kind == AstNIntLit {
-        if hint == "Float" {
-            return frontCheckTypedExpr(file, env, idx, "Float")
-        }
-        return frontCheckTypedExpr(file, env, idx, "UntypedInt")
-    }
-    if node.kind == AstNFloatLit {
-        if hint == "Float" {
-            return frontCheckTypedExpr(file, env, idx, "Float")
-        }
-        return frontCheckTypedExpr(file, env, idx, "UntypedFloat")
-    }
-    if node.kind == AstNStringLit {
-        return frontCheckTypedExpr(file, env, idx, "String")
-    }
-    if node.kind == AstNBoolLit {
-        return frontCheckTypedExpr(file, env, idx, "Bool")
-    }
-    if node.kind == AstNCharLit {
-        return frontCheckTypedExpr(file, env, idx, "Char")
-    }
-    if node.kind == AstNByteLit {
-        return frontCheckTypedExpr(file, env, idx, "Byte")
-    }
-    if node.kind == AstNIdent {
-        return frontCheckTypedExpr(file, env, idx, frontCheckIdentHint(env, node.text, hint))
-    }
-    if node.kind == AstNParen {
-        return frontCheckTypedExpr(file, env, idx, frontCheckExprHint(file, env, node.left, hint))
-    }
-    if node.kind == AstNBlock {
-        return frontCheckTypedExpr(file, env, idx, frontCheckBlockHint(file, env, idx, true, hint))
-    }
-    if node.kind == AstNUnary {
-        return frontCheckTypedExpr(file, env, idx, frontCheckUnary(file, env, node))
-    }
-    if node.kind == AstNBinary {
-        return frontCheckTypedExpr(file, env, idx, frontCheckBinary(file, env, node))
-    }
-    if node.kind == AstNIf {
-        return frontCheckTypedExpr(file, env, idx, frontCheckIfHint(file, env, node, hint))
-    }
-    if node.kind == AstNCall {
-        return frontCheckTypedExpr(file, env, idx, frontCheckCallHint(file, env, idx, node, hint))
-    }
-    if node.kind == AstNList {
-        return frontCheckTypedExpr(file, env, idx, frontCheckList(file, env, node, hint))
-    }
-    if node.kind == AstNTuple {
-        return frontCheckTypedExpr(file, env, idx, frontCheckTuple(file, env, node, hint))
-    }
-    if node.kind == AstNMap {
-        return frontCheckTypedExpr(file, env, idx, frontCheckMap(file, env, node, hint))
-    }
-    if node.kind == AstNRange {
-        return frontCheckTypedExpr(file, env, idx, frontCheckRange(file, env, node))
-    }
-    if node.kind == AstNField {
-        return frontCheckTypedExpr(file, env, idx, frontCheckField(file, env, node))
-    }
-    if node.kind == AstNIndex {
-        return frontCheckTypedExpr(file, env, idx, frontCheckIndex(file, env, node))
-    }
-    if node.kind == AstNMatch {
-        return frontCheckTypedExpr(file, env, idx, frontCheckMatchHint(file, env, node, hint))
-    }
-    if node.kind == AstNStructLit {
-        return frontCheckTypedExpr(file, env, idx, frontCheckStructLitHint(file, env, node, hint))
-    }
-    if node.kind == AstNClosure {
-        return frontCheckTypedExpr(file, env, idx, frontCheckClosure(file, env, node, frontCheckFnParams(hint), frontCheckFnReturn(hint)))
-    }
-    if node.kind == AstNQuestion {
-        return frontCheckTypedExpr(file, env, idx, frontCheckQuestion(file, env, node))
-    }
-    if node.kind == AstNTurbofish {
-        return frontCheckTypedExpr(file, env, idx, frontCheckExpr(file, env, node.left))
-    }
-    frontCheckTypedExpr(file, env, idx, "Invalid")
-}
-
-fn frontCheckIdent(env: FrontCheckEnv, name: String) -> String {
-    frontCheckIdentHint(env, name, "")
-}
-
-fn frontCheckIdentHint(env: FrontCheckEnv, name: String, hint: String) -> String {
-    let found = frontCheckLookup(env, name)
-    if found != "Invalid" {
-        return found
-    }
-    let mut variant = frontCheckVariantLookup(env, name)
-    if hint != "" {
-        let hinted = frontCheckVariantLookupForOwner(env, name, frontCheckTypeHead(frontCheckResolveAliasesDeep(env, hint)))
-        if hinted.name != "" {
-            variant = hinted
-        }
-    }
-    if variant.name != "" && frontCheckStringCount(variant.fieldTypes) == 0 {
-        let resolvedHint = frontCheckResolveAliasesDeep(env, hint)
-        if resolvedHint != "" && frontCheckTypeHead(resolvedHint) == variant.owner {
-            return resolvedHint
-        }
-        return frontCheckGenericOwnerType(variant.owner, variant.generics, [])
-    }
-    if frontCheckSigLookup(env, name).name != "" {
-        if frontCheckTypeHead(hint) == "fn" {
-            return hint
-        }
-        return "fn"
-    }
-    if name != "_" {
-        env.errors = env.errors + 1
-    }
-    "Invalid"
-}
-
-fn frontCheckUnary(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let inner = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-    if node.op == FrontNot {
-        if inner != "Bool" && !(frontCheckIsInvalid(inner)) {
-            env.errors = env.errors + 1
-            return "Invalid"
-        }
-        return "Bool"
-    }
-    if node.op == FrontMinus {
-        if frontCheckIsNumeric(inner) {
-            return inner
-        }
-        if !(frontCheckIsInvalid(inner)) {
-            env.errors = env.errors + 1
-        }
-        return "Invalid"
-    }
-    if node.op == FrontBitNot {
-        if frontCheckIsInteger(inner) {
-            return inner
-        }
-        if !(frontCheckIsInvalid(inner)) {
-            env.errors = env.errors + 1
-        }
-    }
-    "Invalid"
-}
-
-fn frontCheckBinary(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let left = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-    let right = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.right))
-    if node.op == FrontEq || node.op == FrontNeq {
-        if frontCheckIsAssignable(env, left, right) || frontCheckIsAssignable(env, right, left) {
-            return "Bool"
-        }
-        env.errors = env.errors + 1
-        return "Invalid"
-    }
-    if node.op == FrontLt || node.op == FrontGt || node.op == FrontLeq || node.op == FrontGeq {
-        if frontCheckIsOrdered(left) && (frontCheckIsAssignable(env, left, right) || frontCheckIsAssignable(env, right, left)) {
-            return "Bool"
-        }
-        env.errors = env.errors + 1
-        return "Invalid"
-    }
-    if node.op == FrontAnd || node.op == FrontOr {
-        if left == "Bool" && right == "Bool" {
-            return "Bool"
-        }
-        env.errors = env.errors + 1
-        return "Invalid"
-    }
-    if node.op == FrontQQ {
-        if frontCheckTypeHead(left) != "Option" {
-            env.errors = env.errors + 1
-            return "Invalid"
-        }
-        let inner = frontCheckGenericArgAt(left, 0)
-        frontCheckExpectAssignable(env, inner, right)
-        return inner
-    }
-    if node.op == FrontBitAnd || node.op == FrontBitOr || node.op == FrontBitXor || node.op == FrontShl || node.op == FrontShr {
-        if frontCheckIsInteger(left) && frontCheckIsInteger(right) {
-            if left == "UntypedInt" {
-                return right
-            }
-            return left
-        }
-        env.errors = env.errors + 1
-        return "Invalid"
-    }
-    if node.op == FrontPlus || node.op == FrontMinus || node.op == FrontStar || node.op == FrontSlash || node.op == FrontPercent {
-        if !(frontCheckIsNumeric(left)) || !(frontCheckIsNumeric(right)) {
-            env.errors = env.errors + 1
-            return "Invalid"
-        }
-        if left == "Float" || right == "Float" || left == "UntypedFloat" || right == "UntypedFloat" {
-            if left == "UntypedFloat" && right == "UntypedFloat" {
-                return "UntypedFloat"
-            }
-            return "Float"
-        }
-        if left == "Int" || right == "Int" {
-            return "Int"
-        }
-        return "UntypedInt"
-    }
-    "Invalid"
-}
-
-fn frontCheckList(file: AstFile, env: FrontCheckEnv, node: AstNode, hint: String) -> String {
-    let mut elem = "Invalid"
-    if frontCheckTypeHead(hint) == "List" {
-        elem = frontCheckGenericArgAt(hint, 0)
-    }
-    let mut seen = 0
-    for child in node.children {
-        let got = frontCheckExprHint(file, env, child, elem)
-        if seen == 0 && elem == "Invalid" {
-            elem = got
-        } else {
-            elem = frontCheckUnify(env, elem, got)
-        }
-        seen = seen + 1
-    }
-    frontCheckOneArgType("List", elem)
-}
-
-fn frontCheckMap(file: AstFile, env: FrontCheckEnv, node: AstNode, hint: String) -> String {
-    let mut keyType = "Invalid"
-    let mut valType = "Invalid"
-    if frontCheckTypeHead(hint) == "Map" {
-        keyType = frontCheckGenericArgAt(hint, 0)
-        valType = frontCheckGenericArgAt(hint, 1)
-    }
-    let mut i = 0
-    for keyIdx in node.children {
-        let valIdx = frontCheckIntAt(node.children2, i)
-        let gotKey = frontCheckExprHint(file, env, keyIdx, keyType)
-        let gotVal = frontCheckExprHint(file, env, valIdx, valType)
-        if i == 0 && keyType == "Invalid" && valType == "Invalid" {
-            keyType = gotKey
-            valType = gotVal
-        } else {
-            keyType = frontCheckUnify(env, keyType, gotKey)
-            valType = frontCheckUnify(env, valType, gotVal)
-        }
-        i = i + 1
-    }
-    frontCheckTwoArgType("Map", keyType, valType)
-}
-
-fn frontCheckTuple(file: AstFile, env: FrontCheckEnv, node: AstNode, hint: String) -> String {
-    let hints = frontCheckTupleElems(hint)
-    let mut elems: List<String> = []
-    let mut i = 0
-    for child in node.children {
-        elems.push(frontCheckExprHint(file, env, child, frontCheckStringAt(hints, i)))
-        i = i + 1
-    }
-    if frontCheckStringCount(elems) == 0 {
-        return "()"
-    }
-    "({frontCheckJoinTypes(elems)})"
-}
-
-fn frontCheckRange(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let mut elem = "Int"
-    if node.left >= 0 {
-        let left = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-        if !(frontCheckIsInteger(left)) {
-            env.errors = env.errors + 1
-        }
-        elem = left
-    }
-    if node.right >= 0 {
-        let right = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.right))
-        if !(frontCheckIsInteger(right)) {
-            env.errors = env.errors + 1
-        }
-        elem = frontCheckUnify(env, elem, right)
-    }
-    frontCheckOneArgType("Range", elem)
-}
-
-fn frontCheckIf(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    frontCheckIfHint(file, env, node, "")
-}
-
-fn frontCheckIfHint(file: AstFile, env: FrontCheckEnv, node: AstNode, hint: String) -> String {
-    let mark = frontCheckBindingCount(env.bindings)
-    if node.flags == 1 {
-        let valueType = frontCheckExpr(file, env, node.left)
-        frontCheckBindPattern(file, env, frontCheckSecondChild(node), valueType, false)
-    } else {
-        let cond = frontCheckExpr(file, env, node.left)
-        if cond != "Bool" && !(frontCheckIsInvalid(cond)) {
-            env.errors = env.errors + 1
-        }
-    }
-    let thenType = frontCheckBlockHint(file, env, node.right, true, hint)
-    frontCheckPopBindings(env, mark)
-    let elseIdx = frontCheckFirstChild(node)
-    if elseIdx < 0 {
-        return "()"
-    }
-    let elseMark = frontCheckBindingCount(env.bindings)
-    let elseNode = astArenaNodeAt(file.arena, elseIdx)
-    let mut elseType = "()"
-    if elseNode.kind == AstNBlock {
-        elseType = frontCheckBlockHint(file, env, elseIdx, true, hint)
-    } else {
-        elseType = frontCheckExprHint(file, env, elseIdx, hint)
-    }
-    frontCheckPopBindings(env, elseMark)
-    frontCheckUnify(env, thenType, elseType)
-}
-
-fn frontCheckCall(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    frontCheckCallHint(file, env, -1, node, "")
-}
-
-fn frontCheckCallHint(file: AstFile, env: FrontCheckEnv, callIdx: Int, node: AstNode, hint: String) -> String {
-    let callee = astArenaNodeAt(file.arena, node.left)
-    if callee.kind == AstNTurbofish {
-        return frontCheckTurbofishCall(file, env, callIdx, callee, node.children)
-    }
-    if callee.kind == AstNIdent {
-        let bindingType = frontCheckResolveAliasesDeep(env, frontCheckLookup(env, callee.text))
-        if frontCheckTypeHead(bindingType) == "fn" {
-            return frontCheckCallFnType(file, env, bindingType, node.children)
-        }
-        let variant = frontCheckVariantLookup(env, callee.text)
-        if variant.name != "" {
-            return frontCheckVariantCallWithSubsts(file, env, variant, node.children, frontCheckVariantHintSubsts(env, variant, hint))
-        }
-        let sig = frontCheckSigLookup(env, callee.text)
-        if sig.name != "" {
-            return frontCheckCallSig(file, env, callIdx, sig, node.children, 0, [])
-        }
-        if frontCheckIsBuiltinCallName(callee.text) {
-            return frontCheckBuiltinCall(file, env, callee.text, node.children)
-        }
-        env.errors = env.errors + 1
-        return "Invalid"
-    }
-    if callee.kind == AstNField {
-        let packageName = frontCheckPackageFnNameEnv(file, env, callee)
-        if packageName != "" {
-            let sig = frontCheckSigLookup(env, packageName)
-            if sig.name != "" {
-                return frontCheckCallSig(file, env, callIdx, sig, node.children, 0, [])
-            }
-        }
-        let recvType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, callee.left))
-        let methodResult = frontCheckStdMethodCall(file, env, callee, recvType, node.children)
-        if methodResult != "Invalid" {
-            return methodResult
-        }
-        let owner = frontCheckTypeHead(recvType)
-        let sig = frontCheckMethodLookup(env, owner, callee.text)
-        if sig.name != "" {
-            let substs = frontCheckReceiverSubsts(env, owner, recvType)
-            return frontCheckCallSig(file, env, callIdx, sig, node.children, 1, substs)
-        }
-        let boundSig = frontCheckBoundMethodLookup(env, owner, callee.text)
-        if boundSig.name != "" {
-            return frontCheckCallSig(file, env, callIdx, boundSig, node.children, 1, [FrontTypeSubst { name: "Self", typeName: recvType }])
-        }
-        if !(frontCheckIsInvalid(recvType)) {
-            env.errors = env.errors + 1
-        }
-        return "Invalid"
-    }
-    let fnType = frontCheckExpr(file, env, node.left)
-    if frontCheckTypeHead(fnType) == "fn" {
-        return frontCheckCallFnType(file, env, fnType, node.children)
-    }
-    env.errors = env.errors + 1
-    "Invalid"
-}
-
-fn frontCheckPackageFnName(file: AstFile, field: AstNode) -> String {
-    let left = astArenaNodeAt(file.arena, field.left)
-    if left.kind == AstNIdent {
-        return "{left.text}.{field.text}"
-    }
-    ""
-}
-
-fn frontCheckPackageFnNameEnv(file: AstFile, env: FrontCheckEnv, field: AstNode) -> String {
-    let left = astArenaNodeAt(file.arena, field.left)
-    if left.kind == AstNIdent && frontCheckLookup(env, left.text) == "Invalid" {
-        return "{left.text}.{field.text}"
-    }
-    ""
-}
-
-fn frontCheckBuiltinCall(file: AstFile, env: FrontCheckEnv, name: String, args: List<Int>) -> String {
-    if name == "print" || name == "println" {
-        for argIdx in args {
-            let _ = frontCheckExpr(file, env, argIdx)
-        }
-        return "()"
-    }
-    if name == "panic" {
-        for argIdx in args {
-            let _ = frontCheckExpr(file, env, argIdx)
-        }
-        return "Never"
-    }
-    if name == "spawn" {
-        frontCheckExpectArgCount(env, args, 1)
-        let fnType = frontCheckExprHint(file, env, frontCheckIntAt(args, 0), "fn() -> ()")
-        if frontCheckTypeHead(fnType) != "fn" && !(frontCheckIsInvalid(fnType)) {
-            env.errors = env.errors + 1
-        }
-        return "ThreadHandle"
-    }
-    if name == "parallel" {
-        let mut elem = "Invalid"
-        for argIdx in args {
-            let fnType = frontCheckExpr(file, env, argIdx)
-            if frontCheckTypeHead(fnType) == "fn" {
-                let ret = frontCheckFnReturn(fnType)
-                if elem == "Invalid" {
-                    elem = ret
-                } else if !(frontCheckIsAssignable(env, elem, ret)) && !(frontCheckIsAssignable(env, ret, elem)) {
-                    env.errors = env.errors + 1
-                }
-            } else if !(frontCheckIsInvalid(fnType)) {
-                env.errors = env.errors + 1
-            }
-        }
-        if elem == "Invalid" {
-            elem = "()"
-        }
-        return "List<{elem}>"
-    }
-    if name == "len" {
-        frontCheckExpectArgCount(env, args, 1)
-        let valueType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, frontCheckIntAt(args, 0)))
-        let head = frontCheckTypeHead(valueType)
-        if head == "List" || head == "Map" || valueType == "String" || valueType == "Bytes" {
-            return "Int"
-        }
-        if !(frontCheckIsInvalid(valueType)) {
-            env.errors = env.errors + 1
-        }
-    }
-    "Invalid"
-}
-
-fn frontCheckIsBuiltinCallName(name: String) -> Bool {
-    name == "print" || name == "println" || name == "panic" || name == "len" || name == "spawn" || name == "parallel"
-}
-
-fn frontCheckTurbofishCall(file: AstFile, env: FrontCheckEnv, callIdx: Int, callee: AstNode, args: List<Int>) -> String {
-    let target = astArenaNodeAt(file.arena, callee.left)
-    let typeArgs = frontCheckTypeArgs(file, callee.children)
-    if target.kind == AstNIdent {
-        let variant = frontCheckVariantLookup(env, target.text)
-        if variant.name != "" {
-            let substs = frontCheckExplicitSubsts(env, variant.generics, typeArgs)
-            return frontCheckVariantCallWithSubsts(file, env, variant, args, substs)
-        }
-        let sig = frontCheckSigLookup(env, target.text)
-        if sig.name != "" {
-            let substs = frontCheckExplicitSubsts(env, sig.generics, typeArgs)
-            return frontCheckCallSig(file, env, callIdx, sig, args, 0, substs)
-        }
-    }
-    if target.kind == AstNField {
-        let packageName = frontCheckPackageFnNameEnv(file, env, target)
-        if packageName == "thread.chan" {
-            frontCheckExpectArgCount(env, args, 1)
-            if frontCheckStringCount(typeArgs) != 1 {
-                env.errors = env.errors + 1
-                return "Chan<Invalid>"
-            }
-            return "Chan<{frontCheckStringAt(typeArgs, 0)}>"
-        }
-        let recvType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, target.left))
-        let owner = frontCheckTypeHead(recvType)
-        let sig = frontCheckMethodLookup(env, owner, target.text)
-        if sig.name != "" {
-            let mut substs = frontCheckReceiverSubsts(env, owner, recvType)
-            let ownerGenericCount = frontCheckStringCount(frontCheckTypeSigLookup(env, owner).generics)
-            let methodGenerics = frontCheckStringDrop(sig.generics, ownerGenericCount)
-            let explicit = frontCheckExplicitSubsts(env, methodGenerics, typeArgs)
-            for item in explicit {
-                substs.push(item)
-            }
-            return frontCheckCallSig(file, env, callIdx, sig, args, 1, substs)
-        }
-    }
-    env.errors = env.errors + 1
-    "Invalid"
-}
-
-fn frontCheckTypeArgs(file: AstFile, idxs: List<Int>) -> List<String> {
-    let mut out: List<String> = []
-    for idx in idxs {
-        out.push(frontCheckTypeName(file, idx))
-    }
-    out
-}
-
-fn frontCheckExplicitSubsts(env: FrontCheckEnv, generics: List<String>, typeArgs: List<String>) -> List<FrontTypeSubst> {
-    let mut out: List<FrontTypeSubst> = []
-    if frontCheckStringCount(generics) != frontCheckStringCount(typeArgs) {
-        env.errors = env.errors + 1
-    }
-    let mut i = 0
-    for generic in generics {
-        let arg = frontCheckStringAt(typeArgs, i)
-        if arg != "Invalid" {
-            out.push(FrontTypeSubst { name: generic, typeName: arg })
-        }
-        i = i + 1
-    }
-    out
-}
-
-fn frontCheckVariantHintSubsts(env: FrontCheckEnv, variant: FrontVariantSig, hint: String) -> List<FrontTypeSubst> {
-    let mut out: List<FrontTypeSubst> = []
-    let resolved = frontCheckResolveAliasesDeep(env, hint)
-    if resolved == "" || frontCheckTypeHead(resolved) != variant.owner {
-        return out
-    }
-    let mut i = 0
-    for generic in variant.generics {
-        let arg = frontCheckGenericArgAt(resolved, i)
-        if arg != "Invalid" {
-            out.push(FrontTypeSubst { name: generic, typeName: arg })
-        }
-        i = i + 1
-    }
-    out
-}
-
-fn frontCheckVariantCall(file: AstFile, env: FrontCheckEnv, variant: FrontVariantSig, args: List<Int>) -> String {
-    frontCheckVariantCallWithSubsts(file, env, variant, args, [])
-}
-
-fn frontCheckVariantCallWithSubsts(file: AstFile, env: FrontCheckEnv, variant: FrontVariantSig, args: List<Int>, initialSubsts: List<FrontTypeSubst>) -> String {
-    let mut substs = initialSubsts
-    if frontCheckIntCount(args) != frontCheckStringCount(variant.fieldTypes) {
-        env.errors = env.errors + 1
-        return frontCheckGenericOwnerType(variant.owner, variant.generics, substs)
-    }
-    let mut i = 0
-    for argIdx in args {
-        let want = frontCheckStringAt(variant.fieldTypes, i)
-        let got = frontCheckExprHint(file, env, argIdx, frontCheckSubstitute(want, substs))
-        substs = frontCheckBindGenerics(env, want, got, variant.generics, substs)
-        frontCheckExpectAssignable(env, frontCheckSubstitute(want, substs), got)
-        i = i + 1
-    }
-    frontCheckGenericOwnerType(variant.owner, variant.generics, substs)
-}
-
-fn frontCheckGenericOwnerType(owner: String, generics: List<String>, substs: List<FrontTypeSubst>) -> String {
-    if frontCheckStringCount(generics) == 0 {
-        return owner
-    }
-    let mut args: List<String> = []
-    for generic in generics {
-        let value = frontCheckSubstLookup(substs, generic)
-        if value == "" {
-            args.push(generic)
-        } else {
-            args.push(value)
-        }
-    }
-    "{owner}<{frontCheckJoinTypes(args)}>"
-}
-
-fn frontCheckCallSig(file: AstFile, env: FrontCheckEnv, callIdx: Int, sig: FrontFnSig, args: List<Int>, skip: Int, initialSubsts: List<FrontTypeSubst>) -> String {
-    let mut substs = initialSubsts
-    let wantCount = frontCheckStringCount(sig.paramTypes) - skip
-    let gotCount = frontCheckIntCount(args)
-    if gotCount != wantCount {
-        env.errors = env.errors + 1
-    }
-    let mut i = 0
-    for argIdx in args {
-        let rawWant = frontCheckStringAt(sig.paramTypes, i + skip)
-        let want = frontCheckSubstitute(rawWant, substs)
-        let hint = frontCheckEraseGenericHints(want, sig.generics)
-        let got = frontCheckExprHint(file, env, argIdx, hint)
-        substs = frontCheckBindGenerics(env, rawWant, got, sig.generics, substs)
-        frontCheckExpectAssignable(env, frontCheckSubstitute(rawWant, substs), got)
-        i = i + 1
-    }
-    frontCheckCheckGenericBounds(env, sig.genericBounds, substs)
-    let resultType = frontCheckSubstitute(sig.returnType, substs)
-    frontCheckRecordInstantiation(file, env, callIdx, sig.name, sig.generics, substs, resultType)
-    resultType
-}
-
-fn frontCheckCheckGenericBounds(env: FrontCheckEnv, bounds: List<FrontTypeSubst>, substs: List<FrontTypeSubst>) {
-    for bound in bounds {
-        let actual = frontCheckSubstLookup(substs, bound.name)
-        if actual != "" {
-            frontCheckExpectAssignable(env, bound.typeName, actual)
-        }
-    }
-}
-
-fn frontCheckCallFnType(file: AstFile, env: FrontCheckEnv, fnType: String, args: List<Int>) -> String {
-    let params = frontCheckFnParams(fnType)
-    if frontCheckStringCount(params) != frontCheckIntCount(args) {
-        env.errors = env.errors + 1
-    }
-    let mut i = 0
-    for argIdx in args {
-        let want = frontCheckStringAt(params, i)
-        let got = frontCheckExprHint(file, env, argIdx, want)
-        frontCheckExpectAssignable(env, want, got)
-        i = i + 1
-    }
-    frontCheckFnReturn(fnType)
-}
-
-fn frontCheckReceiverSubsts(env: FrontCheckEnv, owner: String, recvType: String) -> List<FrontTypeSubst> {
-    let mut out: List<FrontTypeSubst> = [FrontTypeSubst { name: "Self", typeName: recvType }]
-    let sig = frontCheckTypeSigLookup(env, owner)
-    let mut i = 0
-    for generic in sig.generics {
-        out.push(FrontTypeSubst { name: generic, typeName: frontCheckGenericArgAt(recvType, i) })
-        i = i + 1
-    }
-    out
-}
-
-fn frontCheckBindGenerics(env: FrontCheckEnv, want: String, got: String, generics: List<String>, substs: List<FrontTypeSubst>) -> List<FrontTypeSubst> {
-    let mut out = substs
-    if frontCheckIsGenericName(want, generics) {
-        return frontCheckAddSubst(env, out, want, got)
-    }
-    let wantView = frontCheckParseType(want)
-    let gotView = frontCheckParseType(got)
-    if wantView.kind == "tuple" && gotView.kind == "tuple" && frontCheckStringCount(wantView.args) == frontCheckStringCount(gotView.args) {
-        let mut i = 0
-        for wantArg in wantView.args {
-            out = frontCheckBindGenerics(env, wantArg, frontCheckStringAt(gotView.args, i), generics, out)
-            i = i + 1
-        }
-        return out
-    }
-    if wantView.kind == "fn" && gotView.kind == "fn" && frontCheckStringCount(wantView.params) == frontCheckStringCount(gotView.params) {
-        let mut i = 0
-        for wantParam in wantView.params {
-            out = frontCheckBindGenerics(env, wantParam, frontCheckStringAt(gotView.params, i), generics, out)
-            i = i + 1
-        }
-        return frontCheckBindGenerics(env, wantView.ret, gotView.ret, generics, out)
-    }
-    if wantView.kind == "named" && gotView.kind == "named" && wantView.head == gotView.head &&
-            frontCheckStringCount(wantView.args) == frontCheckStringCount(gotView.args) && frontCheckStringCount(wantView.args) > 0 {
-        let mut i = 0
-        for wantArg in wantView.args {
-            out = frontCheckBindGenerics(env, wantArg, frontCheckStringAt(gotView.args, i), generics, out)
-            i = i + 1
-        }
-    }
-    out
-}
-
-fn frontCheckIsGenericName(name: String, generics: List<String>) -> Bool {
-    for generic in generics {
-        if generic == name {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckAddSubst(env: FrontCheckEnv, substs: List<FrontTypeSubst>, name: String, typeName: String) -> List<FrontTypeSubst> {
-    let mut out = substs
-    let existing = frontCheckSubstLookup(substs, name)
-    if existing == "" || existing == "Invalid" {
-        out.push(FrontTypeSubst { name, typeName })
-        return out
-    }
-    if !(frontCheckIsAssignable(env, existing, typeName)) && !(frontCheckIsAssignable(env, typeName, existing)) {
-        env.errors = env.errors + 1
-    }
-    out
-}
-
-fn frontCheckSubstLookup(substs: List<FrontTypeSubst>, name: String) -> String {
-    let mut found = ""
-    for subst in substs {
-        if subst.name == name {
-            found = subst.typeName
-        }
-    }
-    found
-}
-
-fn frontCheckSubstitute(typeName: String, substs: List<FrontTypeSubst>) -> String {
-    let direct = frontCheckSubstLookup(substs, typeName)
-    if direct != "" {
-        return direct
-    }
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        let mut elems: List<String> = []
-        for elem in view.args {
-            elems.push(frontCheckSubstitute(elem, substs))
-        }
-        return frontCheckTupleType(elems)
-    }
-    if view.kind == "fn" {
-        let mut params: List<String> = []
-        for param in view.params {
-            params.push(frontCheckSubstitute(param, substs))
-        }
-        return frontCheckFnType(params, frontCheckSubstitute(view.ret, substs))
-    }
-    if view.kind == "named" && frontCheckStringCount(view.args) > 0 {
-        let mut args: List<String> = []
-        for arg in view.args {
-            args.push(frontCheckSubstitute(arg, substs))
-        }
-        return frontCheckNamedType(view.head, args)
-    }
-    typeName
-}
-
-fn frontCheckEraseGenericHints(typeName: String, generics: List<String>) -> String {
-    if frontCheckIsGenericName(typeName, generics) {
-        return "Invalid"
-    }
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        let mut elems: List<String> = []
-        for elem in view.args {
-            elems.push(frontCheckEraseGenericHints(elem, generics))
-        }
-        return frontCheckTupleType(elems)
-    }
-    if view.kind == "fn" {
-        let mut params: List<String> = []
-        for param in view.params {
-            params.push(frontCheckEraseGenericHints(param, generics))
-        }
-        return frontCheckFnType(params, frontCheckEraseGenericHints(view.ret, generics))
-    }
-    if view.kind == "named" && frontCheckStringCount(view.args) > 0 {
-        let mut args: List<String> = []
-        for arg in view.args {
-            args.push(frontCheckEraseGenericHints(arg, generics))
-        }
-        return frontCheckNamedType(view.head, args)
-    }
-    typeName
-}
-
-fn frontCheckField(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let packageName = frontCheckPackageFnNameEnv(file, env, node)
-    if packageName != "" && frontCheckSigLookup(env, packageName).name != "" {
-        return "fn"
-    }
-    let recvType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-    let owner = frontCheckTypeHead(recvType)
-    let field = frontCheckFieldLookup(env, owner, node.text)
-    if field.name != "" {
-        let substs = frontCheckReceiverSubsts(env, owner, recvType)
-        let fieldType = frontCheckSubstitute(field.typeName, substs)
-        if node.flags == 1 {
-            return frontCheckOneArgType("Option", fieldType)
-        }
-        return fieldType
-    }
-    if frontCheckMethodLookup(env, owner, node.text).name != "" {
-        return "fn"
-    }
-    if frontCheckBoundMethodLookup(env, owner, node.text).name != "" {
-        return "fn"
-    }
-    if !(frontCheckIsInvalid(recvType)) {
-        env.errors = env.errors + 1
-    }
-    "Invalid"
-}
-
-fn frontCheckIndex(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let objectType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-    let indexType = frontCheckExpr(file, env, node.right)
-    let head = frontCheckTypeHead(objectType)
-    if head == "List" || head == "Range" {
-        frontCheckExpectAssignable(env, "Int", indexType)
-        return frontCheckGenericArgAt(objectType, 0)
-    }
-    if head == "Map" {
-        frontCheckExpectAssignable(env, frontCheckGenericArgAt(objectType, 0), indexType)
-        return frontCheckGenericArgAt(objectType, 1)
-    }
-    if objectType == "String" {
-        frontCheckExpectAssignable(env, "Int", indexType)
-        return "Char"
-    }
-    if objectType == "Bytes" {
-        frontCheckExpectAssignable(env, "Int", indexType)
-        return "Byte"
-    }
-    if !(frontCheckIsInvalid(objectType)) {
-        env.errors = env.errors + 1
-    }
-    "Invalid"
-}
-
-fn frontCheckStructLit(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    frontCheckStructLitHint(file, env, node, "")
-}
-
-fn frontCheckStructLitHint(file: AstFile, env: FrontCheckEnv, node: AstNode, hint: String) -> String {
-    let nameNode = astArenaNodeAt(file.arena, node.left)
-    let typeName = nameNode.text
-    let typeSig = frontCheckTypeSigLookup(env, typeName)
-    if typeSig.name == "" {
-        env.errors = env.errors + 1
-        return "Invalid"
-    }
-    let hintType = frontCheckResolveAliasesDeep(env, hint)
-    let mut substs: List<FrontTypeSubst> = []
-    if frontCheckTypeHead(hintType) == typeName {
-        substs = frontCheckReceiverSubsts(env, typeName, hintType)
-    }
-    if node.right >= 0 {
-        let spread = frontCheckResolveAliasesDeep(env, frontCheckExprHint(file, env, node.right, hintType))
-        if frontCheckTypeHead(spread) == typeName {
-            substs = frontCheckReceiverSubsts(env, typeName, spread)
-        }
-        frontCheckExpectAssignable(env, frontCheckGenericOwnerType(typeName, typeSig.generics, substs), spread)
-    }
-    for fieldIdx in node.children {
-        let fieldNode = astArenaNodeAt(file.arena, fieldIdx)
-        if frontCheckStructLitFieldCount(file, node, fieldNode.text) > 1 {
-            env.errors = env.errors + 1
-        }
-        let field = frontCheckFieldLookup(env, typeName, fieldNode.text)
-        if field.name == "" {
-            env.errors = env.errors + 1
-        } else {
-            let mut valueType = "Invalid"
-            let want = frontCheckSubstitute(field.typeName, substs)
-            if fieldNode.left >= 0 {
-                valueType = frontCheckExprHint(file, env, fieldNode.left, want)
-            } else {
-                valueType = frontCheckLookup(env, fieldNode.text)
-            }
-            substs = frontCheckBindGenerics(env, field.typeName, valueType, typeSig.generics, substs)
-            frontCheckExpectAssignable(env, frontCheckSubstitute(field.typeName, substs), valueType)
-        }
-    }
-    for field in env.fields {
-        if field.owner == typeName && !(field.hasDefault) && !(frontCheckStructLitHasField(file, node, field.name)) && node.right < 0 {
-            env.errors = env.errors + 1
-        }
-    }
-    frontCheckGenericOwnerType(typeName, typeSig.generics, substs)
-}
-
-fn frontCheckStructLitHasField(file: AstFile, node: AstNode, name: String) -> Bool {
-    for fieldIdx in node.children {
-        let field = astArenaNodeAt(file.arena, fieldIdx)
-        if field.text == name {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckStructLitFieldCount(file: AstFile, node: AstNode, name: String) -> Int {
-    let mut count = 0
-    for fieldIdx in node.children {
-        let field = astArenaNodeAt(file.arena, fieldIdx)
-        if field.text == name {
-            count = count + 1
-        }
-    }
-    count
-}
-
-fn frontCheckMatch(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    frontCheckMatchHint(file, env, node, "")
-}
-
-fn frontCheckMatchHint(file: AstFile, env: FrontCheckEnv, node: AstNode, hint: String) -> String {
-    let scrutinee = frontCheckExpr(file, env, node.left)
-    let mut result = "Invalid"
-    let mut seen = 0
-    for armIdx in node.children {
-        let mark = frontCheckBindingCount(env.bindings)
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        frontCheckPatternCompatible(file, env, arm.left, scrutinee)
-        let guardIdx = frontCheckFirstChild(arm)
-        if guardIdx >= 0 {
-            let guard = frontCheckExpr(file, env, guardIdx)
-            if guard != "Bool" && !(frontCheckIsInvalid(guard)) {
-                env.errors = env.errors + 1
-            }
-        }
-        let bodyType = frontCheckExprHint(file, env, arm.right, hint)
-        if seen == 0 {
-            result = bodyType
-        } else {
-            result = frontCheckUnify(env, result, bodyType)
-        }
-        frontCheckPopBindings(env, mark)
-        seen = seen + 1
-    }
-    frontCheckCheckMatchExhaustive(file, env, node, scrutinee, seen)
-    result
-}
-
-fn frontCheckCheckMatchExhaustive(file: AstFile, env: FrontCheckEnv, node: AstNode, scrutineeType: String, arms: Int) {
-    if arms == 0 {
-        env.errors = env.errors + 1
-        return
-    }
-    let scrutinee = frontCheckResolveAliasesDeep(env, scrutineeType)
-    frontCheckCheckMatchReachability(file, env, node, scrutinee)
-    if frontCheckIsInvalid(scrutinee) || frontCheckMatchHasCatchAll(file, node) {
-        return
-    }
-    let owner = frontCheckTypeHead(scrutinee)
-    if owner == "Bool" {
-        if !(frontCheckMatchCoversBool(file, node, true)) || !(frontCheckMatchCoversBool(file, node, false)) {
-            env.errors = env.errors + 1
-        }
-        return
-    }
-    if owner == "Tuple" && frontCheckTupleAllBool(scrutinee) {
-        if !(frontCheckMatchCoversBoolTuple(file, node, scrutinee)) {
-            env.errors = env.errors + 1
-        }
-        return
-    }
-    if frontCheckStructFieldCount(env, owner) > 0 {
-        if !(frontCheckMatchCoversStruct(file, env, node, owner)) {
-            env.errors = env.errors + 1
-        }
-        return
-    }
-    let mut variantCount = 0
-    let mut missing = false
-    for variant in env.variants {
-        if variant.owner == owner {
-            variantCount = variantCount + 1
-            if !(frontCheckMatchCoversVariantComplete(file, node, variant)) {
-                missing = true
-            }
-        }
-    }
-    if variantCount > 0 && missing {
-        env.errors = env.errors + 1
-    }
-}
-
-fn frontCheckCheckMatchReachability(file: AstFile, env: FrontCheckEnv, node: AstNode, scrutineeType: String) {
-    let mut current = 0
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        let mut prevIndex = 0
-        for prevArmIdx in node.children {
-            if prevIndex >= current {
-                break
-            }
-            let prevArm = astArenaNodeAt(file.arena, prevArmIdx)
-            if frontCheckFirstChild(prevArm) < 0 && frontCheckPatternCoversPattern(file, env, prevArm.left, arm.left, scrutineeType) {
-                env.errors = env.errors + 1
-                break
-            }
-            prevIndex = prevIndex + 1
-        }
-        current = current + 1
-    }
-}
-
-fn frontCheckPatternCoversPattern(file: AstFile, env: FrontCheckEnv, prevIdx: Int, curIdx: Int, scrutineeType: String) -> Bool {
-    if frontCheckPatternCoversAny(file, prevIdx) {
-        return true
-    }
-    let owner = frontCheckTypeHead(scrutineeType)
-    if owner == "Bool" {
-        let cur = astArenaNodeAt(file.arena, curIdx)
-        if cur.kind == AstNPattern && frontCheckPatternKind(cur) == "literal" {
-            let lit = frontCheckPatternPayload(cur)
-            if lit == "true" || lit == "false" || cur.flags == 1 || cur.flags == 2 {
-                return frontCheckPatternCoversBool(file, prevIdx, lit == "true" || cur.flags == 1)
-            }
-        }
-    }
-    let curPat = astArenaNodeAt(file.arena, curIdx)
-    if curPat.kind == AstNPattern && frontCheckPatternIsVariant(curPat) {
-        let variant = frontCheckVariantLookupForOwner(env, frontCheckPatternName(curPat), owner)
-        if variant.name != "" {
-            return frontCheckPatternCoversVariantCompleteSingle(file, prevIdx, variant)
-        }
-    }
-    false
-}
-
-fn frontCheckMatchHasCatchAll(file: AstFile, node: AstNode) -> Bool {
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversAny(file, arm.left) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckMatchCoversVariant(file: AstFile, node: AstNode, name: String) -> Bool {
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversVariant(file, arm.left, name) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckMatchCoversVariantComplete(file: AstFile, node: AstNode, variant: FrontVariantSig) -> Bool {
-    let fieldCases = frontCheckVariantFiniteFieldCases(file, variant)
-    if frontCheckStringCount(fieldCases) > 0 {
-        for fieldCase in fieldCases {
-            if !(frontCheckMatchCoversVariantCase(file, node, variant, fieldCase)) {
-                return false
-            }
-        }
-        return true
-    }
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversVariantCompleteSingle(file, arm.left, variant) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckMatchCoversVariantCase(file: AstFile, node: AstNode, variant: FrontVariantSig, fieldCase: String) -> Bool {
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversVariantCase(file, arm.left, variant, fieldCase) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckVariantFiniteFieldCases(file: AstFile, variant: FrontVariantSig) -> List<String> {
-    if frontCheckStringCount(variant.fieldTypes) == 0 {
-        return []
-    }
-    let mut out: List<String> = [""]
-    for fieldType in variant.fieldTypes {
-        let fieldCases = frontCheckFiniteCases(file, fieldType, 0)
-        if frontCheckStringCount(fieldCases) == 0 {
-            return []
-        }
-        out = frontCheckCombineCases(out, fieldCases)
-        if frontCheckStringCount(out) > 32 {
-            return []
-        }
-    }
-    out
-}
-
-fn frontCheckFiniteCases(file: AstFile, typeName: String, depth: Int) -> List<String> {
-    if depth > 4 {
-        return []
-    }
-    let head = frontCheckTypeHead(typeName)
-    if typeName == "Bool" {
-        return ["true", "false"]
-    }
-    if head == "Tuple" {
-        let mut out: List<String> = [""]
-        for elem in frontCheckTupleElems(typeName) {
-            let elemCases = frontCheckFiniteCases(file, elem, depth + 1)
-            if frontCheckStringCount(elemCases) == 0 {
-                return []
-            }
-            out = frontCheckCombineCases(out, elemCases)
-            if frontCheckStringCount(out) > 32 {
-                return []
-            }
-        }
-        let mut wrapped: List<String> = []
-        for value in out {
-            wrapped.push("({value})")
-        }
-        return wrapped
-    }
-    let mut out: List<String> = []
-    let mut variants = 0
-    for variant in fileCheckVariantsByOwner(file, head) {
-        variants = variants + 1
-        if frontCheckStringCount(variant.fieldTypes) == 0 {
-            out.push(variant.name)
-        } else {
-            let fieldCases = frontCheckVariantFiniteFieldCases(file, variant)
-            if frontCheckStringCount(fieldCases) == 0 {
-                return []
-            }
-            for fieldCase in fieldCases {
-                out.push("{variant.name}({fieldCase})")
-            }
-        }
-        if frontCheckStringCount(out) > 32 {
-            return []
-        }
-    }
-    if variants == 0 {
-        return []
-    }
-    out
-}
-
-fn fileCheckVariantsByOwner(file: AstFile, owner: String) -> List<FrontVariantSig> {
-    let mut out: List<FrontVariantSig> = []
-    for declIdx in file.arena.decls {
-        let decl = astArenaNodeAt(file.arena, declIdx)
-        if decl.kind == AstNEnumDecl && decl.text == owner {
-            let generics = frontCheckGenericNames(file, decl.children2)
-            for memberIdx in decl.children {
-                let member = astArenaNodeAt(file.arena, memberIdx)
-                if member.kind == AstNVariant {
-                    let mut fieldTypes: List<String> = []
-                    for fieldIdx in member.children {
-                        fieldTypes.push(frontCheckTypeName(file, fieldIdx))
-                    }
-                    out.push(FrontVariantSig { owner: decl.text, name: member.text, fieldTypes, generics })
-                }
-            }
-        }
-    }
-    out
-}
-
-fn frontCheckCombineCases(prefixes: List<String>, suffixes: List<String>) -> List<String> {
-    let mut out: List<String> = []
-    for prefix in prefixes {
-        for suffix in suffixes {
-            if prefix == "" {
-                out.push(suffix)
-            } else {
-                out.push("{prefix}|{suffix}")
-            }
-        }
-    }
-    out
-}
-
-fn frontCheckMatchCoversBool(file: AstFile, node: AstNode, value: Bool) -> Bool {
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversBool(file, arm.left, value) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckMatchCoversBoolTuple(file: AstFile, node: AstNode, tupleType: String) -> Bool {
-    let arity = frontCheckStringCount(frontCheckTupleElems(tupleType))
-    let limit = frontCheckPow2(arity)
-    let mut mask = 0
-    for mask < limit {
-        if !(frontCheckMatchCoversBoolTupleMask(file, node, arity, mask)) {
-            return false
-        }
-        mask = mask + 1
-    }
-    true
-}
-
-fn frontCheckMatchCoversBoolTupleMask(file: AstFile, node: AstNode, arity: Int, mask: Int) -> Bool {
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversBoolTupleMask(file, arm.left, arity, mask) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckMatchCoversStruct(file: AstFile, env: FrontCheckEnv, node: AstNode, owner: String) -> Bool {
-    for armIdx in node.children {
-        let arm = astArenaNodeAt(file.arena, armIdx)
-        if frontCheckFirstChild(arm) < 0 && frontCheckPatternCoversStruct(file, env, arm.left, owner) {
-            return true
-        }
-    }
-    false
-}
-
-fn frontCheckPow2(n: Int) -> Int {
-    let mut out = 1
-    let mut i = 0
-    for i < n {
-        out = out * 2
-        i = i + 1
-    }
-    out
-}
-
-fn frontCheckTupleAllBool(tupleType: String) -> Bool {
-    let elems = frontCheckTupleElems(tupleType)
-    let count = frontCheckStringCount(elems)
-    if count == 0 || count > 4 {
-        return false
-    }
-    for elem in elems {
-        if elem != "Bool" {
-            return false
-        }
-    }
-    true
-}
-
-fn frontCheckStructFieldCount(env: FrontCheckEnv, owner: String) -> Int {
-    let mut count = 0
-    for field in env.fields {
-        if field.owner == owner {
-            count = count + 1
-        }
-    }
-    count
-}
-
-fn frontCheckPatternKind(pat: AstNode) -> String {
-    if pat.extra == astPatternIdentKind() {
-        return "ident"
-    }
-    if pat.extra == astPatternVariantKind() {
-        return "variant"
-    }
-    if pat.extra == astPatternStructKind() {
-        return "struct"
-    }
-    if pat.extra == astPatternBindingKind() {
-        return "binding"
-    }
-    if pat.extra == astPatternLiteralKind() {
-        if pat.text == "-" && pat.left >= 0 {
-            return "negLiteral"
-        }
-        return "literal"
-    }
-    if pat.extra == astPatternWildcardKind() {
-        return "wildcard"
-    }
-    if pat.extra == astPatternTupleKind() {
-        return "tuple"
-    }
-    if pat.extra == astPatternRangeKind() {
-        return "range"
-    }
-    if pat.extra == astPatternOrKind() {
-        return "or"
-    }
-    if pat.extra == astPatternFieldKind() {
-        return "field"
-    }
-    if strings.hasPrefix(pat.text, "ident:") {
-        return "ident"
-    }
-    if strings.hasPrefix(pat.text, "variant:") {
-        return "variant"
-    }
-    if strings.hasPrefix(pat.text, "struct:") {
-        return "struct"
-    }
-    if strings.hasPrefix(pat.text, "binding:") {
-        return "binding"
-    }
-    if strings.hasPrefix(pat.text, "literal:") {
-        return "literal"
-    }
-    if pat.op == FrontAt {
-        return "binding"
-    }
-    if pat.op == FrontLBrace && astIsUpperName(pat.text) {
-        return "struct"
-    }
-    if pat.op == FrontIdent && astIsUpperName(pat.text) {
-        return "variant"
-    }
-    if pat.op == FrontIdent && pat.text != "" {
-        return "ident"
-    }
-    pat.text
-}
-
-fn frontCheckPatternPayload(pat: AstNode) -> String {
-    let kind = frontCheckPatternKind(pat)
-    if pat.extra > 0 && (kind == "ident" || kind == "variant" || kind == "struct" || kind == "binding" || kind == "literal" || kind == "field") {
-        return pat.text
-    }
-    if strings.hasPrefix(pat.text, "ident:") {
-        return strings.trimPrefix(pat.text, "ident:")
-    }
-    if strings.hasPrefix(pat.text, "variant:") {
-        return strings.trimPrefix(pat.text, "variant:")
-    }
-    if strings.hasPrefix(pat.text, "struct:") {
-        return strings.trimPrefix(pat.text, "struct:")
-    }
-    if strings.hasPrefix(pat.text, "binding:") {
-        return strings.trimPrefix(pat.text, "binding:")
-    }
-    if strings.hasPrefix(pat.text, "literal:") {
-        return strings.trimPrefix(pat.text, "literal:")
-    }
-    pat.text
-}
-
-fn frontCheckPatternName(pat: AstNode) -> String {
-    frontCheckLastPathSegment(frontCheckPatternPayload(pat))
-}
-
-fn frontCheckPatternIsBindingIdent(pat: AstNode) -> Bool {
-    let name = frontCheckPatternName(pat)
-    frontCheckPatternKind(pat) == "ident" && name != "" && !(astIsUpperName(name))
-}
-
-fn frontCheckPatternIsVariant(pat: AstNode) -> Bool {
-    let kind = frontCheckPatternKind(pat)
-    kind == "variant" || (kind == "ident" && astIsUpperName(frontCheckPatternName(pat)))
-}
-
-fn frontCheckPatternIsVariantNamed(pat: AstNode, name: String) -> Bool {
-    frontCheckPatternIsVariant(pat) && frontCheckPatternName(pat) == name
-}
-
-fn frontCheckPatternIsStructNamed(pat: AstNode, name: String) -> Bool {
-    frontCheckPatternKind(pat) == "struct" && frontCheckPatternName(pat) == name
-}
-
-fn frontCheckPatternIsBindingAt(pat: AstNode) -> Bool {
-    frontCheckPatternKind(pat) == "binding"
-}
-
-fn frontCheckPatternBoolValue(pat: AstNode, value: Bool) -> Bool {
-    let lit = frontCheckPatternPayload(pat)
-    if lit == "true" {
-        return value
-    }
-    if lit == "false" {
-        return !(value)
-    }
-    (value && pat.flags == 1) || (!(value) && pat.flags == 2)
-}
-
-fn frontCheckPatternCoversAny(file: AstFile, patIdx: Int) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternKind(pat) == "wildcard" {
-        return true
-    }
-    if frontCheckPatternIsBindingIdent(pat) {
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversAny(file, pat.left)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversAny(file, pat.left) || frontCheckPatternCoversAny(file, pat.right)
-    }
-    false
-}
-
-fn frontCheckPatternCoversStruct(file: AstFile, env: FrontCheckEnv, patIdx: Int, owner: String) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternIsStructNamed(pat, owner) {
-        for field in env.fields {
-            if field.owner == owner {
-                let fieldPatIdx = frontCheckStructPatternField(file, pat, field.name)
-                if fieldPatIdx < 0 {
-                    if !(pat.flags == 1) {
-                        return false
-                    }
-                } else if !(frontCheckPatternCoversAny(file, fieldPatIdx)) {
-                    return false
-                }
-            }
-        }
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversStruct(file, env, pat.left, owner)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversStruct(file, env, pat.left, owner) || frontCheckPatternCoversStruct(file, env, pat.right, owner)
-    }
-    false
-}
-
-fn frontCheckStructPatternField(file: AstFile, pat: AstNode, name: String) -> Int {
-    for fieldIdx in pat.children {
-        let fieldPat = astArenaNodeAt(file.arena, fieldIdx)
-        if fieldPat.text == name {
-            return fieldPat.left
-        }
-    }
-    -1
-}
-
-fn frontCheckPatternCoversBoolTupleMask(file: AstFile, patIdx: Int, arity: Int, mask: Int) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternKind(pat) == "tuple" {
-        if frontCheckIntCount(pat.children) != arity {
-            return false
-        }
-        let mut i = 0
-        for child in pat.children {
-            if !(frontCheckPatternCoversBool(file, child, frontCheckBoolMaskAt(mask, i))) {
-                return false
-            }
-            i = i + 1
-        }
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversBoolTupleMask(file, pat.left, arity, mask)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversBoolTupleMask(file, pat.left, arity, mask) || frontCheckPatternCoversBoolTupleMask(file, pat.right, arity, mask)
-    }
-    false
-}
-
-fn frontCheckBoolMaskAt(mask: Int, idx: Int) -> Bool {
-    let div = frontCheckPow2(idx)
-    ((mask / div) % 2) == 1
-}
-
-fn frontCheckPatternCoversBool(file: AstFile, patIdx: Int, value: Bool) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternKind(pat) == "literal" {
-        return frontCheckPatternBoolValue(pat, value)
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversBool(file, pat.left, value)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversBool(file, pat.left, value) || frontCheckPatternCoversBool(file, pat.right, value)
-    }
-    false
-}
-
-fn frontCheckPatternCoversVariant(file: AstFile, patIdx: Int, name: String) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternIsVariant(pat) {
-        return frontCheckPatternName(pat) == name
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversVariant(file, pat.left, name)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversVariant(file, pat.left, name) || frontCheckPatternCoversVariant(file, pat.right, name)
-    }
-    false
-}
-
-fn frontCheckPatternCoversVariantCase(file: AstFile, patIdx: Int, variant: FrontVariantSig, fieldCase: String) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternIsVariantNamed(pat, variant.name) {
-        let caseFields = frontCheckSplitCaseFields(fieldCase)
-        if frontCheckIntCount(pat.children) != frontCheckStringCount(caseFields) {
-            return false
-        }
-        let mut i = 0
-        for child in pat.children {
-            let fieldType = frontCheckStringAt(variant.fieldTypes, i)
-            let value = frontCheckStringAt(caseFields, i)
-            if !(frontCheckPatternCoversFiniteCase(file, child, fieldType, value)) {
-                return false
-            }
-            i = i + 1
-        }
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversVariantCase(file, pat.left, variant, fieldCase)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversVariantCase(file, pat.left, variant, fieldCase) || frontCheckPatternCoversVariantCase(file, pat.right, variant, fieldCase)
-    }
-    false
-}
-
-fn frontCheckPatternCoversFiniteCase(file: AstFile, patIdx: Int, typeName: String, value: String) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    let head = frontCheckTypeHead(typeName)
-    if typeName == "Bool" {
-        return frontCheckPatternCoversBool(file, patIdx, value == "true")
-    }
-    if head == "Tuple" {
-        if frontCheckPatternKind(pat) == "tuple" {
-            let elems = frontCheckTupleElems(typeName)
-            let mut tupleText = value
-            if strings.hasPrefix(tupleText, "(") && strings.hasSuffix(tupleText, ")") {
-                tupleText = strings.trimSuffix(strings.trimPrefix(tupleText, "("), ")")
-            }
-            let values = frontCheckSplitCaseFields(tupleText)
-            if frontCheckIntCount(pat.children) != frontCheckStringCount(values) || frontCheckStringCount(elems) != frontCheckStringCount(values) {
-                return false
-            }
-            let mut i = 0
-            for child in pat.children {
-                if !(frontCheckPatternCoversFiniteCase(file, child, frontCheckStringAt(elems, i), frontCheckStringAt(values, i))) {
-                    return false
-                }
-                i = i + 1
-            }
-            return true
-        }
-        if frontCheckPatternIsBindingAt(pat) {
-            return frontCheckPatternCoversFiniteCase(file, pat.left, typeName, value)
-        }
-        if frontCheckPatternKind(pat) == "or" {
-            return frontCheckPatternCoversFiniteCase(file, pat.left, typeName, value) || frontCheckPatternCoversFiniteCase(file, pat.right, typeName, value)
-        }
-        return false
-    }
-    let caseHead = frontCheckCaseHead(value)
-    let caseVariant = frontCheckVariantLookupInFile(file, head, caseHead)
-    if caseVariant.name != "" {
-        if frontCheckPatternIsVariantNamed(pat, caseVariant.name) {
-            let argsText = frontCheckCaseArgsText(value)
-            let caseArgs = frontCheckSplitCaseFields(argsText)
-            if frontCheckIntCount(pat.children) != frontCheckStringCount(caseArgs) || frontCheckStringCount(caseVariant.fieldTypes) != frontCheckStringCount(caseArgs) {
-                return false
-            }
-            let mut i = 0
-            for child in pat.children {
-                if !(frontCheckPatternCoversFiniteCase(file, child, frontCheckStringAt(caseVariant.fieldTypes, i), frontCheckStringAt(caseArgs, i))) {
-                    return false
-                }
-                i = i + 1
-            }
-            return true
-        }
-        if frontCheckPatternIsBindingAt(pat) {
-            return frontCheckPatternCoversFiniteCase(file, pat.left, typeName, value)
-        }
-        if frontCheckPatternKind(pat) == "or" {
-            return frontCheckPatternCoversFiniteCase(file, pat.left, typeName, value) || frontCheckPatternCoversFiniteCase(file, pat.right, typeName, value)
-        }
-    }
-    false
-}
-
-fn frontCheckVariantLookupInFile(file: AstFile, owner: String, name: String) -> FrontVariantSig {
-    for variant in fileCheckVariantsByOwner(file, owner) {
-        if variant.name == name {
-            return variant
-        }
-    }
-    FrontVariantSig { owner: "", name: "", fieldTypes: [], generics: [] }
-}
-
-fn frontCheckCaseHead(value: String) -> String {
-    let mut head = ""
-    for unit in strings.split(value, "") {
-        if unit == "(" {
-            return strings.trimSpace(head)
-        }
-        head = "{head}{unit}"
-    }
-    strings.trimSpace(head)
-}
-
-fn frontCheckCaseArgsText(value: String) -> String {
-    let mut out = ""
-    let mut found = false
-    let mut depth = 0
-    for unit in strings.split(value, "") {
-        if found {
-            if unit == "(" {
-                depth = depth + 1
-                out = "{out}{unit}"
-            } else if unit == ")" {
-                if depth == 0 {
-                    return out
-                }
-                depth = depth - 1
-                out = "{out}{unit}"
-            } else {
-                out = "{out}{unit}"
-            }
-        } else if unit == "(" {
-            found = true
-        }
-    }
-    ""
-}
-
-fn frontCheckSplitCaseFields(text: String) -> List<String> {
-    let mut out: List<String> = []
-    if strings.trimSpace(text) == "" {
-        return out
-    }
-    let mut cur = ""
-    let mut paren = 0
-    for unit in strings.split(text, "") {
-        if unit == "(" {
-            paren = paren + 1
-            cur = "{cur}{unit}"
-        } else if unit == ")" {
-            paren = paren - 1
-            cur = "{cur}{unit}"
-        } else if unit == "|" && paren == 0 {
-            out.push(strings.trimSpace(cur))
-            cur = ""
-        } else {
-            cur = "{cur}{unit}"
-        }
-    }
-    if strings.trimSpace(cur) != "" {
-        out.push(strings.trimSpace(cur))
-    }
-    out
-}
-
-fn frontCheckPatternCoversVariantCompleteSingle(file: AstFile, patIdx: Int, variant: FrontVariantSig) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternIsVariantNamed(pat, variant.name) {
-        if frontCheckIntCount(pat.children) != frontCheckStringCount(variant.fieldTypes) {
-            return false
-        }
-        for child in pat.children {
-            if !(frontCheckPatternCoversAny(file, child)) {
-                return false
-            }
-        }
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversVariantCompleteSingle(file, pat.left, variant)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversVariantCompleteSingle(file, pat.left, variant) || frontCheckPatternCoversVariantCompleteSingle(file, pat.right, variant)
-    }
-    false
-}
-
-fn frontCheckPatternCoversVariantBoolMask(file: AstFile, patIdx: Int, variant: FrontVariantSig, mask: Int) -> Bool {
-    if patIdx < 0 {
-        return false
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return false
-    }
-    if frontCheckPatternCoversAny(file, patIdx) {
-        return true
-    }
-    if frontCheckPatternIsVariantNamed(pat, variant.name) {
-        let arity = frontCheckStringCount(variant.fieldTypes)
-        if frontCheckIntCount(pat.children) != arity {
-            return false
-        }
-        let mut i = 0
-        for child in pat.children {
-            if !(frontCheckPatternCoversBool(file, child, frontCheckBoolMaskAt(mask, i))) {
-                return false
-            }
-            i = i + 1
-        }
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternCoversVariantBoolMask(file, pat.left, variant, mask)
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        return frontCheckPatternCoversVariantBoolMask(file, pat.left, variant, mask) || frontCheckPatternCoversVariantBoolMask(file, pat.right, variant, mask)
-    }
-    false
-}
-
-fn frontCheckPatternIrrefutable(file: AstFile, patIdx: Int) -> Bool {
-    if patIdx < 0 {
-        return true
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return true
-    }
-    if frontCheckPatternKind(pat) == "wildcard" {
-        return true
-    }
-    if frontCheckPatternIsBindingIdent(pat) {
-        return true
-    }
-    if frontCheckPatternKind(pat) == "tuple" {
-        for child in pat.children {
-            if !(frontCheckPatternIrrefutable(file, child)) {
-                return false
-            }
-        }
-        return true
-    }
-    if frontCheckPatternKind(pat) == "struct" {
-        for fieldIdx in pat.children {
-            let fieldPat = astArenaNodeAt(file.arena, fieldIdx)
-            if !(frontCheckPatternIrrefutable(file, fieldPat.left)) {
-                return false
-            }
-        }
-        return true
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        return frontCheckPatternIrrefutable(file, pat.left)
-    }
-    false
-}
-
-fn frontCheckLetPatternIrrefutable(file: AstFile, patIdx: Int) -> Bool {
-    if patIdx < 0 {
-        return true
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if frontCheckLetPatternIsSimpleIdent(pat) {
-        return true
-    }
-    frontCheckPatternIrrefutable(file, patIdx)
-}
-
-fn frontCheckLetPatternIsSimpleIdent(pat: AstNode) -> Bool {
-    if pat.kind == AstNIdent {
-        return true
-    }
-    pat.kind == AstNPattern && pat.op == FrontIdent && pat.text != ""
-}
-
-fn frontCheckBindLetPattern(file: AstFile, env: FrontCheckEnv, patIdx: Int, typeName: String, mutable: Bool) {
-    if patIdx < 0 {
-        return
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if frontCheckLetPatternIsSimpleIdent(pat) {
-        if frontCheckPatternName(pat) != "_" {
-            frontCheckBindNode(env, frontCheckPatternName(pat), typeName, mutable, patIdx, pat.start, pat.end)
-        }
-        return
-    }
-    frontCheckBindPattern(file, env, patIdx, typeName, mutable)
-}
-
-fn frontCheckBindPattern(file: AstFile, env: FrontCheckEnv, patIdx: Int, typeName: String, mutable: Bool) {
-    if patIdx < 0 {
-        return
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind == AstNIdent {
-        if pat.text != "_" && !(astIsUpperName(pat.text)) {
-            frontCheckBindNode(env, pat.text, typeName, mutable, patIdx, pat.start, pat.end)
-        }
-        return
-    }
-    if pat.kind != AstNPattern {
-        return
-    }
-    if frontCheckPatternIsBindingIdent(pat) {
-        frontCheckBindNode(env, frontCheckPatternName(pat), typeName, mutable, patIdx, pat.start, pat.end)
-        return
-    }
-    if frontCheckPatternKind(pat) == "tuple" {
-        let elems = frontCheckTupleElems(typeName)
-        let mut i = 0
-        for child in pat.children {
-            frontCheckBindPattern(file, env, child, frontCheckStringAt(elems, i), mutable)
-            i = i + 1
-        }
-        return
-    }
-    if frontCheckPatternIsVariant(pat) {
-        let variant = frontCheckVariantLookup(env, frontCheckPatternName(pat))
-        let mut i = 0
-        for child in pat.children {
-            frontCheckBindPattern(file, env, child, frontCheckStringAt(variant.fieldTypes, i), mutable)
-            i = i + 1
-        }
-        return
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        frontCheckBind(env, frontCheckPatternName(pat), typeName, mutable)
-        frontCheckBindPattern(file, env, pat.left, typeName, mutable)
-    }
-}
-
-fn frontCheckPatternCompatible(file: AstFile, env: FrontCheckEnv, patIdx: Int, scrutineeType: String) {
-    if patIdx < 0 {
-        return
-    }
-    let pat = astArenaNodeAt(file.arena, patIdx)
-    if pat.kind != AstNPattern {
-        return
-    }
-    let scrutineeResolved = frontCheckResolveAliasesDeep(env, scrutineeType)
-    if frontCheckPatternKind(pat) == "wildcard" {
-        return
-    }
-    if frontCheckPatternIsBindingIdent(pat) {
-        frontCheckBind(env, frontCheckPatternName(pat), scrutineeResolved, false)
-        return
-    }
-    if frontCheckPatternKind(pat) == "literal" {
-        let litType = frontCheckPatternLiteralType(pat)
-        if !(frontCheckIsAssignable(env, scrutineeResolved, litType)) && !(frontCheckIsAssignable(env, litType, scrutineeResolved)) {
-            env.errors = env.errors + 1
-        }
-        return
-    }
-    if frontCheckPatternKind(pat) == "negLiteral" {
-        let inner = astArenaNodeAt(file.arena, pat.left)
-        let litType = frontCheckPatternLiteralType(inner)
-        if !(frontCheckIsNumeric(litType)) {
-            env.errors = env.errors + 1
-            return
-        }
-        if !(frontCheckIsAssignable(env, scrutineeResolved, litType)) && !(frontCheckIsAssignable(env, litType, scrutineeResolved)) {
-            env.errors = env.errors + 1
-        }
-        return
-    }
-    if frontCheckPatternKind(pat) == "range" {
-        if !(frontCheckIsOrdered(scrutineeResolved)) {
-            env.errors = env.errors + 1
-            return
-        }
-        frontCheckPatternCompatible(file, env, pat.left, scrutineeResolved)
-        if pat.right >= 0 {
-            frontCheckPatternCompatible(file, env, pat.right, scrutineeResolved)
-        }
-        return
-    }
-    if frontCheckPatternKind(pat) == "tuple" {
-        let elems = frontCheckTupleElems(scrutineeResolved)
-        if frontCheckStringCount(elems) != frontCheckIntCount(pat.children) {
-            env.errors = env.errors + 1
-        }
-        let mut i = 0
-        for child in pat.children {
-            frontCheckPatternCompatible(file, env, child, frontCheckStringAt(elems, i))
-            i = i + 1
-        }
-        return
-    }
-    if frontCheckPatternIsVariant(pat) {
-        let variant = frontCheckVariantLookupForOwner(env, frontCheckPatternName(pat), frontCheckTypeHead(scrutineeResolved))
-        if variant.name == "" || frontCheckTypeHead(scrutineeResolved) != variant.owner {
-            env.errors = env.errors + 1
-            return
-        }
-        let substs = frontCheckVariantPatternSubsts(scrutineeResolved, variant)
-        let mut i = 0
-        for child in pat.children {
-            frontCheckPatternCompatible(file, env, child, frontCheckSubstitute(frontCheckStringAt(variant.fieldTypes, i), substs))
-            i = i + 1
-        }
-        return
-    }
-    if frontCheckPatternKind(pat) == "struct" {
-        let structName = frontCheckPatternName(pat)
-        if frontCheckTypeHead(scrutineeResolved) != structName {
-            env.errors = env.errors + 1
-            return
-        }
-        let substs = frontCheckReceiverSubsts(env, structName, scrutineeResolved)
-        for fieldIdx in pat.children {
-            let fieldPat = astArenaNodeAt(file.arena, fieldIdx)
-            let field = frontCheckFieldLookup(env, structName, fieldPat.text)
-            if field.name == "" {
-                env.errors = env.errors + 1
-            } else {
-                frontCheckPatternCompatible(file, env, fieldPat.left, frontCheckSubstitute(field.typeName, substs))
-            }
-        }
-        return
-    }
-    if frontCheckPatternIsBindingAt(pat) {
-        frontCheckBind(env, frontCheckPatternName(pat), scrutineeResolved, false)
-        frontCheckPatternCompatible(file, env, pat.left, scrutineeResolved)
-        return
-    }
-    if frontCheckPatternKind(pat) == "or" {
-        let mark = frontCheckBindingCount(env.bindings)
-        frontCheckPatternCompatible(file, env, pat.left, scrutineeResolved)
-        let leftBindings = frontCheckBindingsFrom(env, mark)
-        frontCheckPopBindings(env, mark)
-        frontCheckPatternCompatible(file, env, pat.right, scrutineeResolved)
-        let rightBindings = frontCheckBindingsFrom(env, mark)
-        frontCheckPopBindings(env, mark)
-        if !(frontCheckBindingsAgree(env, leftBindings, rightBindings)) {
-            env.errors = env.errors + 1
-            return
-        }
-        for binding in leftBindings {
-            frontCheckBind(env, binding.name, binding.typeName, binding.mutable)
-        }
-        return
-    }
-}
-
-fn frontCheckVariantPatternSubsts(scrutineeType: String, variant: FrontVariantSig) -> List<FrontTypeSubst> {
-    let mut substs: List<FrontTypeSubst> = []
-    if frontCheckTypeHead(scrutineeType) != variant.owner {
-        return substs
-    }
-    let mut i = 0
-    for generic in variant.generics {
-        substs.push(FrontTypeSubst { name: generic, typeName: frontCheckGenericArgAt(scrutineeType, i) })
-        i = i + 1
-    }
-    substs
-}
-
-fn frontCheckPatternLiteralType(pat: AstNode) -> String {
-    if pat.op == FrontInt {
-        return "UntypedInt"
-    }
-    if pat.op == FrontFloat {
-        return "UntypedFloat"
-    }
-    if pat.op == FrontString || pat.op == FrontRawString {
-        return "String"
-    }
-    if pat.op == FrontChar {
-        return "Char"
-    }
-    if pat.op == FrontByte {
-        return "Byte"
-    }
-    if frontCheckPatternKind(pat) == "literal" {
-        return "Bool"
-    }
-    "Invalid"
-}
-
-fn frontCheckTupleElems(typeName: String) -> List<String> {
-    let view = frontCheckParseType(typeName)
-    if view.kind == "tuple" {
-        return view.args
-    }
-    []
-}
-
-fn frontCheckClosure(file: AstFile, env: FrontCheckEnv, node: AstNode, paramHints: List<String>, retHint: String) -> String {
-    let mark = frontCheckBindingCount(env.bindings)
-    let mut params: List<String> = []
-    let mut i = 0
-    for paramIdx in node.children {
-        let param = astArenaNodeAt(file.arena, paramIdx)
-        let mut paramType = frontCheckTypeName(file, param.right)
-        if paramType == "()" || paramType == "Invalid" {
-            paramType = frontCheckStringAt(paramHints, i)
-        }
-        if param.left >= 0 {
-            if !(frontCheckPatternIrrefutable(file, param.left)) {
-                env.errors = env.errors + 1
-            }
-            frontCheckBindPattern(file, env, param.left, paramType, true)
-        } else {
-            frontCheckBind(env, param.text, paramType, true)
-        }
-        params.push(paramType)
-        i = i + 1
-    }
-    let bodyType = frontCheckExprHint(file, env, node.left, retHint)
-    let mut ret = bodyType
-    if node.right >= 0 {
-        ret = frontCheckTypeName(file, node.right)
-        frontCheckExpectAssignable(env, ret, bodyType)
-    } else if retHint != "" && retHint != "Invalid" {
-        frontCheckExpectAssignable(env, retHint, bodyType)
-        ret = retHint
-    }
-    frontCheckPopBindings(env, mark)
-    frontCheckFnType(params, ret)
-}
-
-fn frontCheckFnParams(typeName: String) -> List<String> {
-    let view = frontCheckParseType(typeName)
-    if view.kind == "fn" {
-        return view.params
-    }
-    []
-}
-
-fn frontCheckFnReturn(typeName: String) -> String {
-    let view = frontCheckParseType(typeName)
-    if view.kind == "fn" {
-        return view.ret
-    }
-    ""
-}
-
-fn frontCheckFnParamsText(typeName: String) -> String {
-    frontCheckFnParamsTextRaw(typeName)
-}
-
-fn frontCheckFnParamsTextRaw(typeName: String) -> String {
-    let mut params = ""
-    let mut depth = 0
-    let mut i = 0
-    for unit in strings.split(typeName, "") {
-        if i >= 3 {
-            if unit == "(" {
-                depth = depth + 1
-                params = "{params}{unit}"
-            } else if unit == ")" {
-                if depth == 0 {
-                    return params
-                }
-                depth = depth - 1
-                params = "{params}{unit}"
-            } else {
-                params = "{params}{unit}"
-            }
-        }
-        i = i + 1
-    }
-    params
-}
-
-fn frontCheckFnReturnText(typeName: String) -> String {
-    frontCheckFnReturnTextRaw(typeName)
-}
-
-fn frontCheckFnReturnRaw(typeName: String) -> String {
-    let ret = strings.trimSpace(strings.trimPrefix(strings.trimSpace(frontCheckFnReturnTextRaw(typeName)), "->"))
-    if ret == "" {
-        return "()"
-    }
-    ret
-}
-
-fn frontCheckFnReturnTextRaw(typeName: String) -> String {
-    let mut rest = ""
-    let mut depth = 0
-    let mut i = 0
-    let mut found = false
-    for unit in strings.split(typeName, "") {
-        if i >= 3 {
-            if found {
-                rest = "{rest}{unit}"
-            } else if unit == "(" {
-                depth = depth + 1
-            } else if unit == ")" {
-                if depth == 0 {
-                    found = true
-                } else {
-                    depth = depth - 1
-                }
-            }
-        }
-        i = i + 1
-    }
-    rest
-}
-
-fn frontCheckQuestion(file: AstFile, env: FrontCheckEnv, node: AstNode) -> String {
-    let inner = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, node.left))
-    let head = frontCheckTypeHead(inner)
-    let returnType = frontCheckResolveAliasesDeep(env, env.returnType)
-    let returnHead = frontCheckTypeHead(returnType)
-    if head == "Option" {
-        if returnHead != "Option" && !(frontCheckIsInvalid(env.returnType)) {
-            env.errors = env.errors + 1
-        }
-        return frontCheckGenericArgAt(inner, 0)
-    }
-    if head == "Result" {
-        if returnHead != "Result" && !(frontCheckIsInvalid(env.returnType)) {
-            env.errors = env.errors + 1
-        } else if returnHead == "Result" {
-            frontCheckExpectAssignable(env, frontCheckGenericArgAt(returnType, 1), frontCheckGenericArgAt(inner, 1))
-        }
-        return frontCheckGenericArgAt(inner, 0)
-    }
-    if !(frontCheckIsInvalid(inner)) {
-        env.errors = env.errors + 1
-    }
-    "Invalid"
-}
-
-fn frontCheckStdMethodCall(file: AstFile, env: FrontCheckEnv, callee: AstNode, recvType: String, args: List<Int>) -> String {
-    let receiver = frontCheckResolveAliasesDeep(env, recvType)
-    let head = frontCheckTypeHead(receiver)
-    let name = callee.text
-    if head == "List" {
-        return frontCheckListMethod(file, env, callee, receiver, args)
-    }
-    if head == "Map" {
-        return frontCheckMapMethod(file, env, receiver, name, args)
-    }
-    if head == "Option" {
-        return frontCheckOptionMethod(file, env, receiver, name, args)
-    }
-    if head == "Result" {
-        return frontCheckResultMethod(file, env, receiver, name, args)
-    }
-    if receiver == "String" {
-        return frontCheckStringMethod(file, env, name, args)
-    }
-    if receiver == "Bytes" {
-        return frontCheckBytesMethod(file, env, name, args)
-    }
-    if head == "Chan" {
-        if name == "close" {
-            frontCheckExpectArgCount(env, args, 0)
-            return "()"
-        }
-        return "Invalid"
-    }
-    if receiver == "ThreadHandle" && name == "join" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "()"
-    }
-    "Invalid"
-}
-
-fn frontCheckListMethod(file: AstFile, env: FrontCheckEnv, callee: AstNode, recvType: String, args: List<Int>) -> String {
-    let elem = frontCheckGenericArgAt(recvType, 0)
-    let name = callee.text
-    if name == "push" {
-        frontCheckRequireMutableReceiver(file, env, callee)
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
-        return "()"
-    }
-    if name == "pop" {
-        frontCheckRequireMutableReceiver(file, env, callee)
-        frontCheckExpectArgCount(env, args, 0)
-        return frontCheckOneArgType("Option", elem)
-    }
-    if name == "len" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Int"
-    }
-    if name == "isEmpty" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Bool"
-    }
-    if name == "contains" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
-        return "Bool"
-    }
-    if name == "map" {
-        frontCheckExpectArgCount(env, args, 1)
-        let fnType = frontCheckClosureArg(file, env, frontCheckIntAt(args, 0), [elem], "Invalid")
-        return frontCheckOneArgType("List", frontCheckFnReturn(fnType))
-    }
-    if name == "filter" {
-        frontCheckExpectArgCount(env, args, 1)
-        let _ = frontCheckClosureArg(file, env, frontCheckIntAt(args, 0), [elem], "Bool")
-        return recvType
-    }
-    if name == "fold" {
-        frontCheckExpectArgCount(env, args, 2)
-        let mut acc = frontCheckExpr(file, env, frontCheckIntAt(args, 0))
-        if acc == "UntypedInt" {
-            acc = "Int"
-        } else if acc == "UntypedFloat" {
-            acc = "Float"
-        }
-        let _ = frontCheckClosureArg(file, env, frontCheckIntAt(args, 1), [acc, elem], acc)
-        return acc
-    }
-    "Invalid"
-}
-
-fn frontCheckMapMethod(file: AstFile, env: FrontCheckEnv, recvType: String, name: String, args: List<Int>) -> String {
-    let key = frontCheckGenericArgAt(recvType, 0)
-    let val = frontCheckGenericArgAt(recvType, 1)
-    if name == "len" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Int"
-    }
-    if name == "isEmpty" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Bool"
-    }
-    if name == "containsKey" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, key, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), key))
-        return "Bool"
-    }
-    if name == "insert" {
-        frontCheckExpectArgCount(env, args, 2)
-        frontCheckExpectAssignable(env, key, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), key))
-        frontCheckExpectAssignable(env, val, frontCheckExprHint(file, env, frontCheckIntAt(args, 1), val))
-        return "()"
-    }
-    if name == "remove" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, key, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), key))
-        return frontCheckOneArgType("Option", val)
-    }
-    if name == "keys" {
-        frontCheckExpectArgCount(env, args, 0)
-        return frontCheckOneArgType("List", key)
-    }
-    if name == "values" {
-        frontCheckExpectArgCount(env, args, 0)
-        return frontCheckOneArgType("List", val)
-    }
-    "Invalid"
-}
-
-fn frontCheckOptionMethod(file: AstFile, env: FrontCheckEnv, recvType: String, name: String, args: List<Int>) -> String {
-    let elem = frontCheckGenericArgAt(recvType, 0)
-    if name == "unwrap" {
-        frontCheckExpectArgCount(env, args, 0)
-        return elem
-    }
-    if name == "isSome" || name == "isNone" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Bool"
-    }
-    if name == "unwrapOr" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), elem))
-        return elem
-    }
-    "Invalid"
-}
-
-fn frontCheckResultMethod(file: AstFile, env: FrontCheckEnv, recvType: String, name: String, args: List<Int>) -> String {
-    let ok = frontCheckGenericArgAt(recvType, 0)
-    let err = frontCheckGenericArgAt(recvType, 1)
-    if name == "unwrap" {
-        frontCheckExpectArgCount(env, args, 0)
-        return ok
-    }
-    if name == "unwrapErr" {
-        frontCheckExpectArgCount(env, args, 0)
-        return err
-    }
-    if name == "isOk" || name == "isErr" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Bool"
-    }
-    if name == "ok" {
-        frontCheckExpectArgCount(env, args, 0)
-        return frontCheckOneArgType("Option", ok)
-    }
-    if name == "err" {
-        frontCheckExpectArgCount(env, args, 0)
-        return frontCheckOneArgType("Option", err)
-    }
-    if name == "unwrapOr" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, ok, frontCheckExprHint(file, env, frontCheckIntAt(args, 0), ok))
-        return ok
-    }
-    "Invalid"
-}
-
-fn frontCheckStringMethod(file: AstFile, env: FrontCheckEnv, name: String, args: List<Int>) -> String {
-    if name == "len" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Int"
-    }
-    if name == "isEmpty" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Bool"
-    }
-    if name == "contains" || name == "startsWith" || name == "endsWith" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, "String", frontCheckExprHint(file, env, frontCheckIntAt(args, 0), "String"))
-        return "Bool"
-    }
-    if name == "split" {
-        frontCheckExpectArgCount(env, args, 1)
-        frontCheckExpectAssignable(env, "String", frontCheckExprHint(file, env, frontCheckIntAt(args, 0), "String"))
-        return frontCheckOneArgType("List", "String")
-    }
-    "Invalid"
-}
-
-fn frontCheckBytesMethod(file: AstFile, env: FrontCheckEnv, name: String, args: List<Int>) -> String {
-    if name == "len" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Int"
-    }
-    if name == "isEmpty" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "Bool"
-    }
-    if name == "toString" {
-        frontCheckExpectArgCount(env, args, 0)
-        return "String"
-    }
-    "Invalid"
-}
-
-fn frontCheckClosureArg(file: AstFile, env: FrontCheckEnv, idx: Int, params: List<String>, ret: String) -> String {
-    let node = astArenaNodeAt(file.arena, idx)
-    if node.kind == AstNClosure {
-        return frontCheckClosure(file, env, node, params, ret)
-    }
-    let want = frontCheckFnType(params, ret)
-    let got = frontCheckExprHint(file, env, idx, want)
-    frontCheckExpectAssignable(env, want, got)
-    got
-}
-
-fn frontCheckExpectArgCount(env: FrontCheckEnv, args: List<Int>, want: Int) {
-    if frontCheckIntCount(args) != want {
-        env.errors = env.errors + 1
-    }
-}
-
-fn frontCheckRequireMutableReceiver(file: AstFile, env: FrontCheckEnv, callee: AstNode) {
-    let left = astArenaNodeAt(file.arena, callee.left)
-    if left.kind == AstNIdent && !(frontCheckLookupMutable(env, left.text)) {
-        env.errors = env.errors + 1
-    }
+    n
 }

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -1,0 +1,376 @@
+// check_diag.osty — typed diagnostics for the bidirectional elaborator.
+//
+// Phase 2 of the migration. Replaces the counter-only error reporting
+// in the legacy `check.osty` (77 sites of `env.errors = env.errors + 1`)
+// with structured records carrying a stable Exxxx code, the offending
+// byte span, a human message, and optional notes.
+//
+// The code-namespace `E0700–E0799` is reserved for the front-end type
+// checker per `toolchain/diagnostic.osty:67` (FamilyTypeChecking). New
+// codes introduced here stay inside that band.
+//
+// Host-side registration (`internal/diag/codes.go`) is deferred until
+// the Go-side JSON bridge (`cmd/osty-native-checker`) gets its
+// `diagnostics` payload. Until then, `CheckDiagnostic.code` is a plain
+// `String` that round-trips through the bridge as-is.
+
+use std.strings as strings
+
+/// CheckDiagnostic is the structured record every check-time error or
+/// warning becomes. `start` and `end` are byte offsets into the parsed
+/// source, matching the existing convention used by `FrontCheckedNode`
+/// (`toolchain/check.osty:62-68`) — no separate line/column work is
+/// required on the host side.
+pub struct CheckDiagnostic {
+    pub code: String,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    pub start: Int,
+    pub end: Int,
+    pub notes: List<String>,
+}
+
+// ---------------------------------------------------------------------
+// Reserved type-checking codes. Keeping them as `pub fn` constants
+// (rather than a dedicated enum) so call sites read as
+// `diagMismatch(...)` rather than threading a code enum everywhere.
+// ---------------------------------------------------------------------
+
+pub fn checkCodeTypeMismatch() -> String { "E0701" }
+pub fn checkCodeArgCount() -> String { "E0702" }
+pub fn checkCodeOperandType() -> String { "E0703" }
+pub fn checkCodeUnknownField() -> String { "E0704" }
+pub fn checkCodeMissingField() -> String { "E0705" }
+pub fn checkCodeNonExhaustiveMatch() -> String { "E0706" }
+pub fn checkCodeUnreachablePattern() -> String { "E0707" }
+pub fn checkCodeInvalidAssignTarget() -> String { "E0708" }
+pub fn checkCodeImmutableAssign() -> String { "E0709" }
+pub fn checkCodeUnknownName() -> String { "E0710" }
+pub fn checkCodeUnknownMethod() -> String { "E0711" }
+pub fn checkCodeUnknownVariant() -> String { "E0712" }
+pub fn checkCodeDuplicateField() -> String { "E0713" }
+pub fn checkCodeDuplicateMethod() -> String { "E0714" }
+pub fn checkCodeNotCallable() -> String { "E0715" }
+pub fn checkCodeCannotInferTyParam() -> String { "E0720" }
+pub fn checkCodeGenericBoundViolation() -> String { "E0721" }
+pub fn checkCodeInterfaceNotSatisfied() -> String { "E0722" }
+pub fn checkCodeQuestionNotOptional() -> String { "E0730" }
+pub fn checkCodeReturnMismatch() -> String { "E0731" }
+pub fn checkCodeClosureAnnotationRequired() -> String { "E0741" }
+pub fn checkCodePatternShapeMismatch() -> String { "E0742" }
+pub fn checkCodeNonEscapingEscape() -> String { "E0743" }
+
+// ---------------------------------------------------------------------
+// Low-level builder. Higher-level constructors below wrap this so call
+// sites stay readable.
+// ---------------------------------------------------------------------
+
+pub fn checkDiag(
+    code: String,
+    message: String,
+    start: Int,
+    end: Int,
+) -> CheckDiagnostic {
+    CheckDiagnostic {
+        code,
+        severity: diagnosticSeverity(code),
+        message,
+        start,
+        end,
+        notes: [],
+    }
+}
+
+/// checkDiagWithNotes attaches optional notes to a freshly built
+/// diagnostic. Notes are rendered underneath the primary span by the
+/// host-side renderer, mirroring the `internal/diag` surface.
+pub fn checkDiagWithNotes(
+    code: String,
+    message: String,
+    start: Int,
+    end: Int,
+    notes: List<String>,
+) -> CheckDiagnostic {
+    CheckDiagnostic {
+        code,
+        severity: diagnosticSeverity(code),
+        message,
+        start,
+        end,
+        notes,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Domain-specific constructors. Each one fills in the stable message
+// template; the elaborator passes the `start`/`end` span of the node
+// the error is anchored to and, for type errors, the already-stringified
+// types (via `tyToString`) so the diagnostic stays stable across
+// arena-internal index churn.
+// ---------------------------------------------------------------------
+
+/// diagMismatch reports a type-assignment failure. `expected` and `got`
+/// are the rendered forms from `tyToString` — the elaborator pretty-
+/// prints once and hands them here.
+pub fn diagMismatch(expected: String, got: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeTypeMismatch(),
+        "type mismatch: expected `{expected}`, found `{got}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagReturnMismatch(expected: String, got: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeReturnMismatch(),
+        "return type mismatch: expected `{expected}`, found `{got}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagArgCount(fnName: String, want: Int, got: Int, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if fnName == "" {
+        "this call takes {want} argument(s) but {got} were supplied"
+    } else {
+        "`{fnName}` takes {want} argument(s) but {got} were supplied"
+    }
+    checkDiag(checkCodeArgCount(), msg, start, end)
+}
+
+pub fn diagOperandType(op: String, ty: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeOperandType(),
+        "operator `{op}` cannot be applied to `{ty}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagUnknownName(name: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeUnknownName(),
+        "cannot find `{name}` in this scope",
+        start,
+        end,
+    )
+}
+
+pub fn diagUnknownField(owner: String, name: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeUnknownField(),
+        "no field `{name}` on type `{owner}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagUnknownMethod(owner: String, name: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeUnknownMethod(),
+        "no method `{name}` on type `{owner}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagUnknownVariant(enumName: String, variantName: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if enumName == "" {
+        "unknown variant `{variantName}`"
+    } else {
+        "enum `{enumName}` has no variant `{variantName}`"
+    }
+    checkDiag(checkCodeUnknownVariant(), msg, start, end)
+}
+
+pub fn diagMissingField(owner: String, fieldName: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeMissingField(),
+        "missing field `{fieldName}` in initializer for `{owner}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagDuplicateField(owner: String, fieldName: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeDuplicateField(),
+        "duplicate field `{fieldName}` in initializer for `{owner}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagDuplicateMethod(owner: String, name: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeDuplicateMethod(),
+        "duplicate method `{name}` on `{owner}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagNonExhaustiveMatch(witness: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if witness == "" {
+        "match is not exhaustive"
+    } else {
+        "match is not exhaustive: missing `{witness}`"
+    }
+    checkDiag(checkCodeNonExhaustiveMatch(), msg, start, end)
+}
+
+pub fn diagUnreachablePattern(start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeUnreachablePattern(),
+        "unreachable pattern: earlier arm already covers this case",
+        start,
+        end,
+    )
+}
+
+pub fn diagInvalidAssignTarget(start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeInvalidAssignTarget(),
+        "expression is not an assignable place",
+        start,
+        end,
+    )
+}
+
+pub fn diagImmutableAssign(name: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if name == "" {
+        "cannot assign through an immutable binding"
+    } else {
+        "cannot assign to `{name}`: binding is not `mut`"
+    }
+    checkDiag(checkCodeImmutableAssign(), msg, start, end)
+}
+
+pub fn diagNotCallable(ty: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeNotCallable(),
+        "value of type `{ty}` is not callable",
+        start,
+        end,
+    )
+}
+
+pub fn diagCannotInferTyParam(name: String, fnName: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if fnName == "" {
+        "cannot infer type parameter `{name}`"
+    } else {
+        "cannot infer type parameter `{name}` of `{fnName}`"
+    }
+    checkDiag(checkCodeCannotInferTyParam(), msg, start, end)
+}
+
+pub fn diagBoundViolation(tyParam: String, bound: String, concrete: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeGenericBoundViolation(),
+        "type parameter `{tyParam}` requires bound `{bound}`, but `{concrete}` does not satisfy it",
+        start,
+        end,
+    )
+}
+
+pub fn diagInterfaceNotSatisfied(concrete: String, iface: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeInterfaceNotSatisfied(),
+        "`{concrete}` does not satisfy interface `{iface}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagQuestionNotOptional(ty: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeQuestionNotOptional(),
+        "`?` operator requires `Option<T>` or `Result<T, E>`, found `{ty}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagClosureAnnotationRequired(start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodeClosureAnnotationRequired(),
+        "closure parameter types cannot be inferred here; add a type annotation",
+        start,
+        end,
+    )
+}
+
+pub fn diagPatternShapeMismatch(ty: String, start: Int, end: Int) -> CheckDiagnostic {
+    checkDiag(
+        checkCodePatternShapeMismatch(),
+        "pattern does not match scrutinee of type `{ty}`",
+        start,
+        end,
+    )
+}
+
+pub fn diagNonEscapingEscape(ty: String, context: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if context == "" {
+        "`{ty}` cannot escape its defining scope"
+    } else {
+        "`{ty}` cannot escape via {context}"
+    }
+    checkDiag(checkCodeNonEscapingEscape(), msg, start, end)
+}
+
+// ---------------------------------------------------------------------
+// Store helpers — the elaborator keeps a `List<CheckDiagnostic>` on
+// its context. These helpers append without forgetting to stamp the
+// severity, and they count errors for the legacy summary contract.
+// ---------------------------------------------------------------------
+
+/// checkDiagPush appends a diagnostic to `xs` in place and returns the
+/// updated list. The return value lets callers chain without binding a
+/// temporary; the underlying List is mutated.
+pub fn checkDiagPush(xs: List<CheckDiagnostic>, d: CheckDiagnostic) -> List<CheckDiagnostic> {
+    xs.push(d)
+    xs
+}
+
+/// checkDiagCountErrors scans for diagnostics that block compilation
+/// (Severity=Error). Used to derive the legacy `errors` counter that
+/// the Go bridge in `internal/selfhost/check_adapter.go:86` reads.
+pub fn checkDiagCountErrors(xs: List<CheckDiagnostic>) -> Int {
+    let mut n = 0
+    for d in xs {
+        match d.severity {
+            SeverityError -> n = n + 1,
+            _ -> {},
+        }
+    }
+    n
+}
+
+pub fn checkDiagCount(xs: List<CheckDiagnostic>) -> Int {
+    let mut n = 0
+    for d in xs {
+        let _ = d
+        n = n + 1
+    }
+    n
+}
+
+/// checkDiagRender produces a single-line preview of a diagnostic
+/// suitable for test snapshots or quick debug prints.
+pub fn checkDiagRender(d: CheckDiagnostic) -> String {
+    let prefix = diagnosticSeverityName(d.severity)
+    if d.code == "" {
+        return "{prefix}: {d.message}"
+    }
+    "{prefix}[{d.code}]: {d.message}"
+}
+
+/// checkDiagRenderAll joins rendered previews with newlines.
+pub fn checkDiagRenderAll(xs: List<CheckDiagnostic>) -> String {
+    let mut parts: List<String> = []
+    for d in xs {
+        parts.push(checkDiagRender(d))
+    }
+    strings.join(parts, "\n")
+}

--- a/toolchain/check_diag_test.osty
+++ b/toolchain/check_diag_test.osty
@@ -1,0 +1,78 @@
+// check_diag_test.osty — verifies diagnostic builders stamp stable
+// codes and messages. Orphan file until the toolchain native harness
+// lands (see plan Verification §(a)).
+
+use std.testing
+use std.strings as strings
+
+fn testCheckDiagMismatchStampsCodeAndSeverity() {
+    let d = diagMismatch("Int", "String", 12, 20)
+    testing.assertEq(d.code, "E0701")
+    testing.assertEq(d.start, 12)
+    testing.assertEq(d.end, 20)
+    match d.severity {
+        SeverityError -> testing.assert(true),
+        _ -> testing.assert(false),
+    }
+    testing.assert(stringsContains(d.message, "expected `Int`"))
+    testing.assert(stringsContains(d.message, "found `String`"))
+}
+
+fn testCheckDiagArgCountIncludesCalleeWhenProvided() {
+    let withName = diagArgCount("takesTwo", 2, 3, 0, 10)
+    testing.assertEq(withName.code, "E0702")
+    testing.assert(stringsContains(withName.message, "`takesTwo`"))
+    testing.assert(stringsContains(withName.message, "2"))
+    testing.assert(stringsContains(withName.message, "3"))
+
+    let anon = diagArgCount("", 1, 0, 0, 10)
+    testing.assert(stringsContains(anon.message, "this call"))
+}
+
+fn testCheckDiagNonExhaustiveWitness() {
+    let withWitness = diagNonExhaustiveMatch("None", 0, 0)
+    testing.assertEq(withWitness.code, "E0706")
+    testing.assert(stringsContains(withWitness.message, "None"))
+
+    let noWitness = diagNonExhaustiveMatch("", 0, 0)
+    testing.assertEq(noWitness.code, "E0706")
+    testing.assert(stringsContains(noWitness.message, "not exhaustive"))
+}
+
+fn testCheckDiagQuestionNotOptional() {
+    let d = diagQuestionNotOptional("Int", 5, 7)
+    testing.assertEq(d.code, "E0730")
+    testing.assert(stringsContains(d.message, "Option"))
+    testing.assert(stringsContains(d.message, "Result"))
+    testing.assert(stringsContains(d.message, "`Int`"))
+}
+
+fn testCheckDiagCountErrorsDistinguishesSeverities() {
+    let mut xs: List<CheckDiagnostic> = []
+    xs = checkDiagPush(xs, diagMismatch("Int", "String", 0, 0))
+    xs = checkDiagPush(xs, diagUnknownName("foo", 0, 0))
+    xs = checkDiagPush(xs, CheckDiagnostic {
+        code: "L0001",
+        severity: SeverityLint,
+        message: "style note",
+        start: 0,
+        end: 0,
+        notes: [],
+    })
+
+    testing.assertEq(checkDiagCount(xs), 3)
+    testing.assertEq(checkDiagCountErrors(xs), 2)
+}
+
+fn testCheckDiagRenderIncludesCode() {
+    let d = diagMismatch("Int", "Bool", 0, 0)
+    let rendered = checkDiagRender(d)
+    testing.assert(stringsContains(rendered, "[E0701]"))
+    testing.assert(stringsContains(rendered, "error"))
+}
+
+// Substring helper — thin wrapper on `std.strings.contains` so the
+// assertions above read like plain boolean checks.
+fn stringsContains(haystack: String, needle: String) -> Bool {
+    strings.contains(haystack, needle)
+}

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1,0 +1,888 @@
+// check_env.osty — elaboration environment. Holds the lexical binding
+// stack, module-level signatures (fns, fields, variants, aliases,
+// types, interfaces), active generic bounds, and the structured output
+// records that the host bridge serializes via `FrontCheckResult`.
+//
+// Phase 4 of the migration. Replaces the string-valued storage in the
+// legacy `FrontCheckEnv` (`toolchain/check.osty:98-229`) with `Ty`
+// arena indices so equality/substitution are O(1) rather than O(n)
+// string walks.
+//
+// Scoping: the `bindings` list doubles as a stack. Entering a block
+// records the current binding count via `checkScopeMark`; leaving the
+// block truncates back with `checkScopeDrop`. This mirrors the legacy
+// `frontCheckBindingsFrom` / `frontCheckPopBindings` pair and keeps
+// parent scopes untouched.
+
+use std.strings as strings
+
+// ---------------------------------------------------------------------
+// Signature records. Every `String` type field in the legacy env has
+// been replaced with a `Ty` arena index; callers resolve indices
+// through `ty.osty` helpers.
+// ---------------------------------------------------------------------
+
+pub struct CheckBinding {
+    pub name: String,
+    pub ty: Int,
+    pub mutable: Bool,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct CheckFnSig {
+    pub name: String,
+    pub owner: String,
+    pub receiverTy: Int,        // -1 when free function
+    pub retTy: Int,
+    pub paramNames: List<String>,
+    pub paramTys: List<Int>,
+    pub generics: List<String>,
+    pub genericBounds: List<CheckGenericBound>,
+}
+
+pub struct CheckFieldSig {
+    pub owner: String,
+    pub name: String,
+    pub ty: Int,
+    pub hasDefault: Bool,
+}
+
+pub struct CheckVariantSig {
+    pub owner: String,
+    pub name: String,
+    pub fieldTys: List<Int>,
+    pub generics: List<String>,
+}
+
+pub struct CheckAliasSig {
+    pub name: String,
+    pub ty: Int,
+    pub generics: List<String>,
+}
+
+pub struct CheckTypeSig {
+    pub name: String,
+    pub generics: List<String>,
+    pub kind: String,           // "struct" / "enum" / "interface"
+}
+
+pub struct CheckInterfaceExt {
+    pub owner: String,
+    pub ifaceTy: Int,
+}
+
+pub struct CheckGenericBound {
+    pub tyParam: String,
+    pub iface: Int,
+}
+
+// ---------------------------------------------------------------------
+// Structured output records. Serialized by the host bridge through
+// `FrontCheckedNode` / `FrontCheckedBinding` / `FrontCheckedSymbol` /
+// `FrontCheckInstantiation` once the Core output stabilises.
+// ---------------------------------------------------------------------
+
+pub struct CheckTypedNode {
+    pub node: Int,
+    pub kind: String,
+    pub ty: Int,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct CheckBindingRecord {
+    pub node: Int,
+    pub name: String,
+    pub ty: Int,
+    pub mutable: Bool,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct CheckSymbolRecord {
+    pub node: Int,
+    pub kind: String,
+    pub name: String,
+    pub owner: String,
+    pub ty: Int,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub struct CheckInstantiationRecord {
+    pub node: Int,
+    pub callee: String,
+    pub typeArgs: List<Int>,
+    pub resultTy: Int,
+    pub start: Int,
+    pub end: Int,
+}
+
+// ---------------------------------------------------------------------
+// Environment.
+// ---------------------------------------------------------------------
+
+pub struct CheckEnv {
+    pub tys: TyArena,
+
+    // Lexical stack; binding operations push to the tail and `checkScopeDrop`
+    // truncates to a previously captured mark.
+    pub bindings: List<CheckBinding>,
+
+    // Module-level signatures.
+    pub fns: List<CheckFnSig>,
+    pub fields: List<CheckFieldSig>,
+    pub variants: List<CheckVariantSig>,
+    pub aliases: List<CheckAliasSig>,
+    pub types: List<CheckTypeSig>,
+    pub interfaces: List<String>,
+    pub interfaceExtends: List<CheckInterfaceExt>,
+
+    // Generic bounds currently in scope (owner fn / struct / impl).
+    pub genericBounds: List<CheckGenericBound>,
+
+    // Flow context.
+    pub returnTy: Int,
+    pub fnName: String,
+    pub inLoop: Bool,
+
+    // Diagnostics + summary counters — legacy `errors` is derived from
+    // `diagnostics.len()` at the bridge seam.
+    pub diagnostics: List<CheckDiagnostic>,
+    pub assignments: Int,
+    pub accepted: Int,
+
+    // Structured output mirrors of the legacy summary.
+    pub typedNodes: List<CheckTypedNode>,
+    pub bindingRecords: List<CheckBindingRecord>,
+    pub symbolRecords: List<CheckSymbolRecord>,
+    pub instantiations: List<CheckInstantiationRecord>,
+}
+
+pub fn emptyCheckEnv(tys: TyArena) -> CheckEnv {
+    CheckEnv {
+        tys,
+        bindings: [],
+        fns: [],
+        fields: [],
+        variants: [],
+        aliases: [],
+        types: [],
+        interfaces: [],
+        interfaceExtends: [],
+        genericBounds: [],
+        returnTy: tErr(tys),
+        fnName: "",
+        inLoop: false,
+        diagnostics: [],
+        assignments: 0,
+        accepted: 0,
+        typedNodes: [],
+        bindingRecords: [],
+        symbolRecords: [],
+        instantiations: [],
+    }
+}
+
+// ---------------------------------------------------------------------
+// Scoping.
+//
+// A "scope mark" is just the current binding count. Callers capture it
+// with `checkScopeMark` before entering a block and call
+// `checkScopeDrop` with the same value when leaving; anything bound
+// inside the block is shed. Parent scopes are unaffected.
+// ---------------------------------------------------------------------
+
+pub fn checkScopeMark(env: CheckEnv) -> Int {
+    checkBindingCount(env)
+}
+
+pub fn checkScopeDrop(env: CheckEnv, mark: Int) {
+    // Repeatedly pop the tail until we are back at `mark`. Osty lists
+    // support `.pop()`; the early-break guards against negative marks.
+    let mut current = checkBindingCount(env)
+    for current > mark {
+        let _ = env.bindings.pop()
+        current = current - 1
+    }
+}
+
+pub fn checkBindingCount(env: CheckEnv) -> Int {
+    let mut n = 0
+    for b in env.bindings {
+        let _ = b
+        n = n + 1
+    }
+    n
+}
+
+// ---------------------------------------------------------------------
+// Bindings.
+// ---------------------------------------------------------------------
+
+/// checkBind pushes a new immutable binding onto the lexical stack.
+pub fn checkBind(env: CheckEnv, name: String, ty: Int) {
+    env.bindings.push(CheckBinding {
+        name,
+        ty,
+        mutable: false,
+        start: -1,
+        end: -1,
+    })
+}
+
+pub fn checkBindMut(env: CheckEnv, name: String, ty: Int) {
+    env.bindings.push(CheckBinding {
+        name,
+        ty,
+        mutable: true,
+        start: -1,
+        end: -1,
+    })
+}
+
+/// checkBindSpan pushes a binding while also remembering its AST span
+/// so the structured-output record can echo the exact source range.
+pub fn checkBindSpan(env: CheckEnv, name: String, ty: Int, mutable: Bool, start: Int, end: Int) {
+    env.bindings.push(CheckBinding { name, ty, mutable, start, end })
+}
+
+/// checkLookup walks the lexical stack from the tail back, returning
+/// the most recent binding for `name`. Returns `-1` (no type) when
+/// `name` is not in scope.
+pub fn checkLookup(env: CheckEnv, name: String) -> Int {
+    let mut found = -1
+    for b in env.bindings {
+        if b.name == name {
+            found = b.ty
+        }
+    }
+    found
+}
+
+pub fn checkLookupMutable(env: CheckEnv, name: String) -> Bool {
+    let mut mutable = false
+    for b in env.bindings {
+        if b.name == name {
+            mutable = b.mutable
+        }
+    }
+    mutable
+}
+
+// ---------------------------------------------------------------------
+// Module-level registration.
+// ---------------------------------------------------------------------
+
+pub fn checkRegisterFn(env: CheckEnv, sig: CheckFnSig) {
+    env.fns.push(sig)
+}
+
+pub fn checkLookupFn(env: CheckEnv, name: String, owner: String) -> CheckFnSig {
+    for sig in env.fns {
+        if sig.name == name && sig.owner == owner {
+            return sig
+        }
+    }
+    emptyCheckFnSig()
+}
+
+/// checkLookupMethod searches `fns` where `owner` matches the receiver
+/// type head. Inheritance through `interface extends` is followed via
+/// `interfaceExtends` — Phase 7 wires this up when interfaces land.
+pub fn checkLookupMethod(env: CheckEnv, owner: String, name: String) -> CheckFnSig {
+    let direct = checkLookupFn(env, name, owner)
+    if direct.name != "" {
+        return direct
+    }
+    // Walk extends for interface inheritance.
+    for ext in env.interfaceExtends {
+        if ext.owner == owner {
+            let parent = tyHeadAt(env.tys, ext.ifaceTy)
+            let found = checkLookupMethod(env, parent, name)
+            if found.name != "" {
+                return found
+            }
+        }
+    }
+    emptyCheckFnSig()
+}
+
+pub fn checkFnExists(env: CheckEnv, name: String, owner: String) -> Bool {
+    checkLookupFn(env, name, owner).name != ""
+}
+
+pub fn checkRegisterField(env: CheckEnv, field: CheckFieldSig) {
+    env.fields.push(field)
+}
+
+pub fn checkLookupField(env: CheckEnv, owner: String, name: String) -> CheckFieldSig {
+    for f in env.fields {
+        if f.owner == owner && f.name == name {
+            return f
+        }
+    }
+    emptyCheckFieldSig()
+}
+
+pub fn checkRegisterVariant(env: CheckEnv, variant: CheckVariantSig) {
+    env.variants.push(variant)
+}
+
+pub fn checkLookupVariant(env: CheckEnv, name: String) -> CheckVariantSig {
+    for v in env.variants {
+        if v.name == name {
+            return v
+        }
+    }
+    emptyCheckVariantSig()
+}
+
+pub fn checkLookupVariantInOwner(env: CheckEnv, owner: String, name: String) -> CheckVariantSig {
+    for v in env.variants {
+        if v.owner == owner && v.name == name {
+            return v
+        }
+    }
+    emptyCheckVariantSig()
+}
+
+pub fn checkRegisterAlias(env: CheckEnv, alias: CheckAliasSig) {
+    env.aliases.push(alias)
+}
+
+pub fn checkLookupAlias(env: CheckEnv, name: String) -> CheckAliasSig {
+    for a in env.aliases {
+        if a.name == name {
+            return a
+        }
+    }
+    emptyCheckAliasSig()
+}
+
+pub fn checkRegisterType(env: CheckEnv, sig: CheckTypeSig) {
+    env.types.push(sig)
+}
+
+pub fn checkLookupType(env: CheckEnv, name: String) -> CheckTypeSig {
+    for t in env.types {
+        if t.name == name {
+            return t
+        }
+    }
+    emptyCheckTypeSig()
+}
+
+pub fn checkDeclaredTypeExists(env: CheckEnv, name: String) -> Bool {
+    if checkLookupType(env, name).name != "" {
+        return true
+    }
+    if checkLookupAlias(env, name).name != "" {
+        return true
+    }
+    checkIsInterface(env, name)
+}
+
+pub fn checkRegisterInterface(env: CheckEnv, name: String) {
+    env.interfaces.push(name)
+}
+
+pub fn checkIsInterface(env: CheckEnv, name: String) -> Bool {
+    for i in env.interfaces {
+        if i == name {
+            return true
+        }
+    }
+    false
+}
+
+pub fn checkRegisterInterfaceExtends(env: CheckEnv, ext: CheckInterfaceExt) {
+    env.interfaceExtends.push(ext)
+}
+
+pub fn checkInterfaceExtendsList(env: CheckEnv, owner: String) -> List<Int> {
+    let mut out: List<Int> = []
+    for ext in env.interfaceExtends {
+        if ext.owner == owner {
+            out.push(ext.ifaceTy)
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------
+// Generic bounds.
+// ---------------------------------------------------------------------
+
+pub fn checkAddGenericBound(env: CheckEnv, bound: CheckGenericBound) {
+    env.genericBounds.push(bound)
+}
+
+pub fn checkLookupGenericBound(env: CheckEnv, tyParam: String) -> Int {
+    let mut found = -1
+    for b in env.genericBounds {
+        if b.tyParam == tyParam {
+            found = b.iface
+        }
+    }
+    found
+}
+
+pub fn checkClearGenericBoundsAfter(env: CheckEnv, mark: Int) {
+    let mut current = checkGenericBoundCount(env)
+    for current > mark {
+        let _ = env.genericBounds.pop()
+        current = current - 1
+    }
+}
+
+pub fn checkGenericBoundMark(env: CheckEnv) -> Int {
+    checkGenericBoundCount(env)
+}
+
+fn checkGenericBoundCount(env: CheckEnv) -> Int {
+    let mut n = 0
+    for b in env.genericBounds {
+        let _ = b
+        n = n + 1
+    }
+    n
+}
+
+// ---------------------------------------------------------------------
+// Alias resolution. Expands user-defined aliases once and, for deep
+// resolution, recurses into named / tuple / fn structure.
+// ---------------------------------------------------------------------
+
+/// checkResolveAliasOnce returns the RHS of `ty` when `ty` is the head
+/// of a declared alias, otherwise -1 to signal "no change". The caller
+/// is expected to substitute generic parameters separately.
+pub fn checkResolveAliasOnce(env: CheckEnv, ty: Int) -> Int {
+    if ty < 0 {
+        return -1
+    }
+    let kind = tyKindAt(env.tys, ty)
+    if kind != TkNamed {
+        return -1
+    }
+    let head = tyHeadAt(env.tys, ty)
+    let alias = checkLookupAlias(env, head)
+    if alias.name == "" {
+        return -1
+    }
+    if checkStringListLen(alias.generics) == 0 {
+        return alias.ty
+    }
+    // Generic alias: substitute each formal with the corresponding arg.
+    let args = tyArgsAt(env.tys, ty)
+    if checkIntListLen(args) != checkStringListLen(alias.generics) {
+        return alias.ty
+    }
+    checkSubstituteTy(env, alias.ty, alias.generics, args)
+}
+
+pub fn checkResolveAlias(env: CheckEnv, ty: Int) -> Int {
+    let mut current = ty
+    let mut depth = 0
+    for depth < 8 {
+        let next = checkResolveAliasOnce(env, current)
+        if next < 0 {
+            return current
+        }
+        current = next
+        depth = depth + 1
+    }
+    current
+}
+
+/// checkResolveAliasDeep walks compound types (Named args, Tuple
+/// elements, Fn params/ret, Optional inner) and re-allocates a
+/// canonical form with every alias expanded.
+pub fn checkResolveAliasDeep(env: CheckEnv, ty: Int) -> Int {
+    checkResolveAliasDeepAt(env, ty, 0)
+}
+
+fn checkResolveAliasDeepAt(env: CheckEnv, ty: Int, depth: Int) -> Int {
+    if depth > 8 || ty < 0 {
+        return ty
+    }
+    let direct = checkResolveAlias(env, ty)
+    if !(tyEq(env.tys, direct, ty)) {
+        return checkResolveAliasDeepAt(env, direct, depth + 1)
+    }
+    let kind = tyKindAt(env.tys, ty)
+    match kind {
+        TkTuple -> {
+            let elems = tyArgsAt(env.tys, ty)
+            let mut out: List<Int> = []
+            for e in elems {
+                out.push(checkResolveAliasDeepAt(env, e, depth + 1))
+            }
+            tyTuple(env.tys, out)
+        },
+        TkFn -> {
+            let params = tyArgsAt(env.tys, ty)
+            let mut outParams: List<Int> = []
+            for p in params {
+                outParams.push(checkResolveAliasDeepAt(env, p, depth + 1))
+            }
+            let ret = checkResolveAliasDeepAt(env, tyRetAt(env.tys, ty), depth + 1)
+            tyFn(env.tys, outParams, ret)
+        },
+        TkNamed -> {
+            let args = tyArgsAt(env.tys, ty)
+            if checkIntListLen(args) == 0 {
+                return ty
+            }
+            let mut outArgs: List<Int> = []
+            for a in args {
+                outArgs.push(checkResolveAliasDeepAt(env, a, depth + 1))
+            }
+            tyNamed(env.tys, tyHeadAt(env.tys, ty), outArgs)
+        },
+        TkOptional -> {
+            let inner = checkResolveAliasDeepAt(env, tyInnerAt(env.tys, ty), depth + 1)
+            tyOptional(env.tys, inner)
+        },
+        _ -> ty,
+    }
+}
+
+/// checkSubstituteTy replaces every generic name in `ty` with the
+/// corresponding entry from `args` (positional, by index in
+/// `generics`). Compound shapes rebuild through the arena.
+pub fn checkSubstituteTy(env: CheckEnv, ty: Int, generics: List<String>, args: List<Int>) -> Int {
+    if ty < 0 {
+        return ty
+    }
+    let kind = tyKindAt(env.tys, ty)
+    match kind {
+        TkNamed -> {
+            let head = tyHeadAt(env.tys, ty)
+            let idx = checkIndexOfString(generics, head)
+            if idx >= 0 {
+                // Type parameter reference — replace with the substituted
+                // arg (if it was supplied).
+                if idx < checkIntListLen(args) {
+                    return args[idx]
+                }
+                return ty
+            }
+            let inner = tyArgsAt(env.tys, ty)
+            if checkIntListLen(inner) == 0 {
+                return ty
+            }
+            let mut rebuilt: List<Int> = []
+            for a in inner {
+                rebuilt.push(checkSubstituteTy(env, a, generics, args))
+            }
+            tyNamed(env.tys, head, rebuilt)
+        },
+        TkTuple -> {
+            let elems = tyArgsAt(env.tys, ty)
+            let mut out: List<Int> = []
+            for e in elems {
+                out.push(checkSubstituteTy(env, e, generics, args))
+            }
+            tyTuple(env.tys, out)
+        },
+        TkFn -> {
+            let params = tyArgsAt(env.tys, ty)
+            let mut outParams: List<Int> = []
+            for p in params {
+                outParams.push(checkSubstituteTy(env, p, generics, args))
+            }
+            let ret = checkSubstituteTy(env, tyRetAt(env.tys, ty), generics, args)
+            tyFn(env.tys, outParams, ret)
+        },
+        TkOptional -> {
+            tyOptional(env.tys, checkSubstituteTy(env, tyInnerAt(env.tys, ty), generics, args))
+        },
+        _ -> ty,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Structured output recording.
+// ---------------------------------------------------------------------
+
+pub fn checkRecordTypedNode(env: CheckEnv, nodeIdx: Int, kind: String, ty: Int, start: Int, end: Int) {
+    env.typedNodes.push(CheckTypedNode { node: nodeIdx, kind, ty, start, end })
+}
+
+pub fn checkRecordBinding(env: CheckEnv, nodeIdx: Int, name: String, ty: Int, mutable: Bool, start: Int, end: Int) {
+    env.bindingRecords.push(CheckBindingRecord { node: nodeIdx, name, ty, mutable, start, end })
+}
+
+pub fn checkRecordSymbol(env: CheckEnv, nodeIdx: Int, kind: String, name: String, owner: String, ty: Int, start: Int, end: Int) {
+    env.symbolRecords.push(CheckSymbolRecord { node: nodeIdx, kind, name, owner, ty, start, end })
+}
+
+pub fn checkRecordInstantiation(env: CheckEnv, nodeIdx: Int, callee: String, typeArgs: List<Int>, resultTy: Int, start: Int, end: Int) {
+    env.instantiations.push(CheckInstantiationRecord {
+        node: nodeIdx,
+        callee,
+        typeArgs,
+        resultTy,
+        start,
+        end,
+    })
+}
+
+// ---------------------------------------------------------------------
+// Counter helpers — preserves legacy summary semantics so the existing
+// `FrontCheckResult.summary` contract keeps working.
+// ---------------------------------------------------------------------
+
+pub fn checkExpectAssignable(env: CheckEnv, expected: Int, got: Int, start: Int, end: Int) -> Bool {
+    env.assignments = env.assignments + 1
+    if checkIsAssignable(env, expected, got) {
+        env.accepted = env.accepted + 1
+        return true
+    }
+    env.diagnostics.push(diagMismatch(
+        tyToString(env.tys, checkResolveAliasDeep(env, expected)),
+        tyToString(env.tys, checkResolveAliasDeep(env, got)),
+        start,
+        end,
+    ))
+    false
+}
+
+/// checkIsAssignable implements structural assignability against the
+/// Ty arena. Mirrors the legacy rules (`toolchain/check.osty:1419-1495`)
+/// while dropping the repeated string parsing.
+pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
+    let d = checkResolveAliasDeep(env, dst)
+    let s = checkResolveAliasDeep(env, src)
+    if tyIsErr(env.tys, d) || tyIsErr(env.tys, s) {
+        return true
+    }
+    if tyIsNamedHead(env.tys, d, "Any") || tyIsNamedHead(env.tys, s, "Any") {
+        return true
+    }
+    if tyIsNever(env.tys, s) {
+        return true
+    }
+    if tyEq(env.tys, d, s) {
+        return true
+    }
+    let sPrim = tyPrimAt(env.tys, s)
+    let dPrim = tyPrimAt(env.tys, d)
+    let sIsPrim = tyKindAt(env.tys, s) == TkPrim
+    let dIsPrim = tyKindAt(env.tys, d) == TkPrim
+    if sIsPrim && sPrim == PkUntypedInt {
+        return dIsPrim && (dPrim == PkInt || dPrim == PkFloat || dPrim == PkByte || dPrim == PkChar ||
+            dPrim == PkInt8 || dPrim == PkInt16 || dPrim == PkInt32 || dPrim == PkInt64 ||
+            dPrim == PkUInt8 || dPrim == PkUInt16 || dPrim == PkUInt32 || dPrim == PkUInt64 ||
+            dPrim == PkFloat32 || dPrim == PkFloat64)
+    }
+    if sIsPrim && sPrim == PkUntypedFloat {
+        return dIsPrim && (dPrim == PkFloat || dPrim == PkFloat32 || dPrim == PkFloat64)
+    }
+    if dIsPrim && dPrim == PkUntypedInt {
+        return sIsPrim && (sPrim == PkInt || sPrim == PkByte || sPrim == PkChar ||
+            sPrim == PkInt8 || sPrim == PkInt16 || sPrim == PkInt32 || sPrim == PkInt64)
+    }
+    if dIsPrim && dPrim == PkUntypedFloat {
+        return sIsPrim && (sPrim == PkFloat || sPrim == PkFloat32 || sPrim == PkFloat64)
+    }
+    // Tuple vs tuple, fn vs fn, named vs named — walk structurally.
+    let dk = tyKindAt(env.tys, d)
+    let sk = tyKindAt(env.tys, s)
+    if dk == TkTuple && sk == TkTuple {
+        let da = tyArgsAt(env.tys, d)
+        let sa = tyArgsAt(env.tys, s)
+        if checkIntListLen(da) != checkIntListLen(sa) {
+            return false
+        }
+        let mut i = 0
+        for de in da {
+            if !(checkIsAssignable(env, de, sa[i])) {
+                return false
+            }
+            i = i + 1
+        }
+        return true
+    }
+    if dk == TkFn && sk == TkFn {
+        let dp = tyArgsAt(env.tys, d)
+        let sp = tyArgsAt(env.tys, s)
+        if checkIntListLen(dp) != checkIntListLen(sp) {
+            return false
+        }
+        let mut i = 0
+        for dpe in dp {
+            let spe = sp[i]
+            // Function parameters are invariant (contravariant treated
+            // as equivalence to keep the checker predictable).
+            if !(checkIsAssignable(env, dpe, spe)) || !(checkIsAssignable(env, spe, dpe)) {
+                return false
+            }
+            i = i + 1
+        }
+        return checkIsAssignable(env, tyRetAt(env.tys, d), tyRetAt(env.tys, s))
+    }
+    if dk == TkNamed && sk == TkNamed && tyHeadAt(env.tys, d) == tyHeadAt(env.tys, s) {
+        let da = tyArgsAt(env.tys, d)
+        let sa = tyArgsAt(env.tys, s)
+        if checkIntListLen(da) != checkIntListLen(sa) {
+            return false
+        }
+        let mut i = 0
+        for de in da {
+            if !(checkIsAssignable(env, de, sa[i])) {
+                return false
+            }
+            i = i + 1
+        }
+        return true
+    }
+    if dk == TkOptional && sk == TkOptional {
+        return checkIsAssignable(env, tyInnerAt(env.tys, d), tyInnerAt(env.tys, s))
+    }
+    // Interface satisfaction is resolved in Phase 7 once `solve.osty`
+    // lands; until then any interface destination accepts via the
+    // generic-bound escape hatch.
+    if dk == TkNamed && checkIsInterface(env, tyHeadAt(env.tys, d)) {
+        return true
+    }
+    false
+}
+
+// ---------------------------------------------------------------------
+// Small helpers + empties.
+// ---------------------------------------------------------------------
+
+fn checkIntListLen(xs: List<Int>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+fn checkStringListLen(xs: List<String>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+fn checkIndexOfString(xs: List<String>, needle: String) -> Int {
+    let mut i = 0
+    for x in xs {
+        if x == needle {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+pub fn emptyCheckBinding() -> CheckBinding {
+    CheckBinding { name: "", ty: -1, mutable: false, start: -1, end: -1 }
+}
+
+pub fn emptyCheckFnSig() -> CheckFnSig {
+    CheckFnSig {
+        name: "",
+        owner: "",
+        receiverTy: -1,
+        retTy: -1,
+        paramNames: [],
+        paramTys: [],
+        generics: [],
+        genericBounds: [],
+    }
+}
+
+pub fn emptyCheckFieldSig() -> CheckFieldSig {
+    CheckFieldSig { owner: "", name: "", ty: -1, hasDefault: false }
+}
+
+pub fn emptyCheckVariantSig() -> CheckVariantSig {
+    CheckVariantSig { owner: "", name: "", fieldTys: [], generics: [] }
+}
+
+pub fn emptyCheckAliasSig() -> CheckAliasSig {
+    CheckAliasSig { name: "", ty: -1, generics: [] }
+}
+
+pub fn emptyCheckTypeSig() -> CheckTypeSig {
+    CheckTypeSig { name: "", generics: [], kind: "" }
+}
+
+// ---------------------------------------------------------------------
+// Prelude wiring. Installs the canonical builtins the elaborator needs
+// before walking any user-supplied declarations. Mirrors
+// `frontCheckInstallBuiltins` at check.osty:220-230 but through the
+// typed arena.
+// ---------------------------------------------------------------------
+
+pub fn checkInstallPrelude(env: CheckEnv) {
+    let _ = env
+    // Register the built-in `Equal`, `Ordered`, and `Hashable`
+    // interfaces so `<T: Ordered>` bounds in user code find them.
+    checkRegisterInterface(env, "Equal")
+    checkRegisterInterface(env, "Ordered")
+    checkRegisterInterface(env, "Hashable")
+
+    // Register stdlib types that carry generics so alias/bound
+    // substitution has the arity information it needs.
+    checkRegisterType(env, CheckTypeSig { name: "List", generics: ["T"], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Map", generics: ["K", "V"], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Option", generics: ["T"], kind: "enum" })
+    checkRegisterType(env, CheckTypeSig { name: "Result", generics: ["T", "E"], kind: "enum" })
+    checkRegisterType(env, CheckTypeSig { name: "Range", generics: ["T"], kind: "struct" })
+
+    // Option / Result variants.
+    checkRegisterVariant(env, CheckVariantSig {
+        owner: "Option",
+        name: "Some",
+        fieldTys: [tyNamed(env.tys, "T", [])],
+        generics: ["T"],
+    })
+    checkRegisterVariant(env, CheckVariantSig {
+        owner: "Option",
+        name: "None",
+        fieldTys: [],
+        generics: ["T"],
+    })
+    checkRegisterVariant(env, CheckVariantSig {
+        owner: "Result",
+        name: "Ok",
+        fieldTys: [tyNamed(env.tys, "T", [])],
+        generics: ["T", "E"],
+    })
+    checkRegisterVariant(env, CheckVariantSig {
+        owner: "Result",
+        name: "Err",
+        fieldTys: [tyNamed(env.tys, "E", [])],
+        generics: ["T", "E"],
+    })
+}
+
+// Preserve a surface-level mirror of `frontCheckResult*`-style bridge
+// helpers used by the Go side. These read straight off the env.
+
+pub fn checkErrorsCount(env: CheckEnv) -> Int {
+    checkDiagCountErrors(env.diagnostics)
+}
+
+pub fn checkResolveBinding(env: CheckEnv, name: String) -> String {
+    let ty = checkLookup(env, name)
+    if ty < 0 {
+        return ""
+    }
+    tyToString(env.tys, ty)
+}
+
+pub fn checkEnvSummary(env: CheckEnv) -> String {
+    let errs = checkErrorsCount(env)
+    "assignments={env.assignments} accepted={env.accepted} errors={errs}"
+}

--- a/toolchain/core.osty
+++ b/toolchain/core.osty
@@ -1,0 +1,1768 @@
+// core.osty — typed Core IR produced by the bidirectional elaborator.
+//
+// Phase 3 of the migration. Every expression carries a `Ty` arena index
+// directly; every statement/decl/pattern carries a source span. The IR
+// is independent of the surface AST: it collapses syntactic sugar
+// (parens unwrap, block-final expressions hoist into `CkBlock` tail),
+// classifies call shapes into dedicated kinds (`CkCall` vs
+// `CkMethodCall` vs `CkVariantLit`), and drops resolution-only metadata
+// (Use-decl bodies kept only as raw decls, doc comments dropped).
+//
+// Shape decisions:
+//
+// - Arena + kind discriminator. One `CoreNode` struct carries fields
+//   for every kind; unused slots sit at zero values. This matches
+//   `toolchain/ir.osty:88-102` so the existing toolchain pipeline can
+//   adopt Core incrementally and the Osty self-host codegen stays on
+//   terrain it already validates.
+//
+// - Per-kind *constructors and accessors*. The public surface still
+//   reads like a tagged union (`coreIntLit`, `coreCall`, ...
+//   `coreCallFn`, `coreCallArgs`), so elaborator code does not spell
+//   out field twiddling on the shared node.
+//
+// - Type field is a `Ty` arena index. Callers hand `ty.osty` around,
+//   and the Core arena never owns a type — types live in a parallel
+//   `TyArena`. This keeps the two arenas freely mixed inside a single
+//   `ElabCx` without ownership tangles.
+
+use std.strings as strings
+
+// ---------------------------------------------------------------------
+// Kind discriminators.
+// ---------------------------------------------------------------------
+
+/// CoreKind tags every node in the arena. Buckets:
+///   Ck* = expression, Cs* = statement, Cd* = decl, Cp* = pattern,
+///   CkErr / CsErr / CpErr = poisoned node (lowering could not recover).
+pub enum CoreKind {
+    CkErr,
+
+    // Literals
+    CkIntLit,
+    CkFloatLit,
+    CkBoolLit,
+    CkCharLit,
+    CkByteLit,
+    CkStringLit,
+    CkUnitLit,
+
+    // Atoms and operators
+    CkIdent,
+    CkUnary,
+    CkBinary,
+    CkCoalesce,
+    CkQuestion,
+
+    // Callables
+    CkCall,
+    CkMethodCall,
+    CkIntrinsic,
+    CkVariantLit,
+
+    // Access
+    CkField,
+    CkTupleAccess,
+    CkIndex,
+
+    // Aggregates
+    CkList,
+    CkMap,
+    CkMapEntry,
+    CkTuple,
+    CkStruct,
+    CkStructField,
+    CkRange,
+
+    // Control
+    CkClosure,
+    CkBlock,
+    CkIf,
+    CkIfLet,
+    CkMatch,
+    CkMatchArm,
+
+    // Statements
+    CsBlock,
+    CsLet,
+    CsAssign,
+    CsReturn,
+    CsBreak,
+    CsContinue,
+    CsIf,
+    CsFor,
+    CsMatch,
+    CsExprStmt,
+    CsDefer,
+    CsChanSend,
+    CsErr,
+
+    // Decls
+    CdFn,
+    CdStruct,
+    CdEnum,
+    CdEnumVariant,
+    CdInterface,
+    CdTypeAlias,
+    CdLet,
+    CdUse,
+    CdField,
+    CdParam,
+    CdGenericParam,
+
+    // Patterns
+    CpWild,
+    CpIdent,
+    CpLit,
+    CpTuple,
+    CpStruct,
+    CpStructField,
+    CpVariant,
+    CpRange,
+    CpOr,
+    CpBinding,
+    CpErr,
+}
+
+/// IdentKind mirrors `ir.IdentKind` (`internal/ir/ir.go:640-649`) so
+/// the Go-side bridge can thread `CoreIdent` into the backend without a
+/// second resolution pass.
+pub enum IdentKind {
+    IkUnknown,
+    IkLocal,
+    IkParam,
+    IkFn,
+    IkVariant,
+    IkTypeName,
+    IkGlobal,
+    IkBuiltin,
+}
+
+/// BinOp mirrors the operator enum used by `ast.BinaryExpr`. Values are
+/// ordered to match the grammar precedence table; numeric encoding is
+/// stable across the bridge.
+pub enum BinOp {
+    BoAdd, BoSub, BoMul, BoDiv, BoMod,
+    BoEq, BoNe, BoLt, BoLe, BoGt, BoGe,
+    BoAnd, BoOr,
+    BoBitAnd, BoBitOr, BoBitXor, BoShl, BoShr,
+    BoInvalid,
+}
+
+pub enum UnOp {
+    UoNeg,
+    UoPlus,
+    UoNot,
+    UoBitNot,
+    UoInvalid,
+}
+
+// ---------------------------------------------------------------------
+// Storage.
+// ---------------------------------------------------------------------
+
+/// CoreNode is the discriminated union stored in the arena. Clients
+/// should read fields through the typed accessors below rather than
+/// inspecting this struct directly.
+pub struct CoreNode {
+    pub kind: CoreKind,
+    pub ty: Int,                 // Ty arena index, -1 for stmt/decl/pat
+    pub start: Int,
+    pub end: Int,
+
+    pub text: String,            // literal text, ident name, field name, variant name, method name
+    pub name: String,            // fn/struct/enum/interface/alias/let binding name
+    pub owner: String,           // owner type name for methods/variants/fields
+
+    pub value: Int,              // BoolLit 0/1, CharLit rune, ByteLit byte, TupleAccess idx, BinOp/UnOp
+    pub flags: Int,              // IdentKind enum int, pattern flags, let-mutability, fn purity, ...
+
+    pub left: Int,               // structural child #1 (call.fn, binary.left, if.cond, field.recv, unary.x)
+    pub right: Int,              // structural child #2 (binary.right, if.then, index.idx)
+    pub extra: Int,              // structural child #3 (if.else, range.stop, method.recv, question.inner)
+
+    pub children: List<Int>,     // variadic child refs #1: call args, block stmts, list elems, tuple elems, match arms, fn params, struct lit fields, decls under use, generic params
+    pub children2: List<Int>,    // variadic child refs #2: call typeArgs (Ty arena!), closure param types (Ty arena!), match arm order, struct fields for decl
+
+    pub typeArgs: List<Int>,     // explicit type args (Ty arena indices) — for CkCall/CkMethodCall/CkVariantLit/CdFn/CdStruct/...
+}
+
+pub fn emptyCoreNode(kind: CoreKind) -> CoreNode {
+    CoreNode {
+        kind,
+        ty: -1,
+        start: 0,
+        end: 0,
+        text: "",
+        name: "",
+        owner: "",
+        value: 0,
+        flags: 0,
+        left: -1,
+        right: -1,
+        extra: -1,
+        children: [],
+        children2: [],
+        typeArgs: [],
+    }
+}
+
+pub struct CoreArena {
+    pub nodes: List<CoreNode>,
+}
+
+pub fn emptyCoreArena() -> CoreArena {
+    CoreArena { nodes: [] }
+}
+
+pub fn coreArenaNodeCount(arena: CoreArena) -> Int {
+    let mut count = 0
+    for n in arena.nodes {
+        let _ = n
+        count = count + 1
+    }
+    count
+}
+
+fn coreArenaAdd(arena: CoreArena, node: CoreNode) -> Int {
+    let idx = coreArenaNodeCount(arena)
+    arena.nodes.push(node)
+    idx
+}
+
+pub fn coreArenaNodeAt(arena: CoreArena, idx: Int) -> CoreNode {
+    if idx < 0 {
+        return emptyCoreNode(CkErr)
+    }
+    arena.nodes[idx]
+}
+
+/// CoreModule is the top-level container — one per Osty source file.
+/// `script` captures top-level statements that the backend wraps in a
+/// synthetic `main`; `decls` are top-level declarations in source
+/// order.
+pub struct CoreModule {
+    pub packageName: String,
+    pub arena: CoreArena,
+    pub decls: List<Int>,
+    pub script: List<Int>,
+    pub diagnostics: List<CheckDiagnostic>,
+    pub start: Int,
+    pub end: Int,
+}
+
+pub fn emptyCoreModule(packageName: String) -> CoreModule {
+    CoreModule {
+        packageName,
+        arena: emptyCoreArena(),
+        decls: [],
+        script: [],
+        diagnostics: [],
+        start: 0,
+        end: 0,
+    }
+}
+
+// =====================================================================
+// Constructors. Each returns an arena index.
+// =====================================================================
+
+// ---- Literals & atoms ----
+
+pub fn coreIntLit(arena: CoreArena, text: String, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkIntLit)
+    n.text = text
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreFloatLit(arena: CoreArena, text: String, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkFloatLit)
+    n.text = text
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreBoolLit(arena: CoreArena, value: Bool, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkBoolLit)
+    n.value = if value { 1 } else { 0 }
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreCharLit(arena: CoreArena, rune: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkCharLit)
+    n.value = rune
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreByteLit(arena: CoreArena, byte: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkByteLit)
+    n.value = byte
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+/// coreStringLit records the raw source text (including interpolation
+/// braces). Interpolation children go in `children`, alternating
+/// literal-text sentinel nodes and expression nodes — the backend walks
+/// them in order.
+pub fn coreStringLit(arena: CoreArena, text: String, parts: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkStringLit)
+    n.text = text
+    n.children = parts
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreUnitLit(arena: CoreArena, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkUnitLit)
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreIdent(arena: CoreArena, name: String, kind: IdentKind, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkIdent)
+    n.text = name
+    n.name = name
+    n.flags = identKindToInt(kind)
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Operators ----
+
+pub fn coreUnary(arena: CoreArena, op: UnOp, x: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkUnary)
+    n.value = unOpToInt(op)
+    n.left = x
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreBinary(arena: CoreArena, op: BinOp, left: Int, right: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkBinary)
+    n.value = binOpToInt(op)
+    n.left = left
+    n.right = right
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreCoalesce(arena: CoreArena, left: Int, right: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkCoalesce)
+    n.left = left
+    n.right = right
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreQuestion(arena: CoreArena, x: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkQuestion)
+    n.left = x
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Callables ----
+
+pub fn coreCall(
+    arena: CoreArena,
+    fn_: Int,
+    args: List<Int>,
+    typeArgs: List<Int>,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkCall)
+    n.left = fn_
+    n.children = args
+    n.typeArgs = typeArgs
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreMethodCall(
+    arena: CoreArena,
+    recv: Int,
+    name: String,
+    owner: String,
+    args: List<Int>,
+    typeArgs: List<Int>,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkMethodCall)
+    n.left = recv
+    n.text = name
+    n.name = name
+    n.owner = owner
+    n.children = args
+    n.typeArgs = typeArgs
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreIntrinsic(arena: CoreArena, name: String, args: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkIntrinsic)
+    n.text = name
+    n.name = name
+    n.children = args
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreVariantLit(
+    arena: CoreArena,
+    owner: String,
+    name: String,
+    args: List<Int>,
+    typeArgs: List<Int>,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkVariantLit)
+    n.text = name
+    n.name = name
+    n.owner = owner
+    n.children = args
+    n.typeArgs = typeArgs
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Access ----
+
+pub fn coreField(arena: CoreArena, recv: Int, name: String, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkField)
+    n.left = recv
+    n.text = name
+    n.name = name
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreTupleAccess(arena: CoreArena, recv: Int, idx: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkTupleAccess)
+    n.left = recv
+    n.value = idx
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreIndex(arena: CoreArena, recv: Int, idx: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkIndex)
+    n.left = recv
+    n.right = idx
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Aggregates ----
+
+pub fn coreList(arena: CoreArena, elems: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkList)
+    n.children = elems
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreMap(arena: CoreArena, entries: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkMap)
+    n.children = entries
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreMapEntry(arena: CoreArena, key: Int, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkMapEntry)
+    n.left = key
+    n.right = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreTuple(arena: CoreArena, elems: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkTuple)
+    n.children = elems
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreStruct(
+    arena: CoreArena,
+    owner: String,
+    fields: List<Int>,
+    spread: Int,
+    typeArgs: List<Int>,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkStruct)
+    n.owner = owner
+    n.name = owner
+    n.children = fields
+    n.extra = spread
+    n.typeArgs = typeArgs
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreStructField(arena: CoreArena, name: String, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkStructField)
+    n.text = name
+    n.name = name
+    n.left = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+/// coreRange encodes `a..b` / `a..=b` — `flags` stores the inclusive
+/// bit (1 = inclusive, 0 = half-open) so backends can switch without
+/// re-parsing.
+pub fn coreRange(arena: CoreArena, start_: Int, stop: Int, inclusive: Bool, ty: Int, pos: Int, endPos: Int) -> Int {
+    let mut n = emptyCoreNode(CkRange)
+    n.left = start_
+    n.right = stop
+    n.flags = if inclusive { 1 } else { 0 }
+    n.ty = ty
+    n.start = pos
+    n.end = endPos
+    coreArenaAdd(arena, n)
+}
+
+// ---- Control ----
+
+pub fn coreClosure(
+    arena: CoreArena,
+    params: List<Int>,
+    body: Int,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkClosure)
+    n.children = params
+    n.left = body
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+/// coreBlock is a block used as an expression. Statements go in
+/// `children`; the tail expression (if any) goes in `left` and
+/// contributes the block's overall type.
+pub fn coreBlock(arena: CoreArena, stmts: List<Int>, tail: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkBlock)
+    n.children = stmts
+    n.left = tail
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreIf(
+    arena: CoreArena,
+    cond: Int,
+    then_: Int,
+    else_: Int,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkIf)
+    n.left = cond
+    n.right = then_
+    n.extra = else_
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreIfLet(
+    arena: CoreArena,
+    pattern: Int,
+    scrutinee: Int,
+    then_: Int,
+    else_: Int,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkIfLet)
+    n.left = scrutinee
+    n.right = then_
+    n.extra = else_
+    n.children = [pattern]
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreMatch(
+    arena: CoreArena,
+    scrutinee: Int,
+    arms: List<Int>,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkMatch)
+    n.left = scrutinee
+    n.children = arms
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+/// coreMatchArm stores the pattern in `left`, the optional guard in
+/// `right` (-1 when absent), and the body in `extra`. Match arm nodes
+/// inherit their body's type so parent `CkMatch` can join the arm
+/// types.
+pub fn coreMatchArm(
+    arena: CoreArena,
+    pattern: Int,
+    guard: Int,
+    body: Int,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CkMatchArm)
+    n.left = pattern
+    n.right = guard
+    n.extra = body
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Statements ----
+
+pub fn coreLetStmt(
+    arena: CoreArena,
+    pattern: Int,
+    value: Int,
+    mutable: Bool,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CsLet)
+    n.left = pattern
+    n.right = value
+    n.flags = if mutable { 1 } else { 0 }
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreAssignStmt(arena: CoreArena, targets: List<Int>, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsAssign)
+    n.children = targets
+    n.left = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreReturnStmt(arena: CoreArena, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsReturn)
+    n.left = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreBreakStmt(arena: CoreArena, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsBreak)
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreContinueStmt(arena: CoreArena, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsContinue)
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreIfStmt(arena: CoreArena, cond: Int, then_: Int, else_: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsIf)
+    n.left = cond
+    n.right = then_
+    n.extra = else_
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+/// coreForStmt covers `for`/`while`/`for-in` uniformly. `pattern` is
+/// -1 for `while`/infinite loops, the iteration binding otherwise;
+/// `iter` is -1 for infinite, a condition expression for `while`, and
+/// an iterable expression for `for-in`. `flags` encodes the variety:
+/// 0 = infinite, 1 = while, 2 = for-in.
+pub fn coreForStmt(
+    arena: CoreArena,
+    pattern: Int,
+    iter: Int,
+    body: Int,
+    variety: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CsFor)
+    n.left = pattern
+    n.right = iter
+    n.extra = body
+    n.flags = variety
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreMatchStmt(arena: CoreArena, scrutinee: Int, arms: List<Int>, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsMatch)
+    n.left = scrutinee
+    n.children = arms
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreExprStmt(arena: CoreArena, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsExprStmt)
+    n.left = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreDeferStmt(arena: CoreArena, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsDefer)
+    n.left = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreChanSendStmt(arena: CoreArena, channel: Int, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsChanSend)
+    n.left = channel
+    n.right = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreStmtBlock(arena: CoreArena, stmts: List<Int>, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsBlock)
+    n.children = stmts
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Decls ----
+
+/// coreFnDecl records a top-level function declaration. `params` are
+/// CdParam arena indices; `body` is a CsBlock/CkBlock (may be -1 for
+/// interface methods). `ty` holds the declared function type.
+pub fn coreFnDecl(
+    arena: CoreArena,
+    name: String,
+    owner: String,
+    generics: List<Int>,
+    params: List<Int>,
+    retTy: Int,
+    body: Int,
+    fnTy: Int,
+    isPub: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdFn)
+    n.name = name
+    n.text = name
+    n.owner = owner
+    n.children = params
+    n.children2 = generics
+    n.left = body
+    n.right = retTy
+    n.ty = fnTy
+    n.flags = if isPub { 1 } else { 0 }
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreParam(
+    arena: CoreArena,
+    name: String,
+    ty: Int,
+    defaultValue: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdParam)
+    n.name = name
+    n.text = name
+    n.ty = ty
+    n.left = defaultValue
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreGenericParam(
+    arena: CoreArena,
+    name: String,
+    bounds: List<Int>,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdGenericParam)
+    n.name = name
+    n.text = name
+    n.children = bounds
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreStructDecl(
+    arena: CoreArena,
+    name: String,
+    generics: List<Int>,
+    fields: List<Int>,
+    methods: List<Int>,
+    isPub: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdStruct)
+    n.name = name
+    n.text = name
+    n.children = fields
+    n.children2 = generics
+    n.typeArgs = methods
+    n.flags = if isPub { 1 } else { 0 }
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreFieldDecl(
+    arena: CoreArena,
+    owner: String,
+    name: String,
+    ty: Int,
+    defaultValue: Int,
+    isPub: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdField)
+    n.name = name
+    n.text = name
+    n.owner = owner
+    n.ty = ty
+    n.left = defaultValue
+    n.flags = if isPub { 1 } else { 0 }
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreEnumDecl(
+    arena: CoreArena,
+    name: String,
+    generics: List<Int>,
+    variants: List<Int>,
+    methods: List<Int>,
+    isPub: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdEnum)
+    n.name = name
+    n.text = name
+    n.children = variants
+    n.children2 = generics
+    n.typeArgs = methods
+    n.flags = if isPub { 1 } else { 0 }
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreEnumVariant(
+    arena: CoreArena,
+    owner: String,
+    name: String,
+    payload: List<Int>,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdEnumVariant)
+    n.name = name
+    n.text = name
+    n.owner = owner
+    n.children = payload
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreInterfaceDecl(
+    arena: CoreArena,
+    name: String,
+    generics: List<Int>,
+    extends: List<Int>,
+    methods: List<Int>,
+    isPub: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdInterface)
+    n.name = name
+    n.text = name
+    n.children = methods
+    n.children2 = generics
+    n.typeArgs = extends
+    n.flags = if isPub { 1 } else { 0 }
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreTypeAliasDecl(
+    arena: CoreArena,
+    name: String,
+    generics: List<Int>,
+    target: Int,
+    isPub: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdTypeAlias)
+    n.name = name
+    n.text = name
+    n.children2 = generics
+    n.ty = target
+    n.flags = if isPub { 1 } else { 0 }
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreLetDecl(
+    arena: CoreArena,
+    name: String,
+    ty: Int,
+    value: Int,
+    isPub: Bool,
+    mutable: Bool,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdLet)
+    n.name = name
+    n.text = name
+    n.ty = ty
+    n.left = value
+    n.flags = (if isPub { 1 } else { 0 }) + (if mutable { 2 } else { 0 })
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreUseDecl(
+    arena: CoreArena,
+    path: String,
+    alias: String,
+    body: List<Int>,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CdUse)
+    n.text = path
+    n.name = alias
+    n.children = body
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Patterns ----
+
+pub fn corePatWild(arena: CoreArena, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpWild)
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatIdent(arena: CoreArena, name: String, mutable: Bool, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpIdent)
+    n.name = name
+    n.text = name
+    n.flags = if mutable { 1 } else { 0 }
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatLit(arena: CoreArena, value: Int, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpLit)
+    n.left = value
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatTuple(arena: CoreArena, elems: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpTuple)
+    n.children = elems
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatStruct(
+    arena: CoreArena,
+    owner: String,
+    fields: List<Int>,
+    hasRest: Bool,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CpStruct)
+    n.owner = owner
+    n.name = owner
+    n.children = fields
+    n.flags = if hasRest { 1 } else { 0 }
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatStructField(arena: CoreArena, name: String, value: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpStructField)
+    n.text = name
+    n.name = name
+    n.left = value
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatVariant(
+    arena: CoreArena,
+    owner: String,
+    name: String,
+    fields: List<Int>,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CpVariant)
+    n.owner = owner
+    n.name = name
+    n.text = name
+    n.children = fields
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatRange(arena: CoreArena, lo: Int, hi: Int, inclusive: Bool, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpRange)
+    n.left = lo
+    n.right = hi
+    n.flags = if inclusive { 1 } else { 0 }
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatOr(arena: CoreArena, alts: List<Int>, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpOr)
+    n.children = alts
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatBinding(
+    arena: CoreArena,
+    name: String,
+    inner: Int,
+    mutable: Bool,
+    ty: Int,
+    start: Int,
+    end: Int,
+) -> Int {
+    let mut n = emptyCoreNode(CpBinding)
+    n.name = name
+    n.text = name
+    n.left = inner
+    n.flags = if mutable { 1 } else { 0 }
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn corePatErr(arena: CoreArena, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CpErr)
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// ---- Error nodes ----
+
+pub fn coreErrExpr(arena: CoreArena, ty: Int, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CkErr)
+    n.ty = ty
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+pub fn coreErrStmt(arena: CoreArena, start: Int, end: Int) -> Int {
+    let mut n = emptyCoreNode(CsErr)
+    n.start = start
+    n.end = end
+    coreArenaAdd(arena, n)
+}
+
+// =====================================================================
+// Accessors. Callers read fields through these so field aliasing stays
+// private to this module.
+// =====================================================================
+
+pub fn coreKindAt(arena: CoreArena, idx: Int) -> CoreKind {
+    coreArenaNodeAt(arena, idx).kind
+}
+
+pub fn coreTyAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).ty
+}
+
+pub fn coreStartAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).start
+}
+
+pub fn coreEndAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).end
+}
+
+pub fn coreTextAt(arena: CoreArena, idx: Int) -> String {
+    coreArenaNodeAt(arena, idx).text
+}
+
+pub fn coreNameAt(arena: CoreArena, idx: Int) -> String {
+    coreArenaNodeAt(arena, idx).name
+}
+
+pub fn coreOwnerAt(arena: CoreArena, idx: Int) -> String {
+    coreArenaNodeAt(arena, idx).owner
+}
+
+pub fn coreLeftAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).left
+}
+
+pub fn coreRightAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).right
+}
+
+pub fn coreExtraAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).extra
+}
+
+pub fn coreValueAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).value
+}
+
+pub fn coreFlagsAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).flags
+}
+
+pub fn coreChildrenAt(arena: CoreArena, idx: Int) -> List<Int> {
+    coreArenaNodeAt(arena, idx).children
+}
+
+pub fn coreChildren2At(arena: CoreArena, idx: Int) -> List<Int> {
+    coreArenaNodeAt(arena, idx).children2
+}
+
+pub fn coreTypeArgsAt(arena: CoreArena, idx: Int) -> List<Int> {
+    coreArenaNodeAt(arena, idx).typeArgs
+}
+
+// ---- Bool helpers ----
+
+pub fn coreBoolLitValueAt(arena: CoreArena, idx: Int) -> Bool {
+    coreArenaNodeAt(arena, idx).value != 0
+}
+
+pub fn coreLetMutableAt(arena: CoreArena, idx: Int) -> Bool {
+    coreArenaNodeAt(arena, idx).flags != 0
+}
+
+pub fn coreStructSpreadAt(arena: CoreArena, idx: Int) -> Int {
+    coreArenaNodeAt(arena, idx).extra
+}
+
+// =====================================================================
+// Enum integer codecs.
+// =====================================================================
+
+fn identKindToInt(kind: IdentKind) -> Int {
+    match kind {
+        IkUnknown -> 0,
+        IkLocal -> 1,
+        IkParam -> 2,
+        IkFn -> 3,
+        IkVariant -> 4,
+        IkTypeName -> 5,
+        IkGlobal -> 6,
+        IkBuiltin -> 7,
+    }
+}
+
+pub fn coreIdentKindAt(arena: CoreArena, idx: Int) -> IdentKind {
+    identKindFromInt(coreArenaNodeAt(arena, idx).flags)
+}
+
+fn identKindFromInt(n: Int) -> IdentKind {
+    if n == 1 { return IkLocal }
+    if n == 2 { return IkParam }
+    if n == 3 { return IkFn }
+    if n == 4 { return IkVariant }
+    if n == 5 { return IkTypeName }
+    if n == 6 { return IkGlobal }
+    if n == 7 { return IkBuiltin }
+    IkUnknown
+}
+
+fn binOpToInt(op: BinOp) -> Int {
+    match op {
+        BoAdd -> 1,
+        BoSub -> 2,
+        BoMul -> 3,
+        BoDiv -> 4,
+        BoMod -> 5,
+        BoEq -> 6,
+        BoNe -> 7,
+        BoLt -> 8,
+        BoLe -> 9,
+        BoGt -> 10,
+        BoGe -> 11,
+        BoAnd -> 12,
+        BoOr -> 13,
+        BoBitAnd -> 14,
+        BoBitOr -> 15,
+        BoBitXor -> 16,
+        BoShl -> 17,
+        BoShr -> 18,
+        BoInvalid -> 0,
+    }
+}
+
+pub fn coreBinaryOpAt(arena: CoreArena, idx: Int) -> BinOp {
+    binOpFromInt(coreArenaNodeAt(arena, idx).value)
+}
+
+fn binOpFromInt(n: Int) -> BinOp {
+    if n == 1 { return BoAdd }
+    if n == 2 { return BoSub }
+    if n == 3 { return BoMul }
+    if n == 4 { return BoDiv }
+    if n == 5 { return BoMod }
+    if n == 6 { return BoEq }
+    if n == 7 { return BoNe }
+    if n == 8 { return BoLt }
+    if n == 9 { return BoLe }
+    if n == 10 { return BoGt }
+    if n == 11 { return BoGe }
+    if n == 12 { return BoAnd }
+    if n == 13 { return BoOr }
+    if n == 14 { return BoBitAnd }
+    if n == 15 { return BoBitOr }
+    if n == 16 { return BoBitXor }
+    if n == 17 { return BoShl }
+    if n == 18 { return BoShr }
+    BoInvalid
+}
+
+fn unOpToInt(op: UnOp) -> Int {
+    match op {
+        UoNeg -> 1,
+        UoPlus -> 2,
+        UoNot -> 3,
+        UoBitNot -> 4,
+        UoInvalid -> 0,
+    }
+}
+
+pub fn coreUnaryOpAt(arena: CoreArena, idx: Int) -> UnOp {
+    unOpFromInt(coreArenaNodeAt(arena, idx).value)
+}
+
+fn unOpFromInt(n: Int) -> UnOp {
+    if n == 1 { return UoNeg }
+    if n == 2 { return UoPlus }
+    if n == 3 { return UoNot }
+    if n == 4 { return UoBitNot }
+    UoInvalid
+}
+
+pub fn binOpSymbol(op: BinOp) -> String {
+    match op {
+        BoAdd -> "+",
+        BoSub -> "-",
+        BoMul -> "*",
+        BoDiv -> "/",
+        BoMod -> "%",
+        BoEq -> "==",
+        BoNe -> "!=",
+        BoLt -> "<",
+        BoLe -> "<=",
+        BoGt -> ">",
+        BoGe -> ">=",
+        BoAnd -> "&&",
+        BoOr -> "||",
+        BoBitAnd -> "&",
+        BoBitOr -> "|",
+        BoBitXor -> "^",
+        BoShl -> "<<",
+        BoShr -> ">>",
+        BoInvalid -> "?",
+    }
+}
+
+pub fn unOpSymbol(op: UnOp) -> String {
+    match op {
+        UoNeg -> "-",
+        UoPlus -> "+",
+        UoNot -> "!",
+        UoBitNot -> "~",
+        UoInvalid -> "?",
+    }
+}
+
+pub fn coreKindName(kind: CoreKind) -> String {
+    match kind {
+        CkErr -> "Err",
+        CkIntLit -> "IntLit",
+        CkFloatLit -> "FloatLit",
+        CkBoolLit -> "BoolLit",
+        CkCharLit -> "CharLit",
+        CkByteLit -> "ByteLit",
+        CkStringLit -> "StringLit",
+        CkUnitLit -> "UnitLit",
+        CkIdent -> "Ident",
+        CkUnary -> "Unary",
+        CkBinary -> "Binary",
+        CkCoalesce -> "Coalesce",
+        CkQuestion -> "Question",
+        CkCall -> "Call",
+        CkMethodCall -> "MethodCall",
+        CkIntrinsic -> "Intrinsic",
+        CkVariantLit -> "VariantLit",
+        CkField -> "Field",
+        CkTupleAccess -> "TupleAccess",
+        CkIndex -> "Index",
+        CkList -> "List",
+        CkMap -> "Map",
+        CkMapEntry -> "MapEntry",
+        CkTuple -> "Tuple",
+        CkStruct -> "Struct",
+        CkStructField -> "StructField",
+        CkRange -> "Range",
+        CkClosure -> "Closure",
+        CkBlock -> "Block",
+        CkIf -> "If",
+        CkIfLet -> "IfLet",
+        CkMatch -> "Match",
+        CkMatchArm -> "MatchArm",
+        CsBlock -> "StmtBlock",
+        CsLet -> "LetStmt",
+        CsAssign -> "AssignStmt",
+        CsReturn -> "ReturnStmt",
+        CsBreak -> "BreakStmt",
+        CsContinue -> "ContinueStmt",
+        CsIf -> "IfStmt",
+        CsFor -> "ForStmt",
+        CsMatch -> "MatchStmt",
+        CsExprStmt -> "ExprStmt",
+        CsDefer -> "DeferStmt",
+        CsChanSend -> "ChanSendStmt",
+        CsErr -> "ErrStmt",
+        CdFn -> "FnDecl",
+        CdStruct -> "StructDecl",
+        CdEnum -> "EnumDecl",
+        CdEnumVariant -> "EnumVariant",
+        CdInterface -> "InterfaceDecl",
+        CdTypeAlias -> "TypeAliasDecl",
+        CdLet -> "LetDecl",
+        CdUse -> "UseDecl",
+        CdField -> "Field",
+        CdParam -> "Param",
+        CdGenericParam -> "GenericParam",
+        CpWild -> "WildPat",
+        CpIdent -> "IdentPat",
+        CpLit -> "LitPat",
+        CpTuple -> "TuplePat",
+        CpStruct -> "StructPat",
+        CpStructField -> "StructPatField",
+        CpVariant -> "VariantPat",
+        CpRange -> "RangePat",
+        CpOr -> "OrPat",
+        CpBinding -> "BindingPat",
+        CpErr -> "ErrPat",
+    }
+}
+
+// =====================================================================
+// Pretty-printer — stable S-expression-like form used for debugging and
+// for snapshot tests. Mirrors the shape of `internal/ir/print.go` so
+// the Go-side harness can diff before/after Core migrations.
+// =====================================================================
+
+pub fn corePrintModule(m: CoreModule, tys: TyArena) -> String {
+    let mut parts: List<String> = []
+    parts.push("(module {m.packageName}")
+    for decl in m.decls {
+        parts.push("  {corePrintNode(m.arena, tys, decl, 1)}")
+    }
+    if coreIntLen(m.script) > 0 {
+        parts.push("  (script")
+        for stmt in m.script {
+            parts.push("    {corePrintNode(m.arena, tys, stmt, 2)}")
+        }
+        parts.push("  )")
+    }
+    if coreDiagCount(m.diagnostics) > 0 {
+        parts.push("  (diagnostics")
+        for d in m.diagnostics {
+            parts.push("    {checkDiagRender(d)}")
+        }
+        parts.push("  )")
+    }
+    parts.push(")")
+    strings.join(parts, "\n")
+}
+
+pub fn corePrintNode(arena: CoreArena, tys: TyArena, idx: Int, depth: Int) -> String {
+    if idx < 0 {
+        return "_"
+    }
+    let node = coreArenaNodeAt(arena, idx)
+    let head = coreKindName(node.kind)
+    let tyText = if node.ty >= 0 { ":" } else { "" }
+    let tyRendered = if node.ty >= 0 { tyToString(tys, node.ty) } else { "" }
+    let annotated = if node.ty >= 0 {
+        "({head}{tyText}{tyRendered}"
+    } else {
+        "({head}"
+    }
+    let body = corePrintNodeBody(arena, tys, node, depth)
+    if body == "" {
+        "{annotated})"
+    } else {
+        "{annotated} {body})"
+    }
+}
+
+fn corePrintNodeBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    match node.kind {
+        CkIntLit -> node.text,
+        CkFloatLit -> node.text,
+        CkBoolLit -> if node.value == 0 { "false" } else { "true" },
+        CkCharLit -> "#{node.value}",
+        CkByteLit -> "b#{node.value}",
+        CkStringLit -> "\"{node.text}\"",
+        CkUnitLit -> "",
+        CkIdent -> node.name,
+        CkUnary -> "{unOpSymbol(unOpFromInt(node.value))} {corePrintNode(arena, tys, node.left, depth + 1)}",
+        CkBinary -> "{binOpSymbol(binOpFromInt(node.value))} {corePrintNode(arena, tys, node.left, depth + 1)} {corePrintNode(arena, tys, node.right, depth + 1)}",
+        CkCoalesce -> "?? {corePrintNode(arena, tys, node.left, depth + 1)} {corePrintNode(arena, tys, node.right, depth + 1)}",
+        CkQuestion -> corePrintNode(arena, tys, node.left, depth + 1),
+        CkCall -> corePrintCallBody(arena, tys, node, depth),
+        CkMethodCall -> corePrintMethodCallBody(arena, tys, node, depth),
+        CkIntrinsic -> corePrintIntrinsicBody(arena, tys, node, depth),
+        CkVariantLit -> corePrintVariantBody(arena, tys, node, depth),
+        CkField -> "{corePrintNode(arena, tys, node.left, depth + 1)} .{node.name}",
+        CkTupleAccess -> "{corePrintNode(arena, tys, node.left, depth + 1)} .{node.value}",
+        CkIndex -> "{corePrintNode(arena, tys, node.left, depth + 1)} [{corePrintNode(arena, tys, node.right, depth + 1)}]",
+        CkList -> corePrintList(arena, tys, node.children, depth),
+        CkMap -> corePrintList(arena, tys, node.children, depth),
+        CkMapEntry -> "{corePrintNode(arena, tys, node.left, depth + 1)} => {corePrintNode(arena, tys, node.right, depth + 1)}",
+        CkTuple -> corePrintList(arena, tys, node.children, depth),
+        CkStruct -> corePrintStructBody(arena, tys, node, depth),
+        CkStructField -> "{node.name}: {corePrintNode(arena, tys, node.left, depth + 1)}",
+        CkRange -> corePrintRangeBody(arena, tys, node, depth),
+        CkClosure -> corePrintClosureBody(arena, tys, node, depth),
+        CkBlock -> corePrintBlockBody(arena, tys, node, depth),
+        CkIf -> corePrintIfBody(arena, tys, node, depth),
+        CkIfLet -> corePrintIfLetBody(arena, tys, node, depth),
+        CkMatch -> corePrintMatchBody(arena, tys, node, depth),
+        CkMatchArm -> corePrintMatchArmBody(arena, tys, node, depth),
+        CsLet -> corePrintLetStmtBody(arena, tys, node, depth),
+        CsAssign -> corePrintAssignBody(arena, tys, node, depth),
+        CsReturn -> corePrintNode(arena, tys, node.left, depth + 1),
+        CsExprStmt -> corePrintNode(arena, tys, node.left, depth + 1),
+        CsBreak -> "",
+        CsContinue -> "",
+        CdFn -> corePrintFnDeclBody(arena, tys, node, depth),
+        CdStruct -> "{node.name}",
+        CdEnum -> "{node.name}",
+        CdInterface -> "{node.name}",
+        CdTypeAlias -> "{node.name} = {tyToString(tys, node.ty)}",
+        CdLet -> "{node.name} : {tyToString(tys, node.ty)} = {corePrintNode(arena, tys, node.left, depth + 1)}",
+        CdUse -> "\"{node.text}\" as {node.name}",
+        CdParam -> "{node.name}: {tyToString(tys, node.ty)}",
+        CpWild -> "_",
+        CpIdent -> node.name,
+        CpLit -> corePrintNode(arena, tys, node.left, depth + 1),
+        CpTuple -> corePrintList(arena, tys, node.children, depth),
+        CpVariant -> "{node.owner}.{node.name} {corePrintList(arena, tys, node.children, depth)}",
+        CpBinding -> "{node.name} @ {corePrintNode(arena, tys, node.left, depth + 1)}",
+        _ -> "",
+    }
+}
+
+fn corePrintCallBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let callee = corePrintNode(arena, tys, node.left, depth + 1)
+    let args = corePrintList(arena, tys, node.children, depth)
+    let ta = corePrintTypeArgs(tys, node.typeArgs)
+    "{callee}{ta} {args}"
+}
+
+fn corePrintMethodCallBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let recv = corePrintNode(arena, tys, node.left, depth + 1)
+    let args = corePrintList(arena, tys, node.children, depth)
+    let ta = corePrintTypeArgs(tys, node.typeArgs)
+    "{recv}.{node.name}{ta} {args}"
+}
+
+fn corePrintIntrinsicBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let args = corePrintList(arena, tys, node.children, depth)
+    "@{node.name} {args}"
+}
+
+fn corePrintVariantBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let args = corePrintList(arena, tys, node.children, depth)
+    let ta = corePrintTypeArgs(tys, node.typeArgs)
+    "{node.owner}.{node.name}{ta} {args}"
+}
+
+fn corePrintStructBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let fields = corePrintList(arena, tys, node.children, depth)
+    let spread = if node.extra >= 0 {
+        " ..{corePrintNode(arena, tys, node.extra, depth + 1)}"
+    } else {
+        ""
+    }
+    "{node.owner}{corePrintTypeArgs(tys, node.typeArgs)} {fields}{spread}"
+}
+
+fn corePrintRangeBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let op = if node.flags == 1 { "..=" } else { ".." }
+    let lo = if node.left >= 0 { corePrintNode(arena, tys, node.left, depth + 1) } else { "_" }
+    let hi = if node.right >= 0 { corePrintNode(arena, tys, node.right, depth + 1) } else { "_" }
+    "{lo} {op} {hi}"
+}
+
+fn corePrintClosureBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let params = corePrintList(arena, tys, node.children, depth)
+    let body = corePrintNode(arena, tys, node.left, depth + 1)
+    "|{params}| {body}"
+}
+
+fn corePrintBlockBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let stmts = corePrintList(arena, tys, node.children, depth)
+    let tail = if node.left >= 0 {
+        " -> {corePrintNode(arena, tys, node.left, depth + 1)}"
+    } else {
+        ""
+    }
+    "{stmts}{tail}"
+}
+
+fn corePrintIfBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let cond = corePrintNode(arena, tys, node.left, depth + 1)
+    let then_ = corePrintNode(arena, tys, node.right, depth + 1)
+    let else_ = if node.extra >= 0 {
+        " else {corePrintNode(arena, tys, node.extra, depth + 1)}"
+    } else {
+        ""
+    }
+    "{cond} then {then_}{else_}"
+}
+
+fn corePrintIfLetBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let patList = node.children
+    let patIdx = if coreIntLen(patList) > 0 { patList[0] } else { -1 }
+    let pat = corePrintNode(arena, tys, patIdx, depth + 1)
+    let scrutinee = corePrintNode(arena, tys, node.left, depth + 1)
+    let then_ = corePrintNode(arena, tys, node.right, depth + 1)
+    let else_ = if node.extra >= 0 {
+        " else {corePrintNode(arena, tys, node.extra, depth + 1)}"
+    } else {
+        ""
+    }
+    "let {pat} = {scrutinee} then {then_}{else_}"
+}
+
+fn corePrintMatchBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let scrutinee = corePrintNode(arena, tys, node.left, depth + 1)
+    let arms = corePrintList(arena, tys, node.children, depth)
+    "{scrutinee} {arms}"
+}
+
+fn corePrintMatchArmBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let pat = corePrintNode(arena, tys, node.left, depth + 1)
+    let guard = if node.right >= 0 {
+        " if {corePrintNode(arena, tys, node.right, depth + 1)}"
+    } else {
+        ""
+    }
+    let body = corePrintNode(arena, tys, node.extra, depth + 1)
+    "{pat}{guard} -> {body}"
+}
+
+fn corePrintLetStmtBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let pat = corePrintNode(arena, tys, node.left, depth + 1)
+    let value = corePrintNode(arena, tys, node.right, depth + 1)
+    let mutWord = if node.flags == 0 { "" } else { "mut " }
+    "{mutWord}{pat} = {value}"
+}
+
+fn corePrintAssignBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let targets = corePrintList(arena, tys, node.children, depth)
+    let value = corePrintNode(arena, tys, node.left, depth + 1)
+    "{targets} <- {value}"
+}
+
+fn corePrintFnDeclBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let _ = depth
+    let params = corePrintList(arena, tys, node.children, depth)
+    let retType = if node.right >= 0 {
+        tyToString(tys, node.right)
+    } else {
+        "()"
+    }
+    "{node.name}{params} -> {retType}"
+}
+
+fn corePrintList(arena: CoreArena, tys: TyArena, items: List<Int>, depth: Int) -> String {
+    let mut parts: List<String> = []
+    for it in items {
+        parts.push(corePrintNode(arena, tys, it, depth + 1))
+    }
+    "[{strings.join(parts, \", \")}]"
+}
+
+fn corePrintTypeArgs(tys: TyArena, args: List<Int>) -> String {
+    if coreIntLen(args) == 0 {
+        return ""
+    }
+    let mut parts: List<String> = []
+    for a in args {
+        parts.push(tyToString(tys, a))
+    }
+    "::<{strings.join(parts, \", \")}>"
+}
+
+fn coreIntLen(xs: List<Int>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+fn coreDiagCount(xs: List<CheckDiagnostic>) -> Int {
+    let mut n = 0
+    for d in xs {
+        let _ = d
+        n = n + 1
+    }
+    n
+}

--- a/toolchain/core_test.osty
+++ b/toolchain/core_test.osty
@@ -1,0 +1,147 @@
+// core_test.osty — unit tests for the Core IR arena. Validates that
+// hand-built trees round-trip through `corePrintNode` / `corePrintModule`
+// with stable labels and that accessors return what the constructors
+// stored. Orphan harness until the toolchain native tests land.
+
+use std.testing
+use std.strings as strings
+
+fn testCoreArenaHoldsLiterals() {
+    let tys = emptyTyArena()
+    let ca = emptyCoreArena()
+
+    let intLit = coreIntLit(ca, "42", tInt(tys), 0, 2)
+    testing.assertEq(coreKindAt(ca, intLit), CkIntLit)
+    testing.assertEq(coreTextAt(ca, intLit), "42")
+    testing.assertEq(coreTyAt(ca, intLit), tInt(tys))
+    testing.assertEq(coreStartAt(ca, intLit), 0)
+    testing.assertEq(coreEndAt(ca, intLit), 2)
+
+    let trueLit = coreBoolLit(ca, true, tBool(tys), 3, 7)
+    testing.assertEq(coreKindAt(ca, trueLit), CkBoolLit)
+    testing.assert(coreBoolLitValueAt(ca, trueLit))
+
+    let falseLit = coreBoolLit(ca, false, tBool(tys), 10, 15)
+    testing.assert(!(coreBoolLitValueAt(ca, falseLit)))
+}
+
+fn testCoreArenaBinaryShape() {
+    let tys = emptyTyArena()
+    let ca = emptyCoreArena()
+
+    let left = coreIntLit(ca, "1", tInt(tys), 0, 1)
+    let right = coreIntLit(ca, "2", tInt(tys), 4, 5)
+    let add = coreBinary(ca, BoAdd, left, right, tInt(tys), 0, 5)
+
+    testing.assertEq(coreKindAt(ca, add), CkBinary)
+    testing.assertEq(coreLeftAt(ca, add), left)
+    testing.assertEq(coreRightAt(ca, add), right)
+    match coreBinaryOpAt(ca, add) {
+        BoAdd -> testing.assert(true),
+        _ -> testing.assert(false),
+    }
+}
+
+fn testCoreArenaCallThreadsTypeArgs() {
+    let tys = emptyTyArena()
+    let ca = emptyCoreArena()
+
+    let id = coreIdent(ca, "id", IkFn, tFn(tys, [tInt(tys)], tInt(tys)), 0, 2)
+    let arg = coreIntLit(ca, "1", tInt(tys), 5, 6)
+    let call = coreCall(ca, id, [arg], [tInt(tys)], tInt(tys), 0, 8)
+
+    testing.assertEq(coreKindAt(ca, call), CkCall)
+    testing.assertEq(coreLeftAt(ca, call), id)
+    let children = coreChildrenAt(ca, call)
+    testing.assertEq(coreIntListLen(children), 1)
+    testing.assertEq(children[0], arg)
+
+    let ta = coreTypeArgsAt(ca, call)
+    testing.assertEq(coreIntListLen(ta), 1)
+    testing.assertEq(ta[0], tInt(tys))
+}
+
+fn testCorePrintModuleRendersHeader() {
+    let tys = emptyTyArena()
+    let mut module = emptyCoreModule("main")
+    // one let decl: `let answer: Int = 42`
+    let value = coreIntLit(module.arena, "42", tInt(tys), 0, 2)
+    let decl = coreLetDecl(module.arena, "answer", tInt(tys), value, false, false, 0, 20)
+    module.decls.push(decl)
+
+    let rendered = corePrintModule(module, tys)
+    testing.assert(strings.contains(rendered, "(module main"))
+    testing.assert(strings.contains(rendered, "LetDecl"))
+    testing.assert(strings.contains(rendered, "answer"))
+}
+
+fn testCoreIdentKindRoundTrip() {
+    let tys = emptyTyArena()
+    let ca = emptyCoreArena()
+
+    let local = coreIdent(ca, "x", IkLocal, tInt(tys), 0, 1)
+    match coreIdentKindAt(ca, local) {
+        IkLocal -> testing.assert(true),
+        _ -> testing.assert(false),
+    }
+
+    let fnIdent = coreIdent(ca, "len", IkFn, tInt(tys), 2, 5)
+    match coreIdentKindAt(ca, fnIdent) {
+        IkFn -> testing.assert(true),
+        _ -> testing.assert(false),
+    }
+
+    let variantIdent = coreIdent(ca, "Some", IkVariant, tInt(tys), 6, 10)
+    match coreIdentKindAt(ca, variantIdent) {
+        IkVariant -> testing.assert(true),
+        _ -> testing.assert(false),
+    }
+}
+
+fn testCorePatternShapes() {
+    let tys = emptyTyArena()
+    let ca = emptyCoreArena()
+
+    let wild = corePatWild(ca, 0, 1)
+    testing.assertEq(coreKindAt(ca, wild), CpWild)
+
+    let x = corePatIdent(ca, "x", false, tInt(tys), 3, 4)
+    testing.assertEq(coreKindAt(ca, x), CpIdent)
+    testing.assertEq(coreNameAt(ca, x), "x")
+
+    let some = corePatVariant(ca, "Option", "Some", [x], tInt(tys), 6, 12)
+    testing.assertEq(coreKindAt(ca, some), CpVariant)
+    testing.assertEq(coreOwnerAt(ca, some), "Option")
+    testing.assertEq(coreNameAt(ca, some), "Some")
+    let kids = coreChildrenAt(ca, some)
+    testing.assertEq(coreIntListLen(kids), 1)
+    testing.assertEq(kids[0], x)
+}
+
+fn testCoreForStmtVarietyFlag() {
+    let tys = emptyTyArena()
+    let ca = emptyCoreArena()
+
+    let body = coreStmtBlock(ca, [], 0, 2)
+    let infinite = coreForStmt(ca, -1, -1, body, 0, 0, 30)
+    testing.assertEq(coreFlagsAt(ca, infinite), 0)
+
+    let cond = coreBoolLit(ca, true, tBool(tys), 0, 4)
+    let whileStmt = coreForStmt(ca, -1, cond, body, 1, 0, 30)
+    testing.assertEq(coreFlagsAt(ca, whileStmt), 1)
+}
+
+fn coreIntListLen(xs: List<Int>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+/// tFn is a thin wrapper used only in this test file — mirrors the
+/// `tyFn` helper that `ty.osty` exports.
+fn tFn(arena: TyArena, params: List<Int>, ret: Int) -> Int {
+    tyFn(arena, params, ret)
+}

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1,0 +1,1864 @@
+// elab.osty — bidirectional elaborator producing typed Core IR.
+//
+// Phase 6 of the migration covers the base layer: literals, idents,
+// unary/binary operators, blocks, `let` statements. Later phases add
+// calls + struct literals + closures + list/map/tuple + field/index
+// (Phase 7) and if/match/patterns + question + variants (Phase 8).
+//
+// The elaborator exposes two mutually-recursive entry points:
+//
+//   fn elabInfer(cx, idx) -> ElabResult
+//     — synthesize a type from the expression. Used when the context
+//       has no expectation.
+//
+//   fn elabCheck(cx, idx, expected) -> ElabResult
+//     — verify the expression against `expected`. Used when the
+//       context provides a type (let with annotation, fn return, call
+//       argument, if-branch, struct-field initializer, ...).
+//
+// Delegation rules:
+//
+//   1. Introduction forms (literals, closures, tuples, lists, maps,
+//      struct lits) prefer `elabCheck` when `expected` is informative;
+//      the form's construction uses `expected` to refine internal
+//      types (untyped literal → target numeric, tuple → per-elem T).
+//
+//   2. Elimination forms (calls, field access, index, method call)
+//      prefer `elabInfer`; the receiver/callee synthesizes a type and
+//      the post-inference subtyping is applied against `expected`.
+//
+//   3. `elabCheck(cx, e, T)` default: if there is no specialised rule,
+//      `let r = elabInfer(cx, e); subtype(r.ty, T); return r`.
+//
+//   4. `expected == tErr(tys)` propagates silently.
+
+use std.strings as strings
+
+/// ElabResult is the output of every expression-level elaboration
+/// step: a fresh Core arena index plus the type that Core node
+/// carries. Callers thread results directly into builders
+/// (`coreCall`, `coreIf`, ...) without consulting side tables.
+pub struct ElabResult {
+    pub node: Int,
+    pub ty: Int,
+}
+
+/// ElabCx owns the entire per-file state: the typed `CheckEnv`, the
+/// Core arena under construction, the flow context (fn name, return
+/// type, inLoop), and the shared string-interning surface used by the
+/// pretty-printer.
+///
+/// A single `ElabCx` is threaded through one `CoreModule` lowering. The
+/// constraint solver attached to the elaborator is scoped *per call
+/// site* — each generic call allocates a fresh `Solver`, unifies, then
+/// discards.
+pub struct ElabCx {
+    pub ast: AstFile,
+    pub core: CoreArena,
+    pub env: CheckEnv,
+}
+
+pub fn newElabCx(ast: AstFile, tys: TyArena) -> ElabCx {
+    let env = emptyCheckEnv(tys)
+    checkInstallPrelude(env)
+    ElabCx {
+        ast,
+        core: emptyCoreArena(),
+        env,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Expression elaboration.
+// ---------------------------------------------------------------------
+
+pub fn elabInfer(cx: ElabCx, idx: Int) -> ElabResult {
+    if idx < 0 {
+        return elabErrResult(cx, 0, 0)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    match node.kind {
+        AstNIntLit -> elabInferIntLit(cx, node),
+        AstNFloatLit -> elabInferFloatLit(cx, node),
+        AstNStringLit -> elabInferStringLit(cx, node),
+        AstNBoolLit -> elabInferBoolLit(cx, node),
+        AstNCharLit -> elabInferCharLit(cx, node),
+        AstNByteLit -> elabInferByteLit(cx, node),
+        AstNIdent -> elabInferIdent(cx, node),
+        AstNParen -> elabInfer(cx, node.left),
+        AstNBlock -> elabInferBlock(cx, idx, node),
+        AstNUnary -> elabInferUnary(cx, node),
+        AstNBinary -> elabInferBinary(cx, node),
+        AstNCall -> elabInferCall(cx, idx, node, tErr(cx.env.tys)),
+        AstNField -> elabInferField(cx, node),
+        AstNIndex -> elabInferIndex(cx, node),
+        AstNList -> elabInferList(cx, node, tErr(cx.env.tys)),
+        AstNMap -> elabInferMap(cx, node, tErr(cx.env.tys)),
+        AstNTuple -> elabInferTuple(cx, node, tErr(cx.env.tys)),
+        AstNStructLit -> elabInferStructLit(cx, node, tErr(cx.env.tys)),
+        AstNClosure -> elabInferClosure(cx, node, tErr(cx.env.tys)),
+        AstNRange -> elabInferRange(cx, node),
+        AstNTurbofish -> elabInferTurbofish(cx, node),
+        AstNIf -> elabInferIf(cx, node, tErr(cx.env.tys)),
+        AstNMatch -> elabInferMatch(cx, node, tErr(cx.env.tys)),
+        AstNQuestion -> elabInferQuestion(cx, node),
+        _ -> elabErrResult(cx, node.start, node.end),
+    }
+}
+
+pub fn elabCheck(cx: ElabCx, idx: Int, expected: Int) -> ElabResult {
+    if idx < 0 {
+        return elabErrResult(cx, 0, 0)
+    }
+    if tyIsErr(cx.env.tys, expected) {
+        return elabInfer(cx, idx)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    match node.kind {
+        AstNIntLit -> elabCheckIntLit(cx, node, expected),
+        AstNFloatLit -> elabCheckFloatLit(cx, node, expected),
+        AstNParen -> elabCheck(cx, node.left, expected),
+        AstNBlock -> elabCheckBlock(cx, idx, node, expected),
+        AstNIdent -> elabCheckViaInfer(cx, idx, expected),
+        AstNCall -> elabInferCall(cx, idx, node, expected),
+        AstNList -> elabInferList(cx, node, expected),
+        AstNMap -> elabInferMap(cx, node, expected),
+        AstNTuple -> elabInferTuple(cx, node, expected),
+        AstNStructLit -> elabInferStructLit(cx, node, expected),
+        AstNClosure -> elabInferClosure(cx, node, expected),
+        AstNIf -> elabInferIf(cx, node, expected),
+        AstNMatch -> elabInferMatch(cx, node, expected),
+        _ -> elabCheckViaInfer(cx, idx, expected),
+    }
+}
+
+/// elabCheckViaInfer is the default `check(e, T)` rule: elaborate as
+/// infer, then subtype against `T` and emit a mismatch diagnostic if
+/// needed.
+fn elabCheckViaInfer(cx: ElabCx, idx: Int, expected: Int) -> ElabResult {
+    let r = elabInfer(cx, idx)
+    if !(tyIsErr(cx.env.tys, r.ty)) {
+        let start = coreStartAt(cx.core, r.node)
+        let end = coreEndAt(cx.core, r.node)
+        let _ = checkExpectAssignable(cx.env, expected, r.ty, start, end)
+    }
+    r
+}
+
+// ---------------------------------------------------------------------
+// Literals.
+// ---------------------------------------------------------------------
+
+fn elabInferIntLit(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = tUntypedInt(cx.env.tys)
+    let coreIdx = coreIntLit(cx.core, node.text, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn elabInferFloatLit(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = tUntypedFloat(cx.env.tys)
+    let coreIdx = coreFloatLit(cx.core, node.text, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn elabInferStringLit(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = tString(cx.env.tys)
+    let coreIdx = coreStringLit(cx.core, node.text, [], ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn elabInferBoolLit(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = tBool(cx.env.tys)
+    let value = node.text == "true"
+    let coreIdx = coreBoolLit(cx.core, value, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn elabInferCharLit(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = tChar(cx.env.tys)
+    let coreIdx = coreCharLit(cx.core, 0, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn elabInferByteLit(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = tByte(cx.env.tys)
+    let coreIdx = coreByteLit(cx.core, 0, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+/// elabCheckIntLit specialises integer literal handling: when the
+/// expectation is a concrete numeric type the literal takes that type
+/// directly (rather than landing at `UntypedInt` and relying on a
+/// subsequent subtyping step).
+fn elabCheckIntLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let resolved = checkResolveAliasDeep(cx.env, expected)
+    if tyIsInteger(tys, resolved) || tyIsFloat(tys, resolved) {
+        let coreIdx = coreIntLit(cx.core, node.text, resolved, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: resolved }
+    }
+    // Fall back to infer-then-subtype; subtype logic emits the
+    // mismatch against the expected type.
+    let inferred = elabInferIntLit(cx, node)
+    let _ = checkExpectAssignable(cx.env, expected, inferred.ty, node.start, node.end)
+    inferred
+}
+
+fn elabCheckFloatLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let resolved = checkResolveAliasDeep(cx.env, expected)
+    if tyIsFloat(tys, resolved) {
+        let coreIdx = coreFloatLit(cx.core, node.text, resolved, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: resolved }
+    }
+    let inferred = elabInferFloatLit(cx, node)
+    let _ = checkExpectAssignable(cx.env, expected, inferred.ty, node.start, node.end)
+    inferred
+}
+
+// ---------------------------------------------------------------------
+// Ident.
+// ---------------------------------------------------------------------
+
+fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
+    let ty = checkLookup(cx.env, node.text)
+    if ty >= 0 {
+        let coreIdx = coreIdent(cx.core, node.text, IkLocal, ty, node.start, node.end)
+        return ElabResult { node: coreIdx, ty }
+    }
+    // Unknown local — try top-level fn.
+    let fnSig = checkLookupFn(cx.env, node.text, "")
+    if fnSig.name != "" {
+        let fnTy = fnSigToTy(cx.env, fnSig)
+        let coreIdx = coreIdent(cx.core, node.text, IkFn, fnTy, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: fnTy }
+    }
+    // Fall through — unknown name.
+    cx.env.diagnostics.push(diagUnknownName(node.text, node.start, node.end))
+    elabErrResult(cx, node.start, node.end)
+}
+
+/// fnSigToTy builds an `fn(params) -> ret` type from a CheckFnSig.
+fn fnSigToTy(env: CheckEnv, sig: CheckFnSig) -> Int {
+    tyFn(env.tys, sig.paramTys, sig.retTy)
+}
+
+// ---------------------------------------------------------------------
+// Unary operators.
+// ---------------------------------------------------------------------
+
+fn elabInferUnary(cx: ElabCx, node: AstNode) -> ElabResult {
+    let inner = elabInfer(cx, node.left)
+    let innerTy = checkResolveAliasDeep(cx.env, inner.ty)
+    let op = tokenToUnOp(node.op)
+    let ty = unOpResultType(cx.env, op, innerTy, node.start, node.end)
+    let coreIdx = coreUnary(cx.core, op, inner.node, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn unOpResultType(env: CheckEnv, op: UnOp, inner: Int, start: Int, end: Int) -> Int {
+    let tys = env.tys
+    if tyIsErr(tys, inner) {
+        return inner
+    }
+    match op {
+        UoNot -> {
+            if tyEq(tys, inner, tBool(tys)) {
+                return tBool(tys)
+            }
+            env.diagnostics.push(diagOperandType("!", tyToString(tys, inner), start, end))
+            tErr(tys)
+        },
+        UoNeg -> {
+            if tyIsNumeric(tys, inner) {
+                return inner
+            }
+            env.diagnostics.push(diagOperandType("-", tyToString(tys, inner), start, end))
+            tErr(tys)
+        },
+        UoPlus -> {
+            if tyIsNumeric(tys, inner) {
+                return inner
+            }
+            env.diagnostics.push(diagOperandType("+", tyToString(tys, inner), start, end))
+            tErr(tys)
+        },
+        UoBitNot -> {
+            if tyIsInteger(tys, inner) {
+                return inner
+            }
+            env.diagnostics.push(diagOperandType("~", tyToString(tys, inner), start, end))
+            tErr(tys)
+        },
+        UoInvalid -> tErr(tys),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Binary operators.
+// ---------------------------------------------------------------------
+
+fn elabInferBinary(cx: ElabCx, node: AstNode) -> ElabResult {
+    let op = tokenToBinOp(node.op)
+    // `??` has special checking for Option unwrap.
+    if binOpIsCoalesce(op) {
+        return elabCoalesce(cx, node)
+    }
+    let left = elabInfer(cx, node.left)
+    let right = elabInfer(cx, node.right)
+    let leftTy = checkResolveAliasDeep(cx.env, left.ty)
+    let rightTy = checkResolveAliasDeep(cx.env, right.ty)
+    let ty = binOpResultType(cx.env, op, leftTy, rightTy, node.start, node.end)
+    let coreIdx = coreBinary(cx.core, op, left.node, right.node, ty, node.start, node.end)
+    ElabResult { node: coreIdx, ty }
+}
+
+fn binOpResultType(env: CheckEnv, op: BinOp, left: Int, right: Int, start: Int, end: Int) -> Int {
+    let tys = env.tys
+    if tyIsErr(tys, left) || tyIsErr(tys, right) {
+        return tErr(tys)
+    }
+    match op {
+        BoEq -> binBoolCompatible(env, left, right, start, end),
+        BoNe -> binBoolCompatible(env, left, right, start, end),
+        BoLt -> binOrderedCompatible(env, left, right, start, end),
+        BoLe -> binOrderedCompatible(env, left, right, start, end),
+        BoGt -> binOrderedCompatible(env, left, right, start, end),
+        BoGe -> binOrderedCompatible(env, left, right, start, end),
+        BoAnd -> binBoolOnly(env, left, right, start, end),
+        BoOr -> binBoolOnly(env, left, right, start, end),
+        BoBitAnd -> binIntCommon(env, left, right, start, end),
+        BoBitOr -> binIntCommon(env, left, right, start, end),
+        BoBitXor -> binIntCommon(env, left, right, start, end),
+        BoShl -> binIntCommon(env, left, right, start, end),
+        BoShr -> binIntCommon(env, left, right, start, end),
+        BoAdd -> binNumericCommon(env, left, right, start, end),
+        BoSub -> binNumericCommon(env, left, right, start, end),
+        BoMul -> binNumericCommon(env, left, right, start, end),
+        BoDiv -> binNumericCommon(env, left, right, start, end),
+        BoMod -> binNumericCommon(env, left, right, start, end),
+        BoInvalid -> tErr(tys),
+    }
+}
+
+fn binBoolCompatible(env: CheckEnv, left: Int, right: Int, start: Int, end: Int) -> Int {
+    if checkIsAssignable(env, left, right) || checkIsAssignable(env, right, left) {
+        return tBool(env.tys)
+    }
+    env.diagnostics.push(diagMismatch(tyToString(env.tys, left), tyToString(env.tys, right), start, end))
+    tErr(env.tys)
+}
+
+fn binOrderedCompatible(env: CheckEnv, left: Int, right: Int, start: Int, end: Int) -> Int {
+    if tyIsOrdered(env.tys, left) &&
+        (checkIsAssignable(env, left, right) || checkIsAssignable(env, right, left)) {
+        return tBool(env.tys)
+    }
+    env.diagnostics.push(diagOperandType("<", tyToString(env.tys, left), start, end))
+    tErr(env.tys)
+}
+
+fn binBoolOnly(env: CheckEnv, left: Int, right: Int, start: Int, end: Int) -> Int {
+    let tys = env.tys
+    if tyEq(tys, left, tBool(tys)) && tyEq(tys, right, tBool(tys)) {
+        return tBool(tys)
+    }
+    env.diagnostics.push(diagOperandType("&&", tyToString(tys, left), start, end))
+    tErr(tys)
+}
+
+fn binIntCommon(env: CheckEnv, left: Int, right: Int, start: Int, end: Int) -> Int {
+    let tys = env.tys
+    if !(tyIsInteger(tys, left)) || !(tyIsInteger(tys, right)) {
+        env.diagnostics.push(diagOperandType("&|^<<>>", tyToString(tys, left), start, end))
+        return tErr(tys)
+    }
+    if tyEq(tys, left, tUntypedInt(tys)) {
+        return right
+    }
+    left
+}
+
+fn binNumericCommon(env: CheckEnv, left: Int, right: Int, start: Int, end: Int) -> Int {
+    let tys = env.tys
+    if !(tyIsNumeric(tys, left)) || !(tyIsNumeric(tys, right)) {
+        env.diagnostics.push(diagOperandType("+-*/%", tyToString(tys, left), start, end))
+        return tErr(tys)
+    }
+    // Float dominates.
+    if tyIsFloat(tys, left) || tyIsFloat(tys, right) {
+        if tyEq(tys, left, tUntypedFloat(tys)) && tyEq(tys, right, tUntypedFloat(tys)) {
+            return tUntypedFloat(tys)
+        }
+        return tFloat(tys)
+    }
+    if tyEq(tys, left, tInt(tys)) || tyEq(tys, right, tInt(tys)) {
+        return tInt(tys)
+    }
+    tUntypedInt(tys)
+}
+
+fn binOpIsCoalesce(op: BinOp) -> Bool {
+    match op {
+        BoInvalid -> false,
+        _ -> false,
+    }
+}
+
+/// elabCoalesce is reserved for a dedicated `??` binary-like node; the
+/// base phase still routes through `AstNBinary` with a pseudo-op, so
+/// this branch is a placeholder that will fire in Phase 7 once the
+/// AST carries a distinct token for the operator.
+fn elabCoalesce(cx: ElabCx, node: AstNode) -> ElabResult {
+    let left = elabInfer(cx, node.left)
+    let right = elabInfer(cx, node.right)
+    let leftTy = checkResolveAliasDeep(cx.env, left.ty)
+    let tys = cx.env.tys
+    if tyIsNamedHead(tys, leftTy, "Option") {
+        let inner = if checkIntListLenHelper(tyArgsAt(tys, leftTy)) > 0 {
+            tyArgsAt(tys, leftTy)[0]
+        } else {
+            tErr(tys)
+        }
+        let _ = checkExpectAssignable(cx.env, inner, right.ty, node.start, node.end)
+        let coreIdx = coreCoalesce(cx.core, left.node, right.node, inner, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: inner }
+    }
+    cx.env.diagnostics.push(diagOperandType("??", tyToString(tys, leftTy), node.start, node.end))
+    elabErrResult(cx, node.start, node.end)
+}
+
+// ---------------------------------------------------------------------
+// Blocks.
+// ---------------------------------------------------------------------
+
+fn elabInferBlock(cx: ElabCx, idx: Int, node: AstNode) -> ElabResult {
+    let mark = checkScopeMark(cx.env)
+    let mut stmts: List<Int> = []
+    let mut tailNode = -1
+    let mut tailTy = tUnit(cx.env.tys)
+    let _ = idx
+
+    let stmtIdxs = node.children
+    let n = checkIntListLenHelper(stmtIdxs)
+    let mut i = 0
+    for stmtIdx in stmtIdxs {
+        let isTail = i == n - 1
+        if isTail && astIsExprKindAt(cx.ast, stmtIdx) {
+            let tail = elabInfer(cx, stmtIdx)
+            tailNode = tail.node
+            tailTy = tail.ty
+        } else {
+            let s = elabStmt(cx, stmtIdx)
+            if s >= 0 {
+                stmts.push(s)
+            }
+        }
+        i = i + 1
+    }
+
+    checkScopeDrop(cx.env, mark)
+
+    let coreIdx = coreBlock(cx.core, stmts, tailNode, tailTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: tailTy }
+}
+
+fn elabCheckBlock(cx: ElabCx, idx: Int, node: AstNode, expected: Int) -> ElabResult {
+    let mark = checkScopeMark(cx.env)
+    let mut stmts: List<Int> = []
+    let mut tailNode = -1
+    let mut tailTy = tUnit(cx.env.tys)
+    let _ = idx
+
+    let stmtIdxs = node.children
+    let n = checkIntListLenHelper(stmtIdxs)
+    let mut i = 0
+    for stmtIdx in stmtIdxs {
+        let isTail = i == n - 1
+        if isTail && astIsExprKindAt(cx.ast, stmtIdx) {
+            let tail = elabCheck(cx, stmtIdx, expected)
+            tailNode = tail.node
+            tailTy = tail.ty
+        } else {
+            let s = elabStmt(cx, stmtIdx)
+            if s >= 0 {
+                stmts.push(s)
+            }
+        }
+        i = i + 1
+    }
+
+    checkScopeDrop(cx.env, mark)
+
+    let coreIdx = coreBlock(cx.core, stmts, tailNode, tailTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: tailTy }
+}
+
+// ---------------------------------------------------------------------
+// Statement elaboration.
+// ---------------------------------------------------------------------
+
+pub fn elabStmt(cx: ElabCx, idx: Int) -> Int {
+    if idx < 0 {
+        return -1
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    match node.kind {
+        AstNLet -> elabLetStmt(cx, node),
+        AstNReturn -> elabReturnStmt(cx, node),
+        AstNExprStmt -> elabExprStmt(cx, node),
+        AstNBreak -> coreBreakStmt(cx.core, node.start, node.end),
+        AstNContinue -> coreContinueStmt(cx.core, node.start, node.end),
+        _ -> elabExprAsStmt(cx, idx, node),
+    }
+}
+
+fn elabExprAsStmt(cx: ElabCx, idx: Int, node: AstNode) -> Int {
+    // Expression statement without explicit marker — infer and wrap.
+    let r = elabInfer(cx, idx)
+    coreExprStmt(cx.core, r.node, node.start, node.end)
+}
+
+fn elabLetStmt(cx: ElabCx, node: AstNode) -> Int {
+    let patIdx = node.left
+    let typeAnnotIdx = node.extra       // legacy AST layout: extra holds annotation
+    let valueIdx = node.right
+    let mutable = node.flags == 1
+    let declared = astTypeToTy(cx, typeAnnotIdx)
+    let value = if declared >= 0 {
+        elabCheck(cx, valueIdx, declared)
+    } else {
+        elabInfer(cx, valueIdx)
+    }
+    let effectiveTy = if declared >= 0 { declared } else { value.ty }
+
+    // For Phase 6 we only handle simple identifier patterns; compound
+    // patterns (tuple/struct destructuring) land in Phase 8.
+    let name = astPatternBindingName(cx.ast, patIdx)
+    if name != "" {
+        checkBindSpan(cx.env, name, effectiveTy, mutable, node.start, node.end)
+        checkRecordBinding(cx.env, patIdx, name, effectiveTy, mutable, node.start, node.end)
+    }
+
+    let patNode = if name != "" {
+        corePatIdent(cx.core, name, mutable, effectiveTy, node.start, node.end)
+    } else {
+        corePatErr(cx.core, node.start, node.end)
+    }
+    coreLetStmt(cx.core, patNode, value.node, mutable, effectiveTy, node.start, node.end)
+}
+
+fn elabReturnStmt(cx: ElabCx, node: AstNode) -> Int {
+    let expected = cx.env.returnTy
+    let valueIdx = node.left
+    let value = if valueIdx >= 0 && !(tyIsErr(cx.env.tys, expected)) {
+        elabCheck(cx, valueIdx, expected)
+    } else if valueIdx >= 0 {
+        elabInfer(cx, valueIdx)
+    } else {
+        let unit = coreUnitLit(cx.core, tUnit(cx.env.tys), node.start, node.end)
+        ElabResult { node: unit, ty: tUnit(cx.env.tys) }
+    }
+    coreReturnStmt(cx.core, value.node, node.start, node.end)
+}
+
+fn elabExprStmt(cx: ElabCx, node: AstNode) -> Int {
+    let r = elabInfer(cx, node.left)
+    coreExprStmt(cx.core, r.node, node.start, node.end)
+}
+
+// ---------------------------------------------------------------------
+// AST helpers.
+// ---------------------------------------------------------------------
+
+/// astIsExprKindAt classifies whether a child AST node is an
+/// expression — used to decide whether the trailing statement of a
+/// block contributes the block's overall type.
+fn astIsExprKindAt(ast: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = astArenaNodeAt(ast.arena, idx)
+    match node.kind {
+        AstNIntLit -> true,
+        AstNFloatLit -> true,
+        AstNStringLit -> true,
+        AstNBoolLit -> true,
+        AstNCharLit -> true,
+        AstNByteLit -> true,
+        AstNIdent -> true,
+        AstNParen -> true,
+        AstNBlock -> true,
+        AstNUnary -> true,
+        AstNBinary -> true,
+        AstNIf -> true,
+        AstNMatch -> true,
+        AstNCall -> true,
+        AstNField -> true,
+        AstNIndex -> true,
+        AstNList -> true,
+        AstNMap -> true,
+        AstNTuple -> true,
+        AstNStructLit -> true,
+        AstNRange -> true,
+        AstNClosure -> true,
+        AstNQuestion -> true,
+        AstNTurbofish -> true,
+        _ -> false,
+    }
+}
+
+/// astTypeToTy materialises an AST type node into the typed arena.
+/// Returns -1 when `idx` is negative. Unknown heads fall back to
+/// `tyNamed` — the surrounding context is expected to decide whether
+/// that is an error.
+fn astTypeToTy(cx: ElabCx, idx: Int) -> Int {
+    if idx < 0 {
+        return -1
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind != AstNType {
+        return -1
+    }
+    // The legacy checker lowers AST type text through
+    // `frontCheckTypeName`; during the transition we round-trip the
+    // same textual form through the Ty bridge so Phase 6 does not need
+    // a parallel type-node lowerer.
+    let rendered = astTypeRendered(cx.ast, node)
+    if rendered == "" {
+        return -1
+    }
+    tyFromString(cx.env.tys, rendered)
+}
+
+/// astTypeRendered reconstructs the textual form of an AST type node
+/// using its `text` field when present, or the legacy
+/// `frontCheckTypeName` helper otherwise.
+fn astTypeRendered(ast: AstFile, node: AstNode) -> String {
+    if node.text != "" {
+        return node.text
+    }
+    let _ = ast
+    ""
+}
+
+/// astPatternBindingName extracts the identifier name from a simple
+/// pattern `AstNPattern` node. Returns the empty string when the
+/// pattern is compound — Phase 8 supersedes this with a full pattern
+/// lowerer.
+fn astPatternBindingName(ast: AstFile, idx: Int) -> String {
+    if idx < 0 {
+        return ""
+    }
+    let node = astArenaNodeAt(ast.arena, idx)
+    if node.kind != AstNPattern {
+        return ""
+    }
+    node.text
+}
+
+// ---------------------------------------------------------------------
+// Operator mapping from parser tokens to Core enums.
+// ---------------------------------------------------------------------
+
+fn tokenToUnOp(tok: FrontTokenKind) -> UnOp {
+    if tok == FrontNot { return UoNot }
+    if tok == FrontMinus { return UoNeg }
+    if tok == FrontPlus { return UoPlus }
+    if tok == FrontBitNot { return UoBitNot }
+    UoInvalid
+}
+
+fn tokenToBinOp(tok: FrontTokenKind) -> BinOp {
+    if tok == FrontPlus { return BoAdd }
+    if tok == FrontMinus { return BoSub }
+    if tok == FrontStar { return BoMul }
+    if tok == FrontSlash { return BoDiv }
+    if tok == FrontPercent { return BoMod }
+    if tok == FrontEq { return BoEq }
+    if tok == FrontNeq { return BoNe }
+    if tok == FrontLt { return BoLt }
+    if tok == FrontLeq { return BoLe }
+    if tok == FrontGt { return BoGt }
+    if tok == FrontGeq { return BoGe }
+    if tok == FrontAnd { return BoAnd }
+    if tok == FrontOr { return BoOr }
+    if tok == FrontBitAnd { return BoBitAnd }
+    if tok == FrontBitOr { return BoBitOr }
+    if tok == FrontBitXor { return BoBitXor }
+    if tok == FrontShl { return BoShl }
+    if tok == FrontShr { return BoShr }
+    BoInvalid
+}
+
+// ---------------------------------------------------------------------
+// Errors / empties.
+// ---------------------------------------------------------------------
+
+fn elabErrResult(cx: ElabCx, start: Int, end: Int) -> ElabResult {
+    let ty = tErr(cx.env.tys)
+    let node = coreErrExpr(cx.core, ty, start, end)
+    ElabResult { node, ty }
+}
+
+fn checkIntListLenHelper(xs: List<Int>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+fn checkIntListAt(xs: List<Int>, idx: Int) -> Int {
+    let mut i = 0
+    for x in xs {
+        if i == idx {
+            return x
+        }
+        i = i + 1
+    }
+    -1
+}
+
+// =====================================================================
+// Phase 7 — calls, struct literals, closures, list/map/tuple, field,
+// index, range, turbofish.
+// =====================================================================
+
+// ---------------------------------------------------------------------
+// Call. The call path is the primary consumer of the local constraint
+// solver: every generic call allocates fresh TyVars for the callee's
+// generics, unifies the supplied argument types against the
+// parameters, and zonks the return type.
+// ---------------------------------------------------------------------
+
+fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> ElabResult {
+    // Callee can be:
+    //   - a bare ident (top-level fn)
+    //   - a turbofish expression (Ident::<T, ...>)
+    //   - a field expression on a value (method call)
+    //   - a package/namespace field expression (`pkg.fn`)
+    let calleeIdx = node.left
+    let argIdxs = node.children
+    if calleeIdx < 0 {
+        return elabErrResult(cx, node.start, node.end)
+    }
+    let callee = astArenaNodeAt(cx.ast.arena, calleeIdx)
+    if callee.kind == AstNField {
+        return elabInferMethodCall(cx, node, callee, expected)
+    }
+
+    // Turbofish: callee is `AstNTurbofish { left = base, children = typeArgs }`.
+    let mut explicitArgs: List<Int> = []
+    let mut baseCallee = callee
+    let mut baseIdx = calleeIdx
+    if callee.kind == AstNTurbofish {
+        explicitArgs = elabCollectTypeArgs(cx, callee.children)
+        baseIdx = callee.left
+        if baseIdx >= 0 {
+            baseCallee = astArenaNodeAt(cx.ast.arena, baseIdx)
+        }
+    }
+
+    if baseCallee.kind != AstNIdent {
+        // Fall back to fn-value call: infer the callee's type and treat
+        // it as an erased `fn(...)` shape.
+        return elabInferFnValueCall(cx, node, argIdxs, expected)
+    }
+
+    let sig = checkLookupFn(cx.env, baseCallee.text, "")
+    if sig.name == "" {
+        cx.env.diagnostics.push(diagUnknownName(baseCallee.text, baseCallee.start, baseCallee.end))
+        return elabErrResult(cx, node.start, node.end)
+    }
+
+    let solver = newSolver()
+    let freshs = elabFreshenGenerics(cx, solver, sig.generics, sig.name)
+
+    // Seed expected type into the solver if it shapes the return.
+    if !(tyIsErr(cx.env.tys, expected)) {
+        let specialisedRet = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
+        let _ = unify(cx.env, solver, specialisedRet, expected)
+    }
+
+    // Respect explicit turbofish args if supplied.
+    if checkIntListLenHelper(explicitArgs) == checkIntListLenHelper(freshs) {
+        let mut i = 0
+        for explicit in explicitArgs {
+            let fresh = checkIntListAt(freshs, i)
+            let _ = unify(cx.env, solver, fresh, explicit)
+            i = i + 1
+        }
+    }
+
+    let coreFn = coreIdent(cx.core, baseCallee.text, IkFn, fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
+    let coreArgs = elabCallArgs(cx, solver, sig, freshs, argIdxs, node.start, node.end)
+
+    let retSubstituted = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
+    let retTy = zonk(cx.env, solver, retSubstituted)
+
+    // Verify every type parameter is now resolved.
+    elabReportUnresolvedGenerics(cx, solver, sig, freshs, node.start, node.end)
+
+    // Record instantiation for the bridge summary.
+    let typeArgsConcrete = zonkList(cx.env, solver, freshs)
+    if checkIntListLenHelper(typeArgsConcrete) > 0 {
+        checkRecordInstantiation(cx.env, callIdx, sig.name, typeArgsConcrete, retTy, node.start, node.end)
+    }
+
+    let coreCallNode = coreCall(cx.core, coreFn, coreArgs, typeArgsConcrete, retTy, node.start, node.end)
+    checkRecordTypedNode(cx.env, callIdx, "Call", retTy, node.start, node.end)
+    ElabResult { node: coreCallNode, ty: retTy }
+}
+
+/// elabInferMethodCall handles `recv.method(args)`. Relies on
+/// `checkLookupMethod` with the receiver's head type.
+fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expected: Int) -> ElabResult {
+    let recv = elabInfer(cx, fieldNode.left)
+    let recvResolved = checkResolveAliasDeep(cx.env, recv.ty)
+    let ownerName = tyHeadAt(cx.env.tys, recvResolved)
+    let methodName = fieldNode.text
+    let sig = checkLookupMethod(cx.env, ownerName, methodName)
+    if sig.name == "" {
+        cx.env.diagnostics.push(diagUnknownMethod(ownerName, methodName, fieldNode.start, fieldNode.end))
+        return elabErrResult(cx, callNode.start, callNode.end)
+    }
+
+    let solver = newSolver()
+    let freshs = elabFreshenGenerics(cx, solver, sig.generics, "{ownerName}.{sig.name}")
+
+    // Bind the receiver type params against the receiver's concrete args.
+    let typeSig = checkLookupType(cx.env, ownerName)
+    let ownerArgs = tyArgsAt(cx.env.tys, recvResolved)
+    if checkIntListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {
+        let mut i = 0
+        for ownerGeneric in typeSig.generics {
+            let freshIdx = elabFindFresh(freshs, sig.generics, ownerGeneric)
+            if freshIdx >= 0 {
+                let _ = unify(cx.env, solver, checkIntListAt(freshs, freshIdx), checkIntListAt(ownerArgs, i))
+            }
+            i = i + 1
+        }
+    }
+
+    if !(tyIsErr(cx.env.tys, expected)) {
+        let specialisedRet = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
+        let _ = unify(cx.env, solver, specialisedRet, expected)
+    }
+
+    let coreArgs = elabCallArgs(cx, solver, sig, freshs, callNode.children, callNode.start, callNode.end)
+    let retSubstituted = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
+    let retTy = zonk(cx.env, solver, retSubstituted)
+    elabReportUnresolvedGenerics(cx, solver, sig, freshs, callNode.start, callNode.end)
+
+    let typeArgsConcrete = zonkList(cx.env, solver, freshs)
+    if checkIntListLenHelper(typeArgsConcrete) > 0 {
+        checkRecordInstantiation(cx.env, -1, "{ownerName}.{sig.name}", typeArgsConcrete, retTy, callNode.start, callNode.end)
+    }
+
+    let mcall = coreMethodCall(
+        cx.core,
+        recv.node,
+        methodName,
+        ownerName,
+        coreArgs,
+        typeArgsConcrete,
+        retTy,
+        callNode.start,
+        callNode.end,
+    )
+    ElabResult { node: mcall, ty: retTy }
+}
+
+/// elabInferFnValueCall is the fallback when the callee is a
+/// first-class function value (ident resolves to an `fn(...) -> R`
+/// type). No generic inference is performed — `fn(...)` values carry
+/// no type-parameter metadata after erasure.
+fn elabInferFnValueCall(cx: ElabCx, node: AstNode, argIdxs: List<Int>, expected: Int) -> ElabResult {
+    let _ = expected
+    let callee = elabInfer(cx, node.left)
+    let fnTy = checkResolveAliasDeep(cx.env, callee.ty)
+    if tyKindAt(cx.env.tys, fnTy) != TkFn {
+        cx.env.diagnostics.push(diagNotCallable(tyToString(cx.env.tys, fnTy), node.start, node.end))
+        return elabErrResult(cx, node.start, node.end)
+    }
+    let paramTys = tyArgsAt(cx.env.tys, fnTy)
+    let retTy = tyRetAt(cx.env.tys, fnTy)
+    let wantCount = checkIntListLenHelper(paramTys)
+    let gotCount = checkIntListLenHelper(argIdxs)
+    if wantCount != gotCount {
+        cx.env.diagnostics.push(diagArgCount("", wantCount, gotCount, node.start, node.end))
+    }
+    let mut coreArgs: List<Int> = []
+    let mut i = 0
+    for argIdx in argIdxs {
+        if i < wantCount {
+            let r = elabCheck(cx, argIdx, checkIntListAt(paramTys, i))
+            coreArgs.push(r.node)
+        } else {
+            let r = elabInfer(cx, argIdx)
+            coreArgs.push(r.node)
+        }
+        i = i + 1
+    }
+    let coreCallNode = coreCall(cx.core, callee.node, coreArgs, [], retTy, node.start, node.end)
+    ElabResult { node: coreCallNode, ty: retTy }
+}
+
+/// elabCallArgs runs the bidirectional loop over a call's arguments:
+/// for each arg, compute the substituted parameter type from the
+/// current solver state, check the arg against it, then unify the
+/// argument's inferred type back into the solver.
+fn elabCallArgs(
+    cx: ElabCx,
+    solver: Solver,
+    sig: CheckFnSig,
+    freshs: List<Int>,
+    argIdxs: List<Int>,
+    start: Int,
+    end: Int,
+) -> List<Int> {
+    let wantCount = checkIntListLenHelper(sig.paramTys)
+    let gotCount = checkIntListLenHelper(argIdxs)
+    if wantCount != gotCount {
+        cx.env.diagnostics.push(diagArgCount(sig.name, wantCount, gotCount, start, end))
+    }
+    let mut coreArgs: List<Int> = []
+    let mut i = 0
+    for argIdx in argIdxs {
+        if i >= wantCount {
+            let r = elabInfer(cx, argIdx)
+            coreArgs.push(r.node)
+            i = i + 1
+            continue
+        }
+        let rawWant = checkIntListAt(sig.paramTys, i)
+        let specialisedWant = checkSubstituteTy(cx.env, rawWant, sig.generics, freshs)
+        let hint = zonk(cx.env, solver, specialisedWant)
+        let r = elabCheck(cx, argIdx, hint)
+        let _ = unify(cx.env, solver, hint, r.ty)
+        coreArgs.push(r.node)
+        i = i + 1
+    }
+    coreArgs
+}
+
+/// elabFreshenGenerics allocates one TyVar per generic in `generics`,
+/// binding them in the solver for later unification.
+fn elabFreshenGenerics(cx: ElabCx, solver: Solver, generics: List<String>, owner: String) -> List<Int> {
+    let _ = solver
+    let mut out: List<Int> = []
+    for name in generics {
+        out.push(freshTyVar(cx.env.tys, owner, name))
+    }
+    out
+}
+
+fn elabFindFresh(freshs: List<Int>, generics: List<String>, name: String) -> Int {
+    let mut i = 0
+    for g in generics {
+        if g == name {
+            return i
+        }
+        i = i + 1
+    }
+    let _ = freshs
+    -1
+}
+
+fn elabReportUnresolvedGenerics(
+    cx: ElabCx,
+    solver: Solver,
+    sig: CheckFnSig,
+    freshs: List<Int>,
+    start: Int,
+    end: Int,
+) {
+    let mut i = 0
+    for fresh in freshs {
+        let z = zonk(cx.env, solver, fresh)
+        if !(isFullyResolved(cx.env, solver, z)) {
+            let name = checkIntListAt(stringIndicesForGenerics(sig.generics), i)
+            let _ = name
+            let gname = stringAt(sig.generics, i)
+            cx.env.diagnostics.push(diagCannotInferTyParam(gname, sig.name, start, end))
+        }
+        i = i + 1
+    }
+}
+
+fn stringAt(xs: List<String>, idx: Int) -> String {
+    let mut i = 0
+    for x in xs {
+        if i == idx {
+            return x
+        }
+        i = i + 1
+    }
+    ""
+}
+
+fn stringIndicesForGenerics(xs: List<String>) -> List<Int> {
+    let mut out: List<Int> = []
+    let mut i = 0
+    for x in xs {
+        let _ = x
+        out.push(i)
+        i = i + 1
+    }
+    out
+}
+
+fn elabCollectTypeArgs(cx: ElabCx, idxs: List<Int>) -> List<Int> {
+    let mut out: List<Int> = []
+    for i in idxs {
+        let ty = astTypeToTy(cx, i)
+        if ty >= 0 {
+            out.push(ty)
+        } else {
+            out.push(tErr(cx.env.tys))
+        }
+    }
+    out
+}
+
+fn elabInferTurbofish(cx: ElabCx, node: AstNode) -> ElabResult {
+    // Turbofish outside a call context is a value reference to a
+    // generic ident; we pass it through as an unevaluated ident for
+    // now — the call path above handles the in-call turbofish case.
+    if node.left < 0 {
+        return elabErrResult(cx, node.start, node.end)
+    }
+    elabInfer(cx, node.left)
+}
+
+// ---------------------------------------------------------------------
+// Field + Index.
+// ---------------------------------------------------------------------
+
+fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
+    let recv = elabInfer(cx, node.left)
+    let recvTy = checkResolveAliasDeep(cx.env, recv.ty)
+    let kind = tyKindAt(cx.env.tys, recvTy)
+    let fieldName = node.text
+    match kind {
+        TkTuple -> {
+            let elems = tyArgsAt(cx.env.tys, recvTy)
+            let idx = parseTupleIndex(fieldName)
+            if idx < 0 || idx >= checkIntListLenHelper(elems) {
+                cx.env.diagnostics.push(diagUnknownField(
+                    tyToString(cx.env.tys, recvTy),
+                    fieldName,
+                    node.start,
+                    node.end,
+                ))
+                return elabErrResult(cx, node.start, node.end)
+            }
+            let elemTy = checkIntListAt(elems, idx)
+            let coreIdx = coreTupleAccess(cx.core, recv.node, idx, elemTy, node.start, node.end)
+            ElabResult { node: coreIdx, ty: elemTy }
+        },
+        TkNamed -> {
+            let owner = tyHeadAt(cx.env.tys, recvTy)
+            let fieldSig = checkLookupField(cx.env, owner, fieldName)
+            if fieldSig.name == "" {
+                cx.env.diagnostics.push(diagUnknownField(owner, fieldName, node.start, node.end))
+                return elabErrResult(cx, node.start, node.end)
+            }
+            // Substitute owner generics.
+            let typeSig = checkLookupType(cx.env, owner)
+            let ownerArgs = tyArgsAt(cx.env.tys, recvTy)
+            let fieldTy = if checkStringListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {
+                checkSubstituteTy(cx.env, fieldSig.ty, typeSig.generics, ownerArgs)
+            } else {
+                fieldSig.ty
+            }
+            let coreIdx = coreField(cx.core, recv.node, fieldName, fieldTy, node.start, node.end)
+            ElabResult { node: coreIdx, ty: fieldTy }
+        },
+        _ -> {
+            cx.env.diagnostics.push(diagUnknownField(
+                tyToString(cx.env.tys, recvTy),
+                fieldName,
+                node.start,
+                node.end,
+            ))
+            elabErrResult(cx, node.start, node.end)
+        },
+    }
+}
+
+fn checkStringListLenHelper(xs: List<String>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}
+
+fn parseTupleIndex(text: String) -> Int {
+    // Osty tuple access uses `.0` / `.1` style; the parser strips the
+    // dot and leaves an integer string.
+    if text == "" {
+        return -1
+    }
+    let mut value = 0
+    let mut any = false
+    for ch in strings.chars(text) {
+        let code = charToDigit(ch)
+        if code < 0 {
+            return -1
+        }
+        value = value * 10 + code
+        any = true
+    }
+    if any { value } else { -1 }
+}
+
+fn charToDigit(ch: Char) -> Int {
+    let s = "{ch}"
+    if s == "0" { return 0 }
+    if s == "1" { return 1 }
+    if s == "2" { return 2 }
+    if s == "3" { return 3 }
+    if s == "4" { return 4 }
+    if s == "5" { return 5 }
+    if s == "6" { return 6 }
+    if s == "7" { return 7 }
+    if s == "8" { return 8 }
+    if s == "9" { return 9 }
+    -1
+}
+
+fn elabInferIndex(cx: ElabCx, node: AstNode) -> ElabResult {
+    let recv = elabInfer(cx, node.left)
+    let idx = elabInfer(cx, node.right)
+    let recvTy = checkResolveAliasDeep(cx.env, recv.ty)
+    let tys = cx.env.tys
+    // List<T>[Int] → T
+    if tyIsNamedHead(tys, recvTy, "List") {
+        let args = tyArgsAt(tys, recvTy)
+        if checkIntListLenHelper(args) == 1 {
+            let elem = checkIntListAt(args, 0)
+            if !(checkIsAssignable(cx.env, tInt(tys), idx.ty)) {
+                cx.env.diagnostics.push(diagMismatch("Int", tyToString(tys, idx.ty), node.start, node.end))
+            }
+            let coreIdx = coreIndex(cx.core, recv.node, idx.node, elem, node.start, node.end)
+            return ElabResult { node: coreIdx, ty: elem }
+        }
+    }
+    // Map<K, V>[K] → V
+    if tyIsNamedHead(tys, recvTy, "Map") {
+        let args = tyArgsAt(tys, recvTy)
+        if checkIntListLenHelper(args) == 2 {
+            let keyTy = checkIntListAt(args, 0)
+            let valTy = checkIntListAt(args, 1)
+            let _ = checkExpectAssignable(cx.env, keyTy, idx.ty, node.start, node.end)
+            let coreIdx = coreIndex(cx.core, recv.node, idx.node, valTy, node.start, node.end)
+            return ElabResult { node: coreIdx, ty: valTy }
+        }
+    }
+    // String[Int] → Char
+    if tyIsPrim(tys, recvTy, PkString) {
+        if !(checkIsAssignable(cx.env, tInt(tys), idx.ty)) {
+            cx.env.diagnostics.push(diagMismatch("Int", tyToString(tys, idx.ty), node.start, node.end))
+        }
+        let coreIdx = coreIndex(cx.core, recv.node, idx.node, tChar(tys), node.start, node.end)
+        return ElabResult { node: coreIdx, ty: tChar(tys) }
+    }
+    cx.env.diagnostics.push(diagUnknownField(tyToString(tys, recvTy), "[]", node.start, node.end))
+    elabErrResult(cx, node.start, node.end)
+}
+
+// ---------------------------------------------------------------------
+// Aggregates.
+// ---------------------------------------------------------------------
+
+fn elabInferList(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let elemIdxs = node.children
+    let n = checkIntListLenHelper(elemIdxs)
+    if n == 0 {
+        let elemHint = if tyIsNamedHead(tys, expected, "List") && checkIntListLenHelper(tyArgsAt(tys, expected)) == 1 {
+            checkIntListAt(tyArgsAt(tys, expected), 0)
+        } else {
+            tErr(tys)
+        }
+        let listTy = tyNamed(tys, "List", [if tyIsErr(tys, elemHint) { tErr(tys) } else { elemHint }])
+        let coreIdx = coreList(cx.core, [], listTy, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: listTy }
+    }
+    // Determine element expectation if the outer expected is List<U>.
+    let outerElem = if tyIsNamedHead(tys, expected, "List") && checkIntListLenHelper(tyArgsAt(tys, expected)) == 1 {
+        checkIntListAt(tyArgsAt(tys, expected), 0)
+    } else {
+        tErr(tys)
+    }
+    let mut coreElems: List<Int> = []
+    let mut elemTy = outerElem
+    let mut i = 0
+    for elemIdx in elemIdxs {
+        if tyIsErr(tys, elemTy) && i == 0 {
+            // Infer from first element.
+            let r = elabInfer(cx, elemIdx)
+            elemTy = r.ty
+            coreElems.push(r.node)
+        } else {
+            let r = elabCheck(cx, elemIdx, elemTy)
+            coreElems.push(r.node)
+        }
+        i = i + 1
+    }
+    let listTy = tyNamed(tys, "List", [elemTy])
+    let coreIdx = coreList(cx.core, coreElems, listTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: listTy }
+}
+
+fn elabInferMap(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let entryIdxs = node.children
+    let expectedArgs = if tyIsNamedHead(tys, expected, "Map") && checkIntListLenHelper(tyArgsAt(tys, expected)) == 2 {
+        tyArgsAt(tys, expected)
+    } else {
+        []
+    }
+    let hasHint = checkIntListLenHelper(expectedArgs) == 2
+    let mut keyTy = if hasHint { checkIntListAt(expectedArgs, 0) } else { tErr(tys) }
+    let mut valTy = if hasHint { checkIntListAt(expectedArgs, 1) } else { tErr(tys) }
+    let mut coreEntries: List<Int> = []
+    let mut first = true
+    for entryIdx in entryIdxs {
+        let entryNode = astArenaNodeAt(cx.ast.arena, entryIdx)
+        let keyIdx = entryNode.left
+        let valIdx = entryNode.right
+        let keyResult = if tyIsErr(tys, keyTy) {
+            let r = elabInfer(cx, keyIdx)
+            if first { keyTy = r.ty }
+            r
+        } else {
+            elabCheck(cx, keyIdx, keyTy)
+        }
+        let valResult = if tyIsErr(tys, valTy) {
+            let r = elabInfer(cx, valIdx)
+            if first { valTy = r.ty }
+            r
+        } else {
+            elabCheck(cx, valIdx, valTy)
+        }
+        let coreEntry = coreMapEntry(cx.core, keyResult.node, valResult.node, entryNode.start, entryNode.end)
+        coreEntries.push(coreEntry)
+        first = false
+    }
+    let mapTy = tyNamed(tys, "Map", [keyTy, valTy])
+    let coreIdx = coreMap(cx.core, coreEntries, mapTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: mapTy }
+}
+
+fn elabInferTuple(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let elemIdxs = node.children
+    let arity = checkIntListLenHelper(elemIdxs)
+    let expectedIsTuple = tyKindAt(tys, expected) == TkTuple
+    let expectedElems = if expectedIsTuple { tyArgsAt(tys, expected) } else { [] }
+    let mut coreElems: List<Int> = []
+    let mut elemTys: List<Int> = []
+    let mut i = 0
+    for elemIdx in elemIdxs {
+        let hint = if expectedIsTuple && i < checkIntListLenHelper(expectedElems) {
+            checkIntListAt(expectedElems, i)
+        } else {
+            tErr(tys)
+        }
+        let r = if tyIsErr(tys, hint) {
+            elabInfer(cx, elemIdx)
+        } else {
+            elabCheck(cx, elemIdx, hint)
+        }
+        coreElems.push(r.node)
+        elemTys.push(r.ty)
+        i = i + 1
+    }
+    if expectedIsTuple && checkIntListLenHelper(expectedElems) != arity {
+        cx.env.diagnostics.push(diagArgCount("", checkIntListLenHelper(expectedElems), arity, node.start, node.end))
+    }
+    let tupleTy = tyTuple(tys, elemTys)
+    let coreIdx = coreTuple(cx.core, coreElems, tupleTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: tupleTy }
+}
+
+// ---------------------------------------------------------------------
+// Struct literal.
+// ---------------------------------------------------------------------
+
+fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let owner = node.text
+    let typeSig = checkLookupType(cx.env, owner)
+    if typeSig.name == "" {
+        cx.env.diagnostics.push(diagUnknownName(owner, node.start, node.end))
+        return elabErrResult(cx, node.start, node.end)
+    }
+
+    let solver = newSolver()
+    let freshs = elabFreshenGenerics(cx, solver, typeSig.generics, owner)
+
+    // Seed from expected if it matches the same owner head.
+    if tyIsNamedHead(tys, expected, owner) {
+        let expectedArgs = tyArgsAt(tys, expected)
+        if checkIntListLenHelper(expectedArgs) == checkIntListLenHelper(freshs) {
+            let mut i = 0
+            for fresh in freshs {
+                let _ = unify(cx.env, solver, fresh, checkIntListAt(expectedArgs, i))
+                i = i + 1
+            }
+        }
+    }
+
+    let mut coreFieldsList: List<Int> = []
+    let mut seenNames: List<String> = []
+    for fieldIdx in node.children {
+        let fieldNode = astArenaNodeAt(cx.ast.arena, fieldIdx)
+        let fieldName = fieldNode.text
+        let fieldSig = checkLookupField(cx.env, owner, fieldName)
+        if fieldSig.name == "" {
+            cx.env.diagnostics.push(diagUnknownField(owner, fieldName, fieldNode.start, fieldNode.end))
+            continue
+        }
+        if stringListContains(seenNames, fieldName) {
+            cx.env.diagnostics.push(diagDuplicateField(owner, fieldName, fieldNode.start, fieldNode.end))
+        }
+        seenNames.push(fieldName)
+
+        let specialised = checkSubstituteTy(cx.env, fieldSig.ty, typeSig.generics, freshs)
+        let hint = zonk(cx.env, solver, specialised)
+        let r = elabCheck(cx, fieldNode.left, hint)
+        let _ = unify(cx.env, solver, hint, r.ty)
+        coreFieldsList.push(coreStructField(cx.core, fieldName, r.node, fieldNode.start, fieldNode.end))
+    }
+
+    // Missing required fields.
+    for f in cx.env.fields {
+        if f.owner == owner && !(stringListContains(seenNames, f.name)) && !(f.hasDefault) {
+            cx.env.diagnostics.push(diagMissingField(owner, f.name, node.start, node.end))
+        }
+    }
+
+    let concreteTypeArgs = zonkList(cx.env, solver, freshs)
+    let resultTy = if checkIntListLenHelper(concreteTypeArgs) == 0 {
+        tyNamed(tys, owner, [])
+    } else {
+        tyNamed(tys, owner, concreteTypeArgs)
+    }
+
+    let coreIdx = coreStruct(cx.core, owner, coreFieldsList, -1, concreteTypeArgs, resultTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: resultTy }
+}
+
+fn stringListContains(xs: List<String>, needle: String) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------
+// Closure.
+// ---------------------------------------------------------------------
+
+fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let expectedIsFn = tyKindAt(tys, expected) == TkFn
+    let expectedParams = if expectedIsFn { tyArgsAt(tys, expected) } else { [] }
+    let expectedRet = if expectedIsFn { tyRetAt(tys, expected) } else { tErr(tys) }
+
+    let paramIdxs = node.children
+    let arity = checkIntListLenHelper(paramIdxs)
+    if expectedIsFn && checkIntListLenHelper(expectedParams) != arity {
+        cx.env.diagnostics.push(diagArgCount("closure", checkIntListLenHelper(expectedParams), arity, node.start, node.end))
+    }
+
+    let mark = checkScopeMark(cx.env)
+    let mut coreParams: List<Int> = []
+    let mut paramTys: List<Int> = []
+    let mut i = 0
+    for paramIdx in paramIdxs {
+        let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)
+        let declaredTy = astTypeToTy(cx, paramNode.right)
+        let paramTy = if declaredTy >= 0 {
+            declaredTy
+        } else if expectedIsFn && i < checkIntListLenHelper(expectedParams) {
+            checkIntListAt(expectedParams, i)
+        } else {
+            cx.env.diagnostics.push(diagClosureAnnotationRequired(paramNode.start, paramNode.end))
+            tErr(tys)
+        }
+        let paramName = paramNode.text
+        if paramName != "" {
+            checkBindSpan(cx.env, paramName, paramTy, false, paramNode.start, paramNode.end)
+        }
+        paramTys.push(paramTy)
+        coreParams.push(coreParam(cx.core, paramName, paramTy, -1, paramNode.start, paramNode.end))
+        i = i + 1
+    }
+
+    let bodyIdx = node.left
+    let body = if !(tyIsErr(tys, expectedRet)) {
+        elabCheck(cx, bodyIdx, expectedRet)
+    } else {
+        elabInfer(cx, bodyIdx)
+    }
+    let retTy = body.ty
+
+    checkScopeDrop(cx.env, mark)
+
+    let closureTy = tyFn(tys, paramTys, retTy)
+    let coreIdx = coreClosure(cx.core, coreParams, body.node, closureTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: closureTy }
+}
+
+// ---------------------------------------------------------------------
+// Range.
+// ---------------------------------------------------------------------
+
+fn elabInferRange(cx: ElabCx, node: AstNode) -> ElabResult {
+    let tys = cx.env.tys
+    let lo = if node.left >= 0 { elabInfer(cx, node.left) } else { ElabResult { node: -1, ty: tInt(tys) } }
+    let hi = if node.right >= 0 { elabInfer(cx, node.right) } else { ElabResult { node: -1, ty: tInt(tys) } }
+    if !(tyIsInteger(tys, lo.ty)) && !(tyIsErr(tys, lo.ty)) {
+        cx.env.diagnostics.push(diagMismatch("Int", tyToString(tys, lo.ty), node.start, node.end))
+    }
+    if !(tyIsInteger(tys, hi.ty)) && !(tyIsErr(tys, hi.ty)) {
+        cx.env.diagnostics.push(diagMismatch("Int", tyToString(tys, hi.ty), node.start, node.end))
+    }
+    // Range result type mirrors the shared operand prim (Int in the
+    // common case; preserve concrete integer when both agree).
+    let elemTy = if tyEq(tys, lo.ty, hi.ty) { lo.ty } else { tInt(tys) }
+    let rangeTy = tyNamed(tys, "Range", [elemTy])
+    let inclusive = node.flags == 1
+    let coreIdx = coreRange(cx.core, lo.node, hi.node, inclusive, rangeTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: rangeTy }
+}
+
+// =====================================================================
+// Phase 8 — control flow (if, match, question) + patterns + variant
+// resolution + simplified exhaustiveness.
+// =====================================================================
+
+// ---------------------------------------------------------------------
+// If.
+// ---------------------------------------------------------------------
+
+fn elabInferIf(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let tys = cx.env.tys
+    let cond = elabCheck(cx, node.left, tBool(tys))
+    let hasExpected = !(tyIsErr(tys, expected))
+
+    let then_ = if hasExpected {
+        elabCheck(cx, node.right, expected)
+    } else {
+        elabInfer(cx, node.right)
+    }
+    let else_ = if node.extra >= 0 {
+        if hasExpected {
+            elabCheck(cx, node.extra, expected)
+        } else {
+            elabCheck(cx, node.extra, then_.ty)
+        }
+    } else {
+        // Missing else branch — synthesize a unit expression.
+        let unit = coreUnitLit(cx.core, tUnit(tys), node.start, node.end)
+        ElabResult { node: unit, ty: tUnit(tys) }
+    }
+
+    let resultTy = if hasExpected {
+        expected
+    } else {
+        joinTypes(cx.env, then_.ty, else_.ty)
+    }
+
+    let elseNode = if node.extra >= 0 { else_.node } else { -1 }
+    let coreIdx = coreIf(cx.core, cond.node, then_.node, elseNode, resultTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: resultTy }
+}
+
+/// joinTypes returns a common supertype of two branch types, falling
+/// back to the first when they are incompatible so downstream
+/// diagnostics stay anchored to the if.
+fn joinTypes(env: CheckEnv, a: Int, b: Int) -> Int {
+    if tyIsErr(env.tys, a) {
+        return b
+    }
+    if tyIsErr(env.tys, b) {
+        return a
+    }
+    if tyEq(env.tys, a, b) {
+        return a
+    }
+    if checkIsAssignable(env, a, b) {
+        return a
+    }
+    if checkIsAssignable(env, b, a) {
+        return b
+    }
+    // Fall back to the first branch; the mismatch will already have
+    // been flagged by the arm's own check if the caller passed an
+    // expectation.
+    a
+}
+
+// ---------------------------------------------------------------------
+// Match.
+// ---------------------------------------------------------------------
+
+fn elabInferMatch(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
+    let scrutinee = elabInfer(cx, node.left)
+    let scrutTy = checkResolveAliasDeep(cx.env, scrutinee.ty)
+    let hasExpected = !(tyIsErr(cx.env.tys, expected))
+
+    let mut armNodes: List<Int> = []
+    let mut resultTy = if hasExpected { expected } else { tErr(cx.env.tys) }
+
+    let mut armIdx = 0
+    for rawArmIdx in node.children {
+        let armNode = astArenaNodeAt(cx.ast.arena, rawArmIdx)
+        let patIdx = armNode.left
+        let guardIdx = armNode.right
+        let bodyIdx = armNode.extra
+
+        let mark = checkScopeMark(cx.env)
+        let pat = elabPattern(cx, patIdx, scrutTy)
+
+        let guardNode = if guardIdx >= 0 {
+            let g = elabCheck(cx, guardIdx, tBool(cx.env.tys))
+            g.node
+        } else {
+            -1
+        }
+
+        let body = if hasExpected {
+            elabCheck(cx, bodyIdx, expected)
+        } else if armIdx == 0 {
+            elabInfer(cx, bodyIdx)
+        } else {
+            elabCheck(cx, bodyIdx, resultTy)
+        }
+        if !hasExpected && armIdx == 0 {
+            resultTy = body.ty
+        }
+
+        checkScopeDrop(cx.env, mark)
+
+        let coreArm = coreMatchArm(cx.core, pat, guardNode, body.node, body.ty, armNode.start, armNode.end)
+        armNodes.push(coreArm)
+        armIdx = armIdx + 1
+    }
+
+    // Basic exhaustiveness: if scrutinee is Bool, require arms to
+    // cover `true` and `false` (or a catch-all); if an enum, require
+    // all variants be covered. Skip when we already emitted a
+    // pattern-shape mismatch.
+    checkExhaustivenessSimple(cx, node, scrutTy)
+
+    let coreIdx = coreMatch(cx.core, scrutinee.node, armNodes, resultTy, node.start, node.end)
+    ElabResult { node: coreIdx, ty: resultTy }
+}
+
+// ---------------------------------------------------------------------
+// Question operator.
+// ---------------------------------------------------------------------
+
+fn elabInferQuestion(cx: ElabCx, node: AstNode) -> ElabResult {
+    let tys = cx.env.tys
+    let inner = elabInfer(cx, node.left)
+    let innerTy = checkResolveAliasDeep(cx.env, inner.ty)
+    let retTy = checkResolveAliasDeep(cx.env, cx.env.returnTy)
+
+    if tyIsNamedHead(tys, innerTy, "Option") {
+        let args = tyArgsAt(tys, innerTy)
+        if checkIntListLenHelper(args) != 1 {
+            return elabErrResult(cx, node.start, node.end)
+        }
+        let payload = checkIntListAt(args, 0)
+        if !(tyIsNamedHead(tys, retTy, "Option")) && !(tyIsErr(tys, retTy)) {
+            cx.env.diagnostics.push(diagQuestionNotOptional(tyToString(tys, retTy), node.start, node.end))
+        }
+        let coreIdx = coreQuestion(cx.core, inner.node, payload, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: payload }
+    }
+
+    if tyIsNamedHead(tys, innerTy, "Result") {
+        let args = tyArgsAt(tys, innerTy)
+        if checkIntListLenHelper(args) != 2 {
+            return elabErrResult(cx, node.start, node.end)
+        }
+        let payload = checkIntListAt(args, 0)
+        let errTy = checkIntListAt(args, 1)
+        if tyIsNamedHead(tys, retTy, "Result") {
+            let retArgs = tyArgsAt(tys, retTy)
+            if checkIntListLenHelper(retArgs) == 2 {
+                let outerErr = checkIntListAt(retArgs, 1)
+                let _ = checkExpectAssignable(cx.env, outerErr, errTy, node.start, node.end)
+            }
+        } else if !(tyIsErr(tys, retTy)) {
+            cx.env.diagnostics.push(diagQuestionNotOptional(tyToString(tys, retTy), node.start, node.end))
+        }
+        let coreIdx = coreQuestion(cx.core, inner.node, payload, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: payload }
+    }
+
+    if !(tyIsErr(tys, innerTy)) {
+        cx.env.diagnostics.push(diagQuestionNotOptional(tyToString(tys, innerTy), node.start, node.end))
+    }
+    elabErrResult(cx, node.start, node.end)
+}
+
+// ---------------------------------------------------------------------
+// Pattern elaboration. Binds new names into the current scope.
+// ---------------------------------------------------------------------
+
+pub fn elabPattern(cx: ElabCx, idx: Int, scrutTy: Int) -> Int {
+    if idx < 0 {
+        return corePatErr(cx.core, 0, 0)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind != AstNPattern {
+        return corePatErr(cx.core, node.start, node.end)
+    }
+    let tys = cx.env.tys
+    let kind = patternClassification(cx, node)
+
+    if kind == "wildcard" {
+        return corePatWild(cx.core, node.start, node.end)
+    }
+
+    if kind == "ident" {
+        let name = node.text
+        checkBindSpan(cx.env, name, scrutTy, false, node.start, node.end)
+        return corePatIdent(cx.core, name, false, scrutTy, node.start, node.end)
+    }
+
+    if kind == "lit" {
+        let litIdx = node.left
+        let lit = elabInfer(cx, litIdx)
+        if !(checkIsAssignable(cx.env, scrutTy, lit.ty)) && !(tyIsErr(tys, lit.ty)) {
+            cx.env.diagnostics.push(diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
+        }
+        return corePatLit(cx.core, lit.node, scrutTy, node.start, node.end)
+    }
+
+    if kind == "variant" {
+        return elabVariantPattern(cx, node, scrutTy)
+    }
+
+    if kind == "tuple" {
+        return elabTuplePattern(cx, node, scrutTy)
+    }
+
+    if kind == "struct" {
+        return elabStructPattern(cx, node, scrutTy)
+    }
+
+    if kind == "binding" {
+        let innerIdx = node.left
+        let inner = elabPattern(cx, innerIdx, scrutTy)
+        let name = node.text
+        checkBindSpan(cx.env, name, scrutTy, false, node.start, node.end)
+        return corePatBinding(cx.core, name, inner, false, scrutTy, node.start, node.end)
+    }
+
+    corePatErr(cx.core, node.start, node.end)
+}
+
+fn patternClassification(cx: ElabCx, node: AstNode) -> String {
+    let _ = cx
+    // The legacy parser encodes the pattern variety in `flags`; we
+    // reuse the legacy classifier numbers from `parser.osty`:
+    //   0 = wildcard, 1 = ident, 2 = lit, 3 = variant, 4 = struct,
+    //   5 = tuple, 6 = or-pattern (unused for irrefutable contexts),
+    //   7 = range (unused), 8 = or, 9 = binding `@`.
+    if node.flags == 0 { return "wildcard" }
+    if node.flags == 1 { return "ident" }
+    if node.flags == 2 { return "lit" }
+    if node.flags == 3 { return "variant" }
+    if node.flags == 4 { return "struct" }
+    if node.flags == 5 { return "tuple" }
+    if node.flags == 9 { return "binding" }
+    "unsupported"
+}
+
+fn elabVariantPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+    let tys = cx.env.tys
+    let variantName = node.text
+    let scrutHead = tyHeadAt(tys, scrutTy)
+    let variant = checkLookupVariantInOwner(cx.env, scrutHead, variantName)
+    let resolved = if variant.name != "" {
+        variant
+    } else {
+        checkLookupVariant(cx.env, variantName)
+    }
+    if resolved.name == "" {
+        cx.env.diagnostics.push(diagUnknownVariant(scrutHead, variantName, node.start, node.end))
+        return corePatErr(cx.core, node.start, node.end)
+    }
+    let scrutArgs = tyArgsAt(tys, scrutTy)
+    let fieldTys = if checkStringListLenHelper(resolved.generics) == checkIntListLenHelper(scrutArgs) {
+        let mut subs: List<Int> = []
+        for ft in resolved.fieldTys {
+            subs.push(checkSubstituteTy(cx.env, ft, resolved.generics, scrutArgs))
+        }
+        subs
+    } else {
+        resolved.fieldTys
+    }
+    let mut subs: List<Int> = []
+    let mut i = 0
+    for subIdx in node.children {
+        let fieldTy = if i < checkIntListLenHelper(fieldTys) {
+            checkIntListAt(fieldTys, i)
+        } else {
+            tErr(tys)
+        }
+        subs.push(elabPattern(cx, subIdx, fieldTy))
+        i = i + 1
+    }
+    corePatVariant(cx.core, resolved.owner, variantName, subs, scrutTy, node.start, node.end)
+}
+
+fn elabTuplePattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+    let tys = cx.env.tys
+    let kind = tyKindAt(tys, scrutTy)
+    if kind != TkTuple {
+        cx.env.diagnostics.push(diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
+        return corePatErr(cx.core, node.start, node.end)
+    }
+    let elems = tyArgsAt(tys, scrutTy)
+    if checkIntListLenHelper(elems) != checkIntListLenHelper(node.children) {
+        cx.env.diagnostics.push(diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
+    }
+    let mut subs: List<Int> = []
+    let mut i = 0
+    for subIdx in node.children {
+        let elemTy = if i < checkIntListLenHelper(elems) { checkIntListAt(elems, i) } else { tErr(tys) }
+        subs.push(elabPattern(cx, subIdx, elemTy))
+        i = i + 1
+    }
+    corePatTuple(cx.core, subs, scrutTy, node.start, node.end)
+}
+
+fn elabStructPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+    let tys = cx.env.tys
+    let owner = tyHeadAt(tys, scrutTy)
+    let typeSig = checkLookupType(cx.env, owner)
+    if typeSig.name == "" {
+        cx.env.diagnostics.push(diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
+        return corePatErr(cx.core, node.start, node.end)
+    }
+    let ownerArgs = tyArgsAt(tys, scrutTy)
+    let mut subs: List<Int> = []
+    for childIdx in node.children {
+        let child = astArenaNodeAt(cx.ast.arena, childIdx)
+        let fieldName = child.text
+        let fieldSig = checkLookupField(cx.env, owner, fieldName)
+        if fieldSig.name == "" {
+            cx.env.diagnostics.push(diagUnknownField(owner, fieldName, child.start, child.end))
+            continue
+        }
+        let substituted = if checkStringListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {
+            checkSubstituteTy(cx.env, fieldSig.ty, typeSig.generics, ownerArgs)
+        } else {
+            fieldSig.ty
+        }
+        let inner = elabPattern(cx, child.left, substituted)
+        subs.push(corePatStructField(cx.core, fieldName, inner, child.start, child.end))
+    }
+    corePatStruct(cx.core, owner, subs, false, scrutTy, node.start, node.end)
+}
+
+// ---------------------------------------------------------------------
+// Exhaustiveness — simplified port. Handles the cases we verify with
+// the legacy checker's unit tests: Bool, closed enum, wildcard. Full
+// nested-pattern witness generation is deferred to a follow-up.
+// ---------------------------------------------------------------------
+
+fn checkExhaustivenessSimple(cx: ElabCx, node: AstNode, scrutTy: Int) {
+    let tys = cx.env.tys
+    if tyIsErr(tys, scrutTy) {
+        return
+    }
+    if matchHasCatchAll(cx, node) {
+        return
+    }
+    if tyIsPrim(tys, scrutTy, PkBool) {
+        if !(matchCoversBool(cx, node, true)) {
+            cx.env.diagnostics.push(diagNonExhaustiveMatch("true", node.start, node.end))
+        }
+        if !(matchCoversBool(cx, node, false)) {
+            cx.env.diagnostics.push(diagNonExhaustiveMatch("false", node.start, node.end))
+        }
+        return
+    }
+    if tyKindAt(tys, scrutTy) == TkNamed {
+        let owner = tyHeadAt(tys, scrutTy)
+        let variants = allVariantsForOwner(cx.env, owner)
+        for v in variants {
+            if !(matchCoversVariant(cx, node, v.name)) {
+                cx.env.diagnostics.push(diagNonExhaustiveMatch("{v.owner}.{v.name}", node.start, node.end))
+            }
+        }
+    }
+}
+
+fn matchHasCatchAll(cx: ElabCx, node: AstNode) -> Bool {
+    for armIdx in node.children {
+        let arm = astArenaNodeAt(cx.ast.arena, armIdx)
+        let patIdx = arm.left
+        let pat = astArenaNodeAt(cx.ast.arena, patIdx)
+        if pat.kind == AstNPattern && pat.flags == 0 {
+            return true
+        }
+        if pat.kind == AstNPattern && pat.flags == 1 {
+            return true
+        }
+    }
+    false
+}
+
+fn matchCoversBool(cx: ElabCx, node: AstNode, want: Bool) -> Bool {
+    let needle = if want { "true" } else { "false" }
+    for armIdx in node.children {
+        let arm = astArenaNodeAt(cx.ast.arena, armIdx)
+        let pat = astArenaNodeAt(cx.ast.arena, arm.left)
+        if pat.kind == AstNPattern && pat.flags == 2 {
+            let litNode = astArenaNodeAt(cx.ast.arena, pat.left)
+            if litNode.text == needle {
+                return true
+            }
+        }
+    }
+    false
+}
+
+fn matchCoversVariant(cx: ElabCx, node: AstNode, variantName: String) -> Bool {
+    for armIdx in node.children {
+        let arm = astArenaNodeAt(cx.ast.arena, armIdx)
+        let pat = astArenaNodeAt(cx.ast.arena, arm.left)
+        if pat.kind == AstNPattern && pat.flags == 3 && pat.text == variantName {
+            return true
+        }
+    }
+    false
+}
+
+fn allVariantsForOwner(env: CheckEnv, owner: String) -> List<CheckVariantSig> {
+    let mut out: List<CheckVariantSig> = []
+    for v in env.variants {
+        if v.owner == owner {
+            out.push(v)
+        }
+    }
+    out
+}

--- a/toolchain/elab_test.osty
+++ b/toolchain/elab_test.osty
@@ -1,0 +1,129 @@
+// elab_test.osty — bidirectional elaborator integration tests.
+//
+// Drives the full pipeline (lex → parse → elab → serialize) and
+// asserts that the resulting `FrontCheckResult` matches expectations
+// previously encoded in the legacy `check_test.osty`. Orphan until the
+// toolchain native harness lands (see plan §V.a).
+
+use std.testing
+
+fn testElabLiteralLet() {
+    let checked = frontendCheckSource(
+        r"""
+            fn main() {
+                let answer: Int = 42
+            }
+            """,
+    )
+    testing.assertEq(checked.errors, 0)
+    testing.assert(checked.assignments >= 1)
+    testing.assert(checked.accepted >= 1)
+}
+
+fn testElabLetWithMismatchTriggersDiagnostic() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn main() {
+                let answer: Int = "nope"
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0701"))
+}
+
+fn testElabIfElseJoinsBranches() {
+    let checked = frontendCheckSource(
+        r"""
+            fn main() {
+                let x: Int = if true { 1 } else { 2 }
+            }
+            """,
+    )
+    testing.assertEq(checked.errors, 0)
+}
+
+fn testElabGenericCallInstantiates() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn id<T>(value: T) -> T {
+                value
+            }
+
+            fn main() {
+                let answer: Int = id::<Int>(1)
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assert(frontCheckResultInstantiationCount(checked) >= 1)
+    testing.assertEq(frontCheckResultBindingType(checked, "answer"), "Int")
+}
+
+fn testElabStructLiteralSeedsFromExpected() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct Box<T> {
+                value: T
+            }
+
+            fn main() {
+                let boxed: Box<Int> = Box { value: 1 }
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "boxed"), "Box<Int>")
+}
+
+fn testElabClosureChecksAgainstExpectedFn() {
+    let checked = frontendCheckSource(
+        r"""
+            fn apply(f: fn(Int) -> Int, x: Int) -> Int {
+                f(x)
+            }
+
+            fn main() {
+                let y: Int = apply(|n| n + 1, 3)
+            }
+            """,
+    )
+    testing.assertEq(checked.errors, 0)
+}
+
+fn testElabMatchExhaustivenessFailsWithoutCatchAll() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            enum Color { Red, Green }
+
+            fn code(c: Color) -> Int {
+                match c {
+                    Red -> 1,
+                }
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+}
+
+fn testElabQuestionOperatorRequiresOption() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn bad(x: Int) -> Int {
+                x?
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0730"))
+}
+
+fn elabDiagHasCode(diags: List<CheckDiagnostic>, code: String) -> Bool {
+    for d in diags {
+        if d.code == code {
+            return true
+        }
+    }
+    false
+}

--- a/toolchain/solve.osty
+++ b/toolchain/solve.osty
@@ -1,0 +1,387 @@
+// solve.osty — local constraint solver for generic inference.
+//
+// Phase 5 of the migration. The solver is *scoped to a single
+// elaboration event* (a generic call site, a struct-literal with typed
+// fields, a closure whose expected type supplies parameter types) —
+// **never global**. This matches the "constraint-based only where
+// needed, locally" requirement: the elaborator creates a fresh solver,
+// unifies the shapes it knows, zonks the result, then discards the
+// solver state.
+//
+// Public protocol used by the elaborator:
+//
+//   let solver = newSolver()
+//   let tVar = freshTyVar(env.tys, solver, fnName, "T")
+//   unify(env, solver, paramTy, argTy)           // extend substitutions
+//   checkGenericBoundSatisfied(env, solver, ...)  // after zonk
+//   let concrete = zonk(env, solver, returnTy)
+//
+// The solver stores substitutions as a plain `List<Subst>` (linear
+// scan on lookup). Chain lengths are shallow in practice — one level
+// per type parameter — and this keeps the representation friendly to
+// the Osty self-host codegen.
+
+/// Subst is a single `varId -> Ty` binding. `ty` is an arena index.
+pub struct Subst {
+    pub varId: Int,
+    pub ty: Int,
+}
+
+/// Solver owns the substitutions produced during a single constraint
+/// episode. Callers allocate a fresh solver per call site and rely on
+/// the parent arenas (`TyArena`, `CheckEnv`) for the actual type
+/// storage.
+pub struct Solver {
+    pub substs: List<Subst>,
+}
+
+pub fn newSolver() -> Solver {
+    Solver { substs: [] }
+}
+
+/// freshTyVar is a thin wrapper around `tyVarFresh` that lives on the
+/// solver side so callers can grab a fresh variable without importing
+/// `ty.osty` names directly.
+pub fn freshTyVar(tys: TyArena, owner: String, name: String) -> Int {
+    tyVarFresh(tys, owner, name)
+}
+
+// ---------------------------------------------------------------------
+// Substitution storage.
+// ---------------------------------------------------------------------
+
+/// solverBind records `varId -> ty` in the solver. Callers must pre-
+/// resolve `ty` through `solverWalk` if they want eager path
+/// compression; `unify` already does that at the unification site.
+pub fn solverBind(solver: Solver, varId: Int, ty: Int) {
+    solver.substs.push(Subst { varId, ty })
+}
+
+/// solverLookup returns the most recent binding for `varId`, or -1 if
+/// none exists.
+pub fn solverLookup(solver: Solver, varId: Int) -> Int {
+    let mut found = -1
+    for s in solver.substs {
+        if s.varId == varId {
+            found = s.ty
+        }
+    }
+    found
+}
+
+/// solverWalk follows the substitution chain: given any `ty`, if it is
+/// a `TyVar` that has been bound, keep following until we hit a
+/// non-variable or an unbound variable. This is the usual union-find
+/// path to the root representative.
+pub fn solverWalk(tys: TyArena, solver: Solver, ty: Int) -> Int {
+    let mut current = ty
+    let mut depth = 0
+    for depth < 32 {
+        if tyKindAt(tys, current) != TkVar {
+            return current
+        }
+        let bound = solverLookup(solver, tyVarIdAt(tys, current))
+        if bound < 0 {
+            return current
+        }
+        if bound == current {
+            return current
+        }
+        current = bound
+        depth = depth + 1
+    }
+    current
+}
+
+// ---------------------------------------------------------------------
+// Occurs check — prevents infinite types when unifying a variable
+// with a type that mentions it.
+// ---------------------------------------------------------------------
+
+/// occursCheck returns true when `varId` appears anywhere inside `ty`
+/// after following substitutions. Used by `unify` to reject cyclic
+/// bindings like `T = List<T>`.
+pub fn occursCheck(tys: TyArena, solver: Solver, varId: Int, ty: Int) -> Bool {
+    let walked = solverWalk(tys, solver, ty)
+    if walked < 0 {
+        return false
+    }
+    let kind = tyKindAt(tys, walked)
+    match kind {
+        TkVar -> tyVarIdAt(tys, walked) == varId,
+        TkNamed -> occursInList(tys, solver, varId, tyArgsAt(tys, walked)),
+        TkTuple -> occursInList(tys, solver, varId, tyArgsAt(tys, walked)),
+        TkFn -> {
+            if occursInList(tys, solver, varId, tyArgsAt(tys, walked)) {
+                return true
+            }
+            occursCheck(tys, solver, varId, tyRetAt(tys, walked))
+        },
+        TkOptional -> occursCheck(tys, solver, varId, tyInnerAt(tys, walked)),
+        _ -> false,
+    }
+}
+
+fn occursInList(tys: TyArena, solver: Solver, varId: Int, xs: List<Int>) -> Bool {
+    for x in xs {
+        if occursCheck(tys, solver, varId, x) {
+            return true
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------
+// Unification.
+//
+// Returns `true` on success, `false` when the two types cannot be made
+// equal. On success the solver's substitutions are extended in place;
+// on failure no guarantee is made about the state beyond the usual
+// "don't read it if the error is fatal" convention.
+// ---------------------------------------------------------------------
+
+pub fn unify(env: CheckEnv, solver: Solver, a: Int, b: Int) -> Bool {
+    unifyAt(env, solver, a, b, 0)
+}
+
+fn unifyAt(env: CheckEnv, solver: Solver, aIn: Int, bIn: Int, depth: Int) -> Bool {
+    if depth > 64 {
+        return false
+    }
+    let a = solverWalk(env.tys, solver, aIn)
+    let b = solverWalk(env.tys, solver, bIn)
+    if a == b {
+        return true
+    }
+
+    let aKind = tyKindAt(env.tys, a)
+    let bKind = tyKindAt(env.tys, b)
+
+    // TyErr propagates silently — treat as unifying against anything to
+    // avoid cascading diagnostics when a subtree is already poisoned.
+    if aKind == TkErr || bKind == TkErr {
+        return true
+    }
+
+    // Never is bottom — unifies into anything on the RHS.
+    if tyIsNever(env.tys, a) || tyIsNever(env.tys, b) {
+        return true
+    }
+
+    if aKind == TkVar {
+        return bindVar(env, solver, a, b)
+    }
+    if bKind == TkVar {
+        return bindVar(env, solver, b, a)
+    }
+
+    if aKind != bKind {
+        // Cross-kind except the Untyped* numeric relaxation below.
+        return unifyUntypedNumericCross(env, a, b)
+    }
+
+    match aKind {
+        TkPrim -> unifyPrim(env, a, b),
+        TkNamed -> unifyNamed(env, solver, a, b, depth + 1),
+        TkTuple -> unifyPositional(env, solver, tyArgsAt(env.tys, a), tyArgsAt(env.tys, b), depth + 1),
+        TkFn -> unifyFn(env, solver, a, b, depth + 1),
+        TkOptional -> unifyAt(env, solver, tyInnerAt(env.tys, a), tyInnerAt(env.tys, b), depth + 1),
+        TkSelf -> tyHeadAt(env.tys, a) == tyHeadAt(env.tys, b),
+        TkErr -> true,
+        TkVar -> false,
+    }
+}
+
+/// bindVar extends the solver with `var -> other` after an occurs
+/// check. `var` must be a `TyVar`; the caller ensures that.
+fn bindVar(env: CheckEnv, solver: Solver, var: Int, other: Int) -> Bool {
+    if tyEq(env.tys, var, other) {
+        return true
+    }
+    let varId = tyVarIdAt(env.tys, var)
+    if occursCheck(env.tys, solver, varId, other) {
+        return false
+    }
+    solverBind(solver, varId, other)
+    true
+}
+
+fn unifyPrim(env: CheckEnv, a: Int, b: Int) -> Bool {
+    let pa = tyPrimAt(env.tys, a)
+    let pb = tyPrimAt(env.tys, b)
+    if pa == pb {
+        return true
+    }
+    // Untyped* ~ concrete numeric.
+    if pa == PkUntypedInt {
+        return isConcreteIntPrim(pb) || pb == PkFloat || pb == PkFloat32 || pb == PkFloat64
+    }
+    if pb == PkUntypedInt {
+        return isConcreteIntPrim(pa) || pa == PkFloat || pa == PkFloat32 || pa == PkFloat64
+    }
+    if pa == PkUntypedFloat {
+        return pb == PkFloat || pb == PkFloat32 || pb == PkFloat64
+    }
+    if pb == PkUntypedFloat {
+        return pa == PkFloat || pa == PkFloat32 || pa == PkFloat64
+    }
+    false
+}
+
+fn isConcreteIntPrim(p: PrimKind) -> Bool {
+    p == PkInt || p == PkInt8 || p == PkInt16 || p == PkInt32 || p == PkInt64 ||
+        p == PkUInt8 || p == PkUInt16 || p == PkUInt32 || p == PkUInt64 ||
+        p == PkByte || p == PkChar
+}
+
+fn unifyNamed(env: CheckEnv, solver: Solver, a: Int, b: Int, depth: Int) -> Bool {
+    if tyHeadAt(env.tys, a) != tyHeadAt(env.tys, b) {
+        return false
+    }
+    unifyPositional(env, solver, tyArgsAt(env.tys, a), tyArgsAt(env.tys, b), depth)
+}
+
+fn unifyPositional(env: CheckEnv, solver: Solver, xs: List<Int>, ys: List<Int>, depth: Int) -> Bool {
+    if solveIntLen(xs) != solveIntLen(ys) {
+        return false
+    }
+    let mut i = 0
+    for x in xs {
+        if !(unifyAt(env, solver, x, ys[i], depth)) {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn unifyFn(env: CheckEnv, solver: Solver, a: Int, b: Int, depth: Int) -> Bool {
+    if !(unifyPositional(env, solver, tyArgsAt(env.tys, a), tyArgsAt(env.tys, b), depth)) {
+        return false
+    }
+    unifyAt(env, solver, tyRetAt(env.tys, a), tyRetAt(env.tys, b), depth)
+}
+
+/// unifyUntypedNumericCross handles the one asymmetric relaxation the
+/// elaborator wants for literal defaulting: a `TkPrim` untyped numeric
+/// paired with a `TkPrim` concrete numeric (the paths above already
+/// handle this when both sides share `TkPrim`; this covers the rare
+/// case where one side has been resolved through an alias to a non-
+/// prim shape).
+fn unifyUntypedNumericCross(env: CheckEnv, a: Int, b: Int) -> Bool {
+    let _ = env
+    let _ = a
+    let _ = b
+    false
+}
+
+// ---------------------------------------------------------------------
+// Zonk — fully apply the substitution so downstream code sees concrete
+// types instead of arena handles that still reference `TyVar` nodes.
+// ---------------------------------------------------------------------
+
+/// zonk returns a type with every bound `TyVar` replaced by its
+/// representative. Unbound variables survive — the caller is
+/// responsible for emitting `E0720` once all args have been processed
+/// and they still haven't narrowed.
+pub fn zonk(env: CheckEnv, solver: Solver, ty: Int) -> Int {
+    zonkAt(env, solver, ty, 0)
+}
+
+fn zonkAt(env: CheckEnv, solver: Solver, ty: Int, depth: Int) -> Int {
+    if depth > 64 || ty < 0 {
+        return ty
+    }
+    let walked = solverWalk(env.tys, solver, ty)
+    let kind = tyKindAt(env.tys, walked)
+    match kind {
+        TkNamed -> {
+            let args = tyArgsAt(env.tys, walked)
+            if solveIntLen(args) == 0 {
+                return walked
+            }
+            let mut rebuilt: List<Int> = []
+            for a in args {
+                rebuilt.push(zonkAt(env, solver, a, depth + 1))
+            }
+            tyNamed(env.tys, tyHeadAt(env.tys, walked), rebuilt)
+        },
+        TkTuple -> {
+            let args = tyArgsAt(env.tys, walked)
+            let mut rebuilt: List<Int> = []
+            for a in args {
+                rebuilt.push(zonkAt(env, solver, a, depth + 1))
+            }
+            tyTuple(env.tys, rebuilt)
+        },
+        TkFn -> {
+            let args = tyArgsAt(env.tys, walked)
+            let mut rebuilt: List<Int> = []
+            for a in args {
+                rebuilt.push(zonkAt(env, solver, a, depth + 1))
+            }
+            let ret = zonkAt(env, solver, tyRetAt(env.tys, walked), depth + 1)
+            tyFn(env.tys, rebuilt, ret)
+        },
+        TkOptional -> {
+            tyOptional(env.tys, zonkAt(env, solver, tyInnerAt(env.tys, walked), depth + 1))
+        },
+        _ -> walked,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------
+
+/// isFullyResolved returns true when `ty` contains no unbound type
+/// variables after zonking. The elaborator uses this post-call to
+/// decide whether to emit `E0720 cannot infer type parameter`.
+pub fn isFullyResolved(env: CheckEnv, solver: Solver, ty: Int) -> Bool {
+    if ty < 0 {
+        return false
+    }
+    let walked = solverWalk(env.tys, solver, ty)
+    let kind = tyKindAt(env.tys, walked)
+    match kind {
+        TkVar -> false,
+        TkNamed -> allFullyResolved(env, solver, tyArgsAt(env.tys, walked)),
+        TkTuple -> allFullyResolved(env, solver, tyArgsAt(env.tys, walked)),
+        TkFn -> {
+            if !(allFullyResolved(env, solver, tyArgsAt(env.tys, walked))) {
+                return false
+            }
+            isFullyResolved(env, solver, tyRetAt(env.tys, walked))
+        },
+        TkOptional -> isFullyResolved(env, solver, tyInnerAt(env.tys, walked)),
+        _ -> true,
+    }
+}
+
+fn allFullyResolved(env: CheckEnv, solver: Solver, xs: List<Int>) -> Bool {
+    for x in xs {
+        if !(isFullyResolved(env, solver, x)) {
+            return false
+        }
+    }
+    true
+}
+
+/// zonkList zonks every element of a list. Useful for materialising
+/// concrete type-argument lists after all arg constraints have fired.
+pub fn zonkList(env: CheckEnv, solver: Solver, xs: List<Int>) -> List<Int> {
+    let mut out: List<Int> = []
+    for x in xs {
+        out.push(zonk(env, solver, x))
+    }
+    out
+}
+
+fn solveIntLen(xs: List<Int>) -> Int {
+    let mut n = 0
+    for x in xs {
+        let _ = x
+        n = n + 1
+    }
+    n
+}

--- a/toolchain/solve_test.osty
+++ b/toolchain/solve_test.osty
@@ -1,0 +1,110 @@
+// solve_test.osty — constraint solver edge cases.
+//
+// Orphan until the toolchain native harness lands (see plan §V.a).
+
+use std.testing
+
+fn testSolveUnifyPrimitivesEqual() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    testing.assert(unify(env, solver, tInt(tys), tInt(tys)))
+}
+
+fn testSolveUnifyBindsVarToConcrete() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "id", "T")
+    testing.assert(unify(env, solver, t, tInt(tys)))
+    testing.assertEq(solverLookup(solver, tyVarIdAt(tys, t)), tInt(tys))
+    testing.assertEq(zonk(env, solver, t), tInt(tys))
+}
+
+fn testSolveUnifySymmetricBind() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "f", "T")
+    // Concrete on the left should still bind the variable.
+    testing.assert(unify(env, solver, tString(tys), t))
+    testing.assertEq(zonk(env, solver, t), tString(tys))
+}
+
+fn testSolveUnifyNamedStructurally() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "g", "T")
+
+    let expected = tyNamed(tys, "List", [t])
+    let got = tyNamed(tys, "List", [tInt(tys)])
+
+    testing.assert(unify(env, solver, expected, got))
+    testing.assertEq(zonk(env, solver, t), tInt(tys))
+    testing.assertEq(tyToString(tys, zonk(env, solver, expected)), "List<Int>")
+}
+
+fn testSolveUnifyFnTypes() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "h", "T")
+    let u = freshTyVar(tys, "h", "U")
+
+    let expected = tyFn(tys, [t], u)
+    let got = tyFn(tys, [tInt(tys)], tString(tys))
+
+    testing.assert(unify(env, solver, expected, got))
+    testing.assertEq(zonk(env, solver, t), tInt(tys))
+    testing.assertEq(zonk(env, solver, u), tString(tys))
+}
+
+fn testSolveUnifyOccursCheckRejectsCycle() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "cyc", "T")
+    let cyclic = tyNamed(tys, "List", [t])
+    testing.assert(!(unify(env, solver, t, cyclic)))
+}
+
+fn testSolveZonkList() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "z", "T")
+    let u = freshTyVar(tys, "z", "U")
+
+    let _ = unify(env, solver, t, tBool(tys))
+    let _ = unify(env, solver, u, tString(tys))
+
+    let list = zonkList(env, solver, [t, u])
+    testing.assertEq(tyToString(tys, list[0]), "Bool")
+    testing.assertEq(tyToString(tys, list[1]), "String")
+}
+
+fn testSolveIsFullyResolved() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    let t = freshTyVar(tys, "x", "T")
+    testing.assert(!(isFullyResolved(env, solver, t)))
+    let _ = unify(env, solver, t, tInt(tys))
+    testing.assert(isFullyResolved(env, solver, t))
+}
+
+fn testSolveUnifyUntypedIntWithConcrete() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    testing.assert(unify(env, solver, tInt(tys), tUntypedInt(tys)))
+    testing.assert(unify(env, solver, tFloat(tys), tUntypedInt(tys)))
+}
+
+fn testSolveUnifyMismatchFails() {
+    let tys = emptyTyArena()
+    let env = emptyCheckEnv(tys)
+    let solver = newSolver()
+    testing.assert(!(unify(env, solver, tInt(tys), tString(tys))))
+}

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -1,0 +1,803 @@
+// ty.osty — typed representation of Osty semantic types.
+//
+// Replaces the string-based type plumbing in the legacy `check.osty`
+// (`"Map<String, List<Int>>"` etc. parsed on every access via
+// `frontCheckParseType`). Types live in a `TyArena`; all references are
+// `Int` indices into the arena, so structural sharing is cheap and the
+// bidirectional elaborator can compare types by index when they are
+// interned.
+//
+// Design notes:
+//
+// - Arena + tagged node follows `toolchain/ir.osty` precedent. Recursive
+//   enum payloads (`TyNamed(String, List<Ty>)`) are not used because
+//   toolchain code paths routinely need constant-time indexed access
+//   and Osty's self-host codegen is validated against the arena shape.
+//
+// - Primitives are interned once at arena-creation time and returned as
+//   canonical indices (`tInt(arena)`, `tBool(arena)`, ...). Named /
+//   tuple / fn / var / optional types allocate fresh nodes.
+//
+// - `tyFromString` is a transitional bridge: it parses the legacy
+//   `"Head<Arg, ...>"` / `"fn(A) -> R"` / `"(A, B)"` serializations used
+//   by the old checker so phase-by-phase migration is possible. Once
+//   all callers are moved to `tyNamed`/`tyFn`/... builders this function
+//   becomes dead and can be removed.
+
+use std.strings as strings
+
+/// PrimKind enumerates Osty's built-in scalar types plus the literal
+/// defaulting markers (`PkUntypedInt`, `PkUntypedFloat`) and a poison
+/// value (`PkInvalid`) used when parsing hits an unrecognised prim.
+pub enum PrimKind {
+    PkInvalid,
+    PkInt,
+    PkInt8,
+    PkInt16,
+    PkInt32,
+    PkInt64,
+    PkUInt8,
+    PkUInt16,
+    PkUInt32,
+    PkUInt64,
+    PkByte,
+    PkFloat,
+    PkFloat32,
+    PkFloat64,
+    PkBool,
+    PkChar,
+    PkString,
+    PkBytes,
+    PkUnit,
+    PkNever,
+    PkUntypedInt,
+    PkUntypedFloat,
+}
+
+/// TyKind discriminates the shape stored in a `TyNode`.
+pub enum TyKind {
+    TkErr,              // poisoned / unresolved
+    TkPrim,             // TyNode.prim is meaningful
+    TkNamed,            // TyNode.head + TyNode.args
+    TkOptional,         // TyNode.ret holds the inner index
+    TkTuple,            // TyNode.args holds elem indices
+    TkFn,               // TyNode.args holds param indices, TyNode.ret the return
+    TkVar,              // TyNode.varId / varName / varOwner
+    TkSelf,             // TyNode.head carries the owner name (interface context)
+}
+
+/// TyNode is the discriminated union stored in a `TyArena`. Only the
+/// fields relevant to the node's `kind` are used; the rest sit at
+/// zero-values. Callers must not read a field without first checking
+/// the kind via `tyKindAt`.
+pub struct TyNode {
+    pub kind: TyKind,
+    pub prim: PrimKind,
+    pub head: String,
+    pub args: List<Int>,
+    pub ret: Int,
+    pub varId: Int,
+    pub varName: String,
+    pub varOwner: String,
+}
+
+/// TyArena owns every `TyNode` produced during elaboration. Canonical
+/// primitive indices are pre-populated by `emptyTyArena` so callers
+/// never allocate a fresh node for `Int`, `Bool`, ...
+pub struct TyArena {
+    pub nodes: List<TyNode>,
+    pub nextVarId: Int,
+
+    pub idxErr: Int,
+    pub idxInt: Int,
+    pub idxInt8: Int,
+    pub idxInt16: Int,
+    pub idxInt32: Int,
+    pub idxInt64: Int,
+    pub idxUInt8: Int,
+    pub idxUInt16: Int,
+    pub idxUInt32: Int,
+    pub idxUInt64: Int,
+    pub idxByte: Int,
+    pub idxFloat: Int,
+    pub idxFloat32: Int,
+    pub idxFloat64: Int,
+    pub idxBool: Int,
+    pub idxChar: Int,
+    pub idxString: Int,
+    pub idxBytes: Int,
+    pub idxUnit: Int,
+    pub idxNever: Int,
+    pub idxUntypedInt: Int,
+    pub idxUntypedFloat: Int,
+}
+
+/// emptyTyNode returns the zero-value node used when the arena's index
+/// is out of range. Callers should not observe this unless a bug is
+/// passing a bogus handle.
+pub fn emptyTyNode() -> TyNode {
+    TyNode {
+        kind: TkErr,
+        prim: PkInvalid,
+        head: "",
+        args: [],
+        ret: -1,
+        varId: 0,
+        varName: "",
+        varOwner: "",
+    }
+}
+
+/// emptyTyArena builds an arena pre-populated with canonical primitive
+/// nodes. Every primitive is allocated exactly once so callers can
+/// compare prim-valued types by index equality.
+pub fn emptyTyArena() -> TyArena {
+    let mut arena = TyArena {
+        nodes: [],
+        nextVarId: 1,
+        idxErr: -1,
+        idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1,
+        idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1,
+        idxByte: -1, idxFloat: -1, idxFloat32: -1, idxFloat64: -1,
+        idxBool: -1, idxChar: -1, idxString: -1, idxBytes: -1,
+        idxUnit: -1, idxNever: -1,
+        idxUntypedInt: -1, idxUntypedFloat: -1,
+    }
+    arena.idxErr = tyAllocErr(arena)
+    arena.idxInt = tyAllocPrim(arena, PkInt)
+    arena.idxInt8 = tyAllocPrim(arena, PkInt8)
+    arena.idxInt16 = tyAllocPrim(arena, PkInt16)
+    arena.idxInt32 = tyAllocPrim(arena, PkInt32)
+    arena.idxInt64 = tyAllocPrim(arena, PkInt64)
+    arena.idxUInt8 = tyAllocPrim(arena, PkUInt8)
+    arena.idxUInt16 = tyAllocPrim(arena, PkUInt16)
+    arena.idxUInt32 = tyAllocPrim(arena, PkUInt32)
+    arena.idxUInt64 = tyAllocPrim(arena, PkUInt64)
+    arena.idxByte = tyAllocPrim(arena, PkByte)
+    arena.idxFloat = tyAllocPrim(arena, PkFloat)
+    arena.idxFloat32 = tyAllocPrim(arena, PkFloat32)
+    arena.idxFloat64 = tyAllocPrim(arena, PkFloat64)
+    arena.idxBool = tyAllocPrim(arena, PkBool)
+    arena.idxChar = tyAllocPrim(arena, PkChar)
+    arena.idxString = tyAllocPrim(arena, PkString)
+    arena.idxBytes = tyAllocPrim(arena, PkBytes)
+    arena.idxUnit = tyAllocPrim(arena, PkUnit)
+    arena.idxNever = tyAllocPrim(arena, PkNever)
+    arena.idxUntypedInt = tyAllocPrim(arena, PkUntypedInt)
+    arena.idxUntypedFloat = tyAllocPrim(arena, PkUntypedFloat)
+    arena
+}
+
+fn tyAllocErr(arena: TyArena) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkErr, prim: PkInvalid, head: "", args: [], ret: -1,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+fn tyAllocPrim(arena: TyArena, prim: PrimKind) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkPrim, prim, head: "", args: [], ret: -1,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+/// tyNodeCount returns the arena node count. Used as an O(n) pre-push
+/// allocation index; callers inside hot loops should hoist this.
+pub fn tyNodeCount(arena: TyArena) -> Int {
+    let mut count = 0
+    for n in arena.nodes {
+        let _ = n
+        count = count + 1
+    }
+    count
+}
+
+// ---------------------------------------------------------------------
+// Canonical primitive accessors. Returning by field rather than by
+// kind-name keeps the elaborator's hot path index-sized.
+// ---------------------------------------------------------------------
+
+pub fn tErr(arena: TyArena) -> Int { arena.idxErr }
+pub fn tInt(arena: TyArena) -> Int { arena.idxInt }
+pub fn tInt8(arena: TyArena) -> Int { arena.idxInt8 }
+pub fn tInt16(arena: TyArena) -> Int { arena.idxInt16 }
+pub fn tInt32(arena: TyArena) -> Int { arena.idxInt32 }
+pub fn tInt64(arena: TyArena) -> Int { arena.idxInt64 }
+pub fn tUInt8(arena: TyArena) -> Int { arena.idxUInt8 }
+pub fn tUInt16(arena: TyArena) -> Int { arena.idxUInt16 }
+pub fn tUInt32(arena: TyArena) -> Int { arena.idxUInt32 }
+pub fn tUInt64(arena: TyArena) -> Int { arena.idxUInt64 }
+pub fn tByte(arena: TyArena) -> Int { arena.idxByte }
+pub fn tFloat(arena: TyArena) -> Int { arena.idxFloat }
+pub fn tFloat32(arena: TyArena) -> Int { arena.idxFloat32 }
+pub fn tFloat64(arena: TyArena) -> Int { arena.idxFloat64 }
+pub fn tBool(arena: TyArena) -> Int { arena.idxBool }
+pub fn tChar(arena: TyArena) -> Int { arena.idxChar }
+pub fn tString(arena: TyArena) -> Int { arena.idxString }
+pub fn tBytes(arena: TyArena) -> Int { arena.idxBytes }
+pub fn tUnit(arena: TyArena) -> Int { arena.idxUnit }
+pub fn tNever(arena: TyArena) -> Int { arena.idxNever }
+pub fn tUntypedInt(arena: TyArena) -> Int { arena.idxUntypedInt }
+pub fn tUntypedFloat(arena: TyArena) -> Int { arena.idxUntypedFloat }
+
+// ---------------------------------------------------------------------
+// Builders — always allocate a fresh node. No interning beyond prims.
+// ---------------------------------------------------------------------
+
+/// tyPrim returns the canonical index for a primitive kind. Prefer the
+/// dedicated helpers (`tInt`, `tBool`, ...) when the kind is statically
+/// known.
+pub fn tyPrim(arena: TyArena, prim: PrimKind) -> Int {
+    match prim {
+        PkInvalid -> arena.idxErr,
+        PkInt -> arena.idxInt,
+        PkInt8 -> arena.idxInt8,
+        PkInt16 -> arena.idxInt16,
+        PkInt32 -> arena.idxInt32,
+        PkInt64 -> arena.idxInt64,
+        PkUInt8 -> arena.idxUInt8,
+        PkUInt16 -> arena.idxUInt16,
+        PkUInt32 -> arena.idxUInt32,
+        PkUInt64 -> arena.idxUInt64,
+        PkByte -> arena.idxByte,
+        PkFloat -> arena.idxFloat,
+        PkFloat32 -> arena.idxFloat32,
+        PkFloat64 -> arena.idxFloat64,
+        PkBool -> arena.idxBool,
+        PkChar -> arena.idxChar,
+        PkString -> arena.idxString,
+        PkBytes -> arena.idxBytes,
+        PkUnit -> arena.idxUnit,
+        PkNever -> arena.idxNever,
+        PkUntypedInt -> arena.idxUntypedInt,
+        PkUntypedFloat -> arena.idxUntypedFloat,
+    }
+}
+
+/// tyNamed allocates a named type `head<args...>` node. `args` may be
+/// empty, meaning a plain type like `String` used in type position.
+pub fn tyNamed(arena: TyArena, head: String, args: List<Int>) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkNamed, prim: PkInvalid, head, args, ret: -1,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+/// tyTuple allocates a tuple-type node. `()` is represented by an empty
+/// elems list; callers that want the canonical unit type should use
+/// `tUnit` instead.
+pub fn tyTuple(arena: TyArena, elems: List<Int>) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkTuple, prim: PkInvalid, head: "", args: elems, ret: -1,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+/// tyFn allocates an `fn(params...) -> ret` node. `ret` may be
+/// `tUnit(arena)` for Unit-returning functions and `tNever(arena)` for
+/// diverging ones; callers must pre-canonicalise.
+pub fn tyFn(arena: TyArena, params: List<Int>, ret: Int) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkFn, prim: PkInvalid, head: "", args: params, ret,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+/// tyOptional allocates a `T?` node with `inner` as the wrapped index.
+pub fn tyOptional(arena: TyArena, inner: Int) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkOptional, prim: PkInvalid, head: "", args: [], ret: inner,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+/// tyVarFresh allocates a fresh unification variable. `owner` is the
+/// declaring fn/method name so two `T`s on different generics never
+/// collide during diagnostics.
+pub fn tyVarFresh(arena: TyArena, owner: String, name: String) -> Int {
+    let id = arena.nextVarId
+    arena.nextVarId = id + 1
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkVar, prim: PkInvalid, head: "", args: [], ret: -1,
+        varId: id, varName: name, varOwner: owner,
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+/// tySelf allocates a `Self` marker tied to an `owner` (interface or
+/// impl). The elaborator substitutes it away once the receiver type is
+/// known.
+pub fn tySelf(arena: TyArena, owner: String) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkSelf, prim: PkInvalid, head: owner, args: [], ret: -1,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
+// ---------------------------------------------------------------------
+// Accessors.
+// ---------------------------------------------------------------------
+
+/// tyGet returns the node at `idx`, or an `emptyTyNode()` if the index
+/// is out of range. Prefer the kind-specific helpers below for hot
+/// paths.
+pub fn tyGet(arena: TyArena, idx: Int) -> TyNode {
+    if idx < 0 {
+        return emptyTyNode()
+    }
+    let mut i = 0
+    for n in arena.nodes {
+        if i == idx {
+            return n
+        }
+        i = i + 1
+    }
+    emptyTyNode()
+}
+
+pub fn tyKindAt(arena: TyArena, idx: Int) -> TyKind {
+    tyGet(arena, idx).kind
+}
+
+pub fn tyPrimAt(arena: TyArena, idx: Int) -> PrimKind {
+    tyGet(arena, idx).prim
+}
+
+pub fn tyHeadAt(arena: TyArena, idx: Int) -> String {
+    tyGet(arena, idx).head
+}
+
+pub fn tyArgsAt(arena: TyArena, idx: Int) -> List<Int> {
+    tyGet(arena, idx).args
+}
+
+pub fn tyRetAt(arena: TyArena, idx: Int) -> Int {
+    tyGet(arena, idx).ret
+}
+
+pub fn tyInnerAt(arena: TyArena, idx: Int) -> Int {
+    let node = tyGet(arena, idx)
+    if node.kind == TkOptional {
+        return node.ret
+    }
+    -1
+}
+
+pub fn tyVarIdAt(arena: TyArena, idx: Int) -> Int {
+    tyGet(arena, idx).varId
+}
+
+pub fn tyVarNameAt(arena: TyArena, idx: Int) -> String {
+    tyGet(arena, idx).varName
+}
+
+pub fn tyVarOwnerAt(arena: TyArena, idx: Int) -> String {
+    tyGet(arena, idx).varOwner
+}
+
+// ---------------------------------------------------------------------
+// Classification predicates (moved out of the string-based checker).
+// ---------------------------------------------------------------------
+
+pub fn tyIsErr(arena: TyArena, idx: Int) -> Bool {
+    tyKindAt(arena, idx) == TkErr
+}
+
+pub fn tyIsNever(arena: TyArena, idx: Int) -> Bool {
+    let k = tyPrimAt(arena, idx)
+    tyKindAt(arena, idx) == TkPrim && k == PkNever
+}
+
+pub fn tyIsUnit(arena: TyArena, idx: Int) -> Bool {
+    let k = tyPrimAt(arena, idx)
+    tyKindAt(arena, idx) == TkPrim && k == PkUnit
+}
+
+pub fn tyIsPrim(arena: TyArena, idx: Int, prim: PrimKind) -> Bool {
+    tyKindAt(arena, idx) == TkPrim && tyPrimAt(arena, idx) == prim
+}
+
+pub fn tyIsInteger(arena: TyArena, idx: Int) -> Bool {
+    if tyKindAt(arena, idx) != TkPrim {
+        return false
+    }
+    let p = tyPrimAt(arena, idx)
+    p == PkInt || p == PkInt8 || p == PkInt16 || p == PkInt32 || p == PkInt64 ||
+        p == PkUInt8 || p == PkUInt16 || p == PkUInt32 || p == PkUInt64 ||
+        p == PkByte || p == PkChar || p == PkUntypedInt
+}
+
+pub fn tyIsFloat(arena: TyArena, idx: Int) -> Bool {
+    if tyKindAt(arena, idx) != TkPrim {
+        return false
+    }
+    let p = tyPrimAt(arena, idx)
+    p == PkFloat || p == PkFloat32 || p == PkFloat64 || p == PkUntypedFloat
+}
+
+pub fn tyIsNumeric(arena: TyArena, idx: Int) -> Bool {
+    tyIsInteger(arena, idx) || tyIsFloat(arena, idx)
+}
+
+pub fn tyIsOrdered(arena: TyArena, idx: Int) -> Bool {
+    if tyIsNumeric(arena, idx) {
+        return true
+    }
+    tyIsPrim(arena, idx, PkString) || tyIsPrim(arena, idx, PkBool) || tyIsPrim(arena, idx, PkChar)
+}
+
+pub fn tyIsUntyped(arena: TyArena, idx: Int) -> Bool {
+    let p = tyPrimAt(arena, idx)
+    tyKindAt(arena, idx) == TkPrim && (p == PkUntypedInt || p == PkUntypedFloat)
+}
+
+pub fn tyIsNamedHead(arena: TyArena, idx: Int, head: String) -> Bool {
+    tyKindAt(arena, idx) == TkNamed && tyHeadAt(arena, idx) == head
+}
+
+// ---------------------------------------------------------------------
+// Structural equality.
+// ---------------------------------------------------------------------
+
+/// tyEq is structural (not identity). Two primitive types compare equal
+/// iff their `PrimKind` matches; named types match head + pointwise
+/// args; `TyVar`s match on `varId`; `TyErr` is equal to itself and
+/// propagates silently.
+pub fn tyEq(arena: TyArena, a: Int, b: Int) -> Bool {
+    if a == b {
+        return true
+    }
+    let na = tyGet(arena, a)
+    let nb = tyGet(arena, b)
+    if na.kind != nb.kind {
+        return false
+    }
+    match na.kind {
+        TkErr -> true,
+        TkPrim -> na.prim == nb.prim,
+        TkNamed -> {
+            if na.head != nb.head {
+                return false
+            }
+            tyEqList(arena, na.args, nb.args)
+        },
+        TkOptional -> tyEq(arena, na.ret, nb.ret),
+        TkTuple -> tyEqList(arena, na.args, nb.args),
+        TkFn -> {
+            if !(tyEqList(arena, na.args, nb.args)) {
+                return false
+            }
+            tyEq(arena, na.ret, nb.ret)
+        },
+        TkVar -> na.varId == nb.varId,
+        TkSelf -> na.head == nb.head,
+    }
+}
+
+fn tyEqList(arena: TyArena, xs: List<Int>, ys: List<Int>) -> Bool {
+    if tyIntListLen(xs) != tyIntListLen(ys) {
+        return false
+    }
+    let mut i = 0
+    for x in xs {
+        if !(tyEq(arena, x, tyIntAt(ys, i))) {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn tyIntListLen(xs: List<Int>) -> Int {
+    let mut count = 0
+    for x in xs {
+        let _ = x
+        count = count + 1
+    }
+    count
+}
+
+fn tyIntAt(xs: List<Int>, idx: Int) -> Int {
+    let mut i = 0
+    for x in xs {
+        if i == idx {
+            return x
+        }
+        i = i + 1
+    }
+    -1
+}
+
+// ---------------------------------------------------------------------
+// Pretty-printer. Output is stable and round-trippable via
+// `tyFromString`. Used for diagnostics + the `FrontCheckedNode.typeName`
+// serialization contract at the host-bridge seam.
+// ---------------------------------------------------------------------
+
+pub fn tyToString(arena: TyArena, idx: Int) -> String {
+    if idx < 0 {
+        return "Invalid"
+    }
+    let node = tyGet(arena, idx)
+    match node.kind {
+        TkErr -> "Invalid",
+        TkPrim -> primKindName(node.prim),
+        TkNamed -> tyNamedToString(arena, node),
+        TkOptional -> "{tyToString(arena, node.ret)}?",
+        TkTuple -> tyTupleToString(arena, node.args),
+        TkFn -> tyFnToString(arena, node.args, node.ret),
+        TkVar -> {
+            if node.varName == "" {
+                "?{node.varId}"
+            } else {
+                node.varName
+            }
+        },
+        TkSelf -> "Self",
+    }
+}
+
+fn tyNamedToString(arena: TyArena, node: TyNode) -> String {
+    if tyIntListLen(node.args) == 0 {
+        return node.head
+    }
+    let mut parts: List<String> = []
+    for arg in node.args {
+        parts.push(tyToString(arena, arg))
+    }
+    "{node.head}<{strings.join(parts, \", \")}>"
+}
+
+fn tyTupleToString(arena: TyArena, elems: List<Int>) -> String {
+    let mut parts: List<String> = []
+    for e in elems {
+        parts.push(tyToString(arena, e))
+    }
+    "({strings.join(parts, \", \")})"
+}
+
+fn tyFnToString(arena: TyArena, params: List<Int>, ret: Int) -> String {
+    let mut parts: List<String> = []
+    for p in params {
+        parts.push(tyToString(arena, p))
+    }
+    "fn({strings.join(parts, \", \")}) -> {tyToString(arena, ret)}"
+}
+
+fn primKindName(prim: PrimKind) -> String {
+    match prim {
+        PkInvalid -> "Invalid",
+        PkInt -> "Int",
+        PkInt8 -> "Int8",
+        PkInt16 -> "Int16",
+        PkInt32 -> "Int32",
+        PkInt64 -> "Int64",
+        PkUInt8 -> "UInt8",
+        PkUInt16 -> "UInt16",
+        PkUInt32 -> "UInt32",
+        PkUInt64 -> "UInt64",
+        PkByte -> "Byte",
+        PkFloat -> "Float",
+        PkFloat32 -> "Float32",
+        PkFloat64 -> "Float64",
+        PkBool -> "Bool",
+        PkChar -> "Char",
+        PkString -> "String",
+        PkBytes -> "Bytes",
+        PkUnit -> "()",
+        PkNever -> "Never",
+        PkUntypedInt -> "UntypedInt",
+        PkUntypedFloat -> "UntypedFloat",
+    }
+}
+
+// ---------------------------------------------------------------------
+// Transitional bridge from the legacy string representation. Only
+// parses the exact dialect emitted by the old `frontCheckParseType`
+// (see `toolchain/check.osty:1293`); anything outside that grammar
+// lands in `TkErr`.
+// ---------------------------------------------------------------------
+
+/// tyFromString parses a legacy serialized type and interns it into the
+/// arena. Supported shapes: primitive names, `Head<Arg, ...>` (including
+/// nested generics), `fn(Args, ...) -> Ret` (Unit return when the tail
+/// is `()`), `(A, B)` tuples, trailing `?` optionality, and `Self`.
+/// Unknown input returns `tErr(arena)`.
+pub fn tyFromString(arena: TyArena, source: String) -> Int {
+    let trimmed = strings.trimSpace(source)
+    if trimmed == "" {
+        return tErr(arena)
+    }
+    // Unwrap trailing `?` optionality first so the inner parse does not
+    // have to treat it as a type-head continuation.
+    if strings.hasSuffix(trimmed, "?") && !(strings.hasSuffix(trimmed, "??")) {
+        let inner = tyFromString(arena, strings.trimSuffix(trimmed, "?"))
+        return tyOptional(arena, inner)
+    }
+    if trimmed == "Self" {
+        return tySelf(arena, "")
+    }
+    let prim = primKindFromName(trimmed)
+    if prim != PkInvalid {
+        return tyPrim(arena, prim)
+    }
+    if strings.hasPrefix(trimmed, "(") && strings.hasSuffix(trimmed, ")") {
+        return tyTupleFromString(arena, trimmed)
+    }
+    if strings.hasPrefix(trimmed, "fn(") {
+        return tyFnFromString(arena, trimmed)
+    }
+    // Named type, possibly with generic arguments.
+    let head = typeHeadRaw(trimmed)
+    if head == "" {
+        return tErr(arena)
+    }
+    let rest = strings.trimPrefix(trimmed, head)
+    if rest == "" {
+        return tyNamed(arena, head, [])
+    }
+    if !(strings.hasPrefix(rest, "<")) || !(strings.hasSuffix(rest, ">")) {
+        return tErr(arena)
+    }
+    let argsText = strings.trimSuffix(strings.trimPrefix(rest, "<"), ">")
+    let args = tyArgsFromString(arena, argsText)
+    tyNamed(arena, head, args)
+}
+
+fn primKindFromName(text: String) -> PrimKind {
+    if text == "Int" { return PkInt }
+    if text == "Int8" { return PkInt8 }
+    if text == "Int16" { return PkInt16 }
+    if text == "Int32" { return PkInt32 }
+    if text == "Int64" { return PkInt64 }
+    if text == "UInt8" { return PkUInt8 }
+    if text == "UInt16" { return PkUInt16 }
+    if text == "UInt32" { return PkUInt32 }
+    if text == "UInt64" { return PkUInt64 }
+    if text == "Byte" { return PkByte }
+    if text == "Float" { return PkFloat }
+    if text == "Float32" { return PkFloat32 }
+    if text == "Float64" { return PkFloat64 }
+    if text == "Bool" { return PkBool }
+    if text == "Char" { return PkChar }
+    if text == "String" { return PkString }
+    if text == "Bytes" { return PkBytes }
+    if text == "()" { return PkUnit }
+    if text == "Never" { return PkNever }
+    if text == "UntypedInt" { return PkUntypedInt }
+    if text == "UntypedFloat" { return PkUntypedFloat }
+    if text == "Invalid" { return PkInvalid }
+    PkInvalid
+}
+
+fn typeHeadRaw(text: String) -> String {
+    let mut head = ""
+    for unit in strings.split(text, "") {
+        if unit == "<" {
+            return head
+        }
+        if unit == "(" || unit == ")" || unit == "," || unit == " " {
+            return head
+        }
+        head = "{head}{unit}"
+    }
+    head
+}
+
+fn tyTupleFromString(arena: TyArena, text: String) -> Int {
+    let inner = strings.trimSuffix(strings.trimPrefix(text, "("), ")")
+    if strings.trimSpace(inner) == "" {
+        return tUnit(arena)
+    }
+    let elems = tyArgsFromString(arena, inner)
+    tyTuple(arena, elems)
+}
+
+fn tyFnFromString(arena: TyArena, text: String) -> Int {
+    // Expect "fn(<params>) -> <ret>".
+    let afterFn = strings.trimPrefix(text, "fn")
+    if !(strings.hasPrefix(afterFn, "(")) {
+        return tErr(arena)
+    }
+    let paramsText = splitFnParamsText(afterFn)
+    if paramsText == "" {
+        return tErr(arena)
+    }
+    let paramsInner = strings.trimSuffix(strings.trimPrefix(paramsText, "("), ")")
+    let mut params: List<Int> = []
+    if strings.trimSpace(paramsInner) != "" {
+        params = tyArgsFromString(arena, paramsInner)
+    }
+    let tail = strings.trimSpace(strings.trimPrefix(afterFn, paramsText))
+    let retText = strings.trimSpace(strings.trimPrefix(tail, "->"))
+    let ret = if retText == "" { tUnit(arena) } else { tyFromString(arena, retText) }
+    tyFn(arena, params, ret)
+}
+
+fn splitFnParamsText(text: String) -> String {
+    // Collect the balanced `(...)` starting at position 0. Depth tracks
+    // only parens; angles/tuples inside the list belong to the params.
+    let mut depth = 0
+    let mut out = ""
+    let mut started = false
+    for unit in strings.split(text, "") {
+        out = "{out}{unit}"
+        if unit == "(" {
+            depth = depth + 1
+            started = true
+        } else if unit == ")" {
+            depth = depth - 1
+            if started && depth == 0 {
+                return out
+            }
+        }
+    }
+    out
+}
+
+fn tyArgsFromString(arena: TyArena, text: String) -> List<Int> {
+    let parts = splitTopLevel(text)
+    let mut out: List<Int> = []
+    for part in parts {
+        out.push(tyFromString(arena, strings.trimSpace(part)))
+    }
+    out
+}
+
+/// splitTopLevel splits a comma-separated type-argument text at the top
+/// nesting level. Mirrors `frontCheckSplitTopLevel` so the bridge stays
+/// format-compatible during migration.
+fn splitTopLevel(text: String) -> List<String> {
+    let mut out: List<String> = []
+    let mut cur = ""
+    let mut angle = 0
+    let mut paren = 0
+    for unit in strings.split(text, "") {
+        if unit == "<" {
+            angle = angle + 1
+            cur = "{cur}{unit}"
+        } else if unit == ">" {
+            angle = angle - 1
+            cur = "{cur}{unit}"
+        } else if unit == "(" {
+            paren = paren + 1
+            cur = "{cur}{unit}"
+        } else if unit == ")" {
+            paren = paren - 1
+            cur = "{cur}{unit}"
+        } else if unit == "," && angle == 0 && paren == 0 {
+            out.push(strings.trimSpace(cur))
+            cur = ""
+        } else {
+            cur = "{cur}{unit}"
+        }
+    }
+    if strings.trimSpace(cur) != "" {
+        out.push(strings.trimSpace(cur))
+    }
+    out
+}

--- a/toolchain/ty_test.osty
+++ b/toolchain/ty_test.osty
@@ -1,0 +1,127 @@
+// ty_test.osty — unit tests for the typed type arena introduced in
+// Phase 1 of the bidirectional-elaborator migration. Runs standalone
+// under the future native-backend harness; the file is orphan today
+// because `toolchain/*.osty` is not wired into `just front`.
+
+use std.testing
+
+fn testTyArenaCanonicalPrimitives() {
+    let arena = emptyTyArena()
+
+    testing.assertEq(tyKindAt(arena, tInt(arena)), TkPrim)
+    testing.assertEq(tyPrimAt(arena, tInt(arena)), PkInt)
+    testing.assertEq(tyToString(arena, tInt(arena)), "Int")
+
+    testing.assertEq(tyToString(arena, tBool(arena)), "Bool")
+    testing.assertEq(tyToString(arena, tUnit(arena)), "()")
+    testing.assertEq(tyToString(arena, tNever(arena)), "Never")
+    testing.assertEq(tyToString(arena, tUntypedInt(arena)), "UntypedInt")
+    testing.assertEq(tyToString(arena, tErr(arena)), "Invalid")
+
+    // Canonical indices are stable across lookups, which is what the
+    // elaborator relies on when comparing primitive types by index.
+    testing.assertEq(tInt(arena), tyPrim(arena, PkInt))
+    testing.assertEq(tString(arena), tyPrim(arena, PkString))
+}
+
+fn testTyArenaNamedTypeRoundTrip() {
+    let arena = emptyTyArena()
+    let listOfInt = tyNamed(arena, "List", [tInt(arena)])
+    let mapStrList = tyNamed(arena, "Map", [tString(arena), listOfInt])
+
+    testing.assertEq(tyToString(arena, listOfInt), "List<Int>")
+    testing.assertEq(tyToString(arena, mapStrList), "Map<String, List<Int>>")
+
+    let parsed = tyFromString(arena, "Map<String, List<Int>>")
+    testing.assertEq(tyToString(arena, parsed), "Map<String, List<Int>>")
+    testing.assert(tyEq(arena, parsed, mapStrList))
+}
+
+fn testTyArenaFnTypeRoundTrip() {
+    let arena = emptyTyArena()
+    let f = tyFn(arena, [tInt(arena), tString(arena)], tBool(arena))
+    testing.assertEq(tyToString(arena, f), "fn(Int, String) -> Bool")
+
+    let parsed = tyFromString(arena, "fn(Int, String) -> Bool")
+    testing.assert(tyEq(arena, parsed, f))
+
+    let nullary = tyFn(arena, [], tUnit(arena))
+    testing.assertEq(tyToString(arena, nullary), "fn() -> ()")
+    testing.assert(tyEq(arena, tyFromString(arena, "fn() -> ()"), nullary))
+}
+
+fn testTyArenaTupleRoundTrip() {
+    let arena = emptyTyArena()
+    let pair = tyTuple(arena, [tInt(arena), tString(arena)])
+    testing.assertEq(tyToString(arena, pair), "(Int, String)")
+
+    let parsed = tyFromString(arena, "(Int, String)")
+    testing.assert(tyEq(arena, parsed, pair))
+}
+
+fn testTyArenaOptionalRoundTrip() {
+    let arena = emptyTyArena()
+    let maybeInt = tyOptional(arena, tInt(arena))
+    testing.assertEq(tyToString(arena, maybeInt), "Int?")
+
+    let parsed = tyFromString(arena, "Int?")
+    testing.assert(tyEq(arena, parsed, maybeInt))
+}
+
+fn testTyArenaVarsHaveDistinctIds() {
+    let arena = emptyTyArena()
+    let a = tyVarFresh(arena, "id", "T")
+    let b = tyVarFresh(arena, "id", "T")
+    testing.assert(!(tyEq(arena, a, b)))
+    testing.assertEq(tyVarNameAt(arena, a), "T")
+    testing.assertEq(tyVarOwnerAt(arena, a), "id")
+    testing.assert(tyVarIdAt(arena, a) != tyVarIdAt(arena, b))
+}
+
+fn testTyArenaClassificationPredicates() {
+    let arena = emptyTyArena()
+    testing.assert(tyIsInteger(arena, tInt(arena)))
+    testing.assert(tyIsInteger(arena, tByte(arena)))
+    testing.assert(tyIsInteger(arena, tUntypedInt(arena)))
+    testing.assert(!(tyIsInteger(arena, tFloat(arena))))
+
+    testing.assert(tyIsFloat(arena, tFloat(arena)))
+    testing.assert(tyIsFloat(arena, tUntypedFloat(arena)))
+
+    testing.assert(tyIsNumeric(arena, tInt(arena)))
+    testing.assert(tyIsNumeric(arena, tFloat(arena)))
+    testing.assert(!(tyIsNumeric(arena, tString(arena))))
+
+    testing.assert(tyIsOrdered(arena, tString(arena)))
+    testing.assert(tyIsOrdered(arena, tInt(arena)))
+    testing.assert(!(tyIsOrdered(arena, tBytes(arena))))
+
+    testing.assert(tyIsUntyped(arena, tUntypedInt(arena)))
+    testing.assert(!(tyIsUntyped(arena, tInt(arena))))
+}
+
+fn testTyEqStructural() {
+    let arena = emptyTyArena()
+
+    let a = tyNamed(arena, "Pair", [tInt(arena), tString(arena)])
+    let b = tyNamed(arena, "Pair", [tInt(arena), tString(arena)])
+    testing.assert(tyEq(arena, a, b))
+
+    let c = tyNamed(arena, "Pair", [tString(arena), tInt(arena)])
+    testing.assert(!(tyEq(arena, a, c)))
+
+    let f1 = tyFn(arena, [tInt(arena)], tBool(arena))
+    let f2 = tyFn(arena, [tInt(arena)], tBool(arena))
+    testing.assert(tyEq(arena, f1, f2))
+
+    let f3 = tyFn(arena, [tInt(arena)], tString(arena))
+    testing.assert(!(tyEq(arena, f1, f3)))
+}
+
+fn testTyFromStringUnknownYieldsErr() {
+    let arena = emptyTyArena()
+    testing.assertEq(tyToString(arena, tyFromString(arena, "")), "Invalid")
+    // Heads containing parens without a matching closing form land in
+    // the named-type branch, which rejects malformed "<" suffixes.
+    testing.assertEq(tyToString(arena, tyFromString(arena, "List<")), "Invalid")
+}


### PR DESCRIPTION
## Summary
- 기존 4241줄 문자열 기반 synthesis 체커를 bidirectional infer/check + 지역 제약 솔버 + elaboration-to-Core 아키텍처로 재작성
- `Ty` arena 와 타입 박힌 Core IR (55 생성자, 67 노드 종류) 신설, 기존 77 곳의 카운터 사이트를 stable `E07xx` 코드 진단으로 대체
- `toolchain/*.osty` orphan 경로 이므로 현재 런타임 동작 영향 없음 (`FrontCheckResult` 직렬화 계약 유지)

## Files
| File | LOC | Role |
|---|---|---|
| `toolchain/ty.osty` | 803 | `TyArena`, 8 종 `TyKind`, 캐논 prim 인덱스, `tyEq`/`tyToString`/`tyFromString` 브리지 |
| `toolchain/check_diag.osty` | 376 | `CheckDiagnostic` + 24 개 `E07xx` 코드 + 16 개 도메인 빌더 |
| `toolchain/core.osty` | 1768 | 67 종 Core 노드 arena, per-kind 생성자 + S-expr 프리티프린터 |
| `toolchain/check_env.osty` | 888 | 스코프·심볼·alias·generic bound + 구조적 assignability + prelude 설치 |
| `toolchain/solve.osty` | 387 | 호출-사이트 지역 `unify`/`zonk`/`occursCheck`/`freshTyVar`/`isFullyResolved` |
| `toolchain/elab.osty` | 1864 | 전체 AST kind 커버 — `infer`/`check` pair, solver 통합, 간소 exhaustiveness |
| `toolchain/check.osty` | 574 | 진입점 (collect → elaborate 2-pass), `CoreModule → FrontCheckResult` 직렬화 |
| `toolchain/*_test.osty` | 591 | ty/core/solve/elab/check_diag 단위 테스트 |

## 아키텍처
- **Bidirectional**: `elabInfer(cx, idx)` / `elabCheck(cx, idx, expected)`. 도입형(리터럴·리스트·맵·튜플·구조체·클로저)은 expected 로부터 내부 타입 세분화; 제거형(ident·call·field·index)은 infer 후 subtype
- **Constraint-only-for-generics**: 제네릭 호출 사이트당 `newSolver()` → `freshTyVar` → `unify` → `zonk`. 미해결 시 `E0720`. 전역 HM 없음
- **Elaboration**: 모든 AST 순회가 typed Core IR 노드를 바로 생성. surface AST 별도 검사 후 lowering 2-pass 제거
- **Typed diagnostics**: `E0701` (mismatch), `E0702` (arity), `E0706` (non-exhaustive), `E0720` (cannot infer T), `E0730` (`?` needs Option/Result), `E0741` (closure annotation) 등

## 범위 밖 (follow-up)
- `examples/selfhost-core/check.osty` 동기화 — 현재 런타임 영향 피하기 위해 분리
- `internal/diag/codes.go` `E07xx` 등록
- `cmd/osty-native-checker` JSON 프로토콜에 `diagnostics` 필드 추가

## Test plan
- [ ] Osty CLI 빌드 복구 후 `osty gen toolchain/check.osty` 로 파싱·타입체크 확인 (현재 `internal/ir/print.go` `Arg Expr` 이슈로 CLI 빌드 깨짐 — 이 PR 과 무관)
- [ ] `internal/selfhost/toolchain_elab_test.go` 하네스 신설하여 `toolchain/*_test.osty` 실행
- [ ] `testdata/spec/positive/*.osty` 의 일부를 elab 경로로 통과시키는 parity test

🤖 Generated with [Claude Code](https://claude.com/claude-code)