### PR TITLE
feat(llvmgen): ?? nil-coalesce lowering + precise downcast vtable lookup

### DIFF
--- a/internal/llvmgen/coalesce_test.go
+++ b/internal/llvmgen/coalesce_test.go
@@ -1,8 +1,15 @@
 package llvmgen
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 // `a ?? b` on a `String?` (inner type is ptr) lowers to a branch+phi
@@ -135,5 +142,153 @@ func TestGenerateCoalesceChainsRightAssoc(t *testing.T) {
 	}
 	if count := strings.Count(got, "phi ptr"); count < 2 {
 		t.Fatalf("expected two phi nodes for chained `??`, got %d:\n%s", count, got)
+	}
+}
+
+// End-to-end: full compilation pipeline (parser → resolve → check →
+// ir.Lower → mir.Lower → GenerateFromMIR → fall back to
+// GenerateModule on ErrUnsupported) reaches the legacy emitter and
+// produces coalesce IR. This is the path that real `osty build`
+// takes, so the test is the definitive proof that `??` works.
+//
+// The MIR emitter currently refuses Option<String> locals with
+// LLVM000 ("unsupported local type <error>") so the backend
+// dispatcher falls back to the HIR→AST bridge automatically. The
+// fallback behavior is not under test here — what matters is that
+// *some* path produces working coalesce IR for the full pipeline.
+func TestGenerateCoalesceFullPipeline(t *testing.T) {
+	src := `fn resolve(name: String?) -> String {
+    name ?? "anonymous"
+}
+
+fn main() {}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/pipeline_coalesce.osty"}
+
+	// Mirror the dispatcher: MIR first, legacy fallback on ErrUnsupported.
+	out, err := GenerateFromMIR(mirMod, opts)
+	if err != nil {
+		if !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("GenerateFromMIR hard error (not ErrUnsupported): %v", err)
+		}
+		out, err = GenerateModule(mod, opts)
+		if err != nil {
+			t.Fatalf("GenerateModule fallback error: %v", err)
+		}
+	}
+
+	got := string(out)
+	for _, want := range []string{
+		"define ptr @resolve(ptr %name)",
+		"coalesce.some",
+		"coalesce.none",
+		"coalesce.end",
+		"phi ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("full-pipeline IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Right-side side effects (and their GC-visible fallout) must
+// execute exactly once and only on the None path. Here the RHS is a
+// user function call that would normally emit an `osty.gc.safepoint`
+// marker — it must appear after the `coalesce.none` label, never
+// before the null-check, and never twice.
+func TestGenerateCoalesceRightSideEffectsLazy(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn compute() -> Int {
+    42
+}
+
+fn pick(age: Int?) -> Int {
+    age ?? compute()
+}
+`)
+
+	irOut, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/coalesce_sideffect.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(irOut)
+
+	callIdx := strings.Index(got, "call i64 @compute()")
+	if callIdx < 0 {
+		t.Fatalf("RHS call `@compute` missing from IR:\n%s", got)
+	}
+	if strings.Count(got, "call i64 @compute()") != 1 {
+		t.Fatalf("expected exactly one call to @compute (lazy, once), got %d:\n%s",
+			strings.Count(got, "call i64 @compute()"), got)
+	}
+	noneIdx := strings.Index(got, "coalesce.none")
+	if noneIdx < 0 || callIdx < noneIdx {
+		t.Fatalf("RHS call (%d) must appear after `coalesce.none` label (%d):\n%s",
+			callIdx, noneIdx, got)
+	}
+}
+
+// Canonical spec pattern (LANG_SPEC_v0.5 §4 / CLAUDE.md §A.6):
+// `user?.profile?.title ?? "Untitled"` — optional chain feeding a
+// coalesce. Exercises the interaction between `?.` (each hop emits
+// its own null-check + phi) and `??` (final fallback) so a
+// regression in either direction surfaces here.
+func TestGenerateCoalesceOptionalChainFallback(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Profile {
+    title: String,
+}
+
+struct User {
+    pub profile: Profile?,
+}
+
+fn titleOf(user: User?) -> String {
+    user?.profile?.title ?? "Untitled"
+}
+`)
+
+	irOut, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/coalesce_chain_opt.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(irOut)
+	// Each `?.` emits an `optional.*` label, and the `??` emits its
+	// own coalesce.* labels. Missing either means one half of the
+	// composition regressed.
+	for _, want := range []string{
+		"optional.then",
+		"optional.nil",
+		"coalesce.some",
+		"coalesce.none",
+		"phi ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("optional-chain + coalesce IR missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/internal/llvmgen/coalesce_test.go
+++ b/internal/llvmgen/coalesce_test.go
@@ -1,0 +1,139 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// `a ?? b` on a `String?` (inner type is ptr) lowers to a branch+phi
+// with no intermediate load — the optional ptr doubles as the Some
+// payload. Right-side is lazy, reached only from the null branch, and
+// the phi merges at `coalesce.end`.
+func TestGenerateCoalescePtrInner(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn resolve(name: String?) -> String {
+    name ?? "anonymous"
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/coalesce_ptr.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define ptr @resolve(ptr %name)",
+		"icmp eq ptr",
+		"coalesce.some",
+		"coalesce.none",
+		"coalesce.end",
+		"phi ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// `a ?? b` on an `Int?` (inner type is i64, boxed) loads the payload
+// from the non-null pointer in the Some branch and phis it against
+// the literal fallback in the None branch. The phi must be typed
+// `i64`, not `ptr`.
+func TestGenerateCoalesceBoxedInt(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn ageOr(age: Int?) -> Int {
+    age ?? 0
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/coalesce_int.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @ageOr(ptr %age)",
+		"icmp eq ptr",
+		"coalesce.some",
+		"coalesce.none",
+		"load i64, ptr",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Right-side laziness is visible in the IR: the RHS instructions must
+// be emitted inside the `coalesce.none` block, after the null-check
+// branch. If the emitter eagerly evaluated both sides, the RHS would
+// appear before the branch.
+func TestGenerateCoalesceRightSideIsLazy(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn pick(a: Int?, b: Int, c: Int) -> Int {
+    a ?? (b + c)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/coalesce_lazy.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	branchIdx := strings.Index(got, "coalesce.none")
+	if branchIdx < 0 {
+		t.Fatalf("missing coalesce.none label in IR:\n%s", got)
+	}
+	labelEnd := strings.Index(got[branchIdx:], ":")
+	if labelEnd < 0 {
+		t.Fatalf("malformed coalesce.none label (no trailing colon):\n%s", got)
+	}
+	afterLabel := branchIdx + labelEnd
+	addIdx := strings.Index(got, "add i64 %b, %c")
+	if addIdx < 0 {
+		t.Fatalf("missing `add` for b + c in IR:\n%s", got)
+	}
+	if addIdx < afterLabel {
+		t.Fatalf("right-side `add` (%d) appears before `coalesce.none` label (%d) — right side is not lazy:\n%s",
+			addIdx, afterLabel, got)
+	}
+}
+
+// `a ?? b ?? c` is right-associative per the grammar, so it parses
+// as `a ?? (b ?? c)`. In IR that produces two nested branch+phi
+// shapes — two `coalesce.end` labels and two phis.
+func TestGenerateCoalesceChainsRightAssoc(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn pickTitle(a: String?, b: String?) -> String {
+    a ?? b ?? "fallback"
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/coalesce_chain.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	if count := strings.Count(got, "coalesce.end"); count < 4 {
+		// Two `??` ops × two references each (label use + definition)
+		// in the textual IR. <4 hits means the inner `??` collapsed.
+		t.Fatalf("expected chained `??` to produce two nested branch+phi shapes (>=4 `coalesce.end` occurrences), got %d:\n%s",
+			count, got)
+	}
+	if count := strings.Count(got, "phi ptr"); count < 2 {
+		t.Fatalf("expected two phi nodes for chained `??`, got %d:\n%s", count, got)
+	}
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -728,6 +728,13 @@ func (g *generator) emitUnary(e *ast.UnaryExpr) (value, error) {
 }
 
 func (g *generator) emitBinary(e *ast.BinaryExpr) (value, error) {
+	// `??` lowers to a branch+phi rather than the usual eager binary
+	// shape — the right side is lazy per spec §7.3 (Option fallback).
+	// Intercept before emitExpr so the default is never evaluated when
+	// the left is Some.
+	if e.Op == token.QQ {
+		return g.emitCoalesce(e)
+	}
 	left, err := g.emitExpr(e.Left)
 	if err != nil {
 		return value{}, err
@@ -767,6 +774,111 @@ func (g *generator) emitBinary(e *ast.BinaryExpr) (value, error) {
 	out := llvmBinaryI64(emitter, op, toOstyValue(left), toOstyValue(right))
 	g.takeOstyEmitter(emitter)
 	return fromOstyValue(out), nil
+}
+
+// emitCoalesce lowers `left ?? right`, the Option-fallback operator.
+//
+// Semantics (LANG_SPEC_v0.5 §7.3): `left` has type `T?`, `right` has
+// type `T`. If `left` is Some(v), the result is v; if None, the
+// result is `right`. The right side is evaluated lazily — only when
+// the left side is None.
+//
+// Lowering mirrors the null-check/phi shape used by `?` and `?.`:
+//
+//   %is_nil = icmp eq ptr %left, null
+//   br i1 %is_nil, label %none, label %some
+//  some:
+//    ; unwrap: inner-ptr types use %left directly; others load the
+//    ; boxed payload via `load innerTyp, ptr %left`.
+//    br label %end
+//  none:
+//    ; evaluate %right (may be any side-effecting expression).
+//    br label %end
+//  end:
+//    %out = phi innerTyp [ %unwrapped, %some.pred ], [ %right, %none.pred ]
+//
+// Nil-coalesce is intentionally right-associative at the surface so
+// `a ?? b ?? c` parses as `a ?? (b ?? c)`; here we only see one
+// operator at a time, and the recursive emitExpr on `e.Right` handles
+// any chained `??` naturally.
+func (g *generator) emitCoalesce(e *ast.BinaryExpr) (value, error) {
+	leftSrc, ok := g.staticExprSourceType(e.Left)
+	if !ok {
+		return value{}, unsupported("type-system", "?? left source type unknown")
+	}
+	innerSrc, ok := unwrapOptionalSourceType(leftSrc)
+	if !ok {
+		return value{}, unsupported("type-system", "?? requires Option<T> on the left")
+	}
+	innerTyp, err := llvmType(innerSrc, g.typeEnv())
+	if err != nil {
+		return value{}, err
+	}
+	left, err := g.emitExpr(e.Left)
+	if err != nil {
+		return value{}, err
+	}
+	if left.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "?? left type %s, want ptr", left.typ)
+	}
+
+	emitter := g.toOstyEmitter()
+	isNil := llvmCompare(emitter, "eq", toOstyValue(left), toOstyValue(value{typ: "ptr", ref: "null"}))
+	someLabel := llvmNextLabel(emitter, "coalesce.some")
+	noneLabel := llvmNextLabel(emitter, "coalesce.none")
+	endLabel := llvmNextLabel(emitter, "coalesce.end")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, noneLabel, someLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(someLabel)
+
+	var leftUnwrapped value
+	if innerTyp == "ptr" {
+		leftUnwrapped = left
+		leftUnwrapped.sourceType = innerSrc
+	} else {
+		lv, err := g.loadTypedPointerValue(left, innerTyp)
+		if err != nil {
+			return value{}, err
+		}
+		lv.sourceType = innerSrc
+		leftUnwrapped = lv
+	}
+	somePred := g.currentBlock
+	g.branchTo(endLabel)
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(noneLabel)
+
+	right, err := g.emitExpr(e.Right)
+	if err != nil {
+		return value{}, err
+	}
+	if right.typ != innerTyp {
+		return value{}, unsupportedf("type-system", "?? right type %s, want %s", right.typ, innerTyp)
+	}
+	nonePred := g.currentBlock
+	g.branchTo(endLabel)
+
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]",
+		tmp, innerTyp, leftUnwrapped.ref, somePred, right.ref, nonePred,
+	))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+
+	out := value{typ: innerTyp, ref: tmp, sourceType: innerSrc}
+	out.rootPaths = g.rootPathsForType(innerTyp)
+	if innerTyp == "ptr" {
+		mergeContainerMetadata(&out, leftUnwrapped, right)
+		out.gcManaged = leftUnwrapped.gcManaged || right.gcManaged
+	}
+	return out, nil
 }
 
 func (g *generator) emitLogical(op token.Kind, left, right value) (value, error) {

--- a/internal/llvmgen/iface_downcast.go
+++ b/internal/llvmgen/iface_downcast.go
@@ -131,8 +131,25 @@ func (g *generator) emitInterfaceDowncastCall(call *ast.CallExpr) (value, bool, 
 		return value{}, true, unsupportedf("call",
 			"downcast target must be a single-segment named type")
 	}
-	vtableSym, ok := g.lookupVtableSymForImpl(targetName)
+	// Prefer the receiver's exact interface when we can recover it from
+	// the static source type — that catches the spec-relevant class of
+	// mistake where `T` implements a *different* interface than the
+	// receiver (e.g. `Printable.downcast::<FsError>()` when FsError
+	// only implements Error). Falls through to the any-interface match
+	// when the receiver's source type isn't available (common in the
+	// legacy-bridge path where the receiver is a synthesized AST node
+	// with no attached source type).
+	ifaceName := ""
+	if src, ok := g.staticExprSourceType(fx.X); ok {
+		ifaceName = namedTypeSingleSegment(src)
+	}
+	vtableSym, ok := g.lookupVtableSymForDowncast(targetName, ifaceName)
 	if !ok {
+		if ifaceName != "" {
+			return value{}, true, unsupportedf("call",
+				"downcast target %q does not implement interface %q",
+				targetName, ifaceName)
+		}
 		return value{}, true, unsupportedf("call",
 			"downcast target %q does not implement any registered interface", targetName)
 	}
@@ -150,10 +167,10 @@ func (g *generator) emitInterfaceDowncastCall(call *ast.CallExpr) (value, bool, 
 // lookupVtableSymForImpl returns the vtable symbol emitted for the
 // named impl across any registered interface. The generator emits
 // one vtable per (impl, iface) pair; when an impl satisfies multiple
-// interfaces the first hit wins. downcast::<T>() is coarser than the
-// method-dispatch path: it compares the runtime vtable against the
-// target impl's vtable without re-selecting by interface, which is
-// safe because the spec pins downcast to the Error interface.
+// interfaces the first hit wins. This is the coarse lookup used when
+// the downcast receiver's interface can't be recovered statically —
+// callers that do know the interface name should prefer
+// lookupVtableSymForDowncast for stronger mismatch detection.
 func (g *generator) lookupVtableSymForImpl(implName string) (string, bool) {
 	for _, iface := range g.interfacesByName {
 		if iface == nil {
@@ -163,6 +180,37 @@ func (g *generator) lookupVtableSymForImpl(implName string) (string, bool) {
 			if impl.implName == implName {
 				return impl.vtableSym, true
 			}
+		}
+	}
+	return "", false
+}
+
+// lookupVtableSymForDowncast resolves the (impl, iface) vtable symbol
+// that should back `recv.downcast::<T>()` where `recv` is statically
+// known to satisfy `ifaceName`. When `ifaceName` is empty (source
+// type unavailable) the lookup falls back to the any-interface match,
+// preserving the behavior the backend shipped with when the checker
+// still blocked downcast end-to-end.
+//
+// The receiver-interface-aware form catches the mistake of
+// downcasting to a type that implements an *unrelated* interface:
+// e.g. `printable.downcast::<FsError>()` where FsError only impls
+// Error, not Printable. Without this check the lowering would still
+// emit a vtable compare, but against FsError's Error vtable — a
+// pointer that never matches the runtime Printable vtable embedded
+// in `printable`, so the result is always None. Raising an error at
+// compile time surfaces the bug at its source instead.
+func (g *generator) lookupVtableSymForDowncast(implName, ifaceName string) (string, bool) {
+	if ifaceName == "" {
+		return g.lookupVtableSymForImpl(implName)
+	}
+	iface := g.interfacesByName[ifaceName]
+	if iface == nil {
+		return "", false
+	}
+	for _, impl := range iface.impls {
+		if impl.implName == implName {
+			return impl.vtableSym, true
 		}
 	}
 	return "", false

--- a/internal/llvmgen/iface_downcast_test.go
+++ b/internal/llvmgen/iface_downcast_test.go
@@ -95,7 +95,63 @@ fn probe(p: Printable) -> Unrelated? {
 	if err == nil {
 		t.Fatal("expected error for downcast target that implements no interface")
 	}
-	if !strings.Contains(err.Error(), "does not implement any registered interface") {
+	// Either the coarse ("any registered interface") or the precise
+	// ("does not implement interface %q") form is acceptable — the
+	// precise form fires when the receiver's source type carries the
+	// interface name, the coarse form when it doesn't.
+	msg := err.Error()
+	if !strings.Contains(msg, "does not implement any registered interface") &&
+		!strings.Contains(msg, "does not implement interface") {
 		t.Fatalf("error does not mention the missing-impl reason: %v", err)
+	}
+}
+
+// When the target type implements an *unrelated* interface — not the
+// one the receiver is statically typed at — the backend rejects the
+// downcast at compile time rather than emitting a vtable compare that
+// would always produce None at runtime.
+func TestInterfaceDowncastTargetMustImplementReceiverInterface(t *testing.T) {
+	file := parseLLVMGenFile(t, `interface Printable {
+    fn show(self) -> String
+}
+
+interface Tagged {
+    fn tag(self) -> Int
+}
+
+struct Note {
+    pub msg: String,
+
+    pub fn show(self) -> String {
+        self.msg
+    }
+}
+
+struct Marker {
+    pub n: Int,
+
+    pub fn tag(self) -> Int {
+        self.n
+    }
+}
+
+fn probe(p: Printable) -> Marker? {
+    p.downcast::<Marker>()
+}
+`)
+
+	_, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/iface_downcast_wrong_iface.osty",
+	})
+	if err == nil {
+		t.Fatal("expected error when target implements a different interface than the receiver")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "does not implement interface") {
+		t.Fatalf("error does not mention the specific-interface mismatch: %v", err)
+	}
+	if !strings.Contains(msg, "Printable") {
+		t.Fatalf("error does not name the receiver's interface %q: %v", "Printable", err)
 	}
 }

--- a/internal/llvmgen/iface_downcast_test.go
+++ b/internal/llvmgen/iface_downcast_test.go
@@ -1,8 +1,15 @@
 package llvmgen
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 // The `recv.downcast::<T>()` AST recognizer is wired into emitCall
@@ -153,5 +160,78 @@ fn probe(p: Printable) -> Marker? {
 	}
 	if !strings.Contains(msg, "Printable") {
 		t.Fatalf("error does not name the receiver's interface %q: %v", "Printable", err)
+	}
+}
+
+// End-to-end: full compilation pipeline (parser → resolve → check →
+// ir.Lower → mir.Lower → GenerateFromMIR → fall back to
+// GenerateModule on ErrUnsupported) exercises the real `osty build`
+// route. Without this test the backend-only `generateFromAST` tests
+// don't prove anything about whether a user writing
+// `recv.downcast::<T>()` in a `.osty` source file actually reaches
+// the vtable-compare lowering.
+func TestInterfaceDowncastFullPipeline(t *testing.T) {
+	src := `interface Printable {
+    fn show(self) -> String
+}
+
+struct Note {
+    pub msg: String,
+
+    pub fn show(self) -> String {
+        self.msg
+    }
+}
+
+fn probe(p: Printable) -> Note? {
+    p.downcast::<Note>()
+}
+
+fn main() {}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+		Privileged:    true,
+	})
+	mod, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("monomorphize: %v", monoErrs)
+	}
+	mirMod := mir.Lower(monoMod)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/pipeline_downcast.osty"}
+
+	out, err := GenerateFromMIR(mirMod, opts)
+	if err != nil {
+		if !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("GenerateFromMIR hard error (not ErrUnsupported): %v", err)
+		}
+		out, err = GenerateModule(mod, opts)
+		if err != nil {
+			t.Fatalf("GenerateModule fallback error: %v", err)
+		}
+	}
+
+	got := string(out)
+	for _, want := range []string{
+		"%osty.iface = type { ptr, ptr }",
+		"@osty.vtable.Note__Printable",
+		"extractvalue %osty.iface",
+		"icmp eq ptr",
+		"select i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("full-pipeline IR missing %q:\n%s", want, got)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Strengthens LLVM backend coverage of two Option/Error-related features that were previously 미구현 at the native backend.

### `??` (nil-coalesce)

The front end parses `??` into a `BinaryExpr{Op: token.QQ}` and the IR already carries a dedicated `CoalesceExpr` node, but the LLVM legacy-bridge path had no handler — `emitBinary` fell through to the integer/ptr cases and failed. This PR adds `emitCoalesce` in `internal/llvmgen/expr.go`, intercepted at the top of `emitBinary` so the right side is evaluated lazily per `LANG_SPEC_v0.5 §7.3`.

Lowering shape:
```
%is_nil = icmp eq ptr %left, null
br i1 %is_nil, label %coalesce.none, label %coalesce.some
coalesce.some:
  ; inner-ptr types use %left directly; others `load innerTyp, ptr %left`
  br label %coalesce.end
coalesce.none:
  ; evaluate right side (may be any side-effecting expression)
  br label %coalesce.end
coalesce.end:
  %out = phi innerTyp [ %unwrapped, %some.pred ], [ %right, %none.pred ]
```

### `downcast::<T>()`

The backend already shipped a four-instruction vtable-compare lowering in `iface_downcast.go`, but the recognizer used `lookupVtableSymForImpl` — it accepted any interface the target implemented, not necessarily the receiver's interface. That would silently emit a compile-time never-matching vtable compare when callers downcast across unrelated interfaces.

This PR adds `lookupVtableSymForDowncast(implName, ifaceName)` and threads the receiver's interface name through `staticExprSourceType`, falling back to the original coarse lookup when the source type isn't recoverable (e.g. synthesized AST nodes from the legacy bridge). The mismatch now surfaces as a stable diagnostic at generate time.

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestGenerateCoalesce` — 4 new tests (ptr-inner, boxed-int, laziness, chained right-assoc) all pass
- [x] `go test ./internal/llvmgen/ -run TestInterfaceDowncast` — existing tests still pass, new `TestInterfaceDowncastTargetMustImplementReceiverInterface` covers the cross-interface rejection
- [x] `go test ./internal/ir/...` — clean
- [x] `go build ./...` — clean
- [x] Full `./internal/llvmgen/...` suite — introduces zero new failures (12 pre-existing Raw*/GenerateModule* failures unchanged)

https://claude.ai/code/session_01GyqBVqQ9yb1uwEVDZmMVc3