### PR TITLE
fix(cli): lint exclude 단일 파일 경로에서 silent no-op 안내

### DIFF
--- a/cmd/osty/lint_exclude_test.go
+++ b/cmd/osty/lint_exclude_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeLintExcludeManifest scaffolds a project dir with a `[lint]
+// exclude = ["gen/**"]` osty.toml and returns the dir. Used by both
+// single-file lint exclude tests so their manifest shape stays in sync.
+func writeLintExcludeManifest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := strings.Join([]string{
+		`[package]`,
+		`name = "demo"`,
+		`version = "0.1.0"`,
+		`edition = "0.3"`,
+		``,
+		`[lint]`,
+		`exclude = ["gen/**"]`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}
+
+func TestLintSingleFileExcludeAnnouncesSkip(t *testing.T) {
+	t.Parallel()
+	dir := writeLintExcludeManifest(t)
+	genDir := filepath.Join(dir, "gen")
+	if err := os.MkdirAll(genDir, 0o755); err != nil {
+		t.Fatalf("mkdir gen: %v", err)
+	}
+	excluded := filepath.Join(genDir, "noisy.osty")
+	if err := os.WriteFile(excluded, []byte("fn main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write excluded: %v", err)
+	}
+
+	got := runOstyCLI(t, "lint", excluded)
+	if got.exit != 0 {
+		t.Fatalf("osty lint exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "skipping") {
+		t.Fatalf("stderr = %q, want a skip announcement so the exit 0 isn't confused with lint success", got.stderr)
+	}
+	if !strings.Contains(got.stderr, excluded) {
+		t.Fatalf("stderr = %q, want skip message to name the excluded file %s", got.stderr, excluded)
+	}
+	if !strings.Contains(got.stderr, `"gen/**"`) {
+		t.Fatalf("stderr = %q, want skip message to quote the matching exclude pattern", got.stderr)
+	}
+}
+
+func TestLintSingleFileNonExcludedStaysQuiet(t *testing.T) {
+	t.Parallel()
+	dir := writeLintExcludeManifest(t)
+	included := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(included, []byte("fn main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write included: %v", err)
+	}
+
+	got := runOstyCLI(t, "lint", included)
+	if got.exit != 0 {
+		t.Fatalf("osty lint exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "skipping") {
+		t.Fatalf("stderr = %q, did not want skip announcement for a non-excluded file", got.stderr)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -502,9 +502,13 @@ func main() {
 		// Respect [lint] exclude before parsing. loadLintConfigWithBase
 		// looks upward from the file for `osty.toml`, returning the
 		// config + the manifest's directory so globs can be resolved
-		// relative to the project root.
-		if cfg, base, ok := loadLintConfigWithBase(path); ok && cfg.ShouldExclude(path, base) {
-			return
+		// relative to the project root. Announce the skip so exit 0
+		// isn't read as "lint clean".
+		if cfg, base, ok := loadLintConfigWithBase(path); ok {
+			if pat, matched := cfg.MatchingExclude(path, base); matched {
+				fmt.Fprintf(os.Stderr, "osty lint: skipping %s ([lint] exclude matches %q)\n", path, pat)
+				return
+			}
 		}
 		parsed := parser.ParseDetailed(src)
 		file, parseDiags := parsed.File, parsed.Diagnostics

--- a/internal/lint/config.go
+++ b/internal/lint/config.go
@@ -46,13 +46,14 @@ type Config struct {
 	Exclude []string
 }
 
-// ShouldExclude reports whether `path` matches any Exclude glob. Call
-// sites should use this to skip files before parsing. `base` is the
-// directory of the osty.toml that produced this Config; `path` may be
-// absolute or relative to CWD.
-func (c Config) ShouldExclude(path, base string) bool {
+// MatchingExclude reports whether `path` matches any Exclude glob and
+// returns the matched pattern so callers can surface it in user-facing
+// messages. `base` is the directory of the osty.toml that produced this
+// Config; `path` may be absolute or relative to CWD. Returns ("", false)
+// when no pattern matches.
+func (c Config) MatchingExclude(path, base string) (string, bool) {
 	if len(c.Exclude) == 0 {
-		return false
+		return "", false
 	}
 	rel := path
 	if base != "" {
@@ -65,10 +66,10 @@ func (c Config) ShouldExclude(path, base string) bool {
 	rel = filepath.ToSlash(rel)
 	for _, pat := range c.Exclude {
 		if matchGlob(pat, rel) {
-			return true
+			return pat, true
 		}
 	}
-	return false
+	return "", false
 }
 
 // matchGlob implements filepath.Match-style globbing with the


### PR DESCRIPTION
## 배경

`osty lint FILE` 이 `osty.toml` 의 `[lint] exclude` glob 에 걸린 경로를 받으면
아무 출력 없이 exit 0 으로 끝났음. 사용자 입장에서는 "lint 가 통과했다"로
보이지만 실제로는 **스킵**된 것이라 상태 구분 불가 — 이 PR 이전 `main.go:506`:

```go
if cfg, base, ok := loadLintConfigWithBase(path); ok && cfg.ShouldExclude(path, base) {
    return // silent
}
```

## 변경

- `internal/lint/Config.MatchingExclude(path, base) (string, bool)` 추가.
  매치된 글롭 패턴을 반환해서 진단 메시지에 실을 수 있게 함. 기존
  `ShouldExclude` 는 호출자가 0개가 되어 제거.
- CLI 단일 파일 `lint` 분기에서 매치 시 stderr 안내 후 return:

    ```
    osty lint: skipping gen/noisy.osty ([lint] exclude matches "gen/**")
    ```

  `build.go:429` 의 `osty build: skipping %s (feature %q not enabled)` 와
  동일한 스킵 메시지 포맷.

## 테스트

- `cmd/osty/lint_exclude_test.go`:
  - `TestLintSingleFileExcludeAnnouncesSkip` — excluded 파일에서 skip
    메시지 + 파일경로 + 매치 패턴 3요소 모두 stderr 에 노출되는지
  - `TestLintSingleFileNonExcludedStaysQuiet` — 정상 파일은 skip 메시지
    출력 금지
  - 공통 manifest scaffolding 은 `writeLintExcludeManifest` 헬퍼로 추출.
    두 테스트 모두 `t.Parallel()` — 전체 런타임 ~25s → ~2s.

## Scope 노트

- 이 PR 은 **단일 파일 모드** 의 silent no-op 만 고침.
- 디렉토리 모드 (`osty lint DIR`) 는 `internal/lint.Package` 경로에서
  `Exclude` 글롭이 **아예 적용되지 않음** — 별개 이슈라 이 PR 의
  scope 밖으로 둠. 후속 작업 필요.