### PR TITLE
feat(check): 미식별 식별자 진단에 "did you mean" 제안 부착

### DIFF
--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -344,6 +344,162 @@ pub fn diagRefutablePattern(context: String, start: Int, end: Int) -> CheckDiagn
 }
 
 // ---------------------------------------------------------------------
+// Suggestion helpers — used to attach "did you mean `foo`?" hints to
+// diagnostics whose primary message is of the form "cannot find
+// `{name}` ...". Callers gather the candidate pool (in-scope bindings,
+// struct fields, enum variants, ...) and hand it off here; the
+// suggestion picks the nearest neighbour by bounded edit distance.
+// ---------------------------------------------------------------------
+
+/// checkSuggestSimilar returns the closest match from `candidates` for
+/// `name` using bounded Levenshtein distance, or `""` when no
+/// candidate is within edit distance 2. The early-exit logic keeps
+/// this usable at every unknown-name site without quadratic blowup —
+/// only candidates within ±(limit-1) characters get the full matrix.
+pub fn checkSuggestSimilar(candidates: List<String>, name: String) -> String {
+    if name == "" {
+        return ""
+    }
+    let mut best = ""
+    let mut bestDist = 3
+    let nameLen = checkDiagStringUnitCount(name)
+    for candidate in candidates {
+        if candidate == "" || candidate == name {
+            continue
+        }
+        let candLen = checkDiagStringUnitCount(candidate)
+        let diff = candLen - nameLen
+        if diff > bestDist - 1 || 0 - diff > bestDist - 1 {
+            continue
+        }
+        let dist = checkDiagLevenshteinBounded(name, candidate, bestDist)
+        if dist < bestDist {
+            best = candidate
+            bestDist = dist
+            if bestDist == 1 {
+                return best
+            }
+        }
+    }
+    best
+}
+
+/// diagDidYouMean formats `suggestion` as the canonical "did you mean
+/// `x`?" hint, or returns `""` when `suggestion` is empty. Keeping the
+/// formatting here means every diagnostic site phrases the hint
+/// identically without threading a literal template.
+pub fn diagDidYouMean(suggestion: String) -> String {
+    if suggestion == "" {
+        return ""
+    }
+    "did you mean `{suggestion}`?"
+}
+
+/// checkDiagAttachHint returns a copy of `d` with an extra
+/// "hint: {text}" note appended. When `text` is empty the diagnostic
+/// is returned unchanged so callers can funnel optional suggestions
+/// through without conditionals at the call site.
+pub fn checkDiagAttachHint(d: CheckDiagnostic, text: String) -> CheckDiagnostic {
+    if text == "" {
+        return d
+    }
+    let mut notes: List<String> = []
+    for existing in d.notes {
+        notes.push(existing)
+    }
+    notes.push("hint: {text}")
+    CheckDiagnostic {
+        code: d.code,
+        severity: d.severity,
+        message: d.message,
+        start: d.start,
+        end: d.end,
+        notes,
+    }
+}
+
+fn checkDiagStringUnitCount(text: String) -> Int {
+    let mut count = 0
+    for unit in strings.split(text, "") {
+        if unit != "" {
+            count = count + 1
+        }
+    }
+    count
+}
+
+fn checkDiagLevenshteinBounded(left: String, right: String, limit: Int) -> Int {
+    if left == right {
+        return 0
+    }
+    let leftUnits = strings.split(left, "")
+    let rightUnits = strings.split(right, "")
+    let leftLen = checkDiagStringUnitCount(left)
+    let rightLen = checkDiagStringUnitCount(right)
+    let diff = leftLen - rightLen
+    if diff >= limit || 0 - diff >= limit {
+        return limit
+    }
+    let mut prev: List<Int> = []
+    let mut cur: List<Int> = []
+    let mut j = 0
+    for j <= rightLen {
+        prev.push(j)
+        cur.push(0)
+        j = j + 1
+    }
+    let mut i = 1
+    for i <= leftLen {
+        cur[0] = i
+        let mut rowMin = cur[0]
+        j = 1
+        for j <= rightLen {
+            let leftUnit = checkDiagStringListAt(leftUnits, i - 1)
+            let rightUnit = checkDiagStringListAt(rightUnits, j - 1)
+            let cost = if leftUnit == rightUnit {
+                0
+            } else {
+                1
+            }
+            let mut dist = prev[j] + 1
+            if cur[j - 1] + 1 < dist {
+                dist = cur[j - 1] + 1
+            }
+            if prev[j - 1] + cost < dist {
+                dist = prev[j - 1] + cost
+            }
+            cur[j] = dist
+            if dist < rowMin {
+                rowMin = dist
+            }
+            j = j + 1
+        }
+        if rowMin >= limit {
+            return limit
+        }
+        j = 0
+        for j <= rightLen {
+            prev[j] = cur[j]
+            cur[j] = 0
+            j = j + 1
+        }
+        i = i + 1
+    }
+    prev[rightLen]
+}
+
+fn checkDiagStringListAt(items: List<String>, target: Int) -> String {
+    let mut idx = 0
+    for item in items {
+        if idx == target {
+            return item
+        }
+        idx = idx + 1
+    }
+    ""
+}
+
+// ---------------------------------------------------------------------
 // Store helpers — the elaborator keeps a `List<CheckDiagnostic>` on
 // its context. These helpers append without forgetting to stamp the
 // severity, and they count errors for the legacy summary contract.

--- a/toolchain/check_diag_test.osty
+++ b/toolchain/check_diag_test.osty
@@ -71,6 +71,39 @@ fn testCheckDiagRenderIncludesCode() {
     testing.assert(stringsContains(rendered, "error"))
 }
 
+fn testCheckSuggestSimilarReturnsNearestName() {
+    let suggestion = checkSuggestSimilar(["length", "weight", "height"], "lenght")
+    testing.assertEq(suggestion, "length")
+}
+
+fn testCheckSuggestSimilarIgnoresSelfAndFarCandidates() {
+    let none = checkSuggestSimilar(["bar", "baz"], "completelyUnrelated")
+    testing.assertEq(none, "")
+
+    let selfSkipped = checkSuggestSimilar(["foo", "foobar"], "foo")
+    testing.assertEq(selfSkipped, "")
+}
+
+fn testDiagDidYouMeanFormatsSuggestion() {
+    testing.assertEq(diagDidYouMean("length"), "did you mean `length`?")
+    testing.assertEq(diagDidYouMean(""), "")
+}
+
+fn testCheckDiagAttachHintAppendsHintNote() {
+    let base = diagUnknownName("lenght", 0, 6)
+    let annotated = checkDiagAttachHint(base, diagDidYouMean("length"))
+    testing.assertEq(annotated.code, "E0745")
+    testing.assertEq(annotated.notes.len(), 1)
+    testing.assert(stringsContains(annotated.notes[0], "did you mean `length`"))
+    testing.assert(stringsContains(annotated.notes[0], "hint"))
+}
+
+fn testCheckDiagAttachHintIgnoresEmptyText() {
+    let base = diagUnknownName("foo", 0, 3)
+    let unchanged = checkDiagAttachHint(base, "")
+    testing.assertEq(unchanged.notes.len(), 0)
+}
+
 // Substring helper — thin wrapper on `std.strings.contains` so the
 // assertions above read like plain boolean checks.
 fn stringsContains(haystack: String, needle: String) -> Bool {

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1144,6 +1144,25 @@ fn checkStringListContainsLocal(xs: List<String>, needle: String) -> Bool {
     false
 }
 
+/// checkVisibleBindingNames collects the identifiers reachable at the
+/// current elaboration point — all active lexical bindings plus every
+/// registered top-level free function. This is the candidate pool the
+/// unknown-ident diagnostic path hands to `checkSuggestSimilar`.
+pub fn checkVisibleBindingNames(env: CheckEnv) -> List<String> {
+    let mut out: List<String> = []
+    for b in env.bindings {
+        if !(checkStringListContainsLocal(out, b.name)) {
+            out.push(b.name)
+        }
+    }
+    for sig in env.fns {
+        if sig.owner == "" && !(checkStringListContainsLocal(out, sig.name)) {
+            out.push(sig.name)
+        }
+    }
+    out
+}
+
 pub fn emptyCheckBinding() -> CheckBinding {
     CheckBinding { name: "", ty: -1, mutable: false, start: -1, end: -1 }
 }

--- a/toolchain/check_test.osty
+++ b/toolchain/check_test.osty
@@ -120,6 +120,30 @@ fn checkResultSymbolType(result: FrontCheckResult, kind: String, name: String, o
     found
 }
 
+fn testSelfCheckerSuggestsSimilarNameForTypoIdent() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            fn main() {
+                let length: Int = 10
+                let n: Int = lenght
+            }
+            """,
+    )
+
+    testing.assert(checked.summary.errors > 0)
+    let mut sawSuggestion = false
+    for d in checked.diagnostics {
+        if d.code == "E0745" {
+            for note in d.notes {
+                if note == "hint: did you mean `length`?" {
+                    sawSuggestion = true
+                }
+            }
+        }
+    }
+    testing.assert(sawSuggestion)
+}
+
 fn testSelfCheckerReportsAssignmentReturnAndCallErrors() {
     let checked = frontendCheckSource(
         r"""

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -260,7 +260,15 @@ fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
         return ElabResult { node: coreIdx, ty: fnTy }
     }
     // Fall through — unknown name.
-    cx.env.diagnostics.push(diagUnknownName(node.text, node.start, node.end))
+    let suggestion = checkSuggestSimilar(
+        checkVisibleBindingNames(cx.env),
+        node.text,
+    )
+    let diag = checkDiagAttachHint(
+        diagUnknownName(node.text, node.start, node.end),
+        diagDidYouMean(suggestion),
+    )
+    cx.env.diagnostics.push(diag)
     elabPoisonResult(cx, node.start, node.end)
 }
 


### PR DESCRIPTION
## Summary
- `elabInferIdent`의 fallthrough 경로가 미식별 이름을 만나면 현재 스코프의 로컬 바인딩 + 최상위 free 함수 후보에 bounded Levenshtein(limit 3)을 돌려 최근접 이름을 찾고, `hint: did you mean \`x\`?` 노트를 E0745에 첨부한다.
- 진단 유틸은 `toolchain/check_diag.osty`에 공개 API 3종(`checkSuggestSimilar`, `diagDidYouMean`, `checkDiagAttachHint`)으로 추가했고, 후보 풀 수집은 `check_env.osty`의 `checkVisibleBindingNames`가 담당한다.

## Details
- `check_diag.osty`: 편집 거리 한도(limit 3)와 ±(limit-1) 길이 컷오프로 O(nm) 행렬을 후보별로 부분적으로만 채운다. 비 ASCII 대응은 `strings.split(s, "")` 기반 유닛 카운트로 처리.
- `check_env.osty`: 활성 바인딩 스택(`env.bindings`)과 `env.fns` 중 `owner == ""`인 자유 함수만 모아 중복 없이 반환.
- `elab.osty`: 기존 `diagUnknownName(...)` 대신 suggestion + `checkDiagAttachHint` 조합으로 감싸 push. 제안이 비어 있으면 attach가 원본을 그대로 돌려주므로 성능/포맷 회귀 없음.

## Scope notes
- 제안 부착은 우선 E0745 한 경로에만 연결. `diagUnknownField` / `diagUnknownMethod` / `diagUnknownVariant`도 같은 패턴으로 확장 가능하지만 후보 풀 수집기가 필요해 분리 PR로 남긴다.
- `internal/selfhost/generated.go`는 현재 사전에 깨진 상태(regen이 사전 실패)라 이 PR에서는 재생성하지 않았다. 번들러가 복구되면 다음 regen에 자동 반영된다.

## Test plan
- [ ] `just front` (기존 회귀 감시)
- [ ] `go test ./internal/check ./internal/diag` (현재 그린)
- [ ] 번들 재생성 복구 이후 `frontendCheckSourceStructured`를 타는 `testSelfCheckerSuggestsSimilarNameForTypoIdent`가 실제 노트 전파를 확인

https://claude.ai/code/session_012tw1M8a41FT5WhSEhwqHo9