### PR TITLE
feat: Interface vtable Phase 6b — boxing + method dispatch

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -288,11 +288,17 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
   - Phase 6a(interface vtable scaffold)는 llvmgen 렌더러에서 구조만
     갖춘다: `%osty.iface = type { ptr, ptr }` fat-pointer 타입과
     structural match 기반으로 발견된 (impl, interface) 쌍마다
-    `@osty.vtable.<impl>__<iface>` 상수 global을 emit. Boxing과
-    method dispatch 경로는 Phase 6b+로 보류
+    `@osty.vtable.<impl>__<iface>` 상수 global을 emit
     (smoke: `TestGenerateModuleInterfaceVtableEmitted`).
+  - Phase 6b(interface boxing + vtable dispatch) 추가: `llvmType`이
+    interface를 `%osty.iface`로 반환, `emitLet`의 concrete→interface
+    경로에서 boxing (alloca + insertvalue 2회), `emitInterfaceMethodCall`
+    이 수신자가 `%osty.iface`인 call을 vtable extractvalue + getelementptr
+    + indirect call로 낮춘다. 현 Phase 6b 한계: 메서드는 non-self
+    인자 0개만 (추가 인자는 `LLVM0xx unsupported`로 바운드).
+    smoke: `TestGenerateModuleInterfaceBoxingDispatch`.
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
-    interface value의 boxing + vtable dispatch (Phase 6b+),
+    interface method의 non-self 인자 지원 (Phase 6c),
     payload-free / 비-리터럴 인자를 가진 variant call의 타입
     복원(궁극적으로는 checker 쪽 generic variant-constructor inference
     보강).

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1950,6 +1950,10 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitEnumVariantCall(call); found || err != nil {
 		return v, err
 	}
+	// Phase 6b: interface value method dispatch via `%osty.iface` vtable.
+	if v, found, err := g.emitInterfaceMethodCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitListMethodCall(call); found || err != nil {
 		return v, err
 	}
@@ -2395,4 +2399,84 @@ func (g *generator) enumVariantCallTarget(call *ast.CallExpr) (enumVariantRef, b
 	default:
 		return enumVariantRef{}, false, nil
 	}
+}
+
+// emitInterfaceMethodCall dispatches a method call whose receiver is
+// an interface value (`%osty.iface` fat pointer). The fat pointer is
+// split into (data, vtable), the correct function-pointer slot is
+// loaded from the vtable array, and the call is emitted as an
+// `indirect call` with the data pointer threaded in as `self`.
+//
+// Phase 6b scope: zero non-self arguments only. Methods carrying
+// extra parameters return `found=true` with an `unsupported`
+// diagnostic so callers know the dispatch path was recognised.
+func (g *generator) emitInterfaceMethodCall(call *ast.CallExpr) (value, bool, error) {
+	fx, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || fx == nil {
+		return value{}, false, nil
+	}
+	recv, err := g.emitExpr(fx.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	if recv.typ != "%osty.iface" {
+		return value{}, false, nil
+	}
+	iface, slot := g.findInterfaceMethod(fx.Name)
+	if iface == nil {
+		return value{}, true, unsupportedf("call", "no interface declares method %q", fx.Name)
+	}
+	if slot < 0 || slot >= len(iface.decl.Methods) {
+		return value{}, true, unsupportedf("call", "interface %q has no slot for %q", iface.name, fx.Name)
+	}
+	methodDecl := iface.decl.Methods[slot]
+	if methodDecl == nil || methodDecl.ReturnType == nil {
+		return value{}, true, unsupportedf("call", "interface method %q has no return type", fx.Name)
+	}
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "interface method %q with %d non-self args (Phase 6c scope)", fx.Name, len(call.Args))
+	}
+	retTyp, err := llvmType(methodDecl.ReturnType, g.typeEnv())
+	if err != nil {
+		return value{}, true, err
+	}
+	emitter := g.toOstyEmitter()
+	dataPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %%osty.iface %s, 0", dataPtr, recv.ref))
+	vtable := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %%osty.iface %s, 1", vtable, recv.ref))
+	fnPtrSlot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  %s = getelementptr [%d x ptr], ptr %s, i64 0, i64 %d",
+		fnPtrSlot, len(iface.methods), vtable, slot,
+	))
+	fnPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, fnPtrSlot))
+	ret := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  %s = call %s %s(ptr %s)",
+		ret, retTyp, fnPtr, dataPtr,
+	))
+	g.takeOstyEmitter(emitter)
+	return value{typ: retTyp, ref: ret}, true, nil
+}
+
+// findInterfaceMethod locates the (interface, slot) pair for a method
+// name across every known interface. Returns (nil, -1) when no
+// interface declares the name. Ambiguity — two different interfaces
+// declaring the same method name — picks the first match; a stricter
+// resolution (requiring the receiver's static interface type) is a
+// Phase 6c refinement.
+func (g *generator) findInterfaceMethod(name string) (*interfaceInfo, int) {
+	for _, iface := range g.interfacesByName {
+		if iface == nil {
+			continue
+		}
+		for i, m := range iface.methods {
+			if m.name == name {
+				return iface, i
+			}
+		}
+	}
+	return nil, -1
 }

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -229,6 +229,36 @@ fn main() {
 	}
 }
 
+func TestGenerateModuleInterfaceBoxingDispatch(t *testing.T) {
+	src := `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn main() {
+    let v = Vec { count: 3 }
+    let s: Sized = v
+    println(s.size())
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6b_box_dispatch.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		"@osty.vtable.Vec__Sized",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -14,6 +14,7 @@ package llvmgen
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/token"
@@ -155,11 +156,77 @@ func (g *generator) emitLet(stmt *ast.LetStmt) error {
 		if err != nil {
 			return err
 		}
+		// Phase 6b: when a let binds a concrete struct/enum value into
+		// an interface-typed slot, box it into a `{data, vtable}` fat
+		// pointer before the type-check.
+		if typ == "%osty.iface" && v.typ != "%osty.iface" {
+			boxed, boxErr := g.boxInterfaceValue(stmt.Type, v)
+			if boxErr != nil {
+				return boxErr
+			}
+			v = boxed
+		}
 		if typ != v.typ {
 			return unsupportedf("type-system", "let pattern type %s, value %s", typ, v.typ)
 		}
 	}
 	return g.bindLetPattern(stmt.Pattern, v, stmt.Mut)
+}
+
+// boxInterfaceValue synthesises the `%osty.iface` fat pointer holding
+// (data_ptr, vtable_ptr) for a concrete value assigned into an
+// interface-typed slot. The concrete value is stack-allocated with
+// `alloca`, the interface decl is resolved from `ifaceType`, and the
+// (impl, iface) vtable symbol is pulled out of `interfaceInfo.impls`.
+// Method dispatch through the boxed value is handled separately in
+// emitInterfaceMethodCall.
+func (g *generator) boxInterfaceValue(ifaceType ast.Type, v value) (value, error) {
+	ifaceName := interfaceNominalName(ifaceType)
+	if ifaceName == "" {
+		return value{}, unsupportedf("type-system", "interface target %T", ifaceType)
+	}
+	iface := g.interfacesByName[ifaceName]
+	if iface == nil {
+		return value{}, unsupportedf("type-system", "unknown interface %q", ifaceName)
+	}
+	implName := strings.TrimPrefix(v.typ, "%")
+	if implName == v.typ || implName == "" {
+		return value{}, unsupportedf("type-system", "cannot box non-aggregate value %s into interface %q", v.typ, ifaceName)
+	}
+	var vtableSym string
+	for _, impl := range iface.impls {
+		if impl.implName == implName {
+			vtableSym = impl.vtableSym
+			break
+		}
+	}
+	if vtableSym == "" {
+		return value{}, unsupportedf("type-system", "type %q does not implement interface %q", implName, ifaceName)
+	}
+	emitter := g.toOstyEmitter()
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, v.typ))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", v.typ, v.ref, slot))
+	step1 := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface undef, ptr %s, 0", step1, slot))
+	step2 := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface %s, ptr %s, 1", step2, step1, vtableSym))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "%osty.iface", ref: step2}, nil
+}
+
+// interfaceNominalName returns the single-segment interface source
+// name from a type annotation, or "" if the annotation isn't a simple
+// named interface reference.
+func interfaceNominalName(t ast.Type) string {
+	nt, ok := t.(*ast.NamedType)
+	if !ok || nt == nil {
+		return ""
+	}
+	if len(nt.Path) != 1 {
+		return ""
+	}
+	return nt.Path[0]
 }
 
 func (g *generator) emitAssign(stmt *ast.AssignStmt) error {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -81,7 +81,11 @@ func llvmRuntimeABIType(t ast.Type, env typeEnv) (string, error) {
 				enumType = info.typ
 			}
 			if env.interfaces[name] != nil {
-				return "ptr", nil
+				// Phase 6b: interface values are `%osty.iface` fat
+				// pointers (data ptr + vtable ptr). At the runtime-ABI
+				// boundary they're passed by value just like any other
+				// aggregate.
+				return "%osty.iface", nil
 			}
 		}
 		return llvmRuntimeAbiNamedType(name, len(tt.Path), len(tt.Args), structType, enumType), nil
@@ -724,7 +728,10 @@ func llvmType(t ast.Type, env typeEnv) (string, error) {
 				enumType = info.typ
 			}
 			if env.interfaces[name] != nil {
-				return "ptr", nil
+				// Phase 6b: interface values carry a `{data, vtable}`
+				// fat pointer laid out as `%osty.iface` (see
+				// renderInterfaceVtables in generator.go).
+				return "%osty.iface", nil
 			}
 		}
 		if typ := llvmNamedType(name, len(tt.Path), len(tt.Args), structType, enumType); typ != "" {


### PR DESCRIPTION
## Summary

Phase 6a(#225)의 `%osty.iface` 타입 + vtable global 토대 위에 **실제 사용 경로** 추가:
1. `let s: Sized = v`처럼 concrete struct/enum을 interface-typed let으로 받을 때 fat pointer로 **boxing**
2. Interface value에서의 method call을 vtable **indirect call**로 dispatch

Base branch는 `claude/phase6a-interface-vtable-scaffold`.

## 구현

### `internal/llvmgen/type.go`
두 곳의 interface 분기(runtime-ABI + 일반 lowering)에서 반환값을 `"ptr"` → `"%osty.iface"`로 변경. 모든 interface-typed value가 fat pointer로 통과.

### `internal/llvmgen/stmt.go`
- `emitLet`: lhs가 `%osty.iface`이고 rhs가 concrete(`%Vec` 등)이면 `boxInterfaceValue`로 fat pointer 생성 뒤 type-check.
- 신규 `boxInterfaceValue`: interface decl을 `interfacesByName`에서 resolve → `interfaceInfo.impls`에서 impl의 vtable symbol lookup → `alloca %ImplType` + `store` + `insertvalue %osty.iface …, data, 0` + `insertvalue …, vtable, 1`.

### `internal/llvmgen/expr.go`
- `emitCall` dispatch 체인에 `emitInterfaceMethodCall` 추가.
- 신규 `emitInterfaceMethodCall`: receiver의 value type이 `%osty.iface`일 때만 처리. `findInterfaceMethod`로 method name의 interface/슬롯 찾기 → `extractvalue` 2회로 (data, vtable) 분리 → `getelementptr [N x ptr]` + `load ptr`로 fn pointer 획득 → `call <ret> %fn(ptr %data)`.

## 테스트

- `internal/llvmgen/ir_module_test.go`:
  `TestGenerateModuleInterfaceBoxingDispatch` — `interface Sized { fn size(self) -> Int }` + `struct Vec { …; fn size(self) -> Int { … } }` + `let s: Sized = v; println(s.size())` 소스가 `%osty.iface`, `@osty.vtable.Vec__Sized`를 포함하는 IR을 생성함을 검증. Phase 6a의 vtable smoke도 green 유지.

## 한계 / Phase 6c+로 보류

- **Non-self 인자**: interface method에 self 외 추가 인자가 있으면 현 Phase 6b는 `unsupported (Phase 6c)`로 막는다. signature-aware arg lowering이 필요.
- **Generic interface specialization의 vtable**: Phase 5가 `_ZTSN…E`로 mangle한 interface와 Phase 6a의 vtable scaffold 통합은 별도.
- **Interface boxing의 다른 맥락**: let 외에 assign, return, 함수 인자에 대한 자동 boxing은 별도.

## Test plan

- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleInterface' -count=1` — vtable + boxing/dispatch 둘 다 pass
- [x] `go test ./internal/ir/ ./internal/llvmgen/ -run 'Monomorph|TestGenerateModuleGeneric|TestGenerateModuleMethod|TestGenerateModuleInterface' -count=1` — Phase 1-6a 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)