### PR TITLE
feat(check): bring native-checker fixes from PR #318 to main

### DIFF
--- a/internal/selfhost/check_telemetry.go
+++ b/internal/selfhost/check_telemetry.go
@@ -5,6 +5,100 @@ import (
 	"strings"
 )
 
+// selfhostTypesAliasEqual reports whether two type names differ only by
+// a leading `alias.` qualifier on one side. FFI collection registers a
+// struct declared inside `use X as alias { struct Foo {} }` under the
+// bare name `Foo`; the receiver-side call annotation then refers to it
+// as `alias.Foo`. Without this equivalence every cross-use of those
+// names trips frontCheckExpectAssignable. Applied recursively over
+// generic argument lists so `Option<Manifest>` ~ `Option<host.Manifest>`
+// also match.
+func selfhostTypesAliasEqual(a string, b string) bool {
+	if a == b {
+		return true
+	}
+	aHead, aArgs := selfhostSplitTypeHead(a)
+	bHead, bArgs := selfhostSplitTypeHead(b)
+	if !selfhostHeadsAliasEqual(aHead, bHead) {
+		return false
+	}
+	if len(aArgs) != len(bArgs) {
+		return false
+	}
+	for i := range aArgs {
+		if !selfhostTypesAliasEqual(aArgs[i], bArgs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func selfhostHeadsAliasEqual(a string, b string) bool {
+	if a == b {
+		return true
+	}
+	if selfhostStripSingleAliasPrefix(a) == b {
+		return true
+	}
+	if a == selfhostStripSingleAliasPrefix(b) {
+		return true
+	}
+	return false
+}
+
+func selfhostStripSingleAliasPrefix(name string) string {
+	i := strings.IndexByte(name, '.')
+	if i <= 0 {
+		return name
+	}
+	prefix := name[:i]
+	// Only strip when the prefix looks like a bare identifier (no nested
+	// separators). This avoids collapsing `std.strings` (a real qualified
+	// path) or parametric prefixes emitted by the type printer.
+	for j := 0; j < len(prefix); j++ {
+		c := prefix[j]
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (j > 0 && c >= '0' && c <= '9') {
+			continue
+		}
+		return name
+	}
+	return name[i+1:]
+}
+
+// selfhostSplitTypeHead parses a type-printer string of shape
+// `Head<arg1, arg2, ...>` into (head, args). Passing through strings
+// with no generic brackets returns (name, nil). Nested angle brackets
+// inside args are preserved by tracking depth during the comma split.
+func selfhostSplitTypeHead(t string) (string, []string) {
+	lt := strings.IndexByte(t, '<')
+	if lt < 0 || !strings.HasSuffix(t, ">") {
+		return t, nil
+	}
+	head := t[:lt]
+	inner := t[lt+1 : len(t)-1]
+	if inner == "" {
+		return head, nil
+	}
+	var args []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(inner); i++ {
+		switch inner[i] {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				args = append(args, strings.TrimSpace(inner[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	args = append(args, strings.TrimSpace(inner[start:]))
+	return head, args
+}
+
 // selfhostUseDeclAlias resolves the canonical alias name for a UseDecl
 // node. The parser stores the `use ... as <alias>` alias ident in
 // children2[0] when present; otherwise the alias falls back to the last

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -28445,7 +28445,7 @@ func frontCheckCallHint(file *AstFile, env *FrontCheckEnv, callIdx int, node *As
 		// Osty: /tmp/selfhost_merged.osty:11343:9
 		if !(frontCheckIsInvalid(recvType)) {
 			// Osty: /tmp/selfhost_merged.osty:11344:16
-			selfhostBumpError(env)
+			selfhostBumpErrorWithDetail(env, fmt.Sprintf("%s.%s", owner, callee.text))
 		}
 		// Osty: /tmp/selfhost_merged.osty:11346:9
 		return "Invalid"
@@ -29319,7 +29319,7 @@ func frontCheckField(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 	// Osty: /tmp/selfhost_merged.osty:11757:5
 	if !(frontCheckIsInvalid(recvType)) {
 		// Osty: /tmp/selfhost_merged.osty:11758:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("%s.%s", owner, node.text))
 	}
 	return "Invalid"
 }
@@ -32220,6 +32220,18 @@ func frontCheckListMethod(file *AstFile, env *FrontCheckEnv, callee *AstNode, re
 		// Osty: /tmp/selfhost_merged.osty:13168:9
 		return "Bool"
 	}
+	if name == "insert" {
+		// List.insert(index: Int, item: T) -> ()
+		// Mirrors the `pub fn insert(mut self, index: Int, item: T)` primitive
+		// declared in internal/stdlib/modules/collections.osty; the bootstrapped
+		// method table was missing this entry, surfacing as frontCheckCallHint
+		// misses whenever toolchain code used `list.insert(i, x)`.
+		frontCheckRequireMutableReceiver(file, env, callee)
+		frontCheckExpectArgCount(env, args, 2)
+		frontCheckExpectAssignable(env, "Int", frontCheckExprHint(file, env, frontCheckIntAt(args, 0), "Int"))
+		frontCheckExpectAssignable(env, elem, frontCheckExprHint(file, env, frontCheckIntAt(args, 1), elem))
+		return "()"
+	}
 	// Osty: /tmp/selfhost_merged.osty:13170:5
 	if name == "map" {
 		// Osty: /tmp/selfhost_merged.osty:13171:9
@@ -32531,6 +32543,43 @@ func frontCheckStringMethod(file *AstFile, env *FrontCheckEnv, name string, args
 		frontCheckExpectAssignable(env, "String", frontCheckExprHint(file, env, frontCheckIntAt(args, 0), "String"))
 		// Osty: /tmp/selfhost_merged.osty:13298:9
 		return frontCheckOneArgType("List", "String")
+	}
+	// Additional String primitive methods that the bootstrapped table was
+	// missing. The authoritative surface lives in
+	// internal/stdlib/primitives/string.osty; these entries cover the
+	// shapes toolchain/* actually calls today and were visible as
+	// frontCheckCallHint misses like `String.chars` / `String.bytes`.
+	if name == "chars" {
+		frontCheckExpectArgCount(env, args, 0)
+		return frontCheckOneArgType("List", "Char")
+	}
+	if name == "bytes" {
+		frontCheckExpectArgCount(env, args, 0)
+		return frontCheckOneArgType("List", "Byte")
+	}
+	if name == "graphemes" {
+		frontCheckExpectArgCount(env, args, 0)
+		return frontCheckOneArgType("List", "String")
+	}
+	if name == "lines" {
+		frontCheckExpectArgCount(env, args, 0)
+		return frontCheckOneArgType("List", "String")
+	}
+	if name == "charCount" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "Int"
+	}
+	if name == "toBytes" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "Bytes"
+	}
+	if name == "toString" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "String"
+	}
+	if name == "toUpper" || name == "toLower" || name == "trim" || name == "trimStart" || name == "trimEnd" {
+		frontCheckExpectArgCount(env, args, 0)
+		return "String"
 	}
 	return "Invalid"
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -28024,7 +28024,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11129:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("eq: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11130:9
 		return "Invalid"
 	}
@@ -28036,7 +28036,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11136:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("ord: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11137:9
 		return "Invalid"
 	}
@@ -28048,7 +28048,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return "Bool"
 		}
 		// Osty: /tmp/selfhost_merged.osty:11143:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("logical: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11144:9
 		return "Invalid"
 	}
@@ -28057,7 +28057,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11147:9
 		if frontCheckTypeHead(left) != "Option" {
 			// Osty: /tmp/selfhost_merged.osty:11148:16
-			selfhostBumpError(env)
+			selfhostBumpErrorWithDetail(env, fmt.Sprintf("?? lhs: %s", left))
 			// Osty: /tmp/selfhost_merged.osty:11149:13
 			return "Invalid"
 		}
@@ -28082,7 +28082,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 			return left
 		}
 		// Osty: /tmp/selfhost_merged.osty:11162:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("bit: %s, %s", left, right))
 		// Osty: /tmp/selfhost_merged.osty:11163:9
 		return "Invalid"
 	}
@@ -28091,7 +28091,7 @@ func frontCheckBinary(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 		// Osty: /tmp/selfhost_merged.osty:11166:9
 		if !(frontCheckIsNumeric(left)) || !(frontCheckIsNumeric(right)) {
 			// Osty: /tmp/selfhost_merged.osty:11167:16
-			selfhostBumpError(env)
+			selfhostBumpErrorWithDetail(env, fmt.Sprintf("arith: %s, %s", left, right))
 			// Osty: /tmp/selfhost_merged.osty:11168:13
 			return "Invalid"
 		}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -26904,6 +26904,14 @@ func frontCheckIsAssignable(env *FrontCheckEnv, dstRaw string, srcRaw string) bo
 		// Osty: /tmp/selfhost_merged.osty:10573:9
 		return true
 	}
+	// `use X as alias { struct Foo {} fn NilFoo() -> Foo }` registers the
+	// return type in bare form (`Foo`) while call-site annotations qualify
+	// it (`alias.Foo`). The bootstrapped type table has no edge joining
+	// the two, so treat them as the same type when their last dotted
+	// segment matches modulo a bare `<identifier>.` prefix on one side.
+	if selfhostTypesAliasEqual(dst, src) {
+		return true
+	}
 	// Osty: /tmp/selfhost_merged.osty:10575:5
 	if src == "UntypedInt" {
 		// Osty: /tmp/selfhost_merged.osty:10576:9
@@ -27085,7 +27093,7 @@ func frontCheckExpectAssignable(env *FrontCheckEnv, dst string, src string) {
 		}()
 	} else {
 		// Osty: /tmp/selfhost_merged.osty:10646:12
-		selfhostBumpError(env)
+		selfhostBumpErrorWithDetail(env, fmt.Sprintf("%s <- %s", dst, src))
 	}
 }
 


### PR DESCRIPTION
## Context

PR [#311](https://github.com/choiceoh/osty/pull/311) and PR [#318](https://github.com/choiceoh/osty/pull/318) both merged on GitHub, but #318's base was the (now-closed) #311 head branch, not \`main\`. As a result the last three commits of that work never reached \`main\`:

- \`d0dcbb7\` — `feat(check): native checker primitive method table` (935 → 808)
- \`cb17c1c\` — `feat(check): alias-prefix type equivalence in frontCheckIsAssignable` (808 → 145) ← biggest single wedge
- \`f90f59d\` — `feat(check): finer telemetry for frontCheckBinary error sites` (visibility only)

This PR cherry-picks all three onto latest \`main\` so the native-checker error count on the toolchain actually drops to the number PR #318 claimed.

No content changes vs. the cherry-pick sources; commit messages preserved.

## Before / after

On \`osty check --airepair=false toolchain\`, measured against this branch tip:

| Metric | \`main\` today | This branch |
|---|---:|---:|
| Aggregate errors | **935** | **144** |
| `frontCheckIdentHint` | ~587 | 20 |
| `frontCheckCallHint` | ~31 | 2 |
| `frontCheckBinary` | ~82 | 36 |
| `frontCheckFor` | ~22 | 3 |

The remaining 144 errors break down (detail bucket from \`--dump-native-diags\`):

```
36  frontCheckBinary            (8 × String+String, 9 × Char==String — real bugs)
33  frontCheckField             (FFI struct field access; next wedge)
22  frontCheckExpectAssignable  (8 × Int<-Range, 4 × Bool<-List<Int> — real bugs)
20  frontCheckIdentHint         (local closure/scope misses)
 7  frontCheckUnary
 6  frontCheckPatternCompatible
 6  frontCheckStmt
 4  frontCheckCallSig
 3  frontCheckFor
 2  frontCheckCallHint          (Char.toInt, String.trimPrefix — toolchain bugs)
 1  frontCheckCheckMatchExhaustive
```

## Test plan

- [x] \`go test -short ./internal/check/\` passes
- [x] \`go test -short ./internal/selfhost/\` passes
- [x] \`go test -short ./cmd/osty-native-checker/\` passes
- [x] Manual: \`osty --dump-native-diags check --airepair=false toolchain\` reports 144 errors with the expected breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)