### PR TITLE
test: large-tail sweep probes for ir/check_env parity

### DIFF
--- a/internal/llvmgen/large_tail_sweep_test.go
+++ b/internal/llvmgen/large_tail_sweep_test.go
@@ -1,6 +1,7 @@
 package llvmgen
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -154,6 +155,32 @@ func TestSweepToolchainLargeTailLLVM011Subwalls(t *testing.T) {
 	}
 }
 
+// TestSweepToolchainLargeTailFocus prints the full wall message for
+// ir.osty and check_env.osty so the first-hit signature is visible
+// without scrolling the full sweep output. Info-only.
+func TestSweepToolchainLargeTailFocus(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	focus := []string{"ir.osty", "check_env.osty"}
+	for _, name := range focus {
+		path := filepath.Join(root, "toolchain", name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Logf("  %s: READ_ERR %v", name, err)
+			continue
+		}
+		file, _ := parser.ParseDiagnostics(src)
+		if file == nil {
+			t.Logf("  %s: PARSE_FAIL", name)
+			continue
+		}
+		_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
+		t.Logf("  %s: %s", name, formatWall(err))
+	}
+}
+
 // TestSweepToolchainLargeTailLLVM015Subwalls — same as LLVM011 sweep
 // but for LLVM015 (call dispatch). Info-only.
 func TestSweepToolchainLargeTailLLVM015Subwalls(t *testing.T) {
@@ -197,6 +224,10 @@ func wallCode(msg string) string {
 	return "OTHER"
 }
 
+// classifyLLVM011 splits the LLVM011 bucket into the concrete backend
+// features that would retire each sub-wall. Categories are named
+// after what the backend would need to grow, not what the source
+// looks like — keeps the histogram pointing at real work.
 func classifyLLVM011(msg string) string {
 	switch {
 	case strings.Contains(msg, "interpolation of i64 value requires .toString()"):
@@ -205,15 +236,66 @@ func classifyLLVM011(msg string) string {
 		return "float_interp_toString"
 	case strings.Contains(msg, "interpolation"):
 		return "interp_other"
-	case strings.Contains(msg, `parameter `) && strings.Contains(msg, ": type "):
-		return "fn_param_struct_type"
 	case strings.Contains(msg, "type \"T\""):
 		return "generic_T"
+	case strings.Contains(msg, "field ") && strings.Contains(msg, ": type "):
+		return "struct_field_type"
+	case strings.Contains(msg, "parameter ") && strings.Contains(msg, ": type "):
+		return "fn_param_struct_type"
+	case strings.Contains(msg, "return type: type "):
+		return "fn_return_struct_type"
 	case strings.Contains(msg, "field type"):
-		return "field_type"
+		return "field_type_legacy"
 	case strings.Contains(msg, "return type"):
 		return "return_type_mismatch"
+	case strings.Contains(msg, "struct literal type "):
+		return "struct_literal_type"
+	case strings.Contains(msg, "unknown struct "):
+		return "unknown_struct"
+	case strings.Contains(msg, "generic type alias "):
+		return "generic_type_alias"
+	case strings.Contains(msg, "cyclic type alias "):
+		return "cyclic_type_alias"
+	case strings.Contains(msg, "runtime ABI type "):
+		return "runtime_abi_type"
+	case strings.Contains(msg, "LLVM enum payloads"):
+		return "enum_payload_type"
+	case strings.Contains(msg, "type %T") || strings.Contains(msg, " type *ast."):
+		return "ast_type_node"
 	default:
 		return "other"
 	}
+}
+
+func classifyLLVM015(msg string) string {
+	switch {
+	case strings.Contains(msg, "*ast.FieldExpr"):
+		return "method_call_field"
+	case strings.Contains(msg, "*ast.Ident"):
+		return "dynamic_ident_call"
+	default:
+		return "other"
+	}
+}
+
+// formatWall renders a generateFromAST error as "CODE [subclass] — msg"
+// (or "CLEAN" on nil). Shared by the focus/parity probes so every
+// sweep speaks the same line format.
+func formatWall(err error) string {
+	if err == nil {
+		return "CLEAN"
+	}
+	msg := err.Error()
+	code := wallCode(msg)
+	sub := ""
+	switch code {
+	case "LLVM011":
+		sub = classifyLLVM011(msg)
+	case "LLVM015":
+		sub = classifyLLVM015(msg)
+	}
+	if sub == "" {
+		return fmt.Sprintf("%s — %s", code, msg)
+	}
+	return fmt.Sprintf("%s [%s] — %s", code, sub, msg)
 }

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -9,6 +9,99 @@ import (
 	"github.com/osty/osty/internal/parser"
 )
 
+// mergeToolchainSources concatenates toolchain files in order into a
+// single source buffer. The parser tolerates duplicate
+// `use std.strings as strings` stanzas, so repeats across files are
+// fine; this is the cheap whole-program approximation the AST path
+// supports.
+func mergeToolchainSources(t *testing.T, root string, files []string) []byte {
+	t.Helper()
+	var buf strings.Builder
+	for _, name := range files {
+		src, err := os.ReadFile(filepath.Join(root, "toolchain", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		buf.WriteString("// === ")
+		buf.WriteString(name)
+		buf.WriteString(" ===\n")
+		buf.Write(src)
+		buf.WriteString("\n")
+	}
+	return []byte(buf.String())
+}
+
+// TestProbeLargeFileParity lowers ir.osty and check_env.osty merged
+// with their cross-module type declarations. Single-file sweeps flag
+// these as LLVM011 — merging reveals whether that wall is a real
+// backend gap or cross-module scope. Info-only.
+func TestProbeLargeFileParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("info-only; skipped in -short")
+	}
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	cases := []struct {
+		name  string
+		files []string
+	}{
+		{
+			name:  "check_env",
+			files: []string{"frontend.osty", "lexer.osty", "diagnostic.osty", "ty.osty", "check_diag.osty", "check_env.osty"},
+		},
+		{
+			name:  "ir",
+			files: []string{"frontend.osty", "parser.osty", "ir.osty"},
+		},
+	}
+	for _, c := range cases {
+		merged := mergeToolchainSources(t, root, c.files)
+		file, _ := parser.ParseDiagnostics(merged)
+		if file == nil {
+			t.Logf("  %s (merged=%v): PARSE_FAIL", c.name, c.files)
+			continue
+		}
+		_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/" + c.name + "_merged.osty"})
+		t.Logf("  %s (merged=%v): %s", c.name, c.files, formatWall(err))
+	}
+}
+
+// TestProbeWholeToolchainMerged lowers every non-test toolchain module
+// merged into one buffer — reveals the actual global backend surface
+// independent of cross-module scope. Info-only. Slow (~6 min), gated
+// by -short.
+func TestProbeWholeToolchainMerged(t *testing.T) {
+	if testing.Short() {
+		t.Skip("info-only; slow (~6 min); skipped in -short")
+	}
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		files = append(files, name)
+	}
+	merged := mergeToolchainSources(t, root, files)
+	file, _ := parser.ParseDiagnostics(merged)
+	if file == nil {
+		t.Fatalf("whole-toolchain merged parse returned nil (%d files, %d bytes)", len(files), len(merged))
+	}
+	_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/toolchain_merged.osty"})
+	t.Logf("WHOLE TOOLCHAIN first wall: %s", formatWall(err))
+}
+
 // TestProbeDiagnosticMergedWithLexer checks whether the LLVM011 wall on
 // diagnostic.osty is a real backend gap or just the single-file probe's
 // scope limitation. We concatenate diagnostic.osty + lexer.osty (which


### PR DESCRIPTION
## Summary
- Refine `classifyLLVM011` so the LLVM011 sub-wall histogram stops hiding 15/24 hits in `other`; new buckets (`struct_field_type: 12`, `fn_param_struct_type: 7`, `fn_return_struct_type: 2`) point at concrete backend features.
- Add three info-only probes to make the parity story for `ir.osty` / `check_env.osty` visible:
  - `TestSweepToolchainLargeTailFocus` — prints the first-wall message verbatim for the two focus modules.
  - `TestProbeLargeFileParity` — merges each focus module with its cross-module type deps; reveals `ir.osty` has **no** real LLVM011 wall (the first-wall signature was cross-module scope, not backend gap) and hits `LLVM015 dynamic_ident_call` instead.
  - `TestProbeWholeToolchainMerged` — merges every non-test toolchain file; first real wall is `LLVM002 runtime-ffi` (`runtime.golegacy.astbridge`), not type-system.
- `formatWall` helper dedupes the wall-logging block shared by focus / merge probes.
- Slow merge probes (~380s combined) gated by `testing.Short()` so `just short` isn't penalized.

## Why
The existing `TestSweepToolchainLargeTail*` tooling was the natural starting point for driving large files (`ir.osty` 1411 LOC, `check_env.osty` 1023 LOC) toward `CLEAN` parity — but its output was misleading: a refined classifier + multi-file probe show the LLVM011 walls on these two files are mostly cross-module scope artifacts, not backend capability gaps. This PR extends the tooling so the next round of parity work targets the right wall class (LLVM015 dynamic ident call, LLVM002 runtime-ffi) instead of a phantom type-system surface.

## Test plan
- [x] `go test ./internal/llvmgen/ -run 'TestSweepToolchainLargeTail|TestProbeLargeFileParity' -v` — all pass, new output visible
- [x] `go test -short ./internal/llvmgen/ -run 'TestProbeLargeFileParity|TestProbeWholeToolchainMerged' -v` — slow tests skip
- [x] `go vet ./internal/llvmgen/` clean
- [ ] Reviewer: scan the new probe log output to confirm the "scope illusion vs. real backend wall" split matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)