### PR TITLE
feat: Generic Monomorphization Phase 1 통합 + Phase 2 (struct/enum)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,10 +169,18 @@ per-symbol types in `Result.SymTypes`. Entry points mirror
 
 The main v0.4 front-end static guarantee hooks are wired here:
 
-- generic call sites are recorded in `Result.Instantiations`; this
-  originally fed demand-driven monomorphization in `internal/gen` and
-  remains available as front-end metadata while that legacy path is
-  retired,
+- generic call sites are recorded in `Result.Instantiations`; the IR
+  lowerer forwards these onto `ir.CallExpr.TypeArgs` and leaves struct
+  literal / variant / type-annotation arguments on the corresponding
+  `NamedType.Args` slots. `ir.Monomorphize` (invoked from
+  `backend.PrepareEntry` before `ir.Validate`) materializes one
+  specialization per reachable (generic fn, concrete type-args) tuple
+  *and* per (generic struct/enum, concrete type-args) tuple, so LLVM
+  only ever sees concrete symbols. Function symbols use Itanium
+  `_Z…` mangling; nominal type symbols use the `_ZTS…` track for easy
+  distinction. Method-local generic parameters, generic interface
+  declarations, and bare function-pointer turbofish stay out of scope
+  for this phase,
 - structural interface satisfaction checks composed interfaces,
   `Self`-typed signatures, generic receiver substitution, params, and
   generic bounds,

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -254,6 +254,24 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
   - exported symbol mangling
   - duplicate runtime/helper emission 제거
 - generic monomorphization 결과를 LLVM symbol로 materialize한다.
+  - Phase 1(generic free function)은 이미 구현되어 있다:
+    `toolchain/monomorph.osty`의 Itanium-호환 mangling 정책 +
+    `internal/ir.Monomorphize`가 `backend.PrepareEntry`에서 호출되어
+    LLVM 진입 시점에는 generic free fn이 concrete specialization으로
+    이미 lowered 되어 있다 (smoke: `TestGenerateModuleGenericIdentityMonomorphized`).
+  - Phase 2(generic struct/enum 선언 + struct-level method)도 IR
+    단계에서 구현되어 있다: `_ZTS…` 나미널-타입 mangling 트랙,
+    `rewriteType`이 StructLit/VariantLit/LetStmt/Field/Variant Payload
+    등 모든 NamedType slot을 재작성, dedupe 키는 fn 네임스페이스와
+    분리 (`MonomorphTypeDedupeKey`). Struct LLVM smoke 통과:
+    `TestGenerateModuleGenericStructPairMonomorphized`
+    (mangled nominal 타입이 aggregate로 emit). Enum variant-call E2E
+    smoke는 llvmgen의 legacy variant-lowering이 mangled enum 이름을
+    처리하도록 확장되기 전까지 skipped 상태로 두며 IR-level 테스트
+    `TestMonomorphizeGenericEnumSpecialization`이 행동을 잠근다.
+  - 남은 범위: generic interface 선언, method-local generic parameter,
+    bare function-pointer turbofish (`let f = id::<Int>`),
+    llvmgen enum variant-call lowering의 mangled 이름 지원.
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ coverage. The public compiler path is now native-only through the LLVM backend.
 | LSP (`internal/lsp`, wired as `osty lsp`) | done — hover, definition, formatting, documentSymbol, lint diagnostics, editor policy backed by toolchain sources |
 | Native LLVM backend (`internal/backend`, `internal/llvmgen`) | public backend path; scalar/control-flow/string smoke subset emits LLVM IR/object/binary, later phase 64-73 value/control-flow smoke expansion is documented, unsupported shapes report Osty-authored LLVM diagnostics |
 | Go transpiler (`internal/gen`) | bootstrap-only seed path compiled with `selfhostgen`; no longer exposed as a public backend |
-| Independent IR (`internal/ir`) | done — patterns, match, closures, struct/field/method |
+| Independent IR (`internal/ir`) | done — patterns, match, closures, struct/field/method, generic free-fn + generic struct/enum monomorphization with Itanium-mangled specializations (`ir.Monomorphize`, invoked from `backend.PrepareEntry`; fn symbols use `_Z…`, nominal types use `_ZTS…`) |
 | Project scaffolding (`internal/scaffold`, `osty new` / `osty init`) | done — `--bin`, `--lib`, `--workspace`, `--cli`, `--service` |
 | Manifest + lockfile + SemVer (`internal/manifest`, `lockfile`, `pkgmgr/semver`) | done (parse + validate + resolve) |
 | Build orchestrator (`osty build`) | done — manifest → front-end → native backend, profile/target/feature wiring, backend-aware artifact/cache paths |

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -25,8 +25,18 @@ func PrepareEntry(packageName, sourcePath string, file *ast.File, res *resolve.R
 		return entry, fmt.Errorf("backend: nil source file")
 	}
 	mod, issues := ir.Lower(packageName, file, res, chk)
-	entry.IR = mod
 	entry.IRIssues = append(entry.IRIssues, issues...)
+	// Monomorphize generic free functions in-place on the lowered module.
+	// The backend contract is "no TypeVar leaves IR once it reaches the
+	// emitter", so we run this transform before validation rather than
+	// leaving it to each backend. A nil input produces a nil output; keep
+	// the original module in that pathological case so the validator can
+	// still report its own issues below.
+	if monoMod, monoErrs := ir.Monomorphize(mod); monoMod != nil {
+		mod = monoMod
+		entry.IRIssues = append(entry.IRIssues, monoErrs...)
+	}
+	entry.IR = mod
 	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
 		entry.IRIssues = append(entry.IRIssues, validateErrs...)
 		return entry, errors.Join(validateErrs...)

--- a/internal/ir/clone_test.go
+++ b/internal/ir/clone_test.go
@@ -1,0 +1,159 @@
+package ir
+
+import "testing"
+
+// ==== CloneType ====
+
+func TestCloneTypePreservesSingletons(t *testing.T) {
+	// Primitive and ErrType singletons must not be duplicated — downstream
+	// code switches on pointer identity for fast dispatch.
+	cases := []Type{TInt, TString, TBool, TUnit, TNever, ErrTypeVal}
+	for _, orig := range cases {
+		if CloneType(orig) != orig {
+			t.Fatalf("CloneType duplicated singleton %T (%v)", orig, orig)
+		}
+	}
+}
+
+func TestCloneTypeNamedIsDeep(t *testing.T) {
+	orig := &NamedType{Name: "List", Args: []Type{TInt}, Builtin: true}
+	cp, ok := CloneType(orig).(*NamedType)
+	if !ok || cp == orig {
+		t.Fatalf("expected fresh *NamedType clone, got %T same=%v", CloneType(orig), cp == orig)
+	}
+	if cp.Name != "List" || !cp.Builtin || len(cp.Args) != 1 || cp.Args[0] != TInt {
+		t.Fatalf("clone lost field data: %+v", cp)
+	}
+	// Mutating the clone's Args slice must not leak back to the original.
+	cp.Args[0] = TString
+	if orig.Args[0] != TInt {
+		t.Fatalf("mutation on clone leaked to original Args[0]=%v", orig.Args[0])
+	}
+}
+
+func TestCloneTypeOptionalAndTuple(t *testing.T) {
+	opt := &OptionalType{Inner: &NamedType{Name: "Box", Args: []Type{TInt}}}
+	cp, ok := CloneType(opt).(*OptionalType)
+	if !ok || cp == opt {
+		t.Fatalf("expected fresh OptionalType clone")
+	}
+	if _, ok := cp.Inner.(*NamedType); !ok {
+		t.Fatalf("inner not cloned to NamedType, got %T", cp.Inner)
+	}
+	if cp.Inner == opt.Inner {
+		t.Fatalf("Inner pointer shared with original")
+	}
+
+	tup := &TupleType{Elems: []Type{TInt, &NamedType{Name: "X"}}}
+	cpT, ok := CloneType(tup).(*TupleType)
+	if !ok || cpT == tup {
+		t.Fatalf("expected fresh TupleType clone")
+	}
+	if len(cpT.Elems) != 2 || cpT.Elems[0] != TInt {
+		t.Fatalf("tuple elems lost: %+v", cpT.Elems)
+	}
+	if cpT.Elems[1] == tup.Elems[1] {
+		t.Fatalf("non-primitive tuple elem pointer shared with original")
+	}
+}
+
+func TestCloneTypeFnTypeDeep(t *testing.T) {
+	ft := &FnType{Params: []Type{TInt, &TypeVar{Name: "T"}}, Return: &TypeVar{Name: "T"}}
+	cp, ok := CloneType(ft).(*FnType)
+	if !ok || cp == ft {
+		t.Fatalf("expected fresh FnType clone")
+	}
+	if cp.Params[1] == ft.Params[1] {
+		t.Fatalf("FnType TypeVar param shared with original")
+	}
+	if cp.Return == ft.Return {
+		t.Fatalf("FnType return TypeVar shared with original")
+	}
+	if cp.Params[0] != TInt {
+		t.Fatalf("primitive param should still share singleton")
+	}
+}
+
+func TestCloneTypeVarCopiedWithFields(t *testing.T) {
+	orig := &TypeVar{Name: "T", Owner: "id"}
+	cp, ok := CloneType(orig).(*TypeVar)
+	if !ok || cp == orig {
+		t.Fatalf("expected fresh *TypeVar clone")
+	}
+	if cp.Name != "T" || cp.Owner != "id" {
+		t.Fatalf("TypeVar fields not preserved: %+v", cp)
+	}
+}
+
+func TestCloneTypeNilSafe(t *testing.T) {
+	if CloneType(nil) != nil {
+		t.Fatalf("CloneType(nil) should return nil")
+	}
+	if Clone(nil) != nil {
+		t.Fatalf("Clone(nil) should return nil")
+	}
+}
+
+// ==== Clone (nodes) ====
+
+func TestCloneFnDeclProducesIndependentBody(t *testing.T) {
+	orig := &FnDecl{
+		Name:   "id",
+		Return: TInt,
+		Params: []*Param{{Name: "x", Type: TInt}},
+		Body: &Block{Stmts: []Stmt{
+			&ReturnStmt{Value: &Ident{Name: "x", Kind: IdentParam, T: TInt}},
+		}},
+	}
+	cp, ok := Clone(orig).(*FnDecl)
+	if !ok || cp == orig {
+		t.Fatalf("expected fresh *FnDecl clone")
+	}
+	if cp.Body == orig.Body {
+		t.Fatalf("Body pointer should not be shared")
+	}
+	if cp.Params[0] == orig.Params[0] {
+		t.Fatalf("Param pointer should not be shared")
+	}
+	// Mutate the clone — original must stay intact.
+	cp.Body.Stmts = append(cp.Body.Stmts, &BreakStmt{})
+	if got := len(orig.Body.Stmts); got != 1 {
+		t.Fatalf("original body mutated (len=%d)", got)
+	}
+	cp.Name = "id_Int"
+	if orig.Name != "id" {
+		t.Fatalf("original name mutated: %q", orig.Name)
+	}
+}
+
+func TestCloneModuleDeclsNotShared(t *testing.T) {
+	fn := &FnDecl{Name: "f", Return: TUnit, Body: &Block{}}
+	mod := &Module{Package: "main", Decls: []Decl{fn}}
+	cp, ok := Clone(mod).(*Module)
+	if !ok || cp == mod {
+		t.Fatalf("expected fresh *Module clone")
+	}
+	if len(cp.Decls) != 1 || cp.Decls[0] == fn {
+		t.Fatalf("Decls element pointer shared with original")
+	}
+	cp.Decls = append(cp.Decls, &FnDecl{Name: "g", Return: TUnit})
+	if got := len(mod.Decls); got != 1 {
+		t.Fatalf("original Decls mutated (len=%d)", got)
+	}
+}
+
+func TestCloneIdentCarriesTypeArgs(t *testing.T) {
+	// Bare turbofish (`f::<Int>`) attaches type args to an Ident. Clone
+	// must not share the TypeArgs slice.
+	orig := &Ident{Name: "f", Kind: IdentFn, TypeArgs: []Type{&NamedType{Name: "X"}}, T: ErrTypeVal}
+	cp, ok := Clone(orig).(*Ident)
+	if !ok || cp == orig {
+		t.Fatalf("expected fresh Ident clone")
+	}
+	if len(cp.TypeArgs) != 1 {
+		t.Fatalf("TypeArgs lost: %+v", cp.TypeArgs)
+	}
+	if cp.TypeArgs[0] == orig.TypeArgs[0] {
+		t.Fatalf("non-primitive TypeArgs element shared with original")
+	}
+}

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -38,28 +38,44 @@ func Monomorphize(mod *Module) (*Module, []error) {
 		return nil, nil
 	}
 	state := &monoState{
-		pkg:            mod.Package,
-		out:            &Module{Package: mod.Package, SpanV: mod.SpanV},
-		genericsByName: map[string]*FnDecl{},
-		seen:           map[string]string{},
+		pkg:                  mod.Package,
+		out:                  &Module{Package: mod.Package, SpanV: mod.SpanV},
+		genericsByName:       map[string]*FnDecl{},
+		seen:                 map[string]string{},
+		genericStructsByName: map[string]*StructDecl{},
+		genericEnumsByName:   map[string]*EnumDecl{},
+		typeSeen:             map[string]string{},
 	}
 
-	// Pass 1: index generic free fns so the scanner can resolve
-	// callees against the original declarations without revisiting
-	// mod.Decls for each call site.
+	// Pass 1: index every generic top-level declaration so the scanner
+	// can resolve references against the original forms without
+	// revisiting mod.Decls for each call/type site. Generic free fns go
+	// in genericsByName; generic struct/enum declarations go in
+	// genericStructsByName / genericEnumsByName (Phase 2).
 	for _, d := range mod.Decls {
-		if fn, ok := d.(*FnDecl); ok && len(fn.Generics) > 0 {
-			state.genericsByName[fn.Name] = fn
+		switch x := d.(type) {
+		case *FnDecl:
+			if len(x.Generics) > 0 {
+				state.genericsByName[x.Name] = x
+			}
+		case *StructDecl:
+			if len(x.Generics) > 0 {
+				state.genericStructsByName[x.Name] = x
+			}
+		case *EnumDecl:
+			if len(x.Generics) > 0 {
+				state.genericEnumsByName[x.Name] = x
+			}
 		}
 	}
 
 	// Pass 2: copy non-generic decls into the output module (cloning so
 	// rewrites are isolated from the input), scan their bodies for
-	// initial instantiation requests, and append the script.
+	// initial instantiation requests, and append the script. Generic
+	// top-level declarations are dropped here; their specializations
+	// will be appended during worklist drain.
 	for _, d := range mod.Decls {
-		if fn, ok := d.(*FnDecl); ok && len(fn.Generics) > 0 {
-			// generic free fn — drop from output; specializations will
-			// be appended at the end.
+		if isGenericTopLevel(d) {
 			continue
 		}
 		out := cloneDecl(d)
@@ -72,16 +88,37 @@ func Monomorphize(mod *Module) (*Module, []error) {
 		state.scanStmt(cloned)
 	}
 
-	// Pass 3: drain the worklist. Each iteration clones an original
-	// generic fn, substitutes type parameters, scans its body for
-	// further instantiations (which append to the queue), and adds the
-	// specialization to the output.
-	for i := 0; i < len(state.queue); i++ {
-		rec := state.queue[i]
-		state.emitSpecialization(rec)
+	// Pass 3+4 (interleaved): drain both queues until neither grows.
+	// Emitting a specialization may discover further generic call sites
+	// (grows fn queue) or generic type references (grows type queue),
+	// so we loop until both reach a fixed point.
+	for len(state.queue) > 0 || len(state.typeQueue) > 0 {
+		for i := 0; i < len(state.queue); i++ {
+			state.emitSpecialization(state.queue[i])
+		}
+		state.queue = state.queue[:0]
+		for i := 0; i < len(state.typeQueue); i++ {
+			state.emitTypeSpecialization(state.typeQueue[i])
+		}
+		state.typeQueue = state.typeQueue[:0]
 	}
 
 	return state.out, state.errs
+}
+
+// isGenericTopLevel reports whether a top-level declaration carries
+// generic parameters and therefore must be replaced by concrete
+// specializations rather than copied verbatim into the output.
+func isGenericTopLevel(d Decl) bool {
+	switch x := d.(type) {
+	case *FnDecl:
+		return len(x.Generics) > 0
+	case *StructDecl:
+		return len(x.Generics) > 0
+	case *EnumDecl:
+		return len(x.Generics) > 0
+	}
+	return false
 }
 
 // monoState carries the per-module monomorphization bookkeeping.
@@ -96,6 +133,19 @@ type monoState struct {
 	// drain lets new entries appended during scanning be picked up.
 	queue []monoInstance
 	errs  []error
+
+	// Phase 2: generic nominal-type bookkeeping.
+	//
+	// genericStructsByName / genericEnumsByName index the original
+	// generic declarations so scanning can recognize a generic
+	// NamedType reference by source name.
+	genericStructsByName map[string]*StructDecl
+	genericEnumsByName   map[string]*EnumDecl
+	// typeSeen maps a MonomorphTypeDedupeKey to the mangled type-symbol
+	// so duplicate requests short-circuit.
+	typeSeen map[string]string
+	// typeQueue is the worklist of pending struct/enum specializations.
+	typeQueue []monoTypeInstance
 }
 
 // monoInstance is one pending free-fn specialization.
@@ -103,6 +153,18 @@ type monoInstance struct {
 	fn       *FnDecl
 	typeArgs []Type
 	mangled  string
+}
+
+// monoTypeInstance is one pending nominal-type specialization. Exactly
+// one of structDecl / enumDecl is non-nil; the other distinguishes the
+// emitter branch. typeArgs are the concrete types matching the
+// declaration's generics, and mangled is the `_ZTS…` symbol the engine
+// has already assigned and written to typeSeen.
+type monoTypeInstance struct {
+	structDecl *StructDecl
+	enumDecl   *EnumDecl
+	typeArgs   []Type
+	mangled    string
 }
 
 // addErr appends a non-fatal issue.
@@ -166,39 +228,402 @@ func (s *monoState) request(fn *FnDecl, typeArgs []Type) string {
 	return mangled
 }
 
+// requestStructType enqueues a (generic struct decl, concrete type-args)
+// pair for specialization and returns the mangled type-symbol the
+// caller should substitute at the reference site. Duplicate requests
+// short-circuit via the typeSeen map. Returns "" when the request is
+// malformed (arity mismatch, unresolved type parameters).
+func (s *monoState) requestStructType(decl *StructDecl, typeArgs []Type) string {
+	if decl == nil {
+		return ""
+	}
+	if !MonomorphShouldInstantiate(len(typeArgs), len(decl.Generics)) {
+		s.addErr("monomorph: arity mismatch for struct %s: %d type args vs %d generics",
+			decl.Name, len(typeArgs), len(decl.Generics))
+		return ""
+	}
+	for i, ta := range typeArgs {
+		if containsTypeVar(ta) {
+			s.addErr("monomorph: type arg %d of struct %s still contains a type variable (%s)",
+				i, decl.Name, typeString(ta))
+			return ""
+		}
+	}
+	typeArgCodes := make([]string, len(typeArgs))
+	for i, ta := range typeArgs {
+		typeArgCodes[i] = typeCodeOf(ta, s.pkg)
+	}
+	key := MonomorphTypeDedupeKey(decl.Name, s.pkg, typeArgCodes)
+	if mangled, ok := s.typeSeen[key]; ok {
+		return mangled
+	}
+	req := NewMonomorphTypeRequest(s.pkg, decl.Name, typeArgCodes)
+	mangled := MonomorphMangleType(req).Symbol()
+	// Important: record the mangled name *before* enqueueing so that a
+	// recursive field type (e.g. `struct List<T> { next: Option<List<T>>? }`)
+	// that requests the same specialization from inside the emitter hits
+	// the seen cache and terminates instead of looping.
+	s.typeSeen[key] = mangled
+	s.typeQueue = append(s.typeQueue, monoTypeInstance{
+		structDecl: decl,
+		typeArgs:   append([]Type(nil), typeArgs...),
+		mangled:    mangled,
+	})
+	return mangled
+}
+
+// requestEnumType is the enum counterpart of requestStructType.
+func (s *monoState) requestEnumType(decl *EnumDecl, typeArgs []Type) string {
+	if decl == nil {
+		return ""
+	}
+	if !MonomorphShouldInstantiate(len(typeArgs), len(decl.Generics)) {
+		s.addErr("monomorph: arity mismatch for enum %s: %d type args vs %d generics",
+			decl.Name, len(typeArgs), len(decl.Generics))
+		return ""
+	}
+	for i, ta := range typeArgs {
+		if containsTypeVar(ta) {
+			s.addErr("monomorph: type arg %d of enum %s still contains a type variable (%s)",
+				i, decl.Name, typeString(ta))
+			return ""
+		}
+	}
+	typeArgCodes := make([]string, len(typeArgs))
+	for i, ta := range typeArgs {
+		typeArgCodes[i] = typeCodeOf(ta, s.pkg)
+	}
+	key := MonomorphTypeDedupeKey(decl.Name, s.pkg, typeArgCodes)
+	if mangled, ok := s.typeSeen[key]; ok {
+		return mangled
+	}
+	req := NewMonomorphTypeRequest(s.pkg, decl.Name, typeArgCodes)
+	mangled := MonomorphMangleType(req).Symbol()
+	s.typeSeen[key] = mangled
+	s.typeQueue = append(s.typeQueue, monoTypeInstance{
+		enumDecl: decl,
+		typeArgs: append([]Type(nil), typeArgs...),
+		mangled:  mangled,
+	})
+	return mangled
+}
+
+// emitTypeSpecialization dispatches one queued nominal-type instance
+// to the appropriate struct/enum emitter.
+func (s *monoState) emitTypeSpecialization(rec monoTypeInstance) {
+	switch {
+	case rec.structDecl != nil:
+		s.emitStructSpecialization(rec)
+	case rec.enumDecl != nil:
+		s.emitEnumSpecialization(rec)
+	}
+}
+
+// emitStructSpecialization materializes one queued struct instance:
+// clones the original declaration, renames it to the mangled symbol,
+// substitutes type parameters inside fields and method signatures/bodies,
+// rewrites any surviving user-generic references (nested generics like
+// `Option<Pair<T, T>>` become `Option<_ZTSN…E>` after `T` is concretized),
+// drops any method carrying its own generics (Phase 3+ scope), scans
+// surviving method bodies for further generic call sites, and appends
+// the result to out.Decls.
+func (s *monoState) emitStructSpecialization(rec monoTypeInstance) {
+	clone := cloneStructDecl(rec.structDecl)
+	clone.Name = rec.mangled
+	clone.Generics = nil
+	env := buildSubstEnv(rec.structDecl.Generics, rec.typeArgs)
+	SubstituteTypes(clone, env)
+	for _, f := range clone.Fields {
+		if f == nil {
+			continue
+		}
+		f.Type = s.rewriteType(f.Type)
+	}
+	clone.Methods = s.keepNonGenericMethods(clone.Name, clone.Methods)
+	s.out.Decls = append(s.out.Decls, clone)
+}
+
+// emitEnumSpecialization is the enum counterpart of emitStructSpecialization.
+func (s *monoState) emitEnumSpecialization(rec monoTypeInstance) {
+	clone := cloneEnumDecl(rec.enumDecl)
+	clone.Name = rec.mangled
+	clone.Generics = nil
+	env := buildSubstEnv(rec.enumDecl.Generics, rec.typeArgs)
+	SubstituteTypes(clone, env)
+	for _, v := range clone.Variants {
+		if v == nil {
+			continue
+		}
+		for i, p := range v.Payload {
+			v.Payload[i] = s.rewriteType(p)
+		}
+	}
+	clone.Methods = s.keepNonGenericMethods(clone.Name, clone.Methods)
+	s.out.Decls = append(s.out.Decls, clone)
+}
+
+// rewriteType walks a Type tree top-down rewriting every generic
+// user-declared NamedType into a concrete `_ZTS…` mangled reference
+// and enqueueing the matching specialization on typeQueue. Because Go's
+// Type is an interface, caller-side reassignment at the parent slot
+// drives the traversal — the returned Type should be stored back into
+// the slot the original came from (e.g. `p.Type = s.rewriteType(p.Type)`).
+//
+// NamedType.Args are rewritten first (bottom-up) so nested generic
+// references (`Pair<Maybe<Bool>, …>`) encode their inner mangled names
+// into the outer request's type-arg codes.
+func (s *monoState) rewriteType(t Type) Type {
+	if t == nil {
+		return nil
+	}
+	switch x := t.(type) {
+	case *NamedType:
+		for i, a := range x.Args {
+			x.Args[i] = s.rewriteType(a)
+		}
+		if x.Builtin {
+			return x
+		}
+		// Only user-declared nominal types drive specialization.
+		// Concrete (non-generic) references like `Point` fall through
+		// unchanged — they were not indexed in Pass 1.
+		if len(x.Args) == 0 {
+			return x
+		}
+		if sd, ok := s.genericStructsByName[x.Name]; ok {
+			if mangled := s.requestStructType(sd, x.Args); mangled != "" {
+				return &NamedType{Name: mangled}
+			}
+		}
+		if ed, ok := s.genericEnumsByName[x.Name]; ok {
+			if mangled := s.requestEnumType(ed, x.Args); mangled != "" {
+				return &NamedType{Name: mangled}
+			}
+		}
+		return x
+	case *OptionalType:
+		x.Inner = s.rewriteType(x.Inner)
+		return x
+	case *TupleType:
+		for i, e := range x.Elems {
+			x.Elems[i] = s.rewriteType(e)
+		}
+		return x
+	case *FnType:
+		for i, p := range x.Params {
+			x.Params[i] = s.rewriteType(p)
+		}
+		x.Return = s.rewriteType(x.Return)
+		return x
+	}
+	return t
+}
+
+// rewriteExprType rewrites every Type-valued field on an expression
+// node (e.g. Expr.T, ListLit.Elem, MapLit.KeyT/ValT, Closure.Return/T,
+// Ident.TypeArgs, CallExpr.TypeArgs, …). For StructLit/VariantLit it
+// also syncs TypeName/Enum with the mangled nominal name so later
+// lowering stages agree on the specialization to dispatch against.
+//
+// Called at the top of scanExpr so every visited expression has its
+// type slots brought up to date before the recursion drills further —
+// including deeply nested expressions inside closures and match arms.
+func (s *monoState) rewriteExprType(e Expr) {
+	if e == nil {
+		return
+	}
+	switch x := e.(type) {
+	case *IntLit:
+		x.T = s.rewriteType(x.T)
+	case *FloatLit:
+		x.T = s.rewriteType(x.T)
+	case *Ident:
+		x.T = s.rewriteType(x.T)
+		for i, ta := range x.TypeArgs {
+			x.TypeArgs[i] = s.rewriteType(ta)
+		}
+	case *UnaryExpr:
+		x.T = s.rewriteType(x.T)
+	case *BinaryExpr:
+		x.T = s.rewriteType(x.T)
+	case *CallExpr:
+		x.T = s.rewriteType(x.T)
+		for i, ta := range x.TypeArgs {
+			x.TypeArgs[i] = s.rewriteType(ta)
+		}
+	case *MethodCall:
+		x.T = s.rewriteType(x.T)
+		for i, ta := range x.TypeArgs {
+			x.TypeArgs[i] = s.rewriteType(ta)
+		}
+	case *ListLit:
+		x.Elem = s.rewriteType(x.Elem)
+	case *MapLit:
+		x.KeyT = s.rewriteType(x.KeyT)
+		x.ValT = s.rewriteType(x.ValT)
+	case *TupleLit:
+		x.T = s.rewriteType(x.T)
+	case *StructLit:
+		x.T = s.rewriteType(x.T)
+		if nt, ok := x.T.(*NamedType); ok && nt.Name != "" {
+			// Only override TypeName when the rewrite actually changed
+			// the nominal: a non-generic struct lit keeps its source
+			// name so existing llvmgen dispatch stays intact.
+			if x.TypeName != nt.Name {
+				x.TypeName = nt.Name
+			}
+		}
+	case *VariantLit:
+		x.T = s.rewriteType(x.T)
+		if nt, ok := x.T.(*NamedType); ok && nt.Name != "" {
+			if x.Enum != "" && x.Enum != nt.Name {
+				x.Enum = nt.Name
+			}
+		}
+	case *BlockExpr:
+		x.T = s.rewriteType(x.T)
+	case *IfExpr:
+		x.T = s.rewriteType(x.T)
+	case *IfLetExpr:
+		x.T = s.rewriteType(x.T)
+	case *MatchExpr:
+		x.T = s.rewriteType(x.T)
+	case *FieldExpr:
+		x.T = s.rewriteType(x.T)
+	case *IndexExpr:
+		x.T = s.rewriteType(x.T)
+	case *TupleAccess:
+		x.T = s.rewriteType(x.T)
+	case *RangeLit:
+		x.T = s.rewriteType(x.T)
+	case *QuestionExpr:
+		x.T = s.rewriteType(x.T)
+	case *CoalesceExpr:
+		x.T = s.rewriteType(x.T)
+	case *Closure:
+		x.Return = s.rewriteType(x.Return)
+		x.T = s.rewriteType(x.T)
+		for _, p := range x.Params {
+			if p == nil {
+				continue
+			}
+			p.Type = s.rewriteType(p.Type)
+		}
+		for _, c := range x.Captures {
+			if c == nil {
+				continue
+			}
+			c.T = s.rewriteType(c.T)
+		}
+	case *ErrorExpr:
+		x.T = s.rewriteType(x.T)
+	}
+}
+
+// keepNonGenericMethods filters a specialization's method list: methods
+// carrying their own generic parameters are dropped with a warning
+// (method-local generics are Phase 3+ scope). Surviving methods have
+// their bodies scanned so any nested generic call sites they contain
+// still drive the worklist.
+func (s *monoState) keepNonGenericMethods(owner string, methods []*FnDecl) []*FnDecl {
+	if len(methods) == 0 {
+		return methods
+	}
+	kept := methods[:0]
+	for _, m := range methods {
+		if m == nil {
+			continue
+		}
+		if len(m.Generics) > 0 {
+			s.addErr("monomorph: method %s.%s has method-local generics; skipped (Phase 3+ scope)",
+				owner, m.Name)
+			continue
+		}
+		// Rewrite the post-substitution signature so any user-generic
+		// references surviving `SubstituteTypes` (nested or built-in
+		// wrapping like `Option<Pair<T, T>>`) become mangled symbols,
+		// then scan the body for call/type sites nested inside.
+		s.rewriteFnSignature(m)
+		s.scanFnBody(m)
+		kept = append(kept, m)
+	}
+	return kept
+}
+
 // emitSpecialization materializes one queued free-fn instance: clones
 // the original body, substitutes type parameters, rewrites nested
-// generic calls, and appends the result to out.Decls.
+// generic references in the post-substitution signature (so a return
+// type like `Pair<T, T>` mangled into `Pair<Int, Int>` further lowers
+// to the `_ZTS…` nominal), scans the body, and appends the result.
 func (s *monoState) emitSpecialization(rec monoInstance) {
 	clone := cloneFnDecl(rec.fn)
 	clone.Name = rec.mangled
 	clone.Generics = nil
 	env := buildSubstEnv(rec.fn.Generics, rec.typeArgs)
 	SubstituteTypes(clone, env)
+	s.rewriteFnSignature(clone)
 	s.scanFnBody(clone)
 	s.out.Decls = append(s.out.Decls, clone)
 }
 
 // scanDecl walks a top-level declaration looking for generic call sites
-// that need rewriting in-place. Only non-generic bodies are scanned here
-// — generic bodies are handled by emitSpecialization after substitution.
+// and generic type references that need rewriting in-place. Only
+// non-generic bodies are scanned here — generic bodies are handled by
+// emitSpecialization / emitStructSpecialization / emitEnumSpecialization
+// after substitution. Declaration-level Type fields (function signatures,
+// struct fields, enum payloads) are not visited by scanExpr, so we
+// rewrite them explicitly here.
 func (s *monoState) scanDecl(d Decl) {
 	switch d := d.(type) {
 	case *FnDecl:
+		s.rewriteFnSignature(d)
 		s.scanFnBody(d)
 	case *StructDecl:
+		for _, f := range d.Fields {
+			if f != nil {
+				f.Type = s.rewriteType(f.Type)
+			}
+		}
 		for _, m := range d.Methods {
+			s.rewriteFnSignature(m)
 			s.scanFnBody(m)
 		}
 	case *EnumDecl:
+		for _, v := range d.Variants {
+			if v == nil {
+				continue
+			}
+			for i, p := range v.Payload {
+				v.Payload[i] = s.rewriteType(p)
+			}
+		}
 		for _, m := range d.Methods {
+			s.rewriteFnSignature(m)
 			s.scanFnBody(m)
 		}
 	case *LetDecl:
+		d.Type = s.rewriteType(d.Type)
 		if d.Value != nil {
 			s.scanExpr(d.Value)
 		}
 	}
+}
+
+// rewriteFnSignature rewrites the param and return type slots of a
+// function declaration. Used by scanDecl and by the struct/enum
+// specialization emitters to keep method signatures concrete once their
+// owner has been substituted.
+func (s *monoState) rewriteFnSignature(fn *FnDecl) {
+	if fn == nil {
+		return
+	}
+	for _, p := range fn.Params {
+		if p == nil {
+			continue
+		}
+		p.Type = s.rewriteType(p.Type)
+	}
+	fn.Return = s.rewriteType(fn.Return)
 }
 
 // scanFnBody walks a function body in place rewriting every generic
@@ -228,6 +653,7 @@ func (s *monoState) scanStmt(st Stmt) {
 	case *Block:
 		s.scanBlock(st)
 	case *LetStmt:
+		st.Type = s.rewriteType(st.Type)
 		if st.Value != nil {
 			s.scanExpr(st.Value)
 		}
@@ -283,6 +709,11 @@ func (s *monoState) scanExpr(e Expr) {
 	if e == nil {
 		return
 	}
+	// Phase 2: rewrite every generic NamedType reference buried in the
+	// expression's own type fields (e.g. StructLit.T, CallExpr.T,
+	// Ident.T). Safe to run before the case dispatch — idempotent on
+	// already-mangled references.
+	s.rewriteExprType(e)
 	switch e := e.(type) {
 	case *CallExpr:
 		// Rewrite generic call to mangled specialization.
@@ -489,6 +920,18 @@ func typeCodeOf(t Type, pkg string) string {
 		}
 		if t.Builtin {
 			return builtinTypeCode(t, pkg)
+		}
+		// Phase 2: a user-declared generic reference carries its concrete
+		// type arguments via NamedType.Args. Encode them through the
+		// template-nested form so a generic free function whose type arg
+		// is itself user-generic (e.g. `id::<Pair<Int,Int>>`) gets a
+		// unique mangled fn symbol per concrete Pair instantiation.
+		if len(t.Args) > 0 {
+			var sb strings.Builder
+			for _, a := range t.Args {
+				sb.WriteString(typeCodeOf(a, pkg))
+			}
+			return MonomorphUserTemplateNested(firstNonEmpty(pkg, "main"), t.Name, sb.String())
 		}
 		return MonomorphUserNested(firstNonEmpty(pkg, "main"), t.Name)
 	case *OptionalType:

--- a/internal/ir/monomorph_snapshot.go
+++ b/internal/ir/monomorph_snapshot.go
@@ -6,6 +6,10 @@
 // before the toolchain is itself re-translated.
 //
 // Keep this file in lockstep with toolchain/monomorph.osty.
+// Phase 2 additions: MonomorphTypeRequest, MonomorphMangleType,
+// MonomorphMangleTypeName, MonomorphUserTemplateNested, and
+// MonomorphTypeDedupeKey handle the nominal-type symbol track
+// (`_ZTS…`) used for generic struct/enum specializations.
 
 package ir
 
@@ -15,16 +19,23 @@ import (
 
 // Osty: toolchain/monomorph.osty:14:5
 type MonomorphRequest struct {
-	pkg             string
-	fnName          string
-	typeArgCodes    []string
-	paramTypeCodes  []string
-	returnTypeCode  string
+	pkg            string
+	fnName         string
+	typeArgCodes   []string
+	paramTypeCodes []string
+	returnTypeCode string
 }
 
 // Osty: toolchain/monomorph.osty:25:5
 type MonomorphMangled struct {
 	symbol string
+}
+
+// Osty: toolchain/monomorph.osty (Phase 2, MonomorphTypeRequest)
+type MonomorphTypeRequest struct {
+	pkg          string
+	typeName     string
+	typeArgCodes []string
 }
 
 // Symbol returns the mangled LLVM symbol string. Exposed so the IR
@@ -47,6 +58,17 @@ func NewMonomorphRequest(pkg, fnName string, typeArgCodes, paramTypeCodes []stri
 		typeArgCodes:   append([]string(nil), typeArgCodes...),
 		paramTypeCodes: append([]string(nil), paramTypeCodes...),
 		returnTypeCode: returnTypeCode,
+	}
+}
+
+// NewMonomorphTypeRequest is the struct/enum counterpart of
+// NewMonomorphRequest. Defensively copies typeArgCodes so callers can
+// reuse the caller's slice without worrying about aliasing.
+func NewMonomorphTypeRequest(pkg, typeName string, typeArgCodes []string) *MonomorphTypeRequest {
+	return &MonomorphTypeRequest{
+		pkg:          pkg,
+		typeName:     typeName,
+		typeArgCodes: append([]string(nil), typeArgCodes...),
 	}
 }
 
@@ -143,6 +165,13 @@ func MonomorphUserNested(pkg, name string) string {
 	return "N" + head + tail + "E"
 }
 
+// Osty: toolchain/monomorph.osty (Phase 2, monomorphUserTemplateNested)
+func MonomorphUserTemplateNested(pkg, name, argCodes string) string {
+	head := MonomorphLengthPrefix(pkg)
+	tail := MonomorphLengthPrefix(name)
+	return "N" + head + tail + "I" + argCodes + "EE"
+}
+
 // Osty: toolchain/monomorph.osty:133:5
 func MonomorphTemplateArgs(codes []string) string {
 	if len(codes) == 0 {
@@ -185,6 +214,33 @@ func MonomorphMangleFnName(pkg, name string) string {
 	return "N" + pkgPart + namePart + "E"
 }
 
+// Osty: toolchain/monomorph.osty (Phase 2, monomorphMangleType)
+func MonomorphMangleType(req *MonomorphTypeRequest) *MonomorphMangled {
+	if req == nil {
+		return &MonomorphMangled{}
+	}
+	body := MonomorphMangleTypeName(req.pkg, req.typeName, req.typeArgCodes)
+	return &MonomorphMangled{symbol: "_ZTS" + body}
+}
+
+// Osty: toolchain/monomorph.osty (Phase 2, monomorphMangleTypeName)
+func MonomorphMangleTypeName(pkg, name string, typeArgCodes []string) string {
+	// Type symbols always carry a package segment so demanglers can
+	// print a qualified name; fall back to "main" for script files that
+	// leave the package blank.
+	actualPkg := pkg
+	if actualPkg == "" {
+		actualPkg = "main"
+	}
+	pkgPart := MonomorphLengthPrefix(actualPkg)
+	namePart := MonomorphLengthPrefix(name)
+	args := ""
+	for _, c := range typeArgCodes {
+		args += c
+	}
+	return "N" + pkgPart + namePart + "I" + args + "EE"
+}
+
 // Osty: toolchain/monomorph.osty:182:5
 func MonomorphDedupeKey(fnName, pkg string, typeArgCodes []string) string {
 	// Using the ASCII Unit Separator (0x1f) as a delimiter — it cannot
@@ -192,6 +248,20 @@ func MonomorphDedupeKey(fnName, pkg string, typeArgCodes []string) string {
 	// injective over the inputs.
 	sep := "\x1f"
 	key := pkg + sep + fnName
+	for _, c := range typeArgCodes {
+		key += sep + c
+	}
+	return key
+}
+
+// Osty: toolchain/monomorph.osty (Phase 2, monomorphTypeDedupeKey)
+//
+// Separate namespace from MonomorphDedupeKey so a generic function and
+// a generic struct sharing a source name cannot collide in the engine's
+// seen-map.
+func MonomorphTypeDedupeKey(typeName, pkg string, typeArgCodes []string) string {
+	sep := "\x1f"
+	key := pkg + sep + "type" + sep + typeName
 	for _, c := range typeArgCodes {
 		key += sep + c
 	}

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -1,0 +1,1394 @@
+package ir
+
+import (
+	"strings"
+	"testing"
+)
+
+// genericIdentity constructs an `fn id<T>(x: T) -> T { x }` declaration.
+// Exposed as a helper so the individual tests stay focused on what they
+// exercise rather than on boilerplate IR construction.
+func genericIdentity() *FnDecl {
+	tv := &TypeVar{Name: "T"}
+	return &FnDecl{
+		Name:     "id",
+		Generics: []*TypeParam{{Name: "T"}},
+		Params:   []*Param{{Name: "x", Type: tv}},
+		Return:   tv,
+		Body: &Block{
+			Result: &Ident{Name: "x", Kind: IdentParam, T: tv},
+		},
+	}
+}
+
+// genericCall produces an `id::<T>(value)` call expression used inside a
+// caller's body.
+func genericCall(typeArg Type, value Expr, resultT Type) *CallExpr {
+	return &CallExpr{
+		Callee:   &Ident{Name: "id", Kind: IdentFn, T: ErrTypeVal},
+		TypeArgs: []Type{typeArg},
+		Args:     []Arg{{Value: value}},
+		T:        resultT,
+	}
+}
+
+// ==== Module-level shape ====
+
+func TestMonomorphizeNilModule(t *testing.T) {
+	out, errs := Monomorphize(nil)
+	if out != nil {
+		t.Fatalf("expected nil module for nil input, got %+v", out)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestMonomorphizeEmptyModulePassesThrough(t *testing.T) {
+	in := &Module{Package: "main"}
+	out, errs := Monomorphize(in)
+	if out == nil {
+		t.Fatalf("expected non-nil output module")
+	}
+	if out.Package != "main" {
+		t.Fatalf("expected package copy, got %q", out.Package)
+	}
+	if len(out.Decls) != 0 || len(out.Script) != 0 {
+		t.Fatalf("expected empty output, got Decls=%d Script=%d", len(out.Decls), len(out.Script))
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestMonomorphizeUnusedGenericIsDropped(t *testing.T) {
+	// A generic free fn with no concrete callers must not end up in the
+	// output — demand-driven spec semantics.
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity()}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(out.Decls) != 0 {
+		t.Fatalf("expected 0 decls after dropping unused generic, got %d: %+v", len(out.Decls), out.Decls)
+	}
+}
+
+// ==== Single specialization ====
+
+func TestMonomorphizeSingleFreeFnSpecialization(t *testing.T) {
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: genericCall(TInt, intLit("5"), TInt)},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), caller}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	// Expected layout: caller followed by the specialization at the tail.
+	if got := len(out.Decls); got != 2 {
+		t.Fatalf("expected 2 output decls, got %d", got)
+	}
+	mainCp, ok := out.Decls[0].(*FnDecl)
+	if !ok || mainCp.Name != "main" {
+		t.Fatalf("expected main at [0], got %T (%v)", out.Decls[0], out.Decls[0])
+	}
+	spec, ok := out.Decls[1].(*FnDecl)
+	if !ok {
+		t.Fatalf("expected FnDecl specialization at [1], got %T", out.Decls[1])
+	}
+	if len(spec.Generics) != 0 {
+		t.Fatalf("specialization must shed generics, got %d", len(spec.Generics))
+	}
+	if spec.Params[0].Type != TInt || spec.Return != TInt {
+		t.Fatalf("specialization signature not substituted: params[0]=%T return=%T",
+			spec.Params[0].Type, spec.Return)
+	}
+	if bodyIdent, ok := spec.Body.Result.(*Ident); !ok || bodyIdent.T != TInt {
+		t.Fatalf("specialization body ident type not concrete")
+	}
+
+	callCp := mainCp.Body.Stmts[0].(*ExprStmt).X.(*CallExpr)
+	if len(callCp.TypeArgs) != 0 {
+		t.Fatalf("call site TypeArgs should be cleared, got %+v", callCp.TypeArgs)
+	}
+	id, ok := callCp.Callee.(*Ident)
+	if !ok {
+		t.Fatalf("call callee should be Ident, got %T", callCp.Callee)
+	}
+	if id.Name != spec.Name {
+		t.Fatalf("call site name not rewritten: got %q, expected %q", id.Name, spec.Name)
+	}
+	// Original generic fn must be untouched — Monomorphize returns a new
+	// Module rather than mutating the input.
+	origFn := in.Decls[0].(*FnDecl)
+	if origFn.Name != "id" || len(origFn.Generics) != 1 {
+		t.Fatalf("original module mutated: %+v", origFn)
+	}
+}
+
+// ==== Dedup ====
+
+func TestMonomorphizeDedupesSameTypeArgs(t *testing.T) {
+	// Two `id::<Int>(...)` calls must share one specialization.
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: genericCall(TInt, intLit("5"), TInt)},
+			&ExprStmt{X: genericCall(TInt, intLit("6"), TInt)},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), caller}}
+	out, _ := Monomorphize(in)
+	specCount := 0
+	var mangled string
+	for _, d := range out.Decls {
+		fn, ok := d.(*FnDecl)
+		if !ok || fn.Name == "main" {
+			continue
+		}
+		specCount++
+		mangled = fn.Name
+	}
+	if specCount != 1 {
+		t.Fatalf("expected exactly 1 specialization for duplicate calls, got %d", specCount)
+	}
+	mainCp := out.Decls[0].(*FnDecl)
+	for i, stmt := range mainCp.Body.Stmts {
+		id := stmt.(*ExprStmt).X.(*CallExpr).Callee.(*Ident)
+		if id.Name != mangled {
+			t.Fatalf("call %d: want mangled %q, got %q", i, mangled, id.Name)
+		}
+	}
+}
+
+func TestMonomorphizeDistinctTypeArgsMakeTwoSpecializations(t *testing.T) {
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: genericCall(TInt, intLit("5"), TInt)},
+			&ExprStmt{X: genericCall(TString, strLit("hi"), TString)},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), caller}}
+	out, _ := Monomorphize(in)
+	var mangledNames []string
+	for _, d := range out.Decls {
+		if fn, ok := d.(*FnDecl); ok && fn.Name != "main" {
+			mangledNames = append(mangledNames, fn.Name)
+		}
+	}
+	if len(mangledNames) != 2 {
+		t.Fatalf("expected 2 specializations for distinct type args, got %d (%v)", len(mangledNames), mangledNames)
+	}
+	if mangledNames[0] == mangledNames[1] {
+		t.Fatalf("specializations must have distinct mangled names, got duplicate %q", mangledNames[0])
+	}
+}
+
+// ==== Non-generic paths ====
+
+func TestMonomorphizePreservesNonGenericDecls(t *testing.T) {
+	// A plain fn with a plain call must be copied as-is with no extra
+	// specialization artifacts.
+	f := &FnDecl{
+		Name:   "add1",
+		Return: TInt,
+		Params: []*Param{{Name: "x", Type: TInt}},
+		Body: &Block{Result: &BinaryExpr{
+			Op:    BinAdd,
+			Left:  &Ident{Name: "x", Kind: IdentParam, T: TInt},
+			Right: intLit("1"),
+			T:     TInt,
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{f}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(out.Decls) != 1 {
+		t.Fatalf("expected 1 decl preserved, got %d", len(out.Decls))
+	}
+	cp := out.Decls[0].(*FnDecl)
+	if cp == f {
+		t.Fatalf("non-generic fn should be cloned, not aliased")
+	}
+	if cp.Name != "add1" || len(cp.Generics) != 0 {
+		t.Fatalf("unexpected specialization on non-generic fn: %+v", cp)
+	}
+}
+
+// ==== Nested generic calls inside a specialization body ====
+
+func TestMonomorphizeNestedGenericCallDiscoversAdditionalSpecialization(t *testing.T) {
+	// fn id<T>(x: T) -> T { x }
+	// fn wrap<U>(y: U) -> U { id::<U>(y) }
+	// fn main() { wrap::<Int>(5) }
+	// → two specializations: id_Int and wrap_Int.
+	idFn := genericIdentity()
+	wrap := &FnDecl{
+		Name:     "wrap",
+		Generics: []*TypeParam{{Name: "U"}},
+		Params:   []*Param{{Name: "y", Type: &TypeVar{Name: "U"}}},
+		Return:   &TypeVar{Name: "U"},
+		Body: &Block{Result: &CallExpr{
+			Callee:   &Ident{Name: "id", Kind: IdentFn, T: ErrTypeVal},
+			TypeArgs: []Type{&TypeVar{Name: "U"}},
+			Args:     []Arg{{Value: &Ident{Name: "y", Kind: IdentParam, T: &TypeVar{Name: "U"}}}},
+			T:        &TypeVar{Name: "U"},
+		}},
+	}
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: &CallExpr{
+			Callee:   &Ident{Name: "wrap", Kind: IdentFn, T: ErrTypeVal},
+			TypeArgs: []Type{TInt},
+			Args:     []Arg{{Value: intLit("5")}},
+			T:        TInt,
+		}}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{idFn, wrap, caller}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	specCount := 0
+	sawIdInt := false
+	sawWrapInt := false
+	for _, d := range out.Decls {
+		fn, ok := d.(*FnDecl)
+		if !ok || fn.Name == "main" {
+			continue
+		}
+		specCount++
+		switch {
+		case strings.HasPrefix(fn.Name, "_Z") && strings.Contains(fn.Name, "2id"):
+			sawIdInt = true
+		case strings.HasPrefix(fn.Name, "_Z") && strings.Contains(fn.Name, "4wrap"):
+			sawWrapInt = true
+		}
+	}
+	if specCount != 2 {
+		t.Fatalf("expected 2 specializations (wrap + nested id), got %d", specCount)
+	}
+	if !sawIdInt || !sawWrapInt {
+		t.Fatalf("expected both id and wrap specializations; sawId=%v sawWrap=%v", sawIdInt, sawWrapInt)
+	}
+}
+
+// ==== Builtin aggregate type argument ====
+
+func TestMonomorphizeBuiltinListTypeArg(t *testing.T) {
+	// id::<List<Int>>(xs) — aggregate type code should be accepted.
+	listInt := &NamedType{Name: "List", Args: []Type{TInt}, Builtin: true}
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: &CallExpr{
+			Callee:   &Ident{Name: "id", Kind: IdentFn, T: ErrTypeVal},
+			TypeArgs: []Type{listInt},
+			Args:     []Arg{{Value: &ListLit{Elem: TInt}}},
+			T:        listInt,
+		}}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), caller}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	specCount := 0
+	for _, d := range out.Decls {
+		if fn, ok := d.(*FnDecl); ok && fn.Name != "main" {
+			specCount++
+			// Substituted parameter should be the list aggregate, not a
+			// TypeVar.
+			if _, isVar := fn.Params[0].Type.(*TypeVar); isVar {
+				t.Fatalf("specialization param still a TypeVar: %+v", fn.Params[0].Type)
+			}
+		}
+	}
+	if specCount != 1 {
+		t.Fatalf("expected 1 List<Int> specialization, got %d", specCount)
+	}
+}
+
+// ==== Error paths ====
+
+func TestMonomorphizeArityMismatchRecordsError(t *testing.T) {
+	// fn f<T, U>(x: T) { … } — call supplies only one type arg.
+	fn := &FnDecl{
+		Name:     "f",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "U"}},
+		Params:   []*Param{{Name: "x", Type: &TypeVar{Name: "T"}}},
+		Return:   TUnit,
+		Body:     &Block{},
+	}
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: &CallExpr{
+			Callee:   &Ident{Name: "f", Kind: IdentFn, T: ErrTypeVal},
+			TypeArgs: []Type{TInt},
+			Args:     []Arg{{Value: intLit("5")}},
+			T:        TUnit,
+		}}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{fn, caller}}
+	_, errs := Monomorphize(in)
+	if len(errs) == 0 {
+		t.Fatalf("expected arity-mismatch error, got none")
+	}
+	if !strings.Contains(errs[0].Error(), "arity mismatch") {
+		t.Fatalf("expected error to mention arity mismatch, got %q", errs[0].Error())
+	}
+}
+
+func TestMonomorphizeLingeringTypeVarRecordsError(t *testing.T) {
+	// A caller that is itself generic would leave a TypeVar in the type
+	// args when an outer specialization tries to request with an unbound
+	// param. We simulate this directly: the top-level caller is generic,
+	// so Monomorphize never enters it, but its body still sits in the
+	// input. We call a generic fn with a TypeVar that's not in env from
+	// inside a *non-generic* fn — the rewriter should flag it.
+	tv := &TypeVar{Name: "T"}
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: &CallExpr{
+			Callee:   &Ident{Name: "id", Kind: IdentFn, T: ErrTypeVal},
+			TypeArgs: []Type{tv}, // unbound in caller — bug case
+			Args:     []Arg{{Value: intLit("5")}},
+			T:        tv,
+		}}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), caller}}
+	_, errs := Monomorphize(in)
+	if len(errs) == 0 {
+		t.Fatalf("expected lingering-TypeVar error, got none")
+	}
+	joined := ""
+	for _, e := range errs {
+		joined += e.Error() + "\n"
+	}
+	if !strings.Contains(joined, "type variable") {
+		t.Fatalf("expected error to mention type variable, got %q", joined)
+	}
+}
+
+// ==== Mangled symbol validity ====
+
+func TestMonomorphizeMangledNameIsValidLLVMIdent(t *testing.T) {
+	caller := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: genericCall(TInt, intLit("5"), TInt)},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), caller}}
+	out, _ := Monomorphize(in)
+	for _, d := range out.Decls {
+		fn, ok := d.(*FnDecl)
+		if !ok || fn.Name == "main" {
+			continue
+		}
+		if !isSimpleIdent(fn.Name) {
+			t.Fatalf("specialization name %q is not a simple identifier", fn.Name)
+		}
+		if !strings.HasPrefix(fn.Name, "_Z") {
+			t.Fatalf("specialization name %q missing Itanium `_Z` prefix", fn.Name)
+		}
+	}
+}
+
+// isSimpleIdent mirrors the subset LLVM will accept for bare global names.
+func isSimpleIdent(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case 'a' <= r && r <= 'z':
+		case 'A' <= r && r <= 'Z':
+		case i > 0 && '0' <= r && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ==== Methods on types ====
+
+func TestMonomorphizeScansStructMethodBodies(t *testing.T) {
+	// A struct method body that contains a generic call site must still
+	// get rewritten and must add a specialization to the output.
+	method := &FnDecl{
+		Name:   "use",
+		Return: TInt,
+		Params: []*Param{{Name: "self", Type: &NamedType{Name: "S"}}},
+		Body:   &Block{Result: genericCall(TInt, intLit("7"), TInt)},
+	}
+	sd := &StructDecl{Name: "S", Methods: []*FnDecl{method}}
+	in := &Module{Package: "main", Decls: []Decl{genericIdentity(), sd}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Struct copied over + 1 specialization for id::<Int>.
+	specCount := 0
+	var structCp *StructDecl
+	for _, d := range out.Decls {
+		switch d := d.(type) {
+		case *StructDecl:
+			structCp = d
+		case *FnDecl:
+			specCount++
+		}
+	}
+	if structCp == nil {
+		t.Fatalf("struct decl missing from output")
+	}
+	if specCount != 1 {
+		t.Fatalf("expected 1 specialization from method body scan, got %d", specCount)
+	}
+	// Method body call must be rewritten.
+	bodyCall := structCp.Methods[0].Body.Result.(*CallExpr)
+	if len(bodyCall.TypeArgs) != 0 {
+		t.Fatalf("method body call TypeArgs should be cleared")
+	}
+	id := bodyCall.Callee.(*Ident)
+	if !strings.HasPrefix(id.Name, "_Z") {
+		t.Fatalf("method body call not rewritten to mangled name: %q", id.Name)
+	}
+}
+
+// ==== Script-level call sites ====
+
+func TestMonomorphizeScansTopLevelScript(t *testing.T) {
+	// Top-level `id::<Int>(5)` (not inside a fn) must also drive
+	// specialization and get rewritten.
+	in := &Module{
+		Package: "main",
+		Decls:   []Decl{genericIdentity()},
+		Script:  []Stmt{&ExprStmt{X: genericCall(TInt, intLit("5"), TInt)}},
+	}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(out.Script) != 1 {
+		t.Fatalf("expected one script stmt, got %d", len(out.Script))
+	}
+	call := out.Script[0].(*ExprStmt).X.(*CallExpr)
+	if len(call.TypeArgs) != 0 {
+		t.Fatalf("script call TypeArgs not cleared: %+v", call.TypeArgs)
+	}
+	id := call.Callee.(*Ident)
+	if !strings.HasPrefix(id.Name, "_Z") {
+		t.Fatalf("script call not rewritten, got %q", id.Name)
+	}
+	// Specialization must sit in Decls.
+	specCount := 0
+	for _, d := range out.Decls {
+		if _, ok := d.(*FnDecl); ok {
+			specCount++
+		}
+	}
+	if specCount != 1 {
+		t.Fatalf("expected 1 specialization from script scan, got %d", specCount)
+	}
+}
+
+// ==== Phase 2 mangling helpers (Osty policy snapshot) ====
+
+func TestMonomorphMangleTypePairIntInt(t *testing.T) {
+	req := NewMonomorphTypeRequest("main", "Pair", []string{"l", "l"})
+	got := MonomorphMangleType(req).Symbol()
+	const want = "_ZTSN4main4PairIllEE"
+	if got != want {
+		t.Fatalf("MonomorphMangleType(Pair<Int,Int>): got %q, want %q", got, want)
+	}
+}
+
+func TestMonomorphMangleTypeEnumMaybeInt(t *testing.T) {
+	req := NewMonomorphTypeRequest("main", "Maybe", []string{"l"})
+	got := MonomorphMangleType(req).Symbol()
+	const want = "_ZTSN4main5MaybeIlEE"
+	if got != want {
+		t.Fatalf("MonomorphMangleType(Maybe<Int>): got %q, want %q", got, want)
+	}
+}
+
+func TestMonomorphMangleTypeNamePartMatches(t *testing.T) {
+	// The symbol must be decomposable as `_ZTS` + <nested-template-name>.
+	req := NewMonomorphTypeRequest("main", "Box", []string{"b"})
+	sym := MonomorphMangleType(req).Symbol()
+	body := MonomorphMangleTypeName("main", "Box", []string{"b"})
+	if sym != "_ZTS"+body {
+		t.Fatalf("symbol %q not equal to _ZTS + body %q", sym, body)
+	}
+}
+
+func TestMonomorphMangleTypeEmptyPkgDefaultsToMain(t *testing.T) {
+	// Script files lower with Package="" — type symbols must still carry
+	// a package segment so demanglers print a qualified name.
+	got := MonomorphMangleTypeName("", "Box", []string{"l"})
+	const want = "N4main3BoxIlEE"
+	if got != want {
+		t.Fatalf("MonomorphMangleTypeName with blank pkg: got %q, want %q", got, want)
+	}
+}
+
+func TestMonomorphUserTemplateNestedNestedGeneric(t *testing.T) {
+	// User-declared generic referenced inside another type-code position
+	// (e.g. id::<Pair<Int, Int>>) must produce an `I…E` template wrap.
+	argCodes := "ll"
+	got := MonomorphUserTemplateNested("main", "Pair", argCodes)
+	const want = "N4main4PairIllEE"
+	if got != want {
+		t.Fatalf("MonomorphUserTemplateNested: got %q, want %q", got, want)
+	}
+}
+
+func TestMonomorphTypeDedupeKeyDistinctFromFn(t *testing.T) {
+	fnKey := MonomorphDedupeKey("Pair", "main", []string{"l", "l"})
+	typeKey := MonomorphTypeDedupeKey("Pair", "main", []string{"l", "l"})
+	if fnKey == typeKey {
+		t.Fatalf("fn and type dedupe keys must not collide for same name/args\nfn:   %q\ntype: %q", fnKey, typeKey)
+	}
+	// Sanity: the type key carries the "type" segment so the distinction
+	// is visible to anyone debugging the engine.
+	if !strings.Contains(typeKey, "\x1ftype\x1f") {
+		t.Fatalf("type dedupe key should contain the `type` marker, got %q", typeKey)
+	}
+}
+
+// ==== Phase 2 typeCodeOf user-generic extension ====
+
+func TestTypeCodeOfUserGenericNamedType(t *testing.T) {
+	// A user-declared `Pair<Int, Int>` reference routes through the new
+	// MonomorphUserTemplateNested branch so fn symbols that take it as a
+	// type argument stay unique per concrete instantiation.
+	pair := &NamedType{Name: "Pair", Args: []Type{TInt, TInt}}
+	got := typeCodeOf(pair, "main")
+	const want = "N4main4PairIllEE"
+	if got != want {
+		t.Fatalf("typeCodeOf(Pair<Int,Int>): got %q, want %q", got, want)
+	}
+}
+
+func TestTypeCodeOfUserGenericDistinctArgs(t *testing.T) {
+	a := typeCodeOf(&NamedType{Name: "Pair", Args: []Type{TInt, TBool}}, "main")
+	b := typeCodeOf(&NamedType{Name: "Pair", Args: []Type{TBool, TInt}}, "main")
+	if a == b {
+		t.Fatalf("distinct generic args must produce distinct type codes, both %q", a)
+	}
+}
+
+func TestTypeCodeOfNestedUserGeneric(t *testing.T) {
+	// Maybe<Pair<Int, Bool>> — the inner Pair must expand recursively so
+	// the outer encoding is decidable.
+	inner := &NamedType{Name: "Pair", Args: []Type{TInt, TBool}}
+	outer := &NamedType{Name: "Maybe", Args: []Type{inner}}
+	got := typeCodeOf(outer, "main")
+	const want = "N4main5MaybeIN4main4PairIlbEEEE"
+	if got != want {
+		t.Fatalf("typeCodeOf(Maybe<Pair<Int,Bool>>): got %q, want %q", got, want)
+	}
+}
+
+func TestTypeCodeOfUserNamedWithoutArgsUnchanged(t *testing.T) {
+	// A non-generic user struct reference should still hit the plain
+	// MonomorphUserNested branch — the Phase 2 change must not disturb
+	// existing fn-mangle symbols for non-generic user types.
+	got := typeCodeOf(&NamedType{Name: "Point"}, "main")
+	const want = "N4main5PointE"
+	if got != want {
+		t.Fatalf("typeCodeOf(Point): got %q, want %q", got, want)
+	}
+}
+
+// ==== Phase 2 rewriteType helper ====
+
+// newTestMonoState builds a blank monoState populated only with the
+// index maps and package — enough for exercising rewriteType and the
+// request* helpers in isolation.
+func newTestMonoState(structs map[string]*StructDecl, enums map[string]*EnumDecl) *monoState {
+	return &monoState{
+		pkg:                  "main",
+		out:                  &Module{Package: "main"},
+		genericsByName:       map[string]*FnDecl{},
+		seen:                 map[string]string{},
+		genericStructsByName: structs,
+		genericEnumsByName:   enums,
+		typeSeen:             map[string]string{},
+	}
+}
+
+func TestRewriteTypePassesThroughUnknownNamed(t *testing.T) {
+	s := newTestMonoState(nil, nil)
+	nt := &NamedType{Name: "Unknown", Args: []Type{TInt}}
+	out := s.rewriteType(nt)
+	if out != nt {
+		t.Fatalf("unknown NamedType should be returned unchanged, got %T", out)
+	}
+	if len(s.typeQueue) != 0 {
+		t.Fatalf("typeQueue should stay empty for unknown names, got %d", len(s.typeQueue))
+	}
+}
+
+func TestRewriteTypeReplacesGenericStruct(t *testing.T) {
+	pair := &StructDecl{
+		Name:     "Pair",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "U"}},
+		Fields: []*Field{
+			{Name: "first", Type: &TypeVar{Name: "T"}},
+			{Name: "second", Type: &TypeVar{Name: "U"}},
+		},
+	}
+	s := newTestMonoState(map[string]*StructDecl{"Pair": pair}, nil)
+	nt := &NamedType{Name: "Pair", Args: []Type{TInt, TInt}}
+	out := s.rewriteType(nt)
+	named, ok := out.(*NamedType)
+	if !ok {
+		t.Fatalf("expected NamedType after rewrite, got %T", out)
+	}
+	if !strings.HasPrefix(named.Name, "_ZTS") {
+		t.Fatalf("rewrite should produce Itanium type-symbol, got %q", named.Name)
+	}
+	if len(named.Args) != 0 {
+		t.Fatalf("mangled NamedType should drop Args, got %+v", named.Args)
+	}
+	if len(s.typeQueue) != 1 {
+		t.Fatalf("expected one queued type spec, got %d", len(s.typeQueue))
+	}
+	if s.typeQueue[0].structDecl != pair {
+		t.Fatalf("queued spec should reference the original decl")
+	}
+}
+
+func TestRewriteTypeReplacesGenericEnum(t *testing.T) {
+	maybe := &EnumDecl{
+		Name:     "Maybe",
+		Generics: []*TypeParam{{Name: "T"}},
+		Variants: []*Variant{
+			{Name: "Some", Payload: []Type{&TypeVar{Name: "T"}}},
+			{Name: "None"},
+		},
+	}
+	s := newTestMonoState(nil, map[string]*EnumDecl{"Maybe": maybe})
+	nt := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	out := s.rewriteType(nt)
+	named, _ := out.(*NamedType)
+	if named == nil || !strings.HasPrefix(named.Name, "_ZTS") {
+		t.Fatalf("expected mangled enum reference, got %T %+v", out, out)
+	}
+	if len(s.typeQueue) != 1 || s.typeQueue[0].enumDecl != maybe {
+		t.Fatalf("queued spec mismatch: %+v", s.typeQueue)
+	}
+}
+
+func TestRewriteTypeDedupesRepeatedRequests(t *testing.T) {
+	pair := &StructDecl{
+		Name:     "Pair",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "U"}},
+	}
+	s := newTestMonoState(map[string]*StructDecl{"Pair": pair}, nil)
+	first := s.rewriteType(&NamedType{Name: "Pair", Args: []Type{TInt, TInt}})
+	second := s.rewriteType(&NamedType{Name: "Pair", Args: []Type{TInt, TInt}})
+	if first.(*NamedType).Name != second.(*NamedType).Name {
+		t.Fatalf("dedupe: repeated rewrite should produce identical mangled name, got %q vs %q",
+			first.(*NamedType).Name, second.(*NamedType).Name)
+	}
+	if len(s.typeQueue) != 1 {
+		t.Fatalf("dedupe: typeQueue should hold one entry, got %d", len(s.typeQueue))
+	}
+}
+
+func TestRewriteTypeBottomUpNestedGeneric(t *testing.T) {
+	pair := &StructDecl{
+		Name:     "Pair",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "U"}},
+	}
+	maybe := &EnumDecl{
+		Name:     "Maybe",
+		Generics: []*TypeParam{{Name: "T"}},
+	}
+	s := newTestMonoState(
+		map[string]*StructDecl{"Pair": pair},
+		map[string]*EnumDecl{"Maybe": maybe},
+	)
+	// Pair<Maybe<Int>, Bool> — inner Maybe<Int> must specialize first so
+	// Pair's type-arg codes reference the inner mangled symbol.
+	inner := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	outer := &NamedType{Name: "Pair", Args: []Type{inner, TBool}}
+	out := s.rewriteType(outer)
+	named, _ := out.(*NamedType)
+	if named == nil {
+		t.Fatalf("expected outer rewrite to produce NamedType, got %T", out)
+	}
+	if len(s.typeQueue) != 2 {
+		t.Fatalf("expected two queued specs (inner + outer), got %d", len(s.typeQueue))
+	}
+	// The outer instance must have been enqueued *after* the inner one
+	// because the engine encodes the inner mangled symbol as part of
+	// the outer request's type-arg codes.
+	if s.typeQueue[0].enumDecl != maybe {
+		t.Fatalf("inner enum spec should be enqueued first, got %+v", s.typeQueue[0])
+	}
+	if s.typeQueue[1].structDecl != pair {
+		t.Fatalf("outer struct spec should be enqueued second, got %+v", s.typeQueue[1])
+	}
+}
+
+func TestRewriteTypeBuiltinPreservesArgs(t *testing.T) {
+	// Builtin generics (List<T>, Option<T>) must NOT request
+	// user-struct specializations — they stay as-is so the LLVM runtime
+	// paths keep handling them.
+	s := newTestMonoState(nil, nil)
+	list := &NamedType{Name: "List", Args: []Type{TInt}, Builtin: true}
+	out := s.rewriteType(list)
+	if out != list {
+		t.Fatalf("builtin NamedType must not be replaced, got %T", out)
+	}
+	if len(s.typeQueue) != 0 {
+		t.Fatalf("builtin NamedType must not enqueue type specs")
+	}
+}
+
+func TestRewriteTypeArityMismatchRecordsError(t *testing.T) {
+	pair := &StructDecl{
+		Name:     "Pair",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "U"}},
+	}
+	s := newTestMonoState(map[string]*StructDecl{"Pair": pair}, nil)
+	// Only one type arg for a two-param generic.
+	s.rewriteType(&NamedType{Name: "Pair", Args: []Type{TInt}})
+	if len(s.errs) == 0 {
+		t.Fatalf("expected arity-mismatch error, got none")
+	}
+}
+
+// ==== Phase 2 integration — generic struct / enum specialization ====
+
+// genericPairStruct returns `struct Pair<T, U> { first: T, second: U }`.
+// Shared helper so the integration tests stay focused on behavior.
+func genericPairStruct() *StructDecl {
+	return &StructDecl{
+		Name:     "Pair",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "U"}},
+		Fields: []*Field{
+			{Name: "first", Type: &TypeVar{Name: "T"}},
+			{Name: "second", Type: &TypeVar{Name: "U"}},
+		},
+	}
+}
+
+// genericMaybeEnum returns `enum Maybe<T> { Some(T), None }`.
+func genericMaybeEnum() *EnumDecl {
+	return &EnumDecl{
+		Name:     "Maybe",
+		Generics: []*TypeParam{{Name: "T"}},
+		Variants: []*Variant{
+			{Name: "Some", Payload: []Type{&TypeVar{Name: "T"}}},
+			{Name: "None"},
+		},
+	}
+}
+
+// findStructSpec returns the first mangled StructDecl in a module, or
+// nil when none is present. Non-mangled structs (original unchanged
+// declarations or non-generic user types) are skipped.
+func findStructSpec(m *Module) *StructDecl {
+	for _, d := range m.Decls {
+		if sd, ok := d.(*StructDecl); ok && strings.HasPrefix(sd.Name, "_ZTS") {
+			return sd
+		}
+	}
+	return nil
+}
+
+// findEnumSpec returns the first mangled EnumDecl in a module.
+func findEnumSpec(m *Module) *EnumDecl {
+	for _, d := range m.Decls {
+		if ed, ok := d.(*EnumDecl); ok && strings.HasPrefix(ed.Name, "_ZTS") {
+			return ed
+		}
+	}
+	return nil
+}
+
+// countSpecs returns how many mangled struct-or-enum specializations
+// appear in the module output. Used by dedup/distinct tests.
+func countSpecs(m *Module) int {
+	n := 0
+	for _, d := range m.Decls {
+		switch x := d.(type) {
+		case *StructDecl:
+			if strings.HasPrefix(x.Name, "_ZTS") {
+				n++
+			}
+		case *EnumDecl:
+			if strings.HasPrefix(x.Name, "_ZTS") {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func TestMonomorphizeGenericStructSpecialization(t *testing.T) {
+	pair := genericPairStruct()
+	pairT := &NamedType{Name: "Pair", Args: []Type{TInt, TInt}}
+	lit := &StructLit{
+		TypeName: "Pair",
+		T:        pairT,
+		Fields: []StructLitField{
+			{Name: "first", Value: intLit("1")},
+			{Name: "second", Value: intLit("2")},
+		},
+	}
+	main := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "p", Value: lit, Type: pairT},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Expected: main (copied) + 1 Pair specialization. Original generic
+	// Pair must be dropped.
+	spec := findStructSpec(out)
+	if spec == nil {
+		t.Fatalf("Pair specialization missing from output decls: %+v", out.Decls)
+	}
+	if spec.Generics != nil {
+		t.Fatalf("specialization must shed generics, got %d", len(spec.Generics))
+	}
+	if spec.Fields[0].Type != TInt || spec.Fields[1].Type != TInt {
+		t.Fatalf("fields not substituted: %+v", spec.Fields)
+	}
+	// Original Pair must be dropped.
+	for _, d := range out.Decls {
+		if sd, ok := d.(*StructDecl); ok && sd.Name == "Pair" {
+			t.Fatalf("original generic Pair leaked into output")
+		}
+	}
+}
+
+func TestMonomorphizeGenericEnumSpecialization(t *testing.T) {
+	maybe := genericMaybeEnum()
+	maybeT := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	lit := &VariantLit{
+		Enum:    "Maybe",
+		Variant: "Some",
+		T:       maybeT,
+		Args:    []Arg{{Value: intLit("42")}},
+	}
+	main := &FnDecl{
+		Name:   "main",
+		Return: TUnit,
+		Body:   &Block{Stmts: []Stmt{&LetStmt{Name: "m", Value: lit, Type: maybeT}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	spec := findEnumSpec(out)
+	if spec == nil {
+		t.Fatalf("Maybe specialization missing from output decls: %+v", out.Decls)
+	}
+	if spec.Generics != nil {
+		t.Fatalf("specialization must shed generics")
+	}
+	// Some variant's payload must be concretized to Int.
+	var some *Variant
+	for _, v := range spec.Variants {
+		if v.Name == "Some" {
+			some = v
+		}
+	}
+	if some == nil || len(some.Payload) != 1 || some.Payload[0] != TInt {
+		t.Fatalf("Some variant payload not substituted to Int: %+v", some)
+	}
+}
+
+func TestMonomorphizeStructLitRewrittenToMangled(t *testing.T) {
+	pair := genericPairStruct()
+	pairT := &NamedType{Name: "Pair", Args: []Type{TInt, TInt}}
+	lit := &StructLit{
+		TypeName: "Pair",
+		T:        pairT,
+		Fields: []StructLitField{
+			{Name: "first", Value: intLit("1")},
+			{Name: "second", Value: intLit("2")},
+		},
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: lit}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, _ := Monomorphize(in)
+	mainCp := out.Decls[0].(*FnDecl)
+	litCp := mainCp.Body.Stmts[0].(*ExprStmt).X.(*StructLit)
+	if !strings.HasPrefix(litCp.TypeName, "_ZTS") {
+		t.Fatalf("StructLit.TypeName should be mangled, got %q", litCp.TypeName)
+	}
+	nt, ok := litCp.T.(*NamedType)
+	if !ok || nt.Name != litCp.TypeName {
+		t.Fatalf("StructLit.T name must equal TypeName: T=%+v TypeName=%q", litCp.T, litCp.TypeName)
+	}
+	if len(nt.Args) != 0 {
+		t.Fatalf("mangled NamedType should drop Args, got %+v", nt.Args)
+	}
+}
+
+func TestMonomorphizeLetStmtTypeAnnotationRewritten(t *testing.T) {
+	pair := genericPairStruct()
+	pairT := &NamedType{Name: "Pair", Args: []Type{TInt, TInt}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name: "p",
+			Type: pairT,
+			Value: &StructLit{
+				TypeName: "Pair",
+				T:        pairT,
+				Fields: []StructLitField{
+					{Name: "first", Value: intLit("1")},
+					{Name: "second", Value: intLit("2")},
+				},
+			},
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, _ := Monomorphize(in)
+	mainCp := out.Decls[0].(*FnDecl)
+	let := mainCp.Body.Stmts[0].(*LetStmt)
+	nt, ok := let.Type.(*NamedType)
+	if !ok || !strings.HasPrefix(nt.Name, "_ZTS") {
+		t.Fatalf("LetStmt.Type must be mangled NamedType, got %+v", let.Type)
+	}
+}
+
+func TestMonomorphizeStructDedupesSameTypeArgs(t *testing.T) {
+	pair := genericPairStruct()
+	makeLit := func() *StructLit {
+		pairT := &NamedType{Name: "Pair", Args: []Type{TInt, TInt}}
+		return &StructLit{
+			TypeName: "Pair", T: pairT,
+			Fields: []StructLitField{
+				{Name: "first", Value: intLit("1")},
+				{Name: "second", Value: intLit("2")},
+			},
+		}
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: makeLit()},
+			&ExprStmt{X: makeLit()},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, _ := Monomorphize(in)
+	if got := countSpecs(out); got != 1 {
+		t.Fatalf("dedupe: expected 1 specialization for duplicate lits, got %d", got)
+	}
+}
+
+func TestMonomorphizeStructDistinctTypeArgs(t *testing.T) {
+	pair := genericPairStruct()
+	mkLit := func(a, b Type) *StructLit {
+		return &StructLit{
+			TypeName: "Pair",
+			T:        &NamedType{Name: "Pair", Args: []Type{a, b}},
+			Fields: []StructLitField{
+				{Name: "first", Value: intLit("1")},
+				{Name: "second", Value: intLit("2")},
+			},
+		}
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: mkLit(TInt, TBool)},
+			&ExprStmt{X: mkLit(TBool, TInt)},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, _ := Monomorphize(in)
+	if got := countSpecs(out); got != 2 {
+		t.Fatalf("distinct args: expected 2 specializations, got %d", got)
+	}
+}
+
+func TestMonomorphizeNestedGenericStructType(t *testing.T) {
+	// Pair<Maybe<Bool>, Int> — the inner Maybe must be specialized before
+	// the outer Pair's request so Pair's type-arg codes can embed the
+	// inner mangled name.
+	pair := genericPairStruct()
+	maybe := genericMaybeEnum()
+	maybeBool := &NamedType{Name: "Maybe", Args: []Type{TBool}}
+	pairT := &NamedType{Name: "Pair", Args: []Type{maybeBool, TInt}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name: "p",
+			Type: pairT,
+			Value: &StructLit{
+				TypeName: "Pair",
+				T:        pairT,
+				Fields: []StructLitField{
+					{Name: "first", Value: intLit("0")},
+					{Name: "second", Value: intLit("0")},
+				},
+			},
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, maybe, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := countSpecs(out); got != 2 {
+		t.Fatalf("expected 2 specs (inner Maybe + outer Pair), got %d\n%+v", got, out.Decls)
+	}
+}
+
+func TestMonomorphizeUnusedGenericStructDropped(t *testing.T) {
+	pair := genericPairStruct()
+	in := &Module{Package: "main", Decls: []Decl{pair}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(out.Decls) != 0 {
+		t.Fatalf("expected empty output for unused generic struct, got %+v", out.Decls)
+	}
+}
+
+func TestMonomorphizeFnWithGenericStructReturn(t *testing.T) {
+	// fn pack<T>(x: T) -> Pair<T, T> { Pair { first: x, second: x } }
+	// fn main() { pack::<Int>(1) }
+	// Expect: pack specialization AND Pair<Int,Int> specialization.
+	pair := genericPairStruct()
+	tv := &TypeVar{Name: "T"}
+	pairTT := &NamedType{Name: "Pair", Args: []Type{tv, tv}}
+	pack := &FnDecl{
+		Name:     "pack",
+		Generics: []*TypeParam{{Name: "T"}},
+		Params:   []*Param{{Name: "x", Type: tv}},
+		Return:   pairTT,
+		Body: &Block{Result: &StructLit{
+			TypeName: "Pair",
+			T:        pairTT,
+			Fields: []StructLitField{
+				{Name: "first", Value: &Ident{Name: "x", Kind: IdentParam, T: tv}},
+				{Name: "second", Value: &Ident{Name: "x", Kind: IdentParam, T: tv}},
+			},
+		}},
+	}
+	mainCall := &CallExpr{
+		Callee:   &Ident{Name: "pack", Kind: IdentFn, T: ErrTypeVal},
+		TypeArgs: []Type{TInt},
+		Args:     []Arg{{Value: intLit("1")}},
+		T:        &NamedType{Name: "Pair", Args: []Type{TInt, TInt}},
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: mainCall}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, pack, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Collect fn and struct specs.
+	var fnSpecs, structSpecs int
+	for _, d := range out.Decls {
+		switch x := d.(type) {
+		case *FnDecl:
+			if strings.HasPrefix(x.Name, "_Z") && !strings.HasPrefix(x.Name, "_ZTS") {
+				fnSpecs++
+			}
+		case *StructDecl:
+			if strings.HasPrefix(x.Name, "_ZTS") {
+				structSpecs++
+			}
+		}
+	}
+	if fnSpecs != 1 || structSpecs != 1 {
+		t.Fatalf("expected 1 fn spec + 1 struct spec; got fn=%d struct=%d\n%+v",
+			fnSpecs, structSpecs, out.Decls)
+	}
+	// The fn specialization's return type must be the mangled Pair.
+	for _, d := range out.Decls {
+		if fn, ok := d.(*FnDecl); ok && strings.HasPrefix(fn.Name, "_Z") && !strings.HasPrefix(fn.Name, "_ZTS") {
+			nt, _ := fn.Return.(*NamedType)
+			if nt == nil || !strings.HasPrefix(nt.Name, "_ZTS") {
+				t.Fatalf("pack specialization return type not rewritten: %+v", fn.Return)
+			}
+		}
+	}
+}
+
+func TestMonomorphizeVariantLitEnumFieldMangled(t *testing.T) {
+	maybe := genericMaybeEnum()
+	lit := &VariantLit{
+		Enum:    "Maybe",
+		Variant: "Some",
+		T:       &NamedType{Name: "Maybe", Args: []Type{TInt}},
+		Args:    []Arg{{Value: intLit("42")}},
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: lit}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, _ := Monomorphize(in)
+	mainCp := out.Decls[0].(*FnDecl)
+	litCp := mainCp.Body.Stmts[0].(*ExprStmt).X.(*VariantLit)
+	if !strings.HasPrefix(litCp.Enum, "_ZTS") {
+		t.Fatalf("VariantLit.Enum should be mangled, got %q", litCp.Enum)
+	}
+}
+
+func TestMonomorphizeStructMethodSpecialization(t *testing.T) {
+	// struct Pair<T, U> { … } impl { fn first(self) -> T { self.first } }
+	// fn main() { let p = Pair<Int, Bool>; p.first() }
+	// → specialization's method has concrete receiver + return type.
+	pair := genericPairStruct()
+	tv := &TypeVar{Name: "T"}
+	pair.Methods = []*FnDecl{{
+		Name:   "first",
+		Return: tv,
+		Params: []*Param{{Name: "self", Type: &NamedType{Name: "Pair", Args: []Type{tv, &TypeVar{Name: "U"}}}}},
+		Body:   &Block{Result: &FieldExpr{X: &Ident{Name: "self", Kind: IdentParam, T: tv}, Name: "first", T: tv}},
+	}}
+	pairT := &NamedType{Name: "Pair", Args: []Type{TInt, TBool}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name: "p",
+			Type: pairT,
+			Value: &StructLit{
+				TypeName: "Pair",
+				T:        pairT,
+				Fields: []StructLitField{
+					{Name: "first", Value: intLit("1")},
+					{Name: "second", Value: &BoolLit{Value: true}},
+				},
+			},
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	spec := findStructSpec(out)
+	if spec == nil || len(spec.Methods) != 1 {
+		t.Fatalf("struct spec missing method: %+v", spec)
+	}
+	m := spec.Methods[0]
+	if m.Return != TInt {
+		t.Fatalf("method return type not substituted to Int: %T", m.Return)
+	}
+	// The receiver param's type must have been rewritten to the mangled
+	// Pair specialization so llvmgen's method-owner resolution succeeds.
+	recvT, ok := m.Params[0].Type.(*NamedType)
+	if !ok || !strings.HasPrefix(recvT.Name, "_ZTS") {
+		t.Fatalf("method receiver type not rewritten to mangled: %+v", m.Params[0].Type)
+	}
+}
+
+func TestMonomorphizeStructMethodCallReceiverTypeRewritten(t *testing.T) {
+	// p.first() call — receiver expression type must be the mangled
+	// specialization so downstream method dispatch resolves correctly.
+	pair := genericPairStruct()
+	tv := &TypeVar{Name: "T"}
+	pair.Methods = []*FnDecl{{
+		Name:   "first",
+		Return: tv,
+		Params: []*Param{{Name: "self", Type: &NamedType{Name: "Pair", Args: []Type{tv, &TypeVar{Name: "U"}}}}},
+		Body:   &Block{Result: &FieldExpr{X: &Ident{Name: "self", Kind: IdentParam, T: tv}, Name: "first", T: tv}},
+	}}
+	pairT := &NamedType{Name: "Pair", Args: []Type{TInt, TBool}}
+	recv := &Ident{Name: "p", Kind: IdentLocal, T: pairT}
+	call := &MethodCall{
+		Receiver: recv,
+		Name:     "first",
+		T:        TInt,
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "p", Type: pairT, Value: &StructLit{
+				TypeName: "Pair", T: pairT,
+				Fields: []StructLitField{
+					{Name: "first", Value: intLit("1")},
+					{Name: "second", Value: &BoolLit{Value: true}},
+				},
+			}},
+			&ExprStmt{X: call},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	out, _ := Monomorphize(in)
+	mainCp := out.Decls[0].(*FnDecl)
+	callCp := mainCp.Body.Stmts[1].(*ExprStmt).X.(*MethodCall)
+	recvT, ok := callCp.Receiver.(*Ident).T.(*NamedType)
+	if !ok || !strings.HasPrefix(recvT.Name, "_ZTS") {
+		t.Fatalf("MethodCall receiver type not rewritten, got %+v", callCp.Receiver.(*Ident).T)
+	}
+}
+
+func TestMonomorphizeEnumMethodBodyScanned(t *testing.T) {
+	// enum Maybe<T> { Some(T), None } impl { fn wrap(self) -> T { id::<T>(0) } }
+	// Use a generic free fn `id<U>(x: U) -> U` inside an enum method so
+	// the method body's call site still drives the fn worklist after
+	// specialization. The concrete T = Int ⇒ id::<Int>(0) ⇒ one fn spec.
+	idFn := genericIdentity()
+	maybe := genericMaybeEnum()
+	tv := &TypeVar{Name: "T"}
+	maybe.Methods = []*FnDecl{{
+		Name:   "wrap",
+		Return: tv,
+		Params: []*Param{{Name: "self", Type: &NamedType{Name: "Maybe", Args: []Type{tv}}}},
+		Body: &Block{Result: &CallExpr{
+			Callee:   &Ident{Name: "id", Kind: IdentFn, T: ErrTypeVal},
+			TypeArgs: []Type{tv},
+			Args:     []Arg{{Value: intLit("0")}},
+			T:        tv,
+		}},
+	}}
+	maybeT := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name: "m", Type: maybeT,
+			Value: &VariantLit{Enum: "Maybe", Variant: "Some", T: maybeT,
+				Args: []Arg{{Value: intLit("1")}}},
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{idFn, maybe, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Expect at least one fn spec (id::<Int>) + one enum spec (Maybe<Int>).
+	fnSpecs := 0
+	enumSpecs := 0
+	for _, d := range out.Decls {
+		switch x := d.(type) {
+		case *FnDecl:
+			if strings.HasPrefix(x.Name, "_Z") && !strings.HasPrefix(x.Name, "_ZTS") {
+				fnSpecs++
+			}
+		case *EnumDecl:
+			if strings.HasPrefix(x.Name, "_ZTS") {
+				enumSpecs++
+			}
+		}
+	}
+	if fnSpecs < 1 {
+		t.Fatalf("expected id specialization from enum method body, got %d fn specs\n%+v",
+			fnSpecs, out.Decls)
+	}
+	if enumSpecs != 1 {
+		t.Fatalf("expected 1 Maybe<Int> spec, got %d\n%+v", enumSpecs, out.Decls)
+	}
+}
+
+func TestMonomorphizeMethodLocalGenericSkipsWithWarning(t *testing.T) {
+	// struct Box<T> { value: T }
+	// impl { fn cast<U>(self) -> U { … } }  ← method-local generic U
+	// Phase 2 should drop cast from the specialization and warn.
+	box := &StructDecl{
+		Name:     "Box",
+		Generics: []*TypeParam{{Name: "T"}},
+		Fields:   []*Field{{Name: "value", Type: &TypeVar{Name: "T"}}},
+		Methods: []*FnDecl{{
+			Name:     "cast",
+			Generics: []*TypeParam{{Name: "U"}}, // method-local
+			Params:   []*Param{{Name: "self", Type: &NamedType{Name: "Box", Args: []Type{&TypeVar{Name: "T"}}}}},
+			Return:   &TypeVar{Name: "U"},
+			Body:     &Block{},
+		}},
+	}
+	boxT := &NamedType{Name: "Box", Args: []Type{TInt}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name: "b", Type: boxT,
+			Value: &StructLit{TypeName: "Box", T: boxT, Fields: []StructLitField{
+				{Name: "value", Value: intLit("1")},
+			}},
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{box, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) == 0 {
+		t.Fatalf("expected method-local generics warning, got none")
+	}
+	joined := ""
+	for _, e := range errs {
+		joined += e.Error() + "\n"
+	}
+	if !strings.Contains(joined, "method-local generics") {
+		t.Fatalf("expected 'method-local generics' in err, got %q", joined)
+	}
+	spec := findStructSpec(out)
+	if spec == nil {
+		t.Fatalf("Box specialization missing")
+	}
+	if len(spec.Methods) != 0 {
+		t.Fatalf("cast method should have been dropped, got %+v", spec.Methods)
+	}
+}
+
+func TestMonomorphizeStructArityMismatchRecordsError(t *testing.T) {
+	pair := genericPairStruct()
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name: "p",
+			Type: &NamedType{Name: "Pair", Args: []Type{TInt}},
+			Value: &StructLit{
+				TypeName: "Pair",
+				T:        &NamedType{Name: "Pair", Args: []Type{TInt}},
+				Fields:   []StructLitField{{Name: "first", Value: intLit("1")}},
+			},
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{pair, main}}
+	_, errs := Monomorphize(in)
+	if len(errs) == 0 {
+		t.Fatalf("expected arity-mismatch error for Pair with 1 type arg, got none")
+	}
+	joined := ""
+	for _, e := range errs {
+		joined += e.Error() + "\n"
+	}
+	if !strings.Contains(joined, "arity mismatch") || !strings.Contains(joined, "Pair") {
+		t.Fatalf("expected 'arity mismatch' + struct name in err, got %q", joined)
+	}
+}

--- a/internal/ir/subst_test.go
+++ b/internal/ir/subst_test.go
@@ -1,0 +1,123 @@
+package ir
+
+import "testing"
+
+func TestSubstituteTypesReplacesTypeVarInNamedArgs(t *testing.T) {
+	v := &TypeVar{Name: "T"}
+	list := &NamedType{Name: "List", Args: []Type{v}, Builtin: true}
+	fn := &FnDecl{Name: "f", Return: list, Body: &Block{}}
+	SubstituteTypes(fn, SubstEnv{"T": TInt})
+	if got := list.Args[0]; got != TInt {
+		t.Fatalf("expected TInt after subst, got %T (%v)", got, got)
+	}
+}
+
+func TestSubstituteTypesNoopOnEmptyEnv(t *testing.T) {
+	v := &TypeVar{Name: "T"}
+	list := &NamedType{Name: "List", Args: []Type{v}, Builtin: true}
+	fn := &FnDecl{Return: list, Body: &Block{}}
+	SubstituteTypes(fn, SubstEnv{})
+	if list.Args[0] != v {
+		t.Fatalf("empty env should leave TypeVar untouched, got %T", list.Args[0])
+	}
+}
+
+func TestSubstituteTypesNilRootIsSafe(t *testing.T) {
+	// Must not panic.
+	SubstituteTypes(nil, SubstEnv{"T": TInt})
+}
+
+func TestSubstituteTypesOnlyReplacesNamedVars(t *testing.T) {
+	// A TypeVar with a name not in the env must survive the walk.
+	v := &TypeVar{Name: "U"}
+	opt := &OptionalType{Inner: v}
+	SubstituteTypes(&FnDecl{Return: opt, Body: &Block{}}, SubstEnv{"T": TInt})
+	if opt.Inner != v {
+		t.Fatalf("unrelated TypeVar should be untouched, got %T", opt.Inner)
+	}
+}
+
+func TestSubstituteTypesDeepOptional(t *testing.T) {
+	opt := &OptionalType{Inner: &TypeVar{Name: "T"}}
+	SubstituteTypes(&FnDecl{Return: opt, Body: &Block{}}, SubstEnv{"T": TString})
+	if opt.Inner != TString {
+		t.Fatalf("expected TString inner, got %T", opt.Inner)
+	}
+}
+
+func TestSubstituteTypesDeepTuple(t *testing.T) {
+	tup := &TupleType{Elems: []Type{&TypeVar{Name: "T"}, TBool}}
+	SubstituteTypes(&FnDecl{Return: tup, Body: &Block{}}, SubstEnv{"T": TInt})
+	if tup.Elems[0] != TInt || tup.Elems[1] != TBool {
+		t.Fatalf("tuple subst dropped sibling: %+v", tup.Elems)
+	}
+}
+
+func TestSubstituteTypesFnTypeParamsAndReturn(t *testing.T) {
+	ft := &FnType{Params: []Type{&TypeVar{Name: "T"}}, Return: &TypeVar{Name: "T"}}
+	SubstituteTypes(&FnDecl{Return: ft, Body: &Block{}}, SubstEnv{"T": TInt})
+	if ft.Params[0] != TInt || ft.Return != TInt {
+		t.Fatalf("FnType subst failed: params=%v return=%v", ft.Params[0], ft.Return)
+	}
+}
+
+func TestSubstituteTypesReachesFnDeclParamsAndBody(t *testing.T) {
+	// End-to-end: substitution of a generic fn declaration should replace
+	// every Type field reachable from the declaration — params, return,
+	// and the expression types inside the body.
+	v := &TypeVar{Name: "T"}
+	bodyIdent := &Ident{Name: "x", Kind: IdentParam, T: v}
+	fn := &FnDecl{
+		Name:   "id",
+		Return: v,
+		Params: []*Param{{Name: "x", Type: v}},
+		Body: &Block{
+			Stmts:  []Stmt{&LetStmt{Name: "y", Type: v, Value: bodyIdent}},
+			Result: &Ident{Name: "y", Kind: IdentLocal, T: v},
+		},
+	}
+	SubstituteTypes(fn, SubstEnv{"T": TInt})
+	if fn.Params[0].Type != TInt {
+		t.Fatalf("param type not substituted: %T", fn.Params[0].Type)
+	}
+	if fn.Return != TInt {
+		t.Fatalf("return type not substituted: %T", fn.Return)
+	}
+	if bodyIdent.T != TInt {
+		t.Fatalf("body ident type not substituted: %T", bodyIdent.T)
+	}
+	letStmt := fn.Body.Stmts[0].(*LetStmt)
+	if letStmt.Type != TInt {
+		t.Fatalf("let stmt annotation type not substituted: %T", letStmt.Type)
+	}
+	if fn.Body.Result.(*Ident).T != TInt {
+		t.Fatalf("body result ident type not substituted")
+	}
+}
+
+func TestSubstituteTypesRewritesCallExprTypeArgs(t *testing.T) {
+	// A generic call inside a specialization body needs its TypeArgs
+	// rewritten before the outer worklist picks them up. The call's own
+	// result type also ripples through.
+	call := &CallExpr{
+		Callee:   &Ident{Name: "id", Kind: IdentFn, T: ErrTypeVal},
+		TypeArgs: []Type{&TypeVar{Name: "T"}},
+		Args:     []Arg{{Value: &Ident{Name: "x", Kind: IdentParam, T: &TypeVar{Name: "T"}}}},
+		T:        &TypeVar{Name: "T"},
+	}
+	fn := &FnDecl{
+		Name:   "caller",
+		Return: TUnit,
+		Body:   &Block{Stmts: []Stmt{&ExprStmt{X: call}}},
+	}
+	SubstituteTypes(fn, SubstEnv{"T": TInt})
+	if call.TypeArgs[0] != TInt {
+		t.Fatalf("call TypeArgs not substituted: %T", call.TypeArgs[0])
+	}
+	if call.T != TInt {
+		t.Fatalf("call result type not substituted: %T", call.T)
+	}
+	if argT := call.Args[0].Value.(*Ident).T; argT != TInt {
+		t.Fatalf("call arg ident type not substituted: %T", argT)
+	}
+}

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -65,3 +65,154 @@ func TestGenerateModuleWhileLoopCompat(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerateModuleGenericIdentityMonomorphized exercises the full
+// pipeline including monomorphization: a generic free function must be
+// specialized to a concrete symbol by the time LLVM IR is emitted, and
+// the call site at main must reference that specialization by its
+// Itanium-mangled name.
+//
+// The expected mangled symbol is derived by the Osty-authored policy in
+// toolchain/monomorph.osty: pkg "main" (unqualified encoding) + fn "id"
+// (2id) + template arg list "IlE" + parameter list "l" → "_Z2idIlEl".
+// Asserting on the literal string documents the contract so policy
+// regressions surface immediately.
+func TestGenerateModuleGenericIdentityMonomorphized(t *testing.T) {
+	src := `fn id<T>(x: T) -> T { x }
+
+fn main() {
+    let v = id::<Int>(42)
+    println(v)
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower returned issues: %v", issues)
+	}
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("ir.Monomorphize returned errors: %v", monoErrs)
+	}
+	if validateErrs := ir.Validate(monoMod); len(validateErrs) != 0 {
+		t.Fatalf("ir.Validate returned errors: %v", validateErrs)
+	}
+	out, err := GenerateModule(monoMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/generic_identity_ir.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	got := string(out)
+	const wantSymbol = "_Z2idIlEl"
+	if !strings.Contains(got, wantSymbol) {
+		t.Fatalf("generated IR missing mangled specialization %q:\n%s", wantSymbol, got)
+	}
+	// The specialization should be emitted as a function definition, not
+	// merely referenced at the call site, so both `define` and `call`
+	// occurrences of the mangled name must appear.
+	if !strings.Contains(got, "define") || !strings.Contains(got, "@"+wantSymbol) {
+		t.Fatalf("expected both a definition and a @%s reference in IR, got:\n%s", wantSymbol, got)
+	}
+}
+
+// runMonoLowerPipeline wires a Phase 2 smoke test through the same
+// pipeline the backend uses: parse → resolve → check → ir.Lower →
+// ir.Monomorphize → ir.Validate → GenerateModule. Returns the textual
+// LLVM IR or fails the test.
+func runMonoLowerPipeline(t *testing.T, src, sourcePath string) string {
+	t.Helper()
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("ir.Monomorphize errors: %v", monoErrs)
+	}
+	if validateErrs := ir.Validate(monoMod); len(validateErrs) != 0 {
+		t.Fatalf("ir.Validate errors: %v", validateErrs)
+	}
+	out, err := GenerateModule(monoMod, Options{
+		PackageName: "main",
+		SourcePath:  sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("GenerateModule error: %v\n--- source ---\n%s", err, src)
+	}
+	return string(out)
+}
+
+// TestGenerateModuleGenericStructPairMonomorphized verifies that a
+// generic `struct Pair<T, U>` declaration survives the full pipeline
+// and lands in LLVM IR as a concrete mangled nominal type with
+// Itanium-style `_ZTS…` naming. The smoke stays intentionally narrow —
+// just enough source to drive a StructLit specialization — so that
+// unrelated LLVM-backend gaps (missing field-read intrinsics etc.)
+// don't bleed into the test's signal.
+func TestGenerateModuleGenericStructPairMonomorphized(t *testing.T) {
+	src := `struct Pair<T, U> { first: T, second: U }
+
+fn main() {
+    let p = Pair { first: 1, second: 2 }
+    println(1)
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_pair_ir.osty")
+	const wantTypeName = "_ZTSN4main4PairIllEE"
+	if !strings.Contains(got, wantTypeName) {
+		t.Fatalf("generated IR missing mangled struct type %q:\n%s", wantTypeName, got)
+	}
+	// The mangled name should appear as an LLVM struct type identifier
+	// (`%…`) because llvmgen prefixes struct names with `%` at emit time.
+	if !strings.Contains(got, "%"+wantTypeName) {
+		t.Fatalf("expected %%%s struct type reference in IR, got:\n%s", wantTypeName, got)
+	}
+}
+
+// TestGenerateModuleGenericEnumMaybeMonomorphized verifies that a
+// generic `enum Maybe<T>` lands as a concrete mangled nominal.
+//
+// Currently skipped: Phase 2 correctly rewrites the IR but the LLVM
+// backend's legacy variant-call conversion (`Maybe.Some(42)` → dotted
+// AST FieldExpr) fires an `LLVM015` unsupported diagnostic when the
+// enum name is a mangled Itanium symbol. The IR-level behaviour is
+// covered by TestMonomorphizeGenericEnumSpecialization in
+// internal/ir/monomorph_test.go; the end-to-end smoke is left here as a
+// regression beacon and picked up by the llvmgen enum-lowering
+// follow-up (tracked alongside Phase 2 scope in LLVM_MIGRATION_PLAN.md).
+func TestGenerateModuleGenericEnumMaybeMonomorphized(t *testing.T) {
+	t.Skip("llvmgen variant-call lowering with mangled enum names is Phase 3+ scope")
+	src := `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let m = Maybe.Some(42)
+    println(1)
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_maybe_ir.osty")
+	const wantTypeName = "_ZTSN4main5MaybeIlEE"
+	if !strings.Contains(got, wantTypeName) {
+		t.Fatalf("generated IR missing mangled enum type %q:\n%s", wantTypeName, got)
+	}
+}

--- a/toolchain/monomorph.osty
+++ b/toolchain/monomorph.osty
@@ -27,6 +27,17 @@ pub struct MonomorphMangled {
     pub symbol: String,
 }
 
+/// MonomorphTypeRequest is the struct/enum counterpart of MonomorphRequest.
+/// Go assembles the package name, the generic declaration's source name,
+/// and already-encoded type codes for each template argument; Osty only
+/// ever sees strings. Used by Phase 2 to mangle nominal type symbols
+/// separately from function symbols (Itanium `_ZTS` prefix).
+pub struct MonomorphTypeRequest {
+    pub pkg: String,
+    pub typeName: String,
+    pub typeArgCodes: List<String>,
+}
+
 /// monomorphPrimCode maps an Osty primitive source name to its Itanium
 /// ABI builtin-type code. Returns "" for non-primitives so callers can
 /// fall back to the nested / template encodings. The table mirrors
@@ -142,6 +153,20 @@ pub fn monomorphUserNested(pkg: String, name: String) -> String {
     "N{head}{tail}E"
 }
 
+/// monomorphUserTemplateNested produces the
+/// `N<pkg-len><pkg><name-len><name>I<argCodes>EE` encoding for
+/// user-declared generic nominal types referenced inside other type
+/// codes (e.g. `id::<Pair<Int, String>>` routes Pair through this so the
+/// enclosing function's symbol stays unique per type-argument tuple).
+/// `argCodes` is the already-encoded concatenation of template arg codes
+/// — callers that have an empty arg list should fall back to the
+/// non-template `monomorphUserNested` instead.
+pub fn monomorphUserTemplateNested(pkg: String, name: String, argCodes: String) -> String {
+    let head = monomorphLengthPrefix(pkg)
+    let tail = monomorphLengthPrefix(name)
+    "N{head}{tail}I{argCodes}EE"
+}
+
 /// monomorphTemplateArgs wraps a list of encoded type codes in the
 /// `I...E` template-argument bracket. Empty input returns "" — callers
 /// should therefore skip inserting template args when a function has no
@@ -199,12 +224,61 @@ pub fn monomorphMangleFnName(pkg: String, name: String) -> String {
     "N{pkgPart}{namePart}E"
 }
 
+/// monomorphMangleType assembles the final `_ZTS…` type-symbol for a
+/// generic struct or enum specialization. The `_ZTS` prefix is the
+/// Itanium ABI's "type-string" tag (§2.9.5): keeps nominal type symbols
+/// distinct from the `_Z` function-symbol namespace so tools that
+/// partition by prefix (profilers, demanglers, LLVM text-IR greps) can
+/// tell them apart at a glance.
+///
+/// An empty typeArgCodes list is treated as "caller should not have
+/// routed a non-generic nominal through the monomorphizer"; the function
+/// stays safe and emits a well-formed (if not particularly useful)
+/// symbol in that case.
+pub fn monomorphMangleType(req: MonomorphTypeRequest) -> MonomorphMangled {
+    let body = monomorphMangleTypeName(req.pkg, req.typeName, req.typeArgCodes)
+    MonomorphMangled { symbol: "_ZTS{body}" }
+}
+
+/// monomorphMangleTypeName produces the `<nested-template-name>` portion
+/// of a type symbol (`N<pkgL><pkg><nameL><name>I<args>EE`). Kept public so
+/// Go-side tests can assert the split between `_ZTS` prefix and nested
+/// template encoding without coupling to the final symbol layout.
+///
+/// Unlike function mangling, `main` is still length-prefixed here because
+/// `_ZTS` symbols are value-level identifiers, not callable entry
+/// points, and demanglers expect the package segment to be present.
+pub fn monomorphMangleTypeName(pkg: String, name: String, typeArgCodes: List<String>) -> String {
+    let scope = pkg
+    let actualPkg = if scope == "" { "main" } else { scope }
+    let pkgPart = monomorphLengthPrefix(actualPkg)
+    let namePart = monomorphLengthPrefix(name)
+    let mut args = ""
+    for c in typeArgCodes {
+        args = "{args}{c}"
+    }
+    "N{pkgPart}{namePart}I{args}EE"
+}
+
 /// monomorphDedupeKey returns a stable unique string for a specialization
 /// request. Used by the Go-side worklist to skip duplicate enqueues.
 /// The `\u{1f}` (Unit Separator) byte cannot appear in source identifiers
 /// so the concatenation stays injective.
 pub fn monomorphDedupeKey(fnName: String, pkg: String, typeArgCodes: List<String>) -> String {
     let mut key = "{pkg}\u{1f}{fnName}"
+    for c in typeArgCodes {
+        key = "{key}\u{1f}{c}"
+    }
+    key
+}
+
+/// monomorphTypeDedupeKey is the struct/enum counterpart of
+/// monomorphDedupeKey. The extra "type" tag segment ensures that a
+/// generic function and a generic struct sharing a source name (say,
+/// `Pair`) cannot collide in the engine's seen-map. Same injective
+/// separator contract as monomorphDedupeKey.
+pub fn monomorphTypeDedupeKey(typeName: String, pkg: String, typeArgCodes: List<String>) -> String {
+    let mut key = "{pkg}\u{1f}type\u{1f}{typeName}"
     for c in typeArgCodes {
         key = "{key}\u{1f}{c}"
     }


### PR DESCRIPTION
## Summary

- **Phase 1 파이프라인 통합**: `ir.Monomorphize`(#196에서 만든 엔진)를 `backend.PrepareEntry`의 `ir.Lower` → `ir.Validate` 사이에 실제로 연결해서, LLVM 백엔드는 이제 `Generics=0`인 IR만 받는다. 후속 PR에서 채울 예정이던 단위 테스트(31건) + LLVM E2E smoke도 함께 추가.
- **Phase 2 generic struct/enum 선언**: `struct Pair<T, U>`, `enum Maybe<T>` 같은 generic 선언을 concrete type-tuple마다 specialization으로 낮추고, 사용 site(StructLit/VariantLit/LetStmt.Type/필드/variant payload/method signature)를 전부 Itanium `_ZTS…` 나미널 심볼로 재작성한다.

## Phase 1 (파이프라인 통합)

- `internal/backend/entry.go:26-42` — `ir.Lower` → `ir.Monomorphize` → `ir.Validate` 순서로 훅 삽입.
- `internal/ir/clone_test.go`, `subst_test.go`, `monomorph_test.go` 신규 — deep clone 동등성, TypeVar 전파, free-fn specialization / dedup / nested call / mangled-ident validity / arity mismatch 등 31 테스트.
- `internal/llvmgen/ir_module_test.go`에 `TestGenerateModuleGenericIdentityMonomorphized` — `id::<Int>(42)` 호출이 `@_Z2idIlEl` 심볼로 LLVM IR에 emit됨을 검증.

## Phase 2 (struct/enum 선언)

### Mangling
- 함수 심볼은 `_Z…`, 나미널 타입은 Itanium RTTI 스타일 `_ZTS…` 로 분리. 예: `Pair<Int, Int>` → `_ZTSN4main4PairIllEE`.
- `toolchain/monomorph.osty`에 `MonomorphTypeRequest`, `monomorphMangleType/TypeName`, `monomorphUserTemplateNested`, `monomorphTypeDedupeKey` 추가. `internal/ir/monomorph_snapshot.go`도 1:1 동기화.

### 엔진
- `monoState`에 `genericStructsByName`/`genericEnumsByName`/`typeSeen`/`typeQueue` 추가. Pass 1이 struct/enum 선언도 인덱스.
- 메인 루프를 `for len(queue) > 0 || len(typeQueue) > 0`로 바꿔 fn queue와 type queue를 인터리브 drain (fixed-point).
- `rewriteType`이 `NamedType.Args`를 bottom-up으로 walk한 뒤 자기 자신을 request — nested generic(`Pair<Maybe<Bool>, Int>`)도 자연스럽게 encode.
- `rewriteExprType`/`rewriteFnSignature`가 모든 `Expr.T`, `StructLit.{TypeName,T}`, `VariantLit.{Enum,T}`, `Ident.TypeArgs`, `CallExpr.TypeArgs`, `MethodCall.TypeArgs`, `LetStmt.Type`, `FnDecl.{Params,Return}`, `Field.Type`, `Variant.Payload`, `Closure.Captures` 등을 재작성.
- `emitStructSpecialization`/`emitEnumSpecialization`이 치환 후 field/payload/method signature 재작성. **Method-local generic은 skip + warning** (Phase 3+ 범위 명시).
- `typeCodeOf`가 user generic `NamedType`을 `MonomorphUserTemplateNested`로 인코딩해 fn 심볼도 nested generic type args를 반영.

### 테스트
- `internal/ir/monomorph_test.go`에 29건 추가: mangling helper(6), `typeCodeOf` user-generic(4), `rewriteType` isolated(7), struct/enum integration(12).
- LLVM E2E smoke:
  - ✅ `TestGenerateModuleGenericStructPairMonomorphized` — `%_ZTSN4main4PairIllEE` 나미널 타입이 LLVM IR에 emit.
  - ⏸️ `TestGenerateModuleGenericEnumMaybeMonomorphized` — `t.Skip`. llvmgen legacy variant-call lowering이 mangled enum 이름을 처리하도록 확장된 뒤 활성화 예정. IR-level 동작은 `TestMonomorphizeGenericEnumSpecialization`으로 잠금.

## 문서

- `ARCHITECTURE.md`: Instantiations → Monomorphize 경로에 struct/enum 트랙 추가, `_Z`/`_ZTS` 네임스페이스 구분 명시.
- `LLVM_MIGRATION_PLAN.md` Phase 5: Phase 1+2 완료 + 남은 범위(generic interface, method-local generic, bare turbofish, llvmgen enum lowering).
- `README.md`: IR 항목에 generic struct/enum monomorphization 반영.

## 남은 범위 (Phase 3+)

- `llvmgen` variant-call lowering의 mangled enum name 지원 → enum smoke 활성화
- Generic interface 선언
- Method-local generic parameter (`fn map<U>(...)`)
- Bare function-pointer turbofish (`let f = id::<Int>`)

## Test plan

- [x] `go test ./internal/ir/ -count=1` — 60건(Phase 1 31 + Phase 2 29) 전부 pass
- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleGeneric' -count=1` — identity + struct smoke pass, enum skipped
- [x] `go vet ./internal/ir/ ./internal/llvmgen/ ./internal/backend/` clean
- [x] `gofmt -l` clean on touched files
- [x] `internal/backend`·`internal/llvmgen`의 pre-existing 실패 목록은 이 PR 전후 동일 (stash/diff로 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)