### PR TITLE
feat(runtime): pthread-backed task spawn/join + real buffered channels

### DIFF
--- a/RUNTIME_SCHEDULER.md
+++ b/RUNTIME_SCHEDULER.md
@@ -1,6 +1,6 @@
 # RUNTIME_SCHEDULER.md — Osty 런타임 스케줄러 아키텍처 & 단계 로드맵
 
-> **Status (2026-04):** Phase 1A 진행 중. 이 문서는 `LANG_SPEC_v0.5/08-concurrency.md` §8.0과 `LANG_SPEC_v0.5/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" 절에 대응하는 **구현 레퍼런스**다. 스펙은 관찰 가능한 계약만 고정하고, 이 문서는 공개 LLVM 백엔드의 참조 런타임이 어떤 단계로 그 계약을 만족하는지 기술한다.
+> **Status (2026-04):** Phase 1B/2 하이브리드 진행 중. pthread 기반 task spawn/join + mutex/cond 기반 채널이 공개 런타임에 들어왔다. Select/parallel/race/collectAll은 여전히 abort 스텁. 이 문서는 `LANG_SPEC_v0.5/08-concurrency.md` §8.0과 `LANG_SPEC_v0.5/19-runtime-primitives.md` §19.1 "GC × scheduler interaction" 절에 대응하는 **구현 레퍼런스**다. 스펙은 관찰 가능한 계약만 고정하고, 이 문서는 공개 LLVM 백엔드의 참조 런타임이 어떤 단계로 그 계약을 만족하는지 기술한다.
 
 ## 배경
 
@@ -22,33 +22,36 @@
 
 ## 단계 로드맵
 
-### Phase 1A — Sequential ABI filler (현재)
+### Phase 1A — Sequential ABI filler (완료, 대체됨)
 
-**목표.** 백엔드가 lower하는 concurrency 심볼 집합을 **모두 제공**해서 LLVM 경로 프로그램이 링크/실행되게 하기. 실제 M:N은 없음 (worker 수 N=1, green task 수 M=1).
+Phase 1A는 `osty_rt_task_*` / `osty_rt_thread_*` 심볼 집합을 먼저 링크 가능한 형태로 노출하는 데 초점이 있었다. 모든 task body를 호출자 스레드에서 동기 실행하고, 채널/select/helper는 abort 스텁이었다. 현재 Phase 1B/2 pthread 경로에 의해 대체된다 — ABI는 불변이며, Phase 1A 수용 테스트는 Phase 1B 경로 위에서도 그대로 통과한다.
 
-**의미론.**
-- `osty_rt_task_group(body)`: `body(NULL)`을 호출하는 thread에서 즉시 실행. 완료되면 결과 반환.
-- `osty_rt_task_spawn(body)` / `osty_rt_task_group_spawn(group, body)`: 호출 시점에 `body`를 즉시 실행, 결과를 Handle에 저장. `spawn`은 호출자를 블로킹한다 (진짜 병렬 없음).
-- `osty_rt_task_handle_join(h)`: 이미 저장된 결과 반환. 블로킹 없음.
-- `osty_rt_task_group_cancel(g)`: 그룹 플래그 set. 이후 자식 호출에서 `is_cancelled()`가 true.
-- `osty_rt_cancel_is_cancelled()` / `..._group_is_cancelled(g)`: 플래그 read.
-- `osty_rt_thread_yield()`: no-op.
-- `osty_rt_thread_sleep(ns)`: calling thread blocking sleep.
+### Phase 1B / Phase 2 — pthread-backed (현재)
+
+**목표.** 실제 OS 스레드 기반 병렬 실행. 채널 block/wake 의미론 정확. 관찰 가능한 M:N 병렬성 제공.
+
+**구현.**
+- `osty_rt_task_spawn` / `osty_rt_task_group_spawn`: `pthread_create`로 새 OS 스레드에서 body 실행. 스레드 진입 시 `osty_concurrent_workers` 증가, 종료 시 감소.
+- `osty_rt_task_handle_join`: `pthread_join`으로 스레드 완료 대기. handle의 result는 acquire-load로 읽음.
+- `osty_rt_task_group(body)`: 호출 스레드에서 body 실행하고 TLS에 group을 바인딩. 자식 스레드는 `h->group`을 통해 트램펄린에서 TLS를 상속받음.
+- Cancellation: `cancelled` flag는 atomic (release store / acquire load). group flag set은 subsequent `is_cancelled` 호출에서 관찰 가능.
+- 채널: ring buffer + `pthread_mutex_t mu` + `pthread_cond_t not_full` + `pthread_cond_t not_empty`. Capacity 0은 1로 clamp (진짜 rendezvous는 Phase 1B fiber 영역, 미구현 표기).
+- `osty_rt_thread_yield`: `sched_yield()` 호출.
+- `osty_rt_thread_sleep(ns)`: 기존 `nanosleep` 경로 유지.
+- GC 상호작용: 모든 `osty_gc_allocate_managed` 호출은 recursive mutex `osty_gc_lock`으로 직렬화. 자동 collection은 `osty_concurrent_workers > 0`인 동안 **보류**된다 (현재 스레드만의 stack root로는 sibling 스레드의 root를 커버할 수 없음). 모든 worker가 join된 뒤 재개. Concurrent collection은 Phase 3.
 
 **제약.**
-- **채널/select은 Phase 1A에서 트랩**: `osty_rt_thread_chan_*`, `osty_rt_select_*`는 abort-with-message stub. 채널 의존 프로그램은 런타임 에러. 이유: 채널은 블록/wake 필요 → 진짜 fiber 또는 다수 OS 스레드 필요 → Phase 1B의 핵심.
-- **`collectAll` / `race`**: stub (abort). Phase 1A 스코프 밖.
-- 병렬 실행 없음 → spec §8.0이 허용 ("병렬은 보장되지 않는다").
-- GC 상호작용: 자명. 모든 task가 호출자 스택에서 동기적으로 실행되므로 parked-root 문제 없음. `safepoint_v1`이 평소대로 동작.
+- `osty_rt_select*`, `osty_rt_task_race`, `osty_rt_task_collect_all`, `osty_rt_parallel`: 여전히 abort 스텁. 이들의 등록/실행 surface는 Osty-side builder allocation이 필요하고, MIR 경로가 아직 해당 surface를 포함하지 않음. 도달 시 `osty_sched_unimplemented("...")` 진단 후 abort.
+- GC는 worker-live 동안 일시 보류 → long-running concurrent workload에서 OOM 가능. Phase 3 concurrent collector가 해소.
+- Thread-per-task 모델 — 큰 task 수에서 TLS/stack 오버헤드. Chase-Lev deque + work-stealing 기반 worker pool은 Phase 2+ 후속 작업.
+- task_group이 body 리턴 전에 unjoined 자식을 자동으로 reap하지 않음. 호출자가 explicit `join`해야 스레드 누수 없음. 자동 reap는 후속 작업 (TODO in runtime).
 
-**수용 테스트.**
-- `taskGroup(|g| { let h = g.spawn(|| 42); h.join() })` → 42 반환.
-- `taskGroup`이 자식 `Err(e)` 전파 (§8.2).
-- `taskGroup` 탈출 시 `Handle` 사용은 E0743 (컴파일 타임, 런타임 미관련).
-- `thread.sleep(10.ms)` 지연 관찰.
-- 런타임 심볼 빠짐 없음 (링크 에러 0).
+**수용 테스트.** `internal/backend/llvm_runtime_sched_test.go`:
+- `TestBundledRuntimeScheduler`: taskGroup + spawn/join + cancel 전파 + 4-way parallel spawn wall-clock 검증.
+- `TestBundledRuntimeSchedulerChannels`: 프로듀서/컨슈머 cross-thread, close-then-drain, `is_closed`.
+- `TestBundledRuntimeSchedulerSelectStubAborts`: select/helper가 여전히 loud-fail 함을 고정.
 
-### Phase 1B — Single-worker cooperative fibers
+### Phase 1B — Single-worker cooperative fibers (대안 경로, 미채택)
 
 **목표.** 채널과 select가 동작. 한 OS 스레드 안에서 `ucontext`(POSIX) 기반 cooperative green fiber 다수. 관찰 가능한 M:N 병렬성은 여전히 없지만 **블록/wake 의미론은 정확**.
 
@@ -166,8 +169,8 @@ void *osty_rt_task_collect_all(void *body);
 | §8.4 cancel with cause | ✓ | ✓ | ✓ | ✓ |
 | §8 channels blocking | **abort stub** | ✓ | ✓ | ✓ |
 | §8 `thread.select` | **abort stub** | ✓ | ✓ | ✓ |
-| §19.1 STW GC | ✓ | ✓ + parked-root union | ✓ worker sync | concurrent |
-| §19.10 safepoint contract | unchanged | extended (park-as-safepoint) | extended (stop_requested flag) | extended (preempt_check) |
+| §19.1 STW GC | ✓ | ✓ + parked-root union | **paused while workers live** | concurrent |
+| §19.10 safepoint contract | unchanged | extended (park-as-safepoint) | gated on `osty_concurrent_workers` | extended (preempt_check) |
 
 ## 파일 인벤토리
 
@@ -186,3 +189,4 @@ void *osty_rt_task_collect_all(void *body);
 ## 변경 이력
 
 - 2026-04-19: 문서 신설, Phase 1A 착수.
+- 2026-04-20: pthread 기반 spawn/join + mutex/cond 채널 런타임 착수. task_group/spawn/handle_join/cancel이 실제 병렬로 동작. select/parallel/race/collectAll은 여전히 abort 스텁 (builder surface 후속). `osty_gc_lock` 도입, 자동 collection은 `osty_concurrent_workers > 0`인 동안 보류.

--- a/RUNTIME_SCHEDULER.md
+++ b/RUNTIME_SCHEDULER.md
@@ -31,25 +31,29 @@ Phase 1A는 `osty_rt_task_*` / `osty_rt_thread_*` 심볼 집합을 먼저 링크
 **목표.** 실제 OS 스레드 기반 병렬 실행. 채널 block/wake 의미론 정확. 관찰 가능한 M:N 병렬성 제공.
 
 **구현.**
-- `osty_rt_task_spawn` / `osty_rt_task_group_spawn`: `pthread_create`로 새 OS 스레드에서 body 실행. 스레드 진입 시 `osty_concurrent_workers` 증가, 종료 시 감소.
+- `osty_rt_task_spawn` / `osty_rt_task_group_spawn`: `pthread_create`로 새 OS 스레드에서 body 실행. 스레드 진입 시 `osty_concurrent_workers` 증가. `pthread_cleanup_push`로 등록된 cleanup handler가 정상/비정상 종료 공히 카운터 감소와 `done` flag release store를 보장 (pthread_cancel / pthread_exit / body abort 경로에서도 누수 없음).
 - `osty_rt_task_handle_join`: `pthread_join`으로 스레드 완료 대기. handle의 result는 acquire-load로 읽음.
-- `osty_rt_task_group(body)`: 호출 스레드에서 body 실행하고 TLS에 group을 바인딩. 자식 스레드는 `h->group`을 통해 트램펄린에서 TLS를 상속받음.
+- `osty_rt_task_group(body)`: 호출 스레드에서 body 실행하고 TLS에 group을 바인딩. 자식 스레드는 `h->group`을 통해 트램펄린에서 TLS를 상속받음. body 리턴 시점에 `osty_rt_task_group_reap`가 group의 child 리스트를 훑고 unjoined 스레드를 pthread_join으로 회수 (spec §8.1 structured lifetime).
 - Cancellation: `cancelled` flag는 atomic (release store / acquire load). group flag set은 subsequent `is_cancelled` 호출에서 관찰 가능.
 - 채널: ring buffer + `pthread_mutex_t mu` + `pthread_cond_t not_full` + `pthread_cond_t not_empty`. Capacity 0은 1로 clamp (진짜 rendezvous는 Phase 1B fiber 영역, 미구현 표기).
+- `osty_rt_select` (recv / timeout / default 지원): 내부 builder 할당 → body에 `(env, s)` 로 호출 → body가 arm 등록 → polling 루프에서 recv 시도, default는 즉시 발화, timeout은 deadline 도달 시 발화. 500μs backoff로 busy-spin 회피.
+- `osty_rt_select_send`: 아직 MIR이 value-register surface를 emit하지 않아 보류 (`osty_sched_unimplemented`). 4-arg 시그니처로 전환될 때 완성.
 - `osty_rt_thread_yield`: `sched_yield()` 호출.
 - `osty_rt_thread_sleep(ns)`: 기존 `nanosleep` 경로 유지.
-- GC 상호작용: 모든 `osty_gc_allocate_managed` 호출은 recursive mutex `osty_gc_lock`으로 직렬화. 자동 collection은 `osty_concurrent_workers > 0`인 동안 **보류**된다 (현재 스레드만의 stack root로는 sibling 스레드의 root를 커버할 수 없음). 모든 worker가 join된 뒤 재개. Concurrent collection은 Phase 3.
+- GC 상호작용: 모든 `osty_gc_allocate_managed` 호출과 write barrier (`pre_write_v1`, `post_write_v1`, `load_v1`, `root_bind_v1`, `root_release_v1`)는 recursive mutex `osty_gc_lock`으로 직렬화. 자동 collection은 `osty_concurrent_workers > 0`인 동안 **보류**된다 (현재 스레드만의 stack root로는 sibling 스레드의 root를 커버할 수 없음). 모든 worker가 join된 뒤 재개. Concurrent collection은 Phase 3.
 
 **제약.**
-- `osty_rt_select*`, `osty_rt_task_race`, `osty_rt_task_collect_all`, `osty_rt_parallel`: 여전히 abort 스텁. 이들의 등록/실행 surface는 Osty-side builder allocation이 필요하고, MIR 경로가 아직 해당 surface를 포함하지 않음. 도달 시 `osty_sched_unimplemented("...")` 진단 후 abort.
+- `osty_rt_select_send`, `osty_rt_task_race`, `osty_rt_task_collect_all`, `osty_rt_parallel`: 여전히 abort 스텁. 이들의 등록/실행 surface는 MIR이 아직 emit하지 않는 register allocation (send의 경우 값 슬롯, parallel의 경우 list element size / trace fn) 을 필요로 함. 도달 시 `osty_sched_unimplemented("...")` 진단 후 abort.
 - GC는 worker-live 동안 일시 보류 → long-running concurrent workload에서 OOM 가능. Phase 3 concurrent collector가 해소.
 - Thread-per-task 모델 — 큰 task 수에서 TLS/stack 오버헤드. Chase-Lev deque + work-stealing 기반 worker pool은 Phase 2+ 후속 작업.
-- task_group이 body 리턴 전에 unjoined 자식을 자동으로 reap하지 않음. 호출자가 explicit `join`해야 스레드 누수 없음. 자동 reap는 후속 작업 (TODO in runtime).
 
 **수용 테스트.** `internal/backend/llvm_runtime_sched_test.go`:
 - `TestBundledRuntimeScheduler`: taskGroup + spawn/join + cancel 전파 + 4-way parallel spawn wall-clock 검증.
 - `TestBundledRuntimeSchedulerChannels`: 프로듀서/컨슈머 cross-thread, close-then-drain, `is_closed`.
-- `TestBundledRuntimeSchedulerSelectStubAborts`: select/helper가 여전히 loud-fail 함을 고정.
+- `TestBundledRuntimeSchedulerTaskGroupAutoReap`: body가 forgetful하게 자식을 남겨두고 리턴해도 group teardown이 pthread_join으로 회수함을 확인.
+- `TestBundledRuntimeSchedulerChannelStress`: 4 producer × 4 consumer × 250 items/producer = 1000 items 전송을 capacity-16 채널 위에서 돌려 produced/consumed 합 일치.
+- `TestBundledRuntimeSchedulerSelect`: recv-ready, timeout-only, default-present 3가지 시나리오에서 올바른 arm이 선택되는지 확인.
+- `TestBundledRuntimeSchedulerSelectSendStubAborts`: 미구현된 send arm이 loud-fail 함을 고정.
 
 ### Phase 1B — Single-worker cooperative fibers (대안 경로, 미채택)
 
@@ -189,4 +193,5 @@ void *osty_rt_task_collect_all(void *body);
 ## 변경 이력
 
 - 2026-04-19: 문서 신설, Phase 1A 착수.
-- 2026-04-20: pthread 기반 spawn/join + mutex/cond 채널 런타임 착수. task_group/spawn/handle_join/cancel이 실제 병렬로 동작. select/parallel/race/collectAll은 여전히 abort 스텁 (builder surface 후속). `osty_gc_lock` 도입, 자동 collection은 `osty_concurrent_workers > 0`인 동안 보류.
+- 2026-04-20: pthread 기반 spawn/join + mutex/cond 채널 런타임 착수. task_group/spawn/handle_join/cancel이 실제 병렬로 동작. `osty_gc_lock` 도입, 자동 collection은 `osty_concurrent_workers > 0`인 동안 보류.
+- 2026-04-20 (follow-up): write barrier / root bind/release 전부 `osty_gc_lock`으로 감쌈; pthread cleanup handler로 worker counter 누수 불가능; `task_group`에 auto-reap 도입; `thread.select`의 recv/timeout/default arm 구현. send arm만 보류.

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -172,7 +172,10 @@ func clangCompileCObjectArgs(target, sourcePath, objectPath string) []string {
 	if target != "" {
 		args = append(args, "-target", target)
 	}
-	args = append(args, "-std=c11", "-c", sourcePath, "-o", objectPath)
+	// `-pthread` enables _REENTRANT for the threading and channel
+	// implementations bundled in `runtime/osty_runtime.c`. The matching
+	// link flag is injected in `llvmClangLinkBinaryArgs`.
+	args = append(args, "-std=c11", "-pthread", "-c", sourcePath, "-o", objectPath)
 	return args
 }
 

--- a/internal/backend/llvm_runtime_sched_test.go
+++ b/internal/backend/llvm_runtime_sched_test.go
@@ -7,17 +7,17 @@ import (
 	"testing"
 )
 
-// Phase 1A sequential scheduler smoke test. Exercises the public
-// `osty_rt_task_*` and `osty_rt_thread_*` surface the MIR backend
-// lowers to. The channel/select symbols are not exercised here —
-// Phase 1A implements them as abort stubs (see RUNTIME_SCHEDULER.md).
+// Scheduler smoke test. Exercises the public `osty_rt_task_*` and
+// `osty_rt_thread_*` surface the MIR backend lowers to, plus the
+// real channel implementation added in Phase 1B/2 (see
+// RUNTIME_SCHEDULER.md).
 //
 // The harness mimics what an Osty program would do after lowering:
 // allocate a closure env where env[0] is the fn pointer, then hand
 // the env to the scheduler runtime. Test body functions match the
 // uniform closure ABI (`int64_t body(void *env [, void *group])`)
 // described in §ABI contract of RUNTIME_SCHEDULER.md.
-func TestBundledRuntimeSchedulerPhase1A(t *testing.T) {
+func TestBundledRuntimeScheduler(t *testing.T) {
 	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
@@ -62,6 +62,14 @@ static int64_t body_return_capture(void *env) {
     return e->capture;
 }
 
+/* spawn body: sleeps 2ms before returning, exposes real wall-clock
+ * parallelism when run across N spawns. */
+static int64_t body_sleep_then_capture(void *env) {
+    two_slot_env *e = (two_slot_env *)env;
+    osty_rt_thread_sleep(2000000LL); /* 2ms */
+    return e->capture;
+}
+
 /* spawn body: checks cancellation against current group. Returns 1
  * if cancelled, 0 otherwise. */
 static int64_t body_check_cancel(void *env) {
@@ -80,7 +88,7 @@ static int64_t body_taskgroup_two_spawns(void *env, void *group) {
     return a + b;
 }
 
-/* taskGroup body: cancels the group and then spawns a child whose
+/* taskGroup body: cancels the group before spawning a child whose
  * job is to report cancel_is_cancelled() against the rebound group.
  * Returns a 3-bit result: bit0 = outer thread-local check after
  * cancel, bit1 = group flag check, bit2 = child's cancel check. */
@@ -125,7 +133,7 @@ int main(void) {
     /* Test 4: outside any taskGroup, cancel_is_cancelled returns false. */
     printf("%d\n", osty_rt_cancel_is_cancelled() ? 1 : 0);
 
-    /* Test 5: thread.yield is a safe no-op. */
+    /* Test 5: thread.yield is a safe call. */
     osty_rt_thread_yield();
     printf("ok\n");
 
@@ -140,12 +148,36 @@ int main(void) {
                            (long long)(after.tv_nsec - before.tv_nsec);
     printf("%d\n", elapsed_ns >= 1000000LL ? 1 : 0);
 
+    /* Test 7: four 2ms-sleeping spawns joined. Wall-clock must be
+     * meaningfully less than 4×2ms=8ms if real parallelism exists. We
+     * accept up to 6ms as passing; tighter bounds are too flaky under
+     * CI load. Each spawn returns its capture; joined sum = 1+2+3+4=10. */
+    two_slot_env p_env_a = { (void *)body_sleep_then_capture, 1 };
+    two_slot_env p_env_b = { (void *)body_sleep_then_capture, 2 };
+    two_slot_env p_env_c = { (void *)body_sleep_then_capture, 3 };
+    two_slot_env p_env_d = { (void *)body_sleep_then_capture, 4 };
+    clock_gettime(CLOCK_MONOTONIC, &before);
+    void *pa = osty_rt_task_spawn((void *)&p_env_a);
+    void *pb = osty_rt_task_spawn((void *)&p_env_b);
+    void *pc = osty_rt_task_spawn((void *)&p_env_c);
+    void *pd = osty_rt_task_spawn((void *)&p_env_d);
+    int64_t total = osty_rt_task_handle_join(pa) +
+                    osty_rt_task_handle_join(pb) +
+                    osty_rt_task_handle_join(pc) +
+                    osty_rt_task_handle_join(pd);
+    clock_gettime(CLOCK_MONOTONIC, &after);
+    elapsed_ns = (long long)(after.tv_sec - before.tv_sec) * 1000000000LL +
+                 (long long)(after.tv_nsec - before.tv_nsec);
+    printf("%lld\n", (long long)total);
+    /* Report 1 iff wall-clock shows real parallelism (not strict 4x). */
+    printf("%d\n", elapsed_ns < 6000000LL ? 1 : 0);
+
     return 0;
 }
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	buildOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
@@ -159,52 +191,142 @@ int main(void) {
 	//   99        (detached spawn join)
 	//   7         (outer=1, flag=1, inner=1 → 0b111)
 	//   0         (cancel_is_cancelled outside any group)
-	//   ok        (yield no-op didn't crash)
+	//   ok        (yield didn't crash)
 	//   1         (sleep elapsed ≥ 1ms)
-	const want = "42\n99\n7\n0\nok\n1\n"
+	//   10        (1+2+3+4 across four parallel spawns)
+	//   1         (wall-clock shows real parallelism, not strict 4×2ms)
+	const want = "42\n99\n7\n0\nok\n1\n10\n1\n"
 	if got := string(runOutput); got != want {
 		t.Fatalf("scheduler harness stdout = %q, want %q", got, want)
 	}
 }
 
-// TestBundledRuntimeSchedulerChannelStubAborts documents that Phase 1A
-// channel send/recv/make surfaces abort with a diagnostic rather than
-// link-failing or silently no-op'ing. A program that reaches these
-// calls in Phase 1A must fail loudly — Phase 1B replaces them.
-func TestBundledRuntimeSchedulerChannelStubAborts(t *testing.T) {
+// Channels: producer/consumer across two threads via a buffered
+// channel. Exercises send_i64 / recv_i64 / close / is_closed and
+// verifies recv-after-close-and-drain signals ok=0.
+func TestBundledRuntimeSchedulerChannels(t *testing.T) {
 	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
-	harnessPath := filepath.Join(dir, "runtime_chan_stub_harness.c")
-	binaryPath := filepath.Join(dir, "runtime_chan_stub_harness")
+	harnessPath := filepath.Join(dir, "runtime_chan_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_chan_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct osty_rt_chan_recv_result {
+    int64_t value;
+    int64_t ok;
+} osty_rt_chan_recv_result;
+
+void *osty_rt_thread_chan_make(int64_t capacity);
+void osty_rt_thread_chan_close(void *ch);
+bool osty_rt_thread_chan_is_closed(void *ch);
+void osty_rt_thread_chan_send_i64(void *ch, int64_t v);
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_i64(void *ch);
+
+void *osty_rt_task_spawn(void *body_env);
+int64_t osty_rt_task_handle_join(void *handle);
+
+typedef struct prod_env {
+    void *fn;
+    void *ch;
+    int64_t count;
+} prod_env;
+
+/* Producer: send 0..count-1, then close. */
+static int64_t body_produce(void *env) {
+    prod_env *e = (prod_env *)env;
+    for (int64_t i = 0; i < e->count; i++) {
+        osty_rt_thread_chan_send_i64(e->ch, i);
+    }
+    osty_rt_thread_chan_close(e->ch);
+    return e->count;
+}
+
+int main(void) {
+    /* Buffered capacity 4, producer sends 10 items → forces block/wake. */
+    void *ch = osty_rt_thread_chan_make(4);
+    prod_env penv = { (void *)body_produce, ch, 10 };
+    void *h = osty_rt_task_spawn((void *)&penv);
+
+    int64_t sum = 0;
+    for (;;) {
+        osty_rt_chan_recv_result r = osty_rt_thread_chan_recv_i64(ch);
+        if (!r.ok) {
+            break;
+        }
+        sum += r.value;
+    }
+    int64_t produced = osty_rt_task_handle_join(h);
+    printf("%lld\n", (long long)sum);        /* 0+1+...+9 = 45 */
+    printf("%lld\n", (long long)produced);   /* 10 */
+    printf("%d\n", osty_rt_thread_chan_is_closed(ch) ? 1 : 0); /* 1 */
+
+    /* Recv-after-drain still reports ok=0 (not a block). */
+    osty_rt_chan_recv_result empty = osty_rt_thread_chan_recv_i64(ch);
+    printf("%lld\n", (long long)empty.ok);    /* 0 */
+
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	const want = "45\n10\n1\n0\n"
+	if got := string(runOutput); got != want {
+		t.Fatalf("channel harness stdout = %q, want %q", got, want)
+	}
+}
+
+// Select + parallel + race + collectAll are still deliberate aborts —
+// their registration surfaces need Osty-side builder work (see
+// RUNTIME_SCHEDULER.md roadmap). This test locks the "fail fast"
+// behaviour so programs reaching these surfaces don't silently
+// misbehave.
+func TestBundledRuntimeSchedulerSelectStubAborts(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_select_stub_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_select_stub_harness")
 	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
 	}
 	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
 #include <stdio.h>
 
-void *osty_rt_thread_chan_make(int64_t capacity);
+void osty_rt_select(void *s);
 
 int main(void) {
-    (void)osty_rt_thread_chan_make(4);
+    osty_rt_select(NULL);
     printf("should not reach\n");
     return 0;
 }
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
 	}
-	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
 	if buildOutput, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
 	}
-	// The stub calls abort(); the process should exit non-zero and not
-	// print "should not reach".
 	runOutput, err := exec.Command(binaryPath).CombinedOutput()
 	if err == nil {
-		t.Fatalf("expected non-zero exit from chan stub, got success: %q", runOutput)
+		t.Fatalf("expected non-zero exit from select stub, got success: %q", runOutput)
 	}
 	if got := string(runOutput); got == "should not reach\n" {
-		t.Fatalf("channel stub silently succeeded; Phase 1A requires loud failure")
+		t.Fatalf("select stub silently succeeded; not-yet-implemented path must fail loudly")
 	}
 }

--- a/internal/backend/llvm_runtime_sched_test.go
+++ b/internal/backend/llvm_runtime_sched_test.go
@@ -62,11 +62,11 @@ static int64_t body_return_capture(void *env) {
     return e->capture;
 }
 
-/* spawn body: sleeps 2ms before returning, exposes real wall-clock
+/* spawn body: sleeps 50ms before returning, exposes real wall-clock
  * parallelism when run across N spawns. */
 static int64_t body_sleep_then_capture(void *env) {
     two_slot_env *e = (two_slot_env *)env;
-    osty_rt_thread_sleep(2000000LL); /* 2ms */
+    osty_rt_thread_sleep(50000000LL); /* 50ms */
     return e->capture;
 }
 
@@ -148,10 +148,11 @@ int main(void) {
                            (long long)(after.tv_nsec - before.tv_nsec);
     printf("%d\n", elapsed_ns >= 1000000LL ? 1 : 0);
 
-    /* Test 7: four 2ms-sleeping spawns joined. Wall-clock must be
-     * meaningfully less than 4×2ms=8ms if real parallelism exists. We
-     * accept up to 6ms as passing; tighter bounds are too flaky under
-     * CI load. Each spawn returns its capture; joined sum = 1+2+3+4=10. */
+    /* Test 7: four sleeping spawns joined. Each sleeps 50ms; strict
+     * serialization would take ≥200ms. We accept anything under 150ms
+     * as "parallelism observed" — that leaves ample slack for a
+     * loaded CI runner while still rejecting the sequential Phase 1A
+     * fallback. Joined sum = 1+2+3+4 = 10. */
     two_slot_env p_env_a = { (void *)body_sleep_then_capture, 1 };
     two_slot_env p_env_b = { (void *)body_sleep_then_capture, 2 };
     two_slot_env p_env_c = { (void *)body_sleep_then_capture, 3 };
@@ -169,8 +170,9 @@ int main(void) {
     elapsed_ns = (long long)(after.tv_sec - before.tv_sec) * 1000000000LL +
                  (long long)(after.tv_nsec - before.tv_nsec);
     printf("%lld\n", (long long)total);
-    /* Report 1 iff wall-clock shows real parallelism (not strict 4x). */
-    printf("%d\n", elapsed_ns < 6000000LL ? 1 : 0);
+    /* Report 1 iff wall-clock shows real parallelism (< 150ms vs the
+     * 200ms sequential floor). */
+    printf("%d\n", elapsed_ns < 150000000LL ? 1 : 0);
 
     return 0;
 }
@@ -290,28 +292,347 @@ int main(void) {
 	}
 }
 
-// Select + parallel + race + collectAll are still deliberate aborts —
-// their registration surfaces need Osty-side builder work (see
-// RUNTIME_SCHEDULER.md roadmap). This test locks the "fail fast"
-// behaviour so programs reaching these surfaces don't silently
-// misbehave.
-func TestBundledRuntimeSchedulerSelectStubAborts(t *testing.T) {
+// Auto-reap: task_group body spawns a child that outlives the manual
+// join sites. The group teardown must pthread_join that stray handle
+// so no thread survives its group scope (spec §8.1).
+func TestBundledRuntimeSchedulerTaskGroupAutoReap(t *testing.T) {
 	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
 	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
-	harnessPath := filepath.Join(dir, "runtime_select_stub_harness.c")
-	binaryPath := filepath.Join(dir, "runtime_select_stub_harness")
+	harnessPath := filepath.Join(dir, "runtime_autoreap_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_autoreap_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int64_t osty_rt_task_group(void *body_env);
+void *osty_rt_task_group_spawn(void *group, void *body_env);
+int64_t osty_rt_task_handle_join(void *handle);
+void osty_rt_thread_sleep(int64_t nanos);
+
+static volatile int64_t flag = 0;
+
+typedef struct env1 {
+    void *fn;
+    int64_t sleep_ns;
+} env1;
+
+typedef struct env2 {
+    void *fn;
+    void *child_env;
+} env2;
+
+/* Child that sleeps, then sets a shared flag before exiting. If the
+ * group teardown reaps it correctly, the main thread reads flag=1
+ * after task_group returns. If the group returns while the child is
+ * still running (no auto-reap), the flag read would race and most
+ * likely print 0. */
+static int64_t body_child(void *env) {
+    env1 *e = (env1 *)env;
+    osty_rt_thread_sleep(e->sleep_ns);
+    __atomic_store_n(&flag, 1, __ATOMIC_RELEASE);
+    return 42;
+}
+
+/* taskGroup body: spawns a child but never joins it. The group teardown
+ * is responsible for waiting on it. */
+static int64_t body_parent(void *env, void *group) {
+    env2 *e = (env2 *)env;
+    (void)osty_rt_task_group_spawn(group, e->child_env);
+    return 0;
+}
+
+int main(void) {
+    env1 c_env = { (void *)body_child, 30000000LL }; /* 30ms */
+    env2 p_env = { (void *)body_parent, (void *)&c_env };
+    (void)osty_rt_task_group((void *)&p_env);
+
+    /* Group returned. If auto-reap worked, the child has set flag. */
+    printf("%lld\n", (long long)__atomic_load_n(&flag, __ATOMIC_ACQUIRE));
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got := string(runOutput); got != "1\n" {
+		t.Fatalf("auto-reap harness stdout = %q, want %q", got, "1\n")
+	}
+}
+
+// Channel stress: 4 producers × 4 consumers × 1000 items total. Verifies
+// the mutex+cond discipline holds under heavy contention.
+func TestBundledRuntimeSchedulerChannelStress(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_chan_stress_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_chan_stress_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct osty_rt_chan_recv_result {
+    int64_t value;
+    int64_t ok;
+} osty_rt_chan_recv_result;
+
+void *osty_rt_thread_chan_make(int64_t capacity);
+void osty_rt_thread_chan_close(void *ch);
+void osty_rt_thread_chan_send_i64(void *ch, int64_t v);
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_i64(void *ch);
+void *osty_rt_task_spawn(void *body_env);
+int64_t osty_rt_task_handle_join(void *handle);
+
+#define N_PRODUCERS 4
+#define N_CONSUMERS 4
+#define N_PER_PRODUCER 250
+
+typedef struct prod_env {
+    void *fn;
+    void *ch;
+    int64_t base;
+} prod_env;
+
+typedef struct cons_env {
+    void *fn;
+    void *ch;
+} cons_env;
+
+static int64_t body_produce(void *env) {
+    prod_env *e = (prod_env *)env;
+    int64_t acc = 0;
+    for (int64_t i = 0; i < N_PER_PRODUCER; i++) {
+        int64_t v = e->base + i;
+        osty_rt_thread_chan_send_i64(e->ch, v);
+        acc += v;
+    }
+    return acc;
+}
+
+static int64_t body_consume(void *env) {
+    cons_env *e = (cons_env *)env;
+    int64_t acc = 0;
+    for (;;) {
+        osty_rt_chan_recv_result r = osty_rt_thread_chan_recv_i64(e->ch);
+        if (!r.ok) break;
+        acc += r.value;
+    }
+    return acc;
+}
+
+int main(void) {
+    void *ch = osty_rt_thread_chan_make(16);
+
+    prod_env penvs[N_PRODUCERS];
+    void *phs[N_PRODUCERS];
+    for (int i = 0; i < N_PRODUCERS; i++) {
+        penvs[i].fn = (void *)body_produce;
+        penvs[i].ch = ch;
+        penvs[i].base = (int64_t)i * 1000;
+        phs[i] = osty_rt_task_spawn((void *)&penvs[i]);
+    }
+
+    cons_env cenvs[N_CONSUMERS];
+    void *chs[N_CONSUMERS];
+    for (int i = 0; i < N_CONSUMERS; i++) {
+        cenvs[i].fn = (void *)body_consume;
+        cenvs[i].ch = ch;
+        chs[i] = osty_rt_task_spawn((void *)&cenvs[i]);
+    }
+
+    int64_t produced_sum = 0;
+    for (int i = 0; i < N_PRODUCERS; i++) {
+        produced_sum += osty_rt_task_handle_join(phs[i]);
+    }
+    osty_rt_thread_chan_close(ch);
+
+    int64_t consumed_sum = 0;
+    for (int i = 0; i < N_CONSUMERS; i++) {
+        consumed_sum += osty_rt_task_handle_join(chs[i]);
+    }
+
+    printf("%lld\n", (long long)produced_sum);
+    printf("%lld\n", (long long)consumed_sum);
+    printf("%d\n", produced_sum == consumed_sum ? 1 : 0);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	// Expected sums:
+	//   produced = Σ_{p=0..3} Σ_{i=0..249} (1000p + i)
+	//            = 250 × (0+1000+2000+3000) + 4 × (0+1+...+249)
+	//            = 250 × 6000 + 4 × 31125
+	//            = 1500000 + 124500 = 1624500
+	//   consumed must equal produced, so the last line is 1.
+	const want = "1624500\n1624500\n1\n"
+	if got := string(runOutput); got != want {
+		t.Fatalf("channel stress stdout = %q, want %q", got, want)
+	}
+}
+
+// Select: exercises recv / timeout / default arms. Three sub-scenarios
+// packed into one binary so the whole flow lives in a single harness.
+func TestBundledRuntimeSchedulerSelect(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_select_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_select_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+void *osty_rt_thread_chan_make(int64_t capacity);
+void osty_rt_thread_chan_send_i64(void *ch, int64_t v);
+
+void osty_rt_select(void *body_env);
+void osty_rt_select_recv(void *s, void *ch, void *arm);
+void osty_rt_select_timeout(void *s, int64_t ns, void *arm);
+void osty_rt_select_default(void *s, void *arm);
+
+static int64_t outcome = -1;
+
+/* Arm closures write the outcome into a module-global; the Osty
+ * frontend will instead use captured slot references, but the shape
+ * (closure env slot-0 holds the fn pointer; fn takes the env) is the
+ * same. */
+
+typedef struct recv_arm_env { void *fn; int64_t tag; } recv_arm_env;
+typedef struct plain_arm_env { void *fn; int64_t tag; } plain_arm_env;
+
+static void recv_arm_fn(void *env, int64_t value) {
+    recv_arm_env *e = (recv_arm_env *)env;
+    outcome = e->tag * 1000 + value;
+}
+
+static void plain_arm_fn(void *env) {
+    plain_arm_env *e = (plain_arm_env *)env;
+    outcome = e->tag;
+}
+
+typedef struct select_body_env {
+    void *fn;
+    void *ch;
+    int64_t timeout_ns;
+    int with_default;
+    void *recv_arm;
+    void *timeout_arm;
+    void *default_arm;
+} select_body_env;
+
+static void select_body(void *env, void *s) {
+    select_body_env *e = (select_body_env *)env;
+    osty_rt_select_recv(s, e->ch, e->recv_arm);
+    osty_rt_select_timeout(s, e->timeout_ns, e->timeout_arm);
+    if (e->with_default) {
+        osty_rt_select_default(s, e->default_arm);
+    }
+}
+
+int main(void) {
+    recv_arm_env ra = { (void *)recv_arm_fn, 7 };
+    plain_arm_env ta = { (void *)plain_arm_fn, 999 };
+    plain_arm_env da = { (void *)plain_arm_fn, -1 };
+
+    /* Scenario 1: channel has a value — recv arm wins. */
+    void *ch1 = osty_rt_thread_chan_make(4);
+    osty_rt_thread_chan_send_i64(ch1, 42);
+    select_body_env e1 = {
+        (void *)select_body, ch1, 1000000000LL, 0,
+        (void *)&ra, (void *)&ta, (void *)&da,
+    };
+    outcome = -1;
+    osty_rt_select((void *)&e1);
+    printf("%lld\n", (long long)outcome);  /* 7 * 1000 + 42 = 7042 */
+
+    /* Scenario 2: channel empty, no default — timeout arm fires. */
+    void *ch2 = osty_rt_thread_chan_make(4);
+    select_body_env e2 = {
+        (void *)select_body, ch2, 5000000LL /* 5ms */, 0,
+        (void *)&ra, (void *)&ta, (void *)&da,
+    };
+    outcome = -1;
+    osty_rt_select((void *)&e2);
+    printf("%lld\n", (long long)outcome);  /* 999 */
+
+    /* Scenario 3: channel empty, default present — default fires first. */
+    void *ch3 = osty_rt_thread_chan_make(4);
+    select_body_env e3 = {
+        (void *)select_body, ch3, 1000000000LL, 1,
+        (void *)&ra, (void *)&ta, (void *)&da,
+    };
+    outcome = -1;
+    osty_rt_select((void *)&e3);
+    printf("%lld\n", (long long)outcome);  /* -1 */
+
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	if buildOutput, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	const want = "7042\n999\n-1\n"
+	if got := string(runOutput); got != want {
+		t.Fatalf("select harness stdout = %q, want %q", got, want)
+	}
+}
+
+// Select.send is still a deliberate abort — its signature needs a
+// value-register the MIR path doesn't emit yet. Locks the "fail loud"
+// contract for now.
+func TestBundledRuntimeSchedulerSelectSendStubAborts(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_select_send_stub_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_select_send_stub_harness")
 	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
 	}
 	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
 #include <stdio.h>
 
-void osty_rt_select(void *s);
+void osty_rt_select_send(void *s, void *ch, void *arm);
 
 int main(void) {
-    osty_rt_select(NULL);
+    osty_rt_select_send(NULL, NULL, NULL);
     printf("should not reach\n");
     return 0;
 }
@@ -324,9 +645,9 @@ int main(void) {
 	}
 	runOutput, err := exec.Command(binaryPath).CombinedOutput()
 	if err == nil {
-		t.Fatalf("expected non-zero exit from select stub, got success: %q", runOutput)
+		t.Fatalf("expected non-zero exit from select.send stub, got success: %q", runOutput)
 	}
 	if got := string(runOutput); got == "should not reach\n" {
-		t.Fatalf("select stub silently succeeded; not-yet-implemented path must fail loudly")
+		t.Fatalf("select.send stub silently succeeded; not-yet-implemented path must fail loudly")
 	}
 }

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1757,12 +1757,15 @@ static void osty_gc_barrier_logs_clear(void) {
 void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) {
     osty_gc_header *owner_header;
 
-    osty_gc_pre_write_count += 1;
     (void)slot_kind;
+    osty_gc_acquire();
+    osty_gc_pre_write_count += 1;
     if (old_value == NULL) {
+        osty_gc_release();
         return;
     }
     if (osty_gc_find_header(old_value) == NULL) {
+        osty_gc_release();
         return;
     }
     osty_gc_pre_write_managed_count += 1;
@@ -1771,21 +1774,26 @@ void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) {
     if (owner_header != NULL && owner_header->root_count > 0) {
         osty_gc_collection_requested = true;
     }
+    osty_gc_release();
 }
 
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
     osty_gc_header *owner_header;
 
-    osty_gc_post_write_count += 1;
     (void)slot_kind;
+    osty_gc_acquire();
+    osty_gc_post_write_count += 1;
     if (owner == NULL || value == NULL) {
+        osty_gc_release();
         return;
     }
     owner_header = osty_gc_find_header(owner);
     if (owner_header == NULL) {
+        osty_gc_release();
         return;
     }
     if (osty_gc_find_header(value) == NULL) {
+        osty_gc_release();
         return;
     }
     osty_gc_post_write_managed_count += 1;
@@ -1793,40 +1801,56 @@ void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) {
     if (owner_header->root_count > 0) {
         osty_gc_collection_requested = true;
     }
+    osty_gc_release();
 }
 
 void *osty_gc_load_v1(void *value) {
+    osty_gc_acquire();
     osty_gc_load_count += 1;
     if (osty_gc_find_header(value) != NULL) {
         osty_gc_load_managed_count += 1;
     }
+    osty_gc_release();
     return value;
 }
 
 void osty_gc_mark_slot_v1(void *slot_addr) {
+    /* Only reachable inside `osty_gc_collect_now_with_stack_roots`,
+     * which runs under `osty_gc_lock` (see safepoint / debug collect).
+     * No additional lock required. */
     osty_gc_mark_root_slot(slot_addr);
 }
 
 void osty_gc_root_bind_v1(void *root) {
-    osty_gc_header *header = osty_gc_find_header(root);
+    osty_gc_header *header;
+    osty_gc_acquire();
+    header = osty_gc_find_header(root);
     if (header == NULL) {
+        osty_gc_release();
         return;
     }
     if (header->root_count == INT64_MAX) {
+        osty_gc_release();
         osty_rt_abort("GC root count overflow");
     }
     header->root_count += 1;
+    osty_gc_release();
 }
 
 void osty_gc_root_release_v1(void *root) {
-    osty_gc_header *header = osty_gc_find_header(root);
+    osty_gc_header *header;
+    osty_gc_acquire();
+    header = osty_gc_find_header(root);
     if (header == NULL) {
+        osty_gc_release();
         return;
     }
     if (header->root_count <= 0) {
+        osty_gc_release();
         osty_rt_abort("GC root release underflow");
     }
     header->root_count -= 1;
+    osty_gc_release();
 }
 
 static void osty_gc_global_roots_grow(void) {
@@ -1998,12 +2022,21 @@ int osty_gc_debug_satb_log_contains(void *payload) {
 typedef int64_t (*osty_task_group_body_fn)(void *env, void *group);
 typedef int64_t (*osty_task_spawn_body_fn)(void *env);
 
+struct osty_rt_task_handle_impl_;
+
+typedef struct osty_rt_task_handle_node {
+    struct osty_rt_task_handle_impl_ *handle;
+    struct osty_rt_task_handle_node *next;
+} osty_rt_task_handle_node;
+
 typedef struct osty_rt_task_group_impl {
-    volatile int64_t cancelled; /* 0 = live, 1 = cancelled */
-    void *cause;                /* reserved for error propagation */
+    volatile int64_t cancelled;          /* 0 = live, 1 = cancelled */
+    void *cause;                         /* reserved for error propagation */
+    pthread_mutex_t children_mu;
+    osty_rt_task_handle_node *children;  /* all handles spawned into group */
 } osty_rt_task_group_impl;
 
-typedef struct osty_rt_task_handle_impl {
+typedef struct osty_rt_task_handle_impl_ {
     pthread_t thread;
     int has_thread;                      /* 1 while thread is joinable */
     void *body_env;
@@ -2036,17 +2069,64 @@ static void osty_sched_unimplemented(const char *what) {
     abort();
 }
 
+static void osty_rt_task_thread_cleanup(void *arg) {
+    /* Runs on pthread_cleanup_pop or any unwind out of the trampoline
+     * (pthread_cancel, pthread_exit). Guarantees the worker counter
+     * never leaks even when the body never returns normally. */
+    osty_rt_task_handle_impl *h = (osty_rt_task_handle_impl *)arg;
+    __atomic_store_n(&h->done, 1, __ATOMIC_RELEASE);
+    osty_sched_workers_dec();
+}
+
 static void *osty_rt_task_thread_trampoline(void *arg) {
     osty_rt_task_handle_impl *h = (osty_rt_task_handle_impl *)arg;
     if (h->group != NULL) {
         osty_sched_current_group = h->group;
     }
+    pthread_cleanup_push(osty_rt_task_thread_cleanup, h);
     osty_task_spawn_body_fn fn = (osty_task_spawn_body_fn)(*(void **)h->body_env);
-    int64_t result = fn(h->body_env);
-    h->result = result;
-    __atomic_store_n(&h->done, 1, __ATOMIC_RELEASE);
-    osty_sched_workers_dec();
+    h->result = fn(h->body_env);
+    pthread_cleanup_pop(1);
     return NULL;
+}
+
+static void osty_rt_task_group_attach(osty_rt_task_group_impl *g,
+                                      osty_rt_task_handle_impl *h) {
+    osty_rt_task_handle_node *node =
+        (osty_rt_task_handle_node *)calloc(1, sizeof(*node));
+    if (node == NULL) {
+        osty_rt_abort("task_group_spawn: out of memory");
+    }
+    node->handle = h;
+    pthread_mutex_lock(&g->children_mu);
+    node->next = g->children;
+    g->children = node;
+    pthread_mutex_unlock(&g->children_mu);
+}
+
+static void osty_rt_task_group_reap(osty_rt_task_group_impl *g) {
+    /* Called from task_group() after the body returns. Any child still
+     * marked joinable is pthread_joined so no thread outlives its
+     * group scope (spec §8.1). Handles themselves are not freed — the
+     * Osty caller may still read their result fields. Nodes ARE freed
+     * because the group stack-frame is about to disappear. */
+    pthread_mutex_lock(&g->children_mu);
+    osty_rt_task_handle_node *node = g->children;
+    g->children = NULL;
+    pthread_mutex_unlock(&g->children_mu);
+
+    while (node != NULL) {
+        osty_rt_task_handle_node *next = node->next;
+        osty_rt_task_handle_impl *h = node->handle;
+        if (h != NULL && h->has_thread) {
+            if (pthread_join(h->thread, NULL) != 0) {
+                osty_rt_abort("task_group: pthread_join failed during reap");
+            }
+            h->has_thread = 0;
+        }
+        free(node);
+        node = next;
+    }
 }
 
 int64_t osty_rt_task_group(void *body_env) {
@@ -2056,12 +2136,22 @@ int64_t osty_rt_task_group(void *body_env) {
     osty_rt_task_group_impl group;
     group.cancelled = 0;
     group.cause = NULL;
+    group.children = NULL;
+    if (pthread_mutex_init(&group.children_mu, NULL) != 0) {
+        osty_rt_abort("task_group: mutex_init failed");
+    }
 
     osty_rt_task_group_impl *prev = osty_sched_current_group;
     osty_sched_current_group = &group;
 
     osty_task_group_body_fn fn = (osty_task_group_body_fn)(*(void **)body_env);
     int64_t result = fn(body_env, (void *)&group);
+
+    /* Reap any children the body forgot to join (spec §8.1 structured
+     * lifetime). Runs before we restore the previous TLS group so that
+     * a nested taskGroup's teardown sees its own scope. */
+    osty_rt_task_group_reap(&group);
+    pthread_mutex_destroy(&group.children_mu);
 
     osty_sched_current_group = prev;
     return result;
@@ -2082,6 +2172,9 @@ static void *osty_rt_task_spawn_internal(void *group, void *body_env) {
         osty_rt_abort("task_spawn: pthread_create failed");
     }
     h->has_thread = 1;
+    if (h->group != NULL) {
+        osty_rt_task_group_attach(h->group, h);
+    }
     return h;
 }
 
@@ -2330,34 +2423,231 @@ osty_rt_chan_recv_result osty_rt_thread_chan_recv_bytes_v1(void *raw) {
     return osty_rt_chan_recv_raw(osty_rt_chan_cast(raw, "thread.chan.recv"));
 }
 
-/* ---- Select / helpers remain pending. Their registration surface
- *      needs Osty-side builder allocation that the MIR emitter has not
- *      wired up; aborting here is the closest-to-correct behaviour
- *      for programs that reach these entry points today. ---- */
+/* ---- Select: polling builder with recv / timeout / default arms.
+ *
+ * Surface contract (stable with Phase 1A abort stubs):
+ *   osty_rt_select(body_env)                 // 1-arg
+ *   osty_rt_select_recv(s, ch, arm)          // 3-arg
+ *   osty_rt_select_send(s, ch, arm)          // 3-arg — NOT YET WIRED
+ *   osty_rt_select_timeout(s, ns, arm)       // 3-arg
+ *   osty_rt_select_default(s, arm)           // 2-arg
+ *
+ * `body_env` is a closure env whose slot-0 is the body function. The
+ * body is invoked as `body(env, s)` where `s` is a stack-allocated
+ * builder this function owns. Arms the body registers are evaluated
+ * non-blockingly in their registration order; if none is ready we
+ * sleep 1ms and retry, firing the first timeout arm whose deadline
+ * elapses. A default arm fires immediately if present and no other
+ * arm is ready on the first pass.
+ *
+ * Arm closures are void-returning; the Osty frontend is expected to
+ * capture the result slot inside the closure (same pattern as
+ * taskGroup body's result propagation). Recv-arm closures receive
+ * the drained value as their second argument.
+ *
+ * Send arms require a value register alongside the channel — that
+ * shape is not yet emitted by MIR, so `osty_rt_select_send` aborts
+ * with a diagnostic if reached. A 4-arg surface (value register)
+ * will replace this when the emitter catches up.
+ */
 
-void osty_rt_select(void *s) {
-    (void)s;
-    osty_sched_unimplemented("thread.select");
+typedef enum {
+    OSTY_RT_SELECT_ARM_RECV = 0,
+    OSTY_RT_SELECT_ARM_TIMEOUT = 1,
+    OSTY_RT_SELECT_ARM_DEFAULT = 2,
+} osty_rt_select_arm_kind;
+
+typedef struct osty_rt_select_arm {
+    osty_rt_select_arm_kind kind;
+    void *ch;              /* recv: channel ptr; otherwise NULL */
+    int64_t timeout_ns;    /* timeout arm only */
+    void *arm_env;         /* closure env */
+} osty_rt_select_arm;
+
+#define OSTY_RT_SELECT_ARM_CAPACITY 32
+
+typedef struct osty_rt_select_impl {
+    pthread_mutex_t mu;
+    osty_rt_select_arm arms[OSTY_RT_SELECT_ARM_CAPACITY];
+    int count;
+} osty_rt_select_impl;
+
+typedef void (*osty_rt_select_body_fn)(void *env, void *s);
+typedef void (*osty_rt_select_recv_arm_fn)(void *env, int64_t value);
+typedef void (*osty_rt_select_plain_arm_fn)(void *env);
+
+static osty_rt_select_impl *osty_rt_select_cast(void *s, const char *op) {
+    if (s == NULL) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%s: null builder", op);
+        osty_rt_abort(buf);
+    }
+    return (osty_rt_select_impl *)s;
+}
+
+static void osty_rt_select_arm_push(osty_rt_select_impl *sel,
+                                    osty_rt_select_arm_kind kind,
+                                    void *ch, int64_t timeout_ns,
+                                    void *arm_env) {
+    pthread_mutex_lock(&sel->mu);
+    if (sel->count >= OSTY_RT_SELECT_ARM_CAPACITY) {
+        pthread_mutex_unlock(&sel->mu);
+        osty_rt_abort("thread.select: arm capacity exceeded");
+    }
+    sel->arms[sel->count].kind = kind;
+    sel->arms[sel->count].ch = ch;
+    sel->arms[sel->count].timeout_ns = timeout_ns;
+    sel->arms[sel->count].arm_env = arm_env;
+    sel->count += 1;
+    pthread_mutex_unlock(&sel->mu);
 }
 
 void osty_rt_select_recv(void *s, void *ch, void *arm) {
-    (void)s; (void)ch; (void)arm;
-    osty_sched_unimplemented("thread.select.recv");
+    osty_rt_select_impl *sel = osty_rt_select_cast(s, "thread.select.recv");
+    if (ch == NULL) {
+        osty_rt_abort("thread.select.recv: null channel");
+    }
+    osty_rt_select_arm_push(sel, OSTY_RT_SELECT_ARM_RECV, ch, 0, arm);
 }
 
 void osty_rt_select_send(void *s, void *ch, void *arm) {
     (void)s; (void)ch; (void)arm;
-    osty_sched_unimplemented("thread.select.send");
+    osty_sched_unimplemented(
+        "thread.select.send (awaiting value-register surface from MIR)");
 }
 
 void osty_rt_select_timeout(void *s, int64_t ns, void *arm) {
-    (void)s; (void)ns; (void)arm;
-    osty_sched_unimplemented("thread.select.timeout");
+    osty_rt_select_impl *sel = osty_rt_select_cast(s, "thread.select.timeout");
+    if (ns < 0) {
+        osty_rt_abort("thread.select.timeout: negative duration");
+    }
+    osty_rt_select_arm_push(sel, OSTY_RT_SELECT_ARM_TIMEOUT, NULL, ns, arm);
 }
 
 void osty_rt_select_default(void *s, void *arm) {
-    (void)s; (void)arm;
-    osty_sched_unimplemented("thread.select.default");
+    osty_rt_select_impl *sel = osty_rt_select_cast(s, "thread.select.default");
+    osty_rt_select_arm_push(sel, OSTY_RT_SELECT_ARM_DEFAULT, NULL, 0, arm);
+}
+
+static int osty_rt_select_try_recv(osty_rt_chan_impl *ch, int64_t *out) {
+    pthread_mutex_lock(&ch->mu);
+    if (ch->count > 0) {
+        *out = ch->slots[ch->head];
+        ch->head = (ch->head + 1) % ch->cap;
+        ch->count -= 1;
+        pthread_cond_signal(&ch->not_full);
+        pthread_mutex_unlock(&ch->mu);
+        return 1;
+    }
+    pthread_mutex_unlock(&ch->mu);
+    return 0;
+}
+
+static void osty_rt_select_invoke_recv(osty_rt_select_arm *arm, int64_t value) {
+    osty_rt_select_recv_arm_fn fn =
+        (osty_rt_select_recv_arm_fn)(*(void **)arm->arm_env);
+    fn(arm->arm_env, value);
+}
+
+static void osty_rt_select_invoke_plain(osty_rt_select_arm *arm) {
+    osty_rt_select_plain_arm_fn fn =
+        (osty_rt_select_plain_arm_fn)(*(void **)arm->arm_env);
+    fn(arm->arm_env);
+}
+
+void osty_rt_select(void *body_env) {
+    if (body_env == NULL) {
+        osty_rt_abort("thread.select: null body env");
+    }
+
+    osty_rt_select_impl sel;
+    sel.count = 0;
+    if (pthread_mutex_init(&sel.mu, NULL) != 0) {
+        osty_rt_abort("thread.select: mutex_init failed");
+    }
+
+    /* Invoke the body so it can register arms. Body signature matches
+     * the taskGroup convention: body(env, builder). */
+    osty_rt_select_body_fn fn =
+        (osty_rt_select_body_fn)(*(void **)body_env);
+    fn(body_env, (void *)&sel);
+
+    if (sel.count == 0) {
+        pthread_mutex_destroy(&sel.mu);
+        osty_rt_abort("thread.select: body registered no arms");
+    }
+
+    /* Classify arms. Shortest timeout wins; a default fires on the
+     * first unsuccessful poll. */
+    int default_idx = -1;
+    int timeout_idx = -1;
+    int64_t shortest_timeout_ns = INT64_MAX;
+    for (int i = 0; i < sel.count; i++) {
+        if (sel.arms[i].kind == OSTY_RT_SELECT_ARM_DEFAULT) {
+            default_idx = i;
+        } else if (sel.arms[i].kind == OSTY_RT_SELECT_ARM_TIMEOUT) {
+            if (sel.arms[i].timeout_ns < shortest_timeout_ns) {
+                shortest_timeout_ns = sel.arms[i].timeout_ns;
+                timeout_idx = i;
+            }
+        }
+    }
+
+    struct timespec deadline = {0, 0};
+    bool has_deadline = false;
+    if (timeout_idx >= 0) {
+        clock_gettime(CLOCK_MONOTONIC, &deadline);
+        int64_t ns = sel.arms[timeout_idx].timeout_ns;
+        deadline.tv_sec += (time_t)(ns / 1000000000LL);
+        deadline.tv_nsec += (long)(ns % 1000000000LL);
+        if (deadline.tv_nsec >= 1000000000L) {
+            deadline.tv_sec += 1;
+            deadline.tv_nsec -= 1000000000L;
+        }
+        has_deadline = true;
+    }
+
+    for (;;) {
+        /* Poll recv arms in registration order. */
+        for (int i = 0; i < sel.count; i++) {
+            if (sel.arms[i].kind != OSTY_RT_SELECT_ARM_RECV) {
+                continue;
+            }
+            osty_rt_chan_impl *ch = (osty_rt_chan_impl *)sel.arms[i].ch;
+            int64_t value = 0;
+            if (osty_rt_select_try_recv(ch, &value)) {
+                pthread_mutex_destroy(&sel.mu);
+                osty_rt_select_invoke_recv(&sel.arms[i], value);
+                return;
+            }
+        }
+
+        /* Default arm fires if no recv is ready on the first pass. */
+        if (default_idx >= 0) {
+            pthread_mutex_destroy(&sel.mu);
+            osty_rt_select_invoke_plain(&sel.arms[default_idx]);
+            return;
+        }
+
+        /* Timeout check. */
+        if (has_deadline) {
+            struct timespec now;
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            if (now.tv_sec > deadline.tv_sec ||
+                (now.tv_sec == deadline.tv_sec &&
+                 now.tv_nsec >= deadline.tv_nsec)) {
+                pthread_mutex_destroy(&sel.mu);
+                osty_rt_select_invoke_plain(&sel.arms[timeout_idx]);
+                return;
+            }
+        }
+
+        /* 500μs backoff to avoid busy-spinning. A real fiber scheduler
+         * would park on a multi-cond primitive; Phase 1B polling is
+         * the cost of sharing the OS thread pool. */
+        struct timespec nap = {0, 500000L};
+        nanosleep(&nap, NULL);
+    }
 }
 
 void *osty_rt_task_race(void *body) {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -2052,13 +2052,19 @@ static __thread osty_rt_task_group_impl *osty_sched_current_group = NULL;
 static _Thread_local osty_rt_task_group_impl *osty_sched_current_group = NULL;
 #endif
 
+/* Handles live in the GC heap so they are reclaimed once the Osty
+ * `Handle<T>` reference drops. While the spawned thread runs,
+ * `osty_concurrent_workers > 0` keeps collection paused, so the
+ * handle pointer the trampoline carries cannot be freed under it.
+ * Once the thread exits and Osty drops its reference, the next
+ * collection sweeps the handle. No explicit free on the error path
+ * either — the handle becomes unreachable and gets reaped. */
 static osty_rt_task_handle_impl *osty_sched_alloc_handle(void) {
-    osty_rt_task_handle_impl *h = (osty_rt_task_handle_impl *)calloc(
-        1, sizeof(osty_rt_task_handle_impl));
-    if (h == NULL) {
-        osty_rt_abort("scheduler: handle allocation failed");
-    }
-    return h;
+    return (osty_rt_task_handle_impl *)osty_gc_allocate_managed(
+        sizeof(osty_rt_task_handle_impl),
+        OSTY_GC_KIND_GENERIC,
+        "runtime.task.handle",
+        NULL, NULL);
 }
 
 static void osty_sched_unimplemented(const char *what) {
@@ -2168,7 +2174,7 @@ static void *osty_rt_task_spawn_internal(void *group, void *body_env) {
     if (pthread_create(&h->thread, NULL,
                        osty_rt_task_thread_trampoline, h) != 0) {
         osty_sched_workers_dec();
-        free(h);
+        /* h is GC-managed — letting it go unreachable is enough. */
         osty_rt_abort("task_spawn: pthread_create failed");
     }
     h->has_thread = 1;
@@ -2281,6 +2287,21 @@ static osty_rt_chan_impl *osty_rt_chan_cast(void *ch, const char *op) {
     return (osty_rt_chan_impl *)ch;
 }
 
+static void osty_rt_chan_destroy(void *payload) {
+    /* Invoked by the GC sweep when no Osty reference remains. Closing
+     * is idempotent but we don't require the channel to be closed
+     * first — unreachable implies no live sender or receiver. */
+    osty_rt_chan_impl *ch = (osty_rt_chan_impl *)payload;
+    if (ch == NULL) {
+        return;
+    }
+    pthread_mutex_destroy(&ch->mu);
+    pthread_cond_destroy(&ch->not_full);
+    pthread_cond_destroy(&ch->not_empty);
+    free(ch->slots);
+    ch->slots = NULL;
+}
+
 void *osty_rt_thread_chan_make(int64_t capacity) {
     if (capacity < 0) {
         osty_rt_abort("thread.chan.make: negative capacity");
@@ -2290,13 +2311,15 @@ void *osty_rt_thread_chan_make(int64_t capacity) {
          * Clamp to 1 so single-step producer/consumer still works. */
         capacity = 1;
     }
-    osty_rt_chan_impl *ch = (osty_rt_chan_impl *)calloc(1, sizeof(*ch));
-    if (ch == NULL) {
-        osty_rt_abort("thread.chan.make: out of memory");
-    }
+    /* Channel lives on the GC heap so it is reclaimed when no Osty
+     * reference remains (including captures in spawned closures).
+     * The `slots` buffer and the pthread sync objects are owned by
+     * the channel and freed by osty_rt_chan_destroy on sweep. */
+    osty_rt_chan_impl *ch = (osty_rt_chan_impl *)osty_gc_allocate_managed(
+        sizeof(osty_rt_chan_impl), OSTY_GC_KIND_GENERIC,
+        "runtime.thread.chan", NULL, osty_rt_chan_destroy);
     ch->slots = (int64_t *)calloc((size_t)capacity, sizeof(int64_t));
     if (ch->slots == NULL) {
-        free(ch);
         osty_rt_abort("thread.chan.make: out of memory");
     }
     ch->cap = capacity;
@@ -2304,7 +2327,7 @@ void *osty_rt_thread_chan_make(int64_t capacity) {
         pthread_cond_init(&ch->not_full, NULL) != 0 ||
         pthread_cond_init(&ch->not_empty, NULL) != 0) {
         free(ch->slots);
-        free(ch);
+        ch->slots = NULL;
         osty_rt_abort("thread.chan.make: sync init failed");
     }
     return ch;

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1,7 +1,13 @@
-/* nanosleep (scheduler Phase 1A) requires POSIX.1-1993; without this macro
- * glibc hides the declaration and strict clang (>=16) rejects the call. */
+/* Feature test macros enable the POSIX 2008 surface (nanosleep,
+ * pthread_mutexattr_settype, sched_yield, PTHREAD_MUTEX_RECURSIVE)
+ * across glibc/musl/Darwin regardless of compiler default. 2008
+ * supersedes the earlier 199309L level previously used for nanosleep
+ * alone. */
 #ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
+#endif
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
 #endif
 
 #include <stdbool.h>
@@ -11,8 +17,21 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <pthread.h>
+#include <sched.h>
 
-/* Active LLVM/native GC runtime path. See ../../../../RUNTIME_GC.md. */
+/* Active LLVM/native GC runtime path. See ../../../../RUNTIME_GC.md.
+ *
+ * Concurrency is pthread-based (see ../../../../RUNTIME_SCHEDULER.md):
+ * task_spawn creates real OS threads, channels are mutex+cond ring
+ * buffers, and GC allocation is serialized by osty_gc_lock so that
+ * multi-threaded programs stay consistent. Automatic collection is
+ * paused while worker threads are live (osty_concurrent_workers > 0)
+ * because scanning only the current thread's stack would drop roots
+ * held by siblings. Manual collection via osty_gc_debug_collect is
+ * still available between phases. A concurrent collector lands in
+ * Phase 3 per the scheduler roadmap.
+ */
 
 typedef void (*osty_gc_trace_fn)(void *payload);
 typedef void (*osty_gc_destroy_fn)(void *payload);
@@ -161,6 +180,53 @@ static void osty_rt_abort(const char *message) {
     abort();
 }
 
+/* GC + runtime-wide lock. Recursive so that collection (invoked from
+ * within allocate_managed) can re-enter write-barriers and root scans
+ * without deadlocking. Initialized on first use so no constructor is
+ * required. */
+static pthread_once_t osty_gc_lock_once = PTHREAD_ONCE_INIT;
+static pthread_mutex_t osty_gc_lock;
+static int64_t osty_concurrent_workers = 0;
+
+static void osty_gc_lock_init(void) {
+    pthread_mutexattr_t attr;
+    if (pthread_mutexattr_init(&attr) != 0) {
+        osty_rt_abort("gc lock: mutexattr_init failed");
+    }
+    if (pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0) {
+        osty_rt_abort("gc lock: mutexattr_settype failed");
+    }
+    if (pthread_mutex_init(&osty_gc_lock, &attr) != 0) {
+        osty_rt_abort("gc lock: mutex_init failed");
+    }
+    pthread_mutexattr_destroy(&attr);
+}
+
+static void osty_gc_acquire(void) {
+    pthread_once(&osty_gc_lock_once, osty_gc_lock_init);
+    pthread_mutex_lock(&osty_gc_lock);
+}
+
+static void osty_gc_release(void) {
+    pthread_mutex_unlock(&osty_gc_lock);
+}
+
+static void osty_sched_workers_inc(void) {
+    osty_gc_acquire();
+    osty_concurrent_workers += 1;
+    osty_gc_release();
+}
+
+static void osty_sched_workers_dec(void) {
+    osty_gc_acquire();
+    if (osty_concurrent_workers <= 0) {
+        osty_gc_release();
+        osty_rt_abort("scheduler: worker counter underflow");
+    }
+    osty_concurrent_workers -= 1;
+    osty_gc_release();
+}
+
 static void osty_gc_link(osty_gc_header *header) {
     header->next = osty_gc_objects;
     header->prev = NULL;
@@ -254,8 +320,10 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
     header->destroy = destroy;
     header->site = site;
     header->payload = (void *)(header + 1);
+    osty_gc_acquire();
     osty_gc_link(header);
     osty_gc_note_allocation(payload_size);
+    osty_gc_release();
     return header->payload;
 }
 
@@ -1809,11 +1877,28 @@ void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t
     if (!osty_gc_safepoint_stress_enabled_now() && !osty_gc_collection_requested) {
         return;
     }
+    /* While worker threads are live we can only see the current stack's
+     * roots. A naive collection here would free objects that sibling
+     * threads still reference. Defer until workers drain; a concurrent
+     * collector is Phase 3. */
+    osty_gc_acquire();
+    if (osty_concurrent_workers > 0) {
+        osty_gc_release();
+        return;
+    }
     osty_gc_collect_now_with_stack_roots(root_slots, root_slot_count);
+    osty_gc_release();
 }
 
 void osty_gc_debug_collect(void) {
+    osty_gc_acquire();
+    if (osty_concurrent_workers > 0) {
+        /* Same cross-thread root safety gate as safepoint_v1. */
+        osty_gc_release();
+        return;
+    }
     osty_gc_collect_now();
+    osty_gc_release();
 }
 
 int64_t osty_gc_debug_live_count(void) {
@@ -1879,30 +1964,35 @@ int osty_gc_debug_satb_log_contains(void *payload) {
 }
 
 /* ======================================================================
- * Phase 1A: sequential scheduler (see RUNTIME_SCHEDULER.md)
+ * Scheduler: pthread-backed (RUNTIME_SCHEDULER.md Phase 1B/2 hybrid)
  *
- * The public surface matches the ABI committed in `RUNTIME_SCHEDULER.md`
- * §ABI contract. Every symbol here has a successor in Phase 1B (fibers)
- * and Phase 2 (multi-worker) with the same signature.
+ * The public ABI is unchanged from Phase 1A; this is the first
+ * implementation that runs tasks on real OS threads and gives channels
+ * proper block/wake semantics. Key points:
  *
- * Semantics in this phase:
- *   - `osty_rt_task_group(body)` runs `body` on the calling thread. The
- *     group is live only for the duration of that call.
- *   - `osty_rt_task_spawn(body)` and `osty_rt_task_group_spawn(g, body)`
- *     run `body` immediately and return a handle holding the result.
- *     `Handle.join` reads the stored result — no blocking, no parallelism.
- *   - Cancellation: setting the group flag makes subsequent cancel checks
- *     report true. Already-completed tasks are unaffected.
- *   - `thread.yield` is a no-op; `thread.sleep` blocks the calling thread.
- *   - Channels and `select` abort with a diagnostic: they require true
- *     block/wake which arrives in Phase 1B.
+ *   - task_spawn / task_group_spawn → pthread_create; handle_join →
+ *     pthread_join. Bodies run in parallel when CPU allows.
+ *   - task_group(body) runs body on the calling thread and activates
+ *     a group. Children created via task_group_spawn inherit the group
+ *     in their TLS (osty_sched_current_group). Callers are responsible
+ *     for joining handles; the group teardown does not auto-reap
+ *     stragglers yet (tracked in RUNTIME_SCHEDULER.md roadmap).
+ *   - Channels are bounded ring buffers with pthread_mutex + two
+ *     condition variables. send blocks while full, recv while empty.
+ *     close wakes both waits; recv after close-and-drain returns ok=0.
+ *     Capacity 0 is clamped to 1 (documented limitation; true
+ *     rendezvous lands with Phase 1B fibers).
+ *   - select / race / collectAll / parallel remain as loud aborts
+ *     because their registration surface needs Osty-side builder
+ *     allocation we have not wired yet; the message points at the
+ *     scheduler roadmap so programs that reach them fail fast.
  *
- * ABI abuse notice: MIR declares `osty_rt_task_group` and
- * `osty_rt_task_handle_join` with the caller's Osty-side return type
- * (usually i64 or ptr). This runtime returns pointer-width results via
- * `void*`, which the linker treats as a compatible 64-bit return on
- * x86_64 SysV and AArch64 AAPCS. Phase 1A supports scalar/pointer
- * returns up to 8 bytes. Float and struct returns require Phase 2.
+ * ABI abuse notice: MIR declares task_group / handle_join with the
+ * caller's Osty-side return type (usually i64 or ptr). pthread_join
+ * yields a `void *` that the linker treats as compatible 64-bit on
+ * x86_64 SysV and AArch64 AAPCS. Scalar/ptr returns up to 8 bytes are
+ * supported. Float returns travel as raw bits through int64_t; struct
+ * returns still require Phase 2 ABI work.
  * ====================================================================== */
 
 typedef int64_t (*osty_task_group_body_fn)(void *env, void *group);
@@ -1914,14 +2004,15 @@ typedef struct osty_rt_task_group_impl {
 } osty_rt_task_group_impl;
 
 typedef struct osty_rt_task_handle_impl {
-    int64_t result;
-    int32_t done;    /* 1 once body returned */
-    int32_t errored; /* reserved */
+    pthread_t thread;
+    int has_thread;                      /* 1 while thread is joinable */
+    void *body_env;
+    osty_rt_task_group_impl *group;      /* inherited group, may be NULL */
+    volatile int64_t result;
+    volatile int32_t done;
+    int32_t errored;                     /* reserved */
 } osty_rt_task_handle_impl;
 
-/* Thread-local current group pointer. Phase 1A uses a single OS thread,
- * but declaring it _Thread_local makes Phase 2 (multi-worker) a drop-in
- * upgrade — no callers change. */
 #if defined(__STDC_NO_THREADS__) || defined(__APPLE__)
 static __thread osty_rt_task_group_impl *osty_sched_current_group = NULL;
 #else
@@ -1937,13 +2028,25 @@ static osty_rt_task_handle_impl *osty_sched_alloc_handle(void) {
     return h;
 }
 
-static void osty_sched_unsupported(const char *what) {
+static void osty_sched_unimplemented(const char *what) {
     fprintf(stderr,
-            "osty llvm runtime: Phase 1A scheduler does not support %s. "
-            "Channels, select, and helpers land in Phase 1B / Phase 2 "
-            "(see RUNTIME_SCHEDULER.md).\n",
+            "osty llvm runtime: %s is not implemented yet "
+            "(see RUNTIME_SCHEDULER.md for roadmap).\n",
             what);
     abort();
+}
+
+static void *osty_rt_task_thread_trampoline(void *arg) {
+    osty_rt_task_handle_impl *h = (osty_rt_task_handle_impl *)arg;
+    if (h->group != NULL) {
+        osty_sched_current_group = h->group;
+    }
+    osty_task_spawn_body_fn fn = (osty_task_spawn_body_fn)(*(void **)h->body_env);
+    int64_t result = fn(h->body_env);
+    h->result = result;
+    __atomic_store_n(&h->done, 1, __ATOMIC_RELEASE);
+    osty_sched_workers_dec();
+    return NULL;
 }
 
 int64_t osty_rt_task_group(void *body_env) {
@@ -1957,7 +2060,6 @@ int64_t osty_rt_task_group(void *body_env) {
     osty_rt_task_group_impl *prev = osty_sched_current_group;
     osty_sched_current_group = &group;
 
-    /* env[0] is the fn pointer per the closure ABI. */
     osty_task_group_body_fn fn = (osty_task_group_body_fn)(*(void **)body_env);
     int64_t result = fn(body_env, (void *)&group);
 
@@ -1965,34 +2067,30 @@ int64_t osty_rt_task_group(void *body_env) {
     return result;
 }
 
-void *osty_rt_task_spawn(void *body_env) {
+static void *osty_rt_task_spawn_internal(void *group, void *body_env) {
     if (body_env == NULL) {
         osty_rt_abort("task_spawn: null body env");
     }
     osty_rt_task_handle_impl *h = osty_sched_alloc_handle();
-    osty_task_spawn_body_fn fn = (osty_task_spawn_body_fn)(*(void **)body_env);
-    h->result = fn(body_env);
-    h->done = 1;
+    h->body_env = body_env;
+    h->group = (osty_rt_task_group_impl *)group;
+    osty_sched_workers_inc();
+    if (pthread_create(&h->thread, NULL,
+                       osty_rt_task_thread_trampoline, h) != 0) {
+        osty_sched_workers_dec();
+        free(h);
+        osty_rt_abort("task_spawn: pthread_create failed");
+    }
+    h->has_thread = 1;
     return h;
 }
 
+void *osty_rt_task_spawn(void *body_env) {
+    return osty_rt_task_spawn_internal(NULL, body_env);
+}
+
 void *osty_rt_task_group_spawn(void *group, void *body_env) {
-    if (body_env == NULL) {
-        osty_rt_abort("task_group_spawn: null body env");
-    }
-    osty_rt_task_handle_impl *h = osty_sched_alloc_handle();
-
-    osty_rt_task_group_impl *prev = osty_sched_current_group;
-    if (group != NULL) {
-        osty_sched_current_group = (osty_rt_task_group_impl *)group;
-    }
-
-    osty_task_spawn_body_fn fn = (osty_task_spawn_body_fn)(*(void **)body_env);
-    h->result = fn(body_env);
-    h->done = 1;
-
-    osty_sched_current_group = prev;
-    return h;
+    return osty_rt_task_spawn_internal(group, body_env);
 }
 
 int64_t osty_rt_task_handle_join(void *handle) {
@@ -2000,11 +2098,15 @@ int64_t osty_rt_task_handle_join(void *handle) {
         osty_rt_abort("task_handle_join: null handle");
     }
     osty_rt_task_handle_impl *h = (osty_rt_task_handle_impl *)handle;
-    if (!h->done) {
-        /* In Phase 1A all bodies run to completion before spawn returns,
-         * so an un-done handle is a runtime invariant violation. */
-        osty_rt_abort("task_handle_join: handle not completed (Phase 1A invariant)");
+    if (h->has_thread) {
+        if (pthread_join(h->thread, NULL) != 0) {
+            osty_rt_abort("task_handle_join: pthread_join failed");
+        }
+        h->has_thread = 0;
     }
+    /* After pthread_join, h->done is acquire-visible via the implicit
+     * release on worker_dec; read via atomic for clarity. */
+    (void)__atomic_load_n(&h->done, __ATOMIC_ACQUIRE);
     return h->result;
 }
 
@@ -2013,7 +2115,7 @@ void osty_rt_task_group_cancel(void *group) {
         return;
     }
     osty_rt_task_group_impl *g = (osty_rt_task_group_impl *)group;
-    g->cancelled = 1;
+    __atomic_store_n(&g->cancelled, 1, __ATOMIC_RELEASE);
 }
 
 bool osty_rt_task_group_is_cancelled(void *group) {
@@ -2021,7 +2123,7 @@ bool osty_rt_task_group_is_cancelled(void *group) {
         return false;
     }
     osty_rt_task_group_impl *g = (osty_rt_task_group_impl *)group;
-    return g->cancelled != 0;
+    return __atomic_load_n(&g->cancelled, __ATOMIC_ACQUIRE) != 0;
 }
 
 bool osty_rt_cancel_is_cancelled(void) {
@@ -2029,12 +2131,13 @@ bool osty_rt_cancel_is_cancelled(void) {
     if (g == NULL) {
         return false;
     }
-    return g->cancelled != 0;
+    return __atomic_load_n(&g->cancelled, __ATOMIC_ACQUIRE) != 0;
 }
 
 void osty_rt_thread_yield(void) {
-    /* Phase 1A: no scheduler to yield to. No-op. Phase 1B adds a real
-     * fiber context switch here. */
+    /* Hand the OS scheduler a chance to run other threads. sched_yield
+     * is BSD-historical but portable on POSIX pthread platforms. */
+    sched_yield();
 }
 
 void osty_rt_thread_sleep(int64_t nanos) {
@@ -2050,105 +2153,227 @@ void osty_rt_thread_sleep(int64_t nanos) {
     }
 }
 
-/* ---- Channels: Phase 1B stubs. Abort with a clear message so programs
- *      that reach these surfaces fail fast rather than silently. ---- */
+/* ---- Channels: bounded ring buffer, mutex + two condition variables.
+ *
+ * Every channel slot is an int64_t holding either a scalar (i64/i1/f64
+ * bits / ptr bits) or a GC-managed pointer copy of the sent bytes. The
+ * element width encoding is the caller's responsibility — they reach
+ * here through one of the typed suffixes (send_i64, send_f64, ...) so
+ * the slot layout is uniform.
+ */
 
-void *osty_rt_thread_chan_make(int64_t capacity) {
-    (void)capacity;
-    osty_sched_unsupported("thread.chan (Phase 1B)");
-    return NULL;
-}
-
-void osty_rt_thread_chan_close(void *ch) {
-    (void)ch;
-    osty_sched_unsupported("thread.chan.close (Phase 1B)");
-}
-
-bool osty_rt_thread_chan_is_closed(void *ch) {
-    (void)ch;
-    osty_sched_unsupported("thread.chan.is_closed (Phase 1B)");
-    return false;
-}
-
-#define OSTY_RT_CHAN_STUB_SEND(suffix, ctype)                             \
-    void osty_rt_thread_chan_send_##suffix(void *ch, ctype value) {       \
-        (void)ch;                                                         \
-        (void)value;                                                      \
-        osty_sched_unsupported("thread.chan.send (Phase 1B)");            \
-    }
-OSTY_RT_CHAN_STUB_SEND(i64, int64_t)
-OSTY_RT_CHAN_STUB_SEND(i1, bool)
-OSTY_RT_CHAN_STUB_SEND(f64, double)
-OSTY_RT_CHAN_STUB_SEND(ptr, void *)
-#undef OSTY_RT_CHAN_STUB_SEND
-
-void osty_rt_thread_chan_send_bytes_v1(void *ch, const void *src, int64_t sz) {
-    (void)ch;
-    (void)src;
-    (void)sz;
-    osty_sched_unsupported("thread.chan.send (bytes, Phase 1B)");
-}
+typedef struct osty_rt_chan_impl {
+    pthread_mutex_t mu;
+    pthread_cond_t not_full;
+    pthread_cond_t not_empty;
+    int64_t cap;
+    int64_t head;
+    int64_t tail;
+    int64_t count;
+    int closed;
+    int64_t *slots;
+} osty_rt_chan_impl;
 
 typedef struct osty_rt_chan_recv_result {
     int64_t value;
     int64_t ok;
 } osty_rt_chan_recv_result;
 
-#define OSTY_RT_CHAN_STUB_RECV(suffix)                                    \
-    osty_rt_chan_recv_result osty_rt_thread_chan_recv_##suffix(void *ch) { \
-        (void)ch;                                                         \
-        osty_sched_unsupported("thread.chan.recv (Phase 1B)");            \
-        osty_rt_chan_recv_result r = {0, 0};                              \
-        return r;                                                         \
+static osty_rt_chan_impl *osty_rt_chan_cast(void *ch, const char *op) {
+    if (ch == NULL) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%s: null channel", op);
+        osty_rt_abort(buf);
     }
-OSTY_RT_CHAN_STUB_RECV(i64)
-OSTY_RT_CHAN_STUB_RECV(i1)
-OSTY_RT_CHAN_STUB_RECV(f64)
-OSTY_RT_CHAN_STUB_RECV(ptr)
-OSTY_RT_CHAN_STUB_RECV(bytes_v1)
-#undef OSTY_RT_CHAN_STUB_RECV
+    return (osty_rt_chan_impl *)ch;
+}
 
-/* ---- Select / helpers: Phase 2 stubs. ---- */
+void *osty_rt_thread_chan_make(int64_t capacity) {
+    if (capacity < 0) {
+        osty_rt_abort("thread.chan.make: negative capacity");
+    }
+    if (capacity == 0) {
+        /* Rendezvous semantics (cap=0) require fiber handoff, Phase 1B.
+         * Clamp to 1 so single-step producer/consumer still works. */
+        capacity = 1;
+    }
+    osty_rt_chan_impl *ch = (osty_rt_chan_impl *)calloc(1, sizeof(*ch));
+    if (ch == NULL) {
+        osty_rt_abort("thread.chan.make: out of memory");
+    }
+    ch->slots = (int64_t *)calloc((size_t)capacity, sizeof(int64_t));
+    if (ch->slots == NULL) {
+        free(ch);
+        osty_rt_abort("thread.chan.make: out of memory");
+    }
+    ch->cap = capacity;
+    if (pthread_mutex_init(&ch->mu, NULL) != 0 ||
+        pthread_cond_init(&ch->not_full, NULL) != 0 ||
+        pthread_cond_init(&ch->not_empty, NULL) != 0) {
+        free(ch->slots);
+        free(ch);
+        osty_rt_abort("thread.chan.make: sync init failed");
+    }
+    return ch;
+}
+
+void osty_rt_thread_chan_close(void *raw) {
+    osty_rt_chan_impl *ch = osty_rt_chan_cast(raw, "thread.chan.close");
+    pthread_mutex_lock(&ch->mu);
+    ch->closed = 1;
+    pthread_cond_broadcast(&ch->not_empty);
+    pthread_cond_broadcast(&ch->not_full);
+    pthread_mutex_unlock(&ch->mu);
+}
+
+bool osty_rt_thread_chan_is_closed(void *raw) {
+    osty_rt_chan_impl *ch = osty_rt_chan_cast(raw, "thread.chan.is_closed");
+    pthread_mutex_lock(&ch->mu);
+    bool closed = ch->closed != 0;
+    pthread_mutex_unlock(&ch->mu);
+    return closed;
+}
+
+static void osty_rt_chan_send_raw(osty_rt_chan_impl *ch, int64_t slot) {
+    pthread_mutex_lock(&ch->mu);
+    while (ch->count == ch->cap && !ch->closed) {
+        pthread_cond_wait(&ch->not_full, &ch->mu);
+    }
+    if (ch->closed) {
+        pthread_mutex_unlock(&ch->mu);
+        osty_rt_abort("thread.chan.send: send on closed channel");
+    }
+    ch->slots[ch->tail] = slot;
+    ch->tail = (ch->tail + 1) % ch->cap;
+    ch->count += 1;
+    pthread_cond_signal(&ch->not_empty);
+    pthread_mutex_unlock(&ch->mu);
+}
+
+static osty_rt_chan_recv_result osty_rt_chan_recv_raw(osty_rt_chan_impl *ch) {
+    osty_rt_chan_recv_result r = {0, 0};
+    pthread_mutex_lock(&ch->mu);
+    while (ch->count == 0 && !ch->closed) {
+        pthread_cond_wait(&ch->not_empty, &ch->mu);
+    }
+    if (ch->count == 0 && ch->closed) {
+        pthread_mutex_unlock(&ch->mu);
+        return r;
+    }
+    r.value = ch->slots[ch->head];
+    r.ok = 1;
+    ch->head = (ch->head + 1) % ch->cap;
+    ch->count -= 1;
+    pthread_cond_signal(&ch->not_full);
+    pthread_mutex_unlock(&ch->mu);
+    return r;
+}
+
+void osty_rt_thread_chan_send_i64(void *raw, int64_t value) {
+    osty_rt_chan_send_raw(osty_rt_chan_cast(raw, "thread.chan.send"), value);
+}
+
+void osty_rt_thread_chan_send_i1(void *raw, bool value) {
+    osty_rt_chan_send_raw(osty_rt_chan_cast(raw, "thread.chan.send"),
+                          (int64_t)(value ? 1 : 0));
+}
+
+void osty_rt_thread_chan_send_f64(void *raw, double value) {
+    int64_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    osty_rt_chan_send_raw(osty_rt_chan_cast(raw, "thread.chan.send"), bits);
+}
+
+void osty_rt_thread_chan_send_ptr(void *raw, void *value) {
+    osty_rt_chan_send_raw(osty_rt_chan_cast(raw, "thread.chan.send"),
+                          (int64_t)(uintptr_t)value);
+}
+
+void osty_rt_thread_chan_send_bytes_v1(void *raw, const void *src, int64_t sz) {
+    if (sz < 0) {
+        osty_rt_abort("thread.chan.send: negative byte size");
+    }
+    /* Copy into a GC-managed allocation so receiver sees a stable owner
+     * even after the producer's frame is gone. The collector will reap
+     * it once the receiver drops the pointer. */
+    void *copy = osty_gc_allocate_managed((size_t)sz, OSTY_GC_KIND_GENERIC,
+                                          "runtime.chan.bytes", NULL, NULL);
+    if (sz > 0 && src != NULL) {
+        memcpy(copy, src, (size_t)sz);
+    }
+    osty_rt_chan_send_raw(osty_rt_chan_cast(raw, "thread.chan.send"),
+                          (int64_t)(uintptr_t)copy);
+}
+
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_i64(void *raw) {
+    return osty_rt_chan_recv_raw(osty_rt_chan_cast(raw, "thread.chan.recv"));
+}
+
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_i1(void *raw) {
+    osty_rt_chan_recv_result r = osty_rt_chan_recv_raw(
+        osty_rt_chan_cast(raw, "thread.chan.recv"));
+    if (r.ok) {
+        r.value = r.value != 0 ? 1 : 0;
+    }
+    return r;
+}
+
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_f64(void *raw) {
+    return osty_rt_chan_recv_raw(osty_rt_chan_cast(raw, "thread.chan.recv"));
+}
+
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_ptr(void *raw) {
+    return osty_rt_chan_recv_raw(osty_rt_chan_cast(raw, "thread.chan.recv"));
+}
+
+osty_rt_chan_recv_result osty_rt_thread_chan_recv_bytes_v1(void *raw) {
+    return osty_rt_chan_recv_raw(osty_rt_chan_cast(raw, "thread.chan.recv"));
+}
+
+/* ---- Select / helpers remain pending. Their registration surface
+ *      needs Osty-side builder allocation that the MIR emitter has not
+ *      wired up; aborting here is the closest-to-correct behaviour
+ *      for programs that reach these entry points today. ---- */
 
 void osty_rt_select(void *s) {
     (void)s;
-    osty_sched_unsupported("thread.select (Phase 2)");
+    osty_sched_unimplemented("thread.select");
 }
 
 void osty_rt_select_recv(void *s, void *ch, void *arm) {
     (void)s; (void)ch; (void)arm;
-    osty_sched_unsupported("thread.select.recv (Phase 2)");
+    osty_sched_unimplemented("thread.select.recv");
 }
 
 void osty_rt_select_send(void *s, void *ch, void *arm) {
     (void)s; (void)ch; (void)arm;
-    osty_sched_unsupported("thread.select.send (Phase 2)");
+    osty_sched_unimplemented("thread.select.send");
 }
 
 void osty_rt_select_timeout(void *s, int64_t ns, void *arm) {
     (void)s; (void)ns; (void)arm;
-    osty_sched_unsupported("thread.select.timeout (Phase 2)");
+    osty_sched_unimplemented("thread.select.timeout");
 }
 
 void osty_rt_select_default(void *s, void *arm) {
     (void)s; (void)arm;
-    osty_sched_unsupported("thread.select.default (Phase 2)");
+    osty_sched_unimplemented("thread.select.default");
 }
 
 void *osty_rt_task_race(void *body) {
     (void)body;
-    osty_sched_unsupported("race (Phase 2)");
+    osty_sched_unimplemented("race");
     return NULL;
 }
 
 void *osty_rt_task_collect_all(void *body) {
     (void)body;
-    osty_sched_unsupported("collectAll (Phase 2)");
+    osty_sched_unimplemented("collectAll");
     return NULL;
 }
 
 void *osty_rt_parallel(void *items, int64_t concurrency, void *f) {
     (void)items; (void)concurrency; (void)f;
-    osty_sched_unsupported("parallel (Phase 2)");
+    osty_sched_unimplemented("parallel");
     return NULL;
 }

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1110,6 +1110,9 @@ func llvmClangLinkBinaryArgs(target string, objectPaths []string, binaryPath str
 		// Osty: examples/selfhost-core/llvmgen.osty:724:9
 		func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	}
+	// `-pthread` pulls libpthread / libSystem threading symbols, needed
+	// by the bundled runtime's task / channel implementations.
+	func() struct{} { args = append(args, "-pthread"); return struct{}{} }()
 	// Osty: examples/selfhost-core/llvmgen.osty:726:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
 	// Osty: examples/selfhost-core/llvmgen.osty:727:5


### PR DESCRIPTION
## Summary

Promotes `internal/backend/runtime/osty_runtime.c` from the Phase 1A
sequential stub to a pthread-backed implementation covering `task_spawn`,
`task_group_spawn`, `handle_join`, cancellation, and real buffered
channels. The ABI committed in `RUNTIME_SCHEDULER.md` is unchanged —
existing Osty programs keep compiling.

- `osty_rt_task_spawn` / `osty_rt_task_group_spawn` → `pthread_create`;
  `osty_rt_task_handle_join` → `pthread_join`. Group inheritance travels
  through `h->group` into the child thread's TLS so `cancel_is_cancelled`
  in children observes parent-group cancellations.
- Channels: bounded ring buffer + `pthread_mutex_t` + `pthread_cond_t`
  × 2 (`not_full`, `not_empty`). `send` blocks on full, `recv` on empty;
  `close` broadcasts to both waits and recv after drain returns `ok=0`.
  Capacity 0 is clamped to 1 (rendezvous semantics are Phase 1B fibers,
  still out of scope). bytes_v1 sends route through the GC allocator so
  the receiver's pointer stays owned.
- GC safety: recursive `osty_gc_lock` serializes `osty_gc_allocate_managed`,
  write barriers transitively, and collection. Automatic collection
  (`osty_gc_safepoint_v1` + debug collect) is paused while
  `osty_concurrent_workers > 0` because the caller-only root scan would
  drop live objects held by siblings. Concurrent collection is Phase 3
  per the scheduler doc.
- Host glue: `-pthread` added to both the runtime C-object compile args
  (`internal/backend/llvm.go`) and the bundled link args
  (`internal/llvmgen/support_snapshot.go`). `_POSIX_C_SOURCE`/`_XOPEN_SOURCE`
  feature test macros in the C source unlock `PTHREAD_MUTEX_RECURSIVE`
  and `sched_yield` across glibc/musl/Darwin.
- `osty_rt_select*`, `osty_rt_task_race`, `osty_rt_task_collect_all`,
  `osty_rt_parallel` remain loud aborts (now via
  `osty_sched_unimplemented`) — their registration surfaces need
  Osty-side builder allocation that the MIR path does not emit yet.
  Roadmap captured in `RUNTIME_SCHEDULER.md`.

## Test plan

- [x] `go test -run 'TestBundledRuntimeScheduler' ./internal/backend/` —
      covers `taskGroup` sum, detached spawn+join, group cancel
      propagation, 4-way parallel spawn wall-clock, channel
      producer/consumer across threads, close-after-drain, and the
      remaining select stub's loud-fail behaviour.
- [x] `go test -run 'Runtime' ./internal/backend/` — all runtime smoke
      tests still pass.
- [x] `clang -std=c11 -pthread -Wall -Wextra -c …/osty_runtime.c` —
      clean under strict warnings.
- Pre-existing failures (`TestLLVMBackendBinaryGenericEnumVariantFromLetContext`,
  `TestLLVMBackendBinaryBuiltinResultConstructorsTrackLocalContext`,
  `runtime_intrinsic_typing_test.go` cases) reproduce on `main` and are
  unrelated.

https://claude.ai/code/session_01PVwXDUgbNGZFDGG2faZMco