### PR TITLE
feat: Phase A — canonical identity 타입 (NodeKey/SymbolID/TypeID)

### DIFF
--- a/internal/query/osty/hash.go
+++ b/internal/query/osty/hash.go
@@ -191,112 +191,27 @@ func primarySpanOffset(d *diag.Diagnostic) int {
 	return -1
 }
 
-// ---- Symbols ----
+// ---- Symbols & Types ----
+//
+// Symbols and types have content-hash IDs computed once in their
+// home packages ([resolve.Symbol.ID], [types.ID]). The hash.go file
+// writes those precomputed [32]byte identities into the hasher
+// instead of re-serializing each symbol / type's fields. This keeps
+// per-query-run hashing to simple byte appends.
 
-// hashSymbol serializes a resolver symbol by its semantic identity —
-// name, kind, declaration position, visibility, package origin. This
-// is crucial for resolver early cutoff: two ResolvePackage runs over
-// equivalent source produce fresh *Symbol pointers but identical
-// semantic tuples.
 func hashSymbol(h *stableHasher, s *resolve.Symbol) {
 	if s == nil {
 		h.byte(0)
 		return
 	}
 	h.byte(1)
-	h.str(s.Name)
-	h.byte(byte(s.Kind))
-	h.pos(s.Pos)
-	h.bool(s.Pub)
-	if s.Package != nil {
-		h.byte(1)
-		h.str(s.Package.Dir)
-	} else {
-		h.byte(0)
-	}
-	// Decl's concrete type is 1-to-1 with Symbol.Kind (SymFn↔FnDecl,
-	// SymStruct↔StructDecl, ...), so hashing Decl's type tag would be
-	// redundant with the Kind byte above. A nil-vs-set distinction
-	// is the only extra signal worth preserving: builtins have
-	// Decl == nil.
-	if s.Decl == nil {
-		h.byte(0)
-	} else {
-		h.byte(1)
-	}
+	id := s.ID()
+	h.h.Write(id[:])
 }
 
-// ---- Types ----
-
-// hashType serializes a semantic type by structure. The generic
-// parameter TypeVar references its declaring Symbol by the same
-// symbol-hash used above; Named types include both the declaring
-// symbol and the recursive argument types.
 func hashType(h *stableHasher, t types.Type) {
-	if t == nil {
-		h.byte(0)
-		return
-	}
-	switch tt := t.(type) {
-	case *types.Primitive:
-		h.byte(1)
-		h.byte(byte(tt.Kind))
-	case *types.Untyped:
-		h.byte(2)
-		h.byte(byte(tt.Kind))
-	case *types.Tuple:
-		h.byte(3)
-		h.u32(uint32(len(tt.Elems)))
-		for _, e := range tt.Elems {
-			hashType(h, e)
-		}
-	case *types.Optional:
-		h.byte(4)
-		hashType(h, tt.Inner)
-	case *types.FnType:
-		h.byte(5)
-		h.u32(uint32(len(tt.Params)))
-		for _, p := range tt.Params {
-			hashType(h, p)
-		}
-		hashType(h, tt.Return)
-	case *types.Named:
-		h.byte(6)
-		hashSymbol(h, tt.Sym)
-		h.u32(uint32(len(tt.Args)))
-		for _, a := range tt.Args {
-			hashType(h, a)
-		}
-	case *types.TypeVar:
-		h.byte(7)
-		hashSymbol(h, tt.Sym)
-		h.u32(uint32(len(tt.Bounds)))
-		for _, b := range tt.Bounds {
-			hashType(h, b)
-		}
-	case *types.Builder:
-		h.byte(8)
-		hashType(h, tt.Struct)
-		// Set membership: emit sorted names so permutation doesn't
-		// affect the hash.
-		names := make([]string, 0, len(tt.Set))
-		for n := range tt.Set {
-			names = append(names, n)
-		}
-		sort.Strings(names)
-		h.u32(uint32(len(names)))
-		for _, n := range names {
-			h.str(n)
-		}
-		h.bool(tt.Preloaded)
-	case *types.Error:
-		h.byte(9)
-	default:
-		// Unknown kind: fall back to a stable tag so we at least don't
-		// panic. Downstream cutoff loses precision for this case, but
-		// correctness is preserved.
-		h.byte(255)
-	}
+	id := types.ID(t)
+	h.h.Write(id[:])
 }
 
 // ---- ResolvePackage ----

--- a/internal/resolve/scope.go
+++ b/internal/resolve/scope.go
@@ -11,6 +11,8 @@
 package resolve
 
 import (
+	"sync"
+
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/token"
 )
@@ -109,6 +111,12 @@ type Symbol struct {
 	// deferred to the package manager), Package stays nil and the
 	// member-access code falls back to a permissive diagnostic.
 	Package *Package
+
+	// idOnce guards idCache. See ID() in symbolid.go — the cache
+	// holds the symbol's content-hash identity and is populated on
+	// first access.
+	idOnce  sync.Once
+	idCache SymbolID
 }
 
 // IsBuiltin returns true for prelude/primitive symbols.

--- a/internal/resolve/symbolid.go
+++ b/internal/resolve/symbolid.go
@@ -1,0 +1,78 @@
+package resolve
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+)
+
+// SymbolID is a content-addressable identity for a [Symbol]. Two
+// Symbol pointers allocated by different resolver runs over the same
+// source compare equal by ID even though their pointers differ.
+//
+// Callers that build cross-run indexes (incremental query caches,
+// reverse reference tables, on-disk symbol databases) key by ID
+// instead of by *Symbol pointer. For in-run lookup during a single
+// analysis, the existing pointer-keyed maps (`Result.Refs`,
+// `check.Result.SymTypes`, etc.) remain the fast path.
+type SymbolID [32]byte
+
+// ID returns the symbol's content-hash identity. Computed lazily on
+// first call and cached; subsequent calls are O(1). Safe to call from
+// multiple goroutines.
+//
+// The ID covers the fields that determine semantic identity:
+//
+//   - Name and Kind — a struct named Foo and an fn named Foo have
+//     distinct IDs.
+//   - Declaration position (byte offset) — two symbols named Foo
+//     declared at different offsets are distinct.
+//   - Visibility (Pub) — promoting a private to pub changes the ID.
+//   - Owning package directory — the same name defined in two
+//     packages has distinct IDs.
+//
+// The Decl's concrete AST type is NOT hashed separately: Kind is
+// 1-to-1 with the Decl type for non-builtin symbols.
+func (s *Symbol) ID() SymbolID {
+	if s == nil {
+		return SymbolID{}
+	}
+	s.idOnce.Do(func() { s.idCache = computeSymbolID(s) })
+	return s.idCache
+}
+
+func computeSymbolID(s *Symbol) SymbolID {
+	h := sha256.New()
+	writeLenBytes(h, []byte(s.Name))
+	h.Write([]byte{byte(s.Kind)})
+	writeU64(h, uint64(s.Pos.Offset))
+	if s.Pub {
+		h.Write([]byte{1})
+	} else {
+		h.Write([]byte{0})
+	}
+	if s.Package != nil {
+		writeLenBytes(h, []byte(s.Package.Dir))
+	} else {
+		writeLenBytes(h, nil)
+	}
+	var out SymbolID
+	h.Sum(out[:0])
+	return out
+}
+
+// writeLenBytes writes a length-prefixed byte slice so concatenated
+// fields can't collide ("ab" + "c" vs "a" + "bc").
+func writeLenBytes(h interface{ Write([]byte) (int, error) }, b []byte) {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(len(b)))
+	_, _ = h.Write(buf[:])
+	if len(b) > 0 {
+		_, _ = h.Write(b)
+	}
+}
+
+func writeU64(h interface{ Write([]byte) (int, error) }, v uint64) {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	_, _ = h.Write(buf[:])
+}

--- a/internal/resolve/symbolid_test.go
+++ b/internal/resolve/symbolid_test.go
@@ -1,0 +1,109 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/token"
+)
+
+// mkSym is a tiny helper for building Symbol values in this file's
+// ID tests. We deliberately don't use the resolver's own construction
+// paths — the point is to exercise ID() over known fields.
+func mkSym(name string, kind SymbolKind, offset int, pub bool, pkgDir string) *Symbol {
+	s := &Symbol{
+		Name: name,
+		Kind: kind,
+		Pos:  token.Pos{Offset: offset, Line: 1, Column: 1},
+		Pub:  pub,
+	}
+	if pkgDir != "" {
+		s.Package = &Package{Dir: pkgDir}
+	}
+	return s
+}
+
+func TestSymbolIDStableAcrossInstances(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg/a")
+	b := mkSym("Foo", SymStruct, 42, true, "/pkg/a")
+	if a.ID() != b.ID() {
+		t.Fatalf("same fields must produce same ID; got %x vs %x", a.ID(), b.ID())
+	}
+}
+
+func TestSymbolIDDistinguishesName(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	b := mkSym("Bar", SymStruct, 42, true, "/pkg")
+	if a.ID() == b.ID() {
+		t.Fatal("different Name must produce different ID")
+	}
+}
+
+func TestSymbolIDDistinguishesKind(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	b := mkSym("Foo", SymFn, 42, true, "/pkg")
+	if a.ID() == b.ID() {
+		t.Fatal("different Kind must produce different ID")
+	}
+}
+
+func TestSymbolIDDistinguishesPosition(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	b := mkSym("Foo", SymStruct, 99, true, "/pkg")
+	if a.ID() == b.ID() {
+		t.Fatal("different Pos.Offset must produce different ID")
+	}
+}
+
+func TestSymbolIDDistinguishesPub(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	b := mkSym("Foo", SymStruct, 42, false, "/pkg")
+	if a.ID() == b.ID() {
+		t.Fatal("different Pub must produce different ID")
+	}
+}
+
+func TestSymbolIDDistinguishesPackage(t *testing.T) {
+	a := mkSym("Foo", SymStruct, 42, true, "/pkg/a")
+	b := mkSym("Foo", SymStruct, 42, true, "/pkg/b")
+	if a.ID() == b.ID() {
+		t.Fatal("different Package.Dir must produce different ID")
+	}
+}
+
+func TestSymbolIDHandlesNilPackage(t *testing.T) {
+	a := mkSym("Foo", SymBuiltin, 0, true, "")
+	b := mkSym("Foo", SymBuiltin, 0, true, "")
+	if a.ID() != b.ID() {
+		t.Fatal("builtins with no package must still produce consistent ID")
+	}
+	// And differ from same-name symbol with a package.
+	c := mkSym("Foo", SymBuiltin, 0, true, "/pkg")
+	if a.ID() == c.ID() {
+		t.Fatal("nil Package must produce different ID than non-nil Package")
+	}
+}
+
+func TestSymbolIDNilSafe(t *testing.T) {
+	var s *Symbol
+	if got := s.ID(); got != (SymbolID{}) {
+		t.Fatalf("nil Symbol.ID() should be zero value, got %x", got)
+	}
+}
+
+func TestSymbolIDCachesResult(t *testing.T) {
+	s := mkSym("Foo", SymStruct, 42, true, "/pkg")
+	first := s.ID()
+	second := s.ID()
+	if first != second {
+		t.Fatal("repeat ID() calls must return identical cached value")
+	}
+	// Mutating fields after first ID() should NOT change cached ID —
+	// the contract is: ID reflects the symbol at the moment of first
+	// observation. Callers who want to re-hash a mutated symbol need
+	// to construct a fresh Symbol.
+	s.Name = "Bar"
+	third := s.ID()
+	if third != first {
+		t.Fatal("cached ID must not change after mutation; construct a new Symbol to re-hash")
+	}
+}

--- a/internal/token/nodekey.go
+++ b/internal/token/nodekey.go
@@ -1,0 +1,39 @@
+package token
+
+// NodeKey is a stable, content-addressable identifier for an AST node's
+// source position. Unlike a `*ast.Node` pointer, NodeKey is equal
+// across re-parses of the same source: the byte offset is a property
+// of the source text, not of the parser run.
+//
+// Callers building cross-run indexes (incremental query caches,
+// diff-aware LSP features, persistent on-disk indexes) should key by
+// NodeKey rather than by AST pointer. Within a single-file resolution
+// context [Offset] alone is unique; package-level consumers that
+// combine multiple files should use [PackageNodeKey] instead.
+type NodeKey struct {
+	// Offset is the byte offset into the source file at which the
+	// node's first token starts. Matches [Pos.Offset] of the node's
+	// Pos() value.
+	Offset int
+}
+
+// NodeKeyOf extracts a NodeKey from any positioned value. Callers
+// typically pass an AST node's Pos() result, but any token.Pos works.
+func NodeKeyOf(p Pos) NodeKey { return NodeKey{Offset: p.Offset} }
+
+// PackageNodeKey extends [NodeKey] with a file path, so package-level
+// maps whose files share overlapping offset ranges can key without
+// collisions. The path is typically the [PackageFile.Path] that owned
+// the node at parse time.
+type PackageNodeKey struct {
+	Path   string
+	Offset int
+}
+
+// PackageNodeKeyOf combines a file path and a position into a
+// [PackageNodeKey]. The path is caller-normalized (absolute path,
+// forward slashes) so different callers keying the same file hit the
+// same bucket.
+func PackageNodeKeyOf(path string, p Pos) PackageNodeKey {
+	return PackageNodeKey{Path: path, Offset: p.Offset}
+}

--- a/internal/token/nodekey_test.go
+++ b/internal/token/nodekey_test.go
@@ -1,0 +1,41 @@
+package token
+
+import "testing"
+
+func TestNodeKeyOfMirrorsOffset(t *testing.T) {
+	p := Pos{Offset: 42, Line: 7, Column: 3}
+	k := NodeKeyOf(p)
+	if k.Offset != 42 {
+		t.Fatalf("NodeKeyOf dropped offset: got %d", k.Offset)
+	}
+	// Line / Column intentionally not part of the key — offset is
+	// enough to disambiguate within a single file.
+}
+
+func TestNodeKeyEqualityAcrossConstructions(t *testing.T) {
+	a := NodeKey{Offset: 10}
+	b := NodeKeyOf(Pos{Offset: 10, Line: 2, Column: 5})
+	if a != b {
+		t.Fatalf("same offset must produce equal NodeKey; got %+v vs %+v", a, b)
+	}
+}
+
+func TestNodeKeyDistinctByOffset(t *testing.T) {
+	a := NodeKey{Offset: 10}
+	b := NodeKey{Offset: 11}
+	if a == b {
+		t.Fatal("different offsets must produce distinct NodeKey values")
+	}
+}
+
+func TestPackageNodeKeyCombinesPathAndOffset(t *testing.T) {
+	a := PackageNodeKeyOf("/pkg/a.osty", Pos{Offset: 10})
+	b := PackageNodeKeyOf("/pkg/b.osty", Pos{Offset: 10})
+	if a == b {
+		t.Fatal("same offset in different files must produce distinct PackageNodeKey")
+	}
+	c := PackageNodeKeyOf("/pkg/a.osty", Pos{Offset: 10})
+	if a != c {
+		t.Fatal("same path + offset must produce equal PackageNodeKey")
+	}
+}

--- a/internal/types/typeid.go
+++ b/internal/types/typeid.go
@@ -1,0 +1,119 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"sort"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+// TypeID is a content-addressable identity for a [Type]. Structurally
+// equal types (two `List<Int>` values built from the same prelude
+// symbols) share an ID; structurally distinct types differ.
+//
+// TypeID is intended for cross-run comparison: an incremental query
+// cache can compare two check results by walking their type maps and
+// comparing IDs, without keeping the original pointers alive.
+type TypeID [32]byte
+
+// ID returns the type's content-hash identity. Computed on every
+// call — types are internally pointer-shared in many cases, so
+// caching inside the type value would bloat every allocation. Callers
+// that hash many types in a loop should collect IDs into a slice
+// once and reuse them.
+func ID(t Type) TypeID {
+	h := sha256.New()
+	writeType(h, t)
+	var out TypeID
+	h.Sum(out[:0])
+	return out
+}
+
+// writeType serializes a type's structure into h. The tag bytes
+// (1..9) distinguish the kinds so different kinds with coincidentally
+// identical field writes can't collide.
+func writeType(h hashWriter, t Type) {
+	if t == nil {
+		h.Write([]byte{0})
+		return
+	}
+	switch tt := t.(type) {
+	case *Primitive:
+		h.Write([]byte{1, byte(tt.Kind)})
+	case *Untyped:
+		h.Write([]byte{2, byte(tt.Kind)})
+	case *Tuple:
+		h.Write([]byte{3})
+		writeU32(h, uint32(len(tt.Elems)))
+		for _, e := range tt.Elems {
+			writeType(h, e)
+		}
+	case *Optional:
+		h.Write([]byte{4})
+		writeType(h, tt.Inner)
+	case *FnType:
+		h.Write([]byte{5})
+		writeU32(h, uint32(len(tt.Params)))
+		for _, p := range tt.Params {
+			writeType(h, p)
+		}
+		writeType(h, tt.Return)
+	case *Named:
+		h.Write([]byte{6})
+		writeSymbolID(h, tt.Sym)
+		writeU32(h, uint32(len(tt.Args)))
+		for _, a := range tt.Args {
+			writeType(h, a)
+		}
+	case *TypeVar:
+		h.Write([]byte{7})
+		writeSymbolID(h, tt.Sym)
+		writeU32(h, uint32(len(tt.Bounds)))
+		for _, b := range tt.Bounds {
+			writeType(h, b)
+		}
+	case *Builder:
+		h.Write([]byte{8})
+		// Struct is a *Named; delegating captures its symbol + args.
+		writeType(h, tt.Struct)
+		names := make([]string, 0, len(tt.Set))
+		for n := range tt.Set {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		writeU32(h, uint32(len(names)))
+		for _, n := range names {
+			writeLenStr(h, n)
+		}
+		if tt.Preloaded {
+			h.Write([]byte{1})
+		} else {
+			h.Write([]byte{0})
+		}
+	case *Error:
+		h.Write([]byte{9})
+	default:
+		// Unknown type — write a sentinel tag so at least the ID is
+		// stable for this value, even if structurally opaque.
+		h.Write([]byte{255})
+	}
+}
+
+func writeSymbolID(h hashWriter, s *resolve.Symbol) {
+	id := s.ID()
+	h.Write(id[:])
+}
+
+func writeU32(h hashWriter, v uint32) {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], v)
+	_, _ = h.Write(buf[:])
+}
+
+func writeLenStr(h hashWriter, s string) {
+	writeU32(h, uint32(len(s)))
+	_, _ = h.Write([]byte(s))
+}
+
+type hashWriter interface{ Write([]byte) (int, error) }

--- a/internal/types/typeid_test.go
+++ b/internal/types/typeid_test.go
@@ -1,0 +1,127 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/token"
+)
+
+func mkNamed(name string, args ...Type) *Named {
+	return &Named{
+		Sym: &resolve.Symbol{
+			Name: name,
+			Kind: resolve.SymStruct,
+			Pos:  token.Pos{Offset: 1},
+			Pub:  true,
+		},
+		Args: args,
+	}
+}
+
+func TestTypeIDPrimitiveEquality(t *testing.T) {
+	a := &Primitive{Kind: PInt}
+	b := &Primitive{Kind: PInt}
+	if ID(a) != ID(b) {
+		t.Fatal("same-kind Primitive must hash equal")
+	}
+	c := &Primitive{Kind: PString}
+	if ID(a) == ID(c) {
+		t.Fatal("different-kind Primitive must hash distinctly")
+	}
+}
+
+func TestTypeIDTupleStructural(t *testing.T) {
+	a := &Tuple{Elems: []Type{&Primitive{Kind: PInt}, &Primitive{Kind: PString}}}
+	b := &Tuple{Elems: []Type{&Primitive{Kind: PInt}, &Primitive{Kind: PString}}}
+	c := &Tuple{Elems: []Type{&Primitive{Kind: PString}, &Primitive{Kind: PInt}}}
+	if ID(a) != ID(b) {
+		t.Fatal("same-shape Tuple must hash equal")
+	}
+	if ID(a) == ID(c) {
+		t.Fatal("element-order matters for Tuple hash")
+	}
+}
+
+func TestTypeIDOptional(t *testing.T) {
+	a := &Optional{Inner: &Primitive{Kind: PInt}}
+	b := &Optional{Inner: &Primitive{Kind: PInt}}
+	c := &Optional{Inner: &Primitive{Kind: PString}}
+	if ID(a) != ID(b) {
+		t.Fatal("same Inner Optional must hash equal")
+	}
+	if ID(a) == ID(c) {
+		t.Fatal("different Inner must hash distinctly")
+	}
+}
+
+func TestTypeIDFnType(t *testing.T) {
+	a := &FnType{
+		Params: []Type{&Primitive{Kind: PInt}},
+		Return: &Primitive{Kind: PString},
+	}
+	b := &FnType{
+		Params: []Type{&Primitive{Kind: PInt}},
+		Return: &Primitive{Kind: PString},
+	}
+	if ID(a) != ID(b) {
+		t.Fatal("structurally equal FnType must hash equal")
+	}
+	// Swap params / return — must differ.
+	c := &FnType{
+		Params: []Type{&Primitive{Kind: PString}},
+		Return: &Primitive{Kind: PInt},
+	}
+	if ID(a) == ID(c) {
+		t.Fatal("swapped param/return must hash distinctly")
+	}
+}
+
+func TestTypeIDNamedByDeclarationIdentity(t *testing.T) {
+	// Named types compare by declaring Symbol's ID.
+	a := mkNamed("List", &Primitive{Kind: PInt})
+	b := mkNamed("List", &Primitive{Kind: PInt})
+	if ID(a) != ID(b) {
+		t.Fatalf("Named with equivalent Sym+Args must hash equal; got %x vs %x", ID(a), ID(b))
+	}
+	// Different type argument.
+	c := mkNamed("List", &Primitive{Kind: PString})
+	if ID(a) == ID(c) {
+		t.Fatal("Named with different Args must hash distinctly")
+	}
+	// Different name.
+	d := mkNamed("Set", &Primitive{Kind: PInt})
+	if ID(a) == ID(d) {
+		t.Fatal("Named with different Sym must hash distinctly")
+	}
+}
+
+func TestTypeIDErrorSingleton(t *testing.T) {
+	a := &Error{}
+	b := &Error{}
+	if ID(a) != ID(b) {
+		t.Fatal("Error singleton must hash consistently")
+	}
+}
+
+func TestTypeIDNilHashesStably(t *testing.T) {
+	var a Type
+	var b Type
+	if ID(a) != ID(b) {
+		t.Fatal("nil Type must hash stably")
+	}
+	// Nil should differ from Error.
+	if ID(a) == ID(&Error{}) {
+		t.Fatal("nil must differ from Error")
+	}
+}
+
+func TestTypeIDKindTagsDontCollide(t *testing.T) {
+	// A single-element tuple and its element shouldn't collide by
+	// accident — tag bytes disambiguate kinds.
+	a := &Primitive{Kind: PInt}
+	b := &Tuple{Elems: []Type{&Primitive{Kind: PInt}}}
+	if ID(a) == ID(b) {
+		t.Fatal("Primitive and single-element Tuple must not collide")
+	}
+}


### PR DESCRIPTION
## Summary

Salsa 쿼리 엔진의 **포인터 신원 기반 맵 키 문제**(`map[*ast.Ident]*Symbol`, `map[*resolve.Symbol]types.Type` 등 — 재파싱마다 포인터가 바뀌어 cross-run 비교 불가)를 푸는 **Phase A (비침투적 foundation)**.

기존 맵 타입/소비자 코드는 **전혀 건드리지 않고** 옆에 content-addressable ID만 추가:

- \`token.NodeKey{Offset}\` — 바이트 오프셋 기반 stable key
- \`token.PackageNodeKey{Path, Offset}\` — 패키지 레벨 offset 충돌 방지
- \`resolve.SymbolID [32]byte\` — Symbol의 content hash, \`Symbol.ID()\`로 접근, sync.Once 캐시
- \`types.TypeID [32]byte\` — Type 구조의 content hash, \`types.ID(t)\` pure function

## 효과

\`internal/query/osty/hash.go\`의 \`hashSymbol\`/\`hashType\`가 5-write field serialize → 32바이트 ID append로 축소 (각 ~100줄 → 5줄). 쿼리 output 해시 계산이 precomputed ID 조합으로 바뀜.

Early-cutoff 기존 동작 유지:
- \`TestCutoffOnTrivialWhitespaceEdit\`: \`{Reruns:2 Cutoffs:1}\` ✓
- \`TestEngineBackedAnalyzeCutoffsOnWhitespaceEdit\`: \`{Reruns:2 Cutoffs:3}\` ✓

## 비침투성

기존 맵 타입(\`map[*ast.Ident]*Symbol\`, \`map[ast.Expr]types.Type\`, \`map[*resolve.Symbol]types.Type\`, \`map[*ast.CallExpr][]types.Type\`)과 소비자 코드(\`internal/lsp/*\`, \`internal/lint/*\`, \`internal/ir/*\`, \`internal/backend/*\`) **모두 unchanged**. 유일한 struct 변경은 \`resolve.Symbol\`에 \`idOnce sync.Once\` + \`idCache SymbolID\` 2 필드 추가.

## Phase B (후속 PR, 이번 범위 밖)

- 맵 타입을 NodeKey/SymbolID 기반으로 교체
- 모든 소비자 일괄 마이그레이션
- \`internal/selfhost/generated.go\` 재생성 필요 (Osty→Go 제너레이터 업데이트 선행)

## 주요 파일

- \`internal/token/nodekey.go\` (new) — NodeKey + PackageNodeKey
- \`internal/resolve/symbolid.go\` (new) — SymbolID + Symbol.ID()
- \`internal/resolve/scope.go\` — Symbol에 캐시 필드 2개 추가
- \`internal/types/typeid.go\` (new) — TypeID + types.ID()
- \`internal/query/osty/hash.go\` — hashSymbol/hashType가 ID 사용하도록 축소

## Test plan

- [x] \`go test ./internal/token/ ./internal/resolve/ ./internal/types/\` — 21 ID 테스트
- [x] \`go test ./internal/query/... ./internal/lsp/...\` — 엔진 + cutoff 회귀 없음
- [x] \`go build\` clean, \`go vet\` clean
- [x] 기존 \`TestCutoffOnTrivialWhitespaceEdit\` / \`TestEngineBackedAnalyzeCutoffs*\` 계속 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)