### PR TITLE
feat(check): finer telemetry for frontCheckBinary error sites

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -28024,7 +28024,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11129:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("eq: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11130:9
 		return "Invalid"
 	}
@@ -28036,7 +28036,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11136:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("ord: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11137:9
 		return "Invalid"
 	}
@@ -28048,7 +28048,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11143:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("logical: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11144:9
 		return "Invalid"
 	}
@@ -28057,7 +28057,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11147:9
 		if frontCheckTypeHead(left) != "Option" {
 			// Osty: /tmp/selfhost_merged.osty:11148:16
-			selfhostBumpError(env)
+			selfhostBumpErrorWithDetail(env, fmt.Sprintf("?? lhs: %s", left))
 			// Osty: /tmp/selfhost_merged.osty:11149:13
 			return "Invalid"
 		}
@@ -28082,7 +28082,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return left
 		}
 		// Osty: /tmp/selfhost_merged.osty:11162:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("bit: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11163:9
 		return "Invalid"
 	}
@@ -28091,7 +28091,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11166:9
 		if !(frontCheckIsNumeric(left)) || !(frontCheckIsNumeric(right)) {
 			// Osty: /tmp/selfhost_merged.osty:11167:16
-			selfhostBumpError(env)
+			selfhostBumpErrorWithDetail(env, fmt.Sprintf("arith: %s, %s", left, right))
 			// Osty: /tmp/selfhost_merged.osty:11168:13
 			return "Invalid"
 		}


### PR DESCRIPTION
## Summary

Stacked on top of [#311](https://github.com/choiceoh/osty/pull/311). Routes each of the six bump sites inside `frontCheckBinary` (eq/ord/logical/\`??\`/bit/arith) through `selfhostBumpErrorWithDetail` so `--dump-native-diags` splits the 37-entry tail by operator + operand-type pair.

## What the detail breakdown reveals

Running `osty check --airepair=false toolchain` from the 145-error baseline (after #311's alias-equality fix):

```
37  frontCheckBinary
         9  eq:      Char, String
         8  arith:   String, String     ← spec §18.107 forbids + on String
         8  arith:   Invalid, String
         4  arith:   (), UntypedInt
         3  logical: Bool, Invalid
         3  logical: Invalid, Invalid
         1  arith:   List<Int>, UntypedInt
         1  ord:     Invalid, UntypedInt
```

Two cohorts that stand out:

- **8 × `arith: String, String`** — real spec violations in `toolchain/pkg_policy.osty`, `toolchain/runner.osty`, `toolchain/profile_flags.osty`, `toolchain/test_runner.osty`. All use \`\"...\" + var + \"...\"\` where the spec (LANG_SPEC_v0.4/18-change-history.md:107: \`String concatenation: concat method only — no + operator.\`) permits only string interpolation or \`.concat()\`. Left as-is in this change; a follow-up spec-alignment pass will rewrite them.

- **9 × `eq: Char, String`** — suspicious. Needs a look at the call sites to decide whether the toolchain is erroneously comparing a single-char string literal against a `Char` primitive, or whether the checker's assignability rule for `Char`/`String` is too strict.

The remaining entries (Invalid, ()) are cascades from upstream errors.

## Scope

Telemetry only. Zero change in aggregate error count. No new bump sites, no new OK paths — each existing bump now just carries a detail key.

## Test plan

- [x] `go test -short ./internal/check/` passes
- [x] `go test -short ./internal/selfhost/` passes
- [x] `go test -short ./cmd/osty-native-checker/` passes
- [x] Manual: `osty --dump-native-diags check --airepair=false toolchain` shows the new detail lines under `frontCheckBinary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)