### PR TITLE
feat(scaffold): roll back partial writes on mid-stream failure

### DIFF
--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -202,10 +202,12 @@ func Create(opts Options) (string, *diag.Diagnostic) {
 	} else if !os.IsNotExist(err) {
 		return "", ioErr(dir, err)
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	tx := &writeTx{}
+	if err := tx.mkdir(dir); err != nil {
 		return "", ioErr(dir, err)
 	}
-	if d := writeLayout(dir, opts); d != nil {
+	if d := writeLayout(tx, dir, opts); d != nil {
+		tx.rollback()
 		return dir, d
 	}
 	return dir, nil
@@ -252,7 +254,9 @@ func Init(opts Options) (string, *diag.Diagnostic) {
 	if d := checkNoConflicts(parent, opts); d != nil {
 		return "", d
 	}
-	if d := writeLayout(parent, opts); d != nil {
+	tx := &writeTx{}
+	if d := writeLayout(tx, parent, opts); d != nil {
+		tx.rollback()
 		return parent, d
 	}
 	return parent, nil
@@ -354,7 +358,9 @@ func expectedPaths(dir string, opts Options) []string {
 
 // writeLayout renders and writes every file in the layout. Called by
 // both Create and Init — the directory it writes into already exists.
-func writeLayout(dir string, opts Options) *diag.Diagnostic {
+// tx tracks files and directories the layout creates so Create/Init
+// can roll back on a mid-write failure, leaving no partial state.
+func writeLayout(tx *writeTx, dir string, opts Options) *diag.Diagnostic {
 	edition := opts.Edition
 	if edition == "" {
 		edition = CurrentEdition
@@ -366,81 +372,107 @@ func writeLayout(dir string, opts Options) *diag.Diagnostic {
 			member = "core"
 		}
 		memberDir := filepath.Join(dir, member)
-		if err := os.MkdirAll(memberDir, 0o755); err != nil {
+		if err := tx.mkdir(memberDir); err != nil {
 			return ioErr(memberDir, err)
 		}
-		files := []struct {
-			path    string
-			content string
-		}{
+		return tx.writeFiles([]fileSpec{
 			{filepath.Join(dir, "osty.toml"), renderWorkspaceManifest(opts.Name, edition, member)},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
 			{filepath.Join(memberDir, "osty.toml"), renderManifest(member, edition, KindBin)},
 			{filepath.Join(memberDir, "main.osty"), binSourceTemplate},
 			{filepath.Join(memberDir, "main_test.osty"), binTestTemplate},
 			{filepath.Join(memberDir, ".gitignore"), gitignoreTemplate},
-		}
-		return writeFiles(files)
+		})
 	case KindLib:
-		files := []struct {
-			path    string
-			content string
-		}{
+		return tx.writeFiles([]fileSpec{
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindLib)},
 			{filepath.Join(dir, "lib.osty"), libSourceTemplate},
 			{filepath.Join(dir, "lib_test.osty"), libTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
-		}
-		return writeFiles(files)
+		})
 	case KindCli:
-		files := []struct {
-			path    string
-			content string
-		}{
+		return tx.writeFiles([]fileSpec{
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindCli)},
 			{filepath.Join(dir, "main.osty"), cliMainTemplate},
 			{filepath.Join(dir, "args.osty"), cliArgsTemplate},
 			{filepath.Join(dir, "app.osty"), cliAppTemplate},
 			{filepath.Join(dir, "app_test.osty"), cliAppTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
-		}
-		return writeFiles(files)
+		})
 	case KindService:
-		files := []struct {
-			path    string
-			content string
-		}{
+		return tx.writeFiles([]fileSpec{
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindService)},
 			{filepath.Join(dir, "main.osty"), serviceMainTemplate},
 			{filepath.Join(dir, "routes.osty"), serviceRoutesTemplate},
 			{filepath.Join(dir, "routes_test.osty"), serviceRoutesTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
-		}
-		return writeFiles(files)
+		})
 	default: // KindBin
-		files := []struct {
-			path    string
-			content string
-		}{
+		return tx.writeFiles([]fileSpec{
 			{filepath.Join(dir, "osty.toml"), renderManifest(opts.Name, edition, KindBin)},
 			{filepath.Join(dir, "main.osty"), binSourceTemplate},
 			{filepath.Join(dir, "main_test.osty"), binTestTemplate},
 			{filepath.Join(dir, ".gitignore"), gitignoreTemplate},
-		}
-		return writeFiles(files)
+		})
 	}
 }
 
-func writeFiles(files []struct {
+type fileSpec struct {
 	path    string
 	content string
-}) *diag.Diagnostic {
+}
+
+// writeTx records directories and files a scaffold run creates so
+// rollback can restore the filesystem to its pre-run state on a
+// mid-write failure. Without rollback, a partial scaffold blocks the
+// next `osty new` / `osty init` with CodeScaffoldDestExists and forces
+// the user to clean up by hand.
+type writeTx struct {
+	createdDirs  []string // mkdir order; removed in reverse
+	createdFiles []string // writeFile order; removed in reverse
+}
+
+// mkdir creates dir (and parents) and records it for rollback. Only
+// directories mkdir creates belong to the transaction — preexisting
+// directories are left alone on rollback.
+func (tx *writeTx) mkdir(dir string) error {
+	if _, err := os.Stat(dir); err == nil {
+		return nil // already exists; not ours to remove on rollback
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tx.createdDirs = append(tx.createdDirs, dir)
+	return nil
+}
+
+// writeFiles writes each fileSpec in order, recording successful
+// writes for rollback. Stops on first error.
+func (tx *writeTx) writeFiles(files []fileSpec) *diag.Diagnostic {
 	for _, f := range files {
 		if err := os.WriteFile(f.path, []byte(f.content), 0o644); err != nil {
 			return ioErr(f.path, err)
 		}
+		tx.createdFiles = append(tx.createdFiles, f.path)
 	}
 	return nil
+}
+
+// rollback best-effort removes files and directories the transaction
+// created. Errors are swallowed so the caller's original diagnostic is
+// preserved. os.Remove on a non-empty directory returns ENOTEMPTY
+// (not a no-op), so a dir that somehow acquired unrelated contents
+// between mkdir and rollback stays put — the swallowed error is the
+// right outcome.
+func (tx *writeTx) rollback() {
+	for i := len(tx.createdFiles) - 1; i >= 0; i-- {
+		_ = os.Remove(tx.createdFiles[i])
+	}
+	for i := len(tx.createdDirs) - 1; i >= 0; i-- {
+		_ = os.Remove(tx.createdDirs[i])
+	}
 }
 
 func existsDiag(dir string) *diag.Diagnostic {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -1,0 +1,197 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCreateHappyPath(t *testing.T) {
+	parent := t.TempDir()
+	path, d := Create(Options{Parent: parent, Name: "myproj", Kind: KindBin})
+	if d != nil {
+		t.Fatalf("Create returned diagnostic: %v", d)
+	}
+	if path == "" {
+		t.Fatal("Create returned empty path")
+	}
+	for _, f := range []string{"osty.toml", "main.osty", "main_test.osty", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(path, f)); err != nil {
+			t.Errorf("expected %s to exist: %v", f, err)
+		}
+	}
+}
+
+func TestInitHappyPath(t *testing.T) {
+	parent := t.TempDir()
+	_, d := Init(Options{Parent: parent, Name: "myproj", Kind: KindLib})
+	if d != nil {
+		t.Fatalf("Init returned diagnostic: %v", d)
+	}
+	for _, f := range []string{"osty.toml", "lib.osty", "lib_test.osty", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(parent, f)); err != nil {
+			t.Errorf("expected %s to exist: %v", f, err)
+		}
+	}
+}
+
+// TestCreateRollbackOnMkdirFailure verifies that when MkdirAll fails
+// (read-only parent dir) no partial outer directory is left behind.
+func TestCreateRollbackOnMkdirFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatalf("chmod parent: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	path, d := Create(Options{Parent: parent, Name: "myproj", Kind: KindBin})
+	if d == nil {
+		t.Fatalf("expected diagnostic from read-only parent, got none (path=%q)", path)
+	}
+	target := filepath.Join(parent, "myproj")
+	if _, err := os.Stat(target); err == nil {
+		t.Errorf("outer dir %s exists after failed Create", target)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("unexpected stat err on %s: %v", target, err)
+	}
+}
+
+// TestInitRollbackOnMidWriteFailure induces a WriteFile failure on the
+// second file by staging a dangling symlink in its place. The symlink
+// target doesn't exist, so checkNoConflicts treats the slot as free
+// (stat follows links), but the subsequent WriteFile fails. The
+// transaction should roll back the first file and leave the filesystem
+// in its pre-Init state.
+func TestInitRollbackOnMidWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	parent := t.TempDir()
+	// KindBin writes: osty.toml, main.osty, main_test.osty, .gitignore.
+	// Place a dangling symlink at main.osty so file #2 fails.
+	dangling := filepath.Join(parent, "main.osty")
+	if err := os.Symlink(filepath.Join(parent, "nonexistent", "target"), dangling); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, d := Init(Options{Parent: parent, Name: "myproj", Kind: KindBin})
+	if d == nil {
+		t.Fatal("expected diagnostic from dangling-symlink write, got none")
+	}
+
+	// osty.toml was written then rolled back.
+	if _, err := os.Stat(filepath.Join(parent, "osty.toml")); err == nil {
+		t.Errorf("osty.toml still present after rollback")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("unexpected stat err on osty.toml: %v", err)
+	}
+	// Later files were never attempted.
+	for _, name := range []string{"main_test.osty", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(parent, name)); err == nil {
+			t.Errorf("%s present but should not have been written", name)
+		}
+	}
+	// The dangling symlink itself is pre-existing and must be left alone.
+	if fi, err := os.Lstat(dangling); err != nil {
+		t.Errorf("pre-existing symlink removed by rollback: %v", err)
+	} else if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("main.osty is no longer a symlink after rollback")
+	}
+}
+
+// TestInitWorkspaceRollbackOnMidWriteFailure exercises the multi-dir
+// case: a workspace scaffold writes root files, then enters the member
+// directory. A failing slot inside the member dir must trigger
+// rollback of the root files and the member osty.toml that had already
+// been written.
+func TestInitWorkspaceRollbackOnMidWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	parent := t.TempDir()
+	// Workspace writes root osty.toml, root .gitignore, then inside
+	// core/: osty.toml, main.osty, main_test.osty, .gitignore.
+	// Pre-create memberDir and plant a dangling symlink at main.osty
+	// so the write inside the member dir fails. memberDir pre-exists
+	// here (we had to put the symlink somewhere), so tx.mkdir won't
+	// claim ownership of it — the rollback scope is the files written
+	// inside it, which is what this test asserts.
+	memberDir := filepath.Join(parent, "core")
+	if err := os.MkdirAll(memberDir, 0o755); err != nil {
+		t.Fatalf("mkdir memberDir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(parent, "nonexistent", "target"),
+		filepath.Join(memberDir, "main.osty")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, d := Init(Options{Parent: parent, Kind: KindWorkspace, WorkspaceMember: "core"})
+	if d == nil {
+		t.Fatal("expected diagnostic from workspace mid-write failure")
+	}
+	// Root files written before the failure should be rolled back.
+	for _, name := range []string{"osty.toml", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(parent, name)); err == nil {
+			t.Errorf("%s still present after rollback", name)
+		}
+	}
+	// The member osty.toml written just before the failure must be gone.
+	if _, err := os.Stat(filepath.Join(memberDir, "osty.toml")); err == nil {
+		t.Errorf("core/osty.toml still present after rollback")
+	}
+}
+
+// TestWriteTxMkdirSkipsExisting verifies that an existing directory is
+// not recorded for rollback, so a preexisting directory survives
+// rollback.
+func TestWriteTxMkdirSkipsExisting(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("pre-mkdir: %v", err)
+	}
+	tx := &writeTx{}
+	if err := tx.mkdir(sub); err != nil {
+		t.Fatalf("tx.mkdir on existing: %v", err)
+	}
+	if len(tx.createdDirs) != 0 {
+		t.Errorf("existing dir recorded for rollback: %v", tx.createdDirs)
+	}
+	tx.rollback()
+	if _, err := os.Stat(sub); err != nil {
+		t.Errorf("preexisting dir removed by rollback: %v", err)
+	}
+}
+
+// TestWriteTxRollbackOrderFilesBeforeDirs verifies that rollback
+// removes files before their containing directories, so rmdir sees an
+// empty directory.
+func TestWriteTxRollbackOrderFilesBeforeDirs(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+
+	tx := &writeTx{}
+	if err := tx.mkdir(sub); err != nil {
+		t.Fatalf("tx.mkdir: %v", err)
+	}
+	if d := tx.writeFiles([]fileSpec{
+		{filepath.Join(sub, "a.txt"), "a"},
+		{filepath.Join(sub, "b.txt"), "b"},
+	}); d != nil {
+		t.Fatalf("tx.writeFiles: %v", d)
+	}
+	tx.rollback()
+
+	if _, err := os.Stat(sub); err == nil {
+		t.Errorf("sub dir still present after rollback")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("unexpected stat err: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `osty new` / `osty init` now roll back on a mid-write IO failure (disk full, permission denied, read-only parent) — previously a partial scaffold blocked the next run with `CodeScaffoldDestExists` and forced manual cleanup.
- Introduces `writeTx` in `internal/scaffold` that records the leaf directory and each written file; `Create` / `Init` call `tx.rollback()` best-effort on `writeLayout` failure. Preexisting dirs/files are left alone.
- Adds seven tests in `internal/scaffold/scaffold_test.go`. The package had zero tests before this change.

## What the rollback covers

| Trigger | Before | After |
|---|---|---|
| Disk full on 2nd file of `osty new` | `osty.toml` remains, next run errors on it | outer dir removed, filesystem untouched |
| Read-only parent on `osty new` | `ioErr` returned (outer dir never created) | unchanged |
| Dangling symlink at a file slot in `osty init` | previously-written files remain | files rolled back |
| Mid-write failure inside workspace member dir | root files + partial member files remain | all tx-owned artifacts removed |

## Out of scope

- SIGINT handling — belongs at the CLI supervisor, not scaffold
- Atomic rename semantics — cross-filesystem and dir-over-existing-dir race complexity, marginal value
- `fsync` — scaffold runs at human speed, crash safety isn't a goal

## Test plan

- [x] `go test ./internal/scaffold/...` (7 tests, all pass)
- [x] `go build ./...` (clean)
- [x] Short unrelated failures (`internal/llvmgen`, `internal/backend`, `cmd/osty` AI-repair) verified to be pre-existing on `origin/main` — not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)