### PR TITLE
docs: v0.5 shipped-vs-pending CHANGELOG

### DIFF
--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -1,0 +1,108 @@
+# CHANGELOG — v0.5
+
+Tracks the user-visible slice of the v0.5 spec (`LANG_SPEC_v0.5/`) that
+has landed in the compiler today, separate from the spec itself. The
+spec is the authority on what v0.5 *will* be; this file is the
+authority on what v0.5 *is* right now.
+
+See [`LANG_SPEC_v0.5/18-change-history.md`](./LANG_SPEC_v0.5/18-change-history.md)
+for the full v0.4 → v0.5 decision log (15 resolved gaps, G20 – G35) and
+[`SPEC_GAPS.md`](./SPEC_GAPS.md) for per-gap rationale.
+
+## Shipped in the compiler
+
+### Syntax
+
+| Form | Status | Notes |
+|---|---|---|
+| `use path::{a, b as c}` — scoped / grouped imports | **shipped** (G28) | Pre-parse rewrite in [`internal/parser/scoped_imports.go`](./internal/parser/scoped_imports.go); one flat `use` per item, rename preserved. |
+| `pub use path.Sym` — cross-module re-export | **shipped** (G30) | Post-parse `IsPub` flag via [`internal/parser/pub_use.go`](./internal/parser/pub_use.go). Resolver honors the flag; cycles diagnose as `E0552`. |
+| `#[cfg(key = "value")]` — conditional compilation | **shipped** (G29) | Pre-resolve filter in [`internal/resolve/cfg.go`](./internal/resolve/cfg.go). Keys: `os`, `target`, `arch`, `feature`. Unknown key → `E0405`. Composition forms (`all` / `any` / `not`) are spec-visible but not yet parsed. |
+| `#[test]` inline test annotation | **shipped** (G32) | Discovery in [`cmd/osty/test_native.go`](./cmd/osty/test_native.go) accepts any zero-arity function carrying `#[test]`, including those outside `_test.osty`. Legacy `test*` prefix still works. |
+| Doctest blocks in `///` comments | **shipped** (G32) | Extraction in [`internal/doctest`](./internal/doctest). `osty test --doc` synthesises a runner per package and routes blocks through the normal test pipeline. |
+
+### Stdlib — signatures
+
+These modules publish v0.5 signatures so user code that imports and
+references them type-checks under the front-end checker. Runtime
+behavior for the new surface is still the G18 stub convention —
+bodies exist so the stub checker accepts imports.
+
+- **`std.option`** — combinators: `isSome / isNone / isSomeAnd / isNoneOr / contains / take / replace / unwrap / expect / unwrapOr / unwrapOrElse / and / andThen / or / orElse / xor / filter / inspect / map / mapOr / mapOrElse / zip / okOr / okOrElse`.
+- **`std.result`** — combinators: `isOk / isErr / isOkAnd / isErrAnd / contains / containsErr / unwrap / expect / unwrapErr / expectErr / unwrapOr / unwrapOrElse / ok / err / and / andThen / or / orElse / inspect / inspectErr / map / mapErr / mapOr / mapOrElse`.
+- **`std.collections`** — `List.{chunked, windowed, partition, reduce, scan, flatMap, zip3}` in addition to the existing v0.4 surface. `Map.{getOrInsert, getOrInsertWith, merge, mapValues, filter}`.
+- **`std.strings`** — full Unicode-aware chapter. Everything referenced by name in `LANG_SPEC_v0.5/10-standard-library` is now a real `.osty` signature.
+- **`std.error`** — `Error.wrap(context)` / `Error.chain()` default methods, `WrappedError` struct, free functions `wrap()` / `rootCause()`.
+- **`std.testing`** — `Gen<T>` type + `property / propertyN / propertySeeded` runners.
+- **`std.testing.gen`** (new submodule) — 17 generator constructors: primitives (`int`, `intRange`, `bool`, `float`, `char`, `byte`, `asciiString`) and combinators (`oneOf`, `oneOfGens`, `map`, `filter`, `pair`, `triple`, `list`, `listOfSize`, `option`, `result`, `constant`).
+
+### Tooling
+
+- **`osty test --doc`** — extract and run doctest blocks as additional
+  test cases. One synthesised `__osty_doctest_runner__.osty` per
+  package; `fn test_doc_<owner>_<n>()` per block. Failures report
+  which owner + ordinal broke.
+- **Inline `#[test]`** discovery rejects `#[test]` on parameterised
+  functions (silently skipped) and on a function literally named
+  `testing`.
+
+### Diagnostic codes
+
+| Code | Meaning | Where |
+|---|---|---|
+| `E0405` | Unknown `#[cfg]` key | `internal/resolve/cfg.go` |
+| `E0552` | `pub use` cycle | resolver re-export walk |
+| `E0553` | `pub use` of a private symbol | resolver |
+| `E0554` | Duplicate item in scoped `use path::{...}` | resolver |
+| `E0754`–`E0756` | `#[op(...)]` signature / duplicate / not-allowed — reserved for G35 | `internal/diag/codes.go` |
+| `E0757` | `as?` on a non-`Error` expression — reserved for G27 | `internal/diag/codes.go` |
+| `E0758` / `E0759` | Enum integer discriminant on payload variant / duplicate discriminant — reserved for G31 | `internal/diag/codes.go` |
+| `E0763` | Unknown loop label in `break 'lbl` | reserved for G24 |
+| `E0764` | Label shadowing | reserved for G24 |
+| `E0765` | Implicit narrowing conversion (numeric) | reserved for G34 |
+
+All codes appear in [`ERROR_CODES.md`](./ERROR_CODES.md) (generated) and
+have focused tests under `internal/diag/testdata`.
+
+## Not yet shipped
+
+The following v0.5 forms are spec-frozen but blocked on regenerating
+the self-hosted parser (see [issue #362](https://github.com/choiceoh/osty/issues/362)
+— `go generate ./internal/selfhost` round-trip). They parse today
+**only** if hand-edited through the pre-parse rewrites above; grammar-
+level support lands when the regen pipeline is restored.
+
+- `loop { break value }` — value-returning unbounded loop (G22)
+- `'label: for / loop …` + labeled `break 'label` / `continue 'label` (G24)
+- Range step `0..100 by 2` (G25)
+- Struct update shorthand `receiver { field: value }` (G26)
+- Trailing closure `f(x) |y| { body }` (G23)
+- `err as? T` downcast syntax (G27) — equivalent `err.downcast::<T>()` also pending `Error.downcast` runtime
+- `pub? const fn` — compile-time evaluable functions (G21 extension)
+- Enum integer discriminants `pub enum X: Int { A = 1, ... }` (G31)
+- `#[op(+)]` operator overload (G35) — six-operator allow-list
+- Lossless numeric widening (G34)
+- Function-value parameter-name preservation (G20)
+- `#[cfg]` composition forms `all(...)` / `any(...)` / `not(...)` (G29 partial)
+
+## Native checker status
+
+The stub stdlib and the v0.5 syntax rewrites above run end-to-end
+through parse + resolve. The native checker (`OSTY_NATIVE_CHECKER_BIN`)
+does **not** yet know about the newly published method signatures on
+`List` / `Map` / `Option` / `Result` / `Error`, so front-end checking
+in isolation may flag `E0703` (no method) on the new surface even
+though the stdlib signatures are present. This is a checker-side gap
+tracked alongside the bootstrap regen work.
+
+## Migration from v0.4
+
+v0.5 is additive by design — every v0.4 program compiles unchanged
+under v0.5 grammar. Code that wants to opt in today can do so for
+the **shipped** list above; anything under "Not yet shipped" is a
+spec-level commitment, not a usable surface, until regen lands.
+
+The project edition remains `edition = "0.4"` in `osty.toml` — there
+is no `edition = "0.5"` yet because several of the shipped forms
+(scoped imports, `pub use`, `#[cfg]`, `#[test]`) are grammar-additive
+and readable by 0.4 tooling.

--- a/README.md
+++ b/README.md
@@ -625,9 +625,11 @@ edition is still **0.4** today: `osty new` / `osty init` write
 historical `0.3` / `0.4` range used by checked-in examples. Future
 surface changes follow the normal versioning process and land in a new
 spec directory. See [`SPEC_GAPS.md`](./SPEC_GAPS.md) for the full
-decision log. When docs discuss newer surface area, be explicit about
-whether it is a design target or behavior already wired in the CLI and
-tests.
+decision log and [`CHANGELOG_v0.5.md`](./CHANGELOG_v0.5.md) for which
+parts of the v0.5 surface are wired in the CLI today versus still
+waiting on regen. When docs discuss newer surface area, be explicit
+about whether it is a design target or behavior already wired in the
+CLI and tests.
 
 Conventions:
 - Every new error site gets a stable `Exxxx` code in


### PR DESCRIPTION
## Summary
- New `CHANGELOG_v0.5.md` enumerates which v0.5 spec surface is wired in the CLI today (scoped imports, `pub use`, `#[cfg]`, inline `#[test]`, doctest, stdlib signature additions) and which is blocked on the bootstrap-gen regen pipeline (loop / labels / range-by / `as?` / `const fn` / enum discriminants / operator overload / numeric widening).
- Cross-references every shipped item to the file that implements it and every diagnostic code to `internal/diag/codes.go`.
- README's Contributing section links the CHANGELOG so design target vs. implemented surface is one click apart.

## Test plan
- [x] Every referenced path exists (`internal/parser/scoped_imports.go`, `internal/parser/pub_use.go`, `internal/resolve/cfg.go`, `internal/doctest/`, `cmd/osty/test_native.go`)
- [x] Every diagnostic code (E0405, E0552–E0554, E0754–E0759, E0763–E0765) matches `internal/diag/codes.go`
- [x] Every G-number (G20–G35) cross-checked against `LANG_SPEC_v0.5/18-change-history.md`
- [x] Docs-only — no code touched; no test run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)