### PR TITLE
feat(mir): stage 3.12 — composite map value types + map ABI fix

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -994,14 +994,45 @@ MIR tests isolated from front-end churn.
   That's the MVP shape — a follow-up can pack per-safepoint precise
   roots if the runtime needs them.
 
+- **Stage 3.12 (landed — composite map value types + ABI fix).**
+  `Map<K, V>` intrinsics (`.set` / `.get`) and `IndexProj` on a map
+  base now use the runtime's `(ptr map, K key, ptr value_slot)`
+  contract uniformly:
+
+  - **`map.set(k, v)`** spills `v` into a stack slot
+    (`alloca <VType>` + `store`) and passes the slot pointer as the
+    third arg of `osty_rt_map_insert_<keySuffix>`. Works for
+    primitive, ptr, and composite `V` — the runtime memcpy's
+    `value_size` bytes from the slot into its internal storage.
+  - **`m.get(k)` / `m[k]`** allocates an out-slot sized to
+    `<VType>`, calls
+    `void osty_rt_map_get_or_abort_<keySuffix>(ptr, K, ptr out)`,
+    then loads the result back. The old MIR-emitter signature was
+    `ptr(ptr, K)` — mismatched with the runtime, which returns
+    void and writes into `*out_value`. The rewrite matches the
+    runtime contract exactly and enables composite `V` as a
+    side-effect.
+  - **`IndexProj` on a map base** is now accepted in
+    `checkProjectionsSupported`; the read-projection emit loop
+    dispatches between List and Map via `isListPtrType` /
+    `isMapPtrType` on the running MIR type.
+  - The emit loop now tracks `curT` (MIR type of the running
+    value) alongside `curLLVM` (LLVM type name) so each
+    projection step knows how to interpret its base.
+
+  The old `inttoptr` widening shim in `map.set` is gone — it
+  happened to produce syntactically valid IR for primitive `V` but
+  passed the value bit-pattern as a pointer, which the runtime
+  would have dereferenced into garbage if linked end-to-end.
+
 - **Stage 5 (deferred — still needs parity).** Remove
   `legacyFileFromModule` and the AST-driven emitter. Outstanding
-  parity gaps after Stage 3.11: composite **map** element types,
-  heap-escaping closure envs, and `DerefProj` on anything other
-  than a closure env. Top-level globals crossed off in Stage 3.10;
-  GC roots / safepoints crossed off in Stage 3.11. See the MIR
-  emitter's `checkSupported` and `checkRValueSupported` for the
-  current whitelist.
+  parity gaps after Stage 3.12: heap-escaping closure envs and
+  `DerefProj` on anything other than a closure env. Top-level
+  globals crossed off in Stage 3.10; GC roots / safepoints
+  crossed off in Stage 3.11; composite map values crossed off in
+  Stage 3.12. See the MIR emitter's `checkSupported` and
+  `checkRValueSupported` for the current whitelist.
 
 Each stage is an opportunity to tighten the MIR shape: Stage 3 is
 where we learn which invariants the backend actually needs, Stage 4 is

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -367,20 +367,20 @@ func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx st
 		case *mir.FieldProj, *mir.TupleProj, *mir.VariantProj, *mir.DerefProj:
 			// allowed
 		case *mir.IndexProj:
-			// Accept IndexProj only when the projection base is a
-			// List. Walking the projection chain from scratch would
-			// be overkill for the common case (`local[i]`), so we
-			// check the immediate preceding type: if it's the first
-			// projection, the base type is the local's type; else
-			// it's the previous projection's type.
+			// Accept IndexProj on List and Map bases. Walking the
+			// projection chain from scratch would be overkill for the
+			// common case (`local[i]` / `m[k]`), so we check the
+			// immediate preceding type: if it's the first projection,
+			// the base type is the local's type; else it's the
+			// previous projection's type.
 			var baseT mir.Type
 			if i == 0 {
 				baseT = g.localType(p.Local)
 			} else {
 				baseT = projectionType(p.Projections[i-1])
 			}
-			if !isListPtrType(baseT) {
-				return unsupported("mir-mvp", fmt.Sprintf("%s IndexProj on non-List base %s in %s", ctx, mirTypeString(baseT), fn.Name))
+			if !isListPtrType(baseT) && !isMapPtrType(baseT) {
+				return unsupported("mir-mvp", fmt.Sprintf("%s IndexProj on non-List/Map base %s in %s", ctx, mirTypeString(baseT), fn.Name))
 			}
 		default:
 			return unsupported("mir-mvp", fmt.Sprintf("%s projection %T not yet supported in %s", ctx, proj, fn.Name))
@@ -394,6 +394,17 @@ func (g *mirGen) checkProjectionsSupported(fn *mir.Function, p mir.Place, ctx st
 func isListPtrType(t mir.Type) bool {
 	if nt, ok := t.(*ir.NamedType); ok {
 		return nt.Name == "List" && nt.Builtin
+	}
+	return false
+}
+
+// isMapPtrType reports whether t is a `Map<K, V>` builtin (which
+// lowers to a ptr at the LLVM boundary). Used by the IndexProj read
+// path to dispatch to the map_get_or_abort runtime when the base is
+// a map rather than a list.
+func isMapPtrType(t mir.Type) bool {
+	if nt, ok := t.(*ir.NamedType); ok {
+		return nt.Name == "Map" && nt.Builtin
 	}
 	return false
 }
@@ -1502,9 +1513,55 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
+		// Map get uses a caller-supplied out-slot: the runtime copies
+		// value_size bytes from its internal storage into the slot.
+		// That shape matches the real runtime
+		// (`void(ptr, K, ptr out)`) and works uniformly for scalar and
+		// composite value types — including `Map<String, Point>`.
+		vLLVM := g.llvmType(valT)
+		outSlot := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(outSlot)
+		g.fnBuf.WriteString(" = alloca ")
+		g.fnBuf.WriteString(vLLVM)
+		g.fnBuf.WriteByte('\n')
 		sym := "osty_rt_map_get_or_abort_" + mapSetKeySuffix(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, "+keyLLVM+")")
-		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + mapReg, keyLLVM + " " + kReg})
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
+		g.fnBuf.WriteString("  call void @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(mapReg)
+		g.fnBuf.WriteString(", ")
+		g.fnBuf.WriteString(keyLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(kReg)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(outSlot)
+		g.fnBuf.WriteString(")\n")
+		if i.Dest == nil {
+			return nil
+		}
+		// Load from the out-slot and store into the destination local.
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return fmt.Errorf("mir-mvp: map_get into unknown local %d", i.Dest.Local)
+		}
+		loaded := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(loaded)
+		g.fnBuf.WriteString(" = load ")
+		g.fnBuf.WriteString(vLLVM)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(outSlot)
+		g.fnBuf.WriteByte('\n')
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(g.llvmType(destLoc.Type))
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(loaded)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+		g.fnBuf.WriteByte('\n')
+		return nil
 	case mir.IntrinsicMapSet:
 		if len(i.Args) != 3 {
 			return unsupported("mir-mvp", "map_set arity")
@@ -1519,20 +1576,25 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		vLLVM := g.llvmType(vOp.Type())
-		// Map insert expects a ptr-sized value; widen if needed.
-		if vLLVM != "ptr" {
-			widened, err := g.toI64Slot(vReg, vOp.Type())
-			if err != nil {
-				return err
-			}
-			ptr := g.fresh()
-			g.fnBuf.WriteString("  ")
-			g.fnBuf.WriteString(ptr)
-			g.fnBuf.WriteString(" = inttoptr i64 ")
-			g.fnBuf.WriteString(widened)
-			g.fnBuf.WriteString(" to ptr\n")
-			vReg = ptr
-		}
+		// Spill the value into a stack slot so the runtime can memcpy
+		// value_size bytes from it. This works uniformly for primitive
+		// scalars, ptr-sized handles, and composite aggregates — and
+		// replaces the old inttoptr widening shim, which was semantically
+		// wrong for primitives (it passed the value bitpattern AS a
+		// pointer) and outright impossible for structs / tuples.
+		valSlot := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(valSlot)
+		g.fnBuf.WriteString(" = alloca ")
+		g.fnBuf.WriteString(vLLVM)
+		g.fnBuf.WriteByte('\n')
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(vLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(vReg)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(valSlot)
+		g.fnBuf.WriteByte('\n')
 		sym := "osty_rt_map_insert_" + mapSetKeySuffix(keyLLVM, keyString)
 		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
 		g.fnBuf.WriteString("  call void @")
@@ -1544,7 +1606,7 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		g.fnBuf.WriteByte(' ')
 		g.fnBuf.WriteString(kReg)
 		g.fnBuf.WriteString(", ptr ")
-		g.fnBuf.WriteString(vReg)
+		g.fnBuf.WriteString(valSlot)
 		g.fnBuf.WriteString(")\n")
 		return nil
 	case mir.IntrinsicMapRemove:
@@ -3258,6 +3320,11 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 
 	curLLVM := baseLLVM
 	curReg := aggReg
+	// curT tracks the MIR type of the running value so IndexProj can
+	// tell whether its base is a List (list_get) or a Map
+	// (map_get_or_abort). Each projection updates curT to the output
+	// of that step.
+	curT := baseT
 	for i, proj := range place.Projections {
 		// DerefProj rebinds the running value to the declared
 		// aggregate loaded from the current ptr. Used by the MIR
@@ -3281,15 +3348,13 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 			g.fnBuf.WriteByte('\n')
 			curReg = loaded
 			curLLVM = innerLLVM
+			curT = innerT
 			_ = i
 			continue
 		}
-		// IndexProj on a List base routes through the runtime — the
-		// LLVM view of a List is opaque `ptr`, so we can't use
-		// `extractvalue`. Emit `osty_rt_list_get_<suffix>(list, idx)`
-		// for typed elements and hand the result back as the new
-		// running value (the projection chain can keep going from
-		// there; e.g. `xs[i].name`).
+		// IndexProj on a List or Map base routes through the runtime —
+		// the LLVM view of both is opaque `ptr`, so we can't use
+		// `extractvalue`. Dispatch on the running MIR type.
 		if ip, ok := proj.(*mir.IndexProj); ok {
 			elemT := projectionType(proj)
 			if elemT == nil {
@@ -3300,6 +3365,53 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 				}
 			}
 			elemLLVM := g.llvmType(elemT)
+			// Map IndexProj: spill an out-slot sized to V, call
+			// map_get_or_abort_<keySuffix>, load back. Mirrors the
+			// IntrinsicMapGet emit path so `m[k]` and `m.get(k)`
+			// share a single ABI.
+			if isMapPtrType(curT) {
+				keyT, _ := mapKeyValueTypes(curT)
+				if keyT == nil {
+					return "", unsupported("mir-mvp", "map IndexProj without key type")
+				}
+				keyLLVM := g.llvmType(keyT)
+				keyString := isStringLLVMType(keyT)
+				kReg, err := g.evalOperand(ip.Index, keyT)
+				if err != nil {
+					return "", err
+				}
+				outSlot := g.fresh()
+				g.fnBuf.WriteString("  ")
+				g.fnBuf.WriteString(outSlot)
+				g.fnBuf.WriteString(" = alloca ")
+				g.fnBuf.WriteString(elemLLVM)
+				g.fnBuf.WriteByte('\n')
+				sym := "osty_rt_map_get_or_abort_" + mapSetKeySuffix(keyLLVM, keyString)
+				g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
+				g.fnBuf.WriteString("  call void @")
+				g.fnBuf.WriteString(sym)
+				g.fnBuf.WriteString("(ptr ")
+				g.fnBuf.WriteString(curReg)
+				g.fnBuf.WriteString(", ")
+				g.fnBuf.WriteString(keyLLVM)
+				g.fnBuf.WriteByte(' ')
+				g.fnBuf.WriteString(kReg)
+				g.fnBuf.WriteString(", ptr ")
+				g.fnBuf.WriteString(outSlot)
+				g.fnBuf.WriteString(")\n")
+				loaded := g.fresh()
+				g.fnBuf.WriteString("  ")
+				g.fnBuf.WriteString(loaded)
+				g.fnBuf.WriteString(" = load ")
+				g.fnBuf.WriteString(elemLLVM)
+				g.fnBuf.WriteString(", ptr ")
+				g.fnBuf.WriteString(outSlot)
+				g.fnBuf.WriteByte('\n')
+				curReg = loaded
+				curLLVM = elemLLVM
+				curT = elemT
+				continue
+			}
 			idxOp := ip.Index
 			idxVal, err := g.evalOperand(idxOp, mir.TInt)
 			if err != nil {
@@ -3322,6 +3434,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 				g.fnBuf.WriteString(")\n")
 				curReg = next
 				curLLVM = elemLLVM
+				curT = elemT
 				continue
 			}
 			// Composite element — use bytes_v1 out-pointer ABI.
@@ -3355,6 +3468,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 			g.fnBuf.WriteByte('\n')
 			curReg = loaded
 			curLLVM = elemLLVM
+			curT = elemT
 			continue
 		}
 		idx, ok := projectionIndex(proj)
@@ -3388,6 +3502,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 			}
 			curReg = narrowed
 			curLLVM = g.llvmType(elemT)
+			curT = elemT
 			continue
 		}
 		elemLLVM := g.llvmType(elemT)
@@ -3403,6 +3518,7 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 		g.fnBuf.WriteByte('\n')
 		curLLVM = elemLLVM
 		curReg = next
+		curT = elemT
 	}
 	return curReg, nil
 }

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -886,6 +886,180 @@ func TestGenerateFromMIRMapGetAndSet(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRMapStructValueSet — Map<String, Point> insert.
+// The composite value is spilled into a stack slot sized to %Point,
+// then passed by pointer to the runtime. This is the same shape the
+// primitive-value path uses after the Stage 3.11-follow-up rewrite;
+// composite values are what made the rewrite necessary.
+func TestGenerateFromMIRMapStructValueSet(t *testing.T) {
+	// struct Point { x: Int, y: Int }
+	// fn store(m: Map<String, Point>, k: String, p: Point) { m.set(k, p) }
+	pointT := &ir.NamedType{Name: "Point"}
+	pointDecl := &ir.StructDecl{
+		Name: "Point",
+		Fields: []*ir.Field{
+			{Name: "x", Type: ir.TInt, Exported: true},
+			{Name: "y", Type: ir.TInt, Exported: true},
+		},
+	}
+	mapT := &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, pointT}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "store",
+		Return: ir.TUnit,
+		Params: []*ir.Param{
+			{Name: "m", Type: mapT},
+			{Name: "k", Type: ir.TString},
+			{Name: "p", Type: pointT},
+		},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.ExprStmt{X: &ir.MethodCall{
+					Receiver: &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
+					Name:     "set",
+					Args: []ir.Arg{
+						{Value: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString}},
+						{Value: &ir.Ident{Name: "p", Kind: ir.IdentParam, T: pointT}},
+					},
+					T: ir.TUnit,
+				}},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/map_struct_set.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		// Struct layout for Point.
+		"%Point = type { i64, i64 }",
+		// Insert signature stays `(ptr, key, ptr)`.
+		"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
+		// Value is spilled into a %Point slot before the call.
+		"alloca %Point",
+		"store %Point ",
+		// The runtime gets the composite by pointer.
+		"call void @osty_rt_map_insert_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Order check: the alloca and store must precede the map_insert
+	// call — otherwise the runtime would memcpy from undef memory.
+	allocaIdx := strings.Index(got, "alloca %Point")
+	storeIdx := strings.Index(got, "store %Point ")
+	callIdx := strings.Index(got, "call void @osty_rt_map_insert_string(")
+	if allocaIdx < 0 || storeIdx < 0 || callIdx < 0 {
+		t.Fatalf("ordering markers missing in:\n%s", got)
+	}
+	if !(allocaIdx < storeIdx && storeIdx < callIdx) {
+		t.Fatalf("expected alloca → store → call ordering in:\n%s", got)
+	}
+}
+
+// TestGenerateFromMIRMapStructValueGet — Map<String, Point> read.
+// The out-slot is sized to %Point; the runtime writes into it; we
+// load and store into the destination local. Validates the rewritten
+// `void(ptr, K, ptr)` signature and the post-load copy to dest.
+func TestGenerateFromMIRMapStructValueGet(t *testing.T) {
+	// struct Point { x: Int, y: Int }
+	// fn lookup(m: Map<String, Point>, k: String) -> Point { m[k] }
+	pointT := &ir.NamedType{Name: "Point"}
+	pointDecl := &ir.StructDecl{
+		Name: "Point",
+		Fields: []*ir.Field{
+			{Name: "x", Type: ir.TInt, Exported: true},
+			{Name: "y", Type: ir.TInt, Exported: true},
+		},
+	}
+	mapT := &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, pointT}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "lookup",
+		Return: pointT,
+		Params: []*ir.Param{
+			{Name: "m", Type: mapT},
+			{Name: "k", Type: ir.TString},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X:     &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
+				Index: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString},
+				T:     pointT,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{pointDecl, fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/map_struct_get.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Point = type { i64, i64 }",
+		// Get now has the corrected `void(ptr, K, ptr)` signature
+		// matching the real runtime.
+		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
+		// Out-slot sized to %Point.
+		"alloca %Point",
+		// The call takes the out-slot as its third argument.
+		"call void @osty_rt_map_get_or_abort_string(",
+		// Load from the out-slot.
+		"load %Point, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRMapPrimitiveGet — primitive-value map_get after
+// the rewrite. Regression guard against reverting to the old
+// ptr-returning signature.
+func TestGenerateFromMIRMapPrimitiveGet(t *testing.T) {
+	// fn lookup(m: Map<String, Int>, k: String) -> Int { m[k] }
+	mapT := &ir.NamedType{Name: "Map", Args: []ir.Type{ir.TString, ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "lookup",
+		Return: ir.TInt,
+		Params: []*ir.Param{
+			{Name: "m", Type: mapT},
+			{Name: "k", Type: ir.TString},
+		},
+		Body: &ir.Block{
+			Result: &ir.IndexExpr{
+				X:     &ir.Ident{Name: "m", Kind: ir.IdentParam, T: mapT},
+				Index: &ir.Ident{Name: "k", Kind: ir.IdentParam, T: ir.TString},
+				T:     ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/map_prim_get.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
+		"call void @osty_rt_map_get_or_abort_string(",
+		"alloca i64",
+		"load i64, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	// The old ptr-returning signature must not leak back in.
+	if strings.Contains(got, "declare ptr @osty_rt_map_get_or_abort_") {
+		t.Fatalf("regressed to ptr-returning get signature:\n%s", got)
+	}
+}
+
 func TestGenerateFromMIRSetContains(t *testing.T) {
 	setT := &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TInt}, Builtin: true}
 	fn := &ir.FnDecl{


### PR DESCRIPTION
## Summary

- Rewrites `Map<K, V>` intrinsics and `IndexProj` on a map base to use the runtime's `(ptr map, K key, ptr value_slot)` contract uniformly.
- **`map.set(k, v)`** now spills `v` into an `alloca <VType>` stack slot and passes the slot pointer as the third argument of `osty_rt_map_insert_<keySuffix>`. Works for primitive, ptr, and composite `V` uniformly — the runtime memcpy's `value_size` bytes.
- **`m.get(k)` / `m[k]`** allocates an out-slot sized to `V`, calls `void osty_rt_map_get_or_abort_<keySuffix>(ptr, K, ptr out)`, then loads the result back. The old MIR-emitter signature was `ptr(ptr, K)` — **mismatched with the runtime**, which returns void and writes into `*out_value`. This rewrite matches the runtime contract exactly.
- **`IndexProj` on a map base** is now accepted in `checkProjectionsSupported`; the read-projection emit loop dispatches between List and Map via `isListPtrType` / `isMapPtrType` on a new `curT` tracker that runs alongside `curLLVM`.
- Removes the old `inttoptr` widening shim in `map.set` — it produced syntactically valid IR for primitive `V` but passed the value bit-pattern as a pointer, which the runtime would have dereferenced into garbage if linked end-to-end.

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestGenerateFromMIRMap -v` — four map tests pass:
  - existing `TestGenerateFromMIRMapGetAndSet` (primitive set, unchanged assertion)
  - new `TestGenerateFromMIRMapStructValueSet` — `Map<String, Point>` set via `.set`
  - new `TestGenerateFromMIRMapStructValueGet` — same pair read via `m[k]`
  - new `TestGenerateFromMIRMapPrimitiveGet` — regression guard on the rewritten get signature
- [x] Full MIR suite still green (`go test ./internal/llvmgen/ -run 'TestGenerateFromMIR|TestMIR'`).
- [ ] Runtime parity — once the managed runtime links end-to-end, composite-valued maps can replace the legacy AST emitter's identical path.

After this lands, remaining Stage 5 gaps are heap-escaping closure envs and `DerefProj` beyond the closure-env shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)