### PR TITLE
[codex] add local dev workflow defaults

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+PATH_add .bin
+PATH_add .osty/bin
+
+export GOBIN="$PWD/.bin"
+export OSTY_ROOT="$PWD"
+
+if [[ -x "$PWD/.osty/bin/osty-native-checker" ]]; then
+    export OSTY_NATIVE_CHECKER_BIN="$PWD/.osty/bin/osty-native-checker"
+else
+    export OSTY_NATIVE_CHECKER_BIN="$PWD/scripts/osty-native-checker"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Osty build/test output
+.bin/
 .osty/
 **/.osty/
+.profiles/
+.direnv/
 
 # VS Code extension dependencies and packages
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repo Defaults
+
+- Prefer `just` recipes for common loops instead of ad-hoc shell commands.
+- Fast verification first: use `just front`, `just short`, or focused `just lsp <regex>` / `just gen <regex>` before broader sweeps.
+- Use `just build-checker` when you want the native checker prebuilt for repeated runs; `.envrc` points `OSTY_NATIVE_CHECKER_BIN` at the prebuilt binary when present and otherwise falls back to `scripts/osty-native-checker`.
+- Use `just repair-check`, `just ci`, and `just verify-selfhost` for wider validation when touching CLI, toolchain, or generated outputs.
+- Prefer targeted `go test -count=1 -vet=off <pkg>` over whole-tree runs unless the change is broad; run `just vet` separately when needed.
+- Local generated artifacts live in `.bin/`, `.osty/`, `.profiles/`, and `.direnv/`.

--- a/justfile
+++ b/justfile
@@ -1,32 +1,76 @@
 set shell := ["bash", "-cu"]
 
 bin := ".bin/osty"
-front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline ./internal/speccorpus"
+checker_bin := ".osty/bin/osty-native-checker"
+front_packages := "./internal/lexer ./internal/parser ./internal/resolve ./internal/check ./internal/diag ./internal/format ./internal/lint ./internal/pipeline"
+test_flags := "-count=1 -vet=off"
 
-default:
-    just front
+default: front
+
+help:
+    just --list
 
 build:
     mkdir -p .bin
     go build -o {{bin}} ./cmd/osty
 
+build-checker:
+    mkdir -p .osty/bin
+    go build -o {{checker_bin}} ./cmd/osty-native-checker
+
+build-all: build build-checker
+
 front:
-    go test -count=1 {{front_packages}}
+    go test {{test_flags}} {{front_packages}}
 
 spec:
-    go test -count=1 ./internal/speccorpus -v
+    go test {{test_flags}} ./internal/speccorpus -v
 
 short:
-    go test -short ./...
+    go test {{test_flags}} -short ./...
 
 full:
-    go test ./...
+    go test {{test_flags}} ./...
+
+test pkg="./...":
+    go test {{test_flags}} {{pkg}}
+
+vet:
+    go vet ./...
+
+fmt:
+    gofmt -w $(git ls-files '*.go')
+
+fmt-check:
+    unformatted="$$(gofmt -l $$(git ls-files '*.go'))"; if [ -n "$$unformatted" ]; then printf '%s\n' "$$unformatted"; exit 1; fi
 
 lsp test=".":
-    go test -count=1 ./internal/lsp -run '{{test}}' -v
+    go test {{test_flags}} ./internal/lsp -run '{{test}}' -v
 
 cmd test=".":
-    go test -count=1 ./cmd/osty -run '{{test}}' -v
+    go test {{test_flags}} ./cmd/osty -run '{{test}}' -v
+
+gen test=".":
+    go test {{test_flags}} ./cmd/osty -run '{{test}}' -v
+
+diag test=".":
+    go test {{test_flags}} ./internal/diag -run '{{test}}' -v
+
+repair-check: build
+    while IFS= read -r file; do case "$$file" in testdata/spec/negative/*) continue ;; esac; {{bin}} repair --check "$$file"; done < <(git ls-files '*.osty')
+
+ci: build
+    {{bin}} ci .
+
+verify-selfhost:
+    go generate ./toolchain
+    git diff --exit-code -- toolchain/generated.go
+    go generate ./internal/ci
+    git diff --exit-code -- internal/ci/osty_generated.go
+
+check: fmt-check vet front
+
+prepush: fmt-check vet repair-check ci
 
 pipe target:
     test -x {{bin}} || just build
@@ -42,10 +86,13 @@ profile target:
     {{bin}} pipeline --per-decl --cpuprofile .profiles/cpu.pprof --memprofile .profiles/mem.pprof {{target}}
 
 watch-front:
-    watchexec -e go,osty,md -- just front
+    watchexec -e go,osty,md --restart -- just front
+
+watch-short:
+    watchexec -e go,osty,md --restart -- just short
 
 watch-pipe target:
-    watchexec -e go,osty -- just pipe {{target}}
+    watchexec -e go,osty --restart -- just pipe {{target}}
 
-sum:
-    gotestsum -- ./...
+sum pkg="./...":
+    if command -v gotestsum >/dev/null 2>&1; then gotestsum -- {{pkg}}; else go test {{test_flags}} {{pkg}}; fi


### PR DESCRIPTION
## What changed
- expanded the repo `justfile` with faster local loops, focused test targets, watch recipes, and pre-push checks
- added a repo-local `.envrc` that wires `.bin`, `.osty/bin`, and `OSTY_NATIVE_CHECKER_BIN`
- added a repo `AGENTS.md` to steer Codex toward the local workflow defaults
- ignored local workflow artifacts such as `.bin/`, `.profiles/`, and `.direnv/`

## Why
- local developer setup was spread across ad-hoc commands and lacked repo-level guidance for repeatable fast loops
- the previous `front` recipe also included `speccorpus`, which makes the quick loop noisy because current waiver drift already fails there

## Impact
- faster and more predictable local build/test workflows
- repo-scoped environment setup for contributors using `direnv`
- clearer Codex guidance for this repository's preferred validation commands

## Validation
- `just build-checker`
- `just gen TestLoadGenPackageEntryLoadsSiblingFiles`
- `just lsp TestCompletionItemUsesSelfHostedPolicy`
- `just front`
- `just spec` currently still fails due to existing `speccorpus` waiver drift in the repo (`06-scripts.osty`, `E0201`, `E0608`, plus stale waiver entries)
