### PR TITLE
Refactor selfhost bundle wiring

### DIFF
--- a/internal/selfhost/bundle/bundle.go
+++ b/internal/selfhost/bundle/bundle.go
@@ -1,0 +1,144 @@
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var generatedFiles = []string{
+	"examples/selfhost-core/semver.osty",
+	"examples/selfhost-core/semver_parse.osty",
+	"examples/selfhost-core/frontend.osty",
+	"toolchain/lexer.osty",
+	"toolchain/parser.osty",
+	"examples/selfhost-core/formatter_ast.osty",
+	"examples/selfhost-core/check_bridge.osty",
+	"examples/selfhost-core/check.osty",
+	"examples/selfhost-core/resolve.osty",
+	"examples/selfhost-core/lint.osty",
+	"internal/selfhost/ast_lower.osty",
+}
+
+var toolchainCheckerFiles = []string{
+	"examples/selfhost-core/semver.osty",
+	"examples/selfhost-core/semver_parse.osty",
+	"toolchain/frontend.osty",
+	"toolchain/lexer.osty",
+	"toolchain/parser.osty",
+	"examples/selfhost-core/formatter_ast.osty",
+	"toolchain/check_bridge.osty",
+	"toolchain/diagnostic.osty",
+	"toolchain/check_diag.osty",
+	"toolchain/ty.osty",
+	"toolchain/core.osty",
+	"toolchain/check_env.osty",
+	"toolchain/solve.osty",
+	"toolchain/elab.osty",
+	"toolchain/check.osty",
+	"examples/selfhost-core/resolve.osty",
+	"examples/selfhost-core/lint.osty",
+	"internal/selfhost/ast_lower.osty",
+}
+
+const stringsPrelude = `use go "strings" as strings {
+    fn Count(s: String, substr: String) -> Int
+    fn Fields(s: String) -> List<String>
+    fn HasPrefix(s: String, prefix: String) -> Bool
+    fn HasSuffix(s: String, suffix: String) -> Bool
+    fn Join(elems: List<String>, sep: String) -> String
+    fn ReplaceAll(s: String, old: String, new: String) -> String
+    fn Repeat(s: String, count: Int) -> String
+    fn Split(s: String, sep: String) -> List<String>
+    fn SplitN(s: String, sep: String, n: Int) -> List<String>
+    fn TrimPrefix(s: String, prefix: String) -> String
+    fn TrimSpace(s: String) -> String
+    fn TrimSuffix(s: String, suffix: String) -> String
+}
+`
+
+func GeneratedFiles() []string {
+	return append([]string(nil), generatedFiles...)
+}
+
+func ToolchainCheckerFiles() []string {
+	return append([]string(nil), toolchainCheckerFiles...)
+}
+
+func MergeSelfhostGenerated(root string) ([]byte, error) {
+	return MergeFiles(root, generatedFiles)
+}
+
+func MergeToolchainChecker(root string) ([]byte, error) {
+	return MergeFiles(root, toolchainCheckerFiles)
+}
+
+func MergeFiles(root string, files []string) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString(stringsPrelude)
+	b.WriteByte('\n')
+
+	for _, rel := range files {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		b.WriteString("// ---- ")
+		b.WriteString(rel)
+		b.WriteString(" ----\n")
+		trimmed := stripLeadingStringsUse(string(data))
+		trimmed = normalizeStdStringsCalls(trimmed)
+		b.WriteString(trimmed)
+		if !strings.HasSuffix(trimmed, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+	}
+
+	return []byte(b.String()), nil
+}
+
+func stripLeadingStringsUse(src string) string {
+	const goPrefix = `use go "strings" as strings {`
+	const stdPrefix = "use std.strings as strings"
+
+	lines := strings.SplitAfter(src, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		switch {
+		case strings.HasPrefix(trimmed, goPrefix):
+			for j := i + 1; j < len(lines); j++ {
+				if strings.TrimSpace(lines[j]) == "}" {
+					return strings.Join(lines[:i], "") + strings.Join(lines[j+1:], "")
+				}
+			}
+			return src
+		case trimmed == stdPrefix:
+			return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
+		}
+	}
+
+	return src
+}
+
+func normalizeStdStringsCalls(src string) string {
+	for _, pair := range [][2]string{
+		{"strings.split(", "strings.Split("},
+		{"strings.join(", "strings.Join("},
+		{"strings.hasPrefix(", "strings.HasPrefix("},
+		{"strings.hasSuffix(", "strings.HasSuffix("},
+		{"strings.trimSpace(", "strings.TrimSpace("},
+		{"strings.replaceAll(", "strings.ReplaceAll("},
+		{"strings.trimPrefix(", "strings.TrimPrefix("},
+		{"strings.trimSuffix(", "strings.TrimSuffix("},
+		{"strings.repeat(", "strings.Repeat("},
+		{"strings.count(", "strings.Count("},
+		{"strings.fields(", "strings.Fields("},
+		{"strings.splitN(", "strings.SplitN("},
+	} {
+		src = strings.ReplaceAll(src, pair[0], pair[1])
+	}
+	return src
+}

--- a/internal/selfhost/bundle/bundle_test.go
+++ b/internal/selfhost/bundle/bundle_test.go
@@ -1,0 +1,79 @@
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBundleRoutesFrontendSourcesByConsumer(t *testing.T) {
+	generated := GeneratedFiles()
+	toolchain := ToolchainCheckerFiles()
+
+	if !contains(generated, "examples/selfhost-core/frontend.osty") {
+		t.Fatalf("generated bundle missing selfhost-core frontend: %#v", generated)
+	}
+	if contains(generated, "toolchain/frontend.osty") {
+		t.Fatalf("generated bundle unexpectedly routes through toolchain frontend: %#v", generated)
+	}
+	if !contains(toolchain, "toolchain/frontend.osty") {
+		t.Fatalf("toolchain checker bundle missing toolchain frontend: %#v", toolchain)
+	}
+}
+
+func TestMergeFilesPrependsPreludeAndNormalizesStringsUsage(t *testing.T) {
+	root := t.TempDir()
+	writeBundleFile(t, root, "go_strings.osty", `use go "strings" as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+fn demoGo() -> Int {
+    strings.Split("a,b", ",").len()
+}
+`)
+	writeBundleFile(t, root, "std_strings.osty", `use std.strings as strings
+
+fn demoStd() -> String {
+    strings.join(["a", "b"], ",")
+}
+`)
+
+	merged, err := MergeFiles(root, []string{"go_strings.osty", "std_strings.osty"})
+	if err != nil {
+		t.Fatalf("MergeFiles() error = %v", err)
+	}
+	got := string(merged)
+	if !strings.HasPrefix(got, stringsPrelude+"\n") {
+		t.Fatalf("merged source missing shared strings prelude:\n%s", got)
+	}
+	if count := strings.Count(got, `use go "strings" as strings {`); count != 1 {
+		t.Fatalf("merged source should keep exactly one shared Go strings import, got %d:\n%s", count, got)
+	}
+	if strings.Contains(got, "use std.strings as strings") {
+		t.Fatalf("merged source kept per-file std.strings import:\n%s", got)
+	}
+	if strings.Contains(got, "strings.join(") {
+		t.Fatalf("merged source kept std.strings camelCase call:\n%s", got)
+	}
+	if !strings.Contains(got, `strings.Join(["a", "b"], ",")`) {
+		t.Fatalf("merged source missing normalized PascalCase strings call:\n%s", got)
+	}
+}
+
+func writeBundleFile(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -10,37 +10,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/osty/osty/internal/selfhost/bundle"
 )
-
-var sourceFiles = []string{
-	"examples/selfhost-core/semver.osty",
-	"examples/selfhost-core/semver_parse.osty",
-	"examples/selfhost-core/frontend.osty",
-	"toolchain/lexer.osty",
-	"toolchain/parser.osty",
-	"examples/selfhost-core/formatter_ast.osty",
-	"examples/selfhost-core/check_bridge.osty",
-	"examples/selfhost-core/check.osty",
-	"examples/selfhost-core/resolve.osty",
-	"examples/selfhost-core/lint.osty",
-	"internal/selfhost/ast_lower.osty",
-}
-
-const stringsPrelude = `use go "strings" as strings {
-    fn Count(s: String, substr: String) -> Int
-    fn Fields(s: String) -> List<String>
-    fn HasPrefix(s: String, prefix: String) -> Bool
-    fn HasSuffix(s: String, suffix: String) -> Bool
-    fn Join(elems: List<String>, sep: String) -> String
-    fn ReplaceAll(s: String, old: String, new: String) -> String
-    fn Repeat(s: String, count: Int) -> String
-    fn Split(s: String, sep: String) -> List<String>
-    fn SplitN(s: String, sep: String, n: Int) -> List<String>
-    fn TrimPrefix(s: String, prefix: String) -> String
-    fn TrimSpace(s: String) -> String
-    fn TrimSuffix(s: String, suffix: String) -> String
-}
-`
 
 func main() {
 	if err := run(); err != nil {
@@ -66,7 +38,7 @@ func run() error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	merged, err := mergedSource(root)
+	merged, err := bundle.MergeSelfhostGenerated(root)
 	if err != nil {
 		return err
 	}
@@ -135,7 +107,7 @@ func generatedSelfhostUpToDate(root, outPath string) (bool, error) {
 	if err := checkPath(filepath.Join(root, "internal/selfhost/gen_selfhost.go")); err != nil {
 		return false, fmt.Errorf("stat selfhost generator: %w", err)
 	}
-	for _, rel := range sourceFiles {
+	for _, rel := range bundle.GeneratedFiles() {
 		if err := checkPath(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
 			return false, fmt.Errorf("stat %s: %w", rel, err)
 		}
@@ -158,78 +130,6 @@ func findRepoRoot() (string, error) {
 		}
 		dir = parent
 	}
-}
-
-func mergedSource(root string) ([]byte, error) {
-	var b strings.Builder
-	b.WriteString(stringsPrelude)
-	b.WriteByte('\n')
-	for _, rel := range sourceFiles {
-		path := filepath.Join(root, filepath.FromSlash(rel))
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", rel, err)
-		}
-		b.WriteString("// ---- ")
-		b.WriteString(rel)
-		b.WriteString(" ----\n")
-		trimmed := stripLeadingStringsUse(string(data))
-		trimmed = normalizeStdStringsCalls(trimmed)
-		b.WriteString(trimmed)
-		if !strings.HasSuffix(trimmed, "\n") {
-			b.WriteByte('\n')
-		}
-		b.WriteByte('\n')
-	}
-	return []byte(b.String()), nil
-}
-
-func stripLeadingStringsUse(src string) string {
-	const goPrefix = `use go "strings" as strings {`
-	const stdPrefix = "use std.strings as strings"
-
-	lines := strings.SplitAfter(src, "\n")
-	for i := 0; i < len(lines); i++ {
-		trimmed := strings.TrimSpace(lines[i])
-		switch {
-		case strings.HasPrefix(trimmed, goPrefix):
-			for j := i + 1; j < len(lines); j++ {
-				if strings.TrimSpace(lines[j]) == "}" {
-					return strings.Join(lines[:i], "") + strings.Join(lines[j+1:], "")
-				}
-			}
-			return src
-		case trimmed == stdPrefix:
-			return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
-		}
-	}
-
-	return src
-}
-
-// normalizeStdStringsCalls rewrites camelCase strings.xxx() calls (from
-// std.strings) to PascalCase so they match the Go FFI declarations in
-// stringsPrelude. Only applies to files that originally used std.strings.
-func normalizeStdStringsCalls(src string) string {
-	// Only touch files that had the std.strings import (now stripped).
-	// We detect this by checking whether any camelCase strings.* call appears.
-	for _, pair := range [][2]string{
-		{"strings.split(", "strings.Split("},
-		{"strings.join(", "strings.Join("},
-		{"strings.hasPrefix(", "strings.HasPrefix("},
-		{"strings.hasSuffix(", "strings.HasSuffix("},
-		{"strings.trimSpace(", "strings.TrimSpace("},
-		{"strings.replaceAll(", "strings.ReplaceAll("},
-		{"strings.trimPrefix(", "strings.TrimPrefix("},
-		{"strings.trimSuffix(", "strings.TrimSuffix("},
-		{"strings.repeat(", "strings.Repeat("},
-		{"strings.count(", "strings.Count("},
-		{"strings.fields(", "strings.Fields("},
-		{"strings.splitN(", "strings.SplitN("},
-	} {
-		src = strings.ReplaceAll(src, pair[0], pair[1])
-	}
-	return src
 }
 
 func patchGenerated(path string) error {

--- a/internal/selfhost/toolchain_checker_gen_test.go
+++ b/internal/selfhost/toolchain_checker_gen_test.go
@@ -2,50 +2,13 @@ package selfhost
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/selfhost/bundle"
 )
-
-var toolchainCheckerSourceFiles = []string{
-	"examples/selfhost-core/semver.osty",
-	"examples/selfhost-core/semver_parse.osty",
-	"toolchain/frontend.osty",
-	"toolchain/lexer.osty",
-	"toolchain/parser.osty",
-	"examples/selfhost-core/formatter_ast.osty",
-	"toolchain/check_bridge.osty",
-	"toolchain/diagnostic.osty",
-	"toolchain/check_diag.osty",
-	"toolchain/ty.osty",
-	"toolchain/core.osty",
-	"toolchain/check_env.osty",
-	"toolchain/solve.osty",
-	"toolchain/elab.osty",
-	"toolchain/check.osty",
-	"examples/selfhost-core/resolve.osty",
-	"examples/selfhost-core/lint.osty",
-	"internal/selfhost/ast_lower.osty",
-}
-
-const toolchainCheckerStringsPrelude = `use go "strings" as strings {
-    fn Count(s: String, substr: String) -> Int
-    fn Fields(s: String) -> List<String>
-    fn HasPrefix(s: String, prefix: String) -> Bool
-    fn HasSuffix(s: String, prefix: String) -> Bool
-    fn Join(elems: List<String>, sep: String) -> String
-    fn ReplaceAll(s: String, old: String, new: String) -> String
-    fn Repeat(s: String, count: Int) -> String
-    fn Split(s: String, sep: String) -> List<String>
-    fn SplitN(s: String, sep: String, n: Int) -> List<String>
-    fn TrimPrefix(s: String, prefix: String) -> String
-    fn TrimSpace(s: String) -> String
-    fn TrimSuffix(s: String, suffix: String) -> String
-}
-`
 
 func TestToolchainCheckerSourcesTranspile(t *testing.T) {
 	if testing.Short() {
@@ -53,7 +16,7 @@ func TestToolchainCheckerSourcesTranspile(t *testing.T) {
 	}
 
 	repoRoot := filepath.Join("..", "..")
-	merged, err := mergeToolchainCheckerSources(repoRoot)
+	merged, err := bundle.MergeToolchainChecker(repoRoot)
 	if err != nil {
 		t.Fatalf("merge toolchain checker sources: %v", err)
 	}
@@ -92,73 +55,4 @@ func TestToolchainCheckerSourcesTranspile(t *testing.T) {
 	if !bytes.Contains(generated, []byte("func elabInfer(")) {
 		t.Fatalf("generated file does not include elaborator entrypoints")
 	}
-}
-
-func mergeToolchainCheckerSources(root string) ([]byte, error) {
-	var b strings.Builder
-	b.WriteString(toolchainCheckerStringsPrelude)
-	b.WriteByte('\n')
-
-	for _, rel := range toolchainCheckerSourceFiles {
-		path := filepath.Join(root, filepath.FromSlash(rel))
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", rel, err)
-		}
-		b.WriteString("// ---- ")
-		b.WriteString(rel)
-		b.WriteString(" ----\n")
-		trimmed := stripToolchainCheckerStringsUse(string(data))
-		trimmed = normalizeToolchainCheckerStdStringsCalls(trimmed)
-		b.WriteString(trimmed)
-		if !strings.HasSuffix(trimmed, "\n") {
-			b.WriteByte('\n')
-		}
-		b.WriteByte('\n')
-	}
-
-	return []byte(b.String()), nil
-}
-
-func stripToolchainCheckerStringsUse(src string) string {
-	const goPrefix = `use go "strings" as strings {`
-	const stdPrefix = "use std.strings as strings"
-
-	lines := strings.SplitAfter(src, "\n")
-	for i := 0; i < len(lines); i++ {
-		trimmed := strings.TrimSpace(lines[i])
-		switch {
-		case strings.HasPrefix(trimmed, goPrefix):
-			for j := i + 1; j < len(lines); j++ {
-				if strings.TrimSpace(lines[j]) == "}" {
-					return strings.Join(lines[:i], "") + strings.Join(lines[j+1:], "")
-				}
-			}
-			return src
-		case trimmed == stdPrefix:
-			return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
-		}
-	}
-
-	return src
-}
-
-func normalizeToolchainCheckerStdStringsCalls(src string) string {
-	for _, pair := range [][2]string{
-		{"strings.split(", "strings.Split("},
-		{"strings.join(", "strings.Join("},
-		{"strings.hasPrefix(", "strings.HasPrefix("},
-		{"strings.hasSuffix(", "strings.HasSuffix("},
-		{"strings.trimSpace(", "strings.TrimSpace("},
-		{"strings.replaceAll(", "strings.ReplaceAll("},
-		{"strings.trimPrefix(", "strings.TrimPrefix("},
-		{"strings.trimSuffix(", "strings.TrimSuffix("},
-		{"strings.repeat(", "strings.Repeat("},
-		{"strings.count(", "strings.Count("},
-		{"strings.fields(", "strings.Fields("},
-		{"strings.splitN(", "strings.SplitN("},
-	} {
-		src = strings.ReplaceAll(src, pair[0], pair[1])
-	}
-	return src
 }


### PR DESCRIPTION
## Summary
- extract shared selfhost bundle assembly into `internal/selfhost/bundle`
- make `gen_selfhost.go` and the toolchain checker transpile smoke test use the same merge and normalization helpers
- add focused tests that lock the frontend routing split and strings import normalization behavior

## Testing
- `go test ./internal/selfhost/bundle -count=1`
- `go test ./internal/selfhost -run ^ -count=1`
- `go test ./cmd/osty -run ^ -count=1`

## Notes
- the heavier selfhost regeneration and transpile path is still blocked in the current tree by the pre-existing `undefined name `while`` error from bundled selfhost sources.