### PR TITLE
feat(backend): foundation for bodied stdlib fn lowering

### DIFF
--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -669,6 +669,14 @@ pub fn llvmUnsupportedDiagnostic(kind: String, detail: String) -> LlvmUnsupporte
             "use non-generic functions with identifier parameters and Int/Bool types",
         )
     }
+    if kind == "stdlib-body" {
+        return llvmUnsupportedDiagnosticWith(
+            "LLVM018",
+            kind,
+            detail,
+            "call stdlib functions whose bodies the LLVM backend can currently lower, or add a runtime shim for this symbol",
+        )
+    }
 
     let mut reason = detail
     if reason == "" {

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -1,0 +1,60 @@
+package backend
+
+import (
+	"sort"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// ReachableStdlibFn pairs a stdlib function AST with the module it came
+// from, so a downstream caller can route lowering through the module's
+// own resolve.Package without reconstructing the mapping.
+type ReachableStdlibFn struct {
+	// Module is the stdlib module name ("strings", "collections", ...).
+	Module string
+	// Fn is the AST declaration as held in the registry. Callers must not
+	// mutate it — the registry owns a shared immutable copy.
+	Fn *ast.FnDecl
+}
+
+// ReachableStdlibFns returns the stdlib `fn` declarations referenced
+// directly from mod, in deterministic (module, name) order.
+//
+// Only first-hop references are collected: a stdlib body that itself
+// calls another stdlib function does not transitively pull the callee
+// in. Transitive closure is the next step once the lowering pipeline
+// can accept injected stdlib decls — today it would just queue more
+// work that has nowhere to land.
+//
+// Non-stdlib `qualifier.name` calls (runtime FFI aliases, user module
+// aliases) are silently skipped: they are identified by their absence
+// from reg.Modules. A nil module or nil registry returns nil.
+func ReachableStdlibFns(mod *ir.Module, reg *stdlib.Registry) []ReachableStdlibFn {
+	if mod == nil || reg == nil {
+		return nil
+	}
+	type key struct{ module, name string }
+	seen := map[key]struct{}{}
+	var found []ReachableStdlibFn
+	for ref := range ir.Reach(mod) {
+		k := key{module: ref.Qualifier, name: ref.Name}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		fn := reg.LookupFnDecl(ref.Qualifier, ref.Name)
+		if fn == nil {
+			continue
+		}
+		seen[k] = struct{}{}
+		found = append(found, ReachableStdlibFn{Module: ref.Qualifier, Fn: fn})
+	}
+	sort.Slice(found, func(i, j int) bool {
+		if found[i].Module != found[j].Module {
+			return found[i].Module < found[j].Module
+		}
+		return found[i].Fn.Name < found[j].Fn.Name
+	})
+	return found
+}

--- a/internal/backend/stdlib_inject_test.go
+++ b/internal/backend/stdlib_inject_test.go
@@ -1,0 +1,91 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func TestReachableStdlibFnsEmpty(t *testing.T) {
+	if got := ReachableStdlibFns(nil, nil); got != nil {
+		t.Fatalf("both nil = %v, want nil", got)
+	}
+	reg := stdlib.LoadCached()
+	if got := ReachableStdlibFns(nil, reg); got != nil {
+		t.Fatalf("nil module = %v, want nil", got)
+	}
+	mod := &ir.Module{Package: "main"}
+	if got := ReachableStdlibFns(mod, nil); got != nil {
+		t.Fatalf("nil registry = %v, want nil", got)
+	}
+	if got := ReachableStdlibFns(mod, reg); len(got) != 0 {
+		t.Fatalf("empty module = %v, want empty", got)
+	}
+}
+
+func TestReachableStdlibFnsFindsStringsCompare(t *testing.T) {
+	reg := stdlib.LoadCached()
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.CallExpr{
+				Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "compare"},
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "a"}},
+					{Value: &ir.Ident{Name: "b"}},
+				},
+			}},
+		},
+	}
+	got := ReachableStdlibFns(mod, reg)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries (%v), want 1", len(got), got)
+	}
+	if got[0].Module != "strings" || got[0].Fn.Name != "compare" {
+		t.Fatalf("got[0] = {%s, %s}, want {strings, compare}", got[0].Module, got[0].Fn.Name)
+	}
+	if got[0].Fn.Body == nil {
+		t.Fatalf("got[0].Fn.Body = nil, want body of stdlib fn")
+	}
+}
+
+func TestReachableStdlibFnsSkipsUnknownQualifier(t *testing.T) {
+	reg := stdlib.LoadCached()
+	// `userAlias.helper(x)` is not a stdlib call.
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.CallExpr{
+				Callee: &ir.FieldExpr{X: &ir.Ident{Name: "userAlias"}, Name: "helper"},
+				Args:   []ir.Arg{{Value: &ir.Ident{Name: "x"}}},
+			}},
+		},
+	}
+	if got := ReachableStdlibFns(mod, reg); len(got) != 0 {
+		t.Fatalf("got %v, want no stdlib hits for a user-alias call", got)
+	}
+}
+
+func TestReachableStdlibFnsDeterministicOrder(t *testing.T) {
+	reg := stdlib.LoadCached()
+	mk := func(mod, name string) ir.Stmt {
+		return &ir.ExprStmt{X: &ir.CallExpr{
+			Callee: &ir.FieldExpr{X: &ir.Ident{Name: mod}, Name: name},
+		}}
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			mk("strings", "compare"),
+			mk("strings", "compareCI"),
+		},
+	}
+	got := ReachableStdlibFns(mod, reg)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2: %v", len(got), got)
+	}
+	if got[0].Fn.Name > got[1].Fn.Name {
+		t.Fatalf("got out of order: %q before %q", got[0].Fn.Name, got[1].Fn.Name)
+	}
+}

--- a/internal/ir/reach.go
+++ b/internal/ir/reach.go
@@ -1,0 +1,47 @@
+package ir
+
+// QualifiedRef is a `qualifier.name` reference observed in a module,
+// typically a stdlib module call like `strings.compare` or
+// `collections.update`. Reach reports these so a caller can decide
+// which stdlib declarations need to be lowered alongside user code.
+//
+// Qualifier is the left-hand Ident name exactly as it appears in
+// source. Name is the FieldExpr name on the right. Both are raw
+// strings with no stdlib validation attached; cross-referencing
+// against a stdlib.Registry happens in the caller.
+type QualifiedRef struct {
+	Qualifier string
+	Name      string
+}
+
+// Reach walks mod and returns every `qualifier.name` pair used in
+// call positions. The result is deduplicated; iteration order is not
+// guaranteed.
+//
+// A bare identifier not under a FieldExpr (e.g. a local variable
+// reference) is ignored. TypeNames and turbofish arguments are also
+// skipped — stdlib body reachability starts from call sites because
+// stdlib APIs are consumed by call, not by type reference.
+func Reach(mod *Module) map[QualifiedRef]struct{} {
+	out := map[QualifiedRef]struct{}{}
+	if mod == nil {
+		return out
+	}
+	Walk(reachVisitor(out), mod)
+	return out
+}
+
+type reachVisitor map[QualifiedRef]struct{}
+
+func (r reachVisitor) Visit(n Node) Visitor {
+	call, ok := n.(*CallExpr)
+	if !ok {
+		return r
+	}
+	if field, ok := call.Callee.(*FieldExpr); ok {
+		if ident, ok := field.X.(*Ident); ok && ident.Name != "" && field.Name != "" {
+			r[QualifiedRef{Qualifier: ident.Name, Name: field.Name}] = struct{}{}
+		}
+	}
+	return r
+}

--- a/internal/ir/reach_test.go
+++ b/internal/ir/reach_test.go
@@ -1,0 +1,125 @@
+package ir
+
+import "testing"
+
+func TestReachEmptyModule(t *testing.T) {
+	if got := Reach(nil); len(got) != 0 {
+		t.Fatalf("Reach(nil) = %v, want empty", got)
+	}
+	if got := Reach(&Module{Package: "main"}); len(got) != 0 {
+		t.Fatalf("Reach(empty) = %v, want empty", got)
+	}
+}
+
+func TestReachIgnoresBareIdents(t *testing.T) {
+	// `a + b` has no qualified refs.
+	mod := &Module{
+		Package: "main",
+		Script: []Stmt{
+			&ExprStmt{X: &BinaryExpr{
+				Op:    BinAdd,
+				Left:  &Ident{Name: "a", Kind: IdentLocal},
+				Right: &Ident{Name: "b", Kind: IdentLocal},
+			}},
+		},
+	}
+	if got := Reach(mod); len(got) != 0 {
+		t.Fatalf("Reach() = %v, want empty", got)
+	}
+}
+
+func TestReachCollectsQualifiedCall(t *testing.T) {
+	// `strings.compare(a, b)` at script level.
+	call := &CallExpr{
+		Callee: &FieldExpr{
+			X:    &Ident{Name: "strings", Kind: IdentUnknown},
+			Name: "compare",
+		},
+		Args: []Arg{
+			{Value: &Ident{Name: "a", Kind: IdentLocal}},
+			{Value: &Ident{Name: "b", Kind: IdentLocal}},
+		},
+	}
+	mod := &Module{
+		Package: "main",
+		Script:  []Stmt{&ExprStmt{X: call}},
+	}
+	got := Reach(mod)
+	want := QualifiedRef{Qualifier: "strings", Name: "compare"}
+	if _, ok := got[want]; !ok {
+		t.Fatalf("Reach() = %v, want contains %v", got, want)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Reach() = %v, want exactly one entry", got)
+	}
+}
+
+func TestReachDedupesRepeatedCalls(t *testing.T) {
+	mk := func() *CallExpr {
+		return &CallExpr{
+			Callee: &FieldExpr{X: &Ident{Name: "strings"}, Name: "compare"},
+			Args: []Arg{
+				{Value: &Ident{Name: "a"}},
+				{Value: &Ident{Name: "b"}},
+			},
+		}
+	}
+	mod := &Module{
+		Package: "main",
+		Script: []Stmt{
+			&ExprStmt{X: mk()},
+			&ExprStmt{X: mk()},
+		},
+	}
+	if got := Reach(mod); len(got) != 1 {
+		t.Fatalf("Reach() size = %d, want 1 (deduped)", len(got))
+	}
+}
+
+func TestReachWalksIntoFnBody(t *testing.T) {
+	// fn f() { strings.compare(a, b) }
+	callInside := &CallExpr{
+		Callee: &FieldExpr{X: &Ident{Name: "strings"}, Name: "compare"},
+		Args: []Arg{
+			{Value: &Ident{Name: "a"}},
+			{Value: &Ident{Name: "b"}},
+		},
+	}
+	fn := &FnDecl{
+		Name: "f",
+		Body: &Block{Stmts: []Stmt{&ExprStmt{X: callInside}}},
+	}
+	mod := &Module{
+		Package: "main",
+		Decls:   []Decl{fn},
+	}
+	got := Reach(mod)
+	want := QualifiedRef{Qualifier: "strings", Name: "compare"}
+	if _, ok := got[want]; !ok {
+		t.Fatalf("Reach() = %v, want contains %v", got, want)
+	}
+}
+
+func TestReachSkipsFieldAccessOnNonIdent(t *testing.T) {
+	// (getObj.load()).compare(a) — outer receiver is CallExpr, not Ident.
+	inner := &CallExpr{
+		Callee: &FieldExpr{X: &Ident{Name: "getObj"}, Name: "load"},
+	}
+	outer := &CallExpr{
+		Callee: &FieldExpr{X: inner, Name: "compare"},
+		Args:   []Arg{{Value: &Ident{Name: "a"}}},
+	}
+	mod := &Module{
+		Package: "main",
+		Script:  []Stmt{&ExprStmt{X: outer}},
+	}
+	got := Reach(mod)
+	if _, ok := got[QualifiedRef{Qualifier: "getObj", Name: "load"}]; !ok {
+		t.Fatalf("Reach() missing inner getObj.load: %v", got)
+	}
+	for ref := range got {
+		if ref.Name == "compare" {
+			t.Fatalf("Reach() unexpectedly contained %v (outer receiver is a call, not Ident)", ref)
+		}
+	}
+}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1203,7 +1203,12 @@ func llvmUnsupportedDiagnostic(kind string, detail string) *LlvmUnsupportedDiagn
 		// Osty: examples/selfhost-core/llvmgen.osty:833:9
 		return llvmUnsupportedDiagnosticWith("LLVM017", kind, detail, "use non-generic functions with identifier parameters and Int/Bool types")
 	}
-	// Osty: examples/selfhost-core/llvmgen.osty:841:5
+	// Osty: examples/selfhost-core/llvmgen.osty:840:5
+	if kind == "stdlib-body" {
+		// Osty: examples/selfhost-core/llvmgen.osty:841:9
+		return llvmUnsupportedDiagnosticWith("LLVM018", kind, detail, "call stdlib functions whose bodies the LLVM backend can currently lower, or add a runtime shim for this symbol")
+	}
+	// Osty: examples/selfhost-core/llvmgen.osty:849:5
 	reason := detail
 	_ = reason
 	// Osty: examples/selfhost-core/llvmgen.osty:842:5

--- a/internal/llvmgen/unsupported_diag_test.go
+++ b/internal/llvmgen/unsupported_diag_test.go
@@ -1,0 +1,56 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUnsupportedDiagnosticKindMapping asserts every "kind" string that the
+// LLVM backend routes through llvmUnsupportedDiagnostic yields the right
+// stable code. This is the contract downstream callers (tests, CLI
+// renderer) depend on, so a regression here would silently demote a
+// structured error into LLVM000.
+func TestUnsupportedDiagnosticKindMapping(t *testing.T) {
+	cases := []struct {
+		kind string
+		want string
+	}{
+		{"go-ffi", "LLVM001"},
+		{"runtime-ffi", "LLVM002"},
+		{"source-layout", "LLVM010"},
+		{"type-system", "LLVM011"},
+		{"statement", "LLVM012"},
+		{"expression", "LLVM013"},
+		{"control-flow", "LLVM014"},
+		{"call", "LLVM015"},
+		{"name", "LLVM016"},
+		{"function-signature", "LLVM017"},
+		{"stdlib-body", "LLVM018"},
+		{"anything-else", "LLVM000"},
+	}
+	for _, tc := range cases {
+		got := UnsupportedDiagnosticFor(tc.kind, "detail")
+		if got.Code != tc.want {
+			t.Errorf("UnsupportedDiagnosticFor(%q).Code = %q, want %q", tc.kind, got.Code, tc.want)
+		}
+	}
+}
+
+// TestUnsupportedStdlibBodyHint verifies the LLVM018 hint is specific enough
+// to direct users to either the stdlib lowering backlog or a runtime shim
+// workaround rather than offering the generic "reduce to smoke subset"
+// fallback.
+func TestUnsupportedStdlibBodyHint(t *testing.T) {
+	got := UnsupportedDiagnosticFor("stdlib-body", "strings.compare body")
+	if got.Code != "LLVM018" {
+		t.Fatalf("Code = %q, want LLVM018", got.Code)
+	}
+	if got.Hint == "" {
+		t.Fatalf("Hint is empty")
+	}
+	for _, want := range []string{"stdlib", "runtime shim"} {
+		if !strings.Contains(got.Hint, want) {
+			t.Errorf("Hint = %q, missing %q", got.Hint, want)
+		}
+	}
+}

--- a/internal/stdlib/lookup_test.go
+++ b/internal/stdlib/lookup_test.go
@@ -1,0 +1,44 @@
+package stdlib
+
+import "testing"
+
+func TestLookupFnDeclFindsStringsCompare(t *testing.T) {
+	reg := LoadCached()
+	fn := reg.LookupFnDecl("strings", "compare")
+	if fn == nil {
+		t.Fatalf("LookupFnDecl(strings, compare) = nil, want *ast.FnDecl")
+	}
+	if fn.Name != "compare" {
+		t.Fatalf("fn.Name = %q, want compare", fn.Name)
+	}
+	if fn.Body == nil {
+		t.Fatalf("fn.Body = nil, want non-nil body for a bodied stdlib fn")
+	}
+	if len(fn.Params) != 2 {
+		t.Fatalf("fn.Params = %d, want 2", len(fn.Params))
+	}
+}
+
+func TestLookupFnDeclUnknownReturnsNil(t *testing.T) {
+	reg := LoadCached()
+	cases := []struct {
+		module, name string
+	}{
+		{"strings", "nonexistent_fn_zzz"},
+		{"no_such_module", "compare"},
+		{"", "compare"},
+		{"strings", ""},
+	}
+	for _, tc := range cases {
+		if got := reg.LookupFnDecl(tc.module, tc.name); got != nil {
+			t.Errorf("LookupFnDecl(%q, %q) = %v, want nil", tc.module, tc.name, got)
+		}
+	}
+}
+
+func TestLookupFnDeclNilReceiver(t *testing.T) {
+	var reg *Registry
+	if got := reg.LookupFnDecl("strings", "compare"); got != nil {
+		t.Fatalf("nil.LookupFnDecl = %v, want nil", got)
+	}
+}

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -387,6 +387,35 @@ func (r *Registry) LookupPackage(dotPath string) *resolve.Package {
 	return nil
 }
 
+// LookupFnDecl returns the top-level `fn` declaration with the given name
+// inside the stdlib module, or nil if the module or function is not
+// present. Only public and private free functions at file scope are
+// considered — methods declared inside struct/enum/interface bodies are
+// not exposed here because a backend that wants a method body must look
+// it up against its receiver type.
+//
+// The returned AST is the shared immutable registry copy; callers must
+// not mutate it.
+func (r *Registry) LookupFnDecl(module, name string) *ast.FnDecl {
+	if r == nil || module == "" || name == "" {
+		return nil
+	}
+	mod, ok := r.Modules[module]
+	if !ok || mod == nil || mod.File == nil {
+		return nil
+	}
+	for _, decl := range mod.File.Decls {
+		fn, ok := decl.(*ast.FnDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
 // collectStubPaths walks the embedded file system and returns every
 // .osty path in lexical order. Deterministic ordering keeps diagnostic
 // output stable across runs.


### PR DESCRIPTION
## Summary

Groundwork for lowering Osty-bodied stdlib functions (e.g. `strings.compare`, `Map.update`) through the LLVM backend instead of the case-by-case runtime C shim pattern that currently covers `osty_rt_strings_Equal` / `Concat` only. Follows the M1–M3 plan agreed in plan-ceo-review.

This PR only lands the **reusable foundation** — no user-facing behavior changes. Full-pipeline integration (name mangling, resolve-context merge, IR injection, reachable-fn lowering) is the next PR.

## What's in

- **`ir.Reach`** (`internal/ir/reach.go`) — walks an IR module and returns every `qualifier.name` call site as a deduped set. Foundation for stdlib-body reachability analysis.
- **`stdlib.Registry.LookupFnDecl`** (`internal/stdlib/stdlib.go`) — resolve `(module, name)` to the top-level `*ast.FnDecl` held by the registry.
- **`backend.ReachableStdlibFns`** (`internal/backend/stdlib_inject.go`) — intersects the two above to find first-hop stdlib functions a user module references, in deterministic order. Transitive closure stays out until the lowering pipeline can consume injected decls.
- **`LLVM018` stdlib-body diagnostic** — new stable code for "stdlib fn body could not be lowered by the LLVM backend." Added to the Osty source of truth (`examples/selfhost-core/llvmgen.osty`) and mirrored in the Go snapshot (`internal/llvmgen/support_snapshot.go`).

## Why

`toolchain/semver.osty` (and soon Map helper tests) call into Osty-bodied stdlib functions. Today those calls hit `LLVM016 unknown identifier "strings"` because the backend only receives the user `*ast.File` — stdlib bodies live in resolve/check only and never reach IR. Three response options were considered:

- (A) Full-pipeline stdlib injection — works for generics + closure-taking helpers, reuses `ir.Monomorphize` and `mir.Lower`. **Chosen.**
- (B) Expanded runtime C shims — can't encode closure parameters (`mergeWith`'s `combine: fn(V,V)->V`), so doesn't scale past non-generic pure functions. Would be short-term pain relief only.
- (C) AOT stdlib compile + link — hybrid with (A) because generic mono is caller-site, not AOT.

This PR lays the minimum infrastructure for (A) without changing the compilation contract.

## Why small

The full lowering path needs a resolve-context merge (user Refs + stdlib Refs by pointer identity) and a callsite-rewriting pass so `strings.compare` in user IR maps to a mangled symbol of the injected stdlib decl. Bundling that into one PR means touching `ir.Lower`, `ir.Monomorphize`, and `backend.PrepareEntry` at once. Splitting keeps each review tractable.

## Tests

13 new tests added:

- `ir.Reach` × 6 — empty/nil module, bare-ident ignore, qualified call collection, dedup, walks into fn bodies, skips non-Ident receivers.
- `stdlib.LookupFnDecl` × 3 — finds `strings.compare`, handles unknown inputs, nil receiver.
- `backend.ReachableStdlibFns` × 4 — nil cases, finds `strings.compare`, skips non-stdlib qualifiers, deterministic order.
- `llvmgen` diagnostic mapping × 2 — every kind string routes to its stable LLVM0xx code (locks LLVM001–LLVM018 against drift); LLVM018 hint specificity.

## Test plan

- [x] `go test ./internal/ir/ -run TestReach`
- [x] `go test ./internal/llvmgen/ -run TestUnsupported`
- [x] `go test ./internal/stdlib/ -run TestLookup`
- [x] `go test ./internal/backend/ -run TestReachable`
- [x] Full front-end suite (`lexer parser resolve check diag format lint pipeline ir stdlib`) green
- [x] No regressions in `internal/llvmgen` diagnostic mapping
- [ ] Follow-up PR: wire injection into `backend.PrepareEntry`, name-mangle, land end-to-end `strings.compare` via `toolchain/semver.osty`

## Risk / rollback

Additive only — no existing call sites changed. `ReachableStdlibFns` is not yet invoked by `PrepareEntry`. Revert is a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)