### PR TITLE
feat(backend): #[intrinsic] → ir.FnDecl.IsIntrinsic propagation — §19.5 spike

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -223,6 +223,7 @@ func cloneFnDecl(fn *FnDecl) *FnDecl {
 		SpanV:        fn.SpanV,
 		ExportSymbol: fn.ExportSymbol,
 		CABI:         fn.CABI,
+		IsIntrinsic:  fn.IsIntrinsic,
 	}
 	if len(fn.Params) > 0 {
 		out.Params = make([]*Param, len(fn.Params))

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -331,6 +331,15 @@ type FnDecl struct {
 	// the symbol can satisfy the runtime ABI contract; the two
 	// annotations are independently representable in the IR.
 	CABI bool
+
+	// IsIntrinsic is set when the function carries `#[intrinsic]`
+	// (LANG_SPEC §19.5 / §19.6). The body is a placeholder; the
+	// backend supplies the implementation at each call site (the
+	// 13 §19.5 `raw.*` intrinsics map to specific LLVM IR sequences
+	// per §19.7). The MIR pipeline currently bails on functions
+	// where this is set — backends must add per-intrinsic dispatch
+	// before the pipeline can consume them.
+	IsIntrinsic bool
 }
 
 func (*FnDecl) declNode()          {}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -133,6 +133,7 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 		SpanV:        nodeSpan(fn),
 		ExportSymbol: extractExportSymbol(fn.Annotations),
 		CABI:         hasNamedAnnotation(fn.Annotations, "c_abi"),
+		IsIntrinsic:  hasNamedAnnotation(fn.Annotations, "intrinsic"),
 	}
 	if out.Return == nil {
 		out.Return = TUnit

--- a/internal/llvmgen/intrinsic_propagation_test.go
+++ b/internal/llvmgen/intrinsic_propagation_test.go
@@ -1,0 +1,143 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestIntrinsicFlagFlowsThroughIRAndMIR verifies the §19.5 / §19.6
+// `#[intrinsic]` annotation propagates through the front-end into
+// `ir.FnDecl.IsIntrinsic` and onward to `mir.Function.IsIntrinsic`.
+//
+// The flag exists from earlier work; this PR is the first to set it
+// from the user-facing annotation. The MIR backend already refuses
+// to compile modules containing intrinsic functions ("mir-mvp:
+// intrinsic function declaration X") — that guard now becomes
+// reachable from source.
+func TestIntrinsicFlagFlowsThroughIRAndMIR(t *testing.T) {
+	// Bodyless `#[intrinsic]` declaration matching the stdlib stub
+	// form (`std.runtime.raw.null`, etc.).
+	src := `
+#[intrinsic]
+pub fn raw_null() -> Int
+
+fn main() {}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := ir.Lower("main", file, res, chk)
+
+	// IR-side check.
+	var found *ir.FnDecl
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*ir.FnDecl); ok && fd.Name == "raw_null" {
+			found = fd
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("raw_null not in IR module decls")
+	}
+	if !found.IsIntrinsic {
+		t.Fatal("ir.FnDecl.IsIntrinsic not set from #[intrinsic] annotation")
+	}
+
+	// MIR-side propagation.
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	var mirFn *mir.Function
+	for _, f := range mirMod.Functions {
+		if f != nil && f.Name == "raw_null" {
+			mirFn = f
+			break
+		}
+	}
+	if mirFn == nil {
+		t.Fatal("raw_null not in MIR module functions")
+	}
+	if !mirFn.IsIntrinsic {
+		t.Fatal("mir.Function.IsIntrinsic not propagated from ir.FnDecl")
+	}
+}
+
+// TestIntrinsicAbsenceIsFalse — regression guard: a fn without
+// `#[intrinsic]` must not have IsIntrinsic = true. Catches accidental
+// always-true setters in the lowerer.
+func TestIntrinsicAbsenceIsFalse(t *testing.T) {
+	src := `
+pub fn ordinary() -> Int { 42 }
+
+fn main() {}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, _ := ir.Lower("main", file, res, chk)
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*ir.FnDecl); ok && fd.Name == "ordinary" {
+			if fd.IsIntrinsic {
+				t.Fatal("plain fn must not have IsIntrinsic=true")
+			}
+		}
+	}
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	for _, f := range mirMod.Functions {
+		if f != nil && f.Name == "ordinary" && f.IsIntrinsic {
+			t.Fatal("plain fn's MIR Function must not have IsIntrinsic=true")
+		}
+	}
+}
+
+// TestIntrinsicCausesMIRBackendBail wires the propagation into the
+// MIR LLVM backend and verifies the existing "unsupported" guard
+// fires. This is the safety net: before per-intrinsic LLVM lowering
+// lands, any `#[intrinsic]` fn in a compiled module produces a
+// clear error rather than silently emitting a body-less stub.
+func TestIntrinsicCausesMIRBackendBail(t *testing.T) {
+	mod := &ir.Module{
+		Package: "main",
+		Decls: []ir.Decl{
+			&ir.FnDecl{
+				Name:        "raw_null",
+				IsIntrinsic: true,
+				Return:      &ir.PrimType{Kind: ir.PrimInt},
+				Exported:    true,
+			},
+		},
+	}
+	monoMod, _ := ir.Monomorphize(mod)
+	mirMod := mir.Lower(monoMod)
+	_, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/intrinsic.osty",
+	})
+	if err == nil {
+		t.Fatal("expected MIR backend to bail on intrinsic fn, got nil error")
+	}
+	if !strings.Contains(err.Error(), "intrinsic") {
+		t.Fatalf("expected error to mention 'intrinsic', got: %v", err)
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -282,6 +282,7 @@ func (l *lowerer) lowerFunction(fn *ir.FnDecl, owner string, asMethod bool) *Fun
 	out.Exported = fn.Exported
 	out.ExportSymbol = fn.ExportSymbol
 	out.CABI = fn.CABI
+	out.IsIntrinsic = fn.IsIntrinsic
 	if fn.Body == nil {
 		out.IsExternal = true
 		// Strip blocks for external stubs: the validator rejects empty


### PR DESCRIPTION
## Summary

Thirteenth spike on the GC self-hosting path. Wires `#[intrinsic]` through the same ir.FnDecl → mir.Function pipeline used by `#[export]` ([#329](https://github.com/choiceoh/osty/pull/329)) and `#[c_abi]` ([#330](https://github.com/choiceoh/osty/pull/330)). The MIR backend's existing `IsIntrinsic` guard now becomes reachable from source — any module containing a user-declared `#[intrinsic]` fn fails the backend with a clear `intrinsic function declaration X` error rather than silently emitting a body-less stub.

## Background

The `mir.Function.IsIntrinsic` field has existed since the print-family work but **no code path ever set it from source**. With this PR, `#[intrinsic]` declarations (LANG_SPEC §19.5 / §19.6 — used by every fn in `std.runtime.raw.osty`) flow through to the flag, hardening the contract that intrinsics need per-call-site backend lowering before they can compile.

## What this PR adds

Mirrors the #329 / #330 plumbing 1:1:

| Change | File |
|---|---|
| `ir.FnDecl.IsIntrinsic bool` + clone | `internal/ir/ir.go`, `internal/ir/clone.go` |
| Populate from `#[intrinsic]` via `hasNamedAnnotation` | `internal/ir/lower.go` |
| Propagate to `mir.Function.IsIntrinsic` | `internal/mir/lower.go` |
| 3 tests | `internal/llvmgen/intrinsic_propagation_test.go` (new) |

## Test evidence (3 cases)

```
$ go test ./internal/llvmgen/ -run TestIntrinsic
ok (3/3 pass)
```

- **`TestIntrinsicFlagFlowsThroughIRAndMIR`** — source-level `#[intrinsic] pub fn raw_null() -> Int` (body-less, matching stdlib stub form) → ir.FnDecl.IsIntrinsic = true → mir.Function.IsIntrinsic = true
- **`TestIntrinsicAbsenceIsFalse`** — regression guard: ordinary fn does NOT carry the flag at either layer
- **`TestIntrinsicCausesMIRBackendBail`** — verifies the existing backend guard fires with `intrinsic function declaration` so an accidental intrinsic in a compiled module fails fast

## Note on `raw.null()` actual lowering

This PR sets up the propagation; it does NOT yet emit `ptr null` at `raw.null()` call sites. A probe test (now removed) demonstrated that `raw.null()` currently parses as `*ir.MethodCall` and the native checker assigns it `*ir.ErrType` because stdlib member-access type inference for `use std.runtime.raw` is not yet flowing the return type back.

**Full intrinsic lowering needs three follow-up pieces:**
1. Native checker support for typed stdlib member access (`raw.null()` carries a real `RawPtr` return type)
2. New `mir.IntrinsicRawNull` (and 12 siblings) enum entries + dispatch in `lowerCallExprInto`
3. LLVM emit cases in `emitIntrinsic` mapping each kind to its §19.7 IR sequence

Each is a separate spike. This PR is the smallest piece that moves the runtime-sublanguage backend pipeline forward without depending on those.

## Spec references

- LANG_SPEC §19.5 (intrinsic declaration form)
- LANG_SPEC §19.6 (annotation table)
- LANG_SPEC §19.7 (per-intrinsic LLVM IR mapping — for follow-ups)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/llvmgen/ -run TestIntrinsic` — 3/3 pass
- [ ] `go test -short ./...` — no new failures
- [ ] User-source `#[intrinsic] pub fn foo() -> Int` produces clear backend error if compiled

🤖 Generated with [Claude Code](https://claude.com/claude-code)