### PR TITLE
feat: Pod in prelude + privilege gate covers generic bounds — §19.4 spike

### DIFF
--- a/internal/check/pod_bound_test.go
+++ b/internal/check/pod_bound_test.go
@@ -1,0 +1,150 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+)
+
+// Pod-bound end-to-end tests. These exercise the full parser →
+// resolver → privilege + pod + noalloc pipeline for `<T: Pod>`
+// bound clauses. Before this spike, `Pod` was unknown to the
+// resolver and `E0500` fired in privileged packages too; the
+// prelude registration in this PR lets the resolver bind `Pod`
+// to a SymBuiltin so generic bound clauses typecheck cleanly
+// inside privileged packages.
+
+func TestPodBoundPrivilegedCellResolves(t *testing.T) {
+	src := `
+#[pod]
+#[repr(c)]
+pub struct Cell<T: Pod> {
+    pub v: T,
+}
+`
+	diags := runEndToEnd(t, src, true)
+	errs := errorsOnly(diags)
+	if len(errs) > 0 {
+		t.Fatalf("privileged `Cell<T: Pod>` must resolve cleanly, got:\n%s",
+			renderDiagList(errs))
+	}
+}
+
+func TestPodBoundPrivilegedMultipleParamsResolve(t *testing.T) {
+	src := `
+#[pod]
+#[repr(c)]
+pub struct Pair<A: Pod, B: Pod> {
+    pub a: A,
+    pub b: B,
+}
+`
+	diags := runEndToEnd(t, src, true)
+	errs := errorsOnly(diags)
+	if len(errs) > 0 {
+		t.Fatalf("multiple Pod-bounded generics must resolve, got:\n%s",
+			renderDiagList(errs))
+	}
+}
+
+func TestPodBoundPrivilegedFnGenericResolves(t *testing.T) {
+	// Plain `<T: Pod>` on a fn with no runtime-intrinsic calls in the
+	// body. Verifies the bound binds cleanly now that `Pod` is in the
+	// prelude. Intrinsic-call machinery (`raw.*`) is a later spike.
+	src := `
+#[no_alloc]
+pub fn identityPod<T: Pod>(v: T) -> T {
+    v
+}
+`
+	diags := runEndToEnd(t, src, true)
+	errs := errorsOnly(diags)
+	if len(errs) > 0 {
+		t.Fatalf("privileged `<T: Pod>` on a fn must resolve cleanly, got:\n%s",
+			renderDiagList(errs))
+	}
+}
+
+func TestPodBoundUnprivilegedFnRejected(t *testing.T) {
+	src := `
+pub fn takesPod<T: Pod>(value: T) -> T {
+    value
+}
+`
+	diags := runEndToEnd(t, src, false)
+	if countByCode(diags, diag.CodeRuntimePrivilegeViolation) == 0 {
+		t.Fatalf("user code with `<T: Pod>` must produce E0770, got:\n%s",
+			renderDiagList(diags))
+	}
+}
+
+func TestPodBoundUnprivilegedStructRejected(t *testing.T) {
+	src := `
+pub struct Holder<T: Pod> {
+    pub v: T,
+}
+`
+	diags := runEndToEnd(t, src, false)
+	if countByCode(diags, diag.CodeRuntimePrivilegeViolation) == 0 {
+		t.Fatalf("user struct with `<T: Pod>` must produce E0770, got:\n%s",
+			renderDiagList(diags))
+	}
+}
+
+func TestPodBoundUnprivilegedEnumRejected(t *testing.T) {
+	src := `
+pub enum Wrap<T: Pod> {
+    Empty,
+    Full(T),
+}
+`
+	diags := runEndToEnd(t, src, false)
+	if countByCode(diags, diag.CodeRuntimePrivilegeViolation) == 0 {
+		t.Fatalf("user enum with `<T: Pod>` must produce E0770, got:\n%s",
+			renderDiagList(diags))
+	}
+}
+
+func TestPodBoundUnprivilegedTypeAliasRejected(t *testing.T) {
+	src := `
+pub type PodList<T: Pod> = List<T>
+`
+	diags := runEndToEnd(t, src, false)
+	if countByCode(diags, diag.CodeRuntimePrivilegeViolation) == 0 {
+		t.Fatalf("user type alias with `<T: Pod>` must produce E0770, got:\n%s",
+			renderDiagList(diags))
+	}
+}
+
+func TestPodBoundUnprivilegedInterfaceRejected(t *testing.T) {
+	src := `
+pub interface Storage<T: Pod> {
+    fn put(self, v: T)
+}
+`
+	diags := runEndToEnd(t, src, false)
+	if countByCode(diags, diag.CodeRuntimePrivilegeViolation) == 0 {
+		t.Fatalf("user interface with `<T: Pod>` must produce E0770, got:\n%s",
+			renderDiagList(diags))
+	}
+}
+
+func TestPodBoundOrdinaryBoundsUnaffected(t *testing.T) {
+	// `<T: Ordered>` is NOT runtime-gated; user code must continue
+	// to use it freely. The privilege gate widening must not cause
+	// false positives on ordinary prelude bounds.
+	src := `
+pub fn sortable<T: Ordered>(xs: List<T>) -> List<T> {
+    xs
+}
+
+pub fn hashed<T: Hashable + Equal>(x: T) -> Int {
+    x.hash()
+}
+`
+	diags := runEndToEnd(t, src, false)
+	if countByCode(diags, diag.CodeRuntimePrivilegeViolation) > 0 {
+		t.Fatalf("ordinary Ordered/Hashable bounds must not be gated, got:\n%s",
+			renderDiagList(diags))
+	}
+}

--- a/internal/check/privilege.go
+++ b/internal/check/privilege.go
@@ -123,6 +123,7 @@ func (g *privilegeGate) walkDecl(d ast.Decl) {
 	switch n := d.(type) {
 	case *ast.FnDecl:
 		g.checkAnnotations(n.Annotations)
+		g.walkGenerics(n.Generics)
 		g.walkType(n.ReturnType)
 		for _, p := range n.Params {
 			if p != nil {
@@ -131,6 +132,7 @@ func (g *privilegeGate) walkDecl(d ast.Decl) {
 		}
 	case *ast.StructDecl:
 		g.checkAnnotations(n.Annotations)
+		g.walkGenerics(n.Generics)
 		for _, f := range n.Fields {
 			if f != nil {
 				g.checkAnnotations(f.Annotations)
@@ -144,6 +146,7 @@ func (g *privilegeGate) walkDecl(d ast.Decl) {
 		}
 	case *ast.EnumDecl:
 		g.checkAnnotations(n.Annotations)
+		g.walkGenerics(n.Generics)
 		for _, m := range n.Methods {
 			if m != nil {
 				g.walkDecl(m)
@@ -151,12 +154,31 @@ func (g *privilegeGate) walkDecl(d ast.Decl) {
 		}
 	case *ast.InterfaceDecl:
 		g.checkAnnotations(n.Annotations)
+		g.walkGenerics(n.Generics)
 	case *ast.TypeAliasDecl:
 		g.checkAnnotations(n.Annotations)
+		g.walkGenerics(n.Generics)
 		g.walkType(n.Target)
 	case *ast.LetDecl:
 		g.checkAnnotations(n.Annotations)
 		g.walkType(n.Type)
+	}
+}
+
+// walkGenerics inspects each generic parameter's constraint list for
+// references to runtime-only names. A constraint like `<T: Pod>` or
+// `<T: Ordered + RawPtr>` appears as a Type in the parameter's
+// Constraints slice and is walked identically to a regular type
+// position — so the privilege gate catches runtime-only types used in
+// bound clauses too.
+func (g *privilegeGate) walkGenerics(gps []*ast.GenericParam) {
+	for _, gp := range gps {
+		if gp == nil {
+			continue
+		}
+		for _, c := range gp.Constraints {
+			g.walkType(c)
+		}
 	}
 }
 

--- a/internal/check/privilege_test.go
+++ b/internal/check/privilege_test.go
@@ -124,13 +124,10 @@ pub fn takesPod<T: Pod>(value: T) -> T {
     value
 }
 `
-	// The `Pod` appears in the generic bound position; the spike
-	// walker only inspects parameter/return/field *types*, not bound
-	// clauses. So the current implementation produces 0 here. This is
-	// deliberate: bound clauses go through the resolver, which is the
-	// right place to reject runtime-only constraint names. Document
-	// the known gap.
-	assertPrivilegeCount(t, src, false, 0)
+	// `Pod` appears in the generic bound position. The privilege gate
+	// now walks generic constraint lists too (closing the spike-#292
+	// M1 gap), so the unprivileged use is rejected with `E0770`.
+	assertPrivilegeCount(t, src, false, 1)
 }
 
 func TestPrivilegeRejectsRawPtrInReturnType(t *testing.T) {

--- a/internal/resolve/prelude.go
+++ b/internal/resolve/prelude.go
@@ -62,6 +62,15 @@ var preludeNames = []struct {
 	{"Ordered", SymBuiltin},
 	{"Hashable", SymBuiltin},
 
+	// Runtime-only marker interface (LANG_SPEC §19.4). Resolved as a
+	// built-in symbol so generic bound clauses `<T: Pod>` inside
+	// privileged packages typecheck; the privilege gate in
+	// `internal/check/privilege.go` (`E0770`) rejects references from
+	// ordinary user packages. `Pod` has no methods — it is a
+	// compile-time marker whose membership is decided structurally by
+	// the checker (§19.4 derivation rules), not by user `impl`.
+	{"Pod", SymBuiltin},
+
 	// Bool literals (treated as values via prelude — the parser already
 	// emits them as BoolLit, but `true`/`false` may also appear in
 	// patterns where the resolver sees them as Idents).


### PR DESCRIPTION
## Summary

Sixth spike on the GC self-hosting path. Closes the M1 gap from [#292](https://github.com/choiceoh/osty/pull/292)'s privilege gate: the resolver now binds `Pod` in generic bound clauses (so `<T: Pod>` resolves cleanly in privileged packages), and the privilege gate walks `GenericParam.Constraints` so `<T: Pod>` in *user* code is rejected with `E0770`.

## Background

Prior to this PR, a privileged struct like

```osty
#[pod] #[repr(c)] struct Cell<T: Pod> { v: T }
```

emitted `E0500: undefined type 'Pod'` at resolve time, because `Pod` was only a string pattern in the privilege gate and the pod shape checker — not a real prelude symbol. That made the §19.4 "unconditional Pod generic" rule effectively unreachable.

[#292](https://github.com/choiceoh/osty/pull/292)'s `TestPrivilegeRejectsPodTypeReference` documented the gap. This PR closes both halves simultaneously: **resolver binding + gate coverage**.

## What this PR adds

| Change | File |
|---|---|
| `"Pod"` added to `preludeNames` as `SymBuiltin` | `internal/resolve/prelude.go` |
| `privilegeGate.walkGenerics` — walks constraint lists through `walkType` | `internal/check/privilege.go` |
| Flip `TestPrivilegeRejectsPodTypeReference` from "gap documented" to "gap fixed" | `internal/check/privilege_test.go` |
| 9 end-to-end tests | `internal/check/pod_bound_test.go` (new) |

## Test evidence

```
$ go test ./internal/check/ -run "TestPodBound|TestPrivilege|TestRawPtr|TestEndToEnd"
ok (all pass)

$ go test -short ./internal/types/ ./internal/check/ ./internal/resolve/ \
    ./internal/parser/ ./internal/stdlib/ ./internal/cst/
all green
```

9 tests:
- **positives** (privileged): `Cell<T: Pod>`, `Pair<A: Pod, B: Pod>`, `identityPod<T: Pod>(v: T)`
- **rejections** (user): fn / struct / enum / type alias / interface all with `<T: Pod>` produce `E0770`
- **negative sanity**: ordinary `<T: Ordered>` / `<T: Hashable>` unaffected — no false positives

## Deliberately out of scope

- **`Pod` as a first-class interface with methods** — `Pod` is a compile-time marker per §19.4; no methods needed.
- **`std.runtime.raw.*` intrinsic resolution** — deferred to the stdlib-nesting spike.
- **LLVM lowering** for Pod-constrained generics — same as for any other monomorphized generic.

## Spec references

- LANG_SPEC §19.4 (Pod marker trait, derivation rules)
- LANG_SPEC §19.3 (runtime-only names; gated use)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/check/...` green
- [ ] `go test -short ./...` — no new failures
- [ ] Privileged `<T: Pod>` on fn / struct / enum / interface / type alias resolves cleanly
- [ ] User code with `<T: Pod>` produces `E0770`
- [ ] Ordinary `<T: Ordered>` / `<T: Hashable>` unaffected

**Note on pre-existing test failure.** `selfhost.TestParseSnapshot/testdata_spec_positive_08-concurrency` fails on current main too (verified by stashing this PR's changes). Unrelated to this spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)