### PR TITLE
fix(format): keep `"{expr}"` interpolations flat

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -96,6 +96,14 @@ type printer struct {
 	pendingNL   bool
 	atLineStart bool
 
+	// inlineOnly suppresses every multi-line rendering decision made
+	// inside a single-quoted string interpolation. A `"..."` literal
+	// cannot hold a newline (§1.6.3 — only `"""..."""` can), so any
+	// `{expr}` nested in it must serialize flat regardless of width.
+	// Set by printStringLit around each interpolated-expression emit;
+	// printBracketedList and shouldBreakChain check it to force flat.
+	inlineOnly bool
+
 	// comments is the queue of yet-to-be-emitted comments in source
 	// order. commentIdx is the sliding front pointer.
 	comments   []token.Comment
@@ -136,6 +144,7 @@ type snapshot struct {
 	level       int
 	pendingNL   bool
 	atLineStart bool
+	inlineOnly  bool
 	commentIdx  int
 	lastSrcLine int
 	mapLen      int
@@ -147,6 +156,7 @@ func (p *printer) snapshot() snapshot {
 		level:       p.level,
 		pendingNL:   p.pendingNL,
 		atLineStart: p.atLineStart,
+		inlineOnly:  p.inlineOnly,
 		commentIdx:  p.commentIdx,
 		lastSrcLine: p.lastSrcLine,
 		mapLen:      p.maps.Snapshot(),
@@ -158,6 +168,7 @@ func (p *printer) restore(s snapshot) {
 	p.level = s.level
 	p.pendingNL = s.pendingNL
 	p.atLineStart = s.atLineStart
+	p.inlineOnly = s.inlineOnly
 	p.commentIdx = s.commentIdx
 	p.lastSrcLine = s.lastSrcLine
 	p.maps.Restore(s.mapLen)

--- a/internal/format/printer.go
+++ b/internal/format/printer.go
@@ -309,6 +309,20 @@ func printBracketedList[T any](p *printer, open, close string, items []T, forceM
 		p.write(close)
 		return
 	}
+	// Inside a single-quoted string interpolation the list MUST stay
+	// flat — overflowing MaxLineWidth or containing an embedded newline
+	// is preferable to splitting, which would emit invalid source.
+	if p.inlineOnly {
+		p.write(open)
+		for i, it := range items {
+			if i > 0 {
+				p.write(", ")
+			}
+			emit(it)
+		}
+		p.write(close)
+		return
+	}
 	if !forceMulti {
 		snap := p.snapshot()
 		p.write(open)
@@ -938,7 +952,7 @@ func (p *printer) printExprInner(e ast.Expr) {
 		p.printExpr(n.X)
 		p.write("?")
 	case *ast.CallExpr:
-		if base, segs := collectChain(n); shouldBreakChain(base, segs) {
+		if base, segs := collectChain(n); !p.inlineOnly && shouldBreakChain(base, segs) {
 			p.printMethodChain(base, segs)
 			return
 		}
@@ -1053,13 +1067,22 @@ func (p *printer) printStringLit(s *ast.StringLit) {
 		return
 	}
 	p.write("\"")
+	// Interpolations inside a `"..."` literal must stay flat: the lexer
+	// rejects embedded newlines, so any multi-line rendering that
+	// printBracketedList / shouldBreakChain would normally pick for a
+	// long call or chain would round-trip as a parse error. Force flat
+	// only across the interpolation expression; literal segments are
+	// unaffected.
+	prevInline := p.inlineOnly
 	for _, part := range s.Parts {
 		if part.IsLit {
 			p.write(escapeStringText(part.Lit))
 			continue
 		}
 		p.write("{")
+		p.inlineOnly = true
 		p.printExpr(part.Expr)
+		p.inlineOnly = prevInline
 		p.write("}")
 	}
 	p.write("\"")


### PR DESCRIPTION
## Summary

Canonical printer was splitting long call arg lists and method chains inside single-quoted string interpolations `"{expr}"`, producing output with embedded newlines that the selfhost package adapter correctly rejected (E0001 at tokens 8115/8129 when checking `toolchain/core.osty` and `toolchain/diagnostic.osty`).

Root cause: §1.6.3 forbids newlines inside `"..."`, but `printBracketedList` / `shouldBreakChain` were freely breaking across lines when the flat render exceeded MaxLineWidth, unaware they were nested in a single-quoted literal.

## Fix

- `internal/format/format.go`: add `printer.inlineOnly` flag, preserve across snapshot/restore.
- `internal/format/printer.go`:
  - `printStringLit` single-quoted path: set `inlineOnly` around each interpolated-expression emit; literal segments and triple-quoted strings are unaffected.
  - `printBracketedList`: when `inlineOnly`, force flat regardless of width or `forceMulti`.
  - `CallExpr` branch: skip `shouldBreakChain` when `inlineOnly` so method chains stay inline too.

## Measurement

| metric | before | after |
|---|---|---|
| selfhost package-adapter parse over canonical toolchain sources | 37/39 | **39/39** |
| `osty gen toolchain/{lexer,parser,formatter_ast}.osty` block class | `selfhostBuildPackageAst` E0001 parse error | later front-end type-check error (expected — different layer) |
| `osty fmt` testdata regressions | — | 0 (10/11 still pass; `full` was already failing on pre-existing struct-spread parsing, unrelated) |

## Scope note

The original plan was worded as "gen keeps the old path, rewire to `check.File`." Investigation showed that premise didn't fit — gen's workspace path already uses the new `CheckPackageStructured` entry, and the regression actually lived in the canonical printer. This PR fixes the real root cause (canonical → selfhost parse divergence). The secondary claim "7 files pass check but blocked in gen, restore to 7" is not delivered by this PR: parsing is unblocked for all 39 files, but toolchain package check still surfaces 6843 type-check errors from the native checker, and 4 gen targets still hit backend gaps (LLVM011/015). Those are separate layers — candidates for follow-up work.

## Test plan

- [x] `go build ./...`
- [x] Run selfhost package-adapter canonical-source probe over `toolchain/*.osty` — 39/39 accept.
- [x] `osty fmt` over `internal/format/testdata/*.input.osty` — 10/11 match expected (`full` was already failing on main).
- [x] `osty check` / `osty gen` over the 8 fast-path toolchain targets — block-class shift confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)