### PR TITLE
feat: Salsa-style 증분 쿼리 엔진 + LSP 파일 모드 이관

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -118,6 +118,14 @@ func main() {
 		}
 		os.Exit(server.ExitCode())
 	}
+	// query-check runs a single file through the incremental query
+	// engine and optionally prints cache metrics. Primarily a demo /
+	// measurement tool; LSP and future long-lived tooling are the
+	// main engine consumers.
+	if cmd == "query-check" {
+		runQueryCheck(args[1:])
+		return
+	}
 	// new takes a project name and optional --lib/--bin flags — not a
 	// file path — so it has its own flag parser and dispatch.
 	if cmd == "new" {

--- a/cmd/osty/query.go
+++ b/cmd/osty/query.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/diag"
+	ostyquery "github.com/osty/osty/internal/query/osty"
+)
+
+// runQueryCheck implements
+//
+//	osty query-check [--metrics] [--twice] FILE
+//
+// Runs Parse / Resolve / Check / Lint / FileDiagnostics through the
+// incremental query engine and prints any diagnostics. The flag
+// --metrics dumps the engine's hit/miss/rerun/cutoff counters after
+// the analysis, useful for observing cache behavior. --twice runs
+// the analysis twice over the same input to exhibit cache hits on
+// the second pass.
+//
+// Unlike `osty check`, which runs each invocation in a fresh process
+// and thus gets no carry-over caching, this subcommand is primarily
+// a demonstration / measurement tool for the engine. The engine
+// itself is intended to be embedded in long-lived processes (LSP,
+// build daemons) where cross-request caching pays off.
+func runQueryCheck(args []string) {
+	fs := flag.NewFlagSet("query-check", flag.ExitOnError)
+	var (
+		showMetrics bool
+		runTwice    bool
+	)
+	fs.BoolVar(&showMetrics, "metrics", false, "print engine metrics after analysis")
+	fs.BoolVar(&runTwice, "twice", false, "re-run the same analysis to exercise the cache path")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr,
+			"usage: osty query-check [--metrics] [--twice] FILE")
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	path := fs.Arg(0)
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty query-check: %v\n", err)
+		os.Exit(1)
+	}
+
+	eng := ostyquery.NewEngine()
+	key := ostyquery.NormalizePath(path)
+	dir := ostyquery.PackageDirOf(key)
+
+	eng.Inputs.SourceText.Set(eng.DB, key, src)
+	eng.Inputs.PackageFiles.Set(eng.DB, dir, []string{key})
+
+	before := eng.DB.Metrics()
+	diags := eng.Queries.FileDiagnostics.Get(eng.DB, key)
+	firstDelta := eng.DB.Metrics().Sub(before)
+
+	if showMetrics {
+		fmt.Fprintf(os.Stderr, "first pass: %+v\n", firstDelta)
+	}
+
+	if runTwice {
+		before = eng.DB.Metrics()
+		diags = eng.Queries.FileDiagnostics.Get(eng.DB, key)
+		secondDelta := eng.DB.Metrics().Sub(before)
+		if showMetrics {
+			fmt.Fprintf(os.Stderr, "second pass (cache): %+v\n", secondDelta)
+		}
+	}
+
+	if len(diags) == 0 {
+		return
+	}
+	f := &diag.Formatter{Filename: path, Source: src}
+	fmt.Fprintln(os.Stderr, f.FormatAll(diags))
+
+	anyErr := false
+	for _, d := range diags {
+		if d.Severity == diag.Error {
+			anyErr = true
+			break
+		}
+	}
+	if anyErr {
+		os.Exit(1)
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lint"
 	"github.com/osty/osty/internal/parser"
+	ostyquery "github.com/osty/osty/internal/query/osty"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
@@ -64,6 +65,14 @@ type Server struct {
 	// invalidated whenever any document changes — subsequent
 	// queries rebuild from disk.
 	wsIndex workspaceIndex
+
+	// engine is the Salsa-style incremental query engine. For file-
+	// mode analysis (scratch buffers / files without .osty siblings)
+	// it backs the analyze path and persists cached parse / resolve
+	// / check results across document edits. Package and workspace
+	// modes retain their legacy eager paths pending a follow-up
+	// migration.
+	engine *ostyquery.Engine
 }
 
 // workspaceIndex stores every package loaded from a single workspace
@@ -95,13 +104,16 @@ func NewServer(in io.Reader, out io.Writer, logOut io.Writer) *Server {
 	if logOut == nil {
 		logOut = io.Discard
 	}
+	prelude := resolve.NewPrelude()
+	reg := stdlib.LoadCached()
 	return &Server{
 		conn:    newConn(in, out),
 		log:     log.New(logOut, "osty-lsp: ", log.LstdFlags),
-		prelude: resolve.NewPrelude(),
+		prelude: prelude,
 		docs:    docStore{m: map[string]*document{}},
 		exit:    make(chan struct{}),
 		trace:   os.Getenv("OSTY_LSP_TRACE") != "",
+		engine:  ostyquery.NewEngineForTest(prelude, reg),
 	}
 }
 
@@ -375,7 +387,7 @@ func (s *Server) analyze(uri string, src []byte) *docAnalysis {
 			return a
 		}
 	}
-	return s.analyzeSingleFile(src)
+	return s.analyzeSingleFileViaEngine(uri, src)
 }
 
 // analyzePackageContaining walks the on-disk context of `path` and runs
@@ -642,8 +654,11 @@ func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
 	return pos.Offset <= len(pf.Source)
 }
 
-// analyzeSingleFile is the original file-only analysis used for
-// scratch buffers and files without .osty siblings.
+// analyzeSingleFile is the legacy eager analysis path — retained for
+// call sites that still need it while the engine-backed path is
+// promoted. New callers should prefer analyzeSingleFileViaEngine so
+// repeated edits of the same buffer benefit from the incremental
+// cache and early cutoff.
 func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
 	file, parseDiags := parser.ParseDiagnostics(src)
 	res := resolve.File(file, s.prelude)
@@ -664,6 +679,55 @@ func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
 		diags:      all,
 		identIndex: buildIdentIndex(res),
 	}
+}
+
+// analyzeSingleFileViaEngine uses the Salsa-style incremental query
+// engine for file-mode analysis. The URI serves as the engine key
+// (normalized for `file://` URIs, verbatim for scratch buffers) so
+// successive edits of the same buffer share a cache lineage.
+//
+// When the new source hashes identical to the cached input the engine
+// skips the entire Parse/Resolve/Check cascade; when the source
+// differs but the resolver's semantic output doesn't (e.g. whitespace
+// or comment-only edits), the early-cutoff path spares the checker
+// and linter re-runs. The result mirrors analyzeSingleFile's docAnalysis
+// shape so existing handlers need no changes.
+func (s *Server) analyzeSingleFileViaEngine(uri string, src []byte) *docAnalysis {
+	key := engineKeyForURI(uri)
+	s.engine.Inputs.SourceText.Set(s.engine.DB, key, src)
+	// PackageFiles must be seeded for BuildPackage to succeed. A
+	// scratch buffer is treated as a one-file package keyed by its
+	// directory (or by the URI itself when we have no path).
+	dir := ostyquery.PackageDirOf(key)
+	// Build the list deterministically from what the engine already
+	// knows about — i.e., just this one file. Multi-file scratch
+	// scenarios are rare in single-file mode.
+	s.engine.Inputs.PackageFiles.Set(s.engine.DB, dir, []string{key})
+
+	pr := s.engine.Queries.Parse.Get(s.engine.DB, key)
+	rr := s.engine.Queries.ResolveFile.Get(s.engine.DB, key)
+	chk := s.engine.Queries.CheckFile.Get(s.engine.DB, key)
+	lr := s.engine.Queries.LintFile.Get(s.engine.DB, key)
+	idx := s.engine.Queries.IdentIndex.Get(s.engine.DB, key)
+	all := s.engine.Queries.FileDiagnostics.Get(s.engine.DB, key)
+	return &docAnalysis{
+		lines:      newLineIndex(src),
+		file:       pr.File,
+		resolve:    rr,
+		check:      chk,
+		lint:       lr,
+		diags:      all,
+		identIndex: idx,
+	}
+}
+
+// engineKeyForURI converts an LSP URI to the engine's canonical key.
+// Defers to ostyquery.FromURI for file:// URIs; returns the URI
+// verbatim for other schemes so scratch-buffer identity is preserved
+// across edits.
+func engineKeyForURI(uri string) string {
+	key, _ := ostyquery.FromURI(uri)
+	return key
 }
 
 func lspCheckOpts(src []byte) check.Opts {

--- a/internal/lsp/server_incremental_test.go
+++ b/internal/lsp/server_incremental_test.go
@@ -1,0 +1,83 @@
+package lsp
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestEngineBackedAnalyzeCachesRepeatedEdits verifies that
+// analyzeSingleFileViaEngine actually reuses cached work: re-analyzing
+// the same buffer should produce a metric delta with zero misses and
+// zero reruns, just hits.
+func TestEngineBackedAnalyzeCachesRepeatedEdits(t *testing.T) {
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	uri := "untitled:Scratch-1.osty"
+	src := []byte("pub fn main() { }\n")
+
+	// First analyze — everything cold.
+	_ = s.analyzeSingleFileViaEngine(uri, src)
+
+	before := s.engine.DB.Metrics()
+	_ = s.analyzeSingleFileViaEngine(uri, src)
+	after := s.engine.DB.Metrics().Sub(before)
+
+	if after.Misses != 0 {
+		t.Errorf("repeated same-source analyze should not miss: %+v", after)
+	}
+	if after.Reruns != 0 {
+		t.Errorf("repeated same-source analyze should not rerun: %+v", after)
+	}
+	if after.Hits == 0 {
+		t.Errorf("repeated same-source analyze should produce hits: %+v", after)
+	}
+}
+
+// TestEngineBackedAnalyzeCutoffsOnWhitespaceEdit validates the
+// cornerstone Salsa-style behavior: a byte-level change that doesn't
+// alter the resolver's semantic output lets downstream queries
+// (CheckFile, LintFile) stay cached via early cutoff.
+func TestEngineBackedAnalyzeCutoffsOnWhitespaceEdit(t *testing.T) {
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	uri := "untitled:Scratch-2.osty"
+	src := []byte("pub fn main() { }\n")
+	_ = s.analyzeSingleFileViaEngine(uri, src)
+
+	// Add a trailing newline. Source bytes differ → Parse re-runs.
+	// The resolver's output (Refs/TypeRefs/PkgScope content) is
+	// unchanged → ResolvePackage hash matches → CheckFile / LintFile
+	// stay cached via cutoff.
+	srcPlusNewline := append([]byte(nil), src...)
+	srcPlusNewline = append(srcPlusNewline, '\n')
+
+	before := s.engine.DB.Metrics()
+	_ = s.analyzeSingleFileViaEngine(uri, srcPlusNewline)
+	after := s.engine.DB.Metrics().Sub(before)
+
+	if after.Cutoffs == 0 {
+		t.Errorf("expected at least one cutoff on whitespace-only edit: %+v", after)
+	}
+	if after.Reruns == 0 {
+		t.Errorf("expected at least Parse to re-run on byte diff: %+v", after)
+	}
+	t.Logf("whitespace-edit metrics: %+v", after)
+}
+
+// TestEngineBackedAnalyzeInvalidatesOnRealEdit proves the flip side:
+// a semantic edit (new top-level decl) flushes the downstream cache
+// and forces re-runs all the way through CheckFile.
+func TestEngineBackedAnalyzeInvalidatesOnRealEdit(t *testing.T) {
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	uri := "untitled:Scratch-3.osty"
+	_ = s.analyzeSingleFileViaEngine(uri, []byte("pub fn a() { }\n"))
+
+	before := s.engine.DB.Metrics()
+	_ = s.analyzeSingleFileViaEngine(uri, []byte("pub fn a() { }\npub fn b() { }\n"))
+	after := s.engine.DB.Metrics().Sub(before)
+
+	if after.Reruns == 0 {
+		t.Errorf("expected reruns after adding a new decl: %+v", after)
+	}
+}

--- a/internal/query/cycle.go
+++ b/internal/query/cycle.go
@@ -1,0 +1,49 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CycleError is returned (via panic) when a query transitively
+// depends on itself. The message lists the full chain for
+// debuggability.
+type CycleError struct {
+	Chain []string
+}
+
+func (e *CycleError) Error() string {
+	var b strings.Builder
+	b.WriteString("query cycle detected: ")
+	for i, name := range e.Chain {
+		if i > 0 {
+			b.WriteString(" -> ")
+		}
+		b.WriteString(name)
+	}
+	return b.String()
+}
+
+// checkCycle walks the current stack and returns a CycleError if
+// (qid, key) is already being computed. Must be called under db.mu.
+func (db *Database) checkCycle(qid QueryID, key any) *CycleError {
+	for _, f := range db.stack {
+		if f.qid == qid && keysEqual(f.key, key) {
+			chain := make([]string, 0, len(db.stack)+1)
+			for _, s := range db.stack {
+				chain = append(chain, fmt.Sprintf("%s(%v)", db.names[s.qid], s.key))
+			}
+			chain = append(chain, fmt.Sprintf("%s(%v)", db.names[qid], key))
+			return &CycleError{Chain: chain}
+		}
+	}
+	return nil
+}
+
+// keysEqual compares two query keys for equality. The key type is
+// erased to `any` in the slot store, so we rely on Go's built-in
+// equality — valid since keys are constrained to comparable types at
+// query registration (Query[K comparable, V any]).
+func keysEqual(a, b any) bool {
+	return a == b
+}

--- a/internal/query/db.go
+++ b/internal/query/db.go
@@ -1,0 +1,132 @@
+// Package query implements a Salsa-style incremental query engine for
+// pull-based, revision-tracked computation with early cutoff.
+//
+// The engine has three top-level abstractions:
+//
+//   - [Database] — the top-level holder. Owns the global revision
+//     counter, the slot storage for every registered query, and the
+//     execution stack used for dependency tracking and cycle detection.
+//   - [Input] — a source of truth. Callers [Input.Set] values keyed by
+//     something comparable; reads via [Input.Get] or via a downstream
+//     query reading the same key.
+//   - [Query] — a derived computation. Pure function of its inputs
+//     plus other queries. Registered with a [QueryFn] and an optional
+//     hashFn used for early cutoff.
+//
+// The engine is independent of the Osty compiler; callers build their
+// query set on top via [Register] and [RegisterInput]. See
+// [github.com/osty/osty/internal/query/osty] for the compiler-specific
+// binding.
+package query
+
+import (
+	"sync"
+
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// Revision is a monotonically increasing counter stamped onto every
+// slot. An input [Input.Set] call that observes a hash-different value
+// bumps the revision; derived queries use revisions to decide whether
+// their cached value is still valid without recomputing.
+type Revision uint64
+
+// QueryID is the engine's internal handle for a registered query or
+// input. Values are assigned in registration order and are not
+// meaningful across processes; they exist only to key slot storage and
+// to identify frames on the execution stack.
+type QueryID uint32
+
+// Database is the root of a query universe. All queries registered
+// against the same Database share one slot store, one revision
+// counter, and one execution stack.
+//
+// The MVP uses a single big mutex. Every [Query.Get] and [Input.Set]
+// call serializes through it. This matches the LSP's existing
+// per-handler serialization and is correct by construction for
+// dependency recording; per-slot locks can be added later without API
+// changes.
+type Database struct {
+	mu sync.Mutex
+
+	// rev is the current global revision. Bumps whenever an input's
+	// Set observes a hash-different payload.
+	rev Revision
+
+	// slots[qid][key] is the cached record for one (query, key) pair.
+	slots map[QueryID]map[any]*slot
+
+	// names records a human-readable label per QueryID for error
+	// messages and metrics.
+	names map[QueryID]string
+
+	// isInput records whether a QueryID was registered as an input.
+	// Only inputs may be Set/Cleared.
+	isInput map[QueryID]bool
+
+	// validators is the type-erased dispatch table used during
+	// dep-walks. Each Register / RegisterInput call installs one
+	// entry keyed by the query's QueryID. See validator type in
+	// query.go.
+	validators map[QueryID]validator
+
+	// nextID hands out QueryIDs in registration order.
+	nextID QueryID
+
+	// stack is the currently-running call chain. Each frame records
+	// the deps observed while its query body executes. Used both for
+	// dep-edge recording and for cycle detection.
+	stack []*frame
+
+	// metrics count hits / misses / reruns / cutoffs across the
+	// Database lifetime. See [MetricsSnapshot].
+	metrics Metrics
+
+	// prelude and stdlib are process-lifetime singletons baked into
+	// the Database at construction. Queries read them directly from
+	// [Ctx.Prelude] / [Ctx.Stdlib] without recording a dep edge —
+	// they never change.
+	prelude *resolve.Scope
+	stdlib  *stdlib.Registry
+}
+
+// NewDatabase constructs a Database with the given process-lifetime
+// prelude and stdlib registry. Both may be nil for test harnesses that
+// don't need them.
+func NewDatabase(prelude *resolve.Scope, reg *stdlib.Registry) *Database {
+	return &Database{
+		slots:      make(map[QueryID]map[any]*slot),
+		names:      make(map[QueryID]string),
+		isInput:    make(map[QueryID]bool),
+		validators: make(map[QueryID]validator),
+		prelude:    prelude,
+		stdlib:     reg,
+	}
+}
+
+// Revision returns the current global revision. Mostly useful for
+// tests asserting "an edit did (not) bump the revision".
+func (db *Database) Revision() Revision {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.rev
+}
+
+// Metrics returns a snapshot of the hit/miss/rerun/cutoff counters.
+func (db *Database) Metrics() MetricsSnapshot {
+	return db.metrics.Snapshot()
+}
+
+// allocID reserves a new QueryID for a registration. Must be called
+// under db.mu (or before any concurrent access, i.e. during setup).
+func (db *Database) allocID(name string, input bool) QueryID {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	id := db.nextID
+	db.nextID++
+	db.names[id] = name
+	db.isInput[id] = input
+	db.slots[id] = make(map[any]*slot)
+	return id
+}

--- a/internal/query/db_test.go
+++ b/internal/query/db_test.go
@@ -1,0 +1,451 @@
+package query
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// ---- Shared helpers ----
+
+func hashBytes(b []byte) [32]byte { return sha256.Sum256(b) }
+
+func hashInt(n int) [32]byte {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(n))
+	return sha256.Sum256(buf[:])
+}
+
+func hashString(s string) [32]byte { return sha256.Sum256([]byte(s)) }
+
+// ---- Input mechanics ----
+
+func TestInputSetBumpsRevisionOnlyOnContentChange(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	if got := db.Revision(); got != 0 {
+		t.Fatalf("fresh db should have rev 0, got %d", got)
+	}
+
+	src.Set(db, "a", []byte("hello"))
+	if got := db.Revision(); got != 1 {
+		t.Fatalf("first set should bump rev to 1, got %d", got)
+	}
+
+	src.Set(db, "a", []byte("hello")) // identical
+	if got := db.Revision(); got != 1 {
+		t.Fatalf("same-content set should not bump rev, got %d", got)
+	}
+
+	src.Set(db, "a", []byte("world"))
+	if got := db.Revision(); got != 2 {
+		t.Fatalf("diff-content set should bump rev, got %d", got)
+	}
+
+	// different key, different content
+	src.Set(db, "b", []byte("other"))
+	if got := db.Revision(); got != 3 {
+		t.Fatalf("new key should bump rev, got %d", got)
+	}
+}
+
+func TestInputGetReturnsLatest(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	src.Set(db, "a", []byte("v1"))
+	if got := src.Get(db, "a"); string(got) != "v1" {
+		t.Fatalf("want v1, got %s", got)
+	}
+
+	src.Set(db, "a", []byte("v2"))
+	if got := src.Get(db, "a"); string(got) != "v2" {
+		t.Fatalf("want v2, got %s", got)
+	}
+}
+
+func TestInputGetUnsetPanics(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic, got none")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "Src") {
+			t.Fatalf("want panic mentioning Src, got %v", r)
+		}
+	}()
+	_ = src.Get(db, "missing")
+}
+
+// ---- Basic derived query ----
+
+func TestDerivedQueryMissThenHit(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	var bodyCount int
+	parse := Register(db, "Parse",
+		func(ctx *Ctx, key string) int {
+			bodyCount++
+			v := src.Fetch(ctx, key)
+			return len(v)
+		},
+		hashInt,
+	)
+
+	src.Set(db, "a", []byte("12345"))
+
+	before := db.Metrics()
+	got := parse.Get(db, "a")
+	if got != 5 {
+		t.Fatalf("want 5, got %d", got)
+	}
+	after := db.Metrics().Sub(before)
+	if after.Misses != 1 || after.Hits != 1 /* input Fetch inside body counts a hit */ {
+		t.Fatalf("miss+input-hit expected, got %+v", after)
+	}
+	if bodyCount != 1 {
+		t.Fatalf("body ran %d times, want 1", bodyCount)
+	}
+
+	// Second call should be a cached hit: no body run, verifiedAt
+	// already at current rev.
+	before = db.Metrics()
+	got = parse.Get(db, "a")
+	after = db.Metrics().Sub(before)
+	if got != 5 || bodyCount != 1 {
+		t.Fatalf("want cached; body=%d got=%d", bodyCount, got)
+	}
+	if after.Hits != 1 || after.Misses != 0 || after.Reruns != 0 {
+		t.Fatalf("expected 1 hit, got %+v", after)
+	}
+}
+
+// ---- Input change → derived rerun ----
+
+func TestDerivedRerunsOnInputChange(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	var bodyCount int
+	length := Register(db, "Length",
+		func(ctx *Ctx, key string) int {
+			bodyCount++
+			return len(src.Fetch(ctx, key))
+		},
+		hashInt,
+	)
+
+	src.Set(db, "a", []byte("hello"))
+	_ = length.Get(db, "a")
+	if bodyCount != 1 {
+		t.Fatalf("initial run: body=%d", bodyCount)
+	}
+
+	// Content-identical Set: no rerun even though we pulled after.
+	src.Set(db, "a", []byte("hello"))
+	_ = length.Get(db, "a")
+	if bodyCount != 1 {
+		t.Fatalf("same-content Set should not trigger rerun, body=%d", bodyCount)
+	}
+
+	// Content change → rerun.
+	src.Set(db, "a", []byte("world!"))
+	before := db.Metrics()
+	got := length.Get(db, "a")
+	after := db.Metrics().Sub(before)
+	if got != 6 {
+		t.Fatalf("len changed: got %d", got)
+	}
+	if bodyCount != 2 {
+		t.Fatalf("body should run again, got %d", bodyCount)
+	}
+	if after.Reruns != 1 {
+		t.Fatalf("expected 1 rerun, got %+v", after)
+	}
+}
+
+// ---- Early cutoff for derived queries ----
+
+func TestDerivedEarlyCutoff(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	// Mid-layer query: returns the length of its input.
+	lenBodyCount := 0
+	length := Register(db, "Length",
+		func(ctx *Ctx, key string) int {
+			lenBodyCount++
+			return len(src.Fetch(ctx, key))
+		},
+		hashInt,
+	)
+
+	// Downstream query: returns length times 10. If Length's output
+	// hash didn't change, this downstream body must NOT re-run.
+	mulBodyCount := 0
+	mul := Register(db, "Mul10",
+		func(ctx *Ctx, key string) int {
+			mulBodyCount++
+			return length.Fetch(ctx, key) * 10
+		},
+		hashInt,
+	)
+
+	src.Set(db, "a", []byte("abcde")) // length 5
+	if got := mul.Get(db, "a"); got != 50 {
+		t.Fatalf("want 50, got %d", got)
+	}
+	if lenBodyCount != 1 || mulBodyCount != 1 {
+		t.Fatalf("initial: len=%d mul=%d", lenBodyCount, mulBodyCount)
+	}
+
+	// Change input to a value with the SAME LENGTH. Length.fn will
+	// re-run but produce the same output 5 → same hash → cutoff.
+	// Mul10 depends on Length; its dep-walk sees Length's computedAt
+	// NOT advanced, so Mul10 stays cached and its body does not run.
+	before := db.Metrics()
+	src.Set(db, "a", []byte("vwxyz"))
+	if got := mul.Get(db, "a"); got != 50 {
+		t.Fatalf("same length, want 50, got %d", got)
+	}
+	after := db.Metrics().Sub(before)
+	if lenBodyCount != 2 {
+		t.Fatalf("Length body should re-run, got %d", lenBodyCount)
+	}
+	if mulBodyCount != 1 {
+		t.Fatalf("Mul10 body should be spared by cutoff, got %d", mulBodyCount)
+	}
+	if after.Cutoffs != 1 {
+		t.Fatalf("expected 1 cutoff, got %+v", after)
+	}
+
+	// Change input to different length. Length's hash changes.
+	// Mul10 must re-run.
+	src.Set(db, "a", []byte("longer string"))
+	if got := mul.Get(db, "a"); got != 130 {
+		t.Fatalf("want 130, got %d", got)
+	}
+	if lenBodyCount != 3 || mulBodyCount != 2 {
+		t.Fatalf("after diff-len change: len=%d mul=%d", lenBodyCount, mulBodyCount)
+	}
+}
+
+// ---- Transitive dep validation ----
+
+func TestTransitiveCacheHitWhenUnrelatedInputChanges(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	lenBody := 0
+	length := Register(db, "Length",
+		func(ctx *Ctx, key string) int {
+			lenBody++
+			return len(src.Fetch(ctx, key))
+		},
+		hashInt,
+	)
+
+	src.Set(db, "a", []byte("one"))
+	src.Set(db, "b", []byte("two2"))
+
+	_ = length.Get(db, "a")
+	_ = length.Get(db, "b")
+	if lenBody != 2 {
+		t.Fatalf("initial: body=%d", lenBody)
+	}
+
+	// Change only "a"; querying "b" should hit cache.
+	src.Set(db, "a", []byte("changed"))
+	before := db.Metrics()
+	_ = length.Get(db, "b")
+	after := db.Metrics().Sub(before)
+	if lenBody != 2 {
+		t.Fatalf("b's body should not re-run, got %d", lenBody)
+	}
+	// Cache hit: one hit for length("b"), plus one hit for
+	// src.Fetch("b") happens ONLY if body re-ran, which it didn't.
+	if after.Hits != 1 || after.Reruns != 0 {
+		t.Fatalf("b should be pure cache hit, got %+v", after)
+	}
+}
+
+// ---- Cycle detection ----
+
+func TestCycleDetection(t *testing.T) {
+	db := NewDatabase(nil, nil)
+
+	// Two mutually-recursive queries.
+	var a, b *Query[string, int]
+	a = Register(db, "A",
+		func(ctx *Ctx, key string) int {
+			return b.Fetch(ctx, key)
+		},
+		hashInt,
+	)
+	b = Register(db, "B",
+		func(ctx *Ctx, key string) int {
+			return a.Fetch(ctx, key)
+		},
+		hashInt,
+	)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected cycle panic")
+		}
+		err, ok := r.(*CycleError)
+		if !ok {
+			t.Fatalf("want *CycleError, got %T: %v", r, r)
+		}
+		if len(err.Chain) < 3 {
+			t.Fatalf("chain too short: %v", err.Chain)
+		}
+	}()
+	_ = a.Get(db, "x")
+}
+
+// ---- Dep tracking correctness ----
+
+func TestDepEdgesRecordedFromFetch(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	twoKeysBody := 0
+	sum := Register(db, "Sum",
+		func(ctx *Ctx, _ struct{}) int {
+			twoKeysBody++
+			a := src.Fetch(ctx, "a")
+			b := src.Fetch(ctx, "b")
+			return len(a) + len(b)
+		},
+		hashInt,
+	)
+
+	src.Set(db, "a", []byte("aa"))
+	src.Set(db, "b", []byte("bbb"))
+
+	if got := sum.Get(db, struct{}{}); got != 5 {
+		t.Fatalf("want 5, got %d", got)
+	}
+	if twoKeysBody != 1 {
+		t.Fatalf("initial body=%d", twoKeysBody)
+	}
+
+	// Change only "a" → Sum should re-run.
+	src.Set(db, "a", []byte("aaaa"))
+	if got := sum.Get(db, struct{}{}); got != 7 {
+		t.Fatalf("want 7, got %d", got)
+	}
+	if twoKeysBody != 2 {
+		t.Fatalf("after a-change body=%d", twoKeysBody)
+	}
+
+	// Change only "b" → Sum should re-run.
+	src.Set(db, "b", []byte("bbbbb"))
+	if got := sum.Get(db, struct{}{}); got != 9 {
+		t.Fatalf("want 9, got %d", got)
+	}
+	if twoKeysBody != 3 {
+		t.Fatalf("after b-change body=%d", twoKeysBody)
+	}
+
+	// No change → no re-run.
+	if got := sum.Get(db, struct{}{}); got != 9 {
+		t.Fatalf("cached: got %d", got)
+	}
+	if twoKeysBody != 3 {
+		t.Fatalf("cached body=%d", twoKeysBody)
+	}
+}
+
+// ---- Cutoff cascade across layers ----
+
+func TestCutoffCascadesAcrossMultipleLayers(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	aCount, bCount, cCount := 0, 0, 0
+	layerA := Register(db, "A",
+		func(ctx *Ctx, k string) int {
+			aCount++
+			return len(src.Fetch(ctx, k))
+		},
+		hashInt,
+	)
+	layerB := Register(db, "B",
+		func(ctx *Ctx, k string) int {
+			bCount++
+			return layerA.Fetch(ctx, k) + 1
+		},
+		hashInt,
+	)
+	layerC := Register(db, "C",
+		func(ctx *Ctx, k string) int {
+			cCount++
+			return layerB.Fetch(ctx, k) * 2
+		},
+		hashInt,
+	)
+
+	src.Set(db, "k", []byte("abc")) // A=3, B=4, C=8
+	if got := layerC.Get(db, "k"); got != 8 {
+		t.Fatalf("want 8, got %d", got)
+	}
+	if aCount != 1 || bCount != 1 || cCount != 1 {
+		t.Fatalf("initial: a=%d b=%d c=%d", aCount, bCount, cCount)
+	}
+
+	// Change input to same-length bytes. A re-runs, hash same, cutoff.
+	// B and C should not re-run their bodies.
+	src.Set(db, "k", []byte("xyz"))
+	if got := layerC.Get(db, "k"); got != 8 {
+		t.Fatalf("want 8, got %d", got)
+	}
+	if aCount != 2 {
+		t.Fatalf("A should re-run, got %d", aCount)
+	}
+	if bCount != 1 {
+		t.Fatalf("B should be cut off, got %d", bCount)
+	}
+	if cCount != 1 {
+		t.Fatalf("C should be cut off (transitively), got %d", cCount)
+	}
+}
+
+// ---- Input.Has ----
+
+func TestInputHas(t *testing.T) {
+	db := NewDatabase(nil, nil)
+	src := RegisterInput[string, []byte](db, "Src", hashBytes)
+
+	if src.Has(db, "x") {
+		t.Fatal("unset key should not Has")
+	}
+	src.Set(db, "x", []byte("v"))
+	if !src.Has(db, "x") {
+		t.Fatal("set key should Has")
+	}
+	src.Clear(db, "x")
+	if src.Has(db, "x") {
+		t.Fatal("cleared key should not Has")
+	}
+}
+
+// ---- Metrics sanity ----
+
+func TestMetricsSubtraction(t *testing.T) {
+	a := MetricsSnapshot{Hits: 10, Misses: 5, Reruns: 2, Cutoffs: 1, InputSet: 8}
+	b := MetricsSnapshot{Hits: 3, Misses: 1, Reruns: 0, Cutoffs: 0, InputSet: 2}
+	d := a.Sub(b)
+	if d != (MetricsSnapshot{Hits: 7, Misses: 4, Reruns: 2, Cutoffs: 1, InputSet: 6}) {
+		t.Fatalf("sub: %+v", d)
+	}
+}

--- a/internal/query/metrics.go
+++ b/internal/query/metrics.go
@@ -1,0 +1,49 @@
+package query
+
+import "sync/atomic"
+
+// Metrics is the Database-wide counter set tracked across all
+// [Query.Get] and [Input.Set] calls. Counters are monotonic and
+// thread-safe. The expected use is assertive: tests snapshot before a
+// scripted sequence and after, then compare the delta against the
+// expected cache effect ("this edit should cause exactly one rerun
+// and N-1 validations").
+type Metrics struct {
+	hits     atomic.Uint64 // cached value returned without re-running
+	misses   atomic.Uint64 // slot absent, executed fresh
+	reruns   atomic.Uint64 // slot present but stale, re-executed with value change
+	cutoffs  atomic.Uint64 // re-executed but output hash unchanged — downstream spared
+	inputSet atomic.Uint64 // Input.Set calls that actually bumped the revision
+}
+
+// MetricsSnapshot is a point-in-time copy of the counters.
+type MetricsSnapshot struct {
+	Hits     uint64
+	Misses   uint64
+	Reruns   uint64
+	Cutoffs  uint64
+	InputSet uint64
+}
+
+// Snapshot copies all counters atomically-per-field. Field-level
+// tearing is harmless (tests compare deltas, not absolute totals).
+func (m *Metrics) Snapshot() MetricsSnapshot {
+	return MetricsSnapshot{
+		Hits:     m.hits.Load(),
+		Misses:   m.misses.Load(),
+		Reruns:   m.reruns.Load(),
+		Cutoffs:  m.cutoffs.Load(),
+		InputSet: m.inputSet.Load(),
+	}
+}
+
+// Sub returns the counter delta between two snapshots.
+func (a MetricsSnapshot) Sub(b MetricsSnapshot) MetricsSnapshot {
+	return MetricsSnapshot{
+		Hits:     a.Hits - b.Hits,
+		Misses:   a.Misses - b.Misses,
+		Reruns:   a.Reruns - b.Reruns,
+		Cutoffs:  a.Cutoffs - b.Cutoffs,
+		InputSet: a.InputSet - b.InputSet,
+	}
+}

--- a/internal/query/osty/db.go
+++ b/internal/query/osty/db.go
@@ -1,0 +1,51 @@
+package osty
+
+import (
+	"github.com/osty/osty/internal/query"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// Engine bundles the Database, input handles, and registered query
+// handles into one struct. Construct with [NewEngine]; the Engine is
+// safe to store on long-lived server/CLI state.
+//
+// Typical usage:
+//
+//	eng := osty.NewEngine()
+//	defer eng.Close()
+//	eng.Inputs.SourceText.Set(eng.DB, "/abs/path/main.osty", srcBytes)
+//	diags := eng.Queries.FileDiagnostics.Get(eng.DB, "/abs/path/main.osty")
+//
+// All path keys must be normalized via [NormalizePath] or [FromURI].
+type Engine struct {
+	DB      *query.Database
+	Inputs  Inputs
+	Queries Queries
+}
+
+// NewEngine constructs an Engine seeded with the process-singleton
+// prelude and stdlib registry. The returned Engine is ready to accept
+// input [Inputs.SourceText.Set] calls and serve derived queries via
+// [Queries].
+func NewEngine() *Engine {
+	return newEngineWith(resolve.NewPrelude(), stdlib.LoadCached())
+}
+
+// NewEngineForTest constructs an Engine with custom prelude and stdlib,
+// typically used by test harnesses that want a fresh prelude per test
+// or want to simulate "no stdlib" environments.
+func NewEngineForTest(prelude *resolve.Scope, reg *stdlib.Registry) *Engine {
+	return newEngineWith(prelude, reg)
+}
+
+func newEngineWith(prelude *resolve.Scope, reg *stdlib.Registry) *Engine {
+	db := query.NewDatabase(prelude, reg)
+	inp := registerInputs(db)
+	qs := registerQueries(db, inp)
+	return &Engine{DB: db, Inputs: inp, Queries: qs}
+}
+
+// Close is reserved for future cleanup hooks (e.g. releasing cached
+// slots on shutdown). Currently a no-op; calling it is always safe.
+func (e *Engine) Close() {}

--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -1,0 +1,654 @@
+package osty
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"hash"
+	"sort"
+	"sync"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/token"
+	"github.com/osty/osty/internal/types"
+)
+
+// stableHasher is a thin wrapper around sha256 that exposes a handful
+// of length-prefixed write methods. Every variable-length field is
+// prefixed with its length so concatenating unrelated fields can't
+// collide.
+//
+// Hashers are pooled via hasherPool because every query execution
+// allocates one and the cascade fires several per keystroke; pooling
+// keeps the hot path off the heap.
+type stableHasher struct{ h hash.Hash }
+
+var hasherPool = sync.Pool{
+	New: func() any { return &stableHasher{h: sha256.New()} },
+}
+
+func newHasher() *stableHasher {
+	s := hasherPool.Get().(*stableHasher)
+	s.h.Reset()
+	return s
+}
+
+
+// sum returns the accumulated hash and returns the hasher to the
+// pool. Callers use this once per top-level hashFn (and once per
+// intermediate hash in helpers like the SymTypes symbol-hashing
+// inner loop) to avoid heap allocation on the analyze hot path.
+func (s *stableHasher) sum() [32]byte {
+	var out [32]byte
+	s.h.Sum(out[:0])
+	hasherPool.Put(s)
+	return out
+}
+
+func (s *stableHasher) byte(b byte) { s.h.Write([]byte{b}) }
+
+func (s *stableHasher) u32(n uint32) {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], n)
+	s.h.Write(buf[:])
+}
+
+func (s *stableHasher) u64(n uint64) {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], n)
+	s.h.Write(buf[:])
+}
+
+func (s *stableHasher) str(v string) {
+	s.u32(uint32(len(v)))
+	s.h.Write([]byte(v))
+}
+
+func (s *stableHasher) bytes(v []byte) {
+	s.u32(uint32(len(v)))
+	s.h.Write(v)
+}
+
+func (s *stableHasher) bool(v bool) {
+	if v {
+		s.byte(1)
+	} else {
+		s.byte(0)
+	}
+}
+
+func (s *stableHasher) pos(p token.Pos) {
+	s.u32(uint32(p.Offset))
+	s.u32(uint32(p.Line))
+	s.u32(uint32(p.Column))
+}
+
+// ---- Parse ----
+
+// hashParseResult fingerprints a [ParseResult]. Because Parse is a
+// pure function of [SourceText] and Parse only re-runs when SourceText
+// bumped (which implies a source byte difference), the natural hash
+// is the source bytes themselves — any byte-level diff produces a new
+// Parse hash and dependents must not cut off. Downstream queries
+// (Resolve, Check) gain the benefit of cutoff because THEIR hashes
+// ignore parse-only differences like whitespace/comments that don't
+// alter resolver or checker output.
+func hashParseResult(r ParseResult) [32]byte {
+	h := newHasher()
+	h.bytes(r.Source)
+	h.u32(uint32(len(r.Diags)))
+	for _, d := range r.Diags {
+		hashDiagnostic(h, d)
+	}
+	return h.sum()
+}
+
+// ---- Diagnostics ----
+
+func hashDiagnostic(h *stableHasher, d *diag.Diagnostic) {
+	if d == nil {
+		h.byte(0)
+		return
+	}
+	h.byte(1)
+	h.byte(byte(d.Severity))
+	h.str(d.Code)
+	h.str(d.Message)
+	h.u32(uint32(len(d.Spans)))
+	for _, sp := range d.Spans {
+		h.pos(sp.Span.Start)
+		h.pos(sp.Span.End)
+		h.str(sp.Label)
+		h.bool(sp.Primary)
+	}
+	h.u32(uint32(len(d.Notes)))
+	for _, n := range d.Notes {
+		h.str(n)
+	}
+	h.str(d.Hint)
+	h.u32(uint32(len(d.Suggestions)))
+	for _, sg := range d.Suggestions {
+		hashSuggestion(h, sg)
+	}
+}
+
+func hashSuggestion(h *stableHasher, s diag.Suggestion) {
+	h.str(s.Label)
+	h.str(s.Replacement)
+	h.pos(s.Span.Start)
+	h.pos(s.Span.End)
+	if s.CopyFrom != nil {
+		h.byte(1)
+		h.pos(s.CopyFrom.Start)
+		h.pos(s.CopyFrom.End)
+	} else {
+		h.byte(0)
+	}
+	h.bool(s.MachineApplicable)
+}
+
+func hashDiagsList(h *stableHasher, ds []*diag.Diagnostic) {
+	// Stable sort by (primary-span-offset, code, message). The
+	// resolver and checker typically produce diagnostics in source
+	// order already, but we sort defensively so hash equality is
+	// insensitive to emission order in case that changes.
+	sorted := make([]*diag.Diagnostic, len(ds))
+	copy(sorted, ds)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		ap := primarySpanOffset(a)
+		bp := primarySpanOffset(b)
+		if ap != bp {
+			return ap < bp
+		}
+		if a.Code != b.Code {
+			return a.Code < b.Code
+		}
+		return a.Message < b.Message
+	})
+	h.u32(uint32(len(sorted)))
+	for _, d := range sorted {
+		hashDiagnostic(h, d)
+	}
+}
+
+func primarySpanOffset(d *diag.Diagnostic) int {
+	if d == nil {
+		return -1
+	}
+	for _, s := range d.Spans {
+		if s.Primary {
+			return s.Span.Start.Offset
+		}
+	}
+	if len(d.Spans) > 0 {
+		return d.Spans[0].Span.Start.Offset
+	}
+	return -1
+}
+
+// ---- Symbols ----
+
+// hashSymbol serializes a resolver symbol by its semantic identity —
+// name, kind, declaration position, visibility, package origin. This
+// is crucial for resolver early cutoff: two ResolvePackage runs over
+// equivalent source produce fresh *Symbol pointers but identical
+// semantic tuples.
+func hashSymbol(h *stableHasher, s *resolve.Symbol) {
+	if s == nil {
+		h.byte(0)
+		return
+	}
+	h.byte(1)
+	h.str(s.Name)
+	h.byte(byte(s.Kind))
+	h.pos(s.Pos)
+	h.bool(s.Pub)
+	if s.Package != nil {
+		h.byte(1)
+		h.str(s.Package.Dir)
+	} else {
+		h.byte(0)
+	}
+	// Decl's concrete type is 1-to-1 with Symbol.Kind (SymFn↔FnDecl,
+	// SymStruct↔StructDecl, ...), so hashing Decl's type tag would be
+	// redundant with the Kind byte above. A nil-vs-set distinction
+	// is the only extra signal worth preserving: builtins have
+	// Decl == nil.
+	if s.Decl == nil {
+		h.byte(0)
+	} else {
+		h.byte(1)
+	}
+}
+
+// ---- Types ----
+
+// hashType serializes a semantic type by structure. The generic
+// parameter TypeVar references its declaring Symbol by the same
+// symbol-hash used above; Named types include both the declaring
+// symbol and the recursive argument types.
+func hashType(h *stableHasher, t types.Type) {
+	if t == nil {
+		h.byte(0)
+		return
+	}
+	switch tt := t.(type) {
+	case *types.Primitive:
+		h.byte(1)
+		h.byte(byte(tt.Kind))
+	case *types.Untyped:
+		h.byte(2)
+		h.byte(byte(tt.Kind))
+	case *types.Tuple:
+		h.byte(3)
+		h.u32(uint32(len(tt.Elems)))
+		for _, e := range tt.Elems {
+			hashType(h, e)
+		}
+	case *types.Optional:
+		h.byte(4)
+		hashType(h, tt.Inner)
+	case *types.FnType:
+		h.byte(5)
+		h.u32(uint32(len(tt.Params)))
+		for _, p := range tt.Params {
+			hashType(h, p)
+		}
+		hashType(h, tt.Return)
+	case *types.Named:
+		h.byte(6)
+		hashSymbol(h, tt.Sym)
+		h.u32(uint32(len(tt.Args)))
+		for _, a := range tt.Args {
+			hashType(h, a)
+		}
+	case *types.TypeVar:
+		h.byte(7)
+		hashSymbol(h, tt.Sym)
+		h.u32(uint32(len(tt.Bounds)))
+		for _, b := range tt.Bounds {
+			hashType(h, b)
+		}
+	case *types.Builder:
+		h.byte(8)
+		hashType(h, tt.Struct)
+		// Set membership: emit sorted names so permutation doesn't
+		// affect the hash.
+		names := make([]string, 0, len(tt.Set))
+		for n := range tt.Set {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		h.u32(uint32(len(names)))
+		for _, n := range names {
+			h.str(n)
+		}
+		h.bool(tt.Preloaded)
+	case *types.Error:
+		h.byte(9)
+	default:
+		// Unknown kind: fall back to a stable tag so we at least don't
+		// panic. Downstream cutoff loses precision for this case, but
+		// correctness is preserved.
+		h.byte(255)
+	}
+}
+
+// ---- ResolvePackage ----
+
+// hashResolvedPackage fingerprints the ResolvedPackage view. Captures
+// every Refs/TypeRefs entry (sorted by head token offset), the
+// package scope's exported symbols, and the diag list.
+func hashResolvedPackage(rp *ResolvedPackage) [32]byte {
+	h := newHasher()
+	if rp == nil || rp.pkg == nil {
+		return h.sum()
+	}
+	h.str(rp.pkg.Dir)
+	h.str(rp.pkg.Name)
+
+	// Files are already in lexicographic order by Path, but sort
+	// defensively.
+	files := make([]*resolve.PackageFile, len(rp.pkg.Files))
+	copy(files, rp.pkg.Files)
+	sort.SliceStable(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	h.u32(uint32(len(files)))
+	for _, pf := range files {
+		h.str(pf.Path)
+		hashFileRefs(h, pf)
+		h.u32(uint32(len(pf.ParseDiags)))
+		for _, d := range pf.ParseDiags {
+			hashDiagnostic(h, d)
+		}
+	}
+
+	// Top-level declarations across all files. This captures
+	// "package added/removed a top-level symbol" cases where no
+	// existing reference changed but a new name became visible to
+	// importers.
+	hashPkgTopLevelDecls(h, rp.pkg)
+
+	if rp.res != nil {
+		hashDiagsList(h, rp.res.Diags)
+	}
+	return h.sum()
+}
+
+// hashFileRefs captures the per-file resolve output. Refs and TypeRefs
+// are sorted by ident position; each entry is (offset, name, symbol).
+func hashFileRefs(h *stableHasher, pf *resolve.PackageFile) {
+	// Refs
+	type refEntry struct {
+		off  int
+		name string
+		sym  *resolve.Symbol
+	}
+	refs := make([]refEntry, 0, len(pf.Refs))
+	for id, sym := range pf.Refs {
+		refs = append(refs, refEntry{off: id.Pos().Offset, name: id.Name, sym: sym})
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].off != refs[j].off {
+			return refs[i].off < refs[j].off
+		}
+		return refs[i].name < refs[j].name
+	})
+	h.u32(uint32(len(refs)))
+	for _, r := range refs {
+		h.u32(uint32(r.off))
+		h.str(r.name)
+		hashSymbol(h, r.sym)
+	}
+
+	// TypeRefs
+	type typeRefEntry struct {
+		off int
+		sym *resolve.Symbol
+	}
+	tr := make([]typeRefEntry, 0, len(pf.TypeRefs))
+	for nt, sym := range pf.TypeRefs {
+		tr = append(tr, typeRefEntry{off: nt.Pos().Offset, sym: sym})
+	}
+	sort.Slice(tr, func(i, j int) bool { return tr[i].off < tr[j].off })
+	h.u32(uint32(len(tr)))
+	for _, r := range tr {
+		h.u32(uint32(r.off))
+		hashSymbol(h, r.sym)
+	}
+}
+
+// hashPkgTopLevelDecls walks every top-level declaration across all
+// files in pkg and emits (path, offset, kind, name) for each.
+// Captures the "added a top-level symbol" case that per-file Refs
+// can't see when no existing reference changed.
+//
+// We hash the AST's declarations rather than PkgScope because
+// resolve.Scope's internal name map is unexported and the declaration
+// list is sufficient: every top-level symbol in PkgScope was installed
+// from exactly one of these Decl nodes during declarePass.
+func hashPkgTopLevelDecls(h *stableHasher, pkg *resolve.Package) {
+	if pkg == nil {
+		h.u32(0)
+		return
+	}
+	type entry struct {
+		path string
+		off  int
+		kind string
+		name string
+		pub  bool
+	}
+	var entries []entry
+	for _, pf := range pkg.Files {
+		if pf == nil || pf.File == nil {
+			continue
+		}
+		for _, d := range pf.File.Decls {
+			if d == nil {
+				continue
+			}
+			name, kind, pub := declIdentity(d)
+			entries = append(entries, entry{
+				path: pf.Path,
+				off:  d.Pos().Offset,
+				kind: kind,
+				name: name,
+				pub:  pub,
+			})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].path != entries[j].path {
+			return entries[i].path < entries[j].path
+		}
+		return entries[i].off < entries[j].off
+	})
+	h.u32(uint32(len(entries)))
+	for _, e := range entries {
+		h.str(e.path)
+		h.u32(uint32(e.off))
+		h.str(e.kind)
+		h.str(e.name)
+		h.bool(e.pub)
+	}
+}
+
+// declIdentity projects an AST declaration onto its semantically
+// relevant surface: the name, kind tag, and pub flag. This is what
+// PkgScope captures after declarePass.
+func declIdentity(d ast.Decl) (name, kind string, pub bool) {
+	switch dd := d.(type) {
+	case *ast.FnDecl:
+		return dd.Name, "fn", dd.Pub
+	case *ast.StructDecl:
+		return dd.Name, "struct", dd.Pub
+	case *ast.EnumDecl:
+		return dd.Name, "enum", dd.Pub
+	case *ast.InterfaceDecl:
+		return dd.Name, "iface", dd.Pub
+	case *ast.TypeAliasDecl:
+		return dd.Name, "alias", dd.Pub
+	case *ast.LetDecl:
+		return dd.Name, "let", dd.Pub
+	case *ast.UseDecl:
+		if dd.Alias != "" {
+			return dd.Alias, "use", false
+		}
+		if len(dd.Path) > 0 {
+			return dd.Path[len(dd.Path)-1], "use", false
+		}
+		return "", "use", false
+	}
+	return "", "node", false
+}
+
+// ---- ResolveFile ----
+
+// hashResolveFileResult fingerprints the per-file slice.
+func hashResolveFileResult(r *resolve.Result) [32]byte {
+	h := newHasher()
+	if r == nil {
+		return h.sum()
+	}
+	// Build an ephemeral PackageFile-like shape so we can reuse the
+	// file ref hashing.
+	pf := &resolve.PackageFile{Refs: r.Refs, TypeRefs: r.TypeRefs}
+	hashFileRefs(h, pf)
+	hashDiagsList(h, r.Diags)
+	return h.sum()
+}
+
+// ---- CheckResult ----
+
+// hashCheckResult fingerprints a check result. Because the underlying
+// maps are keyed by AST pointers (unstable across re-parses), we
+// project each entry onto a (position, type-hash) pair before sorting.
+func hashCheckResult(r *check.Result) [32]byte {
+	h := newHasher()
+	if r == nil {
+		return h.sum()
+	}
+	// Types: map[ast.Expr]types.Type
+	type typeEntry struct {
+		off int
+		t   types.Type
+	}
+	tEntries := make([]typeEntry, 0, len(r.Types))
+	for expr, t := range r.Types {
+		if expr == nil {
+			continue
+		}
+		tEntries = append(tEntries, typeEntry{off: expr.Pos().Offset, t: t})
+	}
+	sort.Slice(tEntries, func(i, j int) bool { return tEntries[i].off < tEntries[j].off })
+	h.u32(uint32(len(tEntries)))
+	for _, e := range tEntries {
+		h.u32(uint32(e.off))
+		hashType(h, e.t)
+	}
+
+	// LetTypes: map[ast.Node]types.Type
+	lEntries := make([]typeEntry, 0, len(r.LetTypes))
+	for node, t := range r.LetTypes {
+		if node == nil {
+			continue
+		}
+		lEntries = append(lEntries, typeEntry{off: node.Pos().Offset, t: t})
+	}
+	sort.Slice(lEntries, func(i, j int) bool { return lEntries[i].off < lEntries[j].off })
+	h.u32(uint32(len(lEntries)))
+	for _, e := range lEntries {
+		h.u32(uint32(e.off))
+		hashType(h, e.t)
+	}
+
+	// SymTypes: map[*Symbol]types.Type — sort by symbol hash.
+	type symEntry struct {
+		sh [32]byte
+		t  types.Type
+	}
+	sEntries := make([]symEntry, 0, len(r.SymTypes))
+	for sym, t := range r.SymTypes {
+		ph := newHasher()
+		hashSymbol(ph, sym)
+		sEntries = append(sEntries, symEntry{sh: ph.sum(), t: t})
+	}
+	sort.Slice(sEntries, func(i, j int) bool {
+		return bytes.Compare(sEntries[i].sh[:], sEntries[j].sh[:]) < 0
+	})
+	h.u32(uint32(len(sEntries)))
+	for _, e := range sEntries {
+		h.h.Write(e.sh[:])
+		hashType(h, e.t)
+	}
+
+	// Instantiations: map[*ast.CallExpr][]types.Type
+	type instEntry struct {
+		off  int
+		args []types.Type
+	}
+	iEntries := make([]instEntry, 0, len(r.Instantiations))
+	for call, args := range r.Instantiations {
+		if call == nil {
+			continue
+		}
+		iEntries = append(iEntries, instEntry{off: call.Pos().Offset, args: args})
+	}
+	sort.Slice(iEntries, func(i, j int) bool { return iEntries[i].off < iEntries[j].off })
+	h.u32(uint32(len(iEntries)))
+	for _, e := range iEntries {
+		h.u32(uint32(e.off))
+		h.u32(uint32(len(e.args)))
+		for _, a := range e.args {
+			hashType(h, a)
+		}
+	}
+
+	// Diags
+	hashDiagsList(h, r.Diags)
+	return h.sum()
+}
+
+// ---- Lint, IdentIndex, FileDiagnostics ----
+
+func hashLintResult(r *lint.Result) [32]byte {
+	h := newHasher()
+	if r == nil {
+		return h.sum()
+	}
+	hashDiagsList(h, r.Diags)
+	return h.sum()
+}
+
+func hashDiagList(ds []*diag.Diagnostic) [32]byte {
+	h := newHasher()
+	hashDiagsList(h, ds)
+	return h.sum()
+}
+
+func hashIdentIndex(m map[int]*resolve.Symbol) [32]byte {
+	h := newHasher()
+	keys := make([]int, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	h.u32(uint32(len(keys)))
+	for _, k := range keys {
+		h.u32(uint32(k))
+		hashSymbol(h, m[k])
+	}
+	return h.sum()
+}
+
+// ---- Workspace check map ----
+
+func hashCheckWorkspaceMap(m map[string]*check.Result) [32]byte {
+	h := newHasher()
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h.u32(uint32(len(keys)))
+	for _, k := range keys {
+		h.str(k)
+		sub := hashCheckResult(m[k])
+		h.h.Write(sub[:])
+	}
+	return h.sum()
+}
+
+// ---- Input hashers ----
+
+func hashBytesInput(b []byte) [32]byte { return sha256.Sum256(b) }
+
+func hashStringSlice(ss []string) [32]byte {
+	// Fast path for the single-file case — single-file LSP analyze
+	// hits this on every keystroke with a one-element slice.
+	if len(ss) <= 1 {
+		h := newHasher()
+		h.u32(uint32(len(ss)))
+		if len(ss) == 1 {
+			h.str(ss[0])
+		}
+		return h.sum()
+	}
+	h := newHasher()
+	sorted := make([]string, len(ss))
+	copy(sorted, ss)
+	sort.Strings(sorted)
+	h.u32(uint32(len(sorted)))
+	for _, s := range sorted {
+		h.str(s)
+	}
+	return h.sum()
+}
+

--- a/internal/query/osty/inputs.go
+++ b/internal/query/osty/inputs.go
@@ -1,0 +1,44 @@
+package osty
+
+import (
+	"github.com/osty/osty/internal/query"
+)
+
+// Inputs groups the three primitive input handles that drive the
+// entire Osty query graph. Callers (LSP, CLI) use these to push the
+// current world state into the Database; every derived query reads
+// from them transitively.
+//
+// Key discipline: all path-shaped keys must be normalized via
+// [NormalizePath] (and for LSP URIs, via [FromURI]). Mixing raw and
+// normalized forms will produce duplicate slots.
+type Inputs struct {
+	// SourceText maps a normalized file path to the current raw UTF-8
+	// source bytes. The LSP's `didChange` handler pushes the new
+	// buffer here; CLI entry points read files from disk and push
+	// once at startup. Setting bytes that hash-equal the existing
+	// value is a no-op — no revision bump, no downstream invalidation.
+	SourceText *query.Input[string, []byte]
+
+	// PackageFiles maps a normalized package directory to the list of
+	// .osty source files belonging to the package. Kept as a separate
+	// input (rather than recomputed from the filesystem inside a
+	// query) so the LSP and CLI can control when disk is scanned.
+	// Unsaved files should appear in this list only if they belong
+	// to the package by path convention.
+	PackageFiles *query.Input[string, []string]
+
+	// WorkspaceMembers lists every package directory in the current
+	// workspace. Keyed by struct{} so there is exactly one slot.
+	// CLI entry points populate this from the osty.toml manifest;
+	// the LSP populates it by discovering the workspace root on open.
+	WorkspaceMembers *query.Input[struct{}, []string]
+}
+
+func registerInputs(db *query.Database) Inputs {
+	return Inputs{
+		SourceText:       query.RegisterInput[string, []byte](db, "SourceText", hashBytesInput),
+		PackageFiles:     query.RegisterInput[string, []string](db, "PackageFiles", hashStringSlice),
+		WorkspaceMembers: query.RegisterInput[struct{}, []string](db, "WorkspaceMembers", hashStringSlice),
+	}
+}

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -1,0 +1,342 @@
+package osty
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/query"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// ---- Value types ----
+
+// ParseResult is the output of the [Parse] query — the AST plus any
+// lexer/parser diagnostics. The Source field holds the bytes the
+// parser consumed, enabling diagnostic rendering without re-reading
+// the file.
+type ParseResult struct {
+	Source []byte
+	File   *ast.File
+	Diags  []*diag.Diagnostic
+}
+
+// ResolvedPackage is an immutable view over a resolved package. Once
+// returned from [Queries.ResolvePackage] the pointer must not be
+// mutated by the caller; the Database holds it verbatim.
+type ResolvedPackage struct {
+	pkg *resolve.Package
+	res *resolve.PackageResult
+}
+
+// Package returns the underlying resolve.Package. Callers must treat
+// the returned pointer as read-only.
+func (rp *ResolvedPackage) Package() *resolve.Package { return rp.pkg }
+
+// PackageResult returns the resolver's summary output (package scope
+// and diagnostics). Read-only.
+func (rp *ResolvedPackage) PackageResult() *resolve.PackageResult { return rp.res }
+
+// FileResult produces a per-file resolve.Result slice for the given
+// path. Returns nil if the path does not belong to this package.
+func (rp *ResolvedPackage) FileResult(path string) *resolve.Result {
+	if rp == nil || rp.pkg == nil {
+		return nil
+	}
+	norm := NormalizePath(path)
+	for _, pf := range rp.pkg.Files {
+		if NormalizePath(pf.Path) != norm {
+			continue
+		}
+		return &resolve.Result{
+			Refs:      pf.Refs,
+			TypeRefs:  pf.TypeRefs,
+			FileScope: pf.FileScope,
+			Diags:     rp.res.Diags,
+		}
+	}
+	return nil
+}
+
+// ---- Queries struct ----
+
+// Queries groups the derived query handles. Constructed once by
+// [NewEngine] and reused for the Database's lifetime.
+type Queries struct {
+	// Parse: (path) -> parsed AST + diagnostics.
+	// Depends on: SourceText(path).
+	Parse *query.Query[string, ParseResult]
+
+	// BuildPackage: (dir) -> fresh *resolve.Package with PackageFiles
+	// assembled from Parse'd contents. Not directly useful to
+	// callers; exists so ResolvePackage can rebuild cleanly on each
+	// run without retaining a pointer that the resolver has mutated.
+	// Depends on: PackageFiles(dir), Parse(f) for each f.
+	BuildPackage *query.Query[string, *resolve.Package]
+
+	// ResolvePackage: (dir) -> resolved view of the package. Runs the
+	// resolver over BuildPackage's fresh Package. The returned
+	// ResolvedPackage is immutable.
+	// Depends on: BuildPackage(dir).
+	ResolvePackage *query.Query[string, *ResolvedPackage]
+
+	// ResolveFile: (path) -> per-file resolve.Result sliced out of
+	// ResolvePackage. Convenience for file-centric callers.
+	// Depends on: ResolvePackage(packageDirOf(path)).
+	ResolveFile *query.Query[string, *resolve.Result]
+
+	// CheckPackage: (dir) -> type-check result for the whole package.
+	// Depends on: ResolvePackage(dir).
+	CheckPackage *query.Query[string, *check.Result]
+
+	// CheckFile: (path) -> type-check result covering the file. In
+	// package mode this shares maps with CheckPackage for that dir.
+	// Depends on: CheckPackage(packageDirOf(path)).
+	CheckFile *query.Query[string, *check.Result]
+
+	// LintFile: (path) -> lint diagnostics for one file.
+	// Depends on: Parse(path), ResolveFile(path), CheckFile(path).
+	LintFile *query.Query[string, *lint.Result]
+
+	// IdentIndex: (path) -> offset → resolver Symbol. Used by LSP
+	// hover / completion for O(1) position lookup.
+	// Depends on: ResolveFile(path).
+	IdentIndex *query.Query[string, map[int]*resolve.Symbol]
+
+	// FileDiagnostics: (path) -> unified diagnostic list for the
+	// file, aggregating parse, resolve (per-file), check (per-file),
+	// and lint results. This is the one query LSP's publishDiagnostics
+	// ultimately needs.
+	// Depends on: Parse(path), ResolveFile(path), CheckFile(path),
+	// LintFile(path).
+	FileDiagnostics *query.Query[string, []*diag.Diagnostic]
+}
+
+func registerQueries(db *query.Database, inp Inputs) Queries {
+	var qs Queries
+
+	qs.Parse = query.Register(db, "Parse",
+		func(ctx *query.Ctx, path string) ParseResult {
+			src := inp.SourceText.Fetch(ctx, path)
+			file, diags := parser.ParseDiagnostics(src)
+			return ParseResult{Source: src, File: file, Diags: diags}
+		},
+		hashParseResult,
+	)
+
+	// BuildPackage has no hashFn: its output carries fresh
+	// *resolve.Package + *ast.File pointers every run and cannot be
+	// content-compared cheaply. Downstream ResolvePackage supplies
+	// the real cutoff via its semantic output hash, so BuildPackage
+	// just bumps computedAt on every rerun.
+	qs.BuildPackage = query.Register(db, "BuildPackage",
+		func(ctx *query.Ctx, dir string) *resolve.Package {
+			files := inp.PackageFiles.Fetch(ctx, dir)
+			pkg := &resolve.Package{
+				Dir:   dir,
+				Name:  packageNameFromDir(dir),
+				Files: make([]*resolve.PackageFile, 0, len(files)),
+			}
+			for _, f := range files {
+				pr := qs.Parse.Fetch(ctx, f)
+				pkg.Files = append(pkg.Files, &resolve.PackageFile{
+					Path:       f,
+					Source:     pr.Source,
+					File:       pr.File,
+					ParseDiags: pr.Diags,
+				})
+			}
+			return pkg
+		},
+		nil,
+	)
+
+	qs.ResolvePackage = query.Register(db, "ResolvePackage",
+		func(ctx *query.Ctx, dir string) *ResolvedPackage {
+			built := qs.BuildPackage.Fetch(ctx, dir)
+			// Allocate a brand-new Package with copied PackageFile
+			// entries so resolve.ResolvePackage's in-place mutation
+			// doesn't corrupt the BuildPackage cache. We reuse the
+			// already-parsed *ast.File pointers — they are read-only.
+			pkg := &resolve.Package{
+				Dir:   built.Dir,
+				Name:  built.Name,
+				Files: make([]*resolve.PackageFile, len(built.Files)),
+			}
+			for i, pf := range built.Files {
+				pkg.Files[i] = &resolve.PackageFile{
+					Path:       pf.Path,
+					Source:     pf.Source,
+					File:       pf.File,
+					ParseDiags: pf.ParseDiags,
+				}
+			}
+			// Stdlib attachment requires an unexported resolve.Workspace
+			// field; until that's exposed, package-mode resolution
+			// matches the LSP's pre-query behavior (no auto std import).
+			res := resolve.ResolvePackage(pkg, ctx.Prelude())
+			return &ResolvedPackage{pkg: pkg, res: res}
+		},
+		hashResolvedPackage,
+	)
+
+	qs.ResolveFile = query.Register(db, "ResolveFile",
+		func(ctx *query.Ctx, path string) *resolve.Result {
+			dir := PackageDirOf(path)
+			rp := qs.ResolvePackage.Fetch(ctx, dir)
+			if rp == nil {
+				return &resolve.Result{}
+			}
+			r := rp.FileResult(path)
+			if r == nil {
+				return &resolve.Result{}
+			}
+			return r
+		},
+		hashResolveFileResult,
+	)
+
+	qs.CheckPackage = query.Register(db, "CheckPackage",
+		func(ctx *query.Ctx, dir string) *check.Result {
+			rp := qs.ResolvePackage.Fetch(ctx, dir)
+			if rp == nil || rp.pkg == nil {
+				return &check.Result{}
+			}
+			opts := check.Opts{Stdlib: resolveStdlibProvider(ctx)}
+			return check.Package(rp.pkg, rp.res, opts)
+		},
+		hashCheckResult,
+	)
+
+	qs.CheckFile = query.Register(db, "CheckFile",
+		func(ctx *query.Ctx, path string) *check.Result {
+			dir := PackageDirOf(path)
+			return qs.CheckPackage.Fetch(ctx, dir)
+		},
+		hashCheckResult,
+	)
+
+	qs.LintFile = query.Register(db, "LintFile",
+		func(ctx *query.Ctx, path string) *lint.Result {
+			pr := qs.Parse.Fetch(ctx, path)
+			if pr.File == nil {
+				return &lint.Result{}
+			}
+			rr := qs.ResolveFile.Fetch(ctx, path)
+			chk := qs.CheckFile.Fetch(ctx, path)
+			return lint.File(pr.File, rr, chk)
+		},
+		hashLintResult,
+	)
+
+	qs.IdentIndex = query.Register(db, "IdentIndex",
+		func(ctx *query.Ctx, path string) map[int]*resolve.Symbol {
+			rr := qs.ResolveFile.Fetch(ctx, path)
+			return buildIdentIndex(rr)
+		},
+		hashIdentIndex,
+	)
+
+	qs.FileDiagnostics = query.Register(db, "FileDiagnostics",
+		func(ctx *query.Ctx, path string) []*diag.Diagnostic {
+			pr := qs.Parse.Fetch(ctx, path)
+			rr := qs.ResolveFile.Fetch(ctx, path)
+			chk := qs.CheckFile.Fetch(ctx, path)
+			lr := qs.LintFile.Fetch(ctx, path)
+			return collectFileDiagnostics(path, pr, rr, chk, lr)
+		},
+		hashDiagList,
+	)
+
+	return qs
+}
+
+// ---- Helpers ----
+
+// packageNameFromDir returns a stable name for a package given its
+// directory. Uses the basename so the resolver's error messages have
+// something more meaningful than a full absolute path.
+func packageNameFromDir(dir string) string {
+	if dir == "" {
+		return "<pkg>"
+	}
+	for i := len(dir) - 1; i >= 0; i-- {
+		if dir[i] == '/' || dir[i] == '\\' {
+			if i == len(dir)-1 {
+				continue
+			}
+			return dir[i+1:]
+		}
+	}
+	return dir
+}
+
+// resolveStdlibProvider returns the stdlib provider suitable for
+// passing to check.Opts. Returns nil if the Database was constructed
+// without a stdlib registry.
+func resolveStdlibProvider(ctx *query.Ctx) resolve.StdlibProvider {
+	reg := ctx.Stdlib()
+	if reg == nil {
+		return nil
+	}
+	return reg
+}
+
+// buildIdentIndex inverts the resolve.Result's Refs and TypeRefs
+// maps into an offset → Symbol map. Mirrors the pre-query
+// implementation lifted from internal/lsp/server.go.
+func buildIdentIndex(r *resolve.Result) map[int]*resolve.Symbol {
+	if r == nil {
+		return map[int]*resolve.Symbol{}
+	}
+	out := make(map[int]*resolve.Symbol, len(r.Refs)+len(r.TypeRefs))
+	for id, sym := range r.Refs {
+		out[id.Pos().Offset] = sym
+	}
+	for nt, sym := range r.TypeRefs {
+		out[nt.Pos().Offset] = sym
+	}
+	return out
+}
+
+// collectFileDiagnostics merges every diagnostic produced by the
+// pipeline into one sorted list for the given file. Filtering by
+// path is necessary because the package-level resolve/check
+// diagnostics may cover multiple files.
+func collectFileDiagnostics(
+	path string,
+	pr ParseResult,
+	rr *resolve.Result,
+	chk *check.Result,
+	lr *lint.Result,
+) []*diag.Diagnostic {
+	norm := NormalizePath(path)
+	out := make([]*diag.Diagnostic, 0, len(pr.Diags)+len(rr.Diags)+len(chk.Diags)+len(lr.Diags))
+	appendFiltered := func(ds []*diag.Diagnostic) {
+		for _, d := range ds {
+			if d == nil {
+				continue
+			}
+			if !diagnosticBelongsTo(d, norm) {
+				continue
+			}
+			out = append(out, d)
+		}
+	}
+	// Parse diagnostics are always about the file that was parsed —
+	// no position-based filtering needed.
+	out = append(out, pr.Diags...)
+	appendFiltered(rr.Diags)
+	appendFiltered(chk.Diags)
+	appendFiltered(lr.Diags)
+	return out
+}
+
+// diagnosticBelongsTo is a placeholder for per-file filtering. Span
+// filtering by path can't be done until token.Pos carries a file
+// identifier; callers currently receive every diagnostic and sort by
+// position for rendering.
+func diagnosticBelongsTo(d *diag.Diagnostic, normalizedPath string) bool {
+	return d != nil
+}

--- a/internal/query/osty/queries_test.go
+++ b/internal/query/osty/queries_test.go
@@ -1,0 +1,202 @@
+package osty
+
+import (
+	"strings"
+	"testing"
+)
+
+// Helper: seed one "package" with one file for tests.
+func seedFile(eng *Engine, dir, name, src string) string {
+	path := NormalizePath(dir + "/" + name)
+	eng.Inputs.SourceText.Set(eng.DB, path, []byte(src))
+	eng.Inputs.PackageFiles.Set(eng.DB, NormalizePath(dir), []string{path})
+	return path
+}
+
+func TestParseMissThenHit(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	path := seedFile(eng, "/tmp/pkg", "main.osty", "pub fn main() { }")
+
+	before := eng.DB.Metrics()
+	pr := eng.Queries.Parse.Get(eng.DB, path)
+	if pr.File == nil {
+		t.Fatal("parse returned nil file")
+	}
+	after := eng.DB.Metrics().Sub(before)
+	if after.Misses == 0 {
+		t.Fatal("expected at least one miss on first parse")
+	}
+
+	// Second Get with same source: pure cache hit, no misses, no reruns.
+	before = eng.DB.Metrics()
+	pr2 := eng.Queries.Parse.Get(eng.DB, path)
+	after = eng.DB.Metrics().Sub(before)
+	if pr2.File == nil {
+		t.Fatal("second parse returned nil file")
+	}
+	if after.Misses != 0 || after.Reruns != 0 {
+		t.Fatalf("cached call should not miss/rerun, got %+v", after)
+	}
+	if after.Hits == 0 {
+		t.Fatalf("cached call should hit, got %+v", after)
+	}
+}
+
+func TestParseRerunsOnSourceChange(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	path := seedFile(eng, "/tmp/pkg2", "main.osty", "pub fn a() { }")
+
+	_ = eng.Queries.Parse.Get(eng.DB, path)
+
+	// Change source.
+	eng.Inputs.SourceText.Set(eng.DB, path, []byte("pub fn b() { }"))
+
+	before := eng.DB.Metrics()
+	_ = eng.Queries.Parse.Get(eng.DB, path)
+	after := eng.DB.Metrics().Sub(before)
+	if after.Reruns != 1 {
+		t.Fatalf("expected 1 rerun after source change, got %+v", after)
+	}
+}
+
+func TestResolveFileIndependentPaths(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	// Two independent packages. Editing one must not invalidate the
+	// other's resolve result.
+	pathA := seedFile(eng, "/tmp/pkg_a", "a.osty", "pub fn a() { }")
+	pathB := seedFile(eng, "/tmp/pkg_b", "b.osty", "pub fn b() { }")
+
+	_ = eng.Queries.ResolveFile.Get(eng.DB, pathA)
+	_ = eng.Queries.ResolveFile.Get(eng.DB, pathB)
+
+	// Change only A's source.
+	eng.Inputs.SourceText.Set(eng.DB, pathA, []byte("pub fn a2() { }"))
+
+	before := eng.DB.Metrics()
+	_ = eng.Queries.ResolveFile.Get(eng.DB, pathB)
+	after := eng.DB.Metrics().Sub(before)
+	if after.Reruns > 0 {
+		t.Fatalf("B should not rerun when A changes: %+v", after)
+	}
+	if after.Misses > 0 {
+		t.Fatalf("B should be fully cached: %+v", after)
+	}
+}
+
+func TestDiagnosticsChangeOnError(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	// Start with valid source.
+	path := seedFile(eng, "/tmp/pkg_err", "main.osty", "pub fn main() { }")
+	diags := eng.Queries.FileDiagnostics.Get(eng.DB, path)
+	validDiagCount := len(diags)
+
+	// Inject a parse error.
+	eng.Inputs.SourceText.Set(eng.DB, path, []byte("pub fn {"))
+	diags = eng.Queries.FileDiagnostics.Get(eng.DB, path)
+	if len(diags) <= validDiagCount {
+		t.Fatalf("expected new diagnostics after parse error; before=%d after=%d",
+			validDiagCount, len(diags))
+	}
+}
+
+// Whitespace-only edit: the AST shape may differ, the source bytes
+// differ, but the resolver's output should be structurally identical
+// (no symbol name / position changes). Verifies the early-cutoff
+// cascade path.
+func TestCutoffOnTrivialWhitespaceEdit(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+
+	// An unambiguous, single-symbol program. Adding a trailing
+	// newline is a byte-level diff but the top-level decl list and
+	// its offsets are identical.
+	path := seedFile(eng, "/tmp/pkg_ws", "main.osty", "pub fn a() { }\n")
+
+	// Prime the cache all the way to CheckFile.
+	_ = eng.Queries.CheckFile.Get(eng.DB, path)
+
+	// Add another trailing newline — bytes differ, but semantic
+	// content of the decl is unchanged.
+	eng.Inputs.SourceText.Set(eng.DB, path, []byte("pub fn a() { }\n\n"))
+
+	before := eng.DB.Metrics()
+	_ = eng.Queries.CheckFile.Get(eng.DB, path)
+	after := eng.DB.Metrics().Sub(before)
+
+	// Parse MUST re-run (bytes differ). ResolvePackage's semantic
+	// output is identical → its hash should match → downstream
+	// CheckPackage/CheckFile/LintFile stay cached via early cutoff.
+	if after.Reruns == 0 {
+		t.Fatal("expected at least Parse to re-run after whitespace change")
+	}
+	if after.Cutoffs == 0 {
+		t.Fatalf("expected early-cutoff to fire for whitespace-only edit, got %+v", after)
+	}
+	t.Logf("whitespace-edit metrics delta: %+v", after)
+}
+
+func TestIdentIndexUpdatesWithSymbols(t *testing.T) {
+	eng := NewEngine()
+	defer eng.Close()
+	path := seedFile(eng, "/tmp/pkg_ii", "main.osty", "pub fn foo() { }\npub fn bar() { }\n")
+
+	idx := eng.Queries.IdentIndex.Get(eng.DB, path)
+	if idx == nil {
+		t.Fatal("IdentIndex returned nil")
+	}
+
+	// Cached repeat.
+	before := eng.DB.Metrics()
+	idx2 := eng.Queries.IdentIndex.Get(eng.DB, path)
+	after := eng.DB.Metrics().Sub(before)
+	if after.Misses != 0 || after.Reruns != 0 {
+		t.Fatalf("second call should be cached: %+v", after)
+	}
+	if len(idx) != len(idx2) {
+		t.Fatalf("index differs across cached calls: %d vs %d", len(idx), len(idx2))
+	}
+}
+
+func TestNormalizePathIdempotent(t *testing.T) {
+	samples := []string{
+		"/abs/path/main.osty",
+		"relative/path.osty",
+		"./nested/../file.osty",
+	}
+	for _, s := range samples {
+		once := NormalizePath(s)
+		twice := NormalizePath(once)
+		if once != twice {
+			t.Errorf("NormalizePath not idempotent for %q: %q -> %q", s, once, twice)
+		}
+	}
+}
+
+func TestFromURI(t *testing.T) {
+	tests := []struct {
+		uri      string
+		wantOK   bool
+		wantPart string
+	}{
+		{"file:///c:/some/path/main.osty", true, "main.osty"},
+		{"file:///home/user/pkg/main.osty", true, "main.osty"},
+		{"untitled:Untitled-1", false, "untitled:"},
+	}
+	for _, tc := range tests {
+		got, ok := FromURI(tc.uri)
+		if ok != tc.wantOK {
+			t.Errorf("FromURI(%q).ok = %v, want %v", tc.uri, ok, tc.wantOK)
+		}
+		if !strings.Contains(got, tc.wantPart) {
+			t.Errorf("FromURI(%q) = %q, expected substring %q", tc.uri, got, tc.wantPart)
+		}
+	}
+}

--- a/internal/query/osty/uri.go
+++ b/internal/query/osty/uri.go
@@ -1,0 +1,69 @@
+// Package osty wires the Osty compiler pipeline into the generic
+// query engine in [github.com/osty/osty/internal/query]. Callers
+// (LSP, CLI) construct an [Engine], seed inputs (SourceText,
+// PackageFiles, WorkspaceMembers), and pull results via typed query
+// handles (Parse, ResolvePackage, CheckFile, FileDiagnostics, etc.).
+//
+// # Input seams
+//
+// The engine treats source bytes, the set of files in a package, and
+// the set of packages in a workspace as the three primitive inputs.
+// Everything downstream is a derived query whose identity is computed
+// from those inputs and the Prelude/Stdlib singletons baked into the
+// Database at construction.
+//
+// # Early cutoff
+//
+// Every derived query registers a content-based hash function. When a
+// re-run produces a value whose hash matches the previous cache, the
+// slot's computedAt is preserved and downstream dependents skip their
+// own re-runs. See hash.go for the serialisation rules.
+package osty
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// NormalizePath returns the canonical form used as the key for
+// [SourceText] and related path-keyed queries. Paths are made absolute
+// (when possible), slashes forward-normalised, and cleaned of "." /
+// ".." segments. Callers must pass NormalizePath output for every
+// Input.Set / Query.Get, so the Database sees one key per file.
+func NormalizePath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	return filepath.ToSlash(filepath.Clean(p))
+}
+
+// FromURI converts an LSP `file://` URI into the normalized path the
+// engine uses as its key. For non-file URIs (untitled/scratch buffers,
+// in-memory schemes) the URI is returned verbatim and ok reports
+// false; callers can still use the returned key but should be aware
+// that the key is not a filesystem path.
+func FromURI(uri string) (key string, ok bool) {
+	const prefix = "file://"
+	if !strings.HasPrefix(uri, prefix) {
+		return uri, false
+	}
+	p := strings.TrimPrefix(uri, prefix)
+	// On Windows the URI looks like file:///C:/path. Strip the leading
+	// slash so filepath.Abs does the right thing.
+	if len(p) >= 3 && p[0] == '/' && p[2] == ':' {
+		p = p[1:]
+	}
+	// Percent-decode the few characters LSP clients encode. We only
+	// handle the common cases (space, colon); callers sending exotic
+	// URIs should normalize on their side.
+	p = strings.ReplaceAll(p, "%20", " ")
+	p = strings.ReplaceAll(p, "%3A", ":")
+	p = strings.ReplaceAll(p, "%3a", ":")
+	return NormalizePath(p), true
+}
+
+// PackageDirOf returns the normalized directory containing path. Used
+// as the key for package-level queries.
+func PackageDirOf(path string) string {
+	return NormalizePath(filepath.Dir(path))
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1,0 +1,408 @@
+package query
+
+import (
+	"bytes"
+
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// ---- Frame ----
+
+// frame is one entry on the execution stack. Exactly one frame per
+// actively-executing query body; while a body runs, every child
+// [Query.Fetch] / [Input.Fetch] call records a dep edge onto the top
+// frame's deps slice.
+type frame struct {
+	qid  QueryID
+	key  any
+	deps []depRecord
+}
+
+// currentFrame returns the top of the stack or nil if empty. Must be
+// called under db.mu.
+func (db *Database) currentFrame() *frame {
+	if n := len(db.stack); n > 0 {
+		return db.stack[n-1]
+	}
+	return nil
+}
+
+// pushFrame / popFrame are internal helpers; must be called under db.mu.
+func (db *Database) pushFrame(f *frame) { db.stack = append(db.stack, f) }
+
+func (db *Database) popFrame() *frame {
+	n := len(db.stack)
+	f := db.stack[n-1]
+	db.stack = db.stack[:n-1]
+	return f
+}
+
+// ---- Ctx ----
+
+// Ctx is handed to a query body while it executes. It exposes the
+// Database-level constants (prelude, stdlib) and is the token required
+// to call [Query.Fetch] / [Input.Fetch] — since Ctx can only be
+// obtained from within a body, this prevents callers from bypassing
+// the Database mutex by calling the non-locking Fetch path.
+type Ctx struct {
+	db *Database
+}
+
+// Prelude returns the process-lifetime prelude scope. Not dependency-
+// tracked — it's a Database construction-time constant.
+func (c *Ctx) Prelude() *resolve.Scope { return c.db.prelude }
+
+// Stdlib returns the process-lifetime stdlib registry. Not dependency-
+// tracked for the same reason as Prelude.
+func (c *Ctx) Stdlib() *stdlib.Registry { return c.db.stdlib }
+
+// ---- QueryFn, Query, Input ----
+
+// QueryFn is the body of a derived query. It receives the current
+// [Ctx] and the query-specific key, and returns the computed value.
+// The body may call [Query.Fetch] / [Input.Fetch] to read other
+// queries and inputs; those reads are tracked automatically.
+type QueryFn[K comparable, V any] func(*Ctx, K) V
+
+// Query is a registered derived query. Construct with [Register].
+type Query[K comparable, V any] struct {
+	id     QueryID
+	name   string
+	fn     QueryFn[K, V]
+	hashFn func(V) [32]byte
+}
+
+// ID reports the engine-internal identifier. Stable within one
+// Database instance; not meaningful across processes.
+func (q *Query[K, V]) ID() QueryID { return q.id }
+
+// Name returns the human-readable label supplied at registration.
+func (q *Query[K, V]) Name() string { return q.name }
+
+// Input is a registered input. Construct with [RegisterInput]. Inputs
+// differ from derived queries in two ways: they are externally
+// [Input.Set], and their hashFn is mandatory (used to decide whether
+// a Set actually bumps the revision).
+type Input[K comparable, V any] struct {
+	q      *Query[K, V] // hosts the slot machinery; fn is unused for inputs
+	hashFn func(V) [32]byte
+}
+
+// ID forwards the underlying QueryID.
+func (i *Input[K, V]) ID() QueryID { return i.q.id }
+
+// ---- Registration ----
+
+// Register adds a derived query to db. The optional hashFn enables
+// early cutoff: when a re-run produces a value whose hash matches the
+// cached value's hash, the slot's computedAt is left untouched so
+// downstream queries that read this one can reuse their own caches.
+// Pass nil hashFn to disable early cutoff (all re-runs bump
+// computedAt).
+func Register[K comparable, V any](
+	db *Database,
+	name string,
+	fn QueryFn[K, V],
+	hashFn func(V) [32]byte,
+) *Query[K, V] {
+	id := db.allocID(name, false)
+	q := &Query[K, V]{id: id, name: name, fn: fn, hashFn: hashFn}
+	db.mu.Lock()
+	if db.validators == nil {
+		db.validators = make(map[QueryID]validator)
+	}
+	db.validators[id] = func(d *Database, key any) *slot {
+		k, ok := key.(K)
+		if !ok {
+			return nil
+		}
+		return q.validateOrRunLocked(d, k)
+	}
+	db.mu.Unlock()
+	return q
+}
+
+// RegisterInput adds an input to db. The hashFn must be non-nil and
+// will decide whether [Input.Set] bumps the revision (a Set with a
+// value whose hash matches the current cached hash is a no-op).
+func RegisterInput[K comparable, V any](
+	db *Database,
+	name string,
+	hashFn func(V) [32]byte,
+) *Input[K, V] {
+	if hashFn == nil {
+		panic("query: input hashFn must be non-nil")
+	}
+	id := db.allocID(name, true)
+	q := &Query[K, V]{id: id, name: name, hashFn: hashFn}
+	// Inputs do not need a validator: their slots are only written
+	// via Input.Set and read via the derived dep-walk, which reads
+	// the slot directly.
+	db.mu.Lock()
+	if db.validators == nil {
+		db.validators = make(map[QueryID]validator)
+	}
+	db.validators[id] = func(d *Database, key any) *slot {
+		// Input "validation" is trivial: whatever is in the slot
+		// table is the truth; Set bumps rev when value actually
+		// changes, so no recomputation needed here.
+		m := d.slots[id]
+		if m == nil {
+			return nil
+		}
+		return m[key]
+	}
+	db.mu.Unlock()
+	return &Input[K, V]{q: q, hashFn: hashFn}
+}
+
+// ---- validator dispatch ----
+
+// validator is the type-erased entry point to a query's validate-or-run
+// path. Every Register stores one; validateDepLocked dispatches via
+// this table during dep-walks.
+type validator func(*Database, any) *slot
+
+// validateDepLocked invokes the validator for dep d. Used by
+// validateOrRunLocked when walking a slot's recorded deps. Must be
+// called under db.mu.
+func (db *Database) validateDepLocked(d depRecord) *slot {
+	v := db.validators[d.qid]
+	if v == nil {
+		return nil
+	}
+	return v(db, d.key)
+}
+
+// ---- Query.Get / Query.Fetch ----
+
+// Get is the user-facing entry point. Acquires db.mu, validates or
+// runs the slot for key, records a dep edge on the caller's frame if
+// one is active, and returns the value.
+//
+// Body code inside another query must use [Query.Fetch] instead — Get
+// would try to re-acquire the mutex and deadlock.
+func (q *Query[K, V]) Get(db *Database, key K) V {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return q.getLocked(db, key)
+}
+
+// Fetch is the body-facing entry point. The [Ctx] is the witness that
+// db.mu is already held; Fetch performs the same logic as Get without
+// re-locking.
+func (q *Query[K, V]) Fetch(ctx *Ctx, key K) V {
+	return q.getLocked(ctx.db, key)
+}
+
+func (q *Query[K, V]) getLocked(db *Database, key K) V {
+	// Capture parent BEFORE any recursion so dep edges are attributed
+	// correctly when this call was issued from a body.
+	parent := db.currentFrame()
+
+	if err := db.checkCycle(q.id, key); err != nil {
+		panic(err)
+	}
+
+	s := q.validateOrRunLocked(db, key)
+
+	if parent != nil {
+		parent.deps = append(parent.deps, depRecord{
+			qid:       q.id,
+			key:       key,
+			changedAt: s.computedAt,
+		})
+	}
+
+	return s.value.(V)
+}
+
+// validateOrRunLocked is the heart of the engine. Returns the slot
+// for (q, key) guaranteed to be verified at db.rev. Must be called
+// under db.mu.
+func (q *Query[K, V]) validateOrRunLocked(db *Database, key K) *slot {
+	m := db.slots[q.id]
+	s := m[any(key)]
+
+	if s == nil {
+		// Cold slot — run fresh. Accounts as miss.
+		return q.runAndStoreLocked(db, key, nil)
+	}
+
+	if s.verifiedAt == db.rev {
+		db.metrics.hits.Add(1)
+		return s
+	}
+
+	// Walk deps. If any dep's computedAt has advanced beyond what we
+	// recorded, this slot is stale.
+	stale := false
+	for _, d := range s.deps {
+		depSlot := db.validateDepLocked(d)
+		if depSlot == nil || depSlot.computedAt > d.changedAt {
+			stale = true
+			break
+		}
+	}
+
+	if !stale {
+		// All deps still valid — bump verifiedAt, keep value.
+		s.verifiedAt = db.rev
+		db.metrics.hits.Add(1)
+		return s
+	}
+
+	return q.runAndStoreLocked(db, key, s)
+}
+
+// runAndStoreLocked executes the body, hashes the result, and writes
+// a new slot. If oldSlot is non-nil and the hashFn matches, early
+// cutoff applies: the new slot's computedAt is inherited from the old
+// slot, sparing dependents a cascade. Must be called under db.mu.
+func (q *Query[K, V]) runAndStoreLocked(db *Database, key K, oldSlot *slot) *slot {
+	isInput := db.isInput[q.id]
+	if isInput {
+		// Inputs shouldn't reach here: their slots are created by
+		// Input.Set and validateDepLocked only reads them. A rerun
+		// attempt for a missing input slot is a programmer error.
+		panic("query: input " + db.names[q.id] + " has no slot (did you forget to Set it?)")
+	}
+
+	f := &frame{qid: q.id, key: key}
+	db.pushFrame(f)
+	value := q.fn(&Ctx{db: db}, key)
+	popped := db.popFrame()
+	_ = popped // == f
+
+	var newHash [32]byte
+	hasHash := q.hashFn != nil
+	if hasHash {
+		newHash = q.hashFn(value)
+	}
+
+	computedAt := db.rev
+	cutoff := false
+	if oldSlot != nil && hasHash && oldSlot.hasHash && bytes.Equal(newHash[:], oldSlot.outputHash[:]) {
+		// Early cutoff: value is semantically identical.
+		computedAt = oldSlot.computedAt
+		cutoff = true
+	}
+
+	newSlot := &slot{
+		value:      value,
+		outputHash: newHash,
+		hasHash:    hasHash,
+		computedAt: computedAt,
+		verifiedAt: db.rev,
+		deps:       f.deps,
+	}
+
+	if db.slots[q.id] == nil {
+		db.slots[q.id] = make(map[any]*slot)
+	}
+	db.slots[q.id][any(key)] = newSlot
+
+	if oldSlot == nil {
+		db.metrics.misses.Add(1)
+	} else if cutoff {
+		db.metrics.cutoffs.Add(1)
+	} else {
+		db.metrics.reruns.Add(1)
+	}
+
+	return newSlot
+}
+
+// ---- Input ----
+
+// Set writes val into the input slot for key. If val's hash matches
+// the existing slot's hash, this is a no-op — no revision bump, no
+// invalidation cascade. Otherwise the revision is bumped and the slot
+// is updated; downstream queries will notice on their next Get.
+func (i *Input[K, V]) Set(db *Database, key K, val V) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	newHash := i.hashFn(val)
+	m := db.slots[i.q.id]
+	if m == nil {
+		m = make(map[any]*slot)
+		db.slots[i.q.id] = m
+	}
+	if old, ok := m[any(key)]; ok && old.hasHash && bytes.Equal(newHash[:], old.outputHash[:]) {
+		// Same content — don't bump anything.
+		return
+	}
+
+	db.rev++
+	m[any(key)] = &slot{
+		value:      val,
+		outputHash: newHash,
+		hasHash:    true,
+		computedAt: db.rev,
+		verifiedAt: db.rev,
+	}
+	db.metrics.inputSet.Add(1)
+}
+
+// Clear removes the slot for key. Bumps the revision unconditionally
+// since anything that read the input needs to re-check. Callers that
+// might re-Set the same value after clearing should just call Set —
+// content-hash cutoff avoids the cascade there.
+func (i *Input[K, V]) Clear(db *Database, key K) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	m := db.slots[i.q.id]
+	if m == nil {
+		return
+	}
+	if _, ok := m[any(key)]; !ok {
+		return
+	}
+	delete(m, any(key))
+	db.rev++
+}
+
+// Get returns the current value for key. Panics if the key has never
+// been Set — inputs have no default; callers must seed them before
+// any dependent query is pulled.
+func (i *Input[K, V]) Get(db *Database, key K) V {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return i.getLocked(db, key)
+}
+
+// Fetch is the body-facing counterpart to Get. Records a dep edge on
+// the currently-executing frame.
+func (i *Input[K, V]) Fetch(ctx *Ctx, key K) V {
+	return i.getLocked(ctx.db, key)
+}
+
+func (i *Input[K, V]) getLocked(db *Database, key K) V {
+	parent := db.currentFrame()
+	m := db.slots[i.q.id]
+	s, ok := m[any(key)]
+	if !ok {
+		panic("query: input " + db.names[i.q.id] + " has no value set for key")
+	}
+	if parent != nil {
+		parent.deps = append(parent.deps, depRecord{
+			qid:       i.q.id,
+			key:       key,
+			changedAt: s.computedAt,
+		})
+	}
+	db.metrics.hits.Add(1)
+	return s.value.(V)
+}
+
+// Has reports whether key has been Set. Never records a dep edge
+// (checking existence is orthogonal to reading the value). Exposed
+// primarily for LSP seeding logic.
+func (i *Input[K, V]) Has(db *Database, key K) bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, ok := db.slots[i.q.id][any(key)]
+	return ok
+}

--- a/internal/query/slot.go
+++ b/internal/query/slot.go
@@ -1,0 +1,37 @@
+package query
+
+// slot is the cached record for one (QueryID, key) pair.
+//
+// The three revision numbers encode the Salsa invariant:
+//
+//   - computedAt: the revision at which value was last produced. A
+//     downstream query decides "my dep changed" by comparing its
+//     recorded depRecord.changedAt against the dep's current
+//     computedAt.
+//   - verifiedAt: the revision at which we last confirmed that every
+//     dep was still valid. Advances without running the query body
+//     whenever the dep-walk finds no dep stale.
+//   - deps: the exact edges captured when the body last ran.
+//
+// Early cutoff: when re-running the body produces a value whose hash
+// matches the stored outputHash, we leave computedAt alone — only
+// verifiedAt advances. Dependents that ask "did my dep's computedAt
+// move?" answer no, and cascade stops.
+type slot struct {
+	value      any
+	outputHash [32]byte // zero if the query has no hashFn
+	hasHash    bool
+	computedAt Revision
+	verifiedAt Revision
+	deps       []depRecord
+}
+
+// depRecord is one edge captured when a query body read a value. The
+// recorded changedAt is the dep slot's computedAt at the moment of
+// capture — we detect staleness by comparing it against the dep slot's
+// current computedAt, not its verifiedAt.
+type depRecord struct {
+	qid       QueryID
+	key       any
+	changedAt Revision
+}


### PR DESCRIPTION
## Summary

- rust-analyzer Salsa / Roslyn Compiler API 형태의 pull-based 증분 쿼리 엔진 도입 (`internal/query`)
- 컴파일러 파이프라인(Parse/Resolve/Check/Lint)을 쿼리로 래핑하고 output content-hash 기반 early cutoff 제공 (`internal/query/osty`)
- LSP 파일 모드를 엔진 경유로 전환 — 공백/주석만 다른 편집은 downstream 캐시 유지
- `osty query-check` 서브커맨드로 엔진 동작 계측 가능

## 핵심 동작

**의미적 신원 기반 해시** — `resolve.Result`/`check.Result`의 포인터 신원이 아니라 `(Name, Kind, Pos.Offset, Pub)` 튜플로 해시. AST 재파싱으로 포인터는 새로 할당되지만 semantic content가 같으면 hash 일치.

**Early cutoff cascade** — 재실행된 쿼리의 output hash가 기존과 같으면 `computedAt`은 유지, `verifiedAt`만 advance. Downstream 쿼리의 dep-walk가 `dep.computedAt > depRecord.changedAt` 체크에서 변경 없음 확인 → 재실행 스킵.

**실측** (공백 추가 편집):
- `TestCutoffOnTrivialWhitespaceEdit`: `{Reruns:2 Cutoffs:1}`
- `TestEngineBackedAnalyzeCutoffsOnWhitespaceEdit`: `{Reruns:2 Cutoffs:3}`

## 범위 밖 (후속 PR)

- 패키지/워크스페이스 단위 granular 무효화 (resolver declare/body 분리 필요)
- 프로세스 간 지속 캐시 (`.osty/cache` 확장)
- 병렬 쿼리 실행 (현재 단일 mutex)

현재는 LSP 파일 모드만 엔진 경유. 패키지/워크스페이스 모드는 레거시 경로 유지.

## 주요 파일

- `internal/query/{db,query,slot,cycle,metrics}.go` — 제너릭 엔진 (~820 LOC)
- `internal/query/osty/{db,queries,inputs,hash,uri}.go` — 컴파일러 바인딩 + 해시 (~1200 LOC)
- `internal/lsp/server.go` — `analyzeSingleFileViaEngine` 추가
- `cmd/osty/query.go` — `osty query-check` 서브커맨드

## Test plan

- [x] `go test ./internal/query/...` — 엔진 12 유닛 테스트
- [x] `go test ./internal/query/osty/...` — 8 통합 테스트
- [x] `go test ./internal/lsp/...` — 3 증분성 테스트 + 기존 14 테스트
- [x] `go build ./internal/query/... ./internal/lsp/...` clean
- [x] `go vet ./internal/query/... ./internal/lsp/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)