### PR TITLE
fix: panic in selfhost span index on interface methods without default body

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -467,6 +468,13 @@ func (idx *selfhostSpanIndex) scopeFor(key selfhostSpanKey) *resolve.Scope {
 
 func (idx *selfhostSpanIndex) addNode(n ast.Node, base int, scope *resolve.Scope, sm *sourcemap.Map) {
 	if n == nil {
+		return
+	}
+	// Nilable AST fields (e.g. FnDecl.Body for interface methods without a
+	// default) arrive here as a non-nil ast.Node interface wrapping a nil
+	// pointer. The `n == nil` guard above misses that; the type switch below
+	// would then dereference the nil pointer.
+	if rv := reflect.ValueOf(n); rv.Kind() == reflect.Ptr && rv.IsNil() {
 		return
 	}
 	key, haveKey := spanKeyForNode(n, base, sm)

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -81,6 +81,35 @@ fn main() {
 	}
 }
 
+// Regression: FnDecl.Body is nil for interface-declared methods without a
+// default. Passing it as ast.Node turned the nil *ast.Block into a typed-nil
+// interface that slipped past the n == nil guard in addNode and
+// nil-dereferenced inside the Block arm of the type switch.
+func TestNativeBoundaryIndexesInterfaceMethodWithoutDefaultBody(t *testing.T) {
+	src := []byte(`pub interface Reader {
+    fn read(self, n: Int) -> Int
+    fn close(self) -> Int { 0 }
+}
+
+fn main() {}
+`)
+	file, res := parseResolvedFile(t, src)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return fakeNativeChecker{result: nativeCheckResult{
+			Summary: nativeCheckSummary{Assignments: 0, Accepted: 0, Errors: 0},
+		}}, ""
+	}
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	// Must not panic.
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+}
+
 func TestNativeBoundaryReportsMissingExecutable(t *testing.T) {
 	src := []byte("fn main() {}\n")
 	file, res := parseResolvedFile(t, src)


### PR DESCRIPTION
## Summary

- `selfhostSpanIndex.addNode` panicked on any `ast.Node` that held a typed-nil pointer (e.g. `FnDecl.Body` for interface methods without a default). The `n == nil` guard misses non-nil interfaces wrapping nil pointers, so the `case *ast.Block:` arm dereferenced the nil pointer.
- Because `airepair.probe` drives `check.File` over fixture files that contain interface declarations, the panic fired at the very first probe — making `osty gen --backend=llvm` crash on effectively every input.
- Fix: add a reflect-based typed-nil guard at the top of `addNode`. Centralized in one place rather than scattering checks across the ~20 call sites that pass nilable fields.

## Repro (before fix)

```
$ echo 'fn main() { println("hi") }' > /tmp/smoke.osty
$ osty gen --backend=llvm /tmp/smoke.osty
...
panic: runtime error: invalid memory address or nil pointer dereference
  selfhostSpanIndex.addNode host_boundary.go:578
  selfhostSpanIndex.addNode host_boundary.go:501   # FnDecl -> Body
  selfhostSpanIndex.addNode host_boundary.go:530   # InterfaceDecl -> Methods
  buildSelfhostSpanIndex    host_boundary.go:433
```

## Test plan

- [x] Added `TestNativeBoundaryIndexesInterfaceMethodWithoutDefaultBody` — verified it reproduces the exact panic stack with the fix reverted, passes with the fix applied.
- [x] `go test ./internal/check/ -count=1 -short` passes.
- [x] `go build ./...` clean.
- [x] Confirmed `osty gen --backend=llvm` no longer panics at the previously-failing probe step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)