### PR TITLE
feat(llvmgen): Set.remove + Bytes.len/isEmpty backend dispatch

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -54,6 +54,11 @@ typedef struct osty_rt_set {
     unsigned char *items;
 } osty_rt_set;
 
+typedef struct osty_rt_bytes {
+    unsigned char *data;
+    int64_t len;
+} osty_rt_bytes;
+
 #if defined(__APPLE__)
 #define OSTY_GC_SYMBOL(name) "_" name
 #else
@@ -66,6 +71,7 @@ enum {
     OSTY_GC_KIND_STRING = 1025,
     OSTY_GC_KIND_MAP = 1026,
     OSTY_GC_KIND_SET = 1027,
+    OSTY_GC_KIND_BYTES = 1028,
 };
 
 enum {
@@ -1508,6 +1514,29 @@ OSTY_RT_DEFINE_SET_KEY_OPS(i1, bool)
 OSTY_RT_DEFINE_SET_KEY_OPS(f64, double)
 OSTY_RT_DEFINE_SET_KEY_OPS(ptr, void *)
 OSTY_RT_DEFINE_SET_KEY_OPS(string, const char *)
+
+/*
+ * Bytes primitive ABI. Values flow as `osty_rt_bytes *` — an opaque
+ * pointer to a `{unsigned char *data; int64_t len}` struct. Only the
+ * length / emptiness queries are wired up at the LLVM layer right now;
+ * construction (literals, string.bytes(), etc.) is not yet surfaced,
+ * but the ABI is fixed so future call sites can link against it.
+ */
+int64_t osty_rt_bytes_len(void *raw_bytes) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    if (b == NULL) {
+        return 0;
+    }
+    return b->len;
+}
+
+bool osty_rt_bytes_is_empty(void *raw_bytes) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    if (b == NULL) {
+        return true;
+    }
+    return b->len == 0;
+}
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
 void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -448,7 +448,9 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicMapRemove:
 		return true
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
-		mir.IntrinsicSetToList:
+		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
+		return true
+	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -1396,8 +1398,10 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicMapRemove:
 		return g.emitMapIntrinsic(i)
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
-		mir.IntrinsicSetToList:
+		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
 		return g.emitSetIntrinsic(i)
+	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty:
+		return g.emitBytesIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
 		return g.emitChannelIntrinsic(i)
@@ -1762,8 +1766,57 @@ func (g *mirGen) emitSetIntrinsic(i *mir.IntrinsicInstr) error {
 			elemString)
 		g.flushOstyEmitter(em)
 		return nil
+	case mir.IntrinsicSetRemove:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "set_remove arity")
+		}
+		vReg, err := g.evalOperand(i.Args[1], elemT)
+		if err != nil {
+			return err
+		}
+		sym := setRuntimeRemoveSymbol(elemLLVM, elemString)
+		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, "+elemLLVM+")")
+		em := g.ostyEmitter()
+		result := llvmSetRemove(em,
+			&LlvmValue{typ: "ptr", name: setReg},
+			&LlvmValue{typ: elemLLVM, name: vReg},
+			elemString)
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("set intrinsic kind %d", i.Kind))
+}
+
+// emitBytesIntrinsic dispatches bytes primitive methods to runtime
+// symbols. Bytes values flow through the runtime as opaque pointers
+// to `osty_rt_bytes { ptr data; i64 len }`. The runtime functions
+// live beside the list/string helpers in osty_runtime.c.
+func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
+	if len(i.Args) < 1 {
+		return unsupported("mir-mvp", "bytes intrinsic with no receiver")
+	}
+	bytesOp := i.Args[0]
+	bytesReg, err := g.evalOperand(bytesOp, bytesOp.Type())
+	if err != nil {
+		return err
+	}
+	switch i.Kind {
+	case mir.IntrinsicBytesLen:
+		sym := "osty_rt_bytes_len"
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicBytesIsEmpty:
+		sym := "osty_rt_bytes_is_empty"
+		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "i1", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("bytes intrinsic kind %d", i.Kind))
 }
 
 // ==== concurrency intrinsics ====

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2258,3 +2258,148 @@ func TestGenerateFromMIRStringOrdering(t *testing.T) {
 		})
 	}
 }
+
+// TestGenerateFromMIRSetRemove verifies Set.remove(item) dispatches
+// through the runtime `osty_rt_set_remove_<kind>` symbols. The ABI
+// mirrors set_insert — i1 return, typed by element LLVM kind.
+func TestGenerateFromMIRSetRemove(t *testing.T) {
+	setT := &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TInt}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "drop",
+		Return: ir.TBool,
+		Params: []*ir.Param{
+			{Name: "s", Type: setT},
+			{Name: "v", Type: ir.TInt},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: setT},
+				Name:     "remove",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "v", Kind: ir.IdentParam, T: ir.TInt}},
+				},
+				T: ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/set_remove.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_set_remove_i64(ptr, i64)",
+		"call i1 @osty_rt_set_remove_i64(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRSetRemoveString verifies the string-key runtime
+// suffix variant — Set<String>.remove routes through the string
+// dispatch.
+func TestGenerateFromMIRSetRemoveString(t *testing.T) {
+	setT := &ir.NamedType{Name: "Set", Args: []ir.Type{ir.TString}, Builtin: true}
+	fn := &ir.FnDecl{
+		Name:   "drop",
+		Return: ir.TBool,
+		Params: []*ir.Param{
+			{Name: "s", Type: setT},
+			{Name: "v", Type: ir.TString},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: setT},
+				Name:     "remove",
+				Args: []ir.Arg{
+					{Value: &ir.Ident{Name: "v", Kind: ir.IdentParam, T: ir.TString}},
+				},
+				T: ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/set_remove_string.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_set_remove_string(ptr, ptr)",
+		"call i1 @osty_rt_set_remove_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesLen verifies Bytes.len() dispatches through
+// `osty_rt_bytes_len(ptr) -> i64`. Bytes is a primitive, lowered to
+// an opaque pointer at the LLVM level.
+func TestGenerateFromMIRBytesLen(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "sz",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "b", Type: ir.TBytes}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "len",
+				T:        ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_len.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_bytes_len(ptr)",
+		"call i64 @osty_rt_bytes_len(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesIsEmpty verifies Bytes.isEmpty() dispatches
+// through `osty_rt_bytes_is_empty(ptr) -> i1`.
+func TestGenerateFromMIRBytesIsEmpty(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "blank",
+		Return: ir.TBool,
+		Params: []*ir.Param{{Name: "b", Type: ir.TBytes}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "isEmpty",
+				T:        ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_empty.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i1 @osty_rt_bytes_is_empty(ptr)",
+		"call i1 @osty_rt_bytes_is_empty(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3072,6 +3072,8 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 			return IntrinsicSetLen
 		case "toList":
 			return IntrinsicSetToList
+		case "remove":
+			return IntrinsicSetRemove
 		}
 	case "Option", "Maybe":
 		switch name {

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -453,6 +453,8 @@ const (
 	IntrinsicSetLen
 	// IntrinsicSetToList materialises a List<T>. Args: [set].
 	IntrinsicSetToList
+	// IntrinsicSetRemove deletes an element. Args: [set, elem]. Dest nil.
+	IntrinsicSetRemove
 
 	// ---- stdlib: String ----
 

--- a/internal/mir/print.go
+++ b/internal/mir/print.go
@@ -524,6 +524,8 @@ func intrinsicName(k IntrinsicKind) string {
 		return "set_len"
 	case IntrinsicSetToList:
 		return "set_to_list"
+	case IntrinsicSetRemove:
+		return "set_remove"
 	case IntrinsicStringLen:
 		return "string_len"
 	case IntrinsicStringIsEmpty:


### PR DESCRIPTION
## Summary

LLVM 백엔드가 놓치고 있던 컬렉션/프리미티브 인트린식을 채움 —
`Set<T>.remove`, `Bytes.len`, `Bytes.isEmpty` 세 지점.

- **Set.remove**: 스펙(`collections.osty:488`)과 런타임(`osty_rt_set_remove_*`,
  이미 5가지 element kind 구현)은 준비돼 있었지만 MIR 인트린식과 LLVM
  dispatch가 비어 있던 상태. `IntrinsicSetRemove` 추가 → 메서드 룩업
  연결 → `emitSetIntrinsic` 케이스 배선.
- **Bytes.len / Bytes.isEmpty**: MIR 인트린식(`IntrinsicBytesLen`,
  `IntrinsicBytesIsEmpty`)은 이미 정의돼 있었지만 `isSupportedIntrinsic`
  화이트리스트 + dispatch 경로가 전혀 없어서 호출 즉시
  "unsupported intrinsic"으로 떨어짐. `emitBytesIntrinsic` 추가.
- C 런타임에 `osty_rt_bytes { data, len }` 구조체와 `osty_rt_bytes_len`,
  `osty_rt_bytes_is_empty` 함수 추가. `OSTY_GC_KIND_BYTES = 1028`도 예약
  (트레이서/컨스트럭터는 아직 미구현 — ABI만 fix).

스코프 외 (후속):
- `Bytes.get(i: Int) -> Byte?` — Option 반환 MIR 컨벤션이 아직 없어서 보류
- Bytes 리터럴 (`b"..."`) / `String.bytes()` 생산자 — 프런트엔드/컨스트럭터 작업
- Set intrinsic의 `SetNew` / Bytes GC trace&destroy

## Test plan
- [x] `go build ./...` 통과
- [x] 신규 테스트 4종 통과 (`TestGenerateFromMIRSetRemove`,
      `TestGenerateFromMIRSetRemoveString`, `TestGenerateFromMIRBytesLen`,
      `TestGenerateFromMIRBytesIsEmpty`)
- [x] `go test ./internal/llvmgen/ -run 'Set|Bytes'` — 기존 Set 테스트도 통과
- [x] `go test ./internal/mir/ ./internal/ir/ ./internal/check/ -short` 통과
- [x] `cc -c internal/backend/runtime/osty_runtime.c` — C 런타임도 여전히 컴파일

https://claude.ai/code/session_013WHQtCUxqfHdrS6ebb1q1x