### PR TITLE
feat(stdlib): std.runtime.raw module + nested stub paths — §19.5 spike

### DIFF
--- a/internal/stdlib/modules/runtime/raw.osty
+++ b/internal/stdlib/modules/runtime/raw.osty
@@ -1,0 +1,55 @@
+// std.runtime.raw — raw memory primitives for the runtime sublanguage.
+//
+// This package is part of the LANG_SPEC §19 runtime sublanguage and is
+// only usable from privileged packages (§19.2). User code that
+// attempts to `use std.runtime.raw` is rejected by the privilege gate
+// in `internal/check/privilege.go` with `E0770`.
+//
+// Every function here is `#[intrinsic]`: the body shown is a
+// placeholder for stub-resolution purposes only. The LLVM lowering
+// layer (§19.7) replaces each call with the table-specified IR
+// sequence at emit time. Intrinsics never appear as real symbols in
+// the output object file.
+//
+// For user-facing opaque semantics see §19.3 (RawPtr type) and §19.4
+// (Pod marker). Every generic intrinsic is constrained to `T: Pod`;
+// instantiation at a non-Pod type is `E0727` at the call site.
+
+#[intrinsic]
+pub fn null() -> RawPtr
+
+#[intrinsic]
+pub fn fromBits(n: Int) -> RawPtr
+
+#[intrinsic]
+pub fn bits(p: RawPtr) -> Int
+
+#[intrinsic]
+pub fn alloc(bytes: Int, align: Int) -> RawPtr
+
+#[intrinsic]
+pub fn free(p: RawPtr)
+
+#[intrinsic]
+pub fn zero(p: RawPtr, bytes: Int)
+
+#[intrinsic]
+pub fn copy(dst: RawPtr, src: RawPtr, bytes: Int)
+
+#[intrinsic]
+pub fn offset(p: RawPtr, bytes: Int) -> RawPtr
+
+#[intrinsic]
+pub fn read<T: Pod>(p: RawPtr) -> T
+
+#[intrinsic]
+pub fn write<T: Pod>(p: RawPtr, v: T)
+
+#[intrinsic]
+pub fn cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
+
+#[intrinsic]
+pub fn sizeOf<T: Pod>() -> Int
+
+#[intrinsic]
+pub fn alignOf<T: Pod>() -> Int

--- a/internal/stdlib/runtime_raw_e2e_test.go
+++ b/internal/stdlib/runtime_raw_e2e_test.go
@@ -1,0 +1,74 @@
+package stdlib
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// TestRuntimeRawImportResolves end-to-end: a fixture file that
+// imports `std.runtime.raw` and references every intrinsic resolves
+// cleanly through parser + resolver + stdlib registry.
+//
+// This is the first test proving the full import path of the runtime
+// sublanguage actually works — previous spikes only verified
+// individual pieces (annotations, types, pod shape, bound clauses).
+func TestRuntimeRawImportResolves(t *testing.T) {
+	src := `
+use std.runtime.raw
+
+pub fn demo() -> Int {
+    let p = raw.alloc(64, 8)
+    raw.write::<Int>(p, 42)
+    let v = raw.read::<Int>(p)
+    raw.free(p)
+    v
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+
+	// The resolver binds `raw.alloc`, `raw.write`, `raw.read`, `raw.free`
+	// against the imported package. `Pod` in the turbofish bound is also
+	// bound via the prelude (spike #314).
+	for _, d := range res.Diags {
+		if d == nil || d.Severity != diag.Error {
+			continue
+		}
+		// Allow E0500 "undefined name `abort`" only if it creeps in from
+		// stdlib noise unrelated to runtime.raw — but our fixture does
+		// not reference abort, so surface everything.
+		t.Errorf("resolver rejected runtime.raw fixture: %s: %s",
+			d.Code, d.Message)
+	}
+}
+
+// TestRuntimeRawNoClashWithOrdinaryNames checks that adding
+// `std.runtime.raw` did not shadow anything in user scope. A user
+// writing a local `raw` identifier in an ordinary file must continue
+// to resolve that identifier locally, not against the stdlib module.
+func TestRuntimeRawNoClashWithOrdinaryNames(t *testing.T) {
+	src := `
+pub fn takesLocal(raw: Int) -> Int {
+    raw + 1
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	reg := Load()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	for _, d := range res.Diags {
+		if d == nil || d.Severity != diag.Error {
+			continue
+		}
+		t.Errorf("ordinary code broke: %s: %s", d.Code, d.Message)
+	}
+}

--- a/internal/stdlib/runtime_raw_test.go
+++ b/internal/stdlib/runtime_raw_test.go
@@ -1,0 +1,97 @@
+package stdlib
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+// TestRuntimeRawModuleLoads verifies the nested `modules/runtime/raw.osty`
+// stub is embedded and loaded as `std.runtime.raw`. Exercises the
+// moduleName extension that converts nested paths to dotted logical
+// names.
+func TestRuntimeRawModuleLoads(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["runtime.raw"]
+	if mod == nil {
+		t.Fatalf("std.runtime.raw module not registered; Modules=%v",
+			moduleKeys(reg))
+	}
+	if mod.Package == nil {
+		t.Fatalf("std.runtime.raw has no resolved Package")
+	}
+}
+
+// TestRuntimeRawLookupPackage exercises the StdlibProvider-facing
+// lookup for nested paths. The resolver consults this when a user
+// writes `use std.runtime.raw`.
+func TestRuntimeRawLookupPackage(t *testing.T) {
+	reg := Load()
+	pkg := reg.LookupPackage("std.runtime.raw")
+	if pkg == nil {
+		t.Fatalf("LookupPackage(\"std.runtime.raw\") returned nil")
+	}
+}
+
+// TestRuntimeRawIntrinsicsExposed checks every §19.5 intrinsic is
+// present as a top-level symbol in the module's package scope.
+func TestRuntimeRawIntrinsicsExposed(t *testing.T) {
+	reg := Load()
+	mod := reg.Modules["runtime.raw"]
+	if mod == nil || mod.Package == nil {
+		t.Fatalf("std.runtime.raw not loaded")
+	}
+	intrinsics := []string{
+		"null",
+		"fromBits",
+		"bits",
+		"alloc",
+		"free",
+		"zero",
+		"copy",
+		"offset",
+		"read",
+		"write",
+		"cas",
+		"sizeOf",
+		"alignOf",
+	}
+	for _, name := range intrinsics {
+		sym := mod.Package.PkgScope.LookupLocal(name)
+		if sym == nil {
+			t.Errorf("std.runtime.raw missing intrinsic `%s`", name)
+			continue
+		}
+		if sym.Kind != resolve.SymFn {
+			t.Errorf("std.runtime.raw.%s kind = %s, want fn", name, sym.Kind)
+		}
+		if !sym.Pub {
+			t.Errorf("std.runtime.raw.%s is not pub", name)
+		}
+	}
+}
+
+// TestFlatModulesStillWork pins that the moduleName change did not
+// break existing flat stubs.
+func TestFlatModulesStillWork(t *testing.T) {
+	reg := Load()
+	// A representative flat module that was previously keyed by
+	// basename — must still be reachable.
+	for _, name := range []string{"fs", "cmp", "io", "error"} {
+		if reg.Modules[name] == nil {
+			t.Errorf("flat module `%s` no longer registered after moduleName change", name)
+		}
+	}
+	// LookupPackage for a flat module must also still work.
+	if reg.LookupPackage("std.fs") == nil {
+		t.Errorf("LookupPackage(\"std.fs\") regressed")
+	}
+}
+
+func moduleKeys(r *Registry) []string {
+	out := make([]string, 0, len(r.Modules))
+	for k := range r.Modules {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -406,7 +406,23 @@ func collectStubPaths() []string {
 }
 
 // moduleName derives a module's logical name from its stub path.
-// "modules/io.osty" -> "io"; "primitives/int.osty" -> "int".
+//
+//	modules/io.osty             -> "io"             (std.io)
+//	modules/runtime/raw.osty    -> "runtime.raw"    (std.runtime.raw)
+//	primitives/int.osty         -> "int"
+//
+// The prefix (`modules/` or `primitives/`) is stripped; the remaining
+// relative path is dot-joined so nested packages produce dotted logical
+// names matching their `std.*` import path.
 func moduleName(p string) string {
+	clean := strings.TrimSuffix(p, stubExt)
+	if rel, ok := strings.CutPrefix(clean, "modules/"); ok {
+		return strings.ReplaceAll(rel, "/", ".")
+	}
+	if rel, ok := strings.CutPrefix(clean, "primitives/"); ok {
+		return strings.ReplaceAll(rel, "/", ".")
+	}
+	// Fallback for unexpected layouts — treat as a flat basename so
+	// callers never observe a broken module key.
 	return strings.TrimSuffix(path.Base(p), stubExt)
 }


### PR DESCRIPTION
## Summary

Eighth spike on the GC self-hosting path. Introduces the 13 §19.5 intrinsic signatures as an embedded stdlib stub and extends the registry loader to support nested stub directories.

**End-to-end proof.** Every previous spike validated individual pieces (annotations, types, pod shape, bound clauses). This one proves a privileged caller can actually write:

```osty
use std.runtime.raw

pub fn demo() -> Int {
    let p = raw.alloc(64, 8)
    raw.write::<Int>(p, 42)
    let v = raw.read::<Int>(p)
    raw.free(p)
    v
}
```

and have every name resolve cleanly through parser + resolver + stdlib registry. No manual hooks, no string matching.

## What this PR adds

| Change | File |
|---|---|
| 13 intrinsic stubs (`#[intrinsic]` body-less) | `internal/stdlib/modules/runtime/raw.osty` (new) |
| `moduleName` extended for nested paths | `internal/stdlib/stdlib.go` |
| 4 registry tests | `internal/stdlib/runtime_raw_test.go` (new) |
| 2 end-to-end tests | `internal/stdlib/runtime_raw_e2e_test.go` (new) |

### `moduleName` behavior

| Stub path | Logical name |
|---|---|
| `modules/io.osty` | `io` (unchanged) |
| `modules/fs.osty` | `fs` (unchanged) |
| `modules/runtime/raw.osty` | `runtime.raw` (new) |
| `primitives/int.osty` | `int` (unchanged) |

`LookupPackage("std.runtime.raw")` returns the nested package without any lookup-side changes — the existing `Modules[name]` indexing handles dotted keys for free once `moduleName` produces them.

## The 13 intrinsics

```osty
#[intrinsic] pub fn null() -> RawPtr
#[intrinsic] pub fn fromBits(n: Int) -> RawPtr
#[intrinsic] pub fn bits(p: RawPtr) -> Int
#[intrinsic] pub fn alloc(bytes: Int, align: Int) -> RawPtr
#[intrinsic] pub fn free(p: RawPtr)
#[intrinsic] pub fn zero(p: RawPtr, bytes: Int)
#[intrinsic] pub fn copy(dst: RawPtr, src: RawPtr, bytes: Int)
#[intrinsic] pub fn offset(p: RawPtr, bytes: Int) -> RawPtr
#[intrinsic] pub fn read<T: Pod>(p: RawPtr) -> T
#[intrinsic] pub fn write<T: Pod>(p: RawPtr, v: T)
#[intrinsic] pub fn cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
#[intrinsic] pub fn sizeOf<T: Pod>() -> Int
#[intrinsic] pub fn alignOf<T: Pod>() -> Int
```

Uses `RawPtr` (from [#312](https://github.com/choiceoh/osty/pull/312)) and `Pod` (from [#314](https://github.com/choiceoh/osty/pull/314)) — both in the prelude.

## Test evidence

```
$ go test ./internal/stdlib/ -run "TestRuntime|TestFlat"
ok (6/6 pass)

$ go test -short ./internal/stdlib/ ./internal/resolve/ ./internal/check/ \
    ./internal/parser/ ./internal/types/ ./internal/cst/
all green
```

6 tests:
- registry load
- `LookupPackage("std.runtime.raw")`
- every intrinsic exposed as `SymFn`
- flat modules (`io`, `fs`, `cmp`, `error`) still work
- full import + 4 intrinsic calls + turbofish bound resolves cleanly
- ordinary user code with a local `raw` identifier not shadowed

## Deliberately out of scope

- **Intrinsic lowering** — `raw.null()` → `inttoptr i64 0 to i8*` etc. Each intrinsic has a body-less stub the resolver is happy with; the LLVM backend does not yet replace them with §19.7 IR sequences.
- **Privilege gate coverage** — the gate already rejects `use std.runtime.*` from user code (#292). Privileged code now finds a real module behind the import instead of an empty namespace.

## Spec references

- LANG_SPEC §19.5 (intrinsic surface)
- LANG_SPEC §19.2 (privilege gate governs who may import)
- LANG_SPEC §19.4 (Pod bound on generic intrinsics)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/stdlib/...` green
- [ ] `go test -short ./...` — no new failures
- [ ] `std.runtime.raw` reachable via `LookupPackage` + direct registry access
- [ ] Flat modules (`io`, `fs`, `cmp`) unaffected by the `moduleName` change
- [ ] End-to-end: `use std.runtime.raw; raw.alloc/write/read/free` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)