### PR TITLE
feat(stdlib): flesh out Option/Result 콤비네이터 세트

### DIFF
--- a/internal/stdlib/modules/option.osty
+++ b/internal/stdlib/modules/option.osty
@@ -22,6 +22,39 @@ pub enum Option<T> {
         }
     }
 
+    pub fn isSomeAnd(self, pred: fn(T) -> Bool) -> Bool {
+        match self {
+            Some(value) -> pred(value),
+            None -> false,
+        }
+    }
+
+    pub fn isNoneOr(self, pred: fn(T) -> Bool) -> Bool {
+        match self {
+            Some(value) -> pred(value),
+            None -> true,
+        }
+    }
+
+    pub fn contains(self, item: T) -> Bool {
+        match self {
+            Some(value) -> value == item,
+            None -> false,
+        }
+    }
+
+    pub fn take(mut self) -> T? {
+        let old = self
+        self = None
+        old
+    }
+
+    pub fn replace(mut self, value: T) -> T? {
+        let old = self
+        self = Some(value)
+        old
+    }
+
     pub fn unwrap(self) -> T {
         match self {
             Some(value) -> value,
@@ -112,6 +145,30 @@ pub enum Option<T> {
         }
     }
 
+    pub fn mapOr<U>(self, fallback: U, f: fn(T) -> U) -> U {
+        match self {
+            Some(value) -> f(value),
+            None -> fallback,
+        }
+    }
+
+    pub fn mapOrElse<U>(self, fallback: fn() -> U, f: fn(T) -> U) -> U {
+        match self {
+            Some(value) -> f(value),
+            None -> fallback(),
+        }
+    }
+
+    pub fn zip<U>(self, other: U?) -> (T, U)? {
+        match self {
+            Some(a) -> match other {
+                Some(b) -> Some((a, b)),
+                None -> None,
+            },
+            None -> None,
+        }
+    }
+
     pub fn orError(self, msg: String) -> Result<T, Error> {
         match self {
             Some(value) -> Ok(value),
@@ -121,6 +178,13 @@ pub enum Option<T> {
 
     pub fn okOr(self, msg: String) -> Result<T, Error> {
         self.orError(msg)
+    }
+
+    pub fn okOrElse<E>(self, err: fn() -> E) -> Result<T, E> {
+        match self {
+            Some(value) -> Ok(value),
+            None -> Err(err()),
+        }
     }
 
     pub fn toString(self) -> String {

--- a/internal/stdlib/modules/result.osty
+++ b/internal/stdlib/modules/result.osty
@@ -23,6 +23,34 @@ pub enum Result<T, E> {
         }
     }
 
+    pub fn isOkAnd(self, pred: fn(T) -> Bool) -> Bool {
+        match self {
+            Ok(value) -> pred(value),
+            Err(_) -> false,
+        }
+    }
+
+    pub fn isErrAnd(self, pred: fn(E) -> Bool) -> Bool {
+        match self {
+            Ok(_) -> false,
+            Err(error) -> pred(error),
+        }
+    }
+
+    pub fn contains(self, item: T) -> Bool {
+        match self {
+            Ok(value) -> value == item,
+            Err(_) -> false,
+        }
+    }
+
+    pub fn containsErr(self, err: E) -> Bool {
+        match self {
+            Ok(_) -> false,
+            Err(error) -> error == err,
+        }
+    }
+
     pub fn unwrap(self) -> T {
         match self {
             Ok(value) -> value,
@@ -138,6 +166,20 @@ pub enum Result<T, E> {
         match self {
             Ok(value) -> Ok(value),
             Err(error) -> Err(f(error)),
+        }
+    }
+
+    pub fn mapOr<U>(self, fallback: U, f: fn(T) -> U) -> U {
+        match self {
+            Ok(value) -> f(value),
+            Err(_) -> fallback,
+        }
+    }
+
+    pub fn mapOrElse<U>(self, fallback: fn(E) -> U, f: fn(T) -> U) -> U {
+        match self {
+            Ok(value) -> f(value),
+            Err(error) -> fallback(error),
         }
     }
 


### PR DESCRIPTION
## Summary

Option/Result에 canonical 콤비네이터 14개 추가. `match`로 전부 표현 가능하지만 전용 메서드가 없으면 사용 코드 리듬이 깨진다는 원칙.

**Option<T>** (+8):
- predicate: `isSomeAnd`, `isNoneOr`, `contains`
- transform: `mapOr`, `mapOrElse`, `zip`
- mutate (`mut self`): `take`, `replace`
- convert: `okOrElse`

**Result<T, E>** (+6):
- predicate: `isOkAnd`, `isErrAnd`, `contains`, `containsErr`
- transform: `mapOr`, `mapOrElse`

네이밍/파라미터 순서는 Rust `std` parity (fallback-first). 기존 파일 스타일(match self + `__{option,result}Abort` placeholder) 유지.

## 주의

- `take`/`replace`는 variant 재할당 (`self = None` / `self = Some(v)`) 사용. **checker 통과만 확인**. LLVM 백엔드 codegen이 WIP라 런타임 검증은 백엔드 완성 후 필요. 그전까지는 checker-level stub.
- 기존 backend 테스트 실패는 pre-existing (`code generation is not implemented yet`) — 본 PR 변경과 무관.

## 제외

- `flatten`: self-type 제약 (`Option<Option<T>>`) 필요, enum 메서드 문법에서 표현 불가. 유저는 `opt.andThen(|x| x)`로 우회 가능.

## Test plan

- [x] `go test ./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/stdlib` 통과
- [ ] LLVM 백엔드 완성 후 `take`/`replace` 런타임 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)