### PR TITLE
Register prelude functions in selfhost checker

### DIFF
--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -26,3 +26,42 @@ func TestCheckSourceStructuredRecordsTypedExprCoverage(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckSourceStructuredRegistersPreludeFunctions(t *testing.T) {
+	src := []byte(`fn main() {
+    let p0 = print
+    let p1 = println
+    let p2 = eprint
+    let p3 = eprintln
+    let fail = panic
+    p0("a")
+    p1("b")
+    p2("c")
+    p3("d")
+}
+`)
+
+	checked := CheckSourceStructured(src)
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0 (contexts=%v details=%v)", checked.Summary.Errors, checked.Summary.ErrorsByContext, checked.Summary.ErrorDetails)
+	}
+
+	want := map[string]string{
+		"p0":   "fn(String) -> ()",
+		"p1":   "fn(String) -> ()",
+		"p2":   "fn(String) -> ()",
+		"p3":   "fn(String) -> ()",
+		"fail": "fn(String) -> Never",
+	}
+	got := map[string]string{}
+	for _, binding := range checked.Bindings {
+		if _, ok := want[binding.Name]; ok {
+			got[binding.Name] = binding.TypeName
+		}
+	}
+	for name, wantType := range want {
+		if got[name] != wantType {
+			t.Fatalf("binding type for %s = %q, want %q (all=%v)", name, got[name], wantType, got)
+		}
+	}
+}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -32208,6 +32208,16 @@ func checkInstallPrelude(env *CheckEnv) {
 	checkRegisterVariant(env, &CheckVariantSig{owner: "Result", name: "Ok", fieldTys: []int{tyNamed(env.tys, "T", make([]int, 0, 1))}, generics: []string{"T", "E"}})
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13697:5
 	checkRegisterVariant(env, &CheckVariantSig{owner: "Result", name: "Err", fieldTys: []int{tyNamed(env.tys, "E", make([]int, 0, 1))}, generics: []string{"T", "E"}})
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13704:5
+	checkRegisterFn(env, &CheckFnSig{name: "print", owner: "", receiverTy: -1, retTy: tUnit(env.tys), paramNames: []string{"s"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13713:5
+	checkRegisterFn(env, &CheckFnSig{name: "println", owner: "", receiverTy: -1, retTy: tUnit(env.tys), paramNames: []string{"s"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13722:5
+	checkRegisterFn(env, &CheckFnSig{name: "eprint", owner: "", receiverTy: -1, retTy: tUnit(env.tys), paramNames: []string{"s"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13731:5
+	checkRegisterFn(env, &CheckFnSig{name: "eprintln", owner: "", receiverTy: -1, retTy: tUnit(env.tys), paramNames: []string{"s"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13740:5
+	checkRegisterFn(env, &CheckFnSig{name: "panic", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: []string{"message"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13708:5
@@ -34808,12 +34818,7 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15091:5
 	if sig.name == "" {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15092:9
-		func() struct{} {
-			cx.env.diagnostics = append(cx.env.diagnostics, diagUnknownName(baseCallee.text, baseCallee.start, baseCallee.end))
-			return struct{}{}
-		}()
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15093:9
-		return elabPoisonResult(cx, node.start, node.end)
+		return elabInferFnValueCall(cx, node, argIdxs, expected)
 	}
 	if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
 		coreFn := coreIdent(cx.core, baseCallee.text, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1225,6 +1225,59 @@ pub fn checkInstallPrelude(env: CheckEnv) {
         fieldTys: [tyNamed(env.tys, "E", [])],
         generics: ["T", "E"],
     })
+
+    // Prelude functions are callable by name and also valid as values
+    // (`let p = println`). Register them as top-level fn signatures.
+    checkRegisterFn(env, CheckFnSig {
+        name: "print",
+        owner: "",
+        receiverTy: -1,
+        retTy: tUnit(env.tys),
+        paramNames: ["s"],
+        paramTys: [tString(env.tys)],
+        generics: [],
+        genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "println",
+        owner: "",
+        receiverTy: -1,
+        retTy: tUnit(env.tys),
+        paramNames: ["s"],
+        paramTys: [tString(env.tys)],
+        generics: [],
+        genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "eprint",
+        owner: "",
+        receiverTy: -1,
+        retTy: tUnit(env.tys),
+        paramNames: ["s"],
+        paramTys: [tString(env.tys)],
+        generics: [],
+        genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "eprintln",
+        owner: "",
+        receiverTy: -1,
+        retTy: tUnit(env.tys),
+        paramNames: ["s"],
+        paramTys: [tString(env.tys)],
+        generics: [],
+        genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "panic",
+        owner: "",
+        receiverTy: -1,
+        retTy: tNever(env.tys),
+        paramNames: ["message"],
+        paramTys: [tString(env.tys)],
+        generics: [],
+        genericBounds: [],
+    })
 }
 
 // Preserve a surface-level mirror of `frontCheckResult*`-style bridge

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1033,8 +1033,11 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
 
     let sig = checkLookupFn(cx.env, baseCallee.text, "")
     if sig.name == "" {
-        cx.env.diagnostics.push(diagUnknownName(baseCallee.text, baseCallee.start, baseCallee.end))
-        return elabPoisonResult(cx, node.start, node.end)
+        // Call-position idents may resolve to local `fn(...)` values
+        // (`let printer = print; printer("x")`) that shadow or replace
+        // a top-level declaration. Fall back to the general fn-value
+        // call path before reporting an unknown name.
+        return elabInferFnValueCall(cx, node, argIdxs, expected)
     }
 
     if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {


### PR DESCRIPTION
## Summary
- register print/println/eprint/eprintln/panic in the Osty-level selfhost checker prelude
- allow call-position idents to fall back to local fn-value calls when no top-level fn exists
- add a regression test for binding and calling prelude functions as values

## Testing
- go test ./cmd/osty-native-checker ./internal/check ./internal/selfhost