### PR TITLE
feat(ir): propagate #[json(...)] metadata onto Field/Variant

### DIFF
--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -383,11 +383,14 @@ func cloneParam(p *Param) *Param {
 
 func cloneField(f *Field) *Field {
 	return &Field{
-		Name:     f.Name,
-		Type:     CloneType(f.Type),
-		Default:  cloneExprOrNil(f.Default),
-		Exported: f.Exported,
-		SpanV:    f.SpanV,
+		Name:         f.Name,
+		Type:         CloneType(f.Type),
+		Default:      cloneExprOrNil(f.Default),
+		Exported:     f.Exported,
+		SpanV:        f.SpanV,
+		JSONKey:      f.JSONKey,
+		JSONSkip:     f.JSONSkip,
+		JSONOptional: f.JSONOptional,
 	}
 }
 
@@ -400,7 +403,12 @@ func cloneTypeParam(tp *TypeParam) *TypeParam {
 }
 
 func cloneVariant(v *Variant) *Variant {
-	out := &Variant{Name: v.Name, SpanV: v.SpanV}
+	out := &Variant{
+		Name:     v.Name,
+		SpanV:    v.SpanV,
+		JSONTag:  v.JSONTag,
+		JSONSkip: v.JSONSkip,
+	}
 	if len(v.Payload) > 0 {
 		out.Payload = cloneTypes(v.Payload)
 	}

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -430,6 +430,24 @@ type Field struct {
 	Default  Expr
 	Exported bool
 	SpanV    Span
+
+	// JSONKey is the override from `#[json(key = "...")]`. Empty when
+	// no override is set; downstream backends should fall back to
+	// `Name` in that case. Populated by the IR lowerer from the AST
+	// annotation list so the resolver's validation (`E0407`,
+	// `E0408`) does not have to be re-run by each backend.
+	JSONKey string
+
+	// JSONSkip is true when `#[json(skip)]` is present on the field.
+	// Marshal paths must omit the field entirely; unmarshal paths
+	// must leave it at its zero/default value.
+	JSONSkip bool
+
+	// JSONOptional is true when `#[json(optional)]` is present. The
+	// resolver guarantees the field's declared type is an Option,
+	// so backends can always materialise `None` when the key is
+	// missing in input and elide `null` on output.
+	JSONOptional bool
 }
 
 func (f *Field) At() Span { return f.SpanV }
@@ -454,6 +472,18 @@ type Variant struct {
 	Name    string
 	Payload []Type
 	SpanV   Span
+
+	// JSONTag is the discriminator string override from
+	// `#[json(key = "...")]` on a variant. Empty when not overridden;
+	// backends fall back to `Name`. Lifted from the AST annotation
+	// list by the IR lowerer so backends do not redo the
+	// (resolver-validated) literal parse.
+	JSONTag string
+
+	// JSONSkip is true when `#[json(skip)]` is present on the
+	// variant. The resolver already refuses duplicate-after-skip
+	// collisions; encoders drop skipped variants from the case space.
+	JSONSkip bool
 }
 
 func (v *Variant) At() Span { return v.SpanV }

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -199,6 +199,74 @@ func extractExportSymbol(annots []*ast.Annotation) string {
 	return ""
 }
 
+// jsonFieldOptions extracts `#[json(...)]` metadata from a struct
+// field's annotation list. Returns (key, skip, optional) where an
+// empty key means "use the field name". The resolver has already
+// validated argument shape (E0407) and that `optional` only attaches
+// to Option-typed fields (E0408), so this helper accepts any
+// argument form silently — malformed inputs cannot reach IR.
+func jsonFieldOptions(annots []*ast.Annotation) (key string, skip, optional bool) {
+	for _, a := range annots {
+		if a == nil || a.Name != "json" {
+			continue
+		}
+		for _, arg := range a.Args {
+			switch arg.Key {
+			case "key":
+				if s, ok := annotationStringLit(arg.Value); ok {
+					key = s
+				}
+			case "skip":
+				skip = true
+			case "optional":
+				optional = true
+			}
+		}
+	}
+	return key, skip, optional
+}
+
+// jsonVariantOptions extracts `#[json(...)]` metadata from an enum
+// variant's annotation list. Returns (tag, skip); empty tag means
+// "use the variant name". Only `key` and `skip` are defined for
+// variants — `optional` is a field-level knob.
+func jsonVariantOptions(annots []*ast.Annotation) (tag string, skip bool) {
+	for _, a := range annots {
+		if a == nil || a.Name != "json" {
+			continue
+		}
+		for _, arg := range a.Args {
+			switch arg.Key {
+			case "key":
+				if s, ok := annotationStringLit(arg.Value); ok {
+					tag = s
+				}
+			case "skip":
+				skip = true
+			}
+		}
+	}
+	return tag, skip
+}
+
+// annotationStringLit concatenates the literal parts of a string
+// literal `ast.Expr`. Interpolation segments force a false return
+// since the resolver forbids non-literal annotation arguments.
+func annotationStringLit(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.StringLit)
+	if !ok {
+		return "", false
+	}
+	var buf []byte
+	for _, p := range lit.Parts {
+		if !p.IsLit {
+			return "", false
+		}
+		buf = append(buf, p.Lit...)
+	}
+	return string(buf), true
+}
+
 func (l *lowerer) lowerParam(p *ast.Param) *Param {
 	out := &Param{
 		Type:  l.lowerType(p.Type),
@@ -246,6 +314,7 @@ func (l *lowerer) lowerStructDecl(sd *ast.StructDecl) *StructDecl {
 		if f.Default != nil {
 			field.Default = l.lowerExpr(f.Default)
 		}
+		field.JSONKey, field.JSONSkip, field.JSONOptional = jsonFieldOptions(f.Annotations)
 		out.Fields = append(out.Fields, field)
 	}
 	for _, m := range sd.Methods {
@@ -268,6 +337,7 @@ func (l *lowerer) lowerEnumDecl(ed *ast.EnumDecl) *EnumDecl {
 		for _, ty := range v.Fields {
 			variant.Payload = append(variant.Payload, l.lowerType(ty))
 		}
+		variant.JSONTag, variant.JSONSkip = jsonVariantOptions(v.Annotations)
 		out.Variants = append(out.Variants, variant)
 	}
 	for _, m := range ed.Methods {

--- a/internal/ir/print.go
+++ b/internal/ir/print.go
@@ -105,7 +105,17 @@ func (p *printer) printDecl(d Decl) {
 		p.indent++
 		for _, f := range d.Fields {
 			p.nl()
-			p.writef("(field %s %s)", f.Name, typeString(f.Type))
+			p.writef("(field %s %s", f.Name, typeString(f.Type))
+			if f.JSONKey != "" {
+				p.writef(" json-key=%q", f.JSONKey)
+			}
+			if f.JSONSkip {
+				p.b.WriteString(" json-skip")
+			}
+			if f.JSONOptional {
+				p.b.WriteString(" json-optional")
+			}
+			p.b.WriteByte(')')
 		}
 		for _, m := range d.Methods {
 			p.nl()
@@ -121,6 +131,12 @@ func (p *printer) printDecl(d Decl) {
 			p.writef("(variant %s", v.Name)
 			for _, pl := range v.Payload {
 				p.writef(" %s", typeString(pl))
+			}
+			if v.JSONTag != "" {
+				p.writef(" json-tag=%q", v.JSONTag)
+			}
+			if v.JSONSkip {
+				p.b.WriteString(" json-skip")
 			}
 			p.b.WriteByte(')')
 		}

--- a/internal/ir/runtime_annot_propagation_test.go
+++ b/internal/ir/runtime_annot_propagation_test.go
@@ -105,6 +105,173 @@ func TestPodAbsenceIsFalse(t *testing.T) {
 	t.Fatal("User not in module decls")
 }
 
+// --- #[json(...)] on struct fields -> ir.Field.JSON* ---
+
+func TestJSONFieldAnnotationsFlowToIR(t *testing.T) {
+	src := `
+pub struct ApiUser {
+    #[json(key = "user_id")]
+    pub id: Int,
+    #[json(key = "full_name")]
+    pub name: String,
+    #[json(skip)]
+    cache: Int,
+    #[json(optional)]
+    nickname: String?,
+    pub age: Int,
+}
+`
+	mod := lowerSrc(t, src)
+	var sd *StructDecl
+	for _, decl := range mod.Decls {
+		if s, ok := decl.(*StructDecl); ok && s.Name == "ApiUser" {
+			sd = s
+			break
+		}
+	}
+	if sd == nil {
+		t.Fatal("ApiUser not in module decls")
+	}
+
+	byName := map[string]*Field{}
+	for _, f := range sd.Fields {
+		byName[f.Name] = f
+	}
+
+	cases := []struct {
+		field    string
+		key      string
+		skip     bool
+		optional bool
+	}{
+		{"id", "user_id", false, false},
+		{"name", "full_name", false, false},
+		{"cache", "", true, false},
+		{"nickname", "", false, true},
+		{"age", "", false, false},
+	}
+	for _, c := range cases {
+		f := byName[c.field]
+		if f == nil {
+			t.Errorf("field %q missing from lowered struct", c.field)
+			continue
+		}
+		if f.JSONKey != c.key {
+			t.Errorf("field %q JSONKey = %q, want %q", c.field, f.JSONKey, c.key)
+		}
+		if f.JSONSkip != c.skip {
+			t.Errorf("field %q JSONSkip = %v, want %v", c.field, f.JSONSkip, c.skip)
+		}
+		if f.JSONOptional != c.optional {
+			t.Errorf("field %q JSONOptional = %v, want %v", c.field, f.JSONOptional, c.optional)
+		}
+	}
+}
+
+// --- #[json(...)] on enum variants -> ir.Variant.JSON* ---
+
+func TestJSONVariantAnnotationsFlowToIR(t *testing.T) {
+	src := `
+pub enum Shape {
+    #[json(key = "circle")]
+    Round(Int),
+    #[json(skip)]
+    Hidden,
+    Square(Int),
+}
+`
+	mod := lowerSrc(t, src)
+	var ed *EnumDecl
+	for _, decl := range mod.Decls {
+		if e, ok := decl.(*EnumDecl); ok && e.Name == "Shape" {
+			ed = e
+			break
+		}
+	}
+	if ed == nil {
+		t.Fatal("Shape not in module decls")
+	}
+
+	byName := map[string]*Variant{}
+	for _, v := range ed.Variants {
+		byName[v.Name] = v
+	}
+
+	cases := []struct {
+		variant string
+		tag     string
+		skip    bool
+	}{
+		{"Round", "circle", false},
+		{"Hidden", "", true},
+		{"Square", "", false},
+	}
+	for _, c := range cases {
+		v := byName[c.variant]
+		if v == nil {
+			t.Errorf("variant %q missing from lowered enum", c.variant)
+			continue
+		}
+		if v.JSONTag != c.tag {
+			t.Errorf("variant %q JSONTag = %q, want %q", c.variant, v.JSONTag, c.tag)
+		}
+		if v.JSONSkip != c.skip {
+			t.Errorf("variant %q JSONSkip = %v, want %v", c.variant, v.JSONSkip, c.skip)
+		}
+	}
+}
+
+// --- Ensure fields/variants without #[json] leave metadata empty ---
+
+func TestJSONMetadataAbsenceIsZero(t *testing.T) {
+	src := `
+pub struct Plain { pub x: Int }
+pub enum Color { Red, Green }
+`
+	mod := lowerSrc(t, src)
+	for _, decl := range mod.Decls {
+		if s, ok := decl.(*StructDecl); ok && s.Name == "Plain" {
+			for _, f := range s.Fields {
+				if f.JSONKey != "" || f.JSONSkip || f.JSONOptional {
+					t.Errorf("plain field carries json metadata: %+v", f)
+				}
+			}
+		}
+		if e, ok := decl.(*EnumDecl); ok && e.Name == "Color" {
+			for _, v := range e.Variants {
+				if v.JSONTag != "" || v.JSONSkip {
+					t.Errorf("plain variant carries json metadata: %+v", v)
+				}
+			}
+		}
+	}
+}
+
+// --- Cloning preserves JSON metadata ---
+
+func TestCloneFieldPreservesJSON(t *testing.T) {
+	orig := &Field{
+		Name:         "x",
+		Type:         TInt,
+		Exported:     true,
+		JSONKey:      "renamed",
+		JSONSkip:     false,
+		JSONOptional: true,
+	}
+	c := cloneField(orig)
+	if c.JSONKey != "renamed" || c.JSONOptional != true {
+		t.Errorf("cloneField dropped JSON metadata: %+v", c)
+	}
+}
+
+func TestCloneVariantPreservesJSON(t *testing.T) {
+	orig := &Variant{Name: "V", JSONTag: "v-renamed", JSONSkip: true}
+	c := cloneVariant(orig)
+	if c.JSONTag != "v-renamed" || !c.JSONSkip {
+		t.Errorf("cloneVariant dropped JSON metadata: %+v", c)
+	}
+}
+
 // --- combined: every runtime annotation in one fn ---
 
 func TestAllRuntimeAnnotationsCoexistOnFn(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ir.Field` now carries `JSONKey` / `JSONSkip` / `JSONOptional` lifted from `#[json(...)]` on struct fields.
- `ir.Variant` now carries `JSONTag` / `JSONSkip` lifted from `#[json(...)]` on enum variants.
- `clone.go` and `print.go` preserve/expose the new metadata.

## Why

The resolver already validates `#[json(...)]` argument shape (E0407/E0408), but that information never reached IR, so non-Go backends (LLVM) had no way to learn the JSON key overrides or `skip`/`optional` markers without re-walking `ast.Annotation` trees. This commit wires the resolver-approved literals onto `ir.Field` / `ir.Variant`, giving the LLVM backend the metadata it will need for eventual JSON codec emission.

This PR only handles the IR-level plumbing. Actual LLVM JSON marshal/unmarshal lowering and builder auto-derive (checker synthesis + IR + LLVM) remain follow-up work.

## Test plan

- [x] `go test ./internal/ir/ -count=1` (ok)
- [x] `go test ./internal/check/ ./internal/resolve/ ./internal/parser/ -short -count=1` (ok)
- [x] New focus tests in `runtime_annot_propagation_test.go`:
  - `TestJSONFieldAnnotationsFlowToIR`
  - `TestJSONVariantAnnotationsFlowToIR`
  - `TestJSONMetadataAbsenceIsZero`
  - `TestCloneFieldPreservesJSON`
  - `TestCloneVariantPreservesJSON`
- [ ] Follow-up: LLVM backend consumes the new metadata to emit JSON codecs
- [ ] Follow-up: Builder auto-derive (checker synthesis of `Type.builder()` + IR lowering)

https://claude.ai/code/session_01DgZg2UzXYkW3y9uPmBbboh