### PR TITLE
feat: LLVM 백엔드 Generic Monomorphization Phase 1

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -1,0 +1,938 @@
+package ir
+
+// Clone returns a deep copy of an IR subtree. Primitive type singletons
+// (TInt, TString, etc. defined in ir.go) are shared — they're immutable
+// and copying them would break pointer equality the rest of the package
+// relies on. Every other node, type, and container is freshly allocated.
+//
+// Clone exists primarily to support monomorphization: a generic fn body
+// is cloned once per concrete type tuple before type parameters are
+// substituted in place. Clients that need a plain traversal should reach
+// for Walk / Inspect instead.
+//
+// Clone is defensively nil-safe: Clone(nil) returns nil.
+func Clone(n Node) Node {
+	if n == nil {
+		return nil
+	}
+	return cloneNode(n)
+}
+
+// CloneType deep-copies a Type. Primitive singletons are returned as-is.
+// Returns nil when the input is nil.
+func CloneType(t Type) Type {
+	if t == nil {
+		return nil
+	}
+	switch t := t.(type) {
+	case *PrimType:
+		// Primitive types are shared singletons (TInt, TString, …).
+		return t
+	case *NamedType:
+		out := &NamedType{
+			Package: t.Package,
+			Name:    t.Name,
+			Builtin: t.Builtin,
+		}
+		if len(t.Args) > 0 {
+			out.Args = make([]Type, len(t.Args))
+			for i, a := range t.Args {
+				out.Args[i] = CloneType(a)
+			}
+		}
+		return out
+	case *OptionalType:
+		return &OptionalType{Inner: CloneType(t.Inner)}
+	case *TupleType:
+		out := &TupleType{}
+		if len(t.Elems) > 0 {
+			out.Elems = make([]Type, len(t.Elems))
+			for i, e := range t.Elems {
+				out.Elems[i] = CloneType(e)
+			}
+		}
+		return out
+	case *FnType:
+		out := &FnType{Return: CloneType(t.Return)}
+		if len(t.Params) > 0 {
+			out.Params = make([]Type, len(t.Params))
+			for i, p := range t.Params {
+				out.Params[i] = CloneType(p)
+			}
+		}
+		return out
+	case *TypeVar:
+		return &TypeVar{Name: t.Name, Owner: t.Owner}
+	case *ErrType:
+		// Shared singleton, same rationale as PrimType.
+		return t
+	}
+	return t
+}
+
+// cloneTypes clones each element of a slice.
+func cloneTypes(ts []Type) []Type {
+	if len(ts) == 0 {
+		return nil
+	}
+	out := make([]Type, len(ts))
+	for i, t := range ts {
+		out[i] = CloneType(t)
+	}
+	return out
+}
+
+// cloneNode dispatches on concrete node kind. Every case returns a fresh
+// pointer; callers receive a disjoint subtree.
+func cloneNode(n Node) Node {
+	switch n := n.(type) {
+
+	// ---- Module ----
+	case *Module:
+		return cloneModule(n)
+
+	// ---- Decls ----
+	case *FnDecl:
+		return cloneFnDecl(n)
+	case *StructDecl:
+		return cloneStructDecl(n)
+	case *EnumDecl:
+		return cloneEnumDecl(n)
+	case *LetDecl:
+		return cloneLetDecl(n)
+	case *InterfaceDecl:
+		return cloneInterfaceDecl(n)
+	case *TypeAliasDecl:
+		return cloneTypeAliasDecl(n)
+	case *UseDecl:
+		return cloneUseDecl(n)
+
+	// ---- Decl sub-nodes ----
+	case *Param:
+		return cloneParam(n)
+	case *Field:
+		return cloneField(n)
+	case *TypeParam:
+		return cloneTypeParam(n)
+	case *Variant:
+		return cloneVariant(n)
+
+	// ---- Stmts ----
+	case *Block:
+		return cloneBlock(n)
+	case *LetStmt:
+		return cloneLetStmt(n)
+	case *ExprStmt:
+		return &ExprStmt{X: cloneExpr(n.X), SpanV: n.SpanV}
+	case *AssignStmt:
+		return cloneAssignStmt(n)
+	case *ReturnStmt:
+		return &ReturnStmt{Value: cloneExprOrNil(n.Value), SpanV: n.SpanV}
+	case *BreakStmt:
+		return &BreakStmt{SpanV: n.SpanV}
+	case *ContinueStmt:
+		return &ContinueStmt{SpanV: n.SpanV}
+	case *IfStmt:
+		return &IfStmt{
+			Cond:  cloneExpr(n.Cond),
+			Then:  cloneBlockOrNil(n.Then),
+			Else:  cloneBlockOrNil(n.Else),
+			SpanV: n.SpanV,
+		}
+	case *ForStmt:
+		return cloneForStmt(n)
+	case *DeferStmt:
+		return &DeferStmt{Body: cloneBlockOrNil(n.Body), SpanV: n.SpanV}
+	case *ChanSendStmt:
+		return &ChanSendStmt{
+			Channel: cloneExpr(n.Channel),
+			Value:   cloneExpr(n.Value),
+			SpanV:   n.SpanV,
+		}
+	case *MatchStmt:
+		return cloneMatchStmt(n)
+	case *ErrorStmt:
+		return &ErrorStmt{Note: n.Note, SpanV: n.SpanV}
+	}
+
+	// Expressions and patterns dispatch through their own helpers.
+	if e, ok := n.(Expr); ok {
+		return cloneExpr(e)
+	}
+	if p, ok := n.(Pattern); ok {
+		return clonePattern(p)
+	}
+	return n
+}
+
+// ==== Module, decls ====
+
+func cloneModule(m *Module) *Module {
+	if m == nil {
+		return nil
+	}
+	out := &Module{Package: m.Package, SpanV: m.SpanV}
+	if len(m.Decls) > 0 {
+		out.Decls = make([]Decl, 0, len(m.Decls))
+		for _, d := range m.Decls {
+			out.Decls = append(out.Decls, cloneDecl(d))
+		}
+	}
+	if len(m.Script) > 0 {
+		out.Script = make([]Stmt, 0, len(m.Script))
+		for _, s := range m.Script {
+			out.Script = append(out.Script, cloneStmt(s))
+		}
+	}
+	return out
+}
+
+func cloneDecl(d Decl) Decl {
+	if d == nil {
+		return nil
+	}
+	switch d := d.(type) {
+	case *FnDecl:
+		return cloneFnDecl(d)
+	case *StructDecl:
+		return cloneStructDecl(d)
+	case *EnumDecl:
+		return cloneEnumDecl(d)
+	case *LetDecl:
+		return cloneLetDecl(d)
+	case *InterfaceDecl:
+		return cloneInterfaceDecl(d)
+	case *TypeAliasDecl:
+		return cloneTypeAliasDecl(d)
+	case *UseDecl:
+		return cloneUseDecl(d)
+	}
+	return d
+}
+
+func cloneFnDecl(fn *FnDecl) *FnDecl {
+	if fn == nil {
+		return nil
+	}
+	out := &FnDecl{
+		Name:     fn.Name,
+		Return:   CloneType(fn.Return),
+		Body:     cloneBlockOrNil(fn.Body),
+		Exported: fn.Exported,
+		SpanV:    fn.SpanV,
+	}
+	if len(fn.Params) > 0 {
+		out.Params = make([]*Param, len(fn.Params))
+		for i, p := range fn.Params {
+			out.Params[i] = cloneParam(p)
+		}
+	}
+	if len(fn.Generics) > 0 {
+		out.Generics = make([]*TypeParam, len(fn.Generics))
+		for i, g := range fn.Generics {
+			out.Generics[i] = cloneTypeParam(g)
+		}
+	}
+	return out
+}
+
+func cloneStructDecl(s *StructDecl) *StructDecl {
+	out := &StructDecl{
+		Name:     s.Name,
+		Exported: s.Exported,
+		SpanV:    s.SpanV,
+	}
+	if len(s.Fields) > 0 {
+		out.Fields = make([]*Field, len(s.Fields))
+		for i, f := range s.Fields {
+			out.Fields[i] = cloneField(f)
+		}
+	}
+	if len(s.Methods) > 0 {
+		out.Methods = make([]*FnDecl, len(s.Methods))
+		for i, m := range s.Methods {
+			out.Methods[i] = cloneFnDecl(m)
+		}
+	}
+	if len(s.Generics) > 0 {
+		out.Generics = make([]*TypeParam, len(s.Generics))
+		for i, g := range s.Generics {
+			out.Generics[i] = cloneTypeParam(g)
+		}
+	}
+	return out
+}
+
+func cloneEnumDecl(e *EnumDecl) *EnumDecl {
+	out := &EnumDecl{
+		Name:     e.Name,
+		Exported: e.Exported,
+		SpanV:    e.SpanV,
+	}
+	if len(e.Variants) > 0 {
+		out.Variants = make([]*Variant, len(e.Variants))
+		for i, v := range e.Variants {
+			out.Variants[i] = cloneVariant(v)
+		}
+	}
+	if len(e.Methods) > 0 {
+		out.Methods = make([]*FnDecl, len(e.Methods))
+		for i, m := range e.Methods {
+			out.Methods[i] = cloneFnDecl(m)
+		}
+	}
+	if len(e.Generics) > 0 {
+		out.Generics = make([]*TypeParam, len(e.Generics))
+		for i, g := range e.Generics {
+			out.Generics[i] = cloneTypeParam(g)
+		}
+	}
+	return out
+}
+
+func cloneLetDecl(l *LetDecl) *LetDecl {
+	return &LetDecl{
+		Name:     l.Name,
+		Type:     CloneType(l.Type),
+		Value:    cloneExprOrNil(l.Value),
+		Mut:      l.Mut,
+		Exported: l.Exported,
+		SpanV:    l.SpanV,
+	}
+}
+
+func cloneInterfaceDecl(i *InterfaceDecl) *InterfaceDecl {
+	out := &InterfaceDecl{
+		Name:     i.Name,
+		Exported: i.Exported,
+		SpanV:    i.SpanV,
+	}
+	if len(i.Methods) > 0 {
+		out.Methods = make([]*FnDecl, len(i.Methods))
+		for j, m := range i.Methods {
+			out.Methods[j] = cloneFnDecl(m)
+		}
+	}
+	if len(i.Extends) > 0 {
+		out.Extends = cloneTypes(i.Extends)
+	}
+	if len(i.Generics) > 0 {
+		out.Generics = make([]*TypeParam, len(i.Generics))
+		for j, g := range i.Generics {
+			out.Generics[j] = cloneTypeParam(g)
+		}
+	}
+	return out
+}
+
+func cloneTypeAliasDecl(t *TypeAliasDecl) *TypeAliasDecl {
+	out := &TypeAliasDecl{
+		Name:     t.Name,
+		Target:   CloneType(t.Target),
+		Exported: t.Exported,
+		SpanV:    t.SpanV,
+	}
+	if len(t.Generics) > 0 {
+		out.Generics = make([]*TypeParam, len(t.Generics))
+		for i, g := range t.Generics {
+			out.Generics[i] = cloneTypeParam(g)
+		}
+	}
+	return out
+}
+
+func cloneUseDecl(u *UseDecl) *UseDecl {
+	out := &UseDecl{
+		Path:         append([]string(nil), u.Path...),
+		RawPath:      u.RawPath,
+		Alias:        u.Alias,
+		IsGoFFI:      u.IsGoFFI,
+		IsRuntimeFFI: u.IsRuntimeFFI,
+		GoPath:       u.GoPath,
+		RuntimePath:  u.RuntimePath,
+		SpanV:        u.SpanV,
+	}
+	if len(u.GoBody) > 0 {
+		out.GoBody = make([]Decl, 0, len(u.GoBody))
+		for _, d := range u.GoBody {
+			out.GoBody = append(out.GoBody, cloneDecl(d))
+		}
+	}
+	return out
+}
+
+func cloneParam(p *Param) *Param {
+	if p == nil {
+		return nil
+	}
+	return &Param{
+		Name:    p.Name,
+		Pattern: clonePattern(p.Pattern),
+		Type:    CloneType(p.Type),
+		Default: cloneExprOrNil(p.Default),
+		SpanV:   p.SpanV,
+	}
+}
+
+func cloneField(f *Field) *Field {
+	return &Field{
+		Name:     f.Name,
+		Type:     CloneType(f.Type),
+		Default:  cloneExprOrNil(f.Default),
+		Exported: f.Exported,
+		SpanV:    f.SpanV,
+	}
+}
+
+func cloneTypeParam(tp *TypeParam) *TypeParam {
+	out := &TypeParam{Name: tp.Name, SpanV: tp.SpanV}
+	if len(tp.Bounds) > 0 {
+		out.Bounds = cloneTypes(tp.Bounds)
+	}
+	return out
+}
+
+func cloneVariant(v *Variant) *Variant {
+	out := &Variant{Name: v.Name, SpanV: v.SpanV}
+	if len(v.Payload) > 0 {
+		out.Payload = cloneTypes(v.Payload)
+	}
+	return out
+}
+
+// ==== Statements ====
+
+func cloneStmt(s Stmt) Stmt {
+	if s == nil {
+		return nil
+	}
+	switch s := s.(type) {
+	case *Block:
+		return cloneBlock(s)
+	case *LetStmt:
+		return cloneLetStmt(s)
+	case *ExprStmt:
+		return &ExprStmt{X: cloneExpr(s.X), SpanV: s.SpanV}
+	case *AssignStmt:
+		return cloneAssignStmt(s)
+	case *ReturnStmt:
+		return &ReturnStmt{Value: cloneExprOrNil(s.Value), SpanV: s.SpanV}
+	case *BreakStmt:
+		return &BreakStmt{SpanV: s.SpanV}
+	case *ContinueStmt:
+		return &ContinueStmt{SpanV: s.SpanV}
+	case *IfStmt:
+		return &IfStmt{
+			Cond:  cloneExpr(s.Cond),
+			Then:  cloneBlockOrNil(s.Then),
+			Else:  cloneBlockOrNil(s.Else),
+			SpanV: s.SpanV,
+		}
+	case *ForStmt:
+		return cloneForStmt(s)
+	case *DeferStmt:
+		return &DeferStmt{Body: cloneBlockOrNil(s.Body), SpanV: s.SpanV}
+	case *ChanSendStmt:
+		return &ChanSendStmt{
+			Channel: cloneExpr(s.Channel),
+			Value:   cloneExpr(s.Value),
+			SpanV:   s.SpanV,
+		}
+	case *MatchStmt:
+		return cloneMatchStmt(s)
+	case *ErrorStmt:
+		return &ErrorStmt{Note: s.Note, SpanV: s.SpanV}
+	}
+	return s
+}
+
+func cloneBlock(b *Block) *Block {
+	out := &Block{SpanV: b.SpanV}
+	if len(b.Stmts) > 0 {
+		out.Stmts = make([]Stmt, 0, len(b.Stmts))
+		for _, s := range b.Stmts {
+			out.Stmts = append(out.Stmts, cloneStmt(s))
+		}
+	}
+	if b.Result != nil {
+		out.Result = cloneExpr(b.Result)
+	}
+	return out
+}
+
+func cloneBlockOrNil(b *Block) *Block {
+	if b == nil {
+		return nil
+	}
+	return cloneBlock(b)
+}
+
+func cloneLetStmt(s *LetStmt) *LetStmt {
+	return &LetStmt{
+		Name:    s.Name,
+		Pattern: clonePattern(s.Pattern),
+		Type:    CloneType(s.Type),
+		Value:   cloneExprOrNil(s.Value),
+		Mut:     s.Mut,
+		SpanV:   s.SpanV,
+	}
+}
+
+func cloneAssignStmt(s *AssignStmt) *AssignStmt {
+	out := &AssignStmt{
+		Op:    s.Op,
+		Value: cloneExpr(s.Value),
+		SpanV: s.SpanV,
+	}
+	if len(s.Targets) > 0 {
+		out.Targets = make([]Expr, len(s.Targets))
+		for i, t := range s.Targets {
+			out.Targets[i] = cloneExpr(t)
+		}
+	}
+	return out
+}
+
+func cloneForStmt(s *ForStmt) *ForStmt {
+	return &ForStmt{
+		Kind:      s.Kind,
+		Var:       s.Var,
+		Pattern:   clonePattern(s.Pattern),
+		Cond:      cloneExprOrNil(s.Cond),
+		Iter:      cloneExprOrNil(s.Iter),
+		Start:     cloneExprOrNil(s.Start),
+		End:       cloneExprOrNil(s.End),
+		Inclusive: s.Inclusive,
+		Body:      cloneBlockOrNil(s.Body),
+		SpanV:     s.SpanV,
+	}
+}
+
+func cloneMatchStmt(s *MatchStmt) *MatchStmt {
+	out := &MatchStmt{
+		Scrutinee: cloneExpr(s.Scrutinee),
+		SpanV:     s.SpanV,
+	}
+	if len(s.Arms) > 0 {
+		out.Arms = make([]*MatchArm, len(s.Arms))
+		for i, a := range s.Arms {
+			out.Arms[i] = cloneMatchArm(a)
+		}
+	}
+	// Decision tree carries backend-specific bookkeeping; leaving it
+	// nil here forces the monomorphised body to be recompiled on demand
+	// by backends that rely on arm-by-arm fallback.
+	return out
+}
+
+// ==== Expressions ====
+
+func cloneExprOrNil(e Expr) Expr {
+	if e == nil {
+		return nil
+	}
+	return cloneExpr(e)
+}
+
+func cloneExpr(e Expr) Expr {
+	if e == nil {
+		return nil
+	}
+	switch e := e.(type) {
+	case *IntLit:
+		return &IntLit{Text: e.Text, T: CloneType(e.T), SpanV: e.SpanV}
+	case *FloatLit:
+		return &FloatLit{Text: e.Text, T: CloneType(e.T), SpanV: e.SpanV}
+	case *BoolLit:
+		return &BoolLit{Value: e.Value, SpanV: e.SpanV}
+	case *CharLit:
+		return &CharLit{Value: e.Value, SpanV: e.SpanV}
+	case *ByteLit:
+		return &ByteLit{Value: e.Value, SpanV: e.SpanV}
+	case *StringLit:
+		return cloneStringLit(e)
+	case *UnitLit:
+		return &UnitLit{SpanV: e.SpanV}
+	case *Ident:
+		return &Ident{
+			Name:     e.Name,
+			Kind:     e.Kind,
+			TypeArgs: cloneTypes(e.TypeArgs),
+			T:        CloneType(e.T),
+			SpanV:    e.SpanV,
+		}
+	case *UnaryExpr:
+		return &UnaryExpr{
+			Op:    e.Op,
+			X:     cloneExpr(e.X),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *BinaryExpr:
+		return &BinaryExpr{
+			Op:    e.Op,
+			Left:  cloneExpr(e.Left),
+			Right: cloneExpr(e.Right),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *CallExpr:
+		return cloneCallExpr(e)
+	case *IntrinsicCall:
+		return cloneIntrinsicCall(e)
+	case *MethodCall:
+		return cloneMethodCall(e)
+	case *ListLit:
+		return cloneListLit(e)
+	case *MapLit:
+		return cloneMapLit(e)
+	case *TupleLit:
+		return cloneTupleLit(e)
+	case *StructLit:
+		return cloneStructLit(e)
+	case *VariantLit:
+		return cloneVariantLit(e)
+	case *BlockExpr:
+		return &BlockExpr{
+			Block: cloneBlockOrNil(e.Block),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *IfExpr:
+		return &IfExpr{
+			Cond:  cloneExpr(e.Cond),
+			Then:  cloneBlockOrNil(e.Then),
+			Else:  cloneBlockOrNil(e.Else),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *IfLetExpr:
+		return &IfLetExpr{
+			Pattern:   clonePattern(e.Pattern),
+			Scrutinee: cloneExpr(e.Scrutinee),
+			Then:      cloneBlockOrNil(e.Then),
+			Else:      cloneBlockOrNil(e.Else),
+			T:         CloneType(e.T),
+			SpanV:     e.SpanV,
+		}
+	case *MatchExpr:
+		return cloneMatchExpr(e)
+	case *FieldExpr:
+		return &FieldExpr{
+			X:        cloneExpr(e.X),
+			Name:     e.Name,
+			Optional: e.Optional,
+			T:        CloneType(e.T),
+			SpanV:    e.SpanV,
+		}
+	case *IndexExpr:
+		return &IndexExpr{
+			X:     cloneExpr(e.X),
+			Index: cloneExpr(e.Index),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *TupleAccess:
+		return &TupleAccess{
+			X:     cloneExpr(e.X),
+			Index: e.Index,
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *RangeLit:
+		return &RangeLit{
+			Start:     cloneExprOrNil(e.Start),
+			End:       cloneExprOrNil(e.End),
+			Inclusive: e.Inclusive,
+			T:         CloneType(e.T),
+			SpanV:     e.SpanV,
+		}
+	case *QuestionExpr:
+		return &QuestionExpr{
+			X:     cloneExpr(e.X),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *CoalesceExpr:
+		return &CoalesceExpr{
+			Left:  cloneExpr(e.Left),
+			Right: cloneExpr(e.Right),
+			T:     CloneType(e.T),
+			SpanV: e.SpanV,
+		}
+	case *Closure:
+		return cloneClosure(e)
+	case *ErrorExpr:
+		return &ErrorExpr{Note: e.Note, T: CloneType(e.T), SpanV: e.SpanV}
+	}
+	return e
+}
+
+func cloneStringLit(s *StringLit) *StringLit {
+	out := &StringLit{IsRaw: s.IsRaw, IsTriple: s.IsTriple, SpanV: s.SpanV}
+	if len(s.Parts) > 0 {
+		out.Parts = make([]StringPart, len(s.Parts))
+		for i, p := range s.Parts {
+			out.Parts[i] = StringPart{
+				IsLit: p.IsLit,
+				Lit:   p.Lit,
+			}
+			if !p.IsLit && p.Expr != nil {
+				out.Parts[i].Expr = cloneExpr(p.Expr)
+			}
+		}
+	}
+	return out
+}
+
+func cloneCallExpr(c *CallExpr) *CallExpr {
+	out := &CallExpr{
+		Callee:   cloneExpr(c.Callee),
+		TypeArgs: cloneTypes(c.TypeArgs),
+		T:        CloneType(c.T),
+		SpanV:    c.SpanV,
+	}
+	out.Args = cloneArgs(c.Args)
+	return out
+}
+
+func cloneIntrinsicCall(i *IntrinsicCall) *IntrinsicCall {
+	return &IntrinsicCall{
+		Kind:  i.Kind,
+		Args:  cloneArgs(i.Args),
+		SpanV: i.SpanV,
+	}
+}
+
+func cloneMethodCall(m *MethodCall) *MethodCall {
+	out := &MethodCall{
+		Receiver: cloneExpr(m.Receiver),
+		Name:     m.Name,
+		TypeArgs: cloneTypes(m.TypeArgs),
+		T:        CloneType(m.T),
+		SpanV:    m.SpanV,
+	}
+	out.Args = cloneArgs(m.Args)
+	return out
+}
+
+func cloneArgs(as []Arg) []Arg {
+	if len(as) == 0 {
+		return nil
+	}
+	out := make([]Arg, len(as))
+	for i, a := range as {
+		out[i] = Arg{
+			Name:  a.Name,
+			Value: cloneExpr(a.Value),
+			SpanV: a.SpanV,
+		}
+	}
+	return out
+}
+
+func cloneListLit(l *ListLit) *ListLit {
+	out := &ListLit{Elem: CloneType(l.Elem), SpanV: l.SpanV}
+	if len(l.Elems) > 0 {
+		out.Elems = make([]Expr, len(l.Elems))
+		for i, e := range l.Elems {
+			out.Elems[i] = cloneExpr(e)
+		}
+	}
+	return out
+}
+
+func cloneMapLit(m *MapLit) *MapLit {
+	out := &MapLit{
+		KeyT:  CloneType(m.KeyT),
+		ValT:  CloneType(m.ValT),
+		SpanV: m.SpanV,
+	}
+	if len(m.Entries) > 0 {
+		out.Entries = make([]MapEntry, len(m.Entries))
+		for i, en := range m.Entries {
+			out.Entries[i] = MapEntry{
+				Key:   cloneExpr(en.Key),
+				Value: cloneExpr(en.Value),
+				SpanV: en.SpanV,
+			}
+		}
+	}
+	return out
+}
+
+func cloneTupleLit(t *TupleLit) *TupleLit {
+	out := &TupleLit{T: CloneType(t.T), SpanV: t.SpanV}
+	if len(t.Elems) > 0 {
+		out.Elems = make([]Expr, len(t.Elems))
+		for i, e := range t.Elems {
+			out.Elems[i] = cloneExpr(e)
+		}
+	}
+	return out
+}
+
+func cloneStructLit(s *StructLit) *StructLit {
+	out := &StructLit{
+		TypeName: s.TypeName,
+		Spread:   cloneExprOrNil(s.Spread),
+		T:        CloneType(s.T),
+		SpanV:    s.SpanV,
+	}
+	if len(s.Fields) > 0 {
+		out.Fields = make([]StructLitField, len(s.Fields))
+		for i, f := range s.Fields {
+			out.Fields[i] = StructLitField{
+				Name:  f.Name,
+				Value: cloneExprOrNil(f.Value),
+				SpanV: f.SpanV,
+			}
+		}
+	}
+	return out
+}
+
+func cloneVariantLit(v *VariantLit) *VariantLit {
+	return &VariantLit{
+		Enum:    v.Enum,
+		Variant: v.Variant,
+		Args:    cloneArgs(v.Args),
+		T:       CloneType(v.T),
+		SpanV:   v.SpanV,
+	}
+}
+
+func cloneMatchExpr(m *MatchExpr) *MatchExpr {
+	out := &MatchExpr{
+		Scrutinee: cloneExpr(m.Scrutinee),
+		T:         CloneType(m.T),
+		SpanV:     m.SpanV,
+	}
+	if len(m.Arms) > 0 {
+		out.Arms = make([]*MatchArm, len(m.Arms))
+		for i, a := range m.Arms {
+			out.Arms[i] = cloneMatchArm(a)
+		}
+	}
+	return out
+}
+
+func cloneMatchArm(a *MatchArm) *MatchArm {
+	if a == nil {
+		return nil
+	}
+	return &MatchArm{
+		Pattern: clonePattern(a.Pattern),
+		Guard:   cloneExprOrNil(a.Guard),
+		Body:    cloneBlockOrNil(a.Body),
+		SpanV:   a.SpanV,
+	}
+}
+
+func cloneClosure(c *Closure) *Closure {
+	out := &Closure{
+		Return: CloneType(c.Return),
+		Body:   cloneBlockOrNil(c.Body),
+		T:      CloneType(c.T),
+		SpanV:  c.SpanV,
+	}
+	if len(c.Params) > 0 {
+		out.Params = make([]*Param, len(c.Params))
+		for i, p := range c.Params {
+			out.Params[i] = cloneParam(p)
+		}
+	}
+	if len(c.Captures) > 0 {
+		out.Captures = make([]*Capture, len(c.Captures))
+		for i, cap := range c.Captures {
+			out.Captures[i] = &Capture{
+				Name:  cap.Name,
+				Kind:  cap.Kind,
+				T:     CloneType(cap.T),
+				Mut:   cap.Mut,
+				SpanV: cap.SpanV,
+			}
+		}
+	}
+	return out
+}
+
+// ==== Patterns ====
+
+func clonePattern(p Pattern) Pattern {
+	if p == nil {
+		return nil
+	}
+	switch p := p.(type) {
+	case *WildPat:
+		return &WildPat{SpanV: p.SpanV}
+	case *IdentPat:
+		return &IdentPat{Name: p.Name, Mut: p.Mut, SpanV: p.SpanV}
+	case *LitPat:
+		return &LitPat{Value: cloneExprOrNil(p.Value), SpanV: p.SpanV}
+	case *TuplePat:
+		out := &TuplePat{SpanV: p.SpanV}
+		if len(p.Elems) > 0 {
+			out.Elems = make([]Pattern, len(p.Elems))
+			for i, e := range p.Elems {
+				out.Elems[i] = clonePattern(e)
+			}
+		}
+		return out
+	case *StructPat:
+		out := &StructPat{
+			TypeName: p.TypeName,
+			Rest:     p.Rest,
+			SpanV:    p.SpanV,
+		}
+		if len(p.Fields) > 0 {
+			out.Fields = make([]StructPatField, len(p.Fields))
+			for i, f := range p.Fields {
+				out.Fields[i] = StructPatField{
+					Name:    f.Name,
+					Pattern: clonePattern(f.Pattern),
+					SpanV:   f.SpanV,
+				}
+			}
+		}
+		return out
+	case *VariantPat:
+		out := &VariantPat{
+			Enum:    p.Enum,
+			Variant: p.Variant,
+			SpanV:   p.SpanV,
+		}
+		if len(p.Args) > 0 {
+			out.Args = make([]Pattern, len(p.Args))
+			for i, a := range p.Args {
+				out.Args[i] = clonePattern(a)
+			}
+		}
+		return out
+	case *RangePat:
+		return &RangePat{
+			Low:       cloneExprOrNil(p.Low),
+			High:      cloneExprOrNil(p.High),
+			Inclusive: p.Inclusive,
+			SpanV:     p.SpanV,
+		}
+	case *OrPat:
+		out := &OrPat{SpanV: p.SpanV}
+		if len(p.Alts) > 0 {
+			out.Alts = make([]Pattern, len(p.Alts))
+			for i, a := range p.Alts {
+				out.Alts[i] = clonePattern(a)
+			}
+		}
+		return out
+	case *BindingPat:
+		return &BindingPat{
+			Name:    p.Name,
+			Pattern: clonePattern(p.Pattern),
+			SpanV:   p.SpanV,
+		}
+	case *ErrorPat:
+		return &ErrorPat{Note: p.Note, SpanV: p.SpanV}
+	}
+	return p
+}

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -1,0 +1,550 @@
+package ir
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Monomorphize performs generic monomorphization over an IR Module,
+// returning a new Module in which:
+//
+//   - every generic free FnDecl has been replaced by its set of
+//     concrete specializations (one per (fn, type-args) tuple reachable
+//     from non-generic callers);
+//   - every generic CallExpr has been retargeted at the mangled
+//     specialization name, with TypeArgs cleared;
+//   - every TypeVar has been substituted with its concrete type.
+//
+// Generic fns that are never called are dropped entirely — matching the
+// language spec's "header-like" demand-driven framing
+// (LANG_SPEC_v0.4/02-type-system.md §2.7.3).
+//
+// The returned []error collects non-fatal issues (unresolved type
+// parameters, arity mismatches). A nil module yields (nil, nil).
+//
+// Phase 1 scope:
+//   - generic free functions
+//   - type-args may include builtin aggregates (List<T>, Option<T>, …);
+//     mangled symbol names reflect that, and the existing emitter paths
+//     handle the aggregate runtime layout
+//
+// Out of scope (Phase 2+):
+//   - generic struct / enum / interface declarations
+//   - generic methods (they stay under the existing unsupported
+//     diagnostic)
+//   - turbofish on bare function-pointer expressions (`let f = id::<Int>`)
+func Monomorphize(mod *Module) (*Module, []error) {
+	if mod == nil {
+		return nil, nil
+	}
+	state := &monoState{
+		pkg:            mod.Package,
+		out:            &Module{Package: mod.Package, SpanV: mod.SpanV},
+		genericsByName: map[string]*FnDecl{},
+		seen:           map[string]string{},
+	}
+
+	// Pass 1: index generic free fns so the scanner can resolve
+	// callees against the original declarations without revisiting
+	// mod.Decls for each call site.
+	for _, d := range mod.Decls {
+		if fn, ok := d.(*FnDecl); ok && len(fn.Generics) > 0 {
+			state.genericsByName[fn.Name] = fn
+		}
+	}
+
+	// Pass 2: copy non-generic decls into the output module (cloning so
+	// rewrites are isolated from the input), scan their bodies for
+	// initial instantiation requests, and append the script.
+	for _, d := range mod.Decls {
+		if fn, ok := d.(*FnDecl); ok && len(fn.Generics) > 0 {
+			// generic free fn — drop from output; specializations will
+			// be appended at the end.
+			continue
+		}
+		out := cloneDecl(d)
+		state.out.Decls = append(state.out.Decls, out)
+		state.scanDecl(out)
+	}
+	for _, s := range mod.Script {
+		cloned := cloneStmt(s)
+		state.out.Script = append(state.out.Script, cloned)
+		state.scanStmt(cloned)
+	}
+
+	// Pass 3: drain the worklist. Each iteration clones an original
+	// generic fn, substitutes type parameters, scans its body for
+	// further instantiations (which append to the queue), and adds the
+	// specialization to the output.
+	for i := 0; i < len(state.queue); i++ {
+		rec := state.queue[i]
+		state.emitSpecialization(rec)
+	}
+
+	return state.out, state.errs
+}
+
+// monoState carries the per-module monomorphization bookkeeping.
+type monoState struct {
+	pkg            string
+	out            *Module
+	genericsByName map[string]*FnDecl // generic free fn by source name
+	// seen maps a dedup key to the mangled symbol name so duplicate
+	// requests short-circuit to the same specialization.
+	seen map[string]string
+	// queue is the worklist of pending specializations. Index-based
+	// drain lets new entries appended during scanning be picked up.
+	queue []monoInstance
+	errs  []error
+}
+
+// monoInstance is one pending free-fn specialization.
+type monoInstance struct {
+	fn       *FnDecl
+	typeArgs []Type
+	mangled  string
+}
+
+// addErr appends a non-fatal issue.
+func (s *monoState) addErr(format string, args ...any) {
+	s.errs = append(s.errs, fmt.Errorf(format, args...))
+}
+
+// request enqueues a (generic fn, concrete type-args) pair for
+// specialization and returns the mangled name the caller should use at
+// the call site. Duplicate requests short-circuit via the seen map.
+// Returns "" when the request is malformed (arity mismatch, unresolved
+// type parameters).
+func (s *monoState) request(fn *FnDecl, typeArgs []Type) string {
+	if fn == nil {
+		return ""
+	}
+	if !MonomorphShouldInstantiate(len(typeArgs), len(fn.Generics)) {
+		s.addErr("monomorph: arity mismatch for %s: %d type args vs %d generics",
+			fn.Name, len(typeArgs), len(fn.Generics))
+		return ""
+	}
+	// Concrete type args must not contain lingering TypeVars — that
+	// means an upstream substitution missed a scope. Bail so we don't
+	// emit an invalid symbol.
+	for i, ta := range typeArgs {
+		if containsTypeVar(ta) {
+			s.addErr("monomorph: type arg %d of %s still contains a type variable (%s)",
+				i, fn.Name, typeString(ta))
+			return ""
+		}
+	}
+	typeArgCodes := make([]string, len(typeArgs))
+	for i, ta := range typeArgs {
+		typeArgCodes[i] = typeCodeOf(ta, s.pkg)
+	}
+	key := MonomorphDedupeKey(fn.Name, s.pkg, typeArgCodes)
+	if mangled, ok := s.seen[key]; ok {
+		return mangled
+	}
+	// Encode param types for the symbol tail, substituting this
+	// instance's env so the parameter codes reflect concrete types.
+	paramCodes := make([]string, 0, len(fn.Params))
+	env := buildSubstEnv(fn.Generics, typeArgs)
+	for _, p := range fn.Params {
+		substituted := cloneAndSubstType(p.Type, env)
+		paramCodes = append(paramCodes, typeCodeOf(substituted, s.pkg))
+	}
+	returnCode := ""
+	if fn.Return != nil {
+		substituted := cloneAndSubstType(fn.Return, env)
+		returnCode = typeCodeOf(substituted, s.pkg)
+	}
+	req := NewMonomorphRequest(s.pkg, fn.Name, typeArgCodes, paramCodes, returnCode)
+	mangled := MonomorphMangleFn(req).Symbol()
+	s.seen[key] = mangled
+	s.queue = append(s.queue, monoInstance{
+		fn:       fn,
+		typeArgs: append([]Type(nil), typeArgs...),
+		mangled:  mangled,
+	})
+	return mangled
+}
+
+// emitSpecialization materializes one queued free-fn instance: clones
+// the original body, substitutes type parameters, rewrites nested
+// generic calls, and appends the result to out.Decls.
+func (s *monoState) emitSpecialization(rec monoInstance) {
+	clone := cloneFnDecl(rec.fn)
+	clone.Name = rec.mangled
+	clone.Generics = nil
+	env := buildSubstEnv(rec.fn.Generics, rec.typeArgs)
+	SubstituteTypes(clone, env)
+	s.scanFnBody(clone)
+	s.out.Decls = append(s.out.Decls, clone)
+}
+
+// scanDecl walks a top-level declaration looking for generic call sites
+// that need rewriting in-place. Only non-generic bodies are scanned here
+// — generic bodies are handled by emitSpecialization after substitution.
+func (s *monoState) scanDecl(d Decl) {
+	switch d := d.(type) {
+	case *FnDecl:
+		s.scanFnBody(d)
+	case *StructDecl:
+		for _, m := range d.Methods {
+			s.scanFnBody(m)
+		}
+	case *EnumDecl:
+		for _, m := range d.Methods {
+			s.scanFnBody(m)
+		}
+	case *LetDecl:
+		if d.Value != nil {
+			s.scanExpr(d.Value)
+		}
+	}
+}
+
+// scanFnBody walks a function body in place rewriting every generic
+// call site to point at its mangled specialization. Non-generic calls
+// are left untouched. No-op for decls without a body (interface stubs).
+func (s *monoState) scanFnBody(fn *FnDecl) {
+	if fn == nil || fn.Body == nil {
+		return
+	}
+	s.scanBlock(fn.Body)
+}
+
+func (s *monoState) scanBlock(b *Block) {
+	if b == nil {
+		return
+	}
+	for _, st := range b.Stmts {
+		s.scanStmt(st)
+	}
+	if b.Result != nil {
+		s.scanExpr(b.Result)
+	}
+}
+
+func (s *monoState) scanStmt(st Stmt) {
+	switch st := st.(type) {
+	case *Block:
+		s.scanBlock(st)
+	case *LetStmt:
+		if st.Value != nil {
+			s.scanExpr(st.Value)
+		}
+	case *ExprStmt:
+		s.scanExpr(st.X)
+	case *AssignStmt:
+		for _, t := range st.Targets {
+			s.scanExpr(t)
+		}
+		s.scanExpr(st.Value)
+	case *ReturnStmt:
+		if st.Value != nil {
+			s.scanExpr(st.Value)
+		}
+	case *IfStmt:
+		s.scanExpr(st.Cond)
+		s.scanBlock(st.Then)
+		s.scanBlock(st.Else)
+	case *ForStmt:
+		if st.Cond != nil {
+			s.scanExpr(st.Cond)
+		}
+		if st.Iter != nil {
+			s.scanExpr(st.Iter)
+		}
+		if st.Start != nil {
+			s.scanExpr(st.Start)
+		}
+		if st.End != nil {
+			s.scanExpr(st.End)
+		}
+		s.scanBlock(st.Body)
+	case *DeferStmt:
+		s.scanBlock(st.Body)
+	case *ChanSendStmt:
+		s.scanExpr(st.Channel)
+		s.scanExpr(st.Value)
+	case *MatchStmt:
+		s.scanExpr(st.Scrutinee)
+		for _, a := range st.Arms {
+			if a == nil {
+				continue
+			}
+			if a.Guard != nil {
+				s.scanExpr(a.Guard)
+			}
+			s.scanBlock(a.Body)
+		}
+	}
+}
+
+func (s *monoState) scanExpr(e Expr) {
+	if e == nil {
+		return
+	}
+	switch e := e.(type) {
+	case *CallExpr:
+		// Rewrite generic call to mangled specialization.
+		if len(e.TypeArgs) > 0 {
+			s.rewriteGenericCall(e)
+		}
+		s.scanExpr(e.Callee)
+		for i := range e.Args {
+			s.scanExpr(e.Args[i].Value)
+		}
+	case *MethodCall:
+		// Generic method monomorphization is out of scope for Phase 1.
+		// Non-generic method calls still need their args walked for
+		// generic calls nested inside.
+		s.scanExpr(e.Receiver)
+		for i := range e.Args {
+			s.scanExpr(e.Args[i].Value)
+		}
+	case *IntrinsicCall:
+		for i := range e.Args {
+			s.scanExpr(e.Args[i].Value)
+		}
+	case *UnaryExpr:
+		s.scanExpr(e.X)
+	case *BinaryExpr:
+		s.scanExpr(e.Left)
+		s.scanExpr(e.Right)
+	case *ListLit:
+		for _, el := range e.Elems {
+			s.scanExpr(el)
+		}
+	case *MapLit:
+		for i := range e.Entries {
+			s.scanExpr(e.Entries[i].Key)
+			s.scanExpr(e.Entries[i].Value)
+		}
+	case *TupleLit:
+		for _, el := range e.Elems {
+			s.scanExpr(el)
+		}
+	case *StructLit:
+		for i := range e.Fields {
+			if e.Fields[i].Value != nil {
+				s.scanExpr(e.Fields[i].Value)
+			}
+		}
+		if e.Spread != nil {
+			s.scanExpr(e.Spread)
+		}
+	case *VariantLit:
+		for i := range e.Args {
+			s.scanExpr(e.Args[i].Value)
+		}
+	case *BlockExpr:
+		s.scanBlock(e.Block)
+	case *IfExpr:
+		s.scanExpr(e.Cond)
+		s.scanBlock(e.Then)
+		s.scanBlock(e.Else)
+	case *IfLetExpr:
+		s.scanExpr(e.Scrutinee)
+		s.scanBlock(e.Then)
+		s.scanBlock(e.Else)
+	case *MatchExpr:
+		s.scanExpr(e.Scrutinee)
+		for _, a := range e.Arms {
+			if a == nil {
+				continue
+			}
+			if a.Guard != nil {
+				s.scanExpr(a.Guard)
+			}
+			s.scanBlock(a.Body)
+		}
+	case *FieldExpr:
+		s.scanExpr(e.X)
+	case *IndexExpr:
+		s.scanExpr(e.X)
+		s.scanExpr(e.Index)
+	case *TupleAccess:
+		s.scanExpr(e.X)
+	case *RangeLit:
+		if e.Start != nil {
+			s.scanExpr(e.Start)
+		}
+		if e.End != nil {
+			s.scanExpr(e.End)
+		}
+	case *QuestionExpr:
+		s.scanExpr(e.X)
+	case *CoalesceExpr:
+		s.scanExpr(e.Left)
+		s.scanExpr(e.Right)
+	case *Closure:
+		s.scanBlock(e.Body)
+	case *StringLit:
+		for _, p := range e.Parts {
+			if !p.IsLit && p.Expr != nil {
+				s.scanExpr(p.Expr)
+			}
+		}
+	}
+}
+
+// rewriteGenericCall translates a generic free-fn call site into its
+// mangled specialization. Only calls whose callee resolves to a
+// top-level generic FnDecl are rewritten; others are left alone (the
+// checker should have rejected anything else, but we stay defensive).
+func (s *monoState) rewriteGenericCall(c *CallExpr) {
+	id, ok := c.Callee.(*Ident)
+	if !ok {
+		return
+	}
+	orig, ok := s.genericsByName[id.Name]
+	if !ok {
+		return
+	}
+	mangled := s.request(orig, c.TypeArgs)
+	if mangled == "" {
+		return
+	}
+	id.Name = mangled
+	id.TypeArgs = nil
+	c.TypeArgs = nil
+}
+
+// ==== Helpers ====
+
+// buildSubstEnv pairs up a generic parameter list with its concrete
+// type arguments. Out-of-range indices are skipped so malformed input
+// degrades gracefully.
+func buildSubstEnv(params []*TypeParam, args []Type) SubstEnv {
+	env := make(SubstEnv, len(params))
+	for i, p := range params {
+		if p == nil || i >= len(args) {
+			break
+		}
+		env[p.Name] = args[i]
+	}
+	return env
+}
+
+// cloneAndSubstType returns a substituted copy of t without mutating
+// the original.
+func cloneAndSubstType(t Type, env SubstEnv) Type {
+	cloned := CloneType(t)
+	return substType(cloned, env)
+}
+
+// containsTypeVar reports whether a Type still contains a TypeVar
+// anywhere in its structure.
+func containsTypeVar(t Type) bool {
+	switch t := t.(type) {
+	case *TypeVar:
+		return true
+	case *NamedType:
+		for _, a := range t.Args {
+			if containsTypeVar(a) {
+				return true
+			}
+		}
+		return false
+	case *OptionalType:
+		return containsTypeVar(t.Inner)
+	case *TupleType:
+		for _, e := range t.Elems {
+			if containsTypeVar(e) {
+				return true
+			}
+		}
+		return false
+	case *FnType:
+		for _, p := range t.Params {
+			if containsTypeVar(p) {
+				return true
+			}
+		}
+		return containsTypeVar(t.Return)
+	}
+	return false
+}
+
+// typeCodeOf produces an Itanium-compatible encoding for an IR Type,
+// routing through the Osty-authored snapshot for primitives and
+// builtin aggregates. Unknown / poisoned types return "?" so callers
+// can detect and bail.
+func typeCodeOf(t Type, pkg string) string {
+	if t == nil {
+		return "?"
+	}
+	switch t := t.(type) {
+	case *PrimType:
+		if code := MonomorphPrimCode(t.String()); code != "" {
+			return code
+		}
+		return "?"
+	case *NamedType:
+		// Bare primitive reference (the checker occasionally lowers
+		// `Int` as a NamedType). Defer to the primitive table.
+		if t.Package == "" && len(t.Args) == 0 {
+			if code := MonomorphPrimCode(t.Name); code != "" {
+				return code
+			}
+		}
+		if t.Builtin {
+			return builtinTypeCode(t, pkg)
+		}
+		return MonomorphUserNested(firstNonEmpty(pkg, "main"), t.Name)
+	case *OptionalType:
+		inner := typeCodeOf(t.Inner, pkg)
+		return MonomorphBuiltinTemplate("Option", inner)
+	case *TupleType:
+		var sb strings.Builder
+		for _, e := range t.Elems {
+			sb.WriteString(typeCodeOf(e, pkg))
+		}
+		return MonomorphBuiltinTemplate("Tuple", sb.String())
+	case *FnType:
+		// Itanium pointer-to-function form `PF<ret><params>E`. Rare
+		// enough in generics that we approximate; the dedup key only
+		// needs uniqueness so this is fine for Phase 1.
+		var sb strings.Builder
+		sb.WriteString("PF")
+		if t.Return != nil {
+			sb.WriteString(typeCodeOf(t.Return, pkg))
+		} else {
+			sb.WriteString("v")
+		}
+		for _, p := range t.Params {
+			sb.WriteString(typeCodeOf(p, pkg))
+		}
+		sb.WriteByte('E')
+		return sb.String()
+	case *TypeVar:
+		return "?"
+	case *ErrType:
+		return "?"
+	}
+	return "?"
+}
+
+// builtinTypeCode encodes prelude aggregates (List, Map, Set, Option,
+// Result, Bytes, String, …). When the type has no template args it
+// collapses to the simple nested form.
+func builtinTypeCode(n *NamedType, pkg string) string {
+	if n == nil {
+		return "?"
+	}
+	if len(n.Args) == 0 {
+		return MonomorphBuiltinNested(n.Name)
+	}
+	var sb strings.Builder
+	for _, a := range n.Args {
+		sb.WriteString(typeCodeOf(a, pkg))
+	}
+	return MonomorphBuiltinTemplate(n.Name, sb.String())
+}
+
+// firstNonEmpty returns a when non-empty, else b.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/ir/monomorph_snapshot.go
+++ b/internal/ir/monomorph_snapshot.go
@@ -1,0 +1,212 @@
+// monomorph_snapshot.go snapshots the Osty-authored generic
+// monomorphization helper surface (toolchain/monomorph.osty) into the
+// IR package. The Osty sources remain the long-term owners of the
+// encoding table and symbol-assembly rules; this file is a
+// hand-translated seed so the Go bootstrap has something to call
+// before the toolchain is itself re-translated.
+//
+// Keep this file in lockstep with toolchain/monomorph.osty.
+
+package ir
+
+import (
+	"fmt"
+)
+
+// Osty: toolchain/monomorph.osty:14:5
+type MonomorphRequest struct {
+	pkg             string
+	fnName          string
+	typeArgCodes    []string
+	paramTypeCodes  []string
+	returnTypeCode  string
+}
+
+// Osty: toolchain/monomorph.osty:25:5
+type MonomorphMangled struct {
+	symbol string
+}
+
+// Symbol returns the mangled LLVM symbol string. Exposed so the IR
+// monomorph engine (internal/ir) can consume Osty's output without
+// reaching into an unexported field.
+func (m *MonomorphMangled) Symbol() string {
+	if m == nil {
+		return ""
+	}
+	return m.symbol
+}
+
+// NewMonomorphRequest constructs a request with the shape Osty's
+// pure helpers expect. Exposed for cross-package callers; Osty itself
+// gets a struct literal.
+func NewMonomorphRequest(pkg, fnName string, typeArgCodes, paramTypeCodes []string, returnTypeCode string) *MonomorphRequest {
+	return &MonomorphRequest{
+		pkg:            pkg,
+		fnName:         fnName,
+		typeArgCodes:   append([]string(nil), typeArgCodes...),
+		paramTypeCodes: append([]string(nil), paramTypeCodes...),
+		returnTypeCode: returnTypeCode,
+	}
+}
+
+// Osty: toolchain/monomorph.osty:37:5
+func MonomorphPrimCode(name string) string {
+	if name == "Int" {
+		return "l"
+	}
+	if name == "Int8" {
+		return "a"
+	}
+	if name == "Int16" {
+		return "s"
+	}
+	if name == "Int32" {
+		return "i"
+	}
+	if name == "Int64" {
+		return "x"
+	}
+	if name == "UInt8" {
+		return "h"
+	}
+	if name == "UInt16" {
+		return "t"
+	}
+	if name == "UInt32" {
+		return "j"
+	}
+	if name == "UInt64" {
+		return "y"
+	}
+	if name == "Byte" {
+		return "h"
+	}
+	if name == "Float" {
+		return "d"
+	}
+	if name == "Float32" {
+		return "f"
+	}
+	if name == "Float64" {
+		return "d"
+	}
+	if name == "Bool" {
+		return "b"
+	}
+	if name == "Char" {
+		return "w"
+	}
+	if name == "Unit" {
+		return "v"
+	}
+	return ""
+}
+
+// Osty: toolchain/monomorph.osty:81:5
+func MonomorphIsPrim(name string) bool {
+	return MonomorphPrimCode(name) != ""
+}
+
+// Osty: toolchain/monomorph.osty:87:5
+func MonomorphLengthPrefix(text string) string {
+	return fmt.Sprintf("%d%s", monomorphByteLength(text), text)
+}
+
+// Osty: toolchain/monomorph.osty:94:5
+func MonomorphNestedName(components []string) string {
+	body := ""
+	for _, c := range components {
+		body += c
+	}
+	return "N" + body + "E"
+}
+
+// Osty: toolchain/monomorph.osty:105:5
+func MonomorphBuiltinNested(name string) string {
+	head := MonomorphLengthPrefix("osty")
+	tail := MonomorphLengthPrefix(name)
+	return "N" + head + tail + "E"
+}
+
+// Osty: toolchain/monomorph.osty:114:5
+func MonomorphBuiltinTemplate(name string, argCodes string) string {
+	head := MonomorphLengthPrefix("osty")
+	tail := MonomorphLengthPrefix(name)
+	return "N" + head + tail + "I" + argCodes + "EE"
+}
+
+// Osty: toolchain/monomorph.osty:124:5
+func MonomorphUserNested(pkg, name string) string {
+	head := MonomorphLengthPrefix(pkg)
+	tail := MonomorphLengthPrefix(name)
+	return "N" + head + tail + "E"
+}
+
+// Osty: toolchain/monomorph.osty:133:5
+func MonomorphTemplateArgs(codes []string) string {
+	if len(codes) == 0 {
+		return ""
+	}
+	body := ""
+	for _, c := range codes {
+		body += c
+	}
+	return "I" + body + "E"
+}
+
+// Osty: toolchain/monomorph.osty:145:5
+func MonomorphParamList(codes []string) string {
+	body := ""
+	for _, c := range codes {
+		body += c
+	}
+	return body
+}
+
+// Osty: toolchain/monomorph.osty:158:5
+func MonomorphMangleFn(req *MonomorphRequest) *MonomorphMangled {
+	if req == nil {
+		return &MonomorphMangled{}
+	}
+	nameEncoded := MonomorphMangleFnName(req.pkg, req.fnName)
+	targs := MonomorphTemplateArgs(req.typeArgCodes)
+	params := MonomorphParamList(req.paramTypeCodes)
+	return &MonomorphMangled{symbol: "_Z" + nameEncoded + targs + params}
+}
+
+// Osty: toolchain/monomorph.osty:168:5
+func MonomorphMangleFnName(pkg, name string) string {
+	if pkg == "" || pkg == "main" {
+		return MonomorphLengthPrefix(name)
+	}
+	pkgPart := MonomorphLengthPrefix(pkg)
+	namePart := MonomorphLengthPrefix(name)
+	return "N" + pkgPart + namePart + "E"
+}
+
+// Osty: toolchain/monomorph.osty:182:5
+func MonomorphDedupeKey(fnName, pkg string, typeArgCodes []string) string {
+	// Using the ASCII Unit Separator (0x1f) as a delimiter — it cannot
+	// appear in Osty source identifiers, so the concatenation stays
+	// injective over the inputs.
+	sep := "\x1f"
+	key := pkg + sep + fnName
+	for _, c := range typeArgCodes {
+		key += sep + c
+	}
+	return key
+}
+
+// Osty: toolchain/monomorph.osty:193:5
+func MonomorphShouldInstantiate(typeArgsLen, fnGenericsLen int) bool {
+	return typeArgsLen > 0 && typeArgsLen == fnGenericsLen
+}
+
+// monomorphByteLength mirrors std.strings.len's UTF-8 byte counting so
+// the length prefix produced by MonomorphLengthPrefix matches what an
+// Itanium demangler expects. Kept unexported because the public
+// surface is deliberately the Osty-authored API.
+func monomorphByteLength(s string) int {
+	return len(s)
+}

--- a/internal/ir/subst.go
+++ b/internal/ir/subst.go
@@ -1,0 +1,401 @@
+package ir
+
+// SubstEnv maps a generic type parameter name to its concrete
+// replacement Type. Backed by a plain map so callers can build it in
+// whatever order they need.
+type SubstEnv map[string]Type
+
+// SubstituteTypes walks an IR subtree and replaces every TypeVar whose
+// Name is present in env with a fresh clone of env[Name]. Mutation is
+// in place — callers that need to preserve the input tree should pass a
+// cloned copy (see Clone).
+//
+// A nil env is a no-op; a nil subtree is a no-op. The function does not
+// cross into sibling decls through symbol references; substitution stops
+// at the provided root.
+func SubstituteTypes(n Node, env SubstEnv) {
+	if n == nil || len(env) == 0 {
+		return
+	}
+	subst(n, env)
+}
+
+// substType replaces TypeVars in-place within t and returns the
+// potentially-replaced type. NamedType etc. are mutated in place so
+// structural identity is preserved for nested Args.
+func substType(t Type, env SubstEnv) Type {
+	if t == nil || len(env) == 0 {
+		return t
+	}
+	switch t := t.(type) {
+	case *TypeVar:
+		if rep, ok := env[t.Name]; ok {
+			return CloneType(rep)
+		}
+		return t
+	case *NamedType:
+		for i, a := range t.Args {
+			t.Args[i] = substType(a, env)
+		}
+		return t
+	case *OptionalType:
+		t.Inner = substType(t.Inner, env)
+		return t
+	case *TupleType:
+		for i, e := range t.Elems {
+			t.Elems[i] = substType(e, env)
+		}
+		return t
+	case *FnType:
+		for i, p := range t.Params {
+			t.Params[i] = substType(p, env)
+		}
+		t.Return = substType(t.Return, env)
+		return t
+	case *PrimType, *ErrType:
+		return t
+	}
+	return t
+}
+
+// substTypes replaces TypeVars in-place in a slice.
+func substTypes(ts []Type, env SubstEnv) {
+	for i, t := range ts {
+		ts[i] = substType(t, env)
+	}
+}
+
+// subst dispatches by node kind and substitutes both embedded Type
+// fields and recursively walks child nodes.
+func subst(n Node, env SubstEnv) {
+	switch n := n.(type) {
+
+	// ---- Module ----
+	case *Module:
+		for _, d := range n.Decls {
+			subst(d, env)
+		}
+		for _, s := range n.Script {
+			subst(s, env)
+		}
+
+	// ---- Decls ----
+	case *FnDecl:
+		n.Return = substType(n.Return, env)
+		for _, p := range n.Params {
+			subst(p, env)
+		}
+		if n.Body != nil {
+			subst(n.Body, env)
+		}
+	case *StructDecl:
+		for _, f := range n.Fields {
+			subst(f, env)
+		}
+		for _, m := range n.Methods {
+			subst(m, env)
+		}
+	case *EnumDecl:
+		for _, v := range n.Variants {
+			substTypes(v.Payload, env)
+		}
+		for _, m := range n.Methods {
+			subst(m, env)
+		}
+	case *LetDecl:
+		n.Type = substType(n.Type, env)
+		if n.Value != nil {
+			subst(n.Value, env)
+		}
+	case *InterfaceDecl:
+		substTypes(n.Extends, env)
+		for _, m := range n.Methods {
+			subst(m, env)
+		}
+	case *TypeAliasDecl:
+		n.Target = substType(n.Target, env)
+	case *UseDecl:
+		for _, d := range n.GoBody {
+			subst(d, env)
+		}
+
+	// ---- Decl sub-nodes ----
+	case *Param:
+		n.Type = substType(n.Type, env)
+		if n.Default != nil {
+			subst(n.Default, env)
+		}
+	case *Field:
+		n.Type = substType(n.Type, env)
+		if n.Default != nil {
+			subst(n.Default, env)
+		}
+
+	// ---- Stmts ----
+	case *Block:
+		for _, s := range n.Stmts {
+			subst(s, env)
+		}
+		if n.Result != nil {
+			subst(n.Result, env)
+		}
+	case *LetStmt:
+		n.Type = substType(n.Type, env)
+		if n.Value != nil {
+			subst(n.Value, env)
+		}
+	case *ExprStmt:
+		if n.X != nil {
+			subst(n.X, env)
+		}
+	case *AssignStmt:
+		for _, t := range n.Targets {
+			subst(t, env)
+		}
+		if n.Value != nil {
+			subst(n.Value, env)
+		}
+	case *ReturnStmt:
+		if n.Value != nil {
+			subst(n.Value, env)
+		}
+	case *BreakStmt, *ContinueStmt:
+		// leaves
+	case *IfStmt:
+		if n.Cond != nil {
+			subst(n.Cond, env)
+		}
+		if n.Then != nil {
+			subst(n.Then, env)
+		}
+		if n.Else != nil {
+			subst(n.Else, env)
+		}
+	case *ForStmt:
+		if n.Cond != nil {
+			subst(n.Cond, env)
+		}
+		if n.Iter != nil {
+			subst(n.Iter, env)
+		}
+		if n.Start != nil {
+			subst(n.Start, env)
+		}
+		if n.End != nil {
+			subst(n.End, env)
+		}
+		if n.Body != nil {
+			subst(n.Body, env)
+		}
+	case *DeferStmt:
+		if n.Body != nil {
+			subst(n.Body, env)
+		}
+	case *ChanSendStmt:
+		subst(n.Channel, env)
+		subst(n.Value, env)
+	case *MatchStmt:
+		subst(n.Scrutinee, env)
+		for _, a := range n.Arms {
+			substMatchArm(a, env)
+		}
+	case *ErrorStmt:
+		// leaf
+
+	// ---- Exprs with Type field (via Type() accessor) ----
+	case *IntLit:
+		n.T = substType(n.T, env)
+	case *FloatLit:
+		n.T = substType(n.T, env)
+	case *BoolLit, *CharLit, *ByteLit, *UnitLit:
+		// Primitive-only; no TypeVar possible.
+	case *StringLit:
+		for _, p := range n.Parts {
+			if !p.IsLit && p.Expr != nil {
+				subst(p.Expr, env)
+			}
+		}
+	case *Ident:
+		n.T = substType(n.T, env)
+		substTypes(n.TypeArgs, env)
+	case *UnaryExpr:
+		n.T = substType(n.T, env)
+		if n.X != nil {
+			subst(n.X, env)
+		}
+	case *BinaryExpr:
+		n.T = substType(n.T, env)
+		if n.Left != nil {
+			subst(n.Left, env)
+		}
+		if n.Right != nil {
+			subst(n.Right, env)
+		}
+	case *CallExpr:
+		n.T = substType(n.T, env)
+		substTypes(n.TypeArgs, env)
+		if n.Callee != nil {
+			subst(n.Callee, env)
+		}
+		for i := range n.Args {
+			if n.Args[i].Value != nil {
+				subst(n.Args[i].Value, env)
+			}
+		}
+	case *IntrinsicCall:
+		for i := range n.Args {
+			if n.Args[i].Value != nil {
+				subst(n.Args[i].Value, env)
+			}
+		}
+	case *MethodCall:
+		n.T = substType(n.T, env)
+		substTypes(n.TypeArgs, env)
+		if n.Receiver != nil {
+			subst(n.Receiver, env)
+		}
+		for i := range n.Args {
+			if n.Args[i].Value != nil {
+				subst(n.Args[i].Value, env)
+			}
+		}
+	case *ListLit:
+		n.Elem = substType(n.Elem, env)
+		for _, e := range n.Elems {
+			subst(e, env)
+		}
+	case *MapLit:
+		n.KeyT = substType(n.KeyT, env)
+		n.ValT = substType(n.ValT, env)
+		for i := range n.Entries {
+			if n.Entries[i].Key != nil {
+				subst(n.Entries[i].Key, env)
+			}
+			if n.Entries[i].Value != nil {
+				subst(n.Entries[i].Value, env)
+			}
+		}
+	case *TupleLit:
+		n.T = substType(n.T, env)
+		for _, e := range n.Elems {
+			subst(e, env)
+		}
+	case *StructLit:
+		n.T = substType(n.T, env)
+		for i := range n.Fields {
+			if n.Fields[i].Value != nil {
+				subst(n.Fields[i].Value, env)
+			}
+		}
+		if n.Spread != nil {
+			subst(n.Spread, env)
+		}
+	case *VariantLit:
+		n.T = substType(n.T, env)
+		for i := range n.Args {
+			if n.Args[i].Value != nil {
+				subst(n.Args[i].Value, env)
+			}
+		}
+	case *BlockExpr:
+		n.T = substType(n.T, env)
+		if n.Block != nil {
+			subst(n.Block, env)
+		}
+	case *IfExpr:
+		n.T = substType(n.T, env)
+		if n.Cond != nil {
+			subst(n.Cond, env)
+		}
+		if n.Then != nil {
+			subst(n.Then, env)
+		}
+		if n.Else != nil {
+			subst(n.Else, env)
+		}
+	case *IfLetExpr:
+		n.T = substType(n.T, env)
+		if n.Scrutinee != nil {
+			subst(n.Scrutinee, env)
+		}
+		if n.Then != nil {
+			subst(n.Then, env)
+		}
+		if n.Else != nil {
+			subst(n.Else, env)
+		}
+	case *MatchExpr:
+		n.T = substType(n.T, env)
+		if n.Scrutinee != nil {
+			subst(n.Scrutinee, env)
+		}
+		for _, a := range n.Arms {
+			substMatchArm(a, env)
+		}
+	case *FieldExpr:
+		n.T = substType(n.T, env)
+		if n.X != nil {
+			subst(n.X, env)
+		}
+	case *IndexExpr:
+		n.T = substType(n.T, env)
+		if n.X != nil {
+			subst(n.X, env)
+		}
+		if n.Index != nil {
+			subst(n.Index, env)
+		}
+	case *TupleAccess:
+		n.T = substType(n.T, env)
+		if n.X != nil {
+			subst(n.X, env)
+		}
+	case *RangeLit:
+		n.T = substType(n.T, env)
+		if n.Start != nil {
+			subst(n.Start, env)
+		}
+		if n.End != nil {
+			subst(n.End, env)
+		}
+	case *QuestionExpr:
+		n.T = substType(n.T, env)
+		if n.X != nil {
+			subst(n.X, env)
+		}
+	case *CoalesceExpr:
+		n.T = substType(n.T, env)
+		if n.Left != nil {
+			subst(n.Left, env)
+		}
+		if n.Right != nil {
+			subst(n.Right, env)
+		}
+	case *Closure:
+		n.Return = substType(n.Return, env)
+		n.T = substType(n.T, env)
+		for _, p := range n.Params {
+			subst(p, env)
+		}
+		for _, c := range n.Captures {
+			c.T = substType(c.T, env)
+		}
+		if n.Body != nil {
+			subst(n.Body, env)
+		}
+	case *ErrorExpr:
+		n.T = substType(n.T, env)
+	}
+}
+
+func substMatchArm(a *MatchArm, env SubstEnv) {
+	if a == nil {
+		return
+	}
+	if a.Guard != nil {
+		subst(a.Guard, env)
+	}
+	if a.Body != nil {
+		subst(a.Body, env)
+	}
+}

--- a/toolchain/monomorph.osty
+++ b/toolchain/monomorph.osty
@@ -1,0 +1,228 @@
+/// Generic monomorphization policy (Itanium ABI-compatible mangling +
+/// dedup key formatting). Pure functions consumed by the native LLVM
+/// backend; no emitter state or IR references escape this module. The
+/// Go-side walker pre-encodes IR types into short Itanium code strings
+/// by recursing on Type and feeding the results back into these
+/// assembly helpers.
+///
+/// Osty is the owner of the encoding table and of the symbol-assembly
+/// format; when either needs to change, change it here first and then
+/// refresh the Go-side snapshot in internal/llvmgen/monomorph_snapshot.go.
+
+/// MonomorphRequest is the Osty-side projection of a single specialization
+/// request. Go assembles the type codes and package path; Osty only ever
+/// sees strings.
+pub struct MonomorphRequest {
+    pub pkg: String,
+    pub fnName: String,
+    pub typeArgCodes: List<String>,
+    pub paramTypeCodes: List<String>,
+    pub returnTypeCode: String,
+}
+
+/// MonomorphMangled carries the final symbol string emitted into LLVM
+/// IR. Wrapped in a struct so the Go-side snapshot can add fields later
+/// (e.g. demangled hint) without changing the bridge signature.
+pub struct MonomorphMangled {
+    pub symbol: String,
+}
+
+/// monomorphPrimCode maps an Osty primitive source name to its Itanium
+/// ABI builtin-type code. Returns "" for non-primitives so callers can
+/// fall back to the nested / template encodings. The table mirrors
+/// LANG_SPEC_v0.4/02-type-system.md §2.2 plus the relevant C++ ABI
+/// encodings; Osty's canonical `Int` is platform-independent i64 and
+/// maps to `l` (C `long`) to distinguish it from explicit `Int64` (`x`).
+pub fn monomorphPrimCode(name: String) -> String {
+    if name == "Int" {
+        return "l"
+    }
+    if name == "Int8" {
+        return "a"
+    }
+    if name == "Int16" {
+        return "s"
+    }
+    if name == "Int32" {
+        return "i"
+    }
+    if name == "Int64" {
+        return "x"
+    }
+    if name == "UInt8" {
+        return "h"
+    }
+    if name == "UInt16" {
+        return "t"
+    }
+    if name == "UInt32" {
+        return "j"
+    }
+    if name == "UInt64" {
+        return "y"
+    }
+    if name == "Byte" {
+        return "h"
+    }
+    if name == "Float" {
+        return "d"
+    }
+    if name == "Float32" {
+        return "f"
+    }
+    if name == "Float64" {
+        return "d"
+    }
+    if name == "Bool" {
+        return "b"
+    }
+    if name == "Char" {
+        return "w"
+    }
+    if name == "Unit" {
+        return "v"
+    }
+    ""
+}
+
+/// monomorphIsPrim reports whether the given Osty source type name is
+/// in the primitive table and therefore encoded directly as a single
+/// letter code.
+pub fn monomorphIsPrim(name: String) -> Bool {
+    monomorphPrimCode(name) != ""
+}
+
+/// monomorphLengthPrefix emits a `<len><text>` Itanium source-name
+/// component. Length is measured in UTF-8 bytes to match the ABI
+/// specification.
+pub fn monomorphLengthPrefix(text: String) -> String {
+    let byteLen = stringByteLength(text)
+    "{byteLen}{text}"
+}
+
+/// monomorphNestedName wraps one or more `<len><name>` components in
+/// Itanium's `N...E` nested-name construct. The `components` list has
+/// already been assembled by the caller (Osty for simple cases, Go for
+/// the full package path when routed through the bridge).
+pub fn monomorphNestedName(components: List<String>) -> String {
+    let mut body = ""
+    for c in components {
+        body = "{body}{c}"
+    }
+    "N{body}E"
+}
+
+/// monomorphBuiltinNested produces the `N4osty<len><name>E` encoding
+/// used for Osty prelude aggregates (String, List, Option, Result,
+/// Map, Set, Bytes, Tuple). Used as a nested qualifier only; template
+/// args (if any) are appended by monomorphBuiltinTemplate.
+pub fn monomorphBuiltinNested(name: String) -> String {
+    let head = monomorphLengthPrefix("osty")
+    let tail = monomorphLengthPrefix(name)
+    "N{head}{tail}E"
+}
+
+/// monomorphBuiltinTemplate produces `N4osty<len><name>I<argCodes>E`
+/// for Osty prelude generic aggregates (List<T>, Option<T>, Tuple<...>
+/// etc.). `argCodes` is the comma-less concatenation of already-encoded
+/// type codes for the template arguments.
+pub fn monomorphBuiltinTemplate(name: String, argCodes: String) -> String {
+    let head = monomorphLengthPrefix("osty")
+    let tail = monomorphLengthPrefix(name)
+    "N{head}{tail}I{argCodes}EE"
+}
+
+/// monomorphUserNested produces the `N<pkg-len><pkg><name-len><name>E`
+/// encoding used for user-declared struct / enum / alias types in the
+/// module's package. Callers pass the already-lowered package name
+/// (typically "main" for script files).
+pub fn monomorphUserNested(pkg: String, name: String) -> String {
+    let head = monomorphLengthPrefix(pkg)
+    let tail = monomorphLengthPrefix(name)
+    "N{head}{tail}E"
+}
+
+/// monomorphTemplateArgs wraps a list of encoded type codes in the
+/// `I...E` template-argument bracket. Empty input returns "" — callers
+/// should therefore skip inserting template args when a function has no
+/// generics.
+pub fn monomorphTemplateArgs(codes: List<String>) -> String {
+    if codes.len() == 0 {
+        return ""
+    }
+    let mut body = ""
+    for c in codes {
+        body = "{body}{c}"
+    }
+    "I{body}E"
+}
+
+/// monomorphParamList concatenates encoded parameter type codes without
+/// separator (Itanium's `<param-types>`). Empty input returns "".
+pub fn monomorphParamList(codes: List<String>) -> String {
+    let mut body = ""
+    for c in codes {
+        body = "{body}{c}"
+    }
+    body
+}
+
+/// monomorphMangleFn assembles the final `_Z…` symbol from its parts.
+/// Template arguments appear between the unqualified name and the
+/// parameter list, matching the Itanium C++ ABI
+/// (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-type).
+/// When a function has no template args the template bracket is
+/// omitted — such calls should not be routed through this function in
+/// the first place, but the code stays safe.
+///
+/// Packages other than "main" are wrapped in an Itanium nested name
+/// `N<pkg><name>E`; bare "main" falls back to the unscoped
+/// `<name-len><name>` form so test fixtures stay readable in
+/// demanglers (`c++filt` prints `foo` instead of `main::foo`).
+pub fn monomorphMangleFn(req: MonomorphRequest) -> MonomorphMangled {
+    let nameEncoded = monomorphMangleFnName(req.pkg, req.fnName)
+    let targs = monomorphTemplateArgs(req.typeArgCodes)
+    let params = monomorphParamList(req.paramTypeCodes)
+    let symbol = "_Z{nameEncoded}{targs}{params}"
+    MonomorphMangled { symbol }
+}
+
+/// monomorphMangleFnName produces the `<name-encoded>` portion of a
+/// mangled function symbol. Kept public so Go-side monomorph tests can
+/// assert the split between name encoding and template-arg wrapping.
+pub fn monomorphMangleFnName(pkg: String, name: String) -> String {
+    if pkg == "" || pkg == "main" {
+        return monomorphLengthPrefix(name)
+    }
+    let pkgPart = monomorphLengthPrefix(pkg)
+    let namePart = monomorphLengthPrefix(name)
+    "N{pkgPart}{namePart}E"
+}
+
+/// monomorphDedupeKey returns a stable unique string for a specialization
+/// request. Used by the Go-side worklist to skip duplicate enqueues.
+/// The `\u{1f}` (Unit Separator) byte cannot appear in source identifiers
+/// so the concatenation stays injective.
+pub fn monomorphDedupeKey(fnName: String, pkg: String, typeArgCodes: List<String>) -> String {
+    let mut key = "{pkg}\u{1f}{fnName}"
+    for c in typeArgCodes {
+        key = "{key}\u{1f}{c}"
+    }
+    key
+}
+
+/// monomorphShouldInstantiate answers "should this call site be routed
+/// through the monomorph queue?". Returns false when the call has no
+/// type arguments (non-generic) or when the arg count mismatches the
+/// declared generic count (malformed checker output — let the backend's
+/// usual paths handle it).
+pub fn monomorphShouldInstantiate(typeArgsLen: Int, fnGenericsLen: Int) -> Bool {
+    typeArgsLen > 0 && typeArgsLen == fnGenericsLen
+}
+
+/// stringByteLength returns the UTF-8 byte length of a string. Matches
+/// std.strings.len's implementation so the Itanium length prefix agrees
+/// with what a demangler expects.
+fn stringByteLength(s: String) -> Int {
+    s.bytes().len()
+}


### PR DESCRIPTION
## Summary

LLVM 백엔드 제네릭 monomorphization의 Phase 1(기반 엔진) 구현.
제네릭 free function 호출을 IR→IR 변환 패스에서 specialized 복사본으로 전개하며, Osty가 인코딩 정책 owner, Go IR 패키지가 메커니즘 소유.

## 배경

- v0.4 스펙(`LANG_SPEC_v0.4/02-type-system.md` §2.7.3)이 monomorphization을 공식 컴파일 모델로 확정
- 프론트엔드는 이미 완전 지원 — checker가 `check.Result.Instantiations`에 call site별 concrete type args 기록, `internal/ir/lower.go:991-1004`가 `CallExpr.TypeArgs`로 threading
- LLVM 백엔드는 그동안 제네릭 함수를 \"generic functions are not supported\" 진단으로 거부 (`internal/llvmgen/llvmgen.go:1321`, `toolchain/llvmgen.osty:1241-1246`)
- Legacy `internal/gen/monomorph.go`에 Go 백엔드용 참조 구현이 있지만 LLVM은 별도 필요

## 변경 내용

**Osty 정책 (신규)**
- `toolchain/monomorph.osty`: Itanium ABI 계열 primitive type code 표, 심볼 조립 규칙(`_Z<name><I targs E><params>`), dedup key 포맷. emitter state를 잡지 않는 pure function만.

**Go IR 메커니즘 (신규)**
- `internal/ir/monomorph_snapshot.go`: 위 Osty 소스의 손-번역 시드. CLAUDE.md의 self-host seed 패턴을 따름.
- `internal/ir/clone.go`: IR node deep-copy. primitive type singleton은 공유, 다른 모든 노드는 fresh allocation. generic body를 (fn, typeArgs) 튜플별로 복제하는 전제.
- `internal/ir/subst.go`: TypeVar → concrete type 치환. expression의 T 필드, NamedType.Args, FnType, OptionalType, TupleType 재귀. in-place 수정이므로 Clone 이후 호출.
- `internal/ir/monomorph.go`: `Monomorphize(mod *Module) (*Module, []error)` 공개 엔트리.
  1. 제네릭 free FnDecl 인덱스
  2. 비-제네릭 decl + script 복사, seed 스캔으로 워크리스트 초기화
  3. Fixed-point drain: clone + subst + rescan. 중첩된 generic call이 발견되면 큐에 append
  4. 호출되지 않은 generic fn은 §2.7.3 \"header-like\" semantics 대로 drop

## 스코프

| 상태 | 항목 |
|------|-----|
| ✅ | 제네릭 free function: `fn id<T>(x: T) -> T`, `fn max<T: Ordered>(a:T, b:T) -> T` |
| ✅ | composite type-arg: `List<T>`, `Option<T>`, `Tuple<T1,T2>` |
| ✅ | 중첩 instantiation (outer generic이 inner generic 호출) |
| ✅ | dedup (동일한 (fn, typeArgs) 튜플은 한 번만 specialize) |
| ❌ Phase 2+ | 제네릭 struct/enum/interface 선언 |
| ❌ Phase 2+ | 제네릭 method (기존 unsupported diagnostic 경로 유지) |
| ❌ Phase 2+ | bare function-pointer turbofish (`let f = id::<Int>`) |

## 후속 PR (Phase 1 나머지)

이번 PR은 A/B 스테이지만. C/D는 별도:
- C1: `GenerateModule` 진입점에 `ir.Monomorphize` 호출 삽입
- C2: `ir.Validate`에 post-monomorph 불변 assert (TypeVar/Generics 0개)
- C3: `internal/ir/doc.go`의 threading gap 주석 제거
- D1-D4: IR golden + LLVM `.ll` 스냅샷 테스트, `testdata/spec/positive/02-types.osty` max 호출 추가

## Test plan
- [x] `go build ./...` 성공
- [x] `go vet ./internal/ir/...` 0 warnings
- [x] `go test ./internal/ir/... -count=1` 통과 (기존 테스트 regression 없음)
- [ ] (후속 PR) golden 테스트로 Monomorphize 출력 고정
- [ ] (후속 PR) `.ll` 스냅샷으로 `_Z...` 심볼 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)