### PR TITLE
feat(check): unknown field/method/variant 진단에 "did you mean" 제안 부착

### DIFF
--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1163,6 +1163,64 @@ pub fn checkVisibleBindingNames(env: CheckEnv) -> List<String> {
     out
 }
 
+/// checkFieldNamesOf returns every field declared on `owner`. Powers the
+/// "did you mean `x`?" hint attached to E0702 at unknown-field sites.
+pub fn checkFieldNamesOf(env: CheckEnv, owner: String) -> List<String> {
+    let mut out: List<String> = []
+    if owner == "" {
+        return out
+    }
+    for f in env.fields {
+        if f.owner == owner && !(checkStringListContainsLocal(out, f.name)) {
+            out.push(f.name)
+        }
+    }
+    out
+}
+
+/// checkMethodNamesOf returns every method available on `owner`, walking
+/// interface `extends` to surface inherited methods. Matches the
+/// lookup order in `checkLookupMethod` so suggestions reflect what
+/// would actually resolve.
+pub fn checkMethodNamesOf(env: CheckEnv, owner: String) -> List<String> {
+    let mut seen: List<String> = []
+    checkCollectMethodNames(env, owner, seen)
+}
+
+fn checkCollectMethodNames(env: CheckEnv, owner: String, acc: List<String>) -> List<String> {
+    if owner == "" {
+        return acc
+    }
+    let mut out = acc
+    for sig in env.fns {
+        if sig.owner == owner && !(checkStringListContainsLocal(out, sig.name)) {
+            out.push(sig.name)
+        }
+    }
+    for ext in env.interfaceExtends {
+        if ext.owner == owner {
+            let parent = tyHeadAt(env.tys, ext.ifaceTy)
+            out = checkCollectMethodNames(env, parent, out)
+        }
+    }
+    out
+}
+
+/// checkVariantNamesOf returns every variant declared on the enum
+/// `owner`. When `owner == ""` the full variant pool is returned so
+/// bare-variant sites (match arms using `Some(x)` without the `Option.`
+/// prefix) still get relevant hints.
+pub fn checkVariantNamesOf(env: CheckEnv, owner: String) -> List<String> {
+    let mut out: List<String> = []
+    for v in env.variants {
+        let matches = owner == "" || v.owner == owner
+        if matches && !(checkStringListContainsLocal(out, v.name)) {
+            out.push(v.name)
+        }
+    }
+    out
+}
+
 pub fn emptyCheckBinding() -> CheckBinding {
     CheckBinding { name: "", ty: -1, mutable: false, start: -1, end: -1 }
 }

--- a/toolchain/check_test.osty
+++ b/toolchain/check_test.osty
@@ -131,17 +131,73 @@ fn testSelfCheckerSuggestsSimilarNameForTypoIdent() {
     )
 
     testing.assert(checked.summary.errors > 0)
-    let mut sawSuggestion = false
-    for d in checked.diagnostics {
-        if d.code == "E0745" {
-            for note in d.notes {
-                if note == "hint: did you mean `length`?" {
-                    sawSuggestion = true
+    testing.assert(sawDiagnosticWithNote(checked, "E0745", "hint: did you mean `length`?"))
+}
+
+fn testSelfCheckerSuggestsSimilarNameForTypoField() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct User { name: String, age: Int }
+
+            fn labelOf(user: User) -> String {
+                user.nmae
+            }
+            """,
+    )
+
+    testing.assert(checked.summary.errors > 0)
+    testing.assert(sawDiagnosticWithNote(checked, "E0702", "hint: did you mean `name`?"))
+}
+
+fn testSelfCheckerSuggestsSimilarNameForTypoMethod() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            struct Counter {
+                value: Int
+
+                fn increment(self) -> Int { self.value + 1 }
+            }
+
+            fn bump(counter: Counter) -> Int {
+                counter.incremnt()
+            }
+            """,
+    )
+
+    testing.assert(checked.summary.errors > 0)
+    testing.assert(sawDiagnosticWithNote(checked, "E0703", "hint: did you mean `increment`?"))
+}
+
+fn testSelfCheckerSuggestsSimilarNameForTypoVariant() {
+    let checked = frontendCheckSourceStructured(
+        r"""
+            enum Color { Red, Green, Blue }
+
+            fn code(color: Color) -> Int {
+                match color {
+                    Red -> 1,
+                    Gren -> 2,
+                    Blue -> 3,
+                }
+            }
+            """,
+    )
+
+    testing.assert(checked.summary.errors > 0)
+    testing.assert(sawDiagnosticWithNote(checked, "E0728", "hint: did you mean `Green`?"))
+}
+
+fn sawDiagnosticWithNote(result: FrontCheckResult, code: String, note: String) -> Bool {
+    for d in result.diagnostics {
+        if d.code == code {
+            for n in d.notes {
+                if n == note {
+                    return true
                 }
             }
         }
     }
-    testing.assert(sawSuggestion)
+    false
 }
 
 fn testSelfCheckerReportsAssignmentReturnAndCallErrors() {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1099,7 +1099,13 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
     let methodName = fieldNode.text
     let sig = checkLookupMethod(cx.env, ownerName, methodName)
     if sig.name == "" {
-        cx.env.diagnostics.push(diagUnknownMethod(ownerName, methodName, fieldNode.start, fieldNode.end))
+        let hint = diagDidYouMean(
+            checkSuggestSimilar(checkMethodNamesOf(cx.env, ownerName), methodName),
+        )
+        cx.env.diagnostics.push(checkDiagAttachHint(
+            diagUnknownMethod(ownerName, methodName, fieldNode.start, fieldNode.end),
+            hint,
+        ))
         return elabPoisonResult(cx, callNode.start, callNode.end)
     }
 
@@ -1474,7 +1480,13 @@ fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
             let owner = tyHeadAt(cx.env.tys, recvTy)
             let fieldSig = checkLookupField(cx.env, owner, fieldName)
             if fieldSig.name == "" {
-                cx.env.diagnostics.push(diagUnknownField(owner, fieldName, node.start, node.end))
+                let hint = diagDidYouMean(
+                    checkSuggestSimilar(checkFieldNamesOf(cx.env, owner), fieldName),
+                )
+                cx.env.diagnostics.push(checkDiagAttachHint(
+                    diagUnknownField(owner, fieldName, node.start, node.end),
+                    hint,
+                ))
                 return elabPoisonResult(cx, node.start, node.end)
             }
             // Substitute owner generics.
@@ -1752,7 +1764,13 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         let fieldName = fieldNode.text
         let fieldSig = checkLookupField(cx.env, owner, fieldName)
         if fieldSig.name == "" {
-            cx.env.diagnostics.push(diagUnknownField(owner, fieldName, fieldNode.start, fieldNode.end))
+            let suggestion = diagDidYouMean(
+                checkSuggestSimilar(checkFieldNamesOf(cx.env, owner), fieldName),
+            )
+            cx.env.diagnostics.push(checkDiagAttachHint(
+                diagUnknownField(owner, fieldName, fieldNode.start, fieldNode.end),
+                suggestion,
+            ))
             continue
         }
         if stringListContains(seenNames, fieldName) {
@@ -2235,7 +2253,13 @@ fn elabVariantPattern(cx: ElabCx, node: AstNode, scrutTy: Int, mutable: Bool, re
         checkLookupVariant(cx.env, variantName)
     }
     if resolved.name == "" {
-        cx.env.diagnostics.push(diagUnknownVariant(scrutHead, variantName, node.start, node.end))
+        let suggestion = diagDidYouMean(
+            checkSuggestSimilar(checkVariantNamesOf(cx.env, scrutHead), variantName),
+        )
+        cx.env.diagnostics.push(checkDiagAttachHint(
+            diagUnknownVariant(scrutHead, variantName, node.start, node.end),
+            suggestion,
+        ))
         return corePatErr(cx.core, node.start, node.end)
     }
     let scrutArgs = tyArgsAt(tys, scrutTy)
@@ -2298,7 +2322,13 @@ fn elabStructPattern(cx: ElabCx, node: AstNode, scrutTy: Int, mutable: Bool, rec
         let fieldName = child.text
         let fieldSig = checkLookupField(cx.env, owner, fieldName)
         if fieldSig.name == "" {
-            cx.env.diagnostics.push(diagUnknownField(owner, fieldName, child.start, child.end))
+            let suggestion = diagDidYouMean(
+                checkSuggestSimilar(checkFieldNamesOf(cx.env, owner), fieldName),
+            )
+            cx.env.diagnostics.push(checkDiagAttachHint(
+                diagUnknownField(owner, fieldName, child.start, child.end),
+                suggestion,
+            ))
             continue
         }
         let substituted = if checkStringListLenHelper(typeSig.generics) == checkIntListLenHelper(ownerArgs) {


### PR DESCRIPTION
## Summary
PR #403이 E0745에만 연결했던 `hint: did you mean \`x\`?` 힌트 패턴을 나머지 unknown-* 진단으로 확장한다.

- **E0702** unknown field — `elabInferField`의 `TkNamed`, struct literal, struct pattern 3곳
- **E0703** unknown method — `elabInferMethodCall`
- **E0728** unknown variant — `elabVariantPattern`

## Details
- `check_env.osty` 에 후보 풀 수집기 3종 추가. `checkMethodNamesOf`는 `checkLookupMethod`와 동일한 interface extends 재귀를 따라 상속된 메서드까지 포함해 제안이 실제 해석 결과와 일치한다.
- 힌트 생성은 기존 `checkSuggestSimilar` + `diagDidYouMean` + `checkDiagAttachHint` 조합을 재사용. 제안이 비면 `checkDiagAttachHint`가 원본을 그대로 돌려주므로 폴백 비용 0.
- 튜플 필드(숫자 인덱스) / 비-Named 수신자 / `[]` 인덱스 경로는 후보 풀이 없으므로 기존 포맷 유지.

## Test plan
- [x] `go test ./internal/check ./internal/diag` — green
- [ ] 번들 regen 복구 이후 아래 테스트가 실제 노트 전파를 확인:
  - `testSelfCheckerSuggestsSimilarNameForTypoField` (E0702 → `name`)
  - `testSelfCheckerSuggestsSimilarNameForTypoMethod` (E0703 → `increment`)
  - `testSelfCheckerSuggestsSimilarNameForTypoVariant` (E0728 → `Green`)

https://claude.ai/code/session_012tw1M8a41FT5WhSEhwqHo9