### PR TITLE
feat(llvmgen): MIR → Osty primitive wiring — scalar + out-slot + Channel

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1420,9 +1420,12 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		return g.emitListPushOperand(listReg, i.Args[1], elemT)
 	case mir.IntrinsicListLen:
-		sym := "osty_rt_list_len"
+		sym := listRuntimeLenSymbol()
 		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "i64", []string{"ptr " + listReg})
+		em := g.ostyEmitter()
+		result := llvmListLen(em, &LlvmValue{typ: "ptr", name: listReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListIsEmpty:
 		sym := "osty_rt_list_is_empty"
 		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
@@ -1437,9 +1440,15 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		if listUsesTypedRuntime(elemLLVM) {
-			sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
+			sym := listRuntimeGetSymbol(elemLLVM)
 			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
-			return g.emitSimpleCall(i, sym, elemLLVM, []string{"ptr " + listReg, "i64 " + idxReg})
+			em := g.ostyEmitter()
+			result := llvmListGet(em,
+				&LlvmValue{typ: "ptr", name: listReg},
+				&LlvmValue{typ: "i64", name: idxReg},
+				elemLLVM)
+			g.flushOstyEmitter(em)
+			return g.storeIntrinsicResult(i, result)
 		}
 		// Composite element — use the bytes-v1 helper with a stack
 		// slot as the out-pointer. Backend writes the value into the
@@ -1453,7 +1462,10 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "list_sorted on element type "+elemLLVM)
 		}
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + listReg})
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicListToSet:
 		elemString := isStringLLVMType(elemT)
 		sym := listRuntimeToSetSymbol(elemLLVM, elemString)
@@ -1461,7 +1473,10 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "list_to_set on element type "+elemLLVM)
 		}
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + listReg})
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("list intrinsic kind %d", i.Kind))
 }
@@ -1487,13 +1502,19 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 	_ = valT
 	switch i.Kind {
 	case mir.IntrinsicMapLen:
-		sym := "osty_rt_map_len"
+		sym := llvmMapRuntimeLenSymbol()
 		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "i64", []string{"ptr " + mapReg})
+		em := g.ostyEmitter()
+		result := llvmMapLen(em, &LlvmValue{typ: "ptr", name: mapReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicMapKeys:
-		sym := "osty_rt_map_keys"
+		sym := mapRuntimeKeysSymbol()
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + mapReg})
+		em := g.ostyEmitter()
+		result := llvmMapKeys(em, &LlvmValue{typ: "ptr", name: mapReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicMapContains:
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "map_contains arity")
@@ -1502,9 +1523,15 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_map_contains_" + mapSetKeySuffix(keyLLVM, keyString)
+		sym := mapRuntimeContainsSymbol(keyLLVM, keyString)
 		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+keyLLVM+")")
-		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + mapReg, keyLLVM + " " + kReg})
+		em := g.ostyEmitter()
+		result := llvmMapContains(em,
+			&LlvmValue{typ: "ptr", name: mapReg},
+			&LlvmValue{typ: keyLLVM, name: kReg},
+			keyString)
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicMapGet:
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "map_get arity")
@@ -1558,25 +1585,21 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		vLLVM := g.llvmType(vOp.Type())
+		sym := mapRuntimeInsertSymbol(keyLLVM, keyString)
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
 		// Spill the value into a stack slot so the runtime can memcpy
 		// value_size bytes from it. This replaces the old inttoptr
 		// widening shim, which was semantically wrong for primitives
 		// (it passed the value bitpattern AS a pointer) and outright
 		// impossible for structs / tuples.
-		valSlot := g.spillToSlot(vReg, vLLVM)
-		sym := "osty_rt_map_insert_" + mapSetKeySuffix(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(mapReg)
-		g.fnBuf.WriteString(", ")
-		g.fnBuf.WriteString(keyLLVM)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(kReg)
-		g.fnBuf.WriteString(", ptr ")
-		g.fnBuf.WriteString(valSlot)
-		g.fnBuf.WriteString(")\n")
+		em := g.ostyEmitter()
+		slot := llvmSpillToSlot(em, &LlvmValue{typ: vLLVM, name: vReg})
+		llvmMapInsert(em,
+			&LlvmValue{typ: "ptr", name: mapReg},
+			&LlvmValue{typ: keyLLVM, name: kReg},
+			slot,
+			keyString)
+		g.flushOstyEmitter(em)
 		return nil
 	case mir.IntrinsicMapRemove:
 		if len(i.Args) != 2 {
@@ -1586,17 +1609,17 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_map_remove_" + mapSetKeySuffix(keyLLVM, keyString)
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+")")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(mapReg)
-		g.fnBuf.WriteString(", ")
-		g.fnBuf.WriteString(keyLLVM)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(kReg)
-		g.fnBuf.WriteString(")\n")
+		sym := mapRuntimeRemoveSymbol(keyLLVM, keyString)
+		// Runtime returns i1 (true = was present); MIR ignores it — the
+		// temp fall-through to DCE is fine but the decl must match the
+		// C runtime so the verifier accepts the call.
+		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+keyLLVM+")")
+		em := g.ostyEmitter()
+		_ = llvmMapRemove(em,
+			&LlvmValue{typ: "ptr", name: mapReg},
+			&LlvmValue{typ: keyLLVM, name: kReg},
+			keyString)
+		g.flushOstyEmitter(em)
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("map intrinsic kind %d", i.Kind))
@@ -1613,61 +1636,41 @@ func (g *mirGen) emitMapIntrinsic(i *mir.IntrinsicInstr) error {
 // Shared between `IntrinsicMapGet` and `IndexProj` on a map base so
 // `m.get(k)` and `m[k]` can't drift in ABI.
 func (g *mirGen) emitMapGetOrAbort(mapReg, keyReg, keyLLVM string, keyString bool, valLLVM, outSlot string) string {
+	sym := mapRuntimeGetOrAbortSymbol(keyLLVM, keyString)
+	g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
+	em := g.ostyEmitter()
+	var slot *LlvmValue
 	ownsSlot := outSlot == ""
 	if ownsSlot {
-		outSlot = g.fresh()
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(outSlot)
-		g.fnBuf.WriteString(" = alloca ")
-		g.fnBuf.WriteString(valLLVM)
-		g.fnBuf.WriteByte('\n')
+		slot = llvmAllocaSlot(em, valLLVM)
+	} else {
+		slot = &LlvmValue{typ: "ptr", name: outSlot, pointer: false}
 	}
-	sym := "osty_rt_map_get_or_abort_" + mapSetKeySuffix(keyLLVM, keyString)
-	g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+keyLLVM+", ptr)")
-	g.fnBuf.WriteString("  call void @")
-	g.fnBuf.WriteString(sym)
-	g.fnBuf.WriteString("(ptr ")
-	g.fnBuf.WriteString(mapReg)
-	g.fnBuf.WriteString(", ")
-	g.fnBuf.WriteString(keyLLVM)
-	g.fnBuf.WriteByte(' ')
-	g.fnBuf.WriteString(keyReg)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(outSlot)
-	g.fnBuf.WriteString(")\n")
+	llvmMapGetOrAbort(em,
+		&LlvmValue{typ: "ptr", name: mapReg},
+		&LlvmValue{typ: keyLLVM, name: keyReg},
+		slot,
+		keyString)
 	if !ownsSlot {
+		g.flushOstyEmitter(em)
 		return ""
 	}
-	loaded := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(loaded)
-	g.fnBuf.WriteString(" = load ")
-	g.fnBuf.WriteString(valLLVM)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(outSlot)
-	g.fnBuf.WriteByte('\n')
-	return loaded
+	loaded := llvmLoadFromSlot(em, slot, valLLVM)
+	g.flushOstyEmitter(em)
+	return loaded.name
 }
 
 // spillToSlot materialises `val` (an SSA register of `llvmType`) in
 // an `alloca <llvmType>` stack slot and returns the slot register.
 // Useful when a runtime call takes its value by pointer — composite
-// map values, composite list elements, etc.
+// map values, composite list elements, etc. Thin shim over the
+// Osty-owned `llvmSpillToSlot`; keep the `mirGen` receiver so existing
+// call sites don't need to thread an emitter.
 func (g *mirGen) spillToSlot(val, llvmType string) string {
-	slot := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteString(" = alloca ")
-	g.fnBuf.WriteString(llvmType)
-	g.fnBuf.WriteByte('\n')
-	g.fnBuf.WriteString("  store ")
-	g.fnBuf.WriteString(llvmType)
-	g.fnBuf.WriteByte(' ')
-	g.fnBuf.WriteString(val)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteByte('\n')
-	return slot
+	em := g.ostyEmitter()
+	slot := llvmSpillToSlot(em, &LlvmValue{typ: llvmType, name: val})
+	g.flushOstyEmitter(em)
+	return slot.name
 }
 
 // emitSetIntrinsic dispatches set intrinsics to runtime symbols.
@@ -1684,13 +1687,19 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 	elemString := isStringLLVMType(elemT)
 	switch i.Kind {
 	case mir.IntrinsicSetLen:
-		sym := "osty_rt_set_len"
+		sym := setRuntimeLenSymbol()
 		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "i64", []string{"ptr " + setReg})
+		em := g.ostyEmitter()
+		result := llvmSetLen(em, &LlvmValue{typ: "ptr", name: setReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicSetToList:
-		sym := "osty_rt_set_to_list"
+		sym := setRuntimeToListSymbol()
 		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "ptr", []string{"ptr " + setReg})
+		em := g.ostyEmitter()
+		result := llvmSetToList(em, &LlvmValue{typ: "ptr", name: setReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicSetContains:
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "set_contains arity")
@@ -1699,9 +1708,15 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_set_contains_" + mapSetKeySuffix(elemLLVM, elemString)
+		sym := setRuntimeContainsSymbol(elemLLVM, elemString)
 		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+elemLLVM+")")
-		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + setReg, elemLLVM + " " + vReg})
+		em := g.ostyEmitter()
+		result := llvmSetContains(em,
+			&LlvmValue{typ: "ptr", name: setReg},
+			&LlvmValue{typ: elemLLVM, name: vReg},
+			elemString)
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicSetInsert:
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "set_insert arity")
@@ -1710,17 +1725,17 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_set_insert_" + mapSetKeySuffix(elemLLVM, elemString)
-		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+elemLLVM+")")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(setReg)
-		g.fnBuf.WriteString(", ")
-		g.fnBuf.WriteString(elemLLVM)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(vReg)
-		g.fnBuf.WriteString(")\n")
+		sym := setRuntimeInsertSymbol(elemLLVM, elemString)
+		// Runtime returns i1 (true = newly added); MIR discards the
+		// result when this intrinsic is used as a statement. Decl must
+		// match the C runtime — the temp ends up DCE'd.
+		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+elemLLVM+")")
+		em := g.ostyEmitter()
+		_ = llvmSetInsert(em,
+			&LlvmValue{typ: "ptr", name: setReg},
+			&LlvmValue{typ: elemLLVM, name: vReg},
+			elemString)
+		g.flushOstyEmitter(em)
 		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("set intrinsic kind %d", i.Kind))
@@ -1745,20 +1760,20 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 	switch i.Kind {
 	case mir.IntrinsicChanMake:
-		// Args: [capacity]. Element type comes from the Dest's
-		// `Channel<T>` type.
 		if len(i.Args) != 1 {
 			return unsupported("mir-mvp", "chan_make arity")
 		}
-		cap, err := g.evalOperand(i.Args[0], mir.TInt)
+		capReg, err := g.evalOperand(i.Args[0], mir.TInt)
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_thread_chan_make"
+		sym := llvmChanRuntimeMakeSymbol()
 		g.declareRuntime(sym, "declare ptr @"+sym+"(i64)")
-		return g.emitSimpleCall(i, sym, "ptr", []string{"i64 " + cap})
+		em := g.ostyEmitter()
+		result := llvmChanMake(em, &LlvmValue{typ: "i64", name: capReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	case mir.IntrinsicChanSend:
-		// Args: [channel, value].
 		if len(i.Args) != 2 {
 			return unsupported("mir-mvp", "chan_send arity")
 		}
@@ -1777,51 +1792,28 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		elemLLVM := g.llvmType(elemT)
+		chanVal := &LlvmValue{typ: "ptr", name: chReg}
 		if listUsesTypedRuntime(elemLLVM) {
-			sym := "osty_rt_thread_chan_send_" + listRuntimeSymbolSuffix(elemLLVM)
+			sym := llvmChanRuntimeSendSymbol(llvmListElementSuffix(elemLLVM))
 			g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+elemLLVM+")")
-			g.fnBuf.WriteString("  call void @")
-			g.fnBuf.WriteString(sym)
-			g.fnBuf.WriteString("(ptr ")
-			g.fnBuf.WriteString(chReg)
-			g.fnBuf.WriteString(", ")
-			g.fnBuf.WriteString(elemLLVM)
-			g.fnBuf.WriteByte(' ')
-			g.fnBuf.WriteString(valReg)
-			g.fnBuf.WriteString(")\n")
+			em := g.ostyEmitter()
+			llvmChanSend(em, chanVal, &LlvmValue{typ: elemLLVM, name: valReg})
+			g.flushOstyEmitter(em)
 			return nil
 		}
 		// Composite element — bytes fallback.
-		slot := g.fresh()
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(slot)
-		g.fnBuf.WriteString(" = alloca ")
-		g.fnBuf.WriteString(elemLLVM)
-		g.fnBuf.WriteByte('\n')
-		g.fnBuf.WriteString("  store ")
-		g.fnBuf.WriteString(elemLLVM)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(valReg)
-		g.fnBuf.WriteString(", ptr ")
-		g.fnBuf.WriteString(slot)
-		g.fnBuf.WriteByte('\n')
-		sizeReg := g.emitSizeOf(elemLLVM)
-		sym := "osty_rt_thread_chan_send_bytes_v1"
+		sym := llvmChanRuntimeSendBytesSymbol()
 		g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, i64)")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(chReg)
-		g.fnBuf.WriteString(", ptr ")
-		g.fnBuf.WriteString(slot)
-		g.fnBuf.WriteString(", i64 ")
-		g.fnBuf.WriteString(sizeReg)
-		g.fnBuf.WriteString(")\n")
+		em := g.ostyEmitter()
+		slot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: valReg})
+		size := llvmSizeOf(em, elemLLVM)
+		llvmChanSendBytes(em, chanVal, slot, size)
+		g.flushOstyEmitter(em)
 		return nil
 	case mir.IntrinsicChanRecv:
-		// Args: [channel]. Dest receives Option<T>. The runtime
-		// returns a `{i64 disc, i64 payload}` aggregate matching the
-		// MIR enum layout, so we call and store directly.
+		// Dest receives Option<T>. The runtime returns a `{i64 disc,
+		// i64 payload}` aggregate matching the MIR enum layout, so we
+		// call and store directly.
 		if len(i.Args) != 1 {
 			return unsupported("mir-mvp", "chan_recv arity")
 		}
@@ -1835,33 +1827,21 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 			return unsupported("mir-mvp", "chan_recv: missing element type")
 		}
 		elemLLVM := g.llvmType(elemT)
-		sym := "osty_rt_thread_chan_recv_" + chanRecvSuffix(elemLLVM)
+		sym := llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemLLVM))
 		g.declareRuntime(sym, "declare { i64, i64 } @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmChanRecv(em, &LlvmValue{typ: "ptr", name: chReg}, elemLLVM)
 		if i.Dest == nil {
-			g.fnBuf.WriteString("  call { i64, i64 } @")
-			g.fnBuf.WriteString(sym)
-			g.fnBuf.WriteString("(ptr ")
-			g.fnBuf.WriteString(chReg)
-			g.fnBuf.WriteString(")\n")
+			g.flushOstyEmitter(em)
 			return nil
 		}
-		tmp := g.fresh()
-		g.fnBuf.WriteString("  ")
-		g.fnBuf.WriteString(tmp)
-		g.fnBuf.WriteString(" = call { i64, i64 } @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(chReg)
-		g.fnBuf.WriteString(")\n")
 		destLoc := g.fn.Local(i.Dest.Local)
 		if destLoc == nil {
+			g.flushOstyEmitter(em)
 			return fmt.Errorf("mir-mvp: chan_recv dest %d", i.Dest.Local)
 		}
-		g.fnBuf.WriteString("  store { i64, i64 } ")
-		g.fnBuf.WriteString(tmp)
-		g.fnBuf.WriteString(", ptr ")
-		g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
-		g.fnBuf.WriteByte('\n')
+		em.body = append(em.body, fmt.Sprintf("  store { i64, i64 } %s, ptr %s", result.name, g.localSlots[i.Dest.Local]))
+		g.flushOstyEmitter(em)
 		return nil
 	case mir.IntrinsicChanClose:
 		if len(i.Args) != 1 {
@@ -1871,13 +1851,11 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_thread_chan_close"
+		sym := llvmChanRuntimeCloseSymbol()
 		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(chReg)
-		g.fnBuf.WriteString(")\n")
+		em := g.ostyEmitter()
+		llvmChanClose(em, &LlvmValue{typ: "ptr", name: chReg})
+		g.flushOstyEmitter(em)
 		return nil
 	case mir.IntrinsicChanIsClosed:
 		if len(i.Args) != 1 {
@@ -1887,9 +1865,12 @@ func (g *mirGen) emitChannelIntrinsic(i *mir.IntrinsicInstr) error {
 		if err != nil {
 			return err
 		}
-		sym := "osty_rt_thread_chan_is_closed"
+		sym := llvmChanRuntimeIsClosedSymbol()
 		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
-		return g.emitSimpleCall(i, sym, "i1", []string{"ptr " + chReg})
+		em := g.ostyEmitter()
+		result := llvmChanIsClosed(em, &LlvmValue{typ: "ptr", name: chReg})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("channel intrinsic kind %d", i.Kind))
 }
@@ -1904,13 +1885,10 @@ func channelElementType(t mir.Type) mir.Type {
 }
 
 // chanRecvSuffix maps an element LLVM type to the `_<suffix>` used by
-// the chan_recv runtime. Composite element types route through a
-// bytes variant that writes into an out-param slot.
+// the chan_recv runtime. Delegates to the Osty-owned policy so the
+// scalar/composite split stays in lockstep with `llvmChanRecv`.
 func chanRecvSuffix(elemLLVM string) string {
-	if listUsesTypedRuntime(elemLLVM) {
-		return listRuntimeSymbolSuffix(elemLLVM)
-	}
-	return "bytes_v1"
+	return llvmChanElementSuffix(elemLLVM)
 }
 
 // emitTaskIntrinsic dispatches structured-task ops to runtime symbols.
@@ -3005,17 +2983,16 @@ func (g *mirGen) emitListLiteral(rv *mir.AggregateRV, aggT mir.Type) (string, er
 	if elemT == nil {
 		return "", unsupported("mir-mvp", "list literal: missing element type")
 	}
-	g.declareRuntime("osty_rt_list_new", "declare ptr @osty_rt_list_new()")
-	list := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(list)
-	g.fnBuf.WriteString(" = call ptr @osty_rt_list_new()\n")
+	g.declareRuntime(listRuntimeNewSymbol(), "declare ptr @"+listRuntimeNewSymbol()+"()")
+	em := g.ostyEmitter()
+	listVal := llvmListNew(em)
+	g.flushOstyEmitter(em)
 	for _, f := range rv.Fields {
-		if err := g.emitListPushOperand(list, f, elemT); err != nil {
+		if err := g.emitListPushOperand(listVal.name, f, elemT); err != nil {
 			return "", err
 		}
 	}
-	return list, nil
+	return listVal.name, nil
 }
 
 // emitListPushOperand pushes one value onto a list by runtime ABI
@@ -3028,47 +3005,29 @@ func (g *mirGen) emitListPushOperand(listReg string, op mir.Operand, elemT mir.T
 	}
 	elemLLVM := g.llvmType(elemT)
 	if listUsesTypedRuntime(elemLLVM) {
-		sym := "osty_rt_list_push_" + listRuntimeSymbolSuffix(elemLLVM)
+		sym := listRuntimePushSymbol(elemLLVM)
 		g.declareRuntime(sym, "declare void @"+sym+"(ptr, "+elemLLVM+")")
-		g.fnBuf.WriteString("  call void @")
-		g.fnBuf.WriteString(sym)
-		g.fnBuf.WriteString("(ptr ")
-		g.fnBuf.WriteString(listReg)
-		g.fnBuf.WriteString(", ")
-		g.fnBuf.WriteString(elemLLVM)
-		g.fnBuf.WriteByte(' ')
-		g.fnBuf.WriteString(val)
-		g.fnBuf.WriteString(")\n")
+		em := g.ostyEmitter()
+		llvmListPush(em,
+			&LlvmValue{typ: "ptr", name: listReg, pointer: false},
+			&LlvmValue{typ: elemLLVM, name: val, pointer: false})
+		g.flushOstyEmitter(em)
 		return nil
 	}
 	// Composite element (struct / tuple) — stage into a stack slot,
 	// compute the size via the `getelementptr null, 1` idiom, and
 	// call the bytes helper.
-	slot := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteString(" = alloca ")
-	g.fnBuf.WriteString(elemLLVM)
-	g.fnBuf.WriteByte('\n')
-	g.fnBuf.WriteString("  store ")
-	g.fnBuf.WriteString(elemLLVM)
-	g.fnBuf.WriteByte(' ')
-	g.fnBuf.WriteString(val)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteByte('\n')
-	sizeReg := g.emitSizeOf(elemLLVM)
-	sym := "osty_rt_list_push_bytes_v1"
+	sym := listRuntimePushBytesV1Symbol()
 	g.declareRuntime(sym, "declare void @"+sym+"(ptr, ptr, i64)")
-	g.fnBuf.WriteString("  call void @")
-	g.fnBuf.WriteString(sym)
-	g.fnBuf.WriteString("(ptr ")
-	g.fnBuf.WriteString(listReg)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteString(", i64 ")
-	g.fnBuf.WriteString(sizeReg)
-	g.fnBuf.WriteString(")\n")
+	em := g.ostyEmitter()
+	slot := llvmSpillToSlot(em, &LlvmValue{typ: elemLLVM, name: val})
+	size := llvmSizeOf(em, elemLLVM)
+	llvmCallVoid(em, sym, []*LlvmValue{
+		{typ: "ptr", name: listReg},
+		slot,
+		size,
+	})
+	g.flushOstyEmitter(em)
 	return nil
 }
 
@@ -3078,71 +3037,42 @@ func (g *mirGen) emitListPushOperand(listReg string, op mir.Operand, elemT mir.T
 // the intrinsic's optional destination.
 func (g *mirGen) emitListGetBytes(i *mir.IntrinsicInstr, listReg, idxReg string, elemT mir.Type) error {
 	elemLLVM := g.llvmType(elemT)
-	slot := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteString(" = alloca ")
-	g.fnBuf.WriteString(elemLLVM)
-	g.fnBuf.WriteByte('\n')
-	sizeReg := g.emitSizeOf(elemLLVM)
-	sym := "osty_rt_list_get_bytes_v1"
+	sym := listRuntimeGetBytesV1Symbol()
 	g.declareRuntime(sym, "declare void @"+sym+"(ptr, i64, ptr, i64)")
-	g.fnBuf.WriteString("  call void @")
-	g.fnBuf.WriteString(sym)
-	g.fnBuf.WriteString("(ptr ")
-	g.fnBuf.WriteString(listReg)
-	g.fnBuf.WriteString(", i64 ")
-	g.fnBuf.WriteString(idxReg)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteString(", i64 ")
-	g.fnBuf.WriteString(sizeReg)
-	g.fnBuf.WriteString(")\n")
+	em := g.ostyEmitter()
+	slot := llvmAllocaSlot(em, elemLLVM)
+	size := llvmSizeOf(em, elemLLVM)
+	llvmCallVoid(em, sym, []*LlvmValue{
+		{typ: "ptr", name: listReg},
+		{typ: "i64", name: idxReg},
+		slot,
+		size,
+	})
 	if i.Dest == nil {
+		g.flushOstyEmitter(em)
 		return nil
 	}
 	destLoc := g.fn.Local(i.Dest.Local)
 	if destLoc == nil {
+		g.flushOstyEmitter(em)
 		return fmt.Errorf("mir-mvp: list_get_bytes into unknown local %d", i.Dest.Local)
 	}
-	// Load the staged value, then store into dest.
-	loaded := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(loaded)
-	g.fnBuf.WriteString(" = load ")
-	g.fnBuf.WriteString(elemLLVM)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(slot)
-	g.fnBuf.WriteByte('\n')
-	g.fnBuf.WriteString("  store ")
-	g.fnBuf.WriteString(g.llvmType(destLoc.Type))
-	g.fnBuf.WriteByte(' ')
-	g.fnBuf.WriteString(loaded)
-	g.fnBuf.WriteString(", ptr ")
-	g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
-	g.fnBuf.WriteByte('\n')
-	return nil
+	loaded := llvmLoadFromSlot(em, slot, elemLLVM)
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, loaded)
 }
 
 // emitSizeOf returns a fresh register holding the size in bytes of
 // the named LLVM type. Uses the standard `getelementptr null, 1`
 // idiom — LLVM's constant folder collapses it to a numeric literal
 // during opt. Works for any first-class type, including user
-// structs referenced by their `%Name` handle.
+// structs referenced by their `%Name` handle. Thin shim over the
+// Osty-owned `llvmSizeOf`.
 func (g *mirGen) emitSizeOf(llvmType string) string {
-	gep := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(gep)
-	g.fnBuf.WriteString(" = getelementptr ")
-	g.fnBuf.WriteString(llvmType)
-	g.fnBuf.WriteString(", ptr null, i32 1\n")
-	size := g.fresh()
-	g.fnBuf.WriteString("  ")
-	g.fnBuf.WriteString(size)
-	g.fnBuf.WriteString(" = ptrtoint ptr ")
-	g.fnBuf.WriteString(gep)
-	g.fnBuf.WriteString(" to i64\n")
-	return size
+	em := g.ostyEmitter()
+	size := llvmSizeOf(em, llvmType)
+	g.flushOstyEmitter(em)
+	return size.name
 }
 
 func listElemType(t mir.Type) mir.Type {
@@ -4052,6 +3982,58 @@ func (g *mirGen) fresh() string {
 	name := fmt.Sprintf("%%t%d", g.tempSeq)
 	g.tempSeq++
 	return name
+}
+
+// ostyEmitter returns an LlvmEmitter whose temp counter is seeded from
+// g.tempSeq. Call any Osty-authored emission helper (llvmListNew,
+// llvmListPush, …) against the returned emitter, then splice the
+// accumulated body into g.fnBuf via flushOstyEmitter. This is the
+// adapter that lets mir_generator.go delegate actual LLVM text to
+// toolchain/llvmgen.osty without double-counting temps.
+func (g *mirGen) ostyEmitter() *LlvmEmitter {
+	return &LlvmEmitter{temp: g.tempSeq, body: nil}
+}
+
+// flushOstyEmitter writes the emitter's body lines into g.fnBuf and
+// syncs the temp counter back. Every Osty helper output line already
+// carries its leading 2-space indent — we only need to add the
+// trailing newline.
+func (g *mirGen) flushOstyEmitter(em *LlvmEmitter) {
+	g.tempSeq = em.temp
+	for _, line := range em.body {
+		g.fnBuf.WriteString(line)
+		g.fnBuf.WriteByte('\n')
+	}
+}
+
+// storeIntrinsicResult handles the dest-local store half of the
+// old emitSimpleCall path after an Osty-authored helper has produced
+// the value-returning call. Returns nil when the intrinsic has no
+// destination (call result discarded); coerces scalar widths when the
+// dest local's type differs from what the runtime returned.
+func (g *mirGen) storeIntrinsicResult(i *mir.IntrinsicInstr, result *LlvmValue) error {
+	if i.Dest == nil {
+		return nil
+	}
+	destLoc := g.fn.Local(i.Dest.Local)
+	if destLoc == nil {
+		return nil
+	}
+	destLLVM := g.llvmType(destLoc.Type)
+	stored := result.name
+	if destLLVM != result.typ {
+		if widened, err := g.coerceValue(result.name, result.typ, destLLVM); err == nil {
+			stored = widened
+		}
+	}
+	g.fnBuf.WriteString("  store ")
+	g.fnBuf.WriteString(destLLVM)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(stored)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+	g.fnBuf.WriteByte('\n')
+	return nil
 }
 
 // ==== helpers ====

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -292,6 +292,27 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	}
 }
 
+func TestGeneratedListPushDispatchesBySuffix(t *testing.T) {
+	cases := []struct {
+		valTyp string
+		valReg string
+		want   string
+	}{
+		{"i64", "42", "call void @osty_rt_list_push_i64(ptr %list, i64 42)"},
+		{"i1", "true", "call void @osty_rt_list_push_i1(ptr %list, i1 true)"},
+		{"double", "3.14", "call void @osty_rt_list_push_f64(ptr %list, double 3.14)"},
+		{"ptr", "@.str0", "call void @osty_rt_list_push_ptr(ptr %list, ptr @.str0)"},
+	}
+	for _, c := range cases {
+		em := llvmEmitter()
+		llvmListPush(em,
+			&LlvmValue{typ: "ptr", name: "%list"},
+			&LlvmValue{typ: c.valTyp, name: c.valReg})
+		got := strings.Join(em.body, "\n")
+		assertGeneratedIRContains(t, got, c.want)
+	}
+}
+
 func TestGeneratedListRuntimeSymbolsAreOstyOwned(t *testing.T) {
 	cases := []struct {
 		name string
@@ -545,6 +566,95 @@ func TestGeneratedSetBasicSmokeIR(t *testing.T) {
 	assertGeneratedIRContains(t, ir, "= call i64 @osty_rt_set_len(ptr %t0)")
 	assertGeneratedIRContains(t, ir, "= call ptr @osty_rt_set_to_list(ptr %t0)")
 	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGeneratedChanRuntimeSymbolsAreOstyOwned(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"make", llvmChanRuntimeMakeSymbol(), "osty_rt_thread_chan_make"},
+		{"close", llvmChanRuntimeCloseSymbol(), "osty_rt_thread_chan_close"},
+		{"is_closed", llvmChanRuntimeIsClosedSymbol(), "osty_rt_thread_chan_is_closed"},
+		{"send_bytes", llvmChanRuntimeSendBytesSymbol(), "osty_rt_thread_chan_send_bytes_v1"},
+		{"send_i64", llvmChanRuntimeSendSymbol("i64"), "osty_rt_thread_chan_send_i64"},
+		{"send_f64", llvmChanRuntimeSendSymbol("f64"), "osty_rt_thread_chan_send_f64"},
+		{"recv_ptr", llvmChanRuntimeRecvSymbol("ptr"), "osty_rt_thread_chan_recv_ptr"},
+		{"recv_bytes", llvmChanRuntimeRecvSymbol("bytes_v1"), "osty_rt_thread_chan_recv_bytes_v1"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Fatalf("%s: got %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestGeneratedChanElementSuffixMatchesPolicy(t *testing.T) {
+	cases := []struct {
+		elem string
+		want string
+	}{
+		{"i64", "i64"},
+		{"i1", "i1"},
+		{"double", "f64"},
+		{"ptr", "ptr"},
+		{"%MyStruct", "bytes_v1"},
+		{"", "bytes_v1"},
+	}
+	for _, c := range cases {
+		if got := llvmChanElementSuffix(c.elem); got != c.want {
+			t.Fatalf("llvmChanElementSuffix(%q) = %q, want %q", c.elem, got, c.want)
+		}
+	}
+}
+
+func TestGeneratedChanRuntimeDeclarationsAreOstyOwned(t *testing.T) {
+	decls := strings.Join(llvmChanRuntimeDeclarations(), "\n")
+
+	want := []string{
+		"declare ptr @osty_rt_thread_chan_make(i64)",
+		"declare void @osty_rt_thread_chan_close(ptr)",
+		"declare i1 @osty_rt_thread_chan_is_closed(ptr)",
+		"declare void @osty_rt_thread_chan_send_i64(ptr, i64)",
+		"declare void @osty_rt_thread_chan_send_f64(ptr, double)",
+		"declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_bytes_v1(ptr)",
+	}
+	for _, w := range want {
+		assertGeneratedIRContains(t, decls, w)
+	}
+}
+
+func TestGeneratedChanSendDispatchesBySuffix(t *testing.T) {
+	cases := []struct {
+		valTyp string
+		valReg string
+		want   string
+	}{
+		{"i64", "42", "call void @osty_rt_thread_chan_send_i64(ptr %ch, i64 42)"},
+		{"double", "3.14", "call void @osty_rt_thread_chan_send_f64(ptr %ch, double 3.14)"},
+		{"ptr", "@.str0", "call void @osty_rt_thread_chan_send_ptr(ptr %ch, ptr @.str0)"},
+	}
+	for _, c := range cases {
+		em := llvmEmitter()
+		llvmChanSend(em,
+			&LlvmValue{typ: "ptr", name: "%ch"},
+			&LlvmValue{typ: c.valTyp, name: c.valReg})
+		got := strings.Join(em.body, "\n")
+		assertGeneratedIRContains(t, got, c.want)
+	}
+}
+
+func TestGeneratedChanRecvReturnsAggregate(t *testing.T) {
+	em := llvmEmitter()
+	result := llvmChanRecv(em, &LlvmValue{typ: "ptr", name: "%ch"}, "i64")
+	if result.typ != "{ i64, i64 }" {
+		t.Fatalf("recv result typ = %q, want %q", result.typ, "{ i64, i64 }")
+	}
+	assertGeneratedIRContains(t, strings.Join(em.body, "\n"),
+		"= call { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr %ch)")
 }
 
 func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -216,6 +216,32 @@ func llvmSlotAsPtr(slot *LlvmValue) *LlvmValue {
 	return &LlvmValue{typ: "ptr", name: slot.name, pointer: false}
 }
 
+func llvmAllocaSlot(emitter *LlvmEmitter, llvmType string) *LlvmValue {
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, llvmType))
+	return &LlvmValue{typ: "ptr", name: slot, pointer: false}
+}
+
+func llvmSpillToSlot(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	slot := llvmAllocaSlot(emitter, value.typ)
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", value.typ, value.name, slot.name))
+	return slot
+}
+
+func llvmLoadFromSlot(emitter *LlvmEmitter, slot *LlvmValue, llvmType string) *LlvmValue {
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, llvmType, slot.name))
+	return &LlvmValue{typ: llvmType, name: tmp, pointer: false}
+}
+
+func llvmSizeOf(emitter *LlvmEmitter, llvmType string) *LlvmValue {
+	gep := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", gep, llvmType))
+	size := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", size, gep))
+	return &LlvmValue{typ: "i64", name: size, pointer: false}
+}
+
 func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
 	// Osty: examples/selfhost-core/llvmgen.osty:166:5
 	ptr := llvmNextTemp(emitter)
@@ -856,6 +882,10 @@ func llvmRenderModuleWithSetRuntime(sourcePath string, target string, typeDefs [
 
 func llvmRenderModuleWithStringRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmStringRuntimeDeclarations(), definitions)
+}
+
+func llvmRenderModuleWithChannelRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmChanRuntimeDeclarations(), definitions)
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:581:1
@@ -1584,6 +1614,16 @@ func llvmListPushPtr(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
 	llvmCallVoid(emitter, "osty_rt_list_push_ptr", []*LlvmValue{list, value})
 }
 
+func llvmListPush(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	symbol := llvmListRuntimePushSymbol(llvmListElementSuffix(value.typ))
+	llvmCallVoid(emitter, symbol, []*LlvmValue{list, value})
+}
+
+func llvmListGet(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, elemTyp string) *LlvmValue {
+	symbol := llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
+	return llvmCall(emitter, elemTyp, symbol, []*LlvmValue{list, index})
+}
+
 func llvmListGetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_list_get_i64", []*LlvmValue{list, index})
 }
@@ -1736,6 +1776,26 @@ func llvmMapGetOrAbortString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue,
 	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", []*LlvmValue{m, key, outSlot})
 }
 
+func llvmMapContains(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
+	symbol := llvmMapRuntimeContainsSymbol(key.typ, isString)
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{m, key})
+}
+
+func llvmMapInsert(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue, isString bool) {
+	symbol := llvmMapRuntimeInsertSymbol(key.typ, isString)
+	llvmCallVoid(emitter, symbol, []*LlvmValue{m, key, valueSlot})
+}
+
+func llvmMapRemove(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
+	symbol := llvmMapRuntimeRemoveSymbol(key.typ, isString)
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{m, key})
+}
+
+func llvmMapGetOrAbort(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue, isString bool) {
+	symbol := llvmMapRuntimeGetOrAbortSymbol(key.typ, isString)
+	llvmCallVoid(emitter, symbol, []*LlvmValue{m, key, outSlot})
+}
+
 func llvmSetRuntimeDeclarations() []string {
 	return []string{
 		"declare ptr @osty_rt_set_new(i64)",
@@ -1829,6 +1889,96 @@ func llvmSetRemovePtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *Ll
 
 func llvmSetRemoveString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_string", []*LlvmValue{set, item})
+}
+
+func llvmSetContains(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
+	symbol := llvmSetRuntimeContainsSymbol(item.typ, isString)
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
+}
+
+func llvmSetInsert(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
+	symbol := llvmSetRuntimeInsertSymbol(item.typ, isString)
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
+}
+
+func llvmSetRemove(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
+	symbol := llvmSetRuntimeRemoveSymbol(item.typ, isString)
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
+}
+
+func llvmChanElementSuffix(elemTyp string) string {
+	if llvmListUsesTypedRuntime(elemTyp) {
+		return llvmListElementSuffix(elemTyp)
+	}
+	return "bytes_v1"
+}
+
+func llvmChanRuntimeMakeSymbol() string {
+	return "osty_rt_thread_chan_make"
+}
+
+func llvmChanRuntimeSendSymbol(suffix string) string {
+	return "osty_rt_thread_chan_send_" + suffix
+}
+
+func llvmChanRuntimeSendBytesSymbol() string {
+	return "osty_rt_thread_chan_send_bytes_v1"
+}
+
+func llvmChanRuntimeRecvSymbol(suffix string) string {
+	return "osty_rt_thread_chan_recv_" + suffix
+}
+
+func llvmChanRuntimeCloseSymbol() string {
+	return "osty_rt_thread_chan_close"
+}
+
+func llvmChanRuntimeIsClosedSymbol() string {
+	return "osty_rt_thread_chan_is_closed"
+}
+
+func llvmChanRuntimeDeclarations() []string {
+	return []string{
+		"declare ptr @osty_rt_thread_chan_make(i64)",
+		"declare void @osty_rt_thread_chan_close(ptr)",
+		"declare i1 @osty_rt_thread_chan_is_closed(ptr)",
+		"declare void @osty_rt_thread_chan_send_i64(ptr, i64)",
+		"declare void @osty_rt_thread_chan_send_i1(ptr, i1)",
+		"declare void @osty_rt_thread_chan_send_f64(ptr, double)",
+		"declare void @osty_rt_thread_chan_send_ptr(ptr, ptr)",
+		"declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_i1(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_f64(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_ptr(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_bytes_v1(ptr)",
+	}
+}
+
+func llvmChanMake(emitter *LlvmEmitter, capacity *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", llvmChanRuntimeMakeSymbol(), []*LlvmValue{capacity})
+}
+
+func llvmChanSend(emitter *LlvmEmitter, channel *LlvmValue, value *LlvmValue) {
+	symbol := llvmChanRuntimeSendSymbol(llvmListElementSuffix(value.typ))
+	llvmCallVoid(emitter, symbol, []*LlvmValue{channel, value})
+}
+
+func llvmChanSendBytes(emitter *LlvmEmitter, channel *LlvmValue, slot *LlvmValue, size *LlvmValue) {
+	llvmCallVoid(emitter, llvmChanRuntimeSendBytesSymbol(), []*LlvmValue{channel, slot, size})
+}
+
+func llvmChanRecv(emitter *LlvmEmitter, channel *LlvmValue, elemTyp string) *LlvmValue {
+	symbol := llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemTyp))
+	return llvmCall(emitter, "{ i64, i64 }", symbol, []*LlvmValue{channel})
+}
+
+func llvmChanClose(emitter *LlvmEmitter, channel *LlvmValue) {
+	llvmCallVoid(emitter, llvmChanRuntimeCloseSymbol(), []*LlvmValue{channel})
+}
+
+func llvmChanIsClosed(emitter *LlvmEmitter, channel *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", llvmChanRuntimeIsClosedSymbol(), []*LlvmValue{channel})
 }
 
 func llvmClosureEnvTypeName(elemTags []string) string {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -185,6 +185,53 @@ pub fn llvmSlotAsPtr(slot: LlvmValue) -> LlvmValue {
     LlvmValue { typ: "ptr", name: slot.name, pointer: false }
 }
 
+/// Emit a bare `%tN = alloca <type>` and return the slot as a plain
+/// `ptr`-typed LlvmValue. Unlike `llvmMutableLetSlot` this does not
+/// store an initial value or bind a name — the result is ready to
+/// hand directly to a runtime call that wants an out-pointer.
+pub fn llvmAllocaSlot(emitter: LlvmEmitter, llvmType: String) -> LlvmValue {
+    let slot = llvmNextTemp(emitter)
+    emitter.body.push("  {slot} = alloca {llvmType}")
+    LlvmValue { typ: "ptr", name: slot, pointer: false }
+}
+
+/// Emit `alloca <value.typ>` + `store <value.typ> <value>, ptr <slot>`
+/// and return the slot as a plain `ptr`-typed LlvmValue. Use when a
+/// runtime call wants the value spilled through memory (composite
+/// Map/List value ABI, channel bytes path, …).
+pub fn llvmSpillToSlot(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    let slot = llvmAllocaSlot(emitter, value.typ)
+    emitter.body.push("  store {value.typ} {value.name}, ptr {slot.name}")
+    slot
+}
+
+/// Emit `%tN = load <llvmType>, ptr <slot>` and return the loaded
+/// value. Use after a runtime call has written into a slot allocated
+/// by `llvmAllocaSlot` — the typed variant of `llvmLoad`, which needs
+/// a `pointer: true` slot struct.
+pub fn llvmLoadFromSlot(
+    emitter: LlvmEmitter,
+    slot: LlvmValue,
+    llvmType: String,
+) -> LlvmValue {
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push("  {tmp} = load {llvmType}, ptr {slot.name}")
+    LlvmValue { typ: llvmType, name: tmp, pointer: false }
+}
+
+/// Emit the `getelementptr null, 1` / `ptrtoint` idiom that yields the
+/// byte size of an LLVM type at codegen time. LLVM's constant folder
+/// collapses both instructions to a numeric literal during opt, so the
+/// runtime receives a bare integer. Works for any first-class type,
+/// including user structs referenced by their `%Name` handle.
+pub fn llvmSizeOf(emitter: LlvmEmitter, llvmType: String) -> LlvmValue {
+    let gep = llvmNextTemp(emitter)
+    emitter.body.push("  {gep} = getelementptr {llvmType}, ptr null, i32 1")
+    let size = llvmNextTemp(emitter)
+    emitter.body.push("  {size} = ptrtoint ptr {gep} to i64")
+    LlvmValue { typ: "i64", name: size, pointer: false }
+}
+
 pub fn llvmAssign(emitter: LlvmEmitter, name: String, value: LlvmValue) -> Bool {
     let lookup = llvmLookup(emitter, name)
     if !(lookup.found) || !(lookup.value.pointer) || lookup.value.typ != value.typ {
@@ -652,6 +699,23 @@ pub fn llvmRenderModuleWithSetRuntime(
         typeDefs,
         stringGlobals,
         llvmSetRuntimeDeclarations(),
+        definitions,
+    )
+}
+
+pub fn llvmRenderModuleWithChannelRuntime(
+    sourcePath: String,
+    target: String,
+    typeDefs: List<String>,
+    stringGlobals: List<LlvmStringGlobal>,
+    definitions: List<String>,
+) -> String {
+    llvmRenderModuleWithRuntimeDeclarations(
+        sourcePath,
+        target,
+        typeDefs,
+        stringGlobals,
+        llvmChanRuntimeDeclarations(),
         definitions,
     )
 }
@@ -1425,6 +1489,31 @@ pub fn llvmListPushPtr(emitter: LlvmEmitter, list: LlvmValue, value: LlvmValue) 
     llvmCallVoid(emitter, "osty_rt_list_push_ptr", [list, value])
 }
 
+/// Emit a typed `osty_rt_list_push_<suffix>` call, picking the runtime
+/// symbol from `value.typ`. Precondition: the caller has already
+/// verified `llvmListUsesTypedRuntime(value.typ)` — composite struct
+/// elements need the `push_bytes_v1` path which this helper does not
+/// cover.
+pub fn llvmListPush(emitter: LlvmEmitter, list: LlvmValue, value: LlvmValue) {
+    let symbol = llvmListRuntimePushSymbol(llvmListElementSuffix(value.typ))
+    llvmCallVoid(emitter, symbol, [list, value])
+}
+
+/// Emit a typed `osty_rt_list_get_<suffix>` call and return the loaded
+/// element. `elemTyp` is the LLVM element type (`"i64"`, `"double"`,
+/// `"ptr"`, …) and drives both the runtime suffix and the LLVM return
+/// type of the call. Typed path only — composite elements use the
+/// `get_bytes_v1` out-pointer ABI.
+pub fn llvmListGet(
+    emitter: LlvmEmitter,
+    list: LlvmValue,
+    index: LlvmValue,
+    elemTyp: String,
+) -> LlvmValue {
+    let symbol = llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
+    llvmCall(emitter, elemTyp, symbol, [list, index])
+}
+
 pub fn llvmListGetI64(emitter: LlvmEmitter, list: LlvmValue, index: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "i64", "osty_rt_list_get_i64", [list, index])
 }
@@ -1590,6 +1679,61 @@ pub fn llvmMapGetOrAbortString(emitter: LlvmEmitter, map: LlvmValue, key: LlvmVa
     llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", [map, key, outSlot])
 }
 
+/// Emit `osty_rt_map_contains_<suffix>(map, key)` picking the suffix
+/// from `key.typ` / `isString`. Returns the `i1` result register. Use
+/// `isString = true` when the key is a string-typed `ptr` so the
+/// runtime selects byte-wise hashing rather than pointer identity.
+pub fn llvmMapContains(
+    emitter: LlvmEmitter,
+    map: LlvmValue,
+    key: LlvmValue,
+    isString: Bool,
+) -> LlvmValue {
+    let symbol = llvmMapRuntimeContainsSymbol(key.typ, isString)
+    llvmCall(emitter, "i1", symbol, [map, key])
+}
+
+/// Emit `osty_rt_map_insert_<suffix>(map, key, ptr valueSlot)`. Caller
+/// must have already stashed the value in `valueSlot` via
+/// `llvmMutableLetSlot` + `llvmSlotAsPtr` — the runtime memcpys
+/// `value_size` bytes from the slot into its bucket.
+pub fn llvmMapInsert(
+    emitter: LlvmEmitter,
+    map: LlvmValue,
+    key: LlvmValue,
+    valueSlot: LlvmValue,
+    isString: Bool,
+) {
+    let symbol = llvmMapRuntimeInsertSymbol(key.typ, isString)
+    llvmCallVoid(emitter, symbol, [map, key, valueSlot])
+}
+
+/// Emit `osty_rt_map_remove_<suffix>(map, key)`. Returns an `i1` whose
+/// value is true when the key was present (and has now been erased).
+pub fn llvmMapRemove(
+    emitter: LlvmEmitter,
+    map: LlvmValue,
+    key: LlvmValue,
+    isString: Bool,
+) -> LlvmValue {
+    let symbol = llvmMapRuntimeRemoveSymbol(key.typ, isString)
+    llvmCall(emitter, "i1", symbol, [map, key])
+}
+
+/// Emit `osty_rt_map_get_or_abort_<suffix>(map, key, ptr outSlot)`.
+/// Runtime aborts the program on key-miss; on hit it writes
+/// `value_size` bytes into `outSlot`. Caller loads back from the slot.
+pub fn llvmMapGetOrAbort(
+    emitter: LlvmEmitter,
+    map: LlvmValue,
+    key: LlvmValue,
+    outSlot: LlvmValue,
+    isString: Bool,
+) {
+    let symbol = llvmMapRuntimeGetOrAbortSymbol(key.typ, isString)
+    llvmCallVoid(emitter, symbol, [map, key, outSlot])
+}
+
 /// LLVM forward declarations for the `osty_rt_set_*` C runtime surface.
 /// Unlike Map, Set items are passed through the typed ABI (by value),
 /// so the declaration set mirrors the 5 key variants directly. The
@@ -1691,6 +1835,148 @@ pub fn llvmSetRemovePtr(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -
 
 pub fn llvmSetRemoveString(emitter: LlvmEmitter, set: LlvmValue, item: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "i1", "osty_rt_set_remove_string", [set, item])
+}
+
+/// Emit `osty_rt_set_contains_<suffix>(set, item)` picking the suffix
+/// from `item.typ` / `isString`. Returns the `i1` membership result.
+pub fn llvmSetContains(
+    emitter: LlvmEmitter,
+    set: LlvmValue,
+    item: LlvmValue,
+    isString: Bool,
+) -> LlvmValue {
+    let symbol = llvmSetRuntimeContainsSymbol(item.typ, isString)
+    llvmCall(emitter, "i1", symbol, [set, item])
+}
+
+/// Emit `osty_rt_set_insert_<suffix>(set, item)`. Returns an `i1` whose
+/// value is true when the item was newly added (not already present).
+pub fn llvmSetInsert(
+    emitter: LlvmEmitter,
+    set: LlvmValue,
+    item: LlvmValue,
+    isString: Bool,
+) -> LlvmValue {
+    let symbol = llvmSetRuntimeInsertSymbol(item.typ, isString)
+    llvmCall(emitter, "i1", symbol, [set, item])
+}
+
+/// Emit `osty_rt_set_remove_<suffix>(set, item)`. Returns an `i1` that
+/// is true when the item was present and has now been removed.
+pub fn llvmSetRemove(
+    emitter: LlvmEmitter,
+    set: LlvmValue,
+    item: LlvmValue,
+    isString: Bool,
+) -> LlvmValue {
+    let symbol = llvmSetRuntimeRemoveSymbol(item.typ, isString)
+    llvmCall(emitter, "i1", symbol, [set, item])
+}
+
+/// Channel-element suffix follows the same "typed or bytes_v1" split
+/// as the other scalar-vs-composite runtime surfaces: i64/i1/f64/ptr
+/// get a typed entry point, everything else routes through the
+/// composite `_bytes_v1` helper that takes a `ptr size` out-param.
+pub fn llvmChanElementSuffix(elemTyp: String) -> String {
+    if llvmListUsesTypedRuntime(elemTyp) {
+        return llvmListElementSuffix(elemTyp)
+    }
+    "bytes_v1"
+}
+
+pub fn llvmChanRuntimeMakeSymbol() -> String {
+    "osty_rt_thread_chan_make"
+}
+
+pub fn llvmChanRuntimeSendSymbol(suffix: String) -> String {
+    "osty_rt_thread_chan_send_{suffix}"
+}
+
+pub fn llvmChanRuntimeSendBytesSymbol() -> String {
+    "osty_rt_thread_chan_send_bytes_v1"
+}
+
+pub fn llvmChanRuntimeRecvSymbol(suffix: String) -> String {
+    "osty_rt_thread_chan_recv_{suffix}"
+}
+
+pub fn llvmChanRuntimeCloseSymbol() -> String {
+    "osty_rt_thread_chan_close"
+}
+
+pub fn llvmChanRuntimeIsClosedSymbol() -> String {
+    "osty_rt_thread_chan_is_closed"
+}
+
+/// LLVM forward declarations for the `osty_rt_thread_chan_*` runtime.
+/// Returns all 10 entry points (make + close + is_closed + 4 typed
+/// send + 4 typed recv + 1 composite send + 1 composite recv). The
+/// Osty runtime that backs these symbols is still under construction —
+/// the native backend emits the declarations so modules that touch
+/// channels compile through the MIR path until the runtime lands.
+pub fn llvmChanRuntimeDeclarations() -> List<String> {
+    [
+        "declare ptr @osty_rt_thread_chan_make(i64)",
+        "declare void @osty_rt_thread_chan_close(ptr)",
+        "declare i1 @osty_rt_thread_chan_is_closed(ptr)",
+        "declare void @osty_rt_thread_chan_send_i64(ptr, i64)",
+        "declare void @osty_rt_thread_chan_send_i1(ptr, i1)",
+        "declare void @osty_rt_thread_chan_send_f64(ptr, double)",
+        "declare void @osty_rt_thread_chan_send_ptr(ptr, ptr)",
+        "declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)",
+        "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_i64(ptr)",
+        "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_i1(ptr)",
+        "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_f64(ptr)",
+        "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_ptr(ptr)",
+        "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_bytes_v1(ptr)",
+    ]
+}
+
+/// Emit `call ptr @osty_rt_thread_chan_make(i64 capacity)`.
+pub fn llvmChanMake(emitter: LlvmEmitter, capacity: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", llvmChanRuntimeMakeSymbol(), [capacity])
+}
+
+/// Emit a typed `osty_rt_thread_chan_send_<suffix>(ch, val)` picking
+/// the suffix from `value.typ`. Precondition: caller has verified
+/// `llvmListUsesTypedRuntime(value.typ)` — composite values route
+/// through `llvmChanSendBytes`.
+pub fn llvmChanSend(emitter: LlvmEmitter, channel: LlvmValue, value: LlvmValue) {
+    let symbol = llvmChanRuntimeSendSymbol(llvmListElementSuffix(value.typ))
+    llvmCallVoid(emitter, symbol, [channel, value])
+}
+
+/// Emit the composite-send path
+/// `osty_rt_thread_chan_send_bytes_v1(ch, ptr slot, i64 size)`. Caller
+/// has already spilled the value into `slot` and computed `size` via
+/// `llvmSpillToSlot` + `llvmSizeOf`.
+pub fn llvmChanSendBytes(
+    emitter: LlvmEmitter,
+    channel: LlvmValue,
+    slot: LlvmValue,
+    size: LlvmValue,
+) {
+    llvmCallVoid(emitter, llvmChanRuntimeSendBytesSymbol(), [channel, slot, size])
+}
+
+/// Emit `osty_rt_thread_chan_recv_<suffix>(ch)` and return the
+/// `{ i64 disc, i64 payload }` aggregate — matches the Option<T>
+/// enum layout the MIR lowerer expects, so callers can store it
+/// directly into their dest local.
+pub fn llvmChanRecv(emitter: LlvmEmitter, channel: LlvmValue, elemTyp: String) -> LlvmValue {
+    let symbol = llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemTyp))
+    llvmCall(emitter, "\{ i64, i64 \}", symbol, [channel])
+}
+
+/// Emit `call void @osty_rt_thread_chan_close(ptr ch)`.
+pub fn llvmChanClose(emitter: LlvmEmitter, channel: LlvmValue) {
+    llvmCallVoid(emitter, llvmChanRuntimeCloseSymbol(), [channel])
+}
+
+/// Emit `call i1 @osty_rt_thread_chan_is_closed(ptr ch)` and return
+/// the i1 result register.
+pub fn llvmChanIsClosed(emitter: LlvmEmitter, channel: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "i1", llvmChanRuntimeIsClosedSymbol(), [channel])
 }
 
 /// Build the canonical `ClosureEnv.<tag0>.<tag1>…` type name used by the

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -878,6 +878,24 @@ fn testLlvmSmokeBoolMutableIsOstyOwned() {
     assertLlvmContains(ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 42)")
 }
 
+fn testLlvmListPushDispatchesBySuffix() {
+    let i64Em = llvmEmitter()
+    let list = LlvmValue { typ: "ptr", name: "%list", pointer: false }
+    llvmListPush(i64Em, list, LlvmValue { typ: "i64", name: "42", pointer: false })
+    let i64Body = llvmTestStrings.join(i64Em.body, "\n")
+    assertLlvmContains(i64Body, "call void @osty_rt_list_push_i64(ptr %list, i64 42)")
+
+    let f64Em = llvmEmitter()
+    llvmListPush(f64Em, list, LlvmValue { typ: "double", name: "3.14", pointer: false })
+    let f64Body = llvmTestStrings.join(f64Em.body, "\n")
+    assertLlvmContains(f64Body, "call void @osty_rt_list_push_f64(ptr %list, double 3.14)")
+
+    let ptrEm = llvmEmitter()
+    llvmListPush(ptrEm, list, LlvmValue { typ: "ptr", name: "@.str0", pointer: false })
+    let ptrBody = llvmTestStrings.join(ptrEm.body, "\n")
+    assertLlvmContains(ptrBody, "call void @osty_rt_list_push_ptr(ptr %list, ptr @.str0)")
+}
+
 fn testLlvmListRuntimeSymbolsAreOstyOwned() {
     testing.assertEq(llvmListRuntimeNewSymbol(), "osty_rt_list_new")
     testing.assertEq(llvmListRuntimeLenSymbol(), "osty_rt_list_len")
@@ -1124,6 +1142,65 @@ fn testLlvmSmokeSetBasicIsOstyOwned() {
     assertLlvmContains(ir, "= call i64 @osty_rt_set_len(ptr %t0)")
     assertLlvmContains(ir, "= call ptr @osty_rt_set_to_list(ptr %t0)")
     assertLlvmContains(ir, "ret i32 0")
+}
+
+fn testLlvmChanRuntimeSymbolsAreOstyOwned() {
+    testing.assertEq(llvmChanRuntimeMakeSymbol(), "osty_rt_thread_chan_make")
+    testing.assertEq(llvmChanRuntimeCloseSymbol(), "osty_rt_thread_chan_close")
+    testing.assertEq(llvmChanRuntimeIsClosedSymbol(), "osty_rt_thread_chan_is_closed")
+    testing.assertEq(llvmChanRuntimeSendBytesSymbol(), "osty_rt_thread_chan_send_bytes_v1")
+    testing.assertEq(llvmChanRuntimeSendSymbol("i64"), "osty_rt_thread_chan_send_i64")
+    testing.assertEq(llvmChanRuntimeSendSymbol("f64"), "osty_rt_thread_chan_send_f64")
+    testing.assertEq(llvmChanRuntimeRecvSymbol("ptr"), "osty_rt_thread_chan_recv_ptr")
+    testing.assertEq(llvmChanRuntimeRecvSymbol("bytes_v1"), "osty_rt_thread_chan_recv_bytes_v1")
+}
+
+fn testLlvmChanElementSuffixMatchesPolicy() {
+    testing.assertEq(llvmChanElementSuffix("i64"), "i64")
+    testing.assertEq(llvmChanElementSuffix("i1"), "i1")
+    testing.assertEq(llvmChanElementSuffix("double"), "f64")
+    testing.assertEq(llvmChanElementSuffix("ptr"), "ptr")
+    testing.assertEq(llvmChanElementSuffix("%MyStruct"), "bytes_v1")
+    testing.assertEq(llvmChanElementSuffix(""), "bytes_v1")
+}
+
+fn testLlvmChanRuntimeDeclarationsAreOstyOwned() {
+    let declarations = llvmTestStrings.join(llvmChanRuntimeDeclarations(), "\n")
+
+    assertLlvmContains(declarations, "declare ptr @osty_rt_thread_chan_make(i64)")
+    assertLlvmContains(declarations, "declare void @osty_rt_thread_chan_close(ptr)")
+    assertLlvmContains(declarations, "declare i1 @osty_rt_thread_chan_is_closed(ptr)")
+    assertLlvmContains(declarations, "declare void @osty_rt_thread_chan_send_i64(ptr, i64)")
+    assertLlvmContains(declarations, "declare void @osty_rt_thread_chan_send_f64(ptr, double)")
+    assertLlvmContains(declarations, "declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)")
+    assertLlvmContains(declarations, "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_i64(ptr)")
+    assertLlvmContains(declarations, "declare \{ i64, i64 \} @osty_rt_thread_chan_recv_bytes_v1(ptr)")
+}
+
+fn testLlvmChanSendDispatchesBySuffix() {
+    let i64Em = llvmEmitter()
+    let ch = LlvmValue { typ: "ptr", name: "%ch", pointer: false }
+    llvmChanSend(i64Em, ch, LlvmValue { typ: "i64", name: "42", pointer: false })
+    assertLlvmContains(
+        llvmTestStrings.join(i64Em.body, "\n"),
+        "call void @osty_rt_thread_chan_send_i64(ptr %ch, i64 42)",
+    )
+
+    let f64Em = llvmEmitter()
+    llvmChanSend(f64Em, ch, LlvmValue { typ: "double", name: "3.14", pointer: false })
+    assertLlvmContains(
+        llvmTestStrings.join(f64Em.body, "\n"),
+        "call void @osty_rt_thread_chan_send_f64(ptr %ch, double 3.14)",
+    )
+}
+
+fn testLlvmChanRecvReturnsAggregate() {
+    let em = llvmEmitter()
+    let ch = LlvmValue { typ: "ptr", name: "%ch", pointer: false }
+    let recvRes = llvmChanRecv(em, ch, "i64")
+    let body = llvmTestStrings.join(em.body, "\n")
+    testing.assertEq(recvRes.typ, "\{ i64, i64 \}")
+    assertLlvmContains(body, "= call \{ i64, i64 \} @osty_rt_thread_chan_recv_i64(ptr %ch)")
 }
 
 fn testLlvmStringRuntimeSymbolsAreOstyOwned() {


### PR DESCRIPTION
## 요약

PR #285 (`feat(llvmgen): 컨테이너 + 문자열 + 클로저 방출 primitive Osty 소유로 이전`) 위에 얹는 **2차 wiring PR**. MIR generator가 Osty-authored emission primitive를 실제로 경유하도록 `mir_generator.go`의 hand-rolled LLVM 텍스트를 대부분 제거한다.

**두 PR 관계 (중요):**
- PR #285 — 1차 wiring. Symbol 이름 / 정책 / forward decl / emission primitive를 Osty로 이전.
- **이 PR (#286 가정)** — 2차 wiring. 위 primitive들을 `mir_generator.go`에서 실제로 호출하도록 배선.
- 두 브랜치 모두 `d8fe564` (PR #285 내용) 을 공유. 이 PR은 거기에 `5fcb936` 한 커밋 추가. GitHub diff UI상으로는 양쪽 내용이 함께 보이지만 실제 검토 포커스는 **`5fcb936` 커밋 하나**.
- PR #285 먼저 머지 → 이 PR의 diff는 자동으로 `5fcb936` 만 남음.

## 이 커밋 (`5fcb936`) 이 하는 일 — 4개 wedge

### Wedge 1 — parametric list push + mirGen ↔ Osty 브리지
- `llvmListPush(em, list, val)` — `value.typ` 로 심볼 suffix 자동 선택.
- **`mirGen.ostyEmitter()` / `flushOstyEmitter()`** — 모든 후속 migration의 기반. `tempSeq` 공유, Osty 헬퍼의 body를 `fnBuf`로 splice.
- `emitListLiteral` + `emitListPushOperand` typed path → `llvmListNew` / `llvmListPush` 경유.

### Wedge 2 — scalar intrinsic 이전
- 파라메트릭 헬퍼: `llvmListGet`, `llvmMapContains/Insert/Remove/GetOrAbort`, `llvmSetContains/Insert/Remove`.
- `storeIntrinsicResult(i, result)` — dest-local store 공통 헬퍼 (coerce 포함).
- 12개 intrinsic 경로 Osty 경유: List Len/Get (typed)/Sorted/ToSet, Map Len/Keys/Contains/Remove, Set Len/ToList/Contains/Insert.
- **Latent bug fix**: `IntrinsicMapRemove` / `IntrinsicSetInsert` forward decl 을 `void` → `i1` (C 런타임 실제 반환과 일치).

### Wedge 3 — out-slot 패턴 이전
- 공용 primitive: `llvmAllocaSlot`, `llvmSpillToSlot`, `llvmLoadFromSlot`, `llvmSizeOf`.
- `spillToSlot` / `emitSizeOf` Go 헬퍼 → Osty 위임 shim.
- alloca+store+call+load 시퀀스 5곳 전부 이전: `emitMapGetOrAbort` 내부, `IntrinsicMapSet`, `emitListGetBytes`, `emitListPushOperand` composite, Channel `ChanSend` composite.

### Wedge 4 — Channel 런타임 family 전체 Osty로
- 6개 symbol 빌더 + `llvmChanElementSuffix` 정책 + 13개 forward decl + 6개 방출 헬퍼 + `llvmRenderModuleWithChannelRuntime`.
- `emitChannelIntrinsic` 5개 ops 전부 Osty primitive 경유. `chanRecvSuffix` → `llvmChanElementSuffix` 위임.

## 수치

- `mir_generator.go`: **net −246 줄** (emission hand-roll 대부분 제거)
- `toolchain/llvmgen.osty`: +286 (parametric dispatcher + alloca family + Channel 표면)
- `support_snapshot.go`: +150 Go mirror
- Test: +187 (Osty 77 + Go 110)

## 테스트 계획

- [x] MIR 통합 테스트 byte-identical 유지: `TestGenerateListPushStmtUsesRuntimeABI`, `TestGenerateOpaqueListLiteralsUseRuntimeABI`, `TestGenerateForInOverListStringUsesRuntimeABI`, `TestGenerateCollectionsUseManagedRuntimeABI`, `TestGenerateListLenUsesRuntimeABI`, `TestGenerateFromMIRChanSendRecv`, `TestGenerateFromMIRChanMakeAndClose`, `TestMIRDualEmitFromSource`.
- [x] 새 포커스 테스트 20+개 — symbol 빌더, 정책, declaration, parametric dispatch, out-slot 시퀀스, recv aggregate 반환.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] Pre-existing 실패 (`TestGenerateModuleInterface*`, `TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields` 등) 는 pristine main 에서도 동일하게 실패 — `internal/check` churn, 이 PR 무관.

## 남은 hand-roll (follow-up)

Task / TaskGroup / Select / Parallel / Cancel intrinsics. 같은 migration 패턴 (symbol family → decl → emission helper → intrinsic 이전) 이지만 surface ~20+ 심볼이라 별도 PR로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)