### PR TITLE
feat(check): native checker telemetry + UseDecl alias collect fix

### DIFF
--- a/cmd/osty-native-checker/main.go
+++ b/cmd/osty-native-checker/main.go
@@ -14,9 +14,11 @@ type checkRequest struct {
 }
 
 type checkSummary struct {
-	Assignments int `json:"assignments"`
-	Accepted    int `json:"accepted"`
-	Errors      int `json:"errors"`
+	Assignments     int                       `json:"assignments"`
+	Accepted        int                       `json:"accepted"`
+	Errors          int                       `json:"errors"`
+	ErrorsByContext map[string]int            `json:"errorsByContext,omitempty"`
+	ErrorDetails    map[string]map[string]int `json:"errorDetails,omitempty"`
 }
 
 type checkedNode struct {
@@ -78,9 +80,11 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	checked := selfhost.CheckSourceStructured([]byte(req.Source))
 	resp := checkResponse{
 		Summary: checkSummary{
-			Assignments: checked.Summary.Assignments,
-			Accepted:    checked.Summary.Accepted,
-			Errors:      checked.Summary.Errors,
+			Assignments:     checked.Summary.Assignments,
+			Accepted:        checked.Summary.Accepted,
+			Errors:          checked.Summary.Errors,
+			ErrorsByContext: checked.Summary.ErrorsByContext,
+			ErrorDetails:    checked.Summary.ErrorDetails,
 		},
 		TypedNodes:     make([]checkedNode, 0, len(checked.TypedNodes)),
 		Bindings:       make([]checkedBinding, 0, len(checked.Bindings)),

--- a/cmd/osty/dump_native_diags.go
+++ b/cmd/osty/dump_native_diags.go
@@ -1,0 +1,102 @@
+package main
+
+// Helpers for `osty check --dump-native-diags`. The flag surfaces the
+// bootstrapped native checker's per-context error histogram so callers
+// working against aggregate error counts (1700-style summaries) can
+// split the tail by enclosing-function category without regenerating
+// internal/selfhost/generated.go.
+//
+// Telemetry origin: internal/selfhost/check_telemetry.go tags every
+// call to selfhostBumpError with its Go caller name. host_boundary.go
+// plumbs the map into check.Result.NativeCheckerTelemetry.
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/osty/osty/internal/check"
+)
+
+// dumpNativeDiagsFor prints the native checker's per-context histogram
+// for one already-checked scope (file, package, or workspace entry) to
+// stderr. Silent when the native checker was unavailable or reported
+// zero errors — no output is always preferable to a misleading "0 of 0"
+// banner.
+func dumpNativeDiagsFor(label string, chk *check.Result) {
+	if chk == nil || chk.NativeCheckerTelemetry == nil {
+		return
+	}
+	t := chk.NativeCheckerTelemetry
+	if t.Errors == 0 && t.Assignments == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "native checker telemetry: %s\n", label)
+	fmt.Fprintf(os.Stderr, "  assignments: %d\n", t.Assignments)
+	fmt.Fprintf(os.Stderr, "  accepted:    %d\n", t.Accepted)
+	fmt.Fprintf(os.Stderr, "  tail:        %d (= assignments - accepted)\n", t.Assignments-t.Accepted)
+	fmt.Fprintf(os.Stderr, "  errors:      %d\n", t.Errors)
+	if len(t.ErrorsByContext) == 0 {
+		fmt.Fprintf(os.Stderr, "  (no per-context breakdown available)\n")
+		return
+	}
+	type row struct {
+		name  string
+		count int
+	}
+	rows := make([]row, 0, len(t.ErrorsByContext))
+	total := 0
+	for name, count := range t.ErrorsByContext {
+		rows = append(rows, row{name: name, count: count})
+		total += count
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].count != rows[j].count {
+			return rows[i].count > rows[j].count
+		}
+		return rows[i].name < rows[j].name
+	})
+	fmt.Fprintf(os.Stderr, "  by context (total %d):\n", total)
+	for _, r := range rows {
+		fmt.Fprintf(os.Stderr, "    %6d  %s\n", r.count, r.name)
+		writeContextDetail(os.Stderr, t.ErrorDetails[r.name])
+	}
+}
+
+// writeContextDetail prints the top-10 detail rows under a context bucket,
+// indented so they visually nest under the parent. No output when the
+// bucket is empty — only contexts wired to selfhostBumpErrorWithDetail
+// carry data, and callers should not assume every bucket is populated.
+func writeContextDetail(w *os.File, details map[string]int) {
+	if len(details) == 0 {
+		return
+	}
+	type row struct {
+		name  string
+		count int
+	}
+	rows := make([]row, 0, len(details))
+	for name, count := range details {
+		rows = append(rows, row{name: name, count: count})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].count != rows[j].count {
+			return rows[i].count > rows[j].count
+		}
+		return rows[i].name < rows[j].name
+	})
+	limit := 10
+	if len(rows) < limit {
+		limit = len(rows)
+	}
+	for i := 0; i < limit; i++ {
+		fmt.Fprintf(w, "             %5d  %s\n", rows[i].count, rows[i].name)
+	}
+	if len(rows) > limit {
+		remaining := 0
+		for _, r := range rows[limit:] {
+			remaining += r.count
+		}
+		fmt.Fprintf(w, "             %5d  (+ %d more)\n", remaining, len(rows)-limit)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -86,6 +86,12 @@ type cliFlags struct {
 	inspect    bool // check: emit one InspectRecord per expression (stdout)
 	aiRepair   bool // front-end: adapt AI-authored foreign syntax in memory
 	aiMode     airepair.Mode
+	// dumpNativeDiags prints the native checker's per-context error
+	// histogram (assignments/accepted/errors + breakdown) to stderr after
+	// a `check` / `typecheck` run. Populated from `internal/check.Result`
+	// once the native-checker boundary has been invoked. Off by default;
+	// nil-safe when the native checker was unavailable.
+	dumpNativeDiags bool
 }
 
 func main() {
@@ -454,6 +460,9 @@ func main() {
 		if flags.inspect {
 			runInspect(file, chk, flags)
 		}
+		if flags.dumpNativeDiags {
+			dumpNativeDiagsFor(path, chk)
+		}
 		if hasError(all) {
 			os.Exit(1)
 		}
@@ -556,6 +565,7 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.trace, "trace", false, "stream per-phase timing to stderr (single-file front-end commands)")
 	flag.BoolVar(&f.explain, "explain", false, "after diagnostics, print the `osty explain CODE` text for each unique code")
 	flag.BoolVar(&f.inspect, "inspect", false, "check: emit one record per expression showing the inference rule, type, and hint (see LANG_SPEC_v0.4/02a-type-inference.md)")
+	flag.BoolVar(&f.dumpNativeDiags, "dump-native-diags", false, "check: after the run, print the native checker's per-context error histogram to stderr")
 	flag.Usage = usage
 	flag.Parse()
 	return f
@@ -605,6 +615,9 @@ func runCheckPackage(dir string, flags cliFlags) {
 	printPackageDiags(pkg, diags, flags)
 	if flags.inspect {
 		runInspectPackage(pkg, chk, flags)
+	}
+	if flags.dumpNativeDiags {
+		dumpNativeDiagsFor(dir, chk)
 	}
 	if hasError(diags) {
 		os.Exit(1)
@@ -677,6 +690,9 @@ func runCheckWorkspace(dir string, flags cliFlags) {
 		printPackageDiags(pkg, diags, flags)
 		if flags.inspect && cr != nil {
 			runInspectPackage(pkg, cr, flags)
+		}
+		if flags.dumpNativeDiags && cr != nil {
+			dumpNativeDiagsFor(p, cr)
 		}
 		if hasError(diags) {
 			anyErr = true

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -33,6 +33,26 @@ type Result struct {
 
 	// Diags aggregates the diagnostics produced during checking.
 	Diags []*diag.Diagnostic
+
+	// NativeCheckerTelemetry carries the per-context error histogram the
+	// bootstrapped native checker produced alongside the aggregate summary
+	// diagnostic. Populated by host_boundary on the File / Package / Workspace
+	// entry points. Consumed by `osty check --dump-native-diags`; nil when
+	// the native checker was unavailable or reported no errors.
+	NativeCheckerTelemetry *NativeCheckerTelemetry
+}
+
+// NativeCheckerTelemetry bundles the counters the bootstrapped native checker
+// surfaces to host tooling.
+type NativeCheckerTelemetry struct {
+	Assignments     int
+	Accepted        int
+	Errors          int
+	ErrorsByContext map[string]int
+	// ErrorDetails optionally maps a context key from ErrorsByContext to a
+	// finer breakdown — e.g. frontCheckIdentHint → unresolved identifier
+	// counts. Only populated at sites wired to selfhostBumpErrorWithDetail.
+	ErrorDetails map[string]map[string]int
 }
 
 // LookupSymType returns the declared type of a resolver symbol, or nil

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -35,9 +35,11 @@ type nativeCheckRequest struct {
 }
 
 type nativeCheckSummary struct {
-	Assignments int `json:"assignments"`
-	Accepted    int `json:"accepted"`
-	Errors      int `json:"errors"`
+	Assignments     int                       `json:"assignments"`
+	Accepted        int                       `json:"accepted"`
+	Errors          int                       `json:"errors"`
+	ErrorsByContext map[string]int            `json:"errorsByContext,omitempty"`
+	ErrorDetails    map[string]map[string]int `json:"errorDetails,omitempty"`
 }
 
 type nativeCheckedNode struct {
@@ -121,9 +123,11 @@ func (embeddedNativeChecker) CheckSourceStructured(src []byte) (nativeCheckResul
 func adaptEmbeddedCheckResult(checked selfhost.CheckResult) nativeCheckResult {
 	result := nativeCheckResult{
 		Summary: nativeCheckSummary{
-			Assignments: checked.Summary.Assignments,
-			Accepted:    checked.Summary.Accepted,
-			Errors:      checked.Summary.Errors,
+			Assignments:     checked.Summary.Assignments,
+			Accepted:        checked.Summary.Accepted,
+			Errors:          checked.Summary.Errors,
+			ErrorsByContext: cloneStringIntMap(checked.Summary.ErrorsByContext),
+			ErrorDetails:    cloneErrorDetailMap(checked.Summary.ErrorDetails),
 		},
 		TypedNodes:     make([]nativeCheckedNode, 0, len(checked.TypedNodes)),
 		Bindings:       make([]nativeCheckedBinding, 0, len(checked.Bindings)),
@@ -236,6 +240,9 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 		return
 	}
 	checkedSrc := selfhostFileSource(file, rr, src, stdlib)
+	if dump := os.Getenv("OSTY_NATIVE_CHECKER_SOURCE_DUMP"); dump != "" {
+		_ = os.WriteFile(dump, checkedSrc.source, 0o644)
+	}
 	checked, err := runner.CheckSourceStructured(checkedSrc.source)
 	if err != nil {
 		result.Diags = append(result.Diags, checkerUnavailableDiag(
@@ -246,6 +253,7 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 		return
 	}
 	result.Diags = nativeCheckerDiags(checkedSrc.source, checked)
+	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked)
 	overlaySelfhostResult(result, checkedSrc, checked)
 }
 
@@ -267,6 +275,9 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 		return
 	}
 	src := selfhostPackageSource(pkg, ws, stdlib)
+	if dump := os.Getenv("OSTY_NATIVE_CHECKER_SOURCE_DUMP"); dump != "" {
+		_ = os.WriteFile(dump, src.source, 0o644)
+	}
 	if len(src.source) == 0 {
 		result.Diags = append(result.Diags, checkerUnavailableDiag(
 			"package",
@@ -284,6 +295,7 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 		return
 	}
 	result.Diags = nativeCheckerDiags(src.source, checked)
+	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked)
 	overlaySelfhostResult(result, src, checked)
 }
 
@@ -302,6 +314,41 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.
 		}
 		applySelfhostPackageResult(result, pkg, nil, ws, stdlib)
 	}
+}
+
+func nativeCheckerTelemetry(checked nativeCheckResult) *NativeCheckerTelemetry {
+	if checked.Summary.Assignments == 0 && checked.Summary.Errors == 0 && len(checked.Summary.ErrorsByContext) == 0 {
+		return nil
+	}
+	return &NativeCheckerTelemetry{
+		Assignments:     checked.Summary.Assignments,
+		Accepted:        checked.Summary.Accepted,
+		Errors:          checked.Summary.Errors,
+		ErrorsByContext: cloneStringIntMap(checked.Summary.ErrorsByContext),
+		ErrorDetails:    cloneErrorDetailMap(checked.Summary.ErrorDetails),
+	}
+}
+
+func cloneErrorDetailMap(src map[string]map[string]int) map[string]map[string]int {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]int, len(src))
+	for ctx, inner := range src {
+		out[ctx] = cloneStringIntMap(inner)
+	}
+	return out
+}
+
+func cloneStringIntMap(src map[string]int) map[string]int {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
 }
 
 func nativeCheckerDiags(src []byte, checked nativeCheckResult) []*diag.Diagnostic {

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -9,6 +9,14 @@ type CheckSummary struct {
 	Assignments int
 	Accepted    int
 	Errors      int
+	// ErrorsByContext buckets the total Errors count by the enclosing
+	// native-checker function at each error-detection site. Populated by
+	// selfhostBumpError; consumed by `osty check --dump-native-diags`.
+	ErrorsByContext map[string]int
+	// ErrorDetails optionally holds a second-level split under a given
+	// context. Populated only at sites that call selfhostBumpErrorWithDetail
+	// — currently frontCheckIdentHint (keyed by unresolved identifier).
+	ErrorDetails map[string]map[string]int
 }
 
 // CheckedNode records a checked expression node and its inferred type name.
@@ -61,6 +69,8 @@ type CheckResult struct {
 }
 
 // CheckSource runs the bootstrapped Osty checker over one source string.
+// The returned Summary carries ErrorsByContext so lightweight telemetry
+// callers do not need to materialise the full structured result.
 func CheckSource(src []byte) CheckSummary {
 	return CheckSourceStructured(src).Summary
 }
@@ -87,9 +97,36 @@ func adaptCheckSummary(checked *FrontCheckSummary) CheckSummary {
 	}
 }
 
+func adaptCheckSummaryWithContext(checked *FrontCheckResult) CheckSummary {
+	if checked == nil {
+		return CheckSummary{}
+	}
+	s := adaptCheckSummary(checked.summary)
+	if len(checked.errorsByContext) > 0 {
+		s.ErrorsByContext = make(map[string]int, len(checked.errorsByContext))
+		for k, v := range checked.errorsByContext {
+			s.ErrorsByContext[k] = v
+		}
+	}
+	if len(checked.errorDetails) > 0 {
+		s.ErrorDetails = make(map[string]map[string]int, len(checked.errorDetails))
+		for ctx, inner := range checked.errorDetails {
+			if len(inner) == 0 {
+				continue
+			}
+			copied := make(map[string]int, len(inner))
+			for k, v := range inner {
+				copied[k] = v
+			}
+			s.ErrorDetails[ctx] = copied
+		}
+	}
+	return s
+}
+
 func adaptCheckResult(checked *FrontCheckResult, lexed *OstyLexedSource) CheckResult {
 	result := CheckResult{
-		Summary:        adaptCheckSummary(checked.summary),
+		Summary:        adaptCheckSummaryWithContext(checked),
 		TypedNodes:     make([]CheckedNode, 0, len(checked.typedNodes)),
 		Bindings:       make([]CheckedBinding, 0, len(checked.bindings)),
 		Symbols:        make([]CheckedSymbol, 0, len(checked.symbols)),

--- a/internal/selfhost/check_telemetry.go
+++ b/internal/selfhost/check_telemetry.go
@@ -1,0 +1,80 @@
+package selfhost
+
+import (
+	"runtime"
+	"strings"
+)
+
+// selfhostUseDeclAlias resolves the canonical alias name for a UseDecl
+// node. The parser stores the `use ... as <alias>` alias ident in
+// children2[0] when present; otherwise the alias falls back to the last
+// segment of the raw path, stripped of any surrounding quote characters
+// that a Go-FFI path literal (e.g. `use go "strings"`) would otherwise
+// retain. Fixing this at collection time makes `env.fns` register the
+// alias-qualified fn names the call-site lookup actually uses.
+func selfhostUseDeclAlias(file *AstFile, decl *AstNode) string {
+	if len(decl.children2) > 0 {
+		aliasNode := astArenaNodeAt(file.arena, decl.children2[0])
+		if aliasNode != nil && aliasNode.text != "" {
+			return aliasNode.text
+		}
+	}
+	last := frontCheckLastPathSegment(decl.text)
+	return strings.Trim(last, "\"")
+}
+
+
+// selfhostBumpError increments env.errors and records the caller's Go
+// function name in env.errorsByContext. The generated native checker
+// invokes this at every error-detection site so downstream tooling can
+// split the aggregate error count by category (see cmd/osty check
+// --dump-native-diags).
+//
+// The package-qualified function name is trimmed to the bare Go
+// identifier, which matches the shape of the enclosing Osty function
+// closely enough to serve as a category key without extra bookkeeping.
+func selfhostBumpError(env *FrontCheckEnv) {
+	env.errors++
+	if env.errorsByContext == nil {
+		env.errorsByContext = make(map[string]int)
+	}
+	env.errorsByContext[selfhostErrorCallerContext(2)]++
+}
+
+// selfhostBumpErrorWithDetail is the detail-carrying variant: it buckets the
+// caller context like selfhostBumpError, then drills one level deeper into
+// env.errorDetails[<context>][<detail>]. Used from sites where the category
+// alone hides the real hot spot — e.g. frontCheckIdentHint benefits from
+// seeing which identifier name went unresolved most often.
+func selfhostBumpErrorWithDetail(env *FrontCheckEnv, detail string) {
+	env.errors++
+	ctx := selfhostErrorCallerContext(2)
+	if env.errorsByContext == nil {
+		env.errorsByContext = make(map[string]int)
+	}
+	env.errorsByContext[ctx]++
+	if env.errorDetails == nil {
+		env.errorDetails = make(map[string]map[string]int)
+	}
+	bucket := env.errorDetails[ctx]
+	if bucket == nil {
+		bucket = make(map[string]int)
+		env.errorDetails[ctx] = bucket
+	}
+	bucket[detail]++
+}
+
+// selfhostErrorCallerContext resolves a stack frame to a bare Go function
+// name. `skip` follows the runtime.Caller contract (0 = this helper, 1 =
+// its caller, 2 = the caller's caller, etc.).
+func selfhostErrorCallerContext(skip int) string {
+	pc, _, _, ok := runtime.Caller(skip)
+	if !ok {
+		return "<unknown>"
+	}
+	name := runtime.FuncForPC(pc).Name()
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	return name
+}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -24752,6 +24752,8 @@ type FrontCheckEnv struct {
 	assignments      int
 	accepted         int
 	errors           int
+	errorsByContext  map[string]int
+	errorDetails     map[string]map[string]int
 	typedNodes       []*FrontCheckedNode
 	checkedBindings  []*FrontCheckedBinding
 	checkedSymbols   []*FrontCheckedSymbol
@@ -24760,11 +24762,13 @@ type FrontCheckEnv struct {
 
 // Osty: /tmp/selfhost_merged.osty:9463:5
 type FrontCheckResult struct {
-	summary        *FrontCheckSummary
-	typedNodes     []*FrontCheckedNode
-	bindings       []*FrontCheckedBinding
-	symbols        []*FrontCheckedSymbol
-	instantiations []*FrontCheckInstantiation
+	summary         *FrontCheckSummary
+	typedNodes      []*FrontCheckedNode
+	bindings        []*FrontCheckedBinding
+	symbols         []*FrontCheckedSymbol
+	instantiations  []*FrontCheckInstantiation
+	errorsByContext map[string]int
+	errorDetails    map[string]map[string]int
 }
 
 // Osty: /tmp/selfhost_merged.osty:9471:5
@@ -24816,13 +24820,13 @@ func frontCheckSummaryFromEnv(env *FrontCheckEnv) *FrontCheckSummary {
 
 // Osty: /tmp/selfhost_merged.osty:9509:1
 func frontCheckResultFromEnv(env *FrontCheckEnv) *FrontCheckResult {
-	return &FrontCheckResult{summary: frontCheckSummaryFromEnv(env), typedNodes: env.typedNodes, bindings: env.checkedBindings, symbols: env.checkedSymbols, instantiations: env.instantiations}
+	return &FrontCheckResult{summary: frontCheckSummaryFromEnv(env), typedNodes: env.typedNodes, bindings: env.checkedBindings, symbols: env.checkedSymbols, instantiations: env.instantiations, errorsByContext: env.errorsByContext, errorDetails: env.errorDetails}
 }
 
 // Osty: /tmp/selfhost_merged.osty:9519:1
 func frontCheckEnv(returnType string) *FrontCheckEnv {
 	// Osty: /tmp/selfhost_merged.osty:9520:5
-	env := &FrontCheckEnv{bindings: make([]*FrontCheckBinding, 0, 1), fns: make([]*FrontFnSig, 0, 1), fields: make([]*FrontFieldSig, 0, 1), variants: make([]*FrontVariantSig, 0, 1), aliases: make([]*FrontAliasSig, 0, 1), types: make([]*FrontTypeSig, 0, 1), interfaces: make([]string, 0, 1), interfaceExtends: make([]*FrontInterfaceExtSig, 0, 1), genericBounds: make([]*FrontTypeSubst, 0, 1), returnType: returnType, assignments: 0, accepted: 0, errors: 0, typedNodes: make([]*FrontCheckedNode, 0, 1), checkedBindings: make([]*FrontCheckedBinding, 0, 1), checkedSymbols: make([]*FrontCheckedSymbol, 0, 1), instantiations: make([]*FrontCheckInstantiation, 0, 1)}
+	env := &FrontCheckEnv{bindings: make([]*FrontCheckBinding, 0, 1), fns: make([]*FrontFnSig, 0, 1), fields: make([]*FrontFieldSig, 0, 1), variants: make([]*FrontVariantSig, 0, 1), aliases: make([]*FrontAliasSig, 0, 1), types: make([]*FrontTypeSig, 0, 1), interfaces: make([]string, 0, 1), interfaceExtends: make([]*FrontInterfaceExtSig, 0, 1), genericBounds: make([]*FrontTypeSubst, 0, 1), returnType: returnType, assignments: 0, accepted: 0, errors: 0, errorsByContext: make(map[string]int), typedNodes: make([]*FrontCheckedNode, 0, 1), checkedBindings: make([]*FrontCheckedBinding, 0, 1), checkedSymbols: make([]*FrontCheckedSymbol, 0, 1), instantiations: make([]*FrontCheckInstantiation, 0, 1)}
 	_ = env
 	// Osty: /tmp/selfhost_merged.osty:9539:5
 	frontCheckInstallBuiltins(env)
@@ -24831,7 +24835,7 @@ func frontCheckEnv(returnType string) *FrontCheckEnv {
 
 // Osty: /tmp/selfhost_merged.osty:9543:1
 func frontCheckChildEnv(parent *FrontCheckEnv, returnType string) *FrontCheckEnv {
-	return &FrontCheckEnv{bindings: parent.bindings, fns: parent.fns, fields: parent.fields, variants: parent.variants, aliases: parent.aliases, types: parent.types, interfaces: parent.interfaces, interfaceExtends: parent.interfaceExtends, genericBounds: parent.genericBounds, returnType: returnType, assignments: 0, accepted: 0, errors: 0, typedNodes: make([]*FrontCheckedNode, 0, 1), checkedBindings: make([]*FrontCheckedBinding, 0, 1), checkedSymbols: parent.checkedSymbols, instantiations: make([]*FrontCheckInstantiation, 0, 1)}
+	return &FrontCheckEnv{bindings: parent.bindings, fns: parent.fns, fields: parent.fields, variants: parent.variants, aliases: parent.aliases, types: parent.types, interfaces: parent.interfaces, interfaceExtends: parent.interfaceExtends, genericBounds: parent.genericBounds, returnType: returnType, assignments: 0, accepted: 0, errors: 0, errorsByContext: make(map[string]int), typedNodes: make([]*FrontCheckedNode, 0, 1), checkedBindings: make([]*FrontCheckedBinding, 0, 1), checkedSymbols: parent.checkedSymbols, instantiations: make([]*FrontCheckInstantiation, 0, 1)}
 }
 
 // Osty: /tmp/selfhost_merged.osty:9565:1
@@ -24916,6 +24920,29 @@ func frontCheckMerge(parent *FrontCheckEnv, child *FrontCheckEnv) {
 		}
 		return _p1930 + _rhs1931
 	}()
+	if len(child.errorsByContext) > 0 {
+		if parent.errorsByContext == nil {
+			parent.errorsByContext = make(map[string]int)
+		}
+		for k, v := range child.errorsByContext {
+			parent.errorsByContext[k] += v
+		}
+	}
+	if len(child.errorDetails) > 0 {
+		if parent.errorDetails == nil {
+			parent.errorDetails = make(map[string]map[string]int)
+		}
+		for ctx, inner := range child.errorDetails {
+			bucket := parent.errorDetails[ctx]
+			if bucket == nil {
+				bucket = make(map[string]int, len(inner))
+				parent.errorDetails[ctx] = bucket
+			}
+			for detail, n := range inner {
+				bucket[detail] += n
+			}
+		}
+	}
 	// Osty: /tmp/selfhost_merged.osty:9580:5
 	for _, typed := range child.typedNodes {
 		// Osty: /tmp/selfhost_merged.osty:9581:9
@@ -25151,17 +25178,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 		// Osty: /tmp/selfhost_merged.osty:9723:9
 		if frontCheckFnExists(env, decl.text, owner) {
 			// Osty: /tmp/selfhost_merged.osty:9724:16
-			env.errors = func() int {
-				var _p1938 int = env.errors
-				var _rhs1939 int = 1
-				if _rhs1939 > 0 && _p1938 > math.MaxInt-_rhs1939 {
-					panic("integer overflow")
-				}
-				if _rhs1939 < 0 && _p1938 < math.MinInt-_rhs1939 {
-					panic("integer overflow")
-				}
-				return _p1938 + _rhs1939
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:9726:9
 		frontCheckCheckGenericParams(file, env, decl.children2)
@@ -25185,17 +25202,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 		// Osty: /tmp/selfhost_merged.osty:9735:9
 		if frontCheckDeclaredTypeExists(env, decl.text) {
 			// Osty: /tmp/selfhost_merged.osty:9736:16
-			env.errors = func() int {
-				var _p1940 int = env.errors
-				var _rhs1941 int = 1
-				if _rhs1941 > 0 && _p1940 > math.MaxInt-_rhs1941 {
-					panic("integer overflow")
-				}
-				if _rhs1941 < 0 && _p1940 < math.MinInt-_rhs1941 {
-					panic("integer overflow")
-				}
-				return _p1940 + _rhs1941
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:9738:9
 		func() struct{} {
@@ -25214,17 +25221,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 				// Osty: /tmp/selfhost_merged.osty:9743:17
 				if frontCheckFieldLookup(env, decl.text, member.text).name != "" {
 					// Osty: /tmp/selfhost_merged.osty:9744:24
-					env.errors = func() int {
-						var _p1942 int = env.errors
-						var _rhs1943 int = 1
-						if _rhs1943 > 0 && _p1942 > math.MaxInt-_rhs1943 {
-							panic("integer overflow")
-						}
-						if _rhs1943 < 0 && _p1942 < math.MinInt-_rhs1943 {
-							panic("integer overflow")
-						}
-						return _p1942 + _rhs1943
-					}()
+					selfhostBumpError(env)
 				}
 				// Osty: /tmp/selfhost_merged.osty:9746:17
 				field := &FrontFieldSig{owner: decl.text, name: member.text, typeName: frontCheckTypeName(file, member.right), hasDefault: member.left >= 0}
@@ -25251,17 +25248,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 		// Osty: /tmp/selfhost_merged.osty:9763:9
 		if frontCheckDeclaredTypeExists(env, decl.text) {
 			// Osty: /tmp/selfhost_merged.osty:9764:16
-			env.errors = func() int {
-				var _p1944 int = env.errors
-				var _rhs1945 int = 1
-				if _rhs1945 > 0 && _p1944 > math.MaxInt-_rhs1945 {
-					panic("integer overflow")
-				}
-				if _rhs1945 < 0 && _p1944 < math.MinInt-_rhs1945 {
-					panic("integer overflow")
-				}
-				return _p1944 + _rhs1945
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:9766:9
 		func() struct{} {
@@ -25280,17 +25267,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 				// Osty: /tmp/selfhost_merged.osty:9771:17
 				if frontCheckVariantLookupForOwner(env, member.text, decl.text).name != "" {
 					// Osty: /tmp/selfhost_merged.osty:9772:24
-					env.errors = func() int {
-						var _p1946 int = env.errors
-						var _rhs1947 int = 1
-						if _rhs1947 > 0 && _p1946 > math.MaxInt-_rhs1947 {
-							panic("integer overflow")
-						}
-						if _rhs1947 < 0 && _p1946 < math.MinInt-_rhs1947 {
-							panic("integer overflow")
-						}
-						return _p1946 + _rhs1947
-					}()
+					selfhostBumpError(env)
 				}
 				// Osty: /tmp/selfhost_merged.osty:9774:17
 				var fieldTypes []string = make([]string, 0, 1)
@@ -25323,17 +25300,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 		// Osty: /tmp/selfhost_merged.osty:9787:9
 		if frontCheckDeclaredTypeExists(env, decl.text) {
 			// Osty: /tmp/selfhost_merged.osty:9788:16
-			env.errors = func() int {
-				var _p1948 int = env.errors
-				var _rhs1949 int = 1
-				if _rhs1949 > 0 && _p1948 > math.MaxInt-_rhs1949 {
-					panic("integer overflow")
-				}
-				if _rhs1949 < 0 && _p1948 < math.MinInt-_rhs1949 {
-					panic("integer overflow")
-				}
-				return _p1948 + _rhs1949
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:9789:9
 		frontCheckCheckGenericParams(file, env, decl.children2)
@@ -25359,17 +25326,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 				// Osty: /tmp/selfhost_merged.osty:9799:17
 				if frontCheckFnExists(env, member.text, decl.text) {
 					// Osty: /tmp/selfhost_merged.osty:9800:24
-					env.errors = func() int {
-						var _p1950 int = env.errors
-						var _rhs1951 int = 1
-						if _rhs1951 > 0 && _p1950 > math.MaxInt-_rhs1951 {
-							panic("integer overflow")
-						}
-						if _rhs1951 < 0 && _p1950 < math.MinInt-_rhs1951 {
-							panic("integer overflow")
-						}
-						return _p1950 + _rhs1951
-					}()
+					selfhostBumpError(env)
 				}
 				// Osty: /tmp/selfhost_merged.osty:9802:17
 				frontCheckCheckGenericParams(file, env, member.children2)
@@ -25401,17 +25358,7 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 		// Osty: /tmp/selfhost_merged.osty:9814:9
 		if frontCheckDeclaredTypeExists(env, decl.text) {
 			// Osty: /tmp/selfhost_merged.osty:9815:16
-			env.errors = func() int {
-				var _p1952 int = env.errors
-				var _rhs1953 int = 1
-				if _rhs1953 > 0 && _p1952 > math.MaxInt-_rhs1953 {
-					panic("integer overflow")
-				}
-				if _rhs1953 < 0 && _p1952 < math.MinInt-_rhs1953 {
-					panic("integer overflow")
-				}
-				return _p1952 + _rhs1953
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:9817:9
 		func() struct{} {
@@ -25439,7 +25386,14 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 	// Osty: /tmp/selfhost_merged.osty:9828:5
 	if ostyEqual(decl.kind, AstNodeKind(&AstNodeKind_AstNUseDecl{})) {
 		// Osty: /tmp/selfhost_merged.osty:9829:9
-		alias := frontCheckLastPathSegment(decl.text)
+		// The bootstrapped source stored `frontCheckLastPathSegment(decl.text)`
+		// here, which returned the Go FFI path literal with its surrounding
+		// quotes intact (e.g. `"strings"`). Call-site selector lookup uses
+		// the bare identifier, so every `use go "X" as X { fn Y ... }` alias
+		// failed to register in env.fns. Routing through selfhostUseDeclAlias
+		// prefers the parser's alias ident (children2[0]) and strips stray
+		// quote characters on the fallback path.
+		alias := selfhostUseDeclAlias(file, decl)
 		_ = alias
 		// Osty: /tmp/selfhost_merged.osty:9830:9
 		for _, itemIdx := range decl.children {
@@ -25550,17 +25504,7 @@ func frontCheckCheckGenericParams(file *AstFile, env *FrontCheckEnv, idxs []int)
 		// Osty: /tmp/selfhost_merged.osty:9893:9
 		if frontCheckStringContains(seen, n.text) {
 			// Osty: /tmp/selfhost_merged.osty:9894:16
-			env.errors = func() int {
-				var _p1954 int = env.errors
-				var _rhs1955 int = 1
-				if _rhs1955 > 0 && _p1954 > math.MaxInt-_rhs1955 {
-					panic("integer overflow")
-				}
-				if _rhs1955 < 0 && _p1954 < math.MinInt-_rhs1955 {
-					panic("integer overflow")
-				}
-				return _p1954 + _rhs1955
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:9896:9
 		func() struct{} { seen = append(seen, n.text); return struct{}{} }()
@@ -27141,17 +27085,7 @@ func frontCheckExpectAssignable(env *FrontCheckEnv, dst string, src string) {
 		}()
 	} else {
 		// Osty: /tmp/selfhost_merged.osty:10646:12
-		env.errors = func() int {
-			var _p2012 int = env.errors
-			var _rhs2013 int = 1
-			if _rhs2013 > 0 && _p2012 > math.MaxInt-_rhs2013 {
-				panic("integer overflow")
-			}
-			if _rhs2013 < 0 && _p2012 < math.MinInt-_rhs2013 {
-				panic("integer overflow")
-			}
-			return _p2012 + _rhs2013
-		}()
+		selfhostBumpError(env)
 	}
 }
 
@@ -27456,17 +27390,7 @@ func frontCheckUnify(env *FrontCheckEnv, left string, right string) string {
 		return right
 	}
 	// Osty: /tmp/selfhost_merged.osty:10788:8
-	env.errors = func() int {
-		var _p2024 int = env.errors
-		var _rhs2025 int = 1
-		if _rhs2025 > 0 && _p2024 > math.MaxInt-_rhs2025 {
-			panic("integer overflow")
-		}
-		if _rhs2025 < 0 && _p2024 < math.MinInt-_rhs2025 {
-			panic("integer overflow")
-		}
-		return _p2024 + _rhs2025
-	}()
+	selfhostBumpError(env)
 	return "Invalid"
 }
 
@@ -27591,17 +27515,7 @@ func frontCheckStmt(file *AstFile, env *FrontCheckEnv, idx int) string {
 		// Osty: /tmp/selfhost_merged.osty:10847:9
 		if !(frontCheckPatternIrrefutable(file, node.left)) {
 			// Osty: /tmp/selfhost_merged.osty:10848:16
-			env.errors = func() int {
-				var _p2030 int = env.errors
-				var _rhs2031 int = 1
-				if _rhs2031 > 0 && _p2030 > math.MaxInt-_rhs2031 {
-					panic("integer overflow")
-				}
-				if _rhs2031 < 0 && _p2030 < math.MinInt-_rhs2031 {
-					panic("integer overflow")
-				}
-				return _p2030 + _rhs2031
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:10850:9
 		finalType := valueType
@@ -27644,17 +27558,7 @@ func frontCheckStmt(file *AstFile, env *FrontCheckEnv, idx int) string {
 				return _p2032 + _rhs2033
 			}()
 			// Osty: /tmp/selfhost_merged.osty:10865:16
-			env.errors = func() int {
-				var _p2034 int = env.errors
-				var _rhs2035 int = 1
-				if _rhs2035 > 0 && _p2034 > math.MaxInt-_rhs2035 {
-					panic("integer overflow")
-				}
-				if _rhs2035 < 0 && _p2034 < math.MinInt-_rhs2035 {
-					panic("integer overflow")
-				}
-				return _p2034 + _rhs2035
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:10867:9
 		return "()"
@@ -27676,17 +27580,7 @@ func frontCheckStmt(file *AstFile, env *FrontCheckEnv, idx int) string {
 			frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, node.right, elem))
 		} else if !(frontCheckIsInvalid(chanType)) {
 			// Osty: /tmp/selfhost_merged.osty:10876:16
-			env.errors = func() int {
-				var _p2036 int = env.errors
-				var _rhs2037 int = 1
-				if _rhs2037 > 0 && _p2036 > math.MaxInt-_rhs2037 {
-					panic("integer overflow")
-				}
-				if _rhs2037 < 0 && _p2036 < math.MinInt-_rhs2037 {
-					panic("integer overflow")
-				}
-				return _p2036 + _rhs2037
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:10878:9
 		return "()"
@@ -27741,17 +27635,7 @@ func frontCheckFor(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:10906:9
 		if condType != "Bool" && !(frontCheckIsInvalid(condType)) {
 			// Osty: /tmp/selfhost_merged.osty:10907:16
-			env.errors = func() int {
-				var _p2038 int = env.errors
-				var _rhs2039 int = 1
-				if _rhs2039 > 0 && _p2038 > math.MaxInt-_rhs2039 {
-					panic("integer overflow")
-				}
-				if _rhs2039 < 0 && _p2038 < math.MinInt-_rhs2039 {
-					panic("integer overflow")
-				}
-				return _p2038 + _rhs2039
-			}()
+			selfhostBumpError(env)
 		}
 	} else if node.text == "forlet" {
 		// Osty: /tmp/selfhost_merged.osty:10910:9
@@ -27769,17 +27653,7 @@ func frontCheckFor(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:10915:9
 		if elemType == "Invalid" {
 			// Osty: /tmp/selfhost_merged.osty:10916:16
-			env.errors = func() int {
-				var _p2040 int = env.errors
-				var _rhs2041 int = 1
-				if _rhs2041 > 0 && _p2040 > math.MaxInt-_rhs2041 {
-					panic("integer overflow")
-				}
-				if _rhs2041 < 0 && _p2040 < math.MinInt-_rhs2041 {
-					panic("integer overflow")
-				}
-				return _p2040 + _rhs2041
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:10918:9
 		frontCheckBindPattern(file, env, frontCheckIntAt(node.children, 0), elemType, false)
@@ -28073,17 +27947,7 @@ func frontCheckIdentHint(env *FrontCheckEnv, name string, hint string) string {
 	// Osty: /tmp/selfhost_merged.osty:11087:5
 	if name != "_" {
 		// Osty: /tmp/selfhost_merged.osty:11088:12
-		env.errors = func() int {
-			var _p2044 int = env.errors
-			var _rhs2045 int = 1
-			if _rhs2045 > 0 && _p2044 > math.MaxInt-_rhs2045 {
-				panic("integer overflow")
-			}
-			if _rhs2045 < 0 && _p2044 < math.MinInt-_rhs2045 {
-				panic("integer overflow")
-			}
-			return _p2044 + _rhs2045
-		}()
+		selfhostBumpErrorWithDetail(env, name)
 	}
 	return "Invalid"
 }
@@ -28098,17 +27962,7 @@ func frontCheckUnary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11096:9
 		if inner != "Bool" && !(frontCheckIsInvalid(inner)) {
 			// Osty: /tmp/selfhost_merged.osty:11097:16
-			env.errors = func() int {
-				var _p2046 int = env.errors
-				var _rhs2047 int = 1
-				if _rhs2047 > 0 && _p2046 > math.MaxInt-_rhs2047 {
-					panic("integer overflow")
-				}
-				if _rhs2047 < 0 && _p2046 < math.MinInt-_rhs2047 {
-					panic("integer overflow")
-				}
-				return _p2046 + _rhs2047
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:11098:13
 			return "Invalid"
 		}
@@ -28125,17 +27979,7 @@ func frontCheckUnary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11106:9
 		if !(frontCheckIsInvalid(inner)) {
 			// Osty: /tmp/selfhost_merged.osty:11107:16
-			env.errors = func() int {
-				var _p2048 int = env.errors
-				var _rhs2049 int = 1
-				if _rhs2049 > 0 && _p2048 > math.MaxInt-_rhs2049 {
-					panic("integer overflow")
-				}
-				if _rhs2049 < 0 && _p2048 < math.MinInt-_rhs2049 {
-					panic("integer overflow")
-				}
-				return _p2048 + _rhs2049
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11109:9
 		return "Invalid"
@@ -28150,17 +27994,7 @@ func frontCheckUnary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11115:9
 		if !(frontCheckIsInvalid(inner)) {
 			// Osty: /tmp/selfhost_merged.osty:11116:16
-			env.errors = func() int {
-				var _p2050 int = env.errors
-				var _rhs2051 int = 1
-				if _rhs2051 > 0 && _p2050 > math.MaxInt-_rhs2051 {
-					panic("integer overflow")
-				}
-				if _rhs2051 < 0 && _p2050 < math.MinInt-_rhs2051 {
-					panic("integer overflow")
-				}
-				return _p2050 + _rhs2051
-			}()
+			selfhostBumpError(env)
 		}
 	}
 	return "Invalid"
@@ -28182,17 +28016,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11129:12
-		env.errors = func() int {
-			var _p2052 int = env.errors
-			var _rhs2053 int = 1
-			if _rhs2053 > 0 && _p2052 > math.MaxInt-_rhs2053 {
-				panic("integer overflow")
-			}
-			if _rhs2053 < 0 && _p2052 < math.MinInt-_rhs2053 {
-				panic("integer overflow")
-			}
-			return _p2052 + _rhs2053
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11130:9
 		return "Invalid"
 	}
@@ -28204,17 +28028,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11136:12
-		env.errors = func() int {
-			var _p2054 int = env.errors
-			var _rhs2055 int = 1
-			if _rhs2055 > 0 && _p2054 > math.MaxInt-_rhs2055 {
-				panic("integer overflow")
-			}
-			if _rhs2055 < 0 && _p2054 < math.MinInt-_rhs2055 {
-				panic("integer overflow")
-			}
-			return _p2054 + _rhs2055
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11137:9
 		return "Invalid"
 	}
@@ -28226,17 +28040,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11143:12
-		env.errors = func() int {
-			var _p2056 int = env.errors
-			var _rhs2057 int = 1
-			if _rhs2057 > 0 && _p2056 > math.MaxInt-_rhs2057 {
-				panic("integer overflow")
-			}
-			if _rhs2057 < 0 && _p2056 < math.MinInt-_rhs2057 {
-				panic("integer overflow")
-			}
-			return _p2056 + _rhs2057
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11144:9
 		return "Invalid"
 	}
@@ -28245,17 +28049,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11147:9
 		if frontCheckTypeHead(left) != "Option" {
 			// Osty: /tmp/selfhost_merged.osty:11148:16
-			env.errors = func() int {
-				var _p2058 int = env.errors
-				var _rhs2059 int = 1
-				if _rhs2059 > 0 && _p2058 > math.MaxInt-_rhs2059 {
-					panic("integer overflow")
-				}
-				if _rhs2059 < 0 && _p2058 < math.MinInt-_rhs2059 {
-					panic("integer overflow")
-				}
-				return _p2058 + _rhs2059
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:11149:13
 			return "Invalid"
 		}
@@ -28280,17 +28074,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return left
 		}
 		// Osty: /tmp/selfhost_merged.osty:11162:12
-		env.errors = func() int {
-			var _p2060 int = env.errors
-			var _rhs2061 int = 1
-			if _rhs2061 > 0 && _p2060 > math.MaxInt-_rhs2061 {
-				panic("integer overflow")
-			}
-			if _rhs2061 < 0 && _p2060 < math.MinInt-_rhs2061 {
-				panic("integer overflow")
-			}
-			return _p2060 + _rhs2061
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11163:9
 		return "Invalid"
 	}
@@ -28299,17 +28083,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11166:9
 		if !(frontCheckIsNumeric(left)) || !(frontCheckIsNumeric(right)) {
 			// Osty: /tmp/selfhost_merged.osty:11167:16
-			env.errors = func() int {
-				var _p2062 int = env.errors
-				var _rhs2063 int = 1
-				if _rhs2063 > 0 && _p2062 > math.MaxInt-_rhs2063 {
-					panic("integer overflow")
-				}
-				if _rhs2063 < 0 && _p2062 < math.MinInt-_rhs2063 {
-					panic("integer overflow")
-				}
-				return _p2062 + _rhs2063
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:11168:13
 			return "Invalid"
 		}
@@ -28485,17 +28259,7 @@ func frontCheckRange(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11244:9
 		if !(frontCheckIsInteger(left)) {
 			// Osty: /tmp/selfhost_merged.osty:11245:16
-			env.errors = func() int {
-				var _p2070 int = env.errors
-				var _rhs2071 int = 1
-				if _rhs2071 > 0 && _p2070 > math.MaxInt-_rhs2071 {
-					panic("integer overflow")
-				}
-				if _rhs2071 < 0 && _p2070 < math.MinInt-_rhs2071 {
-					panic("integer overflow")
-				}
-				return _p2070 + _rhs2071
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11247:9
 		elem = left
@@ -28508,17 +28272,7 @@ func frontCheckRange(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11251:9
 		if !(frontCheckIsInteger(right)) {
 			// Osty: /tmp/selfhost_merged.osty:11252:16
-			env.errors = func() int {
-				var _p2072 int = env.errors
-				var _rhs2073 int = 1
-				if _rhs2073 > 0 && _p2072 > math.MaxInt-_rhs2073 {
-					panic("integer overflow")
-				}
-				if _rhs2073 < 0 && _p2072 < math.MinInt-_rhs2073 {
-					panic("integer overflow")
-				}
-				return _p2072 + _rhs2073
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11254:9
 		elem = frontCheckUnify(env, elem, right)
@@ -28550,17 +28304,7 @@ func frontCheckIfHint(file *AstFile, env *FrontCheckEnv, node *AstNode, hint str
 		// Osty: /tmp/selfhost_merged.osty:11270:9
 		if cond != "Bool" && !(frontCheckIsInvalid(cond)) {
 			// Osty: /tmp/selfhost_merged.osty:11271:16
-			env.errors = func() int {
-				var _p2074 int = env.errors
-				var _rhs2075 int = 1
-				if _rhs2075 > 0 && _p2074 > math.MaxInt-_rhs2075 {
-					panic("integer overflow")
-				}
-				if _rhs2075 < 0 && _p2074 < math.MinInt-_rhs2075 {
-					panic("integer overflow")
-				}
-				return _p2074 + _rhs2075
-			}()
+			selfhostBumpError(env)
 		}
 	}
 	// Osty: /tmp/selfhost_merged.osty:11274:5
@@ -28645,17 +28389,7 @@ func frontCheckCallHint(file *AstFile, env *FrontCheckEnv, callIdx int, node *As
 			return frontCheckBuiltinCall(file, env, callee.text, node.children)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11317:12
-		env.errors = func() int {
-			var _p2076 int = env.errors
-			var _rhs2077 int = 1
-			if _rhs2077 > 0 && _p2076 > math.MaxInt-_rhs2077 {
-				panic("integer overflow")
-			}
-			if _rhs2077 < 0 && _p2076 < math.MinInt-_rhs2077 {
-				panic("integer overflow")
-			}
-			return _p2076 + _rhs2077
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11318:9
 		return "Invalid"
 	}
@@ -28711,17 +28445,7 @@ func frontCheckCallHint(file *AstFile, env *FrontCheckEnv, callIdx int, node *As
 		// Osty: /tmp/selfhost_merged.osty:11343:9
 		if !(frontCheckIsInvalid(recvType)) {
 			// Osty: /tmp/selfhost_merged.osty:11344:16
-			env.errors = func() int {
-				var _p2078 int = env.errors
-				var _rhs2079 int = 1
-				if _rhs2079 > 0 && _p2078 > math.MaxInt-_rhs2079 {
-					panic("integer overflow")
-				}
-				if _rhs2079 < 0 && _p2078 < math.MinInt-_rhs2079 {
-					panic("integer overflow")
-				}
-				return _p2078 + _rhs2079
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11346:9
 		return "Invalid"
@@ -28735,17 +28459,7 @@ func frontCheckCallHint(file *AstFile, env *FrontCheckEnv, callIdx int, node *As
 		return frontCheckCallFnType(file, env, fnType, node.children)
 	}
 	// Osty: /tmp/selfhost_merged.osty:11352:8
-	env.errors = func() int {
-		var _p2080 int = env.errors
-		var _rhs2081 int = 1
-		if _rhs2081 > 0 && _p2080 > math.MaxInt-_rhs2081 {
-			panic("integer overflow")
-		}
-		if _rhs2081 < 0 && _p2080 < math.MinInt-_rhs2081 {
-			panic("integer overflow")
-		}
-		return _p2080 + _rhs2081
-	}()
+	selfhostBumpError(env)
 	return "Invalid"
 }
 
@@ -28807,17 +28521,7 @@ func frontCheckBuiltinCall(file *AstFile, env *FrontCheckEnv, name string, args 
 		// Osty: /tmp/selfhost_merged.osty:11388:9
 		if frontCheckTypeHead(fnType) != "fn" && !(frontCheckIsInvalid(fnType)) {
 			// Osty: /tmp/selfhost_merged.osty:11389:16
-			env.errors = func() int {
-				var _p2082 int = env.errors
-				var _rhs2083 int = 1
-				if _rhs2083 > 0 && _p2082 > math.MaxInt-_rhs2083 {
-					panic("integer overflow")
-				}
-				if _rhs2083 < 0 && _p2082 < math.MinInt-_rhs2083 {
-					panic("integer overflow")
-				}
-				return _p2082 + _rhs2083
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11391:9
 		return "ThreadHandle"
@@ -28843,31 +28547,11 @@ func frontCheckBuiltinCall(file *AstFile, env *FrontCheckEnv, name string, args 
 					elem = ret
 				} else if !(frontCheckIsAssignable(env, elem, ret)) && !(frontCheckIsAssignable(env, ret, elem)) {
 					// Osty: /tmp/selfhost_merged.osty:11402:24
-					env.errors = func() int {
-						var _p2084 int = env.errors
-						var _rhs2085 int = 1
-						if _rhs2085 > 0 && _p2084 > math.MaxInt-_rhs2085 {
-							panic("integer overflow")
-						}
-						if _rhs2085 < 0 && _p2084 < math.MinInt-_rhs2085 {
-							panic("integer overflow")
-						}
-						return _p2084 + _rhs2085
-					}()
+					selfhostBumpError(env)
 				}
 			} else if !(frontCheckIsInvalid(fnType)) {
 				// Osty: /tmp/selfhost_merged.osty:11405:20
-				env.errors = func() int {
-					var _p2086 int = env.errors
-					var _rhs2087 int = 1
-					if _rhs2087 > 0 && _p2086 > math.MaxInt-_rhs2087 {
-						panic("integer overflow")
-					}
-					if _rhs2087 < 0 && _p2086 < math.MinInt-_rhs2087 {
-						panic("integer overflow")
-					}
-					return _p2086 + _rhs2087
-				}()
+				selfhostBumpError(env)
 			}
 		}
 		// Osty: /tmp/selfhost_merged.osty:11408:9
@@ -28896,17 +28580,7 @@ func frontCheckBuiltinCall(file *AstFile, env *FrontCheckEnv, name string, args 
 		// Osty: /tmp/selfhost_merged.osty:11420:9
 		if !(frontCheckIsInvalid(valueType)) {
 			// Osty: /tmp/selfhost_merged.osty:11421:16
-			env.errors = func() int {
-				var _p2088 int = env.errors
-				var _rhs2089 int = 1
-				if _rhs2089 > 0 && _p2088 > math.MaxInt-_rhs2089 {
-					panic("integer overflow")
-				}
-				if _rhs2089 < 0 && _p2088 < math.MinInt-_rhs2089 {
-					panic("integer overflow")
-				}
-				return _p2088 + _rhs2089
-			}()
+			selfhostBumpError(env)
 		}
 	}
 	return "Invalid"
@@ -28962,17 +28636,7 @@ func frontCheckTurbofishCall(file *AstFile, env *FrontCheckEnv, callIdx int, cal
 			// Osty: /tmp/selfhost_merged.osty:11450:13
 			if frontCheckStringCount(typeArgs) != 1 {
 				// Osty: /tmp/selfhost_merged.osty:11451:20
-				env.errors = func() int {
-					var _p2090 int = env.errors
-					var _rhs2091 int = 1
-					if _rhs2091 > 0 && _p2090 > math.MaxInt-_rhs2091 {
-						panic("integer overflow")
-					}
-					if _rhs2091 < 0 && _p2090 < math.MinInt-_rhs2091 {
-						panic("integer overflow")
-					}
-					return _p2090 + _rhs2091
-				}()
+				selfhostBumpError(env)
 				// Osty: /tmp/selfhost_merged.osty:11452:17
 				return "Chan<Invalid>"
 			}
@@ -29012,17 +28676,7 @@ func frontCheckTurbofishCall(file *AstFile, env *FrontCheckEnv, callIdx int, cal
 		}
 	}
 	// Osty: /tmp/selfhost_merged.osty:11470:8
-	env.errors = func() int {
-		var _p2092 int = env.errors
-		var _rhs2093 int = 1
-		if _rhs2093 > 0 && _p2092 > math.MaxInt-_rhs2093 {
-			panic("integer overflow")
-		}
-		if _rhs2093 < 0 && _p2092 < math.MinInt-_rhs2093 {
-			panic("integer overflow")
-		}
-		return _p2092 + _rhs2093
-	}()
+	selfhostBumpError(env)
 	return "Invalid"
 }
 
@@ -29047,17 +28701,7 @@ func frontCheckExplicitSubsts(env *FrontCheckEnv, generics []string, typeArgs []
 	// Osty: /tmp/selfhost_merged.osty:11484:5
 	if frontCheckStringCount(generics) != frontCheckStringCount(typeArgs) {
 		// Osty: /tmp/selfhost_merged.osty:11485:12
-		env.errors = func() int {
-			var _p2094 int = env.errors
-			var _rhs2095 int = 1
-			if _rhs2095 > 0 && _p2094 > math.MaxInt-_rhs2095 {
-				panic("integer overflow")
-			}
-			if _rhs2095 < 0 && _p2094 < math.MinInt-_rhs2095 {
-				panic("integer overflow")
-			}
-			return _p2094 + _rhs2095
-		}()
+		selfhostBumpError(env)
 	}
 	// Osty: /tmp/selfhost_merged.osty:11487:5
 	i := 0
@@ -29143,17 +28787,7 @@ func frontCheckVariantCallWithSubsts(file *AstFile, env *FrontCheckEnv, variant 
 	// Osty: /tmp/selfhost_merged.osty:11521:5
 	if frontCheckIntCount(args) != frontCheckStringCount(variant.fieldTypes) {
 		// Osty: /tmp/selfhost_merged.osty:11522:12
-		env.errors = func() int {
-			var _p2100 int = env.errors
-			var _rhs2101 int = 1
-			if _rhs2101 > 0 && _p2100 > math.MaxInt-_rhs2101 {
-				panic("integer overflow")
-			}
-			if _rhs2101 < 0 && _p2100 < math.MinInt-_rhs2101 {
-				panic("integer overflow")
-			}
-			return _p2100 + _rhs2101
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11523:9
 		return frontCheckGenericOwnerType(variant.owner, variant.generics, substs)
 	}
@@ -29239,17 +28873,7 @@ func frontCheckCallSig(file *AstFile, env *FrontCheckEnv, callIdx int, sig *Fron
 	// Osty: /tmp/selfhost_merged.osty:11556:5
 	if gotCount != wantCount {
 		// Osty: /tmp/selfhost_merged.osty:11557:12
-		env.errors = func() int {
-			var _p2106 int = env.errors
-			var _rhs2107 int = 1
-			if _rhs2107 > 0 && _p2106 > math.MaxInt-_rhs2107 {
-				panic("integer overflow")
-			}
-			if _rhs2107 < 0 && _p2106 < math.MinInt-_rhs2107 {
-				panic("integer overflow")
-			}
-			return _p2106 + _rhs2107
-		}()
+		selfhostBumpError(env)
 	}
 	// Osty: /tmp/selfhost_merged.osty:11559:5
 	i := 0
@@ -29328,17 +28952,7 @@ func frontCheckCallFnType(file *AstFile, env *FrontCheckEnv, fnType string, args
 	// Osty: /tmp/selfhost_merged.osty:11586:5
 	if frontCheckStringCount(params) != frontCheckIntCount(args) {
 		// Osty: /tmp/selfhost_merged.osty:11587:12
-		env.errors = func() int {
-			var _p2112 int = env.errors
-			var _rhs2113 int = 1
-			if _rhs2113 > 0 && _p2112 > math.MaxInt-_rhs2113 {
-				panic("integer overflow")
-			}
-			if _rhs2113 < 0 && _p2112 < math.MinInt-_rhs2113 {
-				panic("integer overflow")
-			}
-			return _p2112 + _rhs2113
-		}()
+		selfhostBumpError(env)
 	}
 	// Osty: /tmp/selfhost_merged.osty:11589:5
 	i := 0
@@ -29526,17 +29140,7 @@ func frontCheckAddSubst(env *FrontCheckEnv, substs []*FrontTypeSubst, name strin
 	// Osty: /tmp/selfhost_merged.osty:11660:5
 	if !(frontCheckIsAssignable(env, existing, typeName)) && !(frontCheckIsAssignable(env, typeName, existing)) {
 		// Osty: /tmp/selfhost_merged.osty:11661:12
-		env.errors = func() int {
-			var _p2124 int = env.errors
-			var _rhs2125 int = 1
-			if _rhs2125 > 0 && _p2124 > math.MaxInt-_rhs2125 {
-				panic("integer overflow")
-			}
-			if _rhs2125 < 0 && _p2124 < math.MinInt-_rhs2125 {
-				panic("integer overflow")
-			}
-			return _p2124 + _rhs2125
-		}()
+		selfhostBumpError(env)
 	}
 	return out
 }
@@ -29715,17 +29319,7 @@ func frontCheckField(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 	// Osty: /tmp/selfhost_merged.osty:11757:5
 	if !(frontCheckIsInvalid(recvType)) {
 		// Osty: /tmp/selfhost_merged.osty:11758:12
-		env.errors = func() int {
-			var _p2126 int = env.errors
-			var _rhs2127 int = 1
-			if _rhs2127 > 0 && _p2126 > math.MaxInt-_rhs2127 {
-				panic("integer overflow")
-			}
-			if _rhs2127 < 0 && _p2126 < math.MinInt-_rhs2127 {
-				panic("integer overflow")
-			}
-			return _p2126 + _rhs2127
-		}()
+		selfhostBumpError(env)
 	}
 	return "Invalid"
 }
@@ -29772,17 +29366,7 @@ func frontCheckIndex(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 	// Osty: /tmp/selfhost_merged.osty:11783:5
 	if !(frontCheckIsInvalid(objectType)) {
 		// Osty: /tmp/selfhost_merged.osty:11784:12
-		env.errors = func() int {
-			var _p2128 int = env.errors
-			var _rhs2129 int = 1
-			if _rhs2129 > 0 && _p2128 > math.MaxInt-_rhs2129 {
-				panic("integer overflow")
-			}
-			if _rhs2129 < 0 && _p2128 < math.MinInt-_rhs2129 {
-				panic("integer overflow")
-			}
-			return _p2128 + _rhs2129
-		}()
+		selfhostBumpError(env)
 	}
 	return "Invalid"
 }
@@ -29806,17 +29390,7 @@ func frontCheckStructLitHint(file *AstFile, env *FrontCheckEnv, node *AstNode, h
 	// Osty: /tmp/selfhost_merged.osty:11797:5
 	if typeSig.name == "" {
 		// Osty: /tmp/selfhost_merged.osty:11798:12
-		env.errors = func() int {
-			var _p2130 int = env.errors
-			var _rhs2131 int = 1
-			if _rhs2131 > 0 && _p2130 > math.MaxInt-_rhs2131 {
-				panic("integer overflow")
-			}
-			if _rhs2131 < 0 && _p2130 < math.MinInt-_rhs2131 {
-				panic("integer overflow")
-			}
-			return _p2130 + _rhs2131
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11799:9
 		return "Invalid"
 	}
@@ -29852,17 +29426,7 @@ func frontCheckStructLitHint(file *AstFile, env *FrontCheckEnv, node *AstNode, h
 		// Osty: /tmp/selfhost_merged.osty:11815:9
 		if frontCheckStructLitFieldCount(file, node, fieldNode.text) > 1 {
 			// Osty: /tmp/selfhost_merged.osty:11816:16
-			env.errors = func() int {
-				var _p2132 int = env.errors
-				var _rhs2133 int = 1
-				if _rhs2133 > 0 && _p2132 > math.MaxInt-_rhs2133 {
-					panic("integer overflow")
-				}
-				if _rhs2133 < 0 && _p2132 < math.MinInt-_rhs2133 {
-					panic("integer overflow")
-				}
-				return _p2132 + _rhs2133
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11818:9
 		field := frontCheckFieldLookup(env, typeName, fieldNode.text)
@@ -29870,17 +29434,7 @@ func frontCheckStructLitHint(file *AstFile, env *FrontCheckEnv, node *AstNode, h
 		// Osty: /tmp/selfhost_merged.osty:11819:9
 		if field.name == "" {
 			// Osty: /tmp/selfhost_merged.osty:11820:16
-			env.errors = func() int {
-				var _p2134 int = env.errors
-				var _rhs2135 int = 1
-				if _rhs2135 > 0 && _p2134 > math.MaxInt-_rhs2135 {
-					panic("integer overflow")
-				}
-				if _rhs2135 < 0 && _p2134 < math.MinInt-_rhs2135 {
-					panic("integer overflow")
-				}
-				return _p2134 + _rhs2135
-			}()
+			selfhostBumpError(env)
 		} else {
 			// Osty: /tmp/selfhost_merged.osty:11822:13
 			valueType := "Invalid"
@@ -29907,17 +29461,7 @@ func frontCheckStructLitHint(file *AstFile, env *FrontCheckEnv, node *AstNode, h
 		// Osty: /tmp/selfhost_merged.osty:11834:9
 		if field.owner == typeName && !(field.hasDefault) && !(frontCheckStructLitHasField(file, node, field.name)) && node.right < 0 {
 			// Osty: /tmp/selfhost_merged.osty:11835:16
-			env.errors = func() int {
-				var _p2136 int = env.errors
-				var _rhs2137 int = 1
-				if _rhs2137 > 0 && _p2136 > math.MaxInt-_rhs2137 {
-					panic("integer overflow")
-				}
-				if _rhs2137 < 0 && _p2136 < math.MinInt-_rhs2137 {
-					panic("integer overflow")
-				}
-				return _p2136 + _rhs2137
-			}()
+			selfhostBumpError(env)
 		}
 	}
 	return frontCheckGenericOwnerType(typeName, typeSig.generics, substs)
@@ -30005,17 +29549,7 @@ func frontCheckMatchHint(file *AstFile, env *FrontCheckEnv, node *AstNode, hint 
 			// Osty: /tmp/selfhost_merged.osty:11877:13
 			if guard != "Bool" && !(frontCheckIsInvalid(guard)) {
 				// Osty: /tmp/selfhost_merged.osty:11878:20
-				env.errors = func() int {
-					var _p2140 int = env.errors
-					var _rhs2141 int = 1
-					if _rhs2141 > 0 && _p2140 > math.MaxInt-_rhs2141 {
-						panic("integer overflow")
-					}
-					if _rhs2141 < 0 && _p2140 < math.MinInt-_rhs2141 {
-						panic("integer overflow")
-					}
-					return _p2140 + _rhs2141
-				}()
+				selfhostBumpError(env)
 			}
 		}
 		// Osty: /tmp/selfhost_merged.osty:11881:9
@@ -30054,17 +29588,7 @@ func frontCheckCheckMatchExhaustive(file *AstFile, env *FrontCheckEnv, node *Ast
 	// Osty: /tmp/selfhost_merged.osty:11895:5
 	if arms == 0 {
 		// Osty: /tmp/selfhost_merged.osty:11896:12
-		env.errors = func() int {
-			var _p2144 int = env.errors
-			var _rhs2145 int = 1
-			if _rhs2145 > 0 && _p2144 > math.MaxInt-_rhs2145 {
-				panic("integer overflow")
-			}
-			if _rhs2145 < 0 && _p2144 < math.MinInt-_rhs2145 {
-				panic("integer overflow")
-			}
-			return _p2144 + _rhs2145
-		}()
+		selfhostBumpError(env)
 		// Osty: /tmp/selfhost_merged.osty:11897:9
 		return
 	}
@@ -30086,17 +29610,7 @@ func frontCheckCheckMatchExhaustive(file *AstFile, env *FrontCheckEnv, node *Ast
 		// Osty: /tmp/selfhost_merged.osty:11906:9
 		if !(frontCheckMatchCoversBool(file, node, true)) || !(frontCheckMatchCoversBool(file, node, false)) {
 			// Osty: /tmp/selfhost_merged.osty:11907:16
-			env.errors = func() int {
-				var _p2146 int = env.errors
-				var _rhs2147 int = 1
-				if _rhs2147 > 0 && _p2146 > math.MaxInt-_rhs2147 {
-					panic("integer overflow")
-				}
-				if _rhs2147 < 0 && _p2146 < math.MinInt-_rhs2147 {
-					panic("integer overflow")
-				}
-				return _p2146 + _rhs2147
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11909:9
 		return
@@ -30106,17 +29620,7 @@ func frontCheckCheckMatchExhaustive(file *AstFile, env *FrontCheckEnv, node *Ast
 		// Osty: /tmp/selfhost_merged.osty:11912:9
 		if !(frontCheckMatchCoversBoolTuple(file, node, scrutinee)) {
 			// Osty: /tmp/selfhost_merged.osty:11913:16
-			env.errors = func() int {
-				var _p2148 int = env.errors
-				var _rhs2149 int = 1
-				if _rhs2149 > 0 && _p2148 > math.MaxInt-_rhs2149 {
-					panic("integer overflow")
-				}
-				if _rhs2149 < 0 && _p2148 < math.MinInt-_rhs2149 {
-					panic("integer overflow")
-				}
-				return _p2148 + _rhs2149
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11915:9
 		return
@@ -30126,17 +29630,7 @@ func frontCheckCheckMatchExhaustive(file *AstFile, env *FrontCheckEnv, node *Ast
 		// Osty: /tmp/selfhost_merged.osty:11918:9
 		if !(frontCheckMatchCoversStruct(file, env, node, owner)) {
 			// Osty: /tmp/selfhost_merged.osty:11919:16
-			env.errors = func() int {
-				var _p2150 int = env.errors
-				var _rhs2151 int = 1
-				if _rhs2151 > 0 && _p2150 > math.MaxInt-_rhs2151 {
-					panic("integer overflow")
-				}
-				if _rhs2151 < 0 && _p2150 < math.MinInt-_rhs2151 {
-					panic("integer overflow")
-				}
-				return _p2150 + _rhs2151
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:11921:9
 		return
@@ -30173,17 +29667,7 @@ func frontCheckCheckMatchExhaustive(file *AstFile, env *FrontCheckEnv, node *Ast
 	// Osty: /tmp/selfhost_merged.osty:11933:5
 	if variantCount > 0 && missing {
 		// Osty: /tmp/selfhost_merged.osty:11934:12
-		env.errors = func() int {
-			var _p2154 int = env.errors
-			var _rhs2155 int = 1
-			if _rhs2155 > 0 && _p2154 > math.MaxInt-_rhs2155 {
-				panic("integer overflow")
-			}
-			if _rhs2155 < 0 && _p2154 < math.MinInt-_rhs2155 {
-				panic("integer overflow")
-			}
-			return _p2154 + _rhs2155
-		}()
+		selfhostBumpError(env)
 	}
 }
 
@@ -30213,17 +29697,7 @@ func frontCheckCheckMatchReachability(file *AstFile, env *FrontCheckEnv, node *A
 			// Osty: /tmp/selfhost_merged.osty:11948:13
 			if frontCheckFirstChild(prevArm) < 0 && frontCheckPatternCoversPattern(file, env, prevArm.left, arm.left, scrutineeType) {
 				// Osty: /tmp/selfhost_merged.osty:11949:20
-				env.errors = func() int {
-					var _p2156 int = env.errors
-					var _rhs2157 int = 1
-					if _rhs2157 > 0 && _p2156 > math.MaxInt-_rhs2157 {
-						panic("integer overflow")
-					}
-					if _rhs2157 < 0 && _p2156 < math.MinInt-_rhs2157 {
-						panic("integer overflow")
-					}
-					return _p2156 + _rhs2157
-				}()
+				selfhostBumpError(env)
 				// Osty: /tmp/selfhost_merged.osty:11950:17
 				break
 			}
@@ -31981,17 +31455,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		elems := frontCheckTupleElems(scrutineeResolved)
 		_ = elems
 		if frontCheckStringCount(elems) != frontCheckIntCount(pat.children) {
-			env.errors = func() int {
-				var _p2208 int = env.errors
-				var _rhs2209 int = 1
-				if _rhs2209 > 0 && _p2208 > math.MaxInt-_rhs2209 {
-					panic("integer overflow")
-				}
-				if _rhs2209 < 0 && _p2208 < math.MinInt-_rhs2209 {
-					panic("integer overflow")
-				}
-				return _p2208 + _rhs2209
-			}()
+			selfhostBumpError(env)
 		}
 		i := 0
 		_ = i
@@ -32042,17 +31506,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12829:9
 		if !(frontCheckIsAssignable(env, scrutineeResolved, litType)) && !(frontCheckIsAssignable(env, litType, scrutineeResolved)) {
 			// Osty: /tmp/selfhost_merged.osty:12830:16
-			env.errors = func() int {
-				var _p2200 int = env.errors
-				var _rhs2201 int = 1
-				if _rhs2201 > 0 && _p2200 > math.MaxInt-_rhs2201 {
-					panic("integer overflow")
-				}
-				if _rhs2201 < 0 && _p2200 < math.MinInt-_rhs2201 {
-					panic("integer overflow")
-				}
-				return _p2200 + _rhs2201
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:12832:9
 		return
@@ -32068,34 +31522,14 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12837:9
 		if !(frontCheckIsNumeric(litType)) {
 			// Osty: /tmp/selfhost_merged.osty:12838:16
-			env.errors = func() int {
-				var _p2202 int = env.errors
-				var _rhs2203 int = 1
-				if _rhs2203 > 0 && _p2202 > math.MaxInt-_rhs2203 {
-					panic("integer overflow")
-				}
-				if _rhs2203 < 0 && _p2202 < math.MinInt-_rhs2203 {
-					panic("integer overflow")
-				}
-				return _p2202 + _rhs2203
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:12839:13
 			return
 		}
 		// Osty: /tmp/selfhost_merged.osty:12841:9
 		if !(frontCheckIsAssignable(env, scrutineeResolved, litType)) && !(frontCheckIsAssignable(env, litType, scrutineeResolved)) {
 			// Osty: /tmp/selfhost_merged.osty:12842:16
-			env.errors = func() int {
-				var _p2204 int = env.errors
-				var _rhs2205 int = 1
-				if _rhs2205 > 0 && _p2204 > math.MaxInt-_rhs2205 {
-					panic("integer overflow")
-				}
-				if _rhs2205 < 0 && _p2204 < math.MinInt-_rhs2205 {
-					panic("integer overflow")
-				}
-				return _p2204 + _rhs2205
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:12844:9
 		return
@@ -32105,17 +31539,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12847:9
 		if !(frontCheckIsOrdered(scrutineeResolved)) {
 			// Osty: /tmp/selfhost_merged.osty:12848:16
-			env.errors = func() int {
-				var _p2206 int = env.errors
-				var _rhs2207 int = 1
-				if _rhs2207 > 0 && _p2206 > math.MaxInt-_rhs2207 {
-					panic("integer overflow")
-				}
-				if _rhs2207 < 0 && _p2206 < math.MinInt-_rhs2207 {
-					panic("integer overflow")
-				}
-				return _p2206 + _rhs2207
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:12849:13
 			return
 		}
@@ -32137,17 +31561,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12859:9
 		if frontCheckStringCount(elems) != frontCheckIntCount(pat.children) {
 			// Osty: /tmp/selfhost_merged.osty:12860:16
-			env.errors = func() int {
-				var _p2208 int = env.errors
-				var _rhs2209 int = 1
-				if _rhs2209 > 0 && _p2208 > math.MaxInt-_rhs2209 {
-					panic("integer overflow")
-				}
-				if _rhs2209 < 0 && _p2208 < math.MinInt-_rhs2209 {
-					panic("integer overflow")
-				}
-				return _p2208 + _rhs2209
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:12862:9
 		i := 0
@@ -32180,17 +31594,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12871:9
 		if variant.name == "" || frontCheckTypeHead(scrutineeResolved) != variant.owner {
 			// Osty: /tmp/selfhost_merged.osty:12872:16
-			env.errors = func() int {
-				var _p2212 int = env.errors
-				var _rhs2213 int = 1
-				if _rhs2213 > 0 && _p2212 > math.MaxInt-_rhs2213 {
-					panic("integer overflow")
-				}
-				if _rhs2213 < 0 && _p2212 < math.MinInt-_rhs2213 {
-					panic("integer overflow")
-				}
-				return _p2212 + _rhs2213
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:12873:13
 			return
 		}
@@ -32228,17 +31632,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12885:9
 		if frontCheckTypeHead(scrutineeResolved) != structName {
 			// Osty: /tmp/selfhost_merged.osty:12886:16
-			env.errors = func() int {
-				var _p2216 int = env.errors
-				var _rhs2217 int = 1
-				if _rhs2217 > 0 && _p2216 > math.MaxInt-_rhs2217 {
-					panic("integer overflow")
-				}
-				if _rhs2217 < 0 && _p2216 < math.MinInt-_rhs2217 {
-					panic("integer overflow")
-				}
-				return _p2216 + _rhs2217
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:12887:13
 			return
 		}
@@ -32256,17 +31650,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 			// Osty: /tmp/selfhost_merged.osty:12893:13
 			if field.name == "" {
 				// Osty: /tmp/selfhost_merged.osty:12894:20
-				env.errors = func() int {
-					var _p2218 int = env.errors
-					var _rhs2219 int = 1
-					if _rhs2219 > 0 && _p2218 > math.MaxInt-_rhs2219 {
-						panic("integer overflow")
-					}
-					if _rhs2219 < 0 && _p2218 < math.MinInt-_rhs2219 {
-						panic("integer overflow")
-					}
-					return _p2218 + _rhs2219
-				}()
+				selfhostBumpError(env)
 			} else {
 				// Osty: /tmp/selfhost_merged.osty:12896:17
 				frontCheckPatternCompatible(file, env, fieldPat.left, frontCheckSubstitute(field.typeName, substs))
@@ -32306,17 +31690,7 @@ func frontCheckPatternCompatible(file *AstFile, env *FrontCheckEnv, patIdx int, 
 		// Osty: /tmp/selfhost_merged.osty:12914:9
 		if !(frontCheckBindingsAgree(env, leftBindings, rightBindings)) {
 			// Osty: /tmp/selfhost_merged.osty:12915:16
-			env.errors = func() int {
-				var _p2220 int = env.errors
-				var _rhs2221 int = 1
-				if _rhs2221 > 0 && _p2220 > math.MaxInt-_rhs2221 {
-					panic("integer overflow")
-				}
-				if _rhs2221 < 0 && _p2220 < math.MinInt-_rhs2221 {
-					panic("integer overflow")
-				}
-				return _p2220 + _rhs2221
-			}()
+			selfhostBumpError(env)
 			// Osty: /tmp/selfhost_merged.osty:12916:13
 			return
 		}
@@ -32443,17 +31817,7 @@ func frontCheckClosure(file *AstFile, env *FrontCheckEnv, node *AstNode, paramHi
 			// Osty: /tmp/selfhost_merged.osty:12979:13
 			if !(frontCheckPatternIrrefutable(file, param.left)) {
 				// Osty: /tmp/selfhost_merged.osty:12980:20
-				env.errors = func() int {
-					var _p2224 int = env.errors
-					var _rhs2225 int = 1
-					if _rhs2225 > 0 && _p2224 > math.MaxInt-_rhs2225 {
-						panic("integer overflow")
-					}
-					if _rhs2225 < 0 && _p2224 < math.MinInt-_rhs2225 {
-						panic("integer overflow")
-					}
-					return _p2224 + _rhs2225
-				}()
+				selfhostBumpError(env)
 			}
 			// Osty: /tmp/selfhost_merged.osty:12982:13
 			frontCheckBindPattern(file, env, param.left, paramType, true)
@@ -32711,17 +32075,7 @@ func frontCheckQuestion(file *AstFile, env *FrontCheckEnv, node *AstNode) string
 		// Osty: /tmp/selfhost_merged.osty:13088:9
 		if returnHead != "Option" && !(frontCheckIsInvalid(env.returnType)) {
 			// Osty: /tmp/selfhost_merged.osty:13089:16
-			env.errors = func() int {
-				var _p2240 int = env.errors
-				var _rhs2241 int = 1
-				if _rhs2241 > 0 && _p2240 > math.MaxInt-_rhs2241 {
-					panic("integer overflow")
-				}
-				if _rhs2241 < 0 && _p2240 < math.MinInt-_rhs2241 {
-					panic("integer overflow")
-				}
-				return _p2240 + _rhs2241
-			}()
+			selfhostBumpError(env)
 		}
 		// Osty: /tmp/selfhost_merged.osty:13091:9
 		return frontCheckGenericArgAt(inner, 0)
@@ -32731,17 +32085,7 @@ func frontCheckQuestion(file *AstFile, env *FrontCheckEnv, node *AstNode) string
 		// Osty: /tmp/selfhost_merged.osty:13094:9
 		if returnHead != "Result" && !(frontCheckIsInvalid(env.returnType)) {
 			// Osty: /tmp/selfhost_merged.osty:13095:16
-			env.errors = func() int {
-				var _p2242 int = env.errors
-				var _rhs2243 int = 1
-				if _rhs2243 > 0 && _p2242 > math.MaxInt-_rhs2243 {
-					panic("integer overflow")
-				}
-				if _rhs2243 < 0 && _p2242 < math.MinInt-_rhs2243 {
-					panic("integer overflow")
-				}
-				return _p2242 + _rhs2243
-			}()
+			selfhostBumpError(env)
 		} else if returnHead == "Result" {
 			// Osty: /tmp/selfhost_merged.osty:13097:13
 			frontCheckExpectAssignable(env, frontCheckGenericArgAt(returnType, 1), frontCheckGenericArgAt(inner, 1))
@@ -32752,17 +32096,7 @@ func frontCheckQuestion(file *AstFile, env *FrontCheckEnv, node *AstNode) string
 	// Osty: /tmp/selfhost_merged.osty:13101:5
 	if !(frontCheckIsInvalid(inner)) {
 		// Osty: /tmp/selfhost_merged.osty:13102:12
-		env.errors = func() int {
-			var _p2244 int = env.errors
-			var _rhs2245 int = 1
-			if _rhs2245 > 0 && _p2244 > math.MaxInt-_rhs2245 {
-				panic("integer overflow")
-			}
-			if _rhs2245 < 0 && _p2244 < math.MinInt-_rhs2245 {
-				panic("integer overflow")
-			}
-			return _p2244 + _rhs2245
-		}()
+		selfhostBumpError(env)
 	}
 	return "Invalid"
 }
@@ -33253,17 +32587,7 @@ func frontCheckExpectArgCount(env *FrontCheckEnv, args []int, want int) {
 	// Osty: /tmp/selfhost_merged.osty:13331:5
 	if frontCheckIntCount(args) != want {
 		// Osty: /tmp/selfhost_merged.osty:13332:12
-		env.errors = func() int {
-			var _p2246 int = env.errors
-			var _rhs2247 int = 1
-			if _rhs2247 > 0 && _p2246 > math.MaxInt-_rhs2247 {
-				panic("integer overflow")
-			}
-			if _rhs2247 < 0 && _p2246 < math.MinInt-_rhs2247 {
-				panic("integer overflow")
-			}
-			return _p2246 + _rhs2247
-		}()
+		selfhostBumpError(env)
 	}
 }
 
@@ -33275,17 +32599,7 @@ func frontCheckRequireMutableReceiver(file *AstFile, env *FrontCheckEnv, callee 
 	// Osty: /tmp/selfhost_merged.osty:13338:5
 	if ostyEqual(left.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) && !(frontCheckLookupMutable(env, left.text)) {
 		// Osty: /tmp/selfhost_merged.osty:13339:12
-		env.errors = func() int {
-			var _p2248 int = env.errors
-			var _rhs2249 int = 1
-			if _rhs2249 > 0 && _p2248 > math.MaxInt-_rhs2249 {
-				panic("integer overflow")
-			}
-			if _rhs2249 < 0 && _p2248 < math.MinInt-_rhs2249 {
-				panic("integer overflow")
-			}
-			return _p2248 + _rhs2249
-		}()
+		selfhostBumpError(env)
 	}
 }
 

--- a/toolchain/docgen.osty
+++ b/toolchain/docgen.osty
@@ -1,13 +1,13 @@
 use go "strings" as strings {
-    fn HasPrefix(s: String, prefix: String) -> Bool
-    fn Join(elems: List<String>, sep: String) -> String
-    fn Repeat(s: String, count: Int) -> String
-    fn ReplaceAll(s: String, old: String, new: String) -> String
-    fn Split(s: String, sep: String) -> List<String>
-    fn SplitN(s: String, sep: String, n: Int) -> List<String>
-    fn ToLower(s: String) -> String
-    fn TrimPrefix(s: String, prefix: String) -> String
-    fn TrimSpace(s: String) -> String
+    fn hasPrefix(s: String, prefix: String) -> Bool
+    fn join(elems: List<String>, sep: String) -> String
+    fn repeat(s: String, count: Int) -> String
+    fn replaceAll(s: String, old: String, new: String) -> String
+    fn split(s: String, sep: String) -> List<String>
+    fn splitN(s: String, sep: String, n: Int) -> List<String>
+    fn toLower(s: String) -> String
+    fn trimPrefix(s: String, prefix: String) -> String
+    fn trimSpace(s: String) -> String
 }
 
 /// SelfDocPackage is the self-hosted documentation root for one package.
@@ -246,7 +246,7 @@ pub fn selfDocRenderMarkdown(pkg: SelfDocPackage) -> String {
         }
     }
 
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocRenderHTML(pkg: SelfDocPackage) -> String {
@@ -288,7 +288,7 @@ fn selfDocRenderHTML(pkg: SelfDocPackage) -> String {
     lines.push("</main>")
     lines.push("</body>")
     lines.push("</html>")
-    let rendered = strings.Join(lines, "\n")
+    let rendered = strings.join(lines, "\n")
     "{rendered}\n"
 }
 
@@ -312,7 +312,7 @@ fn selfDocRenderHTMLTOC(pkg: SelfDocPackage) -> String {
             lines.push("</ul>")
         }
     }
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocRenderHTMLDecl(decl: SelfDocDecl, level: Int, refs: List<SelfDocRef>) -> String {
@@ -361,7 +361,7 @@ fn selfDocRenderHTMLDecl(decl: SelfDocDecl, level: Int, refs: List<SelfDocRef>) 
         lines.push("<h4>Variants</h4>")
         lines.push("<ul class=\"variants\">")
         for variant in decl.variants {
-            let payload = strings.Join(variant.payload, ", ")
+            let payload = strings.join(variant.payload, ", ")
             let safeVariantName = selfDocHTMLEscape(variant.name)
             let variantDoc = selfDocHTMLDashDoc(variant.doc)
             if payload == "" {
@@ -382,7 +382,7 @@ fn selfDocRenderHTMLDecl(decl: SelfDocDecl, level: Int, refs: List<SelfDocRef>) 
         lines.push("</div>")
     }
     lines.push("</article>")
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocRenderHTMLMethod(method: SelfDocMethod, level: Int, refs: List<SelfDocRef>) -> String {
@@ -399,7 +399,7 @@ fn selfDocRenderHTMLMethod(method: SelfDocMethod, level: Int, refs: List<SelfDoc
     }
     lines = selfDocAppendInfoHTML(lines, method.info)
     lines.push("</article>")
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocAppendInfoHTML(lines: List<String>, info: SelfDocInfo) -> List<String> {
@@ -456,7 +456,7 @@ fn selfDocRenderWorkspaceMarkdown(ws: SelfDocWorkspace, ext: String) -> String {
     }
     if selfDocPackageListCount(ws.packages) == 0 {
         lines.push("_No documented packages._")
-        let rendered = strings.Join(lines, "\n")
+        let rendered = strings.join(lines, "\n")
         return "{rendered}\n"
     }
     lines.push("## Packages")
@@ -470,7 +470,7 @@ fn selfDocRenderWorkspaceMarkdown(ws: SelfDocWorkspace, ext: String) -> String {
         lines.push("| [`{pkg.name}`]({filename}{ext}) | {escapedSummary} |")
     }
     lines.push("")
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocRenderWorkspaceHTML(ws: SelfDocWorkspace, ext: String) -> String {
@@ -494,7 +494,7 @@ fn selfDocRenderWorkspaceHTML(ws: SelfDocWorkspace, ext: String) -> String {
         lines.push("</main>")
         lines.push("</body>")
         lines.push("</html>")
-        let rendered = strings.Join(lines, "\n")
+        let rendered = strings.join(lines, "\n")
         return "{rendered}\n"
     }
     lines.push("<h2>Packages</h2>")
@@ -514,7 +514,7 @@ fn selfDocRenderWorkspaceHTML(ws: SelfDocWorkspace, ext: String) -> String {
     lines.push("</main>")
     lines.push("</body>")
     lines.push("</html>")
-    let rendered = strings.Join(lines, "\n")
+    let rendered = strings.join(lines, "\n")
     "{rendered}\n"
 }
 
@@ -822,8 +822,8 @@ fn selfDocParseDoc(raw: String) -> SelfDocInfo {
 
     let mut section = "prose"
     let mut exampleLines: List<String> = []
-    for rawLine in strings.Split(raw, "\n") {
-        let line = strings.TrimSpace(rawLine)
+    for rawLine in strings.split(raw, "\n") {
+        let line = strings.trimSpace(rawLine)
         if selfDocIsSection(line, "Params:") || selfDocIsSection(line, "Param:") || selfDocIsSection(
             line,
             "Args:",
@@ -882,7 +882,7 @@ fn selfDocParseDoc(raw: String) -> SelfDocInfo {
 
 fn selfDocRenderDeclMarkdown(decl: SelfDocDecl, level: Int, refs: List<SelfDocRef>) -> String {
     let mut lines: List<String> = []
-    let heading = strings.Repeat("#", level)
+    let heading = strings.repeat("#", level)
     let title = selfDocKindTitle(decl.kind)
     lines.push("{heading} {title} `{decl.name}`")
     lines.push("")
@@ -903,7 +903,7 @@ fn selfDocRenderDeclMarkdown(decl: SelfDocDecl, level: Int, refs: List<SelfDocRe
     lines = selfDocAppendInfoMarkdown(lines, decl.info, level + 1)
 
     if selfDocFieldCount(decl.fields) > 0 {
-        let subHeading = strings.Repeat("#", level + 1)
+        let subHeading = strings.repeat("#", level + 1)
         lines.push("{subHeading} Fields")
         lines.push("")
         let anyFieldDoc = selfDocFieldsHaveDoc(decl.fields)
@@ -925,11 +925,11 @@ fn selfDocRenderDeclMarkdown(decl: SelfDocDecl, level: Int, refs: List<SelfDocRe
     }
 
     if selfDocVariantCount(decl.variants) > 0 {
-        let subHeading = strings.Repeat("#", level + 1)
+        let subHeading = strings.repeat("#", level + 1)
         lines.push("{subHeading} Variants")
         lines.push("")
         for variant in decl.variants {
-            let payload = strings.Join(variant.payload, ", ")
+            let payload = strings.join(variant.payload, ", ")
             let variantDoc = selfDocDashDoc(variant.doc)
             if payload == "" {
                 lines.push("- `{variant.name}` {variantDoc}")
@@ -941,7 +941,7 @@ fn selfDocRenderDeclMarkdown(decl: SelfDocDecl, level: Int, refs: List<SelfDocRe
     }
 
     if selfDocMethodCount(decl.methods) > 0 {
-        let subHeading = strings.Repeat("#", level + 1)
+        let subHeading = strings.repeat("#", level + 1)
         lines.push("{subHeading} Methods")
         lines.push("")
         for method in decl.methods {
@@ -949,12 +949,12 @@ fn selfDocRenderDeclMarkdown(decl: SelfDocDecl, level: Int, refs: List<SelfDocRe
         }
     }
 
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocRenderMethodMarkdown(method: SelfDocMethod, level: Int, refs: List<SelfDocRef>) -> String {
     let mut lines: List<String> = []
-    let heading = strings.Repeat("#", level)
+    let heading = strings.repeat("#", level)
     lines.push("{heading} Function `{method.name}`")
     lines.push("")
     lines.push("```osty")
@@ -972,7 +972,7 @@ fn selfDocRenderMethodMarkdown(method: SelfDocMethod, level: Int, refs: List<Sel
         lines.push("")
     }
     lines = selfDocAppendInfoMarkdown(lines, method.info, level + 1)
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocAppendInfoMarkdown(lines: List<String>, info: SelfDocInfo, level: Int) -> List<String> {
@@ -986,7 +986,7 @@ fn selfDocAppendInfoMarkdown(lines: List<String>, info: SelfDocInfo, level: Int)
         out.push("")
     }
     if selfDocParamDocCount(info.params) > 0 {
-        let heading = strings.Repeat("#", level)
+        let heading = strings.repeat("#", level)
         out.push("{heading} Parameters")
         out.push("")
         out.push("| Name | Description |")
@@ -998,14 +998,14 @@ fn selfDocAppendInfoMarkdown(lines: List<String>, info: SelfDocInfo, level: Int)
         out.push("")
     }
     if info.returns != "" {
-        let heading = strings.Repeat("#", level)
+        let heading = strings.repeat("#", level)
         out.push("{heading} Returns")
         out.push("")
         out.push(info.returns)
         out.push("")
     }
     for example in info.examples {
-        let heading = strings.Repeat("#", level)
+        let heading = strings.repeat("#", level)
         out.push("{heading} Example")
         out.push("")
         out.push("```osty")
@@ -1014,7 +1014,7 @@ fn selfDocAppendInfoMarkdown(lines: List<String>, info: SelfDocInfo, level: Int)
         out.push("")
     }
     if selfDocStringListCount(info.see) > 0 {
-        let heading = strings.Repeat("#", level)
+        let heading = strings.repeat("#", level)
         out.push("{heading} See also")
         out.push("")
         for ref in info.see {
@@ -1036,7 +1036,7 @@ fn selfDocRenderTOC(pkg: SelfDocPackage) -> String {
             }
         }
     }
-    strings.Join(lines, "\n")
+    strings.join(lines, "\n")
 }
 
 fn selfDocRenderFnSignature(file: AstFile, node: AstNode) -> String {
@@ -1051,7 +1051,7 @@ fn selfDocRenderFnSignature(file: AstFile, node: AstNode) -> String {
         let param = astArenaNodeAt(file.arena, paramIdx)
         parts.push(selfDocRenderParam(file, param))
     }
-    let params = strings.Join(parts, ", ")
+    let params = strings.join(parts, ", ")
     text = "{text}{params})"
     if node.left >= 0 {
         let ret = selfDocRenderType(file, node.left)
@@ -1152,7 +1152,7 @@ fn selfDocRenderGenerics(file: AstFile, params: List<Int>) -> String {
         }
         parts.push(text)
     }
-    let rendered = strings.Join(parts, ", ")
+    let rendered = strings.join(parts, ", ")
     "<{rendered}>"
 }
 
@@ -1161,7 +1161,7 @@ fn selfDocRenderTypeList(file: AstFile, ids: List<Int>, sep: String) -> String {
     for id in ids {
         parts.push(selfDocRenderType(file, id))
     }
-    strings.Join(parts, sep)
+    strings.join(parts, sep)
 }
 
 fn selfDocRenderType(file: AstFile, idx: Int) -> String {
@@ -1217,7 +1217,7 @@ fn selfDocRenderExpr(file: AstFile, idx: Int) -> String {
             args.push(selfDocRenderExpr(file, argIdx))
         }
         let callee = selfDocRenderExpr(file, node.left)
-        let renderedArgs = strings.Join(args, ", ")
+        let renderedArgs = strings.join(args, ", ")
         return "{callee}({renderedArgs})"
     }
     "..."
@@ -1272,12 +1272,12 @@ fn selfDocFlushExample(info: SelfDocInfo, lines: List<String>) -> SelfDocInfo {
 fn selfDocTrimJoinedLines(lines: List<String>) -> String {
     let mut kept: List<String> = []
     for line in lines {
-        let trimmed = strings.TrimSpace(line)
+        let trimmed = strings.trimSpace(line)
         if selfDocStringListCount(kept) > 0 || trimmed != "" {
             kept.push(line)
         }
     }
-    for selfDocStringListCount(kept) > 0 && strings.TrimSpace(
+    for selfDocStringListCount(kept) > 0 && strings.trimSpace(
         kept[selfDocStringListCount(kept) - 1],
     ) == "" {
         let mut next: List<String> = []
@@ -1287,18 +1287,18 @@ fn selfDocTrimJoinedLines(lines: List<String>) -> String {
         }
         kept = next
     }
-    strings.Join(kept, "\n")
+    strings.join(kept, "\n")
 }
 
 fn selfDocAddParamLine(info: SelfDocInfo, line: String) -> SelfDocInfo {
     let mut out = info
-    let trimmed = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "- "), "* "))
-    let parts = strings.SplitN(trimmed, ":", 2)
+    let trimmed = strings.trimSpace(strings.trimPrefix(strings.trimPrefix(line, "- "), "* "))
+    let parts = strings.splitN(trimmed, ":", 2)
     if selfDocStringListCount(parts) == 2 {
         out.params.push(
             SelfDocParamDoc {
-                name: strings.TrimSpace(parts[0]),
-                desc: strings.TrimSpace(parts[1]),
+                name: strings.trimSpace(parts[0]),
+                desc: strings.trimSpace(parts[1]),
             },
         )
     } else if selfDocParamDocCount(out.params) > 0 && trimmed != "" {
@@ -1314,12 +1314,12 @@ fn selfDocAddParamLine(info: SelfDocInfo, line: String) -> SelfDocInfo {
 
 fn selfDocAddSeeLine(info: SelfDocInfo, line: String) -> SelfDocInfo {
     let mut out = info
-    let trimmed = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "- "), "* "))
+    let trimmed = strings.trimSpace(strings.trimPrefix(strings.trimPrefix(line, "- "), "* "))
     if trimmed == "" {
         return out
     }
-    for part in strings.Split(trimmed, ",") {
-        let ref = strings.TrimSpace(part)
+    for part in strings.split(trimmed, ",") {
+        let ref = strings.trimSpace(part)
         if ref != "" {
             out.see.push(ref)
         }
@@ -1335,13 +1335,13 @@ fn selfDocAppendSentence(current: String, next: String) -> String {
 }
 
 fn selfDocIsSection(line: String, label: String) -> Bool {
-    strings.HasPrefix(strings.ToLower(line), strings.ToLower(label))
+    strings.hasPrefix(strings.toLower(line), strings.toLower(label))
 }
 
 fn selfDocSectionRest(line: String) -> String {
-    let parts = strings.SplitN(line, ":", 2)
+    let parts = strings.splitN(line, ":", 2)
     if selfDocStringListCount(parts) == 2 {
-        return strings.TrimSpace(parts[1])
+        return strings.trimSpace(parts[1])
     }
     ""
 }
@@ -1352,10 +1352,10 @@ fn selfDocRenderDeclAnchor(decl: SelfDocDecl) -> String {
 }
 
 fn selfDocSlug(s: String) -> String {
-    let lower = strings.ToLower(s)
-    let noTicks = strings.ReplaceAll(lower, "`", "")
-    let spaces = strings.ReplaceAll(noTicks, " ", "-")
-    strings.ReplaceAll(spaces, "_", "-")
+    let lower = strings.toLower(s)
+    let noTicks = strings.replaceAll(lower, "`", "")
+    let spaces = strings.replaceAll(noTicks, " ", "-")
+    strings.replaceAll(spaces, "_", "-")
 }
 
 fn selfDocKindTitle(kind: String) -> String {
@@ -1381,11 +1381,11 @@ fn selfDocKindTitle(kind: String) -> String {
 }
 
 fn selfDocFirstLine(s: String) -> String {
-    let lines = strings.Split(s, "\n")
+    let lines = strings.split(s, "\n")
     if selfDocStringListCount(lines) == 0 {
         return ""
     }
-    strings.TrimSpace(lines[0])
+    strings.trimSpace(lines[0])
 }
 
 fn selfDocDashDoc(s: String) -> String {
@@ -1397,7 +1397,7 @@ fn selfDocDashDoc(s: String) -> String {
 }
 
 fn selfDocEscapePipes(s: String) -> String {
-    strings.ReplaceAll(s, "|", "\\|")
+    strings.replaceAll(s, "|", "\\|")
 }
 
 fn selfDocBuildIndex(pkg: SelfDocPackage) -> List<SelfDocRef> {
@@ -1441,7 +1441,7 @@ fn selfDocAddRefsFromText(
     exclude: String,
 ) -> List<String> {
     let mut out = existing
-    let units = strings.Split(text, "")
+    let units = strings.split(text, "")
     let mut idx = 0
     let count = selfDocStringListCount(units)
     for idx < count {
@@ -1503,11 +1503,11 @@ fn selfDocJoinRefLinks(names: List<String>, refs: List<SelfDocRef>) -> String {
             parts.push("[`{name}`](#{anchor})")
         }
     }
-    strings.Join(parts, ", ")
+    strings.join(parts, ", ")
 }
 
 fn selfDocLinkifyHTML(text: String, refs: List<SelfDocRef>, exclude: String) -> String {
-    let units = strings.Split(text, "")
+    let units = strings.split(text, "")
     let mut idx = 0
     let count = selfDocStringListCount(units)
     let mut parts: List<String> = []
@@ -1532,7 +1532,7 @@ fn selfDocLinkifyHTML(text: String, refs: List<SelfDocRef>, exclude: String) -> 
             idx = idx + 1
         }
     }
-    strings.Join(parts, "")
+    strings.join(parts, "")
 }
 
 fn selfDocFieldsHaveDoc(fields: List<SelfDocField>) -> Bool {
@@ -1545,11 +1545,11 @@ fn selfDocFieldsHaveDoc(fields: List<SelfDocField>) -> Bool {
 }
 
 fn selfDocHTMLEscape(s: String) -> String {
-    let amp = strings.ReplaceAll(s, "&", "&amp;")
-    let lt = strings.ReplaceAll(amp, "<", "&lt;")
-    let gt = strings.ReplaceAll(lt, ">", "&gt;")
-    let quote = strings.ReplaceAll(gt, "\"", "&#34;")
-    strings.ReplaceAll(quote, "'", "&#39;")
+    let amp = strings.replaceAll(s, "&", "&amp;")
+    let lt = strings.replaceAll(amp, "<", "&lt;")
+    let gt = strings.replaceAll(lt, ">", "&gt;")
+    let quote = strings.replaceAll(gt, "\"", "&#34;")
+    strings.replaceAll(quote, "'", "&#39;")
 }
 
 fn selfDocHeadingTag(level: Int) -> String {
@@ -1595,7 +1595,7 @@ fn selfDocSafePackageFilename(name: String) -> String {
     if name == "" {
         return "doc"
     }
-    let units = strings.Split(name, "")
+    let units = strings.split(name, "")
     let mut out: List<String> = []
     for unit in units {
         if selfDocSafeFilenameUnit(unit) {
@@ -1604,7 +1604,7 @@ fn selfDocSafePackageFilename(name: String) -> String {
             out.push("_")
         }
     }
-    strings.Join(out, "")
+    strings.join(out, "")
 }
 
 fn selfDocSafeFilenameUnit(unit: String) -> Bool {
@@ -1627,7 +1627,7 @@ fn selfDocBaseName(path: String) -> String {
     if path == "" {
         return ""
     }
-    let parts = strings.Split(path, "/")
+    let parts = strings.split(path, "/")
     if selfDocStringListCount(parts) == 0 {
         return path
     }

--- a/toolchain/lsp.osty
+++ b/toolchain/lsp.osty
@@ -1,5 +1,5 @@
 use runtime.strings as strings {
-    fn Split(s: String, sep: String) -> List<String>
+    fn split(s: String, sep: String) -> List<String>
 }
 
 /// LspSemanticToken is the self-hosted policy shape for one LSP semantic
@@ -551,7 +551,7 @@ pub fn lspFindNameOffset(source: String, declStart: Int, declEnd: Int, name: Str
     if name == "" || declStart < 0 {
         return -1
     }
-    let units = strings.Split(source, "")
+    let units = strings.split(source, "")
     if declEnd > units.len() || declEnd <= declStart {
         return -1
     }
@@ -569,7 +569,7 @@ pub fn lspFindNameOffset(source: String, declStart: Int, declEnd: Int, name: Str
 }
 
 pub fn lspPrecedingCompletionContext(source: String, offset: Int) -> LspCompletionContext {
-    let units = strings.Split(source, "")
+    let units = strings.split(source, "")
     let mut end = offset
     if end > units.len() {
         end = units.len()
@@ -598,7 +598,7 @@ pub fn lspPrecedingCompletionContext(source: String, offset: Int) -> LspCompleti
 }
 
 pub fn lspIdentifierAt(source: String, offset: Int) -> String {
-    let units = strings.Split(source, "")
+    let units = strings.split(source, "")
     if offset < 0 || offset >= units.len() {
         return ""
     }
@@ -768,7 +768,7 @@ pub fn lspKeyWithAlias(group: Int, key: String, alias: String) -> String {
 }
 
 pub fn lspUseSourceText(source: String, start: Int, end: Int) -> String {
-    let units = strings.Split(source, "")
+    let units = strings.split(source, "")
     if start < 0 || end > units.len() || start >= end {
         return ""
     }
@@ -780,7 +780,7 @@ pub fn lspUseSourceText(source: String, start: Int, end: Int) -> String {
 }
 
 pub fn lspEndOfLineOffset(source: String, offset: Int) -> Int {
-    let units = strings.Split(source, "")
+    let units = strings.split(source, "")
     let mut off = offset
     if off < 0 {
         off = 0
@@ -801,7 +801,7 @@ pub fn lspEndOfLineOffset(source: String, offset: Int) -> Int {
 }
 
 pub fn lspHasTriviaBetweenOffsets(source: String, start: Int, end: Int) -> Bool {
-    let units = strings.Split(source, "")
+    let units = strings.split(source, "")
     if start < 0 || end > units.len() || start >= end {
         return false
     }
@@ -1131,7 +1131,7 @@ fn lspFnTypeTail(typeText: String) -> String {
     if !(lspStringHasPrefix(typeText, "fn")) {
         return ""
     }
-    let units = strings.Split(typeText, "")
+    let units = strings.split(typeText, "")
     return frontLexemeFromUnits(units, 2, units.len() - 2)
 }
 
@@ -1180,8 +1180,8 @@ fn lspStringHasPrefix(text: String, prefix: String) -> Bool {
     if prefix == "" {
         return true
     }
-    let textUnits = strings.Split(text, "")
-    let prefixUnits = strings.Split(prefix, "")
+    let textUnits = strings.split(text, "")
+    let prefixUnits = strings.split(prefix, "")
     if prefixUnits.len() > textUnits.len() {
         return false
     }

--- a/toolchain/manifest_validation.osty
+++ b/toolchain/manifest_validation.osty
@@ -1,11 +1,11 @@
 use go "strings" as strings {
-    fn Contains(s: String, substr: String) -> Bool
-    fn Fields(s: String) -> List<String>
-    fn HasPrefix(s: String, prefix: String) -> Bool
-    fn Join(elems: List<String>, sep: String) -> String
-    fn Split(s: String, sep: String) -> List<String>
-    fn SplitN(s: String, sep: String, n: Int) -> List<String>
-    fn TrimSpace(s: String) -> String
+    fn contains(s: String, substr: String) -> Bool
+    fn fields(s: String) -> List<String>
+    fn hasPrefix(s: String, prefix: String) -> Bool
+    fn join(elems: List<String>, sep: String) -> String
+    fn split(s: String, sep: String) -> List<String>
+    fn splitN(s: String, sep: String, n: Int) -> List<String>
+    fn trimSpace(s: String) -> String
 }
 
 /// ManifestPackageSpec is the self-hosted subset of a [package] table.
@@ -364,7 +364,7 @@ pub fn manifestPackageNameValid(name: String) -> Bool {
         return false
     }
     let mut index = 0
-    for unit in strings.Split(name, "") {
+    for unit in strings.split(name, "") {
         if index == 0 {
             if !(manifestPackageNameStart(unit)) {
                 return false
@@ -378,16 +378,16 @@ pub fn manifestPackageNameValid(name: String) -> Bool {
 }
 
 pub fn manifestPackageVersionValid(version: String) -> Bool {
-    if version == "" || strings.HasPrefix(version, "v") {
+    if version == "" || strings.hasPrefix(version, "v") {
         return false
     }
 
-    let plus = splitSummary(strings.SplitN(version, "+", 2))
+    let plus = splitSummary(strings.splitN(version, "+", 2))
     if plus.count == 2 && !(buildIdentifiersValid(plus.second)) {
         return false
     }
 
-    let dash = splitSummary(strings.SplitN(plus.first, "-", 2))
+    let dash = splitSummary(strings.splitN(plus.first, "-", 2))
     let mut coreValid = false
     match parseSemCore(dash.first) {
         Ok(_) -> {
@@ -411,7 +411,7 @@ pub fn manifestEditionKnown(edition: String) -> Bool {
 }
 
 pub fn manifestTargetTripleValid(triple: String) -> Bool {
-    let parts = splitSummary(strings.SplitN(triple, "-", 2))
+    let parts = splitSummary(strings.splitN(triple, "-", 2))
     parts.count == 2 && parts.first != "" && parts.second != ""
 }
 
@@ -425,14 +425,14 @@ pub fn manifestProfileExists(name: String, profiles: List<ManifestProfileSpec>) 
 }
 
 pub fn manifestVersionReqValid(req: String) -> Bool {
-    let text = strings.TrimSpace(req)
+    let text = strings.trimSpace(req)
     if text == "" {
         return false
     }
     if text == "*" {
         return true
     }
-    for part in strings.Fields(text) {
+    for part in strings.fields(text) {
         if !(manifestVersionReqPartValid(part)) {
             return false
         }
@@ -645,7 +645,7 @@ fn manifestVersionIdentifiersValid(text: String) -> Bool {
     if text == "" {
         return false
     }
-    for part in strings.Split(text, ".") {
+    for part in strings.split(text, ".") {
         if !(identifierTextValid(part)) {
             return false
         }
@@ -654,13 +654,13 @@ fn manifestVersionIdentifiersValid(text: String) -> Bool {
 }
 
 fn manifestVersionReqPartValid(part: String) -> Bool {
-    if strings.HasPrefix(part, "^") {
+    if strings.hasPrefix(part, "^") {
         return manifestPartialVersionValid(manifestTrimPrefix1(part))
     }
-    if strings.HasPrefix(part, "~") {
+    if strings.hasPrefix(part, "~") {
         return manifestPartialVersionValid(manifestTrimPrefix1(part))
     }
-    if strings.Contains(part, "*") {
+    if strings.contains(part, "*") {
         return manifestWildcardReqValid(part)
     }
     let split = manifestSplitReqOp(part)
@@ -671,7 +671,7 @@ fn manifestPartialVersionValid(version: String) -> Bool {
     if version == "" {
         return false
     }
-    let text = if strings.HasPrefix(version, "v") {
+    let text = if strings.hasPrefix(version, "v") {
         manifestTrimPrefix1(version)
     } else {
         version
@@ -680,9 +680,9 @@ fn manifestPartialVersionValid(version: String) -> Bool {
         return false
     }
 
-    let plus = splitSummary(strings.SplitN(text, "+", 2))
-    let dash = splitSummary(strings.SplitN(plus.first, "-", 2))
-    let parts = splitSummary(strings.Split(dash.first, "."))
+    let plus = splitSummary(strings.splitN(text, "+", 2))
+    let dash = splitSummary(strings.splitN(plus.first, "-", 2))
+    let parts = splitSummary(strings.split(dash.first, "."))
     if parts.count < 1 || parts.count > 3 {
         return false
     }
@@ -702,7 +702,7 @@ fn manifestWildcardReqValid(req: String) -> Bool {
     if req == "*" {
         return true
     }
-    let parts = splitSummary(strings.Split(req, "."))
+    let parts = splitSummary(strings.split(req, "."))
     if parts.count > 3 {
         return false
     }
@@ -749,19 +749,19 @@ fn manifestReqNumberValid(text: String) -> Bool {
 }
 
 fn manifestSplitReqOp(part: String) -> SemSplit {
-    if strings.HasPrefix(part, ">=") {
+    if strings.hasPrefix(part, ">=") {
         return SemSplit { count: 2, first: ">=", second: manifestTrimPrefixN(part, 2), third: "" }
     }
-    if strings.HasPrefix(part, "<=") {
+    if strings.hasPrefix(part, "<=") {
         return SemSplit { count: 2, first: "<=", second: manifestTrimPrefixN(part, 2), third: "" }
     }
-    if strings.HasPrefix(part, ">") {
+    if strings.hasPrefix(part, ">") {
         return SemSplit { count: 2, first: ">", second: manifestTrimPrefix1(part), third: "" }
     }
-    if strings.HasPrefix(part, "<") {
+    if strings.hasPrefix(part, "<") {
         return SemSplit { count: 2, first: "<", second: manifestTrimPrefix1(part), third: "" }
     }
-    if strings.HasPrefix(part, "=") {
+    if strings.hasPrefix(part, "=") {
         return SemSplit { count: 2, first: "=", second: manifestTrimPrefix1(part), third: "" }
     }
     SemSplit { count: 1, first: "", second: part, third: "" }
@@ -772,7 +772,7 @@ fn manifestTrimPrefix1(text: String) -> String {
 }
 
 fn manifestTrimPrefixN(text: String, n: Int) -> String {
-    let units = strings.Split(text, "")
+    let units = strings.split(text, "")
     let mut out: List<String> = []
     let mut i = 0
     for unit in units {
@@ -781,7 +781,7 @@ fn manifestTrimPrefixN(text: String, n: Int) -> String {
         }
         i = i + 1
     }
-    strings.Join(out, "")
+    strings.join(out, "")
 }
 
 fn manifestBuiltinProfile(name: String) -> Bool {


### PR DESCRIPTION
## Summary

Teach the bootstrapped native checker to surface a per-context / per-detail error histogram, expose it through a new `--dump-native-diags` flag on `osty check`, and fix the long-standing UseDecl alias collection bug that kept every `use go \"X\" as X { fn Y }` FFI declaration out of `env.fns`.

Running `osty check --airepair=false toolchain` before and after:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Total errors | 1674 | **935** | **−44%** |
| `frontCheckIdentHint` bucket | 802 | **68** | **−92%** |
| Non-call tail | 1042 | **250** | **−76%** |
| Call/return/assign tail | 632 | 685 | +53 (previously-blocked sites now visible) |

## What changed

### New: per-context / per-detail telemetry
- `internal/selfhost/check_telemetry.go` (new): `selfhostBumpError` + `selfhostBumpErrorWithDetail` helpers use `runtime.Caller` to bucket each native-checker error by its enclosing Go function, and optionally by a second-level detail (e.g. unresolved identifier name).
- `internal/selfhost/generated.go`: 72 inline `env.errors = func() int { … overflow-checked add … }()` blocks rewritten to `selfhostBumpError(env)`; `frontCheckIdentHint` now routes through the detail helper so unresolved-identifier misses are classified by name.
- `internal/selfhost/check_adapter.go`, `internal/check/host_boundary.go`, `internal/check/check.go`, `cmd/osty-native-checker/main.go`: plumb the maps through the Go-facing `CheckSummary`, the JSON envelope of the external native-checker binary, and `check.Result.NativeCheckerTelemetry`.
- `cmd/osty/dump_native_diags.go` (new) + `cmd/osty/main.go`: `--dump-native-diags` prints a sorted histogram (top 10 details per context) to stderr after `osty check`.

### Fix: UseDecl alias collection
- Root cause: `frontCheckCollectDecl` called `frontCheckLastPathSegment(decl.text)` to derive the alias name. For Go-FFI paths (`use go \"strings\" as strings { … }`) the parser stored the path literal with its surrounding quotes intact, so every fn registered in `env.fns` as `\"strings\".hasPrefix` while call sites looked up the unquoted `strings.hasPrefix`. 374 `frontCheckIdentHint` misses in the toolchain were alias-name miss cascades.
- Fix: new `selfhostUseDeclAlias` prefers the parser's alias ident (`children2[0]`) with a quote-stripping fallback for the last-path-segment case.

### Cleanup: PascalCase → camelCase in toolchain
- `toolchain/docgen.osty`, `toolchain/manifest_validation.osty`, `toolchain/lsp.osty`: 99 `strings.HasPrefix` / `strings.Split` / `strings.TrimSpace`-style Go-idiom call sites, and 13 matching `fn HasPrefix(...)` FFI declarations, normalized to camelCase to match both the Osty naming convention and the host-synthesised `std.strings` FFI stub.

### Debug hook
- `OSTY_NATIVE_CHECKER_SOURCE_DUMP=path` on `osty check` writes the merged source that actually reaches the native checker — useful for reproducing alias-related issues on a single file.

## How to verify

```bash
go build -o /tmp/osty ./cmd/osty
rm -f ./.osty/toolchain/osty-dev/osty-native-checker
/tmp/osty --dump-native-diags check --airepair=false toolchain 2>&1 | tail -20
```

## Test plan

- [x] `go test -short ./internal/check/` passes
- [x] `go test -short ./internal/selfhost/` passes
- [x] `go test -short ./cmd/osty-native-checker/` passes
- [x] `go test -short ./...` — LLVM test failures in `internal/llvmgen/` and `internal/backend/` are pre-existing on `main` at the same SHA (verified via `git stash -u` against HEAD); not caused by this change
- [x] Minimal repro (`use go \"strings\" as strings { fn hasPrefix ... }` + two call sites) goes from 2 errors to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)