### PR TITLE
Expand IR lowering coverage and validation

### DIFF
--- a/internal/ir/ir_test.go
+++ b/internal/ir/ir_test.go
@@ -350,6 +350,50 @@ func TestValidateRejectsForWithBothVarAndPattern(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsDuplicateGenericParam(t *testing.T) {
+	fn := &FnDecl{
+		Name:     "id",
+		Generics: []*TypeParam{{Name: "T"}, {Name: "T"}},
+		Return:   TInt,
+		Body:     &Block{},
+	}
+	m := &Module{Package: "main", Decls: []Decl{fn}}
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected validation error for duplicate generic params")
+	}
+}
+
+func TestValidateRejectsNilCallTypeArg(t *testing.T) {
+	e := &CallExpr{
+		Callee:   &Ident{Name: "id", Kind: IdentFn, T: &FnType{Params: []Type{TInt}, Return: TInt}},
+		TypeArgs: []Type{nil},
+		Args:     []Arg{{Value: intLit("1")}},
+		T:        TInt,
+	}
+	m := moduleWithExpr(e)
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected validation error for nil call TypeArg")
+	}
+}
+
+func TestValidateRejectsInvalidMatchTree(t *testing.T) {
+	e := &MatchExpr{
+		Scrutinee: intLit("1"),
+		Arms: []*MatchArm{
+			{Pattern: &WildPat{}, Body: &Block{Result: intLit("1")}},
+		},
+		Tree: &DecisionLeaf{ArmIndex: 99},
+		T:    TInt,
+	}
+	m := moduleWithExpr(e)
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected validation error for invalid match tree")
+	}
+}
+
 // ==== Helpers ====
 
 func moduleWithExpr(e Expr) *Module {

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -521,6 +521,14 @@ func (l *lowerer) lowerStmt(s ast.Stmt) Stmt {
 	case *ast.LetStmt:
 		return l.lowerLetStmt(s)
 	case *ast.ExprStmt:
+		switch x := s.X.(type) {
+		case *ast.IfExpr:
+			if !x.IsIfLet {
+				return l.lowerIfStmt(x)
+			}
+		case *ast.MatchExpr:
+			return l.lowerMatchStmt(x)
+		}
 		x := l.lowerExpr(s.X)
 		return &ExprStmt{X: x, SpanV: Span{Start: posFromToken(s.Pos()), End: posFromToken(s.End())}}
 	case *ast.ReturnStmt:
@@ -633,6 +641,40 @@ func (l *lowerer) lowerForStmt(s *ast.ForStmt) Stmt {
 		Iter:    l.lowerExpr(s.Iter),
 		Body:    body,
 		SpanV:   nodeSpan(s),
+	}
+}
+
+func (l *lowerer) lowerIfStmt(e *ast.IfExpr) Stmt {
+	return &IfStmt{
+		Cond:  l.lowerExpr(e.Cond),
+		Then:  l.lowerBlock(e.Then),
+		Else:  l.lowerElseStmt(e.Else),
+		SpanV: nodeSpan(e),
+	}
+}
+
+func (l *lowerer) lowerElseStmt(alt ast.Expr) *Block {
+	switch alt := alt.(type) {
+	case nil:
+		return nil
+	case *ast.Block:
+		return l.lowerBlock(alt)
+	case *ast.IfExpr:
+		if !alt.IsIfLet {
+			stmt := l.lowerIfStmt(alt)
+			return &Block{Stmts: []Stmt{stmt}, SpanV: nodeSpan(alt)}
+		}
+		lowered := l.lowerIfExpr(alt)
+		return &Block{
+			Stmts: []Stmt{&ExprStmt{X: lowered, SpanV: lowered.At()}},
+			SpanV: nodeSpan(alt),
+		}
+	default:
+		lowered := l.lowerExpr(alt)
+		return &Block{
+			Stmts: []Stmt{&ExprStmt{X: lowered, SpanV: lowered.At()}},
+			SpanV: lowered.At(),
+		}
 	}
 }
 
@@ -781,7 +823,7 @@ func (l *lowerer) lowerIdent(id *ast.Ident) Expr {
 	out := &Ident{Name: id.Name, SpanV: nodeSpan(id), T: ErrTypeVal}
 	if l.res != nil {
 		if sym := l.res.Refs[id]; sym != nil {
-			out.Kind = identKind(sym.Kind)
+			out.Kind = identKind(sym)
 		}
 	}
 	if l.chk != nil {
@@ -803,9 +845,15 @@ func (l *lowerer) symbol(id *ast.Ident) *resolve.Symbol {
 	return l.res.Refs[id]
 }
 
-func identKind(k resolve.SymbolKind) IdentKind {
-	switch k {
+func identKind(sym *resolve.Symbol) IdentKind {
+	if sym == nil {
+		return IdentUnknown
+	}
+	switch sym.Kind {
 	case resolve.SymLet:
+		if _, ok := sym.Decl.(*ast.LetDecl); ok {
+			return IdentGlobal
+		}
 		return IdentLocal
 	case resolve.SymParam:
 		return IdentParam
@@ -922,8 +970,13 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 			return out
 		}
 		// Check if this is a variant constructor: e.g. Some(42), Ok(x).
-		if sym := l.symbol(id); sym != nil && sym.Kind == resolve.SymVariant {
-			return l.lowerVariantCall(e, "", id.Name)
+		if sym := l.symbol(id); sym != nil {
+			if sym.Kind == resolve.SymVariant {
+				return l.lowerVariantCall(e, "", sym.Name)
+			}
+			if sym.Kind == resolve.SymBuiltin && isPreludeVariantName(sym.Name) {
+				return l.lowerVariantCall(e, "", sym.Name)
+			}
 		}
 	}
 	// Strip a turbofish wrapper to retain its type arguments.
@@ -1058,6 +1111,14 @@ func intrinsicByName(name string) (IntrinsicKind, bool) {
 		return IntrinsicEprintln, true
 	}
 	return 0, false
+}
+
+func isPreludeVariantName(name string) bool {
+	switch name {
+	case "Some", "None", "Ok", "Err":
+		return true
+	}
+	return false
 }
 
 func (l *lowerer) lowerList(e *ast.ListExpr) Expr {
@@ -1334,13 +1395,31 @@ func (l *lowerer) lowerTurbofish(tf *ast.TurbofishExpr) Expr {
 	return base
 }
 
+func (l *lowerer) lowerMatchStmt(m *ast.MatchExpr) Stmt {
+	out := &MatchStmt{
+		Scrutinee: l.lowerExpr(m.Scrutinee),
+		Arms:      l.lowerMatchArms(m.Arms),
+		SpanV:     nodeSpan(m),
+	}
+	out.Tree = CompileDecisionTree(out.Scrutinee.Type(), out.Arms)
+	return out
+}
+
 func (l *lowerer) lowerMatchExpr(m *ast.MatchExpr) Expr {
 	out := &MatchExpr{
 		Scrutinee: l.lowerExpr(m.Scrutinee),
 		T:         l.exprType(m),
 		SpanV:     nodeSpan(m),
 	}
-	for _, arm := range m.Arms {
+	out.Arms = l.lowerMatchArms(m.Arms)
+	// Compile a decision tree when the arm shapes are specialisable.
+	out.Tree = CompileDecisionTree(out.Scrutinee.Type(), out.Arms)
+	return out
+}
+
+func (l *lowerer) lowerMatchArms(arms []*ast.MatchArm) []*MatchArm {
+	out := make([]*MatchArm, 0, len(arms))
+	for _, arm := range arms {
 		a := &MatchArm{
 			Pattern: l.lowerPattern(arm.Pattern),
 			SpanV:   Span{Start: posFromToken(arm.Pos()), End: posFromToken(arm.End())},
@@ -1349,10 +1428,8 @@ func (l *lowerer) lowerMatchExpr(m *ast.MatchExpr) Expr {
 			a.Guard = l.lowerExpr(arm.Guard)
 		}
 		a.Body = l.lowerArmBody(arm.Body)
-		out.Arms = append(out.Arms, a)
+		out = append(out, a)
 	}
-	// Compile a decision tree when the arm shapes are specialisable.
-	out.Tree = CompileDecisionTree(out.Scrutinee.Type(), out.Arms)
 	return out
 }
 

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -1,0 +1,151 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestLowerClassifiesTopLevelLetRefsAsGlobal(t *testing.T) {
+	global := &ast.LetDecl{
+		Name:  "g",
+		Value: &ast.IntLit{Text: "1"},
+	}
+	ref := &ast.Ident{Name: "g"}
+	closure := &ast.ClosureExpr{Body: ref}
+	file := &ast.File{
+		Decls: []ast.Decl{global},
+		Stmts: []ast.Stmt{&ast.ExprStmt{X: closure}},
+	}
+	res := &resolve.Result{
+		Refs: map[*ast.Ident]*resolve.Symbol{
+			ref: {Name: "g", Kind: resolve.SymLet, Decl: global},
+		},
+	}
+
+	mod, issues := Lower("main", file, res, nil)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+
+	stmt, ok := mod.Script[0].(*ExprStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *ExprStmt", mod.Script[0])
+	}
+	cl, ok := stmt.X.(*Closure)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *Closure", stmt.X)
+	}
+	if len(cl.Captures) != 1 {
+		t.Fatalf("closure captures = %+v, want 1 global capture", cl.Captures)
+	}
+	if cl.Captures[0].Kind != CaptureGlobal {
+		t.Fatalf("capture kind = %v, want %v", cl.Captures[0].Kind, CaptureGlobal)
+	}
+	id, ok := cl.Body.Result.(*Ident)
+	if !ok {
+		t.Fatalf("closure body result = %T, want *Ident", cl.Body.Result)
+	}
+	if id.Kind != IdentGlobal {
+		t.Fatalf("ident kind = %v, want %v", id.Kind, IdentGlobal)
+	}
+}
+
+func TestLowerPreludeVariantCallBecomesVariantLit(t *testing.T) {
+	some := &ast.Ident{Name: "Some"}
+	call := &ast.CallExpr{
+		Fn: some,
+		Args: []*ast.Arg{{
+			Value: &ast.IntLit{Text: "1"},
+		}},
+	}
+	file := &ast.File{
+		Stmts: []ast.Stmt{&ast.ExprStmt{X: call}},
+	}
+	res := &resolve.Result{
+		Refs: map[*ast.Ident]*resolve.Symbol{
+			some: {Name: "Some", Kind: resolve.SymBuiltin, Pub: true},
+		},
+	}
+
+	mod, issues := Lower("main", file, res, nil)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+
+	stmt, ok := mod.Script[0].(*ExprStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *ExprStmt", mod.Script[0])
+	}
+	lit, ok := stmt.X.(*VariantLit)
+	if !ok {
+		t.Fatalf("stmt.X = %T, want *VariantLit", stmt.X)
+	}
+	if lit.Enum != "" {
+		t.Fatalf("variant enum = %q, want empty prelude enum", lit.Enum)
+	}
+	if lit.Variant != "Some" {
+		t.Fatalf("variant name = %q, want %q", lit.Variant, "Some")
+	}
+	if got := len(lit.Args); got != 1 {
+		t.Fatalf("variant args = %d, want 1", got)
+	}
+}
+
+func TestLowerStatementIfBecomesIfStmt(t *testing.T) {
+	cond := &ast.BoolLit{Value: true}
+	ifExpr := &ast.IfExpr{
+		Cond: cond,
+		Then: &ast.Block{
+			Stmts: []ast.Stmt{&ast.ExprStmt{X: &ast.IntLit{Text: "1"}}},
+		},
+	}
+	file := &ast.File{
+		Stmts: []ast.Stmt{&ast.ExprStmt{X: ifExpr}},
+	}
+
+	mod, issues := Lower("main", file, nil, nil)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+
+	if _, ok := mod.Script[0].(*IfStmt); !ok {
+		t.Fatalf("script[0] = %T, want *IfStmt", mod.Script[0])
+	}
+}
+
+func TestLowerStatementMatchBecomesMatchStmt(t *testing.T) {
+	match := &ast.MatchExpr{
+		Scrutinee: &ast.IntLit{Text: "1"},
+		Arms: []*ast.MatchArm{
+			{
+				Pattern: &ast.LiteralPat{Literal: &ast.IntLit{Text: "1"}},
+				Body:    &ast.IntLit{Text: "10"},
+			},
+			{
+				Pattern: &ast.WildcardPat{},
+				Body:    &ast.IntLit{Text: "0"},
+			},
+		},
+	}
+	file := &ast.File{
+		Stmts: []ast.Stmt{&ast.ExprStmt{X: match}},
+	}
+
+	mod, issues := Lower("main", file, nil, nil)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+
+	stmt, ok := mod.Script[0].(*MatchStmt)
+	if !ok {
+		t.Fatalf("script[0] = %T, want *MatchStmt", mod.Script[0])
+	}
+	if stmt.Tree == nil {
+		t.Fatal("MatchStmt.Tree = nil, want compiled decision tree")
+	}
+	if got := len(stmt.Arms); got != 2 {
+		t.Fatalf("match arms = %d, want 2", got)
+	}
+}

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -68,9 +68,12 @@ func (v *validator) validateDecl(d Decl) {
 	case *FnDecl:
 		v.validateFnDecl(d, false)
 	case *StructDecl:
+		v.validateTypeParams("struct "+d.Name, d.Generics)
 		for _, f := range d.Fields {
 			if f.Type == nil {
 				v.addf("struct %s: field %s has nil Type", d.Name, f.Name)
+			} else {
+				v.validateType(f.Type, fmt.Sprintf("struct %s field %s", d.Name, f.Name))
 			}
 			if f.Default != nil {
 				v.validateExpr(f.Default)
@@ -89,11 +92,26 @@ func (v *validator) validateDecl(d Decl) {
 				v.addf("enum %s: duplicate variant %s", d.Name, vr.Name)
 			}
 			seen[vr.Name] = true
+			for i, p := range vr.Payload {
+				if p == nil {
+					v.addf("enum %s: variant %s payload[%d] nil Type", d.Name, vr.Name, i)
+					continue
+				}
+				v.validateType(p, fmt.Sprintf("enum %s variant %s payload[%d]", d.Name, vr.Name, i))
+			}
 		}
 		for _, m := range d.Methods {
 			v.validateFnDecl(m, false)
 		}
 	case *InterfaceDecl:
+		v.validateTypeParams("interface "+d.Name, d.Generics)
+		for i, ext := range d.Extends {
+			if ext == nil {
+				v.addf("interface %s: extends[%d] nil Type", d.Name, i)
+				continue
+			}
+			v.validateType(ext, fmt.Sprintf("interface %s extends[%d]", d.Name, i))
+		}
 		old := v.inInterface
 		v.inInterface = true
 		for _, m := range d.Methods {
@@ -103,10 +121,16 @@ func (v *validator) validateDecl(d Decl) {
 	case *TypeAliasDecl:
 		if d.Target == nil {
 			v.addf("alias %s: nil Target", d.Name)
+		} else {
+			v.validateTypeParams("alias "+d.Name, d.Generics)
+			v.validateType(d.Target, "alias "+d.Name)
 		}
 	case *LetDecl:
 		if d.Name == "" {
 			v.addf("top-level let: empty Name")
+		}
+		if d.Type != nil {
+			v.validateType(d.Type, "top-level let "+d.Name)
 		}
 		if d.Value == nil {
 			v.addf("top-level let %s: nil Value", d.Name)
@@ -126,7 +150,10 @@ func (v *validator) validateFnDecl(fn *FnDecl, allowNoBody bool) {
 	}
 	if fn.Return == nil {
 		v.addf("fn %s: nil Return", fn.Name)
+	} else {
+		v.validateType(fn.Return, "fn "+fn.Name+" return")
 	}
+	v.validateTypeParams("fn "+fn.Name, fn.Generics)
 	for i, p := range fn.Params {
 		if p == nil {
 			v.addf("fn %s: param[%d] nil", fn.Name, i)
@@ -134,6 +161,8 @@ func (v *validator) validateFnDecl(fn *FnDecl, allowNoBody bool) {
 		}
 		if p.Type == nil {
 			v.addf("fn %s: param %q nil Type", fn.Name, p.Name)
+		} else {
+			v.validateType(p.Type, fmt.Sprintf("fn %s param[%d]", fn.Name, i))
 		}
 		if p.Name == "" && p.Pattern == nil {
 			v.addf("fn %s: param[%d] has neither Name nor Pattern", fn.Name, i)
@@ -175,6 +204,9 @@ func (v *validator) validateStmt(s Stmt) {
 	case *LetStmt:
 		if s.Name == "" && s.Pattern == nil {
 			v.addf("let: both Name and Pattern empty")
+		}
+		if s.Type != nil {
+			v.validateType(s.Type, "let stmt")
 		}
 		if s.Value != nil {
 			v.validateExpr(s.Value)
@@ -268,6 +300,11 @@ func (v *validator) validateStmt(s Stmt) {
 			}
 			v.validateMatchArm(a)
 		}
+		if s.Tree != nil {
+			for _, err := range ValidateDecisionTree(s.Tree, len(s.Arms)) {
+				v.addf("MatchStmt tree: %v", err)
+			}
+		}
 	case *ErrorStmt:
 		// allowed by design
 	}
@@ -281,14 +318,30 @@ func (v *validator) validateExpr(e Expr) {
 	if e.Type() == nil {
 		v.addf("%T: nil Type()", e)
 	}
+	v.validateType(e.Type(), fmt.Sprintf("%T", e))
 	switch e := e.(type) {
 	case *UnaryExpr:
 		v.validateExpr(e.X)
 	case *BinaryExpr:
 		v.validateExpr(e.Left)
 		v.validateExpr(e.Right)
+	case *Ident:
+		for i, ta := range e.TypeArgs {
+			if ta == nil {
+				v.addf("Ident %s: TypeArgs[%d] nil", e.Name, i)
+				continue
+			}
+			v.validateType(ta, fmt.Sprintf("Ident %s TypeArgs[%d]", e.Name, i))
+		}
 	case *CallExpr:
 		v.validateExpr(e.Callee)
+		for i, ta := range e.TypeArgs {
+			if ta == nil {
+				v.addf("CallExpr: TypeArgs[%d] nil", i)
+				continue
+			}
+			v.validateType(ta, fmt.Sprintf("CallExpr TypeArgs[%d]", i))
+		}
 		for _, a := range e.Args {
 			v.validateArg(a)
 		}
@@ -298,14 +351,27 @@ func (v *validator) validateExpr(e Expr) {
 		}
 	case *MethodCall:
 		v.validateExpr(e.Receiver)
+		if e.Name == "" {
+			v.addf("MethodCall: empty Name")
+		}
+		for i, ta := range e.TypeArgs {
+			if ta == nil {
+				v.addf("MethodCall %s: TypeArgs[%d] nil", e.Name, i)
+				continue
+			}
+			v.validateType(ta, fmt.Sprintf("MethodCall %s TypeArgs[%d]", e.Name, i))
+		}
 		for _, a := range e.Args {
 			v.validateArg(a)
 		}
 	case *ListLit:
+		v.validateType(e.Elem, "ListLit Elem")
 		for _, el := range e.Elems {
 			v.validateExpr(el)
 		}
 	case *MapLit:
+		v.validateType(e.KeyT, "MapLit KeyT")
+		v.validateType(e.ValT, "MapLit ValT")
 		for _, en := range e.Entries {
 			v.validateExpr(en.Key)
 			v.validateExpr(en.Value)
@@ -315,6 +381,9 @@ func (v *validator) validateExpr(e Expr) {
 			v.validateExpr(el)
 		}
 	case *StructLit:
+		if e.TypeName == "" {
+			v.addf("StructLit: empty TypeName")
+		}
 		for _, f := range e.Fields {
 			if f.Value != nil {
 				v.validateExpr(f.Value)
@@ -343,6 +412,7 @@ func (v *validator) validateExpr(e Expr) {
 		v.validateExpr(e.X)
 		v.validateExpr(e.Index)
 	case *Closure:
+		v.validateType(e.Return, "Closure Return")
 		v.validateBlock(e.Body)
 		for i, c := range e.Captures {
 			if c == nil {
@@ -352,8 +422,23 @@ func (v *validator) validateExpr(e Expr) {
 			if c.Name == "" {
 				v.addf("Closure: capture[%d] empty Name", i)
 			}
+			v.validateType(c.T, fmt.Sprintf("Closure capture[%d]", i))
+		}
+		for i, p := range e.Params {
+			if p == nil {
+				v.addf("Closure: param[%d] nil", i)
+				continue
+			}
+			if p.Type == nil {
+				v.addf("Closure: param[%d] nil Type", i)
+				continue
+			}
+			v.validateType(p.Type, fmt.Sprintf("Closure param[%d]", i))
 		}
 	case *VariantLit:
+		if e.Variant == "" {
+			v.addf("VariantLit: empty Variant")
+		}
 		for _, a := range e.Args {
 			v.validateArg(a)
 		}
@@ -383,12 +468,100 @@ func (v *validator) validateExpr(e Expr) {
 			}
 			v.validateMatchArm(a)
 		}
+		if e.Tree != nil {
+			for _, err := range ValidateDecisionTree(e.Tree, len(e.Arms)) {
+				v.addf("MatchExpr tree: %v", err)
+			}
+		}
 	case *StringLit:
 		for _, p := range e.Parts {
 			if !p.IsLit && p.Expr != nil {
 				v.validateExpr(p.Expr)
 			}
 		}
+	}
+}
+
+func (v *validator) validateTypeParams(owner string, params []*TypeParam) {
+	if len(params) == 0 {
+		return
+	}
+	seen := map[string]bool{}
+	for i, p := range params {
+		if p == nil {
+			v.addf("%s: generic[%d] nil", owner, i)
+			continue
+		}
+		if p.Name == "" {
+			v.addf("%s: generic[%d] empty Name", owner, i)
+		} else if seen[p.Name] {
+			v.addf("%s: duplicate generic %s", owner, p.Name)
+		}
+		seen[p.Name] = true
+		for j, b := range p.Bounds {
+			if b == nil {
+				v.addf("%s: generic %s bound[%d] nil", owner, p.Name, j)
+				continue
+			}
+			v.validateType(b, fmt.Sprintf("%s generic %s bound[%d]", owner, p.Name, j))
+		}
+	}
+}
+
+func (v *validator) validateType(t Type, where string) {
+	if t == nil {
+		v.addf("%s: nil Type", where)
+		return
+	}
+	switch t := t.(type) {
+	case *PrimType:
+		if t.Kind == PrimInvalid {
+			v.addf("%s: invalid primitive type", where)
+		}
+	case *NamedType:
+		if t.Name == "" {
+			v.addf("%s: NamedType empty Name", where)
+		}
+		for i, a := range t.Args {
+			if a == nil {
+				v.addf("%s: NamedType arg[%d] nil", where, i)
+				continue
+			}
+			v.validateType(a, fmt.Sprintf("%s arg[%d]", where, i))
+		}
+	case *OptionalType:
+		if t.Inner == nil {
+			v.addf("%s: OptionalType nil Inner", where)
+			return
+		}
+		v.validateType(t.Inner, where+" inner")
+	case *TupleType:
+		for i, e := range t.Elems {
+			if e == nil {
+				v.addf("%s: TupleType elem[%d] nil", where, i)
+				continue
+			}
+			v.validateType(e, fmt.Sprintf("%s elem[%d]", where, i))
+		}
+	case *FnType:
+		for i, p := range t.Params {
+			if p == nil {
+				v.addf("%s: FnType param[%d] nil", where, i)
+				continue
+			}
+			v.validateType(p, fmt.Sprintf("%s param[%d]", where, i))
+		}
+		if t.Return != nil {
+			v.validateType(t.Return, where+" return")
+		}
+	case *TypeVar:
+		if t.Name == "" {
+			v.addf("%s: TypeVar empty Name", where)
+		}
+	case *ErrType:
+		// allowed
+	default:
+		v.addf("%s: unknown Type %T", where, t)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand IR lowering so statement-position `if` and `match` become `IfStmt` and `MatchStmt`
- classify top-level `let` references as `IdentGlobal` and lower prelude `Some`/`None`/`Ok`/`Err` calls as `VariantLit`
- strengthen IR validation for generic/type shapes, type args, closure metadata, and invalid decision trees
- add regression tests for lowering and validation coverage

## Testing
- `go test ./internal/ir/... ./internal/backend`
- `go test ./cmd/osty -run TestRunTestMainPassesNativeLLVMTest`

## Notes
- `go test ./cmd/osty` still has existing native LLVM unsupported failures in `TestRunTestMainPassesNativeLLVMResultTests` and `TestRunTestMainPassesNativeLLVMTupleTableTests`.
