### PR TITLE
chore: 로컬 개발 도구 섹션 + .claude allowlist + gen_selfhost .exe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(just *)",
+      "Bash(go test *)",
+      "Bash(go build *)",
+      "Bash(go vet *)",
+      "Bash(go env *)",
+      "Bash(go generate *)",
+      "Bash(gofmt *)",
+      "Bash(gotestsum *)",
+      "Bash(watchexec *)",
+      "Bash(./.bin/osty *)",
+      "Bash(./.osty/bin/*)",
+      "Bash(./scripts/*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,35 @@ source → lexer → parser → resolve → check → (format / lint / ir / back
   - `testdata/spec/negative/reject.osty` — `// === CASE: Exxxx ===` 블록별로 풀 파이프라인 실행 후 해당 코드 발화 검증. 새 CASE 블록은 추가만 하면 자동 참여. 현재 어긋나는 케이스는 `negativeWaivers`에 `"Exxxx/<hint>"` 키로 등록
   - waiver는 갭 트래킹 용도. 컴파일러가 올바른 코드를 발화하기 시작하면 해당 waiver 엔트리는 테스트 실패와 함께 제거 요청
 - 골든 스냅샷: `go test ./internal/diag/ -run TestGolden -update` 후 diff 확인
-- 일상 루프는 `justfile`:
+- 일상 루프는 `justfile` **우선**. 직접 `go test`/`go build` 호출은 특수 상황만.
   - `just front` — 프론트엔드 패키지만 (수 초, 스펙 코퍼스 포함)
   - `just spec` — 스펙 코퍼스만 verbose 출력
   - `just short` — `-short` 플래그로 러닝-헤비 제외
-  - `just gen <TestName>` / `just lsp <TestName>`
-  - `just pipe <path>` — 파이프라인 타이밍
+  - `just full` — 전체 `./...` (push 전 선택 검증)
+  - `just gen <TestName>` / `just lsp <TestName>` / `just diag <TestName>` / `just cmd <TestName>`
+  - `just pipe <path>` / `just pipe-gen <path>` — 파이프라인 타이밍 / 코드젠
+  - `just profile <target>` — `.profiles/{cpu,mem}.pprof` 생성
+  - `just watch-front` / `just watch-short` / `just watch-pipe <target>` — 저장 시 자동 재실행 (watchexec 필요)
+  - `just sum` — gotestsum 설치 시 색상/요약 테스트 출력
+  - `just prepush` — `fmt-check` + `vet` + `repair-check` + `ci` 게이트
+
+## 로컬 개발 도구
+
+신규 dev 환경 부트스트랩 (한 번만):
+
+```sh
+just build-all                                              # .bin/osty + .osty/bin/osty-native-checker
+go install gotest.tools/gotestsum@latest                    # 테스트 출력
+go install github.com/go-delve/delve/cmd/dlv@latest         # 디버거
+winget install --id Casey.Just --scope user                 # just (없으면)
+winget install --id LLVM.LLVM                              # clang/lld/llc (머신 스코프; 최종 링크 단계)
+# watchexec: winget에 없음. https://github.com/watchexec/watchexec/releases 에서
+#           x86_64-pc-windows-msvc.zip 받아 $GOPATH/bin 또는 PATH에 배치
+```
+
+- `osty-native-checker`는 CLI가 `.osty/toolchain/<ver>/` 밑에서 자동 관리함
+- `OSTY_NATIVE_CHECKER_BIN`은 **디버그/override 전용**. 글로벌 셸 프로파일에 고정하지 말 것 (워크트리 간 stale 참조 위험)
+- LLVM은 `osty build --backend llvm` / `osty run`의 최종 링크 단계에서만 필요. 프론트엔드/체커만 만지면 없어도 됨
 
 ## v0.5 baseline 규칙
 

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/osty/osty/internal/selfhost/bundle"
@@ -47,7 +48,11 @@ func run() error {
 		return fmt.Errorf("write merged selfhost source: %w", err)
 	}
 	tmpOutPath := filepath.Join(tmpDir, "generated.go")
-	checkerPath := filepath.Join(tmpDir, "osty-native-checker")
+	checkerName := "osty-native-checker"
+	if runtime.GOOS == "windows" {
+		checkerName += ".exe"
+	}
+	checkerPath := filepath.Join(tmpDir, checkerName)
 	if override := strings.TrimSpace(os.Getenv("OSTY_NATIVE_CHECKER_BIN")); override != "" {
 		checkerPath = override
 	} else if err := buildNativeChecker(root, checkerPath); err != nil {


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: `justfile` 우선 규칙 명시화 + `watch-*`/`profile`/`sum`/`prepush` 타깃 목록화 + 신규 "## 로컬 개발 도구" 섹션(gotestsum·dlv·just·LLVM·watchexec 부트스트랩 명령 카탈로그)
- **`.claude/settings.json`** 신규: repo-local Claude Code 권한 allowlist. `just *`, `go test *`, `go build *`, `gofmt *`, `./.bin/osty *` 등 12개 패턴 prompt 없이 실행
- **`internal/selfhost/gen_selfhost.go`**: Windows `.exe` 접미사 분기 추가. #433이 `internal/check/native_checker_exec_test.go`를 고친 것과 나란한 패턴으로 남아있던 부트스트랩 생성기 경로 보강

## Why

Claude 에이전트가 로컬 작업 시 ad-hoc `go test` 대신 `just front`/`just sum`/`just watch-*` 등 정제된 루프를 기본 선택하도록 두 가지 유도 장치(CLAUDE.md 규칙 + settings.json allowlist)를 team-shared 레벨에 배치. 동시에 #433이 놓친 마지막 exe-suffix 사이트 하나를 정리해 Windows에서 `go generate ./internal/selfhost` 경로가 재그런(regen)을 시도할 때 동일한 "executable not found" 증상을 피함.

## Review notes

- CLAUDE.md 섹션 위치는 "## 테스트 규칙" 직후, "## v0.5 baseline 규칙" 직전. 기존 `just` 언급을 확장·분리하는 형태
- `.claude/settings.json`은 `.gitignore`에 없는 위치라 team에 공유됨. 원치 않으면 `.claude/settings.local.json`으로 이관 가능 (이 PR에서는 의도적으로 공유 파일로 배치)
- `gen_selfhost.go`는 `//go:build ignore` 부트스트랩이라 `internal/toolchain` 의존성 추가 대신 인라인 `runtime.GOOS` 분기로 처리 — `internal/check` 수정과 동일한 스타일
- 전체 `just front` 통과 확인 (`internal/check` 포함 7/8 패키지 ok, `internal/lint`·`internal/pipeline`은 no test files)

## Test plan

- [x] `just front` — 8 패키지 모두 ok
- [x] `go build ./internal/selfhost/gen_selfhost.go` — 컴파일 통과
- [ ] 리뷰어: 새 Claude 세션에서 `.claude/settings.json` 로드 후 `just front` prompt 없이 실행되는지 확인
- [ ] 리뷰어: 다른 워크트리에서 체크아웃 시 `.claude/settings.json`이 예상대로 활성화되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)