### PR TITLE
refactor(llvmgen): GC-heap fn-value env + package-level sweep probe

### DIFF
--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -83,14 +83,13 @@ fn main() {
 	}
 	got := string(ir)
 	for _, want := range []string{
-		// Env type def emitted when any fn-value is materialised.
-		"%osty.closure.env.ptr = type { ptr }",
 		// Thunk symbol for the top-level identity fn.
 		"define private i64 @__osty_closure_thunk_identity(ptr %env, i64 %arg0)",
 		// Thunk body delegates to real symbol.
 		"call i64 @identity(i64 %arg0)",
-		// Env alloca in main + store of thunk addr.
-		"alloca %osty.closure.env.ptr",
+		// Env allocated on the GC heap (not stack) so the value can
+		// outlive the enclosing frame.
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
 		"store ptr @__osty_closure_thunk_identity, ptr",
 		// Indirect call at the use site: load fn ptr from env[0],
 		// invoke through the loaded ptr with env as implicit arg 0.
@@ -100,6 +99,12 @@ fn main() {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
 		}
+	}
+	// The env must be registered as a GC root slot so a collection
+	// triggered between the env-alloc and the indirect call won't
+	// reclaim it.
+	if !strings.Contains(got, "osty.gc.root_bind_v1") {
+		t.Fatalf("env not registered as a GC root:\n%s", got)
 	}
 }
 
@@ -134,8 +139,9 @@ fn main() {
 		t.Fatalf("direct call to @double missing:\n%s", got)
 	}
 	if strings.Count(got, "__osty_closure_thunk_double") < 2 {
-		// One occurrence in the `define` header, one in the store that
-		// materialises the env.
+		// One occurrence in the `define` header, one in the `store`
+		// that materialises the env (the GC-alloc line itself doesn't
+		// reference the thunk name, only the post-alloc store does).
 		t.Fatalf("expected thunk define + env store for @double, got:\n%s", got)
 	}
 }
@@ -189,6 +195,8 @@ fn main() {
 		"%Hook = type { ptr }",
 		// Thunk for inc so the value form has the env-first ABI.
 		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
+		// The env is GC-allocated rather than stack-allocated.
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
 		// The FieldExpr call path loads the fn ptr from env and
 		// dispatches through it.
 		"= call i64 (ptr, i64)",
@@ -226,10 +234,9 @@ fn main() {
 		// apply takes a ptr env as its first user-visible param.
 		"define i64 @apply(ptr %f, i64 %x)",
 		// The call-site inside apply loads fn ptr from env and dispatches.
-		"= load ptr, ptr %f",
 		"= call i64 (ptr, i64)",
-		// main materialises a closure env for `inc` and passes it to apply.
-		"%osty.closure.env.ptr = type { ptr }",
+		// main materialises a GC-heap env for `inc` and passes it to apply.
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
 		"define private i64 @__osty_closure_thunk_inc(ptr %env, i64 %arg0)",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -19,12 +19,6 @@ import (
 	"github.com/osty/osty/internal/ast"
 )
 
-// fnValueEnvTypeName is the module-level struct used for bare
-// (no-captures) fn-value envs. A 1-field env is sufficient — the
-// thunk pointer. Closure envs with captures get their own types in
-// phase 2+.
-const fnValueEnvTypeName = "osty.closure.env.ptr"
-
 func fnValueThunkSymbol(realSymbol string) string {
 	return "__osty_closure_thunk_" + realSymbol
 }
@@ -74,27 +68,50 @@ func (g *generator) ensureFnValueThunk(sig *fnSig) string {
 	return symbol
 }
 
+// fnValueEnvKind is the GC kind tag for closure envs. Uses the
+// generic kind (1) for now — phase 1 envs have no captures so the
+// default trace-none/destroy-none layout works. Phase 4 will want
+// its own kind with a trace that marks captured ptrs.
+const fnValueEnvKind = 1
+
+// fnValueEnvByteSize is the size in bytes of the bare 1-field env.
+// Stays a compile-time literal because the env layout is fixed: one
+// ptr slot, 8 bytes on every target this backend supports (LLVM
+// target triple is 64-bit).
+const fnValueEnvByteSize = 8
+
 // emitFnValueEnv materialises a 1-field closure env holding the
 // thunk pointer for the given top-level fn. Returns a `ptr`-typed
 // value tagged with fnSigRef so a subsequent call site can do
 // indirect dispatch with the correct signature.
 //
-// The alloca is emitted into the current function's body. Callers
-// must already be inside a function — there is no module-level
-// fn-value literal path (globals would need a separate constant
-// initialiser ABI; deferred until a user-visible need appears).
+// Allocation goes through the GC (`osty.gc.alloc_v1`) rather than a
+// stack alloca so the env can safely outlive the enclosing frame —
+// e.g. when stored in a `List<fn(...)>`, a struct field, or passed
+// into a higher-order fn that memoises it. The returned value is
+// tagged `gcManaged: true` so downstream `bindNamedLocal` registers
+// it as a frame root.
+//
+// Callers must already be inside a function — there is no
+// module-level fn-value literal path (globals would need a separate
+// constant initialiser ABI; deferred until a user-visible need
+// appears).
 func (g *generator) emitFnValueEnv(sig *fnSig) (value, error) {
 	if sig == nil {
 		return value{}, unsupportedf("call", "fn-value env for nil signature")
 	}
 	thunk := g.ensureFnValueThunk(sig)
-	g.fnValueEnvTypeNeeded = true
 	emitter := g.toOstyEmitter()
-	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", slot, fnValueEnvTypeName))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunk, slot))
+	env := llvmGcAlloc(emitter, fnValueEnvKind, fnValueEnvByteSize, "runtime.closure.env.ptr")
+	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunk, env.name))
 	g.takeOstyEmitter(emitter)
-	return value{typ: "ptr", ref: slot, fnSigRef: sig}, nil
+	g.needsGCRuntime = true
+	return value{
+		typ:       "ptr",
+		ref:       env.name,
+		fnSigRef:  sig,
+		gcManaged: true,
+	}, nil
 }
 
 // emitFnValueIndirectCall lowers a call through a fn-value env.
@@ -160,13 +177,6 @@ func (g *generator) emitFnValueIndirectCall(envVal value, sig *fnSig, args []*Ll
 	out.gcManaged = valueNeedsManagedRoot(out)
 	out.rootPaths = g.rootPathsForType(out.typ)
 	return out, nil
-}
-
-// fnValueEnvTypeDef returns the module-level struct def for the bare
-// (1-field) fn-value env, emitted into the module's type-def block
-// when any fn-value has been materialised.
-func fnValueEnvTypeDef() string {
-	return fmt.Sprintf("%%%s = type { ptr }", fnValueEnvTypeName)
 }
 
 // synthFnSigFromFnType builds a call-site-only *fnSig from an

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -51,10 +51,6 @@ type generator struct {
 	// first / machinery second. See fn_value.go.
 	fnValueThunkDefs  map[string]string
 	fnValueThunkOrder []string
-	// True once any fn-value env has been materialised; gates the
-	// module-level `%osty.closure.env.ptr` typedef so plain programs
-	// that never touch first-class fns stay free of the noise.
-	fnValueEnvTypeNeeded bool
 
 	temp              int
 	label             int
@@ -228,9 +224,6 @@ func (g *generator) render(defs []string) []byte {
 	allDefs = append(allDefs, g.globalDefs...)
 	allDefs = append(allDefs, defs...)
 	typeDefs := make([]string, 0, len(g.structs)+len(g.enumsByType)+len(g.tupleTypes)+len(g.resultTypes))
-	if g.fnValueEnvTypeNeeded {
-		typeDefs = append(typeDefs, fnValueEnvTypeDef())
-	}
 	for _, info := range g.structs {
 		fieldTypes := make([]string, 0, len(info.fields))
 		for _, field := range info.fields {

--- a/internal/llvmgen/large_tail_sweep_test.go
+++ b/internal/llvmgen/large_tail_sweep_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/parser"
 )
 
@@ -227,6 +228,65 @@ func TestSweepToolchainLargeTailLLVM015Subwalls(t *testing.T) {
 		}
 		t.Logf("  %s — %s", name, err.Error())
 	}
+}
+
+// TestSweepToolchainPackageLevel merges every non-test
+// toolchain/*.osty file into a SINGLE combined `ast.File` before
+// lowering. This matches what `osty build` does for a real package
+// — cross-file fn references (e.g. `stringUnitCount` defined in
+// `semver_parse.osty` but called from `frontend.osty`) resolve
+// because every top-level decl is in the same `g.functions` map.
+//
+// Contrast with TestSweepToolchainLargeTail which lowers each file
+// in isolation. The single-file view is useful for attributing a
+// wall to a specific source file, but it over-reports LLVM015 on
+// benign cross-file references (the "test-harness artifact" noted
+// in PR #375).
+//
+// Info-only: never fails. Prints CLEAN or the single wall so the
+// operator can tell whether the remaining single-file LLVM015 was a
+// true capability gap or just missing-symbol noise.
+func TestSweepToolchainPackageLevel(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+
+	var merged ast.File
+	sourceCount := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		file, _ := parser.ParseDiagnostics(src)
+		if file == nil {
+			continue
+		}
+		merged.Uses = append(merged.Uses, file.Uses...)
+		merged.Decls = append(merged.Decls, file.Decls...)
+		sourceCount++
+	}
+	t.Logf("merged %d source files into one package", sourceCount)
+
+	_, err = generateFromAST(&merged, Options{
+		PackageName: "toolchain",
+		SourcePath:  filepath.Join(dir, "<package>"),
+	})
+	if err == nil {
+		t.Logf("=== package-level wall === CLEAN")
+		return
+	}
+	t.Logf("=== package-level wall === %s", formatWall(err))
 }
 
 func wallCode(msg string) string {


### PR DESCRIPTION
## Summary

PR #375 (first-class fn value lowering) 의 follow-up 두 건. 당초 #375 에 부속 커밋으로 붙였다가 이미 merge된 것을 뒤늦게 발견하여 이 PR 로 분리합니다.

## What changed

### 1) fn-value env 를 GC heap 으로 이동
- `emitFnValueEnv` 가 stack `alloca %osty.closure.env.ptr` 대신 `call ptr @osty.gc.alloc_v1(i64 1, i64 8, ...)` 로 전환
- 반환 value 에 `gcManaged: true` 태그 → `bindNamedLocal` 이 GC root slot 등록
- 기존 stack alloca 로는 env 가 enclosing 프레임을 escape 하면 안전하지 않음 (예: `List<fn(...)>`, struct field, 상위 스코프 반환). heap + root 등록으로 collection 사이 생존 보장
- 이제 참조하지 않는 `%osty.closure.env.ptr` struct typedef + `fnValueEnvTypeNeeded` 플래그 제거 (CLAUDE.md "사용되지 않는 자원 유지 금지")

### 2) 새 info-only 테스트 `TestSweepToolchainPackageLevel`
- `toolchain/*.osty` 39개를 단일 `ast.File` 로 merge 한 뒤 `generateFromAST`
- PR #375 의 "frontend.osty LLVM015 는 single-file 테스트 하니스 아티팩트" 가설 확인 — package-level 에선 LLVM015 안 뜨고 첫 벽은 LLVM002 (runtime FFI `runtime.golegacy.astbridge`)
- 즉 `stringUnitCount` 같은 cross-file 참조는 정상 resolve. 기존 `TestSweepToolchainLargeTail` (single-file) 과 병행해서 "진짜 capability 갭 vs scope 아티팩트" 구분 가능

## Why

- **GC 이관**: PR #375 회고에서 명시한 follow-up — stack alloca 는 fn-value 가 프레임을 넘는 순간 UB. `List<fn(Int)->Int>` 같은 자연스러운 스펙 패턴을 안전하게 하려면 heap 필수
- **package-level sweep**: histogram 해석 시 false positive 감산 도구 — 단일 파일 sweep 의 LLVM015/LLVM011 숫자 중 실제 capability 갭이 아닌 "타 파일에 정의된 심볼" 건수를 분별

## Test plan

- [x] `go build ./...` clean
- [x] Phase 1/2/3 focused 테스트 4개 heap-alloc ABI 로 업데이트 후 통과 (`TestGenerateFnValueBoundLocalIndirectCall`, `TestGenerateFnValueCoexistsWithDirectCall`, `TestGenerateFnTypedStructFieldIndirectCall`, `TestGenerateFnTypedParameterHigherOrder`)
- [x] 새 `TestSweepToolchainPackageLevel` 통과 (첫 벽이 LLVM002 임을 확인)
- [x] `go test ./internal/llvmgen/` — PR #375 와 동일한 1 pre-existing fail 외 통과, 회귀 0건
- [x] `go test ./cmd/osty/` — pre-existing 10 fail 그대로, 회귀 0건

## Reviewer notes

- fn-value env 는 더 이상 type alias 를 갖지 않음. alloc 사이즈는 리터럴 8바이트 (1 ptr). Phase 4 (captures) 가 오면 각 capture-layout 별 kind + 크기 계산으로 확장
- GC kind 는 `OSTY_GC_KIND_GENERIC = 1` 사용. Phase 4 에서 captures 가 managed ptr 을 담으면 trace 함수 가진 전용 kind 필요

## Follow-ups (별도)

- Phase 4: capture 있는 클로저 `|x| x + captured` — env slot 1..N + lifted body 가 env 직접 사용 + capture 가 managed ptr 이면 GC trace 함수 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)