### PR TITLE
feat(check): register FFI struct types + fields during UseDecl collect

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -25411,6 +25411,31 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 				func() struct{} { env.fns = append(env.fns, sig); return struct{}{} }()
 				// Osty: /tmp/selfhost_merged.osty:9836:17
 				frontCheckRecordSymbol(env, itemIdx, item, "fn", sig.name, alias, frontCheckFnType(sig.paramTypes, sig.returnType))
+			} else if ostyEqual(item.kind, AstNodeKind(&AstNodeKind_AstNStructDecl{})) {
+				// `use go "..." as alias { struct Foo { field: T, ... } }`:
+				// register the struct under both its bare name (`Foo`) and
+				// the qualified `alias.Foo` form so field access resolves
+				// regardless of how the receiver type is spelled in the
+				// call site. Without this pass every FFI struct field
+				// access bumped through the frontCheckField tail (see the
+				// host.SymbolRef.Pkg / LoadResult.Error / Diff.Added
+				// clusters in --dump-native-diags).
+				generics := frontCheckGenericNames(file, item.children2)
+				_ = generics
+				qualified := fmt.Sprintf("%s.%s", ostyToString(alias), ostyToString(item.text))
+				env.types = append(env.types, &FrontTypeSig{name: item.text, generics: generics})
+				env.types = append(env.types, &FrontTypeSig{name: qualified, generics: generics})
+				frontCheckRecordSymbol(env, itemIdx, item, "struct", item.text, alias, frontCheckGenericOwnerType(item.text, generics, make([]*FrontTypeSubst, 0, 1)))
+				for _, memberIdx := range item.children {
+					member := astArenaNodeAt(file.arena, memberIdx)
+					if ostyEqual(member.kind, AstNodeKind(&AstNodeKind_AstNField_{})) {
+						fieldType := frontCheckTypeName(file, member.right)
+						hasDefault := member.left >= 0
+						env.fields = append(env.fields, &FrontFieldSig{owner: item.text, name: member.text, typeName: fieldType, hasDefault: hasDefault})
+						env.fields = append(env.fields, &FrontFieldSig{owner: qualified, name: member.text, typeName: fieldType, hasDefault: hasDefault})
+						frontCheckRecordSymbol(env, memberIdx, member, "field", member.text, item.text, fieldType)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Stacked on [#326](https://github.com/choiceoh/osty/pull/326). The native checker's \`frontCheckCollectDecl\` UseDecl branch registered only \`fn\` items from FFI blocks. Every \`struct Foo { ... }\` declaration inside a \`use go \"...\" as alias { ... }\` was silently dropped, so field access \`val.fieldName\` on a value whose type came from the block had no target in \`env.fields\` and bumped out through the \`frontCheckField\` tail.

## What changed

When collecting a UseDecl, also walk \`AstNStructDecl\` items. For each:

- Register the struct type under both the bare name (\`Foo\`) and the qualified form (\`alias.Foo\`), so return-type annotations like \`fn NilFoo() -> Foo\` resolve regardless of how the call site spells the receiver.
- Register every \`AstNField_\` member in \`env.fields\` under both owner spellings, so field lookup succeeds against either form.
- Emit one \`frontCheckRecordSymbol\` per struct + field so structural IDE output stays in sync.

Function items (the existing branch) are untouched. Struct methods are not supported here — FFI blocks in toolchain today declare none.

## Before / after

From the 114-error baseline after #326:

| Metric | Before | After |
|---|---:|---:|
| Aggregate errors | 114 | **70** |
| \`frontCheckField\` | 33 | **0** |
| \`frontCheckBinary\` | 22 | 21 (cascade cleanup) |
| \`frontCheckIdentHint\` | 20 | 13 (cascade cleanup) |

Cumulative across the session (from the 1674 starting point): **−96%**.

### What's left
Session-remaining 70 errors are dominated by:
- **21 frontCheckBinary** (8 × String+String spec violations, 9 × Char==String suspicious)
- **13 frontCheckIdentHint** (local closure / scope misses)
- **7 frontCheckUnary**
- **6 frontCheckExpectAssignable** (3 real toolchain bugs: Bool<-List<Int>, Int<-(), List<Int><-List<String>)
- **6 each frontCheckPatternCompatible / frontCheckStmt**
- **4 frontCheckCallSig**
- **2 frontCheckCallHint** (Char.toInt, String.trimPrefix — toolchain bugs)
- **1 frontCheckCheckMatchExhaustive**

## Test plan

- [x] \`go test -short ./internal/check/\` passes
- [x] \`go test -short ./internal/selfhost/\` passes
- [x] Manual: \`osty --dump-native-diags check --airepair=false toolchain\` reports 70 errors; the frontCheckField bucket is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)