### PR TITLE
feat(mir): stage 3.4 — non-capturing closures + indirect call in MIR-direct emitter

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -794,6 +794,28 @@ MIR tests isolated from front-end churn.
     still fall back to legacy — the bytes runtime path needs a
     struct-size computation that the MVP doesn't ship yet.
 
+- **Stage 3.4 (landed — non-capturing closures + indirect call).**
+
+  - **`FnConst`** constants now render as `@<symbol>` LLVM value
+    references, so MIR operands holding fn pointers flow through
+    the emitter without an extra alloca.
+  - **`AggregateRV{AggClosure}`** with a *single* field (a bare
+    `FnConst`, i.e. a non-capturing closure) collapses to the fn
+    pointer value. No allocation, no struct — the emitted MIR just
+    becomes `store ptr @<lifted-closure-symbol>, ptr <slot>`.
+    Capturing closures (multi-field `AggClosure`) still return
+    `ErrUnsupported` because they need a heap-backed environment
+    the MVP hasn't designed yet.
+  - **`IndirectCall`** is accepted when the callee operand has an
+    `FnType`. The emitter reads the LLVM signature off the FnType,
+    lowers each argument against the declared param types, and
+    emits `call <ret> (<params>) <ptr-operand>(<args>)`.
+  - **MIR lowerer fix**: `resolveCall` now routes
+    `Ident{Kind: IdentLocal|IdentParam}` callees through
+    `IndirectCall` (carrying a `CopyOp` of the local) instead of
+    minting a stray `FnRef` to a symbol that doesn't exist. That
+    unblocks first-class fn values passed as parameters.
+
 - **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
   backend now prefers the MIR-direct emitter by default for raw
   `llvm-ir` output. The legacy HIR→AST bridge remains callable under
@@ -803,14 +825,15 @@ MIR tests isolated from front-end churn.
 
 - **Stage 5 (deferred — still needs parity).** Remove
   `legacyFileFromModule` and the AST-driven emitter. Blocked on the
-  MIR emitter covering closure captures (`AggClosure`), indirect
-  calls, concurrency intrinsics (the MIR lowerer already emits
-  them but the emitter doesn't map them to runtime symbols), GC
-  roots / safepoints, composite list/map element types, and the
-  `IndexProj` / `DerefProj` place projections. The cheapest next
-  wedge is closure captures — that unlocks large swathes of the
-  stdlib. See the MIR emitter's `checkSupported` and
-  `checkRValueSupported` for the current whitelist.
+  MIR emitter covering **capturing** closures (`AggClosure` with
+  captures, heap-backed environment, per-call capture unpacking),
+  concurrency intrinsics (the MIR lowerer already emits them but the
+  emitter doesn't map them to runtime symbols), GC roots /
+  safepoints, composite list/map element types, and the `IndexProj`
+  / `DerefProj` place projections. Non-capturing closures + indirect
+  calls landed in Stage 3.4; capturing closures are the next wedge.
+  See the MIR emitter's `checkSupported` and `checkRValueSupported`
+  for the current whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -246,8 +246,12 @@ func (g *mirGen) checkInstrSupported(fn *mir.Function, inst mir.Instr) error {
 				return err
 			}
 		}
-		if _, ok := x.Callee.(*mir.FnRef); !ok {
-			return unsupported("mir-mvp", "indirect call not yet supported in "+fn.Name)
+		switch x.Callee.(type) {
+		case *mir.FnRef, *mir.IndirectCall:
+			// both supported now — IndirectCall through a fn-pointer
+			// operand.
+		default:
+			return unsupported("mir-mvp", fmt.Sprintf("call target %T not yet supported in %s", x.Callee, fn.Name))
 		}
 	case *mir.IntrinsicInstr:
 		if !isSupportedIntrinsic(x.Kind) {
@@ -286,6 +290,15 @@ func (g *mirGen) checkRValueSupported(fn *mir.Function, rv mir.RValue) error {
 		switch r.Kind {
 		case mir.AggStruct, mir.AggTuple, mir.AggEnumVariant, mir.AggList:
 			return nil
+		case mir.AggClosure:
+			// Non-capturing closures (just a function pointer, no
+			// captures) are supported; capturing closures still need
+			// a heap-backed environment — leave them for a later
+			// stage and fall back to legacy.
+			if len(r.Fields) == 1 {
+				return nil
+			}
+			return unsupported("mir-mvp", fmt.Sprintf("closure with %d captures in %s", len(r.Fields)-1, fn.Name))
 		}
 		return unsupported("mir-mvp", fmt.Sprintf("aggregate kind %d not yet supported in %s", r.Kind, fn.Name))
 	}
@@ -767,10 +780,18 @@ func (g *mirGen) emitAssign(a *mir.AssignInstr) error {
 }
 
 func (g *mirGen) emitCall(c *mir.CallInstr) error {
-	fnRef, ok := c.Callee.(*mir.FnRef)
-	if !ok {
-		return unsupported("mir-mvp", "indirect call")
+	switch callee := c.Callee.(type) {
+	case *mir.FnRef:
+		return g.emitDirectCall(c, callee)
+	case *mir.IndirectCall:
+		return g.emitIndirectCall(c, callee)
 	}
+	return unsupported("mir-mvp", fmt.Sprintf("call target %T", c.Callee))
+}
+
+// emitDirectCall handles `call <ret> @<symbol>(args)` — the common
+// case where the callee's signature is known at compile time.
+func (g *mirGen) emitDirectCall(c *mir.CallInstr, fnRef *mir.FnRef) error {
 	sig, known := g.functionTypes[fnRef.Symbol]
 	if !known {
 		return unsupported("mir-mvp", "call to unresolved symbol "+fnRef.Symbol)
@@ -793,16 +814,68 @@ func (g *mirGen) emitCall(c *mir.CallInstr) error {
 		}
 		argStrs = append(argStrs, g.llvmType(paramT)+" "+val)
 	}
-	// Build the call.
+	return g.emitCallSiteByName(c, fnRef.Symbol, sig.retLLVM, argStrs)
+}
+
+// emitIndirectCall handles calls through a ptr-typed operand, used
+// when a fn-typed variable / closure value is invoked. The MIR
+// emitter MVP supports non-capturing closures (the operand is a
+// plain fn pointer), so we read the LLVM signature off the operand's
+// FnType.
+func (g *mirGen) emitIndirectCall(c *mir.CallInstr, callee *mir.IndirectCall) error {
+	calleeOp := callee.Callee
+	if calleeOp == nil {
+		return unsupported("mir-mvp", "indirect call with nil callee")
+	}
+	fnT, ok := calleeOp.Type().(*ir.FnType)
+	if !ok {
+		return unsupported("mir-mvp", fmt.Sprintf("indirect call on non-function type %s", mirTypeString(calleeOp.Type())))
+	}
+	// Resolve the fn pointer.
+	ptrVal, err := g.evalOperand(calleeOp, calleeOp.Type())
+	if err != nil {
+		return err
+	}
+	// Lower args against the declared FnType signature.
+	retLLVM := "void"
+	if fnT.Return != nil && !isUnitType(fnT.Return) {
+		retLLVM = g.llvmType(fnT.Return)
+	}
+	argStrs := make([]string, 0, len(c.Args))
+	for i, op := range c.Args {
+		var paramT mir.Type
+		if i < len(fnT.Params) {
+			paramT = fnT.Params[i]
+		}
+		if paramT == nil {
+			paramT = op.Type()
+		}
+		val, err := g.evalOperand(op, paramT)
+		if err != nil {
+			return err
+		}
+		argStrs = append(argStrs, g.llvmType(paramT)+" "+val)
+	}
+	// Build the LLVM call-type string matching the declared FnType.
+	paramParts := make([]string, 0, len(fnT.Params))
+	for _, p := range fnT.Params {
+		paramParts = append(paramParts, g.llvmType(p))
+	}
+	callType := retLLVM + " (" + strings.Join(paramParts, ", ") + ")"
+	return g.emitCallSiteIndirect(c, callType, ptrVal, retLLVM, argStrs)
+}
+
+// emitCallSiteByName writes the actual `call` / `store` / void-call
+// lines for a direct fn-symbol call.
+func (g *mirGen) emitCallSiteByName(c *mir.CallInstr, symbol, retLLVM string, argStrs []string) error {
 	if c.Dest != nil {
 		destLoc := g.fn.Local(c.Dest.Local)
 		if destLoc == nil {
 			return fmt.Errorf("mir-mvp: call dest into unknown local %d", c.Dest.Local)
 		}
 		if isUnitType(destLoc.Type) {
-			// Call returns unit — emit as void call, no dest.
 			g.fnBuf.WriteString("  call void @")
-			g.fnBuf.WriteString(fnRef.Symbol)
+			g.fnBuf.WriteString(symbol)
 			g.fnBuf.WriteByte('(')
 			g.fnBuf.WriteString(strings.Join(argStrs, ", "))
 			g.fnBuf.WriteString(")\n")
@@ -812,9 +885,9 @@ func (g *mirGen) emitCall(c *mir.CallInstr) error {
 		g.fnBuf.WriteString("  ")
 		g.fnBuf.WriteString(tmp)
 		g.fnBuf.WriteString(" = call ")
-		g.fnBuf.WriteString(sig.retLLVM)
+		g.fnBuf.WriteString(retLLVM)
 		g.fnBuf.WriteString(" @")
-		g.fnBuf.WriteString(fnRef.Symbol)
+		g.fnBuf.WriteString(symbol)
 		g.fnBuf.WriteByte('(')
 		g.fnBuf.WriteString(strings.Join(argStrs, ", "))
 		g.fnBuf.WriteString(")\n")
@@ -827,11 +900,58 @@ func (g *mirGen) emitCall(c *mir.CallInstr) error {
 		g.fnBuf.WriteByte('\n')
 		return nil
 	}
-	// Void / discarded call.
 	g.fnBuf.WriteString("  call ")
-	g.fnBuf.WriteString(sig.retLLVM)
+	g.fnBuf.WriteString(retLLVM)
 	g.fnBuf.WriteString(" @")
-	g.fnBuf.WriteString(fnRef.Symbol)
+	g.fnBuf.WriteString(symbol)
+	g.fnBuf.WriteByte('(')
+	g.fnBuf.WriteString(strings.Join(argStrs, ", "))
+	g.fnBuf.WriteString(")\n")
+	return nil
+}
+
+// emitCallSiteIndirect writes the call sequence for an indirect fn
+// pointer invocation (`call <ret> (<params>) %ptr(args)`). Dest
+// semantics mirror the direct path.
+func (g *mirGen) emitCallSiteIndirect(c *mir.CallInstr, callType, ptrVal, retLLVM string, argStrs []string) error {
+	if c.Dest != nil {
+		destLoc := g.fn.Local(c.Dest.Local)
+		if destLoc == nil {
+			return fmt.Errorf("mir-mvp: call dest into unknown local %d", c.Dest.Local)
+		}
+		if isUnitType(destLoc.Type) {
+			g.fnBuf.WriteString("  call ")
+			g.fnBuf.WriteString(callType)
+			g.fnBuf.WriteByte(' ')
+			g.fnBuf.WriteString(ptrVal)
+			g.fnBuf.WriteByte('(')
+			g.fnBuf.WriteString(strings.Join(argStrs, ", "))
+			g.fnBuf.WriteString(")\n")
+			return nil
+		}
+		tmp := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(" = call ")
+		g.fnBuf.WriteString(callType)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(ptrVal)
+		g.fnBuf.WriteByte('(')
+		g.fnBuf.WriteString(strings.Join(argStrs, ", "))
+		g.fnBuf.WriteString(")\n")
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(g.llvmType(destLoc.Type))
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(g.localSlots[c.Dest.Local])
+		g.fnBuf.WriteByte('\n')
+		return nil
+	}
+	g.fnBuf.WriteString("  call ")
+	g.fnBuf.WriteString(callType)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(ptrVal)
 	g.fnBuf.WriteByte('(')
 	g.fnBuf.WriteString(strings.Join(argStrs, ", "))
 	g.fnBuf.WriteString(")\n")
@@ -1633,6 +1753,14 @@ func (g *mirGen) emitAggregate(rv *mir.AggregateRV, hintT mir.Type) (string, err
 		return g.emitEnumVariant(rv, aggT)
 	case mir.AggList:
 		return g.emitListLiteral(rv, aggT)
+	case mir.AggClosure:
+		// Stage 3.4 MVP: non-capturing closures only. The single
+		// field is a FnConst; the resulting ptr *is* the closure
+		// value.
+		if len(rv.Fields) != 1 {
+			return "", unsupported("mir-mvp", "closure with captures")
+		}
+		return g.evalOperand(rv.Fields[0], rv.Fields[0].Type())
 	}
 	elems, err := g.aggregateElementTypes(aggT, rv)
 	if err != nil {
@@ -2099,6 +2227,15 @@ func (g *mirGen) renderConst(c mir.Const, hintT mir.Type) (string, error) {
 		return sym, nil
 	case *mir.NullConst:
 		return "null", nil
+	case *mir.FnConst:
+		// Function-pointer literal. Renders as the global symbol
+		// reference — LLVM accepts `@fnname` wherever a ptr value is
+		// expected. The `discoverFunctions` pass has already recorded
+		// the target's signature so indirect calls can look it up.
+		if k.Symbol == "" {
+			return "", unsupported("mir-mvp", "FnConst with empty symbol")
+		}
+		return "@" + k.Symbol, nil
 	}
 	return "", unsupported("mir-mvp", fmt.Sprintf("const %T", c))
 }

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -973,3 +973,92 @@ func TestGenerateFromMIRListSorted(t *testing.T) {
 		}
 	}
 }
+
+// ==== Stage 3.4: non-capturing closures + indirect calls ====
+
+func TestGenerateFromMIRNonCapturingClosureValue(t *testing.T) {
+	// fn pickDouble() -> fn(Int) -> Int { |x| x + 1 }
+	// MIR lowering for a non-capturing closure produces AggregateRV{
+	// Kind: AggClosure, Fields: [FnConst("<parent>__closure1")]}.
+	// The MIR emitter should collapse that to the fn-pointer value,
+	// emitting `@<symbol>` directly.
+	fnType := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}
+	pickDouble := &ir.FnDecl{
+		Name:   "pickDouble",
+		Return: fnType,
+		Body: &ir.Block{
+			Result: &ir.Closure{
+				Params: []*ir.Param{{Name: "x", Type: ir.TInt}},
+				Return: ir.TInt,
+				Body: &ir.Block{Result: &ir.BinaryExpr{
+					Op:    ir.BinAdd,
+					Left:  &ir.Ident{Name: "x", Kind: ir.IdentParam, T: ir.TInt},
+					Right: &ir.IntLit{Text: "1", T: ir.TInt},
+					T:     ir.TInt,
+				}},
+				T: fnType,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{pickDouble}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/closure.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	// Two functions should appear: the outer pickDouble and the lifted
+	// closure body. The outer returns a fn-pointer @ symbol directly.
+	if !strings.Contains(got, "define ptr @pickDouble()") {
+		t.Fatalf("expected pickDouble to return ptr, got:\n%s", got)
+	}
+	if !strings.Contains(got, "@pickDouble__closure1") {
+		t.Fatalf("expected lifted closure symbol in output:\n%s", got)
+	}
+	// The fn-pointer value should flow as an `@` literal, not as a
+	// struct / alloca — one of the most common signals we get this
+	// right is an `ret ptr @pickDouble__closure1` or a store of the
+	// raw @symbol into the return slot.
+	if !strings.Contains(got, "store ptr @pickDouble__closure1") {
+		t.Fatalf("expected fn-pointer store of @pickDouble__closure1:\n%s", got)
+	}
+}
+
+func TestGenerateFromMIRIndirectCall(t *testing.T) {
+	// fn apply(f: fn(Int) -> Int, x: Int) -> Int { f(x) }
+	fnType := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}
+	fn := &ir.FnDecl{
+		Name:   "apply",
+		Return: ir.TInt,
+		Params: []*ir.Param{
+			{Name: "f", Type: fnType},
+			{Name: "x", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.CallExpr{
+				Callee: &ir.Ident{Name: "f", Kind: ir.IdentLocal, T: fnType},
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "x", Kind: ir.IdentParam, T: ir.TInt}},
+				},
+				T: ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/apply.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	// The body must call through the ptr-typed local, with a parenthesised
+	// signature that matches `fn(Int) -> Int`.
+	for _, want := range []string{
+		"define i64 @apply(ptr %arg0, i64 %arg1)",
+		"call i64 (i64)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2406,6 +2406,16 @@ func (bs *bodyState) resolveCall(c *ir.CallExpr) ([]Operand, Callee) {
 			// let the caller re-route through lowerExprToRValue.
 			return nil, nil
 		}
+		// Local / param idents holding a fn-typed value route through
+		// an indirect call — they are NOT module symbols. Globals
+		// that happen to hold a fn value would also land here today,
+		// but MIR lowering for global reads still goes through the
+		// generic path; revisit if that shape becomes common.
+		if cal.Kind == ir.IdentLocal || cal.Kind == ir.IdentParam {
+			calleeOp := bs.lowerIdent(cal)
+			args := bs.orderArgs(c.Args, nil)
+			return args, &IndirectCall{Callee: calleeOp}
+		}
 		sig := bs.l.signatureForFn(cal.Name)
 		args := bs.orderArgs(c.Args, sig)
 		ft := cal.T


### PR DESCRIPTION
Adds the first-class-function wedge to the MIR-direct LLVM emitter: non-capturing closure literals and calls through fn-pointer operands now flow through the MIR path instead of falling back to legacy. Capturing closures still need a heap-backed environment and remain deferred.

## Emitter changes

- **`renderConst` handles `FnConst`** — emits `@<symbol>` LLVM value references, so MIR operands holding fn pointers flow through without an extra alloca.
- **`AggregateRV{AggClosure}` with a single field** (a bare `FnConst`, i.e. a non-capturing closure) collapses to the fn-pointer value. No allocation, no struct — the emitted IR becomes `store ptr @<lifted-closure-symbol>, ptr <slot>`. Capturing closures (multi-field `AggClosure`) still return `ErrUnsupported`.
- **`IndirectCall`** accepted when the callee operand has an `FnType`. The emitter reads the LLVM signature off the FnType, lowers each argument against the declared param types, and emits `call <ret> (<params>) <ptr-operand>(<args>)`. Direct and indirect call sites share `emitCallSiteByName` / `emitCallSiteIndirect` helpers so dest / void / store patterns stay identical.
- **`checkInstrSupported`** accepts both `FnRef` and `IndirectCall` callee kinds; **`checkRValueSupported`** accepts `AggregateRV{AggClosure}` when `len(Fields) == 1`.

## MIR lowerer fix

- `resolveCall` now routes `Ident{Kind: IdentLocal|IdentParam}` callees through `IndirectCall` (carrying a `CopyOp` of the local) instead of minting a stray `FnRef` to a symbol that doesn't exist. This is what enables first-class fn values passed as parameters to reach the MIR-direct emitter.

## Tests — 2 new cases

- `TestGenerateFromMIRNonCapturingClosureValue` — a closure with no captures returns `store ptr @pickDouble__closure1`; both the outer and lifted fn are defined.
- `TestGenerateFromMIRIndirectCall` — `fn apply(f, x) { f(x) }` emits `call i64 (i64) %ptr(...)` through the ptr-typed parameter.

## Test plan

- [x] `go test ./internal/mir`
- [x] `go test -run MIR ./internal/llvmgen`
- [x] `go test ./internal/parser ./internal/ir`
- [x] All Stage 3.x tests continue to pass unchanged.

## Stage 5 gap (deferred, still needs parity)

- **Capturing closures** — need a heap-backed env struct `{ fn, cap0, cap1, … }`, plus capture unpacking at every indirect call site that targets a closure value. Non-trivial: want a runtime `closure_alloc` symbol or an SROA-friendly inline struct with a concrete LLVM type per closure shape.
- Concurrency intrinsic runtime mapping (the MIR lowerer emits them; emitter doesn't map them to runtime symbols yet).
- GC roots / safepoints.
- Composite list / map / set element types.
- `IndexProj` / `DerefProj` place projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)