### PR TITLE
feat(selfhost): run/build/airepair CLI policy → toolchain/*.osty

### DIFF
--- a/cmd/osty/airepair.go
+++ b/cmd/osty/airepair.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/osty/osty/internal/airepair"
 	"github.com/osty/osty/internal/repair"
+	"github.com/osty/osty/internal/runner"
 )
 
 // runAIRepair implements `osty airepair`: a small pre-parser source fixer
@@ -175,19 +176,16 @@ func reportRepairSummary(w io.Writer, prefix, path string, res repair.Result) {
 	fmt.Fprintf(w, "%s: applied %d repair(s)\n", prefix, len(res.Changes))
 }
 
+// parseAIRepairMode routes the flag string through the shared
+// toolchain/airepair_flags.osty policy and then re-types the
+// canonical name back to airepair.Mode (the policy side stays
+// stringly-typed to keep it free of Go package imports).
 func parseAIRepairMode(value string) (airepair.Mode, bool) {
-	switch value {
-	case "", string(airepair.ModeAutoAssist):
-		return airepair.ModeAutoAssist, true
-	case string(airepair.ModeRewriteOnly):
-		return airepair.ModeRewriteOnly, true
-	case string(airepair.ModeParseAssist):
-		return airepair.ModeParseAssist, true
-	case string(airepair.ModeFrontEndAssist):
-		return airepair.ModeFrontEndAssist, true
-	default:
+	res := runner.ParseAiRepairMode(value)
+	if !res.Ok {
 		return "", false
 	}
+	return airepair.Mode(res.Mode), true
 }
 
 func registerAIRepairCommandFlags(fs *flag.FlagSet, enabled *bool, mode *string) {

--- a/cmd/osty/airepair_capture.go
+++ b/cmd/osty/airepair_capture.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/osty/osty/internal/airepair"
+	"github.com/osty/osty/internal/runner"
 )
 
 type aiRepairCaptureMode string
@@ -18,28 +19,22 @@ const (
 	aiRepairCaptureAlways   aiRepairCaptureMode = "always"
 )
 
+// parseAIRepairCaptureMode routes the --capture-if flag through
+// toolchain/airepair_flags.osty and re-types the canonical name.
 func parseAIRepairCaptureMode(value string) (aiRepairCaptureMode, bool) {
-	switch value {
-	case "", string(aiRepairCaptureResidual):
-		return aiRepairCaptureResidual, true
-	case string(aiRepairCaptureChanged):
-		return aiRepairCaptureChanged, true
-	case string(aiRepairCaptureAlways):
-		return aiRepairCaptureAlways, true
-	default:
+	res := runner.ParseAiRepairCaptureMode(value)
+	if !res.Ok {
 		return "", false
 	}
+	return aiRepairCaptureMode(res.Mode), true
 }
 
+// shouldCaptureAIRepairResult destructures the airepair.Result
+// down to (changed, totalErrorsAfter) and lets the shared policy
+// decide. Keeps the airepair.Result Go type out of Osty so the
+// toolchain module stays pure.
 func shouldCaptureAIRepairResult(result airepair.Result, mode aiRepairCaptureMode) bool {
-	switch mode {
-	case aiRepairCaptureAlways:
-		return true
-	case aiRepairCaptureChanged:
-		return result.Changed
-	default:
-		return result.After.TotalErrors > 0
-	}
+	return runner.ShouldCaptureAiRepair(string(mode), result.Changed, result.After.TotalErrors)
 }
 
 func captureAIRepairCase(dir, base string, result airepair.Result) error {

--- a/cmd/osty/backend_helpers.go
+++ b/cmd/osty/backend_helpers.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/runner"
 )
 
 func firstBackendWarning(r *backend.Result) error {
@@ -19,11 +20,21 @@ func defaultBackendName() string {
 	return backend.NameLLVM.String()
 }
 
+// defaultEmitMode delegates the text-vs-binary decision to
+// runner (toolchain/runner.osty) and then parses the canonical
+// string back into a backend.EmitMode. The Go backend was isolated
+// as bootstrap-only in af4e03b so the production registry only
+// exposes llvm-ir / binary / object; both of runner's outputs
+// (llvm-ir, binary) parse cleanly in the default build.
 func defaultEmitMode(tool string, name backend.Name) backend.EmitMode {
-	if tool == "gen" || tool == "pipeline" {
-		return backend.EmitLLVMIR
+	raw := runner.DefaultEmitMode(tool)
+	mode, err := backend.ParseEmitMode(raw)
+	if err != nil {
+		// runner only returns "llvm-ir" or "binary"; both are
+		// registered modes, so a parse failure here is a harness bug.
+		return backend.EmitBinary
 	}
-	return backend.EmitBinary
+	return mode
 }
 
 func parseCLIBackend(raw string) (backend.Name, error) {
@@ -38,16 +49,15 @@ func parseCLIEmitMode(raw string) (backend.EmitMode, error) {
 	return mode, nil
 }
 
+// validateCLIEmit runs two layers of validation. The tool-level
+// rules ("gen with backend go must emit go", "run requires
+// binary") live in toolchain/runner.osty so every future subcommand
+// that wraps the backend inherits the same UX. The backend's own
+// ValidateEmit then enforces capability ("this backend can't
+// produce this format at all").
 func validateCLIEmit(tool string, name backend.Name, mode backend.EmitMode) error {
-	switch tool {
-	case "gen", "pipeline":
-		if name == backend.NameLLVM && mode != backend.EmitLLVMIR {
-			return fmt.Errorf("%s with backend %q cannot emit %q (want %q)", tool, name, mode, backend.EmitLLVMIR)
-		}
-	case "run", "test":
-		if mode != backend.EmitBinary {
-			return fmt.Errorf("%s requires --emit=%q", tool, backend.EmitBinary)
-		}
+	if d := runner.ToolEmitCompat(tool, string(name), string(mode)); d != nil {
+		return errors.New(d.Message)
 	}
 	return backend.ValidateEmit(name, mode)
 }

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/toolchain"
 )
@@ -456,13 +457,22 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 	profileName, triple := resolvedKey(resolved)
 	binName := ""
 	if emitMode == backend.EmitBinary {
-		binName = binaryName(m)
-		if triple != "" {
-			binName += "-" + triple
+		// Binary filename policy lives in toolchain/runner.osty —
+		// base name + optional -<triple> + optional .exe are all a
+		// function of (manifest, target, host). See internal/runner.
+		binBaseOverride := ""
+		pkgName := ""
+		if m != nil {
+			if m.Bin != nil {
+				binBaseOverride = m.Bin.Name
+			}
+			pkgName = m.Package.Name
 		}
-		if runtime.GOOS == "windows" && (triple == "" || resolved.Target == nil || resolved.Target.OS == "windows") {
-			binName += ".exe"
+		targetOS := ""
+		if resolved.Target != nil {
+			targetOS = resolved.Target.OS
 		}
+		binName = runner.BuildBinaryName(binBaseOverride, pkgName, triple, targetOS, runtime.GOOS)
 	}
 	selectedBackend := backendFromCLI("build", backendID)
 	entry, err := backend.PrepareEntry("main", entryAbs, entryFile.File, res, chk)
@@ -504,19 +514,6 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 	fmt.Fprintf(os.Stderr, "osty build: backend %q emit %q did not produce a buildable artifact\n", backendID, emitMode)
 	os.Exit(1)
 	return nil
-}
-
-// binaryName returns the binary name for the package: the manifest's
-// [bin].name override, the package name, or "app" as a last-resort
-// default.
-func binaryName(m *manifest.Manifest) string {
-	if m != nil && m.Bin != nil && m.Bin.Name != "" {
-		return m.Bin.Name
-	}
-	if m != nil && m.Package.Name != "" {
-		return m.Package.Name
-	}
-	return "app"
 }
 
 // resolvedKey unpacks a Resolved into (profile name, triple) so the

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osty/osty/internal/pkgmgr"
 	"github.com/osty/osty/internal/profile"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -87,15 +88,18 @@ func runRun(args []string, cliF cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", perr)
 		os.Exit(2)
 	}
-	// `osty run` is a build-and-execute shortcut. A non-host target
-	// triple would produce a binary that can't run on this machine,
-	// so steer the user toward `osty build --target` instead.
+	// `osty run` is a build-and-execute shortcut. Policy for "may
+	// we exec this on the host?" lives in toolchain/runner.osty via
+	// runner.CrossCompileGuard so the same rule applies to any
+	// future host that wraps the run command (e.g. `osty test`
+	// running a native artifact).
+	targetTriple := ""
 	if resolved.Target != nil {
-		fmt.Fprintf(os.Stderr,
-			"osty run: cannot execute cross-compiled binary for %s on host\n",
-			resolved.Target.Triple)
-		fmt.Fprintln(os.Stderr,
-			"hint: use `osty build --target "+resolved.Target.Triple+"` to produce the binary")
+		targetTriple = resolved.Target.Triple
+	}
+	if guard := runner.CrossCompileGuard(targetTriple); guard.Blocked {
+		fmt.Fprintln(os.Stderr, "osty run: "+guard.Diag.Message)
+		fmt.Fprintln(os.Stderr, "hint: "+guard.Diag.Hint)
 		os.Exit(2)
 	}
 	_ = filepath.Join(root, manifest.ManifestFile) // kept for future inline rewriting
@@ -112,11 +116,14 @@ func runRun(args []string, cliF cliFlags) {
 	deps := pkgmgr.NewDepProvider(m, graph, env)
 
 	// Step 2: pick the entry file. A binary project uses main.osty
-	// at the project root unless [bin].path overrides it.
-	entry := filepath.Join(root, "main.osty")
-	if m.Bin != nil && m.Bin.Path != "" {
-		entry = filepath.Join(root, m.Bin.Path)
+	// at the project root unless [bin].path overrides it. The rule
+	// lives in toolchain/runner.osty; cross-platform separator is
+	// the host's filepath.Separator.
+	binPath := ""
+	if m.Bin != nil {
+		binPath = m.Bin.Path
 	}
+	entry := runner.EntryPathFor(root, binPath, string(filepath.Separator))
 	if _, err := os.Stat(entry); err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: entry %s not found: %v\n", entry, err)
 		fmt.Fprintln(os.Stderr, "hint: create main.osty or override with [bin].path in osty.toml")
@@ -193,11 +200,18 @@ func runRun(args []string, cliF cliFlags) {
 	if resolved.Target != nil {
 		triple = resolved.Target.Triple
 	}
-	binName := ""
-	binName = binaryName(m)
-	if runtime.GOOS == "windows" {
-		binName += ".exe"
+	// Binary filename policy (base name + optional .exe suffix) is
+	// authored in toolchain/runner.osty and snapshotted in
+	// internal/runner. Keep this call site free of OS-shape logic.
+	binBaseOverride := ""
+	pkgName := ""
+	if m != nil {
+		if m.Bin != nil {
+			binBaseOverride = m.Bin.Name
+		}
+		pkgName = m.Package.Name
 	}
+	binName := runner.BinaryNameFor(binBaseOverride, pkgName, runtime.GOOS)
 	selectedBackend := backendFromCLI("run", backendID)
 	backendEntry, err := backend.PrepareEntry("main", entryAbs, file, res, chk)
 	if err != nil {
@@ -245,40 +259,3 @@ func runNativeBinary(binPath string, args []string, dir string) {
 	}
 }
 
-// mergeEnv overlays per-build env overrides (GOOS, GOARCH,
-// CGO_ENABLED, plus any user-declared vars) on top of the parent
-// process's environment and returns a slice suitable for exec.Cmd.Env.
-// A later entry with the same key wins — the convention matches
-// exec.Command's own lookup.
-func mergeEnv(parent []string, overrides map[string]string) []string {
-	if len(overrides) == 0 {
-		return parent
-	}
-	// Copy parent so the caller's slice stays intact.
-	out := make([]string, 0, len(parent)+len(overrides))
-	seen := map[string]bool{}
-	for k, v := range overrides {
-		out = append(out, k+"="+v)
-		seen[k] = true
-	}
-	for _, kv := range parent {
-		// KEY=VALUE — locate the '='; skip the parent entry when
-		// an override shadows it.
-		eq := -1
-		for i := 0; i < len(kv); i++ {
-			if kv[i] == '=' {
-				eq = i
-				break
-			}
-		}
-		if eq < 0 {
-			out = append(out, kv)
-			continue
-		}
-		if seen[kv[:eq]] {
-			continue
-		}
-		out = append(out, kv)
-	}
-	return out
-}

--- a/internal/runner/airepair_policy.go
+++ b/internal/runner/airepair_policy.go
@@ -1,0 +1,74 @@
+// airepair_policy.go is the Go snapshot of
+// toolchain/airepair_flags.osty. The Osty source is authoritative;
+// see generate.go for the long-term automation plan.
+package runner
+
+// AiRepairModeResult mirrors toolchain/airepair_flags.osty's
+// AiRepairModeResult. Empty Mode + Ok=false means "unknown value".
+//
+// Osty: toolchain/airepair_flags.osty:11
+type AiRepairModeResult struct {
+	Mode string
+	Ok   bool
+}
+
+// AiRepairCaptureModeResult is the --capture-if shape.
+//
+// Osty: toolchain/airepair_flags.osty:17
+type AiRepairCaptureModeResult struct {
+	Mode string
+	Ok   bool
+}
+
+// ParseAiRepairMode accepts the --airepair-mode flag and returns
+// the canonical mode name. Empty string resolves to "auto" so that
+// an unset flag behaves like `--airepair-mode=auto`.
+//
+// Osty: toolchain/airepair_flags.osty:30
+func ParseAiRepairMode(value string) AiRepairModeResult {
+	switch value {
+	case "", "auto":
+		return AiRepairModeResult{Mode: "auto", Ok: true}
+	case "rewrite":
+		return AiRepairModeResult{Mode: "rewrite", Ok: true}
+	case "parse":
+		return AiRepairModeResult{Mode: "parse", Ok: true}
+	case "frontend":
+		return AiRepairModeResult{Mode: "frontend", Ok: true}
+	default:
+		return AiRepairModeResult{Mode: "", Ok: false}
+	}
+}
+
+// ParseAiRepairCaptureMode accepts the --capture-if flag. Empty
+// resolves to "residual" (conservative default).
+//
+// Osty: toolchain/airepair_flags.osty:47
+func ParseAiRepairCaptureMode(value string) AiRepairCaptureModeResult {
+	switch value {
+	case "", "residual":
+		return AiRepairCaptureModeResult{Mode: "residual", Ok: true}
+	case "changed":
+		return AiRepairCaptureModeResult{Mode: "changed", Ok: true}
+	case "always":
+		return AiRepairCaptureModeResult{Mode: "always", Ok: true}
+	default:
+		return AiRepairCaptureModeResult{Mode: "", Ok: false}
+	}
+}
+
+// ShouldCaptureAiRepair decides whether an airepair run warrants
+// writing a capture artifact, given the resolved --capture-if mode
+// and two facts from the repair result.
+//
+// Osty: toolchain/airepair_flags.osty:68
+func ShouldCaptureAiRepair(captureMode string, changed bool, totalErrorsAfter int) bool {
+	switch captureMode {
+	case "always":
+		return true
+	case "changed":
+		return changed
+	default:
+		return totalErrorsAfter > 0
+	}
+}

--- a/internal/runner/airepair_policy_test.go
+++ b/internal/runner/airepair_policy_test.go
@@ -1,0 +1,88 @@
+package runner
+
+import "testing"
+
+func TestParseAiRepairModeKnownValues(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "auto"},
+		{"auto", "auto"},
+		{"rewrite", "rewrite"},
+		{"parse", "parse"},
+		{"frontend", "frontend"},
+	}
+	for _, c := range cases {
+		got := ParseAiRepairMode(c.in)
+		if !got.Ok {
+			t.Errorf("ParseAiRepairMode(%q).Ok = false, want true", c.in)
+		}
+		if got.Mode != c.want {
+			t.Errorf("ParseAiRepairMode(%q).Mode = %q, want %q", c.in, got.Mode, c.want)
+		}
+	}
+}
+
+func TestParseAiRepairModeRejectsUnknown(t *testing.T) {
+	got := ParseAiRepairMode("nope")
+	if got.Ok {
+		t.Errorf("ParseAiRepairMode(nope).Ok = true, want false")
+	}
+	if got.Mode != "" {
+		t.Errorf("ParseAiRepairMode(nope).Mode = %q, want empty", got.Mode)
+	}
+}
+
+func TestParseAiRepairCaptureModeKnownValues(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "residual"},
+		{"residual", "residual"},
+		{"changed", "changed"},
+		{"always", "always"},
+	}
+	for _, c := range cases {
+		got := ParseAiRepairCaptureMode(c.in)
+		if !got.Ok {
+			t.Errorf("ParseAiRepairCaptureMode(%q).Ok = false, want true", c.in)
+		}
+		if got.Mode != c.want {
+			t.Errorf("ParseAiRepairCaptureMode(%q).Mode = %q, want %q", c.in, got.Mode, c.want)
+		}
+	}
+}
+
+func TestParseAiRepairCaptureModeRejectsUnknown(t *testing.T) {
+	got := ParseAiRepairCaptureMode("sometimes")
+	if got.Ok {
+		t.Errorf("ParseAiRepairCaptureMode(sometimes).Ok = true, want false")
+	}
+}
+
+func TestShouldCaptureAiRepair(t *testing.T) {
+	cases := []struct {
+		name         string
+		mode         string
+		changed      bool
+		totalErrors  int
+		want         bool
+	}{
+		{"always-no-changes-no-errors", "always", false, 0, true},
+		{"always-changed-errors", "always", true, 5, true},
+		{"changed-true", "changed", true, 0, true},
+		{"changed-false", "changed", false, 5, false},
+		{"residual-errors-remain", "residual", false, 1, true},
+		{"residual-no-errors", "residual", true, 0, false},
+		{"empty-defaults-to-residual-no-errors", "", false, 0, false},
+		{"empty-defaults-to-residual-with-errors", "", false, 3, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ShouldCaptureAiRepair(c.mode, c.changed, c.totalErrors); got != c.want {
+				t.Errorf("ShouldCaptureAiRepair(%q, %v, %d) = %v, want %v",
+					c.mode, c.changed, c.totalErrors, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestPolicySnapshotParityWithOsty guards against drift between
+// Osty policy files under toolchain/ (source of truth) and the Go
+// snapshots in this package (consumed at build time).
+//
+// It parses each Osty file for every `pub fn` and `pub struct` and
+// asserts a correspondingly-named exported Go symbol exists
+// somewhere in this package. The naming rule is: upper-camel in
+// Osty stays upper-camel in Go, lower-camel in Osty is capitalized
+// (since Go uses leading capitals for export). Unexported Osty
+// identifiers (`fn`/`struct` without `pub`) are helpers and
+// intentionally not enforced — they may be inlined or renamed in
+// the Go snapshot.
+//
+// Add a new Osty file to `ostySources` when migrating more CLI
+// policy to the toolchain.
+//
+// When this test fails, either:
+//
+//   - You changed an Osty file; mirror the change in the Go
+//     snapshot and update goNameOf's allowlist if the API
+//     genuinely diverges.
+//   - You changed a Go snapshot; backport the change to its Osty
+//     source so the toolchain stays the authority.
+func TestPolicySnapshotParityWithOsty(t *testing.T) {
+	ostySources := []string{"runner.osty", "airepair_flags.osty"}
+
+	// The Go side adapts names to Go conventions; RunnerDiag
+	// specifically is shortened to Diag here because the full
+	// package path makes "runner.Diag" clearer than
+	// "runner.RunnerDiag". Other names are a pure capitalisation
+	// round-trip.
+	goNameOf := func(osty string) string {
+		if osty == "RunnerDiag" {
+			return "Diag"
+		}
+		return strings.ToUpper(osty[:1]) + osty[1:]
+	}
+
+	exports := collectGoExports(t)
+
+	for _, rel := range ostySources {
+		t.Run(rel, func(t *testing.T) {
+			ostyPath := repoRelPath(t, "toolchain", rel)
+			src, err := os.ReadFile(ostyPath)
+			if err != nil {
+				t.Fatalf("read %s: %v", ostyPath, err)
+			}
+			pubFns := extractOstyPubNames(string(src), `pub\s+fn\s+([A-Za-z_][A-Za-z0-9_]*)`)
+			pubStructs := extractOstyPubNames(string(src), `pub\s+struct\s+([A-Za-z_][A-Za-z0-9_]*)`)
+			if len(pubFns) == 0 && len(pubStructs) == 0 {
+				t.Fatalf("%s declared no pub fns/structs — parser regression?", rel)
+			}
+			for _, name := range pubFns {
+				want := goNameOf(name)
+				if _, ok := exports[want]; !ok {
+					t.Errorf("pub fn %s from %s has no Go export %s", name, rel, want)
+				}
+			}
+			for _, name := range pubStructs {
+				want := goNameOf(name)
+				if _, ok := exports[want]; !ok {
+					t.Errorf("pub struct %s from %s has no Go export %s", name, rel, want)
+				}
+			}
+		})
+	}
+}
+
+func extractOstyPubNames(src, pattern string) []string {
+	re := regexp.MustCompile(pattern)
+	matches := re.FindAllStringSubmatch(src, -1)
+	seen := map[string]bool{}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		if seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		out = append(out, m[1])
+	}
+	return out
+}
+
+func collectGoExports(t *testing.T) map[string]struct{} {
+	t.Helper()
+	dir := repoRelPath(t, "internal", "runner")
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", dir, err)
+	}
+	out := map[string]struct{}{}
+	for _, pkg := range pkgs {
+		for _, f := range pkg.Files {
+			for _, decl := range f.Decls {
+				switch d := decl.(type) {
+				case *ast.FuncDecl:
+					if d.Name.IsExported() {
+						out[d.Name.Name] = struct{}{}
+					}
+				case *ast.GenDecl:
+					for _, spec := range d.Specs {
+						if ts, ok := spec.(*ast.TypeSpec); ok && ts.Name.IsExported() {
+							out[ts.Name.Name] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// repoRelPath resolves a repo-relative path by walking up from the
+// test's working directory (the package under test) until it finds
+// go.mod. This keeps the test robust to `go test ./internal/runner`
+// invoked from any cwd.
+func repoRelPath(t *testing.T, parts ...string) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod from %s", dir)
+		}
+		dir = parent
+	}
+	return filepath.Join(append([]string{dir}, parts...)...)
+}

--- a/internal/runner/generate.go
+++ b/internal/runner/generate.go
@@ -1,0 +1,57 @@
+// Package runner ships both the Osty source (toolchain/runner.osty)
+// and a hand-maintained Go snapshot (policy.go). The long-term goal
+// is for `osty gen` to emit policy.go directly; the rest of this
+// file documents why that isn't wired up yet and what the next
+// maintainer needs to fix.
+//
+// Experiment (2026-04-18):
+//
+//	# Isolated (toolchain/ siblings have unrelated pre-existing
+//	# front-end errors; run from a scratch dir):
+//	mkdir -p /tmp/runner-gen-src
+//	cp toolchain/runner.osty /tmp/runner-gen-src/
+//	osty gen --backend go --emit go --package runner \
+//	    -o internal/runner/generated.go \
+//	    /tmp/runner-gen-src/runner.osty
+//
+// What works:
+//
+//   - The gen command accepts a single-file package that `use
+//     std.strings`es and produces a syntactically valid Go file with
+//     the correct package declaration and line markers.
+//
+// What still breaks:
+//
+//  1. std.strings doesn't lower. Generated calls read
+//     `strings.concat`, `strings.hasSuffix`, `strings.indexOf`, etc.
+//     — the Osty surface, not Go's strings.HasSuffix / strings.Index
+//     / `+` concatenation. The gen backend needs a prelude that maps
+//     each stdlib function to its Go equivalent (or ships a runtime
+//     helper).
+//
+//  2. `pub` doesn't propagate to Go export. Field `pub severity`
+//     emits as lowercase `severity` and `pub fn binaryBaseName`
+//     emits as lowercase `binaryBaseName`. Callers outside the
+//     package can't see them. Fix: capitalise identifiers declared
+//     `pub` when the emit target is `go`.
+//
+//  3. Option types round-trip through `**T`. `RunnerDiag?` in the
+//     Osty CrossCompileOutcome lowers to `**RunnerDiag`. For a
+//     hand-written Go API `*RunnerDiag` is the idiomatic shape.
+//
+//  4. `if` expressions wrap in `func() any { ... }()`. Harmless for
+//     bootstrap bundles that already depend on `any`-typed helpers,
+//     but the standalone-package emit path should produce concrete
+//     Go types so nothing boxes through `any`.
+//
+// Once (1)–(4) are addressed, replace this file with:
+//
+//	//go:generate go run gen_runner.go
+//
+// and add a `gen_runner.go` mirroring internal/selfhost/gen_selfhost.go.
+// For now, policy.go is the source of truth at `go build` time and
+// toolchain/runner.osty is the source of truth at review time; the
+// drift_test.go in this package enforces that the two stay in sync
+// (every `pub fn` / `pub struct` in the Osty file must have a
+// matching exported Go symbol here).
+package runner

--- a/internal/runner/policy.go
+++ b/internal/runner/policy.go
@@ -1,0 +1,219 @@
+// Package runner is a manual Go snapshot of the pure `osty run`
+// policy that lives in toolchain/runner.osty.
+//
+// The Osty file is the source of truth per the project's self-host
+// rule ("Osty로 작성 가능한 것은 Go로 작성 금지"). This package
+// exists so cmd/osty and internal callers can link the policy
+// without requiring a live compile of Osty at `go build` time. When
+// the self-host pipeline can fully consume toolchain/runner.osty
+// this file should be regenerated rather than hand-edited.
+//
+// Rules for editors:
+//
+//   - Any behaviour change starts in toolchain/runner.osty with a
+//     test in toolchain/runner_test.osty.
+//   - This file is then updated to match. The line markers below
+//     ("// Osty: toolchain/runner.osty:NN") flag the counterpart in
+//     the Osty source.
+//   - No I/O, no filepath, no os/runtime lookups live here — the
+//     caller injects sep/goos so this package remains pure.
+package runner
+
+import "strings"
+
+// Osty: toolchain/runner.osty:13
+type Diag struct {
+	Severity string
+	Code     string
+	Message  string
+	Hint     string
+}
+
+// Osty: toolchain/runner.osty:21
+type EnvEntry struct {
+	Key   string
+	Value string
+}
+
+// Osty: toolchain/runner.osty:32
+type CrossCompileOutcome struct {
+	Blocked bool
+	Diag    *Diag
+}
+
+// BinaryBaseName picks the binary filename stem from the manifest.
+// Precedence: [bin].name override, then package name, then "app".
+//
+// Osty: toolchain/runner.osty:44
+func BinaryBaseName(binName, pkgName string) string {
+	if binName != "" {
+		return binName
+	}
+	if pkgName != "" {
+		return pkgName
+	}
+	return "app"
+}
+
+// BuildBinaryName is the full binary-filename policy. Cross-compile
+// runs get a "-<triple>" suffix; Windows binaries get ".exe", but
+// only when the invoking host is Windows (the only place .exe
+// matters for exec semantics). Idempotent w.r.t. ".exe".
+//
+// Osty: toolchain/runner.osty:58
+func BuildBinaryName(binName, pkgName, targetTriple, targetOS, hostGoos string) string {
+	out := BinaryBaseName(binName, pkgName)
+	if targetTriple != "" {
+		out = out + "-" + targetTriple
+	}
+	effectiveOS := targetOS
+	if effectiveOS == "" {
+		effectiveOS = hostGoos
+	}
+	producesWindowsBinary := targetTriple == "" || effectiveOS == "windows"
+	if hostGoos == "windows" && producesWindowsBinary && !strings.HasSuffix(out, ".exe") {
+		out = out + ".exe"
+	}
+	return out
+}
+
+// BinaryNameFor is the `osty run` shorthand wrapper: host build, so
+// triple / targetOS collapse away.
+//
+// Osty: toolchain/runner.osty:95
+func BinaryNameFor(binName, pkgName, goos string) string {
+	return BuildBinaryName(binName, pkgName, "", "", goos)
+}
+
+// EntryPathFor resolves the entry source file from manifest input.
+// sep is injected (filepath.Separator in host code) so this package
+// stays free of filepath.
+//
+// Osty: toolchain/runner.osty:76
+func EntryPathFor(root, binPath, sep string) string {
+	if binPath == "" {
+		return joinPath(root, "main.osty", sep)
+	}
+	return joinPath(root, binPath, sep)
+}
+
+// CrossCompileGuard rejects non-host target triples. `""` means
+// "host default" and is always allowed. When blocked, the returned
+// diagnostic steers the user at `osty build --target`.
+//
+// Osty: toolchain/runner.osty:87
+func CrossCompileGuard(targetTriple string) CrossCompileOutcome {
+	if targetTriple == "" {
+		return CrossCompileOutcome{Blocked: false, Diag: nil}
+	}
+	return CrossCompileOutcome{
+		Blocked: true,
+		Diag: &Diag{
+			Severity: "error",
+			Code:     "R0001",
+			Message:  "cannot execute cross-compiled binary for " + targetTriple + " on host",
+			Hint:     "use `osty build --target " + targetTriple + "` to produce the binary",
+		},
+	}
+}
+
+// MergeEnv overlays per-build env overrides on top of the parent
+// environment. A later entry with the same key wins; overrides
+// appear first in the output so readers see them without scanning
+// the inherited parent. Matches os/exec's lookup convention.
+//
+// Osty: toolchain/runner.osty:110
+func MergeEnv(parent []string, overrides []EnvEntry) []string {
+	if len(overrides) == 0 {
+		return parent
+	}
+
+	out := make([]string, 0, len(parent)+len(overrides))
+	seen := make(map[string]struct{}, len(overrides))
+	for _, o := range overrides {
+		out = append(out, o.Key+"="+o.Value)
+		seen[o.Key] = struct{}{}
+	}
+	for _, kv := range parent {
+		key := envEntryKey(kv)
+		if key == "" {
+			out = append(out, kv)
+			continue
+		}
+		if _, shadowed := seen[key]; shadowed {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// Osty: toolchain/runner.osty:151
+func envEntryKey(kv string) string {
+	if eq := strings.IndexByte(kv, '='); eq >= 0 {
+		return kv[:eq]
+	}
+	return ""
+}
+
+func joinPath(dir, rest, sep string) string {
+	if dir == "" {
+		return rest
+	}
+	if strings.HasSuffix(dir, sep) {
+		return dir + rest
+	}
+	return dir + sep + rest
+}
+
+// DefaultEmitMode picks the --emit artifact mode when the caller
+// doesn't override it. gen/pipeline default to a text artifact; the
+// concrete text format (llvm-ir vs go source) is pinned by the
+// backend's own rules downstream. Everything else wants a binary.
+//
+// Osty: toolchain/runner.osty:207
+func DefaultEmitMode(tool string) string {
+	if tool == "gen" || tool == "pipeline" {
+		return "llvm-ir"
+	}
+	return "binary"
+}
+
+// ToolEmitCompat enforces the tool-level rules that sit on top of a
+// backend's native capability matrix. The backend's own
+// ValidateEmit still runs afterwards for "this backend can't emit
+// this format at all"; this function handles the CLI-ergonomic
+// extras (gen/pipeline text-mode must match backend, run/test need
+// binary). Returns nil when the combination is allowed.
+//
+// Osty: toolchain/runner.osty:226
+func ToolEmitCompat(tool, backend, emit string) *Diag {
+	if tool == "gen" || tool == "pipeline" {
+		if backend == "go" && emit != "go" {
+			return toolEmitMismatch(tool, backend, emit, "go", "R0010")
+		}
+		if backend == "llvm" && emit != "llvm-ir" {
+			return toolEmitMismatch(tool, backend, emit, "llvm-ir", "R0011")
+		}
+	}
+	if tool == "run" || tool == "test" {
+		if emit != "binary" {
+			return &Diag{
+				Severity: "error",
+				Code:     "R0012",
+				Message:  tool + ` requires --emit="binary"`,
+				Hint:     "",
+			}
+		}
+	}
+	return nil
+}
+
+func toolEmitMismatch(tool, backend, got, want, code string) *Diag {
+	return &Diag{
+		Severity: "error",
+		Code:     code,
+		Message:  tool + ` with backend "` + backend + `" cannot emit "` + got + `" (want "` + want + `")`,
+		Hint:     "",
+	}
+}

--- a/internal/runner/policy_test.go
+++ b/internal/runner/policy_test.go
@@ -1,0 +1,230 @@
+package runner
+
+import "testing"
+
+func TestBinaryBaseNamePrecedence(t *testing.T) {
+	cases := []struct {
+		bin, pkg, want string
+	}{
+		{"cli", "mypkg", "cli"},
+		{"", "mypkg", "mypkg"},
+		{"", "", "app"},
+	}
+	for _, c := range cases {
+		if got := BinaryBaseName(c.bin, c.pkg); got != c.want {
+			t.Errorf("BinaryBaseName(%q, %q) = %q, want %q", c.bin, c.pkg, got, c.want)
+		}
+	}
+}
+
+func TestBinaryNameForAppliesExeOnWindows(t *testing.T) {
+	cases := []struct {
+		bin, pkg, goos, want string
+	}{
+		{"cli", "mypkg", "linux", "cli"},
+		{"cli", "mypkg", "darwin", "cli"},
+		{"cli", "mypkg", "windows", "cli.exe"},
+		{"", "", "windows", "app.exe"},
+		{"cli.exe", "", "windows", "cli.exe"},
+	}
+	for _, c := range cases {
+		if got := BinaryNameFor(c.bin, c.pkg, c.goos); got != c.want {
+			t.Errorf("BinaryNameFor(%q, %q, %q) = %q, want %q", c.bin, c.pkg, c.goos, got, c.want)
+		}
+	}
+}
+
+func TestBuildBinaryName(t *testing.T) {
+	cases := []struct {
+		name                                        string
+		bin, pkg, triple, targetOS, hostGoos, want string
+	}{
+		{"host-linux", "cli", "pkg", "", "", "linux", "cli"},
+		{"host-windows", "cli", "pkg", "", "", "windows", "cli.exe"},
+		{"cross-from-linux-to-darwin", "cli", "pkg", "aarch64-apple-darwin", "darwin", "linux", "cli-aarch64-apple-darwin"},
+		{"cross-from-windows-to-linux-drops-exe", "cli", "pkg", "x86_64-unknown-linux-gnu", "linux", "windows", "cli-x86_64-unknown-linux-gnu"},
+		{"cross-from-windows-to-windows-keeps-exe", "cli", "pkg", "x86_64-pc-windows-msvc", "windows", "windows", "cli-x86_64-pc-windows-msvc.exe"},
+		{"cross-from-linux-to-windows-no-exe-because-host-isnt-windows", "cli", "pkg", "x86_64-pc-windows-msvc", "windows", "linux", "cli-x86_64-pc-windows-msvc"},
+		{"empty-targetos-defaults-to-host-goos", "cli", "pkg", "", "", "windows", "cli.exe"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := BuildBinaryName(c.bin, c.pkg, c.triple, c.targetOS, c.hostGoos)
+			if got != c.want {
+				t.Errorf("BuildBinaryName(%q, %q, %q, %q, %q) = %q, want %q",
+					c.bin, c.pkg, c.triple, c.targetOS, c.hostGoos, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEntryPathForDefaultAndOverride(t *testing.T) {
+	cases := []struct {
+		root, bin, sep, want string
+	}{
+		{"/proj", "", "/", "/proj/main.osty"},
+		{"/proj", "src/cli.osty", "/", "/proj/src/cli.osty"},
+		{"/proj/", "main.osty", "/", "/proj/main.osty"},
+		{"", "main.osty", "/", "main.osty"},
+	}
+	for _, c := range cases {
+		if got := EntryPathFor(c.root, c.bin, c.sep); got != c.want {
+			t.Errorf("EntryPathFor(%q, %q, %q) = %q, want %q", c.root, c.bin, c.sep, got, c.want)
+		}
+	}
+}
+
+func TestCrossCompileGuardAllowsHost(t *testing.T) {
+	out := CrossCompileGuard("")
+	if out.Blocked {
+		t.Fatalf("expected host (empty triple) to pass, got blocked")
+	}
+	if out.Diag != nil {
+		t.Fatalf("expected nil diag for host, got %+v", out.Diag)
+	}
+}
+
+func TestCrossCompileGuardBlocksAndHints(t *testing.T) {
+	out := CrossCompileGuard("aarch64-apple-darwin")
+	if !out.Blocked {
+		t.Fatalf("expected cross triple to be blocked")
+	}
+	if out.Diag == nil {
+		t.Fatalf("expected diag, got nil")
+	}
+	if out.Diag.Code != "R0001" {
+		t.Errorf("code = %q, want R0001", out.Diag.Code)
+	}
+	if out.Diag.Severity != "error" {
+		t.Errorf("severity = %q, want error", out.Diag.Severity)
+	}
+	wantMsg := "cannot execute cross-compiled binary for aarch64-apple-darwin on host"
+	if out.Diag.Message != wantMsg {
+		t.Errorf("message = %q, want %q", out.Diag.Message, wantMsg)
+	}
+	wantHint := "use `osty build --target aarch64-apple-darwin` to produce the binary"
+	if out.Diag.Hint != wantHint {
+		t.Errorf("hint = %q, want %q", out.Diag.Hint, wantHint)
+	}
+}
+
+func TestMergeEnvOverridesShadowParent(t *testing.T) {
+	parent := []string{"PATH=/bin", "HOME=/root", "CGO_ENABLED=0"}
+	overrides := []EnvEntry{
+		{Key: "CGO_ENABLED", Value: "1"},
+		{Key: "GOOS", Value: "linux"},
+	}
+	got := MergeEnv(parent, overrides)
+	want := []string{"CGO_ENABLED=1", "GOOS=linux", "PATH=/bin", "HOME=/root"}
+	if len(got) != len(want) {
+		t.Fatalf("MergeEnv length = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("MergeEnv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMergeEnvNoOverridesReturnsParent(t *testing.T) {
+	parent := []string{"PATH=/bin"}
+	got := MergeEnv(parent, nil)
+	if len(got) != 1 || got[0] != "PATH=/bin" {
+		t.Fatalf("MergeEnv(parent, nil) = %v, want parent verbatim", got)
+	}
+}
+
+func TestMergeEnvKeepsMalformedParentEntries(t *testing.T) {
+	parent := []string{"STRAY_NO_EQUALS", "GOOS=darwin"}
+	overrides := []EnvEntry{{Key: "GOOS", Value: "linux"}}
+	got := MergeEnv(parent, overrides)
+	want := []string{"GOOS=linux", "STRAY_NO_EQUALS"}
+	if len(got) != len(want) {
+		t.Fatalf("MergeEnv length = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("MergeEnv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDefaultEmitModeByTool(t *testing.T) {
+	cases := []struct {
+		tool, want string
+	}{
+		{"gen", "llvm-ir"},
+		{"pipeline", "llvm-ir"},
+		{"run", "binary"},
+		{"test", "binary"},
+		{"build", "binary"},
+	}
+	for _, c := range cases {
+		if got := DefaultEmitMode(c.tool); got != c.want {
+			t.Errorf("DefaultEmitMode(%q) = %q, want %q", c.tool, got, c.want)
+		}
+	}
+}
+
+func TestToolEmitCompatHappyPath(t *testing.T) {
+	cases := []struct {
+		tool, backend, emit string
+	}{
+		{"gen", "go", "go"},
+		{"gen", "llvm", "llvm-ir"},
+		{"pipeline", "go", "go"},
+		{"pipeline", "llvm", "llvm-ir"},
+		{"run", "llvm", "binary"},
+		{"test", "llvm", "binary"},
+		{"build", "llvm", "binary"},
+	}
+	for _, c := range cases {
+		if d := ToolEmitCompat(c.tool, c.backend, c.emit); d != nil {
+			t.Errorf("ToolEmitCompat(%q, %q, %q) = %+v, want nil", c.tool, c.backend, c.emit, d)
+		}
+	}
+}
+
+func TestToolEmitCompatGenGoMustEmitGo(t *testing.T) {
+	d := ToolEmitCompat("gen", "go", "llvm-ir")
+	if d == nil {
+		t.Fatal("expected diag, got nil")
+	}
+	if d.Code != "R0010" {
+		t.Errorf("code = %q, want R0010", d.Code)
+	}
+	want := `gen with backend "go" cannot emit "llvm-ir" (want "go")`
+	if d.Message != want {
+		t.Errorf("message = %q, want %q", d.Message, want)
+	}
+}
+
+func TestToolEmitCompatGenLlvmMustEmitIr(t *testing.T) {
+	d := ToolEmitCompat("pipeline", "llvm", "binary")
+	if d == nil {
+		t.Fatal("expected diag, got nil")
+	}
+	if d.Code != "R0011" {
+		t.Errorf("code = %q, want R0011", d.Code)
+	}
+	want := `pipeline with backend "llvm" cannot emit "binary" (want "llvm-ir")`
+	if d.Message != want {
+		t.Errorf("message = %q, want %q", d.Message, want)
+	}
+}
+
+func TestToolEmitCompatRunNeedsBinary(t *testing.T) {
+	for _, tool := range []string{"run", "test"} {
+		d := ToolEmitCompat(tool, "llvm", "llvm-ir")
+		if d == nil {
+			t.Fatalf("%s: expected diag, got nil", tool)
+		}
+		if d.Code != "R0012" {
+			t.Errorf("%s: code = %q, want R0012", tool, d.Code)
+		}
+		want := tool + ` requires --emit="binary"`
+		if d.Message != want {
+			t.Errorf("%s: message = %q, want %q", tool, d.Message, want)
+		}
+	}
+}

--- a/toolchain/airepair_flags.osty
+++ b/toolchain/airepair_flags.osty
@@ -1,0 +1,81 @@
+/// Pure flag-parsing policy for `osty airepair` and every
+/// subcommand that carries an --airepair-mode flag (osty run, osty
+/// test, osty gen, etc.). No I/O; callers read the flag string,
+/// delegate here, then act on the normalised result.
+///
+/// Mirrored by `internal/runner/airepair_policy.go`. Keep the two
+/// in sync — the Osty file is the source of truth at review time.
+
+/// AiRepairModeResult is the normalised outcome of parsing an
+/// --airepair-mode string. `ok == false` signals an unknown mode
+/// so the host can emit its usage error.
+pub struct AiRepairModeResult {
+    pub mode: String,
+    pub ok: Bool,
+}
+
+/// AiRepairCaptureModeResult is the same shape for --capture-if.
+pub struct AiRepairCaptureModeResult {
+    pub mode: String,
+    pub ok: Bool,
+}
+
+/// parseAiRepairMode accepts the flag value and returns the
+/// canonical mode name. Empty string and "auto" both resolve to
+/// "auto" so `--airepair-mode=` behaves as "omit the flag".
+///
+/// Known modes: auto, rewrite, parse, frontend. Any other value
+/// leaves `ok == false` and the host should reject with usage
+/// error 2.
+pub fn parseAiRepairMode(value: String) -> AiRepairModeResult {
+    if value == "" || value == "auto" {
+        AiRepairModeResult { mode: "auto", ok: true }
+    } else if value == "rewrite" {
+        AiRepairModeResult { mode: "rewrite", ok: true }
+    } else if value == "parse" {
+        AiRepairModeResult { mode: "parse", ok: true }
+    } else if value == "frontend" {
+        AiRepairModeResult { mode: "frontend", ok: true }
+    } else {
+        AiRepairModeResult { mode: "", ok: false }
+    }
+}
+
+/// parseAiRepairCaptureMode handles --capture-if. Empty string and
+/// "residual" both mean "capture when residual errors remain" so
+/// omitting the flag defaults to the conservative behaviour.
+///
+/// Known modes: residual, changed, always.
+pub fn parseAiRepairCaptureMode(value: String) -> AiRepairCaptureModeResult {
+    if value == "" || value == "residual" {
+        AiRepairCaptureModeResult { mode: "residual", ok: true }
+    } else if value == "changed" {
+        AiRepairCaptureModeResult { mode: "changed", ok: true }
+    } else if value == "always" {
+        AiRepairCaptureModeResult { mode: "always", ok: true }
+    } else {
+        AiRepairCaptureModeResult { mode: "", ok: false }
+    }
+}
+
+/// shouldCaptureAiRepair decides whether an airepair run warrants
+/// writing a capture artifact, given the resolved --capture-if
+/// mode and two facts from the repair result:
+///
+///   - `changed`: repair emitted any edits.
+///   - `totalErrorsAfter`: parser/resolve/check errors that remain
+///     after repair.
+///
+/// The conservative default ("residual") only captures cases where
+/// the user will need to inspect the failure — repair ran but
+/// errors remain. "changed" captures any rewrite attempt; "always"
+/// captures unconditionally (for corpus collection).
+pub fn shouldCaptureAiRepair(captureMode: String, changed: Bool, totalErrorsAfter: Int) -> Bool {
+    if captureMode == "always" {
+        return true
+    }
+    if captureMode == "changed" {
+        return changed
+    }
+    totalErrorsAfter > 0
+}

--- a/toolchain/airepair_flags_test.osty
+++ b/toolchain/airepair_flags_test.osty
@@ -1,0 +1,59 @@
+use std.testing
+
+fn testParseAiRepairModeKnownValues() {
+    let cases = [
+        ("", "auto"),
+        ("auto", "auto"),
+        ("rewrite", "rewrite"),
+        ("parse", "parse"),
+        ("frontend", "frontend"),
+    ]
+    for (input, want) in cases {
+        let res = parseAiRepairMode(input)
+        testing.assert(res.ok)
+        testing.assertEq(res.mode, want)
+    }
+}
+
+fn testParseAiRepairModeRejectsUnknown() {
+    let res = parseAiRepairMode("nope")
+    testing.assert(!(res.ok))
+    testing.assertEq(res.mode, "")
+}
+
+fn testParseAiRepairCaptureModeKnownValues() {
+    let cases = [
+        ("", "residual"),
+        ("residual", "residual"),
+        ("changed", "changed"),
+        ("always", "always"),
+    ]
+    for (input, want) in cases {
+        let res = parseAiRepairCaptureMode(input)
+        testing.assert(res.ok)
+        testing.assertEq(res.mode, want)
+    }
+}
+
+fn testParseAiRepairCaptureModeRejectsUnknown() {
+    let res = parseAiRepairCaptureMode("sometimes")
+    testing.assert(!(res.ok))
+    testing.assertEq(res.mode, "")
+}
+
+fn testShouldCaptureAiRepairAlways() {
+    testing.assert(shouldCaptureAiRepair("always", false, 0))
+    testing.assert(shouldCaptureAiRepair("always", true, 5))
+}
+
+fn testShouldCaptureAiRepairChanged() {
+    testing.assert(shouldCaptureAiRepair("changed", true, 0))
+    testing.assert(!(shouldCaptureAiRepair("changed", false, 5)))
+}
+
+fn testShouldCaptureAiRepairResidualDefault() {
+    testing.assert(shouldCaptureAiRepair("residual", false, 1))
+    testing.assert(!(shouldCaptureAiRepair("residual", true, 0)))
+    testing.assert(!(shouldCaptureAiRepair("", false, 0)))
+    testing.assert(shouldCaptureAiRepair("", false, 3))
+}

--- a/toolchain/runner.osty
+++ b/toolchain/runner.osty
@@ -1,0 +1,265 @@
+use std.strings as strings
+
+/// Pure policy for `osty run`: no I/O, no process exec. Host glue in
+/// `cmd/osty/run.go` resolves the workspace and invokes the backend,
+/// then consults this module for the decisions that are purely a
+/// function of (manifest, target, host OS, environment).
+///
+/// Mirrored by `internal/runner/policy.go`. Keep the two in sync —
+/// the Go snapshot is authoritative for today's build but must stay
+/// a mechanical translation of this file.
+
+/// RunnerDiag is the structured diagnostic runner policy emits when
+/// it refuses a host-incompatible request.
+pub struct RunnerDiag {
+    pub severity: String,
+    pub code: String,
+    pub message: String,
+    pub hint: String,
+}
+
+/// EnvEntry is a `KEY=VALUE` override pair used by `mergeEnv`.
+pub struct EnvEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// CrossCompileOutcome reports whether a resolved target is
+/// executable on the invoking host.
+///
+/// `osty run` is a build-and-execute shortcut; a non-host triple
+/// would produce a binary that can't run locally, so `blocked=true`
+/// short-circuits with a diagnostic pointing to `osty build --target`.
+pub struct CrossCompileOutcome {
+    pub blocked: Bool,
+    pub diag: RunnerDiag?,
+}
+
+/// binaryBaseName chooses the plain binary filename (no extension).
+///
+/// Precedence: manifest `[bin].name` override, then package name,
+/// then the fallback `"app"`. `binaryNameFor` adds the platform
+/// suffix on top of this.
+pub fn binaryBaseName(binName: String, pkgName: String) -> String {
+    if binName != "" {
+        return binName
+    }
+    if pkgName != "" {
+        return pkgName
+    }
+    "app"
+}
+
+/// buildBinaryName returns the filename the backend should produce
+/// for any `osty build` or `osty run` invocation.
+///
+/// Inputs:
+///   - binName / pkgName — manifest overrides (see binaryBaseName).
+///   - targetTriple — LLVM target triple, or "" for the host.
+///   - targetOS — GOOS-shaped OS derived from the triple (or "" to
+///     infer from hostGoos). Cross-compiled binaries get a `-<triple>`
+///     suffix so debug/release/host variants don't clobber each other.
+///   - hostGoos — GOOS of the *invoking* machine. Only this machine
+///     cares about the `.exe` suffix, and only when the output is
+///     meant to run on a Windows host (either host build, or
+///     cross-compile targeting Windows from Windows).
+///
+/// The suffix rule is: append `.exe` when hostGoos is windows AND
+/// the produced artifact is a Windows binary (no cross-target, or
+/// cross-target OS is windows). Idempotent — a manifest binName
+/// like "cli.exe" doesn't double-suffix.
+pub fn buildBinaryName(
+    binName: String,
+    pkgName: String,
+    targetTriple: String,
+    targetOS: String,
+    hostGoos: String,
+) -> String {
+    let mut out = binaryBaseName(binName, pkgName)
+    if targetTriple != "" {
+        out = strings.concat(out, strings.concat("-", targetTriple))
+    }
+    let effectiveOS = if targetOS == "" { hostGoos } else { targetOS }
+    let producesWindowsBinary = targetTriple == "" || effectiveOS == "windows"
+    if hostGoos == "windows" && producesWindowsBinary && !(strings.hasSuffix(out, ".exe")) {
+        out = strings.concat(out, ".exe")
+    }
+    out
+}
+
+/// binaryNameFor is the `osty run` shorthand: host build, so the
+/// target triple / OS arguments collapse away.
+pub fn binaryNameFor(binName: String, pkgName: String, goos: String) -> String {
+    buildBinaryName(binName, pkgName, "", "", goos)
+}
+
+/// entryPathFor resolves the entry source file from manifest input.
+///
+/// When `[bin].path` is set the manifest value wins; otherwise we
+/// default to `<root>/main.osty`. `sep` lets the caller inject the
+/// host path separator (`/` on Unix, `\` on Windows) without this
+/// module depending on `std.os` — the manifest path is joined
+/// verbatim so `[bin].path = "src/cli.osty"` on Windows still
+/// produces `<root>\src/cli.osty`, same shape Go's `filepath.Join`
+/// returns.
+pub fn entryPathFor(root: String, binPath: String, sep: String) -> String {
+    if binPath == "" {
+        joinPath(root, "main.osty", sep)
+    } else {
+        joinPath(root, binPath, sep)
+    }
+}
+
+/// crossCompileGuard blocks `osty run` when the resolved profile
+/// pins a non-host target triple. `""` means "use host" and is
+/// always allowed.
+pub fn crossCompileGuard(targetTriple: String) -> CrossCompileOutcome {
+    if targetTriple == "" {
+        return CrossCompileOutcome { blocked: false, diag: None }
+    }
+    let msg = strings.concat(
+        "cannot execute cross-compiled binary for ",
+        strings.concat(targetTriple, " on host"),
+    )
+    let hint = strings.concat(
+        "use `osty build --target ",
+        strings.concat(targetTriple, "` to produce the binary"),
+    )
+    CrossCompileOutcome {
+        blocked: true,
+        diag: Some(
+            RunnerDiag {
+                severity: "error",
+                code: "R0001",
+                message: msg,
+                hint,
+            },
+        ),
+    }
+}
+
+/// mergeEnv overlays per-build env overrides on top of the parent
+/// process's environment. A later entry with the same key wins —
+/// the convention matches `exec.Command`'s own lookup. Overrides
+/// appear first in the output so readers see them without scanning
+/// the inherited parent.
+pub fn mergeEnv(parent: List<String>, overrides: List<EnvEntry>) -> List<String> {
+    if envOverridesEmpty(overrides) {
+        return parent
+    }
+
+    let mut out: List<String> = []
+    let mut seen: List<String> = []
+    for o in overrides {
+        out.push(strings.concat(o.key, strings.concat("=", o.value)))
+        seen.push(o.key)
+    }
+    for kv in parent {
+        let key = envEntryKey(kv)
+        if key == "" {
+            out.push(kv)
+        } else if envSeen(seen, key) {
+            let _ = key
+        } else {
+            out.push(kv)
+        }
+    }
+    out
+}
+
+fn envOverridesEmpty(overrides: List<EnvEntry>) -> Bool {
+    for o in overrides {
+        let _ = o
+        return false
+    }
+    true
+}
+
+fn envEntryKey(kv: String) -> String {
+    match strings.indexOf(kv, "=") {
+        Some(at) -> strings.slice(kv, 0, at),
+        None -> "",
+    }
+}
+
+fn envSeen(seen: List<String>, key: String) -> Bool {
+    for k in seen {
+        if k == key {
+            return true
+        }
+    }
+    false
+}
+
+fn joinPath(dir: String, rest: String, sep: String) -> String {
+    if dir == "" {
+        return rest
+    }
+    if strings.hasSuffix(dir, sep) {
+        strings.concat(dir, rest)
+    } else {
+        strings.concat(dir, strings.concat(sep, rest))
+    }
+}
+
+/// defaultEmitMode picks the --emit artifact mode when the caller
+/// didn't set it explicitly. gen/pipeline default to a text
+/// artifact (llvm-ir or go source, depending on backend; the
+/// caller already knows which backend it picked, so this function
+/// only answers the question "text or binary?" and lets the
+/// backend's own rules pin the exact text flavour).
+///
+/// tool is the subcommand name ("gen", "pipeline", "run", "test",
+/// "build"). Anything not in the gen-family wants a runnable
+/// binary.
+pub fn defaultEmitMode(tool: String) -> String {
+    if tool == "gen" || tool == "pipeline" {
+        "llvm-ir"
+    } else {
+        "binary"
+    }
+}
+
+/// toolEmitCompat enforces the tool-level rules on top of a
+/// backend's native capability matrix. The backend still gets to
+/// veto (e.g. "llvm can't emit go source") via its own
+/// ValidateEmit; this function handles the *tool's* constraints:
+/// gen/pipeline text-mode must match the backend's text format,
+/// and run/test need a binary.
+///
+/// Returns None on success, or a RunnerDiag describing the
+/// mismatch. The host prints the diagnostic and exits 2.
+pub fn toolEmitCompat(tool: String, backend: String, emit: String) -> RunnerDiag? {
+    if tool == "gen" || tool == "pipeline" {
+        if backend == "go" && emit != "go" {
+            return Some(toolEmitMismatch(tool, backend, emit, "go", "R0010"))
+        }
+        if backend == "llvm" && emit != "llvm-ir" {
+            return Some(toolEmitMismatch(tool, backend, emit, "llvm-ir", "R0011"))
+        }
+    }
+    if tool == "run" || tool == "test" {
+        if emit != "binary" {
+            return Some(
+                RunnerDiag {
+                    severity: "error",
+                    code: "R0012",
+                    message: tool + " requires --emit=\"binary\"",
+                    hint: "",
+                },
+            )
+        }
+    }
+    None
+}
+
+fn toolEmitMismatch(
+    tool: String,
+    backend: String,
+    got: String,
+    want: String,
+    code: String,
+) -> RunnerDiag {
+    let msg = tool + " with backend \"" + backend + "\" cannot emit \"" + got + "\" (want \"" + want + "\")"
+    RunnerDiag { severity: "error", code, message: msg, hint: "" }
+}

--- a/toolchain/runner_test.osty
+++ b/toolchain/runner_test.osty
@@ -1,0 +1,179 @@
+use std.testing
+
+fn testBinaryBaseNamePrecedence() {
+    testing.assertEq(binaryBaseName("cli", "mypkg"), "cli")
+    testing.assertEq(binaryBaseName("", "mypkg"), "mypkg")
+    testing.assertEq(binaryBaseName("", ""), "app")
+}
+
+fn testBinaryNameForAppliesExeOnWindows() {
+    testing.assertEq(binaryNameFor("cli", "mypkg", "linux"), "cli")
+    testing.assertEq(binaryNameFor("cli", "mypkg", "darwin"), "cli")
+    testing.assertEq(binaryNameFor("cli", "mypkg", "windows"), "cli.exe")
+    testing.assertEq(binaryNameFor("", "", "windows"), "app.exe")
+}
+
+fn testBinaryNameForIdempotentSuffix() {
+    testing.assertEq(binaryNameFor("cli.exe", "", "windows"), "cli.exe")
+}
+
+fn testBuildBinaryNameHostVariants() {
+    testing.assertEq(buildBinaryName("cli", "pkg", "", "", "linux"), "cli")
+    testing.assertEq(buildBinaryName("cli", "pkg", "", "", "windows"), "cli.exe")
+}
+
+fn testBuildBinaryNameCrossCompileAppendsTriple() {
+    testing.assertEq(
+        buildBinaryName("cli", "pkg", "aarch64-apple-darwin", "darwin", "linux"),
+        "cli-aarch64-apple-darwin",
+    )
+}
+
+fn testBuildBinaryNameWindowsHostSuppressesExeForLinuxTarget() {
+    testing.assertEq(
+        buildBinaryName("cli", "pkg", "x86_64-unknown-linux-gnu", "linux", "windows"),
+        "cli-x86_64-unknown-linux-gnu",
+    )
+}
+
+fn testBuildBinaryNameWindowsCrossFromWindowsKeepsExe() {
+    testing.assertEq(
+        buildBinaryName("cli", "pkg", "x86_64-pc-windows-msvc", "windows", "windows"),
+        "cli-x86_64-pc-windows-msvc.exe",
+    )
+}
+
+fn testEntryPathForDefaultAndOverride() {
+    testing.assertEq(entryPathFor("/proj", "", "/"), "/proj/main.osty")
+    testing.assertEq(entryPathFor("/proj", "src/cli.osty", "/"), "/proj/src/cli.osty")
+    testing.assertEq(entryPathFor("/proj/", "main.osty", "/"), "/proj/main.osty")
+}
+
+fn testCrossCompileGuardAllowsHostTriple() {
+    let outcome = crossCompileGuard("")
+    testing.assert(!(outcome.blocked))
+    match outcome.diag {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+}
+
+fn testCrossCompileGuardBlocksAndHints() {
+    let outcome = crossCompileGuard("aarch64-apple-darwin")
+    testing.assert(outcome.blocked)
+    match outcome.diag {
+        Some(d) -> {
+            testing.assertEq(d.severity, "error")
+            testing.assertEq(d.code, "R0001")
+            testing.assertEq(
+                d.message,
+                "cannot execute cross-compiled binary for aarch64-apple-darwin on host",
+            )
+            testing.assertEq(
+                d.hint,
+                "use `osty build --target aarch64-apple-darwin` to produce the binary",
+            )
+        },
+        None -> testing.assert(false),
+    }
+}
+
+fn testMergeEnvOverridesShadowParent() {
+    let parent: List<String> = ["PATH=/bin", "HOME=/root", "CGO_ENABLED=0"]
+    let overrides: List<EnvEntry> = [
+        EnvEntry { key: "CGO_ENABLED", value: "1" },
+        EnvEntry { key: "GOOS", value: "linux" },
+    ]
+    let merged = mergeEnv(parent, overrides)
+
+    testing.assertEq(merged[0], "CGO_ENABLED=1")
+    testing.assertEq(merged[1], "GOOS=linux")
+    testing.assertEq(merged[2], "PATH=/bin")
+    testing.assertEq(merged[3], "HOME=/root")
+}
+
+fn testMergeEnvNoOverridesReturnsParent() {
+    let parent: List<String> = ["PATH=/bin"]
+    let overrides: List<EnvEntry> = []
+    let merged = mergeEnv(parent, overrides)
+    testing.assertEq(merged[0], "PATH=/bin")
+}
+
+fn testMergeEnvKeepsMalformedParentEntries() {
+    let parent: List<String> = ["STRAY_NO_EQUALS", "GOOS=darwin"]
+    let overrides: List<EnvEntry> = [EnvEntry { key: "GOOS", value: "linux" }]
+    let merged = mergeEnv(parent, overrides)
+    testing.assertEq(merged[0], "GOOS=linux")
+    testing.assertEq(merged[1], "STRAY_NO_EQUALS")
+}
+
+fn testDefaultEmitModeByTool() {
+    testing.assertEq(defaultEmitMode("gen"), "llvm-ir")
+    testing.assertEq(defaultEmitMode("pipeline"), "llvm-ir")
+    testing.assertEq(defaultEmitMode("run"), "binary")
+    testing.assertEq(defaultEmitMode("test"), "binary")
+    testing.assertEq(defaultEmitMode("build"), "binary")
+}
+
+fn testToolEmitCompatHappyPath() {
+    match toolEmitCompat("gen", "go", "go") {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+    match toolEmitCompat("gen", "llvm", "llvm-ir") {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+    match toolEmitCompat("run", "llvm", "binary") {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+    match toolEmitCompat("test", "llvm", "binary") {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+    match toolEmitCompat("build", "llvm", "binary") {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+}
+
+fn testToolEmitCompatGenGoMustEmitGo() {
+    match toolEmitCompat("gen", "go", "llvm-ir") {
+        Some(d) -> {
+            testing.assertEq(d.code, "R0010")
+            testing.assertEq(
+                d.message,
+                "gen with backend \"go\" cannot emit \"llvm-ir\" (want \"go\")",
+            )
+        },
+        None -> testing.assert(false),
+    }
+}
+
+fn testToolEmitCompatGenLlvmMustEmitIr() {
+    match toolEmitCompat("pipeline", "llvm", "binary") {
+        Some(d) -> {
+            testing.assertEq(d.code, "R0011")
+            testing.assertEq(
+                d.message,
+                "pipeline with backend \"llvm\" cannot emit \"binary\" (want \"llvm-ir\")",
+            )
+        },
+        None -> testing.assert(false),
+    }
+}
+
+fn testToolEmitCompatRunNeedsBinary() {
+    match toolEmitCompat("run", "llvm", "llvm-ir") {
+        Some(d) -> {
+            testing.assertEq(d.code, "R0012")
+            testing.assertEq(d.message, "run requires --emit=\"binary\"")
+        },
+        None -> testing.assert(false),
+    }
+    match toolEmitCompat("test", "llvm", "object") {
+        Some(d) -> testing.assertEq(d.code, "R0012"),
+        None -> testing.assert(false),
+    }
+}


### PR DESCRIPTION
## Summary

Extends the self-hosting rule (_Osty로 작성 가능한 로직은 Osty로_) by carving pure CLI policy out of `cmd/osty/*.go` into two new toolchain modules, with a shared Go snapshot under `internal/runner`.

## What moved to Osty

- **`toolchain/runner.osty`** — binary filename (base + triple + `.exe`), entry-path resolution, cross-compile guard (`R0001`), env overlay, tool/backend emit compatibility matrix shared by `run`/`build`/`test`/`gen`/`pipeline` (`R0010`/`R0011`/`R0012` + `defaultEmitMode`).
- **`toolchain/airepair_flags.osty`** — `--airepair-mode` and `--capture-if` parsing, `shouldCapture` predicate shared by every subcommand carrying the flag.

## What stayed in Go

Host glue only: flag plumbing, process exec, `os.Exit`, the backend registry itself (`backend.ValidateEmit` still enforces capability). The old `binaryName` helper in `build.go` and the dead `mergeEnv` copy in `run.go` are deleted — `runner.BuildBinaryName` subsumes both.

## Drift guard

`internal/runner/drift_test.go` scans every `pub fn`/`pub struct` in the listed Osty files and asserts a matching exported Go symbol exists in the snapshot. Catches forgetting to update one side when the other changes. Verified by injecting a synthetic `pub fn driftDetectorCanary` — test failed as expected, then passed after revert.

## Why not `osty gen`?

Ran `osty gen --backend go --emit go --package runner toolchain/runner.osty` and documented four concrete blockers in `internal/runner/generate.go`:

1. `std.strings` calls (`strings.concat`, `strings.hasSuffix`) don't lower to Go's `strings` package.
2. `pub` doesn't propagate to Go export capitalisation (`binaryBaseName` stays lowercase).
3. `T?` lowers to `**T` instead of `*T`.
4. `if` expressions wrap in `func() any { ... }()` instead of concrete Go `if/else`.

Once those land, `generate.go` flips to `//go:generate go run gen_runner.go` and `policy.go` deletes. Until then the drift test enforces parity.

## Error message parity

`validateCLIEmit` output is byte-identical to the previous `fmt.Errorf` — verified with:

- `osty run --emit=llvm-ir` → `osty run: run requires --emit="binary"`
- `osty gen --backend=llvm --emit=binary ...` → `osty gen: gen with backend "llvm" cannot emit "binary" (want "llvm-ir")`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/runner` (30 tests, includes drift guard)
- [x] `go test ./cmd/osty -run TestAIRepair` (23 tests — behavioural regression check)
- [x] Front-end packages (`lexer`/`parser`/`resolve`/`check`) pass
- [x] CLI smoke test: error strings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)