### PR TITLE
test(llvmgen): toolchain large-tail sweep tooling for tracking LLVM-wall progress

### DIFF
--- a/internal/llvmgen/large_tail_sweep_test.go
+++ b/internal/llvmgen/large_tail_sweep_test.go
@@ -1,0 +1,219 @@
+package llvmgen
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestSweepToolchainLargeTail walks all non-test toolchain/*.osty modules
+// and reports each one's first lowering wall (or "clean"). Aggregates
+// into a histogram so the class mix is visible at a glance instead of
+// scrolling through dozens of per-file diagnostics.
+//
+// Info-only: never fails. Run with `go test -v -run
+// TestSweepToolchainLargeTail` to see the histogram.
+func TestSweepToolchainLargeTail(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+
+	type result struct {
+		path  string
+		clean bool
+		wall  string
+	}
+	var results []result
+	histogram := map[string]int{}
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		file, _ := parser.ParseDiagnostics(src)
+		if file == nil {
+			continue
+		}
+		_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
+		r := result{path: name}
+		if err == nil {
+			r.clean = true
+			histogram["CLEAN"]++
+		} else {
+			r.wall = wallCode(err.Error())
+			histogram[r.wall]++
+		}
+		results = append(results, r)
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].path < results[j].path
+	})
+
+	t.Logf("=== per-file ===")
+	for _, r := range results {
+		if r.clean {
+			t.Logf("  %s: CLEAN", r.path)
+		} else {
+			t.Logf("  %s: %s", r.path, r.wall)
+		}
+	}
+	t.Logf("=== histogram ===")
+	keys := make([]string, 0, len(histogram))
+	for k := range histogram {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		t.Logf("  %s: %d", k, histogram[k])
+	}
+}
+
+// TestSweepToolchainLargeTailLLVM011Subwalls drills into the LLVM011
+// bucket by classifying each error message into a sub-pattern. Goal:
+// identify the highest-leverage sub-wall to attack next.
+//
+// Info-only.
+func TestSweepToolchainLargeTailLLVM011Subwalls(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+
+	type hit struct {
+		file string
+		msg  string
+	}
+	hits := []hit{}
+	histogram := map[string]int{}
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		file, _ := parser.ParseDiagnostics(src)
+		if file == nil {
+			continue
+		}
+		_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
+		if err == nil || !strings.Contains(err.Error(), "LLVM011") {
+			continue
+		}
+		category := classifyLLVM011(err.Error())
+		histogram[category]++
+		hits = append(hits, hit{file: name, msg: err.Error()})
+	}
+
+	t.Logf("=== LLVM011 sub-walls ===")
+	keys := make([]string, 0, len(histogram))
+	for k := range histogram {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return histogram[keys[i]] > histogram[keys[j]]
+	})
+	for _, k := range keys {
+		t.Logf("  %s: %d", k, histogram[k])
+	}
+	t.Logf("=== examples (first per category) ===")
+	seenCat := map[string]bool{}
+	for _, h := range hits {
+		c := classifyLLVM011(h.msg)
+		if seenCat[c] {
+			continue
+		}
+		seenCat[c] = true
+		t.Logf("  [%s] %s — %s", c, h.file, h.msg)
+	}
+}
+
+// TestSweepToolchainLargeTailLLVM015Subwalls — same as LLVM011 sweep
+// but for LLVM015 (call dispatch). Info-only.
+func TestSweepToolchainLargeTailLLVM015Subwalls(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		file, _ := parser.ParseDiagnostics(src)
+		if file == nil {
+			continue
+		}
+		_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
+		if err == nil || !strings.Contains(err.Error(), "LLVM015") {
+			continue
+		}
+		t.Logf("  %s — %s", name, err.Error())
+	}
+}
+
+func wallCode(msg string) string {
+	for _, code := range []string{"LLVM011", "LLVM012", "LLVM013", "LLVM014", "LLVM015", "LLVM016", "LLVM017", "LLVM018"} {
+		if strings.Contains(msg, code) {
+			return code
+		}
+	}
+	return "OTHER"
+}
+
+func classifyLLVM011(msg string) string {
+	switch {
+	case strings.Contains(msg, "interpolation of i64 value requires .toString()"):
+		return "int_interp_toString"
+	case strings.Contains(msg, "interpolation of f64 value requires .toString()"):
+		return "float_interp_toString"
+	case strings.Contains(msg, "interpolation"):
+		return "interp_other"
+	case strings.Contains(msg, `parameter `) && strings.Contains(msg, ": type "):
+		return "fn_param_struct_type"
+	case strings.Contains(msg, "type \"T\""):
+		return "generic_T"
+	case strings.Contains(msg, "field type"):
+		return "field_type"
+	case strings.Contains(msg, "return type"):
+		return "return_type_mismatch"
+	default:
+		return "other"
+	}
+}

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -1,0 +1,48 @@
+package llvmgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestProbeDiagnosticMergedWithLexer checks whether the LLVM011 wall on
+// diagnostic.osty is a real backend gap or just the single-file probe's
+// scope limitation. We concatenate diagnostic.osty + lexer.osty (which
+// defines FrontLexStream) and feed the joined source through the same
+// lowering path. If diagnostic alone fails but the merged source
+// succeeds — or fails on a *different* type — the wall is purely
+// cross-file scope, not a backend limitation.
+//
+// Info-only.
+func TestProbeDiagnosticMergedWithLexer(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	a, err := os.ReadFile(filepath.Join(root, "toolchain/lexer.osty"))
+	if err != nil {
+		t.Fatalf("read lexer: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "toolchain/diagnostic.osty"))
+	if err != nil {
+		t.Fatalf("read diagnostic: %v", err)
+	}
+	merged := string(a) + "\n" + string(b)
+	file, _ := parser.ParseDiagnostics([]byte(merged))
+	if file == nil {
+		t.Fatalf("parse merged returned nil")
+	}
+	_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/merged.osty"})
+	if err != nil {
+		t.Logf("merged source still errors: %v", err)
+		if strings.Contains(err.Error(), "FrontLexStream") {
+			t.Logf("still complains about FrontLexStream — likely needs more deps merged")
+		}
+	} else {
+		t.Logf("merged source lowers cleanly — diagnostic.osty wall is cross-file scope")
+	}
+}


### PR DESCRIPTION
## Summary

Info-only tests that walk every non-test `toolchain/*.osty` module through `generateFromAST` and aggregate the failures into histograms. Surfaced LLVM011 sub-wall progress during the recent tail-unblock series (compare/None-Some/Join via #344, Int/Float interp via #350, split/trim via #352, Bool interp via #356) and remains a useful \"what's next?\" map for whoever picks up the next wall.

## What's added

- **`TestSweepToolchainLargeTail`** — per-file headline wall + histogram. Surfaces CLEAN count and wall-class mix at a glance (CLEAN / LLVM011 / LLVM014 / LLVM015 / OTHER).
- **`TestSweepToolchainLargeTailLLVM011Subwalls`** — drills into the LLVM011 bucket by sub-message pattern (`int_interp_toString`, `fn_param_struct_type`, `return_type_mismatch`, `generic_T`, ...). Lists one example per category so picking the next attack vector takes one log read.
- **`TestSweepToolchainLargeTailLLVM015Subwalls`** — same shape for LLVM015 (call dispatch).
- **`TestProbeDiagnosticMergedWithLexer`** — concatenates `lexer.osty` + `diagnostic.osty` before generation. Confirms that several `fn_param_struct_type` walls are **cross-file scope artefacts** of the single-file probe, not real backend gaps: when the struct decl is in scope, the wall transitions to a deeper site. That insight pointed the LLVM011 attack vector at actual gaps (scalar interpolation) instead of chasing the cross-file mirage.

## Why info-only

These never fail — they only log. They're tools for surveying the toolchain attack surface, not regression gates. Run with `go test -v -run TestSweepToolchainLargeTail` to see the histogram.

A regression-gate version (\"this file MUST stay clean\") lives at `TestProbeSmallTailLower` (added in #344, refined in #352). When a file from the sweep transitions to permanently-clean it's promoted to that probe.

## Sample output

```
=== histogram ===
  CLEAN: 6
  LLVM011: 24
  LLVM015: 5
  OTHER: 4

=== LLVM011 sub-walls ===
  other: 14
  fn_param_struct_type: 7
  return_type_mismatch: 2
```

## Test plan

- [x] `go test -v -run \"TestSweepToolchainLargeTail|TestProbeDiagnosticMergedWithLexer\" ./internal/llvmgen/` — all pass, all log useful info, none fail
- [x] Adds zero source-changing logic — purely tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)