### PR TITLE
feat: canonicalize E07xx diag namespace + implement G14 and struct spread

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -499,7 +499,7 @@ pub fn f() {}
 
 ---
 
-## Type checking (E0700–E0743)
+## Type checking (E0700–E0753)
 
 ### E0700 — `CodeTypeMismatch`
 
@@ -757,15 +757,15 @@ Match arm is unreachable because a previous arm fully covers its cases.
 
 **Fix**: merge or remove the shadowed arm.
 
-### E0741 — `CodeRefutableClosurePattern`
+### E0741 — `CodeRefutablePattern`
 
-Closure parameter pattern can fail to match.
+Pattern in an irrefutable position can fail to match.
 
-Closure parameters are destructured at every call site, so their patterns must be irrefutable: identifiers, `_`, tuples/structs made only of irrefutable sub-patterns, or `name @ irrefutable`.
+Three spec sites require irrefutable patterns: `let p = e` (§A.5 let bindings), `for p in e` (§A.5 for-in bindings), and closure parameters (G16 — destructured at every call site). Irrefutable means: identifiers, `_`, tuples/structs made only of irrefutable sub-patterns, or `name @ irrefutable`.
 
-Spec: v0.4 G16
+Spec: v0.4 §A.5, G16
 
-**Fix**: accept the value with an irrefutable parameter pattern, then use `match` or `if let` inside the closure body.
+**Fix**: accept the value with an irrefutable pattern, then use `match` or `if let` inside the body for the refutable cases.
 
 ### E0742 — `CodeGenericCallableReference`
 
@@ -786,6 +786,73 @@ Structured-concurrency capability escapes its group scope.
 Spec: v0.4 G13
 
 **Fix**: join/use the handle inside the `taskGroup` closure and return an ordinary value.
+
+### E0744 — `CodeOperandType`
+
+Operator cannot be applied to the operand's type.
+
+Currently the runtime's catch-all for unary (`!`, `-`, `+`, `~`), binary arithmetic / bitwise / comparison / logical, `??` coalesce, `<-` channel send, and `in` membership type mismatches. The more specialized codes E0713/E0714/E0720/E0737/E0738 are reserved but not currently emitted — callers should expect E0744 today.
+
+**Fix**: convert an operand, or switch to an operator defined on the type.
+
+### E0745 — `CodeUnknownName`
+
+Resolver could not find a name in the current scope.
+
+Emitted by the checker when an identifier reference doesn't match any local binding or top-level function in scope (the resolver passed it through as a last-chance lookup, typically because of missing imports or a typo).
+
+**Fix**: check spelling, imports, and receiver type; if it's a method, write the receiver explicitly.
+
+### E0746 — `CodeDuplicateField`
+
+Struct literal (or declaration) names the same field twice.
+
+**Fix**: remove the duplicate or rename one of the entries.
+
+### E0747 — `CodeDuplicateMethod`
+
+Two methods on the same type share a name.
+
+**Fix**: rename one of the methods, or merge their bodies.
+
+### E0748 — `CodeCannotInferTyParam`
+
+A type parameter could not be inferred from the arguments.
+
+**Fix**: supply the type argument explicitly via turbofish `f::<T>(...)`, or pass an argument whose type constrains the parameter.
+
+### E0749 — `CodeGenericBoundViolation`
+
+A type argument violates a generic bound.
+
+```osty
+fn f<T: Ordered>(x: T) { ... }
+f("hello")     // String is not Ordered → rejected
+```
+
+**Fix**: switch to a type that satisfies the bound, or relax the bound.
+
+### E0751 — `CodeInterfaceNotSatisfied`
+
+A concrete type does not satisfy a required interface.
+
+Osty's interfaces are structural — every method in the interface must be present on the concrete type with a matching signature.
+
+**Fix**: add the missing methods, or switch to a type that already satisfies the interface.
+
+### E0752 — `CodeClosureAnnotationRequired`
+
+Closure parameter lacks a type annotation in a context where it cannot be inferred (no expected-type hint from the call site).
+
+**Fix**: annotate the parameter explicitly (`|x: Int| ...`), or use the closure in a position that provides an expected type.
+
+### E0753 — `CodePatternShapeMismatch`
+
+Pattern structure does not match the scrutinee's type.
+
+Covers literal / range / tuple-arity / struct / variant pattern shape errors — a broader category than the literal-type mismatch E0722: the scrutinee might be an Int where the pattern is a tuple, or the scrutinee a tuple of arity 3 where the pattern is arity 2.
+
+**Fix**: rewrite the pattern to match the scrutinee's shape, or guard with a type-narrowing arm above it.
 
 ---
 

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -595,15 +595,17 @@ const (
 	// Fix: merge or remove the shadowed arm.
 	CodeUnreachableArm = "E0740"
 
-	// Closure parameter pattern can fail to match.
+	// Pattern in an irrefutable position can fail to match.
 	//
-	// Closure parameters are destructured at every call site, so their
-	// patterns must be irrefutable: identifiers, `_`, tuples/structs
-	// made only of irrefutable sub-patterns, or `name @ irrefutable`.
+	// Three spec sites require irrefutable patterns: `let p = e` (§A.5
+	// let bindings), `for p in e` (§A.5 for-in bindings), and closure
+	// parameters (G16 — destructured at every call site). Irrefutable
+	// means: identifiers, `_`, tuples/structs made only of irrefutable
+	// sub-patterns, or `name @ irrefutable`.
 	//
-	// Spec: v0.4 G16
-	// Fix: accept the value with an irrefutable parameter pattern, then use `match` or `if let` inside the closure body.
-	CodeRefutableClosurePattern = "E0741"
+	// Spec: v0.4 §A.5, G16
+	// Fix: accept the value with an irrefutable pattern, then use `match` or `if let` inside the body for the refutable cases.
+	CodeRefutablePattern = "E0741"
 
 	// Generic function or method is referenced without being called.
 	//
@@ -626,6 +628,75 @@ const (
 	// Spec: v0.4 G13
 	// Fix: join/use the handle inside the `taskGroup` closure and return an ordinary value.
 	CodeCapabilityEscape = "E0743"
+
+	// Operator cannot be applied to the operand's type.
+	//
+	// Currently the runtime's catch-all for unary (`!`, `-`, `+`, `~`),
+	// binary arithmetic / bitwise / comparison / logical, `??` coalesce,
+	// `<-` channel send, and `in` membership type mismatches. The more
+	// specialized codes E0713/E0714/E0720/E0737/E0738 are reserved but
+	// not currently emitted — callers should expect E0744 today.
+	//
+	// Fix: convert an operand, or switch to an operator defined on the type.
+	CodeOperandType = "E0744"
+
+	// Resolver could not find a name in the current scope.
+	//
+	// Emitted by the checker when an identifier reference doesn't match
+	// any local binding or top-level function in scope (the resolver
+	// passed it through as a last-chance lookup, typically because of
+	// missing imports or a typo).
+	//
+	// Fix: check spelling, imports, and receiver type; if it's a method, write the receiver explicitly.
+	CodeUnknownName = "E0745"
+
+	// Struct literal (or declaration) names the same field twice.
+	//
+	// Fix: remove the duplicate or rename one of the entries.
+	CodeDuplicateField = "E0746"
+
+	// Two methods on the same type share a name.
+	//
+	// Fix: rename one of the methods, or merge their bodies.
+	CodeDuplicateMethod = "E0747"
+
+	// A type parameter could not be inferred from the arguments.
+	//
+	// Fix: supply the type argument explicitly via turbofish `f::<T>(...)`, or pass an argument whose type constrains the parameter.
+	CodeCannotInferTyParam = "E0748"
+
+	// A type argument violates a generic bound.
+	//
+	// Example:
+	//   fn f<T: Ordered>(x: T) { ... }
+	//   f("hello")     // String is not Ordered → rejected
+	//
+	// Fix: switch to a type that satisfies the bound, or relax the bound.
+	CodeGenericBoundViolation = "E0749"
+
+	// A concrete type does not satisfy a required interface.
+	//
+	// Osty's interfaces are structural — every method in the interface
+	// must be present on the concrete type with a matching signature.
+	//
+	// Fix: add the missing methods, or switch to a type that already satisfies the interface.
+	CodeInterfaceNotSatisfied = "E0751"
+
+	// Closure parameter lacks a type annotation in a context where it
+	// cannot be inferred (no expected-type hint from the call site).
+	//
+	// Fix: annotate the parameter explicitly (`|x: Int| ...`), or use the closure in a position that provides an expected type.
+	CodeClosureAnnotationRequired = "E0752"
+
+	// Pattern structure does not match the scrutinee's type.
+	//
+	// Covers literal / range / tuple-arity / struct / variant pattern
+	// shape errors — a broader category than the literal-type mismatch
+	// E0722: the scrutinee might be an Int where the pattern is a tuple,
+	// or the scrutinee a tuple of arity 3 where the pattern is arity 2.
+	//
+	// Fix: rewrite the pattern to match the scrutinee's shape, or guard with a type-narrowing arm above it.
+	CodePatternShapeMismatch = "E0753"
 
 	// Deprecation warning.
 

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -36,30 +36,35 @@ pub struct CheckDiagnostic {
 // `diagMismatch(...)` rather than threading a code enum everywhere.
 // ---------------------------------------------------------------------
 
-pub fn checkCodeTypeMismatch() -> String { "E0701" }
-pub fn checkCodeArgCount() -> String { "E0702" }
-pub fn checkCodeOperandType() -> String { "E0703" }
-pub fn checkCodeUnknownField() -> String { "E0704" }
-pub fn checkCodeMissingField() -> String { "E0705" }
-pub fn checkCodeNonExhaustiveMatch() -> String { "E0706" }
-pub fn checkCodeUnreachablePattern() -> String { "E0707" }
-pub fn checkCodeInvalidAssignTarget() -> String { "E0708" }
-pub fn checkCodeImmutableAssign() -> String { "E0709" }
-pub fn checkCodeUnknownName() -> String { "E0710" }
-pub fn checkCodeUnknownMethod() -> String { "E0711" }
-pub fn checkCodeUnknownVariant() -> String { "E0712" }
-pub fn checkCodeDuplicateField() -> String { "E0713" }
-pub fn checkCodeDuplicateMethod() -> String { "E0714" }
-pub fn checkCodeNotCallable() -> String { "E0715" }
-pub fn checkCodeCannotInferTyParam() -> String { "E0720" }
-pub fn checkCodeGenericBoundViolation() -> String { "E0721" }
-pub fn checkCodeInterfaceNotSatisfied() -> String { "E0722" }
-pub fn checkCodeQuestionNotOptional() -> String { "E0730" }
-pub fn checkCodeReturnMismatch() -> String { "E0731" }
-pub fn checkCodeClosureAnnotationRequired() -> String { "E0741" }
-pub fn checkCodePatternShapeMismatch() -> String { "E0742" }
+// Codes return the canonical E07xx numbers defined in
+// internal/diag/codes.go (the source that ERROR_CODES.md is generated
+// from). Do not renumber individually; either update both tables, or
+// add a new constant to codes.go first and reference it here.
+pub fn checkCodeTypeMismatch() -> String { "E0700" }
+pub fn checkCodeArgCount() -> String { "E0701" }
+pub fn checkCodeUnknownField() -> String { "E0702" }
+pub fn checkCodeUnknownMethod() -> String { "E0703" }
+pub fn checkCodeNotCallable() -> String { "E0704" }
+pub fn checkCodeMissingField() -> String { "E0708" }
+pub fn checkCodeQuestionNotOptional() -> String { "E0717" }
+pub fn checkCodeInvalidAssignTarget() -> String { "E0724" }
+pub fn checkCodeImmutableAssign() -> String { "E0725" }
+pub fn checkCodeReturnMismatch() -> String { "E0726" }
+pub fn checkCodeUnknownVariant() -> String { "E0728" }
+pub fn checkCodeNonExhaustiveMatch() -> String { "E0731" }
+pub fn checkCodeUnreachablePattern() -> String { "E0740" }
+pub fn checkCodeRefutablePattern() -> String { "E0741" }
+pub fn checkCodeGenericCallableReference() -> String { "E0742" }
 pub fn checkCodeNonEscapingEscape() -> String { "E0743" }
-pub fn checkCodeRefutablePattern() -> String { "E0744" }
+pub fn checkCodeOperandType() -> String { "E0744" }
+pub fn checkCodeUnknownName() -> String { "E0745" }
+pub fn checkCodeDuplicateField() -> String { "E0746" }
+pub fn checkCodeDuplicateMethod() -> String { "E0747" }
+pub fn checkCodeCannotInferTyParam() -> String { "E0748" }
+pub fn checkCodeGenericBoundViolation() -> String { "E0749" }
+pub fn checkCodeInterfaceNotSatisfied() -> String { "E0751" }
+pub fn checkCodeClosureAnnotationRequired() -> String { "E0752" }
+pub fn checkCodePatternShapeMismatch() -> String { "E0753" }
 
 // ---------------------------------------------------------------------
 // Low-level builder. Higher-level constructors below wrap this so call
@@ -318,6 +323,15 @@ pub fn diagNonEscapingEscape(ty: String, context: String, start: Int, end: Int) 
         "`{ty}` cannot escape via {context}"
     }
     checkDiag(checkCodeNonEscapingEscape(), msg, start, end)
+}
+
+pub fn diagGenericCallableReference(name: String, start: Int, end: Int) -> CheckDiagnostic {
+    let msg = if name == "" {
+        "generic callable cannot be referenced as a value; wrap it in a closure that fixes the type arguments"
+    } else {
+        "generic callable `{name}` cannot be referenced as a value; wrap it in a closure such as `|x| {name}::<T>(x)`"
+    }
+    checkDiag(checkCodeGenericCallableReference(), msg, start, end)
 }
 
 pub fn diagRefutablePattern(context: String, start: Int, end: Int) -> CheckDiagnostic {

--- a/toolchain/check_diag_test.osty
+++ b/toolchain/check_diag_test.osty
@@ -7,7 +7,7 @@ use std.strings as strings
 
 fn testCheckDiagMismatchStampsCodeAndSeverity() {
     let d = diagMismatch("Int", "String", 12, 20)
-    testing.assertEq(d.code, "E0701")
+    testing.assertEq(d.code, "E0700")
     testing.assertEq(d.start, 12)
     testing.assertEq(d.end, 20)
     match d.severity {
@@ -20,7 +20,7 @@ fn testCheckDiagMismatchStampsCodeAndSeverity() {
 
 fn testCheckDiagArgCountIncludesCalleeWhenProvided() {
     let withName = diagArgCount("takesTwo", 2, 3, 0, 10)
-    testing.assertEq(withName.code, "E0702")
+    testing.assertEq(withName.code, "E0701")
     testing.assert(stringsContains(withName.message, "`takesTwo`"))
     testing.assert(stringsContains(withName.message, "2"))
     testing.assert(stringsContains(withName.message, "3"))
@@ -31,17 +31,17 @@ fn testCheckDiagArgCountIncludesCalleeWhenProvided() {
 
 fn testCheckDiagNonExhaustiveWitness() {
     let withWitness = diagNonExhaustiveMatch("None", 0, 0)
-    testing.assertEq(withWitness.code, "E0706")
+    testing.assertEq(withWitness.code, "E0731")
     testing.assert(stringsContains(withWitness.message, "None"))
 
     let noWitness = diagNonExhaustiveMatch("", 0, 0)
-    testing.assertEq(noWitness.code, "E0706")
+    testing.assertEq(noWitness.code, "E0731")
     testing.assert(stringsContains(noWitness.message, "not exhaustive"))
 }
 
 fn testCheckDiagQuestionNotOptional() {
     let d = diagQuestionNotOptional("Int", 5, 7)
-    testing.assertEq(d.code, "E0730")
+    testing.assertEq(d.code, "E0717")
     testing.assert(stringsContains(d.message, "Option"))
     testing.assert(stringsContains(d.message, "Result"))
     testing.assert(stringsContains(d.message, "`Int`"))
@@ -67,7 +67,7 @@ fn testCheckDiagCountErrorsDistinguishesSeverities() {
 fn testCheckDiagRenderIncludesCode() {
     let d = diagMismatch("Int", "Bool", 0, 0)
     let rendered = checkDiagRender(d)
-    testing.assert(stringsContains(rendered, "[E0701]"))
+    testing.assert(stringsContains(rendered, "[E0700]"))
     testing.assert(stringsContains(rendered, "error"))
 }
 

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -229,6 +229,14 @@ fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
     // Unknown local — try top-level fn.
     let fnSig = checkLookupFn(cx.env, node.text, "")
     if fnSig.name != "" {
+        // G14: generic callables may not be referenced as values. A bare
+        // ident or a value-position turbofish `f::<T>` both land here; the
+        // call path in `elabInferCall` resolves via `checkLookupFn`
+        // directly and bypasses this site, so calls are unaffected.
+        if checkStringListLenHelper(fnSig.generics) > 0 {
+            cx.env.diagnostics.push(diagGenericCallableReference(node.text, node.start, node.end))
+            return elabErrResult(cx, node.start, node.end)
+        }
         let fnTy = fnSigToTy(cx.env, fnSig)
         let coreIdx = coreIdent(cx.core, node.text, IkFn, fnTy, node.start, node.end)
         return ElabResult { node: coreIdx, ty: fnTy }
@@ -1512,6 +1520,27 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         }
     }
 
+    // Struct literal spread: `{ ..x, f: v, ... }`. The spread operand must
+    // produce a value of the same owner type; explicit fields below
+    // override spread values at runtime, so we collect spread-supplied
+    // names separately from `seenNames` (which still drives duplicate
+    // detection among the explicit fields).
+    let mut coreSpread = -1
+    let mut spreadSupplied: List<String> = []
+    if node.right >= 0 {
+        let spreadHint = tyNamed(tys, owner, freshs)
+        let spreadResult = elabCheck(cx, node.right, spreadHint)
+        coreSpread = spreadResult.node
+        let _ = unify(cx.env, solver, spreadHint, spreadResult.ty)
+        if tyIsNamedHead(tys, spreadResult.ty, owner) {
+            for f in cx.env.fields {
+                if f.owner == owner {
+                    spreadSupplied.push(f.name)
+                }
+            }
+        }
+    }
+
     let mut coreFieldsList: List<Int> = []
     let mut seenNames: List<String> = []
     for fieldIdx in node.children {
@@ -1534,9 +1563,13 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         coreFieldsList.push(coreStructField(cx.core, fieldName, r.node, fieldNode.start, fieldNode.end))
     }
 
-    // Missing required fields.
+    // Missing required fields — a spread supplies every field of the
+    // owner, so we skip fields supplied either explicitly or via spread.
     for f in cx.env.fields {
-        if f.owner == owner && !(stringListContains(seenNames, f.name)) && !(f.hasDefault) {
+        if f.owner == owner
+           && !(stringListContains(seenNames, f.name))
+           && !(stringListContains(spreadSupplied, f.name))
+           && !(f.hasDefault) {
             cx.env.diagnostics.push(diagMissingField(owner, f.name, node.start, node.end))
         }
     }
@@ -1549,7 +1582,7 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         tyNamed(tys, owner, concreteTypeArgs)
     }
 
-    let coreIdx = coreStruct(cx.core, owner, coreFieldsList, -1, concreteTypeArgs, resultTy, node.start, node.end)
+    let coreIdx = coreStruct(cx.core, owner, coreFieldsList, coreSpread, concreteTypeArgs, resultTy, node.start, node.end)
     ElabResult { node: coreIdx, ty: resultTy }
 }
 

--- a/toolchain/elab_test.osty
+++ b/toolchain/elab_test.osty
@@ -29,7 +29,7 @@ fn testElabLetWithMismatchTriggersDiagnostic() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0701"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0700"))
 }
 
 fn testElabLetTuplePatternBindsDestructuredNames() {
@@ -54,7 +54,7 @@ fn testElabLetRefutablePatternTriggersDiagnostic() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0744"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0741"))
     testing.assertEq(frontCheckResultBindingType(checked, "value"), "Int")
 }
 
@@ -148,7 +148,7 @@ fn testElabRejectsUnsatisfiedGenericBounds() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0721"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0749"))
 }
 
 fn testElabRespectsInterfaceExtendsWhenCheckingBounds() {
@@ -239,7 +239,7 @@ fn testElabRejectsUnsatisfiedOwnerGenericBounds() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0721"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0749"))
 }
 
 fn testElabIfElseJoinsBranches() {
@@ -314,7 +314,7 @@ fn testElabMatchExhaustivenessFailsWithoutCatchAll() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 fn testElabMatchBoolMissingFalse() {
@@ -328,7 +328,7 @@ fn testElabMatchBoolMissingFalse() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 fn testElabMatchBoolComplete() {
@@ -342,8 +342,8 @@ fn testElabMatchBoolComplete() {
             }
             """,
     )
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0706")))
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0707")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0731")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0740")))
 }
 
 fn testElabMatchOrPatternCoversBothBools() {
@@ -356,7 +356,7 @@ fn testElabMatchOrPatternCoversBothBools() {
             }
             """,
     )
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0706")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0731")))
 }
 
 fn testElabMatchIntRequiresCatchAll() {
@@ -371,7 +371,7 @@ fn testElabMatchIntRequiresCatchAll() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 fn testElabMatchOptionNonWildcardPayload() {
@@ -388,7 +388,7 @@ fn testElabMatchOptionNonWildcardPayload() {
     // Phase 1 treats `Some(42)` as non-covering (payload is a literal,
     // not irrefutable), so the match is non-exhaustive with witness
     // `Option.Some(_)`.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 fn testElabMatchReachabilityDuplicateTrue() {
@@ -403,7 +403,7 @@ fn testElabMatchReachabilityDuplicateTrue() {
             }
             """,
     )
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchReachabilityCatchAllBeforeSpecific() {
@@ -419,7 +419,7 @@ fn testElabMatchReachabilityCatchAllBeforeSpecific() {
             }
             """,
     )
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchReachabilityGuardedDoesNotShadow() {
@@ -437,7 +437,7 @@ fn testElabMatchReachabilityGuardedDoesNotShadow() {
     )
     // Guarded arm must not cause the trailing catch-all to be flagged
     // unreachable, because the guard can fail.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0707")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0740")))
 }
 
 // ---------------------------------------------------------------------
@@ -456,7 +456,7 @@ fn testElabMatchPhase2OrPatternExhaustsOption() {
     )
     // Phase 2 recognises `Some(_) | None` as full enumeration without
     // a catch-all.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0706")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0731")))
 }
 
 fn testElabMatchPhase2NestedOptionExhaustive() {
@@ -471,7 +471,7 @@ fn testElabMatchPhase2NestedOptionExhaustive() {
             }
             """,
     )
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0706")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0731")))
 }
 
 fn testElabMatchPhase2NestedOptionMissingInner() {
@@ -486,7 +486,7 @@ fn testElabMatchPhase2NestedOptionMissingInner() {
             """,
     )
     // `Some(None)` is missing — E0706 witness should mention it.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 fn testElabMatchPhase2PayloadReachabilityDuplicate() {
@@ -501,7 +501,7 @@ fn testElabMatchPhase2PayloadReachabilityDuplicate() {
             }
             """,
     )
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase2TupleCartesianExhaustive() {
@@ -518,7 +518,7 @@ fn testElabMatchPhase2TupleCartesianExhaustive() {
     )
     // (true, _) covers {(true, true), (true, false)} and the other two
     // arms cover the false column; Phase 2 recognises the cartesian.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0706")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0731")))
 }
 
 fn testElabMatchPhase2TupleMissingSlot() {
@@ -533,7 +533,7 @@ fn testElabMatchPhase2TupleMissingSlot() {
             """,
     )
     // Missing (true, false) and (false, true). Phase 2 reports E0706.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 // ---------------------------------------------------------------------
@@ -556,8 +556,8 @@ fn testElabMatchPhase3MultiWitnessListsMultipleMissing() {
     // both in its witness phrase. We only assert the code fires once;
     // witness inspection (string contains "Green" and "Blue") is left
     // to the golden snapshot when the harness runs this file.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
-    testing.assertEq(elabDiagCodeCount(checked.diagnostics, "E0706"), 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
+    testing.assertEq(elabDiagCodeCount(checked.diagnostics, "E0731"), 1)
 }
 
 fn testElabMatchPhase3OrPatternRedundantAlt() {
@@ -575,7 +575,7 @@ fn testElabMatchPhase3OrPatternRedundantAlt() {
             """,
     )
     // `Red | Red` — the second alt is redundant, arm flagged unreachable.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase3OrPatternSubsumedByPriorArm() {
@@ -592,7 +592,7 @@ fn testElabMatchPhase3OrPatternSubsumedByPriorArm() {
     // Arm 2's `true` alternative is subsumed by arm 1; E0707 fires.
     // (The `false` alternative is still useful but the redundancy in the
     // or-pat is reported at the arm level.)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn elabDiagCodeCount(diags: List<CheckDiagnostic>, code: String) -> Int {
@@ -622,7 +622,7 @@ fn testElabMatchPhase4IntLiteralInsidePriorRange() {
             """,
     )
     // `3` falls inside `1..=5` → arm 2 is unreachable.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase4IntLiteralOutsidePriorRange() {
@@ -638,7 +638,7 @@ fn testElabMatchPhase4IntLiteralOutsidePriorRange() {
             """,
     )
     // `7` is outside `1..=5` → arm 2 is reachable.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0707")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0740")))
 }
 
 fn testElabMatchPhase4RangeContainedInPriorRange() {
@@ -654,7 +654,7 @@ fn testElabMatchPhase4RangeContainedInPriorRange() {
             """,
     )
     // `2..=8` ⊂ `0..=10` → arm 2 is unreachable.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase4RangeEscapesPriorRange() {
@@ -670,7 +670,7 @@ fn testElabMatchPhase4RangeEscapesPriorRange() {
             """,
     )
     // `3..=10` extends beyond `0..=5` → arm 2 is reachable.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0707")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0740")))
 }
 
 fn testElabMatchPhase4NegativeIntLiteral() {
@@ -686,7 +686,7 @@ fn testElabMatchPhase4NegativeIntLiteral() {
             """,
     )
     // `-3` is in `-5..=5` → arm 2 is unreachable.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase4StructExhaustive() {
@@ -703,7 +703,7 @@ fn testElabMatchPhase4StructExhaustive() {
     )
     // Struct has exactly one constructor; the all-wildcard match is
     // exhaustive without a catch-all.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0706")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0731")))
 }
 
 fn testElabMatchPhase4StructNonExhaustive() {
@@ -719,7 +719,7 @@ fn testElabMatchPhase4StructNonExhaustive() {
             """,
     )
     // Missing `Flags { a: false, b: _ }` branch → E0706 reports it.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0706"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0731"))
 }
 
 // ---------------------------------------------------------------------
@@ -739,7 +739,7 @@ fn testElabMatchPhase5HexLiteralInsidePriorRange() {
             """,
     )
     // 0x10 == 16, inside [0, 31].
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase5BinLiteralInsidePriorRange() {
@@ -755,7 +755,7 @@ fn testElabMatchPhase5BinLiteralInsidePriorRange() {
             """,
     )
     // 0b1010 == 10, inside [0, 15].
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase5OctLiteralInsidePriorRange() {
@@ -771,7 +771,7 @@ fn testElabMatchPhase5OctLiteralInsidePriorRange() {
             """,
     )
     // 0o77 == 63, inside [0, 100].
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase5UnboundedLoRangeCoversLiteral() {
@@ -787,7 +787,7 @@ fn testElabMatchPhase5UnboundedLoRangeCoversLiteral() {
             """,
     )
     // 3 ∈ (-∞, 5].
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase5UnboundedHiRangeCoversLiteral() {
@@ -803,7 +803,7 @@ fn testElabMatchPhase5UnboundedHiRangeCoversLiteral() {
             """,
     )
     // 42 ∈ [10, +∞).
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabMatchPhase5UnboundedLoRangeRejectsOutside() {
@@ -819,7 +819,7 @@ fn testElabMatchPhase5UnboundedLoRangeRejectsOutside() {
             """,
     )
     // 7 ∉ (-∞, 5] → arm 2 reachable.
-    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0707")))
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0740")))
 }
 
 fn testElabMatchPhase5BoundedRangeSubsumedByUnbounded() {
@@ -835,7 +835,7 @@ fn testElabMatchPhase5BoundedRangeSubsumedByUnbounded() {
             """,
     )
     // [5, 10] ⊂ [0, +∞) → arm 2 unreachable.
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0707"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0740"))
 }
 
 fn testElabQuestionOperatorRequiresOption() {
@@ -847,7 +847,201 @@ fn testElabQuestionOperatorRequiresOption() {
             """,
     )
     testing.assert(checked.summary.errors >= 1)
-    testing.assert(elabDiagHasCode(checked.diagnostics, "E0730"))
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0717"))
+}
+
+// ---------------------------------------------------------------------
+// G14 — generic callable value references.
+// ---------------------------------------------------------------------
+
+fn testElabGenericFnBareReferenceRejected() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn id<T>(x: T) -> T { x }
+
+            fn main() {
+                let g = id
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0742"))
+}
+
+fn testElabGenericFnTurbofishValueReferenceRejected() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn id<T>(x: T) -> T { x }
+
+            fn main() {
+                let g = id::<Int>
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0742"))
+}
+
+fn testElabGenericFnDirectCallAllowed() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn id<T>(x: T) -> T { x }
+
+            fn main() {
+                let r = id(1)
+            }
+            """,
+    )
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0742")))
+}
+
+fn testElabGenericFnTurbofishCallAllowed() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn id<T>(x: T) -> T { x }
+
+            fn main() {
+                let r = id::<Int>(1)
+            }
+            """,
+    )
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0742")))
+}
+
+fn testElabGenericFnClosureWrapAllowed() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn id<T>(x: T) -> T { x }
+
+            fn main() {
+                let g = |x: Int| id::<Int>(x)
+            }
+            """,
+    )
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0742")))
+}
+
+fn testElabNonGenericFnValueReferenceAllowed() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn add(x: Int, y: Int) -> Int { x + y }
+
+            fn main() {
+                let f = add
+            }
+            """,
+    )
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0742")))
+}
+
+// ---------------------------------------------------------------------
+// Struct spread (§A.2) — `{ ..x, field: v }`.
+// ---------------------------------------------------------------------
+
+fn testElabStructSpreadOverrideSingleField() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct P { x: Int, y: Int }
+
+            fn bump(p: P) -> P {
+                P { ..p, x: p.x + 1 }
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+}
+
+fn testElabStructSpreadCoversMissingFields() {
+    // Without spread the literal would be missing `y`, but `..p` supplies it.
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct P { x: Int, y: Int }
+
+            fn twiddle(p: P) -> P {
+                P { ..p, x: 5 }
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+    testing.assert(!(elabDiagHasCode(checked.diagnostics, "E0708")))
+}
+
+fn testElabStructLiteralWithoutSpreadStillRequiresAllFields() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct P { x: Int, y: Int }
+
+            fn partial() -> P {
+                P { x: 5 }
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0708"))
+}
+
+fn testElabStructSpreadRejectsWrongOwnerType() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct P { x: Int, y: Int }
+            struct Q { a: Int, b: Int }
+
+            fn bad(q: Q) -> P {
+                P { ..q, x: 5 }
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+}
+
+// ---------------------------------------------------------------------
+// G15 — function values erase default / keyword metadata.
+//
+// An `fn(...) -> R` type stores only positional parameter types; the
+// runtime therefore rejects calls that rely on defaults or keyword
+// arguments at the value site. Direct calls against the original
+// declaration still honor both. These tests pin that contract so a
+// future refactor cannot silently regrow default handling on fn values.
+// ---------------------------------------------------------------------
+
+fn testElabDirectCallHonorsDefaultArg() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn connect(host: String, port: Int = 80) -> Int { port }
+
+            fn main() {
+                let n = connect("api.com")
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
+}
+
+fn testElabFnValueCallRequiresExactArity() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn connect(host: String, port: Int = 80) -> Int { port }
+
+            fn call1(f: fn(String, Int) -> Int) -> Int {
+                f("api.com")
+            }
+            """,
+    )
+    testing.assert(checked.summary.errors >= 1)
+    testing.assert(elabDiagHasCode(checked.diagnostics, "E0701"))
+}
+
+fn testElabFnValueCallAcceptsAllPositional() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn connect(host: String, port: Int = 80) -> Int { port }
+
+            fn call2(f: fn(String, Int) -> Int) -> Int {
+                f("api.com", 443)
+            }
+            """,
+    )
+    testing.assertEq(checked.summary.errors, 0)
 }
 
 fn elabDiagHasCode(diags: List<CheckDiagnostic>, code: String) -> Bool {


### PR DESCRIPTION
## Summary

Two linked things: (1) collapse the E07xx diagnostic-code drift between `internal/diag/codes.go` (the `go:generate` source for `ERROR_CODES.md`) and `toolchain/check_diag.osty` (the runtime emitter) onto `codes.go` as canonical, (2) land three of four edge fixes on top of the clean namespace.

## Why

`codes.go` and `check_diag.osty` had silently split-brained. Same numbers meant different things (E0742: `GenericCallableReference` vs `PatternShapeMismatch`; E0706: `NotAStruct` vs `NonExhaustiveMatch`, and ~15 more), and each side carried codes the other didn't know about. `ERROR_CODES.md` is generated from `codes.go`, so once the selfhost checker wires up the type-check pipeline, users would have been reading one schema and receiving another. Fix it before adding new emission sites on top.

## What changed

**Diag namespace alignment** (`codes.go` canonical):
- Rename `CodeRefutableClosurePattern` → `CodeRefutablePattern`, broaden doc to cover `let` / `for-in` / closure-param (the three spec sites in §A.5, G16).
- Add 9 new codes at the free slots `E0744`–`E0749`, `E0751`–`E0753` for concepts the Osty side was using without Go counterparts: `OperandType`, `UnknownName`, `DuplicateField`, `DuplicateMethod`, `CannotInferTyParam`, `GenericBoundViolation`, `InterfaceNotSatisfied`, `ClosureAnnotationRequired`, `PatternShapeMismatch`.
- Rewrite `toolchain/check_diag.osty` so every `checkCode*()` returns the canonical number (function names unchanged — all elab.osty callsites unaffected).
- Update the orphan test files (`check_diag_test.osty`, `elab_test.osty`, ~45 assertions) to the new numbering.
- Regenerate `ERROR_CODES.md` via `go generate ./internal/diag/...`.

**G14** — reject generic callable value references (spec §G14, now emits [E0742](#)):
- `elabInferIdent` now checks `fnSig.generics.len() > 0` before building a function-value type and pushes `diagGenericCallableReference` instead. Covers bare `let g = f` and the turbofish value-ref `let g = f::<Int>` (the latter funnels through the same ident lookup).
- Direct calls `f(x)` and `f::<T>(x)` are untouched — the call path resolves via `checkLookupFn` without passing through `elabInferIdent`.
- Six tests: bare / turbofish-value rejected, direct-call / turbofish-call / closure-wrap / non-generic-value accepted.

**Struct spread merge** (spec §A.2):
- The parser stored the spread operand at `node.right`, but `elabInferStructLit` never read it — so `P { ..p, x: 5 }` wrongly fired `E0708` for every field supplied by `..p`.
- Now: elaborate the spread with the owner type as hint (propagates literal polymorphism into its sub-expressions), unify, collect its supplied field names into `spreadSupplied` separately from `seenNames` (so explicit overrides aren't flagged as duplicates), and pass the elaborated node through to `coreStruct`'s spread slot.
- Four tests: override, missing-field coverage by spread, no-spread-still-strict, wrong-owner rejection.

**G15** — pin the function-value arity contract:
- `FnType` stores only positional param types, so default and keyword metadata are naturally erased at the value site. `elabInferFnValueCall` already enforces exact arity via `diagArgCount`. Add three tests that lock this in: direct call honors default, fn-value call with missing positional fires E0701, full positional accepted.

## Deferred

- **E0743 escape analysis** (`Handle<T>` / `TaskGroup` / `Chan<T>`): these types aren't in the checker's type registry yet, so capability-tracking has nothing to hook on. Separate PR once the concurrency primitives register.
- **Prelude drift** (checker vs native backend structural-satisfaction judgement): architectural, needs spec-level decision on single source.
- **bootstrap-gen parser failure**: pre-existing (reproduces with all changes stashed on `main`) — `osty-bootstrap-gen: resolve: expected IDENT, got fn` blocks regenerating `internal/selfhost/generated.go`. All changes in this PR are source-level complete; they activate in the runtime once bootstrap-gen is fixed. Go build passes, `internal/diag` / `internal/check` / `internal/selfhost` / `internal/types` / `internal/parser` tests pass.

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./internal/diag/... ./internal/check/... ./internal/selfhost/... ./internal/types/... ./internal/parser/...` all pass
- [x] Pre-existing failures in `internal/llvmgen` and `internal/lsp` reproduced without this change (stash + rerun) — confirmed unrelated
- [x] `go generate ./internal/diag/...` re-runs cleanly; `ERROR_CODES.md` diff matches the new codes
- [ ] Runtime activation waits on bootstrap-gen repair (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)