### PR TITLE
feat(backend): inject bodied stdlib fns into user IR (flag-gated)

### DIFF
--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -3,13 +3,28 @@ package backend
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
 	"github.com/osty/osty/internal/ir"
 	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
+
+// stdlibBodyLoweringEnabled reports whether the `PrepareEntry` step
+// should inject Osty-bodied stdlib functions into the user module. The
+// feature is off by default during rollout — users opt in by setting
+// `OSTY_STDLIB_BODY_LOWER=1`. Once the pipeline is stable the default
+// flips and this gate is removed.
+func stdlibBodyLoweringEnabled() bool {
+	switch os.Getenv("OSTY_STDLIB_BODY_LOWER") {
+	case "", "0", "false", "off":
+		return false
+	}
+	return true
+}
 
 // PrepareEntry lowers a checked front-end source unit into the backend-neutral
 // IR contract. Validation failures are returned as an error because they
@@ -34,6 +49,16 @@ func PrepareEntry(packageName, sourcePath string, file *ast.File, res *resolve.R
 	}
 	mod, issues := ir.Lower(packageName, file, res, chk)
 	entry.IRIssues = append(entry.IRIssues, issues...)
+	// Inject bodied stdlib functions reached from the user module before
+	// monomorphization runs, so any stdlib-owned generic body participates
+	// in the same mono pass. Rewriting callsites after injection rebinds
+	// `strings.foo(...)` to the mangled symbol the injected decl carries.
+	// Gated behind OSTY_STDLIB_BODY_LOWER during rollout.
+	if stdlibBodyLoweringEnabled() {
+		injected, injectionErrs := injectReachableStdlibBodies(mod, stdlib.LoadCached())
+		entry.IRIssues = append(entry.IRIssues, injectionErrs...)
+		mod.Decls = append(mod.Decls, injected...)
+	}
 	// Monomorphize generic free functions in-place on the lowered module.
 	// The backend contract is "no TypeVar leaves IR once it reaches the
 	// emitter", so we run this transform before validation rather than

--- a/internal/backend/entry_inject_test.go
+++ b/internal/backend/entry_inject_test.go
@@ -1,0 +1,40 @@
+package backend
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdlibBodyLoweringEnabledOff(t *testing.T) {
+	cases := []string{"", "0", "false", "off"}
+	for _, v := range cases {
+		t.Run("OSTY_STDLIB_BODY_LOWER="+v, func(t *testing.T) {
+			t.Setenv("OSTY_STDLIB_BODY_LOWER", v)
+			if stdlibBodyLoweringEnabled() {
+				t.Fatalf("enabled for %q, want disabled", v)
+			}
+		})
+	}
+}
+
+func TestStdlibBodyLoweringEnabledOn(t *testing.T) {
+	cases := []string{"1", "true", "yes", "on"}
+	for _, v := range cases {
+		t.Run("OSTY_STDLIB_BODY_LOWER="+v, func(t *testing.T) {
+			t.Setenv("OSTY_STDLIB_BODY_LOWER", v)
+			if !stdlibBodyLoweringEnabled() {
+				t.Fatalf("disabled for %q, want enabled", v)
+			}
+		})
+	}
+}
+
+func TestStdlibBodyLoweringEnabledDefaultOff(t *testing.T) {
+	// Sanity guard: unset env yields off. Running this test in a shell
+	// that exports the flag would make it fail, which is the correct
+	// behavior — "default" means unset.
+	os.Unsetenv("OSTY_STDLIB_BODY_LOWER")
+	if stdlibBodyLoweringEnabled() {
+		t.Fatalf("unset env yields enabled, want disabled default")
+	}
+}

--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -57,4 +58,64 @@ func ReachableStdlibFns(mod *ir.Module, reg *stdlib.Registry) []ReachableStdlibF
 		return found[i].Fn.Name < found[j].Fn.Name
 	})
 	return found
+}
+
+// injectReachableStdlibBodies lowers every reachable stdlib function in
+// mod, renames each lowered fn to its mangled symbol, and rewrites the
+// matching call sites in mod in place. The returned []ir.Decl must be
+// appended to the user module's Decls.
+//
+// Each stdlib module carries its own resolve.Package; this function
+// constructs a lightweight resolve.Result from the file-level Refs/
+// TypeRefs/FileScope so lowerer identifier-kind queries hit the correct
+// stdlib scope. Checker information is not currently plumbed through —
+// lowering degrades gracefully to ErrTypeVal on typed expressions,
+// which the monomorphizer + MIR validator will flag if they reach a
+// consumer that cannot handle the gap.
+//
+// A nil module or nil registry returns (nil, nil). Any lowering issue
+// is propagated as a non-fatal error; callers should surface them via
+// entry.IRIssues rather than treat them as fatal.
+func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Decl, []error) {
+	if mod == nil || reg == nil {
+		return nil, nil
+	}
+	reached := ReachableStdlibFns(mod, reg)
+	if len(reached) == 0 {
+		return nil, nil
+	}
+	var out []ir.Decl
+	var issues []error
+	for _, r := range reached {
+		res := stdlibResolveResult(reg, r.Module)
+		lowered, fnIssues := ir.LowerFnDecl(mod.Package, r.Fn, res, nil)
+		issues = append(issues, fnIssues...)
+		if lowered == nil {
+			continue
+		}
+		lowered.Name = StdlibSymbol(r.Module, r.Fn.Name)
+		out = append(out, lowered)
+	}
+	RewriteStdlibCallsites(mod, reached)
+	return out, issues
+}
+
+// stdlibResolveResult projects one stdlib module's parsed package into a
+// resolve.Result suitable for the lowerer. Returns nil if the module or
+// its parsed file is absent, which lets the lowerer degrade gracefully
+// rather than panic.
+func stdlibResolveResult(reg *stdlib.Registry, module string) *resolve.Result {
+	if reg == nil {
+		return nil
+	}
+	mod, ok := reg.Modules[module]
+	if !ok || mod == nil || mod.Package == nil || len(mod.Package.Files) == 0 {
+		return nil
+	}
+	pf := mod.Package.Files[0]
+	return &resolve.Result{
+		Refs:      pf.Refs,
+		TypeRefs:  pf.TypeRefs,
+		FileScope: pf.FileScope,
+	}
 }

--- a/internal/backend/stdlib_inject_e2e_test.go
+++ b/internal/backend/stdlib_inject_e2e_test.go
@@ -1,0 +1,68 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestInjectReachableStdlibBodiesLowersAndRewrites drives the full inject
+// helper on a user module that calls `strings.compare(a, b)`. Asserts:
+//  1. injection returns one lowered fn with the mangled symbol name
+//  2. the user callsite is rewritten to a bare Ident referencing that symbol
+//
+// Checker output is not plumbed yet (chk=nil in injectReachableStdlibBodies
+// for stdlib decls), so we do not assert types on the lowered fn body.
+func TestInjectReachableStdlibBodiesLowersAndRewrites(t *testing.T) {
+	reg := stdlib.LoadCached()
+	call := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "compare"},
+		Args: []ir.Arg{
+			{Value: &ir.Ident{Name: "a"}},
+			{Value: &ir.Ident{Name: "b"}},
+		},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{&ir.ExprStmt{X: call}},
+	}
+	injected, issues := injectReachableStdlibBodies(mod, reg)
+	for _, issue := range issues {
+		t.Logf("non-fatal issue: %v", issue)
+	}
+	if len(injected) != 1 {
+		t.Fatalf("injected = %d decls, want 1", len(injected))
+	}
+	fn, ok := injected[0].(*ir.FnDecl)
+	if !ok {
+		t.Fatalf("injected[0] = %T, want *ir.FnDecl", injected[0])
+	}
+	wantName := "osty_std_strings__compare"
+	if fn.Name != wantName {
+		t.Errorf("fn.Name = %q, want %q", fn.Name, wantName)
+	}
+	if fn.Body == nil {
+		t.Errorf("fn.Body = nil, want lowered block")
+	}
+	// Callsite rewritten?
+	ident, ok := call.Callee.(*ir.Ident)
+	if !ok {
+		t.Fatalf("callsite not rewritten: callee = %T, want *ir.Ident", call.Callee)
+	}
+	if ident.Name != wantName {
+		t.Errorf("callsite ident = %q, want %q", ident.Name, wantName)
+	}
+}
+
+func TestInjectReachableStdlibBodiesEmptyModule(t *testing.T) {
+	reg := stdlib.LoadCached()
+	mod := &ir.Module{Package: "main"}
+	injected, issues := injectReachableStdlibBodies(mod, reg)
+	if len(injected) != 0 {
+		t.Fatalf("injected = %v, want none", injected)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("issues = %v, want none", issues)
+	}
+}

--- a/internal/backend/stdlib_mangle.go
+++ b/internal/backend/stdlib_mangle.go
@@ -1,0 +1,73 @@
+package backend
+
+import (
+	"github.com/osty/osty/internal/ir"
+)
+
+// StdlibSymbol returns the mangled IR name for a stdlib function injected
+// alongside user code. The scheme is `osty_std_<module>__<name>` — the
+// `osty_std_` prefix makes the provenance obvious in generated IR, the
+// double underscore separates the module segment from the function name
+// so a future `module_with_underscore` cannot collide with a function
+// name, and only ASCII identifier characters are used so backends that
+// are strict about symbol charsets accept the result unchanged.
+//
+// StdlibSymbol does not validate its inputs — the caller has already
+// looked up the module and fn via stdlib.Registry.
+func StdlibSymbol(module, name string) string {
+	return "osty_std_" + module + "__" + name
+}
+
+// RewriteStdlibCallsites walks mod and rewrites every `module.name(...)`
+// call whose (module, name) pair is in reached to a bare call against
+// the mangled symbol. reached is the set produced by
+// ReachableStdlibFns — only calls with a matching entry are rewritten.
+// Other qualified calls (runtime FFI, unknown user aliases) are left
+// alone so their own diagnostics remain accurate.
+//
+// Rewriting happens in place on mod. Returns the number of call sites
+// that were updated; 0 means no change.
+func RewriteStdlibCallsites(mod *ir.Module, reached []ReachableStdlibFn) int {
+	if mod == nil || len(reached) == 0 {
+		return 0
+	}
+	set := map[ir.QualifiedRef]string{}
+	for _, r := range reached {
+		set[ir.QualifiedRef{Qualifier: r.Module, Name: r.Fn.Name}] = StdlibSymbol(r.Module, r.Fn.Name)
+	}
+	rw := &stdlibCallsiteRewriter{set: set}
+	ir.Walk(rw, mod)
+	return rw.count
+}
+
+type stdlibCallsiteRewriter struct {
+	set   map[ir.QualifiedRef]string
+	count int
+}
+
+func (r *stdlibCallsiteRewriter) Visit(n ir.Node) ir.Visitor {
+	call, ok := n.(*ir.CallExpr)
+	if !ok {
+		return r
+	}
+	field, ok := call.Callee.(*ir.FieldExpr)
+	if !ok {
+		return r
+	}
+	ident, ok := field.X.(*ir.Ident)
+	if !ok || ident.Name == "" || field.Name == "" {
+		return r
+	}
+	mangled, hit := r.set[ir.QualifiedRef{Qualifier: ident.Name, Name: field.Name}]
+	if !hit {
+		return r
+	}
+	call.Callee = &ir.Ident{
+		Name:  mangled,
+		Kind:  ir.IdentFn,
+		T:     field.T,
+		SpanV: field.SpanV,
+	}
+	r.count++
+	return r
+}

--- a/internal/backend/stdlib_mangle_test.go
+++ b/internal/backend/stdlib_mangle_test.go
@@ -1,0 +1,109 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/ir"
+)
+
+func TestStdlibSymbolFormat(t *testing.T) {
+	cases := []struct {
+		module, name, want string
+	}{
+		{"strings", "compare", "osty_std_strings__compare"},
+		{"collections", "groupBy", "osty_std_collections__groupBy"},
+	}
+	for _, tc := range cases {
+		if got := StdlibSymbol(tc.module, tc.name); got != tc.want {
+			t.Errorf("StdlibSymbol(%q, %q) = %q, want %q", tc.module, tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRewriteStdlibCallsitesEmpty(t *testing.T) {
+	if got := RewriteStdlibCallsites(nil, nil); got != 0 {
+		t.Fatalf("nil inputs = %d, want 0", got)
+	}
+	mod := &ir.Module{Package: "main"}
+	if got := RewriteStdlibCallsites(mod, nil); got != 0 {
+		t.Fatalf("empty reached = %d, want 0", got)
+	}
+}
+
+func TestRewriteStdlibCallsitesRewritesMatch(t *testing.T) {
+	call := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "compare"},
+		Args: []ir.Arg{
+			{Value: &ir.Ident{Name: "a"}},
+			{Value: &ir.Ident{Name: "b"}},
+		},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{&ir.ExprStmt{X: call}},
+	}
+	reached := []ReachableStdlibFn{
+		{Module: "strings", Fn: &ast.FnDecl{Name: "compare"}},
+	}
+	got := RewriteStdlibCallsites(mod, reached)
+	if got != 1 {
+		t.Fatalf("rewrite count = %d, want 1", got)
+	}
+	ident, ok := call.Callee.(*ir.Ident)
+	if !ok {
+		t.Fatalf("callee = %T, want *ir.Ident after rewrite", call.Callee)
+	}
+	if ident.Name != "osty_std_strings__compare" {
+		t.Fatalf("callee name = %q, want osty_std_strings__compare", ident.Name)
+	}
+	if ident.Kind != ir.IdentFn {
+		t.Fatalf("callee kind = %v, want IdentFn", ident.Kind)
+	}
+}
+
+func TestRewriteStdlibCallsitesLeavesNonMatchesAlone(t *testing.T) {
+	// `userAlias.compare(x)` must not be rewritten even if "compare" is reached
+	// under a different module.
+	call := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "userAlias"}, Name: "compare"},
+		Args:   []ir.Arg{{Value: &ir.Ident{Name: "x"}}},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{&ir.ExprStmt{X: call}},
+	}
+	reached := []ReachableStdlibFn{
+		{Module: "strings", Fn: &ast.FnDecl{Name: "compare"}},
+	}
+	if got := RewriteStdlibCallsites(mod, reached); got != 0 {
+		t.Fatalf("rewrite count = %d, want 0 (qualifier mismatch)", got)
+	}
+	if _, ok := call.Callee.(*ir.FieldExpr); !ok {
+		t.Fatalf("callee = %T, want unchanged *ir.FieldExpr", call.Callee)
+	}
+}
+
+func TestRewriteStdlibCallsitesRewritesNested(t *testing.T) {
+	// Inside a fn body: `fn f() { strings.compare(a, b) }`
+	inner := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "compare"},
+	}
+	fn := &ir.FnDecl{
+		Name: "f",
+		Body: &ir.Block{Stmts: []ir.Stmt{&ir.ExprStmt{X: inner}}},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Decls:   []ir.Decl{fn},
+	}
+	reached := []ReachableStdlibFn{
+		{Module: "strings", Fn: &ast.FnDecl{Name: "compare"}},
+	}
+	if got := RewriteStdlibCallsites(mod, reached); got != 1 {
+		t.Fatalf("rewrite count = %d, want 1", got)
+	}
+	if _, ok := inner.Callee.(*ir.Ident); !ok {
+		t.Fatalf("nested callee not rewritten: %T", inner.Callee)
+	}
+}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -10,6 +10,27 @@ import (
 	"github.com/osty/osty/internal/types"
 )
 
+// LowerFnDecl lowers a single Osty function declaration to its IR form.
+//
+// Unlike Lower, which consumes a whole file and its resolver/checker
+// results, LowerFnDecl is the entry point for lowering one fn body in
+// isolation — for example an Osty-bodied stdlib function being injected
+// alongside a user module. The caller supplies the resolve and check
+// results that cover fn's body; both may be nil when unavailable, with
+// the same degraded behavior as Lower (identifier kinds default to
+// IdentUnknown and expression types fall back to ErrTypeVal).
+//
+// Returns the lowered FnDecl plus any non-fatal lowering issues. A nil
+// input returns (nil, nil).
+func LowerFnDecl(pkgName string, fn *ast.FnDecl, res *resolve.Result, chk *check.Result) (*FnDecl, []error) {
+	if fn == nil {
+		return nil, nil
+	}
+	l := &lowerer{pkgName: pkgName, res: res, chk: chk}
+	out := l.lowerFnDecl(fn)
+	return out, l.issues
+}
+
 // Lower converts a type-checked Osty file into an independent IR Module.
 //
 // pkgName is the module's package name (e.g. "main"). res and chk may be

--- a/internal/ir/lower_fndecl_test.go
+++ b/internal/ir/lower_fndecl_test.go
@@ -1,0 +1,65 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+func TestLowerFnDeclNilInput(t *testing.T) {
+	fn, issues := LowerFnDecl("main", nil, nil, nil)
+	if fn != nil {
+		t.Fatalf("fn = %v, want nil", fn)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("issues = %v, want none", issues)
+	}
+}
+
+func TestLowerFnDeclMinimalBody(t *testing.T) {
+	// fn answer() -> Int { 42 }
+	body := &ast.Block{
+		Stmts: []ast.Stmt{&ast.ExprStmt{X: &ast.IntLit{Text: "42"}}},
+	}
+	fn := &ast.FnDecl{
+		Name:       "answer",
+		Pub:        true,
+		ReturnType: &ast.NamedType{Path: []string{"Int"}},
+		Body:       body,
+	}
+	out, issues := LowerFnDecl("main", fn, nil, nil)
+	if out == nil {
+		t.Fatalf("LowerFnDecl returned nil fn")
+	}
+	if out.Name != "answer" {
+		t.Fatalf("out.Name = %q, want answer", out.Name)
+	}
+	if !out.Exported {
+		t.Fatalf("out.Exported = false, want true (pub)")
+	}
+	if out.Body == nil {
+		t.Fatalf("out.Body = nil, want lowered block")
+	}
+	for _, issue := range issues {
+		t.Logf("issue: %v", issue)
+	}
+}
+
+func TestLowerFnDeclMethodSkipsReceiverAtTopLevel(t *testing.T) {
+	// A fn with Recv (method) still lowers through LowerFnDecl because the
+	// caller explicitly asked for it — top-level skip logic lives in
+	// lowerDecl, not lowerFnDecl. This matters for stdlib injection where
+	// a single method body may need standalone lowering.
+	fn := &ast.FnDecl{
+		Name: "method",
+		Recv: &ast.Receiver{Mut: true},
+		Body: &ast.Block{Stmts: []ast.Stmt{&ast.ExprStmt{X: &ast.IntLit{Text: "1"}}}},
+	}
+	out, _ := LowerFnDecl("main", fn, nil, nil)
+	if out == nil {
+		t.Fatalf("LowerFnDecl(method) = nil, want non-nil (receiver handled by caller)")
+	}
+	if !out.ReceiverMut {
+		t.Fatalf("out.ReceiverMut = false, want true")
+	}
+}

--- a/internal/ir/lower_stdlib_test.go
+++ b/internal/ir/lower_stdlib_test.go
@@ -1,0 +1,50 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestLowerFnDeclLowersStdlibStringsCompare drives LowerFnDecl against a
+// real stdlib function — strings.compare — using the stdlib's own
+// resolve.Package for identifier context. The asserts here are deliberately
+// loose (non-nil IR, no hard-fail issues): the goal is to verify that
+// LowerFnDecl is usable with stdlib-owned resolve data rather than to
+// lock in an exact IR shape that might legitimately change.
+func TestLowerFnDeclLowersStdlibStringsCompare(t *testing.T) {
+	reg := stdlib.LoadCached()
+	fn := reg.LookupFnDecl("strings", "compare")
+	if fn == nil {
+		t.Fatalf("stdlib.LookupFnDecl(strings, compare) = nil — stdlib stubs missing?")
+	}
+	mod := reg.Modules["strings"]
+	if mod == nil || mod.Package == nil || len(mod.Package.Files) == 0 {
+		t.Fatalf("stdlib strings module missing parsed package")
+	}
+	pf := mod.Package.Files[0]
+	res := &resolve.Result{
+		Refs:      pf.Refs,
+		TypeRefs:  pf.TypeRefs,
+		FileScope: pf.FileScope,
+	}
+
+	out, issues := LowerFnDecl("stdlib_strings", fn, res, nil)
+	if out == nil {
+		t.Fatalf("LowerFnDecl returned nil for strings.compare")
+	}
+	if out.Name != "compare" {
+		t.Errorf("out.Name = %q, want compare", out.Name)
+	}
+	if out.Body == nil {
+		t.Errorf("out.Body = nil, want lowered block")
+	}
+	if len(out.Params) != 2 {
+		t.Errorf("out.Params = %d, want 2", len(out.Params))
+	}
+	// Issues are non-fatal; surface them for visibility but don't fail.
+	for _, issue := range issues {
+		t.Logf("non-fatal lowering issue: %v", issue)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #320. Wires the reach scanner + LLVM018 diagnostic + `ReachableStdlibFns` collector foundation into `backend.PrepareEntry` so that Osty-bodied stdlib functions (`strings.compare`, eventually `Map.update` etc.) can flow through the IR → MIR → LLVM pipeline alongside user code.

Default **off**. Users opt in with `OSTY_STDLIB_BODY_LOWER=1`. Existing behavior is unchanged without the flag.

## What's in

- **`ir.LowerFnDecl`** (`internal/ir/lower.go`) — exposes the single-fn code path in the lowerer so callers can lower a stdlib fn AST with a custom `resolve.Result` without synthesizing a full `*ast.File`.
- **`backend.StdlibSymbol(module, name)`** + **`RewriteStdlibCallsites`** (`internal/backend/stdlib_mangle.go`) — `osty_std_<module>__<name>` mangling scheme plus an `ir.Visitor` that rewrites matching callsites from `strings.compare(...)` to bare `Ident`-callee calls against the mangled symbol.
- **`injectReachableStdlibBodies`** (`internal/backend/stdlib_inject.go`) — per-module `resolve.Result` synthesis from the registry's parsed package, single-fn lower via `ir.LowerFnDecl`, symbol rename, callsite rewrite. Checker context is intentionally nil for now — typed-body lowering lands in the next step.
- **`PrepareEntry` hook** (`internal/backend/entry.go`) — `stdlibBodyLoweringEnabled()` gates the injection between `ir.Lower` and `ir.Monomorphize`, so injected generic stdlib bodies participate in the same mono pass.

## Why

Today `toolchain/semver.osty` hits `LLVM016 unknown identifier "strings"` because the backend receives only the user `*ast.File` and never sees stdlib bodies. #320 added the reachability + lookup + diagnostic foundation; this commit turns that into an actual lowering path. The hook lands behind a flag so the change is a no-op for anyone who doesn't opt in, and the existing pre-existing `llvmgen` regressions around `strings.Split` stay unchanged — those are the LLVM014/016 gaps this work is building toward, not new damage.

## What's NOT in (remaining M2 work)

- **Checker context propagation.** `injectReachableStdlibBodies` passes `chk=nil` to the stdlib-fn lowerer today, so typed expressions in the stdlib body fall back to `ErrTypeVal`. That is enough to exercise the mechanical injection + rewrite path, but MIR lowering + the LLVM backend both need real types to emit. The follow-up is to project each stdlib module's `check.Result` into the same shape we project `resolve.Result`.
- **End-to-end `strings.compare` via `toolchain/semver.osty`.** Depends on the typed-lowering above.
- **Transitive stdlib-to-stdlib reach.** `ReachableStdlibFns` captures first-hop only by design; walking stdlib fn bodies for nested qualified calls is a separate task that belongs once the lowering path is typed end-to-end.
- **Method-receiver stdlib injection** (`Map.update`, etc.). That is the M3 track and requires a different reachability shape — methods dispatch on value type, not a module prefix.

## Tests

14 new tests, all green:

- **`ir.LowerFnDecl`** × 3 — nil input, minimal `fn answer() -> Int { 42 }`, method receiver retained (top-level skip lives in `lowerDecl`, not `lowerFnDecl`).
- **`ir.LowerFnDecl` on real stdlib** × 1 — drives the lowerer against `strings.compare` with the stdlib's own parsed package; non-nil IR, no fatal issues.
- **`backend.StdlibSymbol`** × 1 — mangling format for `strings.compare` and `collections.groupBy`.
- **`RewriteStdlibCallsites`** × 4 — empty inputs, match, qualifier mismatch is a no-op, nested callsite inside a fn body.
- **`injectReachableStdlibBodies` e2e** × 2 — real registry + real `strings.compare`: asserts one lowered fn with mangled name + callsite rewritten in place; empty module yields nothing.
- **`stdlibBodyLoweringEnabled` flag parsing** × 3 groups — off values (`""`, `"0"`, `"false"`, `"off"`), on values (`"1"`, `"true"`, `"yes"`, `"on"`), default-unset.

## Test plan

- [x] `go test ./internal/ir/ -run "TestReach|TestLowerFnDecl"`
- [x] `go test ./internal/backend/ -run "TestStdlibSymbol|TestRewrite|TestInject|TestStdlibBodyLowering|TestReachable"`
- [x] Full front + ir + stdlib regression (`lexer parser resolve check diag format lint pipeline ir stdlib`)
- [x] `OSTY_STDLIB_BODY_LOWER=1` smoke — new tests green, pre-existing llvmgen failures unchanged
- [ ] Follow-up PR: plumb `check.Result` for stdlib modules and verify end-to-end `strings.compare` via `toolchain/semver.osty`

## Risk / rollback

Additive behind a flag. `PrepareEntry` default is unchanged. Revert is one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)