### PR TITLE
feat(resolve): runtime annotation argument validators — §19.6 spike

### DIFF
--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -507,15 +507,124 @@ func (r *resolver) checkAnnotations(annots []*ast.Annotation, target ast.Annotat
 }
 
 // checkAnnotationArgs validates each `#[name(arg = value)]` argument
-// against the fixed signature for that annotation (§3.8). Unknown keys
-// and wrong-typed values are both reported here.
+// against the fixed signature for that annotation (§3.8 / §19.6).
+// Unknown keys and wrong-typed values are both reported here.
 func (r *resolver) checkAnnotationArgs(a *ast.Annotation, target ast.AnnotationTarget) {
 	switch a.Name {
 	case "json":
 		r.checkJSONArgs(a, target)
 	case "deprecated":
 		r.checkDeprecatedArgs(a)
+	case "repr":
+		r.checkReprArgs(a)
+	case "export":
+		r.checkExportArgs(a)
+	case "intrinsic", "pod", "c_abi", "no_alloc":
+		r.checkNoArgsRuntime(a)
 	}
+}
+
+// checkReprArgs validates `#[repr(c)]` per LANG_SPEC §19.6: exactly
+// one bare-flag argument whose key is `c`. The v0.4 spec allocates
+// only the `c` form; future repr modes (e.g. `packed`) would extend
+// this set but are not part of v0.5.
+func (r *resolver) checkReprArgs(a *ast.Annotation) {
+	if len(a.Args) == 0 {
+		r.emit(diag.New(diag.Error,
+			"`#[repr]` requires a layout argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(a.PosV, "missing argument `(c)`").
+			Note("LANG_SPEC §19.6: the only accepted form is `#[repr(c)]`").
+			Build())
+		return
+	}
+	if len(a.Args) > 1 {
+		r.emit(diag.New(diag.Error,
+			"`#[repr]` accepts exactly one argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(a.Args[1].PosV, "extra argument").
+			Build())
+	}
+	arg := a.Args[0]
+	if !isFlagOrTrue(arg) {
+		r.emit(diag.New(diag.Error,
+			"`#[repr]` takes a bare-flag argument, not a value").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(arg.PosV, "expected `c`").
+			Build())
+		return
+	}
+	if arg.Key != "c" {
+		r.emit(diag.New(diag.Error,
+			fmt.Sprintf("`#[repr(%s)]` is not a recognized layout", arg.Key)).
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(arg.PosV, "only `#[repr(c)]` is accepted").
+			Note("LANG_SPEC §19.6: v0.5 recognizes only the `c` layout").
+			Build())
+	}
+}
+
+// checkExportArgs validates `#[export("symbol")]` per LANG_SPEC §19.6:
+// exactly one positional string-literal argument naming the emitted
+// symbol. The argument has no key — the annotation-argument parser
+// stores the string literal as `Key="" Value=StringLit`.
+func (r *resolver) checkExportArgs(a *ast.Annotation) {
+	if len(a.Args) == 0 {
+		r.emit(diag.New(diag.Error,
+			"`#[export]` requires a symbol-name argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(a.PosV, "missing string literal, e.g. `(\"osty.gc.alloc_v1\")`").
+			Note("LANG_SPEC §19.6: `#[export(\"name\")]` takes one string literal").
+			Build())
+		return
+	}
+	if len(a.Args) > 1 {
+		r.emit(diag.New(diag.Error,
+			"`#[export]` accepts exactly one argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(a.Args[1].PosV, "extra argument").
+			Build())
+	}
+	arg := a.Args[0]
+	if arg.Key != "" {
+		r.emit(diag.New(diag.Error,
+			"`#[export]` takes a positional string literal, not a key-value argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(arg.PosV, fmt.Sprintf("remove `%s =`", arg.Key)).
+			Build())
+		return
+	}
+	name, ok := stringArg(arg.Value)
+	if !ok {
+		r.emit(diag.New(diag.Error,
+			"`#[export]` requires a string literal argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(arg.PosV, "expected string literal").
+			Build())
+		return
+	}
+	if name == "" {
+		r.emit(diag.New(diag.Error,
+			"`#[export]` symbol name must be non-empty").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(arg.PosV, "empty symbol name").
+			Build())
+	}
+}
+
+// checkNoArgsRuntime validates the runtime annotations that take no
+// arguments: `#[intrinsic]`, `#[pod]`, `#[c_abi]`, `#[no_alloc]`.
+// Any argument is rejected.
+func (r *resolver) checkNoArgsRuntime(a *ast.Annotation) {
+	if len(a.Args) == 0 {
+		return
+	}
+	r.emit(diag.New(diag.Error,
+		fmt.Sprintf("`#[%s]` does not take arguments", a.Name)).
+		Code(diag.CodeAnnotationBadArg).
+		PrimaryPos(a.Args[0].PosV, "unexpected argument").
+		Note("LANG_SPEC §19.6: this annotation is a bare flag").
+		Build())
 }
 
 // checkJSONArgs validates #[json(...)] argument shapes per §3.8.1:

--- a/internal/resolve/runtime_annot_test.go
+++ b/internal/resolve/runtime_annot_test.go
@@ -1,0 +1,264 @@
+package resolve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+)
+
+// runAnnotArgs parses + resolves the given source and returns every
+// annotation-related diagnostic. Used by the arg-validator tests to
+// assert the exact E0739 shape of the runtime annotation arg rules
+// added in this spike.
+func runAnnotArgs(t *testing.T, src string) []*diag.Diagnostic {
+	t.Helper()
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	res := File(file, NewPrelude())
+	return res.Diags
+}
+
+func countArgBad(ds []*diag.Diagnostic) int {
+	n := 0
+	for _, d := range ds {
+		if d != nil && d.Code == diag.CodeAnnotationBadArg {
+			n++
+		}
+	}
+	return n
+}
+
+func renderDiags(ds []*diag.Diagnostic) string {
+	var b strings.Builder
+	for _, d := range ds {
+		if d == nil {
+			continue
+		}
+		b.WriteString("  ")
+		b.WriteString(d.Code)
+		b.WriteString(": ")
+		b.WriteString(d.Message)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// --- #[repr] ---
+
+func TestReprAcceptsC(t *testing.T) {
+	src := `
+#[repr(c)]
+pub struct S {
+    pub x: Int,
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739, got %d:\n%s", got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestReprRejectsMissingArg(t *testing.T) {
+	src := `
+#[repr]
+pub struct S {
+    pub x: Int,
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 (missing arg), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestReprRejectsUnknownLayout(t *testing.T) {
+	src := `
+#[repr(foo)]
+pub struct S {
+    pub x: Int,
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 (unknown layout), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestReprRejectsPacked(t *testing.T) {
+	// `packed` is a common C layout request but v0.5 accepts only `c`.
+	src := `
+#[repr(packed)]
+pub struct S {
+    pub x: Int,
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 (packed not accepted), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestReprRejectsExtraArg(t *testing.T) {
+	src := `
+#[repr(c, packed)]
+pub struct S {
+    pub x: Int,
+}
+`
+	got := countArgBad(runAnnotArgs(t, src))
+	if got < 1 {
+		t.Fatalf("expected at least 1 E0739 (extra arg), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// --- #[export] ---
+
+func TestExportAcceptsStringLiteral(t *testing.T) {
+	src := `
+#[export("osty.gc.alloc_v1")]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestExportRejectsMissingArg(t *testing.T) {
+	src := `
+#[export]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 (missing arg), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestExportRejectsEmptyStringName(t *testing.T) {
+	src := `
+#[export("")]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 (empty name), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestExportRejectsKeyValue(t *testing.T) {
+	src := `
+#[export(name = "foo")]
+pub fn f() -> Int {
+    0
+}
+`
+	got := countArgBad(runAnnotArgs(t, src))
+	if got < 1 {
+		t.Fatalf("expected at least 1 E0739 (key=value form), got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// --- no-arg annotations ---
+
+func TestIntrinsicAcceptsBare(t *testing.T) {
+	src := `
+#[intrinsic]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestIntrinsicRejectsArgs(t *testing.T) {
+	src := `
+#[intrinsic(foo)]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestPodRejectsArgs(t *testing.T) {
+	src := `
+#[pod(tight)]
+#[repr(c)]
+pub struct S {
+    pub x: Int,
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestCAbiRejectsArgs(t *testing.T) {
+	src := `
+#[c_abi(fast)]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestNoAllocRejectsArgs(t *testing.T) {
+	src := `
+#[no_alloc(strict)]
+pub fn f() -> Int {
+    0
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// --- combined: full canonical runtime annotation stack ---
+
+func TestCanonicalRuntimeStackValidates(t *testing.T) {
+	// The canonical stacking from LANG_SPEC §19.6 — all args well-formed.
+	src := `
+#[export("osty.gc.alloc_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn alloc_v1(bytes: Int, kind: Int) -> Int {
+    0
+}
+
+#[pod]
+#[repr(c)]
+pub struct Header {
+    pub next: Int,
+    pub size: Int32,
+}
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("canonical stack must produce 0 E0739, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}


### PR DESCRIPTION
## Summary

Seventh spike on the GC self-hosting path. The six runtime annotations were registered in `ast.annotationRules` but had no arg-shape validation, so malformed uses silently passed resolve.

## The silent acceptance surface this PR closes

```osty
#[repr(foo)]      // should reject: only `c` is valid
#[repr]           // should reject: missing required arg
#[export]         // should reject: missing symbol name
#[export("")]     // should reject: empty symbol name
#[no_alloc(x)]    // should reject: no args allowed
```

All of these passed silently before this PR. After: `E0739` (`CodeAnnotationBadArg`) on each.

## What this PR adds

| Validator | Rule |
|---|---|
| `checkReprArgs` | Exactly one bare-flag arg, must be `c`. v0.5 rejects `packed`/other layouts. |
| `checkExportArgs` | Exactly one positional string literal, non-empty. Rejects missing / empty / key-value / non-string. |
| `checkNoArgsRuntime` | Shared for `#[intrinsic]`, `#[pod]`, `#[c_abi]`, `#[no_alloc]`. Any arg rejected. |

Dispatch from `checkAnnotationArgs` extended to cover all six runtime annotation names. No new diag codes — reuses `E0739` (the same code `#[json]` and `#[deprecated]` validators use).

## Test evidence

15 cases in `internal/resolve/runtime_annot_test.go`:

- **`#[repr]`** (5): accepts `c`, rejects missing / unknown (`foo`) / `packed` / extra args
- **`#[export]`** (4): accepts well-formed string, rejects missing / empty-string / key-value
- **No-arg** (5): each of intrinsic / pod / c_abi / no_alloc accepts bare, rejects any arg
- **Canonical stack** (1): §19.6 example — `#[export("osty.gc.alloc_v1")] #[c_abi] #[no_alloc] pub fn alloc_v1(...)` + `#[pod] #[repr(c)] pub struct Header` — validates cleanly

```
$ go test ./internal/resolve/ -run "TestRepr|TestExport|TestIntrinsic|TestPod|TestCAbi|TestNoAlloc|TestCanonical"
ok (15/15 pass)

$ go test -short ./internal/resolve/ ./internal/check/ ./internal/parser/ \
    ./internal/types/ ./internal/stdlib/ ./internal/cst/
all green
```

## Methodology note

Before writing validators, a throwaway probe test confirmed the parser's `AnnotationArg` shape for each form:
- `#[export("foo")]` → `{Key="", Value=StringLit("foo")}`
- `#[repr(c)]` → `{Key="c", Value=nil}`

Validators are written against these confirmed shapes.

## Deliberately out of scope

- **`#[repr(packed)]` / `#[repr(transparent)]`** — would require an edition proposal under the v0.5 freeze policy. Not added.
- **Multi-arg forms** — no §19 use case needs them; stacking is the canonical pattern.

## Spec references

- LANG_SPEC §19.6 (runtime annotation table and argument shapes)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/resolve/...` green
- [ ] `go test -short ./...` — no new failures
- [ ] Canonical `#[export("name")] #[c_abi] #[no_alloc]` stack validates
- [ ] `#[repr(foo)]`, `#[repr]`, `#[export]`, `#[export("")]`, `#[no_alloc(x)]` all reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)