### PR TITLE
chore: linguist로 GitHub 언어 통계 보정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Osty source files — linguist detection
+*.osty linguist-language=Swift linguist-detectable=true
+
+# Generated sources — exclude from language stats
+**/generated.go linguist-generated=true
+ERROR_CODES.md linguist-generated=true


### PR DESCRIPTION
## Summary
- `.osty` 파일을 Swift로 매핑 (`linguist-language=Swift linguist-detectable=true`). linguist upstream에 Osty 미등록 상태라 라벨은 띄울 수 없고, 문법 유사도(Optional `?`, struct/enum, 키워드 등) 가장 높은 Swift로 우회 표시
- `**/generated.go` 4개(6만 라인)와 `ERROR_CODES.md`를 `linguist-generated=true`로 통계 제외 → Go 비율이 생성물로 부풀려지던 왜곡 제거

## Why
푸시 후 GitHub 레포 상단 언어 바가 지금은 대부분 Go(대다수가 자동 생성물)로 표시됨. 생성물 제외 + `.osty` detect 활성화로 실제 수작업 비율을 반영.

## Notes for reviewer
- 장기적으로는 [github-linguist/linguist](https://github.com/github-linguist/linguist)에 Osty 엔트리 upstream PR이 필요 (현재 단일 레포라 수용 기준 "수백 개 public repo 사용" 미달). 그 PR이 머지되면 `.gitattributes`의 `Swift`를 `Osty`로 한 글자만 바꾸면 됨
- `testdata/` 아래 `.osty` 스펙 코퍼스(67개)는 **제외하지 않음** — 정품 Osty 예제이므로 통계에 포함
- `generated.go` 글로브 범위 확인: 4개 파일(`internal/selfhost/{,astbridge/}generated.go`, `internal/docgen/{,astbridge/}generated.go`) 모두 `cmd/osty-bootstrap-gen` 생성물

## Test plan
- [ ] PR 머지 후 GitHub 레포 페이지 언어 바에서 Swift가 최상단에 표시되는지 확인
- [ ] Go 비율이 현저히 감소했는지 확인 (생성물 제외 효과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)