### PR TITLE
fix(llvmgen): clear non-ASCII string literal wall for diag_examples/monomorph

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -251,7 +251,7 @@ a < b < c      // rejected
 Spec: v0.4 O6
 
 ```osty
-foo::bar()     // rejected — did you mean `foo.bar()`?
+foo::bar()     // rejected -- did you mean `foo.bar()`?
 ```
 
 **Fix**: use `.` for member access or `::<T>` for type application.

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -188,7 +188,7 @@ const (
 	//
 	// Spec: v0.4 O6
 	// Example:
-	//   foo::bar()     // rejected — did you mean `foo.bar()`?
+	//   foo::bar()     // rejected -- did you mean `foo.bar()`?
 	// Fix: use `.` for member access or `::<T>` for type application.
 	CodeTurbofishMissingLT = "E0201"
 

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -628,6 +628,8 @@ func llvmCStringEscape(text string) string {
 		} else if unit == "\\" {
 			// Osty: examples/selfhost-core/llvmgen.osty:401:13
 			encoded = fmt.Sprintf("%s\\5C", ostyToString(encoded))
+		} else if unit == "\x1f" {
+			encoded = fmt.Sprintf("%s\\1F", ostyToString(encoded))
 		} else {
 			// Osty: examples/selfhost-core/llvmgen.osty:403:13
 			encoded = fmt.Sprintf("%s%s", ostyToString(encoded), ostyToString(unit))
@@ -1334,7 +1336,7 @@ func llvmLogicalInstruction(op string) string {
 
 func llvmIsAsciiStringText(text string) bool {
 	for _, c := range text {
-		if c == '\n' || c == '\t' || c == '\r' {
+		if c == '\n' || c == '\t' || c == '\r' || c == '\x1f' {
 			continue
 		}
 		if c < ' ' || c > '~' {

--- a/toolchain/diag_examples.osty
+++ b/toolchain/diag_examples.osty
@@ -25,7 +25,7 @@ pub fn diagHarvestCases() -> List<DiagHarvestCase> {
         DiagHarvestCase { code: "E0101", example: "use go \"net/http\" \{\n    fn Get(url: String) -> String \{ \"x\" \}  // rejected\n\}", phase: "resolve" },
         DiagHarvestCase { code: "E0106", example: "fn connect(t: Int = computeTimeout()) \{\}  // rejected", phase: "resolve" },
         DiagHarvestCase { code: "E0200", example: "a < b < c      // rejected\n0..10..20      // rejected", phase: "resolve" },
-        DiagHarvestCase { code: "E0201", example: "foo::bar()     // rejected — did you mean `foo.bar()`?", phase: "resolve" },
+        DiagHarvestCase { code: "E0201", example: "foo::bar()     // rejected -- did you mean `foo.bar()`?", phase: "resolve" },
         DiagHarvestCase { code: "E0203", example: "let f = |x: Int| -> Int x * 2       // rejected\nlet f = |x: Int| -> Int \{ x * 2 \}   // ok", phase: "resolve" },
         DiagHarvestCase { code: "E0604", example: "let x = _  // rejected", phase: "check" },
         DiagHarvestCase { code: "E0609", example: "#[deprecated]\n#[deprecated]           // rejected\npub fn f() \{\}", phase: "check" },

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -516,6 +516,8 @@ pub fn llvmCStringEscape(text: String) -> String {
             encoded = "{encoded}\\22"
         } else if unit == "\\" {
             encoded = "{encoded}\\5C"
+        } else if unit == "\u{1F}" {
+            encoded = "{encoded}\\1F"
         } else {
             encoded = "{encoded}{unit}"
         }
@@ -1191,7 +1193,7 @@ pub fn llvmLogicalInstruction(op: String) -> String {
 
 pub fn llvmIsAsciiStringText(text: String) -> Bool {
     for c in text.chars() {
-        if c == '\n' || c == '\t' || c == '\r' {
+        if c == '\n' || c == '\t' || c == '\r' || c == '\u{1F}' {
             continue
         }
         if c < ' ' || c > '~' {


### PR DESCRIPTION
## Summary

toolchain sweep에서 LLVM011 `string_non_ascii` 서브월에 걸려 있던 두 파일(`diag_examples.osty`, `monomorph.osty`) 해소. 둘 다 실제 StringLit.Lit 내용에 non-ASCII 바이트가 박혀 있었지만 **주입 경로는 서로 다름**.

## 조사 요약

LLVM011 `string_non_ascii` 서브월 히트 = 2:

### diag_examples.osty:28 — em dash 누출
- Lit: `"foo::bar()     // rejected — did you mean \`foo.bar()\`?"` (byte 0xE2 E2 80 94 = U+2014 `—`)
- 자동 생성 파일 (line 1: `AUTO-GENERATED by go generate ./internal/diag/...`)
- 원천: [internal/diag/codes.go:191](internal/diag/codes.go#L191)의 `CodeTurbofishMissingLT` Example 주석에 em dash 존재
- codesdoc harvester가 주석 텍스트를 그대로 Osty 문자열 리터럴로 구움

### monomorph.osty — `\u{1F}` escape expansion
- 6개 StringLit 파트에 byte 0x1F (Unit Separator)
- 예: `let mut key = "{pkg}\u{1f}{fnName}"` in [monomorphDedupeKey](toolchain/monomorph.osty#L267) — ABI-style 네임 dedupe용 injective 구분자로 **의도적으로** 사용
- raw source bytes는 순수 ASCII (`\u{1f}`가 6개 printable chars), 하지만 **lex escape expansion 후** Lit에 0x1F 박힘
- 기존 ASCII 체크 `c < ' '`는 `\n\t\r`만 허용 → 0x1F 탈락

## Changes

| 파일 | 변경 |
|---|---|
| [`internal/diag/codes.go`](internal/diag/codes.go#L191) | E0201 Example: em dash → `--` |
| [`ERROR_CODES.md`](ERROR_CODES.md), [`toolchain/diag_examples.osty`](toolchain/diag_examples.osty#L28) | `go generate ./internal/diag/...`로 재생성 |
| [`toolchain/llvmgen.osty`](toolchain/llvmgen.osty#L506) | `llvmCStringEscape` / `llvmIsAsciiStringText`에 `\u{1F}` 명시 허용 추가 |
| [`internal/llvmgen/support_snapshot.go`](internal/llvmgen/support_snapshot.go#L608) | 동일 변경을 Go 스냅샷에 미러 |

LLVM `c"..."` 바이트 문자열에는 `\1F` 16진 에스케이프로 출력. 기존 `\n\t\r\\"\\` 에스케이프 패턴과 동일한 명시 열거 스타일 유지 (0x00-0x7F 전체 일반화는 범위 밖).

## Test plan

- [x] `TestSweepToolchainLargeTailLLVM011Subwalls` 히스토그램에서 `string_non_ascii: 2` 카테고리 소멸 확인
- [x] `diag_examples.osty`: CLEAN
- [x] `monomorph.osty`: non-ASCII 벽 통과, 다음 벽(`String.bytes requires Byte/List<Byte> lowering`)으로 전진 — 별개 capability gap
- [x] `go test ./internal/diag/...` pass
- [x] 선행 실패 테스트(`TestRuntimeIntrinsicTyping*`)는 main에서도 동일 실패 — 본 변경과 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)