### PR TITLE
fix: stable-alias normalizer preserves `def`/`func`/etc. as identifiers

### DIFF
--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -129,21 +129,19 @@ Two equally-valid fixes:
    primitives (`stringAt`, char-index loops, etc). Faster, but doesn't
    help any of the other files that will eventually want `std.strings`.
 
-### E0001 — parser trips on `def: Expr` parameter
+### E0001 — parser trips on `def: Expr` parameter — **fixed**
 
-```
-fn FieldNode(pos: Pos, end: Pos, isPub: Bool, name: String, typ: Type, def: Expr, …)
-fn ParamNode(pos: Pos, end: Pos, name: String, pat: Pattern, typ: Type, def: Expr)
-```
+Root cause was the stable-alias pre-pass in `internal/parser/normalize.go`:
+it rewrote every `IDENT` token matching `def` / `func` / `function` /
+`import` / `while` to its canonical keyword form, regardless of position.
+`fn FieldNode(…, def: Expr, …)` and `fn ParamNode(…, def: Expr)` therefore
+had `def` silently rewritten to `fn`, producing four E0001 diagnostics at
+`ast_lower.osty:91` and `:93`.
 
-Both signatures live inside a `use runtime.golegacy.astbridge as astbridge {
-... }` FFI block (lines 1 – 254 of `ast_lower.osty`). The parser reports
-"expected IDENT, got fn" at the column of `def`, which suggests `def` is
-being handled as a reserved keyword in this position even though the
-grammar spec (`OSTY_GRAMMAR_v0.4.md`) doesn't list it. Worth double-checking
-the FFI-block param parser specifically — the regular fn-decl param parser
-accepts `def` fine (see `toolchain/ir.osty` and `ast_lower.osty:1043` which
-use `let mut def = …`).
+Fix: in `normalizeStableAliases`, skip the rewrite when the identifier is
+immediately followed by `:` (parameter / struct field / keyword-argument
+slot). Regression test in
+`internal/parser/parser_features_test.go::TestParseStableAliasesPreservedAsIdentifiers`.
 
 ### E0700 — 1700 checker errors, 97.6% accept rate
 
@@ -183,8 +181,9 @@ runnable binary" is dominated by Layer 1 + Layer 2, not Layer 3.
    one file say the demand is real) or rewrite `ast_lower.osty` against
    existing primitives. Unblocks `ast_lower.osty`.
 
-4. **Investigate parser sensitivity to `def`** inside FFI `use` blocks.
-   One call site, low effort, cleans up E0001/E0010.
+4. ~~**Investigate parser sensitivity to `def`** inside FFI `use` blocks.~~
+   Done — stable-alias pre-pass now skips rewrites when the identifier
+   sits in `name : type` position.
 
 5. **Re-run `osty check toolchain`** — expect the 1700 native-checker
    summary to collapse with most cascades gone. Remaining tail becomes a

--- a/internal/parser/normalize.go
+++ b/internal/parser/normalize.go
@@ -65,12 +65,18 @@ func normalizeStableAliases(src []byte) ([]byte, []ProvenanceStep) {
 	toks, _, _ := selfhost.Lex(src)
 	var edits []stableAliasEdit
 
-	for _, tok := range toks {
+	for i, tok := range toks {
 		if tok.Kind != token.IDENT {
 			continue
 		}
 		spec, ok := stableAliasSpecs[tok.Value]
 		if !ok {
+			continue
+		}
+		// Preserve the identifier when it sits in `name : type` position
+		// (parameter, struct field, keyword argument, struct-literal field,
+		// map entry). Keyword aliases never legitimately appear there.
+		if i+1 < len(toks) && toks[i+1].Kind == token.COLON {
 			continue
 		}
 		replacement := aliasReplacement(spec.alias, spec.canonical)

--- a/internal/parser/parser_features_test.go
+++ b/internal/parser/parser_features_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
 )
 
 func TestParseSlashSeparatedUsePath(t *testing.T) {
@@ -152,6 +153,27 @@ func TestParseAcceptsStableAliases(t *testing.T) {
 	}
 	if result.Provenance == nil || len(result.Provenance.Aliases) != 3 {
 		t.Fatalf("alias provenance = %#v, want 3 stable alias entries", result.Provenance)
+	}
+}
+
+func TestParseStableAliasesPreservedAsIdentifiers(t *testing.T) {
+	// Identifiers named after stable aliases (def, func, function, import, while)
+	// must survive when they occupy `name : type` slots — parameters, struct
+	// fields, keyword arguments. Otherwise FFI signatures that borrow host
+	// names (e.g. astbridge `def: Expr` in ParamNode/FieldNode) become E0001.
+	src := []byte(`use host.bridge as bridge {
+    fn FieldNode(name: String, def: Int) -> Int
+    fn ParamNode(name: String, def: Int) -> Int
+}
+`)
+	result := ParseDetailed(src)
+	for _, d := range result.Diagnostics {
+		if d.Severity == diag.Error {
+			t.Fatalf("unexpected parse error: %s — %s", d.Code, d.Message)
+		}
+	}
+	if result.Provenance != nil && len(result.Provenance.Aliases) != 0 {
+		t.Fatalf("alias provenance = %#v, want no rewrites for param names", result.Provenance.Aliases)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Parser pre-pass `normalizeStableAliases` was unconditionally rewriting every IDENT matching `def`/`func`/`function`/`import`/`while` to its canonical keyword form. FFI signatures like `fn FieldNode(…, def: Expr, …)` in [toolchain/ast_lower.osty:91](toolchain/ast_lower.osty#L91) and `:93` therefore had `def` silently rewritten to `fn`, producing four E0001 "expected IDENT, got fn" diagnostics.
- Skip the rewrite when the identifier is immediately followed by `:` — parameter, struct field, keyword-argument, map-entry, or struct-literal-field slot. Keyword aliases never legitimately appear there.
- Regression test `TestParseStableAliasesPreservedAsIdentifiers` in [internal/parser/parser_features_test.go](internal/parser/parser_features_test.go) pins the mechanism (no provenance alias entries recorded) rather than just the symptom.

## Why

The normalizer runs on every parsed source. It's a textual byte-rewrite pre-pass, so it needs minimal context awareness to avoid clobbering identifiers that happen to share a spelling with accepted alias keywords. `name : type` position is the one spot in v0.4 grammar where `fn`/`use`/`for`/`import` never legitimately appear, so it's a safe contextual guard.

Also marks the corresponding TODO in [docs/toolchain_llvm_status.md](docs/toolchain_llvm_status.md) as done.

## Test plan

- [x] `go test ./internal/parser/...` — all passing
- [x] `go test ./internal/lexer/... ./internal/resolve/...` — no regressions
- [x] `go run ./cmd/osty check toolchain/ast_lower.osty` — the 4 E0001 errors at lines 91, 93 are gone (downstream E0500 checker errors are a separate issue tracked in docs/toolchain_llvm_status.md)
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)