### PR TITLE
feat+fix: CST trailing trivia 분리 + 기존 에러 19개 해결 (runtime FFI · IR 왕복)

### DIFF
--- a/internal/cst/build.go
+++ b/internal/cst/build.go
@@ -17,9 +17,10 @@ import (
 //     statements are not yet structured. The public Red API does not depend
 //     on that structuring, so consumers can migrate when the native Green
 //     parser (blocked on the self-host generator) lands.
-//  3. Trivia attached as leading runs on tokens. Conservative policy: all
-//     trivia preceding a token is leading for that token. Tail trivia sits
-//     under the root via a zero-width GkErrorMissing sentinel.
+//  3. Trivia attached as leading and trailing runs on tokens. Runs between
+//     tokens split at the first newline or doc comment — see
+//     pairTriviaToTokens for the exact rule. Tail trivia after the last
+//     token sits under the root via a zero-width GkErrorMissing sentinel.
 //
 // Byte coverage: every source byte is reachable from the tree via either a
 // token's text or a trivia record. TestBuildRoundTrip enforces this.
@@ -35,7 +36,7 @@ func BuildFromParsed(src []byte, file *ast.File, toks []token.Token, trivias []T
 	for i, tr := range trivias {
 		triviaIDs[i] = arena.AddTrivia(tr)
 	}
-	leading, tailTrivia := pairTriviaToTokens(toks, trivias)
+	leading, trailing, tailTrivia := pairTriviaToTokens(toks, trivias)
 
 	entities := collectEntities(file)
 
@@ -47,12 +48,12 @@ func BuildFromParsed(src []byte, file *ast.File, toks []token.Token, trivias []T
 
 		// Orphan tokens before the entity attach to the file root.
 		for tokIdx < len(toks) && !isEOF(toks[tokIdx]) && toks[tokIdx].Pos.Offset < startOff {
-			emitToken(b, toks[tokIdx], src, leading[tokIdx], triviaIDs)
+			emitToken(b, toks[tokIdx], src, leading[tokIdx], trailing[tokIdx], triviaIDs)
 			tokIdx++
 		}
 		b.StartNode(ent.kind)
 		for tokIdx < len(toks) && !isEOF(toks[tokIdx]) && toks[tokIdx].Pos.Offset < endOff {
-			emitToken(b, toks[tokIdx], src, leading[tokIdx], triviaIDs)
+			emitToken(b, toks[tokIdx], src, leading[tokIdx], trailing[tokIdx], triviaIDs)
 			tokIdx++
 		}
 		b.FinishNode()
@@ -62,7 +63,7 @@ func BuildFromParsed(src []byte, file *ast.File, toks []token.Token, trivias []T
 		if isEOF(tk) {
 			break
 		}
-		emitToken(b, tk, src, leading[tokIdx], triviaIDs)
+		emitToken(b, tk, src, leading[tokIdx], trailing[tokIdx], triviaIDs)
 		tokIdx++
 	}
 
@@ -157,33 +158,123 @@ func stmtKind(s ast.Stmt) GreenKind {
 
 func isEOF(tk token.Token) bool { return tk.Kind == token.EOF }
 
-// pairTriviaToTokens assigns each trivia as leading for exactly one token.
-// Policy: every trivia whose span ends at or before a token's start becomes
-// that token's leading trivia. Trivia remaining after the last token is
-// returned separately as tailTrivia for root-level emission.
+// pairTriviaToTokens splits each trivia run into leading/trailing attachments.
 //
-// This is the conservative Phase-4 rule. A future "same-line trailing"
-// refinement will split runs on the token side of an intervening newline.
-func pairTriviaToTokens(toks []token.Token, trivias []Trivia) (leading [][]int, tailTrivia []int) {
+// Osty emits a real token.NEWLINE token for each significant line terminator,
+// so the line-ending `\n` is usually NOT trivia — it's its own token. Trivia
+// only includes whitespace, comments, and the EXTRA newlines that make blank
+// lines. The attachment rule reflects that structure:
+//
+//   - First non-EOF token: no previous token exists, so its entire preceding
+//     trivia run is leading (handles shebang, BOM, file-leading comments).
+//   - Previous token is NEWLINE: the run is on a logically new line, so the
+//     whole run goes to the next token's leading (or to file tail if there
+//     is no next token). A NEWLINE token never carries trailing trivia.
+//   - Previous token is a normal token: the run stays on the same logical
+//     line as the previous token (before the next NEWLINE token arrives),
+//     with one carveout — if the run contains a TriviaDocComment, everything
+//     from that doc comment onward flows forward to the next token's leading
+//     so `///` always documents the following declaration.
+func pairTriviaToTokens(toks []token.Token, trivias []Trivia) (leading, trailing [][]int, tailTrivia []int) {
 	leading = make([][]int, len(toks))
+	trailing = make([][]int, len(toks))
+
+	lastNonEOF := -1
+	for i, tk := range toks {
+		if !isEOF(tk) {
+			lastNonEOF = i
+		}
+	}
+
 	triIdx := 0
-	for ti, tk := range toks {
+	prevNonEOF := -1
+	for i, tk := range toks {
 		if isEOF(tk) {
 			break
 		}
-		start := tk.Pos.Offset
-		for triIdx < len(trivias) && trivias[triIdx].Offset+trivias[triIdx].Length <= start {
-			leading[ti] = append(leading[ti], triIdx)
+		// Collect the run of trivia that ends at or before this token's start.
+		runStart := triIdx
+		for triIdx < len(trivias) && trivias[triIdx].Offset+trivias[triIdx].Length <= tk.Pos.Offset {
 			triIdx++
 		}
+		runEnd := triIdx
+
+		switch {
+		case prevNonEOF < 0:
+			// First real token.
+			for k := runStart; k < runEnd; k++ {
+				leading[i] = append(leading[i], k)
+			}
+		case toks[prevNonEOF].Kind == token.NEWLINE:
+			// Previous token ended the line — the run is on the next line.
+			for k := runStart; k < runEnd; k++ {
+				leading[i] = append(leading[i], k)
+			}
+		default:
+			// Same-line trailing for the previous token, except that a doc
+			// comment in the run peels the remainder forward.
+			docAt := findFirstDocComment(trivias, runStart, runEnd)
+			if docAt < 0 {
+				for k := runStart; k < runEnd; k++ {
+					trailing[prevNonEOF] = append(trailing[prevNonEOF], k)
+				}
+			} else {
+				for k := runStart; k < docAt; k++ {
+					trailing[prevNonEOF] = append(trailing[prevNonEOF], k)
+				}
+				for k := docAt; k < runEnd; k++ {
+					leading[i] = append(leading[i], k)
+				}
+			}
+		}
+		prevNonEOF = i
 	}
-	for ; triIdx < len(trivias); triIdx++ {
-		tailTrivia = append(tailTrivia, triIdx)
+
+	// Tail: trivia after the last non-EOF token.
+	if lastNonEOF >= 0 && triIdx < len(trivias) {
+		if toks[lastNonEOF].Kind == token.NEWLINE {
+			// The last real token ended a line — everything after is tail.
+			for k := triIdx; k < len(trivias); k++ {
+				tailTrivia = append(tailTrivia, k)
+			}
+		} else {
+			docAt := findFirstDocComment(trivias, triIdx, len(trivias))
+			if docAt < 0 {
+				for k := triIdx; k < len(trivias); k++ {
+					trailing[lastNonEOF] = append(trailing[lastNonEOF], k)
+				}
+			} else {
+				for k := triIdx; k < docAt; k++ {
+					trailing[lastNonEOF] = append(trailing[lastNonEOF], k)
+				}
+				for k := docAt; k < len(trivias); k++ {
+					tailTrivia = append(tailTrivia, k)
+				}
+			}
+		}
+	} else {
+		// No non-EOF tokens: everything is tail.
+		for k := triIdx; k < len(trivias); k++ {
+			tailTrivia = append(tailTrivia, k)
+		}
 	}
-	return leading, tailTrivia
+	return leading, trailing, tailTrivia
 }
 
-func emitToken(b *GreenBuilder, tk token.Token, src []byte, leadingIdx []int, triviaIDs []int) {
+// findFirstDocComment returns the index of the first TriviaDocComment in
+// trivias[lo:hi), or -1 if none. Doc comments are the only in-run split point
+// — all other same-line trivia stays trailing of the previous token because
+// Osty's NEWLINE tokens, not TriviaNewline, mark line boundaries.
+func findFirstDocComment(trivias []Trivia, lo, hi int) int {
+	for k := lo; k < hi; k++ {
+		if trivias[k].Kind == TriviaDocComment {
+			return k
+		}
+	}
+	return -1
+}
+
+func emitToken(b *GreenBuilder, tk token.Token, src []byte, leadingIdx, trailingIdx []int, triviaIDs []int) {
 	width := tk.End.Offset - tk.Pos.Offset
 	if width < 0 {
 		width = 0
@@ -192,7 +283,9 @@ func emitToken(b *GreenBuilder, tk token.Token, src []byte, leadingIdx []int, tr
 	if tk.Pos.Offset >= 0 && tk.End.Offset <= len(src) && tk.Pos.Offset <= tk.End.Offset {
 		text = string(src[tk.Pos.Offset:tk.End.Offset])
 	}
-	b.Token(GkToken, int(tk.Kind), text, width, translateTriviaIDs(leadingIdx, triviaIDs), nil)
+	b.Token(GkToken, int(tk.Kind), text, width,
+		translateTriviaIDs(leadingIdx, triviaIDs),
+		translateTriviaIDs(trailingIdx, triviaIDs))
 }
 
 func translateTriviaIDs(indices []int, triviaIDs []int) []int {

--- a/internal/cst/build_test.go
+++ b/internal/cst/build_test.go
@@ -126,17 +126,229 @@ pub fn main() {}
 	}
 }
 
-// emitTreeBytes walks the tree in pre-order and concatenates each token's
-// leading trivia bytes followed by its text. Result must equal tree.Source.
-func emitTreeBytes(tree *cst.Tree) []byte {
-	src := tree.Source
-	out := make([]byte, 0, len(src))
+// TestBuildTrailingCommentInline checks that a same-line comment after a
+// real (non-NEWLINE) token ends up as trailing trivia on that token. This is
+// the central case the split policy exists to enable; pre-policy, the
+// comment was buried in the next line's leading.
+func TestBuildTrailingCommentInline(t *testing.T) {
+	const source = `let x = 1 // hi
+let y = 2
+`
+	tree := buildTreeFromSource(t, source)
+	tokens := collectRealTokens(tree)
+
+	oneTok, ok := findTokenByText(tokens, "1")
+	if !ok {
+		t.Fatal("expected a `1` token in the tree")
+	}
+	letIdx := findNthTokenByText(tokens, "let", 2)
+	if letIdx < 0 {
+		t.Fatal("expected a second `let` token in the tree")
+	}
+	secondLet := tokens[letIdx]
+
+	gotTexts := triviaTexts(tree, oneTok.TrailingTrivia)
+	gotKinds := triviaKinds(tree, oneTok.TrailingTrivia)
+	if !containsKind(gotKinds, cst.TriviaLineComment) {
+		t.Errorf("`1` trailing should contain the line comment; got kinds=%v texts=%q", gotKinds, gotTexts)
+	}
+
+	secondLeadKinds := triviaKinds(tree, secondLet.LeadingTrivia)
+	if containsKind(secondLeadKinds, cst.TriviaLineComment) {
+		t.Errorf("second `let` leading must not carry the inline comment; got kinds=%v", secondLeadKinds)
+	}
+}
+
+// TestBuildTrailingNewlineTokenCarriesNoTrailing verifies the NEWLINE-token
+// rule: trivia that sits after a NEWLINE token never becomes its trailing;
+// it flows to the next token's leading. This keeps "the line that just
+// ended" (the NEWLINE text alone) cleanly separated from "what's on the
+// next line" (trivia in the following token's leading).
+func TestBuildTrailingNewlineTokenCarriesNoTrailing(t *testing.T) {
+	const source = `fn a() {}
+
+fn b() {}
+`
+	tree := buildTreeFromSource(t, source)
+
+	// Blank-line extra newline must land on the second fn's leading, never
+	// on the NEWLINE token's trailing.
+	var sawBlankLineOnFn bool
+	var newlineTokensTrailed int
 	tree.Root().Walk(func(r cst.Red) bool {
-		if !r.IsToken() {
+		if !r.IsToken() || r.Kind() != cst.GkToken {
 			return true
 		}
 		tok := r.Token()
-		for _, triID := range tok.LeadingTrivia {
+		if tok.Text == "\n" {
+			if len(tok.TrailingTrivia) > 0 {
+				newlineTokensTrailed++
+			}
+		}
+		if tok.Text == "fn" && r.Offset() > 0 {
+			if containsKind(triviaKinds(tree, tok.LeadingTrivia), cst.TriviaNewline) {
+				sawBlankLineOnFn = true
+			}
+		}
+		return true
+	})
+
+	if newlineTokensTrailed != 0 {
+		t.Errorf("NEWLINE tokens must not carry trailing trivia; %d did", newlineTokensTrailed)
+	}
+	if !sawBlankLineOnFn {
+		t.Error("second `fn` leading should carry the blank-line TriviaNewline")
+	}
+}
+
+// TestBuildDocCommentAttachesToNext verifies the doc-comment carveout: `///`
+// always stays with the following declaration, even if the previous real
+// token would otherwise accumulate trailing trivia.
+func TestBuildDocCommentAttachesToNext(t *testing.T) {
+	const source = `let x = 1
+/// doc
+fn f() {}
+`
+	tree := buildTreeFromSource(t, source)
+	tokens := collectRealTokens(tree)
+
+	fnIdx := findNthTokenByText(tokens, "fn", 1)
+	if fnIdx < 0 {
+		t.Fatal("expected an `fn` token")
+	}
+	fnTok := tokens[fnIdx]
+
+	fnLeadKinds := triviaKinds(tree, fnTok.LeadingTrivia)
+	if !containsKind(fnLeadKinds, cst.TriviaDocComment) {
+		t.Errorf("`fn` leading should own the doc comment; got kinds=%v", fnLeadKinds)
+	}
+
+	// No real token's trailing should swallow the doc comment.
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() || r.Kind() != cst.GkToken {
+			return true
+		}
+		tok := r.Token()
+		if containsKind(triviaKinds(tree, tok.TrailingTrivia), cst.TriviaDocComment) {
+			t.Errorf("token %q trailing contains doc comment; doc must always lead the next decl", tok.Text)
+		}
+		return true
+	})
+}
+
+// TestBuildTailTriviaAfterNewline verifies that trivia following a trailing
+// NEWLINE token becomes file-tail trivia (under the GkErrorMissing sentinel
+// for now) rather than being attached as trailing of the NEWLINE. Round-trip
+// must still reproduce the source byte-for-byte.
+func TestBuildTailTriviaAfterNewline(t *testing.T) {
+	const source = "fn f() {}\n// tail\n"
+	tree := buildTreeFromSource(t, source)
+
+	var newlineTrailedLineComment bool
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() || r.Kind() != cst.GkToken {
+			return true
+		}
+		tok := r.Token()
+		if tok.Text == "\n" && containsKind(triviaKinds(tree, tok.TrailingTrivia), cst.TriviaLineComment) {
+			newlineTrailedLineComment = true
+		}
+		return true
+	})
+	if newlineTrailedLineComment {
+		t.Error("NEWLINE token must not carry a trailing line-comment; it belongs to file tail")
+	}
+
+	if got := string(emitTreeBytes(tree)); got != source {
+		t.Fatalf("round-trip mismatch:\nwant: %q\n got: %q", source, got)
+	}
+}
+
+// --- test helpers ---
+
+func buildTreeFromSource(t *testing.T, source string) *cst.Tree {
+	t.Helper()
+	tree, _ := selfhost.ParseCST([]byte(source))
+	if tree == nil {
+		t.Fatal("ParseCST returned nil tree")
+	}
+	return tree
+}
+
+func collectRealTokens(tree *cst.Tree) []cst.GreenToken {
+	var out []cst.GreenToken
+	tree.Root().Walk(func(r cst.Red) bool {
+		if r.IsToken() && r.Kind() == cst.GkToken {
+			out = append(out, r.Token())
+		}
+		return true
+	})
+	return out
+}
+
+func findTokenByText(tokens []cst.GreenToken, text string) (cst.GreenToken, bool) {
+	for _, tok := range tokens {
+		if tok.Text == text {
+			return tok, true
+		}
+	}
+	return cst.GreenToken{}, false
+}
+
+func findNthTokenByText(tokens []cst.GreenToken, text string, n int) int {
+	seen := 0
+	for i, tok := range tokens {
+		if tok.Text == text {
+			seen++
+			if seen == n {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func triviaTexts(tree *cst.Tree, ids []int) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		tri := tree.Arena.TriviaAt(id)
+		lo, hi := tri.Offset, tri.Offset+tri.Length
+		if lo < 0 || hi > len(tree.Source) {
+			out = append(out, "<oob>")
+			continue
+		}
+		out = append(out, string(tree.Source[lo:hi]))
+	}
+	return out
+}
+
+func triviaKinds(tree *cst.Tree, ids []int) []cst.TriviaKind {
+	out := make([]cst.TriviaKind, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, tree.Arena.TriviaAt(id).Kind)
+	}
+	return out
+}
+
+func containsKind(kinds []cst.TriviaKind, target cst.TriviaKind) bool {
+	for _, k := range kinds {
+		if k == target {
+			return true
+		}
+	}
+	return false
+}
+
+// emitTreeBytes walks the tree in pre-order and concatenates, for each token
+// leaf: leading trivia + text + trailing trivia. Result must equal
+// tree.Source. Trailing trivia is the addition over the pre-split-policy
+// implementation; omitting it here would break round-trip as soon as any
+// token carries same-line trailing trivia.
+func emitTreeBytes(tree *cst.Tree) []byte {
+	src := tree.Source
+	out := make([]byte, 0, len(src))
+	emitRun := func(indices []int) {
+		for _, triID := range indices {
 			tri := tree.Arena.TriviaAt(triID)
 			lo, hi := tri.Offset, tri.Offset+tri.Length
 			if lo < 0 {
@@ -149,7 +361,15 @@ func emitTreeBytes(tree *cst.Tree) []byte {
 				out = append(out, src[lo:hi]...)
 			}
 		}
+	}
+	tree.Root().Walk(func(r cst.Red) bool {
+		if !r.IsToken() {
+			return true
+		}
+		tok := r.Token()
+		emitRun(tok.LeadingTrivia)
 		out = append(out, tok.Text...)
+		emitRun(tok.TrailingTrivia)
 		return true
 	})
 	return out


### PR DESCRIPTION
이 PR 은 연속한 세션에서 **프론트엔드 CST 품질 개선**과 **기존 실패 테스트 19개 해결**을 묶어 올린다. 주제가 두 줄기라 커밋으로 분리되어 있음:

## 커밋 구성

1. **feat: CST trailing trivia 분리** (42c1f67) — \`BuildFromParsed\` 의 trivia 부착 정책 "전부 leading" → "같은 줄 trailing / 다음 줄 leading 분리". \`Token.TrailingTrivia\` 인프라 활성화.
2. **feat: GkEndOfFile + parser.ParseCST 파사드** (cbee802) — tail trivia 용 \`GkErrorMissing\` 해킹 제거, \`internal/parser\` 에 CST 파사드 노출.
3. **fix: runtime FFI dispatch + IR 왕복 수신자 mut 보존** (511c3d7) — 아래 "기존 에러 해결" 섹션 참조.
4. **chore: parse snapshot 드리프트 갱신 (15 files)** (0d0b826) — triple-quoted 파서 수정이 남긴 offset 시프트와 E0006 소실 반영.

## CST 작업 (커밋 1-2)

### 정책 (pairTriviaToTokens)

- **첫 토큰**: 앞선 run 전체 → leading (shebang/BOM/파일 선두 주석 처리)
- **이전이 \`token.NEWLINE\`**: run 전체 → 다음 토큰 leading (또는 tail). NEWLINE은 trailing을 가지지 않음
- **그 외**: 같은 줄 trailing 으로 이전 토큰에 귀속
- **\`TriviaDocComment\` 카브아웃**: \`///\` 는 항상 다음 선언 leading

Osty 가 \`\\n\` 을 실제 \`token.NEWLINE\` 로 방출한다는 구조(lexer ASI 경로)가 핵심 불변. 일반적 Roslyn 스타일 "첫 newline-trivia 로 분할" 규칙은 여기서 거의 의미가 없음 — 대부분의 \`\\n\` 이 trivia 가 아니라 토큰이기 때문.

### GkEndOfFile + parser.ParseCST

- \`GkEndOfFile\` kind 추가. \`IsLeaf=true\`, \`IsError=false\`. \`GkErrorMissing\` 은 진짜 "expected X here" 복구 마커 의미로만 쓰도록 분리.
- \`parser.ParseCST\` 파사드 — 상위 레이어(포매터/LSP)가 \`internal/selfhost\` 내부를 건너뛰고 \`internal/parser\` → \`internal/cst\` 경로로 접근.

## 기존 에러 해결 (커밋 3)

전체 스위트 failure **21 → 2**. 세 군데 버그가 대부분의 실패를 만들고 있었음:

### 1. selfhost/astbridge UseDeclNode 의 runtime FFI 감지 누락

docgen 쪽 generated.go 에는 \`if Path[0] == "runtime" → IsRuntimeFFI\` 로직이 있었는데 selfhost 쪽 generator 에 빠져서, 모든 AST 가 \`IsRuntimeFFI=false\` 로 기록됨. generator 템플릿 수정 + generated.go 재생성.

### 2. ir.lower 가 file.Uses 를 순회하지 않음

\`run()\` 이 \`file.Decls\` + \`file.Stmts\` 만 돌고 \`file.Uses\` 를 누락. 결과적으로 IR 모듈에 use 선언 0 개 → \`ir_module.legacyFileFromModule\` 로 복원된 AST 의 Uses 가 빈 슬라이스 → \`collectRuntimeFFI\` 가 빈 맵 → runtime FFI FieldExpr 호출이 LLVM015 로 터짐. \`file.Uses\` 를 Decl 앞에 순회하도록 보완.

### 3. ir.FnDecl 가 Receiver.Mut 을 소실

AST → IR 로우어링에서 receiver 정보 통째로 버림. IR → legacy AST 복원 시 \`Receiver.Mut=false\` 로 항상 재구성. \`mut self\` 메서드가 "assignment to immutable field" 진단으로 차단됨. \`FnDecl\` 에 \`RecvMut bool\` 한 필드 추가하고 lower/clone/legacy 세 경로에서 전파.

### 해결되는 실패

- \`internal/parser\`: \`TestParseRuntimeFFIUse\`
- \`internal/llvmgen\` (7개): \`TestGenerate{Safepoint,ManagedAggregateList,OptionalRuntimeFFIAlias,RuntimeFFIUsesRuntimeABI,UnknownRuntimeFFI,ForInOverTempManagedList,ManagedTempCallArg}\`
- \`internal/backend\` (6개): \`TestLLVMBackendBinary{Safepoints,AutoCollects,ForInOver,ManagedTempCallArg,ManagedListLoop,MutReceiverMethod}\`
- \`cmd/osty\` (4개): \`TestRunTestMain{PassesNativeLLVMTest,ReportsNativeLLVMFailure,ReportsNativeLLVMExpectOkFailure,PassesNativeLLVMManagedAggregateListTests}\`
- \`internal/selfhost\`: \`TestParseSnapshot\` (커밋 4 에서 처리)

## 남은 실패 2 개 (별건 PR 후보)

- \`cmd/osty/TestRunTestMainPassesNativeLLVMResultTests\` — LLVM 백엔드가 \`Result<T,E>\` 제네릭 인스턴스화 타입을 \`<error>\` 로 떨어뜨림.
- \`cmd/osty/TestRunTestMainPassesNativeLLVMTupleTableTests\` — 튜플 원소 리스트 리터럴에서 ptr vs 구조체 값 boxing 불일치.

둘 다 LLVM 백엔드의 제네릭 인스턴스화/박싱 레이어 미구현이라 스코프가 커서 이관.

## Test plan

- [x] \`go test ./internal/cst/...\` — 그린, 라운드트립 코퍼스 15 개 파일 byte-exact
- [x] \`go test ./internal/parser/...\` — 그린
- [x] \`go test ./internal/llvmgen/...\` — 그린
- [x] \`go test ./internal/backend/...\` — 그린
- [x] \`go test ./internal/selfhost/...\` — 그린
- [x] \`go test ./internal/ir/...\` — 그린
- [x] 전체 스위트: 2 개 실패 남음 (위 "남은 실패" 섹션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)