### PR TITLE
test(llvmgen): native-path whole-toolchain probe + astbridge bootstrap-only 마킹

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -712,6 +712,49 @@ match 분해)를 추가한다.
 - C API/cgo binding은 incremental compile, object cache, debug metadata 품질이
   textual IR 방식의 한계에 닿았을 때만 재검토한다.
 
+## Bootstrap-only 호스트 어댑터 (astbridge 포함)
+
+**요약**: 현재 `toolchain/*.osty`의 4개 파일은 Go 호스트 바인딩을 통과하는 **bootstrap-only 어댑터**다. 이들은 LLVM 셀프-컴파일 경로 밖에 있고, whole-toolchain LLVM probe에서 자동으로 스킵된다. 이 구조 덕분에 sub-wall 히스토그램과 probe가 "셀프호스팅 시 진짜 남는 벽"만 보여준다.
+
+### 4개 bootstrap-only 파일
+
+| 파일 | FFI | 역할 | native 대체 경로 |
+|---|---|---|---|
+| `toolchain/ast_lower.osty` | `use runtime.golegacy.astbridge` | parser.osty AstArena → Go `*ast.File` 변환 | CLI가 Osty-native check/llvmgen을 호출하도록 재배선되면 dead code |
+| `toolchain/ci.osty` | `use go "github.com/osty/osty/internal/cihost"` | CI 드라이버 (format/lint/snapshot/manifest 호스트 호출) | native runtime ABI의 fs/process primitive 정의 후 포팅 |
+| `toolchain/docgen.osty` | `use go` | 문서 생성기 (파일 I/O + HTML emit) | 동상 |
+| `toolchain/manifest_validation.osty` | `use go` | manifest/lockfile 검증 (파일 해시, 경로 검사) | 동상 |
+
+### 분류 규칙
+
+`internal/llvmgen/multifile_probe_test.go:isBootstrapOnlyOstyFile`가 다음 두 패턴 중 하나라도 포함한 파일을 자동 bootstrap-only로 분류한다:
+
+- `use runtime.golegacy.*` — 명시적 legacy bootstrap 브릿지
+- `use go "..."` — 임의 Go 패키지 호스트 바인딩 (CLAUDE.md "호스트 경계" 허용 카테고리)
+
+두 패턴 모두 LLVM native lowering 없이는 LLVM binary로 self-compile 불가. 명시적 `// bootstrap-only` 주석 마커 대신 FFI 스탠자 존재를 시맨틱 시그널로 사용한다. 새 파일 추가 시 별도 작업 불필요 — `use go` / `use runtime.golegacy`를 쓰면 자동 분류됨.
+
+### Probe 쌍
+
+- `TestProbeWholeToolchainMerged` — 모든 파일 포함. 현재 첫 wall **LLVM002 `runtime.golegacy.astbridge`** (bootstrap artifact).
+- `TestProbeNativeToolchainMerged` — bootstrap-only 파일 제외. 현재 첫 wall **LLVM011 `fn_param_struct_type: Char`** (`charToDigit` param). **진짜 native 경로의 다음 벽**.
+
+두 probe의 첫-wall 차이 = bootstrap 브릿지가 히스토그램에 주입하는 노이즈 양. migration 진전은 native probe의 first-wall 이동으로 측정한다.
+
+### astbridge 제거 경로
+
+astbridge는 한 방에 제거하지 않고 **CLI 재배선이 완료되면 자동 dead code**가 되는 구조다:
+
+1. **현재 상태**: Go CLI (`cmd/osty`) → `internal/selfhost/parse.go:Parse` → `ast_lower.osty`가 `*ast.File` 생성 → Go `internal/check` / `internal/resolve` / `internal/llvmgen` 소비.
+2. **목표 상태**: Go CLI → Osty-native `check.osty`/`llvmgen.osty`/`resolve.osty` 직접 호출 → 이들은 이미 parser.osty `AstArena` + `AstNodeKind`를 네이티브 소비. `ast_lower.osty`와 `internal/selfhost/astbridge/` 둘 다 unused → 삭제.
+3. **전제 조건**: Osty-native downstream을 Go CLI에서 호출할 수 있는 ABI. 이는 Phase 4 runtime ABI 작업과 연결된다.
+
+중요: **`toolchain/ast.osty` 같은 신규 네이티브 AST 타입을 도입하지 않는다.** parser.osty의 `AstArena`가 이미 네이티브 AST 역할을 하고 있고, native downstream 모듈 전부 이를 이미 소비 중. 신규 AST 타입 도입은 순수 중복 작업이며 불필요하다 (이 결정은 PR #372에서 확정).
+
+### 비-bootstrap `use go` 파일이 앞으로 추가되면
+
+CLAUDE.md 호스트 경계 규칙상 `use go`는 특별 허가 영역(`cmd/*`, I/O, CLI glue)에서만 허용된다. 새로운 `use go` 파일이 들어오면 자동으로 bootstrap-only probe에서 스킵되므로 native path에는 영향 없음. 단, 그 파일의 LLVM native 대체 계획은 이 문서 § 4개 테이블에 추가 필수.
+
 ## 테스트 전략
 
 - Unit:

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -102,6 +102,77 @@ func TestProbeWholeToolchainMerged(t *testing.T) {
 	t.Logf("WHOLE TOOLCHAIN first wall: %s", formatWall(err))
 }
 
+// isBootstrapOnlyOstyFile reports whether the source is a
+// host-boundary bootstrap adapter — i.e., whether it declares either
+//
+//   - a `use runtime.golegacy.*` FFI (the legacy Go AST bridge), or
+//   - a `use go "..."` FFI (arbitrary Go package host binding)
+//
+// Both forms require the Osty compiler to be running under the
+// Go-hosted bootstrap CLI; neither has native LLVM runtime lowering
+// by design. Files carrying either stanza are skipped by the
+// native-path whole-toolchain probe. See LLVM_MIGRATION_PLAN.md
+// § "astbridge bootstrap-only adapter" for the migration path.
+func isBootstrapOnlyOstyFile(src []byte) bool {
+	s := string(src)
+	return strings.Contains(s, "use runtime.golegacy.") ||
+		strings.Contains(s, "use go \"")
+}
+
+// TestProbeNativeToolchainMerged is the whole-toolchain probe with
+// bootstrap-only files (those that import runtime.golegacy.*) filtered
+// out. Reveals the first real LLVM wall along the native self-host
+// path — the wall that remains once the CLI is rewired off the
+// Go-hosted bridge adapter. Info-only.
+//
+// Pair with TestProbeWholeToolchainMerged: the difference between the
+// two walls tells us how much signal the bootstrap bridge is injecting
+// into the histogram. Today: whole-merged → LLVM002 (bridge FFI);
+// native-merged → the next real backend gap.
+func TestProbeNativeToolchainMerged(t *testing.T) {
+	if testing.Short() {
+		t.Skip("info-only; slow; skipped in -short")
+	}
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+	var files []string
+	var skipped []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		if isBootstrapOnlyOstyFile(src) {
+			skipped = append(skipped, name)
+			continue
+		}
+		files = append(files, name)
+	}
+	if len(skipped) == 0 {
+		t.Logf("no bootstrap-only files detected; this probe is equivalent to TestProbeWholeToolchainMerged")
+	} else {
+		t.Logf("bootstrap-only files skipped (%d): %s", len(skipped), strings.Join(skipped, ", "))
+	}
+	merged := mergeToolchainSources(t, root, files)
+	file, _ := parser.ParseDiagnostics(merged)
+	if file == nil {
+		t.Fatalf("native-toolchain merged parse returned nil (%d files, %d bytes)", len(files), len(merged))
+	}
+	_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/toolchain_native_merged.osty"})
+	t.Logf("NATIVE TOOLCHAIN first wall: %s", formatWall(err))
+}
+
 // TestProbeDiagnosticMergedWithLexer checks whether the LLVM011 wall on
 // diagnostic.osty is a real backend gap or just the single-file probe's
 // scope limitation. We concatenate diagnostic.osty + lexer.osty (which

--- a/toolchain/ast_lower.osty
+++ b/toolchain/ast_lower.osty
@@ -1,3 +1,26 @@
+// ast_lower.osty — Osty-side bootstrap bridge adapter.
+//
+// Converts the self-hosted parser.osty arena (AstArena + AstNodeKind)
+// into the Go compiler's *ast.File representation by calling
+// runtime.golegacy.astbridge FFI functions. This file is
+// **bootstrap-only** and is NOT part of the LLVM self-compilation path.
+//
+// Downstream native toolchain modules (check.osty, llvmgen.osty,
+// resolve.osty, elab.osty, lint.osty, formatter_ast.osty) consume
+// the AstArena directly via `match node.kind { AstN... -> ... }` and
+// do not go through this adapter. ast_lower.osty is required only
+// because the outer Go CLI (internal/selfhost/parse.go:Parse) still
+// needs to return *ast.File to feed Go-hosted internal/check,
+// internal/resolve, and internal/llvmgen.
+//
+// LLVM whole-toolchain probes SKIP this file: any file containing
+// `use runtime.golegacy.*` is treated as bootstrap-only. The
+// resulting LLVM002 `runtime.golegacy.astbridge` diagnostic is
+// expected and does not represent a real backend gap. See
+// LLVM_MIGRATION_PLAN.md (§ "astbridge bootstrap-only adapter") for
+// the migration path: this adapter becomes dead code once the Go
+// CLI is rewired to Osty-native check/llvmgen consumers of AstArena.
+
 use std.strings as strings
 
 use runtime.golegacy.astbridge as astbridge {


### PR DESCRIPTION
## Summary

- `TestProbeWholeToolchainMerged`의 첫 wall `LLVM002 runtime.golegacy.astbridge`는 **bootstrap-only adapter (ast_lower.osty) 존재 자체의 artifact**였다. 진짜 native 셀프호스팅 경로의 벽이 아니다.
- bootstrap-only 파일을 자동 스킵하는 새 `TestProbeNativeToolchainMerged` 추가. 진짜 다음 벽을 드러냄: **LLVM011 `fn_param_struct_type: Char`** (`charToDigit` parameter).
- `ast_lower.osty`에 역할/migration 경로 설명 헤더 추가, `LLVM_MIGRATION_PLAN.md`에 "Bootstrap-only 호스트 어댑터" 섹션 추가.

## Before / After

두 probe 모두 존재, 역할이 다름:

| Probe | Scope | First wall |
|---|---|---|
| `TestProbeWholeToolchainMerged` | 모든 파일 | LLVM002 `runtime.golegacy.astbridge` (bootstrap artifact) |
| `TestProbeNativeToolchainMerged` (신규) | bootstrap-only 4개 제외 | LLVM011 `fn_param_struct_type: Char` (real gap) |

두 probe의 first-wall 차이 = bootstrap 브릿지가 히스토그램에 주입하는 노이즈 양. Migration 진전은 **native probe의 first-wall 이동**으로 측정.

## 중요 발견

`astbridge` FFI는 **`ast_lower.osty` 단 1파일만** 사용. 나머지 native toolchain 모듈 (`check.osty`, `llvmgen.osty`, `resolve.osty`, `elab.osty`, `lint.osty` 등) 전부 `parser.osty`의 `AstArena` + `AstNodeKind`를 직접 네이티브 소비 중. 즉 astbridge는 **Go CLI가 `*ast.File`을 기대하기 때문에 존재하는 one-way adapter**이고, CLI가 Osty-native downstream을 직접 호출하도록 재배선되면 자동으로 dead code가 된다.

**결과**: `toolchain/ast.osty` 같은 신규 네이티브 AST 타입 도입이 불필요하다는 것이 확정됨. 이 결정은 `LLVM_MIGRATION_PLAN.md`의 새 섹션에 기록.

## 분류 규칙

`isBootstrapOnlyOstyFile()` helper는 다음 두 패턴 중 하나라도 포함한 파일을 bootstrap-only로 자동 분류:

- `use runtime.golegacy.*` — 명시적 legacy 브릿지
- `use go "..."` — 임의 Go 패키지 호스트 바인딩 (CLAUDE.md "호스트 경계" 카테고리)

둘 다 LLVM native lowering 없이 self-compile 불가. 따라서 동일 시맨틱 클래스. 현재 4개 파일이 이 규칙으로 스킵됨:

- `ast_lower.osty` (runtime.golegacy.astbridge)
- `ci.osty`, `docgen.osty`, `manifest_validation.osty` (use go)

## Why

1. Whole-toolchain LLVM probe가 첫 wall 하나로 가려진 실제 native path 진전을 측정할 수 없었음
2. "astbridge 제거 위해 새 ast.osty 설계" 계획을 세웠다가, 이미 parser.osty arena가 native AST 역할을 하고 있는 걸 실측으로 발견. 헛된 migration 방향을 문서화로 차단
3. 다음 PR이 공격할 real gap이 LLVM011 histogram에서 보이던 "fn_param_struct_type: Char"와 정확히 일치 — 신호 체인 통일

## Test plan

- [x] `go test -v -run TestProbeNativeToolchainMerged ./internal/llvmgen/ -timeout 10m` → `NATIVE TOOLCHAIN first wall: LLVM011 [fn_param_struct_type]` 확인
- [x] `go test -v -run TestProbeWholeToolchainMerged ./internal/llvmgen/ -timeout 10m` → 기존 LLVM002 wall 여전히 reports (regression 없음)
- [x] `go vet ./internal/llvmgen/` clean
- [x] `go test -short -run "TestSweepToolchain|TestProbeLargeFile|TestProbeDiagnosticMerged|TestProbeNative" ./internal/llvmgen/` 전체 green
- [x] Pre-existing `TestGenerateModuleStdTestingExpectOkCompat` 실패는 pristine main에서도 fail — 이 PR과 무관

## 후속

다음 PR들이 공격할 real LLVM011 gap (우선순위):
1. **LLVM011 `Char` param boundary** — `lsp.osty lspUtf16UnitsForChar`, `charToDigit` 등. Native probe의 현재 wall.
2. **LLVM011 list_mixed_ptr** — `llvmgen.osty` list literal with mixed String/ptr
3. **LLVM011 string_non_ascii** — `monomorph.osty` non-ASCII string literal

이 PR은 signal 인프라만. 다음 PR에서 (1) 공격.

🤖 Generated with [Claude Code](https://claude.com/claude-code)