### PR TITLE
feat(llvmgen): strings.splitN shim

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -969,6 +969,63 @@ void *osty_rt_strings_Split(const char *value, const char *sep) {
     return out;
 }
 
+// osty_rt_strings_SplitN caps the output at `n` pieces, matching the
+// pure-Osty body in internal/stdlib/modules/strings.osty:
+//   n == 0 → empty list
+//   n <  0 → unbounded split (delegate to osty_rt_strings_Split)
+//   n == 1 → single-element list containing the original string
+//   n >  1 → split at the first n-1 separator occurrences, then append
+//            the remainder as the last element.
+// Empty separator falls back to byte-level expansion — we match the
+// surrounding Split semantics rather than Osty's char-level split,
+// because every other runtime here is byte-level. Toolchain callers
+// pass ASCII separators ("+", "-", "."), so this does not regress.
+void *osty_rt_strings_SplitN(const char *value, const char *sep, int64_t n) {
+    osty_rt_list *out;
+    const char *cursor;
+    const char *next;
+    size_t sep_len;
+    int64_t produced;
+
+    if (n == 0) {
+        return osty_rt_list_new();
+    }
+    if (n < 0) {
+        return osty_rt_strings_Split(value, sep);
+    }
+    out = (osty_rt_list *)osty_rt_list_new();
+    if (value == NULL) {
+        osty_rt_list_push_ptr(out, osty_rt_string_dup_range("", 0));
+        return out;
+    }
+    if (n == 1) {
+        osty_rt_list_push_ptr(out, osty_rt_string_dup_range(value, strlen(value)));
+        return out;
+    }
+    if (sep == NULL || sep[0] == '\0') {
+        produced = 0;
+        while (*value != '\0' && produced + 1 < n) {
+            char *piece = osty_rt_string_dup_range(value, 1);
+            osty_rt_list_push_ptr(out, piece);
+            value += 1;
+            produced++;
+        }
+        osty_rt_list_push_ptr(out, osty_rt_string_dup_range(value, strlen(value)));
+        return out;
+    }
+    sep_len = strlen(sep);
+    cursor = value;
+    produced = 0;
+    while (produced + 1 < n && (next = strstr(cursor, sep)) != NULL) {
+        char *piece = osty_rt_string_dup_range(cursor, (size_t)(next - cursor));
+        osty_rt_list_push_ptr(out, piece);
+        cursor = next + sep_len;
+        produced++;
+    }
+    osty_rt_list_push_ptr(out, osty_rt_string_dup_range(cursor, strlen(cursor)));
+    return out;
+}
+
 const char *osty_rt_strings_Join(void *raw_parts, const char *sep) {
     osty_rt_list *parts;
     int64_t i;

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -75,6 +75,9 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 	case "split":
 		v, err := g.emitStdStringsSplit(call)
 		return v, true, err
+	case "splitN":
+		v, err := g.emitStdStringsSplitN(call)
+		return v, true, err
 	case "trimPrefix":
 		v, err := g.emitStdStringsBinaryString(call, "trimPrefix", llvmStringRuntimeTrimPrefixSymbol())
 		return v, true, err
@@ -112,7 +115,7 @@ func (g *generator) stdStringsCallStaticResult(call *ast.CallExpr) (value, bool)
 		return value{typ: "i1"}, true
 	case "concat", "join", "trim", "trimSpace", "trimPrefix", "trimSuffix":
 		return value{typ: "ptr", gcManaged: true}, true
-	case "split":
+	case "split", "splitN":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true}, true
 	}
 	return value{}, false
@@ -134,6 +137,50 @@ func (g *generator) emitStdStringsSplit(call *ast.CallExpr) (value, error) {
 	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
 	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(sep)})
+	g.takeOstyEmitter(emitter)
+	parts := fromOstyValue(out)
+	parts.gcManaged = true
+	parts.listElemTyp = "ptr"
+	parts.listElemString = true
+	return parts, nil
+}
+
+// emitStdStringsSplitN mirrors emitStdStringsSplit but threads a third
+// Int argument to the runtime cap. The runtime body lives in
+// osty_rt_strings_SplitN; semantics match the pure-Osty stdlib body.
+// `n` bypasses emitStdStringsArg because that helper enforces ptr
+// (String) for every argument — splitN's count is the one outlier.
+func (g *generator) emitStdStringsSplitN(call *ast.CallExpr) (value, error) {
+	if len(call.Args) != 3 {
+		return value{}, unsupportedf("call", "strings.splitN expects 3 arguments, got %d", len(call.Args))
+	}
+	s, err := g.emitStdStringsArg(call.Args[0], "splitN", 0)
+	if err != nil {
+		return value{}, err
+	}
+	sep, err := g.emitStdStringsArg(call.Args[1], "splitN", 1)
+	if err != nil {
+		return value{}, err
+	}
+	nArg := call.Args[2]
+	if nArg == nil || nArg.Name != "" || nArg.Value == nil {
+		return value{}, unsupportedf("call", "strings.splitN requires positional arguments")
+	}
+	nVal, err := g.emitExpr(nArg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	nLoaded, err := g.loadIfPointer(nVal)
+	if err != nil {
+		return value{}, err
+	}
+	if nLoaded.typ != "i64" {
+		return value{}, unsupportedf("type-system", "strings.splitN arg 3 type %s, want Int", nLoaded.typ)
+	}
+	symbol := llvmStringRuntimeSplitNSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(sep), toOstyValue(nLoaded)})
 	g.takeOstyEmitter(emitter)
 	parts := fromOstyValue(out)
 	parts.gcManaged = true

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2119,6 +2119,10 @@ func llvmStringRuntimeSplitSymbol() string {
 	return "osty_rt_strings_Split"
 }
 
+func llvmStringRuntimeSplitNSymbol() string {
+	return "osty_rt_strings_SplitN"
+}
+
 func llvmStringRuntimeConcatSymbol() string {
 	return "osty_rt_strings_Concat"
 }


### PR DESCRIPTION
## Summary

Adds runtime + backend plumbing for `strings.splitN(s, sep, n)` so that
`osty gen --backend llvm` can lower the second toolchain fast-path
target (`toolchain/semver_parse.osty`) to complete LLVM IR.

The pure-Osty body in `internal/stdlib/modules/strings.osty` depends on
Char-level iteration the backend can't lower yet; the existing shim
layer covered `split` / `trim*` / `compare` / `concat` / `contains` /
`hasPrefix` / `hasSuffix` / `join` but stopped there. `semver_parse`
calls `strings.splitN(text, "+", 2)` to peel off build metadata, which
tripped `LLVM015 call target *ast.FieldExpr` once parsing cleared.

## Changes

- `internal/backend/runtime/osty_runtime.c` — `osty_rt_strings_SplitN(value, sep, n)`:
  - `n == 0` → empty list
  - `n <  0` → unbounded split (delegates to `osty_rt_strings_Split`)
  - `n == 1` → single-element list
  - `n >  1` → cap at `n - 1` separator matches + tail
  - Byte-level like `osty_rt_strings_Split`; toolchain callers pass ASCII separators.
- `internal/llvmgen/support_snapshot.go` — `llvmStringRuntimeSplitNSymbol()`.
- `internal/llvmgen/stdlib_shim.go`:
  - `case "splitN"` in the dispatch switch.
  - `emitStdStringsSplitN` — reuses `emitStdStringsArg` for the two string args, then emits the Int cap directly because the shared helper enforces ptr/String for every position.
  - `stdStringsCallStaticResult` returns the `List<String>` static shape for `splitN`.

## Measurement

| `osty gen --backend llvm` target | Before | After |
|---|---|---|
| `toolchain/semver.osty` | 969 IR lines | 969 IR lines |
| `toolchain/semver_parse.osty` | LLVM015 FieldExpr | **2099 IR lines** |
| `toolchain/frontend.osty` | LLVM015 FieldExpr | advances past splitN to the next LLVM011 wall (separate work) |
| `toolchain/check_bridge.osty` | LLVM015 FieldExpr | advances past splitN to the next LLVM011 wall |

Fast-path IR-clean count: **1/8 → 2/8**.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/llvmgen/ -run 'StdStrings|StringsShim|StdlibShim' -count=1` — passes.
- [x] `osty gen --backend llvm toolchain/semver_parse.osty` produces 2099 lines of IR.
- [x] `osty gen --backend llvm toolchain/semver.osty` still produces 969 IR lines (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)