### PR TITLE
test(llvmgen): large-tail parity probe covers 4 god-node modules

### DIFF
--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -31,10 +31,16 @@ func mergeToolchainSources(t *testing.T, root string, files []string) []byte {
 	return []byte(buf.String())
 }
 
-// TestProbeLargeFileParity lowers ir.osty and check_env.osty merged
-// with their cross-module type declarations. Single-file sweeps flag
-// these as LLVM011 — merging reveals whether that wall is a real
-// backend gap or cross-module scope. Info-only.
+// TestProbeLargeFileParity lowers each large / god-node toolchain
+// module merged with its cross-module type declarations. Single-file
+// sweeps flag every one of these as LLVM011; merging reveals whether
+// that wall is a real backend gap or pure cross-module scope.
+//
+// Coverage: ir.osty, check_env.osty, and the four god-nodes elab /
+// parser / lint / resolve. For each entry, `files` is the minimum
+// merge set that clears the single-file first wall — picked by walking
+// the first-wall type payload back to its declaring toolchain basename.
+// Info-only; never fails.
 func TestProbeLargeFileParity(t *testing.T) {
 	if testing.Short() {
 		t.Skip("info-only; skipped in -short")
@@ -54,6 +60,39 @@ func TestProbeLargeFileParity(t *testing.T) {
 		{
 			name:  "ir",
 			files: []string{"frontend.osty", "parser.osty", "ir.osty"},
+		},
+		{
+			name:  "parser",
+			files: []string{"frontend.osty", "parser.osty"},
+		},
+		{
+			name:  "resolve",
+			files: []string{"frontend.osty", "parser.osty", "resolve.osty"},
+		},
+		{
+			name:  "lint",
+			files: []string{"frontend.osty", "parser.osty", "resolve.osty", "lint.osty"},
+		},
+		{
+			// elab's type signature spans the whole check/diag closure, so
+			// each unresolved cross-file type is a scope artifact rather
+			// than a new backend wall — the merge set has to include every
+			// declaring basename in one shot.
+			name: "elab",
+			files: []string{
+				"frontend.osty",
+				"lexer.osty",
+				"parser.osty",
+				"diagnostic.osty",
+				"ty.osty",
+				"check_diag.osty",
+				"check_env.osty",
+				"resolve.osty",
+				"lint.osty",
+				"solve.osty",
+				"core.osty",
+				"elab.osty",
+			},
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Extends `TestProbeLargeFileParity` (daf0143) with `elab` / `parser` / `lint` / `resolve` — the last unexcluded god-node modules in `toolchain/`. Each one merged with its type-declaring deps dissolves to **LLVM015 [dynamic_ident_call]**, the same wall `ir.osty` hits. None hide a real LLVM011 backend gap.

## Finding

| File | Wall (single-file sweep) | Wall (merged with type deps) |
|------|---|---|
| `parser.osty` | LLVM011 `cross_file_scope_field` | LLVM015 `dynamic_ident_call` |
| `resolve.osty` | LLVM011 `cross_file_scope_param` | LLVM015 `dynamic_ident_call` |
| `lint.osty`   | LLVM011 `cross_file_scope_param` | LLVM015 `dynamic_ident_call` |
| `elab.osty`   | LLVM011 `cross_file_scope_field` | LLVM015 `dynamic_ident_call` |

Every god-node's single-file LLVM011 classification turned out to be a pure cross-module scope artifact. Fixing LLVM015 call dispatch unblocks five modules at once (ir + the four god-nodes), not just one.

## Merge-set picking

For each entry, `files` is the minimum set that clears the single-file first wall — picked by walking the first-wall `type "X"` payload back to its declaring basename.

- `parser`: needs `frontend` (for `FrontTokenKind`)
- `resolve` / `lint`: parser + the prior layer
- `elab`: requires the full check/diag closure — `CoreArena` → `CheckDiagnostic` → `DiagnosticSeverity` → `CheckEnv` → `SelfLintDiagnostic` → `Solver`, so 12 files total

## Test plan

- [x] `go test -count=1 -v -run TestProbeLargeFileParity ./internal/llvmgen/` passes (~25s), prints the wall class per entry
- [x] `gofmt -l` clean on the changed file
- [x] Pre-existing `TestRuntimeIntrinsicTypingRaw*` failures in this package verified against clean `main` — unrelated

Info-only, `-short`-gated, no backend code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)