### PR TITLE
feat(selfhost): pinpoint native-diags telemetry with source line/col

### DIFF
--- a/cmd/osty/dump_native_diags.go
+++ b/cmd/osty/dump_native_diags.go
@@ -3,12 +3,14 @@ package main
 // Helpers for `osty check --dump-native-diags`. The flag surfaces the
 // bootstrapped native checker's per-context error histogram so callers
 // working against aggregate error counts (1700-style summaries) can
-// split the tail by enclosing-function category without regenerating
+// split the tail by diagnostic code without regenerating
 // internal/selfhost/generated.go.
 //
-// Telemetry origin: internal/selfhost/check_telemetry.go tags every
-// call to selfhostBumpError with its Go caller name. host_boundary.go
-// plumbs the map into check.Result.NativeCheckerTelemetry.
+// Telemetry origin: internal/selfhost/check_telemetry.go buckets the
+// typed checker's structured CheckDiagnostic stream by stable code and
+// suffixes each detail row with `@Lnn:Cnn` drawn from the diagnostic's
+// primary span. host_boundary.go plumbs the resulting maps into
+// check.Result.NativeCheckerTelemetry.
 
 import (
 	"fmt"
@@ -65,8 +67,9 @@ func dumpNativeDiagsFor(label string, chk *check.Result) {
 
 // writeContextDetail prints the top-10 detail rows under a context bucket,
 // indented so they visually nest under the parent. No output when the
-// bucket is empty — only contexts wired to selfhostBumpErrorWithDetail
-// carry data, and callers should not assume every bucket is populated.
+// bucket is empty — a diagnostic whose primary span is unresolved (or
+// missing) yields a bare message with no `@Lnn:Cnn` suffix, and diagnostic
+// severities other than error never land here to begin with.
 func writeContextDetail(w *os.File, details map[string]int) {
 	if len(details) == 0 {
 		return

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -50,8 +50,11 @@ type NativeCheckerTelemetry struct {
 	Errors          int
 	ErrorsByContext map[string]int
 	// ErrorDetails optionally maps a context key from ErrorsByContext to a
-	// finer breakdown — e.g. frontCheckIdentHint → unresolved identifier
-	// counts. Only populated at sites wired to selfhostBumpErrorWithDetail.
+	// finer breakdown of rendered diagnostic messages under that code.
+	// Populated by selfhostDiagnosticTelemetry in the selfhost adapter;
+	// each message is suffixed with `@Lnn:Cnn` when the native checker
+	// surfaced a resolvable span, so identical messages at different
+	// source positions remain distinguishable.
 	ErrorDetails map[string]map[string]int
 }
 

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -27,9 +28,14 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 		if segmentIdx < len(layout.files) {
 			base = layout.files[segmentIdx].base
 		}
+		name := ""
+		if pf.Path != "" {
+			name = filepath.Base(pf.Path)
+		}
 		input.Files = append(input.Files, selfhost.PackageCheckFile{
 			Source: append([]byte(nil), src...),
 			Base:   base,
+			Name:   name,
 		})
 		segmentIdx++
 	}

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -98,28 +98,50 @@ func adaptCheckSummary(checked *FrontCheckSummary) CheckSummary {
 	}
 }
 
-func adaptCheckSummaryWithContext(checked *FrontCheckResult) CheckSummary {
+func adaptCheckSummaryWithContext(checked *FrontCheckResult, posLookup selfhostTokenPos) CheckSummary {
 	if checked == nil {
 		return CheckSummary{}
 	}
 	s := adaptCheckSummary(checked.summary)
-	s.ErrorsByContext, s.ErrorDetails = selfhostDiagnosticTelemetry(checked.diagnostics)
+	s.ErrorsByContext, s.ErrorDetails = selfhostDiagnosticTelemetry(checked.diagnostics, posLookup)
 	return s
 }
 
-func adaptCheckResult(checked *FrontCheckResult, lexed *OstyLexedSource) CheckResult {
-	result := CheckResult{
-		Summary:        adaptCheckSummaryWithContext(checked),
-		TypedNodes:     make([]CheckedNode, 0, len(checked.typedNodes)),
-		Bindings:       make([]CheckedBinding, 0, len(checked.bindings)),
-		Symbols:        make([]CheckedSymbol, 0, len(checked.symbols)),
-		Instantiations: make([]CheckInstantiation, 0, len(checked.instantiations)),
+// selfhostStreamTokenPos returns a selfhostTokenPos that reads 1-based
+// (line, column) directly off the lex stream's token positions. The
+// filename is always empty — file mode already surfaces the path in the
+// dump label above each telemetry block, so repeating it in every
+// suffix would only add noise.
+func selfhostStreamTokenPos(stream *FrontLexStream) selfhostTokenPos {
+	if stream == nil {
+		return nil
 	}
+	tokens := stream.tokens
+	return func(tokenIdx int) (string, int, int, bool) {
+		if tokenIdx < 0 || tokenIdx >= len(tokens) {
+			return "", 0, 0, false
+		}
+		tok := tokens[tokenIdx]
+		if tok == nil || tok.start == nil {
+			return "", 0, 0, false
+		}
+		return "", tok.start.line, tok.start.column, true
+	}
+}
+
+func adaptCheckResult(checked *FrontCheckResult, lexed *OstyLexedSource) CheckResult {
 	rt := newRuneTable("")
 	var stream *FrontLexStream
 	if lexed != nil {
 		rt = newRuneTable(lexed.source)
 		stream = lexed.stream
+	}
+	result := CheckResult{
+		Summary:        adaptCheckSummaryWithContext(checked, selfhostStreamTokenPos(stream)),
+		TypedNodes:     make([]CheckedNode, 0, len(checked.typedNodes)),
+		Bindings:       make([]CheckedBinding, 0, len(checked.bindings)),
+		Symbols:        make([]CheckedSymbol, 0, len(checked.symbols)),
+		Instantiations: make([]CheckInstantiation, 0, len(checked.instantiations)),
 	}
 	for _, node := range checked.typedNodes {
 		if node == nil {

--- a/internal/selfhost/check_telemetry.go
+++ b/internal/selfhost/check_telemetry.go
@@ -1,8 +1,20 @@
 package selfhost
 
 import (
+	"fmt"
 	"strings"
 )
+
+// selfhostTokenPos resolves a diagnostic's start-token index back to a
+// display filename plus 1-based (line, column) so telemetry can pinpoint
+// the source location of each bucketed error. Filename is empty for
+// callers that don't carry per-token file provenance (the single-file
+// path already surfaces the filename in the dump label). ok=false when
+// the token index is out of range, negative, or the underlying token
+// carried no position. Callers pass nil when source position enrichment
+// is not available (e.g. external exec runners that lost stream access)
+// — the detail strings stay un-suffixed in that case.
+type selfhostTokenPos func(tokenIdx int) (file string, line int, col int, ok bool)
 
 // selfhostTypesAliasEqual reports whether two type names differ only by
 // a leading `alias.` qualifier on one side. FFI collection registers a
@@ -129,7 +141,11 @@ func selfhostLastPathSegment(path string) string {
 // typed checker's structured diagnostics. The old checker reported caller-site
 // buckets directly; the typed checker instead exposes stable diagnostic codes,
 // so we bucket errors by code and retain the rendered message as detail rows.
-func selfhostDiagnosticTelemetry(diags []*CheckDiagnostic) (map[string]int, map[string]map[string]int) {
+// When posLookup is non-nil, each detail row is suffixed with `@Lnn:Cnn`
+// pointing at the diagnostic's primary span, which lets
+// `osty check --dump-native-diags` pinpoint individual parity failures
+// instead of collapsing structurally-identical messages into one bucket.
+func selfhostDiagnosticTelemetry(diags []*CheckDiagnostic, posLookup selfhostTokenPos) (map[string]int, map[string]map[string]int) {
 	if len(diags) == 0 {
 		return nil, nil
 	}
@@ -151,6 +167,9 @@ func selfhostDiagnosticTelemetry(diags []*CheckDiagnostic) (map[string]int, map[
 		if detail == "" {
 			continue
 		}
+		if suffix := selfhostDiagnosticPosSuffix(d, posLookup); suffix != "" {
+			detail = detail + " " + suffix
+		}
 		if details == nil {
 			details = make(map[string]map[string]int)
 		}
@@ -162,6 +181,27 @@ func selfhostDiagnosticTelemetry(diags []*CheckDiagnostic) (map[string]int, map[
 		bucket[detail]++
 	}
 	return byContext, details
+}
+
+// selfhostDiagnosticPosSuffix renders the source-position tag appended
+// to each detail row. `@<file>:Lnn:Cnn` when the lookup surfaces a
+// filename (package/workspace mode where the dump label covers multiple
+// files), otherwise `@Lnn:Cnn` (single-file mode where the filename is
+// already in the dump label). Empty when posLookup is nil, the
+// diagnostic carries no valid span, or the lookup reports the token as
+// unresolved.
+func selfhostDiagnosticPosSuffix(d *CheckDiagnostic, posLookup selfhostTokenPos) string {
+	if d == nil || posLookup == nil {
+		return ""
+	}
+	file, line, col, ok := posLookup(d.start)
+	if !ok || line <= 0 || col <= 0 {
+		return ""
+	}
+	if file == "" {
+		return fmt.Sprintf("@L%d:C%d", line, col)
+	}
+	return fmt.Sprintf("@%s:L%d:C%d", file, line, col)
 }
 
 func selfhostDiagnosticIsError(d *CheckDiagnostic) bool {

--- a/internal/selfhost/check_telemetry_test.go
+++ b/internal/selfhost/check_telemetry_test.go
@@ -10,7 +10,7 @@ func TestSelfhostDiagnosticTelemetryBucketsErrorDiagnosticsByCode(t *testing.T) 
 		{severity: DiagnosticSeverity(&DiagnosticSeverity_SeverityError{}), message: "uncoded error"},
 	}
 
-	byContext, details := selfhostDiagnosticTelemetry(diags)
+	byContext, details := selfhostDiagnosticTelemetry(diags, nil)
 
 	if got := byContext["E0700"]; got != 2 {
 		t.Fatalf("E0700 count = %d, want 2", got)
@@ -29,5 +29,56 @@ func TestSelfhostDiagnosticTelemetryBucketsErrorDiagnosticsByCode(t *testing.T) 
 	}
 	if got := details["error"]["uncoded error"]; got != 1 {
 		t.Fatalf("fallback detail count = %d, want 1", got)
+	}
+}
+
+func TestSelfhostDiagnosticTelemetryAppendsSourcePosSuffix(t *testing.T) {
+	diags := []*CheckDiagnostic{
+		// File-mode lookup (filename empty) → `@Lnn:Cnn` suffix, since the
+		// filename already sits in the dump label above the bucket.
+		{code: "E0700", severity: DiagnosticSeverity(&DiagnosticSeverity_SeverityError{}), message: "type mismatch: expected `Int`, found `String`", start: 5, end: 6},
+		{code: "E0700", severity: DiagnosticSeverity(&DiagnosticSeverity_SeverityError{}), message: "type mismatch: expected `Int`, found `String`", start: 9, end: 10},
+		// Package-mode lookup (filename present) → `@<file>:Lnn:Cnn` so
+		// cross-file parity failures stay distinguishable under one label.
+		{code: "E0700", severity: DiagnosticSeverity(&DiagnosticSeverity_SeverityError{}), message: "type mismatch: expected `Int`, found `String`", start: 17, end: 18},
+		{code: "E0701", severity: DiagnosticSeverity(&DiagnosticSeverity_SeverityError{}), message: "arity off", start: -1, end: -1},
+		{code: "E0702", severity: DiagnosticSeverity(&DiagnosticSeverity_SeverityError{}), message: "unresolved", start: 42, end: 43},
+	}
+
+	posLookup := func(tokenIdx int) (string, int, int, bool) {
+		switch tokenIdx {
+		case 5:
+			return "", 10, 3, true
+		case 9:
+			return "", 10, 20, true
+		case 17:
+			return "b.osty", 4, 12, true
+		}
+		return "", 0, 0, false
+	}
+
+	_, details := selfhostDiagnosticTelemetry(diags, posLookup)
+
+	if got := details["E0700"]["type mismatch: expected `Int`, found `String` @L10:C3"]; got != 1 {
+		t.Fatalf("file-mode E0700 with @L10:C3 = %d, want 1 (details=%v)", got, details["E0700"])
+	}
+	if got := details["E0700"]["type mismatch: expected `Int`, found `String` @L10:C20"]; got != 1 {
+		t.Fatalf("file-mode E0700 with @L10:C20 = %d, want 1 (details=%v)", got, details["E0700"])
+	}
+	if got := details["E0700"]["type mismatch: expected `Int`, found `String` @b.osty:L4:C12"]; got != 1 {
+		t.Fatalf("package-mode E0700 with @b.osty:L4:C12 = %d, want 1 (details=%v)", got, details["E0700"])
+	}
+	// Structurally-identical messages with distinct source positions no longer
+	// collapse into a single bucket — this is the whole point of the suffix.
+	if _, collapsed := details["E0700"]["type mismatch: expected `Int`, found `String`"]; collapsed {
+		t.Fatalf("un-suffixed detail leaked into E0700 bucket: %v", details["E0700"])
+	}
+	// Diagnostics whose token index is unresolved keep their bare detail so
+	// the suffix stays opt-in and never lies about position.
+	if got := details["E0701"]["arity off"]; got != 1 {
+		t.Fatalf("unresolved-position detail = %d, want 1 (details=%v)", got, details["E0701"])
+	}
+	if got := details["E0702"]["unresolved"]; got != 1 {
+		t.Fatalf("out-of-range-position detail = %d, want 1 (details=%v)", got, details["E0702"])
 	}
 }

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -5,6 +5,10 @@ import "fmt"
 type PackageCheckFile struct {
 	Source []byte
 	Base   int
+	// Name is the display filename surfaced in diagnostic telemetry (typically
+	// a basename like `user.osty`). Empty when unknown; the telemetry suffix
+	// falls back to `@Lnn:Cnn` without a filename prefix in that case.
+	Name string
 }
 
 type PackageCheckGenericBound struct {
@@ -90,8 +94,15 @@ func CheckPackageStructured(input PackageCheckInput) (CheckResult, error) {
 }
 
 type selfhostPackageTokenLayout struct {
-	starts []int
-	ends   []int
+	starts     []int
+	ends       []int
+	startLines []int
+	startCols  []int
+	// fileIdx[i] indexes into files for token i. -1 when the file carried no
+	// display name (selfhostLayoutTokenPos then emits an empty filename and
+	// the telemetry suffix drops back to `@Lnn:Cnn`).
+	fileIdx []int
+	files   []string
 }
 
 func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPackageTokenLayout, error) {
@@ -111,7 +122,12 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 			return nil, nil, fmt.Errorf("selfhost package adapter: parse errors: %s", astFormatErrors(parsed))
 		}
 		tokenBase := len(layout.starts)
-		selfhostAppendTokenLayout(layout, lexed, file.Base)
+		fileIdx := -1
+		if file.Name != "" {
+			fileIdx = len(layout.files)
+			layout.files = append(layout.files, file.Name)
+		}
+		selfhostAppendTokenLayout(layout, lexed, file.Base, fileIdx)
 		selfhostMergeAstArena(arena, parsed.arena, tokenBase)
 		haveFile = true
 	}
@@ -121,19 +137,77 @@ func selfhostBuildPackageAst(files []PackageCheckFile) (*AstFile, *selfhostPacka
 	return &AstFile{arena: arena}, layout, nil
 }
 
-func selfhostAppendTokenLayout(layout *selfhostPackageTokenLayout, lexed *OstyLexedSource, base int) {
+func selfhostAppendTokenLayout(layout *selfhostPackageTokenLayout, lexed *OstyLexedSource, base int, fileIdx int) {
 	if layout == nil || lexed == nil || lexed.stream == nil {
 		return
 	}
 	rt := newRuneTable(lexed.source)
+	// Grow all parallel slices in one amortised step — appends still happen
+	// per token inside the loop, but the underlying array is sized for the
+	// incoming stream up-front, so we avoid the repeated-realloc cost that
+	// multi-MB merged packages would otherwise pay on every `append`.
+	n := len(lexed.stream.tokens)
+	newLen := len(layout.starts) + n
+	layout.starts = selfhostGrowIntSlice(layout.starts, newLen)
+	layout.ends = selfhostGrowIntSlice(layout.ends, newLen)
+	layout.startLines = selfhostGrowIntSlice(layout.startLines, newLen)
+	layout.startCols = selfhostGrowIntSlice(layout.startCols, newLen)
+	layout.fileIdx = selfhostGrowIntSlice(layout.fileIdx, newLen)
 	for _, tok := range lexed.stream.tokens {
 		if tok == nil || tok.start == nil || tok.end == nil {
 			layout.starts = append(layout.starts, base)
 			layout.ends = append(layout.ends, base)
+			layout.startLines = append(layout.startLines, 0)
+			layout.startCols = append(layout.startCols, 0)
+			layout.fileIdx = append(layout.fileIdx, fileIdx)
 			continue
 		}
 		layout.starts = append(layout.starts, base+rt.byteOffset(tok.start.offset))
 		layout.ends = append(layout.ends, base+rt.byteOffset(tok.end.offset))
+		layout.startLines = append(layout.startLines, tok.start.line)
+		layout.startCols = append(layout.startCols, tok.start.column)
+		layout.fileIdx = append(layout.fileIdx, fileIdx)
+	}
+}
+
+// selfhostGrowIntSlice reserves capacity for at least `want` total elements
+// without changing the slice's logical length, so subsequent `append`s stay
+// allocation-free for large per-file token batches.
+func selfhostGrowIntSlice(xs []int, want int) []int {
+	if cap(xs) >= want {
+		return xs
+	}
+	grown := make([]int, len(xs), want)
+	copy(grown, xs)
+	return grown
+}
+
+// selfhostLayoutTokenPos returns a selfhostTokenPos backed by the per-file
+// (filename, line, column) slices recorded during selfhostAppendTokenLayout.
+// Mirrors selfhostStreamTokenPos for the package/workspace call paths where
+// the lex stream is materialised per-file and then discarded. Filename is
+// empty when the originating PackageCheckFile carried no Name, which lets
+// the telemetry suffix drop back to `@Lnn:Cnn` without lying about the file.
+func selfhostLayoutTokenPos(layout *selfhostPackageTokenLayout) selfhostTokenPos {
+	if layout == nil {
+		return nil
+	}
+	return func(tokenIdx int) (string, int, int, bool) {
+		if tokenIdx < 0 || tokenIdx >= len(layout.startLines) || tokenIdx >= len(layout.startCols) {
+			return "", 0, 0, false
+		}
+		line := layout.startLines[tokenIdx]
+		col := layout.startCols[tokenIdx]
+		if line <= 0 || col <= 0 {
+			return "", 0, 0, false
+		}
+		file := ""
+		if tokenIdx < len(layout.fileIdx) {
+			if idx := layout.fileIdx[tokenIdx]; idx >= 0 && idx < len(layout.files) {
+				file = layout.files[idx]
+			}
+		}
+		return file, line, col, true
 	}
 }
 
@@ -201,7 +275,7 @@ func selfhostShiftTokenIndex(idx, base int) int {
 
 func adaptCheckResultWithTokenLayout(checked *FrontCheckResult, layout *selfhostPackageTokenLayout) CheckResult {
 	result := CheckResult{
-		Summary:        adaptCheckSummaryWithContext(checked),
+		Summary:        adaptCheckSummaryWithContext(checked, selfhostLayoutTokenPos(layout)),
 		TypedNodes:     make([]CheckedNode, 0, len(checked.typedNodes)),
 		Bindings:       make([]CheckedBinding, 0, len(checked.bindings)),
 		Symbols:        make([]CheckedSymbol, 0, len(checked.symbols)),


### PR DESCRIPTION
## Summary

- `osty check --dump-native-diags` now suffixes every detail row with `@<file>:Lnn:Cnn` (package/workspace mode) or `@Lnn:Cnn` (file mode — filename already in the dump label).
- Replaces the previous behavior where structurally-identical messages collapsed into a single bucket: 36 parity failures used to show as one line like \`eq: String, Int\` with no way to tell which call site each count came from.
- Correct seam was at the existing telemetry layer — `CheckDiagnostic` already carries a token-index span, so telemetry just needs a lookup to resolve \`(file, line, col)\` at bucket-build time. No changes to the typed checker itself.

## What changed

**`internal/selfhost/check_telemetry.go`** — new \`selfhostTokenPos\` fn type threading an optional \`(file, line, col, ok)\` lookup into \`selfhostDiagnosticTelemetry\`. Nil lookup → suffix omitted (keeps external exec runners that lost stream access working). New \`selfhostDiagnosticPosSuffix\` renders the tag.

**`internal/selfhost/check_adapter.go`** — \`selfhostStreamTokenPos\` reads positions directly off \`lexed.stream.tokens[i].start\` for single-file mode. Filename is intentionally empty (the dump label already shows the file path).

**`internal/selfhost/package_adapter.go`**:
- \`PackageCheckFile\` gains an optional \`Name\` field for telemetry display.
- \`selfhostPackageTokenLayout\` gains parallel \`startLines\`/\`startCols\`/\`fileIdx\` int slices plus a small \`files []string\` lookup table (filename stored once per file, not once per token).
- \`selfhostAppendTokenLayout\` pre-reserves slice capacity via a new \`selfhostGrowIntSlice\` helper so multi-MB merged packages don't pay repeated-realloc cost.
- \`selfhostLayoutTokenPos\` mirrors \`selfhostStreamTokenPos\` for the package/workspace path.

**`internal/check/package_input.go`** — wires \`filepath.Base(pf.Path)\` into the new \`PackageCheckFile.Name\` field so the selfhost adapter can surface file-scoped pinpoints.

**`internal/check/check.go` / `cmd/osty/dump_native_diags.go`** — stale comments referencing the old (nonexistent) \`selfhostBumpErrorWithDetail\` counter model updated to reflect the structured-diagnostic reality.

## Why

On the embedded selfhost checker, parity failures between the Go reference checker and the Osty native checker all bucket under the same diagnostic code. With message-only detail rows, two failures at completely different source locations look identical in telemetry, so there's no way to split a 36-count bucket into individual investigation targets.

## Before / after

Package-mode (two-file, three errors):

\`\`\`
# before
2  E0700
        2  type mismatch: expected ...

# after
2  E0700
        1  type mismatch: expected \`Int\`, found \`String\` @b.osty:L2:C18
        1  type mismatch: expected \`String\`, found \`UntypedInt\` @a.osty:L2:C21
1  E0703
        1  no method \`len\` on type \`\` @a.osty:L3:C6
\`\`\`

File-mode stays compact (filename is already in the scope label):

\`\`\`
2  E0700
        1  type mismatch: expected \`Bool\`, found \`UntypedInt\` @L3:C19
        1  type mismatch: expected \`Int\`, found \`String\` @L2:C18
\`\`\`

## Test plan

- [x] \`go test ./internal/selfhost/ ./internal/check/ -short\` green
- [x] \`go vet ./internal/selfhost/ ./internal/check/ ./cmd/osty/\` clean
- [x] New \`TestSelfhostDiagnosticTelemetryAppendsSourcePosSuffix\` covers file-mode (empty filename), package-mode (filename present), span-less diagnostics (bare detail kept), and out-of-range token indexes (graceful fallback).
- [x] Manual E2E on two-file package reproduces per-file \`@<basename>:Lnn:Cnn\`.
- [x] Manual E2E on single file reproduces compact \`@Lnn:Cnn\`.
- [x] \`TestCheckWithAIRepairPasses*\` failures in cmd/osty confirmed pre-existing (reproduce on stashed HEAD) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)