### PR TITLE
[codex] update selfhosting status docs

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -51,20 +51,20 @@
 
 | 기능 | 非-test 사용 | 현재 상태 | 관련 phase |
 |---|---|---|---|
-| `List<T>` literal + 메서드 lowering | 974회 | 🚧 runtime struct만 존재, emitter 없음 | TBD (Tier A-1) |
-| `Map<K,V>` literal + 메서드 lowering | 심볼 테이블 등 다수 | 🚧 runtime struct만 존재 | TBD (Tier A-2) |
-| `String` concat/slice/interpolation | 대부분 파일 | 🚧 ASCII literal + `println`만 | TBD (Tier A-3) |
-| Closure + env capture | AST visitor 전반 | 🚧 IR capture만 존재 | TBD (Tier A-4) |
-| Multi-file package emit + link | 37개 non-test 파일 | ❌ 단일 엔트리만 | TBD (Tier A-5) |
-| `std.strings` 함수 구현 | 20+ 파일에서 import | ❌ Go seed 경유 | TBD (Tier A-6) |
+| `List<T>` literal + 메서드 lowering | 974회 | 🟡 부분 구현 — legacy AST emitter가 list literal + `push` 및 일부 컬렉션 브리지를 낮춘다. 다만 whole-toolchain coverage는 아직 incomplete | TBD (Tier A-1) |
+| `Map<K,V>` literal + 메서드 lowering | 심볼 테이블 등 다수 | 🟡 부분 구현 — legacy AST emitter가 map literal + `insert` / `remove`를 낮춘다. 더 넓은 toolchain surface는 아직 incomplete | TBD (Tier A-2) |
+| `String` concat/slice/interpolation | 대부분 파일 | 🟡 부분 구현 — ASCII / runtime-backed concat / interpolation은 존재하지만 `Char`/`Byte` iteration (`String.chars` / `bytes`)과 더 넓은 string ABI가 blocker | TBD (Tier A-3) |
+| Closure + env capture | AST visitor 전반 | 🟡 부분 구현 — MIR path에는 capturing-closure env emission + tests가 있다. legacy AST emitter의 first-class fn-value/capture surface는 아직 incomplete | TBD (Tier A-4) |
+| Multi-file package emit + link | 37개 non-test 파일 | ❌ merged-probe가 주 검증 경로이며 package-level native self-compile/link는 아직 blocker | TBD (Tier A-5) |
+| `std.strings` 함수 구현 | 20+ 파일에서 import | 🟡 부분 구현 — legacy llvmgen이 일부 함수를 runtime shim으로 우회하지만 pure-Osty body는 여전히 `Char` / `List<Char>` lowering에 막힘 | TBD (Tier A-6) |
 
 ### Tier B — pkgmgr (`semver`, `manifest`, `registry`, `solve`, `pkgmgr`) 자가 컴파일 blocker
 
 | 기능 | 非-test 사용 | 현재 상태 | 관련 phase |
 |---|---|---|---|
 | `String` payload enum (`PreText(String)`) | `semver.osty:5` | 🚧 Phase 54-63 — fixture 추가됨, 드라이브 확인 중 | [§Phase 54-63](#phase-54-63-payload-enum-generalization-floatstring) |
-| `Result<T, String>` ABI | semver_parse, manifest_validation | ❌ Result as enum 미설계 | 신규 phase 필요 |
-| `?` 전파 (Result) | `semver_parse.osty` 8곳 | 🚧 Option<ptr>만 지원 ([expr.go:713](internal/llvmgen/expr.go)) | 신규 phase 필요 |
+| `Result<T, String>` ABI | semver_parse, manifest_validation | 🟡 부분 구현 — legacy AST emitter가 aggregate `Result<T, E> = {tag, ok, err}`를 갖고 있으나 pkgmgr 전체 shape는 아직 다 못 덮음 | 신규 phase 필요 |
+| `?` 전파 (Result) | `semver_parse.osty` 8곳 | 🟡 부분 구현 — legacy AST path가 matching `Result<_, E>` 반환 함수에서 `?`를 낮춘다. broader selfhost coverage는 아직 미완 | 신규 phase 필요 |
 | struct/enum 복합 payload (Ok(SemVersion)) | semver_parse, manifest_validation | ❌ single-field scalar/ptr만 | 신규 phase 필요 |
 
 ### 非-blocker (당초 Tier B 오판 항목)
@@ -84,9 +84,9 @@ single-scalar-payload + bare tag이다.
 ### 관심 순서
 
 1. Tier A-1 (List) + A-3 (String concat/slice) — 모든 frontend 경로가 의존.
-2. Tier A-2 (Map) + A-4 (Closure) — resolve/check/visitor가 의존.
-3. Tier A-5 (Multi-file linking) — Tier A가 한 파일에서 되면 즉시 다음 관문.
-4. Tier A-6 (`std.strings` 순수 구현) — A-3 위에서 얹음.
+2. Tier A-6 (`std.strings` 순수 구현) — 현재 native probe first-wall이 `Char`이므로 A-3와 사실상 한 묶음.
+3. Tier A-2 (Map) + A-4 (Closure) — resolve/check/visitor가 의존.
+4. Tier A-5 (Multi-file linking) — Tier A가 한 파일에서 되면 즉시 다음 관문.
 5. Tier B — pkgmgr 경로. 核 셀프호스트와 독립적으로 진행 가능.
 6. 非-blocker는 유저 코드 예시 호환성 위주로 여유 시 진행.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ in older status docs is closed again. A fresh hello-world
 Current selfhosting/toolchain tracking is therefore about remaining front-end
 and toolchain-surface gaps, not a blanket "all LLVM CLI calls panic" state.
 
+Code-level re-audit on the same date narrows that further: the tree is not yet
+"fully self-hosted" end-to-end. `internal/check` still prefers a managed
+external `osty-native-checker` binary under `.osty/toolchain/<tool-version>/`
+and falls back to the embedded selfhost bridge when that executable is
+unavailable, and `go generate ./internal/selfhost` still shells out to
+`cmd/osty-bootstrap-gen` to refresh `internal/selfhost/generated.go`. The
+whole-toolchain LLVM probe still first-walls on the bootstrap-only
+`runtime.golegacy.astbridge` bridge; when those bootstrap-only files are
+excluded, the current native probe first-walls on `Char` parameter lowering
+(`lspUtf16UnitsForChar`). Collections, `Result<T, E>` propagation, and MIR
+closure env emission are partially implemented today, so the remaining work is
+uneven runtime/backend surface coverage rather than a single missing subsystem.
+
 The front-end (lex → parse → resolve → type-check) is **coverage-complete
 for the v0.4 core**: spec blocks parse, package/workspace resolution is
 covered, reject-rules have stable `Exxxx` diagnostics, and the checker

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -1,10 +1,11 @@
 # Toolchain × LLVM compilability — status report
 
 Snapshot date: 2026-04-19. This refresh revalidated the universal CLI / LLVM
-smoke path and the previously named `internal/llvmgen` regressions. The deeper
-`toolchain/*.osty` error-budget counts below are still the 2026-04-18 sample
-until they are re-run end-to-end. Stage numbers shift week-over-week; for the
-live MIR-direct coverage see
+smoke path, re-ran the whole/native merged toolchain probes, and cross-checked
+the current code paths (`internal/check`, `internal/selfhost`,
+`internal/llvmgen`, `internal/bootstrap/gen`) so this report distinguishes
+historical samples from current-tree observations. Stage numbers shift
+week-over-week; for the live MIR-direct coverage see
 [docs/mir_design.md](./mir_design.md) Stage 3.x + Stage 5 sections.
 
 ## TL;DR
@@ -19,25 +20,39 @@ As of 2026-04-19:
 - the four targeted `internal/llvmgen` tests called out in the previous
   snapshot now pass again
 - the parser-side `def: Expr` stable-alias issue remains fixed
+- the whole-toolchain merged LLVM probe still first-walls on the
+  bootstrap-only `runtime.golegacy.astbridge` bridge
+- the native-only merged LLVM probe (with bootstrap-only files skipped)
+  now first-walls on `LLVM011 [fn_param_struct_type]` for `Char`
+  (`lspUtf16UnitsForChar`)
+- the current `osty check --airepair=false toolchain` surface is an
+  aggregate native-checker summary of `3846 error(s)` with
+  `20657 / 20749` assignment/return/call checks accepted
+- code-path inspection shows the remaining gap is no longer best described as
+  "no collections / no Result / no closures": list/map literals and some
+  methods, `Result<T, E>` `?`, runtime-backed `std.strings` shims, and MIR
+  capturing-closure env emission all exist in partial form
 
 That means the universal LLVM entry wedge is closed. The remaining
 toolchain/selfhosting work is now about front-end/toolchain coverage, not "any
 CLI use of LLVM crashes before backend emission."
 
-The 2026-04-18 full-toolchain sample still showed the following blockers:
+Current-tree observations from the code re-audit:
 
 | Layer | Where | What blocks |
 |---|---|---|
-| CLI wiring | historical 2026-04-18 blocker | **resolved in the 2026-04-19 refresh** — hello-world `osty gen --backend=llvm` now exits 0 and writes `.ll` output |
-| Front-end (lexer) | `internal/lexer` string-interpolation path | `"0_{label}"` / `"[a-z0-9_-]*"` inside string literals are flagged E0008 |
-| Front-end (resolver) | `internal/resolve` / `internal/stdlib` | `std.strings` module not in scope — 39 × E0500 in `toolchain/ast_lower.osty` alone |
-| Front-end (parser) | historical 2026-04-18 blocker | **resolved before this refresh** — `def: Expr` is no longer rewritten in `name: Type` positions |
-| Type checker | `internal/check` | 1700 aggregated errors across the package (but 97.6% of assignment/return/call checks still accept — tail is small per-file) |
+| CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
+| Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
+| Native backend surface | merged native-only probe | first wall is `LLVM011 [fn_param_struct_type]` on `Char` (`lspUtf16UnitsForChar`) after skipping 4 bootstrap-only files |
+| Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |
+| Toolchain package health | `osty check --airepair=false toolchain` | current CLI surface is still an aggregate `E0700` summary (`3846 error(s)`) rather than a clean self-compile pass |
+| Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers, but `Char`/`Byte` iteration (`String.chars`, `String.bytes`) still blocks the pure native path |
 
-The MIR-direct emitter itself (Stages 3.1–3.11) covers most of the language
-shapes toolchain uses. The 2026-04-19 refresh narrows the story further:
-backend entry is no longer the first blocker; the remaining wedge is front-end
-bookkeeping plus still-unported/selfhost-only toolchain usage.
+The MIR-direct emitter itself (Stages 3.1–3.11) covers a growing subset of the
+language shapes toolchain uses. The 2026-04-19 refresh narrows the story
+further: backend entry is no longer the first blocker, but the current tree is
+still not "fully self-hosted" because the bootstrap bridge, checker boundary,
+and `Char`/runtime surface all remain live.
 
 ## How the probe was run
 
@@ -45,8 +60,8 @@ bookkeeping plus still-unported/selfhost-only toolchain usage.
 go build -o /tmp/osty ./cmd/osty
 /tmp/osty gen   --backend=llvm   /tmp/hello.osty      >/tmp/hello.ll
 go test ./internal/llvmgen -run 'TestGenerateModuleInterfaceVtableEmitted|TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields|TestGenerateManagedAggregateListsTraceNestedRoots|TestGenerateModulePtrBackedListToSetAndBoolPrint' -count=1
+go test ./internal/llvmgen -run 'TestProbeWholeToolchainMerged|TestProbeNativeToolchainMerged' -count=1 -v
 /tmp/osty check --airepair=false toolchain > /tmp/tc.log 2>&1
-/tmp/osty gen   --backend=llvm   toolchain/core.osty  2>&1   # historical 2026-04-18 sample
 /tmp/osty build --backend=llvm   examples/calc        2>&1
 ```
 
@@ -59,6 +74,16 @@ Observed in the 2026-04-19 refresh:
   `.ll` module containing `define i32 @main()`
 - the targeted `internal/llvmgen` regression set returned
   `ok github.com/osty/osty/internal/llvmgen`
+- `TestProbeWholeToolchainMerged` reported
+  `LLVM002 runtime-ffi: ... runtime.golegacy.astbridge ...`
+- `TestProbeNativeToolchainMerged` skipped
+  `ast_lower.osty, ci.osty, docgen.osty, manifest_validation.osty` and then
+  first-walled on
+  `LLVM011 [fn_param_struct_type] ... type "Char" ... lspUtf16UnitsForChar`
+- `/tmp/osty check --airepair=false toolchain` exited with the aggregate
+  summary
+  `native checker reported type errors: 3846 error(s)` plus
+  `native checker accepted 20657 of 20749 assignment/return/call checks`
 
 ## Layer 1 — universal CLI panic wedge (resolved)
 
@@ -94,7 +119,21 @@ broken before backend reachability." The backend entry path is alive again; the
 next re-profile should focus on actual `toolchain/*.osty` diagnostics and
 selfhosting surface gaps.
 
-## Layer 2 — front-end error budget in `toolchain/` (historical 2026-04-18 sample)
+## Layer 2 — checker error budget (`toolchain/`)
+
+Current-tree command surface:
+
+```text
+$ /tmp/osty check --airepair=false toolchain
+error[E0700]: native checker reported type errors: 3846 error(s)
+= note: native checker accepted 20657 of 20749 assignment/return/call checks
+```
+
+That means the older per-file breakdown below is no longer current-tree ground
+truth; it remains useful only as a historical clue for where the first wave of
+front-end issues was observed before the code re-audit.
+
+### Historical 2026-04-18 sample
 
 Aggregated from `osty check --airepair=false toolchain`:
 
@@ -133,7 +172,7 @@ diagnostics. The fix lives in the lexer's string-literal scanner; the
 symptom is that the number-separator rule is reached from inside the string
 state instead of staying in the number state.
 
-### E0500 — `std.strings` not in scope
+### E0500 — `std.strings` not in scope (historical sample)
 
 29 call sites in `toolchain/ast_lower.osty` (39 diagnostics — some lines
 hold two calls) reference `strings.HasPrefix`, `strings.TrimPrefix`,
@@ -150,6 +189,14 @@ Two equally-valid fixes:
    primitives (`stringAt`, char-index loops, etc). Faster, but doesn't
    help any of the other files that will eventually want `std.strings`.
 
+Code-path note for the current tree: the backend path is no longer best
+described as "`std.strings` is entirely absent". `internal/llvmgen` now ships a
+targeted `std.strings` runtime shim for `compare`, `concat`, `contains`,
+`hasPrefix`, `hasSuffix`, `join`, `split`, `splitN`, `trim*`, and related
+helpers. The remaining blocker is that the pure-Osty stdlib body still depends
+on `Char` iteration / `List<Char>` lowering, so the shim is a bridge rather
+than the final self-hosted endpoint.
+
 ### E0001 — parser trips on `def: Expr` parameter — **fixed**
 
 Root cause was the stable-alias pre-pass in `internal/parser/normalize.go`:
@@ -164,52 +211,59 @@ immediately followed by `:` (parameter / struct field / keyword-argument
 slot). Regression test in
 `internal/parser/parser_features_test.go::TestParseStableAliasesPreservedAsIdentifiers`.
 
-### E0700 — 1700 checker errors, 97.6% accept rate
+### E0700 — aggregate checker summary
 
 ```
 native checker reported type errors: 1700 error(s)
 note: native checker accepted 26191 of 26850 assignment/return/call checks
 ```
 
-Most likely a cascade from the E0500 / E0001 failures above: once a type
-can't be resolved (e.g. a `strings.Split` call site), every transitively
-dependent `Arg`/`Return` site also fails its type constraint. Clearing
-Layer 1 + 2 should knock this number down by an order of magnitude before
-any individual-site chasing is worthwhile.
+On the current tree the visible summary is larger (`3846` errors with
+`20657 / 20749` accepted), so the old `1700` figure should now be treated as a
+historical snapshot only. The same general caveat still applies: large summary
+counts are likely to hide a much smaller set of root-cause wedges, and the
+whole/native probe results suggest `Char` + bootstrap-only host boundaries are
+now higher-priority roots than the old parser alias bug.
 
 ## Layer 3 — MIR-direct backend coverage (for context)
 
 Live coverage and remaining gaps are tracked in
 [docs/mir_design.md](./mir_design.md) (Stage 3.x for landed shapes,
-Stage 5 for deferred parity items). The outstanding items at the time
-of writing are not tripped during `osty check` or `osty gen` IR
-emission, so the work budget to reach "`toolchain/*.osty` links into a
-runnable binary" is dominated by Layer 1 + Layer 2, not Layer 3.
+Stage 5 for deferred parity items). The code re-audit also found that the tree
+already has more backend surface than the earlier prose implied:
+
+- legacy AST llvmgen lowers list/map literals plus a subset of collection
+  methods
+- legacy AST llvmgen lowers `Result<T, E>` `?` when the enclosing function
+  returns a compatible `Result<_, E>`
+- MIR lowering already has capturing-closure env emission and tests
+
+So the remaining budget is not "add collections/Result/closures from zero"; it
+is closer to "finish the missing runtime/type surface, retire the shims, and
+rewire the remaining Go-hosted boundaries."
 
 ## Recommended fix order (smallest → largest unlock)
 
-1. **Re-run the full `toolchain` sample on the current tree** and replace the
-   historical 2026-04-18 counts. The universal CLI panic wedge is already
-   closed, so fresh numbers matter more than old ones now.
+1. **Treat the merged native probe as the current primary signal.**
+   The first real wall is now `Char` parameter lowering, not the old CLI panic
+   and not the already-fixed `def: Expr` alias issue.
 
-2. **Fix the string-interpolation lexer bug** (E0008). Six sites in the last
-   full sample,
-   pattern is well-defined, fixture is small. Unblocks `lsp.osty`,
-   `ci.osty`, `manifest_validation.osty`.
+2. **Shrink the aggregate checker summary on the current tree.**
+   Re-profile the `3846`-error native-checker summary into a current histogram
+   before making more claims from the 2026-04-18 sample.
 
-3. **Decide `std.strings` policy.** Either port it (29 call sites in
-   one file say the demand is real) or rewrite `ast_lower.osty` against
-   existing primitives. Unblocks `ast_lower.osty`.
+3. **Finish the `Char` / `Byte` / string iteration surface.**
+   The native probe's first wall and the current `std.strings` shim both point
+   at the same missing runtime/type area (`String.chars`, `String.bytes`,
+   `List<Char>`, and related ABI details).
 
-4. ~~**Investigate parser sensitivity to `def`** inside FFI `use` blocks.~~
-   Done — stable-alias pre-pass now skips rewrites when the identifier
-   sits in `name : type` position.
+4. **Retire the bootstrap-only bridge files from the critical path.**
+   Whole-toolchain merged lowering still first-walls on
+   `runtime.golegacy.astbridge`, so the self-hosting story stays incomplete
+   until the CLI is rewired away from those files or they remain explicitly
+   outside the native path.
 
-5. **Re-run `osty check toolchain`** — expect the 1700 native-checker
-   summary to collapse with most cascades gone. Remaining tail becomes a
-   focused second pass.
-
-6. **Try `osty gen --backend=llvm toolchain/<file>.osty`** per-file.
-   The MIR-direct emitter covers most of the language shapes toolchain
-   uses (see [mir_design.md](./mir_design.md)); anything that trips
-   `mir-mvp` unsupported is a new, narrower wedge for the MIR roadmap.
+5. **Then re-run `osty check toolchain` and per-file `osty gen --backend=llvm`
+   probes.**
+   Once the `Char`/bootstrap wedges move, the remaining tail should become a
+   much narrower backend/runtime parity queue.


### PR DESCRIPTION
## What changed
Updated the self-hosting / LLVM status docs to match the current code paths and probe results.

## Why
The previous docs were directionally useful, but several points were outdated or too absolute compared with the current tree. In particular, the code now has partial support for collections, `Result<T, E>` propagation, `std.strings` runtime shims, and MIR closure env emission, while the real remaining blockers are the bootstrap bridge, the managed native-checker boundary, and the current `Char`-related native probe wall.

## Impact
Readers should now get a more accurate picture of how far the repository is from full self-hosting and which gaps are still live in code today.

## Root cause
The docs had not been refreshed against the latest implementation and probe outputs after the LLVM entry wedge was resolved and partial backend/runtime surface area had landed.

## Validation
- Reviewed the current implementations in `internal/check`, `internal/selfhost`, `internal/llvmgen`, `internal/bootstrap/gen`, and related toolchain files
- Re-ran the whole/native merged LLVM probe tests
- Re-ran `osty check --airepair=false toolchain` and reflected the current aggregate summary in the status doc
