### PR TITLE
docs: ?-family cheat sheet on spec README

### DIFF
--- a/LANG_SPEC_v0.5/README.md
+++ b/LANG_SPEC_v0.5/README.md
@@ -29,6 +29,33 @@ the full v0.1 → v0.2 → v0.3 → v0.4 → v0.5 evolution.
 - `../OSTY_GRAMMAR_v0.4.md` — historical v0.4 grammar snapshot.
 - `../SPEC_GAPS.md` — archive of resolved gaps per version. No open items as of v0.5; new gap numbers are prohibited post-freeze.
 
+## `?`-family cheat sheet
+
+Four punctuation operators share the `?` glyph. They look related — three
+of them are — but each has a distinct role. Read this table before §4.
+
+| Form | Role | Operand → Result | Example | Spec |
+|---|---|---|---|---|
+| `expr?` | **Propagate** `Err`/`None` out of the enclosing function | `Result<T,E> → T` or `Option<T> → T` | `let cfg = parse(text)?` | §4.5 |
+| `expr?.m` | **Chain** on `Option`; short-circuit to `None` on the first missing step | `Option<T> → Option<U>` | `user?.address?.city` | §4.6 |
+| `lhs ?? rhs` | **Unwrap-or-default**; right side is lazy | `Option<T>, T → T` | `user?.name ?? "anon"` | §4.6 |
+| `err as? T` | **Downcast** an `Error` to its concrete nominal type (shortcut for `err.downcast::<T>()`) | `Error → T?` | `err as? FsError` | §7.4 (G27) |
+
+**Disambiguations (read once, save hours).**
+
+- `?` is legal on both `Result` and `Option`, but the enclosing function
+  must return the matching shape; mixing is a compile error — convert
+  with `Option.orError(msg)` or `Result.ok()`.
+- `?.` stays inside `Option`. It does **not** return from the function.
+  To exit a chain, end with `?` (`user?.address?.city?` in a fn
+  returning `Option<_>`).
+- `??` is `Option`-only. For `Result`, use `.unwrapOr(d)` / `match`.
+- `as?` is **not** a general type test. It works only on `Error`
+  values, using the nominal tag attached at up-cast time (§7.4). For
+  other "is it this variant?" questions, use pattern matching.
+- None of the four introduces null/nil. `?` in a type (`T?`) is sugar
+  for `Option<T>` (§2.5) — a separate surface.
+
 ## Table of Contents
 
 - [1. Lexical Structure](./01-lexical-structure.md)


### PR DESCRIPTION
## Summary

Adds a `?`-family cheat sheet to [`LANG_SPEC_v0.5/README.md`](LANG_SPEC_v0.5/README.md) — placed above the TOC so it's the first concrete content new readers hit.

## Why

Osty has four punctuation operators sharing the `?` glyph, each with a distinct role:

| Form | Role | Spec |
|---|---|---|
| `expr?` | propagate `Err`/`None` | §4.5 |
| `expr?.m` | option chain | §4.6 |
| `lhs ?? rhs` | unwrap-or-default | §4.6 |
| `err as? T` | Error downcast (G27) | §7.4 |

They're spread across three spec sections. Without a single index, the first few hours of learning are spent cross-referencing to disambiguate them — a cost that stacks against Osty's simplicity story (no null, no exceptions, no inheritance).

This is a **docs-only pointer table** with accurate links back to authoritative chapters. No semantic change; authoritative prose stays in §4/§7.

## What's in the cheat sheet

- 4-row table: form / role / signature / one-line example / spec ref
- Five disambiguation bullets covering the common traps:
  - `?` mixing between `Result` and `Option`
  - `?.` does not propagate out of the function
  - `??` is `Option`-only (use `.unwrapOr` / `match` for `Result`)
  - `as?` is nominal-tag-only on `Error`, not a general type test
  - `T?` is `Option<T>` sugar (§2.5), distinct from the four operators

## Reviewer notes

- Verified every cited reference against the current spec: §2.5 sugar, §4.5 propagation, §4.6 `?.`/`??`, §7.4 + G27 for `as?`, §18 change history for `unwrapOr` membership on both `Option` and `Result`.
- **Side finding (not fixed in this PR):** `as?` is declared in `OSTY_GRAMMAR_v0.5.md` and announced in §18 (G27), but the §4/§7 body prose still only describes `Error.downcast::<T>()`. The cheat sheet anchors to §7.4 as the best available ref, but the grammar/prose drift itself is worth a follow-up PR adding one paragraph in §7.4 (or §4.9) that introduces `as?` as the canonical surface with `downcast::<T>()` as the desugaring.

## Test plan

- [ ] Render `LANG_SPEC_v0.5/README.md` on GitHub and confirm the table renders and links resolve
- [ ] Skim the cheat sheet claims against §4.5, §4.6, §7.4 prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)