### PR TITLE
[codex] Strengthen checker poison recovery

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -25866,6 +25866,10 @@ type TyKind_TkErr struct{ _ref byte }
 
 func (TyKind_TkErr) _isTyKind() {}
 
+type TyKind_TkPoison struct{ _ref byte }
+
+func (TyKind_TkPoison) _isTyKind() {}
+
 type TyKind_TkPrim struct{ _ref byte }
 
 func (TyKind_TkPrim) _isTyKind() {}
@@ -25912,6 +25916,7 @@ type TyArena struct {
 	internKeys      []string
 	internValues    []int
 	idxErr          int
+	idxPoison       int
 	idxInt          int
 	idxInt8         int
 	idxInt16        int
@@ -25943,11 +25948,13 @@ func emptyTyNode() *TyNode {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10241:5
 func emptyTyArena() *TyArena {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10242:5
-	arena := &TyArena{nodes: make([]*TyNode, 0, 1), internKeys: make([]string, 0, 1), internValues: make([]int, 0, 1), idxErr: -1, idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1, idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1, idxByte: -1, idxFloat: -1, idxFloat32: -1, idxFloat64: -1, idxBool: -1, idxChar: -1, idxString: -1, idxBytes: -1, idxUnit: -1, idxNever: -1, idxUntypedInt: -1, idxUntypedFloat: -1}
+	arena := &TyArena{nodes: make([]*TyNode, 0, 1), internKeys: make([]string, 0, 1), internValues: make([]int, 0, 1), idxErr: -1, idxPoison: -1, idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1, idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1, idxByte: -1, idxFloat: -1, idxFloat32: -1, idxFloat64: -1, idxBool: -1, idxChar: -1, idxString: -1, idxBytes: -1, idxUnit: -1, idxNever: -1, idxUntypedInt: -1, idxUntypedFloat: -1}
 	_ = arena
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10252:10
 	arena.idxErr = tyAllocErr(arena)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10253:10
+	arena.idxPoison = tyAllocPoison(arena)
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10254:10
 	arena.idxInt = tyAllocPrim(arena, PrimKind(&PrimKind_PkInt{}))
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10254:10
 	arena.idxInt8 = tyAllocPrim(arena, PrimKind(&PrimKind_PkInt8{}))
@@ -26006,6 +26013,19 @@ func tyAllocErr(arena *TyArena) int {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10287:1
+func tyAllocPoison(arena *TyArena) int {
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10288:5
+	idx := tyNodeCount(arena)
+	_ = idx
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10289:5
+	node := &TyNode{kind: TyKind(&TyKind_TkPoison{}), prim: PrimKind(&PrimKind_PkInvalid{}), head: "", args: make([]int, 0, 1), ret: -1, varId: 0, varName: "", varOwner: ""}
+	_ = node
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10293:5
+	func() struct{} { arena.nodes = append(arena.nodes, node); return struct{}{} }()
+	return idx
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10287:1
 func tyAllocPrim(arena *TyArena, prim PrimKind) int {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10288:5
 	idx := tyNodeCount(arena)
@@ -26026,6 +26046,11 @@ func tyNodeCount(arena *TyArena) int {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10313:5
 func tErr(arena *TyArena) int {
 	return arena.idxErr
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10314:5
+func tPoison(arena *TyArena) int {
+	return arena.idxPoison
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10314:5
@@ -26393,6 +26418,16 @@ func tyIsErr(arena *TyArena, idx int) bool {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10521:5
+func tyIsPoison(arena *TyArena, idx int) bool {
+	return ostyEqual(tyKindAt(arena, idx), TyKind(&TyKind_TkPoison{}))
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10525:5
+func tyIsBad(arena *TyArena, idx int) bool {
+	return tyIsErr(arena, idx) || tyIsPoison(arena, idx)
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10521:5
 func tyIsNever(arena *TyArena, idx int) bool {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10522:5
 	k := tyPrimAt(arena, idx)
@@ -26491,6 +26526,9 @@ func tyEq(arena *TyArena, a int, b int) bool {
 		if func() bool { _, ok := _m1964.(*TyKind_TkErr); return ok }() {
 			return true
 		}
+		if func() bool { _, ok := _m1964.(*TyKind_TkPoison); return ok }() {
+			return true
+		}
 		if func() bool { _, ok := _m1964.(*TyKind_TkPrim); return ok }() {
 			return ostyEqual(na.prim, nb.prim)
 		}
@@ -26577,6 +26615,9 @@ func tyToString(arena *TyArena, idx int) string {
 		_ = _m1971
 		if func() bool { _, ok := _m1971.(*TyKind_TkErr); return ok }() {
 			return "Invalid"
+		}
+		if func() bool { _, ok := _m1971.(*TyKind_TkPoison); return ok }() {
+			return "Poison"
 		}
 		if func() bool { _, ok := _m1971.(*TyKind_TkPrim); return ok }() {
 			return primKindName(node.prim)
@@ -26746,6 +26787,11 @@ func tyFromString(arena *TyArena, source string) int {
 	if trimmed == "" {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10743:9
 		return tErr(arena)
+	}
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10745:5
+	if trimmed == "Poison" {
+		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10746:9
+		return tPoison(arena)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10747:5
 	if strings.HasSuffix(trimmed, "?") && !(strings.HasSuffix(trimmed, "??")) {
@@ -31647,7 +31693,7 @@ func checkIsAssignable(env *CheckEnv, dst int, src int) bool {
 	s := checkResolveAliasDeep(env, src)
 	_ = s
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13395:5
-	if tyIsErr(env.tys, d) || tyIsErr(env.tys, s) {
+	if tyIsBad(env.tys, d) || tyIsBad(env.tys, s) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13396:9
 		return true
 	}
@@ -31846,7 +31892,7 @@ func checkTypeSatisfiesInterface(env *CheckEnv, concrete int, iface int) bool {
 	ifaceResolved := checkResolveAliasDeep(env, iface)
 	_ = ifaceResolved
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13490:5
-	if tyIsErr(env.tys, concreteResolved) || tyIsErr(env.tys, ifaceResolved) {
+	if tyIsBad(env.tys, concreteResolved) || tyIsBad(env.tys, ifaceResolved) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13491:9
 		return true
 	}
@@ -32324,7 +32370,7 @@ func unifyAt(env *CheckEnv, solver *Solver, aIn int, bIn int, depth int) bool {
 	bKind := tyKindAt(env.tys, b)
 	_ = bKind
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13887:5
-	if ostyEqual(aKind, TyKind(&TyKind_TkErr{})) || ostyEqual(bKind, TyKind(&TyKind_TkErr{})) {
+	if ostyEqual(aKind, TyKind(&TyKind_TkErr{})) || ostyEqual(bKind, TyKind(&TyKind_TkErr{})) || ostyEqual(aKind, TyKind(&TyKind_TkPoison{})) || ostyEqual(bKind, TyKind(&TyKind_TkPoison{})) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13888:9
 		return true
 	}
@@ -32410,6 +32456,9 @@ func unifyAt(env *CheckEnv, solver *Solver, aIn int, bIn int, depth int) bool {
 			return tyHeadAt(env.tys, a) == tyHeadAt(env.tys, b)
 		}
 		if func() bool { _, ok := _m2081.(*TyKind_TkErr); return ok }() {
+			return true
+		}
+		if func() bool { _, ok := _m2081.(*TyKind_TkPoison); return ok }() {
 			return true
 		}
 		if func() bool { _, ok := _m2081.(*TyKind_TkVar); return ok }() {
@@ -32811,6 +32860,13 @@ type ElabCx struct {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14186:5
+type InstSession struct {
+	solver   *Solver
+	generics []string
+	freshs   []int
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14186:5
 func newElabCx(ast *AstFile, tys *TyArena) *ElabCx {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14187:5
 	env := emptyCheckEnv(tys)
@@ -32939,7 +32995,7 @@ func elabCheckImpl(cx *ElabCx, idx int, expected int) *ElabResult {
 		return elabErrResult(cx, 0, 0)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14250:5
-	if tyIsErr(cx.env.tys, expected) {
+	if tyIsBad(cx.env.tys, expected) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14251:9
 		return elabInferImpl(cx, idx)
 	}
@@ -33000,7 +33056,7 @@ func elabCheckViaInfer(cx *ElabCx, idx int, expected int) *ElabResult {
 	r := elabInferImpl(cx, idx)
 	_ = r
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14277:5
-	if !(tyIsErr(cx.env.tys, r.ty)) {
+	if !(tyIsBad(cx.env.tys, r.ty)) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14278:9
 		start := coreStartAt(cx.core, r.node)
 		_ = start
@@ -33156,7 +33212,7 @@ func elabInferIdent(cx *ElabCx, node *AstNode) *ElabResult {
 				return struct{}{}
 			}()
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14375:13
-			return elabErrResult(cx, node.start, node.end)
+			return elabPoisonResult(cx, node.start, node.end)
 		}
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14377:9
 		fnTy := fnSigToTy(cx.env, fnSig)
@@ -33172,7 +33228,7 @@ func elabInferIdent(cx *ElabCx, node *AstNode) *ElabResult {
 		cx.env.diagnostics = append(cx.env.diagnostics, diagUnknownName(node.text, node.start, node.end))
 		return struct{}{}
 	}()
-	return elabErrResult(cx, node.start, node.end)
+	return elabPoisonResult(cx, node.start, node.end)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14387:1
@@ -33206,7 +33262,7 @@ func unOpResultType(env *CheckEnv, op UnOp, inner int, start int, end int) int {
 	tys := env.tys
 	_ = tys
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14406:5
-	if tyIsErr(tys, inner) {
+	if tyIsBad(tys, inner) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14407:9
 		return inner
 	}
@@ -33323,8 +33379,11 @@ func binOpResultType(env *CheckEnv, op BinOp, left int, right int, start int, en
 	tys := env.tys
 	_ = tys
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14468:5
-	if tyIsErr(tys, left) || tyIsErr(tys, right) {
+	if tyIsBad(tys, left) || tyIsBad(tys, right) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14469:9
+		if tyIsPoison(tys, left) || tyIsPoison(tys, right) {
+			return tPoison(tys)
+		}
 		return tErr(tys)
 	}
 	return func() int {
@@ -33906,7 +33965,7 @@ func elabReturnStmt(cx *ElabCx, node *AstNode) int {
 	_ = valueIdx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14739:5
 	value := func() *ElabResult {
-		if valueIdx >= 0 && !(tyIsErr(cx.env.tys, expected)) {
+		if valueIdx >= 0 && !(tyIsBad(cx.env.tys, expected)) {
 			return elabCheck(cx, valueIdx, expected)
 		} else if valueIdx >= 0 {
 			return elabInfer(cx, valueIdx)
@@ -33947,7 +34006,7 @@ func elabChanSendStmt(cx *ElabCx, node *AstNode) int {
 	_ = elemTy
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14763:5
 	value := func() *ElabResult {
-		if tyIsErr(cx.env.tys, elemTy) {
+		if tyIsBad(cx.env.tys, elemTy) {
 			return elabInfer(cx, node.right)
 		} else {
 			return elabCheck(cx, node.right, elemTy)
@@ -34103,7 +34162,10 @@ func elabChannelElemTy(cx *ElabCx, ty int, start int, end int) int {
 		}
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14846:5
-	if !(tyIsErr(tys, resolved)) {
+	if tyIsBad(tys, resolved) {
+		return resolved
+	}
+	if !(tyIsBad(tys, resolved)) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14847:9
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagOperandType("<-", tyToString(tys, resolved), start, end))
@@ -34122,9 +34184,9 @@ func elabForIterableElemTy(cx *ElabCx, ty int, start int, end int) int {
 	resolved := checkResolveAliasDeep(cx.env, ty)
 	_ = resolved
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14855:5
-	if tyIsErr(tys, resolved) {
+	if tyIsBad(tys, resolved) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14856:9
-		return tErr(tys)
+		return resolved
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14858:5
 	if tyIsPrim(tys, resolved, PrimKind(&PrimKind_PkString{})) {
@@ -34358,7 +34420,7 @@ func astBlockEscapesMatchResult(ast *AstFile, node *AstNode) bool {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14925:1
 func elabRecordTypedExpr(cx *ElabCx, idx int, out *ElabResult) {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14926:5
-	if idx < 0 || out.node < 0 || tyIsErr(cx.env.tys, out.ty) {
+	if idx < 0 || out.node < 0 || tyIsBad(cx.env.tys, out.ty) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14927:9
 		return
 	}
@@ -34591,6 +34653,17 @@ func elabErrResult(cx *ElabCx, start int, end int) *ElabResult {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15024:1
+func elabPoisonResult(cx *ElabCx, start int, end int) *ElabResult {
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15025:5
+	ty := tPoison(cx.env.tys)
+	_ = ty
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15026:5
+	node := coreErrExpr(cx.core, ty, start, end)
+	_ = node
+	return &ElabResult{node: node, ty: ty}
+}
+
+// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15024:1
 func checkIntListLenHelper(xs []int) int {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15025:5
 	n := 0
@@ -34702,76 +34775,40 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 			return struct{}{}
 		}()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15093:9
-		return elabErrResult(cx, node.start, node.end)
+		return elabPoisonResult(cx, node.start, node.end)
 	}
 	if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
 		coreFn := coreIdent(cx.core, baseCallee.text, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
 		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
 		retTy := sig.retTy
-		if !(tyIsErr(cx.env.tys, expected)) {
+		if !(tyIsBad(cx.env.tys, expected)) {
 			_ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
 		}
 		coreCallNode := coreCall(cx.core, coreFn, coreArgs, make([]int, 0, 1), retTy, node.start, node.end)
 		return &ElabResult{node: coreCallNode, ty: retTy}
 	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15096:5
-	solver := newSolver()
-	_ = solver
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15097:5
-	freshs := elabFreshenGenerics(cx, solver, sig.generics, sig.name)
-	_ = freshs
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15100:5
-	if !(tyIsErr(cx.env.tys, expected)) {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15101:9
-		specialisedRet := checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
-		_ = specialisedRet
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15102:9
-		_ = unify(cx.env, solver, specialisedRet, expected)
-	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15106:5
-	if checkIntListLenHelper(explicitArgs) == checkIntListLenHelper(freshs) {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15107:9
-		i := 0
-		_ = i
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15108:9
-		for _, explicit := range explicitArgs {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15109:13
-			fresh := checkIntListAt(freshs, i)
-			_ = fresh
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15110:13
-			_ = unify(cx.env, solver, fresh, explicit)
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15111:13
-			func() {
-				var _cur2125 int = i
-				var _rhs2126 int = 1
-				if _rhs2126 > 0 && _cur2125 > math.MaxInt-_rhs2126 {
-					panic("integer overflow")
-				}
-				if _rhs2126 < 0 && _cur2125 < math.MinInt-_rhs2126 {
-					panic("integer overflow")
-				}
-				i = _cur2125 + _rhs2126
-			}()
-		}
-	}
+	inst := instBegin(cx, sig.generics, sig.name)
+	_ = inst
+	instSeedExpectedRet(cx, inst, sig.retTy, expected)
+	instSeedPositionalArgs(cx, inst, explicitArgs)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15115:5
 	coreFn := coreIdent(cx.core, baseCallee.text, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
 	_ = coreFn
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15116:5
-	coreArgs := elabCallArgs(cx, solver, sig, freshs, argIdxs, node.start, node.end)
+	coreArgs := elabCallArgs(cx, inst.solver, sig, inst.freshs, argIdxs, node.start, node.end)
 	_ = coreArgs
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15118:5
-	retSubstituted := checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
+	retSubstituted := instSubstitute(cx, inst, sig.retTy)
 	_ = retSubstituted
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15119:5
-	retTy := zonk(cx.env, solver, retSubstituted)
+	retTy := instZonk(cx, inst, retSubstituted)
 	_ = retTy
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15122:5
-	elabReportUnresolvedGenerics(cx, solver, sig, freshs, node.start, node.end)
+	elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, node.start, node.end)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15123:5
-	elabCheckGenericBounds(cx, solver, sig.generics, sig.genericBounds, freshs, node.start, node.end)
+	instCheckBounds(cx, inst, sig.genericBounds, node.start, node.end)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15126:5
-	typeArgsConcrete := zonkList(cx.env, solver, freshs)
+	typeArgsConcrete := instConcreteArgs(cx, inst)
 	_ = typeArgsConcrete
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15127:5
 	if checkIntListLenHelper(typeArgsConcrete) > 0 {
@@ -34792,6 +34829,11 @@ func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expe
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15139:5
 	recvResolved := checkResolveAliasDeep(cx.env, recv.ty)
 	_ = recvResolved
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15139:9
+	if tyIsBad(cx.env.tys, recvResolved) {
+		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15140:13
+		return elabPoisonResult(cx, callNode.start, callNode.end)
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15140:5
 	ownerName := tyHeadAt(cx.env.tys, recvResolved)
 	_ = ownerName
@@ -34809,81 +34851,42 @@ func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expe
 			return struct{}{}
 		}()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15145:9
-		return elabErrResult(cx, callNode.start, callNode.end)
+		return elabPoisonResult(cx, callNode.start, callNode.end)
 	}
 	if checkStringListLenHelper(sig.generics) == 0 {
 		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, callNode.children, callNode.start, callNode.end)
 		retTy := sig.retTy
-		if !(tyIsErr(cx.env.tys, expected)) {
+		if !(tyIsBad(cx.env.tys, expected)) {
 			_ = checkExpectAssignable(cx.env, expected, retTy, callNode.start, callNode.end)
 		}
 		mcall := coreMethodCall(cx.core, recv.node, methodName, ownerName, coreArgs, make([]int, 0, 1), retTy, callNode.start, callNode.end)
 		return &ElabResult{node: mcall, ty: retTy}
 	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15148:5
-	solver := newSolver()
-	_ = solver
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15149:5
-	freshs := elabFreshenGenerics(cx, solver, sig.generics, fmt.Sprintf("%s.%s", ostyToString(ownerName), ostyToString(sig.name)))
-	_ = freshs
+	inst := instBegin(cx, sig.generics, fmt.Sprintf("%s.%s", ostyToString(ownerName), ostyToString(sig.name)))
+	_ = inst
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15152:5
 	typeSig := checkLookupType(cx.env, ownerName)
 	_ = typeSig
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15153:5
 	ownerArgs := tyArgsAt(cx.env.tys, recvResolved)
 	_ = ownerArgs
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15154:5
-	if checkStringListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15155:9
-		i := 0
-		_ = i
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15156:9
-		for _, ownerGeneric := range typeSig.generics {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15157:13
-			freshIdx := elabFindFresh(freshs, sig.generics, ownerGeneric)
-			_ = freshIdx
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15158:13
-			if freshIdx >= 0 {
-				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15159:17
-				_ = unify(cx.env, solver, checkIntListAt(freshs, freshIdx), checkIntListAt(ownerArgs, i))
-			}
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15161:13
-			func() {
-				var _cur2127 int = i
-				var _rhs2128 int = 1
-				if _rhs2128 > 0 && _cur2127 > math.MaxInt-_rhs2128 {
-					panic("integer overflow")
-				}
-				if _rhs2128 < 0 && _cur2127 < math.MinInt-_rhs2128 {
-					panic("integer overflow")
-				}
-				i = _cur2127 + _rhs2128
-			}()
-		}
-	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15165:5
-	if !(tyIsErr(cx.env.tys, expected)) {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15166:9
-		specialisedRet := checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
-		_ = specialisedRet
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15167:9
-		_ = unify(cx.env, solver, specialisedRet, expected)
-	}
+	instSeedOwnerArgs(cx, inst, typeSig.generics, ownerArgs)
+	instSeedExpectedRet(cx, inst, sig.retTy, expected)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15170:5
-	coreArgs := elabCallArgs(cx, solver, sig, freshs, callNode.children, callNode.start, callNode.end)
+	coreArgs := elabCallArgs(cx, inst.solver, sig, inst.freshs, callNode.children, callNode.start, callNode.end)
 	_ = coreArgs
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15171:5
-	retSubstituted := checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
+	retSubstituted := instSubstitute(cx, inst, sig.retTy)
 	_ = retSubstituted
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15172:5
-	retTy := zonk(cx.env, solver, retSubstituted)
+	retTy := instZonk(cx, inst, retSubstituted)
 	_ = retTy
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15173:5
-	elabReportUnresolvedGenerics(cx, solver, sig, freshs, callNode.start, callNode.end)
+	elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, callNode.start, callNode.end)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15174:5
-	elabCheckGenericBounds(cx, solver, sig.generics, sig.genericBounds, freshs, callNode.start, callNode.end)
+	instCheckBounds(cx, inst, sig.genericBounds, callNode.start, callNode.end)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15176:5
-	typeArgsConcrete := zonkList(cx.env, solver, freshs)
+	typeArgsConcrete := instConcreteArgs(cx, inst)
 	_ = typeArgsConcrete
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15177:5
 	if checkIntListLenHelper(typeArgsConcrete) > 0 {
@@ -34906,6 +34909,11 @@ func elabInferFnValueCall(cx *ElabCx, node *AstNode, argIdxs []int, expected int
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15202:5
 	fnTy := checkResolveAliasDeep(cx.env, callee.ty)
 	_ = fnTy
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15202:9
+	if tyIsBad(cx.env.tys, fnTy) {
+		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15203:13
+		return elabPoisonResult(cx, node.start, node.end)
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15203:5
 	if !ostyEqual(tyKindAt(cx.env.tys, fnTy), TyKind(&TyKind_TkFn{})) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15204:9
@@ -34914,7 +34922,7 @@ func elabInferFnValueCall(cx *ElabCx, node *AstNode, argIdxs []int, expected int
 			return struct{}{}
 		}()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15205:9
-		return elabErrResult(cx, node.start, node.end)
+		return elabPoisonResult(cx, node.start, node.end)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15207:5
 	paramTys := tyArgsAt(cx.env.tys, fnTy)
@@ -35085,6 +35093,62 @@ func elabCallArgsMonomorphic(cx *ElabCx, callee string, paramTys []int, argIdxs 
 		i++
 	}
 	return coreArgs
+}
+
+func instBegin(cx *ElabCx, generics []string, owner string) *InstSession {
+	solver := newSolver()
+	freshs := elabFreshenGenerics(cx, solver, generics, owner)
+	return &InstSession{solver: solver, generics: generics, freshs: freshs}
+}
+
+func instSubstitute(cx *ElabCx, inst *InstSession, ty int) int {
+	return checkSubstituteTy(cx.env, ty, inst.generics, inst.freshs)
+}
+
+func instSeedExpectedRet(cx *ElabCx, inst *InstSession, retTy int, expected int) {
+	if tyIsBad(cx.env.tys, expected) {
+		return
+	}
+	specialisedRet := instSubstitute(cx, inst, retTy)
+	_ = unify(cx.env, inst.solver, specialisedRet, expected)
+}
+
+func instSeedPositionalArgs(cx *ElabCx, inst *InstSession, args []int) {
+	if checkIntListLenHelper(args) != checkIntListLenHelper(inst.freshs) {
+		return
+	}
+	i := 0
+	for _, arg := range args {
+		fresh := checkIntListAt(inst.freshs, i)
+		_ = unify(cx.env, inst.solver, fresh, arg)
+		i++
+	}
+}
+
+func instSeedOwnerArgs(cx *ElabCx, inst *InstSession, ownerGenerics []string, ownerArgs []int) {
+	if checkStringListLenHelper(ownerGenerics) != checkIntListLenHelper(ownerArgs) {
+		return
+	}
+	i := 0
+	for _, ownerGeneric := range ownerGenerics {
+		freshIdx := elabFindFresh(inst.freshs, inst.generics, ownerGeneric)
+		if freshIdx >= 0 {
+			_ = unify(cx.env, inst.solver, checkIntListAt(inst.freshs, freshIdx), checkIntListAt(ownerArgs, i))
+		}
+		i++
+	}
+}
+
+func instZonk(cx *ElabCx, inst *InstSession, ty int) int {
+	return zonk(cx.env, inst.solver, ty)
+}
+
+func instConcreteArgs(cx *ElabCx, inst *InstSession) []int {
+	return zonkList(cx.env, inst.solver, inst.freshs)
+}
+
+func instCheckBounds(cx *ElabCx, inst *InstSession, bounds []*CheckGenericBound, start int, end int) {
+	elabCheckGenericBounds(cx, inst.solver, inst.generics, bounds, inst.freshs, start, end)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15274:1
@@ -35306,6 +35370,9 @@ func elabInferField(cx *ElabCx, node *AstNode) *ElabResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15398:5
 	recvTy := checkResolveAliasDeep(cx.env, recv.ty)
 	_ = recvTy
+	if tyIsBad(cx.env.tys, recvTy) {
+		return elabPoisonResult(cx, node.start, node.end)
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15399:5
 	kind := tyKindAt(cx.env.tys, recvTy)
 	_ = kind
@@ -35330,7 +35397,7 @@ func elabInferField(cx *ElabCx, node *AstNode) *ElabResult {
 					return struct{}{}
 				}()
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15412:17
-				return elabErrResult(cx, node.start, node.end)
+				return elabPoisonResult(cx, node.start, node.end)
 			}
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15414:13
 			elemTy := checkIntListAt(elems, idx)
@@ -35355,7 +35422,7 @@ func elabInferField(cx *ElabCx, node *AstNode) *ElabResult {
 					return struct{}{}
 				}()
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15423:17
-				return elabErrResult(cx, node.start, node.end)
+				return elabPoisonResult(cx, node.start, node.end)
 			}
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15426:13
 			typeSig := checkLookupType(cx.env, owner)
@@ -35383,7 +35450,7 @@ func elabInferField(cx *ElabCx, node *AstNode) *ElabResult {
 				cx.env.diagnostics = append(cx.env.diagnostics, diagUnknownField(tyToString(cx.env.tys, recvTy), fieldName, node.start, node.end))
 				return struct{}{}
 			}()
-			return elabErrResult(cx, node.start, node.end)
+			return elabPoisonResult(cx, node.start, node.end)
 		}
 	}()
 }
@@ -35557,6 +35624,9 @@ func elabInferIndex(cx *ElabCx, node *AstNode) *ElabResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15494:5
 	tys := cx.env.tys
 	_ = tys
+	if tyIsBad(tys, recvTy) || tyIsBad(tys, idx.ty) {
+		return elabPoisonResult(cx, node.start, node.end)
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15496:5
 	if tyIsNamedHead(tys, recvTy, "List") {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15497:9
@@ -35652,7 +35722,9 @@ func elabInferList(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		_ = elemHint
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15544:9
 		listTy := tyNamed(tys, "List", []int{func() int {
-			if tyIsErr(tys, elemHint) {
+			if tyIsPoison(tys, elemHint) {
+				return tPoison(tys)
+			} else if tyIsErr(tys, elemHint) {
 				return tErr(tys)
 			} else {
 				return elemHint
@@ -35686,7 +35758,7 @@ func elabInferList(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15557:5
 	for _, elemIdx := range elemIdxs {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15558:9
-		if tyIsErr(tys, elemTy) && i == 0 {
+		if tyIsBad(tys, elemTy) && i == 0 {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15560:13
 			r := elabInfer(cx, elemIdx)
 			_ = r
@@ -35779,7 +35851,7 @@ func elabInferMap(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		_ = valIdx
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15590:9
 		keyResult := func() *ElabResult {
-			if tyIsErr(tys, keyTy) {
+			if tyIsBad(tys, keyTy) {
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15591:13
 				r := elabInfer(cx, keyIdx)
 				_ = r
@@ -35796,7 +35868,7 @@ func elabInferMap(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		_ = keyResult
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15597:9
 		valResult := func() *ElabResult {
-			if tyIsErr(tys, valTy) {
+			if tyIsBad(tys, valTy) {
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15598:13
 				r := elabInfer(cx, valIdx)
 				_ = r
@@ -35872,7 +35944,7 @@ func elabInferTuple(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		_ = hint
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15631:9
 		r := func() *ElabResult {
-			if tyIsErr(tys, hint) {
+			if tyIsBad(tys, hint) {
 				return elabInfer(cx, elemIdx)
 			} else {
 				return elabCheck(cx, elemIdx, hint)
@@ -35932,42 +36004,17 @@ func elabInferStructLit(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 			return struct{}{}
 		}()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15658:9
-		return elabErrResult(cx, node.start, node.end)
+		return elabPoisonResult(cx, node.start, node.end)
 	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15661:5
-	solver := newSolver()
-	_ = solver
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15662:5
-	freshs := elabFreshenGenerics(cx, solver, typeSig.generics, owner)
-	_ = freshs
+	inst := instBegin(cx, typeSig.generics, owner)
+	_ = inst
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15665:5
 	if tyIsNamedHead(tys, expected, owner) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15666:9
 		expectedArgs := tyArgsAt(tys, expected)
 		_ = expectedArgs
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15667:9
-		if checkIntListLenHelper(expectedArgs) == checkIntListLenHelper(freshs) {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15668:13
-			i := 0
-			_ = i
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15669:13
-			for _, fresh := range freshs {
-				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15670:17
-				_ = unify(cx.env, solver, fresh, checkIntListAt(expectedArgs, i))
-				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15671:17
-				func() {
-					var _cur2154 int = i
-					var _rhs2155 int = 1
-					if _rhs2155 > 0 && _cur2154 > math.MaxInt-_rhs2155 {
-						panic("integer overflow")
-					}
-					if _rhs2155 < 0 && _cur2154 < math.MinInt-_rhs2155 {
-						panic("integer overflow")
-					}
-					i = _cur2154 + _rhs2155
-				}()
-			}
-		}
+		instSeedPositionalArgs(cx, inst, expectedArgs)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15681:5
 	coreSpread := -1
@@ -35978,7 +36025,7 @@ func elabInferStructLit(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15683:5
 	if node.right >= 0 {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15684:9
-		spreadHint := tyNamed(tys, owner, freshs)
+		spreadHint := tyNamed(tys, owner, inst.freshs)
 		_ = spreadHint
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15685:9
 		spreadResult := elabCheck(cx, node.right, spreadHint)
@@ -35986,7 +36033,7 @@ func elabInferStructLit(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15686:9
 		coreSpread = spreadResult.node
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15687:9
-		_ = unify(cx.env, solver, spreadHint, spreadResult.ty)
+		_ = unify(cx.env, inst.solver, spreadHint, spreadResult.ty)
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15688:9
 		if tyIsNamedHead(tys, spreadResult.ty, owner) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15689:13
@@ -36037,16 +36084,16 @@ func elabInferStructLit(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15710:9
 		func() struct{} { seenNames = append(seenNames, fieldName); return struct{}{} }()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15712:9
-		specialised := checkSubstituteTy(cx.env, fieldSig.ty, typeSig.generics, freshs)
+		specialised := instSubstitute(cx, inst, fieldSig.ty)
 		_ = specialised
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15713:9
-		hint := zonk(cx.env, solver, specialised)
+		hint := instZonk(cx, inst, specialised)
 		_ = hint
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15714:9
 		r := elabCheck(cx, fieldNode.left, hint)
 		_ = r
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15715:9
-		_ = unify(cx.env, solver, hint, r.ty)
+		_ = unify(cx.env, inst.solver, hint, r.ty)
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15716:9
 		func() struct{} {
 			coreFieldsList = append(coreFieldsList, coreStructField(cx.core, fieldName, r.node, fieldNode.start, fieldNode.end))
@@ -36065,9 +36112,9 @@ func elabInferStructLit(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		}
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15730:5
-	elabCheckGenericBounds(cx, solver, typeSig.generics, typeSig.genericBounds, freshs, node.start, node.end)
+	instCheckBounds(cx, inst, typeSig.genericBounds, node.start, node.end)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15731:5
-	concreteTypeArgs := zonkList(cx.env, solver, freshs)
+	concreteTypeArgs := instConcreteArgs(cx, inst)
 	_ = concreteTypeArgs
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15732:5
 	resultTy := func() int {
@@ -36223,7 +36270,7 @@ func elabInferClosure(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	_ = bodyIdx
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15806:5
 	body := func() *ElabResult {
-		if !(tyIsErr(tys, expectedRet)) {
+		if !(tyIsBad(tys, expectedRet)) {
 			return elabCheck(cx, bodyIdx, expectedRet)
 		} else {
 			return elabInfer(cx, bodyIdx)
@@ -36268,7 +36315,7 @@ func elabInferRange(cx *ElabCx, node *AstNode) *ElabResult {
 	}()
 	_ = hi
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15828:5
-	if !(tyIsInteger(tys, lo.ty)) && !(tyIsErr(tys, lo.ty)) {
+	if !(tyIsInteger(tys, lo.ty)) && !(tyIsBad(tys, lo.ty)) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15829:9
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagMismatch("Int", tyToString(tys, lo.ty), node.start, node.end))
@@ -36276,7 +36323,7 @@ func elabInferRange(cx *ElabCx, node *AstNode) *ElabResult {
 		}()
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15831:5
-	if !(tyIsInteger(tys, hi.ty)) && !(tyIsErr(tys, hi.ty)) {
+	if !(tyIsInteger(tys, hi.ty)) && !(tyIsBad(tys, hi.ty)) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15832:9
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagMismatch("Int", tyToString(tys, hi.ty), node.start, node.end))
@@ -36313,7 +36360,7 @@ func elabInferIf(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	cond := elabCheck(cx, node.left, tBool(tys))
 	_ = cond
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15855:5
-	hasExpected := !(tyIsErr(tys, expected))
+	hasExpected := !(tyIsBad(tys, expected))
 	_ = hasExpected
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15857:5
 	then_ := func() *ElabResult {
@@ -36369,12 +36416,12 @@ func elabInferIf(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15888:1
 func joinTypes(env *CheckEnv, a int, b int) int {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15889:5
-	if tyIsErr(env.tys, a) {
+	if tyIsBad(env.tys, a) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15890:9
 		return b
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15892:5
-	if tyIsErr(env.tys, b) {
+	if tyIsBad(env.tys, b) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15893:9
 		return a
 	}
@@ -36405,7 +36452,7 @@ func elabInferMatch(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	scrutTy := checkResolveAliasDeep(cx.env, scrutinee.ty)
 	_ = scrutTy
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15917:5
-	hasExpected := !(tyIsErr(cx.env.tys, expected))
+	hasExpected := !(tyIsBad(cx.env.tys, expected))
 	_ = hasExpected
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15919:5
 	var armNodes []int = make([]int, 0, 1)
@@ -36467,7 +36514,7 @@ func elabInferMatch(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		body := func() *ElabResult {
 			if hasExpected {
 				return elabCheck(cx, bodyIdx, expected)
-			} else if tyIsErr(cx.env.tys, resultTy) {
+			} else if tyIsBad(cx.env.tys, resultTy) {
 				return elabInfer(cx, bodyIdx)
 			} else {
 				return elabCheck(cx, bodyIdx, resultTy)
@@ -36475,7 +36522,7 @@ func elabInferMatch(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		}()
 		_ = body
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15946:9
-		if !hasExpected && tyIsErr(cx.env.tys, resultTy) && !bodyEscapes {
+		if !hasExpected && tyIsBad(cx.env.tys, resultTy) && !bodyEscapes {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15947:13
 			resultTy = body.ty
 		}
@@ -36555,6 +36602,9 @@ func elabInferQuestion(cx *ElabCx, node *AstNode) *ElabResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15988:5
 	retTy := checkResolveAliasDeep(cx.env, cx.env.returnTy)
 	_ = retTy
+	if tyIsBad(tys, innerTy) || tyIsBad(tys, retTy) {
+		return elabPoisonResult(cx, node.start, node.end)
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15990:5
 	if tyIsNamedHead(tys, innerTy, "Option") {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15991:9
@@ -36569,7 +36619,7 @@ func elabInferQuestion(cx *ElabCx, node *AstNode) *ElabResult {
 		payload := checkIntListAt(args, 0)
 		_ = payload
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15996:9
-		if !(tyIsNamedHead(tys, retTy, "Option")) && !(tyIsErr(tys, retTy)) {
+		if !(tyIsNamedHead(tys, retTy, "Option")) && !(tyIsBad(tys, retTy)) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15997:13
 			func() struct{} {
 				cx.env.diagnostics = append(cx.env.diagnostics, diagQuestionNotOptional(tyToString(tys, retTy), node.start, node.end))
@@ -36611,7 +36661,7 @@ func elabInferQuestion(cx *ElabCx, node *AstNode) *ElabResult {
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16014:17
 				_ = checkExpectAssignable(cx.env, outerErr, errTy, node.start, node.end)
 			}
-		} else if !(tyIsErr(tys, retTy)) {
+		} else if !(tyIsBad(tys, retTy)) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16017:13
 			func() struct{} {
 				cx.env.diagnostics = append(cx.env.diagnostics, diagQuestionNotOptional(tyToString(tys, retTy), node.start, node.end))
@@ -36625,14 +36675,14 @@ func elabInferQuestion(cx *ElabCx, node *AstNode) *ElabResult {
 		return &ElabResult{node: coreIdx, ty: payload}
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16023:5
-	if !(tyIsErr(tys, innerTy)) {
+	if !(tyIsBad(tys, innerTy)) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16024:9
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagQuestionNotOptional(tyToString(tys, innerTy), node.start, node.end))
 			return struct{}{}
 		}()
 	}
-	return elabErrResult(cx, node.start, node.end)
+	return elabPoisonResult(cx, node.start, node.end)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16033:5
@@ -36695,7 +36745,7 @@ func elabPatternMode(cx *ElabCx, idx int, scrutTy int, mutable bool, recordBindi
 		lit := elabInfer(cx, litIdx)
 		_ = lit
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16068:9
-		if !(checkIsAssignable(cx.env, scrutTy, lit.ty)) && !(tyIsErr(tys, lit.ty)) {
+		if !(checkIsAssignable(cx.env, scrutTy, lit.ty)) && !(tyIsBad(tys, lit.ty)) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16069:13
 			func() struct{} {
 				cx.env.diagnostics = append(cx.env.diagnostics, diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
@@ -36853,7 +36903,7 @@ func elabRangePattern(cx *ElabCx, node *AstNode, scrutTy int) int {
 	tys := cx.env.tys
 	_ = tys
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16157:5
-	if !(tyIsErr(tys, scrutTy)) && !(tyIsInteger(tys, scrutTy)) && !(tyIsPrim(tys, scrutTy, PrimKind(&PrimKind_PkChar{}))) {
+	if !(tyIsBad(tys, scrutTy)) && !(tyIsInteger(tys, scrutTy)) && !(tyIsPrim(tys, scrutTy, PrimKind(&PrimKind_PkChar{}))) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16160:9
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
@@ -37354,7 +37404,7 @@ func exhaustCheckMatch(cx *ElabCx, matchNode *AstNode, scrutTy int) {
 	tys := cx.env.tys
 	_ = tys
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16425:5
-	if tyIsErr(tys, scrutTy) {
+	if tyIsBad(tys, scrutTy) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16426:9
 		return
 	}
@@ -37663,7 +37713,7 @@ func reachCheckArms(cx *ElabCx, matchNode *AstNode, scrutTy int) {
 	tys := cx.env.tys
 	_ = tys
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16600:5
-	if tyIsErr(tys, scrutTy) {
+	if tyIsBad(tys, scrutTy) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16601:9
 		return
 	}
@@ -38421,7 +38471,7 @@ func pmCheckMatch(cx *ElabCx, matchNode *AstNode, scrutTy int) *PmCheckOutcome {
 	tys := cx.env.tys
 	_ = tys
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17068:5
-	if tyIsErr(tys, scrutTy) {
+	if tyIsBad(tys, scrutTy) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17069:9
 		return pmNotHandled()
 	}
@@ -41459,7 +41509,7 @@ func serializeCheckResult(cx *ElabCx) *FrontCheckResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18672:5
 	for _, node := range cx.core.nodes {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18673:9
-		if node.originAst < 0 || tyIsErr(cx.env.tys, node.ty) {
+		if node.originAst < 0 || tyIsBad(cx.env.tys, node.ty) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18674:13
 			continue
 		}

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -898,7 +898,7 @@ pub fn checkExpectAssignable(env: CheckEnv, expected: Int, got: Int, start: Int,
 pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
     let d = checkResolveAliasDeep(env, dst)
     let s = checkResolveAliasDeep(env, src)
-    if tyIsErr(env.tys, d) || tyIsErr(env.tys, s) {
+    if tyIsBad(env.tys, d) || tyIsBad(env.tys, s) {
         return true
     }
     if tyIsNamedHead(env.tys, d, "Any") || tyIsNamedHead(env.tys, s, "Any") {
@@ -993,7 +993,7 @@ pub fn checkIsAssignable(env: CheckEnv, dst: Int, src: Int) -> Bool {
 pub fn checkTypeSatisfiesInterface(env: CheckEnv, concrete: Int, iface: Int) -> Bool {
     let concreteResolved = checkResolveAliasDeep(env, concrete)
     let ifaceResolved = checkResolveAliasDeep(env, iface)
-    if tyIsErr(env.tys, concreteResolved) || tyIsErr(env.tys, ifaceResolved) {
+    if tyIsBad(env.tys, concreteResolved) || tyIsBad(env.tys, ifaceResolved) {
         return true
     }
     if tyEq(env.tys, concreteResolved, ifaceResolved) {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -58,6 +58,12 @@ pub struct ElabCx {
     pub env: CheckEnv,
 }
 
+pub struct InstSession {
+    pub solver: Solver,
+    pub generics: List<String>,
+    pub freshs: List<Int>,
+}
+
 pub fn newElabCx(ast: AstFile, tys: TyArena) -> ElabCx {
     let env = emptyCheckEnv(tys)
     checkInstallPrelude(env)
@@ -122,7 +128,7 @@ fn elabCheckImpl(cx: ElabCx, idx: Int, expected: Int) -> ElabResult {
     if idx < 0 {
         return elabErrResult(cx, 0, 0)
     }
-    if tyIsErr(cx.env.tys, expected) {
+    if tyIsBad(cx.env.tys, expected) {
         return elabInferImpl(cx, idx)
     }
     let node = astArenaNodeAt(cx.ast.arena, idx)
@@ -149,7 +155,7 @@ fn elabCheckImpl(cx: ElabCx, idx: Int, expected: Int) -> ElabResult {
 /// needed.
 fn elabCheckViaInfer(cx: ElabCx, idx: Int, expected: Int) -> ElabResult {
     let r = elabInferImpl(cx, idx)
-    if !(tyIsErr(cx.env.tys, r.ty)) {
+    if !(tyIsBad(cx.env.tys, r.ty)) {
         let start = coreStartAt(cx.core, r.node)
         let end = coreEndAt(cx.core, r.node)
         let _ = checkExpectAssignable(cx.env, expected, r.ty, start, end)
@@ -247,7 +253,7 @@ fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
         // directly and bypasses this site, so calls are unaffected.
         if checkStringListLenHelper(fnSig.generics) > 0 {
             cx.env.diagnostics.push(diagGenericCallableReference(node.text, node.start, node.end))
-            return elabErrResult(cx, node.start, node.end)
+            return elabPoisonResult(cx, node.start, node.end)
         }
         let fnTy = fnSigToTy(cx.env, fnSig)
         let coreIdx = coreIdent(cx.core, node.text, IkFn, fnTy, node.start, node.end)
@@ -255,7 +261,7 @@ fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
     }
     // Fall through — unknown name.
     cx.env.diagnostics.push(diagUnknownName(node.text, node.start, node.end))
-    elabErrResult(cx, node.start, node.end)
+    elabPoisonResult(cx, node.start, node.end)
 }
 
 /// fnSigToTy builds an `fn(params) -> ret` type from a CheckFnSig.
@@ -278,7 +284,7 @@ fn elabInferUnary(cx: ElabCx, node: AstNode) -> ElabResult {
 
 fn unOpResultType(env: CheckEnv, op: UnOp, inner: Int, start: Int, end: Int) -> Int {
     let tys = env.tys
-    if tyIsErr(tys, inner) {
+    if tyIsBad(tys, inner) {
         return inner
     }
     // Each arm delegates to a helper so the match body stays a
@@ -340,7 +346,10 @@ fn elabInferBinary(cx: ElabCx, node: AstNode) -> ElabResult {
 
 fn binOpResultType(env: CheckEnv, op: BinOp, left: Int, right: Int, start: Int, end: Int) -> Int {
     let tys = env.tys
-    if tyIsErr(tys, left) || tyIsErr(tys, right) {
+    if tyIsBad(tys, left) || tyIsBad(tys, right) {
+        if tyIsPoison(tys, left) || tyIsPoison(tys, right) {
+            return tPoison(tys)
+        }
         return tErr(tys)
     }
     match op {
@@ -611,7 +620,7 @@ fn elabAssignableTarget(cx: ElabCx, idx: Int) -> ElabResult {
 fn elabReturnStmt(cx: ElabCx, node: AstNode) -> Int {
     let expected = cx.env.returnTy
     let valueIdx = node.left
-    let value = if valueIdx >= 0 && !(tyIsErr(cx.env.tys, expected)) {
+    let value = if valueIdx >= 0 && !(tyIsBad(cx.env.tys, expected)) {
         elabCheck(cx, valueIdx, expected)
     } else if valueIdx >= 0 {
         elabInfer(cx, valueIdx)
@@ -635,7 +644,7 @@ fn elabDeferStmt(cx: ElabCx, node: AstNode) -> Int {
 fn elabChanSendStmt(cx: ElabCx, node: AstNode) -> Int {
     let channel = elabInfer(cx, node.left)
     let elemTy = elabChannelElemTy(cx, channel.ty, node.start, node.end)
-    let value = if tyIsErr(cx.env.tys, elemTy) {
+    let value = if tyIsBad(cx.env.tys, elemTy) {
         elabInfer(cx, node.right)
     } else {
         elabCheck(cx, node.right, elemTy)
@@ -718,7 +727,10 @@ fn elabChannelElemTy(cx: ElabCx, ty: Int, start: Int, end: Int) -> Int {
             return checkIntListAt(args, 0)
         }
     }
-    if !(tyIsErr(tys, resolved)) {
+    if tyIsBad(tys, resolved) {
+        return resolved
+    }
+    if !(tyIsBad(tys, resolved)) {
         cx.env.diagnostics.push(diagOperandType("<-", tyToString(tys, resolved), start, end))
     }
     tErr(tys)
@@ -727,8 +739,8 @@ fn elabChannelElemTy(cx: ElabCx, ty: Int, start: Int, end: Int) -> Int {
 fn elabForIterableElemTy(cx: ElabCx, ty: Int, start: Int, end: Int) -> Int {
     let tys = cx.env.tys
     let resolved = checkResolveAliasDeep(cx.env, ty)
-    if tyIsErr(tys, resolved) {
-        return tErr(tys)
+    if tyIsBad(tys, resolved) {
+        return resolved
     }
     if tyIsPrim(tys, resolved, PkString) {
         return tChar(tys)
@@ -849,7 +861,7 @@ fn astBlockEscapesMatchResult(ast: AstFile, node: AstNode) -> Bool {
 }
 
 fn elabRecordTypedExpr(cx: ElabCx, idx: Int, out: ElabResult) {
-    if idx < 0 || out.node < 0 || tyIsErr(cx.env.tys, out.ty) {
+    if idx < 0 || out.node < 0 || tyIsBad(cx.env.tys, out.ty) {
         return
     }
     coreSetOrigin(cx.core, out.node, idx)
@@ -947,6 +959,12 @@ fn elabErrResult(cx: ElabCx, start: Int, end: Int) -> ElabResult {
     ElabResult { node, ty }
 }
 
+fn elabPoisonResult(cx: ElabCx, start: Int, end: Int) -> ElabResult {
+    let ty = tPoison(cx.env.tys)
+    let node = coreErrExpr(cx.core, ty, start, end)
+    ElabResult { node, ty }
+}
+
 fn checkIntListLenHelper(xs: List<Int>) -> Int {
     let mut n = 0
     for x in xs {
@@ -1016,51 +1034,40 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
     let sig = checkLookupFn(cx.env, baseCallee.text, "")
     if sig.name == "" {
         cx.env.diagnostics.push(diagUnknownName(baseCallee.text, baseCallee.start, baseCallee.end))
-        return elabErrResult(cx, node.start, node.end)
+        return elabPoisonResult(cx, node.start, node.end)
     }
 
     if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
         let coreFn = coreIdent(cx.core, baseCallee.text, IkFn, fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
         let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
         let retTy = sig.retTy
-        if !(tyIsErr(cx.env.tys, expected)) {
+        if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
         }
         let coreCallNode = coreCall(cx.core, coreFn, coreArgs, [], retTy, node.start, node.end)
         return ElabResult { node: coreCallNode, ty: retTy }
     }
 
-    let solver = newSolver()
-    let freshs = elabFreshenGenerics(cx, solver, sig.generics, sig.name)
+    let inst = instBegin(cx, sig.generics, sig.name)
 
     // Seed expected type into the solver if it shapes the return.
-    if !(tyIsErr(cx.env.tys, expected)) {
-        let specialisedRet = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
-        let _ = unify(cx.env, solver, specialisedRet, expected)
-    }
+    instSeedExpectedRet(cx, inst, sig.retTy, expected)
 
     // Respect explicit turbofish args if supplied.
-    if checkIntListLenHelper(explicitArgs) == checkIntListLenHelper(freshs) {
-        let mut i = 0
-        for explicit in explicitArgs {
-            let fresh = checkIntListAt(freshs, i)
-            let _ = unify(cx.env, solver, fresh, explicit)
-            i = i + 1
-        }
-    }
+    instSeedPositionalArgs(cx, inst, explicitArgs)
 
     let coreFn = coreIdent(cx.core, baseCallee.text, IkFn, fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
-    let coreArgs = elabCallArgs(cx, solver, sig, freshs, argIdxs, node.start, node.end)
+    let coreArgs = elabCallArgs(cx, inst.solver, sig, inst.freshs, argIdxs, node.start, node.end)
 
-    let retSubstituted = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
-    let retTy = zonk(cx.env, solver, retSubstituted)
+    let retSubstituted = instSubstitute(cx, inst, sig.retTy)
+    let retTy = instZonk(cx, inst, retSubstituted)
 
     // Verify every type parameter is now resolved.
-    elabReportUnresolvedGenerics(cx, solver, sig, freshs, node.start, node.end)
-    elabCheckGenericBounds(cx, solver, sig.generics, sig.genericBounds, freshs, node.start, node.end)
+    elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, node.start, node.end)
+    instCheckBounds(cx, inst, sig.genericBounds, node.start, node.end)
 
     // Record instantiation for the bridge summary.
-    let typeArgsConcrete = zonkList(cx.env, solver, freshs)
+    let typeArgsConcrete = instConcreteArgs(cx, inst)
     if checkIntListLenHelper(typeArgsConcrete) > 0 {
         checkRecordInstantiation(cx.env, callIdx, sig.name, typeArgsConcrete, retTy, node.start, node.end)
     }
@@ -1074,18 +1081,21 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
 fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expected: Int) -> ElabResult {
     let recv = elabInfer(cx, fieldNode.left)
     let recvResolved = checkResolveAliasDeep(cx.env, recv.ty)
+    if tyIsBad(cx.env.tys, recvResolved) {
+        return elabPoisonResult(cx, callNode.start, callNode.end)
+    }
     let ownerName = tyHeadAt(cx.env.tys, recvResolved)
     let methodName = fieldNode.text
     let sig = checkLookupMethod(cx.env, ownerName, methodName)
     if sig.name == "" {
         cx.env.diagnostics.push(diagUnknownMethod(ownerName, methodName, fieldNode.start, fieldNode.end))
-        return elabErrResult(cx, callNode.start, callNode.end)
+        return elabPoisonResult(cx, callNode.start, callNode.end)
     }
 
     if checkStringListLenHelper(sig.generics) == 0 {
         let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, callNode.children, callNode.start, callNode.end)
         let retTy = sig.retTy
-        if !(tyIsErr(cx.env.tys, expected)) {
+        if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, callNode.start, callNode.end)
         }
         let mcall = coreMethodCall(
@@ -1102,35 +1112,21 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
         return ElabResult { node: mcall, ty: retTy }
     }
 
-    let solver = newSolver()
-    let freshs = elabFreshenGenerics(cx, solver, sig.generics, "{ownerName}.{sig.name}")
+    let inst = instBegin(cx, sig.generics, "{ownerName}.{sig.name}")
 
     // Bind the receiver type params against the receiver's concrete args.
     let typeSig = checkLookupType(cx.env, ownerName)
     let ownerArgs = tyArgsAt(cx.env.tys, recvResolved)
-    if checkStringListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {
-        let mut i = 0
-        for ownerGeneric in typeSig.generics {
-            let freshIdx = elabFindFresh(freshs, sig.generics, ownerGeneric)
-            if freshIdx >= 0 {
-                let _ = unify(cx.env, solver, checkIntListAt(freshs, freshIdx), checkIntListAt(ownerArgs, i))
-            }
-            i = i + 1
-        }
-    }
+    instSeedOwnerArgs(cx, inst, typeSig.generics, ownerArgs)
+    instSeedExpectedRet(cx, inst, sig.retTy, expected)
 
-    if !(tyIsErr(cx.env.tys, expected)) {
-        let specialisedRet = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
-        let _ = unify(cx.env, solver, specialisedRet, expected)
-    }
+    let coreArgs = elabCallArgs(cx, inst.solver, sig, inst.freshs, callNode.children, callNode.start, callNode.end)
+    let retSubstituted = instSubstitute(cx, inst, sig.retTy)
+    let retTy = instZonk(cx, inst, retSubstituted)
+    elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, callNode.start, callNode.end)
+    instCheckBounds(cx, inst, sig.genericBounds, callNode.start, callNode.end)
 
-    let coreArgs = elabCallArgs(cx, solver, sig, freshs, callNode.children, callNode.start, callNode.end)
-    let retSubstituted = checkSubstituteTy(cx.env, sig.retTy, sig.generics, freshs)
-    let retTy = zonk(cx.env, solver, retSubstituted)
-    elabReportUnresolvedGenerics(cx, solver, sig, freshs, callNode.start, callNode.end)
-    elabCheckGenericBounds(cx, solver, sig.generics, sig.genericBounds, freshs, callNode.start, callNode.end)
-
-    let typeArgsConcrete = zonkList(cx.env, solver, freshs)
+    let typeArgsConcrete = instConcreteArgs(cx, inst)
     if checkIntListLenHelper(typeArgsConcrete) > 0 {
         checkRecordInstantiation(cx.env, -1, "{ownerName}.{sig.name}", typeArgsConcrete, retTy, callNode.start, callNode.end)
     }
@@ -1157,9 +1153,12 @@ fn elabInferFnValueCall(cx: ElabCx, node: AstNode, argIdxs: List<Int>, expected:
     let _ = expected
     let callee = elabInfer(cx, node.left)
     let fnTy = checkResolveAliasDeep(cx.env, callee.ty)
+    if tyIsBad(cx.env.tys, fnTy) {
+        return elabPoisonResult(cx, node.start, node.end)
+    }
     if tyKindAt(cx.env.tys, fnTy) != TkFn {
         cx.env.diagnostics.push(diagNotCallable(tyToString(cx.env.tys, fnTy), node.start, node.end))
-        return elabErrResult(cx, node.start, node.end)
+        return elabPoisonResult(cx, node.start, node.end)
     }
     let paramTys = tyArgsAt(cx.env.tys, fnTy)
     let retTy = tyRetAt(cx.env.tys, fnTy)
@@ -1253,6 +1252,62 @@ fn elabCallArgsMonomorphic(
         i = i + 1
     }
     coreArgs
+}
+
+fn instBegin(cx: ElabCx, generics: List<String>, owner: String) -> InstSession {
+    let solver = newSolver()
+    let freshs = elabFreshenGenerics(cx, solver, generics, owner)
+    InstSession { solver, generics, freshs }
+}
+
+fn instSubstitute(cx: ElabCx, inst: InstSession, ty: Int) -> Int {
+    checkSubstituteTy(cx.env, ty, inst.generics, inst.freshs)
+}
+
+fn instSeedExpectedRet(cx: ElabCx, inst: InstSession, retTy: Int, expected: Int) {
+    if tyIsBad(cx.env.tys, expected) {
+        return
+    }
+    let specialisedRet = instSubstitute(cx, inst, retTy)
+    let _ = unify(cx.env, inst.solver, specialisedRet, expected)
+}
+
+fn instSeedPositionalArgs(cx: ElabCx, inst: InstSession, args: List<Int>) {
+    if checkIntListLenHelper(args) != checkIntListLenHelper(inst.freshs) {
+        return
+    }
+    let mut i = 0
+    for arg in args {
+        let fresh = checkIntListAt(inst.freshs, i)
+        let _ = unify(cx.env, inst.solver, fresh, arg)
+        i = i + 1
+    }
+}
+
+fn instSeedOwnerArgs(cx: ElabCx, inst: InstSession, ownerGenerics: List<String>, ownerArgs: List<Int>) {
+    if checkStringListLenHelper(ownerGenerics) != checkIntListLenHelper(ownerArgs) {
+        return
+    }
+    let mut i = 0
+    for ownerGeneric in ownerGenerics {
+        let freshIdx = elabFindFresh(inst.freshs, inst.generics, ownerGeneric)
+        if freshIdx >= 0 {
+            let _ = unify(cx.env, inst.solver, checkIntListAt(inst.freshs, freshIdx), checkIntListAt(ownerArgs, i))
+        }
+        i = i + 1
+    }
+}
+
+fn instZonk(cx: ElabCx, inst: InstSession, ty: Int) -> Int {
+    zonk(cx.env, inst.solver, ty)
+}
+
+fn instConcreteArgs(cx: ElabCx, inst: InstSession) -> List<Int> {
+    zonkList(cx.env, inst.solver, inst.freshs)
+}
+
+fn instCheckBounds(cx: ElabCx, inst: InstSession, bounds: List<CheckGenericBound>, start: Int, end: Int) {
+    elabCheckGenericBounds(cx, inst.solver, inst.generics, bounds, inst.freshs, start, end)
 }
 
 /// elabFreshenGenerics allocates one TyVar per generic in `generics`,
@@ -1382,6 +1437,9 @@ fn elabInferTurbofish(cx: ElabCx, node: AstNode) -> ElabResult {
 fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
     let recv = elabInfer(cx, node.left)
     let recvTy = checkResolveAliasDeep(cx.env, recv.ty)
+    if tyIsBad(cx.env.tys, recvTy) {
+        return elabPoisonResult(cx, node.start, node.end)
+    }
     let kind = tyKindAt(cx.env.tys, recvTy)
     let fieldName = node.text
     match kind {
@@ -1395,7 +1453,7 @@ fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
                     node.start,
                     node.end,
                 ))
-                return elabErrResult(cx, node.start, node.end)
+                return elabPoisonResult(cx, node.start, node.end)
             }
             let elemTy = checkIntListAt(elems, idx)
             let coreIdx = coreTupleAccess(cx.core, recv.node, idx, elemTy, node.start, node.end)
@@ -1406,7 +1464,7 @@ fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
             let fieldSig = checkLookupField(cx.env, owner, fieldName)
             if fieldSig.name == "" {
                 cx.env.diagnostics.push(diagUnknownField(owner, fieldName, node.start, node.end))
-                return elabErrResult(cx, node.start, node.end)
+                return elabPoisonResult(cx, node.start, node.end)
             }
             // Substitute owner generics.
             let typeSig = checkLookupType(cx.env, owner)
@@ -1426,7 +1484,7 @@ fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
                 node.start,
                 node.end,
             ))
-            elabErrResult(cx, node.start, node.end)
+            elabPoisonResult(cx, node.start, node.end)
         },
     }
 }
@@ -1478,6 +1536,9 @@ fn elabInferIndex(cx: ElabCx, node: AstNode) -> ElabResult {
     let idx = elabInfer(cx, node.right)
     let recvTy = checkResolveAliasDeep(cx.env, recv.ty)
     let tys = cx.env.tys
+    if tyIsBad(tys, recvTy) || tyIsBad(tys, idx.ty) {
+        return elabPoisonResult(cx, node.start, node.end)
+    }
     // List<T>[Int] → T
     if tyIsNamedHead(tys, recvTy, "List") {
         let args = tyArgsAt(tys, recvTy)
@@ -1510,7 +1571,7 @@ fn elabInferIndex(cx: ElabCx, node: AstNode) -> ElabResult {
         return ElabResult { node: coreIdx, ty: tChar(tys) }
     }
     cx.env.diagnostics.push(diagUnknownField(tyToString(tys, recvTy), "[]", node.start, node.end))
-    elabErrResult(cx, node.start, node.end)
+    elabPoisonResult(cx, node.start, node.end)
 }
 
 // ---------------------------------------------------------------------
@@ -1527,7 +1588,7 @@ fn elabInferList(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         } else {
             tErr(tys)
         }
-        let listTy = tyNamed(tys, "List", [if tyIsErr(tys, elemHint) { tErr(tys) } else { elemHint }])
+        let listTy = tyNamed(tys, "List", [if tyIsPoison(tys, elemHint) { tPoison(tys) } else if tyIsErr(tys, elemHint) { tErr(tys) } else { elemHint }])
         let coreIdx = coreList(cx.core, [], listTy, node.start, node.end)
         return ElabResult { node: coreIdx, ty: listTy }
     }
@@ -1541,7 +1602,7 @@ fn elabInferList(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     let mut elemTy = outerElem
     let mut i = 0
     for elemIdx in elemIdxs {
-        if tyIsErr(tys, elemTy) && i == 0 {
+        if tyIsBad(tys, elemTy) && i == 0 {
             // Infer from first element.
             let r = elabInfer(cx, elemIdx)
             elemTy = r.ty
@@ -1573,14 +1634,14 @@ fn elabInferMap(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         let entryNode = astArenaNodeAt(cx.ast.arena, entryIdx)
         let keyIdx = entryNode.left
         let valIdx = entryNode.right
-        let keyResult = if tyIsErr(tys, keyTy) {
+        let keyResult = if tyIsBad(tys, keyTy) {
             let r = elabInfer(cx, keyIdx)
             if first { keyTy = r.ty }
             r
         } else {
             elabCheck(cx, keyIdx, keyTy)
         }
-        let valResult = if tyIsErr(tys, valTy) {
+        let valResult = if tyIsBad(tys, valTy) {
             let r = elabInfer(cx, valIdx)
             if first { valTy = r.ty }
             r
@@ -1614,7 +1675,7 @@ fn elabInferTuple(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         } else {
             tErr(tys)
         }
-        let r = if tyIsErr(tys, hint) {
+        let r = if tyIsBad(tys, hint) {
             elabInfer(cx, elemIdx)
         } else {
             elabCheck(cx, elemIdx, hint)
@@ -1641,22 +1702,15 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     let typeSig = checkLookupType(cx.env, owner)
     if typeSig.name == "" {
         cx.env.diagnostics.push(diagUnknownName(owner, node.start, node.end))
-        return elabErrResult(cx, node.start, node.end)
+        return elabPoisonResult(cx, node.start, node.end)
     }
 
-    let solver = newSolver()
-    let freshs = elabFreshenGenerics(cx, solver, typeSig.generics, owner)
+    let inst = instBegin(cx, typeSig.generics, owner)
 
     // Seed from expected if it matches the same owner head.
     if tyIsNamedHead(tys, expected, owner) {
         let expectedArgs = tyArgsAt(tys, expected)
-        if checkIntListLenHelper(expectedArgs) == checkIntListLenHelper(freshs) {
-            let mut i = 0
-            for fresh in freshs {
-                let _ = unify(cx.env, solver, fresh, checkIntListAt(expectedArgs, i))
-                i = i + 1
-            }
-        }
+        instSeedPositionalArgs(cx, inst, expectedArgs)
     }
 
     // Struct literal spread: `{ ..x, f: v, ... }`. The spread operand must
@@ -1667,10 +1721,10 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     let mut coreSpread = -1
     let mut spreadSupplied: List<String> = []
     if node.right >= 0 {
-        let spreadHint = tyNamed(tys, owner, freshs)
+        let spreadHint = tyNamed(tys, owner, inst.freshs)
         let spreadResult = elabCheck(cx, node.right, spreadHint)
         coreSpread = spreadResult.node
-        let _ = unify(cx.env, solver, spreadHint, spreadResult.ty)
+        let _ = unify(cx.env, inst.solver, spreadHint, spreadResult.ty)
         if tyIsNamedHead(tys, spreadResult.ty, owner) {
             for f in cx.env.fields {
                 if f.owner == owner {
@@ -1695,10 +1749,10 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         }
         seenNames.push(fieldName)
 
-        let specialised = checkSubstituteTy(cx.env, fieldSig.ty, typeSig.generics, freshs)
-        let hint = zonk(cx.env, solver, specialised)
+        let specialised = instSubstitute(cx, inst, fieldSig.ty)
+        let hint = instZonk(cx, inst, specialised)
         let r = elabCheck(cx, fieldNode.left, hint)
-        let _ = unify(cx.env, solver, hint, r.ty)
+        let _ = unify(cx.env, inst.solver, hint, r.ty)
         coreFieldsList.push(coreStructField(cx.core, fieldName, r.node, fieldNode.start, fieldNode.end))
     }
 
@@ -1713,8 +1767,8 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         }
     }
 
-    elabCheckGenericBounds(cx, solver, typeSig.generics, typeSig.genericBounds, freshs, node.start, node.end)
-    let concreteTypeArgs = zonkList(cx.env, solver, freshs)
+    instCheckBounds(cx, inst, typeSig.genericBounds, node.start, node.end)
+    let concreteTypeArgs = instConcreteArgs(cx, inst)
     let resultTy = if checkIntListLenHelper(concreteTypeArgs) == 0 {
         tyNamed(tys, owner, [])
     } else {
@@ -1789,7 +1843,7 @@ fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     }
 
     let bodyIdx = node.left
-    let body = if !(tyIsErr(tys, expectedRet)) {
+    let body = if !(tyIsBad(tys, expectedRet)) {
         elabCheck(cx, bodyIdx, expectedRet)
     } else {
         elabInfer(cx, bodyIdx)
@@ -1811,10 +1865,10 @@ fn elabInferRange(cx: ElabCx, node: AstNode) -> ElabResult {
     let tys = cx.env.tys
     let lo = if node.left >= 0 { elabInfer(cx, node.left) } else { ElabResult { node: -1, ty: tInt(tys) } }
     let hi = if node.right >= 0 { elabInfer(cx, node.right) } else { ElabResult { node: -1, ty: tInt(tys) } }
-    if !(tyIsInteger(tys, lo.ty)) && !(tyIsErr(tys, lo.ty)) {
+    if !(tyIsInteger(tys, lo.ty)) && !(tyIsBad(tys, lo.ty)) {
         cx.env.diagnostics.push(diagMismatch("Int", tyToString(tys, lo.ty), node.start, node.end))
     }
-    if !(tyIsInteger(tys, hi.ty)) && !(tyIsErr(tys, hi.ty)) {
+    if !(tyIsInteger(tys, hi.ty)) && !(tyIsBad(tys, hi.ty)) {
         cx.env.diagnostics.push(diagMismatch("Int", tyToString(tys, hi.ty), node.start, node.end))
     }
     // Range result type mirrors the shared operand prim (Int in the
@@ -1838,7 +1892,7 @@ fn elabInferRange(cx: ElabCx, node: AstNode) -> ElabResult {
 fn elabInferIf(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     let tys = cx.env.tys
     let cond = elabCheck(cx, node.left, tBool(tys))
-    let hasExpected = !(tyIsErr(tys, expected))
+    let hasExpected = !(tyIsBad(tys, expected))
 
     let then_ = if hasExpected {
         elabCheck(cx, node.right, expected)
@@ -1872,10 +1926,10 @@ fn elabInferIf(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
 /// back to the first when they are incompatible so downstream
 /// diagnostics stay anchored to the if.
 fn joinTypes(env: CheckEnv, a: Int, b: Int) -> Int {
-    if tyIsErr(env.tys, a) {
+    if tyIsBad(env.tys, a) {
         return b
     }
-    if tyIsErr(env.tys, b) {
+    if tyIsBad(env.tys, b) {
         return a
     }
     if tyEq(env.tys, a, b) {
@@ -1900,7 +1954,7 @@ fn joinTypes(env: CheckEnv, a: Int, b: Int) -> Int {
 fn elabInferMatch(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     let scrutinee = elabInfer(cx, node.left)
     let scrutTy = checkResolveAliasDeep(cx.env, scrutinee.ty)
-    let hasExpected = !(tyIsErr(cx.env.tys, expected))
+    let hasExpected = !(tyIsBad(cx.env.tys, expected))
 
     let mut armNodes: List<Int> = []
     let mut resultTy = if hasExpected { expected } else { tErr(cx.env.tys) }
@@ -1929,12 +1983,12 @@ fn elabInferMatch(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         let bodyEscapes = astExprEscapesMatchResult(cx.ast, bodyIdx)
         let body = if hasExpected {
             elabCheck(cx, bodyIdx, expected)
-        } else if tyIsErr(cx.env.tys, resultTy) {
+        } else if tyIsBad(cx.env.tys, resultTy) {
             elabInfer(cx, bodyIdx)
         } else {
             elabCheck(cx, bodyIdx, resultTy)
         }
-        if !hasExpected && tyIsErr(cx.env.tys, resultTy) && !bodyEscapes {
+        if !hasExpected && tyIsBad(cx.env.tys, resultTy) && !bodyEscapes {
             resultTy = body.ty
         }
 
@@ -1977,6 +2031,9 @@ fn elabInferQuestion(cx: ElabCx, node: AstNode) -> ElabResult {
     let inner = elabInfer(cx, node.left)
     let innerTy = checkResolveAliasDeep(cx.env, inner.ty)
     let retTy = checkResolveAliasDeep(cx.env, cx.env.returnTy)
+    if tyIsBad(tys, innerTy) || tyIsBad(tys, retTy) {
+        return elabPoisonResult(cx, node.start, node.end)
+    }
 
     if tyIsNamedHead(tys, innerTy, "Option") {
         let args = tyArgsAt(tys, innerTy)
@@ -1984,7 +2041,7 @@ fn elabInferQuestion(cx: ElabCx, node: AstNode) -> ElabResult {
             return elabErrResult(cx, node.start, node.end)
         }
         let payload = checkIntListAt(args, 0)
-        if !(tyIsNamedHead(tys, retTy, "Option")) && !(tyIsErr(tys, retTy)) {
+        if !(tyIsNamedHead(tys, retTy, "Option")) && !(tyIsBad(tys, retTy)) {
             cx.env.diagnostics.push(diagQuestionNotOptional(tyToString(tys, retTy), node.start, node.end))
         }
         let coreIdx = coreQuestion(cx.core, inner.node, payload, node.start, node.end)
@@ -2004,14 +2061,14 @@ fn elabInferQuestion(cx: ElabCx, node: AstNode) -> ElabResult {
                 let outerErr = checkIntListAt(retArgs, 1)
                 let _ = checkExpectAssignable(cx.env, outerErr, errTy, node.start, node.end)
             }
-        } else if !(tyIsErr(tys, retTy)) {
+        } else if !(tyIsBad(tys, retTy)) {
             cx.env.diagnostics.push(diagQuestionNotOptional(tyToString(tys, retTy), node.start, node.end))
         }
         let coreIdx = coreQuestion(cx.core, inner.node, payload, node.start, node.end)
         return ElabResult { node: coreIdx, ty: payload }
     }
 
-    if !(tyIsErr(tys, innerTy)) {
+    if !(tyIsBad(tys, innerTy)) {
         cx.env.diagnostics.push(diagQuestionNotOptional(tyToString(tys, innerTy), node.start, node.end))
     }
     elabErrResult(cx, node.start, node.end)
@@ -2056,7 +2113,7 @@ fn elabPatternMode(cx: ElabCx, idx: Int, scrutTy: Int, mutable: Bool, recordBind
     if kind == "lit" {
         let litIdx = node.left
         let lit = elabInfer(cx, litIdx)
-        if !(checkIsAssignable(cx.env, scrutTy, lit.ty)) && !(tyIsErr(tys, lit.ty)) {
+        if !(checkIsAssignable(cx.env, scrutTy, lit.ty)) && !(tyIsBad(tys, lit.ty)) {
             cx.env.diagnostics.push(diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
         }
         return corePatLit(cx.core, lit.node, scrutTy, node.start, node.end)
@@ -2145,7 +2202,7 @@ fn elabRangePattern(cx: ElabCx, node: AstNode, scrutTy: Int) -> Int {
     // Core IR round-trips correctly. Validate that the scrutinee is an
     // ordered type (integer / char) and emit E0742 otherwise.
     let tys = cx.env.tys
-    if !(tyIsErr(tys, scrutTy))
+    if !(tyIsBad(tys, scrutTy))
         && !(tyIsInteger(tys, scrutTy))
         && !(tyIsPrim(tys, scrutTy, PkChar)) {
         cx.env.diagnostics.push(diagPatternShapeMismatch(tyToString(tys, scrutTy), node.start, node.end))
@@ -2413,7 +2470,7 @@ fn anyUnguardedIrrefutableArm(cx: ElabCx, matchNode: AstNode, scrutTy: Int) -> B
 
 fn exhaustCheckMatch(cx: ElabCx, matchNode: AstNode, scrutTy: Int) {
     let tys = cx.env.tys
-    if tyIsErr(tys, scrutTy) {
+    if tyIsBad(tys, scrutTy) {
         return
     }
     if anyUnguardedIrrefutableArm(cx, matchNode, scrutTy) {
@@ -2588,7 +2645,7 @@ fn variantSubsAllIrrefutable(cx: ElabCx, p: AstNode, v: CheckVariantSig) -> Bool
 
 fn reachCheckArms(cx: ElabCx, matchNode: AstNode, scrutTy: Int) {
     let tys = cx.env.tys
-    if tyIsErr(tys, scrutTy) {
+    if tyIsBad(tys, scrutTy) {
         return
     }
     let isBool = tyIsPrim(tys, scrutTy, PkBool)
@@ -3056,7 +3113,7 @@ fn pmNotHandled() -> PmCheckOutcome {
 /// Phase 1 logic in that case.
 fn pmCheckMatch(cx: ElabCx, matchNode: AstNode, scrutTy: Int) -> PmCheckOutcome {
     let tys = cx.env.tys
-    if tyIsErr(tys, scrutTy) {
+    if tyIsBad(tys, scrutTy) {
         return pmNotHandled()
     }
     if !(pmTypeSupported(cx, scrutTy)) {

--- a/toolchain/solve.osty
+++ b/toolchain/solve.osty
@@ -157,9 +157,9 @@ fn unifyAt(env: CheckEnv, solver: Solver, aIn: Int, bIn: Int, depth: Int) -> Boo
     let aKind = tyKindAt(env.tys, a)
     let bKind = tyKindAt(env.tys, b)
 
-    // TyErr propagates silently — treat as unifying against anything to
-    // avoid cascading diagnostics when a subtree is already poisoned.
-    if aKind == TkErr || bKind == TkErr {
+    // Err/Poison propagate silently — once a subtree is already bad we
+    // avoid feeding that failure back into the local solver.
+    if aKind == TkErr || bKind == TkErr || aKind == TkPoison || bKind == TkPoison {
         return true
     }
 
@@ -188,6 +188,7 @@ fn unifyAt(env: CheckEnv, solver: Solver, aIn: Int, bIn: Int, depth: Int) -> Boo
         TkOptional -> unifyAt(env, solver, tyInnerAt(env.tys, a), tyInnerAt(env.tys, b), depth + 1),
         TkSelf -> tyHeadAt(env.tys, a) == tyHeadAt(env.tys, b),
         TkErr -> true,
+        TkPoison -> true,
         TkVar -> false,
     }
 }

--- a/toolchain/ty.osty
+++ b/toolchain/ty.osty
@@ -58,6 +58,7 @@ pub enum PrimKind {
 /// TyKind discriminates the shape stored in a `TyNode`.
 pub enum TyKind {
     TkErr,              // poisoned / unresolved
+    TkPoison,           // hard error sentinel: suppress follow-up diagnostics
     TkPrim,             // TyNode.prim is meaningful
     TkNamed,            // TyNode.head + TyNode.args
     TkOptional,         // TyNode.ret holds the inner index
@@ -91,6 +92,7 @@ pub struct TyArena {
     pub internValues: List<Int>,
 
     pub idxErr: Int,
+    pub idxPoison: Int,
     pub idxInt: Int,
     pub idxInt8: Int,
     pub idxInt16: Int,
@@ -139,6 +141,7 @@ pub fn emptyTyArena() -> TyArena {
         internKeys: [],
         internValues: [],
         idxErr: -1,
+        idxPoison: -1,
         idxInt: -1, idxInt8: -1, idxInt16: -1, idxInt32: -1, idxInt64: -1,
         idxUInt8: -1, idxUInt16: -1, idxUInt32: -1, idxUInt64: -1,
         idxByte: -1, idxFloat: -1, idxFloat32: -1, idxFloat64: -1,
@@ -147,6 +150,7 @@ pub fn emptyTyArena() -> TyArena {
         idxUntypedInt: -1, idxUntypedFloat: -1,
     }
     arena.idxErr = tyAllocErr(arena)
+    arena.idxPoison = tyAllocPoison(arena)
     arena.idxInt = tyAllocPrim(arena, PkInt)
     arena.idxInt8 = tyAllocPrim(arena, PkInt8)
     arena.idxInt16 = tyAllocPrim(arena, PkInt16)
@@ -181,6 +185,16 @@ fn tyAllocErr(arena: TyArena) -> Int {
     idx
 }
 
+fn tyAllocPoison(arena: TyArena) -> Int {
+    let idx = tyNodeCount(arena)
+    let node = TyNode {
+        kind: TkPoison, prim: PkInvalid, head: "", args: [], ret: -1,
+        varId: 0, varName: "", varOwner: "",
+    }
+    arena.nodes.push(node)
+    idx
+}
+
 fn tyAllocPrim(arena: TyArena, prim: PrimKind) -> Int {
     let idx = tyNodeCount(arena)
     let node = TyNode {
@@ -203,6 +217,7 @@ pub fn tyNodeCount(arena: TyArena) -> Int {
 // ---------------------------------------------------------------------
 
 pub fn tErr(arena: TyArena) -> Int { arena.idxErr }
+pub fn tPoison(arena: TyArena) -> Int { arena.idxPoison }
 pub fn tInt(arena: TyArena) -> Int { arena.idxInt }
 pub fn tInt8(arena: TyArena) -> Int { arena.idxInt8 }
 pub fn tInt16(arena: TyArena) -> Int { arena.idxInt16 }
@@ -454,6 +469,14 @@ pub fn tyIsErr(arena: TyArena, idx: Int) -> Bool {
     tyKindAt(arena, idx) == TkErr
 }
 
+pub fn tyIsPoison(arena: TyArena, idx: Int) -> Bool {
+    tyKindAt(arena, idx) == TkPoison
+}
+
+pub fn tyIsBad(arena: TyArena, idx: Int) -> Bool {
+    tyIsErr(arena, idx) || tyIsPoison(arena, idx)
+}
+
 pub fn tyIsNever(arena: TyArena, idx: Int) -> Bool {
     let k = tyPrimAt(arena, idx)
     tyKindAt(arena, idx) == TkPrim && k == PkNever
@@ -531,6 +554,7 @@ pub fn tyEq(arena: TyArena, a: Int, b: Int) -> Bool {
     // short-circuit `&&`.
     match na.kind {
         TkErr -> true,
+        TkPoison -> true,
         TkPrim -> na.prim == nb.prim,
         TkNamed -> na.head == nb.head && tyEqList(arena, na.args, nb.args),
         TkOptional -> tyEq(arena, na.ret, nb.ret),
@@ -579,6 +603,7 @@ pub fn tyToString(arena: TyArena, idx: Int) -> String {
     let node = tyGet(arena, idx)
     match node.kind {
         TkErr -> "Invalid",
+        TkPoison -> "Poison",
         TkPrim -> primKindName(node.prim),
         TkNamed -> tyNamedToString(arena, node),
         TkOptional -> "{tyToString(arena, node.ret)}?",
@@ -668,6 +693,9 @@ pub fn tyFromString(arena: TyArena, source: String) -> Int {
     let trimmed = strings.trimSpace(source)
     if trimmed == "" {
         return tErr(arena)
+    }
+    if trimmed == "Poison" {
+        return tPoison(arena)
     }
     // Unwrap trailing `?` optionality first so the inner parse does not
     // have to treat it as a type-head continuation.


### PR DESCRIPTION
## Summary
- add a dedicated poison type sentinel for the new checker and propagate it through solver and assignability paths
- share generic instantiation logic across call, method, and struct literal elaboration via `InstSession`
- sync the selfhost generated runtime so bad-type recovery and typed node filtering follow the same rules

## Why
The new checker was still relying on `tErr` alone in several hot paths, which let the first typing failure cascade into noisy follow-up diagnostics. At the same time, generic instantiation logic was duplicated across multiple elaboration paths, making recovery behavior harder to keep consistent.

## Validation
- `go test ./cmd/osty-native-checker`
- `go test ./internal/check`
- `go test ./internal/selfhost`
