### PR TITLE
fix(parser): hoist prefix unary over postfix operands (!x.y precedence)

### DIFF
--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -23,16 +23,25 @@ As of 2026-04-19:
 - the whole-toolchain merged LLVM probe still first-walls on the
   bootstrap-only `runtime.golegacy.astbridge` bridge
 - the native-only merged LLVM probe (with bootstrap-only files skipped)
-  now first-walls on `LLVM011 [other] type-system: logical not on
-  %PmCheckOutcome` — a separate structural-enum booleanisation gap
-  (`!enumValue` on a nominal enum type). The whole LLVM015
-  [method_call_field] chain that preceded it is closed: `List.isEmpty`
-  / `Map.isEmpty` / `Set.isEmpty` are inlined as `icmp eq i64 <len>,
-  0` (the stdlib default body form), with `osty_rt_map_len` landing
-  in the C runtime alongside the dispatch (the Go wrapper was already
-  declared); `List.pop()` discard sites go through the upstream
-  `osty_rt_list_pop_discard` helper; nested `IndexExpr` propagates
-  List / Map / Set element shapes via `decorateStaticValueFromSourceType`.
+  now first-walls on `LLVM011 [list_mixed_ptr] type-system: list literal
+  mixes String and non-String ptr-backed values` — a collection-literal
+  typing gap (heterogeneous ptr-backed element types in the same
+  `[...]` literal). The earlier LLVM011 `logical not on %PmCheckOutcome`
+  wall is closed: it was a **parser precedence bug**, not a backend
+  gap. The v0.5 grammar has `UnaryExpr ::= prefix UnaryExpr |
+  PostfixExpr`, so `!x.y` must parse as `!(x.y)`; the self-hosted
+  front-end was emitting `(!x).y`. Fixed at stable-AST lowering time
+  in `internal/parser/lower.go` via `hoistUnaryOverPostfix`, which
+  swaps prefix / postfix when a postfix node's receiver is a prefix
+  UnaryExpr (-, !, ~). Unblocks every `!a.b`, `!a[i]`, `!a()`,
+  `!a.m()` site in the toolchain. The whole LLVM015 [method_call_field]
+  chain that preceded it is also still closed: `List.isEmpty` /
+  `Map.isEmpty` / `Set.isEmpty` are inlined as `icmp eq i64 <len>, 0`
+  (the stdlib default body form), with `osty_rt_map_len` landing
+  in the C runtime alongside the dispatch; `List.pop()` discard sites
+  go through the `osty_rt_list_pop_discard` helper; nested `IndexExpr`
+  propagates List / Map / Set element shapes via
+  `decorateStaticValueFromSourceType`.
   The LLVM012 statement-form category has been cleared for the
   toolchain's actual shape: `LLVM011 [fn_param_struct_type]` Char wall
   at `lspUtf16UnitsForChar` fell first (Char→i32 / Byte→i8 lowering),
@@ -71,7 +80,7 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
-| Native backend surface | merged native-only probe | first wall is now `LLVM011 [other] type-system: logical not on %PmCheckOutcome` (structural-enum booleanisation — `!enumValue` on a nominal enum) after skipping 4 bootstrap-only files; the whole upstream LLVM015 [method_call_field] chain is closed — List / Map / Set `isEmpty` inline as `icmp eq i64 <len>, 0` (with `osty_rt_map_len` now implemented in the C runtime), nested `IndexExpr` propagates container element shapes, and `list.pop()` discard sites route through `osty_rt_list_pop_discard`; the `LLVM011 Char`, `LLVM012 *ast.MatchExpr`, and `LLVM012 field assignment base *ast.FieldExpr` walls remain closed |
+| Native backend surface | merged native-only probe | first wall is now `LLVM011 [list_mixed_ptr] list literal mixes String and non-String ptr-backed values` (heterogeneous ptr element types in a single `[...]` literal) after skipping 4 bootstrap-only files; the earlier `logical not on %PmCheckOutcome` wall was a parser precedence bug — `!x.y` was emitted as `(!x).y` instead of `!(x.y)` by the self-hosted front-end, now hoisted at stable-AST lowering time; List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites all remain closed |
 | Native backend surface | merged native-only probe | first wall is now `LLVM012 statement: field assignment base *ast.FieldExpr` (nested field assignment) after skipping 4 bootstrap-only files; the earlier `LLVM011 [fn_param_struct_type]` Char wall and the subsequent `LLVM012 *ast.MatchExpr is not a call` wall are both closed |
 | Native backend surface | merged native-only probe | first wall is now `LLVM012` (statement form) after skipping 4 bootstrap-only files; the earlier `LLVM011 [fn_param_struct_type]` Char wall is closed |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |

--- a/internal/parser/lower.go
+++ b/internal/parser/lower.go
@@ -151,7 +151,7 @@ func (l *stableLowerer) lowerExpr(expr ast.Expr) ast.Expr {
 		return n
 	case *ast.QuestionExpr:
 		n.X = l.lowerExpr(n.X)
-		return n
+		return hoistUnaryOverPostfix(n)
 	case *ast.CallExpr:
 		n.Fn = l.lowerExpr(n.Fn)
 		for i := range n.Args {
@@ -162,20 +162,20 @@ func (l *stableLowerer) lowerExpr(expr ast.Expr) ast.Expr {
 		if lowered, ok := l.lowerBuiltinLenCall(n); ok {
 			return lowered
 		}
-		return n
+		return hoistUnaryOverPostfix(n)
 	case *ast.FieldExpr:
 		n.X = l.lowerExpr(n.X)
-		return n
+		return hoistUnaryOverPostfix(n)
 	case *ast.IndexExpr:
 		n.X = l.lowerExpr(n.X)
 		n.Index = l.lowerExpr(n.Index)
-		return n
+		return hoistUnaryOverPostfix(n)
 	case *ast.TurbofishExpr:
 		n.Base = l.lowerExpr(n.Base)
 		for i := range n.Args {
 			n.Args[i] = l.lowerType(n.Args[i])
 		}
-		return n
+		return hoistUnaryOverPostfix(n)
 	case *ast.RangeExpr:
 		n.Start = l.lowerExpr(n.Start)
 		n.Stop = l.lowerExpr(n.Stop)
@@ -243,6 +243,78 @@ func (l *stableLowerer) lowerExpr(expr ast.Expr) ast.Expr {
 	default:
 		return n
 	}
+}
+
+// hoistUnaryOverPostfix fixes up a bootstrap-parser precedence bug.
+//
+// Per the v0.5 grammar `UnaryExpr ::= ('-' | '!' | '~') UnaryExpr |
+// PostfixExpr`, so `!x.y` must parse as `!(x.y)`. The self-hosted
+// front-end currently emits a flat token-span tree that, after
+// structural reassembly, yields `(!x).y` — the postfix op ends up
+// wrapping the UnaryExpr instead of being absorbed by the UnaryExpr's
+// operand. This breaks every `!a.b`, `!a[i]`, `!a()`, `!a?`, `!a.m()`
+// site in the toolchain source (and every user program with the same
+// shape).
+//
+// Rather than restructure the front-end parser tree we patch it up at
+// AST lowering time: when a postfix node's immediate receiver is a
+// prefix UnaryExpr (-, !, ~), swap them so the prefix wraps the
+// postfix. Idempotent for already-correct trees because the walker
+// only fires when the receiver is literally a *ast.UnaryExpr.
+//
+// Span preservation: the outer (originally postfix) node keeps its
+// own EndV — that's still the true source end. The new inner
+// postfix's PosV is the old unary operand's Pos so its span covers
+// "x.y" rather than "!x.y"; the wrapping UnaryExpr's PosV is the old
+// postfix PosV (the `!` position).
+func hoistUnaryOverPostfix(expr ast.Expr) ast.Expr {
+	switch n := expr.(type) {
+	case *ast.FieldExpr:
+		u, ok := n.X.(*ast.UnaryExpr)
+		if !ok || !isPrefixUnaryOp(u.Op) {
+			return n
+		}
+		n.X = u.X
+		n.PosV = u.X.Pos()
+		return &ast.UnaryExpr{PosV: u.PosV, EndV: n.EndV, Op: u.Op, X: hoistUnaryOverPostfix(n)}
+	case *ast.IndexExpr:
+		u, ok := n.X.(*ast.UnaryExpr)
+		if !ok || !isPrefixUnaryOp(u.Op) {
+			return n
+		}
+		n.X = u.X
+		n.PosV = u.X.Pos()
+		return &ast.UnaryExpr{PosV: u.PosV, EndV: n.EndV, Op: u.Op, X: hoistUnaryOverPostfix(n)}
+	case *ast.CallExpr:
+		u, ok := n.Fn.(*ast.UnaryExpr)
+		if !ok || !isPrefixUnaryOp(u.Op) {
+			return n
+		}
+		n.Fn = u.X
+		n.PosV = u.X.Pos()
+		return &ast.UnaryExpr{PosV: u.PosV, EndV: n.EndV, Op: u.Op, X: hoistUnaryOverPostfix(n)}
+	case *ast.QuestionExpr:
+		u, ok := n.X.(*ast.UnaryExpr)
+		if !ok || !isPrefixUnaryOp(u.Op) {
+			return n
+		}
+		n.X = u.X
+		n.PosV = u.X.Pos()
+		return &ast.UnaryExpr{PosV: u.PosV, EndV: n.EndV, Op: u.Op, X: hoistUnaryOverPostfix(n)}
+	case *ast.TurbofishExpr:
+		u, ok := n.Base.(*ast.UnaryExpr)
+		if !ok || !isPrefixUnaryOp(u.Op) {
+			return n
+		}
+		n.Base = u.X
+		n.PosV = u.X.Pos()
+		return &ast.UnaryExpr{PosV: u.PosV, EndV: n.EndV, Op: u.Op, X: hoistUnaryOverPostfix(n)}
+	}
+	return expr
+}
+
+func isPrefixUnaryOp(op token.Kind) bool {
+	return op == token.NOT || op == token.MINUS || op == token.BITNOT
 }
 
 func (l *stableLowerer) lowerType(ty ast.Type) ast.Type {

--- a/internal/parser/unary_postfix_test.go
+++ b/internal/parser/unary_postfix_test.go
@@ -1,0 +1,142 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/token"
+)
+
+// parseExprFromFn parses `fn __test() -> X { <expr> }` (or a statement-ish
+// wrapper) and returns the final expression. Used to pin down exactly what
+// the post-lowering AST shape looks like for a given source fragment.
+func parseExprInMain(t *testing.T, src string) ast.Expr {
+	t.Helper()
+	file, diags := ParseDiagnostics([]byte("fn __test() { let _probe = " + src + "\n}\n"))
+	if len(diags) > 0 {
+		t.Fatalf("ParseDiagnostics returned %d diagnostics: %v", len(diags), diags[0])
+	}
+	if file == nil {
+		t.Fatalf("ParseDiagnostics returned nil file")
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FnDecl)
+		if !ok || fn.Name != "__test" || fn.Body == nil {
+			continue
+		}
+		for _, stmt := range fn.Body.Stmts {
+			letStmt, ok := stmt.(*ast.LetStmt)
+			if !ok {
+				continue
+			}
+			return letStmt.Value
+		}
+	}
+	t.Fatalf("failed to locate probe expression in parsed AST")
+	return nil
+}
+
+// TestUnaryPostfixHoistingField is the canonical regression for the
+// `!pmOut.exhaustive` wall. Per grammar UnaryExpr sits above
+// PostfixExpr, so the parsed tree must be `Unary{!, Field{pmOut,
+// exhaustive}}` not `Field{Unary{!, pmOut}, exhaustive}`. The
+// self-hosted front-end emits the second shape; lower.go's
+// `hoistUnaryOverPostfix` fixes it up during the stable-AST lowering
+// pass.
+func TestUnaryPostfixHoistingField(t *testing.T) {
+	expr := parseExprInMain(t, "!foo.bar")
+	u, ok := expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("root type = %T, want *ast.UnaryExpr", expr)
+	}
+	if u.Op != token.NOT {
+		t.Fatalf("root op = %s, want !", u.Op)
+	}
+	field, ok := u.X.(*ast.FieldExpr)
+	if !ok {
+		t.Fatalf("inner type = %T, want *ast.FieldExpr", u.X)
+	}
+	if field.Name != "bar" {
+		t.Fatalf("inner field name = %q, want %q", field.Name, "bar")
+	}
+	if id, ok := field.X.(*ast.Ident); !ok || id.Name != "foo" {
+		t.Fatalf("deepest type = %T (%v), want Ident(foo)", field.X, field.X)
+	}
+}
+
+func TestUnaryPostfixHoistingIndex(t *testing.T) {
+	expr := parseExprInMain(t, "!items[0]")
+	u, ok := expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("root type = %T, want *ast.UnaryExpr", expr)
+	}
+	if _, ok := u.X.(*ast.IndexExpr); !ok {
+		t.Fatalf("inner type = %T, want *ast.IndexExpr", u.X)
+	}
+}
+
+func TestUnaryPostfixHoistingCall(t *testing.T) {
+	expr := parseExprInMain(t, "!check()")
+	u, ok := expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("root type = %T, want *ast.UnaryExpr", expr)
+	}
+	if _, ok := u.X.(*ast.CallExpr); !ok {
+		t.Fatalf("inner type = %T, want *ast.CallExpr", u.X)
+	}
+}
+
+// TestUnaryPostfixHoistingFieldMethodCall covers the compound shape
+// `!obj.method()` — the front-end first builds
+// `Call{Field{Unary{!, obj}, method}}`; hoisting fires twice (once for
+// the Field, once for the Call) to produce `Unary{!, Call{Field{obj,
+// method}}}`.
+func TestUnaryPostfixHoistingFieldMethodCall(t *testing.T) {
+	expr := parseExprInMain(t, "!outcome.isEmpty()")
+	u, ok := expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("root type = %T, want *ast.UnaryExpr", expr)
+	}
+	call, ok := u.X.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("inner type = %T, want *ast.CallExpr", u.X)
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		t.Fatalf("call.Fn type = %T, want *ast.FieldExpr", call.Fn)
+	}
+	if field.Name != "isEmpty" {
+		t.Fatalf("field name = %q, want %q", field.Name, "isEmpty")
+	}
+	if id, ok := field.X.(*ast.Ident); !ok || id.Name != "outcome" {
+		t.Fatalf("receiver = %T (%v), want Ident(outcome)", field.X, field.X)
+	}
+}
+
+// TestUnaryPostfixHoistingMinus and TestUnaryPostfixHoistingBitNot pin
+// the same behaviour for the other prefix operators so future regressions
+// in `-x.y` / `~x.y` surface immediately.
+func TestUnaryPostfixHoistingMinus(t *testing.T) {
+	expr := parseExprInMain(t, "-point.x")
+	u, ok := expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("root type = %T, want *ast.UnaryExpr", expr)
+	}
+	if u.Op != token.MINUS {
+		t.Fatalf("op = %s, want -", u.Op)
+	}
+	if _, ok := u.X.(*ast.FieldExpr); !ok {
+		t.Fatalf("inner type = %T, want *ast.FieldExpr", u.X)
+	}
+}
+
+func TestUnaryPostfixHoistingBitNot(t *testing.T) {
+	expr := parseExprInMain(t, "~mask.bits")
+	u, ok := expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("root type = %T, want *ast.UnaryExpr", expr)
+	}
+	if u.Op != token.BITNOT {
+		t.Fatalf("op = %s, want ~", u.Op)
+	}
+}


### PR DESCRIPTION
## Summary

- The v0.5 grammar specifies `UnaryExpr ::= ('-' | '!' | '~') UnaryExpr | PostfixExpr`, so `!x.y` must parse as `!(x.y)`. The self-hosted front-end was instead emitting `(!x).y` — the `.y` postfix ended up wrapping the UnaryExpr instead of being absorbed by its operand.
- This broke every `!a.b`, `!a[i]`, `!a()`, `!a?`, `!a.m()` site. Concretely it walled `TestProbeNativeToolchainMerged` on `LLVM011 type-system: logical not on %PmCheckOutcome` — the backend only knows how to `!` an `i1` and was being handed the struct receiver because `.exhaustive` had been applied on top of the `!` in `!pmOut.exhaustive` (elab.osty:2129).
- Rather than restructure the bootstrap front-end tree, patch up the shape in the stable-AST lowering pass. `hoistUnaryOverPostfix` in `internal/parser/lower.go` recursively walks FieldExpr / IndexExpr / CallExpr / QuestionExpr / TurbofishExpr, and when the receiver is a prefix `*ast.UnaryExpr` (NOT / MINUS / BITNOT) it swaps the two: `Field{Unary{!, x}, y}` becomes `Unary{!, Field{x, y}}`. Span metadata is preserved — the outer UnaryExpr keeps the `!` start position and the inner postfix keeps the receiver's start.

## Probe wall movement

- Before: `LLVM011 [other] type-system: logical not on %PmCheckOutcome`
- After: `LLVM011 [list_mixed_ptr] list literal mixes String and non-String ptr-backed values` (separate collection-literal typing gap)

## Test plan

- [x] `go test ./internal/parser -run 'TestUnaryPostfix' -count=1 -v` — 6 new tests pin the hoisting behaviour (Field / Index / Call / Field-method / MINUS / BITNOT)
- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — confirms new wall is `list_mixed_ptr`
- [x] `go test ./internal/llvmgen -count=1 -short` — same 12 preexisting failures (RawNull / RuntimeIntrinsicTyping / GenericEnumMaybe / BuiltinResultConstructors), no new regressions
- [x] `go test ./internal/parser ./internal/backend/... -count=1 -short` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)