### PR TITLE
feat(llvmgen): raw.null() intrinsic LLVM lowering (§19.5)

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -274,7 +274,8 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 			ir.PrimUInt8, ir.PrimUInt16, ir.PrimUInt32, ir.PrimUInt64,
 			ir.PrimByte, ir.PrimBool, ir.PrimChar,
 			ir.PrimFloat, ir.PrimFloat32, ir.PrimFloat64,
-			ir.PrimString, ir.PrimBytes, ir.PrimUnit, ir.PrimNever:
+			ir.PrimString, ir.PrimBytes, ir.PrimRawPtr,
+			ir.PrimUnit, ir.PrimNever:
 			return true
 		}
 	case *ir.NamedType:
@@ -464,6 +465,9 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	case mir.IntrinsicParallel, mir.IntrinsicRace, mir.IntrinsicCollectAll:
 		return true
+	// LANG_SPEC §19 runtime sublanguage.
+	case mir.IntrinsicRawNull:
+		return true
 	}
 	return false
 }
@@ -479,6 +483,8 @@ func mirIntrinsicLabel(k mir.IntrinsicKind) string {
 		return "eprint"
 	case mir.IntrinsicEprintln:
 		return "eprintln"
+	case mir.IntrinsicRawNull:
+		return "raw.null"
 	}
 	return fmt.Sprintf("kind=%d", int(k))
 }
@@ -1406,6 +1412,8 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitCancelIntrinsic(i)
 	case mir.IntrinsicParallel, mir.IntrinsicRace, mir.IntrinsicCollectAll:
 		return g.emitConcurrencyHelperIntrinsic(i)
+	case mir.IntrinsicRawNull:
+		return g.emitRuntimeRawNull(i)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("intrinsic %s", mirIntrinsicLabel(i.Kind)))
 }
@@ -3859,6 +3867,12 @@ func (g *mirGen) llvmType(t mir.Type) string {
 			return "float"
 		case ir.PrimString, ir.PrimBytes:
 			return "ptr"
+		case ir.PrimRawPtr:
+			// LANG_SPEC §19.3 — RawPtr is an opaque pointer-shaped
+			// scalar; in opaque-pointer LLVM (the toolchain's required
+			// version) it lowers to `ptr`. Width is `sizeof(uintptr_t)`,
+			// 8 bytes on the supported 64-bit targets.
+			return "ptr"
 		case ir.PrimUnit:
 			return "void"
 		case ir.PrimNever:
@@ -4096,6 +4110,17 @@ func (g *mirGen) storeIntrinsicResult(i *mir.IntrinsicInstr, result *LlvmValue) 
 	g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
 	g.fnBuf.WriteByte('\n')
 	return nil
+}
+
+// emitRuntimeRawNull lowers `raw.null()` from LANG_SPEC §19.5. The
+// result is the pointer-shaped null constant: in opaque-pointer LLVM
+// (the toolchain's required version) that's just `null` as a `ptr`.
+// No instruction needed beyond the store into the dest slot.
+func (g *mirGen) emitRuntimeRawNull(i *mir.IntrinsicInstr) error {
+	if len(i.Args) != 0 {
+		return unsupported("mir-mvp", "raw.null() takes no arguments")
+	}
+	return g.storeIntrinsicResult(i, &LlvmValue{typ: "ptr", name: "null"})
 }
 
 // ==== helpers ====

--- a/internal/llvmgen/runtime_intrinsic_codegen_test.go
+++ b/internal/llvmgen/runtime_intrinsic_codegen_test.go
@@ -1,0 +1,129 @@
+package llvmgen
+
+// LANG_SPEC §19.5 — `raw.null()` LLVM lowering.
+//
+// MIR rewrites the call into `IntrinsicRawNull` (no symbol, no
+// CallInstr); the LLVM emitter stores the opaque-pointer constant
+// `null` into the destination slot. There is no runtime symbol — the
+// pointer-shaped null constant is materialised inline.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+const rawNullSrc = `
+use std.runtime.raw
+
+#[no_alloc]
+pub fn demo() -> RawPtr {
+    raw.null()
+}
+
+fn main() {}
+`
+
+// lowerPrivilegedToMIR runs the full front-end + IR + MIR pipeline on
+// a privileged source and returns the MIR module. Tests for §19
+// intrinsics share this helper so adding a new intrinsic test is one
+// `lowerPrivilegedToMIR(t, src)` line, not 12 lines of boilerplate.
+func lowerPrivilegedToMIR(t *testing.T, src string) *mir.Module {
+	t.Helper()
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, _ := ir.Monomorphize(mod)
+	return mir.Lower(monoMod)
+}
+
+func TestRawNullEndToEndLLVMEmit(t *testing.T) {
+	mirMod := lowerPrivilegedToMIR(t, rawNullSrc)
+	out, err := GenerateFromMIR(mirMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/raw_null.osty",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR error: %v", err)
+	}
+	got := string(out)
+	// If MIR left raw.null as a CallInstr, the symbol would leak as
+	// either the qualified path or the printer label.
+	for _, bad := range []string{
+		"@std.runtime.raw.null",
+		`@"std.runtime.raw.null"`,
+		"@raw.null",
+	} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("MIR left raw.null as a call instead of intercepting (found %q):\n%s", bad, got)
+		}
+	}
+	// `ptr null` is the canonical opaque-pointer constant in LLVM IR
+	// and is what storeIntrinsicResult emits for IntrinsicRawNull.
+	if !strings.Contains(got, "ptr null") {
+		t.Fatalf("expected `ptr null` constant in emitted LLVM IR:\n%s", got)
+	}
+}
+
+func TestRawNullMIRIntrinsicShape(t *testing.T) {
+	mirMod := lowerPrivilegedToMIR(t, rawNullSrc)
+
+	var fn *mir.Function
+	var seenNames []string
+	for _, f := range mirMod.Functions {
+		if f == nil {
+			continue
+		}
+		seenNames = append(seenNames, f.Name)
+		if f.Name == "demo" {
+			fn = f
+		}
+	}
+	if fn == nil {
+		t.Fatalf("demo not in MIR module; saw functions %v", seenNames)
+	}
+	var found *mir.IntrinsicInstr
+	var seenInstrs []string
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, inst := range bb.Instrs {
+			if ii, ok := inst.(*mir.IntrinsicInstr); ok {
+				if ii.Kind == mir.IntrinsicRawNull {
+					found = ii
+					break
+				}
+				seenInstrs = append(seenInstrs, "intrinsic")
+			} else {
+				seenInstrs = append(seenInstrs, "other")
+			}
+		}
+		if found != nil {
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("MIR demo body has no IntrinsicRawNull — call was not intercepted; instrs=%v", seenInstrs)
+	}
+	if len(found.Args) != 0 {
+		t.Fatalf("IntrinsicRawNull arity = %d, want 0", len(found.Args))
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2368,6 +2368,10 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 				bs.emitConcurrencyIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 				return
 			}
+			if kind := runtimeIntrinsicForFree(qualifierOf(use), fx.Name); kind != IntrinsicInvalid {
+				bs.emitRuntimeIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+				return
+			}
 		}
 	}
 	args, callee := bs.resolveCall(c)
@@ -2395,6 +2399,23 @@ func (bs *bodyState) emitConcurrencyIntrinsic(kind IntrinsicKind, args []ir.Arg,
 		destPtr = nil
 	}
 	if isVoidConcurrencyIntrinsic(kind) {
+		destPtr = nil
+	}
+	bs.emit(&IntrinsicInstr{Dest: destPtr, Kind: kind, Args: out, SpanV: sp})
+}
+
+// emitRuntimeIntrinsic lowers args in source order and emits a single
+// IntrinsicInstr for a §19 runtime intrinsic. Void-returning kinds
+// (free / zero / copy / write) will need their own dest-clearing
+// branch when they land; today every supported runtime intrinsic
+// returns a value, so the unit-check above suffices.
+func (bs *bodyState) emitRuntimeIntrinsic(kind IntrinsicKind, args []ir.Arg, dest *Place, destT Type, sp Span) {
+	out := make([]Operand, len(args))
+	for i, a := range args {
+		out[i] = bs.lowerExprAsOperand(a.Value)
+	}
+	destPtr := dest
+	if destPtr != nil && isUnit(destT) {
 		destPtr = nil
 	}
 	bs.emit(&IntrinsicInstr{Dest: destPtr, Kind: kind, Args: out, SpanV: sp})
@@ -2584,6 +2605,10 @@ func (bs *bodyState) lowerMethodCallInto(mc *ir.MethodCall, dest Place, destT Ty
 	if use := bs.l.useAliasFor(mc.Receiver); use != nil {
 		if kind := concurrencyIntrinsicForFree(qualifierOf(use), mc.Name); kind != IntrinsicInvalid {
 			bs.emitConcurrencyIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
+			return
+		}
+		if kind := runtimeIntrinsicForFree(qualifierOf(use), mc.Name); kind != IntrinsicInvalid {
+			bs.emitRuntimeIntrinsic(kind, mc.Args, &dest, destT, mc.SpanV)
 			return
 		}
 		args := make([]Operand, len(mc.Args))
@@ -2826,6 +2851,27 @@ func (bs *bodyState) lowerVariantLit(v *ir.VariantLit, hint Type) RValue {
 }
 
 // ==== concurrency intrinsic recognition ====
+
+// runtimeIntrinsicForFree maps a `std.runtime.raw`-qualified free
+// function call to its MIR intrinsic kind, per LANG_SPEC §19.5.
+// Returns IntrinsicInvalid when the qualifier/name pair is not a
+// known runtime intrinsic.
+//
+// `qualifier` is the `use`-level RawPath; for `use std.runtime.raw`
+// that is the literal "std.runtime.raw". Aliased forms
+// (`use std.runtime.raw as raw`) would arrive here with the same
+// RawPath, so the alias name is irrelevant — the resolver canonicalises
+// to the full path.
+func runtimeIntrinsicForFree(qualifier, name string) IntrinsicKind {
+	if qualifier != "std.runtime.raw" {
+		return IntrinsicInvalid
+	}
+	switch name {
+	case "null":
+		return IntrinsicRawNull
+	}
+	return IntrinsicInvalid
+}
 
 // concurrencyIntrinsicForFree maps a prelude / `thread`-namespaced
 // top-level function name to its MIR intrinsic kind. Returns

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -512,6 +512,12 @@ const (
 	IntrinsicResultUnwrap
 	// IntrinsicResultUnwrapOr returns T. Args: [result, default].
 	IntrinsicResultUnwrapOr
+
+	// ---- LANG_SPEC §19 runtime sublanguage ----
+
+	// IntrinsicRawNull returns the null RawPtr. Args: [].
+	// Lowers to `inttoptr i64 0 to ptr` (or `ptr null`).
+	IntrinsicRawNull
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do


### PR DESCRIPTION
## Summary

First real codegen for a LANG_SPEC §19 runtime intrinsic. `raw.null()` now lowers end-to-end:

- **MIR** intercepts the qualified call (`std.runtime.raw.null`) at lowering time and rewrites it to `IntrinsicInstr{Kind: IntrinsicRawNull}` — no `CallInstr`, no symbol leak.
- **LLVM** emits the canonical opaque-pointer constant: `store ptr null, ptr <dest-slot>`. No runtime symbol involved.

This unblocks the rest of the §19 intrinsic table (alloc/free/zero/copy/offset/read/write/cas/sizeOf/alignOf/fromBits/bits) — each one slots into the same dispatcher + `emitIntrinsic` case shape.

### Changes

- `internal/mir/mir.go` — new `IntrinsicRawNull` enum entry.
- `internal/mir/lower.go` — `runtimeIntrinsicForFree` dispatcher (mirrors `concurrencyIntrinsicForFree`); `emitRuntimeIntrinsic` helper; both `lowerCallExprInto`/FieldExpr path and `lowerMethodCallInto` wired.
- `internal/llvmgen/mir_generator.go` — `PrimRawPtr → "ptr"` in `llvmType` + `typeSupported`; `IntrinsicRawNull` added to `isSupportedIntrinsic`, `mirIntrinsicLabel`, `emitIntrinsic` dispatch; `emitRuntimeRawNull` implementation (one-liner over `storeIntrinsicResult`).
- `internal/llvmgen/runtime_intrinsic_codegen_test.go` — end-to-end LLVM emit test + MIR shape test, sharing a `lowerPrivilegedToMIR(t, src) *mir.Module` helper that future §19 intrinsic tests can reuse.

### Pre-merge cleanup

`/simplify` review caught and fixed:

- Dropped always-false `isVoidRuntimeIntrinsic` stub (will reintroduce when first void runtime intrinsic lands).
- Dropped speculative `"raw"` / `"runtime.raw"` qualifier alternatives — `qualifierOf` returns `RawPath` which is always `"std.runtime.raw"` for `use std.runtime.raw`.
- Deduped 12-line test setup boilerplate into one helper.

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestRawNull` — both new tests pass
- [x] `go test ./internal/mir/...` — green
- [x] `go test ./internal/llvmgen/` — only pre-existing `TestGenerateModuleStdTestingExpectOkCompat` fails (verified on `main` via `git stash`)
- [x] `go test ./internal/check/... ./internal/ir/... ./internal/parser/... ./internal/resolve/...` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)