### PR TITLE
[codex] preserve ffi surface on legacy fallback

### DIFF
--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -23,6 +23,9 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if mod == nil {
 		return nil, unsupported("source-layout", "nil module")
 	}
+	if err := validateLegacyFFISurface(mod); err != nil {
+		return nil, err
+	}
 	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
 		return nil, &UnsupportedError{Diagnostic: diag}
 	}
@@ -34,7 +37,106 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return appendExportAliases(out, mod), nil
+	return finalizeLegacyFFISurface(out, mod), nil
+}
+
+// validateLegacyFFISurface rejects FFI-only contracts the legacy
+// AST-based emitter cannot represent faithfully. `#[intrinsic]` bodies
+// must never become ordinary LLVM definitions, so we fail early with the
+// same explicit message the MIR emitter uses instead of letting the
+// bridge drift into a generic "has no body" source-layout error.
+func validateLegacyFFISurface(mod *ostyir.Module) error {
+	if mod == nil {
+		return nil
+	}
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case *ostyir.FnDecl:
+			if d != nil && d.IsIntrinsic {
+				return unsupported("mir-mvp", "intrinsic function declaration "+d.Name)
+			}
+		case *ostyir.StructDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.IsIntrinsic {
+					return unsupported("mir-mvp", "intrinsic function declaration "+llvmMethodIRName(d.Name, method.Name))
+				}
+			}
+		case *ostyir.EnumDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.IsIntrinsic {
+					return unsupported("mir-mvp", "intrinsic function declaration "+llvmMethodIRName(d.Name, method.Name))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// finalizeLegacyFFISurface re-applies the runtime-sublanguage contracts
+// that the IR->AST bridge cannot encode directly today.
+func finalizeLegacyFFISurface(out []byte, mod *ostyir.Module) []byte {
+	out = applyLegacyCABICallingConvention(out, mod)
+	return appendExportAliases(out, mod)
+}
+
+// applyLegacyCABICallingConvention patches legacy-emitted `define`
+// lines for `#[c_abi]` functions so MIR fallback keeps the
+// calling-convention marker visible in the textual LLVM IR. The legacy
+// bridge emits user functions as definitions only, so constraining the
+// rewrite to `define` avoids touching unrelated runtime declarations
+// that might happen to share a symbol name.
+func applyLegacyCABICallingConvention(out []byte, mod *ostyir.Module) []byte {
+	if mod == nil || len(out) == 0 {
+		return out
+	}
+	cabiSymbols := legacyCABISymbols(mod)
+	if len(cabiSymbols) == 0 {
+		return out
+	}
+	lines := strings.Split(string(out), "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "define ") {
+			continue
+		}
+		for symbol := range cabiSymbols {
+			if !strings.Contains(line, "@"+symbol+"(") {
+				continue
+			}
+			if !strings.HasPrefix(line, "define ccc ") {
+				lines[i] = strings.Replace(line, "define ", "define ccc ", 1)
+			}
+			break
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func legacyCABISymbols(mod *ostyir.Module) map[string]struct{} {
+	if mod == nil {
+		return nil
+	}
+	out := map[string]struct{}{}
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case *ostyir.FnDecl:
+			if d != nil && d.CABI {
+				out[d.Name] = struct{}{}
+			}
+		case *ostyir.StructDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.CABI {
+					out[llvmMethodIRName(d.Name, method.Name)] = struct{}{}
+				}
+			}
+		case *ostyir.EnumDecl:
+			for _, method := range d.Methods {
+				if method != nil && method.CABI {
+					out[llvmMethodIRName(d.Name, method.Name)] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
 }
 
 // appendExportAliases scans the IR module for `*ostyir.FnDecl` with

--- a/internal/llvmgen/legacy_export_alias_test.go
+++ b/internal/llvmgen/legacy_export_alias_test.go
@@ -93,10 +93,55 @@ fn main() {}
 	}
 }
 
+func TestLegacyCABIExportSurface(t *testing.T) {
+	src := `
+#[export("osty.gc.legacy_cabi_v1")]
+#[c_abi]
+#[no_alloc]
+pub fn legacy_cabi_v1() -> Int { 13 }
+
+fn main() {}
+`
+	out := buildLegacyIR(t, src)
+	got := string(out)
+
+	if !strings.Contains(got, "define ccc i64 @legacy_cabi_v1(") {
+		t.Fatalf("expected legacy path to preserve `#[c_abi]` as `define ccc`:\n%s", got)
+	}
+	if !strings.Contains(got, "@osty.gc.legacy_cabi_v1 = dso_local alias ptr, ptr @legacy_cabi_v1") {
+		t.Fatalf("expected legacy path to preserve `#[export]` alias alongside `#[c_abi]`:\n%s", got)
+	}
+}
+
+func TestLegacyIntrinsicRejectedExplicitly(t *testing.T) {
+	src := `
+#[intrinsic]
+pub fn raw_null() -> Int
+
+fn main() {}
+`
+	_, err := buildLegacyIRResult(t, src)
+	if err == nil {
+		t.Fatal("expected legacy GenerateModule to reject #[intrinsic], got nil error")
+	}
+	if !strings.Contains(err.Error(), "intrinsic function declaration raw_null") {
+		t.Fatalf("legacy intrinsic rejection must stay explicit, got: %v", err)
+	}
+}
+
 // buildLegacyIR drives the full source-level pipeline through
 // `GenerateModule` (the default, legacy AST-based emit path) and
 // returns the raw LLVM IR bytes.
 func buildLegacyIR(t *testing.T, src string) []byte {
+	t.Helper()
+	out, err := buildLegacyIRResult(t, src)
+	if err != nil {
+		t.Fatalf("GenerateModule error: %v", err)
+	}
+	return out
+}
+
+func buildLegacyIRResult(t *testing.T, src string) ([]byte, error) {
 	t.Helper()
 	file := parseLLVMGenFile(t, src)
 	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
@@ -111,12 +156,8 @@ func buildLegacyIR(t *testing.T, src string) []byte {
 	})
 	mod, _ := ir.Lower("main", file, res, chk)
 	monoMod, _ := ir.Monomorphize(mod)
-	out, err := GenerateModule(monoMod, Options{
+	return GenerateModule(monoMod, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/legacy_export_test.osty",
 	})
-	if err != nil {
-		t.Fatalf("GenerateModule error: %v", err)
-	}
-	return out
 }


### PR DESCRIPTION
## What changed
- validate legacy `GenerateModule` input so `#[intrinsic]` functions fail with the same explicit backend error used by the MIR path
- re-apply `#[c_abi]` to legacy-emitted LLVM `define` lines before appending existing `#[export]` aliases
- add legacy-path regression tests covering `#[export] + #[c_abi]` and explicit `#[intrinsic]` rejection

## Why
MIR codegen already preserved the runtime FFI surface, but the legacy fallback path still dropped part of that contract. When MIR fell back to `GenerateModule`, `#[export]` survived via aliases while `#[c_abi]` visibility was lost and `#[intrinsic]` failed with a vague source-layout error.

## Impact
- legacy fallback now keeps the intended FFI surface visible for runtime-facing functions
- intrinsic declarations fail fast with a clearer backend diagnostic instead of drifting into a generic bridge error
- the behavior is locked in with regression coverage on the legacy emitter path

## Validation
- `go test ./internal/llvmgen -run 'TestLegacy(ExportAlias|CABI|Intrinsic)|Test(IntrinsicPropagation|CABI|ExportSymbol)' -count=1`
- `go test ./internal/backend ./internal/llvmgen -count=1` *(currently fails in pre-existing `TestRuntimeIntrinsicTypingRawNull`, `TestRuntimeIntrinsicTypingRawAlloc`, and `TestRuntimeIntrinsicTypingRawBits` due to RawPtr typing returning `<error>`)*
