### PR TITLE
fix(selfhost): unwrap AstNExprStmt at block tail for type inference

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -33933,9 +33933,14 @@ func elabInferBlock(cx *ElabCx, idx int, node *AstNode) *ElabResult {
 		}()
 		_ = isTail
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14597:9
-		if isTail && astIsExprKindAt(cx.ast, stmtIdx) {
+		// Unwrap AstNExprStmt before testing `astIsExprKindAt` so a
+		// trailing expression used as a statement (parser.osty:1099)
+		// still contributes its type to the block's tail. Mirrored from
+		// toolchain/elab.osty pending a regen fix.
+		tailExprIdx := blockTailExprIdx(cx.ast, stmtIdx)
+		if isTail && tailExprIdx >= 0 && astIsExprKindAt(cx.ast, tailExprIdx) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14598:13
-			tail := elabInfer(cx, stmtIdx)
+			tail := elabInfer(cx, tailExprIdx)
 			_ = tail
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14599:13
 			tailNode = tail.node
@@ -33970,6 +33975,19 @@ func elabInferBlock(cx *ElabCx, idx int, node *AstNode) *ElabResult {
 	coreIdx := coreBlock(cx.core, stmts, tailNode, tailTy, node.start, node.end)
 	_ = coreIdx
 	return &ElabResult{node: coreIdx, ty: tailTy}
+}
+
+// blockTailExprIdx unwraps AstNExprStmt for the last-stmt-as-tail path.
+// Mirrored from toolchain/elab.osty pending a regen fix.
+func blockTailExprIdx(ast *AstFile, stmtIdx int) int {
+	if stmtIdx < 0 {
+		return stmtIdx
+	}
+	node := astArenaNodeAt(ast.arena, stmtIdx)
+	if _, ok := node.kind.(*AstNodeKind_AstNExprStmt); ok {
+		return node.left
+	}
+	return stmtIdx
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14616:1
@@ -34013,9 +34031,11 @@ func elabCheckBlock(cx *ElabCx, idx int, node *AstNode, expected int) *ElabResul
 		}()
 		_ = isTail
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14628:9
-		if isTail && astIsExprKindAt(cx.ast, stmtIdx) {
+		// Unwrap AstNExprStmt for the tail (mirror of elabInferBlock).
+		tailExprIdx := blockTailExprIdx(cx.ast, stmtIdx)
+		if isTail && tailExprIdx >= 0 && astIsExprKindAt(cx.ast, tailExprIdx) {
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14629:13
-			tail := elabCheck(cx, stmtIdx, expected)
+			tail := elabCheck(cx, tailExprIdx, expected)
 			_ = tail
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14630:13
 			tailNode = tail.node

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -511,8 +511,9 @@ fn elabInferBlock(cx: ElabCx, idx: Int, node: AstNode) -> ElabResult {
     let mut i = 0
     for stmtIdx in stmtIdxs {
         let isTail = i == n - 1
-        if isTail && astIsExprKindAt(cx.ast, stmtIdx) {
-            let tail = elabInfer(cx, stmtIdx)
+        let tailExprIdx = blockTailExprIdx(cx.ast, stmtIdx)
+        if isTail && tailExprIdx >= 0 && astIsExprKindAt(cx.ast, tailExprIdx) {
+            let tail = elabInfer(cx, tailExprIdx)
             tailNode = tail.node
             tailTy = tail.ty
         } else {
@@ -530,6 +531,25 @@ fn elabInferBlock(cx: ElabCx, idx: Int, node: AstNode) -> ElabResult {
     ElabResult { node: coreIdx, ty: tailTy }
 }
 
+/// blockTailExprIdx unwraps an `AstNExprStmt` wrapper when it appears
+/// as the last statement of a block. The parser wraps every
+/// expression-used-as-statement in that wrapper (parser.osty:1099);
+/// without this unwrap, `astIsExprKindAt` (which has no `AstNExprStmt`
+/// arm) rejects the tail, elabInferBlock falls into the statement
+/// path, and every block-expression silently reports type `()` —
+/// forcing the enclosing `if cond { ... } else { ... }` to join with
+/// the synthesized Unit else-branch back to `()`.
+fn blockTailExprIdx(ast: AstFile, stmtIdx: Int) -> Int {
+    if stmtIdx < 0 {
+        return stmtIdx
+    }
+    let node = astArenaNodeAt(ast.arena, stmtIdx)
+    if node.kind == AstNExprStmt {
+        return node.left
+    }
+    stmtIdx
+}
+
 fn elabCheckBlock(cx: ElabCx, idx: Int, node: AstNode, expected: Int) -> ElabResult {
     let mark = checkScopeMark(cx.env)
     let mut stmts: List<Int> = []
@@ -542,8 +562,9 @@ fn elabCheckBlock(cx: ElabCx, idx: Int, node: AstNode, expected: Int) -> ElabRes
     let mut i = 0
     for stmtIdx in stmtIdxs {
         let isTail = i == n - 1
-        if isTail && astIsExprKindAt(cx.ast, stmtIdx) {
-            let tail = elabCheck(cx, stmtIdx, expected)
+        let tailExprIdx = blockTailExprIdx(cx.ast, stmtIdx)
+        if isTail && tailExprIdx >= 0 && astIsExprKindAt(cx.ast, tailExprIdx) {
+            let tail = elabCheck(cx, tailExprIdx, expected)
             tailNode = tail.node
             tailTy = tail.ty
         } else {


### PR DESCRIPTION
## Summary

The parser wraps every expression-used-as-statement in an `AstNExprStmt { left: expr }` node ([parser.osty:1099](toolchain/parser.osty)). That means the **last child of every block is an `AstNExprStmt`**, never the raw expression. `elabInferBlock` / `elabCheckBlock` decided whether to carry the tail's type out of the block using `astIsExprKindAt(stmtIdx)` — but that helper has no `AstNExprStmt` arm, so it returned `false`, the tail branch was skipped, and the block's inferred type stayed the initial `tUnit` default.

**Consequence**: every block-valued expression typed as `()`.

```osty
let y = if cond { x } else { 0 }   // y: (), not Int
let retEffective = if retTy >= 0 { retTy } else { tUnit(...) }
S { retTy: retEffective }           // expected Int, found () — cascade
```

All the `expected Int, found ()` / `expected Bool, found ()` / `no field X on type ()` / `operator + cannot be applied to ()` errors in the native-only toolchain histogram traced back to this one inference hole. The field-on-`()` errors in particular were the second-order cascade of locals binding to `()`.

## What changed

Add a small `blockTailExprIdx` helper that unwraps `AstNExprStmt` and use it in both `elabInferBlock` and `elabCheckBlock` before consulting `astIsExprKindAt`. The wrapper's inner expression is what `astIsExprKindAt` understands; the block then carries a proper tail type out as an ordinary expression-block result.

## Measured impact

Toolchain histograms (`selfhost.CheckPackageStructured`), native-only:

| | before | after | Δ |
|---|---|---|---|
| native-only errors | 210 | **64** | **−146 (−69.5%)** |
| E0700 (type mismatch) | 112 | **17** | **−95 (−85%)** |
| E0702 (no field on ()) | 33 | **0** | **−33 (−100%)** |
| E0744 (operator on ()) | 32 | **14** | **−18 (−56%)** |
| accepted | 23606 / 23705 | 25353 / 25359 | **+1747** |

The remaining 17 E0700 are legitimate type mismatches in the checker's real logic (e.g. `expected Char, found String` at `parser.osty:2030` — a real callsite bug unrelated to this inference hole).

## Cumulative selfhost progress

| | main before [#421](https://github.com/choiceoh/osty/pull/421) | now |
|---|---|---|
| native-only errors | ~6308 | **64** |
| overall reduction | — | **~99%** over nine PRs |

## Verification

- Minimal `fn pick(x: Int) -> Int { let y = if x >= 0 { x } else { 0 }; let z = y + 1; z }` → 0 errors (was `E0744 operator \`+-*/%\` cannot be applied to \`()\``)
- `osty gen --backend=llvm` on hello → exit 0
- 4 targeted `internal/llvmgen` tests → pass
- `TestProbeWholeToolchainMerged` → unchanged (`runtime.golegacy.astbridge`)
- `TestProbeNativeToolchainMerged` → unchanged (`LLVM011 list_mixed_ptr`)
- `internal/lexer`, `internal/parser` → pass

## Mirror protocol

Edits live in `toolchain/elab.osty` (source of truth) and `internal/selfhost/generated.go`. Regen is still blocked on bootstrap-gen, so the generated-side hunks carry the usual `// Mirrored from ... pending a regen fix` comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)