### PR TITLE
fix(llvmgen): String이 아닌 ptr 비교를 strings_Equal로 잘못 낮추던 버그 차단

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -710,7 +710,8 @@ func (g *generator) emitBinary(e *ast.BinaryExpr) (value, error) {
 		return value{}, err
 	}
 	if llvmIsCompareOp(e.Op.String()) {
-		return g.emitCompare(e.Op, left, right)
+		isString := g.staticExprIsString(e.Left) || g.staticExprIsString(e.Right)
+		return g.emitCompare(e.Op, left, right, isString)
 	}
 	if e.Op == token.AND || e.Op == token.OR {
 		return g.emitLogical(e.Op, left, right)
@@ -755,7 +756,7 @@ func (g *generator) emitLogical(op token.Kind, left, right value) (value, error)
 	return fromOstyValue(out), nil
 }
 
-func (g *generator) emitCompare(op token.Kind, left, right value) (value, error) {
+func (g *generator) emitCompare(op token.Kind, left, right value, isString bool) (value, error) {
 	if left.typ != right.typ {
 		return value{}, unsupportedf("type-system", "compare type mismatch %s/%s", left.typ, right.typ)
 	}
@@ -778,6 +779,9 @@ func (g *generator) emitCompare(op token.Kind, left, right value) (value, error)
 		out = llvmCompareF64(emitter, pred, toOstyValue(left), toOstyValue(right))
 	case "ptr":
 		g.takeOstyEmitter(emitter)
+		if !isString {
+			return value{}, unsupportedf("type-system", "comparison operator %q on non-String ptr values is not yet lowered", op)
+		}
 		return g.emitRuntimeStringCompare(op, left, right)
 	default:
 		g.takeOstyEmitter(emitter)

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -132,6 +132,30 @@ func TestGenerateStringCompareUsesRuntimeABI(t *testing.T) {
 	}
 }
 
+func TestGenerateNonStringPtrCompareRejected(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let a: List<Int> = [1, 2]
+    let b: List<Int> = [3, 4]
+    if a == b {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+
+	_, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/nonstr_compare.osty",
+	})
+	if err == nil {
+		t.Fatal("Generate succeeded, want unsupported diagnostic for non-String ptr ==")
+	}
+	if got := err.Error(); !strings.Contains(got, "non-String ptr") {
+		t.Fatalf("error = %q, want to mention non-String ptr", got)
+	}
+}
+
 func TestGenerateLibraryModuleWithoutMain(t *testing.T) {
 	file := parseLLVMGenFile(t, `enum Kind {
     Manifest,

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -787,7 +787,8 @@ func (g *generator) emitTestingCompare(call *ast.CallExpr, op token.Kind, name s
 	if err != nil {
 		return err
 	}
-	cond, err := g.emitCompare(op, left, right)
+	isString := g.staticExprIsString(call.Args[0].Value) || g.staticExprIsString(call.Args[1].Value)
+	cond, err := g.emitCompare(op, left, right, isString)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 요약

LLVM 백엔드의 `emitCompare`가 `ptr` 타입 비교를 정적 타입 검사 없이 전부 `osty_rt_strings_Equal`에 라우팅하고 있었음. String이 아닌 힙 포인터(List/Map/struct/enum/Option 등)에 도달하면 대상 메모리를 C 문자열처럼 읽어 UB를 유발.

네이티브 체커가 현재 이런 `==`를 거부하므로 트리거 경로는 없지만, 체커가 완화되거나 백엔드가 직접 호출되는 테스트 harness에서 조용히 miscompile하는 함정이었다. 방어선을 세워 명확한 진단으로 차단.

## 변경 사항

- [`internal/llvmgen/expr.go`](../blob/claude/angry-yonath-653178/internal/llvmgen/expr.go)
  - `emitBinary`: 좌/우 피연산자에 `staticExprIsString`을 돌려 `isString` 플래그를 구성해 `emitCompare`에 전달
  - `emitCompare`: `ptr` 케이스에서 `isString=false`면 `unsupportedf("type-system", "comparison operator %q on non-String ptr values is not yet lowered", op)` 로 즉시 중단
- [`internal/llvmgen/stmt.go`](../blob/claude/angry-yonath-653178/internal/llvmgen/stmt.go) — `emitTestingCompare`의 `emitCompare` 호출도 동일 경로로 갱신
- [`internal/llvmgen/runtime_ffi_test.go`](../blob/claude/angry-yonath-653178/internal/llvmgen/runtime_ffi_test.go) — `TestGenerateNonStringPtrCompareRejected` 추가: `List<Int> == List<Int>` 소스가 체커를 우회해 백엔드에 도달해도 진단으로 거부됨을 잠금

## 테스트 계획

- [x] `go test ./internal/llvmgen/ -run 'TestGenerateStringCompareUsesRuntimeABI|TestGenerateNonStringPtrCompareRejected' -count=1` — 둘 다 PASS
- [x] 전체 `./internal/llvmgen/` 테스트 스위트 — 이 변경과 무관한 pre-existing 실패(`TestGenerateLetStructPatternDestructuring` 등 `strings` 식별자 문제)만 남음. main 대비 베이스라인 동일 확인
- [x] `go build ./...` 통과

## 리뷰 메모

- 타입 힌트는 `value.sourceType`이 아니라 AST(`e.Left`/`e.Right`)에서 직접 `staticExprIsString`으로 뽑는다. 문자열 리터럴 경로(`emitStringLiteral`)가 `value.sourceType`을 채우지 않기 때문.
- 체커가 진짜 `List<T> == List<T>`나 `Struct == Struct`를 허용하도록 발전하면, 이 guard를 실제 lowering(예: 구조적 Equal derive → 전용 런타임 심볼 호출)로 대체하면 된다. 지금은 조용한 UB 대신 "아직 안 낮춤" 진단을 돌려주는 것이 목표.

🤖 Generated with [Claude Code](https://claude.com/claude-code)