### PR TITLE
feat: add L0008 dead_store rule to self-hosted linter

### DIFF
--- a/examples/selfhost-core/lint.osty
+++ b/examples/selfhost-core/lint.osty
@@ -675,6 +675,7 @@ fn selfLintAstCheckFunction(
     if node.right >= 0 {
         out = selfLintAstCheckFunctionScopes(file, node, out)
         out = selfLintAstCheckBlockUsage(file, node.right, resolved, out)
+        out = selfLintAstCheckDeadStore(file, node.right, resolved, out)
         out = selfLintAstCheckDeadCode(file, node.right, out)
         out = selfLintAstCheckFlow(file, node.right, out)
         out = selfLintAstCheckSimplifyNode(file, node.right, resolved, out)
@@ -1037,6 +1038,260 @@ fn selfLintAstUnusedMutFix(file: AstFile, stmt: AstNode, item: SelfLintName) -> 
         return selfLintFix(stmt.start + 1, item.start + 1, item.name, "remove `mut`")
     }
     selfLintFix(stmt.start + 1, stmt.start + 2, "", "remove `mut`")
+}
+
+/// SelfLintPending tracks one `let mut x = E` whose initial value has not
+/// yet been observed. When the same block reassigns `x` without an
+/// intervening read, the initial store is dead and L0008 fires.
+struct SelfLintPending {
+    name: String,
+    nameStart: Int,
+    nameEnd: Int,
+    nameNode: Int,
+    initStart: Int,
+    initEnd: Int,
+    active: Bool,
+}
+
+fn selfLintAstCheckDeadStore(
+    file: AstFile,
+    idx: Int,
+    resolved: SelfResolveResult,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNBlock {
+        out = selfLintAstCheckBlockDeadStore(file, idx, resolved, out)
+    }
+    out = selfLintAstCheckDeadStore(file, node.left, resolved, out)
+    out = selfLintAstCheckDeadStore(file, node.right, resolved, out)
+    for child in node.children {
+        out = selfLintAstCheckDeadStore(file, child, resolved, out)
+    }
+    for child in node.children2 {
+        out = selfLintAstCheckDeadStore(file, child, resolved, out)
+    }
+    out
+}
+
+fn selfLintAstCheckBlockDeadStore(
+    file: AstFile,
+    blockIdx: Int,
+    resolved: SelfResolveResult,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let block = selfLintAstNode(file, blockIdx)
+    if block.kind != AstNBlock {
+        return report
+    }
+    let mut out = report
+    let mut pending: List<SelfLintPending> = []
+    for stmtIdx in block.children {
+        let stmt = selfLintAstNode(file, stmtIdx)
+        if stmt.kind == AstNLet {
+            if stmt.right >= 0 {
+                pending = selfLintClearPendingByExprReads(file, stmt.right, pending, resolved)
+            }
+            if stmt.flags == 1 {
+                let names = selfLintAstPatternNames(file, stmt.left, [])
+                for item in names {
+                    if !(selfLintIsIntentionalDiscard(item.name)) {
+                        pending.push(SelfLintPending {
+                            name: item.name,
+                            nameStart: item.start,
+                            nameEnd: item.end,
+                            nameNode: item.node,
+                            initStart: stmt.start,
+                            initEnd: stmt.end,
+                            active: true,
+                        })
+                    }
+                }
+            }
+        } else if stmt.kind == AstNAssign && stmt.op == FrontAssign {
+            let targetNode = selfLintAstNode(file, stmt.left)
+            if targetNode.kind == AstNIdent {
+                pending = selfLintClearPendingByExprReads(file, stmt.right, pending, resolved)
+                let result = selfLintEmitDeadStores(out, pending, stmt.left, resolved)
+                out = result.report
+                pending = result.pending
+            } else {
+                pending = selfLintClearPendingByWriteTargetReads(file, stmt.left, pending, resolved)
+                pending = selfLintClearPendingByExprReads(file, stmt.right, pending, resolved)
+            }
+        } else {
+            pending = selfLintClearPendingByStmtReads(file, stmtIdx, pending, resolved)
+        }
+    }
+    out
+}
+
+struct SelfLintDeadStoreResult {
+    report: SelfLintReport,
+    pending: List<SelfLintPending>,
+}
+
+fn selfLintEmitDeadStores(
+    report: SelfLintReport,
+    pending: List<SelfLintPending>,
+    targetIdx: Int,
+    resolved: SelfResolveResult,
+) -> SelfLintDeadStoreResult {
+    let mut out = report
+    let mut next: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfResolveRefNodeTargets(
+            resolved,
+            targetIdx,
+            entry.name,
+            entry.nameStart,
+            entry.nameEnd,
+            entry.nameNode,
+        ) {
+            out = selfLintEmitAtNode(
+                out,
+                "L0008",
+                "value of `{entry.name}` is overwritten before being read",
+                entry.name,
+                entry.initStart,
+                entry.initEnd,
+                entry.nameNode,
+            )
+            copy.active = false
+        }
+        next.push(copy)
+    }
+    SelfLintDeadStoreResult { report: out, pending: next }
+}
+
+fn selfLintClearPendingByStmtReads(
+    file: AstFile,
+    stmtIdx: Int,
+    pending: List<SelfLintPending>,
+    resolved: SelfResolveResult,
+) -> List<SelfLintPending> {
+    let mut out: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfLintAstReadsBindingInExpr(file, stmtIdx, entry, resolved) {
+            copy.active = false
+        }
+        out.push(copy)
+    }
+    out
+}
+
+fn selfLintClearPendingByExprReads(
+    file: AstFile,
+    idx: Int,
+    pending: List<SelfLintPending>,
+    resolved: SelfResolveResult,
+) -> List<SelfLintPending> {
+    let mut out: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfLintAstReadsBindingInExpr(file, idx, entry, resolved) {
+            copy.active = false
+        }
+        out.push(copy)
+    }
+    out
+}
+
+fn selfLintClearPendingByWriteTargetReads(
+    file: AstFile,
+    idx: Int,
+    pending: List<SelfLintPending>,
+    resolved: SelfResolveResult,
+) -> List<SelfLintPending> {
+    let mut out: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfLintAstReadsBindingInWriteTarget(file, idx, entry, resolved) {
+            copy.active = false
+        }
+        out.push(copy)
+    }
+    out
+}
+
+/// selfLintAstReadsBindingInExpr returns true when any identifier inside
+/// `idx` resolves to `entry`'s binding. Treats the LHS of nested
+/// AstNAssign nodes as a write target so plain `x = E` is not counted as
+/// a read of `x`, while `x.field = E` and `x[i] = E` still are.
+fn selfLintAstReadsBindingInExpr(
+    file: AstFile,
+    idx: Int,
+    entry: SelfLintPending,
+    resolved: SelfResolveResult,
+) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNIdent {
+        return selfResolveRefNodeTargets(
+            resolved,
+            idx,
+            entry.name,
+            entry.nameStart,
+            entry.nameEnd,
+            entry.nameNode,
+        )
+    }
+    if node.kind == AstNAssign {
+        if selfLintAstReadsBindingInWriteTarget(file, node.left, entry, resolved) {
+            return true
+        }
+        return selfLintAstReadsBindingInExpr(file, node.right, entry, resolved)
+    }
+    if node.kind == AstNLet {
+        return selfLintAstReadsBindingInExpr(file, node.right, entry, resolved)
+    }
+    if selfLintAstReadsBindingInExpr(file, node.left, entry, resolved) {
+        return true
+    }
+    if selfLintAstReadsBindingInExpr(file, node.right, entry, resolved) {
+        return true
+    }
+    for child in node.children {
+        if selfLintAstReadsBindingInExpr(file, child, entry, resolved) {
+            return true
+        }
+    }
+    for child in node.children2 {
+        if selfLintAstReadsBindingInExpr(file, child, entry, resolved) {
+            return true
+        }
+    }
+    false
+}
+
+/// selfLintAstReadsBindingInWriteTarget treats `x` in `x = E` as a write,
+/// not a read. But `x.field = E` and `x[i] = E` do read `x` to access the
+/// field/element, so we descend into those carriers as ordinary reads.
+fn selfLintAstReadsBindingInWriteTarget(
+    file: AstFile,
+    idx: Int,
+    entry: SelfLintPending,
+    resolved: SelfResolveResult,
+) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNIdent {
+        return false
+    }
+    if node.kind == AstNParen {
+        return selfLintAstReadsBindingInWriteTarget(file, node.left, entry, resolved)
+    }
+    selfLintAstReadsBindingInExpr(file, idx, entry, resolved)
 }
 
 fn selfLintAstCheckUsageInNode(

--- a/examples/selfhost-core/lint_test.osty
+++ b/examples/selfhost-core/lint_test.osty
@@ -420,6 +420,87 @@ fn testSelfLintReportsParseRecoveryErrors() {
     testing.assert(report.parseErrors > 0)
 }
 
+fn testSelfLintFindsDeadStore() {
+    let report = selfLintSource(
+        r"""
+            fn work() -> Int {
+                let mut x = 1
+                x = 2
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 1)
+}
+
+fn testSelfLintIgnoresDeadStoreWhenRhsReadsBinding() {
+    let report = selfLintSource(
+        r"""
+            fn work() -> Int {
+                let mut x = 1
+                x = x + 1
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
+fn testSelfLintIgnoresDeadStoreAfterRead() {
+    let report = selfLintSource(
+        r"""
+            fn work() -> Int {
+                let mut x = 1
+                println(x)
+                x = 2
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
+fn testSelfLintIgnoresDeadStoreOnFieldWrite() {
+    let report = selfLintSource(
+        r"""
+            struct Counter { value: Int }
+
+            fn bump(c: Counter) -> Int {
+                let mut x = c
+                x.value = 2
+                x.value
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
+fn testSelfLintFindsDeadStoreAcrossNestedBlockReads() {
+    let report = selfLintSource(
+        r"""
+            fn work(flag: Bool) -> Int {
+                let mut x = 1
+                if flag {
+                    println(x)
+                }
+                x = 2
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
 fn assertLintFirstFix(
     report: SelfLintReport,
     code: String,

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -669,6 +669,7 @@ fn selfLintAstCheckFunction(
     if node.right >= 0 {
         out = selfLintAstCheckFunctionScopes(file, node, out)
         out = selfLintAstCheckBlockUsage(file, node.right, resolved, out)
+        out = selfLintAstCheckDeadStore(file, node.right, resolved, out)
         out = selfLintAstCheckDeadCode(file, node.right, out)
         out = selfLintAstCheckFlow(file, node.right, out)
         out = selfLintAstCheckSimplifyNode(file, node.right, resolved, out)
@@ -1031,6 +1032,260 @@ fn selfLintAstUnusedMutFix(file: AstFile, stmt: AstNode, item: SelfLintName) -> 
         return selfLintFix(stmt.start + 1, item.start + 1, item.name, "remove `mut`")
     }
     selfLintFix(stmt.start + 1, stmt.start + 2, "", "remove `mut`")
+}
+
+/// SelfLintPending tracks one `let mut x = E` whose initial value has not
+/// yet been observed. When the same block reassigns `x` without an
+/// intervening read, the initial store is dead and L0008 fires.
+struct SelfLintPending {
+    name: String,
+    nameStart: Int,
+    nameEnd: Int,
+    nameNode: Int,
+    initStart: Int,
+    initEnd: Int,
+    active: Bool,
+}
+
+fn selfLintAstCheckDeadStore(
+    file: AstFile,
+    idx: Int,
+    resolved: SelfResolveResult,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNBlock {
+        out = selfLintAstCheckBlockDeadStore(file, idx, resolved, out)
+    }
+    out = selfLintAstCheckDeadStore(file, node.left, resolved, out)
+    out = selfLintAstCheckDeadStore(file, node.right, resolved, out)
+    for child in node.children {
+        out = selfLintAstCheckDeadStore(file, child, resolved, out)
+    }
+    for child in node.children2 {
+        out = selfLintAstCheckDeadStore(file, child, resolved, out)
+    }
+    out
+}
+
+fn selfLintAstCheckBlockDeadStore(
+    file: AstFile,
+    blockIdx: Int,
+    resolved: SelfResolveResult,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let block = selfLintAstNode(file, blockIdx)
+    if block.kind != AstNBlock {
+        return report
+    }
+    let mut out = report
+    let mut pending: List<SelfLintPending> = []
+    for stmtIdx in block.children {
+        let stmt = selfLintAstNode(file, stmtIdx)
+        if stmt.kind == AstNLet {
+            if stmt.right >= 0 {
+                pending = selfLintClearPendingByExprReads(file, stmt.right, pending, resolved)
+            }
+            if stmt.flags == 1 {
+                let names = selfLintAstPatternNames(file, stmt.left, [])
+                for item in names {
+                    if !(selfLintIsIntentionalDiscard(item.name)) {
+                        pending.push(SelfLintPending {
+                            name: item.name,
+                            nameStart: item.start,
+                            nameEnd: item.end,
+                            nameNode: item.node,
+                            initStart: stmt.start,
+                            initEnd: stmt.end,
+                            active: true,
+                        })
+                    }
+                }
+            }
+        } else if stmt.kind == AstNAssign && stmt.op == FrontAssign {
+            let targetNode = selfLintAstNode(file, stmt.left)
+            if targetNode.kind == AstNIdent {
+                pending = selfLintClearPendingByExprReads(file, stmt.right, pending, resolved)
+                let result = selfLintEmitDeadStores(out, pending, stmt.left, resolved)
+                out = result.report
+                pending = result.pending
+            } else {
+                pending = selfLintClearPendingByWriteTargetReads(file, stmt.left, pending, resolved)
+                pending = selfLintClearPendingByExprReads(file, stmt.right, pending, resolved)
+            }
+        } else {
+            pending = selfLintClearPendingByStmtReads(file, stmtIdx, pending, resolved)
+        }
+    }
+    out
+}
+
+struct SelfLintDeadStoreResult {
+    report: SelfLintReport,
+    pending: List<SelfLintPending>,
+}
+
+fn selfLintEmitDeadStores(
+    report: SelfLintReport,
+    pending: List<SelfLintPending>,
+    targetIdx: Int,
+    resolved: SelfResolveResult,
+) -> SelfLintDeadStoreResult {
+    let mut out = report
+    let mut next: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfResolveRefNodeTargets(
+            resolved,
+            targetIdx,
+            entry.name,
+            entry.nameStart,
+            entry.nameEnd,
+            entry.nameNode,
+        ) {
+            out = selfLintEmitAtNode(
+                out,
+                "L0008",
+                "value of `{entry.name}` is overwritten before being read",
+                entry.name,
+                entry.initStart,
+                entry.initEnd,
+                entry.nameNode,
+            )
+            copy.active = false
+        }
+        next.push(copy)
+    }
+    SelfLintDeadStoreResult { report: out, pending: next }
+}
+
+fn selfLintClearPendingByStmtReads(
+    file: AstFile,
+    stmtIdx: Int,
+    pending: List<SelfLintPending>,
+    resolved: SelfResolveResult,
+) -> List<SelfLintPending> {
+    let mut out: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfLintAstReadsBindingInExpr(file, stmtIdx, entry, resolved) {
+            copy.active = false
+        }
+        out.push(copy)
+    }
+    out
+}
+
+fn selfLintClearPendingByExprReads(
+    file: AstFile,
+    idx: Int,
+    pending: List<SelfLintPending>,
+    resolved: SelfResolveResult,
+) -> List<SelfLintPending> {
+    let mut out: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfLintAstReadsBindingInExpr(file, idx, entry, resolved) {
+            copy.active = false
+        }
+        out.push(copy)
+    }
+    out
+}
+
+fn selfLintClearPendingByWriteTargetReads(
+    file: AstFile,
+    idx: Int,
+    pending: List<SelfLintPending>,
+    resolved: SelfResolveResult,
+) -> List<SelfLintPending> {
+    let mut out: List<SelfLintPending> = []
+    for entry in pending {
+        let mut copy = entry
+        if entry.active && selfLintAstReadsBindingInWriteTarget(file, idx, entry, resolved) {
+            copy.active = false
+        }
+        out.push(copy)
+    }
+    out
+}
+
+/// selfLintAstReadsBindingInExpr returns true when any identifier inside
+/// `idx` resolves to `entry`'s binding. Treats the LHS of nested
+/// AstNAssign nodes as a write target so plain `x = E` is not counted as
+/// a read of `x`, while `x.field = E` and `x[i] = E` still are.
+fn selfLintAstReadsBindingInExpr(
+    file: AstFile,
+    idx: Int,
+    entry: SelfLintPending,
+    resolved: SelfResolveResult,
+) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNIdent {
+        return selfResolveRefNodeTargets(
+            resolved,
+            idx,
+            entry.name,
+            entry.nameStart,
+            entry.nameEnd,
+            entry.nameNode,
+        )
+    }
+    if node.kind == AstNAssign {
+        if selfLintAstReadsBindingInWriteTarget(file, node.left, entry, resolved) {
+            return true
+        }
+        return selfLintAstReadsBindingInExpr(file, node.right, entry, resolved)
+    }
+    if node.kind == AstNLet {
+        return selfLintAstReadsBindingInExpr(file, node.right, entry, resolved)
+    }
+    if selfLintAstReadsBindingInExpr(file, node.left, entry, resolved) {
+        return true
+    }
+    if selfLintAstReadsBindingInExpr(file, node.right, entry, resolved) {
+        return true
+    }
+    for child in node.children {
+        if selfLintAstReadsBindingInExpr(file, child, entry, resolved) {
+            return true
+        }
+    }
+    for child in node.children2 {
+        if selfLintAstReadsBindingInExpr(file, child, entry, resolved) {
+            return true
+        }
+    }
+    false
+}
+
+/// selfLintAstReadsBindingInWriteTarget treats `x` in `x = E` as a write,
+/// not a read. But `x.field = E` and `x[i] = E` do read `x` to access the
+/// field/element, so we descend into those carriers as ordinary reads.
+fn selfLintAstReadsBindingInWriteTarget(
+    file: AstFile,
+    idx: Int,
+    entry: SelfLintPending,
+    resolved: SelfResolveResult,
+) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNIdent {
+        return false
+    }
+    if node.kind == AstNParen {
+        return selfLintAstReadsBindingInWriteTarget(file, node.left, entry, resolved)
+    }
+    selfLintAstReadsBindingInExpr(file, idx, entry, resolved)
 }
 
 fn selfLintAstCheckUsageInNode(

--- a/toolchain/lint_test.osty
+++ b/toolchain/lint_test.osty
@@ -420,6 +420,87 @@ fn testSelfLintReportsParseRecoveryErrors() {
     testing.assert(report.parseErrors > 0)
 }
 
+fn testSelfLintFindsDeadStore() {
+    let report = selfLintSource(
+        r"""
+            fn work() -> Int {
+                let mut x = 1
+                x = 2
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 1)
+}
+
+fn testSelfLintIgnoresDeadStoreWhenRhsReadsBinding() {
+    let report = selfLintSource(
+        r"""
+            fn work() -> Int {
+                let mut x = 1
+                x = x + 1
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
+fn testSelfLintIgnoresDeadStoreAfterRead() {
+    let report = selfLintSource(
+        r"""
+            fn work() -> Int {
+                let mut x = 1
+                println(x)
+                x = 2
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
+fn testSelfLintIgnoresDeadStoreOnFieldWrite() {
+    let report = selfLintSource(
+        r"""
+            struct Counter { value: Int }
+
+            fn bump(c: Counter) -> Int {
+                let mut x = c
+                x.value = 2
+                x.value
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
+fn testSelfLintFindsDeadStoreAcrossNestedBlockReads() {
+    let report = selfLintSource(
+        r"""
+            fn work(flag: Bool) -> Int {
+                let mut x = 1
+                if flag {
+                    println(x)
+                }
+                x = 2
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
+}
+
 fn assertLintFirstFix(
     report: SelfLintReport,
     code: String,


### PR DESCRIPTION
## Summary

Closes a gap between the Go-based linter and the self-hosted linter by porting the **L0008 `dead_store`** rule into `toolchain/lint.osty` (and the synced `examples/selfhost-core/lint.osty`). Detects the pattern `let mut x = E1; x = E2` where `E1` is overwritten without ever being read.

## What changed

- **New AST pass** `selfLintAstCheckDeadStore` wired into `selfLintAstCheckFunction` after the existing block-usage check.
- **Block-local analysis** (`selfLintAstCheckBlockDeadStore`) maintains a `pending` list of unread `let mut` initializers, walks each subsequent statement to clear pending entries that are read, and emits `L0008` when a single bare-ident `=` overwrites an entry whose RHS doesn't reference the same binding.
- **Read tracker** (`selfLintAstReadsBindingInExpr` / `...InWriteTarget`) recurses into nested blocks (`if`, `match`, `for`, closures) so a read inside any nested expression keeps the outer `mut` alive.

## Why

`L0008` was the highest-value gap in the Osty-side linter — it catches real bugs (forgotten reads, accidental overwrites of expensive computations) and reuses resolver machinery that's already in place. Bringing it self-host removes another reason the Go linter still has to be the source of truth.

## Notes for reviewers

- **Improvement over the Go implementation**: only bare-ident targets count as overwrites. `x.field = E` and `x[i] = E` are treated as reads of `x` (since they access the carrier), avoiding the false positive currently emitted at `toolchain/lint.osty:161` (`let mut report = ...; report.resolveErrors = ...`).
- **Conservative read tracking**: closure bodies are walked as reads, matching the standard linter convention.
- **Both source copies kept in sync**: `toolchain/lint.osty` (canonical, `use std.strings`) and `examples/selfhost-core/lint.osty` (Go-bridge form) carry identical logic.
- **Tests**: 5 focused cases in `*_test.osty` covering basic dead-store, RHS-self-read, post-read assign, field write, and nested-block reads.
- The `internal/selfhost/generated.go` regen path is broken on `main` due to pre-existing `while` keyword usage in `examples/selfhost-core/resolve.osty:1680`. Out of scope for this change; surfaces only when `go generate ./internal/selfhost` runs.

## Test plan

- [x] `go test -count=1 ./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline` — all green
- [x] `go test -count=1 -short ./internal/selfhost/` — green
- [x] `./osty parse toolchain/lint.osty` — clean parse, no syntax regressions
- [ ] Self-host lint test cases (`testSelfLintFindsDeadStore` etc.) — exercised end-to-end once the generated bridge can be regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)