### PR TITLE
Expand selfhost checker elaboration

### DIFF
--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -163,37 +163,23 @@ func mergedSource(root string) ([]byte, error) {
 }
 
 func stripLeadingStringsUse(src string) string {
-	trimmed := strings.TrimLeft(src, "\ufeff \t\r\n")
-
-	// Handle Go FFI form: use go "strings" as strings { ... }
 	const goPrefix = `use go "strings" as strings {`
-	if strings.HasPrefix(trimmed, goPrefix) {
-		lines := strings.SplitAfter(src, "\n")
-		started := false
-		for i, line := range lines {
-			t := strings.TrimSpace(line)
-			if !started {
-				if strings.HasPrefix(t, goPrefix) {
-					started = true
-				}
-				continue
-			}
-			if t == "}" {
-				return strings.Join(lines[i+1:], "")
-			}
-		}
-		return src
-	}
-
-	// Handle std.strings form: use std.strings as strings  (single line)
 	const stdPrefix = "use std.strings as strings"
-	if strings.HasPrefix(trimmed, stdPrefix) {
-		idx := strings.Index(src, stdPrefix)
-		end := strings.IndexByte(src[idx:], '\n')
-		if end >= 0 {
-			return src[:idx] + src[idx+end+1:]
+
+	lines := strings.SplitAfter(src, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		switch {
+		case strings.HasPrefix(trimmed, goPrefix):
+			for j := i + 1; j < len(lines); j++ {
+				if strings.TrimSpace(lines[j]) == "}" {
+					return strings.Join(lines[:i], "") + strings.Join(lines[j+1:], "")
+				}
+			}
+			return src
+		case trimmed == stdPrefix:
+			return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
 		}
-		return src[:idx]
 	}
 
 	return src

--- a/internal/selfhost/toolchain_checker_gen_test.go
+++ b/internal/selfhost/toolchain_checker_gen_test.go
@@ -1,0 +1,164 @@
+package selfhost
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var toolchainCheckerSourceFiles = []string{
+	"examples/selfhost-core/semver.osty",
+	"examples/selfhost-core/semver_parse.osty",
+	"toolchain/frontend.osty",
+	"toolchain/lexer.osty",
+	"toolchain/parser.osty",
+	"examples/selfhost-core/formatter_ast.osty",
+	"toolchain/check_bridge.osty",
+	"toolchain/diagnostic.osty",
+	"toolchain/check_diag.osty",
+	"toolchain/ty.osty",
+	"toolchain/core.osty",
+	"toolchain/check_env.osty",
+	"toolchain/solve.osty",
+	"toolchain/elab.osty",
+	"toolchain/check.osty",
+	"examples/selfhost-core/resolve.osty",
+	"examples/selfhost-core/lint.osty",
+	"internal/selfhost/ast_lower.osty",
+}
+
+const toolchainCheckerStringsPrelude = `use go "strings" as strings {
+    fn Count(s: String, substr: String) -> Int
+    fn Fields(s: String) -> List<String>
+    fn HasPrefix(s: String, prefix: String) -> Bool
+    fn HasSuffix(s: String, prefix: String) -> Bool
+    fn Join(elems: List<String>, sep: String) -> String
+    fn ReplaceAll(s: String, old: String, new: String) -> String
+    fn Repeat(s: String, count: Int) -> String
+    fn Split(s: String, sep: String) -> List<String>
+    fn SplitN(s: String, sep: String, n: Int) -> List<String>
+    fn TrimPrefix(s: String, prefix: String) -> String
+    fn TrimSpace(s: String) -> String
+    fn TrimSuffix(s: String, suffix: String) -> String
+}
+`
+
+func TestToolchainCheckerSourcesTranspile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping toolchain checker transpile smoke test in short mode")
+	}
+
+	repoRoot := filepath.Join("..", "..")
+	merged, err := mergeToolchainCheckerSources(repoRoot)
+	if err != nil {
+		t.Fatalf("merge toolchain checker sources: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	mergedPath := filepath.Join(tmpDir, "toolchain_checker_merged.osty")
+	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
+		t.Fatalf("write merged source: %v", err)
+	}
+	generatedPath := filepath.Join(tmpDir, "toolchain_checker_generated.go")
+
+	cmd := exec.Command(
+		"go", "run", "-tags", "selfhostgen", "./cmd/osty", "gen",
+		"--backend", "go",
+		"--emit", "go",
+		"--package", "selfhostsmoke",
+		"-o", generatedPath,
+		mergedPath,
+	)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("transpile merged toolchain checker: %v\n%s", err, bytes.TrimSpace(out))
+	}
+
+	generated, err := os.ReadFile(generatedPath)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	if len(generated) == 0 {
+		t.Fatalf("generated file is empty")
+	}
+	if !bytes.Contains(generated, []byte("func frontendCheckSourceStructured(")) {
+		t.Fatalf("generated file does not include checker entrypoints")
+	}
+	if !bytes.Contains(generated, []byte("func elabInfer(")) {
+		t.Fatalf("generated file does not include elaborator entrypoints")
+	}
+}
+
+func mergeToolchainCheckerSources(root string) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString(toolchainCheckerStringsPrelude)
+	b.WriteByte('\n')
+
+	for _, rel := range toolchainCheckerSourceFiles {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		b.WriteString("// ---- ")
+		b.WriteString(rel)
+		b.WriteString(" ----\n")
+		trimmed := stripToolchainCheckerStringsUse(string(data))
+		trimmed = normalizeToolchainCheckerStdStringsCalls(trimmed)
+		b.WriteString(trimmed)
+		if !strings.HasSuffix(trimmed, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+	}
+
+	return []byte(b.String()), nil
+}
+
+func stripToolchainCheckerStringsUse(src string) string {
+	const goPrefix = `use go "strings" as strings {`
+	const stdPrefix = "use std.strings as strings"
+
+	lines := strings.SplitAfter(src, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		switch {
+		case strings.HasPrefix(trimmed, goPrefix):
+			for j := i + 1; j < len(lines); j++ {
+				if strings.TrimSpace(lines[j]) == "}" {
+					return strings.Join(lines[:i], "") + strings.Join(lines[j+1:], "")
+				}
+			}
+			return src
+		case trimmed == stdPrefix:
+			return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
+		}
+	}
+
+	return src
+}
+
+func normalizeToolchainCheckerStdStringsCalls(src string) string {
+	for _, pair := range [][2]string{
+		{"strings.split(", "strings.Split("},
+		{"strings.join(", "strings.Join("},
+		{"strings.hasPrefix(", "strings.HasPrefix("},
+		{"strings.hasSuffix(", "strings.HasSuffix("},
+		{"strings.trimSpace(", "strings.TrimSpace("},
+		{"strings.replaceAll(", "strings.ReplaceAll("},
+		{"strings.trimPrefix(", "strings.TrimPrefix("},
+		{"strings.trimSuffix(", "strings.TrimSuffix("},
+		{"strings.repeat(", "strings.Repeat("},
+		{"strings.count(", "strings.Count("},
+		{"strings.fields(", "strings.Fields("},
+		{"strings.splitN(", "strings.SplitN("},
+	} {
+		src = strings.ReplaceAll(src, pair[0], pair[1])
+	}
+	return src
+}

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -24,17 +24,9 @@
 // populated by `check_diag.osty`; the summary counters are derived
 // values kept in sync for bridge stability.
 
-use std.strings as strings
-
 // ---------------------------------------------------------------------
 // Bridge record types (preserved for Go host compatibility).
 // ---------------------------------------------------------------------
-
-pub struct FrontCheckSummary {
-    pub assignments: Int,
-    pub accepted: Int,
-    pub errors: Int,
-}
 
 pub struct FrontCheckedNode {
     pub node: Int,
@@ -99,7 +91,7 @@ pub fn frontendCheckLexedSource(lexed: OstyLexedSource) -> FrontCheckSummary {
 }
 
 pub fn frontendCheckLexedSourceStructured(lexed: OstyLexedSource) -> FrontCheckResult {
-    let parsed = ostyParseLexed(lexed)
+    let parsed = astParseLexedSource(lexed)
     frontendCheckAstStructured(parsed)
 }
 
@@ -320,7 +312,7 @@ fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
     let mut i = 0
     for pname in sig.paramNames {
         let pty = if i < checkIntListLenLocal(sig.paramTys) { checkIntListAtLocal(sig.paramTys, i) } else { tErr(cx.env.tys) }
-        checkBindSpan(cx.env, pname, pty, false, node.start, node.end)
+        checkBindSpan(cx.env, pname, pty, true, node.start, node.end)
         i = i + 1
     }
 

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -59,6 +59,7 @@ pub fn checkCodeReturnMismatch() -> String { "E0731" }
 pub fn checkCodeClosureAnnotationRequired() -> String { "E0741" }
 pub fn checkCodePatternShapeMismatch() -> String { "E0742" }
 pub fn checkCodeNonEscapingEscape() -> String { "E0743" }
+pub fn checkCodeRefutablePattern() -> String { "E0744" }
 
 // ---------------------------------------------------------------------
 // Low-level builder. Higher-level constructors below wrap this so call
@@ -319,6 +320,15 @@ pub fn diagNonEscapingEscape(ty: String, context: String, start: Int, end: Int) 
     checkDiag(checkCodeNonEscapingEscape(), msg, start, end)
 }
 
+pub fn diagRefutablePattern(context: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if context == "" {
+        "pattern must be irrefutable here"
+    } else {
+        "pattern must be irrefutable in {context}"
+    }
+    checkDiag(checkCodeRefutablePattern(), msg, start, end)
+}
+
 // ---------------------------------------------------------------------
 // Store helpers — the elaborator keeps a `List<CheckDiagnostic>` on
 // its context. These helpers append without forgetting to stamp the
@@ -339,9 +349,8 @@ pub fn checkDiagPush(xs: List<CheckDiagnostic>, d: CheckDiagnostic) -> List<Chec
 pub fn checkDiagCountErrors(xs: List<CheckDiagnostic>) -> Int {
     let mut n = 0
     for d in xs {
-        match d.severity {
-            SeverityError -> n = n + 1,
-            _ -> {},
+        if d.severity == SeverityError {
+            n = n + 1
         }
     }
     n

--- a/toolchain/check_test.osty
+++ b/toolchain/check_test.osty
@@ -139,6 +139,20 @@ fn testSelfCheckerReportsAssignmentReturnAndCallErrors() {
     testing.assert(checked.assignments >= 3)
 }
 
+fn testSelfCheckerBindsTuplePatternsInLets() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn main() {
+                let (id, name) = (1, "Ada")
+            }
+            """,
+    )
+
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "id"), "Int")
+    testing.assertEq(frontCheckResultBindingType(checked, "name"), "String")
+}
+
 fn testSelfCheckerAcceptsFieldAssignmentThroughStructValues() {
     let checked = frontendCheckSource(
         r"""
@@ -171,7 +185,7 @@ fn testSelfCheckerUnifiesUntypedIntWithConcreteGenericArgs() {
 }
 
 fn testSelfCheckerBindsForInIdentifierPatterns() {
-    let checked = frontendCheckSource(
+    let checked = frontendCheckSourceStructured(
         r"""
             fn sum(xs: List<Int>) -> Int {
                 let mut total = 0
@@ -183,7 +197,8 @@ fn testSelfCheckerBindsForInIdentifierPatterns() {
             """,
     )
 
-    testing.assertEq(checked.errors, 0)
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "x"), "Int")
 }
 
 fn testSelfCheckerAllowsParameterAccumulators() {

--- a/toolchain/core.osty
+++ b/toolchain/core.osty
@@ -1571,7 +1571,7 @@ fn corePrintNodeBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int)
         CkIndex -> "{corePrintNode(arena, tys, node.left, depth + 1)} [{corePrintNode(arena, tys, node.right, depth + 1)}]",
         CkList -> corePrintList(arena, tys, node.children, depth),
         CkMap -> corePrintList(arena, tys, node.children, depth),
-        CkMapEntry -> "{corePrintNode(arena, tys, node.left, depth + 1)} => {corePrintNode(arena, tys, node.right, depth + 1)}",
+        CkMapEntry -> corePrintMapEntryBody(arena, tys, node, depth),
         CkTuple -> corePrintList(arena, tys, node.children, depth),
         CkStruct -> corePrintStructBody(arena, tys, node, depth),
         CkStructField -> "{node.name}: {corePrintNode(arena, tys, node.left, depth + 1)}",
@@ -1611,6 +1611,12 @@ fn corePrintCallBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int)
     let args = corePrintList(arena, tys, node.children, depth)
     let ta = corePrintTypeArgs(tys, node.typeArgs)
     "{callee}{ta} {args}"
+}
+
+fn corePrintMapEntryBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
+    let left = corePrintNode(arena, tys, node.left, depth + 1)
+    let right = corePrintNode(arena, tys, node.right, depth + 1)
+    strings.join([left, " =", ">", " ", right], "")
 }
 
 fn corePrintMethodCallBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: Int) -> String {
@@ -1731,22 +1737,24 @@ fn corePrintFnDeclBody(arena: CoreArena, tys: TyArena, node: CoreNode, depth: In
 }
 
 fn corePrintList(arena: CoreArena, tys: TyArena, items: List<Int>, depth: Int) -> String {
+    let sep = ", "
     let mut parts: List<String> = []
     for it in items {
         parts.push(corePrintNode(arena, tys, it, depth + 1))
     }
-    "[{strings.join(parts, \", \")}]"
+    "[{strings.join(parts, sep)}]"
 }
 
 fn corePrintTypeArgs(tys: TyArena, args: List<Int>) -> String {
     if coreIntLen(args) == 0 {
         return ""
     }
+    let sep = ", "
     let mut parts: List<String> = []
     for a in args {
         parts.push(tyToString(tys, a))
     }
-    "::<{strings.join(parts, \", \")}>"
+    "::<{strings.join(parts, sep)}>"
 }
 
 fn coreIntLen(xs: List<Int>) -> Int {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -505,7 +505,11 @@ pub fn elabStmt(cx: ElabCx, idx: Int) -> Int {
     let node = astArenaNodeAt(cx.ast.arena, idx)
     match node.kind {
         AstNLet -> elabLetStmt(cx, node),
+        AstNAssign -> elabAssignStmt(cx, node),
         AstNReturn -> elabReturnStmt(cx, node),
+        AstNDefer -> elabDeferStmt(cx, node),
+        AstNFor -> elabForStmt(cx, node),
+        AstNChanSend -> elabChanSendStmt(cx, node),
         AstNExprStmt -> elabExprStmt(cx, node),
         AstNBreak -> coreBreakStmt(cx.core, node.start, node.end),
         AstNContinue -> coreContinueStmt(cx.core, node.start, node.end),
@@ -521,7 +525,11 @@ fn elabExprAsStmt(cx: ElabCx, idx: Int, node: AstNode) -> Int {
 
 fn elabLetStmt(cx: ElabCx, node: AstNode) -> Int {
     let patIdx = node.left
-    let typeAnnotIdx = node.extra       // legacy AST layout: extra holds annotation
+    let typeAnnotIdx = if checkIntListLenHelper(node.children) > 0 {
+        checkIntListAt(node.children, 0)
+    } else {
+        node.extra
+    }
     let valueIdx = node.right
     let mutable = node.flags == 1
     let declared = astTypeToTy(cx, typeAnnotIdx)
@@ -532,20 +540,47 @@ fn elabLetStmt(cx: ElabCx, node: AstNode) -> Int {
     }
     let effectiveTy = if declared >= 0 { declared } else { value.ty }
 
-    // For Phase 6 we only handle simple identifier patterns; compound
-    // patterns (tuple/struct destructuring) land in Phase 8.
-    let name = astPatternBindingName(cx.ast, patIdx)
-    if name != "" {
-        checkBindSpan(cx.env, name, effectiveTy, mutable, node.start, node.end)
-        checkRecordBinding(cx.env, patIdx, name, effectiveTy, mutable, node.start, node.end)
+    if !(patIsIrrefutable(cx, patIdx, effectiveTy)) {
+        cx.env.diagnostics.push(diagRefutablePattern("let binding", node.start, node.end))
     }
 
-    let patNode = if name != "" {
-        corePatIdent(cx.core, name, mutable, effectiveTy, node.start, node.end)
-    } else {
-        corePatErr(cx.core, node.start, node.end)
-    }
+    let patNode = elabBindPattern(cx, patIdx, effectiveTy, mutable)
     coreLetStmt(cx.core, patNode, value.node, mutable, effectiveTy, node.start, node.end)
+}
+
+fn elabAssignStmt(cx: ElabCx, node: AstNode) -> Int {
+    let target = elabAssignableTarget(cx, node.left)
+    let value = if node.op == FrontAssign {
+        elabCheck(cx, node.right, target.ty)
+    } else {
+        let rhs = elabCheck(cx, node.right, target.ty)
+        let op = assignTokenToBinOp(node.op)
+        let resultTy = binOpResultType(cx.env, op, target.ty, rhs.ty, node.start, node.end)
+        let valueNode = coreBinary(cx.core, op, target.node, rhs.node, resultTy, node.start, node.end)
+        ElabResult { node: valueNode, ty: resultTy }
+    }
+    coreAssignStmt(cx.core, [target.node], value.node, node.start, node.end)
+}
+
+fn elabAssignableTarget(cx: ElabCx, idx: Int) -> ElabResult {
+    if idx < 0 {
+        cx.env.diagnostics.push(diagInvalidAssignTarget(0, 0))
+        return elabErrResult(cx, 0, 0)
+    }
+    let node = astArenaNodeAt(cx.ast.arena, idx)
+    if node.kind != AstNIdent && node.kind != AstNField && node.kind != AstNIndex {
+        let target = elabInfer(cx, idx)
+        cx.env.diagnostics.push(diagInvalidAssignTarget(node.start, node.end))
+        return target
+    }
+    let target = elabInfer(cx, idx)
+    if node.kind == AstNIdent {
+        let name = node.text
+        if checkLookup(cx.env, name) >= 0 && !(checkLookupMutable(cx.env, name)) {
+            cx.env.diagnostics.push(diagImmutableAssign(name, node.start, node.end))
+        }
+    }
+    target
 }
 
 fn elabReturnStmt(cx: ElabCx, node: AstNode) -> Int {
@@ -565,6 +600,135 @@ fn elabReturnStmt(cx: ElabCx, node: AstNode) -> Int {
 fn elabExprStmt(cx: ElabCx, node: AstNode) -> Int {
     let r = elabInfer(cx, node.left)
     coreExprStmt(cx.core, r.node, node.start, node.end)
+}
+
+fn elabDeferStmt(cx: ElabCx, node: AstNode) -> Int {
+    let value = elabInfer(cx, node.left)
+    coreDeferStmt(cx.core, value.node, node.start, node.end)
+}
+
+fn elabChanSendStmt(cx: ElabCx, node: AstNode) -> Int {
+    let channel = elabInfer(cx, node.left)
+    let elemTy = elabChannelElemTy(cx, channel.ty, node.start, node.end)
+    let value = if tyIsErr(cx.env.tys, elemTy) {
+        elabInfer(cx, node.right)
+    } else {
+        elabCheck(cx, node.right, elemTy)
+    }
+    coreChanSendStmt(cx.core, channel.node, value.node, node.start, node.end)
+}
+
+fn elabForStmt(cx: ElabCx, node: AstNode) -> Int {
+    let patIdx = if checkIntListLenHelper(node.children) > 0 {
+        checkIntListAt(node.children, 0)
+    } else {
+        -1
+    }
+    let iterIdx = if checkIntListLenHelper(node.children) > 1 {
+        checkIntListAt(node.children, 1)
+    } else {
+        -1
+    }
+
+    if node.text == "infinite" {
+        let body = elabLoopBody(cx, node.right)
+        return coreForStmt(cx.core, -1, -1, body, 0, node.start, node.end)
+    }
+
+    if node.text == "cond" {
+        let cond = elabCheck(cx, node.left, tBool(cx.env.tys))
+        let body = elabLoopBody(cx, node.right)
+        return coreForStmt(cx.core, -1, cond.node, body, 1, node.start, node.end)
+    }
+
+    if node.text == "forlet" {
+        let scrutinee = elabInfer(cx, node.left)
+        let mark = checkScopeMark(cx.env)
+        let patNode = elabBindPattern(cx, patIdx, scrutinee.ty, false)
+        let body = elabLoopBody(cx, node.right)
+        checkScopeDrop(cx.env, mark)
+        return coreForStmt(cx.core, patNode, scrutinee.node, body, 1, node.start, node.end)
+    }
+
+    if node.text == "forin" {
+        let iter = elabInfer(cx, iterIdx)
+        let elemTy = elabForIterableElemTy(cx, iter.ty, node.start, node.end)
+        if !(patIsIrrefutable(cx, patIdx, elemTy)) {
+            cx.env.diagnostics.push(diagRefutablePattern("for-in binding", node.start, node.end))
+        }
+        let mark = checkScopeMark(cx.env)
+        let patNode = elabBindPattern(cx, patIdx, elemTy, false)
+        let body = elabLoopBody(cx, node.right)
+        checkScopeDrop(cx.env, mark)
+        return coreForStmt(cx.core, patNode, iter.node, body, 2, node.start, node.end)
+    }
+
+    let body = elabLoopBody(cx, node.right)
+    coreForStmt(cx.core, -1, -1, body, 0, node.start, node.end)
+}
+
+fn elabLoopBody(cx: ElabCx, bodyIdx: Int) -> Int {
+    if bodyIdx < 0 {
+        return coreStmtBlock(cx.core, [], 0, 0)
+    }
+    let prevInLoop = cx.env.inLoop
+    cx.env.inLoop = true
+    let node = astArenaNodeAt(cx.ast.arena, bodyIdx)
+    let body = if node.kind == AstNBlock {
+        elabInferBlock(cx, bodyIdx, node).node
+    } else {
+        let stmt = elabStmt(cx, bodyIdx)
+        coreStmtBlock(cx.core, [stmt], node.start, node.end)
+    }
+    cx.env.inLoop = prevInLoop
+    body
+}
+
+fn elabChannelElemTy(cx: ElabCx, ty: Int, start: Int, end: Int) -> Int {
+    let tys = cx.env.tys
+    let resolved = checkResolveAliasDeep(cx.env, ty)
+    if tyIsNamedHead(tys, resolved, "Chan") || tyIsNamedHead(tys, resolved, "Channel") {
+        let args = tyArgsAt(tys, resolved)
+        if checkIntListLenHelper(args) > 0 {
+            return checkIntListAt(args, 0)
+        }
+    }
+    if !(tyIsErr(tys, resolved)) {
+        cx.env.diagnostics.push(diagOperandType("<-", tyToString(tys, resolved), start, end))
+    }
+    tErr(tys)
+}
+
+fn elabForIterableElemTy(cx: ElabCx, ty: Int, start: Int, end: Int) -> Int {
+    let tys = cx.env.tys
+    let resolved = checkResolveAliasDeep(cx.env, ty)
+    if tyIsErr(tys, resolved) {
+        return tErr(tys)
+    }
+    if tyIsPrim(tys, resolved, PkString) {
+        return tChar(tys)
+    }
+    if tyIsPrim(tys, resolved, PkBytes) {
+        return tByte(tys)
+    }
+    if tyIsNamedHead(tys, resolved, "Map") {
+        let args = tyArgsAt(tys, resolved)
+        if checkIntListLenHelper(args) == 2 {
+            return tyTuple(tys, [checkIntListAt(args, 0), checkIntListAt(args, 1)])
+        }
+    }
+    if tyIsNamedHead(tys, resolved, "List")
+        || tyIsNamedHead(tys, resolved, "Range")
+        || tyIsNamedHead(tys, resolved, "Chan")
+        || tyIsNamedHead(tys, resolved, "Channel")
+        || tyIsNamedHead(tys, resolved, "Iter") {
+        let args = tyArgsAt(tys, resolved)
+        if checkIntListLenHelper(args) > 0 {
+            return checkIntListAt(args, 0)
+        }
+    }
+    cx.env.diagnostics.push(diagOperandType("in", tyToString(tys, resolved), start, end))
+    tErr(tys)
 }
 
 // ---------------------------------------------------------------------
@@ -642,21 +806,6 @@ fn astTypeRendered(ast: AstFile, node: AstNode) -> String {
     ""
 }
 
-/// astPatternBindingName extracts the identifier name from a simple
-/// pattern `AstNPattern` node. Returns the empty string when the
-/// pattern is compound — Phase 8 supersedes this with a full pattern
-/// lowerer.
-fn astPatternBindingName(ast: AstFile, idx: Int) -> String {
-    if idx < 0 {
-        return ""
-    }
-    let node = astArenaNodeAt(ast.arena, idx)
-    if node.kind != AstNPattern {
-        return ""
-    }
-    node.text
-}
-
 // ---------------------------------------------------------------------
 // Operator mapping from parser tokens to Core enums.
 // ---------------------------------------------------------------------
@@ -688,6 +837,20 @@ fn tokenToBinOp(tok: FrontTokenKind) -> BinOp {
     if tok == FrontBitXor { return BoBitXor }
     if tok == FrontShl { return BoShl }
     if tok == FrontShr { return BoShr }
+    BoInvalid
+}
+
+fn assignTokenToBinOp(tok: FrontTokenKind) -> BinOp {
+    if tok == FrontPlusEq { return BoAdd }
+    if tok == FrontMinusEq { return BoSub }
+    if tok == FrontStarEq { return BoMul }
+    if tok == FrontSlashEq { return BoDiv }
+    if tok == FrontPercentEq { return BoMod }
+    if tok == FrontBitAndEq { return BoBitAnd }
+    if tok == FrontBitOrEq { return BoBitOr }
+    if tok == FrontBitXorEq { return BoBitXor }
+    if tok == FrontShlEq { return BoShl }
+    if tok == FrontShrEq { return BoShr }
     BoInvalid
 }
 
@@ -1398,7 +1561,7 @@ fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         }
         let paramName = paramNode.text
         if paramName != "" {
-            checkBindSpan(cx.env, paramName, paramTy, false, paramNode.start, paramNode.end)
+            checkBindSpan(cx.env, paramName, paramTy, true, paramNode.start, paramNode.end)
         }
         paramTys.push(paramTy)
         coreParams.push(coreParam(cx.core, paramName, paramTy, -1, paramNode.start, paramNode.end))
@@ -1634,6 +1797,14 @@ fn elabInferQuestion(cx: ElabCx, node: AstNode) -> ElabResult {
 // ---------------------------------------------------------------------
 
 pub fn elabPattern(cx: ElabCx, idx: Int, scrutTy: Int) -> Int {
+    elabPatternMode(cx, idx, scrutTy, false, false)
+}
+
+fn elabBindPattern(cx: ElabCx, idx: Int, scrutTy: Int, mutable: Bool) -> Int {
+    elabPatternMode(cx, idx, scrutTy, mutable, true)
+}
+
+fn elabPatternMode(cx: ElabCx, idx: Int, scrutTy: Int, mutable: Bool, recordBinding: Bool) -> Int {
     if idx < 0 {
         return corePatErr(cx.core, 0, 0)
     }
@@ -1650,8 +1821,11 @@ pub fn elabPattern(cx: ElabCx, idx: Int, scrutTy: Int) -> Int {
 
     if kind == "ident" {
         let name = node.text
-        checkBindSpan(cx.env, name, scrutTy, false, node.start, node.end)
-        return corePatIdent(cx.core, name, false, scrutTy, node.start, node.end)
+        checkBindSpan(cx.env, name, scrutTy, mutable, node.start, node.end)
+        if recordBinding {
+            checkRecordBinding(cx.env, idx, name, scrutTy, mutable, node.start, node.end)
+        }
+        return corePatIdent(cx.core, name, mutable, scrutTy, node.start, node.end)
     }
 
     if kind == "lit" {
@@ -1664,27 +1838,30 @@ pub fn elabPattern(cx: ElabCx, idx: Int, scrutTy: Int) -> Int {
     }
 
     if kind == "variant" {
-        return elabVariantPattern(cx, node, scrutTy)
+        return elabVariantPattern(cx, node, scrutTy, mutable, recordBinding)
     }
 
     if kind == "tuple" {
-        return elabTuplePattern(cx, node, scrutTy)
+        return elabTuplePattern(cx, node, scrutTy, mutable, recordBinding)
     }
 
     if kind == "struct" {
-        return elabStructPattern(cx, node, scrutTy)
+        return elabStructPattern(cx, node, scrutTy, mutable, recordBinding)
     }
 
     if kind == "binding" {
         let innerIdx = node.left
-        let inner = elabPattern(cx, innerIdx, scrutTy)
+        let inner = elabPatternMode(cx, innerIdx, scrutTy, mutable, recordBinding)
         let name = node.text
-        checkBindSpan(cx.env, name, scrutTy, false, node.start, node.end)
-        return corePatBinding(cx.core, name, inner, false, scrutTy, node.start, node.end)
+        checkBindSpan(cx.env, name, scrutTy, mutable, node.start, node.end)
+        if recordBinding {
+            checkRecordBinding(cx.env, idx, name, scrutTy, mutable, node.start, node.end)
+        }
+        return corePatBinding(cx.core, name, inner, mutable, scrutTy, node.start, node.end)
     }
 
     if kind == "or" {
-        return elabOrPattern(cx, node, scrutTy)
+        return elabOrPattern(cx, node, scrutTy, mutable, recordBinding)
     }
 
     if kind == "range" {
@@ -1713,28 +1890,28 @@ fn patternClassification(cx: ElabCx, node: AstNode) -> String {
     "unsupported"
 }
 
-fn elabOrPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+fn elabOrPattern(cx: ElabCx, node: AstNode, scrutTy: Int, mutable: Bool, recordBinding: Bool) -> Int {
     // Parser encodes or-pattern as a binary tree via `left` + `right`
     // (see `opParsePattern` in parser.osty). Walk both subtrees so we
     // flatten nested `A | B | C` into one alternative list for the
     // Core IR.
     let mut alts: List<Int> = []
-    orPatternFlatten(cx, node.left, scrutTy, alts)
-    orPatternFlatten(cx, node.right, scrutTy, alts)
+    orPatternFlatten(cx, node.left, scrutTy, mutable, recordBinding, alts)
+    orPatternFlatten(cx, node.right, scrutTy, mutable, recordBinding, alts)
     corePatOr(cx.core, alts, scrutTy, node.start, node.end)
 }
 
-fn orPatternFlatten(cx: ElabCx, idx: Int, scrutTy: Int, alts: List<Int>) {
+fn orPatternFlatten(cx: ElabCx, idx: Int, scrutTy: Int, mutable: Bool, recordBinding: Bool, alts: List<Int>) {
     if idx < 0 {
         return
     }
     let sub = astArenaNodeAt(cx.ast.arena, idx)
     if sub.kind == AstNPattern && sub.extra == astPatternOrKind() {
-        orPatternFlatten(cx, sub.left, scrutTy, alts)
-        orPatternFlatten(cx, sub.right, scrutTy, alts)
+        orPatternFlatten(cx, sub.left, scrutTy, mutable, recordBinding, alts)
+        orPatternFlatten(cx, sub.right, scrutTy, mutable, recordBinding, alts)
         return
     }
-    alts.push(elabPattern(cx, idx, scrutTy))
+    alts.push(elabPatternMode(cx, idx, scrutTy, mutable, recordBinding))
 }
 
 fn elabRangePattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
@@ -1754,7 +1931,7 @@ fn elabRangePattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
     corePatRange(cx.core, lo, hi, inclusive, scrutTy, node.start, node.end)
 }
 
-fn elabVariantPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+fn elabVariantPattern(cx: ElabCx, node: AstNode, scrutTy: Int, mutable: Bool, recordBinding: Bool) -> Int {
     let tys = cx.env.tys
     let variantName = node.text
     let scrutHead = tyHeadAt(tys, scrutTy)
@@ -1786,13 +1963,13 @@ fn elabVariantPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
         } else {
             tErr(tys)
         }
-        subs.push(elabPattern(cx, subIdx, fieldTy))
+        subs.push(elabPatternMode(cx, subIdx, fieldTy, mutable, recordBinding))
         i = i + 1
     }
     corePatVariant(cx.core, resolved.owner, variantName, subs, scrutTy, node.start, node.end)
 }
 
-fn elabTuplePattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+fn elabTuplePattern(cx: ElabCx, node: AstNode, scrutTy: Int, mutable: Bool, recordBinding: Bool) -> Int {
     let tys = cx.env.tys
     let kind = tyKindAt(tys, scrutTy)
     if kind != TkTuple {
@@ -1807,13 +1984,13 @@ fn elabTuplePattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
     let mut i = 0
     for subIdx in node.children {
         let elemTy = if i < checkIntListLenHelper(elems) { checkIntListAt(elems, i) } else { tErr(tys) }
-        subs.push(elabPattern(cx, subIdx, elemTy))
+        subs.push(elabPatternMode(cx, subIdx, elemTy, mutable, recordBinding))
         i = i + 1
     }
     corePatTuple(cx.core, subs, scrutTy, node.start, node.end)
 }
 
-fn elabStructPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
+fn elabStructPattern(cx: ElabCx, node: AstNode, scrutTy: Int, mutable: Bool, recordBinding: Bool) -> Int {
     let tys = cx.env.tys
     let owner = tyHeadAt(tys, scrutTy)
     let typeSig = checkLookupType(cx.env, owner)
@@ -1836,7 +2013,15 @@ fn elabStructPattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
         } else {
             fieldSig.ty
         }
-        let inner = elabPattern(cx, child.left, substituted)
+        let inner = if child.left >= 0 {
+            elabPatternMode(cx, child.left, substituted, mutable, recordBinding)
+        } else {
+            checkBindSpan(cx.env, fieldName, substituted, mutable, child.start, child.end)
+            if recordBinding {
+                checkRecordBinding(cx.env, childIdx, fieldName, substituted, mutable, child.start, child.end)
+            }
+            corePatIdent(cx.core, fieldName, mutable, substituted, child.start, child.end)
+        }
         subs.push(corePatStructField(cx.core, fieldName, inner, child.start, child.end))
     }
     corePatStruct(cx.core, owner, subs, false, scrutTy, node.start, node.end)

--- a/toolchain/elab_test.osty
+++ b/toolchain/elab_test.osty
@@ -32,6 +32,73 @@ fn testElabLetWithMismatchTriggersDiagnostic() {
     testing.assert(elabDiagHasCode(checked.diagnostics, "E0701"))
 }
 
+fn testElabLetTuplePatternBindsDestructuredNames() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn main() {
+                let (count, label) = (1, "hi")
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "count"), "Int")
+    testing.assertEq(frontCheckResultBindingType(checked, "label"), "String")
+}
+
+fn testElabLetRefutablePatternTriggersDiagnostic() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn main() {
+                let Some(value) = Some(1)
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0744"))
+    testing.assertEq(frontCheckResultBindingType(checked, "value"), "Int")
+}
+
+fn testElabAllowsParameterReassignment() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn bump(total: Int) -> Int {
+                total = total + 1
+                total
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+}
+
+fn testElabAllowsFieldAssignmentThroughParameters() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct Counter { value: Int }
+
+            fn bump(counter: Counter) {
+                counter.value = counter.value + 1
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+}
+
+fn testElabForInBindsLoopElementType() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn sum(xs: List<Int>) -> Int {
+                let mut total = 0
+                for x in xs {
+                    total = total + x
+                }
+                total
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "x"), "Int")
+}
+
 fn testElabIfElseJoinsBranches() {
     let checked = frontendCheckSource(
         r"""

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -565,27 +565,30 @@ fn tyNamedToString(arena: TyArena, node: TyNode) -> String {
     if tyIntListLen(node.args) == 0 {
         return node.head
     }
+    let sep = ", "
     let mut parts: List<String> = []
     for arg in node.args {
         parts.push(tyToString(arena, arg))
     }
-    "{node.head}<{strings.join(parts, \", \")}>"
+    "{node.head}<{strings.join(parts, sep)}>"
 }
 
 fn tyTupleToString(arena: TyArena, elems: List<Int>) -> String {
+    let sep = ", "
     let mut parts: List<String> = []
     for e in elems {
         parts.push(tyToString(arena, e))
     }
-    "({strings.join(parts, \", \")})"
+    "({strings.join(parts, sep)})"
 }
 
 fn tyFnToString(arena: TyArena, params: List<Int>, ret: Int) -> String {
+    let sep = ", "
     let mut parts: List<String> = []
     for p in params {
         parts.push(tyToString(arena, p))
     }
-    "fn({strings.join(parts, \", \")}) -> {tyToString(arena, ret)}"
+    "fn({strings.join(parts, sep)}) -> {tyToString(arena, ret)}"
 }
 
 fn primKindName(prim: PrimKind) -> String {


### PR DESCRIPTION
## Summary
- extend the Osty elaborator to handle assignment, defer, for-loop, and channel-send statements directly
- bind destructured `let` patterns and loop patterns through the typed checker, with a new refutable-pattern diagnostic for `let` and `for in`
- add selfhost smoke coverage and source-level regression tests for tuple lets, loop bindings, and parameter reassignment

## Testing
- `go test ./internal/check ./internal/lsp ./cmd/osty-native-checker`
- `go test ./internal/selfhost -run TestToolchainCheckerSourcesTranspile -count=1`