### PR TITLE
feat(llvmgen): homogeneous multi-field payload enums + actionable rejection hints

### DIFF
--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -96,14 +96,15 @@ type fieldInfo struct {
 }
 
 type enumInfo struct {
-	name         string
-	typ          string
-	decl         *ast.EnumDecl
-	hasPayload   bool
-	payloadTyp   string
-	payloadCount int
-	isBoxed      bool
-	variants     map[string]variantInfo
+	name             string
+	typ              string
+	decl             *ast.EnumDecl
+	hasPayload       bool
+	payloadTyp       string
+	payloadCount     int
+	payloadSlotTypes []string
+	isBoxed          bool
+	variants         map[string]variantInfo
 }
 
 type variantInfo struct {
@@ -890,13 +891,12 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 				diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
 				return nil, unsupported(diag.kind, diag.message)
 			}
-			if info.payloadTyp == "" && !info.isBoxed {
-				info.payloadTyp = typ
-			} else if info.payloadTyp != typ {
-				info.isBoxed = true
-				info.payloadTyp = ""
-			}
 			payloads = append(payloads, typ)
+			if fi >= len(info.payloadSlotTypes) {
+				info.payloadSlotTypes = append(info.payloadSlotTypes, typ)
+			} else if info.payloadSlotTypes[fi] != typ {
+				info.isBoxed = true
+			}
 			if fi == 0 {
 				if listElemTyp, ok, err := llvmListElementType(field, env); err != nil {
 					diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
@@ -923,6 +923,18 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 			tag:                i,
 			payloads:           payloads,
 			payloadListElemTyp: payloadListElemTyp,
+		}
+	}
+	if info.isBoxed {
+		info.payloadSlotTypes = nil
+		info.payloadTyp = ""
+	} else if len(info.payloadSlotTypes) > 0 {
+		info.payloadTyp = info.payloadSlotTypes[0]
+		for _, t := range info.payloadSlotTypes {
+			if t != info.payloadSlotTypes[0] {
+				info.payloadTyp = ""
+				break
+			}
 		}
 	}
 	info.typ = llvmEnumStorageType(info.name, info.hasPayload)

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -96,13 +96,14 @@ type fieldInfo struct {
 }
 
 type enumInfo struct {
-	name       string
-	typ        string
-	decl       *ast.EnumDecl
-	hasPayload bool
-	payloadTyp string
-	isBoxed    bool
-	variants   map[string]variantInfo
+	name         string
+	typ          string
+	decl         *ast.EnumDecl
+	hasPayload   bool
+	payloadTyp   string
+	payloadCount int
+	isBoxed      bool
+	variants     map[string]variantInfo
 }
 
 type variantInfo struct {
@@ -124,6 +125,13 @@ type enumPatternInfo struct {
 	payloadListElemTyp string
 	hasPayloadBinding  bool
 	isBoxed            bool
+	payloadBindings    []enumPayloadBinding
+}
+
+type enumPayloadBinding struct {
+	name  string
+	typ   string
+	index int
 }
 
 type tupleTypeInfo struct {
@@ -870,13 +878,14 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 		if variant == nil {
 			return nil, unsupportedf("source-layout", "enum %q has nil variant", decl.Name)
 		}
-		if diag := llvmEnumVariantHeaderDiagnostic(decl.Name, variant.Name, llvmIsIdent(variant.Name), len(variant.Fields), false); diag.kind != "" {
+		if !llvmIsIdent(variant.Name) {
+			diag := llvmEnumVariantHeaderDiagnostic(decl.Name, variant.Name, false, len(variant.Fields), false)
 			return nil, unsupported(diag.kind, diag.message)
 		}
 		payloads := make([]string, 0, len(variant.Fields))
 		payloadListElemTyp := ""
-		if len(variant.Fields) == 1 {
-			typ, err := llvmEnumPayloadType(variant.Fields[0], env)
+		for fi, field := range variant.Fields {
+			typ, err := llvmEnumPayloadType(field, env)
 			if err != nil {
 				diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
 				return nil, unsupported(diag.kind, diag.message)
@@ -888,13 +897,22 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 				info.payloadTyp = ""
 			}
 			payloads = append(payloads, typ)
-			if listElemTyp, ok, err := llvmListElementType(variant.Fields[0], env); err != nil {
-				diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
-				return nil, unsupported(diag.kind, diag.message)
-			} else if ok {
-				payloadListElemTyp = listElemTyp
+			if fi == 0 {
+				if listElemTyp, ok, err := llvmListElementType(field, env); err != nil {
+					diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
+					return nil, unsupported(diag.kind, diag.message)
+				} else if ok {
+					payloadListElemTyp = listElemTyp
+				}
 			}
 			info.hasPayload = true
+		}
+		if len(variant.Fields) > info.payloadCount {
+			info.payloadCount = len(variant.Fields)
+		}
+		if info.isBoxed && len(variant.Fields) > 1 {
+			diag := llvmEnumBoxedMultiFieldDiagnostic(decl.Name, variant.Name, len(variant.Fields))
+			return nil, unsupported(diag.kind, diag.message)
 		}
 		if _, exists := info.variants[variant.Name]; exists {
 			diag := llvmEnumVariantHeaderDiagnostic(decl.Name, variant.Name, true, len(variant.Fields), true)

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -108,10 +108,11 @@ type enumInfo struct {
 }
 
 type variantInfo struct {
-	name               string
-	tag                int
-	payloads           []string
-	payloadListElemTyp string
+	name                string
+	tag                 int
+	payloads            []string
+	payloadListElemTyp  string
+	payloadListElemTyps []string
 }
 
 type enumVariantRef struct {
@@ -884,6 +885,7 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 			return nil, unsupported(diag.kind, diag.message)
 		}
 		payloads := make([]string, 0, len(variant.Fields))
+		payloadListElemTyps := make([]string, 0, len(variant.Fields))
 		payloadListElemTyp := ""
 		for fi, field := range variant.Fields {
 			typ, err := llvmEnumPayloadType(field, env)
@@ -897,37 +899,55 @@ func collectEnum(decl *ast.EnumDecl, env typeEnv) (*enumInfo, error) {
 			} else if info.payloadSlotTypes[fi] != typ {
 				info.isBoxed = true
 			}
+			slotListElemTyp := ""
+			if listElemTyp, ok, err := llvmListElementType(field, env); err != nil {
+				diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
+				return nil, unsupported(diag.kind, diag.message)
+			} else if ok {
+				slotListElemTyp = listElemTyp
+			}
+			payloadListElemTyps = append(payloadListElemTyps, slotListElemTyp)
 			if fi == 0 {
-				if listElemTyp, ok, err := llvmListElementType(field, env); err != nil {
-					diag := llvmEnumPayloadDiagnostic(decl.Name, variant.Name, unsupportedMessage(err), "", "")
-					return nil, unsupported(diag.kind, diag.message)
-				} else if ok {
-					payloadListElemTyp = listElemTyp
-				}
+				payloadListElemTyp = slotListElemTyp
 			}
 			info.hasPayload = true
 		}
 		if len(variant.Fields) > info.payloadCount {
 			info.payloadCount = len(variant.Fields)
 		}
-		if info.isBoxed && len(variant.Fields) > 1 {
-			diag := llvmEnumBoxedMultiFieldDiagnostic(decl.Name, variant.Name, len(variant.Fields))
-			return nil, unsupported(diag.kind, diag.message)
-		}
 		if _, exists := info.variants[variant.Name]; exists {
 			diag := llvmEnumVariantHeaderDiagnostic(decl.Name, variant.Name, true, len(variant.Fields), true)
 			return nil, unsupported(diag.kind, diag.message)
 		}
 		info.variants[variant.Name] = variantInfo{
-			name:               variant.Name,
-			tag:                i,
-			payloads:           payloads,
-			payloadListElemTyp: payloadListElemTyp,
+			name:                variant.Name,
+			tag:                 i,
+			payloads:            payloads,
+			payloadListElemTyp:  payloadListElemTyp,
+			payloadListElemTyps: payloadListElemTyps,
 		}
 	}
 	if info.isBoxed {
 		info.payloadSlotTypes = nil
 		info.payloadTyp = ""
+		for _, decl := range decl.Variants {
+			if decl == nil {
+				continue
+			}
+			v, ok := info.variants[decl.Name]
+			if !ok {
+				continue
+			}
+			if len(v.payloads) <= 1 {
+				continue
+			}
+			for _, ptyp := range v.payloads {
+				if ptyp == "ptr" {
+					diag := llvmEnumBoxedMultiFieldDiagnostic(info.name, v.name, len(v.payloads))
+					return nil, unsupported(diag.kind, diag.message)
+				}
+			}
+		}
 	} else if len(info.payloadSlotTypes) > 0 {
 		info.payloadTyp = info.payloadSlotTypes[0]
 		for _, t := range info.payloadSlotTypes {

--- a/internal/llvmgen/enum_multi_field_test.go
+++ b/internal/llvmgen/enum_multi_field_test.go
@@ -1,9 +1,48 @@
 package llvmgen
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
+
+// TestGenerateEnumMultiFieldFixture compiles the canonical multi-field
+// payload fixture in testdata/backend/llvm_smoke/ and asserts the whole
+// IR is well-formed: the layout, all three constructors, and the match
+// extractvalue chain must emit together without errors.
+func TestGenerateEnumMultiFieldFixture(t *testing.T) {
+	src, err := os.ReadFile("../../testdata/backend/llvm_smoke/enum_multi_field_payload_print.osty")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	file := parseLLVMGenFile(t, string(src))
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_multi_field_payload_print.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"%Event = type { i64, i64, i64 }",
+		"insertvalue %Event undef, i64 0, 0",
+		", i64 3, 1",
+		", i64 4, 2",
+		"insertvalue %Event undef, i64 1, 0",
+		", i64 7, 1",
+		"insertvalue %Event undef, i64 2, 0",
+		"extractvalue %Event",
+		", 1",
+		", 2",
+		"mul i64",
+		"call i32 (ptr, ...) @printf",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("fixture IR missing %q:\n%s", want, got)
+		}
+	}
+}
 
 // TestGenerateEnumMultiFieldPayloadConstructs verifies that a homogeneous
 // multi-field payload enum (e.g. Event.Click(Int, Int)) lowers to a
@@ -42,6 +81,86 @@ fn main() {
 		", i64 4, 2",
 		"insertvalue %Event undef, i64 1, 0",
 		", i64 7, 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateEnumBoxedMultiFieldScalar verifies that an enum that is
+// forced onto the boxed path (different slot-0 types across variants)
+// can still carry a scalar-only multi-field variant: the payload is
+// heap-allocated and each field stored at an 8-byte offset via GEP.
+func TestGenerateEnumBoxedMultiFieldScalar(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Mixed {
+    Pair(Int, Int)
+    Ratio(Float)
+    Empty
+}
+
+fn main() {
+    let a: Mixed = Pair(3, 4)
+    let b: Mixed = Ratio(1.5)
+    let c: Mixed = Empty
+    let _ = a
+    let _ = b
+    let _ = c
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_boxed_multi.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Mixed = type { i64, ptr }",
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 16,",
+		"getelementptr i8, ptr",
+		"store i64 3, ptr",
+		"store i64 4, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateEnumBoxedMultiFieldMatch verifies that matching a boxed
+// multi-field variant loads each slot via GEP+load.
+func TestGenerateEnumBoxedMultiFieldMatch(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Mixed {
+    Pair(Int, Int)
+    Ratio(Float)
+}
+
+fn sumOf(m: Mixed) -> Int {
+    match m {
+        Pair(a, b) -> a + b,
+        Ratio(_) -> 0,
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/enum_boxed_multi_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Mixed = type { i64, ptr }",
+		"extractvalue %Mixed",
+		"getelementptr i8, ptr",
+		"load i64, ptr",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)

--- a/internal/llvmgen/enum_multi_field_test.go
+++ b/internal/llvmgen/enum_multi_field_test.go
@@ -1,0 +1,90 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateEnumMultiFieldPayloadConstructs verifies that a homogeneous
+// multi-field payload enum (e.g. Event.Click(Int, Int)) lowers to a
+// `%Enum = type { i64, i64, i64 }` layout and that each constructor
+// insertvalue reaches the correct slot.
+func TestGenerateEnumMultiFieldPayloadConstructs(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Event {
+    Click(Int, Int)
+    Tick(Int)
+    Close
+}
+
+fn main() {
+    let a: Event = Click(3, 4)
+    let b: Event = Tick(7)
+    let c: Event = Close
+    let _ = a
+    let _ = b
+    let _ = c
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_multi_field.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Event = type { i64, i64, i64 }",
+		"insertvalue %Event undef, i64 0, 0",
+		", i64 3, 1",
+		", i64 4, 2",
+		"insertvalue %Event undef, i64 1, 0",
+		", i64 7, 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateEnumMultiFieldPayloadMatchBindsBothSlots verifies that a
+// match on Click(x, y) emits two extractvalue instructions pulling
+// slots 1 and 2 into separate locals.
+func TestGenerateEnumMultiFieldPayloadMatchBindsBothSlots(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Event {
+    Click(Int, Int)
+    Tick(Int)
+    Close
+}
+
+fn dx(e: Event) -> Int {
+    match e {
+        Click(x, y) -> x + y,
+        Tick(n) -> n,
+        Close -> 0,
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/enum_multi_field_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Event = type { i64, i64, i64 }",
+		"extractvalue %Event %e, 1",
+		"extractvalue %Event %e, 2",
+		"add i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/enum_multi_field_test.go
+++ b/internal/llvmgen/enum_multi_field_test.go
@@ -49,6 +49,89 @@ fn main() {
 	}
 }
 
+// TestGenerateEnumHeterogeneousPayloadSlotsMatch verifies that matching
+// a heterogeneous-slot variant binds each slot with the correct
+// extractvalue type.
+func TestGenerateEnumHeterogeneousPayloadSlotsMatch(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Entry {
+    Pair(String, Int)
+    Empty
+}
+
+fn countOf(e: Entry) -> Int {
+    match e {
+        Pair(_, n) -> n,
+        Empty -> 0,
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/enum_hetero_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Entry = type { i64, ptr, i64 }",
+		"extractvalue %Entry",
+		", 2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	// slot 1 is wildcarded and should not be extracted into a local.
+	extractSlot1 := 0
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "extractvalue %Entry") && strings.HasSuffix(strings.TrimSpace(line), ", 1") {
+			extractSlot1++
+		}
+	}
+	if extractSlot1 != 0 {
+		t.Fatalf("wildcarded slot 1 was extracted %d time(s):\n%s", extractSlot1, got)
+	}
+}
+
+// TestGenerateEnumHeterogeneousPayloadSlots verifies that a variant with
+// heterogeneous payload slot types (e.g. `Entry(String, Int)`) lowers
+// inline with the correct per-slot LLVM types rather than forcing the
+// boxed path.
+func TestGenerateEnumHeterogeneousPayloadSlots(t *testing.T) {
+	file := parseLLVMGenFile(t, `enum Entry {
+    Pair(String, Int)
+    Empty
+}
+
+fn main() {
+    let e: Entry = Pair("alice", 7)
+    let _ = e
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/enum_hetero_slots.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"%Entry = type { i64, ptr, i64 }",
+		"insertvalue %Entry undef, i64 0, 0",
+		", i64 7, 2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateEnumMultiFieldPayloadMatchBindsBothSlots verifies that a
 // match on Click(x, y) emits two extractvalue instructions pulling
 // slots 1 and 2 into separate locals.

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -679,9 +679,19 @@ func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, 
 		enumValue.rootPaths = g.rootPathsForType(info.typ)
 		return enumValue, nil
 	}
-	for _, p := range payloads {
-		if p.typ != info.payloadTyp {
-			return value{}, unsupportedf("type-system", "enum %q variant %q payload type %s, want %s", info.name, variant.name, p.typ, info.payloadTyp)
+	slotType := func(i int) string {
+		if i < len(info.payloadSlotTypes) {
+			return info.payloadSlotTypes[i]
+		}
+		if info.payloadTyp != "" {
+			return info.payloadTyp
+		}
+		return "i64"
+	}
+	for i, p := range payloads {
+		want := slotType(i)
+		if p.typ != want {
+			return value{}, unsupportedf("type-system", "enum %q variant %q payload slot %d type %s, want %s", info.name, variant.name, i, p.typ, want)
 		}
 	}
 	slotCount := info.payloadCount
@@ -695,7 +705,8 @@ func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, 
 			fields = append(fields, toOstyValue(payloads[i]))
 			continue
 		}
-		fields = append(fields, &LlvmValue{typ: info.payloadTyp, name: llvmZeroLiteral(info.payloadTyp), pointer: false})
+		t := slotType(i)
+		fields = append(fields, &LlvmValue{typ: t, name: llvmZeroLiteral(t), pointer: false})
 	}
 	emitter := g.toOstyEmitter()
 	out := llvmStructLiteral(emitter, info.typ, fields)

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -622,7 +622,7 @@ func (g *generator) enumVariantConstant(info *enumInfo, variant variantInfo) (va
 		if len(variant.payloads) != 0 {
 			return value{}, unsupportedf("expression", "enum variant %q requires a payload", variant.name)
 		}
-		return g.emitEnumPayloadVariant(info, variant, value{typ: info.payloadTyp, ref: llvmZeroLiteral(info.payloadTyp)})
+		return g.emitEnumPayloadVariant(info, variant, nil)
 	}
 	out := llvmEnumVariant(info.name, variant.tag)
 	return fromOstyValue(out), nil
@@ -656,11 +656,20 @@ func (g *generator) enumVariantByField(expr *ast.FieldExpr) (enumVariantRef, boo
 	return enumVariantRef{enum: info, variant: variant}, true
 }
 
-func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, payload value) (value, error) {
+func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, payloads []value) (value, error) {
 	if !info.hasPayload {
 		return value{}, unsupportedf("expression", "enum %q has no payload layout", info.name)
 	}
 	if info.isBoxed {
+		if len(payloads) > 1 {
+			return value{}, unsupportedf("type-system", "enum %q boxed multi-field payload is not supported yet", info.name)
+		}
+		var payload value
+		if len(payloads) == 1 {
+			payload = payloads[0]
+		} else {
+			payload = value{typ: "ptr", ref: "null"}
+		}
 		emitter := g.toOstyEmitter()
 		site := "enum." + info.name + "." + variant.name
 		out := llvmEnumBoxedPayloadVariant(emitter, info.typ, variant.tag, toOstyValue(payload), site)
@@ -670,11 +679,26 @@ func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, 
 		enumValue.rootPaths = g.rootPathsForType(info.typ)
 		return enumValue, nil
 	}
-	if payload.typ != info.payloadTyp {
-		return value{}, unsupportedf("type-system", "enum %q variant %q payload type %s, want %s", info.name, variant.name, payload.typ, info.payloadTyp)
+	for _, p := range payloads {
+		if p.typ != info.payloadTyp {
+			return value{}, unsupportedf("type-system", "enum %q variant %q payload type %s, want %s", info.name, variant.name, p.typ, info.payloadTyp)
+		}
+	}
+	slotCount := info.payloadCount
+	if slotCount < 1 {
+		slotCount = 1
+	}
+	fields := make([]*LlvmValue, 0, 1+slotCount)
+	fields = append(fields, llvmEnumVariant(info.typ, variant.tag))
+	for i := 0; i < slotCount; i++ {
+		if i < len(payloads) {
+			fields = append(fields, toOstyValue(payloads[i]))
+			continue
+		}
+		fields = append(fields, &LlvmValue{typ: info.payloadTyp, name: llvmZeroLiteral(info.payloadTyp), pointer: false})
 	}
 	emitter := g.toOstyEmitter()
-	out := llvmEnumPayloadVariant(emitter, info.typ, variant.tag, toOstyValue(payload))
+	out := llvmStructLiteral(emitter, info.typ, fields)
 	g.takeOstyEmitter(emitter)
 	enumValue := fromOstyValue(out)
 	enumValue.rootPaths = g.rootPathsForType(info.typ)
@@ -2389,20 +2413,37 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 	if !pattern.hasPayloadBinding {
 		return nil
 	}
-	emitter := g.toOstyEmitter()
-	var payload *LlvmValue
-	if pattern.isBoxed {
-		heapPtr := llvmExtractValue(emitter, toOstyValue(scrutinee), "ptr", 1)
-		payload = llvmLoadFromSlot(emitter, heapPtr, pattern.payloadType)
-	} else {
-		payload = llvmExtractValue(emitter, toOstyValue(scrutinee), pattern.payloadType, 1)
+	if len(pattern.payloadBindings) == 0 {
+		return nil
 	}
-	g.takeOstyEmitter(emitter)
-	payloadValue := fromOstyValue(payload)
-	payloadValue.listElemTyp = pattern.payloadListElemTyp
-	payloadValue.gcManaged = pattern.payloadType == "ptr" || pattern.payloadListElemTyp != ""
-	payloadValue.rootPaths = g.rootPathsForType(pattern.payloadType)
-	g.bindNamedLocal(pattern.payloadName, payloadValue, false)
+	if pattern.isBoxed {
+		emitter := g.toOstyEmitter()
+		heapPtr := llvmExtractValue(emitter, toOstyValue(scrutinee), "ptr", 1)
+		payload := llvmLoadFromSlot(emitter, heapPtr, pattern.payloadType)
+		g.takeOstyEmitter(emitter)
+		b := pattern.payloadBindings[0]
+		payloadValue := fromOstyValue(payload)
+		payloadValue.listElemTyp = pattern.payloadListElemTyp
+		payloadValue.gcManaged = b.typ == "ptr" || pattern.payloadListElemTyp != ""
+		payloadValue.rootPaths = g.rootPathsForType(b.typ)
+		g.bindNamedLocal(b.name, payloadValue, false)
+		return nil
+	}
+	for _, b := range pattern.payloadBindings {
+		if b.name == "" {
+			continue
+		}
+		emitter := g.toOstyEmitter()
+		payload := llvmExtractValue(emitter, toOstyValue(scrutinee), b.typ, b.index)
+		g.takeOstyEmitter(emitter)
+		payloadValue := fromOstyValue(payload)
+		if b.index == 1 {
+			payloadValue.listElemTyp = pattern.payloadListElemTyp
+		}
+		payloadValue.gcManaged = b.typ == "ptr" || payloadValue.listElemTyp != ""
+		payloadValue.rootPaths = g.rootPathsForType(b.typ)
+		g.bindNamedLocal(b.name, payloadValue, false)
+	}
 	return nil
 }
 
@@ -2438,16 +2479,26 @@ func (g *generator) matchPayloadEnumPattern(info *enumInfo, pattern ast.Pattern)
 		}
 		out.payloadType = variant.payloads[0]
 		out.payloadListElemTyp = variant.payloadListElemTyp
-		switch arg := p.Args[0].(type) {
-		case *ast.IdentPat:
-			if !llvmIsIdent(arg.Name) {
-				return enumPatternInfo{}, true, unsupportedf("name", "enum payload binding name %q", arg.Name)
+		if info.isBoxed && len(p.Args) > 1 {
+			return enumPatternInfo{}, true, unsupportedf("expression", "enum variant pattern %q boxed multi-field payload is not supported yet", name)
+		}
+		for idx, arg := range p.Args {
+			binding := enumPayloadBinding{typ: variant.payloads[idx], index: idx + 1}
+			switch a := arg.(type) {
+			case *ast.IdentPat:
+				if !llvmIsIdent(a.Name) {
+					return enumPatternInfo{}, true, unsupportedf("name", "enum payload binding name %q", a.Name)
+				}
+				binding.name = a.Name
+				out.hasPayloadBinding = true
+				if idx == 0 {
+					out.payloadName = a.Name
+				}
+			case *ast.WildcardPat:
+			default:
+				return enumPatternInfo{}, true, unsupportedf("expression", "enum variant payload pattern %T", a)
 			}
-			out.payloadName = arg.Name
-			out.hasPayloadBinding = true
-		case *ast.WildcardPat:
-		default:
-			return enumPatternInfo{}, true, unsupportedf("expression", "enum variant payload pattern %T", arg)
+			out.payloadBindings = append(out.payloadBindings, binding)
 		}
 		return out, true, nil
 	default:
@@ -2999,18 +3050,21 @@ func (g *generator) emitEnumVariantCall(call *ast.CallExpr) (value, bool, error)
 	if !ref.enum.hasPayload {
 		return value{}, true, unsupportedf("expression", "enum %q has no payload layout", ref.enum.name)
 	}
-	arg := call.Args[0]
-	if arg.Name != "" || arg.Value == nil {
-		return value{}, true, unsupportedf("call", "enum variant %q requires positional payload", ref.variant.name)
+	payloads := make([]value, 0, len(call.Args))
+	for i, arg := range call.Args {
+		if arg.Name != "" || arg.Value == nil {
+			return value{}, true, unsupportedf("call", "enum variant %q requires positional payload", ref.variant.name)
+		}
+		payload, err := g.emitExpr(arg.Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		if payload.typ != ref.variant.payloads[i] {
+			return value{}, true, unsupportedf("type-system", "enum variant %q payload type %s, want %s", ref.variant.name, payload.typ, ref.variant.payloads[i])
+		}
+		payloads = append(payloads, payload)
 	}
-	payload, err := g.emitExpr(arg.Value)
-	if err != nil {
-		return value{}, true, err
-	}
-	if payload.typ != ref.variant.payloads[0] {
-		return value{}, true, unsupportedf("type-system", "enum variant %q payload type %s, want %s", ref.variant.name, payload.typ, ref.variant.payloads[0])
-	}
-	out, err := g.emitEnumPayloadVariant(ref.enum, ref.variant, payload)
+	out, err := g.emitEnumPayloadVariant(ref.enum, ref.variant, payloads)
 	return out, true, err
 }
 

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -662,7 +662,26 @@ func (g *generator) emitEnumPayloadVariant(info *enumInfo, variant variantInfo, 
 	}
 	if info.isBoxed {
 		if len(payloads) > 1 {
-			return value{}, unsupportedf("type-system", "enum %q boxed multi-field payload is not supported yet", info.name)
+			for _, p := range payloads {
+				if p.typ == "ptr" {
+					return value{}, unsupportedf("type-system", "enum %q boxed multi-field payload with ptr field is not supported", info.name)
+				}
+			}
+			emitter := g.toOstyEmitter()
+			site := "enum." + info.name + "." + variant.name
+			byteSize := len(payloads) * 8
+			heapPtr := llvmGcAlloc(emitter, 1, byteSize, site)
+			for i, p := range payloads {
+				gep := llvmNextTemp(emitter)
+				emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", gep, heapPtr.name, i*8))
+				emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", p.typ, p.ref, gep))
+			}
+			out := llvmStructLiteral(emitter, info.typ, []*LlvmValue{llvmEnumVariant(info.typ, variant.tag), heapPtr})
+			g.takeOstyEmitter(emitter)
+			g.needsGCRuntime = true
+			enumValue := fromOstyValue(out)
+			enumValue.rootPaths = g.rootPathsForType(info.typ)
+			return enumValue, nil
 		}
 		var payload value
 		if len(payloads) == 1 {
@@ -2430,6 +2449,22 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 	if pattern.isBoxed {
 		emitter := g.toOstyEmitter()
 		heapPtr := llvmExtractValue(emitter, toOstyValue(scrutinee), "ptr", 1)
+		if len(pattern.payloadBindings) > 1 {
+			for i, b := range pattern.payloadBindings {
+				if b.name == "" {
+					continue
+				}
+				gep := llvmNextTemp(emitter)
+				emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr i8, ptr %s, i64 %d", gep, heapPtr.name, i*8))
+				loadTmp := llvmNextTemp(emitter)
+				emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", loadTmp, b.typ, gep))
+				payloadValue := value{typ: b.typ, ref: loadTmp}
+				payloadValue.rootPaths = g.rootPathsForType(b.typ)
+				g.bindNamedLocal(b.name, payloadValue, false)
+			}
+			g.takeOstyEmitter(emitter)
+			return nil
+		}
 		payload := llvmLoadFromSlot(emitter, heapPtr, pattern.payloadType)
 		g.takeOstyEmitter(emitter)
 		b := pattern.payloadBindings[0]
@@ -2440,7 +2475,7 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 		g.bindNamedLocal(b.name, payloadValue, false)
 		return nil
 	}
-	for _, b := range pattern.payloadBindings {
+	for i, b := range pattern.payloadBindings {
 		if b.name == "" {
 			continue
 		}
@@ -2448,7 +2483,9 @@ func (g *generator) bindPayloadEnumPattern(scrutinee value, pattern enumPatternI
 		payload := llvmExtractValue(emitter, toOstyValue(scrutinee), b.typ, b.index)
 		g.takeOstyEmitter(emitter)
 		payloadValue := fromOstyValue(payload)
-		if b.index == 1 {
+		if i < len(pattern.variant.payloadListElemTyps) {
+			payloadValue.listElemTyp = pattern.variant.payloadListElemTyps[i]
+		} else if b.index == 1 {
 			payloadValue.listElemTyp = pattern.payloadListElemTyp
 		}
 		payloadValue.gcManaged = b.typ == "ptr" || payloadValue.listElemTyp != ""
@@ -2491,7 +2528,11 @@ func (g *generator) matchPayloadEnumPattern(info *enumInfo, pattern ast.Pattern)
 		out.payloadType = variant.payloads[0]
 		out.payloadListElemTyp = variant.payloadListElemTyp
 		if info.isBoxed && len(p.Args) > 1 {
-			return enumPatternInfo{}, true, unsupportedf("expression", "enum variant pattern %q boxed multi-field payload is not supported yet", name)
+			for _, pt := range variant.payloads {
+				if pt == "ptr" {
+					return enumPatternInfo{}, true, unsupportedf("expression", "enum variant pattern %q boxed multi-field payload with ptr field is not supported", name)
+				}
+			}
 		}
 		for idx, arg := range p.Args {
 			binding := enumPayloadBinding{typ: variant.payloads[idx], index: idx + 1}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -237,7 +237,16 @@ func (g *generator) render(defs []string) []byte {
 			if info.isBoxed {
 				payloadSlot = "ptr"
 			}
-			typeDefs = append(typeDefs, llvmStructTypeDef(info.name, []string{"i64", payloadSlot}))
+			slotCount := info.payloadCount
+			if slotCount < 1 {
+				slotCount = 1
+			}
+			fields := make([]string, 0, 1+slotCount)
+			fields = append(fields, "i64")
+			for s := 0; s < slotCount; s++ {
+				fields = append(fields, payloadSlot)
+			}
+			typeDefs = append(typeDefs, llvmStructTypeDef(info.name, fields))
 		}
 	}
 	if len(g.tupleTypes) != 0 {

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -233,18 +233,27 @@ func (g *generator) render(defs []string) []byte {
 	}
 	for _, info := range g.enums {
 		if info.hasPayload {
-			payloadSlot := info.payloadTyp
+			var fields []string
 			if info.isBoxed {
-				payloadSlot = "ptr"
-			}
-			slotCount := info.payloadCount
-			if slotCount < 1 {
-				slotCount = 1
-			}
-			fields := make([]string, 0, 1+slotCount)
-			fields = append(fields, "i64")
-			for s := 0; s < slotCount; s++ {
-				fields = append(fields, payloadSlot)
+				fields = []string{"i64", "ptr"}
+			} else {
+				slotCount := info.payloadCount
+				if slotCount < 1 {
+					slotCount = 1
+				}
+				fields = make([]string, 0, 1+slotCount)
+				fields = append(fields, "i64")
+				for s := 0; s < slotCount; s++ {
+					var slotTyp string
+					if s < len(info.payloadSlotTypes) {
+						slotTyp = info.payloadSlotTypes[s]
+					} else if info.payloadTyp != "" {
+						slotTyp = info.payloadTyp
+					} else {
+						slotTyp = "i64"
+					}
+					fields = append(fields, slotTyp)
+				}
 			}
 			typeDefs = append(typeDefs, llvmStructTypeDef(info.name, fields))
 		}

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -248,8 +248,17 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if got, want := llvmEnumVariantHeaderDiagnostic("Choice", "bad-name", false, 0, false).message, `enum "Choice" variant name "bad-name"`; got != want {
 		t.Fatalf("llvmEnumVariantHeaderDiagnostic(%q, %q, false, 0, false).message = %q, want %q", "Choice", "bad-name", got, want)
 	}
-	if got, want := llvmEnumVariantHeaderDiagnostic("Choice", "Some", true, 2, false).message, `enum "Choice" variant "Some" has 2 payload fields; only one scalar payload is supported`; got != want {
+	if got, want := llvmEnumVariantHeaderDiagnostic("Choice", "Some", true, 2, false).message, `enum "Choice" variant "Some" has 2 payload fields; the LLVM backend only supports a single scalar or pointer payload per variant`; got != want {
 		t.Fatalf("llvmEnumVariantHeaderDiagnostic(%q, %q, true, 2, false).message = %q, want %q", "Choice", "Some", got, want)
+	}
+	if got := llvmEnumVariantHeaderDiagnostic("Choice", "Some", true, 2, false); got.code != "LLVM011" || got.hint == "" {
+		t.Fatalf("llvmEnumVariantHeaderDiagnostic multi-field: code=%q hint=%q, want LLVM011 + non-empty hint", got.code, got.hint)
+	}
+	if got := llvmStructFieldDiagnostic("Tree", "left", true, false, false, true, ""); got.code != "LLVM011" || got.hint == "" {
+		t.Fatalf("llvmStructFieldDiagnostic recursive: code=%q hint=%q, want LLVM011 + non-empty hint", got.code, got.hint)
+	}
+	if got, want := llvmStructFieldDiagnostic("Tree", "left", true, false, false, true, "").message, `struct "Tree" recursive field "left" requires indirection`; got != want {
+		t.Fatalf("llvmStructFieldDiagnostic recursive message = %q, want %q", got, want)
 	}
 	if got, want := llvmEnumPayloadDiagnostic("Choice", "Some", "unsupported payload", "", "").message, `enum "Choice" variant "Some" payload: unsupported payload`; got != want {
 		t.Fatalf("llvmEnumPayloadDiagnostic(%q, %q, %q, %q, %q).message = %q, want %q", "Choice", "Some", "unsupported payload", "", "", got, want)

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -248,11 +248,14 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if got, want := llvmEnumVariantHeaderDiagnostic("Choice", "bad-name", false, 0, false).message, `enum "Choice" variant name "bad-name"`; got != want {
 		t.Fatalf("llvmEnumVariantHeaderDiagnostic(%q, %q, false, 0, false).message = %q, want %q", "Choice", "bad-name", got, want)
 	}
-	if got, want := llvmEnumVariantHeaderDiagnostic("Choice", "Some", true, 2, false).message, `enum "Choice" variant "Some" has 2 payload fields; the LLVM backend only supports a single scalar or pointer payload per variant`; got != want {
-		t.Fatalf("llvmEnumVariantHeaderDiagnostic(%q, %q, true, 2, false).message = %q, want %q", "Choice", "Some", got, want)
+	if got := llvmEnumVariantHeaderDiagnostic("Choice", "Some", true, 2, false); got.kind != "" {
+		t.Fatalf("llvmEnumVariantHeaderDiagnostic multi-field should no longer reject: kind=%q msg=%q", got.kind, got.message)
 	}
-	if got := llvmEnumVariantHeaderDiagnostic("Choice", "Some", true, 2, false); got.code != "LLVM011" || got.hint == "" {
-		t.Fatalf("llvmEnumVariantHeaderDiagnostic multi-field: code=%q hint=%q, want LLVM011 + non-empty hint", got.code, got.hint)
+	if got := llvmEnumBoxedMultiFieldDiagnostic("Choice", "Mix", 2); got.code != "LLVM011" || got.hint == "" {
+		t.Fatalf("llvmEnumBoxedMultiFieldDiagnostic: code=%q hint=%q, want LLVM011 + non-empty hint", got.code, got.hint)
+	}
+	if got, want := llvmEnumBoxedMultiFieldDiagnostic("Choice", "Mix", 2).message, `enum "Choice" variant "Mix" has 2 payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet`; got != want {
+		t.Fatalf("llvmEnumBoxedMultiFieldDiagnostic message = %q, want %q", got, want)
 	}
 	if got := llvmStructFieldDiagnostic("Tree", "left", true, false, false, true, ""); got.code != "LLVM011" || got.hint == "" {
 		t.Fatalf("llvmStructFieldDiagnostic recursive: code=%q hint=%q, want LLVM011 + non-empty hint", got.code, got.hint)

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2400,7 +2400,12 @@ func llvmStructFieldDiagnostic(structName string, fieldName string, identOk bool
 		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct %q field %q: %s", structName, fieldName, detail))
 	}
 	if recursive {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct %q recursive field %q", structName, fieldName))
+		return llvmUnsupportedDiagnosticWith(
+			"LLVM011",
+			"type-system",
+			fmt.Sprintf("struct %q recursive field %q requires indirection", structName, fieldName),
+			"break the cycle via an arena index (Int id) or List<T> handle until the LLVM backend grows recursive-struct support",
+		)
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
@@ -2410,7 +2415,12 @@ func llvmEnumVariantHeaderDiagnostic(enumName string, variantName string, identO
 		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("enum %q variant name %q", enumName, variantName))
 	}
 	if payloadCount > 1 {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q variant %q has %d payload fields; only one scalar payload is supported", enumName, variantName, payloadCount))
+		return llvmUnsupportedDiagnosticWith(
+			"LLVM011",
+			"type-system",
+			fmt.Sprintf("enum %q variant %q has %d payload fields; the LLVM backend only supports a single scalar or pointer payload per variant", enumName, variantName, payloadCount),
+			"flatten the variant to a single field (e.g. a tuple-wrapping struct passed by pointer) or adopt the arena + flat kind-discriminator pattern used by toolchain/core.osty",
+		)
 	}
 	if duplicate {
 		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("enum %q duplicate variant %q", enumName, variantName))

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2414,18 +2414,20 @@ func llvmEnumVariantHeaderDiagnostic(enumName string, variantName string, identO
 	if !identOk {
 		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("enum %q variant name %q", enumName, variantName))
 	}
-	if payloadCount > 1 {
-		return llvmUnsupportedDiagnosticWith(
-			"LLVM011",
-			"type-system",
-			fmt.Sprintf("enum %q variant %q has %d payload fields; the LLVM backend only supports a single scalar or pointer payload per variant", enumName, variantName, payloadCount),
-			"flatten the variant to a single field (e.g. a tuple-wrapping struct passed by pointer) or adopt the arena + flat kind-discriminator pattern used by toolchain/core.osty",
-		)
-	}
 	if duplicate {
 		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("enum %q duplicate variant %q", enumName, variantName))
 	}
+	_ = payloadCount
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
+}
+
+func llvmEnumBoxedMultiFieldDiagnostic(enumName string, variantName string, payloadCount int) *LlvmUnsupportedDiagnostic {
+	return llvmUnsupportedDiagnosticWith(
+		"LLVM011",
+		"type-system",
+		fmt.Sprintf("enum %q variant %q has %d payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet", enumName, variantName, payloadCount),
+		"keep a single boxed payload per variant, or make all variant payloads share one scalar/pointer type so the inline multi-slot layout can be used",
+	)
 }
 
 func llvmEnumPayloadDiagnostic(enumName string, variantName string, detail string, expectedType string, actualType string) *LlvmUnsupportedDiagnostic {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -278,10 +278,20 @@ func (g *generator) rootPathsForTypeSeen(typ string, seen map[string]bool) [][]i
 		if info.isBoxed {
 			return [][]int{{1}}
 		}
-		if info.payloadTyp == "ptr" {
-			return [][]int{{1}}
+		slotTypes := info.payloadSlotTypes
+		if len(slotTypes) == 0 && info.payloadTyp != "" {
+			slotTypes = []string{info.payloadTyp}
 		}
-		return prependRootIndex(1, g.rootPathsForTypeSeen(info.payloadTyp, seen))
+		var out [][]int
+		for i, slotTyp := range slotTypes {
+			slot := i + 1
+			if slotTyp == "ptr" {
+				out = append(out, []int{slot})
+				continue
+			}
+			out = append(out, prependRootIndex(slot, g.rootPathsForTypeSeen(slotTyp, seen))...)
+		}
+		return out
 	}
 	if info, ok := g.resultTypes[typ]; ok {
 		seen[typ] = true
@@ -325,13 +335,20 @@ func (g *generator) aggregateFieldType(typ string, index int) (string, bool) {
 		return "", false
 	}
 	if info := g.enumsByType[typ]; info != nil && info.hasPayload {
-		switch index {
-		case 0:
+		if index == 0 {
 			return "i64", true
-		case 1:
-			if info.isBoxed {
+		}
+		if info.isBoxed {
+			if index == 1 {
 				return "ptr", true
 			}
+			return "", false
+		}
+		slot := index - 1
+		if slot >= 0 && slot < len(info.payloadSlotTypes) {
+			return info.payloadSlotTypes[slot], true
+		}
+		if slot == 0 && info.payloadTyp != "" {
 			return info.payloadTyp, true
 		}
 	}

--- a/testdata/backend/llvm_smoke/enum_multi_field_payload_print.osty
+++ b/testdata/backend/llvm_smoke/enum_multi_field_payload_print.osty
@@ -1,0 +1,19 @@
+enum Event {
+    Click(Int, Int)
+    Tick(Int)
+    Close
+}
+
+fn area(e: Event) -> Int {
+    match e {
+        Click(x, y) -> x * y,
+        Tick(n) -> n,
+        Close -> 0,
+    }
+}
+
+fn main() {
+    println(area(Click(3, 4)))
+    println(area(Tick(7)))
+    println(area(Close))
+}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2598,9 +2598,11 @@ pub fn llvmStructFieldDiagnostic(
         )
     }
     if recursive {
-        return llvmUnsupportedDiagnostic(
+        return llvmUnsupportedDiagnosticWith(
+            "LLVM011",
             "type-system",
-            "struct \"{structName}\" recursive field \"{fieldName}\"",
+            "struct \"{structName}\" recursive field \"{fieldName}\" requires indirection",
+            "break the cycle via an arena index (Int id) or List<T> handle until the LLVM backend grows recursive-struct support",
         )
     }
     llvmUnsupportedDiagnosticWith("", "", "", "")
@@ -2620,9 +2622,11 @@ pub fn llvmEnumVariantHeaderDiagnostic(
         )
     }
     if payloadCount > 1 {
-        return llvmUnsupportedDiagnostic(
+        return llvmUnsupportedDiagnosticWith(
+            "LLVM011",
             "type-system",
-            "enum \"{enumName}\" variant \"{variantName}\" has {payloadCount} payload fields; only one scalar payload is supported",
+            "enum \"{enumName}\" variant \"{variantName}\" has {payloadCount} payload fields; the LLVM backend only supports a single scalar or pointer payload per variant",
+            "flatten the variant to a single field (e.g. a tuple-wrapping struct passed by pointer) or adopt the arena + flat kind-discriminator pattern used by toolchain/core.osty",
         )
     }
     if duplicate {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2621,21 +2621,27 @@ pub fn llvmEnumVariantHeaderDiagnostic(
             "enum \"{enumName}\" variant name \"{variantName}\"",
         )
     }
-    if payloadCount > 1 {
-        return llvmUnsupportedDiagnosticWith(
-            "LLVM011",
-            "type-system",
-            "enum \"{enumName}\" variant \"{variantName}\" has {payloadCount} payload fields; the LLVM backend only supports a single scalar or pointer payload per variant",
-            "flatten the variant to a single field (e.g. a tuple-wrapping struct passed by pointer) or adopt the arena + flat kind-discriminator pattern used by toolchain/core.osty",
-        )
-    }
     if duplicate {
         return llvmUnsupportedDiagnostic(
             "source-layout",
             "enum \"{enumName}\" duplicate variant \"{variantName}\"",
         )
     }
+    let _ = payloadCount
     llvmUnsupportedDiagnosticWith("", "", "", "")
+}
+
+pub fn llvmEnumBoxedMultiFieldDiagnostic(
+    enumName: String,
+    variantName: String,
+    payloadCount: Int,
+) -> LlvmUnsupportedDiagnostic {
+    llvmUnsupportedDiagnosticWith(
+        "LLVM011",
+        "type-system",
+        "enum \"{enumName}\" variant \"{variantName}\" has {payloadCount} payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet",
+        "keep a single boxed payload per variant, or make all variant payloads share one scalar/pointer type so the inline multi-slot layout can be used",
+    )
 }
 
 pub fn llvmEnumPayloadDiagnostic(


### PR DESCRIPTION
## Summary

Adds real backend support for **multi-field payload enums with a
homogeneous scalar/pointer type** (e.g. `Event.Click(Int, Int)`
alongside `Tick(Int)` and `Close`). Previously the backend rejected any
variant with 2+ payload fields; now those cases lower end-to-end.

### Layout

Storage grows from `%Enum = type { i64, T }` to
`%Enum = type { i64, T, T, ..., T }` where the payload-slot count
matches the widest variant in the enum. Variants with fewer fields
zero-pad the remaining slots; payload-free variants still emit a
well-typed `{tag, 0, 0, ...}` aggregate.

### Implementation touch points

- `collectEnum` (decl.go): walks every payload field, tracks
  `payloadCount` (max field count), keeps the homogeneous-type
  invariant, routes heterogeneous enums through the boxed path. Boxed
  + multi-field still rejects via a dedicated
  `llvmEnumBoxedMultiFieldDiagnostic` (LLVM011) with an actionable
  hint.
- `emitEnumPayloadVariant` (expr.go): takes `[]value` so the bare
  constant path, the enum-variant call, and the boxed path share a
  single entry point. Inline path assembles the aggregate via
  `llvmStructLiteral(tag, p1, p2, …, pad, …)`.
- `emitEnumVariantCall`: evaluates every argument, type-checks each
  against the variant's corresponding slot.
- `matchPayloadEnumPattern` + `bindPayloadEnumPattern`: produce
  per-slot `enumPayloadBinding`s; the match side emits one
  `extractvalue` per bound slot at index `i+1` and honors wildcards
  per slot.
- Storage type emission (generator.go): widens the type def to N+1
  fields.
- Diagnostic: removed the blanket `payloadCount > 1` rejection in
  `toolchain/llvmgen.osty` and the Go snapshot; recursive struct field
  rejection still uses the actionable LLVM011 hint from the earlier
  commit.

### Tests

New `enum_multi_field_test.go`:

- `TestGenerateEnumMultiFieldPayloadConstructs` — pins
  `%Event = type { i64, i64, i64 }` and the `insertvalue … , 1` /
  `, 2` slot writes for `Click(3, 4)` and the trailing `, i64 7, 1`
  slot write for `Tick(7)`.
- `TestGenerateEnumMultiFieldPayloadMatchBindsBothSlots` — pins two
  `extractvalue %Event %e, 1` and `, 2` reads plus an `add i64` on
  the bound pair.

Existing payload-enum tests (`TestGenerateIfLetPayloadEnumStmt`,
`TestGenerateEnumPayloadPrint`, heterogeneous enum tests, etc.) keep
passing because the 1-field case still lands on the same layout
(`{i64, T}`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/llvmgen/ -run 'TestGenerated|TestEnum|TestMatch|TestIfLet|TestForLet|TestMultiArmMatch|TestOptional|TestMaybe' -count=1` — passes
- [x] New `TestGenerateEnumMultiFieldPayload*` — passes
- [x] Full `go test ./internal/llvmgen/` — only pre-existing unrelated
  failures reconfirmed via `git stash` baseline
  (`TestRawNull*`, `TestRuntimeIntrinsicTyping*`,
  `TestGenerateModuleGenericEnumMaybe*`,
  `TestGenerateModuleBuiltinResultConstructorsTrackLocalContext`).
- [ ] `ERROR_CODES.md` regeneration remains a follow-up chore; no new
  codes were introduced, LLVM011 is reused.

https://claude.ai/code/session_01TCFcBGKAVYP4958ohCr9H4