### PR TITLE
feat: default LLVM IR emission to MIR path

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -66,13 +66,13 @@ source
   → ir.Validate      (HIR invariants)
   → mir.Lower        (HIR → MIR)              ⟵ Stage 1 landed
   → mir.Validate     (MIR invariants)         ⟵ Stage 1 landed
-  → backend dispatch (Stage 3):
+  → backend dispatch (Stage 4 partial default):
       if Options.UseMIR && Entry.MIR != nil:
         llvmgen.GenerateFromMIR(Entry.MIR, opts)
         └── on ErrUnsupported, falls back to HIR path
       else:
         llvmgen.GenerateModule(Entry.IR, opts)
-        └── legacy HIR→AST bridge (the default until Stage 4)
+        └── legacy HIR→AST bridge (explicit opt-out / fallback path)
 ```
 
 MIR lowering runs *after* monomorphisation: every `TypeVar` is gone,
@@ -672,8 +672,8 @@ MIR tests isolated from front-end churn.
   overlaps with the deferred closure-to-SSA story. They fall
   through to the ordinary `CallInstr` path for now.
 
-- **Stage 3 (landed — MVP).** Introduces an opt-in MIR-direct path
-  through `internal/llvmgen`.
+- **Stage 3 (landed — MVP).** Introduces a MIR-direct path through
+  `internal/llvmgen`.
 
   - **`backend.PrepareEntry` produces MIR.** `Entry` grows `MIR
     *mir.Module` and `MIRIssues []error` fields alongside the existing
@@ -681,18 +681,20 @@ MIR tests isolated from front-end churn.
     pipeline calls `mir.Lower` on the monomorphic HIR and runs
     `mir.Validate` on the result. MIR issues are collected as
     warnings rather than blocking the dispatch — the HIR path remains
-    authoritative until Stage 4 flips the default.
+    authoritative while the MIR emitter grows to parity.
   - **`llvmgen.GenerateFromMIR(m, opts)`** is the new public entry
     point. It consumes a `*mir.Module` directly (no HIR→AST bridge)
     and emits textual LLVM IR via an alloca-per-local SSA scheme
     (LLVM's mem2reg pass promotes to register form during opt).
-  - **Option gate.** `llvmgen.Options.UseMIR` selects the path.
-    The backend dispatcher (`internal/backend/llvm.go`) flips the
-    option on when the request carries `--feature mir-backend` and
-    routes to `GenerateFromMIR(entry.MIR, opts)`. On `ErrUnsupported`
-    the dispatcher catches the sentinel and falls back to the legacy
-    `GenerateModule(entry.IR, opts)` path so coverage regressions
-    are impossible until parity lands.
+  - **Dispatcher gate.** `llvmgen.Options.UseMIR` selects the path.
+    The backend dispatcher (`internal/backend/llvm.go`) now prefers
+    `GenerateFromMIR(entry.MIR, opts)` by default on raw `llvm-ir`
+    emission, lets requests opt back into the legacy bridge with the
+    `legacy-llvmgen` feature, and still allows explicit opt-in on
+    object/binary emission via `mir-backend`. On `ErrUnsupported` the
+    dispatcher catches the sentinel and falls back to
+    `GenerateModule(entry.IR, opts)` automatically, so coverage
+    regressions are impossible while parity lands.
   - **MVP coverage.** Primitive types (Int / UInt / Byte / Bool /
     Char / Float{32,64} / String / Unit), functions with primitive
     params + return types, `Assign` with Use/Unary/Binary/Const
@@ -711,9 +713,12 @@ MIR tests isolated from front-end churn.
     `GenerateFromMIR` with `ErrUnsupported` and accepted by the
     legacy path.
 
-- **Stage 4.** Flip the default at `GenerateModule` to the MIR path
-  once parity is green on the full corpus. Keep the legacy bridge
-  callable under a fallback flag.
+- **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
+  backend now prefers the MIR-direct emitter by default for raw
+  `llvm-ir` output. The legacy HIR→AST bridge remains callable under
+  the `legacy-llvmgen` feature, object/binary emission can still opt in
+  explicitly with `mir-backend`, and the dispatcher falls back
+  automatically on `ErrUnsupported`.
 
 - **Stage 5.** Remove `legacyFileFromModule` and the AST-driven
   emitter. `internal/llvmgen` now speaks only MIR. Future backends

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -56,17 +56,18 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 		PackageName: req.Entry.PackageName,
 		SourcePath:  req.Entry.SourcePath,
 		Target:      req.Layout.Target,
-		UseMIR:      featureEnabled(req.Features, "mir-backend"),
+		UseMIR:      useMIRBackend(req.Features, req.Emit),
 	}
 	// IR is the sole input contract. The backend dispatcher never reaches
 	// for req.Entry.File — the AST is a front-end artifact that the LLVM
 	// backend does not consume directly any more.
 	//
-	// When the request opts into Stage 3 MIR emission (`--feature
-	// mir-backend`), route through the MIR-direct path if the entry
-	// carries a MIR module. Otherwise, and on MIR-emitter refusal, fall
-	// back to the legacy HIR→AST bridge so coverage stays identical to
-	// before the opt-in flag existed.
+	// MIR-first dispatch now defaults on the raw `llvm-ir` emission
+	// path. Requests can opt back into the legacy HIR→AST bridge with
+	// the `legacy-llvmgen` feature, or opt further in with
+	// `mir-backend` on object/binary emission while parity continues to
+	// grow. On MIR-emitter refusal we still fall back automatically, so
+	// enabling the new path cannot reduce coverage.
 	var (
 		irOut  []byte
 		genErr error
@@ -194,8 +195,7 @@ func runClang(ctx context.Context, action string, args []string) error {
 }
 
 // featureEnabled reports whether `name` appears in the features
-// slice. Used by the LLVM backend to check opt-in flags like
-// "mir-backend".
+// slice.
 func featureEnabled(features []string, name string) bool {
 	for _, f := range features {
 		if f == name {
@@ -203,4 +203,19 @@ func featureEnabled(features []string, name string) bool {
 		}
 	}
 	return false
+}
+
+// useMIRBackend reports whether LLVM emission should prefer the
+// MIR-direct path. Raw `llvm-ir` emission is MIR-first by default;
+// callers can opt back into the legacy HIR→AST bridge with the
+// `legacy-llvmgen` feature, or opt further in on object/binary
+// emission with `mir-backend` while parity stabilizes.
+func useMIRBackend(features []string, emit EmitMode) bool {
+	if featureEnabled(features, "legacy-llvmgen") {
+		return false
+	}
+	if featureEnabled(features, "mir-backend") {
+		return true
+	}
+	return emit == EmitLLVMIR
 }

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -229,10 +229,33 @@ func TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
 	}
-	for _, want := range []string{"for.cond", "@printf"} {
-		if !strings.Contains(string(data), want) {
-			t.Fatalf("IR-only backend output missing %q:\n%s", want, data)
-		}
+	got := string(data)
+	if !strings.Contains(got, "@printf") {
+		t.Fatalf("IR-only backend output missing %q:\n%s", "@printf", got)
+	}
+	if !strings.Contains(got, "for.cond") && !strings.Contains(got, "bb1:") {
+		t.Fatalf("IR-only backend output missing loop label from either legacy or MIR path:\n%s", got)
+	}
+}
+
+func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
+	if !useMIRBackend(nil, EmitLLVMIR) {
+		t.Fatal("useMIRBackend(nil, EmitLLVMIR) = false, want true")
+	}
+	if useMIRBackend(nil, EmitBinary) {
+		t.Fatal("useMIRBackend(nil, EmitBinary) = true, want false")
+	}
+	if !useMIRBackend([]string{"mir-backend"}, EmitBinary) {
+		t.Fatal("useMIRBackend(mir-backend, EmitBinary) = false, want true")
+	}
+}
+
+func TestUseMIRBackendLegacyFeatureDisables(t *testing.T) {
+	if useMIRBackend([]string{"legacy-llvmgen"}, EmitLLVMIR) {
+		t.Fatal("useMIRBackend(legacy-llvmgen, EmitLLVMIR) = true, want false")
+	}
+	if useMIRBackend([]string{"mir-backend", "legacy-llvmgen"}, EmitBinary) {
+		t.Fatal("legacy-llvmgen should win when both features are present")
 	}
 }
 

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -15,7 +15,7 @@
 //   - runtime_ffi.go     — Osty runtime C ABI surface + symbol tables
 //   - ir_module.go       — IR → AST bridge (transitional; see doc.go)
 //   - support_snapshot.go — Osty-authored `llvm*` helpers (hand-maintained
-//                          snapshot of toolchain/llvmgen.osty)
+//     snapshot of toolchain/llvmgen.osty)
 //
 // Keep this file small: it is the contract with external callers.
 package llvmgen
@@ -36,12 +36,11 @@ var ErrUnsupported = errors.New("llvmgen: unsupported source shape")
 
 // Options configures textual LLVM IR emission.
 //
-// UseMIR opts into the Stage 3 MIR-direct emitter. When true,
-// GenerateModule dispatches to GenerateFromMIR (using the caller-
-// prepared MIR module on the Entry); when false, the legacy HIR→AST
-// bridge path is taken. The flag is false by default so existing
-// callers stay on the proven path while the MIR emitter grows to
-// parity.
+// UseMIR selects the MIR-direct emitter. The LLVM backend now enables
+// it by default and falls back automatically on ErrUnsupported; direct
+// callers can still leave the zero value to stay on the legacy
+// HIR→AST bridge or set it explicitly when running dual-emission
+// tests.
 type Options struct {
 	PackageName string
 	SourcePath  string


### PR DESCRIPTION
## Summary
- prefer the MIR-direct LLVM emitter by default for raw `llvm-ir` emission
- keep `legacy-llvmgen` as an explicit opt-out and preserve automatic fallback on `ErrUnsupported`
- document the partial Stage 4 flip and add backend tests for the new dispatch policy

## Why
We tried flipping MIR as the default backend path more broadly, but object/binary emission still shows real regressions in managed and mut-receiver cases. This change moves the safe part of Stage 4 forward now: `llvm-ir` generation becomes MIR-first, while executable paths stay conservative unless callers opt in with `mir-backend`.

## Validation
- `go test -count=1 ./internal/backend -run 'TestUseMIRBackend|TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback|TestLLVMBackendBinaryRunsBreakAndContinueLoops|TestLLVMBackendBinaryRunsBitwiseIntOps'`
- `go test -count=1 ./internal/llvmgen -run 'TestGenerateFromMIRConstReturn|TestGenerateFromMIRIfBranch|TestMIRDualEmitFromSource|TestMIRDualEmitGracefulFallback'`

## Notes
- full `./internal/backend` still has existing MIR/runtime gaps on managed binary paths, so this keeps the flip scoped to raw IR output for now.
