### PR TITLE
[codex] Refine selfhost lexer boundary

### DIFF
--- a/internal/docgen/generated.go
+++ b/internal/docgen/generated.go
@@ -8692,7 +8692,7 @@ func ostyLexStringPartFromFront(units []string, tok *FrontLexToken, part *FrontS
 		// Osty: /tmp/docgen_merged.osty:6398:9
 		text = ostyNormalizeTripleSegment(text)
 	}
-	return &OstyLexStringPart{ownerToken: part.ownerToken, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})) && !(tok.triple), exprTokenStart: 0, exprTokenCount: 0}
+	return &OstyLexStringPart{ownerToken: part.ownerToken, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})), exprTokenStart: 0, exprTokenCount: 0}
 }
 
 // Osty: /tmp/docgen_merged.osty:6410:1
@@ -8705,7 +8705,7 @@ func ostyDefaultStringPart(units []string, tok *FrontLexToken, owner int) *OstyL
 		// Osty: /tmp/docgen_merged.osty:6413:9
 		text = ostyNormalizeTripleSegment(text)
 	}
-	return &OstyLexStringPart{ownerToken: owner, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})) && !(tok.triple), exprTokenStart: 0, exprTokenCount: 0}
+	return &OstyLexStringPart{ownerToken: owner, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})), exprTokenStart: 0, exprTokenCount: 0}
 }
 
 // Osty: /tmp/docgen_merged.osty:6425:1

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -14,27 +14,30 @@ type Error = diag.Diagnostic
 // Lexer wraps the self-hosted front end and exposes the same surface as the
 // former hand-written Go lexer.
 type Lexer struct {
-	run *selfhost.FrontendRun
+	toks     []token.Token
+	errs     []*diag.Diagnostic
+	comments []token.Comment
 }
 
 // New returns a Lexer over src.
 func New(src []byte) *Lexer {
-	return &Lexer{run: selfhost.Run(src)}
+	toks, errs, comments := selfhost.Lex(src)
+	return &Lexer{toks: toks, errs: errs, comments: comments}
 }
 
 // Lex returns the complete token stream, terminated by EOF.
 func (l *Lexer) Lex() []token.Token {
-	return l.run.Tokens()
+	return l.toks
 }
 
 // Errors returns lexical errors.
 func (l *Lexer) Errors() []*diag.Diagnostic {
-	return l.run.LexDiagnostics()
+	return l.errs
 }
 
 // Comments returns every comment (line, block, doc) in source order.
 func (l *Lexer) Comments() []token.Comment {
-	return l.run.Comments()
+	return l.comments
 }
 
 // IsIdentStart reports whether b is a valid first byte of an Osty identifier

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -219,6 +219,47 @@ func TestLexTripleStringStripsIndent(t *testing.T) {
 	}
 }
 
+func TestLexTripleStringDecodesEscapesAfterIndentNormalize(t *testing.T) {
+	src := "let s = \"\"\"\n    line\\nnext\\{ok\\}\n    \"\"\""
+	l := New([]byte(src))
+	toks := l.Lex()
+	if errs := l.Errors(); len(errs) != 0 {
+		t.Fatalf("unexpected lex errors: %v", errs)
+	}
+	var got *token.Token
+	for i := range toks {
+		if toks[i].Kind == token.STRING && toks[i].Triple {
+			got = &toks[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("no triple STRING token; tokens=%v", toks)
+	}
+	if len(got.Parts) != 1 || got.Parts[0].Kind != token.PartText {
+		t.Fatalf("expected one PartText, got parts=%+v", got.Parts)
+	}
+	want := "line\nnext{ok}"
+	if got.Parts[0].Text != want {
+		t.Fatalf("triple body = %q; want %q", got.Parts[0].Text, want)
+	}
+}
+
+func TestLexCommentsAndErrorsAvailableWithoutLexCall(t *testing.T) {
+	src := "// note\nlet s = \"bad\\q\"\n"
+	l := New([]byte(src))
+	if got := len(l.Comments()); got != 1 {
+		t.Fatalf("Comments() count = %d; want 1", got)
+	}
+	errs := l.Errors()
+	if len(errs) != 1 {
+		t.Fatalf("Errors() count = %d; want 1", len(errs))
+	}
+	if errs[0].Code != "E0003" {
+		t.Fatalf("Errors()[0].Code = %q; want E0003", errs[0].Code)
+	}
+}
+
 func TestLexShebangAndBomIgnored(t *testing.T) {
 	src := "\ufeff#!/usr/bin/env osty\nfn main() {}\n"
 	l := New([]byte(src))

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -17393,7 +17393,7 @@ func ostyLexStringPartFromFront(units []string, tok *FrontLexToken, part *FrontS
 		// Osty: /tmp/selfhost_merged.osty:6397:9
 		text = ostyNormalizeTripleSegment(text)
 	}
-	return &OstyLexStringPart{ownerToken: part.ownerToken, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})) && !(tok.triple), exprTokenStart: 0, exprTokenCount: 0}
+	return &OstyLexStringPart{ownerToken: part.ownerToken, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})), exprTokenStart: 0, exprTokenCount: 0}
 }
 
 // Osty: /tmp/selfhost_merged.osty:6409:1
@@ -17406,7 +17406,7 @@ func ostyDefaultStringPart(units []string, tok *FrontLexToken, owner int) *OstyL
 		// Osty: /tmp/selfhost_merged.osty:6412:9
 		text = ostyNormalizeTripleSegment(text)
 	}
-	return &OstyLexStringPart{ownerToken: owner, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})) && !(tok.triple), exprTokenStart: 0, exprTokenCount: 0}
+	return &OstyLexStringPart{ownerToken: owner, kindCode: 0, text: text, decodeEscapes: ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontString{})), exprTokenStart: 0, exprTokenCount: 0}
 }
 
 // Osty: /tmp/selfhost_merged.osty:6424:1

--- a/toolchain/lexer.osty
+++ b/toolchain/lexer.osty
@@ -396,7 +396,7 @@ fn ostyLexStringPartFromFront(
         ownerToken: part.ownerToken,
         kindCode: 0,
         text,
-        decodeEscapes: tok.kind == FrontString && !(tok.triple),
+        decodeEscapes: tok.kind == FrontString,
         exprTokenStart: 0,
         exprTokenCount: 0,
     }
@@ -411,7 +411,7 @@ fn ostyDefaultStringPart(units: List<String>, tok: FrontLexToken, owner: Int) ->
         ownerToken: owner,
         kindCode: 0,
         text,
-        decodeEscapes: tok.kind == FrontString && !(tok.triple),
+        decodeEscapes: tok.kind == FrontString,
         exprTokenStart: 0,
         exprTokenCount: 0,
     }


### PR DESCRIPTION
## Summary
- keep triple-quoted standard strings decoding escapes after indentation normalization
- route the public lexer facade through the lex-only selfhost path instead of the full parser run
- add lexer regression tests for triple-string escapes and using comments/errors without calling `Lex()` first

## Root Cause
- triple-string adaptation disabled escape decoding whenever a token was marked triple-quoted
- the public `internal/lexer` facade eagerly constructed a full `selfhost.Run`, so lex-only callers paid parser cost

## Validation
- `go test ./internal/lexer ./internal/selfhost ./internal/cst ./internal/docgen`

## Notes
- documented `b"..."` byte-string literal support is intentionally left for follow-up because it reaches beyond lexer wiring into downstream literal contracts
