### PR TITLE
chore: ignore graphify-out/ (local knowledge-graph artifact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 .DS_Store
 .idea/
 *.swp
+
+# graphify knowledge graph (local dev artifact, rebuild with /graphify)
+graphify-out/


### PR DESCRIPTION
## Summary
- Adds `graphify-out/` to `.gitignore` so the knowledge-graph output from `/graphify` doesn't get accidentally committed.
- `graphify-out/` contains a ~12MB `graph.json` plus an 11MB `cache/` directory — it's a derived artifact (rebuilt per-developer with `/graphify .` or `/graphify . --update`), not a source file.

## Why
CLAUDE.md already treats `graphify-out/` as a read/navigate target (god nodes, wiki), but never specified whether it should be tracked. After running `/graphify . --wiki` on the full repo, `git status` flagged the whole ~23MB tree as untracked — this PR closes that footgun before anyone runs `git add -A` and regrets it.

## Test plan
- [ ] `git status` on a fresh `/graphify` run no longer lists `graphify-out/`.
- [ ] Existing committed files unaffected (`git check-ignore` of any tracked path returns nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)