### PR TITLE
fix(check): Poison 센티넬 bridge 위생 (source↔generated sync + native boundary clamp)

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1041,7 +1041,7 @@ func bindingPatternName(p ast.Pattern) string {
 func parseSelfhostTypeName(raw string, scope *resolve.Scope) types.Type {
 	text := strings.TrimSpace(raw)
 	switch text {
-	case "", "Invalid":
+	case "", "Invalid", "Poison":
 		return types.ErrorType
 	case "()", "Unit":
 		return types.Unit

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -553,7 +553,7 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
 
     let mut typedNodes: List<FrontCheckedNode> = []
     for node in cx.core.nodes {
-        if node.originAst < 0 || tyIsErr(cx.env.tys, node.ty) {
+        if node.originAst < 0 || tyIsBad(cx.env.tys, node.ty) {
             continue
         }
         let kind = typedExprKindNameAt(cx.ast, node.originAst)


### PR DESCRIPTION
## Summary
[PR #382](https://github.com/choiceoh/osty/pull/382) (checker poison recovery) 이후 Osty 셀프호스트 체커는 하드 에러 사이트에서 `tPoison`을 반환하는데, 이 타입이 Osty↔Go 경계를 넘는 두 지점이 커버되지 않아 있었습니다. 이번 패치는 두 줄 수정으로 잠재 leak 경로를 막고 소스↔생성 파일 drift를 정리합니다.

## Changes
- **[toolchain/check.osty:556](toolchain/check.osty:556)** `serializeCheckResult`의 노드 필터 `tyIsErr` → `tyIsBad`
  - `internal/selfhost/generated.go`는 이미 `tyIsBad`를 쓰고 있었기에 **런타임 동작 변화는 없음**. 누적된 source↔generated drift 정리.
- **[internal/check/host_boundary.go:1044](internal/check/host_boundary.go:1044)** `parseSelfhostTypeName` switch에 `"Poison"` 추가
  - 기존엔 `"Invalid"`만 `types.ErrorType`로 클램프. `"Poison"` typeName이 경계를 넘어오면 fallback 경로에서 가짜 `Named{Poison}` 별칭이 합성되어 네이티브 체커가 연쇄 타입 에러를 뱉을 수 있음.
  - 현재 HEAD에선 generated.go 상 이 경로를 타는 케이스가 없지만, 향후 셀프호스트 bridge 변경이나 외부 `OSTY_NATIVE_CHECKER_BIN` 버전 drift에 대한 방어선.

## What this PR is *not*
리뷰 중 `cmd/osty/airepair_test.go`의 red 12건을 발견했지만, 이는 **poison 마이그레이션과 무관**하며 별건으로 처리 필요:
- 동일 패턴은 `10a634d`(테스트 도입 커밋)에서도 이미 레드 — 최초부터 의도와 실제가 어긋나 있었음
- 루트 원인: 셀프호스트 체커의 `checkInstallPrelude`([toolchain/check_env.osty:1187](toolchain/check_env.osty:1187))에 `println`/`print`/`eprintln`/`eprint`/`panic` 등 prelude 함수 미등록
- 재현: `fn main() { println(\"hi\") }` → native checker 1 error
- 해결 경로는 별도 PR에서 (① 12건 전부 Skip 처리로 리포 상태 정직화, ② prelude 보강은 bootstrap/gen regen 이슈 해결 후 따로)

## Test plan
- [x] `go build ./...` 클린
- [x] `go test ./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline` 전부 green
- [x] `go test -short ./internal/selfhost/...` green
- [x] regen 없이도 런타임 동치성 확인 (check.osty 수정은 source↔generated sync 용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)