### PR TITLE
feat(check): range-based slice indexing in frontCheckIndex

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -29343,6 +29343,20 @@ func frontCheckIndex(file *AstFile, env *FrontCheckEnv, node *AstNode) string {
 	// Osty: /tmp/selfhost_merged.osty:11766:5
 	head := frontCheckTypeHead(objectType)
 	_ = head
+	// Range-based slicing: `container[start..end]`. Returns a slice of the
+	// same container shape. The bootstrapped table only supported scalar
+	// integer indexing, so every `s[0..3]` / `list[0..n]` call sites
+	// spent an error bump on `Int <- Range<...>` during assignability
+	// checking, which was the single biggest cluster left in the tail.
+	if frontCheckTypeHead(indexType) == "Range" {
+		inner := frontCheckGenericArgAt(indexType, 0)
+		if inner != "" && !frontCheckIsInteger(inner) {
+			selfhostBumpErrorWithDetail(env, fmt.Sprintf("slice-index non-integer: %s", inner))
+		}
+		if head == "List" || objectType == "String" || objectType == "Bytes" {
+			return objectType
+		}
+	}
 	// Osty: /tmp/selfhost_merged.osty:11767:5
 	if head == "List" || head == "Range" {
 		// Osty: /tmp/selfhost_merged.osty:11768:9


### PR DESCRIPTION
## Summary

Stacked on [#324](https://github.com/choiceoh/osty/pull/324). The bootstrapped native checker's \`frontCheckIndex\` required every index expression to be \`Int\`-assignable for every container type. Toolchain code uses slice-by-range forms (\`s[0..3]\`, \`s[n - 3..n]\`, \`list[a..b]\`) — each tripped \`Int <- Range<...>\` on \`frontCheckExpectAssignable\`.

Added a Range-head fast path at the top of \`frontCheckIndex\`: validates that the range's inner type is an integer, then returns the container type itself (slice of the same shape) for \`List\`, \`String\`, and \`Bytes\`. Scalar integer indexing falls through unchanged.

## Before / after

From the 144-error baseline after #324:

| Metric | Before | After |
|---|---:|---:|
| Aggregate errors | 144 | **114** |
| \`frontCheckExpectAssignable\` | 22 | **6** |
| \`frontCheckBinary\` | 36 | 22 (cascade cleanup) |

### What 16 disappeared entries look like

12 direct \`Int <- Range\` sites (the \`0..3\` / \`s[...]\` form) plus 4 \`String <- Char\` bumps that were downstream cascades of slice expressions previously returning \`Invalid\`.

### What's left in \`frontCheckExpectAssignable\`

```
6  frontCheckExpectAssignable
    4  Bool <- List<Int>       (real bug in toolchain: passing list as bool condition)
    1  Int <- ()               (real bug)
    1  List<Int> <- List<String>  (real bug)
```

## Test plan

- [x] \`go test -short ./internal/check/\` passes
- [x] \`go test -short ./internal/selfhost/\` passes
- [x] Manual: \`s[0..3]\` on String returns \`String\`; \`list[a..b]\` on List<T> returns \`List<T>\`; scalar integer indexing still returns element type

🤖 Generated with [Claude Code](https://claude.com/claude-code)