### PR TITLE
feat(backend): legacy GenerateModule emits #[export] aliases — §19.6

### DIFF
--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -30,7 +30,57 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return generateASTFile(file, opts)
+	out, err := generateASTFile(file, opts)
+	if err != nil {
+		return nil, err
+	}
+	return appendExportAliases(out, mod), nil
+}
+
+// appendExportAliases scans the IR module for `*ostyir.FnDecl` with
+// non-empty `ExportSymbol` (set from `#[export("name")]` per
+// LANG_SPEC §19.6) and appends an LLVM IR `alias` line per fn:
+//
+//	@<symbol> = dso_local alias ptr, ptr @<fn.Name>
+//
+// This makes the export symbol resolvable at link time without
+// renaming the function (which would break in-module call sites).
+// The MIR pipeline (`GenerateFromMIR`, opt-in via Options.UseMIR)
+// uses a different mechanism — it overrides the emitted name
+// directly because MIR has no internal callers in the v0.4
+// surface today. Both paths converge at link-time on the same
+// exported symbol name.
+//
+// For C ABI purposes the LLVM-IR-side alias type need only be
+// `ptr` — the linker resolves the symbol by name and the C
+// consumer's header carries the actual function signature.
+func appendExportAliases(out []byte, mod *ostyir.Module) []byte {
+	if mod == nil {
+		return out
+	}
+	var aliases []byte
+	for _, decl := range mod.Decls {
+		fn, ok := decl.(*ostyir.FnDecl)
+		if !ok || fn == nil {
+			continue
+		}
+		if fn.ExportSymbol == "" || fn.ExportSymbol == fn.Name {
+			continue
+		}
+		aliases = append(aliases, "@"...)
+		aliases = append(aliases, fn.ExportSymbol...)
+		aliases = append(aliases, " = dso_local alias ptr, ptr @"...)
+		aliases = append(aliases, fn.Name...)
+		aliases = append(aliases, '\n')
+	}
+	if len(aliases) == 0 {
+		return out
+	}
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	out = append(out, aliases...)
+	return out
 }
 
 func moduleUnsupportedDiagnostic(mod *ostyir.Module) (UnsupportedDiagnostic, bool) {

--- a/internal/llvmgen/legacy_export_alias_test.go
+++ b/internal/llvmgen/legacy_export_alias_test.go
@@ -1,0 +1,122 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestLegacyExportAliasEmitsBothSymbols verifies the §19.6
+// `#[export("name")]` annotation produces an LLVM `alias` line in
+// the default `GenerateModule` (legacy) emit path.
+//
+// Background: PR #329 wired ExportSymbol through the MIR pipeline
+// (`GenerateFromMIR`, opt-in via `Options.UseMIR`). Default callers
+// route through `GenerateModule` → `legacyFileFromModule` →
+// `generateASTFile`, which never knew about `#[export]`. This PR
+// adds a post-process step in `GenerateModule` that scans the IR
+// module for ExportSymbol-bearing fns and appends one alias line
+// per fn so the export symbol is link-resolvable without renaming
+// the underlying function (which would break in-module callers).
+func TestLegacyExportAliasEmitsBothSymbols(t *testing.T) {
+	src := `
+#[export("osty.gc.legacy_v1")]
+pub fn legacy_v1() -> Int { 11 }
+
+fn main() {}
+`
+	out := buildLegacyIR(t, src)
+	got := string(out)
+
+	if !strings.Contains(got, "define i64 @legacy_v1(") {
+		t.Errorf("expected `define i64 @legacy_v1(` in IR — original fn name should remain:\n%s", got)
+	}
+	if !strings.Contains(got, "@osty.gc.legacy_v1 = dso_local alias ptr, ptr @legacy_v1") {
+		t.Errorf("expected alias `@osty.gc.legacy_v1 = ... alias ptr, ptr @legacy_v1` in IR:\n%s", got)
+	}
+}
+
+// TestLegacyExportAliasMultipleFns verifies the post-process loop
+// handles every #[export]-tagged fn, not just the first.
+func TestLegacyExportAliasMultipleFns(t *testing.T) {
+	src := `
+#[export("osty.gc.first_v1")]
+pub fn first() -> Int { 1 }
+
+#[export("osty.gc.second_v1")]
+pub fn second() -> Int { 2 }
+
+fn main() {}
+`
+	out := buildLegacyIR(t, src)
+	got := string(out)
+	for _, sym := range []string{"osty.gc.first_v1", "osty.gc.second_v1"} {
+		if !strings.Contains(got, "@"+sym+" = dso_local alias") {
+			t.Errorf("missing alias for `%s`:\n%s", sym, got)
+		}
+	}
+}
+
+// TestLegacyNoExportAliasForOrdinaryFn — regression guard:
+// ordinary functions (no #[export]) must not produce alias lines.
+func TestLegacyNoExportAliasForOrdinaryFn(t *testing.T) {
+	src := `
+pub fn ordinary() -> Int { 0 }
+
+fn main() {}
+`
+	out := buildLegacyIR(t, src)
+	got := string(out)
+	if strings.Contains(got, "= dso_local alias ptr") {
+		t.Errorf("ordinary fn must not produce alias:\n%s", got)
+	}
+}
+
+// TestLegacyExportAliasRedundantNameSkipped — when ExportSymbol
+// equals the fn's existing name (no rename needed), don't emit a
+// no-op alias `@foo = alias ptr, ptr @foo`.
+func TestLegacyExportAliasRedundantNameSkipped(t *testing.T) {
+	src := `
+#[export("redundant")]
+pub fn redundant() -> Int { 0 }
+
+fn main() {}
+`
+	out := buildLegacyIR(t, src)
+	got := string(out)
+	if strings.Contains(got, "@redundant = dso_local alias") {
+		t.Errorf("redundant alias (same name) must be skipped:\n%s", got)
+	}
+}
+
+// buildLegacyIR drives the full source-level pipeline through
+// `GenerateModule` (the default, legacy AST-based emit path) and
+// returns the raw LLVM IR bytes.
+func buildLegacyIR(t *testing.T, src string) []byte {
+	t.Helper()
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, _ := ir.Lower("main", file, res, chk)
+	monoMod, _ := ir.Monomorphize(mod)
+	out, err := GenerateModule(monoMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/legacy_export_test.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateModule error: %v", err)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Sixteenth spike on the GC self-hosting path. Closes the gap that made `#[export("name")]` invisible to the **default `GenerateModule` emit path**.

PR [#329](https://github.com/choiceoh/osty/pull/329) wired ExportSymbol through the MIR pipeline (opt-in via `Options.UseMIR`); this PR adds the legacy AST-based path so the export symbol reaches the linker regardless of which backend dispatch a caller uses.

## Background

The default `GenerateModule` reifies IR → AST and hands off to `generateASTFile`. Neither layer knew about `#[export]`, so a privileged user package compiled through the default path emitted `@legacy_v1` rather than `@osty.gc.legacy_v1`. The MIR pipeline solved this by **overriding** the emitted `@<name>` directly, but that mechanism doesn't work for the legacy AST emitter — it would also break in-module call sites that reference the original name.

## What this PR adds

```go
// appendExportAliases scans the IR module for *ir.FnDecl with
// non-empty ExportSymbol and appends one alias line per fn:
//
//   @<symbol> = dso_local alias ptr, ptr @<fn.Name>
```

| Property | Behavior |
|---|---|
| Original `define` line | preserved (in-module callers continue to resolve) |
| Export symbol | added as a linker alias, `dso_local` preemption |
| Alias type | `ptr` — for ABI purposes the linker resolves by symbol name; C consumer's header carries the function signature |
| `ExportSymbol == fn.Name` | skipped (no no-op self-alias) |

## Test evidence (4 cases)

```
$ go test ./internal/llvmgen/ -run "TestLegacyExportAlias|TestLegacyNoExport"
ok (4/4 pass)
```

| Test | Coverage |
|---|---|
| `TestLegacyExportAliasEmitsBothSymbols` | flagship: source `#[export("osty.gc.legacy_v1")] pub fn legacy_v1()` produces both the `define` line AND the alias |
| `TestLegacyExportAliasMultipleFns` | every #[export]-tagged fn gets its alias |
| `TestLegacyNoExportAliasForOrdinaryFn` | ordinary fn produces no alias (regression guard) |
| `TestLegacyExportAliasRedundantNameSkipped` | `ExportSymbol == fn.Name` produces no self-alias |

## After this PR

**Both backend paths now honor `#[export]`:**
- MIR pipeline: overrides emitted name ([#329](https://github.com/choiceoh/osty/pull/329))
- Legacy AST path: keeps the name + emits a linker alias (this PR)

Both converge at link time on the same exported symbol, so a runtime ABI consumer linking against `@osty.gc.alloc_v1` works regardless of which Osty backend produced the object file.

`#[c_abi]` legacy integration is a separate follow-up — same pattern likely (function attribute on the alias or post-process attribute injection).

## Pre-existing failure

`TestGenerateModuleStdTestingExpectOkCompat` fails on current main too — verified by stashing this PR's changes and re-running. Unrelated.

## Spec references

- LANG_SPEC §19.6 (`#[export("name")]`)
- LANG_SPEC §19.7 (lowering — exact symbol, dso_local preemption)
- LANG_SPEC §19.11 implementation status table — should be updated next sync
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/llvmgen/ -run "TestLegacyExportAlias|TestLegacyNoExport"` — 4/4 pass
- [ ] `go test -short ./...` — no NEW failures (pre-existing failure unrelated)
- [ ] Source `#[export("foo.bar")] pub fn baz()` → both `@baz` and `@foo.bar` in IR
- [ ] Ordinary fn produces no alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)