### PR TITLE
fix(selfhost): package import 경로도 Poison 센티넬 클램프

### DIFF
--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -493,7 +493,7 @@ func selfhostTypeNameToTy(env *CheckEnv, typeName string) int {
 	if typeName == "()" {
 		return tUnit(env.tys)
 	}
-	if typeName == "Invalid" {
+	if typeName == "Invalid" || typeName == "Poison" {
 		return tErr(env.tys)
 	}
 	return tyFromString(env.tys, typeName)


### PR DESCRIPTION
## Summary

- [PR #391 (0b714ae)](https://github.com/choiceoh/osty/pull/391) 후속. `selfhostTypeNameToTy`도 `"Invalid"`뿐 아니라 `"Poison"`을 `tErr`로 클램프하도록 정리
- `parseSelfhostTypeName`(네이티브 Go 체커)의 직접 대응쌍인데 0b714ae에서 빠져 있던 비대칭 처리 보완
- 런타임 동작 변화 없음 (현재 `tyFromString`의 "Poison" early-return이 이미 같은 효과를 내지만, 셀프호스트 바이너리 drift 대비 명시적 경계 방어선 추가)

## 배경

0b714ae가 고친 두 경계 중 `parseSelfhostTypeName`의 직접 쌍인 `selfhostTypeNameToTy`는 남아 있었습니다. 이 함수는 외부 패키지에서 import한 타입 이름을 importer의 TyArena로 materialize합니다:

```go
// before
if typeName == "Invalid" {
    return tErr(env.tys)
}
return tyFromString(env.tys, typeName)

// after
if typeName == "Invalid" || typeName == "Poison" {
    return tErr(env.tys)
}
return tyFromString(env.tys, typeName)
```

## 왜 클램프해야 하나

- **대칭성**: `parseSelfhostTypeName`은 `case "", "Invalid", "Poison":` → `types.ErrorType`으로 이미 클램프. 두 함수가 같은 boundary를 다루므로 동일하게 처리
- **Drift 방어**: `tyFromString`의 "Poison" early-return이 미래에 바뀌면 `tyNamed{Poison}` bogus alias가 합성될 수 있음 (0b714ae가 parseSelfhostTypeName에서 막은 동일 잠재 버그)
- **의미론**: 교차 패키지 경계에서 session-local sentinel인 Poison이 generic bad-type(Err)으로 decay하는 편이 깔끔 — consumer 체커는 producer의 hard-error/soft-error 구분을 알 필요 없음

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/check/... ./internal/selfhost/...` 전부 통과
- [x] 기존 테스트에 cross-bridge Poison 의존 없음 확인 (grep 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)