### PR TITLE
feat(mir): stage 3.11 — GC roots / safepoints in MIR emitter

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -955,16 +955,53 @@ MIR tests isolated from front-end churn.
     walk through the same `checkFunctionSupported` whitelist as
     user fns so unsupported init shapes still trigger fallback.
 
+- **Stage 3.11 (landed — GC roots / safepoints, opt-in).** Adds
+  `Options.EmitGC` to `internal/llvmgen`. When set, the MIR emitter
+  instruments every function with the Osty GC runtime contract:
+
+  - **Managed locals** — any local whose MIR type lowers to an LLVM
+    `ptr` and is not a function pointer. Concretely: `String`,
+    `Bytes`, `List<T>`, `Map<K, V>`, `Set<T>`, `Channel`, `Handle`,
+    `Group`, `TaskGroup`, `Select`, `Duration`, `ClosureEnv`.
+  - **Entry prologue.** After the alloca/store preamble runs, each
+    non-param managed slot is zero-initialised
+    (`store ptr null, ptr %lN`) so the GC never observes undef
+    memory; then every managed slot (params included) is bound via
+    `call void @osty.gc.root_bind_v1(ptr %slot)`. Finally the
+    function takes an entry poll via
+    `call void @osty.gc.safepoint_v1(i64 <id>, ptr null, i64 0)`.
+    Pointer-free functions still take the entry safepoint but don't
+    emit any root_bind — this keeps cancellation responsive
+    everywhere.
+  - **Terminator epilogue.** `ReturnTerm` and `UnreachableTerm`
+    release every bound root in reverse bind order before the `ret`
+    / `unreachable`. For value-returning functions the return load
+    runs *before* the releases so the live value is already in an
+    SSA register when its backing slot drops off the root list.
+  - **Loop back-edges.** `GotoTerm` and `BranchTerm` emit a
+    safepoint whenever they jump to a block with ID ≤ the current
+    block's ID. That heuristic catches the standard
+    `cond → body → cond` while-loop shape `mir.Lower` produces, plus
+    any future loop construct that preserves block-id-monotone CFG
+    order.
+  - **Runtime declarations.** The emitter pulls
+    `@osty.gc.safepoint_v1(i64, ptr, i64)` in on first use; the
+    bind/release pair is pulled in together on the first bind or
+    release site so the declaration order is stable.
+
+  Passing `null/0` for the safepoint's explicit-root vector relies
+  on the runtime's bound-root tracking to locate live references.
+  That's the MVP shape — a follow-up can pack per-safepoint precise
+  roots if the runtime needs them.
+
 - **Stage 5 (deferred — still needs parity).** Remove
   `legacyFileFromModule` and the AST-driven emitter. Outstanding
-  parity gaps after Stage 3.10: GC roots / safepoints, composite
-  **map** element types, heap-escaping closure envs, and
-  `DerefProj` on anything other than a closure env. Top-level
-  globals crossed off in Stage 3.10; GC roots / safepoints are the
-  biggest remaining wedge — they thread through function entry,
-  call sites, and alloca slots so they deserve their own Stage
-  3.11+ design pass. See the MIR emitter's `checkSupported` and
-  `checkRValueSupported` for the current whitelist.
+  parity gaps after Stage 3.11: composite **map** element types,
+  heap-escaping closure envs, and `DerefProj` on anything other
+  than a closure env. Top-level globals crossed off in Stage 3.10;
+  GC roots / safepoints crossed off in Stage 3.11. See the MIR
+  emitter's `checkSupported` and `checkRValueSupported` for the
+  current whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -41,11 +41,19 @@ var ErrUnsupported = errors.New("llvmgen: unsupported source shape")
 // callers can still leave the zero value to stay on the legacy
 // HIR→AST bridge or set it explicitly when running dual-emission
 // tests.
+//
+// EmitGC asks the MIR emitter to instrument generated code with the
+// Osty GC runtime contract — root-slot binding for managed locals,
+// release on return, and safepoint calls at function entry + loop
+// back-edges. Off by default so existing MIR-emission tests stay
+// byte-stable; opt in when you want to link against the managed
+// runtime.
 type Options struct {
 	PackageName string
 	SourcePath  string
 	Target      string
 	UseMIR      bool
+	EmitGC      bool
 }
 
 // SmokeExecutableCase describes one LLVM executable parity case. The data is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -97,6 +97,20 @@ type mirGen struct {
 	localSlots  map[mir.LocalID]string
 	fnBuf       strings.Builder
 
+	// GC instrumentation state (per-function, populated only when
+	// opts.EmitGC is set). gcRoots lists the managed-ptr locals in
+	// the order root_bind_v1 was emitted for them; emitter sites use
+	// the same order in reverse for root_release_v1 on return.
+	// curBlockID tracks the block we're currently emitting so
+	// GotoTerm can detect loop back-edges (goto whose target block
+	// ID is <= the current block's ID) and emit a safepoint.
+	gcRoots    []mir.LocalID
+	curBlockID mir.BlockID
+
+	// Module-scoped safepoint counter — matches the AST emitter's
+	// safepoint-v1 ABI so each call site has a stable numeric id.
+	nextSafepoint int
+
 	// Module-level state.
 	functionTypes map[string]mirFnSig // symbol → declared signature
 	declares      map[string]string   // runtime name → full declaration line
@@ -718,6 +732,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	g.blockLabels = map[mir.BlockID]string{}
 	g.localSlots = map[mir.LocalID]string{}
 	g.fnBuf.Reset()
+	g.gcRoots = g.gcRoots[:0]
 
 	if fn.IsExternal {
 		// External stub: just a declare.
@@ -765,6 +780,9 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	// Entry-block preamble: alloca one slot per non-parameter local,
 	// and store incoming params into their alloca slots.
 	g.emitAllocaPreamble(fn)
+	// Register managed-ptr locals as GC roots and take a safepoint at
+	// the function entry. No-op unless opts.EmitGC is set.
+	g.emitGCEntry(fn)
 
 	// Emit each block in ID order. The entry block was already opened
 	// (its label is implicit in LLVM, but we still emit it for clarity
@@ -778,6 +796,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 			g.fnBuf.WriteString(g.blockLabels[bb.ID])
 			g.fnBuf.WriteString(":\n")
 		}
+		g.curBlockID = bb.ID
 		for _, inst := range bb.Instrs {
 			if err := g.emitInstr(inst); err != nil {
 				return err
@@ -842,6 +861,130 @@ func (g *mirGen) emitAllocaPreamble(fn *mir.Function) {
 		g.fnBuf.WriteString(slot)
 		g.fnBuf.WriteByte('\n')
 	}
+}
+
+// ==== GC instrumentation ====
+//
+// Only emitted when opts.EmitGC is set. The ABI matches the legacy
+// AST emitter (see internal/llvmgen/generator.go):
+//
+//   declare void @osty.gc.root_bind_v1(ptr)
+//   declare void @osty.gc.root_release_v1(ptr)
+//   declare void @osty.gc.safepoint_v1(i64, ptr, i64)
+//
+// The runtime keeps a per-thread root list populated by
+// `root_bind_v1` for each ptr-sized local; `safepoint_v1` is a poll
+// point that can scan the bound-root list. We don't pass an explicit
+// root vector at each safepoint — that's an optimisation the legacy
+// emitter uses for precise scanning, but the bound-root tracking is
+// sufficient for the MVP.
+
+// isManagedLocal reports whether a local should be tracked as a GC
+// root. A local is managed when it lowers to an LLVM ptr AND the MIR
+// type is not a function pointer (static code addresses never move).
+// Unit-typed locals are skipped — they have no storage.
+func (g *mirGen) isManagedLocal(loc *mir.Local) bool {
+	if loc == nil || loc.Type == nil {
+		return false
+	}
+	if isUnitType(loc.Type) {
+		return false
+	}
+	if _, isFn := loc.Type.(*ir.FnType); isFn {
+		return false
+	}
+	return g.llvmType(loc.Type) == "ptr"
+}
+
+// emitGCEntry registers every managed local of the current function
+// as a GC root and emits a safepoint at function entry. Parameter
+// slots are bound after their arg value is stored; non-param slots
+// are null-initialised before binding so the GC never scans undef
+// memory.
+func (g *mirGen) emitGCEntry(fn *mir.Function) {
+	if !g.opts.EmitGC {
+		return
+	}
+	// Collect managed locals in ID order. Params are listed first
+	// (their IDs are the lowest) so release-on-return unwinds in
+	// reverse bind order naturally.
+	for _, loc := range fn.Locals {
+		if !g.isManagedLocal(loc) {
+			continue
+		}
+		g.gcRoots = append(g.gcRoots, loc.ID)
+	}
+	if len(g.gcRoots) == 0 {
+		// Still emit an entry safepoint so cancellation / GC polls
+		// fire even on pointer-free functions.
+		g.emitGCSafepoint()
+		return
+	}
+	// Zero non-param managed slots before binding. Param slots
+	// already hold the incoming arg from the preamble's store loop.
+	for _, id := range g.gcRoots {
+		loc := fn.Local(id)
+		if loc == nil || loc.IsParam {
+			continue
+		}
+		g.fnBuf.WriteString("  store ptr null, ptr ")
+		g.fnBuf.WriteString(g.localSlots[id])
+		g.fnBuf.WriteByte('\n')
+	}
+	// Bind each managed slot as a root.
+	g.declareRootBindRelease()
+	for _, id := range g.gcRoots {
+		g.fnBuf.WriteString("  call void @osty.gc.root_bind_v1(ptr ")
+		g.fnBuf.WriteString(g.localSlots[id])
+		g.fnBuf.WriteString(")\n")
+	}
+	// Entry safepoint.
+	g.emitGCSafepoint()
+}
+
+// emitGCReleaseRoots releases every bound root in reverse bind order.
+// Called before every ret / unreachable terminator.
+func (g *mirGen) emitGCReleaseRoots() {
+	if !g.opts.EmitGC || len(g.gcRoots) == 0 {
+		return
+	}
+	g.declareRootBindRelease()
+	for i := len(g.gcRoots) - 1; i >= 0; i-- {
+		slot := g.localSlots[g.gcRoots[i]]
+		g.fnBuf.WriteString("  call void @osty.gc.root_release_v1(ptr ")
+		g.fnBuf.WriteString(slot)
+		g.fnBuf.WriteString(")\n")
+	}
+}
+
+// emitGCSafepoint emits a single safepoint poll. The ABI matches the
+// legacy emitter: `safepoint_v1(i64 id, ptr roots, i64 nroots)` — we
+// pass null/0 because root_bind_v1 already registered the live set.
+func (g *mirGen) emitGCSafepoint() {
+	if !g.opts.EmitGC {
+		return
+	}
+	g.declareSafepoint()
+	id := g.nextSafepoint
+	g.nextSafepoint++
+	g.fnBuf.WriteString("  call void @osty.gc.safepoint_v1(i64 ")
+	g.fnBuf.WriteString(strconv.Itoa(id))
+	g.fnBuf.WriteString(", ptr null, i64 0)\n")
+}
+
+// declareSafepoint registers @osty.gc.safepoint_v1 — split from
+// root_bind/root_release so pointer-free functions don't pull in
+// unused root declarations.
+func (g *mirGen) declareSafepoint() {
+	g.declareRuntime("osty.gc.safepoint_v1", "declare void @osty.gc.safepoint_v1(i64, ptr, i64)")
+}
+
+// declareRootBindRelease registers the bind/release pair in a single
+// call so their order in the runtime-declaration block is stable
+// regardless of whether bind or release emits first.
+func (g *mirGen) declareRootBindRelease() {
+	g.declareRuntime("osty.gc.root_bind_v1", "declare void @osty.gc.root_bind_v1(ptr)")
+	g.declareRuntime("osty.gc.root_release_v1", "declare void @osty.gc.root_release_v1(ptr)")
 }
 
 // ==== instructions ====
@@ -2101,10 +2244,26 @@ func (g *mirGen) emitPrintlnLike(op mir.Operand, newline bool) error {
 func (g *mirGen) emitTerm(t mir.Terminator) error {
 	switch x := t.(type) {
 	case *mir.GotoTerm:
+		// Loop back-edges — a goto whose target is at or before the
+		// current block in CFG order — get a safepoint poll. This
+		// matches the legacy emitter's "safepoint at loop headers"
+		// convention and keeps cancellation responsive in tight
+		// loops. Forward gotos (if/else joins, fall-throughs) do
+		// not need extra polls because the function already took
+		// one at entry.
+		if g.opts.EmitGC && x.Target <= g.curBlockID {
+			g.emitGCSafepoint()
+		}
 		g.fnBuf.WriteString("  br label %")
 		g.fnBuf.WriteString(g.blockLabels[x.Target])
 		g.fnBuf.WriteByte('\n')
 	case *mir.BranchTerm:
+		// Same back-edge rule applied to conditional branches —
+		// covers `while cond { ... }` style loops where the cond
+		// block has a conditional branch back to its own body.
+		if g.opts.EmitGC && (x.Then <= g.curBlockID || x.Else <= g.curBlockID) {
+			g.emitGCSafepoint()
+		}
 		cond, err := g.evalOperand(x.Cond, mir.TBool)
 		if err != nil {
 			return err
@@ -2142,6 +2301,10 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 		g.fnBuf.WriteString("  ]\n")
 	case *mir.ReturnTerm:
 		if g.fn.ReturnType == nil || isUnitType(g.fn.ReturnType) {
+			// Release bound roots BEFORE ret so the GC doesn't
+			// scan dead slots for in-flight tail calls on other
+			// threads.
+			g.emitGCReleaseRoots()
 			g.fnBuf.WriteString("  ret void\n")
 			return nil
 		}
@@ -2155,12 +2318,17 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 		g.fnBuf.WriteString(", ptr ")
 		g.fnBuf.WriteString(retSlot)
 		g.fnBuf.WriteByte('\n')
+		// Release roots after we've loaded the return value but
+		// before the ret — the value is now in an SSA register so
+		// it's safe for the slot to drop out of the root list.
+		g.emitGCReleaseRoots()
 		g.fnBuf.WriteString("  ret ")
 		g.fnBuf.WriteString(llvmT)
 		g.fnBuf.WriteByte(' ')
 		g.fnBuf.WriteString(tmp)
 		g.fnBuf.WriteByte('\n')
 	case *mir.UnreachableTerm:
+		g.emitGCReleaseRoots()
 		g.fnBuf.WriteString("  unreachable\n")
 	default:
 		return unsupported("mir-mvp", fmt.Sprintf("terminator %T", t))

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1650,3 +1650,244 @@ func TestGenerateFromMIRCancellationHelpers(t *testing.T) {
 		}
 	}
 }
+
+// ==== Stage 3.11: GC roots / safepoints (Options.EmitGC) ====
+
+// TestGenerateFromMIREmitGCDefaultOff — With EmitGC off (the default),
+// none of the osty.gc.* runtime symbols may appear even when the
+// function owns a managed-ptr local. This keeps the pre-Stage-3.11
+// MIR corpus byte-stable.
+func TestGenerateFromMIREmitGCDefaultOff(t *testing.T) {
+	// fn identity(s: String) -> String { s }
+	fn := &ir.FnDecl{
+		Name:   "identity",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Result: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/gc-off.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, gcSym := range []string{
+		"osty.gc.root_bind_v1",
+		"osty.gc.root_release_v1",
+		"osty.gc.safepoint_v1",
+	} {
+		if strings.Contains(got, gcSym) {
+			t.Fatalf("unexpected GC symbol %q with EmitGC off:\n%s", gcSym, got)
+		}
+	}
+}
+
+// TestGenerateFromMIREmitGCManagedParam — A function with a
+// managed-ptr param (String) should bind the param slot as a root,
+// take an entry safepoint, and release the root before ret.
+func TestGenerateFromMIREmitGCManagedParam(t *testing.T) {
+	// fn identity(s: String) -> String { s }
+	fn := &ir.FnDecl{
+		Name:   "identity",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Result: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-param.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		// Runtime declarations.
+		"declare void @osty.gc.root_bind_v1(ptr)",
+		"declare void @osty.gc.root_release_v1(ptr)",
+		"declare void @osty.gc.safepoint_v1(i64, ptr, i64)",
+		// Entry safepoint with numeric id 0.
+		"call void @osty.gc.safepoint_v1(i64 0, ptr null, i64 0)",
+		// Param slot is bound as a root.
+		"call void @osty.gc.root_bind_v1(ptr %p",
+		// Release on the return path.
+		"call void @osty.gc.root_release_v1(ptr %p",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// The return value load must happen before root_release so the
+	// live value is in an SSA register when the slot drops out of
+	// the root list.
+	loadIdx := strings.Index(got, "load ptr, ptr %p")
+	releaseIdx := strings.Index(got, "call void @osty.gc.root_release_v1")
+	retIdx := strings.Index(got, "ret ptr")
+	if loadIdx < 0 || releaseIdx < 0 || retIdx < 0 {
+		t.Fatalf("ordering markers missing in:\n%s", got)
+	}
+	if !(loadIdx < releaseIdx && releaseIdx < retIdx) {
+		t.Fatalf("expected load → release → ret ordering in:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIREmitGCNonParamLocalZeroInit — A non-param
+// managed local must be null-initialised before root_bind so the GC
+// never scans undef memory.
+func TestGenerateFromMIREmitGCNonParamLocalZeroInit(t *testing.T) {
+	// fn first(xs: List<Int>) -> List<Int> { let y = xs; y }
+	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "first",
+		Return: listInt,
+		Params: []*ir.Param{{Name: "xs", Type: listInt}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name:  "y",
+					Type:  listInt,
+					Value: &ir.Ident{Name: "xs", Kind: ir.IdentParam, T: listInt},
+				},
+			},
+			Result: &ir.Ident{Name: "y", Kind: ir.IdentLocal, T: listInt},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-local.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "store ptr null, ptr %l") {
+		t.Fatalf("expected non-param local to be null-initialised in:\n%s", got)
+	}
+	// The null-init must happen before the bind so the GC sees a
+	// valid (null) pointer at every safepoint.
+	zeroIdx := strings.Index(got, "store ptr null, ptr %l")
+	bindIdx := strings.Index(got, "call void @osty.gc.root_bind_v1(ptr %l")
+	if zeroIdx < 0 || bindIdx < 0 {
+		t.Fatalf("zero-init / bind markers missing in:\n%s", got)
+	}
+	if !(zeroIdx < bindIdx) {
+		t.Fatalf("expected zero-init before root_bind in:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIREmitGCNoManagedLocals — A function with only
+// value-typed locals still gets an entry safepoint. root_bind /
+// root_release never fire because there are no managed slots.
+func TestGenerateFromMIREmitGCNoManagedLocals(t *testing.T) {
+	// fn answer() -> Int { 42 }
+	fn := &ir.FnDecl{
+		Name:   "answer",
+		Return: ir.TInt,
+		Body: &ir.Block{
+			Result: &ir.IntLit{Text: "42", T: ir.TInt},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-noptr.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "call void @osty.gc.safepoint_v1") {
+		t.Fatalf("expected entry safepoint in:\n%s", got)
+	}
+	if strings.Contains(got, "osty.gc.root_bind_v1") {
+		t.Fatalf("unexpected root_bind in pointer-free function:\n%s", got)
+	}
+	if strings.Contains(got, "osty.gc.root_release_v1") {
+		t.Fatalf("unexpected root_release in pointer-free function:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIREmitGCLoopSafepoint — A while-loop lowers to a
+// cond block whose branch terminator targets the loop body and the
+// exit. The back-edge from the body to the cond block must carry a
+// safepoint so cancellation / GC polls fire inside tight loops.
+func TestGenerateFromMIREmitGCLoopSafepoint(t *testing.T) {
+	// fn count() { let mut i = 0; while i < 10 { i = i + 1 } }
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:   "count",
+				Return: ir.TUnit,
+				Body: &ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.LetStmt{
+							Name:  "i",
+							Type:  ir.TInt,
+							Mut:   true,
+							Value: &ir.IntLit{Text: "0", T: ir.TInt},
+						},
+						&ir.ForStmt{
+							Kind: ir.ForWhile,
+							Cond: &ir.BinaryExpr{
+								Op:    ir.BinLt,
+								Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+								Right: &ir.IntLit{Text: "10", T: ir.TInt},
+								T:     ir.TBool,
+							},
+							Body: &ir.Block{
+								Stmts: []ir.Stmt{
+									&ir.AssignStmt{
+										Op:      ir.AssignEq,
+										Targets: []ir.Expr{&ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt}},
+										Value: &ir.BinaryExpr{
+											Op:    ir.BinAdd,
+											Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+											Right: &ir.IntLit{Text: "1", T: ir.TInt},
+											T:     ir.TInt,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-loop.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	// Entry + at least one back-edge safepoint = ≥2 calls.
+	safepoints := strings.Count(got, "call void @osty.gc.safepoint_v1")
+	if safepoints < 2 {
+		t.Fatalf("expected ≥2 safepoints (entry + back-edge), got %d in:\n%s", safepoints, got)
+	}
+	// Safepoint ids must be strictly increasing per emission site.
+	if !strings.Contains(got, "safepoint_v1(i64 0,") {
+		t.Fatalf("expected safepoint id 0 in:\n%s", got)
+	}
+	if !strings.Contains(got, "safepoint_v1(i64 1,") {
+		t.Fatalf("expected safepoint id 1 in:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Options.EmitGC` to `internal/llvmgen`. Off by default so the
  existing MIR-emission corpus stays byte-stable; callers opt in when
  they need to link against the managed runtime.
- With `EmitGC: true`, the MIR-direct emitter instruments every
  function with the Osty GC runtime contract:
  - **Managed locals** — ptr-lowered types (`String`, `Bytes`,
    `List`, `Map`, `Set`, `Channel`, `Handle`, `Group`, `TaskGroup`,
    `Select`, `Duration`, `ClosureEnv`), excluding fn pointers —
    are null-initialised (non-param only) then bound via
    `osty.gc.root_bind_v1` right after the alloca/store preamble.
  - **Release on exit** — `ReturnTerm` / `UnreachableTerm` emit
    `osty.gc.root_release_v1` in reverse bind order before the
    actual `ret`/`unreachable`. Value-returning functions load the
    return value first so the live value is already in an SSA
    register when its slot drops off the root list.
  - **Safepoints** — `osty.gc.safepoint_v1(i64 id, ptr null, i64 0)`
    at function entry (every function, including pointer-free
    ones), plus one on every loop back-edge detected as a goto /
    branch whose target block ID is ≤ the current block. Pass
    `null/0` for the explicit-root vector because `root_bind_v1`
    already registered the live set.
- Runtime declarations (`@osty.gc.root_bind_v1(ptr)`,
  `@osty.gc.root_release_v1(ptr)`,
  `@osty.gc.safepoint_v1(i64, ptr, i64)`) are pulled in on first use
  only so pointer-free functions don't drag in bind/release symbols.

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestGenerateFromMIREmitGC -v`
  covers five cases: default-off silence, managed param bind +
  release + load/release/ret ordering, non-param null-init ordering,
  pointer-free function entry-only safepoint, and loop back-edge
  safepoint count + id sequencing.
- [x] Full MIR suite still passes
  (`go test ./internal/llvmgen/ -run 'TestGenerateFromMIR|TestMIR'`).
- [ ] Runtime parity — once the managed runtime links against the
  new symbol set end-to-end, promote `EmitGC` from opt-in to the
  default and drop the AST emitter's GC path in Stage 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)