### PR TITLE
fix(stdlib): json 백슬래시 이스케이프 렉서 버그 우회

### DIFF
--- a/internal/stdlib/modules/json.osty
+++ b/internal/stdlib/modules/json.osty
@@ -128,7 +128,8 @@ fn escapeJsonString(s: String) -> String {
         if c == 0x22 {
             out = "{out}\\\""
         } else if c == 0x5C {
-            out = "{out}\\\\"
+            let bs = "\\"
+            out = "{out}{bs}{bs}"
         } else if c == 0x08 {
             out = "{out}\\b"
         } else if c == 0x0C {


### PR DESCRIPTION
## Summary

- stdlib 전체 35개 `.osty` 파일을 parse 레벨로 점검. 유일한 parse 에러: [`internal/stdlib/modules/json.osty:131`](../blob/claude/gracious-jemison-3a0784/internal/stdlib/modules/json.osty#L131) 의 `out = "{out}\\\\"` 에서 `E0003 unknown escape sequence`.
- 소스는 정당한 Osty. 원인은 렉서(`internal/selfhost/generated.go`)의 stale `escaped` 플래그 — `toolchain/frontend.osty` 에서는 이미 제거됐지만 generated.go가 재생성되지 않음. `skip = escape.consumed` 와 `escaped = true` 가 동시에 세팅돼 `\x\\` 이스케이프 연쇄에서 이중 소비 발생.
- 해당 라인을 `let bs = "\\"; out = "{out}{bs}{bs}"` 로 바꿔 버그 패턴을 회피. 의미 동일, 주변 `out = "{out}..."` 리듬 유지.

## Why a workaround

- 근본 수정 경로(`go generate ./internal/selfhost/`)는 현재 `osty-bootstrap-gen` 의 resolve 에러로 깨져 있음 — toolchain 소스가 seed bootstrap 이 파싱할 수 있는 범위를 넘어섰기 때문.
- generated.go 수동 패치는 생성 파일 규칙에 어긋나고, 다른 세션과 충돌 위험도 있음.
- stdlib 소스 한 줄 수정이 가장 narrow 한 개입.
- 렉서 자체 수정은 별도 태스크로 분리 (세션에서 spawn chip 등록). 수정 완료 시 이 workaround는 원상 복구 가능.

## Test plan

- [x] `.bin/osty parse internal/stdlib/modules/json.osty` — 0 error
- [x] `.bin/osty parse` 전체 stdlib 35개 파일 — 0 error
- [x] `.bin/osty check internal/stdlib/modules/json.osty` — 213 native checker 에러 (pre-existing, stdlib-wide)
- [x] `go test -count=1 ./internal/stdlib ./internal/lexer ./internal/parser ./internal/check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)