### PR TITLE
feat: Generic Monomorphization Phase 5 — generic interface 선언

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -187,8 +187,10 @@ The main v0.4 front-end static guarantee hooks are wired here:
   `rewriteGenericMethodCall` + `emitMethodSpecialization`, appended to
   the owner's Methods list so the existing llvmgen dispatch keeps
   working; original generic method templates are stripped by a final
-  cleanup pass. Generic interface declarations and bare function-pointer
-  turbofish stay out of scope for this phase,
+  cleanup pass. Generic interface declarations (`interface Iterator<T>`)
+  are specialized through the same typeQueue path as struct/enum via
+  `requestInterfaceType` + `emitInterfaceSpecialization`. Bare
+  function-pointer turbofish stays out of scope for this phase,
 - structural interface satisfaction checks composed interfaces,
   `Self`-typed signatures, generic receiver substitution, params, and
   generic bounds,

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -281,10 +281,14 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     worklist 세 개를 인터리브 drain, emit 시점에 receiverEnv ⊕ methodEnv를
     머지. 원본 generic method는 Pass 6이 출력에서 제거한다. smoke:
     `TestGenerateModuleMethodLocalGenericGetMonomorphized`.
-  - 남은 범위: generic interface 선언, bare function-pointer turbofish
-    (`let f = id::<Int>`), payload-free / 비-리터럴 인자를 가진 variant
-    call의 타입 복원(궁극적으로는 checker 쪽 generic variant-constructor
-    inference 보강).
+  - Phase 5(generic interface 선언)도 IR 단계에서 구현되어 있다:
+    struct/enum과 동일한 `_ZTS` 나미널 트랙을 interface에도 확장,
+    `requestInterfaceType` + `emitInterfaceSpecialization`로 type queue에
+    편입. Interface-as-value vtable dispatch 경로는 별도 스코프.
+  - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
+    interface value의 vtable dispatch, payload-free / 비-리터럴 인자를
+    가진 variant call의 타입 복원(궁극적으로는 checker 쪽 generic
+    variant-constructor inference 보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -38,21 +38,22 @@ func Monomorphize(mod *Module) (*Module, []error) {
 		return nil, nil
 	}
 	state := &monoState{
-		pkg:                  mod.Package,
-		out:                  &Module{Package: mod.Package, SpanV: mod.SpanV},
-		genericsByName:       map[string]*FnDecl{},
-		seen:                 map[string]string{},
-		genericStructsByName: map[string]*StructDecl{},
-		genericEnumsByName:   map[string]*EnumDecl{},
-		typeSeen:             map[string]string{},
-		structsByName:        map[string]*StructDecl{},
-		enumsByName:          map[string]*EnumDecl{},
-		structsByMangled:     map[string]*StructDecl{},
-		enumsByMangled:       map[string]*EnumDecl{},
-		originalStructOf:     map[string]*StructDecl{},
-		originalEnumOf:       map[string]*EnumDecl{},
-		receiverEnvOf:        map[string]SubstEnv{},
-		methodSeen:           map[string]string{},
+		pkg:                     mod.Package,
+		out:                     &Module{Package: mod.Package, SpanV: mod.SpanV},
+		genericsByName:          map[string]*FnDecl{},
+		seen:                    map[string]string{},
+		genericStructsByName:    map[string]*StructDecl{},
+		genericEnumsByName:      map[string]*EnumDecl{},
+		genericInterfacesByName: map[string]*InterfaceDecl{},
+		typeSeen:                map[string]string{},
+		structsByName:           map[string]*StructDecl{},
+		enumsByName:             map[string]*EnumDecl{},
+		structsByMangled:        map[string]*StructDecl{},
+		enumsByMangled:          map[string]*EnumDecl{},
+		originalStructOf:        map[string]*StructDecl{},
+		originalEnumOf:          map[string]*EnumDecl{},
+		receiverEnvOf:           map[string]SubstEnv{},
+		methodSeen:              map[string]string{},
 	}
 
 	// Pass 1: index every generic top-level declaration so the scanner
@@ -78,6 +79,10 @@ func Monomorphize(mod *Module) (*Module, []error) {
 			state.enumsByName[x.Name] = x
 			if len(x.Generics) > 0 {
 				state.genericEnumsByName[x.Name] = x
+			}
+		case *InterfaceDecl:
+			if len(x.Generics) > 0 {
+				state.genericInterfacesByName[x.Name] = x
 			}
 		}
 	}
@@ -150,6 +155,8 @@ func isGenericTopLevel(d Decl) bool {
 		return len(x.Generics) > 0
 	case *EnumDecl:
 		return len(x.Generics) > 0
+	case *InterfaceDecl:
+		return len(x.Generics) > 0
 	}
 	return false
 }
@@ -167,17 +174,18 @@ type monoState struct {
 	queue []monoInstance
 	errs  []error
 
-	// Phase 2: generic nominal-type bookkeeping.
+	// Phase 2/5: generic nominal-type bookkeeping.
 	//
-	// genericStructsByName / genericEnumsByName index the original
-	// generic declarations so scanning can recognize a generic
-	// NamedType reference by source name.
-	genericStructsByName map[string]*StructDecl
-	genericEnumsByName   map[string]*EnumDecl
+	// genericStructsByName / genericEnumsByName / genericInterfacesByName
+	// index the original generic declarations so scanning can recognize
+	// a generic NamedType reference by source name.
+	genericStructsByName    map[string]*StructDecl
+	genericEnumsByName      map[string]*EnumDecl
+	genericInterfacesByName map[string]*InterfaceDecl
 	// typeSeen maps a MonomorphTypeDedupeKey to the mangled type-symbol
 	// so duplicate requests short-circuit.
 	typeSeen map[string]string
-	// typeQueue is the worklist of pending struct/enum specializations.
+	// typeQueue is the worklist of pending struct/enum/interface specializations.
 	typeQueue []monoTypeInstance
 
 	// Phase 4: method-specialization bookkeeping.
@@ -234,15 +242,17 @@ type monoInstance struct {
 }
 
 // monoTypeInstance is one pending nominal-type specialization. Exactly
-// one of structDecl / enumDecl is non-nil; the other distinguishes the
-// emitter branch. typeArgs are the concrete types matching the
-// declaration's generics, and mangled is the `_ZTS…` symbol the engine
-// has already assigned and written to typeSeen.
+// one of structDecl / enumDecl / interfaceDecl is non-nil; the
+// populated slot distinguishes the emitter branch. typeArgs are the
+// concrete types matching the declaration's generics, and mangled is
+// the `_ZTS…` symbol the engine has already assigned and written to
+// typeSeen.
 type monoTypeInstance struct {
-	structDecl *StructDecl
-	enumDecl   *EnumDecl
-	typeArgs   []Type
-	mangled    string
+	structDecl    *StructDecl
+	enumDecl      *EnumDecl
+	interfaceDecl *InterfaceDecl
+	typeArgs      []Type
+	mangled       string
 }
 
 // addErr appends a non-fatal issue.
@@ -394,14 +404,78 @@ func (s *monoState) requestEnumType(decl *EnumDecl, typeArgs []Type) string {
 }
 
 // emitTypeSpecialization dispatches one queued nominal-type instance
-// to the appropriate struct/enum emitter.
+// to the appropriate struct/enum/interface emitter.
 func (s *monoState) emitTypeSpecialization(rec monoTypeInstance) {
 	switch {
 	case rec.structDecl != nil:
 		s.emitStructSpecialization(rec)
 	case rec.enumDecl != nil:
 		s.emitEnumSpecialization(rec)
+	case rec.interfaceDecl != nil:
+		s.emitInterfaceSpecialization(rec)
 	}
+}
+
+// requestInterfaceType is the interface counterpart of
+// requestStructType / requestEnumType.
+func (s *monoState) requestInterfaceType(decl *InterfaceDecl, typeArgs []Type) string {
+	if decl == nil {
+		return ""
+	}
+	if !MonomorphShouldInstantiate(len(typeArgs), len(decl.Generics)) {
+		s.addErr("monomorph: arity mismatch for interface %s: %d type args vs %d generics",
+			decl.Name, len(typeArgs), len(decl.Generics))
+		return ""
+	}
+	for i, ta := range typeArgs {
+		if containsTypeVar(ta) {
+			s.addErr("monomorph: type arg %d of interface %s still contains a type variable (%s)",
+				i, decl.Name, typeString(ta))
+			return ""
+		}
+	}
+	typeArgCodes := make([]string, len(typeArgs))
+	for i, ta := range typeArgs {
+		typeArgCodes[i] = typeCodeOf(ta, s.pkg)
+	}
+	key := MonomorphTypeDedupeKey(decl.Name, s.pkg, typeArgCodes)
+	if mangled, ok := s.typeSeen[key]; ok {
+		return mangled
+	}
+	req := NewMonomorphTypeRequest(s.pkg, decl.Name, typeArgCodes)
+	mangled := MonomorphMangleType(req).Symbol()
+	s.typeSeen[key] = mangled
+	s.typeQueue = append(s.typeQueue, monoTypeInstance{
+		interfaceDecl: decl,
+		typeArgs:      append([]Type(nil), typeArgs...),
+		mangled:       mangled,
+	})
+	return mangled
+}
+
+// emitInterfaceSpecialization materializes one queued interface
+// instance. Mirrors emitStructSpecialization: the interface is cloned,
+// Extends + method signatures are substituted, and the specialization
+// is appended to out.Decls. Method-local generic parameters on
+// interface methods are preserved as templates (matching struct/enum
+// policy); the Pass-6 cleanup strips them from the output.
+func (s *monoState) emitInterfaceSpecialization(rec monoTypeInstance) {
+	clone := cloneInterfaceDecl(rec.interfaceDecl)
+	clone.Name = rec.mangled
+	clone.Generics = nil
+	env := buildSubstEnv(rec.interfaceDecl.Generics, rec.typeArgs)
+	SubstituteTypes(clone, env)
+	for i, ext := range clone.Extends {
+		clone.Extends[i] = s.rewriteType(ext)
+	}
+	for _, m := range clone.Methods {
+		if m == nil || len(m.Generics) > 0 {
+			continue
+		}
+		s.rewriteFnSignature(m)
+		s.scanFnBody(m)
+	}
+	s.out.Decls = append(s.out.Decls, clone)
 }
 
 // emitStructSpecialization materializes one queued struct instance:
@@ -491,6 +565,11 @@ func (s *monoState) rewriteType(t Type) Type {
 		}
 		if ed, ok := s.genericEnumsByName[x.Name]; ok {
 			if mangled := s.requestEnumType(ed, x.Args); mangled != "" {
+				return &NamedType{Name: mangled}
+			}
+		}
+		if id, ok := s.genericInterfacesByName[x.Name]; ok {
+			if mangled := s.requestInterfaceType(id, x.Args); mangled != "" {
 				return &NamedType{Name: mangled}
 			}
 		}
@@ -1003,6 +1082,8 @@ func (s *monoState) dropPreservedGenericMethods() {
 		case *StructDecl:
 			x.Methods = filterOutGenericMethods(x.Methods)
 		case *EnumDecl:
+			x.Methods = filterOutGenericMethods(x.Methods)
+		case *InterfaceDecl:
 			x.Methods = filterOutGenericMethods(x.Methods)
 		}
 	}

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -1646,6 +1646,154 @@ func TestMonomorphMangleMethodHelpers(t *testing.T) {
 	}
 }
 
+// ==== Phase 5 generic interface specialization ====
+
+// genericIteratorInterface returns `interface Iterator<T> { fn next(self) -> T }`.
+func genericIteratorInterface() *InterfaceDecl {
+	tv := &TypeVar{Name: "T"}
+	return &InterfaceDecl{
+		Name:     "Iterator",
+		Generics: []*TypeParam{{Name: "T"}},
+		Methods: []*FnDecl{{
+			Name:   "next",
+			Params: []*Param{{Name: "self", Type: &NamedType{Name: "Iterator", Args: []Type{tv}}}},
+			Return: tv,
+		}},
+	}
+}
+
+// findInterfaceSpec returns the first mangled InterfaceDecl in a module.
+func findInterfaceSpec(m *Module) *InterfaceDecl {
+	for _, d := range m.Decls {
+		if id, ok := d.(*InterfaceDecl); ok && strings.HasPrefix(id.Name, "_ZTS") {
+			return id
+		}
+	}
+	return nil
+}
+
+func TestMonomorphizeGenericInterfaceSpecialization(t *testing.T) {
+	// interface Iterator<T> { fn next(self) -> T }
+	// fn use(it: Iterator<Int>) { ... }
+	// The parameter type triggers specialization of Iterator<Int>.
+	iter := genericIteratorInterface()
+	user := &FnDecl{
+		Name:   "use",
+		Params: []*Param{{Name: "it", Type: &NamedType{Name: "Iterator", Args: []Type{TInt}}}},
+		Return: TUnit,
+		Body:   &Block{},
+	}
+	in := &Module{Package: "main", Decls: []Decl{iter, user}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	spec := findInterfaceSpec(out)
+	if spec == nil {
+		t.Fatalf("Iterator specialization missing from output: %+v", out.Decls)
+	}
+	if spec.Generics != nil {
+		t.Fatalf("specialization must shed generics, got %d", len(spec.Generics))
+	}
+	// The cloned fn `use` must have its param type rewritten to the mangled interface.
+	userCp := out.Decls[0].(*FnDecl)
+	pt, ok := userCp.Params[0].Type.(*NamedType)
+	if !ok || !strings.HasPrefix(pt.Name, "_ZTS") {
+		t.Fatalf("use.Params[0].Type not rewritten to mangled interface: %+v", userCp.Params[0].Type)
+	}
+	if pt.Name != spec.Name {
+		t.Fatalf("mangled names mismatch: param=%q spec=%q", pt.Name, spec.Name)
+	}
+	// Method signature must have concrete return.
+	if len(spec.Methods) != 1 || spec.Methods[0].Return != TInt {
+		t.Fatalf("interface method return not substituted to Int: %+v", spec.Methods)
+	}
+}
+
+func TestMonomorphizeGenericInterfaceDedup(t *testing.T) {
+	iter := genericIteratorInterface()
+	makeUser := func(name string) *FnDecl {
+		return &FnDecl{
+			Name:   name,
+			Params: []*Param{{Name: "it", Type: &NamedType{Name: "Iterator", Args: []Type{TInt}}}},
+			Return: TUnit,
+			Body:   &Block{},
+		}
+	}
+	in := &Module{Package: "main", Decls: []Decl{iter, makeUser("a"), makeUser("b")}}
+	out, _ := Monomorphize(in)
+	specs := 0
+	for _, d := range out.Decls {
+		if id, ok := d.(*InterfaceDecl); ok && strings.HasPrefix(id.Name, "_ZTS") {
+			specs++
+		}
+	}
+	if specs != 1 {
+		t.Fatalf("expected 1 deduped Iterator<Int> spec, got %d", specs)
+	}
+}
+
+func TestMonomorphizeGenericInterfaceDistinctArgs(t *testing.T) {
+	iter := genericIteratorInterface()
+	a := &FnDecl{
+		Name:   "a",
+		Params: []*Param{{Name: "it", Type: &NamedType{Name: "Iterator", Args: []Type{TInt}}}},
+		Return: TUnit, Body: &Block{},
+	}
+	b := &FnDecl{
+		Name:   "b",
+		Params: []*Param{{Name: "it", Type: &NamedType{Name: "Iterator", Args: []Type{TBool}}}},
+		Return: TUnit, Body: &Block{},
+	}
+	in := &Module{Package: "main", Decls: []Decl{iter, a, b}}
+	out, _ := Monomorphize(in)
+	specs := 0
+	for _, d := range out.Decls {
+		if id, ok := d.(*InterfaceDecl); ok && strings.HasPrefix(id.Name, "_ZTS") {
+			specs++
+		}
+	}
+	if specs != 2 {
+		t.Fatalf("expected 2 specs for distinct type args, got %d", specs)
+	}
+}
+
+func TestMonomorphizeUnusedGenericInterfaceDropped(t *testing.T) {
+	iter := genericIteratorInterface()
+	in := &Module{Package: "main", Decls: []Decl{iter}}
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	for _, d := range out.Decls {
+		if _, ok := d.(*InterfaceDecl); ok {
+			t.Fatalf("unused generic interface should be dropped, still in output: %+v", d)
+		}
+	}
+}
+
+func TestMonomorphizeGenericInterfaceArityMismatch(t *testing.T) {
+	iter := genericIteratorInterface() // Generics=1
+	// Iterator<Int, Bool> — 2 type args
+	user := &FnDecl{
+		Name:   "use",
+		Params: []*Param{{Name: "it", Type: &NamedType{Name: "Iterator", Args: []Type{TInt, TBool}}}},
+		Return: TUnit, Body: &Block{},
+	}
+	in := &Module{Package: "main", Decls: []Decl{iter, user}}
+	_, errs := Monomorphize(in)
+	if len(errs) == 0 {
+		t.Fatalf("expected arity-mismatch error, got none")
+	}
+	joined := ""
+	for _, e := range errs {
+		joined += e.Error() + "\n"
+	}
+	if !strings.Contains(joined, "arity mismatch") || !strings.Contains(joined, "Iterator") {
+		t.Fatalf("expected 'arity mismatch' + 'Iterator' in err, got %q", joined)
+	}
+}
+
 // ==== Phase 3 VariantLit type recovery ====
 
 func TestRecoverLiteralTypeHandlesCommonLiterals(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase 4(#216) 위에 쌓는 **dependent PR**. `interface Iterator<T> { fn next(self) -> T }` 같은 generic interface 선언을 struct/enum과 동일한 `_ZTS` 나미널 트랙으로 specialize. Base branch는 `claude/phase4-method-local-generics`.

Interface value의 vtable dispatch는 별도 스코프 — 이번 PR은 **IR 레벨 specialization**만 다룬다.

## 구현

- `internal/ir/monomorph.go`:
  - `isGenericTopLevel`에 `InterfaceDecl` 케이스 추가 — Pass 2가 원본 generic interface를 output에서 drop.
  - `monoState`에 `genericInterfacesByName` 인덱스 + Pass 1 등록.
  - `monoTypeInstance`에 `interfaceDecl *InterfaceDecl` 필드 추가.
  - `rewriteType`의 NamedType 분기에 interface lookup 추가 — generic user-interface reference를 `_ZTSN…E`로 재작성 + typeQueue enqueue.
  - `requestInterfaceType`: struct/enum counterpart와 동일 패턴 (arity 체크, containsTypeVar 가드, `typeCodeOf` 인코딩, `typeSeen` dedup).
  - `emitInterfaceSpecialization`: `cloneInterfaceDecl` → `SubstituteTypes` → `Extends` rewrite → non-generic methods의 `rewriteFnSignature`+`scanFnBody` (generic method는 preserve, Pass 6이 strip).
  - `emitTypeSpecialization` dispatch에 interface 케이스.
  - `dropPreservedGenericMethods`가 `InterfaceDecl`도 포함하도록 확장.

## 테스트 (모두 IR 레벨)

- `TestMonomorphizeGenericInterfaceSpecialization` — `Iterator<Int>`를 param으로 받는 fn에서 specialization 트리거 + 메서드 return 치환 검증
- `TestMonomorphizeGenericInterfaceDedup` / `DistinctArgs` — `Iterator<Int>` × 2 = 1개 spec, `Iterator<Int>` + `Iterator<Bool>` = 2개
- `TestMonomorphizeUnusedGenericInterfaceDropped` — 참조 없으면 drop
- `TestMonomorphizeGenericInterfaceArityMismatch` — 잘못된 type-arg 개수 → err 누적

LLVM E2E smoke는 이번 PR에 포함하지 않음 — interface value의 vtable lowering이 llvmgen에서 별도 작업이라서.

## 남은 범위

- Interface value의 vtable dispatch (interface as value type 런타임 경로)
- Bare function-pointer turbofish (`let f = id::<Int>`)
- Payload-free / non-literal variant call type 복원 (checker 보강)

## 문서

- `ARCHITECTURE.md`: Generic interface specialization 언급 추가.
- `LLVM_MIGRATION_PLAN.md` Phase 5: Phase 5 완료 + 남은 범위 축소.

## Test plan

- [x] `go test ./internal/ir/ -count=1` — 기존 + Phase 5 신규 5건 모두 pass
- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleGeneric|TestGenerateModuleMethod' -count=1` — 기존 smoke 모두 pass (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)