### PR TITLE
feat(llvmgen): heterogeneous-payload enum lowering (boxed ABI)

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1234,12 +1234,26 @@ void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
 void osty_gc_root_bind_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_bind_v1"));
 void osty_gc_root_release_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.root_release_v1"));
 void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t root_slot_count) __asm__(OSTY_GC_SYMBOL("osty.gc.safepoint_v1"));
+void *osty_rt_enum_alloc_ptr_v1(const char *site) __asm__(OSTY_GC_SYMBOL("osty.rt.enum_alloc_ptr_v1"));
+void *osty_rt_enum_alloc_scalar_v1(const char *site) __asm__(OSTY_GC_SYMBOL("osty.rt.enum_alloc_scalar_v1"));
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) {
     if (byte_size < 0) {
         osty_rt_abort("negative GC allocation size");
     }
     return osty_gc_allocate_managed((size_t)byte_size, object_kind == 0 ? OSTY_GC_KIND_GENERIC : object_kind, site, NULL, NULL);
+}
+
+static void osty_rt_enum_ptr_payload_trace(void *payload) {
+    osty_gc_mark_root_slot(payload);
+}
+
+void *osty_rt_enum_alloc_ptr_v1(const char *site) {
+    return osty_gc_allocate_managed(8, OSTY_GC_KIND_GENERIC, site, osty_rt_enum_ptr_payload_trace, NULL);
+}
+
+void *osty_rt_enum_alloc_scalar_v1(const char *site) {
+    return osty_gc_allocate_managed(8, OSTY_GC_KIND_GENERIC, site, NULL, NULL);
 }
 
 void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) {

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -101,6 +101,7 @@ type enumInfo struct {
 	decl       *ast.EnumDecl
 	hasPayload bool
 	payloadTyp string
+	isBoxed    bool
 	variants   map[string]variantInfo
 }
 
@@ -122,6 +123,7 @@ type enumPatternInfo struct {
 	payloadType        string
 	payloadListElemTyp string
 	hasPayloadBinding  bool
+	isBoxed            bool
 }
 
 type tupleTypeInfo struct {
@@ -879,11 +881,11 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 				diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
 				return nil, unsupported(diag.kind, diag.message)
 			}
-			if info.payloadTyp == "" {
+			if info.payloadTyp == "" && !info.isBoxed {
 				info.payloadTyp = typ
 			} else if info.payloadTyp != typ {
-				diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, "", info.payloadTyp, typ)
-				return nil, unsupported(diag.kind, diag.message)
+				info.isBoxed = true
+				info.payloadTyp = ""
 			}
 			payloads = append(payloads, typ)
 			if listElemTyp, ok, err := llvmListElementType(variant.Fields[0], env); err != nil {
@@ -1363,6 +1365,9 @@ func (g *generator) constEnumVariantIdent(name string) (constValue, bool, error)
 }
 
 func (g *generator) constEnumVariant(info *enumInfo, variant variantInfo, payload *constValue) (constValue, error) {
+	if info.isBoxed {
+		return constValue{}, unsupportedf("type-system", "enum %q has heterogeneous (boxed) payloads; variants cannot be used in a constant expression because construction requires a runtime GC allocation. Use a constructor function (e.g. `fn makeX() -> %s { ... }`) and call it at runtime.", info.name, info.name)
+	}
 	if info.hasPayload {
 		payloadValue := constValue{typ: info.payloadTyp, init: llvmZeroLiteral(info.payloadTyp)}
 		if payload != nil {

--- a/internal/llvmgen/enum_heterogeneous_test.go
+++ b/internal/llvmgen/enum_heterogeneous_test.go
@@ -1,0 +1,292 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateHeterogeneousEnumDeclarationSucceeds confirms that a
+// heterogeneous-payload enum can be declared and registered in the LLVM
+// backend's type environment without erroring at collection time.
+// The enum lowers with a boxed `{i64 tag, ptr payload}` storage layout.
+func TestGenerateHeterogeneousEnumDeclarationSucceeds(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+fn main() {
+    println(0)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_decl.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error for unused boxed enum: %v", err)
+	}
+	if !strings.Contains(string(ir), "%SemPreIdent = type { i64, ptr }") {
+		t.Fatalf("generated IR missing boxed storage typedef:\n%s", ir)
+	}
+}
+
+// TestGenerateHeterogeneousEnumBoxedScalarConstruction verifies that
+// `SemPreIdent.PreNumber(42)` lowers to a GC heap allocation for the
+// payload, a store of the Int into that slot, and assembly of the
+// outer `{i64 tag, ptr}` aggregate.
+func TestGenerateHeterogeneousEnumBoxedScalarConstruction(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+fn main() {
+    let x = SemPreIdent.PreNumber(42)
+    let _ = x
+    println(0)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_ctor_scalar.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error for boxed scalar construction: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty.rt.enum_alloc_scalar_v1(ptr)",
+		"call ptr @osty.rt.enum_alloc_scalar_v1(ptr",
+		"store i64 42, ptr",
+		"insertvalue %SemPreIdent undef, i64 1, 0",
+		"insertvalue %SemPreIdent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateHeterogeneousEnumBoxedBareVariant verifies that
+// `SemPreIdent.PreNone`, a payload-free variant of a boxed enum, lowers
+// to `{i64 0, ptr null}` with no GC allocation.
+func TestGenerateHeterogeneousEnumBoxedBareVariant(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+fn main() {
+    let x = SemPreIdent.PreNone
+    let _ = x
+    println(0)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_ctor_bare.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error for boxed bare variant: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"insertvalue %SemPreIdent undef, i64 0, 0",
+		"insertvalue %SemPreIdent",
+		"ptr null, 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	// Bare variant must NOT allocate.
+	for _, symbol := range []string{"osty.rt.enum_alloc_ptr_v1", "osty.rt.enum_alloc_scalar_v1"} {
+		callMarker := "call ptr @" + symbol + "("
+		if strings.Contains(got, callMarker) {
+			t.Fatalf("bare variant unexpectedly emitted %s call:\n%s", symbol, got)
+		}
+	}
+}
+
+// TestGenerateHeterogeneousEnumMatchTagOnly verifies that matching a boxed
+// enum without binding any payload lowers to a tag extract + icmp chain.
+// No extractvalue/load of the heap payload is needed because no arm
+// binds it.
+func TestGenerateHeterogeneousEnumMatchTagOnly(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+fn describe(x: SemPreIdent) -> Int {
+    match x {
+        SemPreIdent.PreNone -> 0,
+        SemPreIdent.PreNumber(_) -> 1,
+        _ -> 2,
+    }
+}
+
+fn main() {
+    println(0)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_match_tag.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error for boxed tag match: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"extractvalue %SemPreIdent",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateHeterogeneousEnumSemverShape mirrors the real toolchain
+// SemPreIdent usage: 3-arm exhaustive match returning a String, with one
+// arm binding a String payload and another a bare variant fallback.
+// This is the end-to-end shape the toolchain port needs.
+func TestGenerateHeterogeneousEnumSemverShape(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+fn toText(x: SemPreIdent) -> String {
+    match x {
+        SemPreIdent.PreNone -> "none",
+        SemPreIdent.PreNumber(_) -> "num",
+        SemPreIdent.PreText(t) -> t,
+    }
+}
+
+fn main() {
+    let a = SemPreIdent.PreNone
+    let b = SemPreIdent.PreNumber(42)
+    let c = SemPreIdent.PreText("alpha")
+    let _ = toText(a)
+    let _ = toText(b)
+    let _ = toText(c)
+    println(0)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_semver.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error for semver-shape boxed enum: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"%SemPreIdent = type { i64, ptr }",
+		"call ptr @osty.rt.enum_alloc_scalar_v1(ptr",
+		"call ptr @osty.rt.enum_alloc_ptr_v1(ptr",
+		"store i64 42, ptr",
+		"store ptr",
+		"insertvalue %SemPreIdent undef, i64 0, 0",
+		"insertvalue %SemPreIdent undef, i64 1, 0",
+		"insertvalue %SemPreIdent undef, i64 2, 0",
+		"load ptr, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateHeterogeneousEnumConstRejectsWithActionableHint verifies that
+// using a boxed-payload enum variant in a constant expression (e.g. a top-level
+// `pub let X: T = EnumName.Variant`) is rejected with a diagnostic that points
+// the user at the runtime-constructor workaround.
+func TestGenerateHeterogeneousEnumConstRejectsWithActionableHint(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+pub let DefaultIdent: SemPreIdent = SemPreIdent.PreNone
+
+fn main() {
+    println(0)
+}
+`)
+
+	_, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_const.osty",
+	})
+	if err == nil {
+		t.Fatalf("Generate succeeded unexpectedly for const boxed variant")
+	}
+	diag := UnsupportedDiagnosticForError(err)
+	for _, want := range []string{
+		`enum "SemPreIdent"`,
+		"heterogeneous",
+		"constant expression",
+		"runtime GC allocation",
+		"constructor function",
+	} {
+		if !strings.Contains(diag.Message, want) {
+			t.Fatalf("diag.Message = %q, missing %q", diag.Message, want)
+		}
+	}
+}
+
+// TestGenerateHeterogeneousEnumMatchBindsBoxedPayload verifies that an arm
+// binding the payload of a boxed variant emits extractvalue for the heap
+// ptr at index 1 followed by a typed load of the payload from that ptr.
+func TestGenerateHeterogeneousEnumMatchBindsBoxedPayload(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum SemPreIdent {
+    PreNone,
+    PreNumber(Int),
+    PreText(String),
+}
+
+fn numberOrZero(x: SemPreIdent) -> Int {
+    match x {
+        SemPreIdent.PreNumber(n) -> n,
+        _ -> 0,
+    }
+}
+
+fn main() {
+    println(0)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_heterogeneous_match_bind.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error for boxed payload bind: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"extractvalue %SemPreIdent",
+		"load i64, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -527,6 +527,17 @@ func (g *generator) enumVariantIdent(name string) (value, bool, error) {
 }
 
 func (g *generator) enumVariantConstant(info *enumInfo, variant variantInfo) (value, error) {
+	if info.isBoxed {
+		if len(variant.payloads) != 0 {
+			return value{}, unsupportedf("expression", "enum variant %q requires a payload", variant.name)
+		}
+		emitter := g.toOstyEmitter()
+		out := llvmEnumBoxedBareVariant(emitter, info.typ, variant.tag)
+		g.takeOstyEmitter(emitter)
+		enumValue := fromOstyValue(out)
+		enumValue.rootPaths = g.rootPathsForType(info.typ)
+		return enumValue, nil
+	}
 	if info.hasPayload {
 		if len(variant.payloads) != 0 {
 			return value{}, unsupportedf("expression", "enum variant %q requires a payload", variant.name)
@@ -568,6 +579,16 @@ func (g *generator) enumVariantByField(expr *ast.FieldExpr) (enumVariantRef, boo
 func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, payload value) (value, error) {
 	if !info.hasPayload {
 		return value{}, unsupportedf("expression", "enum %q has no payload layout", info.name)
+	}
+	if info.isBoxed {
+		emitter := g.toOstyEmitter()
+		site := "enum." + info.name + "." + variant.name
+		out := llvmEnumBoxedPayloadVariant(emitter, info.typ, variant.tag, toOstyValue(payload), site)
+		g.takeOstyEmitter(emitter)
+		g.needsGCRuntime = true
+		enumValue := fromOstyValue(out)
+		enumValue.rootPaths = g.rootPathsForType(info.typ)
+		return enumValue, nil
 	}
 	if payload.typ != info.payloadTyp {
 		return value{}, unsupportedf("type-system", "enum %q variant %q payload type %s, want %s", info.name, variant.name, payload.typ, info.payloadTyp)
@@ -2087,7 +2108,13 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 		return nil
 	}
 	emitter := g.toOstyEmitter()
-	payload := llvmExtractValue(emitter, toOstyValue(scrutinee), pattern.payloadType, 1)
+	var payload *LlvmValue
+	if pattern.isBoxed {
+		heapPtr := llvmExtractValue(emitter, toOstyValue(scrutinee), "ptr", 1)
+		payload = llvmLoadFromSlot(emitter, heapPtr, pattern.payloadType)
+	} else {
+		payload = llvmExtractValue(emitter, toOstyValue(scrutinee), pattern.payloadType, 1)
+	}
 	g.takeOstyEmitter(emitter)
 	payloadValue := fromOstyValue(payload)
 	payloadValue.listElemTyp = pattern.payloadListElemTyp
@@ -2107,7 +2134,7 @@ func (g *generator) matchPayloadEnumPattern(info *enumInfo, pattern ast.Pattern)
 		if len(variant.payloads) != 0 {
 			return enumPatternInfo{}, true, unsupportedf("expression", "enum variant pattern %q must bind its payload", p.Name)
 		}
-		return enumPatternInfo{variant: variant}, true, nil
+		return enumPatternInfo{variant: variant, isBoxed: info.isBoxed}, true, nil
 	case *ast.VariantPat:
 		if len(p.Path) == 0 || len(p.Path) > 2 {
 			return enumPatternInfo{}, false, nil
@@ -2123,7 +2150,7 @@ func (g *generator) matchPayloadEnumPattern(info *enumInfo, pattern ast.Pattern)
 		if len(p.Args) != len(variant.payloads) {
 			return enumPatternInfo{}, true, unsupportedf("expression", "enum variant pattern %q payload count", name)
 		}
-		out := enumPatternInfo{variant: variant}
+		out := enumPatternInfo{variant: variant, isBoxed: info.isBoxed}
 		if len(variant.payloads) == 0 {
 			return out, true, nil
 		}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -200,7 +200,11 @@ func (g *generator) render(defs []string) []byte {
 	}
 	for _, info := range g.enums {
 		if info.hasPayload {
-			typeDefs = append(typeDefs, llvmStructTypeDef(info.name, []string{"i64", info.payloadTyp}))
+			payloadSlot := info.payloadTyp
+			if info.isBoxed {
+				payloadSlot = "ptr"
+			}
+			typeDefs = append(typeDefs, llvmStructTypeDef(info.name, []string{"i64", payloadSlot}))
 		}
 	}
 	if len(g.tupleTypes) != 0 {

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -254,7 +254,7 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if got, want := llvmEnumPayloadDiagnostic("Choice", "Some", "unsupported payload", "", "").message, `enum "Choice" variant "Some" payload: unsupported payload`; got != want {
 		t.Fatalf("llvmEnumPayloadDiagnostic(%q, %q, %q, %q, %q).message = %q, want %q", "Choice", "Some", "unsupported payload", "", "", got, want)
 	}
-	if got, want := llvmEnumPayloadDiagnostic("Choice", "Some", "", "i64", "double").message, `enum "Choice" mixes payload types i64 and double`; got != want {
+	if got, want := llvmEnumPayloadDiagnostic("Choice", "Some", "", "i64", "double").message, `enum "Choice" mixes payload types i64 and double; heterogeneous-payload enums require boxed representation (deferred)`; got != want {
 		t.Fatalf("llvmEnumPayloadDiagnostic(%q, %q, %q, %q, %q).message = %q, want %q", "Choice", "Some", "", "i64", "double", got, want)
 	}
 	if got, want := llvmRuntimeFfiHeaderUnsupported(true, 0), "methods are not supported"; got != want {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -150,6 +150,21 @@ func llvmEnumPayloadVariant(emitter *LlvmEmitter, typ string, tag int, payload *
 	return llvmStructLiteral(emitter, typ, []*LlvmValue{llvmEnumVariant(typ, tag), payload})
 }
 
+func llvmEnumBoxedPayloadVariant(emitter *LlvmEmitter, enumTyp string, tag int, payload *LlvmValue, site string) *LlvmValue {
+	symbol := "osty.rt.enum_alloc_scalar_v1"
+	if payload.typ == "ptr" {
+		symbol = "osty.rt.enum_alloc_ptr_v1"
+	}
+	heapPtr := llvmCall(emitter, "ptr", symbol, []*LlvmValue{llvmStringLiteral(emitter, site)})
+	llvmStore(emitter, heapPtr, payload)
+	return llvmStructLiteral(emitter, enumTyp, []*LlvmValue{llvmEnumVariant(enumTyp, tag), heapPtr})
+}
+
+func llvmEnumBoxedBareVariant(emitter *LlvmEmitter, enumTyp string, tag int) *LlvmValue {
+	nullPtr := &LlvmValue{typ: "ptr", name: "null", pointer: false}
+	return llvmStructLiteral(emitter, enumTyp, []*LlvmValue{llvmEnumVariant(enumTyp, tag), nullPtr})
+}
+
 // Osty: examples/selfhost-core/llvmgen.osty:126:5
 func llvmParam(name string, typ string) *LlvmParam {
 	return &LlvmParam{name: name, typ: typ}
@@ -403,7 +418,7 @@ func llvmCallVoid(emitter *LlvmEmitter, name string, args []*LlvmValue) {
 
 // Osty: examples/selfhost-core/llvmgen.osty:275:5
 func llvmGcRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)", "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)", "declare void @osty.gc.post_write_v1(ptr, ptr, i64)", "declare ptr @osty.gc.load_v1(ptr)", "declare void @osty.gc.root_bind_v1(ptr)", "declare void @osty.gc.root_release_v1(ptr)"}
+	return []string{"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)", "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)", "declare void @osty.gc.post_write_v1(ptr, ptr, i64)", "declare ptr @osty.gc.load_v1(ptr)", "declare void @osty.gc.root_bind_v1(ptr)", "declare void @osty.gc.root_release_v1(ptr)", "declare ptr @osty.rt.enum_alloc_ptr_v1(ptr)", "declare ptr @osty.rt.enum_alloc_scalar_v1(ptr)"}
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:284:5
@@ -2300,7 +2315,7 @@ func llvmEnumPayloadDiagnostic(enumName string, variantName string, detail strin
 		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q variant %q payload: %s", enumName, variantName, detail))
 	}
 	if expectedType != "" && actualType != "" && expectedType != actualType {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q mixes payload types %s and %s", enumName, expectedType, actualType))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q mixes payload types %s and %s; heterogeneous-payload enums require boxed representation (deferred)", enumName, expectedType, actualType))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -275,6 +275,9 @@ func (g *generator) rootPathsForTypeSeen(typ string, seen map[string]bool) [][]i
 	if info := g.enumsByType[typ]; info != nil && info.hasPayload {
 		seen[typ] = true
 		defer delete(seen, typ)
+		if info.isBoxed {
+			return [][]int{{1}}
+		}
 		if info.payloadTyp == "ptr" {
 			return [][]int{{1}}
 		}
@@ -326,6 +329,9 @@ func (g *generator) aggregateFieldType(typ string, index int) (string, bool) {
 		case 0:
 			return "i64", true
 		case 1:
+			if info.isBoxed {
+				return "ptr", true
+			}
 			return info.payloadTyp, true
 		}
 	}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -120,6 +120,47 @@ pub fn llvmEnumPayloadVariant(
     llvmStructLiteral(emitter, typ, [llvmEnumVariant(typ, tag), payload])
 }
 
+/// Construct a heterogeneous-payload ("boxed") enum value: allocate a
+/// single-field GC heap slot for the variant payload, store the payload
+/// value into that slot, then assemble the outer `{i64 tag, ptr payload}`
+/// aggregate. The current ABI assumes every supported payload type
+/// (i64/double/ptr) is 8 bytes. Dispatch selects a trace-aware allocator
+/// when the payload is a managed pointer so the GC can follow it; scalar
+/// payloads use a no-trace allocator.
+pub fn llvmEnumBoxedPayloadVariant(
+    emitter: LlvmEmitter,
+    enumTyp: String,
+    tag: Int,
+    payload: LlvmValue,
+    site: String,
+) -> LlvmValue {
+    let symbol = if payload.typ == "ptr" {
+        "osty.rt.enum_alloc_ptr_v1"
+    } else {
+        "osty.rt.enum_alloc_scalar_v1"
+    }
+    let heapPtr = llvmCall(
+        emitter,
+        "ptr",
+        symbol,
+        [llvmStringLiteral(emitter, site)],
+    )
+    llvmStore(emitter, heapPtr, payload)
+    llvmStructLiteral(emitter, enumTyp, [llvmEnumVariant(enumTyp, tag), heapPtr])
+}
+
+/// Construct a payload-free variant of a boxed enum: `{i64 tag, ptr null}`.
+/// Shared by bare-only variants (e.g. `SemPreIdent.PreNone`) of an enum
+/// whose other variants carry heterogeneous payloads.
+pub fn llvmEnumBoxedBareVariant(
+    emitter: LlvmEmitter,
+    enumTyp: String,
+    tag: Int,
+) -> LlvmValue {
+    let nullPtr = LlvmValue { typ: "ptr", name: "null", pointer: false }
+    llvmStructLiteral(emitter, enumTyp, [llvmEnumVariant(enumTyp, tag), nullPtr])
+}
+
 pub fn llvmParam(name: String, typ: String) -> LlvmParam {
     LlvmParam { name, typ }
 }
@@ -333,6 +374,8 @@ pub fn llvmGcRuntimeDeclarations() -> List<String> {
         "declare ptr @osty.gc.load_v1(ptr)",
         "declare void @osty.gc.root_bind_v1(ptr)",
         "declare void @osty.gc.root_release_v1(ptr)",
+        "declare ptr @osty.rt.enum_alloc_ptr_v1(ptr)",
+        "declare ptr @osty.rt.enum_alloc_scalar_v1(ptr)",
     ]
 }
 
@@ -2486,7 +2529,7 @@ pub fn llvmEnumPayloadDiagnostic(
     if expectedType != "" && actualType != "" && expectedType != actualType {
         return llvmUnsupportedDiagnostic(
             "type-system",
-            "enum \"{enumName}\" mixes payload types {expectedType} and {actualType}",
+            "enum \"{enumName}\" mixes payload types {expectedType} and {actualType}; heterogeneous-payload enums require boxed representation (deferred)",
         )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")


### PR DESCRIPTION
## Summary

LLVM 백엔드가 이질 payload enum(`SemPreIdent { PreNone, PreNumber(Int), PreText(String) }`)을 수용하도록 확장. 동질 payload 경로는 기존 `{tag, T}` flat 레이아웃을 유지하고, 이질 payload에 한해 boxed 레이아웃 `{i64 tag, ptr payload}` + GC heap alloc 으로 분기.

`toolchain/semver.osty` 가 필요로 하던 enum 모양을 IR 레벨에서 풀었다. 진단/테스트는 모두 SemPreIdent 를 실제로 태워서 검증.

## What changed

### β.1 — Plumbing
- `enumInfo.isBoxed` 플래그 추가; `collectEnum` 이 이질성을 감지하면 마킹만 하고 계속
- 6 개 emission site 에 per-site gate: construction / match / const / if-let / variant-constant

### β.2.a — Construction
- 새 Osty 헬퍼 `llvmEnumBoxedPayloadVariant` / `llvmEnumBoxedBareVariant`
- Payload 있는 variant: `osty.rt.enum_alloc_*` 호출 → `store` → `{tag, ptr}` insertvalue
- Bare variant: 할당 없이 `{tag, ptr null}`

### β.2.b — Pattern match
- `enumPatternInfo.isBoxed` 를 `matchPayloadEnumPattern` 이 전파
- `bindPayloadEnumPattern`: boxed 일 때 `extractvalue(ptr, 1)` + `load(payloadType, heapPtr)`
- 동질 경로의 단일 `extractvalue` 는 변화 없음

### β.2.c.1 — GC trace
- 런타임 C: `osty_rt_enum_alloc_ptr_v1` (single-ptr trace fn 등록) / `osty_rt_enum_alloc_scalar_v1` (no-trace)
- Osty helper 가 `payload.typ == \"ptr\"` 이면 ptr alloc 으로 dispatch
- 결과: `PreText(String)` 이 GC cycle 을 안전히 생존 (use-after-free 방지)

### β.2.c.3 — Const rejection
- Const-expression 에서의 boxed 사용은 runtime GC alloc 이 필요해 원천 불가
- 진단 메시지에 이유 + 해결책(constructor fn) 을 담음

## Coverage

`internal/llvmgen/enum_heterogeneous_test.go` (신규):
- declaration succeeds, boxed typedef `{i64, ptr}` 방출
- scalar payload construction → `alloc_scalar_v1` + `store i64`
- bare variant construction → 할당 없이 `{tag 0, null}`
- tag-only match → `extractvalue` + `icmp`
- payload-binding match → `extractvalue` + `load`
- semver-shape 3-arm E2E
- const-expression rejection with actionable hint

## Non-goals (deferred)

- **E2E compile + link + run of semver.osty**: pre-existing MIR backend stack overflow (`internal/backend` 테스트의 \"code generation is not implemented yet\" 경로) 이 blocker. 이 변경과 무관하며 별도 세션 작업
- **Multi-field variant payload**: 현재 ABI 는 variant 당 단일 payload (spec 현 제약과 동일). 복수 필드는 별도 설계 필요

## Behavior delta

- 동질 payload enum (Option, Result, 사용자 정의) — 경로/IR 변화 0
- 이질 payload enum — 이전에 collection 시점에 `\"enum X mixes payload types ...\"` 로 거부되던 것이 이제 정상 방출

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestGenerateHeterogeneousEnum` — 7 tests PASS
- [x] `go test ./internal/lexer ./internal/parser ./internal/resolve ./internal/check` — 모두 PASS
- [x] 선행 llvmgen 실패 9 개 / backend MIR stack overflow — 본 PR 이전/이후 동일 (stash 로 검증)
- [x] 동질 payload 경로 smoke: `TestGenerateIfLetPayloadEnumStmt`, `TestGenerateForLetPayloadEnumLoop`, `TestGenerateOptionalFieldAccess` 등 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)