### PR TITLE
Make airepair automatic before parsing

### DIFF
--- a/LANG_SPEC_v0.4/13-tooling.md
+++ b/LANG_SPEC_v0.4/13-tooling.md
@@ -48,6 +48,13 @@ switches are not part of the public CLI contract. `run` requires a host
 binary and rejects cross-target execution. Native `osty test`
 execution is still pending.
 
+Front-end-bearing commands (`check`, `resolve`, `typecheck`, `lint`,
+`build`, `run`, `test`, and `gen`) apply the in-memory `airepair`
+adaptation pass by default before parsing so AI-authored foreign syntax
+is normalized without requiring an explicit opt-in flag. Debugging flags
+may narrow or disable that behavior, but the default user contract is
+best-effort automatic adaptation.
+
 ### 13.2 Manifest
 
 A project is described by `osty.toml` at its root. `osty.lock` records

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Legacy alias: `osty repair`
 - `triage DIR` — summarize captured `.report.json` files by status, source habit, and residual diagnostic code
 - `promote CASE` — copy a captured case into `internal/airepair/testdata/corpus/` (override with `--dest DIR` or `--name NAME`)
 - `--stdin-name NAME` — filename to use in reports when reading from stdin via `-`
-- `--mode rewrite|parse|frontend` — choose whether airepair scores candidate output by rewrite activity, parse diagnostics, or full front-end diagnostics
+- `--mode auto|rewrite|parse|frontend` — debug acceptance mode; `auto` is the default best-effort mode and should usually be left alone
 
 `osty airepair -` reads from stdin and writes the repaired source (or JSON report
 with `--json`) to stdout.
@@ -297,14 +297,18 @@ For quick triage, `osty airepair triage tmp/airepair-cases`
 To promote one captured case into the checked-in corpus, `osty airepair promote tmp/airepair-cases/python_enumerate_case`
 
 Single-file `osty check`, `osty resolve`, `osty typecheck`, and `osty lint`
-also accept in-memory adaptation flags after the subcommand:
+run airepair in memory by default before parsing. You can still tune or disable it
+after the subcommand:
 
-- `--airepair` — run airepair before the front-end pipeline without rewriting the file
-- `--airepair-mode rewrite|parse|frontend` — choose the acceptance heuristic for the adapted source
+- `--airepair` — keep the default automatic in-memory airepair enabled
+- `--no-airepair` — disable automatic in-memory airepair for debugging/raw parser behavior
+- `--airepair-mode auto|rewrite|parse|frontend` — debug acceptance mode; `auto` is the default
 
 The manifest-driven `osty build`, `osty run`, and `osty test` commands also
-accept `--airepair` and `--airepair-mode ...`; those rewrites stay in memory
-unless you explicitly run `osty airepair --write`.
+run airepair in memory by default before any parser / resolver / checker work.
+Use `--airepair=false` to disable it or `--airepair-mode auto|rewrite|parse|frontend`
+to debug the acceptance heuristic. `osty gen` now uses the same automatic
+best-effort in-memory airepair path before loading package sources.
 
 Repairs include common foreign-language carryovers such as `func`/`def`,
 `var`/`const`, `while`, `switch`/`case`, `nil`/`null`, Python word

--- a/cmd/osty/airepair.go
+++ b/cmd/osty/airepair.go
@@ -29,13 +29,13 @@ func runAIRepairMain(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 	fs := flag.NewFlagSet("airepair", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: osty airepair [--check] [--write] [--json] [--capture-dir DIR] [--capture-name NAME] [--capture-if residual|changed|always] [--stdin-name NAME] [--mode rewrite|parse|frontend] FILE|-")
+		fmt.Fprintln(stderr, "usage: osty airepair [--check] [--write] [--json] [--capture-dir DIR] [--capture-name NAME] [--capture-if residual|changed|always] [--stdin-name NAME] [--mode auto|rewrite|parse|frontend] FILE|-")
 		fmt.Fprintln(stderr, "       osty airepair triage [--top N] DIR")
 		fmt.Fprintln(stderr, "       osty airepair promote [--dest DIR] [--name NAME] CASE")
 	}
 	var checkMode, writeMode, jsonMode bool
 	stdinName := "<stdin>"
-	modeName := string(airepair.ModeFrontEndAssist)
+	modeName := string(airepair.ModeAutoAssist)
 	captureDir := ""
 	captureName := ""
 	captureModeName := string(aiRepairCaptureResidual)
@@ -48,7 +48,7 @@ func runAIRepairMain(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 	fs.StringVar(&captureName, "capture-name", captureName, "basename for captured airepair artifacts")
 	fs.StringVar(&captureModeName, "capture-if", captureModeName, "capture when residual, changed, or always")
 	fs.StringVar(&stdinName, "stdin-name", stdinName, "filename to use in reports when reading from stdin")
-	fs.StringVar(&modeName, "mode", modeName, "acceptance mode (rewrite, parse, frontend)")
+	fs.StringVar(&modeName, "mode", modeName, "debug acceptance mode (auto, rewrite, parse, frontend)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -73,7 +73,7 @@ func runAIRepairMain(args []string, stdin io.Reader, stdout, stderr io.Writer) i
 
 	mode, ok := parseAIRepairMode(modeName)
 	if !ok {
-		fmt.Fprintf(stderr, "osty airepair: unknown mode %q (want rewrite, parse, or frontend)\n", modeName)
+		fmt.Fprintf(stderr, "osty airepair: unknown mode %q (want auto, rewrite, parse, or frontend)\n", modeName)
 		return 2
 	}
 	captureMode, ok := parseAIRepairCaptureMode(captureModeName)
@@ -174,11 +174,13 @@ func reportRepairSummary(w io.Writer, prefix, path string, res repair.Result) {
 
 func parseAIRepairMode(value string) (airepair.Mode, bool) {
 	switch value {
+	case "", string(airepair.ModeAutoAssist):
+		return airepair.ModeAutoAssist, true
 	case string(airepair.ModeRewriteOnly):
 		return airepair.ModeRewriteOnly, true
 	case string(airepair.ModeParseAssist):
 		return airepair.ModeParseAssist, true
-	case "", string(airepair.ModeFrontEndAssist):
+	case string(airepair.ModeFrontEndAssist):
 		return airepair.ModeFrontEndAssist, true
 	default:
 		return "", false
@@ -186,10 +188,10 @@ func parseAIRepairMode(value string) (airepair.Mode, bool) {
 }
 
 func registerAIRepairCommandFlags(fs *flag.FlagSet, enabled *bool, mode *string) {
-	fs.BoolVar(enabled, "airepair", false, "adapt common AI-authored foreign syntax in memory")
-	fs.BoolVar(enabled, "repair", false, "alias for --airepair")
-	fs.StringVar(mode, "airepair-mode", string(airepair.ModeFrontEndAssist), "acceptance mode (rewrite, parse, or frontend)")
-	fs.StringVar(mode, "repair-mode", string(airepair.ModeFrontEndAssist), "alias for --airepair-mode")
+	fs.BoolVar(enabled, "airepair", true, "adapt common AI-authored foreign syntax in memory (enabled by default)")
+	fs.BoolVar(enabled, "repair", true, "alias for --airepair")
+	fs.StringVar(mode, "airepair-mode", string(airepair.ModeAutoAssist), "debug acceptance mode (auto, rewrite, parse, or frontend)")
+	fs.StringVar(mode, "repair-mode", string(airepair.ModeAutoAssist), "alias for --airepair-mode")
 }
 
 func readAIRepairInput(path string, stdin io.Reader, stdinName string) (string, []byte, error) {

--- a/cmd/osty/airepair_test.go
+++ b/cmd/osty/airepair_test.go
@@ -125,7 +125,7 @@ func TestUsageOutputUsesCanonicalAIRepairNames(t *testing.T) {
 		if got.exit != 2 {
 			t.Fatalf("osty repair exit = %d, want 2\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
 		}
-		if !strings.Contains(got.stderr, "usage: osty airepair [--check] [--write] [--json] [--capture-dir DIR] [--capture-name NAME] [--capture-if residual|changed|always] [--stdin-name NAME] [--mode rewrite|parse|frontend] FILE|-") {
+		if !strings.Contains(got.stderr, "usage: osty airepair [--check] [--write] [--json] [--capture-dir DIR] [--capture-name NAME] [--capture-if residual|changed|always] [--stdin-name NAME] [--mode auto|rewrite|parse|frontend] FILE|-") {
 			t.Fatalf("stderr = %q, want canonical airepair subcommand usage", got.stderr)
 		}
 		if !strings.Contains(got.stderr, "osty airepair triage [--top N] DIR") {
@@ -184,8 +184,8 @@ func TestAIRepairJSONReportFromStdin(t *testing.T) {
 	if report.Filename != "agent.osty" {
 		t.Fatalf("filename = %q, want agent.osty", report.Filename)
 	}
-	if report.Mode != "frontend" {
-		t.Fatalf("mode = %q, want frontend", report.Mode)
+	if report.Mode != "auto" {
+		t.Fatalf("mode = %q, want auto", report.Mode)
 	}
 	if report.Status != "repaired_clean" {
 		t.Fatalf("status = %q, want repaired_clean", report.Status)
@@ -448,14 +448,14 @@ func TestCheckWithAIRepairPassesForeignSyntax(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 1 repair(s)") {
 		t.Fatalf("stderr = %q, want in-memory airepair summary", with.stderr)
@@ -470,14 +470,14 @@ func TestCheckWithAIRepairPassesPythonStyleBlocks(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 2 repair(s)") {
 		t.Fatalf("stderr = %q, want multi-phase airepair summary", with.stderr)
@@ -492,14 +492,14 @@ func TestCheckWithAIRepairPassesPythonElifBlocks(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 3 repair(s)") {
 		t.Fatalf("stderr = %q, want multi-phase elif airepair summary", with.stderr)
@@ -514,14 +514,14 @@ func TestCheckWithAIRepairPassesPythonBareTupleForBlocks(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 2 repair(s)") {
 		t.Fatalf("stderr = %q, want tuple-loop airepair summary", with.stderr)
@@ -536,14 +536,14 @@ func TestCheckWithAIRepairPassesJSForOfLoops(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 1 repair(s)") {
 		t.Fatalf("stderr = %q, want JS for-of airepair summary", with.stderr)
@@ -558,14 +558,14 @@ func TestCheckWithAIRepairPassesJSDestructuringForOfLoops(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 1 repair(s)") {
 		t.Fatalf("stderr = %q, want JS destructuring for-of airepair summary", with.stderr)
@@ -580,14 +580,14 @@ func TestCheckWithAIRepairPassesPythonRangeLoops(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 2 repair(s)") {
 		t.Fatalf("stderr = %q, want Python range airepair summary", with.stderr)
@@ -602,14 +602,14 @@ func TestResolveWithAIRepairPassesPythonEnumerateLoops(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "resolve", path)
+	without := runOstyCLI(t, "resolve", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("resolve without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("resolve --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "resolve", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "resolve", path)
 	if with.exit != 0 {
-		t.Fatalf("resolve --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("resolve auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty resolve --airepair: applied 2 repair(s)") {
 		t.Fatalf("stderr = %q, want Python enumerate airepair summary", with.stderr)
@@ -624,14 +624,14 @@ func TestCheckWithAIRepairPassesPythonMatchCaseBlocks(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
-	without := runOstyCLI(t, "check", path)
+	without := runOstyCLI(t, "check", "--no-airepair", path)
 	if without.exit == 0 {
-		t.Fatalf("check without airepair exit = %d, want non-zero parse failure", without.exit)
+		t.Fatalf("check --no-airepair exit = %d, want non-zero parse failure", without.exit)
 	}
 
-	with := runOstyCLI(t, "check", "--airepair", "--airepair-mode=parse", path)
+	with := runOstyCLI(t, "check", path)
 	if with.exit != 0 {
-		t.Fatalf("check --airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
+		t.Fatalf("check auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", with.exit, with.stdout, with.stderr)
 	}
 	if !strings.Contains(with.stderr, "osty check --airepair: applied 6 repair(s)") {
 		t.Fatalf("stderr = %q, want multi-phase match/case airepair summary", with.stderr)

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -45,7 +45,7 @@ import (
 func runBuild(args []string, flags cliFlags) {
 	fs := flag.NewFlagSet("build", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty build [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [--force] [--airepair] [--airepair-mode MODE] [PATH]")
+		fmt.Fprintln(os.Stderr, "usage: osty build [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [--force] [--airepair=false] [--airepair-mode MODE] [PATH]")
 	}
 	var offline, force, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
@@ -63,7 +63,7 @@ func runBuild(args []string, flags cliFlags) {
 	_ = fs.Parse(args)
 	mode, ok := parseAIRepairMode(aiRepairModeName)
 	if !ok {
-		fmt.Fprintf(os.Stderr, "osty build: unknown airepair mode %q (want rewrite, parse, or frontend)\n", aiRepairModeName)
+		fmt.Fprintf(os.Stderr, "osty build: unknown airepair mode %q (want auto, rewrite, parse, or frontend)\n", aiRepairModeName)
 		os.Exit(2)
 	}
 	flags.aiMode = mode
@@ -287,6 +287,7 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}
+	ws.SourceTransform = aiRepairSourceTransform("osty build --airepair", os.Stderr, flags)
 	ws.Stdlib = stdlib.Load()
 	ws.Deps = deps
 	if m.HasPackage {
@@ -296,16 +297,6 @@ func buildWorkspace(dir string, m *manifest.Manifest, flags cliFlags, deps resol
 		if _, err := ws.LoadPackage(mem); err != nil {
 			fmt.Fprintf(os.Stderr, "osty build: member %s: %v\n", mem, err)
 			os.Exit(1)
-		}
-	}
-	if flags.aiRepair {
-		paths := make([]string, 0, len(ws.Packages))
-		for p := range ws.Packages {
-			paths = append(paths, p)
-		}
-		sort.Strings(paths)
-		for _, p := range paths {
-			applyAIRepairToPackage(ws.Packages[p], "osty build --airepair", os.Stderr, flags)
 		}
 	}
 	results := ws.ResolveAll()
@@ -360,21 +351,12 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 			fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 			os.Exit(1)
 		}
+		ws.SourceTransform = aiRepairSourceTransform("osty build --airepair", os.Stderr, flags)
 		ws.Stdlib = stdlib.Load()
 		ws.Deps = deps
 		if _, err := ws.LoadPackage(""); err != nil {
 			fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 			os.Exit(1)
-		}
-		if flags.aiRepair {
-			paths := make([]string, 0, len(ws.Packages))
-			for p := range ws.Packages {
-				paths = append(paths, p)
-			}
-			sort.Strings(paths)
-			for _, p := range paths {
-				applyAIRepairToPackage(ws.Packages[p], "osty build --airepair", os.Stderr, flags)
-			}
 		}
 		results := ws.ResolveAll()
 		checks := check.Workspace(ws, results, checkOpts())
@@ -398,12 +380,11 @@ func buildPackage(dir string, m *manifest.Manifest, flags cliFlags, deps resolve
 		}
 		return nil
 	}
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform("osty build --airepair", os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}
-	applyAIRepairToPackage(pkg, "osty build --airepair", os.Stderr, flags)
 	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	chk := check.Package(pkg, res, checkOpts())
 	ds := append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -350,17 +350,12 @@ func main() {
 	}
 
 	if cmd == "check" || cmd == "typecheck" || cmd == "resolve" {
-		selected, handled, err := loadSelectedPackageEntry(path)
+		selected, handled, err := loadSelectedPackageEntryWithTransform(path, aiRepairSourceTransform(aiRepairPrefix(cmd), os.Stderr, flags))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 			os.Exit(1)
 		}
 		if handled {
-			if flags.aiRepair {
-				applyAIRepairToPackage(selected.pkg, aiRepairPrefix(cmd), os.Stderr, flags)
-				selected.res = resolve.ResolvePackage(selected.pkg, resolve.NewPrelude())
-				selected.chk = check.Package(selected.pkg, selected.res, checkOpts())
-			}
 			if flags.trace {
 				pipeline.RunLoadedPackage(selected.pkg, os.Stderr, pipeline.Config{})
 			}
@@ -592,12 +587,11 @@ func runCheckPackage(dir string, flags cliFlags) {
 		runCheckWorkspace(dir, flags)
 		return
 	}
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("check"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	applyAIRepairToPackage(pkg, aiRepairPrefix("check"), os.Stderr, flags)
 	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	chk := check.Package(pkg, res, checkOpts())
 	diags := append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...)
@@ -641,6 +635,7 @@ func runCheckWorkspace(dir string, flags cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
+	ws.SourceTransform = aiRepairSourceTransform(aiRepairPrefix("check"), os.Stderr, flags)
 	ws.Stdlib = stdlib.LoadCached()
 	// Seed the loader with the root package (if any) plus every
 	// immediate subdirectory that contains .osty files. LoadPackage
@@ -648,16 +643,6 @@ func runCheckWorkspace(dir string, flags cliFlags) {
 	// pulled in lazily.
 	for _, p := range resolve.WorkspacePackagePaths(dir) {
 		_, _ = ws.LoadPackage(p)
-	}
-	if flags.aiRepair {
-		paths := make([]string, 0, len(ws.Packages))
-		for p := range ws.Packages {
-			paths = append(paths, p)
-		}
-		sort.Strings(paths)
-		for _, p := range paths {
-			applyAIRepairToPackage(ws.Packages[p], aiRepairPrefix("check"), os.Stderr, flags)
-		}
 	}
 	results := ws.ResolveAll()
 	// Run the type checker over every package, producing one Result per
@@ -705,12 +690,11 @@ func runLintPackage(dir string, flags cliFlags) {
 		runLintWorkspace(dir, flags)
 		return
 	}
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("lint"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	applyAIRepairToPackage(pkg, aiRepairPrefix("lint"), os.Stderr, flags)
 	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	chk := check.Package(pkg, res, checkOpts())
 	cfg, cfgBase, hasCfg := loadLintConfigWithBase(dir)
@@ -728,6 +712,7 @@ func runLintWorkspace(dir string, flags cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
+	ws.SourceTransform = aiRepairSourceTransform(aiRepairPrefix("lint"), os.Stderr, flags)
 	ws.Stdlib = stdlib.LoadCached()
 	anyErr, anyWarn := false, false
 	runOne := func(path string) {
@@ -737,7 +722,6 @@ func runLintWorkspace(dir string, flags cliFlags) {
 			anyErr = true
 			return
 		}
-		applyAIRepairToPackage(pkg, aiRepairPrefix("lint"), os.Stderr, flags)
 		res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 		chk := check.Package(pkg, res, checkOpts())
 		cfg, cfgBase, hasCfg := loadLintConfigWithBase(pkg.Dir)
@@ -782,12 +766,11 @@ func runLintLoadedPackage(
 
 // runResolvePackage is runCheckPackage plus a resolution dump per file.
 func runResolvePackage(dir string, flags cliFlags) {
-	pkg, err := resolve.LoadPackage(dir)
+	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("resolve"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	applyAIRepairToPackage(pkg, aiRepairPrefix("resolve"), os.Stderr, flags)
 	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	printPackageDiags(pkg, res.Diags, flags)
 	for _, f := range pkg.Files {
@@ -1082,8 +1065,9 @@ func usesFrontEndAIRepair(cmd string) bool {
 
 func consumeFrontEndAIRepairFlags(args []string, flags cliFlags) ([]string, cliFlags, error) {
 	rest := make([]string, 0, len(args))
+	flags.aiRepair = true
 	if flags.aiMode == "" {
-		flags.aiMode = airepair.ModeFrontEndAssist
+		flags.aiMode = airepair.ModeAutoAssist
 	}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -1112,7 +1096,7 @@ func consumeFrontEndAIRepairFlags(args []string, flags cliFlags) ([]string, cliF
 			}
 			mode, ok := parseAIRepairMode(args[i+1])
 			if !ok {
-				return nil, flags, fmt.Errorf("unknown airepair mode %q (want rewrite, parse, or frontend)", args[i+1])
+				return nil, flags, fmt.Errorf("unknown airepair mode %q (want auto, rewrite, parse, or frontend)", args[i+1])
 			}
 			flags.aiMode = mode
 			i++
@@ -1120,14 +1104,14 @@ func consumeFrontEndAIRepairFlags(args []string, flags cliFlags) ([]string, cliF
 			value := strings.TrimPrefix(arg, "--airepair-mode=")
 			mode, ok := parseAIRepairMode(value)
 			if !ok {
-				return nil, flags, fmt.Errorf("unknown airepair mode %q (want rewrite, parse, or frontend)", value)
+				return nil, flags, fmt.Errorf("unknown airepair mode %q (want auto, rewrite, parse, or frontend)", value)
 			}
 			flags.aiMode = mode
 		case strings.HasPrefix(arg, "--repair-mode="):
 			value := strings.TrimPrefix(arg, "--repair-mode=")
 			mode, ok := parseAIRepairMode(value)
 			if !ok {
-				return nil, flags, fmt.Errorf("unknown airepair mode %q (want rewrite, parse, or frontend)", value)
+				return nil, flags, fmt.Errorf("unknown airepair mode %q (want auto, rewrite, parse, or frontend)", value)
 			}
 			flags.aiMode = mode
 		default:
@@ -1139,6 +1123,15 @@ func consumeFrontEndAIRepairFlags(args []string, flags cliFlags) ([]string, cliF
 
 func aiRepairPrefix(cmd string) string {
 	return fmt.Sprintf("osty %s --airepair", cmd)
+}
+
+func aiRepairSourceTransform(prefix string, summary io.Writer, flags cliFlags) resolve.SourceTransform {
+	if !flags.aiRepair {
+		return nil
+	}
+	return func(path string, src []byte) []byte {
+		return maybeAIRepairSource(path, src, prefix, summary, flags)
+	}
 }
 
 func maybeAIRepairSource(path string, src []byte, prefix string, summary io.Writer, flags cliFlags) []byte {
@@ -1157,35 +1150,6 @@ func maybeAIRepairSource(path string, src []byte, prefix string, summary io.Writ
 		return result.Repaired
 	}
 	return src
-}
-
-func applyAIRepairToPackage(pkg *resolve.Package, prefix string, summary io.Writer, flags cliFlags) {
-	if !flags.aiRepair || pkg == nil {
-		return
-	}
-	for _, pf := range pkg.Files {
-		if pf == nil {
-			continue
-		}
-		result := airepair.Analyze(airepair.Request{
-			Source:   pf.Source,
-			Filename: pf.Path,
-			Mode:     flags.aiMode,
-		})
-		if !flags.jsonOutput && result.Accepted && (len(result.Repair.Changes) > 0 || result.Repair.Skipped > 0) {
-			reportRepairSummary(summary, prefix, pf.Path, result.Repair)
-		}
-		if !result.Accepted || !result.Changed {
-			continue
-		}
-		file, parseDiags := parser.ParseDiagnostics(result.Repaired)
-		pf.Source = result.Repaired
-		pf.File = file
-		pf.ParseDiags = parseDiags
-		pf.FileScope = nil
-		pf.Refs = nil
-		pf.TypeRefs = nil
-	}
 }
 
 // loadLintConfigWithBase is loadLintConfigNear that also returns the
@@ -1408,10 +1372,11 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --dest DIR         promote: destination corpus directory")
 	fmt.Fprintln(os.Stderr, "  --name NAME        promote: basename for promoted corpus files")
 	fmt.Fprintln(os.Stderr, "  --stdin-name NAME  filename to use in reports when FILE is -")
-	fmt.Fprintln(os.Stderr, "  --mode MODE        acceptance mode: rewrite, parse, or frontend")
+	fmt.Fprintln(os.Stderr, "  --mode MODE        debug acceptance mode: auto, rewrite, parse, or frontend")
 	fmt.Fprintln(os.Stderr, "front-end airepair flags (after check/resolve/typecheck/lint):")
-	fmt.Fprintln(os.Stderr, "  --airepair         adapt common AI-authored foreign syntax in memory")
-	fmt.Fprintln(os.Stderr, "  --airepair-mode    acceptance mode: rewrite, parse, or frontend")
+	fmt.Fprintln(os.Stderr, "  --airepair         keep automatic AI repair enabled (default)")
+	fmt.Fprintln(os.Stderr, "  --no-airepair      disable automatic AI repair")
+	fmt.Fprintln(os.Stderr, "  --airepair-mode    debug acceptance mode: auto, rewrite, parse, or frontend")
 	fmt.Fprintln(os.Stderr, "gen-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  -o PATH            write generated artifact to PATH instead of stdout")
 	fmt.Fprintln(os.Stderr, "  --package NAME     backend package/module name (default: main)")
@@ -1613,7 +1578,11 @@ func runGen(args []string, flags cliFlags) {
 		os.Exit(2)
 	}
 	path := fs.Arg(0)
-	entry, err := loadGenPackageEntry(path)
+	flags.aiRepair = true
+	if flags.aiMode == "" {
+		flags.aiMode = airepair.ModeAutoAssist
+	}
+	entry, err := loadGenPackageEntryWithTransform(path, aiRepairSourceTransform("osty gen --airepair", os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty gen: %v\n", err)
 		os.Exit(1)
@@ -1721,17 +1690,22 @@ type genPackageEntry struct {
 }
 
 func loadGenPackageEntry(path string) (*genPackageEntry, error) {
+	return loadGenPackageEntryWithTransform(path, nil)
+}
+
+func loadGenPackageEntryWithTransform(path string, transform resolve.SourceTransform) (*genPackageEntry, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
 	if files := toolchainGenInputFiles(absPath); len(files) > 0 {
-		return loadSelectedGenFiles(absPath, files)
+		return loadSelectedGenFilesWithTransform(absPath, files, transform)
 	}
 	ws, err := resolve.NewWorkspace(filepath.Dir(absPath))
 	if err != nil {
 		return nil, err
 	}
+	ws.SourceTransform = transform
 	ws.Stdlib = stdlib.LoadCached()
 	if _, err := ws.LoadPackage(""); err != nil {
 		return nil, err
@@ -1777,6 +1751,10 @@ func loadGenPackageEntry(path string) (*genPackageEntry, error) {
 }
 
 func loadSelectedGenFiles(sourcePath string, files []string) (*genPackageEntry, error) {
+	return loadSelectedGenFilesWithTransform(sourcePath, files, nil)
+}
+
+func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transform resolve.SourceTransform) (*genPackageEntry, error) {
 	pkgDir := filepath.Dir(sourcePath)
 	pkg := &resolve.Package{
 		Dir:  pkgDir,
@@ -1789,6 +1767,9 @@ func loadSelectedGenFiles(sourcePath string, files []string) (*genPackageEntry, 
 		src, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
+		}
+		if transform != nil {
+			src = transform(path, src)
 		}
 		file, parseDiags := parser.ParseDiagnostics(src)
 		pf := &resolve.PackageFile{

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/airepair"
 	"github.com/osty/osty/internal/diag"
 )
 
@@ -100,6 +102,26 @@ func TestSplitGenCheckDiagsDefersUnavailableChecker(t *testing.T) {
 	}
 	if len(deferredDiags) != 1 || deferredDiags[0] != unavailable {
 		t.Fatalf("deferred diags = %#v, want only the unavailable checker diag", deferredDiags)
+	}
+}
+
+func TestLoadGenPackageEntryWithTransformRepairsForeignSyntax(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", "func main() -> Int { 1 }\n")
+
+	flags := cliFlags{aiRepair: true, aiMode: airepair.ModeAutoAssist}
+	entry, err := loadGenPackageEntryWithTransform(target, aiRepairSourceTransform("osty gen --airepair", io.Discard, flags))
+	if err != nil {
+		t.Fatalf("loadGenPackageEntryWithTransform() error = %v", err)
+	}
+	if entry == nil || entry.file == nil {
+		t.Fatal("expected a loaded gen package entry")
+	}
+	if got, want := string(entry.file.Source), "fn main() -> Int { 1 }\n"; got != want {
+		t.Fatalf("entry source = %q, want %q", got, want)
+	}
+	if hasError(entry.res.Diags) {
+		t.Fatalf("resolve diags = %#v, want no blocking front-end errors after airepair", entry.res.Diags)
 	}
 }
 

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 
 	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/check"
@@ -48,7 +47,7 @@ import (
 func runRun(args []string, cliF cliFlags) {
 	fs := flag.NewFlagSet("run", flag.ExitOnError)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: osty run [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [--airepair] [--airepair-mode MODE] [-- ARGS...]")
+		fmt.Fprintln(os.Stderr, "usage: osty run [--offline | --locked | --frozen] [--profile NAME | --release] [--target TRIPLE] [--features LIST] [--no-default-features] [--backend NAME] [--emit MODE] [--airepair=false] [--airepair-mode MODE] [-- ARGS...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
@@ -65,7 +64,7 @@ func runRun(args []string, cliF cliFlags) {
 	_ = fs.Parse(args)
 	mode, ok := parseAIRepairMode(aiRepairModeName)
 	if !ok {
-		fmt.Fprintf(os.Stderr, "osty run: unknown airepair mode %q (want rewrite, parse, or frontend)\n", aiRepairModeName)
+		fmt.Fprintf(os.Stderr, "osty run: unknown airepair mode %q (want auto, rewrite, parse, or frontend)\n", aiRepairModeName)
 		os.Exit(2)
 	}
 	cliF.aiMode = mode
@@ -131,22 +130,13 @@ func runRun(args []string, cliF cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
 	}
+	ws.SourceTransform = aiRepairSourceTransform("osty run --airepair", os.Stderr, cliF)
 	ws.Stdlib = stdlib.Load()
 	ws.Deps = deps
 	rootPkg, err := ws.LoadPackage("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
-	}
-	if cliF.aiRepair {
-		paths := make([]string, 0, len(ws.Packages))
-		for p := range ws.Packages {
-			paths = append(paths, p)
-		}
-		sort.Strings(paths)
-		for _, p := range paths {
-			applyAIRepairToPackage(ws.Packages[p], "osty run --airepair", os.Stderr, cliF)
-		}
 	}
 	results := ws.ResolveAll()
 	checks := check.Workspace(ws, results, checkOpts())

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -32,7 +32,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [--airepair] [--airepair-mode MODE] [PATH|FILTER...]")
+		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [--airepair=false] [--airepair-mode MODE] [PATH|FILTER...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
@@ -51,7 +51,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	}
 	mode, ok := parseAIRepairMode(aiRepairModeName)
 	if !ok {
-		fmt.Fprintf(stderr, "osty test: unknown airepair mode %q (want rewrite, parse, or frontend)\n", aiRepairModeName)
+		fmt.Fprintf(stderr, "osty test: unknown airepair mode %q (want auto, rewrite, parse, or frontend)\n", aiRepairModeName)
 		return 2
 	}
 	flags.aiMode = mode
@@ -67,12 +67,11 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	pkg, err := resolve.LoadPackageWithTests(pkgDir)
+	pkg, err := resolve.LoadPackageWithTestsTransform(pkgDir, aiRepairSourceTransform("osty test --airepair", stderr, flags))
 	if err != nil {
 		fmt.Fprintf(stderr, "osty test: %v\n", err)
 		return 1
 	}
-	applyAIRepairToPackage(pkg, "osty test --airepair", stderr, flags)
 	parseDiags := packageParseDiags(pkg)
 	if hasError(parseDiags) {
 		printPackageDiags(pkg, parseDiags, flags)

--- a/cmd/osty/test_native_test.go
+++ b/cmd/osty/test_native_test.go
@@ -230,21 +230,21 @@ func TestRunTestMainAIRepairAllowsForeignSyntaxBeforeDiscovery(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
-	if code == 0 {
-		t.Fatalf("runTestMain() without airepair exit = %d, want parse failure\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
-	}
-
-	stdout.Reset()
-	stderr.Reset()
-	code = runTestMain([]string{"--airepair", "--airepair-mode=parse", dir}, cliFlags{}, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("runTestMain() with airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+		t.Fatalf("runTestMain() auto airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}
 	if got := stdout.String(); !strings.Contains(got, "running 0 tests") {
 		t.Fatalf("stdout = %q, want zero-test summary", got)
 	}
 	if got := stderr.String(); !strings.Contains(got, "osty test --airepair: applied 1 repair(s)") {
 		t.Fatalf("stderr = %q, want in-memory airepair summary", got)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runTestMain([]string{"--airepair=false", dir}, cliFlags{}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("runTestMain() --airepair=false exit = %d, want parse failure\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
 	}
 }
 

--- a/cmd/osty/toolchain_context.go
+++ b/cmd/osty/toolchain_context.go
@@ -21,6 +21,10 @@ type selectedPackageEntry struct {
 }
 
 func loadSelectedPackageEntry(path string) (*selectedPackageEntry, bool, error) {
+	return loadSelectedPackageEntryWithTransform(path, nil)
+}
+
+func loadSelectedPackageEntryWithTransform(path string, transform resolve.SourceTransform) (*selectedPackageEntry, bool, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, false, err
@@ -29,7 +33,7 @@ func loadSelectedPackageEntry(path string) (*selectedPackageEntry, bool, error) 
 	if len(files) == 0 {
 		return nil, false, nil
 	}
-	entry, err := loadSelectedPackageFiles(absPath, files)
+	entry, err := loadSelectedPackageFilesWithTransform(absPath, files, transform)
 	if err != nil {
 		return nil, true, err
 	}
@@ -37,7 +41,11 @@ func loadSelectedPackageEntry(path string) (*selectedPackageEntry, bool, error) 
 }
 
 func loadSelectedPackageFiles(sourcePath string, files []string) (*selectedPackageEntry, error) {
-	pkg, err := resolve.LoadPackageFiles(files, stdlib.LoadCached())
+	return loadSelectedPackageFilesWithTransform(sourcePath, files, nil)
+}
+
+func loadSelectedPackageFilesWithTransform(sourcePath string, files []string, transform resolve.SourceTransform) (*selectedPackageEntry, error) {
+	pkg, err := resolve.LoadPackageFilesWithTransform(files, stdlib.LoadCached(), transform)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/airepair/airepair.go
+++ b/internal/airepair/airepair.go
@@ -24,6 +24,10 @@ type phaseFunc func(src []byte, diags []*diag.Diagnostic) repair.Result
 type Mode string
 
 const (
+	// ModeAutoAssist prioritizes parser success first, then resolve/check
+	// quality. This is the default because AI-authored mixed syntax is most
+	// useful when the source becomes front-end-runnable at all.
+	ModeAutoAssist Mode = "auto"
 	// ModeRewriteOnly runs the lexical repair phase and reports its result
 	// without treating front-end metrics as the primary objective.
 	ModeRewriteOnly Mode = "rewrite"
@@ -109,7 +113,7 @@ type ReportChange struct {
 func Analyze(req Request) Result {
 	mode := req.Mode
 	if mode == "" {
-		mode = ModeFrontEndAssist
+		mode = ModeAutoAssist
 	}
 
 	original := append([]byte(nil), req.Source...)
@@ -238,8 +242,10 @@ func isImproved(mode Mode, before, after ProbeStats, repaired repair.Result) boo
 		return len(repaired.Changes) > 0
 	case ModeParseAssist:
 		return compareParseAssist(before, after) > 0
-	default:
+	case ModeFrontEndAssist:
 		return compareFrontEndAssist(before, after) > 0
+	default:
+		return compareAutoAssist(before, after) > 0
 	}
 }
 
@@ -252,8 +258,10 @@ func isAccepted(mode Mode, before, after ProbeStats, repaired repair.Result) boo
 		return true
 	case ModeParseAssist:
 		return compareParseAssist(before, after) >= 0
-	default:
+	case ModeFrontEndAssist:
 		return compareFrontEndAssist(before, after) >= 0
+	default:
+		return compareAutoAssist(before, after) >= 0
 	}
 }
 
@@ -271,6 +279,34 @@ func compareParseAssist(before, after ProbeStats) int {
 	}
 	if after.TotalErrors != before.TotalErrors {
 		if after.TotalErrors < before.TotalErrors {
+			return 1
+		}
+		return -1
+	}
+	if after.TotalWarnings != before.TotalWarnings {
+		if after.TotalWarnings < before.TotalWarnings {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+func compareAutoAssist(before, after ProbeStats) int {
+	if after.Parse.Errors != before.Parse.Errors {
+		if after.Parse.Errors < before.Parse.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.Resolve.Errors != before.Resolve.Errors {
+		if after.Resolve.Errors < before.Resolve.Errors {
+			return 1
+		}
+		return -1
+	}
+	if after.Check.Errors != before.Check.Errors {
+		if after.Check.Errors < before.Check.Errors {
 			return 1
 		}
 		return -1

--- a/internal/resolve/load_selected.go
+++ b/internal/resolve/load_selected.go
@@ -2,17 +2,20 @@ package resolve
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
-
-	"github.com/osty/osty/internal/parser"
 )
 
 // LoadPackageFiles loads the provided Osty source files as one package while
 // preserving their original paths for diagnostics. Paths may span a synthetic
 // selection rather than a full on-disk directory listing.
 func LoadPackageFiles(paths []string, stdlib StdlibProvider) (*Package, error) {
+	return LoadPackageFilesWithTransform(paths, stdlib, nil)
+}
+
+// LoadPackageFilesWithTransform is LoadPackageFiles plus an optional
+// pre-parse source transform.
+func LoadPackageFilesWithTransform(paths []string, stdlib StdlibProvider, transform SourceTransform) (*Package, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("load selected package: no files")
 	}
@@ -33,18 +36,10 @@ func LoadPackageFiles(paths []string, stdlib StdlibProvider) (*Package, error) {
 	if stdlib != nil {
 		pkg.workspace = newStdlibOnlyWorkspace(stdlib)
 	}
-	for _, p := range absPaths {
-		src, err := os.ReadFile(p)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", p, err)
-		}
-		file, parseDiags := parser.ParseDiagnostics(src)
-		pkg.Files = append(pkg.Files, &PackageFile{
-			Path:       p,
-			Source:     src,
-			File:       file,
-			ParseDiags: parseDiags,
-		})
+	loaded, err := loadPackagePaths(absPaths, dir, filepath.Base(dir), transform)
+	if err != nil {
+		return nil, err
 	}
+	pkg.Files = loaded.Files
 	return pkg, nil
 }

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -10,6 +10,10 @@ import (
 	"github.com/osty/osty/internal/parser"
 )
 
+// SourceTransform lets callers rewrite raw source bytes before the
+// parser sees them. nil preserves the on-disk bytes.
+type SourceTransform func(path string, src []byte) []byte
+
 // LoadPackage discovers and parses every `.osty` file directly under
 // dir (non-recursive) and returns them as a single Package ready for
 // ResolvePackage. Test files (`*_test.osty`) are excluded per v0.4 §11
@@ -18,6 +22,13 @@ import (
 // The returned Package has Files sorted lexicographically by path for
 // deterministic diagnostic ordering.
 func LoadPackage(dir string) (*Package, error) {
+	return LoadPackageWithTransform(dir, nil)
+}
+
+// LoadPackageWithTransform is LoadPackage plus an optional pre-parse
+// source transform. The callback can normalize foreign syntax or inject
+// generated source before diagnostics are computed.
+func LoadPackageWithTransform(dir string, transform SourceTransform) (*Package, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -42,30 +53,18 @@ func LoadPackage(dir string) (*Package, error) {
 		paths = append(paths, filepath.Join(abs, name))
 	}
 	sort.Strings(paths)
-
-	pkg := &Package{
-		Dir:  abs,
-		Name: filepath.Base(abs),
-	}
-	for _, p := range paths {
-		src, err := os.ReadFile(p)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", p, err)
-		}
-		file, parseDiags := parser.ParseDiagnostics(src)
-		pkg.Files = append(pkg.Files, &PackageFile{
-			Path:       p,
-			Source:     src,
-			File:       file,
-			ParseDiags: parseDiags,
-		})
-	}
-	return pkg, nil
+	return loadPackagePaths(paths, abs, filepath.Base(abs), transform)
 }
 
 // LoadPackageWithTests is like LoadPackage but also includes every
 // `*_test.osty` file. Used by `osty test` and similar commands.
 func LoadPackageWithTests(dir string) (*Package, error) {
+	return LoadPackageWithTestsTransform(dir, nil)
+}
+
+// LoadPackageWithTestsTransform is LoadPackageWithTests plus an
+// optional pre-parse source transform.
+func LoadPackageWithTestsTransform(dir string, transform SourceTransform) (*Package, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -85,12 +84,18 @@ func LoadPackageWithTests(dir string) (*Package, error) {
 		}
 	}
 	sort.Strings(paths)
+	return loadPackagePaths(paths, abs, filepath.Base(abs), transform)
+}
 
-	pkg := &Package{Dir: abs, Name: filepath.Base(abs)}
+func loadPackagePaths(paths []string, dir, name string, transform SourceTransform) (*Package, error) {
+	pkg := &Package{Dir: dir, Name: name}
 	for _, p := range paths {
 		src, err := os.ReadFile(p)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		if transform != nil {
+			src = transform(p, src)
 		}
 		file, parseDiags := parser.ParseDiagnostics(src)
 		pkg.Files = append(pkg.Files, &PackageFile{

--- a/internal/resolve/workspace.go
+++ b/internal/resolve/workspace.go
@@ -126,6 +126,11 @@ type Workspace struct {
 	// error.
 	Deps DepProvider
 
+	// SourceTransform rewrites source bytes before parsing. The CLI uses
+	// this to adapt AI-authored foreign syntax before any parser or
+	// resolver work begins.
+	SourceTransform SourceTransform
+
 	// stdlibStub is set to true when the workspace should tolerate
 	// `std.*` imports even though no stdlib sources are present. Useful
 	// in tests and before the stdlib is bundled with the compiler.
@@ -220,7 +225,7 @@ func (w *Workspace) LoadPackage(dotPath string) (*Package, error) {
 	w.loading[dotPath] = true
 	defer delete(w.loading, dotPath)
 
-	pkg, err := LoadPackage(dir)
+	pkg, err := LoadPackageWithTransform(dir, w.SourceTransform)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +286,7 @@ func (w *Workspace) loadFromExternalDir(key, dir string) (*Package, error) {
 	w.loading[key] = true
 	defer delete(w.loading, key)
 
-	pkg, err := LoadPackage(dir)
+	pkg, err := LoadPackageWithTransform(dir, w.SourceTransform)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- make `airepair` default to `auto` and enable it by default for front-end commands
- run airepair before parsing by wiring source transforms into package and workspace loaders
- update docs and tests to reflect automatic early adaptation across `check`, `resolve`, `lint`, `build`, `run`, `test`, and `gen`

## Testing
- `go test ./cmd/osty -run 'Test(AIRepairCommandAndLegacyAliasRewriteSource|FmtAIRepairFlagAliasesDisableAutomaticFixes|UsageOutputUsesCanonicalAIRepairNames|AIRepairJSONReportFromStdin|AIRepairCaptureResidualCaseWritesCorpusArtifacts|AIRepairCaptureResidualDefaultSkipsCleanCases|AIRepairCaptureChangedWritesCleanRepairedCase|AIRepairCaptureFlagsRequireCaptureDir|AIRepairTriageSummarizesCapturedReports|AIRepairPromoteCopiesCapturedCaseIntoCorpus|CheckWithAIRepairPassesForeignSyntax|CheckWithAIRepairPassesPythonStyleBlocks|CheckWithAIRepairPassesPythonElifBlocks|CheckWithAIRepairPassesPythonBareTupleForBlocks|CheckWithAIRepairPassesJSForOfLoops|CheckWithAIRepairPassesJSDestructuringForOfLoops|CheckWithAIRepairPassesPythonRangeLoops|ResolveWithAIRepairPassesPythonEnumerateLoops|CheckWithAIRepairPassesPythonMatchCaseBlocks|RunTestMainAIRepairAllowsForeignSyntaxBeforeDiscovery)$'`
- `go test ./cmd/osty -run 'Test(LoadGenPackageEntryLoadsSiblingFiles|ParseGenEmitFileMergesPackageSources|ParseGenEmitFilePreservesOriginalASTNodes|SplitGenCheckDiagsDefersUnavailableChecker|LoadGenPackageEntryWithTransformRepairsForeignSyntax)$'`
- `go test ./cmd/osty -run ^`
- `go test ./internal/airepair`
- `go test ./internal/resolve -run ^`
- `go test ./internal/lsp -run 'Test(FixAllActionUsesAIRepairForForeignSyntax|FixAllActionUsesAIRepairForPythonBlocks|FixAllActionUsesAIRepairForPythonElif|FixAllActionUsesAIRepairForPythonBareTupleLoop|FixAllActionUsesAIRepairForJSForOfLoop|FixAllActionUsesAIRepairForJSDestructuringForOfLoop|FixAllActionUsesAIRepairForPythonRangeLoop|FixAllActionUsesAIRepairForPythonEnumerateLoop|FixAllActionUsesAIRepairForPythonMatchCase)$'`