### PR TITLE
feat: track builtin Result constructor context

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -691,7 +691,6 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
-
 func TestLLVMBackendBinaryGenericEnumVariantFromLetContext(t *testing.T) {
 	if _, err := exec.LookPath("clang"); err != nil {
 		t.Skip("clang not found on PATH")

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -809,3 +809,44 @@ func TestLLVMBackendBinaryBuiltinResultFieldConstructors(t *testing.T) {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryBuiltinResultConstructorsTrackLocalContext(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `struct Holder {
+    ok: Result<Int, String>
+    flag: Result<Bool, String>
+}
+
+fn wrap(value: Int) -> Result<Int, String> {
+    return Result.Ok(value)
+}
+
+fn consume(value: Result<Bool, String>) -> Int {
+    1
+}
+
+fn main() {
+    let ok: Result<Int, String> = Result.Ok(42)
+    let flag: Result<Bool, String> = Result.Ok(true)
+    let holder = Holder { ok: Result.Err("bad"), flag: Result.Ok(true) }
+    let wrapped = wrap(7)
+    println(consume(Result.Ok(true)))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -177,6 +177,26 @@ type builtinResultType struct {
 	errTyp string
 }
 
+func builtinResultTypeFromAST(t ast.Type, env typeEnv) (builtinResultType, bool) {
+	named, ok := t.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "Result" || len(named.Args) != 2 {
+		return builtinResultType{}, false
+	}
+	okTyp, err := llvmType(named.Args[0], env)
+	if err != nil {
+		return builtinResultType{}, false
+	}
+	errTyp, err := llvmType(named.Args[1], env)
+	if err != nil {
+		return builtinResultType{}, false
+	}
+	return builtinResultType{
+		typ:    llvmResultTypeName(okTyp, errTyp),
+		okTyp:  okTyp,
+		errTyp: errTyp,
+	}, true
+}
+
 func collectDeclarations(file *ast.File) (*declarations, error) {
 	out := &declarations{
 		functionsByName:   map[string]*fnSig{},
@@ -612,19 +632,8 @@ func collectBuiltinResultTypeFromAST(out map[string]builtinResultType, t ast.Typ
 	}
 	switch tt := t.(type) {
 	case *ast.NamedType:
-		if len(tt.Path) == 1 && tt.Path[0] == "Result" && len(tt.Args) == 2 {
-			okTyp, err := llvmType(tt.Args[0], env)
-			if err == nil {
-				errTyp, err2 := llvmType(tt.Args[1], env)
-				if err2 == nil {
-					info := builtinResultType{
-						typ:    llvmResultTypeName(okTyp, errTyp),
-						okTyp:  okTyp,
-						errTyp: errTyp,
-					}
-					out[info.typ] = info
-				}
-			}
+		if info, ok := builtinResultTypeFromAST(tt, env); ok {
+			out[info.typ] = info
 		}
 		for _, arg := range tt.Args {
 			collectBuiltinResultTypeFromAST(out, arg, env)
@@ -946,6 +955,7 @@ func (g *generator) emitMainFunction(sig *fnSig) (string, error) {
 func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 	g.beginFunction()
 	g.returnType = sig.ret
+	g.returnSourceType = sig.returnSourceType
 	g.returnListElemTyp = sig.retListElemTyp
 	for _, p := range sig.params {
 		v := value{
@@ -981,7 +991,7 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 			g.takeOstyEmitter(emitter)
 		}
 	} else {
-		if err := g.emitReturningBlock(sig.decl.Body.Stmts, sig.ret, sig.retListElemTyp, sig.retMapKeyTyp, sig.retMapValueTyp, sig.retSetElemTyp); err != nil {
+		if err := g.emitReturningBlock(sig.decl.Body.Stmts, sig.ret, sig.returnSourceType, sig.retListElemTyp, sig.retMapKeyTyp, sig.retMapValueTyp, sig.retSetElemTyp); err != nil {
 			return "", err
 		}
 	}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -314,7 +314,7 @@ func (g *generator) emitStructLit(lit *ast.StructLit) (value, error) {
 		if litField.Value == nil {
 			v, err = g.emitIdent(litField.Name)
 		} else {
-			v, err = g.emitExprWithHint(litField.Value, field.listElemTyp, field.listElemString, field.mapKeyTyp, field.mapValueTyp, field.mapKeyString, field.setElemTyp, field.setElemString)
+			v, err = g.emitExprWithHintAndSourceType(litField.Value, field.sourceType, field.listElemTyp, field.listElemString, field.mapKeyTyp, field.mapValueTyp, field.mapKeyString, field.setElemTyp, field.setElemString)
 		}
 		if err != nil {
 			return value{}, err
@@ -1265,6 +1265,66 @@ func (g *generator) emitExprWithHint(expr ast.Expr, listElemTyp string, listElem
 	return g.emitExpr(expr)
 }
 
+func builtinResultPayloadSourceType(sourceType ast.Type, constructor string) ast.Type {
+	named, ok := sourceType.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "Result" || len(named.Args) != 2 {
+		return nil
+	}
+	if constructor == "Err" {
+		return named.Args[1]
+	}
+	return named.Args[0]
+}
+
+func (g *generator) emitExprWithHintAndSourceType(expr ast.Expr, sourceType ast.Type, listElemTyp string, listElemString bool, mapKeyTyp string, mapValueTyp string, mapKeyString bool, setElemTyp string, setElemString bool) (value, error) {
+	if sourceType != nil {
+		if listElemTyp == "" {
+			if elemTyp, elemString, ok, err := llvmListElementInfo(sourceType, g.typeEnv()); err != nil {
+				return value{}, err
+			} else if ok {
+				listElemTyp = elemTyp
+				listElemString = elemString
+			}
+		}
+		if mapKeyTyp == "" && mapValueTyp == "" {
+			if keyTyp, valueTyp, keyString, ok, err := llvmMapTypes(sourceType, g.typeEnv()); err != nil {
+				return value{}, err
+			} else if ok {
+				mapKeyTyp = keyTyp
+				mapValueTyp = valueTyp
+				mapKeyString = keyString
+			}
+		}
+		if setElemTyp == "" {
+			if elemTyp, elemString, ok, err := llvmSetElementType(sourceType, g.typeEnv()); err != nil {
+				return value{}, err
+			} else if ok {
+				setElemTyp = elemTyp
+				setElemString = elemString
+			}
+		}
+	}
+	if info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv()); ok {
+		g.resultContexts = append(g.resultContexts, builtinResultContext{
+			info:       info,
+			sourceType: sourceType,
+		})
+		defer func() {
+			g.resultContexts = g.resultContexts[:len(g.resultContexts)-1]
+		}()
+	}
+	v, err := g.emitExprWithHint(expr, listElemTyp, listElemString, mapKeyTyp, mapValueTyp, mapKeyString, setElemTyp, setElemString)
+	if err != nil {
+		return value{}, err
+	}
+	if v.sourceType == nil && sourceType != nil {
+		if typ, err := llvmType(sourceType, g.typeEnv()); err == nil && typ == v.typ {
+			v.sourceType = sourceType
+		}
+	}
+	return v, nil
+}
+
 func (g *generator) usesAggregateListABI(elemTyp string) bool {
 	switch elemTyp {
 	case "", "i64", "i1", "double", "ptr":
@@ -2061,7 +2121,7 @@ func (g *generator) emitBuiltinResultConstructor(call *ast.CallExpr) (value, boo
 	if !ok {
 		return value{}, false, nil
 	}
-	info, ok := g.currentBuiltinResultType()
+	ctx, ok := g.currentBuiltinResultContext()
 	if !ok {
 		return value{}, true, unsupportedf("call", "%s requires a concrete Result<T, E> context", name)
 	}
@@ -2069,14 +2129,14 @@ func (g *generator) emitBuiltinResultConstructor(call *ast.CallExpr) (value, boo
 		return value{}, true, unsupportedf("call", "%s requires one positional argument", name)
 	}
 	payloadIndex := 1
-	payloadType := info.okTyp
+	payloadType := ctx.info.okTyp
 	tag := "0"
 	if name == "Err" {
 		payloadIndex = 2
-		payloadType = info.errTyp
+		payloadType = ctx.info.errTyp
 		tag = "1"
 	}
-	payload, err := g.emitExpr(call.Args[0].Value)
+	payload, err := g.emitExprWithHintAndSourceType(call.Args[0].Value, builtinResultPayloadSourceType(ctx.sourceType, name), "", false, "", "", false, "", false)
 	if err != nil {
 		return value{}, true, err
 	}
@@ -2086,27 +2146,31 @@ func (g *generator) emitBuiltinResultConstructor(call *ast.CallExpr) (value, boo
 	emitter := g.toOstyEmitter()
 	fields := []*LlvmValue{
 		toOstyValue(value{typ: "i64", ref: tag}),
-		toOstyValue(llvmZeroValue(info.okTyp)),
-		toOstyValue(llvmZeroValue(info.errTyp)),
+		toOstyValue(llvmZeroValue(ctx.info.okTyp)),
+		toOstyValue(llvmZeroValue(ctx.info.errTyp)),
 	}
 	fields[payloadIndex] = toOstyValue(payload)
-	out := llvmStructLiteral(emitter, info.typ, fields)
+	out := llvmStructLiteral(emitter, ctx.info.typ, fields)
 	g.takeOstyEmitter(emitter)
 	result := fromOstyValue(out)
+	result.sourceType = ctx.sourceType
 	result.rootPaths = g.rootPathsForType(result.typ)
 	return result, true, nil
 }
 
-func (g *generator) currentBuiltinResultType() (builtinResultType, bool) {
+func (g *generator) currentBuiltinResultContext() (builtinResultContext, bool) {
+	if n := len(g.resultContexts); n != 0 {
+		return g.resultContexts[n-1], true
+	}
 	if info, ok := g.resultTypes[g.returnType]; ok {
-		return info, true
+		return builtinResultContext{info: info, sourceType: g.returnSourceType}, true
 	}
 	if len(g.resultTypes) == 1 {
 		for _, info := range g.resultTypes {
-			return info, true
+			return builtinResultContext{info: info}, true
 		}
 	}
-	return builtinResultType{}, false
+	return builtinResultContext{}, false
 }
 
 func (g *generator) optionalUserCallTarget(call *ast.CallExpr) (*fnSig, ast.Type, bool, error) {
@@ -2192,7 +2256,7 @@ func (g *generator) optionalUserCallArgs(sig *fnSig, innerSource ast.Type, base 
 			return nil, unsupportedf("call", "function %q requires positional arguments", sig.name)
 		}
 		param := sig.params[i+1]
-		v, err := g.emitExprWithHint(arg.Value, param.listElemTyp, param.listElemString, param.mapKeyTyp, param.mapValueTyp, param.mapKeyString, param.setElemTyp, param.setElemString)
+		v, err := g.emitExprWithHintAndSourceType(arg.Value, param.sourceType, param.listElemTyp, param.listElemString, param.mapKeyTyp, param.mapValueTyp, param.mapKeyString, param.setElemTyp, param.setElemString)
 		if err != nil {
 			return nil, err
 		}
@@ -2297,7 +2361,7 @@ func (g *generator) userCallArgs(sig *fnSig, receiverExpr ast.Expr, call *ast.Ca
 			return nil, unsupportedf("call", "function %q requires positional arguments", sig.name)
 		}
 		param := sig.params[paramIndex+i]
-		v, err := g.emitExprWithHint(arg.Value, param.listElemTyp, param.listElemString, param.mapKeyTyp, param.mapValueTyp, param.mapKeyString, param.setElemTyp, param.setElemString)
+		v, err := g.emitExprWithHintAndSourceType(arg.Value, param.sourceType, param.listElemTyp, param.listElemString, param.mapKeyTyp, param.mapValueTyp, param.mapKeyString, param.setElemTyp, param.setElemString)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -49,9 +49,11 @@ type generator struct {
 	body              []string
 	locals            []map[string]value
 	returnType        string
+	returnSourceType  ast.Type
 	returnListElemTyp string
 	currentBlock      string
 	currentReachable  bool
+	resultContexts    []builtinResultContext
 
 	needsGCRuntime bool
 	gcRootSlots    []value
@@ -90,6 +92,11 @@ type value struct {
 	rootPaths      [][]int
 }
 
+type builtinResultContext struct {
+	info       builtinResultType
+	sourceType ast.Type
+}
+
 const (
 	llvmGcRuntimeFrameSlotKind = 5
 )
@@ -100,6 +107,7 @@ func (g *generator) beginFunction() {
 	g.body = nil
 	g.locals = []map[string]value{{}}
 	g.returnType = ""
+	g.returnSourceType = nil
 	g.returnListElemTyp = ""
 	g.gcRootSlots = nil
 	g.gcRootMarks = []int{0}
@@ -108,6 +116,7 @@ func (g *generator) beginFunction() {
 	g.currentBlock = "entry"
 	g.currentReachable = true
 	g.loopStack = nil
+	g.resultContexts = nil
 }
 
 func (g *generator) bindGCRootIfManagedPointer(emitter *LlvmEmitter, slot value) {

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -332,3 +332,37 @@ func TestGenerateModuleBuiltinResultFieldConstructors(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateModuleBuiltinResultConstructorsTrackLocalContext(t *testing.T) {
+	src := `struct Holder {
+    ok: Result<Int, String>
+    flag: Result<Bool, String>
+}
+
+fn wrap(value: Int) -> Result<Int, String> {
+    return Result.Ok(value)
+}
+
+fn consume(value: Result<Bool, String>) -> Int {
+    1
+}
+
+fn main() {
+    let ok: Result<Int, String> = Result.Ok(42)
+    let flag: Result<Bool, String> = Result.Ok(true)
+    let holder = Holder { ok: Result.Err("bad"), flag: Result.Ok(true) }
+    let wrapped = wrap(7)
+    println(consume(Result.Ok(true)))
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_result_context_ir.osty")
+	for _, want := range []string{
+		"%Result.i64.ptr",
+		"%Result.i1.ptr",
+		"@consume",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -243,7 +243,7 @@ func (g *generator) runtimeFFICallArgs(fn *runtimeFFIFunction, callArgs []*ast.A
 			return nil, unsupportedf("call", "runtime FFI %s.%s requires positional arguments", fn.path, fn.sourceName)
 		}
 		param := fn.params[i]
-		v, err := g.emitExprWithHint(arg.Value, param.listElemTyp, false, "", "", false, "", false)
+		v, err := g.emitExprWithHintAndSourceType(arg.Value, param.sourceType, param.listElemTyp, false, "", "", false, "", false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -19,7 +19,7 @@ import (
 	"github.com/osty/osty/internal/token"
 )
 
-func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp string, retMapKeyTyp string, retMapValueTyp string, retSetElemTyp string) error {
+func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType string, retSourceType ast.Type, retListElemTyp string, retMapKeyTyp string, retMapValueTyp string, retSetElemTyp string) error {
 	if len(stmts) == 0 {
 		return unsupported("function-signature", "function body has no return value")
 	}
@@ -38,7 +38,7 @@ func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp
 			if s.Value == nil {
 				return unsupported("function-signature", "bare return in value-returning function")
 			}
-			v, err := g.emitExprWithHint(s.Value, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
+			v, err := g.emitExprWithHintAndSourceType(s.Value, retSourceType, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
 			if err != nil {
 				return err
 			}
@@ -52,7 +52,7 @@ func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType, retListElemTyp
 			g.leaveBlock()
 			return nil
 		case *ast.ExprStmt:
-			v, err := g.emitExprWithHint(s.X, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
+			v, err := g.emitExprWithHintAndSourceType(s.X, retSourceType, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,7 @@ func (g *generator) emitLet(stmt *ast.LetStmt) error {
 			hintedSetElemString = setElemString
 		}
 	}
-	v, err := g.emitExprWithHint(stmt.Value, hintedListElemTyp, hintedListElemString, hintedMapKeyTyp, hintedMapValueTyp, hintedMapKeyString, hintedSetElemTyp, hintedSetElemString)
+	v, err := g.emitExprWithHintAndSourceType(stmt.Value, stmt.Type, hintedListElemTyp, hintedListElemString, hintedMapKeyTyp, hintedMapValueTyp, hintedMapKeyString, hintedSetElemTyp, hintedSetElemString)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
 		if !slot.mutable {
 			return unsupportedf("statement", "assignment to immutable identifier %q", target.Name)
 		}
-		v, err := g.emitExprWithHint(stmt.Value, slot.listElemTyp, slot.listElemString, slot.mapKeyTyp, slot.mapValueTyp, slot.mapKeyString, slot.setElemTyp, slot.setElemString)
+		v, err := g.emitExprWithHintAndSourceType(stmt.Value, slot.sourceType, slot.listElemTyp, slot.listElemString, slot.mapKeyTyp, slot.mapValueTyp, slot.mapKeyString, slot.setElemTyp, slot.setElemString)
 		if err != nil {
 			return err
 		}
@@ -229,7 +229,7 @@ func (g *generator) emitFieldAssign(target *ast.FieldExpr, rhs ast.Expr) error {
 	if !ok {
 		return unsupportedf("expression", "struct %q has no field %q", info.name, target.Name)
 	}
-	v, err := g.emitExprWithHint(rhs, field.listElemTyp, field.listElemString, field.mapKeyTyp, field.mapValueTyp, field.mapKeyString, field.setElemTyp, field.setElemString)
+	v, err := g.emitExprWithHintAndSourceType(rhs, field.sourceType, field.listElemTyp, field.listElemString, field.mapKeyTyp, field.mapValueTyp, field.mapKeyString, field.setElemTyp, field.setElemString)
 	if err != nil {
 		return err
 	}
@@ -542,7 +542,7 @@ func (g *generator) emitReturn(stmt *ast.ReturnStmt) error {
 	case g.returnType == "" || g.returnType == "void":
 		return unsupported("function-signature", "return with value in void-returning function")
 	default:
-		ret, err = g.emitExprWithHint(stmt.Value, g.returnListElemTyp, false, "", "", false, "", false)
+		ret, err = g.emitExprWithHintAndSourceType(stmt.Value, g.returnSourceType, g.returnListElemTyp, false, "", "", false, "", false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- thread concrete `Result<T, E>` source-type context through llvmgen expression lowering instead of relying on a file-wide singleton fallback
- use that context for builtin `Result.Ok(...)` / `Result.Err(...)` in lets, returns, struct fields, function arguments, and runtime FFI arguments
- add mixed-Result IR/backend coverage so multiple concrete Result shapes in one file keep lowering correctly

## Testing
- `go test ./internal/parser ./internal/ir ./internal/llvmgen ./internal/backend`