### PR TITLE
Extend selfhost checker owner generic bounds

### DIFF
--- a/cmd/osty-native-checker/main_test.go
+++ b/cmd/osty-native-checker/main_test.go
@@ -41,3 +41,34 @@ func TestRunRejectsInvalidJSON(t *testing.T) {
 		t.Fatalf("run error = %v, want decode error", err)
 	}
 }
+
+func TestRunChecksGenericBoundsAndInterfaceExtends(t *testing.T) {
+	var goodOut bytes.Buffer
+	goodIn := strings.NewReader(`{"source":"interface Named { fn name(self) -> String }\ninterface Tagged: Named { fn tag(self) -> String }\nstruct User { name: String fn name(self) -> String { self.name } fn tag(self) -> String { \"user\" } }\nfn display<T: Tagged>(value: T) -> String { value.name() }\nfn main() { let user: User = User { name: \"Ada\" } let label: String = display(user) }\n"}`)
+	if err := run(goodIn, &goodOut); err != nil {
+		t.Fatalf("run good error: %v", err)
+	}
+	var goodResp checkResponse
+	if err := json.Unmarshal(goodOut.Bytes(), &goodResp); err != nil {
+		t.Fatalf("decode good response: %v", err)
+	}
+	if goodResp.Summary.Errors != 0 {
+		t.Fatalf("good summary errors = %d, want 0", goodResp.Summary.Errors)
+	}
+	if len(goodResp.Instantiations) == 0 {
+		t.Fatalf("good instantiations = %#v, want generic call facts", goodResp.Instantiations)
+	}
+
+	var badOut bytes.Buffer
+	badIn := strings.NewReader(`{"source":"interface Named { fn name(self) -> String }\nstruct User { age: Int }\nfn display<T: Named>(value: T) -> String { value.name() }\nfn main() { let user: User = User { age: 37 } let label: String = display(user) }\n"}`)
+	if err := run(badIn, &badOut); err != nil {
+		t.Fatalf("run bad error: %v", err)
+	}
+	var badResp checkResponse
+	if err := json.Unmarshal(badOut.Bytes(), &badResp); err != nil {
+		t.Fatalf("decode bad response: %v", err)
+	}
+	if badResp.Summary.Errors == 0 {
+		t.Fatalf("bad summary errors = %d, want > 0", badResp.Summary.Errors)
+	}
+}

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -129,7 +129,7 @@ fn collectDecls(cx: ElabCx) {
     for declIdx in cx.ast.arena.decls {
         let node = astArenaNodeAt(cx.ast.arena, declIdx)
         match node.kind {
-            AstNFnDecl -> collectFnDecl(cx, declIdx, node, "", []),
+            AstNFnDecl -> collectFnDecl(cx, declIdx, node, "", [], []),
             AstNStructDecl -> collectStructDecl(cx, declIdx, node),
             AstNEnumDecl -> collectEnumDecl(cx, declIdx, node),
             AstNInterfaceDecl -> collectInterfaceDecl(cx, declIdx, node),
@@ -140,10 +140,18 @@ fn collectDecls(cx: ElabCx) {
     }
 }
 
-fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGenerics: List<String>) {
+fn collectFnDecl(
+    cx: ElabCx,
+    declIdx: Int,
+    node: AstNode,
+    owner: String,
+    ownerGenerics: List<String>,
+    ownerBounds: List<CheckGenericBound>,
+) {
     let name = node.text
     let generics = collectGenericNames(cx, node.children2)
     let combinedGenerics = appendStringLists(ownerGenerics, generics)
+    let combinedBounds = appendGenericBounds(ownerBounds, collectGenericBounds(cx, node.children2))
 
     // Build paramTys / paramNames from node.children (AstNParam entries).
     let mut paramNames: List<String> = []
@@ -175,7 +183,7 @@ fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGe
         paramNames,
         paramTys,
         generics: combinedGenerics,
-        genericBounds: collectGenericBounds(cx, node.children2),
+        genericBounds: combinedBounds,
     }
     checkRegisterFn(cx.env, sig)
 
@@ -187,7 +195,8 @@ fn collectFnDecl(cx: ElabCx, declIdx: Int, node: AstNode, owner: String, ownerGe
 fn collectStructDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
     let name = node.text
     let generics = collectGenericNames(cx, node.children2)
-    checkRegisterType(cx.env, CheckTypeSig { name, generics, kind: "struct" })
+    let genericBounds = collectGenericBounds(cx, node.children2)
+    checkRegisterType(cx.env, CheckTypeSig { name, generics, genericBounds, kind: "struct" })
     let ownerTy = tyNamed(cx.env.tys, name, genericListToTyArgs(cx, generics))
     checkRecordSymbol(cx.env, declIdx, "struct", name, "", ownerTy, node.start, node.end)
 
@@ -207,7 +216,7 @@ fn collectStructDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
                 checkRegisterField(cx.env, field)
                 checkRecordSymbol(cx.env, memberIdx, "field", member.text, name, effectiveTy, member.start, member.end)
             },
-            AstNFnDecl -> collectFnDecl(cx, memberIdx, member, name, generics),
+            AstNFnDecl -> collectFnDecl(cx, memberIdx, member, name, generics, genericBounds),
             _ -> {},
         }
     }
@@ -216,7 +225,8 @@ fn collectStructDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
 fn collectEnumDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
     let name = node.text
     let generics = collectGenericNames(cx, node.children2)
-    checkRegisterType(cx.env, CheckTypeSig { name, generics, kind: "enum" })
+    let genericBounds = collectGenericBounds(cx, node.children2)
+    checkRegisterType(cx.env, CheckTypeSig { name, generics, genericBounds, kind: "enum" })
     let ownerTy = tyNamed(cx.env.tys, name, genericListToTyArgs(cx, generics))
     checkRecordSymbol(cx.env, declIdx, "enum", name, "", ownerTy, node.start, node.end)
 
@@ -240,7 +250,7 @@ fn collectEnumDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
                 })
                 checkRecordSymbol(cx.env, memberIdx, "variant", member.text, name, ownerTy, member.start, member.end)
             },
-            AstNFnDecl -> collectFnDecl(cx, memberIdx, member, name, generics),
+            AstNFnDecl -> collectFnDecl(cx, memberIdx, member, name, generics, genericBounds),
             _ -> {},
         }
     }
@@ -248,14 +258,19 @@ fn collectEnumDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
 
 fn collectInterfaceDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
     let name = node.text
-    let generics = collectGenericNames(cx, node.children2)
     checkRegisterInterface(cx.env, name)
-    checkRegisterType(cx.env, CheckTypeSig { name, generics, kind: "interface" })
+    checkRegisterType(cx.env, CheckTypeSig { name, generics: [], genericBounds: [], kind: "interface" })
     checkRecordSymbol(cx.env, declIdx, "interface", name, "", tyNamed(cx.env.tys, name, []), node.start, node.end)
+    for superIdx in node.children2 {
+        let ifaceTy = astTypeToTyInCollect(cx, superIdx)
+        if ifaceTy >= 0 {
+            checkRegisterInterfaceExtends(cx.env, CheckInterfaceExt { owner: name, ifaceTy })
+        }
+    }
     for memberIdx in node.children {
         let member = astArenaNodeAt(cx.ast.arena, memberIdx)
         if member.kind == AstNFnDecl {
-            collectFnDecl(cx, memberIdx, member, name, generics)
+            collectFnDecl(cx, memberIdx, member, name, [], [])
         }
     }
 }
@@ -303,10 +318,14 @@ fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
         return
     }
     let mark = checkScopeMark(cx.env)
+    let boundsMark = checkGenericBoundMark(cx.env)
     let prevReturn = cx.env.returnTy
     let prevFnName = cx.env.fnName
     cx.env.returnTy = sig.retTy
     cx.env.fnName = sig.name
+    for bound in sig.genericBounds {
+        checkAddGenericBound(cx.env, bound)
+    }
 
     // Bind parameters.
     let mut i = 0
@@ -323,6 +342,7 @@ fn elaborateFnBody(cx: ElabCx, node: AstNode, owner: String) {
 
     cx.env.returnTy = prevReturn
     cx.env.fnName = prevFnName
+    checkClearGenericBoundsAfter(cx.env, boundsMark)
     checkScopeDrop(cx.env, mark)
 }
 
@@ -394,6 +414,17 @@ fn collectGenericBounds(cx: ElabCx, idxs: List<Int>) -> List<CheckGenericBound> 
 
 fn appendStringLists(a: List<String>, b: List<String>) -> List<String> {
     let mut out: List<String> = []
+    for x in a {
+        out.push(x)
+    }
+    for y in b {
+        out.push(y)
+    }
+    out
+}
+
+fn appendGenericBounds(a: List<CheckGenericBound>, b: List<CheckGenericBound>) -> List<CheckGenericBound> {
+    let mut out: List<CheckGenericBound> = []
     for x in a {
         out.push(x)
     }

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -64,6 +64,7 @@ pub struct CheckAliasSig {
 pub struct CheckTypeSig {
     pub name: String,
     pub generics: List<String>,
+    pub genericBounds: List<CheckGenericBound>,
     pub kind: String,           // "struct" / "enum" / "interface"
 }
 
@@ -296,6 +297,13 @@ pub fn checkLookupMethod(env: CheckEnv, owner: String, name: String) -> CheckFnS
     if direct.name != "" {
         return direct
     }
+    for ifaceTy in checkGenericBoundsFor(env, owner) {
+        let ifaceHead = tyHeadAt(env.tys, checkResolveAliasDeep(env, ifaceTy))
+        let found = checkLookupMethod(env, ifaceHead, name)
+        if found.name != "" {
+            return found
+        }
+    }
     // Walk extends for interface inheritance.
     for ext in env.interfaceExtends {
         if ext.owner == owner {
@@ -427,6 +435,16 @@ pub fn checkLookupGenericBound(env: CheckEnv, tyParam: String) -> Int {
         }
     }
     found
+}
+
+pub fn checkGenericBoundsFor(env: CheckEnv, tyParam: String) -> List<Int> {
+    let mut out: List<Int> = []
+    for b in env.genericBounds {
+        if b.tyParam == tyParam {
+            out.push(b.iface)
+        }
+    }
+    out
 }
 
 pub fn checkClearGenericBoundsAfter(env: CheckEnv, mark: Int) {
@@ -637,13 +655,24 @@ pub fn checkRecordInstantiation(env: CheckEnv, nodeIdx: Int, callee: String, typ
 
 pub fn checkExpectAssignable(env: CheckEnv, expected: Int, got: Int, start: Int, end: Int) -> Bool {
     env.assignments = env.assignments + 1
-    if checkIsAssignable(env, expected, got) {
+    let expectedResolved = checkResolveAliasDeep(env, expected)
+    let gotResolved = checkResolveAliasDeep(env, got)
+    if checkIsAssignable(env, expectedResolved, gotResolved) {
         env.accepted = env.accepted + 1
         return true
     }
+    if tyKindAt(env.tys, expectedResolved) == TkNamed && checkIsInterface(env, tyHeadAt(env.tys, expectedResolved)) {
+        env.diagnostics.push(diagInterfaceNotSatisfied(
+            tyToString(env.tys, gotResolved),
+            tyToString(env.tys, expectedResolved),
+            start,
+            end,
+        ))
+        return false
+    }
     env.diagnostics.push(diagMismatch(
-        tyToString(env.tys, checkResolveAliasDeep(env, expected)),
-        tyToString(env.tys, checkResolveAliasDeep(env, got)),
+        tyToString(env.tys, expectedResolved),
+        tyToString(env.tys, gotResolved),
         start,
         end,
     ))
@@ -742,13 +771,92 @@ pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
     if dk == TkOptional && sk == TkOptional {
         return checkIsAssignable(env, tyInnerAt(env.tys, d), tyInnerAt(env.tys, s))
     }
-    // Interface satisfaction is resolved in Phase 7 once `solve.osty`
-    // lands; until then any interface destination accepts via the
-    // generic-bound escape hatch.
     if dk == TkNamed && checkIsInterface(env, tyHeadAt(env.tys, d)) {
+        return checkTypeSatisfiesInterface(env, s, d)
+    }
+    false
+}
+
+pub fn checkTypeSatisfiesInterface(env: CheckEnv, concrete: Int, iface: Int) -> Bool {
+    let concreteResolved = checkResolveAliasDeep(env, concrete)
+    let ifaceResolved = checkResolveAliasDeep(env, iface)
+    if tyIsErr(env.tys, concreteResolved) || tyIsErr(env.tys, ifaceResolved) {
+        return true
+    }
+    if tyEq(env.tys, concreteResolved, ifaceResolved) {
+        return true
+    }
+    if tyKindAt(env.tys, ifaceResolved) != TkNamed {
+        return false
+    }
+    let ifaceHead = tyHeadAt(env.tys, ifaceResolved)
+    if !(checkIsInterface(env, ifaceHead)) {
+        return false
+    }
+    if tyKindAt(env.tys, concreteResolved) == TkNamed {
+        let concreteHead = tyHeadAt(env.tys, concreteResolved)
+        for boundTy in checkGenericBoundsFor(env, concreteHead) {
+            if checkTypeSatisfiesInterface(env, boundTy, ifaceResolved) {
+                return true
+            }
+        }
+        let required = checkInterfaceMethodSet(env, ifaceHead)
+        for req in required {
+            let found = checkLookupMethod(env, concreteHead, req.name)
+            if found.name == "" {
+                return false
+            }
+            let wantTy = checkConcreteMethodTy(env, req, ifaceResolved)
+            let gotTy = checkConcreteMethodTy(env, found, concreteResolved)
+            if !(checkIsAssignable(env, wantTy, gotTy)) {
+                return false
+            }
+        }
         return true
     }
     false
+}
+
+fn checkInterfaceMethodSet(env: CheckEnv, owner: String) -> List<CheckFnSig> {
+    let mut out: List<CheckFnSig> = []
+    let mut seen: List<String> = []
+    checkCollectInterfaceMethods(env, owner, out, seen)
+    out
+}
+
+fn checkCollectInterfaceMethods(env: CheckEnv, owner: String, out: List<CheckFnSig>, seen: List<String>) {
+    for sig in env.fns {
+        if sig.owner == owner && !(checkStringListContainsLocal(seen, sig.name)) {
+            out.push(sig)
+            seen.push(sig.name)
+        }
+    }
+    for extTy in checkInterfaceExtendsList(env, owner) {
+        let extHead = tyHeadAt(env.tys, checkResolveAliasDeep(env, extTy))
+        if extHead != "" {
+            checkCollectInterfaceMethods(env, extHead, out, seen)
+        }
+    }
+}
+
+fn checkConcreteMethodTy(env: CheckEnv, sig: CheckFnSig, ownerTy: Int) -> Int {
+    let ownerResolved = checkResolveAliasDeep(env, ownerTy)
+    let ownerHead = tyHeadAt(env.tys, ownerResolved)
+    let ownerSig = checkLookupType(env, ownerHead)
+    let ownerArgs = tyArgsAt(env.tys, ownerResolved)
+    let mut params: List<Int> = []
+    let ret = if checkStringListLen(ownerSig.generics) == checkIntListLen(ownerArgs) {
+        for p in sig.paramTys {
+            params.push(checkSubstituteTy(env, p, ownerSig.generics, ownerArgs))
+        }
+        checkSubstituteTy(env, sig.retTy, ownerSig.generics, ownerArgs)
+    } else {
+        for p in sig.paramTys {
+            params.push(p)
+        }
+        sig.retTy
+    }
+    tyFn(env.tys, params, ret)
 }
 
 // ---------------------------------------------------------------------
@@ -784,6 +892,15 @@ fn checkIndexOfString(xs: List<String>, needle: String) -> Int {
     -1
 }
 
+fn checkStringListContainsLocal(xs: List<String>, needle: String) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
 pub fn emptyCheckBinding() -> CheckBinding {
     CheckBinding { name: "", ty: -1, mutable: false, start: -1, end: -1 }
 }
@@ -814,7 +931,7 @@ pub fn emptyCheckAliasSig() -> CheckAliasSig {
 }
 
 pub fn emptyCheckTypeSig() -> CheckTypeSig {
-    CheckTypeSig { name: "", generics: [], kind: "" }
+    CheckTypeSig { name: "", generics: [], genericBounds: [], kind: "" }
 }
 
 // ---------------------------------------------------------------------
@@ -834,11 +951,11 @@ pub fn checkInstallPrelude(env: CheckEnv) {
 
     // Register stdlib types that carry generics so alias/bound
     // substitution has the arity information it needs.
-    checkRegisterType(env, CheckTypeSig { name: "List", generics: ["T"], kind: "struct" })
-    checkRegisterType(env, CheckTypeSig { name: "Map", generics: ["K", "V"], kind: "struct" })
-    checkRegisterType(env, CheckTypeSig { name: "Option", generics: ["T"], kind: "enum" })
-    checkRegisterType(env, CheckTypeSig { name: "Result", generics: ["T", "E"], kind: "enum" })
-    checkRegisterType(env, CheckTypeSig { name: "Range", generics: ["T"], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "List", generics: ["T"], genericBounds: [], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Map", generics: ["K", "V"], genericBounds: [], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Option", generics: ["T"], genericBounds: [], kind: "enum" })
+    checkRegisterType(env, CheckTypeSig { name: "Result", generics: ["T", "E"], genericBounds: [], kind: "enum" })
+    checkRegisterType(env, CheckTypeSig { name: "Range", generics: ["T"], genericBounds: [], kind: "struct" })
 
     // Option / Result variants.
     checkRegisterVariant(env, CheckVariantSig {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -963,6 +963,7 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
 
     // Verify every type parameter is now resolved.
     elabReportUnresolvedGenerics(cx, solver, sig, freshs, node.start, node.end)
+    elabCheckGenericBounds(cx, solver, sig.generics, sig.genericBounds, freshs, node.start, node.end)
 
     // Record instantiation for the bridge summary.
     let typeArgsConcrete = zonkList(cx.env, solver, freshs)
@@ -1014,6 +1015,7 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
     let retSubstituted = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
     let retTy = zonk(cx.env, solver, retSubstituted)
     elabReportUnresolvedGenerics(cx, solver, sig, freshs, callNode.start, callNode.end)
+    elabCheckGenericBounds(cx, solver, sig.generics, sig.genericBounds, freshs, callNode.start, callNode.end)
 
     let typeArgsConcrete = zonkList(cx.env, solver, freshs)
     if checkIntListLenHelper(typeArgsConcrete) > 0 {
@@ -1148,6 +1150,37 @@ fn elabReportUnresolvedGenerics(
             cx.env.diagnostics.push(diagCannotInferTyParam(gname, sig.name, start, end))
         }
         i = i + 1
+    }
+}
+
+fn elabCheckGenericBounds(
+    cx: ElabCx,
+    solver: Solver,
+    generics: List<String>,
+    bounds: List<CheckGenericBound>,
+    freshs: List<Int>,
+    start: Int,
+    end: Int,
+) {
+    for bound in bounds {
+        let freshIdx = elabFindFresh(freshs, generics, bound.tyParam)
+        if freshIdx < 0 {
+            continue
+        }
+        let concrete = zonk(cx.env, solver, checkIntListAt(freshs, freshIdx))
+        if !(isFullyResolved(cx.env, solver, concrete)) {
+            continue
+        }
+        let ifaceTy = zonk(cx.env, solver, checkSubstituteTy(cx.env, bound.iface, generics, freshs))
+        if !(checkGenericBoundSatisfied(cx.env, solver, concrete, ifaceTy)) {
+            cx.env.diagnostics.push(diagBoundViolation(
+                bound.tyParam,
+                tyToString(cx.env.tys, ifaceTy),
+                tyToString(cx.env.tys, concrete),
+                start,
+                end,
+            ))
+        }
     }
 }
 
@@ -1508,6 +1541,7 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         }
     }
 
+    elabCheckGenericBounds(cx, solver, typeSig.generics, typeSig.genericBounds, freshs, node.start, node.end)
     let concreteTypeArgs = zonkList(cx.env, solver, freshs)
     let resultTy = if checkIntListLenHelper(concreteTypeArgs) == 0 {
         tyNamed(tys, owner, [])

--- a/toolchain/elab_test.osty
+++ b/toolchain/elab_test.osty
@@ -99,6 +99,148 @@ fn testElabForInBindsLoopElementType() {
     testing.assertEq(frontCheckResultBindingType(checked, "x"), "Int")
 }
 
+fn testElabAllowsMethodCallsThroughGenericBounds() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            interface Named {
+                fn name(self) -> String
+            }
+
+            struct User {
+                name: String
+
+                fn name(self) -> String {
+                    self.name
+                }
+            }
+
+            fn display<T: Named>(value: T) -> String {
+                value.name()
+            }
+
+            fn main() {
+                let user: User = User { name: "Ada" }
+                let label: String = display(user)
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "label"), "String")
+}
+
+fn testElabRejectsUnsatisfiedGenericBounds() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            interface Named {
+                fn name(self) -> String
+            }
+
+            struct User { age: Int }
+
+            fn display<T: Named>(value: T) -> String {
+                value.name()
+            }
+
+            fn main() {
+                let user: User = User { age: 37 }
+                let label: String = display(user)
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0721"))
+}
+
+fn testElabRespectsInterfaceExtendsWhenCheckingBounds() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            interface Named {
+                fn name(self) -> String
+            }
+
+            interface Tagged: Named {
+                fn tag(self) -> String
+            }
+
+            struct User {
+                name: String
+
+                fn name(self) -> String {
+                    self.name
+                }
+
+                fn tag(self) -> String {
+                    "user"
+                }
+            }
+
+            fn display<T: Tagged>(value: T) -> String {
+                value.name()
+            }
+
+            fn main() {
+                let user: User = User { name: "Ada" }
+                let label: String = display(user)
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "label"), "String")
+}
+
+fn testElabCarriesOwnerGenericBoundsIntoMethods() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            interface Named {
+                fn name(self) -> String
+            }
+
+            struct User {
+                name: String
+
+                fn name(self) -> String {
+                    self.name
+                }
+            }
+
+            struct Box<T: Named> {
+                value: T
+
+                fn display(self) -> String {
+                    self.value.name()
+                }
+            }
+
+            fn main() {
+                let box: Box<User> = Box { value: User { name: "Ada" } }
+                let label: String = box.display()
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assertEq(frontCheckResultBindingType(checked, "label"), "String")
+}
+
+fn testElabRejectsUnsatisfiedOwnerGenericBounds() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            interface Named {
+                fn name(self) -> String
+            }
+
+            struct Box<T: Named> {
+                value: T
+            }
+
+            fn main() {
+                let box: Box<Int> = Box { value: 1 }
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0721"))
+}
+
 fn testElabIfElseJoinsBranches() {
     let checked = frontendCheckSource(
         r"""

--- a/toolchain/solve.osty
+++ b/toolchain/solve.osty
@@ -377,6 +377,14 @@ pub fn zonkList(env: CheckEnv, solver: Solver, xs: List<Int>) -> List<Int> {
     out
 }
 
+/// checkGenericBoundSatisfied asks whether the zonked `concreteTy`
+/// implements the interface bound `ifaceTy`.
+pub fn checkGenericBoundSatisfied(env: CheckEnv, solver: Solver, concreteTy: Int, ifaceTy: Int) -> Bool {
+    let concrete = zonk(env, solver, concreteTy)
+    let iface = zonk(env, solver, ifaceTy)
+    checkTypeSatisfiesInterface(env, concrete, iface)
+}
+
 fn solveIntLen(xs: List<Int>) -> Int {
     let mut n = 0
     for x in xs {


### PR DESCRIPTION
## Summary
- carry owner generic bounds from struct and enum declarations into collected method signatures
- validate owner generic bounds during struct literal elaboration as well as generic call inference
- add regression coverage for owner-bound method bodies and failing owner-bound instantiations

## Testing
- `go test ./internal/check ./internal/lsp ./cmd/osty-native-checker`
- `go test ./internal/selfhost -run TestToolchainCheckerSourcesTranspile -count=1`
- `git diff --check`