### PR TITLE
fix(llvmgen): backport LLVM018/LLVM001/LLVM002 drift + Osty classifier

### DIFF
--- a/examples/selfhost-core/diagnostic.osty
+++ b/examples/selfhost-core/diagnostic.osty
@@ -22,6 +22,7 @@ pub enum DiagnosticFamily {
     FamilyScaffold,
     FamilyLint,
     FamilyWarning,
+    FamilyBackend,
     FamilyUnknown,
 }
 
@@ -33,6 +34,8 @@ pub fn diagnosticSeverity(code: String) -> DiagnosticSeverity {
         SeverityWarning
     } else if code >= "L0000" && code <= "L9999" {
         SeverityLint
+    } else if code >= "LLVM000" && code <= "LLVM999" {
+        SeverityError
     } else {
         SeverityUnknown
     }
@@ -49,9 +52,16 @@ pub fn diagnosticSeverityName(severity: DiagnosticSeverity) -> String {
 }
 
 /// diagnosticFamily classifies a stable code into the phase family that
-/// owns it. The body delegates to the generated manifest so adding a
-/// new code in internal/diag/codes.go is a one-file change.
+/// owns it. E/W/L codes delegate to the generated manifest so adding a
+/// new Go-side code in internal/diag/codes.go is a one-file change.
+/// Backend codes (`LLVM000-LLVM999`) short-circuit to `FamilyBackend`
+/// because they are populated by the self-hosted LLVM backend in
+/// toolchain/llvmgen.osty, outside the diag_manifest.osty generator's
+/// scope.
 pub fn diagnosticFamily(code: String) -> DiagnosticFamily {
+    if code >= "LLVM000" && code <= "LLVM999" {
+        return FamilyBackend
+    }
     diagnosticFamilyForCode(code)
 }
 
@@ -70,6 +80,7 @@ pub fn diagnosticFamilyName(family: DiagnosticFamily) -> String {
         FamilyScaffold -> "scaffold",
         FamilyLint -> "lint",
         FamilyWarning -> "warning",
+        FamilyBackend -> "backend",
         FamilyUnknown -> "unknown",
     }
 }

--- a/examples/selfhost-core/diagnostic_test.osty
+++ b/examples/selfhost-core/diagnostic_test.osty
@@ -25,6 +25,10 @@ fn testDiagnosticExamplesClassifySeverityPrefixes() {
     assertDiagnosticSeverity("W9999", "warning")
     assertDiagnosticSeverity("L0000", "lint")
     assertDiagnosticSeverity("L9999", "lint")
+    assertDiagnosticSeverity("LLVM000", "error")
+    assertDiagnosticSeverity("LLVM001", "error")
+    assertDiagnosticSeverity("LLVM018", "error")
+    assertDiagnosticSeverity("LLVM999", "error")
     assertDiagnosticSeverity("X0001", "unknown")
     assertDiagnosticSeverity("", "unknown")
 }
@@ -64,6 +68,16 @@ fn testDiagnosticExamplesClassifyToolFamilies() {
     assertDiagnosticFamily("W0750", "warning")
 }
 
+fn testDiagnosticExamplesClassifyBackendCodes() {
+    assertDiagnosticFamily("LLVM000", "backend")
+    assertDiagnosticFamily("LLVM001", "backend")
+    assertDiagnosticFamily("LLVM002", "backend")
+    assertDiagnosticFamily("LLVM010", "backend")
+    assertDiagnosticFamily("LLVM011", "backend")
+    assertDiagnosticFamily("LLVM018", "backend")
+    assertDiagnosticFamily("LLVM999", "backend")
+}
+
 fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
     assertDiagnosticFamily("E0000", "unknown")
     assertDiagnosticFamily("E0099", "unknown")
@@ -71,11 +85,15 @@ fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
     assertDiagnosticFamily("E2040", "unknown")
     assertDiagnosticFamily("L0000", "unknown")
     assertDiagnosticFamily("Z0000", "unknown")
+    assertDiagnosticFamily("LLVMabc", "unknown")
 }
 
 fn testDiagnosticExamplesIdentifyCompilationBlockers() {
     testing.assert(diagnosticIsCompilerError("E0500"))
     testing.assert(diagnosticIsCompilerError("E2017"))
+    testing.assert(diagnosticIsCompilerError("LLVM001"))
+    testing.assert(diagnosticIsCompilerError("LLVM011"))
+    testing.assert(diagnosticIsCompilerError("LLVM018"))
     testing.assert(!(diagnosticIsCompilerError("W0001")))
     testing.assert(!(diagnosticIsCompilerError("L0001")))
     testing.assert(!(diagnosticIsCompilerError("Z0000")))

--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -612,9 +612,21 @@ pub fn llvmUnsupportedDiagnostic(kind: String, detail: String) -> LlvmUnsupporte
         }
         return LlvmUnsupportedDiagnostic {
             code: "LLVM001",
-            kind: "go-only",
-            message: "use go \"{target}\" is only supported by the Go backend",
-            hint: "replace it with a native/runtime binding before using --backend=llvm",
+            kind: "foreign-ffi",
+            message: "Go FFI import {target} is not supported by the self-hosted native backend",
+            hint: "rewrite the binding as `use runtime.cabi.<lib> { ... }` for extern C symbols, or `use runtime.<surface> { ... }` for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)",
+        }
+    }
+    if kind == "runtime-ffi" {
+        let mut target = detail
+        if target == "" {
+            target = "<unknown>"
+        }
+        return LlvmUnsupportedDiagnostic {
+            code: "LLVM002",
+            kind: "runtime-ffi",
+            message: "Osty runtime FFI import {target} needs native runtime lowering",
+            hint: "add the runtime ABI shim and lowering before compiling this source natively",
         }
     }
 

--- a/internal/llvmgen/unsupported_diag_parity_test.go
+++ b/internal/llvmgen/unsupported_diag_parity_test.go
@@ -1,0 +1,132 @@
+package llvmgen
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// TestUnsupportedDiagnosticOstySnapshotParity pins the kind → (code, hint)
+// mapping agreement across the three places it lives:
+//
+//   - toolchain/llvmgen.osty              (declared source of truth; see
+//     llvmgen.go header + toolchain/llvmgen.osty:1325 comment)
+//   - examples/selfhost-core/llvmgen.osty (bootstrap seed mirror)
+//   - support_snapshot.go                 (hand-maintained Go snapshot,
+//     exported via UnsupportedDiagnosticFor)
+//
+// Without this gate a branch added to one file and forgotten in the
+// others silently drifts. That is how LLVM018 (stdlib-body) ended up
+// present in examples/selfhost-core + the Go snapshot but absent from
+// toolchain/llvmgen.osty between commits 3b23c72 and the follow-up fix.
+//
+// Both branch shapes are covered:
+//   - uniform call form: `llvmUnsupportedDiagnosticWith("LLVMNNN", ...)`
+//     (LLVM010..LLVM018)
+//   - field-literal form: `return LlvmUnsupportedDiagnostic { code:
+//     "LLVMNNN", ..., hint: "..." }` (LLVM001 / LLVM002)
+//
+// LLVM000 (the implicit default branch at the tail of the function)
+// has no `if kind == "..."` anchor so it is out of scope here; its
+// code/hint contract is pinned by TestUnsupportedDiagnosticKindMapping
+// + TestUnsupportedDiagnosticHintAnchors.
+func TestUnsupportedDiagnosticOstySnapshotParity(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	sources := []string{
+		"toolchain/llvmgen.osty",
+		"examples/selfhost-core/llvmgen.osty",
+	}
+	extracted := make(map[string]map[string][2]string) // rel path → kind → [code, hint]
+	for _, rel := range sources {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		extracted[rel] = parseLlvmUnsupportedWithBranches(string(data))
+		if len(extracted[rel]) == 0 {
+			t.Fatalf("%s: parsed 0 llvmUnsupportedDiagnosticWith branches; parser regex is stale or the source was restructured", rel)
+		}
+	}
+	kinds := map[string]struct{}{}
+	for _, m := range extracted {
+		for k := range m {
+			kinds[k] = struct{}{}
+		}
+	}
+	sortedKinds := make([]string, 0, len(kinds))
+	for k := range kinds {
+		sortedKinds = append(sortedKinds, k)
+	}
+	sort.Strings(sortedKinds)
+	for _, kind := range sortedKinds {
+		snap := UnsupportedDiagnosticFor(kind, "")
+		for _, rel := range sources {
+			br, ok := extracted[rel][kind]
+			if !ok {
+				t.Errorf("kind %q: missing from %s (Go snapshot maps it to %s)",
+					kind, rel, snap.Code)
+				continue
+			}
+			if br[0] != snap.Code {
+				t.Errorf("kind %q: %s has code %q, Go snapshot has %q",
+					kind, rel, br[0], snap.Code)
+			}
+			if br[1] != snap.Hint {
+				t.Errorf("kind %q: %s hint drift\n  osty:     %q\n  snapshot: %q",
+					kind, rel, br[1], snap.Hint)
+			}
+		}
+	}
+}
+
+var (
+	ostyKindBranchRE = regexp.MustCompile(`if kind == "([^"]+)"`)
+	ostyUnsupportedCallRE = regexp.MustCompile(
+		`llvmUnsupportedDiagnosticWith\(\s*"(LLVM\d{3})"\s*,\s*kind\s*,\s*detail\s*,\s*"((?:[^"\\]|\\.)*)"`,
+	)
+	ostyUnsupportedLiteralCodeRE = regexp.MustCompile(`code:\s*"(LLVM\d{3})"`)
+	ostyUnsupportedLiteralHintRE = regexp.MustCompile(`hint:\s*"((?:[^"\\]|\\.)*)"`)
+)
+
+// parseLlvmUnsupportedWithBranches walks an Osty source and returns a
+// kind → [code, hint] map for each `if kind == "..."` branch in
+// llvmUnsupportedDiagnostic. Two branch shapes are recognized:
+//
+//   - uniform helper call:
+//       return llvmUnsupportedDiagnosticWith("LLVMNNN", kind, detail, "hint")
+//   - field-literal return (LLVM001 / LLVM002, which decorate the kind
+//     they emit so they can't reuse the helper):
+//       return LlvmUnsupportedDiagnostic {
+//         code: "LLVMNNN", ..., hint: "hint", ...,
+//       }
+//
+// Each branch is bounded to the source slice between its kind anchor
+// and the next branch's anchor, so a field-literal hint pattern from
+// branch N cannot bleed into branch N+1.
+func parseLlvmUnsupportedWithBranches(src string) map[string][2]string {
+	out := map[string][2]string{}
+	matches := ostyKindBranchRE.FindAllStringSubmatchIndex(src, -1)
+	for i, m := range matches {
+		kind := src[m[2]:m[3]]
+		windowEnd := len(src)
+		if i+1 < len(matches) {
+			windowEnd = matches[i+1][0]
+		}
+		window := src[m[1]:windowEnd]
+		if c := ostyUnsupportedCallRE.FindStringSubmatch(window); c != nil {
+			out[kind] = [2]string{c[1], c[2]}
+			continue
+		}
+		codeMatch := ostyUnsupportedLiteralCodeRE.FindStringSubmatch(window)
+		hintMatch := ostyUnsupportedLiteralHintRE.FindStringSubmatch(window)
+		if codeMatch != nil && hintMatch != nil {
+			out[kind] = [2]string{codeMatch[1], hintMatch[1]}
+		}
+	}
+	return out
+}

--- a/internal/llvmgen/unsupported_diag_test.go
+++ b/internal/llvmgen/unsupported_diag_test.go
@@ -36,21 +36,48 @@ func TestUnsupportedDiagnosticKindMapping(t *testing.T) {
 	}
 }
 
-// TestUnsupportedStdlibBodyHint verifies the LLVM018 hint is specific enough
-// to direct users to either the stdlib lowering backlog or a runtime shim
-// workaround rather than offering the generic "reduce to smoke subset"
-// fallback.
-func TestUnsupportedStdlibBodyHint(t *testing.T) {
-	got := UnsupportedDiagnosticFor("stdlib-body", "strings.compare body")
-	if got.Code != "LLVM018" {
-		t.Fatalf("Code = %q, want LLVM018", got.Code)
+// TestUnsupportedDiagnosticHintAnchors pins each LLVM0xx hint to stable
+// anchor substrings. The intent is to catch silent regressions where a
+// refactor of the Osty source in toolchain/llvmgen.osty (or its Go
+// snapshot in support_snapshot.go) weakens a hint back to the generic
+// "reduce to smoke subset" fallback. Each anchor is picked to survive
+// minor rewording while pinning the actionable content — the specific
+// migration path (runtime.cabi, runtime ABI shim), the supported
+// subset (Int or Bool, range loops, ASCII identifiers, …), or the
+// gap category (stdlib + runtime shim).
+func TestUnsupportedDiagnosticHintAnchors(t *testing.T) {
+	cases := []struct {
+		kind    string
+		code    string
+		anchors []string
+	}{
+		{"go-ffi", "LLVM001", []string{"runtime.cabi"}},
+		{"runtime-ffi", "LLVM002", []string{"runtime ABI shim"}},
+		{"source-layout", "LLVM010", []string{"main function"}},
+		{"type-system", "LLVM011", []string{"Int or Bool"}},
+		{"statement", "LLVM012", []string{"range-for"}},
+		{"expression", "LLVM013", []string{"value-if"}},
+		{"control-flow", "LLVM014", []string{"range loops"}},
+		{"call", "LLVM015", []string{"positional Int/Bool"}},
+		{"name", "LLVM016", []string{"ASCII identifiers"}},
+		{"function-signature", "LLVM017", []string{"non-generic"}},
+		{"stdlib-body", "LLVM018", []string{"stdlib", "runtime shim"}},
+		{"anything-else", "LLVM000", []string{"LLVM smoke subset"}},
 	}
-	if got.Hint == "" {
-		t.Fatalf("Hint is empty")
-	}
-	for _, want := range []string{"stdlib", "runtime shim"} {
-		if !strings.Contains(got.Hint, want) {
-			t.Errorf("Hint = %q, missing %q", got.Hint, want)
+	for _, tc := range cases {
+		got := UnsupportedDiagnosticFor(tc.kind, "detail")
+		if got.Code != tc.code {
+			t.Errorf("kind=%q: Code = %q, want %q", tc.kind, got.Code, tc.code)
+		}
+		if got.Hint == "" {
+			t.Errorf("kind=%q (%s): Hint is empty", tc.kind, got.Code)
+			continue
+		}
+		for _, anchor := range tc.anchors {
+			if !strings.Contains(got.Hint, anchor) {
+				t.Errorf("kind=%q (%s): Hint = %q, missing anchor %q",
+					tc.kind, got.Code, got.Hint, anchor)
+			}
 		}
 	}
 }

--- a/toolchain/diagnostic.osty
+++ b/toolchain/diagnostic.osty
@@ -22,20 +22,22 @@ pub enum DiagnosticFamily {
     FamilyScaffold,
     FamilyLint,
     FamilyWarning,
+    FamilyBackend,
     FamilyUnknown,
 }
 
 /// diagnosticSeverity classifies a stable code by prefix.
 ///
 /// Codes follow a simple range convention: `E0000-E9999` errors,
-/// `W0000-W9999` warnings, `L0000-L9999` lints. Anything outside
-/// these ranges is `SeverityUnknown` so unknown codes never silently
-/// pass as errors.
+/// `W0000-W9999` warnings, `L0000-L9999` lints, `LLVM000-LLVM999`
+/// backend errors. Anything outside these ranges is `SeverityUnknown`
+/// so unknown codes never silently pass as errors.
 ///
 /// ```osty
 /// testing.assertEq(diagnosticSeverityName(diagnosticSeverity("E0001")), "error")
 /// testing.assertEq(diagnosticSeverityName(diagnosticSeverity("W0100")), "warning")
 /// testing.assertEq(diagnosticSeverityName(diagnosticSeverity("L0002")), "lint")
+/// testing.assertEq(diagnosticSeverityName(diagnosticSeverity("LLVM011")), "error")
 /// testing.assertEq(diagnosticSeverityName(diagnosticSeverity("X9999")), "unknown")
 /// testing.assertEq(diagnosticSeverityName(diagnosticSeverity("")), "unknown")
 /// ```
@@ -46,6 +48,8 @@ pub fn diagnosticSeverity(code: String) -> DiagnosticSeverity {
         SeverityWarning
     } else if code >= "L0000" && code <= "L9999" {
         SeverityLint
+    } else if code >= "LLVM000" && code <= "LLVM999" {
+        SeverityError
     } else {
         SeverityUnknown
     }
@@ -62,8 +66,12 @@ pub fn diagnosticSeverityName(severity: DiagnosticSeverity) -> String {
 }
 
 /// diagnosticFamily classifies a stable code into the phase family that
-/// owns it. The body delegates to the generated manifest so adding a
-/// new code in internal/diag/codes.go is a one-file change.
+/// owns it. E/W/L codes delegate to the generated manifest so adding a
+/// new Go-side code in internal/diag/codes.go is a one-file change.
+/// Backend codes (`LLVM000-LLVM999`) short-circuit to `FamilyBackend`
+/// because they are populated by the self-hosted LLVM backend in
+/// toolchain/llvmgen.osty, outside the diag_manifest.osty generator's
+/// scope.
 ///
 /// ```osty
 /// testing.assertEq(diagnosticFamilyName(diagnosticFamily("E0001")), "lexical")
@@ -73,9 +81,14 @@ pub fn diagnosticSeverityName(severity: DiagnosticSeverity) -> String {
 /// testing.assertEq(diagnosticFamilyName(diagnosticFamily("E2000")), "manifest")
 /// testing.assertEq(diagnosticFamilyName(diagnosticFamily("L0001")), "lint")
 /// testing.assertEq(diagnosticFamilyName(diagnosticFamily("W0750")), "warning")
+/// testing.assertEq(diagnosticFamilyName(diagnosticFamily("LLVM001")), "backend")
+/// testing.assertEq(diagnosticFamilyName(diagnosticFamily("LLVM018")), "backend")
 /// testing.assertEq(diagnosticFamilyName(diagnosticFamily("E9999")), "unknown")
 /// ```
 pub fn diagnosticFamily(code: String) -> DiagnosticFamily {
+    if code >= "LLVM000" && code <= "LLVM999" {
+        return FamilyBackend
+    }
     diagnosticFamilyForCode(code)
 }
 
@@ -94,6 +107,7 @@ pub fn diagnosticFamilyName(family: DiagnosticFamily) -> String {
         FamilyScaffold -> "scaffold",
         FamilyLint -> "lint",
         FamilyWarning -> "warning",
+        FamilyBackend -> "backend",
         FamilyUnknown -> "unknown",
     }
 }

--- a/toolchain/diagnostic_test.osty
+++ b/toolchain/diagnostic_test.osty
@@ -24,6 +24,10 @@ fn testDiagnosticExamplesClassifySeverityPrefixes() {
     assertDiagnosticSeverity("W9999", "warning")
     assertDiagnosticSeverity("L0000", "lint")
     assertDiagnosticSeverity("L9999", "lint")
+    assertDiagnosticSeverity("LLVM000", "error")
+    assertDiagnosticSeverity("LLVM001", "error")
+    assertDiagnosticSeverity("LLVM018", "error")
+    assertDiagnosticSeverity("LLVM999", "error")
     assertDiagnosticSeverity("X0001", "unknown")
     assertDiagnosticSeverity("", "unknown")
 }
@@ -63,6 +67,16 @@ fn testDiagnosticExamplesClassifyToolFamilies() {
     assertDiagnosticFamily("W0750", "warning")
 }
 
+fn testDiagnosticExamplesClassifyBackendCodes() {
+    assertDiagnosticFamily("LLVM000", "backend")
+    assertDiagnosticFamily("LLVM001", "backend")
+    assertDiagnosticFamily("LLVM002", "backend")
+    assertDiagnosticFamily("LLVM010", "backend")
+    assertDiagnosticFamily("LLVM011", "backend")
+    assertDiagnosticFamily("LLVM018", "backend")
+    assertDiagnosticFamily("LLVM999", "backend")
+}
+
 fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
     assertDiagnosticFamily("E0000", "unknown")
     assertDiagnosticFamily("E0099", "unknown")
@@ -70,11 +84,15 @@ fn testDiagnosticExamplesClassifyUnknownFamilyGaps() {
     assertDiagnosticFamily("E2040", "unknown")
     assertDiagnosticFamily("L0000", "unknown")
     assertDiagnosticFamily("Z0000", "unknown")
+    assertDiagnosticFamily("LLVMabc", "unknown")
 }
 
 fn testDiagnosticExamplesIdentifyCompilationBlockers() {
     testing.assert(diagnosticIsCompilerError("E0500"))
     testing.assert(diagnosticIsCompilerError("E2017"))
+    testing.assert(diagnosticIsCompilerError("LLVM001"))
+    testing.assert(diagnosticIsCompilerError("LLVM011"))
+    testing.assert(diagnosticIsCompilerError("LLVM018"))
     testing.assert(!(diagnosticIsCompilerError("W0001")))
     testing.assert(!(diagnosticIsCompilerError("L0001")))
     testing.assert(!(diagnosticIsCompilerError("Z0000")))

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1061,6 +1061,14 @@ pub fn llvmUnsupportedDiagnostic(kind: String, detail: String) -> LlvmUnsupporte
             "use non-generic functions with identifier parameters and Int/Bool types",
         )
     }
+    if kind == "stdlib-body" {
+        return llvmUnsupportedDiagnosticWith(
+            "LLVM018",
+            kind,
+            detail,
+            "call stdlib functions whose bodies the LLVM backend can currently lower, or add a runtime shim for this symbol",
+        )
+    }
 
     let mut reason = detail
     if reason == "" {


### PR DESCRIPTION
## Summary

LLVM 진단 surface의 **세 곳 사이 드리프트**를 해소하고, **재발 방지 parity 게이트**를 추가하며, Osty 측 진단 분류 체계에 **LLVM 코드를 정식 등록**한다.

LLVM 진단은 세 곳에 미러링돼 있음:

| 위치 | 역할 |
|---|---|
| `toolchain/llvmgen.osty` | source-of-truth (파일 주석 및 `llvmgen.go:17-18` 헤더 명시) |
| `examples/selfhost-core/llvmgen.osty` | bootstrap seed 미러 |
| `internal/llvmgen/support_snapshot.go` | hand-maintained Go 미러 |

현재 이 셋을 동기화하는 자동 가드가 없어 드리프트가 누적되던 상태였음.

## Drift fixes

**LLVM018 (stdlib-body)** — 커밋 [3b23c72](https://github.com/choiceoh/osty/commit/3b23c72) (`feat(backend): foundation for bodied stdlib fn lowering`)가 examples + Go 스냅샷에만 브랜치를 추가하고 source-of-truth인 `toolchain/llvmgen.osty`를 놓쳤음. 본 PR에서 backport.

**LLVM001 / LLVM002 (foreign/runtime FFI)** — 커밋 [307a88e](https://github.com/choiceoh/osty/commit/307a88e) (`feat(llvmgen): runtime.cabi.* path for extern C symbol FFI`)가 toolchain + 스냅샷만 갱신하고 `examples/selfhost-core/llvmgen.osty`를 놓쳤음:
- LLVM001 kind 옛 `"go-only"` → 현 `"foreign-ffi"`
- hint 단순 교체 제안 → `runtime.cabi.<lib>` / `runtime.<surface>` 마이그레이션 경로 상세
- LLVM002 (runtime-ffi) 브랜치 자체 누락 → 추가

이 드리프트는 아래의 확장된 parity 테스트가 **자동 감지**한 것.

## Regression prevention

**`TestUnsupportedDiagnosticOstySnapshotParity`** — 두 Osty 복사본과 Go 스냅샷(`UnsupportedDiagnosticFor`)의 `kind → (code, hint)` 매핑 일치를 검증. 두 브랜치 shape 모두 커버:
- uniform 호출형 `llvmUnsupportedDiagnosticWith("LLVMNNN", ...)` (LLVM010-018)
- field-literal형 `return LlvmUnsupportedDiagnostic { code: "LLVMNNN", ..., hint: "..." }` (LLVM001/002)

**`TestUnsupportedDiagnosticHintAnchors`** — 기존 `TestUnsupportedStdlibBodyHint`(LLVM018 단일 코드만 검증)를 12개 코드 전부로 확장. 각 코드마다 actionable anchor 문자열 assert (`runtime.cabi`, `Int or Bool`, `range-for`, `ASCII identifiers`, `non-generic` 등). reword가 hint를 generic \`smoke subset\` fallback으로 약화시키면 실패.

네거티브 검증 완료: LLVM018 수정을 revert하면 parity 테스트가 즉시 actionable 메시지로 fail:

```
kind "stdlib-body": missing from toolchain/llvmgen.osty (Go snapshot maps it to LLVM018)
```

## Osty classifier registration

이전: `diagnosticSeverity(\"LLVM011\")` → `SeverityUnknown`, `diagnosticFamily(\"LLVM018\")` → `FamilyUnknown`. LLVM 진단이 자체 호스팅 분류기에 등록되지 않은 상태.

- `DiagnosticFamily` enum에 `FamilyBackend` variant 추가
- `diagnosticSeverity`: \`LLVM000-LLVM999\` → `SeverityError` 분류
- `diagnosticFamily`: \`LLVM000-LLVM999\` → `FamilyBackend` short-circuit (manifest 생성기는 backend 코드를 다루지 않기 때문에 수동 분기)
- `diagnosticFamilyName`: `FamilyBackend -> \"backend\"` 매핑
- `toolchain/diagnostic.osty` + `examples/selfhost-core/diagnostic.osty` 동기화
- `*_test.osty`에 LLVM 케이스 assert 추가 (LLVM000-999 에러, LLVM\*\*\* → \`backend\`, mal-formed \`LLVMabc\` → \`unknown\`)

## Test plan

- [x] `go test ./internal/llvmgen -run TestUnsupportedDiagnostic` — 3 tests green (kind mapping, hint anchors, Osty-snapshot parity)
- [x] `go test ./internal/selfhost -run TestToolchainCheckerSourcesTranspile` (48s full bootstrap-gen round-trip) — Osty 진단 source 변경이 transpile까지 안전
- [x] `go test ./internal/selfhost -short` — no regressions
- [x] Negative verification — LLVM018 수정 revert 시 parity 테스트 즉시 fail하는 것 확인
- [ ] `go generate ./internal/selfhost/...` 는 사전존재 bootstrap-gen 파이프라인 이슈(CLAUDE.md에 "새 작업 금지"로 라벨된 영역)로 실패; `installWithBuildGate`가 이전 `generated.go`를 자동 복원. Osty source 변경은 유효 (transpile 통과), Go 스냅샷은 파이프라인 복구 후 catch up 예정
- [ ] 기존 `TestRuntimeIntrinsicTypingRaw*` 실패는 내 변경 이전 baseline에서도 동일하게 발생 — 본 PR과 무관

## Notes for reviewer

- LLVM018은 아직 emit 사이트가 0건임 (follow-up PR 대기; 커밋 3b23c72 메시지 참조). 본 PR은 진단 code/hint 계약과 source-of-truth 일관성만 수립. 실제 `unsupported(\"stdlib-body\", ...)` wiring은 추후 별도 작업.
- `toolchain/` vs `examples/selfhost-core/` 두 Osty 복사본은 구조적으로 여전히 공존. 통합(consolidation)은 bootstrap-gen 파이프라인 재정비와 함께 이뤄지는 더 큰 규모의 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)