### PR TITLE
feat: widen LLVM enum/result support

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -691,3 +691,122 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryGenericEnumVariantFromLetContext(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let value: Maybe<Int> = Maybe.Some(42)
+    if let Maybe.Some(x) = value {
+        println(x)
+    } else {
+        println(0)
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "42\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryGenericEnumVariantInferredFromPayload(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let value = Maybe.Some(42)
+    if let Maybe.Some(x) = value {
+        println(x)
+    } else {
+        println(0)
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "42\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryGenericEnumPayloadFreeVariantFromLetContext(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let value: Maybe<Int> = Maybe.None
+    if let Maybe.None = value {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+func TestLLVMBackendBinaryBuiltinResultFieldConstructors(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let ok: Result<Int, String> = Result.Ok(42)
+    let err: Result<Int, String> = Result.Err("x")
+    println(1)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -82,11 +82,13 @@ func Monomorphize(mod *Module) (*Module, []error) {
 		state.out.Decls = append(state.out.Decls, out)
 		state.scanDecl(out)
 	}
+	state.pushLocalTypeScope()
 	for _, s := range mod.Script {
 		cloned := cloneStmt(s)
 		state.out.Script = append(state.out.Script, cloned)
 		state.scanStmt(cloned)
 	}
+	state.popLocalTypeScope()
 
 	// Pass 3+4 (interleaved): drain both queues until neither grows.
 	// Emitting a specialization may discover further generic call sites
@@ -146,6 +148,10 @@ type monoState struct {
 	typeSeen map[string]string
 	// typeQueue is the worklist of pending struct/enum specializations.
 	typeQueue []monoTypeInstance
+	// localTypeScopes tracks statement-local bindings while scanning a
+	// concrete function or script body so unresolved Idents can recover
+	// a type from an earlier let-binding.
+	localTypeScopes []map[string]Type
 }
 
 // monoInstance is one pending free-fn specialization.
@@ -438,6 +444,11 @@ func (s *monoState) rewriteExprType(e Expr) {
 	case *FloatLit:
 		x.T = s.rewriteType(x.T)
 	case *Ident:
+		if isUnresolvedType(x.T) && (x.Kind == IdentLocal || x.Kind == IdentParam) {
+			if inferred, ok := s.lookupLocalType(x.Name); ok {
+				x.T = CloneType(inferred)
+			}
+		}
 		x.T = s.rewriteType(x.T)
 		for i, ta := range x.TypeArgs {
 			x.TypeArgs[i] = s.rewriteType(ta)
@@ -474,6 +485,11 @@ func (s *monoState) rewriteExprType(e Expr) {
 			}
 		}
 	case *VariantLit:
+		if isUnresolvedType(x.T) {
+			if inferred := s.inferVariantLiteralType(x); inferred != nil {
+				x.T = inferred
+			}
+		}
 		x.T = s.rewriteType(x.T)
 		if nt, ok := x.T.(*NamedType); ok && nt.Name != "" {
 			if x.Enum != "" && x.Enum != nt.Name {
@@ -489,6 +505,21 @@ func (s *monoState) rewriteExprType(e Expr) {
 	case *MatchExpr:
 		x.T = s.rewriteType(x.T)
 	case *FieldExpr:
+		if field, base, ok := s.enumVariantFieldExpr(x); ok {
+			if isUnresolvedType(field.T) {
+				if named, ok := base.T.(*NamedType); ok && named != nil && named.Name != "" && !containsTypeVar(named) {
+					field.T = CloneType(named)
+				}
+			}
+			field.T = s.rewriteType(field.T)
+			if nt, ok := field.T.(*NamedType); ok && nt.Name != "" {
+				base.T = CloneType(nt)
+				if base.Name != nt.Name {
+					base.Name = nt.Name
+				}
+			}
+			return
+		}
 		x.T = s.rewriteType(x.T)
 	case *IndexExpr:
 		x.T = s.rewriteType(x.T)
@@ -604,7 +635,11 @@ func (s *monoState) scanDecl(d Decl) {
 	case *LetDecl:
 		d.Type = s.rewriteType(d.Type)
 		if d.Value != nil {
+			s.seedVariantTypeFromContext(d.Type, d.Value)
 			s.scanExpr(d.Value)
+			if isUnresolvedType(d.Type) {
+				d.Type = cloneResolvedType(d.Value.Type())
+			}
 		}
 	}
 }
@@ -633,13 +668,23 @@ func (s *monoState) scanFnBody(fn *FnDecl) {
 	if fn == nil || fn.Body == nil {
 		return
 	}
+	s.pushLocalTypeScope()
+	for _, p := range fn.Params {
+		if p == nil || p.Name == "" || isUnresolvedType(p.Type) {
+			continue
+		}
+		s.bindLocalType(p.Name, p.Type)
+	}
 	s.scanBlock(fn.Body)
+	s.popLocalTypeScope()
 }
 
 func (s *monoState) scanBlock(b *Block) {
 	if b == nil {
 		return
 	}
+	s.pushLocalTypeScope()
+	defer s.popLocalTypeScope()
 	for _, st := range b.Stmts {
 		s.scanStmt(st)
 	}
@@ -655,7 +700,14 @@ func (s *monoState) scanStmt(st Stmt) {
 	case *LetStmt:
 		st.Type = s.rewriteType(st.Type)
 		if st.Value != nil {
+			s.seedVariantTypeFromContext(st.Type, st.Value)
 			s.scanExpr(st.Value)
+			if isUnresolvedType(st.Type) {
+				st.Type = cloneResolvedType(st.Value.Type())
+			}
+		}
+		if st.Name != "" && !isUnresolvedType(st.Type) {
+			s.bindLocalType(st.Name, st.Type)
 		}
 	case *ExprStmt:
 		s.scanExpr(st.X)
@@ -697,10 +749,326 @@ func (s *monoState) scanStmt(st Stmt) {
 			if a == nil {
 				continue
 			}
+			s.rewritePatternFromScrutinee(a.Pattern, st.Scrutinee.Type())
 			if a.Guard != nil {
 				s.scanExpr(a.Guard)
 			}
 			s.scanBlock(a.Body)
+		}
+	}
+}
+
+func (s *monoState) seedVariantTypeFromContext(expect Type, expr Expr) {
+	if expect == nil || expr == nil {
+		return
+	}
+	if field, base, ok := s.enumVariantFieldExpr(expr); ok {
+		named, ok := expect.(*NamedType)
+		if !ok || named == nil || named.Name == "" {
+			return
+		}
+		field.T = expect
+		if base != nil {
+			base.T = expect
+		}
+		return
+	}
+	lit, ok := expr.(*VariantLit)
+	if !ok || lit == nil {
+		return
+	}
+	if lit.T != nil {
+		if _, unresolved := lit.T.(*ErrType); !unresolved {
+			return
+		}
+	}
+	named, ok := expect.(*NamedType)
+	if !ok || named == nil || named.Name == "" {
+		return
+	}
+	if lit.Enum == "" {
+		return
+	}
+	if _, generic := s.genericEnumsByName[lit.Enum]; !generic && lit.Enum != named.Name {
+		return
+	}
+	lit.T = expect
+}
+
+func (s *monoState) enumVariantFieldExpr(expr Expr) (*FieldExpr, *Ident, bool) {
+	field, ok := expr.(*FieldExpr)
+	if !ok || field == nil || field.Optional {
+		return nil, nil, false
+	}
+	base, ok := field.X.(*Ident)
+	if !ok || base == nil || base.Kind != IdentTypeName {
+		return nil, nil, false
+	}
+	decl := s.genericEnumsByName[base.Name]
+	if decl == nil {
+		return nil, nil, false
+	}
+	for _, variant := range decl.Variants {
+		if variant != nil && variant.Name == field.Name && len(variant.Payload) == 0 {
+			return field, base, true
+		}
+	}
+	return nil, nil, false
+}
+
+func (s *monoState) pushLocalTypeScope() {
+	s.localTypeScopes = append(s.localTypeScopes, map[string]Type{})
+}
+
+func (s *monoState) popLocalTypeScope() {
+	if len(s.localTypeScopes) == 0 {
+		return
+	}
+	s.localTypeScopes = s.localTypeScopes[:len(s.localTypeScopes)-1]
+}
+
+func (s *monoState) bindLocalType(name string, t Type) {
+	if name == "" || isUnresolvedType(t) || len(s.localTypeScopes) == 0 {
+		return
+	}
+	s.localTypeScopes[len(s.localTypeScopes)-1][name] = CloneType(t)
+}
+
+func (s *monoState) lookupLocalType(name string) (Type, bool) {
+	for i := len(s.localTypeScopes) - 1; i >= 0; i-- {
+		if t, ok := s.localTypeScopes[i][name]; ok && !isUnresolvedType(t) {
+			return t, true
+		}
+	}
+	return nil, false
+}
+
+func (s *monoState) inferVariantLiteralType(lit *VariantLit) Type {
+	if lit == nil || lit.Enum == "" {
+		return nil
+	}
+	decl := s.genericEnumsByName[lit.Enum]
+	if decl == nil || len(decl.Generics) == 0 {
+		return nil
+	}
+	var variant *Variant
+	for _, candidate := range decl.Variants {
+		if candidate != nil && candidate.Name == lit.Variant {
+			variant = candidate
+			break
+		}
+	}
+	if variant == nil || len(variant.Payload) != len(lit.Args) {
+		return nil
+	}
+	env := SubstEnv{}
+	for i, payload := range variant.Payload {
+		arg := lit.Args[i].Value
+		argType := s.resolvedExprType(arg)
+		if isUnresolvedType(argType) {
+			return nil
+		}
+		if !bindInferredTypeArgs(env, payload, argType) {
+			return nil
+		}
+	}
+	args := make([]Type, 0, len(decl.Generics))
+	for _, param := range decl.Generics {
+		if param == nil {
+			return nil
+		}
+		arg, ok := env[param.Name]
+		if !ok || isUnresolvedType(arg) || containsTypeVar(arg) {
+			return nil
+		}
+		args = append(args, CloneType(arg))
+	}
+	return &NamedType{Name: decl.Name, Args: args}
+}
+
+func bindInferredTypeArgs(env SubstEnv, pattern Type, actual Type) bool {
+	if pattern == nil || actual == nil || isUnresolvedType(actual) {
+		return false
+	}
+	switch p := pattern.(type) {
+	case *TypeVar:
+		if p.Name == "" {
+			return false
+		}
+		if bound, ok := env[p.Name]; ok {
+			return typesEqual(bound, actual)
+		}
+		env[p.Name] = CloneType(actual)
+		return true
+	case *PrimType:
+		a, ok := actual.(*PrimType)
+		return ok && p.Kind == a.Kind
+	case *NamedType:
+		a, ok := actual.(*NamedType)
+		if !ok || p.Name != a.Name || p.Package != a.Package || p.Builtin != a.Builtin || len(p.Args) != len(a.Args) {
+			return false
+		}
+		for i := range p.Args {
+			if !bindInferredTypeArgs(env, p.Args[i], a.Args[i]) {
+				return false
+			}
+		}
+		return true
+	case *OptionalType:
+		a, ok := actual.(*OptionalType)
+		return ok && bindInferredTypeArgs(env, p.Inner, a.Inner)
+	case *TupleType:
+		a, ok := actual.(*TupleType)
+		if !ok || len(p.Elems) != len(a.Elems) {
+			return false
+		}
+		for i := range p.Elems {
+			if !bindInferredTypeArgs(env, p.Elems[i], a.Elems[i]) {
+				return false
+			}
+		}
+		return true
+	case *FnType:
+		a, ok := actual.(*FnType)
+		if !ok || len(p.Params) != len(a.Params) {
+			return false
+		}
+		for i := range p.Params {
+			if !bindInferredTypeArgs(env, p.Params[i], a.Params[i]) {
+				return false
+			}
+		}
+		return bindInferredTypeArgs(env, p.Return, a.Return)
+	default:
+		return false
+	}
+}
+
+func typesEqual(left Type, right Type) bool {
+	switch l := left.(type) {
+	case nil:
+		return right == nil
+	case *PrimType:
+		r, ok := right.(*PrimType)
+		return ok && l.Kind == r.Kind
+	case *NamedType:
+		r, ok := right.(*NamedType)
+		if !ok || l.Name != r.Name || l.Package != r.Package || l.Builtin != r.Builtin || len(l.Args) != len(r.Args) {
+			return false
+		}
+		for i := range l.Args {
+			if !typesEqual(l.Args[i], r.Args[i]) {
+				return false
+			}
+		}
+		return true
+	case *OptionalType:
+		r, ok := right.(*OptionalType)
+		return ok && typesEqual(l.Inner, r.Inner)
+	case *TupleType:
+		r, ok := right.(*TupleType)
+		if !ok || len(l.Elems) != len(r.Elems) {
+			return false
+		}
+		for i := range l.Elems {
+			if !typesEqual(l.Elems[i], r.Elems[i]) {
+				return false
+			}
+		}
+		return true
+	case *FnType:
+		r, ok := right.(*FnType)
+		if !ok || len(l.Params) != len(r.Params) {
+			return false
+		}
+		for i := range l.Params {
+			if !typesEqual(l.Params[i], r.Params[i]) {
+				return false
+			}
+		}
+		return typesEqual(l.Return, r.Return)
+	case *TypeVar:
+		r, ok := right.(*TypeVar)
+		return ok && l.Name == r.Name && l.Owner == r.Owner
+	case *ErrType:
+		_, ok := right.(*ErrType)
+		return ok
+	default:
+		return false
+	}
+}
+
+func isUnresolvedType(t Type) bool {
+	if t == nil {
+		return true
+	}
+	_, ok := t.(*ErrType)
+	return ok
+}
+
+func cloneResolvedType(t Type) Type {
+	if isUnresolvedType(t) {
+		return t
+	}
+	return CloneType(t)
+}
+
+func (s *monoState) resolvedExprType(e Expr) Type {
+	if e == nil {
+		return nil
+	}
+	if t := e.Type(); !isUnresolvedType(t) {
+		return t
+	}
+	switch x := e.(type) {
+	case *IntLit:
+		return TInt
+	case *FloatLit:
+		return TFloat
+	case *Ident:
+		if inferred, ok := s.lookupLocalType(x.Name); ok {
+			return inferred
+		}
+	case *VariantLit:
+		if inferred := s.inferVariantLiteralType(x); inferred != nil {
+			return inferred
+		}
+	}
+	return e.Type()
+}
+
+func (s *monoState) rewritePatternFromScrutinee(pattern Pattern, scrutinee Type) {
+	if pattern == nil {
+		return
+	}
+	switch p := pattern.(type) {
+	case *BindingPat:
+		s.rewritePatternFromScrutinee(p.Pattern, scrutinee)
+	case *OrPat:
+		for _, alt := range p.Alts {
+			s.rewritePatternFromScrutinee(alt, scrutinee)
+		}
+	case *StructPat:
+		if named, ok := scrutinee.(*NamedType); ok && named != nil && named.Name != "" {
+			if _, generic := s.genericStructsByName[p.TypeName]; generic || p.TypeName == named.Name {
+				p.TypeName = named.Name
+			}
+		}
+		for _, field := range p.Fields {
+			s.rewritePatternFromScrutinee(field.Pattern, nil)
+		}
+	case *VariantPat:
+		if named, ok := scrutinee.(*NamedType); ok && named != nil && named.Name != "" && p.Enum != "" {
+			if _, generic := s.genericEnumsByName[p.Enum]; generic || p.Enum == named.Name {
+				p.Enum = named.Name
+			}
+		}
+		for _, arg := range p.Args {
+			s.rewritePatternFromScrutinee(arg, nil)
+		}
+	case *TuplePat:
+		for _, elem := range p.Elems {
+			s.rewritePatternFromScrutinee(elem, nil)
 		}
 	}
 }
@@ -775,6 +1143,7 @@ func (s *monoState) scanExpr(e Expr) {
 		s.scanBlock(e.Else)
 	case *IfLetExpr:
 		s.scanExpr(e.Scrutinee)
+		s.rewritePatternFromScrutinee(e.Pattern, e.Scrutinee.Type())
 		s.scanBlock(e.Then)
 		s.scanBlock(e.Else)
 	case *MatchExpr:
@@ -783,6 +1152,7 @@ func (s *monoState) scanExpr(e Expr) {
 			if a == nil {
 				continue
 			}
+			s.rewritePatternFromScrutinee(a.Pattern, e.Scrutinee.Type())
 			if a.Guard != nil {
 				s.scanExpr(a.Guard)
 			}

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -1171,6 +1171,167 @@ func TestMonomorphizeVariantLitEnumFieldMangled(t *testing.T) {
 	}
 }
 
+func TestMonomorphizeVariantLitUsesLetContextType(t *testing.T) {
+	maybe := genericMaybeEnum()
+	valueType := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	lit := &VariantLit{
+		Enum:    "Maybe",
+		Variant: "Some",
+		T:       ErrTypeVal,
+		Args:    []Arg{{Value: intLit("42")}},
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{&LetStmt{Name: "m", Type: valueType, Value: lit}}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, _ := Monomorphize(in)
+	mainCp := out.Decls[0].(*FnDecl)
+	letCp := mainCp.Body.Stmts[0].(*LetStmt)
+	litCp := letCp.Value.(*VariantLit)
+	if !strings.HasPrefix(litCp.Enum, "_ZTS") {
+		t.Fatalf("VariantLit.Enum should use let-context mangled type, got %q", litCp.Enum)
+	}
+	nt, ok := litCp.T.(*NamedType)
+	if !ok || nt.Name != litCp.Enum {
+		t.Fatalf("VariantLit.T should match mangled enum, got %#v", litCp.T)
+	}
+}
+
+func TestMonomorphizeVariantPatternUsesScrutineeType(t *testing.T) {
+	maybe := genericMaybeEnum()
+	valueType := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&ExprStmt{X: &IfLetExpr{
+				Pattern: &VariantPat{
+					Enum:    "Maybe",
+					Variant: "Some",
+					Args:    []Pattern{&IdentPat{Name: "x"}},
+				},
+				Scrutinee: &Ident{Name: "m", Kind: IdentLocal, T: valueType},
+				Then:      &Block{},
+				Else:      &Block{},
+				T:         TUnit,
+			}},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, _ := Monomorphize(in)
+	mainCp := out.Decls[0].(*FnDecl)
+	ifLet := mainCp.Body.Stmts[0].(*ExprStmt).X.(*IfLetExpr)
+	pat := ifLet.Pattern.(*VariantPat)
+	if !strings.HasPrefix(pat.Enum, "_ZTS") {
+		t.Fatalf("VariantPat.Enum should use scrutinee mangled type, got %q", pat.Enum)
+	}
+}
+
+func TestMonomorphizeVariantLitInfersTypeFromPayload(t *testing.T) {
+	maybe := genericMaybeEnum()
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{
+				Name: "m",
+				Type: ErrTypeVal,
+				Value: &VariantLit{
+					Enum:    "Maybe",
+					Variant: "Some",
+					T:       ErrTypeVal,
+					Args:    []Arg{{Value: intLit("42")}},
+				},
+			},
+			&ExprStmt{X: &IfLetExpr{
+				Pattern: &VariantPat{
+					Enum:    "Maybe",
+					Variant: "Some",
+					Args:    []Pattern{&IdentPat{Name: "x"}},
+				},
+				Scrutinee: &Ident{Name: "m", Kind: IdentLocal, T: ErrTypeVal},
+				Then:      &Block{},
+				Else:      &Block{},
+				T:         TUnit,
+			}},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	mainCp := out.Decls[0].(*FnDecl)
+	letCp := mainCp.Body.Stmts[0].(*LetStmt)
+	nt, ok := letCp.Type.(*NamedType)
+	if !ok || !strings.HasPrefix(nt.Name, "_ZTS") {
+		t.Fatalf("let type should infer to mangled enum, got %#v", letCp.Type)
+	}
+	litCp := letCp.Value.(*VariantLit)
+	if litCp.Enum != nt.Name {
+		t.Fatalf("VariantLit.Enum = %q, want %q", litCp.Enum, nt.Name)
+	}
+	ifLet := mainCp.Body.Stmts[1].(*ExprStmt).X.(*IfLetExpr)
+	scrutinee := ifLet.Scrutinee.(*Ident)
+	scrutineeType, ok := scrutinee.T.(*NamedType)
+	if !ok || scrutineeType.Name != nt.Name {
+		t.Fatalf("scrutinee type should reuse inferred enum, got %#v", scrutinee.T)
+	}
+	pat := ifLet.Pattern.(*VariantPat)
+	if pat.Enum != nt.Name {
+		t.Fatalf("pattern enum = %q, want %q", pat.Enum, nt.Name)
+	}
+}
+
+func TestMonomorphizePayloadFreeVariantUsesLetContextType(t *testing.T) {
+	maybe := genericMaybeEnum()
+	valueType := &NamedType{Name: "Maybe", Args: []Type{TInt}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{
+				Name: "m",
+				Type: valueType,
+				Value: &FieldExpr{
+					X:    &Ident{Name: "Maybe", Kind: IdentTypeName, T: valueType},
+					Name: "None",
+					T:    ErrTypeVal,
+				},
+			},
+			&ExprStmt{X: &IfLetExpr{
+				Pattern:   &VariantPat{Enum: "Maybe", Variant: "None"},
+				Scrutinee: &Ident{Name: "m", Kind: IdentLocal, T: ErrTypeVal},
+				Then:      &Block{},
+				Else:      &Block{},
+				T:         TUnit,
+			}},
+		}},
+	}
+	in := &Module{Package: "main", Decls: []Decl{maybe, main}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	mainCp := out.Decls[0].(*FnDecl)
+	letCp := mainCp.Body.Stmts[0].(*LetStmt)
+	nt, ok := letCp.Type.(*NamedType)
+	if !ok || !strings.HasPrefix(nt.Name, "_ZTS") {
+		t.Fatalf("let type should rewrite to mangled enum, got %#v", letCp.Type)
+	}
+	fieldCp := letCp.Value.(*FieldExpr)
+	if fieldCp.T == nil || fieldCp.T.String() != nt.String() {
+		t.Fatalf("field expr type = %#v, want %q", fieldCp.T, nt.String())
+	}
+	base := fieldCp.X.(*Ident)
+	if base.Name != nt.Name {
+		t.Fatalf("field base name = %q, want %q", base.Name, nt.Name)
+	}
+	ifLet := mainCp.Body.Stmts[1].(*ExprStmt).X.(*IfLetExpr)
+	pat := ifLet.Pattern.(*VariantPat)
+	if pat.Enum != nt.Name {
+		t.Fatalf("pattern enum = %q, want %q", pat.Enum, nt.Name)
+	}
+}
+
 func TestMonomorphizeStructMethodSpecialization(t *testing.T) {
 	// struct Pair<T, U> { … } impl { fn first(self) -> T { self.first } }
 	// fn main() { let p = Pair<Int, Bool>; p.first() }

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -345,19 +345,16 @@ func collectBuiltinResultTypes(file *ast.File, env typeEnv) map[string]builtinRe
 	for _, decl := range file.Decls {
 		switch d := decl.(type) {
 		case *ast.FnDecl:
-			for _, param := range d.Params {
-				if param == nil {
-					continue
-				}
-				collectBuiltinResultTypeFromAST(out, param.Type, env)
-			}
-			collectBuiltinResultTypeFromAST(out, d.ReturnType, env)
+			collectBuiltinResultTypesFromFn(out, d, env)
 		case *ast.StructDecl:
 			for _, field := range d.Fields {
 				if field == nil {
 					continue
 				}
 				collectBuiltinResultTypeFromAST(out, field.Type, env)
+			}
+			for _, method := range d.Methods {
+				collectBuiltinResultTypesFromFn(out, method, env)
 			}
 		case *ast.EnumDecl:
 			for _, variant := range d.Variants {
@@ -368,11 +365,154 @@ func collectBuiltinResultTypes(file *ast.File, env typeEnv) map[string]builtinRe
 					collectBuiltinResultTypeFromAST(out, field, env)
 				}
 			}
+			for _, method := range d.Methods {
+				collectBuiltinResultTypesFromFn(out, method, env)
+			}
 		case *ast.LetDecl:
 			collectBuiltinResultTypeFromAST(out, d.Type, env)
 		}
 	}
+	for _, stmt := range file.Stmts {
+		collectBuiltinResultTypesFromStmt(out, stmt, env)
+	}
 	return out
+}
+
+func collectBuiltinResultTypesFromFn(out map[string]builtinResultType, fn *ast.FnDecl, env typeEnv) {
+	if out == nil || fn == nil {
+		return
+	}
+	for _, param := range fn.Params {
+		if param == nil {
+			continue
+		}
+		collectBuiltinResultTypeFromAST(out, param.Type, env)
+	}
+	collectBuiltinResultTypeFromAST(out, fn.ReturnType, env)
+	collectBuiltinResultTypesFromBlock(out, fn.Body, env)
+}
+
+func collectBuiltinResultTypesFromBlock(out map[string]builtinResultType, block *ast.Block, env typeEnv) {
+	if out == nil || block == nil {
+		return
+	}
+	for _, stmt := range block.Stmts {
+		collectBuiltinResultTypesFromStmt(out, stmt, env)
+	}
+}
+
+func collectBuiltinResultTypesFromStmt(out map[string]builtinResultType, stmt ast.Stmt, env typeEnv) {
+	if out == nil || stmt == nil {
+		return
+	}
+	switch s := stmt.(type) {
+	case *ast.Block:
+		collectBuiltinResultTypesFromBlock(out, s, env)
+	case *ast.LetStmt:
+		collectBuiltinResultTypeFromAST(out, s.Type, env)
+		collectBuiltinResultTypesFromExpr(out, s.Value, env)
+	case *ast.ExprStmt:
+		collectBuiltinResultTypesFromExpr(out, s.X, env)
+	case *ast.AssignStmt:
+		for _, target := range s.Targets {
+			collectBuiltinResultTypesFromExpr(out, target, env)
+		}
+		collectBuiltinResultTypesFromExpr(out, s.Value, env)
+	case *ast.ReturnStmt:
+		collectBuiltinResultTypesFromExpr(out, s.Value, env)
+	case *ast.ChanSendStmt:
+		collectBuiltinResultTypesFromExpr(out, s.Channel, env)
+		collectBuiltinResultTypesFromExpr(out, s.Value, env)
+	case *ast.DeferStmt:
+		collectBuiltinResultTypesFromExpr(out, s.X, env)
+	case *ast.ForStmt:
+		collectBuiltinResultTypesFromExpr(out, s.Iter, env)
+		collectBuiltinResultTypesFromBlock(out, s.Body, env)
+	}
+}
+
+func collectBuiltinResultTypesFromExpr(out map[string]builtinResultType, expr ast.Expr, env typeEnv) {
+	if out == nil || expr == nil {
+		return
+	}
+	switch e := expr.(type) {
+	case *ast.Block:
+		collectBuiltinResultTypesFromBlock(out, e, env)
+	case *ast.ParenExpr:
+		collectBuiltinResultTypesFromExpr(out, e.X, env)
+	case *ast.UnaryExpr:
+		collectBuiltinResultTypesFromExpr(out, e.X, env)
+	case *ast.BinaryExpr:
+		collectBuiltinResultTypesFromExpr(out, e.Left, env)
+		collectBuiltinResultTypesFromExpr(out, e.Right, env)
+	case *ast.QuestionExpr:
+		collectBuiltinResultTypesFromExpr(out, e.X, env)
+	case *ast.CallExpr:
+		collectBuiltinResultTypesFromExpr(out, e.Fn, env)
+		for _, arg := range e.Args {
+			if arg != nil {
+				collectBuiltinResultTypesFromExpr(out, arg.Value, env)
+			}
+		}
+	case *ast.FieldExpr:
+		collectBuiltinResultTypesFromExpr(out, e.X, env)
+	case *ast.IndexExpr:
+		collectBuiltinResultTypesFromExpr(out, e.X, env)
+		collectBuiltinResultTypesFromExpr(out, e.Index, env)
+	case *ast.TupleExpr:
+		for _, elem := range e.Elems {
+			collectBuiltinResultTypesFromExpr(out, elem, env)
+		}
+	case *ast.ListExpr:
+		for _, elem := range e.Elems {
+			collectBuiltinResultTypesFromExpr(out, elem, env)
+		}
+	case *ast.MapExpr:
+		for _, entry := range e.Entries {
+			if entry == nil {
+				continue
+			}
+			collectBuiltinResultTypesFromExpr(out, entry.Key, env)
+			collectBuiltinResultTypesFromExpr(out, entry.Value, env)
+		}
+	case *ast.StructLit:
+		collectBuiltinResultTypesFromExpr(out, e.Type, env)
+		for _, field := range e.Fields {
+			if field != nil {
+				collectBuiltinResultTypesFromExpr(out, field.Value, env)
+			}
+		}
+		collectBuiltinResultTypesFromExpr(out, e.Spread, env)
+	case *ast.IfExpr:
+		collectBuiltinResultTypesFromExpr(out, e.Cond, env)
+		collectBuiltinResultTypesFromBlock(out, e.Then, env)
+		collectBuiltinResultTypesFromExpr(out, e.Else, env)
+	case *ast.MatchExpr:
+		collectBuiltinResultTypesFromExpr(out, e.Scrutinee, env)
+		for _, arm := range e.Arms {
+			if arm == nil {
+				continue
+			}
+			collectBuiltinResultTypesFromExpr(out, arm.Guard, env)
+			collectBuiltinResultTypesFromExpr(out, arm.Body, env)
+		}
+	case *ast.ClosureExpr:
+		for _, param := range e.Params {
+			if param != nil {
+				collectBuiltinResultTypeFromAST(out, param.Type, env)
+			}
+		}
+		collectBuiltinResultTypeFromAST(out, e.ReturnType, env)
+		collectBuiltinResultTypesFromExpr(out, e.Body, env)
+	case *ast.TurbofishExpr:
+		collectBuiltinResultTypesFromExpr(out, e.Base, env)
+		for _, arg := range e.Args {
+			collectBuiltinResultTypeFromAST(out, arg, env)
+		}
+	case *ast.RangeExpr:
+		collectBuiltinResultTypesFromExpr(out, e.Start, env)
+		collectBuiltinResultTypesFromExpr(out, e.Stop, env)
+	}
 }
 
 func collectTupleTypes(file *ast.File, env typeEnv) map[string]tupleTypeInfo {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2039,22 +2039,39 @@ func (g *generator) emitTestingValueCall(call *ast.CallExpr) (value, bool, error
 	}
 }
 
+func builtinResultConstructorName(expr ast.Expr) (string, bool) {
+	switch fn := expr.(type) {
+	case *ast.Ident:
+		if fn.Name == "Ok" || fn.Name == "Err" {
+			return fn.Name, true
+		}
+	case *ast.FieldExpr:
+		base, ok := fn.X.(*ast.Ident)
+		if ok && base.Name == "Result" && (fn.Name == "Ok" || fn.Name == "Err") {
+			return fn.Name, true
+		}
+	case *ast.TurbofishExpr:
+		return builtinResultConstructorName(fn.Base)
+	}
+	return "", false
+}
+
 func (g *generator) emitBuiltinResultConstructor(call *ast.CallExpr) (value, bool, error) {
-	id, ok := call.Fn.(*ast.Ident)
-	if !ok || (id.Name != "Ok" && id.Name != "Err") {
+	name, ok := builtinResultConstructorName(call.Fn)
+	if !ok {
 		return value{}, false, nil
 	}
 	info, ok := g.currentBuiltinResultType()
 	if !ok {
-		return value{}, true, unsupportedf("call", "%s requires a concrete Result<T, E> context", id.Name)
+		return value{}, true, unsupportedf("call", "%s requires a concrete Result<T, E> context", name)
 	}
 	if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
-		return value{}, true, unsupportedf("call", "%s requires one positional argument", id.Name)
+		return value{}, true, unsupportedf("call", "%s requires one positional argument", name)
 	}
 	payloadIndex := 1
 	payloadType := info.okTyp
 	tag := "0"
-	if id.Name == "Err" {
+	if name == "Err" {
 		payloadIndex = 2
 		payloadType = info.errTyp
 		tag = "1"
@@ -2064,7 +2081,7 @@ func (g *generator) emitBuiltinResultConstructor(call *ast.CallExpr) (value, boo
 		return value{}, true, err
 	}
 	if payload.typ != payloadType {
-		return value{}, true, unsupportedf("type-system", "%s payload type %s, want %s", id.Name, payload.typ, payloadType)
+		return value{}, true, unsupportedf("type-system", "%s payload type %s, want %s", name, payload.typ, payloadType)
 	}
 	emitter := g.toOstyEmitter()
 	fields := []*LlvmValue{

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -255,28 +255,80 @@ fn main() {
 }
 
 // TestGenerateModuleGenericEnumMaybeMonomorphized verifies that a
-// generic `enum Maybe<T>` lands as a concrete mangled nominal.
-//
-// Currently skipped: Phase 2 correctly rewrites the IR but the LLVM
-// backend's legacy variant-call conversion (`Maybe.Some(42)` → dotted
-// AST FieldExpr) fires an `LLVM015` unsupported diagnostic when the
-// enum name is a mangled Itanium symbol. The IR-level behaviour is
-// covered by TestMonomorphizeGenericEnumSpecialization in
-// internal/ir/monomorph_test.go; the end-to-end smoke is left here as a
-// regression beacon and picked up by the llvmgen enum-lowering
-// follow-up (tracked alongside Phase 2 scope in LLVM_MIGRATION_PLAN.md).
+// generic `enum Maybe<T>` lands as a concrete mangled nominal and that
+// a variant literal with only let-context type information still lowers
+// through the legacy AST bridge.
 func TestGenerateModuleGenericEnumMaybeMonomorphized(t *testing.T) {
-	t.Skip("llvmgen variant-call lowering with mangled enum names is Phase 3+ scope")
 	src := `enum Maybe<T> { Some(T), None }
 
 fn main() {
-    let m = Maybe.Some(42)
-    println(1)
+    let m: Maybe<Int> = Maybe.Some(42)
+    if let Maybe.Some(x) = m {
+        println(x)
+    } else {
+        println(0)
+    }
 }
 `
 	got := runMonoLowerPipeline(t, src, "/tmp/phase2_maybe_ir.osty")
 	const wantTypeName = "_ZTSN4main5MaybeIlEE"
 	if !strings.Contains(got, wantTypeName) {
 		t.Fatalf("generated IR missing mangled enum type %q:\n%s", wantTypeName, got)
+	}
+}
+
+func TestGenerateModuleGenericEnumMaybeInferredFromPayload(t *testing.T) {
+	src := `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let m = Maybe.Some(42)
+    if let Maybe.Some(x) = m {
+        println(x)
+    } else {
+        println(0)
+    }
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_maybe_inferred_ir.osty")
+	const wantTypeName = "_ZTSN4main5MaybeIlEE"
+	if !strings.Contains(got, wantTypeName) {
+		t.Fatalf("generated IR missing inferred mangled enum type %q:\n%s", wantTypeName, got)
+	}
+}
+
+func TestGenerateModuleGenericEnumMaybeNoneFromLetContext(t *testing.T) {
+	src := `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let m: Maybe<Int> = Maybe.None
+    if let Maybe.None = m {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_maybe_none_ir.osty")
+	const wantTypeName = "_ZTSN4main5MaybeIlEE"
+	if !strings.Contains(got, wantTypeName) {
+		t.Fatalf("generated IR missing payload-free mangled enum type %q:\n%s", wantTypeName, got)
+	}
+}
+
+func TestGenerateModuleBuiltinResultFieldConstructors(t *testing.T) {
+	src := `fn main() {
+    let ok: Result<Int, String> = Result.Ok(42)
+    let err: Result<Int, String> = Result.Err("x")
+    println(1)
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_result_field_ctor_ir.osty")
+	for _, want := range []string{
+		"%Result.i64.ptr",
+		"insertvalue %Result.i64.ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- extend generic enum monomorphization so payload-inferred and payload-free variants preserve concrete enum context through IR/LLVM lowering
- teach llvmgen to recognize field-form builtin Result constructors like `Result.Ok(...)` / `Result.Err(...)`
- add IR, llvmgen, and backend coverage for the new enum/result paths

## Testing
- `go test ./internal/parser ./internal/ir ./internal/llvmgen ./internal/backend`