### PR TITLE
feat(mir): stage 3.6 — composite list element types via bytes-v1 runtime ABI

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -833,8 +833,28 @@ MIR tests isolated from front-end churn.
     so downstream projections (e.g. `xs[i].name`) compose without
     extra plumbing.
   - Composite list element types (structs, tuples, nested lists)
-    still fall back because the typed runtime ABI requires a
-    scalar-shaped LLVM element.
+    now route through the bytes-v1 fallback (Stage 3.6) rather than
+    falling back to the legacy path.
+
+- **Stage 3.6 (landed — composite list element types).**
+
+  - **`emitListPushOperand`** routes composite elements (anything
+    outside the `listUsesTypedRuntime` scalar set) through the
+    bytes-v1 runtime helper: alloca a slot sized to the element
+    type, store the value, compute the size via the
+    `getelementptr null, 1` + `ptrtoint` idiom, and call
+    `osty_rt_list_push_bytes_v1(list, ptr slot, i64 size)`.
+  - **`emitListGetBytes`** (new) handles the symmetric
+    `osty_rt_list_get_bytes_v1(list, idx, ptr out, i64 size)` ABI:
+    alloca a stack slot, let the runtime write into it, load back.
+    Reachable from both `IntrinsicListGet` (stdlib method) and the
+    `IndexProj` walker in `emitLoad`, so `xs[i]` on a
+    `List<Point>` or `List<(Int, String)>` compiles without
+    falling back.
+  - **`emitSizeOf`** (new) centralises the sizeof idiom —
+    `getelementptr %T, ptr null, i32 1` + `ptrtoint` — so every
+    composite-element call site uses the same LLVM-friendly
+    pattern.
 
 - **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
   backend now prefers the MIR-direct emitter by default for raw
@@ -849,11 +869,13 @@ MIR tests isolated from front-end churn.
   captures, heap-backed environment, per-call capture unpacking),
   concurrency intrinsics (the MIR lowerer already emits them but the
   emitter doesn't map them to runtime symbols), GC roots /
-  safepoints, composite list/map element types, and `DerefProj`
-  place projections. Non-capturing closures + indirect calls landed
-  in Stage 3.4, IndexProj on lists in Stage 3.5; capturing closures
-  are the next wedge. See the MIR emitter's `checkSupported` and
-  `checkRValueSupported` for the current whitelist.
+  safepoints, top-level globals, composite **map** element types,
+  and `DerefProj` place projections. Non-capturing closures +
+  indirect calls landed in Stage 3.4, `IndexProj` on lists in Stage
+  3.5, composite **list** elements via the bytes-v1 ABI in Stage
+  3.6; capturing closures are the next wedge. See the MIR
+  emitter's `checkSupported` and `checkRValueSupported` for the
+  current whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1068,12 +1068,16 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		if !listUsesTypedRuntime(elemLLVM) {
-			return unsupported("mir-mvp", "list_get on composite element type")
+		if listUsesTypedRuntime(elemLLVM) {
+			sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
+			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
+			return g.emitSimpleCall(i, sym, elemLLVM, []string{"ptr " + listReg, "i64 " + idxReg})
 		}
-		sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
-		g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
-		return g.emitSimpleCall(i, sym, elemLLVM, []string{"ptr " + listReg, "i64 " + idxReg})
+		// Composite element — use the bytes-v1 helper with a stack
+		// slot as the out-pointer. Backend writes the value into the
+		// slot; we load it back and store into the intrinsic's dest
+		// (if any).
+		return g.emitListGetBytes(i, listReg, idxReg, elemT)
 	case mir.IntrinsicListSorted:
 		elemString := isStringLLVMType(elemT)
 		sym := listRuntimeSortedSymbol(elemLLVM, elemString)
@@ -2040,11 +2044,108 @@ func (g *mirGen) emitListPushOperand(listReg string, op mir.Operand, elemT mir.T
 		g.fnBuf.WriteString(")\n")
 		return nil
 	}
-	// Composite element — use the bytes helper with a stack-allocated
-	// slot and size=1 byte slot for string (runtime expects ptr). For
-	// true byte-sized elements the runtime looks at the size arg, so
-	// we pass its LLVM width.
-	return unsupported("mir-mvp", "list literal with composite element type: "+elemLLVM)
+	// Composite element (struct / tuple) — stage into a stack slot,
+	// compute the size via the `getelementptr null, 1` idiom, and
+	// call the bytes helper.
+	slot := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteString(" = alloca ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString("  store ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(val)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteByte('\n')
+	sizeReg := g.emitSizeOf(elemLLVM)
+	sym := "osty_rt_list_push_bytes_v1"
+	g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, i64)")
+	g.fnBuf.WriteString("  call void @")
+	g.fnBuf.WriteString(sym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteString(", i64 ")
+	g.fnBuf.WriteString(sizeReg)
+	g.fnBuf.WriteString(")\n")
+	return nil
+}
+
+// emitListGetBytes loads a composite list element via the bytes-v1
+// runtime helper. Allocates a stack slot sized to the element type,
+// asks the runtime to write into it, loads back, and stores into
+// the intrinsic's optional destination.
+func (g *mirGen) emitListGetBytes(i *mir.IntrinsicInstr, listReg, idxReg string, elemT mir.Type) error {
+	elemLLVM := g.llvmType(elemT)
+	slot := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteString(" = alloca ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteByte('\n')
+	sizeReg := g.emitSizeOf(elemLLVM)
+	sym := "osty_rt_list_get_bytes_v1"
+	g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
+	g.fnBuf.WriteString("  call void @")
+	g.fnBuf.WriteString(sym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(", i64 ")
+	g.fnBuf.WriteString(idxReg)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteString(", i64 ")
+	g.fnBuf.WriteString(sizeReg)
+	g.fnBuf.WriteString(")\n")
+	if i.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(i.Dest.Local)
+	if destLoc == nil {
+		return fmt.Errorf("mir-mvp: list_get_bytes into unknown local %d", i.Dest.Local)
+	}
+	// Load the staged value, then store into dest.
+	loaded := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(loaded)
+	g.fnBuf.WriteString(" = load ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString("  store ")
+	g.fnBuf.WriteString(g.llvmType(destLoc.Type))
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(loaded)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+	g.fnBuf.WriteByte('\n')
+	return nil
+}
+
+// emitSizeOf returns a fresh register holding the size in bytes of
+// the named LLVM type. Uses the standard `getelementptr null, 1`
+// idiom — LLVM's constant folder collapses it to a numeric literal
+// during opt. Works for any first-class type, including user
+// structs referenced by their `%Name` handle.
+func (g *mirGen) emitSizeOf(llvmType string) string {
+	gep := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(gep)
+	g.fnBuf.WriteString(" = getelementptr ")
+	g.fnBuf.WriteString(llvmType)
+	g.fnBuf.WriteString(", ptr null, i32 1\n")
+	size := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(size)
+	g.fnBuf.WriteString(" = ptrtoint ptr ")
+	g.fnBuf.WriteString(gep)
+	g.fnBuf.WriteString(" to i64\n")
+	return size
 }
 
 func listElemType(t mir.Type) mir.Type {
@@ -2155,29 +2256,60 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 				}
 			}
 			elemLLVM := g.llvmType(elemT)
-			if !listUsesTypedRuntime(elemLLVM) {
-				return "", unsupported("mir-mvp", "list[i] on composite element type")
-			}
-			sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
-			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
 			idxOp := ip.Index
 			idxVal, err := g.evalOperand(idxOp, mir.TInt)
 			if err != nil {
 				return "", err
 			}
-			next := g.fresh()
+			if listUsesTypedRuntime(elemLLVM) {
+				sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
+				g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
+				next := g.fresh()
+				g.fnBuf.WriteString("  ")
+				g.fnBuf.WriteString(next)
+				g.fnBuf.WriteString(" = call ")
+				g.fnBuf.WriteString(elemLLVM)
+				g.fnBuf.WriteString(" @")
+				g.fnBuf.WriteString(sym)
+				g.fnBuf.WriteString("(ptr ")
+				g.fnBuf.WriteString(curReg)
+				g.fnBuf.WriteString(", i64 ")
+				g.fnBuf.WriteString(idxVal)
+				g.fnBuf.WriteString(")\n")
+				curReg = next
+				curLLVM = elemLLVM
+				continue
+			}
+			// Composite element — use bytes_v1 out-pointer ABI.
+			slot := g.fresh()
 			g.fnBuf.WriteString("  ")
-			g.fnBuf.WriteString(next)
-			g.fnBuf.WriteString(" = call ")
+			g.fnBuf.WriteString(slot)
+			g.fnBuf.WriteString(" = alloca ")
 			g.fnBuf.WriteString(elemLLVM)
-			g.fnBuf.WriteString(" @")
+			g.fnBuf.WriteByte('\n')
+			sizeReg := g.emitSizeOf(elemLLVM)
+			sym := "osty_rt_list_get_bytes_v1"
+			g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
+			g.fnBuf.WriteString("  call void @")
 			g.fnBuf.WriteString(sym)
 			g.fnBuf.WriteString("(ptr ")
 			g.fnBuf.WriteString(curReg)
 			g.fnBuf.WriteString(", i64 ")
 			g.fnBuf.WriteString(idxVal)
+			g.fnBuf.WriteString(", ptr ")
+			g.fnBuf.WriteString(slot)
+			g.fnBuf.WriteString(", i64 ")
+			g.fnBuf.WriteString(sizeReg)
 			g.fnBuf.WriteString(")\n")
-			curReg = next
+			loaded := g.fresh()
+			g.fnBuf.WriteString("  ")
+			g.fnBuf.WriteString(loaded)
+			g.fnBuf.WriteString(" = load ")
+			g.fnBuf.WriteString(elemLLVM)
+			g.fnBuf.WriteString(", ptr ")
+			g.fnBuf.WriteString(slot)
+			g.fnBuf.WriteByte('\n')
+			curReg = loaded
 			curLLVM = elemLLVM
 			continue
 		}

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1141,3 +1141,118 @@ func TestGenerateFromMIRListIndexReadPtrElem(t *testing.T) {
 		}
 	}
 }
+
+// ==== Stage 3.6: composite list element types (bytes ABI) ====
+
+func TestGenerateFromMIRListStructPushAndRead(t *testing.T) {
+	// struct Point { x: Int, y: Int }
+	// fn build() -> Int {
+	//     let xs = [Point { x: 1, y: 2 }]
+	//     xs[0].x
+	// }
+	pointT := &ir.NamedType{Name: "Point"}
+	pointDecl := &ir.StructDecl{
+		Name: "Point",
+		Fields: []*ir.Field{
+			{Name: "x", Type: ir.TInt, Exported: true},
+			{Name: "y", Type: ir.TInt, Exported: true},
+		},
+	}
+	listPoint := &ir.NamedType{Name: "List", Args: []ir.Type{pointT}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "build",
+		Return: ir.TInt,
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "xs",
+					Type: listPoint,
+					Value: &ir.ListLit{
+						Elems: []ir.Expr{
+							&ir.StructLit{
+								TypeName: "Point",
+								Fields: []ir.StructLitField{
+									{Name: "x", Value: &ir.IntLit{Text: "1", T: ir.TInt}},
+									{Name: "y", Value: &ir.IntLit{Text: "2", T: ir.TInt}},
+								},
+								T: pointT,
+							},
+						},
+						Elem: pointT,
+					},
+				},
+			},
+			Result: &ir.FieldExpr{
+				X: &ir.IndexExpr{
+					X:     &ir.Ident{Name: "xs", Kind: ir.IdentLocal, T: listPoint},
+					Index: &ir.IntLit{Text: "0", T: ir.TInt},
+					T:     pointT,
+				},
+				Name: "x",
+				T:    ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_struct.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		// Struct layout for Point.
+		"%Point = type { i64, i64 }",
+		// Bytes-ABI push with a Point stack slot.
+		"declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)",
+		"call void @osty_rt_list_push_bytes_v1(",
+		// Bytes-ABI get with an out-pointer.
+		"declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)",
+		"call void @osty_rt_list_get_bytes_v1(",
+		// Size computed via the gep-null-1 idiom.
+		"getelementptr %Point, ptr null, i32 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRListTupleElement(t *testing.T) {
+	tupT := &ir.TupleType{Elems: []ir.Type{ir.TInt, ir.TString}}
+	listTup := &ir.NamedType{Name: "List", Args: []ir.Type{tupT}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "make",
+		Return: listTup,
+		Body: &ir.Block{
+			Result: &ir.ListLit{
+				Elems: []ir.Expr{
+					&ir.TupleLit{
+						Elems: []ir.Expr{
+							&ir.IntLit{Text: "1", T: ir.TInt},
+							&ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "a"}}},
+						},
+						T: tupT,
+					},
+				},
+				Elem: tupT,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/list_tuple.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Tuple.i64.string = type { i64, ptr }",
+		"call void @osty_rt_list_push_bytes_v1(",
+		"getelementptr %Tuple.i64.string, ptr null, i32 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Unblocks `List<Struct>` / `List<(Int, String)>` / `List<List<T>>` in the MIR-direct LLVM emitter. Scalar element types keep the typed runtime ABI from Stage 3.3; composite elements now route through the bytes-v1 helpers (`osty_rt_list_push_bytes_v1` / `osty_rt_list_get_bytes_v1`) with a stack-allocated slot and the standard `gep null, 1` sizeof idiom.

## What lands

- **`emitListPushOperand` composite branch** — alloca a slot sized to the element type, store the value, compute the size via `getelementptr <T>, ptr null, i32 1` + `ptrtoint`, and emit `call void @osty_rt_list_push_bytes_v1(ptr list, ptr slot, i64 size)`.
- **`emitListGetBytes` (new)** — symmetric ABI for composite reads. Alloca an out-slot, let the runtime write into it, load back, store into the intrinsic's optional destination. Called from both `IntrinsicListGet` (stdlib `xs.get(i)`) and the `IndexProj` walker in `emitLoad` (`xs[i]`).
- **`emitSizeOf` (new)** — centralises the `gep null, 1` + `ptrtoint` sizeof idiom. LLVM's constant folder collapses it to a numeric literal during opt.
- **`IndexProj` walker** falls through to the bytes-v1 path when the element's LLVM type isn't scalar (`listUsesTypedRuntime`).

## Tests

- `TestGenerateFromMIRListStructPushAndRead` — `List<Point>` push then `xs[0].x` read emits both bytes-v1 helpers, a `%Point` alloca slot, the sizeof idiom, and the expected struct field extract.
- `TestGenerateFromMIRListTupleElement` — `List<(Int, String)>` push emits the mangled `%Tuple.i64.string` type def + bytes-v1 push with the right sizeof.

## Test plan

- [x] `go test -run MIR ./internal/llvmgen`
- [x] `go test ./internal/parser ./internal/ir ./internal/mir`
- [x] All Stage 3.x tests continue green.

## Remaining Stage 5 gap (updated)

- **Capturing closures** — heap env struct + capture unpacking (next wedge)
- **Concurrency intrinsic runtime mapping**
- **GC roots / safepoints**
- **Top-level globals**
- **Composite map element types** (map value widening works for ptr-wide values; struct values still need more work)
- **`DerefProj`**

Composite list elements crossed off; composite **map** elements are the remaining collection gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)