### PR TITLE
fix(selfhost): resolve bare enum variants in expression position

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -33395,12 +33395,31 @@ func elabInferIdent(cx *ElabCx, node *AstNode) *ElabResult {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14379:9
 		return &ElabResult{node: coreIdx, ty: fnTy}
 	}
+	// Try enum variant in expression position. Payload-free variants
+	// (FrontQDot, BoMul, AstNBlock, etc.) and generic enum tags like
+	// `None` resolve to `Enum<fresh>`. Payload-ful variant calls
+	// (`Some(x)`) are handled by elabInferCall. Mirrored from
+	// toolchain/elab.osty pending a regen fix.
+	if variant := checkLookupVariant(cx.env, node.text); variant.name != "" && checkIntListLenHelper(variant.fieldTys) == 0 {
+		variantTy := elabVariantOwnerType(cx, variant)
+		coreIdx := coreIdent(cx.core, node.text, IdentKind(&IdentKind_IkVariant{}), variantTy, node.start, node.end)
+		return &ElabResult{node: coreIdx, ty: variantTy}
+	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14382:5
 	func() struct{} {
 		cx.env.diagnostics = append(cx.env.diagnostics, diagUnknownName(node.text, node.start, node.end))
 		return struct{}{}
 	}()
 	return elabPoisonResult(cx, node.start, node.end)
+}
+
+// elabVariantOwnerType — mirror of toolchain/elab.osty.
+func elabVariantOwnerType(cx *ElabCx, variant *CheckVariantSig) int {
+	args := make([]int, 0, len(variant.generics))
+	for _, g := range variant.generics {
+		args = append(args, freshTyVar(cx.env.tys, variant.owner, g))
+	}
+	return tyNamed(cx.env.tys, variant.owner, args)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14387:1

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -259,6 +259,18 @@ fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
         let coreIdx = coreIdent(cx.core, node.text, IkFn, fnTy, node.start, node.end)
         return ElabResult { node: coreIdx, ty: fnTy }
     }
+    // Try enum variant in expression position. The Go-side resolver
+    // registers every variant as a top-level SymVariant, so toolchain
+    // code freely writes bare `FrontQDot` / `BoMul` / `AstNBlock` for
+    // the `Enum.Variant` value. Covers payload-free variants (the
+    // dominant usage in toolchain). Payload-ful variants as call
+    // targets (`Some(x)`) go through elabInferCall.
+    let variant = checkLookupVariant(cx.env, node.text)
+    if variant.name != "" && checkIntListLenHelper(variant.fieldTys) == 0 {
+        let variantTy = elabVariantOwnerType(cx, variant)
+        let coreIdx = coreIdent(cx.core, node.text, IkVariant, variantTy, node.start, node.end)
+        return ElabResult { node: coreIdx, ty: variantTy }
+    }
     // Fall through — unknown name.
     let suggestion = checkSuggestSimilar(
         checkVisibleBindingNames(cx.env),
@@ -270,6 +282,19 @@ fn elabInferIdent(cx: ElabCx, node: AstNode) -> ElabResult {
     )
     cx.env.diagnostics.push(diag)
     elabPoisonResult(cx, node.start, node.end)
+}
+
+/// elabVariantOwnerType builds the enum type `Owner<fresh args>` for a
+/// bare variant reference. For non-generic enums (`FrontTokenKind`) the
+/// result is `tyNamed(owner, [])`; for generic enums (`Option<T>`) we
+/// allocate fresh type variables per enum parameter so downstream
+/// unification can solve them via context.
+fn elabVariantOwnerType(cx: ElabCx, variant: CheckVariantSig) -> Int {
+    let mut args: List<Int> = []
+    for g in variant.generics {
+        args.push(freshTyVar(cx.env.tys, variant.owner, g))
+    }
+    tyNamed(cx.env.tys, variant.owner, args)
 }
 
 /// fnSigToTy builds an `fn(params) -> ret` type from a CheckFnSig.


### PR DESCRIPTION
## Summary

Self-host checker was emitting `E0745 cannot find 'FrontQDot' in this scope` for bare variant references in `toolchain/*.osty` — **3718 of the 6308 aggregate `osty check toolchain` errors (58.9%)**.

Go-side [internal/resolve/resolve.go:424-428](internal/resolve/resolve.go:424) already registers every variant as a top-level `SymVariant`, so toolchain code like:

```osty
if tok.kind == FrontQDot { ... }
if tok == FrontStar { return BoMul }
```

resolves through parse/resolve but then dies in the selfhost checker, because `elabInferIdent` in [toolchain/elab.osty:241](toolchain/elab.osty:241) only looked up locals and fns before falling through to the `diagUnknownName` exit.

## What changed

Extend `elabInferIdent` with a fall-through to `checkLookupVariant`, materializing `Enum<fresh args>` per enum generic:

- `FrontTokenKind` tag variants (`FrontQDot`, `FrontLBrace`, …) → `tyNamed("FrontTokenKind", [])`
- `Option`'s `None` → `tyNamed("Option", [fresh T])`

Covers **payload-free** variants only (the dominant toolchain usage — token kinds, AST node kinds, diag family enums, ident kinds). Payload-ful variant calls (`Some(x)`, `Ok(x)`) already route through `elabInferCall` and are untouched.

Adds a small `elabVariantOwnerType` helper so the fresh-type-var allocation for generic enums stays isolated.

## Why the generated.go edit?

Same reason as [#421](https://github.com/choiceoh/osty/pull/421): `go generate ./internal/selfhost/...` currently fails with `s.chars undefined` + Result `?` nil compare, and the build gate rolls back to the previous `generated.go` on failure. So `toolchain/*.osty` edits must be manually mirrored in `internal/selfhost/generated.go` until the bootstrap-gen transpiler itself is fixed. Each mirrored hunk carries a `// Mirrored from toolchain/elab.osty pending a regen fix` comment.

## Measured impact

Histogram taken via `selfhost.CheckPackageStructured` over the `toolchain/` directory:

| | Before | After | Δ |
|---|---|---|---|
| total errors | 6308 | **4310** | **−1998 (−31.7%)** |
| accepted | 19364 / 19451 | **20878 / 20969** | **+1514** |
| E0745 | 3718 | **1711** | **−2007 (−54%)** |

Post-fix E0745 tail is dominated by the other two root causes the histogram surfaced:

- module aliases (`strings` 310, `astbridge` 289, `ciStrings`/`pkgStrings`/`llvmStrings` ≈60) — `use go "..." as X` not registered on the selfhost side
- for-in / local bindings (`item` 116, `idx` 94, `child` 59, `x` 28, …) — traced to `elabForIterableElemTy` failing because checker-side parameter types like `xs: List<Int>` appear to arrive as `List` without generic args

Both are separate structural fixes — out of scope here.

## Test plan

- [x] `osty gen --backend=llvm` on `fn main() { println(42) }` → exit 0, emits `i64 42` (no regression from #421)
- [x] `go test ./internal/llvmgen -run 'TestGenerate(ModuleInterfaceVtableEmitted|SafepointKeepsImmutableManagedLocalsAndAggregateFields|ManagedAggregateListsTraceNestedRoots|ModulePtrBackedListToSetAndBoolPrint)'` → pass
- [x] `TestProbeWholeToolchainMerged` → unchanged first wall (`runtime.golegacy.astbridge`)
- [x] `TestProbeNativeToolchainMerged` → unchanged first wall (`LLVM015 method_call_field`)
- [x] `go test ./internal/lexer` → pass
- [x] Histogram re-measure confirms the −1998 / −2007 numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)