### PR TITLE
docs(spec): §19.11 — legacy #[export] alias landed (#341), #[c_abi] no-op

### DIFF
--- a/LANG_SPEC_v0.5/19-runtime-primitives.md
+++ b/LANG_SPEC_v0.5/19-runtime-primitives.md
@@ -597,15 +597,20 @@ in the same PR that lands a new piece.
 | `ir.StructDecl.Pod bool` from `#[pod]` | landed | #336 |
 | `ir.StructDecl.ReprC bool` from `#[repr(c)]` | landed | #336 |
 
-**MIR / LLVM emit.** Partial — the MIR pipeline (`GenerateFromMIR`,
-opt-in via `Options.UseMIR`) honors `ExportSymbol` and `CABI`.
+**MIR / LLVM emit.** Both backend paths now honor `#[export]`. The
+MIR pipeline (`GenerateFromMIR`, opt-in via `Options.UseMIR`)
+overrides the emitted `@<name>` directly; the legacy
+`GenerateModule` (default) preserves the original define and
+appends an `alias` line so in-module callers continue to resolve
+while the export symbol is link-reachable.
 
 | Piece | Status | PR |
 |---|---|---|
-| MIR `Function.ExportSymbol` + `define @<symbol>` override | landed (MIR path only) | #329 |
-| MIR `Function.CABI` + `define ccc <ret> @<sym>(...)` emission | landed (MIR path only) | #330 |
-| MIR `Function.IsIntrinsic` propagation + backend-bail safety net | landed (MIR path only) | #334 |
-| Legacy `GenerateModule(IR)` honoring `#[export]` / `#[c_abi]` | **deferred** | — |
+| MIR `Function.ExportSymbol` + `define @<symbol>` override | landed (MIR path) | #329 |
+| MIR `Function.CABI` + `define ccc <ret> @<sym>(...)` emission | landed (MIR path) | #330 |
+| MIR `Function.IsIntrinsic` propagation + backend-bail safety net | landed (MIR path) | #334 |
+| Legacy `GenerateModule(IR)` emits `@<symbol> = dso_local alias ptr, ptr @<fn>` per `#[export]`-tagged fn | landed (legacy path) | #341 |
+| Legacy `GenerateModule(IR)` honoring `#[c_abi]` | n/a — LLVM's default cc is `ccc`, so the legacy path is already correct semantically. The MIR path emits the `ccc ` keyword for documentation; if Osty later switches its native cc to a non-`ccc` form the legacy path will need a post-process inject. | — |
 | Per-intrinsic LLVM emit for the 13 §19.5 `raw.*` intrinsics | **deferred** | — |
 | §19.7 lowering table (`raw.null` → `inttoptr i64 0`, etc.) | **deferred** | — |
 | §19.10 safepoint compiler-emitted root array | **deferred** | — |


### PR DESCRIPTION
## Summary

Seventeenth §19 contribution. Updates the implementation status table introduced by [#339](https://github.com/choiceoh/osty/pull/339) to reflect [#341](https://github.com/choiceoh/osty/pull/341) (legacy `GenerateModule` emits `#[export]` aliases) and clarifies why `#[c_abi]` does not need legacy-path integration.

## Status table changes

The old row `Legacy GenerateModule(IR) honoring #[export] / #[c_abi]` was a single **deferred** line. Split into two with their actual states:

| Piece | Status | PR |
|---|---|---|
| Legacy `GenerateModule(IR)` emits `@<symbol> = dso_local alias ptr, ptr @<fn>` per `#[export]`-tagged fn | **landed (legacy path)** | [#341](https://github.com/choiceoh/osty/pull/341) |
| Legacy `GenerateModule(IR)` honoring `#[c_abi]` | **n/a** — LLVM's default cc is `ccc`, so the legacy path is already correct semantically. The MIR path emits the keyword for documentation. | — |

## Why `#[c_abi]` is n/a in the legacy path

LLVM's default calling convention IS `ccc`. The MIR path emits the keyword explicitly for documentation/forward-compat; the legacy path is already semantically correct without it. If Osty later switches its native cc to a non-`ccc` form (e.g. `fastcc` for native fns), a post-process inject will be needed — but that work is contingent on a future cc change, not on §19.

## Section preamble update

Rewrote the MIR / LLVM emit preamble to describe both paths cooperating:
- **MIR pipeline**: overrides the emitted `@<name>` directly
- **Legacy path**: preserves the original define and appends an `alias` line

Both paths converge at link time on the same exported symbol.

## After this PR

The MIR / LLVM emit row group has **4 landed pieces** and **3 deferred**. Deferred work, all blocked on the native checker stdlib member type inference gap (separately tracked):

1. Per-intrinsic LLVM emit for the 13 §19.5 `raw.*` intrinsics
2. §19.7 lowering table (`raw.null` → `inttoptr i64 0`, etc.)
3. §19.10 safepoint compiler-emitted root array

## Tests

- `go build ./...` green (docs-only)

## Spec references

- LANG_SPEC §19.6 (`#[export]`, `#[c_abi]`)
- LANG_SPEC §19.7 (lowering)
- LANG_SPEC §19.11 (this update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)