### PR TITLE
test(llvmgen): narrow reproducers for String source-type propagation

### DIFF
--- a/internal/llvmgen/stdlib_shim_test.go
+++ b/internal/llvmgen/stdlib_shim_test.go
@@ -379,3 +379,75 @@ fn main() {
 		t.Fatalf("expected no std.strings aliases from runtime FFI use, got %v", aliases)
 	}
 }
+
+// TestStdStringsJoinNestedInListLiteral pins the narrow shape the
+// formatter_ast.osty probe walled on: a String-typed list literal with
+// an alias-qualified `strings.join(...)` call as a middle element. The
+// broader regression bundle lives in
+// field_call_dispatch_test.go:TestGenerateListLiteralOfStringsPropagatesSourceType;
+// this narrower test stays so an alias-stdlib-only regression would
+// fail here first with a smaller repro.
+func TestStdStringsJoinNestedInListLiteral(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let parts: List<String> = ["a", "b"]
+    let out = strings.join(["<", strings.join(parts, ", "), ">"], "")
+    println(out)
+}
+`)
+	_, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_strings_nested_join.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+}
+
+// TestStringLetMutInferredSourceType pins the let-mut-with-bare-""
+// shape: `let mut line = "" ; [tag(), line, tag()]`. Paired with
+// TestStdStringsJoinNestedInListLiteral and
+// TestIfExprStringArmsAgreeSourceType so each of the three source-type
+// propagation paths closed by PR #438 has a dedicated narrow repro.
+func TestStringLetMutInferredSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn tag() -> String { "<t>" }
+
+fn main() {
+    let mut line = ""
+    line = tag()
+    let parts = [tag(), line, tag()]
+    println(parts.len())
+}
+`)
+	_, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/let_mut_string_source_type.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+}
+
+// TestIfExprStringArmsAgreeSourceType pins the if-expression phi
+// shape: `let op = if flag { "..=" } else { ".." }` used inside a
+// later String-typed list literal. Both branches agree on String so
+// mergeContainerMetadata / sameSourceType must preserve the tag.
+func TestIfExprStringArmsAgreeSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn tag() -> String { "<t>" }
+
+fn main() {
+    let flag = true
+    let op = if flag { "..=" } else { ".." }
+    let parts = [tag(), op, tag()]
+    println(parts.len())
+}
+`)
+	_, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/if_expr_string_arms.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

PR #438이 업스트림에 먼저 랜딩하여 `LLVM011 [list_mixed_ptr]` 벽을 닫았습니다. 본 PR은 동 번들 테스트(`TestGenerateListLiteralOfStringsPropagatesSourceType`)와 기능은 중복이지만, 세 경로 각각에 대해 **좁은 repro** 테스트를 추가해 회귀 발생 시 실패 지점을 빨리 좁힙니다.

## 추가된 테스트 (in `internal/llvmgen/stdlib_shim_test.go`)

- `TestStdStringsJoinNestedInListLiteral` — alias-qualified `strings.join(...)` 분류 경로 (`staticStdStringsCallSourceType`)
- `TestStringLetMutInferredSourceType` — `let mut x = ""` 이 String sourceType을 승계하는 경로 (literal emit tagging)
- `TestIfExprStringArmsAgreeSourceType` — if-expr phi가 양 분기 일치 시 sourceType을 보존하는 경로 (`mergeContainerMetadata` + `sameSourceType`)

## 본 PR이 추가 안전망을 제공하는 이유

업스트림 번들 테스트는 세 고장이 한 함수에서 모두 발생해야 실패함. 단일 경로만 회귀시킬 경우 번들이 다른 이유로 여전히 통과할 수 있는데, 본 PR의 좁은 repro는 각 경로 단독으로 회귀를 잡음.

## Test plan

- [x] 신규 3개 테스트 모두 PASS (업스트림 fix 위에서 실행)
- [x] 업스트림 `TestGenerateListLiteralOfStringsPropagatesSourceType`도 계속 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)