### PR TITLE
Fix native LLVM happy path for merged test packages

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1899,21 +1899,9 @@ func parseGenEmitFile(pkg *resolve.Package) (*ast.File, []byte, error) {
 		return nil, nil, fmt.Errorf("missing package input for gen")
 	}
 	var merged bytes.Buffer
-	mergedFile := &ast.File{}
-	first := true
 	for _, pf := range pkg.Files {
 		if pf == nil {
 			continue
-		}
-		if pf.File != nil {
-			if first {
-				mergedFile.PosV = pf.File.Pos()
-				first = false
-			}
-			mergedFile.EndV = pf.File.End()
-			mergedFile.Uses = append(mergedFile.Uses, pf.File.Uses...)
-			mergedFile.Decls = append(mergedFile.Decls, pf.File.Decls...)
-			mergedFile.Stmts = append(mergedFile.Stmts, pf.File.Stmts...)
 		}
 		if len(pf.Source) == 0 {
 			continue
@@ -1930,10 +1918,15 @@ func parseGenEmitFile(pkg *resolve.Package) (*ast.File, []byte, error) {
 	if len(src) == 0 {
 		return nil, nil, fmt.Errorf("%s: no source bytes were available for backend emission", pkg.Dir)
 	}
-	if len(mergedFile.Uses) == 0 && len(mergedFile.Decls) == 0 && len(mergedFile.Stmts) == 0 {
-		return nil, nil, fmt.Errorf("%s: no parsed package files were available for backend emission", pkg.Dir)
+	// Reparse the synthetic single-file source we hand to the backend. Merely
+	// stitching together per-file AST fragments leaves source positions and some
+	// checker inference paths out of sync with the merged byte stream, which in
+	// turn can poison the backend bridge with `<error>` types for otherwise valid
+	// native-test programs.
+	if reparsed, diags := parser.ParseDiagnostics(src); reparsed != nil && !hasError(diags) {
+		return reparsed, src, nil
 	}
-	return mergedFile, src, nil
+	return nil, nil, fmt.Errorf("%s: merged package source could not be reparsed for backend emission", pkg.Dir)
 }
 
 // runNew implements the `osty new NAME` subcommand: scaffold a fresh

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -54,7 +54,7 @@ func TestParseGenEmitFileMergesPackageSources(t *testing.T) {
 	}
 }
 
-func TestParseGenEmitFilePreservesOriginalASTNodes(t *testing.T) {
+func TestParseGenEmitFileReparsesMergedSource(t *testing.T) {
 	dir := t.TempDir()
 	writeGenTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
 	target := writeGenTestFile(t, dir, "b.osty", "fn main() -> Int { helper() }\n")
@@ -73,11 +73,11 @@ func TestParseGenEmitFilePreservesOriginalASTNodes(t *testing.T) {
 	if got, want := len(file.Decls), 2; got != want {
 		t.Fatalf("merged decl count = %d, want %d", got, want)
 	}
-	if got, want := file.Decls[0], entry.pkg.Files[0].File.Decls[0]; got != want {
-		t.Fatalf("decl[0] was reparsed instead of reusing original AST node")
+	if got, want := file.Decls[0], entry.pkg.Files[0].File.Decls[0]; got == want {
+		t.Fatalf("decl[0] reused the original AST node; want a reparsed merged AST")
 	}
-	if got, want := file.Decls[1], entry.pkg.Files[1].File.Decls[0]; got != want {
-		t.Fatalf("decl[1] was reparsed instead of reusing original AST node")
+	if got, want := file.Decls[1], entry.pkg.Files[1].File.Decls[0]; got == want {
+		t.Fatalf("decl[1] reused the original AST node; want a reparsed merged AST")
 	}
 }
 

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 )
 
@@ -268,9 +269,12 @@ func parseNativeTestEntry(pkg *resolve.Package, tc nativeTestCase) (*ast.File, [
 		Name: pkg.Name,
 	}
 	testPkg.Files = append(testPkg.Files, pkg.Files...)
+	runnerFile, runnerDiags := parser.ParseDiagnostics(runner)
 	testPkg.Files = append(testPkg.Files, &resolve.PackageFile{
-		Path:   runnerPath,
-		Source: runner,
+		Path:       runnerPath,
+		Source:     runner,
+		File:       runnerFile,
+		ParseDiags: runnerDiags,
 	})
 	file, src, err := parseGenEmitFile(testPkg)
 	if err != nil {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -360,7 +360,7 @@ func legacyLetDeclFromIR(ld *ostyir.LetDecl) (*ast.LetDecl, error) {
 		Pub:  ld.Exported,
 		Mut:  ld.Mut,
 		Name: ld.Name,
-		Type: legacyTypeFromIR(ld.Type),
+		Type: legacyBindingTypeFromIR(ld.Type, ld.Value != nil),
 	}
 	if ld.Value != nil {
 		value, err := legacyExprFromIR(ld.Value)
@@ -411,6 +411,20 @@ func legacyTypeFromIR(typ ostyir.Type) ast.Type {
 	default:
 		return nil
 	}
+}
+
+func legacyBindingTypeFromIR(typ ostyir.Type, hasValue bool) ast.Type {
+	// Lowering currently bakes inferred let types into IR. If the checker leaves
+	// an inferred value at ErrType, replaying that as an explicit `<error>` type
+	// in the bridge makes the legacy emitter fail even when the value path is
+	// otherwise compilable. Keep the annotation only when it carries useful type
+	// information.
+	if hasValue {
+		if _, ok := typ.(*ostyir.ErrType); ok {
+			return nil
+		}
+	}
+	return legacyTypeFromIR(typ)
 }
 
 func legacyPrimTypeName(kind ostyir.PrimKind) string {
@@ -542,7 +556,7 @@ func legacyLetStmtFromIR(stmt *ostyir.LetStmt) (ast.Stmt, error) {
 		PosV: start,
 		EndV: end,
 		Mut:  stmt.Mut,
-		Type: legacyTypeFromIR(stmt.Type),
+		Type: legacyBindingTypeFromIR(stmt.Type, stmt.Value != nil),
 	}
 	if stmt.Pattern != nil {
 		pat, err := legacyPatternFromIR(stmt.Pattern)

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -366,3 +366,62 @@ fn main() {
 		}
 	}
 }
+
+func TestGenerateModuleStdTestingExpectOkCompat(t *testing.T) {
+	src := `use std.testing
+
+enum CalcError {
+    DivideByZero,
+}
+
+fn div(a: Int, b: Int) -> Result<Int, CalcError> {
+    if b == 0 { Err(DivideByZero) } else { Ok(a / b) }
+}
+
+fn main() {
+    let q = testing.expectOk(div(10, 2))
+    testing.assertEq(q, 5)
+    testing.expectError(div(1, 0))
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_testing_expect_ok_ir.osty")
+	for _, want := range []string{
+		"%Result.i64.i64 = type { i64, i64, i64 }",
+		"extractvalue %Result.i64.i64",
+		"call %Result.i64.i64 @div(i64 10, i64 2)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateModuleTupleTableDrivenLoopCompat(t *testing.T) {
+	src := `fn clamp(v: Int, lo: Int, hi: Int) -> Int {
+    if v < lo { lo } else if v > hi { hi } else { v }
+}
+
+fn main() {
+    let cases = [
+        (5, 0, 10, 5),
+        (-1, 0, 10, 0),
+        (99, 0, 10, 10),
+    ]
+    for c in cases {
+        let (v, lo, hi, expected) = c
+        println(clamp(v, lo, hi) - expected)
+    }
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_tuple_table_ir.osty")
+	for _, want := range []string{
+		"%Tuple.i64.i64.i64.i64 = type { i64, i64, i64, i64 }",
+		"call void @osty_rt_list_push_bytes_v1(",
+		"call void @osty_rt_list_get_bytes_v1(",
+		"extractvalue %Tuple.i64.i64.i64.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -109,7 +109,11 @@ func llvmListElementType(t ast.Type, env typeEnv) (string, bool, error) {
 	if !llvmIsRuntimeAbiListType(name, len(named.Path), len(named.Args)) {
 		return "", false, nil
 	}
-	elemTyp, err := llvmRuntimeABIType(named.Args[0], env)
+	// Lists store the backend's concrete element representation, not the
+	// runtime-call ABI form. That keeps aggregate elements such as tuples,
+	// structs, and Result payloads on the aggregate-bytes path instead of
+	// collapsing them to ptr during IR->AST bridge emission.
+	elemTyp, err := llvmType(named.Args[0], env)
 	if err != nil {
 		return "", true, err
 	}


### PR DESCRIPTION
## Summary
- reparse merged package source before backend emission so checker/backend see a consistent synthetic file
- parse the synthetic native test runner into the package AST so the generated main reaches LLVM emission
- tighten LLVM IR bridge handling for merged let bindings and aggregate list element types, with compat regressions for Result and tuple-table paths

## Testing
- `go test ./cmd/osty -count=1`
- `go test ./internal/llvmgen -count=1`
- `go test ./internal/backend -count=1`