### PR TITLE
fix: Windows CRLF/exe 환경성 이슈 5종 + airepair enumerate 네이밍 잔여 마이그

### DIFF
--- a/cmd/osty/airepair_test.go
+++ b/cmd/osty/airepair_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -863,7 +864,14 @@ func buildOstyCLI(t *testing.T) string {
 			ostyCLIBuildErr = fmt.Errorf("mktemp: %w", err)
 			return
 		}
-		ostyCLIBuildPath = filepath.Join(tmpDir, "osty")
+		name := "osty"
+		if runtime.GOOS == "windows" {
+			// `go build -o NAME` appends .exe automatically on
+			// Windows; match it here so direct exec.Command callers
+			// resolve the binary.
+			name += ".exe"
+		}
+		ostyCLIBuildPath = filepath.Join(tmpDir, name)
 		cmd := exec.Command("go", "build", "-o", ostyCLIBuildPath, ".")
 		cmd.Dir, ostyCLIBuildErr = os.Getwd()
 		if ostyCLIBuildErr != nil {

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -377,6 +377,9 @@ func main() {
 					}
 					runInspect(selected.file.File, selected.chk, flags)
 				}
+				if flags.dumpNativeDiags {
+					dumpNativeDiagsFor(path, selected.chk)
+				}
 				if hasError(diags) {
 					os.Exit(1)
 				}

--- a/internal/airepair/corpus_test.go
+++ b/internal/airepair/corpus_test.go
@@ -1,6 +1,7 @@
 package airepair
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -304,5 +305,8 @@ func readCorpusFixture(t *testing.T, path string) []byte {
 	if err != nil {
 		t.Fatalf("read fixture %s: %v", path, err)
 	}
-	return src
+	// Normalize CRLF→LF so Windows checkouts (core.autocrlf=true) match
+	// the airepair pipeline's own LF normalization and the goldens that
+	// were captured on LF systems.
+	return bytes.ReplaceAll(src, []byte("\r\n"), []byte("\n"))
 }

--- a/internal/airepair/semantic.go
+++ b/internal/airepair/semantic.go
@@ -154,7 +154,7 @@ func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair
 	indexVar := indexBinding
 	switch {
 	case indexBinding == "_":
-		indexVar = fmt.Sprintf("_airepair_index%d", *counter)
+		indexVar = fmt.Sprintf("_osty_index%d", *counter)
 	case isSimpleIdentifierBinding(indexBinding):
 		// use the original binding directly in the rewritten loop header.
 	default:
@@ -163,7 +163,7 @@ func rewriteEnumerateLoopHeader(line sourceLine, counter *int) (string, []repair
 
 	next := *counter
 	*counter = next + 1
-	iterTemp := fmt.Sprintf("_airepair_enumerate%d", next)
+	iterTemp := fmt.Sprintf("_osty_enumerate%d", next)
 
 	bodyIndent := line.indent + semanticIndentStep
 	var out strings.Builder

--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
@@ -163,7 +164,16 @@ func buildRepoNativeChecker(t *testing.T) string {
 		t.Fatalf("getwd: %v", err)
 	}
 	root := filepath.Clean(filepath.Join(cwd, "..", ".."))
-	bin := filepath.Join(t.TempDir(), "osty-native-checker")
+	name := "osty-native-checker"
+	if runtime.GOOS == "windows" {
+		// `go build -o NAME` appends .exe automatically on Windows;
+		// match it here so callers that pass the path directly to
+		// exec.Command (without going through exec.LookPath) find the
+		// binary. The env-var path below goes through LookPath and
+		// handles the extension transparently, so either form works.
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
 	cmd := exec.Command("go", "build", "-o", bin, "./cmd/osty-native-checker")
 	cmd.Dir = root
 	out, err := cmd.CombinedOutput()

--- a/internal/manifest/toml.go
+++ b/internal/manifest/toml.go
@@ -569,6 +569,15 @@ func (p *tomlParser) skipHorizontalWhitespace() {
 		switch p.src[p.pos] {
 		case ' ', '\t':
 			p.pos++
+		case '\r':
+			// Tolerate CRLF: swallow \r when paired with a following
+			// \n so downstream end-of-line checks see the LF. A lone
+			// \r is left to caller so real errors still surface.
+			if p.pos+1 < len(p.src) && p.src[p.pos+1] == '\n' {
+				p.pos++
+				continue
+			}
+			return
 		default:
 			return
 		}

--- a/internal/selfhost/parse_snapshot_test.go
+++ b/internal/selfhost/parse_snapshot_test.go
@@ -70,6 +70,11 @@ func TestParseSnapshot(t *testing.T) {
 				t.Skipf("corpus file missing: %v", err)
 				return
 			}
+			// Normalize CRLF→LF: goldens were captured from a
+			// LF-normalized source, so Windows checkouts with
+			// core.autocrlf=true would otherwise yield different
+			// byte offsets in every Pos field and fail every case.
+			src = []byte(strings.ReplaceAll(string(src), "\r\n", "\n"))
 
 			file, diags := Parse(src)
 			got := dumpParseResult(file, diags)
@@ -86,8 +91,14 @@ func TestParseSnapshot(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read golden (set UPDATE_SNAPSHOT=1 to seed): %v", err)
 			}
-			if string(want) != got {
-				t.Fatalf("parse snapshot drift for %s\nfirst diff line: %s\n(re-run with UPDATE_SNAPSHOT=1 after a deliberate behavior change)", rel, firstDiffLine(string(want), got))
+			// Normalize CRLF→LF: Windows checkouts with
+			// core.autocrlf=true store goldens with \r\n, but `got`
+			// is generated in-memory with \n only. Without this the
+			// test fails with a diff where every line looks
+			// identical but differs by the trailing \r.
+			wantStr := strings.ReplaceAll(string(want), "\r\n", "\n")
+			if wantStr != got {
+				t.Fatalf("parse snapshot drift for %s\nfirst diff line: %s\n(re-run with UPDATE_SNAPSHOT=1 after a deliberate behavior change)", rel, firstDiffLine(wantStr, got))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Windows 체크아웃(core.autocrlf=true)에서 침묵하거나 오진단하던 5개 지점을 정리하고, 부수적으로 #10a634d의 리네임이 빠뜨렸던 airepair 생성 코드 한 군데를 마저 갱신합니다.

개별 커밋 단위로 독립적이고 본질 컴파일러 로직은 미터치.

## Commits

1. **`fix(manifest): TOML header 파서가 CRLF 줄 종결자 허용`**
   `parseHeader`의 `skipHorizontalWhitespace`가 `\r`을 공백으로 취급하지 않아 `[package]\r\n` 뒤에서 **E2000 "garbage after table header"** 로 죽었고, `osty check DIR` 경로가 manifest 로드 단계에서 아예 멈춰 있었다. `skipWhitespaceAndComments`는 이미 CRLF를 관용하므로 동일 처리를 horizontal-whitespace에도 추가 — `\r`이 `\n`과 짝일 때만 소비해서 고아 `\r`은 진단을 계속 발화.

2. **`fix(osty): --dump-native-diags 파일-in-패키지 check 경로에 배선`**
   플래그가 단일-파일(`main.go:466`)과 디렉토리/워크스페이스(`619`, `694`) 경로에는 배선돼 있었지만 `osty check toolchain/check.osty`처럼 패키지 내부 파일 하나를 지정하는 `loadSelectedPackageEntry…` 경로에만 빠져 있어서, 같은 플래그로 같은 텔레메트리를 기대한 호출자가 침묵 결과만 받았다.

3. **`test: Windows에서 test helper가 .exe 확장자를 포함하도록`**
   `go build -o NAME`은 Windows에서 확장자 없으면 `NAME.exe`로 빌드. 테스트 헬퍼 두 곳이 빌드한 바이너리를 직접 `exec.Command`로 호출하면서 확장자 없는 경로를 넘겨 `executable file not found in %PATH%`로 죽었다. 환경변수 경로는 `exec.LookPath`가 PATHEXT를 투명하게 처리하지만 직접 호출 경로는 호출자 책임. 헬퍼 두 개(`internal/check/native_checker_exec_test.go:buildRepoNativeChecker`, `cmd/osty/airepair_test.go:buildOstyCLI`)를 나란히 수정. `internal/check` 테스트 4개가 통과로 전환 (`TestNativeBoundary*`, `TestDefaultNativeChecker*`).

4. **`test(selfhost): CRLF-tolerant parse snapshot 비교`**
   `testdata/parse_snapshots/*.txt` 골든은 autocrlf로 CRLF 저장, `dumpParseResult`는 `\n`만 출력 → byte-exact 비교 실패. `firstDiffLine`이 trailing `\r` 차이를 "line 1: want ===ast=== got ===ast===" 처럼 동일한 줄로 표시해 진단까지 막았다. 또한 `.osty` 코퍼스 자체도 CRLF로 체크아웃돼서 파서가 `\r` 포함 바이트 오프셋을 AST에 박아 넣어 골든 수치와 어긋났다. 골든 + 소스 모두 LF로 정규화. **TestParseSnapshot 16개 서브테스트 전부 PASS로 전환**.

5. **`fix(airepair): enumerate 리라이트 임시변수 네이밍 _osty_ 정렬 + CRLF-tolerant 코퍼스 비교`**
   #10a634d "Promote stable foreign syntax into the parser front-end"가 airepair 생성 이름을 `_airepair_` → `_osty_`로 일괄 리네임하면서 픽스처, 유닛 테스트, LSP 테스트 기대값은 전부 `_osty_`로 바꿨지만 **실제 생성 코드인 `internal/airepair/semantic.go` 두 곳이 빠져** 있어서 Python enumerate 리라이트 계열 테스트가 `_airepair_enumerate0` vs `_osty_enumerate0`으로 실패했다. 두 접두사를 기대값에 맞춰 갱신. 같은 커밋에 `corpus_test.go` 픽스처 읽기도 CRLF→LF 정규화 (airepair 파이프라인 자체가 LF로 출력). **`TestFixAllActionUsesAIRepairForPythonEnumerateLoop` 통과**.

## Test delta (Windows 기준)

- `internal/manifest/…` — 변화 없음, 기존 통과
- `internal/check/…` — 4개 실패 → 0개 (native_checker_exec 계열)
- `internal/selfhost/TestParseSnapshot/…` — 16개 실패 → 0개
- `internal/lsp/TestFixAllActionUsesAIRepairForPythonEnumerateLoop` — 실패 → 통과
- `internal/airepair/…` — `TestAnalyzeCorpus` 12개 실패 → 4개 (`foreign_len_helpers`, `foreign_append_helper`, `python_enumerate_loop`, `python_match_case`). 남은 4건은 리페어 결과물에 대한 native-checker의 `List.len()` / for-in pattern / 모듈 alias 미해소로 본 PR 범위 밖 (regen 파이프라인 의존).

## Test plan

- [ ] `go test -count=1 ./internal/manifest/... ./internal/check/... ./internal/selfhost/... ./internal/airepair/... ./internal/lsp/...` — 새로 통과한 테스트들 녹색 확인
- [ ] Windows 체크아웃(core.autocrlf=true)에서 `osty check toolchain` — 예전엔 `E2000 garbage after table header`로 죽었는데 정상 결과 + `--dump-native-diags`로 컨텍스트 히스토그램 확인

## 범위 밖

`osty check toolchain`의 총 6316 errors(rebase 직후 6340) 본체는 `internal/selfhost/generated.go` 재생성 파이프라인이 깨진 상태(`s.chars undefined`, Result `?` nil compare 등)에 막혀 있어서 별도 이슈로 추적됩니다. 본 PR은 그와 독립적인 환경성 + 테스트 infra 수선만 담당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)