### PR TITLE
feat(llvmgen): first-class fn values + strings.concat/contains shim

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -204,6 +204,7 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
 static void osty_gc_mark_payload(void *payload);
 bool osty_rt_strings_Equal(const char *left, const char *right);
 int64_t osty_rt_strings_Compare(const char *left, const char *right);
+bool osty_rt_strings_Contains(const char *value, const char *substr);
 bool osty_rt_strings_HasSuffix(const char *value, const char *suffix);
 const char *osty_rt_strings_Join(void *raw_parts, const char *sep);
 const char *osty_rt_strings_TrimPrefix(const char *value, const char *prefix);
@@ -905,6 +906,16 @@ const char *osty_rt_strings_Concat(const char *left, const char *right) {
     }
     out[left_len + right_len] = '\0';
     return out;
+}
+
+bool osty_rt_strings_Contains(const char *value, const char *substr) {
+    if (value == NULL || substr == NULL) {
+        return false;
+    }
+    if (substr[0] == '\0') {
+        return true;
+    }
+    return strstr(value, substr) != NULL;
 }
 
 bool osty_rt_strings_HasPrefix(const char *value, const char *prefix) {

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -1068,6 +1068,17 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 			setElemString:  p.setElemString,
 			sourceType:     p.sourceType,
 		}
+		// Phase 3: fn-typed parameter. The value arrives as a ptr to
+		// a closure env (same uniform ABI as phase 1), so we tag the
+		// binding with a synthesised *fnSig so subsequent `p(args)`
+		// inside the body dispatches through emitIndirectUserCall.
+		if ft, ok := p.sourceType.(*ast.FnType); ok {
+			fsig, err := synthFnSigFromFnType(ft, g.typeEnv())
+			if err != nil {
+				return "", err
+			}
+			v.fnSigRef = fsig
+		}
 		v.gcManaged = valueNeedsManagedRoot(v)
 		v.rootPaths = g.rootPathsForType(p.typ)
 		if p.byRef {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -209,6 +209,13 @@ func (g *generator) emitIdent(name string) (value, error) {
 	if v, found, err := g.emitBuiltinOptionNone(name); found || err != nil {
 		return v, err
 	}
+	// Phase 1: bare top-level fn reference used in value position.
+	// Materialise a 1-field closure env pointing at a synthesised
+	// thunk so the uniform env-first-arg call ABI works for plain
+	// fn refs without captures. See internal/llvmgen/fn_value.go.
+	if sig, ok := g.functions[name]; ok && sig != nil && sig.receiverType == "" {
+		return g.emitFnValueEnv(sig)
+	}
 	return value{}, unsupportedf("name", "unknown identifier %q", name)
 }
 
@@ -2554,6 +2561,13 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if !found {
 		if id, ok := call.Fn.(*ast.Ident); ok && id.Name == "println" {
 			return value{}, unsupported("call", "println is only supported as a statement")
+		}
+		// Phase 1: indirect call through a first-class fn value held in a
+		// local/global binding. `f` was bound earlier (e.g. `let f =
+		// someFunc`) and carries fnSigRef so we recover the original
+		// signature for the call-site type string.
+		if v, ok, ierr := g.emitIndirectUserCall(call); ok || ierr != nil {
+			return v, ierr
 		}
 		return value{}, unsupportedf("call", "call target %T", call.Fn)
 	}

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -61,6 +61,85 @@ fn main() {
 	}
 }
 
+// Phase 1 of the first-class fn value lowering: a top-level fn used
+// in value position materialises a closure env + thunk, and the
+// subsequent call through the bound name dispatches indirectly.
+func TestGenerateFnValueBoundLocalIndirectCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn identity(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let f = identity
+    println(f(42))
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/fn_value_bound_local.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		// Env type def emitted when any fn-value is materialised.
+		"%osty.closure.env.ptr = type { ptr }",
+		// Thunk symbol for the top-level identity fn.
+		"define private i64 @__osty_closure_thunk_identity(ptr %env, i64 %arg0)",
+		// Thunk body delegates to real symbol.
+		"call i64 @identity(i64 %arg0)",
+		// Env alloca in main + store of thunk addr.
+		"alloca %osty.closure.env.ptr",
+		"store ptr @__osty_closure_thunk_identity, ptr",
+		// Indirect call at the use site: load fn ptr from env[0],
+		// invoke through the loaded ptr with env as implicit arg 0.
+		"= load ptr, ptr",
+		"= call i64 (ptr, i64)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Regression: if a fn is used as a value AND as a direct call in the
+// same module, the direct call path must keep emitting a plain
+// `call @sym` (not through the thunk). The thunk exists for the
+// value-position use only.
+func TestGenerateFnValueCoexistsWithDirectCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn double(x: Int) -> Int {
+    x + x
+}
+
+fn main() {
+    let f = double
+    let a = f(3)
+    let b = double(4)
+    println(a + b)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/fn_value_coexists.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	// The direct call `double(4)` must route through the real symbol,
+	// not the thunk. The indirect call through `f` goes through the
+	// thunk (evidenced by the env load + typed-signature call).
+	if !strings.Contains(got, "call i64 @double(i64") {
+		t.Fatalf("direct call to @double missing:\n%s", got)
+	}
+	if strings.Count(got, "__osty_closure_thunk_double") < 2 {
+		// One occurrence in the `define` header, one in the store that
+		// materialises the env.
+		t.Fatalf("expected thunk define + env store for @double, got:\n%s", got)
+	}
+}
+
 func TestGenerateStringCharsNoLongerTripsLLVM015(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn main() {
     let chars = "abc".chars()
@@ -77,5 +156,84 @@ func TestGenerateStringCharsNoLongerTripsLLVM015(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "LLVM015") {
 		t.Fatalf("String.chars still failed in FieldExpr call dispatch: %v", err)
+	}
+}
+
+// Phase 2: a struct field whose declared type is fn(...) becomes
+// the callee via `obj.field(args)`. The field value is loaded as a
+// ptr env and dispatched through the same indirect-call ABI.
+func TestGenerateFnTypedStructFieldIndirectCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Hook {
+    cb: fn(Int) -> Int,
+}
+
+fn inc(n: Int) -> Int {
+    n + 1
+}
+
+fn main() {
+    let h = Hook { cb: inc }
+    println(h.cb(41))
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/fn_typed_struct_field.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		// Struct with fn-typed field lowers to a one-ptr aggregate.
+		"%Hook = type { ptr }",
+		// Thunk for inc so the value form has the env-first ABI.
+		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
+		// The FieldExpr call path loads the fn ptr from env and
+		// dispatches through it.
+		"= call i64 (ptr, i64)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Phase 3: a function-typed parameter becomes the callee at an
+// indirect dispatch site inside the function body.
+func TestGenerateFnTypedParameterHigherOrder(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn apply(f: fn(Int) -> Int, x: Int) -> Int {
+    f(x)
+}
+
+fn inc(n: Int) -> Int {
+    n + 1
+}
+
+fn main() {
+    println(apply(inc, 41))
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/fn_typed_param.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		// apply takes a ptr env as its first user-visible param.
+		"define i64 @apply(ptr %f, i64 %x)",
+		// The call-site inside apply loads fn ptr from env and dispatches.
+		"= load ptr, ptr %f",
+		"= call i64 (ptr, i64)",
+		// main materialises a closure env for `inc` and passes it to apply.
+		"%osty.closure.env.ptr = type { ptr }",
+		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -1,0 +1,354 @@
+// fn_value.go — first-class function value lowering for the legacy AST
+// emitter. Mirrors the MIR closure ABI so fn values have a single
+// uniform representation regardless of which emitter produced them:
+//
+//   fn value  ≡  `ptr` to env struct
+//   env       ≡  { ptr fn_or_thunk, cap0, cap1, ... }
+//   call      ≡  `load ptr from env[0]; call ret (ptr, P...) %fn(env, args)`
+//
+// Top-level fn references (no captures) are wrapped in a thunk that
+// takes env as an implicit first arg and delegates to the real symbol.
+// Captured closures will fill in `Fields[1..]` in a later phase and
+// reuse the same call-site shape.
+package llvmgen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+// fnValueEnvTypeName is the module-level struct used for bare
+// (no-captures) fn-value envs. A 1-field env is sufficient — the
+// thunk pointer. Closure envs with captures get their own types in
+// phase 2+.
+const fnValueEnvTypeName = "osty.closure.env.ptr"
+
+func fnValueThunkSymbol(realSymbol string) string {
+	return "__osty_closure_thunk_" + realSymbol
+}
+
+// ensureFnValueThunk registers a closure thunk for `sig` if not yet
+// seen and returns its LLVM symbol name. The thunk is
+// `define private <ret> @__osty_closure_thunk_<sym>(ptr %env, P0, P1, ...)`
+// whose body discards env and forwards to the original symbol.
+//
+// The thunk IR is accumulated on the generator and flushed at module
+// render time — see generator.render().
+func (g *generator) ensureFnValueThunk(sig *fnSig) string {
+	symbol := fnValueThunkSymbol(sig.irName)
+	if g.fnValueThunkDefs == nil {
+		g.fnValueThunkDefs = map[string]string{}
+	}
+	if _, ok := g.fnValueThunkDefs[symbol]; ok {
+		return symbol
+	}
+	retLLVM := sig.ret
+	if retLLVM == "" {
+		retLLVM = "void"
+	}
+	// Build param list for the thunk: `ptr %env, <P0> %arg0, ...`.
+	paramParts := make([]string, 0, 1+len(sig.params))
+	paramParts = append(paramParts, "ptr %env")
+	argParts := make([]string, 0, len(sig.params))
+	for i, p := range sig.params {
+		pLLVM := llvmParamIRType(p)
+		paramParts = append(paramParts, fmt.Sprintf("%s %%arg%d", pLLVM, i))
+		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", pLLVM, i))
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "define private %s @%s(%s) {\n",
+		retLLVM, symbol, strings.Join(paramParts, ", "))
+	b.WriteString("entry:\n")
+	if retLLVM == "void" {
+		fmt.Fprintf(&b, "  call void @%s(%s)\n  ret void\n",
+			sig.irName, strings.Join(argParts, ", "))
+	} else {
+		fmt.Fprintf(&b, "  %%__ret = call %s @%s(%s)\n  ret %s %%__ret\n",
+			retLLVM, sig.irName, strings.Join(argParts, ", "), retLLVM)
+	}
+	b.WriteString("}\n")
+	g.fnValueThunkDefs[symbol] = b.String()
+	g.fnValueThunkOrder = append(g.fnValueThunkOrder, symbol)
+	return symbol
+}
+
+// emitFnValueEnv materialises a 1-field closure env holding the
+// thunk pointer for the given top-level fn. Returns a `ptr`-typed
+// value tagged with fnSigRef so a subsequent call site can do
+// indirect dispatch with the correct signature.
+//
+// The alloca is emitted into the current function's body. Callers
+// must already be inside a function — there is no module-level
+// fn-value literal path (globals would need a separate constant
+// initialiser ABI; deferred until a user-visible need appears).
+func (g *generator) emitFnValueEnv(sig *fnSig) (value, error) {
+	if sig == nil {
+		return value{}, unsupportedf("call", "fn-value env for nil signature")
+	}
+	thunk := g.ensureFnValueThunk(sig)
+	g.fnValueEnvTypeNeeded = true
+	emitter := g.toOstyEmitter()
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", slot, fnValueEnvTypeName))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunk, slot))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "ptr", ref: slot, fnSigRef: sig}, nil
+}
+
+// emitFnValueIndirectCall lowers a call through a fn-value env.
+// `envVal` is the env pointer (already loaded if it came from a
+// local slot); `sig` is the fn's signature inherited from the
+// original top-level declaration; `args` are the user arguments
+// already lowered.
+//
+// Emitted sequence:
+//
+//   %fn = load ptr, ptr %env
+//   (%result = )? call <ret> (ptr, P...) %fn(ptr %env, args...)
+//
+// Returns the call's LLVM result value (or an empty value when the
+// fn has no return).
+func (g *generator) emitFnValueIndirectCall(envVal value, sig *fnSig, args []*LlvmValue) (value, error) {
+	if sig == nil {
+		return value{}, unsupportedf("call", "indirect call with nil signature")
+	}
+	if envVal.typ != "ptr" {
+		return value{}, unsupportedf("call", "indirect call needs ptr env, got %s", envVal.typ)
+	}
+	retLLVM := sig.ret
+	if retLLVM == "" {
+		retLLVM = "void"
+	}
+	// Build the LLVM call-type string: `ret (ptr, P0, P1, ...)`.
+	paramParts := make([]string, 0, 1+len(sig.params))
+	paramParts = append(paramParts, "ptr")
+	for _, p := range sig.params {
+		paramParts = append(paramParts, llvmParamIRType(p))
+	}
+	callType := retLLVM + " (" + strings.Join(paramParts, ", ") + ")"
+
+	emitter := g.toOstyEmitter()
+	fnPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, envVal.ref))
+
+	// Assemble argument list with env prefix.
+	argStrs := make([]string, 0, 1+len(args))
+	argStrs = append(argStrs, fmt.Sprintf("ptr %s", envVal.ref))
+	for _, a := range args {
+		argStrs = append(argStrs, fmt.Sprintf("%s %s", a.typ, a.name))
+	}
+
+	if retLLVM == "void" {
+		emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", callType, fnPtr, strings.Join(argStrs, ", ")))
+		g.takeOstyEmitter(emitter)
+		return value{}, nil
+	}
+	result := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", result, callType, fnPtr, strings.Join(argStrs, ", ")))
+	g.takeOstyEmitter(emitter)
+	out := value{typ: retLLVM, ref: result}
+	out.listElemTyp = sig.retListElemTyp
+	out.listElemString = sig.retListString
+	out.mapKeyTyp = sig.retMapKeyTyp
+	out.mapValueTyp = sig.retMapValueTyp
+	out.mapKeyString = sig.retMapKeyString
+	out.setElemTyp = sig.retSetElemTyp
+	out.setElemString = sig.retSetElemString
+	out.sourceType = sig.returnSourceType
+	out.gcManaged = valueNeedsManagedRoot(out)
+	out.rootPaths = g.rootPathsForType(out.typ)
+	return out, nil
+}
+
+// fnValueEnvTypeDef returns the module-level struct def for the bare
+// (1-field) fn-value env, emitted into the module's type-def block
+// when any fn-value has been materialised.
+func fnValueEnvTypeDef() string {
+	return fmt.Sprintf("%%%s = type { ptr }", fnValueEnvTypeName)
+}
+
+// synthFnSigFromFnType builds a call-site-only *fnSig from an
+// `ast.FnType`. Used when a fn value arrives through a parameter
+// slot or a struct field — the original *fnSig from the defining
+// decl is out of reach, so we reconstruct just what the
+// indirect-call emitter reads: return type, param types, and
+// source-type metadata.
+//
+// Fields not populated here (name, irName, receiverType, decl)
+// intentionally stay empty — the indirect-call path never touches
+// them. A future site that needs direct-call dispatch through a
+// synthesised sig must fill those in then.
+func synthFnSigFromFnType(ft *ast.FnType, env typeEnv) (*fnSig, error) {
+	if ft == nil {
+		return nil, unsupportedf("type-system", "nil fn type")
+	}
+	params := make([]paramInfo, 0, len(ft.Params))
+	for i, pt := range ft.Params {
+		if pt == nil {
+			return nil, unsupportedf("type-system", "fn-type param %d missing type", i)
+		}
+		typ, err := llvmType(pt, env)
+		if err != nil {
+			return nil, err
+		}
+		info := paramInfo{
+			name:       fmt.Sprintf("arg%d", i),
+			typ:        typ,
+			irTyp:      typ,
+			sourceType: pt,
+		}
+		if listElemTyp, listElemString, ok, err := llvmListElementInfo(pt, env); err != nil {
+			return nil, err
+		} else if ok {
+			info.listElemTyp = listElemTyp
+			info.listElemString = listElemString
+		}
+		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(pt, env); err != nil {
+			return nil, err
+		} else if ok {
+			info.mapKeyTyp = mapKeyTyp
+			info.mapValueTyp = mapValueTyp
+			info.mapKeyString = mapKeyString
+		}
+		if setElemTyp, setElemString, ok, err := llvmSetElementType(pt, env); err != nil {
+			return nil, err
+		} else if ok {
+			info.setElemTyp = setElemTyp
+			info.setElemString = setElemString
+		}
+		params = append(params, info)
+	}
+	retLLVM := "void"
+	if ft.ReturnType != nil {
+		typ, err := llvmType(ft.ReturnType, env)
+		if err != nil {
+			return nil, err
+		}
+		retLLVM = typ
+	}
+	sig := &fnSig{
+		ret:              retLLVM,
+		returnSourceType: ft.ReturnType,
+		params:           params,
+	}
+	if ft.ReturnType != nil {
+		if listElemTyp, listElemString, ok, err := llvmListElementInfo(ft.ReturnType, env); err != nil {
+			return nil, err
+		} else if ok {
+			sig.retListElemTyp = listElemTyp
+			sig.retListString = listElemString
+		}
+		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(ft.ReturnType, env); err != nil {
+			return nil, err
+		} else if ok {
+			sig.retMapKeyTyp = mapKeyTyp
+			sig.retMapValueTyp = mapValueTyp
+			sig.retMapKeyString = mapKeyString
+		}
+		if setElemTyp, setElemString, ok, err := llvmSetElementType(ft.ReturnType, env); err != nil {
+			return nil, err
+		} else if ok {
+			sig.retSetElemTyp = setElemTyp
+			sig.retSetElemString = setElemString
+		}
+	}
+	return sig, nil
+}
+
+// emitIndirectUserCall attempts to dispatch `call` as an indirect call
+// through a first-class fn-value. Returns found=true when it
+// recognised the callee shape and produced (or failed to produce) a
+// call; found=false lets the main dispatcher fall through to its
+// LLVM015 diagnostic.
+//
+// Recognised callee shapes:
+//
+//   - Bare `*ast.Ident` bound to a local/global whose value carries
+//     fnSigRef (phase 1 for top-level fn refs, phase 3 for fn-typed
+//     params — both tag their binding at bind time).
+//   - `*ast.FieldExpr` on a struct whose field's source type is an
+//     `*ast.FnType`. The field value extracts to a ptr env; the sig
+//     is reconstructed on-the-fly from the field's source type.
+func (g *generator) emitIndirectUserCall(call *ast.CallExpr) (value, bool, error) {
+	if call == nil {
+		return value{}, false, nil
+	}
+	envVal, sig, found, err := g.indirectCallCallee(call)
+	if err != nil || !found {
+		return value{}, found, err
+	}
+	args, err := g.userCallArgs(sig, nil, call)
+	if err != nil {
+		return value{}, true, err
+	}
+	// Safepoint + scope handling mirrors the direct-call path so GC
+	// roots coming out of arg evaluation are released at the same
+	// cadence.
+	emitter := g.toOstyEmitter()
+	g.emitGCSafepoint(emitter)
+	g.takeOstyEmitter(emitter)
+	g.pushScope()
+	ret, callErr := g.emitFnValueIndirectCall(envVal, sig, args)
+	g.popScope()
+	if callErr != nil {
+		return value{}, true, callErr
+	}
+	return ret, true, nil
+}
+
+// indirectCallCallee resolves the callee side of an indirect call.
+// Returns (envVal, sig, true) on match; (_, _, false) otherwise so
+// the caller falls through to the direct-call diagnostic.
+func (g *generator) indirectCallCallee(call *ast.CallExpr) (value, *fnSig, bool, error) {
+	switch fn := call.Fn.(type) {
+	case *ast.Ident:
+		slot, ok := g.lookupBinding(fn.Name)
+		if !ok || slot.fnSigRef == nil {
+			return value{}, nil, false, nil
+		}
+		envVal, err := g.loadIfPointer(slot)
+		if err != nil {
+			return value{}, nil, true, err
+		}
+		return envVal, slot.fnSigRef, true, nil
+	case *ast.FieldExpr:
+		if fn.IsOptional {
+			return value{}, nil, false, nil
+		}
+		// Only attempt this path when the receiver's static type is
+		// a known struct and the field's source type is an FnType.
+		// Everything else (method calls, optional chains, module
+		// aliases) remains owned by the upstream hooks.
+		baseInfo, ok := g.staticExprInfo(fn.X)
+		if !ok {
+			return value{}, nil, false, nil
+		}
+		structInfo := g.structsByType[baseInfo.typ]
+		if structInfo == nil {
+			return value{}, nil, false, nil
+		}
+		field, ok := structInfo.byName[fn.Name]
+		if !ok {
+			return value{}, nil, false, nil
+		}
+		ft, ok := field.sourceType.(*ast.FnType)
+		if !ok {
+			return value{}, nil, false, nil
+		}
+		sig, err := synthFnSigFromFnType(ft, g.typeEnv())
+		if err != nil {
+			return value{}, nil, true, err
+		}
+		envVal, err := g.emitFieldExpr(fn)
+		if err != nil {
+			return value{}, nil, true, err
+		}
+		if envVal.typ != "ptr" {
+			return value{}, nil, true, unsupportedf("type-system", "fn-typed field %q.%s expected ptr env, got %s", structInfo.name, fn.Name, envVal.typ)
+		}
+		return envVal, sig, true, nil
+	}
+	return value{}, nil, false, nil
+}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -42,6 +42,19 @@ type generator struct {
 	runtimeDeclOrder  []string
 	traceHelpers      map[string]string
 	traceHelperDefs   []string
+	// Closure-env thunks generated on demand when a top-level fn
+	// symbol is used as a first-class value. Mirror of the MIR
+	// closure ABI (internal/llvmgen/mir_generator.go:emitThunks): one
+	// thunk per original symbol, signature `(ptr env, <user params>)`,
+	// body delegates to the real symbol ignoring env. Rendered at the
+	// end of the module so the top-down read order matches user code
+	// first / machinery second. See fn_value.go.
+	fnValueThunkDefs  map[string]string
+	fnValueThunkOrder []string
+	// True once any fn-value env has been materialised; gates the
+	// module-level `%osty.closure.env.ptr` typedef so plain programs
+	// that never touch first-class fns stay free of the noise.
+	fnValueEnvTypeNeeded bool
 
 	temp              int
 	label             int
@@ -92,6 +105,11 @@ type value struct {
 	setElemString  bool
 	sourceType     ast.Type
 	rootPaths      [][]int
+	// fnSigRef is non-nil when this value is a first-class function
+	// value — an env pointer produced by emitFnValueEnv. The sig gives
+	// the call-site indirect-call dispatcher the LLVM signature to
+	// emit. See internal/llvmgen/fn_value.go.
+	fnSigRef *fnSig
 }
 
 type builtinResultContext struct {
@@ -195,10 +213,24 @@ func (g *generator) render(defs []string) []byte {
 	if len(g.traceHelperDefs) != 0 {
 		defs = append(append([]string(nil), g.traceHelperDefs...), defs...)
 	}
+	// Phase 1: closure thunks generated for first-class fn values
+	// live at the tail of the module so the top-down read order is
+	// user functions first, then machinery. Order is deterministic
+	// via fnValueThunkOrder (insertion-ordered).
+	if len(g.fnValueThunkOrder) != 0 {
+		thunks := make([]string, 0, len(g.fnValueThunkOrder))
+		for _, sym := range g.fnValueThunkOrder {
+			thunks = append(thunks, g.fnValueThunkDefs[sym])
+		}
+		defs = append(defs, thunks...)
+	}
 	allDefs := make([]string, 0, len(g.globalDefs)+len(defs))
 	allDefs = append(allDefs, g.globalDefs...)
 	allDefs = append(allDefs, defs...)
 	typeDefs := make([]string, 0, len(g.structs)+len(g.enumsByType)+len(g.tupleTypes)+len(g.resultTypes))
+	if g.fnValueEnvTypeNeeded {
+		typeDefs = append(typeDefs, fnValueEnvTypeDef())
+	}
 	for _, info := range g.structs {
 		fieldTypes := make([]string, 0, len(info.fields))
 		for _, field := range info.fields {
@@ -626,6 +658,7 @@ func copyContainerMetadata(dst *value, src value) {
 	dst.setElemTyp = src.setElemTyp
 	dst.setElemString = src.setElemString
 	dst.sourceType = src.sourceType
+	dst.fnSigRef = src.fnSigRef
 	dst.gcManaged = valueNeedsManagedRoot(*dst)
 }
 

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -57,6 +57,12 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 	case "compare":
 		v, err := g.emitStdStringsBinary(call, "compare", "i64", llvmStringRuntimeCompareSymbol())
 		return v, true, err
+	case "concat":
+		v, err := g.emitStdStringsBinaryString(call, "concat", llvmStringRuntimeConcatSymbol())
+		return v, true, err
+	case "contains":
+		v, err := g.emitStdStringsBinary(call, "contains", "i1", llvmStringRuntimeContainsSymbol())
+		return v, true, err
 	case "hasPrefix":
 		v, err := g.emitStdStringsBinary(call, "hasPrefix", "i1", llvmStringRuntimeHasPrefixSymbol())
 		return v, true, err
@@ -102,9 +108,9 @@ func (g *generator) stdStringsCallStaticResult(call *ast.CallExpr) (value, bool)
 	switch field.Name {
 	case "compare":
 		return value{typ: "i64"}, true
-	case "hasPrefix", "hasSuffix":
+	case "contains", "hasPrefix", "hasSuffix":
 		return value{typ: "i1"}, true
-	case "join", "trim", "trimSpace", "trimPrefix", "trimSuffix":
+	case "concat", "join", "trim", "trimSpace", "trimPrefix", "trimSuffix":
 		return value{typ: "ptr", gcManaged: true}, true
 	case "split":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true}, true

--- a/internal/llvmgen/stdlib_shim_test.go
+++ b/internal/llvmgen/stdlib_shim_test.go
@@ -228,6 +228,53 @@ fn main() {
 	}
 }
 
+func TestStdStringsConcatRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let out = strings.concat("a", "b")
+    println(out)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_concat.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"call ptr @osty_rt_strings_Concat",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
+func TestStdStringsContainsRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    if strings.contains("abcdef", "cd") {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_contains.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare i1 @osty_rt_strings_Contains(ptr, ptr)",
+		"call i1 @osty_rt_strings_Contains",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
 func TestCollectStdStringsAliasesIgnoresRuntimeFFI(t *testing.T) {
 	file := parseLLVMGenFile(t, `use runtime.strings as strings {
     fn HasPrefix(s: String, prefix: String) -> Bool

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2111,6 +2111,10 @@ func llvmStringRuntimeHasSuffixSymbol() string {
 	return "osty_rt_strings_HasSuffix"
 }
 
+func llvmStringRuntimeContainsSymbol() string {
+	return "osty_rt_strings_Contains"
+}
+
 func llvmStringRuntimeSplitSymbol() string {
 	return "osty_rt_strings_Split"
 }
@@ -2160,6 +2164,7 @@ func llvmStringRuntimeDeclarations() []string {
 		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
 		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
 		"declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)",
+		"declare i1 @osty_rt_strings_Contains(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
 		"declare ptr @osty_rt_int_to_string(i64)",

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2223,6 +2223,10 @@ pub fn llvmStringRuntimeHasSuffixSymbol() -> String {
     "osty_rt_strings_HasSuffix"
 }
 
+pub fn llvmStringRuntimeContainsSymbol() -> String {
+    "osty_rt_strings_Contains"
+}
+
 pub fn llvmStringRuntimeSplitSymbol() -> String {
     "osty_rt_strings_Split"
 }
@@ -2278,6 +2282,7 @@ pub fn llvmStringRuntimeDeclarations() -> List<String> {
         "declare i1 @osty_rt_strings_Equal(ptr, ptr)",
         "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
         "declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)",
+        "declare i1 @osty_rt_strings_Contains(ptr, ptr)",
         "declare ptr @osty_rt_strings_Split(ptr, ptr)",
         "declare ptr @osty_rt_strings_Concat(ptr, ptr)",
         "declare ptr @osty_rt_int_to_string(i64)",


### PR DESCRIPTION
## Summary

LLVM015 "call target `*ast.Ident` / `*ast.FieldExpr`" 을 두 축으로 공략:

- **A-part** — `std.strings` shim에 `concat` / `contains` 추가 (runner.osty / test_runner.osty 즉각 언블록)
- **C-part** — legacy AST 경로에 **1급 함수 값 ABI** 도입. MIR 클로저 ABI (`ptr env = { ptr fn, caps... }` + 합성 thunk)를 그대로 미러해서 장래 MIR-full 전환 시 ABI divergence 없음

## What changed

### A-part (shim 확장)
- `osty_rt_strings_Contains` runtime C helper (`strstr` 기반)
- `emitStdStringsCall` + `stdStringsCallStaticResult` 에 `concat`/`contains` 분기
- `toolchain/llvmgen.osty` + `support_snapshot.go` symbol/declaration 동기화

### C-part (fn value lowering) — 새 파일 `internal/llvmgen/fn_value.go`
- 호출 사이트: `load ptr from env[0]; call ret (ptr, P...) %fn(env, args)`
- Top-level fn 값화: 1-필드 env + `__osty_closure_thunk_<sym>` (env 무시 delegate)
- **Phase 1** — `let f = someFunc; f(args)` (Ident binding)
- **Phase 2** — `obj.cb(42)` where `cb: fn(...)` 는 struct field (FieldExpr)
- **Phase 3** — `fn apply(f: fn(Int)->Int, x: Int) { f(x) }` (higher-order)
- `synthFnSigFromFnType` 으로 param/field 경로에서 call-site-only fnSig 재구성

## Why

스펙 §A.5/§B.5 는 이미 first-class fn 을 전제하지만 legacy AST 백엔드는 `emitCall` fallthrough 에서 전부 LLVM015 로 반려. MIR 쪽엔 이미 `emitIndirectCall` + `emitClosureEnv` 가 Stage 3 MVP 로 존재 — 이걸 AST 쪽에도 같은 모양으로 배선해서 stdlib / 툴체인 / 유저 코드가 모두 동일 ABI 로 동작하도록 맞춤.

## Histogram (`TestSweepToolchainLargeTail`)

| | before | after |
|---|---|---|
| CLEAN | 9 | **10** |
| LLVM015 | 3 | **1** |
| LLVM011 | 23 | 24 |
| OTHER | 4 | 4 |

- `runner.osty` / `test_runner.osty` — A-part 로 언블록 (runner 는 다음 벽 LLVM011 로 이동, test_runner 는 완전 CLEAN)
- `frontend.osty` 남은 LLVM015 1건 — `stringUnitCount` 정의가 `semver_parse.osty` 에 있는 cross-file 참조. sweep 하니스가 single-file `generateFromAST` 로 돌리는 테스트 아티팩트 (실제 `osty build` 는 패키지 단위라 정상 resolve). capability 갭 아님.

## 회귀 확인

- `go test ./internal/llvmgen/...` — 1 fail (`TestGenerateModuleStdTestingExpectOkCompat`). **baseline 동일 실패 확인**. pre-existing.
- `go test ./cmd/osty/...` — 10 fails. **baseline 10건 동일**. pre-existing (native LLVM 경로가 closure capture 에서 `code generation is not implemented yet` 로 막힘).
- 나머지 모든 패키지 PASS.
- 이 PR 이 새로 도입한 회귀 0건.

## New tests (모두 PASS)

- `TestStdStringsConcatRoutesToRuntime`, `TestStdStringsContainsRoutesToRuntime`
- `TestGenerateFnValueBoundLocalIndirectCall`
- `TestGenerateFnValueCoexistsWithDirectCall` (direct + indirect 공존 회귀 방지)
- `TestGenerateFnTypedStructFieldIndirectCall`
- `TestGenerateFnTypedParameterHigherOrder`

## Test plan

- [x] `go test ./internal/llvmgen/` — 1 pre-existing fail only
- [x] `go test ./internal/llvmgen/ -run TestSweepToolchainLargeTail` — histogram 확인
- [x] `go build ./...` clean
- [ ] `cmd/osty` native-path fails 는 별도 PR 로 (closure capture 지원 필요, 이 PR 범위 밖)

## Follow-ups (별도 작업)

- **Phase 4**: capture 있는 클로저 (`|x| x + captured`) — env slot 1..N 에 captures 저장 + lifted body 가 env 직접 사용
- **GC roots for fn-value env**: 현재 stack alloca, escape 분석 후 heap 전환 필요
- **sweep 하니스 개선**: package-level 로딩으로 frontend.osty 같은 cross-file 케이스를 true positive 인지 검증

## Reviewer notes

- `fn_value.go` 가 주요 신규 코드 (~220 LOC). 나머지 변경은 기존 파일에 훅 + shim 엔트리 추가로 좁음
- MIR 쪽 (`internal/llvmgen/mir_generator.go:1203 emitIndirectCall`, `:2921 emitClosureEnv`, `:3164 emitFnValueWrapper`) 의 ABI 를 의도적으로 **그대로 미러**. 한쪽 변경 시 다른쪽도 맞춰야 함 (현재는 drift 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)