### PR TITLE
fix(selfhost): read match-arm guard out of the right AST slot

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -37552,10 +37552,16 @@ func patKindOf(n *AstNode) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16288:1
 func armGuarded(cx *ElabCx, armIdx int) bool {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16289:5
+	// `opParseMatchStmt` stores the body in `arm.right` and the guard
+	// expression index in `arm.children[0]` (-1 if absent); the earlier
+	// `arm.right >= 0` check therefore flagged every arm as guarded,
+	// disabling exhaustiveness entirely. Mirrored from
+	// toolchain/elab.osty pending a regen fix.
 	arm := astArenaNodeAt(cx.ast.arena, armIdx)
-	_ = arm
-	return arm.right >= 0
+	if checkIntListLenHelper(arm.children) == 0 {
+		return false
+	}
+	return checkIntListAt(arm.children, 0) >= 0
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16298:1

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -2532,8 +2532,20 @@ fn patKindOf(n: AstNode) -> Int {
 }
 
 fn armGuarded(cx: ElabCx, armIdx: Int) -> Bool {
+    // `opParseMatchStmt` encodes an arm as:
+    //   armNode.left     = pattern
+    //   armNode.right    = body expression
+    //   armNode.children = [guardExprIdx]  (-1 when no guard)
+    //
+    // The previous check looked at `arm.right`, which is always
+    // populated with the body — so every arm registered as
+    // "guarded" and exhaustiveness was effectively disabled. Read
+    // the guard slot out of children[0] instead.
     let arm = astArenaNodeAt(cx.ast.arena, armIdx)
-    arm.right >= 0
+    if checkIntListLenHelper(arm.children) == 0 {
+        return false
+    }
+    checkIntListAt(arm.children, 0) >= 0
 }
 
 /// patIsIrrefutable reports whether a pattern is guaranteed to match


### PR DESCRIPTION
## Summary

`armGuarded` checked `arm.right >= 0`, but [`opParseMatchStmt`](toolchain/parser.osty) stores the arm's **body** in `arm.right` and the guard expression index in `arm.children[0]` (or `-1` when absent). Every arm has a body, so `armGuarded` was universally true — and `exhaustCheckEnum` / `anyArmCoversVariant` skip guarded arms on the assumption their coverage isn't statically known. Result: **every** enum match, including fully-explicit ones like `match op { BoAdd -> ..., BoSub -> ..., ... BoInvalid -> ... }`, got flagged as non-exhaustive with `E0731 match is not exhaustive: missing BinOp.BoAdd | BoSub | ...`.

Fix: read the guard slot out of `arm.children[0]` instead.

## Measured impact

Toolchain histograms (`selfhost.CheckPackageStructured`), native-only:

| | before | after | Δ |
|---|---|---|---|
| native-only errors | 285 | **210** | **−75 (−26.3%)** |
| E0731 | 81 | **0** | **−81 (−100%)** |
| accepted | 23597 / 23696 | 23601 / 23700 | +4 |

E0740 nudged from 0 to 6 — those are "unreachable match arm" diagnostics that exhaustive-checking now actually runs surfaces. All six are legitimate dead arms in the toolchain that the broken `armGuarded` was hiding.

## Probe wall advanced again

`TestProbeNativeToolchainMerged` first wall moved further into the LLVM backend: `LLVM011 type-system: logical not` → `LLVM011 type-system: list literal mixes String and non-String ptr-backed values`. Still backend territory, not selfhost — the front end is reaching deeper into the pipeline before tripping.

## Cumulative selfhost progress

| | main before [#421](https://github.com/choiceoh/osty/pull/421) | now |
|---|---|---|
| native-only errors | ~6308 | **210** |
| overall reduction | — | **~97%** over eight PRs |

## Verification

- Minimal `match c { Red -> .., Green -> .., Blue -> .. }` over a 3-variant enum → 0 errors (was `E0731 missing Color.Red | Color.Green | Color.Blue | ...`)
- BinOp-sized 19-variant match → 0 errors (was `E0731 missing BinOp.BoAdd | BoSub | ...`)
- `osty gen --backend=llvm` hello → exit 0
- 4 targeted `internal/llvmgen` tests → pass
- `TestProbeWholeToolchainMerged` → unchanged (`runtime.golegacy.astbridge`)
- `internal/lexer`, `internal/parser` → pass

## Mirror protocol

Edits live in `toolchain/elab.osty` (source of truth) and `internal/selfhost/generated.go`. Regen is still blocked on bootstrap-gen, so the generated-side hunk carries the usual `// Mirrored from ... pending a regen fix` comment — same protocol as [#421](https://github.com/choiceoh/osty/pull/421) / [#422](https://github.com/choiceoh/osty/pull/422) / [#423](https://github.com/choiceoh/osty/pull/423) / [#430](https://github.com/choiceoh/osty/pull/430) / [#432](https://github.com/choiceoh/osty/pull/432) / [#436](https://github.com/choiceoh/osty/pull/436).

🤖 Generated with [Claude Code](https://claude.com/claude-code)