### PR TITLE
feat: Interface vtable Phase 6c — non-self args in method dispatch

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -294,12 +294,16 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     interface를 `%osty.iface`로 반환, `emitLet`의 concrete→interface
     경로에서 boxing (alloca + insertvalue 2회), `emitInterfaceMethodCall`
     이 수신자가 `%osty.iface`인 call을 vtable extractvalue + getelementptr
-    + indirect call로 낮춘다. 현 Phase 6b 한계: 메서드는 non-self
-    인자 0개만 (추가 인자는 `LLVM0xx unsupported`로 바운드).
+    + indirect call로 낮춘다.
     smoke: `TestGenerateModuleInterfaceBoxingDispatch`.
+  - Phase 6c(interface method의 non-self 인자): `methodDecl.Params`의
+    user-facing 파라미터를 `llvmType`으로 개별 lower하고 `emitExpr`로
+    argument value를 만들어 indirect call에 `ptr %data, <argTyp> %arg…`
+    형태로 threading. smoke: `TestGenerateModuleInterfaceDispatchWithArgs`.
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
-    interface method의 non-self 인자 지원 (Phase 6c),
-    payload-free / 비-리터럴 인자를 가진 variant call의 타입
+    generic interface specialization의 vtable 연결 (Phase 5 `_ZTSN…E` +
+    Phase 6a scaffold), let 외 context(assign/return/fn arg)의 자동
+    boxing, payload-free / 비-리터럴 인자를 가진 variant call의 타입
     복원(궁극적으로는 checker 쪽 generic variant-constructor inference
     보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2433,8 +2433,36 @@ func (g *generator) emitInterfaceMethodCall(call *ast.CallExpr) (value, bool, er
 	if methodDecl == nil || methodDecl.ReturnType == nil {
 		return value{}, true, unsupportedf("call", "interface method %q has no return type", fx.Name)
 	}
-	if len(call.Args) != 0 {
-		return value{}, true, unsupportedf("call", "interface method %q with %d non-self args (Phase 6c scope)", fx.Name, len(call.Args))
+	// Phase 6c: interface method params are lowered individually and
+	// threaded into the indirect call as extra LLVM arguments. The
+	// receiver slot is carried by `FnDecl.Recv` (not `Params`), so
+	// `methodDecl.Params` already lists the non-self user-facing args
+	// 1:1 with `call.Args`.
+	nonSelfParams := methodDecl.Params
+	if len(nonSelfParams) != len(call.Args) {
+		return value{}, true, unsupportedf("call",
+			"interface method %q expects %d non-self args, got %d",
+			fx.Name, len(nonSelfParams), len(call.Args))
+	}
+	argPairs := make([][2]string, 0, len(nonSelfParams))
+	for i, p := range nonSelfParams {
+		if p == nil || p.Type == nil {
+			return value{}, true, unsupportedf("call", "interface method %q arg %d has no type", fx.Name, i)
+		}
+		paramTyp, err := llvmType(p.Type, g.typeEnv())
+		if err != nil {
+			return value{}, true, err
+		}
+		av, err := g.emitExpr(call.Args[i].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		if av.typ != paramTyp {
+			return value{}, true, unsupportedf("call",
+				"interface method %q arg %d: expected %s, got %s",
+				fx.Name, i, paramTyp, av.typ)
+		}
+		argPairs = append(argPairs, [2]string{paramTyp, av.ref})
 	}
 	retTyp, err := llvmType(methodDecl.ReturnType, g.typeEnv())
 	if err != nil {
@@ -2452,10 +2480,14 @@ func (g *generator) emitInterfaceMethodCall(call *ast.CallExpr) (value, bool, er
 	))
 	fnPtr := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, fnPtrSlot))
+	callArgList := fmt.Sprintf("ptr %s", dataPtr)
+	for _, p := range argPairs {
+		callArgList += fmt.Sprintf(", %s %s", p[0], p[1])
+	}
 	ret := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = call %s %s(ptr %s)",
-		ret, retTyp, fnPtr, dataPtr,
+		"  %s = call %s %s(%s)",
+		ret, retTyp, fnPtr, callArgList,
 	))
 	g.takeOstyEmitter(emitter)
 	return value{typ: retTyp, ref: ret}, true, nil

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -259,6 +259,46 @@ fn main() {
 	}
 }
 
+// TestGenerateModuleInterfaceDispatchWithArgs covers Phase 6c: an
+// interface method taking non-self arguments is lowered to an
+// indirect vtable call that threads those arguments through.
+func TestGenerateModuleInterfaceDispatchWithArgs(t *testing.T) {
+	src := `interface Combine {
+    fn combine(self, other: Int) -> Int
+}
+
+struct Thing {
+    x: Int,
+
+    fn combine(self, other: Int) -> Int {
+        self.x + other
+    }
+}
+
+fn main() {
+    let t = Thing { x: 3 }
+    let c: Combine = t
+    println(c.combine(4))
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6c_iface_args.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		"@osty.vtable.Thing__Combine",
+		"ptr @Thing__combine",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	// The indirect call must carry both the data ptr (self) and the
+	// non-self arg. The exact SSA name of the fn ptr is implementation
+	// detail, so we only assert on the shape near the call site.
+	if !strings.Contains(got, ", i64 4)") {
+		t.Fatalf("expected non-self arg `i64 4` threaded into indirect call:\n%s", got)
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call


### PR DESCRIPTION
## Summary

Phase 6b(#228)의 indirect-call 경로가 self 하나만 받던 제한을 해제. 이제 interface method signature에 선언된 추가 파라미터들을 일반 call 인자와 1:1 매칭해 indirect call에 threading. Base branch는 `claude/phase6b-interface-boxing-dispatch`.

## 구현

- `internal/llvmgen/expr.go` `emitInterfaceMethodCall`:
  - 기존의 `len(call.Args) != 0 ⇒ unsupported` 가드 제거.
  - `methodDecl.Params` (AST상 이미 self를 포함하지 않음 — `FnDecl.Recv`가 self를 별도로 소유) 를 그대로 순회해 각 파라미터 타입을 `llvmType`으로 lower.
  - call.Args 개수가 signature의 non-self 파라미터 수와 일치하지 않으면 `unsupported`.
  - 각 arg를 `emitExpr`로 값화 → 타입 불일치 시 `unsupported` (암묵 cast는 Phase 6d+).
  - 최종 indirect call 라인이 `ptr %data, <t0> %a0, <t1> %a1, …` 형태가 되도록 `callArgList` 조립.

## 테스트

- `internal/llvmgen/ir_module_test.go`:
  `TestGenerateModuleInterfaceDispatchWithArgs` —
  `interface Combine { fn combine(self, other: Int) -> Int }` + `struct Thing { …; fn combine(self, other: Int) -> Int { self.x + other } }` + `let c: Combine = t; println(c.combine(4))` 소스가 `%osty.iface`, `@osty.vtable.Thing__Combine`, `ptr @Thing__combine` 심볼과 `i64 4` arg를 indirect call에 emit함을 검증.

## Phase 6d+로 보류

- 암묵 타입 변환 (`Int` literal → `Int32` param 등)
- Generic interface specialization과 scaffold 통합
- let 외 context(assign/return/fn 파라미터)의 자동 boxing

## Test plan

- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleInterface' -count=1` — vtable + boxing/dispatch + args 3건 pass
- [x] `go test ./internal/ir/ ./internal/llvmgen/ -run 'Monomorph|TestGenerateModuleGeneric|TestGenerateModuleMethod|TestGenerateModuleInterface' -count=1` — Phase 1-6b 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)