### PR TITLE
fix(llvmgen): byte-aware C-string escape in Osty source — parity with Go snapshot

### DIFF
--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -520,40 +520,51 @@ pub fn llvmCString(text: String) -> LlvmCString {
     LlvmCString { encoded, byteLen }
 }
 
-// llvmCStringEscape emits an LLVM `c"..."` body for `text`. Walks
-// the string rune-by-rune and preserves the individual chars /
-// multi-byte UTF-8 sequences as-is — LLVM IR `c"..."` globals accept
-// raw bytes in the input stream. The only escapes we emit explicitly
-// are for bytes LLVM can't represent literally in source: the five
-// C-style control escapes plus the quoted-string specials `"` / `\`.
+// llvmCStringEscape emits an LLVM `c"..."` body for `text`. Every
+// byte is escaped as `\HH` — verbose but portable: LLVM IR accepts
+// the hex form for any 8-bit value and we don't depend on
+// `Char.toString()` / byte-literal passthrough, both of which the
+// native backend can't lower yet (`emitPrimitiveToStringCall` covers
+// i64 / double / i1 only; Char is i32). The Go-side snapshot
+// (`internal/llvmgen/support_snapshot.go`) uses a more compact
+// printable-ASCII-passthrough variant; this Osty version stays
+// uniform so the merged-toolchain probe can lower the compiler's
+// own source.
 //
-// The Go-side snapshot (`internal/llvmgen/support_snapshot.go`) holds
-// the fuller byte-at-a-time variant with `\HH` escapes for every
-// non-printable / non-ASCII byte; that's what the native backend
-// actually runs. This Osty-side version stays on the rune path so
-// the native probe can lower `toolchain/llvmgen.osty` itself without
-// pulling in `.toByte()` / Byte-comparison intrinsics the backend
-// hasn't wired yet.
+// Byte values route through `b.toInt()` (zext i8→i64, already wired
+// in emitCharByteConversionCall) rather than `.toByte()` / direct
+// Byte comparisons, which would pull in intrinsics the backend
+// hasn't wired.
 pub fn llvmCStringEscape(text: String) -> String {
     let mut encoded = ""
-    for unit in llvmStrings.split(text, "") {
-        if unit == "\n" {
-            encoded = "{encoded}\\0A"
-        } else if unit == "\t" {
-            encoded = "{encoded}\\09"
-        } else if unit == "\r" {
-            encoded = "{encoded}\\0D"
-        } else if unit == "\"" {
-            encoded = "{encoded}\\22"
-        } else if unit == "\\" {
-            encoded = "{encoded}\\5C"
-        } else if unit == "\u{1F}" {
-            encoded = "{encoded}\\1F"
-        } else {
-            encoded = "{encoded}{unit}"
-        }
+    for b in text.bytes() {
+        encoded = "{encoded}\\{llvmHexByte(b.toInt())}"
     }
     encoded
+}
+
+fn llvmHexByte(n: Int) -> String {
+    let hi = (n / 16) % 16
+    let lo = n % 16
+    "{llvmHexDigit(hi)}{llvmHexDigit(lo)}"
+}
+
+fn llvmHexDigit(n: Int) -> String {
+    if n < 10 {
+        "{n}"
+    } else if n == 10 {
+        "A"
+    } else if n == 11 {
+        "B"
+    } else if n == 12 {
+        "C"
+    } else if n == 13 {
+        "D"
+    } else if n == 14 {
+        "E"
+    } else {
+        "F"
+    }
 }
 
 pub fn llvmPrintlnString(emitter: LlvmEmitter, value: LlvmValue) {


### PR DESCRIPTION
## Summary

PR #445 landed with a deliberate dual-path design: the Go snapshot (`internal/llvmgen/support_snapshot.go`) held the byte-aware escape (`\HH` per UTF-8 byte, correct `byteLen`), while the Osty-side `llvmCStringEscape` stayed rune-based. The split existed because the byte-iteration version needed intrinsics the backend couldn't lower:

- `.toByte()` returns `Result<Byte, Error>` — not a pure conversion.
- `n.toChar().toString()` walks through Char (i32), but `emitPrimitiveToStringCall` only covers i64 / double / i1.

This lands a byte-aware Osty version that bypasses both walls and keeps PR #442's original feature (byte-level escape with `\HH` for multi-byte UTF-8) in the toolchain source:

- Iterate `text.bytes()` and run each byte through `b.toInt()` — zext i8→i64 is already wired in `emitCharByteConversionCall`.
- Always emit `\HH` for every byte (no printable-ASCII passthrough). Verbose compared to the Go snapshot but avoids `Char.toString()` entirely, and LLVM IR happily accepts the uniform hex form. A future optimisation can carve out the ASCII passthrough if / when `Char.toString()` lowers.
- Split the hex conversion into `llvmHexByte` (two-digit) + `llvmHexDigit` (0–15 → one char) using only `Int` arithmetic and `Int.toString()` via interpolation.

The Go snapshot keeps its slightly-more-compact printable-ASCII passthrough variant; both paths produce semantically equivalent IR. The Osty side is now the source of truth for the native probe's merged lowering.

## Probe wall movement

- Before / After (both): `LLVM013 expression: *ast.RangeExpr` (unrelated — next wall in the chain)

The ~~Osty-only~~ byte-aware escape doesn't introduce a wall because `b.toInt()` lowers cleanly; the always-hex strategy avoids the `Char.toString()` wall that would trigger on a printable-ASCII passthrough.

## Test plan

- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — wall unchanged (still `RangeExpr`)
- [x] `go test ./internal/llvmgen -run 'TestGenerateNonAsciiStringLiteralLowersAsByteEscapes|TestGenerateReturnedListOfStringsLiteralPreservesStringHint|TestGenerateStringLenMethodDispatch' -v` — all pass
- [x] `go test ./internal/llvmgen -count=1 -short` — same 12 preexisting failures, no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)