### PR TITLE
feat(doctest): Phase 5.2 — extract Osty doctests from /// blocks (G32)

### DIFF
--- a/internal/doctest/doctest.go
+++ b/internal/doctest/doctest.go
@@ -1,0 +1,181 @@
+// Package doctest extracts runnable Osty code blocks from `///` doc
+// comments on declarations. It implements v0.5 (G32) §11 doctest
+// discovery — the feature that lets library docs double as executable
+// examples.
+//
+// Extraction is source-format driven: the extractor reads the
+// DocComment string attached to each declaration, finds fenced code
+// blocks that declare `osty` as the language, and returns one Doctest
+// per block. It does not compile or run anything.
+//
+// Example doc source:
+//
+//	/// Returns the first element.
+//	///
+//	/// ```osty
+//	/// let xs = [1, 2, 3]
+//	/// testing.assertEq(xs.first(), Some(1))
+//	/// ```
+//	pub fn first<T>(xs: List<T>) -> T?
+//
+// A single Decl may host zero, one, or multiple blocks. Fence
+// recognition:
+//
+//   - opens with three backticks followed immediately by the language
+//     tag `osty` (case-insensitive), trimmed of surrounding whitespace
+//   - a bare ``` opens a non-osty block and is ignored; non-osty
+//     blocks must still be balanced so the extractor can skip them
+//   - closes with three backticks on a line by itself (post-trim)
+//
+// v0.5 scope limits:
+//
+//   - Only `osty` language tag is treated as runnable; variants like
+//     `osty ignore` or `osty no_run` are deferred to a later pass.
+//   - Indented / tilde fence forms are unsupported; only ``` works.
+//   - Nested fences are not supported (Osty itself has no backtick
+//     string syntax, so the ambiguity does not arise in practice).
+
+package doctest
+
+import (
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+// Doctest is one extracted runnable example. Owner names the
+// declaration that hosted the block; OrdinalInOwner disambiguates
+// when a single Decl carries multiple blocks (1-based).
+type Doctest struct {
+	// Owner is the name of the hosting declaration. Fn/struct/enum/
+	// interface/type/let all work; an empty owner indicates the
+	// block came from a file-level doc (not currently extracted).
+	Owner string
+	// OrdinalInOwner counts from 1 within the same Owner so the
+	// generated test name stays stable across re-extractions.
+	OrdinalInOwner int
+	// Source is the raw Osty code between the fences, newline-
+	// delimited. Leading `/// ` prefix and any common indentation
+	// are stripped per the comment-stripping rules.
+	Source string
+}
+
+// Extract walks every annotatable declaration in file and returns
+// the Osty-language doctests it carries. Returns an empty slice for
+// a nil file or a file with no doc-hosting decls.
+//
+// Order is source order: within a file, owners come in declaration
+// order; within an owner, blocks come in the order they appear.
+func Extract(file *ast.File) []Doctest {
+	if file == nil {
+		return nil
+	}
+	var out []Doctest
+	for _, decl := range file.Decls {
+		name, doc := ownerOf(decl)
+		if doc == "" {
+			continue
+		}
+		cleaned := stripCommentPrefix(doc)
+		blocks := extractFencedOsty(cleaned)
+		for i, src := range blocks {
+			out = append(out, Doctest{
+				Owner:          name,
+				OrdinalInOwner: i + 1,
+				Source:         src,
+			})
+		}
+	}
+	return out
+}
+
+// ownerOf returns (name, docComment) for declarations that can host
+// doc comments. Returns ("", "") for kinds that don't.
+func ownerOf(d ast.Decl) (string, string) {
+	switch x := d.(type) {
+	case *ast.FnDecl:
+		return x.Name, x.DocComment
+	case *ast.StructDecl:
+		return x.Name, x.DocComment
+	case *ast.EnumDecl:
+		return x.Name, x.DocComment
+	case *ast.InterfaceDecl:
+		return x.Name, x.DocComment
+	case *ast.TypeAliasDecl:
+		return x.Name, x.DocComment
+	case *ast.LetDecl:
+		return x.Name, x.DocComment
+	}
+	return "", ""
+}
+
+// stripCommentPrefix removes the leading `///` (and optional single
+// space) from every line of a raw doc comment. Lines that consist
+// only of `///` become empty. Indentation inside the Osty code block
+// is preserved — only the comment marker is removed.
+func stripCommentPrefix(doc string) string {
+	lines := strings.Split(doc, "\n")
+	out := make([]string, len(lines))
+	for i, ln := range lines {
+		trimmed := strings.TrimLeft(ln, " \t")
+		if !strings.HasPrefix(trimmed, "///") {
+			// Already de-prefixed line (rare for parser-captured
+			// doc, but handle it idempotently).
+			out[i] = ln
+			continue
+		}
+		// Drop the `///` and exactly one following space if present.
+		body := trimmed[3:]
+		if strings.HasPrefix(body, " ") {
+			body = body[1:]
+		}
+		out[i] = body
+	}
+	return strings.Join(out, "\n")
+}
+
+// extractFencedOsty scans text for ``` fences and returns the body
+// of every block whose opening fence tags the language as `osty`.
+// Other fenced blocks are consumed but discarded.
+func extractFencedOsty(text string) []string {
+	lines := strings.Split(text, "\n")
+	var out []string
+	i := 0
+	for i < len(lines) {
+		tag, ok := openingFence(lines[i])
+		if !ok {
+			i++
+			continue
+		}
+		// Find closing fence.
+		start := i + 1
+		end := start
+		for end < len(lines) && !isClosingFence(lines[end]) {
+			end++
+		}
+		if strings.EqualFold(tag, "osty") {
+			out = append(out, strings.Join(lines[start:end], "\n"))
+		}
+		// Skip past the closing fence (or EOF).
+		i = end + 1
+	}
+	return out
+}
+
+// openingFence returns (tag, true) when line opens a fenced code
+// block; tag is the portion after the backticks, trimmed.
+func openingFence(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "```") {
+		return "", false
+	}
+	rest := strings.TrimSpace(trimmed[3:])
+	return rest, true
+}
+
+// isClosingFence reports whether line is a bare ``` (possibly with
+// surrounding whitespace). The language tag is not allowed on a
+// closing fence in CommonMark, and we match that convention.
+func isClosingFence(line string) bool {
+	return strings.TrimSpace(line) == "```"
+}

--- a/internal/doctest/doctest_test.go
+++ b/internal/doctest/doctest_test.go
@@ -1,0 +1,170 @@
+package doctest
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+func TestExtractSingleBlock(t *testing.T) {
+	src := []byte("/// Returns the first element.\n" +
+		"///\n" +
+		"/// ```osty\n" +
+		"/// let xs = [1, 2, 3]\n" +
+		"/// assertEq(xs.first(), Some(1))\n" +
+		"/// ```\n" +
+		"pub fn first<T>(xs: List<T>) -> T? { xs.first() }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	if file == nil {
+		t.Fatal("parse failed")
+	}
+	docs := Extract(file)
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doctest, got %d", len(docs))
+	}
+	got := docs[0]
+	if got.Owner != "first" {
+		t.Errorf("Owner: got %q, want first", got.Owner)
+	}
+	if got.OrdinalInOwner != 1 {
+		t.Errorf("OrdinalInOwner: got %d, want 1", got.OrdinalInOwner)
+	}
+	want := "let xs = [1, 2, 3]\nassertEq(xs.first(), Some(1))"
+	if got.Source != want {
+		t.Errorf("Source: got %q, want %q", got.Source, want)
+	}
+}
+
+func TestExtractMultipleBlocks(t *testing.T) {
+	src := []byte("/// Adds two numbers.\n" +
+		"///\n" +
+		"/// ```osty\n" +
+		"/// assertEq(add(1, 2), 3)\n" +
+		"/// ```\n" +
+		"///\n" +
+		"/// Overflow is undefined:\n" +
+		"/// ```osty\n" +
+		"/// let _ = add(1, 2)\n" +
+		"/// ```\n" +
+		"pub fn add(a: Int, b: Int) -> Int { a + b }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	docs := Extract(file)
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 doctests, got %d", len(docs))
+	}
+	if docs[0].OrdinalInOwner != 1 || docs[1].OrdinalInOwner != 2 {
+		t.Errorf("ordinals: got %d and %d, want 1 and 2",
+			docs[0].OrdinalInOwner, docs[1].OrdinalInOwner)
+	}
+	if docs[0].Owner != "add" || docs[1].Owner != "add" {
+		t.Errorf("owners: got %q and %q, want add twice", docs[0].Owner, docs[1].Owner)
+	}
+}
+
+func TestExtractIgnoresNonOstyBlocks(t *testing.T) {
+	src := []byte("/// Example output in shell form:\n" +
+		"///\n" +
+		"/// ```shell\n" +
+		"/// $ osty run\n" +
+		"/// ok\n" +
+		"/// ```\n" +
+		"///\n" +
+		"/// Runnable form:\n" +
+		"/// ```osty\n" +
+		"/// assertEq(demo(), 7)\n" +
+		"/// ```\n" +
+		"pub fn demo() -> Int { 7 }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	docs := Extract(file)
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doctest (osty only), got %d", len(docs))
+	}
+	if docs[0].Source != "assertEq(demo(), 7)" {
+		t.Errorf("unexpected source: %q", docs[0].Source)
+	}
+}
+
+func TestExtractIgnoresUntaggedFence(t *testing.T) {
+	src := []byte("/// Example:\n" +
+		"/// ```\n" +
+		"/// this is just prose in a bare fence\n" +
+		"/// ```\n" +
+		"pub fn foo() -> Int { 1 }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	docs := Extract(file)
+	if len(docs) != 0 {
+		t.Errorf("bare fence must not extract; got %d doctests", len(docs))
+	}
+}
+
+func TestExtractCoversMultipleDecls(t *testing.T) {
+	src := []byte("/// First.\n" +
+		"/// ```osty\n" +
+		"/// assertEq(a(), 1)\n" +
+		"/// ```\n" +
+		"pub fn a() -> Int { 1 }\n" +
+		"\n" +
+		"/// Second.\n" +
+		"/// ```osty\n" +
+		"/// assertEq(b(), 2)\n" +
+		"/// ```\n" +
+		"pub fn b() -> Int { 2 }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	docs := Extract(file)
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 doctests across 2 fns, got %d", len(docs))
+	}
+	owners := map[string]bool{}
+	for _, d := range docs {
+		owners[d.Owner] = true
+	}
+	if !owners["a"] || !owners["b"] {
+		t.Errorf("expected owners a and b, got %v", owners)
+	}
+}
+
+func TestExtractNoDocNoCrash(t *testing.T) {
+	src := []byte("pub fn nodoc() -> Int { 42 }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	docs := Extract(file)
+	if len(docs) != 0 {
+		t.Errorf("fn without doc yielded %d doctests", len(docs))
+	}
+}
+
+// The self-hosted parser normalises doc comments by stripping
+// the `///` prefix AND any leading whitespace on each line before
+// attaching DocComment. As a result, indentation inside a fenced
+// block is flattened during parse — code that relies on significant
+// indentation (e.g. Python-style blocks) can't be doctested.
+// Osty's block structure uses braces, so this flattening is lossy
+// for code style but preserves semantics.
+func TestExtractFlattensParserNormalizedIndent(t *testing.T) {
+	src := []byte("/// Walks a tree.\n" +
+		"/// ```osty\n" +
+		"/// for node in nodes {\n" +
+		"///     if node.active {\n" +
+		"///         process(node)\n" +
+		"///     }\n" +
+		"/// }\n" +
+		"/// ```\n" +
+		"pub fn walk(nodes: List<Int>) { }\n")
+	file, _ := parser.ParseDiagnostics(src)
+	docs := Extract(file)
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doctest, got %d", len(docs))
+	}
+	// Parser-flattened — all leading spaces dropped. Test pins the
+	// contract so a future parser change that preserves indent
+	// trips this test and we notice.
+	want := "for node in nodes {\nif node.active {\nprocess(node)\n}\n}"
+	if docs[0].Source != want {
+		t.Errorf("got:\n%s\nwant:\n%s", docs[0].Source, want)
+	}
+}
+
+func TestExtractNilFile(t *testing.T) {
+	if got := Extract(nil); got != nil {
+		t.Errorf("Extract(nil) = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

v0.5 §11 (G32) second half of inline-test work: pull runnable code examples out of `///` doc comments. Extractor-only PR — wiring to `osty test --doc` follows.

- `internal/doctest/Extract(file)` returns one `Doctest{Owner, OrdinalInOwner, Source}` per ` ```osty ``` ` fenced block.
- Owner-scoped ordinals stay stable across multiple blocks on the same decl.
- Non-`osty` fences are parsed and ignored so author narratives in ` ```shell ` or similar don't trip anything.

## Scope limits

- Only `osty` language tag counts as runnable. `osty ignore` / `osty no_run` are deferred.
- Fence syntax is ``` only (no `~~~`, no indented fences).
- Parser flattens indent inside `///` blocks before attaching `DocComment`; documented as a test-pinned contract so a future parser change is noticed.

## Test plan

- [x] `go test ./internal/doctest/...` (8 tests: single, multi, non-osty skip, bare-fence skip, multi-decl, no-doc, indent-flatten contract, nil-file)
- [x] `go build ./...`
- [x] No regression in `internal/parser` / `internal/resolve`

Runner integration (compile each extracted block + run via native test harness) is the next PR in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)