### PR TITLE
feat: stdlib — List.take/drop + testing.assertTrue/assertFalse

### DIFF
--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1,8 +1,8 @@
 // stmt.go — statement-position emission: emitBlock, emitStmt dispatcher,
 // let/assign/for/return/break/continue/expr-stmt, if-stmt / if-let-stmt,
 // list·map·set method-call statements, user-call statements, println, and
-// testing-only statement helpers (testing.assert / assertEq / fail / context
-// / expectOk / expectError).
+// testing-only statement helpers (testing.assert / assertTrue / assertFalse /
+// assertEq / assertNe / fail / context / expectOk / expectError).
 //
 // NOTE(osty-migration): statement emission consumes ast.Stmt shapes and
 // drives the generator through side effects — this is the bulk of the
@@ -708,15 +708,30 @@ func (g *generator) emitTestingCallStmt(call *ast.CallExpr) (bool, error) {
 		return false, nil
 	}
 	switch method {
-	case "assert":
+	case "assert", "assertTrue":
 		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
-			return true, unsupported("call", "testing.assert requires one positional argument")
+			return true, unsupportedf("call", "testing.%s requires one positional argument", method)
 		}
 		cond, err := g.emitExpr(call.Args[0].Value)
 		if err != nil {
 			return true, err
 		}
-		return true, g.emitTestingAssertion(cond, g.testingFailureMessage(call, "assert"))
+		return true, g.emitTestingAssertion(cond, g.testingFailureMessage(call, method))
+	case "assertFalse":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return true, unsupported("call", "testing.assertFalse requires one positional argument")
+		}
+		cond, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return true, err
+		}
+		if cond.typ != "i1" {
+			return true, unsupportedf("type-system", "testing.assertFalse condition type %s, want i1", cond.typ)
+		}
+		emitter := g.toOstyEmitter()
+		negated := llvmNotI1(emitter, toOstyValue(cond))
+		g.takeOstyEmitter(emitter)
+		return true, g.emitTestingAssertion(fromOstyValue(negated), g.testingFailureMessage(call, "assertFalse"))
 	case "assertEq":
 		return true, g.emitTestingCompare(call, token.EQ, "assertEq")
 	case "assertNe":

--- a/internal/stdlib/modules/collections.osty
+++ b/internal/stdlib/modules/collections.osty
@@ -91,6 +91,28 @@ pub struct List<T> {
         }
         out
     }
+    pub fn take(self, n: Int) -> List<T> {
+        let mut out: List<T> = []
+        let len = self.len()
+        let limit = if n <= 0 { 0 } else if n < len { n } else { len }
+        let mut i = 0
+        for i < limit {
+            out.push(self[i])
+            i = i + 1
+        }
+        out
+    }
+    pub fn drop(self, n: Int) -> List<T> {
+        let mut out: List<T> = []
+        let len = self.len()
+        let start = if n <= 0 { 0 } else if n > len { len } else { n }
+        let mut i = start
+        for i < len {
+            out.push(self[i])
+            i = i + 1
+        }
+        out
+    }
     pub fn appended(self, item: T) -> List<T> {
         let mut out: List<T> = []
         for value in self {

--- a/internal/stdlib/modules/testing.osty
+++ b/internal/stdlib/modules/testing.osty
@@ -14,6 +14,12 @@
 pub fn assert(cond: Bool) {
 }
 
+pub fn assertTrue(cond: Bool) {
+}
+
+pub fn assertFalse(cond: Bool) {
+}
+
 pub fn assertEq<T: Equal>(actual: T, expected: T) {
 }
 


### PR DESCRIPTION
## Summary

- **`List.take(n)` / `List.drop(n)`**: pure-Osty slicing helpers on `List<T>` in `internal/stdlib/modules/collections.osty`. Both clamp `n` against `self.len()` with a three-way `if/else if/else`, cache `self.len()` once, and build the output via `push` — matching the style of sibling helpers (`reversed`, `appended`, `concat`).
- **`testing.assertTrue(cond)` / `testing.assertFalse(cond)`**: new stubs in `internal/stdlib/modules/testing.osty` next to `assert` / `assertEq` / `assertNe`. The LLVM test-emit switch in `internal/llvmgen/stmt.go` routes `assertTrue` through the same code path as `assert` and negates the i1 condition for `assertFalse` via the existing `llvmNotI1` helper (same pattern `token.NOT` uses in `expr.go`).

## Why

Filling concrete gaps reported from downstream code: `mapErr` for IO→Sql error lifting (already existed), and the `List.take` / `testing.assertTrue`/`assertFalse` shapes that users reach for but the stdlib didn't yet expose. Paired `drop` / `assertFalse` are added for symmetry — a `take` without a `drop` or `assertTrue` without `assertFalse` feels half-finished.

## Notes for reviewer

- `List<T>.join(sep)` was also requested, but Osty v0.4's grammar is frozen and can't express a method that requires `T = String`. Existing spellings `strings.join(parts, sep)` / `"sep".join(parts)` remain the canonical forms. CLAUDE.md appendix A.1 uses `lines.join("\n")` in prose — that's aspirational until the compiler grows intrinsic dispatch for type-specialized methods.
- `take` / `drop` inherit a pre-existing LLVM codegen gap shared with `reversed` / `sortedBy` / `filter` (user-implemented generic List methods). Not a regression — verified by running `.reversed()` on `main` and observing the same `code generation is not implemented yet` failure.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/stdlib ./internal/check ./internal/resolve` green
- [x] `go test ./internal/llvmgen -run Testing|Assert` green
- [x] `osty test` against a fixture: `assertTrue(true)` / `assertFalse(false)` pass; `assertTrue(false)` / `assertFalse(true)` fail with `testing.assertXxx failed at file:line` pointing to the call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)