### PR TITLE
[codex] fix runtime FFI alias dispatch in llvmgen

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2801,12 +2801,13 @@ func (g *generator) emitInterfaceMethodCall(call *ast.CallExpr) (value, bool, er
 	if !ok || fx == nil {
 		return value{}, false, nil
 	}
+	recvInfo, ok := g.staticExprInfo(fx.X)
+	if !ok || recvInfo.typ != "%osty.iface" {
+		return value{}, false, nil
+	}
 	recv, err := g.emitExpr(fx.X)
 	if err != nil {
 		return value{}, true, err
-	}
-	if recv.typ != "%osty.iface" {
-		return value{}, false, nil
 	}
 	iface, slot := g.findInterfaceMethod(fx.Name)
 	if iface == nil {


### PR DESCRIPTION
## What changed
The LLVM generator now only routes a field call through interface-method dispatch when the receiver statically resolves to `%osty.iface`.

## Why this changed
`emitInterfaceMethodCall` was eagerly evaluating any field-call receiver before confirming it was actually an interface value. That caused runtime FFI aliases such as `strings` in `use runtime.strings as strings { ... }` to be treated like ordinary value receivers, which then failed with `LLVM016 name: unknown identifier "strings"`.

## Impact
Runtime FFI calls like `strings.Split(...)` and downstream GC/runtime integration paths now lower correctly again instead of failing during identifier lookup.

## Root cause
The interface dispatch branch ran too early in the call-resolution order and used `emitExpr(fx.X)` before checking the receiver's static type. Guarding that path with `staticExprInfo(fx.X).typ == "%osty.iface"` keeps runtime FFI aliases on the correct lowering path.

## Validation
- `go test ./internal/llvmgen -run 'TestGenerateRuntimeFFIUsesRuntimeABI|TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields|TestGenerateManagedAggregateListsTraceNestedRoots|TestGenerateModulePtrBackedListToSetAndBoolPrint' -count=1`
- `go test ./internal/llvmgen -count=1`
