### PR TITLE
fix(llvmgen): lower List/Map/Set isEmpty + Map len as runtime len + icmp

### DIFF
--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -23,8 +23,16 @@ As of 2026-04-19:
 - the whole-toolchain merged LLVM probe still first-walls on the
   bootstrap-only `runtime.golegacy.astbridge` bridge
 - the native-only merged LLVM probe (with bootstrap-only files skipped)
-  now first-walls on `LLVM015 [method_call_field] call: call target
-  *ast.FieldExpr` (method call dispatch through a FieldExpr chain).
+  now first-walls on `LLVM011 [other] type-system: logical not on
+  %PmCheckOutcome` — a separate structural-enum booleanisation gap
+  (`!enumValue` on a nominal enum type). The whole LLVM015
+  [method_call_field] chain that preceded it is closed: `List.isEmpty`
+  / `Map.isEmpty` / `Set.isEmpty` are inlined as `icmp eq i64 <len>,
+  0` (the stdlib default body form), with `osty_rt_map_len` landing
+  in the C runtime alongside the dispatch (the Go wrapper was already
+  declared); `List.pop()` discard sites go through the upstream
+  `osty_rt_list_pop_discard` helper; nested `IndexExpr` propagates
+  List / Map / Set element shapes via `decorateStaticValueFromSourceType`.
   The LLVM012 statement-form category has been cleared for the
   toolchain's actual shape: `LLVM011 [fn_param_struct_type]` Char wall
   at `lspUtf16UnitsForChar` fell first (Char→i32 / Byte→i8 lowering),
@@ -63,7 +71,7 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
-| Native backend surface | merged native-only probe | first wall is now `LLVM015 [method_call_field] call target *ast.FieldExpr` (method call through a FieldExpr chain) after skipping 4 bootstrap-only files; the `LLVM011 Char`, `LLVM012 *ast.MatchExpr`, and `LLVM012 field assignment base *ast.FieldExpr` walls are all closed |
+| Native backend surface | merged native-only probe | first wall is now `LLVM011 [other] type-system: logical not on %PmCheckOutcome` (structural-enum booleanisation — `!enumValue` on a nominal enum) after skipping 4 bootstrap-only files; the whole upstream LLVM015 [method_call_field] chain is closed — List / Map / Set `isEmpty` inline as `icmp eq i64 <len>, 0` (with `osty_rt_map_len` now implemented in the C runtime), nested `IndexExpr` propagates container element shapes, and `list.pop()` discard sites route through `osty_rt_list_pop_discard`; the `LLVM011 Char`, `LLVM012 *ast.MatchExpr`, and `LLVM012 field assignment base *ast.FieldExpr` walls remain closed |
 | Native backend surface | merged native-only probe | first wall is now `LLVM012 statement: field assignment base *ast.FieldExpr` (nested field assignment) after skipping 4 bootstrap-only files; the earlier `LLVM011 [fn_param_struct_type]` Char wall and the subsequent `LLVM012 *ast.MatchExpr is not a call` wall are both closed |
 | Native backend surface | merged native-only probe | first wall is now `LLVM012` (statement form) after skipping 4 bootstrap-only files; the earlier `LLVM011 [fn_param_struct_type]` Char wall is closed |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1552,6 +1552,14 @@ static void osty_rt_map_get_or_abort_raw(void *raw_map, const void *key, void *o
     memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
 }
 
+int64_t osty_rt_map_len(void *raw_map) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    if (map == NULL) {
+        osty_rt_abort("map is null");
+    }
+    return map->len;
+}
+
 void *osty_rt_map_keys(void *raw_map) {
     osty_rt_map *map = (osty_rt_map *)raw_map;
     void *out = osty_rt_list_new();

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2353,6 +2353,21 @@ func (g *generator) emitListMethodCall(call *ast.CallExpr) (value, bool, error) 
 		out := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), true, nil
+	case "isEmpty":
+		// `list.isEmpty()` is the stdlib default `self.len() == 0`. We
+		// inline it as `icmp eq i64 <len>, 0` instead of routing through
+		// LLVM018 stdlib-body lowering so the toolchain probe can clear
+		// this wall without the whole default-body lowering stack.
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "list.isEmpty requires no arguments")
+		}
+		g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		lenVal := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
+		cmp := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
+		g.takeOstyEmitter(emitter)
+		return value{typ: "i1", ref: cmp}, true, nil
 	case "sorted":
 		symbol := listRuntimeSortedSymbol(elemTyp, elemString)
 		if len(call.Args) != 0 || symbol == "" {
@@ -2399,6 +2414,26 @@ func (g *generator) emitMapMethodCall(call *ast.CallExpr) (value, bool, error) {
 		return value{}, true, err
 	}
 	switch field.Name {
+	case "len":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "map.len requires no arguments")
+		}
+		g.declareRuntimeSymbol(mapRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i64", mapRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "isEmpty":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "map.isEmpty requires no arguments")
+		}
+		g.declareRuntimeSymbol(mapRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		lenVal := llvmCall(emitter, "i64", mapRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
+		cmp := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
+		g.takeOstyEmitter(emitter)
+		return value{typ: "i1", ref: cmp}, true, nil
 	case "containsKey":
 		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 			return value{}, true, unsupported("call", "map.containsKey requires one positional argument")
@@ -2478,6 +2513,17 @@ func (g *generator) emitSetMethodCall(call *ast.CallExpr) (value, bool, error) {
 		out := llvmCall(emitter, "i64", setRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), true, nil
+	case "isEmpty":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "set.isEmpty requires no arguments")
+		}
+		g.declareRuntimeSymbol(setRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		lenVal := llvmCall(emitter, "i64", setRuntimeLenSymbol(), []*LlvmValue{toOstyValue(base)})
+		cmp := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
+		g.takeOstyEmitter(emitter)
+		return value{typ: "i1", ref: cmp}, true, nil
 	case "contains", "remove":
 		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 			return value{}, true, unsupportedf("call", "set.%s requires one positional argument", field.Name)

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -109,6 +109,40 @@ func TestGenerateExprStmtListPopNoLongerTripsLLVM015(t *testing.T) {
 	}
 }
 
+// TestGenerateCollectionIsEmptyLowersAsLenEqZero verifies that
+// `list.isEmpty()`, `map.isEmpty()`, and `set.isEmpty()` all inline
+// the stdlib default body (`self.len() == 0`) as a runtime `*_len`
+// call followed by `icmp eq i64 ..., 0`, instead of first-walling on
+// LLVM015 [method_call_field] for the default method. Map's `len` /
+// `isEmpty` share the same runtime helper (`osty_rt_map_len`) since
+// the Go wrapper was only declared — the C body had to land alongside
+// the dispatch.
+func TestGenerateCollectionIsEmptyLowersAsLenEqZero(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn allEmpty(xs: List<Int>, m: Map<String, Int>, s: Set<Int>) -> Bool {
+    xs.isEmpty() && m.isEmpty() && s.isEmpty()
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/isempty.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call i64 @osty_rt_list_len(",
+		"call i64 @osty_rt_map_len(",
+		"call i64 @osty_rt_set_len(",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestGenerateIndexedNestedListLenMethodDispatch(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn main() {
     let stacks: List<List<Int>> = [[1, 2], [3]]

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -359,6 +359,10 @@ func mapRuntimeKeysSymbol() string {
 	return llvmMapRuntimeKeysSymbol()
 }
 
+func mapRuntimeLenSymbol() string {
+	return llvmMapRuntimeLenSymbol()
+}
+
 func setRuntimeNewSymbol() string {
 	return llvmSetRuntimeNewSymbol()
 }

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -859,6 +859,8 @@ func (g *generator) staticCollectionMethodResult(call *ast.CallExpr) (value, boo
 		switch field.Name {
 		case "len":
 			return value{typ: "i64"}, true, true
+		case "isEmpty":
+			return value{typ: "i1"}, true, true
 		case "sorted":
 			return value{typ: "ptr", gcManaged: true, listElemTyp: elemTyp, listElemString: elemString}, true, true
 		case "toSet":
@@ -869,6 +871,10 @@ func (g *generator) staticCollectionMethodResult(call *ast.CallExpr) (value, boo
 	}
 	if _, keyTyp, _, keyString, found := g.mapMethodInfo(call); found {
 		switch field := call.Fn.(*ast.FieldExpr); field.Name {
+		case "len":
+			return value{typ: "i64"}, true, true
+		case "isEmpty":
+			return value{typ: "i1"}, true, true
 		case "containsKey":
 			return value{typ: "i1"}, true, true
 		case "keys":
@@ -883,6 +889,8 @@ func (g *generator) staticCollectionMethodResult(call *ast.CallExpr) (value, boo
 		switch field := call.Fn.(*ast.FieldExpr); field.Name {
 		case "len":
 			return value{typ: "i64"}, true, true
+		case "isEmpty":
+			return value{typ: "i1"}, true, true
 		case "contains", "remove":
 			return value{typ: "i1"}, true, true
 		case "toList":
@@ -903,7 +911,7 @@ func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, 
 		return nil, "", false, false
 	}
 	switch field.Name {
-	case "len", "pop", "push", "sorted", "toSet":
+	case "len", "isEmpty", "pop", "push", "sorted", "toSet":
 	default:
 		return nil, "", false, false
 	}
@@ -923,7 +931,7 @@ func (g *generator) mapMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, s
 		return nil, "", "", false, false
 	}
 	switch field.Name {
-	case "containsKey", "insert", "remove", "keys":
+	case "containsKey", "insert", "remove", "keys", "len", "isEmpty":
 	default:
 		return nil, "", "", false, false
 	}
@@ -943,7 +951,7 @@ func (g *generator) setMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, b
 		return nil, "", false, false
 	}
 	switch field.Name {
-	case "len", "contains", "insert", "remove", "toList":
+	case "len", "isEmpty", "contains", "insert", "remove", "toList":
 	default:
 		return nil, "", false, false
 	}


### PR DESCRIPTION
## Summary

- `TestProbeNativeToolchainMerged` was first-walling on `LLVM015 [method_call_field]` at `diag_harvest.osty:92` (`outcome.emittedCodes.isEmpty()`). `isEmpty` is the stdlib default `self.len() == 0`; instead of pulling in the full LLVM018 stdlib-body lowering stack, inline the two-instruction form directly in the collection method dispatchers.
- `List.isEmpty()` / `Map.isEmpty()` / `Set.isEmpty()` lower as a `*_len` runtime call followed by `icmp eq i64 <len>, 0`.
- `Map.len()` was also missing an AST-path dispatch — added alongside `isEmpty` so the map path has something to call into.
- `osty_rt_map_len` was declared in the Go wrapper tables but never implemented in the C runtime — added the body (`return map->len`) so the new dispatch actually links, plus a `mapRuntimeLenSymbol()` wrapper.
- Extended `listMethodInfo` / `mapMethodInfo` / `setMethodInfo` + `staticCollectionMethodResult` to route `isEmpty` (and map `len`) through the same static type-inference path the rest of the collection surface uses.

## Probe wall movement

- Before: `LLVM015 [method_call_field] — call target *ast.FieldExpr (outcome.emittedCodes.isEmpty)`
- After: `LLVM011 [other] type-system: logical not on %PmCheckOutcome` (a separate structural-enum booleanisation gap — `!enumValue` on a nominal enum, outside the method_call_field chain)

The entire LLVM015 [method_call_field] chain (pop → nested-index → isEmpty) is now closed.

## Test plan

- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — confirms new wall is `LLVM011 [other] logical not`
- [x] `go test ./internal/llvmgen -run 'TestGenerateCollectionIsEmptyLowersAsLenEqZero' -count=1 -v` — new focused regression covering list/map/set isEmpty through a single chained expression
- [x] `go test ./internal/llvmgen -count=1 -short` — same 12 preexisting failures (`TestRawNullEndToEndLLVMEmit`, `TestRuntimeIntrinsicTyping*`, `TestGenerateModuleGenericEnumMaybe*`, `TestGenerateModuleBuiltinResultConstructorsTrackLocalContext`), no new regressions
- [x] `go test ./internal/backend/... -count=1 -short` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)