### PR TITLE
fix(selfhost): handle payload-ful variant constructor calls

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -35091,6 +35091,12 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 	_ = sig
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15091:5
 	if sig.name == "" {
+		// Try a variant constructor (`Ok(x)`, `Err(e)`, `Some(v)`,
+		// user-defined payload-ful variants). Mirrored from
+		// toolchain/elab.osty pending a regen fix.
+		if variant := checkLookupVariant(cx.env, baseCallee.text); variant.name != "" {
+			return elabInferVariantCall(cx, callIdx, node, baseCallee, argIdxs, variant, explicitArgs, expected)
+		}
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15092:9
 		return elabInferFnValueCall(cx, node, argIdxs, expected)
 	}
@@ -35135,6 +35141,41 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15131:5
 	coreCallNode := coreCall(cx.core, coreFn, coreArgs, typeArgsConcrete, retTy, node.start, node.end)
 	_ = coreCallNode
+	return &ElabResult{node: coreCallNode, ty: retTy}
+}
+
+// elabInferVariantCall handles payload-ful variant constructors used
+// at call position (`Ok(x)`, `Err(e)`, `Some(v)`, user-defined enum
+// variants with fields). Reuses the fn-call instantiation machinery
+// by synthesising a CheckFnSig whose params are the variant's
+// fieldTys. Mirrored from toolchain/elab.osty pending a regen fix.
+func elabInferVariantCall(cx *ElabCx, callIdx int, node *AstNode, baseCallee *AstNode, argIdxs []int, variant *CheckVariantSig, explicitArgs []int, expected int) *ElabResult {
+	tys := cx.env.tys
+	constructorSig := &CheckFnSig{
+		name:          variant.name,
+		owner:         "",
+		receiverTy:    -1,
+		retTy:         tyNamed(tys, variant.owner, genericListToTyArgs(cx, variant.generics)),
+		paramNames:    make([]string, 0),
+		paramTys:      variant.fieldTys,
+		generics:      variant.generics,
+		genericBounds: make([]*CheckGenericBound, 0),
+	}
+	inst := instBegin(cx, constructorSig.generics, variant.owner)
+	instSeedExpectedRet(cx, inst, constructorSig.retTy, expected)
+	instSeedPositionalArgs(cx, inst, explicitArgs)
+
+	coreFn := coreIdent(cx.core, variant.name, IdentKind(&IdentKind_IkVariant{}), fnSigToTy(cx.env, constructorSig), baseCallee.start, baseCallee.end)
+	coreArgs := elabCallArgs(cx, inst.solver, constructorSig, inst.freshs, argIdxs, node.start, node.end)
+
+	retSubstituted := instSubstitute(cx, inst, constructorSig.retTy)
+	retTy := instZonk(cx, inst, retSubstituted)
+
+	typeArgsConcrete := instConcreteArgs(cx, inst)
+	if checkIntListLenHelper(typeArgsConcrete) > 0 {
+		checkRecordInstantiation(cx.env, callIdx, variant.name, typeArgsConcrete, retTy, node.start, node.end)
+	}
+	coreCallNode := coreCall(cx.core, coreFn, coreArgs, typeArgsConcrete, retTy, node.start, node.end)
 	return &ElabResult{node: coreCallNode, ty: retTy}
 }
 

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1124,10 +1124,19 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
 
     let sig = checkLookupFn(cx.env, baseCallee.text, "")
     if sig.name == "" {
-        // Call-position idents may resolve to local `fn(...)` values
-        // (`let printer = print; printer("x")`) that shadow or replace
-        // a top-level declaration. Fall back to the general fn-value
-        // call path before reporting an unknown name.
+        // Not a fn — try a variant constructor. `Ok(x)` / `Err(e)` /
+        // `Some(v)` and user-defined payload-ful variants all live
+        // here. Payload-free variants (`None`, `FrontQDot`, etc.)
+        // reach `elabInferIdent`'s variant branch without ever being
+        // called.
+        let variant = checkLookupVariant(cx.env, baseCallee.text)
+        if variant.name != "" {
+            return elabInferVariantCall(cx, callIdx, node, baseCallee, argIdxs, variant, explicitArgs, expected)
+        }
+        // Call-position idents may also resolve to local `fn(...)`
+        // values (`let printer = print; printer("x")`) that shadow or
+        // replace a top-level declaration. Fall back to the general
+        // fn-value call path before reporting an unknown name.
         return elabInferFnValueCall(cx, node, argIdxs, expected)
     }
 
@@ -1164,6 +1173,61 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
     let typeArgsConcrete = instConcreteArgs(cx, inst)
     if checkIntListLenHelper(typeArgsConcrete) > 0 {
         checkRecordInstantiation(cx.env, callIdx, sig.name, typeArgsConcrete, retTy, node.start, node.end)
+    }
+
+    let coreCallNode = coreCall(cx.core, coreFn, coreArgs, typeArgsConcrete, retTy, node.start, node.end)
+    ElabResult { node: coreCallNode, ty: retTy }
+}
+
+/// elabInferVariantCall handles payload-ful variant constructors
+/// used at call position — `Ok(x)`, `Err(e)`, `Some(v)`, and any
+/// user-defined enum variant with fields. Reuses the fn-call
+/// instantiation machinery: synthesises a `CheckFnSig` whose params
+/// are the variant's `fieldTys` and whose return is
+/// `tyNamed(owner, generics-as-placeholders)`, then runs `elabCallArgs`
+/// / `instSubstitute` / `instZonk` exactly like a generic fn call.
+///
+/// Unlike fn calls we do *not* emit `diagCannotInferTyParam` for
+/// still-free generics — e.g. `Ok(x)` with `x: Int` leaves
+/// `Result<Int, ?E>` with `E` open for the surrounding context to
+/// solve. `instZonk` will leave it as a fresh TyVar that later
+/// unification can bind; an unsolved leftover is just treated like
+/// any other ambiguous literal.
+fn elabInferVariantCall(
+    cx: ElabCx,
+    callIdx: Int,
+    node: AstNode,
+    baseCallee: AstNode,
+    argIdxs: List<Int>,
+    variant: CheckVariantSig,
+    explicitArgs: List<Int>,
+    expected: Int,
+) -> ElabResult {
+    let tys = cx.env.tys
+    let constructorSig = CheckFnSig {
+        name: variant.name,
+        owner: "",
+        receiverTy: -1,
+        retTy: tyNamed(tys, variant.owner, genericListToTyArgs(cx, variant.generics)),
+        paramNames: [],
+        paramTys: variant.fieldTys,
+        generics: variant.generics,
+        genericBounds: [],
+    }
+
+    let inst = instBegin(cx, constructorSig.generics, variant.owner)
+    instSeedExpectedRet(cx, inst, constructorSig.retTy, expected)
+    instSeedPositionalArgs(cx, inst, explicitArgs)
+
+    let coreFn = coreIdent(cx.core, variant.name, IkVariant, fnSigToTy(cx.env, constructorSig), baseCallee.start, baseCallee.end)
+    let coreArgs = elabCallArgs(cx, inst.solver, constructorSig, inst.freshs, argIdxs, node.start, node.end)
+
+    let retSubstituted = instSubstitute(cx, inst, constructorSig.retTy)
+    let retTy = instZonk(cx, inst, retSubstituted)
+
+    let typeArgsConcrete = instConcreteArgs(cx, inst)
+    if checkIntListLenHelper(typeArgsConcrete) > 0 {
+        checkRecordInstantiation(cx.env, callIdx, variant.name, typeArgsConcrete, retTy, node.start, node.end)
     }
 
     let coreCallNode = coreCall(cx.core, coreFn, coreArgs, typeArgsConcrete, retTy, node.start, node.end)


### PR DESCRIPTION
## Summary

`elabInferCall` looked up `checkLookupFn(callee)` and — on miss — fell straight into `elabInferFnValueCall`. Which meant `Ok(x)` / `Err(e)` / `Some(v)` and every user-defined payload-ful variant used at call position bottomed out in `elabInferIdent` (no fn match, no local binding), where [#422](https://github.com/choiceoh/osty/pull/422) handles only *payload-free* variants. Payload-ful ones fell through to E0745 — **the last 22 native-only E0745 errors** after [#432](https://github.com/choiceoh/osty/pull/432).

## What changed

Route variant constructors through a dedicated `elabInferVariantCall` that reuses the generic fn-call machinery. The implementation synthesises a `CheckFnSig` with `paramTys = variant.fieldTys` and `retTy = tyNamed(owner, generics-as-placeholders)`, then:

1. `instBegin` allocates fresh TyVars for each enum generic.
2. `instSeedExpectedRet` seeds the solver with the call-site expected type when available — `let r: Result<Int, Error> = Ok(42)` pins both `T` and `E`.
3. `elabCallArgs` unifies each argument against the variant's field types substituted with the fresh vars.
4. `instSubstitute` + `instZonk` produce the final return type.

Unlike fn calls we intentionally do **not** emit `diagCannotInferTyParam` for still-free generics — `Ok(x)` with `x: Int` legitimately leaves `Result<Int, ?E>` with `E` open for the surrounding context (a `-> Result<Int, Error>` return, an explicit annotation, a subsequent pattern match), and flagging that here would fire false positives at every such site.

## Measured impact

Toolchain histograms via `selfhost.CheckPackageStructured`:

| | before | after | Δ |
|---|---|---|---|
| full errors | 949 | 928 | −21 |
| **native-only errors** | 306 | **285** | **−21** |
| **native-only E0745** | 22 | **0** | **−22 (−100%)** |

## Native probe wall advanced

`TestProbeNativeToolchainMerged` first wall moved from `LLVM015 [method_call_field]` to `LLVM011 type-system: logical not on %PmCheckOutcome`. The earlier wall — and the dynamic-ident-call / FieldExpr-method-call cascade behind it — are now reachable without tripping on the variant miss, exposing a deeper backend gap (applying `!` to a user-defined pattern-check result type). That's new territory for a follow-up backend PR rather than a regression.

## Cumulative selfhost progress

| | main before [#421](https://github.com/choiceoh/osty/pull/421) | now |
|---|---|---|
| native-only errors | (equivalent to) ~6308 | **285** |
| overall reduction | — | **~95%** over six PRs |

## Verification

- Minimal reproducer `parseInt() -> Result<Int, String>` using `Ok(42)` / `Err("empty")` + `firstNonZero() -> Int?` using `Some(x)` / `None` → 0 errors (was 2 × E0745)
- `osty gen --backend=llvm` on hello → exit 0
- 4 targeted `internal/llvmgen` tests → pass
- `TestProbeWholeToolchainMerged` → unchanged (`runtime.golegacy.astbridge`)
- `internal/lexer`, `internal/parser`, `internal/selfhost` short → pass

## Mirror protocol

Edits live in `toolchain/elab.osty` (source of truth) and `internal/selfhost/generated.go`. Regen is still blocked on bootstrap-gen, so the generated-side hunks carry the usual `// Mirrored from ... pending a regen fix` comments — same protocol as [#421](https://github.com/choiceoh/osty/pull/421) / [#422](https://github.com/choiceoh/osty/pull/422) / [#423](https://github.com/choiceoh/osty/pull/423) / [#430](https://github.com/choiceoh/osty/pull/430) / [#432](https://github.com/choiceoh/osty/pull/432).

🤖 Generated with [Claude Code](https://claude.com/claude-code)