### PR TITLE
fix(bootstrap/gen): drop bare `return` before match-arm let-binding bodies

### DIFF
--- a/internal/bootstrap/gen/expr.go
+++ b/internal/bootstrap/gen/expr.go
@@ -3800,7 +3800,6 @@ func (g *gen) emitIfLetInner(ie *ast.IfExpr, asExpr bool) {
 	g.body.indent()
 	g.emitPatternBindings(tmp, scrutT, ie.Pattern)
 	if asExpr {
-		g.body.write("return ")
 		g.emitArmBody(ie.Then)
 		g.body.nl()
 	} else {
@@ -3816,7 +3815,6 @@ func (g *gen) emitIfLetInner(ie *ast.IfExpr, asExpr bool) {
 		g.body.writeln("} else {")
 		g.body.indent()
 		if asExpr {
-			g.body.write("return ")
 			g.emitArmBody(els)
 			g.body.nl()
 		} else {

--- a/internal/bootstrap/gen/match.go
+++ b/internal/bootstrap/gen/match.go
@@ -118,7 +118,6 @@ func (g *gen) emitMatchArm(scrut string, scrutType types.Type, arm *ast.MatchArm
 // emitted.
 func (g *gen) emitArmTrailer(body ast.Expr, asExpr bool) {
 	if asExpr {
-		g.body.write("return ")
 		g.emitArmBody(body)
 		g.body.nl()
 		return
@@ -134,25 +133,25 @@ func (g *gen) emitArmTrailer(body ast.Expr, asExpr bool) {
 	g.body.nl()
 }
 
-// emitArmBody writes the arm's body expression. A Block body is
-// evaluated via IIFE-free inlining: its final expression becomes the
-// return value.
+// emitArmBody writes `[stmts;] return tailExpr` for the arm body.
+// A Block body has its leading statements emitted inline and its final
+// expression lifted into the return; a bare expression is returned directly.
+// Callers must not pre-emit `return ` — this function owns the full return
+// statement so multi-stmt blocks don't produce a bare `return` before the
+// bindings (see Bug 2 in bootstrap/gen).
 func (g *gen) emitArmBody(body ast.Expr) {
 	if b, ok := body.(*ast.Block); ok && len(b.Stmts) > 0 {
 		last := b.Stmts[len(b.Stmts)-1]
 		if es, ok := last.(*ast.ExprStmt); ok {
-			// emit prior stmts inline, then return the last expr.
-			if len(b.Stmts) > 1 {
-				g.body.writeln("")
-				for _, s := range b.Stmts[:len(b.Stmts)-1] {
-					g.emitStmt(s)
-				}
-				g.body.write("return ")
+			for _, s := range b.Stmts[:len(b.Stmts)-1] {
+				g.emitStmt(s)
 			}
+			g.body.write("return ")
 			g.emitExpr(es.X)
 			return
 		}
 	}
+	g.body.write("return ")
 	g.emitExpr(body)
 }
 


### PR DESCRIPTION
## Summary

- `emitArmTrailer` was pre-emitting `return ` before delegating to `emitArmBody`. For multi-stmt block arm bodies like `{ let x = ...; tail-expr }`, `emitArmBody` then wrote a newline + the let bindings + a *second* `return tail-expr`, leaving the first `return` orphaned on its own line. The emitted Go failed to compile (`not enough return values`).
- Same path was used by `if let` arms via the shared helper, so both forms were broken.
- Refactor: `emitArmBody` now owns the whole `[stmts;] return tail` emission. The three call sites (match arm, if-let then, if-let else) no longer pre-write `return `. Single-stmt and bare-expr arm bodies emit the same Go as before.

## Why

Discovered while auditing `internal/bootstrap/gen` lowering bugs. Without the fix, any `toolchain/*.osty` author writing a natural multi-binding match arm hits an unbuildable seed — current toolchain code avoids the shape only by accident.

## Verification

- Reproducer: `match x { 0 -> { let a = 10; a + 1 }, _ -> -1 }` — pre-fix produces `return\n a := 10\n return a + 1` (Go rejects); post-fix produces clean `a := 10\n return a + 1` and runs correctly.
- `go test -count=1 -run TestToolchainCheckerSourcesTranspile ./internal/selfhost/...` — passes (~6 min). This exercises the real `osty-bootstrap-gen` on the merged toolchain checker source.
- `go test -short ./internal/check/... ./internal/parser/... ./internal/resolve/...` — green.

## Out of scope

Audited four other suspected bootstrap/gen bugs in the same pass:
- if-return + tail value mangling — could not reproduce in HEAD
- early `return` inside match arm escapes IIFE not outer fn — real, but the proper fix needs match-as-statement form (deferred)
- generic `List<T>` element type lost in monomorph — real, deferred
- `std.strings.foo` undefined — root cause is a self-host checker failure, not a `bootstrap/gen` lowering bug

## Test plan

- [ ] CI green
- [ ] Reviewer eyes on the `emitArmBody` ownership change — confirm callers don't have other code paths that still expect a pre-emitted `return `

🤖 Generated with [Claude Code](https://claude.com/claude-code)