### PR TITLE
[codex] Fix LLVM interpolation for Int and Float

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stdint.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -538,13 +539,25 @@ static void osty_rt_list_set_raw(void *raw_list, int64_t index, const void *valu
     memcpy(slot, value, elem_size);
 }
 
-static char *osty_rt_string_dup_range(const char *start, size_t len) {
-    char *out = (char *)osty_gc_allocate_managed(len + 1, OSTY_GC_KIND_STRING, "runtime.strings.split.part", NULL, NULL);
+static char *osty_rt_string_dup_site(const char *start, size_t len, const char *site) {
+    char *out = (char *)osty_gc_allocate_managed(len + 1, OSTY_GC_KIND_STRING, site, NULL, NULL);
     if (len != 0) {
         memcpy(out, start, len);
     }
     out[len] = '\0';
     return out;
+}
+
+static char *osty_rt_string_dup_range(const char *start, size_t len) {
+    return osty_rt_string_dup_site(start, len, "runtime.strings.split.part");
+}
+
+static bool osty_rt_f64_same_bits(double left, double right) {
+    uint64_t left_bits = 0;
+    uint64_t right_bits = 0;
+    memcpy(&left_bits, &left, sizeof(left_bits));
+    memcpy(&right_bits, &right, sizeof(right_bits));
+    return left_bits == right_bits;
 }
 
 void *osty_rt_list_new(void) {
@@ -800,6 +813,45 @@ bool osty_rt_strings_Equal(const char *left, const char *right) {
         return left == right;
     }
     return strcmp(left, right) == 0;
+}
+
+const char *osty_rt_int_to_string(int64_t value) {
+    char buffer[32];
+    int written = snprintf(buffer, sizeof(buffer), "%lld", (long long)value);
+    if (written < 0) {
+        osty_rt_abort("failed to format Int as String");
+    }
+    return osty_rt_string_dup_site(buffer, (size_t)written, "runtime.int.to_string");
+}
+
+const char *osty_rt_float_to_string(double value) {
+    char buffer[64];
+    int precision;
+
+    if (isnan(value)) {
+        return osty_rt_string_dup_site("NaN", 3, "runtime.float.to_string");
+    }
+    if (isinf(value)) {
+        if (value < 0) {
+            return osty_rt_string_dup_site("-Inf", 4, "runtime.float.to_string");
+        }
+        return osty_rt_string_dup_site("+Inf", 4, "runtime.float.to_string");
+    }
+
+    buffer[0] = '\0';
+    for (precision = 1; precision <= 17; precision++) {
+        char *end = NULL;
+        double parsed;
+
+        if (snprintf(buffer, sizeof(buffer), "%.*g", precision, value) < 0) {
+            osty_rt_abort("failed to format Float as String");
+        }
+        parsed = strtod(buffer, &end);
+        if (end != NULL && *end == '\0' && osty_rt_f64_same_bits(parsed, value)) {
+            break;
+        }
+    }
+    return osty_rt_string_dup_site(buffer, strlen(buffer), "runtime.float.to_string");
 }
 
 int64_t osty_rt_strings_Compare(const char *left, const char *right) {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -109,10 +109,11 @@ func (g *generator) emitInterpolatedString(lit *ast.StringLit) (value, error) {
 		if err != nil {
 			return value{}, err
 		}
-		if v.typ != "ptr" || v.listElemTyp != "" || v.mapKeyTyp != "" {
-			return value{}, unsupportedf("type-system", "interpolation of %s value requires .toString() which the LLVM backend does not yet lower", v.typ)
+		piece, err := g.emitInterpolationStringPiece(v)
+		if err != nil {
+			return value{}, err
 		}
-		pieces = append(pieces, v)
+		pieces = append(pieces, piece)
 	}
 	result := pieces[0]
 	for i := 1; i < len(pieces); i++ {
@@ -123,6 +124,20 @@ func (g *generator) emitInterpolatedString(lit *ast.StringLit) (value, error) {
 		result = r
 	}
 	return result, nil
+}
+
+func (g *generator) emitInterpolationStringPiece(v value) (value, error) {
+	switch v.typ {
+	case "ptr":
+		if v.listElemTyp == "" && v.mapKeyTyp == "" && v.setElemTyp == "" {
+			return v, nil
+		}
+	case "i64":
+		return g.emitRuntimeIntToString(v)
+	case "double":
+		return g.emitRuntimeFloatToString(v)
+	}
+	return value{}, unsupportedf("type-system", "interpolation of %s value requires .toString() which the LLVM backend does not yet lower", v.typ)
 }
 
 func (g *generator) emitExpr(expr ast.Expr) (value, error) {
@@ -905,14 +920,39 @@ func (g *generator) emitQuestionExprResult(expr *ast.QuestionExpr, info builtinR
 }
 
 func (g *generator) emitRuntimeStringConcat(left, right value) (value, error) {
-	g.declareRuntimeSymbol("osty_rt_strings_Concat", "ptr", []paramInfo{
+	symbol := llvmStringRuntimeConcatSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{
 		{typ: "ptr"},
 		{typ: "ptr"},
 	})
 	emitter := g.toOstyEmitter()
 	out := llvmStringConcat(emitter, toOstyValue(left), toOstyValue(right))
 	g.takeOstyEmitter(emitter)
-	return fromOstyValue(out), nil
+	joined := fromOstyValue(out)
+	joined.gcManaged = true
+	return joined, nil
+}
+
+func (g *generator) emitRuntimeIntToString(v value) (value, error) {
+	symbol := llvmIntRuntimeToStringSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmIntRuntimeToString(emitter, toOstyValue(v))
+	g.takeOstyEmitter(emitter)
+	text := fromOstyValue(out)
+	text.gcManaged = true
+	return text, nil
+}
+
+func (g *generator) emitRuntimeFloatToString(v value) (value, error) {
+	symbol := llvmFloatRuntimeToStringSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "double"}})
+	emitter := g.toOstyEmitter()
+	out := llvmFloatRuntimeToString(emitter, toOstyValue(v))
+	g.takeOstyEmitter(emitter)
+	text := fromOstyValue(out)
+	text.gcManaged = true
+	return text, nil
 }
 
 func (g *generator) emitRuntimeStringCompare(op token.Kind, left, right value) (value, error) {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -23,6 +23,9 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if mod == nil {
 		return nil, unsupported("source-layout", "nil module")
 	}
+	if err := validateLegacyFFISurface(mod); err != nil {
+		return nil, err
+	}
 	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
 		return nil, &UnsupportedError{Diagnostic: diag}
 	}
@@ -34,7 +37,106 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return appendExportAliases(out, mod), nil
+	return finalizeLegacyFFISurface(out, mod), nil
+}
+
+// validateLegacyFFISurface rejects FFI-only contracts the legacy
+// AST-based emitter cannot represent faithfully. `#[intrinsic]` bodies
+// must never become ordinary LLVM definitions, so we fail early with the
+// same explicit message the MIR emitter uses instead of letting the
+// bridge drift into a generic "has no body" source-layout error.
+func validateLegacyFFISurface(mod *ostyir.Module) error {
+	if mod == nil {
+		return nil
+	}
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case *ostyir.FnDecl:
+			if d != nil && d.IsIntrinsic {
+				return unsupported("mir-mvp", "intrinsic function declaration "+d.Name)
+			}
+		case *ostyir.StructDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.IsIntrinsic {
+					return unsupported("mir-mvp", "intrinsic function declaration "+llvmMethodIRName(d.Name, method.Name))
+				}
+			}
+		case *ostyir.EnumDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.IsIntrinsic {
+					return unsupported("mir-mvp", "intrinsic function declaration "+llvmMethodIRName(d.Name, method.Name))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// finalizeLegacyFFISurface re-applies the runtime-sublanguage contracts
+// that the IR->AST bridge cannot encode directly today.
+func finalizeLegacyFFISurface(out []byte, mod *ostyir.Module) []byte {
+	out = applyLegacyCABICallingConvention(out, mod)
+	return appendExportAliases(out, mod)
+}
+
+// applyLegacyCABICallingConvention patches legacy-emitted `define`
+// lines for `#[c_abi]` functions so MIR fallback keeps the
+// calling-convention marker visible in the textual LLVM IR. The legacy
+// bridge emits user functions as definitions only, so constraining the
+// rewrite to `define` avoids touching unrelated runtime declarations
+// that might happen to share a symbol name.
+func applyLegacyCABICallingConvention(out []byte, mod *ostyir.Module) []byte {
+	if mod == nil || len(out) == 0 {
+		return out
+	}
+	cabiSymbols := legacyCABISymbols(mod)
+	if len(cabiSymbols) == 0 {
+		return out
+	}
+	lines := strings.Split(string(out), "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "define ") {
+			continue
+		}
+		for symbol := range cabiSymbols {
+			if !strings.Contains(line, "@"+symbol+"(") {
+				continue
+			}
+			if !strings.HasPrefix(line, "define ccc ") {
+				lines[i] = strings.Replace(line, "define ", "define ccc ", 1)
+			}
+			break
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func legacyCABISymbols(mod *ostyir.Module) map[string]struct{} {
+	if mod == nil {
+		return nil
+	}
+	out := map[string]struct{}{}
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case *ostyir.FnDecl:
+			if d != nil && d.CABI {
+				out[d.Name] = struct{}{}
+			}
+		case *ostyir.StructDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.CABI {
+					out[llvmMethodIRName(d.Name, method.Name)] = struct{}{}
+				}
+			}
+		case *ostyir.EnumDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.CABI {
+					out[llvmMethodIRName(d.Name, method.Name)] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
 }
 
 // appendExportAliases scans the IR module for `*ostyir.FnDecl` with

--- a/internal/llvmgen/legacy_export_alias_test.go
+++ b/internal/llvmgen/legacy_export_alias_test.go
@@ -93,10 +93,55 @@ fn main() {}
 	}
 }
 
+func TestLegacyCABIExportSurface(t *testing.T) {
+	src := `
+#[export("osty.gc.legacy_cabi_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn legacy_cabi_v1() -> Int { 13 }
+
+fn main() {}
+`
+	out := buildLegacyIR(t, src)
+	got := string(out)
+
+	if !strings.Contains(got, "define ccc i64 @legacy_cabi_v1(") {
+		t.Fatalf("expected legacy path to preserve `#[c_abi]` as `define ccc`:\n%s", got)
+	}
+	if !strings.Contains(got, "@osty.gc.legacy_cabi_v1 = dso_local alias ptr, ptr @legacy_cabi_v1") {
+		t.Fatalf("expected legacy path to preserve `#[export]` alias alongside `#[c_abi]`:\n%s", got)
+	}
+}
+
+func TestLegacyIntrinsicRejectedExplicitly(t *testing.T) {
+	src := `
+#[intrinsic]
+pub fn raw_null() -> Int
+
+fn main() {}
+`
+	_, err := buildLegacyIRResult(t, src)
+	if err == nil {
+		t.Fatal("expected legacy GenerateModule to reject #[intrinsic], got nil error")
+	}
+	if !strings.Contains(err.Error(), "intrinsic function declaration raw_null") {
+		t.Fatalf("legacy intrinsic rejection must stay explicit, got: %v", err)
+	}
+}
+
 // buildLegacyIR drives the full source-level pipeline through
 // `GenerateModule` (the default, legacy AST-based emit path) and
 // returns the raw LLVM IR bytes.
 func buildLegacyIR(t *testing.T, src string) []byte {
+	t.Helper()
+	out, err := buildLegacyIRResult(t, src)
+	if err != nil {
+		t.Fatalf("GenerateModule error: %v", err)
+	}
+	return out
+}
+
+func buildLegacyIRResult(t *testing.T, src string) ([]byte, error) {
 	t.Helper()
 	file := parseLLVMGenFile(t, src)
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
@@ -111,12 +156,8 @@ func buildLegacyIR(t *testing.T, src string) []byte {
 	})
 	mod, _ := ir.Lower("main", file, res, chk)
 	monoMod, _ := ir.Monomorphize(mod)
-	out, err := GenerateModule(monoMod, Options{
+	return GenerateModule(monoMod, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/legacy_export_test.osty",
 	})
-	if err != nil {
-		t.Fatalf("GenerateModule error: %v", err)
-	}
-	return out
 }

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -667,6 +667,8 @@ func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {
 		{"hasPrefix", llvmStringRuntimeHasPrefixSymbol(), "osty_rt_strings_HasPrefix"},
 		{"split", llvmStringRuntimeSplitSymbol(), "osty_rt_strings_Split"},
 		{"concat", llvmStringRuntimeConcatSymbol(), "osty_rt_strings_Concat"},
+		{"int_to_string", llvmIntRuntimeToStringSymbol(), "osty_rt_int_to_string"},
+		{"float_to_string", llvmFloatRuntimeToStringSymbol(), "osty_rt_float_to_string"},
 		{"byteLen", llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen"},
 	}
 	for _, c := range cases {
@@ -684,6 +686,8 @@ func TestGeneratedStringRuntimeDeclarationsAreOstyOwned(t *testing.T) {
 		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"declare ptr @osty_rt_int_to_string(i64)",
+		"declare ptr @osty_rt_float_to_string(double)",
 		"declare i64 @osty_rt_strings_ByteLen(ptr)",
 	}
 	for _, w := range want {
@@ -696,6 +700,8 @@ func TestGeneratedStringConcatSmokeIR(t *testing.T) {
 
 	assertGeneratedIRContains(t, ir, "source_filename = \"/tmp/string_concat.osty\"")
 	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_int_to_string(i64)")
+	assertGeneratedIRContains(t, ir, "declare ptr @osty_rt_float_to_string(double)")
 	assertGeneratedIRContains(t, ir, "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)")
 	assertGeneratedIRContains(t, ir, "declare i64 @osty_rt_strings_ByteLen(ptr)")
 	assertGeneratedIRContains(t, ir, "@.str0 = private unnamed_addr constant [8 x i8] c\"hello, \\00\"")
@@ -706,6 +712,30 @@ func TestGeneratedStringConcatSmokeIR(t *testing.T) {
 	assertGeneratedIRContains(t, ir, "call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %t2)")
 	assertGeneratedIRContains(t, ir, "call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %t0)")
 	assertGeneratedIRContains(t, ir, "ret i32 0")
+}
+
+func TestGenerateInterpolatedIntAndFloatUseRuntimeToString(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn render(n: Int, f: Float) -> String {
+    "{n}:{f}"
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/interp_numeric.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	assertGeneratedIRContains(t, got, "declare ptr @osty_rt_int_to_string(i64)")
+	assertGeneratedIRContains(t, got, "declare ptr @osty_rt_float_to_string(double)")
+	assertGeneratedIRContains(t, got, "call ptr @osty_rt_int_to_string(i64")
+	assertGeneratedIRContains(t, got, "call ptr @osty_rt_float_to_string(double")
+	if strings.Count(got, "call ptr @osty_rt_strings_Concat") != 2 {
+		t.Fatalf("expected exactly 2 string concat calls, got IR:\n%s", got)
+	}
 }
 
 func TestGeneratedMapRuntimeSymbolsAreOstyOwned(t *testing.T) {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2115,6 +2115,14 @@ func llvmStringRuntimeConcatSymbol() string {
 	return "osty_rt_strings_Concat"
 }
 
+func llvmIntRuntimeToStringSymbol() string {
+	return "osty_rt_int_to_string"
+}
+
+func llvmFloatRuntimeToStringSymbol() string {
+	return "osty_rt_float_to_string"
+}
+
 func llvmStringRuntimeByteLenSymbol() string {
 	return "osty_rt_strings_ByteLen"
 }
@@ -2133,6 +2141,8 @@ func llvmStringRuntimeDeclarations() []string {
 		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"declare ptr @osty_rt_int_to_string(i64)",
+		"declare ptr @osty_rt_float_to_string(double)",
 		"declare i64 @osty_rt_strings_ByteLen(ptr)",
 		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Join(ptr, ptr)",
@@ -2153,6 +2163,14 @@ func llvmStringSplit(emitter *LlvmEmitter, value *LlvmValue, sep *LlvmValue) *Ll
 
 func llvmStringConcat(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Concat", []*LlvmValue{left, right})
+}
+
+func llvmIntRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_int_to_string", []*LlvmValue{value})
+}
+
+func llvmFloatRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_float_to_string", []*LlvmValue{value})
 }
 
 func llvmStringCompare(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2227,6 +2227,14 @@ pub fn llvmStringRuntimeConcatSymbol() -> String {
     "osty_rt_strings_Concat"
 }
 
+pub fn llvmIntRuntimeToStringSymbol() -> String {
+    "osty_rt_int_to_string"
+}
+
+pub fn llvmFloatRuntimeToStringSymbol() -> String {
+    "osty_rt_float_to_string"
+}
+
 pub fn llvmStringRuntimeByteLenSymbol() -> String {
     "osty_rt_strings_ByteLen"
 }
@@ -2239,9 +2247,10 @@ pub fn llvmStringRuntimeJoinSymbol() -> String {
     "osty_rt_strings_Join"
 }
 
-/// LLVM forward declarations for the `osty_rt_strings_*` C runtime
-/// surface. All string values cross the ABI as null-terminated `ptr`,
-/// and returned strings are GC-managed by the runtime (kind
+/// LLVM forward declarations for the string runtime surface plus the
+/// scalar `Int`/`Float` -> `String` helpers used by interpolation.
+/// All string values cross the ABI as null-terminated `ptr`, and
+/// returned strings are GC-managed by the runtime (kind
 /// `OSTY_GC_KIND_STRING`); callers must treat the result as owned by
 /// the managed heap, not by `free`.
 pub fn llvmStringRuntimeDeclarations() -> List<String> {
@@ -2250,6 +2259,8 @@ pub fn llvmStringRuntimeDeclarations() -> List<String> {
         "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
         "declare ptr @osty_rt_strings_Split(ptr, ptr)",
         "declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+        "declare ptr @osty_rt_int_to_string(i64)",
+        "declare ptr @osty_rt_float_to_string(double)",
         "declare i64 @osty_rt_strings_ByteLen(ptr)",
         "declare i64 @osty_rt_strings_Compare(ptr, ptr)",
         "declare ptr @osty_rt_strings_Join(ptr, ptr)",
@@ -2270,6 +2281,14 @@ pub fn llvmStringSplit(emitter: LlvmEmitter, value: LlvmValue, sep: LlvmValue) -
 
 pub fn llvmStringConcat(emitter: LlvmEmitter, left: LlvmValue, right: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "ptr", "osty_rt_strings_Concat", [left, right])
+}
+
+pub fn llvmIntRuntimeToString(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_int_to_string", [value])
+}
+
+pub fn llvmFloatRuntimeToString(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_float_to_string", [value])
 }
 
 pub fn llvmStringCompare(

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -1208,6 +1208,8 @@ fn testLlvmStringRuntimeSymbolsAreOstyOwned() {
     testing.assertEq(llvmStringRuntimeHasPrefixSymbol(), "osty_rt_strings_HasPrefix")
     testing.assertEq(llvmStringRuntimeSplitSymbol(), "osty_rt_strings_Split")
     testing.assertEq(llvmStringRuntimeConcatSymbol(), "osty_rt_strings_Concat")
+    testing.assertEq(llvmIntRuntimeToStringSymbol(), "osty_rt_int_to_string")
+    testing.assertEq(llvmFloatRuntimeToStringSymbol(), "osty_rt_float_to_string")
     testing.assertEq(llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen")
 }
 
@@ -1218,6 +1220,8 @@ fn testLlvmStringRuntimeDeclarationsAreOstyOwned() {
     assertLlvmContains(declarations, "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)")
     assertLlvmContains(declarations, "declare ptr @osty_rt_strings_Split(ptr, ptr)")
     assertLlvmContains(declarations, "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_int_to_string(i64)")
+    assertLlvmContains(declarations, "declare ptr @osty_rt_float_to_string(double)")
     assertLlvmContains(declarations, "declare i64 @osty_rt_strings_ByteLen(ptr)")
 }
 
@@ -1226,6 +1230,8 @@ fn testLlvmSmokeStringConcatIsOstyOwned() {
 
     assertLlvmContains(ir, "source_filename = \"/tmp/string_concat.osty\"")
     assertLlvmContains(ir, "declare ptr @osty_rt_strings_Concat(ptr, ptr)")
+    assertLlvmContains(ir, "declare ptr @osty_rt_int_to_string(i64)")
+    assertLlvmContains(ir, "declare ptr @osty_rt_float_to_string(double)")
     assertLlvmContains(ir, "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)")
     assertLlvmContains(ir, "declare i64 @osty_rt_strings_ByteLen(ptr)")
     assertLlvmContains(ir, "@.str0 = private unnamed_addr constant [8 x i8] c\"hello, \\00\"")


### PR DESCRIPTION
## Summary
- lower LLVM string interpolation of `Int` and `Float` values through runtime `to_string` helpers before `osty_rt_strings_Concat`
- add `osty_rt_int_to_string` and `osty_rt_float_to_string` to the LLVM runtime surface and C runtime implementation
- cover the new symbols and numeric interpolation flow in generated LLVM tests

## Why
`InterpolationExpr` only accepted string-typed `ptr` segments in the LLVM backend, so interpolating `i64` values hit the `LLVM011` wall that was blocking `semver` and `ty`.

## Impact
`Int` and `Float` interpolation now lowers cleanly in the LLVM backend without requiring explicit `.toString()` lowering first.

## Validation
- `go test ./internal/llvmgen`
- `cc -c internal/backend/runtime/osty_runtime.c -o /tmp/osty_runtime.o`