### PR TITLE
[codex] Speed up checker call/env hot paths

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -30657,30 +30657,110 @@ type CheckInstantiationRecord struct {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12822:5
 type CheckEnv struct {
-	tys              *TyArena
-	bindings         []*CheckBinding
-	fns              []*CheckFnSig
-	fields           []*CheckFieldSig
-	variants         []*CheckVariantSig
-	aliases          []*CheckAliasSig
-	types            []*CheckTypeSig
-	interfaces       []string
-	interfaceExtends []*CheckInterfaceExt
-	genericBounds    []*CheckGenericBound
-	returnTy         int
-	fnName           string
-	inLoop           bool
-	diagnostics      []*CheckDiagnostic
-	assignments      int
-	accepted         int
-	bindingRecords   []*CheckBindingRecord
-	symbolRecords    []*CheckSymbolRecord
-	instantiations   []*CheckInstantiationRecord
+	tys                     *TyArena
+	bindings                []*CheckBinding
+	bindingIndexNames       []string
+	bindingIndexStacks      [][]*CheckBinding
+	bindingIndexMap         map[string][]*CheckBinding
+	fns                     []*CheckFnSig
+	fnIndexKeys             []string
+	fnIndexValues           []int
+	fnIndexMap              map[string]int
+	fields                  []*CheckFieldSig
+	fieldIndexKeys          []string
+	fieldIndexValues        []int
+	fieldIndexMap           map[string]int
+	variants                []*CheckVariantSig
+	variantIndexKeys        []string
+	variantIndexValues      []int
+	variantOwnerIndexKeys   []string
+	variantOwnerIndexValues []int
+	variantIndexMap         map[string]int
+	variantOwnerIndexMap    map[string]int
+	aliases                 []*CheckAliasSig
+	aliasIndexKeys          []string
+	aliasIndexValues        []int
+	aliasIndexMap           map[string]int
+	types                   []*CheckTypeSig
+	typeIndexKeys           []string
+	typeIndexValues         []int
+	typeIndexMap            map[string]int
+	interfaces              []string
+	interfaceIndexKeys      []string
+	interfaceIndexMap       map[string]bool
+	interfaceExtends        []*CheckInterfaceExt
+	genericBounds           []*CheckGenericBound
+	genericBoundIndexNames  []string
+	genericBoundIndexStacks [][]int
+	genericBoundIndexMap    map[string][]int
+	aliasDeepCache          []int
+	substCacheKeys          []string
+	substCacheValues        []int
+	substCacheMap           map[string]int
+	returnTy                int
+	fnName                  string
+	inLoop                  bool
+	diagnostics             []*CheckDiagnostic
+	assignments             int
+	accepted                int
+	bindingRecords          []*CheckBindingRecord
+	symbolRecords           []*CheckSymbolRecord
+	instantiations          []*CheckInstantiationRecord
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12858:5
 func emptyCheckEnv(tys *TyArena) *CheckEnv {
-	return &CheckEnv{tys: tys, bindings: make([]*CheckBinding, 0, 1), fns: make([]*CheckFnSig, 0, 1), fields: make([]*CheckFieldSig, 0, 1), variants: make([]*CheckVariantSig, 0, 1), aliases: make([]*CheckAliasSig, 0, 1), types: make([]*CheckTypeSig, 0, 1), interfaces: make([]string, 0, 1), interfaceExtends: make([]*CheckInterfaceExt, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1), returnTy: tErr(tys), fnName: "", inLoop: false, diagnostics: make([]*CheckDiagnostic, 0, 1), assignments: 0, accepted: 0, bindingRecords: make([]*CheckBindingRecord, 0, 1), symbolRecords: make([]*CheckSymbolRecord, 0, 1), instantiations: make([]*CheckInstantiationRecord, 0, 1)}
+	return &CheckEnv{
+		tys:                     tys,
+		bindings:                make([]*CheckBinding, 0, 1),
+		bindingIndexNames:       make([]string, 0, 1),
+		bindingIndexStacks:      make([][]*CheckBinding, 0, 1),
+		bindingIndexMap:         make(map[string][]*CheckBinding),
+		fns:                     make([]*CheckFnSig, 0, 1),
+		fnIndexKeys:             make([]string, 0, 1),
+		fnIndexValues:           make([]int, 0, 1),
+		fnIndexMap:              make(map[string]int),
+		fields:                  make([]*CheckFieldSig, 0, 1),
+		fieldIndexKeys:          make([]string, 0, 1),
+		fieldIndexValues:        make([]int, 0, 1),
+		fieldIndexMap:           make(map[string]int),
+		variants:                make([]*CheckVariantSig, 0, 1),
+		variantIndexKeys:        make([]string, 0, 1),
+		variantIndexValues:      make([]int, 0, 1),
+		variantOwnerIndexKeys:   make([]string, 0, 1),
+		variantOwnerIndexValues: make([]int, 0, 1),
+		variantIndexMap:         make(map[string]int),
+		variantOwnerIndexMap:    make(map[string]int),
+		aliases:                 make([]*CheckAliasSig, 0, 1),
+		aliasIndexKeys:          make([]string, 0, 1),
+		aliasIndexValues:        make([]int, 0, 1),
+		aliasIndexMap:           make(map[string]int),
+		types:                   make([]*CheckTypeSig, 0, 1),
+		typeIndexKeys:           make([]string, 0, 1),
+		typeIndexValues:         make([]int, 0, 1),
+		typeIndexMap:            make(map[string]int),
+		interfaces:              make([]string, 0, 1),
+		interfaceIndexKeys:      make([]string, 0, 1),
+		interfaceIndexMap:       make(map[string]bool),
+		interfaceExtends:        make([]*CheckInterfaceExt, 0, 1),
+		genericBounds:           make([]*CheckGenericBound, 0, 1),
+		genericBoundIndexNames:  make([]string, 0, 1),
+		genericBoundIndexStacks: make([][]int, 0, 1),
+		genericBoundIndexMap:    make(map[string][]int),
+		aliasDeepCache:          make([]int, 0, 1),
+		substCacheKeys:          make([]string, 0, 1),
+		substCacheValues:        make([]int, 0, 1),
+		substCacheMap:           make(map[string]int),
+		returnTy:                tErr(tys),
+		fnName:                  "",
+		inLoop:                  false,
+		diagnostics:             make([]*CheckDiagnostic, 0, 1),
+		assignments:             0,
+		accepted:                0,
+		bindingRecords:          make([]*CheckBindingRecord, 0, 1),
+		symbolRecords:           make([]*CheckSymbolRecord, 0, 1),
+		instantiations:          make([]*CheckInstantiationRecord, 0, 1),
+	}
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12891:5
@@ -30695,17 +30775,11 @@ func checkScopeDrop(env *CheckEnv, mark int) {
 	_ = current
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12899:5
 	for current > mark {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12900:9
-		_ = func() **CheckBinding {
-			if len(env.bindings) == 0 {
-				return nil
-			}
-			v := env.bindings[len(env.bindings)-1]
-			var zero *CheckBinding
-			env.bindings[len(env.bindings)-1] = zero
-			env.bindings = env.bindings[:len(env.bindings)-1]
-			return &v
-		}()
+		popped := env.bindings[current-1]
+		var zero *CheckBinding
+		env.bindings[current-1] = zero
+		env.bindings = env.bindings[:current-1]
+		checkBindingIndexPop(env, popped.name)
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12901:9
 		func() {
 			var _cur2038 int = current
@@ -30728,64 +30802,54 @@ func checkBindingCount(env *CheckEnv) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12919:5
 func checkBind(env *CheckEnv, name string, ty int) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12920:5
-	func() struct{} {
-		env.bindings = append(env.bindings, &CheckBinding{name: name, ty: ty, mutable: false, start: -1, end: -1})
-		return struct{}{}
-	}()
+	binding := &CheckBinding{name: name, ty: ty, mutable: false, start: -1, end: -1}
+	env.bindings = append(env.bindings, binding)
+	checkBindingIndexPush(env, binding)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12929:5
 func checkBindMut(env *CheckEnv, name string, ty int) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12930:5
-	func() struct{} {
-		env.bindings = append(env.bindings, &CheckBinding{name: name, ty: ty, mutable: true, start: -1, end: -1})
-		return struct{}{}
-	}()
+	binding := &CheckBinding{name: name, ty: ty, mutable: true, start: -1, end: -1}
+	env.bindings = append(env.bindings, binding)
+	checkBindingIndexPush(env, binding)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12941:5
 func checkBindSpan(env *CheckEnv, name string, ty int, mutable bool, start int, end int) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12942:5
-	func() struct{} {
-		env.bindings = append(env.bindings, &CheckBinding{name: name, ty: ty, mutable: mutable, start: start, end: end})
-		return struct{}{}
-	}()
+	binding := &CheckBinding{name: name, ty: ty, mutable: mutable, start: start, end: end}
+	env.bindings = append(env.bindings, binding)
+	checkBindingIndexPush(env, binding)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12948:5
 func checkLookup(env *CheckEnv, name string) int {
-	for i := len(env.bindings) - 1; i >= 0; i-- {
-		if env.bindings[i].name == name {
-			return env.bindings[i].ty
-		}
+	stack := env.bindingIndexMap[name]
+	if len(stack) == 0 {
+		return -1
 	}
-	return -1
+	return stack[len(stack)-1].ty
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12958:5
 func checkLookupMutable(env *CheckEnv, name string) bool {
-	for i := len(env.bindings) - 1; i >= 0; i-- {
-		if env.bindings[i].name == name {
-			return env.bindings[i].mutable
-		}
+	stack := env.bindingIndexMap[name]
+	if len(stack) == 0 {
+		return false
 	}
-	return false
+	return stack[len(stack)-1].mutable
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12972:5
 func checkRegisterFn(env *CheckEnv, sig *CheckFnSig) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12973:5
-	func() struct{} { env.fns = append(env.fns, sig); return struct{}{} }()
+	idx := len(env.fns)
+	env.fns = append(env.fns, sig)
+	env.fnIndexMap[checkFnKey(sig.name, sig.owner)] = idx
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12976:5
 func checkLookupFn(env *CheckEnv, name string, owner string) *CheckFnSig {
-	for i := len(env.fns) - 1; i >= 0; i-- {
-		sig := env.fns[i]
-		if sig.name == name && sig.owner == owner {
-			return sig
-		}
+	if idx, ok := env.fnIndexMap[checkFnKey(name, owner)]; ok {
+		return env.fns[idx]
 	}
 	return emptyCheckFnSig()
 }
@@ -30841,79 +30905,70 @@ func checkFnExists(env *CheckEnv, name string, owner string) bool {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13017:5
 func checkRegisterField(env *CheckEnv, field *CheckFieldSig) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13018:5
-	func() struct{} { env.fields = append(env.fields, field); return struct{}{} }()
+	idx := len(env.fields)
+	env.fields = append(env.fields, field)
+	env.fieldIndexMap[checkOwnerKey(field.owner, field.name)] = idx
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13021:5
 func checkLookupField(env *CheckEnv, owner string, name string) *CheckFieldSig {
-	for i := len(env.fields) - 1; i >= 0; i-- {
-		f := env.fields[i]
-		if f.owner == owner && f.name == name {
-			return f
-		}
+	if idx, ok := env.fieldIndexMap[checkOwnerKey(owner, name)]; ok {
+		return env.fields[idx]
 	}
 	return emptyCheckFieldSig()
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13030:5
 func checkRegisterVariant(env *CheckEnv, variant *CheckVariantSig) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13031:5
-	func() struct{} { env.variants = append(env.variants, variant); return struct{}{} }()
+	idx := len(env.variants)
+	env.variants = append(env.variants, variant)
+	env.variantIndexMap[variant.name] = idx
+	env.variantOwnerIndexMap[checkOwnerKey(variant.owner, variant.name)] = idx
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13034:5
 func checkLookupVariant(env *CheckEnv, name string) *CheckVariantSig {
-	for i := len(env.variants) - 1; i >= 0; i-- {
-		v := env.variants[i]
-		if v.name == name {
-			return v
-		}
+	if idx, ok := env.variantIndexMap[name]; ok {
+		return env.variants[idx]
 	}
 	return emptyCheckVariantSig()
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13043:5
 func checkLookupVariantInOwner(env *CheckEnv, owner string, name string) *CheckVariantSig {
-	for i := len(env.variants) - 1; i >= 0; i-- {
-		v := env.variants[i]
-		if v.owner == owner && v.name == name {
-			return v
-		}
+	if idx, ok := env.variantOwnerIndexMap[checkOwnerKey(owner, name)]; ok {
+		return env.variants[idx]
 	}
 	return emptyCheckVariantSig()
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13052:5
 func checkRegisterAlias(env *CheckEnv, alias *CheckAliasSig) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13053:5
-	func() struct{} { env.aliases = append(env.aliases, alias); return struct{}{} }()
+	idx := len(env.aliases)
+	env.aliases = append(env.aliases, alias)
+	env.aliasIndexMap[alias.name] = idx
+	env.aliasDeepCache = make([]int, 0, 1)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13056:5
 func checkLookupAlias(env *CheckEnv, name string) *CheckAliasSig {
-	for i := len(env.aliases) - 1; i >= 0; i-- {
-		a := env.aliases[i]
-		if a.name == name {
-			return a
-		}
+	if idx, ok := env.aliasIndexMap[name]; ok {
+		return env.aliases[idx]
 	}
 	return emptyCheckAliasSig()
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13065:5
 func checkRegisterType(env *CheckEnv, sig *CheckTypeSig) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13066:5
-	func() struct{} { env.types = append(env.types, sig); return struct{}{} }()
+	idx := len(env.types)
+	env.types = append(env.types, sig)
+	env.typeIndexMap[sig.name] = idx
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13069:5
 func checkLookupType(env *CheckEnv, name string) *CheckTypeSig {
-	for i := len(env.types) - 1; i >= 0; i-- {
-		t := env.types[i]
-		if t.name == name {
-			return t
-		}
+	if idx, ok := env.typeIndexMap[name]; ok {
+		return env.types[idx]
 	}
 	return emptyCheckTypeSig()
 }
@@ -30935,21 +30990,13 @@ func checkDeclaredTypeExists(env *CheckEnv, name string) bool {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13088:5
 func checkRegisterInterface(env *CheckEnv, name string) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13089:5
-	func() struct{} { env.interfaces = append(env.interfaces, name); return struct{}{} }()
+	env.interfaces = append(env.interfaces, name)
+	env.interfaceIndexMap[name] = true
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13092:5
 func checkIsInterface(env *CheckEnv, name string) bool {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13093:5
-	for _, i := range env.interfaces {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13094:9
-		if i == name {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13095:13
-			return true
-		}
-	}
-	return false
+	return env.interfaceIndexMap[name]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13101:5
@@ -30976,35 +31023,25 @@ func checkInterfaceExtendsList(env *CheckEnv, owner string) []int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13119:5
 func checkAddGenericBound(env *CheckEnv, bound *CheckGenericBound) {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13120:5
-	func() struct{} { env.genericBounds = append(env.genericBounds, bound); return struct{}{} }()
+	env.genericBounds = append(env.genericBounds, bound)
+	checkGenericBoundIndexPush(env, bound.tyParam, bound.iface)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13123:5
 func checkLookupGenericBound(env *CheckEnv, tyParam string) int {
-	for i := len(env.genericBounds) - 1; i >= 0; i-- {
-		b := env.genericBounds[i]
-		if b.tyParam == tyParam {
-			return b.iface
-		}
+	stack := env.genericBoundIndexMap[tyParam]
+	if len(stack) == 0 {
+		return -1
 	}
-	return -1
+	return stack[len(stack)-1]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13133:5
 func checkGenericBoundsFor(env *CheckEnv, tyParam string) []int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13134:5
-	var out []int = make([]int, 0, 1)
-	_ = out
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13135:5
-	for _, b := range env.genericBounds {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13136:9
-		if b.tyParam == tyParam {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13137:13
-			func() struct{} { out = append(out, b.iface); return struct{}{} }()
-		}
+	if stack, ok := env.genericBoundIndexMap[tyParam]; ok {
+		return stack
 	}
-	return out
+	return make([]int, 0, 1)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13143:5
@@ -31014,17 +31051,11 @@ func checkClearGenericBoundsAfter(env *CheckEnv, mark int) {
 	_ = current
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13145:5
 	for current > mark {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13146:9
-		_ = func() **CheckGenericBound {
-			if len(env.genericBounds) == 0 {
-				return nil
-			}
-			v := env.genericBounds[len(env.genericBounds)-1]
-			var zero *CheckGenericBound
-			env.genericBounds[len(env.genericBounds)-1] = zero
-			env.genericBounds = env.genericBounds[:len(env.genericBounds)-1]
-			return &v
-		}()
+		popped := env.genericBounds[current-1]
+		var zero *CheckGenericBound
+		env.genericBounds[current-1] = zero
+		env.genericBounds = env.genericBounds[:current-1]
+		checkGenericBoundIndexPop(env, popped.tyParam)
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13147:9
 		func() {
 			var _cur2042 int = current
@@ -31048,6 +31079,66 @@ func checkGenericBoundMark(env *CheckEnv) int {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13155:1
 func checkGenericBoundCount(env *CheckEnv) int {
 	return len(env.genericBounds)
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13158:1
+func checkBindingIndexPush(env *CheckEnv, binding *CheckBinding) {
+	env.bindingIndexMap[binding.name] = append(env.bindingIndexMap[binding.name], binding)
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13167:1
+func checkBindingIndexPop(env *CheckEnv, name string) {
+	stack := env.bindingIndexMap[name]
+	if len(stack) == 0 {
+		return
+	}
+	var zero *CheckBinding
+	stack[len(stack)-1] = zero
+	env.bindingIndexMap[name] = stack[:len(stack)-1]
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13176:1
+func checkGenericBoundIndexPush(env *CheckEnv, name string, iface int) {
+	env.genericBoundIndexMap[name] = append(env.genericBoundIndexMap[name], iface)
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13185:1
+func checkGenericBoundIndexPop(env *CheckEnv, name string) {
+	stack := env.genericBoundIndexMap[name]
+	if len(stack) == 0 {
+		return
+	}
+	env.genericBoundIndexMap[name] = stack[:len(stack)-1]
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13194:1
+func checkNameIndex(names []string, name string) int {
+	for i := len(names) - 1; i >= 0; i-- {
+		if names[i] == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13203:1
+func checkLookupExactIndex(keys []string, values []int, key string) int {
+	for i := len(keys) - 1; i >= 0; i-- {
+		if keys[i] == key {
+			return values[i]
+		}
+	}
+	return -1
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13212:1
+func checkFnKey(name string, owner string) string {
+	return owner + "\x1f" + name
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13216:1
+func checkOwnerKey(owner string, name string) string {
+	return owner + "\x1f" + name
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13172:5
@@ -31130,7 +31221,13 @@ func checkResolveAlias(env *CheckEnv, ty int) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13213:5
 func checkResolveAliasDeep(env *CheckEnv, ty int) int {
-	return checkResolveAliasDeepAt(env, ty, 0)
+	cached := checkAliasDeepCacheGet(env, ty)
+	if cached >= 0 {
+		return cached
+	}
+	resolved := checkResolveAliasDeepAt(env, ty, 0)
+	checkAliasDeepCacheSet(env, ty, resolved)
+	return resolved
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13217:1
@@ -31312,10 +31409,14 @@ func checkSubstituteTy(env *CheckEnv, ty int, generics []string, args []int) int
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13281:9
 		return ty
 	}
+	cached := checkSubstCacheGet(env, ty, generics, args)
+	if cached >= 0 {
+		return cached
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13283:5
 	kind := tyKindAt(env.tys, ty)
 	_ = kind
-	return func() int {
+	result := func() int {
 		_m2061 := kind
 		_ = _m2061
 		if func() bool { _, ok := _m2061.(*TyKind_TkNamed); return ok }() {
@@ -31334,6 +31435,8 @@ func checkSubstituteTy(env *CheckEnv, ty int, generics []string, args []int) int
 			return ty
 		}
 	}()
+	checkSubstCacheSet(env, ty, generics, args, result)
+	return result
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13296:1
@@ -31412,6 +31515,45 @@ func checkSubstituteTyFn(env *CheckEnv, ty int, generics []string, args []int) i
 	ret := checkSubstituteTy(env, tyRetAt(env.tys, ty), generics, args)
 	_ = ret
 	return tyFn(env.tys, outParams, ret)
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13334:1
+func checkAliasDeepCacheGet(env *CheckEnv, ty int) int {
+	if ty < 0 || ty >= len(env.aliasDeepCache) {
+		return -1
+	}
+	return env.aliasDeepCache[ty]
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13341:1
+func checkAliasDeepCacheSet(env *CheckEnv, ty int, resolved int) {
+	if ty < 0 {
+		return
+	}
+	for len(env.aliasDeepCache) <= ty {
+		env.aliasDeepCache = append(env.aliasDeepCache, -1)
+	}
+	env.aliasDeepCache[ty] = resolved
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13351:1
+func checkSubstCacheGet(env *CheckEnv, ty int, generics []string, args []int) int {
+	key := checkSubstCacheKey(ty, generics, args)
+	if resolved, ok := env.substCacheMap[key]; ok {
+		return resolved
+	}
+	return -1
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13356:1
+func checkSubstCacheSet(env *CheckEnv, ty int, generics []string, args []int, resolved int) {
+	key := checkSubstCacheKey(ty, generics, args)
+	env.substCacheMap[key] = resolved
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13362:1
+func checkSubstCacheKey(ty int, generics []string, args []int) string {
+	return fmt.Sprintf("%d\x1f%s\x1f%s", ty, ostyToString(checkStringKey(generics)), ostyToString(checkIntKey(args)))
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13339:5
@@ -31874,27 +32016,7 @@ func checkIntListLen(xs []int) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13593:1
 func checkStringListLen(xs []string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13594:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13595:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13596:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13597:9
-		func() {
-			var _cur2074 int = n
-			var _rhs2075 int = 1
-			if _rhs2075 > 0 && _cur2074 > math.MaxInt-_rhs2075 {
-				panic("integer overflow")
-			}
-			if _rhs2075 < 0 && _cur2074 < math.MinInt-_rhs2075 {
-				panic("integer overflow")
-			}
-			n = _cur2074 + _rhs2075
-		}()
-	}
-	return n
+	return len(xs)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13602:1
@@ -31905,6 +32027,30 @@ func checkIndexOfString(xs []string, needle string) int {
 		}
 	}
 	return -1
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13608:1
+func checkIntKey(xs []int) string {
+	if len(xs) == 0 {
+		return ""
+	}
+	out := fmt.Sprintf("%d", xs[0])
+	for i := 1; i < len(xs); i++ {
+		out = fmt.Sprintf("%s,%d", ostyToString(out), xs[i])
+	}
+	return out
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13620:1
+func checkStringKey(xs []string) string {
+	if len(xs) == 0 {
+		return ""
+	}
+	out := xs[0]
+	for i := 1; i < len(xs); i++ {
+		out = fmt.Sprintf("%s,%s", ostyToString(out), ostyToString(xs[i]))
+	}
+	return out
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13613:1
@@ -34558,6 +34704,16 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15093:9
 		return elabErrResult(cx, node.start, node.end)
 	}
+	if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
+		coreFn := coreIdent(cx.core, baseCallee.text, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
+		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
+		retTy := sig.retTy
+		if !(tyIsErr(cx.env.tys, expected)) {
+			_ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
+		}
+		coreCallNode := coreCall(cx.core, coreFn, coreArgs, make([]int, 0, 1), retTy, node.start, node.end)
+		return &ElabResult{node: coreCallNode, ty: retTy}
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15096:5
 	solver := newSolver()
 	_ = solver
@@ -34654,6 +34810,15 @@ func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expe
 		}()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15145:9
 		return elabErrResult(cx, callNode.start, callNode.end)
+	}
+	if checkStringListLenHelper(sig.generics) == 0 {
+		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, callNode.children, callNode.start, callNode.end)
+		retTy := sig.retTy
+		if !(tyIsErr(cx.env.tys, expected)) {
+			_ = checkExpectAssignable(cx.env, expected, retTy, callNode.start, callNode.end)
+		}
+		mcall := coreMethodCall(cx.core, recv.node, methodName, ownerName, coreArgs, make([]int, 0, 1), retTy, callNode.start, callNode.end)
+		return &ElabResult{node: mcall, ty: retTy}
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15148:5
 	solver := newSolver()
@@ -34892,6 +35057,32 @@ func elabCallArgs(cx *ElabCx, solver *Solver, sig *CheckFnSig, freshs []int, arg
 			}
 			i = _cur2133 + _rhs2134
 		}()
+	}
+	return coreArgs
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15270:1
+func elabCallArgsMonomorphic(cx *ElabCx, callee string, paramTys []int, argIdxs []int, start int, end int) []int {
+	wantCount := checkIntListLenHelper(paramTys)
+	gotCount := checkIntListLenHelper(argIdxs)
+	if wantCount != gotCount {
+		func() struct{} {
+			cx.env.diagnostics = append(cx.env.diagnostics, diagArgCount(callee, wantCount, gotCount, start, end))
+			return struct{}{}
+		}()
+	}
+	var coreArgs []int = make([]int, 0, 1)
+	i := 0
+	for _, argIdx := range argIdxs {
+		if i >= wantCount {
+			r := elabInfer(cx, argIdx)
+			coreArgs = append(coreArgs, r.node)
+			i++
+			continue
+		}
+		r := elabCheck(cx, argIdx, checkIntListAt(paramTys, i))
+		coreArgs = append(coreArgs, r.node)
+		i++
 	}
 	return coreArgs
 }

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -123,18 +123,42 @@ pub struct CheckEnv {
     // Lexical stack; binding operations push to the tail and `checkScopeDrop`
     // truncates to a previously captured mark.
     pub bindings: List<CheckBinding>,
+    pub bindingIndexNames: List<String>,
+    pub bindingIndexStacks: List<List<CheckBinding>>,
 
     // Module-level signatures.
     pub fns: List<CheckFnSig>,
+    pub fnIndexKeys: List<String>,
+    pub fnIndexValues: List<Int>,
     pub fields: List<CheckFieldSig>,
+    pub fieldIndexKeys: List<String>,
+    pub fieldIndexValues: List<Int>,
     pub variants: List<CheckVariantSig>,
+    pub variantIndexKeys: List<String>,
+    pub variantIndexValues: List<Int>,
+    pub variantOwnerIndexKeys: List<String>,
+    pub variantOwnerIndexValues: List<Int>,
     pub aliases: List<CheckAliasSig>,
+    pub aliasIndexKeys: List<String>,
+    pub aliasIndexValues: List<Int>,
     pub types: List<CheckTypeSig>,
+    pub typeIndexKeys: List<String>,
+    pub typeIndexValues: List<Int>,
     pub interfaces: List<String>,
+    pub interfaceIndexKeys: List<String>,
     pub interfaceExtends: List<CheckInterfaceExt>,
 
     // Generic bounds currently in scope (owner fn / struct / impl).
     pub genericBounds: List<CheckGenericBound>,
+    pub genericBoundIndexNames: List<String>,
+    pub genericBoundIndexStacks: List<List<Int>>,
+
+    // Memoized type rewrites. `aliasDeepCache` is indexed directly by
+    // type handle; substitution cache keys include the generic/arg
+    // environment because the same type can be specialised many ways.
+    pub aliasDeepCache: List<Int>,
+    pub substCacheKeys: List<String>,
+    pub substCacheValues: List<Int>,
 
     // Flow context.
     pub returnTy: Int,
@@ -157,14 +181,34 @@ pub fn emptyCheckEnv(tys: TyArena) -> CheckEnv {
     CheckEnv {
         tys,
         bindings: [],
+        bindingIndexNames: [],
+        bindingIndexStacks: [],
         fns: [],
+        fnIndexKeys: [],
+        fnIndexValues: [],
         fields: [],
+        fieldIndexKeys: [],
+        fieldIndexValues: [],
         variants: [],
+        variantIndexKeys: [],
+        variantIndexValues: [],
+        variantOwnerIndexKeys: [],
+        variantOwnerIndexValues: [],
         aliases: [],
+        aliasIndexKeys: [],
+        aliasIndexValues: [],
         types: [],
+        typeIndexKeys: [],
+        typeIndexValues: [],
         interfaces: [],
+        interfaceIndexKeys: [],
         interfaceExtends: [],
         genericBounds: [],
+        genericBoundIndexNames: [],
+        genericBoundIndexStacks: [],
+        aliasDeepCache: [],
+        substCacheKeys: [],
+        substCacheValues: [],
         returnTy: tErr(tys),
         fnName: "",
         inLoop: false,
@@ -195,7 +239,9 @@ pub fn checkScopeDrop(env: CheckEnv, mark: Int) {
     // support `.pop()`; the early-break guards against negative marks.
     let mut current = env.bindings.len()
     for current > mark {
+        let popped = env.bindings[current - 1]
         let _ = env.bindings.pop()
+        checkBindingIndexPop(env, popped.name)
         current = current - 1
     }
 }
@@ -210,56 +256,62 @@ pub fn checkBindingCount(env: CheckEnv) -> Int {
 
 /// checkBind pushes a new immutable binding onto the lexical stack.
 pub fn checkBind(env: CheckEnv, name: String, ty: Int) {
-    env.bindings.push(CheckBinding {
+    let binding = CheckBinding {
         name,
         ty,
         mutable: false,
         start: -1,
         end: -1,
-    })
+    }
+    env.bindings.push(binding)
+    checkBindingIndexPush(env, binding)
 }
 
 pub fn checkBindMut(env: CheckEnv, name: String, ty: Int) {
-    env.bindings.push(CheckBinding {
+    let binding = CheckBinding {
         name,
         ty,
         mutable: true,
         start: -1,
         end: -1,
-    })
+    }
+    env.bindings.push(binding)
+    checkBindingIndexPush(env, binding)
 }
 
 /// checkBindSpan pushes a binding while also remembering its AST span
 /// so the structured-output record can echo the exact source range.
 pub fn checkBindSpan(env: CheckEnv, name: String, ty: Int, mutable: Bool, start: Int, end: Int) {
-    env.bindings.push(CheckBinding { name, ty, mutable, start, end })
+    let binding = CheckBinding { name, ty, mutable, start, end }
+    env.bindings.push(binding)
+    checkBindingIndexPush(env, binding)
 }
 
 /// checkLookup walks the lexical stack from the tail back, returning
 /// the most recent binding for `name`. Returns `-1` (no type) when
 /// `name` is not in scope.
 pub fn checkLookup(env: CheckEnv, name: String) -> Int {
-    let mut i = env.bindings.len() - 1
-    for i >= 0 {
-        let b = env.bindings[i]
-        if b.name == name {
-            return b.ty
-        }
-        i = i - 1
+    let slot = checkNameIndex(env.bindingIndexNames, name)
+    if slot < 0 {
+        return -1
     }
-    -1
+    let stack = env.bindingIndexStacks[slot]
+    if stack.len() == 0 {
+        return -1
+    }
+    stack[stack.len() - 1].ty
 }
 
 pub fn checkLookupMutable(env: CheckEnv, name: String) -> Bool {
-    let mut i = env.bindings.len() - 1
-    for i >= 0 {
-        let b = env.bindings[i]
-        if b.name == name {
-            return b.mutable
-        }
-        i = i - 1
+    let slot = checkNameIndex(env.bindingIndexNames, name)
+    if slot < 0 {
+        return false
     }
-    false
+    let stack = env.bindingIndexStacks[slot]
+    if stack.len() == 0 {
+        return false
+    }
+    stack[stack.len() - 1].mutable
 }
 
 // ---------------------------------------------------------------------
@@ -267,17 +319,22 @@ pub fn checkLookupMutable(env: CheckEnv, name: String) -> Bool {
 // ---------------------------------------------------------------------
 
 pub fn checkRegisterFn(env: CheckEnv, sig: CheckFnSig) {
+    let idx = env.fns.len()
     env.fns.push(sig)
+    let key = checkFnKey(sig.name, sig.owner)
+    let slot = checkNameIndex(env.fnIndexKeys, key)
+    if slot < 0 {
+        env.fnIndexKeys.push(key)
+        env.fnIndexValues.push(idx)
+    } else {
+        env.fnIndexValues[slot] = idx
+    }
 }
 
 pub fn checkLookupFn(env: CheckEnv, name: String, owner: String) -> CheckFnSig {
-    let mut i = env.fns.len() - 1
-    for i >= 0 {
-        let sig = env.fns[i]
-        if sig.name == name && sig.owner == owner {
-            return sig
-        }
-        i = i - 1
+    let idx = checkLookupExactIndex(env.fnIndexKeys, env.fnIndexValues, checkFnKey(name, owner))
+    if idx >= 0 {
+        return env.fns[idx]
     }
     emptyCheckFnSig()
 }
@@ -315,77 +372,99 @@ pub fn checkFnExists(env: CheckEnv, name: String, owner: String) -> Bool {
 }
 
 pub fn checkRegisterField(env: CheckEnv, field: CheckFieldSig) {
+    let idx = env.fields.len()
     env.fields.push(field)
+    let key = checkOwnerKey(field.owner, field.name)
+    let slot = checkNameIndex(env.fieldIndexKeys, key)
+    if slot < 0 {
+        env.fieldIndexKeys.push(key)
+        env.fieldIndexValues.push(idx)
+    } else {
+        env.fieldIndexValues[slot] = idx
+    }
 }
 
 pub fn checkLookupField(env: CheckEnv, owner: String, name: String) -> CheckFieldSig {
-    let mut i = env.fields.len() - 1
-    for i >= 0 {
-        let f = env.fields[i]
-        if f.owner == owner && f.name == name {
-            return f
-        }
-        i = i - 1
+    let idx = checkLookupExactIndex(env.fieldIndexKeys, env.fieldIndexValues, checkOwnerKey(owner, name))
+    if idx >= 0 {
+        return env.fields[idx]
     }
     emptyCheckFieldSig()
 }
 
 pub fn checkRegisterVariant(env: CheckEnv, variant: CheckVariantSig) {
+    let idx = env.variants.len()
     env.variants.push(variant)
+    let nameSlot = checkNameIndex(env.variantIndexKeys, variant.name)
+    if nameSlot < 0 {
+        env.variantIndexKeys.push(variant.name)
+        env.variantIndexValues.push(idx)
+    } else {
+        env.variantIndexValues[nameSlot] = idx
+    }
+    let ownerKey = checkOwnerKey(variant.owner, variant.name)
+    let ownerSlot = checkNameIndex(env.variantOwnerIndexKeys, ownerKey)
+    if ownerSlot < 0 {
+        env.variantOwnerIndexKeys.push(ownerKey)
+        env.variantOwnerIndexValues.push(idx)
+    } else {
+        env.variantOwnerIndexValues[ownerSlot] = idx
+    }
 }
 
 pub fn checkLookupVariant(env: CheckEnv, name: String) -> CheckVariantSig {
-    let mut i = env.variants.len() - 1
-    for i >= 0 {
-        let v = env.variants[i]
-        if v.name == name {
-            return v
-        }
-        i = i - 1
+    let idx = checkLookupExactIndex(env.variantIndexKeys, env.variantIndexValues, name)
+    if idx >= 0 {
+        return env.variants[idx]
     }
     emptyCheckVariantSig()
 }
 
 pub fn checkLookupVariantInOwner(env: CheckEnv, owner: String, name: String) -> CheckVariantSig {
-    let mut i = env.variants.len() - 1
-    for i >= 0 {
-        let v = env.variants[i]
-        if v.owner == owner && v.name == name {
-            return v
-        }
-        i = i - 1
+    let idx = checkLookupExactIndex(env.variantOwnerIndexKeys, env.variantOwnerIndexValues, checkOwnerKey(owner, name))
+    if idx >= 0 {
+        return env.variants[idx]
     }
     emptyCheckVariantSig()
 }
 
 pub fn checkRegisterAlias(env: CheckEnv, alias: CheckAliasSig) {
+    let idx = env.aliases.len()
     env.aliases.push(alias)
+    let slot = checkNameIndex(env.aliasIndexKeys, alias.name)
+    if slot < 0 {
+        env.aliasIndexKeys.push(alias.name)
+        env.aliasIndexValues.push(idx)
+    } else {
+        env.aliasIndexValues[slot] = idx
+    }
+    env.aliasDeepCache = []
 }
 
 pub fn checkLookupAlias(env: CheckEnv, name: String) -> CheckAliasSig {
-    let mut i = env.aliases.len() - 1
-    for i >= 0 {
-        let a = env.aliases[i]
-        if a.name == name {
-            return a
-        }
-        i = i - 1
+    let idx = checkLookupExactIndex(env.aliasIndexKeys, env.aliasIndexValues, name)
+    if idx >= 0 {
+        return env.aliases[idx]
     }
     emptyCheckAliasSig()
 }
 
 pub fn checkRegisterType(env: CheckEnv, sig: CheckTypeSig) {
+    let idx = env.types.len()
     env.types.push(sig)
+    let slot = checkNameIndex(env.typeIndexKeys, sig.name)
+    if slot < 0 {
+        env.typeIndexKeys.push(sig.name)
+        env.typeIndexValues.push(idx)
+    } else {
+        env.typeIndexValues[slot] = idx
+    }
 }
 
 pub fn checkLookupType(env: CheckEnv, name: String) -> CheckTypeSig {
-    let mut i = env.types.len() - 1
-    for i >= 0 {
-        let t = env.types[i]
-        if t.name == name {
-            return t
-        }
-        i = i - 1
+    let idx = checkLookupExactIndex(env.typeIndexKeys, env.typeIndexValues, name)
+    if idx >= 0 {
+        return env.types[idx]
     }
     emptyCheckTypeSig()
 }
@@ -402,15 +481,13 @@ pub fn checkDeclaredTypeExists(env: CheckEnv, name: String) -> Bool {
 
 pub fn checkRegisterInterface(env: CheckEnv, name: String) {
     env.interfaces.push(name)
+    if checkNameIndex(env.interfaceIndexKeys, name) < 0 {
+        env.interfaceIndexKeys.push(name)
+    }
 }
 
 pub fn checkIsInterface(env: CheckEnv, name: String) -> Bool {
-    for i in env.interfaces {
-        if i == name {
-            return true
-        }
-    }
-    false
+    checkNameIndex(env.interfaceIndexKeys, name) >= 0
 }
 
 pub fn checkRegisterInterfaceExtends(env: CheckEnv, ext: CheckInterfaceExt) {
@@ -433,34 +510,35 @@ pub fn checkInterfaceExtendsList(env: CheckEnv, owner: String) -> List<Int> {
 
 pub fn checkAddGenericBound(env: CheckEnv, bound: CheckGenericBound) {
     env.genericBounds.push(bound)
+    checkGenericBoundIndexPush(env, bound.tyParam, bound.iface)
 }
 
 pub fn checkLookupGenericBound(env: CheckEnv, tyParam: String) -> Int {
-    let mut i = env.genericBounds.len() - 1
-    for i >= 0 {
-        let b = env.genericBounds[i]
-        if b.tyParam == tyParam {
-            return b.iface
-        }
-        i = i - 1
+    let slot = checkNameIndex(env.genericBoundIndexNames, tyParam)
+    if slot < 0 {
+        return -1
     }
-    -1
+    let stack = env.genericBoundIndexStacks[slot]
+    if stack.len() == 0 {
+        return -1
+    }
+    stack[stack.len() - 1]
 }
 
 pub fn checkGenericBoundsFor(env: CheckEnv, tyParam: String) -> List<Int> {
-    let mut out: List<Int> = []
-    for b in env.genericBounds {
-        if b.tyParam == tyParam {
-            out.push(b.iface)
-        }
+    let slot = checkNameIndex(env.genericBoundIndexNames, tyParam)
+    if slot < 0 {
+        return []
     }
-    out
+    env.genericBoundIndexStacks[slot]
 }
 
 pub fn checkClearGenericBoundsAfter(env: CheckEnv, mark: Int) {
     let mut current = checkGenericBoundCount(env)
     for current > mark {
+        let popped = env.genericBounds[current - 1]
         let _ = env.genericBounds.pop()
+        checkGenericBoundIndexPop(env, popped.tyParam)
         current = current - 1
     }
 }
@@ -471,6 +549,76 @@ pub fn checkGenericBoundMark(env: CheckEnv) -> Int {
 
 fn checkGenericBoundCount(env: CheckEnv) -> Int {
     env.genericBounds.len()
+}
+
+fn checkBindingIndexPush(env: CheckEnv, binding: CheckBinding) {
+    let slot = checkNameIndex(env.bindingIndexNames, binding.name)
+    if slot < 0 {
+        env.bindingIndexNames.push(binding.name)
+        env.bindingIndexStacks.push([binding])
+        return
+    }
+    env.bindingIndexStacks[slot].push(binding)
+}
+
+fn checkBindingIndexPop(env: CheckEnv, name: String) {
+    let slot = checkNameIndex(env.bindingIndexNames, name)
+    if slot < 0 {
+        return
+    }
+    if env.bindingIndexStacks[slot].len() > 0 {
+        let _ = env.bindingIndexStacks[slot].pop()
+    }
+}
+
+fn checkGenericBoundIndexPush(env: CheckEnv, name: String, iface: Int) {
+    let slot = checkNameIndex(env.genericBoundIndexNames, name)
+    if slot < 0 {
+        env.genericBoundIndexNames.push(name)
+        env.genericBoundIndexStacks.push([iface])
+        return
+    }
+    env.genericBoundIndexStacks[slot].push(iface)
+}
+
+fn checkGenericBoundIndexPop(env: CheckEnv, name: String) {
+    let slot = checkNameIndex(env.genericBoundIndexNames, name)
+    if slot < 0 {
+        return
+    }
+    if env.genericBoundIndexStacks[slot].len() > 0 {
+        let _ = env.genericBoundIndexStacks[slot].pop()
+    }
+}
+
+fn checkNameIndex(names: List<String>, name: String) -> Int {
+    let mut i = names.len() - 1
+    for i >= 0 {
+        if names[i] == name {
+            return i
+        }
+        i = i - 1
+    }
+    -1
+}
+
+fn checkLookupExactIndex(keys: List<String>, values: List<Int>, key: String) -> Int {
+    let mut i = keys.len() - 1
+    for i >= 0 {
+        if keys[i] == key {
+            return values[i]
+        }
+        i = i - 1
+    }
+    -1
+}
+
+fn checkFnKey(name: String, owner: String) -> String {
+    "{owner}\u{1f}{name}"
+}
+
+fn checkOwnerKey(owner: String, name: String) -> String {
+    "{owner}\u{1f}{name}"
 }
 
 // ---------------------------------------------------------------------
@@ -523,7 +671,13 @@ pub fn checkResolveAlias(env: CheckEnv, ty: Int) -> Int {
 /// elements, Fn params/ret, Optional inner) and re-allocates a
 /// canonical form with every alias expanded.
 pub fn checkResolveAliasDeep(env: CheckEnv, ty: Int) -> Int {
-    checkResolveAliasDeepAt(env, ty, 0)
+    let cached = checkAliasDeepCacheGet(env, ty)
+    if cached >= 0 {
+        return cached
+    }
+    let resolved = checkResolveAliasDeepAt(env, ty, 0)
+    checkAliasDeepCacheSet(env, ty, resolved)
+    resolved
 }
 
 fn checkResolveAliasDeepAt(env: CheckEnv, ty: Int, depth: Int) -> Int {
@@ -592,17 +746,23 @@ pub fn checkSubstituteTy(env: CheckEnv, ty: Int, generics: List<String>, args: L
     if ty < 0 {
         return ty
     }
+    let cached = checkSubstCacheGet(env, ty, generics, args)
+    if cached >= 0 {
+        return cached
+    }
     let kind = tyKindAt(env.tys, ty)
     // See note on checkResolveAliasDeepAt: match arms whose body
     // carries local let-bindings miscompile through the bootstrap
     // transpiler, so each compound arm delegates to a helper.
-    match kind {
+    let result = match kind {
         TkNamed    -> checkSubstituteTyNamed(env, ty, generics, args),
         TkTuple    -> checkSubstituteTyTuple(env, ty, generics, args),
         TkFn       -> checkSubstituteTyFn(env, ty, generics, args),
         TkOptional -> tyOptional(env.tys, checkSubstituteTy(env, tyInnerAt(env.tys, ty), generics, args)),
         _          -> ty,
     }
+    checkSubstCacheSet(env, ty, generics, args, result)
+    result
 }
 
 fn checkSubstituteTyNamed(env: CheckEnv, ty: Int, generics: List<String>, args: List<Int>) -> Int {
@@ -642,6 +802,40 @@ fn checkSubstituteTyFn(env: CheckEnv, ty: Int, generics: List<String>, args: Lis
     }
     let ret = checkSubstituteTy(env, tyRetAt(env.tys, ty), generics, args)
     tyFn(env.tys, outParams, ret)
+}
+
+fn checkAliasDeepCacheGet(env: CheckEnv, ty: Int) -> Int {
+    if ty < 0 || ty >= env.aliasDeepCache.len() {
+        return -1
+    }
+    env.aliasDeepCache[ty]
+}
+
+fn checkAliasDeepCacheSet(env: CheckEnv, ty: Int, resolved: Int) {
+    if ty < 0 {
+        return
+    }
+    let mut n = env.aliasDeepCache.len()
+    for n <= ty {
+        env.aliasDeepCache.push(-1)
+        n = n + 1
+    }
+    env.aliasDeepCache[ty] = resolved
+}
+
+fn checkSubstCacheGet(env: CheckEnv, ty: Int, generics: List<String>, args: List<Int>) -> Int {
+    let key = checkSubstCacheKey(ty, generics, args)
+    checkLookupExactIndex(env.substCacheKeys, env.substCacheValues, key)
+}
+
+fn checkSubstCacheSet(env: CheckEnv, ty: Int, generics: List<String>, args: List<Int>, resolved: Int) {
+    let key = checkSubstCacheKey(ty, generics, args)
+    env.substCacheKeys.push(key)
+    env.substCacheValues.push(resolved)
+}
+
+fn checkSubstCacheKey(ty: Int, generics: List<String>, args: List<Int>) -> String {
+    "{ty}\u{1f}{checkStringKey(generics)}\u{1f}{checkIntKey(args)}"
 }
 
 // ---------------------------------------------------------------------
@@ -898,12 +1092,7 @@ fn checkIntListLen(xs: List<Int>) -> Int {
 }
 
 fn checkStringListLen(xs: List<String>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn checkIndexOfString(xs: List<String>, needle: String) -> Int {
@@ -916,6 +1105,34 @@ fn checkIndexOfString(xs: List<String>, needle: String) -> Int {
         i = i + 1
     }
     -1
+}
+
+fn checkIntKey(xs: List<Int>) -> String {
+    if xs.len() == 0 {
+        return ""
+    }
+    let mut out = "{xs[0]}"
+    let mut i = 1
+    let n = xs.len()
+    for i < n {
+        out = "{out},{xs[i]}"
+        i = i + 1
+    }
+    out
+}
+
+fn checkStringKey(xs: List<String>) -> String {
+    if xs.len() == 0 {
+        return ""
+    }
+    let mut out = xs[0]
+    let mut i = 1
+    let n = xs.len()
+    for i < n {
+        out = "{out},{xs[i]}"
+        i = i + 1
+    }
+    out
 }
 
 fn checkStringListContainsLocal(xs: List<String>, needle: String) -> Bool {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1019,6 +1019,17 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
         return elabErrResult(cx, node.start, node.end)
     }
 
+    if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
+        let coreFn = coreIdent(cx.core, baseCallee.text, IkFn, fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
+        let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
+        let retTy = sig.retTy
+        if !(tyIsErr(cx.env.tys, expected)) {
+            let _ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
+        }
+        let coreCallNode = coreCall(cx.core, coreFn, coreArgs, [], retTy, node.start, node.end)
+        return ElabResult { node: coreCallNode, ty: retTy }
+    }
+
     let solver = newSolver()
     let freshs = elabFreshenGenerics(cx, solver, sig.generics, sig.name)
 
@@ -1069,6 +1080,26 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
     if sig.name == "" {
         cx.env.diagnostics.push(diagUnknownMethod(ownerName, methodName, fieldNode.start, fieldNode.end))
         return elabErrResult(cx, callNode.start, callNode.end)
+    }
+
+    if checkStringListLenHelper(sig.generics) == 0 {
+        let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, callNode.children, callNode.start, callNode.end)
+        let retTy = sig.retTy
+        if !(tyIsErr(cx.env.tys, expected)) {
+            let _ = checkExpectAssignable(cx.env, expected, retTy, callNode.start, callNode.end)
+        }
+        let mcall = coreMethodCall(
+            cx.core,
+            recv.node,
+            methodName,
+            ownerName,
+            coreArgs,
+            [],
+            retTy,
+            callNode.start,
+            callNode.end,
+        )
+        return ElabResult { node: mcall, ty: retTy }
     }
 
     let solver = newSolver()
@@ -1189,6 +1220,35 @@ fn elabCallArgs(
             elabInfer(cx, argIdx)
         }
         let _ = unify(cx.env, solver, hint, r.ty)
+        coreArgs.push(r.node)
+        i = i + 1
+    }
+    coreArgs
+}
+
+fn elabCallArgsMonomorphic(
+    cx: ElabCx,
+    callee: String,
+    paramTys: List<Int>,
+    argIdxs: List<Int>,
+    start: Int,
+    end: Int,
+) -> List<Int> {
+    let wantCount = checkIntListLenHelper(paramTys)
+    let gotCount = checkIntListLenHelper(argIdxs)
+    if wantCount != gotCount {
+        cx.env.diagnostics.push(diagArgCount(callee, wantCount, gotCount, start, end))
+    }
+    let mut coreArgs: List<Int> = []
+    let mut i = 0
+    for argIdx in argIdxs {
+        if i >= wantCount {
+            let r = elabInfer(cx, argIdx)
+            coreArgs.push(r.node)
+            i = i + 1
+            continue
+        }
+        let r = elabCheck(cx, argIdx, checkIntListAt(paramTys, i))
         coreArgs.push(r.node)
         i = i + 1
     }


### PR DESCRIPTION
## Summary
- add monomorphic fast paths for non-generic function and method calls
- memoize alias deep-resolution and type substitution in the new checker
- add env side indexes in toolchain source and runtime Go-map indexes in generated selfhost checker

## Validation
- go test ./cmd/osty-native-checker
- go test ./internal/check
- go test ./internal/selfhost
