### PR TITLE
feat(backend): #[export("name")] symbol emission via MIR pipeline — §19.6 spike

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -215,12 +215,13 @@ func cloneFnDecl(fn *FnDecl) *FnDecl {
 		return nil
 	}
 	out := &FnDecl{
-		Name:        fn.Name,
-		Return:      CloneType(fn.Return),
-		Body:        cloneBlockOrNil(fn.Body),
-		ReceiverMut: fn.ReceiverMut,
-		Exported:    fn.Exported,
-		SpanV:       fn.SpanV,
+		Name:         fn.Name,
+		Return:       CloneType(fn.Return),
+		Body:         cloneBlockOrNil(fn.Body),
+		ReceiverMut:  fn.ReceiverMut,
+		Exported:     fn.Exported,
+		SpanV:        fn.SpanV,
+		ExportSymbol: fn.ExportSymbol,
 	}
 	if len(fn.Params) > 0 {
 		out.Params = make([]*Param, len(fn.Params))

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -316,6 +316,13 @@ type FnDecl struct {
 	Exported    bool
 	Generics    []*TypeParam
 	SpanV       Span
+
+	// ExportSymbol is the verbatim symbol name supplied via
+	// `#[export("name")]` (LANG_SPEC §19.6). When non-empty, the
+	// backend emits the function with this exact symbol instead of
+	// the mangled default. Applicable only to runtime-sublanguage
+	// functions in privileged packages (§19.2).
+	ExportSymbol string
 }
 
 func (*FnDecl) declNode()          {}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -105,11 +105,12 @@ func (l *lowerer) lowerDecl(d ast.Decl) Decl {
 
 func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 	out := &FnDecl{
-		Name:        fn.Name,
-		Return:      l.lowerType(fn.ReturnType),
-		ReceiverMut: fn.Recv != nil && fn.Recv.Mut,
-		Exported:    fn.Pub,
-		SpanV:       nodeSpan(fn),
+		Name:         fn.Name,
+		Return:       l.lowerType(fn.ReturnType),
+		ReceiverMut:  fn.Recv != nil && fn.Recv.Mut,
+		Exported:     fn.Pub,
+		SpanV:        nodeSpan(fn),
+		ExportSymbol: extractExportSymbol(fn.Annotations),
 	}
 	if out.Return == nil {
 		out.Return = TUnit
@@ -124,6 +125,41 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 		out.Body = l.lowerBlock(fn.Body)
 	}
 	return out
+}
+
+// extractExportSymbol reads the `#[export("name")]` annotation from a
+// declaration's annotation list (LANG_SPEC §19.6). Returns the empty
+// string when the annotation is absent or malformed; the resolver's
+// arg validator (`checkExportArgs` in internal/resolve) is the
+// authoritative place that rejects a malformed `#[export]`, so at
+// this point in the pipeline we only pick up the well-formed cases.
+func extractExportSymbol(annots []*ast.Annotation) string {
+	for _, a := range annots {
+		if a == nil || a.Name != "export" {
+			continue
+		}
+		if len(a.Args) != 1 {
+			continue
+		}
+		arg := a.Args[0]
+		if arg == nil || arg.Key != "" || arg.Value == nil {
+			continue
+		}
+		lit, ok := arg.Value.(*ast.StringLit)
+		if !ok {
+			continue
+		}
+		var buf []byte
+		for _, p := range lit.Parts {
+			if !p.IsLit {
+				// Interpolation is a resolver error; ignore here.
+				return ""
+			}
+			buf = append(buf, p.Lit...)
+		}
+		return string(buf)
+	}
+	return ""
 }
 
 func (l *lowerer) lowerParam(p *ast.Param) *Param {

--- a/internal/llvmgen/export_codegen_test.go
+++ b/internal/llvmgen/export_codegen_test.go
@@ -1,0 +1,176 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestExportSymbolFlowsThroughMIR verifies the §19.6 `#[export("name")]`
+// contract end-to-end via the MIR pipeline: a manually constructed
+// ir.FnDecl with ExportSymbol set propagates through ir → mir → LLVM
+// emission and produces `@<exact-symbol>` in the output instead of
+// the mangled default.
+//
+// This is the first backend-side test for the GC self-hosting work.
+// The corresponding front-end pieces (`#[export]` annotation, arg
+// validator, AST → IR extraction) live in PRs #284, #316, and the
+// extractExportSymbol hook added in this PR.
+func TestExportSymbolFlowsThroughMIR(t *testing.T) {
+	// Build a minimal IR module with one exported fn:
+	//   #[export("osty.gc.spike_v1")]
+	//   pub fn spike_v1() -> Int { 0 }
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:         "spike_v1",
+				ExportSymbol: "osty.gc.spike_v1",
+				Return:       &ir.PrimType{Kind: ir.PrimInt},
+				Exported:     true,
+				Body: &ir.Block{
+					Result: &ir.IntLit{Text: "0"},
+				},
+			},
+		},
+	}
+	monoMod, errs := ir.Monomorphize(mod)
+	if len(errs) > 0 {
+		t.Fatalf("monomorphize errors: %v", errs)
+	}
+	mirMod := mir.Lower(monoMod)
+	if mirMod == nil {
+		t.Fatal("mir.Lower returned nil")
+	}
+	// Verify the MIR function carries ExportSymbol.
+	var fn *mir.Function
+	for _, f := range mirMod.Functions {
+		if f != nil && f.Name == "spike_v1" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("spike_v1 not found in MIR functions; have %d functions", len(mirMod.Functions))
+	}
+	if fn.ExportSymbol != "osty.gc.spike_v1" {
+		t.Fatalf("MIR function ExportSymbol = %q, want %q", fn.ExportSymbol, "osty.gc.spike_v1")
+	}
+
+	// Now drive the MIR generator end-to-end and check the LLVM IR.
+	out, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/spike.osty"})
+	if err != nil {
+		t.Fatalf("mir generator error: %v", err)
+	}
+	ir2 := string(out)
+	// Must contain a definition for the exported symbol.
+	if !strings.Contains(ir2, "@osty.gc.spike_v1") {
+		t.Fatalf("LLVM IR missing @osty.gc.spike_v1 reference:\n%s", ir2)
+	}
+	// Must NOT contain the mangled-default form (just `@spike_v1` as a
+	// direct definition would indicate the override didn't apply).
+	// We use a strict prefix check: `define ... @spike_v1(` would be
+	// the unmangled fallback name.
+	if strings.Contains(ir2, "define i64 @spike_v1(") {
+		t.Fatalf("LLVM IR fell back to mangled-default name `@spike_v1` instead of using ExportSymbol:\n%s", ir2)
+	}
+}
+
+// TestExportSymbolEmptyFallsBackToMangled verifies the fallback path:
+// when ExportSymbol is "", emission uses fn.Name as before. Guards
+// against the spike accidentally always overriding.
+func TestExportSymbolEmptyFallsBackToMangled(t *testing.T) {
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:     "ordinary",
+				Return:   &ir.PrimType{Kind: ir.PrimInt},
+				Exported: true,
+				Body: &ir.Block{
+					Result: &ir.IntLit{Text: "42"},
+				},
+			},
+		},
+	}
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	out, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/ord.osty"})
+	if err != nil {
+		t.Fatalf("mir generator error: %v", err)
+	}
+	if !strings.Contains(string(out), "@ordinary") {
+		t.Fatalf("LLVM IR missing default fn name @ordinary:\n%s", out)
+	}
+}
+
+// TestExportSymbolFromSourceFile drives the FULL pipeline (parser →
+// resolver → check → ir.Lower → ir.Monomorphize → mir.Lower →
+// GenerateFromMIR) on a source string with `#[export("name")]` and
+// verifies the symbol survives. Without the `extractExportSymbol`
+// hook in `internal/ir/lower.go`, the front-end would discard the
+// annotation before MIR ever sees it.
+func TestExportSymbolFromSourceFile(t *testing.T) {
+	src := `
+#[export("osty.gc.test_v1")]
+pub fn test_v1() -> Int {
+    7
+}
+
+fn main() {}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+
+	// Spot-check: the `#[export]` annotation flowed into ir.FnDecl.
+	var found bool
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*ir.FnDecl); ok && fd.Name == "test_v1" {
+			if fd.ExportSymbol != "osty.gc.test_v1" {
+				t.Fatalf("ir.FnDecl ExportSymbol = %q, want %q",
+					fd.ExportSymbol, "osty.gc.test_v1")
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("test_v1 not found in IR module")
+	}
+
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	if mirMod == nil {
+		t.Fatal("mir.Lower returned nil")
+	}
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/test_export.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR error: %v", err)
+	}
+	if !strings.Contains(string(out), "@osty.gc.test_v1") {
+		t.Fatalf("LLVM IR missing the exported symbol @osty.gc.test_v1:\n%s", out)
+	}
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -745,13 +745,18 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	g.fnBuf.Reset()
 	g.gcRoots = g.gcRoots[:0]
 
+	emitName := fn.Name
+	if fn.ExportSymbol != "" {
+		emitName = fn.ExportSymbol
+	}
+
 	if fn.IsExternal {
 		// External stub: just a declare.
 		sig := g.functionTypes[fn.Name]
 		g.out.WriteString("declare ")
 		g.out.WriteString(sig.retLLVM)
 		g.out.WriteString(" @")
-		g.out.WriteString(fn.Name)
+		g.out.WriteString(emitName)
 		g.out.WriteByte('(')
 		g.out.WriteString(strings.Join(sig.paramLLVM, ", "))
 		g.out.WriteString(")\n\n")
@@ -775,7 +780,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	g.fnBuf.WriteString("define ")
 	g.fnBuf.WriteString(sig.retLLVM)
 	g.fnBuf.WriteString(" @")
-	g.fnBuf.WriteString(fn.Name)
+	g.fnBuf.WriteString(emitName)
 	g.fnBuf.WriteByte('(')
 	for i, pid := range fn.Params {
 		if i > 0 {

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -280,6 +280,7 @@ func (l *lowerer) lowerFunction(fn *ir.FnDecl, owner string, asMethod bool) *Fun
 	}
 	out := l.newFunction(symbol, params, retT, fn.SpanV, asMethod)
 	out.Exported = fn.Exported
+	out.ExportSymbol = fn.ExportSymbol
 	if fn.Body == nil {
 		out.IsExternal = true
 		// Strip blocks for external stubs: the validator rejects empty

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -128,7 +128,7 @@ type BlockID int
 // Function is one MIR function: parameters, return slot, a set of
 // named locals, a CFG of basic blocks.
 type Function struct {
-	Name        string   // mangled symbol
+	Name        string // mangled symbol
 	Params      []LocalID
 	ReturnType  Type
 	ReturnLocal LocalID
@@ -139,6 +139,12 @@ type Function struct {
 	IsIntrinsic bool
 	Exported    bool
 	SpanV       Span
+
+	// ExportSymbol is the verbatim symbol name set by `#[export("name")]`
+	// (LANG_SPEC §19.6). When non-empty, the LLVM emitter writes
+	// `@<ExportSymbol>` instead of `@<Name>`, bypassing all mangling
+	// so the function can satisfy the runtime ABI contract.
+	ExportSymbol string
 }
 
 // At returns the function's source span.


### PR DESCRIPTION
## Summary

**First backend-side spike** on the GC self-hosting path. Wires the `#[export("name")]` annotation through the four-layer pipeline (AST → IR → MIR → LLVM) so the emitter outputs `@<exact-symbol>` instead of the mangled default for runtime-sublanguage functions.

## Background

The 10-PR front-end series ([#284](https://github.com/choiceoh/osty/pull/284) – [#325](https://github.com/choiceoh/osty/pull/325)) registered the annotation, validated its arg shape, gated it to privileged packages, and proved it parses end-to-end. But nothing downstream knew about it: the AST → IR lowerer dropped the annotation, IR → MIR carried no override field, the LLVM emitter always used the mangled name. So a privileged package's

```osty
#[export("osty.gc.alloc_v1")]
#[c_abi]
#[no_alloc]
pub fn alloc_v1(bytes: Int, kind: Int) -> RawPtr { ... }
```

would emit as `@spike_v1` (or whatever the mangler produced), not the C ABI symbol the runtime needs. **This PR closes that gap.**

## What this PR adds

| Layer | Change |
|---|---|
| `ir.FnDecl` | New `ExportSymbol string` field (cloned correctly) |
| `ir.lowerFnDecl` | New `extractExportSymbol(annots)` extracts the string-literal arg from `#[export("...")]` |
| `mir.Function` | New `ExportSymbol string` field |
| `mir.lowerFunction` | Propagates `ir.FnDecl.ExportSymbol` → `mir.Function.ExportSymbol` |
| `llvmgen.emitFunction` | Uses `ExportSymbol` when non-empty for both `define ... @<name>` and `declare ... @<name>` |

`fn.Name` remains the lookup key for `g.functionTypes` so signature lookup still works — only the emitted `@<name>` changes.

## Test evidence (3 cases)

```
$ go test ./internal/llvmgen/ -run TestExportSymbol
ok (3/3 pass)
```

- **`TestExportSymbolFlowsThroughMIR`** — manual ir.Module with ExportSymbol set; verifies MIR carries it AND LLVM IR contains `@osty.gc.spike_v1`, NOT the mangled-default fallback.
- **`TestExportSymbolEmptyFallsBackToMangled`** — fn without ExportSymbol still emits `@<fn.Name>`.
- **`TestExportSymbolFromSourceFile`** — full source-level pipeline: parser → resolver (privileged=true) → check → ir.Lower → Monomorphize → mir.Lower → GenerateFromMIR. Source: `#[export("osty.gc.test_v1")] pub fn test_v1() -> Int { 7 }`. Verifies the IR FnDecl carries the right ExportSymbol AND the LLVM IR contains `@osty.gc.test_v1`.

## Deliberately out of scope (follow-up spikes)

- **`#[c_abi]` calling convention emission** — emit `ccc` attribute. Same plumbing pattern as `ExportSymbol`; lands as a separate spike to keep this PR's diff focused.
- **Legacy AST emitter (`generateASTFile`) integration** — the default `GenerateModule(ir.Module)` path still rebuilds an AST and uses the legacy emitter. The MIR pipeline (`GenerateFromMIR`) is opt-in (`Options.UseMIR`). For now `#[export]` works through the MIR path; default callers fall through to the unchanged legacy emitter. Hooking the legacy emitter is a separate PR (touches `legacyFnDeclFromIR`).
- **Generics / methods carrying `#[export]`** — §19.6 restricts `#[export]` to top-level fn declarations. Generic / method semantics deliberately undefined; resolver gate restricts the surface upstream.

## Pre-existing failures

`TestGenerateSafepointKeepsImmutable...` and several other llvmgen tests fail on current main (`LLVM016 unknown identifier "strings"`) — verified by stashing this PR's changes and confirming the same failures persist. **Unrelated to this work.**

## Spec references

- LANG_SPEC §19.6 (annotation table — `#[export("name")]`)
- LANG_SPEC §19.7 (lowering — exact symbol, dso_local preemption)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/llvmgen/ -run TestExportSymbol` — 3/3 pass
- [ ] Privileged source `#[export("foo.bar")] pub fn baz() -> Int` produces LLVM `@foo.bar`
- [ ] Ordinary fn (no annotation) still emits `@<fn.Name>`
- [ ] Pre-existing test failures unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)