### PR TITLE
feat(mir): stage 2b — concurrency primitive intrinsics

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -91,7 +91,7 @@ reason about generics.
 | Decision-tree pre-compilation    | yes                 | consumed by lowerer  |
 | Closure captures                 | yes (`Closure.Captures`) | lifted to top-level fn + `AggClosure` (Stage 2a) |
 | `defer` bodies                   | yes                 | function-scoped, replayed at every return edge (Stage 2a; inner-block scoping is Stage 2c) |
-| Concurrency primitives           | yes                 | not yet (Stage 2b)   |
+| Concurrency primitives           | yes                 | `IntrinsicInstr` set (Stage 2b)                      |
 | Compound & multi-target assign   | yes                 | expanded to `BinaryRV` / tuple destructure (Stage 2a) |
 | Top-level global read            | yes (`IdentGlobal`) | `GlobalRefRV` (Stage 2a)                              |
 
@@ -188,10 +188,30 @@ function values. Keyword arguments are gone by the time we enter MIR:
 `mir.Lower` reorders and fills defaults against the callee's declared
 signature.
 
-`IntrinsicInstr` covers backend-neutral built-ins (the `print` family)
-without forcing backends to match on name strings. Additional
-intrinsics (`list-push`, `string-concat`, …) can be added as runtime
-ABI ossifies.
+`IntrinsicInstr` covers backend-neutral built-ins. The `Kind` value
+is the stable ABI contract — backends map each kind to whatever
+runtime symbol their target exposes. Kinds group into families:
+
+- **Print family**: `IntrinsicPrint`, `IntrinsicPrintln`,
+  `IntrinsicEprint`, `IntrinsicEprintln`.
+- **Runtime builders**: `IntrinsicStringConcat` (interpolated string
+  assembly), `IntrinsicAbort` (trap).
+- **Concurrency — channels**: `IntrinsicChanMake`,
+  `IntrinsicChanSend`, `IntrinsicChanRecv` (returns `Option<T>`),
+  `IntrinsicChanClose`, `IntrinsicChanIsClosed`.
+- **Concurrency — structured tasks**: `IntrinsicTaskGroup`,
+  `IntrinsicSpawn` (detached: `[closure]`; scoped: `[group, closure]`),
+  `IntrinsicHandleJoin`, `IntrinsicGroupCancel`,
+  `IntrinsicGroupIsCancelled`.
+- **Concurrency — helpers**: `IntrinsicParallel`, `IntrinsicRace`,
+  `IntrinsicCollectAll`, `IntrinsicSelect`.
+- **Concurrency — cancellation**: `IntrinsicIsCancelled`,
+  `IntrinsicCheckCancelled`, `IntrinsicYield`, `IntrinsicSleep`.
+
+Intrinsics whose runtime ABI is "fire and forget" (`chan_send`,
+`chan_close`, `group_cancel`, `yield`) always carry a nil `Dest` —
+the lowerer drops the destination even when the call site was
+written in expression position.
 
 `StorageLive` / `StorageDead` mark the live range of a local. Backends
 that do not care may ignore them; they exist so that future lifetime
@@ -357,10 +377,28 @@ assigned into.
 - `UnaryExpr`, `BinaryExpr`: recursive lowering, result in a
   `UnaryRV` / `BinaryRV` assigned into a fresh temp.
 - `CallExpr`: map keyword args to positional per the callee's
-  signature; fill defaults; emit `CallInstr`.
+  signature; fill defaults; emit `CallInstr`. Two pre-dispatch
+  fast-paths run first: (a) bare `Ident` callees matching a prelude-
+  visible concurrency name (`taskGroup`, `parallel`, `race`,
+  `collectAll`) emit an `IntrinsicInstr`; (b) `FieldExpr` callees
+  whose `X` names a `use` alias matching a `thread`-namespaced
+  concurrency name (`thread.spawn`, `thread.chan`, `thread.select`,
+  …) do the same.
 - `IntrinsicCall`: `IntrinsicInstr`.
-- `MethodCall`: resolved to a direct function whose first parameter is
-  the receiver; emitted as `CallInstr`.
+- `MethodCall`: first checks for an aliased qualifier (Stage 2a) and
+  a runtime-type concurrency method (Stage 2b — `Channel.recv`,
+  `Channel.close`, `Channel.isClosed`, `Handle.join`, `Group.spawn`,
+  `Group.cancel`, `Group.isCancelled`). Concurrency matches emit an
+  `IntrinsicInstr` with the receiver as the first operand. Otherwise
+  resolves to a direct function whose first parameter is the
+  receiver and emits a `CallInstr`.
+- `ChanSendStmt`: `IntrinsicChanSend{[channel, value]}` with `Dest`
+  always nil.
+- `for x in ch` (channel iterable): receive-loop header → body →
+  step cycle. The header calls `IntrinsicChanRecv` into an
+  `Option<T>` local, reads its discriminant, and dispatches via
+  `SwitchInt` — `Some` unwraps the payload into the loop binding and
+  runs the body; `None` exits the loop.
 - `VariantLit`: `AggregateRV{Kind: EnumVariant}`.
 - `StructLit`: `AggregateRV{Kind: Struct}`. Spread (`..rest`) lowers to
   per-field copies from the spread expression plus per-explicit
@@ -485,10 +523,40 @@ MIR tests isolated from front-end churn.
     (first-class fn-typed fields) fall back to an `IndirectCall`
     through the projected field value.
 
-- **Stage 2b.** Concurrency primitives — `spawn`, channel send / recv,
-  `taskGroup`, `thread.select`, runtime cancel. These are the largest
-  remaining HIR-only shapes; they ship after the runtime ABI is
-  settled so the lowering can target a stable set of intrinsics.
+- **Stage 2b (landed).** Concurrency primitives — `spawn`, channel
+  send / recv / make / close / isClosed, `taskGroup`, `g.spawn`,
+  `h.join`, `thread.select`, `parallel`, `race`, `collectAll`,
+  `thread.isCancelled` / `checkCancelled` / `yield` / `sleep`, and
+  `for x in ch` loops — lower to MIR `IntrinsicInstr`s. Design notes:
+
+  - The MIR intrinsic name is the stable ABI contract. Backends map
+    each kind to whatever runtime symbol their target exposes; the
+    runtime itself is not contract-frozen yet, so we deliberately
+    keep the vocabulary at the semantic layer rather than baking in a
+    specific C ABI.
+  - Channel / Handle / Group / Select method calls (`ch.recv()`,
+    `h.join()`, `g.spawn(f)`, …) are recognised by **receiver type
+    name** (`Channel`, `Handle`, `Group`, `TaskGroup`) and route to
+    the matching intrinsic with the receiver as the first operand,
+    followed by user args in source order. This runs after the
+    Stage 2a use-alias / package-qualifier check, so an aliased
+    `thread.spawn(f)` is spotted as a concurrency call *before* it
+    falls through to the ordinary qualified-call emitter.
+  - Prelude-visible calls (`taskGroup`, `parallel`, `race`,
+    `collectAll`) are recognised from the bare `Ident` callee. No
+    `use` is required for them; they match only when the qualifier
+    is empty.
+  - `ChanSendStmt` (the only dedicated HIR concurrency node) lowers
+    directly to `IntrinsicChanSend` with `[channel, value]` operands.
+  - `for x in channel` compiles to a receive loop: a header block
+    that calls `IntrinsicChanRecv`, loads the result's discriminant,
+    and dispatches `Some` → body / `None` → exit via a `SwitchInt`.
+    The body unwraps the payload into a named local (or destructures
+    via the loop pattern) before running the user statements.
+  - `IntrinsicInstr.Dest` is nil for the no-value kinds (`chan_send`,
+    `chan_close`, `group_cancel`, `yield`). The lowerer drops the
+    destination for those even when the call site was written in
+    expression position.
 
 - **Stage 2c.** Inner-block defer scoping, closure-to-SSA captures
   (upgrade `AggClosure` when borrow rules land), and the stdlib

--- a/internal/mir/dump_example_test.go
+++ b/internal/mir/dump_example_test.go
@@ -88,3 +88,60 @@ func TestMIRDumpClosure(t *testing.T) {
 	}
 	t.Logf("MIR:\n%s", Print(out))
 }
+
+// TestMIRDumpConcurrency prints MIR for a program exercising the
+// Stage 2b concurrency intrinsics: thread.chan, chan_send, chan_close,
+// and for-in over a channel.
+func TestMIRDumpConcurrency(t *testing.T) {
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	use := &ir.UseDecl{
+		Path: []string{"std", "thread"}, RawPath: "std.thread", Alias: "thread",
+	}
+	fn := &ir.FnDecl{
+		Name:   "pump",
+		Return: ir.TUnit,
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "ch",
+					Type: chanInt,
+					Value: &ir.MethodCall{
+						Receiver: &ir.Ident{Name: "thread"},
+						Name:     "chan",
+						TypeArgs: []ir.Type{ir.TInt},
+						Args:     []ir.Arg{{Value: &ir.IntLit{Text: "4", T: ir.TInt}}},
+						T:        chanInt,
+					},
+				},
+				&ir.ChanSendStmt{
+					Channel: &ir.Ident{Name: "ch", Kind: ir.IdentLocal, T: chanInt},
+					Value:   &ir.IntLit{Text: "42", T: ir.TInt},
+				},
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "ch", Kind: ir.IdentLocal, T: chanInt},
+					Name:     "close",
+					T:        ir.TUnit,
+				}},
+				&ir.ForStmt{
+					Kind: ir.ForIn,
+					Var:  "x",
+					Iter: &ir.Ident{Name: "ch", Kind: ir.IdentLocal, T: chanInt},
+					Body: &ir.Block{
+						Stmts: []ir.Stmt{
+							&ir.ExprStmt{X: &ir.IntrinsicCall{
+								Kind: ir.IntrinsicPrintln,
+								Args: []ir.Arg{{Value: &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt}}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{use, fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v", errs)
+	}
+	t.Logf("MIR:\n%s", Print(out))
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -513,7 +513,14 @@ func (bs *bodyState) lowerStmt(s ir.Stmt) {
 			bs.deferStack = append(bs.deferStack, x.Body)
 		}
 	case *ir.ChanSendStmt:
-		bs.l.noteIssue("channel send not lowered to MIR (stage 2 work)")
+		ch := bs.lowerExprAsOperand(x.Channel)
+		val := bs.lowerExprAsOperand(x.Value)
+		bs.emit(&IntrinsicInstr{
+			Dest:  nil,
+			Kind:  IntrinsicChanSend,
+			Args:  []Operand{ch, val},
+			SpanV: x.SpanV,
+		})
 	case *ir.ErrorStmt:
 		bs.l.noteIssue("error stmt reached MIR: %s", x.Note)
 	default:
@@ -978,8 +985,12 @@ func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
 
 func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 	iterT := f.Iter.Type()
+	if isChannelType(iterT) {
+		bs.lowerForInChannel(f, iterT)
+		return
+	}
 	if !isListType(iterT) {
-		bs.l.noteIssue("for-in over non-List iterable is not lowered to MIR yet")
+		bs.l.noteIssue("for-in over non-List/Channel iterable is not lowered to MIR yet")
 		return
 	}
 	elemT := listElementType(iterT)
@@ -1062,6 +1073,79 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		},
 		SpanV: f.SpanV,
 	})
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.cur = exit
+}
+
+// lowerForInChannel lowers `for x in channel { body }`. Each iteration
+// reads a value via IntrinsicChanRecv (which returns Option<T>) and
+// exits when the receive yields None — matching the spec's
+// "`for x in ch` terminates when the channel is closed and drained,
+// or when the surrounding task is cancelled" semantics.
+func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
+	elemT := channelElementType(iterT)
+	optT := &ir.OptionalType{Inner: elemT}
+	iter := bs.fn.NewLocal("_chan", iterT, false, f.SpanV)
+	bs.emit(&StorageLiveInstr{Local: iter, SpanV: f.SpanV})
+	bs.lowerExprInto(f.Iter, iter, iterT)
+
+	header := bs.newBlock(f.SpanV)
+	body := bs.newBlock(f.SpanV)
+	step := bs.newBlock(f.SpanV)
+	exit := bs.newBlock(f.SpanV)
+	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
+
+	bs.cur = header
+	// opt := chan_recv(iter); switch opt { Some => body, None => exit }
+	opt := bs.fn.NewLocal("_recv", optT, false, f.SpanV)
+	bs.emit(&IntrinsicInstr{
+		Dest:  &Place{Local: opt},
+		Kind:  IntrinsicChanRecv,
+		Args:  []Operand{&CopyOp{Place: Place{Local: iter}, T: iterT}},
+		SpanV: f.SpanV,
+	})
+	disc := bs.freshTemp(TInt, f.SpanV)
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: disc},
+		Src:   &DiscriminantRV{Place: Place{Local: opt}, T: TInt},
+		SpanV: f.SpanV,
+	})
+	bs.terminate(&SwitchIntTerm{
+		Scrutinee: &CopyOp{Place: Place{Local: disc}, T: TInt},
+		Cases:     []SwitchCase{{Value: someTagOf(optT), Target: body, Label: "Some"}},
+		Default:   exit,
+		SpanV:     f.SpanV,
+	})
+
+	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: step})
+	bs.cur = body
+	bs.pushScope()
+	// Unwrap the payload into a named local.
+	elemLocal := bs.fn.NewLocal("_elem", elemT, false, f.SpanV)
+	payloadProj := &VariantProj{
+		Variant:  int(someTagOf(optT)),
+		Name:     "Some",
+		FieldIdx: 0,
+		Type:     elemT,
+	}
+	bs.emit(&AssignInstr{
+		Dest:  Place{Local: elemLocal},
+		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: opt}.Project(payloadProj), T: elemT}},
+		SpanV: f.SpanV,
+	})
+	if f.Pattern != nil {
+		bs.bindPattern(f.Pattern, Place{Local: elemLocal}, elemT, f.SpanV)
+	} else if f.Var != "" {
+		bs.bind(f.Var, elemLocal)
+	}
+	for _, s := range f.Body.Stmts {
+		bs.lowerStmt(s)
+	}
+	bs.popScope()
+	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
+
+	bs.cur = step
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
 	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
 	bs.cur = exit
@@ -2107,6 +2191,29 @@ func (bs *bodyState) lowerOptionalFieldInto(fe *ir.FieldExpr, dest Place, destT 
 // ==== calls ====
 
 func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) {
+	// Concurrency-intrinsic fast path:
+	//
+	//   - Bare Ident callee: `taskGroup(...)`, `parallel(...)`,
+	//     `race(...)`, `collectAll(...)`. These reach prelude-visible
+	//     names so `qualifier == ""`.
+	//   - FieldExpr callee whose X names a use alias for a concurrency
+	//     module: `thread.spawn(f)`, `std.thread.chan::<Int>(0)`. The
+	//     qualifier is the use decl's raw path or alias; we lookup
+	//     the intrinsic and emit it directly.
+	if id, ok := c.Callee.(*ir.Ident); ok {
+		if kind := concurrencyIntrinsicForFree("", id.Name); kind != IntrinsicInvalid {
+			bs.emitConcurrencyIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+			return
+		}
+	}
+	if fx, ok := c.Callee.(*ir.FieldExpr); ok {
+		if use := bs.l.useAliasFor(fx.X); use != nil {
+			if kind := concurrencyIntrinsicForFree(qualifierOf(use), fx.Name); kind != IntrinsicInvalid {
+				bs.emitConcurrencyIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+				return
+			}
+		}
+	}
 	args, callee := bs.resolveCall(c)
 	if callee == nil {
 		bs.l.noteIssue("unsupported call: callee %T", c.Callee)
@@ -2116,6 +2223,37 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 		dest = nil
 	}
 	bs.emit(&CallInstr{Dest: dest, Callee: callee, Args: args, SpanV: c.SpanV})
+}
+
+// emitConcurrencyIntrinsic lowers args in source order and emits a
+// single IntrinsicInstr with the given kind. The destination is
+// discarded (set to nil) for kinds whose runtime ABI returns no value
+// (send, close, cancel, yield).
+func (bs *bodyState) emitConcurrencyIntrinsic(kind IntrinsicKind, args []ir.Arg, dest *Place, destT Type, sp Span) {
+	out := make([]Operand, len(args))
+	for i, a := range args {
+		out[i] = bs.lowerExprAsOperand(a.Value)
+	}
+	destPtr := dest
+	if destPtr != nil && isUnit(destT) {
+		destPtr = nil
+	}
+	if isVoidConcurrencyIntrinsic(kind) {
+		destPtr = nil
+	}
+	bs.emit(&IntrinsicInstr{Dest: destPtr, Kind: kind, Args: out, SpanV: sp})
+}
+
+// isVoidConcurrencyIntrinsic reports whether an intrinsic produces no
+// MIR-visible value (send, close, cancel, yield, sleep). Used so that
+// `ch.close()` in expression position doesn't carry a stale dest.
+func isVoidConcurrencyIntrinsic(kind IntrinsicKind) bool {
+	switch kind {
+	case IntrinsicChanSend, IntrinsicChanClose,
+		IntrinsicGroupCancel, IntrinsicYield:
+		return true
+	}
+	return false
 }
 
 // resolveCall figures out the callee and reorders keyword args.
@@ -2272,9 +2410,14 @@ func (bs *bodyState) orderArgs(args []ir.Arg, sig *fnSignature) []Operand {
 func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Type) {
 	// Package/FFI-qualified calls land here when HIR lowered `pkg.fn()`
 	// into MethodCall{Receiver: Ident(pkg), Name: fn}. The receiver is
-	// a use alias, not a value — emit a direct qualified call with no
-	// synthetic `self` argument.
+	// a use alias, not a value — fast-path to a concurrency intrinsic
+	// when the qualifier targets `thread`, or emit a direct qualified
+	// call with no synthetic `self` argument otherwise.
 	if use := bs.l.useAliasFor(mc.Receiver); use != nil {
+		if kind := concurrencyIntrinsicForFree(qualifierOf(use), mc.Name); kind != IntrinsicInvalid {
+			bs.emitConcurrencyIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+			return
+		}
 		args := make([]Operand, len(mc.Args))
 		for i, a := range mc.Args {
 			args[i] = bs.lowerExprAsOperand(a.Value)
@@ -2288,6 +2431,33 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 			Callee: &FnRef{Symbol: qualifiedSymbol(use, mc.Name), Type: mc.T},
 			Args:   args,
 			SpanV:  mc.SpanV,
+		})
+		return
+	}
+
+	// Concurrency-intrinsic fast path for method syntax on runtime-
+	// owned concurrency types: `ch.recv()`, `ch.close()`, `h.join()`,
+	// `g.spawn(f)`, `g.cancel()`, `g.isCancelled()`. The receiver
+	// becomes the first intrinsic arg; user args follow in source
+	// order.
+	if kind := concurrencyIntrinsicForMethod(mc.Receiver.Type(), mc.Name); kind != IntrinsicInvalid {
+		recv := bs.lowerExprAsOperand(mc.Receiver)
+		args := []Operand{recv}
+		for _, a := range mc.Args {
+			args = append(args, bs.lowerExprAsOperand(a.Value))
+		}
+		destPtr := &dest
+		if isUnit(destT) {
+			destPtr = nil
+		}
+		if isVoidConcurrencyIntrinsic(kind) {
+			destPtr = nil
+		}
+		bs.emit(&IntrinsicInstr{
+			Dest:  destPtr,
+			Kind:  kind,
+			Args:  args,
+			SpanV: mc.SpanV,
 		})
 		return
 	}
@@ -2429,6 +2599,118 @@ func (bs *bodyState) lowerVariantLit(v *ir.VariantLit, hint Type) RValue {
 		VariantIdx: idx,
 		VariantTag: v.Variant,
 	}
+}
+
+// ==== concurrency intrinsic recognition ====
+
+// concurrencyIntrinsicForFree maps a prelude / `thread`-namespaced
+// top-level function name to its MIR intrinsic kind. Returns
+// IntrinsicInvalid when the name is not a known concurrency primitive.
+//
+// The lowerer calls this for `Ident{Kind: IdentFn}` callees and for
+// package-qualified callees whose use decl targets `std.thread` —
+// the function call paths normalise both sources into the bare name
+// here. `qualifier` is the `use`-level prefix (e.g. "std.thread",
+// "thread") when the call was qualified, or "" for prelude-visible
+// names like `taskGroup`.
+func concurrencyIntrinsicForFree(qualifier, name string) IntrinsicKind {
+	threadNs := qualifier == "thread" || qualifier == "std.thread"
+	preludeOnly := qualifier == ""
+	switch name {
+	case "taskGroup":
+		if preludeOnly {
+			return IntrinsicTaskGroup
+		}
+	case "parallel":
+		if preludeOnly {
+			return IntrinsicParallel
+		}
+	case "race":
+		if preludeOnly || threadNs {
+			return IntrinsicRace
+		}
+	case "collectAll":
+		if preludeOnly || threadNs {
+			return IntrinsicCollectAll
+		}
+	case "spawn":
+		if threadNs {
+			return IntrinsicSpawn
+		}
+	case "chan":
+		if threadNs {
+			return IntrinsicChanMake
+		}
+	case "select":
+		if threadNs {
+			return IntrinsicSelect
+		}
+	case "isCancelled":
+		if threadNs {
+			return IntrinsicIsCancelled
+		}
+	case "checkCancelled":
+		if threadNs {
+			return IntrinsicCheckCancelled
+		}
+	case "yield":
+		if threadNs {
+			return IntrinsicYield
+		}
+	case "sleep":
+		if threadNs {
+			return IntrinsicSleep
+		}
+	}
+	return IntrinsicInvalid
+}
+
+// concurrencyIntrinsicForMethod maps a (receiverType, methodName)
+// pair to its MIR intrinsic kind. Used for method calls like
+// `ch.recv()`, `g.spawn(f)`, `h.join()`. Returns IntrinsicInvalid
+// when not a concurrency method.
+func concurrencyIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
+	recv := typeNameOf(receiverType)
+	switch recv {
+	case "Channel":
+		switch name {
+		case "recv":
+			return IntrinsicChanRecv
+		case "close":
+			return IntrinsicChanClose
+		case "isClosed":
+			return IntrinsicChanIsClosed
+		}
+	case "Handle":
+		if name == "join" {
+			return IntrinsicHandleJoin
+		}
+	case "Group", "TaskGroup":
+		switch name {
+		case "spawn":
+			return IntrinsicSpawn
+		case "cancel":
+			return IntrinsicGroupCancel
+		case "isCancelled":
+			return IntrinsicGroupIsCancelled
+		}
+	}
+	return IntrinsicInvalid
+}
+
+// qualifierOf extracts the package qualifier from a Use decl, or ""
+// when no use is associated. Used for concurrency-intrinsic lookup.
+func qualifierOf(use *ir.UseDecl) string {
+	if use == nil {
+		return ""
+	}
+	if use.RawPath != "" {
+		return use.RawPath
+	}
+	if use.Alias != "" {
+		return use.Alias
+	}
+	return ""
 }
 
 // ==== closures ====
@@ -2911,6 +3193,25 @@ func isListType(t ir.Type) bool {
 		return nt.Name == "List" && nt.Builtin
 	}
 	return false
+}
+
+// isChannelType reports whether t is a `Channel<T>`. The stdlib
+// declares Channel as a named type rather than a primitive, so we
+// accept both Builtin=false and Builtin=true to match HIR's view.
+func isChannelType(t ir.Type) bool {
+	if nt, ok := t.(*ir.NamedType); ok {
+		return nt.Name == "Channel"
+	}
+	return false
+}
+
+// channelElementType returns the T of a `Channel<T>`, or ErrType
+// when t isn't a channel.
+func channelElementType(t ir.Type) Type {
+	if nt, ok := t.(*ir.NamedType); ok && len(nt.Args) >= 1 {
+		return nt.Args[0]
+	}
+	return ir.ErrTypeVal
 }
 
 // isScalarPayload reports whether a type is a primitive/scalar shape

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -276,6 +276,16 @@ func (i *IntrinsicInstr) At() Span { return i.SpanV }
 // IntrinsicKind enumerates the MIR-visible intrinsics. The values
 // match ir.IntrinsicKind for the print family so that the lowerer can
 // pass them through unchanged.
+//
+// Intrinsics split into broad families:
+//
+//   - print family: formatted output to stdout/stderr.
+//   - string / runtime builders: helpers the lowerer cannot inline.
+//   - concurrency: the runtime ABI for `taskGroup`, channels, spawn,
+//     handles, select, cancellation. Stage 2b introduces these. The
+//     runtime itself is not contract-frozen yet; backends read the
+//     intrinsic name and route to whatever symbol their runtime
+//     exposes.
 type IntrinsicKind int
 
 const (
@@ -286,6 +296,71 @@ const (
 	IntrinsicEprintln               // stderr, newline
 	IntrinsicAbort                  // unreachable runtime trap
 	IntrinsicStringConcat
+
+	// ---- concurrency: channels ----
+
+	// IntrinsicChanMake constructs a new Channel<T>. Args: [capacity
+	// Int]. Dest receives the new channel value; the element type is
+	// read from the destination local's type.
+	IntrinsicChanMake
+	// IntrinsicChanSend sends a value on a channel. Args: [channel,
+	// value]. Dest is nil (the statement has no value).
+	IntrinsicChanSend
+	// IntrinsicChanRecv receives a value from a channel. Args:
+	// [channel]. Dest receives Option<T> — None signals the channel
+	// is drained and closed, or a cancellation was observed.
+	IntrinsicChanRecv
+	// IntrinsicChanClose closes a channel. Args: [channel]. Dest nil.
+	IntrinsicChanClose
+	// IntrinsicChanIsClosed returns Bool. Args: [channel].
+	IntrinsicChanIsClosed
+
+	// ---- concurrency: structured tasks ----
+
+	// IntrinsicTaskGroup wraps a `taskGroup(|g| body)` call. Args:
+	// [closure]. Dest receives the closure's return value.
+	IntrinsicTaskGroup
+	// IntrinsicSpawn launches a task. Args: [closure] (detached) or
+	// [group, closure] (`g.spawn`). Dest receives a Handle<T>.
+	IntrinsicSpawn
+	// IntrinsicHandleJoin joins on a handle. Args: [handle]. Dest is
+	// the handle's T value.
+	IntrinsicHandleJoin
+	// IntrinsicGroupCancel cancels a group. Args: [group]. Dest nil.
+	IntrinsicGroupCancel
+	// IntrinsicGroupIsCancelled reports whether a group is cancelled.
+	// Args: [group]. Dest is Bool.
+	IntrinsicGroupIsCancelled
+
+	// ---- concurrency: high-level helpers ----
+
+	// IntrinsicParallel runs `parallel(items, concurrency, f)`. Args:
+	// [items, concurrency, f]. Dest is List<Result<R, Error>>.
+	IntrinsicParallel
+	// IntrinsicRace runs `race(body)`. Args: [body]. Dest is
+	// Result<T, Error>.
+	IntrinsicRace
+	// IntrinsicCollectAll runs `collectAll(body)`. Args: [body]. Dest
+	// is List<Result<T, Error>>.
+	IntrinsicCollectAll
+
+	// ---- concurrency: select ----
+
+	// IntrinsicSelect runs `thread.select(|s| body)`. Args: [body].
+	// Dest is unit; individual arms (recv/send/timeout/default) run
+	// their closures through the select runtime.
+	IntrinsicSelect
+
+	// ---- concurrency: cancellation ----
+
+	// IntrinsicIsCancelled returns Bool. Args: [].
+	IntrinsicIsCancelled
+	// IntrinsicCheckCancelled returns Result<(), Error>. Args: [].
+	IntrinsicCheckCancelled
+	// IntrinsicYield yields the current task. Args: [].
+	IntrinsicYield
+	// IntrinsicSleep sleeps for a Duration. Args: [duration].
+	IntrinsicSleep
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -1166,3 +1166,348 @@ func TestLowerIfLetOption(t *testing.T) {
 		t.Fatalf("expected switchInt for if-let, got:\n%s", text)
 	}
 }
+
+// ==== Stage 2b: concurrency ====
+
+// threadUse builds a `use std.thread as thread` decl; most
+// concurrency tests start with it so the alias is registered in the
+// lowerer's useAliases index.
+func threadUse() *ir.UseDecl {
+	return &ir.UseDecl{
+		Path:    []string{"std", "thread"},
+		RawPath: "std.thread",
+		Alias:   "thread",
+	}
+}
+
+func TestLowerChanSendStmt(t *testing.T) {
+	// fn push(ch: Channel<Int>, value: Int) { ch <- value }
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "push",
+		Return: ir.TUnit,
+		Params: []*ir.Param{
+			{Name: "ch", Type: chanInt},
+			{Name: "value", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ChanSendStmt{
+					Channel: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt},
+					Value:   &ir.Ident{Name: "value", Kind: ir.IdentParam, T: ir.TInt},
+				},
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic chan_send(_1, _2)") {
+		t.Fatalf("expected chan_send intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerChannelRecvMethod(t *testing.T) {
+	// fn pop(ch: Channel<Int>) -> Int? { ch.recv() }
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	optInt := &ir.OptionalType{Inner: ir.TInt}
+	fn := &ir.FnDecl{
+		Name:   "pop",
+		Return: optInt,
+		Params: []*ir.Param{{Name: "ch", Type: chanInt}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt},
+				Name:     "recv",
+				T:        optInt,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic chan_recv(_1)") {
+		t.Fatalf("expected chan_recv intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerChannelCloseMethod(t *testing.T) {
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "shut",
+		Return: ir.TUnit,
+		Params: []*ir.Param{{Name: "ch", Type: chanInt}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt},
+					Name:     "close",
+					T:        ir.TUnit,
+				}},
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic chan_close(_1)") {
+		t.Fatalf("expected chan_close intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerThreadChanMake(t *testing.T) {
+	// use std.thread as thread
+	// fn make() -> Channel<Int> { thread.chan::<Int>(10) }
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "make",
+		Return: chanInt,
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "thread"},
+				Name:     "chan",
+				TypeArgs: []ir.Type{ir.TInt},
+				Args: []ir.Arg{
+					{Value: &ir.IntLit{Text: "10", T: ir.TInt}},
+				},
+				T: chanInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{threadUse(), fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "intrinsic chan_make(const 10 Int)") {
+		t.Fatalf("expected chan_make intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerThreadSpawn(t *testing.T) {
+	// use std.thread as thread
+	// fn run(f: fn() -> Int) { thread.spawn(f) }
+	fnType := &ir.FnType{Return: ir.TInt}
+	handleT := &ir.NamedType{Name: "Handle", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "run",
+		Return: ir.TUnit,
+		Params: []*ir.Param{{Name: "f", Type: fnType}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "thread"},
+					Name:     "spawn",
+					Args:     []ir.Arg{{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: fnType}}},
+					T:        handleT,
+				}},
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{threadUse(), fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "intrinsic spawn(_1)") {
+		t.Fatalf("expected spawn intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerGroupSpawnMethod(t *testing.T) {
+	// Group.spawn() call — the receiver is a Group value, method
+	// "spawn". Expect IntrinsicSpawn with [group, closure].
+	groupT := &ir.NamedType{Name: "Group"}
+	fnType := &ir.FnType{Return: ir.TInt}
+	handleT := &ir.NamedType{Name: "Handle", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "launch",
+		Return: ir.TUnit,
+		Params: []*ir.Param{
+			{Name: "g", Type: groupT},
+			{Name: "f", Type: fnType},
+		},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "g", Kind: ir.IdentParam, T: groupT},
+					Name:     "spawn",
+					Args:     []ir.Arg{{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: fnType}}},
+					T:        handleT,
+				}},
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic spawn(_1, _2)") {
+		t.Fatalf("expected spawn intrinsic with [group, closure], got:\n%s", text)
+	}
+}
+
+func TestLowerHandleJoin(t *testing.T) {
+	// fn wait(h: Handle<Int>) -> Int { h.join() }
+	handleT := &ir.NamedType{Name: "Handle", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "wait",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "h", Type: handleT}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "h", Kind: ir.IdentParam, T: handleT},
+				Name:     "join",
+				T:        ir.TInt,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic handle_join(_1)") {
+		t.Fatalf("expected handle_join intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerPreludeTaskGroup(t *testing.T) {
+	// fn run(f: fn(Group) -> Int) -> Int { taskGroup(f) }
+	groupT := &ir.NamedType{Name: "Group"}
+	closureT := &ir.FnType{Params: []ir.Type{groupT}, Return: ir.TInt}
+	fn := &ir.FnDecl{
+		Name:   "run",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "f", Type: closureT}},
+		Body: &ir.Block{
+			Result: &ir.CallExpr{
+				Callee: &ir.Ident{Name: "taskGroup", Kind: ir.IdentFn},
+				Args:   []ir.Arg{{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: closureT}}},
+				T:      ir.TInt,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic task_group(_1)") {
+		t.Fatalf("expected task_group intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerPreludeParallel(t *testing.T) {
+	// parallel(items, 4, f) — intrinsic with 3 args, positional.
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fnType := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}
+	fn := &ir.FnDecl{
+		Name:   "compute",
+		Return: listInt,
+		Params: []*ir.Param{
+			{Name: "items", Type: listInt},
+			{Name: "f", Type: fnType},
+		},
+		Body: &ir.Block{
+			Result: &ir.CallExpr{
+				Callee: &ir.Ident{Name: "parallel", Kind: ir.IdentFn},
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "items", Kind: ir.IdentParam, T: listInt}},
+					{Value: &ir.IntLit{Text: "4", T: ir.TInt}},
+					{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: fnType}},
+				},
+				T: listInt,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic parallel(_1, const 4 Int, _2)") {
+		t.Fatalf("expected parallel intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerThreadCancellationHelpers(t *testing.T) {
+	// fn check() -> Bool { thread.isCancelled() }
+	fn := &ir.FnDecl{
+		Name:   "check",
+		Return: ir.TBool,
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "thread"},
+				Name:     "isCancelled",
+				T:        ir.TBool,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{threadUse(), fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if !strings.Contains(text, "intrinsic is_cancelled()") {
+		t.Fatalf("expected is_cancelled intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerForInChannel(t *testing.T) {
+	// use std.thread
+	// fn drain(ch: Channel<Int>) { for x in ch { println(x) } }
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "drain",
+		Return: ir.TUnit,
+		Params: []*ir.Param{{Name: "ch", Type: chanInt}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ForStmt{
+					Kind: ir.ForIn,
+					Var:  "x",
+					Iter: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt},
+					Body: &ir.Block{
+						Stmts: []ir.Stmt{
+							&ir.ExprStmt{X: &ir.IntrinsicCall{
+								Kind: ir.IntrinsicPrintln,
+								Args: []ir.Arg{{Value: &ir.Ident{Name: "x", Kind: ir.IdentLocal, T: ir.TInt}}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic chan_recv(") {
+		t.Fatalf("expected chan_recv intrinsic in for-in, got:\n%s", text)
+	}
+	if !strings.Contains(text, "switchInt ") {
+		t.Fatalf("expected switchInt (Some vs None) for recv loop, got:\n%s", text)
+	}
+}
+
+// Regression: package-qualified `thread.chan` must go to the intrinsic
+// path, NOT to the plain qualified-call path that Stage 2a shipped.
+// Without the Stage 2b intrinsic fast-path, it would lower as
+// `call std.thread.chan(const 10 Int)` — useless to the backend.
+func TestLowerThreadChanIsIntrinsicNotCall(t *testing.T) {
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "make",
+		Return: chanInt,
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "thread"},
+				Name:     "chan",
+				TypeArgs: []ir.Type{ir.TInt},
+				Args:     []ir.Arg{{Value: &ir.IntLit{Text: "10", T: ir.TInt}}},
+				T:        chanInt,
+			},
+		},
+	}
+	mod := &ir.Module{Package: "main", Decls: []ir.Decl{threadUse(), fn}}
+	out := Lower(mod)
+	if errs := Validate(out); len(errs) > 0 {
+		t.Fatalf("validate: %v\n\n%s", errs, Print(out))
+	}
+	text := Print(out)
+	if strings.Contains(text, "call std.thread.chan") || strings.Contains(text, "call thread.chan") {
+		t.Fatalf("thread.chan must lower as an intrinsic, not a qualified call:\n%s", text)
+	}
+	if !strings.Contains(text, "intrinsic chan_make") {
+		t.Fatalf("expected chan_make intrinsic, got:\n%s", text)
+	}
+}

--- a/internal/mir/print.go
+++ b/internal/mir/print.go
@@ -432,6 +432,42 @@ func intrinsicName(k IntrinsicKind) string {
 		return "abort"
 	case IntrinsicStringConcat:
 		return "string_concat"
+	case IntrinsicChanMake:
+		return "chan_make"
+	case IntrinsicChanSend:
+		return "chan_send"
+	case IntrinsicChanRecv:
+		return "chan_recv"
+	case IntrinsicChanClose:
+		return "chan_close"
+	case IntrinsicChanIsClosed:
+		return "chan_is_closed"
+	case IntrinsicTaskGroup:
+		return "task_group"
+	case IntrinsicSpawn:
+		return "spawn"
+	case IntrinsicHandleJoin:
+		return "handle_join"
+	case IntrinsicGroupCancel:
+		return "group_cancel"
+	case IntrinsicGroupIsCancelled:
+		return "group_is_cancelled"
+	case IntrinsicParallel:
+		return "parallel"
+	case IntrinsicRace:
+		return "race"
+	case IntrinsicCollectAll:
+		return "collect_all"
+	case IntrinsicSelect:
+		return "select"
+	case IntrinsicIsCancelled:
+		return "is_cancelled"
+	case IntrinsicCheckCancelled:
+		return "check_cancelled"
+	case IntrinsicYield:
+		return "yield"
+	case IntrinsicSleep:
+		return "sleep"
 	}
 	return "invalid"
 }


### PR DESCRIPTION
Stacked on #237 (Stage 2a). Base is `claude/mir-stage2a`; retarget up the stack as Stage 1 / 2a land on main.

## Summary

Lowers Osty's concurrency surface (`taskGroup`, channels, spawn, handles, select, cancellation helpers) to MIR `IntrinsicInstr` shapes. The intrinsic `Kind` is the stable ABI contract — backends map each kind to whatever symbol their runtime exposes, so the runtime itself is not contract-frozen yet.

### New intrinsic kinds

| Family | Kinds |
|---|---|
| Channels | `ChanMake`, `ChanSend`, `ChanRecv`, `ChanClose`, `ChanIsClosed` |
| Structured tasks | `TaskGroup`, `Spawn` (detached `[closure]` or scoped `[group, closure]`), `HandleJoin`, `GroupCancel`, `GroupIsCancelled` |
| Helpers | `Parallel`, `Race`, `CollectAll` |
| Select | `Select` |
| Cancellation | `IsCancelled`, `CheckCancelled`, `Yield`, `Sleep` |

### Call-site recognition

Three recognisers collaborate:

- **`lowerCallExprInto`** — bare `Ident` callees matching prelude-visible names (`taskGroup`, `parallel`, `race`, `collectAll`) emit `IntrinsicInstr` before `resolveCall` runs. `FieldExpr` callees whose `X` names a `use` alias matching a `thread`-namespaced call (`thread.spawn`, `thread.chan`, …) do the same.
- **`lowerMethodCallInto`** — method syntax on runtime-owned types routes to intrinsics by receiver-type name: `Channel.recv`/`close`/`isClosed`, `Handle.join`, `Group.spawn`/`cancel`/`isCancelled`. The receiver becomes the first operand; user args follow in source order. The Stage 2a use-alias check still runs first so `thread.spawn(f)` written as a `MethodCall` reaches the concurrency fast path, not the qualified-call emitter.
- **`lowerStmt`** — the only dedicated HIR concurrency node, `ChanSendStmt`, lowers to `IntrinsicChanSend{[channel, value]}`.

### Loop lowering

`for x in ch` (when `ch` has type `Channel<T>`) now compiles to a receive loop: the header calls `IntrinsicChanRecv` into an `Option<T>` local, reads the discriminant, and dispatches via a `SwitchInt` — `Some` unwraps the payload into the loop binding and runs the body, `None` exits the loop. This matches the spec's \"terminates when the channel is closed and drained, or when the surrounding task is cancelled\" semantics.

### Destination semantics

Intrinsics whose runtime ABI is fire-and-forget (`chan_send`, `chan_close`, `group_cancel`, `yield`) always carry a nil `Dest`. The lowerer drops the destination even when the call site was written in expression position, so the validator stays happy and backends don't need to special-case stale dests.

## Sample MIR (`TestMIRDumpConcurrency`)

```
fn pump() -> () {
    bb0:
        _1 = intrinsic chan_make(const 4 Int)
        intrinsic chan_send(_1, const 42 Int)
        intrinsic chan_close(_1)
        _3 = use _1
        goto -> bb1
    bb1:
        _4 = intrinsic chan_recv(_3)
        _5 = discriminant _4
        switchInt _5 -> [Some => bb2, _ => bb4]
    bb2:
        _6 = use _4@Some.0
        _7 = intrinsic println(_6)
        goto -> bb3
    bb3:
        goto -> bb1
    bb4:
        _0 = use const ()
        return
}
```

## Tests

- `TestLowerChanSendStmt`, `TestLowerChannelRecvMethod`, `TestLowerChannelCloseMethod`
- `TestLowerThreadChanMake`, `TestLowerThreadSpawn`, `TestLowerThreadCancellationHelpers`
- `TestLowerGroupSpawnMethod`, `TestLowerHandleJoin`
- `TestLowerPreludeTaskGroup`, `TestLowerPreludeParallel`
- `TestLowerForInChannel`
- `TestLowerThreadChanIsIntrinsicNotCall` — regression: ensures aliased `thread.chan` reaches the intrinsic, not the generic qualified-call path introduced in Stage 2a
- `TestMIRDumpConcurrency`

## Test plan

- [x] `go test ./internal/mir`
- [x] `go test ./internal/parser ./internal/ir ./internal/llvmgen ./internal/backend`
- [x] All Stage 1 / 2a tests still pass on this branch

## Out of scope

- The actual runtime ABI for each intrinsic. Backends choose their own symbol naming and parameter packing.
- Inner-block defer scoping and closure borrow rules — Stage 2c.
- Backend rewiring to consume MIR directly — Stage 3+.
- \`thread.select\` body lowering into individual recv/send/timeout arms. Stage 2b emits the closure as a single argument; Stage 2c will expand the DSL into per-arm intrinsics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)