### PR TITLE
fix(selfhost): println(T: ToString) + CRLF triple-string lexing

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -3299,7 +3299,11 @@ func frontStringMissingTripleLeadingNewline(units []string, start int, kind Fron
 			contentStart = _cur182 + _rhs183
 		}()
 	}
-	return frontUnitAt(units, contentStart) != "\n"
+	// Accept LF, CR, or CRLF as the leading triple-quoted newline (Windows
+	// CRLF checkouts previously tripped E0006). Mirrored from
+	// toolchain/frontend.osty pending a regen fix.
+	first := frontUnitAt(units, contentStart)
+	return first != "\n" && first != "\r"
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:1537:5
@@ -4769,19 +4773,15 @@ func frontTripleNormalization(units []string, start int, scan *FrontScanResult, 
 	contentStart := contentStartRaw
 	_ = contentStart
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2041:5
+	// Skip the leading newline after the opening `"""` / `r"""`. Treat LF,
+	// CR, and CRLF uniformly so per-line indent probing starts at actual
+	// content on Windows (CRLF) checkouts. Mirrored from
+	// toolchain/frontend.osty pending a regen fix.
+	if frontUnitAt(units, contentStart) == "\r" {
+		contentStart = contentStart + 1
+	}
 	if frontUnitAt(units, contentStart) == "\n" {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2042:9
-		func() {
-			var _cur356 int = contentStart
-			var _rhs357 int = 1
-			if _rhs357 > 0 && _cur356 > math.MaxInt-_rhs357 {
-				panic("integer overflow")
-			}
-			if _rhs357 < 0 && _cur356 < math.MinInt-_rhs357 {
-				panic("integer overflow")
-			}
-			contentStart = _cur356 + _rhs357
-		}()
+		contentStart = contentStart + 1
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2044:5
 	closeStart := func() int {
@@ -6200,7 +6200,9 @@ func frontStringLikeScan(units []string, start int, unitCount int, kind FrontTok
 				contentStart = _cur500 + _rhs501
 			}()
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2561:13
-			if frontUnitAt(units, contentStart) != "\n" {
+			// Accept LF, CR, or CRLF as the leading newline. Mirrored
+			// from toolchain/frontend.osty pending a regen fix.
+			if first := frontUnitAt(units, contentStart); first != "\n" && first != "\r" {
 				// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2562:17
 				func() {
 					var _cur502 int = errors
@@ -6273,7 +6275,8 @@ func frontStringLikeScan(units []string, start int, unitCount int, kind FrontTok
 			contentStart = _cur510 + _rhs511
 		}()
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2575:9
-		if frontUnitAt(units, contentStart) != "\n" {
+		// Accept LF, CR, or CRLF. Mirrored from toolchain/frontend.osty.
+		if first := frontUnitAt(units, contentStart); first != "\n" && first != "\r" {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2576:13
 			func() {
 				var _cur512 int = errors
@@ -35234,6 +35237,15 @@ func elabCallArgs(cx *ElabCx, solver *Solver, sig *CheckFnSig, freshs []int, arg
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15270:1
+// elabIsToStringFormatter returns true when callee is one of the prelude
+// ToString-consuming formatters (Spec §17): print, println, eprint, eprintln.
+// These accept any `T: ToString`, so call sites must not be type-checked
+// against the String param the prelude signature advertises for fn-value
+// interop. Manually mirrored from toolchain/elab.osty pending a regen fix.
+func elabIsToStringFormatter(name string) bool {
+	return name == "print" || name == "println" || name == "eprint" || name == "eprintln"
+}
+
 func elabCallArgsMonomorphic(cx *ElabCx, callee string, paramTys []int, argIdxs []int, start int, end int) []int {
 	wantCount := checkIntListLenHelper(paramTys)
 	gotCount := checkIntListLenHelper(argIdxs)
@@ -35243,10 +35255,11 @@ func elabCallArgsMonomorphic(cx *ElabCx, callee string, paramTys []int, argIdxs 
 			return struct{}{}
 		}()
 	}
+	skipParamCheck := elabIsToStringFormatter(callee)
 	var coreArgs []int = make([]int, 0, 1)
 	i := 0
 	for _, argIdx := range argIdxs {
-		if i >= wantCount {
+		if i >= wantCount || skipParamCheck {
 			r := elabInfer(cx, argIdx)
 			coreArgs = append(coreArgs, r.node)
 			i++

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1242,6 +1242,15 @@ fn elabCallArgs(
     coreArgs
 }
 
+/// elabIsToStringFormatter returns true when `callee` is one of the
+/// prelude ToString-consuming formatters (Spec §17): `print`, `println`,
+/// `eprint`, `eprintln`. These accept any `T: ToString` rather than a
+/// fixed `String`, so call sites must not be type-checked against the
+/// String param the prelude signature advertises for fn-value interop.
+fn elabIsToStringFormatter(name: String) -> Bool {
+    name == "print" || name == "println" || name == "eprint" || name == "eprintln"
+}
+
 fn elabCallArgsMonomorphic(
     cx: ElabCx,
     callee: String,
@@ -1255,10 +1264,11 @@ fn elabCallArgsMonomorphic(
     if wantCount != gotCount {
         cx.env.diagnostics.push(diagArgCount(callee, wantCount, gotCount, start, end))
     }
+    let skipParamCheck = elabIsToStringFormatter(callee)
     let mut coreArgs: List<Int> = []
     let mut i = 0
     for argIdx in argIdxs {
-        if i >= wantCount {
+        if i >= wantCount || skipParamCheck {
             let r = elabInfer(cx, argIdx)
             coreArgs.push(r.node)
             i = i + 1

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -1137,7 +1137,13 @@ pub fn frontStringMissingTripleLeadingNewline(
     if kind == FrontRawString {
         contentStart = start + 4
     }
-    frontUnitAt(units, contentStart) != "\n"
+    let first = frontUnitAt(units, contentStart)
+    // Accept any of the canonical line terminators: LF (Unix), CR (Mac
+    // classic), or CRLF (Windows). A Windows-checked-out source file
+    // carries `\r\n` between the opening `"""` / `r"""` and the first
+    // content line; the older `!= "\n"` check flagged every such file as
+    // E0006 (see toolchain/docgen.osty:1641).
+    first != "\n" && first != "\r"
 }
 
 pub fn frontStringScanHitNewline(
@@ -1644,6 +1650,12 @@ pub fn frontTripleNormalization(
     }
     let contentStartRaw = frontStringContentStart(units, start, kind, true)
     let mut contentStart = contentStartRaw
+    // Skip the leading newline after the opening `"""` / `r"""`. Treat
+    // LF, CR, and CRLF uniformly so that the per-line indent probe
+    // starts at actual content on Windows (CRLF) checkouts.
+    if frontUnitAt(units, contentStart) == "\r" {
+        contentStart = contentStart + 1
+    }
     if frontUnitAt(units, contentStart) == "\n" {
         contentStart = contentStart + 1
     }
@@ -2164,7 +2176,11 @@ pub fn frontStringLikeScan(
             triple = true
             consumed = 4
             contentStart = start + 4
-            if frontUnitAt(units, contentStart) != "\n" {
+            let first = frontUnitAt(units, contentStart)
+            // Accept LF, CR, or CRLF as the mandatory leading newline
+            // after `r"""`. See toolchain/frontend.osty's comment on
+            // frontStringMissingTripleLeadingNewline.
+            if first != "\n" && first != "\r" {
                 errors = errors + 1
             }
         }
@@ -2178,7 +2194,8 @@ pub fn frontStringLikeScan(
         triple = true
         consumed = 3
         contentStart = start + 3
-        if frontUnitAt(units, contentStart) != "\n" {
+        let first = frontUnitAt(units, contentStart)
+        if first != "\n" && first != "\r" {
             errors = errors + 1
         }
     }


### PR DESCRIPTION
## Summary

Fix two concrete self-hosting regressions surfaced by running the selfhost pipeline directly on a Windows CRLF checkout:

- **`println(42)` rejected by embedded checker**: the prelude signatures in `toolchain/check_env.osty` declare `print`/`println`/`eprint`/`eprintln` as `(s: String)` for fn-value interop (arity erasure), but per [Spec §17](LANG_SPEC_v0.5/17-display-and-format-protocol.md) these formatters accept any `T: ToString`. A freshly-built `osty gen --backend=llvm` of `fn main() { println(42) }` died with `E0700 expected String, found UntypedInt`.
- **Windows CRLF raw/normal triple strings failed to lex**: `frontStringMissingTripleLeadingNewline`, `frontStringLikeScan` (two sites), and `frontTripleNormalization` only accepted `\n` as the mandatory leading newline after `"""` / `r"""`, so every CRLF-checked-out triple string emitted `E0006 invalid triple-quoted string` plus cascading `E0001 unterminated string literal`. [toolchain/docgen.osty:1642](toolchain/docgen.osty)'s stylesheet was the visible casualty, but the bug affected every Windows developer opening a triple-quoted string.

## What changed

- [toolchain/elab.osty](toolchain/elab.osty): add `elabIsToStringFormatter` whitelist in `elabCallArgsMonomorphic` so formatter call sites skip the `String` `elabCheck` and just `elabInfer` the arg. Fn-value / arity-erasure users are unaffected because the sig stays `(String) -> Unit`.
- [toolchain/frontend.osty](toolchain/frontend.osty): accept LF, CR, and CRLF uniformly at three scan sites (`frontStringMissingTripleLeadingNewline`, both triple branches of `frontStringLikeScan`) and in `frontTripleNormalization`'s leading-newline skip.
- [internal/selfhost/generated.go](internal/selfhost/generated.go): mirror both fixes. `go generate ./internal/selfhost/...` currently produces non-compiling Go (`s.chars undefined`, Result `?` nil compare) and is rolled back by the build gate, so the generated bridge must be hand-edited until the bootstrap-gen transpiler itself is fixed. Each mirrored edit carries a `// Mirrored from toolchain/... pending a regen fix` comment.

## Why not regen

`go generate ./internal/selfhost/...` attempts to run `cmd/osty-bootstrap-gen` and fails:

```
internal/selfhost/generated.go:176:11: s.chars undefined (type string has no field or method chars)
internal/selfhost/generated.go:499:13: invalid operation: _q12 == nil (mismatched types Result[*SemVersion, string] and untyped nil)
...
generated selfhost code does not compile; refused to install broken code
```

The build gate restores the pre-existing `generated.go` on failure, so Osty-source-only edits can't propagate. Fixing bootstrap-gen is a larger separate task — tracked as out-of-scope here so the two concrete regressions land cleanly.

## Test plan

- [x] `osty gen --backend=llvm` on `fn main() { println(42) }` → exit 0, emits `%ld\n` + `i64 42`
- [x] Mixed smoke (`println(Int)`, `println(Float)`, `println(Bool)`, `println(String)`, `print(String)`) → check passes, no diagnostics
- [x] Negative case `greet(42)` on a non-formatter `fn greet(name: String)` → still rejected with E0700 (whitelist scoped)
- [x] Minimal CRLF raw-triple fixture → check passes (previously E0006 / E0001)
- [x] `osty check toolchain/docgen.osty` → E0006 at :1642 cleared
- [x] `go test ./internal/llvmgen -run 'TestGenerate(ModuleInterfaceVtableEmitted|SafepointKeepsImmutableManagedLocalsAndAggregateFields|ManagedAggregateListsTraceNestedRoots|ModulePtrBackedListToSetAndBoolPrint)'` → pass
- [x] `TestProbeWholeToolchainMerged` → unchanged first wall (`runtime.golegacy.astbridge`)
- [x] `TestProbeNativeToolchainMerged` → unchanged first wall (`LLVM015 method_call_field`)
- [x] `go test ./internal/lexer` → pass

## Out of scope / known pre-existing failures

- `internal/check/native_checker_exec_test.go` — Windows `.exe`-suffix issue with managed checker path. Unrelated, pre-existing.
- `internal/selfhost/TestParseSnapshot/*` — parse snapshot CRLF drift on Windows. Unrelated, pre-existing.
- Bootstrap-gen regen brokenness (`s.chars`, Result `?` nil compare) — gates Osty-source-only edits from propagating; separate work.
- Native probe `LLVM015 method_call_field` first wall — backend coverage follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)