### PR TITLE
feat: route String ordering through osty_rt_strings_Compare (unblock scaffold_policy LLVM011)

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -969,13 +969,20 @@ func (g *generator) emitRuntimeBoolToString(v value) (value, error) {
 }
 
 func (g *generator) emitRuntimeStringCompare(op token.Kind, left, right value) (value, error) {
-	if op != token.EQ && op != token.NEQ {
-		return value{}, unsupportedf("type-system", "compare type %s", left.typ)
+	switch op {
+	case token.EQ, token.NEQ:
+		g.declareRuntimeSymbol("osty_rt_strings_Equal", "i1", []paramInfo{
+			{typ: "ptr"},
+			{typ: "ptr"},
+		})
+	case token.LT, token.LEQ, token.GT, token.GEQ:
+		g.declareRuntimeSymbol(llvmStringRuntimeCompareSymbol(), "i64", []paramInfo{
+			{typ: "ptr"},
+			{typ: "ptr"},
+		})
+	default:
+		return value{}, unsupportedf("expression", "comparison operator %q", op)
 	}
-	g.declareRuntimeSymbol("osty_rt_strings_Equal", "i1", []paramInfo{
-		{typ: "ptr"},
-		{typ: "ptr"},
-	})
 	emitter := g.toOstyEmitter()
 	out := llvmStringCompare(emitter, op.String(), toOstyValue(left), toOstyValue(right))
 	g.takeOstyEmitter(emitter)

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -3620,6 +3620,9 @@ func (g *mirGen) emitBinary(op mir.BinaryOp, left, right string, argT, resT mir.
 	if (op == mir.BinEq || op == mir.BinNeq) && isHeapEqualityType(argT) {
 		return g.emitHeapEquality(op, left, right)
 	}
+	if isStringOrderingBinOp(op) && isStringPrimType(argT) {
+		return g.emitStringOrdering(op, left, right)
+	}
 	argLLVM := g.llvmType(argT)
 	resLLVM := g.llvmType(resT)
 	isFloat := isFloatType(argT)
@@ -3755,6 +3758,66 @@ func (g *mirGen) emitHeapEquality(op mir.BinaryOp, left, right string) (string, 
 	g.fnBuf.WriteString(eq)
 	g.fnBuf.WriteString(", true\n")
 	return neq, nil
+}
+
+// isStringPrimType reports whether t is the String primitive. Ordering
+// through osty_rt_strings_Compare is String-only; Bytes ordering has no
+// runtime support yet and still hits the raw-icmp path.
+func isStringPrimType(t mir.Type) bool {
+	p, ok := t.(*ir.PrimType)
+	return ok && p.Kind == ir.PrimString
+}
+
+func isStringOrderingBinOp(op mir.BinaryOp) bool {
+	switch op {
+	case mir.BinLt, mir.BinLeq, mir.BinGt, mir.BinGeq:
+		return true
+	}
+	return false
+}
+
+// emitStringOrdering lowers `<` / `<=` / `>` / `>=` on String values to
+// a call to `osty_rt_strings_Compare` (returning i64 -1/0/+1) followed
+// by `icmp <pred> i64 result, 0`. Without this routing the raw icmp
+// path would compare the underlying ptrs, which yields undefined
+// results for content ordering.
+func (g *mirGen) emitStringOrdering(op mir.BinaryOp, left, right string) (string, error) {
+	sym := llvmStringRuntimeCompareSymbol()
+	g.declareRuntime(sym, fmt.Sprintf("declare i64 @%s(ptr, ptr)", sym))
+	cmp := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(cmp)
+	g.fnBuf.WriteString(" = call i64 @")
+	g.fnBuf.WriteString(sym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(left)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(right)
+	g.fnBuf.WriteString(")\n")
+	pred := stringOrderingPredicate(op)
+	out := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(out)
+	g.fnBuf.WriteString(" = icmp ")
+	g.fnBuf.WriteString(pred)
+	g.fnBuf.WriteString(" i64 ")
+	g.fnBuf.WriteString(cmp)
+	g.fnBuf.WriteString(", 0\n")
+	return out, nil
+}
+
+func stringOrderingPredicate(op mir.BinaryOp) string {
+	switch op {
+	case mir.BinLt:
+		return "slt"
+	case mir.BinLeq:
+		return "sle"
+	case mir.BinGt:
+		return "sgt"
+	case mir.BinGeq:
+		return "sge"
+	}
+	return ""
 }
 
 // ==== strings ====

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2199,3 +2199,62 @@ func TestGenerateFromMIRStringInequality(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerateFromMIRStringOrdering — String `<` / `<=` / `>` / `>=`
+// must lower to osty_rt_strings_Compare (i64 -1/0/+1) + `icmp <pred>
+// i64 result, 0`. Without this routing the MIR path would emit a raw
+// `icmp slt ptr` comparison, which reduces to pointer address ordering
+// rather than content ordering.
+func TestGenerateFromMIRStringOrdering(t *testing.T) {
+	cases := []struct {
+		name string
+		op   ir.BinOp
+		pred string
+	}{
+		{"lt", ir.BinLt, "icmp slt i64"},
+		{"leq", ir.BinLeq, "icmp sle i64"},
+		{"gt", ir.BinGt, "icmp sgt i64"},
+		{"geq", ir.BinGeq, "icmp sge i64"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hir := &ir.Module{
+				Package: "main",
+				Decls: []ir.Decl{
+					&ir.FnDecl{
+						Name:   "cmp",
+						Return: ir.TBool,
+						Body: &ir.Block{
+							Result: &ir.BinaryExpr{
+								Op:    tc.op,
+								Left:  &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "a"}}},
+								Right: &ir.StringLit{Parts: []ir.StringPart{{IsLit: true, Lit: "b"}}},
+								T:     ir.TBool,
+							},
+						},
+					},
+				},
+			}
+			m := buildMIRModuleFromHIR(t, hir)
+			out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/strord.osty"})
+			if err != nil {
+				t.Fatalf("GenerateFromMIR: %v", err)
+			}
+			got := string(out)
+			for _, want := range []string{
+				"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
+				"call i64 @osty_rt_strings_Compare(ptr",
+				tc.pred,
+				", 0",
+			} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("missing %q in:\n%s", want, got)
+				}
+			}
+			if strings.Contains(got, "icmp slt ptr") || strings.Contains(got, "icmp sle ptr") ||
+				strings.Contains(got, "icmp sgt ptr") || strings.Contains(got, "icmp sge ptr") {
+				t.Fatalf("found raw icmp on ptr (ordering must route through runtime):\n%s", got)
+			}
+		})
+	}
+}

--- a/internal/llvmgen/scaffold_policy_probe_test.go
+++ b/internal/llvmgen/scaffold_policy_probe_test.go
@@ -1,0 +1,44 @@
+package llvmgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestProbeScaffoldPolicyLowers locks in that scaffold_policy.osty —
+// the first toolchain module to exercise String ordering comparisons
+// (`unit >= "a" && unit <= "z"`) — lowers cleanly through the legacy
+// AST path. Before the ordering fix this tripped LLVM011 "compare
+// type ptr" because emitRuntimeStringCompare only handled EQ/NEQ.
+func TestProbeScaffoldPolicyLowers(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	path := filepath.Join(root, "toolchain/scaffold_policy.osty")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	file, _ := parser.ParseDiagnostics(src)
+	if file == nil {
+		t.Fatalf("parse produced nil file")
+	}
+	out, err := generateFromAST(file, Options{PackageName: "main", SourcePath: path})
+	if err != nil {
+		t.Fatalf("scaffold_policy.osty failed to lower: %s", err.Error())
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
+		"call i64 @osty_rt_strings_Compare",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2188,11 +2188,14 @@ func llvmBoolRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue 
 }
 
 func llvmStringCompare(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	eq := llvmStringEqual(emitter, left, right)
-	if op == "!=" {
-		return llvmNotI1(emitter, eq)
+	if op == "==" {
+		return llvmStringEqual(emitter, left, right)
 	}
-	return eq
+	if op == "!=" {
+		return llvmNotI1(emitter, llvmStringEqual(emitter, left, right))
+	}
+	cmp := llvmStringRuntimeCompare(emitter, left, right)
+	return llvmCompare(emitter, llvmIntComparePredicate(op), cmp, llvmIntLiteral(0))
 }
 
 func llvmStringByteLen(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2311,11 +2311,14 @@ pub fn llvmStringCompare(
     left: LlvmValue,
     right: LlvmValue,
 ) -> LlvmValue {
-    let eq = llvmStringEqual(emitter, left, right)
-    if op == "!=" {
-        return llvmNotI1(emitter, eq)
+    if op == "==" {
+        return llvmStringEqual(emitter, left, right)
     }
-    eq
+    if op == "!=" {
+        return llvmNotI1(emitter, llvmStringEqual(emitter, left, right))
+    }
+    let cmp = llvmStringRuntimeCompare(emitter, left, right)
+    llvmCompare(emitter, llvmIntComparePredicate(op), cmp, llvmIntLiteral(0))
 }
 
 pub fn llvmStringByteLen(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -1211,6 +1211,7 @@ fn testLlvmStringRuntimeSymbolsAreOstyOwned() {
     testing.assertEq(llvmIntRuntimeToStringSymbol(), "osty_rt_int_to_string")
     testing.assertEq(llvmFloatRuntimeToStringSymbol(), "osty_rt_float_to_string")
     testing.assertEq(llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen")
+    testing.assertEq(llvmStringRuntimeCompareSymbol(), "osty_rt_strings_Compare")
 }
 
 fn testLlvmStringRuntimeDeclarationsAreOstyOwned() {
@@ -1223,6 +1224,7 @@ fn testLlvmStringRuntimeDeclarationsAreOstyOwned() {
     assertLlvmContains(declarations, "declare ptr @osty_rt_int_to_string(i64)")
     assertLlvmContains(declarations, "declare ptr @osty_rt_float_to_string(double)")
     assertLlvmContains(declarations, "declare i64 @osty_rt_strings_ByteLen(ptr)")
+    assertLlvmContains(declarations, "declare i64 @osty_rt_strings_Compare(ptr, ptr)")
 }
 
 fn testLlvmSmokeStringConcatIsOstyOwned() {


### PR DESCRIPTION
## Summary

- `scaffold_policy.osty`가 `unit >= "a" && unit <= "z"` 같은 String ordering 비교 때문에 LLVM011 `compare type ptr`에 막혀 있던 것 해소.
- 레거시 AST emitter의 `emitRuntimeStringCompare`를 EQ/NEQ 외 ordering까지 확장하고, MIR emitter에는 String ordering 라우팅을 신규 추가 (기존에는 raw `icmp slt ptr`로 떨어져 포인터 주소 비교되는 잠재 버그).
- 런타임 `osty_rt_strings_Compare(ptr, ptr) -> i64`는 이미 존재, 신규 런타임 코드 없음.

## Changes

- `toolchain/llvmgen.osty::llvmStringCompare` — `<`/`<=`/`>`/`>=` 케이스 추가. `llvmStringRuntimeCompare` 호출 → `icmp <pred> i64 result, 0`.
- `internal/llvmgen/support_snapshot.go` — Go 스냅샷 미러.
- `internal/llvmgen/expr.go::emitRuntimeStringCompare` — op별로 적절한 런타임 심볼(Equal vs Compare) 선언, ordering 허용.
- `internal/llvmgen/mir_generator.go` — `isStringPrimType`/`isStringOrderingBinOp`/`emitStringOrdering` 신규, `emitBinary`에서 라우팅. Bytes ordering은 런타임 지원 없어 제외.
- 테스트:
  - `internal/llvmgen/scaffold_policy_probe_test.go` (신규) — `scaffold_policy.osty` 클린 로우링 회귀.
  - `internal/llvmgen/mir_generator_test.go::TestGenerateFromMIRStringOrdering` — 4개 op × ptr icmp 금지 assert.
  - `toolchain/llvmgen_test.osty` — `osty_rt_strings_Compare` symbol/declaration parity 보강.

## Impact

- `LLVM011` other 버킷 15 → 14 (scaffold_policy 탈출).
- MIR path 잠재 버그 (String ordering = 포인터 주소 비교) 차단.
- 남은 24건(`other: 14`, `fn_param_struct_type: 7`, `return_type_mismatch: 2`)은 전부 레거시 AST path의 struct-값 시그니처/필드 한계 — MIR은 이미 처리하므로 프로덕션 사용자 영향 없음. 본 PR 범위 밖.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/llvmgen/ -run 'TestProbeScaffoldPolicyLowers|TestGenerateFromMIRStringOrdering|TestGenerateFromMIRStringEquality|TestGenerateFromMIRStringInequality'` 전부 통과
- [x] `go test ./internal/llvmgen/ -short` — 기존 `TestGenerateModuleStdTestingExpectOkCompat` 실패는 main에서도 실패하는 사전 이슈, 별건
- [x] `go test ./internal/backend/ -short -run 'Strings'` 통과
- [x] `TestSweepToolchainLargeTailLLVM011Subwalls` histogram: `other` 15 → 14

🤖 Generated with [Claude Code](https://claude.com/claude-code)