### PR TITLE
spec: §19 runtime primitives — package-gated sublanguage for GC self-host

### DIFF
--- a/LANG_SPEC_v0.4/02-type-system.md
+++ b/LANG_SPEC_v0.4/02-type-system.md
@@ -41,6 +41,10 @@ representable.
 Zero-sized structs (e.g. `struct Marker {}`) are allowed. They occupy no
 storage; collections and struct fields treat them as ordinary values.
 
+**Runtime-only types.** `RawPtr` is a pointer-shaped opaque type used by
+the toolchain's runtime sublanguage. It is **not** part of the user
+prelude and is unreachable from ordinary user code. See §19.3.
+
 ### 2.2 Numeric Conversions
 
 No implicit numeric conversions between variables. Conversions via
@@ -298,6 +302,12 @@ Map<K,V>:   K: Hashable + V: Hashable ⇒ Map<K,V>: Hashable
 User code cannot override the built-in `Equal`/`Hashable` instances of
 collection types; they are structural by definition. (Resolves G1 from
 the v0.1 gap list.)
+
+**Runtime-only marker.** `Pod` is a built-in marker interface
+(no methods) used by the runtime sublanguage to constrain raw
+load/store/CAS intrinsics. The compiler decides `Pod` membership
+structurally; user code cannot `impl Pod`. `Pod` is not part of the
+user prelude. See §19.4.
 
 ### 2.7 Generics
 

--- a/LANG_SPEC_v0.4/03-declarations.md
+++ b/LANG_SPEC_v0.4/03-declarations.md
@@ -332,12 +332,28 @@ Aliases are transparent; they create no new type.
 
 Osty has a fixed, compiler-recognized set of annotations. Applying any
 other annotation is a compile error; there is no user-extension
-mechanism. The complete v0.9 set is:
+mechanism. The complete set is:
+
+**User-facing annotations.**
 
 | Annotation | Applies to | Purpose |
 |---|---|---|
 | `#[json(...)]` | struct fields, enum variants | Customize JSON encoding/decoding (§10.8) |
 | `#[deprecated(...)]` | `fn`, `struct`, `enum`, `interface`, `type`, top-level `let`, struct/enum methods, struct fields, enum variants | Emit a warning when the item is referenced |
+
+**Runtime-only annotations** (privileged packages only — see §19.2 and §19.6).
+
+| Annotation | Applies to | Purpose |
+|---|---|---|
+| `#[intrinsic]` | `fn` declarations | Body is supplied by the lowering layer; source body must be empty (§19.5). Generic intrinsics participate in monomorphization. |
+| `#[pod]` | `struct` declarations | Requests the checker to verify the struct's `Pod` shape (§19.4); rejection is `E0771`. |
+| `#[repr(c)]` | `struct` declarations | Forces C ABI field order, padding, and alignment (§19.6). |
+| `#[export("name")]` | top-level `fn` declarations | Emit with the exact symbol name `name`, disabling Osty mangling (§19.6). |
+| `#[c_abi]` | top-level `fn` declarations | Use the platform C calling convention (§19.6). |
+| `#[no_alloc]` | `fn` and method declarations | Forbid managed allocation in the body, and forbid any direct or transitive call to a function that allocates (§19.6.1). |
+
+Applying any runtime-only annotation outside a privileged package is
+`E0770`, not the generic unknown-annotation error.
 
 Syntax is defined in §1.9. Both key/value (`name = value`) and bare-flag
 (`name`) argument forms are accepted.

--- a/LANG_SPEC_v0.4/14-excluded-features.md
+++ b/LANG_SPEC_v0.4/14-excluded-features.md
@@ -24,7 +24,10 @@
 - C-style `for` loops
 - labelled `break` / `continue`
 - `const` (use top-level `let`)
-- `unsafe` (use FFI for foreign code)
+- `unsafe` (use FFI for foreign code; the toolchain's runtime
+  sublanguage in §19 is not a user-facing `unsafe` block — it is
+  implementation-private and rejected outside privileged packages
+  with `E0770`)
 - `where` clauses (use `T: I1 + I2` directly)
 - `yield` / generators
 - anonymous structs / structural records

--- a/LANG_SPEC_v0.4/18-change-history.md
+++ b/LANG_SPEC_v0.4/18-change-history.md
@@ -3,6 +3,34 @@
 This chapter records the evolution of the specification across released
 versions. The latest release is at the top.
 
+### 18.0 v0.4 minor: runtime primitives (additive)
+
+`LANG_SPEC_v0.4/19-runtime-primitives.md` adds a package-gated runtime
+sublanguage. The change is strictly additive:
+
+- **No grammar change.** No new tokens, no new keywords, no EBNF
+  modification. The annotation form `#[name(args?)]` from §1.9 is
+  reused.
+- **No change to user-reachable surface.** `RawPtr`, the `Pod` marker
+  trait, and all six runtime annotations (`#[intrinsic]`, `#[pod]`,
+  `#[repr(...)]`, `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`) are
+  rejected outside privileged packages with `E0770`. Programs that do
+  not opt in observe no behavior change.
+- **`unsafe` exclusion preserved.** §14 still excludes user-facing
+  `unsafe`. The runtime sublanguage is implementation-private; it is
+  reachable only by the toolchain itself, not by registry packages.
+- **New diagnostics.** `E0770` (privilege violation), `E0771`
+  (`#[pod]` shape rejection or unbounded generic), `E0772` (managed
+  allocation in `#[no_alloc]` body, or invalid type size for
+  `raw.cas`). All in the `E0770–E0779` typecheck-extension band; the
+  control-flow band `E0760–E0769` is already in use.
+- **Manifest schema dependency.** §19.2 introduces a `[capabilities]
+  runtime = true` table key in `osty.toml`. The manifest reference
+  (§10/§11/§13) gains this key in the same release.
+
+Recorded in `SPEC_GAPS.md` as **G19 — runtime sublanguage capability
+surface, decided**.
+
 ### 18.1 v0.3 → v0.4
 
 v0.4 closes the v0.3 edge-case decision queue without adding a large new

--- a/LANG_SPEC_v0.4/19-runtime-primitives.md
+++ b/LANG_SPEC_v0.4/19-runtime-primitives.md
@@ -1,0 +1,531 @@
+## 19. Runtime Primitives
+
+This chapter specifies the **runtime sublanguage** — a small, package-gated
+surface that lets the Osty toolchain implement the GC, allocator, and other
+runtime services in Osty itself. None of this surface is reachable from
+ordinary user code; the entire chapter is invisible to programs that do not
+opt into the runtime gate.
+
+The user-facing language guarantees of §9 (Memory Management) are
+unchanged. There is no `unsafe` block, no raw pointer in the user prelude,
+no manual deallocation API on `T`. §14 still excludes `unsafe`; that
+exclusion is about *user* code. This chapter exists so the GC promise of
+§9 has a concrete implementation strategy without requiring that strategy
+to be written in C.
+
+### 19.1 Scope and Non-Goals
+
+**In scope.**
+
+- A single opaque integer-shaped pointer type, `RawPtr`.
+- A compile-time marker trait, `Pod`, that proves a type contains no
+  managed references.
+- Six new annotations: `#[intrinsic]`, `#[pod]`, `#[repr(...)]`,
+  `#[export(...)]`, `#[c_abi]`, `#[no_alloc]`.
+- A package-level gate (§19.2) that restricts the surface to the runtime
+  packages.
+- Lowering rules (§19.7) that connect intrinsics to LLVM IR and to the
+  C ABI used by the runtime symbol set (`osty.gc.*`).
+- The compiler-to-runtime safepoint contract (§19.10) that lets an
+  Osty-side `safepoint_v1` see the same root array the C runtime sees
+  today.
+
+**Out of scope.**
+
+- A general `unsafe` block. There isn't one.
+- Address-of (`&x`) for managed references. Managed references remain
+  GC handles in the language model; their representation is not
+  observable.
+- Stackmap *introspection* intrinsics. The runtime never reads stackmap
+  metadata directly; instead, the compiler-emitted call site for
+  `safepoint_v1` (§19.10) materializes the root array and passes it in.
+  The runtime walks an array, not the stack.
+- Volatile, atomic-fence, or inline-assembly primitives. The first GC
+  delivered through this surface is single-threaded stop-the-world.
+  The `cas` intrinsic (§19.5) is provided for forward compatibility
+  with later concurrent algorithms; the v0.4 single-threaded GC is not
+  required to exercise it.
+
+### 19.2 Privileged Packages
+
+The runtime surface is **gated by package path**. A package is privileged
+if and only if either:
+
+1. Its fully qualified path begins with the prefix `std.runtime.`
+   (the public namespace for runtime intrinsics), or
+2. Its `osty.toml` manifest contains `[capabilities] runtime = true`
+   **and** the manifest is loaded from a path under the toolchain
+   workspace root. The compiler refuses this capability bit when the
+   manifest is loaded from a registry-fetched dependency, regardless of
+   the bit's value in the published manifest.
+
+The `[capabilities]` table is part of the manifest schema; the v0.4
+runtime spec is the first chapter to require it. Manifest loaders that
+do not yet recognize the table treat any unknown key as a parse error
+(per §10/§11/§13 manifest conventions), so older toolchains refuse to
+compile a package that depends on this surface — which is the desired
+fail-closed behavior.
+
+A non-privileged package that:
+
+- declares a function with `#[intrinsic]`, `#[no_alloc]`, `#[c_abi]`, or
+  `#[export(...)]`, or
+- declares a type with `#[pod]` or `#[repr(c)]`, or
+- imports `std.runtime.*` (any subpath), or
+- names `RawPtr` or the `Pod` trait,
+
+is rejected at resolution time with `E0770 runtime primitive used outside
+privileged package`. The diagnostic preferentially points at the import
+when one is present, otherwise at the offending annotation or identifier.
+
+### 19.3 The `RawPtr` Type
+
+```osty
+opaque type RawPtr        // declared in std.runtime
+```
+
+`RawPtr` is an opaque integer-shaped type with the following contract:
+
+- It occupies the target's pointer width. v0.4 supports 64-bit targets
+  only, so `RawPtr` is 8 bytes.
+- It is `Pod` (it contains no managed reference).
+- It implements `Equal` and `Hashable`. It does **not** implement
+  `Ordered`; the runtime uses tag bits, not numeric comparison, when it
+  needs ordering on raw addresses.
+- Pattern matching on `RawPtr` supports identifier and equality patterns
+  (via `Equal`); range patterns are rejected with `E0723` (range
+  pattern requires `Ordered`).
+- The garbage collector does **not** trace `RawPtr` values. A `RawPtr`
+  may dangle, alias, or refer to uninitialized memory. Its semantics
+  are the C `uintptr_t` semantics, not a managed handle.
+
+The literal sugar `T?` is *not* available on `RawPtr` directly — code
+that wants a "maybe-null" representation in the runtime ABI uses
+`RawPtr` and tests against `raw.null()`, because the allocator-failure
+path returns its result in a single register matching the C ABI and an
+`Option` tag would change the calling convention. `Option<RawPtr>`
+*is* permitted in ordinary `#[no_alloc]` code (§19.4 allows
+`Option<T: Pod>` as `Pod`); it just cannot appear as the return type of
+a `#[c_abi]` function.
+
+`RawPtr` values are constructed only by the §19.5 intrinsics
+(`raw.alloc`, `raw.offset`, `raw.read::<RawPtr>`, `raw.null`,
+`raw.fromBits`). They are observed as integers via `raw.bits`.
+
+### 19.4 The `Pod` Marker Trait
+
+```osty
+interface Pod {}          // declared in std.runtime; compiler-derived
+```
+
+`Pod` is a compile-time marker that means: "values of this type contain
+no managed reference, no closure capture, and no padding bits whose
+value the compiler may choose freely". `Pod` membership is decided by
+the checker, not by user impl. There is no `impl Pod for ...` syntax.
+
+A type satisfies `Pod` exactly when one of the following derivation
+rules applies:
+
+1. **Primitives.** `Bool`, `Char`, `Byte`, `Int`, `Int8`–`Int64`,
+   `UInt8`–`UInt64`, `Float` (alias for `Float64`), `Float32`,
+   `Float64`, and `RawPtr` are `Pod`.
+2. **Annotated structs.** A `struct` declaration is `Pod` if it carries
+   both `#[pod]` and `#[repr(c)]` and every field type is `Pod`. The
+   checker verifies the field shape; an offending field is reported as
+   `E0771 type cannot be marked #[pod]`, naming the first non-`Pod`
+   field.
+3. **Generic annotated structs.** A generic `#[pod] #[repr(c)] struct
+   S<T1, …, Tn>` requires every type parameter to carry the bound
+   `Tk: Pod` at the declaration site. The resulting `Pod` instance is
+   unconditional. Per-instantiation `Pod` (membership computed
+   per-use) is **not** supported in v0.4; an unbound generic struct
+   marked `#[pod]` is `E0771`.
+4. **Tuples.** A tuple type `(T1, …, Tn)` is `Pod` if every component
+   is `Pod`. Because struct values have reference semantics in the
+   user-facing language (§2.8), a tuple component of type `S` is `Pod`
+   *only* when `S` is a `#[pod] #[repr(c)]` struct, in which case the
+   tuple stores `S` by value (the runtime sublanguage is the only
+   place this by-value treatment is observable; in user-facing code the
+   reference semantics of §2.8 still hold because user code never sees
+   `Pod` types).
+5. **`Option<T>` of `Pod`.** `Option<T>` is `Pod` when `T: Pod`. The
+   lowering uses a tagged representation whose payload is exactly
+   `sizeOf::<T>()` plus an aligned tag byte; no managed allocation
+   participates.
+6. **Nothing else.** `String`, `Bytes`, `List<T>`, `Map<K, V>`,
+   `Set<T>`, closure values, function values, interface values,
+   `Result<T, E>`, ordinary user-defined enums, and any type that
+   transitively contains one of these are *not* `Pod`. `Result` is
+   excluded because its error arm carries `Error`, an interface.
+   Runtime code that wants result-style propagation returns `RawPtr`
+   sentinels or aborts.
+
+The trait has no methods. It exists only as a constraint:
+
+```osty
+fn raw.read<T: Pod>(p: RawPtr) -> T
+fn raw.write<T: Pod>(p: RawPtr, v: T)
+fn raw.cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
+```
+
+Calling `raw.read::<List<Int>>(p)` is `E0727` (constraint not
+satisfied), not a runtime crash.
+
+**Footgun note.** `RawPtr` is `Pod` because the GC tracer does not
+follow it. A `#[pod] #[repr(c)] struct Header { next: RawPtr, … }`
+therefore satisfies `Pod` even though it stores an address into managed
+memory. The privileged-package author is responsible for ensuring such
+pointers do not become the only handle to a live object — the tracer
+will not preserve them. This is exactly the pattern the current C
+runtime uses for its `osty_gc_header.next` linked list, and the spec
+permits it intentionally.
+
+### 19.5 Intrinsic Functions
+
+The runtime surface declares the following intrinsics inside the
+package `std.runtime.raw`. Each declaration is body-less and carries
+`#[intrinsic]`. Generic intrinsics participate in monomorphization
+exactly like any other generic; the lowering layer (§19.7) supplies the
+specialized body at each instantiation site, so the intrinsic is never
+present as a real symbol in the final object file.
+
+```osty
+package std.runtime.raw
+
+#[intrinsic] pub fn null() -> RawPtr
+#[intrinsic] pub fn fromBits(n: Int) -> RawPtr
+#[intrinsic] pub fn bits(p: RawPtr) -> Int
+#[intrinsic] pub fn alloc(bytes: Int, align: Int) -> RawPtr
+#[intrinsic] pub fn free(p: RawPtr)
+#[intrinsic] pub fn zero(p: RawPtr, bytes: Int)
+#[intrinsic] pub fn copy(dst: RawPtr, src: RawPtr, bytes: Int)
+#[intrinsic] pub fn offset(p: RawPtr, bytes: Int) -> RawPtr
+#[intrinsic] pub fn read<T: Pod>(p: RawPtr) -> T
+#[intrinsic] pub fn write<T: Pod>(p: RawPtr, v: T)
+#[intrinsic] pub fn cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
+#[intrinsic] pub fn sizeOf<T: Pod>() -> Int
+#[intrinsic] pub fn alignOf<T: Pod>() -> Int
+```
+
+Privileged callers reach them through their fully-qualified path:
+
+```osty
+use std.runtime.raw
+
+let header = raw.alloc(64, 8)
+if raw.bits(header) == 0 { abort("oom") }
+raw.write::<Int>(raw.offset(header, 8), 0)
+```
+
+**Behavior contract.**
+
+- `null()` returns a `RawPtr` whose integer value is 0.
+- `fromBits(n)` reinterprets a signed 64-bit integer as a pointer.
+  `bits(p)` is the inverse. Both are total; arithmetic on `Int`
+  follows §2.3.
+- `alloc(bytes, align)` requests a fresh, naturally-aligned block of
+  `bytes` bytes from the host allocator. The block is **not** zeroed;
+  callers that need zero-initialized memory follow `alloc` with
+  `zero` (or use the `alloc_zeroed` helper that the privileged `std.runtime`
+  package layers on top — see §19.7 lowering for the rationale). On
+  failure `alloc` returns the value of `null()`. `align` must be a
+  power of two and at least 1; `bytes` must be non-negative; both
+  preconditions abort on violation. The caller is responsible for
+  matching every successful `alloc` with exactly one `free`.
+- `free(p)` releases a block previously returned by `alloc`. `free`
+  of `null()` is a no-op. `free` of a non-`null`, non-`alloc`-returned
+  pointer aborts.
+- `zero` and `copy` perform `memset` and `memmove` semantics
+  respectively. `bytes` must be non-negative; negative values abort.
+  Overlap is permitted in `copy` (it is `memmove`, not `memcpy`).
+- `offset(p, n)` returns a `RawPtr` whose integer value is `bits(p) +
+  n`. There is no overflow check; raw arithmetic overflow is the
+  caller's problem and matches C `uintptr_t` semantics.
+- `read::<T>(p)` performs an aligned load of `sizeOf::<T>()` bytes
+  from `p`, reinterpreting them as `T`. The caller is responsible for
+  alignment and for `p` pointing at a live, properly-typed location.
+  **Reading from freed or uninitialized memory is undefined behavior**
+  in the LLVM IR sense — the optimizer may transform surrounding code
+  accordingly. The lowering applies an LLVM `freeze` so the resulting
+  value is a fixed-but-unspecified bit pattern rather than `poison`,
+  but this does not retroactively make the surrounding control flow
+  defined. Privileged code that reads possibly-uninitialized memory
+  must mask, check, or otherwise sanitize the result before branching
+  on it.
+- `write::<T>(p, v)` performs the matching aligned store.
+- `cas::<T>(p, old, new)` is a sequentially-consistent
+  compare-and-swap. The type argument is constrained to
+  `sizeOf::<T>() ∈ {1, 2, 4, 8, 16}` and `alignOf::<T>() ==
+  sizeOf::<T>()`. Other sizes are rejected at the call site with
+  `E0772 cas type size invalid` (a checker-side rule, not a link
+  error). The intrinsic is provided for forward compatibility with
+  future concurrent collectors; the v0.4 single-threaded STW GC may
+  leave it unused.
+- `sizeOf::<T>()` and `alignOf::<T>()` are compile-time constants
+  computed by the lowering layer. Calls with a non-`Pod` type
+  argument are rejected statically with `E0727`.
+
+These intrinsics are **not** exported by the standard prelude. User
+code cannot `use std.runtime.raw`; resolution rejects the import with
+`E0770`.
+
+### 19.6 New Annotations
+
+The `#[...]` annotation syntax is unchanged (§1.9). The recognized
+annotation set in §3.8 grows by six entries. None require new tokens
+or grammar rules.
+
+| Annotation | Applies to | Purpose |
+|---|---|---|
+| `#[intrinsic]` | `fn` declarations in privileged packages | Marks a function whose body is supplied by the lowering layer. The source body must be empty (`fn foo() -> T;` or `fn foo() -> T {}`). Generic intrinsics participate in monomorphization (§19.5). |
+| `#[pod]` | `struct` declarations in privileged packages | Requests the checker to verify the struct's `Pod` shape (§19.4); rejection is `E0771`. |
+| `#[repr(c)]` | `struct` declarations in privileged packages | Forces C ABI field order, padding, and alignment. Required on any struct used with `raw.read`/`raw.write` or passed across a `#[c_abi]` boundary. |
+| `#[export("name")]` | top-level `fn` declarations in privileged packages | Emits the function with the exact symbol name `name`, disabling Osty name mangling. The argument is a string literal (§1.9). |
+| `#[c_abi]` | top-level `fn` declarations in privileged packages | Use the platform C calling convention rather than the Osty calling convention. Almost always paired with `#[export("...")]`. The annotation name is `c_abi`, not `ccc`, to keep the surface readable for toolchain authors who do not work in LLVM IR daily. |
+| `#[no_alloc]` | `fn` and method declarations in privileged packages | Forbids managed allocation in the function body, **and** any direct or transitive call to a function that allocates (§19.6.1). |
+
+Annotation order on the same declaration is not significant; the
+following stacking is canonical:
+
+```osty
+#[export("osty.gc.alloc_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn alloc_v1(bytes: Int, kind: Int) -> RawPtr { ... }
+```
+
+The `#[deprecated]` annotation may also appear on these functions.
+`#[json(...)]` may not — privileged types are never serialized through
+the stdlib json codec.
+
+#### 19.6.1 The `#[no_alloc]` Check
+
+A `fn` carrying `#[no_alloc]` must contain no expression whose
+evaluation requires the managed allocator, and must not call any
+function that does. The checker computes a least-fixed-point over the
+call graph restricted to privileged packages. Self-recursion and mutual
+recursion among `#[no_alloc]` functions are permitted.
+
+The checker rejects, with `E0772 managed allocation in #[no_alloc]
+body`, any of the following constructs reachable from the function
+body:
+
+- string interpolation (`"x = {x}"`) and string concatenation that
+  produces a fresh `String`;
+- triple-quoted and raw string literals that produce a fresh `String`
+  at runtime (compile-time-interned static literals — see below — are
+  permitted);
+- list, map, or set literals (`[1, 2, 3]`, `[a: 1]`, `{1, 2, 3}`);
+- struct literals whose declared type is **not** `Pod`;
+- enum variant construction whose enum is not `Option<T: Pod>`
+  (permitted) and not declared in `std.runtime.*` (also permitted).
+  All other enum constructions, including `Result<…, …>`, are
+  rejected;
+- `Builder<T>` use of any kind;
+- direct or transitive call to a function that is not `#[no_alloc]`
+  and lives in the privileged-package call graph;
+- any call into ordinary stdlib (which is non-privileged), regardless
+  of whether that callee actually allocates;
+- **call through a function-pointer parameter or `fn(...)` value** —
+  the body cannot be analyzed, so the call is rejected. Privileged
+  callers that need indirect dispatch use a `match` over a closed enum
+  of `Pod` discriminators;
+- **call through an interface value (vtable dispatch, §2.7.3)** —
+  the dynamic dispatch boundary makes the callee's `#[no_alloc]`-ness
+  unknowable. Privileged callers do not use interface values;
+- **call to a default interface method** unless that default body is
+  itself `#[no_alloc]` and lives in a privileged package.
+
+Permitted constructs include:
+
+- all `Pod`-only arithmetic, comparison, and bit-ops;
+- all `raw.*` intrinsics from §19.5;
+- control flow (`if`, `for`, `match`, `defer`);
+- pattern matching on `Pod` values;
+- calls to other `#[no_alloc]` functions in privileged packages,
+  including self-recursion and mutual recursion;
+- construction of `Option<T: Pod>` and pattern matching on it;
+- construction of variants of enums declared in `std.runtime.*`
+  (the privileged enum hierarchy);
+- struct literals whose declared type is `Pod`;
+- reads from and writes to top-level `let mut` bindings of `Pod` type,
+  and to `Pod` fields of such bindings reached through `Pod` field
+  access;
+- **plain string literals** (`"abort"`, `"oom"`) with no
+  interpolation, no triple-quoting, and no raw form. These are
+  compile-time-interned into `.rodata`-equivalent storage; passing
+  one to a `#[c_abi]` function as an `i8*`-shaped argument is
+  allocation-free. The lowering details are in §19.7.
+
+This check is what makes the GC implementable in Osty: it is impossible
+for `collect_v1` to recursively re-enter the allocator through a
+forgotten string interpolation in a debug log line, and it is
+impossible for the runtime to call into ordinary stdlib (which would
+itself need a working allocator).
+
+### 19.7 Lowering
+
+LLVM lowering of the intrinsics is fixed by this specification. The
+backend is permitted to specialize but not to weaken the contract.
+Lowering syntax below is shown in pre-opaque-pointer LLVM (typed
+pointers) for readability; on the toolchain's required LLVM version
+(opaque pointers, ≥15) every `bitcast i8* p to T*` collapses and `load`
+/ `store` use `ptr` directly.
+
+| Intrinsic | LLVM lowering |
+|---|---|
+| `raw.null()` | `inttoptr i64 0 to i8*` |
+| `raw.fromBits(n)` | `inttoptr i64 %n to i8*` |
+| `raw.bits(p)` | `ptrtoint i8* %p to i64` |
+| `raw.alloc(b, a)` | `call i8* @osty_rt_alloc_aligned(i64 %a, i64 %b)` — see "shim" below. |
+| `raw.free(p)` | `call void @free(i8* %p)` |
+| `raw.zero(p, n)` | `call void @llvm.memset.p0i8.i64(i8* %p, i8 0, i64 %n, i1 false)` |
+| `raw.copy(d, s, n)` | `call void @llvm.memmove.p0i8.p0i8.i64(i8* %d, i8* %s, i64 %n, i1 false)` |
+| `raw.offset(p, n)` | `getelementptr i8, i8* %p, i64 %n` |
+| `raw.read::<T>(p)` | `bitcast i8* %p to T*; %v = load T, T* %1, align alignof(T); freeze T %v` |
+| `raw.write::<T>(p, v)` | `store T %v, T* %1, align alignof(T)` (after the matching bitcast) |
+| `raw.cas::<T>(p, old, new)` | `cmpxchg T* %p, T %old, T %new seq_cst seq_cst`, then extract the success bit. Only emitted when `sizeOf::<T>()` is in `{1, 2, 4, 8, 16}` and `alignOf::<T>() == sizeOf::<T>()`; other shapes are caught at §19.5 by `E0772`. |
+| `raw.sizeOf::<T>()` | constant folded from the data layout (no runtime call). |
+| `raw.alignOf::<T>()` | constant folded from the data layout. |
+
+**`raw.alloc` shim.** The symbol `osty_rt_alloc_aligned` is provided by
+a single-translation-unit C shim at
+`internal/backend/runtime/raw_alloc_shim.c`, unconditionally linked
+into any binary that contains a `raw.alloc` call. Its definition is
+exactly:
+
+```c
+#include <stdlib.h>
+void *osty_rt_alloc_aligned(size_t align, size_t bytes) {
+    void *p = NULL;
+    if (posix_memalign(&p, align < sizeof(void*) ? sizeof(void*) : align, bytes) != 0) {
+        return NULL;
+    }
+    return p;
+}
+```
+
+The shim does **not** zero memory; per §19.5 the contract for
+`raw.alloc` is uninitialized memory. Privileged callers that need a
+zero-initialized block compose `raw.alloc` with `raw.zero`, or use the
+`alloc_zeroed` helper that the privileged `std.runtime` package wraps
+on top:
+
+```osty
+#[no_alloc]
+pub fn alloc_zeroed(bytes: Int, align: Int) -> RawPtr {
+    let p = raw.alloc(bytes, align)
+    if raw.bits(p) != 0 { raw.zero(p, bytes) }
+    p
+}
+```
+
+**Plain string literals.** A bare `"…"` literal in a `#[no_alloc]`
+body is emitted as an LLVM `private unnamed_addr constant` of type
+`[N x i8]` and referenced by a constant `getelementptr` to its first
+byte. When passed to a `#[c_abi]` function declared with an `i8*`-
+shaped parameter (Osty `RawPtr` or, in v0.4 minor, the future
+`CStr` opaque), the value crosses the ABI boundary as a pointer to
+this constant. No allocation, no copy.
+
+**`#[c_abi]`** causes the function declaration to be emitted with
+LLVM's `ccc` calling convention.
+
+**`#[export("name")]`** causes the function to be emitted with
+`external` linkage, the `dso_local` preemption hint, and the exact
+symbol name `name`. The combination of `#[c_abi]` and
+`#[export(...)]` is what lets `osty_runtime.c` and the Osty-side
+runtime export the same `osty.gc.*_v1` ABI symbols interchangeably.
+
+**`#[no_alloc]`** does not produce a runtime check; it is purely a
+front-end discipline. The body, once accepted, lowers like any other
+function.
+
+### 19.8 Interaction with Other Chapters
+
+- **§1.9, §3.8 — Annotations.** The annotation grammar is unchanged.
+  The recognized-annotation table grows by six entries. Applying any
+  of the six in a non-privileged package is `E0770`, not the generic
+  unknown-annotation diagnostic (`E0607`).
+- **§2.1 — Primitive Types.** `RawPtr` is added to the table with a
+  pointer to §19.3. It is not a member of the user prelude.
+- **§2.6 — Interfaces.** `Pod` is added to the built-in instances
+  table with a pointer to §19.4.
+- **§9 — Memory Management.** Unchanged. The chapter still does not
+  pin the GC algorithm; it just becomes possible for the chosen
+  algorithm to be written in Osty.
+- **§10 / §11 / §13 — Manifest schema.** The `[capabilities]` table is
+  introduced by this chapter; the manifest chapter must surface it in
+  the next minor of the manifest reference. Until then the schema
+  reference is §19.2.
+- **§12 — FFI.** Unchanged. `use go "..."` continues to be the only
+  way for *user* code to reach a foreign symbol. The runtime
+  primitives are not an FFI mechanism; they are a code-generation
+  hook for the toolchain itself.
+- **§14 — Excluded Features.** The exclusion of `unsafe` stands.
+  §19 does not introduce an `unsafe` keyword, an `unsafe` block, or a
+  user-reachable raw pointer. The package gate (§19.2) is what makes
+  the surface implementation-private rather than user-facing.
+
+### 19.9 Diagnostics Added by This Chapter
+
+Codes are allocated in the `E0770–E0779` typecheck-extension band.
+The control-flow band `E0760–E0769` is already in use by
+`internal/diag/codes.go` (`CodeUnreachableCode`, `CodeMissingReturn`,
+`CodeDefaultNotLiteral`); the runtime sublanguage uses the next free
+band to avoid collision.
+
+| Code | Meaning |
+|---|---|
+| `E0770` | Runtime primitive (annotation, type, intrinsic, or `std.runtime.*` import) used outside a privileged package. |
+| `E0771` | A struct marked `#[pod]` violates the §19.4 shape rule. The diagnostic names the first offending field, or — for unbounded generic structs — the first type parameter that lacks a `T: Pod` bound. |
+| `E0772` | Either (a) a managed allocation was found inside a `#[no_alloc]` body, with a span pointing at the offending expression and (when transitive) the first non-`#[no_alloc]` callee on the chain; or (b) a `raw.cas::<T>` call where `sizeOf::<T>()` is not in `{1, 2, 4, 8, 16}` or alignment does not match. |
+
+The `Wxxxx` and `Lxxxx` bands are not used by this chapter; runtime-
+primitive misuse is always a hard error.
+
+### 19.10 Compiler-to-Runtime Safepoint Contract
+
+The runtime's safepoint entry point cannot identify roots by reading
+the stack itself (§19.1 makes that out of scope). Instead, the
+compiler emits, at every safepoint call site, a call sequence that
+materializes the live root array and passes it to the runtime
+explicitly. The runtime walks an array, not the stack.
+
+The contract for the C ABI symbol `osty.gc.safepoint_v1` is:
+
+```osty
+// signature, exported from the privileged runtime package
+#[export("osty.gc.safepoint_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn safepoint_v1(
+    site_id: Int,         // statically assigned per call site
+    roots: RawPtr,        // pointer to a contiguous array of N RawPtr slot addresses
+    root_count: Int,      // N
+)
+```
+
+At each safepoint, the LLVM lowering layer:
+
+1. Computes the set of live managed slots at that program point from
+   the LLVM stackmap.
+2. Materializes their addresses into a stack-allocated
+   `[root_count x i8*]` array.
+3. Emits a call to the exported `safepoint_v1` symbol with that
+   array's address and length.
+
+The runtime treats `roots` as a `RawPtr` to the start of an array;
+slot `k` is `raw.read::<RawPtr>(raw.offset(roots, k * 8))`. Each slot
+address points at a managed pointer. The runtime is free to **read**
+those slots (to mark) and to **overwrite** them (for a future moving
+collector); it must not free the addresses themselves.
+
+The matching contract for the existing C runtime ABI symbols
+`osty.gc.root_bind_v1`, `osty.gc.root_release_v1`, `osty.gc.post_write_v1`,
+`osty.gc.load_v1`, `osty.gc.mark_slot_v1`, and `osty.gc.alloc_v1` is
+preserved bit-for-bit. The Osty-side reimplementation of any of these
+declares the same C ABI signature with `#[c_abi]` and the matching
+`#[export("...")]`, and is link-compatible with the existing
+`internal/backend/runtime/osty_runtime.c` so that switching from the C
+runtime to the Osty runtime is purely a build-system decision.

--- a/LANG_SPEC_v0.4/README.md
+++ b/LANG_SPEC_v0.4/README.md
@@ -3,7 +3,7 @@
 Osty is a general-purpose, statically-typed, garbage-collected programming language.
 This directory holds the specification, split into per-section files for easier navigation and editing.
 
-**Status.** v0.4 — supersedes v0.3. Closes the remaining v0.3 edge-case decision queue (G13-G18): non-escaping structured-concurrency capabilities, generic method turbofish/method-reference rules, erased function-value arity, closure parameter irrefutability, stable nested witness policy, and checked stdlib protocol stubs. No known open gaps remain at the time of this release. See [`18-change-history.md`](./18-change-history.md) for the full v0.1 → v0.2 → v0.3 → v0.4 evolution.
+**Status.** v0.4 — supersedes v0.3. Closes the remaining v0.3 edge-case decision queue (G13-G18): non-escaping structured-concurrency capabilities, generic method turbofish/method-reference rules, erased function-value arity, closure parameter irrefutability, stable nested witness policy, and checked stdlib protocol stubs. The v0.4 baseline is later extended additively by §19 (runtime primitives — toolchain-only, no grammar change). No known user-facing open gaps remain at the time of this release. See [`18-change-history.md`](./18-change-history.md) for the full v0.1 → v0.2 → v0.3 → v0.4 evolution.
 
 **Companion documents.**
 
@@ -32,6 +32,7 @@ This directory holds the specification, split into per-section files for easier 
 - [16. I/O Protocol](./16-io-protocol.md)
 - [17. Display and Format Protocol](./17-display-and-format-protocol.md)
 - [18. Change History](./18-change-history.md)
+- [19. Runtime Primitives](./19-runtime-primitives.md) — toolchain-only sublanguage; not part of the user prelude
 
 ## Reading order
 

--- a/OSTY_GRAMMAR_v0.4.md
+++ b/OSTY_GRAMMAR_v0.4.md
@@ -21,6 +21,24 @@ v0.3/v0.4 변경을 통합하여 단일 규범 문서로 재구성.
   닫는 baseline 이며, 자세한 결정은 `SPEC_GAPS.md` 와
   `LANG_SPEC_v0.4/18-change-history.md` 를 따른다.
 
+### v0.4 minor: runtime sublanguage (G19)
+
+- **EBNF 변경 0건.** §19 (runtime primitives) 가 추가되지만
+  새 token, 새 키워드, 새 production 모두 없다. 기존 `Annotation`
+  rule (R 규칙 § Part 2 의 `Annotation ::= '#' '[' IDENT
+  AnnotationArgs? ']'`) 와 fixed annotation set 매커니즘만 재사용한다.
+- 어노테이션 집합이 `#[json]`, `#[deprecated]` 에서 6 개 (`#[intrinsic]`,
+  `#[pod]`, `#[repr(...)]`, `#[export("...")]`, `#[c_abi]`, `#[no_alloc]`)
+  더해진다. 인자 형식은 기존 R 규칙 (key/value literal | bare flag)
+  안에서 처리. 진단은 `E0770`/`E0771`/`E0772` (control-flow 가 이미
+  쓰는 `E0760-E0769` 다음 free band).
+- 새 opaque type `RawPtr` 와 marker interface `Pod` 는 모두
+  type-system 레이어에서 추가되며, parser 의 type production 변경은
+  없다 (보통 식별자로 받아 resolver 가 의미를 부여).
+- Privilege gate 는 parser 가 아니라 resolver/checker 책임이다 — 일반
+  사용자 코드에서 위 어노테이션·타입·`std.runtime.*` import 를 사용하면
+  `E0770` 으로 거부되며 parser 는 변경 없이 그대로 통과시킨다.
+
 ### v0.2 → v0.3
 
 - **R25 확장**: `ClosureParam ::= LetPattern (':' Type)?` — closure

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -3,8 +3,9 @@
 `LANG_SPEC_v0.4/` + `OSTY_GRAMMAR_v0.4.md` 기준.
 
 **v0.4 시점 open gap: 없음.** v0.3 의 구현·진단 경계가 부드럽던
-항목(G13-G18)을 v0.4 에서 모두 결정했다. 새 open gap 이 발견되면
-본 문서에 G19 부터 추가.
+항목(G13-G18)을 v0.4 에서 모두 결정했다. v0.4 baseline 위에 G19
+(runtime sublanguage) 가 additive minor 로 결정되어 §19 에
+명시되었다. 다음 새 gap 은 G20 부터 부여한다.
 
 스펙은 v0.2 부터 폴더 구조이다. §X (X = 1..18) 는 `LANG_SPEC_v0.4/NN-*.md`
 파일. §10 의 서브섹션은 `LANG_SPEC_v0.4/10-standard-library/NN-*.md`.
@@ -32,6 +33,7 @@ v0.4 의 초점은 새 문법을 크게 늘리는 것이 아니라, v0.3 에서 
 | **G16** | closure parameter patterns | closure parameter 는 `LetPattern (':' Type)?` 이되 irrefutable pattern 만 허용한다. ident, wildcard, tuple, struct, nested irrefutable 조합은 허용하고 literal/range/variant/or pattern 은 `E0741`. | decided |
 | **G17** | nested pattern witness diagnostics | exhaustiveness witness 는 한 개의 최소 missing pattern 만 출력한다. tuple/struct 는 좌측부터 첫 missing component 를 구체화하고 나머지는 `_`; closed enum/Option/Result payload 는 재귀 witness, 열린 타입은 `_`; guard arm 은 coverage 에 기여하지 않는다. | decided |
 | **G18** | stdlib protocol executable stubs | §10/§15/§16/§17 protocol 은 checked signature stubs 우선으로 관리한다. bodies 는 dummy 여도 parse/resolve/check 되는 `.osty` stub 이어야 하며, runtime/gen parity 는 language gap 이 아니라 implementation backlog 로 분리한다. | decided |
+| **G19** | runtime sublanguage capability surface | C 로 작성된 GC/allocator (`internal/backend/runtime/osty_runtime.c`) 를 Osty 로 셀프호스트할 수 있도록, **package-gated** 한 작은 surface 를 v0.4 에 additive minor 로 더한다. 사용자 prelude/문법은 변경 없음. opaque type `RawPtr` + marker trait `Pod` + 6 개 어노테이션 (`#[intrinsic]`, `#[pod]`, `#[repr(c)]`, `#[export("...")]`, `#[c_abi]`, `#[no_alloc]`) + `std.runtime.raw.*` 13 개 intrinsic (null/fromBits/bits/alloc/free/zero/copy/offset/read/write/cas/sizeOf/alignOf). 진단 `E0770` / `E0771` / `E0772` 추가. safepoint ABI 는 §19.10 에 명시 (compiler-emitted root array). | decided |
 
 ### Final v0.4 Decisions
 
@@ -47,6 +49,7 @@ front-end 에서 finite 하게 잡을 수 있을 것, 에러 메시지가 안정
 | **G16** | closure parameter 는 `LetPattern (':' Type)?` 를 구현하되 **irrefutable pattern 만** 허용한다. 허용: ident, wildcard, tuple, struct pattern against struct, nested irrefutable 조합. 금지: enum variant, range, literal-only match, refutable or-pattern. 실패 시 `E0741`. | v0.3 스펙과 일치하고 `let` destructuring 규칙을 재사용할 수 있다. refutable closure params 를 허용하지 않아 호출 실패 경로가 생기지 않는다. | parser/gen parity 확인, checker irrefutable predicate + tests 추가. |
 | **G17** | witness 진단은 **한 개의 최소 missing pattern** 만 출력한다. tuple/struct 는 좌측부터 첫 missing component 를 구체화하고 나머지는 `_` 로 둔다. enum/Option/Result payload 는 닫힌 타입이면 재귀 witness, 열린 타입이면 `_`. guard arm 은 coverage 에 기여하지 않는다. | 완벽한 pattern set 출력보다 안정적이고 읽기 쉽다. 현재 exhaustiveness 알고리즘과 잘 맞는다. | `findWitness` stringification 규칙 고정. nested tuple/struct/variant tests 추가. |
 | **G18** | stdlib protocol 은 v0.4 에서 **checked signature stubs 우선**으로 간다. bodies 는 dummy 여도 parse/resolve/check 되는 `.osty` stub 이어야 한다. 구현 없는 런타임 동작은 gen/runtime backlog 로 분리하고, protocol signature 모호성만 G 번호로 승격한다. | 언어/프론트엔드 결정과 런타임 구현을 분리한다. 스펙 drift 를 테스트가 바로 잡게 한다. | `TestAllSignatureStubsCheck` 가 모든 embedded stub 의 parse/resolve/check 를 검증. `std.thread` Handle 생성 body 의 G13 `E0743` 만 예외. |
+| **G19** | **Runtime sublanguage** 을 v0.4 baseline 에 additive minor 로 더한다. 새 surface 는 (a) opaque pointer-shaped type `RawPtr` (Pod, GC traceless), (b) compiler-decided marker interface `Pod`, (c) 어노테이션 6 개 — `#[intrinsic]`/`#[pod]`/`#[repr(c)]`/`#[export("name")]`/`#[c_abi]`/`#[no_alloc]`, (d) `std.runtime.raw` 의 13 개 intrinsic (`null`/`fromBits`/`bits`/`alloc`/`free`/`zero`/`copy`/`offset`/`read`/`write`/`cas`/`sizeOf`/`alignOf`), (e) §19.10 의 compiler-emitted root array safepoint ABI. **Gate 는 package path** 로만 — `std.runtime.*` 또는 toolchain workspace 안의 `[capabilities] runtime = true` 패키지만 사용 가능. 일반 사용자 코드에서 사용 시 `E0770`. `#[pod]` shape 위반은 `E0771`. `#[no_alloc]` 본문에서 managed allocation 발견 (또는 `cas` 의 invalid type size) 은 `E0772`. | (1) GC 를 Osty 로 셀프호스트하려면 raw memory + 주소 산술 + Pod load/store + C ABI export + "본문에서 절대 alloc 안함" 증명 + caller-emitted root array 가 필수다. (2) 사용자 prelude 에 `unsafe` 를 노출하지 않는 cleanest path 는 Rust `core::intrinsics` 와 같은 package-gated surface. (3) 새 grammar token 0 개, 새 키워드 0 개 → v0.4 grammar freeze 유지. (4) Pod 는 generic struct 의 경우 `T: Pod` bound 강제 (per-instantiation 은 v0.5 후보). (5) `cas` 는 `sizeOf<T> ∈ {1,2,4,8,16}` + 자연 정렬 제약. (6) `Option<T: Pod>` 은 Pod 이므로 runtime code 에서 `RawPtr?` 를 자유롭게 쓰지만, `#[c_abi]` 함수 반환 타입으로는 사용 불가 (allocator-failure 는 `null()` sentinel). | §19 새 챕터 작성 (10 개 sub-section). §2.1 / §2.6 / §3.8 / §14 / §18 cross-ref 추가. checker 에 (a) `E0770` privilege gate (annotation/type/import 모두), (b) `E0771` Pod shape 검사 + generic bound 검사, (c) `E0772` no_alloc 본문 walker + `cas` size 검사, (d) `Pod` 자동 derivation (primitives + `#[pod] #[repr(c)]` struct + tuple + `Option<T:Pod>`). lowering 에 (a) `raw.*` intrinsic 13 개 의 LLVM mapping 표 §19.7, (b) `#[c_abi]` → LLVM `ccc` calling conv, (c) `#[export]` → external linkage + `dso_local` preemption + exact symbol, (d) `read` 에 `freeze`. `std.runtime.raw` stdlib package + `osty_rt_alloc_aligned` shim 을 `internal/backend/runtime/raw_alloc_shim.c` 에 unconditionally 링크. 기존 `osty_runtime.c` ABI (alloc_v1/free... safepoint_v1/post_write_v1/...) 보존 테스트는 `internal/backend/llvm_runtime_gc_test.go` 를 그대로 통과시킴. manifest schema 의 `[capabilities] runtime = true` 는 §10/§11/§13 manifest reference 의 다음 minor 에 동기화. |
 
 ### Closed during v0.4 prep
 


### PR DESCRIPTION
## Summary

Adds `LANG_SPEC_v0.4/19-runtime-primitives.md`, an **additive minor** that lets the toolchain self-host the GC currently in C (`internal/backend/runtime/osty_runtime.c`) without exposing any user-facing `unsafe` surface. **Spec only — zero code changes.**

This is "step 1" of the GC self-hosting plan. Future PRs add the checker, the lowering, the `std.runtime.raw` stdlib package, and finally the Osty rewrite of `osty_runtime.c`.

## What §19 adds

All package-gated to `std.runtime.*` or workspace packages with `[capabilities] runtime = true`:

- **Opaque type `RawPtr`** (Pod, GC-traceless, `Equal+Hashable`, no `Ordered`)
- **Compiler-derived marker trait `Pod`** — primitives, `#[pod] #[repr(c)]` structs, tuples of Pod, `Option<T: Pod>`. Generic structs require `T: Pod` bound at decl-site.
- **6 annotations**: `#[intrinsic]`, `#[pod]`, `#[repr(c)]`, `#[export("name")]`, `#[c_abi]`, `#[no_alloc]`
- **13 intrinsics in `std.runtime.raw`**: `null`, `fromBits`, `bits`, `alloc`, `free`, `zero`, `copy`, `offset`, `read<T:Pod>`, `write<T:Pod>`, `cas<T:Pod>`, `sizeOf`, `alignOf`
- **§19.10 safepoint contract** — caller-emitted root array; the runtime walks an array, not the stack

**Diagnostics**: `E0770` (privilege violation), `E0771` (Pod shape rejection), `E0772` (`#[no_alloc]` body alloc, or invalid `cas` type size). Allocated in `E0770-E0779` because `internal/diag/codes.go` already uses `E0760-E0769` for control-flow.

## Why this is additive (not a v0.5 break)

- **0 grammar changes** — no new tokens, no new keywords, no EBNF edits. The existing `#[name(args)]` annotation rule (R-rules in `OSTY_GRAMMAR_v0.4.md`) is reused.
- **0 changes to user-reachable surface** — all 6 annotations, both new types, and the `std.runtime.*` import are rejected with `E0770` outside privileged packages.
- **v0.4 grammar freeze preserved.**
- **§14 `unsafe` exclusion preserved** — this is package-gated, not a user `unsafe` block.

## Files touched

| File | Change |
|---|---|
| `LANG_SPEC_v0.4/19-runtime-primitives.md` | new chapter, 10 sub-sections |
| `LANG_SPEC_v0.4/02-type-system.md` | `RawPtr`/`Pod` entry-points in §2.1 / §2.6 |
| `LANG_SPEC_v0.4/03-declarations.md` | §3.8 annotation table extended |
| `LANG_SPEC_v0.4/14-excluded-features.md` | clarify `unsafe` exclusion vs §19 gate |
| `LANG_SPEC_v0.4/18-change-history.md` | §18.0 v0.4 minor entry |
| `LANG_SPEC_v0.4/README.md` | ToC + status line |
| `OSTY_GRAMMAR_v0.4.md` | "v0.4 minor: runtime sublanguage (G19)" decision log |
| `SPEC_GAPS.md` | G19 in Resolved + Final Decisions |

## Review process

This spec was written, then audited by an independent agent. The audit found 6 BLOCKERs and 11+ MAJOR issues — all addressed in the same patch before this PR. Notable fixes:

- **E0760-E0762 collided** with existing control-flow codes → renumbered to `E0770-E0772`
- `Option<T: Pod>` permitted in `#[no_alloc]` (originally over-restricted)
- Generic struct `Pod` bound rule (M1)
- `cas` size constraint `{1,2,4,8,16}` + natural alignment (M5)
- `posix_memalign` does not zero — `alloc` contract corrected to "uninitialized" (M8)
- §19.10 safepoint ABI added — without this, an Osty-side `safepoint_v1` could not see the root array
- `#[ccc]` → `#[c_abi]` (readable for non-LLVM toolchain authors)
- `RawPtr.fromBits`/`bits` added to intrinsic list (originally referenced but undeclared)

## Test plan

- [ ] Spec reads cleanly end-to-end (no broken cross-refs)
- [ ] No stale `E0760-E0762` or `#[ccc]` references anywhere (grep verified)
- [ ] No conflict with v0.4 grammar freeze (verified — 0 EBNF edits)
- [ ] G19 entry consistent across `SPEC_GAPS.md` Resolved + Final Decisions tables
- [ ] §19 cross-refs (§2.1, §2.6, §3.8, §9, §12, §14) all valid

## Out of scope for this PR

Subsequent PRs land:
1. `#[no_alloc]` checker (the most fundamental piece — should be the first code PR)
2. Resolver privilege gate (`E0770`) and `Pod` shape checker (`E0771`)
3. LLVM lowering for the 13 `raw.*` intrinsics + `#[c_abi]` + `#[export]`
4. `std.runtime.raw` stdlib package + `osty_rt_alloc_aligned` shim
5. `examples/gc/lib.osty` rewrite using the new primitives → eventual replacement of `osty_runtime.c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)