### PR TITLE
Support let struct destructuring in LLVM backend

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -850,3 +850,51 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+func TestLLVMBackendBinaryLetStructPatternDestructuring(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+struct Pair {
+    first: Int
+    second: Int
+}
+
+struct Bucket {
+    pair: Pair
+    items: List<String>
+}
+
+fn main() {
+    let bucket @ Bucket {
+        pair: Pair { first, second },
+        items,
+    } = Bucket {
+        pair: Pair { first: 1, second: 2 },
+        items: strings.Split("pear,apple", ","),
+    }
+    println(first)
+    println(second)
+    println(items.sorted()[0])
+    println(bucket.pair.first)
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	output, err := exec.Command(result.Artifacts.Binary).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "1\n2\napple\n1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -750,6 +750,18 @@ func (g *generator) bindLetPattern(pattern ast.Pattern, v value, mutable bool) e
 		}
 		g.bindNamedLocal(p.Name, v, mutable)
 		return nil
+	case *ast.BindingPat:
+		if mutable {
+			return unsupported("statement", "binding let patterns cannot be mutable yet")
+		}
+		if p.Name == "" {
+			return unsupported("statement", "empty let binding name")
+		}
+		if !llvmIsIdent(p.Name) {
+			return unsupportedf("name", "let name %q", p.Name)
+		}
+		g.bindNamedLocal(p.Name, v, false)
+		return g.bindLetPattern(p.Pattern, v, false)
 	case *ast.TuplePat:
 		if mutable {
 			return unsupported("statement", "tuple let patterns cannot be mutable yet")
@@ -771,8 +783,46 @@ func (g *generator) bindLetPattern(pattern ast.Pattern, v value, mutable bool) e
 			}
 		}
 		return nil
+	case *ast.StructPat:
+		if mutable {
+			return unsupported("statement", "struct let patterns cannot be mutable yet")
+		}
+		if err := g.validateStructLetPatternType(p, v.typ); err != nil {
+			return err
+		}
+		info := g.structsByType[v.typ]
+		if info == nil {
+			return unsupportedf("type-system", "struct pattern on %s", v.typ)
+		}
+		seen := map[string]bool{}
+		for _, fieldPat := range p.Fields {
+			if fieldPat == nil {
+				return unsupportedf("statement", "struct pattern %q has nil field", info.name)
+			}
+			if fieldPat.Name == "" {
+				return unsupportedf("statement", "struct pattern %q has unnamed field", info.name)
+			}
+			if seen[fieldPat.Name] {
+				return unsupportedf("statement", "struct pattern %q duplicate field %q", info.name, fieldPat.Name)
+			}
+			seen[fieldPat.Name] = true
+			fieldValue, err := g.extractStructField(v, info, fieldPat.Name)
+			if err != nil {
+				return err
+			}
+			fieldPattern := fieldPat.Pattern
+			if fieldPattern == nil {
+				fieldPattern = &ast.IdentPat{Name: fieldPat.Name}
+			}
+			if err := g.bindLetPattern(fieldPattern, fieldValue, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	case *ast.VariantPat:
+		return unsupported("statement", "let patterns must be irrefutable; use if let or match for enum variants")
 	default:
-		return unsupported("statement", "only identifier, wildcard, and tuple let patterns are supported")
+		return unsupported("statement", "only identifier, wildcard, tuple, binding, and struct let patterns are supported")
 	}
 }
 
@@ -790,6 +840,57 @@ func (g *generator) extractTupleElement(tuple value, info tupleTypeInfo, index i
 	elem.gcManaged = info.elems[index] == "ptr" || elem.listElemTyp != ""
 	elem.rootPaths = g.rootPathsForType(info.elems[index])
 	return elem, nil
+}
+
+func (g *generator) validateStructLetPatternType(pattern *ast.StructPat, valueTyp string) error {
+	if pattern == nil || len(pattern.Type) == 0 {
+		return nil
+	}
+	name := pattern.Type[len(pattern.Type)-1]
+	if name == "" {
+		return nil
+	}
+	if info := g.structsByName[name]; info != nil {
+		if info.typ != valueTyp {
+			return unsupportedf("type-system", "struct pattern %q on %s", strings.Join(pattern.Type, "."), valueTyp)
+		}
+		return nil
+	}
+	resolved, ok, err := resolveAliasNamedTarget(name, g.typeEnv(), map[string]bool{})
+	if err != nil {
+		return err
+	}
+	if ok {
+		if info := g.structsByName[resolved]; info != nil && info.typ != valueTyp {
+			return unsupportedf("type-system", "struct pattern %q on %s", strings.Join(pattern.Type, "."), valueTyp)
+		}
+	}
+	return nil
+}
+
+func (g *generator) extractStructField(base value, info *structInfo, name string) (value, error) {
+	if info == nil {
+		return value{}, unsupported("type-system", "field extraction on nil struct info")
+	}
+	field, ok := info.byName[name]
+	if !ok {
+		return value{}, unsupportedf("expression", "struct %q has no field %q", info.name, name)
+	}
+	emitter := g.toOstyEmitter()
+	out := llvmExtractValue(emitter, toOstyValue(base), field.typ, field.index)
+	g.takeOstyEmitter(emitter)
+	loaded := fromOstyValue(out)
+	loaded.listElemTyp = field.listElemTyp
+	loaded.listElemString = field.listElemString
+	loaded.mapKeyTyp = field.mapKeyTyp
+	loaded.mapValueTyp = field.mapValueTyp
+	loaded.mapKeyString = field.mapKeyString
+	loaded.setElemTyp = field.setElemTyp
+	loaded.setElemString = field.setElemString
+	loaded.sourceType = field.sourceType
+	loaded.gcManaged = valueNeedsManagedRoot(loaded)
+	loaded.rootPaths = g.rootPathsForType(field.typ)
+	return loaded, nil
 }
 
 func identPatternName(p ast.Pattern) (string, error) {

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -425,3 +425,45 @@ fn main() {
 		}
 	}
 }
+
+func TestGenerateModuleLetStructPatternDestructuring(t *testing.T) {
+	src := `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+struct Pair {
+    first: Int
+    second: Int
+}
+
+struct Bucket {
+    pair: Pair
+    items: List<String>
+}
+
+fn main() {
+    let bucket @ Bucket {
+        pair: Pair { first, second },
+        items,
+    } = Bucket {
+        pair: Pair { first: 1, second: 2 },
+        items: strings.Split("pear,apple", ","),
+    }
+    println(first)
+    println(second)
+    println(items.sorted()[0])
+    println(bucket.pair.first)
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_let_struct_pattern_ir.osty")
+	for _, want := range []string{
+		"extractvalue %Bucket",
+		"extractvalue %Pair",
+		"declare ptr @osty_rt_list_sorted_string(ptr)",
+		"call ptr @osty_rt_list_sorted_string",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/let_pattern_test.go
+++ b/internal/llvmgen/let_pattern_test.go
@@ -1,0 +1,57 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateLetStructPatternDestructuring(t *testing.T) {
+	file := parseLLVMGenFile(t, `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+struct Pair {
+    first: Int
+    second: Int
+}
+
+struct Bucket {
+    pair: Pair
+    items: List<String>
+}
+
+fn main() {
+    let bucket @ Bucket {
+        pair: Pair { first, second },
+        items,
+    } = Bucket {
+        pair: Pair { first: 1, second: 2 },
+        items: strings.Split("pear,apple", ","),
+    }
+    println(first)
+    println(second)
+    println(items.sorted()[0])
+    println(bucket.pair.first)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/let_struct_pattern.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"extractvalue %Bucket",
+		"extractvalue %Pair",
+		"call ptr @osty_rt_list_sorted_string",
+		"call i32 (ptr, ...) @printf",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add recursive LLVM let-pattern binding for `name @ pattern` and struct destructuring
- preserve struct field container metadata when destructuring nested list-backed fields
- cover the new path in direct llvmgen, IR bridge, and backend binary tests

## Testing
- `go test ./internal/parser ./internal/ir ./internal/llvmgen ./internal/backend`