### PR TITLE
feat(llvmgen): Char/Byte primitive lowering (LLVM011 해소)

### DIFF
--- a/LLVM_MIGRATION_PLAN.md
+++ b/LLVM_MIGRATION_PLAN.md
@@ -737,7 +737,7 @@ match 분해)를 추가한다.
 ### Probe 쌍
 
 - `TestProbeWholeToolchainMerged` — 모든 파일 포함. 현재 첫 wall **LLVM002 `runtime.golegacy.astbridge`** (bootstrap artifact).
-- `TestProbeNativeToolchainMerged` — bootstrap-only 파일 제외. 현재 첫 wall **LLVM011 `fn_param_struct_type: Char`** (`charToDigit` param). **진짜 native 경로의 다음 벽**.
+- `TestProbeNativeToolchainMerged` — bootstrap-only 파일 제외. 현재 첫 wall **LLVM012 (statement form)**. 이전의 **LLVM011 `fn_param_struct_type: Char`** 벽(`lspUtf16UnitsForChar`)은 `Char`→i32 / `Byte`→i8 lowering + `Char.toInt()` / `Byte.toInt()` / `Int.toChar()` 폭 변환 + 부호 없는 비교 서술어 도입으로 해소됨.
 
 두 probe의 첫-wall 차이 = bootstrap 브릿지가 히스토그램에 주입하는 노이즈 양. migration 진전은 native probe의 first-wall 이동으로 측정한다.
 

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -23,8 +23,11 @@ As of 2026-04-19:
 - the whole-toolchain merged LLVM probe still first-walls on the
   bootstrap-only `runtime.golegacy.astbridge` bridge
 - the native-only merged LLVM probe (with bootstrap-only files skipped)
-  now first-walls on `LLVM011 [fn_param_struct_type]` for `Char`
-  (`lspUtf16UnitsForChar`)
+  now first-walls on `LLVM012` (statement-form restriction); the previous
+  `LLVM011 [fn_param_struct_type]` Char wall at `lspUtf16UnitsForChar`
+  has been resolved by lowering `Char` to `i32` and `Byte` to `i8`
+  together with `Char.toInt()` / `Byte.toInt()` / `Int.toChar()` width
+  conversions and unsigned compare predicates
 - the current `osty check --airepair=false toolchain` surface is an
   aggregate native-checker summary of `3846 error(s)` with
   `20657 / 20749` assignment/return/call checks accepted
@@ -43,10 +46,10 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
-| Native backend surface | merged native-only probe | first wall is `LLVM011 [fn_param_struct_type]` on `Char` (`lspUtf16UnitsForChar`) after skipping 4 bootstrap-only files |
+| Native backend surface | merged native-only probe | first wall is now `LLVM012` (statement form) after skipping 4 bootstrap-only files; the earlier `LLVM011 [fn_param_struct_type]` Char wall is closed |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |
 | Toolchain package health | `osty check --airepair=false toolchain` | current CLI surface is still an aggregate `E0700` summary (`3846 error(s)`) rather than a clean self-compile pass |
-| Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers, but `Char`/`Byte` iteration (`String.chars`, `String.bytes`) still blocks the pure native path |
+| Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers. `Char` and `Byte` parameters/returns, literals, comparisons, and width conversions now lower; `String.chars` / `String.bytes` still block the pure native path because `List<Char>` / `List<Byte>` collection lowering is separate work |
 
 The MIR-direct emitter itself (Stages 3.1–3.11) covers a growing subset of the
 language shapes toolchain uses. The 2026-04-19 refresh narrows the story
@@ -77,9 +80,10 @@ Observed in the 2026-04-19 refresh:
 - `TestProbeWholeToolchainMerged` reported
   `LLVM002 runtime-ffi: ... runtime.golegacy.astbridge ...`
 - `TestProbeNativeToolchainMerged` skipped
-  `ast_lower.osty, ci.osty, docgen.osty, manifest_validation.osty` and then
-  first-walled on
-  `LLVM011 [fn_param_struct_type] ... type "Char" ... lspUtf16UnitsForChar`
+  `ast_lower.osty, ci.osty, docgen.osty, manifest_validation.osty`. After the
+  `Char`/`Byte` lowering landed the probe first-walls on `LLVM012`
+  (statement form), not the previous `LLVM011 [fn_param_struct_type]` on
+  `Char` at `lspUtf16UnitsForChar`
 - `/tmp/osty check --airepair=false toolchain` exited with the aggregate
   summary
   `native checker reported type errors: 3846 error(s)` plus

--- a/internal/llvmgen/char_byte_lowering_test.go
+++ b/internal/llvmgen/char_byte_lowering_test.go
@@ -1,0 +1,146 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// Char/Byte parameter and return lowering — LLVM011 had previously
+// first-walled on `lspUtf16UnitsForChar(ch: Char)` in the native
+// toolchain probe. Once Char lowered to i32 and Byte to i8, parameter
+// signatures and return types accept them without a diagnostic.
+func TestCharParameterLowersAsI32(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn width(ch: Char) -> Int {
+    if ch.toInt() >= 128 {
+        return 2
+    }
+    return 1
+}
+
+fn main() {
+    println(width('A'))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_param.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @width(i32",
+		"zext i32",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestByteParameterLowersAsI8(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn ordByte(b: Byte) -> Int {
+    b.toInt()
+}
+
+fn main() {
+    println(ordByte(b'Z'))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/byte_param.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @ordByte(i8",
+		"zext i8",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Char comparison lowers via unsigned icmp so codepoints above 127 don't
+// flip under signed ordering. The `'0' <= c && c <= '9'` pattern is the
+// classic lexer shape that the toolchain front-end relies on.
+func TestCharCompareUsesUnsignedPredicate(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn isDigit(c: Char) -> Bool {
+    '0' <= c && c <= '9'
+}
+
+fn main() {
+    if isDigit('5') {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_compare.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"icmp ule i32",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "icmp sle i32") {
+		t.Fatalf("Char compare used signed predicate; want unsigned:\n%s", got)
+	}
+}
+
+// Int.toChar() lowers as a trunc so the Osty-level `(n + '0'.toInt()).toChar()`
+// pattern in stdlib/char.osty hex digit construction works.
+func TestIntToCharTruncates(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn digit(n: Int) -> Char {
+    ('0'.toInt() + n).toChar()
+}
+
+fn main() {
+    let c = digit(3)
+    if c == '3' {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/int_to_char.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"trunc i64",
+		"icmp eq i32",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// lspUtf16UnitsForChar is the exact shape that blocked the native
+// toolchain probe with LLVM011. Once Char is lowered, this compiles
+// cleanly with no unsupported diagnostic.
+func TestLspUtf16ShapeCompiles(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn lspUtf16UnitsForChar(ch: Char) -> Int {
+    if ch.toInt() >= 0x10000 {
+        return 2
+    }
+    return 1
+}
+
+fn main() {
+    println(lspUtf16UnitsForChar('A'))
+}
+`)
+	_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/lsp_utf16.osty"})
+	if err != nil {
+		t.Fatalf("lspUtf16UnitsForChar still errors: %v", err)
+	}
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -146,7 +146,10 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 	switch e := expr.(type) {
 	case *ast.IntLit:
 		text := strings.ReplaceAll(e.Text, "_", "")
-		n, err := strconv.ParseInt(text, 10, 64)
+		// Base 0 so 0x / 0b / 0o prefixes parse correctly alongside
+		// plain decimal literals. Osty grammar allows all four; the
+		// previous base-10 pin silently rejected hex like 0x10000.
+		n, err := strconv.ParseInt(text, 0, 64)
 		if err != nil {
 			return value{}, unsupportedf("expression", "invalid Int literal %q", e.Text)
 		}
@@ -164,6 +167,10 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 			return value{typ: "i1", ref: "true"}, nil
 		}
 		return value{typ: "i1", ref: "false"}, nil
+	case *ast.CharLit:
+		return value{typ: "i32", ref: strconv.FormatInt(int64(e.Value), 10)}, nil
+	case *ast.ByteLit:
+		return value{typ: "i8", ref: strconv.FormatInt(int64(e.Value), 10)}, nil
 	case *ast.StringLit:
 		return g.emitStringLiteral(e)
 	case *ast.Ident:
@@ -792,6 +799,16 @@ func (g *generator) emitCompare(op token.Kind, left, right value, isString bool)
 	switch left.typ {
 	case "i64", "i1":
 		pred := llvmIntComparePredicate(op.String())
+		if pred == "" {
+			g.takeOstyEmitter(emitter)
+			return value{}, unsupportedf("expression", "comparison operator %q", op)
+		}
+		out = llvmCompare(emitter, pred, toOstyValue(left), toOstyValue(right))
+	case "i32", "i8":
+		// Char (i32) and Byte (i8) compare with unsigned predicates so
+		// Byte values 128..255 compare above the low range rather than
+		// below (signed ordering would flip them to negative).
+		pred := llvmUnsignedIntComparePredicate(op.String())
 		if pred == "" {
 			g.takeOstyEmitter(emitter)
 			return value{}, unsupportedf("expression", "comparison operator %q", op)
@@ -1961,6 +1978,58 @@ func (g *generator) emitMapInsert(base, key, val value) error {
 	return nil
 }
 
+// emitCharByteConversionCall lowers the zero-arg width-only conversions
+// between Char (i32), Byte (i8), and Int (i64) that the stdlib
+// `primitives/{char,int}.osty` expose as `#[intrinsic_methods]`:
+//
+//   - `ch.toInt()`  on Char → zext i32 → i64
+//   - `b.toInt()`   on Byte → zext i8  → i64
+//   - `n.toChar()`  on Int  → trunc i64 → i32
+//
+// Other width-changing integer conversions (toInt8, toByte returning
+// Result, etc.) still fall through to the unsupported-call path.
+func (g *generator) emitCharByteConversionCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional {
+		return value{}, false, nil
+	}
+	if len(call.Args) != 0 {
+		return value{}, false, nil
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch {
+	case field.Name == "toInt" && (baseInfo.typ == "i32" || baseInfo.typ == "i8"):
+	case field.Name == "toChar" && baseInfo.typ == "i64":
+	default:
+		return value{}, false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	emitter := g.toOstyEmitter()
+	tmp := llvmNextTemp(emitter)
+	switch {
+	case field.Name == "toInt" && base.typ == "i32":
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = zext i32 %s to i64", tmp, base.ref))
+		g.takeOstyEmitter(emitter)
+		return value{typ: "i64", ref: tmp}, true, nil
+	case field.Name == "toInt" && base.typ == "i8":
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = zext i8 %s to i64", tmp, base.ref))
+		g.takeOstyEmitter(emitter)
+		return value{typ: "i64", ref: tmp}, true, nil
+	case field.Name == "toChar" && base.typ == "i64":
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = trunc i64 %s to i32", tmp, base.ref))
+		g.takeOstyEmitter(emitter)
+		return value{typ: "i32", ref: tmp}, true, nil
+	}
+	g.takeOstyEmitter(emitter)
+	return value{}, false, nil
+}
+
 // stdlib primitives/{int,float,bool}.osty declare toString as
 // `#[intrinsic_methods]` placeholders with empty bodies, which would
 // otherwise lower to dead IR; this dispatcher routes to the same
@@ -2555,6 +2624,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		return v, err
 	}
 	if v, found, err := g.emitPrimitiveToStringCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitCharByteConversionCall(call); found || err != nil {
 		return v, err
 	}
 	if v, found, err := g.emitStringMethodCall(call); found || err != nil {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1262,6 +1262,31 @@ func llvmIntComparePredicate(op string) string {
 	}
 }
 
+// llvmUnsignedIntComparePredicate returns LLVM `icmp` predicates with
+// unsigned ordering for Char/Byte compares. Char codepoints fit in
+// non-negative i32 so signed would coincidentally work, but Byte values
+// 128..255 are negative under signed ordering which would break
+// `b'\x80' > b'\x00'`. Using unsigned predicates makes both surfaces
+// correct uniformly.
+func llvmUnsignedIntComparePredicate(op string) string {
+	switch op {
+	case "==":
+		return "eq"
+	case "!=":
+		return "ne"
+	case "<":
+		return "ult"
+	case ">":
+		return "ugt"
+	case "<=":
+		return "ule"
+	case ">=":
+		return "uge"
+	default:
+		return ""
+	}
+}
+
 func llvmFloatComparePredicate(op string) string {
 	switch op {
 	case "==":
@@ -2260,6 +2285,10 @@ func llvmBuiltinType(name string) string {
 		return "double"
 	case "Bool":
 		return "i1"
+	case "Char":
+		return "i32"
+	case "Byte":
+		return "i8"
 	case "String", "Bytes", "Error":
 		return "ptr"
 	default:
@@ -2269,7 +2298,7 @@ func llvmBuiltinType(name string) string {
 
 func llvmRuntimeAbiBuiltinType(name string) string {
 	switch name {
-	case "Int", "Float", "Bool", "String":
+	case "Int", "Float", "Bool", "Char", "Byte", "String":
 		return llvmBuiltinType(name)
 	default:
 		return ""
@@ -2278,7 +2307,7 @@ func llvmRuntimeAbiBuiltinType(name string) string {
 
 func llvmEnumPayloadBuiltinType(name string) string {
 	switch name {
-	case "Int", "Float", "String":
+	case "Int", "Float", "Char", "Byte", "String":
 		return llvmBuiltinType(name)
 	default:
 		return ""

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -352,6 +352,10 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		return &ast.NamedType{Path: []string{"Float"}}, true
 	case *ast.BoolLit:
 		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case *ast.CharLit:
+		return &ast.NamedType{Path: []string{"Char"}}, true
+	case *ast.ByteLit:
+		return &ast.NamedType{Path: []string{"Byte"}}, true
 	case *ast.StringLit:
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case *ast.Ident:
@@ -438,6 +442,10 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		return value{typ: "double"}, true
 	case *ast.BoolLit:
 		return value{typ: "i1"}, true
+	case *ast.CharLit:
+		return value{typ: "i32"}, true
+	case *ast.ByteLit:
+		return value{typ: "i8"}, true
 	case *ast.StringLit:
 		return value{typ: "ptr"}, true
 	case *ast.Ident:
@@ -449,6 +457,34 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		}
 	case *ast.ParenExpr:
 		return g.staticExprInfo(e.X)
+	case *ast.UnaryExpr:
+		inner, ok := g.staticExprInfo(e.X)
+		if !ok {
+			return value{}, false
+		}
+		if llvmIsCompareOp(e.Op.String()) {
+			return value{typ: "i1"}, true
+		}
+		return value{typ: inner.typ}, true
+	case *ast.BinaryExpr:
+		// Compare/logical ops fold to i1; arithmetic keeps the operand
+		// type so Char/Byte conversion dispatch can see through e.g.
+		// `'0'.toInt() + n` as i64.
+		if llvmIsCompareOp(e.Op.String()) {
+			return value{typ: "i1"}, true
+		}
+		leftInfo, lok := g.staticExprInfo(e.Left)
+		rightInfo, rok := g.staticExprInfo(e.Right)
+		if lok && rok && leftInfo.typ == rightInfo.typ && leftInfo.typ != "" {
+			return value{typ: leftInfo.typ}, true
+		}
+		if lok && leftInfo.typ != "" {
+			return value{typ: leftInfo.typ}, true
+		}
+		if rok && rightInfo.typ != "" {
+			return value{typ: rightInfo.typ}, true
+		}
+		return value{}, false
 	case *ast.TupleExpr:
 		elemTypes := make([]string, 0, len(e.Elems))
 		for _, elem := range e.Elems {
@@ -467,6 +503,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		return value{}, false
 	case *ast.CallExpr:
 		if out, ok := g.staticStringMethodResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.staticCharByteConversionResult(e); ok {
 			return out, true
 		}
 		if out, found, ok := g.staticCollectionMethodResult(e); found {
@@ -675,6 +714,32 @@ func (g *generator) staticStringMethodSourceType(call *ast.CallExpr) (ast.Type, 
 	default:
 		return nil, false
 	}
+}
+
+// staticCharByteConversionResult mirrors emitCharByteConversionCall at
+// the type-inference layer so `.toInt()` / `.toChar()` on a Char/Byte/Int
+// receiver resolves statically — which in turn lets nested forms like
+// `('0'.toInt() + n).toChar()` type-check without materialising each
+// intermediate value.
+func (g *generator) staticCharByteConversionResult(call *ast.CallExpr) (value, bool) {
+	if call == nil || len(call.Args) != 0 {
+		return value{}, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional || field.X == nil {
+		return value{}, false
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok {
+		return value{}, false
+	}
+	switch {
+	case field.Name == "toInt" && (baseInfo.typ == "i32" || baseInfo.typ == "i8"):
+		return value{typ: "i64"}, true
+	case field.Name == "toChar" && baseInfo.typ == "i64":
+		return value{typ: "i32"}, true
+	}
+	return value{}, false
 }
 
 func (g *generator) staticStringMethodResult(call *ast.CallExpr) (value, bool) {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1109,6 +1109,32 @@ pub fn llvmIntComparePredicate(op: String) -> String {
     ""
 }
 
+// Unsigned compare predicates for Char (i32) and Byte (i8). Char
+// codepoints fit in non-negative i32 so signed would coincidentally
+// work, but Byte values 128..255 go negative under signed ordering
+// which would flip `b'\x80' > b'\x00'`. Unsigned is uniformly correct.
+pub fn llvmUnsignedIntComparePredicate(op: String) -> String {
+    if op == "==" {
+        return "eq"
+    }
+    if op == "!=" {
+        return "ne"
+    }
+    if op == "<" {
+        return "ult"
+    }
+    if op == ">" {
+        return "ugt"
+    }
+    if op == "<=" {
+        return "ule"
+    }
+    if op == ">=" {
+        return "uge"
+    }
+    ""
+}
+
 pub fn llvmFloatComparePredicate(op: String) -> String {
     if op == "==" {
         return "oeq"
@@ -2397,6 +2423,12 @@ pub fn llvmBuiltinType(name: String) -> String {
     if name == "Bool" {
         return "i1"
     }
+    if name == "Char" {
+        return "i32"
+    }
+    if name == "Byte" {
+        return "i8"
+    }
     if name == "String" || name == "Bytes" || name == "Error" {
         return "ptr"
     }
@@ -2404,14 +2436,14 @@ pub fn llvmBuiltinType(name: String) -> String {
 }
 
 pub fn llvmRuntimeAbiBuiltinType(name: String) -> String {
-    if name == "Int" || name == "Float" || name == "Bool" || name == "String" {
+    if name == "Int" || name == "Float" || name == "Bool" || name == "Char" || name == "Byte" || name == "String" {
         return llvmBuiltinType(name)
     }
     ""
 }
 
 pub fn llvmEnumPayloadBuiltinType(name: String) -> String {
-    if name == "Int" || name == "Float" || name == "String" {
+    if name == "Int" || name == "Float" || name == "Char" || name == "Byte" || name == "String" {
         return llvmBuiltinType(name)
     }
     ""


### PR DESCRIPTION
## Summary

네이티브 toolchain self-compile probe(`TestProbeNativeToolchainMerged`)가 오랫동안 `LLVM011 [fn_param_struct_type]: Char`(`lspUtf16UnitsForChar`)에서 first-wall을 찍던 문제를 풀었습니다. `Char`를 `i32`로, `Byte`를 `i8`로 lowering하고 폭 변환/비교 경로를 붙여서 native probe의 first-wall이 **LLVM011 → LLVM012 (statement form)** 로 이동합니다.

## 변경

### 타입 lowering
- `llvmBuiltinType`: `Char → i32`, `Byte → i8`
- `llvmRuntimeAbiBuiltinType` / `llvmEnumPayloadBuiltinType`: Char, Byte 포함
- Osty 원본(`toolchain/llvmgen.osty`)도 병행 업데이트

### 리터럴
- `emitExpr`에 `*ast.CharLit` / `*ast.ByteLit` 케이스 추가
- `staticExprInfo` / `staticExprSourceType`에도 대칭 추가

### 비교
- `emitCompare`에 `i32`/`i8` 분기 추가, **부호 없는** predicate 사용 (`ult`/`ugt`/`ule`/`uge`). Byte 값 128..255가 signed에서 음수로 flip되는 것을 방지.
- `llvmUnsignedIntComparePredicate` 헬퍼 (Go + Osty)

### 폭 변환 intrinsic
- `emitCharByteConversionCall` 새 디스패처:
  - `ch.toInt()` on `Char` → `zext i32 → i64`
  - `b.toInt()` on `Byte` → `zext i8 → i64`
  - `n.toChar()` on `Int` → `trunc i64 → i32`
- `staticCharByteConversionResult`로 타입 추론 대칭

### 부차 수정
- `staticExprInfo`에 `UnaryExpr`/`BinaryExpr` 케이스 — `('0'.toInt() + n).toChar()`처럼 중첩된 산술+변환이 통과하도록
- IntLit 디코더를 `strconv.ParseInt(text, 0, 64)`로 변경 — `0x10000` 같은 hex/binary/octal 리터럴이 LLVM 경로에서 reject되던 기존 버그 해결

### 문서
- `docs/toolchain_llvm_status.md`와 `LLVM_MIGRATION_PLAN.md`의 first-wall 기록을 LLVM012로 갱신

## 테스트

`internal/llvmgen/char_byte_lowering_test.go`에 5개 골든 테스트:
- `TestCharParameterLowersAsI32` — `fn width(ch: Char) -> Int`가 `define i64 @width(i32 ...)` + `zext i32`
- `TestByteParameterLowersAsI8` — `fn ordByte(b: Byte) -> Int`가 `define i64 @ordByte(i8 ...)` + `zext i8`
- `TestCharCompareUsesUnsignedPredicate` — `'0' <= c && c <= '9'`가 `icmp ule i32` (signed 아님)
- `TestIntToCharTruncates` — `('0'.toInt() + n).toChar()`가 `trunc i64` + `icmp eq i32`
- `TestLspUtf16ShapeCompiles` — `lspUtf16UnitsForChar(ch: Char)` shape이 진단 없이 컴파일됨 (LLVM011 재발 방지)

`TestProbeNativeToolchainMerged`의 로그: `LLVM011 Char` → **`LLVM012 (statement form)`**.

기존 `-short` 러너의 기존 실패 케이스(`Generic enum`, `raw.*` 등)는 stash 비교로 확인한 **이 변경 전부터 존재하는 pre-existing failures**입니다 — 이 PR이 새로 깨뜨린 테스트는 없습니다.

## 남은 작업 (별도 PR)

- `String.chars()` / `String.bytes()` — `List<Char>` / `List<Byte>` collection lowering 필요 (LLVM015/LLVM011 교집합)
- `Char.isDigit()` / `.isAlpha()` 같은 Unicode-백업 intrinsic — runtime symbol 추가 필요
- `Char.toString()` / `Byte.toString()` interpolation — `osty_rt_char_to_string` / `osty_rt_byte_to_string` runtime 심볼 추가 필요

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/llvmgen/ -run "TestCharParameterLowersAsI32|TestByteParameterLowersAsI8|TestCharCompareUsesUnsignedPredicate|TestIntToCharTruncates|TestLspUtf16ShapeCompiles" -count=1 -v` — 모두 PASS
- [x] `go test ./internal/llvmgen/... -short` — 신규 실패 없음, 기존 실패와 동일
- [x] `go test ./internal/llvmgen/ -run TestProbeNativeToolchainMerged` — first-wall이 LLVM012로 이동 확인
- [x] `go test ./internal/check/ ./internal/parser/ ./internal/lexer/` — PASS