### PR TITLE
feat(ir): #[no_alloc] / #[pod] / #[repr(c)] → IR propagation

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -224,6 +224,7 @@ func cloneFnDecl(fn *FnDecl) *FnDecl {
 		ExportSymbol: fn.ExportSymbol,
 		CABI:         fn.CABI,
 		IsIntrinsic:  fn.IsIntrinsic,
+		NoAlloc:      fn.NoAlloc,
 	}
 	if len(fn.Params) > 0 {
 		out.Params = make([]*Param, len(fn.Params))
@@ -245,6 +246,8 @@ func cloneStructDecl(s *StructDecl) *StructDecl {
 		Name:     s.Name,
 		Exported: s.Exported,
 		SpanV:    s.SpanV,
+		Pod:      s.Pod,
+		ReprC:    s.ReprC,
 	}
 	if len(s.Fields) > 0 {
 		out.Fields = make([]*Field, len(s.Fields))

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -340,6 +340,14 @@ type FnDecl struct {
 	// where this is set — backends must add per-intrinsic dispatch
 	// before the pipeline can consume them.
 	IsIntrinsic bool
+
+	// NoAlloc is set when the function carries `#[no_alloc]`
+	// (LANG_SPEC §19.6.1). The front-end body walker
+	// (`internal/check/noalloc.go`) is the authoritative enforcer;
+	// this field exists so backends and tooling can identify the
+	// allocation-free contract without re-reading annotations. No
+	// codegen behavior is currently attached.
+	NoAlloc bool
 }
 
 func (*FnDecl) declNode()          {}
@@ -385,6 +393,20 @@ type StructDecl struct {
 	Generics []*TypeParam
 	Exported bool
 	SpanV    Span
+
+	// Pod is set when the struct carries `#[pod]` (LANG_SPEC §19.4).
+	// The front-end shape checker (`internal/check/podshape.go`) is
+	// the authoritative validator that the struct meets the §19.4
+	// derivation rules; this field exists so downstream backends and
+	// tooling can identify Pod structs without re-walking annotations.
+	Pod bool
+
+	// ReprC is set when the struct carries `#[repr(c)]` (LANG_SPEC
+	// §19.6). Required on any `#[pod]` struct (§19.4) and on any
+	// struct passed across a `#[c_abi]` boundary or used with
+	// `raw.read`/`raw.write`. The backend will use this to lock the
+	// field layout to C ABI when codegen for §19 lands.
+	ReprC bool
 }
 
 func (*StructDecl) declNode()          {}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -134,6 +134,7 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 		ExportSymbol: extractExportSymbol(fn.Annotations),
 		CABI:         hasNamedAnnotation(fn.Annotations, "c_abi"),
 		IsIntrinsic:  hasNamedAnnotation(fn.Annotations, "intrinsic"),
+		NoAlloc:      hasNamedAnnotation(fn.Annotations, "no_alloc"),
 	}
 	if out.Return == nil {
 		out.Return = TUnit
@@ -229,6 +230,8 @@ func (l *lowerer) lowerStructDecl(sd *ast.StructDecl) *StructDecl {
 		Name:     sd.Name,
 		Exported: sd.Pub,
 		SpanV:    nodeSpan(sd),
+		Pod:      hasNamedAnnotation(sd.Annotations, "pod"),
+		ReprC:    hasNamedAnnotation(sd.Annotations, "repr"),
 	}
 	for _, gp := range sd.Generics {
 		out.Generics = append(out.Generics, l.lowerTypeParam(gp, sd.Name))

--- a/internal/ir/runtime_annot_propagation_test.go
+++ b/internal/ir/runtime_annot_propagation_test.go
@@ -1,0 +1,138 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// lowerSrc parses, resolves, and lowers a privileged-mode source
+// snippet to an ir.Module. Used by the runtime-annotation IR
+// propagation tests.
+func lowerSrc(t *testing.T, src string) *Module {
+	t.Helper()
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse: %v", parseDiags)
+	}
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := Lower("main", file, res, chk)
+	return mod
+}
+
+// --- #[no_alloc] -> ir.FnDecl.NoAlloc ---
+
+func TestNoAllocFlowsToFnDecl(t *testing.T) {
+	src := `
+#[no_alloc]
+pub fn pure_arith(a: Int, b: Int) -> Int {
+    a + b
+}
+`
+	mod := lowerSrc(t, src)
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*FnDecl); ok && fd.Name == "pure_arith" {
+			if !fd.NoAlloc {
+				t.Fatal("ir.FnDecl.NoAlloc not set from #[no_alloc]")
+			}
+			return
+		}
+	}
+	t.Fatal("pure_arith not in module decls")
+}
+
+func TestNoAllocAbsenceIsFalse(t *testing.T) {
+	src := `pub fn ordinary() -> Int { 0 }`
+	mod := lowerSrc(t, src)
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*FnDecl); ok && fd.Name == "ordinary" && fd.NoAlloc {
+			t.Fatal("plain fn must not carry NoAlloc")
+		}
+	}
+}
+
+// --- #[pod] / #[repr] -> ir.StructDecl.Pod / ReprC ---
+
+func TestPodFlowsToStructDecl(t *testing.T) {
+	src := `
+#[pod]
+#[repr(c)]
+pub struct Header {
+    pub size: Int32,
+}
+`
+	mod := lowerSrc(t, src)
+	for _, decl := range mod.Decls {
+		if sd, ok := decl.(*StructDecl); ok && sd.Name == "Header" {
+			if !sd.Pod {
+				t.Fatal("ir.StructDecl.Pod not set from #[pod]")
+			}
+			if !sd.ReprC {
+				t.Fatal("ir.StructDecl.ReprC not set from #[repr(c)]")
+			}
+			return
+		}
+	}
+	t.Fatal("Header not in module decls")
+}
+
+func TestPodAbsenceIsFalse(t *testing.T) {
+	src := `pub struct User { pub name: String }`
+	mod := lowerSrc(t, src)
+	for _, decl := range mod.Decls {
+		if sd, ok := decl.(*StructDecl); ok && sd.Name == "User" {
+			if sd.Pod {
+				t.Fatal("plain struct must not carry Pod")
+			}
+			if sd.ReprC {
+				t.Fatal("plain struct must not carry ReprC")
+			}
+			return
+		}
+	}
+	t.Fatal("User not in module decls")
+}
+
+// --- combined: every runtime annotation in one fn ---
+
+func TestAllRuntimeAnnotationsCoexistOnFn(t *testing.T) {
+	src := `
+#[export("osty.gc.combo_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn combo_v1() -> Int {
+    7
+}
+`
+	mod := lowerSrc(t, src)
+	for _, decl := range mod.Decls {
+		if fd, ok := decl.(*FnDecl); ok && fd.Name == "combo_v1" {
+			if fd.ExportSymbol != "osty.gc.combo_v1" {
+				t.Errorf("ExportSymbol = %q", fd.ExportSymbol)
+			}
+			if !fd.CABI {
+				t.Error("CABI not set")
+			}
+			if !fd.NoAlloc {
+				t.Error("NoAlloc not set")
+			}
+			if fd.IsIntrinsic {
+				t.Error("IsIntrinsic must NOT be set (no #[intrinsic])")
+			}
+			return
+		}
+	}
+	t.Fatal("combo_v1 not in module decls")
+}


### PR DESCRIPTION
## Summary

Fourteenth spike on the GC self-hosting path. **Completes the IR-side propagation of every runtime-sublanguage annotation** introduced by the §19 front-end series.

The previous spikes wired `#[export]` ([#329](https://github.com/choiceoh/osty/pull/329)), `#[c_abi]` ([#330](https://github.com/choiceoh/osty/pull/330)), and `#[intrinsic]` ([#334](https://github.com/choiceoh/osty/pull/334)) through to ir + mir. This PR adds the three remaining bare-flag annotations as declarative metadata so downstream consumers can identify the contract without re-walking AST annotations.

## What this PR adds

| Field | Where | Source annotation |
|---|---|---|
| `ir.FnDecl.NoAlloc bool` | new field + clone | `#[no_alloc]` |
| `ir.StructDecl.Pod bool` | new field + clone | `#[pod]` |
| `ir.StructDecl.ReprC bool` | new field + clone | `#[repr(c)]` |

All three populated in `internal/ir/lower.go` via the `hasNamedAnnotation` helper introduced by [#330](https://github.com/choiceoh/osty/pull/330).

## Why these three are pure plumbing

| Annotation | Authoritative validator | This PR's IR field |
|---|---|---|
| `#[no_alloc]` | `internal/check/noalloc.go` body walker (PR #288) | tooling/analysis handle |
| `#[pod]` | `internal/check/podshape.go` shape checker (PR #295) | backend Pod-recognition handle |
| `#[repr(c)]` | (no current validator — accepted bare-flag) | future C ABI layout handle |

No new codegen behavior — the backend will consume these when §19 native lowering lands.

## Test evidence (5 cases)

```
$ go test ./internal/ir/ -run "TestNoAlloc|TestPod|TestAllRuntime"
ok (5/5 pass)
```

- `TestNoAllocFlowsToFnDecl` — `#[no_alloc] pub fn pure_arith(...)` → IR field set
- `TestNoAllocAbsenceIsFalse` — regression guard
- `TestPodFlowsToStructDecl` — `#[pod] #[repr(c)] pub struct Header` → both fields set
- `TestPodAbsenceIsFalse` — regression guard for ordinary structs
- `TestAllRuntimeAnnotationsCoexistOnFn` — full canonical stack `#[export("osty.gc.combo_v1")] #[c_abi] #[no_alloc]` → ExportSymbol + CABI + NoAlloc all set, IsIntrinsic NOT set

## After this PR

**Every §19.6 annotation is now representable in the IR.** The front-end → IR boundary is closed.

### Remaining backend work
1. **Native checker stdlib member type inference** — so `raw.null()` carries `RawPtr` instead of `ErrType`
2. **Per-intrinsic dispatch + LLVM emit** for the 13 §19.5 intrinsics (`raw.null` → `ptr null`, `raw.alloc` → shim call, etc.)
3. **Legacy emitter integration** so `#[export]` / `#[c_abi]` apply in the default `GenerateModule` path (currently MIR-pipeline opt-in only)

## Spec references

- LANG_SPEC §19.4 (Pod marker)
- LANG_SPEC §19.6 (annotation table — `#[no_alloc]`, `#[pod]`, `#[repr(c)]`)
- LANG_SPEC §19.6.1 (no_alloc body discipline)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/ir/...` green
- [ ] `go test -short ./...` — no NEW failures (pre-existing LLVM016 failures unrelated)
- [ ] Source-level `#[no_alloc]` / `#[pod]` / `#[repr(c)]` reach IR fields
- [ ] Combined annotation stack populates all relevant fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)