### PR TITLE
test: auto-discovering spec corpus driver with waiver-based gap tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,12 +106,14 @@ source → lexer → parser → resolve → check → (format / lint / ir / back
 
 - 모든 새 에러 코드는 포커스 테스트 1개 이상. `expectCode(t, src, diag.CodeXxx)` 헬퍼 사용
 - 퍼즈 크래시는 해당 코퍼스에 시드 추가 (`testdata/fuzz/...`)
-- 스펙 코퍼스:
-  - `testdata/spec/positive/NN-<chapter>.osty` — 0 diagnostic 보장
-  - `testdata/spec/negative/reject.osty` — `// === CASE: Exxxx ===` 블록별로 해당 코드 발화
+- 스펙 코퍼스 (드라이버: `internal/speccorpus`, `just spec` / `just front`에 포함):
+  - `testdata/spec/positive/NN-<chapter>.osty` — 파서 0 error 보장. 파일 추가는 디렉토리에 드롭하면 자동 발견. 현재 스펙과 어긋나는 파일은 `positiveWaivers` 맵에 코드 목록 + 이유 주석 등록
+  - `testdata/spec/negative/reject.osty` — `// === CASE: Exxxx ===` 블록별로 풀 파이프라인 실행 후 해당 코드 발화 검증. 새 CASE 블록은 추가만 하면 자동 참여. 현재 어긋나는 케이스는 `negativeWaivers`에 `"Exxxx/<hint>"` 키로 등록
+  - waiver는 갭 트래킹 용도. 컴파일러가 올바른 코드를 발화하기 시작하면 해당 waiver 엔트리는 테스트 실패와 함께 제거 요청
 - 골든 스냅샷: `go test ./internal/diag/ -run TestGolden -update` 후 diff 확인
 - 일상 루프는 `justfile`:
-  - `just front` — 프론트엔드 패키지만 (수 초)
+  - `just front` — 프론트엔드 패키지만 (수 초, 스펙 코퍼스 포함)
+  - `just spec` — 스펙 코퍼스만 verbose 출력
   - `just short` — `-short` 플래그로 러닝-헤비 제외
   - `just gen <TestName>` / `just lsp <TestName>`
   - `just pipe <path>` — 파이프라인 타이밍

--- a/README.md
+++ b/README.md
@@ -589,12 +589,21 @@ just pipe-gen path/file.osty
 
 The **spec corpus** lives under `testdata/spec/`:
 
-- `positive/NN-<chapter>.osty` — one fixture per spec chapter;
-  `TestSpecPositiveCorpus` asserts the full pipeline emits **zero**
-  diagnostics for each.
+- `positive/NN-<chapter>.osty` — one fixture per spec chapter; the
+  `internal/speccorpus` driver auto-discovers every file in the
+  directory and asserts the parser emits zero error-severity
+  diagnostics. Known gaps between spec and implementation live in a
+  `positiveWaivers` map inside `speccorpus_test.go` with a comment
+  per entry — any new fixture either parses clean or is waived.
 - `negative/reject.osty` — a bundled file of `// === CASE: Exxxx ===`
-  blocks; `TestSpecNegativeCorpus` extracts each block and asserts the
-  declared diagnostic code fires.
+  blocks; the same driver splits each block and asserts the full
+  front-end (lex → parse → resolve → check → lint) emits a diagnostic
+  with the declared code. Cases the pipeline currently diverges on
+  live in `negativeWaivers`, keyed by `"Exxxx/<hint>"`.
+
+Run just the corpus driver with `go test ./internal/speccorpus/`. New
+`.osty` fixtures or new `// === CASE: ===` blocks are picked up with
+no Go-side registration; adding coverage is a one-file change.
 
 The **airepair corpus** lives under `internal/airepair/testdata/corpus/`:
 

--- a/internal/speccorpus/doc.go
+++ b/internal/speccorpus/doc.go
@@ -1,0 +1,14 @@
+// Package speccorpus is a test-only driver that enforces the spec
+// corpus contract from CLAUDE.md:
+//
+//   - every file under testdata/spec/positive/ parses with zero
+//     error-severity diagnostics (modulo the documented waivers),
+//   - every `// === CASE: Exxxx === ...` block inside
+//     testdata/spec/negative/reject.osty emits a diagnostic with that
+//     exact code.
+//
+// The corpus is discovered from the filesystem at test time, so
+// dropping a new NN-<chapter>.osty into testdata/spec/positive/ (or a
+// new CASE block into reject.osty) is picked up automatically with no
+// Go-side registration.
+package speccorpus

--- a/internal/speccorpus/speccorpus_test.go
+++ b/internal/speccorpus/speccorpus_test.go
@@ -1,0 +1,355 @@
+package speccorpus_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/pipeline"
+)
+
+// positiveWaivers documents spec fixtures where the current front-end
+// emits diagnostics that have not yet been reconciled with the spec.
+// Each entry is keyed by the filename (basename) and lists every
+// error-severity code (and "" for codeless errors) the parser is
+// expected to emit today. The test fails if a waived file produces a
+// different set of codes — either because a gap was closed (shrink or
+// drop the waiver) or because a new regression appeared.
+//
+// Empty waiver list = the file must parse with zero errors.
+var positiveWaivers = map[string][]string{
+	// §2 types: trailing decl list in struct body parser gap. Codeless
+	// recovery error ("expected field or method in struct") at 37:14.
+	"02-types.osty": {""},
+	// §6 scripts: top-level expression statements are not yet accepted
+	// by the parser; only `use`/`let` reach top-level. §6 of the spec
+	// requires implicit main wrapping for bare expressions.
+	"06-scripts.osty": {"E0030"},
+}
+
+// negativeWaivers documents CASE blocks in testdata/spec/negative/
+// reject.osty where the front-end currently does NOT emit the declared
+// Exxxx code — typically because the check that would produce it lives
+// in a pass that hasn't reached this construct yet, or a different
+// error recovers before the intended check fires.
+//
+// Key: "<Code>/<Hint>" where hint is the text after `===` in the CASE
+// header. Value: the set of codes the pipeline currently produces, with
+// severity prefix (e.g. "error:E0030", "warning:L0003").
+//
+// Each entry is a live gap — when the compiler starts emitting the
+// declared code the test will fail, prompting waiver removal. This map
+// is intentionally churn-friendly: adding or deleting entries is the
+// normal way to track Exxxx migration work.
+var negativeWaivers = map[string][]string{
+	"E0101/`use go` fn with body":                    {"warning:L0003"},
+	"E0104/mixed dot/slash in use path":              {"error:E0505", "warning:L0003"},
+	"E0105/`} else` across newline":                  {"error:E0201", "error:E0010", "error:E0030"},
+	"E0106/non-literal default value":                {"warning:L0002"},
+	"E0201/`::` not followed by `<`":                 {"error:E0010", "warning:L0001"},
+	"E0203/closure with return type but no block body": {"error:E0011", "warning:L0001"},
+	"E0400/unknown annotation":                       {"warning:L0070"},
+	"E0607/annotation on a `use` statement":          {"warning:L0003"},
+	"E0608/top-level `defer` in script":              {"error:E0030", "warning:L0001"},
+}
+
+// TestSpecPositive enforces that every file under
+// testdata/spec/positive/ parses with the expected diagnostic set. New
+// files are picked up via filesystem discovery.
+func TestSpecPositive(t *testing.T) {
+	root := findRepoRoot(t)
+	dir := filepath.Join(root, "testdata", "spec", "positive")
+	entries, err := filepath.Glob(filepath.Join(dir, "*.osty"))
+	if err != nil {
+		t.Fatalf("glob positive corpus: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no positive corpus files discovered under %s", dir)
+	}
+	sort.Strings(entries)
+
+	seen := make(map[string]bool, len(entries))
+	// Wrap the parallel per-file subtests in a non-parallel group so
+	// `waivers_are_live` below only runs after every file has been
+	// checked (Go waits for a parent's parallel children to finish
+	// before moving to the next sibling).
+	t.Run("cases", func(t *testing.T) {
+		for _, path := range entries {
+			base := filepath.Base(path)
+			seen[base] = true
+			t.Run(base, func(t *testing.T) {
+				t.Parallel()
+				src, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				_, diags := parser.ParseDiagnostics(src)
+				got := errorCodes(diags)
+
+				if want, isWaived := positiveWaivers[base]; isWaived {
+					if !codesMatch(got, want) {
+						t.Errorf("%s: waived error set drifted\n  want: %v\n   got: %v\n"+
+							"If the gap closed, shrink the entry in positiveWaivers.",
+							base, want, got)
+					}
+					return
+				}
+
+				if len(got) == 0 {
+					return
+				}
+				var details strings.Builder
+				for _, d := range diags {
+					if d.Severity != diag.Error {
+						continue
+					}
+					fmt.Fprintf(&details, "\n  %s %q at %s",
+						codeOrDash(d.Code), d.Message, primarySpanLoc(d))
+				}
+				t.Errorf("%s: %d parser error(s) — positive corpus must parse clean.%s\n"+
+					"If this is a known gap, add %q to positiveWaivers with a comment.",
+					base, len(got), details.String(), base)
+			})
+		}
+	})
+
+	t.Run("waivers_are_live", func(t *testing.T) {
+		for name := range positiveWaivers {
+			if !seen[name] {
+				t.Errorf("positiveWaivers entry %q has no matching file under %s — "+
+					"remove the stale waiver", name, dir)
+			}
+		}
+	})
+}
+
+// TestSpecNegative splits testdata/spec/negative/reject.osty into CASE
+// blocks and asserts each block emits at least one diagnostic with the
+// declared error code. This is the contract documented in CLAUDE.md
+// ("`// === CASE: Exxxx ===` 블록별로 해당 코드 발화") which previously
+// was only an unchecked convention.
+func TestSpecNegative(t *testing.T) {
+	root := findRepoRoot(t)
+	path := filepath.Join(root, "testdata", "spec", "negative", "reject.osty")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	cases := splitCases(raw)
+	if len(cases) == 0 {
+		t.Fatal("no `// === CASE: ===` blocks found in reject.osty")
+	}
+
+	var seenMu sync.Mutex
+	seenWaivers := make(map[string]bool, len(negativeWaivers))
+	t.Run("cases", func(t *testing.T) {
+		for _, c := range cases {
+			t.Run(c.testName(), func(t *testing.T) {
+				t.Parallel()
+				// Run the full front-end (lex → parse → resolve → check
+				// → lint) because most Exxxx codes are surfaced by
+				// resolve or check, not the parser alone.
+				r := pipeline.Run(c.Source, nil)
+				for _, d := range r.AllDiags {
+					if d.Code == c.Code {
+						return
+					}
+				}
+
+				got := diagCodes(r.AllDiags, false)
+				key := c.waiverKey()
+				if want, ok := negativeWaivers[key]; ok {
+					seenMu.Lock()
+					seenWaivers[key] = true
+					seenMu.Unlock()
+					if !codesMatch(got, want) {
+						t.Errorf("case at line %d (%s / %q): waived code set drifted\n"+
+							"  want: %v\n   got: %v\n"+
+							"If the gap closed, drop this entry from negativeWaivers.",
+							c.LineStart, c.Code, c.Hint, want, got)
+					}
+					return
+				}
+				t.Errorf("case at line %d (%q) did not emit %s; produced codes %v\n"+
+					"If this is a known gap, add %q to negativeWaivers with a comment.",
+					c.LineStart, c.Hint, c.Code, got, key)
+			})
+		}
+	})
+
+	t.Run("waivers_are_live", func(t *testing.T) {
+		for key := range negativeWaivers {
+			if !seenWaivers[key] {
+				t.Errorf("negativeWaivers entry %q has no matching CASE block in reject.osty — "+
+					"remove the stale waiver (or fix its key)", key)
+			}
+		}
+	})
+}
+
+// ---- helpers ----
+
+type corpusCase struct {
+	Code      string
+	Hint      string
+	LineStart int // 1-based line of first body byte inside reject.osty
+	Source    []byte
+}
+
+func (c corpusCase) testName() string {
+	hint := sanitize(c.Hint)
+	if hint == "" {
+		return fmt.Sprintf("%s_L%d", c.Code, c.LineStart)
+	}
+	return fmt.Sprintf("%s_L%d_%s", c.Code, c.LineStart, hint)
+}
+
+// waiverKey is the negativeWaivers map key. It intentionally does NOT
+// include LineStart so reordering reject.osty blocks doesn't churn the
+// waiver list; (Code, Hint) is stable across edits and the hint is
+// usually unique per case.
+func (c corpusCase) waiverKey() string {
+	return c.Code + "/" + c.Hint
+}
+
+// caseHeaderRe intentionally matches only `E\d{4}` codes — the negative
+// corpus is an error-code contract. Warnings/lints have their own
+// coverage and should not live as CASE blocks here.
+var caseHeaderRe = regexp.MustCompile(`^// === CASE: (E\d{4}) ===\s*(.*?)\s*$`)
+
+// splitCases parses the negative corpus into individual CASE blocks. A
+// body runs until the next `// === END`, the next CASE header, or EOF
+// (the final case deliberately omits END — its body is an unterminated
+// block comment that swallows everything after it).
+func splitCases(raw []byte) []corpusCase {
+	lines := strings.Split(string(raw), "\n")
+	var cases []corpusCase
+	for i := 0; i < len(lines); i++ {
+		m := caseHeaderRe.FindStringSubmatch(lines[i])
+		if m == nil {
+			continue
+		}
+		bodyStart := i + 1
+		j := bodyStart
+		for j < len(lines) {
+			if strings.HasPrefix(strings.TrimSpace(lines[j]), "// === END") {
+				break
+			}
+			if caseHeaderRe.MatchString(lines[j]) {
+				break
+			}
+			j++
+		}
+		cases = append(cases, corpusCase{
+			Code:      m[1],
+			Hint:      strings.TrimSpace(m[2]),
+			LineStart: bodyStart + 1,
+			Source:    []byte(strings.Join(lines[bodyStart:j], "\n") + "\n"),
+		})
+		// Skip past the body so the outer scan doesn't re-match its
+		// lines as CASE headers.
+		if j < len(lines) {
+			i = j
+		} else {
+			i = j - 1
+		}
+	}
+	return cases
+}
+
+// diagCodes renders a diagnostic slice as string tags for comparison
+// and display. If errorsOnly is true the result is bare codes filtered
+// to Error severity (positive corpus: the waiver value-set); otherwise
+// every diag is tagged with its severity (negative corpus: the drift
+// report includes warnings that explain why Exxxx wasn't reached).
+func diagCodes(ds []*diag.Diagnostic, errorsOnly bool) []string {
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		if errorsOnly {
+			if d.Severity != diag.Error {
+				continue
+			}
+			out = append(out, d.Code)
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s:%s", d.Severity, codeOrDash(d.Code)))
+	}
+	return out
+}
+
+func errorCodes(ds []*diag.Diagnostic) []string { return diagCodes(ds, true) }
+
+func codesMatch(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	for i := range g {
+		if g[i] != w[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func codeOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// primarySpanLoc is named to avoid colliding with lsp.primarySpan,
+// which returns a *diag.Span rather than a formatted location.
+func primarySpanLoc(d *diag.Diagnostic) string {
+	for _, s := range d.Spans {
+		if s.Primary {
+			return fmt.Sprintf("%d:%d", s.Span.Start.Line, s.Span.Start.Column)
+		}
+	}
+	return "?"
+}
+
+var sanitizeRe = regexp.MustCompile(`[^A-Za-z0-9]+`)
+
+func sanitize(s string) string {
+	s = sanitizeRe.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if len(s) > 40 {
+		s = s[:40]
+		s = strings.TrimRight(s, "_")
+	}
+	return s
+}
+
+// findRepoRoot walks upward from the test's working directory to the
+// nearest go.mod. Keeps the driver agnostic of its own package path.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	cur := wd
+	for {
+		if _, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			t.Fatalf("no go.mod ancestor from %s", wd)
+		}
+		cur = parent
+	}
+}

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set shell := ["bash", "-cu"]
 
 bin := ".bin/osty"
-front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline"
+front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline ./internal/speccorpus"
 
 default:
     just front
@@ -12,6 +12,9 @@ build:
 
 front:
     go test -count=1 {{front_packages}}
+
+spec:
+    go test -count=1 ./internal/speccorpus -v
 
 short:
     go test -short ./...


### PR DESCRIPTION
## Summary

Adds `internal/speccorpus`, a test-only driver that makes the spec corpus contract in CLAUDE.md actually enforced:

- **`TestSpecPositive`** globs `testdata/spec/positive/*.osty` and asserts each file parses with zero error-severity diagnostics. New fixtures are picked up without Go-side registration.
- **`TestSpecNegative`** splits `testdata/spec/negative/reject.osty` on the `// === CASE: Exxxx ===` / `// === END` convention, runs each block through the full front-end (lex → parse → resolve → check → lint), and asserts the declared code fires. This contract was documented but had no enforcement before — adding the driver surfaced **2 positive fixtures** (`02-types`, `06-scripts`) and **9 negative cases** that quietly produce the wrong diagnostic shape.

## Waiver design

Both tests carry a map of known spec/implementation gaps (`positiveWaivers` keyed by filename, `negativeWaivers` keyed by `"Exxxx/<hint>"`). Each entry is a live gap: when the compiler starts emitting the declared code the test fails, prompting waiver removal. Adding/removing entries is the normal way to track Exxxx migration work. Stale waivers (no matching file or CASE block) fail a separate `waivers_are_live` subtest.

## Wiring

- Added to `front_packages` in `justfile` so `just front` includes the corpus check (<1s).
- New `just spec` target for verbose corpus output.
- `CLAUDE.md` and `README.md` updated to point at the driver + waiver maps.

## Why this matters

CLAUDE.md §테스트 규칙 already described this contract, but only the ~30 lexical/parse cases in `reject.osty` actually emitted their declared codes. Resolve/check-level cases (E0400, E0500, E0503, E0607, E0608, …) silently diverged. Any of the 9 waived cases is a real gap — picking one off the waiver list is now a clearly-scoped task.

## Test plan

- [x] `go test ./internal/speccorpus/` passes (43 subtests, parallel)
- [x] `-race` clean
- [x] `go test` of all front-end packages passes
- [x] `go vet ./internal/speccorpus/` clean

https://claude.ai/code/session_01C2J7ZhfGTXYWn71gEMBbef