### PR TITLE
Support package-native external checker requests

### DIFF
--- a/cmd/osty-native-checker/main.go
+++ b/cmd/osty-native-checker/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 type checkRequest struct {
-	Source string `json:"source"`
+	Source  string                      `json:"source,omitempty"`
+	Package *selfhost.PackageCheckInput `json:"package,omitempty"`
 }
 
 type checkSummary struct {
@@ -77,7 +78,18 @@ func run(stdin io.Reader, stdout io.Writer) error {
 	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
 		return fmt.Errorf("decode checker request: %w", err)
 	}
-	checked := selfhost.CheckSourceStructured([]byte(req.Source))
+	var (
+		checked selfhost.CheckResult
+		err     error
+	)
+	if req.Package != nil {
+		checked, err = selfhost.CheckPackageStructured(*req.Package)
+		if err != nil {
+			return fmt.Errorf("check package request: %w", err)
+		}
+	} else {
+		checked = selfhost.CheckSourceStructured([]byte(req.Source))
+	}
 	resp := checkResponse{
 		Summary: checkSummary{
 			Assignments:     checked.Summary.Assignments,

--- a/cmd/osty-native-checker/main_test.go
+++ b/cmd/osty-native-checker/main_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
 )
 
 func TestRunEmitsStructuredCheckResult(t *testing.T) {
@@ -70,5 +72,43 @@ func TestRunChecksGenericBoundsAndInterfaceExtends(t *testing.T) {
 	}
 	if badResp.Summary.Errors == 0 {
 		t.Fatalf("bad summary errors = %d, want > 0", badResp.Summary.Errors)
+	}
+}
+
+func TestRunChecksPackageStructuredRequest(t *testing.T) {
+	fileA := []byte("fn helper() -> Int { 1 }\n")
+	fileB := []byte("fn main() { let value = helper() }\n")
+	reqBody, err := json.Marshal(checkRequest{
+		Package: &selfhost.PackageCheckInput{
+			Files: []selfhost.PackageCheckFile{
+				{Source: fileA, Base: 0, Name: "a.osty"},
+				{Source: fileB, Base: len(fileA) + 1, Name: "b.osty"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp checkResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0", resp.Summary.Errors)
+	}
+	found := false
+	for _, binding := range resp.Bindings {
+		if binding.Name == "value" && binding.TypeName == "Int" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("bindings = %#v, want value:Int from package request", resp.Bindings)
 	}
 }

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -35,7 +35,8 @@ type nativePackageChecker interface {
 }
 
 type nativeCheckRequest struct {
-	Source string `json:"source"`
+	Source  string                      `json:"source,omitempty"`
+	Package *selfhost.PackageCheckInput `json:"package,omitempty"`
 }
 
 type nativeCheckSummary struct {
@@ -95,7 +96,14 @@ type nativeCheckerExec struct {
 }
 
 func (e nativeCheckerExec) CheckSourceStructured(src []byte) (nativeCheckResult, error) {
-	req := nativeCheckRequest{Source: string(src)}
+	return e.run(nativeCheckRequest{Source: string(src)})
+}
+
+func (e nativeCheckerExec) CheckPackageStructured(input selfhost.PackageCheckInput) (nativeCheckResult, error) {
+	return e.run(nativeCheckRequest{Package: &input})
+}
+
+func (e nativeCheckerExec) run(req nativeCheckRequest) (nativeCheckResult, error) {
 	payload, err := json.Marshal(req)
 	if err != nil {
 		return nativeCheckResult{}, fmt.Errorf("marshal native checker request: %w", err)
@@ -305,11 +313,6 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 	switch r := runner.(type) {
 	case nativePackageChecker:
 		checked, err = r.CheckPackageStructured(input)
-	case nativeCheckerExec:
-		// The external checker protocol is still source-only; keep package and
-		// workspace runs on the structured in-process path until that protocol
-		// grows a package-native request shape.
-		checked, err = embeddedNativeChecker{}.CheckPackageStructured(input)
 	default:
 		checked, err = runner.CheckSourceStructured(src.source)
 	}

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -122,6 +123,36 @@ fn main() {}
 	}
 	if got := chk.LookupSymType(res.FileScope.Lookup("unused")); got == nil || got.String() != "fn(Int) -> Int" {
 		t.Fatalf("unused fn type = %v, want fn(Int) -> Int", got)
+	}
+}
+
+func TestNativeBoundaryExecChecksStructuredPackageInput(t *testing.T) {
+	fileA := []byte("fn helper() -> Int { 1 }\n")
+	fileB := []byte("fn main() { let value = helper() }\n")
+
+	bin := buildRepoNativeChecker(t)
+	runner := nativeCheckerExec{path: bin}
+	checked, err := runner.CheckPackageStructured(selfhost.PackageCheckInput{
+		Files: []selfhost.PackageCheckFile{
+			{Source: fileA, Base: 0, Name: "a.osty"},
+			{Source: fileB, Base: len(fileA) + 1, Name: "b.osty"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CheckPackageStructured error: %v", err)
+	}
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0", checked.Summary.Errors)
+	}
+	found := false
+	for _, binding := range checked.Bindings {
+		if binding.Name == "value" && binding.TypeName == "Int" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("bindings = %#v, want value:Int from package request", checked.Bindings)
 	}
 }
 

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -9,80 +9,80 @@ import (
 )
 
 type PackageCheckFile struct {
-	Source []byte
-	File   *ast.File
+	Source []byte    `json:"source,omitempty"`
+	File   *ast.File `json:"-"`
 	// SourceMap projects original parser AST spans into the canonical checker
 	// source held in Source. Nil when Source is a direct passthrough.
-	SourceMap *sourcemap.Map
-	Base      int
+	SourceMap *sourcemap.Map `json:"-"`
+	Base      int            `json:"base,omitempty"`
 	// Name is the display filename surfaced in diagnostic telemetry (typically
 	// a basename like `user.osty`). Empty when unknown; the telemetry suffix
 	// falls back to `@Lnn:Cnn` without a filename prefix in that case.
-	Name string
+	Name string `json:"name,omitempty"`
 }
 
 type PackageCheckGenericBound struct {
-	TyParam       string
-	InterfaceType string
+	TyParam       string `json:"tyParam,omitempty"`
+	InterfaceType string `json:"interfaceType,omitempty"`
 }
 
 type PackageCheckFn struct {
-	Name          string
-	Owner         string
-	ReceiverType  string
-	ReturnType    string
-	ParamNames    []string
-	ParamTypes    []string
-	Generics      []string
-	GenericBounds []PackageCheckGenericBound
+	Name          string                     `json:"name,omitempty"`
+	Owner         string                     `json:"owner,omitempty"`
+	ReceiverType  string                     `json:"receiverType,omitempty"`
+	ReturnType    string                     `json:"returnType,omitempty"`
+	ParamNames    []string                   `json:"paramNames,omitempty"`
+	ParamTypes    []string                   `json:"paramTypes,omitempty"`
+	Generics      []string                   `json:"generics,omitempty"`
+	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
 }
 
 type PackageCheckField struct {
-	Owner      string
-	Name       string
-	TypeName   string
-	HasDefault bool
+	Owner      string `json:"owner,omitempty"`
+	Name       string `json:"name,omitempty"`
+	TypeName   string `json:"typeName,omitempty"`
+	HasDefault bool   `json:"hasDefault,omitempty"`
 }
 
 type PackageCheckVariant struct {
-	Owner      string
-	Name       string
-	FieldTypes []string
-	Generics   []string
+	Owner      string   `json:"owner,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	FieldTypes []string `json:"fieldTypes,omitempty"`
+	Generics   []string `json:"generics,omitempty"`
 }
 
 type PackageCheckAlias struct {
-	Name     string
-	Target   string
-	Generics []string
+	Name     string   `json:"name,omitempty"`
+	Target   string   `json:"target,omitempty"`
+	Generics []string `json:"generics,omitempty"`
 }
 
 type PackageCheckType struct {
-	Name          string
-	Kind          string
-	Generics      []string
-	GenericBounds []PackageCheckGenericBound
+	Name          string                     `json:"name,omitempty"`
+	Kind          string                     `json:"kind,omitempty"`
+	Generics      []string                   `json:"generics,omitempty"`
+	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
 }
 
 type PackageCheckInterfaceExt struct {
-	Owner         string
-	InterfaceType string
+	Owner         string `json:"owner,omitempty"`
+	InterfaceType string `json:"interfaceType,omitempty"`
 }
 
 type PackageCheckImport struct {
-	Alias           string
-	Functions       []PackageCheckFn
-	Fields          []PackageCheckField
-	Variants        []PackageCheckVariant
-	Aliases         []PackageCheckAlias
-	TypeDecls       []PackageCheckType
-	InterfaceExts   []PackageCheckInterfaceExt
-	RegisterAsIface []string
+	Alias           string                     `json:"alias,omitempty"`
+	Functions       []PackageCheckFn           `json:"functions,omitempty"`
+	Fields          []PackageCheckField        `json:"fields,omitempty"`
+	Variants        []PackageCheckVariant      `json:"variants,omitempty"`
+	Aliases         []PackageCheckAlias        `json:"aliases,omitempty"`
+	TypeDecls       []PackageCheckType         `json:"typeDecls,omitempty"`
+	InterfaceExts   []PackageCheckInterfaceExt `json:"interfaceExts,omitempty"`
+	RegisterAsIface []string                   `json:"registerAsIface,omitempty"`
 }
 
 type PackageCheckInput struct {
-	Files   []PackageCheckFile
-	Imports []PackageCheckImport
+	Files   []PackageCheckFile   `json:"files,omitempty"`
+	Imports []PackageCheckImport `json:"imports,omitempty"`
 }
 
 // CheckPackageStructured lowers one structured package input into a synthetic


### PR DESCRIPTION
## Summary
- extend the native checker protocol to accept structured package requests
- route external checker package runs through CheckPackageStructured instead of embedded fallback
- add CLI and exec-path regression tests for cross-file package checking

## Testing
- go test ./cmd/osty-native-checker ./internal/check -run 'TestRun|TestNativeBoundaryExec|TestDefaultNativeChecker' -count=1
- go test ./internal/selfhost -run 'TestCheckPackageStructured' -count=1