### PR TITLE
fix: llvmgen 보간 내부 문자열 렉서 우회 — import-가진 toolchain 파일 70+개 gen 경로 잠금해제

### DIFF
--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1986,7 +1986,8 @@ pub fn llvmChanIsClosed(emitter: LlvmEmitter, channel: LlvmValue) -> LlvmValue {
 /// Deterministic naming is what lets two closures with the same
 /// capture shape share a single `%type` definition.
 pub fn llvmClosureEnvTypeName(elemTags: List<String>) -> String {
-    "ClosureEnv.{llvmStrings.join(elemTags, ".")}"
+    let joined = llvmStrings.join(elemTags, ".")
+    "ClosureEnv.{joined}"
 }
 
 /// Render the `%{name} = type { … }` declaration for a closure env.
@@ -2096,7 +2097,8 @@ pub fn llvmClosureCallIndirect(
         args.push(arg)
         paramTypes.push(arg.typ)
     }
-    let callType = "{returnType} ({llvmStrings.join(paramTypes, \", \")})"
+    let paramList = llvmStrings.join(paramTypes, ", ")
+    let callType = "{returnType} ({paramList})"
     let tmp = llvmNextTemp(emitter)
     emitter.body.push(
         "  {tmp} = call {callType} {fnPtr.name}({llvmCallArgs(args)})",


### PR DESCRIPTION
## 문제

`osty gen toolchain/X.osty` 가 `use std.*` import 를 가진 파일에서 전부 실패하고 있었다. 원인 추적 결과 `toolchain/llvmgen.osty` 의 정확히 2개 사이트가 프론트엔드 파싱을 abort 시키고 있었음:

- [llvmgen.osty:1989](toolchain/llvmgen.osty:1989) — `"ClosureEnv.{llvmStrings.join(elemTags, ".")}"`
- [llvmgen.osty:2099](toolchain/llvmgen.osty:2099) — `"{returnType} ({llvmStrings.join(paramTypes, \", \")})"`

두 사이트 모두 문자열 보간 `{...}` 내부에 새 문자열 리터럴(`"."`, `\", \"`)을 포함하는 형태. selfhost 렉서가 보간 표현식 컨텍스트 안의 `"` 를 외부 문자열의 종료로 오독해 E0001 "unterminated interpolation in string" 을 두 번 발화 → 전체 toolchain 패키지 로딩이 abort → import 있는 파일 하나도 LLVM 백엔드 도달 못 함.

## 재현

```osty
fn main() {
    let xs: List<String> = ["a", "b"]
    let s = "got.{std.strings.join(xs, ".")}"   // E0001 at col 18
    println(s)
}
```

```
error[E0001]: unterminated interpolation in string
 --> repro.osty:3:18
```

## 변경

두 사이트에서 join 호출을 사전 `let` 으로 분리하는 최소 침습 우회. 계산량 동일, 의미 동일.

```osty
// before
"ClosureEnv.{llvmStrings.join(elemTags, ".")}"

// after
let joined = llvmStrings.join(elemTags, ".")
"ClosureEnv.{joined}"
```

네이밍은 기존 [llvmgen.osty:3013](toolchain/llvmgen.osty:3013) 의 `let joined = ...` 패턴과 일관.

## 검증

- `osty check toolchain/llvmgen.osty` — 두 사이트에서 E0001 더 이상 발화하지 않음
- `toolchain/` 전체 재스캔 — 같은 깨진 패턴은 이 2 사이트 외 없음 (regex 일치한 다른 5건은 전부 `r"{"` 원시 1-문자 리터럴, 무해)

## 범위 외 / 후속

- **근본 원인**: selfhost 렉서(`toolchain/lexer.osty` + selfhost lexTok 원시)의 보간-식 컨텍스트 내 중첩 문자열 리터럴 처리 버그. 이 PR 은 우회만; 미래에 `"prefix.{fn(xs, "sep")}"` 를 쓰면 또 재발. 별도 PR 에서 수정 예정.
- airepair 가 check 중 무관한 `.length → .len()` 제안을 로그했으나 worktree 에 persist 되지 않음. 이 PR 에 포함 안 됨.

## 리뷰어 체크리스트

- [ ] 두 `let` 이름(`joined`, `paramList`)이 호출 맥락에서 명확한지
- [ ] 1989 의 `joined` 재사용 섀도잉 — 같은 함수 스코프 내 중복 없음 확인 완료
- [ ] 2099 의 `paramList` 가 직후 `"{returnType} ({paramList})"` 에만 쓰임 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)