### PR TITLE
feat(llvmgen): String `+`/보간을 osty_rt_strings_Concat에 연결

### DIFF
--- a/examples/concat_interp_e2e/concat_interp_test.osty
+++ b/examples/concat_interp_e2e/concat_interp_test.osty
@@ -1,0 +1,68 @@
+// concat_interp_test.osty — demonstrates the LLVM backend capabilities
+// added by wiring osty_rt_strings_Concat into emitBinary and
+// emitStringLiteral (internal/llvmgen/expr.go).
+//
+// Before this patch: every one of these assertions triggered
+// "interpolated String literals are not supported by LLVM" or
+// "binary operator on ptr/ptr". After the patch, all pass.
+
+use std.testing
+
+// ─── String `+` String ────────────────────────────────────────────
+
+fn testConcatBasic() {
+    testing.assertEq("a" + "b", "ab")
+}
+
+fn testConcatChain() {
+    testing.assertEq("x" + "y" + "z", "xyz")
+}
+
+fn testConcatMixedVarsAndLiterals() {
+    let greeting = "hello"
+    let target = "world"
+    testing.assertEq(greeting + ", " + target, "hello, world")
+}
+
+// ─── String interpolation (String parts only) ─────────────────────
+
+fn testInterpSingle() {
+    let name = "world"
+    testing.assertEq("hi, {name}!", "hi, world!")
+}
+
+fn testInterpMultiple() {
+    let a = "foo"
+    let b = "bar"
+    testing.assertEq("{a}_{b}_{a}", "foo_bar_foo")
+}
+
+fn testInterpAdjacent() {
+    let x = "X"
+    let y = "Y"
+    testing.assertEq("{x}{y}", "XY")
+}
+
+fn testInterpWithListIndex() {
+    let parts = ["a", "b", "c"]
+    testing.assertEq("{parts[0]}-{parts[1]}-{parts[2]}", "a-b-c")
+}
+
+fn testInterpInLoopMutation() {
+    let items = ["a", "b", "c", "d"]
+    let mut out = items[0]
+    for i in 1..items.len() {
+        out = "{out}-{items[i]}"
+    }
+    testing.assertEq(out, "a-b-c-d")
+}
+
+// ─── Raw strings (no interpolation; previously misrejected) ───────
+
+fn testRawPlain() {
+    testing.assertEq(r"hello", "hello")
+}
+
+fn testRawWithBraces() {
+    testing.assertEq(r"{literal-braces}", r"{literal-braces}")
+}

--- a/examples/concat_interp_e2e/osty.toml
+++ b/examples/concat_interp_e2e/osty.toml
@@ -1,0 +1,15 @@
+# concat_interp_e2e — regression harness for String `+` String and
+# String-only interpolation lowering via osty_rt_strings_Concat.
+# Kept separate from fmt_e2e so that unrelated fmt-module compile
+# failures don't mask this patch's behavior.
+#
+# Run from this directory:
+#
+#     osty test
+
+[package]
+name = "concat_interp_e2e"
+version = "0.1.0"
+edition = "0.3"
+
+[dependencies]

--- a/examples/fmt_e2e/fmt_test.osty
+++ b/examples/fmt_e2e/fmt_test.osty
@@ -1,0 +1,215 @@
+// fmt_test.osty — E2E verification of internal/stdlib/modules/fmt.osty
+// via the LLVM backend. Covers every pub fn with happy-path + edge
+// cases.
+//
+// Current status (2026-04-18): all 28 tests still fail under the LLVM
+// backend. The String `+` String and String-interpolation-via-concat
+// gaps were closed (see concat_interp_test.osty which passes 10/10),
+// but fmt bodies depend on additional backend features that are not
+// yet lowered:
+//
+//   1. `Int.toString()` / `Float.toString()` / `Char.toString()` —
+//      no method-dispatch path for numeric/char → String.
+//   2. List<String> methods `.len()` / `.isEmpty()` — fail with
+//      "code generation is not implemented yet" even on trivial
+//      empty or two-element lists.
+//   3. Generic `joinWith<T>` closure — IR validator rejects the
+//      module import with "Closure: param[0] nil Type" whenever
+//      multiple tests share the package (single-test isolation
+//      converts it to the codegen sentinel).
+//
+// Each gap is independent; fixing any one unblocks a subset of fmt.
+// Do not delete this file — re-run whenever a gap closes to see
+// which functions begin passing.
+
+use std.testing
+use std.fmt
+
+// ─── String alignment ─────────────────────────────────────────────
+
+fn testPadLeft() {
+    testing.assertEq(fmt.padLeft("x", 3), "  x")
+    testing.assertEq(fmt.padLeft("abc", 3), "abc")
+    testing.assertEq(fmt.padLeft("abcd", 2), "abcd")
+    testing.assertEq(fmt.padLeft("7", 4, '0'), "0007")
+}
+
+fn testPadRight() {
+    testing.assertEq(fmt.padRight("x", 3), "x  ")
+    testing.assertEq(fmt.padRight("abc", 3), "abc")
+    testing.assertEq(fmt.padRight("7", 4, '0'), "7000")
+}
+
+fn testCenter() {
+    testing.assertEq(fmt.center("x", 5), "  x  ")
+    testing.assertEq(fmt.center("ab", 5), " ab  ")
+    testing.assertEq(fmt.center("abc", 3), "abc")
+    testing.assertEq(fmt.center("hi", 6, '*'), "**hi**")
+}
+
+fn testTruncate() {
+    testing.assertEq(fmt.truncate("hello", 10), "hello")
+    testing.assertEq(fmt.truncate("hello world", 8), "hello...")
+    testing.assertEq(fmt.truncate("abc", 3), "abc")
+    testing.assertEq(fmt.truncate("abcd", 2), "...")
+}
+
+// ─── Integer formatting ───────────────────────────────────────────
+
+fn testIntToBase() {
+    testing.assertEq(fmt.intToBase(0, 10), "0")
+    testing.assertEq(fmt.intToBase(255, 16), "ff")
+    testing.assertEq(fmt.intToBase(-255, 16), "-ff")
+    testing.assertEq(fmt.intToBase(10, 2), "1010")
+    testing.assertEq(fmt.intToBase(35, 36), "z")
+}
+
+fn testInBaseAlias() {
+    testing.assertEq(fmt.inBase(42, 16), fmt.intToBase(42, 16))
+}
+
+fn testBinAliases() {
+    testing.assertEq(fmt.bin(5), "101")
+    testing.assertEq(fmt.binary(5), "101")
+    testing.assertEq(fmt.bin(0), "0")
+}
+
+fn testOctAliases() {
+    testing.assertEq(fmt.oct(8), "10")
+    testing.assertEq(fmt.octal(64), "100")
+}
+
+fn testHex() {
+    testing.assertEq(fmt.hex(255), "ff")
+    testing.assertEq(fmt.hex(255, true), "FF")
+    testing.assertEq(fmt.hexUpper(255), "FF")
+}
+
+fn testZeroPad() {
+    testing.assertEq(fmt.zeroPad(42, 5), "00042")
+    testing.assertEq(fmt.zeroPad(-7, 4), "-007")
+    testing.assertEq(fmt.zeroPad(12345, 3), "12345")
+}
+
+// ─── Float formatting ─────────────────────────────────────────────
+
+fn testFixed() {
+    testing.assertEq(fmt.fixed(3.14159, 2), "3.14")
+    testing.assertEq(fmt.fixed(0.0, 2), "0.00")
+    testing.assertEq(fmt.fixed(-1.5, 1), "-1.5")
+    testing.assertEq(fmt.fixed(1.0, 0), "1")
+    testing.assertEq(fmt.fixed(0.995, 2), "1.00")
+}
+
+fn testToFixedAlias() {
+    testing.assertEq(fmt.toFixed(2.5, 2), fmt.fixed(2.5, 2))
+}
+
+fn testScientific() {
+    testing.assertEq(fmt.scientific(12345.0, 2), "1.23e+4")
+    testing.assertEq(fmt.scientific(0.0012, 2), "1.20e-3")
+    testing.assertEq(fmt.scientific(0.0, 0), "0e+0")
+    testing.assertEq(fmt.scientific(-100.0, 1), "-1.0e+2")
+}
+
+fn testPercentage() {
+    testing.assertEq(fmt.percentage(0.5, 0), "50%")
+    testing.assertEq(fmt.percentage(0.1234, 2), "12.34%")
+    testing.assertEq(fmt.percentage(1.0, 1), "100.0%")
+}
+
+fn testRepeatFn() {
+    testing.assertEq(fmt.repeat("ab", 3), "ababab")
+    testing.assertEq(fmt.repeat("x", 0), "")
+}
+
+// ─── Number display ───────────────────────────────────────────────
+
+fn testThousands() {
+    testing.assertEq(fmt.thousands(0), "0")
+    testing.assertEq(fmt.thousands(1000), "1,000")
+    testing.assertEq(fmt.thousands(1234567), "1,234,567")
+    testing.assertEq(fmt.thousands(-1234567), "-1,234,567")
+    testing.assertEq(fmt.thousands(999), "999")
+    testing.assertEq(fmt.thousands(1000000, "_"), "1_000_000")
+}
+
+fn testOrdinal() {
+    testing.assertEq(fmt.ordinal(1), "1st")
+    testing.assertEq(fmt.ordinal(2), "2nd")
+    testing.assertEq(fmt.ordinal(3), "3rd")
+    testing.assertEq(fmt.ordinal(4), "4th")
+    testing.assertEq(fmt.ordinal(11), "11th")
+    testing.assertEq(fmt.ordinal(21), "21st")
+    testing.assertEq(fmt.ordinal(112), "112th")
+}
+
+fn testSign() {
+    testing.assertEq(fmt.sign(5), "+5")
+    testing.assertEq(fmt.sign(-3), "-3")
+    testing.assertEq(fmt.sign(0), "0")
+}
+
+fn testSignFloat() {
+    testing.assertEq(fmt.signFloat(2.5, 1), "+2.5")
+    testing.assertEq(fmt.signFloat(-2.5, 1), "-2.5")
+}
+
+fn testBytes() {
+    testing.assertEq(fmt.bytes(512), "512 B")
+    testing.assertEq(fmt.bytes(1024), "1.00 KiB")
+    testing.assertEq(fmt.bytes(1536), "1.50 KiB")
+    testing.assertEq(fmt.bytes(1048576), "1.00 MiB")
+}
+
+// ─── Sprintf ──────────────────────────────────────────────────────
+
+fn testFormatBasic() {
+    testing.assertEq(fmt.format(r"hello {0}", ["world"]), "hello world")
+    testing.assertEq(fmt.format(r"{0} + {1} = {2}", ["1", "2", "3"]), "1 + 2 = 3")
+}
+
+fn testFormatEscapes() {
+    testing.assertEq(fmt.format(r"{{0}}", ["x"]), r"{0}")
+    testing.assertEq(fmt.format(r"{0}{0}", ["ab"]), "abab")
+}
+
+fn testFormatOutOfRange() {
+    testing.assertEq(fmt.format(r"{5}", ["only"]), r"{5}")
+}
+
+// ─── Lists ────────────────────────────────────────────────────────
+
+fn testJoinWith() {
+    let nums = [1, 2, 3]
+    let result = fmt.joinWith(nums, "-", |n| n.toString())
+    testing.assertEq(result, "1-2-3")
+}
+
+fn testJoin() {
+    let empty: List<String> = []
+    testing.assertEq(fmt.join(["a", "b", "c"], ", "), "a, b, c")
+    testing.assertEq(fmt.join(["a", "b", "c"], ", ", " and "), "a, b and c")
+    testing.assertEq(fmt.join(["a", "b"], ", ", " and "), "a and b")
+    testing.assertEq(fmt.join(["a"], ", "), "a")
+    testing.assertEq(fmt.join(empty, ", "), "")
+}
+
+fn testBullet() {
+    let empty: List<String> = []
+    testing.assertEq(fmt.bullet(["a", "b"]), "- a\n- b")
+    testing.assertEq(fmt.bullet(["a"], "* "), "* a")
+    testing.assertEq(fmt.bullet(empty), "")
+}
+
+fn testNumbered() {
+    testing.assertEq(fmt.numbered(["a", "b"]), "1. a\n2. b")
+}
+
+fn testTable() {
+    let headers = ["Name", "Age"]
+    let rows = [["Alice", "30"], ["Bob", "5"]]
+    let result = fmt.table(headers, rows)
+    let expected = "Name  | Age\n----- | ---\nAlice | 30 \nBob   | 5  "
+    testing.assertEq(result, expected)
+}

--- a/examples/fmt_e2e/osty.toml
+++ b/examples/fmt_e2e/osty.toml
@@ -1,0 +1,17 @@
+# fmt_e2e — end-to-end verification of internal/stdlib/modules/fmt.osty
+# against the LLVM backend.
+#
+# Run from this directory:
+#
+#     osty test
+#
+# Current status: all 28 tests fail; remaining backend gaps documented
+# in fmt_test.osty's header. For the regression harness of the concat
+# and interpolation path, see ../concat_interp_e2e/.
+
+[package]
+name = "fmt_e2e"
+version = "0.1.0"
+edition = "0.3"
+
+[dependencies]

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -59,17 +59,70 @@ func (g *generator) ifLetCondition(pattern ast.Pattern, scrutinee value) (*LlvmV
 }
 
 func (g *generator) emitStringLiteral(lit *ast.StringLit) (value, error) {
-	text, ok := plainStringLiteral(lit)
-	if !ok {
-		return value{}, unsupported("expression", "interpolated String literals are not supported by LLVM")
+	if lit == nil {
+		return value{}, unsupported("expression", "nil String literal")
 	}
-	if !llvmIsAsciiStringText(text) {
-		return value{}, unsupported("type-system", "plain String literals currently require ASCII text with printable bytes or newline, tab, and carriage-return escapes")
+	allLit := true
+	for _, part := range lit.Parts {
+		if !part.IsLit {
+			allLit = false
+			break
+		}
 	}
-	emitter := g.toOstyEmitter()
-	out := llvmStringLiteral(emitter, text)
-	g.takeOstyEmitter(emitter)
-	return fromOstyValue(out), nil
+	if allLit {
+		var b strings.Builder
+		for _, part := range lit.Parts {
+			b.WriteString(part.Lit)
+		}
+		text := b.String()
+		if !llvmIsAsciiStringText(text) {
+			return value{}, unsupported("type-system", "plain String literals currently require ASCII text with printable bytes or newline, tab, and carriage-return escapes")
+		}
+		emitter := g.toOstyEmitter()
+		out := llvmStringLiteral(emitter, text)
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), nil
+	}
+	return g.emitInterpolatedString(lit)
+}
+
+func (g *generator) emitInterpolatedString(lit *ast.StringLit) (value, error) {
+	if len(lit.Parts) == 0 {
+		emitter := g.toOstyEmitter()
+		out := llvmStringLiteral(emitter, "")
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), nil
+	}
+	pieces := make([]value, 0, len(lit.Parts))
+	for _, part := range lit.Parts {
+		if part.IsLit {
+			if !llvmIsAsciiStringText(part.Lit) {
+				return value{}, unsupported("type-system", "plain String literals currently require ASCII text with printable bytes or newline, tab, and carriage-return escapes")
+			}
+			emitter := g.toOstyEmitter()
+			out := llvmStringLiteral(emitter, part.Lit)
+			g.takeOstyEmitter(emitter)
+			pieces = append(pieces, fromOstyValue(out))
+			continue
+		}
+		v, err := g.emitExpr(part.Expr)
+		if err != nil {
+			return value{}, err
+		}
+		if v.typ != "ptr" || v.listElemTyp != "" || v.mapKeyTyp != "" {
+			return value{}, unsupportedf("type-system", "interpolation of %s value requires .toString() which the LLVM backend does not yet lower", v.typ)
+		}
+		pieces = append(pieces, v)
+	}
+	result := pieces[0]
+	for i := 1; i < len(pieces); i++ {
+		r, err := g.emitRuntimeStringConcat(result, pieces[i])
+		if err != nil {
+			return value{}, err
+		}
+		result = r
+	}
+	return result, nil
 }
 
 func (g *generator) emitExpr(expr ast.Expr) (value, error) {
@@ -672,6 +725,9 @@ func (g *generator) emitBinary(e *ast.BinaryExpr) (value, error) {
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), nil
 	}
+	if left.typ == "ptr" && right.typ == "ptr" && e.Op == token.PLUS {
+		return g.emitRuntimeStringConcat(left, right)
+	}
 	if left.typ != "i64" || right.typ != "i64" {
 		return value{}, unsupportedf("type-system", "binary operator %q on %s/%s", e.Op, left.typ, right.typ)
 	}
@@ -839,6 +895,17 @@ func (g *generator) emitQuestionExprResult(expr *ast.QuestionExpr, info builtinR
 		out.gcManaged = true
 	}
 	return out, nil
+}
+
+func (g *generator) emitRuntimeStringConcat(left, right value) (value, error) {
+	g.declareRuntimeSymbol("osty_rt_strings_Concat", "ptr", []paramInfo{
+		{typ: "ptr"},
+		{typ: "ptr"},
+	})
+	emitter := g.toOstyEmitter()
+	out := llvmStringConcat(emitter, toOstyValue(left), toOstyValue(right))
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), nil
 }
 
 func (g *generator) emitRuntimeStringCompare(op token.Kind, left, right value) (value, error) {


### PR DESCRIPTION
## Summary

LLVM 백엔드가 문자열 보간과 `String + String`을 거부하던 제약을 부분적으로 해소.

- `emitBinary`: 두 피연산자가 모두 `ptr`이고 `op == PLUS`면 `osty_rt_strings_Concat` 런타임으로 분기
- `emitStringLiteral`: 재작성. 모든 부품이 literal이면 종래 경로, 보간 포함이면 `emitInterpolatedString`으로 desugar. 각 non-literal 부품이 bare `ptr`(List/Map 아님)임을 확인한 뒤 concat 체인 생성
- `plainStringLiteral`이 `IsRaw`/`IsTriple`을 무조건 거부하던 부작용도 해소되어 `r"..."`(braces 포함) 동작

숫자/Char 보간은 여전히 `.toString()` 메서드 디스패치 부재로 막혀 있으며, 명시적 `unsupportedf` 에러를 돌려준다(묵음 실패 X).

## Why

`osty test`가 LLVM 백엔드로 진행되는데, 기존 `emitStringLiteral`은 **모든 interpolated String literal**을 `unsupported`로 차단했다([internal/llvmgen/expr.go:64](../internal/llvmgen/expr.go#L64) 원본). 런타임에는 `osty_rt_strings_Concat`이 이미 구현되어 있고([internal/backend/runtime/osty_runtime.c:809](../internal/backend/runtime/osty_runtime.c#L809)), helper `llvmStringConcat`도 존재([support_snapshot.go:2124](../internal/llvmgen/support_snapshot.go#L2124))했지만 `emitBinary`/`emitStringLiteral` 어느 쪽에서도 호출되지 않고 있었다. 이 PR은 그 마지막 연결선만 끼운다.

`examples/fmt_e2e/fmt_test.osty`로 확인한 결과, fmt 본문은 String `+`/보간 외에도 (1) `Int/Float/Char.toString()`, (2) `List<String>.len()/isEmpty()`, (3) generic closure IR 검증 버그에 의존하고 있어 fmt 전체 해제는 별도 PR 필요. 각 갭은 독립적.

## Change scope

```
 internal/llvmgen/expr.go | 85 ++++++++++++++++++++++++++++++++++++-----
 examples/concat_interp_e2e/ (new) — 10/10 passing 회귀 증명
 examples/fmt_e2e/ (new) — 28-test fmt 수트 (헤더에 남은 갭 명시)
```

## Test plan

- [x] `cd examples/concat_interp_e2e && osty test --serial` — 10/10 pass (String concat 체인, 다중 interp, list-indexed interp, for-loop mutation interp, raw braces)
- [x] `cd examples/calc && osty test --serial` — 9/9 pass, 회귀 없음
- [x] `go test ./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline` — pass
- [x] `go test ./internal/llvmgen/` — 통과 테스트 변동 없음 (5건 실패는 main에서도 동일한 pre-existing `LLVM016 identifier "strings"` 실패)

## Reviewer notes

- non-ptr 보간은 의도적으로 명시적 에러. 향후 `.toString()` 디스패치가 붙으면 자연히 풀림
- List/Map이 interp에 잘못 섞이는 것을 막기 위해 `v.listElemTyp != "" || v.mapKeyTyp != ""` 체크 추가
- GC rooting 추가했다가 빈 `rootSlot` 없이 `gcManaged=true`만 달면 기존 테스트를 깨뜨림을 확인하고 제거. 현재 concat 결과는 rooting 없이 즉시 사용되는 전제. 필요해지면 호출부가 `let`으로 바인드하면 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)