### PR TITLE
feat(stdlib): port iter/cmp/csv and fix uuid stubs

### DIFF
--- a/internal/stdlib/modules/cmp.osty
+++ b/internal/stdlib/modules/cmp.osty
@@ -10,15 +10,15 @@
 
 pub interface Equal {
     fn eq(self, other: Self) -> Bool
-    fn ne(self, other: Self) -> Bool { false }
+    fn ne(self, other: Self) -> Bool { !self.eq(other) }
 }
 
 pub interface Ordered {
     Equal
     fn lt(self, other: Self) -> Bool
-    fn le(self, other: Self) -> Bool { false }
-    fn gt(self, other: Self) -> Bool { false }
-    fn ge(self, other: Self) -> Bool { false }
+    fn le(self, other: Self) -> Bool { self.lt(other) || self.eq(other) }
+    fn gt(self, other: Self) -> Bool { !self.le(other) }
+    fn ge(self, other: Self) -> Bool { !self.lt(other) }
 }
 
 pub interface Hashable {

--- a/internal/stdlib/modules/csv.osty
+++ b/internal/stdlib/modules/csv.osty
@@ -1,4 +1,15 @@
 // std.csv — RFC 4180 CSV read/write.
+//
+// The encoder and decoder are implemented in pure Osty. Encoding
+// follows RFC 4180: fields containing the delimiter, quote, or a CR
+// or LF are wrapped in quotes, and embedded quotes are doubled.
+// Decoding is a small state machine over `chars()` that accepts
+// either CRLF or bare LF as a row terminator and tolerates a final
+// row without a trailing newline. `trimSpace` strips ASCII space and
+// tab from the start and end of each *unquoted* field.
+
+use std.strings
+use std.error
 
 pub struct CsvOptions {
     pub delimiter: Char = ',',
@@ -7,21 +18,256 @@ pub struct CsvOptions {
 }
 
 pub fn encode(rows: List<List<String>>) -> String {
-    ""
+    encodeWith(rows, CsvOptions {})
 }
 
 pub fn encodeWith(rows: List<List<String>>, options: CsvOptions) -> String {
-    ""
+    let mut out = ""
+    let mut first = true
+    for row in rows {
+        if !first {
+            out = "{out}\r\n"
+        }
+        first = false
+        out = "{out}{encodeRow(row, options)}"
+    }
+    out
 }
 
 pub fn decode(text: String) -> Result<List<List<String>>, Error> {
-    Ok([])
-}
-
-pub fn decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
-    Ok([])
+    decodeWith(text, CsvOptions {})
 }
 
 pub fn decodeWith(text: String, options: CsvOptions) -> Result<List<List<String>>, Error> {
-    Ok([])
+    let chars = text.chars()
+    let n = chars.len()
+    let delim = options.delimiter
+    let quote = options.quote
+
+    let mut rows: List<List<String>> = []
+    let mut field = ""
+    let mut row: List<String> = []
+
+    // Field state:
+    //   0 = start of field (no characters consumed yet)
+    //   1 = unquoted field in progress
+    //   2 = inside quoted field
+    //   3 = saw a quote inside quoted field (look ahead for `""` or close)
+    let mut state = 0
+    let mut i = 0
+
+    for i < n {
+        let c = chars[i]
+
+        if state == 0 {
+            if c == quote {
+                state = 2
+                i = i + 1
+            } else if c == delim {
+                row.push(finalize(field, false, options))
+                field = ""
+                i = i + 1
+            } else if c == '\n' {
+                row.push(finalize(field, false, options))
+                rows.push(row)
+                row = []
+                field = ""
+                i = i + 1
+            } else if c == '\r' {
+                row.push(finalize(field, false, options))
+                rows.push(row)
+                row = []
+                field = ""
+                if i + 1 < n && chars[i + 1] == '\n' {
+                    i = i + 2
+                } else {
+                    i = i + 1
+                }
+            } else {
+                field = "{field}{c}"
+                state = 1
+                i = i + 1
+            }
+        } else if state == 1 {
+            if c == delim {
+                row.push(finalize(field, false, options))
+                field = ""
+                state = 0
+                i = i + 1
+            } else if c == '\n' {
+                row.push(finalize(field, false, options))
+                rows.push(row)
+                row = []
+                field = ""
+                state = 0
+                i = i + 1
+            } else if c == '\r' {
+                row.push(finalize(field, false, options))
+                rows.push(row)
+                row = []
+                field = ""
+                state = 0
+                if i + 1 < n && chars[i + 1] == '\n' {
+                    i = i + 2
+                } else {
+                    i = i + 1
+                }
+            } else {
+                field = "{field}{c}"
+                i = i + 1
+            }
+        } else if state == 2 {
+            if c == quote {
+                state = 3
+                i = i + 1
+            } else {
+                field = "{field}{c}"
+                i = i + 1
+            }
+        } else {
+            // state == 3: just saw a quote inside a quoted field
+            if c == quote {
+                field = "{field}{c}"
+                state = 2
+                i = i + 1
+            } else if c == delim {
+                row.push(finalize(field, true, options))
+                field = ""
+                state = 0
+                i = i + 1
+            } else if c == '\n' {
+                row.push(finalize(field, true, options))
+                rows.push(row)
+                row = []
+                field = ""
+                state = 0
+                i = i + 1
+            } else if c == '\r' {
+                row.push(finalize(field, true, options))
+                rows.push(row)
+                row = []
+                field = ""
+                state = 0
+                if i + 1 < n && chars[i + 1] == '\n' {
+                    i = i + 2
+                } else {
+                    i = i + 1
+                }
+            } else {
+                return Err(error.new("csv: unexpected character after closing quote"))
+            }
+        }
+    }
+
+    if state == 2 {
+        return Err(error.new("csv: unterminated quoted field"))
+    }
+
+    // Flush trailing field / row. Empty input yields [].
+    if state != 0 || field.len() > 0 || row.len() > 0 {
+        row.push(finalize(field, state == 3, options))
+        rows.push(row)
+    }
+
+    Ok(rows)
+}
+
+pub fn decodeHeaders(text: String) -> Result<List<Map<String, String>>, Error> {
+    let rows = decode(text)?
+    if rows.len() == 0 {
+        return Ok([])
+    }
+    let headers = rows[0]
+    let mut records: List<Map<String, String>> = []
+    let mut r = 1
+    for r < rows.len() {
+        let row = rows[r]
+        let mut record: Map<String, String> = {:}
+        let mut c = 0
+        let cols = if row.len() < headers.len() { row.len() } else { headers.len() }
+        for c < cols {
+            record.set(headers[c], row[c])
+            c = c + 1
+        }
+        records.push(record)
+        r = r + 1
+    }
+    Ok(records)
+}
+
+// Internal helpers ────────────────────────────────────────────────────────────
+
+fn encodeRow(row: List<String>, options: CsvOptions) -> String {
+    let mut out = ""
+    let mut first = true
+    for field in row {
+        if !first {
+            out = "{out}{options.delimiter}"
+        }
+        first = false
+        out = "{out}{encodeField(field, options)}"
+    }
+    out
+}
+
+fn encodeField(field: String, options: CsvOptions) -> String {
+    if needsQuoting(field, options) {
+        let escaped = escapeQuotes(field, options.quote)
+        "{options.quote}{escaped}{options.quote}"
+    } else {
+        field
+    }
+}
+
+fn needsQuoting(field: String, options: CsvOptions) -> Bool {
+    for c in field.chars() {
+        if c == options.delimiter || c == options.quote || c == '\n' || c == '\r' {
+            return true
+        }
+    }
+    false
+}
+
+fn escapeQuotes(field: String, quote: Char) -> String {
+    let mut out = ""
+    for c in field.chars() {
+        if c == quote {
+            out = "{out}{quote}{quote}"
+        } else {
+            out = "{out}{c}"
+        }
+    }
+    out
+}
+
+fn finalize(field: String, wasQuoted: Bool, options: CsvOptions) -> String {
+    if options.trimSpace && !wasQuoted {
+        trimAscii(field)
+    } else {
+        field
+    }
+}
+
+fn trimAscii(s: String) -> String {
+    let chars = s.chars()
+    let n = chars.len()
+    let mut start = 0
+    for start < n && isAsciiSpace(chars[start]) {
+        start = start + 1
+    }
+    let mut end = n
+    for end > start && isAsciiSpace(chars[end - 1]) {
+        end = end - 1
+    }
+    let mut out = ""
+    let mut i = start
+    for i < end {
+        out = "{out}{chars[i]}"
+        i = i + 1
+    }
+    out
+}
+
+fn isAsciiSpace(c: Char) -> Bool {
+    c == ' ' || c == '\t'
 }

--- a/internal/stdlib/modules/iter.osty
+++ b/internal/stdlib/modules/iter.osty
@@ -1,10 +1,20 @@
 // std.iter — lazy iterator adapters and terminal operations.
+//
+// The v0.4 surface is eager over a backing `List<T>`: adapters walk
+// the list once and return a freshly-allocated `Iter<U>`. A lazy
+// pull-based implementation is tracked for post-v0.4 — until then the
+// semantics match `List<T>` methods but live behind the documented
+// fluent API so user code written against the spec works today.
 
 pub struct Iter<T> {
     items: List<T>,
 
     pub fn map<U>(self, f: fn(T) -> U) -> Iter<U> {
-        self.map(f)
+        let mut out: List<U> = []
+        for item in self.items {
+            out.push(f(item))
+        }
+        Iter { items: out }
     }
 
     pub fn filter(self, f: fn(T) -> Bool) -> Iter<T> {
@@ -89,13 +99,20 @@ pub struct Iter<T> {
 }
 
 pub fn from<T>(items: List<T>) -> Iter<T> {
-    from::<T>(items)
+    Iter { items }
 }
 
 pub fn empty<T>() -> Iter<T> {
-    empty::<T>()
+    let items: List<T> = []
+    Iter { items }
 }
 
 pub fn range(start: Int, stop: Int) -> Iter<Int> {
-    range(start, stop)
+    let mut items: List<Int> = []
+    let mut i = start
+    for i < stop {
+        items.push(i)
+        i = i + 1
+    }
+    Iter { items }
 }

--- a/internal/stdlib/modules/uuid.osty
+++ b/internal/stdlib/modules/uuid.osty
@@ -1,27 +1,22 @@
 // std.uuid — UUID generation and parsing.
+//
+// The concrete bytes and the randomness / wall-clock dependencies for
+// v4 / v7 live behind the runtime bridge; this stub is signature-only
+// so the type checker validates calls at the correct surface. The
+// previous placeholder bodies had two bugs: `toBytes` recursed on
+// itself, and `toString` returned the empty string. Both are now
+// body-less declarations, which the backend lowers to the real
+// runtime entry points rather than to bogus Osty fallbacks.
 
 pub struct Uuid {
-    pub fn toString(self) -> String {
-        ""
-    }
-
-    pub fn toBytes(self) -> Bytes {
-        self.toBytes()
-    }
+    pub fn toString(self) -> String
+    pub fn toBytes(self) -> Bytes
 }
 
-pub fn v4() -> Uuid {
-    Uuid {}
-}
+pub fn v4() -> Uuid
 
-pub fn v7() -> Uuid {
-    Uuid {}
-}
+pub fn v7() -> Uuid
 
-pub fn parse(text: String) -> Result<Uuid, Error> {
-    Ok(Uuid {})
-}
+pub fn parse(text: String) -> Result<Uuid, Error>
 
-pub fn nil() -> Uuid {
-    Uuid {}
-}
+pub fn nil() -> Uuid


### PR DESCRIPTION
## Summary

- **iter**: replace the self-referential `map` body and the `from` / `empty` / `range` stubs (which recursed on themselves) with real eager-over-`List<T>` bodies so the §10.7 fluent surface actually runs.
- **cmp**: derive `ne` / `le` / `gt` / `ge` defaults from `eq` / `lt` per LANG_SPEC §2.6 instead of the previous `false`-returning placeholders.
- **csv**: implement RFC 4180 `encode` / `encodeWith` / `decode` / `decodeWith` / `decodeHeaders` in pure Osty — state machine over `chars()`, CRLF + LF row terminators, doubled-quote escaping, `trimSpace` on unquoted fields, header-mapped record output.
- **uuid**: drop the broken placeholder bodies (`toBytes` recursed, `toString` returned `""`). Follow the `fs.osty` pattern — body-less declarations the runtime bridge fills in, so nothing silently returns garbage.

## Why

The affected modules declared the intended surface but several stubs were either infinite-recursive or semantically wrong (e.g. `Ordered.gt` always `false`). Anything downstream that reached them — tests, dogfood compilation, or user code following the spec — would silently misbehave. These changes move them to either correct Osty bodies (iter, cmp, csv) or honest runtime-bridged declarations (uuid).

## Test plan

- [x] `go test ./internal/stdlib/...` ✓
- [x] `go test ./internal/check/... ./internal/resolve/... ./internal/parser/...` ✓
- [x] `go build ./...` ✓

## Follow-ups

Still runtime-dependent (not ported here): `math`, `regex`, `compress`, `random`, `http` / `net` socket ops, `url` parsing, `uuid.v4` / `v7` / `parse`. Those need the LLVM backend's native bridges and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)