### PR TITLE
fix: E0008 오탐 수정 — 문자열 본문에서 숫자 분리자 규칙 누수

### DIFF
--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -52,7 +52,7 @@ func runFrontend(src []byte, adaptTokens bool) *FrontendRun {
 	if adaptTokens {
 		run.ensureLexAdapted()
 	} else {
-		run.lexDiags = lexDiagnosticsFromFacts(rt, run.facts())
+		run.lexDiags = lexDiagnosticsFromFacts(rt, stream, run.facts())
 	}
 	return run
 }
@@ -72,7 +72,7 @@ func (r *FrontendRun) Comments() []token.Comment {
 // LexDiagnostics returns lexer-only diagnostics.
 func (r *FrontendRun) LexDiagnostics() []*diag.Diagnostic {
 	if r.lexDiags == nil {
-		r.lexDiags = lexDiagnosticsFromFacts(r.rt, r.facts())
+		r.lexDiags = lexDiagnosticsFromFacts(r.rt, r.stream, r.facts())
 	}
 	return r.lexDiags
 }
@@ -119,17 +119,17 @@ func adaptLexStream(rt runeTable, stream *FrontLexStream, facts *OstyLexFacts) (
 			EndLine: c.endLine,
 		})
 	}
-	return toks, lexDiagnosticsFromFacts(rt, facts), comments
+	return toks, lexDiagnosticsFromFacts(rt, stream, facts), comments
 }
 
-func lexDiagnosticsFromFacts(rt runeTable, facts *OstyLexFacts) []*diag.Diagnostic {
+func lexDiagnosticsFromFacts(rt runeTable, stream *FrontLexStream, facts *OstyLexFacts) []*diag.Diagnostic {
 	diags := make([]*diag.Diagnostic, 0, len(facts.errors))
 	for _, d := range facts.errors {
 		diags = append(diags, lexDiagnostic(d, rt))
 	}
 	// Bridge until selfhost regen lands: post-scan for §1.6.1 numeric
 	// separator violations and surface them as E0008.
-	diags = append(diags, scanBadNumericSeparators(rt)...)
+	diags = append(diags, scanBadNumericSeparators(rt, stream)...)
 	return diags
 }
 

--- a/internal/selfhost/numeric_sep.go
+++ b/internal/selfhost/numeric_sep.go
@@ -6,120 +6,83 @@ import (
 )
 
 // scanBadNumericSeparators enforces LANG_SPEC_v0.4 §1.6.1: underscores in
-// numeric literals may appear only between two digits of the same base. A
-// literal may not start with `_` (maximal munch turns that into an IDENT
-// anyway), end with `_`, contain `__`, or place `_` immediately after a
-// base prefix. `_` adjacent to `.`, `e`/`E`, or an exponent sign is
-// likewise rejected.
+// numeric literals must sit between two digits of the same base.
 //
-// The lexer core (examples/selfhost-core/frontend.osty:frontNumberScan)
-// has matching logic emitting FrontDiagBadNumericSeparator, but the
-// self-hosted regeneration path in this tree is blocked by pre-existing
-// issues (see resolve.osty `while` loops). Until regen is fixed this
-// Go-side post-processor mirrors the spec so the behavior reaches users
-// today; once regen lands the Osty-side diagnostic will cover it and this
-// helper becomes redundant (but harmless — duplicate diagnostics are
-// deduped by the adapter).
-func scanBadNumericSeparators(rt runeTable) []*diag.Diagnostic {
-	runes := rt.runes
+// Walks INT/FLOAT tokens (top-level and interpolation bodies), so string
+// bodies, comments, and identifiers never trip the check. Bridge until the
+// selfhost lexer emits FrontDiagBadNumericSeparator directly; duplicate
+// diagnostics are deduped by the adapter.
+func scanBadNumericSeparators(rt runeTable, stream *FrontLexStream) []*diag.Diagnostic {
 	var out []*diag.Diagnostic
-	for i := 0; i < len(runes); {
-		r := runes[i]
-		if r < '0' || r > '9' {
-			i++
-			continue
+	check := func(ft *FrontLexToken) {
+		if ft == nil || ft.start == nil {
+			return
 		}
-		// Identify base and body range [bodyStart, bodyEnd).
-		base := 10
-		bodyStart := i
-		bodyEnd := i
-		if r == '0' && i+1 < len(runes) {
-			switch runes[i+1] {
-			case 'x', 'X':
-				base = 16
-				bodyStart = i + 2
-			case 'b', 'B':
-				base = 2
-				bodyStart = i + 2
-			case 'o', 'O':
-				base = 8
-				bodyStart = i + 2
-			}
+		switch ft.kind.(type) {
+		case *FrontTokenKind_FrontInt, *FrontTokenKind_FrontFloat:
+		default:
+			return
 		}
-		// Consume the literal body.
-		j := bodyStart
-		for j < len(runes) && isNumericContinuation(runes[j], base) {
-			j++
+		if d := checkNumericLiteral(rt, ft.start.offset, ft.length); d != nil {
+			out = append(out, d)
 		}
-		bodyEnd = j
-		// For decimal, extend through the fractional part and exponent so
-		// adjacent-to-dot / adjacent-to-e underscores fall inside the
-		// scanned range.
-		if base == 10 {
-			if j < len(runes) && runes[j] == '.' && j+1 < len(runes) && runes[j+1] != '.' && isDecimalDigit(runes[j+1]) {
-				j++
-				for j < len(runes) && isNumericContinuation(runes[j], 10) {
-					j++
-				}
-				bodyEnd = j
-			}
-			if j < len(runes) && (runes[j] == 'e' || runes[j] == 'E') {
-				k := j + 1
-				if k < len(runes) && (runes[k] == '+' || runes[k] == '-') {
-					k++
-				}
-				if k < len(runes) && isDecimalDigit(runes[k]) {
-					j = k
-					for j < len(runes) && isNumericContinuation(runes[j], 10) {
-						j++
-					}
-					bodyEnd = j
-				}
-			}
-		}
-		// Look for any underscore whose neighbors are not both base digits.
-		bad := false
-		for k := bodyStart; k < bodyEnd; k++ {
-			if runes[k] != '_' {
-				continue
-			}
-			var prev, next rune = -1, -1
-			if k > 0 {
-				prev = runes[k-1]
-			}
-			if k+1 < len(runes) {
-				next = runes[k+1]
-			}
-			if !isBaseDigit(prev, base) || !isBaseDigit(next, base) {
-				bad = true
-				break
-			}
-		}
-		if bad {
-			start := posAtRune(runes, i)
-			start.Offset = rt.byteOffset(i)
-			end := posAtRune(runes, bodyEnd)
-			end.Offset = rt.byteOffset(bodyEnd)
-			out = append(out, diag.New(diag.Error, "numeric separator `_` must appear between two digits").
-				Code("E0008").
-				Primary(diag.Span{Start: start, End: end}, "").
-				Hint("place `_` only between two digits").
-				Build())
-		}
-		if j > i {
-			i = j
-		} else {
-			i++
+	}
+	for _, ft := range stream.tokens {
+		check(ft)
+	}
+	for _, it := range stream.interpolationTokens {
+		if it != nil {
+			check(it.token)
 		}
 	}
 	return out
 }
 
-func isNumericContinuation(r rune, base int) bool {
-	if r == '_' {
-		return true
+func checkNumericLiteral(rt runeTable, startRune, length int) *diag.Diagnostic {
+	runes := rt.runes
+	end := startRune + length
+	if end > len(runes) {
+		end = len(runes)
 	}
-	return isBaseDigit(r, base)
+	base := 10
+	bodyStart := startRune
+	if length >= 2 && runes[startRune] == '0' {
+		switch runes[startRune+1] {
+		case 'x', 'X':
+			base = 16
+			bodyStart = startRune + 2
+		case 'b', 'B':
+			base = 2
+			bodyStart = startRune + 2
+		case 'o', 'O':
+			base = 8
+			bodyStart = startRune + 2
+		}
+	}
+	for k := bodyStart; k < end; k++ {
+		if runes[k] != '_' {
+			continue
+		}
+		var prev, next rune = -1, -1
+		if k > startRune {
+			prev = runes[k-1]
+		}
+		if k+1 < end {
+			next = runes[k+1]
+		}
+		if !isBaseDigit(prev, base) || !isBaseDigit(next, base) {
+			startPos := posAtRune(runes, startRune)
+			startPos.Offset = rt.byteOffset(startRune)
+			endPos := posAtRune(runes, end)
+			endPos.Offset = rt.byteOffset(end)
+			return diag.New(diag.Error, "numeric separator `_` must appear between two digits").
+				Code("E0008").
+				Primary(diag.Span{Start: startPos, End: endPos}, "").
+				Hint("place `_` only between two digits").
+				Build()
+		}
+	}
+	return nil
 }
 
 func isBaseDigit(r rune, base int) bool {
@@ -134,10 +97,6 @@ func isBaseDigit(r rune, base int) bool {
 		return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
 	}
 	return false
-}
-
-func isDecimalDigit(r rune) bool {
-	return r >= '0' && r <= '9'
 }
 
 // posAtRune computes a line/column position for the given rune index.


### PR DESCRIPTION
## 문제

`scanBadNumericSeparators`(Go 측 post-processor)가 렉서 토큰 문맥 없이 원시 룬을 훑으며 §1.6.1 규칙을 적용해, 문자열 본문과 정규식 패턴 내부의 `0_`·`9_` 같은 바이트열까지 **잘못된 수치 분리자**로 오판했다.

영향 파일에서 E0008 6건 발생:
- `toolchain/lsp.osty` — `"0_{label}"`, `"1_{label}"`, `"2_{label}"`, `"3_{label}"` (완성 항목 정렬키)
- `toolchain/ci.osty` — `"[a-z][a-z0-9_-]*"` (패키지명 정규식 메시지)
- `toolchain/manifest_validation.osty` — `"...[A-Za-z0-9_-]*"` (매니페스트 검증 메시지)

## 수정

`scanBadNumericSeparators`를 토큰 기반 검사로 재작성:

- `stream.tokens` + `stream.interpolationTokens`를 순회하며 `FrontInt`/`FrontFloat` 토큰만 §1.6.1로 검사
- 문자열/주석/식별자는 자연스럽게 제외 (애초에 INT/FLOAT가 아니므로)
- 보간 내부의 진짜 숫자 리터럴(`{1_000}`)은 여전히 `interpolationTokens`에서 잡힘

## 검증

- `"0_{label}"`, `"[a-z0-9_-]*"`, `"{name}...[A-Za-z0-9_-]*"` → E0008 **0건**
- `1_`, `0x_FF`, `1__000`, `1_.5`, `1.5_e2` → E0008 **정상 발화**
- `internal/lexer` 의 `TestLexBadNumericSeparator*` 4개 모두 통과
- `internal/{lexer,selfhost,parser,check,types,resolve,...}` 전체 통과

## 리뷰어 노트

- 이 helper는 원래 "selfhost regen이 밀리는 동안의 bridge"로 작성된 Go shim. 주석도 이 사실과 dedup 동작을 반영해 갱신
- 셀프호스트 렉서 본체(`toolchain/frontend.osty:frontNumberScan`)가 `FrontDiagBadNumericSeparator`를 직접 발화하는 경로가 완성되면 이 shim은 제거 대상
- 기존 llvmgen·lsp 테스트 실패는 `main`에서도 재현되는 무관한 선행 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)