### PR TITLE
feat: selfhost parser에서 E0106 기본인자 리터럴 검증 구현

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -18880,6 +18880,9 @@ func opIsLiteralDefaultAt(p *OstyParser, idx int) bool {
 	}
 	node := astArenaNodeAt(p.arena, idx)
 	k := node.kind
+	if _, ok := k.(*AstNodeKind_AstNParen); ok {
+		return opIsLiteralDefaultAt(p, node.left)
+	}
 	if _, ok := k.(*AstNodeKind_AstNIntLit); ok {
 		return true
 	}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -18872,6 +18872,78 @@ func opAddNode(p *OstyParser, node *AstNode) int {
 	return astArenaAdd(p.arena, node)
 }
 
+// Hand-authored E0106 helpers (mirror toolchain/parser.osty opIsLiteralDefaultAt / opCheckLiteralDefault)
+// until the bootstrap regen pipeline is repaired.
+func opIsLiteralDefaultAt(p *OstyParser, idx int) bool {
+	if idx < 0 {
+		return true
+	}
+	node := astArenaNodeAt(p.arena, idx)
+	k := node.kind
+	if _, ok := k.(*AstNodeKind_AstNIntLit); ok {
+		return true
+	}
+	if _, ok := k.(*AstNodeKind_AstNFloatLit); ok {
+		return true
+	}
+	if _, ok := k.(*AstNodeKind_AstNStringLit); ok {
+		return true
+	}
+	if _, ok := k.(*AstNodeKind_AstNCharLit); ok {
+		return true
+	}
+	if _, ok := k.(*AstNodeKind_AstNByteLit); ok {
+		return true
+	}
+	if _, ok := k.(*AstNodeKind_AstNBoolLit); ok {
+		return true
+	}
+	if _, ok := k.(*AstNodeKind_AstNUnary); ok {
+		if _, ok := node.op.(*FrontTokenKind_FrontMinus); ok {
+			inner := astArenaNodeAt(p.arena, node.left)
+			if _, ok := inner.kind.(*AstNodeKind_AstNIntLit); ok {
+				return true
+			}
+			if _, ok := inner.kind.(*AstNodeKind_AstNFloatLit); ok {
+				return true
+			}
+		}
+		return false
+	}
+	if _, ok := k.(*AstNodeKind_AstNIdent); ok {
+		return node.text == "None"
+	}
+	if _, ok := k.(*AstNodeKind_AstNCall); ok {
+		callee := astArenaNodeAt(p.arena, node.left)
+		if _, ok := callee.kind.(*AstNodeKind_AstNIdent); ok {
+			if (callee.text == "Ok" || callee.text == "Err") && len(node.children) == 1 {
+				return opIsLiteralDefaultAt(p, node.children[0])
+			}
+		}
+		return false
+	}
+	if _, ok := k.(*AstNodeKind_AstNList); ok {
+		return len(node.children) == 0
+	}
+	if _, ok := k.(*AstNodeKind_AstNTuple); ok {
+		return len(node.children) == 0
+	}
+	if _, ok := k.(*AstNodeKind_AstNMap); ok {
+		return node.flags == 1
+	}
+	return false
+}
+
+func opCheckLiteralDefault(p *OstyParser, idx int) {
+	if idx < 0 {
+		return
+	}
+	if opIsLiteralDefaultAt(p, idx) {
+		return
+	}
+	opErrorFull(p, "default value must be a literal", "use a literal, `None`, `Ok(lit)`, `Err(lit)`, `[]`, `{:}`, or `()`", "spec v0.4 R18: parameter and field defaults are restricted to literal forms", "E0106")
+}
+
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6971:1
 func opSyncDecl(p *OstyParser) {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6972:5
@@ -21884,6 +21956,7 @@ func opParseFnDecl(p *OstyParser, isPub bool, anns []int) int {
 			if opEat(p, FrontTokenKind(&FrontTokenKind_FrontAssign{})) {
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8279:49
 				paramNode.left = opParseExpr(p)
+				opCheckLiteralDefault(p, paramNode.left)
 			}
 		}
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8281:18
@@ -22001,6 +22074,7 @@ func opParseStructDecl(p *OstyParser, isPub bool, anns []int) int {
 			if opEat(p, FrontTokenKind(&FrontTokenKind_FrontAssign{})) {
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8323:40
 				defIdx = opParseExpr(p)
+				opCheckLiteralDefault(p, defIdx)
 			}
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8324:13
 			fNode := emptyAstNode(AstNodeKind(&AstNodeKind_AstNField_{}))

--- a/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
+++ b/internal/selfhost/testdata/parse_snapshots/testdata_spec_negative_reject.txt
@@ -18,6 +18,7 @@ error E0009 "empty byte literal" ^[37:30-37:33]
 error E0105 "`else` must be on the same line as `}`" ^[52:6-53:1] hint="move `else` to the same line: `} else {`" note="v0.2 O2: `} else` must sit on the same line"
 error E0204 "unexpected else in expression" ^[53:5-53:9] hint="an expression starts with a literal, identifier, `(`, `[`, `if`, `match`, or a closure"
 error E0100 "expected declaration, got }" ^[56:1-56:2] hint="a declaration starts with `fn`, `struct`, `enum`, `interface`, `type`, `use`, or `let`"
+error E0106 "default value must be a literal" ^[61:30-61:31] hint="use a literal, `None`, `Ok(lit)`, `Err(lit)`, `[]`, `{:}`, or `()`" note="spec v0.4 R18: parameter and field defaults are restricted to literal forms"
 error E0200 "chained comparison operators require parentheses" ^[66:20-66:21] note="v0.2 R1: comparison operators are non-associative"
 error E0204 "unexpected :: in expression" ^[73:21-73:23] hint="an expression starts with a literal, identifier, `(`, `[`, `if`, `match`, or a closure"
 error E0203 "closure with return type requires block body" ^[78:34-78:35] hint="add `{ ... }`"

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -336,6 +336,7 @@ fn opIsLiteralDefaultAt(p: OstyParser, idx: Int) -> Bool {
     if idx < 0 { return true }
     let node = astArenaNodeAt(p.arena, idx)
     let k = node.kind
+    if k == AstNParen { return opIsLiteralDefaultAt(p, node.left) }
     if k == AstNIntLit || k == AstNFloatLit || k == AstNStringLit || k == AstNCharLit || k == AstNByteLit || k == AstNBoolLit {
         return true
     }

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -314,6 +314,56 @@ fn opError(p: OstyParser, msg: String) { opErrorFull(p, msg, "", "", "") }
 
 fn opAddNode(p: OstyParser, node: AstNode) -> Int { astArenaAdd(p.arena, node) }
 
+fn opIntListCount(xs: List<Int>) -> Int {
+    let mut c = 0
+    for x in xs {
+        let _ = x
+        c = c + 1
+    }
+    c
+}
+
+fn opIntListAt(xs: List<Int>, target: Int) -> Int {
+    let mut i = 0
+    for x in xs {
+        if i == target { return x }
+        i = i + 1
+    }
+    -1
+}
+
+fn opIsLiteralDefaultAt(p: OstyParser, idx: Int) -> Bool {
+    if idx < 0 { return true }
+    let node = astArenaNodeAt(p.arena, idx)
+    let k = node.kind
+    if k == AstNIntLit || k == AstNFloatLit || k == AstNStringLit || k == AstNCharLit || k == AstNByteLit || k == AstNBoolLit {
+        return true
+    }
+    if k == AstNUnary && node.op == FrontMinus {
+        let inner = astArenaNodeAt(p.arena, node.left)
+        if inner.kind == AstNIntLit || inner.kind == AstNFloatLit { return true }
+        return false
+    }
+    if k == AstNIdent && node.text == "None" { return true }
+    if k == AstNCall {
+        let callee = astArenaNodeAt(p.arena, node.left)
+        if callee.kind == AstNIdent && (callee.text == "Ok" || callee.text == "Err") && opIntListCount(node.children) == 1 {
+            return opIsLiteralDefaultAt(p, opIntListAt(node.children, 0))
+        }
+        return false
+    }
+    if k == AstNList && opIntListCount(node.children) == 0 { return true }
+    if k == AstNTuple && opIntListCount(node.children) == 0 { return true }
+    if k == AstNMap && node.flags == 1 { return true }
+    false
+}
+
+fn opCheckLiteralDefault(p: OstyParser, idx: Int) {
+    if idx < 0 { return }
+    if opIsLiteralDefaultAt(p, idx) { return }
+    opErrorFull(p, "default value must be a literal", "use a literal, `None`, `Ok(lit)`, `Err(lit)`, `[]`, `\{:\}`, or `()`", "spec v0.4 R18: parameter and field defaults are restricted to literal forms", "E0106")
+}
+
 // ===================================================================
 // ERROR RECOVERY
 // ===================================================================
@@ -1629,7 +1679,10 @@ fn opParseFnDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
         if opAt(p, FrontIdent) && opPeek(p).text == "self" { paramNode.text = opAdvance(p).text } else {
             paramNode.text = opExpect(p, FrontIdent).text
             if opEat(p, FrontColon) { paramNode.right = opParseType(p) }
-            if opEat(p, FrontAssign) { paramNode.left = opParseExpr(p) }
+            if opEat(p, FrontAssign) {
+                paramNode.left = opParseExpr(p)
+                opCheckLiteralDefault(p, paramNode.left)
+            }
         }
         paramNode.start = ps
         paramNode.end = p.pos
@@ -1673,7 +1726,10 @@ fn opParseStructDecl(p: OstyParser, isPub: Bool, anns: List<Int>) -> Int {
             let _ = opExpect(p, FrontColon)
             let ft = opParseType(p)
             let mut defIdx = -1
-            if opEat(p, FrontAssign) { defIdx = opParseExpr(p) }
+            if opEat(p, FrontAssign) {
+                defIdx = opParseExpr(p)
+                opCheckLiteralDefault(p, defIdx)
+            }
             let mut fNode = emptyAstNode(AstNField_)
             fNode.text = fn_
             fNode.right = ft


### PR DESCRIPTION
## Summary

`toolchain/parser.osty`에 E0106 (`CodeDefaultExprNotLiteral`) 발화 로직을 추가합니다. 지금까지 파서는 non-literal default를 받아도 통과시키고, `testdata/spec/negative/reject.osty`의 E0106 케이스(`fn connect(t: Int = compute())`) 는 어느 단계에서도 코드를 방출하지 않았습니다.

## 구현

### 허용 리터럴 형태 (spec v0.4 R18 / `LANG_SPEC_v0.5/ABRIDGED.md` L30-32)

- 기본 리터럴 (`Int` / `Float` / `String` / `Char` / `Byte` / `Bool`)
- `-` 앞에 붙은 `Int`/`Float`
- `None`
- `Ok(lit)` / `Err(lit)` — 단일 리터럴 payload 허용 (재귀)
- 빈 collection/unit: `[]`, `()`, `{:}`

그 외 표현 (함수 호출, 변수, 필드 접근, `if`/`match`, 바이너리 연산 등) 은 E0106 발화.

### 헬퍼

`toolchain/parser.osty` 에 추가:

- `opIntListCount`, `opIntListAt` — 부트스트랩 transpiler가 `.len()` / `[i]` 를 struct 필드의 `List<Int>` 에 신뢰 있게 낮추지 못해, 다른 toolchain 모듈들이 쓰는 for-loop 패턴을 따름.
- `opIsLiteralDefaultAt(p, idx) -> Bool` — AST 노드 재귀 판별.
- `opCheckLiteralDefault(p, idx)` — 필요 시 `opErrorFull(..., "E0106")` 호출.

### 호출 지점

- `opParseFnDecl` — `paramNode.left = opParseExpr(p)` 직후
- `opParseStructDecl` — 필드 default `defIdx = opParseExpr(p)` 직후

## 왜 `internal/selfhost/generated.go` 도 손으로 고쳤나

부트스트랩 regen 파이프라인이 main 에서도 이미 깨져 있어 (`p.arena.errors.pop`, `param.children.len` 등 pre-existing 실패), 동일한 헬퍼를 hand-authored Go 로 추가했습니다. LLVM 셀프호스팅이 regen 을 대체하면 자동으로 일치됩니다.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/selfhost` — 전부 통과
- [x] `UPDATE_SNAPSHOT=1 go test ./internal/selfhost -run TestParseSnapshot` — 스냅샷 재생성 후 깔끔한 1-line diff (E0106 한 줄 추가)
- [x] toolchain/*.osty 에 false-positive 없는지 수동 확인 (`Int = 0`, `Int = 80` 등 모두 literal)

https://claude.ai/code/session_017CAivvexMYwpvB37dtdV3N