### PR TITLE
fix(toolchain): recover ir.osty +1 native-check regression, squash 3 pre-existing ASI-folding sites

### DIFF
--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1338,7 +1338,7 @@ fn charToDigit(ch: Char) -> Int {
     if s == "7" { return 7 }
     if s == "8" { return 8 }
     if s == "9" { return 9 }
-    -1
+    return -1
 }
 
 fn elabInferIndex(cx: ElabCx, node: AstNode) -> ElabResult {
@@ -3808,7 +3808,7 @@ fn pmDigitValueIn(ch: String, base: Int) -> Int {
         if ch == "e" || ch == "E" { return 14 }
         if ch == "f" || ch == "F" { return 15 }
     }
-    -1
+    return -1
 }
 
 fn pmDigitValue(ch: String) -> Int {
@@ -3822,7 +3822,7 @@ fn pmDigitValue(ch: String) -> Int {
     if ch == "7" { return 7 }
     if ch == "8" { return 8 }
     if ch == "9" { return 9 }
-    -1
+    return -1
 }
 
 pub struct PmInterval {

--- a/toolchain/ir.osty
+++ b/toolchain/ir.osty
@@ -586,9 +586,10 @@ fn irAstAnnotationRoot(node: AstNode) -> Int {
         || node.kind == AstNLet
         || node.kind == AstNField_
         || node.kind == AstNVariant {
-        return node.extra
+        node.extra
+    } else {
+        -1
     }
-    -1
 }
 
 fn irAstAnnotationTreeContains(arena: AstArena, idx: Int, name: String) -> Bool {


### PR DESCRIPTION
## Summary

- canonical normalization이 `}` 줄과 trailing `-1` 줄 사이의 newline을 제거하면서 `} -1`이 이항식 `{block} - 1`로 오해석되어 native-check가 `() - 1` (arith: (), UntypedInt) 오류로 분류.
- 이 커밋은 `ir.osty:irAstAnnotationRoot` (커밋 8876d83이 유입한 +1 사이트) + `elab.osty`의 동종 패턴 3곳(`charToDigit`, `pmDigitValueIn`, `pmDigitValue`)을 동시 수정.
- 결과: `osty check toolchain/` native-check **115 → 111 error(s)**, `arith: (), UntypedInt` **4 → 0**. pre-regression baseline(114)보다 3 낮은 상태로 복구+α.

## Fix pattern

| site | before | after |
|---|---|---|
| `ir.osty:irAstAnnotationRoot` | `if { return node.extra } … -1` | `if X { node.extra } else { -1 }` |
| `elab.osty:charToDigit` / `pmDigitValueIn` / `pmDigitValue` | trailing `-1` | `return -1` |

두 형태 모두 canonicalizer가 join해도 이항 arith 오해석이 발생하지 않음.

## Residual recommendation

canonical 파이프라인이 `-` 앞의 newline을 삼키는 건 여전히 ASI 스펙 위반. 같은 패턴 재발을 막으려면 canonical 단계에서 "leading `-` 앞 newline은 반드시 ASI 분리" 규칙을 추가하는 것이 바람직 — 별도 PR로 제안.

## Test plan

- [x] `go test ./internal/check/... ./internal/selfhost/... -short` — pass
- [x] `osty check toolchain/` — 111 error(s), arith:(),UntypedInt = 0
- [ ] 리뷰어: `osty check --dump-native-diags toolchain/` 히스토그램이 베이스라인 대비 악화 없는지 스팟 체크 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)