### PR TITLE
[codex] refresh docs for current implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,24 @@ emitter core for the native backend, project scaffolding (`osty new` /
 declared packages, API documentation generation (`osty doc`), CI quality
 tooling (`osty ci`), profile/target/feature/cache inspection commands, and a
 package manager (`osty add` / `osty update` / `osty publish`) backed by a
-file-backed HTTP registry server for local/private registries. The current
-language baseline is v0.4: the grammar is frozen, the remaining semantic
-corners are closed, and the next work is native implementation/runtime
-coverage. The public compiler path is now native-only through the LLVM backend.
+file-backed HTTP registry server for local/private registries. The repository
+tracks spec/grammar work in v0.5, but the shipped manifest/scaffolder path is
+still pinned to edition v0.4 today (`osty new` / `osty init` write
+`edition = "0.4"`, and checked-in fixtures still exercise legacy v0.3/v0.4
+inputs). The next work is native implementation/runtime coverage. The public
+compiler path is now native-only through the LLVM backend.
 
 ## Status
 
 | Phase | Status |
 |---|---|
 | Lexer (UTF-8, ASI, triple-quoted strings, interpolation) | done |
-| Parser (v0.4 grammar, error recovery, fuzz-clean) | done |
+| Parser (selfhosted front end, error recovery, fuzz-clean) | done |
 | AST (all node kinds implement `ast.Node`) | done |
 | Diagnostics (`error[E0002]:` with caret, hints, notes) | done |
 | Name resolution (single + multi-file, workspace, typo suggestions) | done |
 | Formatter (`internal/format`) | done |
-| Type checker (`internal/check`) | done for v0.4 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md); `osty check --inspect` observes it at runtime |
+| Type checker (`internal/check`) | done for the shipped v0.4 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md); `osty check --inspect` observes it at runtime |
 | Linter (`internal/lint`, L0001–L0042, `--fix` / `--fix-dry-run`) | done |
 | Multi-file packages (`resolve` loader/package/workspace) | done |
 | LSP (`internal/lsp`, wired as `osty lsp`) | done — hover, definition, formatting, documentSymbol, lint diagnostics, editor policy backed by toolchain sources |
@@ -40,7 +42,7 @@ coverage. The public compiler path is now native-only through the LLVM backend.
 | Manifest + lockfile + SemVer (`internal/manifest`, `lockfile`, `pkgmgr/semver`) | done (parse + validate + resolve) |
 | Build orchestrator (`osty build`) | done — manifest → front-end → native backend, profile/target/feature wiring, backend-aware artifact/cache paths |
 | `osty test` | native backend harness — discovers `test*` functions, compiles each through the LLVM backend, runs in parallel by default with a seeded shuffled order (`--seed`, `--serial`, `--jobs`), reports per-test wall time and an `ok/FAIL` summary; assertions are intercepted by the LLVM generator and failures exit non-zero with the source location. `benchmark`/`snapshot` and per-argument structural diff are not implemented yet |
-| API doc generator (`internal/docgen`, `osty doc`) | done — checked-in generated Go package, HTML + markdown, field docs, cross-refs, workspace mode |
+| API doc generator (`internal/docgen`, `osty doc`) | done — checked-in generated Go package, HTML + markdown, field docs, cross-refs, `--check`, `--verify-examples`, workspace mode |
 | CI quality tooling (`internal/ci`, `osty ci`) | done — Osty-authored generated CI core, signature-aware snapshots, workspace coverage, JSON reports |
 | Pipeline visualizer (`osty pipeline`) | done — per-stage timing, workspace mode, backend-aware gen, baseline diff, LSP trace, `--explain` |
 | Profiles / targets / features / cache (`internal/profile`, `osty profiles` / `targets` / `features` / `cache`) | done — built-in and manifest profiles, cross-target env, feature closure + file pragmas, backend-aware fingerprints |
@@ -50,6 +52,14 @@ coverage. The public compiler path is now native-only through the LLVM backend.
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
 | `osty run` (build + exec through backend) | wired — resolves manifest, vendors deps, emits the native entry artifact, runs the backend binary with profile/feature flags, and rejects cross-target execution |
 | `osty publish` (pack + upload tarball to a registry) | wired — deterministic gzipped tar, sha256 checksum, bearer-auth POST; `--dry-run` stops before upload |
+
+Status note (revalidated 2026-04-19): the universal LLVM CLI wedge called out
+in older status docs is closed again. A fresh hello-world
+`osty gen --backend=llvm` run exits 0 and emits `.ll`, and the four targeted
+`internal/llvmgen` regressions previously cited in
+[`docs/toolchain_llvm_status.md`](./docs/toolchain_llvm_status.md) now pass.
+Current selfhosting/toolchain tracking is therefore about remaining front-end
+and toolchain-surface gaps, not a blanket "all LLVM CLI calls panic" state.
 
 The front-end (lex → parse → resolve → type-check) is **coverage-complete
 for the v0.4 core**: spec blocks parse, package/workspace resolution is
@@ -90,9 +100,9 @@ parity.
 
 ```
 osty/
-├── LANG_SPEC_v0.5/          # Current language spec (prose + examples)
+├── LANG_SPEC_v0.5/          # Current spec prose / design target
 ├── OSTY_GRAMMAR_v0.5.md     # Current EBNF grammar + decision log
-├── SPEC_GAPS.md             # Resolved-gap archive (no open items in v0.4)
+├── SPEC_GAPS.md             # Resolved-gap archive by language version
 ├── LLVM_MIGRATION_PLAN.md   # Native backend migration history/plan
 ├── LLVM_PHASE1_BASELINE.md  # Legacy Go-backend baseline for LLVM migration
 ├── LLVM_BACKEND_CORPUS.md   # Backend parity fixture classes and smoke set
@@ -104,9 +114,10 @@ osty/
 │   └── codesdoc/            # Regenerates ERROR_CODES.md from codes.go
 ├── internal/
 │   ├── token/               # Token kinds + positions
-│   ├── lexer/               # Source bytes → []Token
+│   ├── lexer/               # Thin Go facade over internal/selfhost tokenization
 │   ├── ast/                 # AST node types
-│   ├── parser/              # []Token → *ast.File
+│   ├── parser/              # Thin Go facade + compatibility lowerings over internal/selfhost
+│   ├── selfhost/            # Committed bootstrap-generated front end + adapters
 │   ├── diag/                # Diagnostics + Rust-style renderer
 │   ├── resolve/             # Name resolution (single + multi-file)
 │   ├── stdlib/              # Built-in prelude symbols + `modules/*.osty`
@@ -123,12 +134,13 @@ osty/
 │   ├── cihost/              # Go host bridge for generated CI core
 │   ├── profile/             # Build profiles / targets / features
 │   ├── lsp/                 # Language server (stdio JSON-RPC)
+│   ├── pipeline/            # Shared phase runner / timing helpers
 │   ├── scaffold/            # `osty new` / `osty init` project templates
 │   ├── tomlparse/           # Generic TOML parser (subset)
 │   ├── manifest/            # osty.toml parse + validate + lookup
 │   ├── lockfile/            # osty.lock read/write
 │   ├── registry/            # Package registry client + file-backed HTTP server
-│   └── pkgmgr/semver/       # SemVer parse, compare, constraint match
+│   └── pkgmgr/              # Dependency resolution, fetch/vendoring, SemVer
 ├── examples/                # Executable/sample packages kept under compiler coverage
 ├── toolchain/               # Osty-authored compiler/tooling cores and LLVM emitter prototype
 └── testdata/                # .osty fixtures used by tests and backend corpus
@@ -136,7 +148,7 @@ osty/
 
 ## Building
 
-Requires Go 1.22+.
+Requires Go 1.26.2 or newer (matching `go.mod`).
 
 ```sh
 go build -o osty ./cmd/osty
@@ -198,8 +210,8 @@ implementation work should land in the runtime path first.
 ## CLI
 
 ```sh
-osty new NAME          # scaffold a new project directory (--lib, --workspace)
-osty init              # scaffold into the current directory (same flags as new)
+osty new NAME          # scaffold a new project directory (--bin, --lib, --workspace, --cli, --service)
+osty init              # scaffold into the current directory (same kind flags; --name, --member)
 osty build [DIR]       # manifest-driven: manifest → deps → front-end → backend
 osty add PKG           # append a dependency to osty.toml and re-resolve
 osty remove NAME...    # drop dependencies from osty.toml and re-resolve (alias: rm)
@@ -225,15 +237,18 @@ osty typecheck FILE    # same as check, plus a per-expression type dump
 osty lint FILE|DIR     # style + correctness warnings (L0xxx codes)
 osty fmt FILE          # airepair + format to canonical style (see --check, --write, --engine)
 osty airepair FILE     # auto-fix common AI-authored syntax/idiom slips (legacy alias: repair)
+osty airepair triage DIR
+osty airepair learn DIR
+osty airepair promote CASE
 osty gen FILE          # emit LLVM IR (see -o, --package)
-osty doc PATH          # generate API documentation (HTML + markdown)
+osty doc PATH          # generate API documentation (HTML + markdown; --check, --verify-examples)
 osty ci                # run CI quality checks (signatures, coverage, snapshots)
 osty ci snapshot       # capture the exported API baseline
 osty profiles          # list build profiles (debug, release, profile, test, ...)
 osty targets           # list declared cross-compilation targets
 osty features          # list declared opt-in features
 osty cache [ls|clean|info] # inspect or prune backend build caches
-osty scaffold          # generators (fixture / schema / ffi)
+osty scaffold <kind>   # one-off generators (fixture / schema / ffi)
 osty lsp               # run the language server on stdio
 osty explain [CODE]    # describe a diagnostic (Exxxx/Wxxxx/Lxxxx); no arg lists every code
 osty pipeline FILE|DIR # run every front-end phase; per-stage timing
@@ -359,19 +374,20 @@ surface (`use runtime.* as name { ... }`) before using the native backend.
 
 `new` / `init`-specific flags (after the subcommand):
 
-- `--bin` — scaffold a binary project (default): `main.osty` with `fn main`
-- `--lib` — scaffold a library project: `lib.osty` with a `pub fn` starter,
-  no binary entry point
-- `--workspace` — scaffold a virtual workspace with one default member
-  (`init` only — combined with `--member NAME` to pick the member directory)
+- `--bin`, `--lib`, `--workspace`, `--cli`, `--service` — mutually
+  exclusive starter layouts; `--bin` is the default
+- `--member NAME` — workspace-only: default member directory name
+  (default `core`)
 - `--name NAME` — `init`-only: override the project name (defaults to the
   current directory basename)
 
-The scaffolded layout is three files (`osty.toml`, the source file, and
-`.gitignore`) in a new directory named after `NAME`. The manifest pins
-the current spec edition; `osty new` never overwrites an existing
-directory. `osty init` writes into the current directory instead of
-creating a new one.
+Binary and library starters create `osty.toml`, one source file, one
+companion `*_test.osty`, and `.gitignore`. `--cli` and `--service`
+create multi-file binary starters with tests. `--workspace` creates a
+root manifest plus one default member package. `osty new` never
+overwrites an existing directory; `osty init` writes into the current
+directory after checking for conflicting files. The scaffolder currently
+pins `edition = "0.4"`.
 
 `build` / `run` / `test` / `add` / `update` / `fetch`-specific flags
 (after the subcommand):
@@ -400,8 +416,9 @@ creating a new one.
   through structured diagnostics from the toolchain backend policy.
 - `--emit MODE` — requested artifact mode (`llvm-ir`, `object`, or
   `binary`). `build --backend llvm --emit object|binary` uses `clang`; `run`
-  requires `binary` because it executes the result. Native test execution is
-  still pending.
+  requires `binary` because it executes the result. `osty test` uses the same
+  native path under the hood and then runs discovered test functions through the
+  LLVM-backed harness.
 
 `profiles` / `targets` / `features` / `cache` commands:
 
@@ -498,7 +515,7 @@ a different package without leaving its directory.
 $ osty new myapp
 Created binary project "myapp" at $PWD/myapp
 $ cd myapp
-$ osty add ../my-shared-lib --path ../../shared
+$ osty add --path ../../shared
 Added dependency shared 0.1.0 (path+../../shared)
 $ osty build
 Resolved 1 dependencies for myapp v0.1.0
@@ -601,13 +618,16 @@ regenerations.
 
 ## Contributing
 
-The current baseline is **v0.5** (`LANG_SPEC_v0.5/`,
-`OSTY_GRAMMAR_v0.5.md`). v0.5 closes every known language-decision
-gap (G20-G35) accumulated from the v0.4 usage corpus. Future surface
-changes follow the normal versioning process and land in a new spec
-directory. See [`SPEC_GAPS.md`](./SPEC_GAPS.md) for the full decision
-log. The compiler follows spec decisions literally — if a construct
-"should" work but doesn't, verify it against the grammar first.
+Spec work in this repo is tracked under **v0.5**
+(`LANG_SPEC_v0.5/`, `OSTY_GRAMMAR_v0.5.md`), but the shipped project
+edition is still **0.4** today: `osty new` / `osty init` write
+`edition = "0.4"`, and manifest validation still accepts the
+historical `0.3` / `0.4` range used by checked-in examples. Future
+surface changes follow the normal versioning process and land in a new
+spec directory. See [`SPEC_GAPS.md`](./SPEC_GAPS.md) for the full
+decision log. When docs discuss newer surface area, be explicit about
+whether it is a design target or behavior already wired in the CLI and
+tests.
 
 Conventions:
 - Every new error site gets a stable `Exxxx` code in

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1330,8 +1330,8 @@ func printScopeNode(s *resolve.Scope, depth int) {
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage: osty [flags] (parse|tokens|resolve|check|typecheck|lint|fmt|airepair|gen) FILE")
-	fmt.Fprintln(os.Stderr, "       osty new [--lib] NAME     (scaffold a new project)")
-	fmt.Fprintln(os.Stderr, "       osty init [--lib]         (scaffold into the current directory)")
+	fmt.Fprintln(os.Stderr, "       osty new [--bin|--lib|--workspace|--cli|--service] [--member NAME] NAME")
+	fmt.Fprintln(os.Stderr, "       osty init [--bin|--lib|--workspace|--cli|--service] [--name NAME] [--member NAME]")
 	fmt.Fprintln(os.Stderr, "       osty build [DIR]          (manifest + deps + front end + backend artifacts)")
 	fmt.Fprintln(os.Stderr, "       osty add NAME[@VER]       (add a dependency; also --path, --git)")
 	fmt.Fprintln(os.Stderr, "       osty update [NAME...]     (refresh osty.lock)")
@@ -1354,6 +1354,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "       osty targets              (list declared cross-compilation targets)")
 	fmt.Fprintln(os.Stderr, "       osty features             (list declared opt-in features)")
 	fmt.Fprintln(os.Stderr, "       osty cache [ls|clean|info] (inspect / prune the build cache)")
+	fmt.Fprintln(os.Stderr, "       osty scaffold <fixture|schema|ffi> [flags] NAME")
 	fmt.Fprintln(os.Stderr, "       osty lsp                  (language server on stdio)")
 	fmt.Fprintln(os.Stderr, "       osty explain [CODE]       (describe a diagnostic code; no arg lists every code)")
 	fmt.Fprintln(os.Stderr, "       osty pipeline FILE|DIR    (run every front-end phase; per-stage timing; --gen supports --backend)")
@@ -1407,6 +1408,9 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --lib              scaffold a library project (lib.osty, no main)")
 	fmt.Fprintln(os.Stderr, "  --bin              scaffold a binary project (main.osty) [default]")
 	fmt.Fprintln(os.Stderr, "  --workspace        scaffold a virtual workspace with one default member")
+	fmt.Fprintln(os.Stderr, "  --cli              scaffold a multi-file CLI app starter")
+	fmt.Fprintln(os.Stderr, "  --service          scaffold a multi-file HTTP service starter")
+	fmt.Fprintln(os.Stderr, "  --member NAME      workspace member directory name (default: core)")
 	fmt.Fprintln(os.Stderr, "add-specific flags (after the subcommand):")
 	fmt.Fprintln(os.Stderr, "  --path DIR         local-path dependency (no network)")
 	fmt.Fprintln(os.Stderr, "  --git URL          git dependency; also --tag, --branch, --rev")

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -1,79 +1,100 @@
 # Toolchain × LLVM compilability — status report
 
-Snapshot date: 2026-04-18, against branch tip `5ace7c3`. Stage numbers
-shift week-over-week; for the live MIR-direct coverage see
+Snapshot date: 2026-04-19. This refresh revalidated the universal CLI / LLVM
+smoke path and the previously named `internal/llvmgen` regressions. The deeper
+`toolchain/*.osty` error-budget counts below are still the 2026-04-18 sample
+until they are re-run end-to-end. Stage numbers shift week-over-week; for the
+live MIR-direct coverage see
 [docs/mir_design.md](./mir_design.md) Stage 3.x + Stage 5 sections.
 
 ## TL;DR
 
-Today zero `toolchain/*.osty` files reach `internal/llvmgen`. The pipeline
-stops on one of:
+The old "CLI panic blocks any `osty gen --backend=llvm` call" statement is no
+longer true.
+
+As of 2026-04-19:
+
+- a fresh `fn main() { println(42) }` file goes through
+  `osty gen --backend=llvm` successfully and emits LLVM IR
+- the four targeted `internal/llvmgen` tests called out in the previous
+  snapshot now pass again
+- the parser-side `def: Expr` stable-alias issue remains fixed
+
+That means the universal LLVM entry wedge is closed. The remaining
+toolchain/selfhosting work is now about front-end/toolchain coverage, not "any
+CLI use of LLVM crashes before backend emission."
+
+The 2026-04-18 full-toolchain sample still showed the following blockers:
 
 | Layer | Where | What blocks |
 |---|---|---|
-| CLI wiring | `internal/check/host_boundary.go:578` | `osty gen --backend=llvm <any>.osty` segfaults (nil pointer in `selfhostSpanIndex.addNode`) before the backend is reached |
+| CLI wiring | historical 2026-04-18 blocker | **resolved in the 2026-04-19 refresh** — hello-world `osty gen --backend=llvm` now exits 0 and writes `.ll` output |
 | Front-end (lexer) | `internal/lexer` string-interpolation path | `"0_{label}"` / `"[a-z0-9_-]*"` inside string literals are flagged E0008 |
 | Front-end (resolver) | `internal/resolve` / `internal/stdlib` | `std.strings` module not in scope — 39 × E0500 in `toolchain/ast_lower.osty` alone |
-| Front-end (parser) | `internal/parser` | `fn …(def: Expr)` inside a `use "…" { … }` FFI block fails with E0001 |
+| Front-end (parser) | historical 2026-04-18 blocker | **resolved before this refresh** — `def: Expr` is no longer rewritten in `name: Type` positions |
 | Type checker | `internal/check` | 1700 aggregated errors across the package (but 97.6% of assignment/return/call checks still accept — tail is small per-file) |
 
 The MIR-direct emitter itself (Stages 3.1–3.11) covers most of the language
-shapes toolchain uses. What is blocking is *front-end bookkeeping and CLI
-plumbing*, not backend lowering.
+shapes toolchain uses. The 2026-04-19 refresh narrows the story further:
+backend entry is no longer the first blocker; the remaining wedge is front-end
+bookkeeping plus still-unported/selfhost-only toolchain usage.
 
 ## How the probe was run
 
 ```
 go build -o /tmp/osty ./cmd/osty
+/tmp/osty gen   --backend=llvm   /tmp/hello.osty      >/tmp/hello.ll
+go test ./internal/llvmgen -run 'TestGenerateModuleInterfaceVtableEmitted|TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields|TestGenerateManagedAggregateListsTraceNestedRoots|TestGenerateModulePtrBackedListToSetAndBoolPrint' -count=1
 /tmp/osty check --airepair=false toolchain > /tmp/tc.log 2>&1
-/tmp/osty gen   --backend=llvm   toolchain/core.osty  2>&1
-/tmp/osty gen   --backend=llvm   /tmp/hello.osty      2>&1
+/tmp/osty gen   --backend=llvm   toolchain/core.osty  2>&1   # historical 2026-04-18 sample
 /tmp/osty build --backend=llvm   examples/calc        2>&1
 ```
 
 `/tmp/hello.osty` was a 3-line `fn main() { println(42) }` baseline so the
-panic could be isolated from toolchain-specific issues.
+backend entry path could be isolated from toolchain-specific issues.
 
-## Layer 1 — CLI panic blocks any `osty gen --backend=llvm` call
+Observed in the 2026-04-19 refresh:
 
-Input: a single-line `fn main() { println(42) }`.
+- `/tmp/osty gen --backend=llvm /tmp/hello.osty` exited 0 and emitted a valid
+  `.ll` module containing `define i32 @main()`
+- the targeted `internal/llvmgen` regression set returned
+  `ok github.com/osty/osty/internal/llvmgen`
+
+## Layer 1 — universal CLI panic wedge (resolved)
+
+The previous snapshot's highest-priority blocker was:
 
 ```
 panic: runtime error: invalid memory address or nil pointer dereference
-[signal SIGSEGV: ...]
-  check.(*selfhostSpanIndex).addNode
-    internal/check/host_boundary.go:578
-  check.(*selfhostSpanIndex).addNode
-    internal/check/host_boundary.go:501
-  check.(*selfhostSpanIndex).addNode
-    internal/check/host_boundary.go:530
-  check.buildSelfhostSpanIndex
-    internal/check/host_boundary.go:433
-  check.overlaySelfhostResult
-    internal/check/host_boundary.go:360
-  check.applyNativeFileResult
-    internal/check/host_boundary.go:248
-  check.File
-    internal/check/check.go:108
+...
+check.(*selfhostSpanIndex).addNode
+  internal/check/host_boundary.go:578
 ```
 
-Same root cause as the four pre-existing `internal/llvmgen` test failures:
+That specific universal wedge is now closed.
+
+Current revalidation result:
+
+```text
+$ /tmp/osty gen --backend=llvm /tmp/hello.osty
+$ echo $?
+0
+```
+
+The same refresh also re-ran the four `internal/llvmgen` tests that were named
+as evidence for the panic and they now pass:
 
 - `TestGenerateModuleInterfaceVtableEmitted`
 - `TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields`
 - `TestGenerateManagedAggregateListsTraceNestedRoots`
 - `TestGenerateModulePtrBackedListToSetAndBoolPrint`
 
-These all route through `runMonoLowerPipeline → check.File → …addNode` and
-trip the same nil deref. The Go-side `TestLLVMBackendBinaryRunsBundledRuntime`
-path uses a different entry and passes cleanly, which is why most LLVM
-backend coverage still looks green — the pipeline that the CLI uses is
-broken, the pipeline the Go test harness uses is fine.
+So the current remaining work should no longer be framed as "LLVM CLI path is
+broken before backend reachability." The backend entry path is alive again; the
+next re-profile should focus on actual `toolchain/*.osty` diagnostics and
+selfhosting surface gaps.
 
-This is the single highest-ROI fix on the path to `toolchain/*.osty` through
-LLVM, because every other issue below only matters once this one is gone.
-
-## Layer 2 — front-end error budget in `toolchain/`
+## Layer 2 — front-end error budget in `toolchain/` (historical 2026-04-18 sample)
 
 Aggregated from `osty check --airepair=false toolchain`:
 
@@ -81,7 +102,7 @@ Aggregated from `osty check --airepair=false toolchain`:
 |---|---|---|---|
 | E0500 | 39 | undefined name — `strings` module not in scope | `toolchain/ast_lower.osty` (all 39) |
 | E0008 | 6 | numeric separator `_` must appear between two digits — false-positive inside string literals | `lsp.osty:415-423`, `ci.osty:546`, `manifest_validation.osty:283` |
-| E0001 | 4 | expected IDENT — parser loses sync at `fn ParamNode(…, def: Expr, …)` | `ast_lower.osty:91`, `:93` (× 2 each) |
+| E0001 | 4 (historical) | expected IDENT — parser lost sync at `fn ParamNode(…, def: Expr, …)` before the stable-alias fix | `ast_lower.osty:91`, `:93` (× 2 each) |
 | E0010 | 2 | cascading from E0001 | `ast_lower.osty:1051`, `:1054` |
 | E0700 | 1 | native checker summary — 1700 errors aggregated | `airepair_flags.osty:1` (summary anchor) |
 
@@ -167,13 +188,12 @@ runnable binary" is dominated by Layer 1 + Layer 2, not Layer 3.
 
 ## Recommended fix order (smallest → largest unlock)
 
-1. **Fix the `selfhostSpanIndex.addNode` nil panic** in
-   `internal/check/host_boundary.go`. Unblocks `osty gen --backend=llvm`
-   *and* four pre-existing test failures. Likely a missing nil guard on a
-   span field that is populated for AST-native files but empty for
-   selfhost-overlay files.
+1. **Re-run the full `toolchain` sample on the current tree** and replace the
+   historical 2026-04-18 counts. The universal CLI panic wedge is already
+   closed, so fresh numbers matter more than old ones now.
 
-2. **Fix the string-interpolation lexer bug** (E0008). Six sites today,
+2. **Fix the string-interpolation lexer bug** (E0008). Six sites in the last
+   full sample,
    pattern is well-defined, fixture is small. Unblocks `lsp.osty`,
    `ci.osty`, `manifest_validation.osty`.
 

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -1,30 +1,28 @@
 # Selfhost Front End
 
-`internal/selfhost` is the default lexer and parser implementation used by the
-Go toolchain. The implementation is authored in Osty and compiled into Go.
+`internal/selfhost` contains the committed bootstrap-generated Go bridge for the
+Osty front end plus the adapters that let the rest of the Go codebase talk to
+it.
 
-The source of truth is:
+Today the public entrypoints are:
 
-- `examples/selfhost-core/semver.osty`
-- `examples/selfhost-core/semver_parse.osty`
-- `toolchain/frontend.osty`
-- `toolchain/lexer.osty`
-- `toolchain/parser.osty`
-- `examples/selfhost-core/formatter_ast.osty`
-- `toolchain/check_bridge.osty`
-- `toolchain/diagnostic.osty`
-- `toolchain/check_diag.osty`
-- `toolchain/ty.osty`
-- `toolchain/core.osty`
-- `toolchain/check_env.osty`
-- `toolchain/solve.osty`
-- `toolchain/elab.osty`
-- `toolchain/check.osty`
+- `internal/lexer` — thin Go facade over selfhost tokenization
+- `internal/parser` — thin Go facade over selfhost parsing plus Go-side
+  compatibility lowerings
+- `internal/check` — prefers the external native checker binary and uses the
+  embedded selfhost bridge as the fallback / adaptation boundary
+
+The exact merged Osty inputs live in
+[`internal/selfhost/bundle/bundle.go`](./bundle/bundle.go):
+
+- `GeneratedFiles()` feeds `internal/selfhost/generated.go`
+- `ToolchainCheckerFiles()` feeds the broader checker/bootstrap regeneration path
+
+Notable inputs currently include:
+
+- `examples/selfhost-core/{semver,semver_parse,frontend,formatter_ast,check_bridge,check,resolve,lint}.osty`
+- `toolchain/{frontend,lexer,parser,check_bridge,diagnostic,check_diag,ty,core,check_env,solve,elab,check}.osty`
 - `internal/selfhost/ast_lower.osty`
-
-`toolchain/check_bridge.osty` supplies the small parser adapter needed by the
-shared checker API, and the rest of the checker now comes directly from the
-same `toolchain/*.osty` sources the native checker path exercises.
 
 Regenerate the Go bridge with:
 
@@ -32,13 +30,13 @@ Regenerate the Go bridge with:
 go generate ./internal/selfhost
 ```
 
-The generator merges the selfhost-core sources, emits `generated.go` through
-`cmd/osty gen`, regenerates `internal/selfhost/astbridge/generated.go` from
-`internal/ast`, and reapplies the small Go hot-path overrides that keep lexing
-position lookups linear. Public compiler packages should call
-`internal/lexer` and `internal/parser` for the canonical front end, and
-`internal/check` for type checking. The `internal/check` entrypoints route
-mainstream checker diagnostics through `internal/selfhost.CheckSourceStructured`
-and bridge its typed nodes, bindings, declaration symbols, and generic
-instantiations onto the resolver symbols and AST nodes consumed by codegen and
-editor features. This package is the adaptation boundary for bootstrapped code.
+That flow:
+
+- regenerates `internal/selfhost/astbridge/generated.go`
+- merges the current toolchain/selfhost source bundle
+- builds a temporary `cmd/osty-native-checker`
+- invokes `cmd/osty-bootstrap-gen` to write `internal/selfhost/generated.go`
+- reapplies the small Go hot-path patches in `gen_selfhost.go`
+
+`internal/check` then maps the checker output back onto the resolver symbols and
+AST nodes consumed by codegen, LSP, and the rest of the host-side pipeline.

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -1,24 +1,29 @@
 # Toolchain Sources
 
-`toolchain` no longer contains the generated Go front-end package.
-That bridge was removed as part of the bootstrap cutover.
+`toolchain/` holds the Osty-authored sources that still feed the bootstrapped
+front end, checker, and LLVM pipeline. It no longer contains generated Go
+output; the committed bridge now lives under `internal/selfhost/`.
 
-The Osty-authored source of truth for the front end and checker still lives in:
+The exact merge inputs are defined in
+[`internal/selfhost/bundle/bundle.go`](../internal/selfhost/bundle/bundle.go).
+Today they pull from:
 
-- `toolchain/semver.osty`
-- `toolchain/semver_parse.osty`
-- `toolchain/frontend.osty`
-- `toolchain/lexer.osty`
-- `toolchain/parser.osty`
-- `toolchain/formatter_ast.osty`
-- `toolchain/check_bridge.osty`
-- `toolchain/check.osty`
-- `toolchain/ast_lower.osty`
+- `toolchain/*.osty` for the front-end/checker/backend-facing logic
+- `examples/selfhost-core/*.osty` for the committed selfhost bundle pieces
+- `internal/selfhost/ast_lower.osty` for the Go-bridge lowering step
 
 Mainstream Go packages should call `internal/lexer`, `internal/parser`, and
-`internal/check`. Those entrypoints currently route through the committed
-bootstrap-generated `internal/golegacy` snapshot plus `internal/golegacy/astbridge`.
+`internal/check`. `internal/lexer` and `internal/parser` are thin facades over
+`internal/selfhost`; `internal/check` prefers the external native-checker
+boundary and falls back to the embedded selfhost bridge when needed.
 
-There is no longer a wired `go generate ./toolchain` refresh path in
-the repository. This directory now exists only for the remaining Osty source
-artifacts that have not yet been folded into the final native toolchain pipeline.
+There is no `go generate ./toolchain` path anymore. To refresh the committed
+Go bridge, run:
+
+```sh
+go generate ./internal/selfhost
+```
+
+That regeneration flow is implemented in
+[`internal/selfhost/gen_selfhost.go`](../internal/selfhost/gen_selfhost.go) and
+invokes `cmd/osty-bootstrap-gen` plus the `astbridge` generator.


### PR DESCRIPTION
## What changed
- refreshed the top-level README to match the current shipped CLI and implementation boundaries
- updated the documented status around LLVM reachability so it reflects the current revalidated hello-world path and targeted `internal/llvmgen` regressions
- corrected the public CLI help text for scaffold/new/init options and documented subcommands
- updated the selfhost/toolchain README files so they describe the current `internal/selfhost` bridge and regeneration path instead of older bootstrap wording

## Why
The docs had drifted away from the current code in a few important places: shipped edition vs spec-tracking version, scaffold/help output, and the status of the LLVM CLI path. This brings the user-facing docs back in line with the implementation.

## Impact
Readers now get current commands, current status language, and current ownership/regeneration guidance without running into stale instructions.

## Validation
- `go run ./cmd/osty --help`
- `go run ./cmd/osty doc --help`
- `go test ./internal/llvmgen -run 'TestGenerateModuleInterfaceVtableEmitted|TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields|TestGenerateManagedAggregateListsTraceNestedRoots|TestGenerateModulePtrBackedListToSetAndBoolPrint' -count=1`
- `osty gen --backend=llvm` hello-world revalidation (documented in the status refresh)
