### PR TITLE
feat(mir): stage 3.9 — concurrency intrinsic runtime mapping

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -898,17 +898,52 @@ MIR tests isolated from front-end churn.
   explicitly with `mir-backend`, and the dispatcher falls back
   automatically on `ErrUnsupported`.
 
+- **Stage 3.9 (landed — concurrency intrinsic runtime mapping).**
+  All MIR concurrency intrinsics emitted by the MIR lowerer now
+  route to a stable-but-pending Osty runtime ABI in `internal/
+  llvmgen`:
+
+  - **Channels**: `chan_make` → `osty_rt_thread_chan_make(i64) → ptr`;
+    `chan_send` → `osty_rt_thread_chan_send_<suffix>(ptr, <elem>)`
+    (scalar) or `…_send_bytes_v1(ptr, ptr, i64)` (composite); `chan_recv`
+    → `…_chan_recv_<suffix>(ptr) → {i64, i64}` (the enum layout
+    matches the Option<T> MIR convention); `chan_close` → `…_close(ptr)`;
+    `chan_is_closed` → `…_is_closed(ptr) → i1`.
+  - **Structured tasks**: `task_group(body)` → `osty_rt_task_group(ptr)
+    → <ret>`; detached `spawn(body)` → `osty_rt_task_spawn(ptr) → ptr`;
+    scoped `g.spawn(body)` → `osty_rt_task_group_spawn(ptr, ptr) → ptr`;
+    `h.join()` → `osty_rt_task_handle_join(ptr)`; `g.cancel()` /
+    `g.isCancelled()` → `osty_rt_task_group_cancel` /
+    `…_is_cancelled`.
+  - **Select**: `thread.select(body)` + the arm-registration intrinsics
+    (`s.recv` / `s.send` / `s.timeout` / `s.default`) map to
+    `osty_rt_select` and `osty_rt_select_<arm>`.
+  - **Cancellation / timing**: `thread.isCancelled()` /
+    `checkCancelled()` / `yield()` / `sleep()` →
+    `osty_rt_cancel_is_cancelled` / `…_check_cancelled` /
+    `osty_rt_thread_yield` / `…_sleep`.
+  - **Helpers**: `parallel` / `race` / `collectAll` →
+    `osty_rt_parallel` / `osty_rt_task_race` / `osty_rt_task_collect_all`.
+  - Concurrency runtime-owned types (`Channel<T>`, `Handle<T>`,
+    `Group` / `TaskGroup`, `Select`, `Duration`) all lower to `ptr`
+    at the LLVM boundary; `typeSupported` and `llvmType` accept them
+    without requiring a declared layout.
+  - The runtime itself isn't in-tree yet — generated LLVM text is
+    correct and the declare lines are emitted, but the symbols
+    won't link until the runtime ships. This matches how
+    `osty.gc.alloc_v1` and the list / map / set helpers already
+    operate. What changed: concurrency code now reaches the MIR
+    emitter instead of falling back to the legacy HIR→AST bridge.
+
 - **Stage 5 (deferred — still needs parity).** Remove
   `legacyFileFromModule` and the AST-driven emitter. Outstanding
-  parity gaps after Stage 3.8: concurrency intrinsics (the MIR
-  lowerer already emits them but the emitter doesn't map them to
-  runtime symbols), GC roots / safepoints, top-level globals,
-  composite **map** element types, heap-escaping closure envs, and
-  `DerefProj` on anything other than a closure env. Capturing
-  closures + indirect calls crossed off in Stage 3.8; concurrency
-  intrinsic runtime mapping is the next wedge. See the MIR
-  emitter's `checkSupported` and `checkRValueSupported` for the
-  current whitelist.
+  parity gaps after Stage 3.9: GC roots / safepoints, top-level
+  globals, composite **map** element types, heap-escaping closure
+  envs, and `DerefProj` on anything other than a closure env.
+  Concurrency intrinsics crossed off in Stage 3.9; top-level
+  globals are the next wedge. See the MIR emitter's
+  `checkSupported` and `checkRValueSupported` for the current
+  whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -213,6 +213,13 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 				return true
 			}
 		}
+		// Concurrency runtime types are opaque pointers — the emitter
+		// doesn't need a declared layout for them. These match what
+		// the runtime ABI hands back from chan_make / spawn / etc.
+		switch x.Name {
+		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration":
+			return true
+		}
 		if g.mod != nil && g.mod.Layouts != nil {
 			if _, ok := g.mod.Layouts.Structs[x.Name]; ok {
 				return true
@@ -354,6 +361,21 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList:
+		return true
+	// Concurrency — channels / tasks / select / cancellation / helpers.
+	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
+		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
+		return true
+	case mir.IntrinsicTaskGroup, mir.IntrinsicSpawn, mir.IntrinsicHandleJoin,
+		mir.IntrinsicGroupCancel, mir.IntrinsicGroupIsCancelled:
+		return true
+	case mir.IntrinsicSelect, mir.IntrinsicSelectRecv, mir.IntrinsicSelectSend,
+		mir.IntrinsicSelectTimeout, mir.IntrinsicSelectDefault:
+		return true
+	case mir.IntrinsicIsCancelled, mir.IntrinsicCheckCancelled,
+		mir.IntrinsicYield, mir.IntrinsicSleep:
+		return true
+	case mir.IntrinsicParallel, mir.IntrinsicRace, mir.IntrinsicCollectAll:
 		return true
 	}
 	return false
@@ -1053,6 +1075,20 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList:
 		return g.emitSetIntrinsic(i)
+	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
+		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
+		return g.emitChannelIntrinsic(i)
+	case mir.IntrinsicTaskGroup, mir.IntrinsicSpawn, mir.IntrinsicHandleJoin,
+		mir.IntrinsicGroupCancel, mir.IntrinsicGroupIsCancelled:
+		return g.emitTaskIntrinsic(i)
+	case mir.IntrinsicSelect, mir.IntrinsicSelectRecv, mir.IntrinsicSelectSend,
+		mir.IntrinsicSelectTimeout, mir.IntrinsicSelectDefault:
+		return g.emitSelectIntrinsic(i)
+	case mir.IntrinsicIsCancelled, mir.IntrinsicCheckCancelled,
+		mir.IntrinsicYield, mir.IntrinsicSleep:
+		return g.emitCancelIntrinsic(i)
+	case mir.IntrinsicParallel, mir.IntrinsicRace, mir.IntrinsicCollectAll:
+		return g.emitConcurrencyHelperIntrinsic(i)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("intrinsic %s", mirIntrinsicLabel(i.Kind)))
 }
@@ -1300,6 +1336,430 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("set intrinsic kind %d", i.Kind))
+}
+
+// ==== concurrency intrinsics ====
+//
+// The concurrency family lowers to a stable-but-pending Osty runtime
+// ABI: symbols are prefixed `osty_rt_thread_*` / `osty_rt_task_*` /
+// `osty_rt_select_*` / `osty_rt_cancel_*` / `osty_rt_parallel_*`.
+// The runtime that provides them is still under design; for now the
+// emitter just produces correct LLVM text and declares the symbols —
+// linking will fail until the runtime ships them. This lets MIR-
+// consumed programs that mention concurrency pass through the emitter
+// without falling back to the legacy path.
+
+// emitChannelIntrinsic dispatches channel ops to runtime symbols.
+// Element type is read off the channel's `Channel<T>` NamedType and
+// dispatches through a scalar-vs-composite split mirroring the list
+// runtime ABI: scalar elements use typed `_i64` / `_i1` / `_f64` /
+// `_ptr` suffixes; composites go through the bytes ABI.
+func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
+	switch i.Kind {
+	case mir.IntrinsicChanMake:
+		// Args: [capacity]. Element type comes from the Dest's
+		// `Channel<T>` type.
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "chan_make arity")
+		}
+		cap, err := g.evalOperand(i.Args[0], mir.TInt)
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_thread_chan_make"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(i64)")
+		return g.emitSimpleCall(i, sym, "ptr", []string{"i64 " + cap})
+	case mir.IntrinsicChanSend:
+		// Args: [channel, value].
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "chan_send arity")
+		}
+		chOp := i.Args[0]
+		valOp := i.Args[1]
+		chReg, err := g.evalOperand(chOp, chOp.Type())
+		if err != nil {
+			return err
+		}
+		elemT := channelElementType(chOp.Type())
+		if elemT == nil {
+			return unsupported("mir-mvp", "chan_send: missing element type")
+		}
+		valReg, err := g.evalOperand(valOp, elemT)
+		if err != nil {
+			return err
+		}
+		elemLLVM := g.llvmType(elemT)
+		if listUsesTypedRuntime(elemLLVM) {
+			sym := "osty_rt_thread_chan_send_" + listRuntimeSymbolSuffix(elemLLVM)
+			g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+elemLLVM+")")
+			g.fnBuf.WriteString("  call void @")
+			g.fnBuf.WriteString(sym)
+			g.fnBuf.WriteString("(ptr ")
+			g.fnBuf.WriteString(chReg)
+			g.fnBuf.WriteString(", ")
+			g.fnBuf.WriteString(elemLLVM)
+			g.fnBuf.WriteByte(' ')
+			g.fnBuf.WriteString(valReg)
+			g.fnBuf.WriteString(")\n")
+			return nil
+		}
+		// Composite element — bytes fallback.
+		slot := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(slot)
+		g.fnBuf.WriteString(" = alloca ")
+		g.fnBuf.WriteString(elemLLVM)
+		g.fnBuf.WriteByte('\n')
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(elemLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(valReg)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(slot)
+		g.fnBuf.WriteByte('\n')
+		sizeReg := g.emitSizeOf(elemLLVM)
+		sym := "osty_rt_thread_chan_send_bytes_v1"
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, i64)")
+		g.fnBuf.WriteString("  call void @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(chReg)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(slot)
+		g.fnBuf.WriteString(", i64 ")
+		g.fnBuf.WriteString(sizeReg)
+		g.fnBuf.WriteString(")\n")
+		return nil
+	case mir.IntrinsicChanRecv:
+		// Args: [channel]. Dest receives Option<T>. The runtime
+		// returns a `{i64 disc, i64 payload}` aggregate matching the
+		// MIR enum layout, so we call and store directly.
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "chan_recv arity")
+		}
+		chOp := i.Args[0]
+		chReg, err := g.evalOperand(chOp, chOp.Type())
+		if err != nil {
+			return err
+		}
+		elemT := channelElementType(chOp.Type())
+		if elemT == nil {
+			return unsupported("mir-mvp", "chan_recv: missing element type")
+		}
+		elemLLVM := g.llvmType(elemT)
+		sym := "osty_rt_thread_chan_recv_" + chanRecvSuffix(elemLLVM)
+		g.declareRuntime(sym, "declare { i64, i64 } @"+sym+"(ptr)")
+		if i.Dest == nil {
+			g.fnBuf.WriteString("  call { i64, i64 } @")
+			g.fnBuf.WriteString(sym)
+			g.fnBuf.WriteString("(ptr ")
+			g.fnBuf.WriteString(chReg)
+			g.fnBuf.WriteString(")\n")
+			return nil
+		}
+		tmp := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(" = call { i64, i64 } @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(chReg)
+		g.fnBuf.WriteString(")\n")
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return fmt.Errorf("mir-mvp: chan_recv dest %d", i.Dest.Local)
+		}
+		g.fnBuf.WriteString("  store { i64, i64 } ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+		g.fnBuf.WriteByte('\n')
+		return nil
+	case mir.IntrinsicChanClose:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "chan_close arity")
+		}
+		chReg, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_thread_chan_close"
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		g.fnBuf.WriteString("  call void @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(chReg)
+		g.fnBuf.WriteString(")\n")
+		return nil
+	case mir.IntrinsicChanIsClosed:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "chan_is_closed arity")
+		}
+		chReg, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_thread_chan_is_closed"
+		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + chReg})
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("channel intrinsic kind %d", i.Kind))
+}
+
+// channelElementType pulls T out of `Channel<T>`. Returns nil when t
+// isn't a channel shape.
+func channelElementType(t mir.Type) mir.Type {
+	if nt, ok := t.(*ir.NamedType); ok && nt.Name == "Channel" && len(nt.Args) >= 1 {
+		return nt.Args[0]
+	}
+	return nil
+}
+
+// chanRecvSuffix maps an element LLVM type to the `_<suffix>` used by
+// the chan_recv runtime. Composite element types route through a
+// bytes variant that writes into an out-param slot.
+func chanRecvSuffix(elemLLVM string) string {
+	if listUsesTypedRuntime(elemLLVM) {
+		return listRuntimeSymbolSuffix(elemLLVM)
+	}
+	return "bytes_v1"
+}
+
+// emitTaskIntrinsic dispatches structured-task ops to runtime symbols.
+// `taskGroup(body)` and `spawn(body)` take a closure env ptr as
+// argument; `g.spawn(body)` is the 2-arg form `[group, body]`.
+func (g *mirGen) emitTaskIntrinsic(i *mir.IntrinsicInstr) error {
+	switch i.Kind {
+	case mir.IntrinsicTaskGroup:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "task_group arity")
+		}
+		arg, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		retLLVM := "void"
+		if i.Dest != nil {
+			if dl := g.fn.Local(i.Dest.Local); dl != nil && !isUnitType(dl.Type) {
+				retLLVM = g.llvmType(dl.Type)
+			}
+		}
+		sym := "osty_rt_task_group"
+		g.declareRuntime(sym, "declare "+retLLVM+" @"+sym+"(ptr)")
+		return g.emitSimpleCall(i, sym, retLLVM, []string{"ptr " + arg})
+	case mir.IntrinsicSpawn:
+		// One-arg form: detached spawn(body). Two-arg form:
+		// `g.spawn(body)` — group-scoped. Both return a Handle ptr.
+		if len(i.Args) != 1 && len(i.Args) != 2 {
+			return unsupported("mir-mvp", "spawn arity")
+		}
+		operandArgs := make([]string, 0, len(i.Args))
+		for _, op := range i.Args {
+			v, err := g.evalOperand(op, op.Type())
+			if err != nil {
+				return err
+			}
+			operandArgs = append(operandArgs, "ptr "+v)
+		}
+		sym := "osty_rt_task_spawn"
+		sig := "declare ptr @" + sym + "(ptr)"
+		if len(i.Args) == 2 {
+			sym = "osty_rt_task_group_spawn"
+			sig = "declare ptr @" + sym + "(ptr, ptr)"
+		}
+		g.declareRuntime(sym, sig)
+		return g.emitSimpleCall(i, sym, "ptr", operandArgs)
+	case mir.IntrinsicHandleJoin:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "handle_join arity")
+		}
+		handle, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		// Handle's T is the value the handle will yield; the runtime
+		// returns a ptr-wide slot the caller narrows.
+		retLLVM := "ptr"
+		if i.Dest != nil {
+			if dl := g.fn.Local(i.Dest.Local); dl != nil && !isUnitType(dl.Type) {
+				retLLVM = g.llvmType(dl.Type)
+			}
+		}
+		sym := "osty_rt_task_handle_join"
+		g.declareRuntime(sym, "declare "+retLLVM+" @"+sym+"(ptr)")
+		return g.emitSimpleCall(i, sym, retLLVM, []string{"ptr " + handle})
+	case mir.IntrinsicGroupCancel:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "group_cancel arity")
+		}
+		g.evalOperand(i.Args[0], i.Args[0].Type())
+		return g.emitRuntimeVoidCall(i, "osty_rt_task_group_cancel", "ptr")
+	case mir.IntrinsicGroupIsCancelled:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "group_is_cancelled arity")
+		}
+		group, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_task_group_is_cancelled"
+		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + group})
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("task intrinsic kind %d", i.Kind))
+}
+
+// emitSelectIntrinsic handles the select DSL: the outer `select(body)`
+// call and the arm registrations (recv / send / timeout / default).
+// The arm runtime calls take the select builder as first arg.
+func (g *mirGen) emitSelectIntrinsic(i *mir.IntrinsicInstr) error {
+	switch i.Kind {
+	case mir.IntrinsicSelect:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_select", "void", []mir.Type{nil})
+	case mir.IntrinsicSelectRecv:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_select_recv", "void", nil)
+	case mir.IntrinsicSelectSend:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_select_send", "void", nil)
+	case mir.IntrinsicSelectTimeout:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_select_timeout", "void", nil)
+	case mir.IntrinsicSelectDefault:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_select_default", "void", nil)
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("select intrinsic kind %d", i.Kind))
+}
+
+// emitCancelIntrinsic handles the cancellation + yield + sleep
+// helpers. None take a receiver; they operate on the implicit
+// current task.
+func (g *mirGen) emitCancelIntrinsic(i *mir.IntrinsicInstr) error {
+	switch i.Kind {
+	case mir.IntrinsicIsCancelled:
+		sym := "osty_rt_cancel_is_cancelled"
+		g.declareRuntime(sym, "declare i1 @"+sym+"()")
+		return g.emitSimpleCall(i, sym, "i1", nil)
+	case mir.IntrinsicCheckCancelled:
+		// Returns Result<(), Error> — runtime uses the `{i64, i64}`
+		// enum layout like chan_recv.
+		sym := "osty_rt_cancel_check_cancelled"
+		g.declareRuntime(sym, "declare { i64, i64 } @"+sym+"()")
+		if i.Dest == nil {
+			g.fnBuf.WriteString("  call { i64, i64 } @")
+			g.fnBuf.WriteString(sym)
+			g.fnBuf.WriteString("()\n")
+			return nil
+		}
+		tmp := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(" = call { i64, i64 } @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("()\n")
+		g.fnBuf.WriteString("  store { i64, i64 } ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+		g.fnBuf.WriteByte('\n')
+		return nil
+	case mir.IntrinsicYield:
+		sym := "osty_rt_thread_yield"
+		g.declareRuntime(sym, "declare void @"+sym+"()")
+		g.fnBuf.WriteString("  call void @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("()\n")
+		return nil
+	case mir.IntrinsicSleep:
+		if len(i.Args) != 1 {
+			return unsupported("mir-mvp", "sleep arity")
+		}
+		dur, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_thread_sleep"
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		g.fnBuf.WriteString("  call void @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(dur)
+		g.fnBuf.WriteString(")\n")
+		return nil
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("cancel intrinsic kind %d", i.Kind))
+}
+
+// emitConcurrencyHelperIntrinsic handles `parallel` / `race` /
+// `collectAll` via their runtime entry points.
+func (g *mirGen) emitConcurrencyHelperIntrinsic(i *mir.IntrinsicInstr) error {
+	switch i.Kind {
+	case mir.IntrinsicParallel:
+		// Args: [items, concurrency, f]. Returns List<Result<R, Error>>
+		// which the runtime reports as an opaque ptr.
+		if len(i.Args) != 3 {
+			return unsupported("mir-mvp", "parallel arity")
+		}
+		items, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+		if err != nil {
+			return err
+		}
+		conc, err := g.evalOperand(i.Args[1], mir.TInt)
+		if err != nil {
+			return err
+		}
+		f, err := g.evalOperand(i.Args[2], i.Args[2].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_parallel"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, ptr)")
+		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + items, "i64 " + conc, "ptr " + f})
+	case mir.IntrinsicRace:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_task_race", "ptr", nil)
+	case mir.IntrinsicCollectAll:
+		return g.emitSimpleConcurrencyCall(i, "osty_rt_task_collect_all", "ptr", nil)
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("concurrency helper kind %d", i.Kind))
+}
+
+// emitSimpleConcurrencyCall is a concise path for concurrency runtime
+// calls that take a fixed list of ptr-typed args (one per MIR arg) and
+// return the given LLVM type. If `expected` is non-nil its length
+// must match `len(i.Args)`.
+func (g *mirGen) emitSimpleConcurrencyCall(i *mir.IntrinsicInstr, sym, retLLVM string, expected []mir.Type) error {
+	if expected != nil && len(expected) != len(i.Args) {
+		return unsupported("mir-mvp", fmt.Sprintf("%s arity: got %d args", sym, len(i.Args)))
+	}
+	argParts := make([]string, 0, len(i.Args))
+	for _, op := range i.Args {
+		v, err := g.evalOperand(op, op.Type())
+		if err != nil {
+			return err
+		}
+		argParts = append(argParts, "ptr "+v)
+	}
+	paramParts := make([]string, len(i.Args))
+	for idx := range paramParts {
+		paramParts[idx] = "ptr"
+	}
+	g.declareRuntime(sym, "declare "+retLLVM+" @"+sym+"("+strings.Join(paramParts, ", ")+")")
+	return g.emitSimpleCall(i, sym, retLLVM, argParts)
+}
+
+// emitRuntimeVoidCall emits `call void @<sym>(ptr %arg0)` using the
+// already-evaluated operand chain in i.Args.
+func (g *mirGen) emitRuntimeVoidCall(i *mir.IntrinsicInstr, sym, argLLVM string) error {
+	val, err := g.evalOperand(i.Args[0], i.Args[0].Type())
+	if err != nil {
+		return err
+	}
+	g.declareRuntime(sym, "declare void @"+sym+"("+argLLVM+")")
+	g.fnBuf.WriteString("  call void @")
+	g.fnBuf.WriteString(sym)
+	g.fnBuf.WriteByte('(')
+	g.fnBuf.WriteString(argLLVM)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(val)
+	g.fnBuf.WriteString(")\n")
+	return nil
 }
 
 // emitSimpleCall emits a `call <ret> @<sym>(<args>)` instruction and
@@ -2970,6 +3430,12 @@ func (g *mirGen) llvmType(t mir.Type) string {
 				return "ptr"
 			}
 		}
+		// Concurrency runtime types are opaque pointers too — the
+		// runtime owns their representation.
+		switch x.Name {
+		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration":
+			return "ptr"
+		}
 		// User-declared struct or enum — register the enum in the
 		// layout pool on first use and emit by name.
 		if g.mod != nil && g.mod.Layouts != nil {
@@ -3115,6 +3581,10 @@ func (g *mirGen) llvmTypeForTupleTag(t mir.Type) string {
 			case "List", "Map", "Set", "Bytes", "ClosureEnv":
 				return "ptr"
 			}
+		}
+		switch x.Name {
+		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration":
+			return "ptr"
 		}
 		return x.Name
 	case *ir.TupleType:

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -303,44 +303,28 @@ func TestGenerateFromMIRPrintln(t *testing.T) {
 	}
 }
 
-// TestGenerateFromMIRUnsupportedFallsBack — a module using a
-// concurrency primitive (`taskGroup`, still outside the MIR MVP)
-// should make the MIR emitter return an ErrUnsupported error so the
-// backend dispatcher falls back to the legacy path. Structs /
-// tuples / enums / optional / result / list / map / set / closures
-// (capturing + non-capturing) / indirect calls are all part of MVP
-// coverage as of Stage 3.8; concurrency intrinsics (spawn, chan,
-// taskGroup, select) still need runtime-symbol mapping.
+// TestGenerateFromMIRUnsupportedFallsBack — a module with a top-
+// level global (still outside the MIR MVP — emitting globals needs
+// a ctor-slot or main-prologue init path we haven't designed yet)
+// must trip `ErrUnsupported` so the backend dispatcher falls back
+// to the legacy path.
 func TestGenerateFromMIRUnsupportedFallsBack(t *testing.T) {
-	// fn run(body: fn(Group) -> Int) -> Int { taskGroup(body) }
-	groupT := &ir.NamedType{Name: "Group"}
-	fnType := &ir.FnType{Params: []ir.Type{groupT}, Return: ir.TInt}
+	// pub let version = 42
 	hir := &ir.Module{
 		Package: "main",
 		Decls: []ir.Decl{
-			&ir.FnDecl{
-				Name:   "run",
-				Return: ir.TInt,
-				Params: []*ir.Param{{Name: "body", Type: fnType}},
-				Body: &ir.Block{
-					Result: &ir.CallExpr{
-						Callee: &ir.Ident{
-							Name: "taskGroup", Kind: ir.IdentFn,
-							T: &ir.FnType{Params: []ir.Type{fnType}, Return: ir.TInt},
-						},
-						Args: []ir.Arg{
-							{Value: &ir.Ident{Name: "body", Kind: ir.IdentParam, T: fnType}},
-						},
-						T: ir.TInt,
-					},
-				},
+			&ir.LetDecl{
+				Name:     "version",
+				Type:     ir.TInt,
+				Value:    &ir.IntLit{Text: "42", T: ir.TInt},
+				Exported: true,
 			},
 		},
 	}
 	m := buildMIRModuleFromHIR(t, hir)
-	_, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/taskgroup.osty"})
+	_, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/global.osty"})
 	if err == nil {
-		t.Fatalf("expected ErrUnsupported for taskGroup; got nil")
+		t.Fatalf("expected ErrUnsupported for global; got nil")
 	}
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("error does not wrap ErrUnsupported: %v", err)
@@ -432,28 +416,19 @@ func TestMIRDualEmitFromSource(t *testing.T) {
 // independent of parser / checker restrictions on closure-trailing-
 // expr source shape.
 func TestMIRDualEmitGracefulFallback(t *testing.T) {
-	// Use a taskGroup intrinsic — still outside MVP after Stage 3.8
-	// (concurrency intrinsic runtime mapping is a separate wedge).
-	groupT := &ir.NamedType{Name: "Group"}
-	fnType := &ir.FnType{Params: []ir.Type{groupT}, Return: ir.TInt}
-	fn := &ir.FnDecl{
-		Name:   "run",
-		Return: ir.TInt,
-		Params: []*ir.Param{{Name: "body", Type: fnType}},
-		Body: &ir.Block{
-			Result: &ir.CallExpr{
-				Callee: &ir.Ident{
-					Name: "taskGroup", Kind: ir.IdentFn,
-					T: &ir.FnType{Params: []ir.Type{fnType}, Return: ir.TInt},
-				},
-				Args: []ir.Arg{
-					{Value: &ir.Ident{Name: "body", Kind: ir.IdentParam, T: fnType}},
-				},
-				T: ir.TInt,
+	// Use a top-level global — still outside MVP (globals need a
+	// ctor-slot or main-prologue init path we haven't designed yet).
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.LetDecl{
+				Name:     "version",
+				Type:     ir.TInt,
+				Value:    &ir.IntLit{Text: "1", T: ir.TInt},
+				Exported: true,
 			},
 		},
 	}
-	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
 	monoMod, monoErrs := ir.Monomorphize(hir)
 	if len(monoErrs) != 0 {
 		t.Fatalf("monomorphize: %v", monoErrs)
@@ -462,7 +437,7 @@ func TestMIRDualEmitGracefulFallback(t *testing.T) {
 
 	_, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/fallback.osty"})
 	if err == nil {
-		t.Fatalf("expected MIR emitter to refuse taskGroup program")
+		t.Fatalf("expected MIR emitter to refuse global-bearing program")
 	}
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("expected ErrUnsupported, got %T: %v", err, err)
@@ -1422,5 +1397,163 @@ func TestGenerateFromMIRTopLevelFnAsValue(t *testing.T) {
 	}
 	if !strings.Contains(got, "call i64 @double(i64 %arg0)") {
 		t.Fatalf("expected thunk to delegate to @double, got:\n%s", got)
+	}
+}
+
+// ==== Stage 3.9: concurrency intrinsic runtime mapping ====
+
+func TestGenerateFromMIRChanSendRecv(t *testing.T) {
+	// fn push(ch: Channel<Int>, v: Int) { ch <- v }
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "push",
+		Return: ir.TUnit,
+		Params: []*ir.Param{
+			{Name: "ch", Type: chanInt},
+			{Name: "v", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ChanSendStmt{
+					Channel: &ir.Ident{Name: "ch", Kind: ir.IdentParam, T: chanInt},
+					Value:   &ir.Ident{Name: "v", Kind: ir.IdentParam, T: ir.TInt},
+				},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/chan.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare void @osty_rt_thread_chan_send_i64(ptr, i64)",
+		"call void @osty_rt_thread_chan_send_i64(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRChanMakeAndClose(t *testing.T) {
+	// use std.thread as thread
+	// fn setup() { let ch = thread.chan::<Int>(4); ch.close() }
+	useT := &ir.UseDecl{
+		Path: []string{"std", "thread"}, RawPath: "std.thread", Alias: "thread",
+	}
+	chanInt := &ir.NamedType{Name: "Channel", Args: []ir.Type{ir.TInt}}
+	fn := &ir.FnDecl{
+		Name:   "setup",
+		Return: ir.TUnit,
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name: "ch",
+					Type: chanInt,
+					Value: &ir.MethodCall{
+						Receiver: &ir.Ident{Name: "thread", T: &ir.NamedType{Name: "ThreadModule"}},
+						Name:     "chan",
+						TypeArgs: []ir.Type{ir.TInt},
+						Args:     []ir.Arg{{Value: &ir.IntLit{Text: "4", T: ir.TInt}}},
+						T:        chanInt,
+					},
+				},
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "ch", Kind: ir.IdentLocal, T: chanInt},
+					Name:     "close",
+					T:        ir.TUnit,
+				}},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{useT, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/make.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_thread_chan_make(i64)",
+		"call ptr @osty_rt_thread_chan_make(i64 4)",
+		"declare void @osty_rt_thread_chan_close(ptr)",
+		"call void @osty_rt_thread_chan_close(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRTaskGroupAndSpawn(t *testing.T) {
+	// fn launch(body: fn(Group) -> Int) -> Int { taskGroup(body) }
+	groupT := &ir.NamedType{Name: "Group"}
+	fnType := &ir.FnType{Params: []ir.Type{groupT}, Return: ir.TInt}
+	fn := &ir.FnDecl{
+		Name:   "launch",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "body", Type: fnType}},
+		Body: &ir.Block{
+			Result: &ir.CallExpr{
+				Callee: &ir.Ident{
+					Name: "taskGroup", Kind: ir.IdentFn,
+					T: &ir.FnType{Params: []ir.Type{fnType}, Return: ir.TInt},
+				},
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "body", Kind: ir.IdentParam, T: fnType}},
+				},
+				T: ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/task.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_task_group(ptr)",
+		"call i64 @osty_rt_task_group(ptr ",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRCancellationHelpers(t *testing.T) {
+	useT := &ir.UseDecl{
+		Path: []string{"std", "thread"}, RawPath: "std.thread", Alias: "thread",
+	}
+	fn := &ir.FnDecl{
+		Name:   "check",
+		Return: ir.TBool,
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "thread", T: &ir.NamedType{Name: "ThreadModule"}},
+				Name:     "isCancelled",
+				T:        ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{useT, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/cancel.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_cancel_is_cancelled()",
+		"call i1 @osty_rt_cancel_is_cancelled()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
 	}
 }


### PR DESCRIPTION
Routes every MIR concurrency intrinsic through a stable-but-pending Osty runtime ABI so concurrency code reaches the MIR emitter instead of falling back to the legacy HIR→AST bridge.

The runtime itself isn't in-tree yet (same story as `osty.gc.alloc_v1` and the existing list/map/set helpers): generated LLVM text is correct and declare lines are emitted, but linking will fail until the runtime ships the symbols.

## Runtime ABI

| Family | Symbols |
|---|---|
| **Channels** | `osty_rt_thread_chan_make(i64) -> ptr`; `…_chan_send_<suffix>` (scalar) / `…_chan_send_bytes_v1` (composite); `…_chan_recv_<suffix> -> {i64, i64}` (Option<T> layout); `…_chan_close` / `…_chan_is_closed` |
| **Structured tasks** | `osty_rt_task_group(ptr) -> <ret>`; `osty_rt_task_spawn(ptr) -> ptr`; `osty_rt_task_group_spawn(ptr, ptr) -> ptr`; `osty_rt_task_handle_join`; `osty_rt_task_group_cancel`; `osty_rt_task_group_is_cancelled -> i1` |
| **Select** | `osty_rt_select(ptr body)` + `osty_rt_select_recv/send/timeout/default` for arms |
| **Cancellation** | `osty_rt_cancel_is_cancelled -> i1`; `osty_rt_cancel_check_cancelled -> {i64, i64}`; `osty_rt_thread_yield`; `osty_rt_thread_sleep(ptr duration)` |
| **Helpers** | `osty_rt_parallel(ptr items, i64 n, ptr f) -> ptr`; `osty_rt_task_race`; `osty_rt_task_collect_all` |

Concurrency types (`Channel<T>`, `Handle<T>`, `Group`/`TaskGroup`, `Select`, `Duration`) all lower to `ptr` at the LLVM boundary — they're opaque to the emitter.

## Implementation

- **`isSupportedIntrinsic`** lists all concurrency intrinsic kinds.
- **`emitIntrinsic`** dispatches into five new handlers — `emitChannelIntrinsic`, `emitTaskIntrinsic`, `emitSelectIntrinsic`, `emitCancelIntrinsic`, `emitConcurrencyHelperIntrinsic`.
- `emitChannelIntrinsic` splits scalar/composite element paths for send/recv; recv returns `{i64, i64}` directly, matching the MIR Option layout so the dest store is straight-through.
- `emitTaskIntrinsic` picks 1-arg vs 2-arg spawn by arg count; reads return type off the dest when present.
- `emitSimpleConcurrencyCall` + `emitRuntimeVoidCall` helpers centralise the thin-wrapper pattern (ptr args, fixed return).
- `typeSupported` / `llvmType` / `llvmTypeForTupleTag` accept `Channel` / `Handle` / `Group` / `TaskGroup` / `Select` / `Duration` as ptr-shaped opaque types without declared layouts.

## Tests — 4 new cases

- `TestGenerateFromMIRChanSendRecv` — `ChanSendStmt` emits `osty_rt_thread_chan_send_i64`.
- `TestGenerateFromMIRChanMakeAndClose` — `thread.chan::<Int>(4)` + `ch.close()` emits make + close symbols.
- `TestGenerateFromMIRTaskGroupAndSpawn` — `taskGroup(body)` emits `osty_rt_task_group`.
- `TestGenerateFromMIRCancellationHelpers` — `thread.isCancelled()` emits `osty_rt_cancel_is_cancelled`.

Fallback regression tests (`…UnsupportedFallsBack` / `…GracefulFallback`) move to a top-level-global trigger (still outside the MIR MVP). Concurrency no longer triggers fallback.

## Test plan

- [x] `go test -run MIR ./internal/llvmgen`
- [x] `go test ./internal/parser ./internal/ir ./internal/mir`

## Remaining Stage 5 gap (updated)

- **Top-level globals** — next wedge (`@<name>` LLVM globals + ctor-slot or main-prologue init)
- **GC roots / safepoints**
- **Composite map element types**
- **Heap-escaping closure envs**
- **`DerefProj` beyond closure env**

Concurrency intrinsics crossed off. The runtime side remains pending — this PR only fixes MIR emitter coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)