### PR TITLE
[codex] fix(selfhost): advance native field-call wall

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -330,9 +330,13 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
 static void osty_gc_mark_payload(void *payload);
 bool osty_rt_strings_Equal(const char *left, const char *right);
 int64_t osty_rt_strings_Compare(const char *left, const char *right);
+int64_t osty_rt_strings_Count(const char *value, const char *substr);
 bool osty_rt_strings_Contains(const char *value, const char *substr);
 bool osty_rt_strings_HasSuffix(const char *value, const char *suffix);
 const char *osty_rt_strings_Join(void *raw_parts, const char *sep);
+const char *osty_rt_strings_Repeat(const char *value, int64_t n);
+const char *osty_rt_strings_ReplaceAll(const char *value, const char *old, const char *new_value);
+const char *osty_rt_strings_Slice(const char *value, int64_t start, int64_t end);
 const char *osty_rt_strings_TrimPrefix(const char *value, const char *prefix);
 const char *osty_rt_strings_TrimSuffix(const char *value, const char *suffix);
 const char *osty_rt_strings_TrimSpace(const char *value);
@@ -704,6 +708,14 @@ int64_t osty_rt_list_len(void *raw_list) {
     return list->len;
 }
 
+void osty_rt_list_pop_discard(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    if (list == NULL || list->len <= 0) {
+        osty_rt_abort("list.pop on empty list");
+    }
+    list->len -= 1;
+}
+
 void osty_rt_list_push_i64(void *raw_list, int64_t value) {
     osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }
@@ -1017,6 +1029,30 @@ int64_t osty_rt_strings_Compare(const char *left, const char *right) {
     return 0;
 }
 
+int64_t osty_rt_strings_Count(const char *value, const char *substr) {
+    const char *cursor;
+    const char *next;
+    size_t value_len;
+    size_t substr_len;
+    int64_t total;
+
+    value = (value == NULL) ? "" : value;
+    substr = (substr == NULL) ? "" : substr;
+    value_len = strlen(value);
+    substr_len = strlen(substr);
+    if (substr_len == 0) {
+        return (int64_t)value_len + 1;
+    }
+
+    total = 0;
+    cursor = value;
+    while ((next = strstr(cursor, substr)) != NULL) {
+        total += 1;
+        cursor = next + substr_len;
+    }
+    return total;
+}
+
 int64_t osty_rt_strings_ByteLen(const char *value) {
     if (value == NULL) {
         return 0;
@@ -1203,6 +1239,132 @@ const char *osty_rt_strings_Join(void *raw_parts, const char *sep) {
     }
     *cursor = '\0';
     return out;
+}
+
+const char *osty_rt_strings_Repeat(const char *value, int64_t n) {
+    size_t value_len;
+    size_t total;
+    char *out;
+    char *cursor;
+    int64_t i;
+
+    value = (value == NULL) ? "" : value;
+    if (n <= 0) {
+        return osty_rt_string_dup_site("", 0, "runtime.strings.repeat.empty");
+    }
+    value_len = strlen(value);
+    if (value_len == 0) {
+        return osty_rt_string_dup_site("", 0, "runtime.strings.repeat.empty");
+    }
+    if ((uint64_t)n > (uint64_t)SIZE_MAX / (uint64_t)value_len) {
+        osty_rt_abort("runtime.strings.repeat: size overflow");
+    }
+    total = value_len * (size_t)n;
+    out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.strings.repeat", NULL, NULL);
+    cursor = out;
+    for (i = 0; i < n; i++) {
+        memcpy(cursor, value, value_len);
+        cursor += value_len;
+    }
+    *cursor = '\0';
+    return out;
+}
+
+const char *osty_rt_strings_ReplaceAll(const char *value, const char *old, const char *new_value) {
+    const char *cursor;
+    const char *next;
+    size_t value_len;
+    size_t old_len;
+    size_t new_len;
+    size_t total;
+    int64_t count;
+    char *out;
+    char *dst;
+
+    value = (value == NULL) ? "" : value;
+    old = (old == NULL) ? "" : old;
+    new_value = (new_value == NULL) ? "" : new_value;
+    value_len = strlen(value);
+    old_len = strlen(old);
+    new_len = strlen(new_value);
+
+    if (old_len == 0) {
+        if (new_len != 0 && value_len + 1 > SIZE_MAX / new_len) {
+            osty_rt_abort("runtime.strings.replace_all: size overflow");
+        }
+        total = value_len + (value_len + 1) * new_len;
+        out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.strings.replace_all", NULL, NULL);
+        dst = out;
+        if (new_len != 0) {
+            memcpy(dst, new_value, new_len);
+            dst += new_len;
+        }
+        for (size_t i = 0; i < value_len; i++) {
+            *dst++ = value[i];
+            if (new_len != 0) {
+                memcpy(dst, new_value, new_len);
+                dst += new_len;
+            }
+        }
+        *dst = '\0';
+        return out;
+    }
+
+    count = 0;
+    cursor = value;
+    while ((next = strstr(cursor, old)) != NULL) {
+        count += 1;
+        cursor = next + old_len;
+    }
+    if (count == 0) {
+        return osty_rt_string_dup_site(value, value_len, "runtime.strings.replace_all.copy");
+    }
+    total = value_len;
+    if (new_len >= old_len) {
+        size_t extra = new_len - old_len;
+        if (extra != 0 && (uint64_t)count > (uint64_t)SIZE_MAX / (uint64_t)extra) {
+            osty_rt_abort("runtime.strings.replace_all: size overflow");
+        }
+        total += (size_t)count * extra;
+    } else {
+        total -= (size_t)count * (old_len - new_len);
+    }
+    out = (char *)osty_gc_allocate_managed(total + 1, OSTY_GC_KIND_STRING, "runtime.strings.replace_all", NULL, NULL);
+    dst = out;
+    cursor = value;
+    while ((next = strstr(cursor, old)) != NULL) {
+        size_t prefix_len = (size_t)(next - cursor);
+        if (prefix_len != 0) {
+            memcpy(dst, cursor, prefix_len);
+            dst += prefix_len;
+        }
+        if (new_len != 0) {
+            memcpy(dst, new_value, new_len);
+            dst += new_len;
+        }
+        cursor = next + old_len;
+    }
+    if (*cursor != '\0') {
+        size_t tail_len = strlen(cursor);
+        memcpy(dst, cursor, tail_len);
+        dst += tail_len;
+    }
+    *dst = '\0';
+    return out;
+}
+
+const char *osty_rt_strings_Slice(const char *value, int64_t start, int64_t end) {
+    size_t value_len;
+
+    value = (value == NULL) ? "" : value;
+    value_len = strlen(value);
+    if (start < 0 || end < start) {
+        osty_rt_abort("runtime.strings.slice: invalid bounds");
+    }
+    if ((uint64_t)end > (uint64_t)value_len) {
+        osty_rt_abort("runtime.strings.slice: end out of range");
+    }
+    return osty_rt_string_dup_site(value + start, (size_t)(end - start), "runtime.strings.slice");
 }
 
 const char *osty_rt_strings_TrimPrefix(const char *value, const char *prefix) {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -547,7 +547,7 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 			v := fromOstyValue(out)
 			v.gcManaged = base.listElemTyp == "ptr"
 			v.rootPaths = g.rootPathsForType(base.listElemTyp)
-			return v, nil
+			return g.decorateStaticValueFromSourceType(v, expr), nil
 		}
 		traceSymbol := g.traceCallbackSymbol(base.listElemTyp, g.rootPathsForType(base.listElemTyp))
 		emitter := g.toOstyEmitter()
@@ -563,7 +563,7 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 		loaded := g.loadValueFromAddress(emitter, base.listElemTyp, slot)
 		g.takeOstyEmitter(emitter)
 		loaded.rootPaths = g.rootPathsForType(base.listElemTyp)
-		return loaded, nil
+		return g.decorateStaticValueFromSourceType(loaded, expr), nil
 	case base.mapKeyTyp != "":
 		if index.typ != base.mapKeyTyp {
 			return value{}, unsupportedf("type-system", "map index type %s, want %s", index.typ, base.mapKeyTyp)
@@ -586,7 +586,7 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 		g.takeOstyEmitter(emitter)
 		out.gcManaged = base.mapValueTyp == "ptr"
 		out.rootPaths = g.rootPathsForType(base.mapValueTyp)
-		return out, nil
+		return g.decorateStaticValueFromSourceType(out, expr), nil
 	default:
 		return value{}, unsupportedf("expression", "index expression on %s", base.typ)
 	}
@@ -846,17 +846,17 @@ func (g *generator) emitBinary(e *ast.BinaryExpr) (value, error) {
 //
 // Lowering mirrors the null-check/phi shape used by `?` and `?.`:
 //
-//   %is_nil = icmp eq ptr %left, null
-//   br i1 %is_nil, label %none, label %some
-//  some:
-//    ; unwrap: inner-ptr types use %left directly; others load the
-//    ; boxed payload via `load innerTyp, ptr %left`.
-//    br label %end
-//  none:
-//    ; evaluate %right (may be any side-effecting expression).
-//    br label %end
-//  end:
-//    %out = phi innerTyp [ %unwrapped, %some.pred ], [ %right, %none.pred ]
+//	 %is_nil = icmp eq ptr %left, null
+//	 br i1 %is_nil, label %none, label %some
+//	some:
+//	  ; unwrap: inner-ptr types use %left directly; others load the
+//	  ; boxed payload via `load innerTyp, ptr %left`.
+//	  br label %end
+//	none:
+//	  ; evaluate %right (may be any side-effecting expression).
+//	  br label %end
+//	end:
+//	  %out = phi innerTyp [ %unwrapped, %some.pred ], [ %right, %none.pred ]
 //
 // Nil-coalesce is intentionally right-associative at the surface so
 // `a ?? b ?? c` parses as `a ?? (b ?? c)`; here we only see one
@@ -2865,6 +2865,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		if v, ok, ierr := g.emitIndirectUserCall(call); ok || ierr != nil {
 			return v, ierr
 		}
+		if field, ok := call.Fn.(*ast.FieldExpr); ok {
+			return value{}, unsupportedf("call", "call target %T (%s)", call.Fn, debugFieldCallTarget(field))
+		}
 		return value{}, unsupportedf("call", "call target %T", call.Fn)
 	}
 	if sig.ret == "" {
@@ -2898,6 +2901,24 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	ret.gcManaged = valueNeedsManagedRoot(ret)
 	ret.rootPaths = g.rootPathsForType(sig.ret)
 	return ret, nil
+}
+
+func debugFieldCallTarget(field *ast.FieldExpr) string {
+	if field == nil {
+		return "<nil>"
+	}
+	return debugFieldBase(field.X) + "." + field.Name
+}
+
+func debugFieldBase(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.FieldExpr:
+		return debugFieldCallTarget(e)
+	default:
+		return fmt.Sprintf("%T", expr)
+	}
 }
 
 func (g *generator) emitTestingValueCall(call *ast.CallExpr) (value, bool, error) {

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -61,6 +61,75 @@ fn main() {
 	}
 }
 
+func TestGenerateDiscardedListPopNoLongerTripsLLVM015(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut values: List<Int> = [1, 2, 3]
+    let _ = values.pop()
+    println(values.len())
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/list_pop_discard.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"call void @osty_rt_list_pop_discard",
+		"call i64 @osty_rt_list_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateExprStmtListPopNoLongerTripsLLVM015(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut values: List<Int> = [1, 2]
+    values.pop()
+    println(values.len())
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/list_pop_expr_stmt.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	if got := string(ir); !strings.Contains(got, "call void @osty_rt_list_pop_discard") {
+		t.Fatalf("generated IR missing list pop discard call:\n%s", got)
+	}
+}
+
+func TestGenerateIndexedNestedListLenMethodDispatch(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let stacks: List<List<Int>> = [[1, 2], [3]]
+    let stack = stacks[0]
+    println(stack.len())
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/indexed_nested_list_len.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	if got := string(ir); !strings.Contains(got, "call i64 @osty_rt_list_len") {
+		t.Fatalf("generated IR missing list len call:\n%s", got)
+	}
+}
+
 // Phase 1 of the first-class fn value lowering: a top-level fn used
 // in value position materialises a closure env + thunk, and the
 // subsequent call through the bound name dispatches indirectly.

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -699,6 +699,10 @@ func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {
 		{"float_to_string", llvmFloatRuntimeToStringSymbol(), "osty_rt_float_to_string"},
 		{"bool_to_string", llvmBoolRuntimeToStringSymbol(), "osty_rt_bool_to_string"},
 		{"byteLen", llvmStringRuntimeByteLenSymbol(), "osty_rt_strings_ByteLen"},
+		{"count", llvmStringRuntimeCountSymbol(), "osty_rt_strings_Count"},
+		{"repeat", llvmStringRuntimeRepeatSymbol(), "osty_rt_strings_Repeat"},
+		{"replaceAll", llvmStringRuntimeReplaceAllSymbol(), "osty_rt_strings_ReplaceAll"},
+		{"slice", llvmStringRuntimeSliceSymbol(), "osty_rt_strings_Slice"},
 		{"trimPrefix", llvmStringRuntimeTrimPrefixSymbol(), "osty_rt_strings_TrimPrefix"},
 		{"trimSuffix", llvmStringRuntimeTrimSuffixSymbol(), "osty_rt_strings_TrimSuffix"},
 	}
@@ -722,6 +726,10 @@ func TestGeneratedStringRuntimeDeclarationsAreOstyOwned(t *testing.T) {
 		"declare ptr @osty_rt_float_to_string(double)",
 		"declare ptr @osty_rt_bool_to_string(i1)",
 		"declare i64 @osty_rt_strings_ByteLen(ptr)",
+		"declare i64 @osty_rt_strings_Count(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Repeat(ptr, i64)",
+		"declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)",
+		"declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
 		"declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)",
 		"declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)",
 	}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -299,6 +299,10 @@ func listRuntimeLenSymbol() string {
 	return llvmListRuntimeLenSymbol()
 }
 
+func listRuntimePopDiscardSymbol() string {
+	return "osty_rt_list_pop_discard"
+}
+
 func listRuntimePushBytesV1Symbol() string {
 	return "osty_rt_list_push_bytes_v1"
 }

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -57,6 +57,9 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 	case "compare":
 		v, err := g.emitStdStringsBinary(call, "compare", "i64", llvmStringRuntimeCompareSymbol())
 		return v, true, err
+	case "count":
+		v, err := g.emitStdStringsBinary(call, "count", "i64", llvmStringRuntimeCountSymbol())
+		return v, true, err
 	case "concat":
 		v, err := g.emitStdStringsBinaryString(call, "concat", llvmStringRuntimeConcatSymbol())
 		return v, true, err
@@ -72,11 +75,20 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 	case "join":
 		v, err := g.emitStdStringsJoin(call)
 		return v, true, err
+	case "repeat":
+		v, err := g.emitStdStringsRepeat(call)
+		return v, true, err
+	case "replaceAll":
+		v, err := g.emitStdStringsReplaceAll(call)
+		return v, true, err
 	case "split":
 		v, err := g.emitStdStringsSplit(call)
 		return v, true, err
 	case "splitN":
 		v, err := g.emitStdStringsSplitN(call)
+		return v, true, err
+	case "slice":
+		v, err := g.emitStdStringsSlice(call)
 		return v, true, err
 	case "trimPrefix":
 		v, err := g.emitStdStringsBinaryString(call, "trimPrefix", llvmStringRuntimeTrimPrefixSymbol())
@@ -111,9 +123,11 @@ func (g *generator) stdStringsCallStaticResult(call *ast.CallExpr) (value, bool)
 	switch field.Name {
 	case "compare":
 		return value{typ: "i64"}, true
+	case "count":
+		return value{typ: "i64"}, true
 	case "contains", "hasPrefix", "hasSuffix":
 		return value{typ: "i1"}, true
-	case "concat", "join", "trim", "trimSpace", "trimPrefix", "trimSuffix":
+	case "concat", "join", "repeat", "replaceAll", "slice", "trim", "trimSpace", "trimPrefix", "trimSuffix":
 		return value{typ: "ptr", gcManaged: true}, true
 	case "split", "splitN":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true}, true
@@ -239,6 +253,80 @@ func (g *generator) emitStdStringsJoin(call *ast.CallExpr) (value, error) {
 	return joined, nil
 }
 
+func (g *generator) emitStdStringsRepeat(call *ast.CallExpr) (value, error) {
+	if len(call.Args) != 2 {
+		return value{}, unsupportedf("call", "strings.repeat expects 2 arguments, got %d", len(call.Args))
+	}
+	s, err := g.emitStdStringsArg(call.Args[0], "repeat", 0)
+	if err != nil {
+		return value{}, err
+	}
+	n, err := g.emitStdStringsIntArg(call.Args[1], "repeat", 1)
+	if err != nil {
+		return value{}, err
+	}
+	symbol := llvmStringRuntimeRepeatSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(n)})
+	g.takeOstyEmitter(emitter)
+	repeated := fromOstyValue(out)
+	repeated.gcManaged = true
+	return repeated, nil
+}
+
+func (g *generator) emitStdStringsReplaceAll(call *ast.CallExpr) (value, error) {
+	if len(call.Args) != 3 {
+		return value{}, unsupportedf("call", "strings.replaceAll expects 3 arguments, got %d", len(call.Args))
+	}
+	s, err := g.emitStdStringsArg(call.Args[0], "replaceAll", 0)
+	if err != nil {
+		return value{}, err
+	}
+	old, err := g.emitStdStringsArg(call.Args[1], "replaceAll", 1)
+	if err != nil {
+		return value{}, err
+	}
+	newValue, err := g.emitStdStringsArg(call.Args[2], "replaceAll", 2)
+	if err != nil {
+		return value{}, err
+	}
+	symbol := llvmStringRuntimeReplaceAllSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(old), toOstyValue(newValue)})
+	g.takeOstyEmitter(emitter)
+	replaced := fromOstyValue(out)
+	replaced.gcManaged = true
+	return replaced, nil
+}
+
+func (g *generator) emitStdStringsSlice(call *ast.CallExpr) (value, error) {
+	if len(call.Args) != 3 {
+		return value{}, unsupportedf("call", "strings.slice expects 3 arguments, got %d", len(call.Args))
+	}
+	s, err := g.emitStdStringsArg(call.Args[0], "slice", 0)
+	if err != nil {
+		return value{}, err
+	}
+	start, err := g.emitStdStringsIntArg(call.Args[1], "slice", 1)
+	if err != nil {
+		return value{}, err
+	}
+	end, err := g.emitStdStringsIntArg(call.Args[2], "slice", 2)
+	if err != nil {
+		return value{}, err
+	}
+	symbol := llvmStringRuntimeSliceSymbol()
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(s), toOstyValue(start), toOstyValue(end)})
+	g.takeOstyEmitter(emitter)
+	sliced := fromOstyValue(out)
+	sliced.gcManaged = true
+	return sliced, nil
+}
+
 func (g *generator) emitStdStringsBinary(call *ast.CallExpr, name, retTyp, symbol string) (value, error) {
 	if len(call.Args) != 2 {
 		return value{}, unsupportedf("call", "strings.%s expects 2 arguments, got %d", name, len(call.Args))
@@ -281,6 +369,24 @@ func (g *generator) emitStdStringsArg(arg *ast.Arg, name string, index int) (val
 	}
 	if loaded.typ != "ptr" {
 		return value{}, unsupportedf("type-system", "strings.%s arg %d type %s, want String", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdStringsIntArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "strings.%s requires positional arguments", name)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "i64" {
+		return value{}, unsupportedf("type-system", "strings.%s arg %d type %s, want Int", name, index+1, loaded.typ)
 	}
 	return loaded, nil
 }

--- a/internal/llvmgen/stdlib_shim_test.go
+++ b/internal/llvmgen/stdlib_shim_test.go
@@ -109,6 +109,94 @@ fn main() {
 	}
 }
 
+func TestStdStringsRepeatRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let out = strings.repeat("ab", 3)
+    println(out)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_repeat.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_Repeat(ptr, i64)",
+		"call ptr @osty_rt_strings_Repeat",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
+func TestStdStringsReplaceAllRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let out = strings.replaceAll("a\r\nb\r", "\r", "")
+    println(out)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_replace_all.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)",
+		"call ptr @osty_rt_strings_ReplaceAll",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
+func TestStdStringsCountRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let total = strings.count("ababa", "aba")
+    println(total)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_count.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare i64 @osty_rt_strings_Count(ptr, ptr)",
+		"call i64 @osty_rt_strings_Count",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
+func TestStdStringsSliceRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let piece = strings.slice("abcdef", 1, 4)
+    println(piece)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_slice.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
+		"call ptr @osty_rt_strings_Slice",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
 func TestBareNoneSomeInPtrBackedOptional(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn pickNone() -> String? {
     return None

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -153,6 +153,13 @@ func (g *generator) emitLet(stmt *ast.LetStmt) error {
 	if stmt.Value == nil {
 		return unsupported("statement", "let has no value")
 	}
+	if stmt.Type == nil {
+		if _, ok := stmt.Pattern.(*ast.WildcardPat); ok {
+			if _, ok := stmt.Value.(*ast.CallExpr); ok {
+				return g.emitExprStmt(stmt.Value)
+			}
+		}
+	}
 	hintedListElemTyp := ""
 	hintedListElemString := false
 	hintedMapKeyTyp := ""
@@ -1577,11 +1584,8 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	if field.Name != "push" {
+	if field.Name != "push" && field.Name != "pop" {
 		return false, nil
-	}
-	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
-		return true, unsupported("call", "list.push requires one positional argument")
 	}
 	g.pushScope()
 	defer g.popScope()
@@ -1596,16 +1600,33 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		return true, unsupportedf("type-system", "list receiver type %s", base.typ)
 	}
 	base = g.protectManagedTemporary("list.base", base)
+	baseValue, err := g.loadIfPointer(base)
+	if err != nil {
+		return true, err
+	}
+	if field.Name == "pop" {
+		if len(call.Args) != 0 {
+			return true, unsupported("call", "list.pop requires no arguments")
+		}
+		g.declareRuntimeSymbol(listRuntimePopDiscardSymbol(), "void", []paramInfo{{typ: "ptr"}})
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimePopDiscardSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue)}),
+		))
+		g.takeOstyEmitter(emitter)
+		return true, nil
+	}
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return true, unsupported("call", "list.push requires one positional argument")
+	}
 	arg, err := g.emitExpr(call.Args[0].Value)
 	if err != nil {
 		return true, err
 	}
 	if arg.typ != elemTyp {
 		return true, unsupportedf("type-system", "list.push arg type %s, want %s", arg.typ, elemTyp)
-	}
-	baseValue, err := g.loadIfPointer(base)
-	if err != nil {
-		return true, err
 	}
 	argValue, err := g.loadIfPointer(arg)
 	if err != nil {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2187,8 +2187,24 @@ func llvmStringRuntimeCompareSymbol() string {
 	return "osty_rt_strings_Compare"
 }
 
+func llvmStringRuntimeCountSymbol() string {
+	return "osty_rt_strings_Count"
+}
+
 func llvmStringRuntimeJoinSymbol() string {
 	return "osty_rt_strings_Join"
+}
+
+func llvmStringRuntimeRepeatSymbol() string {
+	return "osty_rt_strings_Repeat"
+}
+
+func llvmStringRuntimeReplaceAllSymbol() string {
+	return "osty_rt_strings_ReplaceAll"
+}
+
+func llvmStringRuntimeSliceSymbol() string {
+	return "osty_rt_strings_Slice"
 }
 
 func llvmStringRuntimeTrimPrefixSymbol() string {
@@ -2216,7 +2232,11 @@ func llvmStringRuntimeDeclarations() []string {
 		"declare ptr @osty_rt_bool_to_string(i1)",
 		"declare i64 @osty_rt_strings_ByteLen(ptr)",
 		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
+		"declare i64 @osty_rt_strings_Count(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Join(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Repeat(ptr, i64)",
+		"declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)",
+		"declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
 		"declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)",
 		"declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)",
 		"declare ptr @osty_rt_strings_TrimSpace(ptr)",
@@ -2274,8 +2294,24 @@ func llvmStringRuntimeCompare(emitter *LlvmEmitter, left *LlvmValue, right *Llvm
 	return llvmCall(emitter, "i64", "osty_rt_strings_Compare", []*LlvmValue{left, right})
 }
 
+func llvmStringRuntimeCount(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_strings_Count", []*LlvmValue{value, substr})
+}
+
 func llvmStringRuntimeJoin(emitter *LlvmEmitter, parts *LlvmValue, sep *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Join", []*LlvmValue{parts, sep})
+}
+
+func llvmStringRuntimeRepeat(emitter *LlvmEmitter, value *LlvmValue, n *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_strings_Repeat", []*LlvmValue{value, n})
+}
+
+func llvmStringRuntimeReplaceAll(emitter *LlvmEmitter, value *LlvmValue, old *LlvmValue, newValue *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_strings_ReplaceAll", []*LlvmValue{value, old, newValue})
+}
+
+func llvmStringRuntimeSlice(emitter *LlvmEmitter, value *LlvmValue, start *LlvmValue, end *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_strings_Slice", []*LlvmValue{value, start, end})
 }
 
 func llvmStringRuntimeTrimPrefix(emitter *LlvmEmitter, value *LlvmValue, prefix *LlvmValue) *LlvmValue {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -447,6 +447,29 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 				return field.sourceType, true
 			}
 		}
+	case *ast.IndexExpr:
+		baseSource, ok := g.staticExprSourceType(e.X)
+		if !ok {
+			return nil, false
+		}
+		resolved, err := llvmResolveAliasType(baseSource, g.typeEnv(), map[string]bool{})
+		if err != nil {
+			return nil, false
+		}
+		named, ok := resolved.(*ast.NamedType)
+		if !ok || len(named.Path) != 1 {
+			return nil, false
+		}
+		switch named.Path[0] {
+		case "List":
+			if len(named.Args) == 1 {
+				return named.Args[0], true
+			}
+		case "Map":
+			if len(named.Args) == 2 {
+				return named.Args[1], true
+			}
+		}
 	}
 	return nil, false
 }
@@ -595,13 +618,38 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		if baseInfo, ok := g.staticExprInfo(e.X); ok {
 			switch {
 			case baseInfo.listElemTyp != "":
-				return value{typ: baseInfo.listElemTyp, gcManaged: baseInfo.listElemTyp == "ptr", rootPaths: g.rootPathsForType(baseInfo.listElemTyp)}, true
+				out := value{typ: baseInfo.listElemTyp, gcManaged: baseInfo.listElemTyp == "ptr", rootPaths: g.rootPathsForType(baseInfo.listElemTyp)}
+				return g.decorateStaticValueFromSourceType(out, e), true
 			case baseInfo.mapKeyTyp != "":
-				return value{typ: baseInfo.mapValueTyp, gcManaged: baseInfo.mapValueTyp == "ptr", rootPaths: g.rootPathsForType(baseInfo.mapValueTyp)}, true
+				out := value{typ: baseInfo.mapValueTyp, gcManaged: baseInfo.mapValueTyp == "ptr", rootPaths: g.rootPathsForType(baseInfo.mapValueTyp)}
+				return g.decorateStaticValueFromSourceType(out, e), true
 			}
 		}
 	}
 	return value{}, false
+}
+
+func (g *generator) decorateStaticValueFromSourceType(out value, expr ast.Expr) value {
+	sourceType, ok := g.staticExprSourceType(expr)
+	if !ok {
+		return out
+	}
+	out.sourceType = sourceType
+	if listElemTyp, listElemString, ok, err := llvmListElementInfo(sourceType, g.typeEnv()); err == nil && ok {
+		out.listElemTyp = listElemTyp
+		out.listElemString = listElemString
+	}
+	if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(sourceType, g.typeEnv()); err == nil && ok {
+		out.mapKeyTyp = mapKeyTyp
+		out.mapValueTyp = mapValueTyp
+		out.mapKeyString = mapKeyString
+	}
+	if setElemTyp, setElemString, ok, err := llvmSetElementType(sourceType, g.typeEnv()); err == nil && ok {
+		out.setElemTyp = setElemTyp
+		out.setElemString = setElemString
+	}
+	out.gcManaged = valueNeedsManagedRoot(out)
+	return out
 }
 
 func (g *generator) staticListLiteralElementInfo(expr *ast.ListExpr) (string, bool, bool) {
@@ -855,7 +903,7 @@ func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, 
 		return nil, "", false, false
 	}
 	switch field.Name {
-	case "len", "push", "sorted", "toSet":
+	case "len", "pop", "push", "sorted", "toSet":
 	default:
 		return nil, "", false, false
 	}


### PR DESCRIPTION
## What changed
- add native `std.strings` runtime shims for `count`, `repeat`, `replaceAll`, and `slice`
- lower discarded `list.pop()` calls in statement and wildcard-let positions
- preserve nested collection metadata through indexed values so follow-up method dispatch keeps working
- improve `LLVM015` diagnostics to print the concrete field-call target
- add llvmgen regressions for discarded `pop`, nested indexed `len`, and the new std.strings runtime routes

## Why
The native merged probe was still stopping on a `FieldExpr` method-call wall. In practice the immediate blocker had shifted to `env.bindings.pop()`, so we needed to cover discarded list-pop lowering and keep collection type metadata alive across indexed expressions.

## Impact
This moves the native toolchain first wall forward from `env.bindings.pop()` to `outcome.emittedCodes.isEmpty`, which gives the self-hosting work a narrower next target.

## Validation
- `git diff --check`
- `go test ./internal/llvmgen -run 'TestGenerate.*(ListPop|NestedListLen)|TestStdStrings|TestGeneratedStringRuntime|TestProbeNativeToolchainMerged' -count=1 -v`
