### PR TITLE
feat: Interface vtable Phase 6a — fat pointer type + vtable global scaffold

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -285,10 +285,17 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     struct/enum과 동일한 `_ZTS` 나미널 트랙을 interface에도 확장,
     `requestInterfaceType` + `emitInterfaceSpecialization`로 type queue에
     편입. Interface-as-value vtable dispatch 경로는 별도 스코프.
+  - Phase 6a(interface vtable scaffold)는 llvmgen 렌더러에서 구조만
+    갖춘다: `%osty.iface = type { ptr, ptr }` fat-pointer 타입과
+    structural match 기반으로 발견된 (impl, interface) 쌍마다
+    `@osty.vtable.<impl>__<iface>` 상수 global을 emit. Boxing과
+    method dispatch 경로는 Phase 6b+로 보류
+    (smoke: `TestGenerateModuleInterfaceVtableEmitted`).
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
-    interface value의 vtable dispatch, payload-free / 비-리터럴 인자를
-    가진 variant call의 타입 복원(궁극적으로는 checker 쪽 generic
-    variant-constructor inference 보강).
+    interface value의 boxing + vtable dispatch (Phase 6b+),
+    payload-free / 비-리터럴 인자를 가진 variant call의 타입
+    복원(궁극적으로는 checker 쪽 generic variant-constructor inference
+    보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -130,9 +130,32 @@ type tupleTypeInfo struct {
 	elemListElemTyps []string
 }
 
+// interfaceInfo carries the collected shape of an `interface` declaration.
+// Phase 6a: `methods` preserves the source-order signature list so the
+// vtable emitter can lay out function-pointer slots in a deterministic
+// order that matches `impls` tables. `impls` lists every struct/enum
+// name whose method set structurally satisfies this interface, in
+// source-declaration order.
 type interfaceInfo struct {
+	name    string
+	decl    *ast.InterfaceDecl
+	methods []interfaceMethodSig
+	impls   []interfaceImpl
+}
+
+// interfaceMethodSig is the minimal surface the vtable emitter needs
+// from each interface method: its source name and an ordinal slot.
+type interfaceMethodSig struct {
 	name string
-	decl *ast.InterfaceDecl
+	slot int
+}
+
+// interfaceImpl records a concrete type that satisfies an interface,
+// together with the symbol its vtable emits.
+type interfaceImpl struct {
+	implName   string // source name of the struct/enum
+	kind       int    // 0 = struct, 1 = enum
+	vtableSym  string // `@osty.vtable.<impl>__<iface>`
 }
 
 type typeAliasInfo struct {
@@ -291,6 +314,10 @@ func collectDeclarations(file *ast.File) (*declarations, error) {
 			return nil, err
 		}
 	}
+	// Phase 6a: once every struct/enum method has been registered in
+	// methodsByType, scan for structural satisfaction so each interface
+	// knows which concrete types need a vtable emitted at render time.
+	discoverInterfaceImplementations(out)
 	return out, nil
 }
 
@@ -510,7 +537,76 @@ func collectInterfaceShell(decl *ast.InterfaceDecl) (*interfaceInfo, error) {
 	if diag := llvmNominalDeclHeaderDiagnostic("interface", decl.Name, llvmIsIdent(decl.Name), len(decl.Generics), len(decl.Methods)); diag.kind != "" {
 		return nil, unsupported(diag.kind, diag.message)
 	}
-	return &interfaceInfo{name: decl.Name, decl: decl}, nil
+	info := &interfaceInfo{name: decl.Name, decl: decl}
+	// Phase 6a: capture method names in source order so the vtable
+	// emitter can lay out function-pointer slots deterministically.
+	for i, m := range decl.Methods {
+		if m == nil || !llvmIsIdent(m.Name) {
+			continue
+		}
+		info.methods = append(info.methods, interfaceMethodSig{name: m.Name, slot: i})
+	}
+	return info, nil
+}
+
+// discoverInterfaceImplementations walks every struct and enum looking
+// for structural satisfaction of each collected interface: if all the
+// interface's source-name methods appear in the type's method set,
+// the type is registered as an implementer. The vtable symbol name
+// follows `osty.vtable.<impl>__<iface>` so multiple implementers of
+// the same interface never collide.
+//
+// Source-name matching is deliberate for Phase 6a: a more strict
+// signature-level match (argument / return types) will be layered on
+// once the dispatch path lands.
+func discoverInterfaceImplementations(decls *declarations) {
+	if decls == nil {
+		return
+	}
+	for _, iface := range decls.interfacesByName {
+		if iface == nil {
+			continue
+		}
+		for _, sd := range decls.structsOrdered {
+			if sd == nil {
+				continue
+			}
+			if interfaceSatisfiedByMethods(iface, decls.methodsByType[sd.typ]) {
+				iface.impls = append(iface.impls, interfaceImpl{
+					implName:  sd.name,
+					kind:      0,
+					vtableSym: "@osty.vtable." + sd.name + "__" + iface.name,
+				})
+			}
+		}
+		for _, ed := range decls.enumsOrdered {
+			if ed == nil {
+				continue
+			}
+			if interfaceSatisfiedByMethods(iface, decls.methodsByType[ed.typ]) {
+				iface.impls = append(iface.impls, interfaceImpl{
+					implName:  ed.name,
+					kind:      1,
+					vtableSym: "@osty.vtable." + ed.name + "__" + iface.name,
+				})
+			}
+		}
+	}
+}
+
+func interfaceSatisfiedByMethods(iface *interfaceInfo, methods map[string]*fnSig) bool {
+	if iface == nil || len(iface.methods) == 0 {
+		return false
+	}
+	if methods == nil {
+		return false
+	}
+	for _, need := range iface.methods {
+		if _, ok := methods[need.name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func collectTypeAliasShell(decl *ast.TypeAliasDecl) (*typeAliasInfo, error) {

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -216,6 +216,14 @@ func (g *generator) render(defs []string) []byte {
 			typeDefs = append(typeDefs, llvmStructTypeDef(strings.TrimPrefix(info.typ, "%"), []string{"i64", info.okTyp, info.errTyp}))
 		}
 	}
+	// Phase 6a: interface fat-pointer type + per (impl, interface) vtable
+	// globals are emitted only when at least one interface has
+	// implementations — avoiding LLVM IR noise in modules that don't use
+	// interfaces at all.
+	if vtableDefs, vtableTypeDef := g.renderInterfaceVtables(); vtableTypeDef != "" {
+		typeDefs = append(typeDefs, vtableTypeDef)
+		allDefs = append(allDefs, vtableDefs...)
+	}
 	runtimeDecls := g.runtimeDeclarationIR()
 	if g.needsGCRuntime {
 		runtimeDecls = append(llvmGcRuntimeDeclarations(), runtimeDecls...)
@@ -224,6 +232,78 @@ func (g *generator) render(defs []string) []byte {
 		return []byte(llvmRenderModuleWithRuntimeDeclarations(g.sourcePath, g.target, typeDefs, g.stringDefs, runtimeDecls, allDefs))
 	}
 	return []byte(llvmRenderModuleWithGlobalsAndTypes(g.sourcePath, g.target, typeDefs, g.stringDefs, allDefs))
+}
+
+// renderInterfaceVtables builds the LLVM IR for the interface
+// fat-pointer type (`%osty.iface`) plus one `constant [N x ptr]`
+// global per (implementer, interface) pair discovered during
+// declaration collection.
+//
+// Returns (defs, typeDef) where typeDef is empty when no vtable is
+// needed (no interfaces, or no implementations of any interface).
+// Phase 6a scope: the globals are emitted and addressable via
+// `@osty.vtable.<impl>__<iface>`, but no boxing or dispatch path
+// consumes them yet — that lands in subsequent phases.
+func (g *generator) renderInterfaceVtables() ([]string, string) {
+	if len(g.interfacesByName) == 0 {
+		return nil, ""
+	}
+	// Stable iteration over interfaces for deterministic IR output.
+	ifaceNames := make([]string, 0, len(g.interfacesByName))
+	for name := range g.interfacesByName {
+		ifaceNames = append(ifaceNames, name)
+	}
+	sort.Strings(ifaceNames)
+	var defs []string
+	haveAny := false
+	for _, ifaceName := range ifaceNames {
+		iface := g.interfacesByName[ifaceName]
+		if iface == nil || len(iface.impls) == 0 {
+			continue
+		}
+		haveAny = true
+		for _, impl := range iface.impls {
+			methodsByName := g.methods[g.ownerTypeFor(impl)]
+			slots := make([]string, 0, len(iface.methods))
+			for _, m := range iface.methods {
+				sig := methodsByName[m.name]
+				if sig == nil {
+					slots = append(slots, "ptr null")
+					continue
+				}
+				slots = append(slots, fmt.Sprintf("ptr @%s", sig.irName))
+			}
+			defs = append(defs, fmt.Sprintf(
+				"%s = constant [%d x ptr] [%s]",
+				impl.vtableSym,
+				len(iface.methods),
+				strings.Join(slots, ", "),
+			))
+		}
+	}
+	if !haveAny {
+		return nil, ""
+	}
+	typeDef := "%osty.iface = type { ptr, ptr }"
+	return defs, typeDef
+}
+
+// ownerTypeFor returns the LLVM IR type symbol (`%Name`) a given
+// interface implementation refers to. Struct implementations carry the
+// struct's LLVM type name; enum implementations carry the enum's
+// tag/payload struct name.
+func (g *generator) ownerTypeFor(impl interfaceImpl) string {
+	switch impl.kind {
+	case 0:
+		if info := g.structsByName[impl.implName]; info != nil {
+			return info.typ
+		}
+	case 1:
+		if info := g.enumsByName[impl.implName]; info != nil {
+			return info.typ
+		}
+	}
+	return ""
 }
 
 func (g *generator) runtimeDeclarationIR() []string {

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -190,6 +190,45 @@ fn main() {
 	}
 }
 
+// TestGenerateModuleInterfaceVtableEmitted covers the Phase 6a scaffold:
+// when a non-generic struct's method set structurally satisfies a
+// non-generic interface, the LLVM IR must gain
+//   - the `%osty.iface = type { ptr, ptr }` fat-pointer type, and
+//   - a `@osty.vtable.<impl>__<iface>` constant global whose function
+//     pointers reference the concrete methods in interface-declaration
+//     order.
+// Boxing and method-dispatch paths stay out of scope for this phase —
+// the smoke only verifies that the vtable *exists*.
+func TestGenerateModuleInterfaceVtableEmitted(t *testing.T) {
+	src := `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn main() {
+    let v = Vec { count: 3 }
+    println(v.size())
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6a_iface_vtable_ir.osty")
+	for _, want := range []string{
+		"%osty.iface = type { ptr, ptr }",
+		"@osty.vtable.Vec__Sized",
+		"ptr @Vec__size",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call


### PR DESCRIPTION
## Summary

Phase 5(#219) 위에 쌓는 **dependent PR**. llvmgen에 interface value 경로가 실질적으로 없는 상태(`interface` 타입을 그냥 `"ptr"`로 매핑)였기 때문에 vtable dispatch를 한 번에 완결하는 대신 **토대만** 깔았다. Boxing/dispatch는 Phase 6b+에서 이 scaffold 위에 쌓는다.

- **새 LLVM 타입**: `%osty.iface = type { ptr, ptr }` (fat pointer)
- **vtable global**: 각 (impl, interface) 쌍마다 `@osty.vtable.<impl>__<iface> = constant [N x ptr] [ptr @<impl>__<method>, …]`

## 구현

### `internal/llvmgen/decl.go`
- `interfaceInfo`에 `methods []interfaceMethodSig`와 `impls []interfaceImpl` 추가 — 선언 순서로 method slot을 보존하고, structural satisfaction으로 발견된 구현자와 그 vtable symbol을 기록.
- `collectInterfaceShell`이 `decl.Methods`를 순회해 `interfaceMethodSig` 리스트를 채운다.
- 신규 `discoverInterfaceImplementations`: 모든 struct/enum의 `methodsByType` 엔트리를 훑어 각 interface의 method-name set을 모두 포함하는지 체크 (structural, source-name 기준). 만족하면 `interfaceImpl{implName, kind, vtableSym}` 등록. vtable symbol 규약: `@osty.vtable.<impl>__<iface>`.
- `collectDeclarations` 말미에서 호출.

### `internal/llvmgen/generator.go`
- `renderInterfaceVtables`: 실제 구현이 있는 interface가 하나라도 있으면 `%osty.iface = type { ptr, ptr }` 타입 정의 + 각 (impl, iface) 쌍의 `<vtable> = constant [N x ptr] [...]`을 반환. 메서드가 이름 match 실패(거의 없음)면 `ptr null` slot — defensive.
- `ownerTypeFor(impl)`: impl kind에 따라 struct/enum LLVM 타입 이름 복구.
- `render`가 결과를 typeDefs/allDefs에 편입.

## 테스트

- `internal/llvmgen/ir_module_test.go`:
  `TestGenerateModuleInterfaceVtableEmitted` — `interface Sized { fn size(self) -> Int }` + `struct Vec { …; fn size(self) -> Int { … } }` 소스로 IR에 `%osty.iface = type { ptr, ptr }`, `@osty.vtable.Vec__Sized`, `ptr @Vec__size` slot이 emit됨을 검증.

## Phase 6b+로 보류

- Interface value의 boxing (`let x: Iface = concrete` → fat pointer)
- Interface method call의 vtable indirect dispatch (`x.method()`)
- Generic interface specialization의 vtable (mangled owner / `_ZTS…` interface 조합)

## Test plan

- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleInterface' -count=1` — vtable smoke pass
- [x] `go test ./internal/ir/ ./internal/llvmgen/ -run 'Monomorph|TestGenerateModuleGeneric|TestGenerateModuleMethod' -count=1` — 기존 Phase 1-5 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)