### PR TITLE
fix(llvmgen): byte-escape UTF-8 in String literals instead of rejecting

### DIFF
--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -23,10 +23,17 @@ As of 2026-04-19:
 - the whole-toolchain merged LLVM probe still first-walls on the
   bootstrap-only `runtime.golegacy.astbridge` bridge
 - the native-only merged LLVM probe (with bootstrap-only files skipped)
-  now first-walls on `LLVM011 [string_non_ascii] plain String literals
-  currently require ASCII text with printable bytes or newline, tab,
-  and carriage-return escapes` — a separate String-literal ASCII-only
-  gap. The earlier `list_mixed_ptr` wall was a **source-type
+  now first-walls on `LLVM013 expression: match arm must be a
+  payload-free enum variant` — a separate match-expression lowering
+  gap. The earlier `LLVM011 [string_non_ascii]` wall is closed: plain
+  String literals with multi-byte UTF-8 content (BOM `\u{FEFF}` at
+  `frontend.osty:600`, Unit Separator `\u{1F}` at the monomorph key
+  builder, Korean / emoji in user text) now lower through
+  `llvmCStringEscape` as one `\HH` escape per UTF-8 byte instead of
+  being rejected by the ASCII gate. `llvmCString` also counts bytes
+  (not runes) so `[N x i8]` globals stay the right size. The legacy
+  `llvmIsAsciiStringText` check is now a no-op stub — kept for
+  call-site stability; a future cleanup may inline it into callers. The earlier `list_mixed_ptr` wall was a **source-type
   propagation gap**, not the genuine "heterogeneous literal" case it
   claimed: (1) alias-qualified stdlib strings calls
   (`strings.join(...)`) never fed through `staticExprSourceType` so
@@ -84,7 +91,7 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
-| Native backend surface | merged native-only probe | first wall is `LLVM011 [string_non_ascii]` (plain String literals currently require ASCII text — a separate non-ASCII literal gap) after skipping 4 bootstrap-only files. Closed walls (in order): `LLVM011 [fn_param_struct_type]` Char on `lspUtf16UnitsForChar`; `LLVM012 *ast.MatchExpr is not a call` (match-as-statement lowering); `LLVM012 field assignment base *ast.FieldExpr` (nested `a.b.c = x` via `llvmInsertValue` rebuild chain); parser precedence `(!x).y` / `!(x.y)` hoisted at stable-AST lowering; `LLVM011 [list_mixed_ptr]` source-type propagation (stdlib strings alias calls, bare `""` literals, if-expr phi branches — `staticStdStringsCallSourceType` + literal sourceType tagging + mergeContainerMetadata sameSourceType). List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites also closed |
+| Native backend surface | merged native-only probe | first wall is `LLVM013` (match arm must be a payload-free enum variant — a separate match-expression lowering gap) after skipping 4 bootstrap-only files. Closed walls (in order): `LLVM011 [fn_param_struct_type]` Char on `lspUtf16UnitsForChar`; `LLVM012 *ast.MatchExpr is not a call` (match-as-statement lowering); `LLVM012 field assignment base *ast.FieldExpr` (nested `a.b.c = x` via `llvmInsertValue` rebuild chain); parser precedence `(!x).y` / `!(x.y)` hoisted at stable-AST lowering; `LLVM011 [list_mixed_ptr]` source-type propagation (stdlib strings alias calls, bare `""` literals, if-expr phi branches — `staticStdStringsCallSourceType` + literal sourceType tagging + mergeContainerMetadata sameSourceType); `LLVM011 [string_non_ascii]` multi-byte UTF-8 literals (BOM / Unit Separator / Korean / emoji) now byte-escaped via `\HH` in `llvmCStringEscape`, with `llvmCString` counting UTF-8 bytes instead of runes. List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites also closed |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |
 | Toolchain package health | `osty check --airepair=false toolchain` | current CLI surface is still an aggregate `E0700` summary (`3846 error(s)`) rather than a clean self-compile pass |
 | Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers. `Char` and `Byte` parameters/returns, literals, comparisons, and width conversions now lower; `String.chars` / `String.bytes` still block the pure native path because `List<Char>` / `List<Byte>` collection lowering is separate work |

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -164,6 +164,52 @@ func TestGenerateIndexedNestedListLenMethodDispatch(t *testing.T) {
 	}
 }
 
+// TestGenerateNonAsciiStringLiteralLowersAsByteEscapes verifies plain
+// String literals containing multi-byte UTF-8 code points (BOM,
+// Korean, emoji) now lower through `llvmCStringEscape` as one `\HH`
+// escape per UTF-8 byte instead of tripping
+// `LLVM011 [string_non_ascii]`. Previously the backend restricted
+// literals to printable ASCII + \n \t \r \x1f; now the gate is a
+// no-op because the escaper walks bytes and byte-escapes everything
+// outside the printable ASCII range (minus `"` / `\`).
+//
+// The toolchain lexer at `toolchain/frontend.osty:600` (`unit ==
+// "\u{FEFF}"`) was the probe's first wall after the `list_mixed_ptr`
+// fix landed; other sites like the monomorphization key builder use
+// `\u{1F}` and are also covered here.
+func TestGenerateNonAsciiStringLiteralLowersAsByteEscapes(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let bom = "\u{FEFF}"
+    let sep = "\u{1F}"
+    let hello = "안녕"
+    println(bom)
+    println(sep)
+    println(hello)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/non_ascii_literal.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	// BOM = U+FEFF → UTF-8 EF BB BF.
+	// Unit Separator = U+001F → UTF-8 1F.
+	// 안 = U+C548 → UTF-8 EC 95 88; 녕 = U+B155 → UTF-8 EB 85 95.
+	for _, want := range []string{
+		`\EF\BB\BF`,
+		`\1F`,
+		`\EC\95\88\EB\85\95`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing byte escape %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateListLiteralOfStringsPropagatesSourceType covers three
 // paths that previously dropped the `String` source type from list
 // literal elements and first-walled on

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -107,8 +107,13 @@ func TestGeneratedComparePoliciesAreOstyOwned(t *testing.T) {
 	if !llvmIsAsciiStringText("line one\n") {
 		t.Fatal(`llvmIsAsciiStringText("line one\n") = false, want true`)
 	}
-	if llvmIsAsciiStringText("bad €") {
-		t.Fatal(`llvmIsAsciiStringText("bad €") = true, want false`)
+	// Non-ASCII text is now accepted — llvmCStringEscape byte-escapes
+	// every non-printable / high byte via `\HH`, so the gate is a
+	// no-op. The earlier `"bad €" => false` assertion was the legacy
+	// ASCII-only behaviour; see commit history / PR on the
+	// string_non_ascii wall for context.
+	if !llvmIsAsciiStringText("bom \ufeff ok") {
+		t.Fatal(`llvmIsAsciiStringText("bom \ufeff ok") = false, want true`)
 	}
 	if !llvmIsIdent("value2") {
 		t.Fatal(`llvmIsIdent("value2") = false, want true`)

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -596,57 +596,45 @@ func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:383:5
+//
+// `byteLen` counts bytes (not runes) so LLVM IR globals sized as
+// `[N x i8]` stay correct for multi-byte UTF-8 text. The previous
+// `strings.Split(text, "")` path returned rune count, which was a
+// silent truncation for anything above U+007F.
 func llvmCString(text string) *LlvmCString {
-	// Osty: examples/selfhost-core/llvmgen.osty:384:5
 	encoded := fmt.Sprintf("%s\\00", ostyToString(llvmCStringEscape(text)))
 	_ = encoded
-	// Osty: examples/selfhost-core/llvmgen.osty:385:5
-	byteLen := func() int {
-		var _p5 int = len(llvmStrings.Split(text, ""))
-		var _rhs6 int = 1
-		if _rhs6 > 0 && _p5 > math.MaxInt-_rhs6 {
-			panic("integer overflow")
-		}
-		if _rhs6 < 0 && _p5 < math.MinInt-_rhs6 {
-			panic("integer overflow")
-		}
-		return _p5 + _rhs6
-	}()
+	byteLen := len(text) + 1
 	_ = byteLen
 	return &LlvmCString{encoded: encoded, byteLen: byteLen}
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:389:5
+//
+// Encodes `text` for an LLVM `c"..."` constant. Iterates over raw
+// bytes (not runes) so multi-byte UTF-8 code points emit one `\HH`
+// escape per byte — LLVM IR string globals are byte arrays, so that's
+// the right shape for downstream `getelementptr` + `printf`/runtime
+// helpers. Printable ASCII passes through verbatim; `"` and `\`
+// always escape; everything else (including 0x00–0x1F, 0x7F, and all
+// high bytes 0x80–0xFF) goes through `\HH`.
 func llvmCStringEscape(text string) string {
-	// Osty: examples/selfhost-core/llvmgen.osty:390:5
-	encoded := ""
-	_ = encoded
-	// Osty: examples/selfhost-core/llvmgen.osty:391:5
-	for _, unit := range llvmStrings.Split(text, "") {
-		// Osty: examples/selfhost-core/llvmgen.osty:392:9
-		if unit == "\n" {
-			// Osty: examples/selfhost-core/llvmgen.osty:393:13
-			encoded = fmt.Sprintf("%s\\0A", ostyToString(encoded))
-		} else if unit == "\t" {
-			// Osty: examples/selfhost-core/llvmgen.osty:395:13
-			encoded = fmt.Sprintf("%s\\09", ostyToString(encoded))
-		} else if unit == "\r" {
-			// Osty: examples/selfhost-core/llvmgen.osty:397:13
-			encoded = fmt.Sprintf("%s\\0D", ostyToString(encoded))
-		} else if unit == "\"" {
-			// Osty: examples/selfhost-core/llvmgen.osty:399:13
-			encoded = fmt.Sprintf("%s\\22", ostyToString(encoded))
-		} else if unit == "\\" {
-			// Osty: examples/selfhost-core/llvmgen.osty:401:13
-			encoded = fmt.Sprintf("%s\\5C", ostyToString(encoded))
-		} else if unit == "\x1f" {
-			encoded = fmt.Sprintf("%s\\1F", ostyToString(encoded))
-		} else {
-			// Osty: examples/selfhost-core/llvmgen.osty:403:13
-			encoded = fmt.Sprintf("%s%s", ostyToString(encoded), ostyToString(unit))
+	var b llvmStrings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		switch {
+		case c == '"':
+			b.WriteString(`\22`)
+		case c == '\\':
+			b.WriteString(`\5C`)
+		case c >= 0x20 && c <= 0x7E:
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, `\%02X`, c)
 		}
 	}
-	return encoded
+	return b.String()
 }
 
 // Osty: examples/selfhost-core/llvmgen.osty:409:5
@@ -1373,15 +1361,16 @@ func llvmLogicalInstruction(op string) string {
 	}
 }
 
+// llvmIsAsciiStringText gates which plain String literals the
+// LLVM backend accepts directly. Since `llvmCStringEscape` now
+// byte-escapes any non-printable / non-ASCII character via `\HH`,
+// the gate only needs to reject text that can't be encoded as a
+// byte sequence at all — i.e. nothing; every Go `string` is a
+// byte sequence. The legacy name is kept for call-site stability;
+// a future rename to `llvmCanEmitStringLiteral` or similar is a
+// pure-cleanup follow-up.
 func llvmIsAsciiStringText(text string) bool {
-	for _, c := range text {
-		if c == '\n' || c == '\t' || c == '\r' || c == '\x1f' {
-			continue
-		}
-		if c < ' ' || c > '~' {
-			return false
-		}
-	}
+	_ = text
 	return true
 }
 

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -511,31 +511,60 @@ pub fn llvmStringLiteral(emitter: LlvmEmitter, text: String) -> LlvmValue {
 }
 
 pub fn llvmCString(text: String) -> LlvmCString {
+    // byteLen counts UTF-8 bytes (not runes) because LLVM IR globals
+    // are sized as `[N x i8]`. `text.bytes().len()` preserves multi-
+    // byte sequences whereas `llvmStrings.split("")` returns rune
+    // count — silently truncating for anything above U+007F.
     let encoded = "{llvmCStringEscape(text)}\\00"
-    let byteLen = llvmStrings.split(text, "").len() + 1
+    let byteLen = text.bytes().len() + 1
     LlvmCString { encoded, byteLen }
 }
 
+// llvmCStringEscape emits an LLVM `c"..."` body for `text`. Iterates
+// over raw UTF-8 bytes so multi-byte code points (BOM, Korean, emoji)
+// emit one `\HH` escape per byte. LLVM IR string globals are byte
+// arrays, so that's the right shape for downstream runtime helpers
+// (strings.Equal, printf, etc.) that treat them as NUL-terminated
+// UTF-8.
 pub fn llvmCStringEscape(text: String) -> String {
     let mut encoded = ""
-    for unit in llvmStrings.split(text, "") {
-        if unit == "\n" {
-            encoded = "{encoded}\\0A"
-        } else if unit == "\t" {
-            encoded = "{encoded}\\09"
-        } else if unit == "\r" {
-            encoded = "{encoded}\\0D"
-        } else if unit == "\"" {
-            encoded = "{encoded}\\22"
-        } else if unit == "\\" {
+    for b in text.bytes() {
+        if b == '\\'.toInt().toByte() {
             encoded = "{encoded}\\5C"
-        } else if unit == "\u{1F}" {
-            encoded = "{encoded}\\1F"
+        } else if b == '"'.toInt().toByte() {
+            encoded = "{encoded}\\22"
+        } else if b >= 0x20.toByte() && b <= 0x7E.toByte() {
+            encoded = "{encoded}{b.toChar().toString()}"
         } else {
-            encoded = "{encoded}{unit}"
+            encoded = "{encoded}\\{llvmHexByte(b)}"
         }
     }
     encoded
+}
+
+fn llvmHexByte(b: Byte) -> String {
+    let n = b.toInt()
+    let hi = (n / 16) % 16
+    let lo = n % 16
+    "{llvmHexDigit(hi)}{llvmHexDigit(lo)}"
+}
+
+fn llvmHexDigit(n: Int) -> String {
+    if n < 10 {
+        "{n}"
+    } else if n == 10 {
+        "A"
+    } else if n == 11 {
+        "B"
+    } else if n == 12 {
+        "C"
+    } else if n == 13 {
+        "D"
+    } else if n == 14 {
+        "E"
+    } else {
+        "F"
+    }
 }
 
 pub fn llvmPrintlnString(emitter: LlvmEmitter, value: LlvmValue) {
@@ -1230,15 +1259,17 @@ pub fn llvmLogicalInstruction(op: String) -> String {
     ""
 }
 
+// llvmIsAsciiStringText gates which plain String literals the LLVM
+// backend accepts directly. Since `llvmCStringEscape` now byte-escapes
+// any non-printable / non-ASCII character via `\HH`, the gate only
+// needs to reject text that can't be encoded as a byte sequence at
+// all — and every `String` is already a valid UTF-8 byte sequence by
+// construction. Kept as a pure `true` stub for call-site stability
+// (formatter_ast / stdlib_shim / decl all fan in here); a future
+// rename to `llvmCanEmitStringLiteral` or inlining into callers is a
+// cleanup follow-up.
 pub fn llvmIsAsciiStringText(text: String) -> Bool {
-    for c in text.chars() {
-        if c == '\n' || c == '\t' || c == '\r' || c == '\u{1F}' {
-            continue
-        }
-        if c < ' ' || c > '~' {
-            return false
-        }
-    }
+    let _ = text
     true
 }
 


### PR DESCRIPTION
## Summary

`TestProbeNativeToolchainMerged` was first-walling on `LLVM011 [string_non_ascii] plain String literals currently require ASCII text`. The toolchain lexer at `frontend.osty:600` compares against `"\u{FEFF}"` (BOM detection), and the monomorphization key builder uses `"\u{1F}"` as a record separator — both tripped the ASCII-only gate.

The gate was an over-approximation: LLVM `c"..."` constants are byte arrays and accept `\HH` escapes for any 8-bit value, so there's no real reason to reject UTF-8 input. Fix in three parts:

- **`llvmCStringEscape`** now iterates the raw UTF-8 byte stream (not runes via `strings.Split(text, "")`) and emits one `\HH` escape per byte outside printable ASCII, plus the existing `\22` / `\5C` for `"` / `\`. Multi-byte code points (BOM, `\u{1F}`, Korean, emoji) round-trip as their UTF-8 sequences: `"안"` → `\EC\95\88`.
- **`llvmCString`** now counts UTF-8 bytes instead of runes so `[N x i8]` globals stay the right size. The previous `strings.Split(text, "")` path silently undersized every global containing code points above U+007F — a latent correctness bug independent of the wall.
- **`llvmIsAsciiStringText`** becomes a no-op stub returning `true`. The legacy ASCII-only check was the entire reason the wall existed; now that the escaper handles every byte, the gate has nothing to guard. Kept as a stub for call-site stability (`expr.go` / `decl.go` / `stdlib_shim.go` all fan in here).

Both the Osty source (`toolchain/llvmgen.osty`) and the Go snapshot (`internal/llvmgen/support_snapshot.go`) are updated in lockstep.

## Probe wall movement

- Before: `LLVM011 [string_non_ascii] plain String literals currently require ASCII text`
- After: `LLVM013 expression: match arm must be a payload-free enum variant` (unrelated match-expression lowering class)

## Test plan

- [x] `go test ./internal/llvmgen -run 'TestGenerateNonAsciiStringLiteralLowersAsByteEscapes' -count=1 -v` — new regression asserts BOM / `\u{1F}` / `"안녕"` lower to `\EF\BB\BF` / `\1F` / `\EC\95\88\EB\85\95`
- [x] `go test ./internal/llvmgen -run 'TestGeneratedComparePoliciesAreOstyOwned' -count=1 -v` — existing assertion updated: `llvmIsAsciiStringText("bom \ufeff ok")` now returns true (was false)
- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — confirms new wall is `LLVM013` match arm
- [x] `go test ./internal/llvmgen -count=1 -short` — same 12 preexisting failures, no new regressions
- [x] `go test ./internal/parser ./internal/backend/... -count=1 -short` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)