### PR TITLE
fix(llvmgen): propagate String source-type through stdlib, let-mut, if-expr

### DIFF
--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -23,12 +23,25 @@ As of 2026-04-19:
 - the whole-toolchain merged LLVM probe still first-walls on the
   bootstrap-only `runtime.golegacy.astbridge` bridge
 - the native-only merged LLVM probe (with bootstrap-only files skipped)
-  now first-walls on `LLVM011 [list_mixed_ptr] type-system: list literal
-  mixes String and non-String ptr-backed values` — a collection-literal
-  typing gap (heterogeneous ptr-backed element types in the same
-  `[...]` literal). The earlier LLVM011 `logical not on %PmCheckOutcome`
-  wall is closed: it was a **parser precedence bug**, not a backend
-  gap. The v0.5 grammar has `UnaryExpr ::= prefix UnaryExpr |
+  now first-walls on `LLVM011 [string_non_ascii] plain String literals
+  currently require ASCII text with printable bytes or newline, tab,
+  and carriage-return escapes` — a separate String-literal ASCII-only
+  gap. The earlier `list_mixed_ptr` wall was a **source-type
+  propagation gap**, not the genuine "heterogeneous literal" case it
+  claimed: (1) alias-qualified stdlib strings calls
+  (`strings.join(...)`) never fed through `staticExprSourceType` so
+  the list-literal isString check couldn't tell they returned String;
+  (2) bare `""` literals carried no `sourceType`, so a `let mut line =
+  ""` binding dropped the String tag; (3) if-expression phi values
+  merged container metadata but not `sourceType`, so `let op = if ...
+  { "a" } else { "b" }` also dropped it. All three plumbed through
+  the merged toolchain probe at
+  `formatter_ast.osty:195` / `275` / `532`. Fixed by adding
+  `staticStdStringsCallSourceType`, tagging literal emission with
+  `sourceType = String`, and merging agreed-sourceType in
+  `mergeContainerMetadata`.
+  The earlier LLVM011 `logical not on %PmCheckOutcome` wall is also
+  closed: it was a **parser precedence bug**, not a backend gap. The v0.5 grammar has `UnaryExpr ::= prefix UnaryExpr |
   PostfixExpr`, so `!x.y` must parse as `!(x.y)`; the self-hosted
   front-end was emitting `(!x).y`. Fixed at stable-AST lowering time
   in `internal/parser/lower.go` via `hoistUnaryOverPostfix`, which
@@ -71,7 +84,7 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
-| Native backend surface | merged native-only probe | first wall is `LLVM011 [list_mixed_ptr]` (heterogeneous ptr element types in a single `[...]` literal) after skipping 4 bootstrap-only files. Closed walls (in order): `LLVM011 [fn_param_struct_type]` Char on `lspUtf16UnitsForChar`; `LLVM012 *ast.MatchExpr is not a call` (match-as-statement lowering); `LLVM012 field assignment base *ast.FieldExpr` (nested `a.b.c = x` via `llvmInsertValue` rebuild chain); parser precedence `(!x).y` / `!(x.y)` hoisted at stable-AST lowering. List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites also closed |
+| Native backend surface | merged native-only probe | first wall is `LLVM011 [string_non_ascii]` (plain String literals currently require ASCII text — a separate non-ASCII literal gap) after skipping 4 bootstrap-only files. Closed walls (in order): `LLVM011 [fn_param_struct_type]` Char on `lspUtf16UnitsForChar`; `LLVM012 *ast.MatchExpr is not a call` (match-as-statement lowering); `LLVM012 field assignment base *ast.FieldExpr` (nested `a.b.c = x` via `llvmInsertValue` rebuild chain); parser precedence `(!x).y` / `!(x.y)` hoisted at stable-AST lowering; `LLVM011 [list_mixed_ptr]` source-type propagation (stdlib strings alias calls, bare `""` literals, if-expr phi branches — `staticStdStringsCallSourceType` + literal sourceType tagging + mergeContainerMetadata sameSourceType). List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites also closed |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |
 | Toolchain package health | `osty check --airepair=false toolchain` | current CLI surface is still an aggregate `E0700` summary (`3846 error(s)`) rather than a clean self-compile pass |
 | Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers. `Char` and `Byte` parameters/returns, literals, comparisons, and width conversions now lower; `String.chars` / `String.bytes` still block the pure native path because `List<Char>` / `List<Byte>` collection lowering is separate work |

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -81,7 +81,14 @@ func (g *generator) emitStringLiteral(lit *ast.StringLit) (value, error) {
 		emitter := g.toOstyEmitter()
 		out := llvmStringLiteral(emitter, text)
 		g.takeOstyEmitter(emitter)
-		return fromOstyValue(out), nil
+		v := fromOstyValue(out)
+		// Tag the literal with its source type so downstream binders
+		// (`let mut line = ""`) propagate the String-ness forward —
+		// without this, a subsequent `[line, otherString]` list literal
+		// fails the isString parity check because the local's
+		// sourceType is nil.
+		v.sourceType = &ast.NamedType{Path: []string{"String"}}
+		return v, nil
 	}
 	return g.emitInterpolatedString(lit)
 }
@@ -123,6 +130,7 @@ func (g *generator) emitInterpolatedString(lit *ast.StringLit) (value, error) {
 		}
 		result = r
 	}
+	result.sourceType = &ast.NamedType{Path: []string{"String"}}
 	return result, nil
 }
 

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -164,6 +164,61 @@ func TestGenerateIndexedNestedListLenMethodDispatch(t *testing.T) {
 	}
 }
 
+// TestGenerateListLiteralOfStringsPropagatesSourceType covers three
+// paths that previously dropped the `String` source type from list
+// literal elements and first-walled on
+// `LLVM011 list literal mixes String and non-String ptr-backed values`:
+//
+//  1. alias-qualified stdlib strings call (`strings.join(...)`) —
+//     now routed through staticStdStringsCallSourceType so the
+//     return-type is known to be String.
+//  2. plain String literal (`""`) bound through `let mut` and reused
+//     in a later list literal — staticExprSourceType walks the
+//     binding's sourceType, which is now tagged at literal-emission
+//     time.
+//  3. if-expression whose both branches are String literals — the
+//     merged phi value now carries the agreed String source type
+//     (mergeContainerMetadata -> sameSourceType).
+//
+// All three shapes appear in `toolchain/formatter_ast.osty`:
+// `strings.join([strings.join(parts, ", "), ...], "")`,
+// `lines.push(strings.join([ostyAstIndent(1), line], ""))` (line is
+// `let mut line = ""`), and `strings.join([pat, op, pat], "")` where
+// `op` binds an if-expression.
+func TestGenerateListLiteralOfStringsPropagatesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn indent(level: Int) -> String {
+    strings.repeat("  ", level)
+}
+
+fn render(parts: List<String>, flag: Int) -> String {
+    let mut line: String = ""
+    line = strings.join(parts, ", ")
+    let op = if flag == 1 { "<" } else { ">" }
+    let chunks = [indent(1), line, strings.join([op, " end"], "")]
+    strings.join(chunks, "")
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/list_mixed_ptr.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_list_new()",
+		"call ptr @osty_rt_strings_Join",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // Phase 1 of the first-class fn value lowering: a top-level fn used
 // in value position materialises a closure env + thunk, and the
 // subsequent call through the bound name dispatches indirectly.

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -815,7 +815,42 @@ func mergeContainerMetadata(dst *value, left, right value) {
 		dst.setElemTyp = left.setElemTyp
 		dst.setElemString = left.setElemString && right.setElemString
 	}
+	// Preserve source-type when both branches agree so downstream
+	// consumers (list-literal isString parity, field-source lookups)
+	// don't lose the String/named-type tag across if-expressions and
+	// match-expressions. Shallow identity/equal-string-form comparison
+	// is sufficient here — the backend only needs "same source type"
+	// to decide whether to propagate; deeper structural equality is a
+	// job for the checker.
+	if sameSourceType(left.sourceType, right.sourceType) {
+		dst.sourceType = left.sourceType
+	}
 	dst.gcManaged = valueNeedsManagedRoot(*dst)
+}
+
+func sameSourceType(a, b ast.Type) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	an, aok := a.(*ast.NamedType)
+	bn, bok := b.(*ast.NamedType)
+	if !aok || !bok {
+		return false
+	}
+	if len(an.Path) != len(bn.Path) || len(an.Args) != len(bn.Args) {
+		return false
+	}
+	for i := range an.Path {
+		if an.Path[i] != bn.Path[i] {
+			return false
+		}
+	}
+	for i := range an.Args {
+		if !sameSourceType(an.Args[i], bn.Args[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 type gcSafepointRoot struct {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -391,6 +391,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStringMethodSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdStringsCallSourceType(e); ok {
+			return src, true
+		}
 		if id, ok := e.Fn.(*ast.Ident); ok {
 			if sig := g.functions[id.Name]; sig != nil && sig.returnSourceType != nil {
 				return sig.returnSourceType, true
@@ -747,6 +750,39 @@ func (g *generator) staticExprListElemIsBytes(expr ast.Expr) bool {
 		return false
 	}
 	return llvmNamedTypeIsBytes(elemResolved)
+}
+
+// staticStdStringsCallSourceType recovers the source-level return type
+// for `strings.<method>(...)` alias-qualified calls (`use std.strings
+// as strings`). Keeps the dispatch layer (`stdStringsCallStaticResult`)
+// and the source-type layer in sync so nested forms like
+// `strings.join([strings.join(parts, ", "), ...], "")` don't pinball
+// between "String" and "unknown ptr-backed" when a list literal asks
+// `isString?` about the inner call.
+func (g *generator) staticStdStringsCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	if call == nil || len(g.stdStringsAliases) == 0 {
+		return nil, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdStringsAliases[alias.Name] {
+		return nil, false
+	}
+	stringT := &ast.NamedType{Path: []string{"String"}}
+	switch field.Name {
+	case "compare", "count":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "contains", "hasPrefix", "hasSuffix":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "concat", "join", "repeat", "replaceAll", "slice", "trim", "trimSpace", "trimPrefix", "trimSuffix":
+		return stringT, true
+	case "split", "splitN":
+		return &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{stringT}}, true
+	}
+	return nil, false
 }
 
 func (g *generator) staticStringMethodSourceType(call *ast.CallExpr) (ast.Type, bool) {


### PR DESCRIPTION
## Summary

`TestProbeNativeToolchainMerged` was first-walling on `LLVM011 [list_mixed_ptr] list literal mixes String and non-String ptr-backed values`. The list literals in question were genuinely all `String` — the backend just lost track of the source type along three independent paths, making one element look String and another look "bare ptr":

1. **Alias-qualified stdlib strings calls** never fed through `staticExprSourceType`. Only the dispatch layer (`stdStringsCallStaticResult`) knew `strings.join(...)` returned String. Added `staticStdStringsCallSourceType` mirroring the dispatch switch so concat/join/repeat/replaceAll/slice/trim/trimSpace/trimPrefix/trimSuffix report String, count/compare report Int, contains/hasPrefix/hasSuffix report Bool, and split/splitN report List<String>.

2. **Plain `""` literals carried no `sourceType`** on the emitted value. A `let mut line: String = ""` binding therefore dropped the tag, and later `[indent(1), line]` couldn't tell whether `line` was a String or a bare ptr. Tagged the literal's emitted value with `sourceType = NamedType{String}` at both the ASCII-fast-path and interpolation-builder ends.

3. **`if cond { "a" } else { "b" }` phi-merged branches** via `mergeContainerMetadata`, which copied List/Map/Set element metadata but not `sourceType`. So `let op = if ... {} else {}` dropped the String tag even when both branches agreed. Preserve `sourceType` when both sides are structurally equal named types (new `sameSourceType` helper).

## Probe wall movement

- Before: `LLVM011 [list_mixed_ptr] list literal mixes String and non-String ptr-backed values`
- After: `LLVM011 [string_non_ascii] plain String literals currently require ASCII text` (separate non-ASCII literal gap)

The three toolchain sites that tripped the wall are `formatter_ast.osty:195 / 275 / 532`:
- `strings.join([strings.join(parts, ", "), ...], "")` (stdlib call in list)
- `lines.push(strings.join([ostyAstIndent(1), line], ""))` where `line` is `let mut line = ""` (let-mut through literal)
- `strings.join([pat, op, pat], "")` where `op` is `if flag { "..=" } else { ".." }` (if-expr phi)

## Test plan

- [x] `go test ./internal/llvmgen -run 'TestGenerateListLiteralOfStringsPropagatesSourceType' -count=1 -v` — new regression covers all three shapes in one fn
- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — confirms new wall is `string_non_ascii`
- [x] `go test ./internal/llvmgen -count=1 -short` — same 12 preexisting failures, no new regressions
- [x] `go test ./internal/parser ./internal/backend/... -count=1 -short` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)