### PR TITLE
feat(backend): #[c_abi] → ccc calling-convention emission — §19.6 spike

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -222,6 +222,7 @@ func cloneFnDecl(fn *FnDecl) *FnDecl {
 		Exported:     fn.Exported,
 		SpanV:        fn.SpanV,
 		ExportSymbol: fn.ExportSymbol,
+		CABI:         fn.CABI,
 	}
 	if len(fn.Params) > 0 {
 		out.Params = make([]*Param, len(fn.Params))

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -323,6 +323,14 @@ type FnDecl struct {
 	// the mangled default. Applicable only to runtime-sublanguage
 	// functions in privileged packages (§19.2).
 	ExportSymbol string
+
+	// CABI is set when the function carries `#[c_abi]` (LANG_SPEC
+	// §19.6). The backend emits the function with the platform's C
+	// calling convention (`ccc` in LLVM) rather than Osty's calling
+	// convention. Almost always paired with `#[export("name")]` so
+	// the symbol can satisfy the runtime ABI contract; the two
+	// annotations are independently representable in the IR.
+	CABI bool
 }
 
 func (*FnDecl) declNode()          {}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -132,6 +132,7 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 		Exported:     fn.Pub,
 		SpanV:        nodeSpan(fn),
 		ExportSymbol: extractExportSymbol(fn.Annotations),
+		CABI:         hasNamedAnnotation(fn.Annotations, "c_abi"),
 	}
 	if out.Return == nil {
 		out.Return = TUnit
@@ -154,6 +155,19 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 // arg validator (`checkExportArgs` in internal/resolve) is the
 // authoritative place that rejects a malformed `#[export]`, so at
 // this point in the pipeline we only pick up the well-formed cases.
+// hasNamedAnnotation reports whether `annots` contains an annotation
+// with the given name. Used by `lowerFnDecl` for bare-flag annotations
+// (`#[c_abi]`, `#[no_alloc]`, `#[intrinsic]`) where presence alone is
+// the signal — argument shape is the resolver's responsibility.
+func hasNamedAnnotation(annots []*ast.Annotation, name string) bool {
+	for _, a := range annots {
+		if a != nil && a.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func extractExportSymbol(annots []*ast.Annotation) string {
 	for _, a := range annots {
 		if a == nil || a.Name != "export" {

--- a/internal/llvmgen/c_abi_codegen_test.go
+++ b/internal/llvmgen/c_abi_codegen_test.go
@@ -1,0 +1,159 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestCABIFlowsThroughMIR verifies the §19.6 `#[c_abi]` contract
+// end-to-end via the MIR pipeline: a manually constructed ir.FnDecl
+// with CABI = true propagates through ir → mir → LLVM emission and
+// causes the `ccc` calling-convention keyword to appear in the
+// emitted `define` line.
+func TestCABIFlowsThroughMIR(t *testing.T) {
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:     "abi_v1",
+				CABI:     true,
+				Return:   &ir.PrimType{Kind: ir.PrimInt},
+				Exported: true,
+				Body: &ir.Block{
+					Result: &ir.IntLit{Text: "0"},
+				},
+			},
+		},
+	}
+	monoMod, errs := ir.Monomorphize(mod)
+	if len(errs) > 0 {
+		t.Fatalf("monomorphize errors: %v", errs)
+	}
+	mirMod := mir.Lower(monoMod)
+	if mirMod == nil {
+		t.Fatal("mir.Lower returned nil")
+	}
+	var fn *mir.Function
+	for _, f := range mirMod.Functions {
+		if f != nil && f.Name == "abi_v1" {
+			fn = f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("abi_v1 not found in MIR functions")
+	}
+	if !fn.CABI {
+		t.Fatalf("MIR function CABI = false, want true")
+	}
+
+	out, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/cabi.osty"})
+	if err != nil {
+		t.Fatalf("mir generator error: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "define ccc i64 @abi_v1") {
+		t.Fatalf("LLVM IR missing `define ccc` for CABI fn:\n%s", got)
+	}
+}
+
+// TestCABINotSetEmitsDefault verifies the absence path: CABI=false
+// produces the same output as before this PR (no `ccc` keyword).
+func TestCABINotSetEmitsDefault(t *testing.T) {
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:     "ordinary_v1",
+				Return:   &ir.PrimType{Kind: ir.PrimInt},
+				Exported: true,
+				Body: &ir.Block{
+					Result: &ir.IntLit{Text: "0"},
+				},
+			},
+		},
+	}
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	out, err := GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/ord.osty"})
+	if err != nil {
+		t.Fatalf("mir generator error: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "define ccc") {
+		t.Fatalf("ordinary fn must not emit `ccc`:\n%s", got)
+	}
+	if !strings.Contains(got, "define i64 @ordinary_v1") {
+		t.Fatalf("ordinary fn missing default emit:\n%s", got)
+	}
+}
+
+// TestCABIFromSourceFile drives the FULL pipeline (parser → resolver
+// → check → ir.Lower → ir.Monomorphize → mir.Lower → GenerateFromMIR)
+// on a source string with `#[c_abi]` (and the canonical paired
+// `#[export]` + `#[no_alloc]`) and verifies BOTH the symbol name
+// override and the calling-convention keyword survive.
+func TestCABIFromSourceFile(t *testing.T) {
+	src := `
+#[export("osty.gc.cabi_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn cabi_v1() -> Int {
+    9
+}
+
+fn main() {}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	var found *ir.FnDecl
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*ir.FnDecl); ok && fd.Name == "cabi_v1" {
+			found = fd
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("cabi_v1 not found in IR module")
+	}
+	if !found.CABI {
+		t.Fatal("ir.FnDecl CABI = false, expected true (#[c_abi] not propagated from AST)")
+	}
+	if found.ExportSymbol != "osty.gc.cabi_v1" {
+		t.Fatalf("ExportSymbol = %q, want osty.gc.cabi_v1", found.ExportSymbol)
+	}
+
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/cabi_e2e.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR error: %v", err)
+	}
+	got := string(out)
+	want := "define ccc i64 @osty.gc.cabi_v1"
+	if !strings.Contains(got, want) {
+		t.Fatalf("LLVM IR missing combined `%s`:\n%s", want, got)
+	}
+}

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -749,11 +749,22 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	if fn.ExportSymbol != "" {
 		emitName = fn.ExportSymbol
 	}
+	// `#[c_abi]` requests the platform C calling convention. LLVM
+	// IR syntax: `declare [cconv] <ret> @<name>(...)`. The `ccc`
+	// keyword goes before the return type. Default is also `ccc`,
+	// so the explicit keyword is currently a documentation/forward-
+	// compatibility marker rather than a behaviour change — but
+	// emitting it makes intent visible in the generated IR.
+	cconv := ""
+	if fn.CABI {
+		cconv = "ccc "
+	}
 
 	if fn.IsExternal {
 		// External stub: just a declare.
 		sig := g.functionTypes[fn.Name]
 		g.out.WriteString("declare ")
+		g.out.WriteString(cconv)
 		g.out.WriteString(sig.retLLVM)
 		g.out.WriteString(" @")
 		g.out.WriteString(emitName)
@@ -778,6 +789,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	// Signature line.
 	sig := g.functionTypes[fn.Name]
 	g.fnBuf.WriteString("define ")
+	g.fnBuf.WriteString(cconv)
 	g.fnBuf.WriteString(sig.retLLVM)
 	g.fnBuf.WriteString(" @")
 	g.fnBuf.WriteString(emitName)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -281,6 +281,7 @@ func (l *lowerer) lowerFunction(fn *ir.FnDecl, owner string, asMethod bool) *Fun
 	out := l.newFunction(symbol, params, retT, fn.SpanV, asMethod)
 	out.Exported = fn.Exported
 	out.ExportSymbol = fn.ExportSymbol
+	out.CABI = fn.CABI
 	if fn.Body == nil {
 		out.IsExternal = true
 		// Strip blocks for external stubs: the validator rejects empty

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -145,6 +145,12 @@ type Function struct {
 	// `@<ExportSymbol>` instead of `@<Name>`, bypassing all mangling
 	// so the function can satisfy the runtime ABI contract.
 	ExportSymbol string
+
+	// CABI is set when the function carries `#[c_abi]` (LANG_SPEC
+	// §19.6). The LLVM emitter inserts the `ccc` calling-convention
+	// keyword in the `define`/`declare` line so the function uses
+	// the platform's C calling convention.
+	CABI bool
 }
 
 // At returns the function's source span.


### PR DESCRIPTION
## Summary

Twelfth spike on the GC self-hosting path. Mirror of [#329](https://github.com/choiceoh/osty/pull/329) for the sibling annotation: `#[c_abi]` now propagates through the same ir.FnDecl → mir.Function → llvmgen pipeline and causes the LLVM emitter to insert the `ccc` calling-convention keyword in the `define`/`declare` line.

## Background

LANG_SPEC §19.6 says `#[c_abi]` instructs the backend to "use the platform C calling convention rather than Osty's calling convention" and that it is "almost always paired with `#[export]`". PR [#329](https://github.com/choiceoh/osty/pull/329) wired `#[export]` end-to-end. **This PR completes the pair** — both annotations now flow from source to LLVM IR.

## What this PR adds

Mirrors the #329 surface 1:1:

| Change | File |
|---|---|
| `ir.FnDecl.CABI bool` + clone propagation | `internal/ir/ir.go`, `internal/ir/clone.go` |
| `hasNamedAnnotation` helper for bare-flag annotations | `internal/ir/lower.go` |
| `mir.Function.CABI bool` + propagation | `internal/mir/mir.go`, `internal/mir/lower.go` |
| Emit `ccc` keyword in `define`/`declare` | `internal/llvmgen/mir_generator.go` |
| 3 tests | `internal/llvmgen/c_abi_codegen_test.go` (new) |

The new `hasNamedAnnotation` helper will serve future bare-flag annotations (`#[no_alloc]`, `#[intrinsic]`, `#[pod]`) when they need IR-side propagation.

## Note on observability

LLVM's default calling convention IS `ccc`, so the explicit keyword does not change behaviour today. The point is:
1. **Make intent visible** in the generated IR (so a reviewer can confirm the runtime ABI surface).
2. **Preserve the contract** when Osty's default calling convention later switches to a non-`ccc` form (e.g. `fastcc` for native fns).

The combined `define ccc i64 @osty.gc.alloc_v1` line is what the runtime ABI consumer expects to see for forward-compat reviews.

## Test evidence (3 cases)

```
$ go test ./internal/llvmgen/ -run TestCABI
ok (3/3 pass)
```

- **`TestCABIFlowsThroughMIR`** — manual ir.Module with CABI=true → `define ccc i64 @abi_v1`
- **`TestCABINotSetEmitsDefault`** — fn without `#[c_abi]` does not emit `ccc` (regression guard)
- **`TestCABIFromSourceFile`** — full source-level pipeline on the canonical `#[export("osty.gc.cabi_v1")] #[c_abi] #[no_alloc] pub fn cabi_v1() -> Int { 9 }` → `define ccc i64 @osty.gc.cabi_v1` — both annotations cooperating end-to-end

## Spec references

- LANG_SPEC §19.6 (`#[c_abi]` table entry)
- LANG_SPEC §19.7 (lowering — Osty/C calling convention split)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/llvmgen/ -run TestCABI` — 3/3 pass
- [ ] Source `#[c_abi] pub fn foo() -> Int` → LLVM `define ccc i64 @foo`
- [ ] Source `#[export("x")] #[c_abi]` → LLVM `define ccc i64 @x`
- [ ] Ordinary fn (no annotations) → `define i64 @foo` (no `ccc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)