### PR TITLE
feat(test): parallel + seeded osty test runner, per-test timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ coverage. The public compiler path is now native-only through the LLVM backend.
 | Project scaffolding (`internal/scaffold`, `osty new` / `osty init`) | done — `--bin`, `--lib`, `--workspace`, `--cli`, `--service` |
 | Manifest + lockfile + SemVer (`internal/manifest`, `lockfile`, `pkgmgr/semver`) | done (parse + validate + resolve) |
 | Build orchestrator (`osty build`) | done — manifest → front-end → native backend, profile/target/feature wiring, backend-aware artifact/cache paths |
-| `osty test` | native backend harness pending; public CLI reports this instead of falling back to Go |
+| `osty test` | native backend harness — discovers `test*` functions, compiles each through the LLVM backend, runs in parallel by default with a seeded shuffled order (`--seed`, `--serial`, `--jobs`), reports per-test wall time and an `ok/FAIL` summary; assertions are intercepted by the LLVM generator and failures exit non-zero with the source location. `benchmark`/`snapshot` and per-argument structural diff are not implemented yet |
 | API doc generator (`internal/docgen`, `osty doc`) | done — checked-in generated Go package, HTML + markdown, field docs, cross-refs, workspace mode |
 | CI quality tooling (`internal/ci`, `osty ci`) | done — Osty-authored generated CI core, signature-aware snapshots, workspace coverage, JSON reports |
 | Pipeline visualizer (`osty pipeline`) | done — per-stage timing, workspace mode, backend-aware gen, baseline diff, LSP trace, `--explain` |
@@ -203,7 +203,7 @@ osty add PKG           # append a dependency to osty.toml and re-resolve
 osty remove NAME...    # drop dependencies from osty.toml and re-resolve (alias: rm)
 osty update [NAMES...] # refresh the lockfile (selective or full)
 osty run [-- ARGS...]  # build and exec the binary through the native backend
-osty test [PATH|FILTERS...] # native test harness pending
+osty test [PATH|FILTERS...] # discover test* functions and run them through the native backend (--seed, --serial, --jobs)
 osty publish           # pack the project and upload to a registry
 osty search QUERY      # full-text search the registry (--registry, --limit)
 osty info PKG          # show registry metadata for a package (--all-versions)

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1324,7 +1324,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty add NAME[@VER]       (add a dependency; also --path, --git)")
 	fmt.Fprintln(os.Stderr, "       osty update [NAME...]     (refresh osty.lock)")
 	fmt.Fprintln(os.Stderr, "       osty run [-- ARGS...]     (build + exec the project's binary)")
-	fmt.Fprintln(os.Stderr, "       osty test [PATH|FILTER...] (native test harness pending)")
+	fmt.Fprintln(os.Stderr, "       osty test [PATH|FILTER...] (discover + run test* functions; --seed, --serial, --jobs)")
 	fmt.Fprintln(os.Stderr, "       osty publish              (pack + upload the package to a registry)")
 	fmt.Fprintln(os.Stderr, "       osty search QUERY         (search the registry for packages)")
 	fmt.Fprintln(os.Stderr, "       osty yank --version V [PKG]   (mark a published version as yanked)")

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -3,14 +3,21 @@ package main
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"io"
+	mathrand "math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/backend"
@@ -34,7 +41,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [--airepair=false] [--airepair-mode MODE] [PATH|FILTER...]")
+		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [--airepair=false] [--airepair-mode MODE] [--seed HEX] [--serial] [--jobs N] [PATH|FILTER...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
@@ -46,9 +53,20 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	var emitName string
 	fs.StringVar(&backendName, "backend", defaultBackendName(), "code generation backend (llvm)")
 	fs.StringVar(&emitName, "emit", "", "artifact mode to execute (binary)")
+	var seedFlag string
+	fs.StringVar(&seedFlag, "seed", "", "deterministic test-order seed (decimal or 0x-hex); default is a fresh random seed")
+	var serial bool
+	fs.BoolVar(&serial, "serial", false, "run tests sequentially in the shuffled order (default: parallel)")
+	var jobs int
+	fs.IntVar(&jobs, "jobs", 0, "max concurrent tests when parallel (0 = runtime.NumCPU())")
 	var pf profileFlags
 	pf.register(fs)
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	seed, err := resolveTestSeed(seedFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "osty test: %v\n", err)
 		return 2
 	}
 	mode, ok := parseAIRepairMode(aiRepairModeName)
@@ -91,6 +109,12 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 		return 0
 	}
 
+	// Shuffle with the resolved seed. Spec §11.7 — tests run in a random
+	// order so accidentally shared state surfaces instead of hiding
+	// behind declaration-order luck; the seed is printed so users can
+	// reproduce.
+	shuffleNativeTests(tests, seed)
+
 	b, err := backend.New(backendID)
 	if err != nil {
 		fmt.Fprintf(stderr, "osty test: %v\n", err)
@@ -103,36 +127,176 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	}
 	defer os.RemoveAll(tmpRoot)
 
-	fmt.Fprintf(stdout, "running %d tests\n", len(tests))
-	failures := 0
-	for _, tc := range tests {
-		run, err := compileAndRunNativeTest(context.Background(), b, emitMode, tmpRoot, pkg, tc)
-		if err != nil {
-			failures++
-			fmt.Fprintf(stdout, "FAIL\t%s\n", tc.Name)
-			fmt.Fprintf(stderr, "osty test: %s: %v\n", tc.Name, err)
-			if strings.TrimSpace(run.Stdout) != "" {
-				fmt.Fprintf(stdout, "%s", run.Stdout)
-				if !strings.HasSuffix(run.Stdout, "\n") {
-					fmt.Fprintln(stdout)
-				}
-			}
-			if strings.TrimSpace(run.Stderr) != "" {
-				fmt.Fprintf(stderr, "%s", run.Stderr)
-				if !strings.HasSuffix(run.Stderr, "\n") {
-					fmt.Fprintln(stderr)
-				}
-			}
-			continue
-		}
-		fmt.Fprintf(stdout, "ok\t%s\n", tc.Name)
-	}
+	fmt.Fprintf(stdout, "running %d tests (seed %s)\n", len(tests), formatTestSeed(seed))
+	started := time.Now()
+	workers := resolveTestWorkers(serial, jobs, len(tests))
+	failures := executeNativeTests(context.Background(), b, emitMode, tmpRoot, pkg, tests, workers, seed, stdout, stderr)
+	elapsed := time.Since(started)
 	if failures > 0 {
-		fmt.Fprintf(stdout, "FAIL\t%d/%d tests failed\n", failures, len(tests))
+		fmt.Fprintf(stdout, "FAIL\t%d/%d tests failed in %s (seed %s)\n", failures, len(tests), formatTestDuration(elapsed), formatTestSeed(seed))
 		return 1
 	}
-	fmt.Fprintf(stdout, "ok\t%d tests passed\n", len(tests))
+	fmt.Fprintf(stdout, "ok\t%d tests passed in %s (seed %s)\n", len(tests), formatTestDuration(elapsed), formatTestSeed(seed))
 	return 0
+}
+
+// executeNativeTests dispatches the compile+run loop over the shuffled
+// tests slice. With workers==1 we keep the serial single-goroutine path
+// so output ordering stays stable and deterministic under the seed.
+// With workers>1 each test is compiled and run on its own goroutine and
+// results are printed in completion order — still reproducible because
+// the *set* of executed tests and the failure verdict do not depend on
+// scheduling.
+func executeNativeTests(ctx context.Context, b backend.Backend, emitMode backend.EmitMode, tmpRoot string, pkg *resolve.Package, tests []nativeTestCase, workers int, seed uint64, stdout, stderr io.Writer) int {
+	if workers <= 1 {
+		failures := 0
+		for _, tc := range tests {
+			if reportNativeTestResult(runSingleNativeTest(ctx, b, emitMode, tmpRoot, pkg, tc), stdout, stderr) {
+				failures++
+			}
+		}
+		return failures
+	}
+	sem := make(chan struct{}, workers)
+	resultsCh := make(chan nativeTestOutcome, len(tests))
+	var wg sync.WaitGroup
+	for _, tc := range tests {
+		tc := tc
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			resultsCh <- runSingleNativeTest(ctx, b, emitMode, tmpRoot, pkg, tc)
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+	failures := 0
+	for outcome := range resultsCh {
+		if reportNativeTestResult(outcome, stdout, stderr) {
+			failures++
+		}
+	}
+	return failures
+}
+
+type nativeTestOutcome struct {
+	Test    nativeTestCase
+	Run     nativeTestRun
+	Err     error
+	Elapsed time.Duration
+}
+
+func runSingleNativeTest(ctx context.Context, b backend.Backend, emitMode backend.EmitMode, tmpRoot string, pkg *resolve.Package, tc nativeTestCase) nativeTestOutcome {
+	start := time.Now()
+	run, err := compileAndRunNativeTest(ctx, b, emitMode, tmpRoot, pkg, tc)
+	return nativeTestOutcome{Test: tc, Run: run, Err: err, Elapsed: time.Since(start)}
+}
+
+// reportNativeTestResult emits the per-test status line and any captured
+// child-process output. Returns true iff the test failed, so callers can
+// tally the failure count without re-inspecting the outcome.
+func reportNativeTestResult(o nativeTestOutcome, stdout, stderr io.Writer) bool {
+	dur := formatTestDuration(o.Elapsed)
+	if o.Err != nil {
+		fmt.Fprintf(stdout, "FAIL\t%s\t%s\n", o.Test.Name, dur)
+		fmt.Fprintf(stderr, "osty test: %s: %v\n", o.Test.Name, o.Err)
+		if strings.TrimSpace(o.Run.Stdout) != "" {
+			fmt.Fprintf(stdout, "%s", o.Run.Stdout)
+			if !strings.HasSuffix(o.Run.Stdout, "\n") {
+				fmt.Fprintln(stdout)
+			}
+		}
+		if strings.TrimSpace(o.Run.Stderr) != "" {
+			fmt.Fprintf(stderr, "%s", o.Run.Stderr)
+			if !strings.HasSuffix(o.Run.Stderr, "\n") {
+				fmt.Fprintln(stderr)
+			}
+		}
+		return true
+	}
+	fmt.Fprintf(stdout, "ok\t%s\t%s\n", o.Test.Name, dur)
+	return false
+}
+
+// resolveTestSeed parses the --seed flag. The empty string produces a
+// fresh cryptographic-quality random seed; a leading `0x` switches the
+// parser to base-16 per spec §11.7's printed format.
+func resolveTestSeed(raw string) (uint64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		var b [8]byte
+		if _, err := cryptorand.Read(b[:]); err != nil {
+			return 0, fmt.Errorf("generate random seed: %w", err)
+		}
+		return binary.LittleEndian.Uint64(b[:]), nil
+	}
+	base := 10
+	s := raw
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		base = 16
+		s = s[2:]
+	}
+	v, err := strconv.ParseUint(s, base, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --seed %q: %w", raw, err)
+	}
+	return v, nil
+}
+
+func formatTestSeed(seed uint64) string {
+	return fmt.Sprintf("0x%X", seed)
+}
+
+// formatTestDuration renders the per-test wall time. Short tests round
+// to milliseconds so the column stays narrow; longer ones promote to
+// seconds with two decimals for readability.
+func formatTestDuration(d time.Duration) string {
+	if d < time.Second {
+		ms := d.Milliseconds()
+		if ms < 1 {
+			ms = 1
+		}
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%.2fs", d.Seconds())
+}
+
+func resolveTestWorkers(serial bool, jobs, n int) int {
+	if serial {
+		return 1
+	}
+	if jobs < 0 {
+		jobs = 0
+	}
+	if jobs == 0 {
+		jobs = runtime.NumCPU()
+	}
+	if jobs < 1 {
+		jobs = 1
+	}
+	if jobs > n {
+		jobs = n
+	}
+	return jobs
+}
+
+// shuffleNativeTests randomizes the test slice in place using a PRNG
+// seeded from the resolved seed. The seeded rng is deterministic so
+// --seed reproduces the same order regardless of host.
+func shuffleNativeTests(tests []nativeTestCase, seed uint64) {
+	// math/rand/v2 needs two uint64 words to seed PCG; derive a second
+	// independent word from the first via a splitmix step so a single
+	// user-supplied seed still fills both slots reproducibly.
+	mix := seed + 0x9E3779B97F4A7C15
+	mix = (mix ^ (mix >> 30)) * 0xBF58476D1CE4E5B9
+	mix = (mix ^ (mix >> 27)) * 0x94D049BB133111EB
+	mix ^= mix >> 31
+	rng := mathrand.New(mathrand.NewPCG(seed, mix))
+	rng.Shuffle(len(tests), func(i, j int) { tests[i], tests[j] = tests[j], tests[i] })
 }
 
 func resolveTestTarget(args []string) (string, []string, error) {

--- a/cmd/osty/test_native_test.go
+++ b/cmd/osty/test_native_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunTestMainPassesNativeLLVMTest(t *testing.T) {
@@ -225,7 +226,11 @@ fn testManagedAggregateList() {
 
 func TestRunTestMainAIRepairAllowsForeignSyntaxBeforeDiscovery(t *testing.T) {
 	dir := t.TempDir()
-	writeNativeTestFile(t, dir, "helper.osty", "func helper() {}\n")
+	// `x := 1` is residual foreign syntax — the parser front-end does not
+	// normalize it (that only covers keyword aliases like `func`→`fn`,
+	// promoted in commit 10a634d), so airepair is the only route that
+	// lets the package reach discovery.
+	writeNativeTestFile(t, dir, "helper.osty", "pub fn helper() -> Int {\n    x := 1\n    x\n}\n")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -262,4 +267,189 @@ func writeNativeTestFile(t *testing.T, dir, name, contents string) string {
 		t.Fatalf("write %s: %v", path, err)
 	}
 	return path
+}
+
+func TestResolveTestSeedAcceptsDecimalAndHex(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+	}{
+		{"0", 0},
+		{"42", 42},
+		{"0x8F3A2B71", 0x8F3A2B71},
+		{"0XFF", 0xFF},
+	}
+	for _, tc := range cases {
+		got, err := resolveTestSeed(tc.in)
+		if err != nil {
+			t.Fatalf("resolveTestSeed(%q) error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("resolveTestSeed(%q) = %#x, want %#x", tc.in, got, tc.want)
+		}
+	}
+	if _, err := resolveTestSeed("not-a-number"); err == nil {
+		t.Fatalf("resolveTestSeed(\"not-a-number\") expected error")
+	}
+}
+
+func TestResolveTestSeedEmptyIsFresh(t *testing.T) {
+	a, err := resolveTestSeed("")
+	if err != nil {
+		t.Fatalf("fresh seed: %v", err)
+	}
+	b, err := resolveTestSeed("")
+	if err != nil {
+		t.Fatalf("fresh seed: %v", err)
+	}
+	// Two fresh seeds almost certainly differ; if both are zero the RNG
+	// source is broken and this test exists to surface that.
+	if a == 0 && b == 0 {
+		t.Fatalf("two fresh seeds were both zero — crypto/rand not wired?")
+	}
+}
+
+func TestShuffleNativeTestsDeterministicPerSeed(t *testing.T) {
+	base := []nativeTestCase{
+		{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}, {Name: "e"},
+		{Name: "f"}, {Name: "g"}, {Name: "h"}, {Name: "i"}, {Name: "j"},
+	}
+	clone := func() []nativeTestCase { return append([]nativeTestCase(nil), base...) }
+	a := clone()
+	b := clone()
+	shuffleNativeTests(a, 0xDEADBEEF)
+	shuffleNativeTests(b, 0xDEADBEEF)
+	if !sameNativeTestOrder(a, b) {
+		t.Fatalf("same seed produced different orders:\n  a=%v\n  b=%v", a, b)
+	}
+	c := clone()
+	shuffleNativeTests(c, 0xCAFEBABE)
+	if sameNativeTestOrder(a, c) {
+		t.Fatalf("different seeds produced the same order: %v", a)
+	}
+}
+
+func sameNativeTestOrder(a, b []nativeTestCase) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+func TestResolveTestWorkersClamps(t *testing.T) {
+	if got := resolveTestWorkers(true, 4, 10); got != 1 {
+		t.Fatalf("--serial should force 1 worker, got %d", got)
+	}
+	if got := resolveTestWorkers(false, 4, 2); got != 2 {
+		t.Fatalf("workers should clamp to len(tests)=2, got %d", got)
+	}
+	if got := resolveTestWorkers(false, -3, 10); got < 1 {
+		t.Fatalf("workers should default to NumCPU>=1, got %d", got)
+	}
+}
+
+func TestFormatTestDurationSwitchesUnits(t *testing.T) {
+	if got := formatTestDuration(120 * time.Millisecond); got != "120ms" {
+		t.Fatalf("120ms format = %q", got)
+	}
+	if got := formatTestDuration(2500 * time.Millisecond); got != "2.50s" {
+		t.Fatalf("2.5s format = %q", got)
+	}
+	if got := formatTestDuration(time.Microsecond); got != "1ms" {
+		t.Fatalf("sub-millisecond rounds up to 1ms, got %q", got)
+	}
+}
+
+func TestRunTestMainHeaderIncludesSeedAndTiming(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib.osty", `pub fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+`)
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing
+
+fn testAdd() {
+    testing.assertEq(add(1, 2), 3)
+}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runTestMain([]string{"--seed", "0x1234", dir}, cliFlags{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTestMain() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "running 1 tests (seed 0x1234)") {
+		t.Fatalf("stdout missing seeded header: %q", got)
+	}
+	// ok\ttestAdd\t<duration> — duration column is present.
+	if !strings.Contains(got, "ok\ttestAdd\t") {
+		t.Fatalf("stdout missing per-test timing column: %q", got)
+	}
+	if !strings.Contains(got, "seed 0x1234") {
+		t.Fatalf("summary should echo the seed: %q", got)
+	}
+}
+
+func TestRunTestMainSerialFlagRunsInShuffledOrder(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib.osty", `pub fn id(x: Int) -> Int { x }
+`)
+	// Three tests — with --serial + fixed seed, output order must be
+	// deterministic across runs.
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing
+
+fn testAlpha() { testing.assertEq(id(1), 1) }
+fn testBravo() { testing.assertEq(id(2), 2) }
+fn testCharlie() { testing.assertEq(id(3), 3) }
+`)
+
+	// Only the test-name order is seed-deterministic; wall-clock
+	// durations legitimately differ between runs, so extract the name
+	// sequence before comparing.
+	capture := func() []string {
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		code := runTestMain([]string{"--seed", "0xABCDEF", "--serial", dir}, cliFlags{}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("runTestMain() exit = %d\nstderr:\n%s", code, stderr.String())
+		}
+		var order []string
+		for _, line := range strings.Split(stdout.String(), "\n") {
+			if strings.HasPrefix(line, "ok\ttest") || strings.HasPrefix(line, "FAIL\ttest") {
+				fields := strings.Split(line, "\t")
+				if len(fields) >= 2 {
+					order = append(order, fields[1])
+				}
+			}
+		}
+		return order
+	}
+	first := capture()
+	second := capture()
+	if strings.Join(first, ",") != strings.Join(second, ",") {
+		t.Fatalf("--serial + fixed seed should reproduce the same order.\nfirst: %v\nsecond: %v", first, second)
+	}
+	if len(first) != 3 {
+		t.Fatalf("expected 3 test status lines, got %v", first)
+	}
+	seen := map[string]bool{}
+	for _, n := range first {
+		seen[n] = true
+	}
+	for _, want := range []string{"testAlpha", "testBravo", "testCharlie"} {
+		if !seen[want] {
+			t.Fatalf("stdout missing %s status line; saw %v", want, first)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- `osty test` now runs in parallel with a **seeded shuffled order** (spec §11.6–11.7): `--seed HEX|DEC`, `--serial`, `--jobs N`. Header prints `running N tests (seed 0x…)`; summary echoes the seed so failures reproduce.
- **Per-test wall timing**: status lines become `ok\t<name>\t<dur>`; summary adds total elapsed. Backward-compatible — existing `strings.Contains(stdout, "ok\\ttestFoo")` checks still match.
- **Bug fix**: `TestRunTestMainAIRepairAllowsForeignSyntaxBeforeDiscovery` was broken after commit `10a634d` promoted `func` into a parser-level stable alias. Swapped the repro to `x := 1`, which is still residual airepair territory (parser normalization doesn't touch Go short-decls).
- README status line, CLI overview, and `usage` help updated. Memory (`project_osty_test.md`) refreshed to reflect the runner's real shape.

## What's not in scope

Spec §11 gaps explicitly left open as follow-ups: structural expected/actual diff in assertion failures (§11.2), `benchmark` execution with timing stats (§11.4), `snapshot` record/replay (§11.5).

## Implementation notes

- Shuffle uses `math/rand/v2` PCG seeded from the resolved seed; a splitmix step derives the second PCG word so a single user seed fills both slots reproducibly.
- Parallel dispatch: goroutine pool + buffered semaphore, completion-order output. `--serial` keeps the old single-goroutine path for strict ordering. Each test gets its own `layoutRoot` under `tmpRoot/<name>`, so the LLVM backend stays parallel-safe.
- Empty `--seed` takes a fresh seed from `crypto/rand`.

## Test plan

- [x] `go test ./cmd/osty/ -run 'TestResolveTestSeed|TestShuffleNativeTests|TestResolveTestWorkers|TestFormatTestDuration|TestRunTestMainHeaderIncludesSeedAndTiming|TestRunTestMainSerialFlagRunsInShuffledOrder'` — 7 new unit/E2E tests pass.
- [x] All previously-passing runner tests (`TestRunTestMainPassesNativeLLVMTest`, `…Failure`, `…ResultTests`, `…ExpectOkFailure`, `…TupleTableTests`, `…AIRepairAllows…`) still pass.
- [ ] `TestRunTestMainPassesNativeLLVMManagedAggregateListTests` still fails — **pre-existing** MIR-emitter coverage gap (`llvm backend: code generation is not implemented yet`). Verified the same failure on the pre-change baseline; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)