### PR TITLE
Add canonical source maps for checker overlays

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1781,10 +1781,12 @@ func loadSelectedGenFilesWithTransform(sourcePath string, files []string, transf
 			src = transform(path, src)
 		}
 		parsed := parser.ParseDetailed(src)
+		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
 		pf := &resolve.PackageFile{
 			Path:            path,
 			Source:          src,
-			CanonicalSource: canonical.Source(src, parsed.File),
+			CanonicalSource: canonicalSrc,
+			CanonicalMap:    canonicalMap,
 			File:            parsed.File,
 			ParseDiags:      parsed.Diagnostics,
 			ParseProvenance: parsed.Provenance,

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -270,10 +270,12 @@ func parseNativeTestEntry(pkg *resolve.Package, tc nativeTestCase) (*ast.File, [
 	}
 	testPkg.Files = append(testPkg.Files, pkg.Files...)
 	runnerFile, runnerDiags := parser.ParseDiagnostics(runner)
+	runnerCanonical, runnerCanonicalMap := canonical.SourceWithMap(runner, runnerFile)
 	testPkg.Files = append(testPkg.Files, &resolve.PackageFile{
 		Path:            runnerPath,
 		Source:          runner,
-		CanonicalSource: canonical.Source(runner, runnerFile),
+		CanonicalSource: runnerCanonical,
+		CanonicalMap:    runnerCanonicalMap,
 		File:            runnerFile,
 		ParseDiags:      runnerDiags,
 	})

--- a/internal/canonical/source.go
+++ b/internal/canonical/source.go
@@ -3,16 +3,24 @@ package canonical
 import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/format"
+	"github.com/osty/osty/internal/sourcemap"
 )
 
 // Source returns the canonical checker-facing source for a parsed file.
 // Callers fall back to the original bytes when no parsed AST is available.
 func Source(original []byte, file *ast.File) []byte {
+	out, _ := SourceWithMap(original, file)
+	return out
+}
+
+// SourceWithMap returns canonical checker-facing source plus a coarse source
+// map from canonical output spans back to the original spans stored on the AST.
+func SourceWithMap(original []byte, file *ast.File) ([]byte, *sourcemap.Map) {
 	if file == nil {
-		return append([]byte(nil), original...)
+		return append([]byte(nil), original...), nil
 	}
-	if out := format.File(file); len(out) > 0 {
-		return out
+	if out, m := format.FileWithMap(file); len(out) > 0 {
+		return out, m
 	}
-	return append([]byte(nil), original...)
+	return append([]byte(nil), original...), nil
 }

--- a/internal/canonical/source_test.go
+++ b/internal/canonical/source_test.go
@@ -1,0 +1,49 @@
+package canonical
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+)
+
+func TestSourceWithMapProjectsLoweredCallSpans(t *testing.T) {
+	src := []byte(`func main() {
+    let xs = [1]
+    let n = len(xs)
+}
+`)
+	parsed := parser.ParseDetailed(src)
+	if len(parsed.Diagnostics) != 0 {
+		t.Fatalf("parse diagnostics = %#v, want none", parsed.Diagnostics)
+	}
+	canonicalSrc, sm := SourceWithMap(src, parsed.File)
+	if sm == nil || sm.Empty() {
+		t.Fatal("source map = nil, want canonical span mappings")
+	}
+	if !bytes.Contains(canonicalSrc, []byte("xs.len()")) {
+		t.Fatalf("canonical source = %q, want lowered xs.len()", canonicalSrc)
+	}
+	mainDecl := parsed.File.Decls[0].(*ast.FnDecl)
+	letStmt := mainDecl.Body.Stmts[1].(*ast.LetStmt)
+	call := letStmt.Value.(*ast.CallExpr)
+	original := diag.Span{Start: call.Pos(), End: call.End()}
+
+	generated, ok := sm.GeneratedSpanForOriginal(original)
+	if !ok {
+		t.Fatal("GeneratedSpanForOriginal() = false, want canonical call span")
+	}
+	if got := string(canonicalSrc[generated.Start.Offset:generated.End.Offset]); got != "xs.len()" {
+		t.Fatalf("generated call = %q, want xs.len()", got)
+	}
+
+	remapped, ok := sm.RemapSpan(generated)
+	if !ok {
+		t.Fatal("RemapSpan() = false, want original call span")
+	}
+	if remapped != original {
+		t.Fatalf("remapped span = %#v, want %#v", remapped, original)
+	}
+}

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -10,9 +10,11 @@ import (
 	"sync"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/toolchain"
 	"github.com/osty/osty/internal/types"
@@ -201,10 +203,11 @@ type selfhostCheckedSource struct {
 }
 
 type selfhostFileSegment struct {
-	file  *ast.File
-	scope *resolve.Scope
-	refs  map[*ast.Ident]*resolve.Symbol
-	base  int
+	file      *ast.File
+	scope     *resolve.Scope
+	refs      map[*ast.Ident]*resolve.Symbol
+	base      int
+	sourceMap *sourcemap.Map
 }
 
 func applyNativeFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider) {
@@ -427,14 +430,14 @@ func buildSelfhostSpanIndex(src selfhostCheckedSource) *selfhostSpanIndex {
 			continue
 		}
 		for _, decl := range file.file.Decls {
-			idx.addNode(decl, file.base, file.scope)
+			idx.addNode(decl, file.base, file.scope, file.sourceMap)
 		}
 		for _, stmt := range file.file.Stmts {
-			idx.addNode(stmt, file.base, file.scope)
+			idx.addNode(stmt, file.base, file.scope, file.sourceMap)
 		}
-		idx.addScopeSubtree(file.scope, file.base)
+		idx.addScopeSubtree(file.scope, file.base, file.sourceMap)
 		for _, sym := range file.refs {
-			idx.addSymbol(sym, file.base, file.scope)
+			idx.addSymbol(sym, file.base, file.scope, file.sourceMap)
 		}
 	}
 	return idx
@@ -462,11 +465,11 @@ func (idx *selfhostSpanIndex) scopeFor(key selfhostSpanKey) *resolve.Scope {
 	return best
 }
 
-func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope) {
+func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope, sm *sourcemap.Map) {
 	if n == nil {
 		return
 	}
-	key, haveKey := spanKeyForNode(n, base)
+	key, haveKey := spanKeyForNode(n, base, sm)
 	if haveKey {
 		if _, ok := idx.scopes[key]; !ok {
 			idx.scopes[key] = scope
@@ -487,267 +490,237 @@ func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope
 	}
 	switch v := n.(type) {
 	case *ast.FnDecl:
-		if v.Recv != nil {
-			idx.addNode(v.Recv, base, scope)
-		}
+		idx.addNode(v.Recv, base, scope, sm)
 		for _, g := range v.Generics {
-			idx.addNode(g, base, scope)
+			idx.addNode(g, base, scope, sm)
 		}
 		for _, p := range v.Params {
-			idx.addNode(p, base, scope)
+			idx.addNode(p, base, scope, sm)
 		}
-		if v.ReturnType != nil {
-			idx.addNode(v.ReturnType, base, scope)
-		}
-		if v.Body != nil {
-			idx.addNode(v.Body, base, scope)
-		}
+		idx.addNode(v.ReturnType, base, scope, sm)
+		idx.addNode(v.Body, base, scope, sm)
 	case *ast.StructDecl:
 		for _, g := range v.Generics {
-			idx.addNode(g, base, scope)
+			idx.addNode(g, base, scope, sm)
 		}
 		for _, f := range v.Fields {
-			idx.addNode(f, base, scope)
+			idx.addNode(f, base, scope, sm)
 		}
 		for _, m := range v.Methods {
-			idx.addNode(m, base, scope)
+			idx.addNode(m, base, scope, sm)
 		}
 	case *ast.EnumDecl:
 		for _, g := range v.Generics {
-			idx.addNode(g, base, scope)
+			idx.addNode(g, base, scope, sm)
 		}
 		for _, variant := range v.Variants {
-			idx.addNode(variant, base, scope)
+			idx.addNode(variant, base, scope, sm)
 		}
 		for _, m := range v.Methods {
-			idx.addNode(m, base, scope)
+			idx.addNode(m, base, scope, sm)
 		}
 	case *ast.InterfaceDecl:
 		for _, g := range v.Generics {
-			idx.addNode(g, base, scope)
+			idx.addNode(g, base, scope, sm)
 		}
 		for _, sup := range v.Extends {
-			idx.addNode(sup, base, scope)
+			idx.addNode(sup, base, scope, sm)
 		}
 		for _, m := range v.Methods {
-			idx.addNode(m, base, scope)
+			idx.addNode(m, base, scope, sm)
 		}
 	case *ast.TypeAliasDecl:
 		for _, g := range v.Generics {
-			idx.addNode(g, base, scope)
+			idx.addNode(g, base, scope, sm)
 		}
-		if v.Target != nil {
-			idx.addNode(v.Target, base, scope)
-		}
+		idx.addNode(v.Target, base, scope, sm)
 	case *ast.LetDecl:
-		if v.Type != nil {
-			idx.addNode(v.Type, base, scope)
-		}
-		if v.Value != nil {
-			idx.addNode(v.Value, base, scope)
-		}
+		idx.addNode(v.Type, base, scope, sm)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.UseDecl:
 		for _, d := range v.GoBody {
-			idx.addNode(d, base, scope)
+			idx.addNode(d, base, scope, sm)
 		}
 	case *ast.Field:
-		if v.Type != nil {
-			idx.addNode(v.Type, base, scope)
-		}
-		if v.Default != nil {
-			idx.addNode(v.Default, base, scope)
-		}
+		idx.addNode(v.Type, base, scope, sm)
+		idx.addNode(v.Default, base, scope, sm)
 	case *ast.Variant:
 		for _, f := range v.Fields {
-			idx.addNode(f, base, scope)
+			idx.addNode(f, base, scope, sm)
 		}
 	case *ast.Param:
 		if haveKey && v.Name != "" {
 			idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: key, name: v.Name}, v)
 		}
-		if v.Pattern != nil {
-			idx.addNode(v.Pattern, base, scope)
-		}
-		if v.Type != nil {
-			idx.addNode(v.Type, base, scope)
-		}
-		if v.Default != nil {
-			idx.addNode(v.Default, base, scope)
-		}
+		idx.addNode(v.Pattern, base, scope, sm)
+		idx.addNode(v.Type, base, scope, sm)
+		idx.addNode(v.Default, base, scope, sm)
 	case *ast.GenericParam:
 		for _, con := range v.Constraints {
-			idx.addNode(con, base, scope)
+			idx.addNode(con, base, scope, sm)
 		}
 	case *ast.NamedType:
 		for _, a := range v.Args {
-			idx.addNode(a, base, scope)
+			idx.addNode(a, base, scope, sm)
 		}
 	case *ast.OptionalType:
-		idx.addNode(v.Inner, base, scope)
+		idx.addNode(v.Inner, base, scope, sm)
 	case *ast.TupleType:
 		for _, elem := range v.Elems {
-			idx.addNode(elem, base, scope)
+			idx.addNode(elem, base, scope, sm)
 		}
 	case *ast.FnType:
 		for _, p := range v.Params {
-			idx.addNode(p, base, scope)
+			idx.addNode(p, base, scope, sm)
 		}
-		if v.ReturnType != nil {
-			idx.addNode(v.ReturnType, base, scope)
-		}
+		idx.addNode(v.ReturnType, base, scope, sm)
 	case *ast.Block:
 		for _, s := range v.Stmts {
-			idx.addNode(s, base, scope)
+			idx.addNode(s, base, scope, sm)
 		}
 	case *ast.LetStmt:
 		if name := bindingPatternName(v.Pattern); name != "" {
-			if patKey, ok := spanKeyForNode(v.Pattern, base); ok {
+			if patKey, ok := spanKeyForNode(v.Pattern, base, sm); ok {
 				idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: patKey, name: name}, v)
 			}
 		}
-		if v.Pattern != nil {
-			idx.addNode(v.Pattern, base, scope)
-		}
-		if v.Type != nil {
-			idx.addNode(v.Type, base, scope)
-		}
-		if v.Value != nil {
-			idx.addNode(v.Value, base, scope)
-		}
+		idx.addNode(v.Pattern, base, scope, sm)
+		idx.addNode(v.Type, base, scope, sm)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.ExprStmt:
-		idx.addNode(v.X, base, scope)
+		idx.addNode(v.X, base, scope, sm)
 	case *ast.AssignStmt:
 		for _, t := range v.Targets {
-			idx.addNode(t, base, scope)
+			idx.addNode(t, base, scope, sm)
 		}
-		idx.addNode(v.Value, base, scope)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.ReturnStmt:
-		idx.addNode(v.Value, base, scope)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.ChanSendStmt:
-		idx.addNode(v.Channel, base, scope)
-		idx.addNode(v.Value, base, scope)
+		idx.addNode(v.Channel, base, scope, sm)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.DeferStmt:
-		idx.addNode(v.X, base, scope)
+		idx.addNode(v.X, base, scope, sm)
 	case *ast.ForStmt:
-		idx.addNode(v.Pattern, base, scope)
-		idx.addNode(v.Iter, base, scope)
-		idx.addNode(v.Body, base, scope)
+		idx.addNode(v.Pattern, base, scope, sm)
+		idx.addNode(v.Iter, base, scope, sm)
+		idx.addNode(v.Body, base, scope, sm)
 	case *ast.UnaryExpr:
-		idx.addNode(v.X, base, scope)
+		idx.addNode(v.X, base, scope, sm)
 	case *ast.BinaryExpr:
-		idx.addNode(v.Left, base, scope)
-		idx.addNode(v.Right, base, scope)
+		idx.addNode(v.Left, base, scope, sm)
+		idx.addNode(v.Right, base, scope, sm)
 	case *ast.QuestionExpr:
-		idx.addNode(v.X, base, scope)
+		idx.addNode(v.X, base, scope, sm)
 	case *ast.CallExpr:
-		idx.addNode(v.Fn, base, scope)
+		idx.addNode(v.Fn, base, scope, sm)
 		for _, a := range v.Args {
-			idx.addNode(a, base, scope)
+			idx.addNode(a, base, scope, sm)
 		}
 	case *ast.Arg:
-		idx.addNode(v.Value, base, scope)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.FieldExpr:
-		idx.addNode(v.X, base, scope)
+		idx.addNode(v.X, base, scope, sm)
 	case *ast.IndexExpr:
-		idx.addNode(v.X, base, scope)
-		idx.addNode(v.Index, base, scope)
+		idx.addNode(v.X, base, scope, sm)
+		idx.addNode(v.Index, base, scope, sm)
 	case *ast.TurbofishExpr:
-		idx.addNode(v.Base, base, scope)
+		idx.addNode(v.Base, base, scope, sm)
 		for _, a := range v.Args {
-			idx.addNode(a, base, scope)
+			idx.addNode(a, base, scope, sm)
 		}
 	case *ast.RangeExpr:
-		idx.addNode(v.Start, base, scope)
-		idx.addNode(v.Stop, base, scope)
+		idx.addNode(v.Start, base, scope, sm)
+		idx.addNode(v.Stop, base, scope, sm)
 	case *ast.ParenExpr:
-		idx.addNode(v.X, base, scope)
+		idx.addNode(v.X, base, scope, sm)
 	case *ast.TupleExpr:
 		for _, e := range v.Elems {
-			idx.addNode(e, base, scope)
+			idx.addNode(e, base, scope, sm)
 		}
 	case *ast.ListExpr:
 		for _, e := range v.Elems {
-			idx.addNode(e, base, scope)
+			idx.addNode(e, base, scope, sm)
 		}
 	case *ast.MapExpr:
 		for _, e := range v.Entries {
-			idx.addNode(e, base, scope)
+			idx.addNode(e, base, scope, sm)
 		}
 	case *ast.MapEntry:
-		idx.addNode(v.Key, base, scope)
-		idx.addNode(v.Value, base, scope)
+		idx.addNode(v.Key, base, scope, sm)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.StructLit:
-		idx.addNode(v.Type, base, scope)
+		idx.addNode(v.Type, base, scope, sm)
 		for _, f := range v.Fields {
-			idx.addNode(f, base, scope)
+			idx.addNode(f, base, scope, sm)
 		}
-		idx.addNode(v.Spread, base, scope)
+		idx.addNode(v.Spread, base, scope, sm)
 	case *ast.StructLitField:
-		idx.addNode(v.Value, base, scope)
+		idx.addNode(v.Value, base, scope, sm)
 	case *ast.IfExpr:
-		idx.addNode(v.Pattern, base, scope)
-		idx.addNode(v.Cond, base, scope)
-		idx.addNode(v.Then, base, scope)
-		idx.addNode(v.Else, base, scope)
+		idx.addNode(v.Pattern, base, scope, sm)
+		idx.addNode(v.Cond, base, scope, sm)
+		idx.addNode(v.Then, base, scope, sm)
+		idx.addNode(v.Else, base, scope, sm)
 	case *ast.MatchExpr:
-		idx.addNode(v.Scrutinee, base, scope)
+		idx.addNode(v.Scrutinee, base, scope, sm)
 		for _, a := range v.Arms {
-			idx.addNode(a, base, scope)
+			idx.addNode(a, base, scope, sm)
 		}
 	case *ast.MatchArm:
-		idx.addNode(v.Pattern, base, scope)
-		idx.addNode(v.Guard, base, scope)
-		idx.addNode(v.Body, base, scope)
+		idx.addNode(v.Pattern, base, scope, sm)
+		idx.addNode(v.Guard, base, scope, sm)
+		idx.addNode(v.Body, base, scope, sm)
 	case *ast.ClosureExpr:
 		for _, p := range v.Params {
-			idx.addNode(p, base, scope)
+			idx.addNode(p, base, scope, sm)
 		}
-		idx.addNode(v.ReturnType, base, scope)
-		idx.addNode(v.Body, base, scope)
+		idx.addNode(v.ReturnType, base, scope, sm)
+		idx.addNode(v.Body, base, scope, sm)
 	case *ast.LiteralPat:
-		idx.addNode(v.Literal, base, scope)
+		idx.addNode(v.Literal, base, scope, sm)
 	case *ast.IdentPat:
 		if haveKey && v.Name != "" {
 			idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: key, name: v.Name}, v)
 		}
 	case *ast.TuplePat:
 		for _, p := range v.Elems {
-			idx.addNode(p, base, scope)
+			idx.addNode(p, base, scope, sm)
 		}
 	case *ast.StructPat:
 		for _, f := range v.Fields {
-			idx.addNode(f, base, scope)
+			idx.addNode(f, base, scope, sm)
 		}
 	case *ast.StructPatField:
-		idx.addNode(v.Pattern, base, scope)
+		idx.addNode(v.Pattern, base, scope, sm)
 	case *ast.VariantPat:
 		for _, a := range v.Args {
-			idx.addNode(a, base, scope)
+			idx.addNode(a, base, scope, sm)
 		}
 	case *ast.RangePat:
-		idx.addNode(v.Start, base, scope)
-		idx.addNode(v.Stop, base, scope)
+		idx.addNode(v.Start, base, scope, sm)
+		idx.addNode(v.Stop, base, scope, sm)
 	case *ast.OrPat:
 		for _, a := range v.Alts {
-			idx.addNode(a, base, scope)
+			idx.addNode(a, base, scope, sm)
 		}
 	case *ast.BindingPat:
 		if haveKey && v.Name != "" {
 			idx.bindNode(selfhostNameSpanKey{selfhostSpanKey: key, name: v.Name}, v)
 		}
-		idx.addNode(v.Pattern, base, scope)
+		idx.addNode(v.Pattern, base, scope, sm)
 	}
 }
 
-func (idx *selfhostSpanIndex) addScopeSubtree(scope *resolve.Scope, base int) {
+func (idx *selfhostSpanIndex) addScopeSubtree(scope *resolve.Scope, base int, sm *sourcemap.Map) {
 	if scope == nil {
 		return
 	}
 	for _, sym := range scope.Symbols() {
-		idx.addSymbol(sym, base, scope)
+		idx.addSymbol(sym, base, scope, sm)
 	}
 	for _, child := range scope.Children() {
-		idx.addScopeSubtree(child, base)
+		idx.addScopeSubtree(child, base, sm)
 	}
 }
 
@@ -928,11 +901,11 @@ func selfhostExprKind(expr ast.Expr) string {
 	}
 }
 
-func (idx *selfhostSpanIndex) addSymbol(sym *resolve.Symbol, base int, scope *resolve.Scope) {
+func (idx *selfhostSpanIndex) addSymbol(sym *resolve.Symbol, base int, scope *resolve.Scope, sm *sourcemap.Map) {
 	if sym == nil || sym.Decl == nil || sym.Name == "" {
 		return
 	}
-	key, ok := spanKeyForNode(sym.Decl, base)
+	key, ok := spanKeyForNode(sym.Decl, base, sm)
 	if !ok {
 		return
 	}
@@ -942,7 +915,7 @@ func (idx *selfhostSpanIndex) addSymbol(sym *resolve.Symbol, base int, scope *re
 	}
 }
 
-func spanKeyForNode(n ast.Node, base int) (key selfhostSpanKey, ok bool) {
+func spanKeyForNode(n ast.Node, base int, sm *sourcemap.Map) (key selfhostSpanKey, ok bool) {
 	if n == nil {
 		return selfhostSpanKey{}, false
 	}
@@ -954,6 +927,15 @@ func spanKeyForNode(n ast.Node, base int) (key selfhostSpanKey, ok bool) {
 	}()
 	start := n.Pos().Offset
 	end := n.End().Offset
+	if sm != nil {
+		if generated, ok := sm.GeneratedSpanForOriginal(diag.Span{
+			Start: n.Pos(),
+			End:   n.End(),
+		}); ok {
+			start = generated.Start.Offset
+			end = generated.End.Offset
+		}
+	}
 	if end < start {
 		return selfhostSpanKey{}, false
 	}
@@ -1172,6 +1154,12 @@ func fileStartSpan(src []byte) diag.Span {
 }
 
 func selfhostFileSource(file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider) selfhostCheckedSource {
+	var canonicalMap *sourcemap.Map
+	if file != nil {
+		if canonicalSrc, sm := canonical.SourceWithMap(src, file); len(canonicalSrc) > 0 && bytes.Equal(canonicalSrc, src) {
+			canonicalMap = sm
+		}
+	}
 	var b bytes.Buffer
 	writeSelfhostImports(&b, nil, stdlib, fileUses(file))
 	if b.Len() > 0 {
@@ -1191,10 +1179,11 @@ func selfhostFileSource(file *ast.File, rr *resolve.Result, src []byte, stdlib r
 	return selfhostCheckedSource{
 		source: b.Bytes(),
 		files: []selfhostFileSegment{{
-			file:  file,
-			scope: scope,
-			refs:  refs,
-			base:  base,
+			file:      file,
+			scope:     scope,
+			refs:      refs,
+			base:      base,
+			sourceMap: canonicalMap,
 		}},
 	}
 }
@@ -1217,10 +1206,11 @@ func selfhostPackageSource(pkg *resolve.Package, ws *resolve.Workspace, stdlib r
 			b.WriteByte('\n')
 		}
 		files = append(files, selfhostFileSegment{
-			file:  pf.File,
-			scope: pf.FileScope,
-			refs:  pf.Refs,
-			base:  base,
+			file:      pf.File,
+			scope:     pf.FileScope,
+			refs:      pf.Refs,
+			base:      base,
+			sourceMap: pf.CanonicalMap,
 		})
 	}
 	return selfhostCheckedSource{source: b.Bytes(), files: files}

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -1,11 +1,13 @@
 package check
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
@@ -137,6 +139,44 @@ fn main() {}
 	}
 	if got := chk.LookupSymType(paramSym); got == nil || got.String() != "Int" {
 		t.Fatalf("unused param type = %v, want Int", got)
+	}
+}
+
+func TestNativeBoundaryOverlaysCanonicalSourceSpansBackToOriginalAST(t *testing.T) {
+	src := []byte(`func main() {
+    let xs = [1]
+    let n = len(xs)
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	mainDecl := file.Decls[0].(*ast.FnDecl)
+	letStmt := mainDecl.Body.Stmts[1].(*ast.LetStmt)
+	call := letStmt.Value.(*ast.CallExpr)
+
+	canonicalSrc, _ := canonical.SourceWithMap(src, file)
+	start := bytes.Index(canonicalSrc, []byte("xs.len()"))
+	if start < 0 {
+		t.Fatalf("canonical source = %q, want lowered xs.len()", canonicalSrc)
+	}
+	end := start + len("xs.len()")
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return fakeNativeChecker{result: nativeCheckResult{
+			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			TypedNodes: []nativeCheckedNode{
+				{Kind: "Call", TypeName: "Int", Start: start, End: end},
+			},
+		}}, ""
+	}
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: canonicalSrc, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	if got := chk.LookupType(call); got == nil || got.String() != "Int" {
+		t.Fatalf("call type = %v, want Int", got)
 	}
 }
 

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lexer"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/sourcemap"
 	"github.com/osty/osty/internal/token"
 )
 
@@ -52,7 +53,7 @@ func Source(src []byte) ([]byte, []*diag.Diagnostic, error) {
 			return nil, diags, fmt.Errorf("cannot format file with parse errors")
 		}
 	}
-	p := newPrinter(l.Comments())
+	p := newPrinter(l.Comments(), nil)
 	// Formatted output is within ~10% of input size for well-written
 	// code; preallocating avoids ~log2(N) buffer reallocations on large
 	// files.
@@ -64,12 +65,22 @@ func Source(src []byte) ([]byte, []*diag.Diagnostic, error) {
 // File prints an already-parsed AST using the canonical Osty printer without
 // reparsing or preserving source comments/trivia.
 func File(file *ast.File) []byte {
+	out, _ := FileWithMap(file)
+	return out
+}
+
+// FileWithMap prints an already-parsed AST and returns a coarse source map
+// from canonical output spans back to the original source spans carried on the
+// AST.
+func FileWithMap(file *ast.File) ([]byte, *sourcemap.Map) {
 	if file == nil {
-		return nil
+		return nil, nil
 	}
-	p := newPrinter(nil)
+	builder := sourcemap.NewBuilder()
+	p := newPrinter(nil, builder)
 	p.printFile(file)
-	return p.bytes()
+	out := p.bytes()
+	return out, builder.Build(out)
 }
 
 // printer is the mutable state carried through one formatting pass.
@@ -93,12 +104,17 @@ type printer struct {
 	// lastSrcLine is the highest original-source line already accounted
 	// for. Blank-line preservation uses a 2-line gap against this.
 	lastSrcLine int
+
+	// maps records coarse node-level output spans so canonical output can be
+	// projected back onto original source spans.
+	maps *sourcemap.Builder
 }
 
-func newPrinter(comments []token.Comment) *printer {
+func newPrinter(comments []token.Comment, maps *sourcemap.Builder) *printer {
 	return &printer{
 		comments:    comments,
 		atLineStart: true,
+		maps:        maps,
 	}
 }
 
@@ -122,6 +138,7 @@ type snapshot struct {
 	atLineStart bool
 	commentIdx  int
 	lastSrcLine int
+	mapLen      int
 }
 
 func (p *printer) snapshot() snapshot {
@@ -132,6 +149,7 @@ func (p *printer) snapshot() snapshot {
 		atLineStart: p.atLineStart,
 		commentIdx:  p.commentIdx,
 		lastSrcLine: p.lastSrcLine,
+		mapLen:      p.maps.Snapshot(),
 	}
 }
 
@@ -142,6 +160,7 @@ func (p *printer) restore(s snapshot) {
 	p.atLineStart = s.atLineStart
 	p.commentIdx = s.commentIdx
 	p.lastSrcLine = s.lastSrcLine
+	p.maps.Restore(s.mapLen)
 }
 
 // currentCol returns the rune offset of the cursor within the current
@@ -177,6 +196,41 @@ func (p *printer) write(s string) {
 		p.emitIndent()
 	}
 	p.buf.WriteString(s)
+}
+
+func (p *printer) currentOffset() int {
+	return p.buf.Len()
+}
+
+func (p *printer) materializeNodeStart() {
+	if p.pendingNL {
+		p.flushNL()
+	}
+	if p.atLineStart {
+		p.emitIndent()
+	}
+}
+
+func (p *printer) recordNode(kind string, span diag.Span, emit func()) {
+	if p == nil {
+		return
+	}
+	if p.maps == nil || (span.Start.Line == 0 && span.Start.Offset == 0 && span.End.Offset == 0) {
+		emit()
+		return
+	}
+	p.materializeNodeStart()
+	start := p.currentOffset()
+	emit()
+	end := p.currentOffset()
+	p.maps.Add(kind, start, end, span)
+}
+
+func spanOfNode(n ast.Node) diag.Span {
+	if n == nil {
+		return diag.Span{}
+	}
+	return diag.Span{Start: n.Pos(), End: n.End()}
 }
 
 // indentString returns the indent prefix for the given level, sliced

--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -20,92 +20,94 @@ func (p *printer) printFile(f *ast.File) {
 	if f == nil {
 		return
 	}
-	p.lastSrcLine = 0
-
-	firstBodyOffset := 1<<31 - 1
-	if len(f.Decls) > 0 {
-		firstBodyOffset = f.Decls[0].Pos().Offset
-	}
-	if len(f.Stmts) > 0 && f.Stmts[0].Pos().Offset < firstBodyOffset {
-		firstBodyOffset = f.Stmts[0].Pos().Offset
-	}
-
-	var topUses, bodyUses []*ast.UseDecl
-	for _, u := range f.Uses {
-		if u.Pos().Offset < firstBodyOffset {
-			topUses = append(topUses, u)
-		} else {
-			bodyUses = append(bodyUses, u)
-		}
-	}
-
-	// Stable sort so two uses that share a group+key stay in original
-	// relative order (matters only for FFI, where multiple imports
-	// with different bodies can't collide on key anyway).
-	sort.SliceStable(topUses, func(i, j int) bool {
-		gi, gj := useGroupOrder(topUses[i]), useGroupOrder(topUses[j])
-		if gi != gj {
-			return gi < gj
-		}
-		return useSortKey(topUses[i]) < useSortKey(topUses[j])
-	})
-
-	// Inside the reordered top-use block, blank lines are managed
-	// explicitly — between groups only. triviaBefore fires just for
-	// the first use so leading file-header comments attach; later
-	// uses bypass it to prevent source-line gaps from a reordered
-	// sequence injecting blanks in the middle of a group.
-	prevGroup := -1
-	for i, u := range topUses {
-		u := u
-		g := useGroupOrder(u)
-		if i == 0 {
-			p.triviaBefore(u.Pos())
-		} else if g != prevGroup {
-			p.blank()
-		}
-		p.printUseDecl(u)
-		prevGroup = g
-	}
-	if len(topUses) > 0 {
-		// Separator between the reordered use block and the body;
-		// reset lastSrcLine so body blank-line detection runs
-		// against body node positions, not stale use positions.
-		p.blank()
+	p.recordNode("file", spanOfNode(f), func() {
 		p.lastSrcLine = 0
-	}
 
-	// Interleave body uses + other decls + stmts by source offset.
-	type topNode struct {
-		pos  token.Pos
-		end  token.Pos
-		emit func()
-	}
-	nodes := make([]topNode, 0, len(bodyUses)+len(f.Decls)+len(f.Stmts))
-	for _, u := range bodyUses {
-		u := u
-		nodes = append(nodes, topNode{u.Pos(), u.End(), func() { p.printUseDecl(u) }})
-	}
-	for _, d := range f.Decls {
-		d := d
-		nodes = append(nodes, topNode{declLeadLinePos(d), d.End(), func() { p.printDecl(d) }})
-	}
-	for _, s := range f.Stmts {
-		s := s
-		nodes = append(nodes, topNode{s.Pos(), s.End(), func() { p.printStmt(s) }})
-	}
-	sort.SliceStable(nodes, func(i, j int) bool {
-		return nodes[i].pos.Offset < nodes[j].pos.Offset
+		firstBodyOffset := 1<<31 - 1
+		if len(f.Decls) > 0 {
+			firstBodyOffset = f.Decls[0].Pos().Offset
+		}
+		if len(f.Stmts) > 0 && f.Stmts[0].Pos().Offset < firstBodyOffset {
+			firstBodyOffset = f.Stmts[0].Pos().Offset
+		}
+
+		var topUses, bodyUses []*ast.UseDecl
+		for _, u := range f.Uses {
+			if u.Pos().Offset < firstBodyOffset {
+				topUses = append(topUses, u)
+			} else {
+				bodyUses = append(bodyUses, u)
+			}
+		}
+
+		// Stable sort so two uses that share a group+key stay in original
+		// relative order (matters only for FFI, where multiple imports
+		// with different bodies can't collide on key anyway).
+		sort.SliceStable(topUses, func(i, j int) bool {
+			gi, gj := useGroupOrder(topUses[i]), useGroupOrder(topUses[j])
+			if gi != gj {
+				return gi < gj
+			}
+			return useSortKey(topUses[i]) < useSortKey(topUses[j])
+		})
+
+		// Inside the reordered top-use block, blank lines are managed
+		// explicitly — between groups only. triviaBefore fires just for
+		// the first use so leading file-header comments attach; later
+		// uses bypass it to prevent source-line gaps from a reordered
+		// sequence injecting blanks in the middle of a group.
+		prevGroup := -1
+		for i, u := range topUses {
+			u := u
+			g := useGroupOrder(u)
+			if i == 0 {
+				p.triviaBefore(u.Pos())
+			} else if g != prevGroup {
+				p.blank()
+			}
+			p.printUseDecl(u)
+			prevGroup = g
+		}
+		if len(topUses) > 0 {
+			// Separator between the reordered use block and the body;
+			// reset lastSrcLine so body blank-line detection runs
+			// against body node positions, not stale use positions.
+			p.blank()
+			p.lastSrcLine = 0
+		}
+
+		// Interleave body uses + other decls + stmts by source offset.
+		type topNode struct {
+			pos  token.Pos
+			end  token.Pos
+			emit func()
+		}
+		nodes := make([]topNode, 0, len(bodyUses)+len(f.Decls)+len(f.Stmts))
+		for _, u := range bodyUses {
+			u := u
+			nodes = append(nodes, topNode{u.Pos(), u.End(), func() { p.printUseDecl(u) }})
+		}
+		for _, d := range f.Decls {
+			d := d
+			nodes = append(nodes, topNode{declLeadLinePos(d), d.End(), func() { p.printDecl(d) }})
+		}
+		for _, s := range f.Stmts {
+			s := s
+			nodes = append(nodes, topNode{s.Pos(), s.End(), func() { p.printStmt(s) }})
+		}
+		sort.SliceStable(nodes, func(i, j int) bool {
+			return nodes[i].pos.Offset < nodes[j].pos.Offset
+		})
+
+		for _, n := range nodes {
+			p.triviaBefore(n.pos)
+			n.emit()
+			p.markSrcLine(n.end.Line)
+		}
+		if p.pendingNL {
+			p.flushNL()
+		}
 	})
-
-	for _, n := range nodes {
-		p.triviaBefore(n.pos)
-		n.emit()
-		p.markSrcLine(n.end.Line)
-	}
-	if p.pendingNL {
-		p.flushNL()
-	}
 }
 
 // useGroupOrder bins a use decl into the canonical group order:
@@ -362,41 +364,43 @@ func (p *printer) printDecl(d ast.Decl) {
 }
 
 func (p *printer) printUseDecl(u *ast.UseDecl) {
-	p.write("use ")
-	if u.IsGoFFI {
-		p.write("go ")
-		p.write(fmt.Sprintf("%q", u.GoPath))
-	} else if u.IsRuntimeFFI {
-		if u.RawPath != "" {
-			p.write(u.RawPath)
-		} else {
-			p.write(strings.Join(u.Path, "."))
-		}
-	} else {
-		// Prefer RawPath when it contains path separators (preserves the
-		// `github.com/...` style); otherwise join the dotted path.
-		if u.RawPath != "" && strings.ContainsAny(u.RawPath, "/:") {
-			p.write(u.RawPath)
-		} else {
-			p.write(strings.Join(u.Path, "."))
-		}
-	}
-	if u.Alias != "" {
-		p.write(" as ")
-		p.write(u.Alias)
-	}
-	if u.IsFFI() && len(u.GoBody) > 0 {
-		p.printBracedBody(u.Pos().Line, false, func() {
-			for _, d := range u.GoBody {
-				p.triviaBefore(d.Pos())
-				p.printDecl(d)
-				p.markSrcLine(d.End().Line)
+	p.recordNode("decl", spanOfNode(u), func() {
+		p.write("use ")
+		if u.IsGoFFI {
+			p.write("go ")
+			p.write(fmt.Sprintf("%q", u.GoPath))
+		} else if u.IsRuntimeFFI {
+			if u.RawPath != "" {
+				p.write(u.RawPath)
+			} else {
+				p.write(strings.Join(u.Path, "."))
 			}
-		})
-		return
-	}
-	p.trailingCommentAfter(u.End().Line)
-	p.nl()
+		} else {
+			// Prefer RawPath when it contains path separators (preserves the
+			// `github.com/...` style); otherwise join the dotted path.
+			if u.RawPath != "" && strings.ContainsAny(u.RawPath, "/:") {
+				p.write(u.RawPath)
+			} else {
+				p.write(strings.Join(u.Path, "."))
+			}
+		}
+		if u.Alias != "" {
+			p.write(" as ")
+			p.write(u.Alias)
+		}
+		if u.IsFFI() && len(u.GoBody) > 0 {
+			p.printBracedBody(u.Pos().Line, false, func() {
+				for _, d := range u.GoBody {
+					p.triviaBefore(d.Pos())
+					p.printDecl(d)
+					p.markSrcLine(d.End().Line)
+				}
+			})
+			return
+		}
+		p.trailingCommentAfter(u.End().Line)
+		p.nl()
+	})
 }
 
 // printDocLines emits a "///"-prefixed block from a DocComment string.
@@ -441,49 +445,51 @@ func (p *printer) printAnnotation(a *ast.Annotation) {
 }
 
 func (p *printer) printFnDecl(f *ast.FnDecl) {
-	p.printDocAndAnnotations(f.DocComment, f.Annotations)
-	p.writePub(f.Pub)
-	p.write("fn ")
-	p.write(f.Name)
-	p.printGenerics(f.Generics)
-	// Unify receiver + params into a single list so the bracketed
-	// renderer gets one decision point (flat vs multi-line) that
-	// accounts for the whole signature — receiver included.
-	type paramItem struct {
-		isSelf  bool
-		mutSelf bool
-		param   *ast.Param
-	}
-	items := make([]paramItem, 0, len(f.Params)+1)
-	if f.Recv != nil {
-		items = append(items, paramItem{isSelf: true, mutSelf: f.Recv.Mut})
-	}
-	for _, prm := range f.Params {
-		items = append(items, paramItem{param: prm})
-	}
-	// Multi-line decision is driven by the parameter span (receiver
-	// alone never forces multi-line).
-	printBracketedList(p, "(", ")", items, spanMultiline(f.Params), func(it paramItem) {
-		if it.isSelf {
-			if it.mutSelf {
-				p.write("mut self")
-			} else {
-				p.write("self")
-			}
-			return
+	p.recordNode("decl", spanOfNode(f), func() {
+		p.printDocAndAnnotations(f.DocComment, f.Annotations)
+		p.writePub(f.Pub)
+		p.write("fn ")
+		p.write(f.Name)
+		p.printGenerics(f.Generics)
+		// Unify receiver + params into a single list so the bracketed
+		// renderer gets one decision point (flat vs multi-line) that
+		// accounts for the whole signature — receiver included.
+		type paramItem struct {
+			isSelf  bool
+			mutSelf bool
+			param   *ast.Param
 		}
-		p.printParam(it.param)
+		items := make([]paramItem, 0, len(f.Params)+1)
+		if f.Recv != nil {
+			items = append(items, paramItem{isSelf: true, mutSelf: f.Recv.Mut})
+		}
+		for _, prm := range f.Params {
+			items = append(items, paramItem{param: prm})
+		}
+		// Multi-line decision is driven by the parameter span (receiver
+		// alone never forces multi-line).
+		printBracketedList(p, "(", ")", items, spanMultiline(f.Params), func(it paramItem) {
+			if it.isSelf {
+				if it.mutSelf {
+					p.write("mut self")
+				} else {
+					p.write("self")
+				}
+				return
+			}
+			p.printParam(it.param)
+		})
+		if f.ReturnType != nil {
+			p.write(" -> ")
+			p.printType(f.ReturnType)
+		}
+		if f.Body != nil {
+			p.write(" ")
+			p.printBlock(f.Body)
+		}
+		// Body is nil for an interface-declared method without a default.
+		p.nl()
 	})
-	if f.ReturnType != nil {
-		p.write(" -> ")
-		p.printType(f.ReturnType)
-	}
-	if f.Body != nil {
-		p.write(" ")
-		p.printBlock(f.Body)
-	}
-	// Body is nil for an interface-declared method without a default.
-	p.nl()
 }
 
 func (p *printer) printGenerics(gs []*ast.GenericParam) {
@@ -505,38 +511,42 @@ func (p *printer) printGenerics(gs []*ast.GenericParam) {
 }
 
 func (p *printer) printParam(prm *ast.Param) {
-	if prm.Pattern != nil {
-		p.printPattern(prm.Pattern)
-	} else {
-		p.write(prm.Name)
-	}
-	if prm.Type != nil {
-		p.write(": ")
-		p.printType(prm.Type)
-	}
-	if prm.Default != nil {
-		p.write(" = ")
-		p.printExpr(prm.Default)
-	}
+	p.recordNode("param", spanOfNode(prm), func() {
+		if prm.Pattern != nil {
+			p.printPattern(prm.Pattern)
+		} else {
+			p.write(prm.Name)
+		}
+		if prm.Type != nil {
+			p.write(": ")
+			p.printType(prm.Type)
+		}
+		if prm.Default != nil {
+			p.write(" = ")
+			p.printExpr(prm.Default)
+		}
+	})
 }
 
 func (p *printer) printStructDecl(s *ast.StructDecl) {
-	p.printDocAndAnnotations(s.DocComment, s.Annotations)
-	p.writePub(s.Pub)
-	p.write("struct ")
-	p.write(s.Name)
-	p.printGenerics(s.Generics)
-	p.printBracedBody(s.Pos().Line, len(s.Fields) == 0 && len(s.Methods) == 0, func() {
-		for _, fld := range s.Fields {
-			p.triviaBefore(leadPos(fld.Pos(), fld.Annotations, ""))
-			p.printField(fld)
-			p.markSrcLine(fld.End().Line)
-		}
-		for _, m := range s.Methods {
-			p.triviaBefore(leadPos(m.Pos(), m.Annotations, m.DocComment))
-			p.printFnDecl(m)
-			p.markSrcLine(m.End().Line)
-		}
+	p.recordNode("decl", spanOfNode(s), func() {
+		p.printDocAndAnnotations(s.DocComment, s.Annotations)
+		p.writePub(s.Pub)
+		p.write("struct ")
+		p.write(s.Name)
+		p.printGenerics(s.Generics)
+		p.printBracedBody(s.Pos().Line, len(s.Fields) == 0 && len(s.Methods) == 0, func() {
+			for _, fld := range s.Fields {
+				p.triviaBefore(leadPos(fld.Pos(), fld.Annotations, ""))
+				p.printField(fld)
+				p.markSrcLine(fld.End().Line)
+			}
+			for _, m := range s.Methods {
+				p.triviaBefore(leadPos(m.Pos(), m.Annotations, m.DocComment))
+				p.printFnDecl(m)
+				p.markSrcLine(m.End().Line)
+			}
+		})
 	})
 }
 
@@ -597,110 +607,128 @@ func declLeadLinePos(d ast.Decl) token.Pos {
 }
 
 func (p *printer) printField(f *ast.Field) {
-	p.printDocAndAnnotations("", f.Annotations)
-	p.writePub(f.Pub)
-	p.write(f.Name)
-	p.write(": ")
-	p.printType(f.Type)
-	if f.Default != nil {
-		p.write(" = ")
-		p.printExpr(f.Default)
-	}
-	p.write(",")
-	p.trailingCommentAfter(f.End().Line)
-	p.nl()
+	p.recordNode("field", spanOfNode(f), func() {
+		p.printDocAndAnnotations("", f.Annotations)
+		p.writePub(f.Pub)
+		p.write(f.Name)
+		p.write(": ")
+		p.printType(f.Type)
+		if f.Default != nil {
+			p.write(" = ")
+			p.printExpr(f.Default)
+		}
+		p.write(",")
+		p.trailingCommentAfter(f.End().Line)
+		p.nl()
+	})
 }
 
 func (p *printer) printEnumDecl(e *ast.EnumDecl) {
-	p.printDocAndAnnotations(e.DocComment, e.Annotations)
-	p.writePub(e.Pub)
-	p.write("enum ")
-	p.write(e.Name)
-	p.printGenerics(e.Generics)
-	p.printBracedBody(e.Pos().Line, len(e.Variants) == 0 && len(e.Methods) == 0, func() {
-		for _, v := range e.Variants {
-			p.triviaBefore(leadPos(v.Pos(), v.Annotations, v.DocComment))
-			p.printVariant(v)
-			p.markSrcLine(v.End().Line)
-		}
-		for _, m := range e.Methods {
-			p.triviaBefore(leadPos(m.Pos(), m.Annotations, m.DocComment))
-			p.printFnDecl(m)
-			p.markSrcLine(m.End().Line)
-		}
+	p.recordNode("decl", spanOfNode(e), func() {
+		p.printDocAndAnnotations(e.DocComment, e.Annotations)
+		p.writePub(e.Pub)
+		p.write("enum ")
+		p.write(e.Name)
+		p.printGenerics(e.Generics)
+		p.printBracedBody(e.Pos().Line, len(e.Variants) == 0 && len(e.Methods) == 0, func() {
+			for _, v := range e.Variants {
+				p.triviaBefore(leadPos(v.Pos(), v.Annotations, v.DocComment))
+				p.printVariant(v)
+				p.markSrcLine(v.End().Line)
+			}
+			for _, m := range e.Methods {
+				p.triviaBefore(leadPos(m.Pos(), m.Annotations, m.DocComment))
+				p.printFnDecl(m)
+				p.markSrcLine(m.End().Line)
+			}
+		})
 	})
 }
 
 func (p *printer) printVariant(v *ast.Variant) {
-	p.printDocAndAnnotations(v.DocComment, v.Annotations)
-	p.write(v.Name)
-	if len(v.Fields) > 0 {
-		p.write("(")
-		for i, t := range v.Fields {
-			if i > 0 {
-				p.write(", ")
+	p.recordNode("variant", spanOfNode(v), func() {
+		p.printDocAndAnnotations(v.DocComment, v.Annotations)
+		p.write(v.Name)
+		if len(v.Fields) > 0 {
+			p.write("(")
+			for i, t := range v.Fields {
+				if i > 0 {
+					p.write(", ")
+				}
+				p.printType(t)
 			}
-			p.printType(t)
+			p.write(")")
 		}
-		p.write(")")
-	}
-	p.write(",")
-	p.trailingCommentAfter(v.End().Line)
-	p.nl()
+		p.write(",")
+		p.trailingCommentAfter(v.End().Line)
+		p.nl()
+	})
 }
 
 func (p *printer) printInterfaceDecl(i *ast.InterfaceDecl) {
-	p.printDocAndAnnotations(i.DocComment, i.Annotations)
-	p.writePub(i.Pub)
-	p.write("interface ")
-	p.write(i.Name)
-	p.printGenerics(i.Generics)
-	p.printBracedBody(i.Pos().Line, len(i.Extends) == 0 && len(i.Methods) == 0, func() {
-		for _, ext := range i.Extends {
-			p.triviaBefore(ext.Pos())
-			p.printType(ext)
-			p.nl()
-			p.markSrcLine(ext.End().Line)
-		}
-		for _, m := range i.Methods {
-			p.triviaBefore(leadPos(m.Pos(), m.Annotations, m.DocComment))
-			p.printFnDecl(m)
-			p.markSrcLine(m.End().Line)
-		}
+	p.recordNode("decl", spanOfNode(i), func() {
+		p.printDocAndAnnotations(i.DocComment, i.Annotations)
+		p.writePub(i.Pub)
+		p.write("interface ")
+		p.write(i.Name)
+		p.printGenerics(i.Generics)
+		p.printBracedBody(i.Pos().Line, len(i.Extends) == 0 && len(i.Methods) == 0, func() {
+			for _, ext := range i.Extends {
+				p.triviaBefore(ext.Pos())
+				p.printType(ext)
+				p.nl()
+				p.markSrcLine(ext.End().Line)
+			}
+			for _, m := range i.Methods {
+				p.triviaBefore(leadPos(m.Pos(), m.Annotations, m.DocComment))
+				p.printFnDecl(m)
+				p.markSrcLine(m.End().Line)
+			}
+		})
 	})
 }
 
 func (p *printer) printTypeAliasDecl(t *ast.TypeAliasDecl) {
-	p.printDocAndAnnotations(t.DocComment, t.Annotations)
-	p.writePub(t.Pub)
-	p.write("type ")
-	p.write(t.Name)
-	p.printGenerics(t.Generics)
-	p.write(" = ")
-	p.printType(t.Target)
-	p.nl()
+	p.recordNode("decl", spanOfNode(t), func() {
+		p.printDocAndAnnotations(t.DocComment, t.Annotations)
+		p.writePub(t.Pub)
+		p.write("type ")
+		p.write(t.Name)
+		p.printGenerics(t.Generics)
+		p.write(" = ")
+		p.printType(t.Target)
+		p.nl()
+	})
 }
 
 func (p *printer) printLetDecl(l *ast.LetDecl) {
-	p.printDocAndAnnotations(l.DocComment, l.Annotations)
-	p.writePub(l.Pub)
-	p.write("let ")
-	if l.Mut {
-		p.write("mut ")
-	}
-	p.write(l.Name)
-	if l.Type != nil {
-		p.write(": ")
-		p.printType(l.Type)
-	}
-	if l.Value != nil {
-		p.write(" = ")
-		p.printExpr(l.Value)
-	}
-	p.nl()
+	p.recordNode("decl", spanOfNode(l), func() {
+		p.printDocAndAnnotations(l.DocComment, l.Annotations)
+		p.writePub(l.Pub)
+		p.write("let ")
+		if l.Mut {
+			p.write("mut ")
+		}
+		p.write(l.Name)
+		if l.Type != nil {
+			p.write(": ")
+			p.printType(l.Type)
+		}
+		if l.Value != nil {
+			p.write(" = ")
+			p.printExpr(l.Value)
+		}
+		p.nl()
+	})
 }
 
 func (p *printer) printType(t ast.Type) {
+	p.recordNode("type", spanOfNode(t), func() {
+		p.printTypeInner(t)
+	})
+}
+
+func (p *printer) printTypeInner(t ast.Type) {
 	switch n := t.(type) {
 	case *ast.NamedType:
 		// Spec §2.5 / §13.3: formatter rewrites Option<T> into T?.
@@ -756,6 +784,12 @@ func (p *printer) printType(t ast.Type) {
 }
 
 func (p *printer) printStmt(s ast.Stmt) {
+	p.recordNode("stmt", spanOfNode(s), func() {
+		p.printStmtInner(s)
+	})
+}
+
+func (p *printer) printStmtInner(s ast.Stmt) {
 	switch n := s.(type) {
 	case *ast.Block:
 		p.printBlock(n)
@@ -825,21 +859,23 @@ func (p *printer) printStmt(s ast.Stmt) {
 }
 
 func (p *printer) printBlock(b *ast.Block) {
-	if b == nil || len(b.Stmts) == 0 {
-		p.write("{}")
-		return
-	}
-	p.write("{")
-	p.nl()
-	p.indent()
-	p.lastSrcLine = b.Pos().Line
-	for _, s := range b.Stmts {
-		p.triviaBefore(s.Pos())
-		p.printStmt(s)
-		p.markSrcLine(s.End().Line)
-	}
-	p.dedent()
-	p.write("}")
+	p.recordNode("block", spanOfNode(b), func() {
+		if b == nil || len(b.Stmts) == 0 {
+			p.write("{}")
+			return
+		}
+		p.write("{")
+		p.nl()
+		p.indent()
+		p.lastSrcLine = b.Pos().Line
+		for _, s := range b.Stmts {
+			p.triviaBefore(s.Pos())
+			p.printStmt(s)
+			p.markSrcLine(s.End().Line)
+		}
+		p.dedent()
+		p.write("}")
+	})
 }
 
 func (p *printer) printForStmt(n *ast.ForStmt) {
@@ -864,6 +900,12 @@ func (p *printer) printForStmt(n *ast.ForStmt) {
 }
 
 func (p *printer) printExpr(e ast.Expr) {
+	p.recordNode("expr", spanOfNode(e), func() {
+		p.printExprInner(e)
+	})
+}
+
+func (p *printer) printExprInner(e ast.Expr) {
 	switch n := e.(type) {
 	case *ast.Ident:
 		p.write(n.Name)
@@ -1281,6 +1323,12 @@ func (p *printer) printClosure(c *ast.ClosureExpr) {
 }
 
 func (p *printer) printPattern(pat ast.Pattern) {
+	p.recordNode("pattern", spanOfNode(pat), func() {
+		p.printPatternInner(pat)
+	})
+}
+
+func (p *printer) printPatternInner(pat ast.Pattern) {
 	switch n := pat.(type) {
 	case *ast.WildcardPat:
 		p.write("_")

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -299,6 +299,7 @@ type docAnalysis struct {
 	lines      *lineIndex
 	file       *ast.File
 	provenance *parser.Provenance
+	canonical  []byte
 	resolve    *resolve.Result
 	check      *check.Result
 	// lint is the lint pass output (may be nil if the pipeline
@@ -556,8 +557,10 @@ func substituteFileSource(pkg *resolve.Package, path string, src []byte) bool {
 			continue
 		}
 		parsed := parser.ParseDetailed(src)
+		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
 		pf.Source = src
-		pf.CanonicalSource = canonical.Source(src, parsed.File)
+		pf.CanonicalSource = canonicalSrc
+		pf.CanonicalMap = canonicalMap
 		pf.File = parsed.File
 		pf.ParseDiags = parsed.Diagnostics
 		pf.ParseProvenance = parsed.Provenance
@@ -597,6 +600,7 @@ func analysisForFileInPackage(
 		lines:      newLineIndex(src),
 		file:       pf.File,
 		provenance: pf.ParseProvenance,
+		canonical:  pf.CanonicalSource,
 		resolve:    fileRes,
 		check:      chk,
 		lint:       lr,
@@ -667,7 +671,8 @@ func diagBelongsToFile(d *diag.Diagnostic, pf *resolve.PackageFile) bool {
 func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
 	parsed := parser.ParseDetailed(src)
 	res := resolve.File(parsed.File, s.prelude)
-	chk := check.File(parsed.File, res, lspCheckOpts(canonical.Source(src, parsed.File)))
+	canonicalSrc, _ := canonical.SourceWithMap(src, parsed.File)
+	chk := check.File(parsed.File, res, lspCheckOpts(canonicalSrc))
 	lr := lint.File(parsed.File, res, chk)
 	all := make([]*diag.Diagnostic, 0,
 		len(parsed.Diagnostics)+len(res.Diags)+len(chk.Diags)+len(lr.Diags))
@@ -679,6 +684,7 @@ func (s *Server) analyzeSingleFile(src []byte) *docAnalysis {
 		lines:      newLineIndex(src),
 		file:       parsed.File,
 		provenance: parsed.Provenance,
+		canonical:  canonicalSrc,
 		resolve:    res,
 		check:      chk,
 		lint:       lr,
@@ -720,6 +726,7 @@ func (s *Server) analyzeSingleFileViaEngine(uri string, src []byte) *docAnalysis
 		lines:      newLineIndex(src),
 		file:       pr.File,
 		provenance: pr.Provenance,
+		canonical:  pr.CanonicalSource,
 		resolve:    rr,
 		check:      chk,
 		lint:       lr,

--- a/internal/query/osty/queries.go
+++ b/internal/query/osty/queries.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/query"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/sourcemap"
 )
 
 // ---- Value types ----
@@ -20,6 +21,7 @@ import (
 type ParseResult struct {
 	Source          []byte
 	CanonicalSource []byte
+	CanonicalMap    *sourcemap.Map
 	File            *ast.File
 	Diags           []*diag.Diagnostic
 	Provenance      *parser.Provenance
@@ -123,9 +125,11 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 		func(ctx *query.Ctx, path string) ParseResult {
 			src := inp.SourceText.Fetch(ctx, path)
 			parsed := parser.ParseDetailed(src)
+			canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
 			return ParseResult{
 				Source:          src,
-				CanonicalSource: canonical.Source(src, parsed.File),
+				CanonicalSource: canonicalSrc,
+				CanonicalMap:    canonicalMap,
 				File:            parsed.File,
 				Diags:           parsed.Diagnostics,
 				Provenance:      parsed.Provenance,
@@ -153,6 +157,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 					Path:            f,
 					Source:          pr.Source,
 					CanonicalSource: pr.CanonicalSource,
+					CanonicalMap:    pr.CanonicalMap,
 					File:            pr.File,
 					ParseDiags:      pr.Diags,
 					ParseProvenance: pr.Provenance,
@@ -180,6 +185,7 @@ func registerQueries(db *query.Database, inp Inputs) Queries {
 					Path:            pf.Path,
 					Source:          pf.Source,
 					CanonicalSource: pf.CanonicalSource,
+					CanonicalMap:    pf.CanonicalMap,
 					File:            pf.File,
 					ParseDiags:      pf.ParseDiags,
 					ParseProvenance: pf.ParseProvenance,

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -99,10 +99,12 @@ func loadPackagePaths(paths []string, dir, name string, transform SourceTransfor
 			src = transform(p, src)
 		}
 		parsed := parser.ParseDetailed(src)
+		canonicalSrc, canonicalMap := canonical.SourceWithMap(src, parsed.File)
 		pkg.Files = append(pkg.Files, &PackageFile{
 			Path:            p,
 			Source:          src,
-			CanonicalSource: canonical.Source(src, parsed.File),
+			CanonicalSource: canonicalSrc,
+			CanonicalMap:    canonicalMap,
 			File:            parsed.File,
 			ParseDiags:      parsed.Diagnostics,
 			ParseProvenance: parsed.Provenance,

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -4,6 +4,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/sourcemap"
 )
 
 // Package is the resolver's view of one Osty package — i.e. one directory
@@ -52,6 +53,10 @@ type PackageFile struct {
 	// the parsed AST after parser-owned normalization/lowering. When empty,
 	// callers should fall back to Source.
 	CanonicalSource []byte
+	// CanonicalMap projects canonical source spans back onto the original source
+	// spans carried by the parsed AST. Nil when the canonical source is a direct
+	// passthrough or no map was produced.
+	CanonicalMap *sourcemap.Map
 	// File is the parsed AST. Never nil, even when Parse reported errors;
 	// best-effort partial trees support multi-error reporting.
 	File *ast.File

--- a/internal/sourcemap/map.go
+++ b/internal/sourcemap/map.go
@@ -1,0 +1,303 @@
+package sourcemap
+
+import (
+	"sort"
+	"unicode/utf8"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/token"
+)
+
+// Entry links one generated canonical source span back to the original source
+// span that produced it.
+type Entry struct {
+	Kind      string
+	Generated diag.Span
+	Original  diag.Span
+}
+
+// Map stores a coarse bidirectional mapping between canonical source emitted by
+// the formatter and the original spans carried on the AST.
+type Map struct {
+	entries []Entry
+}
+
+// Empty reports whether the map carries any span mappings.
+func (m *Map) Empty() bool {
+	return m == nil || len(m.entries) == 0
+}
+
+// Entries returns a read-only view of the stored mappings.
+func (m *Map) Entries() []Entry {
+	if m == nil {
+		return nil
+	}
+	return m.entries
+}
+
+// RemapSpan projects a canonical/generated span back onto the original source.
+func (m *Map) RemapSpan(span diag.Span) (diag.Span, bool) {
+	entry := m.entryForGenerated(span.Start.Offset, span.End.Offset)
+	if entry == nil {
+		return diag.Span{}, false
+	}
+	return entry.Original, true
+}
+
+// GeneratedSpanForOriginal projects an original AST/source span into the
+// canonical/generated source.
+func (m *Map) GeneratedSpanForOriginal(span diag.Span) (diag.Span, bool) {
+	entry := m.entryForOriginal(span.Start.Offset, span.End.Offset)
+	if entry == nil {
+		return diag.Span{}, false
+	}
+	return entry.Generated, true
+}
+
+// RemapDiagnostic returns a deep-cloned diagnostic whose spans and structured
+// suggestions are projected back into the original source wherever possible.
+func (m *Map) RemapDiagnostic(in *diag.Diagnostic) *diag.Diagnostic {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if len(in.Spans) > 0 {
+		out.Spans = make([]diag.LabeledSpan, len(in.Spans))
+		for i, sp := range in.Spans {
+			out.Spans[i] = sp
+			if remapped, ok := m.RemapSpan(sp.Span); ok {
+				out.Spans[i].Span = remapped
+			}
+		}
+	}
+	if len(in.Suggestions) > 0 {
+		out.Suggestions = make([]diag.Suggestion, len(in.Suggestions))
+		for i, sg := range in.Suggestions {
+			out.Suggestions[i] = sg
+			if remapped, ok := m.RemapSpan(sg.Span); ok {
+				out.Suggestions[i].Span = remapped
+			}
+			if sg.CopyFrom != nil {
+				copied := *sg.CopyFrom
+				if remapped, ok := m.RemapSpan(copied); ok {
+					copied = remapped
+				}
+				out.Suggestions[i].CopyFrom = &copied
+			}
+		}
+	}
+	return &out
+}
+
+// RemapDiagnostics clones and remaps every diagnostic in the slice.
+func (m *Map) RemapDiagnostics(in []*diag.Diagnostic) []*diag.Diagnostic {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*diag.Diagnostic, 0, len(in))
+	for _, d := range in {
+		out = append(out, m.RemapDiagnostic(d))
+	}
+	return out
+}
+
+func (m *Map) entryForGenerated(start, end int) *Entry {
+	if m == nil {
+		return nil
+	}
+	if end < start {
+		end = start
+	}
+	var best *Entry
+	bestSize := int(^uint(0) >> 1)
+	for i := range m.entries {
+		entry := &m.entries[i]
+		es := entry.Generated.Start.Offset
+		ee := entry.Generated.End.Offset
+		if ee < es {
+			ee = es
+		}
+		if start < es || end > ee {
+			continue
+		}
+		size := ee - es
+		if start == es && end == ee {
+			if best == nil || best.Generated.Start.Offset != start || best.Generated.End.Offset != end || size < bestSize {
+				best = entry
+				bestSize = size
+			}
+			continue
+		}
+		if size < bestSize {
+			best = entry
+			bestSize = size
+		}
+	}
+	return best
+}
+
+func (m *Map) entryForOriginal(start, end int) *Entry {
+	if m == nil {
+		return nil
+	}
+	if end < start {
+		end = start
+	}
+	var best *Entry
+	bestSize := int(^uint(0) >> 1)
+	for i := range m.entries {
+		entry := &m.entries[i]
+		os := entry.Original.Start.Offset
+		oe := entry.Original.End.Offset
+		if oe < os {
+			oe = os
+		}
+		if start < os || end > oe {
+			continue
+		}
+		size := oe - os
+		if start == os && end == oe {
+			generatedSize := entry.Generated.End.Offset - entry.Generated.Start.Offset
+			bestGeneratedSize := -1
+			if best != nil {
+				bestGeneratedSize = best.Generated.End.Offset - best.Generated.Start.Offset
+			}
+			if best == nil ||
+				best.Original.Start.Offset != start ||
+				best.Original.End.Offset != end ||
+				generatedSize > bestGeneratedSize ||
+				(generatedSize == bestGeneratedSize && size < bestSize) {
+				best = entry
+				bestSize = size
+			}
+			continue
+		}
+		if size < bestSize {
+			best = entry
+			bestSize = size
+		}
+	}
+	return best
+}
+
+type rawEntry struct {
+	kind          string
+	generatedFrom int
+	generatedTo   int
+	original      diag.Span
+}
+
+// Builder accumulates mappings while canonical source is being emitted.
+type Builder struct {
+	entries []rawEntry
+}
+
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) Snapshot() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.entries)
+}
+
+func (b *Builder) Restore(n int) {
+	if b == nil {
+		return
+	}
+	if n < 0 {
+		n = 0
+	}
+	if n > len(b.entries) {
+		n = len(b.entries)
+	}
+	b.entries = b.entries[:n]
+}
+
+// Add records one emitted canonical range and the original span that produced
+// it.
+func (b *Builder) Add(kind string, generatedStart, generatedEnd int, original diag.Span) {
+	if b == nil {
+		return
+	}
+	if original.Start.Line == 0 && original.Start.Offset == 0 && original.End.Offset == 0 {
+		return
+	}
+	if generatedStart < 0 {
+		generatedStart = 0
+	}
+	if generatedEnd < generatedStart {
+		generatedEnd = generatedStart
+	}
+	if original.End.Offset < original.Start.Offset {
+		original.End = original.Start
+	}
+	b.entries = append(b.entries, rawEntry{
+		kind:          kind,
+		generatedFrom: generatedStart,
+		generatedTo:   generatedEnd,
+		original:      original,
+	})
+}
+
+// Build finalizes the map for the given generated canonical source.
+func (b *Builder) Build(generated []byte) *Map {
+	if b == nil || len(b.entries) == 0 {
+		return nil
+	}
+	lineStarts := computeLineStarts(generated)
+	out := &Map{
+		entries: make([]Entry, 0, len(b.entries)),
+	}
+	for _, entry := range b.entries {
+		out.entries = append(out.entries, Entry{
+			Kind: entry.kind,
+			Generated: diag.Span{
+				Start: posForOffset(generated, lineStarts, entry.generatedFrom),
+				End:   posForOffset(generated, lineStarts, entry.generatedTo),
+			},
+			Original: entry.original,
+		})
+	}
+	return out
+}
+
+func computeLineStarts(src []byte) []int {
+	lines := []int{0}
+	for i := 0; i < len(src); i++ {
+		switch src[i] {
+		case '\n':
+			lines = append(lines, i+1)
+		case '\r':
+			if i+1 < len(src) && src[i+1] == '\n' {
+				i++
+			}
+			lines = append(lines, i+1)
+		}
+	}
+	return lines
+}
+
+func posForOffset(src []byte, lineStarts []int, off int) token.Pos {
+	if off < 0 {
+		off = 0
+	}
+	if off > len(src) {
+		off = len(src)
+	}
+	line := sort.Search(len(lineStarts), func(i int) bool {
+		return lineStarts[i] > off
+	}) - 1
+	if line < 0 {
+		line = 0
+	}
+	lineStart := lineStarts[line]
+	column := 1 + utf8.RuneCount(src[lineStart:off])
+	return token.Pos{
+		Offset: off,
+		Line:   line + 1,
+		Column: column,
+	}
+}


### PR DESCRIPTION
## Summary
- add coarse canonical source maps while printing canonical Osty output
- thread canonical maps through package/query/LSP data so canonicalized files keep provenance
- use the map in native checker overlay matching and add focused tests for canonical remapping

## Testing
- go test ./internal/canonical ./internal/check
- go test ./internal/query/osty ./internal/resolve -run '^$'
- go test ./internal/lsp -run '^$'
- go test ./cmd/osty -run '^$'
- go test ./internal/sourcemap -run '^$'