### PR TITLE
fix(selfhost): bundle prelude에 std.strings.concat/chars shim 추가 (#362 부분 해결)

### DIFF
--- a/internal/selfhost/bundle/bundle.go
+++ b/internal/selfhost/bundle/bundle.go
@@ -56,6 +56,9 @@ const stringsPrelude = `use go "strings" as strings {
     fn TrimSpace(s: String) -> String
     fn TrimSuffix(s: String, suffix: String) -> String
 }
+
+fn ostyStringsConcat(a: String, b: String) -> String { a + b }
+fn ostyStringsChars(s: String) -> List<Char> { s.chars() }
 `
 
 func GeneratedFiles() []string {
@@ -138,6 +141,10 @@ func normalizeStdStringsCalls(src string) string {
 		{"strings.count(", "strings.Count("},
 		{"strings.fields(", "strings.Fields("},
 		{"strings.splitN(", "strings.SplitN("},
+		// std.strings extras not covered by the Go `strings` package: route
+		// through Osty shims defined at the top of the merged bundle.
+		{"strings.concat(", "ostyStringsConcat("},
+		{"strings.chars(", "ostyStringsChars("},
 	} {
 		src = strings.ReplaceAll(src, pair[0], pair[1])
 	}


### PR DESCRIPTION
## Summary

- `internal/selfhost/bundle/bundle.go`의 `stringsPrelude`에 Osty shim 함수 2개 추가 (`ostyStringsConcat`, `ostyStringsChars`)
- `normalizeStdStringsCalls`에 `strings.concat(` / `strings.chars(` → shim 호출 rewrite 규칙 추가
- `toolchain/elab.osty`의 `strings.concat` 2건, `strings.chars` 1건이 Go stdlib `strings`에 없는 함수를 참조하던 불일치 해소

## Why

`go generate ./internal/selfhost`가 재생성할 때 `toolchain/*.osty` 소스를 `bundle.MergeToolchainChecker`로 묶고 `use go "strings" as strings` prelude로 FFI 매핑하는데, Go `strings` 패키지에는 없는 `concat`/`chars`가 `toolchain/elab.osty`에서 호출되고 있어 생성된 Go 코드가 `undefined: strings.chars` / `undefined: strings.concat`로 빌드 실패.

`strings.concat(a, b)` 는 `a + b`, `strings.chars(s)` 는 `s.chars()` 와 의미적으로 동등하므로 Osty 레벨 shim으로 흡수. Osty 소스를 편집하는 대신 bundle 단계에서 라우팅해서 toolchain 소스는 unchanged.

## Scope — issue #362

이슈 #362의 근본 원인은 여러 층으로 쌓여 있음. 본 PR은 가장 얕은 층만 수정:

**✅ 이 PR이 해결**: `strings.concat` / `strings.chars` prelude 부재 (재생성 에러 4건 제거)

**❌ 잔존 블로커** (본 PR 범위 밖):

1. **어댑터 surface mismatch** — `internal/selfhost/check_adapter.go` / `check_telemetry.go`가 legacy `FrontCheckEnv.errorsByContext` / `errorDetails` / `frontCheckLastPathSegment`에 의존하지만 Phase 10 `toolchain/check.osty`는 구조화된 `CheckDiagnostic` 리스트를 대신 방출. 어댑터를 `diagnostics` 리스트에서 `code`별로 집계하도록 재작성하는 작업(세션 대화에 초안 있음)은 아래 (2) 없이는 동작 불가라 보류.

2. **bootstrap-gen transpiler 버그** — 재생성된 `generated.go`에 이 타입 에러들이 남음:
   - `checkIntListLenHelper(typeSig.generics)`: `List<String>`이 `[]int`로 잘못 유입 (generic name list 추론 실패)
   - 빈 리스트 리터럴 `[]`이 `[]any`로 추론되어 `[]int` 반환 자리에 못 들어감 (3 call site)
   - `orPatternFlatten` 시그니처 이중 생성 — call은 8 인자, 선언은 6 인자

이들은 별도 이슈로 분리 권장.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./internal/selfhost/bundle/...` 통과
- [ ] 재생성 파이프라인 완전 복구는 잔존 블로커로 보류

🤖 Generated with [Claude Code](https://claude.com/claude-code)