### PR TITLE
fix(bootstrap/gen): lift match w/ escape arms out of IIFE (bug #3)

### DIFF
--- a/internal/bootstrap/gen/gen.go
+++ b/internal/bootstrap/gen/gen.go
@@ -219,6 +219,13 @@ type gen struct {
 	// emitQuestion. Nil when no lift is in progress.
 	questionSubs map[*ast.QuestionExpr]string
 
+	// matchSubs maps a MatchExpr that has been hoisted out of
+	// expression position to the Go identifier holding its value.
+	// Populated by preLiftMatches when an arm body contains a `return`
+	// (which the IIFE form would silently swallow); consumed by
+	// emitMatch. Nil when no match lift is in progress.
+	matchSubs map[*ast.MatchExpr]string
+
 	// instQueue is the pending list of generic-fn monomorphizations
 	// that still need to be emitted. emitCall appends to this queue
 	// each time it encounters a generic call site whose (sym, type

--- a/internal/bootstrap/gen/match.go
+++ b/internal/bootstrap/gen/match.go
@@ -17,7 +17,16 @@ import (
 // A trailing `panic("unreachable match")` covers the non-exhaustive
 // case. Actual exhaustiveness checking is the type checker's job; the
 // transpiler just runs the generated code honestly.
+//
+// When the enclosing statement has lifted this match into statement
+// position (because an arm body contains an explicit `return`), the
+// IIFE is replaced by a reference to the result var recorded in
+// g.matchSubs — see preLiftMatches.
 func (g *gen) emitMatch(m *ast.MatchExpr) {
+	if sub, ok := g.matchSubs[m]; ok {
+		g.body.write(sub)
+		return
+	}
 	retType := "any"
 	if t := g.typeOf(m); t != nil && !types.IsError(t) && !types.IsUnit(t) {
 		retType = g.goType(t)

--- a/internal/bootstrap/gen/match_lift.go
+++ b/internal/bootstrap/gen/match_lift.go
@@ -1,0 +1,421 @@
+package gen
+
+import (
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/types"
+)
+
+// preLiftMatches walks `e` and lifts each MatchExpr whose arm bodies
+// contain a `return` (or other escape that must reach the enclosing
+// Osty function) out of expression position into a statement-position
+// lowering. Each lifted match is recorded in g.matchSubs so the
+// subsequent emitMatch on that node writes the result-var name instead
+// of the IIFE form.
+//
+// Why: the default match emission wraps arms in an IIFE
+// (`func() T { ... }()`). A bare `return X` inside an arm body
+// returns from the IIFE — not from the enclosing Osty function. Used
+// in non-tail position (e.g. `let x = match e { Pat -> { return X } }`)
+// the value X is silently bound to x and the outer function keeps
+// running. Lifting the match into a statement-form lowering puts the
+// arm bodies directly in the outer Go function, so `return` propagates
+// correctly.
+//
+// The walk skips control-flow / closure boundaries to mirror
+// preLiftQuestions: a match nested inside an `if` arm, closure, or
+// block is not lifted from this call. Each consumer runs its own
+// preLiftMatches when it emits its arm bodies (see
+// emitArmTrailerLifted and emitStmt's per-kind paths).
+func (g *gen) preLiftMatches(e ast.Expr) {
+	if e == nil {
+		return
+	}
+	var ms []*ast.MatchExpr
+	g.walkDirectMatches(e, &ms)
+	if len(ms) == 0 {
+		return
+	}
+	if g.matchSubs == nil {
+		g.matchSubs = map[*ast.MatchExpr]string{}
+	}
+	for _, m := range ms {
+		if _, already := g.matchSubs[m]; already {
+			continue
+		}
+		if !matchEscapes(m) {
+			continue
+		}
+		tmp := g.freshVar("_ml")
+		// Save and restore the substitution map across the recursive
+		// lowering: emitMatchLifted emits arm-body statements through
+		// the regular emitStmt path, whose per-kind defer-resets would
+		// otherwise wipe our in-progress outer entries. The inner
+		// scope gets its own fresh map; ours is restored afterwards.
+		saved := g.matchSubs
+		g.matchSubs = nil
+		g.emitMatchLifted(tmp, m)
+		g.matchSubs = saved
+		g.matchSubs[m] = tmp
+	}
+}
+
+// resetMatchSubs clears the substitution map at statement boundary.
+func (g *gen) resetMatchSubs() { g.matchSubs = nil }
+
+// walkDirectMatches collects MatchExpr nodes reachable from `e`
+// without crossing closure or control-flow boundaries. The traversal
+// is preorder in source order, so when a tainted match contains
+// another tainted match in its scrutinee position the inner one is
+// lifted first.
+//
+// IfExpr / Block / ClosureExpr branches are not descended: a match
+// nested inside one of those is consumed by the inner emitter, which
+// runs its own preLiftMatches.
+func (g *gen) walkDirectMatches(e ast.Expr, out *[]*ast.MatchExpr) {
+	if e == nil {
+		return
+	}
+	switch e := e.(type) {
+	case *ast.MatchExpr:
+		g.walkDirectMatches(e.Scrutinee, out)
+		*out = append(*out, e)
+	case *ast.ParenExpr:
+		g.walkDirectMatches(e.X, out)
+	case *ast.UnaryExpr:
+		g.walkDirectMatches(e.X, out)
+	case *ast.BinaryExpr:
+		g.walkDirectMatches(e.Left, out)
+		g.walkDirectMatches(e.Right, out)
+	case *ast.CallExpr:
+		g.walkDirectMatches(e.Fn, out)
+		for _, a := range e.Args {
+			g.walkDirectMatches(a.Value, out)
+		}
+	case *ast.FieldExpr:
+		g.walkDirectMatches(e.X, out)
+	case *ast.IndexExpr:
+		g.walkDirectMatches(e.X, out)
+		g.walkDirectMatches(e.Index, out)
+	case *ast.TurbofishExpr:
+		g.walkDirectMatches(e.Base, out)
+	case *ast.TupleExpr:
+		for _, x := range e.Elems {
+			g.walkDirectMatches(x, out)
+		}
+	case *ast.ListExpr:
+		for _, x := range e.Elems {
+			g.walkDirectMatches(x, out)
+		}
+	case *ast.MapExpr:
+		for _, ent := range e.Entries {
+			g.walkDirectMatches(ent.Key, out)
+			g.walkDirectMatches(ent.Value, out)
+		}
+	case *ast.StructLit:
+		for _, f := range e.Fields {
+			if f.Value != nil {
+				g.walkDirectMatches(f.Value, out)
+			}
+		}
+	case *ast.RangeExpr:
+		g.walkDirectMatches(e.Start, out)
+		g.walkDirectMatches(e.Stop, out)
+	case *ast.QuestionExpr:
+		g.walkDirectMatches(e.X, out)
+	case *ast.IfExpr, *ast.ClosureExpr, *ast.Block:
+		// stop — these emit their own children with their own pre-lift.
+	}
+}
+
+// matchEscapes reports whether any arm body of m contains an explicit
+// `return` statement that would need to escape past the IIFE
+// boundary. Returns inside a nested closure are local to the closure
+// and do not count.
+func matchEscapes(m *ast.MatchExpr) bool {
+	for _, arm := range m.Arms {
+		if exprContainsEscape(arm.Body) {
+			return true
+		}
+		if arm.Guard != nil && exprContainsEscape(arm.Guard) {
+			return true
+		}
+	}
+	return false
+}
+
+// exprContainsEscape walks an Osty expression looking for a `return`
+// statement that targets the enclosing function. Stops at ClosureExpr
+// because returns inside a closure body return from the closure, not
+// the enclosing function.
+func exprContainsEscape(e ast.Expr) bool {
+	if e == nil {
+		return false
+	}
+	switch e := e.(type) {
+	case *ast.Block:
+		for _, s := range e.Stmts {
+			if stmtContainsEscape(s) {
+				return true
+			}
+		}
+	case *ast.IfExpr:
+		if exprContainsEscape(e.Cond) {
+			return true
+		}
+		if e.Then != nil {
+			for _, s := range e.Then.Stmts {
+				if stmtContainsEscape(s) {
+					return true
+				}
+			}
+		}
+		if e.Else != nil && exprContainsEscape(e.Else) {
+			return true
+		}
+	case *ast.MatchExpr:
+		if exprContainsEscape(e.Scrutinee) {
+			return true
+		}
+		for _, arm := range e.Arms {
+			if exprContainsEscape(arm.Body) {
+				return true
+			}
+			if arm.Guard != nil && exprContainsEscape(arm.Guard) {
+				return true
+			}
+		}
+	case *ast.ParenExpr:
+		return exprContainsEscape(e.X)
+	case *ast.UnaryExpr:
+		return exprContainsEscape(e.X)
+	case *ast.BinaryExpr:
+		return exprContainsEscape(e.Left) || exprContainsEscape(e.Right)
+	case *ast.CallExpr:
+		if exprContainsEscape(e.Fn) {
+			return true
+		}
+		for _, a := range e.Args {
+			if exprContainsEscape(a.Value) {
+				return true
+			}
+		}
+	case *ast.FieldExpr:
+		return exprContainsEscape(e.X)
+	case *ast.IndexExpr:
+		return exprContainsEscape(e.X) || exprContainsEscape(e.Index)
+	case *ast.TurbofishExpr:
+		return exprContainsEscape(e.Base)
+	case *ast.TupleExpr:
+		for _, x := range e.Elems {
+			if exprContainsEscape(x) {
+				return true
+			}
+		}
+	case *ast.ListExpr:
+		for _, x := range e.Elems {
+			if exprContainsEscape(x) {
+				return true
+			}
+		}
+	case *ast.MapExpr:
+		for _, ent := range e.Entries {
+			if exprContainsEscape(ent.Key) || exprContainsEscape(ent.Value) {
+				return true
+			}
+		}
+	case *ast.StructLit:
+		for _, f := range e.Fields {
+			if f.Value != nil && exprContainsEscape(f.Value) {
+				return true
+			}
+		}
+	case *ast.RangeExpr:
+		return exprContainsEscape(e.Start) || exprContainsEscape(e.Stop)
+	case *ast.QuestionExpr:
+		return exprContainsEscape(e.X)
+	case *ast.ClosureExpr:
+		return false
+	}
+	return false
+}
+
+func stmtContainsEscape(s ast.Stmt) bool {
+	if s == nil {
+		return false
+	}
+	switch s := s.(type) {
+	case *ast.ReturnStmt:
+		return true
+	case *ast.LetStmt:
+		return exprContainsEscape(s.Value)
+	case *ast.AssignStmt:
+		for _, t := range s.Targets {
+			if exprContainsEscape(t) {
+				return true
+			}
+		}
+		return exprContainsEscape(s.Value)
+	case *ast.ExprStmt:
+		return exprContainsEscape(s.X)
+	case *ast.Block:
+		for _, ss := range s.Stmts {
+			if stmtContainsEscape(ss) {
+				return true
+			}
+		}
+	case *ast.ForStmt:
+		// A `return` inside the loop body still escapes; break/continue
+		// inside it are local to the loop and don't count.
+		if s.Body != nil {
+			for _, ss := range s.Body.Stmts {
+				if stmtContainsEscape(ss) {
+					return true
+				}
+			}
+		}
+		return exprContainsEscape(s.Iter)
+	case *ast.DeferStmt:
+		return exprContainsEscape(s.X)
+	case *ast.ChanSendStmt:
+		return exprContainsEscape(s.Channel) || exprContainsEscape(s.Value)
+	}
+	return false
+}
+
+// emitMatchLifted writes the statement-position lowering of m. The
+// emitted shape wraps the arm chain in a one-shot `for { ... }` loop
+// whose only purpose is to give arms a `break` target distinct from
+// the enclosing function:
+//
+//	var <tmp> T
+//	_ = <tmp>
+//	for {
+//	    _scrut := <scrutinee>
+//	    _ = _scrut
+//	    if <pat1 test> { bindings; <body1 trailer> }
+//	    if <pat2 test> { bindings; <body2 trailer> }
+//	    panic("unreachable match")  // omitted when last arm is total
+//	}
+//
+// Value-producing arms write `<tmp> = <expr>; break` so the loop
+// terminates after first match (matching IIFE first-match
+// semantics). Escape arms (`return` / `break` / `continue` in the
+// arm body's tail) emit the escape statement directly — `return`
+// exits the enclosing function, which makes the missing `break`
+// trivially unreachable.
+//
+// The `for` form is the only Go construct that gives a labeled break
+// target without abusing `goto`; a bare `{ ... }` block is not a
+// break target. The loop iterates exactly once on every code path.
+func (g *gen) emitMatchLifted(tmp string, m *ast.MatchExpr) {
+	retType := "any"
+	if t := g.typeOf(m); t != nil && !types.IsError(t) && !types.IsUnit(t) {
+		retType = g.goType(t)
+	}
+	g.body.writef("var %s %s\n_ = %s\n", tmp, retType, tmp)
+	g.body.writeln("for {")
+	g.body.indent()
+	scrutName := g.freshVar("_m")
+	g.body.writef("%s := ", scrutName)
+	g.emitExpr(m.Scrutinee)
+	g.body.writef("\n_ = %s\n", scrutName)
+
+	scrutType := g.typeOf(m.Scrutinee)
+	totallyCovered := false
+	for i, a := range m.Arms {
+		g.emitMatchArmLifted(tmp, scrutName, scrutType, a)
+		if i == len(m.Arms)-1 && g.isCatchAll(a.Pattern) && a.Guard == nil {
+			totallyCovered = true
+		}
+	}
+	if !totallyCovered {
+		g.body.writeln(`panic("unreachable match")`)
+	}
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+// emitMatchArmLifted is the lifted-mode counterpart of emitMatchArm.
+// Bindings + guard test are unchanged from the IIFE form; only the
+// trailer differs — see emitArmTrailerLifted.
+func (g *gen) emitMatchArmLifted(tmp, scrut string, scrutType types.Type, arm *ast.MatchArm) {
+	catchAll := g.isCatchAll(arm.Pattern)
+
+	if catchAll && arm.Guard == nil {
+		g.body.writeln("{")
+		g.body.indent()
+		g.emitPatternBindings(scrut, scrutType, arm.Pattern)
+		g.emitArmTrailerLifted(tmp, arm.Body)
+		g.body.dedent()
+		g.body.writeln("}")
+		return
+	}
+
+	if !catchAll {
+		g.body.write("if ")
+		g.emitPatternTest(scrut, scrutType, arm.Pattern)
+		g.body.writeln(" {")
+		g.body.indent()
+	} else {
+		g.body.writeln("{")
+		g.body.indent()
+	}
+
+	g.emitPatternBindings(scrut, scrutType, arm.Pattern)
+
+	if arm.Guard != nil {
+		g.body.write("if ")
+		g.emitExpr(arm.Guard)
+		g.body.writeln(" {")
+		g.body.indent()
+		g.emitArmTrailerLifted(tmp, arm.Body)
+		g.body.dedent()
+		g.body.writeln("}")
+	} else {
+		g.emitArmTrailerLifted(tmp, arm.Body)
+	}
+
+	g.body.dedent()
+	g.body.writeln("}")
+}
+
+// emitArmTrailerLifted writes one arm's body in lifted mode.
+//
+// When the body's tail is an escape statement (return / break /
+// continue), the body is emitted as plain statements — no assignment
+// is needed because the escape transfers control before any
+// assignment site, and no `break` from the enclosing for is needed
+// because `return` already exits the function (and break/continue
+// already exit the surrounding loop).
+//
+// Otherwise the body's tail expression is wrapped as `tmp = <expr>`
+// followed by `break` to exit the enclosing one-shot for, giving us
+// first-match semantics. Block bodies are inlined: the leading
+// statements emit through emitStmt (which runs its own pre-lift),
+// then the last expression assigns to tmp and breaks.
+func (g *gen) emitArmTrailerLifted(tmp string, body ast.Expr) {
+	if b, ok := body.(*ast.Block); ok && len(b.Stmts) > 0 {
+		last := b.Stmts[len(b.Stmts)-1]
+		for _, s := range b.Stmts[:len(b.Stmts)-1] {
+			g.emitStmt(s)
+		}
+		switch s := last.(type) {
+		case *ast.ExprStmt:
+			g.preLiftMatches(s.X)
+			g.body.writef("%s = ", tmp)
+			g.emitExpr(s.X)
+			g.body.nl()
+			g.body.writeln("break")
+		default:
+			// Last stmt is non-value (return / break / continue / ...);
+			// emit it directly. Any `break` we add would be unreachable.
+			g.emitStmt(last)
+		}
+		return
+	}
+	g.preLiftMatches(body)
+	g.body.writef("%s = ", tmp)
+	g.emitExpr(body)
+	g.body.nl()
+	g.body.writeln("break")
+}

--- a/internal/bootstrap/gen/stmt.go
+++ b/internal/bootstrap/gen/stmt.go
@@ -48,10 +48,12 @@ func (g *gen) emitStmt(s ast.Stmt) {
 			g.emitQuestionLift("_", e)
 			return
 		}
+		g.preLiftMatches(s.X)
 		g.preLiftQuestions(s.X)
 		g.emitExpr(s.X)
 		g.body.nl()
 		g.resetQuestionSubs()
+		g.resetMatchSubs()
 	case *ast.AssignStmt:
 		g.emitAssign(s)
 	case *ast.ReturnStmt:
@@ -121,7 +123,11 @@ func (g *gen) emitLetStmt(l *ast.LetStmt) {
 
 	// Any `?` nested inside a compound RHS (e.g. `let x = foo(bar()?)`)
 	// gets hoisted out via preLiftQuestions so the remaining expression
-	// is a straight substitution on the lifted temps.
+	// is a straight substitution on the lifted temps. The match lift
+	// runs first so a tainted match in the operand of a `?` is already
+	// substituted by the time the question lift evaluates the operand.
+	g.preLiftMatches(l.Value)
+	defer g.resetMatchSubs()
 	g.preLiftQuestions(l.Value)
 	defer g.resetQuestionSubs()
 
@@ -233,6 +239,8 @@ func (g *gen) emitQuestionLift(name string, q *ast.QuestionExpr) {
 // machinery for tuple / struct / nested subpatterns.
 func (g *gen) emitLetPatternDestructure(p ast.Pattern, value ast.Expr) {
 	tmp := g.freshVar("_p")
+	g.preLiftMatches(value)
+	defer g.resetMatchSubs()
 	g.preLiftQuestions(value)
 	defer g.resetQuestionSubs()
 	g.body.writef("%s := ", tmp)
@@ -245,11 +253,16 @@ func (g *gen) emitLetPatternDestructure(p ast.Pattern, value ast.Expr) {
 // multi-assign `(a, b) = (c, d)`. Multi-assign with a tuple RHS is
 // rewritten to Go's parallel assignment.
 func (g *gen) emitAssign(a *ast.AssignStmt) {
-	// Pre-lift any `?` in targets or value. Targets rarely contain `?`
-	// in practice, but we walk them for completeness.
+	// Pre-lift any escaping match / `?` in targets or value. Targets
+	// rarely contain either in practice, but we walk them for
+	// completeness. Match lift runs before the question lift so a
+	// tainted match feeding a `?` is already substituted.
 	for _, t := range a.Targets {
+		g.preLiftMatches(t)
 		g.preLiftQuestions(t)
 	}
+	g.preLiftMatches(a.Value)
+	defer g.resetMatchSubs()
 	g.preLiftQuestions(a.Value)
 	defer g.resetQuestionSubs()
 
@@ -493,6 +506,8 @@ func (g *gen) emitReturn(r *ast.ReturnStmt) {
 		g.body.writeln("return")
 		return
 	}
+	g.preLiftMatches(r.Value)
+	defer g.resetMatchSubs()
 	g.preLiftQuestions(r.Value)
 	defer g.resetQuestionSubs()
 	g.body.write("return ")

--- a/internal/selfhost/match_lift_e2e_test.go
+++ b/internal/selfhost/match_lift_e2e_test.go
@@ -1,0 +1,103 @@
+package selfhost
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMatchArmReturnLiftsOutOfIIFE pins the bug-#3 fix from the
+// bootstrap/gen transpiler.
+//
+// Before the fix, a `return` inside a match arm body that sits in
+// expression position (e.g. `let x = match e { ... -> { return Y } }`)
+// only escaped the synthesized IIFE — not the enclosing Osty function
+// — so the value Y was silently bound to x and execution continued.
+// The fix lifts any match whose arm bodies contain `return` into a
+// statement-position lowering, putting the arm bodies directly in the
+// outer Go function so `return` propagates correctly.
+//
+// This test exercises the failure mode end-to-end: it transpiles a
+// program whose only behavior difference between buggy and fixed
+// codegen is whether a match-arm `return` propagates, then compiles
+// and runs the generated Go and asserts the printed values match the
+// language-level semantics.
+func TestMatchArmReturnLiftsOutOfIIFE(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping bootstrap/gen e2e match-arm-return test in short mode")
+	}
+
+	repoRoot := filepath.Join("..", "..")
+
+	// Three call sites distinguish buggy vs. fixed lowering:
+	//   classify(0)  — fixed: -1 (return propagates); buggy: -10 (label * 10)
+	//   classify(5)  — both: 10 (label = 1)
+	//   classify(-3) — both: 0  (label = 0)
+	src := `fn classify(n: Int) -> Int {
+    let label = match n {
+        0 -> { return -1 },
+        x if x > 0 -> 1,
+        _ -> 0,
+    }
+    label * 10
+}
+
+fn main() {
+    println("{classify(0)}")
+    println("{classify(5)}")
+    println("{classify(-3)}")
+}
+`
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "match_arm_return.osty")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	genPath := filepath.Join(tmpDir, "match_arm_return.go")
+
+	gen := exec.Command(
+		"go", "run", "./cmd/osty-bootstrap-gen",
+		"--package", "main",
+		"-o", genPath,
+		srcPath,
+	)
+	gen.Dir = repoRoot
+	if out, err := gen.CombinedOutput(); err != nil {
+		t.Fatalf("transpile: %v\n%s", err, bytes.TrimSpace(out))
+	}
+
+	generated, err := os.ReadFile(genPath)
+	if err != nil {
+		t.Fatalf("read generated: %v", err)
+	}
+	if len(generated) == 0 {
+		t.Fatal("generated file is empty")
+	}
+
+	// Sanity check: the lifted lowering declares a result var prefixed
+	// `_ml`. If we see the IIFE shape for `classify` instead, the lift
+	// did not fire and the test below would silently pass on the
+	// buggy output for the wrong reason.
+	if !bytes.Contains(generated, []byte("_ml")) {
+		t.Fatalf("generated Go does not contain a lifted match result var — "+
+			"escaping match was likely emitted as IIFE.\nGenerated:\n%s", generated)
+	}
+
+	run := exec.Command("go", "run", genPath)
+	out, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run generated:\n%v\n%s\nGenerated source:\n%s",
+			err, bytes.TrimSpace(out), generated)
+	}
+
+	got := strings.TrimSpace(string(out))
+	want := "-1\n10\n0"
+	if got != want {
+		t.Fatalf("match-arm return did not propagate.\n got: %q\nwant: %q\n"+
+			"Generated:\n%s", got, want, generated)
+	}
+}


### PR DESCRIPTION
## Summary

- Bug #3 from the bootstrap/gen verified-bug list: a bare `return X` inside a match arm body lowered as `func() T { ... return X }()` returned from the synthesized IIFE — not the enclosing Osty function. Used in non-tail position (e.g. `let x = match e { Pat -> { return X } }`) the value silently bound to `x` and execution continued. Silent miscompile in the bootstrap seed path.
- Fix: detect any match whose arm bodies contain `return`, hoist it into `var _ml T; for { ... break }` statement-position lowering above the consuming statement. Value arms emit `_ml = body; break` (first-match semantics); escape arms emit the `return` directly so it propagates to the outer Go function. Records the substitution in `matchSubs`; `emitMatch` writes the var name at the original use site.
- Wired into `LetStmt` / `AssignStmt` / `ReturnStmt` / `ExprStmt` / `emitLetPatternDestructure`, ahead of the existing question pre-lift so a tainted match feeding a `?` is substituted before the question lift evaluates the operand.
- Replaces the documented workaround ("only put `return` in tail-position match arms"); workaround can be removed from `toolchain/*.osty` style notes.

## Why

Bootstrap/gen is the seed-regeneration path. CLAUDE.md tags it deprecated (LLVM selfhost will replace), but until that's done the silent-miscompile failure mode is a debugging black hole — a bug in `internal/selfhost/generated.go` that's actually a transpiler bug looks like a checker bug. Loud-error guards were considered (smaller patch) but rejected in favor of the real lift since semantics are now identical to the IIFE form for the safe cases and correct for the broken ones.

## What changed

- `internal/bootstrap/gen/match_lift.go` (new) — `preLiftMatches`, `walkDirectMatches`, `matchEscapes`, `exprContainsEscape`, `stmtContainsEscape`, `emitMatchLifted`, `emitMatchArmLifted`, `emitArmTrailerLifted`. Walker stops at `IfExpr` / `ClosureExpr` / `Block` boundaries (each owns its own pre-lift); inner consumers run their own lift recursively. Save/restore on `matchSubs` around the recursive lowering so inner `emitStmt` defer-resets don't blow away the outer in-progress map.
- `internal/bootstrap/gen/gen.go` — `matchSubs map[*ast.MatchExpr]string` field on `gen`.
- `internal/bootstrap/gen/match.go` — `emitMatch` consults `matchSubs` first.
- `internal/bootstrap/gen/stmt.go` — `preLiftMatches` + `resetMatchSubs` paired into the four statement entry points (and `emitLetPatternDestructure`), ordered before the existing question pre-lift.
- `internal/selfhost/match_lift_e2e_test.go` (new) — `TestMatchArmReturnLiftsOutOfIIFE`. Transpiles a 3-arm match with one escape arm and asserts `classify(0) == -1` (return propagates), `classify(5) == 10` (first-match wins), `classify(-3) == 0`. Also greps the generated Go for `_ml` to fail loudly if the lift didn't fire.

## Known remaining limitation

- Only direct `return` inside an arm body triggers the lift. `match { Pat -> if cond { return X } else { Y } }` still lowers the inner `IfExpr` as an IIFE, so the same silent-miscompile pattern remains for if-as-value with internal return. Same lift mechanism applied to `IfExpr` would close it — separate PR.
- Seed regen (`internal/selfhost/generated.go`) intentionally NOT done in this PR — high blast radius, deserves its own commit + review.

## Test plan

- [x] `go build ./internal/bootstrap/gen/` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/selfhost/ -run TestMatchArmReturnLiftsOutOfIIFE` — passes
- [x] `go test ./internal/selfhost/ -run TestToolchainCheckerSourcesTranspile` — passes (292s; toolchain checker full transpile, exercises the lift dispatch on every non-escape match in the seed)
- [ ] Reviewer to consider: should we land seed regeneration as a follow-up?

🤖 Generated with [Claude Code](https://claude.com/claude-code)