### PR TITLE
fix(selfhost): register `use` declaration aliases as module namespaces

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -41047,10 +41047,115 @@ func collectDecls(cx *ElabCx) {
 			if func() bool { _, ok := _m2232.(*AstNodeKind_AstNLetDecl); return ok }() {
 				collectLetDecl(cx, declIdx, node)
 			}
+			// Mirrored from toolchain/check.osty pending a regen fix.
+			if func() bool { _, ok := _m2232.(*AstNodeKind_AstNUseDecl); return ok }() {
+				collectUseDecl(cx, declIdx, node)
+			}
 			{
 			}
 		}
 	}
+}
+
+// collectUseDecl registers `use go "..." as X { fn foo(...) ... }`
+// bodies so toolchain-style namespaced calls (`X.foo(args)`) resolve
+// through the ordinary method-lookup path. Mirrored from
+// toolchain/check.osty pending a regen fix.
+func collectUseDecl(cx *ElabCx, declIdx int, node *AstNode) {
+	alias := useDeclAliasName(cx, node)
+	if alias == "" {
+		return
+	}
+	env := cx.env
+	moduleTy := tyNamed(env.tys, alias, nil)
+	checkBindSpan(env, alias, moduleTy, false, node.start, node.end)
+	checkRecordSymbol(env, declIdx, "use", alias, "", moduleTy, node.start, node.end)
+	// Only register fn members — struct / type-alias collection would
+	// need `<alias>.<Name>` keys to match the dotted form used in
+	// annotations outside the block; that wiring lives in a
+	// follow-up.
+	for _, bodyIdx := range node.children {
+		body := astArenaNodeAt(cx.ast.arena, bodyIdx)
+		if _, ok := body.kind.(*AstNodeKind_AstNFnDecl); ok {
+			collectFnDecl(cx, bodyIdx, body, alias, make([]string, 0), make([]*CheckGenericBound, 0))
+		}
+	}
+	// `use std.strings as X` — pull the hot subset of std.strings under
+	// the alias so `X.hasPrefix(...)` / `X.join(...)` resolve.
+	if node.text == "std.strings" {
+		registerStdStringsAliasFns(env, alias)
+	}
+}
+
+// registerStdStringsAliasFns registers the hot subset of std.strings
+// exports under alias. Mirrored from toolchain/check.osty pending a
+// regen fix.
+func registerStdStringsAliasFns(env *CheckEnv, alias string) {
+	tys := env.tys
+	tString_ := tString(tys)
+	tBool_ := tBool(tys)
+	tInt_ := tInt(tys)
+	tListString := tyNamed(tys, "List", []int{tString_})
+	tListChar_ := tyNamed(tys, "List", []int{tChar(tys)})
+	tListByte_ := tyNamed(tys, "List", []int{tByte(tys)})
+	tOptInt := tyOptional(tys, tInt_)
+
+	empty := func() []string { return make([]string, 0) }
+	bounds := func() []*CheckGenericBound { return make([]*CheckGenericBound, 0) }
+
+	add := func(name string, ret int, paramNames []string, paramTys []int) {
+		checkRegisterFn(env, &CheckFnSig{
+			name: name, owner: alias, receiverTy: -1, retTy: ret,
+			paramNames: paramNames, paramTys: paramTys,
+			generics: empty(), genericBounds: bounds(),
+		})
+	}
+	s1 := func(name string, ret int) {
+		add(name, ret, []string{"s"}, []int{tString_})
+	}
+	s2 := func(name string, ret int, p2 string) {
+		add(name, ret, []string{"s", p2}, []int{tString_, tString_})
+	}
+
+	s1("len", tInt_)
+	s1("isEmpty", tBool_)
+	add("concat", tString_, []string{"a", "b"}, []int{tString_, tString_})
+	s1("chars", tListChar_)
+	s1("bytes", tListByte_)
+	s2("split", tListString, "sep")
+	add("splitN", tListString, []string{"s", "sep", "n"}, []int{tString_, tString_, tInt_})
+	s1("lines", tListString)
+	add("join", tString_, []string{"parts", "sep"}, []int{tListString, tString_})
+	s2("contains", tBool_, "substr")
+	s2("indexOf", tOptInt, "substr")
+	s2("lastIndexOf", tOptInt, "substr")
+	s2("count", tInt_, "substr")
+	s2("startsWith", tBool_, "prefix")
+	s2("hasPrefix", tBool_, "prefix")
+	s2("endsWith", tBool_, "suffix")
+	s2("hasSuffix", tBool_, "suffix")
+	s1("trim", tString_)
+	s1("trimSpace", tString_)
+	s2("trimPrefix", tString_, "prefix")
+	s2("trimSuffix", tString_, "suffix")
+	s1("toUpper", tString_)
+	s1("toLower", tString_)
+	add("compare", tInt_, []string{"a", "b"}, []int{tString_, tString_})
+}
+
+func useDeclAliasName(cx *ElabCx, node *AstNode) string {
+	if checkIntListLenLocal(node.children2) == 0 {
+		return ""
+	}
+	aliasIdx := checkIntListAtLocal(node.children2, 0)
+	if aliasIdx < 0 {
+		return ""
+	}
+	aliasNode := astArenaNodeAt(cx.ast.arena, aliasIdx)
+	if _, ok := aliasNode.kind.(*AstNodeKind_AstNIdent); !ok {
+		return ""
+	}
+	return aliasNode.text
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18261:1

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -136,10 +136,218 @@ fn collectDecls(cx: ElabCx) {
             AstNTypeAlias -> collectTypeAlias(cx, declIdx, node),
             AstNLet -> collectLetDecl(cx, declIdx, node),
             AstNLetDecl -> collectLetDecl(cx, declIdx, node),
+            AstNUseDecl -> collectUseDecl(cx, declIdx, node),
             _ -> {},
         }
     }
 }
+
+/// collectUseDecl handles `use` declarations — both the Go FFI form
+/// with an inline body and the plain `use path as X` aliases.
+/// Registers the alias as a module-like binding and every fn member
+/// under that alias as owner, so call sites like `X.foo(args)`
+/// resolve through the ordinary `checkLookupMethod(env, "X", "foo")`
+/// path. The Go-side resolver threads actual package surfaces
+/// through this symbol; here we only need enough to satisfy the
+/// type checker's dotted-lookup — the native backend still sees the
+/// raw FFI shape.
+///
+/// Note: the probe that filters bootstrap-only files greps the
+/// literal substring `use go <dqlit>` — we deliberately avoid
+/// that token sequence here so a doc comment doesn't accidentally
+/// mark this file as bootstrap-only.
+fn collectUseDecl(cx: ElabCx, declIdx: Int, node: AstNode) {
+    let alias = useDeclAliasName(cx, node)
+    if alias == "" {
+        return
+    }
+    let env = cx.env
+    // Register a binding so bare `X` in expression position has a
+    // type; the head name is what `checkLookupMethod` keys off.
+    let moduleTy = tyNamed(env.tys, alias, [])
+    checkBindSpan(env, alias, moduleTy, false, node.start, node.end)
+    checkRecordSymbol(env, declIdx, "use", alias, "", moduleTy, node.start, node.end)
+
+    // Only register fn members for now. Struct / type-alias bodies
+    // would need to be stored under `<alias>.<Name>` to match the
+    // dotted forms used in type annotations outside the block
+    // (`astbridge.Pos` vs `Pos`) — wiring that into the whole
+    // alias-resolution + unification path is a separate fix.
+    for bodyIdx in node.children {
+        let body = astArenaNodeAt(cx.ast.arena, bodyIdx)
+        if body.kind == AstNFnDecl {
+            collectFnDecl(cx, bodyIdx, body, alias, [], [])
+        }
+    }
+
+    // `use std.strings as X` (no body) — pull the std.strings surface
+    // under the alias. Toolchain code routinely spells this as
+    // `strings`, `ciStrings`, `pkgStrings`, `llvmStrings`, etc.
+    if node.text == "std.strings" {
+        registerStdStringsAliasFns(env, alias)
+    }
+}
+
+/// registerStdStringsAliasFns registers the hot subset of std.strings
+/// exports under `alias` so `alias.fn(...)` resolves. Scope mirrors
+/// the top E0703 names from the `osty check toolchain` histogram so
+/// the net diagnostic reduction is maximal. Additional helpers can
+/// land as they surface; the full std.strings surface lives in
+/// `internal/stdlib/modules/strings.osty`.
+fn registerStdStringsAliasFns(env: CheckEnv, alias: String) {
+    let tys = env.tys
+    let tString_ = tString(tys)
+    let tBool_ = tBool(tys)
+    let tInt_ = tInt(tys)
+    let tListString = tyNamed(tys, "List", [tString_])
+    let tListChar_ = tyNamed(tys, "List", [tChar(tys)])
+    let tListByte_ = tyNamed(tys, "List", [tByte(tys)])
+    let tOptInt = tyOptional(tys, tInt_)
+
+    let emptyGenerics: List<String> = []
+    let emptyBounds: List<CheckGenericBound> = []
+
+    checkRegisterFn(env, CheckFnSig {
+        name: "len", owner: alias, receiverTy: -1, retTy: tInt_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "isEmpty", owner: alias, receiverTy: -1, retTy: tBool_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "concat", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["a", "b"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "chars", owner: alias, receiverTy: -1, retTy: tListChar_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "bytes", owner: alias, receiverTy: -1, retTy: tListByte_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "split", owner: alias, receiverTy: -1, retTy: tListString,
+        paramNames: ["s", "sep"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "splitN", owner: alias, receiverTy: -1, retTy: tListString,
+        paramNames: ["s", "sep", "n"], paramTys: [tString_, tString_, tInt_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "lines", owner: alias, receiverTy: -1, retTy: tListString,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "join", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["parts", "sep"], paramTys: [tListString, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "contains", owner: alias, receiverTy: -1, retTy: tBool_,
+        paramNames: ["s", "substr"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "indexOf", owner: alias, receiverTy: -1, retTy: tOptInt,
+        paramNames: ["s", "substr"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "lastIndexOf", owner: alias, receiverTy: -1, retTy: tOptInt,
+        paramNames: ["s", "substr"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "count", owner: alias, receiverTy: -1, retTy: tInt_,
+        paramNames: ["s", "substr"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "startsWith", owner: alias, receiverTy: -1, retTy: tBool_,
+        paramNames: ["s", "prefix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "hasPrefix", owner: alias, receiverTy: -1, retTy: tBool_,
+        paramNames: ["s", "prefix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "endsWith", owner: alias, receiverTy: -1, retTy: tBool_,
+        paramNames: ["s", "suffix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "hasSuffix", owner: alias, receiverTy: -1, retTy: tBool_,
+        paramNames: ["s", "suffix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "trim", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "trimSpace", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "trimPrefix", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["s", "prefix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "trimSuffix", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["s", "suffix"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "toUpper", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "toLower", owner: alias, receiverTy: -1, retTy: tString_,
+        paramNames: ["s"], paramTys: [tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "compare", owner: alias, receiverTy: -1, retTy: tInt_,
+        paramNames: ["a", "b"], paramTys: [tString_, tString_],
+        generics: emptyGenerics, genericBounds: emptyBounds,
+    })
+}
+
+/// useDeclAliasName returns the declared alias (`as X`) or "" when the
+/// alias is missing. The Go-side resolver falls back to the last path
+/// segment; toolchain code always spells the alias explicitly so we
+/// keep the minimal form here.
+fn useDeclAliasName(cx: ElabCx, node: AstNode) -> String {
+    if checkIntListLenLocal(node.children2) == 0 {
+        return ""
+    }
+    let aliasIdx = checkIntListAtLocal(node.children2, 0)
+    if aliasIdx < 0 {
+        return ""
+    }
+    let aliasNode = astArenaNodeAt(cx.ast.arena, aliasIdx)
+    if aliasNode.kind != AstNIdent {
+        return ""
+    }
+    aliasNode.text
+}
+
 
 fn collectFnDecl(
     cx: ElabCx,


### PR DESCRIPTION
## Summary

Self-host `collectDecls` silently ignored `AstNUseDecl`, so toolchain sites like `strings.hasPrefix(...)` / `llvmStrings.join(...)` / `astbridge.GetPos(...)` never resolved the alias identifier and fired `E0745 cannot find 'strings' in this scope`. **275 of the 297 remaining native-only E0745 errors** (the second-largest class after the intrinsics registered in [#430](https://github.com/choiceoh/osty/pull/430)) came from this miss.

## What changed

Wire up a minimal module-namespace layer in the collect pass:

**1. Alias binding.** `collectUseDecl` registers the alias name (`X` in `use ... as X`) as a module-valued binding with type `tyNamed(alias, [])`. Bare references (`strings`, `astbridge`) now resolve via `elabInferIdent`, so the downstream field access routes through `elabInferMethodCall` with a proper receiver head.

**2. Inline FFI body fns.** Each fn declaration inside a `use <FFI-path> as X { fn foo(...) ... }` block is registered via `collectFnDecl(..., owner=alias, ...)`. `checkLookupMethod(env, alias, name)` then finds them exactly like any struct method. Struct / type-alias members are intentionally left out this round — they'd need `<alias>.<Name>` keys to match the dotted form used in annotations outside the block (`astbridge.Pos` vs `Pos`), and the wiring into alias-aware type unification is a separate fix.

**3. `use std.strings as X` helper set.** Every non-bootstrap toolchain file aliases the prelude strings module under `strings` / `ciStrings` / `pkgStrings` / `llvmStrings`. For `rawPath == "std.strings"` we register a hot subset of std.strings exports under the alias: `len`, `isEmpty`, `concat`, `chars`, `bytes`, `split`, `splitN`, `lines`, `join`, `contains`, `indexOf`, `lastIndexOf`, `count`, `startsWith`, `hasPrefix`, `endsWith`, `hasSuffix`, `trim`, `trimSpace`, `trimPrefix`, `trimSuffix`, `toUpper`, `toLower`, `compare`. Scope matches the top E0703 names from the histogram so the net diagnostic reduction is maximal; the full surface lives in [`internal/stdlib/modules/strings.osty`](internal/stdlib/modules/strings.osty) and lands when the stdlib loader wiring is in place.

## Measured impact

Toolchain histograms via `selfhost.CheckPackageStructured`:

| | before | after | Δ |
|---|---|---|---|
| full errors | 1065 | 949 | −116 |
| **native-only errors** | **570** | **306** | **−264 (−46.3%)** |
| native E0745 | 297 | 22 | **−275 (−92.6%)** |
| full accepted | 24092 / 24194 | 26780 / 27470 | +2688 |

Remaining 22 native E0745 are three payload-ful variant constructor names (`Ok` / `Err` / `Some`) — a separate structural fix.

The full-mode E0700 rises 137 → 725 because the bootstrap-only adapters (`ast_lower.osty`, `ci.osty`, `docgen.osty`, `manifest_validation.osty`) now resolve their FFI fn calls but mismatch on the dotted vs. bare struct names (`astbridge.Pos` vs `Pos`). Those files are explicitly skipped by `TestProbeNativeToolchainMerged` — they **are** the bootstrap bridge — so the cascade does not touch the self-hosting path.

### Cumulative selfhost progress (main → now)

Starting from the 6308 baseline before [#421](https://github.com/choiceoh/osty/pull/421), the toolchain self-check error count on the native path is now down to **306** — roughly a **95% reduction** over five PRs.

## Verification

- Minimal inline-body FFI reproducer → 0 errors
- `use std.strings as ciStrings; fn f(s: String) -> Bool { ciStrings.hasPrefix(s, "!") }` → 0 errors
- `osty gen --backend=llvm` on hello → exit 0
- `TestProbeWholeToolchainMerged` → unchanged wall (`runtime.golegacy.astbridge`)
- `TestProbeNativeToolchainMerged` → unchanged wall (`LLVM015 method_call_field`), still skips exactly the 4 documented bootstrap-only files. (The doc comment in `collectUseDecl` deliberately avoids writing the literal `use go <dqlit>` sequence so the probe's substring filter doesn't accidentally mark `check.osty` as bootstrap-only.)
- 4 targeted `internal/llvmgen` regressions → pass
- `internal/lexer`, `internal/parser` → pass

## Mirror protocol

Edits live in `toolchain/check.osty` (source of truth) and `internal/selfhost/generated.go`. Regen is still blocked on bootstrap-gen, so hunks carry `// Mirrored from ... pending a regen fix` comments — same protocol as [#421](https://github.com/choiceoh/osty/pull/421) / [#422](https://github.com/choiceoh/osty/pull/422) / [#423](https://github.com/choiceoh/osty/pull/423) / [#430](https://github.com/choiceoh/osty/pull/430).

🤖 Generated with [Claude Code](https://claude.com/claude-code)