### PR TITLE
refactor(toolchain): drop unreachable string-prefix pattern dispatch

### DIFF
--- a/toolchain/ast_lower.osty
+++ b/toolchain/ast_lower.osty
@@ -1004,8 +1004,6 @@ fn astLowerLetDecl(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> 
         name = patNode.text
     } else if patNode.kind == AstNPattern && patNode.extra == astPatternIdentKind() {
         name = patNode.text
-    } else if strings.HasPrefix(patNode.text, "ident:") {
-        name = strings.TrimPrefix(patNode.text, "ident:")
     }
     astbridge.LetDeclNode(
         astLowerNodePos(toks, n),
@@ -1514,7 +1512,7 @@ fn astLowerPattern(arena: AstArena, toks: List<astbridge.Token>, idx: Int) -> as
     if n.kind == AstNPattern && n.extra > 0 {
         return astLowerStructuredPattern(arena, toks, n)
     }
-    astLowerTextPattern(arena, toks, n)
+    astbridge.WildcardPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n))
 }
 
 fn astLowerTuplePat(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> astbridge.Pattern {
@@ -1580,68 +1578,6 @@ fn astLowerStructuredPattern(arena: AstArena, toks: List<astbridge.Token>, n: As
     astbridge.WildcardPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n))
 }
 
-fn astLowerTextPattern(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> astbridge.Pattern {
-    if strings.HasPrefix(n.text, "ident:") {
-        return astbridge.IdentPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), strings.TrimPrefix(n.text, "ident:"))
-    }
-    if n.text == "wildcard" {
-        return astbridge.WildcardPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n))
-    }
-    if strings.HasPrefix(n.text, "literal:") {
-        return astbridge.LiteralPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerLiteralPatternExpr(toks, n))
-    }
-    if n.text == "negLiteral" {
-        return astbridge.LiteralPatNode(
-            astLowerNodePos(toks, n),
-            astLowerNodeEnd(toks, n),
-            astbridge.UnaryExprNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerKind(FrontMinus), astLowerLiteralPatternExpr(toks, astArenaNodeAt(arena, n.left))),
-        )
-    }
-    if n.text == "tuple" {
-        return astLowerTuplePat(arena, toks, n)
-    }
-    if strings.HasPrefix(n.text, "variant:") {
-        let mut args = astbridge.EmptyPatternList()
-        for child in n.children {
-            let p = astLowerPattern(arena, toks, child)
-            if !(astbridge.IsNilPattern(p)) {
-                args.push(p)
-            }
-        }
-        return astbridge.VariantPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerSplitPath(strings.TrimPrefix(n.text, "variant:")), args)
-    }
-    if strings.HasPrefix(n.text, "struct:") {
-        let mut fields = astbridge.EmptyStructPatFieldList()
-        for child in n.children {
-            let cn = astArenaNodeAt(arena, child)
-            if cn.text != "" && cn.left >= 0 {
-                fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, cn), cn.text, astLowerPattern(arena, toks, cn.left)))
-            } else {
-                let pat = astLowerPattern(arena, toks, child)
-                let childNode = astArenaNodeAt(arena, child)
-                if childNode.kind == AstNIdent {
-                    fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, childNode), childNode.text, astbridge.NilPattern()))
-                } else if strings.HasPrefix(childNode.text, "ident:") {
-                    fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, childNode), strings.TrimPrefix(childNode.text, "ident:"), astbridge.NilPattern()))
-                } else if !(astbridge.IsNilPattern(pat)) {
-                    fields.push(astbridge.StructPatFieldNode(astLowerNodePos(toks, childNode), "", pat))
-                }
-            }
-        }
-        return astbridge.StructPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerSplitPath(strings.TrimPrefix(n.text, "struct:")), fields, n.flags == 1)
-    }
-    if strings.HasPrefix(n.text, "binding:") {
-        return astbridge.BindingPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), strings.TrimPrefix(n.text, "binding:"), astLowerPattern(arena, toks, n.left))
-    }
-    if n.text == "range" {
-        return astbridge.RangePatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerPatternLiteralExpr(arena, toks, n.left), astLowerPatternLiteralExpr(arena, toks, n.right), n.flags == 1)
-    }
-    if n.text == "or" {
-        return astbridge.OrPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerOrAlts(arena, toks, n))
-    }
-    astbridge.WildcardPatNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n))
-}
-
 fn astLowerOrAlts(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> List<astbridge.Pattern> {
     let mut out = astbridge.EmptyPatternList()
     out = astLowerCollectOrAlt(arena, toks, n.left, out)
@@ -1653,7 +1589,7 @@ fn astLowerCollectOrAlt(arena: AstArena, toks: List<astbridge.Token>, idx: Int, 
         return out
     }
     let n = astArenaNodeAt(arena, idx)
-    if n.extra == astPatternOrKind() || n.text == "or" {
+    if n.extra == astPatternOrKind() {
         let left = astLowerCollectOrAlt(arena, toks, n.left, out)
         return astLowerCollectOrAlt(arena, toks, n.right, left)
     }
@@ -1673,7 +1609,7 @@ fn astLowerPatternLiteralExpr(arena: AstArena, toks: List<astbridge.Token>, idx:
 }
 
 fn astLowerPatternLiteralExprNode(arena: AstArena, toks: List<astbridge.Token>, n: AstNode) -> astbridge.Expr {
-    if n.text == "negLiteral" || (n.extra == astPatternLiteralKind() && n.text == "-" && n.left >= 0) {
+    if n.extra == astPatternLiteralKind() && n.text == "-" && n.left >= 0 {
         return astbridge.UnaryExprNode(astLowerNodePos(toks, n), astLowerNodeEnd(toks, n), astLowerKind(FrontMinus), astLowerLiteralPatternExpr(toks, astArenaNodeAt(arena, n.left)))
     }
     astLowerLiteralPatternExpr(toks, n)
@@ -1682,7 +1618,7 @@ fn astLowerPatternLiteralExprNode(arena: AstArena, toks: List<astbridge.Token>, 
 fn astLowerLiteralPatternExpr(toks: List<astbridge.Token>, n: AstNode) -> astbridge.Expr {
     let pos = astLowerNodePos(toks, n)
     let end = astLowerNodeEnd(toks, n)
-    let text = strings.TrimPrefix(n.text, "literal:")
+    let text = n.text
     if n.op == FrontInt {
         return astbridge.IntLitExpr(pos, end, text)
     }

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -1906,11 +1906,11 @@ fn selfLintAstPatternNames(
         return out
     }
     if selfLintAstPatternIsIdent(node) {
-        out.push(selfLintNameAtNode(selfLintAstPatternName(node.text, "ident:"), node.start, node.end, idx))
-    } else if node.extra == selfLintAstPatternBindingKind() || strings.hasPrefix(node.text, "binding:") {
-        out.push(selfLintNameAtNode(selfLintAstPatternName(node.text, "binding:"), node.start, node.start + 1, idx))
+        out.push(selfLintNameAtNode(node.text, node.start, node.end, idx))
+    } else if node.extra == selfLintAstPatternBindingKind() {
+        out.push(selfLintNameAtNode(node.text, node.start, node.start + 1, idx))
         out = selfLintAstPatternNames(file, node.left, out)
-    } else if node.extra == selfLintAstPatternFieldKind() || (node.extra == 0 && node.text != "" && node.left >= 0) {
+    } else if node.extra == selfLintAstPatternFieldKind() {
         if node.left >= 0 {
             out = selfLintAstPatternNames(file, node.left, out)
         } else {
@@ -1927,7 +1927,7 @@ fn selfLintAstPatternNames(
 }
 
 fn selfLintAstPatternIsIdent(node: AstNode) -> Bool {
-    node.extra == selfLintAstPatternIdentKind() || strings.hasPrefix(node.text, "ident:")
+    node.extra == selfLintAstPatternIdentKind()
 }
 
 fn selfLintAstPatternIdentKind() -> Int { 3 }
@@ -1935,13 +1935,6 @@ fn selfLintAstPatternIdentKind() -> Int { 3 }
 fn selfLintAstPatternBindingKind() -> Int { 9 }
 
 fn selfLintAstPatternFieldKind() -> Int { 10 }
-
-fn selfLintAstPatternName(text: String, prefix: String) -> String {
-    if strings.hasPrefix(text, prefix) {
-        return strings.trimPrefix(text, prefix)
-    }
-    text
-}
 
 fn selfLintAstCountWritesAfter(
     file: AstFile,

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -1445,12 +1445,12 @@ fn srAstPatternNames(
     if node.kind != AstNPattern {
         return out
     }
-    if node.extra == srPatternIdentKind() || strings.hasPrefix(node.text, "ident:") {
-        out.push(selfResolveName(srPatternName(node.text, "ident:"), node.start, node.end, idx))
-    } else if node.extra == srPatternBindingKind() || strings.hasPrefix(node.text, "binding:") {
-        out.push(selfResolveName(srPatternName(node.text, "binding:"), node.start, node.start + 1, idx))
+    if node.extra == srPatternIdentKind() {
+        out.push(selfResolveName(node.text, node.start, node.end, idx))
+    } else if node.extra == srPatternBindingKind() {
+        out.push(selfResolveName(node.text, node.start, node.start + 1, idx))
         out = srAstPatternNames(file, node.left, out)
-    } else if node.extra == srPatternFieldKind() || (node.extra == 0 && node.text != "" && node.left >= 0) {
+    } else if node.extra == srPatternFieldKind() {
         if node.left >= 0 {
             out = srAstPatternNames(file, node.left, out)
         } else {
@@ -1471,13 +1471,6 @@ fn srPatternIdentKind() -> Int { 3 }
 fn srPatternBindingKind() -> Int { 9 }
 
 fn srPatternFieldKind() -> Int { 10 }
-
-fn srPatternName(text: String, prefix: String) -> String {
-    if strings.hasPrefix(text, prefix) {
-        return strings.trimPrefix(text, prefix)
-    }
-    text
-}
 
 fn srAstLetTypeName(file: AstFile, node: AstNode) -> String {
     srAstTypeName(file, srAstChildAt(node.children, 0))


### PR DESCRIPTION
## Summary

The pattern AST consumers in `toolchain/{ast_lower,resolve,lint}.osty` carried a defensive `strings.HasPrefix(n.text, \"ident:\")` cascade alongside the typed `n.extra == astPattern{Ident,...}Kind()` dispatch. Investigating the prompt's premise — *\"a typo in any of these spellings silently reclassifies the pattern as wildcard\"* — revealed the prefix path is **dead code**:

- `toolchain/parser.osty:1170-1303` is the only producer of `AstNPattern` nodes. Every site sets `n.extra` to a typed kind code and `n.text` to the bare name (e.g. `head`, `name`) — never `\"ident:foo\"`.
- Repo-wide grep for `text = \"ident:\"`, `\"ident:\" +`, etc. returns zero hits in `.osty`/`.go` files.
- `astLowerPattern` already routes any `AstNPattern` with `extra > 0` to `astLowerStructuredPattern` first; the fallthrough call to `astLowerTextPattern` (~70 lines) is unreachable.
- `srAstPatternNames` and `selfLintAstPatternNames` similarly never reach their `||` text-prefix legs.

So instead of introducing typed `astbridge.PatTag*()` constants (which would *retype* dead code), this PR **deletes** the unreachable paths. Removing them eliminates the entire stringly-typed failure mode permanently. `n.extra` becomes the single source of truth.

### Changes
- **`ast_lower.osty`**: delete `astLowerTextPattern`; drop dead text checks in `astLowerLetDecl`, `astLowerCollectOrAlt`, `astLowerPatternLiteralExprNode`, `astLowerLiteralPatternExpr`. Fallthrough now returns `WildcardPatNode` directly (matches the prior fallback behavior).
- **`resolve.osty`**: drop `||` text-prefix legs in `srAstPatternNames`; remove the now-unused `srPatternName` helper.
- **`lint.osty`**: same cleanup in `selfLintAstPatternNames` and `selfLintAstPatternIsIdent`; remove unused `selfLintAstPatternName`.

### Diff
`+14 / -92` across 3 files.

## Why

- **Removes failure mode entirely** rather than masking it. Typing the dead path would still leave a parallel-dispatch hazard (typed and prefix-based dispatch coexisting); deletion gives one source of truth.
- Aligns with `CLAUDE.md` rule on dead/unreachable code and \"depth over MVP\" — defensive paths that cannot fire are noise, not safety.

## Verification

- `go run ./cmd/osty check toolchain/ast_lower.osty toolchain/resolve.osty toolchain/lint.osty` → **309 errors** (all \"not in scope\" cross-module refs inherent to single-file checking), down from **330 baseline**. **Zero new diagnostics.**
- Frontend tests pass:
  ```
  ok  ./internal/lexer
  ok  ./internal/parser
  ok  ./internal/resolve
  ok  ./internal/check
  ```
- Failures in `./internal/llvmgen` and `./internal/lsp` (`LLVM016 unknown identifier \"strings\"`, LSP repair panic) reproduce identically on HEAD without these edits — pre-existing, unrelated to this change.

## Reviewer notes

- **`internal/selfhost/generated.go`** and **`internal/docgen/ast_lower.go`** still contain the same dead text-prefix paths. Both are generated artifacts (the former from `cmd/osty-bootstrap-gen`, the latter is a Go transpilation snapshot). Per `CLAUDE.md` they must not be hand-edited; they will re-sync on the next bootstrap-gen run.
- **`examples/selfhost-core/*`** is a frozen snapshot of an earlier toolchain state and is intentionally untouched.
- The change is conservative — only pattern-dispatch sites. Other stringly-typed dispatch in `astLowerType` (`n.text == \"optional\"`, `\"tuple\"`, `\"fn\"`) is a separate type-lowering family and out of scope.

## Test plan

- [x] `go run ./cmd/osty check toolchain/ast_lower.osty toolchain/resolve.osty toolchain/lint.osty` shows no new diagnostics
- [x] `go test -count=1 ./internal/{lexer,parser,resolve,check,...}` passes
- [ ] (Reviewer) Confirm `cmd/osty-bootstrap-gen` regen produces a clean diff in `internal/selfhost/generated.go` (will be a separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)