### PR TITLE
[codex] parallelize backend llvm tests

### DIFF
--- a/internal/backend/llvm_break_continue_test.go
+++ b/internal/backend/llvm_break_continue_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestLLVMBackendBinaryRunsBreakAndContinueLoops(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn main() {
@@ -53,9 +51,7 @@ func TestLLVMBackendBinaryRunsBreakAndContinueLoops(t *testing.T) {
 }
 
 func TestLLVMBackendBinaryManagedListLoopBreakAndContinueSurvivePressure(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestBundledRuntimeDebugCollectRespectsRoots(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
@@ -109,9 +107,7 @@ int main(void) {
 }
 
 func TestBundledRuntimeSafepointScansStackRoots(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
@@ -179,9 +175,7 @@ int main(void) {
 }
 
 func TestBundledRuntimeAutoCollectsAtPressureSafepoints(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
@@ -243,9 +237,7 @@ int main(void) {
 }
 
 func TestBundledRuntimePressureKeepsRootedListChildrenAlive(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
@@ -314,9 +306,7 @@ int main(void) {
 }
 
 func TestBundledRuntimeTracesManagedAggregateListElements(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)

--- a/internal/backend/llvm_runtime_sched_test.go
+++ b/internal/backend/llvm_runtime_sched_test.go
@@ -18,9 +18,7 @@ import (
 // uniform closure ABI (`int64_t body(void *env [, void *group])`)
 // described in §ABI contract of RUNTIME_SCHEDULER.md.
 func TestBundledRuntimeSchedulerPhase1A(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
@@ -174,9 +172,7 @@ int main(void) {
 // link-failing or silently no-op'ing. A program that reaches these
 // calls in Phase 1A must fail loudly — Phase 1B replaces them.
 func TestBundledRuntimeSchedulerChannelStubAborts(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -108,7 +108,22 @@ func newBackendRequest(t *testing.T, emit EmitMode, src string) Request {
 	}
 }
 
+func requireClangForBackendTest(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not found on PATH")
+	}
+}
+
+func parallelClangBackendTest(t *testing.T) {
+	t.Helper()
+	requireClangForBackendTest(t)
+	t.Parallel()
+}
+
 func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
+	t.Parallel()
+
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitBinary, `fn main() {
@@ -177,6 +192,8 @@ func TestLLVMBackendEmitBinaryBuildsBundledRuntime(t *testing.T) {
 }
 
 func TestLLVMBackendEmitLLVMIRSkipsToolchain(t *testing.T) {
+	t.Parallel()
+
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
@@ -206,6 +223,8 @@ func TestLLVMBackendEmitLLVMIRSkipsToolchain(t *testing.T) {
 }
 
 func TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback(t *testing.T) {
+	t.Parallel()
+
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
@@ -239,6 +258,8 @@ func TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback(t *testing.T) {
 }
 
 func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
+	t.Parallel()
+
 	if !useMIRBackend(nil, EmitLLVMIR) {
 		t.Fatal("useMIRBackend(nil, EmitLLVMIR) = false, want true")
 	}
@@ -251,6 +272,8 @@ func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
 }
 
 func TestUseMIRBackendLegacyFeatureDisables(t *testing.T) {
+	t.Parallel()
+
 	if useMIRBackend([]string{"legacy-llvmgen"}, EmitLLVMIR) {
 		t.Fatal("useMIRBackend(legacy-llvmgen, EmitLLVMIR) = true, want false")
 	}
@@ -264,6 +287,8 @@ func TestUseMIRBackendLegacyFeatureDisables(t *testing.T) {
 // rather than silently fall through to any AST-based path (no such
 // path exists any more).
 func TestLLVMBackendRefusesNilIR(t *testing.T) {
+	t.Parallel()
+
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
 	req := newBackendRequest(t, EmitLLVMIR, `fn main() { println(1) }`)
@@ -280,9 +305,7 @@ func TestLLVMBackendRefusesNilIR(t *testing.T) {
 }
 
 func TestLLVMBackendBinaryRunsBundledRuntime(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn touch() {
@@ -317,9 +340,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinarySafepointsKeepManagedRootsAlive(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
@@ -366,9 +387,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryAutoCollectsOnPressure(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
@@ -404,9 +423,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryForInOverTemporaryManagedListSurvivesPressure(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
@@ -436,9 +453,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryManagedTemporaryCallArgSurvivesPressure(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
@@ -474,9 +489,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryRunsBitwiseIntOps(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn main() {
@@ -501,9 +514,7 @@ func TestLLVMBackendBinaryRunsBitwiseIntOps(t *testing.T) {
 }
 
 func TestLLVMBackendBinaryMutReceiverMethodWritesBackToCaller(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `struct Counter {
@@ -541,9 +552,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryCollectionsUseRuntimeContainers(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `struct Pair {
@@ -599,9 +608,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryManagedAggregateContainersSurvivePressureGC(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `struct Bucket {
@@ -639,9 +646,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryExtendedListSortedAndToSet(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn main() {
@@ -682,9 +687,7 @@ func TestLLVMBackendBinaryExtendedListSortedAndToSet(t *testing.T) {
 }
 
 func TestLLVMBackendBinaryPtrBackedListToSetAndBoolPrint(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
@@ -716,9 +719,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryGenericEnumVariantFromLetContext(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `enum Maybe<T> { Some(T), None }
@@ -747,9 +748,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryGenericEnumVariantInferredFromPayload(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `enum Maybe<T> { Some(T), None }
@@ -778,9 +777,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryGenericEnumPayloadFreeVariantFromLetContext(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `enum Maybe<T> { Some(T), None }
@@ -809,9 +806,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryBuiltinResultFieldConstructors(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn main() {
@@ -835,9 +830,7 @@ func TestLLVMBackendBinaryBuiltinResultFieldConstructors(t *testing.T) {
 }
 
 func TestLLVMBackendBinaryBuiltinResultConstructorsTrackLocalContext(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `struct Holder {
@@ -876,9 +869,7 @@ fn main() {
 }
 
 func TestLLVMBackendBinaryLetStructPatternDestructuring(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `use runtime.strings as strings {
@@ -930,9 +921,7 @@ fn main() {
 // value. Complements the IR-only smoke in
 // `internal/llvmgen/ir_module_test.go::TestGenerateModuleGenericIdentityMonomorphized`.
 func TestLLVMBackendBinaryRunsGenericIdentity(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn id<T>(x: T) -> T { x }
@@ -966,9 +955,7 @@ fn main() {
 // confirming the emitted `insertvalue` / `extractvalue` / `load ptr`
 // / indirect-call sequence survives clang and runs correctly.
 func TestLLVMBackendBinaryRunsInterfaceBoxingDispatch(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `interface Sized {

--- a/internal/backend/llvm_while_test.go
+++ b/internal/backend/llvm_while_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestLLVMBackendBinaryRunsWhileStyleForLoop(t *testing.T) {
-	if _, err := exec.LookPath("clang"); err != nil {
-		t.Skip("clang not found on PATH")
-	}
+	parallelClangBackendTest(t)
 
 	backend := LLVMBackend{}
 	req := newBackendRequest(t, EmitBinary, `fn main() {


### PR DESCRIPTION
## What changed
- added a shared helper for clang-backed backend tests that checks tool availability and opts eligible tests into `t.Parallel()`
- parallelized isolated LLVM backend integration tests across the backend test suite
- kept the change scoped to backend tests only

## Why
The slowest package in the test suite was `internal/backend`, and profiling showed many long-running clang/LLVM tests that use isolated temp directories and do not need to run serially.

## Impact
- reduces wall-clock time for backend test runs
- keeps unrelated files and user workspace changes out of the PR

## Root cause
Backend integration tests were running serially even though many of them compile and execute in fully isolated temporary directories.

## Validation
- `go test ./internal/backend -count=1`
- observed package elapsed time drop from about `85.72s` to `67.19s` during local measurement
