### PR TITLE
fix(selfhost): register List / Map / String intrinsic methods

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -32375,6 +32375,65 @@ func checkInstallPrelude(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "eprintln", owner: "", receiverTy: -1, retTy: tUnit(env.tys), paramNames: []string{"s"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13740:5
 	checkRegisterFn(env, &CheckFnSig{name: "panic", owner: "", receiverTy: -1, retTy: tNever(env.tys), paramNames: []string{"message"}, paramTys: []int{tString(env.tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+
+	// Mirrored from toolchain/check_env.osty pending a regen fix.
+	checkInstallBuiltinMethods(env)
+}
+
+// checkInstallBuiltinMethods registers the intrinsic methods spec §10.6
+// gives List<T> / Map<K, V> / String. Mirrored from
+// toolchain/check_env.osty pending a regen fix.
+func checkInstallBuiltinMethods(env *CheckEnv) {
+	tys := env.tys
+	tT := tyNamed(tys, "T", nil)
+	tK := tyNamed(tys, "K", nil)
+	tV := tyNamed(tys, "V", nil)
+	tListT := tyNamed(tys, "List", []int{tT})
+	tListK := tyNamed(tys, "List", []int{tK})
+	tListV := tyNamed(tys, "List", []int{tV})
+	tListChar := tyNamed(tys, "List", []int{tChar(tys)})
+	tListByte := tyNamed(tys, "List", []int{tByte(tys)})
+	tMapKV := tyNamed(tys, "Map", []int{tK, tV})
+	tOptT := tyOptional(tys, tT)
+	tOptV := tyOptional(tys, tV)
+
+	gT := []string{"T"}
+	gKV := []string{"K", "V"}
+	empty := func() []string { return make([]string, 0) }
+	bounds := func() []*CheckGenericBound { return make([]*CheckGenericBound, 0) }
+
+	// List<T>
+	checkRegisterFn(env, &CheckFnSig{name: "push", owner: "List", receiverTy: tListT, retTy: tUnit(tys), paramNames: []string{"item"}, paramTys: []int{tT}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "pop", owner: "List", receiverTy: tListT, retTy: tOptT, paramNames: empty(), paramTys: []int{}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "len", owner: "List", receiverTy: tListT, retTy: tInt(tys), paramNames: empty(), paramTys: []int{}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "isEmpty", owner: "List", receiverTy: tListT, retTy: tBool(tys), paramNames: empty(), paramTys: []int{}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "insert", owner: "List", receiverTy: tListT, retTy: tUnit(tys), paramNames: []string{"index", "item"}, paramTys: []int{tInt(tys), tT}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "get", owner: "List", receiverTy: tListT, retTy: tOptT, paramNames: []string{"index"}, paramTys: []int{tInt(tys)}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "clear", owner: "List", receiverTy: tListT, retTy: tUnit(tys), paramNames: empty(), paramTys: []int{}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "reverse", owner: "List", receiverTy: tListT, retTy: tUnit(tys), paramNames: empty(), paramTys: []int{}, generics: gT, genericBounds: bounds()})
+
+	// Map<K, V>
+	checkRegisterFn(env, &CheckFnSig{name: "insert", owner: "Map", receiverTy: tMapKV, retTy: tUnit(tys), paramNames: []string{"key", "value"}, paramTys: []int{tK, tV}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "get", owner: "Map", receiverTy: tMapKV, retTy: tOptV, paramNames: []string{"key"}, paramTys: []int{tK}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "remove", owner: "Map", receiverTy: tMapKV, retTy: tOptV, paramNames: []string{"key"}, paramTys: []int{tK}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "keys", owner: "Map", receiverTy: tMapKV, retTy: tListK, paramNames: empty(), paramTys: []int{}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "values", owner: "Map", receiverTy: tMapKV, retTy: tListV, paramNames: empty(), paramTys: []int{}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "len", owner: "Map", receiverTy: tMapKV, retTy: tInt(tys), paramNames: empty(), paramTys: []int{}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "isEmpty", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys), paramNames: empty(), paramTys: []int{}, generics: gKV, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "containsKey", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys), paramNames: []string{"key"}, paramTys: []int{tK}, generics: gKV, genericBounds: bounds()})
+
+	// String
+	tString_ := tString(tys)
+	checkRegisterFn(env, &CheckFnSig{name: "len", owner: "String", receiverTy: tString_, retTy: tInt(tys), paramNames: empty(), paramTys: []int{}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "isEmpty", owner: "String", receiverTy: tString_, retTy: tBool(tys), paramNames: empty(), paramTys: []int{}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "chars", owner: "String", receiverTy: tString_, retTy: tListChar, paramNames: empty(), paramTys: []int{}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "bytes", owner: "String", receiverTy: tString_, retTy: tListByte, paramNames: empty(), paramTys: []int{}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "startsWith", owner: "String", receiverTy: tString_, retTy: tBool(tys), paramNames: []string{"prefix"}, paramTys: []int{tString_}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "endsWith", owner: "String", receiverTy: tString_, retTy: tBool(tys), paramNames: []string{"suffix"}, paramTys: []int{tString_}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "contains", owner: "String", receiverTy: tString_, retTy: tBool(tys), paramNames: []string{"needle"}, paramTys: []int{tString_}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "trimPrefix", owner: "String", receiverTy: tString_, retTy: tString_, paramNames: []string{"prefix"}, paramTys: []int{tString_}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "trimSuffix", owner: "String", receiverTy: tString_, retTy: tString_, paramNames: []string{"suffix"}, paramTys: []int{tString_}, generics: empty(), genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "String", receiverTy: tString_, retTy: tyNamed(tys, "Result", []int{tInt(tys), tyNamed(tys, "Error", nil)}), paramNames: empty(), paramTys: []int{}, generics: empty(), genericBounds: bounds()})
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:13708:5

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1355,6 +1355,172 @@ pub fn checkInstallPrelude(env: CheckEnv) {
         generics: [],
         genericBounds: [],
     })
+
+    checkInstallBuiltinMethods(env)
+}
+
+/// checkInstallBuiltinMethods registers the intrinsic methods spec
+/// §10.6 gives `List<T>` / `Map<K, V>` / `String`. These are not
+/// user-written — the backend lowers them directly — but the checker
+/// still needs a signature to type the call.
+///
+/// Scope intentionally covers only what `toolchain/*.osty` actually
+/// uses today (verified via the `osty check toolchain` histogram):
+/// 796 `.push`, 72 `.len`, 9 `.chars`, 6 `.pop`, 5 `.insert`, 4
+/// `.startsWith`, plus a handful of single-site calls. Registering a
+/// minimal set first keeps the diff reviewable; more helpers can
+/// follow when they surface as the next histogram wall.
+fn checkInstallBuiltinMethods(env: CheckEnv) {
+    let tys = env.tys
+    let tT = tyNamed(tys, "T", [])
+    let tK = tyNamed(tys, "K", [])
+    let tV = tyNamed(tys, "V", [])
+    let tListT = tyNamed(tys, "List", [tT])
+    let tListK = tyNamed(tys, "List", [tK])
+    let tListV = tyNamed(tys, "List", [tV])
+    let tListChar = tyNamed(tys, "List", [tChar(tys)])
+    let tListByte = tyNamed(tys, "List", [tByte(tys)])
+    let tMapKV = tyNamed(tys, "Map", [tK, tV])
+    let tOptT = tyOptional(tys, tT)
+    let tOptV = tyOptional(tys, tV)
+
+    // ----- List<T> intrinsics (spec §10.6) -----
+    checkRegisterFn(env, CheckFnSig {
+        name: "push", owner: "List", receiverTy: tListT, retTy: tUnit(tys),
+        paramNames: ["item"], paramTys: [tT],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "pop", owner: "List", receiverTy: tListT, retTy: tOptT,
+        paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "len", owner: "List", receiverTy: tListT, retTy: tInt(tys),
+        paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "isEmpty", owner: "List", receiverTy: tListT, retTy: tBool(tys),
+        paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "insert", owner: "List", receiverTy: tListT, retTy: tUnit(tys),
+        paramNames: ["index", "item"], paramTys: [tInt(tys), tT],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "get", owner: "List", receiverTy: tListT, retTy: tOptT,
+        paramNames: ["index"], paramTys: [tInt(tys)],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "clear", owner: "List", receiverTy: tListT, retTy: tUnit(tys),
+        paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "reverse", owner: "List", receiverTy: tListT, retTy: tUnit(tys),
+        paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
+    })
+
+    // ----- Map<K, V> intrinsics (spec §10.6) -----
+    checkRegisterFn(env, CheckFnSig {
+        name: "insert", owner: "Map", receiverTy: tMapKV, retTy: tUnit(tys),
+        paramNames: ["key", "value"], paramTys: [tK, tV],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "get", owner: "Map", receiverTy: tMapKV, retTy: tOptV,
+        paramNames: ["key"], paramTys: [tK],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "remove", owner: "Map", receiverTy: tMapKV, retTy: tOptV,
+        paramNames: ["key"], paramTys: [tK],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "keys", owner: "Map", receiverTy: tMapKV, retTy: tListK,
+        paramNames: [], paramTys: [],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "values", owner: "Map", receiverTy: tMapKV, retTy: tListV,
+        paramNames: [], paramTys: [],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "len", owner: "Map", receiverTy: tMapKV, retTy: tInt(tys),
+        paramNames: [], paramTys: [],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "isEmpty", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys),
+        paramNames: [], paramTys: [],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "containsKey", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys),
+        paramNames: ["key"], paramTys: [tK],
+        generics: ["K", "V"], genericBounds: [],
+    })
+
+    // ----- String intrinsics -----
+    let tString_ = tString(tys)
+    checkRegisterFn(env, CheckFnSig {
+        name: "len", owner: "String", receiverTy: tString_, retTy: tInt(tys),
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "isEmpty", owner: "String", receiverTy: tString_, retTy: tBool(tys),
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "chars", owner: "String", receiverTy: tString_, retTy: tListChar,
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "bytes", owner: "String", receiverTy: tString_, retTy: tListByte,
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "startsWith", owner: "String", receiverTy: tString_, retTy: tBool(tys),
+        paramNames: ["prefix"], paramTys: [tString_],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "endsWith", owner: "String", receiverTy: tString_, retTy: tBool(tys),
+        paramNames: ["suffix"], paramTys: [tString_],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "contains", owner: "String", receiverTy: tString_, retTy: tBool(tys),
+        paramNames: ["needle"], paramTys: [tString_],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "trimPrefix", owner: "String", receiverTy: tString_, retTy: tString_,
+        paramNames: ["prefix"], paramTys: [tString_],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "trimSuffix", owner: "String", receiverTy: tString_, retTy: tString_,
+        paramNames: ["suffix"], paramTys: [tString_],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "toInt", owner: "String", receiverTy: tString_,
+        retTy: tyNamed(tys, "Result", [tInt(tys), tyNamed(tys, "Error", [])]),
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
 }
 
 // Preserve a surface-level mirror of `frontCheckResult*`-style bridge


### PR DESCRIPTION
## Summary

`checkInstallPrelude` set up generic types, variants, and the prelude free functions, but never registered the **intrinsic methods** spec §10.6 gives `List<T>` / `Map<K, V>` / `String`. Every `xs.push(item)` / `m.insert(k, v)` / `s.startsWith(prefix)` site therefore failed `checkLookupMethod` and fired `E0703 no method 'push' on type 'List'` — **896 of the remaining 1898 toolchain errors**, with `push` alone accounting for 796.

This is the single biggest remaining class after [#421](https://github.com/choiceoh/osty/pull/421) / [#422](https://github.com/choiceoh/osty/pull/422) / [#423](https://github.com/choiceoh/osty/pull/423).

## What changed

Add `checkInstallBuiltinMethods` and call it from `checkInstallPrelude`. Scope matches what `toolchain/*.osty` actually uses today (verified via the `osty check toolchain` histogram):

- **`List<T>`** — `push`, `pop`, `len`, `isEmpty`, `insert`, `get`, `clear`, `reverse`
- **`Map<K, V>`** — `insert`, `get`, `remove`, `keys`, `values`, `len`, `isEmpty`, `containsKey`
- **`String`** — `len`, `isEmpty`, `chars`, `bytes`, `startsWith`, `endsWith`, `contains`, `trimPrefix`, `trimSuffix`, `toInt`

These use the same `CheckFnSig` shape as user-declared methods, so the existing generic-instantiation machinery (`instBegin`, type-arg substitution via `checkSubstituteTy`) handles the call sites without further plumbing. Receivers are built with `tyNamed("List", [T])` etc.; generic slots (`"T"`, `"K"`, `"V"`) match the registered `CheckTypeSig` arity so `genericListToTyArgs` and the usual substitution paths line up.

Keeping the first pass to the **intrinsics that the toolchain actually calls** keeps the diff reviewable. Non-intrinsic §10.6 helpers (`sorted`, `filter`, `mapValues`, etc.) are pure Osty bodies on the stdlib side and land separately when they surface as the next histogram wall.

## Measured impact

Histogram over `toolchain/` (`selfhost.CheckPackageStructured`):

| | baseline on main | **after this PR** | Δ |
|---|---|---|---|
| total errors | 1898 | **1065** | **−833 (−43.9%)** |
| E0703 (unknown method) | 896 | **19** | **−877 (−97.9%)** |
| accepted | 22106 / 22202 | **24092 / 24194** | **+1986** |

Remaining 19 `E0703` are tail cases where the receiver doesn't resolve to `List` / `Map` / `String` head cleanly (type variable or alias resolution) — next ring of work. The overall error count is now dominated by E0745 (749, mostly `use go` module aliases plus three payload-ful variant constructors) and E0700 (137).

## Cumulative selfhost progress (main → now)

| baseline on main before #421 | current |
|---|---|
| 6308 errors | **1065** |
| 19364 / 19451 accepted | **24092 / 24194** |
| — | **−83.1% total errors, +4728 accepts** |

## Verification

- Minimal `xs.push(1); xs.len()` reproducer → 0 errors (was 3 × E0703)
- `osty gen --backend=llvm` on hello → exit 0 (no regression)
- 4 targeted `internal/llvmgen` tests → pass
- `TestProbeWholeToolchainMerged` → unchanged first wall (`runtime.golegacy.astbridge`)
- `TestProbeNativeToolchainMerged` → unchanged first wall (`LLVM015 method_call_field`)
- `internal/lexer`, `internal/parser`, `internal/selfhost` short tests → pass

## Mirror protocol

Edits live in `toolchain/check_env.osty` (source of truth) and `internal/selfhost/generated.go`. Regen is still blocked on bootstrap-gen (`s.chars`, Result `?` nil compare), so hunks in `generated.go` carry `// Mirrored from ... pending a regen fix` comments — same protocol as [#421](https://github.com/choiceoh/osty/pull/421) / [#422](https://github.com/choiceoh/osty/pull/422) / [#423](https://github.com/choiceoh/osty/pull/423).

🤖 Generated with [Claude Code](https://claude.com/claude-code)