### PR TITLE
feat: Interface vtable Phase 6f+6g + void shim hotfix (main 기준)

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -307,11 +307,22 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     `boxInterfaceValue`가 반환 value에 `sourceType: ifaceType`을 태그
     해 slot이 자신의 선언 interface identity를 기억한다. smoke:
     `TestGenerateModuleInterfaceBoxingFromAssign`.
+  - Phase 6f(Phase 5 mangled interface 이름 ↔ Phase 6 vtable 통합):
+    코드 변경 없이 이미 맞물려 있다. Phase 5가 generic interface를
+    specialize할 때 결과 이름은 `_ZTSN…E` Itanium RTTI 포맷이고,
+    Phase 6a의 `discoverInterfaceImplementations`는 이 이름을 그대로
+    소비해 `@osty.vtable.<impl>__<mangled>` vtable global을 emit한다.
+    boxing / dispatch 경로도 `interfaceInfo.name` 기준이라 추가 처리
+    불필요. smoke: `TestGenerateModuleMangledInterfaceNameVtableDispatch`
+    가 mangled 이름을 source identifier로 직접 써서 경로 전체를
+    regression-lock (parser가 generic interface `interface Foo<T>` 선언
+    문법을 아직 수용하지 않아 실제 Container<Int> → Container<Int>
+    specialization E2E는 별도 parser/checker 확장 후).
   - 남은 범위: bare function-pointer turbofish (`let f = id::<Int>`),
-    generic interface specialization의 vtable 연결 (Phase 5 `_ZTSN…E` +
-    Phase 6a scaffold), 암묵 타입 변환, payload-free / 비-리터럴 인자를
-    가진 variant call의 타입 복원(궁극적으로는 checker 쪽 generic
-    variant-constructor inference 보강).
+    generic interface 선언 파서 지원 (`interface Foo<T>` 문법),
+    암묵 타입 변환, payload-free / 비-리터럴 인자를 가진 variant call의
+    타입 복원(궁극적으로는 checker 쪽 generic variant-constructor
+    inference 보강).
 - workspace/dependency graph를 codegen/link order로 변환한다.
 - `use go` FFI는 LLVM backend에서 그대로 지원하기 어렵기 때문에 새 FFI 정책을
   정한다.

--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -307,6 +307,18 @@ artifact/cache layout 정책은 [`LLVM_ARTIFACT_LAYOUT.md`](./LLVM_ARTIFACT_LAYO
     `boxInterfaceValue`가 반환 value에 `sourceType: ifaceType`을 태그
     해 slot이 자신의 선언 interface identity를 기억한다. smoke:
     `TestGenerateModuleInterfaceBoxingFromAssign`.
+  - Phase 6g(vtable calling-convention shim + binary E2E): interface
+    dispatch ABI(`ptr %data + non-self args`)가 실제 method의 struct-
+    by-value receiver convention과 달라 IR-level smoke는 통과해도
+    binary 실행 시 self가 스택 쓰레기로 읽혔다. `renderInterfaceShim`
+    이 (impl, iface, method) 쌍마다 `@osty.shim.<impl>__<iface>__<method>`
+    를 emit해 ptr→struct load 후 실제 method를 호출하는 adapter를
+    담당. vtable slot은 method 대신 이 shim을 가리킨다. mut receiver는
+    포인터를 그대로 forward. `internal/backend/llvm_test.go`에 두 개의
+    binary E2E smoke 추가: `TestLLVMBackendBinaryRunsGenericIdentity`
+    (Phase 1 generic fn `id::<Int>(42)`가 `42\n` 출력) +
+    `TestLLVMBackendBinaryRunsInterfaceBoxingDispatch` (Phase 6b boxing +
+    vtable dispatch가 `3\n` 출력). clang을 미발견 시 skip.
   - Phase 6f(Phase 5 mangled interface 이름 ↔ Phase 6 vtable 통합):
     코드 변경 없이 이미 맞물려 있다. Phase 5가 generic interface를
     specialize할 때 결과 이름은 `_ZTSN…E` Itanium RTTI 포맷이고,

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -691,6 +691,7 @@ fn main() {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }
+
 func TestLLVMBackendBinaryGenericEnumVariantFromLetContext(t *testing.T) {
 	if _, err := exec.LookPath("clang"); err != nil {
 		t.Skip("clang not found on PATH")
@@ -895,6 +896,87 @@ fn main() {
 		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
 	}
 	if got, want := string(output), "1\n2\napple\n1\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsGenericIdentity covers the generic
+// monomorphization path Phase 1 introduced, all the way through clang
+// to an executable. The monomorphizer must produce `_Z2idIlEl`, clang
+// must link and run it, and the process must print the forwarded
+// value. Complements the IR-only smoke in
+// `internal/llvmgen/ir_module_test.go::TestGenerateModuleGenericIdentityMonomorphized`.
+func TestLLVMBackendBinaryRunsGenericIdentity(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn id<T>(x: T) -> T { x }
+
+fn main() {
+    println(id::<Int>(42))
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "42\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
+// TestLLVMBackendBinaryRunsInterfaceBoxingDispatch exercises the full
+// Phase 6a-6e interface pipeline end-to-end: a struct's method set
+// structurally satisfies an interface, the concrete value is boxed
+// into a `%osty.iface` fat pointer at the `let` site, and the
+// subsequent method call is lowered to a vtable indirect call that
+// the linked binary actually executes. Complements the IR-only
+// smokes `TestGenerateModuleInterfaceBoxingDispatch` and friends by
+// confirming the emitted `insertvalue` / `extractvalue` / `load ptr`
+// / indirect-call sequence survives clang and runs correctly.
+func TestLLVMBackendBinaryRunsInterfaceBoxingDispatch(t *testing.T) {
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `interface Sized {
+    fn size(self) -> Int
+}
+
+struct Vec {
+    count: Int,
+
+    fn size(self) -> Int {
+        self.count
+    }
+}
+
+fn main() {
+    let v = Vec { count: 3 }
+    let s: Sized = v
+    println(s.size())
+}
+`)
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "3\n"; got != want {
 		t.Fatalf("binary stdout = %q, want %q", got, want)
 	}
 }

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -360,10 +360,14 @@ func renderInterfaceShim(iface *interfaceInfo, impl interfaceImpl, m interfaceMe
 	if !receiver.byRef {
 		body.WriteString(fmt.Sprintf("  %%self.val = load %s, ptr %%self.ptr\n", receiver.typ))
 	}
-	body.WriteString(fmt.Sprintf("  %%ret.val = call %s @%s(%s)\n", ret, sig.irName, strings.Join(callArgs, ", ")))
 	if ret == "void" {
+		// Void call sites must NOT bind an SSA destination —
+		// `%x = call void @f()` is not valid LLVM IR. Emit the bare
+		// call + `ret void`.
+		body.WriteString(fmt.Sprintf("  call void @%s(%s)\n", sig.irName, strings.Join(callArgs, ", ")))
 		body.WriteString("  ret void\n")
 	} else {
+		body.WriteString(fmt.Sprintf("  %%ret.val = call %s @%s(%s)\n", ret, sig.irName, strings.Join(callArgs, ", ")))
 		body.WriteString(fmt.Sprintf("  ret %s %%ret.val\n", ret))
 	}
 	def := fmt.Sprintf("define internal %s %s(%s) {\n%s}",

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -272,7 +272,8 @@ func (g *generator) renderInterfaceVtables() ([]string, string) {
 		}
 		haveAny = true
 		for _, impl := range iface.impls {
-			methodsByName := g.methods[g.ownerTypeFor(impl)]
+			implType := g.ownerTypeFor(impl)
+			methodsByName := g.methods[implType]
 			slots := make([]string, 0, len(iface.methods))
 			for _, m := range iface.methods {
 				sig := methodsByName[m.name]
@@ -280,7 +281,22 @@ func (g *generator) renderInterfaceVtables() ([]string, string) {
 					slots = append(slots, "ptr null")
 					continue
 				}
-				slots = append(slots, fmt.Sprintf("ptr @%s", sig.irName))
+				// Phase 6f follow-up: the vtable slot does not point
+				// at the concrete method directly because interface
+				// dispatch passes `self` as `ptr %data` while the
+				// underlying method expects the struct/enum value (or
+				// a `ptr` for mut receivers). A per-(impl, iface,
+				// method) shim adapts the calling convention: it
+				// loads the concrete value from the data pointer (or
+				// forwards the pointer for mut receivers) and tail-
+				// calls the real implementation.
+				shimSym, shimDef := renderInterfaceShim(iface, impl, m, sig, implType)
+				if shimDef != "" {
+					defs = append(defs, shimDef)
+					slots = append(slots, "ptr "+shimSym)
+				} else {
+					slots = append(slots, fmt.Sprintf("ptr @%s", sig.irName))
+				}
 			}
 			defs = append(defs, fmt.Sprintf(
 				"%s = constant [%d x ptr] [%s]",
@@ -295,6 +311,64 @@ func (g *generator) renderInterfaceVtables() ([]string, string) {
 	}
 	typeDef := "%osty.iface = type { ptr, ptr }"
 	return defs, typeDef
+}
+
+// renderInterfaceShim returns the `@osty.shim.<impl>__<iface>__<method>`
+// symbol and the LLVM IR definition of a shim that adapts the
+// interface dispatch ABI (`ptr %data, <non-self args>`) to the
+// underlying method's calling convention.
+//
+// For immutable receivers the shim loads the struct/enum value from
+// the data pointer before calling the real method; for `mut` receivers
+// (where the method already takes `ptr %self`) the pointer is
+// forwarded verbatim. A nil return signals a malformed signature the
+// caller must handle by falling back to a direct `ptr @<method>`
+// slot, which is still safe for receiver-less methods but will
+// typically yield an empty-return shim when one is actually needed.
+func renderInterfaceShim(iface *interfaceInfo, impl interfaceImpl, m interfaceMethodSig, sig *fnSig, implType string) (string, string) {
+	if sig == nil || implType == "" {
+		return "", ""
+	}
+	if len(sig.params) == 0 {
+		// No receiver slot — nothing to adapt.
+		return "", ""
+	}
+	receiver := sig.params[0]
+	shimSym := fmt.Sprintf("@osty.shim.%s__%s__%s", impl.implName, iface.name, m.name)
+	ret := sig.ret
+	if ret == "" {
+		ret = "void"
+	}
+	// Build the shim's parameter list: data ptr followed by any
+	// non-self user args. The underlying method will consume them
+	// with its own declared types.
+	shimParams := []string{"ptr %self.ptr"}
+	callArgs := make([]string, 0, len(sig.params))
+	if receiver.byRef {
+		// Mut receiver already expects a pointer — forward it.
+		callArgs = append(callArgs, "ptr %self.ptr")
+	} else {
+		// Immutable receiver expects the struct/enum value.
+		callArgs = append(callArgs, fmt.Sprintf("%s %%self.val", receiver.typ))
+	}
+	for i, p := range sig.params[1:] {
+		name := fmt.Sprintf("%%a%d", i)
+		shimParams = append(shimParams, fmt.Sprintf("%s %s", p.typ, name))
+		callArgs = append(callArgs, fmt.Sprintf("%s %s", p.typ, name))
+	}
+	var body strings.Builder
+	if !receiver.byRef {
+		body.WriteString(fmt.Sprintf("  %%self.val = load %s, ptr %%self.ptr\n", receiver.typ))
+	}
+	body.WriteString(fmt.Sprintf("  %%ret.val = call %s @%s(%s)\n", ret, sig.irName, strings.Join(callArgs, ", ")))
+	if ret == "void" {
+		body.WriteString("  ret void\n")
+	} else {
+		body.WriteString(fmt.Sprintf("  ret %s %%ret.val\n", ret))
+	}
+	def := fmt.Sprintf("define internal %s %s(%s) {\n%s}",
+		ret, shimSym, strings.Join(shimParams, ", "), body.String())
+	return shimSym, def
 }
 
 // ownerTypeFor returns the LLVM IR type symbol (`%Name`) a given

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -531,6 +531,45 @@ fn main() {
 	}
 }
 
+// TestRenderInterfaceShimVoidReturn locks the bug fix for
+// `renderInterfaceShim`'s void-return path: when a method's return
+// is `void`, the shim must emit a bare `call void @impl(...)` rather
+// than binding the result to an SSA register (`%x = call void ...`),
+// which is not valid LLVM IR.
+//
+// Unit-level rather than end-to-end because statement-position
+// interface method calls (`c.clear()` as a stmt) are a separate
+// llvmgen gap; exercising `renderInterfaceShim` directly keeps this
+// regression lock narrowly focused on the fix itself.
+func TestRenderInterfaceShimVoidReturn(t *testing.T) {
+	iface := &interfaceInfo{name: "Clear"}
+	impl := interfaceImpl{
+		implName:  "Bin",
+		kind:      0,
+		vtableSym: "@osty.vtable.Bin__Clear",
+	}
+	m := interfaceMethodSig{name: "clear", slot: 0}
+	sig := &fnSig{
+		name:    "clear",
+		irName:  "Bin__clear",
+		ret:     "void",
+		params:  []paramInfo{{name: "self", typ: "%Bin"}},
+	}
+	sym, def := renderInterfaceShim(iface, impl, m, sig, "%Bin")
+	if sym == "" || def == "" {
+		t.Fatal("expected renderInterfaceShim to produce a shim for a void method")
+	}
+	if strings.Contains(def, "%ret.val = call void") {
+		t.Fatalf("invalid LLVM IR: bound SSA register to void call:\n%s", def)
+	}
+	if !strings.Contains(def, "call void @Bin__clear") {
+		t.Fatalf("expected bare `call void @Bin__clear` in shim body:\n%s", def)
+	}
+	if !strings.Contains(def, "  ret void") {
+		t.Fatalf("expected `ret void` terminator in shim body:\n%s", def)
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -481,6 +481,49 @@ fn main() {
 	}
 }
 
+// TestGenerateModuleMangledInterfaceNameVtableDispatch covers Phase 6f:
+// Phase 5's generic interface specialization emits nominal names in
+// the Itanium `_ZTSN…E` shape. Phase 6a-6e's vtable scaffold must
+// continue to work on those mangled names — discovery, vtable
+// emission, boxing, and dispatch all keyed on the exact string
+// produced by `MonomorphMangleType`. The parser does not yet accept
+// generic interface declarations, so this smoke feeds the mangled
+// name as the raw source identifier; the resulting pipeline stage
+// mirrors what Phase 5 would hand llvmgen for a `Container<Int>`
+// specialization.
+func TestGenerateModuleMangledInterfaceNameVtableDispatch(t *testing.T) {
+	const mangled = "_ZTSN4main9ContainerIlEE"
+	src := `interface ` + mangled + ` {
+    fn get(self) -> Int
+}
+
+struct IntBox {
+    value: Int,
+
+    fn get(self) -> Int {
+        self.value
+    }
+}
+
+fn main() {
+    let b = IntBox { value: 3 }
+    let c: ` + mangled + ` = b
+    println(c.get())
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase6f_mangled_iface.osty")
+	for _, want := range []string{
+		"%osty.iface",
+		mangled,
+		"@osty.vtable.IntBox__" + mangled,
+		"ptr @IntBox__get",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateModuleMethodLocalGenericGetMonomorphized verifies the
 // Phase 4 path: a non-generic struct with a generic method
 // (`fn get<U>(self, u: U) -> U`) gets specialized per turbofish call

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -285,7 +285,12 @@ fn main() {
 	for _, want := range []string{
 		"%osty.iface = type { ptr, ptr }",
 		"@osty.vtable.Vec__Sized",
-		"ptr @Vec__size",
+		// Phase 6f follow-up: the vtable slot points at a shim that
+		// adapts the interface dispatch ABI to the underlying method's
+		// calling convention; the shim's body in turn calls the real
+		// `Vec__size` symbol.
+		"@osty.shim.Vec__Sized__size",
+		"@Vec__size",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
@@ -349,7 +354,8 @@ fn main() {
 	for _, want := range []string{
 		"%osty.iface",
 		"@osty.vtable.Thing__Combine",
-		"ptr @Thing__combine",
+		"@osty.shim.Thing__Combine__combine",
+		"@Thing__combine",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
@@ -516,7 +522,8 @@ fn main() {
 		"%osty.iface",
 		mangled,
 		"@osty.vtable.IntBox__" + mangled,
-		"ptr @IntBox__get",
+		"@osty.shim.IntBox__" + mangled + "__get",
+		"@IntBox__get",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)


### PR DESCRIPTION
## Summary

Phase 6f, 6g, void shim hotfix를 Phase 6b-6e(#249) 위에 얹음.

### 변경 내용

**Phase 6f** — mangled nominal ↔ vtable path lock
- `TestGenerateModuleGenericInterfaceVtableEmitted`: Phase 5 monomorphized interface nominal이 Phase 6 vtable path에서 올바르게 인식됨을 검증

**Phase 6g** — calling-convention shim + binary E2E
- `renderInterfaceShim`: vtable entry가 struct-by-value receiver를 data ptr로 받아 concrete method에 전달하는 adapter function 생성
- `internal/backend/llvm_test.go`: 
  - `TestLLVMBackendBinaryRunsGenericIdentity` — `fn id<T>` 전체 파이프라인 binary E2E (출력 `42`)
  - `TestLLVMBackendBinaryRunsInterfaceBoxingDispatch` — `interface Sized / struct Vec` vtable boxing pipeline binary E2E (출력 `3`)

**Void shim hotfix** — LLVM IR 정합성 수정
- `renderInterfaceShim`의 void return 경로가 `%ret.val = call void @f()` (invalid IR)를 emit했던 버그 수정
- void method shim은 `call void @f()` + `ret void` 로 정정

## Pre-existing failures

`TestGenerateManagedTemporaryCallArgUsesRootSlot` 등 9건은 이 PR 이전 main에도 동일하게 실패. 회귀 아님.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/llvmgen/ -run 'TestGenerateModuleInterface|TestGenerateTopLevel' -count=1`
- [x] `go test ./internal/backend/ -run 'TestLLVMBackendBinaryRunsGenericIdentity|TestLLVMBackendBinaryRunsInterfaceBoxingDispatch' -count=1` (LLVM 설치 환경에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)