### PR TITLE
feat: introduce internal/mir layer under ir for backend-friendly lowering

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -1,0 +1,474 @@
+# MIR design (Osty compiler)
+
+Status: Stage 1 — scaffolding, lowering for the currently green LLVM subset,
+no backend rewiring yet. The existing `internal/llvmgen` IR→AST bridge stays
+in place; MIR is introduced underneath `internal/ir` as a new, backend-
+friendly layer that a future llvmgen rewrite can consume directly.
+
+## Why a second IR
+
+The current `internal/ir` was conceived as a "typed, normalised tree above
+the checker" — what most literature calls an HIR. It has served well for
+optimisation passes (constant folding, algebraic simplification, decision-
+tree pre-compilation) and for the toolchain's own self-hosting needs
+(formatters, linters, docs extraction, LSP). But it carries structural
+debt that grows as the backend matures:
+
+- It still carries source-level sugar: `IfLetExpr`, `MatchExpr` with
+  patterns, `QuestionExpr`, `MethodCall`, `VariantLit`, `FieldExpr` vs.
+  `TupleAccess`, `ForStmt` with destructuring `Pattern`, struct literals
+  with `..spread`, keyword `Arg`s, defaults on `Param`, etc.
+- Every backend must re-implement the same lowering of those constructs:
+  discriminant loads, payload extraction, short-circuit optional chains,
+  early-return semantics for `?`, guard-and-branch for match arms.
+- Control flow is still expression-tree-shaped. Blocks contain statements,
+  statements sometimes contain expressions that themselves encode control
+  flow. Anything doing flow-sensitive analysis has to re-derive the CFG.
+- The LLVM emitter ends up fighting both problems: `internal/llvmgen`
+  currently reifies `*ir.Module` back into a legacy AST
+  (`internal/llvmgen/ir_module.go`) and then lowers the AST — which means
+  source-level pattern semantics leak into the backend by design.
+
+The MIR exists to absorb all of that complexity in one lowering pass and
+hand backends a shape that is:
+
+1. **Sugar-free.** No pattern nodes. No `MethodCall`, no `VariantLit`,
+   no `IfLetExpr`, no `QuestionExpr`, no `for` heads with destructuring.
+2. **CFG-shaped.** Functions are `locals + basic blocks + terminators`.
+   Control flow is always explicit: `Goto`, `Branch`, `SwitchInt`,
+   `Return`, `Unreachable`.
+3. **Monomorphic and layout-aware.** Every local, place, and operand
+   carries its `Type`, and the module carries a `LayoutTable` for
+   aggregate layout information so a backend can emit struct, tuple and
+   enum operations without re-running the type checker.
+
+Non-goals (Stage 1):
+
+- SSA form. MIR locals can be reassigned. We are Rust-MIR-like, not
+  LLVM-IR-like; an SSA pass can sit on top later.
+- A full optimisation pipeline. Stage-1 MIR only needs to be *correct*
+  enough to round-trip the currently green LLVM/backend subset.
+- Concurrency primitives (`taskGroup`, channels, `spawn`). These live in
+  HIR today and will lower to MIR once their runtime ABI is settled.
+- Rewriting `internal/llvmgen` to consume MIR directly.
+
+## Pipeline position
+
+```
+source
+  → lexer
+  → parser
+  → resolve
+  → check
+  → ir.Lower         (HIR — this stays)
+  → ir.Monomorphize  (HIR, monomorphic)
+  → ir.Optimize      (optional; HIR)
+  → ir.Validate      (HIR invariants)
+  → mir.Lower        (HIR → MIR)              ⟵ new, additive
+  → mir.Validate     (MIR invariants)         ⟵ new, additive
+  → backend          (llvmgen today; future: MIR-direct)
+```
+
+MIR lowering runs *after* monomorphisation: every `TypeVar` is gone,
+every generic call has a concrete mangled target, and every generic
+nominal type has been rewritten to its specialisation. MIR never has to
+reason about generics.
+
+## Responsibilities: HIR vs. MIR
+
+| Concern                          | HIR (`internal/ir`) | MIR (`internal/mir`) |
+|----------------------------------|---------------------|----------------------|
+| Name resolution                  | yes (strings + kinds) | no — symbols only |
+| Pattern nodes                    | yes                 | no                   |
+| `match` / `if let` / `for let`   | yes                 | lowered to CFG       |
+| `?` and `?.`                     | yes                 | lowered to branches  |
+| Method syntax                    | yes (`MethodCall`)  | direct `Call` only   |
+| Enum constructor sugar           | yes (`VariantLit`)  | `AggregateRV` only   |
+| Keyword / default arguments      | yes (`Arg.Name`)    | positional only      |
+| Turbofish / generics             | yes                 | eliminated earlier   |
+| Control flow as expressions      | yes (`IfExpr`, `BlockExpr`) | no — only statements |
+| Typed every node                 | yes                 | yes (with layout ids)|
+| Decision-tree pre-compilation    | yes                 | consumed by lowerer  |
+| Closure captures                 | yes (`Closure.Captures`) | not yet (Stage 2+) |
+| `defer` bodies                   | yes                 | not yet (Stage 2+)   |
+| Concurrency primitives           | yes                 | not yet              |
+
+Anything in the "not yet" rows causes `mir.Lower` to return an
+"unsupported" diagnostic today. That signals the caller (e.g. the
+backend dispatcher) to fall back to the existing HIR-based path. As
+each feature gains a settled lowering, it moves from the "not yet" row
+into full MIR coverage.
+
+## MIR node model
+
+### Values
+
+```
+Module
+  Package    string
+  Functions  []*Function
+  Structs    []*StructLayout    // from monomorphic HIR structs
+  Enums      []*EnumLayout      // discriminant + per-variant field tables
+  Globals    []*Global          // top-level `let`s
+  Uses       []*Use             // retained for FFI bridging
+  Layouts    *LayoutTable
+
+Function
+  Name        string            // mangled symbol
+  Params      []LocalID         // subset of locals that hold incoming args
+  ReturnType  Type
+  ReturnLocal LocalID           // _0 by convention; unused when ReturnType == Unit
+  Locals      []*Local
+  Blocks      []*BasicBlock
+  Entry       BlockID           // always 0 in the canonical printer
+  IsExternal  bool              // FFI declarations (no body)
+  IsIntrinsic bool
+  Span        Span
+```
+
+Locals are the single source of storage: parameters, the return slot,
+named bindings, and compiler-introduced temporaries all live here.
+Each local has a type and optional debug name.
+
+### Places, projections, operands
+
+```
+Place {
+  Local        LocalID
+  Projections  []Projection
+}
+
+Projection
+  | FieldProj       { Index int; Field string; Type Type }
+  | TupleProj       { Index int; Type Type }
+  | VariantProj     { Variant int; Name string; Type Type; FieldIdx int }
+  | IndexProj       { Index Operand; ElemType Type }
+  | DerefProj       {}
+
+Operand
+  | CopyOp  { Place; Type }        // non-destructive read
+  | MoveOp  { Place; Type }        // reserved — semantics == Copy today
+  | ConstOp { Const; Type }
+
+Const
+  | IntConst    { Value int64 ; Type }
+  | BoolConst   { Value bool }
+  | FloatConst  { Value float64; Type }
+  | StringConst { Value string }
+  | CharConst   { Value rune }
+  | ByteConst   { Value byte }
+  | UnitConst   {}
+  | NullConst   { Type }           // canonical `None` payload marker
+  | FnConst     { Symbol string; Type } // function-pointer literal
+```
+
+`MoveOp` is kept in the vocabulary even though the current runtime is
+GC-based and copy-on-use is uniformly safe; future owning-pointer or
+linear-type work will distinguish them. Today the validator accepts
+both.
+
+### Instructions
+
+```
+Instr
+  | AssignInstr    { Dest Place; Src RValue }
+  | CallInstr      { Dest Place?; Callee; Args []Operand; Conv }
+  | IntrinsicInstr { Dest Place?; Kind; Args []Operand }
+  | StorageLive    { Local }
+  | StorageDead    { Local }
+```
+
+`CallInstr` with `Dest == nil` is a statement-position call that
+produces no value (unit return, or value discarded). The `Callee` is
+either a direct `FnRef{Symbol}` (already mangled, as chosen by the
+monomorphiser) or an `IndirectCall{Callee Operand}` for first-class
+function values. Keyword arguments are gone by the time we enter MIR:
+`mir.Lower` reorders and fills defaults against the callee's declared
+signature.
+
+`IntrinsicInstr` covers backend-neutral built-ins (the `print` family)
+without forcing backends to match on name strings. Additional
+intrinsics (`list-push`, `string-concat`, …) can be added as runtime
+ABI ossifies.
+
+`StorageLive` / `StorageDead` mark the live range of a local. Backends
+that do not care may ignore them; they exist so that future lifetime
+and GC-root analyses can run over MIR.
+
+### Terminators
+
+```
+Terminator
+  | GotoTerm        { Target BlockID }
+  | BranchTerm      { Cond Operand; Then, Else BlockID }
+  | SwitchIntTerm   { Scrutinee Operand; Cases []SwitchCase; Default BlockID }
+  | ReturnTerm      {}                // reads _0 / ReturnLocal
+  | UnreachableTerm {}
+```
+
+`SwitchCase` is `{Value int64; Target BlockID}`. Enum discriminants and
+integer-literal matches collapse into the same terminator; string /
+float / char matches lower to a chain of `BranchTerm`s ahead of time.
+
+`ReturnTerm` always returns the contents of the function's
+`ReturnLocal`. `Unreachable` sits after calls whose return type is
+`!` / whose match coverage was proven exhaustive by the decision-tree
+compiler.
+
+### RValues
+
+```
+RValue
+  | UseRV          { Op Operand }
+  | UnaryRV        { Op; Arg; Type }
+  | BinaryRV       { Op; Lhs, Rhs; Type }
+  | AggregateRV    { Kind; Fields []Operand; Type; VariantIdx int }
+  | DiscriminantRV { Place; Type }              // enum tag load
+  | LenRV          { Place; Type }              // collection length
+  | CastRV         { Kind; Arg; From, To Type }
+  | AddressOfRV    { Place; Type }              // borrow (future use)
+  | RefRV          { Place; Type }              // wrap into optional Some
+  | NullaryRV      { Kind; Type }               // e.g. NoneOf<T>
+```
+
+`AggregateRV.Kind` enumerates `Tuple`, `Struct`, `EnumVariant`, `List`,
+`Map`. For `EnumVariant`, `VariantIdx` names the active arm and
+`Fields` is the payload tuple. The emitter uses the `LayoutTable` to
+pick the right in-memory representation (`%T = type { i64, ... }` for
+struct; `%Enum = type { i64, i64 }` with variant-specific payload in
+the current LLVM backend).
+
+### Layouts
+
+```
+LayoutTable {
+  Structs map[string]*StructLayout
+  Enums   map[string]*EnumLayout
+  Tuples  map[string]*TupleLayout        // keyed by structural signature
+}
+
+StructLayout {
+  Name         string              // mangled post-monomorphisation
+  Fields       []FieldLayout
+  ByteSize     int                 // 0 when backend computes it
+  Mangled      string              // runtime-visible name
+}
+
+FieldLayout {
+  Index int
+  Name  string
+  Type  Type
+}
+
+EnumLayout {
+  Name         string
+  Mangled      string
+  Discriminant Type                // typically Int / UInt32
+  Variants     []VariantLayout
+}
+
+VariantLayout {
+  Index   int
+  Name    string
+  Payload []FieldLayout            // empty for bare variants
+}
+```
+
+`LayoutTable` starts life as a pure index: the MIR lowerer walks the
+monomorphic HIR's `StructDecl` / `EnumDecl` list and records a single
+entry per type. Backends that need ABI-level byte offsets fill in
+`ByteSize` themselves (LLVM gets it from `DataLayout`; a future
+bytecode VM would compute and pin them here). The table is keyed by
+the post-monomorphisation *structural* name — `List<Int>` and
+`List<String>` are two distinct entries with distinct mangled names.
+
+## Lowering rules
+
+The lowerer walks a HIR `*ir.Module` top-to-bottom and emits a MIR
+`*mir.Module`. It never recurses into the HIR a second time; every
+lowering step is driven off the node under inspection.
+
+### Functions
+
+One HIR function ⇒ one MIR function. Parameters become MIR locals with
+the `IsParam` flag set. The first local is `_0`, the return slot,
+matching the `ReturnLocal` convention. Simple name-bound params become
+their own locals; destructured params (`|(a, b)|`) get one synthetic
+local for the whole value plus a set of projection-based assigns at
+the start of the entry block.
+
+### Blocks and statements
+
+The lowerer threads a `cursor` through basic blocks. Each stmt either
+appends instructions to the current block or terminates it and starts
+a new one.
+
+- `LetStmt` with a simple name: allocate local, emit `StorageLive`,
+  lower RHS into it.
+- `LetStmt` with a pattern: lower RHS into a scratch local, then for
+  each leaf binding emit `Assign Dest = Use(CopyOp(scratch + proj))`.
+  Nested patterns compose by extending the projection list.
+- `AssignStmt` (`=` and compound): lower RHS; for each target on the
+  LHS, lower to a `Place` and emit `Assign`.
+- `ReturnStmt`: lower RHS into `_0`; terminate with `Return`.
+- `Break` / `Continue`: terminate with `Goto` to the loop's
+  `break_target` / `continue_target` recorded on a loop stack.
+- `IfStmt`: lower cond into operand, `Branch → then_bb / else_bb`,
+  lower each arm body into its block, join back into `merge_bb`.
+- `ForStmt`:
+  - `ForInfinite`: one header block that loops back onto itself.
+  - `ForWhile`: header block branches on cond to body or exit.
+  - `ForRange`: allocate index local, initialise, header block does
+    bounds check, body increments.
+  - `ForIn`: treated as unsupported for Stage-1 when the iterable is
+    not a built-in `List<T>`. For `List<T>` it lowers to an index-based
+    loop using `LenRV` and an `IndexProj` read.
+- `MatchStmt`: use `ir.CompileDecisionTree` (when available) to drive
+  the CFG. Each `DecisionSwitch` becomes a `SwitchInt` or a `Branch`
+  cascade; `DecisionBind` becomes an assign with projection;
+  `DecisionGuard.Cond == nil` chains to the next arm; `DecisionFail`
+  becomes `Unreachable` when the original match was proven exhaustive
+  and an explicit abort intrinsic otherwise.
+- `DeferStmt` is not lowered in Stage 1. The lowerer records a
+  non-fatal issue; callers that need full coverage fall back to the
+  HIR path.
+
+### Expressions
+
+Expressions in statement position are lowered recursively through a
+helper that returns an `Operand`. Sub-expressions that produce side
+effects (calls, assignments in nested form) emit instructions into the
+current block and yield a `CopyOp` referencing the temporary they
+assigned into.
+
+- `IntLit`, `BoolLit`, `FloatLit`, `CharLit`, `ByteLit`, `UnitLit`,
+  `StringLit` (non-interpolated): `ConstOp`.
+- `StringLit` with interpolation: lowered to a `StringConcat`
+  intrinsic call that backends route to their runtime's formatted
+  string builder.
+- `Ident`: `CopyOp` on the resolved local / param / global, or
+  `ConstOp(FnConst)` for fn references.
+- `UnaryExpr`, `BinaryExpr`: recursive lowering, result in a
+  `UnaryRV` / `BinaryRV` assigned into a fresh temp.
+- `CallExpr`: map keyword args to positional per the callee's
+  signature; fill defaults; emit `CallInstr`.
+- `IntrinsicCall`: `IntrinsicInstr`.
+- `MethodCall`: resolved to a direct function whose first parameter is
+  the receiver; emitted as `CallInstr`.
+- `VariantLit`: `AggregateRV{Kind: EnumVariant}`.
+- `StructLit`: `AggregateRV{Kind: Struct}`. Spread (`..rest`) lowers to
+  per-field copies from the spread expression plus per-explicit
+  overrides. Shorthand fields (`{name}` with no `:`) lower to
+  `Use(CopyOp(local))`.
+- `TupleLit`: `AggregateRV{Kind: Tuple}`.
+- `ListLit`: for Stage 1 we emit `AggregateRV{Kind: List}` with the
+  element operands inline; the runtime-ABI backend translates that
+  into a sequence of `osty_rt_list_new` + `osty_rt_list_push_*` calls.
+- `FieldExpr` (non-optional): `Place` with a `FieldProj`.
+- `TupleAccess`: `Place` with a `TupleProj`.
+- `IndexExpr`: `Place` with an `IndexProj`.
+- `QuestionExpr`: lower the sub-expression into a scratch local, emit
+  a `DiscriminantRV` + `SwitchInt`; the "happy" successor extracts the
+  payload and continues, the "unhappy" successor wraps the error /
+  empty into the enclosing function's return shape and terminates
+  with `Return`.
+- `FieldExpr` (optional, `x?.field`): lower the receiver, check its
+  discriminant, branch on None → fallthrough to the merge block with
+  a `None` result, or extract the payload, read the field, wrap back
+  in `Some`.
+- `CoalesceExpr`: lower left, check discriminant, select between the
+  unwrapped payload and the lowered right.
+- `IfExpr` / `IfLetExpr` / `MatchExpr` / `BlockExpr` (expression
+  form): same CFG construction as their statement siblings, with the
+  extra step of writing each arm's tail into a single merge local.
+
+### Guarantees
+
+- No pattern nodes appear in MIR output. `StructPat`, `VariantPat`,
+  `TuplePat`, `OrPat`, `BindingPat`, `RangePat`, `LitPat`, `WildPat`,
+  `IdentPat`, `ErrorPat` are HIR-only.
+- `MatchExpr`, `MatchStmt`, `IfLetExpr`, `QuestionExpr`, `MethodCall`,
+  `VariantLit`, `IntrinsicCall` *as HIR nodes* are forbidden in MIR
+  output. Calls are always `CallInstr` or `IntrinsicInstr`; variant
+  construction is always `AggregateRV`; pattern-driven control flow is
+  always CFG.
+- Every `Place` rooted at a local carries only projections whose
+  types are known. The validator rejects projections with a nil
+  `Type`.
+- Every `Operand` carries a type. The validator rejects `nil` types.
+- Every basic block ends in exactly one terminator. The validator
+  rejects instructions *after* a terminator and blocks without one.
+
+## Tests
+
+MIR ships with three test surfaces in `internal/mir/mir_test.go`:
+
+1. **Construction tests** build MIR modules by hand, run the printer,
+   and assert on the rendered output. These pin the textual format
+   and catch accidental API drift.
+2. **Lowering tests** lower a tiny HIR fixture and assert on the MIR
+   printer output. They cover:
+   - constant return / simple arithmetic
+   - if / else with merge
+   - while loop
+   - struct literal + field read
+   - enum variant construction + match via decision tree
+   - `if let` over `Option<T>`
+   - optional chaining `x?.y`
+   - `?` on `Result<T, E>` inside a fallible fn
+   - direct method call on a struct
+3. **Validator tests** intentionally construct malformed MIR modules
+   and assert the validator catches them. These double as executable
+   documentation for the invariants above.
+
+The tests live under `internal/mir/` and depend only on
+`internal/ir`. They do *not* depend on the parser, resolver, or
+checker — each fixture is a hand-written HIR module. That keeps the
+MIR tests isolated from front-end churn.
+
+## Migration plan
+
+- **Stage 1 (this patch).** Add `internal/mir` with types, printer,
+  validator, lowering, and tests. `internal/llvmgen` is untouched.
+  `docs/mir_design.md` is this document.
+
+- **Stage 2.** Expand MIR lowering coverage to match the complete set
+  of HIR nodes exercised by the current LLVM test suite: closures,
+  defer, channels, taskGroup, stdlib intrinsics. Each expansion is a
+  small, independently reviewable patch.
+
+- **Stage 3.** Introduce a new llvmgen entry point —
+  `GenerateFromMIR(m *mir.Module, opts)` — that consumes MIR directly.
+  Route it behind a build flag and run both the old AST path and the
+  new MIR path in CI to catch divergences. Tests live side-by-side.
+
+- **Stage 4.** Flip the default at `GenerateModule` to the MIR path
+  once parity is green on the full corpus. Keep the legacy bridge
+  callable under a fallback flag.
+
+- **Stage 5.** Remove `legacyFileFromModule` and the AST-driven
+  emitter. `internal/llvmgen` now speaks only MIR. Future backends
+  (e.g. a bytecode VM, WASM) start from MIR with no AST knowledge.
+
+Each stage is an opportunity to tighten the MIR shape: Stage 3 is
+where we learn which invariants the backend actually needs, Stage 4 is
+where we can remove any MIR node that turned out to be redundant, and
+Stage 5 is where we can finally forbid any `internal/llvmgen` code
+from importing `internal/ast` at the package-boundary level.
+
+## Out of scope for Stage 1
+
+- SSA. MIR locals can be reassigned. An SSA pass (`mir.ToSSA`) will
+  sit on top once downstream passes want it.
+- Borrow / ownership analysis. `AddressOfRV` and `DerefProj` are
+  in the vocabulary but currently unused.
+- Region-based diagnostics. MIR carries `Span`s, but the current
+  validator reports only structural errors.
+- A production-quality optimizer. The existing HIR optimiser stays
+  where it is; MIR may gain its own passes in Stage 2 (copy
+  propagation, dead-store elimination, simple peepholes) but this
+  patch ships none.
+- Concurrency primitives. `spawn`, `taskGroup`, channel sends / recvs,
+  and `thread.select` remain HIR-only until their runtime ABI is
+  settled; the lowerer emits an unsupported diagnostic when it meets
+  one.

--- a/internal/mir/doc.go
+++ b/internal/mir/doc.go
@@ -1,0 +1,30 @@
+// Package mir defines Osty's backend-facing middle intermediate
+// representation.
+//
+// MIR sits below the language-level IR in internal/ir. The pipeline is
+//
+//	source → lexer → parser → resolve → check → ir.Lower
+//	       → ir.Monomorphize → ir.Validate → mir.Lower → mir.Validate → backend
+//
+// Where HIR (internal/ir) is a normalised tree of source constructs —
+// matches, patterns, `if let`, `?`, method syntax, keyword args — MIR
+// is a Rust-MIR-style shape of explicit locals, basic blocks, places,
+// projections, and terminators. Source sugar is already gone by the
+// time MIR is produced:
+//
+//   - Patterns are lowered to projections + assigns.
+//   - `match` / `if let` / `for let` become CFGs with `SwitchInt` and
+//     `Branch` terminators.
+//   - `?` and optional chaining `?.` become explicit discriminant reads
+//     and early-return branches.
+//   - Method calls become direct calls with an explicit receiver operand.
+//   - Enum constructor sugar becomes `AggregateRV{Kind: EnumVariant}`.
+//
+// The MIR package has no dependencies on `internal/ast`, `internal/resolve`,
+// or `internal/check`; it depends only on `internal/ir` for the type
+// surface (reused so backends need only one type vocabulary).
+//
+// See docs/mir_design.md for the full design rationale, the invariants
+// the validator enforces, and the multi-stage migration plan from the
+// current HIR→AST bridge in `internal/llvmgen` to direct MIR consumption.
+package mir

--- a/internal/mir/dump_example_test.go
+++ b/internal/mir/dump_example_test.go
@@ -1,0 +1,53 @@
+package mir
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// TestMIRDumpExample exercises the printer on a richer module so the
+// canonical output format is recorded alongside the lowering tests.
+// Running `go test -run TestMIRDumpExample -v ./internal/mir/` prints
+// the MIR for manual inspection.
+func TestMIRDumpExample(t *testing.T) {
+	maybeT := &ir.NamedType{Name: "Maybe"}
+	enumDecl := &ir.EnumDecl{
+		Name: "Maybe",
+		Variants: []*ir.Variant{
+			{Name: "Some", Payload: []ir.Type{ir.TInt}},
+			{Name: "None"},
+		},
+	}
+	arms := []*ir.MatchArm{
+		{
+			Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "Some",
+				Args: []ir.Pattern{&ir.IdentPat{Name: "x"}}},
+			Body: &ir.Block{Result: &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt}},
+		},
+		{
+			Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "None"},
+			Body:    &ir.Block{Result: &ir.IntLit{Text: "0", T: ir.TInt}},
+		},
+	}
+	tree := ir.CompileDecisionTree(maybeT, arms)
+	scoreFn := &ir.FnDecl{
+		Name:   "score",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "m", Type: maybeT}},
+		Body: &ir.Block{
+			Result: &ir.MatchExpr{
+				Scrutinee: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: maybeT},
+				Arms:      arms,
+				Tree:      tree,
+				T:         ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{enumDecl, scoreFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v", errs)
+	}
+	t.Logf("MIR:\n%s", Print(out))
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -1,0 +1,2573 @@
+package mir
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// Lower converts a monomorphic HIR module into a MIR module. The
+// caller is expected to have already run `ir.Monomorphize` on the HIR
+// — `Lower` does not handle generic declarations and returns an
+// unsupported issue when it encounters one.
+//
+// The returned *Module is always non-nil (even when the issues slice
+// is non-empty). Non-fatal issues are reported via Module.Issues so
+// that callers can decide whether to fall back to the HIR-based
+// backend path. Fatal bugs — shape invariants the lowerer itself
+// breaks — are caught by `mir.Validate` afterwards.
+func Lower(mod *ir.Module) *Module {
+	if mod == nil {
+		return &Module{Package: "", Layouts: NewLayoutTable()}
+	}
+	l := &lowerer{
+		src:     mod,
+		out:     &Module{Package: mod.Package, SpanV: mod.SpanV, Layouts: NewLayoutTable()},
+		fnSig:   map[string]*fnSignature{},
+		methods: map[string]*fnSignature{},
+		enums:   map[string]*ir.EnumDecl{},
+		structs: map[string]*ir.StructDecl{},
+	}
+	l.run()
+	return l.out
+}
+
+// ==== signatures + lookup tables ====
+
+type fnSignature struct {
+	ir      *ir.FnDecl
+	owner   string // "" for free fns; type name for methods
+	symbol  string
+	params  []*ir.Param
+	retType ir.Type
+}
+
+// signatureForDirectCall returns the signature of a free fn by source
+// name, or nil if not known.
+func (l *lowerer) signatureForFn(name string) *fnSignature {
+	return l.fnSig[name]
+}
+
+// signatureForMethod returns the signature of a type method, or nil
+// when unknown.
+func (l *lowerer) signatureForMethod(typeName, method string) *fnSignature {
+	return l.methods[methodKey(typeName, method)]
+}
+
+func methodKey(typeName, method string) string {
+	return typeName + "::" + method
+}
+
+// ==== lowerer state ====
+
+type lowerer struct {
+	src *ir.Module
+	out *Module
+
+	fnSig   map[string]*fnSignature
+	methods map[string]*fnSignature
+	enums   map[string]*ir.EnumDecl
+	structs map[string]*ir.StructDecl
+}
+
+func (l *lowerer) noteIssue(format string, args ...any) {
+	l.out.Issues = append(l.out.Issues, fmt.Errorf(format, args...))
+}
+
+// run performs the two-pass lowering: collect signatures + layouts,
+// then emit each function and global.
+func (l *lowerer) run() {
+	l.collectSignatures()
+	l.buildLayouts()
+	l.emitDeclarations()
+	l.emitScript()
+}
+
+// ==== pass 1: signatures + layouts ====
+
+func (l *lowerer) collectSignatures() {
+	for _, d := range l.src.Decls {
+		switch x := d.(type) {
+		case *ir.FnDecl:
+			if len(x.Generics) > 0 {
+				l.noteIssue("generic free fn %q reached MIR (monomorphize first)", x.Name)
+				continue
+			}
+			sig := &fnSignature{
+				ir:      x,
+				symbol:  x.Name,
+				params:  x.Params,
+				retType: x.Return,
+			}
+			l.fnSig[x.Name] = sig
+		case *ir.StructDecl:
+			if len(x.Generics) > 0 {
+				l.noteIssue("generic struct %q reached MIR (monomorphize first)", x.Name)
+				continue
+			}
+			l.structs[x.Name] = x
+			for _, m := range x.Methods {
+				sig := &fnSignature{
+					ir:      m,
+					owner:   x.Name,
+					symbol:  mangleMethodSymbol(x.Name, m.Name),
+					params:  m.Params,
+					retType: m.Return,
+				}
+				l.methods[methodKey(x.Name, m.Name)] = sig
+			}
+		case *ir.EnumDecl:
+			if len(x.Generics) > 0 {
+				l.noteIssue("generic enum %q reached MIR (monomorphize first)", x.Name)
+				continue
+			}
+			l.enums[x.Name] = x
+			for _, m := range x.Methods {
+				sig := &fnSignature{
+					ir:      m,
+					owner:   x.Name,
+					symbol:  mangleMethodSymbol(x.Name, m.Name),
+					params:  m.Params,
+					retType: m.Return,
+				}
+				l.methods[methodKey(x.Name, m.Name)] = sig
+			}
+		case *ir.UseDecl:
+			l.emitUse(x)
+		}
+	}
+}
+
+func (l *lowerer) buildLayouts() {
+	for name, s := range l.structs {
+		sl := &StructLayout{Name: name, Mangled: name}
+		for i, f := range s.Fields {
+			sl.Fields = append(sl.Fields, FieldLayout{
+				Index: i,
+				Name:  f.Name,
+				Type:  f.Type,
+			})
+		}
+		l.out.Layouts.Structs[name] = sl
+	}
+	for name, e := range l.enums {
+		el := &EnumLayout{
+			Name:         name,
+			Mangled:      name,
+			Discriminant: TInt,
+		}
+		for i, v := range e.Variants {
+			vl := VariantLayout{Index: i, Name: v.Name}
+			for j, p := range v.Payload {
+				vl.Payload = append(vl.Payload, FieldLayout{
+					Index: j,
+					Name:  fmt.Sprintf("_%d", j),
+					Type:  p,
+				})
+			}
+			el.Variants = append(el.Variants, vl)
+		}
+		l.out.Layouts.Enums[name] = el
+	}
+}
+
+func (l *lowerer) emitUse(u *ir.UseDecl) {
+	if u == nil {
+		return
+	}
+	l.out.Uses = append(l.out.Uses, &Use{
+		Path:         append([]string(nil), u.Path...),
+		RawPath:      u.RawPath,
+		Alias:        u.Alias,
+		IsGoFFI:      u.IsGoFFI,
+		IsRuntimeFFI: u.IsRuntimeFFI,
+		GoPath:       u.GoPath,
+		RuntimePath:  u.RuntimePath,
+		SpanV:        u.SpanV,
+	})
+}
+
+// ==== pass 2: emit functions ====
+
+func (l *lowerer) emitDeclarations() {
+	for _, d := range l.src.Decls {
+		switch x := d.(type) {
+		case *ir.FnDecl:
+			if len(x.Generics) > 0 {
+				continue
+			}
+			fn := l.lowerFunction(x, "", false)
+			if fn != nil {
+				l.out.Functions = append(l.out.Functions, fn)
+			}
+		case *ir.StructDecl:
+			if len(x.Generics) > 0 {
+				continue
+			}
+			for _, m := range x.Methods {
+				if fn := l.lowerFunction(m, x.Name, true); fn != nil {
+					l.out.Functions = append(l.out.Functions, fn)
+				}
+			}
+		case *ir.EnumDecl:
+			if len(x.Generics) > 0 {
+				continue
+			}
+			for _, m := range x.Methods {
+				if fn := l.lowerFunction(m, x.Name, true); fn != nil {
+					l.out.Functions = append(l.out.Functions, fn)
+				}
+			}
+		case *ir.LetDecl:
+			if g := l.lowerGlobal(x); g != nil {
+				l.out.Globals = append(l.out.Globals, g)
+			}
+		}
+	}
+}
+
+func (l *lowerer) emitScript() {
+	if len(l.src.Script) == 0 {
+		return
+	}
+	// Treat script statements as the body of a synthetic main(). The
+	// backend conventionally does the same thing.
+	fn := l.newFunction("main", nil, TUnit, ir.Span{}, false)
+	bs := newBodyState(l, fn)
+	for _, s := range l.src.Script {
+		bs.lowerStmt(s)
+	}
+	bs.finishNoReturn()
+	l.out.Functions = append(l.out.Functions, fn)
+}
+
+// lowerFunction emits a MIR function from one HIR FnDecl. asMethod
+// routes top-level `Self` access through the receiver parameter.
+func (l *lowerer) lowerFunction(fn *ir.FnDecl, owner string, asMethod bool) *Function {
+	if fn == nil {
+		return nil
+	}
+	retT := fn.Return
+	if retT == nil {
+		retT = TUnit
+	}
+	symbol := fn.Name
+	if asMethod {
+		symbol = mangleMethodSymbol(owner, fn.Name)
+	}
+	out := l.newFunction(symbol, fn.Params, retT, fn.SpanV, asMethod)
+	out.Exported = fn.Exported
+	if fn.Body == nil {
+		out.IsExternal = true
+		// Strip blocks for external stubs: the validator rejects empty
+		// block lists for non-external functions, and external ones
+		// must have zero blocks.
+		out.Blocks = nil
+		out.Entry = 0
+		return out
+	}
+	bs := newBodyState(l, out)
+	if asMethod {
+		bs.self = &ownerContext{typeName: owner, localID: bs.paramLocals[0]}
+	}
+	for _, s := range fn.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	if fn.Body.Result != nil {
+		// trailing expression — lower into the return local and return
+		bs.lowerExprInto(fn.Body.Result, out.ReturnLocal, retT)
+		bs.terminate(&ReturnTerm{SpanV: fn.Body.SpanV})
+		return out
+	}
+	bs.finishNoReturn()
+	return out
+}
+
+// lowerGlobal emits a MIR global. The initialiser is a zero-arg
+// function that returns the value; callers use it as they see fit
+// (LLVM materialises this as a `@_init_xxx()` routine today).
+func (l *lowerer) lowerGlobal(let *ir.LetDecl) *Global {
+	if let == nil {
+		return nil
+	}
+	t := let.Type
+	if t == nil && let.Value != nil {
+		t = let.Value.Type()
+	}
+	if t == nil {
+		l.noteIssue("global %q: unknown type", let.Name)
+		return nil
+	}
+	g := &Global{Name: let.Name, Type: t, Mut: let.Mut, SpanV: let.SpanV}
+	if let.Value != nil {
+		initName := "_init_" + let.Name
+		initFn := l.newFunction(initName, nil, t, let.SpanV, false)
+		bs := newBodyState(l, initFn)
+		bs.lowerExprInto(let.Value, initFn.ReturnLocal, t)
+		bs.terminate(&ReturnTerm{SpanV: let.SpanV})
+		g.Init = initFn
+	}
+	return g
+}
+
+// newFunction creates a function shell, allocating the return local
+// and any declared parameters. Returns ids of param locals in
+// bodyState.paramLocals via the caller's access.
+func (l *lowerer) newFunction(name string, params []*ir.Param, retT Type, sp Span, asMethod bool) *Function {
+	fn := &Function{Name: name, ReturnType: retT, SpanV: sp}
+	// _0 is always the return slot.
+	fn.ReturnLocal = fn.NewLocal("_return", retT, true, sp)
+	fn.Locals[fn.ReturnLocal].IsReturn = true
+	// parameters become subsequent locals
+	for _, p := range params {
+		paramName := p.Name
+		if paramName == "" {
+			paramName = fmt.Sprintf("arg%d", len(fn.Params))
+		}
+		id := fn.NewLocal(paramName, p.Type, true, p.SpanV)
+		fn.Locals[id].IsParam = true
+		fn.Params = append(fn.Params, id)
+	}
+	// entry block
+	fn.NewBlock(sp)
+	fn.Entry = 0
+	return fn
+}
+
+// ==== body lowering ====
+
+// bodyState carries per-function cursor state: current block, loop
+// stack, local lookup, and the closed-over function object we're
+// populating.
+type bodyState struct {
+	l   *lowerer
+	fn  *Function
+	cur BlockID
+
+	// locals maps HIR-visible names to MIR local IDs. Pushed on let
+	// binding, popped at the end of scopes.
+	locals []map[string]LocalID
+
+	// paramLocals is a cached view of fn.Params for quick access.
+	paramLocals []LocalID
+
+	// self tracks the receiver for method bodies.
+	self *ownerContext
+
+	// loopStack is a stack of break/continue destinations.
+	loopStack []*loopFrame
+}
+
+type ownerContext struct {
+	typeName string
+	localID  LocalID
+}
+
+type loopFrame struct {
+	breakBlock    BlockID
+	continueBlock BlockID
+}
+
+func newBodyState(l *lowerer, fn *Function) *bodyState {
+	bs := &bodyState{l: l, fn: fn, cur: fn.Entry}
+	bs.pushScope()
+	// seed locals from parameters.
+	for i, p := range fn.Params {
+		loc := fn.Locals[p]
+		if loc != nil && loc.Name != "" {
+			bs.locals[0][loc.Name] = p
+		}
+		bs.paramLocals = append(bs.paramLocals, p)
+		_ = i
+	}
+	return bs
+}
+
+func (bs *bodyState) pushScope() {
+	bs.locals = append(bs.locals, map[string]LocalID{})
+}
+
+func (bs *bodyState) popScope() {
+	if len(bs.locals) == 0 {
+		return
+	}
+	bs.locals = bs.locals[:len(bs.locals)-1]
+}
+
+func (bs *bodyState) bind(name string, id LocalID) {
+	if name == "" {
+		return
+	}
+	bs.locals[len(bs.locals)-1][name] = id
+}
+
+func (bs *bodyState) lookup(name string) (LocalID, bool) {
+	for i := len(bs.locals) - 1; i >= 0; i-- {
+		if id, ok := bs.locals[i][name]; ok {
+			return id, true
+		}
+	}
+	return 0, false
+}
+
+// ==== cursor + block helpers ====
+
+func (bs *bodyState) currentBlock() *BasicBlock { return bs.fn.Block(bs.cur) }
+
+func (bs *bodyState) emit(instr Instr) {
+	bb := bs.currentBlock()
+	if bb == nil {
+		return
+	}
+	if bb.Term != nil {
+		// Unreachable code after a terminator — start a fresh orphan
+		// block so validation still accepts the module. The new block
+		// becomes the cursor.
+		sp := SpanOfInstr(instr)
+		next := bs.fn.NewBlock(sp)
+		bs.cur = next
+		bb = bs.currentBlock()
+	}
+	bb.Append(instr)
+}
+
+func (bs *bodyState) terminate(t Terminator) {
+	bb := bs.currentBlock()
+	if bb == nil {
+		return
+	}
+	if bb.Term == nil {
+		bb.SetTerminator(t)
+	}
+}
+
+// switchTo installs a new cursor and returns the previous.
+func (bs *bodyState) switchTo(id BlockID) BlockID {
+	prev := bs.cur
+	bs.cur = id
+	return prev
+}
+
+// newBlock allocates a fresh block and returns its ID (does not
+// switch to it).
+func (bs *bodyState) newBlock(sp Span) BlockID {
+	return bs.fn.NewBlock(sp)
+}
+
+// gotoBlock terminates the current block with a goto and switches to
+// target.
+func (bs *bodyState) gotoBlock(target BlockID, sp Span) {
+	bs.terminate(&GotoTerm{Target: target, SpanV: sp})
+	bs.cur = target
+}
+
+// ==== statement lowering ====
+
+func (bs *bodyState) lowerStmt(s ir.Stmt) {
+	switch x := s.(type) {
+	case nil:
+		return
+	case *ir.Block:
+		bs.lowerBlockStmt(x)
+	case *ir.LetStmt:
+		bs.lowerLet(x)
+	case *ir.ExprStmt:
+		bs.lowerExprStmt(x)
+	case *ir.AssignStmt:
+		bs.lowerAssign(x)
+	case *ir.ReturnStmt:
+		bs.lowerReturn(x)
+	case *ir.BreakStmt:
+		bs.lowerBreak(x)
+	case *ir.ContinueStmt:
+		bs.lowerContinue(x)
+	case *ir.IfStmt:
+		bs.lowerIfStmt(x)
+	case *ir.ForStmt:
+		bs.lowerForStmt(x)
+	case *ir.MatchStmt:
+		bs.lowerMatchStmt(x)
+	case *ir.DeferStmt:
+		bs.l.noteIssue("defer not lowered to MIR (stage 2 work)")
+	case *ir.ChanSendStmt:
+		bs.l.noteIssue("channel send not lowered to MIR (stage 2 work)")
+	case *ir.ErrorStmt:
+		bs.l.noteIssue("error stmt reached MIR: %s", x.Note)
+	default:
+		bs.l.noteIssue("unsupported stmt %T", s)
+	}
+}
+
+func (bs *bodyState) lowerBlockStmt(b *ir.Block) {
+	bs.pushScope()
+	for _, s := range b.Stmts {
+		bs.lowerStmt(s)
+	}
+	if b.Result != nil {
+		// Block used in statement position — we discard the value but
+		// still need its side effects.
+		_ = bs.lowerExprAsOperand(b.Result)
+	}
+	bs.popScope()
+}
+
+func (bs *bodyState) lowerLet(let *ir.LetStmt) {
+	t := let.Type
+	if t == nil && let.Value != nil {
+		t = let.Value.Type()
+	}
+	if t == nil {
+		t = ir.ErrTypeVal
+	}
+	switch {
+	case let.Pattern != nil:
+		bs.lowerLetPattern(let.Pattern, let.Value, t, let.SpanV)
+	case let.Name != "":
+		id := bs.fn.NewLocal(let.Name, t, let.Mut, let.SpanV)
+		bs.emit(&StorageLiveInstr{Local: id, SpanV: let.SpanV})
+		if let.Value != nil {
+			bs.lowerExprInto(let.Value, id, t)
+		}
+		bs.bind(let.Name, id)
+	default:
+		bs.l.noteIssue("let stmt with neither name nor pattern")
+	}
+}
+
+func (bs *bodyState) lowerLetPattern(pat ir.Pattern, value ir.Expr, valueType Type, sp Span) {
+	scratch := bs.fn.NewLocal("_scratch", valueType, false, sp)
+	bs.emit(&StorageLiveInstr{Local: scratch, SpanV: sp})
+	if value != nil {
+		bs.lowerExprInto(value, scratch, valueType)
+	}
+	scrutPlace := Place{Local: scratch}
+	bs.bindPattern(pat, scrutPlace, valueType, sp)
+}
+
+// bindPattern walks an irrefutable pattern and emits Assign
+// instructions that pull leaves out of scrutinee into named locals.
+// For refutable patterns (reaching let bindings) this is a lowering
+// bug — the checker already forbids it — but the helper still emits
+// best-effort assignments for whatever bindings do appear.
+func (bs *bodyState) bindPattern(pat ir.Pattern, scrutinee Place, scrutineeT Type, sp Span) {
+	switch p := pat.(type) {
+	case nil:
+		return
+	case *ir.WildPat:
+		return
+	case *ir.IdentPat:
+		id := bs.fn.NewLocal(p.Name, scrutineeT, p.Mut, p.SpanV)
+		bs.emit(&StorageLiveInstr{Local: id, SpanV: p.SpanV})
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: id},
+			Src:   &UseRV{Op: &CopyOp{Place: scrutinee, T: scrutineeT}},
+			SpanV: p.SpanV,
+		})
+		bs.bind(p.Name, id)
+	case *ir.BindingPat:
+		// Bind the whole scrutinee to the outer name, then recurse.
+		id := bs.fn.NewLocal(p.Name, scrutineeT, false, p.SpanV)
+		bs.emit(&StorageLiveInstr{Local: id, SpanV: p.SpanV})
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: id},
+			Src:   &UseRV{Op: &CopyOp{Place: scrutinee, T: scrutineeT}},
+			SpanV: p.SpanV,
+		})
+		bs.bind(p.Name, id)
+		bs.bindPattern(p.Pattern, scrutinee, scrutineeT, sp)
+	case *ir.TuplePat:
+		elemTypes := tupleElementTypes(scrutineeT)
+		for i, elem := range p.Elems {
+			et := elementTypeAt(elemTypes, i)
+			child := scrutinee.Project(&TupleProj{Index: i, Type: et})
+			bs.bindPattern(elem, child, et, p.SpanV)
+		}
+	case *ir.StructPat:
+		info := bs.l.structFromType(scrutineeT, p.TypeName)
+		for _, f := range p.Fields {
+			ft := bs.l.fieldType(info, f.Name)
+			proj := &FieldProj{Index: bs.l.fieldIndex(info, f.Name), Name: f.Name, Type: ft}
+			child := scrutinee.Project(proj)
+			if f.Pattern != nil {
+				bs.bindPattern(f.Pattern, child, ft, p.SpanV)
+			} else {
+				id := bs.fn.NewLocal(f.Name, ft, false, p.SpanV)
+				bs.emit(&StorageLiveInstr{Local: id, SpanV: p.SpanV})
+				bs.emit(&AssignInstr{
+					Dest:  Place{Local: id},
+					Src:   &UseRV{Op: &CopyOp{Place: child, T: ft}},
+					SpanV: p.SpanV,
+				})
+				bs.bind(f.Name, id)
+			}
+		}
+	case *ir.VariantPat:
+		// Payload destructuring of a known variant — caller is
+		// responsible for knowing the pattern matches (e.g. reachable
+		// after a decision-tree branch).
+		layout := bs.l.variantLayout(p.Enum, p.Variant)
+		for i, arg := range p.Args {
+			pt := variantPayloadType(layout, i)
+			proj := &VariantProj{
+				Variant:  variantIndex(layout),
+				Name:     p.Variant,
+				FieldIdx: i,
+				Type:     pt,
+			}
+			child := scrutinee.Project(proj)
+			bs.bindPattern(arg, child, pt, p.SpanV)
+		}
+	case *ir.LitPat, *ir.RangePat, *ir.OrPat:
+		// Irrefutable patterns only — refutable ones are decision-tree
+		// driven. Ignore silently when reached from a let.
+	case *ir.ErrorPat:
+		bs.l.noteIssue("error pattern reached MIR: %s", p.Note)
+	default:
+		bs.l.noteIssue("unsupported pattern in let: %T", pat)
+	}
+}
+
+func (bs *bodyState) lowerExprStmt(e *ir.ExprStmt) {
+	_ = bs.lowerExprAsOperand(e.X)
+}
+
+func (bs *bodyState) lowerAssign(a *ir.AssignStmt) {
+	// simple case: single target, AssignEq
+	if len(a.Targets) == 1 && a.Op == ir.AssignEq {
+		dst, ok := bs.lowerExprToPlace(a.Targets[0])
+		if !ok {
+			bs.l.noteIssue("assign: unsupported target %T", a.Targets[0])
+			return
+		}
+		bs.lowerExprIntoPlace(a.Value, dst, a.Value.Type())
+		return
+	}
+	// compound / multi-target assignments not yet handled in MIR.
+	bs.l.noteIssue("compound/multi-target assign not lowered to MIR (op=%d, targets=%d)",
+		a.Op, len(a.Targets))
+}
+
+func (bs *bodyState) lowerReturn(r *ir.ReturnStmt) {
+	if r.Value != nil {
+		bs.lowerExprInto(r.Value, bs.fn.ReturnLocal, bs.fn.ReturnType)
+	}
+	bs.terminate(&ReturnTerm{SpanV: r.SpanV})
+}
+
+func (bs *bodyState) lowerBreak(b *ir.BreakStmt) {
+	if len(bs.loopStack) == 0 {
+		bs.l.noteIssue("break outside loop")
+		return
+	}
+	top := bs.loopStack[len(bs.loopStack)-1]
+	bs.terminate(&GotoTerm{Target: top.breakBlock, SpanV: b.SpanV})
+}
+
+func (bs *bodyState) lowerContinue(c *ir.ContinueStmt) {
+	if len(bs.loopStack) == 0 {
+		bs.l.noteIssue("continue outside loop")
+		return
+	}
+	top := bs.loopStack[len(bs.loopStack)-1]
+	bs.terminate(&GotoTerm{Target: top.continueBlock, SpanV: c.SpanV})
+}
+
+func (bs *bodyState) lowerIfStmt(st *ir.IfStmt) {
+	cond := bs.lowerExprAsOperand(st.Cond)
+	thenBB := bs.newBlock(st.SpanV)
+	elseBB := bs.newBlock(st.SpanV)
+	merge := bs.newBlock(st.SpanV)
+	bs.terminate(&BranchTerm{Cond: cond, Then: thenBB, Else: elseBB, SpanV: st.SpanV})
+
+	bs.cur = thenBB
+	bs.pushScope()
+	for _, s := range st.Then.Stmts {
+		bs.lowerStmt(s)
+	}
+	if st.Then.Result != nil {
+		_ = bs.lowerExprAsOperand(st.Then.Result)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: merge, SpanV: st.SpanV})
+
+	bs.cur = elseBB
+	if st.Else != nil {
+		bs.pushScope()
+		for _, s := range st.Else.Stmts {
+			bs.lowerStmt(s)
+		}
+		if st.Else.Result != nil {
+			_ = bs.lowerExprAsOperand(st.Else.Result)
+		}
+		bs.popScope()
+	}
+	bs.terminate(&GotoTerm{Target: merge, SpanV: st.SpanV})
+
+	bs.cur = merge
+}
+
+func (bs *bodyState) lowerForStmt(f *ir.ForStmt) {
+	switch f.Kind {
+	case ir.ForInfinite:
+		bs.lowerForInfinite(f)
+	case ir.ForWhile:
+		bs.lowerForWhile(f)
+	case ir.ForRange:
+		bs.lowerForRange(f)
+	case ir.ForIn:
+		bs.lowerForIn(f)
+	default:
+		bs.l.noteIssue("unsupported for kind %d", f.Kind)
+	}
+}
+
+func (bs *bodyState) lowerForInfinite(f *ir.ForStmt) {
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = header
+	bs.terminate(&GotoTerm{Target: body, SpanV: f.SpanV})
+	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: header})
+	bs.cur = body
+	bs.pushScope()
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.cur = exit
+}
+
+func (bs *bodyState) lowerForWhile(f *ir.ForStmt) {
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = header
+	cond := bs.lowerExprAsOperand(f.Cond)
+	bs.terminate(&BranchTerm{Cond: cond, Then: body, Else: exit, SpanV: f.SpanV})
+	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: header})
+	bs.cur = body
+	bs.pushScope()
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.cur = exit
+}
+
+// ==== range / in loop lowering ====
+
+func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
+	idx := bs.fn.NewLocal(f.Var, TInt, true, f.SpanV)
+	bs.emit(&StorageLiveInstr{Local: idx, SpanV: f.SpanV})
+	bs.lowerExprInto(f.Start, idx, TInt)
+	end := bs.fn.NewLocal("_end", TInt, false, f.SpanV)
+	bs.lowerExprInto(f.End, end, TInt)
+	bs.bind(f.Var, idx)
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	step := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = header
+	cmpOp := BinLt
+	if f.Inclusive {
+		cmpOp = BinLeq
+	}
+	cmp := bs.freshTemp(TBool, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: cmp},
+		Src: &BinaryRV{
+			Op:    cmpOp,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &CopyOp{Place: Place{Local: end}, T: TInt},
+			T:     TBool,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&BranchTerm{
+		Cond:  &CopyOp{Place: Place{Local: cmp}, T: TBool},
+		Then:  body,
+		Else:  exit,
+		SpanV: f.SpanV,
+	})
+	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: step})
+	bs.cur = body
+	bs.pushScope()
+	bs.bind(f.Var, idx)
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
+	bs.cur = step
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: idx},
+		Src: &BinaryRV{
+			Op:    BinAdd,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+			T:     TInt,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.cur = exit
+}
+
+func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
+	iterT := f.Iter.Type()
+	if !isListType(iterT) {
+		bs.l.noteIssue("for-in over non-List iterable is not lowered to MIR yet")
+		return
+	}
+	elemT := listElementType(iterT)
+	if elemT == nil {
+		elemT = ir.ErrTypeVal
+	}
+	// capture iterable into a temp so we can re-read length and index
+	iter := bs.fn.NewLocal("_iter", iterT, false, f.SpanV)
+	bs.emit(&StorageLiveInstr{Local: iter, SpanV: f.SpanV})
+	bs.lowerExprInto(f.Iter, iter, iterT)
+	lenLocal := bs.fn.NewLocal("_len", TInt, false, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: lenLocal},
+		Src:   &LenRV{Place: Place{Local: iter}, T: TInt},
+		SpanV: f.SpanV,
+	})
+	idx := bs.fn.NewLocal("_idx", TInt, true, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: idx},
+		Src:   &UseRV{Op: &ConstOp{Const: &IntConst{Value: 0, T: TInt}, T: TInt}},
+		SpanV: f.SpanV,
+	})
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	step := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.cur = header
+	cmp := bs.freshTemp(TBool, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: cmp},
+		Src: &BinaryRV{
+			Op:    BinLt,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &CopyOp{Place: Place{Local: lenLocal}, T: TInt},
+			T:     TBool,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&BranchTerm{
+		Cond:  &CopyOp{Place: Place{Local: cmp}, T: TBool},
+		Then:  body,
+		Else:  exit,
+		SpanV: f.SpanV,
+	})
+	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: step})
+	bs.cur = body
+	bs.pushScope()
+	// load current element: elem = iter[idx]
+	elemLocal := bs.fn.NewLocal("_elem", elemT, false, f.SpanV)
+	elemPlace := Place{Local: iter, Projections: []Projection{
+		&IndexProj{
+			Index:    &CopyOp{Place: Place{Local: idx}, T: TInt},
+			ElemType: elemT,
+		},
+	}}
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: elemLocal},
+		Src:   &UseRV{Op: &CopyOp{Place: elemPlace, T: elemT}},
+		SpanV: f.SpanV,
+	})
+	if f.Pattern != nil {
+		bs.bindPattern(f.Pattern, Place{Local: elemLocal}, elemT, f.SpanV)
+	} else if f.Var != "" {
+		bs.bind(f.Var, elemLocal)
+	}
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
+	bs.cur = step
+	bs.emit(&AssignInstr{
+		Dest: Place{Local: idx},
+		Src: &BinaryRV{
+			Op:    BinAdd,
+			Left:  &CopyOp{Place: Place{Local: idx}, T: TInt},
+			Right: &ConstOp{Const: &IntConst{Value: 1, T: TInt}, T: TInt},
+			T:     TInt,
+		},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.cur = exit
+}
+
+// ==== match lowering ====
+
+func (bs *bodyState) lowerMatchStmt(m *ir.MatchStmt) {
+	// Discard the result; we only care about side effects.
+	bs.lowerMatch(m.Scrutinee, m.Arms, m.Tree, m.SpanV, nil, TUnit)
+}
+
+// lowerMatchExprInto lowers a MatchExpr into dest.
+func (bs *bodyState) lowerMatchExprInto(m *ir.MatchExpr, dest LocalID, destT Type) {
+	bs.lowerMatch(m.Scrutinee, m.Arms, m.Tree, m.SpanV, &dest, destT)
+}
+
+// lowerMatch drives match lowering using an optional decision tree.
+func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.DecisionNode, sp Span, dest *LocalID, destT Type) {
+	scrutT := scrutinee.Type()
+	if scrutT == nil {
+		scrutT = ir.ErrTypeVal
+	}
+	scrutLocal := bs.fn.NewLocal("_scrut", scrutT, false, sp)
+	bs.emit(&StorageLiveInstr{Local: scrutLocal, SpanV: sp})
+	bs.lowerExprInto(scrutinee, scrutLocal, scrutT)
+
+	merge := bs.newBlock(sp)
+	armBlocks := make([]BlockID, len(arms))
+	for i, arm := range arms {
+		armBlocks[i] = bs.newBlock(arm.SpanV)
+		_ = arm
+	}
+
+	// If we have a decision tree, use it.
+	if tree != nil {
+		ctx := &matchContext{
+			bs:         bs,
+			scrutLocal: scrutLocal,
+			scrutT:     scrutT,
+			armBlocks:  armBlocks,
+			merge:      merge,
+			sp:         sp,
+		}
+		ctx.lowerTree(tree)
+	} else {
+		// No decision tree: keep the module structurally valid by
+		// routing to arm 0 and flag an issue so the caller knows to
+		// fall back to the HIR backend path.
+		bs.l.noteIssue("match without decision tree not lowered to MIR")
+		if len(armBlocks) > 0 {
+			bs.terminate(&GotoTerm{Target: armBlocks[0], SpanV: sp})
+		} else {
+			bs.terminate(&UnreachableTerm{SpanV: sp})
+		}
+	}
+
+	// Lower each arm body into its block.
+	for i, arm := range arms {
+		bs.cur = armBlocks[i]
+		bs.pushScope()
+		// The decision tree already introduced bindings via MIR assigns.
+		// For tree-less fallback we would destructure here; we skip.
+		if arm.Body != nil {
+			for _, s := range arm.Body.Stmts {
+				bs.lowerStmt(s)
+			}
+			if dest != nil && arm.Body.Result != nil {
+				bs.lowerExprInto(arm.Body.Result, *dest, destT)
+			} else if arm.Body.Result != nil {
+				_ = bs.lowerExprAsOperand(arm.Body.Result)
+			}
+		}
+		bs.popScope()
+		bs.terminate(&GotoTerm{Target: merge, SpanV: arm.SpanV})
+	}
+
+	bs.cur = merge
+}
+
+type matchContext struct {
+	bs         *bodyState
+	scrutLocal LocalID
+	scrutT     Type
+	armBlocks  []BlockID
+	merge      BlockID
+	sp         Span
+}
+
+// lowerTree translates a HIR decision tree into MIR control flow that
+// converges on the appropriate arm block. It assumes the current
+// cursor is the block where the decision cascade should begin.
+func (mc *matchContext) lowerTree(node ir.DecisionNode) {
+	bs := mc.bs
+	switch n := node.(type) {
+	case *ir.DecisionLeaf:
+		if n.ArmIndex < 0 || n.ArmIndex >= len(mc.armBlocks) {
+			bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+			return
+		}
+		bs.terminate(&GotoTerm{Target: mc.armBlocks[n.ArmIndex], SpanV: mc.sp})
+	case *ir.DecisionFail:
+		bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+	case *ir.DecisionBind:
+		// Emit Assign dest = scrutinee[proj]
+		projType := projectionResultType(bs.l, mc.scrutT, n.Proj)
+		if n.T != nil {
+			projType = n.T
+		}
+		place := projectionToPlace(bs.l, mc.scrutLocal, mc.scrutT, n.Proj)
+		id := bs.fn.NewLocal(n.Name, projType, false, mc.sp)
+		bs.emit(&StorageLiveInstr{Local: id, SpanV: mc.sp})
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: id},
+			Src:   &UseRV{Op: &CopyOp{Place: place, T: projType}},
+			SpanV: mc.sp,
+		})
+		bs.bind(n.Name, id)
+		mc.lowerTree(n.Next)
+	case *ir.DecisionGuard:
+		if n.Cond == nil {
+			// Unconditional edge to Then.
+			mc.lowerTree(n.Then)
+			return
+		}
+		cond := bs.lowerExprAsOperand(n.Cond)
+		thenBB := bs.newBlock(mc.sp)
+		elseBB := bs.newBlock(mc.sp)
+		bs.terminate(&BranchTerm{Cond: cond, Then: thenBB, Else: elseBB, SpanV: mc.sp})
+		bs.cur = thenBB
+		mc.lowerTree(n.Then)
+		bs.cur = elseBB
+		mc.lowerTree(n.Else)
+	case *ir.DecisionSwitch:
+		mc.lowerSwitch(n)
+	default:
+		bs.l.noteIssue("decision tree: unsupported node %T", node)
+		bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+	}
+}
+
+func (mc *matchContext) lowerSwitch(sw *ir.DecisionSwitch) {
+	bs := mc.bs
+	projType := projectionResultType(bs.l, mc.scrutT, sw.Proj)
+	projPlace := projectionToPlace(bs.l, mc.scrutLocal, mc.scrutT, sw.Proj)
+	switch sw.Kind {
+	case ir.SwitchVariant:
+		// Read discriminant and dispatch.
+		disc := bs.freshTemp(TInt, mc.sp)
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: disc},
+			Src:   &DiscriminantRV{Place: projPlace, T: TInt},
+			SpanV: mc.sp,
+		})
+		cases := make([]SwitchCase, 0, len(sw.Cases))
+		caseBlocks := make([]BlockID, len(sw.Cases))
+		for i := range sw.Cases {
+			caseBlocks[i] = bs.newBlock(mc.sp)
+		}
+		defaultBB := bs.newBlock(mc.sp)
+		for i, c := range sw.Cases {
+			varIdx := bs.l.variantIndexByName(projType, c.Variant)
+			cases = append(cases, SwitchCase{
+				Value:  int64(varIdx),
+				Target: caseBlocks[i],
+				Label:  c.Variant,
+			})
+		}
+		bs.terminate(&SwitchIntTerm{
+			Scrutinee: &CopyOp{Place: Place{Local: disc}, T: TInt},
+			Cases:     cases,
+			Default:   defaultBB,
+			SpanV:     mc.sp,
+		})
+		for i, c := range sw.Cases {
+			bs.cur = caseBlocks[i]
+			mc.lowerTree(c.Body)
+		}
+		bs.cur = defaultBB
+		if sw.Default != nil {
+			mc.lowerTree(sw.Default)
+		} else {
+			bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+		}
+	case ir.SwitchBool:
+		// Two-way branch on bool projection.
+		thenBB := bs.newBlock(mc.sp)
+		elseBB := bs.newBlock(mc.sp)
+		bs.terminate(&BranchTerm{
+			Cond:  &CopyOp{Place: projPlace, T: TBool},
+			Then:  thenBB,
+			Else:  elseBB,
+			SpanV: mc.sp,
+		})
+		// Cases are either {true} or {false} or both; run them.
+		trueBB, falseBB := thenBB, elseBB
+		trueHandled, falseHandled := false, false
+		for _, c := range sw.Cases {
+			if strings.EqualFold(c.Label, "true") {
+				bs.cur = trueBB
+				mc.lowerTree(c.Body)
+				trueHandled = true
+			} else {
+				bs.cur = falseBB
+				mc.lowerTree(c.Body)
+				falseHandled = true
+			}
+		}
+		if !trueHandled {
+			bs.cur = trueBB
+			if sw.Default != nil {
+				mc.lowerTree(sw.Default)
+			} else {
+				bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+			}
+		}
+		if !falseHandled {
+			bs.cur = falseBB
+			if sw.Default != nil {
+				mc.lowerTree(sw.Default)
+			} else {
+				bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+			}
+		}
+	case ir.SwitchLit:
+		// Chain of eq-branches. First try integer cases into a SwitchInt.
+		// If any case has a non-integer literal we fall back to the
+		// branch chain.
+		allInt := true
+		intVals := make([]int64, 0, len(sw.Cases))
+		for _, c := range sw.Cases {
+			il, ok := c.Lit.(*ir.IntLit)
+			if !ok {
+				allInt = false
+				break
+			}
+			v, err := strconv.ParseInt(il.Text, 0, 64)
+			if err != nil {
+				allInt = false
+				break
+			}
+			intVals = append(intVals, v)
+		}
+		if allInt {
+			cases := make([]SwitchCase, len(sw.Cases))
+			bodies := make([]BlockID, len(sw.Cases))
+			for i := range sw.Cases {
+				bodies[i] = bs.newBlock(mc.sp)
+				cases[i] = SwitchCase{Value: intVals[i], Target: bodies[i], Label: sw.Cases[i].Label}
+			}
+			def := bs.newBlock(mc.sp)
+			bs.terminate(&SwitchIntTerm{
+				Scrutinee: &CopyOp{Place: projPlace, T: projType},
+				Cases:     cases,
+				Default:   def,
+				SpanV:     mc.sp,
+			})
+			for i, c := range sw.Cases {
+				bs.cur = bodies[i]
+				mc.lowerTree(c.Body)
+			}
+			bs.cur = def
+			if sw.Default != nil {
+				mc.lowerTree(sw.Default)
+			} else {
+				bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+			}
+			return
+		}
+		// Mixed / non-integer literal chain.
+		var defTarget BlockID
+		if sw.Default != nil {
+			defTarget = bs.newBlock(mc.sp)
+		} else {
+			defTarget = bs.newBlock(mc.sp)
+		}
+		next := defTarget
+		for i := len(sw.Cases) - 1; i >= 0; i-- {
+			c := sw.Cases[i]
+			caseBB := bs.newBlock(mc.sp)
+			testBB := bs.newBlock(mc.sp)
+			// Lower the literal into an operand.
+			rhs := bs.lowerExprAsOperand(c.Lit)
+			cmp := bs.freshTemp(TBool, mc.sp)
+			bs.emit(&AssignInstr{
+				Dest: Place{Local: cmp},
+				Src: &BinaryRV{
+					Op:    BinEq,
+					Left:  &CopyOp{Place: projPlace, T: projType},
+					Right: rhs,
+					T:     TBool,
+				},
+				SpanV: mc.sp,
+			})
+			bs.terminate(&BranchTerm{
+				Cond:  &CopyOp{Place: Place{Local: cmp}, T: TBool},
+				Then:  caseBB,
+				Else:  next,
+				SpanV: mc.sp,
+			})
+			bs.cur = caseBB
+			mc.lowerTree(c.Body)
+			bs.cur = testBB
+			next = testBB
+		}
+		bs.cur = defTarget
+		if sw.Default != nil {
+			mc.lowerTree(sw.Default)
+		} else {
+			bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+		}
+	case ir.SwitchTuple:
+		// A SwitchTuple has exactly one case that destructures; no
+		// actual conditional branch is needed beyond the bindings.
+		if len(sw.Cases) > 0 {
+			mc.lowerTree(sw.Cases[0].Body)
+		} else if sw.Default != nil {
+			mc.lowerTree(sw.Default)
+		} else {
+			bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+		}
+	default:
+		bs.l.noteIssue("unsupported switch kind %d", sw.Kind)
+		bs.terminate(&UnreachableTerm{SpanV: mc.sp})
+	}
+}
+
+// ==== expression lowering ====
+
+// lowerExprInto lowers e and stores its value in dest.
+func (bs *bodyState) lowerExprInto(e ir.Expr, dest LocalID, destT Type) {
+	bs.lowerExprIntoPlace(e, Place{Local: dest}, destT)
+}
+
+// lowerExprIntoPlace lowers e and stores its value in dest (which may
+// have projections).
+func (bs *bodyState) lowerExprIntoPlace(e ir.Expr, dest Place, destT Type) {
+	switch x := e.(type) {
+	case nil:
+		return
+	case *ir.IfExpr:
+		bs.lowerIfExprInto(x, dest, destT)
+		return
+	case *ir.IfLetExpr:
+		bs.lowerIfLetExprInto(x, dest, destT)
+		return
+	case *ir.BlockExpr:
+		bs.lowerBlockExprInto(x, dest, destT)
+		return
+	case *ir.MatchExpr:
+		bs.lowerMatchExprIntoPlace(x, dest, destT)
+		return
+	case *ir.CoalesceExpr:
+		bs.lowerCoalesceInto(x, dest, destT)
+		return
+	case *ir.QuestionExpr:
+		bs.lowerQuestionInto(x, dest, destT)
+		return
+	case *ir.FieldExpr:
+		if x.Optional {
+			bs.lowerOptionalFieldInto(x, dest, destT)
+			return
+		}
+	case *ir.MethodCall:
+		bs.lowerMethodCallInto(x, dest, destT)
+		return
+	case *ir.CallExpr:
+		bs.lowerCallExprInto(x, &dest, destT)
+		return
+	case *ir.IntrinsicCall:
+		bs.lowerIntrinsicCallInto(x, &dest)
+		return
+	}
+	// Default path: lower to an rvalue and assign.
+	rv := bs.lowerExprToRValue(e, destT)
+	if rv == nil {
+		return
+	}
+	bs.emit(&AssignInstr{Dest: dest, Src: rv, SpanV: exprSpan(e)})
+}
+
+// lowerExprAsOperand lowers e and returns an operand holding its
+// value. Used for call arguments and conditions.
+func (bs *bodyState) lowerExprAsOperand(e ir.Expr) Operand {
+	switch x := e.(type) {
+	case nil:
+		return &ConstOp{Const: &UnitConst{}, T: TUnit}
+	case *ir.IntLit:
+		v, _ := strconv.ParseInt(strings.ReplaceAll(x.Text, "_", ""), 0, 64)
+		t := x.T
+		if t == nil {
+			t = TInt
+		}
+		return &ConstOp{Const: &IntConst{Value: v, T: t}, T: t}
+	case *ir.FloatLit:
+		v, _ := strconv.ParseFloat(strings.ReplaceAll(x.Text, "_", ""), 64)
+		t := x.T
+		if t == nil {
+			t = TFloat
+		}
+		return &ConstOp{Const: &FloatConst{Value: v, T: t}, T: t}
+	case *ir.BoolLit:
+		return &ConstOp{Const: &BoolConst{Value: x.Value}, T: TBool}
+	case *ir.CharLit:
+		return &ConstOp{Const: &CharConst{Value: x.Value}, T: TChar}
+	case *ir.ByteLit:
+		return &ConstOp{Const: &ByteConst{Value: x.Value}, T: TByte}
+	case *ir.UnitLit:
+		return &ConstOp{Const: &UnitConst{}, T: TUnit}
+	case *ir.StringLit:
+		return bs.lowerStringLit(x)
+	case *ir.Ident:
+		return bs.lowerIdent(x)
+	}
+	// For anything else: allocate a temp and lower into it.
+	t := e.Type()
+	if t == nil {
+		t = ir.ErrTypeVal
+	}
+	tmp := bs.freshTemp(t, exprSpan(e))
+	bs.lowerExprInto(e, tmp, t)
+	return &CopyOp{Place: Place{Local: tmp}, T: t}
+}
+
+// lowerExprToRValue lowers a non-control-flow expression into an
+// RValue suitable for the RHS of an Assign.
+func (bs *bodyState) lowerExprToRValue(e ir.Expr, hint Type) RValue {
+	switch x := e.(type) {
+	case nil:
+		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
+	case *ir.UnaryExpr:
+		return &UnaryRV{
+			Op:  mapUnaryOp(x.Op),
+			Arg: bs.lowerExprAsOperand(x.X),
+			T:   x.T,
+		}
+	case *ir.BinaryExpr:
+		return &BinaryRV{
+			Op:    mapBinaryOp(x.Op),
+			Left:  bs.lowerExprAsOperand(x.Left),
+			Right: bs.lowerExprAsOperand(x.Right),
+			T:     x.T,
+		}
+	case *ir.FieldExpr:
+		if !x.Optional {
+			// Plain field access; lower receiver into a place and
+			// project.
+			recvPlace, ok := bs.lowerExprToPlace(x.X)
+			if !ok {
+				// Fall back: lower X into a temp.
+				t := x.X.Type()
+				tmp := bs.freshTemp(t, exprSpan(x.X))
+				bs.lowerExprInto(x.X, tmp, t)
+				recvPlace = Place{Local: tmp}
+			}
+			info := bs.l.structFromType(x.X.Type(), "")
+			idx := bs.l.fieldIndex(info, x.Name)
+			proj := &FieldProj{Index: idx, Name: x.Name, Type: x.T}
+			return &UseRV{Op: &CopyOp{Place: recvPlace.Project(proj), T: x.T}}
+		}
+		// Optional field — handled via lowerOptionalFieldInto (the
+		// caller should have routed us through lowerExprIntoPlace).
+		bs.l.noteIssue("optional field expression reached lowerExprToRValue")
+		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
+	case *ir.TupleAccess:
+		recvPlace, ok := bs.lowerExprToPlace(x.X)
+		if !ok {
+			t := x.X.Type()
+			tmp := bs.freshTemp(t, exprSpan(x.X))
+			bs.lowerExprInto(x.X, tmp, t)
+			recvPlace = Place{Local: tmp}
+		}
+		return &UseRV{Op: &CopyOp{Place: recvPlace.Project(&TupleProj{Index: x.Index, Type: x.T}), T: x.T}}
+	case *ir.IndexExpr:
+		recvPlace, ok := bs.lowerExprToPlace(x.X)
+		if !ok {
+			t := x.X.Type()
+			tmp := bs.freshTemp(t, exprSpan(x.X))
+			bs.lowerExprInto(x.X, tmp, t)
+			recvPlace = Place{Local: tmp}
+		}
+		idx := bs.lowerExprAsOperand(x.Index)
+		return &UseRV{Op: &CopyOp{Place: recvPlace.Project(&IndexProj{Index: idx, ElemType: x.T}), T: x.T}}
+	case *ir.TupleLit:
+		fields := make([]Operand, len(x.Elems))
+		for i, e := range x.Elems {
+			fields[i] = bs.lowerExprAsOperand(e)
+		}
+		return &AggregateRV{Kind: AggTuple, Fields: fields, T: x.T}
+	case *ir.ListLit:
+		fields := make([]Operand, len(x.Elems))
+		for i, e := range x.Elems {
+			fields[i] = bs.lowerExprAsOperand(e)
+		}
+		lt := hint
+		if lt == nil {
+			lt = x.Type()
+		}
+		return &AggregateRV{Kind: AggList, Fields: fields, T: lt}
+	case *ir.StructLit:
+		return bs.lowerStructLit(x, hint)
+	case *ir.VariantLit:
+		return bs.lowerVariantLit(x, hint)
+	case *ir.RangeLit:
+		// Range values — unsupported in value position for MIR stage 1.
+		bs.l.noteIssue("range literal in value position not lowered to MIR")
+		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
+	case *ir.Closure:
+		bs.l.noteIssue("closure literal not lowered to MIR (stage 2 work)")
+		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
+	case *ir.ErrorExpr:
+		bs.l.noteIssue("error expression reached MIR: %s", x.Note)
+		return &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}}
+	}
+	// Fallback: lower as operand and wrap in UseRV.
+	return &UseRV{Op: bs.lowerExprAsOperand(e)}
+}
+
+// lowerExprToPlace tries to describe e as a Place without materialising
+// intermediate storage. Returns false when the expression is not a
+// place expression (arithmetic, call, etc.).
+func (bs *bodyState) lowerExprToPlace(e ir.Expr) (Place, bool) {
+	switch x := e.(type) {
+	case *ir.Ident:
+		if id, ok := bs.lookup(x.Name); ok {
+			return Place{Local: id}, true
+		}
+	case *ir.FieldExpr:
+		if x.Optional {
+			return Place{}, false
+		}
+		recv, ok := bs.lowerExprToPlace(x.X)
+		if !ok {
+			return Place{}, false
+		}
+		info := bs.l.structFromType(x.X.Type(), "")
+		idx := bs.l.fieldIndex(info, x.Name)
+		return recv.Project(&FieldProj{Index: idx, Name: x.Name, Type: x.T}), true
+	case *ir.TupleAccess:
+		recv, ok := bs.lowerExprToPlace(x.X)
+		if !ok {
+			return Place{}, false
+		}
+		return recv.Project(&TupleProj{Index: x.Index, Type: x.T}), true
+	case *ir.IndexExpr:
+		recv, ok := bs.lowerExprToPlace(x.X)
+		if !ok {
+			return Place{}, false
+		}
+		idx := bs.lowerExprAsOperand(x.Index)
+		return recv.Project(&IndexProj{Index: idx, ElemType: x.T}), true
+	}
+	return Place{}, false
+}
+
+// lowerIdent turns an Ident into an operand.
+func (bs *bodyState) lowerIdent(id *ir.Ident) Operand {
+	switch id.Kind {
+	case ir.IdentFn:
+		fnType := id.T
+		return &ConstOp{Const: &FnConst{Symbol: id.Name, T: fnType}, T: fnType}
+	case ir.IdentGlobal:
+		return &CopyOp{Place: Place{Local: bs.externalGlobalLocal(id.Name, id.T)}, T: id.T}
+	case ir.IdentVariant:
+		// bare variant → aggregate with no payload.
+		t := id.T
+		if t == nil {
+			t = ir.ErrTypeVal
+		}
+		tmp := bs.freshTemp(t, id.SpanV)
+		idx := bs.l.variantIndexByName(t, id.Name)
+		bs.emit(&AssignInstr{
+			Dest: Place{Local: tmp},
+			Src: &AggregateRV{
+				Kind:       AggEnumVariant,
+				Fields:     nil,
+				T:          t,
+				VariantIdx: idx,
+				VariantTag: id.Name,
+			},
+			SpanV: id.SpanV,
+		})
+		return &CopyOp{Place: Place{Local: tmp}, T: t}
+	}
+	if localID, ok := bs.lookup(id.Name); ok {
+		loc := bs.fn.Local(localID)
+		t := id.T
+		if loc != nil && loc.Type != nil {
+			t = loc.Type
+		}
+		return &CopyOp{Place: Place{Local: localID}, T: t}
+	}
+	// Unknown identifier — possibly a top-level fn not captured in our
+	// signature table; fall back to FnConst.
+	if id.Name != "" {
+		t := id.T
+		if t == nil {
+			t = ir.ErrTypeVal
+		}
+		return &ConstOp{Const: &FnConst{Symbol: id.Name, T: t}, T: t}
+	}
+	return &ConstOp{Const: &UnitConst{}, T: TUnit}
+}
+
+// externalGlobalLocal allocates a local for a top-level global access
+// on first use. Subsequent reads reuse it.
+func (bs *bodyState) externalGlobalLocal(name string, t Type) LocalID {
+	if id, ok := bs.lookup(name); ok {
+		return id
+	}
+	id := bs.fn.NewLocal(name, t, false, Span{})
+	bs.bind(name, id)
+	// Issue a note — backend consumer will need to materialise the
+	// global load.
+	bs.l.noteIssue("global read %q materialised as uninitialised local (stage 2 work)", name)
+	return id
+}
+
+// lowerStringLit returns an operand for a StringLit.
+func (bs *bodyState) lowerStringLit(s *ir.StringLit) Operand {
+	if !hasInterpolation(s) {
+		var b strings.Builder
+		for _, p := range s.Parts {
+			if p.IsLit {
+				b.WriteString(p.Lit)
+			}
+		}
+		return &ConstOp{Const: &StringConst{Value: b.String()}, T: TString}
+	}
+	// Interpolated: emit a string_concat intrinsic call.
+	args := make([]Operand, 0, len(s.Parts))
+	for _, p := range s.Parts {
+		if p.IsLit {
+			args = append(args, &ConstOp{Const: &StringConst{Value: p.Lit}, T: TString})
+			continue
+		}
+		op := bs.lowerExprAsOperand(p.Expr)
+		args = append(args, op)
+	}
+	tmp := bs.freshTemp(TString, s.SpanV)
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: tmp},
+		Kind:  IntrinsicStringConcat,
+		Args:  args,
+		SpanV: s.SpanV,
+	})
+	return &CopyOp{Place: Place{Local: tmp}, T: TString}
+}
+
+// lowerIfExprInto lowers an IfExpr by reusing the stmt-form lowering
+// and threading a result slot.
+func (bs *bodyState) lowerIfExprInto(ie *ir.IfExpr, dest Place, destT Type) {
+	cond := bs.lowerExprAsOperand(ie.Cond)
+	thenBB := bs.newBlock(ie.SpanV)
+	elseBB := bs.newBlock(ie.SpanV)
+	merge := bs.newBlock(ie.SpanV)
+	bs.terminate(&BranchTerm{Cond: cond, Then: thenBB, Else: elseBB, SpanV: ie.SpanV})
+	bs.cur = thenBB
+	bs.pushScope()
+	for _, s := range ie.Then.Stmts {
+		bs.lowerStmt(s)
+	}
+	if ie.Then.Result != nil {
+		bs.lowerExprIntoPlace(ie.Then.Result, dest, destT)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: merge, SpanV: ie.SpanV})
+	bs.cur = elseBB
+	if ie.Else != nil {
+		bs.pushScope()
+		for _, s := range ie.Else.Stmts {
+			bs.lowerStmt(s)
+		}
+		if ie.Else.Result != nil {
+			bs.lowerExprIntoPlace(ie.Else.Result, dest, destT)
+		}
+		bs.popScope()
+	}
+	bs.terminate(&GotoTerm{Target: merge, SpanV: ie.SpanV})
+	bs.cur = merge
+}
+
+// lowerBlockExprInto lowers a BlockExpr into dest.
+func (bs *bodyState) lowerBlockExprInto(be *ir.BlockExpr, dest Place, destT Type) {
+	if be.Block == nil {
+		return
+	}
+	bs.pushScope()
+	for _, s := range be.Block.Stmts {
+		bs.lowerStmt(s)
+	}
+	if be.Block.Result != nil {
+		bs.lowerExprIntoPlace(be.Block.Result, dest, destT)
+	}
+	bs.popScope()
+}
+
+// lowerIfLetExprInto handles `if let pat = scrut { … } else { … }`.
+// It lowers into a discriminant test + payload binding for Option /
+// enum variants, and falls back to an unsupported note otherwise.
+func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Type) {
+	scrut := ife.Scrutinee
+	scrutT := scrut.Type()
+	scrutLocal := bs.fn.NewLocal("_iflet", scrutT, false, ife.SpanV)
+	bs.emit(&StorageLiveInstr{Local: scrutLocal, SpanV: ife.SpanV})
+	bs.lowerExprInto(scrut, scrutLocal, scrutT)
+
+	vp, ok := ife.Pattern.(*ir.VariantPat)
+	if !ok {
+		bs.l.noteIssue("if-let with non-variant pattern not lowered to MIR: %T", ife.Pattern)
+		// Always take the else branch to stay conservative.
+		if ife.Else != nil {
+			bs.pushScope()
+			for _, s := range ife.Else.Stmts {
+				bs.lowerStmt(s)
+			}
+			if ife.Else.Result != nil {
+				bs.lowerExprIntoPlace(ife.Else.Result, dest, destT)
+			}
+			bs.popScope()
+		}
+		return
+	}
+	varIdx := bs.l.variantIndexByName(scrutT, vp.Variant)
+	disc := bs.freshTemp(TInt, ife.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: disc},
+		Src:   &DiscriminantRV{Place: Place{Local: scrutLocal}, T: TInt},
+		SpanV: ife.SpanV,
+	})
+	thenBB := bs.newBlock(ife.SpanV)
+	elseBB := bs.newBlock(ife.SpanV)
+	merge := bs.newBlock(ife.SpanV)
+	bs.terminate(&SwitchIntTerm{
+		Scrutinee: &CopyOp{Place: Place{Local: disc}, T: TInt},
+		Cases:     []SwitchCase{{Value: int64(varIdx), Target: thenBB, Label: vp.Variant}},
+		Default:   elseBB,
+		SpanV:     ife.SpanV,
+	})
+	bs.cur = thenBB
+	bs.pushScope()
+	// Bind payload elements.
+	layout := bs.l.variantLayout(vp.Enum, vp.Variant)
+	for i, arg := range vp.Args {
+		pt := variantPayloadType(layout, i)
+		proj := &VariantProj{Variant: variantIndex(layout), Name: vp.Variant, FieldIdx: i, Type: pt}
+		child := Place{Local: scrutLocal}.Project(proj)
+		bs.bindPattern(arg, child, pt, ife.SpanV)
+	}
+	for _, s := range ife.Then.Stmts {
+		bs.lowerStmt(s)
+	}
+	if ife.Then.Result != nil {
+		bs.lowerExprIntoPlace(ife.Then.Result, dest, destT)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: merge, SpanV: ife.SpanV})
+	bs.cur = elseBB
+	if ife.Else != nil {
+		bs.pushScope()
+		for _, s := range ife.Else.Stmts {
+			bs.lowerStmt(s)
+		}
+		if ife.Else.Result != nil {
+			bs.lowerExprIntoPlace(ife.Else.Result, dest, destT)
+		}
+		bs.popScope()
+	}
+	bs.terminate(&GotoTerm{Target: merge, SpanV: ife.SpanV})
+	bs.cur = merge
+}
+
+// lowerMatchExprIntoPlace routes through the generic matcher.
+func (bs *bodyState) lowerMatchExprIntoPlace(m *ir.MatchExpr, dest Place, destT Type) {
+	// For simplicity: allocate a local, drive match into it, then copy
+	// into the requested place.
+	t := destT
+	if t == nil {
+		t = m.T
+	}
+	local := bs.fn.NewLocal("_match", t, false, m.SpanV)
+	bs.emit(&StorageLiveInstr{Local: local, SpanV: m.SpanV})
+	bs.lowerMatch(m.Scrutinee, m.Arms, m.Tree, m.SpanV, &local, t)
+	bs.emit(&AssignInstr{
+		Dest:  dest,
+		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: local}, T: t}},
+		SpanV: m.SpanV,
+	})
+}
+
+// lowerCoalesceInto handles `left ?? right`.
+func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Type) {
+	leftT := c.Left.Type()
+	leftLocal := bs.fn.NewLocal("_coalesce", leftT, false, c.SpanV)
+	bs.emit(&StorageLiveInstr{Local: leftLocal, SpanV: c.SpanV})
+	bs.lowerExprInto(c.Left, leftLocal, leftT)
+	disc := bs.freshTemp(TInt, c.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: disc},
+		Src:   &DiscriminantRV{Place: Place{Local: leftLocal}, T: TInt},
+		SpanV: c.SpanV,
+	})
+	someBB := bs.newBlock(c.SpanV)
+	noneBB := bs.newBlock(c.SpanV)
+	merge := bs.newBlock(c.SpanV)
+	bs.terminate(&SwitchIntTerm{
+		Scrutinee: &CopyOp{Place: Place{Local: disc}, T: TInt},
+		Cases:     []SwitchCase{{Value: someTagOf(leftT), Target: someBB, Label: "Some"}},
+		Default:   noneBB,
+		SpanV:     c.SpanV,
+	})
+	bs.cur = someBB
+	payloadProj := &VariantProj{Variant: int(someTagOf(leftT)), Name: "Some", FieldIdx: 0, Type: destT}
+	bs.emit(&AssignInstr{
+		Dest:  dest,
+		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: leftLocal}.Project(payloadProj), T: destT}},
+		SpanV: c.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: merge, SpanV: c.SpanV})
+	bs.cur = noneBB
+	bs.lowerExprIntoPlace(c.Right, dest, destT)
+	bs.terminate(&GotoTerm{Target: merge, SpanV: c.SpanV})
+	bs.cur = merge
+}
+
+// lowerQuestionInto handles `e?`. The receiver must be Option<T> or
+// Result<T, E>. For None/Err we early-return the same none/err value
+// via the function's return local.
+func (bs *bodyState) lowerQuestionInto(q *ir.QuestionExpr, dest Place, destT Type) {
+	xT := q.X.Type()
+	tmp := bs.fn.NewLocal("_q", xT, false, q.SpanV)
+	bs.emit(&StorageLiveInstr{Local: tmp, SpanV: q.SpanV})
+	bs.lowerExprInto(q.X, tmp, xT)
+	disc := bs.freshTemp(TInt, q.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: disc},
+		Src:   &DiscriminantRV{Place: Place{Local: tmp}, T: TInt},
+		SpanV: q.SpanV,
+	})
+	okBB := bs.newBlock(q.SpanV)
+	errBB := bs.newBlock(q.SpanV)
+	bs.terminate(&SwitchIntTerm{
+		Scrutinee: &CopyOp{Place: Place{Local: disc}, T: TInt},
+		Cases:     []SwitchCase{{Value: okTagOf(xT), Target: okBB, Label: okVariantName(xT)}},
+		Default:   errBB,
+		SpanV:     q.SpanV,
+	})
+	bs.cur = errBB
+	// Wrap the failure into the fn's return type; for now we just copy
+	// tmp into the return slot (works when return type is the same as
+	// the operand type, as in typical Result/Option propagation).
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: bs.fn.ReturnLocal},
+		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: tmp}, T: xT}},
+		SpanV: q.SpanV,
+	})
+	bs.terminate(&ReturnTerm{SpanV: q.SpanV})
+	bs.cur = okBB
+	payloadProj := &VariantProj{
+		Variant:  int(okTagOf(xT)),
+		Name:     okVariantName(xT),
+		FieldIdx: 0,
+		Type:     destT,
+	}
+	bs.emit(&AssignInstr{
+		Dest:  dest,
+		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: tmp}.Project(payloadProj), T: destT}},
+		SpanV: q.SpanV,
+	})
+}
+
+// lowerOptionalFieldInto handles `x?.field`.
+func (bs *bodyState) lowerOptionalFieldInto(fe *ir.FieldExpr, dest Place, destT Type) {
+	recvT := fe.X.Type()
+	recvLocal := bs.fn.NewLocal("_opt", recvT, false, fe.SpanV)
+	bs.emit(&StorageLiveInstr{Local: recvLocal, SpanV: fe.SpanV})
+	bs.lowerExprInto(fe.X, recvLocal, recvT)
+	disc := bs.freshTemp(TInt, fe.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: disc},
+		Src:   &DiscriminantRV{Place: Place{Local: recvLocal}, T: TInt},
+		SpanV: fe.SpanV,
+	})
+	someBB := bs.newBlock(fe.SpanV)
+	noneBB := bs.newBlock(fe.SpanV)
+	merge := bs.newBlock(fe.SpanV)
+	bs.terminate(&SwitchIntTerm{
+		Scrutinee: &CopyOp{Place: Place{Local: disc}, T: TInt},
+		Cases:     []SwitchCase{{Value: someTagOf(recvT), Target: someBB, Label: "Some"}},
+		Default:   noneBB,
+		SpanV:     fe.SpanV,
+	})
+	bs.cur = someBB
+	// Extract payload, project field, wrap back in Some.
+	innerT := optionInnerType(recvT)
+	payloadProj := &VariantProj{Variant: int(someTagOf(recvT)), Name: "Some", FieldIdx: 0, Type: innerT}
+	info := bs.l.structFromType(innerT, "")
+	fieldT := bs.l.fieldType(info, fe.Name)
+	idx := bs.l.fieldIndex(info, fe.Name)
+	fieldPlace := Place{Local: recvLocal}.Project(payloadProj).Project(&FieldProj{Index: idx, Name: fe.Name, Type: fieldT})
+	// destT is T? (Option wrapper); wrap.
+	bs.emit(&AssignInstr{
+		Dest: dest,
+		Src: &AggregateRV{
+			Kind:       AggEnumVariant,
+			Fields:     []Operand{&CopyOp{Place: fieldPlace, T: fieldT}},
+			T:          destT,
+			VariantIdx: int(someTagOf(destT)),
+			VariantTag: "Some",
+		},
+		SpanV: fe.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: merge, SpanV: fe.SpanV})
+	bs.cur = noneBB
+	bs.emit(&AssignInstr{
+		Dest: dest,
+		Src: &NullaryRV{
+			Kind: NullaryNone,
+			T:    destT,
+		},
+		SpanV: fe.SpanV,
+	})
+	bs.terminate(&GotoTerm{Target: merge, SpanV: fe.SpanV})
+	bs.cur = merge
+}
+
+// ==== calls ====
+
+func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) {
+	args, callee := bs.resolveCall(c)
+	if callee == nil {
+		bs.l.noteIssue("unsupported call: callee %T", c.Callee)
+		return
+	}
+	if dest != nil && isUnit(destT) {
+		dest = nil
+	}
+	bs.emit(&CallInstr{Dest: dest, Callee: callee, Args: args, SpanV: c.SpanV})
+}
+
+// resolveCall figures out the callee and reorders keyword args.
+func (bs *bodyState) resolveCall(c *ir.CallExpr) ([]Operand, Callee) {
+	switch cal := c.Callee.(type) {
+	case *ir.Ident:
+		if cal.Kind == ir.IdentVariant {
+			// variant construction via call-like syntax; return nil to
+			// let the caller re-route through lowerExprToRValue.
+			return nil, nil
+		}
+		sig := bs.l.signatureForFn(cal.Name)
+		args := bs.orderArgs(c.Args, sig)
+		ft := cal.T
+		return args, &FnRef{Symbol: cal.Name, Type: ft}
+	case *ir.FieldExpr:
+		// Callee like `foo.bar`: a package-qualified or method-style call.
+		// For runtime FFI we still route through FnRef with the field name.
+		recv := bs.lowerExprAsOperand(cal.X)
+		args := append([]Operand{recv}, bs.orderArgs(c.Args, nil)...)
+		return args, &FnRef{Symbol: cal.Name, Type: cal.T}
+	}
+	// Indirect call via operand.
+	args := bs.orderArgs(c.Args, nil)
+	callee := bs.lowerExprAsOperand(c.Callee)
+	return args, &IndirectCall{Callee: callee}
+}
+
+func (bs *bodyState) orderArgs(args []ir.Arg, sig *fnSignature) []Operand {
+	if sig == nil {
+		// No signature available — preserve source order, ignore kw
+		// names. Safe for direct positional calls.
+		out := make([]Operand, len(args))
+		for i, a := range args {
+			out[i] = bs.lowerExprAsOperand(a.Value)
+		}
+		return out
+	}
+	// Map kw → index.
+	paramCount := len(sig.params)
+	out := make([]Operand, paramCount)
+	filled := make([]bool, paramCount)
+	// positional first
+	pos := 0
+	for _, a := range args {
+		if a.IsKeyword() {
+			for i, p := range sig.params {
+				if p.Name == a.Name {
+					out[i] = bs.lowerExprAsOperand(a.Value)
+					filled[i] = true
+					break
+				}
+			}
+			continue
+		}
+		if pos < paramCount {
+			out[pos] = bs.lowerExprAsOperand(a.Value)
+			filled[pos] = true
+		}
+		pos++
+	}
+	// defaults for any unfilled.
+	for i, f := range filled {
+		if f {
+			continue
+		}
+		p := sig.params[i]
+		if p.Default != nil {
+			out[i] = bs.lowerExprAsOperand(p.Default)
+			continue
+		}
+		// leave nil; validator catches it if backend relies on arity.
+		bs.l.noteIssue("call %q: unfilled param %d (%s)", sig.symbol, i, p.Name)
+	}
+	return out
+}
+
+func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Type) {
+	recv := bs.lowerExprAsOperand(mc.Receiver)
+	typeName := typeNameOf(mc.Receiver.Type())
+	sig := bs.l.signatureForMethod(typeName, mc.Name)
+	symbol := mc.Name
+	if sig != nil {
+		symbol = sig.symbol
+	} else if typeName != "" {
+		symbol = mangleMethodSymbol(typeName, mc.Name)
+	}
+	callArgs := []Operand{recv}
+	var rest []Operand
+	if sig != nil {
+		// The stored signature has `self` as its first parameter;
+		// build a virtual signature covering only the non-receiver
+		// params so orderArgs/kwargs lookups match the call site.
+		rest = bs.orderArgs(mc.Args, methodCallSig(sig))
+	} else {
+		rest = make([]Operand, len(mc.Args))
+		for i, a := range mc.Args {
+			rest[i] = bs.lowerExprAsOperand(a.Value)
+		}
+	}
+	callArgs = append(callArgs, rest...)
+	destPtr := &dest
+	if isUnit(destT) {
+		destPtr = nil
+	}
+	bs.emit(&CallInstr{
+		Dest:   destPtr,
+		Callee: &FnRef{Symbol: symbol, Type: mc.T},
+		Args:   callArgs,
+		SpanV:  mc.SpanV,
+	})
+}
+
+func (bs *bodyState) lowerIntrinsicCallInto(ic *ir.IntrinsicCall, dest *Place) {
+	args := make([]Operand, len(ic.Args))
+	for i, a := range ic.Args {
+		args[i] = bs.lowerExprAsOperand(a.Value)
+	}
+	kind := IntrinsicInvalid
+	switch ic.Kind {
+	case ir.IntrinsicPrint:
+		kind = IntrinsicPrint
+	case ir.IntrinsicPrintln:
+		kind = IntrinsicPrintln
+	case ir.IntrinsicEprint:
+		kind = IntrinsicEprint
+	case ir.IntrinsicEprintln:
+		kind = IntrinsicEprintln
+	}
+	bs.emit(&IntrinsicInstr{Dest: dest, Kind: kind, Args: args, SpanV: ic.SpanV})
+}
+
+func (bs *bodyState) lowerStructLit(sl *ir.StructLit, hint Type) RValue {
+	t := sl.T
+	if t == nil {
+		t = hint
+	}
+	info := bs.l.structFromType(t, sl.TypeName)
+	fieldOrder := bs.l.fieldNames(info)
+	if len(fieldOrder) == 0 {
+		// Unknown struct shape: emit a best-effort aggregate with the
+		// provided fields in source order.
+		fields := make([]Operand, len(sl.Fields))
+		for i, f := range sl.Fields {
+			fields[i] = bs.lowerExprAsOperand(f.Value)
+		}
+		return &AggregateRV{Kind: AggStruct, Fields: fields, T: t}
+	}
+	fields := make([]Operand, len(fieldOrder))
+	filled := make([]bool, len(fieldOrder))
+	for _, f := range sl.Fields {
+		i := indexOf(fieldOrder, f.Name)
+		if i < 0 {
+			bs.l.noteIssue("struct lit: unknown field %q", f.Name)
+			continue
+		}
+		if f.Value == nil {
+			// shorthand: lookup local
+			if id, ok := bs.lookup(f.Name); ok {
+				fields[i] = &CopyOp{Place: Place{Local: id}, T: bs.fn.Local(id).Type}
+				filled[i] = true
+				continue
+			}
+		} else {
+			fields[i] = bs.lowerExprAsOperand(f.Value)
+			filled[i] = true
+		}
+	}
+	if sl.Spread != nil {
+		spread, ok := bs.lowerExprToPlace(sl.Spread)
+		if !ok {
+			spreadT := sl.Spread.Type()
+			tmp := bs.freshTemp(spreadT, exprSpan(sl.Spread))
+			bs.lowerExprInto(sl.Spread, tmp, spreadT)
+			spread = Place{Local: tmp}
+		}
+		for i, name := range fieldOrder {
+			if filled[i] {
+				continue
+			}
+			ft := bs.l.fieldType(info, name)
+			fields[i] = &CopyOp{
+				Place: spread.Project(&FieldProj{Index: i, Name: name, Type: ft}),
+				T:     ft,
+			}
+		}
+	}
+	// Any remaining unfilled slot: default value.
+	for i, ok := range filled {
+		if ok || fields[i] != nil {
+			continue
+		}
+		bs.l.noteIssue("struct lit: missing field %q", fieldOrder[i])
+		fields[i] = &ConstOp{Const: &UnitConst{}, T: TUnit}
+	}
+	return &AggregateRV{Kind: AggStruct, Fields: fields, T: t}
+}
+
+func (bs *bodyState) lowerVariantLit(v *ir.VariantLit, hint Type) RValue {
+	t := v.T
+	if t == nil {
+		t = hint
+	}
+	idx := bs.l.variantIndexByName(t, v.Variant)
+	fields := make([]Operand, len(v.Args))
+	for i, a := range v.Args {
+		fields[i] = bs.lowerExprAsOperand(a.Value)
+	}
+	return &AggregateRV{
+		Kind:       AggEnumVariant,
+		Fields:     fields,
+		T:          t,
+		VariantIdx: idx,
+		VariantTag: v.Variant,
+	}
+}
+
+// ==== misc helpers ====
+
+func (bs *bodyState) freshTemp(t Type, sp Span) LocalID {
+	return bs.fn.NewLocal("", t, false, sp)
+}
+
+// finishNoReturn ensures the current block ends in a terminator. For
+// unit-returning functions we insert an implicit Return; otherwise an
+// Unreachable. Callers invoke this at the end of lowerFunction when
+// the HIR body did not provide a trailing expression.
+func (bs *bodyState) finishNoReturn() {
+	bb := bs.currentBlock()
+	if bb != nil && bb.Term != nil {
+		return
+	}
+	if isUnit(bs.fn.ReturnType) {
+		// Seed return local with unit.
+		bs.emit(&AssignInstr{
+			Dest:  Place{Local: bs.fn.ReturnLocal},
+			Src:   &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}},
+			SpanV: bs.fn.SpanV,
+		})
+		bs.terminate(&ReturnTerm{SpanV: bs.fn.SpanV})
+		return
+	}
+	// Non-unit return with no explicit return — shouldn't happen for
+	// well-typed Osty, but keep the function validatable.
+	bs.terminate(&UnreachableTerm{SpanV: bs.fn.SpanV})
+}
+
+// ==== helpers that bridge HIR-level knowledge to layouts ====
+
+type lookupStruct struct {
+	decl *ir.StructDecl
+}
+
+func (l *lowerer) structFromType(t ir.Type, fallbackName string) *lookupStruct {
+	name := fallbackName
+	if name == "" {
+		name = typeNameOf(t)
+	}
+	if name == "" {
+		return &lookupStruct{}
+	}
+	if d, ok := l.structs[name]; ok {
+		return &lookupStruct{decl: d}
+	}
+	return &lookupStruct{}
+}
+
+func (l *lowerer) fieldType(info *lookupStruct, name string) Type {
+	if info == nil || info.decl == nil {
+		return ir.ErrTypeVal
+	}
+	for _, f := range info.decl.Fields {
+		if f.Name == name {
+			return f.Type
+		}
+	}
+	return ir.ErrTypeVal
+}
+
+func (l *lowerer) fieldIndex(info *lookupStruct, name string) int {
+	if info == nil || info.decl == nil {
+		return 0
+	}
+	for i, f := range info.decl.Fields {
+		if f.Name == name {
+			return i
+		}
+	}
+	return 0
+}
+
+func (l *lowerer) fieldNames(info *lookupStruct) []string {
+	if info == nil || info.decl == nil {
+		return nil
+	}
+	out := make([]string, len(info.decl.Fields))
+	for i, f := range info.decl.Fields {
+		out[i] = f.Name
+	}
+	return out
+}
+
+type variantInfo struct {
+	enum    *ir.EnumDecl
+	variant *ir.Variant
+	index   int
+}
+
+func (l *lowerer) variantLayout(enum, name string) *variantInfo {
+	if enum == "" {
+		// Builtin (Option/Result) — fall back to synthesised layout.
+		return nil
+	}
+	e, ok := l.enums[enum]
+	if !ok {
+		return nil
+	}
+	for i, v := range e.Variants {
+		if v.Name == name {
+			return &variantInfo{enum: e, variant: v, index: i}
+		}
+	}
+	return nil
+}
+
+func (l *lowerer) variantIndexByName(t ir.Type, name string) int {
+	// Well-known builtins first.
+	switch name {
+	case "None":
+		return 0
+	case "Some":
+		return 1
+	case "Err":
+		return 0
+	case "Ok":
+		return 1
+	}
+	typeName := typeNameOf(t)
+	if typeName == "" {
+		return 0
+	}
+	if e, ok := l.enums[typeName]; ok {
+		for i, v := range e.Variants {
+			if v.Name == name {
+				return i
+			}
+		}
+	}
+	return 0
+}
+
+// ==== adapter helpers ====
+
+func variantIndex(info *variantInfo) int {
+	if info == nil {
+		return 0
+	}
+	return info.index
+}
+
+func variantPayloadType(info *variantInfo, i int) Type {
+	if info == nil || info.variant == nil {
+		return ir.ErrTypeVal
+	}
+	if i < 0 || i >= len(info.variant.Payload) {
+		return ir.ErrTypeVal
+	}
+	return info.variant.Payload[i]
+}
+
+// projectionToPlace turns a HIR decision-tree projection chain into a
+// MIR Place rooted at the scrutinee local.
+func projectionToPlace(l *lowerer, scrutLocal LocalID, scrutT ir.Type, proj *ir.Projection) Place {
+	// Reverse-walk into a slice root→leaf.
+	if proj == nil {
+		return Place{Local: scrutLocal}
+	}
+	chain := flattenProjection(proj)
+	out := Place{Local: scrutLocal}
+	curT := scrutT
+	for _, node := range chain {
+		switch node.Kind {
+		case ir.ProjScrutinee:
+			continue
+		case ir.ProjTuple:
+			elemTs := tupleElementTypes(curT)
+			nextT := elementTypeAt(elemTs, node.Index)
+			out = out.Project(&TupleProj{Index: node.Index, Type: nextT})
+			curT = nextT
+		case ir.ProjField:
+			info := l.structFromType(curT, "")
+			nextT := l.fieldType(info, node.Field)
+			out = out.Project(&FieldProj{
+				Index: l.fieldIndex(info, node.Field),
+				Name:  node.Field,
+				Type:  nextT,
+			})
+			curT = nextT
+		case ir.ProjVariant:
+			// Select payload of a variant.
+			innerT := variantLookupPayloadType(l, curT, node.Variant, 0)
+			out = out.Project(&VariantProj{
+				Variant:  l.variantIndexByName(curT, node.Variant),
+				Name:     node.Variant,
+				FieldIdx: -1,
+				Type:     innerT,
+			})
+			curT = innerT
+		case ir.ProjVariantN:
+			// If a prior ProjVariant already descended into a scalar
+			// payload, a following ProjVariantN(0) is redundant — skip
+			// the extra projection so the MIR place stays well-typed
+			// and the backend emits a single load.
+			if isScalarPayload(curT) && node.Index == 0 {
+				continue
+			}
+			nextT := variantLookupPayloadType(l, curT, node.Variant, node.Index)
+			out = out.Project(&VariantProj{
+				Variant:  l.variantIndexByName(curT, node.Variant),
+				Name:     node.Variant,
+				FieldIdx: node.Index,
+				Type:     nextT,
+			})
+			curT = nextT
+		}
+	}
+	return out
+}
+
+// projectionResultType returns the type produced by a projection
+// chain starting from scrutT.
+func projectionResultType(l *lowerer, scrutT ir.Type, proj *ir.Projection) Type {
+	if proj == nil {
+		return scrutT
+	}
+	chain := flattenProjection(proj)
+	curT := scrutT
+	for _, node := range chain {
+		switch node.Kind {
+		case ir.ProjScrutinee:
+			continue
+		case ir.ProjTuple:
+			curT = elementTypeAt(tupleElementTypes(curT), node.Index)
+		case ir.ProjField:
+			info := l.structFromType(curT, "")
+			curT = l.fieldType(info, node.Field)
+		case ir.ProjVariant:
+			curT = variantLookupPayloadType(l, curT, node.Variant, 0)
+		case ir.ProjVariantN:
+			curT = variantLookupPayloadType(l, curT, node.Variant, node.Index)
+		}
+	}
+	return curT
+}
+
+// flattenProjection walks base→leaf and returns the chain in
+// root-to-leaf order.
+func flattenProjection(p *ir.Projection) []*ir.Projection {
+	var stack []*ir.Projection
+	for cur := p; cur != nil; cur = cur.Base {
+		stack = append(stack, cur)
+	}
+	for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
+		stack[i], stack[j] = stack[j], stack[i]
+	}
+	return stack
+}
+
+func variantLookupPayloadType(l *lowerer, scrutT ir.Type, variant string, idx int) Type {
+	// If the "scrutinee" at this level is already the payload's scalar
+	// (because a prior ProjVariant already descended past the payload
+	// tuple boundary), then a ProjVariantN at idx==0 is a redundant
+	// projection — just return the same type.
+	if isScalarPayload(scrutT) && idx == 0 {
+		return scrutT
+	}
+	typeName := typeNameOf(scrutT)
+	if typeName == "" {
+		return ir.ErrTypeVal
+	}
+	if e, ok := l.enums[typeName]; ok {
+		for _, v := range e.Variants {
+			if v.Name == variant {
+				if idx < 0 {
+					if len(v.Payload) == 1 {
+						return v.Payload[0]
+					}
+					return ir.ErrTypeVal
+				}
+				if idx < len(v.Payload) {
+					return v.Payload[idx]
+				}
+			}
+		}
+	}
+	// Builtin Option/Result heuristics
+	switch typeName {
+	case "Option", "Maybe":
+		if nt, ok := scrutT.(*ir.NamedType); ok && len(nt.Args) >= 1 {
+			return nt.Args[0]
+		}
+	case "Result":
+		if nt, ok := scrutT.(*ir.NamedType); ok && len(nt.Args) >= 2 {
+			if variant == "Ok" {
+				return nt.Args[0]
+			}
+			if variant == "Err" {
+				return nt.Args[1]
+			}
+		}
+	}
+	// Optional types in surface form T?
+	if ot, ok := scrutT.(*ir.OptionalType); ok {
+		return ot.Inner
+	}
+	return ir.ErrTypeVal
+}
+
+// ==== misc pure helpers ====
+
+func typeNameOf(t ir.Type) string {
+	switch x := t.(type) {
+	case *ir.NamedType:
+		return x.Name
+	case *ir.OptionalType:
+		return "Option"
+	}
+	return ""
+}
+
+func isListType(t ir.Type) bool {
+	if nt, ok := t.(*ir.NamedType); ok {
+		return nt.Name == "List" && nt.Builtin
+	}
+	return false
+}
+
+// isScalarPayload reports whether a type is a primitive/scalar shape
+// that already represents a variant's single payload element. Used to
+// detect redundant ProjVariantN steps after a ProjVariant has already
+// descended into a scalar payload.
+func isScalarPayload(t ir.Type) bool {
+	switch t.(type) {
+	case *ir.PrimType:
+		return true
+	case *ir.OptionalType:
+		return true
+	case *ir.FnType:
+		return true
+	}
+	return false
+}
+
+func listElementType(t ir.Type) Type {
+	if nt, ok := t.(*ir.NamedType); ok && len(nt.Args) >= 1 {
+		return nt.Args[0]
+	}
+	return ir.ErrTypeVal
+}
+
+func isUnit(t ir.Type) bool {
+	if p, ok := t.(*ir.PrimType); ok {
+		return p.Kind == ir.PrimUnit
+	}
+	return false
+}
+
+func tupleElementTypes(t ir.Type) []Type {
+	if tt, ok := t.(*ir.TupleType); ok {
+		return tt.Elems
+	}
+	return nil
+}
+
+func elementTypeAt(ts []Type, i int) Type {
+	if i < 0 || i >= len(ts) {
+		return ir.ErrTypeVal
+	}
+	return ts[i]
+}
+
+func hasInterpolation(s *ir.StringLit) bool {
+	for _, p := range s.Parts {
+		if !p.IsLit {
+			return true
+		}
+	}
+	return false
+}
+
+func mapUnaryOp(op ir.UnOp) UnaryOp {
+	switch op {
+	case ir.UnNeg:
+		return UnNeg
+	case ir.UnPlus:
+		return UnPlus
+	case ir.UnNot:
+		return UnNot
+	case ir.UnBitNot:
+		return UnBitNot
+	}
+	return UnInvalid
+}
+
+func mapBinaryOp(op ir.BinOp) BinaryOp {
+	switch op {
+	case ir.BinAdd:
+		return BinAdd
+	case ir.BinSub:
+		return BinSub
+	case ir.BinMul:
+		return BinMul
+	case ir.BinDiv:
+		return BinDiv
+	case ir.BinMod:
+		return BinMod
+	case ir.BinEq:
+		return BinEq
+	case ir.BinNeq:
+		return BinNeq
+	case ir.BinLt:
+		return BinLt
+	case ir.BinLeq:
+		return BinLeq
+	case ir.BinGt:
+		return BinGt
+	case ir.BinGeq:
+		return BinGeq
+	case ir.BinAnd:
+		return BinAnd
+	case ir.BinOr:
+		return BinOr
+	case ir.BinBitAnd:
+		return BinBitAnd
+	case ir.BinBitOr:
+		return BinBitOr
+	case ir.BinBitXor:
+		return BinBitXor
+	case ir.BinShl:
+		return BinShl
+	case ir.BinShr:
+		return BinShr
+	}
+	return BinInvalid
+}
+
+func indexOf(xs []string, s string) int {
+	for i, x := range xs {
+		if x == s {
+			return i
+		}
+	}
+	return -1
+}
+
+func exprSpan(e ir.Expr) Span {
+	if e == nil {
+		return Span{}
+	}
+	return e.At()
+}
+
+// ==== Option / Result tag helpers ====
+
+// someTagOf returns the discriminant value of the "present" arm of an
+// optional or Maybe/Option enum. Defaults to 1 which matches the
+// convention in internal/llvmgen (None=0, Some=1).
+func someTagOf(t ir.Type) int64 {
+	return 1
+}
+
+// okTagOf returns the discriminant value of the "happy" arm of a
+// `?`-able enum. For Option it's 1 (Some); for Result it's also 1
+// (Ok) in the current LLVM layout.
+func okTagOf(t ir.Type) int64 {
+	return 1
+}
+
+// okVariantName returns the name of the happy arm for `?`.
+func okVariantName(t ir.Type) string {
+	if _, ok := t.(*ir.OptionalType); ok {
+		return "Some"
+	}
+	name := typeNameOf(t)
+	switch name {
+	case "Option", "Maybe":
+		return "Some"
+	case "Result":
+		return "Ok"
+	}
+	return "Ok"
+}
+
+func optionInnerType(t ir.Type) Type {
+	if ot, ok := t.(*ir.OptionalType); ok {
+		return ot.Inner
+	}
+	if nt, ok := t.(*ir.NamedType); ok && len(nt.Args) >= 1 {
+		return nt.Args[0]
+	}
+	return ir.ErrTypeVal
+}
+
+// mangleMethodSymbol returns the method symbol name shared with the
+// llvmgen convention (Type__method).
+func mangleMethodSymbol(owner, method string) string {
+	return owner + "__" + method
+}
+
+// methodCallSig returns a copy of sig without its leading receiver
+// parameter, for use when resolving call-site arguments (which never
+// include `self`).
+func methodCallSig(sig *fnSignature) *fnSignature {
+	if sig == nil || len(sig.params) == 0 {
+		return sig
+	}
+	return &fnSignature{
+		ir:      sig.ir,
+		owner:   sig.owner,
+		symbol:  sig.symbol,
+		params:  sig.params[1:],
+		retType: sig.retType,
+	}
+}

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -1,0 +1,895 @@
+package mir
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// ==== Source positions (shared with HIR) ====
+
+// Pos mirrors ir.Pos; kept as a local type so MIR consumers do not need
+// to import `ir` for position info even though today we just alias it.
+type Pos = ir.Pos
+
+// Span is a half-open [Start, End) source range. Every MIR node carries
+// one so diagnostics can still anchor back to the original source.
+type Span = ir.Span
+
+// ==== Type reuse ====
+
+// Type is a semantic type. We reuse ir.Type directly because (a) it has
+// no back-references to the AST/resolver, (b) monomorphisation runs at
+// the HIR level and every type reaching MIR is already concrete, and
+// (c) having one type vocabulary removes an entire translation layer
+// between HIR and MIR.
+type Type = ir.Type
+
+// Canonical primitive singletons, re-exported so MIR consumers never
+// need to reach into ir.T* themselves.
+var (
+	TInt     = ir.TInt
+	TInt8    = ir.TInt8
+	TInt16   = ir.TInt16
+	TInt32   = ir.TInt32
+	TInt64   = ir.TInt64
+	TUInt8   = ir.TUInt8
+	TUInt16  = ir.TUInt16
+	TUInt32  = ir.TUInt32
+	TUInt64  = ir.TUInt64
+	TByte    = ir.TByte
+	TFloat   = ir.TFloat
+	TFloat32 = ir.TFloat32
+	TFloat64 = ir.TFloat64
+	TBool    = ir.TBool
+	TChar    = ir.TChar
+	TString  = ir.TString
+	TBytes   = ir.TBytes
+	TUnit    = ir.TUnit
+	TNever   = ir.TNever
+)
+
+// ==== Module ====
+
+// Module is the MIR form of an Osty compilation unit. It is always
+// monomorphic: no TypeVar appears in any type reachable from the module
+// root.
+type Module struct {
+	Package   string
+	Functions []*Function
+	Globals   []*Global
+	Uses      []*Use
+	Layouts   *LayoutTable
+	Issues    []error
+	SpanV     Span
+}
+
+// At returns the module's source span.
+func (m *Module) At() Span { return m.SpanV }
+
+// LookupFunction finds a function by mangled symbol. Returns nil when
+// no match exists.
+func (m *Module) LookupFunction(symbol string) *Function {
+	if m == nil {
+		return nil
+	}
+	for _, fn := range m.Functions {
+		if fn != nil && fn.Name == symbol {
+			return fn
+		}
+	}
+	return nil
+}
+
+// ==== Globals / Uses ====
+
+// Global is a top-level `let` binding. The initialiser is a MIR
+// function — the global's value is whatever the function returns. This
+// matches how LLVM lowers top-level state today: the backend emits an
+// initialiser that runs before main.
+type Global struct {
+	Name  string
+	Type  Type
+	Init  *Function // nil when the caller has not lowered an init yet
+	Mut   bool
+	SpanV Span
+}
+
+// At returns the global's span.
+func (g *Global) At() Span { return g.SpanV }
+
+// Use represents an import that MIR still needs to carry for FFI
+// bridging (Go FFI modules, runtime aliases). Non-FFI imports are
+// fully resolved away during MIR lowering.
+type Use struct {
+	Path         []string
+	RawPath      string
+	Alias        string
+	IsGoFFI      bool
+	IsRuntimeFFI bool
+	GoPath       string
+	RuntimePath  string
+	SpanV        Span
+}
+
+// At returns the import's span.
+func (u *Use) At() Span { return u.SpanV }
+
+// ==== Function ====
+
+// LocalID identifies a local within a function. _0 is always the
+// return slot; IDs are dense and contiguous from 0.
+type LocalID int
+
+// BlockID identifies a basic block within a function. The entry block
+// is whatever Function.Entry points at (conventionally 0).
+type BlockID int
+
+// Function is one MIR function: parameters, return slot, a set of
+// named locals, a CFG of basic blocks.
+type Function struct {
+	Name        string   // mangled symbol
+	Params      []LocalID
+	ReturnType  Type
+	ReturnLocal LocalID
+	Locals      []*Local
+	Blocks      []*BasicBlock
+	Entry       BlockID
+	IsExternal  bool
+	IsIntrinsic bool
+	Exported    bool
+	SpanV       Span
+}
+
+// At returns the function's source span.
+func (f *Function) At() Span { return f.SpanV }
+
+// NewLocal appends a fresh local and returns its ID.
+func (f *Function) NewLocal(name string, t Type, mut bool, sp Span) LocalID {
+	id := LocalID(len(f.Locals))
+	f.Locals = append(f.Locals, &Local{
+		ID:    id,
+		Name:  name,
+		Type:  t,
+		Mut:   mut,
+		SpanV: sp,
+	})
+	return id
+}
+
+// Local returns the local with the given ID, or nil if the ID is out
+// of range.
+func (f *Function) Local(id LocalID) *Local {
+	if int(id) < 0 || int(id) >= len(f.Locals) {
+		return nil
+	}
+	return f.Locals[id]
+}
+
+// Block returns the block with the given ID, or nil if the ID is out
+// of range.
+func (f *Function) Block(id BlockID) *BasicBlock {
+	if int(id) < 0 || int(id) >= len(f.Blocks) {
+		return nil
+	}
+	return f.Blocks[id]
+}
+
+// NewBlock appends a fresh block with no instructions and a nil
+// terminator. Callers must install a terminator before validation.
+func (f *Function) NewBlock(sp Span) BlockID {
+	id := BlockID(len(f.Blocks))
+	f.Blocks = append(f.Blocks, &BasicBlock{ID: id, SpanV: sp})
+	return id
+}
+
+// ==== Local ====
+
+// Local is one slot in a function's frame. Locals cover parameters,
+// the return slot, user-named bindings, and compiler temporaries.
+type Local struct {
+	ID       LocalID
+	Name     string // empty for synthetic temporaries
+	Type     Type
+	Mut      bool
+	IsParam  bool
+	IsReturn bool
+	SpanV    Span
+}
+
+// At returns the local's source span.
+func (l *Local) At() Span { return l.SpanV }
+
+// ==== Basic block ====
+
+// BasicBlock is a straight-line run of instructions followed by
+// exactly one terminator. Terminator must be non-nil after lowering.
+type BasicBlock struct {
+	ID     BlockID
+	Instrs []Instr
+	Term   Terminator
+	SpanV  Span
+}
+
+// At returns the block's source span (the span of the first
+// instruction, or the block header if the block is empty).
+func (b *BasicBlock) At() Span { return b.SpanV }
+
+// Append adds an instruction to the block. Callers are expected to
+// respect the invariant that no instruction follows the terminator —
+// the validator catches violations, but the helper does not.
+func (b *BasicBlock) Append(instr Instr) {
+	b.Instrs = append(b.Instrs, instr)
+}
+
+// SetTerminator installs the block's terminator. Subsequent Append
+// calls are a MIR bug; the validator flags them.
+func (b *BasicBlock) SetTerminator(t Terminator) {
+	b.Term = t
+}
+
+// ==== Instructions ====
+
+// Instr is the common interface for every MIR instruction.
+type Instr interface {
+	instrNode()
+	At() Span
+}
+
+// AssignInstr is `dest = rvalue`. The dest Place must reference a
+// local that already exists; projections are allowed (field / tuple /
+// variant / index / deref).
+type AssignInstr struct {
+	Dest  Place
+	Src   RValue
+	SpanV Span
+}
+
+func (*AssignInstr) instrNode()  {}
+func (a *AssignInstr) At() Span  { return a.SpanV }
+
+// CallInstr is a direct or indirect call. Dest is nil when the return
+// value is discarded or when the function returns unit.
+type CallInstr struct {
+	Dest   *Place
+	Callee Callee
+	Args   []Operand
+	SpanV  Span
+}
+
+func (*CallInstr) instrNode() {}
+func (c *CallInstr) At() Span { return c.SpanV }
+
+// IntrinsicInstr is a call to a compiler-known intrinsic (the print
+// family today). Keeping intrinsics distinct from user calls lets
+// backends dispatch without matching on names.
+type IntrinsicInstr struct {
+	Dest  *Place
+	Kind  IntrinsicKind
+	Args  []Operand
+	SpanV Span
+}
+
+func (*IntrinsicInstr) instrNode() {}
+func (i *IntrinsicInstr) At() Span { return i.SpanV }
+
+// IntrinsicKind enumerates the MIR-visible intrinsics. The values
+// match ir.IntrinsicKind for the print family so that the lowerer can
+// pass them through unchanged.
+type IntrinsicKind int
+
+const (
+	IntrinsicInvalid  IntrinsicKind = iota
+	IntrinsicPrint                  // stdout, no newline
+	IntrinsicPrintln                // stdout, newline
+	IntrinsicEprint                 // stderr, no newline
+	IntrinsicEprintln               // stderr, newline
+	IntrinsicAbort                  // unreachable runtime trap
+	IntrinsicStringConcat
+)
+
+// StorageLiveInstr marks a local as alive. Optional; backends that do
+// not care may ignore it.
+type StorageLiveInstr struct {
+	Local LocalID
+	SpanV Span
+}
+
+func (*StorageLiveInstr) instrNode() {}
+func (s *StorageLiveInstr) At() Span { return s.SpanV }
+
+// StorageDeadInstr marks a local as dead. Paired with StorageLive.
+type StorageDeadInstr struct {
+	Local LocalID
+	SpanV Span
+}
+
+func (*StorageDeadInstr) instrNode() {}
+func (s *StorageDeadInstr) At() Span { return s.SpanV }
+
+// ==== Callee ====
+
+// Callee is the target of a CallInstr.
+type Callee interface {
+	calleeNode()
+}
+
+// FnRef is a direct call to a function by its mangled symbol. Type
+// carries the full function type for the validator's benefit.
+type FnRef struct {
+	Symbol string
+	Type   Type
+}
+
+func (*FnRef) calleeNode() {}
+
+// IndirectCall is a call through a first-class function value. The
+// operand's type is expected to be an FnType.
+type IndirectCall struct {
+	Callee Operand
+}
+
+func (*IndirectCall) calleeNode() {}
+
+// ==== Terminators ====
+
+// Terminator is the control-flow edge leaving a basic block. Every
+// block has exactly one.
+type Terminator interface {
+	termNode()
+	At() Span
+}
+
+// GotoTerm is an unconditional jump.
+type GotoTerm struct {
+	Target BlockID
+	SpanV  Span
+}
+
+func (*GotoTerm) termNode()  {}
+func (g *GotoTerm) At() Span { return g.SpanV }
+
+// BranchTerm chooses between two successors based on a boolean
+// operand.
+type BranchTerm struct {
+	Cond  Operand
+	Then  BlockID
+	Else  BlockID
+	SpanV Span
+}
+
+func (*BranchTerm) termNode() {}
+func (b *BranchTerm) At() Span { return b.SpanV }
+
+// SwitchIntTerm dispatches on an integer scrutinee. Cases are tried
+// in order; Default is taken when no case matches.
+type SwitchIntTerm struct {
+	Scrutinee Operand
+	Cases     []SwitchCase
+	Default   BlockID
+	SpanV     Span
+}
+
+func (*SwitchIntTerm) termNode() {}
+func (s *SwitchIntTerm) At() Span { return s.SpanV }
+
+// SwitchCase is one match arm of a SwitchIntTerm.
+type SwitchCase struct {
+	Value  int64
+	Target BlockID
+	Label  string // optional debug label (variant name / literal text)
+}
+
+// ReturnTerm returns from the function. The returned value is the
+// contents of the function's ReturnLocal.
+type ReturnTerm struct {
+	SpanV Span
+}
+
+func (*ReturnTerm) termNode()  {}
+func (r *ReturnTerm) At() Span { return r.SpanV }
+
+// UnreachableTerm marks a path that the compiler believes is
+// unreachable. Emitted at the "no arm matched" sink of an exhaustive
+// match, after `!`-returning calls, etc.
+type UnreachableTerm struct {
+	SpanV Span
+}
+
+func (*UnreachableTerm) termNode() {}
+func (u *UnreachableTerm) At() Span { return u.SpanV }
+
+// ==== Places / projections ====
+
+// Place identifies a storage location. It is a local optionally
+// refined by a chain of projections.
+type Place struct {
+	Local       LocalID
+	Projections []Projection
+}
+
+// Base returns a Place with just the root local and no projections.
+// Useful as a concise way to describe the storage root.
+func (p Place) Base() Place { return Place{Local: p.Local} }
+
+// HasProjections reports whether the place has any refining
+// projections.
+func (p Place) HasProjections() bool { return len(p.Projections) > 0 }
+
+// Project returns a new Place extending p with proj.
+func (p Place) Project(proj Projection) Place {
+	next := make([]Projection, 0, len(p.Projections)+1)
+	next = append(next, p.Projections...)
+	next = append(next, proj)
+	return Place{Local: p.Local, Projections: next}
+}
+
+// Projection is one step refining a Place.
+type Projection interface {
+	projectionNode()
+}
+
+// FieldProj is a struct field access by index + name.
+type FieldProj struct {
+	Index int
+	Name  string
+	Type  Type
+}
+
+func (*FieldProj) projectionNode() {}
+
+// TupleProj is a tuple element access by index.
+type TupleProj struct {
+	Index int
+	Type  Type
+}
+
+func (*TupleProj) projectionNode() {}
+
+// VariantProj descends into an enum payload. FieldIdx < 0 selects the
+// whole payload tuple; otherwise it selects a single payload element.
+type VariantProj struct {
+	Variant  int
+	Name     string
+	FieldIdx int // -1 for "the whole payload"
+	Type     Type
+}
+
+func (*VariantProj) projectionNode() {}
+
+// IndexProj is `place[index]`. Index is an operand (usually an integer
+// local or constant); ElemType is the resulting type.
+type IndexProj struct {
+	Index    Operand
+	ElemType Type
+}
+
+func (*IndexProj) projectionNode() {}
+
+// DerefProj follows a pointer / optional unwrap. Retained in the
+// vocabulary for future borrow work; the current lowering does not
+// emit it.
+type DerefProj struct {
+	Type Type
+}
+
+func (*DerefProj) projectionNode() {}
+
+// ==== Operands ====
+
+// Operand is a read-only value: either a Place read or a literal.
+type Operand interface {
+	operandNode()
+	Type() Type
+}
+
+// CopyOp is a non-destructive read of a Place.
+type CopyOp struct {
+	Place Place
+	T     Type
+}
+
+func (*CopyOp) operandNode()   {}
+func (o *CopyOp) Type() Type   { return o.T }
+
+// MoveOp is a destructive read. Under the current GC-managed runtime
+// MoveOp and CopyOp behave identically; the distinction exists for
+// future owning-pointer lowerings.
+type MoveOp struct {
+	Place Place
+	T     Type
+}
+
+func (*MoveOp) operandNode() {}
+func (o *MoveOp) Type() Type { return o.T }
+
+// ConstOp is a compile-time constant.
+type ConstOp struct {
+	Const Const
+	T     Type
+}
+
+func (*ConstOp) operandNode() {}
+func (o *ConstOp) Type() Type {
+	if o.T != nil {
+		return o.T
+	}
+	if o.Const != nil {
+		return o.Const.Type()
+	}
+	return ir.ErrTypeVal
+}
+
+// ==== Constants ====
+
+// Const is a compile-time value. Every Const knows its type.
+type Const interface {
+	constNode()
+	Type() Type
+}
+
+// IntConst is an integer constant. Value is the two's complement
+// bit pattern reinterpreted as int64; signed vs unsigned is carried
+// by the Type.
+type IntConst struct {
+	Value int64
+	T     Type
+}
+
+func (*IntConst) constNode() {}
+func (c *IntConst) Type() Type {
+	if c.T == nil {
+		return TInt
+	}
+	return c.T
+}
+
+// BoolConst is `true` / `false`.
+type BoolConst struct {
+	Value bool
+}
+
+func (*BoolConst) constNode() {}
+func (*BoolConst) Type() Type { return TBool }
+
+// FloatConst is a float constant.
+type FloatConst struct {
+	Value float64
+	T     Type
+}
+
+func (*FloatConst) constNode() {}
+func (c *FloatConst) Type() Type {
+	if c.T == nil {
+		return TFloat
+	}
+	return c.T
+}
+
+// StringConst is a non-interpolated string constant.
+type StringConst struct {
+	Value string
+}
+
+func (*StringConst) constNode() {}
+func (*StringConst) Type() Type { return TString }
+
+// CharConst is a single code point.
+type CharConst struct {
+	Value rune
+}
+
+func (*CharConst) constNode() {}
+func (*CharConst) Type() Type { return TChar }
+
+// ByteConst is a single byte.
+type ByteConst struct {
+	Value byte
+}
+
+func (*ByteConst) constNode() {}
+func (*ByteConst) Type() Type { return TByte }
+
+// UnitConst is the `()` zero-value.
+type UnitConst struct{}
+
+func (*UnitConst) constNode() {}
+func (*UnitConst) Type() Type { return TUnit }
+
+// NullConst is the canonical "none" constant used to seed optional
+// locals. Backends emit their runtime's None representation when they
+// see this.
+type NullConst struct {
+	T Type
+}
+
+func (*NullConst) constNode() {}
+func (c *NullConst) Type() Type {
+	if c.T == nil {
+		return TUnit
+	}
+	return c.T
+}
+
+// FnConst is a compile-time function pointer literal. The symbol
+// names an already-mangled MIR function.
+type FnConst struct {
+	Symbol string
+	T      Type
+}
+
+func (*FnConst) constNode() {}
+func (c *FnConst) Type() Type {
+	if c.T == nil {
+		return ir.ErrTypeVal
+	}
+	return c.T
+}
+
+// ==== RValues ====
+
+// RValue is the right-hand side of an Assign. RValues never have side
+// effects on their own; side effects become CallInstr or
+// IntrinsicInstr.
+type RValue interface {
+	rvalueNode()
+}
+
+// UseRV is the identity rvalue: copy an operand into the destination.
+type UseRV struct {
+	Op Operand
+}
+
+func (*UseRV) rvalueNode() {}
+
+// UnaryRV is `op(arg)`.
+type UnaryRV struct {
+	Op  UnaryOp
+	Arg Operand
+	T   Type
+}
+
+func (*UnaryRV) rvalueNode() {}
+
+// BinaryRV is `lhs op rhs`.
+type BinaryRV struct {
+	Op    BinaryOp
+	Left  Operand
+	Right Operand
+	T     Type
+}
+
+func (*BinaryRV) rvalueNode() {}
+
+// AggregateKind enumerates the flavors of aggregate construction.
+type AggregateKind int
+
+const (
+	AggTuple AggregateKind = iota + 1
+	AggStruct
+	AggEnumVariant
+	AggList
+	AggMap
+)
+
+// AggregateRV constructs a compound value. For EnumVariant, VariantIdx
+// names the active arm and Fields is the (possibly empty) payload
+// tuple. For Struct, Fields is in declaration order (the lowerer
+// reorders keyword fields). For Tuple / List, Fields is positional.
+type AggregateRV struct {
+	Kind       AggregateKind
+	Fields     []Operand
+	T          Type
+	VariantIdx int    // EnumVariant only
+	VariantTag string // EnumVariant only (debug hint)
+}
+
+func (*AggregateRV) rvalueNode() {}
+
+// DiscriminantRV reads the variant tag of an enum / optional value.
+type DiscriminantRV struct {
+	Place Place
+	T     Type // the discriminant's numeric type
+}
+
+func (*DiscriminantRV) rvalueNode() {}
+
+// LenRV reads the length of a list / string / bytes. Backends map
+// this to their runtime's length query.
+type LenRV struct {
+	Place Place
+	T     Type
+}
+
+func (*LenRV) rvalueNode() {}
+
+// CastKind enumerates the MIR-visible casts. Stage-1 only needs
+// integer sign/width and optional wrap/unwrap.
+type CastKind int
+
+const (
+	CastInvalid     CastKind = iota
+	CastIntResize            // widen/narrow between integer widths
+	CastIntToFloat
+	CastFloatToInt
+	CastFloatResize
+	CastOptionalWrap   // T -> T? (wrap into Some)
+	CastOptionalUnwrap // T? -> T (checked earlier)
+	CastBitcast
+)
+
+// CastRV is a value conversion.
+type CastRV struct {
+	Kind CastKind
+	Arg  Operand
+	From Type
+	To   Type
+}
+
+func (*CastRV) rvalueNode() {}
+
+// AddressOfRV takes the address of a Place. Unused in Stage 1;
+// retained for future borrow analysis.
+type AddressOfRV struct {
+	Place Place
+	T     Type
+}
+
+func (*AddressOfRV) rvalueNode() {}
+
+// RefRV wraps a Place's value inside a reference-typed wrapper. Used
+// by the lowerer to materialise `Some(x)` when we already have x in a
+// place.
+type RefRV struct {
+	Place Place
+	T     Type
+}
+
+func (*RefRV) rvalueNode() {}
+
+// NullaryRVKind enumerates nullary rvalues that backends must
+// recognise by name.
+type NullaryRVKind int
+
+const (
+	NullaryNone NullaryRVKind = iota + 1
+)
+
+// NullaryRV materialises a nullary value such as the canonical None
+// for an Option type.
+type NullaryRV struct {
+	Kind NullaryRVKind
+	T    Type
+}
+
+func (*NullaryRV) rvalueNode() {}
+
+// ==== Unary / binary operators ====
+
+// UnaryOp enumerates MIR unary operators. The vocabulary mirrors HIR.
+type UnaryOp int
+
+const (
+	UnInvalid UnaryOp = iota
+	UnNeg             // -x
+	UnPlus            // +x (identity on numerics; kept for parity)
+	UnNot             // !x (boolean)
+	UnBitNot          // ~x
+)
+
+// BinaryOp enumerates MIR binary operators.
+type BinaryOp int
+
+const (
+	BinInvalid BinaryOp = iota
+
+	BinAdd
+	BinSub
+	BinMul
+	BinDiv
+	BinMod
+
+	BinEq
+	BinNeq
+	BinLt
+	BinLeq
+	BinGt
+	BinGeq
+
+	BinAnd
+	BinOr
+
+	BinBitAnd
+	BinBitOr
+	BinBitXor
+	BinShl
+	BinShr
+)
+
+// ==== Layouts ====
+
+// LayoutTable is the MIR-level index from type names to layout
+// records. Structural types (tuples, lists) are keyed by their
+// canonical string representation.
+type LayoutTable struct {
+	Structs map[string]*StructLayout
+	Enums   map[string]*EnumLayout
+	Tuples  map[string]*TupleLayout
+}
+
+// NewLayoutTable returns an empty layout table with initialised maps.
+func NewLayoutTable() *LayoutTable {
+	return &LayoutTable{
+		Structs: map[string]*StructLayout{},
+		Enums:   map[string]*EnumLayout{},
+		Tuples:  map[string]*TupleLayout{},
+	}
+}
+
+// StructLayout describes a single (possibly monomorphic) struct.
+type StructLayout struct {
+	Name    string
+	Mangled string
+	Fields  []FieldLayout
+	Size    int // 0 when the backend computes it
+	Align   int // 0 when the backend computes it
+}
+
+// FieldLayout is one entry inside a StructLayout or VariantLayout.
+type FieldLayout struct {
+	Index int
+	Name  string
+	Type  Type
+}
+
+// EnumLayout describes a single (possibly monomorphic) enum.
+type EnumLayout struct {
+	Name         string
+	Mangled      string
+	Discriminant Type
+	Variants     []VariantLayout
+}
+
+// VariantLayout is one enum arm.
+type VariantLayout struct {
+	Index   int
+	Name    string
+	Payload []FieldLayout
+}
+
+// TupleLayout describes the structural layout of a tuple. Key is the
+// canonical type string (e.g. "(Int, String)").
+type TupleLayout struct {
+	Key     string
+	Mangled string
+	Fields  []FieldLayout
+}
+
+// ==== Helpers for span propagation ====
+
+// SpanOfInstr returns the span of an instruction, or a zero Span when
+// nil.
+func SpanOfInstr(i Instr) Span {
+	if i == nil {
+		return Span{}
+	}
+	return i.At()
+}
+
+// SpanOfTerm returns the span of a terminator, or a zero Span when
+// nil.
+func SpanOfTerm(t Terminator) Span {
+	if t == nil {
+		return Span{}
+	}
+	return t.At()
+}
+
+// ==== Diagnostics helper ====
+
+// Unsupported returns a sentinel error signalling that MIR lowering
+// has not implemented the given HIR shape. Callers use this to
+// decide whether to fall back to the HIR path.
+func Unsupported(format string, args ...any) error {
+	return fmt.Errorf("mir: unsupported: "+format, args...)
+}

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -1,0 +1,767 @@
+package mir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+)
+
+// ==== construction + printer tests ====
+
+func TestPrintEmptyModule(t *testing.T) {
+	m := &Module{Package: "main", Layouts: NewLayoutTable()}
+	got := Print(m)
+	if !strings.Contains(got, `module "main"`) {
+		t.Fatalf("print missing module header:\n%s", got)
+	}
+}
+
+// TestPrintHandBuiltFunction pins the textual format. The test builds
+// a function with a single block that returns 42 and asserts against
+// the printer output.
+func TestPrintHandBuiltFunction(t *testing.T) {
+	fn := &Function{
+		Name:       "answer",
+		ReturnType: TInt,
+	}
+	fn.ReturnLocal = fn.NewLocal("_return", TInt, false, Span{})
+	fn.Locals[fn.ReturnLocal].IsReturn = true
+	bbID := fn.NewBlock(Span{})
+	fn.Entry = bbID
+	bb := fn.Block(bbID)
+	bb.Append(&AssignInstr{
+		Dest: Place{Local: fn.ReturnLocal},
+		Src:  &UseRV{Op: &ConstOp{Const: &IntConst{Value: 42, T: TInt}, T: TInt}},
+	})
+	bb.SetTerminator(&ReturnTerm{})
+
+	mod := &Module{Package: "main", Functions: []*Function{fn}, Layouts: NewLayoutTable()}
+	got := Print(mod)
+
+	for _, want := range []string{
+		"fn answer() -> Int",
+		"_0 = use const 42 Int",
+		"return",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("printed module missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// ==== validator tests ====
+
+func TestValidateAcceptsWellFormed(t *testing.T) {
+	fn := &Function{Name: "ok", ReturnType: TUnit}
+	fn.ReturnLocal = fn.NewLocal("_return", TUnit, false, Span{})
+	fn.Locals[fn.ReturnLocal].IsReturn = true
+	bb := fn.NewBlock(Span{})
+	fn.Entry = bb
+	fn.Block(bb).SetTerminator(&ReturnTerm{})
+	mod := &Module{Package: "main", Functions: []*Function{fn}, Layouts: NewLayoutTable()}
+	if errs := Validate(mod); len(errs) > 0 {
+		t.Fatalf("Validate returned errors on well-formed module: %v", errs)
+	}
+}
+
+func TestValidateRejectsMissingTerminator(t *testing.T) {
+	fn := &Function{Name: "broken", ReturnType: TUnit}
+	fn.ReturnLocal = fn.NewLocal("_return", TUnit, false, Span{})
+	fn.Locals[fn.ReturnLocal].IsReturn = true
+	bb := fn.NewBlock(Span{})
+	fn.Entry = bb
+	// intentionally omit terminator
+	_ = bb
+	mod := &Module{Package: "main", Functions: []*Function{fn}, Layouts: NewLayoutTable()}
+	errs := Validate(mod)
+	if len(errs) == 0 {
+		t.Fatalf("expected missing-terminator error, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "missing terminator") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing-terminator not reported: %v", errs)
+	}
+}
+
+func TestValidateRejectsEmptyPackage(t *testing.T) {
+	mod := &Module{Package: "", Layouts: NewLayoutTable()}
+	errs := Validate(mod)
+	if len(errs) == 0 {
+		t.Fatalf("expected empty-package error, got none")
+	}
+}
+
+func TestValidateRejectsOutOfRangeLocal(t *testing.T) {
+	fn := &Function{Name: "oops", ReturnType: TUnit}
+	fn.ReturnLocal = fn.NewLocal("_return", TUnit, false, Span{})
+	fn.Locals[fn.ReturnLocal].IsReturn = true
+	bb := fn.NewBlock(Span{})
+	fn.Entry = bb
+	fn.Block(bb).Append(&AssignInstr{
+		Dest: Place{Local: LocalID(99)},
+		Src:  &UseRV{Op: &ConstOp{Const: &UnitConst{}, T: TUnit}},
+	})
+	fn.Block(bb).SetTerminator(&ReturnTerm{})
+	mod := &Module{Package: "main", Functions: []*Function{fn}, Layouts: NewLayoutTable()}
+	errs := Validate(mod)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "out of range") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected out-of-range error, got %v", errs)
+	}
+}
+
+func TestValidateRejectsDuplicateSymbol(t *testing.T) {
+	fn := func() *Function {
+		f := &Function{Name: "dup", ReturnType: TUnit}
+		f.ReturnLocal = f.NewLocal("_return", TUnit, false, Span{})
+		f.Locals[f.ReturnLocal].IsReturn = true
+		bb := f.NewBlock(Span{})
+		f.Entry = bb
+		f.Block(bb).SetTerminator(&ReturnTerm{})
+		return f
+	}
+	mod := &Module{Package: "main", Functions: []*Function{fn(), fn()}, Layouts: NewLayoutTable()}
+	errs := Validate(mod)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "duplicate symbol") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected duplicate-symbol error, got %v", errs)
+	}
+}
+
+// ==== lowering tests ====
+
+// helper: wrap a single statement into a main() function and lower.
+func lowerHIR(t *testing.T, decl *ir.FnDecl) *Module {
+	t.Helper()
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{decl}}
+	out := Lower(mod)
+	if out == nil {
+		t.Fatalf("Lower returned nil")
+	}
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("Validate on lowered module failed:\n%v\n\nprinted:\n%s", errs, Print(out))
+	}
+	return out
+}
+
+// mkFn builds a trivial HIR fn(name) -> returnT with the given body.
+func mkFn(name string, retT ir.Type, body *ir.Block) *ir.FnDecl {
+	return &ir.FnDecl{Name: name, Return: retT, Body: body}
+}
+
+func TestLowerConstReturn(t *testing.T) {
+	fn := mkFn("answer", ir.TInt, &ir.Block{
+		Result: &ir.IntLit{Text: "42", T: ir.TInt},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	for _, want := range []string{
+		"fn answer() -> Int",
+		"_0 = use const 42 Int",
+		"return",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in:\n%s", want, text)
+		}
+	}
+}
+
+func TestLowerBinaryArith(t *testing.T) {
+	fn := mkFn("add", ir.TInt, &ir.Block{
+		Result: &ir.BinaryExpr{
+			Op:    ir.BinAdd,
+			Left:  &ir.IntLit{Text: "1", T: ir.TInt},
+			Right: &ir.IntLit{Text: "2", T: ir.TInt},
+			T:     ir.TInt,
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "const 1 Int + const 2 Int") {
+		t.Fatalf("expected +-rvalue, got:\n%s", text)
+	}
+}
+
+func TestLowerIfExpr(t *testing.T) {
+	fn := mkFn("abs", ir.TInt, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.LetStmt{
+				Name: "n",
+				Type: ir.TInt,
+				Value: &ir.IntLit{Text: "-5", T: ir.TInt},
+			},
+		},
+		Result: &ir.IfExpr{
+			Cond: &ir.BinaryExpr{
+				Op:    ir.BinLt,
+				Left:  &ir.Ident{Name: "n", Kind: ir.IdentLocal, T: ir.TInt},
+				Right: &ir.IntLit{Text: "0", T: ir.TInt},
+				T:     ir.TBool,
+			},
+			Then: &ir.Block{
+				Result: &ir.UnaryExpr{
+					Op: ir.UnNeg,
+					X:  &ir.Ident{Name: "n", Kind: ir.IdentLocal, T: ir.TInt},
+					T:  ir.TInt,
+				},
+			},
+			Else: &ir.Block{
+				Result: &ir.Ident{Name: "n", Kind: ir.IdentLocal, T: ir.TInt},
+			},
+			T: ir.TInt,
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "branch ") {
+		t.Fatalf("if expected branch terminator, got:\n%s", text)
+	}
+	if !strings.Contains(text, "goto -> bb") {
+		t.Fatalf("if expected goto, got:\n%s", text)
+	}
+}
+
+func TestLowerWhileLoop(t *testing.T) {
+	fn := mkFn("count", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.LetStmt{
+				Name:  "i",
+				Type:  ir.TInt,
+				Value: &ir.IntLit{Text: "0", T: ir.TInt},
+				Mut:   true,
+			},
+			&ir.ForStmt{
+				Kind: ir.ForWhile,
+				Cond: &ir.BinaryExpr{
+					Op:    ir.BinLt,
+					Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+					Right: &ir.IntLit{Text: "10", T: ir.TInt},
+					T:     ir.TBool,
+				},
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.AssignStmt{
+							Op:      ir.AssignEq,
+							Targets: []ir.Expr{&ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt}},
+							Value: &ir.BinaryExpr{
+								Op:    ir.BinAdd,
+								Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+								Right: &ir.IntLit{Text: "1", T: ir.TInt},
+								T:     ir.TInt,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	// Expect a branch on the condition and a back-edge goto.
+	if strings.Count(text, "goto -> bb") < 2 {
+		t.Fatalf("expected two gotos for while header/back-edge, got:\n%s", text)
+	}
+	if !strings.Contains(text, "branch ") {
+		t.Fatalf("expected branch for while cond, got:\n%s", text)
+	}
+}
+
+func TestLowerFnCall(t *testing.T) {
+	// fn add(a: Int, b: Int) -> Int { a + b }
+	addFn := &ir.FnDecl{
+		Name:   "add",
+		Return: ir.TInt,
+		Params: []*ir.Param{
+			{Name: "a", Type: ir.TInt},
+			{Name: "b", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.BinaryExpr{
+				Op:    ir.BinAdd,
+				Left:  &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TInt},
+				Right: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TInt},
+				T:     ir.TInt,
+			},
+		},
+	}
+	// fn main() -> Int { add(1, 2) }
+	mainFn := &ir.FnDecl{
+		Name:   "main",
+		Return: ir.TInt,
+		Body: &ir.Block{
+			Result: &ir.CallExpr{
+				Callee: &ir.Ident{Name: "add", Kind: ir.IdentFn},
+				Args: []ir.Arg{
+					{Value: &ir.IntLit{Text: "1", T: ir.TInt}},
+					{Value: &ir.IntLit{Text: "2", T: ir.TInt}},
+				},
+				T: ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{addFn, mainFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "call add(const 1 Int, const 2 Int)") {
+		t.Fatalf("expected call add(...) in:\n%s", text)
+	}
+}
+
+func TestLowerStructLiteralAndField(t *testing.T) {
+	// struct Point { x: Int, y: Int }
+	// fn sum() -> Int { let p = Point { x: 1, y: 2 }; p.x + p.y }
+	pointDecl := &ir.StructDecl{
+		Name: "Point",
+		Fields: []*ir.Field{
+			{Name: "x", Type: ir.TInt, Exported: true},
+			{Name: "y", Type: ir.TInt, Exported: true},
+		},
+	}
+	pointT := &ir.NamedType{Name: "Point"}
+	sumFn := &ir.FnDecl{
+		Name:   "sum",
+		Return: ir.TInt,
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "p",
+					Type: pointT,
+					Value: &ir.StructLit{
+						TypeName: "Point",
+						Fields: []ir.StructLitField{
+							{Name: "x", Value: &ir.IntLit{Text: "1", T: ir.TInt}},
+							{Name: "y", Value: &ir.IntLit{Text: "2", T: ir.TInt}},
+						},
+						T: pointT,
+					},
+				},
+			},
+			Result: &ir.BinaryExpr{
+				Op: ir.BinAdd,
+				Left: &ir.FieldExpr{
+					X:    &ir.Ident{Name: "p", Kind: ir.IdentLocal, T: pointT},
+					Name: "x",
+					T:    ir.TInt,
+				},
+				Right: &ir.FieldExpr{
+					X:    &ir.Ident{Name: "p", Kind: ir.IdentLocal, T: pointT},
+					Name: "y",
+					T:    ir.TInt,
+				},
+				T: ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, sumFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "aggregate struct(const 1 Int, const 2 Int)") {
+		t.Fatalf("expected struct aggregate, got:\n%s", text)
+	}
+	if !strings.Contains(text, ".x") || !strings.Contains(text, ".y") {
+		t.Fatalf("expected .x/.y projections, got:\n%s", text)
+	}
+	if out.Layouts == nil || out.Layouts.Structs["Point"] == nil {
+		t.Fatalf("expected Point layout entry")
+	}
+}
+
+func TestLowerEnumMatch(t *testing.T) {
+	// enum Maybe { Some(Int), None }
+	// fn score(m: Maybe) -> Int { match m { Some(x) -> x, None -> 0 } }
+	maybeT := &ir.NamedType{Name: "Maybe"}
+	enumDecl := &ir.EnumDecl{
+		Name: "Maybe",
+		Variants: []*ir.Variant{
+			{Name: "Some", Payload: []ir.Type{ir.TInt}},
+			{Name: "None"},
+		},
+	}
+	scrut := &ir.Ident{Name: "m", Kind: ir.IdentParam, T: maybeT}
+	arms := []*ir.MatchArm{
+		{
+			Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "Some", Args: []ir.Pattern{&ir.IdentPat{Name: "x"}}},
+			Body:    &ir.Block{Result: &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt}},
+		},
+		{
+			Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "None"},
+			Body:    &ir.Block{Result: &ir.IntLit{Text: "0", T: ir.TInt}},
+		},
+	}
+	tree := ir.CompileDecisionTree(maybeT, arms)
+	if tree == nil {
+		t.Fatalf("CompileDecisionTree returned nil")
+	}
+	scoreFn := &ir.FnDecl{
+		Name:   "score",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "m", Type: maybeT}},
+		Body: &ir.Block{
+			Result: &ir.MatchExpr{
+				Scrutinee: scrut,
+				Arms:      arms,
+				Tree:      tree,
+				T:         ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{enumDecl, scoreFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "discriminant ") {
+		t.Fatalf("expected discriminant read, got:\n%s", text)
+	}
+	if !strings.Contains(text, "switchInt ") {
+		t.Fatalf("expected switchInt terminator, got:\n%s", text)
+	}
+	if out.Layouts.Enums["Maybe"] == nil {
+		t.Fatalf("expected Maybe layout entry")
+	}
+	// Make sure no HIR-only node (e.g. MatchExpr/IfLetExpr/QuestionExpr)
+	// leaked through the printer output.
+	for _, forbidden := range []string{
+		"MatchExpr",
+		"IfLetExpr",
+		"QuestionExpr",
+		"MethodCall",
+		"VariantLit",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("HIR node %q leaked into MIR output:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestLowerMethodCall(t *testing.T) {
+	// struct Point { x: Int, pub fn get(self) -> Int { self.x } }
+	// fn read(p: Point) -> Int { p.get() }
+	pointT := &ir.NamedType{Name: "Point"}
+	getFn := &ir.FnDecl{
+		Name:   "get",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "self", Type: pointT}},
+		Body: &ir.Block{
+			Result: &ir.FieldExpr{
+				X:    &ir.Ident{Name: "self", Kind: ir.IdentParam, T: pointT},
+				Name: "x",
+				T:    ir.TInt,
+			},
+		},
+	}
+	pointDecl := &ir.StructDecl{
+		Name:    "Point",
+		Fields:  []*ir.Field{{Name: "x", Type: ir.TInt, Exported: true}},
+		Methods: []*ir.FnDecl{getFn},
+	}
+	readFn := &ir.FnDecl{
+		Name:   "read",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "p", Type: pointT}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "p", Kind: ir.IdentParam, T: pointT},
+				Name:     "get",
+				T:        ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, readFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "call Point__get(") {
+		t.Fatalf("expected mangled method call, got:\n%s", text)
+	}
+	// Ensure no MethodCall sugar survives.
+	if strings.Contains(text, "MethodCall") {
+		t.Fatalf("HIR MethodCall leaked:\n%s", text)
+	}
+}
+
+func TestLowerIntrinsicPrintln(t *testing.T) {
+	fn := mkFn("hello", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.IntrinsicCall{
+				Kind: ir.IntrinsicPrintln,
+				Args: []ir.Arg{{Value: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "hello"}}}}},
+			}},
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic println(") {
+		t.Fatalf("expected println intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerVariantLit(t *testing.T) {
+	// enum Color { Red, Green }
+	// fn pick() -> Color { Red }
+	colorT := &ir.NamedType{Name: "Color"}
+	enumDecl := &ir.EnumDecl{
+		Name: "Color",
+		Variants: []*ir.Variant{
+			{Name: "Red"},
+			{Name: "Green"},
+		},
+	}
+	pickFn := &ir.FnDecl{
+		Name:   "pick",
+		Return: colorT,
+		Body: &ir.Block{
+			Result: &ir.VariantLit{
+				Enum:    "Color",
+				Variant: "Red",
+				T:       colorT,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{enumDecl, pickFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "aggregate variant Red") {
+		t.Fatalf("expected aggregate variant, got:\n%s", text)
+	}
+	// VariantLit should not survive as a node name in output.
+	if strings.Contains(text, "VariantLit") {
+		t.Fatalf("HIR VariantLit leaked:\n%s", text)
+	}
+}
+
+func TestLowerRejectsUnsupportedClosure(t *testing.T) {
+	// The current stage-1 lowerer emits an unsupported note for
+	// closures; ensure we see it rather than silently succeeding.
+	fn := mkFn("withClosure", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.LetStmt{
+				Name: "f",
+				Type: &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt},
+				Value: &ir.Closure{
+					Params: []*ir.Param{{Name: "x", Type: ir.TInt}},
+					Return: ir.TInt,
+					Body:   &ir.Block{Result: &ir.Ident{Name: "x", Kind: ir.IdentParam, T: ir.TInt}},
+					T:      &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt},
+				},
+			},
+		},
+	})
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	out := Lower(mod)
+	// Expect a "closure not lowered" issue.
+	saw := false
+	for _, issue := range out.Issues {
+		if strings.Contains(issue.Error(), "closure") {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		t.Fatalf("expected 'closure not lowered' issue, got: %v", out.Issues)
+	}
+}
+
+// TestLoweringProducesNoHIRSugarNodes cross-checks the "MIR is sugar-
+// free" invariant by walking the lowered module and making sure none
+// of the forbidden node shapes appear. This catches regressions where
+// a future lowering pass forgets to expand a construct.
+func TestLoweringProducesNoHIRSugarNodes(t *testing.T) {
+	// A grab-bag program exercising many shapes.
+	maybeT := &ir.NamedType{Name: "Maybe"}
+	enumDecl := &ir.EnumDecl{
+		Name: "Maybe",
+		Variants: []*ir.Variant{
+			{Name: "Some", Payload: []ir.Type{ir.TInt}},
+			{Name: "None"},
+		},
+	}
+	pointT := &ir.NamedType{Name: "Point"}
+	pointDecl := &ir.StructDecl{
+		Name: "Point",
+		Fields: []*ir.Field{
+			{Name: "x", Type: ir.TInt, Exported: true},
+			{Name: "y", Type: ir.TInt, Exported: true},
+		},
+	}
+	arms := []*ir.MatchArm{
+		{
+			Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "Some", Args: []ir.Pattern{&ir.IdentPat{Name: "x"}}},
+			Body:    &ir.Block{Result: &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt}},
+		},
+		{
+			Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "None"},
+			Body:    &ir.Block{Result: &ir.IntLit{Text: "0", T: ir.TInt}},
+		},
+	}
+	tree := ir.CompileDecisionTree(maybeT, arms)
+	mainFn := &ir.FnDecl{
+		Name:   "main",
+		Return: ir.TUnit,
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{Name: "p", Type: pointT, Value: &ir.StructLit{
+					TypeName: "Point",
+					Fields: []ir.StructLitField{
+						{Name: "x", Value: &ir.IntLit{Text: "1", T: ir.TInt}},
+						{Name: "y", Value: &ir.IntLit{Text: "2", T: ir.TInt}},
+					},
+					T: pointT,
+				}},
+				&ir.LetStmt{Name: "m", Type: maybeT, Value: &ir.VariantLit{
+					Enum: "Maybe", Variant: "Some",
+					Args: []ir.Arg{{Value: &ir.IntLit{Text: "42", T: ir.TInt}}},
+					T:    maybeT,
+				}},
+				&ir.ExprStmt{X: &ir.MatchExpr{
+					Scrutinee: &ir.Ident{Name: "m", Kind: ir.IdentLocal, T: maybeT},
+					Arms:      arms,
+					Tree:      tree,
+					T:         ir.TInt,
+				}},
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{enumDecl, pointDecl, mainFn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	// Walk every instruction and terminator and assert it's a known MIR
+	// shape. Because we constructed the MIR from pure Go types, this
+	// mostly asserts the nodes dispatched through the printer — the
+	// type system would catch a stray HIR node at compile time
+	// anyway.
+	for _, fn := range out.Functions {
+		for _, bb := range fn.Blocks {
+			for _, instr := range bb.Instrs {
+				switch instr.(type) {
+				case *AssignInstr, *CallInstr, *IntrinsicInstr,
+					*StorageLiveInstr, *StorageDeadInstr:
+					// ok
+				default:
+					t.Fatalf("unexpected MIR instr %T", instr)
+				}
+			}
+			if bb.Term == nil {
+				t.Fatalf("fn %s bb%d: missing terminator", fn.Name, bb.ID)
+			}
+			switch bb.Term.(type) {
+			case *GotoTerm, *BranchTerm, *SwitchIntTerm,
+				*ReturnTerm, *UnreachableTerm:
+				// ok
+			default:
+				t.Fatalf("unexpected MIR terminator %T", bb.Term)
+			}
+		}
+	}
+}
+
+// ==== regression: external / intrinsic function ====
+
+func TestValidateAcceptsExternalFunction(t *testing.T) {
+	ext := &Function{
+		Name:       "std_println",
+		ReturnType: TUnit,
+		IsExternal: true,
+	}
+	// Give it a synthetic return local so other invariants hold; it
+	// should still validate with no blocks.
+	ext.ReturnLocal = ext.NewLocal("_return", TUnit, false, Span{})
+	ext.Locals[ext.ReturnLocal].IsReturn = true
+	ext.Blocks = nil
+	mod := &Module{Package: "main", Functions: []*Function{ext}, Layouts: NewLayoutTable()}
+	if errs := Validate(mod); len(errs) > 0 {
+		t.Fatalf("validate(external): %v", errs)
+	}
+}
+
+// Ensure runtime FFI / Go FFI `use` decls flow through to the Uses
+// table unchanged.
+func TestLowerPreservesUseDecls(t *testing.T) {
+	useDecl := &ir.UseDecl{
+		Path:        []string{"runtime", "strings"},
+		RawPath:     "runtime.strings",
+		Alias:       "strings",
+		IsRuntimeFFI: true,
+		RuntimePath: "strings",
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{useDecl}}
+	out := Lower(mod)
+	if len(out.Uses) != 1 {
+		t.Fatalf("expected 1 use, got %d", len(out.Uses))
+	}
+	if out.Uses[0].Alias != "strings" || !out.Uses[0].IsRuntimeFFI {
+		t.Fatalf("use decl not preserved: %+v", out.Uses[0])
+	}
+}
+
+// TestLowerIfLetOption covers the common `if let Some(x) = maybe { … }`
+// shape over a built-in Option.
+func TestLowerIfLetOption(t *testing.T) {
+	maybeT := &ir.NamedType{Name: "Maybe"}
+	enumDecl := &ir.EnumDecl{
+		Name: "Maybe",
+		Variants: []*ir.Variant{
+			{Name: "Some", Payload: []ir.Type{ir.TInt}},
+			{Name: "None"},
+		},
+	}
+	fn := &ir.FnDecl{
+		Name:   "score",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "m", Type: maybeT}},
+		Body: &ir.Block{
+			Result: &ir.IfLetExpr{
+				Pattern: &ir.VariantPat{Enum: "Maybe", Variant: "Some",
+					Args: []ir.Pattern{&ir.IdentPat{Name: "x"}}},
+				Scrutinee: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: maybeT},
+				Then: &ir.Block{
+					Result: &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt},
+				},
+				Else: &ir.Block{Result: &ir.IntLit{Text: "0", T: ir.TInt}},
+				T:    ir.TInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{enumDecl, fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "discriminant ") {
+		t.Fatalf("expected discriminant test for if-let, got:\n%s", text)
+	}
+	if !strings.Contains(text, "switchInt ") {
+		t.Fatalf("expected switchInt for if-let, got:\n%s", text)
+	}
+}

--- a/internal/mir/print.go
+++ b/internal/mir/print.go
@@ -1,0 +1,551 @@
+package mir
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Print renders a MIR Module in a stable, human-readable form used by
+// tests and for inspection during backend development. The format is
+// deliberately close to Rust MIR dumps so the shape is recognisable.
+func Print(m *Module) string {
+	var p printer
+	p.printModule(m)
+	return p.b.String()
+}
+
+// PrintFunction renders a single function using the same format as
+// Print.
+func PrintFunction(f *Function) string {
+	var p printer
+	p.printFunction(f)
+	return p.b.String()
+}
+
+type printer struct {
+	b      strings.Builder
+	indent int
+}
+
+func (p *printer) pad() {
+	for i := 0; i < p.indent; i++ {
+		p.b.WriteString("    ")
+	}
+}
+
+func (p *printer) line(format string, args ...any) {
+	p.pad()
+	fmt.Fprintf(&p.b, format, args...)
+	p.b.WriteByte('\n')
+}
+
+func (p *printer) printModule(m *Module) {
+	if m == nil {
+		p.b.WriteString("(nil module)\n")
+		return
+	}
+	p.line("module %q", m.Package)
+	if len(m.Uses) > 0 {
+		p.indent++
+		for _, u := range m.Uses {
+			p.printUse(u)
+		}
+		p.indent--
+	}
+	if m.Layouts != nil {
+		p.printLayouts(m.Layouts)
+	}
+	for _, g := range m.Globals {
+		p.b.WriteByte('\n')
+		p.printGlobal(g)
+	}
+	for _, fn := range m.Functions {
+		p.b.WriteByte('\n')
+		p.printFunction(fn)
+	}
+}
+
+func (p *printer) printUse(u *Use) {
+	if u == nil {
+		return
+	}
+	switch {
+	case u.IsGoFFI:
+		p.line("use go %q as %s", u.GoPath, u.Alias)
+	case u.IsRuntimeFFI:
+		p.line("use runtime %q as %s", u.RuntimePath, u.Alias)
+	default:
+		path := u.RawPath
+		if path == "" {
+			path = strings.Join(u.Path, ".")
+		}
+		p.line("use %s as %s", path, u.Alias)
+	}
+}
+
+func (p *printer) printLayouts(tab *LayoutTable) {
+	names := make([]string, 0, len(tab.Structs))
+	for name := range tab.Structs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		sl := tab.Structs[name]
+		p.b.WriteByte('\n')
+		p.line("layout struct %s (mangled=%s) {", sl.Name, orEmpty(sl.Mangled))
+		p.indent++
+		for _, f := range sl.Fields {
+			p.line("[%d] %s: %s", f.Index, f.Name, typeString(f.Type))
+		}
+		p.indent--
+		p.line("}")
+	}
+	enumNames := make([]string, 0, len(tab.Enums))
+	for name := range tab.Enums {
+		enumNames = append(enumNames, name)
+	}
+	sort.Strings(enumNames)
+	for _, name := range enumNames {
+		el := tab.Enums[name]
+		p.b.WriteByte('\n')
+		p.line("layout enum %s (mangled=%s, disc=%s) {", el.Name, orEmpty(el.Mangled), typeString(el.Discriminant))
+		p.indent++
+		for _, v := range el.Variants {
+			if len(v.Payload) == 0 {
+				p.line("variant %d %s", v.Index, v.Name)
+				continue
+			}
+			parts := make([]string, len(v.Payload))
+			for i, f := range v.Payload {
+				parts[i] = typeString(f.Type)
+			}
+			p.line("variant %d %s(%s)", v.Index, v.Name, strings.Join(parts, ", "))
+		}
+		p.indent--
+		p.line("}")
+	}
+	tupleKeys := make([]string, 0, len(tab.Tuples))
+	for key := range tab.Tuples {
+		tupleKeys = append(tupleKeys, key)
+	}
+	sort.Strings(tupleKeys)
+	for _, key := range tupleKeys {
+		tl := tab.Tuples[key]
+		parts := make([]string, len(tl.Fields))
+		for i, f := range tl.Fields {
+			parts[i] = typeString(f.Type)
+		}
+		p.b.WriteByte('\n')
+		p.line("layout tuple %s (mangled=%s) { %s }", tl.Key, orEmpty(tl.Mangled), strings.Join(parts, ", "))
+	}
+}
+
+func (p *printer) printGlobal(g *Global) {
+	if g == nil {
+		return
+	}
+	mut := ""
+	if g.Mut {
+		mut = " mut"
+	}
+	p.line("global%s %s: %s", mut, g.Name, typeString(g.Type))
+	if g.Init != nil {
+		p.indent++
+		p.printFunction(g.Init)
+		p.indent--
+	}
+}
+
+func (p *printer) printFunction(f *Function) {
+	if f == nil {
+		p.b.WriteString("(nil fn)\n")
+		return
+	}
+	kind := "fn"
+	switch {
+	case f.IsExternal:
+		kind = "extern fn"
+	case f.IsIntrinsic:
+		kind = "intrinsic fn"
+	}
+	exported := ""
+	if f.Exported {
+		exported = " pub"
+	}
+	paramParts := make([]string, len(f.Params))
+	for i, pid := range f.Params {
+		loc := f.Local(pid)
+		if loc == nil {
+			paramParts[i] = fmt.Sprintf("_%d", pid)
+			continue
+		}
+		paramParts[i] = fmt.Sprintf("_%d: %s", pid, typeString(loc.Type))
+	}
+	p.line("%s%s %s(%s) -> %s {", kind, exported, f.Name, strings.Join(paramParts, ", "), typeString(f.ReturnType))
+	p.indent++
+	if len(f.Locals) > 0 {
+		// emit local declarations in id order, skipping params (already
+		// described in the signature) to keep the dump short.
+		for _, loc := range f.Locals {
+			if loc == nil {
+				continue
+			}
+			if loc.IsParam {
+				continue
+			}
+			annot := ""
+			if loc.Mut {
+				annot = " mut"
+			}
+			if loc.IsReturn {
+				annot = " return"
+			}
+			name := loc.Name
+			if name == "" {
+				name = "_"
+			}
+			p.line("let%s _%d: %s  // %s", annot, loc.ID, typeString(loc.Type), name)
+		}
+	}
+	if !f.IsExternal {
+		for _, bb := range f.Blocks {
+			p.b.WriteByte('\n')
+			p.printBlock(bb, f)
+		}
+	}
+	p.indent--
+	p.line("}")
+}
+
+func (p *printer) printBlock(bb *BasicBlock, f *Function) {
+	if bb == nil {
+		return
+	}
+	p.line("bb%d:", int(bb.ID))
+	p.indent++
+	for _, instr := range bb.Instrs {
+		p.printInstr(instr, f)
+	}
+	if bb.Term != nil {
+		p.printTerm(bb.Term, f)
+	} else {
+		p.line("<missing terminator>")
+	}
+	p.indent--
+}
+
+func (p *printer) printInstr(instr Instr, f *Function) {
+	switch x := instr.(type) {
+	case *AssignInstr:
+		p.line("%s = %s", placeString(x.Dest, f), rvalueString(x.Src, f))
+	case *CallInstr:
+		dest := ""
+		if x.Dest != nil {
+			dest = placeString(*x.Dest, f) + " = "
+		}
+		callee := calleeString(x.Callee, f)
+		args := operandsString(x.Args, f)
+		p.line("%scall %s(%s)", dest, callee, args)
+	case *IntrinsicInstr:
+		dest := ""
+		if x.Dest != nil {
+			dest = placeString(*x.Dest, f) + " = "
+		}
+		args := operandsString(x.Args, f)
+		p.line("%sintrinsic %s(%s)", dest, intrinsicName(x.Kind), args)
+	case *StorageLiveInstr:
+		p.line("storage_live _%d", int(x.Local))
+	case *StorageDeadInstr:
+		p.line("storage_dead _%d", int(x.Local))
+	default:
+		p.line("(unknown instr %T)", instr)
+	}
+}
+
+func (p *printer) printTerm(t Terminator, f *Function) {
+	switch x := t.(type) {
+	case *GotoTerm:
+		p.line("goto -> bb%d", int(x.Target))
+	case *BranchTerm:
+		p.line("branch %s -> [true: bb%d, false: bb%d]", operandString(x.Cond, f), int(x.Then), int(x.Else))
+	case *SwitchIntTerm:
+		parts := make([]string, 0, len(x.Cases)+1)
+		for _, c := range x.Cases {
+			label := c.Label
+			if label == "" {
+				label = strconv.FormatInt(c.Value, 10)
+			}
+			parts = append(parts, fmt.Sprintf("%s => bb%d", label, int(c.Target)))
+		}
+		parts = append(parts, fmt.Sprintf("_ => bb%d", int(x.Default)))
+		p.line("switchInt %s -> [%s]", operandString(x.Scrutinee, f), strings.Join(parts, ", "))
+	case *ReturnTerm:
+		p.line("return")
+	case *UnreachableTerm:
+		p.line("unreachable")
+	default:
+		p.line("(unknown terminator %T)", t)
+	}
+}
+
+// ==== value rendering ====
+
+func placeString(p Place, f *Function) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "_%d", int(p.Local))
+	for _, proj := range p.Projections {
+		b.WriteString(projectionString(proj, f))
+	}
+	return b.String()
+}
+
+func projectionString(proj Projection, f *Function) string {
+	switch x := proj.(type) {
+	case *FieldProj:
+		if x.Name != "" {
+			return "." + x.Name
+		}
+		return fmt.Sprintf(".field%d", x.Index)
+	case *TupleProj:
+		return fmt.Sprintf(".%d", x.Index)
+	case *VariantProj:
+		if x.FieldIdx < 0 {
+			return "@" + x.Name
+		}
+		return fmt.Sprintf("@%s.%d", x.Name, x.FieldIdx)
+	case *IndexProj:
+		return "[" + operandString(x.Index, f) + "]"
+	case *DerefProj:
+		return ".*"
+	}
+	return "(?)"
+}
+
+func operandString(op Operand, f *Function) string {
+	switch x := op.(type) {
+	case *CopyOp:
+		return placeString(x.Place, f)
+	case *MoveOp:
+		return "move " + placeString(x.Place, f)
+	case *ConstOp:
+		return constString(x.Const)
+	}
+	return "(?)"
+}
+
+func operandsString(ops []Operand, f *Function) string {
+	parts := make([]string, len(ops))
+	for i, op := range ops {
+		parts[i] = operandString(op, f)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func rvalueString(rv RValue, f *Function) string {
+	switch x := rv.(type) {
+	case *UseRV:
+		return "use " + operandString(x.Op, f)
+	case *UnaryRV:
+		return fmt.Sprintf("%s %s", unaryOpName(x.Op), operandString(x.Arg, f))
+	case *BinaryRV:
+		return fmt.Sprintf("%s %s %s", operandString(x.Left, f), binaryOpName(x.Op), operandString(x.Right, f))
+	case *AggregateRV:
+		kind := aggregateKindName(x.Kind)
+		if x.Kind == AggEnumVariant {
+			tag := x.VariantTag
+			if tag == "" {
+				tag = strconv.Itoa(x.VariantIdx)
+			}
+			return fmt.Sprintf("aggregate %s %s(%s)", kind, tag, operandsString(x.Fields, f))
+		}
+		return fmt.Sprintf("aggregate %s(%s)", kind, operandsString(x.Fields, f))
+	case *DiscriminantRV:
+		return "discriminant " + placeString(x.Place, f)
+	case *LenRV:
+		return "len " + placeString(x.Place, f)
+	case *CastRV:
+		return fmt.Sprintf("cast %s %s as %s", castKindName(x.Kind), operandString(x.Arg, f), typeString(x.To))
+	case *AddressOfRV:
+		return "&" + placeString(x.Place, f)
+	case *RefRV:
+		return "ref " + placeString(x.Place, f)
+	case *NullaryRV:
+		return fmt.Sprintf("%s %s", nullaryKindName(x.Kind), typeString(x.T))
+	}
+	return "(?)"
+}
+
+func calleeString(c Callee, f *Function) string {
+	switch x := c.(type) {
+	case *FnRef:
+		return x.Symbol
+	case *IndirectCall:
+		return "*" + operandString(x.Callee, f)
+	}
+	return "(?)"
+}
+
+func constString(c Const) string {
+	switch x := c.(type) {
+	case *IntConst:
+		return fmt.Sprintf("const %d %s", x.Value, typeString(x.Type()))
+	case *BoolConst:
+		if x.Value {
+			return "const true"
+		}
+		return "const false"
+	case *FloatConst:
+		return fmt.Sprintf("const %g %s", x.Value, typeString(x.Type()))
+	case *StringConst:
+		return fmt.Sprintf("const %q", x.Value)
+	case *CharConst:
+		return fmt.Sprintf("const '%c'", x.Value)
+	case *ByteConst:
+		return fmt.Sprintf("const 0x%02x", x.Value)
+	case *UnitConst:
+		return "const ()"
+	case *NullConst:
+		return "const none " + typeString(x.Type())
+	case *FnConst:
+		return "const fn " + x.Symbol
+	}
+	return "(?)"
+}
+
+// ==== enum-style name tables ====
+
+func intrinsicName(k IntrinsicKind) string {
+	switch k {
+	case IntrinsicPrint:
+		return "print"
+	case IntrinsicPrintln:
+		return "println"
+	case IntrinsicEprint:
+		return "eprint"
+	case IntrinsicEprintln:
+		return "eprintln"
+	case IntrinsicAbort:
+		return "abort"
+	case IntrinsicStringConcat:
+		return "string_concat"
+	}
+	return "invalid"
+}
+
+func unaryOpName(op UnaryOp) string {
+	switch op {
+	case UnNeg:
+		return "-"
+	case UnPlus:
+		return "+"
+	case UnNot:
+		return "!"
+	case UnBitNot:
+		return "~"
+	}
+	return "?"
+}
+
+func binaryOpName(op BinaryOp) string {
+	switch op {
+	case BinAdd:
+		return "+"
+	case BinSub:
+		return "-"
+	case BinMul:
+		return "*"
+	case BinDiv:
+		return "/"
+	case BinMod:
+		return "%"
+	case BinEq:
+		return "=="
+	case BinNeq:
+		return "!="
+	case BinLt:
+		return "<"
+	case BinLeq:
+		return "<="
+	case BinGt:
+		return ">"
+	case BinGeq:
+		return ">="
+	case BinAnd:
+		return "&&"
+	case BinOr:
+		return "||"
+	case BinBitAnd:
+		return "&"
+	case BinBitOr:
+		return "|"
+	case BinBitXor:
+		return "^"
+	case BinShl:
+		return "<<"
+	case BinShr:
+		return ">>"
+	}
+	return "?"
+}
+
+func aggregateKindName(k AggregateKind) string {
+	switch k {
+	case AggTuple:
+		return "tuple"
+	case AggStruct:
+		return "struct"
+	case AggEnumVariant:
+		return "variant"
+	case AggList:
+		return "list"
+	case AggMap:
+		return "map"
+	}
+	return "?"
+}
+
+func castKindName(k CastKind) string {
+	switch k {
+	case CastIntResize:
+		return "int_resize"
+	case CastIntToFloat:
+		return "int_to_float"
+	case CastFloatToInt:
+		return "float_to_int"
+	case CastFloatResize:
+		return "float_resize"
+	case CastOptionalWrap:
+		return "optional_wrap"
+	case CastOptionalUnwrap:
+		return "optional_unwrap"
+	case CastBitcast:
+		return "bitcast"
+	}
+	return "?"
+}
+
+func nullaryKindName(k NullaryRVKind) string {
+	switch k {
+	case NullaryNone:
+		return "none"
+	}
+	return "?"
+}
+
+// ==== misc helpers ====
+
+func typeString(t Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.String()
+}
+
+func orEmpty(s string) string {
+	if s == "" {
+		return "?"
+	}
+	return s
+}

--- a/internal/mir/validate.go
+++ b/internal/mir/validate.go
@@ -1,0 +1,403 @@
+package mir
+
+import (
+	"fmt"
+)
+
+// Validate walks a MIR Module and returns a slice of structural
+// errors. An empty slice means the module passes every invariant the
+// MIR layer enforces; a non-empty slice means the lowerer has a bug
+// (not that the user's program is wrong — MIR invariants are internal
+// contracts).
+//
+// The validator is deliberately light-weight: it catches shape bugs
+// that would otherwise surface as an LLVM verifier failure or worse,
+// a silently-miscompiled program. It does NOT redo type checking.
+//
+// Invariants checked:
+//
+//   - Module is non-nil and carries a package name.
+//   - Every function has a non-empty block list when not external, an
+//     entry block whose ID is in range, and every block has a
+//     terminator.
+//   - No instruction follows a terminator inside a block.
+//   - Every Place references a local that exists and every projection
+//     carries a non-nil Type.
+//   - Every Operand carries a non-nil Type.
+//   - Every RValue's inputs carry types.
+//   - Terminator successors reference existing blocks.
+//   - No HIR-only node leaked into MIR: no ir.Pattern, no ir.MatchExpr,
+//     etc. (The design guarantees this at the type level by not
+//     importing the HIR node types directly; the validator's job is
+//     to catch the shape invariants within MIR itself.)
+func Validate(m *Module) []error {
+	v := &validator{}
+	v.validateModule(m)
+	return v.errs
+}
+
+type validator struct {
+	errs []error
+	fn   *Function // current function context
+}
+
+func (v *validator) addf(format string, args ...any) {
+	v.errs = append(v.errs, fmt.Errorf(format, args...))
+}
+
+func (v *validator) validateModule(m *Module) {
+	if m == nil {
+		v.addf("module: nil")
+		return
+	}
+	if m.Package == "" {
+		v.addf("module: empty package")
+	}
+	names := map[string]bool{}
+	for i, fn := range m.Functions {
+		if fn == nil {
+			v.addf("module.Functions[%d]: nil", i)
+			continue
+		}
+		if fn.Name == "" {
+			v.addf("function[%d]: empty name", i)
+		}
+		if names[fn.Name] {
+			v.addf("function %q: duplicate symbol", fn.Name)
+		}
+		names[fn.Name] = true
+		v.validateFunction(fn)
+	}
+	for i, g := range m.Globals {
+		if g == nil {
+			v.addf("module.Globals[%d]: nil", i)
+			continue
+		}
+		v.validateGlobal(g)
+	}
+}
+
+func (v *validator) validateGlobal(g *Global) {
+	if g.Name == "" {
+		v.addf("global: empty name")
+	}
+	if g.Type == nil {
+		v.addf("global %q: nil Type", g.Name)
+	}
+	if g.Init != nil {
+		v.validateFunction(g.Init)
+	}
+}
+
+func (v *validator) validateFunction(fn *Function) {
+	prev := v.fn
+	v.fn = fn
+	defer func() { v.fn = prev }()
+
+	if fn.ReturnType == nil {
+		v.addf("function %q: nil ReturnType", fn.Name)
+	}
+
+	// Return local exists and has the declared return type (when the
+	// function has a body). External / intrinsic functions may carry an
+	// empty locals list.
+	if !fn.IsExternal && !fn.IsIntrinsic {
+		if int(fn.ReturnLocal) < 0 || int(fn.ReturnLocal) >= len(fn.Locals) {
+			v.addf("function %q: ReturnLocal %d out of range (locals=%d)", fn.Name, fn.ReturnLocal, len(fn.Locals))
+		} else {
+			ret := fn.Locals[fn.ReturnLocal]
+			if ret == nil {
+				v.addf("function %q: ReturnLocal %d is nil", fn.Name, fn.ReturnLocal)
+			} else if !ret.IsReturn {
+				v.addf("function %q: ReturnLocal %d is not marked IsReturn", fn.Name, fn.ReturnLocal)
+			}
+		}
+	}
+
+	// Parameters reference existing locals and are flagged as params.
+	for i, pid := range fn.Params {
+		if int(pid) < 0 || int(pid) >= len(fn.Locals) {
+			v.addf("function %q: Params[%d]=%d out of range (locals=%d)", fn.Name, i, pid, len(fn.Locals))
+			continue
+		}
+		loc := fn.Locals[pid]
+		if loc == nil {
+			v.addf("function %q: Params[%d]=%d is nil", fn.Name, i, pid)
+			continue
+		}
+		if !loc.IsParam {
+			v.addf("function %q: Params[%d]=_%d is not marked IsParam", fn.Name, i, pid)
+		}
+	}
+
+	// Locals carry types and unique IDs.
+	for i, loc := range fn.Locals {
+		if loc == nil {
+			v.addf("function %q: Locals[%d]: nil", fn.Name, i)
+			continue
+		}
+		if int(loc.ID) != i {
+			v.addf("function %q: Locals[%d].ID = %d (mismatch)", fn.Name, i, loc.ID)
+		}
+		if loc.Type == nil {
+			v.addf("function %q: Locals[%d]=_%d nil Type", fn.Name, i, loc.ID)
+		}
+	}
+
+	if fn.IsExternal || fn.IsIntrinsic {
+		if len(fn.Blocks) != 0 {
+			v.addf("function %q: external/intrinsic must have no blocks", fn.Name)
+		}
+		return
+	}
+
+	if len(fn.Blocks) == 0 {
+		v.addf("function %q: no blocks", fn.Name)
+		return
+	}
+	if int(fn.Entry) < 0 || int(fn.Entry) >= len(fn.Blocks) {
+		v.addf("function %q: Entry=%d out of range (blocks=%d)", fn.Name, fn.Entry, len(fn.Blocks))
+	}
+
+	for i, bb := range fn.Blocks {
+		if bb == nil {
+			v.addf("function %q: Blocks[%d]: nil", fn.Name, i)
+			continue
+		}
+		if int(bb.ID) != i {
+			v.addf("function %q: Blocks[%d].ID = %d (mismatch)", fn.Name, i, bb.ID)
+		}
+		v.validateBlock(fn, bb)
+	}
+}
+
+func (v *validator) validateBlock(fn *Function, bb *BasicBlock) {
+	for i, instr := range bb.Instrs {
+		if instr == nil {
+			v.addf("function %q bb%d: instruction[%d] nil", fn.Name, bb.ID, i)
+			continue
+		}
+		v.validateInstr(fn, bb, i, instr)
+	}
+	if bb.Term == nil {
+		v.addf("function %q bb%d: missing terminator", fn.Name, bb.ID)
+		return
+	}
+	v.validateTerm(fn, bb, bb.Term)
+}
+
+func (v *validator) validateInstr(fn *Function, bb *BasicBlock, idx int, instr Instr) {
+	switch x := instr.(type) {
+	case *AssignInstr:
+		v.validatePlace(fn, bb, x.Dest, "AssignInstr.Dest")
+		if x.Src == nil {
+			v.addf("function %q bb%d instr[%d]: AssignInstr nil Src", fn.Name, bb.ID, idx)
+			return
+		}
+		v.validateRValue(fn, bb, x.Src)
+	case *CallInstr:
+		if x.Dest != nil {
+			v.validatePlace(fn, bb, *x.Dest, "CallInstr.Dest")
+		}
+		v.validateCallee(fn, bb, x.Callee)
+		for i, op := range x.Args {
+			v.validateOperand(fn, bb, op, fmt.Sprintf("CallInstr.Args[%d]", i))
+		}
+	case *IntrinsicInstr:
+		if x.Dest != nil {
+			v.validatePlace(fn, bb, *x.Dest, "IntrinsicInstr.Dest")
+		}
+		if x.Kind == IntrinsicInvalid {
+			v.addf("function %q bb%d instr[%d]: IntrinsicInvalid", fn.Name, bb.ID, idx)
+		}
+		for i, op := range x.Args {
+			v.validateOperand(fn, bb, op, fmt.Sprintf("IntrinsicInstr.Args[%d]", i))
+		}
+	case *StorageLiveInstr:
+		if int(x.Local) < 0 || int(x.Local) >= len(fn.Locals) {
+			v.addf("function %q bb%d instr[%d]: StorageLive _%d out of range", fn.Name, bb.ID, idx, x.Local)
+		}
+	case *StorageDeadInstr:
+		if int(x.Local) < 0 || int(x.Local) >= len(fn.Locals) {
+			v.addf("function %q bb%d instr[%d]: StorageDead _%d out of range", fn.Name, bb.ID, idx, x.Local)
+		}
+	default:
+		v.addf("function %q bb%d instr[%d]: unknown instruction %T", fn.Name, bb.ID, idx, instr)
+	}
+}
+
+func (v *validator) validateCallee(fn *Function, bb *BasicBlock, c Callee) {
+	switch x := c.(type) {
+	case nil:
+		v.addf("function %q bb%d: CallInstr nil callee", fn.Name, bb.ID)
+	case *FnRef:
+		if x.Symbol == "" {
+			v.addf("function %q bb%d: FnRef empty symbol", fn.Name, bb.ID)
+		}
+	case *IndirectCall:
+		if x.Callee == nil {
+			v.addf("function %q bb%d: IndirectCall nil operand", fn.Name, bb.ID)
+			return
+		}
+		v.validateOperand(fn, bb, x.Callee, "IndirectCall.Callee")
+	default:
+		v.addf("function %q bb%d: unknown callee %T", fn.Name, bb.ID, c)
+	}
+}
+
+func (v *validator) validateRValue(fn *Function, bb *BasicBlock, rv RValue) {
+	switch x := rv.(type) {
+	case *UseRV:
+		v.validateOperand(fn, bb, x.Op, "UseRV")
+	case *UnaryRV:
+		if x.T == nil {
+			v.addf("function %q bb%d: UnaryRV nil Type", fn.Name, bb.ID)
+		}
+		v.validateOperand(fn, bb, x.Arg, "UnaryRV.Arg")
+	case *BinaryRV:
+		if x.T == nil {
+			v.addf("function %q bb%d: BinaryRV nil Type", fn.Name, bb.ID)
+		}
+		v.validateOperand(fn, bb, x.Left, "BinaryRV.Left")
+		v.validateOperand(fn, bb, x.Right, "BinaryRV.Right")
+	case *AggregateRV:
+		if x.T == nil {
+			v.addf("function %q bb%d: AggregateRV nil Type", fn.Name, bb.ID)
+		}
+		if x.Kind == 0 {
+			v.addf("function %q bb%d: AggregateRV zero Kind", fn.Name, bb.ID)
+		}
+		for i, op := range x.Fields {
+			v.validateOperand(fn, bb, op, fmt.Sprintf("AggregateRV.Fields[%d]", i))
+		}
+	case *DiscriminantRV:
+		v.validatePlace(fn, bb, x.Place, "DiscriminantRV.Place")
+		if x.T == nil {
+			v.addf("function %q bb%d: DiscriminantRV nil Type", fn.Name, bb.ID)
+		}
+	case *LenRV:
+		v.validatePlace(fn, bb, x.Place, "LenRV.Place")
+		if x.T == nil {
+			v.addf("function %q bb%d: LenRV nil Type", fn.Name, bb.ID)
+		}
+	case *CastRV:
+		v.validateOperand(fn, bb, x.Arg, "CastRV.Arg")
+		if x.From == nil || x.To == nil {
+			v.addf("function %q bb%d: CastRV nil From/To", fn.Name, bb.ID)
+		}
+	case *AddressOfRV:
+		v.validatePlace(fn, bb, x.Place, "AddressOfRV.Place")
+	case *RefRV:
+		v.validatePlace(fn, bb, x.Place, "RefRV.Place")
+	case *NullaryRV:
+		if x.Kind == 0 {
+			v.addf("function %q bb%d: NullaryRV zero Kind", fn.Name, bb.ID)
+		}
+		if x.T == nil {
+			v.addf("function %q bb%d: NullaryRV nil Type", fn.Name, bb.ID)
+		}
+	default:
+		v.addf("function %q bb%d: unknown rvalue %T", fn.Name, bb.ID, rv)
+	}
+}
+
+func (v *validator) validateOperand(fn *Function, bb *BasicBlock, op Operand, ctx string) {
+	if op == nil {
+		v.addf("function %q bb%d %s: nil operand", fn.Name, bb.ID, ctx)
+		return
+	}
+	if op.Type() == nil {
+		v.addf("function %q bb%d %s: operand has nil Type", fn.Name, bb.ID, ctx)
+	}
+	switch x := op.(type) {
+	case *CopyOp:
+		v.validatePlace(fn, bb, x.Place, ctx+".Place")
+	case *MoveOp:
+		v.validatePlace(fn, bb, x.Place, ctx+".Place")
+	case *ConstOp:
+		if x.Const == nil {
+			v.addf("function %q bb%d %s: ConstOp nil Const", fn.Name, bb.ID, ctx)
+		}
+	default:
+		v.addf("function %q bb%d %s: unknown operand %T", fn.Name, bb.ID, ctx, op)
+	}
+}
+
+func (v *validator) validatePlace(fn *Function, bb *BasicBlock, p Place, ctx string) {
+	if int(p.Local) < 0 || int(p.Local) >= len(fn.Locals) {
+		v.addf("function %q bb%d %s: local _%d out of range", fn.Name, bb.ID, ctx, p.Local)
+		return
+	}
+	if fn.Locals[p.Local] == nil {
+		v.addf("function %q bb%d %s: local _%d is nil", fn.Name, bb.ID, ctx, p.Local)
+		return
+	}
+	for i, proj := range p.Projections {
+		v.validateProjection(fn, bb, proj, fmt.Sprintf("%s.Projections[%d]", ctx, i))
+	}
+}
+
+func (v *validator) validateProjection(fn *Function, bb *BasicBlock, proj Projection, ctx string) {
+	if proj == nil {
+		v.addf("function %q bb%d %s: nil projection", fn.Name, bb.ID, ctx)
+		return
+	}
+	switch x := proj.(type) {
+	case *FieldProj:
+		if x.Type == nil {
+			v.addf("function %q bb%d %s: FieldProj nil Type", fn.Name, bb.ID, ctx)
+		}
+		if x.Index < 0 {
+			v.addf("function %q bb%d %s: FieldProj negative index %d", fn.Name, bb.ID, ctx, x.Index)
+		}
+	case *TupleProj:
+		if x.Type == nil {
+			v.addf("function %q bb%d %s: TupleProj nil Type", fn.Name, bb.ID, ctx)
+		}
+		if x.Index < 0 {
+			v.addf("function %q bb%d %s: TupleProj negative index %d", fn.Name, bb.ID, ctx, x.Index)
+		}
+	case *VariantProj:
+		if x.Type == nil {
+			v.addf("function %q bb%d %s: VariantProj nil Type", fn.Name, bb.ID, ctx)
+		}
+	case *IndexProj:
+		if x.ElemType == nil {
+			v.addf("function %q bb%d %s: IndexProj nil ElemType", fn.Name, bb.ID, ctx)
+		}
+		v.validateOperand(fn, bb, x.Index, ctx+".Index")
+	case *DerefProj:
+		if x.Type == nil {
+			v.addf("function %q bb%d %s: DerefProj nil Type", fn.Name, bb.ID, ctx)
+		}
+	default:
+		v.addf("function %q bb%d %s: unknown projection %T", fn.Name, bb.ID, ctx, proj)
+	}
+}
+
+func (v *validator) validateTerm(fn *Function, bb *BasicBlock, t Terminator) {
+	switch x := t.(type) {
+	case *GotoTerm:
+		v.validateBlockRef(fn, bb, x.Target, "Goto.Target")
+	case *BranchTerm:
+		v.validateOperand(fn, bb, x.Cond, "Branch.Cond")
+		v.validateBlockRef(fn, bb, x.Then, "Branch.Then")
+		v.validateBlockRef(fn, bb, x.Else, "Branch.Else")
+	case *SwitchIntTerm:
+		v.validateOperand(fn, bb, x.Scrutinee, "SwitchInt.Scrutinee")
+		for i, c := range x.Cases {
+			v.validateBlockRef(fn, bb, c.Target, fmt.Sprintf("SwitchInt.Cases[%d]", i))
+		}
+		v.validateBlockRef(fn, bb, x.Default, "SwitchInt.Default")
+	case *ReturnTerm, *UnreachableTerm:
+		// leaf — no successor refs.
+	default:
+		v.addf("function %q bb%d: unknown terminator %T", fn.Name, bb.ID, t)
+	}
+}
+
+func (v *validator) validateBlockRef(fn *Function, bb *BasicBlock, target BlockID, ctx string) {
+	if int(target) < 0 || int(target) >= len(fn.Blocks) {
+		v.addf("function %q bb%d %s: target bb%d out of range (blocks=%d)", fn.Name, bb.ID, ctx, target, len(fn.Blocks))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/mir`: a Rust-MIR-style middle IR (locals + basic blocks + places + projections + terminators) sitting below the existing HIR in `internal/ir`. No pattern nodes, no `MatchExpr`/`IfLetExpr`/`QuestionExpr`/`MethodCall`/`VariantLit` — those lower into explicit CFG + aggregates + projections in one pass.
- Add HIR → MIR lowering for the subset the current LLVM test suite exercises: arithmetic, if/while/for, let with destructuring, direct & method calls, struct/tuple/list literals, enum variant construction, `match` via the HIR decision tree, `if let`, optional chaining `?.`, `??`, and `?` propagation.
- Add `docs/mir_design.md` covering HIR vs MIR responsibilities, the node model, lowering rules per HIR construct, the layout-table strategy, and a 5-stage migration plan from the current `legacyFileFromModule` bridge to direct MIR consumption by backends.

## Why

The current `internal/ir` is effectively a typed HIR: source sugar (patterns, `?`, method syntax, keyword args, `if let`, `for let`, struct spread) still flows all the way into `internal/llvmgen`, which today reifies the IR back into a legacy AST and lowers from there. Every future backend would have to re-implement that lowering. MIR absorbs it once, so a backend can consume `mir.Module` directly with no knowledge of Osty source semantics.

This PR is **Stage 1 only**:

- `internal/mir` package scaffolding (types, printer, validator, lowering)
- Lowering for the subset of HIR currently exercised by LLVM/backend tests
- Design doc + test coverage

Stages 2–5 (closures / defer / concurrency lowering, MIR-direct llvmgen, removing the legacy bridge) are explicitly deferred and documented in the design doc.

## Non-goals / deferred

- No SSA.
- No optimizer passes beyond what's needed for correctness.
- No concurrency (`spawn`, `taskGroup`, channels) lowering yet — those emit "not yet lowered" issues so callers stay on the HIR path.
- **`internal/llvmgen` is untouched.** The IR→AST bridge still backs the LLVM backend; MIR is additive. Current green LLVM/backend tests keep passing unchanged.

## Notable invariants (enforced by `mir.Validate`)

- Every function has an entry block; every block ends in exactly one terminator.
- Every `Place` references a live local; every projection carries a non-nil `Type`.
- Every `Operand` carries a non-nil `Type`.
- Terminator successors reference existing blocks.
- Function symbols are unique.
- No HIR pattern or sugar node can appear in MIR — enforced at the type-system level (the MIR package does not import `ir`'s pattern or `match`/`if let`/`?` node types) and re-asserted by `TestLoweringProducesNoHIRSugarNodes`.

## Files

- [`docs/mir_design.md`](docs/mir_design.md) — design doc
- [`internal/mir/doc.go`](internal/mir/doc.go) — package overview
- [`internal/mir/mir.go`](internal/mir/mir.go) — core types (`Module`, `Function`, `BasicBlock`, `Instr`, `Terminator`, `Place`, `Projection`, `Operand`, `RValue`, `Const`, `LayoutTable`)
- [`internal/mir/print.go`](internal/mir/print.go) — stable Rust-MIR-style debug printer
- [`internal/mir/validate.go`](internal/mir/validate.go) — structural validator
- [`internal/mir/lower.go`](internal/mir/lower.go) — HIR → MIR lowering
- [`internal/mir/mir_test.go`](internal/mir/mir_test.go) + [`internal/mir/dump_example_test.go`](internal/mir/dump_example_test.go) — construction / lowering / validator tests

## Test plan

- [x] `go test ./internal/mir`
- [x] `go test ./internal/parser ./internal/ir ./internal/llvmgen ./internal/backend` — current green subset stays green
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `TestLoweringProducesNoHIRSugarNodes` asserts no HIR pattern / sugar node leaks into MIR output
- [x] Validator tests cover: missing terminator, out-of-range local, duplicate symbol, empty package, external-function acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)