### PR TITLE
feat(llvmgen): MIR path routes String/Bytes equality through runtime helper

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3592,6 +3592,9 @@ func (g *mirGen) emitUnary(op mir.UnaryOp, arg string, t mir.Type) (string, erro
 }
 
 func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.Type) (string, error) {
+	if (op == mir.BinEq || op == mir.BinNeq) && isHeapEqualityType(argT) {
+		return g.emitHeapEquality(op, left, right)
+	}
 	argLLVM := g.llvmType(argT)
 	resLLVM := g.llvmType(resT)
 	isFloat := isFloatType(argT)
@@ -3685,6 +3688,48 @@ func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.
 	}
 	_ = resLLVM
 	return "", unsupported("mir-mvp", fmt.Sprintf("binary op %d", op))
+}
+
+// isHeapEqualityType reports whether MIR `==` / `!=` on values of type t
+// should be lowered to a runtime content-equality call instead of a raw
+// LLVM icmp on the pointer. Stage-1 covers String and Bytes; Bytes uses
+// the String runtime since both values share the C-string ABI.
+func isHeapEqualityType(t mir.Type) bool {
+	p, ok := t.(*ir.PrimType)
+	if !ok {
+		return false
+	}
+	return p.Kind == ir.PrimString || p.Kind == ir.PrimBytes
+}
+
+// emitHeapEquality lowers `==` / `!=` on pointer-shaped runtime values
+// (String, Bytes) to a call to the appropriate `osty_rt_*_Equal`
+// helper, negating the result for `!=`. The helper declarations are
+// registered lazily on first use so modules without any heap equality
+// stay byte-stable.
+func (g *mirGen) emitHeapEquality(op mir.BinaryOp, left, right string) (string, error) {
+	sym := llvmStringRuntimeEqualSymbol()
+	g.declareRuntime(sym, fmt.Sprintf("declare i1 @%s(ptr, ptr)", sym))
+	eq := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(eq)
+	g.fnBuf.WriteString(" = call i1 @")
+	g.fnBuf.WriteString(sym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(left)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(right)
+	g.fnBuf.WriteString(")\n")
+	if op == mir.BinEq {
+		return eq, nil
+	}
+	neq := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(neq)
+	g.fnBuf.WriteString(" = xor i1 ")
+	g.fnBuf.WriteString(eq)
+	g.fnBuf.WriteString(", true\n")
+	return neq, nil
 }
 
 // ==== strings ====

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2123,3 +2123,79 @@ func TestGenerateFromMIREmitGCLoopSafepoint(t *testing.T) {
 		t.Fatalf("expected safepoint id 1 in:\n%s", got)
 	}
 }
+
+// TestGenerateFromMIRStringEquality — `fn eq() -> Bool { "a" == "b" }`
+// must lower to osty_rt_strings_Equal rather than a raw `icmp eq ptr`
+// (the latter would reduce to pointer identity, not content equality).
+func TestGenerateFromMIRStringEquality(t *testing.T) {
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:   "eq",
+				Return: ir.TBool,
+				Body: &ir.Block{
+					Result: &ir.BinaryExpr{
+						Op:    ir.BinEq,
+						Left:  &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "a"}}},
+						Right: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "b"}}},
+						T:     ir.TBool,
+					},
+				},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/streq.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+		"call i1 @osty_rt_strings_Equal(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "icmp eq ptr") {
+		t.Fatalf("found raw icmp eq ptr (should route through runtime helper):\n%s", got)
+	}
+}
+
+// TestGenerateFromMIRStringInequality — `!=` negates the runtime
+// equality result via xor, preserving the content-compare semantics.
+func TestGenerateFromMIRStringInequality(t *testing.T) {
+	hir := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:   "neq",
+				Return: ir.TBool,
+				Body: &ir.Block{
+					Result: &ir.BinaryExpr{
+						Op:    ir.BinNeq,
+						Left:  &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "a"}}},
+						Right: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "b"}}},
+						T:     ir.TBool,
+					},
+				},
+			},
+		},
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/strneq.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"call i1 @osty_rt_strings_Equal(ptr",
+		"xor i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- MIR-first emitter was lowering `BinaryRV{Eq|Neq}` on ptr-shaped operands (String, Bytes) to a raw `icmp eq ptr` — pointer-identity compare, not content compare. Semantically wrong whenever the MIR path handled a module.
- `emitBinary` now detects String/Bytes on `==` / `!=` and routes to a new `emitHeapEquality` that calls `osty_rt_strings_Equal` and xor-negates for `!=`.
- Runtime declare registered lazily, so modules without heap equality stay byte-stable.

## Why

Part of the prioritized MIR gap cleanup (ROI #1). Mirrors the legacy `emitRuntimeStringCompare` behavior so the MIR-first path produces correct IR for String equality without needing to fall back to the legacy AST bridge. Unblocks files that compare strings (e.g. `semver.osty` workflows) when they stay on the MIR-first path.

## Scope

Stage 1 covers String + Bytes (both share the C-string ABI). `List<T>` / `Map` / `Set` content equality is deferred — those need a settled single-ptr runtime value representation and matching `_Equal` helpers before the same pattern can extend.

## Test plan

- [x] New unit tests: `TestGenerateFromMIRStringEquality` + `TestGenerateFromMIRStringInequality` assert the runtime call / xor shape and guard against regression to `icmp eq ptr`.
- [x] End-to-end: `"hello" == "hello"` → `equal`; `"hello" != "world"` → `different`.
- [x] Existing MIR tests still pass; pre-existing LLVM016 "strings" failures are unrelated (verified via `git stash` baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)