### PR TITLE
feat: IR 확장(캡처/디시전트리/최적화) + LLVM 백엔드 AST 경로 제거

### DIFF
--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -1,19 +1,26 @@
 // Package backend defines the small contract shared by concrete Osty
 // code-generation backends.
 //
-// The CLI routes native emission through this package so every backend uses the
-// same artifact/cache layout contract. LLVM lowering is still small, but it can
-// produce textual IR and drive a host clang toolchain for supported
-// object/binary artifacts. LLVM backend meaning, including scalar instruction
-// builders, plain/escaped ASCII string constants/local values/function values,
-// simple struct aggregate values, payload-free and single-`Int` payload enum tag
-// values, payload-free and payload-enum match expressions, and
-// unsupported-source diagnostic categories, including `Float`/`String` payload
-// enum smoke generalization ownership and policy (Phase 54-63) and the phase
-// 64-73 value/control-flow smoke expansion, is authored in Osty toolchain
-// sources. `Float32`/`Float64` policy is deferred. LLVM binary emission also
-// links a local backend runtime ABI object for the `osty.gc.*` surface from the
-// backend runtime directory at native link time rather than relying on Go GC
-// parity. This package remains the bootstrap host shim for file I/O and process
-// execution.
+// The CLI routes native emission through this package so every backend
+// uses the same artifact / cache layout contract. The LLVM dispatcher
+// (llvm.go) consumes IR exclusively: Request.Entry.IR is the sole
+// input it hands to llvmgen. The dispatcher no longer falls back to
+// Request.Entry.File when IR lowering hits an unsupported shape —
+// unsupported input produces an inspectable skeleton artifact instead.
+//
+// LLVM lowering is still small, but it can produce textual IR and
+// drive a host clang toolchain for supported object / binary
+// artifacts. LLVM backend meaning, including scalar instruction
+// builders, plain / escaped ASCII string constants / local values /
+// function values, simple struct aggregate values, payload-free and
+// single-`Int` payload enum tag values, payload-free and payload-enum
+// match expressions, and unsupported-source diagnostic categories,
+// including `Float` / `String` payload enum smoke generalisation
+// ownership and policy (Phase 54-63) and the phase 64-73 value /
+// control-flow smoke expansion, is authored in Osty toolchain sources.
+// `Float32` / `Float64` policy is deferred. LLVM binary emission also
+// links a local backend runtime ABI object for the `osty.gc.*` surface
+// from the backend runtime directory at native link time rather than
+// relying on Go GC parity. This package remains the bootstrap host
+// shim for file I/O and process execution.
 package backend

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -57,23 +57,15 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 		SourcePath:  req.Entry.SourcePath,
 		Target:      req.Layout.Target,
 	}
+	// IR is the sole input contract. The backend dispatcher never reaches
+	// for req.Entry.File — the AST is a front-end artifact that the LLVM
+	// backend does not consume directly any more.
 	irOut, genErr := llvmgen.GenerateModule(req.Entry.IR, opts)
-	var fallbackWarning error
-	if genErr != nil && req.Entry.File != nil && errors.Is(genErr, llvmgen.ErrUnsupported) {
-		bridgeErr := genErr
-		irOut, genErr = llvmgen.Generate(req.Entry.File, opts)
-		if genErr == nil {
-			fallbackWarning = fmt.Errorf("llvm backend: fell back to legacy AST bridge after IR lowering gap: %w", bridgeErr)
-		}
-	}
 	if genErr == nil {
 		if err := os.WriteFile(artifacts.LLVMIR, irOut, 0o644); err != nil {
 			return nil, err
 		}
 		warnings := append([]error(nil), req.Entry.IRIssues...)
-		if fallbackWarning != nil {
-			warnings = append(warnings, fallbackWarning)
-		}
 		out := &Result{
 			Backend:   NameLLVM,
 			Emit:      req.Emit,

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -236,6 +236,26 @@ func TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback(t *testing.T) {
 	}
 }
 
+// TestLLVMBackendRefusesNilIR confirms the dispatcher's IR-only
+// contract: without req.Entry.IR the backend must reject the request
+// rather than silently fall through to any AST-based path (no such
+// path exists any more).
+func TestLLVMBackendRefusesNilIR(t *testing.T) {
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() { println(1) }`)
+	req.Entry.IR = nil
+	// File is still populated; if the dispatcher secretly consulted it
+	// the test would pass by accident — we want a hard reject instead.
+	_, err := backend.Emit(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error when IR is nil, got none")
+	}
+	if !strings.Contains(err.Error(), "missing lowered IR entry") {
+		t.Fatalf("expected IR-missing diagnostic, got: %v", err)
+	}
+}
+
 func TestLLVMBackendBinaryRunsBundledRuntime(t *testing.T) {
 	if _, err := exec.LookPath("clang"); err != nil {
 		t.Skip("clang not found on PATH")

--- a/internal/ir/capture.go
+++ b/internal/ir/capture.go
@@ -1,0 +1,358 @@
+package ir
+
+// ComputeCaptures walks a closure body and returns the free variables
+// referenced inside it that are not bound by the closure itself. The
+// result is stable: the order mirrors first-reference appearance in
+// the body, and each capture appears at most once.
+//
+// params is the closure's parameter list; ComputeCaptures treats
+// those names as locally bound and therefore not captures. Nested
+// closures are NOT re-walked: if the nested closure already carries
+// Captures, those entries are promoted to outer captures whenever the
+// referenced name is not introduced by the outer closure itself. This
+// matches the semantics a lambda-lifting backend needs.
+//
+// This helper is deliberately name-scoped rather than symbol-scoped:
+// by the time lowering finishes, the IR no longer carries resolver
+// symbols, and backends reason about idents by name. When two
+// same-named bindings exist in nested scopes, only the innermost wins
+// — which aligns with how a tree-walk interpreter resolves names.
+func ComputeCaptures(body *Block, params []*Param) []*Capture {
+	if body == nil {
+		return nil
+	}
+	a := &captureAnalyzer{
+		bound:   map[string]bool{},
+		seen:    map[string]bool{},
+		results: nil,
+	}
+	for _, p := range params {
+		a.markParamBound(p)
+	}
+	a.block(body)
+	return a.results
+}
+
+type captureAnalyzer struct {
+	bound   map[string]bool // names introduced by the closure itself
+	seen    map[string]bool // names already emitted as captures
+	results []*Capture
+}
+
+func (a *captureAnalyzer) markParamBound(p *Param) {
+	if p == nil {
+		return
+	}
+	if p.Name != "" {
+		a.bound[p.Name] = true
+		return
+	}
+	if p.Pattern != nil {
+		a.patternNames(p.Pattern)
+	}
+}
+
+// patternNames records every binding name that `p` introduces.
+func (a *captureAnalyzer) patternNames(p Pattern) {
+	switch p := p.(type) {
+	case nil, *WildPat, *LitPat, *RangePat, *ErrorPat:
+		return
+	case *IdentPat:
+		a.bound[p.Name] = true
+	case *BindingPat:
+		a.bound[p.Name] = true
+		a.patternNames(p.Pattern)
+	case *TuplePat:
+		for _, e := range p.Elems {
+			a.patternNames(e)
+		}
+	case *StructPat:
+		for _, f := range p.Fields {
+			if f.Pattern == nil {
+				a.bound[f.Name] = true
+			} else {
+				a.patternNames(f.Pattern)
+			}
+		}
+	case *VariantPat:
+		for _, arg := range p.Args {
+			a.patternNames(arg)
+		}
+	case *OrPat:
+		// An or-pattern's alternatives must bind the same names; walking
+		// one is sufficient.
+		if len(p.Alts) > 0 {
+			a.patternNames(p.Alts[0])
+		}
+	}
+}
+
+// record emits a capture entry unless `name` is bound or already seen.
+func (a *captureAnalyzer) record(name string, kind CaptureKind, t Type, mut bool, span Span) {
+	if name == "" || name == "_" {
+		return
+	}
+	if a.bound[name] {
+		return
+	}
+	if a.seen[name] {
+		return
+	}
+	a.seen[name] = true
+	a.results = append(a.results, &Capture{
+		Name:  name,
+		Kind:  kind,
+		T:     t,
+		Mut:   mut,
+		SpanV: span,
+	})
+}
+
+func (a *captureAnalyzer) block(b *Block) {
+	if b == nil {
+		return
+	}
+	// Save binding set so inner `let` introductions don't leak out.
+	saved := a.snapshot()
+	for _, s := range b.Stmts {
+		a.stmt(s)
+	}
+	if b.Result != nil {
+		a.expr(b.Result)
+	}
+	a.restore(saved)
+}
+
+func (a *captureAnalyzer) snapshot() map[string]bool {
+	out := make(map[string]bool, len(a.bound))
+	for k, v := range a.bound {
+		out[k] = v
+	}
+	return out
+}
+
+func (a *captureAnalyzer) restore(snap map[string]bool) {
+	a.bound = snap
+}
+
+func (a *captureAnalyzer) stmt(s Stmt) {
+	switch s := s.(type) {
+	case nil:
+		return
+	case *Block:
+		a.block(s)
+	case *LetStmt:
+		if s.Value != nil {
+			a.expr(s.Value)
+		}
+		if s.Name != "" {
+			a.bound[s.Name] = true
+		} else if s.Pattern != nil {
+			a.patternNames(s.Pattern)
+		}
+	case *ExprStmt:
+		a.expr(s.X)
+	case *AssignStmt:
+		for _, t := range s.Targets {
+			a.expr(t)
+		}
+		a.expr(s.Value)
+	case *ReturnStmt:
+		if s.Value != nil {
+			a.expr(s.Value)
+		}
+	case *IfStmt:
+		a.expr(s.Cond)
+		a.block(s.Then)
+		if s.Else != nil {
+			a.block(s.Else)
+		}
+	case *ForStmt:
+		saved := a.snapshot()
+		if s.Var != "" {
+			a.bound[s.Var] = true
+		}
+		if s.Pattern != nil {
+			a.patternNames(s.Pattern)
+		}
+		if s.Cond != nil {
+			a.expr(s.Cond)
+		}
+		if s.Iter != nil {
+			a.expr(s.Iter)
+		}
+		if s.Start != nil {
+			a.expr(s.Start)
+		}
+		if s.End != nil {
+			a.expr(s.End)
+		}
+		a.block(s.Body)
+		a.restore(saved)
+	case *DeferStmt:
+		a.block(s.Body)
+	case *ChanSendStmt:
+		a.expr(s.Channel)
+		a.expr(s.Value)
+	case *MatchStmt:
+		a.expr(s.Scrutinee)
+		for _, arm := range s.Arms {
+			a.matchArm(arm)
+		}
+	case *BreakStmt, *ContinueStmt, *ErrorStmt:
+		// no free variables
+	}
+}
+
+func (a *captureAnalyzer) matchArm(arm *MatchArm) {
+	if arm == nil {
+		return
+	}
+	saved := a.snapshot()
+	if arm.Pattern != nil {
+		a.patternNames(arm.Pattern)
+	}
+	if arm.Guard != nil {
+		a.expr(arm.Guard)
+	}
+	a.block(arm.Body)
+	a.restore(saved)
+}
+
+func (a *captureAnalyzer) expr(e Expr) {
+	switch e := e.(type) {
+	case nil:
+		return
+	case *IntLit, *FloatLit, *BoolLit, *CharLit, *ByteLit, *UnitLit, *ErrorExpr:
+		return
+	case *StringLit:
+		for _, p := range e.Parts {
+			if !p.IsLit && p.Expr != nil {
+				a.expr(p.Expr)
+			}
+		}
+	case *Ident:
+		kind := captureKindForIdent(e.Kind)
+		if kind == CaptureUnknown {
+			return
+		}
+		a.record(e.Name, kind, e.T, false, e.SpanV)
+	case *UnaryExpr:
+		a.expr(e.X)
+	case *BinaryExpr:
+		a.expr(e.Left)
+		a.expr(e.Right)
+	case *CallExpr:
+		a.expr(e.Callee)
+		for _, arg := range e.Args {
+			a.expr(arg.Value)
+		}
+	case *IntrinsicCall:
+		for _, arg := range e.Args {
+			a.expr(arg.Value)
+		}
+	case *MethodCall:
+		a.expr(e.Receiver)
+		for _, arg := range e.Args {
+			a.expr(arg.Value)
+		}
+	case *ListLit:
+		for _, el := range e.Elems {
+			a.expr(el)
+		}
+	case *MapLit:
+		for _, en := range e.Entries {
+			a.expr(en.Key)
+			a.expr(en.Value)
+		}
+	case *TupleLit:
+		for _, el := range e.Elems {
+			a.expr(el)
+		}
+	case *StructLit:
+		for _, f := range e.Fields {
+			if f.Value != nil {
+				a.expr(f.Value)
+			} else {
+				// shorthand `{ name }` refers to a variable in the
+				// enclosing scope by that name.
+				a.record(f.Name, CaptureLocal, nil, false, f.SpanV)
+			}
+		}
+		if e.Spread != nil {
+			a.expr(e.Spread)
+		}
+	case *RangeLit:
+		if e.Start != nil {
+			a.expr(e.Start)
+		}
+		if e.End != nil {
+			a.expr(e.End)
+		}
+	case *QuestionExpr:
+		a.expr(e.X)
+	case *CoalesceExpr:
+		a.expr(e.Left)
+		a.expr(e.Right)
+	case *FieldExpr:
+		a.expr(e.X)
+	case *TupleAccess:
+		a.expr(e.X)
+	case *IndexExpr:
+		a.expr(e.X)
+		a.expr(e.Index)
+	case *Closure:
+		// Nested closure: names it captures from outside the current
+		// closure propagate up as our captures too, unless they refer
+		// to a binding we introduced ourselves.
+		for _, cap := range e.Captures {
+			if a.bound[cap.Name] {
+				continue
+			}
+			a.record(cap.Name, cap.Kind, cap.T, cap.Mut, cap.SpanV)
+		}
+	case *VariantLit:
+		for _, arg := range e.Args {
+			a.expr(arg.Value)
+		}
+	case *BlockExpr:
+		a.block(e.Block)
+	case *IfExpr:
+		a.expr(e.Cond)
+		a.block(e.Then)
+		if e.Else != nil {
+			a.block(e.Else)
+		}
+	case *IfLetExpr:
+		a.expr(e.Scrutinee)
+		saved := a.snapshot()
+		if e.Pattern != nil {
+			a.patternNames(e.Pattern)
+		}
+		a.block(e.Then)
+		a.restore(saved)
+		if e.Else != nil {
+			a.block(e.Else)
+		}
+	case *MatchExpr:
+		a.expr(e.Scrutinee)
+		for _, arm := range e.Arms {
+			a.matchArm(arm)
+		}
+	}
+}
+
+// captureKindForIdent classifies a resolved ident's kind as a capture
+// origin. Types, fns, variants and builtins are not captures: they are
+// globally accessible at compile time.
+func captureKindForIdent(k IdentKind) CaptureKind {
+	switch k {
+	case IdentLocal:
+		return CaptureLocal
+	case IdentParam:
+		return CaptureParam
+	case IdentGlobal:
+		return CaptureGlobal
+	}
+	return CaptureUnknown
+}

--- a/internal/ir/decision.go
+++ b/internal/ir/decision.go
@@ -1,0 +1,490 @@
+package ir
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DecisionNode is a node in the decision tree compiled from a match
+// expression or statement. The tree represents the same semantics as
+// the arm list but in a form closer to what a target machine has to
+// emit: a cascade of discriminating tests that eventually reach a
+// leaf (an arm) or a failure sink (an unmatched value).
+//
+// Tree shape in a nutshell:
+//
+//   - DecisionLeaf   — "arm N matched; run its body with these bindings"
+//   - DecisionFail   — "nothing matched" (never reachable when the
+//     match is exhaustive)
+//   - DecisionGuard  — "check an `if` guard; on failure, fall through
+//     to another subtree"
+//   - DecisionSwitch — "test the scrutinee (or a sub-projection) and
+//     branch to one of several children"
+//
+// The tree never owns the arm bodies; DecisionLeaf only carries an
+// index into MatchExpr.Arms / MatchStmt.Arms. Bindings introduced by a
+// pattern are materialised as DecisionBind steps above the leaf.
+type DecisionNode interface {
+	decisionNode()
+	String() string
+}
+
+// DecisionLeaf selects arm ArmIndex (into the owning match's Arms
+// slice) and hands control to its body. Bindings accumulated along the
+// path are recorded as DecisionBind chains, not on the leaf.
+type DecisionLeaf struct {
+	ArmIndex int
+}
+
+func (*DecisionLeaf) decisionNode()   {}
+func (l *DecisionLeaf) String() string { return fmt.Sprintf("leaf(arm=%d)", l.ArmIndex) }
+
+// DecisionFail is reached only when no arm matches. For a match proven
+// exhaustive by the checker this node is unreachable at runtime, but
+// backends must still emit a safe trap (e.g. a runtime abort).
+type DecisionFail struct{}
+
+func (*DecisionFail) decisionNode()   {}
+func (*DecisionFail) String() string { return "fail" }
+
+// DecisionBind adds one pattern binding (`name = projection`) to the
+// current environment and continues with Next. Binding the scrutinee
+// as a whole is represented by Proj == nil (and Index == 0). Tuple
+// fields use Kind=ProjTuple with Index; struct fields use
+// Kind=ProjField with FieldName; variant payload elements use
+// Kind=ProjVariant with Variant + Index.
+type DecisionBind struct {
+	Name string
+	Proj *Projection
+	T    Type
+	Next DecisionNode
+}
+
+func (*DecisionBind) decisionNode() {}
+func (b *DecisionBind) String() string {
+	return fmt.Sprintf("bind(%s=%s) -> %s", b.Name, projectionString(b.Proj), b.Next.String())
+}
+
+// DecisionGuard evaluates Cond; when it is true the match proceeds
+// into Then, otherwise into Else. Guards run after the pattern matched
+// — they refine the match, they do not short-circuit earlier tests.
+type DecisionGuard struct {
+	Cond Expr
+	Then DecisionNode
+	Else DecisionNode
+}
+
+func (*DecisionGuard) decisionNode() {}
+func (g *DecisionGuard) String() string {
+	return fmt.Sprintf("guard -> {%s} / {%s}", g.Then.String(), g.Else.String())
+}
+
+// DecisionSwitch tests Proj against each SwitchCase in order and
+// branches to the matching child. Default is taken when no case
+// matches; it is always non-nil (either another DecisionNode or a
+// DecisionFail sentinel).
+//
+// The switch kind tells backends how to compile the test:
+//
+//   - SwitchVariant: Proj yields an enum value; each case carries a
+//     Variant name and descends into a child where the payload has
+//     been bound.
+//   - SwitchLit:     Proj yields a scalar / string; each case carries
+//     a Lit expression compared structurally.
+//   - SwitchBool:    Proj yields a Bool; exactly two cases in {true,
+//     false} (either may be collapsed into Default).
+//   - SwitchTuple:   Proj yields a tuple; always exactly one case that
+//     destructures the tuple into N projections.
+type DecisionSwitch struct {
+	Kind    SwitchKind
+	Proj    *Projection
+	Cases   []SwitchCase
+	Default DecisionNode
+}
+
+func (*DecisionSwitch) decisionNode() {}
+func (s *DecisionSwitch) String() string {
+	var b strings.Builder
+	b.WriteString("switch(")
+	b.WriteString(switchKindName(s.Kind))
+	b.WriteString(", ")
+	b.WriteString(projectionString(s.Proj))
+	b.WriteString(") [")
+	for i, c := range s.Cases {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(c.Label)
+		b.WriteString(" -> ")
+		b.WriteString(c.Body.String())
+	}
+	b.WriteString("] else ")
+	b.WriteString(s.Default.String())
+	return b.String()
+}
+
+// SwitchKind enumerates the flavor of discrimination a DecisionSwitch
+// performs. It drives backend lowering.
+type SwitchKind int
+
+const (
+	SwitchUnknown SwitchKind = iota
+	SwitchVariant
+	SwitchLit
+	SwitchBool
+	SwitchTuple
+)
+
+// SwitchCase is one child of a DecisionSwitch. Label is a human-
+// readable description (variant name, literal text, "true"/"false");
+// Variant + Lit carry machine-usable payloads where applicable.
+type SwitchCase struct {
+	Label   string
+	Variant string       // SwitchVariant: the variant name
+	Lit     Expr         // SwitchLit: the literal compared against
+	Body    DecisionNode // subtree taken on match
+}
+
+// Projection describes how to extract a sub-value from the match's
+// scrutinee at runtime. Projections chain — a nested pattern like
+// `Some((x, y))` needs to first project the variant payload, then the
+// tuple's .0 and .1 fields.
+//
+// Base is nil for projections rooted at the scrutinee itself;
+// otherwise it points at the parent projection (e.g. "tuple field 0
+// of the payload of the Some variant of the scrutinee").
+type Projection struct {
+	Base    *Projection
+	Kind    ProjectionKind
+	Index   int    // tuple index / variant payload index
+	Field   string // struct field name
+	Variant string // variant name (for ProjVariant payloads)
+}
+
+// ProjectionKind enumerates the kinds of sub-value extraction we
+// currently model. Extendable as the pattern language grows.
+type ProjectionKind int
+
+const (
+	ProjScrutinee ProjectionKind = iota
+	ProjTuple
+	ProjField
+	ProjVariant  // select the payload of a known variant
+	ProjVariantN // select the Nth field inside a known variant's payload
+)
+
+func switchKindName(k SwitchKind) string {
+	switch k {
+	case SwitchVariant:
+		return "variant"
+	case SwitchLit:
+		return "lit"
+	case SwitchBool:
+		return "bool"
+	case SwitchTuple:
+		return "tuple"
+	}
+	return "?"
+}
+
+func projectionString(p *Projection) string {
+	if p == nil {
+		return "."
+	}
+	var parts []string
+	for cur := p; cur != nil; cur = cur.Base {
+		switch cur.Kind {
+		case ProjScrutinee:
+			parts = append(parts, ".")
+		case ProjTuple:
+			parts = append(parts, fmt.Sprintf(".%d", cur.Index))
+		case ProjField:
+			parts = append(parts, "."+cur.Field)
+		case ProjVariant:
+			parts = append(parts, "@"+cur.Variant)
+		case ProjVariantN:
+			parts = append(parts, fmt.Sprintf("@%s.%d", cur.Variant, cur.Index))
+		}
+	}
+	// parts were collected from leaf to root; reverse for display
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	return strings.Join(parts, "")
+}
+
+// ==== Decision tree compilation ====
+
+// CompileDecisionTree builds a decision tree for the given scrutinee
+// type and arms. It returns nil when the shape is outside the
+// compiler's current coverage (unusual pattern mixes, non-obvious
+// range patterns, etc.) — callers should then fall back to arm-by-arm
+// lowering. The resulting tree is well-formed: every interior node
+// has a terminating leaf on every path, and every DecisionLeaf index
+// is within [0, len(arms)).
+//
+// The algorithm is intentionally conservative: it compiles the common
+// shapes (bare variant switches, literal switches, wild catch-all,
+// single-level tuple destructure) and leaves heterogeneous or nested
+// patterns to a fallback DecisionLeaf chain that re-tests each arm in
+// order. That keeps backends simple while still optimising the cases
+// that matter for the Osty corpus today.
+func CompileDecisionTree(scrutineeT Type, arms []*MatchArm) DecisionNode {
+	if len(arms) == 0 {
+		return &DecisionFail{}
+	}
+	root := &Projection{Kind: ProjScrutinee}
+	return compileArms(arms, 0, root, scrutineeT)
+}
+
+// compileArms tries to build a specialised switch for the arms
+// starting at armStart; on unsupported patterns it degrades to a
+// straight chain of arm tests (DecisionGuard cascading to DecisionFail).
+func compileArms(arms []*MatchArm, armStart int, proj *Projection, t Type) DecisionNode {
+	if armStart >= len(arms) {
+		return &DecisionFail{}
+	}
+
+	// Detect a single wildcard / ident arm at this position: that
+	// short-circuits the whole cascade.
+	first := arms[armStart]
+	if isCatchAll(first.Pattern) {
+		return compileArmBody(armStart, first, proj)
+	}
+
+	// Try a specialised variant switch when every reachable arm is a
+	// VariantPat (or wildcard).
+	if sw := tryCompileVariantSwitch(arms, armStart, proj); sw != nil {
+		return sw
+	}
+	// Try a literal switch (for Bool / Int / Char / String).
+	if sw := tryCompileLitSwitch(arms, armStart, proj); sw != nil {
+		return sw
+	}
+
+	// Fallback: straight chain of "try this arm; else continue".
+	return compileArmChain(arms, armStart, proj)
+}
+
+// compileArmBody materialises a single arm into a DecisionBind chain
+// terminating in a DecisionLeaf (plus an optional DecisionGuard).
+func compileArmBody(armIdx int, arm *MatchArm, proj *Projection) DecisionNode {
+	leaf := DecisionNode(&DecisionLeaf{ArmIndex: armIdx})
+	body := bindPattern(arm.Pattern, proj, leaf)
+	if arm.Guard != nil {
+		return &DecisionGuard{Cond: arm.Guard, Then: body, Else: &DecisionFail{}}
+	}
+	return body
+}
+
+// compileArmChain emits "try arm 0; if no match, try arm 1; …" as a
+// cascade of guards + leaves. It is the safe fallback for arms whose
+// patterns we cannot specialise.
+func compileArmChain(arms []*MatchArm, armStart int, proj *Projection) DecisionNode {
+	cur := DecisionNode(&DecisionFail{})
+	for i := len(arms) - 1; i >= armStart; i-- {
+		arm := arms[i]
+		leaf := DecisionNode(&DecisionLeaf{ArmIndex: i})
+		body := bindPattern(arm.Pattern, proj, leaf)
+		if arm.Guard != nil {
+			body = &DecisionGuard{Cond: arm.Guard, Then: body, Else: cur}
+		}
+		// A catch-all collapses everything below it.
+		if isCatchAll(arm.Pattern) && arm.Guard == nil {
+			cur = body
+			continue
+		}
+		cur = &DecisionGuard{Cond: nil, Then: body, Else: cur}
+	}
+	return cur
+}
+
+// tryCompileVariantSwitch returns a DecisionSwitch on variant tags
+// when the arms form a pure variant-dispatch. A trailing
+// wildcard/ident arm becomes the default.
+func tryCompileVariantSwitch(arms []*MatchArm, armStart int, proj *Projection) DecisionNode {
+	cases := map[string][]int{}
+	order := []string{}
+	var defaultArm int = -1
+	for i := armStart; i < len(arms); i++ {
+		arm := arms[i]
+		switch p := arm.Pattern.(type) {
+		case *VariantPat:
+			if _, ok := cases[p.Variant]; !ok {
+				order = append(order, p.Variant)
+			}
+			cases[p.Variant] = append(cases[p.Variant], i)
+		case *WildPat, *IdentPat:
+			if defaultArm == -1 {
+				defaultArm = i
+			}
+			// arms after a catch-all are unreachable — stop scanning
+			i = len(arms)
+		default:
+			return nil
+		}
+	}
+	if len(order) == 0 {
+		return nil
+	}
+	sw := &DecisionSwitch{Kind: SwitchVariant, Proj: proj}
+	for _, name := range order {
+		idx := cases[name][0]
+		arm := arms[idx]
+		pat, _ := arm.Pattern.(*VariantPat)
+		payloadProj := &Projection{Base: proj, Kind: ProjVariant, Variant: pat.Variant}
+		child := compileArmBody(idx, arm, payloadProj)
+		sw.Cases = append(sw.Cases, SwitchCase{
+			Label:   pat.Variant,
+			Variant: pat.Variant,
+			Body:    child,
+		})
+	}
+	if defaultArm >= 0 {
+		sw.Default = compileArmBody(defaultArm, arms[defaultArm], proj)
+	} else {
+		sw.Default = &DecisionFail{}
+	}
+	return sw
+}
+
+// tryCompileLitSwitch compiles arms like `1 => …, 2 => …, _ => …`
+// into a scalar-switch tree. Supports Int, Bool, Char, Byte and
+// String literal patterns.
+func tryCompileLitSwitch(arms []*MatchArm, armStart int, proj *Projection) DecisionNode {
+	cases := []SwitchCase{}
+	var defaultArm int = -1
+	kind := SwitchUnknown
+	for i := armStart; i < len(arms); i++ {
+		arm := arms[i]
+		switch p := arm.Pattern.(type) {
+		case *LitPat:
+			k := switchKindOfLit(p.Value)
+			if k == SwitchUnknown {
+				return nil
+			}
+			if kind == SwitchUnknown {
+				kind = k
+			} else if kind != k {
+				return nil
+			}
+			body := compileArmBody(i, arm, proj)
+			cases = append(cases, SwitchCase{
+				Label: litLabel(p.Value),
+				Lit:   p.Value,
+				Body:  body,
+			})
+		case *WildPat, *IdentPat:
+			if defaultArm == -1 {
+				defaultArm = i
+			}
+			i = len(arms)
+		default:
+			return nil
+		}
+	}
+	if kind == SwitchUnknown || len(cases) == 0 {
+		return nil
+	}
+	sw := &DecisionSwitch{Kind: kind, Proj: proj, Cases: cases}
+	if defaultArm >= 0 {
+		sw.Default = compileArmBody(defaultArm, arms[defaultArm], proj)
+	} else {
+		sw.Default = &DecisionFail{}
+	}
+	return sw
+}
+
+func switchKindOfLit(e Expr) SwitchKind {
+	switch e.(type) {
+	case *BoolLit:
+		return SwitchBool
+	case *IntLit, *CharLit, *ByteLit, *FloatLit:
+		return SwitchLit
+	case *StringLit:
+		return SwitchLit
+	}
+	return SwitchUnknown
+}
+
+func litLabel(e Expr) string {
+	switch v := e.(type) {
+	case *BoolLit:
+		if v.Value {
+			return "true"
+		}
+		return "false"
+	case *IntLit:
+		return v.Text
+	case *FloatLit:
+		return v.Text
+	case *CharLit:
+		return fmt.Sprintf("'%c'", v.Value)
+	case *ByteLit:
+		return fmt.Sprintf("b%d", v.Value)
+	case *StringLit:
+		var b strings.Builder
+		b.WriteByte('"')
+		for _, p := range v.Parts {
+			if p.IsLit {
+				b.WriteString(p.Lit)
+			} else {
+				b.WriteString("{…}")
+			}
+		}
+		b.WriteByte('"')
+		return b.String()
+	}
+	return "?"
+}
+
+// bindPattern materialises a DecisionBind chain for every name that
+// the pattern introduces, then hands control to rest.
+func bindPattern(p Pattern, proj *Projection, rest DecisionNode) DecisionNode {
+	if p == nil {
+		return rest
+	}
+	switch p := p.(type) {
+	case *IdentPat:
+		return &DecisionBind{Name: p.Name, Proj: proj, Next: rest}
+	case *BindingPat:
+		return &DecisionBind{Name: p.Name, Proj: proj, Next: bindPattern(p.Pattern, proj, rest)}
+	case *TuplePat:
+		for i, elem := range p.Elems {
+			childProj := &Projection{Base: proj, Kind: ProjTuple, Index: i}
+			rest = bindPattern(elem, childProj, rest)
+		}
+		return rest
+	case *StructPat:
+		for _, f := range p.Fields {
+			childProj := &Projection{Base: proj, Kind: ProjField, Field: f.Name}
+			if f.Pattern == nil {
+				rest = &DecisionBind{Name: f.Name, Proj: childProj, Next: rest}
+			} else {
+				rest = bindPattern(f.Pattern, childProj, rest)
+			}
+		}
+		return rest
+	case *VariantPat:
+		for i, arg := range p.Args {
+			childProj := &Projection{Base: proj, Kind: ProjVariantN, Variant: p.Variant, Index: i}
+			rest = bindPattern(arg, childProj, rest)
+		}
+		return rest
+	}
+	return rest
+}
+
+// isCatchAll reports whether p matches every value (wildcard or bare
+// ident without further structure).
+func isCatchAll(p Pattern) bool {
+	switch p := p.(type) {
+	case *WildPat:
+		return true
+	case *IdentPat:
+		return !p.Mut
+	case *BindingPat:
+		return isCatchAll(p.Pattern)
+	}
+	return false
+}

--- a/internal/ir/doc.go
+++ b/internal/ir/doc.go
@@ -33,18 +33,27 @@
 //     LetDecl, UseDecl.
 //   - Stmts: Block, LetStmt, ExprStmt, AssignStmt (multi-target),
 //     ReturnStmt, BreakStmt, ContinueStmt, IfStmt, ForStmt (inf /
-//     while / range / in), DeferStmt, ChanSendStmt, MatchStmt,
+//     while / range / in, with optional destructuring pattern),
+//     DeferStmt, ChanSendStmt, MatchStmt (arms + optional DecisionTree),
 //     ErrorStmt.
-//   - Exprs: literals (int/float/bool/char/byte/string/unit), Ident,
-//     UnaryExpr, BinaryExpr, CoalesceExpr, QuestionExpr, CallExpr,
-//     IntrinsicCall (print-family), MethodCall, VariantLit, FieldExpr,
-//     TupleAccess, IndexExpr, ListLit, MapLit, TupleLit, StructLit,
-//     RangeLit, Closure, BlockExpr, IfExpr, IfLetExpr, MatchExpr,
-//     ErrorExpr.
+//   - Exprs: literals (int/float/bool/char/byte/string/unit), Ident
+//     (carries TypeArgs for bare-turbofish references), UnaryExpr,
+//     BinaryExpr, CoalesceExpr, QuestionExpr, CallExpr (TypeArgs + Args),
+//     IntrinsicCall, MethodCall, VariantLit, FieldExpr, TupleAccess,
+//     IndexExpr, ListLit, MapLit, TupleLit, StructLit, RangeLit,
+//     Closure (Captures), BlockExpr, IfExpr, IfLetExpr, MatchExpr (arms
+//     + optional DecisionTree), ErrorExpr.
 //   - Patterns: WildPat, IdentPat, LitPat, TuplePat, StructPat,
 //     VariantPat, RangePat, OrPat, BindingPat, ErrorPat.
-//   - Types: PrimType (with canonical singletons), NamedType,
-//     OptionalType, TupleType, FnType, TypeVar, ErrType.
+//   - Types: PrimType (with canonical singletons), NamedType (Package
+//     qualifier + Name), OptionalType, TupleType, FnType, TypeVar,
+//     ErrType.
+//   - Arg: {Name, Value, SpanV} — keyword arguments preserved on
+//     CallExpr, MethodCall, IntrinsicCall, VariantLit.
+//   - Capture: {Name, Kind, T, Mut, SpanV} — per-Closure free-variable
+//     list computed during lowering.
+//   - DecisionNode: DecisionLeaf / DecisionFail / DecisionBind /
+//     DecisionGuard / DecisionSwitch — compiled match decision tree.
 //
 // Tools
 //
@@ -60,20 +69,30 @@
 //     renderer for tests and visual inspection.
 //
 //   - Validate(m) — lightweight structural sanity check useful during
-//     backend development.
+//     backend development. ValidateDecisionTree(n, armCount) checks a
+//     compiled match decision tree in isolation.
+//
+//   - Optimize(m, opts) — an IR-level optimiser that performs constant
+//     folding, algebraic simplification, dead-code elimination, and
+//     branch-literal folding. Every pass is opt-outable via
+//     OptimizeOptions.
+//
+//   - ComputeCaptures(body, params) — free-variable analysis over a
+//     closure body.
+//
+//   - CompileDecisionTree(scrutineeT, arms) — build a decision tree
+//     for a match.
 //
 // Known gaps (follow-on work)
 //
-//   - The native LLVM backend still consumes the AST directly in several
-//     places. Rewriting it fully against `ir` is a substantial refactor tracked
-//     as a separate effort.
+//   - The native LLVM backend's public API is IR-only: the dispatcher
+//     (internal/backend/llvm.go) accepts lowered IR modules and there
+//     is no fallback to the AST. Internally, llvmgen still routes the
+//     IR through a local IR→AST bridge (llvmgen.legacyFileFromModule)
+//     before feeding the long-standing emitter. That bridge is an
+//     implementation detail, not a public contract.
 //
-//   - Generic monomorphisation info (check.Result.Instantiations) is
-//     not yet threaded through; backends that need per-call-site
-//     type arguments should consult the checker until the IR
-//     surfaces them.
-//
-//   - Destructuring `for` heads lower to ForIn with an empty Var and
-//     a note; a ForDestructure variant may emerge when a consumer
-//     actually needs it.
+//   - The IR remains a typed tree — no SSA/CFG level. Flow-sensitive
+//     analyses (escape, lifetime, nullability) would need a MIR-style
+//     lowering beneath this package.
 package ir

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -165,7 +165,13 @@ var (
 // distinguishes prelude-provided names (List, Map, Set, Option, Result)
 // from user declarations; backends commonly need that distinction to
 // choose between a runtime primitive and a user type.
+//
+// Package is the qualifier preceding the name (empty for bare names).
+// For multi-segment paths like `pkg.sub.Type`, the Package string
+// preserves the dotted prefix so backends can route to the right package
+// without ambiguity.
 type NamedType struct {
+	Package string
 	Name    string
 	Args    []Type
 	Builtin bool
@@ -174,20 +180,32 @@ type NamedType struct {
 func (*NamedType) typeNode() {}
 
 func (n *NamedType) String() string {
-	if len(n.Args) == 0 {
+	var b strings.Builder
+	if n.Package != "" {
+		b.WriteString(n.Package)
+		b.WriteByte('.')
+	}
+	b.WriteString(n.Name)
+	if len(n.Args) > 0 {
+		b.WriteByte('<')
+		for i, a := range n.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(typeString(a))
+		}
+		b.WriteByte('>')
+	}
+	return b.String()
+}
+
+// QualifiedName returns "pkg.Name" when Package is non-empty, otherwise
+// just Name. Useful for debug output and when comparing paths.
+func (n *NamedType) QualifiedName() string {
+	if n.Package == "" {
 		return n.Name
 	}
-	var b strings.Builder
-	b.WriteString(n.Name)
-	b.WriteByte('<')
-	for i, a := range n.Args {
-		if i > 0 {
-			b.WriteString(", ")
-		}
-		b.WriteString(typeString(a))
-	}
-	b.WriteByte('>')
-	return b.String()
+	return n.Package + "." + n.Name
 }
 
 // OptionalType is the surface form `T?`. Kept distinct from
@@ -303,14 +321,24 @@ func (f *FnDecl) DeclName() string { return f.Name }
 
 // Param is one function / method parameter. Default is an already
 // lowered expression or nil when absent.
+//
+// Pattern is non-nil for destructured parameters such as
+// `|(a, b)|` or `|User { name }|`. When Pattern is set, Name is empty
+// and backends destructure the incoming value against the pattern.
+// Simple name-bound params keep Pattern nil and Name populated.
 type Param struct {
 	Name    string
+	Pattern Pattern
 	Type    Type
 	Default Expr
 	SpanV   Span
 }
 
 func (p *Param) At() Span { return p.SpanV }
+
+// IsDestructured reports whether the parameter uses a destructuring
+// pattern rather than a bare name.
+func (p *Param) IsDestructured() bool { return p != nil && p.Pattern != nil }
 
 // TypeParam is a generic type parameter `T` with optional bounds. The
 // bounds are interface names (already-lowered NamedType).
@@ -515,15 +543,20 @@ const (
 //	In:       Var, Iter, Body
 type ForStmt struct {
 	Kind      ForKind
-	Var       string // loop variable (Range, In)
-	Cond      Expr   // While
-	Iter      Expr   // In
-	Start     Expr   // Range
-	End       Expr   // Range
-	Inclusive bool   // Range `..=`
+	Var       string  // loop variable for simple-name Range / In forms
+	Pattern   Pattern // destructuring pattern for In / Range heads
+	Cond      Expr    // While
+	Iter      Expr    // In
+	Start     Expr    // Range
+	End       Expr    // Range
+	Inclusive bool    // Range `..=`
 	Body      *Block
 	SpanV     Span
 }
+
+// IsDestructured reports whether the loop head uses a destructuring
+// pattern rather than a bare identifier.
+func (f *ForStmt) IsDestructured() bool { return f != nil && f.Pattern != nil }
 
 func (*ForStmt) stmtNode()  {}
 func (f *ForStmt) At() Span { return f.SpanV }
@@ -651,11 +684,17 @@ const (
 // Ident is a name reference. Kind distinguishes locals from calls on
 // top-level fn names so the backend can rewrite user calls without a
 // second resolution pass.
+//
+// TypeArgs carries turbofish type arguments written without a following
+// call (`f::<Int>` when used as a value — e.g. as a function pointer).
+// Most idents leave TypeArgs empty; lowerCall lifts the turbofish into
+// CallExpr.TypeArgs instead of leaving it on the callee ident.
 type Ident struct {
-	Name  string
-	Kind  IdentKind
-	T     Type
-	SpanV Span
+	Name     string
+	Kind     IdentKind
+	TypeArgs []Type
+	T        Type
+	SpanV    Span
 }
 
 func (*Ident) exprNode()    {}
@@ -726,12 +765,33 @@ func (*BinaryExpr) exprNode()    {}
 func (e *BinaryExpr) At() Span   { return e.SpanV }
 func (e *BinaryExpr) Type() Type { return e.T }
 
-// CallExpr is a user function / method / closure call.
+// Arg is one argument inside a call, method call, intrinsic call, or
+// variant constructor. Name is empty for positional arguments; for
+// keyword arguments it carries the parameter name written at the call
+// site (`greet(name: "Ada")` yields Arg{Name:"name", Value: StringLit}).
+type Arg struct {
+	Name  string
+	Value Expr
+	SpanV Span
+}
+
+// At returns the argument's source span.
+func (a Arg) At() Span { return a.SpanV }
+
+// IsKeyword reports whether the argument was written with a `name:`
+// prefix at the call site.
+func (a Arg) IsKeyword() bool { return a.Name != "" }
+
+// CallExpr is a user function / method / closure call. TypeArgs records
+// the concrete type arguments supplied at this call site (from
+// turbofish or propagated from the checker's monomorphisation info). It
+// is empty for non-generic calls.
 type CallExpr struct {
-	Callee Expr
-	Args   []Expr
-	T      Type
-	SpanV  Span
+	Callee   Expr
+	TypeArgs []Type
+	Args     []Arg
+	T        Type
+	SpanV    Span
 }
 
 func (*CallExpr) exprNode()    {}
@@ -755,7 +815,7 @@ const (
 // directly rather than string-matching on names.
 type IntrinsicCall struct {
 	Kind  IntrinsicKind
-	Args  []Expr
+	Args  []Arg
 	SpanV Span
 }
 
@@ -898,9 +958,15 @@ func (c *ChanSendStmt) At() Span { return c.SpanV }
 // equivalent expression form (MatchExpr) has a non-unit Type; when the
 // checker determined the match is used for side effects only, the
 // lowerer emits MatchStmt so backends don't synthesise a wasted value.
+//
+// Tree is an optional pre-compiled decision tree (see decision.go). It
+// is nil when the lowerer skipped compilation (disabled, or a pattern
+// shape the tree compiler does not yet handle) — backends should then
+// fall back to arm-by-arm evaluation using Arms.
 type MatchStmt struct {
 	Scrutinee Expr
 	Arms      []*MatchArm
+	Tree      DecisionNode
 	SpanV     Span
 }
 
@@ -942,7 +1008,7 @@ type MethodCall struct {
 	Receiver Expr
 	Name     string
 	TypeArgs []Type
-	Args     []Expr
+	Args     []Arg
 	T        Type
 	SpanV    Span
 }
@@ -1056,12 +1122,38 @@ func (c *CoalesceExpr) Type() Type { return c.T }
 // Closure is `|params| body` (short form) or `|params| -> T { body }`.
 // Body is always lowered as a *Block for uniformity; a single-
 // expression closure is wrapped with Result set and Stmts empty.
+// CaptureKind classifies how a name becomes available inside a closure
+// without being a parameter of that closure.
+type CaptureKind int
+
+const (
+	CaptureUnknown CaptureKind = iota
+	CaptureLocal               // outer `let` binding (stack local)
+	CaptureParam               // outer function / method parameter
+	CaptureGlobal              // top-level `let`
+	CaptureFn                  // top-level function reference
+	CaptureSelf                // enclosing method's receiver
+)
+
+// Capture is one free variable referenced by a closure.
+type Capture struct {
+	Name  string
+	Kind  CaptureKind
+	T     Type
+	Mut   bool
+	SpanV Span
+}
+
+// At returns the capture's source span (the first reference site).
+func (c *Capture) At() Span { return c.SpanV }
+
 type Closure struct {
-	Params []*Param
-	Return Type
-	Body   *Block
-	T      Type
-	SpanV  Span
+	Params   []*Param
+	Return   Type
+	Body     *Block
+	Captures []*Capture
+	T        Type
+	SpanV    Span
 }
 
 func (*Closure) exprNode()    {}
@@ -1074,7 +1166,7 @@ func (c *Closure) Type() Type { return c.T }
 type VariantLit struct {
 	Enum    string
 	Variant string
-	Args    []Expr
+	Args    []Arg
 	T       Type
 	SpanV   Span
 }
@@ -1083,10 +1175,13 @@ func (*VariantLit) exprNode()    {}
 func (v *VariantLit) At() Span   { return v.SpanV }
 func (v *VariantLit) Type() Type { return v.T }
 
-// MatchExpr is `match scrutinee { arm, ... }`.
+// MatchExpr is `match scrutinee { arm, ... }`. Tree is an optional
+// pre-compiled decision tree produced by CompileDecisionTree; it is
+// nil when the arm shapes are outside the compiler's current coverage.
 type MatchExpr struct {
 	Scrutinee Expr
 	Arms      []*MatchArm
+	Tree      DecisionNode
 	T         Type
 	SpanV     Span
 }

--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -1,0 +1,363 @@
+package ir
+
+import (
+	"testing"
+)
+
+// ==== Constant folding ====
+
+func TestOptimizeFoldsIntArithmetic(t *testing.T) {
+	// (1 + 2) * 3
+	e := &BinaryExpr{
+		Op:   BinMul,
+		Left: &BinaryExpr{Op: BinAdd, Left: intLit("1"), Right: intLit("2"), T: TInt},
+		Right: intLit("3"),
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	got := m.Script[0].(*ExprStmt).X
+	lit, ok := got.(*IntLit)
+	if !ok {
+		t.Fatalf("expected IntLit after folding, got %T", got)
+	}
+	if lit.Text != "9" {
+		t.Fatalf("expected 9, got %q", lit.Text)
+	}
+}
+
+func TestOptimizeFoldsBoolLogic(t *testing.T) {
+	// true && false
+	e := &BinaryExpr{
+		Op:    BinAnd,
+		Left:  &BoolLit{Value: true},
+		Right: &BoolLit{Value: false},
+		T:     TBool,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	got := m.Script[0].(*ExprStmt).X
+	lit, ok := got.(*BoolLit)
+	if !ok {
+		t.Fatalf("expected BoolLit after folding, got %T", got)
+	}
+	if lit.Value != false {
+		t.Fatalf("expected false, got %v", lit.Value)
+	}
+}
+
+func TestOptimizeFoldsStringConcat(t *testing.T) {
+	// "hi, " + "world"
+	e := &BinaryExpr{
+		Op: BinAdd,
+		Left: &StringLit{
+			Parts: []StringPart{{IsLit: true, Lit: "hi, "}},
+		},
+		Right: &StringLit{
+			Parts: []StringPart{{IsLit: true, Lit: "world"}},
+		},
+		T: TString,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	got := m.Script[0].(*ExprStmt).X
+	lit, ok := got.(*StringLit)
+	if !ok {
+		t.Fatalf("expected StringLit after folding, got %T", got)
+	}
+	if text := stringLitText(lit); text != "hi, world" {
+		t.Fatalf("expected %q, got %q", "hi, world", text)
+	}
+}
+
+func TestOptimizeSimplifiesIdentities(t *testing.T) {
+	// x + 0 → x
+	e := &BinaryExpr{
+		Op:    BinAdd,
+		Left:  &Ident{Name: "x", Kind: IdentLocal, T: TInt},
+		Right: intLit("0"),
+		T:     TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	got := m.Script[0].(*ExprStmt).X
+	if id, ok := got.(*Ident); !ok || id.Name != "x" {
+		t.Fatalf("expected bare Ident x, got %T (%v)", got, got)
+	}
+}
+
+func TestOptimizeDeadCodeEliminatesAfterReturn(t *testing.T) {
+	blk := &Block{
+		Stmts: []Stmt{
+			&ReturnStmt{Value: intLit("1")},
+			&ExprStmt{X: intLit("2")}, // unreachable
+			&ExprStmt{X: intLit("3")}, // unreachable
+		},
+	}
+	fn := &FnDecl{Name: "f", Return: TInt, Body: blk}
+	m := &Module{Package: "main", Decls: []Decl{fn}}
+	Optimize(m, OptimizeOptions{})
+	if got := len(fn.Body.Stmts); got != 1 {
+		t.Fatalf("expected 1 stmt after DCE, got %d", got)
+	}
+	if _, ok := fn.Body.Stmts[0].(*ReturnStmt); !ok {
+		t.Fatalf("expected ReturnStmt, got %T", fn.Body.Stmts[0])
+	}
+}
+
+func TestOptimizeFoldsConstantIf(t *testing.T) {
+	// if true { 1 } else { 2 }
+	e := &IfExpr{
+		Cond: &BoolLit{Value: true},
+		Then: &Block{Result: intLit("1")},
+		Else: &Block{Result: intLit("2")},
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{})
+	got := m.Script[0].(*ExprStmt).X
+	if lit, ok := got.(*IntLit); !ok || lit.Text != "1" {
+		t.Fatalf("expected IntLit 1 after if-fold, got %T (%v)", got, got)
+	}
+}
+
+func TestOptimizeRespectsDisableFlags(t *testing.T) {
+	e := &BinaryExpr{Op: BinAdd, Left: intLit("1"), Right: intLit("2"), T: TInt}
+	m := moduleWithExpr(e)
+	Optimize(m, OptimizeOptions{DisableConstFold: true})
+	got := m.Script[0].(*ExprStmt).X
+	if _, ok := got.(*BinaryExpr); !ok {
+		t.Fatalf("expected BinaryExpr preserved with DisableConstFold, got %T", got)
+	}
+}
+
+// ==== Decision tree compilation ====
+
+func TestCompileDecisionTreeVariantSwitch(t *testing.T) {
+	// match x { Some(v) => v, None => 0 }
+	arms := []*MatchArm{
+		{
+			Pattern: &VariantPat{Variant: "Some", Args: []Pattern{&IdentPat{Name: "v"}}},
+			Body:    &Block{Result: &Ident{Name: "v", Kind: IdentLocal, T: TInt}},
+		},
+		{
+			Pattern: &VariantPat{Variant: "None"},
+			Body:    &Block{Result: intLit("0")},
+		},
+	}
+	tree := CompileDecisionTree(&NamedType{Name: "Option", Args: []Type{TInt}, Builtin: true}, arms)
+	sw, ok := tree.(*DecisionSwitch)
+	if !ok {
+		t.Fatalf("expected DecisionSwitch, got %T (%v)", tree, tree)
+	}
+	if sw.Kind != SwitchVariant {
+		t.Fatalf("expected SwitchVariant, got %v", sw.Kind)
+	}
+	if len(sw.Cases) != 2 {
+		t.Fatalf("expected 2 cases, got %d", len(sw.Cases))
+	}
+	if sw.Cases[0].Variant != "Some" || sw.Cases[1].Variant != "None" {
+		t.Fatalf("unexpected case order: %+v", sw.Cases)
+	}
+}
+
+func TestCompileDecisionTreeLitSwitch(t *testing.T) {
+	// match x { 1 => "a", 2 => "b", _ => "?" }
+	arms := []*MatchArm{
+		{Pattern: &LitPat{Value: intLit("1")}, Body: &Block{Result: strLit("a")}},
+		{Pattern: &LitPat{Value: intLit("2")}, Body: &Block{Result: strLit("b")}},
+		{Pattern: &WildPat{}, Body: &Block{Result: strLit("?")}},
+	}
+	tree := CompileDecisionTree(TInt, arms)
+	sw, ok := tree.(*DecisionSwitch)
+	if !ok {
+		t.Fatalf("expected DecisionSwitch, got %T", tree)
+	}
+	if sw.Kind != SwitchLit {
+		t.Fatalf("expected SwitchLit, got %v", sw.Kind)
+	}
+	if len(sw.Cases) != 2 {
+		t.Fatalf("expected 2 cases, got %d", len(sw.Cases))
+	}
+	if _, ok := sw.Default.(*DecisionLeaf); !ok {
+		t.Fatalf("expected catch-all leaf as Default, got %T", sw.Default)
+	}
+}
+
+func TestCompileDecisionTreeCatchAllShortCircuits(t *testing.T) {
+	arms := []*MatchArm{
+		{Pattern: &IdentPat{Name: "x"}, Body: &Block{Result: intLit("1")}},
+		{Pattern: &VariantPat{Variant: "Some", Args: []Pattern{&IdentPat{Name: "v"}}}, Body: &Block{}},
+	}
+	tree := CompileDecisionTree(nil, arms)
+	// first arm is a catch-all; we should reach leaf 0 with a binding.
+	bind, ok := tree.(*DecisionBind)
+	if !ok {
+		t.Fatalf("expected DecisionBind at root, got %T", tree)
+	}
+	leaf, ok := bind.Next.(*DecisionLeaf)
+	if !ok || leaf.ArmIndex != 0 {
+		t.Fatalf("expected leaf(arm=0), got %T (%v)", bind.Next, bind.Next)
+	}
+}
+
+func TestValidateDecisionTreeRejectsOutOfRangeLeaf(t *testing.T) {
+	tree := &DecisionLeaf{ArmIndex: 99}
+	errs := ValidateDecisionTree(tree, 2)
+	if len(errs) == 0 {
+		t.Fatal("expected out-of-range error")
+	}
+}
+
+// ==== Capture analysis ====
+
+func TestComputeCapturesBasic(t *testing.T) {
+	// |y| y + x   — x is captured from outer scope
+	body := &Block{
+		Result: &BinaryExpr{
+			Op:    BinAdd,
+			Left:  &Ident{Name: "y", Kind: IdentParam, T: TInt},
+			Right: &Ident{Name: "x", Kind: IdentLocal, T: TInt},
+			T:     TInt,
+		},
+	}
+	params := []*Param{{Name: "y", Type: TInt}}
+	caps := ComputeCaptures(body, params)
+	if len(caps) != 1 {
+		t.Fatalf("expected 1 capture, got %d (%+v)", len(caps), caps)
+	}
+	if caps[0].Name != "x" {
+		t.Fatalf("expected x, got %s", caps[0].Name)
+	}
+	if caps[0].Kind != CaptureLocal {
+		t.Fatalf("expected CaptureLocal, got %v", caps[0].Kind)
+	}
+}
+
+func TestComputeCapturesIgnoresGlobalsAndBuiltins(t *testing.T) {
+	// Identifiers resolved to top-level fns / builtins are not captures.
+	body := &Block{
+		Result: &CallExpr{
+			Callee: &Ident{Name: "println", Kind: IdentBuiltin, T: nil},
+			Args:   []Arg{{Value: &Ident{Name: "helper", Kind: IdentFn, T: nil}}},
+			T:      TUnit,
+		},
+	}
+	caps := ComputeCaptures(body, nil)
+	if len(caps) != 0 {
+		t.Fatalf("expected no captures, got %+v", caps)
+	}
+}
+
+func TestComputeCapturesShadowingInnerLet(t *testing.T) {
+	// { let x = 1; x + 1 } — x is shadowed, no capture
+	body := &Block{
+		Stmts: []Stmt{
+			&LetStmt{Name: "x", Value: intLit("1"), Type: TInt},
+		},
+		Result: &BinaryExpr{
+			Op:    BinAdd,
+			Left:  &Ident{Name: "x", Kind: IdentLocal, T: TInt},
+			Right: intLit("1"),
+			T:     TInt,
+		},
+	}
+	caps := ComputeCaptures(body, nil)
+	if len(caps) != 0 {
+		t.Fatalf("expected 0 captures (inner let shadows), got %+v", caps)
+	}
+}
+
+func TestComputeCapturesNestedClosurePromotes(t *testing.T) {
+	// outer body contains a closure that captures x; outer doesn't bind x,
+	// so x should propagate up.
+	nested := &Closure{
+		Params:   nil,
+		Body:     &Block{Result: &Ident{Name: "x", Kind: IdentLocal, T: TInt}},
+		Captures: []*Capture{{Name: "x", Kind: CaptureLocal, T: TInt}},
+		T:        &FnType{Return: TInt},
+	}
+	outer := &Block{Result: nested}
+	caps := ComputeCaptures(outer, nil)
+	if len(caps) != 1 || caps[0].Name != "x" {
+		t.Fatalf("expected propagated capture x, got %+v", caps)
+	}
+}
+
+// ==== Qualified NamedType ====
+
+func TestNamedTypeQualifiedName(t *testing.T) {
+	n := &NamedType{Package: "std.io", Name: "Reader"}
+	if got := n.QualifiedName(); got != "std.io.Reader" {
+		t.Fatalf("unexpected QualifiedName: %q", got)
+	}
+	if got := n.String(); got != "std.io.Reader" {
+		t.Fatalf("unexpected String: %q", got)
+	}
+}
+
+func TestNamedTypeBareNoPackage(t *testing.T) {
+	n := &NamedType{Name: "List", Args: []Type{TInt}, Builtin: true}
+	if got := n.QualifiedName(); got != "List" {
+		t.Fatalf("unexpected QualifiedName: %q", got)
+	}
+	if got := n.String(); got != "List<Int>" {
+		t.Fatalf("unexpected String: %q", got)
+	}
+}
+
+// ==== Arg keyword preservation ====
+
+func TestArgIsKeyword(t *testing.T) {
+	pos := Arg{Value: intLit("1")}
+	kw := Arg{Name: "x", Value: intLit("1")}
+	if pos.IsKeyword() {
+		t.Fatal("positional Arg should not report IsKeyword")
+	}
+	if !kw.IsKeyword() {
+		t.Fatal("keyword Arg should report IsKeyword")
+	}
+}
+
+// ==== Validate covers new invariants ====
+
+func TestValidateRejectsParamWithBothNameAndPattern(t *testing.T) {
+	fn := &FnDecl{
+		Name:   "f",
+		Return: TUnit,
+		Params: []*Param{{Name: "x", Pattern: &IdentPat{Name: "x"}, Type: TInt}},
+		Body:   &Block{},
+	}
+	m := &Module{Package: "main", Decls: []Decl{fn}}
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected validation error for param with both Name and Pattern")
+	}
+}
+
+func TestValidateRejectsForWithBothVarAndPattern(t *testing.T) {
+	fn := &FnDecl{
+		Name:   "f",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ForStmt{Kind: ForIn, Var: "x", Pattern: &IdentPat{Name: "x"}, Iter: &Ident{Name: "xs", T: TInt}, Body: &Block{}},
+		}},
+	}
+	m := &Module{Package: "main", Decls: []Decl{fn}}
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected validation error for ForStmt with both Var and Pattern")
+	}
+}
+
+// ==== Helpers ====
+
+func moduleWithExpr(e Expr) *Module {
+	return &Module{
+		Package: "main",
+		Script:  []Stmt{&ExprStmt{X: e}},
+	}
+}
+
+func intLit(text string) *IntLit  { return &IntLit{Text: text, T: TInt} }
+func strLit(s string) *StringLit  { return &StringLit{Parts: []StringPart{{IsLit: true, Lit: s}}} }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -121,17 +121,14 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 }
 
 func (l *lowerer) lowerParam(p *ast.Param) *Param {
-	name := p.Name
-	if name == "" && p.Pattern != nil {
-		// Pattern-destructured closure params aren't representable yet;
-		// record an issue and fall back to a placeholder.
-		l.note("pattern-destructured parameter at %v not yet supported", p.Pos())
-		name = "_"
-	}
 	out := &Param{
-		Name:  name,
 		Type:  l.lowerType(p.Type),
 		SpanV: nodeSpan(p),
+	}
+	if p.Name != "" {
+		out.Name = p.Name
+	} else if p.Pattern != nil {
+		out.Pattern = l.lowerPattern(p.Pattern)
 	}
 	if p.Default != nil {
 		out.Default = l.lowerExpr(p.Default)
@@ -255,12 +252,15 @@ func (l *lowerer) lowerType(t ast.Type) Type {
 // NamedType (with Builtin flag populated from the resolver when
 // available), or a TypeVar for generic parameter references.
 func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
-	// Qualified paths (pkg.Type) are kept as a dotted string for now;
-	// the current IR has no first-class package concept.
 	name := nt.Path[len(nt.Path)-1]
+	pkg := ""
+	if len(nt.Path) > 1 {
+		pkg = joinDottedPath(nt.Path[:len(nt.Path)-1])
+	}
 
-	// Primitive scalars short-circuit.
-	if len(nt.Path) == 1 && len(nt.Args) == 0 {
+	// Primitive scalars short-circuit — only when bare (no qualifier, no
+	// type args).
+	if pkg == "" && len(nt.Args) == 0 {
 		if p := primitiveByName(name); p != nil {
 			return p
 		}
@@ -281,15 +281,30 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 					return p
 				}
 			}
-			return &NamedType{Name: sym.Name, Args: args, Builtin: true}
+			return &NamedType{Package: pkg, Name: sym.Name, Args: args, Builtin: true}
 		case resolve.SymGeneric:
 			return &TypeVar{Name: sym.Name, Owner: ""}
 		}
-		return &NamedType{Name: sym.Name, Args: args}
+		return &NamedType{Package: pkg, Name: sym.Name, Args: args}
 	}
 
 	// No resolver data available — best effort on the source name.
-	return &NamedType{Name: name, Args: args}
+	return &NamedType{Package: pkg, Name: name, Args: args}
+}
+
+// joinDottedPath joins a non-empty string slice with '.'.
+func joinDottedPath(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "." + p
+	}
+	return out
 }
 
 func (l *lowerer) typeRef(nt *ast.NamedType) *resolve.Symbol {
@@ -376,15 +391,19 @@ func (l *lowerer) fromCheckerType(t types.Type) Type {
 	case *types.Named:
 		name := "?"
 		builtin := false
+		pkg := ""
 		if t.Sym != nil {
 			name = t.Sym.Name
 			builtin = t.Sym.Kind == resolve.SymBuiltin
+			if t.Sym.Package != nil {
+				pkg = t.Sym.Package.Name
+			}
 		}
 		args := make([]Type, len(t.Args))
 		for i, a := range t.Args {
 			args[i] = l.fromCheckerType(a)
 		}
-		return &NamedType{Name: name, Args: args, Builtin: builtin}
+		return &NamedType{Package: pkg, Name: name, Args: args, Builtin: builtin}
 	case *types.TypeVar:
 		name := "?"
 		if t.Sym != nil {
@@ -581,18 +600,19 @@ func (l *lowerer) lowerForStmt(s *ast.ForStmt) Stmt {
 	if s.Pattern == nil && s.Iter != nil {
 		return &ForStmt{Kind: ForWhile, Cond: l.lowerExpr(s.Iter), Body: body, SpanV: nodeSpan(s)}
 	}
-	name, _ := simpleBindName(s.Pattern)
-	// Non-ident patterns lower to a tuple-style ForIn with a
-	// destructuring binding in the body. For now we keep Var empty and
-	// annotate the issue; a follow-on can introduce ForDestructure.
-	if name == "" {
-		l.note("for with destructuring pattern at %v collapsed to ForIn with unnamed var", s.Pos())
+	var loopVar string
+	var loopPat Pattern
+	if name, ok := simpleBindName(s.Pattern); ok {
+		loopVar = name
+	} else {
+		loopPat = l.lowerPattern(s.Pattern)
 	}
 	// for x in a..b is a numeric range loop.
 	if r, ok := s.Iter.(*ast.RangeExpr); ok && r.Start != nil && r.Stop != nil {
 		return &ForStmt{
 			Kind:      ForRange,
-			Var:       name,
+			Var:       loopVar,
+			Pattern:   loopPat,
 			Start:     l.lowerExpr(r.Start),
 			End:       l.lowerExpr(r.Stop),
 			Inclusive: r.Inclusive,
@@ -600,7 +620,14 @@ func (l *lowerer) lowerForStmt(s *ast.ForStmt) Stmt {
 			SpanV:     nodeSpan(s),
 		}
 	}
-	return &ForStmt{Kind: ForIn, Var: name, Iter: l.lowerExpr(s.Iter), Body: body, SpanV: nodeSpan(s)}
+	return &ForStmt{
+		Kind:    ForIn,
+		Var:     loopVar,
+		Pattern: loopPat,
+		Iter:    l.lowerExpr(s.Iter),
+		Body:    body,
+		SpanV:   nodeSpan(s),
+	}
 }
 
 // assignOp maps a token kind to the IR AssignOp.
@@ -884,11 +911,7 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 		if k, isIntrinsic := intrinsicByName(id.Name); isIntrinsic {
 			out := &IntrinsicCall{Kind: k, SpanV: nodeSpan(e)}
 			for _, a := range e.Args {
-				if a.Name != "" {
-					l.note("keyword arg to intrinsic %s at %v not supported", id.Name, a.Pos())
-					continue
-				}
-				out.Args = append(out.Args, l.lowerExpr(a.Value))
+				out.Args = append(out.Args, l.lowerArg(a))
 			}
 			return out
 		}
@@ -908,15 +931,9 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 	}
 	// Method call: x.name(args).
 	if fx, ok := fn.(*ast.FieldExpr); ok {
-		// But `Enum.Variant(args)` is a qualified variant constructor,
-		// not a method call — detect via the resolved symbol.
 		if id, ok := fx.X.(*ast.Ident); ok {
 			if sym := l.symbol(id); sym != nil &&
 				(sym.Kind == resolve.SymEnum || sym.Kind == resolve.SymStruct) {
-				// Lookup whether fx.Name is a variant on this enum. We
-				// approximate: if the checker assigned the whole call
-				// a Named type whose Sym is an enum, treat it as a
-				// variant constructor.
 				if l.isVariantOfEnum(sym, fx.Name) {
 					return l.lowerVariantCall(e, sym.Name, fx.Name)
 				}
@@ -924,16 +941,47 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 		}
 		return l.lowerMethodCall(e, fx, typeArgs)
 	}
+	// Fall back to the checker's monomorphisation record when no
+	// turbofish was written but the callee is generic.
+	if len(typeArgs) == 0 {
+		typeArgs = l.instantiationArgs(e)
+	}
 	out := &CallExpr{
-		Callee: l.lowerExpr(fn),
-		T:      l.exprType(e),
-		SpanV:  nodeSpan(e),
+		Callee:   l.lowerExpr(fn),
+		TypeArgs: typeArgs,
+		T:        l.exprType(e),
+		SpanV:    nodeSpan(e),
 	}
 	for _, a := range e.Args {
-		if a.Name != "" {
-			l.note("keyword arg at %v collapsed to positional in IR", a.Pos())
-		}
-		out.Args = append(out.Args, l.lowerExpr(a.Value))
+		out.Args = append(out.Args, l.lowerArg(a))
+	}
+	return out
+}
+
+// lowerArg lowers a single call argument, preserving its keyword name
+// when present.
+func (l *lowerer) lowerArg(a *ast.Arg) Arg {
+	return Arg{
+		Name:  a.Name,
+		Value: l.lowerExpr(a.Value),
+		SpanV: Span{Start: posFromToken(a.Pos()), End: posFromToken(a.End())},
+	}
+}
+
+// instantiationArgs returns the concrete type-argument list the
+// checker recorded for this call site (monomorphisation info), or nil
+// when the checker did not annotate it.
+func (l *lowerer) instantiationArgs(e *ast.CallExpr) []Type {
+	if l.chk == nil || l.chk.Instantiations == nil {
+		return nil
+	}
+	raw, ok := l.chk.Instantiations[e]
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make([]Type, 0, len(raw))
+	for _, ta := range raw {
+		out = append(out, l.fromCheckerType(ta))
 	}
 	return out
 }
@@ -960,6 +1008,9 @@ func (l *lowerer) isVariantOfEnum(sym *resolve.Symbol, variantName string) bool 
 // lowerMethodCall lowers `receiver.name(args)` into an IR MethodCall,
 // preserving turbofish type arguments.
 func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs []Type) Expr {
+	if len(typeArgs) == 0 {
+		typeArgs = l.instantiationArgs(e)
+	}
 	out := &MethodCall{
 		Receiver: l.lowerExpr(fx.X),
 		Name:     fx.Name,
@@ -968,10 +1019,7 @@ func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs [
 		SpanV:    nodeSpan(e),
 	}
 	for _, a := range e.Args {
-		if a.Name != "" {
-			l.note("keyword arg at %v collapsed to positional in IR", a.Pos())
-		}
-		out.Args = append(out.Args, l.lowerExpr(a.Value))
+		out.Args = append(out.Args, l.lowerArg(a))
 	}
 	return out
 }
@@ -987,11 +1035,7 @@ func (l *lowerer) lowerVariantCall(e *ast.CallExpr, enum, variant string) Expr {
 		SpanV:   nodeSpan(e),
 	}
 	for _, a := range e.Args {
-		if a.Name != "" {
-			l.note("keyword arg to variant %s at %v not supported", variant, a.Pos())
-			continue
-		}
-		out.Args = append(out.Args, l.lowerExpr(a.Value))
+		out.Args = append(out.Args, l.lowerArg(a))
 	}
 	return out
 }
@@ -1262,16 +1306,26 @@ func (l *lowerer) lowerClosure(c *ast.ClosureExpr) Expr {
 		lowered := l.lowerExpr(c.Body)
 		out.Body = &Block{Result: lowered, SpanV: lowered.At()}
 	}
+	// Compute free-variable captures.
+	out.Captures = ComputeCaptures(out.Body, out.Params)
 	return out
 }
 
 func (l *lowerer) lowerTurbofish(tf *ast.TurbofishExpr) Expr {
-	// A bare turbofish without a call (`f::<Int>`) is rare but legal;
-	// most appearances are stripped by lowerCall. We retain the base
-	// expression and drop the type args when not consumed, since we
-	// can't currently represent "identifier with type args" cleanly.
-	l.note("bare turbofish at %v collapsed; type args dropped", tf.Pos())
-	return l.lowerExpr(tf.Base)
+	// A bare turbofish without a call (`f::<Int>`) — retain the type
+	// args on the underlying ident so backends that monomorphise off
+	// function references can observe them.
+	base := l.lowerExpr(tf.Base)
+	typeArgs := make([]Type, 0, len(tf.Args))
+	for _, a := range tf.Args {
+		typeArgs = append(typeArgs, l.lowerType(a))
+	}
+	if id, ok := base.(*Ident); ok {
+		id.TypeArgs = typeArgs
+		return id
+	}
+	l.note("bare turbofish at %v attached to non-ident base; type args dropped", tf.Pos())
+	return base
 }
 
 func (l *lowerer) lowerMatchExpr(m *ast.MatchExpr) Expr {
@@ -1291,6 +1345,8 @@ func (l *lowerer) lowerMatchExpr(m *ast.MatchExpr) Expr {
 		a.Body = l.lowerArmBody(arm.Body)
 		out.Arms = append(out.Arms, a)
 	}
+	// Compile a decision tree when the arm shapes are specialisable.
+	out.Tree = CompileDecisionTree(out.Scrutinee.Type(), out.Arms)
 	return out
 }
 

--- a/internal/ir/optimize.go
+++ b/internal/ir/optimize.go
@@ -1,0 +1,645 @@
+package ir
+
+import (
+	"math/big"
+	"strconv"
+	"strings"
+)
+
+// OptimizeOptions tunes the IR-level optimisation pipeline. The zero
+// value enables every pass — pass a populated struct to disable
+// specific passes during debugging.
+type OptimizeOptions struct {
+	DisableConstFold bool
+	DisableDeadCode  bool
+	DisableBranch    bool
+	DisableSimplify  bool
+}
+
+// Optimize runs the standard IR optimisation pipeline on m in place
+// and returns the same module for chaining. The passes are deliberately
+// conservative: they only rewrite shapes that are provably safe at
+// this level, so the result remains valid input for every backend.
+//
+// The optimiser is idempotent — running it twice on the same module
+// produces the same IR the first run emitted.
+func Optimize(m *Module, opts OptimizeOptions) *Module {
+	if m == nil {
+		return m
+	}
+	o := &optimizer{opts: opts}
+	o.visitModule(m)
+	return m
+}
+
+type optimizer struct {
+	opts OptimizeOptions
+}
+
+func (o *optimizer) visitModule(m *Module) {
+	for _, d := range m.Decls {
+		o.visitDecl(d)
+	}
+	for i, s := range m.Script {
+		m.Script[i] = o.visitStmt(s)
+	}
+	m.Script = o.simplifyStmts(m.Script)
+}
+
+func (o *optimizer) visitDecl(d Decl) {
+	switch d := d.(type) {
+	case *FnDecl:
+		if d.Body != nil {
+			o.visitBlock(d.Body)
+		}
+	case *StructDecl:
+		for _, f := range d.Fields {
+			if f.Default != nil {
+				f.Default = o.visitExpr(f.Default)
+			}
+		}
+		for _, m := range d.Methods {
+			if m.Body != nil {
+				o.visitBlock(m.Body)
+			}
+		}
+	case *EnumDecl:
+		for _, m := range d.Methods {
+			if m.Body != nil {
+				o.visitBlock(m.Body)
+			}
+		}
+	case *InterfaceDecl:
+		for _, m := range d.Methods {
+			if m.Body != nil {
+				o.visitBlock(m.Body)
+			}
+		}
+	case *LetDecl:
+		if d.Value != nil {
+			d.Value = o.visitExpr(d.Value)
+		}
+	}
+}
+
+func (o *optimizer) visitBlock(b *Block) {
+	if b == nil {
+		return
+	}
+	for i, s := range b.Stmts {
+		b.Stmts[i] = o.visitStmt(s)
+	}
+	if b.Result != nil {
+		b.Result = o.visitExpr(b.Result)
+	}
+	b.Stmts = o.simplifyStmts(b.Stmts)
+}
+
+// simplifyStmts applies dead-code elimination: statements following a
+// terminator (return/break/continue) are unreachable and dropped.
+func (o *optimizer) simplifyStmts(stmts []Stmt) []Stmt {
+	if o.opts.DisableDeadCode {
+		return stmts
+	}
+	for i, s := range stmts {
+		if isTerminator(s) {
+			return stmts[:i+1]
+		}
+	}
+	return stmts
+}
+
+func isTerminator(s Stmt) bool {
+	switch s.(type) {
+	case *ReturnStmt, *BreakStmt, *ContinueStmt:
+		return true
+	}
+	return false
+}
+
+func (o *optimizer) visitStmt(s Stmt) Stmt {
+	switch s := s.(type) {
+	case nil:
+		return nil
+	case *Block:
+		o.visitBlock(s)
+		return s
+	case *LetStmt:
+		if s.Value != nil {
+			s.Value = o.visitExpr(s.Value)
+		}
+		return s
+	case *ExprStmt:
+		s.X = o.visitExpr(s.X)
+		return s
+	case *AssignStmt:
+		for i, t := range s.Targets {
+			s.Targets[i] = o.visitExpr(t)
+		}
+		s.Value = o.visitExpr(s.Value)
+		return s
+	case *ReturnStmt:
+		if s.Value != nil {
+			s.Value = o.visitExpr(s.Value)
+		}
+		return s
+	case *IfStmt:
+		s.Cond = o.visitExpr(s.Cond)
+		o.visitBlock(s.Then)
+		o.visitBlock(s.Else)
+		// Fold `if true`/`if false` when the branch is a no-op side-effectless shape.
+		if !o.opts.DisableBranch {
+			if bl, ok := s.Cond.(*BoolLit); ok {
+				if bl.Value {
+					return s.Then
+				}
+				if s.Else != nil {
+					return s.Else
+				}
+				return &Block{SpanV: s.SpanV}
+			}
+		}
+		return s
+	case *ForStmt:
+		if s.Cond != nil {
+			s.Cond = o.visitExpr(s.Cond)
+		}
+		if s.Iter != nil {
+			s.Iter = o.visitExpr(s.Iter)
+		}
+		if s.Start != nil {
+			s.Start = o.visitExpr(s.Start)
+		}
+		if s.End != nil {
+			s.End = o.visitExpr(s.End)
+		}
+		o.visitBlock(s.Body)
+		return s
+	case *DeferStmt:
+		o.visitBlock(s.Body)
+		return s
+	case *ChanSendStmt:
+		s.Channel = o.visitExpr(s.Channel)
+		s.Value = o.visitExpr(s.Value)
+		return s
+	case *MatchStmt:
+		s.Scrutinee = o.visitExpr(s.Scrutinee)
+		for _, arm := range s.Arms {
+			o.visitMatchArm(arm)
+		}
+		return s
+	}
+	return s
+}
+
+func (o *optimizer) visitMatchArm(a *MatchArm) {
+	if a == nil {
+		return
+	}
+	if a.Guard != nil {
+		a.Guard = o.visitExpr(a.Guard)
+	}
+	if a.Body != nil {
+		o.visitBlock(a.Body)
+	}
+}
+
+func (o *optimizer) visitExpr(e Expr) Expr {
+	switch e := e.(type) {
+	case nil:
+		return nil
+	case *UnaryExpr:
+		e.X = o.visitExpr(e.X)
+		if folded, ok := o.foldUnary(e); ok {
+			return folded
+		}
+		return e
+	case *BinaryExpr:
+		e.Left = o.visitExpr(e.Left)
+		e.Right = o.visitExpr(e.Right)
+		if folded, ok := o.foldBinary(e); ok {
+			return folded
+		}
+		if simplified, ok := o.simplifyBinary(e); ok {
+			return simplified
+		}
+		return e
+	case *CallExpr:
+		e.Callee = o.visitExpr(e.Callee)
+		for i := range e.Args {
+			e.Args[i].Value = o.visitExpr(e.Args[i].Value)
+		}
+		return e
+	case *IntrinsicCall:
+		for i := range e.Args {
+			e.Args[i].Value = o.visitExpr(e.Args[i].Value)
+		}
+		return e
+	case *MethodCall:
+		e.Receiver = o.visitExpr(e.Receiver)
+		for i := range e.Args {
+			e.Args[i].Value = o.visitExpr(e.Args[i].Value)
+		}
+		return e
+	case *ListLit:
+		for i, el := range e.Elems {
+			e.Elems[i] = o.visitExpr(el)
+		}
+		return e
+	case *MapLit:
+		for i := range e.Entries {
+			e.Entries[i].Key = o.visitExpr(e.Entries[i].Key)
+			e.Entries[i].Value = o.visitExpr(e.Entries[i].Value)
+		}
+		return e
+	case *TupleLit:
+		for i, el := range e.Elems {
+			e.Elems[i] = o.visitExpr(el)
+		}
+		return e
+	case *StructLit:
+		for i := range e.Fields {
+			if e.Fields[i].Value != nil {
+				e.Fields[i].Value = o.visitExpr(e.Fields[i].Value)
+			}
+		}
+		if e.Spread != nil {
+			e.Spread = o.visitExpr(e.Spread)
+		}
+		return e
+	case *RangeLit:
+		if e.Start != nil {
+			e.Start = o.visitExpr(e.Start)
+		}
+		if e.End != nil {
+			e.End = o.visitExpr(e.End)
+		}
+		return e
+	case *QuestionExpr:
+		e.X = o.visitExpr(e.X)
+		return e
+	case *CoalesceExpr:
+		e.Left = o.visitExpr(e.Left)
+		e.Right = o.visitExpr(e.Right)
+		return e
+	case *FieldExpr:
+		e.X = o.visitExpr(e.X)
+		return e
+	case *TupleAccess:
+		e.X = o.visitExpr(e.X)
+		// fold (a, b).i when the base is a tuple literal.
+		if tl, ok := e.X.(*TupleLit); ok && e.Index >= 0 && e.Index < len(tl.Elems) && !o.opts.DisableSimplify {
+			return tl.Elems[e.Index]
+		}
+		return e
+	case *IndexExpr:
+		e.X = o.visitExpr(e.X)
+		e.Index = o.visitExpr(e.Index)
+		return e
+	case *Closure:
+		if e.Body != nil {
+			o.visitBlock(e.Body)
+		}
+		return e
+	case *VariantLit:
+		for i := range e.Args {
+			e.Args[i].Value = o.visitExpr(e.Args[i].Value)
+		}
+		return e
+	case *BlockExpr:
+		o.visitBlock(e.Block)
+		// `{ expr }` with no statements collapses to expr when the types agree.
+		if !o.opts.DisableSimplify && e.Block != nil && len(e.Block.Stmts) == 0 && e.Block.Result != nil {
+			return e.Block.Result
+		}
+		return e
+	case *IfExpr:
+		e.Cond = o.visitExpr(e.Cond)
+		o.visitBlock(e.Then)
+		o.visitBlock(e.Else)
+		if !o.opts.DisableBranch {
+			if bl, ok := e.Cond.(*BoolLit); ok {
+				if bl.Value {
+					return blockResult(e.Then, e.T)
+				}
+				return blockResult(e.Else, e.T)
+			}
+		}
+		return e
+	case *IfLetExpr:
+		e.Scrutinee = o.visitExpr(e.Scrutinee)
+		o.visitBlock(e.Then)
+		o.visitBlock(e.Else)
+		return e
+	case *MatchExpr:
+		e.Scrutinee = o.visitExpr(e.Scrutinee)
+		for _, arm := range e.Arms {
+			o.visitMatchArm(arm)
+		}
+		return e
+	case *StringLit:
+		for i := range e.Parts {
+			if !e.Parts[i].IsLit && e.Parts[i].Expr != nil {
+				e.Parts[i].Expr = o.visitExpr(e.Parts[i].Expr)
+			}
+		}
+		return e
+	}
+	return e
+}
+
+// blockResult returns the block's final expression wrapped in a
+// BlockExpr when the block still has stmts, or the raw result when it
+// is pure. Used by the if-const-fold rewrite.
+func blockResult(b *Block, t Type) Expr {
+	if b == nil {
+		return &UnitLit{}
+	}
+	if len(b.Stmts) == 0 && b.Result != nil {
+		return b.Result
+	}
+	return &BlockExpr{Block: b, T: t, SpanV: b.SpanV}
+}
+
+// ==== Constant folding ====
+
+func (o *optimizer) foldUnary(e *UnaryExpr) (Expr, bool) {
+	if o.opts.DisableConstFold {
+		return nil, false
+	}
+	switch e.Op {
+	case UnNeg:
+		if lit, ok := e.X.(*IntLit); ok {
+			if v, ok := parseIntText(lit.Text); ok {
+				v.Neg(v)
+				return &IntLit{Text: v.String(), T: e.T, SpanV: e.SpanV}, true
+			}
+		}
+	case UnPlus:
+		if _, ok := e.X.(*IntLit); ok {
+			return e.X, true
+		}
+		if _, ok := e.X.(*FloatLit); ok {
+			return e.X, true
+		}
+	case UnNot:
+		if lit, ok := e.X.(*BoolLit); ok {
+			return &BoolLit{Value: !lit.Value, SpanV: e.SpanV}, true
+		}
+	case UnBitNot:
+		if lit, ok := e.X.(*IntLit); ok {
+			if v, ok := parseIntText(lit.Text); ok {
+				v.Not(v)
+				return &IntLit{Text: v.String(), T: e.T, SpanV: e.SpanV}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (o *optimizer) foldBinary(e *BinaryExpr) (Expr, bool) {
+	if o.opts.DisableConstFold {
+		return nil, false
+	}
+	// Integer arithmetic / comparison
+	if li, ok := e.Left.(*IntLit); ok {
+		if ri, ok := e.Right.(*IntLit); ok {
+			return foldIntBinary(e, li, ri)
+		}
+	}
+	// Boolean logic
+	if lb, ok := e.Left.(*BoolLit); ok {
+		if rb, ok := e.Right.(*BoolLit); ok {
+			return foldBoolBinary(e, lb, rb)
+		}
+	}
+	// Short-circuit on one-sided bool literal
+	if e.Op == BinAnd {
+		if lb, ok := e.Left.(*BoolLit); ok {
+			if !lb.Value {
+				return &BoolLit{Value: false, SpanV: e.SpanV}, true
+			}
+			return e.Right, true
+		}
+	}
+	if e.Op == BinOr {
+		if lb, ok := e.Left.(*BoolLit); ok {
+			if lb.Value {
+				return &BoolLit{Value: true, SpanV: e.SpanV}, true
+			}
+			return e.Right, true
+		}
+	}
+	// String concatenation of two literal-only strings
+	if e.Op == BinAdd {
+		if ls, ok := e.Left.(*StringLit); ok && isPureStringLit(ls) {
+			if rs, ok := e.Right.(*StringLit); ok && isPureStringLit(rs) {
+				return &StringLit{
+					Parts:    []StringPart{{IsLit: true, Lit: stringLitText(ls) + stringLitText(rs)}},
+					IsRaw:    ls.IsRaw && rs.IsRaw,
+					IsTriple: false,
+					SpanV:    e.SpanV,
+				}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (o *optimizer) simplifyBinary(e *BinaryExpr) (Expr, bool) {
+	if o.opts.DisableSimplify {
+		return nil, false
+	}
+	// x + 0, 0 + x, x - 0
+	if e.Op == BinAdd {
+		if isIntLiteralZero(e.Right) {
+			return e.Left, true
+		}
+		if isIntLiteralZero(e.Left) {
+			return e.Right, true
+		}
+	}
+	if e.Op == BinSub && isIntLiteralZero(e.Right) {
+		return e.Left, true
+	}
+	// x * 1, 1 * x
+	if e.Op == BinMul {
+		if isIntLiteralOne(e.Right) {
+			return e.Left, true
+		}
+		if isIntLiteralOne(e.Left) {
+			return e.Right, true
+		}
+		if isIntLiteralZero(e.Right) || isIntLiteralZero(e.Left) {
+			return &IntLit{Text: "0", T: e.T, SpanV: e.SpanV}, true
+		}
+	}
+	// x / 1
+	if e.Op == BinDiv && isIntLiteralOne(e.Right) {
+		return e.Left, true
+	}
+	return nil, false
+}
+
+func foldIntBinary(e *BinaryExpr, l, r *IntLit) (Expr, bool) {
+	lv, lok := parseIntText(l.Text)
+	rv, rok := parseIntText(r.Text)
+	if !lok || !rok {
+		return nil, false
+	}
+	out := new(big.Int)
+	switch e.Op {
+	case BinAdd:
+		out.Add(lv, rv)
+	case BinSub:
+		out.Sub(lv, rv)
+	case BinMul:
+		out.Mul(lv, rv)
+	case BinDiv:
+		if rv.Sign() == 0 {
+			return nil, false
+		}
+		out.Quo(lv, rv)
+	case BinMod:
+		if rv.Sign() == 0 {
+			return nil, false
+		}
+		out.Rem(lv, rv)
+	case BinBitAnd:
+		out.And(lv, rv)
+	case BinBitOr:
+		out.Or(lv, rv)
+	case BinBitXor:
+		out.Xor(lv, rv)
+	case BinShl:
+		if !rv.IsInt64() || rv.Int64() < 0 || rv.Int64() > 1024 {
+			return nil, false
+		}
+		out.Lsh(lv, uint(rv.Int64()))
+	case BinShr:
+		if !rv.IsInt64() || rv.Int64() < 0 || rv.Int64() > 1024 {
+			return nil, false
+		}
+		out.Rsh(lv, uint(rv.Int64()))
+	case BinEq:
+		return &BoolLit{Value: lv.Cmp(rv) == 0, SpanV: e.SpanV}, true
+	case BinNeq:
+		return &BoolLit{Value: lv.Cmp(rv) != 0, SpanV: e.SpanV}, true
+	case BinLt:
+		return &BoolLit{Value: lv.Cmp(rv) < 0, SpanV: e.SpanV}, true
+	case BinLeq:
+		return &BoolLit{Value: lv.Cmp(rv) <= 0, SpanV: e.SpanV}, true
+	case BinGt:
+		return &BoolLit{Value: lv.Cmp(rv) > 0, SpanV: e.SpanV}, true
+	case BinGeq:
+		return &BoolLit{Value: lv.Cmp(rv) >= 0, SpanV: e.SpanV}, true
+	default:
+		return nil, false
+	}
+	return &IntLit{Text: out.String(), T: e.T, SpanV: e.SpanV}, true
+}
+
+func foldBoolBinary(e *BinaryExpr, l, r *BoolLit) (Expr, bool) {
+	switch e.Op {
+	case BinAnd:
+		return &BoolLit{Value: l.Value && r.Value, SpanV: e.SpanV}, true
+	case BinOr:
+		return &BoolLit{Value: l.Value || r.Value, SpanV: e.SpanV}, true
+	case BinEq:
+		return &BoolLit{Value: l.Value == r.Value, SpanV: e.SpanV}, true
+	case BinNeq:
+		return &BoolLit{Value: l.Value != r.Value, SpanV: e.SpanV}, true
+	}
+	return nil, false
+}
+
+// parseIntText parses an IntLit's original text (handling 0x/0o/0b
+// prefixes and underscore separators) into a big.Int for arbitrary-
+// precision folding.
+func parseIntText(s string) (*big.Int, bool) {
+	text := strings.ReplaceAll(s, "_", "")
+	neg := false
+	if strings.HasPrefix(text, "+") {
+		text = text[1:]
+	} else if strings.HasPrefix(text, "-") {
+		neg = true
+		text = text[1:]
+	}
+	base := 10
+	switch {
+	case strings.HasPrefix(text, "0x") || strings.HasPrefix(text, "0X"):
+		base = 16
+		text = text[2:]
+	case strings.HasPrefix(text, "0o") || strings.HasPrefix(text, "0O"):
+		base = 8
+		text = text[2:]
+	case strings.HasPrefix(text, "0b") || strings.HasPrefix(text, "0B"):
+		base = 2
+		text = text[2:]
+	}
+	if text == "" {
+		return nil, false
+	}
+	if _, err := strconv.ParseInt(text, base, 64); err != nil {
+		// fall back to big.Int (arbitrary precision literals)
+		v, ok := new(big.Int).SetString(text, base)
+		if !ok {
+			return nil, false
+		}
+		if neg {
+			v.Neg(v)
+		}
+		return v, true
+	}
+	v, _ := new(big.Int).SetString(text, base)
+	if v == nil {
+		return nil, false
+	}
+	if neg {
+		v.Neg(v)
+	}
+	return v, true
+}
+
+// isIntLiteralZero / isIntLiteralOne recognise the common algebraic
+// identity operands. Returning false on parse failure is safe: we just
+// skip the simplification.
+func isIntLiteralZero(e Expr) bool {
+	lit, ok := e.(*IntLit)
+	if !ok {
+		return false
+	}
+	v, ok := parseIntText(lit.Text)
+	return ok && v.Sign() == 0
+}
+
+func isIntLiteralOne(e Expr) bool {
+	lit, ok := e.(*IntLit)
+	if !ok {
+		return false
+	}
+	v, ok := parseIntText(lit.Text)
+	return ok && v.Cmp(big.NewInt(1)) == 0
+}
+
+func isPureStringLit(s *StringLit) bool {
+	if s == nil {
+		return false
+	}
+	for _, p := range s.Parts {
+		if !p.IsLit {
+			return false
+		}
+	}
+	return true
+}
+
+func stringLitText(s *StringLit) string {
+	var b strings.Builder
+	for _, p := range s.Parts {
+		if p.IsLit {
+			b.WriteString(p.Lit)
+		}
+	}
+	return b.String()
+}

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -87,7 +87,7 @@ func (p *printer) printDecl(d Decl) {
 			if i > 0 {
 				p.b.WriteByte(' ')
 			}
-			p.writef("%s:%s", pm.Name, typeString(pm.Type))
+			p.printParam(pm)
 		}
 		p.writef(") -> %s", typeString(d.Return))
 		if d.Body != nil {
@@ -240,6 +240,8 @@ func (p *printer) printStmt(s Stmt) {
 		p.writef("(for %s", forKindName(s.Kind))
 		if s.Var != "" {
 			p.writef(" %s", s.Var)
+		} else if s.Pattern != nil {
+			p.writef(" %s", PatternString(s.Pattern))
 		}
 		p.indent++
 		if s.Cond != nil {
@@ -332,6 +334,16 @@ func (p *printer) printExpr(e Expr) {
 		if e.Kind != IdentUnknown {
 			p.writef("#%s", identKindName(e.Kind))
 		}
+		if len(e.TypeArgs) > 0 {
+			p.b.WriteString("::<")
+			for i, ta := range e.TypeArgs {
+				if i > 0 {
+					p.b.WriteByte(',')
+				}
+				p.b.WriteString(typeString(ta))
+			}
+			p.b.WriteByte('>')
+		}
 	case *UnaryExpr:
 		p.writef("(%s ", unOpName(e.Op))
 		p.printExpr(e.X)
@@ -345,16 +357,26 @@ func (p *printer) printExpr(e Expr) {
 	case *CallExpr:
 		p.b.WriteString("(call ")
 		p.printExpr(e.Callee)
+		if len(e.TypeArgs) > 0 {
+			p.b.WriteString(" ::<")
+			for i, ta := range e.TypeArgs {
+				if i > 0 {
+					p.b.WriteByte(',')
+				}
+				p.b.WriteString(typeString(ta))
+			}
+			p.b.WriteByte('>')
+		}
 		for _, a := range e.Args {
 			p.b.WriteByte(' ')
-			p.printExpr(a)
+			p.printArg(a)
 		}
 		p.b.WriteByte(')')
 	case *IntrinsicCall:
 		p.writef("(intrinsic %s", intrinsicKindName(e.Kind))
 		for _, a := range e.Args {
 			p.b.WriteByte(' ')
-			p.printExpr(a)
+			p.printArg(a)
 		}
 		p.b.WriteByte(')')
 	case *MethodCall:
@@ -373,7 +395,7 @@ func (p *printer) printExpr(e Expr) {
 		}
 		for _, a := range e.Args {
 			p.b.WriteByte(' ')
-			p.printExpr(a)
+			p.printArg(a)
 		}
 		p.b.WriteByte(')')
 	case *ListLit:
@@ -473,9 +495,20 @@ func (p *printer) printExpr(e Expr) {
 			if i > 0 {
 				p.b.WriteByte(' ')
 			}
-			p.writef("%s:%s", pm.Name, typeString(pm.Type))
+			p.printParam(pm)
 		}
-		p.writef(") -> %s ", typeString(e.Return))
+		p.writef(") -> %s", typeString(e.Return))
+		if len(e.Captures) > 0 {
+			p.b.WriteString(" captures=[")
+			for i, c := range e.Captures {
+				if i > 0 {
+					p.b.WriteByte(' ')
+				}
+				p.writef("%s:%s", c.Name, typeString(c.T))
+			}
+			p.b.WriteByte(']')
+		}
+		p.b.WriteByte(' ')
 		p.printBlock(e.Body)
 		p.b.WriteByte(')')
 	case *VariantLit:
@@ -486,7 +519,7 @@ func (p *printer) printExpr(e Expr) {
 		p.b.WriteString(e.Variant)
 		for _, a := range e.Args {
 			p.b.WriteByte(' ')
-			p.printExpr(a)
+			p.printArg(a)
 		}
 		p.b.WriteByte(')')
 	case *BlockExpr:
@@ -543,6 +576,28 @@ func (p *printer) printNode(n Node) {
 	default:
 		p.writef("<%T>", n)
 	}
+}
+
+// printParam renders one parameter.
+func (p *printer) printParam(pm *Param) {
+	if pm == nil {
+		p.b.WriteString("?")
+		return
+	}
+	if pm.Pattern != nil {
+		p.writef("%s:%s", PatternString(pm.Pattern), typeString(pm.Type))
+		return
+	}
+	p.writef("%s:%s", pm.Name, typeString(pm.Type))
+}
+
+// printArg renders one call argument. Keyword args are written
+// `name:value`; positional args are the value alone.
+func (p *printer) printArg(a Arg) {
+	if a.Name != "" {
+		p.writef("%s:", a.Name)
+	}
+	p.printExpr(a.Value)
 }
 
 func (p *printer) printMatchArm(a *MatchArm) {

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -1,6 +1,12 @@
 package ir
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+func errDecision(s string) error            { return errors.New(s) }
+func errDecisionf(f string, a ...any) error { return fmt.Errorf(f, a...) }
 
 // Validate performs a light structural sanity check over an IR Module.
 // It does NOT re-run type checking — that's the front-end's job — but
@@ -129,6 +135,12 @@ func (v *validator) validateFnDecl(fn *FnDecl, allowNoBody bool) {
 		if p.Type == nil {
 			v.addf("fn %s: param %q nil Type", fn.Name, p.Name)
 		}
+		if p.Name == "" && p.Pattern == nil {
+			v.addf("fn %s: param[%d] has neither Name nor Pattern", fn.Name, i)
+		}
+		if p.Name != "" && p.Pattern != nil {
+			v.addf("fn %s: param %q has both Name and Pattern", fn.Name, p.Name)
+		}
 	}
 	if fn.Body == nil {
 		if !allowNoBody && !v.inInterface {
@@ -207,6 +219,9 @@ func (v *validator) validateStmt(s Stmt) {
 		} else {
 			v.validateBlock(s.Body)
 		}
+		if s.Var != "" && s.Pattern != nil {
+			v.addf("ForStmt: has both Var and Pattern")
+		}
 		switch s.Kind {
 		case ForWhile:
 			if s.Cond == nil {
@@ -219,6 +234,9 @@ func (v *validator) validateStmt(s Stmt) {
 				v.addf("ForStmt In: nil Iter")
 			} else {
 				v.validateExpr(s.Iter)
+			}
+			if s.Var == "" && s.Pattern == nil {
+				v.addf("ForStmt In: no loop binding")
 			}
 		case ForRange:
 			if s.Start == nil {
@@ -272,16 +290,16 @@ func (v *validator) validateExpr(e Expr) {
 	case *CallExpr:
 		v.validateExpr(e.Callee)
 		for _, a := range e.Args {
-			v.validateExpr(a)
+			v.validateArg(a)
 		}
 	case *IntrinsicCall:
 		for _, a := range e.Args {
-			v.validateExpr(a)
+			v.validateArg(a)
 		}
 	case *MethodCall:
 		v.validateExpr(e.Receiver)
 		for _, a := range e.Args {
-			v.validateExpr(a)
+			v.validateArg(a)
 		}
 	case *ListLit:
 		for _, el := range e.Elems {
@@ -326,9 +344,18 @@ func (v *validator) validateExpr(e Expr) {
 		v.validateExpr(e.Index)
 	case *Closure:
 		v.validateBlock(e.Body)
+		for i, c := range e.Captures {
+			if c == nil {
+				v.addf("Closure: capture[%d] nil", i)
+				continue
+			}
+			if c.Name == "" {
+				v.addf("Closure: capture[%d] empty Name", i)
+			}
+		}
 	case *VariantLit:
 		for _, a := range e.Args {
-			v.validateExpr(a)
+			v.validateArg(a)
 		}
 	case *BlockExpr:
 		v.validateBlock(e.Block)
@@ -376,5 +403,73 @@ func (v *validator) validateMatchArm(a *MatchArm) {
 		v.addf("MatchArm: nil Body")
 	} else {
 		v.validateBlock(a.Body)
+	}
+}
+
+// validateArg validates one call argument.
+func (v *validator) validateArg(a Arg) {
+	if a.Value == nil {
+		v.addf("Arg: nil Value")
+		return
+	}
+	v.validateExpr(a.Value)
+}
+
+// ValidateDecisionTree reports structural issues in a compiled
+// decision tree rooted at n. armCount bounds the valid arm indices.
+func ValidateDecisionTree(n DecisionNode, armCount int) []error {
+	if n == nil {
+		return nil
+	}
+	v := &decisionValidator{armCount: armCount}
+	v.walk(n)
+	return v.errs
+}
+
+type decisionValidator struct {
+	armCount int
+	errs     []error
+}
+
+func (v *decisionValidator) walk(n DecisionNode) {
+	switch n := n.(type) {
+	case nil:
+		v.errs = append(v.errs, errDecision("nil node"))
+	case *DecisionLeaf:
+		if n.ArmIndex < 0 || n.ArmIndex >= v.armCount {
+			v.errs = append(v.errs, errDecisionf("leaf: arm %d out of range [0,%d)", n.ArmIndex, v.armCount))
+		}
+	case *DecisionFail:
+		// terminal
+	case *DecisionBind:
+		if n.Next == nil {
+			v.errs = append(v.errs, errDecision("bind: nil Next"))
+		} else {
+			v.walk(n.Next)
+		}
+	case *DecisionGuard:
+		if n.Then == nil {
+			v.errs = append(v.errs, errDecision("guard: nil Then"))
+		} else {
+			v.walk(n.Then)
+		}
+		if n.Else == nil {
+			v.errs = append(v.errs, errDecision("guard: nil Else"))
+		} else {
+			v.walk(n.Else)
+		}
+	case *DecisionSwitch:
+		if n.Default == nil {
+			v.errs = append(v.errs, errDecision("switch: nil Default"))
+		} else {
+			v.walk(n.Default)
+		}
+		for i, c := range n.Cases {
+			if c.Body == nil {
+				v.errs = append(v.errs, errDecisionf("switch: case[%d] nil Body", i))
+				continue
+			}
+			v.walk(c.Body)
+		}
 	}
 }

--- a/internal/ir/walk.go
+++ b/internal/ir/walk.go
@@ -106,6 +106,9 @@ func walkChildren(v Visitor, n Node) {
 
 	// ---- Decl sub-nodes ----
 	case *Param:
+		if n.Pattern != nil {
+			Walk(v, n.Pattern)
+		}
 		if n.Default != nil {
 			Walk(v, n.Default)
 		}
@@ -155,6 +158,9 @@ func walkChildren(v Visitor, n Node) {
 			Walk(v, n.Else)
 		}
 	case *ForStmt:
+		if n.Pattern != nil {
+			Walk(v, n.Pattern)
+		}
 		if n.Cond != nil {
 			Walk(v, n.Cond)
 		}
@@ -204,16 +210,16 @@ func walkChildren(v Visitor, n Node) {
 	case *CallExpr:
 		Walk(v, n.Callee)
 		for _, a := range n.Args {
-			Walk(v, a)
+			Walk(v, a.Value)
 		}
 	case *IntrinsicCall:
 		for _, a := range n.Args {
-			Walk(v, a)
+			Walk(v, a.Value)
 		}
 	case *MethodCall:
 		Walk(v, n.Receiver)
 		for _, a := range n.Args {
-			Walk(v, a)
+			Walk(v, a.Value)
 		}
 	case *ListLit:
 		for _, e := range n.Elems {
@@ -265,7 +271,7 @@ func walkChildren(v Visitor, n Node) {
 		}
 	case *VariantLit:
 		for _, a := range n.Args {
-			Walk(v, a)
+			Walk(v, a.Value)
 		}
 	case *BlockExpr:
 		if n.Block != nil {

--- a/internal/llvmgen/bitwise_test.go
+++ b/internal/llvmgen/bitwise_test.go
@@ -14,7 +14,7 @@ func TestGenerateBitwiseIntOps(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/bitwise_int_ops.osty",
 	})

--- a/internal/llvmgen/break_continue_test.go
+++ b/internal/llvmgen/break_continue_test.go
@@ -19,7 +19,7 @@ func TestGenerateRangeLoopBreakAndContinue(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/range_break_continue.osty",
 	})
@@ -57,7 +57,7 @@ func TestGenerateWhileLoopBreakAndContinue(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/while_break_continue.osty",
 	})

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -1,32 +1,46 @@
 // Package llvmgen emits textual LLVM IR for the native backend.
 //
-// The first implementation is deliberately small: it supports no-arg main
-// functions or script files, integer println expressions, plain ASCII string
-// println literals, local string values with simple escapes, simple String
-// returns/parameters, simple value-aggregate structs, payload-free enum tags,
-// single-Int payload enum tags (`%Enum = { i64, i64 }`), payload-free enum
-// matches, payload-enum match expressions with payload binding, immutable
-// scalar lets, mutable scalar locals, simple Int/Bool helper functions,
-// statement-position if/else,
-// value-position if/else, simple Bool logical operators, and inclusive/
-// exclusive Int range loops. This phase also includes the `Float` smoke
-// subset as a `double`-backed subset, plus the phase 64-73 value/control-flow
-// smoke expansion for `if`, `Bool`, exclusive range, unary/modulo, and struct
-// field coverage.
-// Unsupported shapes return ErrUnsupported so callers can fall back to
-// inspectable skeleton IR while the backend grows. The module/function/skeleton
-// renderers, scalar/string/struct/enum instruction builders, compare/binary/
-// logical instruction policies, identifier/ASCII-string/fallback policies,
-// zero-literal defaults, declaration/type/signature naming policies,
-// declaration-layout/runtime-FFI validation policies, LLVM toolchain command
-// plans, executable parity plans, and categorized
-// unsupported/backend-capability diagnostics are generated from
-// toolchain/llvmgen.osty so the backend meaning is owned by Osty
-// source. This includes phase-54~63 payload generalization for `Float` and
-// `String` payload enums (return/param/mut/reversed/wildcard match coverage).
-// Qualified constructor/pattern forms remain for a later phase.
+// Public API surface (IR-only)
 //
-// The active GC implementation path paired with this lowering lives in
-// `internal/backend/runtime/osty_runtime.c`; `examples/gc` remains a model/
-// prototype corpus rather than the source of truth for runtime GC behavior.
+//   - GenerateModule(*ir.Module, Options) ([]byte, error) — the sole
+//     entry point for code generation. Consumes the backend-neutral
+//     IR produced by `internal/ir`.
+//
+// The package previously exposed Generate(*ast.File, Options) as an
+// alternate entry point. That AST route has been removed: the LLVM
+// backend dispatcher (internal/backend/llvm.go) no longer accepts an
+// AST, and the in-package helper generateFromAST is unexported so
+// only in-package tests can reach it. All external callers route
+// through IR.
+//
+// Supported source shapes
+//
+// The current implementation is deliberately small: no-arg main
+// functions or script files, integer println expressions, plain ASCII
+// string println literals, local string values with simple escapes,
+// simple String returns/parameters, simple value-aggregate structs,
+// payload-free enum tags, single-Int payload enum tags
+// (`%Enum = { i64, i64 }`), payload-free enum matches, payload-enum
+// match expressions with payload binding, immutable scalar lets,
+// mutable scalar locals, simple Int/Bool helper functions, statement-
+// and value-position if/else, simple Bool logical operators, and
+// inclusive/exclusive Int range loops, plus the phase 54-63 payload
+// generalisation for `Float` and `String` payload enums and the phase
+// 64-73 value/control-flow smoke expansion.
+//
+// Unsupported shapes return ErrUnsupported so the backend dispatcher
+// can fall back to inspectable skeleton IR while the backend grows.
+//
+// Implementation note (transitional)
+//
+// GenerateModule currently bridges the IR back to an AST (see
+// ir_module.go) and then routes through the long-standing AST-driven
+// emitter. This bridge is an implementation detail that the public
+// API does not expose — callers neither construct nor observe the
+// intermediate AST. Follow-on work will rewrite the emitter to consume
+// IR directly and delete the bridge; once that lands the AST is no
+// longer present inside the package at all.
+//
+// The active GC implementation path paired with this lowering lives
+// in `internal/backend/runtime/osty_runtime.c`.
 package llvmgen

--- a/internal/llvmgen/for_let_test.go
+++ b/internal/llvmgen/for_let_test.go
@@ -20,7 +20,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/for_let_payload_loop.osty",
 	})
@@ -58,7 +58,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/for_let_qualified_loop.osty",
 	})

--- a/internal/llvmgen/gc_integration_test.go
+++ b/internal/llvmgen/gc_integration_test.go
@@ -12,7 +12,7 @@ func TestGenerateVoidFunctionReleasesManagedRoots(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/void_gc_roots.osty",
 	})
@@ -64,7 +64,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/gc_safepoint_roots.osty",
 	})
@@ -106,7 +106,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/method_receivers.osty",
 	})
@@ -152,7 +152,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/enum_struct_field.osty",
 	})
@@ -191,7 +191,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/managed_aggregate_list_gc.osty",
 	})

--- a/internal/llvmgen/if_let_test.go
+++ b/internal/llvmgen/if_let_test.go
@@ -21,7 +21,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/if_let_payload_stmt.osty",
 	})
@@ -57,7 +57,7 @@ fn score(value: Maybe) -> Int {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/if_let_payload_expr.osty",
 	})
@@ -93,7 +93,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/if_let_qualified_variant.osty",
 	})

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -9,10 +9,16 @@ import (
 	"github.com/osty/osty/internal/token"
 )
 
-// GenerateModule is the IR-first LLVM entry point used by the production
-// backend path. During migration it reifies the backend-owned IR into the
-// legacy AST bridge so the rest of the emitter can stay stable while the
-// direct AST boundary is removed from backend call sites.
+// GenerateModule is the sole public entry point of the LLVM backend.
+// It consumes the backend-neutral IR (internal/ir) and emits textual
+// LLVM IR.
+//
+// The implementation currently reifies the module back into a legacy
+// AST shape through legacyFileFromModule and then hands off to the
+// long-standing AST-driven emitter. This is a transitional detail:
+// external callers route through IR only, and the in-package test
+// helper generateFromAST is unexported. Once the emitter is rewritten
+// to consume IR directly, the bridge and the AST helper both go away.
 func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if mod == nil {
 		return nil, unsupported("source-layout", "nil module")
@@ -183,6 +189,13 @@ func legacyParamFromIR(param *ostyir.Param) (*ast.Param, error) {
 		EndV: end,
 		Name: param.Name,
 		Type: legacyTypeFromIR(param.Type),
+	}
+	if param.Pattern != nil {
+		pat, err := legacyPatternFromIR(param.Pattern)
+		if err != nil {
+			return nil, err
+		}
+		out.Pattern = pat
 	}
 	if param.Default != nil {
 		value, err := legacyExprFromIR(param.Default)
@@ -370,7 +383,9 @@ func legacyTypeFromIR(typ ostyir.Type) ast.Type {
 		}
 		return &ast.NamedType{Path: []string{name}}
 	case *ostyir.NamedType:
-		out := &ast.NamedType{Path: splitQualifiedName(t.Name)}
+		path := splitQualifiedName(t.Package)
+		path = append(path, t.Name)
+		out := &ast.NamedType{Path: path}
 		for _, arg := range t.Args {
 			out.Args = append(out.Args, legacyTypeFromIR(arg))
 		}
@@ -658,7 +673,11 @@ func legacyForStmtFromIR(stmt *ostyir.ForStmt) (ast.Stmt, error) {
 		out.Iter = iter
 		return out, nil
 	case ostyir.ForRange:
-		out.Pattern = &ast.IdentPat{PosV: start, EndV: start, Name: stmt.Var}
+		pat, err := legacyLoopPattern(stmt, start)
+		if err != nil {
+			return nil, err
+		}
+		out.Pattern = pat
 		startExpr, err := legacyExprFromIR(stmt.Start)
 		if err != nil {
 			return nil, err
@@ -676,7 +695,11 @@ func legacyForStmtFromIR(stmt *ostyir.ForStmt) (ast.Stmt, error) {
 		}
 		return out, nil
 	case ostyir.ForIn:
-		out.Pattern = &ast.IdentPat{PosV: start, EndV: start, Name: stmt.Var}
+		pat, err := legacyLoopPattern(stmt, start)
+		if err != nil {
+			return nil, err
+		}
+		out.Pattern = pat
 		iter, err := legacyExprFromIR(stmt.Iter)
 		if err != nil {
 			return nil, err
@@ -686,6 +709,18 @@ func legacyForStmtFromIR(stmt *ostyir.ForStmt) (ast.Stmt, error) {
 	default:
 		return nil, unsupportedf("control-flow", "IR for-kind %d", stmt.Kind)
 	}
+}
+
+// legacyLoopPattern bridges a for-loop binding back to ast.Pattern.
+func legacyLoopPattern(stmt *ostyir.ForStmt, pos token.Pos) (ast.Pattern, error) {
+	if stmt.Pattern != nil {
+		pat, err := legacyPatternFromIR(stmt.Pattern)
+		if err != nil {
+			return nil, err
+		}
+		return pat, nil
+	}
+	return &ast.IdentPat{PosV: pos, EndV: pos, Name: stmt.Var}, nil
 }
 
 func legacyDeferStmtFromIR(stmt *ostyir.DeferStmt) (ast.Stmt, error) {
@@ -839,13 +874,20 @@ func legacyCallExprFromIR(expr *ostyir.CallExpr) (ast.Expr, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(expr.TypeArgs) > 0 {
+		tf := &ast.TurbofishExpr{PosV: start, EndV: end, Base: fn}
+		for _, ta := range expr.TypeArgs {
+			tf.Args = append(tf.Args, legacyTypeFromIR(ta))
+		}
+		fn = tf
+	}
 	out := &ast.CallExpr{PosV: start, EndV: end, Fn: fn}
 	for _, arg := range expr.Args {
-		value, err := legacyExprFromIR(arg)
+		legacyArg, err := legacyIRArg(arg)
 		if err != nil {
 			return nil, err
 		}
-		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+		out.Args = append(out.Args, legacyArg)
 	}
 	return out, nil
 }
@@ -862,13 +904,26 @@ func legacyIntrinsicCallFromIR(expr *ostyir.IntrinsicCall) (ast.Expr, error) {
 		},
 	}
 	for _, arg := range expr.Args {
-		value, err := legacyExprFromIR(arg)
+		legacyArg, err := legacyIRArg(arg)
 		if err != nil {
 			return nil, err
 		}
-		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+		out.Args = append(out.Args, legacyArg)
 	}
 	return out, nil
+}
+
+// legacyIRArg bridges an ir.Arg into an ast.Arg.
+func legacyIRArg(arg ostyir.Arg) (*ast.Arg, error) {
+	value, err := legacyExprFromIR(arg.Value)
+	if err != nil {
+		return nil, err
+	}
+	pos := value.Pos()
+	if arg.SpanV.Start.Line != 0 {
+		pos = legacyPos(arg.SpanV.Start)
+	}
+	return &ast.Arg{PosV: pos, Name: arg.Name, Value: value}, nil
 }
 
 func legacyListLitFromIR(expr *ostyir.ListLit) (ast.Expr, error) {
@@ -965,11 +1020,11 @@ func legacyMethodCallFromIR(expr *ostyir.MethodCall) (ast.Expr, error) {
 	}
 	out := &ast.CallExpr{PosV: start, EndV: end, Fn: fn}
 	for _, arg := range expr.Args {
-		value, err := legacyExprFromIR(arg)
+		legacyArg, err := legacyIRArg(arg)
 		if err != nil {
 			return nil, err
 		}
-		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+		out.Args = append(out.Args, legacyArg)
 	}
 	return out, nil
 }
@@ -1117,11 +1172,11 @@ func legacyVariantLitFromIR(expr *ostyir.VariantLit) (ast.Expr, error) {
 	}
 	out := &ast.CallExpr{PosV: start, EndV: end, Fn: callee}
 	for _, arg := range expr.Args {
-		value, err := legacyExprFromIR(arg)
+		legacyArg, err := legacyIRArg(arg)
 		if err != nil {
 			return nil, err
 		}
-		out.Args = append(out.Args, &ast.Arg{PosV: value.Pos(), Value: value})
+		out.Args = append(out.Args, legacyArg)
 	}
 	return out, nil
 }

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -13,8 +13,10 @@ import (
 	"github.com/osty/osty/internal/token"
 )
 
-// ErrUnsupported marks source shapes that this early LLVM emitter does not
-// lower yet.
+// ErrUnsupported marks source shapes that this early LLVM emitter does
+// not lower yet. Callers observing this sentinel must render the
+// skeleton IR themselves — the LLVM backend dispatcher no longer falls
+// back to an AST path when IR lowering hits a gap.
 var ErrUnsupported = errors.New("llvmgen: unsupported source shape")
 
 // Options configures textual LLVM IR emission.
@@ -183,8 +185,17 @@ func toUnsupportedDiagnostic(diag UnsupportedDiagnostic) *LlvmUnsupportedDiagnos
 	}
 }
 
-// Generate emits textual LLVM IR for a minimal, scalar subset.
-func Generate(file *ast.File, opts Options) ([]byte, error) {
+// generateFromAST emits textual LLVM IR from a type-checked AST. It is
+// used only as an internal helper: the public entry point is
+// GenerateModule, which consumes the backend-neutral IR. The in-package
+// test suite still exercises this function directly because the
+// generator's rewrite to consume IR in place of AST is a separate
+// refactor — see ir_module.go for the current IR→AST bridge.
+//
+// External callers must route through GenerateModule. The LLVM backend
+// dispatcher (internal/backend/llvm.go) no longer falls back to an AST
+// path when the IR lowering hits a gap.
+func generateFromAST(file *ast.File, opts Options) ([]byte, error) {
 	return generateASTFile(file, opts)
 }
 

--- a/internal/llvmgen/match_guard_test.go
+++ b/internal/llvmgen/match_guard_test.go
@@ -21,7 +21,7 @@ fn describe(value: Maybe) -> String {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/match_guard_payload.osty",
 	})
@@ -62,7 +62,7 @@ fn choose(flag: Bool, kind: Kind) -> Int {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/match_guard_tag.osty",
 	})

--- a/internal/llvmgen/multi_arm_match_test.go
+++ b/internal/llvmgen/multi_arm_match_test.go
@@ -27,7 +27,7 @@ fn score(kind: Kind) -> Int {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/multi_arm_block_match.osty",
 	})
@@ -74,7 +74,7 @@ fn score(kind: Kind) -> Int {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/multi_arm_call_match.osty",
 	})
@@ -118,7 +118,7 @@ fn score(value: Maybe) -> Int {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/payload_multi_arm_block_match.osty",
 	})

--- a/internal/llvmgen/optional_test.go
+++ b/internal/llvmgen/optional_test.go
@@ -15,7 +15,7 @@ fn maybeName(profile: Profile?) -> String? {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/optional_field.osty",
 	})
@@ -51,7 +51,7 @@ fn maybeDisplay(profile: Profile?) -> String? {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/optional_method.osty",
 	})
@@ -81,7 +81,7 @@ fn parts() -> List<String> {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/optional_runtime_ffi.osty",
 	})
@@ -111,7 +111,7 @@ fn requireName(profile: Profile?) -> String? {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/optional_question.osty",
 	})

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -20,7 +20,7 @@ func generateLLVMForTest(t *testing.T, src string) string {
 	if len(diags) > 0 {
 		t.Fatalf("parse returned %d diagnostics: %v", len(diags), diags[0])
 	}
-	ir, err := Generate(file, Options{SourcePath: "/tmp/managed.osty"})
+	ir, err := generateFromAST(file, Options{SourcePath: "/tmp/managed.osty"})
 	if err != nil {
 		t.Fatalf("Generate returned error: %v", err)
 	}

--- a/internal/llvmgen/return_test.go
+++ b/internal/llvmgen/return_test.go
@@ -14,7 +14,7 @@ func TestGenerateNestedReturnInIfStmt(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/nested_return_if.osty",
 	})
@@ -45,7 +45,7 @@ func TestGenerateNestedReturnInLoopBody(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/nested_return_loop.osty",
 	})
@@ -77,7 +77,7 @@ func TestGenerateIfBothBranchesReturnVoid(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/return_void_branches.osty",
 	})

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -37,7 +37,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/runtime_has_prefix.osty",
 		Target:      "x86_64-unknown-linux-gnu",
@@ -81,7 +81,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/runtime_unknown.osty",
 		Target:      "x86_64-unknown-linux-gnu",
@@ -112,7 +112,7 @@ func TestGenerateStringCompareUsesRuntimeABI(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/string_compare.osty",
 	})
@@ -152,7 +152,7 @@ pub fn kindName(kind: Kind) -> String {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/package_entry.osty",
 	})
@@ -185,7 +185,7 @@ pub fn keep(bag: RuntimeBag) -> RuntimeBag {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/runtime_bag.osty",
 	})
@@ -214,7 +214,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/void_call.osty",
 	})
@@ -246,7 +246,7 @@ fn values() -> List<Int> {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/list_literals.osty",
 	})
@@ -274,7 +274,7 @@ func TestGenerateListLenUsesRuntimeABI(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/list_len.osty",
 	})
@@ -300,7 +300,7 @@ func TestGenerateListPushStmtUsesRuntimeABI(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/list_push.osty",
 	})
@@ -328,7 +328,7 @@ func TestGenerateManagedListPushStmtUsesSafepoint(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/list_push_managed.osty",
 	})
@@ -356,7 +356,7 @@ func TestGenerateForInOverListStringUsesRuntimeABI(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "core",
 		SourcePath:  "/tmp/list_for_in.osty",
 	})
@@ -387,7 +387,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/list_for_in_temp.osty",
 	})
@@ -425,7 +425,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/call_arg_temp_root.osty",
 	})
@@ -471,7 +471,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/collections_runtime.osty",
 	})
@@ -512,7 +512,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/collections_trace_runtime.osty",
 	})

--- a/internal/llvmgen/top_level_decl_test.go
+++ b/internal/llvmgen/top_level_decl_test.go
@@ -19,7 +19,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/top_level_alias_let.osty",
 	})
@@ -53,7 +53,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/top_level_interface_let.osty",
 	})
@@ -86,7 +86,7 @@ fn main() {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/top_level_mut_let.osty",
 	})

--- a/internal/llvmgen/while_for_test.go
+++ b/internal/llvmgen/while_for_test.go
@@ -17,7 +17,7 @@ func TestGenerateWhileStyleForLoop(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/while_for.osty",
 	})
@@ -49,7 +49,7 @@ func TestGenerateBareForLoop(t *testing.T) {
 }
 `)
 
-	ir, err := Generate(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/bare_for.osty",
 	})


### PR DESCRIPTION
## Summary

**IR 보강**
- Closure capture 분석, match decision tree 컴파일, IR-level 최적화 (상수 접기/DCE/대수)
- keyword arguments, generic instantiation, qualified paths, for/param destructuring, turbofish on idents 전부 IR로 보존
- Validate + ValidateDecisionTree 불변식 확장, IR 단위 테스트 20개

**LLVM 백엔드 AST 경로 제거**
- `backend/llvm.go`: `llvmgen.Generate(ast.File)` 폴백 삭제. IR이 유일 입력
- `llvmgen.Generate` → `generateFromAST` 내부화 (외부 API surface 0)
- 13개 테스트 파일 46개 호출처 rename
- `TestLLVMBackendRefusesNilIR` — IR-only 계약 회귀 방지 테스트

## Test plan
- [x] `go build ./internal/ir/ ./internal/llvmgen/ ./internal/backend/` — 성공
- [x] `go test ./internal/ir/` — 20/20 통과
- [x] `go test ./internal/backend/` — 통과 (IR-only contract tests 포함)
- [x] `go test ./internal/llvmgen/` — 기존 7개 pre-existing 실패 동일 (회귀 없음)
- [ ] CI 통과 확인

## 남은 내부 구현 세부 (공개 API 아님)

`llvmgen.GenerateModule`는 내부에서 `legacyFileFromModule`로 IR → AST 브리지 경유. 공개 경계에서는 AST가 완전히 사라졌고, 내부 브리지 제거는 별도 리팩터 (llvmgen 7000줄 AST-consumer → IR-consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)