### PR TITLE
feat(mir): stage 2c — inner-block defer scoping and thread.select arm expansion

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -90,7 +90,7 @@ reason about generics.
 | Typed every node                 | yes                 | yes (with layout ids)|
 | Decision-tree pre-compilation    | yes                 | consumed by lowerer  |
 | Closure captures                 | yes (`Closure.Captures`) | lifted to top-level fn + `AggClosure` (Stage 2a) |
-| `defer` bodies                   | yes                 | function-scoped, replayed at every return edge (Stage 2a; inner-block scoping is Stage 2c) |
+| `defer` bodies                   | yes                 | per-block frames, replayed at every exit edge — block fall-through, return, `?`, `break`, `continue` (Stage 2c) |
 | Concurrency primitives           | yes                 | `IntrinsicInstr` set (Stage 2b)                      |
 | Compound & multi-target assign   | yes                 | expanded to `BinaryRV` / tuple destructure (Stage 2a) |
 | Top-level global read            | yes (`IdentGlobal`) | `GlobalRefRV` (Stage 2a)                              |
@@ -204,14 +204,19 @@ runtime symbol their target exposes. Kinds group into families:
   `IntrinsicHandleJoin`, `IntrinsicGroupCancel`,
   `IntrinsicGroupIsCancelled`.
 - **Concurrency — helpers**: `IntrinsicParallel`, `IntrinsicRace`,
-  `IntrinsicCollectAll`, `IntrinsicSelect`.
+  `IntrinsicCollectAll`, `IntrinsicSelect` (the outer `thread.select`
+  call), plus the per-arm intrinsics `IntrinsicSelectRecv`,
+  `IntrinsicSelectSend`, `IntrinsicSelectTimeout`,
+  `IntrinsicSelectDefault` for `s.recv`/`send`/`timeout`/`default`
+  inside the select closure.
 - **Concurrency — cancellation**: `IntrinsicIsCancelled`,
   `IntrinsicCheckCancelled`, `IntrinsicYield`, `IntrinsicSleep`.
 
 Intrinsics whose runtime ABI is "fire and forget" (`chan_send`,
-`chan_close`, `group_cancel`, `yield`) always carry a nil `Dest` —
-the lowerer drops the destination even when the call site was
-written in expression position.
+`chan_close`, `group_cancel`, `yield`, and all four
+`select_recv`/`send`/`timeout`/`default` arm registrations) always
+carry a nil `Dest` — the lowerer drops the destination even when the
+call site was written in expression position.
 
 `StorageLive` / `StorageDead` mark the live range of a local. Backends
 that do not care may ignore them; they exist so that future lifetime
@@ -355,9 +360,15 @@ a new one.
   `DecisionGuard.Cond == nil` chains to the next arm; `DecisionFail`
   becomes `Unreachable` when the original match was proven exhaustive
   and an explicit abort intrinsic otherwise.
-- `DeferStmt` is not lowered in Stage 1. The lowerer records a
-  non-fatal issue; callers that need full coverage fall back to the
-  HIR path.
+- `DeferStmt` registers its body with the innermost defer frame.
+  Frames are pushed/popped around every block-shaped scope. At each
+  control-flow exit the frames are replayed in LIFO:
+  - normal block fall-through replays only the top frame;
+  - `return` / `?` propagation / implicit unit fall-through replays
+    every frame;
+  - `break` and `continue` replay frames down to (inclusive of) the
+    enclosing loop body's frame, since each iteration enters the
+    body scope afresh.
 
 ### Expressions
 
@@ -558,9 +569,44 @@ MIR tests isolated from front-end churn.
     destination for those even when the call site was written in
     expression position.
 
-- **Stage 2c.** Inner-block defer scoping, closure-to-SSA captures
-  (upgrade `AggClosure` when borrow rules land), and the stdlib
-  intrinsic surface.
+- **Stage 2c (landed).** Inner-block defer scoping and the
+  `thread.select` arm expansion. Specifically:
+
+  - `bodyState.deferStack` is replaced by a stack of per-scope defer
+    *frames*. The function-level frame is seeded in `newBodyState`
+    and every block-containing lowerer (`lowerBlockStmt`,
+    `lowerIfStmt`/`lowerIfExprInto`, `lowerForInfinite` / `While` /
+    `Range` / `In` / `InChannel`, match-arm bodies, `if let` arms,
+    `lowerIfLetExprInto`, `lowerBlockExprInto`) pushes/pops its own
+    frame around the statements it emits. The replay rules are:
+    - Normal block fall-through replays the **top** frame before
+      popping.
+    - `return`, `?` propagation, the function's trailing expression,
+      and implicit unit fall-through all replay **every** frame in
+      LIFO.
+    - `break` and `continue` replay frames from the top down to and
+      *including* the enclosing loop body's frame, since each
+      iteration enters the body scope fresh. `loopFrame` records the
+      `deferDepth` captured right after the body frame is pushed.
+  - An inner-block defer no longer leaks into the enclosing
+    function's return — a regression test (`TestLowerDeferInner-
+    BlockDoesNotLeakToOuterReturn`) pins that invariant.
+  - `thread.select(|s| body)` arms are now distinguished by
+    receiver-type recognition. Method calls on a `Select` value —
+    `s.recv(ch, f)`, `s.send(ch, v, f)`, `s.timeout(d, f)`,
+    `s.default(f)` — lower to dedicated intrinsics
+    (`IntrinsicSelectRecv` / `Send` / `Timeout` / `Default`). All
+    four always carry `Dest: nil`, matching the Osty spec where
+    those builder methods are treated as fire-and-forget arm
+    registrations even though the surface signature returns
+    `Select`.
+
+  Closure-to-SSA captures are still deferred until the borrow rules
+  land in the language spec — `AggClosure` stays as-is for now and
+  will be upgraded once the spec stabilises. The stdlib intrinsic
+  surface beyond concurrency (list / string / map runtime entry
+  points) is also deferred; it needs its own table-driven design and
+  a separate review.
 
 - **Stage 3.** Introduce a new llvmgen entry point —
   `GenerateFromMIR(m *mir.Module, opts)` — that consumes MIR directly.

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -370,13 +370,13 @@ type bodyState struct {
 	// loopStack is a stack of break/continue destinations.
 	loopStack []*loopFrame
 
-	// deferStack holds defer bodies in source order; they are replayed
-	// in LIFO at every function exit. Stage 2 keeps defers scoped to
-	// the enclosing function body; inner-block defers are still
-	// accepted but run at function exit rather than at inner-block
-	// exit, and a note records the simplification so callers can tell
-	// the difference.
-	deferStack []*ir.Block
+	// deferFrames is a stack of per-scope defer bodies. Index 0 is
+	// the function-level frame (seeded in newBodyState); deeper
+	// frames are pushed every time the lowerer enters an inner
+	// block scope (explicit Block stmt, `if`/`match` arm, loop body).
+	// Each frame holds HIR blocks in *source* order; replay inlines
+	// them in LIFO at the appropriate exit point.
+	deferFrames [][]*ir.Block
 }
 
 type ownerContext struct {
@@ -387,11 +387,20 @@ type ownerContext struct {
 type loopFrame struct {
 	breakBlock    BlockID
 	continueBlock BlockID
+	// deferDepth records the defer-frame depth active at the top of
+	// the loop body. `break` and `continue` unwind inner frames
+	// *inclusive* of this one — every iteration enters the body
+	// scope fresh, so the body's defers run on both exit paths.
+	deferDepth int
 }
 
 func newBodyState(l *lowerer, fn *Function) *bodyState {
 	bs := &bodyState{l: l, fn: fn, cur: fn.Entry}
 	bs.pushScope()
+	// Function-level defer frame. Stays for the lifetime of the
+	// function and is replayed on every exit edge (return, `?`
+	// propagation, fall-through).
+	bs.pushDeferScope()
 	// seed locals from parameters.
 	for i, p := range fn.Params {
 		loc := fn.Locals[p]
@@ -509,9 +518,7 @@ func (bs *bodyState) lowerStmt(s ir.Stmt) {
 	case *ir.MatchStmt:
 		bs.lowerMatchStmt(x)
 	case *ir.DeferStmt:
-		if x.Body != nil {
-			bs.deferStack = append(bs.deferStack, x.Body)
-		}
+		bs.addDefer(x.Body)
 	case *ir.ChanSendStmt:
 		ch := bs.lowerExprAsOperand(x.Channel)
 		val := bs.lowerExprAsOperand(x.Value)
@@ -530,6 +537,7 @@ func (bs *bodyState) lowerStmt(s ir.Stmt) {
 
 func (bs *bodyState) lowerBlockStmt(b *ir.Block) {
 	bs.pushScope()
+	bs.pushDeferScope()
 	for _, s := range b.Stmts {
 		bs.lowerStmt(s)
 	}
@@ -538,6 +546,8 @@ func (bs *bodyState) lowerBlockStmt(b *ir.Block) {
 		// still need its side effects.
 		_ = bs.lowerExprAsOperand(b.Result)
 	}
+	bs.replayTopFrame(b.SpanV)
+	bs.popDeferScope()
 	bs.popScope()
 }
 
@@ -788,19 +798,81 @@ func (bs *bodyState) lowerReturn(r *ir.ReturnStmt) {
 	bs.terminate(&ReturnTerm{SpanV: r.SpanV})
 }
 
-// runDefers inlines the accumulated defer bodies in LIFO order at
-// the current cursor. The stack is NOT popped — every exit point
-// replays the same set, matching the language semantics that each
-// defer runs exactly once on scope exit. Stage 2 uses function-level
-// scope: when the function ends (ReturnTerm, `?` early return, fall-
-// through), the replay happens at that exit. Break/continue edges
-// do not replay defers (they would run on the eventual loop exit).
-func (bs *bodyState) runDefers(sp Span) {
-	if len(bs.deferStack) == 0 {
+// ==== defer scoping ====
+//
+// Defer is scoped to the enclosing block. Each block pushes a fresh
+// defer frame on entry and pops it on exit. At every control-flow
+// exit edge the lowerer inlines the relevant frames in LIFO order:
+//
+//   - normal fall-through at block exit: replay+pop the top frame
+//   - `return` / `?` propagation / trailing-expr / implicit-unit:
+//     replay every frame (function-level through current) in LIFO
+//   - `break` / `continue`: replay frames down to and including the
+//     enclosing loop body's frame. Continue re-enters the body, so
+//     on the next iteration a fresh body frame is pushed and the
+//     body's defers re-register at compile time inside the same
+//     block. Statically this means the same MIR-inlined defer body
+//     appears at each exit point, not once per iteration.
+
+func (bs *bodyState) pushDeferScope() {
+	bs.deferFrames = append(bs.deferFrames, nil)
+}
+
+func (bs *bodyState) popDeferScope() {
+	if len(bs.deferFrames) == 0 {
 		return
 	}
-	for i := len(bs.deferStack) - 1; i >= 0; i-- {
-		body := bs.deferStack[i]
+	bs.deferFrames = bs.deferFrames[:len(bs.deferFrames)-1]
+}
+
+// addDefer registers a deferred block with the innermost frame.
+func (bs *bodyState) addDefer(body *ir.Block) {
+	if body == nil || len(bs.deferFrames) == 0 {
+		return
+	}
+	top := len(bs.deferFrames) - 1
+	bs.deferFrames[top] = append(bs.deferFrames[top], body)
+}
+
+// replayDefersFromDepth inlines defer frames from the top of the
+// stack down to depth (inclusive). depth=0 replays everything,
+// matching the behaviour expected at `return` / `?`.
+func (bs *bodyState) replayDefersFromDepth(depth int, sp Span) {
+	if depth < 0 {
+		depth = 0
+	}
+	// Skip when the cursor block is already terminated — the exit
+	// edge that ran the terminator has already performed its own
+	// replay, and we must not emit instructions after a terminator.
+	bb := bs.currentBlock()
+	if bb != nil && bb.Term != nil {
+		return
+	}
+	for i := len(bs.deferFrames) - 1; i >= depth; i-- {
+		bs.replayDeferFrame(bs.deferFrames[i], sp)
+	}
+}
+
+// replayTopFrame inlines only the innermost defer frame at the
+// current cursor. Used for normal block fall-through, before the
+// caller pops the frame.
+func (bs *bodyState) replayTopFrame(sp Span) {
+	if len(bs.deferFrames) == 0 {
+		return
+	}
+	bb := bs.currentBlock()
+	if bb != nil && bb.Term != nil {
+		return
+	}
+	bs.replayDeferFrame(bs.deferFrames[len(bs.deferFrames)-1], sp)
+}
+
+// replayDeferFrame inlines one frame in LIFO order. Each body runs
+// in its own name scope so local bindings from the surrounding
+// block don't leak into the cleanup logic.
+func (bs *bodyState) replayDeferFrame(frame []*ir.Block, sp Span) {
+	for i := len(frame) - 1; i >= 0; i-- {
+		body := frame[i]
 		if body == nil {
 			continue
 		}
@@ -816,12 +888,26 @@ func (bs *bodyState) runDefers(sp Span) {
 	_ = sp
 }
 
+// runDefers replays every defer frame (function-level + all inner
+// frames) at the cursor. Called at return / ? / fall-through exits.
+func (bs *bodyState) runDefers(sp Span) {
+	bs.replayDefersFromDepth(0, sp)
+}
+
+// currentDeferDepth returns the number of defer frames currently in
+// place. Recorded in loopFrame so break/continue know which frames
+// to unwind.
+func (bs *bodyState) currentDeferDepth() int {
+	return len(bs.deferFrames)
+}
+
 func (bs *bodyState) lowerBreak(b *ir.BreakStmt) {
 	if len(bs.loopStack) == 0 {
 		bs.l.noteIssue("break outside loop")
 		return
 	}
 	top := bs.loopStack[len(bs.loopStack)-1]
+	bs.replayDefersFromDepth(top.deferDepth, b.SpanV)
 	bs.terminate(&GotoTerm{Target: top.breakBlock, SpanV: b.SpanV})
 }
 
@@ -831,6 +917,7 @@ func (bs *bodyState) lowerContinue(c *ir.ContinueStmt) {
 		return
 	}
 	top := bs.loopStack[len(bs.loopStack)-1]
+	bs.replayDefersFromDepth(top.deferDepth, c.SpanV)
 	bs.terminate(&GotoTerm{Target: top.continueBlock, SpanV: c.SpanV})
 }
 
@@ -843,24 +930,30 @@ func (bs *bodyState) lowerIfStmt(st *ir.IfStmt) {
 
 	bs.cur = thenBB
 	bs.pushScope()
+	bs.pushDeferScope()
 	for _, s := range st.Then.Stmts {
 		bs.lowerStmt(s)
 	}
 	if st.Then.Result != nil {
 		_ = bs.lowerExprAsOperand(st.Then.Result)
 	}
+	bs.replayTopFrame(st.Then.SpanV)
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: merge, SpanV: st.SpanV})
 
 	bs.cur = elseBB
 	if st.Else != nil {
 		bs.pushScope()
+		bs.pushDeferScope()
 		for _, s := range st.Else.Stmts {
 			bs.lowerStmt(s)
 		}
 		if st.Else.Result != nil {
 			_ = bs.lowerExprAsOperand(st.Else.Result)
 		}
+		bs.replayTopFrame(st.Else.SpanV)
+		bs.popDeferScope()
 		bs.popScope()
 	}
 	bs.terminate(&GotoTerm{Target: merge, SpanV: st.SpanV})
@@ -890,15 +983,20 @@ func (bs *bodyState) lowerForInfinite(f *ir.ForStmt) {
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
 	bs.cur = header
 	bs.terminate(&GotoTerm{Target: body, SpanV: f.SpanV})
-	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: header})
 	bs.cur = body
 	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		breakBlock: exit, continueBlock: header, deferDepth: len(bs.deferFrames) - 1,
+	})
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
 	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
-	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
 	bs.cur = exit
 }
 
@@ -910,15 +1008,20 @@ func (bs *bodyState) lowerForWhile(f *ir.ForStmt) {
 	bs.cur = header
 	cond := bs.lowerExprAsOperand(f.Cond)
 	bs.terminate(&BranchTerm{Cond: cond, Then: body, Else: exit, SpanV: f.SpanV})
-	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: header})
 	bs.cur = body
 	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		breakBlock: exit, continueBlock: header, deferDepth: len(bs.deferFrames) - 1,
+	})
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
 	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
-	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
 	bs.cur = exit
 }
 
@@ -958,13 +1061,19 @@ func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
 		Else:  exit,
 		SpanV: f.SpanV,
 	})
-	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: step})
 	bs.cur = body
 	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1,
+	})
 	bs.bind(f.Var, idx)
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
 	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
 	bs.cur = step
@@ -979,7 +1088,6 @@ func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
 		SpanV: f.SpanV,
 	})
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
-	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
 	bs.cur = exit
 }
 
@@ -1036,9 +1144,12 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		Else:  exit,
 		SpanV: f.SpanV,
 	})
-	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: step})
 	bs.cur = body
 	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1,
+	})
 	// load current element: elem = iter[idx]
 	elemLocal := bs.fn.NewLocal("_elem", elemT, false, f.SpanV)
 	elemPlace := Place{Local: iter, Projections: []Projection{
@@ -1060,6 +1171,9 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
 	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
 	bs.cur = step
@@ -1074,7 +1188,6 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		SpanV: f.SpanV,
 	})
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
-	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
 	bs.cur = exit
 }
 
@@ -1118,9 +1231,12 @@ func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
 		SpanV:     f.SpanV,
 	})
 
-	bs.loopStack = append(bs.loopStack, &loopFrame{breakBlock: exit, continueBlock: step})
 	bs.cur = body
 	bs.pushScope()
+	bs.pushDeferScope()
+	bs.loopStack = append(bs.loopStack, &loopFrame{
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1,
+	})
 	// Unwrap the payload into a named local.
 	elemLocal := bs.fn.NewLocal("_elem", elemT, false, f.SpanV)
 	payloadProj := &VariantProj{
@@ -1142,12 +1258,14 @@ func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
 	}
+	bs.replayTopFrame(f.Body.SpanV)
+	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: step, SpanV: f.SpanV})
 
 	bs.cur = step
 	bs.terminate(&GotoTerm{Target: header, SpanV: f.SpanV})
-	bs.loopStack = bs.loopStack[:len(bs.loopStack)-1]
 	bs.cur = exit
 }
 
@@ -1207,6 +1325,7 @@ func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.
 	for i, arm := range arms {
 		bs.cur = armBlocks[i]
 		bs.pushScope()
+		bs.pushDeferScope()
 		// The decision tree already introduced bindings via MIR assigns.
 		// For tree-less fallback we would destructure here; we skip.
 		if arm.Body != nil {
@@ -1218,7 +1337,9 @@ func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.
 			} else if arm.Body.Result != nil {
 				_ = bs.lowerExprAsOperand(arm.Body.Result)
 			}
+			bs.replayTopFrame(arm.Body.SpanV)
 		}
+		bs.popDeferScope()
 		bs.popScope()
 		bs.terminate(&GotoTerm{Target: merge, SpanV: arm.SpanV})
 	}
@@ -1812,23 +1933,29 @@ func (bs *bodyState) lowerIfExprInto(ie *ir.IfExpr, dest Place, destT Type) {
 	bs.terminate(&BranchTerm{Cond: cond, Then: thenBB, Else: elseBB, SpanV: ie.SpanV})
 	bs.cur = thenBB
 	bs.pushScope()
+	bs.pushDeferScope()
 	for _, s := range ie.Then.Stmts {
 		bs.lowerStmt(s)
 	}
 	if ie.Then.Result != nil {
 		bs.lowerExprIntoPlace(ie.Then.Result, dest, destT)
 	}
+	bs.replayTopFrame(ie.Then.SpanV)
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: merge, SpanV: ie.SpanV})
 	bs.cur = elseBB
 	if ie.Else != nil {
 		bs.pushScope()
+		bs.pushDeferScope()
 		for _, s := range ie.Else.Stmts {
 			bs.lowerStmt(s)
 		}
 		if ie.Else.Result != nil {
 			bs.lowerExprIntoPlace(ie.Else.Result, dest, destT)
 		}
+		bs.replayTopFrame(ie.Else.SpanV)
+		bs.popDeferScope()
 		bs.popScope()
 	}
 	bs.terminate(&GotoTerm{Target: merge, SpanV: ie.SpanV})
@@ -1841,12 +1968,15 @@ func (bs *bodyState) lowerBlockExprInto(be *ir.BlockExpr, dest Place, destT Type
 		return
 	}
 	bs.pushScope()
+	bs.pushDeferScope()
 	for _, s := range be.Block.Stmts {
 		bs.lowerStmt(s)
 	}
 	if be.Block.Result != nil {
 		bs.lowerExprIntoPlace(be.Block.Result, dest, destT)
 	}
+	bs.replayTopFrame(be.Block.SpanV)
+	bs.popDeferScope()
 	bs.popScope()
 }
 
@@ -1866,12 +1996,15 @@ func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Typ
 		// Always take the else branch to stay conservative.
 		if ife.Else != nil {
 			bs.pushScope()
+			bs.pushDeferScope()
 			for _, s := range ife.Else.Stmts {
 				bs.lowerStmt(s)
 			}
 			if ife.Else.Result != nil {
 				bs.lowerExprIntoPlace(ife.Else.Result, dest, destT)
 			}
+			bs.replayTopFrame(ife.Else.SpanV)
+			bs.popDeferScope()
 			bs.popScope()
 		}
 		return
@@ -1894,6 +2027,7 @@ func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Typ
 	})
 	bs.cur = thenBB
 	bs.pushScope()
+	bs.pushDeferScope()
 	// Bind payload elements.
 	layout := bs.l.variantLayout(vp.Enum, vp.Variant)
 	for i, arg := range vp.Args {
@@ -1908,17 +2042,22 @@ func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Typ
 	if ife.Then.Result != nil {
 		bs.lowerExprIntoPlace(ife.Then.Result, dest, destT)
 	}
+	bs.replayTopFrame(ife.Then.SpanV)
+	bs.popDeferScope()
 	bs.popScope()
 	bs.terminate(&GotoTerm{Target: merge, SpanV: ife.SpanV})
 	bs.cur = elseBB
 	if ife.Else != nil {
 		bs.pushScope()
+		bs.pushDeferScope()
 		for _, s := range ife.Else.Stmts {
 			bs.lowerStmt(s)
 		}
 		if ife.Else.Result != nil {
 			bs.lowerExprIntoPlace(ife.Else.Result, dest, destT)
 		}
+		bs.replayTopFrame(ife.Else.SpanV)
+		bs.popDeferScope()
 		bs.popScope()
 	}
 	bs.terminate(&GotoTerm{Target: merge, SpanV: ife.SpanV})
@@ -2245,12 +2384,14 @@ func (bs *bodyState) emitConcurrencyIntrinsic(kind IntrinsicKind, args []ir.Arg,
 }
 
 // isVoidConcurrencyIntrinsic reports whether an intrinsic produces no
-// MIR-visible value (send, close, cancel, yield, sleep). Used so that
-// `ch.close()` in expression position doesn't carry a stale dest.
+// MIR-visible value (send, close, cancel, yield, select arms). Used
+// so that calls in expression position do not carry a stale dest.
 func isVoidConcurrencyIntrinsic(kind IntrinsicKind) bool {
 	switch kind {
 	case IntrinsicChanSend, IntrinsicChanClose,
-		IntrinsicGroupCancel, IntrinsicYield:
+		IntrinsicGroupCancel, IntrinsicYield,
+		IntrinsicSelectRecv, IntrinsicSelectSend,
+		IntrinsicSelectTimeout, IntrinsicSelectDefault:
 		return true
 	}
 	return false
@@ -2693,6 +2834,21 @@ func concurrencyIntrinsicForMethod(receiverType Type, name string) IntrinsicKind
 			return IntrinsicGroupCancel
 		case "isCancelled":
 			return IntrinsicGroupIsCancelled
+		}
+	case "Select":
+		// Arms of the `thread.select(|s| body)` DSL. Each method is
+		// a builder call whose signature in stdlib returns `self`, but
+		// the runtime treats them as arm registrations. MIR makes that
+		// explicit by emitting a dedicated intrinsic per arm.
+		switch name {
+		case "recv":
+			return IntrinsicSelectRecv
+		case "send":
+			return IntrinsicSelectSend
+		case "timeout":
+			return IntrinsicSelectTimeout
+		case "default":
+			return IntrinsicSelectDefault
 		}
 	}
 	return IntrinsicInvalid

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -350,6 +350,19 @@ const (
 	// Dest is unit; individual arms (recv/send/timeout/default) run
 	// their closures through the select runtime.
 	IntrinsicSelect
+	// IntrinsicSelectRecv registers a `s.recv(ch, f)` arm on a
+	// Select builder. Args: [select, channel, callback]. Dest nil.
+	IntrinsicSelectRecv
+	// IntrinsicSelectSend registers a `s.send(ch, v, f)` arm on a
+	// Select builder. Args: [select, channel, value, callback].
+	// Dest nil.
+	IntrinsicSelectSend
+	// IntrinsicSelectTimeout registers a `s.timeout(d, f)` arm on a
+	// Select builder. Args: [select, duration, callback]. Dest nil.
+	IntrinsicSelectTimeout
+	// IntrinsicSelectDefault registers a `s.default(f)` arm on a
+	// Select builder. Args: [select, callback]. Dest nil.
+	IntrinsicSelectDefault
 
 	// ---- concurrency: cancellation ----
 

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -1511,3 +1511,289 @@ func TestLowerThreadChanIsIntrinsicNotCall(t *testing.T) {
 		t.Fatalf("expected chan_make intrinsic, got:\n%s", text)
 	}
 }
+
+// ==== Stage 2c: inner-block defer scoping ====
+
+// mkCallStmt is a tiny helper that wraps a print intrinsic in an
+// ExprStmt so tests can name defer bodies by their printed argument.
+func mkCallStmt(name string) ir.Stmt {
+	return &ir.ExprStmt{X: &ir.IntrinsicCall{
+		Kind: ir.IntrinsicPrintln,
+		Args: []ir.Arg{{Value: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: name}}}}},
+	}}
+}
+
+func mkDefer(name string) *ir.DeferStmt {
+	return &ir.DeferStmt{Body: &ir.Block{Stmts: []ir.Stmt{mkCallStmt(name)}}}
+}
+
+// TestLowerDeferInnerBlockRunsAtBlockExit asserts that a defer
+// declared inside an inner `{ … }` block runs at that block's exit,
+// not only at the enclosing function's return.
+func TestLowerDeferInnerBlockRunsAtBlockExit(t *testing.T) {
+	// fn f() {
+	//   { defer inner(); body() }
+	//   after()
+	// }
+	// Expected order in the MIR dump: inner tag appears before after
+	// tag, because the inner block's defer replay happens before the
+	// function falls through to the `after()` call.
+	fn := mkFn("f", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.Block{
+				Stmts: []ir.Stmt{
+					mkDefer("inner"),
+					mkCallStmt("body"),
+				},
+			},
+			mkCallStmt("after"),
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	bodyI := strings.Index(text, `const "body"`)
+	innerI := strings.Index(text, `const "inner"`)
+	afterI := strings.Index(text, `const "after"`)
+	if bodyI < 0 || innerI < 0 || afterI < 0 {
+		t.Fatalf("expected body, inner, after in output:\n%s", text)
+	}
+	if !(bodyI < innerI && innerI < afterI) {
+		t.Fatalf("expected ordering body < inner < after, got %d/%d/%d:\n%s",
+			bodyI, innerI, afterI, text)
+	}
+}
+
+// TestLowerDeferMixedFunctionAndBlockScope confirms LIFO semantics
+// across an outer function-scoped defer and an inner block-scoped
+// defer. Both must replay; the inner one runs when its block exits,
+// the outer one runs at the function's return.
+func TestLowerDeferMixedFunctionAndBlockScope(t *testing.T) {
+	// fn f() {
+	//   defer outer()
+	//   { defer inner(); body() }
+	//   after()
+	// }
+	fn := mkFn("f", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			mkDefer("outer"),
+			&ir.Block{
+				Stmts: []ir.Stmt{
+					mkDefer("inner"),
+					mkCallStmt("body"),
+				},
+			},
+			mkCallStmt("after"),
+			&ir.ReturnStmt{},
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	body := strings.Index(text, `const "body"`)
+	inner := strings.Index(text, `const "inner"`)
+	after := strings.Index(text, `const "after"`)
+	outer := strings.Index(text, `const "outer"`)
+	if body < 0 || inner < 0 || after < 0 || outer < 0 {
+		t.Fatalf("expected all four markers, got:\n%s", text)
+	}
+	// body -> inner (block exit) -> after (outer block stmt) -> outer (return)
+	if !(body < inner && inner < after && after < outer) {
+		t.Fatalf("expected body < inner < after < outer, got %d/%d/%d/%d:\n%s",
+			body, inner, after, outer, text)
+	}
+}
+
+// TestLowerDeferInLoopReplaysOnBreak ensures a defer declared inside
+// a loop body replays on break — not just on return.
+func TestLowerDeferInLoopReplaysOnBreak(t *testing.T) {
+	// fn f() {
+	//   for {
+	//     defer loop()
+	//     break
+	//   }
+	//   after()
+	// }
+	fn := mkFn("f", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.ForStmt{
+				Kind: ir.ForInfinite,
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						mkDefer("loop"),
+						&ir.BreakStmt{},
+					},
+				},
+			},
+			mkCallStmt("after"),
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	loopI := strings.Index(text, `const "loop"`)
+	afterI := strings.Index(text, `const "after"`)
+	if loopI < 0 {
+		t.Fatalf("expected loop defer to be inlined on break:\n%s", text)
+	}
+	if afterI < 0 {
+		t.Fatalf("expected after to appear:\n%s", text)
+	}
+	if loopI > afterI {
+		t.Fatalf("loop defer must run before after (break inlines defers): got %d > %d:\n%s",
+			loopI, afterI, text)
+	}
+}
+
+// TestLowerDeferInLoopReplaysOnContinue ensures a defer declared
+// inside a loop body replays on continue too.
+func TestLowerDeferInLoopReplaysOnContinue(t *testing.T) {
+	fn := mkFn("f", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.ForStmt{
+				Kind: ir.ForInfinite,
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						mkDefer("loop"),
+						&ir.ContinueStmt{},
+					},
+				},
+			},
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, `const "loop"`) {
+		t.Fatalf("expected loop defer to be inlined on continue:\n%s", text)
+	}
+}
+
+// TestLowerDeferInnerBlockDoesNotLeakToOuterReturn proves the fix for
+// the Stage 2a limitation: a defer in an inner block must NOT also
+// re-run at the function's return. If it did, the "inner" marker
+// would appear twice in the dump.
+func TestLowerDeferInnerBlockDoesNotLeakToOuterReturn(t *testing.T) {
+	fn := mkFn("f", ir.TUnit, &ir.Block{
+		Stmts: []ir.Stmt{
+			&ir.Block{
+				Stmts: []ir.Stmt{mkDefer("inner")},
+			},
+			&ir.ReturnStmt{},
+		},
+	})
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if n := strings.Count(text, `const "inner"`); n != 1 {
+		t.Fatalf("expected exactly one inner defer inline, got %d:\n%s", n, text)
+	}
+}
+
+// ==== Stage 2c: thread.select arm expansion ====
+
+func TestLowerSelectRecvArm(t *testing.T) {
+	// fn arm(s: Select, ch: Channel<Int>, f: fn(Int) -> ()) -> Select {
+	//   s.recv(ch, f)
+	// }
+	selectT := &ir.NamedType{Name: "Select"}
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	cbT := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TUnit}
+	fn := &ir.FnDecl{
+		Name:   "arm",
+		Return: selectT,
+		Params: []*ir.Param{
+			{Name: "s", Type: selectT},
+			{Name: "ch", Type: chanInt},
+			{Name: "f", Type: cbT},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: selectT},
+				Name:     "recv",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt}},
+					{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: cbT}},
+				},
+				T: selectT,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic select_recv(_1, _2, _3)") {
+		t.Fatalf("expected select_recv intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerSelectSendArm(t *testing.T) {
+	selectT := &ir.NamedType{Name: "Select"}
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	cbT := &ir.FnType{Return: ir.TUnit}
+	fn := &ir.FnDecl{
+		Name:   "arm",
+		Return: selectT,
+		Params: []*ir.Param{
+			{Name: "s", Type: selectT},
+			{Name: "ch", Type: chanInt},
+			{Name: "v", Type: ir.TInt},
+			{Name: "f", Type: cbT},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: selectT},
+				Name:     "send",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt}},
+					{Value: &ir.Ident{Name: "v", Kind: ir.IdentParam, T: ir.TInt}},
+					{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: cbT}},
+				},
+				T: selectT,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic select_send(_1, _2, _3, _4)") {
+		t.Fatalf("expected select_send intrinsic, got:\n%s", text)
+	}
+}
+
+func TestLowerSelectTimeoutAndDefaultArms(t *testing.T) {
+	selectT := &ir.NamedType{Name: "Select"}
+	durT := &ir.NamedType{Name: "Duration"}
+	cbT := &ir.FnType{Return: ir.TUnit}
+	fn := &ir.FnDecl{
+		Name:   "arms",
+		Return: selectT,
+		Params: []*ir.Param{
+			{Name: "s", Type: selectT},
+			{Name: "d", Type: durT},
+			{Name: "f", Type: cbT},
+		},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: selectT},
+					Name:     "timeout",
+					Args: []ir.Arg{
+						{Value: &ir.Ident{Name: "d", Kind: ir.IdentParam, T: durT}},
+						{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: cbT}},
+					},
+					T: selectT,
+				}},
+			},
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: selectT},
+				Name:     "default",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "f", Kind: ir.IdentParam, T: cbT}},
+				},
+				T: selectT,
+			},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	if !strings.Contains(text, "intrinsic select_timeout(") {
+		t.Fatalf("expected select_timeout intrinsic, got:\n%s", text)
+	}
+	if !strings.Contains(text, "intrinsic select_default(") {
+		t.Fatalf("expected select_default intrinsic, got:\n%s", text)
+	}
+}

--- a/internal/mir/print.go
+++ b/internal/mir/print.go
@@ -460,6 +460,14 @@ func intrinsicName(k IntrinsicKind) string {
 		return "collect_all"
 	case IntrinsicSelect:
 		return "select"
+	case IntrinsicSelectRecv:
+		return "select_recv"
+	case IntrinsicSelectSend:
+		return "select_send"
+	case IntrinsicSelectTimeout:
+		return "select_timeout"
+	case IntrinsicSelectDefault:
+		return "select_default"
 	case IntrinsicIsCancelled:
 		return "is_cancelled"
 	case IntrinsicCheckCancelled:


### PR DESCRIPTION
Stage 2c of the MIR migration plan. Replaces Stage 2a's single function-scoped defer stack with proper per-block defer frames, and expands the `thread.select(|s| body)` DSL so each arm registration lowers to its own MIR intrinsic.

## What lands

### Inner-block defer scoping

- `bodyState.deferStack []*ir.Block` is replaced by `deferFrames [][]*ir.Block` — a stack of per-scope frames.
- Every block-shaped lowerer pushes a fresh frame: `lowerBlockStmt`, `lowerIfStmt`, `lowerIfExprInto`, `lowerForInfinite`/`While`/`Range`/`In`/`InChannel`, match arm bodies, `lowerIfLetExprInto` arms, `lowerBlockExprInto`.
- Replay rules:
  - **Normal block fall-through** replays only the top frame before popping.
  - **`return` / `?` propagation / implicit unit fall-through** replays every frame in LIFO.
  - **`break` / `continue`** replay frames from the top down to and *including* the enclosing loop body's frame — each iteration enters the body scope fresh, so the body's defers run on both exit paths. `loopFrame.deferDepth` records the depth captured right after the body frame is pushed.
- The replay helper refuses to emit after an already-terminated block, so exit paths that already ran their own replay don't double up.
- **Regression guarantee**: an inner-block defer no longer leaks into the enclosing function's return (`TestLowerDeferInnerBlockDoesNotLeakToOuterReturn`).

### `thread.select` arm expansion

Four new intrinsic kinds for the arm registrations inside the select closure:

| Method | Intrinsic | Args |
|---|---|---|
| `s.recv(ch, f)` | `IntrinsicSelectRecv` | `[select, channel, callback]` |
| `s.send(ch, v, f)` | `IntrinsicSelectSend` | `[select, channel, value, callback]` |
| `s.timeout(d, f)` | `IntrinsicSelectTimeout` | `[select, duration, callback]` |
| `s.default(f)` | `IntrinsicSelectDefault` | `[select, callback]` |

All four carry `Dest: nil`. The stdlib's `Select` methods nominally return `self`, but Osty semantics treat them as runtime arm registrations; MIR now encodes that directly via `concurrencyIntrinsicForMethod`'s new `\"Select\"` case and an extended `isVoidConcurrencyIntrinsic` list.

## Tests

Defer scoping:
- `TestLowerDeferInnerBlockRunsAtBlockExit` — inner defer runs at inner-block exit
- `TestLowerDeferMixedFunctionAndBlockScope` — LIFO across outer-fn + inner-block
- `TestLowerDeferInLoopReplaysOnBreak` — break inlines body defers
- `TestLowerDeferInLoopReplaysOnContinue` — continue inlines body defers
- `TestLowerDeferInnerBlockDoesNotLeakToOuterReturn` — no double-run at return

Select DSL:
- `TestLowerSelectRecvArm`
- `TestLowerSelectSendArm`
- `TestLowerSelectTimeoutAndDefaultArms`

## Test plan

- [x] `go test ./internal/mir`
- [x] `go test ./internal/parser ./internal/ir ./internal/llvmgen ./internal/backend`
- [x] Stage 1 / 2a / 2b tests remain green

## Design doc

`docs/mir_design.md` gains a full Stage 2c section covering the frame-stack design, the five replay rules, and the `Select` arm vocabulary. The \"responsibilities\" table and \"fire and forget\" intrinsic list are updated.

## Out of scope

- **Closure-to-SSA captures**. `AggClosure` stays as-is until the language spec's borrow rules land.
- **Stdlib intrinsic surface beyond concurrency** (list / string / map runtime entry points). Needs its own table-driven design and review — deferred.
- **Backend rewiring**. Stage 3+ work: `internal/llvmgen` still consumes MIR via the HIR→AST bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)