### PR TITLE
[codex] unblock selfhost follow-up fixes

### DIFF
--- a/internal/lsp/refactor.go
+++ b/internal/lsp/refactor.go
@@ -270,6 +270,24 @@ func fixAllAction(doc *document) *CodeAction {
 	if a == nil || a.file == nil {
 		return nil
 	}
+	// Parser canonicalization handles syntax-only rewrites such as
+	// `len(x)` -> `x.len()` and `append(x, y)` -> `x.push(y)`, but it
+	// deliberately does not rewrite semantic JS habits like `.length`.
+	// When that property is present, prefer airepair's broader repair so
+	// fix-all doesn't stop after a partial canonicalization.
+	if bytes.Contains(doc.src, []byte(".length")) {
+		if edit := airepairFixAllEdit(doc); edit != nil {
+			return &CodeAction{
+				Title: "Fix all auto-fixable problems",
+				Kind:  CodeActionSourceFixAllOsty,
+				Edit: &WorkspaceEdit{
+					Changes: map[string][]TextEdit{
+						doc.uri: []TextEdit{*edit},
+					},
+				},
+			}
+		}
+	}
 	if edit := parserCanonicalFixAllEdit(doc); edit != nil {
 		return &CodeAction{
 			Title: "Fix all auto-fixable problems",

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -68,13 +68,13 @@ type lowerer struct {
 	src *ir.Module
 	out *Module
 
-	fnSig       map[string]*fnSignature
-	methods     map[string]*fnSignature
-	enums       map[string]*ir.EnumDecl
-	structs     map[string]*ir.StructDecl
-	globals     map[string]*ir.LetDecl
-	useAliases  map[string]*ir.UseDecl // alias name → use decl
-	closureSeq  int
+	fnSig      map[string]*fnSignature
+	methods    map[string]*fnSignature
+	enums      map[string]*ir.EnumDecl
+	structs    map[string]*ir.StructDecl
+	globals    map[string]*ir.LetDecl
+	useAliases map[string]*ir.UseDecl // alias name → use decl
+	closureSeq int
 }
 
 func (l *lowerer) noteIssue(format string, args ...any) {
@@ -1653,6 +1653,9 @@ func (bs *bodyState) lowerExprIntoPlace(e ir.Expr, dest Place, destT Type) {
 	case *ir.IntrinsicCall:
 		bs.lowerIntrinsicCallInto(x, &dest)
 		return
+	case *ir.MapLit:
+		bs.lowerMapLitInto(x, dest, destT)
+		return
 	}
 	// Default path: lower to an rvalue and assign.
 	rv := bs.lowerExprToRValue(e, destT)
@@ -2686,6 +2689,36 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 		Args:   callArgs,
 		SpanV:  mc.SpanV,
 	})
+}
+
+func (bs *bodyState) lowerMapLitInto(m *ir.MapLit, dest Place, destT Type) {
+	mapT := destT
+	if mapT == nil {
+		mapT = m.Type()
+	}
+	destPtr := &dest
+	if isUnit(mapT) {
+		destPtr = nil
+	}
+	bs.emit(&IntrinsicInstr{
+		Dest:  destPtr,
+		Kind:  IntrinsicMapNew,
+		SpanV: m.SpanV,
+	})
+	if len(m.Entries) == 0 {
+		return
+	}
+	for _, entry := range m.Entries {
+		bs.emit(&IntrinsicInstr{
+			Kind: IntrinsicMapSet,
+			Args: []Operand{
+				&CopyOp{Place: dest, T: mapT},
+				bs.lowerExprAsOperand(entry.Key),
+				bs.lowerExprAsOperand(entry.Value),
+			},
+			SpanV: entry.SpanV,
+		})
+	}
 }
 
 func (bs *bodyState) lowerIntrinsicCallInto(ic *ir.IntrinsicCall, dest *Place) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -69,6 +69,23 @@ func ParseDetailed(src []byte) Result {
 	}
 }
 
+// ParseCanonical parses already-canonical source without running the
+// source-level compatibility rewrites that ParseDetailed applies for
+// user-authored code. Callers should use this only for trusted inputs that do
+// not rely on stable-alias keywords, scoped-import expansion, or `pub use`
+// visibility repair.
+//
+// Unlike calling selfhost.Parse directly, this still applies the parser's
+// AST-only lowerings so canonical sources that use lowered surface forms such
+// as builtin `len(...)` continue to match the rest of the compiler pipeline.
+func ParseCanonical(src []byte) (*ast.File, []*diag.Diagnostic) {
+	file, diags := selfhost.Parse(src)
+	if file != nil {
+		lowerStableAST(file)
+	}
+	return file, diags
+}
+
 // ParseDiagnostics lexes and parses src, returning the AST and rich
 // diagnostics. This is the primary entry point for all compiler passes.
 func ParseDiagnostics(src []byte) (*ast.File, []*diag.Diagnostic) {

--- a/internal/query/db.go
+++ b/internal/query/db.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/stdlib"
 )
 
 // Revision is a monotonically increasing counter stamped onto every
@@ -88,13 +87,13 @@ type Database struct {
 	// [Ctx.Prelude] / [Ctx.Stdlib] without recording a dep edge —
 	// they never change.
 	prelude *resolve.Scope
-	stdlib  *stdlib.Registry
+	stdlib  resolve.StdlibProvider
 }
 
 // NewDatabase constructs a Database with the given process-lifetime
 // prelude and stdlib registry. Both may be nil for test harnesses that
 // don't need them.
-func NewDatabase(prelude *resolve.Scope, reg *stdlib.Registry) *Database {
+func NewDatabase(prelude *resolve.Scope, reg resolve.StdlibProvider) *Database {
 	return &Database{
 		slots:      make(map[QueryID]map[any]*slot),
 		names:      make(map[QueryID]string),

--- a/internal/query/osty/db.go
+++ b/internal/query/osty/db.go
@@ -1,6 +1,8 @@
 package osty
 
 import (
+	"sync"
+
 	"github.com/osty/osty/internal/query"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
@@ -29,21 +31,43 @@ type Engine struct {
 // input [Inputs.SourceText.Set] calls and serve derived queries via
 // [Queries].
 func NewEngine() *Engine {
-	return newEngineWith(resolve.NewPrelude(), stdlib.LoadCached())
+	return newEngineWith(resolve.NewPrelude(), newLazyStdlibProvider())
 }
 
 // NewEngineForTest constructs an Engine with custom prelude and stdlib,
 // typically used by test harnesses that want a fresh prelude per test
 // or want to simulate "no stdlib" environments.
-func NewEngineForTest(prelude *resolve.Scope, reg *stdlib.Registry) *Engine {
+func NewEngineForTest(prelude *resolve.Scope, reg resolve.StdlibProvider) *Engine {
 	return newEngineWith(prelude, reg)
 }
 
-func newEngineWith(prelude *resolve.Scope, reg *stdlib.Registry) *Engine {
+func newEngineWith(prelude *resolve.Scope, reg resolve.StdlibProvider) *Engine {
 	db := query.NewDatabase(prelude, reg)
 	inp := registerInputs(db)
 	qs := registerQueries(db, inp)
 	return &Engine{DB: db, Inputs: inp, Queries: qs}
+}
+
+type lazyStdlibProvider struct {
+	once sync.Once
+	reg  *stdlib.Registry
+}
+
+func newLazyStdlibProvider() resolve.StdlibProvider {
+	return &lazyStdlibProvider{}
+}
+
+func (p *lazyStdlibProvider) LookupPackage(dotPath string) *resolve.Package {
+	if p == nil {
+		return nil
+	}
+	p.once.Do(func() {
+		p.reg = stdlib.LoadCached()
+	})
+	if p.reg == nil {
+		return nil
+	}
+	return p.reg.LookupPackage(dotPath)
 }
 
 // Close is reserved for future cleanup hooks (e.g. releasing cached

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	"github.com/osty/osty/internal/resolve"
-	"github.com/osty/osty/internal/stdlib"
 )
 
 // ---- Frame ----
@@ -55,7 +54,7 @@ func (c *Ctx) Prelude() *resolve.Scope { return c.db.prelude }
 
 // Stdlib returns the process-lifetime stdlib registry. Not dependency-
 // tracked for the same reason as Prelude.
-func (c *Ctx) Stdlib() *stdlib.Registry { return c.db.stdlib }
+func (c *Ctx) Stdlib() resolve.StdlibProvider { return c.db.stdlib }
 
 // ---- QueryFn, Query, Input ----
 

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -133,7 +133,11 @@ func loadRegistry() *Registry {
 				Build())
 			continue
 		}
-		file, diags := parser.ParseDiagnostics(src)
+		// Embedded stdlib stubs are authored in canonical Osty syntax, so they
+		// can skip the parser's compatibility rewrites and their extra lex
+		// passes. This keeps startup from paying several full scans over the
+		// generated Unicode-heavy strings stub.
+		file, diags := parser.ParseCanonical(src)
 		r.Diags = append(r.Diags, diags...)
 		if file == nil {
 			continue


### PR DESCRIPTION
## What changed
This PR lands the next self-hosting follow-up fixes in one batch.

- lower MIR `MapLit` nodes directly into runtime map construction instead of falling into the generic recursive fallback
- make the query engine hold a lazy `resolve.StdlibProvider` so file-mode analysis does not eagerly parse the entire bundled stdlib on startup
- add a canonical-parser fast path for embedded stdlib stubs to skip user-facing compatibility rewrites
- prefer `airepair` over parser-only canonicalization in LSP fix-all when `.length` is present so semantic helper rewrites are not dropped

## Why this changed
Two different blockers showed up after the previous LLVM fix.

`internal/mir` could recurse indefinitely on map literals because `MapLit` never got its own lowering path. Separately, `internal/query/osty.NewEngine()` eagerly loaded the full stdlib, and the generated `std.strings` stub made even parse-cache tests pay a large one-time startup cost. While tightening that path, LSP fix-all also needed a small priority fix so semantic `.length -> .len()` repairs were not skipped after parser canonicalization handled only part of the file.

## Impact
- map literals now lower correctly through MIR/runtime container intrinsics
- query-engine startup is cheap again for parse/resolve/check cache tests and single-file editor analysis
- bundled stdlib loading avoids unnecessary compatibility passes
- LSP fix-all repairs semantic helper habits in one shot again

## Validation
- `go test ./internal/query ./internal/query/osty ./internal/lsp ./internal/stdlib -count=1`
- `go test ./internal/mir ./internal/backend ./internal/llvmgen -count=1`
