### PR TITLE
feat: Interface vtable Phase 6d — auto-box return + call-arg positions

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -295,12 +295,19 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     user-facing 파라미터를 `llvmType`으로 개별 lower하고 `emitExpr`로
     argument value를 만들어 indirect call에 `ptr %data, <argTyp> %arg…`
     형태로 threading. smoke: `TestGenerateModuleInterfaceDispatchWithArgs`.
+  - Phase 6d(let 외 context 자동 boxing): return statement / 블록의
+    trailing-expression implicit return / 함수 호출 인자에서 concrete
+    값이 interface-typed slot으로 들어가면 `boxInterfaceValue`가 자동
+    호출되어 fat pointer를 생성한다. `generator`에 `returnSourceType`
+    필드 추가로 AST 레벨 return 타입을 추적. smokes:
+    `TestGenerateModuleInterfaceBoxingFromReturn`,
+    `TestGenerateModuleInterfaceBoxingFromCallArg`.
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
     generic interface specialization의 vtable 연결 (Phase 5 `_ZTSN…E` +
-    Phase 6a scaffold), let 외 context(assign/return/fn arg)의 자동
-    boxing, payload-free / 비-리터럴 인자를 가진 variant call의 타입
-    복원(궁극적으로는 checker 쪽 generic variant-constructor inference
-    보강).
+    Phase 6a scaffold), 암묵 타입 변환, assign-statement 레벨의 자동
+    boxing (현재 let/return/call 세 경로), payload-free / 비-리터럴
+    인자를 가진 variant call의 타입 복원(궁극적으로는 checker 쪽
+    generic variant-constructor inference 보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2369,6 +2369,16 @@ func (g *generator) userCallArgs(sig *fnSig, receiverExpr ast.Expr, call *ast.Ca
 		if err != nil {
 			return nil, err
 		}
+		// Phase 6d: auto-box a concrete value when the callee expects
+		// an interface. Mirrors the `let s: Sized = v` and return-value
+		// paths so call-site conversion lands consistently.
+		if param.typ == "%osty.iface" && v.typ != "%osty.iface" && param.sourceType != nil {
+			boxed, boxErr := g.boxInterfaceValue(param.sourceType, v)
+			if boxErr != nil {
+				return nil, boxErr
+			}
+			v = boxed
+		}
 		if v.typ != param.typ {
 			return nil, unsupportedf("type-system", "function %q arg %d type %s, want %s", sig.name, i+1, v.typ, param.typ)
 		}

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -363,6 +363,81 @@ fn main() {
 	}
 }
 
+// TestGenerateModuleInterfaceBoxingFromReturn covers Phase 6d's
+// return-position auto-boxing: a function whose declared return type
+// is an interface can return a concrete value, and the caller receives
+// a `%osty.iface` fat pointer suitable for subsequent dispatch.
+func TestGenerateModuleInterfaceBoxingFromReturn(t *testing.T) {
+	src := `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn wrap(v: Vec) -> Sized {
+    v
+}
+
+fn main() {
+    let v = Vec { count: 5 }
+    let s = wrap(v)
+    println(s.size())
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6d_return_box.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		"@osty.vtable.Vec__Sized",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateModuleInterfaceBoxingFromCallArg covers Phase 6d's
+// call-argument auto-boxing: passing a concrete value into a parameter
+// whose declared type is an interface must insert a `%osty.iface` fat
+// pointer transparently so the callee's dispatch path works.
+func TestGenerateModuleInterfaceBoxingFromCallArg(t *testing.T) {
+	src := `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn measure(s: Sized) -> Int {
+    s.size()
+}
+
+fn main() {
+    let v = Vec { count: 7 }
+    println(measure(v))
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6d_callarg_box.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		"@osty.vtable.Vec__Sized",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -43,6 +43,15 @@ func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType string, retSour
 			if err != nil {
 				return err
 			}
+			// Phase 6d: auto-box a concrete return value into the
+			// declared interface type (same policy as emitReturn).
+			if retType == "%osty.iface" && v.typ != "%osty.iface" && g.returnSourceType != nil {
+				boxed, boxErr := g.boxInterfaceValue(g.returnSourceType, v)
+				if boxErr != nil {
+					return boxErr
+				}
+				v = boxed
+			}
 			if v.typ != retType {
 				return unsupportedf("type-system", "return type %s, want %s", v.typ, retType)
 			}
@@ -56,6 +65,14 @@ func (g *generator) emitReturningBlock(stmts []ast.Stmt, retType string, retSour
 			v, err := g.emitExprWithHintAndSourceType(s.X, retSourceType, retListElemTyp, false, retMapKeyTyp, retMapValueTyp, false, retSetElemTyp, false)
 			if err != nil {
 				return err
+			}
+			// Phase 6d: trailing-expression implicit return auto-boxing.
+			if retType == "%osty.iface" && v.typ != "%osty.iface" && g.returnSourceType != nil {
+				boxed, boxErr := g.boxInterfaceValue(g.returnSourceType, v)
+				if boxErr != nil {
+					return boxErr
+				}
+				v = boxed
 			}
 			if v.typ != retType {
 				return unsupportedf("type-system", "trailing expression type %s, want %s", v.typ, retType)
@@ -612,6 +629,16 @@ func (g *generator) emitReturn(stmt *ast.ReturnStmt) error {
 		ret, err = g.emitExprWithHintAndSourceType(stmt.Value, g.returnSourceType, g.returnListElemTyp, false, "", "", false, "", false)
 		if err != nil {
 			return err
+		}
+		// Phase 6d: auto-box a concrete return value when the declared
+		// return type is an interface. Mirrors the `let s: Sized = v`
+		// path in emitLet.
+		if g.returnType == "%osty.iface" && ret.typ != "%osty.iface" && g.returnSourceType != nil {
+			boxed, boxErr := g.boxInterfaceValue(g.returnSourceType, ret)
+			if boxErr != nil {
+				return boxErr
+			}
+			ret = boxed
 		}
 		if ret.typ != g.returnType {
 			return unsupportedf("type-system", "return type %s, want %s", ret.typ, g.returnType)


### PR DESCRIPTION
Phase 6d: return-position과 call-arg position에서 concrete→interface 자동 boxing.

- `emitReturn`에서 반환 타입이 interface일 때 concrete value를 fat-ptr로 boxing
- `emitCall`의 call-arg에서 same path

🤖 Generated with [Claude Code](https://claude.com/claude-code)