### PR TITLE
feat: improve self-hosted resolver parity

### DIFF
--- a/examples/selfhost-core/diagnostic.osty
+++ b/examples/selfhost-core/diagnostic.osty
@@ -175,6 +175,14 @@ fn diagnosticSubject(name: String) -> String {
     }
 }
 
+fn diagnosticHint(hint: String) -> String {
+    if hint == "" {
+        ""
+    } else {
+        " hint=\"{hint}\""
+    }
+}
+
 fn diagnosticFormatOne(
     source: String,
     code: String,
@@ -193,7 +201,7 @@ pub fn diagnosticFormatSelfResolveDiagnostic(
     source: String,
     diag: SelfResolveDiagnostic,
 ) -> String {
-    diagnosticFormatOne(source, diag.code, diag.message, diag.name, diag.start, diag.end)
+    "{diagnosticFormatOne(source, diag.code, diag.message, diag.name, diag.start, diag.end)}{diagnosticHint(diag.hint)}"
 }
 
 pub fn diagnosticFormatSelfResolveDiagnostics(

--- a/examples/selfhost-core/diagnostic_test.osty
+++ b/examples/selfhost-core/diagnostic_test.osty
@@ -92,6 +92,14 @@ fn testDiagnosticFormatsResolveDiagnosticsWithLocations() {
     assertDiagnosticTextContains(output, "undefined name `missing`")
 }
 
+fn testDiagnosticFormatsResolveHints() {
+    let source = "fn main() \{\n    let value = 1\n    vaule\n\}\n"
+    let result = selfResolveSource(source)
+    let output = diagnosticFormatSelfResolveDiagnostics(source, result)
+
+    assertDiagnosticTextContains(output, "hint=\"did you mean `value`?\"")
+}
+
 fn testDiagnosticFormatsLintDiagnosticsWithLocations() {
     let source = "fn same(x: Int) -> Bool \{\n    x == (x)\n\}\n"
     let report = selfLintSource(source)

--- a/examples/selfhost-core/resolve.osty
+++ b/examples/selfhost-core/resolve.osty
@@ -26,6 +26,7 @@ pub struct SelfResolveDiagnostic {
     pub start: Int,
     pub end: Int,
     pub node: Int,
+    pub hint: String,
 }
 
 /// SelfResolveResult contains package symbols plus resolver diagnostics and
@@ -91,7 +92,19 @@ fn selfResolveDiagnosticAtNode(
     end: Int,
     node: Int,
 ) -> SelfResolveDiagnostic {
-    SelfResolveDiagnostic { code, message, name, start, end, node }
+    selfResolveDiagnosticHintAtNode(code, message, name, start, end, node, "")
+}
+
+fn selfResolveDiagnosticHintAtNode(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+    hint: String,
+) -> SelfResolveDiagnostic {
+    SelfResolveDiagnostic { code, message, name, start, end, node, hint }
 }
 
 pub fn emptySelfResolveResult() -> SelfResolveResult {
@@ -306,14 +319,27 @@ fn selfResolveName(name: String, start: Int, end: Int, node: Int) -> SelfResolve
 struct SelfResolveScope {
     symbols: List<SelfSymbol>,
     depth: Int,
+    ifaceDefault: Bool,
 }
 
 fn srRootScope(result: SelfResolveResult) -> SelfResolveScope {
-    SelfResolveScope { symbols: srSymbolListCopy(result.symbols), depth: 0 }
+    SelfResolveScope { symbols: srSymbolListCopy(result.symbols), depth: 0, ifaceDefault: false }
 }
 
 fn srChildScope(parent: SelfResolveScope) -> SelfResolveScope {
-    SelfResolveScope { symbols: srSymbolListCopy(parent.symbols), depth: parent.depth + 1 }
+    SelfResolveScope {
+        symbols: srSymbolListCopy(parent.symbols),
+        depth: parent.depth + 1,
+        ifaceDefault: parent.ifaceDefault,
+    }
+}
+
+fn srChildScopeWithIfaceDefault(parent: SelfResolveScope, ifaceDefault: Bool) -> SelfResolveScope {
+    SelfResolveScope {
+        symbols: srSymbolListCopy(parent.symbols),
+        depth: parent.depth + 1,
+        ifaceDefault,
+    }
 }
 
 fn srScopeDefine(
@@ -459,7 +485,7 @@ fn srAstScanFunctionsInDecl(
     let node = srAstNode(file, idx)
     let mut out = result
     if node.kind == AstNFnDecl {
-        return srAstResolveFunction(file, idx, scope, "", out)
+        return srAstResolveFunction(file, idx, scope, "", false, out)
     }
     if node.kind == AstNStructDecl || node.kind == AstNEnumDecl || node.kind == AstNInterfaceDecl {
         return srAstResolveTypeDecl(file, idx, scope, out)
@@ -497,7 +523,7 @@ fn srAstResolveTypeDecl(
                 out = srAstResolveType(file, member.right, typeScope, node.text, out)
                 out = srAstResolveExpr(file, member.left, typeScope, out)
             } else if member.kind == AstNFnDecl {
-                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, false, out)
             }
         }
     } else if node.kind == AstNEnumDecl {
@@ -508,7 +534,7 @@ fn srAstResolveTypeDecl(
                     out = srAstResolveType(file, ty, typeScope, node.text, out)
                 }
             } else if member.kind == AstNFnDecl {
-                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, false, out)
             }
         }
     } else if node.kind == AstNInterfaceDecl {
@@ -518,7 +544,7 @@ fn srAstResolveTypeDecl(
         for memberIdx in node.children {
             let member = srAstNode(file, memberIdx)
             if member.kind == AstNFnDecl {
-                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, member.right >= 0, out)
             } else if member.kind == AstNType {
                 out = srAstResolveType(file, memberIdx, typeScope, node.text, out)
             }
@@ -567,6 +593,7 @@ fn srAstResolveFunction(
     idx: Int,
     scope: SelfResolveScope,
     owner: String,
+    ifaceDefault: Bool,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let node = srAstNode(file, idx)
@@ -582,7 +609,7 @@ fn srAstResolveFunction(
         out = srAstResolveParamBindings(file, paramIdx, fnScope, owner, out)
     }
     out = srAstResolveType(file, node.left, fnScope, owner, out)
-    let bodyScope = srChildScope(fnScope)
+    let bodyScope = srChildScopeWithIfaceDefault(fnScope, ifaceDefault)
     srAstResolveBlock(file, node.right, bodyScope, out)
 }
 
@@ -687,6 +714,12 @@ fn srAstResolveType(
         out = srAstResolveType(file, node.right, scope, owner, out)
     } else {
         out = srResolveOneAstType(node.text, node.start, node.end, idx, scope, owner, out)
+        let head = srPathHead(node.text)
+        let tail = srPathLastSegment(node.text)
+        let sym = srScopeLookup(scope, head)
+        if head != "" && tail != head && sym.kind == "package" {
+            out = srResolvePackageMember(file, sym, tail, node.start, node.end, idx, true, out)
+        }
         for child in node.children {
             out = srAstResolveType(file, child, scope, owner, out)
         }
@@ -709,7 +742,10 @@ fn srAstResolveExpr(
         return srResolveOneAstIdent(node.text, node.start, node.end, idx, scope, out)
     }
     if node.kind == AstNField {
-        return srAstResolveExpr(file, node.left, scope, out)
+        return srAstResolveField(file, idx, node, scope, out)
+    }
+    if node.kind == AstNCall {
+        return srAstResolveCall(file, node, scope, out)
     }
     if node.kind == AstNStructLit {
         out = srAstResolveExpr(file, node.left, scope, out)
@@ -764,6 +800,63 @@ fn srAstResolveStructField(
     srResolveOneAstIdent(node.text, node.start, node.end, idx, scope, result)
 }
 
+fn srAstResolveField(
+    file: AstFile,
+    idx: Int,
+    node: AstNode,
+    scope: SelfResolveScope,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = srAstResolveExpr(file, node.left, scope, result)
+    let base = srAstNode(file, node.left)
+    if base.kind == AstNIdent {
+        let sym = srScopeLookup(scope, base.text)
+        if sym.kind == "package" {
+            return srResolvePackageMember(file, sym, node.text, node.start, node.end, idx, false, out)
+        }
+        if scope.ifaceDefault && node.flags != 1 && base.text == "self" {
+            return srInterfaceDefaultFieldAtNode(out, node.start, node.end, idx)
+        }
+    }
+    out
+}
+
+fn srAstResolveCall(
+    file: AstFile,
+    node: AstNode,
+    scope: SelfResolveScope,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let callee = srAstNode(file, node.left)
+    if callee.kind == AstNField {
+        out = srAstResolveCallField(file, callee, scope, out)
+    } else {
+        out = srAstResolveExpr(file, node.left, scope, out)
+    }
+    for child in node.children {
+        out = srAstResolveExpr(file, child, scope, out)
+    }
+    out
+}
+
+fn srAstResolveCallField(
+    file: AstFile,
+    node: AstNode,
+    scope: SelfResolveScope,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = srAstResolveExpr(file, node.left, scope, result)
+    let base = srAstNode(file, node.left)
+    if base.kind == AstNIdent {
+        let sym = srScopeLookup(scope, base.text)
+        if sym.kind == "package" {
+            out = srResolvePackageMember(file, sym, node.text, node.start, node.end, node.left, false, out)
+        }
+    }
+    out
+}
+
 fn srAstResolveIf(
     file: AstFile,
     node: AstNode,
@@ -807,7 +900,7 @@ fn srAstResolveClosure(
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    let closureScope = srChildScope(scope)
+    let closureScope = srChildScopeWithIfaceDefault(scope, false)
     for paramIdx in node.children {
         let param = srAstNode(file, paramIdx)
         out = srAstResolveType(file, param.right, closureScope, "", out)
@@ -848,7 +941,14 @@ fn srResolveOneAstIdent(
         return srRecordRef(out, name, node, sym)
     }
     out.unresolved = out.unresolved + 1
-    out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
+    let hint = srUndefinedHint(scope, name)
+    if hint == "" {
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
+    } else {
+        out.diagnostics.push(
+            selfResolveDiagnosticHintAtNode("E0500", "undefined name", name, start, end, node, hint),
+        )
+    }
     out
 }
 
@@ -862,26 +962,73 @@ fn srResolveOneAstType(
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    if name == "Self" {
+    let head = srPathHead(name)
+    if head == "" {
+        return out
+    }
+    if head == "Self" {
         if owner == "" {
             return srSelfTypeOutsideAtNode(out, start, end, node)
         }
         return srRecordTypeRef(out, name, node)
     }
-    if srIsBuiltinTypeName(name) {
+    if srIsBuiltinTypeName(head) {
         return srRecordTypeRef(out, name, node)
     }
-    let sym = srScopeLookup(scope, name)
+    let sym = srScopeLookup(scope, head)
     if sym.name == "" {
         out.unresolved = out.unresolved + 1
-        out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined type", name, start, end, node))
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined type", head, start, end, node))
         return out
     }
     if !(srSymbolCanBeType(sym)) {
-        out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", name, start, end, node))
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", head, start, end, node))
         return out
     }
     srRecordTypeRef(out, name, node)
+}
+
+fn srResolvePackageMember(
+    file: AstFile,
+    pkgSym: SelfSymbol,
+    member: String,
+    start: Int,
+    end: Int,
+    node: Int,
+    typePos: Bool,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let useNode = srAstUseNode(file, pkgSym)
+    if useNode.kind != AstNUseDecl {
+        return out
+    }
+    if srAstListCount(useNode.children) == 0 {
+        return out
+    }
+    let sym = srAstLookupPackageMember(file, useNode, member)
+    if sym.name == "" {
+        let noun = if typePos {
+            "type"
+        } else {
+            "name"
+        }
+        out.diagnostics.push(
+            selfResolveDiagnosticAtNode(
+                "E0508",
+                "package `{pkgSym.name}` has no exported {noun}",
+                member,
+                start,
+                end,
+                node,
+            ),
+        )
+        return out
+    }
+    if typePos && !(srSymbolCanBeType(sym)) {
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", member, start, end, node))
+    }
+    out
 }
 
 fn srRecordRef(
@@ -921,6 +1068,27 @@ fn srSelfOutsideAtNode(result: SelfResolveResult, start: Int, end: Int, node: In
 fn srSelfTypeOutsideAtNode(result: SelfResolveResult, start: Int, end: Int, node: Int) -> SelfResolveResult {
     let mut out = result
     out.diagnostics.push(selfResolveDiagnosticAtNode("E0504", "`Self` outside type body", "Self", start, end, node))
+    out
+}
+
+fn srInterfaceDefaultFieldAtNode(
+    result: SelfResolveResult,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(
+        selfResolveDiagnosticHintAtNode(
+            "E0606",
+            "interface default method bodies may not access fields on `self`",
+            "",
+            start,
+            end,
+            node,
+            "expose the value through an interface method and call that instead",
+        ),
+    )
     out
 }
 
@@ -1465,8 +1633,147 @@ fn srStringListIndex(items: List<String>, target: String) -> Int {
     -1
 }
 
+fn srUndefinedHint(scope: SelfResolveScope, name: String) -> String {
+    let suggestion = srSuggestSimilar(scope, name)
+    if suggestion == "" {
+        return ""
+    }
+    "did you mean `{suggestion}`?"
+}
+
+fn srSuggestSimilar(scope: SelfResolveScope, name: String) -> String {
+    let mut best = ""
+    let mut bestDist = 3
+    let nameLen = srStringUnitCount(name)
+    for sym in scope.symbols {
+        let diff = srStringUnitCount(sym.name) - nameLen
+        if diff > bestDist - 1 || 0 - diff > bestDist - 1 {
+            continue
+        }
+        let dist = srLevenshteinBounded(name, sym.name, bestDist)
+        if dist < bestDist {
+            best = sym.name
+            bestDist = dist
+            if bestDist == 1 {
+                return best
+            }
+        }
+    }
+    best
+}
+
+fn srLevenshteinBounded(left: String, right: String, limit: Int) -> Int {
+    if left == right {
+        return 0
+    }
+    let leftUnits = strings.Split(left, "")
+    let rightUnits = strings.Split(right, "")
+    let leftLen = srStringUnitCount(left)
+    let rightLen = srStringUnitCount(right)
+    let diff = leftLen - rightLen
+    if diff >= limit || 0 - diff >= limit {
+        return limit
+    }
+    let mut prev: List<Int> = []
+    let mut cur: List<Int> = []
+    let mut j = 0
+    while j <= rightLen {
+        prev.push(j)
+        cur.push(0)
+        j = j + 1
+    }
+    let mut i = 1
+    while i <= leftLen {
+        cur[0] = i
+        let mut rowMin = cur[0]
+        j = 1
+        while j <= rightLen {
+            let leftUnit = srStringListAt(leftUnits, i - 1)
+            let rightUnit = srStringListAt(rightUnits, j - 1)
+            let cost = if leftUnit == rightUnit {
+                0
+            } else {
+                1
+            }
+            let mut dist = prev[j] + 1
+            if cur[j - 1] + 1 < dist {
+                dist = cur[j - 1] + 1
+            }
+            if prev[j - 1] + cost < dist {
+                dist = prev[j - 1] + cost
+            }
+            cur[j] = dist
+            if dist < rowMin {
+                rowMin = dist
+            }
+            j = j + 1
+        }
+        if rowMin >= limit {
+            return limit
+        }
+        j = 0
+        while j <= rightLen {
+            prev[j] = cur[j]
+            cur[j] = 0
+            j = j + 1
+        }
+        i = i + 1
+    }
+    prev[rightLen]
+}
+
+fn srStringUnitCount(text: String) -> Int {
+    let mut count = 0
+    for unit in strings.Split(text, "") {
+        if unit != "" {
+            count = count + 1
+        }
+    }
+    count
+}
+
 fn srSymbolCanBeType(sym: SelfSymbol) -> Bool {
     sym.kind == "type" || sym.kind == "generic" || sym.kind == "package"
+}
+
+fn srAstUseNode(file: AstFile, pkgSym: SelfSymbol) -> AstNode {
+    if pkgSym.node < 0 {
+        return emptyAstNode(AstNFile)
+    }
+    srAstNode(file, pkgSym.node)
+}
+
+fn srAstLookupPackageMember(file: AstFile, useNode: AstNode, member: String) -> SelfSymbol {
+    for childIdx in useNode.children {
+        let child = srAstNode(file, childIdx)
+        if child.text == member {
+            return selfSymbolAtNode(
+                member,
+                srAstPackageMemberKind(child),
+                "",
+                0,
+                0,
+                child.start,
+                child.end,
+                true,
+                childIdx,
+            )
+        }
+    }
+    srEmptySymbol()
+}
+
+fn srAstPackageMemberKind(node: AstNode) -> String {
+    if node.kind == AstNFnDecl {
+        return "fn"
+    }
+    if node.kind == AstNStructDecl || node.kind == AstNEnumDecl || node.kind == AstNInterfaceDecl || node.kind == AstNTypeAlias {
+        return "type"
+    }
+    if node.kind == AstNLet {
+        return "value"
+    }
+    ""
 }
 
 fn srEmptySymbol() -> SelfSymbol {

--- a/examples/selfhost-core/resolve_test.osty
+++ b/examples/selfhost-core/resolve_test.osty
@@ -213,6 +213,54 @@ fn testSelfResolverReportsTypePositionErrors() {
     testing.assertEq(selfResolveCodeCount(result, "E0502"), 1)
 }
 
+fn testSelfResolverResolvesQualifiedTypeReferences() {
+    let result = selfResolveSource(
+        r"""
+            use std.error as error
+
+            fn wrap(err: error.Error) -> Result<String, error.Error> {
+                Err(err)
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveDiagnosticCount(result), 0)
+    testing.assert(selfResolveHasTypeRef(result, "error.Error"))
+}
+
+fn testSelfResolverReportsMissingGoPackageMembers() {
+    let result = selfResolveSource(
+        r"""
+            use go "net/http" as http {
+                fn Get(url: String) -> String
+                type Client = String
+            }
+
+            fn bad() -> http.MissingType {
+                http.Missing()
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0508"), 2)
+}
+
+fn testSelfResolverReportsWrongKindForQualifiedGoType() {
+    let result = selfResolveSource(
+        r"""
+            use go "net/http" as http {
+                fn Get(url: String) -> String
+            }
+
+            fn bad(value: http.Get) -> Int {
+                0
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0502"), 1)
+}
+
 fn testSelfResolverReportsSelfOutsideMethodAndSelfTypeOutsideType() {
     let result = selfResolveSource(
         r"""
@@ -224,6 +272,21 @@ fn testSelfResolverReportsSelfOutsideMethodAndSelfTypeOutsideType() {
 
     testing.assertEq(selfResolveCodeCount(result, "E0503"), 1)
     testing.assertEq(selfResolveCodeCount(result, "E0504"), 2)
+}
+
+fn testSelfResolverReportsInterfaceDefaultFieldAccess() {
+    let result = selfResolveSource(
+        r"""
+            interface Labeler {
+                fn label(self) -> String {
+                    self.name
+                }
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0606"), 1)
+    testing.assertEq(result.diagnostics[0].hint, "expose the value through an interface method and call that instead")
 }
 
 fn testSelfResolverAllowsSelfTypeInsideTypeBody() {
@@ -317,4 +380,18 @@ fn testSelfResolverAllowsSameMethodNamesAcrossTypes() {
     )
 
     testing.assertEq(selfResolveDiagnosticCount(result), 0)
+}
+
+fn testSelfResolverSuggestsNearbyNames() {
+    let result = selfResolveSource(
+        r"""
+            fn main() {
+                let value = 1
+                vaule
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0500"), 1)
+    testing.assertEq(result.diagnostics[0].hint, "did you mean `value`?")
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -33513,6 +33513,7 @@ type SelfResolveDiagnostic struct {
 	start   int
 	end     int
 	node    int
+	hint    string
 }
 
 // Osty: /tmp/selfhost_merged.osty:13371:5
@@ -33549,7 +33550,11 @@ func selfResolveDiagnostic(code string, message string, name string, start int, 
 
 // Osty: /tmp/selfhost_merged.osty:13424:1
 func selfResolveDiagnosticAtNode(code string, message string, name string, start int, end int, node int) *SelfResolveDiagnostic {
-	return &SelfResolveDiagnostic{code: code, message: message, name: name, start: start, end: end, node: node}
+	return selfResolveDiagnosticHintAtNode(code, message, name, start, end, node, "")
+}
+
+func selfResolveDiagnosticHintAtNode(code string, message string, name string, start int, end int, node int, hint string) *SelfResolveDiagnostic {
+	return &SelfResolveDiagnostic{code: code, message: message, name: name, start: start, end: end, node: node, hint: hint}
 }
 
 // Osty: /tmp/selfhost_merged.osty:13435:5
@@ -33913,28 +33918,31 @@ func selfResolveName(name string, start int, end int, node int) *SelfResolveName
 
 // Osty: /tmp/selfhost_merged.osty:13644:1
 type SelfResolveScope struct {
-	symbols []*SelfSymbol
-	depth   int
+	symbols      []*SelfSymbol
+	depth        int
+	ifaceDefault bool
 }
 
 // Osty: /tmp/selfhost_merged.osty:13649:1
 func srRootScope(result *SelfResolveResult) *SelfResolveScope {
-	return &SelfResolveScope{symbols: srSymbolListCopy(result.symbols), depth: 0}
+	return &SelfResolveScope{symbols: srSymbolListCopy(result.symbols), depth: 0, ifaceDefault: false}
 }
 
 // Osty: /tmp/selfhost_merged.osty:13653:1
 func srChildScope(parent *SelfResolveScope) *SelfResolveScope {
-	return &SelfResolveScope{symbols: srSymbolListCopy(parent.symbols), depth: func() int {
-		var _p2264 int = parent.depth
-		var _rhs2265 int = 1
-		if _rhs2265 > 0 && _p2264 > math.MaxInt-_rhs2265 {
-			panic("integer overflow")
-		}
-		if _rhs2265 < 0 && _p2264 < math.MinInt-_rhs2265 {
-			panic("integer overflow")
-		}
-		return _p2264 + _rhs2265
-	}()}
+	return &SelfResolveScope{
+		symbols:      srSymbolListCopy(parent.symbols),
+		depth:        parent.depth + 1,
+		ifaceDefault: parent.ifaceDefault,
+	}
+}
+
+func srChildScopeWithIfaceDefault(parent *SelfResolveScope, ifaceDefault bool) *SelfResolveScope {
+	return &SelfResolveScope{
+		symbols:      srSymbolListCopy(parent.symbols),
+		depth:        parent.depth + 1,
+		ifaceDefault: ifaceDefault,
+	}
 }
 
 // Osty: /tmp/selfhost_merged.osty:13657:1
@@ -34075,37 +34083,22 @@ func selfResolveAstScanFunctions(file *AstFile, scope *SelfResolveScope, result 
 
 // Osty: /tmp/selfhost_merged.osty:13788:1
 func srAstScanFunctionsInDecl(file *AstFile, idx int, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:13794:5
 	if idx < 0 {
-		// Osty: /tmp/selfhost_merged.osty:13795:9
 		return result
 	}
-	// Osty: /tmp/selfhost_merged.osty:13797:5
 	node := srAstNode(file, idx)
-	_ = node
-	// Osty: /tmp/selfhost_merged.osty:13798:5
 	out := result
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:13799:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNFnDecl{})) {
-		// Osty: /tmp/selfhost_merged.osty:13800:9
-		return srAstResolveFunction(file, idx, scope, "", out)
+		return srAstResolveFunction(file, idx, scope, "", false, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:13802:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNStructDecl{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNEnumDecl{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNInterfaceDecl{})) {
-		// Osty: /tmp/selfhost_merged.osty:13803:9
 		return srAstResolveTypeDecl(file, idx, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:13805:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNTypeAlias{})) {
-		// Osty: /tmp/selfhost_merged.osty:13806:9
 		return srAstResolveTypeAlias(file, node, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:13808:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNLet{})) {
-		// Osty: /tmp/selfhost_merged.osty:13809:9
 		out = srAstResolveType(file, srAstChildAt(node.children, 0), scope, "", out)
-		// Osty: /tmp/selfhost_merged.osty:13810:9
 		return srAstResolveExpr(file, node.right, scope, out)
 	}
 	return out
@@ -34113,73 +34106,42 @@ func srAstScanFunctionsInDecl(file *AstFile, idx int, scope *SelfResolveScope, r
 
 // Osty: /tmp/selfhost_merged.osty:13815:1
 func srAstResolveTypeDecl(file *AstFile, idx int, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:13821:5
 	node := srAstNode(file, idx)
-	_ = node
-	// Osty: /tmp/selfhost_merged.osty:13822:5
 	typeScope := srChildScope(scope)
-	_ = typeScope
-	// Osty: /tmp/selfhost_merged.osty:13823:5
 	out := srScopeDefine(typeScope, result, selfSymbolAtNode("Self", "type", node.text, 0, typeScope.depth, node.start, node.end, true, idx))
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:13828:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNStructDecl{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNEnumDecl{})) {
-		// Osty: /tmp/selfhost_merged.osty:13829:9
 		out = srAstDeclareGenerics(file, node.children2, typeScope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:13831:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNStructDecl{})) {
-		// Osty: /tmp/selfhost_merged.osty:13832:9
 		for _, memberIdx := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:13833:13
 			member := srAstNode(file, memberIdx)
-			_ = member
-			// Osty: /tmp/selfhost_merged.osty:13834:13
 			if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
-				// Osty: /tmp/selfhost_merged.osty:13835:17
 				out = srAstResolveType(file, member.right, typeScope, node.text, out)
-				// Osty: /tmp/selfhost_merged.osty:13836:17
 				out = srAstResolveExpr(file, member.left, typeScope, out)
 			} else if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNFnDecl{})) {
-				// Osty: /tmp/selfhost_merged.osty:13838:17
-				out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+				out = srAstResolveFunction(file, memberIdx, typeScope, node.text, false, out)
 			}
 		}
 	} else if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNEnumDecl{})) {
-		// Osty: /tmp/selfhost_merged.osty:13842:9
 		for _, memberIdx := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:13843:13
 			member := srAstNode(file, memberIdx)
-			_ = member
-			// Osty: /tmp/selfhost_merged.osty:13844:13
 			if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNVariant{})) {
-				// Osty: /tmp/selfhost_merged.osty:13845:17
 				for _, ty := range member.children {
-					// Osty: /tmp/selfhost_merged.osty:13846:21
 					out = srAstResolveType(file, ty, typeScope, node.text, out)
 				}
 			} else if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNFnDecl{})) {
-				// Osty: /tmp/selfhost_merged.osty:13849:17
-				out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+				out = srAstResolveFunction(file, memberIdx, typeScope, node.text, false, out)
 			}
 		}
 	} else if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNInterfaceDecl{})) {
-		// Osty: /tmp/selfhost_merged.osty:13853:9
 		for _, superIdx := range node.children2 {
-			// Osty: /tmp/selfhost_merged.osty:13854:13
 			out = srAstResolveType(file, superIdx, typeScope, node.text, out)
 		}
-		// Osty: /tmp/selfhost_merged.osty:13856:9
 		for _, memberIdx := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:13857:13
 			member := srAstNode(file, memberIdx)
-			_ = member
-			// Osty: /tmp/selfhost_merged.osty:13858:13
 			if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNFnDecl{})) {
-				// Osty: /tmp/selfhost_merged.osty:13859:17
-				out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+				out = srAstResolveFunction(file, memberIdx, typeScope, node.text, member.right >= 0, out)
 			} else if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNType{})) {
-				// Osty: /tmp/selfhost_merged.osty:13861:17
 				out = srAstResolveType(file, memberIdx, typeScope, node.text, out)
 			}
 		}
@@ -34226,38 +34188,21 @@ func srAstDeclareGenerics(file *AstFile, generics []int, scope *SelfResolveScope
 }
 
 // Osty: /tmp/selfhost_merged.osty:13903:1
-func srAstResolveFunction(file *AstFile, idx int, scope *SelfResolveScope, owner string, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:13910:5
+func srAstResolveFunction(file *AstFile, idx int, scope *SelfResolveScope, owner string, ifaceDefault bool, result *SelfResolveResult) *SelfResolveResult {
 	node := srAstNode(file, idx)
-	_ = node
-	// Osty: /tmp/selfhost_merged.osty:13911:5
 	out := result
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:13912:5
 	fnScope := srChildScope(scope)
-	_ = fnScope
-	// Osty: /tmp/selfhost_merged.osty:13913:5
 	out = srAstDeclareGenerics(file, node.children2, fnScope, out)
-	// Osty: /tmp/selfhost_merged.osty:13914:5
 	for _, paramIdx := range node.children {
-		// Osty: /tmp/selfhost_merged.osty:13915:9
 		param := srAstNode(file, paramIdx)
-		_ = param
-		// Osty: /tmp/selfhost_merged.osty:13916:9
 		if param.left >= 0 && param.text != "" {
-			// Osty: /tmp/selfhost_merged.osty:13917:13
 			out = srAstResolveExpr(file, param.left, fnScope, out)
 		}
-		// Osty: /tmp/selfhost_merged.osty:13919:9
 		out = srAstResolveType(file, param.right, fnScope, owner, out)
-		// Osty: /tmp/selfhost_merged.osty:13920:9
 		out = srAstResolveParamBindings(file, paramIdx, fnScope, owner, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:13922:5
 	out = srAstResolveType(file, node.left, fnScope, owner, out)
-	// Osty: /tmp/selfhost_merged.osty:13923:5
-	bodyScope := srChildScope(fnScope)
-	_ = bodyScope
+	bodyScope := srChildScopeWithIfaceDefault(fnScope, ifaceDefault)
 	return srAstResolveBlock(file, node.right, bodyScope, out)
 }
 
@@ -34364,51 +34309,37 @@ func srAstResolveFor(file *AstFile, node *AstNode, scope *SelfResolveScope, resu
 
 // Osty: /tmp/selfhost_merged.osty:13997:1
 func srAstResolveType(file *AstFile, idx int, scope *SelfResolveScope, owner string, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:14004:5
 	if idx < 0 {
-		// Osty: /tmp/selfhost_merged.osty:14005:9
 		return result
 	}
-	// Osty: /tmp/selfhost_merged.osty:14007:5
 	node := srAstNode(file, idx)
-	_ = node
-	// Osty: /tmp/selfhost_merged.osty:14008:5
 	if !ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNType{})) {
-		// Osty: /tmp/selfhost_merged.osty:14009:9
 		return result
 	}
-	// Osty: /tmp/selfhost_merged.osty:14011:5
 	out := result
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:14012:5
 	if node.text == "error" {
-		// Osty: /tmp/selfhost_merged.osty:14013:9
 		return out
 	}
-	// Osty: /tmp/selfhost_merged.osty:14015:5
 	if node.text == "optional" {
-		// Osty: /tmp/selfhost_merged.osty:14016:9
 		out = srAstResolveType(file, node.left, scope, owner, out)
 	} else if node.text == "tuple" {
-		// Osty: /tmp/selfhost_merged.osty:14018:9
 		for _, child := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:14019:13
 			out = srAstResolveType(file, child, scope, owner, out)
 		}
 	} else if node.text == "fn" {
-		// Osty: /tmp/selfhost_merged.osty:14022:9
 		for _, child := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:14023:13
 			out = srAstResolveType(file, child, scope, owner, out)
 		}
-		// Osty: /tmp/selfhost_merged.osty:14025:9
 		out = srAstResolveType(file, node.right, scope, owner, out)
 	} else {
-		// Osty: /tmp/selfhost_merged.osty:14027:9
 		out = srResolveOneAstType(node.text, node.start, node.end, idx, scope, owner, out)
-		// Osty: /tmp/selfhost_merged.osty:14028:9
+		head := srPathHead(node.text)
+		tail := srPathLastSegment(node.text)
+		sym := srScopeLookup(scope, head)
+		if head != "" && tail != head && sym.kind == "package" {
+			out = srResolvePackageMember(file, sym, tail, node.start, node.end, idx, true, out)
+		}
 		for _, child := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:14029:13
 			out = srAstResolveType(file, child, scope, owner, out)
 		}
 	}
@@ -34417,79 +34348,49 @@ func srAstResolveType(file *AstFile, idx int, scope *SelfResolveScope, owner str
 
 // Osty: /tmp/selfhost_merged.osty:14035:1
 func srAstResolveExpr(file *AstFile, idx int, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:14041:5
 	if idx < 0 {
-		// Osty: /tmp/selfhost_merged.osty:14042:9
 		return result
 	}
-	// Osty: /tmp/selfhost_merged.osty:14044:5
 	node := srAstNode(file, idx)
-	_ = node
-	// Osty: /tmp/selfhost_merged.osty:14045:5
 	out := result
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:14046:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
-		// Osty: /tmp/selfhost_merged.osty:14047:9
 		return srResolveOneAstIdent(node.text, node.start, node.end, idx, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14049:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNField{})) {
-		// Osty: /tmp/selfhost_merged.osty:14050:9
-		return srAstResolveExpr(file, node.left, scope, out)
+		return srAstResolveField(file, idx, node, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14052:5
+	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNCall{})) {
+		return srAstResolveCall(file, node, scope, out)
+	}
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNStructLit{})) {
-		// Osty: /tmp/selfhost_merged.osty:14053:9
 		out = srAstResolveExpr(file, node.left, scope, out)
-		// Osty: /tmp/selfhost_merged.osty:14054:9
 		for _, fieldIdx := range node.children {
-			// Osty: /tmp/selfhost_merged.osty:14055:13
 			out = srAstResolveStructField(file, fieldIdx, scope, out)
 		}
-		// Osty: /tmp/selfhost_merged.osty:14057:9
 		return srAstResolveExpr(file, node.right, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14059:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNIf{})) {
-		// Osty: /tmp/selfhost_merged.osty:14060:9
 		return srAstResolveIf(file, node, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14062:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNMatch{})) {
-		// Osty: /tmp/selfhost_merged.osty:14063:9
 		return srAstResolveMatch(file, node, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14065:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNClosure{})) {
-		// Osty: /tmp/selfhost_merged.osty:14066:9
 		return srAstResolveClosure(file, node, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14068:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNBlock{})) {
-		// Osty: /tmp/selfhost_merged.osty:14069:9
 		blockScope := srChildScope(scope)
-		_ = blockScope
-		// Osty: /tmp/selfhost_merged.osty:14070:9
 		return srAstResolveBlock(file, idx, blockScope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14072:5
 	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNType{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNPattern{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNParam{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNGenericParam{})) {
-		// Osty: /tmp/selfhost_merged.osty:14073:9
 		return out
 	}
-	// Osty: /tmp/selfhost_merged.osty:14075:5
 	out = srAstResolveExpr(file, node.left, scope, out)
-	// Osty: /tmp/selfhost_merged.osty:14076:5
 	out = srAstResolveExpr(file, node.right, scope, out)
-	// Osty: /tmp/selfhost_merged.osty:14077:5
 	for _, child := range node.children {
-		// Osty: /tmp/selfhost_merged.osty:14078:9
 		out = srAstResolveExpr(file, child, scope, out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14080:5
 	for _, child := range node.children2 {
-		// Osty: /tmp/selfhost_merged.osty:14081:9
 		out = srAstResolveExpr(file, child, scope, out)
 	}
 	return out
@@ -34497,25 +34398,58 @@ func srAstResolveExpr(file *AstFile, idx int, scope *SelfResolveScope, result *S
 
 // Osty: /tmp/selfhost_merged.osty:14086:1
 func srAstResolveStructField(file *AstFile, idx int, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:14092:5
 	if idx < 0 {
-		// Osty: /tmp/selfhost_merged.osty:14093:9
 		return result
 	}
-	// Osty: /tmp/selfhost_merged.osty:14095:5
 	node := srAstNode(file, idx)
-	_ = node
-	// Osty: /tmp/selfhost_merged.osty:14096:5
 	if !ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
-		// Osty: /tmp/selfhost_merged.osty:14097:9
 		return srAstResolveExpr(file, idx, scope, result)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14099:5
 	if node.left >= 0 {
-		// Osty: /tmp/selfhost_merged.osty:14100:9
 		return srAstResolveExpr(file, node.left, scope, result)
 	}
 	return srResolveOneAstIdent(node.text, node.start, node.end, idx, scope, result)
+}
+
+func srAstResolveField(file *AstFile, idx int, node *AstNode, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
+	out := srAstResolveExpr(file, node.left, scope, result)
+	base := srAstNode(file, node.left)
+	if ostyEqual(base.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+		sym := srScopeLookup(scope, base.text)
+		if sym.kind == "package" {
+			return srResolvePackageMember(file, sym, node.text, node.start, node.end, idx, false, out)
+		}
+		if scope.ifaceDefault && node.flags != 1 && base.text == "self" {
+			return srInterfaceDefaultFieldAtNode(out, node.start, node.end, idx)
+		}
+	}
+	return out
+}
+
+func srAstResolveCall(file *AstFile, node *AstNode, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
+	out := result
+	callee := srAstNode(file, node.left)
+	if ostyEqual(callee.kind, AstNodeKind(&AstNodeKind_AstNField{})) {
+		out = srAstResolveCallField(file, callee, scope, out)
+	} else {
+		out = srAstResolveExpr(file, node.left, scope, out)
+	}
+	for _, child := range node.children {
+		out = srAstResolveExpr(file, child, scope, out)
+	}
+	return out
+}
+
+func srAstResolveCallField(file *AstFile, node *AstNode, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
+	out := srAstResolveExpr(file, node.left, scope, result)
+	base := srAstNode(file, node.left)
+	if ostyEqual(base.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
+		sym := srScopeLookup(scope, base.text)
+		if sym.kind == "package" {
+			out = srResolvePackageMember(file, sym, node.text, node.start, node.end, node.left, false, out)
+		}
+	}
+	return out
 }
 
 // Osty: /tmp/selfhost_merged.osty:14105:1
@@ -34573,23 +34507,13 @@ func srAstResolveMatch(file *AstFile, node *AstNode, scope *SelfResolveScope, re
 
 // Osty: /tmp/selfhost_merged.osty:14141:1
 func srAstResolveClosure(file *AstFile, node *AstNode, scope *SelfResolveScope, result *SelfResolveResult) *SelfResolveResult {
-	// Osty: /tmp/selfhost_merged.osty:14147:5
 	out := result
-	_ = out
-	// Osty: /tmp/selfhost_merged.osty:14148:5
-	closureScope := srChildScope(scope)
-	_ = closureScope
-	// Osty: /tmp/selfhost_merged.osty:14149:5
+	closureScope := srChildScopeWithIfaceDefault(scope, false)
 	for _, paramIdx := range node.children {
-		// Osty: /tmp/selfhost_merged.osty:14150:9
 		param := srAstNode(file, paramIdx)
-		_ = param
-		// Osty: /tmp/selfhost_merged.osty:14151:9
 		out = srAstResolveType(file, param.right, closureScope, "", out)
-		// Osty: /tmp/selfhost_merged.osty:14152:9
 		out = srAstResolveParamBindings(file, paramIdx, closureScope, "", out)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14154:5
 	out = srAstResolveType(file, node.right, closureScope, "", out)
 	return srAstResolveExpr(file, node.left, closureScope, out)
 }
@@ -34651,10 +34575,22 @@ func srResolveOneAstIdent(name string, start int, end int, node int, scope *Self
 		return _p2266 + _rhs2267
 	}()
 	// Osty: /tmp/selfhost_merged.osty:14189:5
-	func() struct{} {
-		out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
-		return struct{}{}
-	}()
+	hint := srUndefinedHint(scope, name)
+	_ = hint
+	// Osty: /tmp/selfhost_merged.osty:14190:5
+	if hint == "" {
+		// Osty: /tmp/selfhost_merged.osty:14191:9
+		func() struct{} {
+			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
+			return struct{}{}
+		}()
+	} else {
+		// Osty: /tmp/selfhost_merged.osty:14193:9
+		func() struct{} {
+			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticHintAtNode("E0500", "undefined name", name, start, end, node, hint))
+			return struct{}{}
+		}()
+	}
 	return out
 }
 
@@ -34664,26 +34600,34 @@ func srResolveOneAstType(name string, start int, end int, node int, scope *SelfR
 	out := result
 	_ = out
 	// Osty: /tmp/selfhost_merged.osty:14203:5
-	if name == "Self" {
-		// Osty: /tmp/selfhost_merged.osty:14204:9
+	head := srPathHead(name)
+	_ = head
+	// Osty: /tmp/selfhost_merged.osty:14204:5
+	if head == "" {
+		// Osty: /tmp/selfhost_merged.osty:14205:9
+		return out
+	}
+	// Osty: /tmp/selfhost_merged.osty:14207:5
+	if head == "Self" {
+		// Osty: /tmp/selfhost_merged.osty:14208:9
 		if owner == "" {
-			// Osty: /tmp/selfhost_merged.osty:14205:13
+			// Osty: /tmp/selfhost_merged.osty:14209:13
 			return srSelfTypeOutsideAtNode(out, start, end, node)
 		}
-		// Osty: /tmp/selfhost_merged.osty:14207:9
+		// Osty: /tmp/selfhost_merged.osty:14211:9
 		return srRecordTypeRef(out, name, node)
 	}
-	// Osty: /tmp/selfhost_merged.osty:14209:5
-	if srIsBuiltinTypeName(name) {
-		// Osty: /tmp/selfhost_merged.osty:14210:9
-		return srRecordTypeRef(out, name, node)
-	}
-	// Osty: /tmp/selfhost_merged.osty:14212:5
-	sym := srScopeLookup(scope, name)
-	_ = sym
 	// Osty: /tmp/selfhost_merged.osty:14213:5
+	if srIsBuiltinTypeName(head) {
+		// Osty: /tmp/selfhost_merged.osty:14214:9
+		return srRecordTypeRef(out, name, node)
+	}
+	// Osty: /tmp/selfhost_merged.osty:14216:5
+	sym := srScopeLookup(scope, head)
+	_ = sym
+	// Osty: /tmp/selfhost_merged.osty:14217:5
 	if sym.name == "" {
-		// Osty: /tmp/selfhost_merged.osty:14214:12
+		// Osty: /tmp/selfhost_merged.osty:14218:12
 		out.unresolved = func() int {
 			var _p2268 int = out.unresolved
 			var _rhs2269 int = 1
@@ -34695,22 +34639,22 @@ func srResolveOneAstType(name string, start int, end int, node int, scope *SelfR
 			}
 			return _p2268 + _rhs2269
 		}()
-		// Osty: /tmp/selfhost_merged.osty:14215:9
-		func() struct{} {
-			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0500", "undefined type", name, start, end, node))
-			return struct{}{}
-		}()
-		// Osty: /tmp/selfhost_merged.osty:14216:9
-		return out
-	}
-	// Osty: /tmp/selfhost_merged.osty:14218:5
-	if !(srSymbolCanBeType(sym)) {
 		// Osty: /tmp/selfhost_merged.osty:14219:9
 		func() struct{} {
-			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0502", "name is not a type", name, start, end, node))
+			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0500", "undefined type", head, start, end, node))
 			return struct{}{}
 		}()
 		// Osty: /tmp/selfhost_merged.osty:14220:9
+		return out
+	}
+	// Osty: /tmp/selfhost_merged.osty:14222:5
+	if !(srSymbolCanBeType(sym)) {
+		// Osty: /tmp/selfhost_merged.osty:14223:9
+		func() struct{} {
+			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0502", "name is not a type", head, start, end, node))
+			return struct{}{}
+		}()
+		// Osty: /tmp/selfhost_merged.osty:14224:9
 		return out
 	}
 	return srRecordTypeRef(out, name, node)
@@ -34796,6 +34740,19 @@ func srSelfTypeOutsideAtNode(result *SelfResolveResult, start int, end int, node
 	// Osty: /tmp/selfhost_merged.osty:14261:5
 	func() struct{} {
 		out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0504", "`Self` outside type body", "Self", start, end, node))
+		return struct{}{}
+	}()
+	return out
+}
+
+// Osty: /tmp/selfhost_merged.osty:14264:1
+func srInterfaceDefaultFieldAtNode(result *SelfResolveResult, start int, end int, node int) *SelfResolveResult {
+	// Osty: /tmp/selfhost_merged.osty:14269:5
+	out := result
+	_ = out
+	// Osty: /tmp/selfhost_merged.osty:14270:5
+	func() struct{} {
+		out.diagnostics = append(out.diagnostics, selfResolveDiagnosticHintAtNode("E0606", "interface default method bodies may not access fields on `self`", "", start, end, node, "expose the value through an interface method and call that instead"))
 		return struct{}{}
 	}()
 	return out
@@ -35761,6 +35718,372 @@ func srStringListIndex(items []string, target string) int {
 		}()
 	}
 	return -1
+}
+
+// Osty: /tmp/selfhost_merged.osty:14806:1
+func srUndefinedHint(scope *SelfResolveScope, name string) string {
+	// Osty: /tmp/selfhost_merged.osty:14807:5
+	suggestion := srSuggestSimilar(scope, name)
+	_ = suggestion
+	// Osty: /tmp/selfhost_merged.osty:14808:5
+	if suggestion == "" {
+		// Osty: /tmp/selfhost_merged.osty:14809:9
+		return ""
+	}
+	return "did you mean `" + suggestion + "`?"
+}
+
+// Osty: /tmp/selfhost_merged.osty:14813:1
+func srSuggestSimilar(scope *SelfResolveScope, name string) string {
+	// Osty: /tmp/selfhost_merged.osty:14814:5
+	best := ""
+	_ = best
+	// Osty: /tmp/selfhost_merged.osty:14815:5
+	bestDist := 3
+	_ = bestDist
+	// Osty: /tmp/selfhost_merged.osty:14816:5
+	nameLen := srStringUnitCount(name)
+	_ = nameLen
+	// Osty: /tmp/selfhost_merged.osty:14817:5
+	for _, sym := range scope.symbols {
+		// Osty: /tmp/selfhost_merged.osty:14818:9
+		diff := func() int {
+			var _p2302 int = srStringUnitCount(sym.name)
+			var _rhs2303 int = nameLen
+			if _rhs2303 > 0 && _p2302 < math.MinInt+_rhs2303 {
+				panic("integer overflow")
+			}
+			if _rhs2303 < 0 && _p2302 > math.MaxInt+_rhs2303 {
+				panic("integer overflow")
+			}
+			return _p2302 - _rhs2303
+		}()
+		_ = diff
+		// Osty: /tmp/selfhost_merged.osty:14819:9
+		if diff > bestDist-1 || 0-diff > bestDist-1 {
+			// Osty: /tmp/selfhost_merged.osty:14820:13
+			continue
+		}
+		// Osty: /tmp/selfhost_merged.osty:14822:9
+		dist := srLevenshteinBounded(name, sym.name, bestDist)
+		_ = dist
+		// Osty: /tmp/selfhost_merged.osty:14823:9
+		if dist < bestDist {
+			// Osty: /tmp/selfhost_merged.osty:14824:13
+			best = sym.name
+			// Osty: /tmp/selfhost_merged.osty:14825:13
+			bestDist = dist
+			// Osty: /tmp/selfhost_merged.osty:14826:13
+			if bestDist == 1 {
+				// Osty: /tmp/selfhost_merged.osty:14827:17
+				return best
+			}
+		}
+	}
+	return best
+}
+
+// Osty: /tmp/selfhost_merged.osty:14832:1
+func srLevenshteinBounded(left string, right string, limit int) int {
+	// Osty: /tmp/selfhost_merged.osty:14833:5
+	if left == right {
+		// Osty: /tmp/selfhost_merged.osty:14834:9
+		return 0
+	}
+	// Osty: /tmp/selfhost_merged.osty:14836:5
+	leftUnits := strings.Split(left, "")
+	_ = leftUnits
+	// Osty: /tmp/selfhost_merged.osty:14837:5
+	rightUnits := strings.Split(right, "")
+	_ = rightUnits
+	// Osty: /tmp/selfhost_merged.osty:14838:5
+	leftLen := srStringUnitCount(left)
+	_ = leftLen
+	// Osty: /tmp/selfhost_merged.osty:14839:5
+	rightLen := srStringUnitCount(right)
+	_ = rightLen
+	// Osty: /tmp/selfhost_merged.osty:14840:5
+	diff := func() int {
+		var _p2304 int = leftLen
+		var _rhs2305 int = rightLen
+		if _rhs2305 > 0 && _p2304 < math.MinInt+_rhs2305 {
+			panic("integer overflow")
+		}
+		if _rhs2305 < 0 && _p2304 > math.MaxInt+_rhs2305 {
+			panic("integer overflow")
+		}
+		return _p2304 - _rhs2305
+	}()
+	_ = diff
+	// Osty: /tmp/selfhost_merged.osty:14841:5
+	if diff >= limit || 0-diff >= limit {
+		// Osty: /tmp/selfhost_merged.osty:14842:9
+		return limit
+	}
+	// Osty: /tmp/selfhost_merged.osty:14844:5
+	prev := make([]int, 0, 1)
+	_ = prev
+	// Osty: /tmp/selfhost_merged.osty:14845:5
+	cur := make([]int, 0, 1)
+	_ = cur
+	// Osty: /tmp/selfhost_merged.osty:14846:5
+	j := 0
+	_ = j
+	// Osty: /tmp/selfhost_merged.osty:14847:5
+	for j <= rightLen {
+		// Osty: /tmp/selfhost_merged.osty:14848:9
+		func() struct{} { prev = append(prev, j); return struct{}{} }()
+		// Osty: /tmp/selfhost_merged.osty:14849:9
+		func() struct{} { cur = append(cur, 0); return struct{}{} }()
+		// Osty: /tmp/selfhost_merged.osty:14850:9
+		func() {
+			var _cur2306 int = j
+			var _rhs2307 int = 1
+			if _rhs2307 > 0 && _cur2306 > math.MaxInt-_rhs2307 {
+				panic("integer overflow")
+			}
+			if _rhs2307 < 0 && _cur2306 < math.MinInt-_rhs2307 {
+				panic("integer overflow")
+			}
+			j = _cur2306 + _rhs2307
+		}()
+	}
+	// Osty: /tmp/selfhost_merged.osty:14852:5
+	i := 1
+	_ = i
+	// Osty: /tmp/selfhost_merged.osty:14853:5
+	for i <= leftLen {
+		// Osty: /tmp/selfhost_merged.osty:14854:9
+		cur[0] = i
+		// Osty: /tmp/selfhost_merged.osty:14855:9
+		rowMin := cur[0]
+		_ = rowMin
+		// Osty: /tmp/selfhost_merged.osty:14856:9
+		j = 1
+		// Osty: /tmp/selfhost_merged.osty:14857:9
+		for j <= rightLen {
+			// Osty: /tmp/selfhost_merged.osty:14858:13
+			leftUnit := srStringListAt(leftUnits, i-1)
+			_ = leftUnit
+			// Osty: /tmp/selfhost_merged.osty:14859:13
+			rightUnit := srStringListAt(rightUnits, j-1)
+			_ = rightUnit
+			// Osty: /tmp/selfhost_merged.osty:14860:13
+			cost := 0
+			_ = cost
+			// Osty: /tmp/selfhost_merged.osty:14861:13
+			if leftUnit == rightUnit {
+				// Osty: /tmp/selfhost_merged.osty:14862:17
+				cost = 0
+			} else {
+				// Osty: /tmp/selfhost_merged.osty:14864:17
+				cost = 1
+			}
+			// Osty: /tmp/selfhost_merged.osty:14866:13
+			dist := func() int {
+				var _p2308 int = srIntListAt(prev, j)
+				var _rhs2309 int = 1
+				if _rhs2309 > 0 && _p2308 > math.MaxInt-_rhs2309 {
+					panic("integer overflow")
+				}
+				if _rhs2309 < 0 && _p2308 < math.MinInt-_rhs2309 {
+					panic("integer overflow")
+				}
+				return _p2308 + _rhs2309
+			}()
+			_ = dist
+			// Osty: /tmp/selfhost_merged.osty:14867:13
+			if srIntListAt(cur, j-1)+1 < dist {
+				// Osty: /tmp/selfhost_merged.osty:14868:17
+				dist = srIntListAt(cur, j-1) + 1
+			}
+			// Osty: /tmp/selfhost_merged.osty:14870:13
+			if srIntListAt(prev, j-1)+cost < dist {
+				// Osty: /tmp/selfhost_merged.osty:14871:17
+				dist = srIntListAt(prev, j-1) + cost
+			}
+			// Osty: /tmp/selfhost_merged.osty:14873:13
+			cur[j] = dist
+			// Osty: /tmp/selfhost_merged.osty:14874:13
+			if dist < rowMin {
+				// Osty: /tmp/selfhost_merged.osty:14875:17
+				rowMin = dist
+			}
+			// Osty: /tmp/selfhost_merged.osty:14877:13
+			func() {
+				var _cur2310 int = j
+				var _rhs2311 int = 1
+				if _rhs2311 > 0 && _cur2310 > math.MaxInt-_rhs2311 {
+					panic("integer overflow")
+				}
+				if _rhs2311 < 0 && _cur2310 < math.MinInt-_rhs2311 {
+					panic("integer overflow")
+				}
+				j = _cur2310 + _rhs2311
+			}()
+		}
+		// Osty: /tmp/selfhost_merged.osty:14879:9
+		if rowMin >= limit {
+			// Osty: /tmp/selfhost_merged.osty:14880:13
+			return limit
+		}
+		// Osty: /tmp/selfhost_merged.osty:14882:9
+		j = 0
+		// Osty: /tmp/selfhost_merged.osty:14883:9
+		for j <= rightLen {
+			// Osty: /tmp/selfhost_merged.osty:14884:13
+			prev[j] = cur[j]
+			// Osty: /tmp/selfhost_merged.osty:14885:13
+			cur[j] = 0
+			// Osty: /tmp/selfhost_merged.osty:14886:13
+			func() {
+				var _cur2312 int = j
+				var _rhs2313 int = 1
+				if _rhs2313 > 0 && _cur2312 > math.MaxInt-_rhs2313 {
+					panic("integer overflow")
+				}
+				if _rhs2313 < 0 && _cur2312 < math.MinInt-_rhs2313 {
+					panic("integer overflow")
+				}
+				j = _cur2312 + _rhs2313
+			}()
+		}
+		// Osty: /tmp/selfhost_merged.osty:14888:9
+		func() {
+			var _cur2314 int = i
+			var _rhs2315 int = 1
+			if _rhs2315 > 0 && _cur2314 > math.MaxInt-_rhs2315 {
+				panic("integer overflow")
+			}
+			if _rhs2315 < 0 && _cur2314 < math.MinInt-_rhs2315 {
+				panic("integer overflow")
+			}
+			i = _cur2314 + _rhs2315
+		}()
+	}
+	return prev[rightLen]
+}
+
+// Osty: /tmp/selfhost_merged.osty:14893:1
+func srStringUnitCount(text string) int {
+	// Osty: /tmp/selfhost_merged.osty:14894:5
+	count := 0
+	_ = count
+	// Osty: /tmp/selfhost_merged.osty:14895:5
+	for _, unit := range strings.Split(text, "") {
+		// Osty: /tmp/selfhost_merged.osty:14896:9
+		if unit != "" {
+			// Osty: /tmp/selfhost_merged.osty:14897:13
+			func() {
+				var _cur2316 int = count
+				var _rhs2317 int = 1
+				if _rhs2317 > 0 && _cur2316 > math.MaxInt-_rhs2317 {
+					panic("integer overflow")
+				}
+				if _rhs2317 < 0 && _cur2316 < math.MinInt-_rhs2317 {
+					panic("integer overflow")
+				}
+				count = _cur2316 + _rhs2317
+			}()
+		}
+	}
+	return count
+}
+
+// Osty: /tmp/selfhost_merged.osty:14901:1
+func srAstUseNode(file *AstFile, pkgSym *SelfSymbol) *AstNode {
+	// Osty: /tmp/selfhost_merged.osty:14902:5
+	if pkgSym.node < 0 {
+		// Osty: /tmp/selfhost_merged.osty:14903:9
+		return emptyAstNode(AstNodeKind(&AstNodeKind_AstNFile{}))
+	}
+	return srAstNode(file, pkgSym.node)
+}
+
+// Osty: /tmp/selfhost_merged.osty:14907:1
+func srAstLookupPackageMember(file *AstFile, useNode *AstNode, member string) *SelfSymbol {
+	// Osty: /tmp/selfhost_merged.osty:14908:5
+	for _, childIdx := range useNode.children {
+		// Osty: /tmp/selfhost_merged.osty:14909:9
+		child := srAstNode(file, childIdx)
+		_ = child
+		// Osty: /tmp/selfhost_merged.osty:14910:9
+		if child.text == member {
+			// Osty: /tmp/selfhost_merged.osty:14911:13
+			return selfSymbolAtNode(member, srAstPackageMemberKind(child), "", 0, 0, child.start, child.end, true, childIdx)
+		}
+	}
+	return srEmptySymbol()
+}
+
+// Osty: /tmp/selfhost_merged.osty:14915:1
+func srAstPackageMemberKind(node *AstNode) string {
+	// Osty: /tmp/selfhost_merged.osty:14916:5
+	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNFnDecl{})) {
+		// Osty: /tmp/selfhost_merged.osty:14917:9
+		return "fn"
+	}
+	// Osty: /tmp/selfhost_merged.osty:14919:5
+	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNStructDecl{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNEnumDecl{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNInterfaceDecl{})) || ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNTypeAlias{})) {
+		// Osty: /tmp/selfhost_merged.osty:14920:9
+		return "type"
+	}
+	// Osty: /tmp/selfhost_merged.osty:14922:5
+	if ostyEqual(node.kind, AstNodeKind(&AstNodeKind_AstNLet{})) {
+		// Osty: /tmp/selfhost_merged.osty:14923:9
+		return "value"
+	}
+	return ""
+}
+
+// Osty: /tmp/selfhost_merged.osty:14927:1
+func srResolvePackageMember(file *AstFile, pkgSym *SelfSymbol, member string, start int, end int, node int, typePos bool, result *SelfResolveResult) *SelfResolveResult {
+	// Osty: /tmp/selfhost_merged.osty:14936:5
+	out := result
+	_ = out
+	// Osty: /tmp/selfhost_merged.osty:14937:5
+	useNode := srAstUseNode(file, pkgSym)
+	_ = useNode
+	// Osty: /tmp/selfhost_merged.osty:14938:5
+	if !ostyEqual(useNode.kind, AstNodeKind(&AstNodeKind_AstNUseDecl{})) {
+		// Osty: /tmp/selfhost_merged.osty:14939:9
+		return out
+	}
+	// Osty: /tmp/selfhost_merged.osty:14941:5
+	if srAstListCount(useNode.children) == 0 {
+		// Osty: /tmp/selfhost_merged.osty:14942:9
+		return out
+	}
+	// Osty: /tmp/selfhost_merged.osty:14944:5
+	sym := srAstLookupPackageMember(file, useNode, member)
+	_ = sym
+	// Osty: /tmp/selfhost_merged.osty:14945:5
+	if sym.name == "" {
+		// Osty: /tmp/selfhost_merged.osty:14946:9
+		noun := "name"
+		_ = noun
+		// Osty: /tmp/selfhost_merged.osty:14947:9
+		if typePos {
+			// Osty: /tmp/selfhost_merged.osty:14948:13
+			noun = "type"
+		}
+		// Osty: /tmp/selfhost_merged.osty:14950:9
+		func() struct{} {
+			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0508", "package `"+pkgSym.name+"` has no exported "+noun, member, start, end, node))
+			return struct{}{}
+		}()
+		// Osty: /tmp/selfhost_merged.osty:14958:9
+		return out
+	}
+	// Osty: /tmp/selfhost_merged.osty:14960:5
+	if typePos && !(srSymbolCanBeType(sym)) {
+		// Osty: /tmp/selfhost_merged.osty:14961:9
+		func() struct{} {
+			out.diagnostics = append(out.diagnostics, selfResolveDiagnosticAtNode("E0502", "name is not a type", member, start, end, node))
+			return struct{}{}
+		}()
+	}
+	return out
 }
 
 // Osty: /tmp/selfhost_merged.osty:14806:1

--- a/toolchain/diagnostic.osty
+++ b/toolchain/diagnostic.osty
@@ -173,6 +173,14 @@ fn diagnosticSubject(name: String) -> String {
     }
 }
 
+fn diagnosticHint(hint: String) -> String {
+    if hint == "" {
+        ""
+    } else {
+        " hint=\"{hint}\""
+    }
+}
+
 fn diagnosticFormatOne(
     source: String,
     code: String,
@@ -191,7 +199,7 @@ pub fn diagnosticFormatSelfResolveDiagnostic(
     source: String,
     diag: SelfResolveDiagnostic,
 ) -> String {
-    diagnosticFormatOne(source, diag.code, diag.message, diag.name, diag.start, diag.end)
+    "{diagnosticFormatOne(source, diag.code, diag.message, diag.name, diag.start, diag.end)}{diagnosticHint(diag.hint)}"
 }
 
 pub fn diagnosticFormatSelfResolveDiagnostics(

--- a/toolchain/diagnostic_test.osty
+++ b/toolchain/diagnostic_test.osty
@@ -90,6 +90,14 @@ fn testDiagnosticFormatsResolveDiagnosticsWithLocations() {
     assertDiagnosticTextContains(output, "undefined name `missing`")
 }
 
+fn testDiagnosticFormatsResolveHints() {
+    let source = "fn main() \{\n    let value = 1\n    vaule\n\}\n"
+    let result = selfResolveSource(source)
+    let output = diagnosticFormatSelfResolveDiagnostics(source, result)
+
+    assertDiagnosticTextContains(output, "hint=\"did you mean `value`?\"")
+}
+
 fn testDiagnosticFormatsLintDiagnosticsWithLocations() {
     let source = "fn same(x: Int) -> Bool \{\n    x == (x)\n\}\n"
     let report = selfLintSource(source)

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -22,6 +22,7 @@ pub struct SelfResolveDiagnostic {
     pub start: Int,
     pub end: Int,
     pub node: Int,
+    pub hint: String,
 }
 
 /// SelfResolveResult contains package symbols plus resolver diagnostics and
@@ -87,7 +88,19 @@ fn selfResolveDiagnosticAtNode(
     end: Int,
     node: Int,
 ) -> SelfResolveDiagnostic {
-    SelfResolveDiagnostic { code, message, name, start, end, node }
+    selfResolveDiagnosticHintAtNode(code, message, name, start, end, node, "")
+}
+
+fn selfResolveDiagnosticHintAtNode(
+    code: String,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+    node: Int,
+    hint: String,
+) -> SelfResolveDiagnostic {
+    SelfResolveDiagnostic { code, message, name, start, end, node, hint }
 }
 
 pub fn emptySelfResolveResult() -> SelfResolveResult {
@@ -302,14 +315,27 @@ fn selfResolveName(name: String, start: Int, end: Int, node: Int) -> SelfResolve
 struct SelfResolveScope {
     symbols: List<SelfSymbol>,
     depth: Int,
+    ifaceDefault: Bool,
 }
 
 fn srRootScope(result: SelfResolveResult) -> SelfResolveScope {
-    SelfResolveScope { symbols: srSymbolListCopy(result.symbols), depth: 0 }
+    SelfResolveScope { symbols: srSymbolListCopy(result.symbols), depth: 0, ifaceDefault: false }
 }
 
 fn srChildScope(parent: SelfResolveScope) -> SelfResolveScope {
-    SelfResolveScope { symbols: srSymbolListCopy(parent.symbols), depth: parent.depth + 1 }
+    SelfResolveScope {
+        symbols: srSymbolListCopy(parent.symbols),
+        depth: parent.depth + 1,
+        ifaceDefault: parent.ifaceDefault,
+    }
+}
+
+fn srChildScopeWithIfaceDefault(parent: SelfResolveScope, ifaceDefault: Bool) -> SelfResolveScope {
+    SelfResolveScope {
+        symbols: srSymbolListCopy(parent.symbols),
+        depth: parent.depth + 1,
+        ifaceDefault,
+    }
 }
 
 fn srScopeDefine(
@@ -455,7 +481,7 @@ fn srAstScanFunctionsInDecl(
     let node = srAstNode(file, idx)
     let mut out = result
     if node.kind == AstNFnDecl {
-        return srAstResolveFunction(file, idx, scope, "", out)
+        return srAstResolveFunction(file, idx, scope, "", false, out)
     }
     if node.kind == AstNStructDecl || node.kind == AstNEnumDecl || node.kind == AstNInterfaceDecl {
         return srAstResolveTypeDecl(file, idx, scope, out)
@@ -493,7 +519,7 @@ fn srAstResolveTypeDecl(
                 out = srAstResolveType(file, member.right, typeScope, node.text, out)
                 out = srAstResolveExpr(file, member.left, typeScope, out)
             } else if member.kind == AstNFnDecl {
-                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, false, out)
             }
         }
     } else if node.kind == AstNEnumDecl {
@@ -504,7 +530,7 @@ fn srAstResolveTypeDecl(
                     out = srAstResolveType(file, ty, typeScope, node.text, out)
                 }
             } else if member.kind == AstNFnDecl {
-                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, false, out)
             }
         }
     } else if node.kind == AstNInterfaceDecl {
@@ -514,7 +540,7 @@ fn srAstResolveTypeDecl(
         for memberIdx in node.children {
             let member = srAstNode(file, memberIdx)
             if member.kind == AstNFnDecl {
-                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, out)
+                out = srAstResolveFunction(file, memberIdx, typeScope, node.text, member.right >= 0, out)
             } else if member.kind == AstNType {
                 out = srAstResolveType(file, memberIdx, typeScope, node.text, out)
             }
@@ -563,6 +589,7 @@ fn srAstResolveFunction(
     idx: Int,
     scope: SelfResolveScope,
     owner: String,
+    ifaceDefault: Bool,
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let node = srAstNode(file, idx)
@@ -578,7 +605,7 @@ fn srAstResolveFunction(
         out = srAstResolveParamBindings(file, paramIdx, fnScope, owner, out)
     }
     out = srAstResolveType(file, node.left, fnScope, owner, out)
-    let bodyScope = srChildScope(fnScope)
+    let bodyScope = srChildScopeWithIfaceDefault(fnScope, ifaceDefault)
     srAstResolveBlock(file, node.right, bodyScope, out)
 }
 
@@ -683,6 +710,12 @@ fn srAstResolveType(
         out = srAstResolveType(file, node.right, scope, owner, out)
     } else {
         out = srResolveOneAstType(node.text, node.start, node.end, idx, scope, owner, out)
+        let head = srPathHead(node.text)
+        let tail = srPathLastSegment(node.text)
+        let sym = srScopeLookup(scope, head)
+        if head != "" && tail != head && sym.kind == "package" {
+            out = srResolvePackageMember(file, sym, tail, node.start, node.end, idx, true, out)
+        }
         for child in node.children {
             out = srAstResolveType(file, child, scope, owner, out)
         }
@@ -705,7 +738,10 @@ fn srAstResolveExpr(
         return srResolveOneAstIdent(node.text, node.start, node.end, idx, scope, out)
     }
     if node.kind == AstNField {
-        return srAstResolveExpr(file, node.left, scope, out)
+        return srAstResolveField(file, idx, node, scope, out)
+    }
+    if node.kind == AstNCall {
+        return srAstResolveCall(file, node, scope, out)
     }
     if node.kind == AstNStructLit {
         out = srAstResolveExpr(file, node.left, scope, out)
@@ -760,6 +796,63 @@ fn srAstResolveStructField(
     srResolveOneAstIdent(node.text, node.start, node.end, idx, scope, result)
 }
 
+fn srAstResolveField(
+    file: AstFile,
+    idx: Int,
+    node: AstNode,
+    scope: SelfResolveScope,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = srAstResolveExpr(file, node.left, scope, result)
+    let base = srAstNode(file, node.left)
+    if base.kind == AstNIdent {
+        let sym = srScopeLookup(scope, base.text)
+        if sym.kind == "package" {
+            return srResolvePackageMember(file, sym, node.text, node.start, node.end, idx, false, out)
+        }
+        if scope.ifaceDefault && node.flags != 1 && base.text == "self" {
+            return srInterfaceDefaultFieldAtNode(out, node.start, node.end, idx)
+        }
+    }
+    out
+}
+
+fn srAstResolveCall(
+    file: AstFile,
+    node: AstNode,
+    scope: SelfResolveScope,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let callee = srAstNode(file, node.left)
+    if callee.kind == AstNField {
+        out = srAstResolveCallField(file, callee, scope, out)
+    } else {
+        out = srAstResolveExpr(file, node.left, scope, out)
+    }
+    for child in node.children {
+        out = srAstResolveExpr(file, child, scope, out)
+    }
+    out
+}
+
+fn srAstResolveCallField(
+    file: AstFile,
+    node: AstNode,
+    scope: SelfResolveScope,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = srAstResolveExpr(file, node.left, scope, result)
+    let base = srAstNode(file, node.left)
+    if base.kind == AstNIdent {
+        let sym = srScopeLookup(scope, base.text)
+        if sym.kind == "package" {
+            out = srResolvePackageMember(file, sym, node.text, node.start, node.end, node.left, false, out)
+        }
+    }
+    out
+}
+
 fn srAstResolveIf(
     file: AstFile,
     node: AstNode,
@@ -803,7 +896,7 @@ fn srAstResolveClosure(
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    let closureScope = srChildScope(scope)
+    let closureScope = srChildScopeWithIfaceDefault(scope, false)
     for paramIdx in node.children {
         let param = srAstNode(file, paramIdx)
         out = srAstResolveType(file, param.right, closureScope, "", out)
@@ -844,7 +937,14 @@ fn srResolveOneAstIdent(
         return srRecordRef(out, name, node, sym)
     }
     out.unresolved = out.unresolved + 1
-    out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
+    let hint = srUndefinedHint(scope, name)
+    if hint == "" {
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined name", name, start, end, node))
+    } else {
+        out.diagnostics.push(
+            selfResolveDiagnosticHintAtNode("E0500", "undefined name", name, start, end, node, hint),
+        )
+    }
     out
 }
 
@@ -858,26 +958,73 @@ fn srResolveOneAstType(
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    if name == "Self" {
+    let head = srPathHead(name)
+    if head == "" {
+        return out
+    }
+    if head == "Self" {
         if owner == "" {
             return srSelfTypeOutsideAtNode(out, start, end, node)
         }
         return srRecordTypeRef(out, name, node)
     }
-    if srIsBuiltinTypeName(name) {
+    if srIsBuiltinTypeName(head) {
         return srRecordTypeRef(out, name, node)
     }
-    let sym = srScopeLookup(scope, name)
+    let sym = srScopeLookup(scope, head)
     if sym.name == "" {
         out.unresolved = out.unresolved + 1
-        out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined type", name, start, end, node))
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0500", "undefined type", head, start, end, node))
         return out
     }
     if !(srSymbolCanBeType(sym)) {
-        out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", name, start, end, node))
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", head, start, end, node))
         return out
     }
     srRecordTypeRef(out, name, node)
+}
+
+fn srResolvePackageMember(
+    file: AstFile,
+    pkgSym: SelfSymbol,
+    member: String,
+    start: Int,
+    end: Int,
+    node: Int,
+    typePos: Bool,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let useNode = srAstUseNode(file, pkgSym)
+    if useNode.kind != AstNUseDecl {
+        return out
+    }
+    if srAstListCount(useNode.children) == 0 {
+        return out
+    }
+    let sym = srAstLookupPackageMember(file, useNode, member)
+    if sym.name == "" {
+        let noun = if typePos {
+            "type"
+        } else {
+            "name"
+        }
+        out.diagnostics.push(
+            selfResolveDiagnosticAtNode(
+                "E0508",
+                "package `{pkgSym.name}` has no exported {noun}",
+                member,
+                start,
+                end,
+                node,
+            ),
+        )
+        return out
+    }
+    if typePos && !(srSymbolCanBeType(sym)) {
+        out.diagnostics.push(selfResolveDiagnosticAtNode("E0502", "name is not a type", member, start, end, node))
+    }
+    out
 }
 
 fn srRecordRef(
@@ -917,6 +1064,27 @@ fn srSelfOutsideAtNode(result: SelfResolveResult, start: Int, end: Int, node: In
 fn srSelfTypeOutsideAtNode(result: SelfResolveResult, start: Int, end: Int, node: Int) -> SelfResolveResult {
     let mut out = result
     out.diagnostics.push(selfResolveDiagnosticAtNode("E0504", "`Self` outside type body", "Self", start, end, node))
+    out
+}
+
+fn srInterfaceDefaultFieldAtNode(
+    result: SelfResolveResult,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(
+        selfResolveDiagnosticHintAtNode(
+            "E0606",
+            "interface default method bodies may not access fields on `self`",
+            "",
+            start,
+            end,
+            node,
+            "expose the value through an interface method and call that instead",
+        ),
+    )
     out
 }
 
@@ -1461,8 +1629,147 @@ fn srStringListIndex(items: List<String>, target: String) -> Int {
     -1
 }
 
+fn srUndefinedHint(scope: SelfResolveScope, name: String) -> String {
+    let suggestion = srSuggestSimilar(scope, name)
+    if suggestion == "" {
+        return ""
+    }
+    "did you mean `{suggestion}`?"
+}
+
+fn srSuggestSimilar(scope: SelfResolveScope, name: String) -> String {
+    let mut best = ""
+    let mut bestDist = 3
+    let nameLen = srStringUnitCount(name)
+    for sym in scope.symbols {
+        let diff = srStringUnitCount(sym.name) - nameLen
+        if diff > bestDist - 1 || 0 - diff > bestDist - 1 {
+            continue
+        }
+        let dist = srLevenshteinBounded(name, sym.name, bestDist)
+        if dist < bestDist {
+            best = sym.name
+            bestDist = dist
+            if bestDist == 1 {
+                return best
+            }
+        }
+    }
+    best
+}
+
+fn srLevenshteinBounded(left: String, right: String, limit: Int) -> Int {
+    if left == right {
+        return 0
+    }
+    let leftUnits = strings.split(left, "")
+    let rightUnits = strings.split(right, "")
+    let leftLen = srStringUnitCount(left)
+    let rightLen = srStringUnitCount(right)
+    let diff = leftLen - rightLen
+    if diff >= limit || 0 - diff >= limit {
+        return limit
+    }
+    let mut prev: List<Int> = []
+    let mut cur: List<Int> = []
+    let mut j = 0
+    while j <= rightLen {
+        prev.push(j)
+        cur.push(0)
+        j = j + 1
+    }
+    let mut i = 1
+    while i <= leftLen {
+        cur[0] = i
+        let mut rowMin = cur[0]
+        j = 1
+        while j <= rightLen {
+            let leftUnit = srStringListAt(leftUnits, i - 1)
+            let rightUnit = srStringListAt(rightUnits, j - 1)
+            let cost = if leftUnit == rightUnit {
+                0
+            } else {
+                1
+            }
+            let mut dist = prev[j] + 1
+            if cur[j - 1] + 1 < dist {
+                dist = cur[j - 1] + 1
+            }
+            if prev[j - 1] + cost < dist {
+                dist = prev[j - 1] + cost
+            }
+            cur[j] = dist
+            if dist < rowMin {
+                rowMin = dist
+            }
+            j = j + 1
+        }
+        if rowMin >= limit {
+            return limit
+        }
+        j = 0
+        while j <= rightLen {
+            prev[j] = cur[j]
+            cur[j] = 0
+            j = j + 1
+        }
+        i = i + 1
+    }
+    prev[rightLen]
+}
+
+fn srStringUnitCount(text: String) -> Int {
+    let mut count = 0
+    for unit in strings.split(text, "") {
+        if unit != "" {
+            count = count + 1
+        }
+    }
+    count
+}
+
 fn srSymbolCanBeType(sym: SelfSymbol) -> Bool {
     sym.kind == "type" || sym.kind == "generic" || sym.kind == "package"
+}
+
+fn srAstUseNode(file: AstFile, pkgSym: SelfSymbol) -> AstNode {
+    if pkgSym.node < 0 {
+        return emptyAstNode(AstNFile)
+    }
+    srAstNode(file, pkgSym.node)
+}
+
+fn srAstLookupPackageMember(file: AstFile, useNode: AstNode, member: String) -> SelfSymbol {
+    for childIdx in useNode.children {
+        let child = srAstNode(file, childIdx)
+        if child.text == member {
+            return selfSymbolAtNode(
+                member,
+                srAstPackageMemberKind(child),
+                "",
+                0,
+                0,
+                child.start,
+                child.end,
+                true,
+                childIdx,
+            )
+        }
+    }
+    srEmptySymbol()
+}
+
+fn srAstPackageMemberKind(node: AstNode) -> String {
+    if node.kind == AstNFnDecl {
+        return "fn"
+    }
+    if node.kind == AstNStructDecl || node.kind == AstNEnumDecl || node.kind == AstNInterfaceDecl || node.kind == AstNTypeAlias {
+        return "type"
+    }
+    if node.kind == AstNLet {
+        return "value"
+    }
+    ""
 }
 
 fn srEmptySymbol() -> SelfSymbol {

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -213,6 +213,54 @@ fn testSelfResolverReportsTypePositionErrors() {
     testing.assertEq(selfResolveCodeCount(result, "E0502"), 1)
 }
 
+fn testSelfResolverResolvesQualifiedTypeReferences() {
+    let result = selfResolveSource(
+        r"""
+            use std.error as error
+
+            fn wrap(err: error.Error) -> Result<String, error.Error> {
+                Err(err)
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveDiagnosticCount(result), 0)
+    testing.assert(selfResolveHasTypeRef(result, "error.Error"))
+}
+
+fn testSelfResolverReportsMissingGoPackageMembers() {
+    let result = selfResolveSource(
+        r"""
+            use go "net/http" as http {
+                fn Get(url: String) -> String
+                type Client = String
+            }
+
+            fn bad() -> http.MissingType {
+                http.Missing()
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0508"), 2)
+}
+
+fn testSelfResolverReportsWrongKindForQualifiedGoType() {
+    let result = selfResolveSource(
+        r"""
+            use go "net/http" as http {
+                fn Get(url: String) -> String
+            }
+
+            fn bad(value: http.Get) -> Int {
+                0
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0502"), 1)
+}
+
 fn testSelfResolverReportsSelfOutsideMethodAndSelfTypeOutsideType() {
     let result = selfResolveSource(
         r"""
@@ -224,6 +272,21 @@ fn testSelfResolverReportsSelfOutsideMethodAndSelfTypeOutsideType() {
 
     testing.assertEq(selfResolveCodeCount(result, "E0503"), 1)
     testing.assertEq(selfResolveCodeCount(result, "E0504"), 2)
+}
+
+fn testSelfResolverReportsInterfaceDefaultFieldAccess() {
+    let result = selfResolveSource(
+        r"""
+            interface Labeler {
+                fn label(self) -> String {
+                    self.name
+                }
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0606"), 1)
+    testing.assertEq(result.diagnostics[0].hint, "expose the value through an interface method and call that instead")
 }
 
 fn testSelfResolverAllowsSelfTypeInsideTypeBody() {
@@ -317,4 +380,18 @@ fn testSelfResolverAllowsSameMethodNamesAcrossTypes() {
     )
 
     testing.assertEq(selfResolveDiagnosticCount(result), 0)
+}
+
+fn testSelfResolverSuggestsNearbyNames() {
+    let result = selfResolveSource(
+        r"""
+            fn main() {
+                let value = 1
+                vaule
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0500"), 1)
+    testing.assertEq(result.diagnostics[0].hint, "did you mean `value`?")
 }


### PR DESCRIPTION
## Summary
- validate qualified package members in the self-hosted resolver for value, call, and type positions
- forbid `self.field` access inside interface default methods and include actionable hints on resolve diagnostics
- add typo suggestions for unresolved names and cover the new behavior with self-hosted resolver/diagnostic tests

## Verification
- `go test ./internal/selfhost -run '^$'`
- `go test ./internal/selfhost` *(currently fails on existing `TestParseSnapshot` snapshot drift unrelated to this resolver change)*
