### PR TITLE
feat(mir): stage 3.5 — IndexProj on List<T> in MIR-direct emitter

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -816,6 +816,26 @@ MIR tests isolated from front-end churn.
     minting a stray `FnRef` to a symbol that doesn't exist. That
     unblocks first-class fn values passed as parameters.
 
+- **Stage 3.5 (landed — `IndexProj` on `List<T>`).**
+
+  - `checkProjectionsSupported` accepts `IndexProj` when the
+    projection base is a builtin `List<T>` (the immediate preceding
+    type in the place chain, or the local's type for a leading
+    index projection).
+  - In `emitLoad`, when the walker hits an `IndexProj` on a ptr-
+    typed list base, it emits
+    `call <elem> @osty_rt_list_get_<suffix>(ptr %list, i64 %idx)`
+    instead of the usual `extractvalue`. The typed suffix (`_i64`,
+    `_i1`, `_f64`, `_ptr`) matches the Stage 3.3 runtime ABI.
+  - `projectionIndex` still returns `false` for `IndexProj` (there
+    is no static field index); the walker handles it via the
+    runtime-call branch. `projectionType` returns `IndexProj.ElemType`
+    so downstream projections (e.g. `xs[i].name`) compose without
+    extra plumbing.
+  - Composite list element types (structs, tuples, nested lists)
+    still fall back because the typed runtime ABI requires a
+    scalar-shaped LLVM element.
+
 - **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
   backend now prefers the MIR-direct emitter by default for raw
   `llvm-ir` output. The legacy HIR→AST bridge remains callable under
@@ -829,11 +849,11 @@ MIR tests isolated from front-end churn.
   captures, heap-backed environment, per-call capture unpacking),
   concurrency intrinsics (the MIR lowerer already emits them but the
   emitter doesn't map them to runtime symbols), GC roots /
-  safepoints, composite list/map element types, and the `IndexProj`
-  / `DerefProj` place projections. Non-capturing closures + indirect
-  calls landed in Stage 3.4; capturing closures are the next wedge.
-  See the MIR emitter's `checkSupported` and `checkRValueSupported`
-  for the current whitelist.
+  safepoints, composite list/map element types, and `DerefProj`
+  place projections. Non-capturing closures + indirect calls landed
+  in Stage 3.4, IndexProj on lists in Stage 3.5; capturing closures
+  are the next wedge. See the MIR emitter's `checkSupported` and
+  `checkRValueSupported` for the current whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -266,19 +266,44 @@ func (g *mirGen) checkInstrSupported(fn *mir.Function, inst mir.Instr) error {
 }
 
 // checkProjectionsSupported walks a Place's projection chain and
-// refuses anything outside the emitter's current coverage. After
-// Stage 3.2 the set is FieldProj / TupleProj / VariantProj. IndexProj
-// and DerefProj still belong to later stages.
+// refuses anything outside the emitter's current coverage. Stage 3.5
+// adds IndexProj for list-typed bases (e.g. `xs[i]`). DerefProj still
+// belongs to later stages.
 func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx string) error {
-	for _, proj := range p.Projections {
+	for i, proj := range p.Projections {
 		switch proj.(type) {
 		case *mir.FieldProj, *mir.TupleProj, *mir.VariantProj:
 			// allowed
+		case *mir.IndexProj:
+			// Accept IndexProj only when the projection base is a
+			// List. Walking the projection chain from scratch would
+			// be overkill for the common case (`local[i]`), so we
+			// check the immediate preceding type: if it's the first
+			// projection, the base type is the local's type; else
+			// it's the previous projection's type.
+			var baseT mir.Type
+			if i == 0 {
+				baseT = g.localType(p.Local)
+			} else {
+				baseT = projectionType(p.Projections[i-1])
+			}
+			if !isListPtrType(baseT) {
+				return unsupported("mir-mvp", fmt.Sprintf("%s IndexProj on non-List base %s in %s", ctx, mirTypeString(baseT), fn.Name))
+			}
 		default:
 			return unsupported("mir-mvp", fmt.Sprintf("%s projection %T not yet supported in %s", ctx, proj, fn.Name))
 		}
 	}
 	return nil
+}
+
+// isListPtrType reports whether t is a `List<T>` builtin (which
+// lowers to a ptr at the LLVM boundary).
+func isListPtrType(t mir.Type) bool {
+	if nt, ok := t.(*ir.NamedType); ok {
+		return nt.Name == "List" && nt.Builtin
+	}
+	return false
 }
 
 func (g *mirGen) checkRValueSupported(fn *mir.Function, rv mir.RValue) error {
@@ -2114,6 +2139,48 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 	curLLVM := baseLLVM
 	curReg := aggReg
 	for i, proj := range place.Projections {
+		// IndexProj on a List base routes through the runtime — the
+		// LLVM view of a List is opaque `ptr`, so we can't use
+		// `extractvalue`. Emit `osty_rt_list_get_<suffix>(list, idx)`
+		// for typed elements and hand the result back as the new
+		// running value (the projection chain can keep going from
+		// there; e.g. `xs[i].name`).
+		if ip, ok := proj.(*mir.IndexProj); ok {
+			elemT := projectionType(proj)
+			if elemT == nil {
+				if i == len(place.Projections)-1 {
+					elemT = t
+				} else {
+					return "", unsupported("mir-mvp", "projection missing Type")
+				}
+			}
+			elemLLVM := g.llvmType(elemT)
+			if !listUsesTypedRuntime(elemLLVM) {
+				return "", unsupported("mir-mvp", "list[i] on composite element type")
+			}
+			sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
+			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
+			idxOp := ip.Index
+			idxVal, err := g.evalOperand(idxOp, mir.TInt)
+			if err != nil {
+				return "", err
+			}
+			next := g.fresh()
+			g.fnBuf.WriteString("  ")
+			g.fnBuf.WriteString(next)
+			g.fnBuf.WriteString(" = call ")
+			g.fnBuf.WriteString(elemLLVM)
+			g.fnBuf.WriteString(" @")
+			g.fnBuf.WriteString(sym)
+			g.fnBuf.WriteString("(ptr ")
+			g.fnBuf.WriteString(curReg)
+			g.fnBuf.WriteString(", i64 ")
+			g.fnBuf.WriteString(idxVal)
+			g.fnBuf.WriteString(")\n")
+			curReg = next
+			curLLVM = elemLLVM
+			continue
+		}
 		idx, ok := projectionIndex(proj)
 		if !ok {
 			return "", unsupported("mir-mvp", fmt.Sprintf("projection %T on read", proj))
@@ -2166,7 +2233,9 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 
 // projectionIndex returns the field index for a FieldProj / TupleProj.
 // VariantProj returns field 1 (the payload slot) because enum layouts
-// uniformly use `{ i64 disc, i64 payload }`.
+// uniformly use `{ i64 disc, i64 payload }`. IndexProj has no static
+// index and returns false — the walker handles it via a runtime call
+// rather than an `extractvalue`.
 func projectionIndex(p mir.Projection) (int, bool) {
 	switch x := p.(type) {
 	case *mir.FieldProj:
@@ -2180,9 +2249,9 @@ func projectionIndex(p mir.Projection) (int, bool) {
 }
 
 // projectionType returns the result type of a FieldProj / TupleProj /
-// VariantProj. For VariantProj the raw type in the place chain is
-// the payload's *declared* type; the enum slot itself is i64 and we
-// narrow at the read site via fromI64Slot.
+// VariantProj / IndexProj. For VariantProj the raw type in the place
+// chain is the payload's *declared* type; the enum slot itself is i64
+// and we narrow at the read site via fromI64Slot.
 func projectionType(p mir.Projection) mir.Type {
 	switch x := p.(type) {
 	case *mir.FieldProj:
@@ -2191,6 +2260,8 @@ func projectionType(p mir.Projection) mir.Type {
 		return x.Type
 	case *mir.VariantProj:
 		return x.Type
+	case *mir.IndexProj:
+		return x.ElemType
 	}
 	return nil
 }

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -429,22 +429,33 @@ func TestMIRDualEmitFromSource(t *testing.T) {
 }
 
 // TestMIRDualEmitGracefulFallback proves that when the MIR emitter
-// refuses a program (IndexProj on a list is still outside the MVP
-// projection whitelist), the backend dispatcher catches
-// `ErrUnsupported` and retries on the HIR path. We hand-build the
-// HIR here so the test is independent of parser / checker
-// restrictions on closure-trailing-expr source shape.
+// refuses a program (a closure with captures is still outside the
+// MVP), the backend dispatcher catches `ErrUnsupported` and retries
+// on the HIR path. We hand-build the HIR here so the test is
+// independent of parser / checker restrictions on closure-trailing-
+// expr source shape.
 func TestMIRDualEmitGracefulFallback(t *testing.T) {
-	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fnType := &ir.FnType{Params: []ir.Type{ir.TInt}, Return: ir.TInt}
 	fn := &ir.FnDecl{
-		Name:   "first",
-		Return: ir.TInt,
-		Params: []*ir.Param{{Name: "xs", Type: listInt}},
+		Name:   "make",
+		Return: fnType,
 		Body: &ir.Block{
-			Result: &ir.IndexExpr{
-				X:     &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
-				Index: &ir.IntLit{Text: "0", T: ir.TInt},
-				T:     ir.TInt,
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{Name: "n", Type: ir.TInt, Value: &ir.IntLit{Text: "1", T: ir.TInt}},
+			},
+			Result: &ir.Closure{
+				Params: []*ir.Param{{Name: "x", Type: ir.TInt}},
+				Return: ir.TInt,
+				Body: &ir.Block{Result: &ir.BinaryExpr{
+					Op:    ir.BinAdd,
+					Left:  &ir.Ident{Name: "x", Kind: ir.IdentParam, T: ir.TInt},
+					Right: &ir.Ident{Name: "n", Kind: ir.IdentLocal, T: ir.TInt},
+					T:     ir.TInt,
+				}},
+				Captures: []*ir.Capture{
+					{Name: "n", Kind: ir.CaptureLocal, T: ir.TInt},
+				},
+				T: fnType,
 			},
 		},
 	}
@@ -457,7 +468,7 @@ func TestMIRDualEmitGracefulFallback(t *testing.T) {
 
 	_, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/fallback.osty"})
 	if err == nil {
-		t.Fatalf("expected MIR emitter to refuse index-projection program")
+		t.Fatalf("expected MIR emitter to refuse capturing-closure program")
 	}
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("expected ErrUnsupported, got %T: %v", err, err)
@@ -1056,6 +1067,74 @@ func TestGenerateFromMIRIndirectCall(t *testing.T) {
 	for _, want := range []string{
 		"define i64 @apply(ptr %arg0, i64 %arg1)",
 		"call i64 (i64)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// ==== Stage 3.5: IndexProj on List ====
+
+func TestGenerateFromMIRListIndexRead(t *testing.T) {
+	// fn first(xs: List<Int>) -> Int { xs[0] }
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "first",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "xs", Type: listInt}},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X:     &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				Index: &ir.IntLit{Text: "0", T: ir.TInt},
+				T:     ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/idx.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+		"call i64 @osty_rt_list_get_i64(ptr ",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRListIndexReadPtrElem(t *testing.T) {
+	// fn head(xs: List<String>) -> String { xs[0] }
+	listStr := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TString}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "head",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "xs", Type: listStr}},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X:     &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listStr},
+				Index: &ir.IntLit{Text: "0", T: ir.TInt},
+				T:     ir.TString,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/idx-str.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	// String elements are ptr-wide in the runtime, so the typed
+	// runtime suffix is `_ptr`.
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_get_ptr(ptr, i64)",
+		"call ptr @osty_rt_list_get_ptr(ptr ",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)


### PR DESCRIPTION
Adds \`xs[i]\` list indexing to the MIR-direct LLVM emitter. The projection routes through the Stage 3.3 runtime ABI (`osty_rt_list_get_<suffix>`) instead of the `extractvalue` path used for struct / tuple / variant projections.

## What lands

- **Support check.** `checkProjectionsSupported` accepts `IndexProj` when the base is a builtin `List<T>`. The base type is resolved from the local's type (if IndexProj is the first projection) or the preceding projection's result type — so chained reads like `xs[i].name` compose naturally.
- **Emitter.** In `emitLoad`'s projection walker, an IndexProj on a ptr-typed list base emits `call <elem> @osty_rt_list_get_<suffix>(ptr %list, i64 %idx)` rather than an `extractvalue`. The runtime symbol is declared lazily via `declareRuntime`; the typed suffix matches Stage 3.3's helpers (`_i64` for Int, `_ptr` for String / Bytes, etc.).
- **Projection helpers.** `projectionIndex` still returns `false` for IndexProj (no static index); the walker checks IndexProj ahead of the static-index branch. `projectionType` returns `IndexProj.ElemType` so downstream chained projections get the right MIR type.
- **Composite element types** (structs / tuples / nested lists) still fall back — the typed runtime ABI wants a scalar-shaped LLVM element, and the bytes fallback path needs a struct-size computation we don't ship yet.

## Tests

- `TestGenerateFromMIRListIndexRead` — `xs[0]` on a `List<Int>` emits `call i64 @osty_rt_list_get_i64(ptr <xs>, i64 0)`.
- `TestGenerateFromMIRListIndexReadPtrElem` — `xs[0]` on a `List<String>` uses the `_ptr` suffix.

The existing fallback regression test (`TestMIRDualEmitGracefulFallback`) moves to a capturing-closure trigger so it still exercises the ErrUnsupported → legacy-path contract (IndexProj is no longer outside MVP).

## Test plan

- [x] `go test -run MIR ./internal/llvmgen`
- [x] `go test ./internal/parser ./internal/ir ./internal/mir`
- [x] All Stage 3.x tests continue green.

## Remaining Stage 5 gap

- **Capturing closures** — heap env struct + capture unpacking (next wedge)
- **Concurrency intrinsic runtime mapping** — MIR lowerer emits them; emitter needs runtime-symbol table
- **GC roots / safepoints**
- **Composite list / map / set element types** (bytes fallback)
- **`DerefProj`** — only remaining projection kind in the refused set

🤖 Generated with [Claude Code](https://claude.com/claude-code)