### PR TITLE
fix: Interface vtable Phase 6g — calling-convention shim + binary E2E

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -312,6 +312,18 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     `boxInterfaceValue`가 반환 value에 `sourceType: ifaceType`을 태그
     해 slot이 자신의 선언 interface identity를 기억한다. smoke:
     `TestGenerateModuleInterfaceBoxingFromAssign`.
+  - Phase 6g(vtable calling-convention shim + binary E2E): interface
+    dispatch ABI(`ptr %data + non-self args`)가 실제 method의 struct-
+    by-value receiver convention과 달라 IR-level smoke는 통과해도
+    binary 실행 시 self가 스택 쓰레기로 읽혔다. `renderInterfaceShim`
+    이 (impl, iface, method) 쌍마다 `@osty.shim.<impl>__<iface>__<method>`
+    를 emit해 ptr→struct load 후 실제 method를 호출하는 adapter를
+    담당. vtable slot은 method 대신 이 shim을 가리킨다. mut receiver는
+    포인터를 그대로 forward. `internal/backend/llvm_test.go`에 두 개의
+    binary E2E smoke 추가: `TestLLVMBackendBinaryRunsGenericIdentity`
+    (Phase 1 generic fn `id::<Int>(42)`가 `42\n` 출력) +
+    `TestLLVMBackendBinaryRunsInterfaceBoxingDispatch` (Phase 6b boxing +
+    vtable dispatch가 `3\n` 출력). clang을 미발견 시 skip.
   - Phase 6f(Phase 5 mangled interface 이름 ↔ Phase 6 vtable 통합):
     코드 변경 없이 이미 맞물려 있다. Phase 5가 generic interface를
     specialize할 때 결과 이름은 `_ZTSN…E` Itanium RTTI 포맷이고,

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -614,3 +614,84 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
+// TestLLVMBackendBinaryRunsGenericIdentity covers the generic
+// monomorphization path Phase 1 introduced, all the way through clang
+// to an executable. The monomorphizer must produce `_Z2idIlEl`, clang
+// must link and run it, and the process must print the forwarded
+// value. Complements the IR-only smoke in
+// `internal/llvmgen/ir_module_test.go::TestGenerateModuleGenericIdentityMonomorphized`.
+func TestLLVMBackendBinaryRunsGenericIdentity(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn id<T>(x: T) -> T { x }
+
+fn main() {
+    println(id::<Int>(42))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "42\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsInterfaceBoxingDispatch exercises the full
+// Phase 6a-6e interface pipeline end-to-end: a struct's method set
+// structurally satisfies an interface, the concrete value is boxed
+// into a `%osty.iface` fat pointer at the `let` site, and the
+// subsequent method call is lowered to a vtable indirect call that
+// the linked binary actually executes. Complements the IR-only
+// smokes `TestGenerateModuleInterfaceBoxingDispatch` and friends by
+// confirming the emitted `insertvalue` / `extractvalue` / `load ptr`
+// / indirect-call sequence survives clang and runs correctly.
+func TestLLVMBackendBinaryRunsInterfaceBoxingDispatch(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn main() {
+    let v = Vec { count: 3 }
+    let s: Sized = v
+    println(s.size())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "3\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -265,7 +265,8 @@ func (g *generator) renderInterfaceVtables() ([]string, string) {
 		}
 		haveAny = true
 		for _, impl := range iface.impls {
-			methodsByName := g.methods[g.ownerTypeFor(impl)]
+			implType := g.ownerTypeFor(impl)
+			methodsByName := g.methods[implType]
 			slots := make([]string, 0, len(iface.methods))
 			for _, m := range iface.methods {
 				sig := methodsByName[m.name]
@@ -273,7 +274,22 @@ func (g *generator) renderInterfaceVtables() ([]string, string) {
 					slots = append(slots, "ptr null")
 					continue
 				}
-				slots = append(slots, fmt.Sprintf("ptr @%s", sig.irName))
+				// Phase 6f follow-up: the vtable slot does not point
+				// at the concrete method directly because interface
+				// dispatch passes `self` as `ptr %data` while the
+				// underlying method expects the struct/enum value (or
+				// a `ptr` for mut receivers). A per-(impl, iface,
+				// method) shim adapts the calling convention: it
+				// loads the concrete value from the data pointer (or
+				// forwards the pointer for mut receivers) and tail-
+				// calls the real implementation.
+				shimSym, shimDef := renderInterfaceShim(iface, impl, m, sig, implType)
+				if shimDef != "" {
+					defs = append(defs, shimDef)
+					slots = append(slots, "ptr "+shimSym)
+				} else {
+					slots = append(slots, fmt.Sprintf("ptr @%s", sig.irName))
+				}
 			}
 			defs = append(defs, fmt.Sprintf(
 				"%s = constant [%d x ptr] [%s]",
@@ -288,6 +304,64 @@ func (g *generator) renderInterfaceVtables() ([]string, string) {
 	}
 	typeDef := "%osty.iface = type { ptr, ptr }"
 	return defs, typeDef
+}
+
+// renderInterfaceShim returns the `@osty.shim.<impl>__<iface>__<method>`
+// symbol and the LLVM IR definition of a shim that adapts the
+// interface dispatch ABI (`ptr %data, <non-self args>`) to the
+// underlying method's calling convention.
+//
+// For immutable receivers the shim loads the struct/enum value from
+// the data pointer before calling the real method; for `mut` receivers
+// (where the method already takes `ptr %self`) the pointer is
+// forwarded verbatim. A nil return signals a malformed signature the
+// caller must handle by falling back to a direct `ptr @<method>`
+// slot, which is still safe for receiver-less methods but will
+// typically yield an empty-return shim when one is actually needed.
+func renderInterfaceShim(iface *interfaceInfo, impl interfaceImpl, m interfaceMethodSig, sig *fnSig, implType string) (string, string) {
+	if sig == nil || implType == "" {
+		return "", ""
+	}
+	if len(sig.params) == 0 {
+		// No receiver slot — nothing to adapt.
+		return "", ""
+	}
+	receiver := sig.params[0]
+	shimSym := fmt.Sprintf("@osty.shim.%s__%s__%s", impl.implName, iface.name, m.name)
+	ret := sig.ret
+	if ret == "" {
+		ret = "void"
+	}
+	// Build the shim's parameter list: data ptr followed by any
+	// non-self user args. The underlying method will consume them
+	// with its own declared types.
+	shimParams := []string{"ptr %self.ptr"}
+	callArgs := make([]string, 0, len(sig.params))
+	if receiver.byRef {
+		// Mut receiver already expects a pointer — forward it.
+		callArgs = append(callArgs, "ptr %self.ptr")
+	} else {
+		// Immutable receiver expects the struct/enum value.
+		callArgs = append(callArgs, fmt.Sprintf("%s %%self.val", receiver.typ))
+	}
+	for i, p := range sig.params[1:] {
+		name := fmt.Sprintf("%%a%d", i)
+		shimParams = append(shimParams, fmt.Sprintf("%s %s", p.typ, name))
+		callArgs = append(callArgs, fmt.Sprintf("%s %s", p.typ, name))
+	}
+	var body strings.Builder
+	if !receiver.byRef {
+		body.WriteString(fmt.Sprintf("  %%self.val = load %s, ptr %%self.ptr\n", receiver.typ))
+	}
+	body.WriteString(fmt.Sprintf("  %%ret.val = call %s @%s(%s)\n", ret, sig.irName, strings.Join(callArgs, ", ")))
+	if ret == "void" {
+		body.WriteString("  ret void\n")
+	} else {
+		body.WriteString(fmt.Sprintf("  ret %s %%ret.val\n", ret))
+	}
+	def := fmt.Sprintf("define internal %s %s(%s) {\n%s}",
+		ret, shimSym, strings.Join(shimParams, ", "), body.String())
+	return shimSym, def
 }
 
 // ownerTypeFor returns the LLVM IR type symbol (`%Name`) a given

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -221,7 +221,12 @@ fn main() {
 	for _, want := range []string{
 		"%osty.iface = type { ptr, ptr }",
 		"@osty.vtable.Vec__Sized",
-		"ptr @Vec__size",
+		// Phase 6f follow-up: the vtable slot points at a shim that
+		// adapts the interface dispatch ABI to the underlying method's
+		// calling convention; the shim's body in turn calls the real
+		// `Vec__size` symbol.
+		"@osty.shim.Vec__Sized__size",
+		"@Vec__size",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
@@ -285,7 +290,8 @@ fn main() {
 	for _, want := range []string{
 		"%osty.iface",
 		"@osty.vtable.Thing__Combine",
-		"ptr @Thing__combine",
+		"@osty.shim.Thing__Combine__combine",
+		"@Thing__combine",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
@@ -452,7 +458,8 @@ fn main() {
 		"%osty.iface",
 		mangled,
 		"@osty.vtable.IntBox__" + mangled,
-		"ptr @IntBox__get",
+		"@osty.shim.IntBox__" + mangled + "__get",
+		"@IntBox__get",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)


### PR DESCRIPTION
## Summary

**IR smoke만으로는 잡지 못한 실제 실행 버그 발견 + 수정**.

Phase 6b-6f의 IR-level smoke가 모두 green이었음에도 실제 clang으로 링크해 실행하면 interface method가 `self`를 스택 쓰레기로 읽는 버그가 있었다. 원인: vtable dispatch ABI는 `ptr %data + non-self args`를 전달하지만 concrete method는 struct-by-value(immutable) 또는 `ptr`(mut) receiver를 기대 — calling convention 불일치.

Base branch는 `claude/phase6f-mangled-interface-vtable-lock`.

## 해결

### `internal/llvmgen/generator.go`
- 신규 `renderInterfaceShim`: (impl, iface, method) 쌍마다 `@osty.shim.<impl>__<iface>__<method>` 를 emit. immutable receiver는 `%self.val = load %Impl, ptr %self.ptr` 후 `call ... @Impl__method(%Impl %self.val, …)`로 adapt. mut receiver는 `ptr %self.ptr`을 그대로 forward.
- `renderInterfaceVtables`: 각 method에 대해 `renderInterfaceShim` 호출 — vtable slot은 이제 method 대신 shim을 가리킨다.

### 테스트 (binary E2E 추가 — 사용자 지적 반영)

- `internal/backend/llvm_test.go`:
  - `TestLLVMBackendBinaryRunsGenericIdentity` — Phase 1 `id::<Int>(42)`가 `42\n` 출력 (`clang` 미발견 시 skip).
  - `TestLLVMBackendBinaryRunsInterfaceBoxingDispatch` — Phase 6 `let s: Sized = v; println(s.size())`가 `3\n` 출력. **이 테스트는 shim 도입 전에 실제로 실패했다** (stdout이 쓰레기 정수). shim 도입 후 올바르게 동작.

### 기존 IR smoke 업데이트

- `TestGenerateModuleInterfaceVtableEmitted` / `TestGenerateModuleInterfaceDispatchWithArgs` / `TestGenerateModuleMangledInterfaceNameVtableDispatch`: assertion에 `@osty.shim…` 심볼 추가 + shim body 내부 `@<impl>__<method>` 참조 유지 확인.

## 회귀 확인

- Phase 1-5 monomorph 테스트 all green
- Phase 6a-6f의 나머지 4 smoke(boxing+dispatch / return boxing / call-arg boxing / assign boxing) green
- Phase 1 + Phase 6 binary E2E 2건 pass

## 배경 (사용자 지적)

> 검증이 주로 llvmgen IR smoke 중심이고, backend binary E2E는 아직 얇습니다.

정확한 지적이었다. IR에 올바른 심볼이 emit돼도 실제 LLVM 시맨틱 / ABI가 일치하지 않으면 빌드/실행 단계에서 파국이 난다는 점을 이번 shim 버그가 직접 보여줬다. 후속 Phase들에 대해서도 binary E2E를 최소 1건씩 추가해 갈 것.

## Test plan

- [x] `go test ./internal/backend/ -run 'TestLLVMBackendBinaryRunsGenericIdentity|TestLLVMBackendBinaryRunsInterfaceBoxingDispatch' -count=1` — binary E2E 2건 pass
- [x] `go test ./internal/ir/ ./internal/llvmgen/ ./internal/backend/ -run 'Monomorph|TestGenerateModuleGeneric|TestGenerateModuleMethod|TestGenerateModuleInterface|TestGenerateModuleMangled|TestLLVMBackendBinaryRuns…' -count=1` — 세 패키지 전부 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)