### PR TITLE
feat(llvmgen): Bool interpolation via osty_rt_bool_to_string

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -824,6 +824,13 @@ const char *osty_rt_int_to_string(int64_t value) {
     return osty_rt_string_dup_site(buffer, (size_t)written, "runtime.int.to_string");
 }
 
+const char *osty_rt_bool_to_string(bool value) {
+    if (value) {
+        return osty_rt_string_dup_site("true", 4, "runtime.bool.to_string");
+    }
+    return osty_rt_string_dup_site("false", 5, "runtime.bool.to_string");
+}
+
 const char *osty_rt_float_to_string(double value) {
     char buffer[64];
     int precision;

--- a/internal/llvmgen/bool_interp_test.go
+++ b/internal/llvmgen/bool_interp_test.go
@@ -1,0 +1,31 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInterpolationCoercesBoolViaRuntime extends #350's Int/Float
+// interpolation coverage to Bool. `"flag={b}"` where b is i1 should now
+// funnel through `osty_rt_bool_to_string` just like Int funnels through
+// `osty_rt_int_to_string`.
+func TestInterpolationCoercesBoolViaRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let b: Bool = true
+    println("flag={b}")
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bool_interp.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bool_to_string(i1)",
+		"call ptr @osty_rt_bool_to_string",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q (Bool interpolation broken):\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -136,6 +136,8 @@ func (g *generator) emitInterpolationStringPiece(v value) (value, error) {
 		return g.emitRuntimeIntToString(v)
 	case "double":
 		return g.emitRuntimeFloatToString(v)
+	case "i1":
+		return g.emitRuntimeBoolToString(v)
 	}
 	return value{}, unsupportedf("type-system", "interpolation of %s value requires .toString() which the LLVM backend does not yet lower", v.typ)
 }
@@ -949,6 +951,17 @@ func (g *generator) emitRuntimeFloatToString(v value) (value, error) {
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "double"}})
 	emitter := g.toOstyEmitter()
 	out := llvmFloatRuntimeToString(emitter, toOstyValue(v))
+	g.takeOstyEmitter(emitter)
+	text := fromOstyValue(out)
+	text.gcManaged = true
+	return text, nil
+}
+
+func (g *generator) emitRuntimeBoolToString(v value) (value, error) {
+	symbol := llvmBoolRuntimeToStringSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "i1"}})
+	emitter := g.toOstyEmitter()
+	out := llvmBoolRuntimeToString(emitter, toOstyValue(v))
 	g.takeOstyEmitter(emitter)
 	text := fromOstyValue(out)
 	text.gcManaged = true

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -669,6 +669,7 @@ func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {
 		{"concat", llvmStringRuntimeConcatSymbol(), "osty_rt_strings_Concat"},
 		{"int_to_string", llvmIntRuntimeToStringSymbol(), "osty_rt_int_to_string"},
 		{"float_to_string", llvmFloatRuntimeToStringSymbol(), "osty_rt_float_to_string"},
+		{"bool_to_string", llvmBoolRuntimeToStringSymbol(), "osty_rt_bool_to_string"},
 		{"byteLen", llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen"},
 	}
 	for _, c := range cases {
@@ -688,6 +689,7 @@ func TestGeneratedStringRuntimeDeclarationsAreOstyOwned(t *testing.T) {
 		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
 		"declare ptr @osty_rt_int_to_string(i64)",
 		"declare ptr @osty_rt_float_to_string(double)",
+		"declare ptr @osty_rt_bool_to_string(i1)",
 		"declare i64 @osty_rt_strings_ByteLen(ptr)",
 	}
 	for _, w := range want {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2123,6 +2123,10 @@ func llvmFloatRuntimeToStringSymbol() string {
 	return "osty_rt_float_to_string"
 }
 
+func llvmBoolRuntimeToStringSymbol() string {
+	return "osty_rt_bool_to_string"
+}
+
 func llvmStringRuntimeByteLenSymbol() string {
 	return "osty_rt_strings_ByteLen"
 }
@@ -2143,6 +2147,7 @@ func llvmStringRuntimeDeclarations() []string {
 		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
 		"declare ptr @osty_rt_int_to_string(i64)",
 		"declare ptr @osty_rt_float_to_string(double)",
+		"declare ptr @osty_rt_bool_to_string(i1)",
 		"declare i64 @osty_rt_strings_ByteLen(ptr)",
 		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Join(ptr, ptr)",
@@ -2171,6 +2176,10 @@ func llvmIntRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 
 func llvmFloatRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_float_to_string", []*LlvmValue{value})
+}
+
+func llvmBoolRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_bool_to_string", []*LlvmValue{value})
 }
 
 func llvmStringCompare(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2235,6 +2235,10 @@ pub fn llvmFloatRuntimeToStringSymbol() -> String {
     "osty_rt_float_to_string"
 }
 
+pub fn llvmBoolRuntimeToStringSymbol() -> String {
+    "osty_rt_bool_to_string"
+}
+
 pub fn llvmStringRuntimeByteLenSymbol() -> String {
     "osty_rt_strings_ByteLen"
 }
@@ -2261,6 +2265,7 @@ pub fn llvmStringRuntimeDeclarations() -> List<String> {
         "declare ptr @osty_rt_strings_Concat(ptr, ptr)",
         "declare ptr @osty_rt_int_to_string(i64)",
         "declare ptr @osty_rt_float_to_string(double)",
+        "declare ptr @osty_rt_bool_to_string(i1)",
         "declare i64 @osty_rt_strings_ByteLen(ptr)",
         "declare i64 @osty_rt_strings_Compare(ptr, ptr)",
         "declare ptr @osty_rt_strings_Join(ptr, ptr)",
@@ -2289,6 +2294,10 @@ pub fn llvmIntRuntimeToString(emitter: LlvmEmitter, value: LlvmValue) -> LlvmVal
 
 pub fn llvmFloatRuntimeToString(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "ptr", "osty_rt_float_to_string", [value])
+}
+
+pub fn llvmBoolRuntimeToString(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_bool_to_string", [value])
 }
 
 pub fn llvmStringCompare(


### PR DESCRIPTION
## Summary

Extends #350's Int/Float interpolation coverage to **Bool** so `\"flag={b}\"` with a Bool-typed `b` lowers through the runtime instead of hitting LLVM011 \"requires .toString()\".

#350 drained the Int and Float interpolation sub-wall but left i1 still falling through the catch-all. This patch is a one-arm extension of the same shape.

## Changes

- **`osty_rt_bool_to_string(bool value)`** — returns \"true\" / \"false\" via `osty_rt_string_dup_site` with `OSTY_GC_KIND_STRING`. Mirrors the Int/Float neighbours in `internal/backend/runtime/osty_runtime.c`.
- **`llvmBoolRuntimeToString*`** in `toolchain/llvmgen.osty` → mirrored in `internal/llvmgen/support_snapshot.go` (symbol, declaration, emitter).
- **`emitRuntimeBoolToString`** in `internal/llvmgen/expr.go` mirrors `emitRuntimeIntToString` / `emitRuntimeFloatToString`.
- **`emitInterpolationStringPiece`** grows one more arm: `case \"i1\"` → `emitRuntimeBoolToString`.

`osty_generated_test.go`'s symbol-name + declaration tables picked up a Bool row too.

## Test plan

- [x] `go test ./internal/llvmgen/` — only remaining failure is pre-existing `TestGenerateModuleStdTestingExpectOkCompat` (LLVM011 generic `T`, separate effort).
- [x] New: `TestInterpolationCoercesBoolViaRuntime` verifies `\"flag={b}\"` emits the `declare ptr @osty_rt_bool_to_string(i1)` + `call ptr @osty_rt_bool_to_string` pair.
- [x] Updated: `TestGeneratedStringRuntimeDeclarationsAreOstyOwned` + runtime-symbol name table in `osty_generated_test.go` include the Bool entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)