### PR TITLE
[codex] Move stable alias handling into selfhost parser

### DIFF
--- a/internal/parser/normalize.go
+++ b/internal/parser/normalize.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"bytes"
-
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/token"
@@ -54,16 +52,9 @@ var stableAliasSpecs = map[string]stableAliasSpec{
 	},
 }
 
-type stableAliasEdit struct {
-	start int
-	end   int
-	text  []byte
-	step  ProvenanceStep
-}
-
-func normalizeStableAliases(src []byte) ([]byte, []ProvenanceStep) {
+func collectStableAliasProvenance(src []byte) []ProvenanceStep {
 	toks, _, _ := selfhost.Lex(src)
-	var edits []stableAliasEdit
+	var steps []ProvenanceStep
 
 	for i, tok := range toks {
 		if tok.Kind != token.IDENT {
@@ -93,46 +84,23 @@ func normalizeStableAliases(src []byte) ([]byte, []ProvenanceStep) {
 		if isAliasInExpressionPosition(toks, i) {
 			continue
 		}
-		replacement := aliasReplacement(spec.alias, spec.canonical)
-		edits = append(edits, stableAliasEdit{
-			start: tok.Pos.Offset,
-			end:   tok.End.Offset,
-			text:  replacement,
-			step: ProvenanceStep{
-				Kind:        spec.kind,
-				SourceHabit: spec.sourceHabit,
-				Span: diag.Span{
-					Start: tok.Pos,
-					End:   tok.End,
-				},
-				Detail: spec.detail,
+		steps = append(steps, ProvenanceStep{
+			Kind:        spec.kind,
+			SourceHabit: spec.sourceHabit,
+			Span: diag.Span{
+				Start: tok.Pos,
+				End:   tok.End,
 			},
+			Detail: spec.detail,
 		})
 	}
-	if len(edits) == 0 {
-		return src, nil
-	}
-
-	out := append([]byte(nil), src...)
-	steps := make([]ProvenanceStep, 0, len(edits))
-	lastStart := len(src) + 1
-	for i := len(edits) - 1; i >= 0; i-- {
-		edit := edits[i]
-		if edit.start < 0 || edit.end < edit.start || edit.end > len(src) || edit.end > lastStart {
-			continue
-		}
-		out = append(append([]byte(nil), out[:edit.start]...), append(edit.text, out[edit.end:]...)...)
-		lastStart = edit.start
-		steps = append(steps, edit.step)
-	}
-	reverseProvenanceSteps(steps)
-	return out, steps
+	return steps
 }
 
 // isAliasInExpressionPosition reports whether the identifier at
 // toks[i] is clearly used as a value / binding target / member access
-// rather than a statement-head keyword. When true, the alias rewrite
-// must be suppressed to avoid stomping user identifiers that happen
+// rather than a statement-head keyword. When true, stable-alias provenance
+// must be suppressed to avoid flagging user identifiers that happen
 // to share a spelling with a stable-alias source habit (common for
 // `def`, `func`, `while`, etc. used as variable names in toolchain
 // code).
@@ -186,19 +154,4 @@ func isAliasInExpressionPosition(toks []token.Token, i int) bool {
 		}
 	}
 	return false
-}
-
-func aliasReplacement(alias, canonical string) []byte {
-	buf := bytes.NewBuffer(make([]byte, 0, len(alias)))
-	buf.WriteString(canonical)
-	for i := len(canonical); i < len(alias); i++ {
-		buf.WriteByte(' ')
-	}
-	return buf.Bytes()
-}
-
-func reverseProvenanceSteps(steps []ProvenanceStep) {
-	for i, j := 0, len(steps)-1; i < j; i, j = i+1, j-1 {
-		steps[i], steps[j] = steps[j], steps[i]
-	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -40,10 +40,8 @@ func ParseDetailed(src []byte) Result {
 	return pipeline.result(file, diags)
 }
 
-// ParseCanonical parses already-canonical source without running the
-// source-level compatibility rewrites that ParseDetailed applies for
-// user-authored code. Callers should use this only for trusted inputs that do
-// not rely on stable-alias keyword rewrites.
+// ParseCanonical parses trusted source without collecting the parser-owned
+// compatibility provenance that ParseDetailed records for user-authored code.
 //
 // Unlike calling selfhost.Parse directly, this still applies the parser's
 // shared AST fixups so canonical sources that use lowered surface forms such

--- a/internal/parser/parser_features_test.go
+++ b/internal/parser/parser_features_test.go
@@ -156,6 +156,28 @@ func TestParseAcceptsStableAliases(t *testing.T) {
 	}
 }
 
+func TestParseCanonicalAcceptsStableAliases(t *testing.T) {
+	src := []byte("import std.testing as t\nfunc main() {\n    while false {\n        break\n    }\n}\n")
+
+	file, diags := ParseCanonical(src)
+	if len(diags) > 0 {
+		t.Fatalf("ParseCanonical returned %d diagnostics: %v", len(diags), diags[0])
+	}
+	if file == nil || len(file.Uses) != 1 || len(file.Decls) != 1 {
+		t.Fatalf("parsed file = %#v, want one use and one decl", file)
+	}
+	fn, ok := file.Decls[0].(*ast.FnDecl)
+	if !ok {
+		t.Fatalf("decl[0] type = %T, want *ast.FnDecl", file.Decls[0])
+	}
+	if fn.Body == nil || len(fn.Body.Stmts) != 1 {
+		t.Fatalf("fn body stmt count = %d, want 1", len(fn.Body.Stmts))
+	}
+	if _, ok := fn.Body.Stmts[0].(*ast.ForStmt); !ok {
+		t.Fatalf("body stmt type = %T, want *ast.ForStmt from stable `while` alias", fn.Body.Stmts[0])
+	}
+}
+
 func TestParseStableAliasesPreservedAsIdentifiers(t *testing.T) {
 	// Identifiers named after stable aliases (def, func, function, import, while)
 	// must survive when they occupy `name : type` slots — parameters, struct

--- a/internal/parser/pipeline.go
+++ b/internal/parser/pipeline.go
@@ -6,7 +6,7 @@ import (
 	"github.com/osty/osty/internal/selfhost"
 )
 
-// parsePipeline keeps parser-owned source rewrites and AST repairs in one
+// parsePipeline keeps parser-owned provenance collection and AST repairs in one
 // place so the various entrypoints do not drift on which stages they run.
 type parsePipeline struct {
 	parsedSrc  []byte
@@ -18,8 +18,7 @@ func newParsePipeline(src []byte) *parsePipeline {
 }
 
 func (p *parsePipeline) applySourceCompat() {
-	normalized, aliases := normalizeStableAliases(p.parsedSrc)
-	p.parsedSrc = normalized
+	aliases := collectStableAliasProvenance(p.parsedSrc)
 	if len(aliases) > 0 {
 		p.provenance.Aliases = append(p.provenance.Aliases, aliases...)
 	}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -18742,6 +18742,27 @@ func opAt(p *OstyParser, kind FrontTokenKind) bool {
 	return ostyEqual(opPeek(p).kind, kind)
 }
 
+func opIsStableAlias(tok *FrontToken, text string) bool {
+	return ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontIdent{})) && tok.text == text
+}
+
+func opIsFnHead(tok *FrontToken) bool {
+	return ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontFn{})) ||
+		opIsStableAlias(tok, "func") ||
+		opIsStableAlias(tok, "def") ||
+		opIsStableAlias(tok, "function")
+}
+
+func opIsUseHead(tok *FrontToken) bool {
+	return ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontUse{})) ||
+		opIsStableAlias(tok, "import")
+}
+
+func opIsForHead(tok *FrontToken) bool {
+	return ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontFor{})) ||
+		opIsStableAlias(tok, "while")
+}
+
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6918:1
 func opAdvance(p *OstyParser) *FrontToken {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6919:5
@@ -18856,10 +18877,13 @@ func opSyncDecl(p *OstyParser) {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6972:5
 	for !(opAt(p, FrontTokenKind(&FrontTokenKind_FrontEOF{}))) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6973:9
+		tok := opPeek(p)
+		_ = tok
+		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6973:9
 		kind := opPeek(p).kind
 		_ = kind
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6974:9
-		if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontFn{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontStruct{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontEnum{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontInterface{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontType{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontUse{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontPub{})) {
+		if opIsFnHead(tok) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontStruct{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontEnum{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontInterface{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontType{})) || opIsUseHead(tok) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontPub{})) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6974:161
 			return
 		}
@@ -18878,6 +18902,9 @@ func opSyncStmt(p *OstyParser) {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6981:5
 	for !(opAt(p, FrontTokenKind(&FrontTokenKind_FrontEOF{}))) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6982:9
+		tok := opPeek(p)
+		_ = tok
+		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6982:9
 		kind := opPeek(p).kind
 		_ = kind
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6983:9
@@ -18893,7 +18920,7 @@ func opSyncStmt(p *OstyParser) {
 			return
 		}
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6988:9
-		if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontLet{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontReturn{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontBreak{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontContinue{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontDefer{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontFor{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontIf{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontMatch{})) {
+		if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontLet{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontReturn{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontBreak{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontContinue{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontDefer{})) || opIsForHead(tok) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontIf{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontMatch{})) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6988:184
 			return
 		}
@@ -19710,10 +19737,12 @@ func opLooksLikeMap(p *OstyParser) bool {
 		return false
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7314:5
-	kind := opPeek(p).kind
+	tok := opPeek(p)
+	_ = tok
+	kind := tok.kind
 	_ = kind
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7315:5
-	if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontLet{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontReturn{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontBreak{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontContinue{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontDefer{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontFor{})) {
+	if ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontLet{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontReturn{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontBreak{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontContinue{})) || ostyEqual(kind, FrontTokenKind(&FrontTokenKind_FrontDefer{})) || opIsForHead(tok) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7315:140
 		p.pos = save
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7316:5
@@ -20497,7 +20526,7 @@ func opParseStmt(p *OstyParser) int {
 		return opParseDeferStmt(p)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7670:5
-	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontFor{})) {
+	if opIsForHead(tok) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7670:31
 		return opParseForStmt(p)
 	}
@@ -21293,7 +21322,7 @@ func opParseTypeAtom(p *OstyParser) int {
 	tok := opPeek(p)
 	_ = tok
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8036:5
-	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontFn{})) {
+	if opIsFnHead(tok) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8036:30
 		return opParseFnType(p)
 	}
@@ -21757,7 +21786,7 @@ func opParseDecl(p *OstyParser) int {
 	tok := opPeek(p)
 	_ = tok
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8249:5
-	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontFn{})) {
+	if opIsFnHead(tok) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8249:30
 		return opParseFnDecl(p, isPub, anns)
 	}
@@ -21782,7 +21811,7 @@ func opParseDecl(p *OstyParser) int {
 		return opParseTypeAliasDecl(p, isPub, anns)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8254:5
-	if ostyEqual(tok.kind, FrontTokenKind(&FrontTokenKind_FrontUse{})) {
+	if opIsUseHead(tok) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8254:31
 		return opParseUseDecl(p, isPub)
 	}

--- a/internal/selfhost/parse_stable_alias_test.go
+++ b/internal/selfhost/parse_stable_alias_test.go
@@ -1,0 +1,15 @@
+package selfhost
+
+import "testing"
+
+func TestParseStableAliasesDirectly(t *testing.T) {
+	src := []byte("import std.testing as t\nfunc main() {\n    while false {\n        break\n    }\n}\n")
+
+	file, diags := Parse(src)
+	if len(diags) > 0 {
+		t.Fatalf("Parse returned %d diagnostics: %v", len(diags), diags[0])
+	}
+	if file == nil || len(file.Uses) != 1 || len(file.Decls) != 1 {
+		t.Fatalf("parsed file = %#v, want one use and one decl", file)
+	}
+}

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -249,6 +249,22 @@ fn opPeekPastNewlines(p: OstyParser) -> FrontToken {
 
 fn opAt(p: OstyParser, kind: FrontTokenKind) -> Bool { opPeek(p).kind == kind }
 
+fn opIsStableAlias(tok: FrontToken, text: String) -> Bool {
+    tok.kind == FrontIdent && tok.text == text
+}
+
+fn opIsFnHead(tok: FrontToken) -> Bool {
+    tok.kind == FrontFn || opIsStableAlias(tok, "func") || opIsStableAlias(tok, "def") || opIsStableAlias(tok, "function")
+}
+
+fn opIsUseHead(tok: FrontToken) -> Bool {
+    tok.kind == FrontUse || opIsStableAlias(tok, "import")
+}
+
+fn opIsForHead(tok: FrontToken) -> Bool {
+    tok.kind == FrontFor || opIsStableAlias(tok, "while")
+}
+
 fn opAdvance(p: OstyParser) -> FrontToken {
     if p.typeGtDebt > 0 {
         p.typeGtDebt = p.typeGtDebt - 1
@@ -304,8 +320,9 @@ fn opAddNode(p: OstyParser, node: AstNode) -> Int { astArenaAdd(p.arena, node) }
 
 fn opSyncDecl(p: OstyParser) {
     for !(opAt(p, FrontEOF)) {
-        let kind = opPeek(p).kind
-        if kind == FrontFn || kind == FrontStruct || kind == FrontEnum || kind == FrontInterface || kind == FrontType || kind == FrontUse || kind == FrontPub { return }
+        let tok = opPeek(p)
+        let kind = tok.kind
+        if opIsFnHead(tok) || kind == FrontStruct || kind == FrontEnum || kind == FrontInterface || kind == FrontType || opIsUseHead(tok) || kind == FrontPub { return }
         if kind == FrontHash && opPeekAt(p, 1).kind == FrontLBracket { return }
         let _ = opAdvance(p)
     }
@@ -313,13 +330,14 @@ fn opSyncDecl(p: OstyParser) {
 
 fn opSyncStmt(p: OstyParser) {
     for !(opAt(p, FrontEOF)) {
-        let kind = opPeek(p).kind
+        let tok = opPeek(p)
+        let kind = tok.kind
         if kind == FrontNewline {
             let _ = opAdvance(p)
             return
         }
         if kind == FrontRBrace { return }
-        if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || kind == FrontFor || kind == FrontIf || kind == FrontMatch { return }
+        if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || opIsForHead(tok) || kind == FrontIf || kind == FrontMatch { return }
         let _ = opAdvance(p)
     }
 }
@@ -645,8 +663,9 @@ fn opLooksLikeMap(p: OstyParser) -> Bool {
     opSkipNewlines(p)
     if opAt(p, FrontRBrace) { p.pos = save
     return false }
-    let kind = opPeek(p).kind
-    if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || kind == FrontFor { p.pos = save
+    let tok = opPeek(p)
+    let kind = tok.kind
+    if kind == FrontLet || kind == FrontReturn || kind == FrontBreak || kind == FrontContinue || kind == FrontDefer || opIsForHead(tok) { p.pos = save
     return false }
     opParseExpr(p)
     let result = opAt(p, FrontColon) && opPeekAt(p, 1).kind != FrontColon
@@ -1001,7 +1020,7 @@ fn opParseStmt(p: OstyParser) -> Int {
         return opAddNode(p, n)
     }
     if tok.kind == FrontDefer { return opParseDeferStmt(p) }
-    if tok.kind == FrontFor { return opParseForStmt(p) }
+    if opIsForHead(tok) { return opParseForStmt(p) }
     let expr = opParseExpr(p)
     let next = opPeek(p)
     if next.kind == FrontChanArrow {
@@ -1367,7 +1386,7 @@ fn opParseType(p: OstyParser) -> Int {
 
 fn opParseTypeAtom(p: OstyParser) -> Int {
     let tok = opPeek(p)
-    if tok.kind == FrontFn { return opParseFnType(p) }
+    if opIsFnHead(tok) { return opParseFnType(p) }
     if tok.kind == FrontLParen { return opParseTupleType(p) }
     if tok.kind == FrontIdent {
         let start = p.pos
@@ -1580,12 +1599,12 @@ fn opParseDecl(p: OstyParser) -> Int {
     let mut isPub = false
     if opEat(p, FrontPub) { isPub = true }
     let tok = opPeek(p)
-    if tok.kind == FrontFn { return opParseFnDecl(p, isPub, anns) }
+    if opIsFnHead(tok) { return opParseFnDecl(p, isPub, anns) }
     if tok.kind == FrontStruct { return opParseStructDecl(p, isPub, anns) }
     if tok.kind == FrontEnum { return opParseEnumDecl(p, isPub, anns) }
     if tok.kind == FrontInterface { return opParseInterfaceDecl(p, isPub, anns) }
     if tok.kind == FrontType { return opParseTypeAliasDecl(p, isPub, anns) }
-    if tok.kind == FrontUse { return opParseUseDecl(p, isPub) }
+    if opIsUseHead(tok) { return opParseUseDecl(p, isPub) }
     if tok.kind == FrontLet { return opParseLetStmt(p, anns) }
     let errKindName = frontTokenKindName(tok.kind)
     opErrorFull(p, "expected declaration, got {errKindName}", "a declaration starts with `fn`, `struct`, `enum`, `interface`, `type`, `use`, or `let`", "", "E0030")


### PR DESCRIPTION
## Summary
- move stable alias keyword handling (`func`, `def`, `function`, `import`, `while`) into the selfhost parser core
- stop rewriting parser input in Go and keep parser compatibility tracking as provenance-only collection
- add canonical parser and direct selfhost regression coverage for stable aliases

## Why
Stable alias support was still split between the selfhost parser and a Go-side source rewrite path, which meant the selfhost parser was not the full source of truth and `ParseCanonical` could not accept those aliases directly.

## Validation
- `go test ./internal/parser -run 'TestParseAcceptsStableAliases|TestParseCanonicalAcceptsStableAliases|TestParseStableAliasesPreservedAsIdentifiers'`
- `go test ./internal/selfhost -run 'TestParseStableAliasesDirectly|TestParseSnapshotDeterministic'`
- `go test ./internal/parser ./internal/cst ./internal/stdlib`