### PR TITLE
feat(check): privilege gate walks fn bodies — §19.2 coverage spike

### DIFF
--- a/internal/check/privilege.go
+++ b/internal/check/privilege.go
@@ -130,6 +130,13 @@ func (g *privilegeGate) walkDecl(d ast.Decl) {
 				g.walkType(p.Type)
 			}
 		}
+		// Walking the body catches runtime-only names in nested type
+		// positions the declaration header doesn't cover: let-binding
+		// annotations, closure parameter type annotations, and
+		// turbofish type arguments. Without this, a user could write
+		// `fn() { let p: RawPtr = 0 }` or `fn() { foo::<RawPtr>() }`
+		// and bypass the gate.
+		g.walkBlock(n.Body)
 	case *ast.StructDecl:
 		g.checkAnnotations(n.Annotations)
 		g.walkGenerics(n.Generics)
@@ -162,6 +169,136 @@ func (g *privilegeGate) walkDecl(d ast.Decl) {
 	case *ast.LetDecl:
 		g.checkAnnotations(n.Annotations)
 		g.walkType(n.Type)
+		g.walkExpr(n.Value)
+	}
+}
+
+// walkBlock walks every statement in a function body, inspecting
+// type annotations on let statements and descending into expression
+// positions that can carry type arguments.
+func (g *privilegeGate) walkBlock(b *ast.Block) {
+	if b == nil {
+		return
+	}
+	for _, s := range b.Stmts {
+		g.walkStmt(s)
+	}
+}
+
+func (g *privilegeGate) walkStmt(s ast.Stmt) {
+	switch n := s.(type) {
+	case nil:
+		return
+	case *ast.LetStmt:
+		g.walkType(n.Type)
+		g.walkExpr(n.Value)
+	case *ast.ExprStmt:
+		g.walkExpr(n.X)
+	case *ast.AssignStmt:
+		for _, t := range n.Targets {
+			g.walkExpr(t)
+		}
+		g.walkExpr(n.Value)
+	case *ast.ReturnStmt:
+		g.walkExpr(n.Value)
+	case *ast.ChanSendStmt:
+		g.walkExpr(n.Channel)
+		g.walkExpr(n.Value)
+	case *ast.DeferStmt:
+		g.walkExpr(n.X)
+	case *ast.ForStmt:
+		g.walkExpr(n.Iter)
+		g.walkBlock(n.Body)
+	case *ast.Block:
+		g.walkBlock(n)
+	}
+}
+
+// walkExpr descends into composite expressions so nested turbofish
+// type arguments, closure parameter types, and struct-literal types
+// are checked. The walker does not try to catch value-position uses
+// of `RawPtr` / `Pod` identifiers — those resolve as SymBuiltin and
+// downstream type-checking already rejects non-type uses. The scope
+// here is the type surface that can carry runtime-only names.
+func (g *privilegeGate) walkExpr(e ast.Expr) {
+	switch n := e.(type) {
+	case nil:
+		return
+	case *ast.UnaryExpr:
+		g.walkExpr(n.X)
+	case *ast.BinaryExpr:
+		g.walkExpr(n.Left)
+		g.walkExpr(n.Right)
+	case *ast.QuestionExpr:
+		g.walkExpr(n.X)
+	case *ast.CallExpr:
+		g.walkExpr(n.Fn)
+		for _, a := range n.Args {
+			if a != nil {
+				g.walkExpr(a.Value)
+			}
+		}
+	case *ast.FieldExpr:
+		g.walkExpr(n.X)
+	case *ast.IndexExpr:
+		g.walkExpr(n.X)
+		g.walkExpr(n.Index)
+	case *ast.TurbofishExpr:
+		g.walkExpr(n.Base)
+		for _, t := range n.Args {
+			g.walkType(t)
+		}
+	case *ast.RangeExpr:
+		g.walkExpr(n.Start)
+		g.walkExpr(n.Stop)
+	case *ast.ParenExpr:
+		g.walkExpr(n.X)
+	case *ast.TupleExpr:
+		for _, el := range n.Elems {
+			g.walkExpr(el)
+		}
+	case *ast.ListExpr:
+		for _, el := range n.Elems {
+			g.walkExpr(el)
+		}
+	case *ast.MapExpr:
+		for _, ent := range n.Entries {
+			if ent != nil {
+				g.walkExpr(ent.Key)
+				g.walkExpr(ent.Value)
+			}
+		}
+	case *ast.StructLit:
+		g.walkExpr(n.Type)
+		for _, f := range n.Fields {
+			if f != nil {
+				g.walkExpr(f.Value)
+			}
+		}
+		g.walkExpr(n.Spread)
+	case *ast.IfExpr:
+		g.walkExpr(n.Cond)
+		g.walkBlock(n.Then)
+		g.walkExpr(n.Else)
+	case *ast.MatchExpr:
+		g.walkExpr(n.Scrutinee)
+		for _, arm := range n.Arms {
+			if arm == nil {
+				continue
+			}
+			g.walkExpr(arm.Guard)
+			g.walkExpr(arm.Body)
+		}
+	case *ast.ClosureExpr:
+		for _, p := range n.Params {
+			if p != nil {
+				g.walkType(p.Type)
+			}
+		}
+		g.walkType(n.ReturnType)
+		g.walkExpr(n.Body)
+	case *ast.Block:
+		g.walkBlock(n)
 	}
 }
 

--- a/internal/check/privilege_body_test.go
+++ b/internal/check/privilege_body_test.go
@@ -1,0 +1,198 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+)
+
+// privilegeGateOnly parses the source and runs ONLY the privilege
+// gate (no resolver, no other checkers), returning the gate's
+// diagnostic list. This isolates the body-walk coverage from unrelated
+// resolver noise such as "unknown name `raw`" when the source uses
+// an unimported runtime namespace.
+func privilegeGateOnly(t *testing.T, src string) []*diag.Diagnostic {
+	t.Helper()
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	return runPrivilegeGate(file, false)
+}
+
+func countPrivilegeE0770(ds []*diag.Diagnostic) int {
+	n := 0
+	for _, d := range ds {
+		if d != nil && d.Code == diag.CodeRuntimePrivilegeViolation {
+			n++
+		}
+	}
+	return n
+}
+
+// --- let-type annotations inside fn bodies ---
+
+func TestPrivilegeBodyLetRawPtr(t *testing.T) {
+	src := `
+pub fn demo() {
+    let p: RawPtr = 0
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for let: RawPtr in fn body, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyLetOptionRawPtr(t *testing.T) {
+	src := `
+pub fn demo() {
+    let p: Option<RawPtr> = None
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for Option<RawPtr> in fn body, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyLetTupleRawPtr(t *testing.T) {
+	src := `
+pub fn demo() {
+    let p: (Int, RawPtr) = (0, 0)
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for (Int, RawPtr) in fn body, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyNestedLetBlocks(t *testing.T) {
+	src := `
+pub fn demo() {
+    if true {
+        let p: RawPtr = 0
+    }
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for let: RawPtr inside if-body, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyForLoopLet(t *testing.T) {
+	src := `
+pub fn demo() {
+    for i in 0..10 {
+        let p: RawPtr = 0
+    }
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for let: RawPtr inside for-body, got %d", got)
+	}
+}
+
+// --- turbofish type args ---
+
+func TestPrivilegeBodyTurbofishRawPtr(t *testing.T) {
+	src := `
+pub fn demo() {
+    foo::<RawPtr>()
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for foo::<RawPtr>, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyNestedTurbofishRawPtr(t *testing.T) {
+	src := `
+pub fn demo() {
+    foo::<List<RawPtr>>()
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for foo::<List<RawPtr>>, got %d", got)
+	}
+}
+
+// --- closure parameter type annotations ---
+
+func TestPrivilegeBodyClosureRawPtrParam(t *testing.T) {
+	src := `
+pub fn demo() {
+    let f = |p: RawPtr| p
+    f(0)
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for closure |p: RawPtr|, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyClosureRawPtrReturn(t *testing.T) {
+	src := `
+pub fn demo() {
+    let f = |x: Int| -> RawPtr { 0 }
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0770 for closure -> RawPtr, got %d", got)
+	}
+}
+
+// --- false-positive guard: ordinary body contents unaffected ---
+
+func TestPrivilegeBodyOrdinaryLetIntUnaffected(t *testing.T) {
+	src := `
+pub fn demo() {
+    let p: Int = 0
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0770 for let: Int, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyOrdinaryTurbofishUnaffected(t *testing.T) {
+	src := `
+pub fn demo() {
+    foo::<Int>()
+    bar::<List<String>>()
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0770 for ordinary turbofish, got %d", got)
+	}
+}
+
+func TestPrivilegeBodyOrdinaryClosureUnaffected(t *testing.T) {
+	src := `
+pub fn demo() {
+    let f = |p: String| -> Int { 0 }
+}
+`
+	if got := countPrivilegeE0770(privilegeGateOnly(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0770 for closure (String) -> Int, got %d", got)
+	}
+}
+
+// --- privileged bypass path: body contents accepted when privileged ---
+
+func TestPrivilegeBodyAllowedWhenPrivileged(t *testing.T) {
+	src := `
+pub fn demo() {
+    let p: RawPtr = 0
+    let q: Option<RawPtr> = None
+    foo::<RawPtr>()
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse diagnostics: %v", parseDiags)
+	}
+	ds := runPrivilegeGate(file, true)
+	if got := countPrivilegeE0770(ds); got != 0 {
+		t.Fatalf("privileged body must produce 0 E0770, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Ninth spike on the GC self-hosting path. Closes the body-coverage gap in the privilege gate: runtime-only type references INSIDE fn bodies now produce `E0770` in user code.

## The gap this closes

Before this PR, the gate only walked declaration **headers** — fn params, fn returns, struct fields, type aliases, top-level let types, generic constraints. Code inside a fn body was unwalked, so all of these slipped past in user code:

```osty
fn demo() {
    let p: RawPtr = 0             // ← not caught
    let q: Option<RawPtr> = None  // ← not caught
    foo::<RawPtr>()               // ← not caught
    let f = |p: RawPtr| p         // ← not caught
}
```

Noted as "future work" in [#292](https://github.com/choiceoh/osty/pull/292); became reachable once `RawPtr` landed in the prelude ([#312](https://github.com/choiceoh/osty/pull/312)) and `Pod` followed ([#314](https://github.com/choiceoh/osty/pull/314)).

## What this PR adds

| Function | Handles |
|---|---|
| `walkBlock` | Iterates every stmt in a fn body |
| `walkStmt` | LetStmt, ExprStmt, AssignStmt, ReturnStmt, ChanSendStmt, DeferStmt, ForStmt, Block |
| `walkExpr` | Call / Turbofish / Field / Index / Unary / Binary / Question / Paren / Tuple / List / Map / StructLit / If / Match / Closure / Block |
| `walkDecl` extension | FnDecl now walks Body; LetDecl walks Value |

The walker pulls `walkType` on let-annotations, turbofish type arguments, and closure parameter/return type annotations. Value-position identifiers (`let x = RawPtr`) are NOT inspected — those resolve as `SymBuiltin` and type-checking downstream is the right place to catch the misuse.

## Test evidence (13 cases)

```
$ go test ./internal/check/ -run TestPrivilegeBody
ok (13/13 pass)

$ go test -short ./internal/check/ ./internal/resolve/ ./internal/parser/ \
    ./internal/types/ ./internal/stdlib/ ./internal/cst/
all green
```

- **Let-type in body**: `RawPtr` / `Option<RawPtr>` / `(Int, RawPtr)` (3)
- **Nested blocks**: `if`-body / `for`-body (2)
- **Turbofish**: `foo::<RawPtr>()` + nested `foo::<List<RawPtr>>()` (2)
- **Closures**: param `|p: RawPtr|` + return `-> RawPtr` (2)
- **False-positive guard**: ordinary let / turbofish / closure unaffected (3)
- **Privileged bypass**: `privileged=true` accepts the whole set (1)

## Deliberately out of scope

- **Value-position `RawPtr` / `Pod` identifiers** — resolver binds them as `SymBuiltin`; type-checking catches non-type uses downstream.
- **Match-arm patterns referencing RawPtr** — patterns are distinct AST nodes the gate does not walk. RawPtr in a pattern is effectively unreachable today.

## Spec references

- LANG_SPEC §19.2 (privilege gate)
- LANG_SPEC §19.3 (RawPtr type gating)
- LANG_SPEC §19.4 (Pod bound gating)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/check/...` green
- [ ] `go test -short ./...` — no new failures
- [ ] User code with `let p: RawPtr` in a fn body produces E0770
- [ ] Privileged code with the same construct passes
- [ ] Ordinary user code with `let p: Int` / `foo::<Int>()` / `|x: String|` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)