### PR TITLE
feat: Generic Monomorphization Phase 3 — enum variant-call 추론

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,9 +178,13 @@ The main v0.4 front-end static guarantee hooks are wired here:
   *and* per (generic struct/enum, concrete type-args) tuple, so LLVM
   only ever sees concrete symbols. Function symbols use Itanium
   `_Z…` mangling; nominal type symbols use the `_ZTS…` track for easy
-  distinction. Method-local generic parameters, generic interface
-  declarations, and bare function-pointer turbofish stay out of scope
-  for this phase,
+  distinction. Generic variant constructor calls (e.g.
+  `Maybe.Some(42)`) whose surface type the checker leaves as `*ErrType`
+  are recovered inside the monomorphizer via `inferVariantLitType` +
+  `recoverLiteralType` — payload TypeVars are unified against the
+  concrete types of the call's literal arguments. Method-local generic
+  parameters, generic interface declarations, and bare function-pointer
+  turbofish stay out of scope for this phase,
 - structural interface satisfaction checks composed interfaces,
   `Self`-typed signatures, generic receiver substitution, params, and
   generic bounds,

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -265,13 +265,21 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     등 모든 NamedType slot을 재작성, dedupe 키는 fn 네임스페이스와
     분리 (`MonomorphTypeDedupeKey`). Struct LLVM smoke 통과:
     `TestGenerateModuleGenericStructPairMonomorphized`
-    (mangled nominal 타입이 aggregate로 emit). Enum variant-call E2E
-    smoke는 llvmgen의 legacy variant-lowering이 mangled enum 이름을
-    처리하도록 확장되기 전까지 skipped 상태로 두며 IR-level 테스트
-    `TestMonomorphizeGenericEnumSpecialization`이 행동을 잠근다.
+    (mangled nominal 타입이 aggregate로 emit).
+  - Phase 3(generic enum variant-call 경로)은
+    `inferVariantLitType` + `recoverLiteralType` 휴리스틱으로 채워진다:
+    checker가 `Maybe.Some(42)` 호출의 surface type을 ErrType으로 비워도
+    (generic variant constructor inference 미구현) Monomorphize가
+    variant의 payload 타입(TypeVar)과 실제 인자 값의 리터럴-유래
+    타입을 unify해서 `Maybe<Int>`를 복원하고 specialization을 몰아준다.
+    `TestGenerateModuleGenericEnumMaybeMonomorphized` 스모크가 이
+    경로를 증명한다. Payload-free variant(`Maybe.None`)처럼 인자로부터
+    T를 유추할 수 없는 경우에는 휴리스틱이 보수적으로 포기하고 기존
+    ErrType을 유지한다.
   - 남은 범위: generic interface 선언, method-local generic parameter,
     bare function-pointer turbofish (`let f = id::<Int>`),
-    llvmgen enum variant-call lowering의 mangled 이름 지원.
+    payload-free / 비-리터럴 인자를 가진 variant call의 타입 복원(궁극적으로는
+    checker 쪽 generic variant-constructor inference 보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -474,6 +474,18 @@ func (s *monoState) rewriteExprType(e Expr) {
 			}
 		}
 	case *VariantLit:
+		// Phase 3 heuristic: when the checker couldn't pin down the
+		// variant's surface type (`x.T` is ErrType or nil), try to
+		// recover `EnumName<concrete…>` from the owning generic enum
+		// declaration by matching each TypeVar-shaped payload against
+		// the concrete type of the corresponding argument value. This
+		// lets `Maybe.Some(42)` drive a `Maybe<Int>` specialization
+		// even when the front-end leaves the call untyped.
+		if needsVariantTypeRecovery(x.T) {
+			if inferred := s.inferVariantLitType(x); inferred != nil {
+				x.T = inferred
+			}
+		}
 		x.T = s.rewriteType(x.T)
 		if nt, ok := x.T.(*NamedType); ok && nt.Name != "" {
 			if x.Enum != "" && x.Enum != nt.Name {
@@ -518,6 +530,140 @@ func (s *monoState) rewriteExprType(e Expr) {
 	case *ErrorExpr:
 		x.T = s.rewriteType(x.T)
 	}
+}
+
+// needsVariantTypeRecovery reports whether a VariantLit's surface type
+// is too fuzzy for rewriteType to drive a specialization request — nil
+// or *ErrType means the front-end gave up typing the variant call and
+// the monomorphizer should try the payload-driven fallback below.
+func needsVariantTypeRecovery(t Type) bool {
+	if t == nil {
+		return true
+	}
+	_, ok := t.(*ErrType)
+	return ok
+}
+
+// inferVariantLitType recovers `EnumName<concrete…>` for a VariantLit
+// whose checker-provided type was missing. It looks up the enum's
+// generic declaration, finds the named variant, and unifies each
+// TypeVar-shaped payload slot against the concrete argument value's
+// type. Returns nil whenever any slot resists inference (non-TypeVar
+// payload, inconsistent bindings, arity mismatch, or a generic
+// parameter that never appears in the variant's payload).
+//
+// Phase 3 scope: simple positional TypeVar payloads only. Variants
+// without payload (e.g. `Maybe.None`) can't be inferred this way — the
+// user must supply a type annotation at the binding site.
+func (s *monoState) inferVariantLitType(v *VariantLit) Type {
+	if v == nil || v.Enum == "" {
+		return nil
+	}
+	decl, ok := s.genericEnumsByName[v.Enum]
+	if !ok {
+		return nil
+	}
+	var payloads []Type
+	for _, va := range decl.Variants {
+		if va != nil && va.Name == v.Variant {
+			payloads = va.Payload
+			break
+		}
+	}
+	if payloads == nil {
+		return nil
+	}
+	if len(payloads) != len(v.Args) {
+		return nil
+	}
+	env := make(SubstEnv)
+	for i := range payloads {
+		pd := payloads[i]
+		argVal := v.Args[i].Value
+		if argVal == nil {
+			return nil
+		}
+		at := recoverLiteralType(argVal)
+		if at == nil {
+			return nil
+		}
+		tv, ok := pd.(*TypeVar)
+		if !ok {
+			// Non-TypeVar payload means the payload type already fixes
+			// the slot; we can't extract a generic param binding from
+			// a position like that. Skip gracefully.
+			continue
+		}
+		if existing, has := env[tv.Name]; has && !typesLooselyEqual(existing, at) {
+			return nil
+		}
+		env[tv.Name] = at
+	}
+	if len(env) != len(decl.Generics) {
+		return nil
+	}
+	args := make([]Type, 0, len(decl.Generics))
+	for _, gp := range decl.Generics {
+		if gp == nil {
+			return nil
+		}
+		t, ok := env[gp.Name]
+		if !ok {
+			return nil
+		}
+		args = append(args, CloneType(t))
+	}
+	return &NamedType{Name: decl.Name, Args: args}
+}
+
+// recoverLiteralType returns the concrete Type for an argument value
+// whose checker-provided Type() is missing or poisoned (ErrType). It
+// covers the literal expression kinds — the cases the variant
+// type-inference heuristic actually has to handle, since those are the
+// only arg shapes where the checker might drop a type annotation.
+// Returns the expression's own type when it's usable; otherwise
+// derives a primitive singleton from the literal kind.
+func recoverLiteralType(e Expr) Type {
+	if e == nil {
+		return nil
+	}
+	if t := e.Type(); t != nil {
+		if _, isErr := t.(*ErrType); !isErr {
+			return t
+		}
+	}
+	switch e.(type) {
+	case *IntLit:
+		return TInt
+	case *FloatLit:
+		return TFloat
+	case *BoolLit:
+		return TBool
+	case *CharLit:
+		return TChar
+	case *StringLit:
+		return TString
+	case *ByteLit:
+		return TByte
+	}
+	return nil
+}
+
+// typesLooselyEqual is a conservative equality check used by variant
+// type inference: primitive singletons compare by pointer; other Types
+// fall back to structural string equality. Kept private — it deliberately
+// ignores niceties like type-alias resolution.
+func typesLooselyEqual(a, b Type) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if _, ok := a.(*PrimType); ok {
+		return false // singleton mismatch
+	}
+	return typeString(a) == typeString(b)
 }
 
 // keepNonGenericMethods filters a specialization's method list: methods
@@ -656,6 +802,16 @@ func (s *monoState) scanStmt(st Stmt) {
 		st.Type = s.rewriteType(st.Type)
 		if st.Value != nil {
 			s.scanExpr(st.Value)
+		}
+		// Phase 3: when the binding had no annotation and the checker
+		// didn't type the value (ErrType), adopt the value's
+		// post-rewrite type so downstream consumers still see a
+		// concrete nominal. Only overwrite a missing / error annotation
+		// to stay conservative about user-written annotations.
+		if st.Value != nil && needsVariantTypeRecovery(st.Type) {
+			if t := st.Value.Type(); t != nil && !needsVariantTypeRecovery(t) {
+				st.Type = t
+			}
 		}
 	case *ExprStmt:
 		s.scanExpr(st.X)

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -1365,6 +1365,116 @@ func TestMonomorphizeMethodLocalGenericSkipsWithWarning(t *testing.T) {
 	}
 }
 
+// ==== Phase 3 VariantLit type recovery ====
+
+func TestRecoverLiteralTypeHandlesCommonLiterals(t *testing.T) {
+	cases := []struct {
+		name string
+		expr Expr
+		want Type
+	}{
+		{"IntLit", &IntLit{Text: "42"}, TInt},
+		{"BoolLit", &BoolLit{Value: true}, TBool},
+		{"StringLit", &StringLit{}, TString},
+		{"FloatLit", &FloatLit{Text: "1.5"}, TFloat},
+		{"CharLit", &CharLit{Value: 'a'}, TChar},
+		{"ByteLit", &ByteLit{Value: 1}, TByte},
+	}
+	for _, tc := range cases {
+		got := recoverLiteralType(tc.expr)
+		if got != tc.want {
+			t.Errorf("%s: recoverLiteralType=%T(%v), want %T(%v)", tc.name, got, got, tc.want, tc.want)
+		}
+	}
+}
+
+func TestRecoverLiteralTypePrefersExprTypeWhenConcrete(t *testing.T) {
+	// A non-Err Type() on the expr must take priority over the literal
+	// fallback — primitives get defaults (Int → TInt) but an annotated
+	// literal (e.g. `42: Int32`) surfaces its carrier type.
+	got := recoverLiteralType(&IntLit{Text: "42", T: TInt32})
+	if got != TInt32 {
+		t.Fatalf("expected TInt32 from expr.T, got %T", got)
+	}
+}
+
+func TestRecoverLiteralTypeFallsBackWhenErrType(t *testing.T) {
+	// When the expr carries ErrType (checker dropped the annotation),
+	// recoverLiteralType must reach for the literal-kind default.
+	got := recoverLiteralType(&IntLit{Text: "42", T: ErrTypeVal})
+	if got != TInt {
+		t.Fatalf("expected TInt fallback for IntLit with ErrType, got %T", got)
+	}
+}
+
+func TestMonomorphizeInfersVariantLitTypeFromIntPayload(t *testing.T) {
+	// Simulate the front-end's ErrType drop: Maybe.Some(42) with every
+	// type slot left as ErrType. The recovery heuristic should infer
+	// `Maybe<Int>` from the IntLit payload, drive a Maybe<Int>
+	// specialization, and rewrite the VariantLit.T + Enum accordingly.
+	maybe := genericMaybeEnum()
+	lit := &VariantLit{
+		Enum:    "Maybe",
+		Variant: "Some",
+		T:       ErrTypeVal,
+		Args:    []Arg{{Value: &IntLit{Text: "42", T: ErrTypeVal}}},
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{
+			Name:  "m",
+			Type:  ErrTypeVal, // no annotation
+			Value: lit,
+		}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	spec := findEnumSpec(out)
+	if spec == nil {
+		t.Fatalf("Maybe specialization missing; decls=%+v", out.Decls)
+	}
+	// Post-rewrite VariantLit should carry the mangled enum name in
+	// both Enum and T fields.
+	mainCp := out.Decls[0].(*FnDecl)
+	litCp := mainCp.Body.Stmts[0].(*LetStmt).Value.(*VariantLit)
+	if !strings.HasPrefix(litCp.Enum, "_ZTS") {
+		t.Fatalf("VariantLit.Enum should be mangled post-recovery, got %q", litCp.Enum)
+	}
+	if nt, ok := litCp.T.(*NamedType); !ok || nt.Name != litCp.Enum {
+		t.Fatalf("VariantLit.T should sync with mangled Enum, got %+v", litCp.T)
+	}
+	// The LetStmt annotation was missing — the scanner should have
+	// adopted the value's concrete type.
+	let := mainCp.Body.Stmts[0].(*LetStmt)
+	if _, isErr := let.Type.(*ErrType); isErr {
+		t.Fatalf("LetStmt.Type should be propagated from value, still ErrType")
+	}
+}
+
+func TestMonomorphizeVariantRecoveryLeavesPayloadFreeAlone(t *testing.T) {
+	// `Maybe.None` has no payload, so there's no concrete type to unify
+	// T against — the heuristic must bail out and leave the VariantLit
+	// untouched (no specialization requested).
+	maybe := genericMaybeEnum()
+	lit := &VariantLit{
+		Enum:    "Maybe",
+		Variant: "None",
+		T:       ErrTypeVal,
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{Name: "m", Type: ErrTypeVal, Value: lit}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, _ := Monomorphize(in)
+	if findEnumSpec(out) != nil {
+		t.Fatalf("payload-free Maybe.None must NOT drive a specialization (no inferable T)")
+	}
+}
+
 func TestMonomorphizeStructArityMismatchRecordsError(t *testing.T) {
 	pair := genericPairStruct()
 	main := &FnDecl{

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -202,7 +202,6 @@ fn main() {
 // regression beacon and picked up by the llvmgen enum-lowering
 // follow-up (tracked alongside Phase 2 scope in LLVM_MIGRATION_PLAN.md).
 func TestGenerateModuleGenericEnumMaybeMonomorphized(t *testing.T) {
-	t.Skip("llvmgen variant-call lowering with mangled enum names is Phase 3+ scope")
 	src := `enum Maybe<T> { Some(T), None }
 
 fn main() {


### PR DESCRIPTION
## Summary

Phase 2(#203) 위에 쌓는 **dependent PR**. PR #203이 skip 상태로 남겼던 generic enum E2E smoke(`TestGenerateModuleGenericEnumMaybeMonomorphized`)를 활성화한다.

Base branch는 `claude/loving-merkle`(#203의 HEAD, Phase 1+2). PR #203 merge 후 diff는 Phase 3 커밋만 남는다.

## 문제

기존 checker가 `Maybe.Some(42)` 같은 generic variant constructor call의 surface type을 추론하지 못해 `VariantLit.T`가 `*ErrType`으로 Lower되고, 인자 `IntLit(42)`의 `T`도 ErrType. 결과적으로 Monomorphize의 `rewriteType`이 specialization 요청을 걸지 못하고, llvmgen은 mangled enum을 본 적이 없어 `enumVariantByField`가 `"Maybe" ↔ enumsByName` lookup에서 실패 → `LLVM015 call: call target *ast.FieldExpr`.

## 해결 (IR 레벨 휴리스틱)

- **`inferVariantLitType`**: `VariantLit.T`가 nil/ErrType일 때 `genericEnumsByName[Enum]`을 lookup해 variant의 payload TypeVar와 실제 인자 값의 타입을 unify하여 `EnumName<concrete…>`를 복원. 그 후 `rewriteType`이 mangled nominal로 교체하고 `typeQueue`에 specialization 요청을 건다.
- **`recoverLiteralType`**: Int/Float/Bool/Char/String/Byte 리터럴은 `Expr.Type()`이 ErrType이라도 리터럴 종류로부터 primitive singleton을 도출. 실제 파이프라인에서 이게 없으면 unify 실패.
- **`needsVariantTypeRecovery`**: `rewriteExprType` VariantLit case의 휴리스틱 진입 가드 — 이미 concrete NamedType이 붙어 있으면 no-op.
- **`scanStmt` LetStmt**: annotation이 ErrType이면 value의 post-rewrite type을 adopt. `let m = …` 같은 어노테이션 생략에도 downstream이 mangled nominal을 찾을 수 있게 한다.

## 테스트

- `internal/ir/monomorph_test.go`:
  - `TestRecoverLiteralTypeHandlesCommonLiterals` — 리터럴 6종 커버
  - `TestRecoverLiteralTypePrefersExprTypeWhenConcrete` — 어노테이션된 리터럴 존중
  - `TestRecoverLiteralTypeFallsBackWhenErrType` — ErrType fallback
  - `TestMonomorphizeInfersVariantLitTypeFromIntPayload` — IntLit 인자로 Maybe<Int> 유도
  - `TestMonomorphizeVariantRecoveryLeavesPayloadFreeAlone` — payload-free `Maybe.None`은 보수적으로 포기
- `internal/llvmgen/ir_module_test.go`: `TestGenerateModuleGenericEnumMaybeMonomorphized` skip 해제 → `Maybe.Some(42)`가 `_ZTSN4main5MaybeIlEE` 나미널로 LLVM IR에 emit.

## 남은 범위 (후속 phase)

- **Payload-free variant**(`Maybe.None`): payload에서 T를 유추할 수 없음 → 외부 type annotation 필요
- **Non-literal 인자**(변수 / 함수 호출 결과): `recoverLiteralType`이 리터럴 기반이라 커버 못함
- **근본 해결책**: checker의 generic variant-constructor inference 보강

## 문서

- `ARCHITECTURE.md`: VariantLit type recovery 경로 기술
- `LLVM_MIGRATION_PLAN.md` Phase 5: Phase 3 완료 상태 + 축소된 남은 범위

## Test plan

- [x] `go test ./internal/ir/ -count=1` — Phase 2 (60건) + Phase 3 (5건) 모두 pass
- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleGeneric' -count=1` — identity + struct + enum smoke 3건 모두 pass
- [x] `internal/backend`·`internal/llvmgen` pre-existing 실패 목록 동일 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)