### PR TITLE
fix(ir): RawPtr flows through ir.Lower — corrects #345 misdiagnosis

### DIFF
--- a/LANG_SPEC_v0.5/19-runtime-primitives.md
+++ b/LANG_SPEC_v0.5/19-runtime-primitives.md
@@ -616,12 +616,13 @@ while the export symbol is link-reachable.
 | §19.7 lowering table (`raw.null` → `inttoptr i64 0`, etc.) | **deferred** | — |
 | §19.10 safepoint compiler-emitted root array | **deferred** | — |
 
-**Type system / native checker.** A known gap blocks intrinsic
-lowering even after the IR plumbing is in place.
+**Type system / native checker / IR lowering.** Multiple layers,
+partially landed.
 
 | Piece | Status | Notes |
 |---|---|---|
-| Stdlib member type inference for `use std.runtime.raw` | **gap** | Today `raw.null()` resolves but checks as `*ir.ErrType` because the native checker does not flow stdlib intrinsic return types back to call sites. Lowering work is blocked on this until fixed. The executable contract for the fix is `internal/llvmgen/runtime_intrinsic_typing_test.go` — 7 `t.Skip`'d tests state the expected typing for each intrinsic (`raw.null` → RawPtr, `raw.alloc` → RawPtr, `raw.bits` → Int, `raw.read::<T>` → T, `raw.cas::<T>` → Bool, `raw.sizeOf::<T>` → Int, chained `alloc/write/read/free`). The fix lands by removing the `t.Skip` lines and watching all 7 pass without further code changes. |
+| Native checker types `raw.null()` / `raw.alloc(b, a)` / `raw.bits(p)` correctly | **landed** | The native checker's `chk.Types[CallExpr]` and `chk.LetTypes[LetStmt]` already return `RawPtr` / `Int` for non-generic intrinsics. PR `claude/native-checker-stdlib-types` added `PrimRawPtr` to `internal/ir/PrimKind` + `TRawPtr` singleton + the missing case arms in `primitiveByKind` / `primitiveByName`, so `ir.Lower` now flows the type to `let.Type` instead of dropping to `ErrTypeVal`. (Original PR #345 misdiagnosed this as a native-checker gap; it was an IR lowerer gap.) |
+| Generic intrinsic typing — `raw.read::<T>` / `raw.write::<T>` / `raw.cas::<T>` / `raw.sizeOf::<T>` / `raw.alignOf::<T>` | **gap** | The `host_boundary`'s `writeSelfhostPackageImport` (`internal/check/host_boundary.go:1324`) strips `<T: Pod>` generic params when forwarding stdlib stub signatures to the native checker. Result: `fn read(p: RawPtr) -> T` reaches the checker with `T` undeclared, and turbofish call sites get `ErrType`. The executable contract is the 5 `t.Skip(genericSkipReason)`'d tests in `internal/llvmgen/runtime_intrinsic_typing_test.go`. The fix is to extend the boundary writer to emit `<T: Pod>` (and to verify the native checker accepts FFI-block generics). |
 
 **Out-of-scope (per §19.1) — never planned.**
 

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -82,6 +82,13 @@ const (
 	PrimString
 	PrimBytes
 
+	// Runtime-only opaque pointer-shaped scalar (LANG_SPEC §19.3).
+	// Represents `RawPtr` from `std.runtime` — an integer-shaped
+	// opaque type used by the runtime sublanguage. Mirrors
+	// `types.PRawPtr` so the IR lowerer can flow native-checker
+	// type info to call sites without losing precision.
+	PrimRawPtr
+
 	PrimUnit  // ()
 	PrimNever // !
 )
@@ -127,6 +134,8 @@ func (p *PrimType) String() string {
 		return "String"
 	case PrimBytes:
 		return "Bytes"
+	case PrimRawPtr:
+		return "RawPtr"
 	case PrimUnit:
 		return "()"
 	case PrimNever:
@@ -155,6 +164,7 @@ var (
 	TChar    = &PrimType{Kind: PrimChar}
 	TString  = &PrimType{Kind: PrimString}
 	TBytes   = &PrimType{Kind: PrimBytes}
+	TRawPtr  = &PrimType{Kind: PrimRawPtr}
 	TUnit    = &PrimType{Kind: PrimUnit}
 	TNever   = &PrimType{Kind: PrimNever}
 )

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -432,6 +432,8 @@ func primitiveByName(name string) *PrimType {
 		return TString
 	case "Bytes":
 		return TBytes
+	case "RawPtr":
+		return TRawPtr
 	}
 	return nil
 }
@@ -534,6 +536,8 @@ func primitiveByKind(k types.PrimitiveKind) *PrimType {
 		return TString
 	case types.PBytes:
 		return TBytes
+	case types.PRawPtr:
+		return TRawPtr
 	case types.PUnit:
 		return TUnit
 	case types.PNever:

--- a/internal/llvmgen/runtime_intrinsic_typing_test.go
+++ b/internal/llvmgen/runtime_intrinsic_typing_test.go
@@ -1,34 +1,34 @@
 package llvmgen
 
-// This file is the executable contract for the §19.11 native-checker
-// gap: stdlib member type inference for `use std.runtime.raw`.
+// Executable contract for the §19.5 intrinsic typing flow.
 //
-// As of the §19 spike series (PRs #284-#343), the front-end +
-// resolver bind `use std.runtime.raw` correctly, the stdlib loader
-// exposes the 13 §19.5 intrinsic stubs, and the privilege gate +
-// pod shape checker enforce the surface. But the native checker
-// does NOT flow stdlib intrinsic return types back to call sites:
-// `raw.null()` resolves but checks as `*ir.ErrType` because the
-// member-access type-inference path doesn't follow the import to
-// the stub's declared return type.
+// **Diagnostic correction.** The original landing of this file
+// (PR #345) attributed the failure to the native checker not
+// flowing stdlib intrinsic return types back to call sites. That
+// diagnosis was wrong — the native checker DOES return correct
+// types (`chk.Types[CallExpr] -> RawPtr`, `chk.LetTypes[LetStmt]
+// -> RawPtr`). The actual bug was in `internal/ir/lower.go`:
+// `primitiveByKind` and `primitiveByName` did not have cases for
+// `types.PRawPtr` (added in PR #312), so when `fromCheckerType`
+// converted a `*types.Primitive{Kind: PRawPtr}` it returned
+// `ErrTypeVal`. PR `claude/native-checker-stdlib-types` adds
+// `PrimRawPtr` to the IR primitive enum + `TRawPtr` singleton +
+// the missing `case` arms.
 //
-// Each test below states what the fixed behavior MUST look like.
-// Today every test calls `t.Skip(skipReason)` so the suite is green
-// while the gap is open. When the native checker is fixed, the
-// expected procedure is:
+// Three of these tests pass after that fix:
+//   - raw.null()       → RawPtr   ✓
+//   - raw.alloc(b, a)  → RawPtr   ✓
+//   - raw.bits(p)      → Int      ✓
 //
-//   1. Land the native-checker change (likely in `toolchain/check.osty`
-//      or the resolver/checker bridge).
-//   2. Run `go test ./internal/check/ -run TestRuntimeIntrinsicTyping`
-//      with the t.Skip lines removed in this file.
-//   3. Every test should pass without further changes.
-//   4. Update LANG_SPEC §19.11 status table: flip the
-//      "Stdlib member type inference for `use std.runtime.raw`"
-//      row from "gap" to "landed (PR #N)".
+// The remaining tests (raw.read::<T>, raw.write::<T>, raw.cas::<T>,
+// raw.sizeOf::<T>, chained alloc/write/read/free) still fail
+// because of a SEPARATE bug — the `host_boundary`'s
+// `writeSelfhostPackageImport` strips `<T: Pod>` generic params
+// when forwarding stdlib stub signatures to the native checker.
+// Those tests carry `t.Skip(genericSkipReason)`.
 //
-// If a test fails after un-skipping, that's a signal that the
-// contract was understood differently. Adjust the test, not the
-// code, ONLY if the spec wording supports the alternative.
+// When the boundary fix lands, removing the Skip lines should
+// flip the remaining tests green.
 
 import (
 	"testing"
@@ -41,8 +41,15 @@ import (
 	"github.com/osty/osty/internal/stdlib"
 )
 
-const skipReason = "blocked on native-checker stdlib member type inference — LANG_SPEC §19.11 known gap. " +
-	"Remove this Skip line when the native checker propagates `use std.runtime.raw` member return types to call sites."
+// genericSkipReason marks tests blocked on a still-open gap: the
+// host_boundary's `writeSelfhostPackageImport` strips generic params
+// from intrinsic signatures, so `fn read<T: Pod>(p: RawPtr) -> T`
+// reaches the native checker as `fn read(p: RawPtr) -> T` with `T`
+// undeclared. Tests for non-generic intrinsics (raw.null, raw.alloc,
+// raw.bits) pass after PR `claude/native-checker-stdlib-types`'s
+// `PrimRawPtr` fix; the generic ones await a boundary writer fix.
+const genericSkipReason = "blocked on host_boundary generic-param stripping — LANG_SPEC §19.11. " +
+	"Remove this Skip line when writeSelfhostPackageImport preserves `<T: Pod>` on intrinsic stubs."
 
 // firstLetTypeIn returns the printed type of the first `let` binding
 // inside the named function in `mod`. Returns "" if the fn or its
@@ -110,7 +117,6 @@ func lowerPrivileged(t *testing.T, src string) *ir.Module {
 // --- raw.null() -> RawPtr ---
 
 func TestRuntimeIntrinsicTypingRawNull(t *testing.T) {
-	t.Skip(skipReason)
 	src := `
 use std.runtime.raw
 
@@ -128,7 +134,6 @@ pub fn demo() {
 // --- raw.alloc(bytes, align) -> RawPtr ---
 
 func TestRuntimeIntrinsicTypingRawAlloc(t *testing.T) {
-	t.Skip(skipReason)
 	src := `
 use std.runtime.raw
 
@@ -146,7 +151,6 @@ pub fn demo() {
 // --- raw.bits(p) -> Int ---
 
 func TestRuntimeIntrinsicTypingRawBits(t *testing.T) {
-	t.Skip(skipReason)
 	src := `
 use std.runtime.raw
 
@@ -188,7 +192,7 @@ pub fn demo() {
 // --- raw.read::<T>(p) -> T ---
 
 func TestRuntimeIntrinsicTypingRawReadInt(t *testing.T) {
-	t.Skip(skipReason)
+	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -224,7 +228,7 @@ pub fn demo() {
 // --- raw.read::<T>(p) -> T (T=Float64) ---
 
 func TestRuntimeIntrinsicTypingRawReadFloat(t *testing.T) {
-	t.Skip(skipReason)
+	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -259,7 +263,7 @@ pub fn demo() {
 // --- raw.cas::<Int>(...) -> Bool ---
 
 func TestRuntimeIntrinsicTypingRawCas(t *testing.T) {
-	t.Skip(skipReason)
+	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -294,7 +298,7 @@ pub fn demo() {
 // --- raw.sizeOf::<T>() -> Int (compile-time constant typing) ---
 
 func TestRuntimeIntrinsicTypingSizeOf(t *testing.T) {
-	t.Skip(skipReason)
+	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -312,7 +316,7 @@ pub fn demo() {
 // --- end-to-end: chained intrinsics in a real-shaped fn ---
 
 func TestRuntimeIntrinsicTypingChainedAllocReadFree(t *testing.T) {
-	t.Skip(skipReason)
+	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 


### PR DESCRIPTION
## Summary

Twentieth §19 contribution. **Fixes the actual bug that PR [#345](https://github.com/choiceoh/osty/pull/345) attributed to the native checker.** Direct probing shows the native checker already returns the correct types — the breakage was in `internal/ir/lower.go`.

## Diagnostic correction

PR #345 declared a "native-checker stdlib member type inference" gap. That diagnosis was wrong.

Direct native-checker probe:
```
LetTypes: 1 entries
  *ast.LetStmt -> RawPtr
Types: 1 entries
  *ast.CallExpr -> RawPtr
Diagnostics: 0
```

The native checker DOES return correct types. The failure observed in #345 was at the IR layer:

- `primitiveByName` in `internal/ir/lower.go` had no case for `"RawPtr"`
- `primitiveByKind` had no case for `types.PRawPtr` (added in [#312](https://github.com/choiceoh/osty/pull/312))

So when `fromCheckerType` converted a `*types.Primitive{Kind: PRawPtr}` it returned `ErrTypeVal`. Downstream `let.Type = out.Value.Type()` then recorded the binding as `*ir.ErrType`.

The `RawPtr` registration in `internal/types` and the prelude was complete; the IR layer just wasn't told about it.

**Lesson:** when a downstream layer reports `<error>`, verify what the upstream layer actually produced before declaring the upstream broken.

## What this PR adds

| Change | File |
|---|---|
| `PrimRawPtr` to `ir.PrimKind` enum + `TRawPtr` singleton + `case PrimRawPtr` in `String()` | `internal/ir/ir.go` |
| `case "RawPtr": return TRawPtr` in `primitiveByName` | `internal/ir/lower.go` |
| `case types.PRawPtr: return TRawPtr` in `primitiveByKind` | `internal/ir/lower.go` |
| Remove `t.Skip` from 3 non-generic intrinsic tests | `internal/llvmgen/runtime_intrinsic_typing_test.go` |
| New `genericSkipReason` for the 5 still-blocked generic tests | same file |
| Corrected docstring explaining the misattribution | same file |
| Spec §19.11 status table split: "landed (non-generic)" vs. "gap (boundary stripping)" | `LANG_SPEC_v0.5/19-runtime-primitives.md` |

## Test evidence

```
$ go test ./internal/llvmgen/ -run TestRuntimeIntrinsicTyping -v
--- PASS: TestRuntimeIntrinsicTypingRawNull       (raw.null() → RawPtr)
--- PASS: TestRuntimeIntrinsicTypingRawAlloc      (raw.alloc → RawPtr)
--- PASS: TestRuntimeIntrinsicTypingRawBits       (raw.bits → Int)
--- SKIP: TestRuntimeIntrinsicTypingRawReadInt    (generic — boundary stripping)
--- SKIP: TestRuntimeIntrinsicTypingRawReadFloat  (generic)
--- SKIP: TestRuntimeIntrinsicTypingRawCas        (generic)
--- SKIP: TestRuntimeIntrinsicTypingSizeOf        (generic)
--- SKIP: TestRuntimeIntrinsicTypingChainedAllocReadFree (generic)
--- PASS: TestRuntimeIntrinsicTypingFileLoads
```

`go test -short ./internal/ir/ ./internal/check/ ./internal/llvmgen/ ./internal/resolve/ ./internal/parser/ ./internal/types/` — green except pre-existing `TestGenerateModuleStdTestingExpectOkCompat` (unrelated).

## What's still blocked

The 5 generic intrinsics need a SEPARATE fix: `host_boundary`'s `writeSelfhostPackageImport` strips `<T: Pod>` when forwarding stdlib stub signatures, so `fn read(p: RawPtr) -> T` reaches the checker with `T` undeclared. The skipped tests document this contract; un-skipping them after the boundary fix should produce 5 more passes.

## Spec references

- LANG_SPEC §19.3 (RawPtr type contract)
- LANG_SPEC §19.5 (intrinsic signatures)
- LANG_SPEC §19.11 (status table corrected)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/llvmgen/ -run TestRuntimeIntrinsicTyping` — 4 PASS + 5 SKIP
- [ ] `go test -short ./...` — no NEW failures
- [ ] `let p = raw.null()` produces `let.Type = RawPtr` in lowered IR
- [ ] Spec status table accurately reflects what's wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)