### PR TITLE
test(llvmgen): sweep classifier를 cross-file scope aware하게 (LLVM011 신호 정화)

### DIFF
--- a/internal/llvmgen/large_tail_sweep_test.go
+++ b/internal/llvmgen/large_tail_sweep_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -101,6 +102,10 @@ func TestSweepToolchainLargeTailLLVM011Subwalls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read toolchain: %v", err)
 	}
+	typeIndex, err := buildToolchainTypeIndex(dir)
+	if err != nil {
+		t.Fatalf("build type index: %v", err)
+	}
 
 	type hit struct {
 		file string
@@ -127,7 +132,7 @@ func TestSweepToolchainLargeTailLLVM011Subwalls(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "LLVM011") {
 			continue
 		}
-		category := classifyLLVM011(err.Error())
+		category := classifyLLVM011Rich(err.Error(), name, typeIndex)
 		histogram[category]++
 		hits = append(hits, hit{file: name, msg: err.Error()})
 	}
@@ -141,12 +146,16 @@ func TestSweepToolchainLargeTailLLVM011Subwalls(t *testing.T) {
 		return histogram[keys[i]] > histogram[keys[j]]
 	})
 	for _, k := range keys {
-		t.Logf("  %s: %d", k, histogram[k])
+		tag := ""
+		if strings.HasPrefix(k, "cross_file_scope_") {
+			tag = "  (scope artifact; type defined in sibling file)"
+		}
+		t.Logf("  %s: %d%s", k, histogram[k], tag)
 	}
 	t.Logf("=== examples (first per category) ===")
 	seenCat := map[string]bool{}
 	for _, h := range hits {
-		c := classifyLLVM011(h.msg)
+		c := classifyLLVM011Rich(h.msg, h.file, typeIndex)
 		if seenCat[c] {
 			continue
 		}
@@ -163,9 +172,14 @@ func TestSweepToolchainLargeTailFocus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("abs root: %v", err)
 	}
+	dir := filepath.Join(root, "toolchain")
+	typeIndex, err := buildToolchainTypeIndex(dir)
+	if err != nil {
+		t.Fatalf("build type index: %v", err)
+	}
 	focus := []string{"ir.osty", "check_env.osty"}
 	for _, name := range focus {
-		path := filepath.Join(root, "toolchain", name)
+		path := filepath.Join(dir, name)
 		src, err := os.ReadFile(path)
 		if err != nil {
 			t.Logf("  %s: READ_ERR %v", name, err)
@@ -177,7 +191,7 @@ func TestSweepToolchainLargeTailFocus(t *testing.T) {
 			continue
 		}
 		_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
-		t.Logf("  %s: %s", name, formatWall(err))
+		t.Logf("  %s: %s", name, formatWallRich(err, name, typeIndex))
 	}
 }
 
@@ -228,7 +242,73 @@ func wallCode(msg string) string {
 // features that would retire each sub-wall. Categories are named
 // after what the backend would need to grow, not what the source
 // looks like — keeps the histogram pointing at real work.
+//
+// Plain wrapper for callers without a cross-file type index. The
+// single-file sweep sees "type \"FooStruct\"" errors on every named
+// type that lives in a sibling toolchain file; those are scope
+// artifacts, not backend gaps. Use classifyLLVM011Rich to tell the
+// difference.
 func classifyLLVM011(msg string) string {
+	return classifyLLVM011Rich(msg, "", nil)
+}
+
+// toolchainTypeIndex maps a top-level type name (struct / enum /
+// type-alias) to the toolchain/*.osty basename that declares it. The
+// single-file sweep uses this index to re-label "type \"X\"" LLVM011
+// errors as cross-file scope when X is defined in a sibling file.
+type toolchainTypeIndex map[string]string
+
+var toolchainTypeDeclRE = regexp.MustCompile(`^\s*(?:pub\s+)?(struct|enum|type)\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+// buildToolchainTypeIndex scans dir for *.osty files and records each
+// top-level struct / enum / type-alias declaration with its basename.
+// Test-only files are skipped. Kept deliberately simple: matches
+// declaration headers line-by-line, which is good enough for the
+// well-formatted toolchain/ layout (no comment-embedded keywords,
+// one declaration per header line).
+func buildToolchainTypeIndex(dir string) (toolchainTypeIndex, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	idx := toolchainTypeIndex{}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(src), "\n") {
+			m := toolchainTypeDeclRE.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			if _, dup := idx[m[2]]; !dup {
+				idx[m[2]] = name
+			}
+		}
+	}
+	return idx, nil
+}
+
+var llvm011TypeQuoteRE = regexp.MustCompile(`type "([^"]+)"`)
+
+// classifyLLVM011Rich refines classifyLLVM011 with cross-file scope
+// detection. When currentFile is non-empty and index is non-nil, a
+// "type \"X\"" error whose X is defined in a sibling toolchain file
+// is re-labelled cross_file_scope_{field|param|return}. Real backend
+// gaps keep their original category.
+func classifyLLVM011Rich(msg, currentFile string, index toolchainTypeIndex) string {
+	if index != nil && currentFile != "" {
+		if role, typeName, ok := extractLLVM011TypeRole(msg); ok {
+			if defFile, found := index[typeName]; found && defFile != currentFile {
+				return "cross_file_scope_" + role
+			}
+		}
+	}
 	switch {
 	case strings.Contains(msg, "interpolation of i64 value requires .toString()"):
 		return "int_interp_toString"
@@ -238,6 +318,10 @@ func classifyLLVM011(msg string) string {
 		return "interp_other"
 	case strings.Contains(msg, "type \"T\""):
 		return "generic_T"
+	case strings.Contains(msg, "list literal mixes"):
+		return "list_mixed_ptr"
+	case strings.Contains(msg, "plain String literals currently require ASCII"):
+		return "string_non_ascii"
 	case strings.Contains(msg, "field ") && strings.Contains(msg, ": type "):
 		return "struct_field_type"
 	case strings.Contains(msg, "parameter ") && strings.Contains(msg, ": type "):
@@ -267,6 +351,25 @@ func classifyLLVM011(msg string) string {
 	}
 }
 
+// extractLLVM011TypeRole pulls the "type \"X\"" payload from a
+// struct-field / fn-param / fn-return LLVM011 message and returns
+// the role marker used in cross_file_scope_{role} categories.
+func extractLLVM011TypeRole(msg string) (role, typeName string, ok bool) {
+	m := llvm011TypeQuoteRE.FindStringSubmatch(msg)
+	if m == nil {
+		return "", "", false
+	}
+	switch {
+	case strings.Contains(msg, "return type: type "):
+		return "return", m[1], true
+	case strings.Contains(msg, "parameter ") && strings.Contains(msg, ": type "):
+		return "param", m[1], true
+	case strings.Contains(msg, "field ") && strings.Contains(msg, ": type "):
+		return "field", m[1], true
+	}
+	return "", "", false
+}
+
 func classifyLLVM015(msg string) string {
 	switch {
 	case strings.Contains(msg, "*ast.FieldExpr"):
@@ -281,7 +384,18 @@ func classifyLLVM015(msg string) string {
 // formatWall renders a generateFromAST error as "CODE [subclass] — msg"
 // (or "CLEAN" on nil). Shared by the focus/parity probes so every
 // sweep speaks the same line format.
+//
+// For single-file sweep callers with a toolchain type index, use
+// formatWallRich instead — it re-labels cross-file scope artifacts.
 func formatWall(err error) string {
+	return formatWallRich(err, "", nil)
+}
+
+// formatWallRich is formatWall with cross-file scope awareness.
+// currentFile is the toolchain/*.osty basename that produced the
+// error; index is built from buildToolchainTypeIndex. When either
+// is zero-valued, behaves identically to formatWall.
+func formatWallRich(err error, currentFile string, index toolchainTypeIndex) string {
 	if err == nil {
 		return "CLEAN"
 	}
@@ -290,7 +404,7 @@ func formatWall(err error) string {
 	sub := ""
 	switch code {
 	case "LLVM011":
-		sub = classifyLLVM011(msg)
+		sub = classifyLLVM011Rich(msg, currentFile, index)
 	case "LLVM015":
 		sub = classifyLLVM015(msg)
 	}


### PR DESCRIPTION
## Summary

- 단일-파일 sweep의 LLVM011 "type X" 에러 23건 중 **20건은 sibling toolchain 파일에 정의된 타입을 못 찾아 발생하는 scope artifact**였음. 나머지 3건만 진짜 백엔드 갭.
- `buildToolchainTypeIndex` + `classifyLLVM011Rich`로 재라벨하고, 기존 "other" 버킷을 `list_mixed_ptr` / `string_non_ascii`로 분리. 백엔드 코드 변경 없음, 테스트 파일만.

## Before / After

기존 (잘못된 프레이밍):
```
struct_field_type:    12
fn_param_struct_type:  7
fn_return_struct_type: 2
other:                 2  (list-mix + non-ASCII string 섞여 있음)
```

지금 (정확한 신호):
```
cross_file_scope_field:  12  (artifact; type defined in sibling file)
cross_file_scope_param:   6  (artifact)
cross_file_scope_return:  2  (artifact)
list_mixed_ptr:           1  (real: llvmgen.osty)
fn_param_struct_type:     1  (real: lsp.osty, Char param boundary)
string_non_ascii:         1  (real: monomorph.osty)
```

진짜 LLVM011 백엔드 갭은 **3개**로 좁혀짐. 셀프호스팅 경로 결정에 쓸 수 있는 신호가 됨.

## Why

1. `multifile_probe_test.go`의 merge 실험이 이미 이 차이를 증명하고 있었음. `diagnostic.osty + lexer.osty` merge하면 `FrontLexStream` wall이 `OstyRichToken.kind: FrontTokenKind`로 이동. 즉 단일-파일에서 보이는 "struct_field_type"은 대부분 cross-file scope.
2. Whole-toolchain merged probe ([multifile_probe_test.go:75](https://github.com/choiceoh/osty/blob/claude/pedantic-bohr-fe7ad7/internal/llvmgen/multifile_probe_test.go#L75)) 첫 wall이 LLVM011이 아니라 **LLVM002 `runtime.golegacy.astbridge`** — sub-wall 히스토그램이 셀프호스팅의 진짜 다음 스텝과 무관했다는 뜻.
3. "개선" 방향이 "struct 지원 확장"이 아니라 "이 3개 갭 + LLVM002 bootstrap shim" 중 택일이 됐음. 그 결정을 하려면 신호가 정확해야 한다.

## 변경 범위

1 파일: [large_tail_sweep_test.go](https://github.com/choiceoh/osty/blob/claude/pedantic-bohr-fe7ad7/internal/llvmgen/large_tail_sweep_test.go)
- `buildToolchainTypeIndex()` — struct/enum/type alias 헤더 라인 스캔
- `classifyLLVM011Rich(msg, currentFile, index)` — "type \"X\""를 추출해서 sibling 정의면 재라벨
- `extractLLVM011TypeRole()` — field/param/return 역할 추출
- `formatWallRich()` — focus 프로브도 같은 신호
- 기존 `classifyLLVM011(msg)` / `formatWall(err)`는 wrapper로 보존 (merged probe 등 currentFile 개념이 없는 호출자 위해)

## Test plan

- [x] `go test -v -run TestSweepToolchainLargeTailLLVM011Subwalls ./internal/llvmgen/` — 새 히스토그램 확인
- [x] `go test -v -run "TestSweepToolchain|TestProbeLargeFile|TestProbeDiagnosticMerged" ./internal/llvmgen/` — 전체 sweep + probe 그린
- [x] `go vet ./internal/llvmgen/` clean
- [x] Pre-existing `TestGenerateModuleStdTestingExpectOkCompat` 실패는 pristine main에서도 동일 — 이 PR과 무관
- [ ] 리뷰어: `go test -v -run TestSweepToolchainLargeTailLLVM011Subwalls ./internal/llvmgen/`를 돌려서 히스토그램을 눈으로 확인

## 후속

별도 PR/턴에서 결정:
- 3 real LLVM011 gap 중 어느 것부터 (list_mixed_ptr, Char param, non-ASCII string)
- 또는 whole-toolchain 다음 wall인 LLVM002 `runtime.golegacy.astbridge` native shim

이 PR은 신호 정화만 — 자체로 self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)