### PR TITLE
feat(llvmgen): 컨테이너 + 문자열 + 클로저 방출 primitive Osty 소유로 이전

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -799,6 +799,27 @@ bool osty_rt_strings_Equal(const char *left, const char *right) {
     return strcmp(left, right) == 0;
 }
 
+int64_t osty_rt_strings_ByteLen(const char *value) {
+    if (value == NULL) {
+        return 0;
+    }
+    return (int64_t)strlen(value);
+}
+
+const char *osty_rt_strings_Concat(const char *left, const char *right) {
+    size_t left_len = (left == NULL) ? 0 : strlen(left);
+    size_t right_len = (right == NULL) ? 0 : strlen(right);
+    char *out = (char *)osty_gc_allocate_managed(left_len + right_len + 1, OSTY_GC_KIND_STRING, "runtime.strings.concat", NULL, NULL);
+    if (left_len != 0) {
+        memcpy(out, left, left_len);
+    }
+    if (right_len != 0) {
+        memcpy(out + left_len, right, right_len);
+    }
+    out[left_len + right_len] = '\0';
+    return out;
+}
+
 bool osty_rt_strings_HasPrefix(const char *value, const char *prefix) {
     size_t prefix_len;
     if (value == NULL || prefix == NULL) {

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -292,6 +292,394 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	}
 }
 
+func TestGeneratedListRuntimeSymbolsAreOstyOwned(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"new", llvmListRuntimeNewSymbol(), "osty_rt_list_new"},
+		{"len", llvmListRuntimeLenSymbol(), "osty_rt_list_len"},
+		{"push_i64", llvmListRuntimePushSymbol("i64"), "osty_rt_list_push_i64"},
+		{"push_f64", llvmListRuntimePushSymbol("f64"), "osty_rt_list_push_f64"},
+		{"get_ptr", llvmListRuntimeGetSymbol("ptr"), "osty_rt_list_get_ptr"},
+		{"set_i1", llvmListRuntimeSetSymbol("i1"), "osty_rt_list_set_i1"},
+		{"sorted_i64", llvmListRuntimeSortedSymbol("i64", false), "osty_rt_list_sorted_i64"},
+		{"sorted_string", llvmListRuntimeSortedSymbol("ptr", true), "osty_rt_list_sorted_string"},
+		{"sorted_unsupported", llvmListRuntimeSortedSymbol("%MyStruct", false), ""},
+		{"to_set_f64", llvmListRuntimeToSetSymbol("double", false), "osty_rt_list_to_set_f64"},
+		{"to_set_string", llvmListRuntimeToSetSymbol("ptr", true), "osty_rt_list_to_set_string"},
+		{"to_set_unsupported", llvmListRuntimeToSetSymbol("%MyStruct", false), ""},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Fatalf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestGeneratedListElementSuffixMatchesRuntimeAbi(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"i64", "i64"},
+		{"i1", "i1"},
+		{"ptr", "ptr"},
+		{"double", "f64"},
+		{"", "ptr"},
+		{"%MyStruct", "_MyStruct"},
+		{"<4 x i32>", "_4_x_i32_"},
+	}
+	for _, c := range cases {
+		if got := llvmListElementSuffix(c.in); got != c.want {
+			t.Fatalf("llvmListElementSuffix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	typed := []string{"i64", "i1", "double", "ptr"}
+	for _, t0 := range typed {
+		if !llvmListUsesTypedRuntime(t0) {
+			t.Fatalf("llvmListUsesTypedRuntime(%q) = false, want true", t0)
+		}
+	}
+	for _, t0 := range []string{"", "%MyStruct", "float"} {
+		if llvmListUsesTypedRuntime(t0) {
+			t.Fatalf("llvmListUsesTypedRuntime(%q) = true, want false", t0)
+		}
+	}
+}
+
+func TestGeneratedListRuntimeDeclarationsAreOstyOwned(t *testing.T) {
+	decls := strings.Join(llvmListRuntimeDeclarations(), "\n")
+
+	want := []string{
+		"declare ptr @osty_rt_list_new()",
+		"declare i64 @osty_rt_list_len(ptr)",
+		"declare void @osty_rt_list_push_i64(ptr, i64)",
+		"declare void @osty_rt_list_push_i1(ptr, i1)",
+		"declare void @osty_rt_list_push_f64(ptr, double)",
+		"declare void @osty_rt_list_push_ptr(ptr, ptr)",
+		"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+		"declare i1 @osty_rt_list_get_i1(ptr, i64)",
+		"declare double @osty_rt_list_get_f64(ptr, i64)",
+		"declare ptr @osty_rt_list_get_ptr(ptr, i64)",
+		"declare void @osty_rt_list_set_i64(ptr, i64, i64)",
+		"declare void @osty_rt_list_set_i1(ptr, i64, i1)",
+		"declare void @osty_rt_list_set_f64(ptr, i64, double)",
+		"declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
+	}
+	for _, w := range want {
+		assertGeneratedIRContains(t, decls, w)
+	}
+}
+
+func TestGeneratedListBasicSmokeIR(t *testing.T) {
+	ir := llvmSmokeListBasicIR("/tmp/list_basic.osty")
+
+	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/list_basic.osty\"")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_list_new()")
+	assertGeneratedIRContains(t, ir, "declare i64 @osty_rt_list_len(ptr)")
+	assertGeneratedIRContains(t, ir, "declare void @osty_rt_list_push_i64(ptr, i64)")
+	assertGeneratedIRContains(t, ir, "declare i64 @osty_rt_list_get_i64(ptr, i64)")
+	assertGeneratedIRContains(t, ir, "%t0 = call ptr @osty_rt_list_new()")
+	assertGeneratedIRContains(t, ir, "call void @osty_rt_list_push_i64(ptr %t0, i64 10)")
+	assertGeneratedIRContains(t, ir, "call void @osty_rt_list_push_i64(ptr %t0, i64 20)")
+	assertGeneratedIRContains(t, ir, "call void @osty_rt_list_push_i64(ptr %t0, i64 30)")
+	assertGeneratedIRContains(t, ir, "= call i64 @osty_rt_list_len(ptr %t0)")
+	assertGeneratedIRContains(t, ir, "= call i64 @osty_rt_list_get_i64(ptr %t0, i64 1)")
+	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGeneratedClosureEnvTypeNameJoinsTags(t *testing.T) {
+	cases := []struct {
+		tags []string
+		want string
+	}{
+		{[]string{"ptr"}, "ClosureEnv.ptr"},
+		{[]string{"ptr", "i64"}, "ClosureEnv.ptr.i64"},
+		{[]string{"ptr", "i64", "double", "ptr"}, "ClosureEnv.ptr.i64.double.ptr"},
+	}
+	for _, c := range cases {
+		if got := llvmClosureEnvTypeName(c.tags); got != c.want {
+			t.Fatalf("llvmClosureEnvTypeName(%v) = %q, want %q", c.tags, got, c.want)
+		}
+	}
+}
+
+func TestGeneratedClosureEnvTypeDefRendersStruct(t *testing.T) {
+	got := llvmClosureEnvTypeDef("ClosureEnv.ptr.i64", []string{"ptr", "i64"})
+	want := "%ClosureEnv.ptr.i64 = type { ptr, i64 }"
+	if got != want {
+		t.Fatalf("llvmClosureEnvTypeDef = %q, want %q", got, want)
+	}
+}
+
+func TestGeneratedClosureThunkNameIsOstyOwned(t *testing.T) {
+	if got := llvmClosureThunkName("double_val"); got != "__osty_closure_thunk_double_val" {
+		t.Fatalf("llvmClosureThunkName = %q", got)
+	}
+	if got := llvmClosureThunkName("add"); got != "__osty_closure_thunk_add" {
+		t.Fatalf("llvmClosureThunkName = %q", got)
+	}
+}
+
+func TestGeneratedClosureThunkDefinitionForwardsArgs(t *testing.T) {
+	def := llvmClosureThunkDefinition("double_val", "i64", []string{"i64"})
+
+	assertGeneratedIRContains(t, def, "define private i64 @__osty_closure_thunk_double_val(ptr %env, i64 %arg0)")
+	assertGeneratedIRContains(t, def, "%ret = call i64 @double_val(i64 %arg0)")
+	assertGeneratedIRContains(t, def, "ret i64 %ret")
+}
+
+func TestGeneratedClosureThunkDefinitionVoidReturn(t *testing.T) {
+	def := llvmClosureThunkDefinition("noop", "void", []string{})
+
+	assertGeneratedIRContains(t, def, "define private void @__osty_closure_thunk_noop(ptr %env)")
+	assertGeneratedIRContains(t, def, "call void @noop()")
+	assertGeneratedIRContains(t, def, "ret void")
+	if strings.Contains(def, "%ret = call") {
+		t.Fatalf("void thunk should not bind a return register\nIR:\n%s", def)
+	}
+}
+
+func TestGeneratedClosureBareFnEnvTypeDefIsOneSlot(t *testing.T) {
+	got := llvmClosureBareFnEnvTypeDef()
+	want := "%ClosureEnv.ptr = type { ptr }"
+	if got != want {
+		t.Fatalf("llvmClosureBareFnEnvTypeDef = %q, want %q", got, want)
+	}
+}
+
+func TestGeneratedClosureThunkSmokeIR(t *testing.T) {
+	ir := llvmSmokeClosureThunkIR("/tmp/closure_thunk.osty")
+
+	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/closure_thunk.osty\"")
+	assertGeneratedIRContains(t, ir, "%ClosureEnv.ptr = type { ptr }")
+	assertGeneratedIRContains(t, ir, "define i64 @double_val(i64 %x)")
+	assertGeneratedIRContains(t, ir, "define private i64 @__osty_closure_thunk_double_val(ptr %env, i64 %arg0)")
+	assertGeneratedIRContains(t, ir, "%ret = call i64 @double_val(i64 %arg0)")
+	assertGeneratedIRContains(t, ir, "define i32 @main()")
+	assertGeneratedIRContains(t, ir, "%t0 = alloca %ClosureEnv.ptr")
+	assertGeneratedIRContains(t, ir, "store ptr @__osty_closure_thunk_double_val, ptr %t1")
+	assertGeneratedIRContains(t, ir, "= call i64 (ptr, i64) ")
+	assertGeneratedIRContains(t, ir, "(ptr %t0, i64 21)")
+	assertGeneratedIRContains(t, ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 ")
+	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGeneratedClosureBasicSmokeIR(t *testing.T) {
+	ir := llvmSmokeClosureBasicIR("/tmp/closure_basic.osty")
+
+	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/closure_basic.osty\"")
+	assertGeneratedIRContains(t, ir, "%ClosureEnv.ptr.i64 = type { ptr, i64 }")
+	assertGeneratedIRContains(t, ir, "define i64 @closure_body(ptr %env)")
+	assertGeneratedIRContains(t, ir, "getelementptr %ClosureEnv.ptr.i64, ptr %env, i32 0, i32 1")
+	assertGeneratedIRContains(t, ir, "= load i64, ptr ")
+	assertGeneratedIRContains(t, ir, "define i32 @main()")
+	assertGeneratedIRContains(t, ir, "%t0 = alloca %ClosureEnv.ptr.i64")
+	assertGeneratedIRContains(t, ir, "%t1 = getelementptr %ClosureEnv.ptr.i64, ptr %t0, i32 0, i32 0")
+	assertGeneratedIRContains(t, ir, "store ptr @closure_body, ptr %t1")
+	assertGeneratedIRContains(t, ir, "%t2 = getelementptr %ClosureEnv.ptr.i64, ptr %t0, i32 0, i32 1")
+	assertGeneratedIRContains(t, ir, "store i64 42, ptr %t2")
+	assertGeneratedIRContains(t, ir, "= load ptr, ptr ")
+	assertGeneratedIRContains(t, ir, "= call i64 (ptr) ")
+	assertGeneratedIRContains(t, ir, "(ptr %t0)")
+	assertGeneratedIRContains(t, ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 ")
+	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGeneratedSetRuntimeSymbolsAreOstyOwned(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"new", llvmSetRuntimeNewSymbol(), "osty_rt_set_new"},
+		{"len", llvmSetRuntimeLenSymbol(), "osty_rt_set_len"},
+		{"to_list", llvmSetRuntimeToListSymbol(), "osty_rt_set_to_list"},
+		{"contains_i64", llvmSetRuntimeContainsSymbol("i64", false), "osty_rt_set_contains_i64"},
+		{"insert_f64", llvmSetRuntimeInsertSymbol("double", false), "osty_rt_set_insert_f64"},
+		{"remove_string", llvmSetRuntimeRemoveSymbol("ptr", true), "osty_rt_set_remove_string"},
+		{"insert_bytes", llvmSetRuntimeInsertSymbol("", false), "osty_rt_set_insert_bytes"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Fatalf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestGeneratedSetRuntimeDeclarationsAreOstyOwned(t *testing.T) {
+	decls := strings.Join(llvmSetRuntimeDeclarations(), "\n")
+
+	want := []string{
+		"declare ptr @osty_rt_set_new(i64)",
+		"declare i64 @osty_rt_set_len(ptr)",
+		"declare ptr @osty_rt_set_to_list(ptr)",
+		"declare i1 @osty_rt_set_contains_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_contains_string(ptr, ptr)",
+		"declare i1 @osty_rt_set_insert_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_insert_f64(ptr, double)",
+		"declare i1 @osty_rt_set_insert_string(ptr, ptr)",
+		"declare i1 @osty_rt_set_remove_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_remove_string(ptr, ptr)",
+	}
+	for _, w := range want {
+		assertGeneratedIRContains(t, decls, w)
+	}
+}
+
+func TestGeneratedSetBasicSmokeIR(t *testing.T) {
+	ir := llvmSmokeSetBasicIR("/tmp/set_basic.osty")
+
+	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/set_basic.osty\"")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_set_new(i64)")
+	assertGeneratedIRContains(t, ir, "declare i1 @osty_rt_set_insert_i64(ptr, i64)")
+	assertGeneratedIRContains(t, ir, "declare i1 @osty_rt_set_contains_i64(ptr, i64)")
+	assertGeneratedIRContains(t, ir, "declare i1 @osty_rt_set_remove_i64(ptr, i64)")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_set_to_list(ptr)")
+	assertGeneratedIRContains(t, ir, "%t0 = call ptr @osty_rt_set_new(i64 1)")
+	assertGeneratedIRContains(t, ir, "%t1 = call i1 @osty_rt_set_insert_i64(ptr %t0, i64 10)")
+	assertGeneratedIRContains(t, ir, "= call i1 @osty_rt_set_contains_i64(ptr %t0, i64 20)")
+	assertGeneratedIRContains(t, ir, "= call i1 @osty_rt_set_remove_i64(ptr %t0, i64 20)")
+	assertGeneratedIRContains(t, ir, "= call i64 @osty_rt_set_len(ptr %t0)")
+	assertGeneratedIRContains(t, ir, "= call ptr @osty_rt_set_to_list(ptr %t0)")
+	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"equal", llvmStringRuntimeEqualSymbol(), "osty_rt_strings_Equal"},
+		{"hasPrefix", llvmStringRuntimeHasPrefixSymbol(), "osty_rt_strings_HasPrefix"},
+		{"split", llvmStringRuntimeSplitSymbol(), "osty_rt_strings_Split"},
+		{"concat", llvmStringRuntimeConcatSymbol(), "osty_rt_strings_Concat"},
+		{"byteLen", llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Fatalf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestGeneratedStringRuntimeDeclarationsAreOstyOwned(t *testing.T) {
+	decls := strings.Join(llvmStringRuntimeDeclarations(), "\n")
+
+	want := []string{
+		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"declare i64 @osty_rt_strings_ByteLen(ptr)",
+	}
+	for _, w := range want {
+		assertGeneratedIRContains(t, decls, w)
+	}
+}
+
+func TestGeneratedStringConcatSmokeIR(t *testing.T) {
+	ir := llvmSmokeStringConcatIR("/tmp/string_concat.osty")
+
+	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/string_concat.osty\"")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+	assertGeneratedIRContains(t, ir, "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)")
+	assertGeneratedIRContains(t, ir, "declare i64 @osty_rt_strings_ByteLen(ptr)")
+	assertGeneratedIRContains(t, ir, "@.str0 = private unnamed_addr constant [8 x i8] c\"hello, \\00\"")
+	assertGeneratedIRContains(t, ir, "@.str1 = private unnamed_addr constant [5 x i8] c\"osty\\00\"")
+	assertGeneratedIRContains(t, ir, "%t0 = call ptr @osty_rt_strings_Concat(ptr @.str0, ptr @.str1)")
+	assertGeneratedIRContains(t, ir, "%t1 = call i1 @osty_rt_strings_HasPrefix(ptr %t0, ptr @.str0)")
+	assertGeneratedIRContains(t, ir, "%t2 = call i64 @osty_rt_strings_ByteLen(ptr %t0)")
+	assertGeneratedIRContains(t, ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %t2)")
+	assertGeneratedIRContains(t, ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %t0)")
+	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGeneratedMapRuntimeSymbolsAreOstyOwned(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"new", llvmMapRuntimeNewSymbol(), "osty_rt_map_new"},
+		{"len", llvmMapRuntimeLenSymbol(), "osty_rt_map_len"},
+		{"keys", llvmMapRuntimeKeysSymbol(), "osty_rt_map_keys"},
+		{"contains_i64", llvmMapRuntimeContainsSymbol("i64", false), "osty_rt_map_contains_i64"},
+		{"insert_string", llvmMapRuntimeInsertSymbol("ptr", true), "osty_rt_map_insert_string"},
+		{"remove_f64", llvmMapRuntimeRemoveSymbol("double", false), "osty_rt_map_remove_f64"},
+		{"get_or_abort_ptr", llvmMapRuntimeGetOrAbortSymbol("ptr", false), "osty_rt_map_get_or_abort_ptr"},
+		{"insert_bytes", llvmMapRuntimeInsertSymbol("", false), "osty_rt_map_insert_bytes"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Fatalf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestGeneratedMapKeySuffixMatchesRuntimeAbi(t *testing.T) {
+	cases := []struct {
+		typ      string
+		isString bool
+		want     string
+	}{
+		{"i64", false, "i64"},
+		{"i1", false, "i1"},
+		{"double", false, "f64"},
+		{"ptr", false, "ptr"},
+		{"ptr", true, "string"},
+		{"i64", true, "string"},
+		{"", false, "bytes"},
+		{"%MyStruct", false, "bytes"},
+	}
+	for _, c := range cases {
+		if got := llvmMapKeySuffix(c.typ, c.isString); got != c.want {
+			t.Fatalf("llvmMapKeySuffix(%q, %v) = %q, want %q", c.typ, c.isString, got, c.want)
+		}
+	}
+}
+
+func TestGeneratedMapRuntimeDeclarationsAreOstyOwned(t *testing.T) {
+	decls := strings.Join(llvmMapRuntimeDeclarations(), "\n")
+
+	want := []string{
+		"declare ptr @osty_rt_map_new()",
+		"declare i64 @osty_rt_map_len(ptr)",
+		"declare ptr @osty_rt_map_keys(ptr)",
+		"declare i1 @osty_rt_map_contains_i64(ptr, i64)",
+		"declare i1 @osty_rt_map_contains_string(ptr, ptr)",
+		"declare void @osty_rt_map_insert_i64(ptr, i64, ptr)",
+		"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
+		"declare i1 @osty_rt_map_remove_i64(ptr, i64)",
+		"declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)",
+		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
+	}
+	for _, w := range want {
+		assertGeneratedIRContains(t, decls, w)
+	}
+}
+
+func TestGeneratedMapBasicSmokeIR(t *testing.T) {
+	ir := llvmSmokeMapBasicIR("/tmp/map_basic.osty")
+
+	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/map_basic.osty\"")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_map_new()")
+	assertGeneratedIRContains(t, ir, "declare void @osty_rt_map_insert_i64(ptr, i64, ptr)")
+	assertGeneratedIRContains(t, ir, "declare i1 @osty_rt_map_contains_i64(ptr, i64)")
+	assertGeneratedIRContains(t, ir, "declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)")
+	assertGeneratedIRContains(t, ir, "%t0 = call ptr @osty_rt_map_new()")
+	assertGeneratedIRContains(t, ir, "%t1 = alloca i64")
+	assertGeneratedIRContains(t, ir, "store i64 42, ptr %t1")
+	assertGeneratedIRContains(t, ir, "call void @osty_rt_map_insert_i64(ptr %t0, i64 7, ptr %t1)")
+	assertGeneratedIRContains(t, ir, "= call i1 @osty_rt_map_contains_i64(ptr %t0, i64 7)")
+	assertGeneratedIRContains(t, ir, "call void @osty_rt_map_get_or_abort_i64(ptr %t0, i64 7, ptr")
+	assertGeneratedIRContains(t, ir, "= call i64 @osty_rt_map_len(ptr %t0)")
+	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
 func TestGenerateLeavesRawStringGlobalsUnmanagedUntilHeapLowering(t *testing.T) {
 	ir := generateLLVMForTest(t, `
 fn main() {

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -4,16 +4,17 @@
 // per-symbol forward declarations, and the container runtime symbol tables
 // (osty_rt_list_* / osty_rt_map_* / osty_rt_set_*) + their ABI-kind policy.
 //
-// NOTE(osty-migration): the runtime symbol tables and `containerAbiKind` /
-// `mapSetKeySuffix` / `listUsesTypedRuntime` / `listRuntimeSymbolSuffix` are
-// all pure-policy (no AST dependency) and are the **first Phase B Osty
-// migration target**. See toolchain/llvmgen.osty and the hand-synced Go
-// mirrors in internal/llvmgen/support_snapshot.go.
+// NOTE(osty-migration): the container runtime policy (`*RuntimeSymbol`,
+// `containerAbiKind`, `mapSetKeySuffix`, `listUsesTypedRuntime`,
+// `listRuntimeSymbolSuffix`) is Osty-owned — every function below is a
+// thin wrapper over the `llvm*` helpers generated from
+// toolchain/llvmgen.osty and mirrored in support_snapshot.go. The
+// wrappers stay here as a stable call surface for MIR generator code;
+// changing the policy means editing the Osty source.
 package llvmgen
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/osty/osty/internal/ast"
 )
@@ -311,49 +312,23 @@ func listRuntimeGetBytesV1Symbol() string {
 }
 
 func listRuntimePushSymbol(elemTyp string) string {
-	return "osty_rt_list_push_" + listRuntimeSymbolSuffix(elemTyp)
+	return llvmListRuntimePushSymbol(llvmListElementSuffix(elemTyp))
 }
 
 func listRuntimeGetSymbol(elemTyp string) string {
-	return "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemTyp)
+	return llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
 }
 
 func listRuntimeSetSymbol(elemTyp string) string {
-	return "osty_rt_list_set_" + listRuntimeSymbolSuffix(elemTyp)
+	return llvmListRuntimeSetSymbol(llvmListElementSuffix(elemTyp))
 }
 
 func listRuntimeSortedSymbol(elemTyp string, elemString bool) string {
-	if elemString {
-		return "osty_rt_list_sorted_string"
-	}
-	switch elemTyp {
-	case "i64":
-		return "osty_rt_list_sorted_i64"
-	case "i1":
-		return "osty_rt_list_sorted_i1"
-	case "double":
-		return "osty_rt_list_sorted_f64"
-	default:
-		return ""
-	}
+	return llvmListRuntimeSortedSymbol(elemTyp, elemString)
 }
 
 func listRuntimeToSetSymbol(elemTyp string, elemString bool) string {
-	if elemString {
-		return "osty_rt_list_to_set_string"
-	}
-	switch elemTyp {
-	case "i64":
-		return "osty_rt_list_to_set_i64"
-	case "i1":
-		return "osty_rt_list_to_set_i1"
-	case "double":
-		return "osty_rt_list_to_set_f64"
-	case "ptr":
-		return "osty_rt_list_to_set_ptr"
-	default:
-		return ""
-	}
+	return llvmListRuntimeToSetSymbol(elemTyp, elemString)
 }
 
 func mapRuntimeNewSymbol() string {
@@ -361,19 +336,19 @@ func mapRuntimeNewSymbol() string {
 }
 
 func mapRuntimeContainsSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_contains_" + mapSetKeySuffix(keyTyp, keyString)
+	return llvmMapRuntimeContainsSymbol(keyTyp, keyString)
 }
 
 func mapRuntimeInsertSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_insert_" + mapSetKeySuffix(keyTyp, keyString)
+	return llvmMapRuntimeInsertSymbol(keyTyp, keyString)
 }
 
 func mapRuntimeRemoveSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_remove_" + mapSetKeySuffix(keyTyp, keyString)
+	return llvmMapRuntimeRemoveSymbol(keyTyp, keyString)
 }
 
 func mapRuntimeGetOrAbortSymbol(keyTyp string, keyString bool) string {
-	return "osty_rt_map_get_or_abort_" + mapSetKeySuffix(keyTyp, keyString)
+	return llvmMapRuntimeGetOrAbortSymbol(keyTyp, keyString)
 }
 
 func mapRuntimeKeysSymbol() string {
@@ -389,15 +364,15 @@ func setRuntimeLenSymbol() string {
 }
 
 func setRuntimeContainsSymbol(elemTyp string, elemString bool) string {
-	return "osty_rt_set_contains_" + mapSetKeySuffix(elemTyp, elemString)
+	return llvmSetRuntimeContainsSymbol(elemTyp, elemString)
 }
 
 func setRuntimeInsertSymbol(elemTyp string, elemString bool) string {
-	return "osty_rt_set_insert_" + mapSetKeySuffix(elemTyp, elemString)
+	return llvmSetRuntimeInsertSymbol(elemTyp, elemString)
 }
 
 func setRuntimeRemoveSymbol(elemTyp string, elemString bool) string {
-	return "osty_rt_set_remove_" + mapSetKeySuffix(elemTyp, elemString)
+	return llvmSetRuntimeRemoveSymbol(elemTyp, elemString)
 }
 
 func setRuntimeToListSymbol() string {
@@ -409,50 +384,13 @@ func containerAbiKind(typ string, isString bool) int {
 }
 
 func mapSetKeySuffix(typ string, isString bool) string {
-	if isString {
-		return "string"
-	}
-	switch typ {
-	case "i64":
-		return "i64"
-	case "i1":
-		return "i1"
-	case "double":
-		return "f64"
-	case "ptr":
-		return "ptr"
-	default:
-		return "bytes"
-	}
+	return llvmMapKeySuffix(typ, isString)
 }
 
 func listUsesTypedRuntime(elemTyp string) bool {
-	switch elemTyp {
-	case "i64", "i1", "double", "ptr":
-		return true
-	default:
-		return false
-	}
+	return llvmListUsesTypedRuntime(elemTyp)
 }
 
 func listRuntimeSymbolSuffix(typ string) string {
-	switch typ {
-	case "i64", "i1", "ptr":
-		return typ
-	case "double":
-		return "f64"
-	}
-	var b strings.Builder
-	for i := 0; i < len(typ); i++ {
-		c := typ[i]
-		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
-			b.WriteByte(c)
-			continue
-		}
-		b.WriteByte('_')
-	}
-	if b.Len() == 0 {
-		return "ptr"
-	}
-	return b.String()
+	return llvmListElementSuffix(typ)
 }

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -212,6 +212,10 @@ func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:161:5
+func llvmSlotAsPtr(slot *LlvmValue) *LlvmValue {
+	return &LlvmValue{typ: "ptr", name: slot.name, pointer: false}
+}
+
 func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
 	// Osty: examples/selfhost-core/llvmgen.osty:166:5
 	ptr := llvmNextTemp(emitter)
@@ -838,6 +842,22 @@ func llvmRenderModuleWithGcRuntime(sourcePath string, target string, typeDefs []
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmGcRuntimeDeclarations(), definitions)
 }
 
+func llvmRenderModuleWithListRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmListRuntimeDeclarations(), definitions)
+}
+
+func llvmRenderModuleWithMapRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmMapRuntimeDeclarations(), definitions)
+}
+
+func llvmRenderModuleWithSetRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmSetRuntimeDeclarations(), definitions)
+}
+
+func llvmRenderModuleWithStringRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmStringRuntimeDeclarations(), definitions)
+}
+
 // Osty: examples/selfhost-core/llvmgen.osty:581:1
 func llvmRenderModuleWithRuntimeDeclarations(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, runtimeDeclarations []string, definitions []string) string {
 	// Osty: examples/selfhost-core/llvmgen.osty:589:5
@@ -1358,6 +1378,51 @@ func llvmListRuntimeToSetI64Symbol() string {
 	return "osty_rt_list_to_set_i64"
 }
 
+// Osty: toolchain/llvmgen.osty (parametric push symbol builder)
+func llvmListRuntimePushSymbol(suffix string) string {
+	return "osty_rt_list_push_" + suffix
+}
+
+func llvmListRuntimeGetSymbol(suffix string) string {
+	return "osty_rt_list_get_" + suffix
+}
+
+func llvmListRuntimeSetSymbol(suffix string) string {
+	return "osty_rt_list_set_" + suffix
+}
+
+func llvmListRuntimeSortedSymbol(elemTyp string, isString bool) string {
+	if isString {
+		return "osty_rt_list_sorted_string"
+	}
+	switch elemTyp {
+	case "i64":
+		return "osty_rt_list_sorted_i64"
+	case "i1":
+		return "osty_rt_list_sorted_i1"
+	case "double":
+		return "osty_rt_list_sorted_f64"
+	}
+	return ""
+}
+
+func llvmListRuntimeToSetSymbol(elemTyp string, isString bool) string {
+	if isString {
+		return "osty_rt_list_to_set_string"
+	}
+	switch elemTyp {
+	case "i64":
+		return "osty_rt_list_to_set_i64"
+	case "i1":
+		return "osty_rt_list_to_set_i1"
+	case "double":
+		return "osty_rt_list_to_set_f64"
+	case "ptr":
+		return "osty_rt_list_to_set_ptr"
+	}
+	return ""
+}
+
 // Osty: toolchain/llvmgen.osty:1108:1
 func llvmMapRuntimeNewSymbol() string {
 	return "osty_rt_map_new"
@@ -1366,6 +1431,43 @@ func llvmMapRuntimeNewSymbol() string {
 // Osty: toolchain/llvmgen.osty:1112:1
 func llvmMapRuntimeKeysSymbol() string {
 	return "osty_rt_map_keys"
+}
+
+func llvmMapRuntimeLenSymbol() string {
+	return "osty_rt_map_len"
+}
+
+func llvmMapKeySuffix(typ string, isString bool) string {
+	if isString {
+		return "string"
+	}
+	switch typ {
+	case "i64":
+		return "i64"
+	case "i1":
+		return "i1"
+	case "double":
+		return "f64"
+	case "ptr":
+		return "ptr"
+	}
+	return "bytes"
+}
+
+func llvmMapRuntimeContainsSymbol(keyTyp string, isString bool) string {
+	return "osty_rt_map_contains_" + llvmMapKeySuffix(keyTyp, isString)
+}
+
+func llvmMapRuntimeInsertSymbol(keyTyp string, isString bool) string {
+	return "osty_rt_map_insert_" + llvmMapKeySuffix(keyTyp, isString)
+}
+
+func llvmMapRuntimeRemoveSymbol(keyTyp string, isString bool) string {
+	return "osty_rt_map_remove_" + llvmMapKeySuffix(keyTyp, isString)
+}
+
+func llvmMapRuntimeGetOrAbortSymbol(keyTyp string, isString bool) string {
+	return "osty_rt_map_get_or_abort_" + llvmMapKeySuffix(keyTyp, isString)
 }
 
 // Osty: toolchain/llvmgen.osty:1116:1
@@ -1381,6 +1483,18 @@ func llvmSetRuntimeLenSymbol() string {
 // Osty: toolchain/llvmgen.osty:1124:1
 func llvmSetRuntimeToListSymbol() string {
 	return "osty_rt_set_to_list"
+}
+
+func llvmSetRuntimeContainsSymbol(elemTyp string, isString bool) string {
+	return "osty_rt_set_contains_" + llvmMapKeySuffix(elemTyp, isString)
+}
+
+func llvmSetRuntimeInsertSymbol(elemTyp string, isString bool) string {
+	return "osty_rt_set_insert_" + llvmMapKeySuffix(elemTyp, isString)
+}
+
+func llvmSetRuntimeRemoveSymbol(elemTyp string, isString bool) string {
+	return "osty_rt_set_remove_" + llvmMapKeySuffix(elemTyp, isString)
 }
 
 // Osty: toolchain/llvmgen.osty:1130:1
@@ -1400,6 +1514,469 @@ func llvmContainerAbiKind(typ string, isString bool) int {
 	default:
 		return 6
 	}
+}
+
+func llvmListUsesTypedRuntime(elemTyp string) bool {
+	return elemTyp == "i64" || elemTyp == "i1" || elemTyp == "double" || elemTyp == "ptr"
+}
+
+func llvmListElementSuffix(typ string) string {
+	switch typ {
+	case "i64", "i1", "ptr":
+		return typ
+	case "double":
+		return "f64"
+	}
+	out := ""
+	for _, c := range typ {
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
+			out += string(c)
+			continue
+		}
+		out += "_"
+	}
+	if out == "" {
+		return "ptr"
+	}
+	return out
+}
+
+func llvmListRuntimeDeclarations() []string {
+	return []string{
+		"declare ptr @osty_rt_list_new()",
+		"declare i64 @osty_rt_list_len(ptr)",
+		"declare void @osty_rt_list_push_i64(ptr, i64)",
+		"declare void @osty_rt_list_push_i1(ptr, i1)",
+		"declare void @osty_rt_list_push_f64(ptr, double)",
+		"declare void @osty_rt_list_push_ptr(ptr, ptr)",
+		"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+		"declare i1 @osty_rt_list_get_i1(ptr, i64)",
+		"declare double @osty_rt_list_get_f64(ptr, i64)",
+		"declare ptr @osty_rt_list_get_ptr(ptr, i64)",
+		"declare void @osty_rt_list_set_i64(ptr, i64, i64)",
+		"declare void @osty_rt_list_set_i1(ptr, i64, i1)",
+		"declare void @osty_rt_list_set_f64(ptr, i64, double)",
+		"declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
+	}
+}
+
+func llvmListNew(emitter *LlvmEmitter) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_list_new", make([]*LlvmValue, 0))
+}
+
+func llvmListLen(emitter *LlvmEmitter, list *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_list_len", []*LlvmValue{list})
+}
+
+func llvmListPushI64(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_push_i64", []*LlvmValue{list, value})
+}
+
+func llvmListPushI1(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_push_i1", []*LlvmValue{list, value})
+}
+
+func llvmListPushF64(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_push_f64", []*LlvmValue{list, value})
+}
+
+func llvmListPushPtr(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_push_ptr", []*LlvmValue{list, value})
+}
+
+func llvmListGetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_list_get_i64", []*LlvmValue{list, index})
+}
+
+func llvmListGetI1(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_list_get_i1", []*LlvmValue{list, index})
+}
+
+func llvmListGetF64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "double", "osty_rt_list_get_f64", []*LlvmValue{list, index})
+}
+
+func llvmListGetPtr(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_list_get_ptr", []*LlvmValue{list, index})
+}
+
+func llvmListSetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_set_i64", []*LlvmValue{list, index, value})
+}
+
+func llvmListSetI1(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_set_i1", []*LlvmValue{list, index, value})
+}
+
+func llvmListSetF64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_set_f64", []*LlvmValue{list, index, value})
+}
+
+func llvmListSetPtr(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_list_set_ptr", []*LlvmValue{list, index, value})
+}
+
+func llvmMapRuntimeDeclarations() []string {
+	return []string{
+		"declare ptr @osty_rt_map_new()",
+		"declare i64 @osty_rt_map_len(ptr)",
+		"declare ptr @osty_rt_map_keys(ptr)",
+		"declare i1 @osty_rt_map_contains_i64(ptr, i64)",
+		"declare i1 @osty_rt_map_contains_i1(ptr, i1)",
+		"declare i1 @osty_rt_map_contains_f64(ptr, double)",
+		"declare i1 @osty_rt_map_contains_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_map_contains_string(ptr, ptr)",
+		"declare void @osty_rt_map_insert_i64(ptr, i64, ptr)",
+		"declare void @osty_rt_map_insert_i1(ptr, i1, ptr)",
+		"declare void @osty_rt_map_insert_f64(ptr, double, ptr)",
+		"declare void @osty_rt_map_insert_ptr(ptr, ptr, ptr)",
+		"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
+		"declare i1 @osty_rt_map_remove_i64(ptr, i64)",
+		"declare i1 @osty_rt_map_remove_i1(ptr, i1)",
+		"declare i1 @osty_rt_map_remove_f64(ptr, double)",
+		"declare i1 @osty_rt_map_remove_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_map_remove_string(ptr, ptr)",
+		"declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)",
+		"declare void @osty_rt_map_get_or_abort_i1(ptr, i1, ptr)",
+		"declare void @osty_rt_map_get_or_abort_f64(ptr, double, ptr)",
+		"declare void @osty_rt_map_get_or_abort_ptr(ptr, ptr, ptr)",
+		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
+	}
+}
+
+func llvmMapNew(emitter *LlvmEmitter) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_map_new", make([]*LlvmValue, 0))
+}
+
+func llvmMapLen(emitter *LlvmEmitter, m *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_map_len", []*LlvmValue{m})
+}
+
+func llvmMapKeys(emitter *LlvmEmitter, m *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_map_keys", []*LlvmValue{m})
+}
+
+func llvmMapContainsI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_i64", []*LlvmValue{m, key})
+}
+
+func llvmMapContainsI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_i1", []*LlvmValue{m, key})
+}
+
+func llvmMapContainsF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_f64", []*LlvmValue{m, key})
+}
+
+func llvmMapContainsPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_ptr", []*LlvmValue{m, key})
+}
+
+func llvmMapContainsString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_string", []*LlvmValue{m, key})
+}
+
+func llvmMapInsertI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_i64", []*LlvmValue{m, key, valueSlot})
+}
+
+func llvmMapInsertI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_i1", []*LlvmValue{m, key, valueSlot})
+}
+
+func llvmMapInsertF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_f64", []*LlvmValue{m, key, valueSlot})
+}
+
+func llvmMapInsertPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_ptr", []*LlvmValue{m, key, valueSlot})
+}
+
+func llvmMapInsertString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_string", []*LlvmValue{m, key, valueSlot})
+}
+
+func llvmMapRemoveI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_i64", []*LlvmValue{m, key})
+}
+
+func llvmMapRemoveI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_i1", []*LlvmValue{m, key})
+}
+
+func llvmMapRemoveF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_f64", []*LlvmValue{m, key})
+}
+
+func llvmMapRemovePtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_ptr", []*LlvmValue{m, key})
+}
+
+func llvmMapRemoveString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_string", []*LlvmValue{m, key})
+}
+
+func llvmMapGetOrAbortI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i64", []*LlvmValue{m, key, outSlot})
+}
+
+func llvmMapGetOrAbortI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i1", []*LlvmValue{m, key, outSlot})
+}
+
+func llvmMapGetOrAbortF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_f64", []*LlvmValue{m, key, outSlot})
+}
+
+func llvmMapGetOrAbortPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_ptr", []*LlvmValue{m, key, outSlot})
+}
+
+func llvmMapGetOrAbortString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", []*LlvmValue{m, key, outSlot})
+}
+
+func llvmSetRuntimeDeclarations() []string {
+	return []string{
+		"declare ptr @osty_rt_set_new(i64)",
+		"declare i64 @osty_rt_set_len(ptr)",
+		"declare ptr @osty_rt_set_to_list(ptr)",
+		"declare i1 @osty_rt_set_contains_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_contains_i1(ptr, i1)",
+		"declare i1 @osty_rt_set_contains_f64(ptr, double)",
+		"declare i1 @osty_rt_set_contains_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_set_contains_string(ptr, ptr)",
+		"declare i1 @osty_rt_set_insert_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_insert_i1(ptr, i1)",
+		"declare i1 @osty_rt_set_insert_f64(ptr, double)",
+		"declare i1 @osty_rt_set_insert_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_set_insert_string(ptr, ptr)",
+		"declare i1 @osty_rt_set_remove_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_remove_i1(ptr, i1)",
+		"declare i1 @osty_rt_set_remove_f64(ptr, double)",
+		"declare i1 @osty_rt_set_remove_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_set_remove_string(ptr, ptr)",
+	}
+}
+
+func llvmSetNew(emitter *LlvmEmitter, elemKind int) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_set_new", []*LlvmValue{llvmIntLiteral(elemKind)})
+}
+
+func llvmSetLen(emitter *LlvmEmitter, set *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_set_len", []*LlvmValue{set})
+}
+
+func llvmSetToList(emitter *LlvmEmitter, set *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_set_to_list", []*LlvmValue{set})
+}
+
+func llvmSetContainsI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_contains_i64", []*LlvmValue{set, item})
+}
+
+func llvmSetContainsI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_contains_i1", []*LlvmValue{set, item})
+}
+
+func llvmSetContainsF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_contains_f64", []*LlvmValue{set, item})
+}
+
+func llvmSetContainsPtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_contains_ptr", []*LlvmValue{set, item})
+}
+
+func llvmSetContainsString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_contains_string", []*LlvmValue{set, item})
+}
+
+func llvmSetInsertI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_insert_i64", []*LlvmValue{set, item})
+}
+
+func llvmSetInsertI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_insert_i1", []*LlvmValue{set, item})
+}
+
+func llvmSetInsertF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_insert_f64", []*LlvmValue{set, item})
+}
+
+func llvmSetInsertPtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_insert_ptr", []*LlvmValue{set, item})
+}
+
+func llvmSetInsertString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_insert_string", []*LlvmValue{set, item})
+}
+
+func llvmSetRemoveI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_remove_i64", []*LlvmValue{set, item})
+}
+
+func llvmSetRemoveI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_remove_i1", []*LlvmValue{set, item})
+}
+
+func llvmSetRemoveF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_remove_f64", []*LlvmValue{set, item})
+}
+
+func llvmSetRemovePtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_remove_ptr", []*LlvmValue{set, item})
+}
+
+func llvmSetRemoveString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_set_remove_string", []*LlvmValue{set, item})
+}
+
+func llvmClosureEnvTypeName(elemTags []string) string {
+	return "ClosureEnv." + llvmStrings.Join(elemTags, ".")
+}
+
+func llvmClosureEnvTypeDef(name string, elemTypes []string) string {
+	return llvmStructTypeDef(name, elemTypes)
+}
+
+func llvmClosureEnvAlloc(emitter *LlvmEmitter, envTypeName string) *LlvmValue {
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", tmp, envTypeName))
+	return &LlvmValue{typ: "ptr", name: tmp, pointer: false}
+}
+
+func llvmClosureEnvSlotGep(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int) string {
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %%%s, ptr %s, i32 0, i32 %d", tmp, envTypeName, envPtr.name, slotIndex))
+	return tmp
+}
+
+func llvmClosureEnvStoreFn(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, fnSymbol string) {
+	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
+	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", fnSymbol, gep))
+}
+
+func llvmClosureEnvStoreCapture(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int, value *LlvmValue) {
+	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", value.typ, value.name, gep))
+}
+
+func llvmClosureEnvLoadFn(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string) *LlvmValue {
+	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", tmp, gep))
+	return &LlvmValue{typ: "ptr", name: tmp, pointer: false}
+}
+
+func llvmClosureEnvLoadCapture(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int, captureType string) *LlvmValue {
+	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, captureType, gep))
+	return &LlvmValue{typ: captureType, name: tmp, pointer: false}
+}
+
+func llvmClosureCallIndirect(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, returnType string, extraArgs []*LlvmValue) *LlvmValue {
+	fnPtr := llvmClosureEnvLoadFn(emitter, envPtr, envTypeName)
+	args := []*LlvmValue{envPtr}
+	paramTypes := []string{"ptr"}
+	for _, a := range extraArgs {
+		args = append(args, a)
+		paramTypes = append(paramTypes, a.typ)
+	}
+	callType := returnType + " (" + llvmStrings.Join(paramTypes, ", ") + ")"
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", tmp, callType, fnPtr.name, llvmCallArgs(args)))
+	return &LlvmValue{typ: returnType, name: tmp, pointer: false}
+}
+
+func llvmClosureThunkName(symbol string) string {
+	return "__osty_closure_thunk_" + symbol
+}
+
+func llvmClosureThunkDefinition(symbol string, returnType string, paramTypes []string) string {
+	headerParts := []string{"ptr %env"}
+	argParts := make([]string, 0, len(paramTypes))
+	for i, p := range paramTypes {
+		headerParts = append(headerParts, fmt.Sprintf("%s %%arg%d", p, i))
+		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", p, i))
+	}
+	header := llvmStrings.Join(headerParts, ", ")
+	callArgs := llvmStrings.Join(argParts, ", ")
+	thunk := llvmClosureThunkName(symbol)
+	lines := []string{
+		fmt.Sprintf("define private %s @%s(%s) {", returnType, thunk, header),
+		"entry:",
+	}
+	if returnType == "void" {
+		lines = append(lines, fmt.Sprintf("  call void @%s(%s)", symbol, callArgs))
+		lines = append(lines, "  ret void")
+	} else {
+		lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", returnType, symbol, callArgs))
+		lines = append(lines, fmt.Sprintf("  ret %s %%ret", returnType))
+	}
+	lines = append(lines, "}")
+	return llvmStrings.Join(lines, "\n")
+}
+
+func llvmClosureBareFnEnv(emitter *LlvmEmitter, symbol string) *LlvmValue {
+	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
+	env := llvmClosureEnvAlloc(emitter, envTypeName)
+	llvmClosureEnvStoreFn(emitter, env, envTypeName, llvmClosureThunkName(symbol))
+	return env
+}
+
+func llvmClosureBareFnEnvTypeDef() string {
+	return llvmClosureEnvTypeDef(llvmClosureEnvTypeName([]string{"ptr"}), []string{"ptr"})
+}
+
+func llvmStringRuntimeEqualSymbol() string {
+	return "osty_rt_strings_Equal"
+}
+
+func llvmStringRuntimeHasPrefixSymbol() string {
+	return "osty_rt_strings_HasPrefix"
+}
+
+func llvmStringRuntimeSplitSymbol() string {
+	return "osty_rt_strings_Split"
+}
+
+func llvmStringRuntimeConcatSymbol() string {
+	return "osty_rt_strings_Concat"
+}
+
+func llvmStringRuntimeByteLenSymbol() string {
+	return "osty_rt_strings_ByteLen"
+}
+
+func llvmStringRuntimeDeclarations() []string {
+	return []string{
+		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"declare i64 @osty_rt_strings_ByteLen(ptr)",
+	}
+}
+
+func llvmStringEqual(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_strings_Equal", []*LlvmValue{left, right})
+}
+
+func llvmStringHasPrefix(emitter *LlvmEmitter, value *LlvmValue, prefix *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_strings_HasPrefix", []*LlvmValue{value, prefix})
+}
+
+func llvmStringSplit(emitter *LlvmEmitter, value *LlvmValue, sep *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_strings_Split", []*LlvmValue{value, sep})
+}
+
+func llvmStringConcat(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_strings_Concat", []*LlvmValue{left, right})
+}
+
+func llvmStringByteLen(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", []*LlvmValue{value})
 }
 
 func llvmBuiltinType(name string) string {
@@ -1676,6 +2253,123 @@ func llvmSmokeGcRuntimeAbiIR(sourcePath string) string {
 	// Osty: examples/selfhost-core/llvmgen.osty:1173:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGcRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeListBasicIR)
+func llvmSmokeListBasicIR(sourcePath string) string {
+	main := llvmEmitter()
+	list := llvmListNew(main)
+	llvmListPushI64(main, list, llvmIntLiteral(10))
+	llvmListPushI64(main, list, llvmIntLiteral(20))
+	llvmListPushI64(main, list, llvmIntLiteral(30))
+	length := llvmListLen(main, list)
+	llvmPrintlnI64(main, length)
+	second := llvmListGetI64(main, list, llvmIntLiteral(1))
+	llvmPrintlnI64(main, second)
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithListRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeClosureThunkIR)
+func llvmSmokeClosureThunkIR(sourcePath string) string {
+	doubleBody := llvmEmitter()
+	llvmBind(doubleBody, "x", &LlvmValue{typ: "i64", name: "%x", pointer: false})
+	doubled := llvmBinaryI64(doubleBody, "mul", llvmIdent(doubleBody, "x"), llvmIntLiteral(2))
+	llvmReturn(doubleBody, doubled)
+
+	main := llvmEmitter()
+	env := llvmClosureBareFnEnv(main, "double_val")
+	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
+	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{llvmIntLiteral(21)})
+	llvmPrintlnI64(main, result)
+	llvmReturnI32Zero(main)
+
+	return llvmRenderModuleWithGlobalsAndTypes(
+		sourcePath,
+		"",
+		[]string{llvmClosureBareFnEnvTypeDef()},
+		main.stringGlobals,
+		[]string{
+			llvmRenderFunction("i64", "double_val", []*LlvmParam{llvmParam("x", "i64")}, doubleBody.body),
+			llvmClosureThunkDefinition("double_val", "i64", []string{"i64"}),
+			llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body),
+		},
+	)
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeClosureBasicIR)
+func llvmSmokeClosureBasicIR(sourcePath string) string {
+	envTypeName := llvmClosureEnvTypeName([]string{"ptr", "i64"})
+	typeDef := llvmClosureEnvTypeDef(envTypeName, []string{"ptr", "i64"})
+
+	body := llvmEmitter()
+	llvmBind(body, "env", &LlvmValue{typ: "ptr", name: "%env", pointer: false})
+	envArg := llvmIdent(body, "env")
+	captured := llvmClosureEnvLoadCapture(body, envArg, envTypeName, 1, "i64")
+	llvmReturn(body, captured)
+
+	main := llvmEmitter()
+	env := llvmClosureEnvAlloc(main, envTypeName)
+	llvmClosureEnvStoreFn(main, env, envTypeName, "closure_body")
+	llvmClosureEnvStoreCapture(main, env, envTypeName, 1, llvmIntLiteral(42))
+	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{})
+	llvmPrintlnI64(main, result)
+	llvmReturnI32Zero(main)
+
+	return llvmRenderModuleWithGlobalsAndTypes(
+		sourcePath,
+		"",
+		[]string{typeDef},
+		main.stringGlobals,
+		[]string{
+			llvmRenderFunction("i64", "closure_body", []*LlvmParam{llvmParam("env", "ptr")}, body.body),
+			llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body),
+		},
+	)
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeSetBasicIR)
+func llvmSmokeSetBasicIR(sourcePath string) string {
+	main := llvmEmitter()
+	set := llvmSetNew(main, llvmContainerAbiKind("i64", false))
+	_ = llvmSetInsertI64(main, set, llvmIntLiteral(10))
+	_ = llvmSetInsertI64(main, set, llvmIntLiteral(20))
+	_ = llvmSetInsertI64(main, set, llvmIntLiteral(30))
+	_ = llvmSetContainsI64(main, set, llvmIntLiteral(20))
+	_ = llvmSetRemoveI64(main, set, llvmIntLiteral(20))
+	llvmPrintlnI64(main, llvmSetLen(main, set))
+	_ = llvmSetToList(main, set)
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithSetRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeStringConcatIR)
+func llvmSmokeStringConcatIR(sourcePath string) string {
+	main := llvmEmitter()
+	left := llvmStringLiteral(main, "hello, ")
+	right := llvmStringLiteral(main, "osty")
+	joined := llvmStringConcat(main, left, right)
+	_ = llvmStringHasPrefix(main, joined, left)
+	length := llvmStringByteLen(main, joined)
+	llvmPrintlnI64(main, length)
+	llvmPrintlnString(main, joined)
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithStringRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeMapBasicIR)
+func llvmSmokeMapBasicIR(sourcePath string) string {
+	main := llvmEmitter()
+	m := llvmMapNew(main)
+	valueSlot := llvmMutableLetSlot(main, "value", llvmIntLiteral(42))
+	llvmMapInsertI64(main, m, llvmIntLiteral(7), llvmSlotAsPtr(valueSlot))
+	_ = llvmMapContainsI64(main, m, llvmIntLiteral(7))
+	outSlot := llvmMutableLetSlot(main, "out", llvmIntLiteral(0))
+	llvmMapGetOrAbortI64(main, m, llvmIntLiteral(7), llvmSlotAsPtr(outSlot))
+	llvmPrintlnI64(main, llvmLoad(main, outSlot))
+	llvmPrintlnI64(main, llvmMapLen(main, m))
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithMapRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:1184:5

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -176,6 +176,15 @@ pub fn llvmStore(emitter: LlvmEmitter, slot: LlvmValue, value: LlvmValue) {
     emitter.body.push("  store {value.typ} {value.name}, ptr {slot.name}")
 }
 
+/// Reinterpret a slot (`{typ: T, pointer: true}` as produced by
+/// `llvmMutableLetSlot`) as a plain `ptr`-typed call argument. Runtime
+/// ABIs that accept out-pointers (Map insert/get_or_abort, composite
+/// List push_bytes, …) need the register address passed as `ptr`, not
+/// the value type the slot represents.
+pub fn llvmSlotAsPtr(slot: LlvmValue) -> LlvmValue {
+    LlvmValue { typ: "ptr", name: slot.name, pointer: false }
+}
+
 pub fn llvmAssign(emitter: LlvmEmitter, name: String, value: LlvmValue) -> Bool {
     let lookup = llvmLookup(emitter, name)
     if !(lookup.found) || !(lookup.value.pointer) || lookup.value.typ != value.typ {
@@ -592,6 +601,74 @@ pub fn llvmRenderModuleWithGcRuntime(
         typeDefs,
         stringGlobals,
         llvmGcRuntimeDeclarations(),
+        definitions,
+    )
+}
+
+pub fn llvmRenderModuleWithListRuntime(
+    sourcePath: String,
+    target: String,
+    typeDefs: List<String>,
+    stringGlobals: List<LlvmStringGlobal>,
+    definitions: List<String>,
+) -> String {
+    llvmRenderModuleWithRuntimeDeclarations(
+        sourcePath,
+        target,
+        typeDefs,
+        stringGlobals,
+        llvmListRuntimeDeclarations(),
+        definitions,
+    )
+}
+
+pub fn llvmRenderModuleWithMapRuntime(
+    sourcePath: String,
+    target: String,
+    typeDefs: List<String>,
+    stringGlobals: List<LlvmStringGlobal>,
+    definitions: List<String>,
+) -> String {
+    llvmRenderModuleWithRuntimeDeclarations(
+        sourcePath,
+        target,
+        typeDefs,
+        stringGlobals,
+        llvmMapRuntimeDeclarations(),
+        definitions,
+    )
+}
+
+pub fn llvmRenderModuleWithSetRuntime(
+    sourcePath: String,
+    target: String,
+    typeDefs: List<String>,
+    stringGlobals: List<LlvmStringGlobal>,
+    definitions: List<String>,
+) -> String {
+    llvmRenderModuleWithRuntimeDeclarations(
+        sourcePath,
+        target,
+        typeDefs,
+        stringGlobals,
+        llvmSetRuntimeDeclarations(),
+        definitions,
+    )
+}
+
+pub fn llvmRenderModuleWithStringRuntime(
+    sourcePath: String,
+    target: String,
+    typeDefs: List<String>,
+    stringGlobals: List<LlvmStringGlobal>,
+    definitions: List<String>,
+) -> String {
+    llvmRenderModuleWithRuntimeDeclarations(
+        sourcePath,
+        target,
+        typeDefs,
+        stringGlobals,
+        llvmStringRuntimeDeclarations(),
         definitions,
     )
 }
@@ -1105,12 +1182,114 @@ pub fn llvmListRuntimeToSetI64Symbol() -> String {
     "osty_rt_list_to_set_i64"
 }
 
+/// Parametric symbol builder for `osty_rt_list_push_<suffix>`. `suffix`
+/// must come from `llvmListElementSuffix` so struct element types are
+/// already sanitized to identifier-safe form.
+pub fn llvmListRuntimePushSymbol(suffix: String) -> String {
+    "osty_rt_list_push_{suffix}"
+}
+
+pub fn llvmListRuntimeGetSymbol(suffix: String) -> String {
+    "osty_rt_list_get_{suffix}"
+}
+
+pub fn llvmListRuntimeSetSymbol(suffix: String) -> String {
+    "osty_rt_list_set_{suffix}"
+}
+
+/// Pick the `osty_rt_list_sorted_*` entry point for an element LLVM
+/// type. Returns `""` when no typed runtime exists — callers use the
+/// empty string as the "unsupported element type" signal and emit a
+/// diagnostic rather than coercing to a wrong variant. Mirrors
+/// `listRuntimeSortedSymbol` in internal/llvmgen/runtime_ffi.go.
+pub fn llvmListRuntimeSortedSymbol(elemTyp: String, isString: Bool) -> String {
+    if isString {
+        return "osty_rt_list_sorted_string"
+    }
+    if elemTyp == "i64" {
+        return "osty_rt_list_sorted_i64"
+    }
+    if elemTyp == "i1" {
+        return "osty_rt_list_sorted_i1"
+    }
+    if elemTyp == "double" {
+        return "osty_rt_list_sorted_f64"
+    }
+    ""
+}
+
+/// Pick the `osty_rt_list_to_set_*` entry point for an element LLVM
+/// type. Returns `""` when no typed runtime exists — same "unsupported"
+/// convention as `llvmListRuntimeSortedSymbol`. Mirrors
+/// `listRuntimeToSetSymbol` in internal/llvmgen/runtime_ffi.go.
+pub fn llvmListRuntimeToSetSymbol(elemTyp: String, isString: Bool) -> String {
+    if isString {
+        return "osty_rt_list_to_set_string"
+    }
+    if elemTyp == "i64" {
+        return "osty_rt_list_to_set_i64"
+    }
+    if elemTyp == "i1" {
+        return "osty_rt_list_to_set_i1"
+    }
+    if elemTyp == "double" {
+        return "osty_rt_list_to_set_f64"
+    }
+    if elemTyp == "ptr" {
+        return "osty_rt_list_to_set_ptr"
+    }
+    ""
+}
+
 pub fn llvmMapRuntimeNewSymbol() -> String {
     "osty_rt_map_new"
 }
 
 pub fn llvmMapRuntimeKeysSymbol() -> String {
     "osty_rt_map_keys"
+}
+
+pub fn llvmMapRuntimeLenSymbol() -> String {
+    "osty_rt_map_len"
+}
+
+/// Encode a Map key LLVM type into the runtime symbol suffix. String
+/// keys collapse to `"string"` regardless of the underlying LLVM type
+/// (the runtime hashes the null-terminated payload, not the pointer).
+/// Mirrors `mapSetKeySuffix` in internal/llvmgen/runtime_ffi.go.
+pub fn llvmMapKeySuffix(typ: String, isString: Bool) -> String {
+    if isString {
+        return "string"
+    }
+    if typ == "i64" {
+        return "i64"
+    }
+    if typ == "i1" {
+        return "i1"
+    }
+    if typ == "double" {
+        return "f64"
+    }
+    if typ == "ptr" {
+        return "ptr"
+    }
+    "bytes"
+}
+
+pub fn llvmMapRuntimeContainsSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_contains_{llvmMapKeySuffix(keyTyp, isString)}"
+}
+
+pub fn llvmMapRuntimeInsertSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_insert_{llvmMapKeySuffix(keyTyp, isString)}"
+}
+
+pub fn llvmMapRuntimeRemoveSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_remove_{llvmMapKeySuffix(keyTyp, isString)}"
+}
+
+pub fn llvmMapRuntimeGetOrAbortSymbol(keyTyp: String, isString: Bool) -> String {
+    "osty_rt_map_get_or_abort_{llvmMapKeySuffix(keyTyp, isString)}"
 }
 
 pub fn llvmSetRuntimeNewSymbol() -> String {
@@ -1123,6 +1302,23 @@ pub fn llvmSetRuntimeLenSymbol() -> String {
 
 pub fn llvmSetRuntimeToListSymbol() -> String {
     "osty_rt_set_to_list"
+}
+
+/// Set element suffix follows the same policy as Map keys: scalar types
+/// map to the typed runtime variants; anything else (including struct
+/// elements) collapses to `"bytes"` and the caller must switch to the
+/// composite path. Delegates to `llvmMapKeySuffix` to keep the two
+/// container key policies in lockstep.
+pub fn llvmSetRuntimeContainsSymbol(elemTyp: String, isString: Bool) -> String {
+    "osty_rt_set_contains_{llvmMapKeySuffix(elemTyp, isString)}"
+}
+
+pub fn llvmSetRuntimeInsertSymbol(elemTyp: String, isString: Bool) -> String {
+    "osty_rt_set_insert_{llvmMapKeySuffix(elemTyp, isString)}"
+}
+
+pub fn llvmSetRuntimeRemoveSymbol(elemTyp: String, isString: Bool) -> String {
+    "osty_rt_set_remove_{llvmMapKeySuffix(elemTyp, isString)}"
 }
 
 /// Container ABI kind code used by the runtime to pick the right traversal
@@ -1144,6 +1340,599 @@ pub fn llvmContainerAbiKind(typ: String, isString: Bool) -> Int {
         return 4
     }
     6
+}
+
+/// True when a List element LLVM type is serviced by the typed runtime
+/// ABI (`_i64`/`_i1`/`_f64`/`_ptr`). Non-matching types go through the
+/// composite `osty_rt_list_*_bytes_v1` path. Mirrors
+/// `listUsesTypedRuntime` in internal/llvmgen/runtime_ffi.go.
+pub fn llvmListUsesTypedRuntime(elemTyp: String) -> Bool {
+    elemTyp == "i64" || elemTyp == "i1" || elemTyp == "double" || elemTyp == "ptr"
+}
+
+/// Convert an LLVM element type string to the runtime symbol suffix.
+/// Scalar types map directly (`i64`, `i1`, `ptr`); `double` maps to
+/// `f64`. Anything else is sanitized into an identifier-safe form for
+/// composite struct elements. Mirrors `listRuntimeSymbolSuffix` in
+/// internal/llvmgen/runtime_ffi.go.
+pub fn llvmListElementSuffix(typ: String) -> String {
+    if typ == "i64" || typ == "i1" || typ == "ptr" {
+        return typ
+    }
+    if typ == "double" {
+        return "f64"
+    }
+    let mut out = ""
+    for c in typ.chars() {
+        if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+            out = "{out}{c}"
+            continue
+        }
+        out = "{out}_"
+    }
+    if out == "" {
+        return "ptr"
+    }
+    out
+}
+
+/// LLVM forward declarations for the `osty_rt_list_*` C runtime surface
+/// used by the scalar List<T> codegen path. The native backend emits
+/// these once per module that touches typed lists.
+pub fn llvmListRuntimeDeclarations() -> List<String> {
+    [
+        "declare ptr @osty_rt_list_new()",
+        "declare i64 @osty_rt_list_len(ptr)",
+        "declare void @osty_rt_list_push_i64(ptr, i64)",
+        "declare void @osty_rt_list_push_i1(ptr, i1)",
+        "declare void @osty_rt_list_push_f64(ptr, double)",
+        "declare void @osty_rt_list_push_ptr(ptr, ptr)",
+        "declare i64 @osty_rt_list_get_i64(ptr, i64)",
+        "declare i1 @osty_rt_list_get_i1(ptr, i64)",
+        "declare double @osty_rt_list_get_f64(ptr, i64)",
+        "declare ptr @osty_rt_list_get_ptr(ptr, i64)",
+        "declare void @osty_rt_list_set_i64(ptr, i64, i64)",
+        "declare void @osty_rt_list_set_i1(ptr, i64, i1)",
+        "declare void @osty_rt_list_set_f64(ptr, i64, double)",
+        "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
+    ]
+}
+
+/// Emit `call ptr @osty_rt_list_new()` and return the resulting list
+/// handle. Callers are responsible for any GC root binding the managed
+/// value requires.
+pub fn llvmListNew(emitter: LlvmEmitter) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_list_new", [])
+}
+
+pub fn llvmListLen(emitter: LlvmEmitter, list: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_list_len", [list])
+}
+
+pub fn llvmListPushI64(emitter: LlvmEmitter, list: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_push_i64", [list, value])
+}
+
+pub fn llvmListPushI1(emitter: LlvmEmitter, list: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_push_i1", [list, value])
+}
+
+pub fn llvmListPushF64(emitter: LlvmEmitter, list: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_push_f64", [list, value])
+}
+
+pub fn llvmListPushPtr(emitter: LlvmEmitter, list: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_push_ptr", [list, value])
+}
+
+pub fn llvmListGetI64(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_list_get_i64", [list, index])
+}
+
+pub fn llvmListGetI1(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_list_get_i1", [list, index])
+}
+
+pub fn llvmListGetF64(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "double", "osty_rt_list_get_f64", [list, index])
+}
+
+pub fn llvmListGetPtr(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_list_get_ptr", [list, index])
+}
+
+pub fn llvmListSetI64(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_set_i64", [list, index, value])
+}
+
+pub fn llvmListSetI1(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_set_i1", [list, index, value])
+}
+
+pub fn llvmListSetF64(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_set_f64", [list, index, value])
+}
+
+pub fn llvmListSetPtr(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue, value: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_list_set_ptr", [list, index, value])
+}
+
+/// LLVM forward declarations for the `osty_rt_map_*` C runtime surface.
+/// Map values cross the ABI through caller-allocated out-slots (`ptr`),
+/// so only the 5 key variants (`i64`/`i1`/`f64`/`ptr`/`string`) shape
+/// the declaration set. `osty_rt_map_new` is declared 0-arg to match
+/// the shape the current native backend emits; a typed-constructor
+/// migration is tracked separately.
+pub fn llvmMapRuntimeDeclarations() -> List<String> {
+    [
+        "declare ptr @osty_rt_map_new()",
+        "declare i64 @osty_rt_map_len(ptr)",
+        "declare ptr @osty_rt_map_keys(ptr)",
+        "declare i1 @osty_rt_map_contains_i64(ptr, i64)",
+        "declare i1 @osty_rt_map_contains_i1(ptr, i1)",
+        "declare i1 @osty_rt_map_contains_f64(ptr, double)",
+        "declare i1 @osty_rt_map_contains_ptr(ptr, ptr)",
+        "declare i1 @osty_rt_map_contains_string(ptr, ptr)",
+        "declare void @osty_rt_map_insert_i64(ptr, i64, ptr)",
+        "declare void @osty_rt_map_insert_i1(ptr, i1, ptr)",
+        "declare void @osty_rt_map_insert_f64(ptr, double, ptr)",
+        "declare void @osty_rt_map_insert_ptr(ptr, ptr, ptr)",
+        "declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
+        "declare i1 @osty_rt_map_remove_i64(ptr, i64)",
+        "declare i1 @osty_rt_map_remove_i1(ptr, i1)",
+        "declare i1 @osty_rt_map_remove_f64(ptr, double)",
+        "declare i1 @osty_rt_map_remove_ptr(ptr, ptr)",
+        "declare i1 @osty_rt_map_remove_string(ptr, ptr)",
+        "declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)",
+        "declare void @osty_rt_map_get_or_abort_i1(ptr, i1, ptr)",
+        "declare void @osty_rt_map_get_or_abort_f64(ptr, double, ptr)",
+        "declare void @osty_rt_map_get_or_abort_ptr(ptr, ptr, ptr)",
+        "declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
+    ]
+}
+
+pub fn llvmMapNew(emitter: LlvmEmitter) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_map_new", [])
+}
+
+pub fn llvmMapLen(emitter: LlvmEmitter, map: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_map_len", [map])
+}
+
+pub fn llvmMapKeys(emitter: LlvmEmitter, map: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_map_keys", [map])
+}
+
+pub fn llvmMapContainsI64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_contains_i64", [map, key])
+}
+
+pub fn llvmMapContainsI1(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_contains_i1", [map, key])
+}
+
+pub fn llvmMapContainsF64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_contains_f64", [map, key])
+}
+
+pub fn llvmMapContainsPtr(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_contains_ptr", [map, key])
+}
+
+pub fn llvmMapContainsString(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_contains_string", [map, key])
+}
+
+/// `valueSlot` must be a caller-allocated LLVM pointer (`ptr`) holding
+/// the value bytes. The runtime copies `value_size` bytes from the slot
+/// into its internal bucket — lifting the value through memory is the
+/// only shape that works uniformly for scalars, handles, and structs.
+pub fn llvmMapInsertI64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, valueSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_insert_i64", [map, key, valueSlot])
+}
+
+pub fn llvmMapInsertI1(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, valueSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_insert_i1", [map, key, valueSlot])
+}
+
+pub fn llvmMapInsertF64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, valueSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_insert_f64", [map, key, valueSlot])
+}
+
+pub fn llvmMapInsertPtr(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, valueSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_insert_ptr", [map, key, valueSlot])
+}
+
+pub fn llvmMapInsertString(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, valueSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_insert_string", [map, key, valueSlot])
+}
+
+pub fn llvmMapRemoveI64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_remove_i64", [map, key])
+}
+
+pub fn llvmMapRemoveI1(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_remove_i1", [map, key])
+}
+
+pub fn llvmMapRemoveF64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_remove_f64", [map, key])
+}
+
+pub fn llvmMapRemovePtr(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_remove_ptr", [map, key])
+}
+
+pub fn llvmMapRemoveString(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_map_remove_string", [map, key])
+}
+
+/// `outSlot` must be a caller-allocated LLVM pointer sized for the value
+/// type. The runtime aborts on key-miss and otherwise writes the value
+/// bytes to the slot. Caller loads from `outSlot` to recover the value.
+pub fn llvmMapGetOrAbortI64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, outSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i64", [map, key, outSlot])
+}
+
+pub fn llvmMapGetOrAbortI1(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, outSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i1", [map, key, outSlot])
+}
+
+pub fn llvmMapGetOrAbortF64(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, outSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_get_or_abort_f64", [map, key, outSlot])
+}
+
+pub fn llvmMapGetOrAbortPtr(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, outSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_get_or_abort_ptr", [map, key, outSlot])
+}
+
+pub fn llvmMapGetOrAbortString(emitter: LlvmEmitter, map: LlvmValue, key: LlvmValue, outSlot: LlvmValue) {
+    llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", [map, key, outSlot])
+}
+
+/// LLVM forward declarations for the `osty_rt_set_*` C runtime surface.
+/// Unlike Map, Set items are passed through the typed ABI (by value),
+/// so the declaration set mirrors the 5 key variants directly. The
+/// constructor takes an element-kind tag (`llvmContainerAbiKind`) so
+/// the runtime knows which storage sizing to allocate.
+pub fn llvmSetRuntimeDeclarations() -> List<String> {
+    [
+        "declare ptr @osty_rt_set_new(i64)",
+        "declare i64 @osty_rt_set_len(ptr)",
+        "declare ptr @osty_rt_set_to_list(ptr)",
+        "declare i1 @osty_rt_set_contains_i64(ptr, i64)",
+        "declare i1 @osty_rt_set_contains_i1(ptr, i1)",
+        "declare i1 @osty_rt_set_contains_f64(ptr, double)",
+        "declare i1 @osty_rt_set_contains_ptr(ptr, ptr)",
+        "declare i1 @osty_rt_set_contains_string(ptr, ptr)",
+        "declare i1 @osty_rt_set_insert_i64(ptr, i64)",
+        "declare i1 @osty_rt_set_insert_i1(ptr, i1)",
+        "declare i1 @osty_rt_set_insert_f64(ptr, double)",
+        "declare i1 @osty_rt_set_insert_ptr(ptr, ptr)",
+        "declare i1 @osty_rt_set_insert_string(ptr, ptr)",
+        "declare i1 @osty_rt_set_remove_i64(ptr, i64)",
+        "declare i1 @osty_rt_set_remove_i1(ptr, i1)",
+        "declare i1 @osty_rt_set_remove_f64(ptr, double)",
+        "declare i1 @osty_rt_set_remove_ptr(ptr, ptr)",
+        "declare i1 @osty_rt_set_remove_string(ptr, ptr)",
+    ]
+}
+
+/// Emit `call ptr @osty_rt_set_new(i64 <elemKind>)` where `elemKind` is
+/// the `llvmContainerAbiKind` tag (1=i64, 2=i1, 3=double, 4=ptr,
+/// 5=string). The runtime rejects other kinds at allocation time.
+pub fn llvmSetNew(emitter: LlvmEmitter, elemKind: Int) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_set_new", [llvmIntLiteral(elemKind)])
+}
+
+pub fn llvmSetLen(emitter: LlvmEmitter, set: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_set_len", [set])
+}
+
+pub fn llvmSetToList(emitter: LlvmEmitter, set: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_set_to_list", [set])
+}
+
+pub fn llvmSetContainsI64(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_contains_i64", [set, item])
+}
+
+pub fn llvmSetContainsI1(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_contains_i1", [set, item])
+}
+
+pub fn llvmSetContainsF64(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_contains_f64", [set, item])
+}
+
+pub fn llvmSetContainsPtr(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_contains_ptr", [set, item])
+}
+
+pub fn llvmSetContainsString(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_contains_string", [set, item])
+}
+
+pub fn llvmSetInsertI64(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_insert_i64", [set, item])
+}
+
+pub fn llvmSetInsertI1(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_insert_i1", [set, item])
+}
+
+pub fn llvmSetInsertF64(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_insert_f64", [set, item])
+}
+
+pub fn llvmSetInsertPtr(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_insert_ptr", [set, item])
+}
+
+pub fn llvmSetInsertString(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_insert_string", [set, item])
+}
+
+pub fn llvmSetRemoveI64(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_remove_i64", [set, item])
+}
+
+pub fn llvmSetRemoveI1(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_remove_i1", [set, item])
+}
+
+pub fn llvmSetRemoveF64(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_remove_f64", [set, item])
+}
+
+pub fn llvmSetRemovePtr(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_remove_ptr", [set, item])
+}
+
+pub fn llvmSetRemoveString(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_set_remove_string", [set, item])
+}
+
+/// Build the canonical `ClosureEnv.<tag0>.<tag1>…` type name used by the
+/// closure-env ABI. Slot 0 is the lifted-fn pointer and its tag is
+/// always `"ptr"`; slots 1..N are captures and their tags must be the
+/// LLVM type of each capture (`"i64"`, `"double"`, `"ptr"`, etc.).
+/// Deterministic naming is what lets two closures with the same
+/// capture shape share a single `%type` definition.
+pub fn llvmClosureEnvTypeName(elemTags: List<String>) -> String {
+    "ClosureEnv.{llvmStrings.join(elemTags, ".")}"
+}
+
+/// Render the `%{name} = type { … }` declaration for a closure env.
+/// `elemTypes` must be the same length as the tag list that produced
+/// `name`: the first entry is `"ptr"` (fn slot) and the rest are each
+/// capture's LLVM type.
+pub fn llvmClosureEnvTypeDef(name: String, elemTypes: List<String>) -> String {
+    llvmStructTypeDef(name, elemTypes)
+}
+
+/// Emit `%tN = alloca %ClosureEnv.<sig>` and return the env pointer.
+/// The caller is responsible for storing the lifted-fn pointer and all
+/// captures before the env escapes. Stack allocation matches the
+/// current MIR lowerer policy — closures that outlive the enclosing
+/// frame need a separate heap path (see docs/mir_design.md Stage 3.8).
+pub fn llvmClosureEnvAlloc(emitter: LlvmEmitter, envTypeName: String) -> LlvmValue {
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push("  {tmp} = alloca %{envTypeName}")
+    LlvmValue { typ: "ptr", name: tmp, pointer: false }
+}
+
+fn llvmClosureEnvSlotGep(
+    emitter: LlvmEmitter,
+    envPtr: LlvmValue,
+    envTypeName: String,
+    slotIndex: Int,
+) -> String {
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push(
+        "  {tmp} = getelementptr %{envTypeName}, ptr {envPtr.name}, i32 0, i32 {slotIndex}",
+    )
+    tmp
+}
+
+/// Store the lifted-fn pointer into slot 0 of a closure env. `fnSymbol`
+/// is the LLVM module-level symbol for the closure body (e.g.
+/// `"closure_body_42"`); the helper prepends the `@` for you.
+pub fn llvmClosureEnvStoreFn(
+    emitter: LlvmEmitter,
+    envPtr: LlvmValue,
+    envTypeName: String,
+    fnSymbol: String,
+) {
+    let gep = llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
+    emitter.body.push("  store ptr @{fnSymbol}, ptr {gep}")
+}
+
+/// Store a captured value into `slotIndex` (must be >= 1 — slot 0 is
+/// reserved for the fn pointer). `value.typ` is what the store
+/// instruction will assert.
+pub fn llvmClosureEnvStoreCapture(
+    emitter: LlvmEmitter,
+    envPtr: LlvmValue,
+    envTypeName: String,
+    slotIndex: Int,
+    value: LlvmValue,
+) {
+    let gep = llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
+    emitter.body.push("  store {value.typ} {value.name}, ptr {gep}")
+}
+
+/// Load slot 0 (the lifted-fn pointer) from an env.
+pub fn llvmClosureEnvLoadFn(
+    emitter: LlvmEmitter,
+    envPtr: LlvmValue,
+    envTypeName: String,
+) -> LlvmValue {
+    let gep = llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push("  {tmp} = load ptr, ptr {gep}")
+    LlvmValue { typ: "ptr", name: tmp, pointer: false }
+}
+
+/// Load a captured value from `slotIndex` (>= 1). The caller supplies
+/// the expected LLVM type so the load instruction matches the layout
+/// used at store time.
+pub fn llvmClosureEnvLoadCapture(
+    emitter: LlvmEmitter,
+    envPtr: LlvmValue,
+    envTypeName: String,
+    slotIndex: Int,
+    captureType: String,
+) -> LlvmValue {
+    let gep = llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push("  {tmp} = load {captureType}, ptr {gep}")
+    LlvmValue { typ: captureType, name: tmp, pointer: false }
+}
+
+/// Emit an indirect call through the env: load slot 0 as the fn
+/// pointer, then call it with `envPtr` as the implicit first argument
+/// followed by `extraArgs`. The lifted function must be codegen'd with
+/// the matching signature `(ptr env, ...extraArgs) -> returnType`.
+/// The emitted call carries the full param-type list (`call RET (ptr,
+/// ARGT…) %fn(…)`) so the LLVM verifier can typecheck the callee.
+pub fn llvmClosureCallIndirect(
+    emitter: LlvmEmitter,
+    envPtr: LlvmValue,
+    envTypeName: String,
+    returnType: String,
+    extraArgs: List<LlvmValue>,
+) -> LlvmValue {
+    let fnPtr = llvmClosureEnvLoadFn(emitter, envPtr, envTypeName)
+    let mut args = [envPtr]
+    let mut paramTypes: List<String> = ["ptr"]
+    for arg in extraArgs {
+        args.push(arg)
+        paramTypes.push(arg.typ)
+    }
+    let callType = "{returnType} ({llvmStrings.join(paramTypes, \", \")})"
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push(
+        "  {tmp} = call {callType} {fnPtr.name}({llvmCallArgs(args)})",
+    )
+    LlvmValue { typ: returnType, name: tmp, pointer: false }
+}
+
+/// Canonical symbol name for the private thunk that wraps bare
+/// function `symbol` into the closure-env ABI. Deterministic so a
+/// second reference to the same bare fn reuses the same thunk def.
+pub fn llvmClosureThunkName(symbol: String) -> String {
+    "__osty_closure_thunk_{symbol}"
+}
+
+/// Render the `define private RET @__osty_closure_thunk_<symbol>(ptr
+/// %env, …)` body. Discards `%env`, forwards the user params, and
+/// returns whatever the underlying `@symbol` returns. The resulting
+/// string is ready to be appended to a module's `definitions` list.
+/// `paramTypes` must be the LLVM types of the WRAPPED function's
+/// parameters — the env parameter is prepended by this helper.
+pub fn llvmClosureThunkDefinition(
+    symbol: String,
+    returnType: String,
+    paramTypes: List<String>,
+) -> String {
+    let mut headerParts: List<String> = ["ptr %env"]
+    let mut argParts: List<String> = []
+    let mut i = 0
+    for paramType in paramTypes {
+        headerParts.push("{paramType} %arg{i}")
+        argParts.push("{paramType} %arg{i}")
+        i = i + 1
+    }
+    let header = llvmStrings.join(headerParts, ", ")
+    let callArgs = llvmStrings.join(argParts, ", ")
+    let thunk = llvmClosureThunkName(symbol)
+    let mut lines: List<String> = []
+    lines.push("define private {returnType} @{thunk}({header}) \{")
+    lines.push("entry:")
+    if returnType == "void" {
+        lines.push("  call void @{symbol}({callArgs})")
+        lines.push("  ret void")
+    } else {
+        lines.push("  %ret = call {returnType} @{symbol}({callArgs})")
+        lines.push("  ret {returnType} %ret")
+    }
+    lines.push("\}")
+    llvmStrings.join(lines, "\n")
+}
+
+/// Construct a 1-slot `%ClosureEnv.ptr` around a bare function so it
+/// can flow through code paths that expect a closure value. The thunk
+/// definition must already be emitted (via `llvmClosureThunkDefinition`)
+/// at module level. Callers invoke the returned env with
+/// `llvmClosureCallIndirect` just like any other closure.
+pub fn llvmClosureBareFnEnv(emitter: LlvmEmitter, symbol: String) -> LlvmValue {
+    let envTypeName = llvmClosureEnvTypeName(["ptr"])
+    let env = llvmClosureEnvAlloc(emitter, envTypeName)
+    llvmClosureEnvStoreFn(emitter, env, envTypeName, llvmClosureThunkName(symbol))
+    env
+}
+
+/// Type-def line for the 1-slot closure env used by
+/// `llvmClosureBareFnEnv`. Emit once per module that wraps any bare
+/// function through the thunk ABI.
+pub fn llvmClosureBareFnEnvTypeDef() -> String {
+    llvmClosureEnvTypeDef(llvmClosureEnvTypeName(["ptr"]), ["ptr"])
+}
+
+pub fn llvmStringRuntimeEqualSymbol() -> String {
+    "osty_rt_strings_Equal"
+}
+
+pub fn llvmStringRuntimeHasPrefixSymbol() -> String {
+    "osty_rt_strings_HasPrefix"
+}
+
+pub fn llvmStringRuntimeSplitSymbol() -> String {
+    "osty_rt_strings_Split"
+}
+
+pub fn llvmStringRuntimeConcatSymbol() -> String {
+    "osty_rt_strings_Concat"
+}
+
+pub fn llvmStringRuntimeByteLenSymbol() -> String {
+    "osty_rt_strings_ByteLen"
+}
+
+/// LLVM forward declarations for the `osty_rt_strings_*` C runtime
+/// surface. All string values cross the ABI as null-terminated `ptr`,
+/// and returned strings are GC-managed by the runtime (kind
+/// `OSTY_GC_KIND_STRING`); callers must treat the result as owned by
+/// the managed heap, not by `free`.
+pub fn llvmStringRuntimeDeclarations() -> List<String> {
+    [
+        "declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+        "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
+        "declare ptr @osty_rt_strings_Split(ptr, ptr)",
+        "declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+        "declare i64 @osty_rt_strings_ByteLen(ptr)",
+    ]
+}
+
+pub fn llvmStringEqual(emitter: LlvmEmitter, left: LlvmValue, right: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_strings_Equal", [left, right])
+}
+
+pub fn llvmStringHasPrefix(emitter: LlvmEmitter, value: LlvmValue, prefix: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", "osty_rt_strings_HasPrefix", [value, prefix])
+}
+
+pub fn llvmStringSplit(emitter: LlvmEmitter, value: LlvmValue, sep: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_Split", [value, sep])
+}
+
+pub fn llvmStringConcat(emitter: LlvmEmitter, left: LlvmValue, right: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_Concat", [left, right])
+}
+
+pub fn llvmStringByteLen(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", [value])
 }
 
 pub fn llvmBuiltinType(name: String) -> String {
@@ -1795,6 +2584,208 @@ pub fn llvmSmokeGcRuntimeAbiIR(sourcePath: String) -> String {
     llvmReturnI32Zero(main)
 
     llvmRenderModuleWithGcRuntime(
+        sourcePath,
+        "",
+        [],
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+/// Smoke fixture exercising the bare-fn → thunk → closure-env path. A
+/// user-visible `double_val(i64) -> i64` function is defined, a private
+/// thunk `__osty_closure_thunk_double_val(ptr %env, i64 %arg0)` forwards
+/// to it ignoring env, and `main` wraps the bare fn into a 1-slot env
+/// + invokes it indirectly with argument `21` to print `42`. Covers the
+/// on-demand thunk generation that Osty uses whenever a plain function
+/// flows into a closure-shaped position.
+pub fn llvmSmokeClosureThunkIR(sourcePath: String) -> String {
+    let doubleBody = llvmEmitter()
+    llvmBind(doubleBody, "x", LlvmValue { typ: "i64", name: "%x", pointer: false })
+    let doubled = llvmBinaryI64(
+        doubleBody,
+        "mul",
+        llvmIdent(doubleBody, "x"),
+        llvmIntLiteral(2),
+    )
+    llvmReturn(doubleBody, doubled)
+
+    let main = llvmEmitter()
+    let env = llvmClosureBareFnEnv(main, "double_val")
+    let envTypeName = llvmClosureEnvTypeName(["ptr"])
+    let result = llvmClosureCallIndirect(
+        main,
+        env,
+        envTypeName,
+        "i64",
+        [llvmIntLiteral(21)],
+    )
+    llvmPrintlnI64(main, result)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobalsAndTypes(
+        sourcePath,
+        "",
+        [llvmClosureBareFnEnvTypeDef()],
+        main.stringGlobals,
+        [
+            llvmRenderFunction(
+                "i64",
+                "double_val",
+                [llvmParam("x", "i64")],
+                doubleBody.body,
+            ),
+            llvmClosureThunkDefinition("double_val", "i64", ["i64"]),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+/// Smoke fixture exercising the closure-env ABI end-to-end. Defines a
+/// two-fn module: `closure_body` takes `(ptr env)` and reads its i64
+/// capture from slot 1; `main` allocates a `%ClosureEnv.ptr.i64`, stores
+/// `@closure_body` at slot 0 + `42` at slot 1, then invokes the closure
+/// indirectly through the env pointer. Covers type-def emission, alloca
+/// + GEP + store, and the `call RET (PTYPES) %fn(ENV, …)` form the
+/// verifier expects.
+pub fn llvmSmokeClosureBasicIR(sourcePath: String) -> String {
+    let envTypeName = llvmClosureEnvTypeName(["ptr", "i64"])
+    let typeDef = llvmClosureEnvTypeDef(envTypeName, ["ptr", "i64"])
+
+    let body = llvmEmitter()
+    llvmBind(body, "env", LlvmValue { typ: "ptr", name: "%env", pointer: false })
+    let envArg = llvmIdent(body, "env")
+    let captured = llvmClosureEnvLoadCapture(body, envArg, envTypeName, 1, "i64")
+    llvmReturn(body, captured)
+
+    let main = llvmEmitter()
+    let env = llvmClosureEnvAlloc(main, envTypeName)
+    llvmClosureEnvStoreFn(main, env, envTypeName, "closure_body")
+    llvmClosureEnvStoreCapture(main, env, envTypeName, 1, llvmIntLiteral(42))
+    let result = llvmClosureCallIndirect(main, env, envTypeName, "i64", [])
+    llvmPrintlnI64(main, result)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithGlobalsAndTypes(
+        sourcePath,
+        "",
+        [typeDef],
+        main.stringGlobals,
+        [
+            llvmRenderFunction(
+                "i64",
+                "closure_body",
+                [llvmParam("env", "ptr")],
+                body.body,
+            ),
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+/// Smoke fixture exercising the `Set<Int>` runtime ABI end-to-end:
+/// allocate an i64-tagged set, insert three items, probe contains,
+/// remove one, print length, and materialize the remaining items as a
+/// list via `osty_rt_set_to_list`. Covers the 1-arg constructor and
+/// typed item ABI that distinguish Set from Map's out-pointer shape.
+pub fn llvmSmokeSetBasicIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let set = llvmSetNew(main, llvmContainerAbiKind("i64", false))
+    let _a = llvmSetInsertI64(main, set, llvmIntLiteral(10))
+    let _b = llvmSetInsertI64(main, set, llvmIntLiteral(20))
+    let _c = llvmSetInsertI64(main, set, llvmIntLiteral(30))
+    let _present = llvmSetContainsI64(main, set, llvmIntLiteral(20))
+    let _removed = llvmSetRemoveI64(main, set, llvmIntLiteral(20))
+    llvmPrintlnI64(main, llvmSetLen(main, set))
+    let _keys = llvmSetToList(main, set)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithSetRuntime(
+        sourcePath,
+        "",
+        [],
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+/// Smoke fixture exercising the `osty_rt_strings_*` runtime: build two
+/// literals, concat them, probe equality against the literal prefix,
+/// compute byte length of the concat result, print both. Covers the
+/// `ptr`-returning GC-managed allocation path that distinguishes
+/// strings from the typed scalar runtime.
+pub fn llvmSmokeStringConcatIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let left = llvmStringLiteral(main, "hello, ")
+    let right = llvmStringLiteral(main, "osty")
+    let joined = llvmStringConcat(main, left, right)
+    let prefixed = llvmStringHasPrefix(main, joined, left)
+    let _unused = prefixed
+    let length = llvmStringByteLen(main, joined)
+    llvmPrintlnI64(main, length)
+    llvmPrintlnString(main, joined)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithStringRuntime(
+        sourcePath,
+        "",
+        [],
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+/// Smoke fixture exercising the `Map<Int, Int>` runtime ABI end-to-end:
+/// allocate a map, insert one entry through a caller-allocated value slot,
+/// probe with `contains`, fetch via `get_or_abort`, read length, and print
+/// the stored value. Covers the out-pointer ABI shape that distinguishes
+/// Map from List and feeds golden IR assertions in llvmgen_test.osty.
+pub fn llvmSmokeMapBasicIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let map = llvmMapNew(main)
+    let valueSlot = llvmMutableLetSlot(main, "value", llvmIntLiteral(42))
+    llvmMapInsertI64(main, map, llvmIntLiteral(7), llvmSlotAsPtr(valueSlot))
+    let _present = llvmMapContainsI64(main, map, llvmIntLiteral(7))
+    let outSlot = llvmMutableLetSlot(main, "out", llvmIntLiteral(0))
+    llvmMapGetOrAbortI64(main, map, llvmIntLiteral(7), llvmSlotAsPtr(outSlot))
+    llvmPrintlnI64(main, llvmLoad(main, outSlot))
+    llvmPrintlnI64(main, llvmMapLen(main, map))
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithMapRuntime(
+        sourcePath,
+        "",
+        [],
+        main.stringGlobals,
+        [
+            llvmRenderFunction("i32", "main", [], main.body),
+        ],
+    )
+}
+
+/// Smoke fixture exercising the `List<Int>` runtime ABI end-to-end: allocate a
+/// list, push three i64 values, read the length, fetch index 1, and print both.
+/// Feeds golden IR assertions in llvmgen_test.osty and mirrors the scalar
+/// runtime surface the native backend will drive from AST lowering.
+pub fn llvmSmokeListBasicIR(sourcePath: String) -> String {
+    let main = llvmEmitter()
+    let list = llvmListNew(main)
+    llvmListPushI64(main, list, llvmIntLiteral(10))
+    llvmListPushI64(main, list, llvmIntLiteral(20))
+    llvmListPushI64(main, list, llvmIntLiteral(30))
+    let len = llvmListLen(main, list)
+    llvmPrintlnI64(main, len)
+    let second = llvmListGetI64(main, list, llvmIntLiteral(1))
+    llvmPrintlnI64(main, second)
+    llvmReturnI32Zero(main)
+
+    llvmRenderModuleWithListRuntime(
         sourcePath,
         "",
         [],

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -877,3 +877,305 @@ fn testLlvmSmokeBoolMutableIsOstyOwned() {
     assertLlvmContains(ir, "load i1")
     assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 42)")
 }
+
+fn testLlvmListRuntimeSymbolsAreOstyOwned() {
+    testing.assertEq(llvmListRuntimeNewSymbol(), "osty_rt_list_new")
+    testing.assertEq(llvmListRuntimeLenSymbol(), "osty_rt_list_len")
+    testing.assertEq(llvmListRuntimePushSymbol("i64"), "osty_rt_list_push_i64")
+    testing.assertEq(llvmListRuntimePushSymbol("f64"), "osty_rt_list_push_f64")
+    testing.assertEq(llvmListRuntimePushSymbol("ptr"), "osty_rt_list_push_ptr")
+    testing.assertEq(llvmListRuntimeGetSymbol("i1"), "osty_rt_list_get_i1")
+    testing.assertEq(llvmListRuntimeGetSymbol("ptr"), "osty_rt_list_get_ptr")
+    testing.assertEq(llvmListRuntimeSetSymbol("i64"), "osty_rt_list_set_i64")
+    testing.assertEq(llvmListRuntimeSetSymbol("f64"), "osty_rt_list_set_f64")
+}
+
+fn testLlvmListRuntimeSortedSymbolPicksEntryPoint() {
+    testing.assertEq(llvmListRuntimeSortedSymbol("i64", false), "osty_rt_list_sorted_i64")
+    testing.assertEq(llvmListRuntimeSortedSymbol("i1", false), "osty_rt_list_sorted_i1")
+    testing.assertEq(llvmListRuntimeSortedSymbol("double", false), "osty_rt_list_sorted_f64")
+    testing.assertEq(llvmListRuntimeSortedSymbol("ptr", true), "osty_rt_list_sorted_string")
+    testing.assertEq(llvmListRuntimeSortedSymbol("ptr", false), "")
+    testing.assertEq(llvmListRuntimeSortedSymbol("%MyStruct", false), "")
+}
+
+fn testLlvmListRuntimeToSetSymbolPicksEntryPoint() {
+    testing.assertEq(llvmListRuntimeToSetSymbol("i64", false), "osty_rt_list_to_set_i64")
+    testing.assertEq(llvmListRuntimeToSetSymbol("i1", false), "osty_rt_list_to_set_i1")
+    testing.assertEq(llvmListRuntimeToSetSymbol("double", false), "osty_rt_list_to_set_f64")
+    testing.assertEq(llvmListRuntimeToSetSymbol("ptr", false), "osty_rt_list_to_set_ptr")
+    testing.assertEq(llvmListRuntimeToSetSymbol("ptr", true), "osty_rt_list_to_set_string")
+    testing.assertEq(llvmListRuntimeToSetSymbol("%MyStruct", false), "")
+}
+
+fn testLlvmListElementSuffixMatchesRuntimeAbi() {
+    testing.assertEq(llvmListElementSuffix("i64"), "i64")
+    testing.assertEq(llvmListElementSuffix("i1"), "i1")
+    testing.assertEq(llvmListElementSuffix("ptr"), "ptr")
+    testing.assertEq(llvmListElementSuffix("double"), "f64")
+    testing.assertEq(llvmListElementSuffix(""), "ptr")
+    testing.assertEq(llvmListElementSuffix("%MyStruct"), "_MyStruct")
+    testing.assertEq(llvmListElementSuffix("<4 x i32>"), "_4_x_i32_")
+}
+
+fn testLlvmListUsesTypedRuntime() {
+    testing.assert(llvmListUsesTypedRuntime("i64"))
+    testing.assert(llvmListUsesTypedRuntime("i1"))
+    testing.assert(llvmListUsesTypedRuntime("double"))
+    testing.assert(llvmListUsesTypedRuntime("ptr"))
+    testing.assert(!(llvmListUsesTypedRuntime("%MyStruct")))
+    testing.assert(!(llvmListUsesTypedRuntime("")))
+}
+
+fn testLlvmListRuntimeDeclarationsAreOstyOwned() {
+    let declarations = llvmTestStrings.join(llvmListRuntimeDeclarations(), "\n")
+
+    assertLlvmContains(declarations, "declare ptr @osty_rt_list_new()")
+    assertLlvmContains(declarations, "declare i64 @osty_rt_list_len(ptr)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_push_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_push_i1(ptr, i1)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_push_f64(ptr, double)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_push_ptr(ptr, ptr)")
+    assertLlvmContains(declarations, "declare i64 @osty_rt_list_get_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_list_get_i1(ptr, i64)")
+    assertLlvmContains(declarations, "declare double @osty_rt_list_get_f64(ptr, i64)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_list_get_ptr(ptr, i64)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_set_i64(ptr, i64, i64)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_set_i1(ptr, i64, i1)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_set_f64(ptr, i64, double)")
+    assertLlvmContains(declarations, "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)")
+}
+
+fn testLlvmSmokeListBasicIsOstyOwned() {
+    let ir = llvmSmokeListBasicIR("/tmp/list_basic.osty")
+
+    assertLlvmContains(ir, "source_filename = \"/tmp/list_basic.osty\"")
+    assertLlvmContains(ir, "declare ptr @osty_rt_list_new()")
+    assertLlvmContains(ir, "declare i64 @osty_rt_list_len(ptr)")
+    assertLlvmContains(ir, "declare void @osty_rt_list_push_i64(ptr, i64)")
+    assertLlvmContains(ir, "declare i64 @osty_rt_list_get_i64(ptr, i64)")
+    assertLlvmContains(ir, "%t0 = call ptr @osty_rt_list_new()")
+    assertLlvmContains(ir, "call void @osty_rt_list_push_i64(ptr %t0, i64 10)")
+    assertLlvmContains(ir, "call void @osty_rt_list_push_i64(ptr %t0, i64 20)")
+    assertLlvmContains(ir, "call void @osty_rt_list_push_i64(ptr %t0, i64 30)")
+    assertLlvmContains(ir, "= call i64 @osty_rt_list_len(ptr %t0)")
+    assertLlvmContains(ir, "= call i64 @osty_rt_list_get_i64(ptr %t0, i64 1)")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmMapRuntimeSymbolsAreOstyOwned() {
+    testing.assertEq(llvmMapRuntimeNewSymbol(), "osty_rt_map_new")
+    testing.assertEq(llvmMapRuntimeLenSymbol(), "osty_rt_map_len")
+    testing.assertEq(llvmMapRuntimeKeysSymbol(), "osty_rt_map_keys")
+    testing.assertEq(llvmMapRuntimeContainsSymbol("i64", false), "osty_rt_map_contains_i64")
+    testing.assertEq(llvmMapRuntimeInsertSymbol("i64", false), "osty_rt_map_insert_i64")
+    testing.assertEq(llvmMapRuntimeRemoveSymbol("double", false), "osty_rt_map_remove_f64")
+    testing.assertEq(llvmMapRuntimeGetOrAbortSymbol("ptr", true), "osty_rt_map_get_or_abort_string")
+    testing.assertEq(llvmMapRuntimeInsertSymbol("", false), "osty_rt_map_insert_bytes")
+}
+
+fn testLlvmMapKeySuffixMatchesRuntimeAbi() {
+    testing.assertEq(llvmMapKeySuffix("i64", false), "i64")
+    testing.assertEq(llvmMapKeySuffix("i1", false), "i1")
+    testing.assertEq(llvmMapKeySuffix("double", false), "f64")
+    testing.assertEq(llvmMapKeySuffix("ptr", false), "ptr")
+    testing.assertEq(llvmMapKeySuffix("ptr", true), "string")
+    testing.assertEq(llvmMapKeySuffix("i64", true), "string")
+    testing.assertEq(llvmMapKeySuffix("", false), "bytes")
+    testing.assertEq(llvmMapKeySuffix("%MyStruct", false), "bytes")
+}
+
+fn testLlvmMapRuntimeDeclarationsAreOstyOwned() {
+    let declarations = llvmTestStrings.join(llvmMapRuntimeDeclarations(), "\n")
+
+    assertLlvmContains(declarations, "declare ptr @osty_rt_map_new()")
+    assertLlvmContains(declarations, "declare i64 @osty_rt_map_len(ptr)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_map_keys(ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_contains_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_contains_i1(ptr, i1)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_contains_f64(ptr, double)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_contains_ptr(ptr, ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_contains_string(ptr, ptr)")
+    assertLlvmContains(declarations, "declare void @osty_rt_map_insert_i64(ptr, i64, ptr)")
+    assertLlvmContains(declarations, "declare void @osty_rt_map_insert_string(ptr, ptr, ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_remove_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_map_remove_string(ptr, ptr)")
+    assertLlvmContains(declarations, "declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)")
+    assertLlvmContains(declarations, "declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)")
+}
+
+fn testLlvmClosureEnvTypeNameJoinsTags() {
+    testing.assertEq(llvmClosureEnvTypeName(["ptr"]), "ClosureEnv.ptr")
+    testing.assertEq(llvmClosureEnvTypeName(["ptr", "i64"]), "ClosureEnv.ptr.i64")
+    testing.assertEq(
+        llvmClosureEnvTypeName(["ptr", "i64", "double", "ptr"]),
+        "ClosureEnv.ptr.i64.double.ptr",
+    )
+}
+
+fn testLlvmClosureEnvTypeDefRendersStruct() {
+    let def = llvmClosureEnvTypeDef("ClosureEnv.ptr.i64", ["ptr", "i64"])
+    testing.assertEq(def, "%ClosureEnv.ptr.i64 = type \{ ptr, i64 \}")
+}
+
+fn testLlvmClosureThunkNameIsOstyOwned() {
+    testing.assertEq(llvmClosureThunkName("double_val"), "__osty_closure_thunk_double_val")
+    testing.assertEq(llvmClosureThunkName("add"), "__osty_closure_thunk_add")
+}
+
+fn testLlvmClosureThunkDefinitionForwardsArgs() {
+    let def = llvmClosureThunkDefinition("double_val", "i64", ["i64"])
+
+    assertLlvmContains(def, "define private i64 @__osty_closure_thunk_double_val(ptr %env, i64 %arg0)")
+    assertLlvmContains(def, "%ret = call i64 @double_val(i64 %arg0)")
+    assertLlvmContains(def, "ret i64 %ret")
+}
+
+fn testLlvmClosureThunkDefinitionVoidReturn() {
+    let def = llvmClosureThunkDefinition("noop", "void", [])
+
+    assertLlvmContains(def, "define private void @__osty_closure_thunk_noop(ptr %env)")
+    assertLlvmContains(def, "call void @noop()")
+    assertLlvmContains(def, "ret void")
+    testing.assert(!(llvmTestStrings.contains(def, "%ret = call")))
+}
+
+fn testLlvmClosureBareFnEnvTypeDefIsOneSlot() {
+    testing.assertEq(llvmClosureBareFnEnvTypeDef(), "%ClosureEnv.ptr = type \{ ptr \}")
+}
+
+fn testLlvmSmokeClosureThunkIsOstyOwned() {
+    let ir = llvmSmokeClosureThunkIR("/tmp/closure_thunk.osty")
+
+    assertLlvmContains(ir, "source_filename = \"/tmp/closure_thunk.osty\"")
+    assertLlvmContains(ir, "%ClosureEnv.ptr = type \{ ptr \}")
+    assertLlvmContains(ir, "define i64 @double_val(i64 %x)")
+    assertLlvmContains(ir, "define private i64 @__osty_closure_thunk_double_val(ptr %env, i64 %arg0)")
+    assertLlvmContains(ir, "%ret = call i64 @double_val(i64 %arg0)")
+    assertLlvmContains(ir, "define i32 @main()")
+    assertLlvmContains(ir, "%t0 = alloca %ClosureEnv.ptr")
+    assertLlvmContains(ir, "store ptr @__osty_closure_thunk_double_val, ptr %t1")
+    assertLlvmContains(ir, "= call i64 (ptr, i64) ")
+    assertLlvmContains(ir, "(ptr %t0, i64 21)")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 ")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmSmokeClosureBasicIsOstyOwned() {
+    let ir = llvmSmokeClosureBasicIR("/tmp/closure_basic.osty")
+
+    assertLlvmContains(ir, "source_filename = \"/tmp/closure_basic.osty\"")
+    assertLlvmContains(ir, "%ClosureEnv.ptr.i64 = type \{ ptr, i64 \}")
+    assertLlvmContains(ir, "define i64 @closure_body(ptr %env)")
+    assertLlvmContains(ir, "getelementptr %ClosureEnv.ptr.i64, ptr %env, i32 0, i32 1")
+    assertLlvmContains(ir, "= load i64, ptr ")
+    assertLlvmContains(ir, "define i32 @main()")
+    assertLlvmContains(ir, "%t0 = alloca %ClosureEnv.ptr.i64")
+    assertLlvmContains(ir, "%t1 = getelementptr %ClosureEnv.ptr.i64, ptr %t0, i32 0, i32 0")
+    assertLlvmContains(ir, "store ptr @closure_body, ptr %t1")
+    assertLlvmContains(ir, "%t2 = getelementptr %ClosureEnv.ptr.i64, ptr %t0, i32 0, i32 1")
+    assertLlvmContains(ir, "store i64 42, ptr %t2")
+    assertLlvmContains(ir, "= load ptr, ptr ")
+    assertLlvmContains(ir, "= call i64 (ptr) ")
+    assertLlvmContains(ir, "(ptr %t0)")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 ")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmSetRuntimeSymbolsAreOstyOwned() {
+    testing.assertEq(llvmSetRuntimeNewSymbol(), "osty_rt_set_new")
+    testing.assertEq(llvmSetRuntimeLenSymbol(), "osty_rt_set_len")
+    testing.assertEq(llvmSetRuntimeToListSymbol(), "osty_rt_set_to_list")
+    testing.assertEq(llvmSetRuntimeContainsSymbol("i64", false), "osty_rt_set_contains_i64")
+    testing.assertEq(llvmSetRuntimeInsertSymbol("double", false), "osty_rt_set_insert_f64")
+    testing.assertEq(llvmSetRuntimeRemoveSymbol("ptr", true), "osty_rt_set_remove_string")
+    testing.assertEq(llvmSetRuntimeInsertSymbol("", false), "osty_rt_set_insert_bytes")
+}
+
+fn testLlvmSetRuntimeDeclarationsAreOstyOwned() {
+    let declarations = llvmTestStrings.join(llvmSetRuntimeDeclarations(), "\n")
+
+    assertLlvmContains(declarations, "declare ptr @osty_rt_set_new(i64)")
+    assertLlvmContains(declarations, "declare i64 @osty_rt_set_len(ptr)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_set_to_list(ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_contains_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_contains_string(ptr, ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_insert_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_insert_f64(ptr, double)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_insert_string(ptr, ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_remove_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_set_remove_string(ptr, ptr)")
+}
+
+fn testLlvmSmokeSetBasicIsOstyOwned() {
+    let ir = llvmSmokeSetBasicIR("/tmp/set_basic.osty")
+
+    assertLlvmContains(ir, "source_filename = \"/tmp/set_basic.osty\"")
+    assertLlvmContains(ir, "declare ptr @osty_rt_set_new(i64)")
+    assertLlvmContains(ir, "declare i64 @osty_rt_set_len(ptr)")
+    assertLlvmContains(ir, "declare i1 @osty_rt_set_insert_i64(ptr, i64)")
+    assertLlvmContains(ir, "declare i1 @osty_rt_set_contains_i64(ptr, i64)")
+    assertLlvmContains(ir, "declare i1 @osty_rt_set_remove_i64(ptr, i64)")
+    assertLlvmContains(ir, "declare ptr @osty_rt_set_to_list(ptr)")
+    assertLlvmContains(ir, "%t0 = call ptr @osty_rt_set_new(i64 1)")
+    assertLlvmContains(ir, "%t1 = call i1 @osty_rt_set_insert_i64(ptr %t0, i64 10)")
+    assertLlvmContains(ir, "= call i1 @osty_rt_set_contains_i64(ptr %t0, i64 20)")
+    assertLlvmContains(ir, "= call i1 @osty_rt_set_remove_i64(ptr %t0, i64 20)")
+    assertLlvmContains(ir, "= call i64 @osty_rt_set_len(ptr %t0)")
+    assertLlvmContains(ir, "= call ptr @osty_rt_set_to_list(ptr %t0)")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmStringRuntimeSymbolsAreOstyOwned() {
+    testing.assertEq(llvmStringRuntimeEqualSymbol(), "osty_rt_strings_Equal")
+    testing.assertEq(llvmStringRuntimeHasPrefixSymbol(), "osty_rt_strings_HasPrefix")
+    testing.assertEq(llvmStringRuntimeSplitSymbol(), "osty_rt_strings_Split")
+    testing.assertEq(llvmStringRuntimeConcatSymbol(), "osty_rt_strings_Concat")
+    testing.assertEq(llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen")
+}
+
+fn testLlvmStringRuntimeDeclarationsAreOstyOwned() {
+    let declarations = llvmTestStrings.join(llvmStringRuntimeDeclarations(), "\n")
+
+    assertLlvmContains(declarations, "declare i1 @osty_rt_strings_Equal(ptr, ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_strings_Split(ptr, ptr)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+    assertLlvmContains(declarations, "declare i64 @osty_rt_strings_ByteLen(ptr)")
+}
+
+fn testLlvmSmokeStringConcatIsOstyOwned() {
+    let ir = llvmSmokeStringConcatIR("/tmp/string_concat.osty")
+
+    assertLlvmContains(ir, "source_filename = \"/tmp/string_concat.osty\"")
+    assertLlvmContains(ir, "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+    assertLlvmContains(ir, "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)")
+    assertLlvmContains(ir, "declare i64 @osty_rt_strings_ByteLen(ptr)")
+    assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [8 x i8] c\"hello, \\00\"")
+    assertLlvmContains(ir, "@.str1 = private unnamed_addr constant [5 x i8] c\"osty\\00\"")
+    assertLlvmContains(ir, "%t0 = call ptr @osty_rt_strings_Concat(ptr @.str0, ptr @.str1)")
+    assertLlvmContains(ir, "%t1 = call i1 @osty_rt_strings_HasPrefix(ptr %t0, ptr @.str0)")
+    assertLlvmContains(ir, "%t2 = call i64 @osty_rt_strings_ByteLen(ptr %t0)")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %t2)")
+    assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %t0)")
+    assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmSmokeMapBasicIsOstyOwned() {
+    let ir = llvmSmokeMapBasicIR("/tmp/map_basic.osty")
+
+    assertLlvmContains(ir, "source_filename = \"/tmp/map_basic.osty\"")
+    assertLlvmContains(ir, "declare ptr @osty_rt_map_new()")
+    assertLlvmContains(ir, "declare i64 @osty_rt_map_len(ptr)")
+    assertLlvmContains(ir, "declare void @osty_rt_map_insert_i64(ptr, i64, ptr)")
+    assertLlvmContains(ir, "declare i1 @osty_rt_map_contains_i64(ptr, i64)")
+    assertLlvmContains(ir, "declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)")
+    assertLlvmContains(ir, "%t0 = call ptr @osty_rt_map_new()")
+    assertLlvmContains(ir, "%t1 = alloca i64")
+    assertLlvmContains(ir, "store i64 42, ptr %t1")
+    assertLlvmContains(ir, "call void @osty_rt_map_insert_i64(ptr %t0, i64 7, ptr %t1)")
+    assertLlvmContains(ir, "= call i1 @osty_rt_map_contains_i64(ptr %t0, i64 7)")
+    assertLlvmContains(ir, "call void @osty_rt_map_get_or_abort_i64(ptr %t0, i64 7, ptr")
+    assertLlvmContains(ir, "= call i64 @osty_rt_map_len(ptr %t0)")
+    assertLlvmContains(ir, "ret i32 0")
+}


### PR DESCRIPTION
## 요약

`toolchain/llvmgen.osty`를 확장해 **List/Map/Set/String 런타임 ABI + closure env/thunk ABI의 방출 기반**을 전부 Osty가 소유하게 하고, `internal/llvmgen/runtime_ffi.go`의 컨테이너 정책 함수 16개를 Osty-owned helper로 delegate해서 **policy source of truth를 Osty 쪽으로 이동**. 기존 MIR generator는 같은 bridge 함수를 계속 부르지만, 이제 동작을 바꾸려면 `toolchain/llvmgen.osty` 편집 한 번으로 끝난다.

## 변경 내용

### Primitive 추가 (5 축)

**List<T>** — 심볼 빌더 (`llvmListRuntimePush/Get/Set/Sorted/ToSetSymbol`), 14개 forward decl, `llvmListElementSuffix` 정규화, `llvmListUsesTypedRuntime` typed-runtime 게이트, 방출 헬퍼 (`llvmListNew/Len/Push{I64,I1,F64,Ptr}/Get{…}/Set{…}`), `llvmRenderModuleWithListRuntime`, `llvmSmokeListBasicIR` 스모크.

**Map<K,V>** — `llvmMapKeySuffix` 정책 (5 key variant + bytes fallback), `llvmMapRuntime{Contains,Insert,Remove,GetOrAbort}Symbol` parametric, 23개 forward decl, 방출 헬퍼 23개, `llvmSlotAsPtr` (out-pointer value ABI용 slot view), `llvmSmokeMapBasicIR`.

**Set** — 1-arg 생성자 `osty_rt_set_new(i64 elem_kind)`, 18개 forward decl, typed item ABI 방출 헬퍼 18개 (List처럼 typed, Map과 달리 out-pointer 아님), `llvmSmokeSetBasicIR`.

**String** — **C 런타임에 `osty_rt_strings_Concat` + `osty_rt_strings_ByteLen` 추가** (`OSTY_GC_KIND_STRING` 관리 할당). Equal/HasPrefix/Split 포함 심볼 빌더 5개, 5개 forward decl, 방출 헬퍼 5개, `llvmSmokeStringConcatIR`.

**Closure env** — `%ClosureEnv.<sig>` deterministic naming (`llvmClosureEnvTypeName`/`TypeDef`), 1-slot alloca, slot 0 (fn ptr) + slot N (captures)에 store/load 헬퍼, 풀 타입 call 형식의 indirect call (`call RET (ptr, ARGT…) %fn(env, …)`), `llvmSmokeClosureBasicIR`.

**Closure thunk** — `__osty_closure_thunk_<symbol>` 네이밍, `define private RET @thunk(ptr %env, user_params…)` 바디 렌더러, `llvmClosureBareFnEnv` (bare fn → 1-slot env 래퍼), `llvmSmokeClosureThunkIR` (21 × 2 = 42 end-to-end).

### Wiring — AST→MIR→primitive 경로 연결

`internal/llvmgen/runtime_ffi.go`의 컨테이너 정책 함수 **16개가 Osty-owned helper의 thin wrapper로 축소** (106줄 → 22줄 net):

- `listRuntimePush/Get/SetSymbol` → `llvmListRuntime*Symbol(llvmListElementSuffix(...))`
- `listRuntimeSorted/ToSetSymbol` → `llvmListRuntime*Symbol`
- `mapRuntime{Contains,Insert,Remove,GetOrAbort}Symbol` → `llvmMapRuntime*Symbol`
- `setRuntime{Contains,Insert,Remove}Symbol` → `llvmSetRuntime*Symbol`
- 정책 함수 `mapSetKeySuffix` / `listUsesTypedRuntime` / `listRuntimeSymbolSuffix` 전부 Osty delegate

이제 `osty_rt_list_push_i64` 같은 심볼을 바꾸려면 `toolchain/llvmgen.osty`만 건드리면 됨.

### Latent bug fix

`llvmListRuntimeSortedSymbol` / `ToSetSymbol`이 unknown element 타입에 대해 **wrong typed variant로 silent coerce**하던 걸 `""` ("unsupported") 반환으로 수정. Caller (`mir_generator.go:1452`, `:1460`)가 `if sym == ""` 체크로 진단 emit하는 기존 contract에 맞춤.

## 테스트 계획

- [x] Osty + Go 양쪽에 포커스 테스트 30+개 추가 (symbol 빌더, 정책 함수, forward decl, 스모크 IR 모양).
- [x] `go test -run "TestGenerated" ./internal/llvmgen/` → **ok**.
- [x] MIR 경유 기존 테스트 전부 regression 0: `TestGenerateListPushStmtUsesRuntimeABI`, `TestGenerateOpaqueListLiteralsUseRuntimeABI`, `TestGenerateForInOverListStringUsesRuntimeABI`, `TestGenerateCollectionsUseManagedRuntimeABI`, `TestGenerateListLenUsesRuntimeABI`, `TestGenerateStringCompareUsesRuntimeABI`, `TestMIRDualEmitFromSource`.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `cc -Wall -Werror internal/backend/runtime/osty_runtime.c` clean.

## 리뷰어 참고 사항

**Pre-existing 실패 (이 PR 무관)**: `TestGenerateModuleInterface*`, `TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields`, `TestGenerateRuntimeFFIUsesRuntimeABI`, `TestGenerateOptionalRuntimeFFIAliasCall` 등이 `internal/check/host_boundary.go:578`의 nil pointer로 실패. pristine main(22커밋 ahead)에서도 동일 재현 — parallel agent가 checker 건드린 churn.

**이 PR에서 의도적으로 뺀 것**:
- List `push_bytes_v1` (struct element) — AST 로워링이 struct payload 몰고 올 때 같이.
- String slicing / utf-8 iteration / interpolation 로워링 — 별도 PR (runtime 추가 + AST 레벨 변경 필요).
- Closure heap-allocated env (escape) — GC 통합 + escape analysis 먼저.
- Thunk dedup 캐시 — 이건 emission driver 레이어.

## Phase B 마이그레이션 진행

runtime_ffi.go 상단 NOTE를 migration-target에서 **완료 상태** 로 업데이트. 컨테이너 정책은 이제 Osty가 owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)