### PR TITLE
feat(lint): self-hosted linter emits L0070 for undocumented pub decls

### DIFF
--- a/examples/selfhost-core/lint.osty
+++ b/examples/selfhost-core/lint.osty
@@ -166,7 +166,8 @@ pub fn selfLintResolvedAstSource(
     let stream = frontendLexStream(source)
     let mut report = emptySelfLintReport(frontLexDiagnosticCount(stream) + astFileErrorCount(file))
     report.resolveErrors = selfResolveDiagnosticCount(resolved)
-    selfLintAstFile(file, resolved, report)
+    report = selfLintAstFile(file, resolved, report)
+    selfLintAstCheckMissingDocs(file, stream, report)
 }
 
 pub fn selfLintDiagnosticCount(report: SelfLintReport) -> Int {
@@ -2389,4 +2390,123 @@ fn selfLintIsLowerCamel(name: String) -> Bool {
 
 fn selfLintFirstUnit(name: String) -> String {
     frontUnitAt(strings.Split(name, ""), 0)
+}
+
+/// selfLintAstCheckMissingDocs walks every decl (and every `pub` method
+/// nested under a struct or enum) and emits L0070 when the `pub` item
+/// carries no leading `///` doc comment.
+fn selfLintAstCheckMissingDocs(
+    file: AstFile,
+    stream: FrontLexStream,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintAstCheckMissingDocsDecl(file, stream, declIdx, out)
+    }
+    out
+}
+
+fn selfLintAstCheckMissingDocsDecl(
+    file: AstFile,
+    stream: FrontLexStream,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNFnDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public function has no doc comment")
+    } else if node.kind == AstNStructDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public struct has no doc comment")
+        out = selfLintAstCheckMissingDocsMembers(file, stream, node.children, out)
+    } else if node.kind == AstNEnumDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public enum has no doc comment")
+        out = selfLintAstCheckMissingDocsMembers(file, stream, node.children, out)
+    } else if node.kind == AstNInterfaceDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public interface has no doc comment")
+    } else if node.kind == AstNTypeAlias {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public type alias has no doc comment")
+    }
+    out
+}
+
+fn selfLintAstCheckMissingDocsMembers(
+    file: AstFile,
+    stream: FrontLexStream,
+    members: List<Int>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for memberIdx in members {
+        let member = selfLintAstNode(file, memberIdx)
+        if member.kind == AstNFnDecl {
+            out = selfLintAstEmitMissingDoc(out, stream, member, memberIdx, "public method has no doc comment")
+        }
+    }
+    out
+}
+
+fn selfLintAstEmitMissingDoc(
+    report: SelfLintReport,
+    stream: FrontLexStream,
+    node: AstNode,
+    idx: Int,
+    message: String,
+) -> SelfLintReport {
+    if node.flags != 1 {
+        return report
+    }
+    if selfLintDeclHasLeadingDoc(stream, node.start) {
+        return report
+    }
+    selfLintEmitAtNode(report, "L0070", message, node.text, node.start, node.start + 1, idx)
+}
+
+/// selfLintDeclHasLeadingDoc reports whether any `///` doc comment is
+/// attached to the declaration whose first parsed token lives at
+/// `startTokenIdx`. The parser consumes `pub` and `#[...]` annotations
+/// before recording a decl's start token, so the doc marker may appear on
+/// one of those preceding tokens rather than on the decl keyword itself.
+fn selfLintDeclHasLeadingDoc(stream: FrontLexStream, startTokenIdx: Int) -> Bool {
+    let count = frontLexTokenCount(stream)
+    if count <= 0 || startTokenIdx < 0 || startTokenIdx >= count {
+        return false
+    }
+    if frontLexTokenAt(stream, startTokenIdx).leadingDocLines > 0 {
+        return true
+    }
+    let mut idx = startTokenIdx - 1
+    let mut budget = 32
+    for idx >= 0 && budget > 0 {
+        let tok = frontLexTokenAt(stream, idx)
+        if !(selfLintIsDeclPrefixTokenKind(tok.kind)) {
+            return false
+        }
+        if tok.leadingDocLines > 0 {
+            return true
+        }
+        idx = idx - 1
+        budget = budget - 1
+    }
+    false
+}
+
+fn selfLintIsDeclPrefixTokenKind(kind: FrontTokenKind) -> Bool {
+    kind == FrontPub
+        || kind == FrontHash
+        || kind == FrontLBracket
+        || kind == FrontRBracket
+        || kind == FrontIdent
+        || kind == FrontAssign
+        || kind == FrontComma
+        || kind == FrontString
+        || kind == FrontRawString
+        || kind == FrontInt
+        || kind == FrontNewline
+        || kind == FrontLParen
+        || kind == FrontRParen
 }

--- a/examples/selfhost-core/lint_test.osty
+++ b/examples/selfhost-core/lint_test.osty
@@ -27,6 +27,7 @@ fn testSelfLintFindsCoreRules() {
 fn testSelfLintLeavesCleanSnippetAlone() {
     let report = selfLintSource(
         r"""
+            /// A user record.
             pub struct User { pub name: String }
             enum Color { Red, Green }
 
@@ -39,6 +40,112 @@ fn testSelfLintLeavesCleanSnippetAlone() {
 
     testing.assertEq(report.parseErrors, 0)
     testing.assertEq(selfLintDiagnosticCount(report), 0)
+}
+
+fn testSelfLintFindsMissingDocOnPubDecls() {
+    let report = selfLintSource(
+        r"""
+            pub struct User { pub name: String }
+
+            pub enum Color { Red, Green }
+
+            pub interface Reader {}
+
+            pub type UserId = Int
+
+            pub fn greet(u: User) -> String {
+                u.name
+            }
+
+            fn internal() -> Int { 1 }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 5)
+}
+
+fn testSelfLintSkipsMissingDocWhenDocCommentPresent() {
+    let report = selfLintSource(
+        r"""
+            /// A user.
+            pub struct User { pub name: String }
+
+            /// A colour.
+            pub enum Color { Red, Green }
+
+            /// A reader.
+            pub interface Reader {}
+
+            /// Stable identifier.
+            pub type UserId = Int
+
+            /// Greet the user.
+            pub fn greet(u: User) -> String {
+                u.name
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 0)
+}
+
+fn testSelfLintFindsMissingDocOnPubMembers() {
+    let report = selfLintSource(
+        r"""
+            /// A user.
+            pub struct User {
+                pub name: String,
+
+                pub fn greet(self) -> String { self.name }
+
+                fn internal(self) -> Int { 1 }
+            }
+
+            /// A colour.
+            pub enum Color {
+                Red,
+                Green,
+
+                pub fn label(self) -> String { "c" }
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 2)
+}
+
+fn testSelfLintSkipsMissingDocOnNonPubDecls() {
+    let report = selfLintSource(
+        r"""
+            struct Internal { value: Int }
+
+            enum InternalColor { Red, Green }
+
+            fn helper() -> Int { 1 }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 0)
+}
+
+fn testSelfLintHonorsAnnotationsBeforePubDecl() {
+    let report = selfLintSource(
+        r"""
+            /// Documented annotated function.
+            #[deprecated(since = "0.5")]
+            pub fn oldApi() -> Int { 1 }
+
+            #[deprecated(since = "0.5")]
+            pub fn undocumented() -> Int { 1 }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 1)
 }
 
 fn testSelfLintFindsSimplifiableSelfOperations() {

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -160,7 +160,8 @@ pub fn selfLintResolvedAstSource(
     let stream = frontendLexStream(source)
     let mut report = emptySelfLintReport(frontLexDiagnosticCount(stream) + astFileErrorCount(file))
     report.resolveErrors = selfResolveDiagnosticCount(resolved)
-    selfLintAstFile(file, resolved, report)
+    report = selfLintAstFile(file, resolved, report)
+    selfLintAstCheckMissingDocs(file, stream, report)
 }
 
 pub fn selfLintDiagnosticCount(report: SelfLintReport) -> Int {
@@ -2376,4 +2377,123 @@ fn selfLintIsLowerCamel(name: String) -> Bool {
 
 fn selfLintFirstUnit(name: String) -> String {
     frontUnitAt(strings.split(name, ""), 0)
+}
+
+/// selfLintAstCheckMissingDocs walks every decl (and every `pub` method
+/// nested under a struct or enum) and emits L0070 when the `pub` item
+/// carries no leading `///` doc comment.
+fn selfLintAstCheckMissingDocs(
+    file: AstFile,
+    stream: FrontLexStream,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintAstCheckMissingDocsDecl(file, stream, declIdx, out)
+    }
+    out
+}
+
+fn selfLintAstCheckMissingDocsDecl(
+    file: AstFile,
+    stream: FrontLexStream,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNFnDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public function has no doc comment")
+    } else if node.kind == AstNStructDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public struct has no doc comment")
+        out = selfLintAstCheckMissingDocsMembers(file, stream, node.children, out)
+    } else if node.kind == AstNEnumDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public enum has no doc comment")
+        out = selfLintAstCheckMissingDocsMembers(file, stream, node.children, out)
+    } else if node.kind == AstNInterfaceDecl {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public interface has no doc comment")
+    } else if node.kind == AstNTypeAlias {
+        out = selfLintAstEmitMissingDoc(out, stream, node, idx, "public type alias has no doc comment")
+    }
+    out
+}
+
+fn selfLintAstCheckMissingDocsMembers(
+    file: AstFile,
+    stream: FrontLexStream,
+    members: List<Int>,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for memberIdx in members {
+        let member = selfLintAstNode(file, memberIdx)
+        if member.kind == AstNFnDecl {
+            out = selfLintAstEmitMissingDoc(out, stream, member, memberIdx, "public method has no doc comment")
+        }
+    }
+    out
+}
+
+fn selfLintAstEmitMissingDoc(
+    report: SelfLintReport,
+    stream: FrontLexStream,
+    node: AstNode,
+    idx: Int,
+    message: String,
+) -> SelfLintReport {
+    if node.flags != 1 {
+        return report
+    }
+    if selfLintDeclHasLeadingDoc(stream, node.start) {
+        return report
+    }
+    selfLintEmitAtNode(report, "L0070", message, node.text, node.start, node.start + 1, idx)
+}
+
+/// selfLintDeclHasLeadingDoc reports whether any `///` doc comment is
+/// attached to the declaration whose first parsed token lives at
+/// `startTokenIdx`. The parser consumes `pub` and `#[...]` annotations
+/// before recording a decl's start token, so the doc marker may appear on
+/// one of those preceding tokens rather than on the decl keyword itself.
+fn selfLintDeclHasLeadingDoc(stream: FrontLexStream, startTokenIdx: Int) -> Bool {
+    let count = frontLexTokenCount(stream)
+    if count <= 0 || startTokenIdx < 0 || startTokenIdx >= count {
+        return false
+    }
+    if frontLexTokenAt(stream, startTokenIdx).leadingDocLines > 0 {
+        return true
+    }
+    let mut idx = startTokenIdx - 1
+    let mut budget = 32
+    for idx >= 0 && budget > 0 {
+        let tok = frontLexTokenAt(stream, idx)
+        if !(selfLintIsDeclPrefixTokenKind(tok.kind)) {
+            return false
+        }
+        if tok.leadingDocLines > 0 {
+            return true
+        }
+        idx = idx - 1
+        budget = budget - 1
+    }
+    false
+}
+
+fn selfLintIsDeclPrefixTokenKind(kind: FrontTokenKind) -> Bool {
+    kind == FrontPub
+        || kind == FrontHash
+        || kind == FrontLBracket
+        || kind == FrontRBracket
+        || kind == FrontIdent
+        || kind == FrontAssign
+        || kind == FrontComma
+        || kind == FrontString
+        || kind == FrontRawString
+        || kind == FrontInt
+        || kind == FrontNewline
+        || kind == FrontLParen
+        || kind == FrontRParen
 }

--- a/toolchain/lint_test.osty
+++ b/toolchain/lint_test.osty
@@ -27,6 +27,7 @@ fn testSelfLintFindsCoreRules() {
 fn testSelfLintLeavesCleanSnippetAlone() {
     let report = selfLintSource(
         r"""
+            /// A user record.
             pub struct User { pub name: String }
             enum Color { Red, Green }
 
@@ -39,6 +40,112 @@ fn testSelfLintLeavesCleanSnippetAlone() {
 
     testing.assertEq(report.parseErrors, 0)
     testing.assertEq(selfLintDiagnosticCount(report), 0)
+}
+
+fn testSelfLintFindsMissingDocOnPubDecls() {
+    let report = selfLintSource(
+        r"""
+            pub struct User { pub name: String }
+
+            pub enum Color { Red, Green }
+
+            pub interface Reader {}
+
+            pub type UserId = Int
+
+            pub fn greet(u: User) -> String {
+                u.name
+            }
+
+            fn internal() -> Int { 1 }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 5)
+}
+
+fn testSelfLintSkipsMissingDocWhenDocCommentPresent() {
+    let report = selfLintSource(
+        r"""
+            /// A user.
+            pub struct User { pub name: String }
+
+            /// A colour.
+            pub enum Color { Red, Green }
+
+            /// A reader.
+            pub interface Reader {}
+
+            /// Stable identifier.
+            pub type UserId = Int
+
+            /// Greet the user.
+            pub fn greet(u: User) -> String {
+                u.name
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 0)
+}
+
+fn testSelfLintFindsMissingDocOnPubMembers() {
+    let report = selfLintSource(
+        r"""
+            /// A user.
+            pub struct User {
+                pub name: String,
+
+                pub fn greet(self) -> String { self.name }
+
+                fn internal(self) -> Int { 1 }
+            }
+
+            /// A colour.
+            pub enum Color {
+                Red,
+                Green,
+
+                pub fn label(self) -> String { "c" }
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 2)
+}
+
+fn testSelfLintSkipsMissingDocOnNonPubDecls() {
+    let report = selfLintSource(
+        r"""
+            struct Internal { value: Int }
+
+            enum InternalColor { Red, Green }
+
+            fn helper() -> Int { 1 }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 0)
+}
+
+fn testSelfLintHonorsAnnotationsBeforePubDecl() {
+    let report = selfLintSource(
+        r"""
+            /// Documented annotated function.
+            #[deprecated(since = "0.5")]
+            pub fn oldApi() -> Int { 1 }
+
+            #[deprecated(since = "0.5")]
+            pub fn undocumented() -> Int { 1 }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0070"), 1)
 }
 
 fn testSelfLintFindsSimplifiableSelfOperations() {


### PR DESCRIPTION
## Summary

- Ports the Go-side `L0070 missing-doc` rule (see `internal/lint/docs.go`) to the Osty self-hosted linter so both surfaces stay in lockstep.
- Walks every top-level decl plus `pub` methods inside struct / enum bodies. Non-`pub` items, fields, and variants are skipped, matching the Go implementation.
- Resolves the doc-comment attachment by scanning backwards from `AstNode.start` through `pub` / `#[...]` prefix tokens — the parser consumes those before recording the decl's first token, so the lexer's `leadingDocLines` marker can land on the `pub`, on an annotation's `#`, etc.
- Updates `testSelfLintLeavesCleanSnippetAlone` to document its `pub struct User` so the clean-snippet invariant still holds, then adds 5 focused tests for the new rule (positive, negative, struct/enum members, non-pub skip, annotation-prefixed decls).

## Files

- `toolchain/lint.osty` + `examples/selfhost-core/lint.osty` — rule implementation (same logic, different `strings` bridge).
- `toolchain/lint_test.osty` + `examples/selfhost-core/lint_test.osty` — new test coverage.

## Test plan

- [ ] `go generate ./internal/selfhost` (regenerates the committed bridge; pre-existing codegen failures on `main` must clear before this lands end-to-end).
- [ ] `osty test ./toolchain testSelfLintFindsMissingDoc` once the bundle regenerates.
- [ ] `go test ./internal/selfhost/...` to confirm no regression in the lint adapter.

https://claude.ai/code/session_01WA4RsWcc5HJBQTyFh6tkBo