### PR TITLE
feat(selfhost): package-manager flag policy → toolchain/pkg_policy.osty

### DIFF
--- a/cmd/osty/pkg_helpers.go
+++ b/cmd/osty/pkg_helpers.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lockfile"
 	"github.com/osty/osty/internal/manifest"
 	"github.com/osty/osty/internal/pkgmgr"
+	"github.com/osty/osty/internal/runner"
 )
 
 // loadManifestWithDiag is the shared manifest entry point used by
@@ -66,32 +67,19 @@ func loadManifestWithDiag(start string, flags cliFlags) (m *manifest.Manifest, r
 	return m, root, false
 }
 
-// resolveOpts bundles the toggles the package-manager flow accepts.
-// Threaded through every CLI subcommand that touches the resolver
-// (build, run, test, fetch, publish, add, update) so behavior stays
-// consistent.
-type resolveOpts struct {
-	// Offline forbids any network or fresh-fetch work. Cached
-	// downloads still satisfy registry deps.
-	Offline bool
-	// Locked refuses to *write* a different lockfile than the one
-	// already on disk. The resolve still runs; if the result would
-	// alter osty.lock, the caller errors out instead of overwriting.
-	// Mirrors `cargo --locked`.
-	Locked bool
-	// Frozen implies Locked AND Offline AND additionally requires
-	// that osty.lock already exist. Mirrors `cargo --frozen`.
-	Frozen bool
-}
+// resolveOpts bundles the --offline / --locked / --frozen toggles
+// threaded through every subcommand that touches the resolver
+// (build, run, test, fetch, publish, add, update). Field semantics
+// mirror cargo's flags of the same name, and the expansion rule
+// (--frozen implies --locked --offline) lives in
+// toolchain/pkg_policy.osty.
+type resolveOpts = runner.ResolveOpts
 
 func resolveAndVendorEnvOpts(m *manifest.Manifest, root string, opts resolveOpts) (*pkgmgr.Graph, *pkgmgr.Env, error) {
 	if m == nil {
 		return nil, nil, fmt.Errorf("nil manifest")
 	}
-	if opts.Frozen {
-		opts.Locked = true
-		opts.Offline = true
-	}
+	opts = runner.ExpandFrozenFlags(opts)
 	env, err := pkgmgr.DefaultEnv(root)
 	if err != nil {
 		return nil, nil, err
@@ -104,7 +92,7 @@ func resolveAndVendorEnvOpts(m *manifest.Manifest, root string, opts resolveOpts
 	// fresh checkout that forgot to commit one.
 	priorLock, _ := lockfile.Read(root)
 	if opts.Frozen && priorLock == nil {
-		return nil, env, fmt.Errorf("--frozen requires an existing %s; run `osty update` first", lockfile.LockFile)
+		return nil, env, errors.New(runner.FrozenMissingLockfileMessage(lockfile.LockFile))
 	}
 	if len(m.Dependencies) == 0 && len(m.DevDependencies) == 0 {
 		return &pkgmgr.Graph{Root: m}, env, nil
@@ -115,14 +103,13 @@ func resolveAndVendorEnvOpts(m *manifest.Manifest, root string, opts resolveOpts
 	}
 	newLock := pkgmgr.LockFromGraph(graph)
 	if opts.Locked {
-		if changes := pkgmgr.DiffLock(priorLock, newLock); len(changes) > 0 {
-			var b strings.Builder
-			fmt.Fprintf(&b, "--locked: %s would change:\n", lockfile.LockFile)
-			for _, c := range changes {
-				fmt.Fprintf(&b, "  %s\n", c.String())
-			}
-			fmt.Fprintf(&b, "rerun without --locked to update the lockfile.")
-			return graph, env, fmt.Errorf("%s", b.String())
+		changes := pkgmgr.DiffLock(priorLock, newLock)
+		changeStrs := make([]string, 0, len(changes))
+		for _, c := range changes {
+			changeStrs = append(changeStrs, c.String())
+		}
+		if msg := runner.LockedDiffMessage(lockfile.LockFile, changeStrs); msg != "" {
+			return graph, env, errors.New(msg)
 		}
 	}
 	if err := pkgmgr.Vendor(graph, env); err != nil {

--- a/internal/runner/drift_test.go
+++ b/internal/runner/drift_test.go
@@ -42,6 +42,7 @@ func TestPolicySnapshotParityWithOsty(t *testing.T) {
 		"diag_policy.osty",
 		"test_runner.osty",
 		"scaffold_policy.osty",
+		"pkg_policy.osty",
 	}
 
 	// The Go side adapts names to Go conventions; RunnerDiag

--- a/internal/runner/pkg_policy.go
+++ b/internal/runner/pkg_policy.go
@@ -1,0 +1,63 @@
+// pkg_policy.go is the Go snapshot of toolchain/pkg_policy.osty.
+// Osty is the source of truth; the drift test in this package
+// enforces parity.
+package runner
+
+import "strings"
+
+// ResolveOpts mirrors toolchain/pkg_policy.osty's ResolveOpts. The
+// three flags are carried through every subcommand that touches
+// the resolver (build/run/test/fetch/publish/add/update).
+//
+// Osty: toolchain/pkg_policy.osty:15
+type ResolveOpts struct {
+	Offline bool
+	Locked  bool
+	Frozen  bool
+}
+
+// ExpandFrozenFlags applies `--frozen`'s implication that it is a
+// strict superset of locked+offline, so downstream code only has
+// to check Offline/Locked and the frozen semantics are already
+// baked in.
+//
+// Osty: toolchain/pkg_policy.osty:22
+func ExpandFrozenFlags(opts ResolveOpts) ResolveOpts {
+	if opts.Frozen {
+		return ResolveOpts{Offline: true, Locked: true, Frozen: true}
+	}
+	return opts
+}
+
+// FrozenMissingLockfileMessage builds the error string for the
+// "--frozen but no lockfile present" rejection. Caller passes in
+// the lockfile basename so lockfile.LockFile stays a single
+// source of truth on the Go side.
+//
+// Osty: toolchain/pkg_policy.osty:42
+func FrozenMissingLockfileMessage(lockfileName string) string {
+	return "--frozen requires an existing " + lockfileName + "; run `osty update` first"
+}
+
+// LockedDiffMessage renders the "--locked: NAME would change:"
+// report. Empty string means no changes (host proceeds as
+// normal). `changes` is each change pre-stringified via
+// pkgmgr.Change.String().
+//
+// Osty: toolchain/pkg_policy.osty:51
+func LockedDiffMessage(lockfileName string, changes []string) string {
+	if len(changes) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("--locked: ")
+	b.WriteString(lockfileName)
+	b.WriteString(" would change:\n")
+	for _, c := range changes {
+		b.WriteString("  ")
+		b.WriteString(c)
+		b.WriteString("\n")
+	}
+	b.WriteString("rerun without --locked to update the lockfile.")
+	return b.String()
+}

--- a/internal/runner/pkg_policy_test.go
+++ b/internal/runner/pkg_policy_test.go
@@ -1,0 +1,66 @@
+package runner
+
+import "testing"
+
+func TestExpandFrozenFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ResolveOpts
+		want ResolveOpts
+	}{
+		{
+			name: "frozen-promotes-to-all-three",
+			in:   ResolveOpts{Frozen: true},
+			want: ResolveOpts{Offline: true, Locked: true, Frozen: true},
+		},
+		{
+			name: "frozen-already-with-offline-locked",
+			in:   ResolveOpts{Offline: true, Locked: true, Frozen: true},
+			want: ResolveOpts{Offline: true, Locked: true, Frozen: true},
+		},
+		{
+			name: "non-frozen-preserved",
+			in:   ResolveOpts{Offline: false, Locked: true, Frozen: false},
+			want: ResolveOpts{Offline: false, Locked: true, Frozen: false},
+		},
+		{
+			name: "all-off-preserved",
+			in:   ResolveOpts{},
+			want: ResolveOpts{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExpandFrozenFlags(c.in)
+			if got != c.want {
+				t.Errorf("ExpandFrozenFlags(%+v) = %+v, want %+v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFrozenMissingLockfileMessage(t *testing.T) {
+	got := FrozenMissingLockfileMessage("osty.lock")
+	want := "--frozen requires an existing osty.lock; run `osty update` first"
+	if got != want {
+		t.Errorf("FrozenMissingLockfileMessage = %q, want %q", got, want)
+	}
+}
+
+func TestLockedDiffMessageEmptyChanges(t *testing.T) {
+	if got := LockedDiffMessage("osty.lock", nil); got != "" {
+		t.Errorf("LockedDiffMessage(nil) = %q, want empty", got)
+	}
+	if got := LockedDiffMessage("osty.lock", []string{}); got != "" {
+		t.Errorf("LockedDiffMessage([]) = %q, want empty", got)
+	}
+}
+
+func TestLockedDiffMessageFormatsChanges(t *testing.T) {
+	changes := []string{"+ foo 1.0.0", "- bar 2.1.3", "~ baz 0.9 -> 1.0"}
+	got := LockedDiffMessage("osty.lock", changes)
+	want := "--locked: osty.lock would change:\n  + foo 1.0.0\n  - bar 2.1.3\n  ~ baz 0.9 -> 1.0\nrerun without --locked to update the lockfile."
+	if got != want {
+		t.Errorf("LockedDiffMessage =\n%q\nwant\n%q", got, want)
+	}
+}

--- a/toolchain/pkg_policy.osty
+++ b/toolchain/pkg_policy.osty
@@ -1,0 +1,59 @@
+use std.strings as strings
+
+/// Pure policy for `osty`'s package-manager CLI flags (--offline /
+/// --locked / --frozen) and the human-readable error messages they
+/// produce. Host glue (`cmd/osty/pkg_helpers.go`,
+/// `internal/lockfile`, `internal/pkgmgr`) owns file I/O and the
+/// actual resolve/vendor machinery; this module decides how the
+/// three flags combine and what text the CLI surfaces on rejection.
+///
+/// Mirrored by `internal/runner/pkg_policy.go`.
+
+pub struct ResolveOpts {
+    pub offline: Bool,
+    pub locked: Bool,
+    pub frozen: Bool,
+}
+
+/// expandFrozenFlags applies `--frozen`'s implications. Frozen is
+/// a strict superset of locked+offline: "use exactly the lockfile
+/// on disk, and don't reach out for anything". The CLI resolves
+/// each subcommand's raw flag state through this expansion before
+/// looking at the individual toggles, so downstream code only has
+/// to check offline/locked and the frozen semantics are already
+/// baked in.
+pub fn expandFrozenFlags(opts: ResolveOpts) -> ResolveOpts {
+    if opts.frozen {
+        return ResolveOpts { offline: true, locked: true, frozen: true }
+    }
+    opts
+}
+
+/// frozenMissingLockfileMessage builds the error string printed
+/// when `--frozen` was requested but no lockfile exists. `name` is
+/// the lockfile basename (e.g. "osty.lock") — passed in so the
+/// constant stays a single source of truth in Go (lockfile.LockFile).
+pub fn frozenMissingLockfileMessage(lockfileName: String) -> String {
+    "--frozen requires an existing " + lockfileName + "; run `osty update` first"
+}
+
+/// lockedDiffMessage assembles the `--locked: NAME would change:`
+/// report. Returns None when the change list is empty (the host
+/// proceeds as normal); returns Some(...) when the host should
+/// reject with the rendered message.
+///
+/// `changes` is each change's pre-stringified form (pkgmgr.Change.String()).
+pub fn lockedDiffMessage(lockfileName: String, changes: List<String>) -> String? {
+    let mut lines: List<String> = []
+    lines.push("--locked: " + lockfileName + " would change:")
+    let mut any = false
+    for c in changes {
+        lines.push("  " + c)
+        any = true
+    }
+    if !(any) {
+        return None
+    }
+    lines.push("rerun without --locked to update the lockfile.")
+    Some(strings.join(lines, "\n"))
+}

--- a/toolchain/pkg_policy_test.osty
+++ b/toolchain/pkg_policy_test.osty
@@ -1,0 +1,43 @@
+use std.testing
+
+fn testExpandFrozenFlagsPromotesOfflineAndLocked() {
+    let expanded = expandFrozenFlags(ResolveOpts { offline: false, locked: false, frozen: true })
+    testing.assert(expanded.offline)
+    testing.assert(expanded.locked)
+    testing.assert(expanded.frozen)
+}
+
+fn testExpandFrozenFlagsLeavesNonFrozenUntouched() {
+    let opts = ResolveOpts { offline: false, locked: true, frozen: false }
+    let expanded = expandFrozenFlags(opts)
+    testing.assert(!(expanded.offline))
+    testing.assert(expanded.locked)
+    testing.assert(!(expanded.frozen))
+}
+
+fn testFrozenMissingLockfileMessageFormat() {
+    testing.assertEq(
+        frozenMissingLockfileMessage("osty.lock"),
+        "--frozen requires an existing osty.lock; run `osty update` first",
+    )
+}
+
+fn testLockedDiffMessageEmptyChangesReturnsNone() {
+    match lockedDiffMessage("osty.lock", []) {
+        Some(_) -> testing.assert(false),
+        None -> testing.assert(true),
+    }
+}
+
+fn testLockedDiffMessageFormatsChanges() {
+    let changes = ["+ foo 1.0.0", "- bar 2.1.3", "~ baz 0.9 -> 1.0"]
+    match lockedDiffMessage("osty.lock", changes) {
+        Some(msg) -> {
+            testing.assertEq(
+                msg,
+                "--locked: osty.lock would change:\n  + foo 1.0.0\n  - bar 2.1.3\n  ~ baz 0.9 -> 1.0\nrerun without --locked to update the lockfile.",
+            )
+        },
+        None -> testing.assert(false),
+    }
+}


### PR DESCRIPTION
## Summary

Fifth round of CLI-policy migration (after #267, #271, #272). Pulls `--offline` / `--locked` / `--frozen` flag semantics and the two user-facing rejection messages out of `cmd/osty/pkg_helpers.go` into pure Osty.

## What moved

- **`ResolveOpts { offline, locked, frozen }`** — the flag bundle threaded through every resolver-touching subcommand (build, run, test, fetch, publish, add, update). `cmd/osty`'s local `resolveOpts` is now a type alias for `runner.ResolveOpts`, so the three call sites and the function signature stay byte-identical.
- **`expandFrozenFlags(opts)`** — `--frozen` is a strict superset of locked + offline. Downstream code only checks offline/locked and the frozen rule is baked in by a single expansion step.
- **`frozenMissingLockfileMessage(name)`** — the "--frozen requires an existing osty.lock; run `osty update` first" string.
- **`lockedDiffMessage(name, changes) -> String?`** — the multi-line `--locked: NAME would change:\n  <change>\n  ...\nrerun without --locked...` report. None on empty change list; Some(formatted) when the host should reject.

## Call site

`cmd/osty/pkg_helpers.go:resolveAndVendorEnvOpts`:
- Runs `runner.ExpandFrozenFlags` before any flag check; `resolveOpts` now aliases `runner.ResolveOpts` so the conversion is literally a no-op.
- Builds the frozen-missing-lockfile error through `runner.FrozenMissingLockfileMessage`.
- Stringifies `pkgmgr.DiffLock` output into `[]string` and hands it to `runner.LockedDiffMessage` for rendering. The `strings` import drops out of pkg_helpers.go.

## Self-review fixes applied

While running `/simplify` on the initial draft I caught:
- Unnecessary narration comments in the Osty source and Go snapshot — dropped.
- Osty-side `lockedDiffMessage` was using `out = out + ...` inside a loop (O(n²) concatenation on linear-string backends). Rewrote to collect lines into a `List<String>` and call `strings.join(lines, "\n")` — O(n).
- Double-wrapped `resolveOpts` struct with the same-shape `runner.ResolveOpts`. Collapsed into a type alias.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `internal/runner` tests pass (80+)
- [x] Error message bytes preserved (verified in unit tests against the literal strings `--locked: osty.lock would change:\n  ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)