### PR TITLE
feat(check): bind top-level pub let UpperName constants at collect time

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -25378,7 +25378,25 @@ func frontCheckCollectDecl(file *AstFile, env *FrontCheckEnv, declIdx int, decl 
 		// Osty: /tmp/selfhost_merged.osty:9823:9
 		if declared != "()" && declared != "Invalid" {
 			// Osty: /tmp/selfhost_merged.osty:9824:13
-			frontCheckBindPattern(file, env, decl.left, declared, decl.flags == 1)
+			// Top-level `pub let UpperName = …` is a constant binding,
+			// but the pattern-binding helpers (frontCheckBindPattern /
+			// frontCheckPatternIsBindingIdent) treat UpperName-style
+			// ident patterns as enum-variant matches and skip the bind.
+			// Valid at body scope (refutable match), wrong at file
+			// scope where the let is a constant. Bypass the filter so
+			// names like CheckFormat / ManifestCore land in
+			// env.bindings and subsequent ident lookups resolve.
+			if decl.left >= 0 {
+				pat := astArenaNodeAt(file.arena, decl.left)
+				if pat != nil && frontCheckPatternKind(pat) == "ident" {
+					name := frontCheckPatternName(pat)
+					if name != "" && name != "_" {
+						frontCheckBindNode(env, name, declared, decl.flags == 1, decl.left, pat.start, pat.end)
+					}
+				} else {
+					frontCheckBindPattern(file, env, decl.left, declared, decl.flags == 1)
+				}
+			}
 		}
 		// Osty: /tmp/selfhost_merged.osty:9826:9
 		return


### PR DESCRIPTION
## Summary

Stacked on [#333](https://github.com/choiceoh/osty/pull/333). \`frontCheckCollectDecl\`'s AstNLet branch delegated to \`frontCheckBindPattern\`, which in turn routes ident patterns through \`frontCheckPatternIsBindingIdent\`. That helper rejects any identifier that starts with an uppercase letter — a reasonable heuristic for body-level match patterns where \`UpperName\` means "match this variant", but wrong at file scope where the same \`pub let UpperName\` is a constant declaration.

Sites like \`pub let CheckFormat: CheckName = \"format\"\` therefore never landed in \`env.bindings\`, and every subsequent reference (\`skipped(CheckFormat)\` etc.) bumped through \`frontCheckIdentHint\`.

## Before / after

From the 70-error baseline after #333:

| Metric | Before | After |
|---|---:|---:|
| Aggregate errors | 70 | **58** |
| \`frontCheckIdentHint\` | 13 | **1** |

12 identifier misses disappeared, all from the \`toolchain/ci.osty\` cluster: \`CheckFormat\`, \`CheckLint\`, \`CheckLockfile\`, \`CheckPolicy\`, \`CheckRelease\`, \`CheckSemver\` (each used in two call sites).

Cumulative across the session (from the 1674 starting point): **−97%**.

## Scope

Only affects file-scope let declarations. Non-ident patterns (tuple, struct destructuring) still route through \`frontCheckBindPattern\` unchanged. Body-level lets are untouched — their uppercase-name filter still applies so \`let Some(x) = …\` continues to be interpreted as a variant match.

## Test plan

- [x] \`go test -short ./internal/check/\` passes
- [x] \`go test -short ./internal/selfhost/\` passes
- [x] Manual: \`osty --dump-native-diags check --airepair=false toolchain\` reports 58 errors, with frontCheckIdentHint down to 1 (the remaining single entry is \`msg\` — a closure-capture issue in unrelated code)

## Remaining 58 errors

```
21  frontCheckBinary            (8 × String+String spec violations, rest cascades)
 7  frontCheckUnary
 6  frontCheckExpectAssignable  (Bool<-List<Int>, Int<-(), List<Int><-List<String> — real bugs)
 6  frontCheckPatternCompatible
 6  frontCheckStmt
 4  frontCheckCallSig
 2  frontCheckCallHint          (Char.toInt, String.trimPrefix — toolchain bugs)
 1  frontCheckCheckMatchExhaustive
 1  frontCheckIdentHint
```

Most of what's left is real toolchain bugs (spec violations in string concatenation, invalid type assumptions). Further checker-side reductions would need deeper semantic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)