### PR TITLE
test: backfill Osty↔Go policy test parity for 4 toolchain files

### DIFF
--- a/toolchain/diag_policy_test.osty
+++ b/toolchain/diag_policy_test.osty
@@ -29,6 +29,10 @@ fn testIsDeferredGenCheckDiagRejectsUnrelatedMessage() {
     testing.assert(!(isDeferredGenCheckDiag("error", "")))
 }
 
+fn testIsDeferredGenCheckDiagRejectsEmptySeverity() {
+    testing.assert(!(isDeferredGenCheckDiag("", "type checking unavailable for x")))
+}
+
 fn testScaffoldExitCodeEmptyIsZero() {
     testing.assertEq(scaffoldExitCode(""), 0)
 }

--- a/toolchain/pkg_policy_test.osty
+++ b/toolchain/pkg_policy_test.osty
@@ -15,6 +15,22 @@ fn testExpandFrozenFlagsLeavesNonFrozenUntouched() {
     testing.assert(!(expanded.frozen))
 }
 
+fn testExpandFrozenFlagsIdempotentWhenAlreadySaturated() {
+    let opts = ResolveOpts { offline: true, locked: true, frozen: true }
+    let expanded = expandFrozenFlags(opts)
+    testing.assert(expanded.offline)
+    testing.assert(expanded.locked)
+    testing.assert(expanded.frozen)
+}
+
+fn testExpandFrozenFlagsAllOffPreserved() {
+    let opts = ResolveOpts { offline: false, locked: false, frozen: false }
+    let expanded = expandFrozenFlags(opts)
+    testing.assert(!(expanded.offline))
+    testing.assert(!(expanded.locked))
+    testing.assert(!(expanded.frozen))
+}
+
 fn testFrozenMissingLockfileMessageFormat() {
     testing.assertEq(
         frozenMissingLockfileMessage("osty.lock"),

--- a/toolchain/profile_flags_test.osty
+++ b/toolchain/profile_flags_test.osty
@@ -21,16 +21,19 @@ fn testSelectProfileNameReleaseConflictReportsUsage() {
 fn testSelectProfileNameExplicitOverridesFallback() {
     let sel = selectProfileName("staging", false, "test")
     testing.assertEq(sel.name, "staging")
+    testing.assertEq(sel.conflict, "")
 }
 
 fn testSelectProfileNameFallbackUsedWhenUnset() {
     let sel = selectProfileName("", false, "test")
     testing.assertEq(sel.name, "test")
+    testing.assertEq(sel.conflict, "")
 }
 
 fn testSelectProfileNameUltimateDefaultIsDebug() {
     let sel = selectProfileName("", false, "")
     testing.assertEq(sel.name, "debug")
+    testing.assertEq(sel.conflict, "")
 }
 
 fn testParseFeatureListSplitsAndTrims() {
@@ -49,6 +52,27 @@ fn testParseFeatureListDropsEmpty() {
 
 fn testParseFeatureListEmptyInputReturnsEmpty() {
     let feats = parseFeatureList("")
+    let mut count = 0
+    for f in feats {
+        let _ = f
+        count = count + 1
+    }
+    testing.assertEq(count, 0)
+}
+
+fn testParseFeatureListSingleElement() {
+    let feats = parseFeatureList("a")
+    testing.assertEq(feats[0], "a")
+    let mut count = 0
+    for f in feats {
+        let _ = f
+        count = count + 1
+    }
+    testing.assertEq(count, 1)
+}
+
+fn testParseFeatureListWhitespaceOnlyIsEmpty() {
+    let feats = parseFeatureList("  ")
     let mut count = 0
     for f in feats {
         let _ = f

--- a/toolchain/scaffold_policy_test.osty
+++ b/toolchain/scaffold_policy_test.osty
@@ -32,15 +32,32 @@ fn testIsValidScaffoldNameRejectsBadChars() {
 }
 
 fn testResolveFixtureCasesDefaultsWhenZeroOrNegative() {
-    testing.assertEq(resolveFixtureCases(0).count, 3)
-    testing.assert(!(resolveFixtureCases(0).overCap))
-    testing.assertEq(resolveFixtureCases(-5).count, 3)
+    let zero = resolveFixtureCases(0)
+    testing.assertEq(zero.count, 3)
+    testing.assert(!(zero.overCap))
+
+    let neg = resolveFixtureCases(-5)
+    testing.assertEq(neg.count, 3)
+    testing.assert(!(neg.overCap))
 }
 
 fn testResolveFixtureCasesPassesThroughWithinRange() {
-    testing.assertEq(resolveFixtureCases(1).count, 1)
-    testing.assertEq(resolveFixtureCases(10).count, 10)
-    testing.assertEq(resolveFixtureCases(64).count, 64)
+    let one = resolveFixtureCases(1)
+    testing.assertEq(one.count, 1)
+    testing.assert(!(one.overCap))
+
+    let ten = resolveFixtureCases(10)
+    testing.assertEq(ten.count, 10)
+    testing.assert(!(ten.overCap))
+
+    let max = resolveFixtureCases(64)
+    testing.assertEq(max.count, 64)
+    testing.assert(!(max.overCap))
+}
+
+fn testScaffoldFixtureCapsConstants() {
+    testing.assertEq(scaffoldFixtureCasesDefault, 3)
+    testing.assertEq(scaffoldFixtureCasesMax, 64)
 }
 
 fn testResolveFixtureCasesClampsOverCap() {


### PR DESCRIPTION
## Summary
- Mirror Go test cases from `internal/runner/*_policy_test.go` into the corresponding `toolchain/*_test.osty` files so the Osty-side suite stops drifting below its Go snapshot.
- Four files touched: `diag_policy_test`, `pkg_policy_test`, `profile_flags_test`, `scaffold_policy_test`. Pure test additions; no production code changed.

## What's added
- **diag_policy_test**: `testIsDeferredGenCheckDiagRejectsEmptySeverity` — the empty-severity branch Go already covered.
- **pkg_policy_test**: `testExpandFrozenFlagsIdempotentWhenAlreadySaturated` + `testExpandFrozenFlagsAllOffPreserved` — the two `ExpandFrozenFlags` cases the Go table-test covered but Osty didn't.
- **profile_flags_test**: `conflict == ""` asserts on the 3 `selectProfileName` tests that only checked `.name`; new `testParseFeatureListSingleElement` and `testParseFeatureListWhitespaceOnlyIsEmpty` cases.
- **scaffold_policy_test**: `overCap == false` asserts for `requested ∈ {-5, 1, 10, 64}` (so every Go row checks both fields); new `testScaffoldFixtureCapsConstants` asserting `scaffoldFixtureCasesDefault == 3` and `scaffoldFixtureCasesMax == 64`.

## Test plan
- [x] `go test ./internal/runner/ -run TestPolicySnapshotParityWithOsty` — Go↔Osty pub-symbol drift test still green.
- [x] `osty parse` clean on all four edited files.
- [ ] `osty test toolchain/<file>_test.osty` once the unrelated toolchain parse breakage is cleared (currently blocked by `llvmgen_test.osty` parser regression, not by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)