### PR TITLE
test: Interface vtable Phase 6f — lock Phase 5 mangled nominals ↔ Phase 6 vtable path

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -312,11 +312,22 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     `boxInterfaceValue`가 반환 value에 `sourceType: ifaceType`을 태그
     해 slot이 자신의 선언 interface identity를 기억한다. smoke:
     `TestGenerateModuleInterfaceBoxingFromAssign`.
+  - Phase 6f(Phase 5 mangled interface 이름 ↔ Phase 6 vtable 통합):
+    코드 변경 없이 이미 맞물려 있다. Phase 5가 generic interface를
+    specialize할 때 결과 이름은 `_ZTSN…E` Itanium RTTI 포맷이고,
+    Phase 6a의 `discoverInterfaceImplementations`는 이 이름을 그대로
+    소비해 `@osty.vtable.<impl>__<mangled>` vtable global을 emit한다.
+    boxing / dispatch 경로도 `interfaceInfo.name` 기준이라 추가 처리
+    불필요. smoke: `TestGenerateModuleMangledInterfaceNameVtableDispatch`
+    가 mangled 이름을 source identifier로 직접 써서 경로 전체를
+    regression-lock (parser가 generic interface `interface Foo<T>` 선언
+    문법을 아직 수용하지 않아 실제 Container<Int> → Container<Int>
+    specialization E2E는 별도 parser/checker 확장 후).
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
-    generic interface specialization의 vtable 연결 (Phase 5 `_ZTSN…E` +
-    Phase 6a scaffold), 암묵 타입 변환, payload-free / 비-리터럴 인자를
-    가진 variant call의 타입 복원(궁극적으로는 checker 쪽 generic
-    variant-constructor inference 보강).
+    generic interface 선언 파서 지원 (`interface Foo<T>` 문법),
+    암묵 타입 변환, payload-free / 비-리터럴 인자를 가진 variant call의
+    타입 복원(궁극적으로는 checker 쪽 generic variant-constructor
+    inference 보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -417,6 +417,49 @@ fn main() {
 	}
 }
 
+// TestGenerateModuleMangledInterfaceNameVtableDispatch covers Phase 6f:
+// Phase 5's generic interface specialization emits nominal names in
+// the Itanium `_ZTSN…E` shape. Phase 6a-6e's vtable scaffold must
+// continue to work on those mangled names — discovery, vtable
+// emission, boxing, and dispatch all keyed on the exact string
+// produced by `MonomorphMangleType`. The parser does not yet accept
+// generic interface declarations, so this smoke feeds the mangled
+// name as the raw source identifier; the resulting pipeline stage
+// mirrors what Phase 5 would hand llvmgen for a `Container<Int>`
+// specialization.
+func TestGenerateModuleMangledInterfaceNameVtableDispatch(t *testing.T) {
+	const mangled = "_ZTSN4main9ContainerIlEE"
+	src := `interface ` + mangled + ` {
+    fn get(self) -> Int
+}
+
+struct IntBox {
+    value: Int,
+
+    fn get(self) -> Int {
+        self.value
+    }
+}
+
+fn main() {
+    let b = IntBox { value: 3 }
+    let c: ` + mangled + ` = b
+    println(c.get())
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6f_mangled_iface.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		mangled,
+		"@osty.vtable.IntBox__" + mangled,
+		"ptr @IntBox__get",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call


### PR DESCRIPTION
## Summary

Phase 5(#219)의 generic interface specialization(`_ZTSN…E`)이 Phase 6a-6e(#225/#228/#229/#230/#232)의 vtable scaffold + boxing + dispatch 경로와 **코드 변경 없이 이미 호환**됨을 확인. 구현 추가 없이 **regression lock용 smoke만** 추가해 두 서브시스템 사이의 암묵적 계약을 명문화.

Base branch는 `claude/phase6e-interface-assign-boxing`.

## 배경

- Phase 5: `interface Foo<T>` → `_ZTSN4main3FooIlEE` 같은 mangled nominal을 IR에 emit (`requestInterfaceType` 경유).
- Phase 6a: `discoverInterfaceImplementations`가 `interfaceInfo.name` 기준 structural match → `@osty.vtable.<impl>__<iface>` global.
- Phase 6b-6e: boxing/dispatch 경로가 `interfaceInfo.name`을 그대로 소비 (mangled 여부 비의존).

따라서 mangled interface 이름이 llvmgen에 들어와도 모든 경로가 자연스럽게 작동. 테스트로 이 사실을 **잠가**, 이후 리팩터에서 mangled 이름 경유 경로가 의도치 않게 깨지지 않도록 회귀 안전망 제공.

## 테스트

`TestGenerateModuleMangledInterfaceNameVtableDispatch` — mangled nominal(`_ZTSN4main9ContainerIlEE`)을 원시 source identifier로 써서 `interface <mangled> { fn get(self) -> Int }` + `struct IntBox` + `let c: <mangled> = b; c.get()` 패턴이 IR에 `%osty.iface`, `@osty.vtable.IntBox__<mangled>`, `ptr @IntBox__get`을 emit함을 검증.

## 실제 generic interface E2E 미해결 부분

`interface Container<T> { … }` 선언 자체는 아직 Osty parser가 수용하지 않는다(`E0001: expected {, got <`). 실제 `Container<Int>` 파이프라인을 돌리려면 parser 문법 확장이 별도로 필요하며, Phase 6 시리즈 범위 밖으로 명시.

## 남은 범위 (Phase 7+)

- Bare function-pointer turbofish (`let f = id::<Int>`)
- Generic interface 선언 파서 지원 (`interface Foo<T>` 문법)
- 암묵 타입 변환
- Payload-free / non-literal variant call type 복원 (checker 보강)

## Test plan

- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleInterface|TestGenerateModuleMangled' -count=1` — Phase 6a-6e 6개 + 이번 1개 총 7개 모두 pass
- [x] `go test ./internal/ir/ ./internal/llvmgen/ -run 'Monomorph|TestGenerateModuleGeneric|TestGenerateModuleMethod|TestGenerateModuleInterface|TestGenerateModuleMangled' -count=1` — Phase 1-6e 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)