### PR TITLE
[codex] speed up new checker hot paths

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -25909,6 +25909,8 @@ type TyNode struct {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10195:5
 type TyArena struct {
 	nodes           []*TyNode
+	internKeys      []string
+	internValues    []int
 	idxErr          int
 	idxInt          int
 	idxInt8         int
@@ -25941,7 +25943,7 @@ func emptyTyNode() *TyNode {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10241:5
 func emptyTyArena() *TyArena {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10242:5
-	arena := &TyArena{nodes: make([]*TyNode, 0, 1), idxErr: -1, idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1, idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1, idxByte: -1, idxFloat: -1, idxFloat32: -1, idxFloat64: -1, idxBool: -1, idxChar: -1, idxString: -1, idxBytes: -1, idxUnit: -1, idxNever: -1, idxUntypedInt: -1, idxUntypedFloat: -1}
+	arena := &TyArena{nodes: make([]*TyNode, 0, 1), internKeys: make([]string, 0, 1), internValues: make([]int, 0, 1), idxErr: -1, idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1, idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1, idxByte: -1, idxFloat: -1, idxFloat32: -1, idxFloat64: -1, idxBool: -1, idxChar: -1, idxString: -1, idxBytes: -1, idxUnit: -1, idxNever: -1, idxUntypedInt: -1, idxUntypedFloat: -1}
 	_ = arena
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10252:10
 	arena.idxErr = tyAllocErr(arena)
@@ -26018,27 +26020,7 @@ func tyAllocPrim(arena *TyArena, prim PrimKind) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10299:5
 func tyNodeCount(arena *TyArena) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10300:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10301:5
-	for _, n := range arena.nodes {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10302:9
-		_ = n
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10303:9
-		func() {
-			var _cur1957 int = count
-			var _rhs1958 int = 1
-			if _rhs1958 > 0 && _cur1957 > math.MaxInt-_rhs1958 {
-				panic("integer overflow")
-			}
-			if _rhs1958 < 0 && _cur1957 < math.MinInt-_rhs1958 {
-				panic("integer overflow")
-			}
-			count = _cur1957 + _rhs1958
-		}()
-	}
-	return count
+	return len(arena.nodes)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10313:5
@@ -26228,54 +26210,34 @@ func tyPrim(arena *TyArena, prim PrimKind) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10372:5
 func tyNamed(arena *TyArena, head string, args []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10373:5
-	idx := tyNodeCount(arena)
-	_ = idx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10374:5
 	node := &TyNode{kind: TyKind(&TyKind_TkNamed{}), prim: PrimKind(&PrimKind_PkInvalid{}), head: head, args: args, ret: -1, varId: 0, varName: "", varOwner: ""}
 	_ = node
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10378:5
-	func() struct{} { arena.nodes = append(arena.nodes, node); return struct{}{} }()
-	return idx
+	return tyInternNode(arena, tyKeyNamed(node.head, node.args), node)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10385:5
 func tyTuple(arena *TyArena, elems []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10386:5
-	idx := tyNodeCount(arena)
-	_ = idx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10387:5
 	node := &TyNode{kind: TyKind(&TyKind_TkTuple{}), prim: PrimKind(&PrimKind_PkInvalid{}), head: "", args: elems, ret: -1, varId: 0, varName: "", varOwner: ""}
 	_ = node
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10391:5
-	func() struct{} { arena.nodes = append(arena.nodes, node); return struct{}{} }()
-	return idx
+	return tyInternNode(arena, tyKeyTuple(node.args), node)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10398:5
 func tyFn(arena *TyArena, params []int, ret int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10399:5
-	idx := tyNodeCount(arena)
-	_ = idx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10400:5
 	node := &TyNode{kind: TyKind(&TyKind_TkFn{}), prim: PrimKind(&PrimKind_PkInvalid{}), head: "", args: params, ret: ret, varId: 0, varName: "", varOwner: ""}
 	_ = node
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10404:5
-	func() struct{} { arena.nodes = append(arena.nodes, node); return struct{}{} }()
-	return idx
+	return tyInternNode(arena, tyKeyFn(node.args, node.ret), node)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10409:5
 func tyOptional(arena *TyArena, inner int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10410:5
-	idx := tyNodeCount(arena)
-	_ = idx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10411:5
 	node := &TyNode{kind: TyKind(&TyKind_TkOptional{}), prim: PrimKind(&PrimKind_PkInvalid{}), head: "", args: make([]int, 0, 1), ret: inner, varId: 0, varName: "", varOwner: ""}
 	_ = node
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10415:5
-	func() struct{} { arena.nodes = append(arena.nodes, node); return struct{}{} }()
-	return idx
+	return tyInternNode(arena, tyKeyOptional(node.ret), node)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10422:5
@@ -26303,48 +26265,72 @@ func tyVarFresh(arena *TyArena, owner string, name string) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10435:5
 func tySelf(arena *TyArena, owner string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10436:5
-	idx := tyNodeCount(arena)
-	_ = idx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10437:5
 	node := &TyNode{kind: TyKind(&TyKind_TkSelf{}), prim: PrimKind(&PrimKind_PkInvalid{}), head: owner, args: make([]int, 0, 1), ret: -1, varId: 0, varName: "", varOwner: ""}
 	_ = node
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10441:5
-	func() struct{} { arena.nodes = append(arena.nodes, node); return struct{}{} }()
+	return tyInternNode(arena, tyKeySelf(node.head), node)
+}
+
+func tyInternNode(arena *TyArena, key string, node *TyNode) int {
+	existing := tyLookupInterned(arena, key)
+	if existing >= 0 {
+		return existing
+	}
+	idx := tyNodeCount(arena)
+	arena.nodes = append(arena.nodes, node)
+	arena.internKeys = append(arena.internKeys, key)
+	arena.internValues = append(arena.internValues, idx)
 	return idx
+}
+
+func tyLookupInterned(arena *TyArena, key string) int {
+	for i := 0; i < len(arena.internKeys); i++ {
+		if arena.internKeys[i] == key {
+			return arena.internValues[i]
+		}
+	}
+	return -1
+}
+
+func tyKeyNamed(head string, args []int) string {
+	return fmt.Sprintf("N|%s|%s", head, tyKeyArgs(args))
+}
+
+func tyKeyTuple(args []int) string {
+	return fmt.Sprintf("T|%s", tyKeyArgs(args))
+}
+
+func tyKeyFn(args []int, ret int) string {
+	return fmt.Sprintf("F|%s|%d", tyKeyArgs(args), ret)
+}
+
+func tyKeyOptional(inner int) string {
+	return fmt.Sprintf("O|%d", inner)
+}
+
+func tyKeySelf(owner string) string {
+	return fmt.Sprintf("S|%s", owner)
+}
+
+func tyKeyArgs(args []int) string {
+	if len(args) == 0 {
+		return ""
+	}
+	out := fmt.Sprintf("%d", args[0])
+	for _, arg := range args[1:] {
+		out = fmt.Sprintf("%s,%d", out, arg)
+	}
+	return out
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10452:5
 func tyGet(arena *TyArena, idx int) *TyNode {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10453:5
-	if idx < 0 {
+	if idx < 0 || idx >= len(arena.nodes) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10454:9
 		return emptyTyNode()
 	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10456:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10457:5
-	for _, n := range arena.nodes {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10458:9
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10459:13
-			return n
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10461:9
-		func() {
-			var _cur1962 int = i
-			var _rhs1963 int = 1
-			if _rhs1963 > 0 && _cur1962 > math.MaxInt-_rhs1963 {
-				panic("integer overflow")
-			}
-			if _rhs1963 < 0 && _cur1962 < math.MinInt-_rhs1963 {
-				panic("integer overflow")
-			}
-			i = _cur1962 + _rhs1963
-		}()
-	}
-	return emptyTyNode()
+	return arena.nodes[idx]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10466:5
@@ -26565,55 +26551,15 @@ func tyEqList(arena *TyArena, xs []int, ys []int) bool {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10622:1
 func tyIntListLen(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10623:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10624:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10625:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10626:9
-		func() {
-			var _cur1967 int = count
-			var _rhs1968 int = 1
-			if _rhs1968 > 0 && _cur1967 > math.MaxInt-_rhs1968 {
-				panic("integer overflow")
-			}
-			if _rhs1968 < 0 && _cur1967 < math.MinInt-_rhs1968 {
-				panic("integer overflow")
-			}
-			count = _cur1967 + _rhs1968
-		}()
-	}
-	return count
+	return len(xs)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10631:1
 func tyIntAt(xs []int, idx int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10632:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10633:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10634:9
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10635:13
-			return x
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10637:9
-		func() {
-			var _cur1969 int = i
-			var _rhs1970 int = 1
-			if _rhs1970 > 0 && _cur1969 > math.MaxInt-_rhs1970 {
-				panic("integer overflow")
-			}
-			if _rhs1970 < 0 && _cur1969 < math.MinInt-_rhs1970 {
-				panic("integer overflow")
-			}
-			i = _cur1969 + _rhs1970
-		}()
+	if idx < 0 || idx >= len(xs) {
+		return -1
 	}
-	return -1
+	return xs[idx]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10648:5
@@ -30777,27 +30723,7 @@ func checkScopeDrop(env *CheckEnv, mark int) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12905:5
 func checkBindingCount(env *CheckEnv) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12906:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12907:5
-	for _, b := range env.bindings {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12908:9
-		_ = b
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12909:9
-		func() {
-			var _cur2040 int = n
-			var _rhs2041 int = 1
-			if _rhs2041 > 0 && _cur2040 > math.MaxInt-_rhs2041 {
-				panic("integer overflow")
-			}
-			if _rhs2041 < 0 && _cur2040 < math.MinInt-_rhs2041 {
-				panic("integer overflow")
-			}
-			n = _cur2040 + _rhs2041
-		}()
-	}
-	return n
+	return len(env.bindings)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12919:5
@@ -30829,34 +30755,22 @@ func checkBindSpan(env *CheckEnv, name string, ty int, mutable bool, start int, 
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12948:5
 func checkLookup(env *CheckEnv, name string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12949:5
-	found := -1
-	_ = found
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12950:5
-	for _, b := range env.bindings {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12951:9
-		if b.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12952:13
-			found = b.ty
+	for i := len(env.bindings) - 1; i >= 0; i-- {
+		if env.bindings[i].name == name {
+			return env.bindings[i].ty
 		}
 	}
-	return found
+	return -1
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12958:5
 func checkLookupMutable(env *CheckEnv, name string) bool {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12959:5
-	mutable := false
-	_ = mutable
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12960:5
-	for _, b := range env.bindings {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12961:9
-		if b.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12962:13
-			mutable = b.mutable
+	for i := len(env.bindings) - 1; i >= 0; i-- {
+		if env.bindings[i].name == name {
+			return env.bindings[i].mutable
 		}
 	}
-	return mutable
+	return false
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12972:5
@@ -30867,11 +30781,9 @@ func checkRegisterFn(env *CheckEnv, sig *CheckFnSig) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12976:5
 func checkLookupFn(env *CheckEnv, name string, owner string) *CheckFnSig {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12977:5
-	for _, sig := range env.fns {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12978:9
+	for i := len(env.fns) - 1; i >= 0; i-- {
+		sig := env.fns[i]
 		if sig.name == name && sig.owner == owner {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12979:13
 			return sig
 		}
 	}
@@ -30935,11 +30847,9 @@ func checkRegisterField(env *CheckEnv, field *CheckFieldSig) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13021:5
 func checkLookupField(env *CheckEnv, owner string, name string) *CheckFieldSig {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13022:5
-	for _, f := range env.fields {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13023:9
+	for i := len(env.fields) - 1; i >= 0; i-- {
+		f := env.fields[i]
 		if f.owner == owner && f.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13024:13
 			return f
 		}
 	}
@@ -30954,11 +30864,9 @@ func checkRegisterVariant(env *CheckEnv, variant *CheckVariantSig) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13034:5
 func checkLookupVariant(env *CheckEnv, name string) *CheckVariantSig {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13035:5
-	for _, v := range env.variants {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13036:9
+	for i := len(env.variants) - 1; i >= 0; i-- {
+		v := env.variants[i]
 		if v.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13037:13
 			return v
 		}
 	}
@@ -30967,11 +30875,9 @@ func checkLookupVariant(env *CheckEnv, name string) *CheckVariantSig {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13043:5
 func checkLookupVariantInOwner(env *CheckEnv, owner string, name string) *CheckVariantSig {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13044:5
-	for _, v := range env.variants {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13045:9
+	for i := len(env.variants) - 1; i >= 0; i-- {
+		v := env.variants[i]
 		if v.owner == owner && v.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13046:13
 			return v
 		}
 	}
@@ -30986,11 +30892,9 @@ func checkRegisterAlias(env *CheckEnv, alias *CheckAliasSig) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13056:5
 func checkLookupAlias(env *CheckEnv, name string) *CheckAliasSig {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13057:5
-	for _, a := range env.aliases {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13058:9
+	for i := len(env.aliases) - 1; i >= 0; i-- {
+		a := env.aliases[i]
 		if a.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13059:13
 			return a
 		}
 	}
@@ -31005,11 +30909,9 @@ func checkRegisterType(env *CheckEnv, sig *CheckTypeSig) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13069:5
 func checkLookupType(env *CheckEnv, name string) *CheckTypeSig {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13070:5
-	for _, t := range env.types {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13071:9
+	for i := len(env.types) - 1; i >= 0; i-- {
+		t := env.types[i]
 		if t.name == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13072:13
 			return t
 		}
 	}
@@ -31080,18 +30982,13 @@ func checkAddGenericBound(env *CheckEnv, bound *CheckGenericBound) {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13123:5
 func checkLookupGenericBound(env *CheckEnv, tyParam string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13124:5
-	found := -1
-	_ = found
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13125:5
-	for _, b := range env.genericBounds {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13126:9
+	for i := len(env.genericBounds) - 1; i >= 0; i-- {
+		b := env.genericBounds[i]
 		if b.tyParam == tyParam {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13127:13
-			found = b.iface
+			return b.iface
 		}
 	}
-	return found
+	return -1
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13133:5
@@ -31150,27 +31047,7 @@ func checkGenericBoundMark(env *CheckEnv) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13155:1
 func checkGenericBoundCount(env *CheckEnv) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13156:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13157:5
-	for _, b := range env.genericBounds {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13158:9
-		_ = b
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13159:9
-		func() {
-			var _cur2044 int = n
-			var _rhs2045 int = 1
-			if _rhs2045 > 0 && _cur2044 > math.MaxInt-_rhs2045 {
-				panic("integer overflow")
-			}
-			if _rhs2045 < 0 && _cur2044 < math.MinInt-_rhs2045 {
-				panic("integer overflow")
-			}
-			n = _cur2044 + _rhs2045
-		}()
-	}
-	return n
+	return len(env.genericBounds)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13172:5
@@ -31992,27 +31869,7 @@ func checkConcreteMethodTy(env *CheckEnv, sig *CheckFnSig, ownerTy int) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13584:1
 func checkIntListLen(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13585:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13586:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13587:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13588:9
-		func() {
-			var _cur2072 int = n
-			var _rhs2073 int = 1
-			if _rhs2073 > 0 && _cur2072 > math.MaxInt-_rhs2073 {
-				panic("integer overflow")
-			}
-			if _rhs2073 < 0 && _cur2072 < math.MinInt-_rhs2073 {
-				panic("integer overflow")
-			}
-			n = _cur2072 + _rhs2073
-		}()
-	}
-	return n
+	return len(xs)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13593:1
@@ -32042,28 +31899,10 @@ func checkStringListLen(xs []string) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13602:1
 func checkIndexOfString(xs []string, needle string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13603:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13604:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13605:9
-		if x == needle {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13606:13
+	for i := 0; i < len(xs); i++ {
+		if xs[i] == needle {
 			return i
 		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13608:9
-		func() {
-			var _cur2076 int = i
-			var _rhs2077 int = 1
-			if _rhs2077 > 0 && _cur2076 > math.MaxInt-_rhs2077 {
-				panic("integer overflow")
-			}
-			if _rhs2077 < 0 && _cur2076 < math.MinInt-_rhs2077 {
-				panic("integer overflow")
-			}
-			i = _cur2076 + _rhs2077
-		}()
 	}
 	return -1
 }

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -193,7 +193,7 @@ pub fn checkScopeMark(env: CheckEnv) -> Int {
 pub fn checkScopeDrop(env: CheckEnv, mark: Int) {
     // Repeatedly pop the tail until we are back at `mark`. Osty lists
     // support `.pop()`; the early-break guards against negative marks.
-    let mut current = checkBindingCount(env)
+    let mut current = env.bindings.len()
     for current > mark {
         let _ = env.bindings.pop()
         current = current - 1
@@ -201,12 +201,7 @@ pub fn checkScopeDrop(env: CheckEnv, mark: Int) {
 }
 
 pub fn checkBindingCount(env: CheckEnv) -> Int {
-    let mut n = 0
-    for b in env.bindings {
-        let _ = b
-        n = n + 1
-    }
-    n
+    env.bindings.len()
 }
 
 // ---------------------------------------------------------------------
@@ -244,23 +239,27 @@ pub fn checkBindSpan(env: CheckEnv, name: String, ty: Int, mutable: Bool, start:
 /// the most recent binding for `name`. Returns `-1` (no type) when
 /// `name` is not in scope.
 pub fn checkLookup(env: CheckEnv, name: String) -> Int {
-    let mut found = -1
-    for b in env.bindings {
+    let mut i = env.bindings.len() - 1
+    for i >= 0 {
+        let b = env.bindings[i]
         if b.name == name {
-            found = b.ty
+            return b.ty
         }
+        i = i - 1
     }
-    found
+    -1
 }
 
 pub fn checkLookupMutable(env: CheckEnv, name: String) -> Bool {
-    let mut mutable = false
-    for b in env.bindings {
+    let mut i = env.bindings.len() - 1
+    for i >= 0 {
+        let b = env.bindings[i]
         if b.name == name {
-            mutable = b.mutable
+            return b.mutable
         }
+        i = i - 1
     }
-    mutable
+    false
 }
 
 // ---------------------------------------------------------------------
@@ -272,10 +271,13 @@ pub fn checkRegisterFn(env: CheckEnv, sig: CheckFnSig) {
 }
 
 pub fn checkLookupFn(env: CheckEnv, name: String, owner: String) -> CheckFnSig {
-    for sig in env.fns {
+    let mut i = env.fns.len() - 1
+    for i >= 0 {
+        let sig = env.fns[i]
         if sig.name == name && sig.owner == owner {
             return sig
         }
+        i = i - 1
     }
     emptyCheckFnSig()
 }
@@ -317,10 +319,13 @@ pub fn checkRegisterField(env: CheckEnv, field: CheckFieldSig) {
 }
 
 pub fn checkLookupField(env: CheckEnv, owner: String, name: String) -> CheckFieldSig {
-    for f in env.fields {
+    let mut i = env.fields.len() - 1
+    for i >= 0 {
+        let f = env.fields[i]
         if f.owner == owner && f.name == name {
             return f
         }
+        i = i - 1
     }
     emptyCheckFieldSig()
 }
@@ -330,19 +335,25 @@ pub fn checkRegisterVariant(env: CheckEnv, variant: CheckVariantSig) {
 }
 
 pub fn checkLookupVariant(env: CheckEnv, name: String) -> CheckVariantSig {
-    for v in env.variants {
+    let mut i = env.variants.len() - 1
+    for i >= 0 {
+        let v = env.variants[i]
         if v.name == name {
             return v
         }
+        i = i - 1
     }
     emptyCheckVariantSig()
 }
 
 pub fn checkLookupVariantInOwner(env: CheckEnv, owner: String, name: String) -> CheckVariantSig {
-    for v in env.variants {
+    let mut i = env.variants.len() - 1
+    for i >= 0 {
+        let v = env.variants[i]
         if v.owner == owner && v.name == name {
             return v
         }
+        i = i - 1
     }
     emptyCheckVariantSig()
 }
@@ -352,10 +363,13 @@ pub fn checkRegisterAlias(env: CheckEnv, alias: CheckAliasSig) {
 }
 
 pub fn checkLookupAlias(env: CheckEnv, name: String) -> CheckAliasSig {
-    for a in env.aliases {
+    let mut i = env.aliases.len() - 1
+    for i >= 0 {
+        let a = env.aliases[i]
         if a.name == name {
             return a
         }
+        i = i - 1
     }
     emptyCheckAliasSig()
 }
@@ -365,10 +379,13 @@ pub fn checkRegisterType(env: CheckEnv, sig: CheckTypeSig) {
 }
 
 pub fn checkLookupType(env: CheckEnv, name: String) -> CheckTypeSig {
-    for t in env.types {
+    let mut i = env.types.len() - 1
+    for i >= 0 {
+        let t = env.types[i]
         if t.name == name {
             return t
         }
+        i = i - 1
     }
     emptyCheckTypeSig()
 }
@@ -419,13 +436,15 @@ pub fn checkAddGenericBound(env: CheckEnv, bound: CheckGenericBound) {
 }
 
 pub fn checkLookupGenericBound(env: CheckEnv, tyParam: String) -> Int {
-    let mut found = -1
-    for b in env.genericBounds {
+    let mut i = env.genericBounds.len() - 1
+    for i >= 0 {
+        let b = env.genericBounds[i]
         if b.tyParam == tyParam {
-            found = b.iface
+            return b.iface
         }
+        i = i - 1
     }
-    found
+    -1
 }
 
 pub fn checkGenericBoundsFor(env: CheckEnv, tyParam: String) -> List<Int> {
@@ -451,12 +470,7 @@ pub fn checkGenericBoundMark(env: CheckEnv) -> Int {
 }
 
 fn checkGenericBoundCount(env: CheckEnv) -> Int {
-    let mut n = 0
-    for b in env.genericBounds {
-        let _ = b
-        n = n + 1
-    }
-    n
+    env.genericBounds.len()
 }
 
 // ---------------------------------------------------------------------
@@ -880,12 +894,7 @@ fn checkConcreteMethodTy(env: CheckEnv, sig: CheckFnSig, ownerTy: Int) -> Int {
 // ---------------------------------------------------------------------
 
 fn checkIntListLen(xs: List<Int>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn checkStringListLen(xs: List<String>) -> Int {
@@ -899,8 +908,9 @@ fn checkStringListLen(xs: List<String>) -> Int {
 
 fn checkIndexOfString(xs: List<String>, needle: String) -> Int {
     let mut i = 0
-    for x in xs {
-        if x == needle {
+    let n = xs.len()
+    for i < n {
+        if xs[i] == needle {
             return i
         }
         i = i + 1

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -16,7 +16,8 @@
 //
 // - Primitives are interned once at arena-creation time and returned as
 //   canonical indices (`tInt(arena)`, `tBool(arena)`, ...). Named /
-//   tuple / fn / var / optional types allocate fresh nodes.
+//   tuple / fn / optional / Self types also intern through a
+//   structural key so repeated rebuilds reuse the same indices.
 //
 // - `tyFromString` is a transitional bridge: it parses the legacy
 //   `"Head<Arg, ...>"` / `"fn(A) -> R"` / `"(A, B)"` serializations used
@@ -86,6 +87,8 @@ pub struct TyNode {
 /// never allocate a fresh node for `Int`, `Bool`, ...
 pub struct TyArena {
     pub nodes: List<TyNode>,
+    pub internKeys: List<String>,
+    pub internValues: List<Int>,
 
     pub idxErr: Int,
     pub idxInt: Int,
@@ -133,6 +136,8 @@ pub fn emptyTyNode() -> TyNode {
 pub fn emptyTyArena() -> TyArena {
     let mut arena = TyArena {
         nodes: [],
+        internKeys: [],
+        internValues: [],
         idxErr: -1,
         idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1,
         idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1,
@@ -186,15 +191,10 @@ fn tyAllocPrim(arena: TyArena, prim: PrimKind) -> Int {
     idx
 }
 
-/// tyNodeCount returns the arena node count. Used as an O(n) pre-push
-/// allocation index; callers inside hot loops should hoist this.
+/// tyNodeCount returns the arena node count. The underlying list length
+/// is already tracked by the runtime, so this stays O(1).
 pub fn tyNodeCount(arena: TyArena) -> Int {
-    let mut count = 0
-    for n in arena.nodes {
-        let _ = n
-        count = count + 1
-    }
-    count
+    arena.nodes.len()
 }
 
 // ---------------------------------------------------------------------
@@ -226,7 +226,8 @@ pub fn tUntypedInt(arena: TyArena) -> Int { arena.idxUntypedInt }
 pub fn tUntypedFloat(arena: TyArena) -> Int { arena.idxUntypedFloat }
 
 // ---------------------------------------------------------------------
-// Builders — always allocate a fresh node. No interning beyond prims.
+// Builders — primitives stay canonical, while composite type shapes
+// intern through structural keys.
 // ---------------------------------------------------------------------
 
 /// tyPrim returns the canonical index for a primitive kind. Prefer the
@@ -262,50 +263,42 @@ pub fn tyPrim(arena: TyArena, prim: PrimKind) -> Int {
 /// tyNamed allocates a named type `head<args...>` node. `args` may be
 /// empty, meaning a plain type like `String` used in type position.
 pub fn tyNamed(arena: TyArena, head: String, args: List<Int>) -> Int {
-    let idx = tyNodeCount(arena)
     let node = TyNode {
         kind: TkNamed, prim: PkInvalid, head, args, ret: -1,
         varId: 0, varName: "", varOwner: "",
     }
-    arena.nodes.push(node)
-    idx
+    tyInternNode(arena, tyKeyNamed(node.head, node.args), node)
 }
 
 /// tyTuple allocates a tuple-type node. `()` is represented by an empty
 /// elems list; callers that want the canonical unit type should use
 /// `tUnit` instead.
 pub fn tyTuple(arena: TyArena, elems: List<Int>) -> Int {
-    let idx = tyNodeCount(arena)
     let node = TyNode {
         kind: TkTuple, prim: PkInvalid, head: "", args: elems, ret: -1,
         varId: 0, varName: "", varOwner: "",
     }
-    arena.nodes.push(node)
-    idx
+    tyInternNode(arena, tyKeyTuple(node.args), node)
 }
 
 /// tyFn allocates an `fn(params...) -> ret` node. `ret` may be
 /// `tUnit(arena)` for Unit-returning functions and `tNever(arena)` for
 /// diverging ones; callers must pre-canonicalise.
 pub fn tyFn(arena: TyArena, params: List<Int>, ret: Int) -> Int {
-    let idx = tyNodeCount(arena)
     let node = TyNode {
         kind: TkFn, prim: PkInvalid, head: "", args: params, ret,
         varId: 0, varName: "", varOwner: "",
     }
-    arena.nodes.push(node)
-    idx
+    tyInternNode(arena, tyKeyFn(node.args, node.ret), node)
 }
 
 /// tyOptional allocates a `T?` node with `inner` as the wrapped index.
 pub fn tyOptional(arena: TyArena, inner: Int) -> Int {
-    let idx = tyNodeCount(arena)
     let node = TyNode {
         kind: TkOptional, prim: PkInvalid, head: "", args: [], ret: inner,
         varId: 0, varName: "", varOwner: "",
     }
-    arena.nodes.push(node)
-    idx
+    tyInternNode(arena, tyKeyOptional(node.ret), node)
 }
 
 /// tyVarFresh allocates a fresh unification variable. `owner` is the
@@ -325,13 +318,71 @@ pub fn tyVarFresh(arena: TyArena, owner: String, name: String) -> Int {
 /// impl). The elaborator substitutes it away once the receiver type is
 /// known.
 pub fn tySelf(arena: TyArena, owner: String) -> Int {
-    let idx = tyNodeCount(arena)
     let node = TyNode {
         kind: TkSelf, prim: PkInvalid, head: owner, args: [], ret: -1,
         varId: 0, varName: "", varOwner: "",
     }
+    tyInternNode(arena, tyKeySelf(node.head), node)
+}
+
+fn tyInternNode(arena: TyArena, key: String, node: TyNode) -> Int {
+    let existing = tyLookupInterned(arena, key)
+    if existing >= 0 {
+        return existing
+    }
+    let idx = tyNodeCount(arena)
     arena.nodes.push(node)
+    arena.internKeys.push(key)
+    arena.internValues.push(idx)
     idx
+}
+
+fn tyLookupInterned(arena: TyArena, key: String) -> Int {
+    let mut i = 0
+    let n = arena.internKeys.len()
+    for i < n {
+        if arena.internKeys[i] == key {
+            return arena.internValues[i]
+        }
+        i = i + 1
+    }
+    -1
+}
+
+fn tyKeyNamed(head: String, args: List<Int>) -> String {
+    "N|{head}|{tyKeyArgs(args)}"
+}
+
+fn tyKeyTuple(args: List<Int>) -> String {
+    "T|{tyKeyArgs(args)}"
+}
+
+fn tyKeyFn(args: List<Int>, ret: Int) -> String {
+    "F|{tyKeyArgs(args)}|{ret}"
+}
+
+fn tyKeyOptional(inner: Int) -> String {
+    "O|{inner}"
+}
+
+fn tyKeySelf(owner: String) -> String {
+    "S|{owner}"
+}
+
+fn tyKeyArgs(args: List<Int>) -> String {
+    if args.len() == 0 {
+        return ""
+    }
+    let mut out = ""
+    let mut i = 0
+    for arg in args {
+        if i > 0 {
+            out = "{out},"
+        }
+        out = "{out}{arg}"
+        i = i + 1
+    }
+    out
 }
 
 // ---------------------------------------------------------------------
@@ -342,17 +393,10 @@ pub fn tySelf(arena: TyArena, owner: String) -> Int {
 /// is out of range. Prefer the kind-specific helpers below for hot
 /// paths.
 pub fn tyGet(arena: TyArena, idx: Int) -> TyNode {
-    if idx < 0 {
+    if idx < 0 || idx >= arena.nodes.len() {
         return emptyTyNode()
     }
-    let mut i = 0
-    for n in arena.nodes {
-        if i == idx {
-            return n
-        }
-        i = i + 1
-    }
-    emptyTyNode()
+    arena.nodes[idx]
 }
 
 pub fn tyKindAt(arena: TyArena, idx: Int) -> TyKind {
@@ -512,23 +556,14 @@ fn tyEqList(arena: TyArena, xs: List<Int>, ys: List<Int>) -> Bool {
 }
 
 fn tyIntListLen(xs: List<Int>) -> Int {
-    let mut count = 0
-    for x in xs {
-        let _ = x
-        count = count + 1
-    }
-    count
+    xs.len()
 }
 
 fn tyIntAt(xs: List<Int>, idx: Int) -> Int {
-    let mut i = 0
-    for x in xs {
-        if i == idx {
-            return x
-        }
-        i = i + 1
+    if idx < 0 || idx >= xs.len() {
+        return -1
     }
-    -1
+    xs[idx]
 }
 
 // ---------------------------------------------------------------------

--- a/toolchain/ty_test.osty
+++ b/toolchain/ty_test.osty
@@ -118,6 +118,30 @@ fn testTyEqStructural() {
     testing.assert(!(tyEq(arena, f1, f3)))
 }
 
+fn testTyArenaInternsCompositeTypes() {
+    let arena = emptyTyArena()
+
+    let listA = tyNamed(arena, "List", [tInt(arena)])
+    let listB = tyNamed(arena, "List", [tInt(arena)])
+    testing.assertEq(listA, listB)
+
+    let fnA = tyFn(arena, [listA, tBool(arena)], tString(arena))
+    let fnB = tyFn(arena, [listB, tBool(arena)], tString(arena))
+    testing.assertEq(fnA, fnB)
+
+    let tupleA = tyTuple(arena, [listA, fnA])
+    let tupleB = tyTuple(arena, [listB, fnB])
+    testing.assertEq(tupleA, tupleB)
+
+    let optA = tyOptional(arena, tupleA)
+    let optB = tyOptional(arena, tupleB)
+    testing.assertEq(optA, optB)
+
+    let selfA = tySelf(arena, "Reader")
+    let selfB = tySelf(arena, "Reader")
+    testing.assertEq(selfA, selfB)
+}
+
 fn testTyFromStringUnknownYieldsErr() {
     let arena = emptyTyArena()
     testing.assertEq(tyToString(arena, tyFromString(arena, "")), "Invalid")


### PR DESCRIPTION
## What changed
- interned composite `TyArena` nodes in the new checker and switched hot-path arena accessors to O(1) length/index access
- tightened `CheckEnv` hot lookups by scanning from the tail and replacing repeated list-length/index helper walks with direct access
- updated the generated selfhost checker snapshot to match the new runtime behavior and added a composite interning test

## Why
The new checker was still paying repeated allocation and linear scan costs in its hottest paths, especially around type construction/access and environment lookup.

## Impact
- lowers repeated type-node churn in the new checker
- reduces binding/signature lookup overhead in selfhost checking paths
- keeps the current selfhost/runtime bridge behavior aligned with the toolchain sources

## Validation
- `go test ./cmd/osty-native-checker ./internal/check ./internal/selfhost`
