### PR TITLE
fix: existing errors — vet warnings, turbofish-field dispatch, LLVM IR bridge

### DIFF
--- a/cmd/osty/airepair_test.go
+++ b/cmd/osty/airepair_test.go
@@ -738,12 +738,14 @@ func TestCheckWithAIRepairPassesSemanticForeignHelpers(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 
+	// `.length` is intentionally no longer parser-lowered (182f819):
+	// parse-time lowering blindly rewrote genuine struct-field reads, so
+	// airepair's type-aware semantic pass owns the rewrite instead. That
+	// means --no-airepair leaves `.length` in place and the native
+	// checker rejects it.
 	without := runOstyCLI(t, "check", "--no-airepair", path)
-	if without.exit != 0 {
-		t.Fatalf("check --no-airepair exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", without.exit, without.stdout, without.stderr)
-	}
-	if strings.Contains(without.stderr, "--airepair") {
-		t.Fatalf("stderr = %q, did not want airepair summary for parser-owned helper lowering", without.stderr)
+	if without.exit == 0 {
+		t.Fatalf("check --no-airepair exit = %d, want non-zero because `.length` requires airepair\nstdout:\n%s\nstderr:\n%s", without.exit, without.stdout, without.stderr)
 	}
 
 	with := runOstyCLI(t, "check", path)
@@ -789,7 +791,10 @@ func TestCheckWithoutAIRepairPassesParserLoweredEnumerateLoop(t *testing.T) {
 func TestCheckWithoutAIRepairPassesParserLoweredSemanticHelpers(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")
-	source := "fn main() {\n    let mut items = [1, 2]\n    let count = len(items)\n    let size = items.length\n    items = append(items, count + size)\n    println(items)\n}\n"
+	// Only the truly parser-owned helpers (`len(list)` → `list.len()`,
+	// `append(list, x)` → `list.push(x)`) — `.length` is airepair-only
+	// after 182f819, so it belongs in TestCheckWithAIRepairPassesSemanticForeignHelpers.
+	source := "fn main() {\n    let mut items = [1, 2]\n    let count = len(items)\n    items = append(items, count)\n    println(items)\n}\n"
 	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -890,10 +890,7 @@ func (g *generator) emitTestingCallStmt(call *ast.CallExpr) (bool, error) {
 }
 
 func (g *generator) testingCallMethod(call *ast.CallExpr) (string, bool) {
-	if call == nil {
-		return "", false
-	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok || field.IsOptional {
 		return "", false
 	}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -763,7 +763,7 @@ func (g *generator) staticStdStringsCallSourceType(call *ast.CallExpr) (ast.Type
 	if call == nil || len(g.stdStringsAliases) == 0 {
 		return nil, false
 	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok {
 		return nil, false
 	}
@@ -826,7 +826,7 @@ func (g *generator) staticCharByteConversionResult(call *ast.CallExpr) (value, b
 	if call == nil || len(call.Args) != 0 {
 		return value{}, false
 	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok || field.IsOptional || field.X == nil {
 		return value{}, false
 	}
@@ -867,10 +867,7 @@ func (g *generator) staticStringMethodResult(call *ast.CallExpr) (value, bool) {
 }
 
 func (g *generator) stringMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
-	if call == nil {
-		return nil, false
-	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok || field.IsOptional || field.X == nil {
 		return nil, false
 	}
@@ -938,11 +935,35 @@ func (g *generator) staticCollectionMethodResult(call *ast.CallExpr) (value, boo
 	return value{}, false, false
 }
 
-func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool, bool) {
+// fieldExprOfCallFn returns the FieldExpr callee of `call`, peeking
+// through a TurbofishExpr wrapper when present. The IR→AST bridge
+// (`legacyMethodCallFromIR`) wraps `recv.method` in a TurbofishExpr
+// whenever the IR MethodCall carries TypeArgs — which the checker
+// records for *every* generic method call, including intrinsic ones
+// like `list.push(1)` where the type arg is the receiver's own T.
+// Dispatchers that used to match a bare FieldExpr would then fall
+// through to the "unsupported call" path. Unwrapping the turbofish
+// here makes the dispatch transparent to the bridge shape.
+func fieldExprOfCallFn(call *ast.CallExpr) (*ast.FieldExpr, bool) {
 	if call == nil {
-		return nil, "", false, false
+		return nil, false
 	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	switch fn := call.Fn.(type) {
+	case *ast.FieldExpr:
+		return fn, fn != nil
+	case *ast.TurbofishExpr:
+		if fn == nil {
+			return nil, false
+		}
+		if fx, ok := fn.Base.(*ast.FieldExpr); ok {
+			return fx, fx != nil
+		}
+	}
+	return nil, false
+}
+
+func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool, bool) {
+	field, ok := fieldExprOfCallFn(call)
 	if !ok || field.IsOptional {
 		return nil, "", false, false
 	}
@@ -959,10 +980,7 @@ func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, 
 }
 
 func (g *generator) mapMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, string, bool, bool) {
-	if call == nil {
-		return nil, "", "", false, false
-	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok || field.IsOptional {
 		return nil, "", "", false, false
 	}
@@ -979,10 +997,7 @@ func (g *generator) mapMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, s
 }
 
 func (g *generator) setMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, bool, bool) {
-	if call == nil {
-		return nil, "", false, false
-	}
-	field, ok := call.Fn.(*ast.FieldExpr)
+	field, ok := fieldExprOfCallFn(call)
 	if !ok || field.IsOptional {
 		return nil, "", false, false
 	}

--- a/internal/pkgmgr/semver/semver.go
+++ b/internal/pkgmgr/semver/semver.go
@@ -6,8 +6,8 @@
 //	1.2.3
 //	1.2.3-alpha
 //	1.2.3-alpha.1
-//	1.2.3+build.meta
-//	1.2.3-alpha.1+build.meta
+//	1.2.3+sha.abcdef
+//	1.2.3-alpha.1+sha.abcdef
 //
 // Supported requirement forms (ParseReq):
 //
@@ -47,7 +47,7 @@ type Version struct {
 	// ["alpha", "1"]. Empty for a stable release.
 	Pre []string
 	// Build is the dot-separated build metadata, e.g.
-	// ["build", "meta"]. Does NOT participate in precedence.
+	// ["sha", "abcdef"]. Does NOT participate in precedence.
 	Build []string
 }
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -301,8 +301,18 @@ func (r *resolver) declareUse(u *ast.UseDecl) {
 	// scope definition above still serves the lexical lookup inside
 	// this file.
 	if u.IsPub && r.pkgScope != nil && r.pkgScope != r.current {
-		pkgSym := *sym // copy so package- and file-scope symbols don't alias identity
-		if _, ok := r.pkgScope.Define(&pkgSym); !ok {
+		// Fresh Symbol instead of `*sym` copy so package- and file-scope
+		// symbols don't alias identity — and so sync.Once (idOnce) isn't
+		// byte-copied (vet's copylocks check).
+		pkgSym := &Symbol{
+			Name:    sym.Name,
+			Kind:    sym.Kind,
+			Pos:     sym.Pos,
+			Decl:    sym.Decl,
+			Pub:     sym.Pub,
+			Package: sym.Package,
+		}
+		if _, ok := r.pkgScope.Define(pkgSym); !ok {
 			// Collision against an already-declared pkg-scope symbol
 			// is a re-export-over-existing conflict. Surface via the
 			// duplicate reporter using the existing symbol's location.
@@ -311,7 +321,6 @@ func (r *resolver) declareUse(u *ast.UseDecl) {
 			// refining the re-export-specific message (E0553) is
 			// Phase 2.2+ follow-up when the full cycle / visibility
 			// checker lands.
-			_ = pkgSym
 		}
 	}
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -35058,7 +35058,7 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15068:5
 	if ostyEqual(callee.kind, AstNodeKind(&AstNodeKind_AstNField{})) {
 		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15069:9
-		return elabInferMethodCall(cx, node, callee, expected)
+		return elabInferMethodCall(cx, node, callee, expected, make([]int, 0, 1))
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15073:5
 	var explicitArgs []int = make([]int, 0, 1)
@@ -35080,6 +35080,12 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15080:13
 			baseCallee = astArenaNodeAt(cx.ast.arena, baseIdx)
 		}
+	}
+	// Turbofish over a Field callee — `raw.read::<Int>(p)` etc. Route
+	// through the method-call path, forwarding the explicit type
+	// arguments. Mirrored from toolchain/elab.osty pending a regen fix.
+	if ostyEqual(baseCallee.kind, AstNodeKind(&AstNodeKind_AstNField{})) {
+		return elabInferMethodCall(cx, node, baseCallee, expected, explicitArgs)
 	}
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15084:5
 	if !ostyEqual(baseCallee.kind, AstNodeKind(&AstNodeKind_AstNIdent{})) {
@@ -35180,7 +35186,10 @@ func elabInferVariantCall(cx *ElabCx, callIdx int, node *AstNode, baseCallee *As
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15137:1
-func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expected int) *ElabResult {
+// explicitArgs carries turbofish type arguments for `recv.method::<T>(args)`
+// forms; pass an empty slice for plain calls. Mirrored from
+// toolchain/elab.osty pending a regen fix.
+func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expected int, explicitArgs []int) *ElabResult {
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15138:5
 	recv := elabInfer(cx, fieldNode.left)
 	_ = recv
@@ -35230,6 +35239,10 @@ func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expe
 	_ = ownerArgs
 	instSeedOwnerArgs(cx, inst, typeSig.generics, ownerArgs)
 	instSeedExpectedRet(cx, inst, sig.retTy, expected)
+	// Turbofish: bind explicit method-level type args. Strict-match
+	// seeder short-circuits when receiver generics are in play; package
+	// aliases (`raw`) have no receiver generics so the seed lands.
+	instSeedPositionalArgs(cx, inst, explicitArgs)
 	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15170:5
 	coreArgs := elabCallArgs(cx, inst.solver, sig, inst.freshs, callNode.children, callNode.start, callNode.end)
 	_ = coreArgs

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1101,7 +1101,7 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
     }
     let callee = astArenaNodeAt(cx.ast.arena, calleeIdx)
     if callee.kind == AstNField {
-        return elabInferMethodCall(cx, node, callee, expected)
+        return elabInferMethodCall(cx, node, callee, expected, [])
     }
 
     // Turbofish: callee is `AstNTurbofish { left = base, children = typeArgs }`.
@@ -1114,6 +1114,16 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
         if baseIdx >= 0 {
             baseCallee = astArenaNodeAt(cx.ast.arena, baseIdx)
         }
+    }
+
+    // Turbofish over a Field callee — `raw.read::<Int>(p)`,
+    // `x.map::<U>(f)` etc. Route through the method-call path, which
+    // already handles package-alias dispatch (owner = alias module) and
+    // method-on-value dispatch. The explicit type arguments are
+    // forwarded so `raw.read::<Int>` binds the method's T = Int even
+    // though the non-turbofish path couldn't see any type info.
+    if baseCallee.kind == AstNField {
+        return elabInferMethodCall(cx, node, baseCallee, expected, explicitArgs)
     }
 
     if baseCallee.kind != AstNIdent {
@@ -1234,9 +1244,11 @@ fn elabInferVariantCall(
     ElabResult { node: coreCallNode, ty: retTy }
 }
 
-/// elabInferMethodCall handles `recv.method(args)`. Relies on
-/// `checkLookupMethod` with the receiver's head type.
-fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expected: Int) -> ElabResult {
+/// elabInferMethodCall handles `recv.method(args)` and the turbofish
+/// form `recv.method::<T>(args)`. Relies on `checkLookupMethod` with
+/// the receiver's head type. `explicitArgs` carries any turbofish type
+/// arguments supplied at the call site; pass `[]` for plain calls.
+fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expected: Int, explicitArgs: List<Int>) -> ElabResult {
     let recv = elabInfer(cx, fieldNode.left)
     let recvResolved = checkResolveAliasDeep(cx.env, recv.ty)
     if tyIsBad(cx.env.tys, recvResolved) {
@@ -1283,6 +1295,14 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
     let ownerArgs = tyArgsAt(cx.env.tys, recvResolved)
     instSeedOwnerArgs(cx, inst, typeSig.generics, ownerArgs)
     instSeedExpectedRet(cx, inst, sig.retTy, expected)
+
+    // Turbofish: bind explicit type args to the method's generics.
+    // Works when `sig.generics` == method's own generics (package-alias
+    // dispatch where `raw` has no receiver generics). For struct methods
+    // like `List<T>.map<U>(f)`, `sig.generics = ["T", "U"]` and the
+    // strict-match seeder short-circuits; receiver-level bindings from
+    // `instSeedOwnerArgs` remain authoritative.
+    instSeedPositionalArgs(cx, inst, explicitArgs)
 
     let coreArgs = elabCallArgs(cx, inst.solver, sig, inst.freshs, callNode.children, callNode.start, callNode.end)
     let retSubstituted = instSubstitute(cx, inst, sig.retTy)


### PR DESCRIPTION
## Summary

Closes every failing test the short suite inherited from `origin/main` on this worktree, plus the two `go vet` warnings that were blocking `just prepush`. Three commits, each scoped to one root cause:

1. **`go vet` warnings** ([86dfdf6](https://github.com/choiceoh/osty/commit/86dfdf6))
   - `internal/resolve/resolve.go`: `declareUse` copied `*sym` by value, which byte-copies `sync.Once` (idOnce) and trips `copylocks`. Replaced with an explicit `&Symbol{...}` literal that copies only the data fields and drops the now-redundant `_ = pkgSym` blank-assign.
   - `internal/pkgmgr/semver/semver.go`: the SemVer example `+build.meta` in a header-comment trips the `buildtag` analyzer with "possible malformed +build comment". Renamed to `+sha.abcdef` (still a valid SemVer 2.0 build-metadata example) and synced the `Build []string` field doc.

2. **§19.5 turbofish intrinsic typing** ([4ccb645](https://github.com/choiceoh/osty/commit/4ccb645))
   - `raw.read::<Int>(p)`, `raw.cas::<Int>`, `raw.sizeOf::<Int>()` etc. were typing as `<error>` in IR because `elabInferCall`'s turbofish branch only handled `AstNIdent` base callees, falling through to `elabInferFnValueCall` for Field bases.
   - `d9a4c1f` originally patched the older `frontCheckTurbofishCall` shape; when the checker was rewritten around `elabInferCall` (`toolchain/elab.osty`) the fix wasn't carried over, silently regressing the 5 failing tests in `runtime_intrinsic_typing_test.go`.
   - Routes `AstNField`-base turbofish through `elabInferMethodCall` and adds an `explicitArgs: List<Int>` parameter that seeds the method-level generics via `instSeedPositionalArgs`. Applied to both the authoritative `toolchain/elab.osty` source and the `internal/selfhost/generated.go` mirror (the Osty→Go transpiler can't currently regenerate cleanly, matching the hand-patch approach `d9a4c1f` used).

3. **LLVM IR→AST bridge turbofish wrap + AIRepair test drift** ([ff1f9e4](https://github.com/choiceoh/osty/commit/ff1f9e4))
   - `legacyMethodCallFromIR` wraps every `MethodCall` with `TypeArgs` in an `ast.TurbofishExpr`, including intrinsic calls like `list.push(1)` where the arg is the receiver's implicit T. All method-info dispatchers (`listMethodInfo`, `mapMethodInfo`, `setMethodInfo`, `stringMethodInfo`, `testingCallMethod`, `staticStdStringsCallSourceType`, `staticCharByteConversionResult`) matched only a bare `FieldExpr`, so bridged calls fell through to LLVM015 "only println calls are supported". Added a shared `fieldExprOfCallFn` helper that peeks through the turbofish wrapper and routed every dispatcher through it.
   - `cmd/osty/airepair_test.go` still asserted `check --no-airepair` passes a source containing `items.length`, but `182f819` moved `.length` → `.len()` out of the parser into airepair's type-aware pass. Flipped `TestCheckWithAIRepairPassesSemanticForeignHelpers` to expect `--no-airepair` to fail, and dropped `.length` from `TestCheckWithoutAIRepairPassesParserLoweredSemanticHelpers` so the source actually only exercises parser-owned lowerings (`len(list)`, `append(list, x)`).

## Test plan

- [x] `go vet ./...` — exit 0 (was 4 warnings)
- [x] `just front` — all front-end packages green
- [x] `just short` — previously-failing tests all green:
  - `TestRuntimeIntrinsicTypingRawReadInt` / `RawReadFloat` / `RawCas` / `SizeOf` / `ChainedAllocReadFree` (5 in `internal/llvmgen`)
  - `TestCheckWithAIRepairPassesSemanticForeignHelpers` / `TestCheckWithoutAIRepairPassesParserLoweredSemanticHelpers` (2 in `cmd/osty`)
  - `TestLLVMBackendEmitBinaryBuildsBundledRuntime` (`internal/backend`)
  - `TestGenerateModuleStdTestingExpectOkCompat` (`internal/llvmgen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)