### PR TITLE
test(llvmgen): per-file parity lock for 9 CLEAN 소형 toolchain 모듈

### DIFF
--- a/internal/llvmgen/small_tail_probe_test.go
+++ b/internal/llvmgen/small_tail_probe_test.go
@@ -3,60 +3,71 @@ package llvmgen
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/osty/osty/internal/parser"
 )
 
-// TestProbeSmallTailLower records the current lowering state of the
-// small-tail toolchain modules. pkg_policy.osty is expected to lower
-// cleanly after the std.strings shim + bare None/Some support; the
-// other two still hit broader walls (LLVM014 Iterable for-in, LLVM011
-// struct-param) tracked separately.
+// TestProbeSmallTailLower is the regression ratchet for per-file LLVM
+// parity on the toolchain/*.osty modules. TestSweepToolchainLargeTail
+// is the info-only discovery probe; this test fails loudly if a
+// previously-clean module starts re-hitting a wall or if a tracked
+// wall moves off its expected code. Keep the clean set in sync with
+// the sweep's CLEAN count.
+//
+// wantWall is the expected wallCode() result for each module; "" means
+// CLEAN. When a walled entry actually lowers cleanly, the test logs a
+// promotion hint instead of failing.
 func TestProbeSmallTailLower(t *testing.T) {
 	root, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatalf("abs root: %v", err)
 	}
 	cases := []struct {
-		rel                string
-		expectClean        bool
-		allowedWallSnippet string // err must contain this iff not clean
+		rel      string
+		wantWall string
 	}{
-		{"toolchain/pkg_policy.osty", true, ""},
-		{"toolchain/profile_flags.osty", true, ""},
-		{"toolchain/diagnostic.osty", false, "LLVM011"},
+		{"toolchain/airepair_flags.osty", ""},
+		{"toolchain/diag_examples.osty", ""},
+		{"toolchain/diag_policy.osty", ""},
+		{"toolchain/diagnostic.osty", "LLVM011"},
+		{"toolchain/manifest_features.osty", ""},
+		{"toolchain/package_entry.osty", ""},
+		{"toolchain/pkg_policy.osty", ""},
+		{"toolchain/profile_flags.osty", ""},
+		{"toolchain/scaffold_policy.osty", ""},
+		{"toolchain/semver.osty", ""},
+		{"toolchain/test_runner.osty", ""},
+		{"toolchain/ty.osty", ""},
 	}
 	for _, tc := range cases {
-		path := filepath.Join(root, tc.rel)
-		src, err := os.ReadFile(path)
-		if err != nil {
-			t.Errorf("%s: read: %v", tc.rel, err)
-			continue
-		}
-		file, diags := parser.ParseDiagnostics(src)
-		if file == nil {
-			t.Errorf("%s: parse nil (%d diags)", tc.rel, len(diags))
-			continue
-		}
-		_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
-		if tc.expectClean {
+		tc := tc
+		t.Run(tc.rel, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(root, tc.rel)
+			src, err := os.ReadFile(path)
 			if err != nil {
-				t.Errorf("%s: expected clean lowering, got: %v", tc.rel, err)
-			} else {
-				t.Logf("%s: lowered cleanly", tc.rel)
+				t.Fatalf("read: %v", err)
 			}
-			continue
-		}
-		if err == nil {
-			t.Logf("%s: lowered cleanly (was expected to hit %s — revisit probe)", tc.rel, tc.allowedWallSnippet)
-			continue
-		}
-		if !strings.Contains(err.Error(), tc.allowedWallSnippet) {
-			t.Errorf("%s: unexpected wall (expected %s): %v", tc.rel, tc.allowedWallSnippet, err)
-		} else {
-			t.Logf("%s: still on expected wall %s: %v", tc.rel, tc.allowedWallSnippet, err)
-		}
+			file, diags := parser.ParseDiagnostics(src)
+			if file == nil {
+				t.Fatalf("parse nil (%d diags)", len(diags))
+			}
+			_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: path})
+			got := ""
+			if err != nil {
+				got = wallCode(err.Error())
+			}
+			switch {
+			case got == tc.wantWall:
+				t.Logf("%s: %s", tc.rel, formatWall(err))
+			case tc.wantWall == "":
+				t.Fatalf("expected clean lowering, got %s: %v", got, err)
+			case got == "":
+				t.Logf("%s: lowered cleanly (was expected %s — promote to clean)", tc.rel, tc.wantWall)
+			default:
+				t.Fatalf("unexpected wall (want %s, got %s): %v", tc.wantWall, got, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 요약

`TestProbeSmallTailLower`가 기존에 추적하던 3개 모듈(pkg_policy / profile_flags / diagnostic)을, 현 시점 single-file LLVM 경로에서 CLEAN 상태인 소형 toolchain 모듈 **9개**를 추가해 총 12개로 확장한다. CLEAN 상태 회귀에 대한 regression ratchet이 보강된다.

## 무엇이 / 왜

`TestSweepToolchainLargeTail`은 info-only discovery probe (`never fails`)이므로 이전에 CLEAN이던 모듈이 다시 벽에 부딪혀도 CI가 잡아내지 못한다. Per-file probe가 그 안전망 역할을 맡아야 하지만, 최근 CLEAN으로 넘어온 소형 모듈들이 반영되지 않아 커버리지 공백이 컸다.

추가된 9개 (알파벳 순):
- `airepair_flags.osty`
- `diag_examples.osty`
- `diag_policy.osty`
- `manifest_features.osty`
- `package_entry.osty`
- `scaffold_policy.osty`
- `semver.osty`
- `test_runner.osty`
- `ty.osty`

walled tail `diagnostic.osty` (LLVM011)는 그대로 유지.

## 리팩터 (리뷰 피드백 반영)

- `expectClean` bool + `allowedWallSnippet` string 두 필드를 단일 `wantWall`(`""` = CLEAN)로 단순화.
- `large_tail_sweep_test.go`의 `wallCode()` / `formatWall()` 헬퍼 재사용 — 원시 `strings.Contains` 드리프트 제거.
- `t.Run(...)` + `t.Parallel()`로 케이스 병렬화: **4.78s → 0.62s** (~7.6×).
- "라인 수 정렬" 주석 대신 알파벳 순으로 self-maintaining.

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestProbeSmallTailLower -v` — 12 subtests PASS (0.62s)
- [x] `go vet ./internal/llvmgen/` — 경고 없음
- [x] `go test ./internal/llvmgen/ -run TestSweepToolchainLargeTail -v` — CLEAN 11개 기준과 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)