### PR TITLE
refactor(llvmgen): extract String equality lowering into llvmgen.osty

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -917,10 +917,7 @@ func (g *generator) emitRuntimeStringCompare(op token.Kind, left, right value) (
 		{typ: "ptr"},
 	})
 	emitter := g.toOstyEmitter()
-	out := llvmCall(emitter, "i1", "osty_rt_strings_Equal", []*LlvmValue{toOstyValue(left), toOstyValue(right)})
-	if op == token.NEQ {
-		out = llvmNotI1(emitter, out)
-	}
+	out := llvmStringCompare(emitter, op.String(), toOstyValue(left), toOstyValue(right))
 	g.takeOstyEmitter(emitter)
 	return fromOstyValue(out), nil
 }

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2140,6 +2140,14 @@ func llvmStringConcat(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Concat", []*LlvmValue{left, right})
 }
 
+func llvmStringCompare(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
+	eq := llvmStringEqual(emitter, left, right)
+	if op == "!=" {
+		return llvmNotI1(emitter, eq)
+	}
+	return eq
+}
+
 func llvmStringByteLen(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", []*LlvmValue{value})
 }

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2262,6 +2262,19 @@ pub fn llvmStringConcat(emitter: LlvmEmitter, left: LlvmValue, right: LlvmValue)
     llvmCall(emitter, "ptr", "osty_rt_strings_Concat", [left, right])
 }
 
+pub fn llvmStringCompare(
+    emitter: LlvmEmitter,
+    op: String,
+    left: LlvmValue,
+    right: LlvmValue,
+) -> LlvmValue {
+    let eq = llvmStringEqual(emitter, left, right)
+    if op == "!=" {
+        return llvmNotI1(emitter, eq)
+    }
+    eq
+}
+
 pub fn llvmStringByteLen(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", [value])
 }


### PR DESCRIPTION
## Summary

- Add `llvmStringCompare(emitter, op, left, right)` helper in `toolchain/llvmgen.osty`, built on the existing `llvmStringEqual` + `llvmNotI1` primitives.
- Mirror the helper in `internal/llvmgen/support_snapshot.go`.
- Route `emitRuntimeStringCompare` through the helper instead of inlining `llvmCall` + `llvmNotI1`, matching the `llvmStringConcat` pattern one line up.

## Why

Project policy: Osty-writable lowering logic lives in `toolchain/*.osty`, with Go acting as the thin bridge. The `==`/`!=` orchestration was inline in Go; this moves it to the Osty-authored surface where the other string runtime helpers already live. Phase 75 scope.

## Test plan

- [x] `go build ./...` clean
- [x] `TestGenerateStringCompareUsesRuntimeABI` passes
- [x] Pre-existing `strings` identifier failures in runtime_ffi_test/optional_test are unrelated (reproduce on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)