### PR TITLE
fix(selfhost): regen 파이프라인 build gate + bootstrap-gen checker-miss fa…

### DIFF
--- a/internal/bootstrap/gen/decl.go
+++ b/internal/bootstrap/gen/decl.go
@@ -1341,7 +1341,10 @@ func (g *gen) emitBlockAsReturn(b *ast.Block, wantReturn bool) {
 			}
 			g.preLiftQuestions(es.X)
 			g.body.write("return ")
+			prevHintType, prevHintGo := g.retHintType, g.retHintGo
+			g.retHintType, g.retHintGo = g.currentRetType, g.currentRetGo
 			g.emitExpr(es.X)
+			g.retHintType, g.retHintGo = prevHintType, prevHintGo
 			g.body.nl()
 			g.resetQuestionSubs()
 			g.body.dedent()

--- a/internal/bootstrap/gen/expr.go
+++ b/internal/bootstrap/gen/expr.go
@@ -204,7 +204,7 @@ func (g *gen) emitStructLit(s *ast.StructLit) {
 			// Shorthand `Point { name }` → `Point{name: name}`.
 			g.body.write(mangleIdent(f.Name))
 		} else {
-			g.emitExpr(f.Value)
+			g.emitStructLitFieldValue(typeName, f.Name, f.Value)
 		}
 	}
 	if s.Spread != nil {
@@ -213,6 +213,25 @@ func (g *gen) emitStructLit(s *ast.StructLit) {
 		g.body.write(" /* TODO(phase3): ..spread on qualified type */ ")
 	}
 	g.body.write("}")
+}
+
+// emitStructLitFieldValue emits a struct-literal field RHS, coercing
+// empty list literals to the field's declared element type when the
+// checker failed to attach a type. Other expressions fall through to
+// plain emission.
+func (g *gen) emitStructLitFieldValue(typeName, fieldName string, value ast.Expr) {
+	if typeName != "" {
+		if fields := g.structFieldTypes[typeName]; fields != nil {
+			if ft := fields[fieldName]; ft != nil {
+				if elem := g.listElemGoTypeExpr(ft); elem != "" {
+					if g.emitExprWithExpectedListElem(value, elem) {
+						return
+					}
+				}
+			}
+		}
+	}
+	g.emitExpr(value)
 }
 
 // emitStructSpreadLit lowers `Type { f: v, ..base }` to an IIFE that
@@ -235,7 +254,7 @@ func (g *gen) emitStructSpreadLit(s *ast.StructLit, typeName string, refStruct b
 		if f.Value == nil {
 			g.body.write(mangleIdent(f.Name))
 		} else {
-			g.emitExpr(f.Value)
+			g.emitStructLitFieldValue(typeName, f.Name, f.Value)
 		}
 		g.body.write("; ")
 	}
@@ -1898,19 +1917,107 @@ func (g *gen) emitRandomGenericMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
 }
 
 func (g *gen) emitCollectionMethod(c *ast.CallExpr, f *ast.FieldExpr) bool {
-	n, ok := g.typeOf(f.X).(*types.Named)
-	if !ok || n.Sym == nil {
+	if n, ok := g.typeOf(f.X).(*types.Named); ok && n.Sym != nil {
+		switch n.Sym.Name {
+		case "List", "Iter":
+			if g.emitListMethod(c, f, n) {
+				return true
+			}
+		case "Map":
+			return g.emitMapMethod(c, f, n)
+		case "Set":
+			return g.emitSetMethod(c, f, n)
+		}
+	}
+	// Syntactic fallback: the native checker occasionally drops types on
+	// a receiver whose annotation is still visible through the AST. For
+	// the method shapes that don't care about the element type (len /
+	// isEmpty) this is enough to pick the right lowering.
+	return g.emitListMethodBySyntax(c, f)
+}
+
+// emitListMethodBySyntax handles the checker-miss fallback for
+// element-type-agnostic List methods. Extend this switch cautiously —
+// anything depending on element type should go through the semantic
+// path so it stays in sync with check.Types.
+func (g *gen) emitListMethodBySyntax(c *ast.CallExpr, f *ast.FieldExpr) bool {
+	if !g.receiverIsSyntacticList(f.X) {
 		return false
 	}
-	switch n.Sym.Name {
-	case "List", "Iter":
-		return g.emitListMethod(c, f, n)
-	case "Map":
-		return g.emitMapMethod(c, f, n)
-	case "Set":
-		return g.emitSetMethod(c, f, n)
+	switch f.Name {
+	case "len":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("len(")
+		g.emitExpr(f.X)
+		g.body.write(")")
+		return true
+	case "isEmpty":
+		if len(c.Args) != 0 {
+			return false
+		}
+		g.body.write("(len(")
+		g.emitExpr(f.X)
+		g.body.write(") == 0)")
+		return true
 	}
 	return false
+}
+
+// receiverIsSyntacticList reports whether an expression's declared
+// (syntactic) type is `List<T>` — used only as a fallback when the
+// checker didn't attach a semantic type.
+func (g *gen) receiverIsSyntacticList(e ast.Expr) bool {
+	t := g.syntacticType(e)
+	if t == nil {
+		return false
+	}
+	nt, ok := t.(*ast.NamedType)
+	if !ok || len(nt.Path) == 0 {
+		return false
+	}
+	last := nt.Path[len(nt.Path)-1]
+	return last == "List" || last == "Iter"
+}
+
+// syntacticType walks an expression and returns its declared AST type
+// annotation when derivable. Covers idents bound to let/param decls and
+// single-level struct field access. Returns nil when the annotation is
+// not locally visible.
+func (g *gen) syntacticType(e ast.Expr) ast.Type {
+	switch e := e.(type) {
+	case *ast.Ident:
+		sym := g.symbolFor(e)
+		if sym == nil {
+			return nil
+		}
+		switch d := sym.Decl.(type) {
+		case *ast.LetStmt:
+			return d.Type
+		case *ast.Param:
+			return d.Type
+		case *ast.Field:
+			return d.Type
+		case *ast.IdentPat:
+			if let, ok := g.letStmtForIdentPat[d]; ok {
+				return let.Type
+			}
+		}
+	case *ast.FieldExpr:
+		recvType := g.syntacticType(e.X)
+		nt, ok := recvType.(*ast.NamedType)
+		if !ok || len(nt.Path) == 0 {
+			return nil
+		}
+		name := nt.Path[len(nt.Path)-1]
+		if fields := g.structFieldTypes[name]; fields != nil {
+			if ft := fields[e.Name]; ft != nil {
+				return ft
+			}
+		}
+	}
+	return nil
 }
 
 func (g *gen) emitListMethod(c *ast.CallExpr, f *ast.FieldExpr, n *types.Named) bool {
@@ -3014,6 +3121,9 @@ func (g *gen) resultTypeArgsAt(callType types.Type, payloadType types.Type, isEr
 		tErr = g.goType(n.Args[1])
 		return tArg, tErr
 	}
+	if a, e, ok := g.resultArgsFromSyntax(g.retHintType); ok {
+		return a, e
+	}
 	// Fallback to payload type on the known side.
 	if payloadType != nil {
 		if isErr {
@@ -3023,6 +3133,25 @@ func (g *gen) resultTypeArgsAt(callType types.Type, payloadType types.Type, isEr
 		}
 	}
 	return tArg, tErr
+}
+
+// resultArgsFromSyntax pulls `Result<T, E>` type args out of a syntactic
+// type annotation — used when the native checker failed to attach a
+// semantic type to an Ok/Err call but the enclosing fn's `ReturnType`
+// tells us what Result shape is expected.
+func (g *gen) resultArgsFromSyntax(t ast.Type) (string, string, bool) {
+	nt, ok := t.(*ast.NamedType)
+	if !ok || len(nt.Args) != 2 {
+		return "", "", false
+	}
+	name := ""
+	if len(nt.Path) > 0 {
+		name = nt.Path[len(nt.Path)-1]
+	}
+	if name != "Result" {
+		return "", "", false
+	}
+	return g.goTypeExpr(nt.Args[0]), g.goTypeExpr(nt.Args[1]), true
 }
 
 // emitBuiltinCall handles prelude intrinsics. Returns true when it
@@ -3175,9 +3304,12 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 				callType = g.typeOf(call)
 			}
 			tArg, tErr := g.resultTypeArgsAt(callType, g.typeOf(args[0].Value), false)
+			prevHintType, prevHintGo := g.retHintType, g.retHintGo
+			g.retHintType, g.retHintGo = nil, ""
 			g.body.writef("resultOk[%s, %s](", tArg, tErr)
 			g.emitExpr(args[0].Value)
 			g.body.write(")")
+			g.retHintType, g.retHintGo = prevHintType, prevHintGo
 			return true
 		}
 	case "Err":
@@ -3188,9 +3320,12 @@ func (g *gen) emitBuiltinCall(name string, args []*ast.Arg, call *ast.CallExpr) 
 				callType = g.typeOf(call)
 			}
 			tArg, tErr := g.resultTypeArgsAt(callType, g.typeOf(args[0].Value), true)
+			prevHintType, prevHintGo := g.retHintType, g.retHintGo
+			g.retHintType, g.retHintGo = nil, ""
 			g.body.writef("resultErr[%s, %s](", tArg, tErr)
 			g.emitExpr(args[0].Value)
 			g.body.write(")")
+			g.retHintType, g.retHintGo = prevHintType, prevHintGo
 			return true
 		}
 	}
@@ -3869,6 +4004,8 @@ func (g *gen) emitIfExpr(ie *ast.IfExpr) {
 	retType := "any"
 	if t := g.typeOf(ie); t != nil && !types.IsError(t) && !types.IsUnit(t) {
 		retType = g.goType(t)
+	} else if g.retHintGo != "" {
+		retType = g.retHintGo
 	}
 	g.body.writef("func() %s {", retType)
 	g.emitIfChain(ie, true)

--- a/internal/bootstrap/gen/gen.go
+++ b/internal/bootstrap/gen/gen.go
@@ -106,6 +106,21 @@ type gen struct {
 	// invocation from field access to a function-valued field.
 	methodNames map[string]map[string]bool
 
+	// structFieldTypes[typeName][fieldName] is the syntactic field type
+	// annotation, used to coerce unannotated RHS expressions (notably
+	// empty list literals `[]`) when the native checker didn't attach a
+	// type to them. Populated alongside structTypes in indexStructDecl.
+	structFieldTypes map[string]map[string]ast.Type
+
+	// letStmtForIdentPat maps an IdentPat to its enclosing LetStmt, so
+	// syntactic fallback paths (e.g. receiver-type inference for
+	// List.len/isEmpty when the checker dropped the expression type)
+	// can recover the declared annotation. The resolver stores IdentPat
+	// as the symbol's Decl for bare-name bindings, so without this
+	// reverse map the LetStmt (and its `Type` annotation) is
+	// unreachable.
+	letStmtForIdentPat map[*ast.IdentPat]*ast.LetStmt
+
 	// freshCounter backs freshVar for synthesized match / IIFE names.
 	freshCounter int
 
@@ -213,6 +228,17 @@ type gen struct {
 	// rather than an explicit AST annotation.
 	currentRetGo string
 
+	// retHintType / retHintGo carry the enclosing function's return type
+	// as a *tail-position* hint. Set by emitReturn and the tail of
+	// emitBlockAsReturn; consumed (and cleared) by emitMatch and the
+	// Ok/Err handlers in emitBuiltinCall when the native checker didn't
+	// attach a type to the match/call expression. Outside tail position
+	// these are nil — non-passthrough emitters clear them before
+	// descending so a nested match/call in, say, a BinaryExpr RHS does
+	// not pick up a stale hint from the outer return.
+	retHintType ast.Type
+	retHintGo   string
+
 	// questionSubs maps a QuestionExpr AST node to the Go expression
 	// text that should be emitted in its place. Populated by the
 	// statement-level pre-lift pass (see preLiftQuestions); consumed by
@@ -262,8 +288,10 @@ func newGen(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resu
 		imports:           map[string]string{},
 		variantOwner:      map[string]string{},
 		enumTypes:         map[string]bool{},
-		structTypes:       map[string]bool{},
-		methodNames:       map[string]map[string]bool{},
+		structTypes:        map[string]bool{},
+		structFieldTypes:   map[string]map[string]ast.Type{},
+		letStmtForIdentPat: map[*ast.IdentPat]*ast.LetStmt{},
+		methodNames:        map[string]map[string]bool{},
 		needStdlibOsty:    map[string]bool{},
 		emittedStdlibOsty: map[string]bool{},
 	}
@@ -281,8 +309,74 @@ func (g *gen) indexTypes() {
 		switch d := d.(type) {
 		case *ast.EnumDecl:
 			g.indexEnumDecl(d)
+			for _, m := range d.Methods {
+				g.indexLetStmtsInFn(m)
+			}
 		case *ast.StructDecl:
 			g.indexStructDecl(d)
+			for _, m := range d.Methods {
+				g.indexLetStmtsInFn(m)
+			}
+		case *ast.FnDecl:
+			g.indexLetStmtsInFn(d)
+		}
+	}
+}
+
+// indexLetStmtsInFn walks a function body to build the
+// IdentPat → LetStmt reverse map used by syntactic type fallback. Only
+// plain-ident patterns get recorded; destructuring let patterns lower
+// through emitLetPatternDestructure where each bound ident already
+// carries its own LetStmt-shaped type info via the checker.
+func (g *gen) indexLetStmtsInFn(fn *ast.FnDecl) {
+	if fn == nil || fn.Body == nil {
+		return
+	}
+	g.indexLetStmtsInBlock(fn.Body)
+}
+
+func (g *gen) indexLetStmtsInBlock(b *ast.Block) {
+	if b == nil {
+		return
+	}
+	for _, s := range b.Stmts {
+		g.indexLetStmtsInStmt(s)
+	}
+}
+
+func (g *gen) indexLetStmtsInStmt(s ast.Stmt) {
+	switch s := s.(type) {
+	case *ast.LetStmt:
+		if ip, ok := s.Pattern.(*ast.IdentPat); ok {
+			g.letStmtForIdentPat[ip] = s
+		}
+	case *ast.ExprStmt:
+		g.indexLetStmtsInExpr(s.X)
+	case *ast.ReturnStmt:
+		g.indexLetStmtsInExpr(s.Value)
+	case *ast.ForStmt:
+		g.indexLetStmtsInExpr(s.Iter)
+		g.indexLetStmtsInBlock(s.Body)
+	case *ast.AssignStmt:
+		g.indexLetStmtsInExpr(s.Value)
+	}
+}
+
+func (g *gen) indexLetStmtsInExpr(e ast.Expr) {
+	switch e := e.(type) {
+	case *ast.Block:
+		g.indexLetStmtsInBlock(e)
+	case *ast.IfExpr:
+		g.indexLetStmtsInExpr(e.Cond)
+		g.indexLetStmtsInExpr(e.Then)
+		g.indexLetStmtsInExpr(e.Else)
+	case *ast.MatchExpr:
+		for _, arm := range e.Arms {
+			g.indexLetStmtsInExpr(arm.Body)
+		}
+	case *ast.ClosureExpr:
+		if e.Body != nil {
+			g.indexLetStmtsInExpr(e.Body)
 		}
 	}
 }
@@ -327,6 +421,16 @@ func (g *gen) indexStructDecl(s *ast.StructDecl) {
 	}
 	for _, m := range s.Methods {
 		g.methodNames[s.Name][m.Name] = true
+	}
+	fields := g.structFieldTypes[s.Name]
+	if fields == nil {
+		fields = map[string]ast.Type{}
+		g.structFieldTypes[s.Name] = fields
+	}
+	for _, f := range s.Fields {
+		if f.Type != nil {
+			fields[f.Name] = f.Type
+		}
 	}
 }
 
@@ -2088,12 +2192,26 @@ func (g *gen) symbolFor(id *ast.Ident) *resolve.Symbol {
 }
 
 // typeOf returns the checked type of an expression, or nil when the
-// checker didn't visit it.
+// checker didn't visit it. For bare idents that the checker skipped, we
+// fall back to the resolver symbol's type — the checker may have typed
+// the binding even when it dropped the use-site expression (common on
+// `let mut x: List<T> = []` where the empty literal poisoned the RHS
+// but the symbol still carries its declared type).
 func (g *gen) typeOf(e ast.Expr) types.Type {
 	if g.chk == nil {
 		return nil
 	}
-	return g.chk.Types[e]
+	if t, ok := g.chk.Types[e]; ok && t != nil {
+		return t
+	}
+	if id, ok := e.(*ast.Ident); ok {
+		if sym := g.symbolFor(id); sym != nil {
+			if t := g.symTypeOf(sym); t != nil {
+				return t
+			}
+		}
+	}
+	return nil
 }
 
 // symTypeOf returns the checked type of a symbol, or nil.

--- a/internal/bootstrap/gen/match.go
+++ b/internal/bootstrap/gen/match.go
@@ -30,7 +30,12 @@ func (g *gen) emitMatch(m *ast.MatchExpr) {
 	retType := "any"
 	if t := g.typeOf(m); t != nil && !types.IsError(t) && !types.IsUnit(t) {
 		retType = g.goType(t)
+	} else if g.retHintGo != "" {
+		retType = g.retHintGo
 	}
+	// Keep retHint alive through arm bodies: each arm returns the IIFE's
+	// value, whose type we just pinned above; a nested match/if/Ok/Err at
+	// the arm tail should see the same expected type as this match does.
 	name := g.freshVar("_m")
 	g.body.writef("func() %s { %s := ", retType, name)
 	g.emitExpr(m.Scrutinee)

--- a/internal/bootstrap/gen/stmt.go
+++ b/internal/bootstrap/gen/stmt.go
@@ -149,7 +149,15 @@ func (g *gen) emitLetStmt(l *ast.LetStmt) {
 		g.body.writef("var %s %s", safe, g.goTypeExpr(l.Type))
 		if l.Value != nil {
 			g.body.write(" = ")
-			g.emitExprAsType(l.Value, g.typeOf(l.Value))
+			elem := g.listElemGoTypeExpr(l.Type)
+			if elem == "" {
+				elem = g.listElemGoType(g.typeOf(l.Value))
+			}
+			if g.emitExprWithExpectedListElem(l.Value, elem) {
+				// handled — list literal coerced to annotated element type
+			} else {
+				g.emitExpr(l.Value)
+			}
 		}
 		g.body.nl()
 		return
@@ -511,7 +519,10 @@ func (g *gen) emitReturn(r *ast.ReturnStmt) {
 	g.preLiftQuestions(r.Value)
 	defer g.resetQuestionSubs()
 	g.body.write("return ")
+	prevHintType, prevHintGo := g.retHintType, g.retHintGo
+	g.retHintType, g.retHintGo = g.currentRetType, g.currentRetGo
 	g.emitExpr(r.Value)
+	g.retHintType, g.retHintGo = prevHintType, prevHintGo
 	g.body.nl()
 }
 

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -80,10 +80,47 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("read patched selfhost code: %w", err)
 	}
+	return installWithBuildGate(root, outPath, data)
+}
+
+// installWithBuildGate atomically swaps generated.go for the freshly
+// emitted content, verifies that the selfhost package still compiles,
+// and rolls back on failure. Without this gate the regen pipeline
+// silently replaced the generated bridge with compile-broken Go —
+// any subsequent `go build` (including the next regen's native
+// checker build) then dies inside the very package the regen was
+// supposed to produce, and the only recovery was a hand-rolled
+// `git checkout --`.
+func installWithBuildGate(root, outPath string, data []byte) error {
+	prev, readErr := os.ReadFile(outPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return fmt.Errorf("read previous selfhost code: %w", readErr)
+	}
+	havePrev := readErr == nil
 	if err := os.WriteFile(outPath, data, 0o644); err != nil {
 		return fmt.Errorf("install generated selfhost code: %w", err)
 	}
-	return nil
+	cmd := exec.Command("go", "build", "./internal/selfhost/...")
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if havePrev {
+		if restoreErr := os.WriteFile(outPath, prev, 0o644); restoreErr != nil {
+			return fmt.Errorf(
+				"generated selfhost code does not compile and restore failed: build=%v (%s); restore=%w",
+				err, bytes.TrimSpace(output), restoreErr,
+			)
+		}
+	} else {
+		_ = os.Remove(outPath)
+	}
+	return fmt.Errorf(
+		"generated selfhost code does not compile; refused to install broken code at %s\n%s",
+		outPath,
+		bytes.TrimSpace(output),
+	)
 }
 
 func buildNativeChecker(root, outPath string) error {
@@ -121,6 +158,24 @@ func generatedSelfhostUpToDate(root, outPath string) (bool, error) {
 	}
 	if err := checkPath(filepath.Join(root, "internal/selfhost/gen_selfhost.go")); err != nil {
 		return false, fmt.Errorf("stat selfhost generator: %w", err)
+	}
+	// bootstrap-gen is the Osty→Go transpiler driver — its sources
+	// directly shape generated.go, so a change here must trigger a
+	// regen. Without this, editing `internal/bootstrap/gen/*.go` would
+	// leave generated.go stale and every downstream test run would
+	// silently reflect the pre-edit output.
+	genDir := filepath.Join(root, "internal/bootstrap/gen")
+	genEntries, err := os.ReadDir(genDir)
+	if err != nil {
+		return false, fmt.Errorf("read bootstrap/gen: %w", err)
+	}
+	for _, entry := range genEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		if err := checkPath(filepath.Join(genDir, entry.Name())); err != nil {
+			return false, fmt.Errorf("stat bootstrap/gen/%s: %w", entry.Name(), err)
+		}
 	}
 	for _, rel := range bundle.ToolchainCheckerFiles() {
 		if err := checkPath(filepath.Join(root, filepath.FromSlash(rel))); err != nil {


### PR DESCRIPTION
…llback

## 무엇을
- `gen_selfhost.go`: regen 후 `go build ./internal/selfhost/...`로 출력 검증, 실패 시 기존 generated.go로 롤백. 이전엔 broken Go가 조용히 committed 파일에 덮어써졌고, 다음 regen이 자기가 만든 출력으로 컴파일 실패 → chicken-and-egg lockout.
- staleness 체크가 `internal/bootstrap/gen/*.go` modtime도 감시. 없던 탓에 bootstrap-gen 수정해도 regen이 skip하던 latent 버그.
- `bootstrap/gen`: native checker가 expression에 타입을 안 붙인 사이트들에 구문적 fallback 추가.
  - `retHintType`/`retHintGo` tail-position hint — `emitReturn`·`emitBlockAsReturn` tail에서 push; `emitMatch`·`emitIfExpr`·Ok/Err 생성자가 checker miss 시 소비
  - `resultArgsFromSyntax`: `Result<T,E>` type args를 enclosing fn의 ReturnType 구문에서 역추출
  - let-stmt + struct literal field: 선언된 annotation으로 empty list literal의 element 타입 coerce
  - `syntacticType`/`receiverIsSyntacticList`: `.len()`/`.isEmpty()` checker miss 시 구문적 해결. resolver가 IdentPat를 Decl로 저장하므로 `letStmtForIdentPat` 역맵 추가
  - `typeOf`가 bare ident에서 `symTypeOf`로 2차 조회

## 왜
- regen 파이프라인이 broken Go 생성하고도 성공 종료 → 다음 regen이 자기 출력으로 lockup. 증상: String.chars() → field access, match 식이 `any`로 fallback, `resultErr[any, any]` vs `Result[T, E]` 불일치, 빈 list literal `make([]any, 0, 1)`.
- 병행 PR #382 (poison recovery)가 일부 cover했지만 match/if expected type, Result 생성자 type arg, list literal elem coercion은 별도 surface fix 필요.
- 잔여 11개 에러 (.pop, FieldExpr 2단 체인, enum variant any→string)는 이 PR 범위 밖이지만 build gate가 향후 이런 regression을 차단.

## 검증
- 기존 main 기반 `go build ./...` clean
- regen이 broken 출력 생성하면 gate가 거부·롤백 동작 확인
- front 패키지 + selfhost 테스트 통과
- 주요 에러 카테고리 50+건 → 11건으로 감소