### PR TITLE
feat(mir): stage 3.10 — top-level globals via module-ctor init

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -935,15 +935,36 @@ MIR tests isolated from front-end churn.
     operate. What changed: concurrency code now reaches the MIR
     emitter instead of falling back to the legacy HIR→AST bridge.
 
+- **Stage 3.10 (landed — top-level globals).** Module-level `let`
+  declarations now round-trip through the MIR emitter:
+
+  - Each `mir.Global` emits as `@<name> = global <T> zeroinitializer`
+    at the module top.
+  - Each `Global.Init` function (a zero-arg fn returning the global's
+    declared type — produced by `mir.Lower` for any `pub let x = e`)
+    is emitted as a regular LLVM fn definition before user functions.
+  - A generated `define private void @__osty_init_globals()`
+    constructor calls every init fn in MIR module order and stores
+    the result into the matching `@<name>` slot. It's registered
+    via `@llvm.global_ctors` at priority 65535 so it runs before
+    `main` but after any runtime setup ctor the runtime provides.
+  - `GlobalRefRV` on the rvalue side emits a `load <T>, ptr @<name>`
+    — the ctor has already initialised the slot by the time user
+    code executes.
+  - `checkSupported` removes the old hard block; global init fns
+    walk through the same `checkFunctionSupported` whitelist as
+    user fns so unsupported init shapes still trigger fallback.
+
 - **Stage 5 (deferred — still needs parity).** Remove
   `legacyFileFromModule` and the AST-driven emitter. Outstanding
-  parity gaps after Stage 3.9: GC roots / safepoints, top-level
-  globals, composite **map** element types, heap-escaping closure
-  envs, and `DerefProj` on anything other than a closure env.
-  Concurrency intrinsics crossed off in Stage 3.9; top-level
-  globals are the next wedge. See the MIR emitter's
-  `checkSupported` and `checkRValueSupported` for the current
-  whitelist.
+  parity gaps after Stage 3.10: GC roots / safepoints, composite
+  **map** element types, heap-escaping closure envs, and
+  `DerefProj` on anything other than a closure env. Top-level
+  globals crossed off in Stage 3.10; GC roots / safepoints are the
+  biggest remaining wedge — they thread through function entry,
+  call sites, and alloca slots so they deserve their own Stage
+  3.11+ design pass. See the MIR emitter's `checkSupported` and
+  `checkRValueSupported` for the current whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -54,6 +54,17 @@ func GenerateFromMIR(m *mir.Module, opts Options) ([]byte, error) {
 	}
 	g.emitHeader()
 	g.discoverFunctions()
+	// Emit the init functions FIRST (before user functions) so
+	// main-prologue call-site lookup finds their symbol types. They
+	// are full LLVM fn definitions just like user functions.
+	for _, glob := range m.Globals {
+		if glob == nil || glob.Init == nil {
+			continue
+		}
+		if err := g.emitFunction(glob.Init); err != nil {
+			return nil, err
+		}
+	}
 	for _, fn := range m.Functions {
 		if fn == nil {
 			continue
@@ -64,6 +75,7 @@ func GenerateFromMIR(m *mir.Module, opts Options) ([]byte, error) {
 	}
 	g.emitTypeDefs()
 	g.emitThunks()
+	g.emitGlobalVars()
 	g.emitStringPool()
 	g.emitRuntimeDeclarations()
 	return []byte(g.out.String()), nil
@@ -183,8 +195,57 @@ func (g *mirGen) checkSupported() error {
 			}
 		}
 	}
-	if len(g.mod.Globals) > 0 {
-		return unsupported("mir-mvp", "top-level globals not yet emitted by MIR backend")
+	for _, glob := range g.mod.Globals {
+		if glob == nil {
+			continue
+		}
+		if glob.Name == "" {
+			return unsupported("mir-mvp", "global with empty name")
+		}
+		if !g.typeSupported(glob.Type) {
+			return unsupported("mir-mvp", fmt.Sprintf("global %q has unsupported type %s", glob.Name, mirTypeString(glob.Type)))
+		}
+		if glob.Init != nil && !glob.Init.IsExternal {
+			// Init fns aren't in Module.Functions, so walk them
+			// through the same whitelist checks as user fns.
+			if err := g.checkFunctionSupported(glob.Init); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkFunctionSupported validates a single function against the
+// emitter whitelist. Used for global-init fns, which are not part of
+// Module.Functions yet still need the same checks.
+func (g *mirGen) checkFunctionSupported(fn *mir.Function) error {
+	if fn.IsIntrinsic {
+		return unsupported("mir-mvp", "intrinsic init fn "+fn.Name)
+	}
+	for _, loc := range fn.Locals {
+		if loc == nil {
+			continue
+		}
+		if !g.typeSupported(loc.Type) {
+			return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s", mirTypeString(loc.Type), fn.Name))
+		}
+	}
+	if fn.ReturnType != nil && !g.typeSupported(fn.ReturnType) {
+		return unsupported("mir-mvp", fmt.Sprintf("unsupported return type %s in %s", mirTypeString(fn.ReturnType), fn.Name))
+	}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, inst := range bb.Instrs {
+			if err := g.checkInstrSupported(fn, inst); err != nil {
+				return err
+			}
+		}
+		if err := g.checkTermSupported(fn, bb.Term); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -326,7 +387,8 @@ func isListPtrType(t mir.Type) bool {
 func (g *mirGen) checkRValueSupported(fn *mir.Function, rv mir.RValue) error {
 	switch r := rv.(type) {
 	case *mir.UseRV, *mir.UnaryRV, *mir.BinaryRV,
-		*mir.DiscriminantRV, *mir.NullaryRV, *mir.CastRV:
+		*mir.DiscriminantRV, *mir.NullaryRV, *mir.CastRV,
+		*mir.GlobalRefRV:
 		return nil
 	case *mir.AggregateRV:
 		switch r.Kind {
@@ -431,6 +493,90 @@ func (g *mirGen) discoverFunctions() {
 		}
 		g.functionTypes[fn.Name] = sig
 	}
+	// Register global-init fns too so call sites can reference them
+	// (currently only the main-prologue wiring does, but recording
+	// signatures here keeps the lookup uniform).
+	for _, glob := range g.mod.Globals {
+		if glob == nil || glob.Init == nil {
+			continue
+		}
+		fn := glob.Init
+		sig := mirFnSig{retLLVM: g.llvmType(fn.ReturnType), returnType: fn.ReturnType}
+		g.functionTypes[fn.Name] = sig
+	}
+}
+
+// emitGlobalVars writes `@<name> = global <T> zeroinitializer` lines
+// for each module-level Global, plus an `@osty_global_init` ctor
+// function that runs every init fn once at program start. The ctor
+// is wired through `@llvm.global_ctors` so it executes before `main`.
+func (g *mirGen) emitGlobalVars() {
+	if g.mod == nil || len(g.mod.Globals) == 0 {
+		return
+	}
+	var block strings.Builder
+	// @<name> = global <T> zeroinitializer — runtime fills this from
+	// the ctor below. We don't try to statically inline the init
+	// value (some init fns have side effects / non-const expressions);
+	// a deferred ctor is the uniform shape.
+	for _, glob := range g.mod.Globals {
+		if glob == nil {
+			continue
+		}
+		block.WriteByte('@')
+		block.WriteString(glob.Name)
+		block.WriteString(" = global ")
+		block.WriteString(g.llvmType(glob.Type))
+		block.WriteString(" zeroinitializer\n")
+	}
+	block.WriteByte('\n')
+	// Ctor function: `@__osty_init_globals() { call <Ti> @_init_xxx();
+	// store <Ti> %tmp, ptr @xxx; ... ret void }`.
+	block.WriteString("define private void @__osty_init_globals() {\n")
+	block.WriteString("entry:\n")
+	for _, glob := range g.mod.Globals {
+		if glob == nil || glob.Init == nil {
+			continue
+		}
+		initName := glob.Init.Name
+		retLLVM := g.llvmType(glob.Type)
+		tmp := "%v" + glob.Name
+		block.WriteString("  ")
+		block.WriteString(tmp)
+		block.WriteString(" = call ")
+		block.WriteString(retLLVM)
+		block.WriteString(" @")
+		block.WriteString(initName)
+		block.WriteString("()\n")
+		block.WriteString("  store ")
+		block.WriteString(retLLVM)
+		block.WriteByte(' ')
+		block.WriteString(tmp)
+		block.WriteString(", ptr @")
+		block.WriteString(glob.Name)
+		block.WriteByte('\n')
+	}
+	block.WriteString("  ret void\n")
+	block.WriteString("}\n\n")
+	// LLVM ctor registration. Priority 65535 runs last among ctors
+	// so anything with lower priority (runtime setup) has already
+	// executed.
+	block.WriteString("@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__osty_init_globals, ptr null }]\n\n")
+
+	// Inject the block before the first `define ` / `declare ` line
+	// so the `@<name>` globals and the ctor sit alongside type defs.
+	body := g.out.String()
+	idx := earliestAfter(body, []string{"define ", "declare "})
+	if idx < 0 {
+		g.out.WriteString(block.String())
+		return
+	}
+	var rewritten strings.Builder
+	rewritten.WriteString(body[:idx])
+	rewritten.WriteString(block.String())
+	rewritten.WriteString(body[idx:])
+	g.out.Reset()
+	g.out.WriteString(rewritten.String())
 }
 
 // emitRuntimeDeclarations writes `declare` lines for every runtime
@@ -2058,6 +2204,19 @@ func (g *mirGen) evalRValue(rv mir.RValue, hintT mir.Type) (string, error) {
 		return g.emitNullaryRV(r, hintT)
 	case *mir.CastRV:
 		return g.emitCastRV(r)
+	case *mir.GlobalRefRV:
+		// Load the declared type from the module-level `@<name>`
+		// global. The ctor initialises it before user code runs, so
+		// the value is always valid when this load executes.
+		tmp := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(tmp)
+		g.fnBuf.WriteString(" = load ")
+		g.fnBuf.WriteString(g.llvmType(r.T))
+		g.fnBuf.WriteString(", ptr @")
+		g.fnBuf.WriteString(r.Name)
+		g.fnBuf.WriteByte('\n')
+		return tmp, nil
 	}
 	return "", unsupported("mir-mvp", fmt.Sprintf("rvalue %T", rv))
 }

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -303,28 +303,28 @@ func TestGenerateFromMIRPrintln(t *testing.T) {
 	}
 }
 
-// TestGenerateFromMIRUnsupportedFallsBack — a module with a top-
-// level global (still outside the MIR MVP — emitting globals needs
-// a ctor-slot or main-prologue init path we haven't designed yet)
-// must trip `ErrUnsupported` so the backend dispatcher falls back
-// to the legacy path.
+// TestGenerateFromMIRUnsupportedFallsBack — a module using an
+// unresolved NamedType (not a Builtin collection, not in the
+// module's LayoutTable, not a known prelude name) must trip
+// `ErrUnsupported` so the backend dispatcher falls back to the
+// legacy path.
 func TestGenerateFromMIRUnsupportedFallsBack(t *testing.T) {
-	// pub let version = 42
+	unknownT := &ir.NamedType{Name: "Unknown"}
 	hir := &ir.Module{
 		Package: "main",
 		Decls: []ir.Decl{
-			&ir.LetDecl{
-				Name:     "version",
-				Type:     ir.TInt,
-				Value:    &ir.IntLit{Text: "42", T: ir.TInt},
-				Exported: true,
+			&ir.FnDecl{
+				Name:   "use",
+				Return: ir.TUnit,
+				Params: []*ir.Param{{Name: "x", Type: unknownT}},
+				Body:   &ir.Block{},
 			},
 		},
 	}
 	m := buildMIRModuleFromHIR(t, hir)
-	_, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/global.osty"})
+	_, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/unknown.osty"})
 	if err == nil {
-		t.Fatalf("expected ErrUnsupported for global; got nil")
+		t.Fatalf("expected ErrUnsupported for unknown NamedType; got nil")
 	}
 	if !errors.Is(err, ErrUnsupported) {
 		t.Fatalf("error does not wrap ErrUnsupported: %v", err)
@@ -416,16 +416,16 @@ func TestMIRDualEmitFromSource(t *testing.T) {
 // independent of parser / checker restrictions on closure-trailing-
 // expr source shape.
 func TestMIRDualEmitGracefulFallback(t *testing.T) {
-	// Use a top-level global — still outside MVP (globals need a
-	// ctor-slot or main-prologue init path we haven't designed yet).
+	// Use an unresolved NamedType — still outside MVP.
+	unknownT := &ir.NamedType{Name: "Unknown"}
 	hir := &ir.Module{
 		Package: "main",
 		Decls: []ir.Decl{
-			&ir.LetDecl{
-				Name:     "version",
-				Type:     ir.TInt,
-				Value:    &ir.IntLit{Text: "1", T: ir.TInt},
-				Exported: true,
+			&ir.FnDecl{
+				Name:   "use",
+				Return: ir.TUnit,
+				Params: []*ir.Param{{Name: "x", Type: unknownT}},
+				Body:   &ir.Block{},
 			},
 		},
 	}
@@ -1397,6 +1397,99 @@ func TestGenerateFromMIRTopLevelFnAsValue(t *testing.T) {
 	}
 	if !strings.Contains(got, "call i64 @double(i64 %arg0)") {
 		t.Fatalf("expected thunk to delegate to @double, got:\n%s", got)
+	}
+}
+
+// ==== Stage 3.10: top-level globals ====
+
+func TestGenerateFromMIRGlobalReadAndInit(t *testing.T) {
+	// pub let version = 42
+	// fn get() -> Int { version }
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.LetDecl{
+				Name:     "version",
+				Type:     ir.TInt,
+				Value:    &ir.IntLit{Text: "42", T: ir.TInt},
+				Exported: true,
+			},
+			&ir.FnDecl{
+				Name:   "get",
+				Return: ir.TInt,
+				Body: &ir.Block{
+					Result: &ir.Ident{Name: "version", Kind: ir.IdentGlobal, T: ir.TInt},
+				},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/global.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		// Module-level global with zeroinitializer.
+		"@version = global i64 zeroinitializer",
+		// Init fn from the MIR lowerer.
+		"define i64 @_init_version()",
+		// Ctor runs the init and stores into the global.
+		"define private void @__osty_init_globals()",
+		"call i64 @_init_version()",
+		"store i64 %vversion, ptr @version",
+		// llvm.global_ctors registration.
+		"@llvm.global_ctors",
+		// Read side in `get` loads from the global.
+		"load i64, ptr @version",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateFromMIRMultipleGlobals(t *testing.T) {
+	// pub let a = 1
+	// pub let b = 2
+	// fn sum() -> Int { a + b }
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.LetDecl{Name: "a", Type: ir.TInt, Value: &ir.IntLit{Text: "1", T: ir.TInt}, Exported: true},
+			&ir.LetDecl{Name: "b", Type: ir.TInt, Value: &ir.IntLit{Text: "2", T: ir.TInt}, Exported: true},
+			&ir.FnDecl{
+				Name:   "sum",
+				Return: ir.TInt,
+				Body: &ir.Block{
+					Result: &ir.BinaryExpr{
+						Op:    ir.BinAdd,
+						Left:  &ir.Ident{Name: "a", Kind: ir.IdentGlobal, T: ir.TInt},
+						Right: &ir.Ident{Name: "b", Kind: ir.IdentGlobal, T: ir.TInt},
+						T:     ir.TInt,
+					},
+				},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/multi.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	// Both globals + both inits + the ctor stores both.
+	for _, want := range []string{
+		"@a = global i64 zeroinitializer",
+		"@b = global i64 zeroinitializer",
+		"call i64 @_init_a()",
+		"call i64 @_init_b()",
+		"store i64 %va, ptr @a",
+		"store i64 %vb, ptr @b",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Module-level `let` declarations round-trip through the MIR emitter instead of falling back to the legacy HIR→AST bridge. Each `mir.Global` produces three pieces of LLVM IR: the global variable slot, the zero-arg init function, and a ctor that populates the slot before user code runs.

## What lands

- **Slot**: `@<name> = global <T> zeroinitializer` — one line per global.
- **Init fn**: `define <T> @_init_<name>() { ... }` — the zero-arg fn `mir.Lower` already produces for any `pub let x = e`. Emitted as a regular LLVM fn definition *before* user fns.
- **Module ctor**: `define private void @__osty_init_globals() { ... }` — calls every init fn in MIR order and stores each result into its matching `@<name>` slot via a stable `%v<name>` register.
- **Ctor registration**: `@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32 65535, ptr @__osty_init_globals, ptr null }]` — priority 65535 so the Osty ctor runs after any runtime-setup ctor.
- **Reads**: `evalRValue` case for `*mir.GlobalRefRV` emits `load <T>, ptr @<name>` directly.
- **Support check**: `checkSupported` drops the hard block on `len(Globals) > 0` and walks every `Global.Init` through a new `checkFunctionSupported` helper. Init fns aren't in `Module.Functions`, so they need their own whitelist pass.

## Tests — 2 new cases

- `TestGenerateFromMIRGlobalReadAndInit` — `pub let version = 42` + `fn get() -> Int { version }` emits the global, init fn, ctor, `@llvm.global_ctors` registration, and the `load i64, ptr @version` read side.
- `TestGenerateFromMIRMultipleGlobals` — two globals with a fn that reads both; asserts both init calls + stores show up in the ctor.

Fallback regression tests (`…UnsupportedFallsBack` / `…GracefulFallback`) move to an unresolved `NamedType{Name: \"Unknown\"}` trigger — still outside MVP since `typeSupported` refuses it.

## Test plan

- [x] `go test -run MIR ./internal/llvmgen`
- [x] `go test ./internal/parser ./internal/ir ./internal/mir`

## Remaining Stage 5 gap (updated)

- **GC roots / safepoints** — next biggest wedge; threads through function entry, call sites, alloca slots. Needs its own design pass.
- **Composite map element types**
- **Heap-escaping closure envs**
- **`DerefProj` beyond closure env**

Top-level globals crossed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)