### PR TITLE
fix(llvmgen): for-iter 바인딩 sourceType 전파로 중첩 루프 == 복구

### DIFF
--- a/internal/llvmgen/regression_manifest_features_test.go
+++ b/internal/llvmgen/regression_manifest_features_test.go
@@ -1,0 +1,87 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestForLoopFieldStringCompareAgainstLocal verifies `feature.name == name`
+// where `feature` comes from a for-loop over List<FeatureSpec>.
+func TestForLoopFieldStringCompareAgainstLocal(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct FeatureSpec {
+    pub name: String,
+    pub deps: List<String>,
+}
+
+fn featureExists(name: String, features: List<FeatureSpec>) -> Bool {
+    for feature in features {
+        if feature.name == name {
+            return true
+        }
+    }
+    false
+}
+
+fn main() {
+    let fs = [FeatureSpec { name: "a", deps: [] }]
+    if featureExists("a", fs) { println(1) } else { println(0) }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/mf1.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST returned error: %v", err)
+	}
+	if !strings.Contains(string(ir), "@osty_rt_strings_Equal") {
+		t.Fatalf("expected String compare via osty_rt_strings_Equal; IR:\n%s", ir)
+	}
+}
+
+// TestForLoopNestedListIterCompareFieldName reproduces the self-reference
+// check from toolchain/manifest_features.osty:
+//
+//	for feature in features { for dep in feature.deps { if dep == feature.name { ... } } }
+//
+// Both `dep` (inner iter) and `feature.name` (outer iter's struct field) must
+// carry a `String` source type through the iter binding so the llvmgen
+// compare guard routes to osty_rt_strings_Equal instead of rejecting the
+// operands as non-String ptr values (LLVM011).
+func TestForLoopNestedListIterCompareFieldName(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct FeatureSpec {
+    pub name: String,
+    pub deps: List<String>,
+}
+
+fn countSelfRefs(features: List<FeatureSpec>) -> Int {
+    let mut n = 0
+    for feature in features {
+        for dep in feature.deps {
+            if dep == feature.name {
+                n = n + 1
+            }
+        }
+    }
+    n
+}
+
+fn main() {
+    let fs = [FeatureSpec { name: "a", deps: ["a"] }]
+    let n = countSelfRefs(fs)
+    println(n)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/mf2.osty",
+	})
+	if err != nil {
+		t.Fatalf("generateFromAST returned error: %v", err)
+	}
+	if !strings.Contains(string(ir), "@osty_rt_strings_Equal") {
+		t.Fatalf("expected String compare via osty_rt_strings_Equal; IR:\n%s", ir)
+	}
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1255,12 +1255,14 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		return err
 	}
 	indexValue := value{typ: "i64", ref: loop.current}
+	elemSource, _ := g.iterableElemSourceType(stmt.Iter)
 	if useAggregateABI {
 		item, err := g.emitListAggregateGet(iterableValue, indexValue, elemTyp)
 		if err != nil {
 			g.popScope()
 			return err
 		}
+		item.sourceType = elemSource
 		g.bindLocal(iterName, item)
 	} else if listUsesTypedRuntime(elemTyp) {
 		getSymbol := listRuntimeGetSymbol(elemTyp)
@@ -1271,6 +1273,7 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		loaded := fromOstyValue(item)
 		loaded.gcManaged = elemTyp == "ptr"
 		loaded.rootPaths = g.rootPathsForType(elemTyp)
+		loaded.sourceType = elemSource
 		g.bindLocal(iterName, loaded)
 	} else {
 		traceSymbol := g.traceCallbackSymbol(elemTyp, g.rootPathsForType(elemTyp))
@@ -1289,6 +1292,7 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		loaded := g.loadValueFromAddress(emitter, elemTyp, slot)
 		g.takeOstyEmitter(emitter)
 		loaded.rootPaths = g.rootPathsForType(elemTyp)
+		loaded.sourceType = elemSource
 		g.bindLocal(iterName, loaded)
 	}
 	if err := g.emitBlock(stmt.Body.Stmts); err != nil {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -573,6 +573,49 @@ func (g *generator) staticExprIsString(expr ast.Expr) bool {
 	return llvmNamedTypeIsString(resolved)
 }
 
+// iterableElemSourceType returns the element source type of a list-shaped
+// iterable, resolving aliases. The fallback reaches into structsByType so
+// nested `for` loops over List-typed struct fields still recover the element
+// source type when the base binding (itself an iter var) has no sourceType.
+func (g *generator) iterableElemSourceType(iter ast.Expr) (ast.Type, bool) {
+	src, ok := g.staticExprSourceType(iter)
+	if !ok {
+		src = g.structFieldListSourceType(iter)
+		if src == nil {
+			return nil, false
+		}
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil {
+		return nil, false
+	}
+	named, ok := resolved.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "List" || len(named.Args) != 1 {
+		return nil, false
+	}
+	return named.Args[0], true
+}
+
+func (g *generator) structFieldListSourceType(expr ast.Expr) ast.Type {
+	field, ok := expr.(*ast.FieldExpr)
+	if !ok || field.IsOptional {
+		return nil
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok {
+		return nil
+	}
+	info := g.structsByType[baseInfo.typ]
+	if info == nil {
+		return nil
+	}
+	f, ok := info.byName[field.Name]
+	if !ok {
+		return nil
+	}
+	return f.sourceType
+}
+
 func (g *generator) staticExprListElemIsBytes(expr ast.Expr) bool {
 	sourceType, ok := g.staticExprSourceType(expr)
 	if !ok {


### PR DESCRIPTION
## Summary
- 27cb857의 `emitCompare` isString 가드가 `emitListFor`의 iter 바인딩에 `sourceType`이 비어 있는 점과 맞물려, 중첩 `for` 루프에서 양쪽 피연산자가 모두 sourceType 없음 → LLVM011로 거절하던 회귀를 수정.
- `toolchain/manifest_features.osty`의 self-reference 체크(`for dep in feature.deps { if dep == feature.name ... }`)가 대표 재현.

## Changes
- `emitListFor` 세 ABI 경로(aggregate / typed-runtime / bytes)에서 iter 바인딩 `value`에 elem `sourceType`을 세팅 ([stmt.go:1258-1296](internal/llvmgen/stmt.go))
- `iterableElemSourceType` 추가: `staticExprSourceType` 성공 시 그대로 사용, 실패 시 `structFieldListSourceType`로 폴백. 폴백은 `structsByType[base.typ].byName[field].sourceType`를 통해 base가 iter 바인딩이라 sourceType이 없을 때도 필드 sourceType을 복구 ([type.go:576-617](internal/llvmgen/type.go))
- 회귀 테스트 2개: 단일 루프(`feature.name == name`)와 중첩 루프(`dep == feature.name`) 모두 `@osty_rt_strings_Equal` 방출 assert ([regression_manifest_features_test.go](internal/llvmgen/regression_manifest_features_test.go))

## Test plan
- [x] `go test ./internal/llvmgen/ -run TestForLoop` — 새 테스트 2개 PASS
- [x] `go test ./internal/llvmgen/` — 기존 실패 목록 동일(선-존재 실패만), 신규 회귀 0
- [x] `go test -short ./internal/check/ ./internal/resolve/ ./internal/parser/` — 모두 PASS
- [ ] `toolchain/manifest_features.osty` end-to-end pipeline 확인(현장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)