### PR TITLE
feat: Interface vtable Phase 6e — auto-box assignment-statement positions

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -307,12 +307,16 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     필드 추가로 AST 레벨 return 타입을 추적. smokes:
     `TestGenerateModuleInterfaceBoxingFromReturn`,
     `TestGenerateModuleInterfaceBoxingFromCallArg`.
+  - Phase 6e(assign-statement 자동 boxing): `let mut s: Iface = concrete`
+    로 bound된 slot에 concrete값을 `s = w`로 재할당하면 자동 boxing.
+    `boxInterfaceValue`가 반환 value에 `sourceType: ifaceType`을 태그
+    해 slot이 자신의 선언 interface identity를 기억한다. smoke:
+    `TestGenerateModuleInterfaceBoxingFromAssign`.
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
     generic interface specialization의 vtable 연결 (Phase 5 `_ZTSN…E` +
-    Phase 6a scaffold), 암묵 타입 변환, assign-statement 레벨의 자동
-    boxing (현재 let/return/call 세 경로), payload-free / 비-리터럴
-    인자를 가진 variant call의 타입 복원(궁극적으로는 checker 쪽
-    generic variant-constructor inference 보강).
+    Phase 6a scaffold), 암묵 타입 변환, payload-free / 비-리터럴 인자를
+    가진 variant call의 타입 복원(궁극적으로는 checker 쪽 generic
+    variant-constructor inference 보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -374,6 +374,49 @@ fn main() {
 	}
 }
 
+// TestGenerateModuleInterfaceBoxingFromAssign covers Phase 6e: after a
+// `let mut s: Iface = concrete` binding, subsequent `s = concrete2`
+// reassignments must auto-box the new concrete value into a
+// `%osty.iface` fat pointer, mirroring the let / return / call-arg
+// boxing paths.
+func TestGenerateModuleInterfaceBoxingFromAssign(t *testing.T) {
+	src := `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn main() {
+    let v = Vec { count: 3 }
+    let mut s: Sized = v
+    let w = Vec { count: 9 }
+    s = w
+    println(s.size())
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6e_assign_box.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		"@osty.vtable.Vec__Sized",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	// Reassignment must emit TWO boxings (initial let + assign), so the
+	// vtable symbol appears at least twice in the final IR.
+	if strings.Count(got, "@osty.vtable.Vec__Sized") < 2 {
+		t.Fatalf("expected vtable symbol referenced at least twice (let + assign), got %d:\n%s",
+			strings.Count(got, "@osty.vtable.Vec__Sized"), got)
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -229,7 +229,10 @@ func (g *generator) boxInterfaceValue(ifaceType ast.Type, v value) (value, error
 	step2 := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %%osty.iface %s, ptr %s, 1", step2, step1, vtableSym))
 	g.takeOstyEmitter(emitter)
-	return value{typ: "%osty.iface", ref: step2}, nil
+	// Phase 6e: tag the boxed value with its interface AST type so
+	// downstream slots (e.g. `let mut s: Iface = …`) remember the
+	// declared interface identity and can auto-box reassignments.
+	return value{typ: "%osty.iface", ref: step2, sourceType: ifaceType}, nil
 }
 
 // interfaceNominalName returns the single-segment interface source
@@ -265,6 +268,17 @@ func (g *generator) emitAssign(stmt *ast.AssignStmt) error {
 		v, err := g.emitExprWithHint(stmt.Value, slot.listElemTyp, slot.listElemString, slot.mapKeyTyp, slot.mapValueTyp, slot.mapKeyString, slot.setElemTyp, slot.setElemString)
 		if err != nil {
 			return err
+		}
+		// Phase 6e: auto-box a concrete rhs when the binding's declared
+		// slot type is an interface. Mirrors the let / return / call-arg
+		// boxing paths so reassignment stays consistent with the other
+		// interface-adjacent positions.
+		if slot.typ == "%osty.iface" && v.typ != "%osty.iface" && slot.sourceType != nil {
+			boxed, boxErr := g.boxInterfaceValue(slot.sourceType, v)
+			if boxErr != nil {
+				return boxErr
+			}
+			v = boxed
 		}
 		if v.typ != slot.typ {
 			return unsupportedf("type-system", "assignment to %q type %s, value %s", target.Name, slot.typ, v.typ)


### PR DESCRIPTION
## Summary

Phase 6d(#230)가 `let`/`return`/call-arg 세 경로에서 concrete→interface auto-boxing을 지원했다면, Phase 6e는 마지막 남은 assign-statement(`s = concrete2`)를 같은 policy로 보강. Base branch는 `claude/phase6d-interface-auto-box-return-callarg`.

## 구현

- `internal/llvmgen/stmt.go` `emitAssign`:
  - target ident의 slot을 lookup → `slot.typ == "%osty.iface"` + rhs가 concrete이면 `boxInterfaceValue(slot.sourceType, v)`로 fat pointer 생성 후 store.
  - 기존 type-check는 boxing 뒤에 동작.

- `internal/llvmgen/stmt.go` `boxInterfaceValue`:
  - 반환 value에 `sourceType: ifaceType` 태그 추가. 초기 `let mut s: Iface = v` 시 slot의 sourceType이 interface AST 타입이 되어, 이후 `s = w` 재할당 시 assignment 경로가 slot.sourceType을 참조해 다시 boxing 할 수 있게 한다.

## 테스트

- `TestGenerateModuleInterfaceBoxingFromAssign` — `let mut s: Sized = v; let w = Vec { … }; s = w` 소스가 IR에서 `@osty.vtable.Vec__Sized` 심볼을 최소 2회 참조(초기 let boxing + 재할당 boxing)하는지 확인. `%osty.iface` 타입 정의도 포함.

Phase 6a-6d의 interface smoke 5개 + 이번 1개 = 총 6개 모두 green. Phase 1-5 monomorph 테스트 회귀 없음.

## 남은 범위

- 암묵 타입 변환 (`Int` literal → `Int32` 등)
- Generic interface specialization(`_ZTSN…E`) vtable 통합
- Payload-free / non-literal variant call type 복원 (checker 보강)

## Test plan

- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleInterface' -count=1` — 6개 interface smoke 전부 pass
- [x] `go test ./internal/ir/ ./internal/llvmgen/ -run 'Monomorph|TestGenerateModuleGeneric|TestGenerateModuleMethod|TestGenerateModuleInterface' -count=1` — Phase 1-6d 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)