### PR TITLE
Protect selfhost artifact during bootstrap regen

### DIFF
--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -74,13 +74,14 @@ func run() error {
 	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
 		return fmt.Errorf("write merged selfhost source: %w", err)
 	}
+	tmpOutPath := filepath.Join(tmpDir, "generated.go")
 
 	cmd := exec.Command(
 		"go", "run", "-tags", "selfhostgen", "./cmd/osty", "gen",
 		"--backend", "go",
 		"--emit", "go",
 		"--package", "selfhost",
-		"-o", outPath,
+		"-o", tmpOutPath,
 		mergedPath,
 	)
 	cmd.Dir = root
@@ -88,7 +89,28 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("generate selfhost parser: %w\n%s", err, bytes.TrimSpace(output))
 	}
-	return patchGenerated(outPath)
+	if selfhostgenMissingTypes(output) {
+		return fmt.Errorf(
+			"generate selfhost parser: selfhostgen emitted untyped bootstrap Go; refusing to overwrite %s\n%s",
+			outPath,
+			bytes.TrimSpace(output),
+		)
+	}
+	if err := patchGenerated(tmpOutPath); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(tmpOutPath)
+	if err != nil {
+		return fmt.Errorf("read patched selfhost code: %w", err)
+	}
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		return fmt.Errorf("install generated selfhost code: %w", err)
+	}
+	return nil
+}
+
+func selfhostgenMissingTypes(output []byte) bool {
+	return bytes.Contains(output, []byte("osty gen: warning: native type checking is unavailable"))
 }
 
 func generatedSelfhostUpToDate(root, outPath string) (bool, error) {


### PR DESCRIPTION
## Summary
- generate selfhost output into a temporary file before touching `internal/selfhost/generated.go`
- refuse to install regenerated output when bootstrap generation falls back to untyped Go
- only copy the patched artifact into place after generation succeeds

## Verification
- `go build ./internal/selfhost`
- `go build ./cmd/osty`
- `go test ./internal/selfhost -run TestParseSnapshotDeterministic -count=1`
- `go test ./cmd/osty -run TestMainGen -count=1`

## Notes
- `go test ./internal/selfhost/...` still reports existing snapshot drift in `TestParseSnapshot`