### PR TITLE
chore(llvmgen): include source identifier in LLVM013/LLVM015 walls

### DIFF
--- a/internal/llvmgen/diagnostic_shape_test.go
+++ b/internal/llvmgen/diagnostic_shape_test.go
@@ -1,0 +1,44 @@
+package llvmgen
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+// TestDebugPatternShape locks the short-form labels emitted by the
+// LLVM013 / LLVM015 family of "what did the user write here?"
+// diagnostics. A bare ident (`PreNone`) collapses to `ident "PreNone"`,
+// a payload variant call (`PreNumber(n)`) collapses to
+// `variant PreNumber with 1 arg(s)`, and so on. The probe driver greps
+// these labels to localize first walls in merged toolchain runs, so
+// keeping the shape stable matters more than the exact wording.
+func TestDebugPatternShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern ast.Pattern
+		want    string
+	}{
+		{"nil", nil, "<nil>"},
+		{"ident", &ast.IdentPat{Name: "PreNone"}, `ident "PreNone"`},
+		{"variant_no_args", &ast.VariantPat{Path: []string{"None"}}, "variant None (no args)"},
+		{"variant_qualified_no_args", &ast.VariantPat{Path: []string{"Pre", "None"}}, "variant Pre.None (no args)"},
+		{"variant_one_arg", &ast.VariantPat{Path: []string{"PreNumber"}, Args: []ast.Pattern{&ast.IdentPat{Name: "n"}}}, "variant PreNumber with 1 arg(s)"},
+		{"variant_two_args", &ast.VariantPat{Path: []string{"Rect"}, Args: []ast.Pattern{&ast.IdentPat{Name: "w"}, &ast.IdentPat{Name: "h"}}}, "variant Rect with 2 arg(s)"},
+		{"wildcard", &ast.WildcardPat{}, "wildcard"},
+		{"literal", &ast.LiteralPat{}, "literal"},
+		{"range", &ast.RangePat{}, "range"},
+		{"or", &ast.OrPat{}, "or-pattern"},
+		{"binding", &ast.BindingPat{Name: "x"}, "binding"},
+		{"tuple_2", &ast.TuplePat{Elems: []ast.Pattern{&ast.IdentPat{Name: "a"}, &ast.IdentPat{Name: "b"}}}, "tuple of 2"},
+		{"struct_unqualified", &ast.StructPat{Type: []string{"Point"}}, "struct Point"},
+		{"struct_qualified", &ast.StructPat{Type: []string{"geom", "Point"}}, "struct geom.Point"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := debugPatternShape(c.pattern); got != c.want {
+				t.Fatalf("debugPatternShape(%T) = %q, want %q", c.pattern, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1550,7 +1550,7 @@ func (g *generator) emitTagEnumMatchSelectValue(scrutinee value, arms []*ast.Mat
 			return value{}, err
 		}
 		if !ok {
-			return value{}, unsupported("expression", "match arm must be a payload-free enum variant")
+			return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s)", debugPatternShape(arm.Pattern))
 		}
 		armValue, err := g.emitMatchArmBodyValue(arm.Body)
 		if err != nil {
@@ -1591,7 +1591,7 @@ func (g *generator) emitTagEnumMatchChainValue(scrutinee value, arms []*ast.Matc
 			if _, ok, err := g.matchEnumTag(arm.Pattern); err != nil {
 				return value{}, err
 			} else if !ok {
-				return value{}, unsupported("expression", "match arm must be a payload-free enum variant")
+				return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s)", debugPatternShape(arm.Pattern))
 			}
 		}
 		return g.emitMatchArmBodyValue(arm.Body)
@@ -1604,7 +1604,7 @@ func (g *generator) emitTagEnumMatchChainValue(scrutinee value, arms []*ast.Matc
 		return value{}, err
 	}
 	if !ok {
-		return value{}, unsupported("expression", "match arm must be a payload-free enum variant")
+		return value{}, unsupportedf("expression", "match arm must be a payload-free enum variant (got %s)", debugPatternShape(arm.Pattern))
 	}
 	emitter := g.toOstyEmitter()
 	cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(value{typ: "i64", ref: strconv.Itoa(tag)}))
@@ -1751,7 +1751,7 @@ func (g *generator) emitTagEnumMatchIfExprValue(scrutinee value, first, second *
 		return value{}, err
 	}
 	if !ok {
-		return value{}, unsupported("expression", "first match arm must be a payload-free enum variant")
+		return value{}, unsupportedf("expression", "first match arm must be a payload-free enum variant (got %s)", debugPatternShape(first.Pattern))
 	}
 	if _, catchAll := second.Pattern.(*ast.WildcardPat); !catchAll {
 		if _, _, err := g.matchEnumTag(second.Pattern); err != nil {
@@ -2953,6 +2953,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		if field, ok := call.Fn.(*ast.FieldExpr); ok {
 			return value{}, unsupportedf("call", "call target %T (%s)", call.Fn, debugFieldCallTarget(field))
 		}
+		if id, ok := call.Fn.(*ast.Ident); ok {
+			return value{}, unsupportedf("call", "call target *ast.Ident (%s) — not a known fn, fn-value binding, or recognized intrinsic", id.Name)
+		}
 		return value{}, unsupportedf("call", "call target %T", call.Fn)
 	}
 	if sig.ret == "" {
@@ -2993,6 +2996,42 @@ func debugFieldCallTarget(field *ast.FieldExpr) string {
 		return "<nil>"
 	}
 	return debugFieldBase(field.X) + "." + field.Name
+}
+
+// debugPatternShape returns a short human label for a match pattern so
+// "match arm must be a payload-free enum variant" diagnostics can name
+// the offending arm. The shape is intentionally compact: the most useful
+// signal is the variant or ident name (so the reader can grep), not a
+// faithful pretty-printing of the whole AST node.
+func debugPatternShape(pattern ast.Pattern) string {
+	switch p := pattern.(type) {
+	case nil:
+		return "<nil>"
+	case *ast.IdentPat:
+		return fmt.Sprintf("ident %q", p.Name)
+	case *ast.VariantPat:
+		path := strings.Join(p.Path, ".")
+		if len(p.Args) == 0 {
+			return fmt.Sprintf("variant %s (no args)", path)
+		}
+		return fmt.Sprintf("variant %s with %d arg(s)", path, len(p.Args))
+	case *ast.WildcardPat:
+		return "wildcard"
+	case *ast.LiteralPat:
+		return "literal"
+	case *ast.RangePat:
+		return "range"
+	case *ast.OrPat:
+		return "or-pattern"
+	case *ast.BindingPat:
+		return "binding"
+	case *ast.TuplePat:
+		return fmt.Sprintf("tuple of %d", len(p.Elems))
+	case *ast.StructPat:
+		return fmt.Sprintf("struct %s", strings.Join(p.Type, "."))
+	default:
+		return fmt.Sprintf("%T", pattern)
+	}
 }
 
 func debugFieldBase(expr ast.Expr) string {


### PR DESCRIPTION
## Summary

Both walls fire from generator dispatch tables that already know what the user wrote, but were dropping that signal in the diagnostic body — forcing maintainers to bisect merged-toolchain probes by hand to find the offending site. This adds the missing context to four `LLVM013` sites and the `LLVM015 dynamic_ident_call` site, behind a small reusable helper.

PR #445 is the textbook case: the wall was \`LLVM013 expression: match arm must be a payload-free enum variant\` with no further context, and the fix author had to manually trace it back to a missing \`FrontDiagBadNumericSeparator\` enum variant. With this PR, the same probe output reads \`(got ident "FrontDiagBadNumericSeparator")\` — same wall, instant grep.

## What changed

### LLVM015 — \`call target *ast.Ident\`

Now appends \`(name) — not a known fn, fn-value binding, or recognized intrinsic\`. The probe driver can grep the bare ident name to localize cross-file scope artifacts versus real backend gaps without re-running with instrumentation.

### LLVM013 — \`match arm must be a payload-free enum variant\` (4 sites)

All four sites in [internal/llvmgen/expr.go](internal/llvmgen/expr.go) (\`emitTagEnumMatchSelectValue\`, two arms of \`emitTagEnumMatchChainValue\`, and \`emitTagEnumMatchIfExprValue\`) now append \`(got <pattern shape>)\`, where the shape comes from a new \`debugPatternShape\` helper covering the nine concrete pattern AST nodes (\`Wildcard\`, \`Literal\`, \`Ident\`, \`Tuple\`, \`Struct\`, \`Variant\`, \`Range\`, \`Or\`, \`Binding\`).

Variant labels include the qualified path and arg count so \`PreNumber(n)\` and \`Pre.None\` render distinctly:

| Pattern | Label |
| --- | --- |
| \`PreNone\` | \`ident "PreNone"\` |
| \`Pre.None\` | \`variant Pre.None (no args)\` |
| \`PreNumber(n)\` | \`variant PreNumber with 1 arg(s)\` |
| \`Rect(w, h)\` | \`variant Rect with 2 arg(s)\` |
| \`0\` (literal) | \`literal\` |
| \`_\` | \`wildcard\` |

## Tests

- \`TestDebugPatternShape\` (new) locks the label shape so the probe greps stay valid.
- All existing tests pass; same 7 pre-existing short-suite failures before and after — none related to diagnostic text.

## Notes

Pure diagnostic-text change. No behaviour change. The new helper is unexported and has no callers outside the four LLVM013 sites; future LLVM-family diagnostics that take a \`Pattern\` can reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)