### PR TITLE
fix: turbofish package-fn dispatch + boundary preserves <T: Pod>

### DIFF
--- a/LANG_SPEC_v0.5/19-runtime-primitives.md
+++ b/LANG_SPEC_v0.5/19-runtime-primitives.md
@@ -616,13 +616,12 @@ while the export symbol is link-reachable.
 | §19.7 lowering table (`raw.null` → `inttoptr i64 0`, etc.) | **deferred** | — |
 | §19.10 safepoint compiler-emitted root array | **deferred** | — |
 
-**Type system / native checker / IR lowering.** Multiple layers,
-partially landed.
+**Type system / native checker / IR lowering.** Closed.
 
 | Piece | Status | Notes |
 |---|---|---|
-| Native checker types `raw.null()` / `raw.alloc(b, a)` / `raw.bits(p)` correctly | **landed** | The native checker's `chk.Types[CallExpr]` and `chk.LetTypes[LetStmt]` already return `RawPtr` / `Int` for non-generic intrinsics. PR `claude/native-checker-stdlib-types` added `PrimRawPtr` to `internal/ir/PrimKind` + `TRawPtr` singleton + the missing case arms in `primitiveByKind` / `primitiveByName`, so `ir.Lower` now flows the type to `let.Type` instead of dropping to `ErrTypeVal`. (Original PR #345 misdiagnosed this as a native-checker gap; it was an IR lowerer gap.) |
-| Generic intrinsic typing — `raw.read::<T>` / `raw.write::<T>` / `raw.cas::<T>` / `raw.sizeOf::<T>` / `raw.alignOf::<T>` | **gap** | The `host_boundary`'s `writeSelfhostPackageImport` (`internal/check/host_boundary.go:1324`) strips `<T: Pod>` generic params when forwarding stdlib stub signatures to the native checker. Result: `fn read(p: RawPtr) -> T` reaches the checker with `T` undeclared, and turbofish call sites get `ErrType`. The executable contract is the 5 `t.Skip(genericSkipReason)`'d tests in `internal/llvmgen/runtime_intrinsic_typing_test.go`. The fix is to extend the boundary writer to emit `<T: Pod>` (and to verify the native checker accepts FFI-block generics). |
+| Native checker types `raw.null()` / `raw.alloc(b, a)` / `raw.bits(p)` correctly | **landed** | The native checker's `chk.Types[CallExpr]` and `chk.LetTypes[LetStmt]` already return `RawPtr` / `Int` for non-generic intrinsics. The IR-side fix (`PrimRawPtr` added to `ir.PrimKind` + `TRawPtr` singleton + missing case arms in `primitiveByKind` / `primitiveByName`) made the native-checker output reach `let.Type` instead of dropping to `ErrTypeVal`. (PR #345 originally misdiagnosed this as a native-checker gap; PR #349 corrected the diagnosis and landed the IR fix.) |
+| Generic intrinsic typing — `raw.read::<T>` / `raw.write::<T>` / `raw.cas::<T>` / `raw.sizeOf::<T>` / `raw.alignOf::<T>` | **landed** | Two fixes in PR `claude/boundary-preserve-generics`: (a) `host_boundary.writeSelfhostPackageImport` now emits `<T: Pod>` via the new `selfhostGenericParams` helper so the native checker sees the stub's generic params; (b) `frontCheckTurbofishCall` (in `examples/selfhost-core/check.osty` + `internal/selfhost/generated.go`) now tries `frontCheckSigLookup(env, packageName)` on package-qualified turbofish calls before falling through to method lookup, mirroring the non-turbofish dispatch. The cached `osty-native-checker` binary at `<projectRoot>/.osty/toolchain/<version>/` must be deleted so `EnsureNativeChecker` rebuilds. The contract suite at `internal/llvmgen/runtime_intrinsic_typing_test.go` now has 9/9 PASS. |
 
 **Out-of-scope (per §19.1) — never planned.**
 

--- a/examples/selfhost-core/check.osty
+++ b/examples/selfhost-core/check.osty
@@ -2117,6 +2117,19 @@ fn frontCheckTurbofishCall(file: AstFile, env: FrontCheckEnv, callIdx: Int, call
             }
             return "Chan<{frontCheckStringAt(typeArgs, 0)}>"
         }
+        // Generic package-fn dispatch — e.g. `raw.read::<Int>(p)`. The
+        // non-turbofish call path (`frontCheckCall`) already does this
+        // lookup; the turbofish path used to fall through to method
+        // lookup, which fails for stdlib intrinsics (the receiver is a
+        // `use go` alias, not a typed value). LANG_SPEC §19.5
+        // turbofish intrinsics depend on this branch.
+        if packageName != "" {
+            let pkgSig = frontCheckSigLookup(env, packageName)
+            if pkgSig.name != "" {
+                let pkgSubsts = frontCheckExplicitSubsts(env, pkgSig.generics, typeArgs)
+                return frontCheckCallSig(file, env, callIdx, pkgSig, args, 0, pkgSubsts)
+            }
+        }
         let recvType = frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, target.left))
         let owner = frontCheckTypeHead(recvType)
         let sig = frontCheckMethodLookup(env, owner, target.text)

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1332,7 +1332,11 @@ func writeSelfhostPackageImport(b *bytes.Buffer, alias string, pkg *resolve.Pack
 			if !ok || !fn.Pub || fn.Recv != nil {
 				continue
 			}
-			fmt.Fprintf(&body, "    fn %s(", fn.Name)
+			fmt.Fprintf(&body, "    fn %s", fn.Name)
+			if generics := selfhostGenericParams(fn.Generics); generics != "" {
+				body.WriteString(generics)
+			}
+			body.WriteByte('(')
 			for i, param := range fn.Params {
 				if i > 0 {
 					body.WriteString(", ")
@@ -1356,6 +1360,37 @@ func writeSelfhostPackageImport(b *bytes.Buffer, alias string, pkg *resolve.Pack
 	fmt.Fprintf(b, "use go %q as %s {\n", alias, alias)
 	b.Write(body.Bytes())
 	b.WriteString("}\n")
+}
+
+// selfhostGenericParams formats a fn's generic parameter list for the
+// boundary writer. Empty list returns "" (no `<>` emitted). Per
+// LANG_SPEC §19.5, runtime intrinsic stubs declare generics like
+// `fn read<T: Pod>(p: RawPtr) -> T`; without this the boundary
+// dropped `<T: Pod>` and the native checker saw `T` as undeclared,
+// producing `ErrType` at every turbofish call site.
+func selfhostGenericParams(gps []*ast.GenericParam) string {
+	if len(gps) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(gps))
+	for _, gp := range gps {
+		if gp == nil {
+			continue
+		}
+		entry := gp.Name
+		if len(gp.Constraints) > 0 {
+			bounds := make([]string, 0, len(gp.Constraints))
+			for _, c := range gp.Constraints {
+				bounds = append(bounds, selfhostTypeSource(c))
+			}
+			entry += ": " + strings.Join(bounds, " + ")
+		}
+		parts = append(parts, entry)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "<" + strings.Join(parts, ", ") + ">"
 }
 
 func selfhostTypeSource(t ast.Type) string {

--- a/internal/llvmgen/runtime_intrinsic_typing_test.go
+++ b/internal/llvmgen/runtime_intrinsic_typing_test.go
@@ -1,34 +1,39 @@
 package llvmgen
 
-// Executable contract for the §19.5 intrinsic typing flow.
+// Executable contract for the §19.5 intrinsic typing flow. All 9
+// tests now pass. The §19.11 status row for this gap can be
+// flipped to "landed" once this PR merges.
 //
-// **Diagnostic correction.** The original landing of this file
-// (PR #345) attributed the failure to the native checker not
-// flowing stdlib intrinsic return types back to call sites. That
-// diagnosis was wrong — the native checker DOES return correct
-// types (`chk.Types[CallExpr] -> RawPtr`, `chk.LetTypes[LetStmt]
-// -> RawPtr`). The actual bug was in `internal/ir/lower.go`:
-// `primitiveByKind` and `primitiveByName` did not have cases for
-// `types.PRawPtr` (added in PR #312), so when `fromCheckerType`
-// converted a `*types.Primitive{Kind: PRawPtr}` it returned
-// `ErrTypeVal`. PR `claude/native-checker-stdlib-types` adds
-// `PrimRawPtr` to the IR primitive enum + `TRawPtr` singleton +
-// the missing `case` arms.
+// **Multi-layer diagnosis history.** This contract suite landed
+// in PR #345 with a wrong attribution to the native checker.
+// Three subsequent fixes were needed to make the full set green:
 //
-// Three of these tests pass after that fix:
-//   - raw.null()       → RawPtr   ✓
-//   - raw.alloc(b, a)  → RawPtr   ✓
-//   - raw.bits(p)      → Int      ✓
+//  1. `internal/ir/lower.go` — `primitiveByKind` / `primitiveByName`
+//     missed `types.PRawPtr`, so `fromCheckerType` returned
+//     `ErrTypeVal` for any RawPtr-typed expression. Fixed by adding
+//     `PrimRawPtr` to the IR enum + `TRawPtr` singleton + missing
+//     case arms. Made `raw.null()` / `raw.alloc()` / `raw.bits()`
+//     pass.
+//  2. `internal/check/host_boundary.go` — `writeSelfhostPackageImport`
+//     stripped `<T: Pod>` from intrinsic stub signatures when
+//     forwarding to the native checker, so `fn read<T: Pod>(p:
+//     RawPtr) -> T` arrived as `fn read(p: RawPtr) -> T` with `T`
+//     undeclared. Fixed by adding `selfhostGenericParams` helper
+//     and emitting `<T: Pod>` on the boundary `fn` line.
+//  3. `examples/selfhost-core/check.osty` /
+//     `internal/selfhost/generated.go` — `frontCheckTurbofishCall`
+//     handled `pkg.method::<T>(args)` only as a method call (with
+//     a special-case for `thread.chan`); for other packages it
+//     fell through to method lookup, never trying
+//     `frontCheckSigLookup(env, "raw.read")`. Mirrored the
+//     non-turbofish `frontCheckCall` path so package-fn dispatch
+//     fires before the method-lookup fallback.
 //
-// The remaining tests (raw.read::<T>, raw.write::<T>, raw.cas::<T>,
-// raw.sizeOf::<T>, chained alloc/write/read/free) still fail
-// because of a SEPARATE bug — the `host_boundary`'s
-// `writeSelfhostPackageImport` strips `<T: Pod>` generic params
-// when forwarding stdlib stub signatures to the native checker.
-// Those tests carry `t.Skip(genericSkipReason)`.
-//
-// When the boundary fix lands, removing the Skip lines should
-// flip the remaining tests green.
+// All three fixes ship in PR `claude/boundary-preserve-generics`
+// (this branch). The cached `osty-native-checker` binary at
+// `<root>/.osty/toolchain/<version>/` must be deleted so
+// `EnsureNativeChecker` rebuilds it from updated `internal/selfhost`
+// generated.go.
 
 import (
 	"testing"
@@ -40,16 +45,6 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
-
-// genericSkipReason marks tests blocked on a still-open gap: the
-// host_boundary's `writeSelfhostPackageImport` strips generic params
-// from intrinsic signatures, so `fn read<T: Pod>(p: RawPtr) -> T`
-// reaches the native checker as `fn read(p: RawPtr) -> T` with `T`
-// undeclared. Tests for non-generic intrinsics (raw.null, raw.alloc,
-// raw.bits) pass after PR `claude/native-checker-stdlib-types`'s
-// `PrimRawPtr` fix; the generic ones await a boundary writer fix.
-const genericSkipReason = "blocked on host_boundary generic-param stripping — LANG_SPEC §19.11. " +
-	"Remove this Skip line when writeSelfhostPackageImport preserves `<T: Pod>` on intrinsic stubs."
 
 // firstLetTypeIn returns the printed type of the first `let` binding
 // inside the named function in `mod`. Returns "" if the fn or its
@@ -192,7 +187,6 @@ pub fn demo() {
 // --- raw.read::<T>(p) -> T ---
 
 func TestRuntimeIntrinsicTypingRawReadInt(t *testing.T) {
-	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -228,7 +222,6 @@ pub fn demo() {
 // --- raw.read::<T>(p) -> T (T=Float64) ---
 
 func TestRuntimeIntrinsicTypingRawReadFloat(t *testing.T) {
-	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -263,7 +256,6 @@ pub fn demo() {
 // --- raw.cas::<Int>(...) -> Bool ---
 
 func TestRuntimeIntrinsicTypingRawCas(t *testing.T) {
-	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -298,7 +290,6 @@ pub fn demo() {
 // --- raw.sizeOf::<T>() -> Int (compile-time constant typing) ---
 
 func TestRuntimeIntrinsicTypingSizeOf(t *testing.T) {
-	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 
@@ -316,7 +307,6 @@ pub fn demo() {
 // --- end-to-end: chained intrinsics in a real-shaped fn ---
 
 func TestRuntimeIntrinsicTypingChainedAllocReadFree(t *testing.T) {
-	t.Skip(genericSkipReason)
 	src := `
 use std.runtime.raw
 

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -28651,6 +28651,18 @@ func frontCheckTurbofishCall(file *AstFile, env *FrontCheckEnv, callIdx int, cal
 			// Osty: /tmp/selfhost_merged.osty:11454:13
 			return fmt.Sprintf("Chan<%s>", ostyToString(frontCheckStringAt(typeArgs, 0)))
 		}
+		// Generic package-fn dispatch — e.g. `raw.read::<Int>(p)`. The
+		// non-turbofish call path (`frontCheckCall`) already does this
+		// lookup; the turbofish path used to fall through to method
+		// lookup, which fails for stdlib intrinsics. Mirrors the source
+		// fix in `examples/selfhost-core/check.osty`.
+		if packageName != "" {
+			pkgSig := frontCheckSigLookup(env, packageName)
+			if pkgSig.name != "" {
+				pkgSubsts := frontCheckExplicitSubsts(env, pkgSig.generics, typeArgs)
+				return frontCheckCallSig(file, env, callIdx, pkgSig, args, 0, pkgSubsts)
+			}
+		}
 		// Osty: /tmp/selfhost_merged.osty:11456:9
 		recvType := frontCheckResolveAliasesDeep(env, frontCheckExpr(file, env, target.left))
 		_ = recvType


### PR DESCRIPTION
## Summary

Twenty-first §19 contribution. **Two coordinated fixes** that together flip the §19.5 generic-intrinsic typing tests from 5 SKIP to 5 PASS. The full §19.11 "Type system / native checker / IR lowering" row group is now closed.

## Fix 1: boundary stripping

`internal/check/host_boundary.go::writeSelfhostPackageImport` wrote each stdlib stub fn as `fn name(params) -> ret`, **dropping the fn's generic param list**. So `fn read<T: Pod>(p: RawPtr) -> T` reached the native checker as `fn read(p: RawPtr) -> T` with `T` undeclared, and any turbofish call lost its type info.

**Fix:** new `selfhostGenericParams(gps)` helper emits `<T: Pod, U: Equal + Hashable>`-shape lists. Inserted between the fn name and the param list.

Verified:
```
fn read<T: Pod>(p: RawPtr) -> T          ← was: fn read(p: RawPtr) -> T
fn write<T: Pod>(p: RawPtr, v: T)
fn cas<T: Pod>(p: RawPtr, old: T, new: T) -> Bool
fn sizeOf<T: Pod>() -> Int
fn alignOf<T: Pod>() -> Int
```

## Fix 2: turbofish package-fn dispatch

`frontCheckTurbofishCall` (in `examples/selfhost-core/check.osty`) handled the `Field`-callee branch by special-casing only `thread.chan`, then falling through to method lookup. So `raw.read::<Int>(p)` never tried `frontCheckSigLookup(env, "raw.read")` — it instead looked up methods on the receiver `raw`'s type and failed.

**Fix:** mirror the non-turbofish `frontCheckCall` path. After the `thread.chan` special-case, try `frontCheckSigLookup(env, packageName)` before falling through to method lookup. If a sig is found, dispatch through `frontCheckCallSig` with the explicit type substitutions.

Both source paths updated:
- `examples/selfhost-core/check.osty` (authoritative source)
- `internal/selfhost/generated.go` (mirror used by the native checker binary)

## Cached binary

`EnsureNativeChecker` caches `osty-native-checker` per worktree at `<root>/.osty/toolchain/<version>/`. The cached binaries had to be deleted to force a rebuild that picks up the generated.go change. **CI / fresh checkouts build the binary from current source on first use, so this is a one-time local hygiene step** (no commit-side artifact).

## Test evidence

```
$ go test ./internal/llvmgen/ -run TestRuntimeIntrinsicTyping -v
--- PASS: TestRuntimeIntrinsicTypingRawNull       (raw.null    → RawPtr)
--- PASS: TestRuntimeIntrinsicTypingRawAlloc      (raw.alloc   → RawPtr)
--- PASS: TestRuntimeIntrinsicTypingRawBits       (raw.bits    → Int)
--- PASS: TestRuntimeIntrinsicTypingRawReadInt    (raw.read::<Int>    → Int)     [NEW]
--- PASS: TestRuntimeIntrinsicTypingRawReadFloat  (raw.read::<Float64>→ Float64) [NEW]
--- PASS: TestRuntimeIntrinsicTypingRawCas        (raw.cas::<Int>     → Bool)    [NEW]
--- PASS: TestRuntimeIntrinsicTypingSizeOf        (raw.sizeOf::<Int>  → Int)     [NEW]
--- PASS: TestRuntimeIntrinsicTypingChainedAllocReadFree                          [NEW]
--- PASS: TestRuntimeIntrinsicTypingFileLoads
```

`go test -short ./internal/check/ ./internal/ir/ ./internal/llvmgen/ ./internal/resolve/ ./internal/parser/ ./internal/types/` — green except pre-existing `TestGenerateModuleStdTestingExpectOkCompat`, unrelated.

## Diagnostic history

The contract suite in `runtime_intrinsic_typing_test.go` started with one wrong attribution ([#345](https://github.com/choiceoh/osty/pull/345)) and split through three fixes:

| # | PR | Fix |
|---|---|---|
| 1 | [#349](https://github.com/choiceoh/osty/pull/349) | IR `primitiveByKind` missing `PRawPtr` |
| 2 | this PR | boundary stripped `<T: Pod>` |
| 3 | this PR | turbofish package-fn dispatch missed |

The docstring records the full history so future contributors have a worked example of why one diagnosis must be probed at every layer before declaring the upstream broken.

## Spec status

LANG_SPEC §19.11 row "Generic intrinsic typing" flipped from **gap** to **landed**. The "Type system / native checker / IR lowering" group is now closed — both the non-generic and generic intrinsic typing paths flow correct types end-to-end.

## Spec references

- LANG_SPEC §19.3 (RawPtr type contract)
- LANG_SPEC §19.5 (intrinsic signatures + Pod bound)
- LANG_SPEC §19.11 (status table flipped)
- SPEC_GAPS.md G19

## Test plan

- [ ] `go test ./internal/llvmgen/ -run TestRuntimeIntrinsicTyping` — 9/9 PASS
- [ ] `go test -short ./...` — no NEW failures
- [ ] `let v = raw.read::<Int>(raw.alloc(8, 8))` produces `let.Type = Int` in lowered IR
- [ ] Spec status table accurately reflects "landed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)