### PR TITLE
feat(llvmgen): lower 'match n { 0 -> A, 1 -> B, _ -> C }' for primitive scrutinees

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1377,6 +1377,15 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 		return g.emitGuardedMatchExprValue(scrutinee, expr.Arms)
 	}
 	if scrutinee.typ == "i64" {
+		// `match n { 0 -> ..., 1 -> ..., _ -> ... }` on a plain Int
+		// scrutinee falls into the same i64 dispatch as a payload-free
+		// enum tag match — but the patterns are LiteralPat, not enum
+		// variant idents, so emitTagEnumMatchExprValue's matchEnumTag
+		// returns false on every arm. Detect the literal-pattern shape
+		// up front and route to the dedicated primitive lowering.
+		if isPrimitiveLiteralMatchArms(expr.Arms) {
+			return g.emitPrimitiveLiteralMatchExprValue(scrutinee, expr.Arms)
+		}
 		return g.emitTagEnumMatchExprValue(scrutinee, expr.Arms)
 	}
 	if info := g.enumsByType[scrutinee.typ]; info != nil && info.hasPayload {
@@ -1526,6 +1535,164 @@ func (g *generator) emitTagEnumMatchExprValue(scrutinee value, arms []*ast.Match
 		return g.emitTagEnumMatchSelectValue(scrutinee, arms)
 	}
 	return g.emitTagEnumMatchChainValue(scrutinee, arms)
+}
+
+// isPrimitiveLiteralMatchArms reports whether every arm of a match
+// expression is either a literal pattern (`0`, `true`, `'a'`) or a
+// wildcard, i.e. the shape `match n { 0 -> ..., 1 -> ..., _ -> ... }`.
+// At least one arm must be a literal — bare `match _ { _ -> body }`
+// is not what this routes to.
+func isPrimitiveLiteralMatchArms(arms []*ast.MatchArm) bool {
+	sawLiteral := false
+	for _, arm := range arms {
+		if arm == nil {
+			return false
+		}
+		switch arm.Pattern.(type) {
+		case *ast.WildcardPat:
+		case *ast.LiteralPat:
+			sawLiteral = true
+		default:
+			return false
+		}
+	}
+	return sawLiteral
+}
+
+// emitPrimitiveLiteralMatchExprValue lowers `match n { 0 -> A, 1 -> B,
+// _ -> C }` for a primitive scalar scrutinee (the i64 dispatch slot).
+// Mirrors emitTagEnumMatchExprValue for shape: select-safe arms
+// collapse to a chain of `select` instructions, the rest fall back to
+// nested if-expr phi.
+func (g *generator) emitPrimitiveLiteralMatchExprValue(scrutinee value, arms []*ast.MatchArm) (value, error) {
+	selectSafe := true
+	for _, arm := range arms {
+		if !matchArmBodyIsSelectSafe(arm.Body) {
+			selectSafe = false
+			break
+		}
+	}
+	if selectSafe {
+		return g.emitPrimitiveLiteralMatchSelectValue(scrutinee, arms)
+	}
+	return g.emitPrimitiveLiteralMatchChainValue(scrutinee, arms)
+}
+
+// emitPrimitiveLiteralMatchSelectValue builds the select chain back to
+// front: each non-wildcard arm becomes
+// `select (icmp eq scrutinee, lit), armValue, current`. Wildcard, when
+// present, must be last (matches the corresponding rule in
+// emitTagEnumMatchSelectValue) and seeds `current`.
+func (g *generator) emitPrimitiveLiteralMatchSelectValue(scrutinee value, arms []*ast.MatchArm) (value, error) {
+	var current value
+	haveCurrent := false
+	for i := len(arms) - 1; i >= 0; i-- {
+		arm := arms[i]
+		if _, catchAll := arm.Pattern.(*ast.WildcardPat); catchAll {
+			if i != len(arms)-1 {
+				return value{}, unsupported("expression", "wildcard match arm must be last")
+			}
+			v, err := g.emitMatchArmBodyValue(arm.Body)
+			if err != nil {
+				return value{}, err
+			}
+			current = v
+			haveCurrent = true
+			continue
+		}
+		litPat, ok := arm.Pattern.(*ast.LiteralPat)
+		if !ok || litPat.Literal == nil {
+			return value{}, unsupportedf("expression", "primitive literal match arm must be a literal pattern (got %T)", arm.Pattern)
+		}
+		litValue, err := g.emitExpr(litPat.Literal)
+		if err != nil {
+			return value{}, err
+		}
+		if litValue.typ != scrutinee.typ {
+			return value{}, unsupportedf("type-system", "match literal type %s does not match scrutinee %s", litValue.typ, scrutinee.typ)
+		}
+		armValue, err := g.emitMatchArmBodyValue(arm.Body)
+		if err != nil {
+			return value{}, err
+		}
+		if !haveCurrent {
+			current = armValue
+			haveCurrent = true
+			continue
+		}
+		if armValue.typ != current.typ {
+			return value{}, unsupportedf("type-system", "match arm types %s/%s", armValue.typ, current.typ)
+		}
+		emitter := g.toOstyEmitter()
+		cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(litValue))
+		g.takeOstyEmitter(emitter)
+		current, err = g.emitSelectValue(cond, armValue, current)
+		if err != nil {
+			return value{}, err
+		}
+	}
+	if !haveCurrent {
+		return value{}, unsupported("expression", "match with no arms")
+	}
+	return current, nil
+}
+
+// emitPrimitiveLiteralMatchChainValue builds nested if-expr phi for
+// non-select-safe arm bodies (block bodies with multiple statements,
+// calls with side effects, etc.). Mirrors emitTagEnumMatchChainValue.
+func (g *generator) emitPrimitiveLiteralMatchChainValue(scrutinee value, arms []*ast.MatchArm) (value, error) {
+	if len(arms) == 0 {
+		return value{}, unsupported("expression", "match with no arms")
+	}
+	arm := arms[0]
+	if arm == nil {
+		return value{}, unsupported("expression", "nil match arm")
+	}
+	if len(arms) == 1 {
+		if _, catchAll := arm.Pattern.(*ast.WildcardPat); catchAll {
+			return g.emitMatchArmBodyValue(arm.Body)
+		}
+		return value{}, unsupported("expression", "primitive literal match must end with a wildcard arm")
+	}
+	if _, catchAll := arm.Pattern.(*ast.WildcardPat); catchAll {
+		return value{}, unsupported("expression", "wildcard match arm must be last")
+	}
+	litPat, ok := arm.Pattern.(*ast.LiteralPat)
+	if !ok || litPat.Literal == nil {
+		return value{}, unsupportedf("expression", "primitive literal match arm must be a literal pattern (got %T)", arm.Pattern)
+	}
+	litValue, err := g.emitExpr(litPat.Literal)
+	if err != nil {
+		return value{}, err
+	}
+	if litValue.typ != scrutinee.typ {
+		return value{}, unsupportedf("type-system", "match literal type %s does not match scrutinee %s", litValue.typ, scrutinee.typ)
+	}
+	emitter := g.toOstyEmitter()
+	cond := llvmCompare(emitter, "eq", toOstyValue(scrutinee), toOstyValue(litValue))
+	labels := llvmIfExprStart(emitter, cond)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	thenValue, err := g.emitMatchArmBodyValue(arm.Body)
+	if err != nil {
+		return value{}, err
+	}
+	thenPred := g.currentBlock
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	elseValue, err := g.emitPrimitiveLiteralMatchChainValue(scrutinee, arms[1:])
+	if err != nil {
+		return value{}, err
+	}
+	elsePred := g.currentBlock
+	if thenValue.typ != elseValue.typ {
+		return value{}, unsupportedf("type-system", "match arm types %s/%s", thenValue.typ, elseValue.typ)
+	}
+	return g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
 }
 
 func (g *generator) emitTagEnumMatchSelectValue(scrutinee value, arms []*ast.MatchArm) (value, error) {

--- a/internal/llvmgen/primitive_literal_match_test.go
+++ b/internal/llvmgen/primitive_literal_match_test.go
@@ -1,0 +1,130 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateIntLiteralMatchExpressionEmitsSelectChain locks the most
+// common shape this PR unblocks: `match n { 0 -> ..., 1 -> ..., _ -> ... }`
+// on an `Int` scrutinee. The reverse-iterated select chain is the same
+// pattern emitTagEnumMatchSelectValue uses for payload-free enum tags,
+// just keyed on `icmp eq i64 %n, <lit>` instead of `icmp eq i64
+// %scrutinee, <tag>`.
+func TestGenerateIntLiteralMatchExpressionEmitsSelectChain(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn label(n: Int) -> String {
+    match n {
+        0 -> "zero",
+        1 -> "one",
+        _ -> "many",
+    }
+}
+
+fn main() {
+    println(label(1))
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/int_literal_match.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define ptr @label(i64 %n)",
+		"icmp eq i64 %n, 0",
+		"icmp eq i64 %n, 1",
+		"select i1",
+		"ret ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected IR to contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "LLVM013") {
+		t.Fatalf("emitted LLVM013 unsupported diagnostic where the new path should fire:\n%s", got)
+	}
+}
+
+// TestGenerateIntLiteralMatchTwoArmsUsesSelect verifies the small-arm
+// case (one literal + wildcard) still routes through the select-chain
+// builder rather than falling back to the if-expr-phi path. Two arms
+// with a single icmp + select keeps the arithmetic-style match cheap.
+func TestGenerateIntLiteralMatchTwoArmsUsesSelect(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn isZero(n: Int) -> Int {
+    match n {
+        0 -> 1,
+        _ -> 0,
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/int_literal_match_2arm.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @isZero(i64 %n)",
+		"icmp eq i64 %n, 0",
+		"select i1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected IR to contain %q, got:\n%s", want, got)
+		}
+	}
+	// Two-arm select-safe path must NOT use phi (which is the chain fallback).
+	if strings.Contains(got, "phi i64") {
+		t.Fatalf("two-arm select-safe match should not emit phi:\n%s", got)
+	}
+}
+
+// TestGenerateIntLiteralMatchNonSelectSafeUsesIfPhi exercises the
+// fallback path: when an arm body is a multi-statement block (not
+// select-safe), the chain emitter splits into nested if-then-else with
+// phi instead of select. The asserted shape mirrors what
+// emitTagEnumMatchChainValue produces for payload-free tag enums.
+func TestGenerateIntLiteralMatchNonSelectSafeUsesIfPhi(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn classify(n: Int) -> Int {
+    match n {
+        0 -> {
+            let base = 10
+            base + 1
+        },
+        1 -> {
+            let base = 20
+            base + 2
+        },
+        _ -> {
+            let base = 30
+            base + 3
+        },
+    }
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/int_literal_match_chain.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define i64 @classify(i64 %n)",
+		"icmp eq i64 %n, 0",
+		"icmp eq i64 %n, 1",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected IR to contain %q, got:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Integer-literal match expressions on a plain \`Int\` scrutinee — a shape the toolchain uses extensively for tag/code dispatch — were tripping \`LLVM013 expression: match arm must be a payload-free enum variant\`. The dispatch in \`emitMatchExprValue\` saw \`scrutinee.typ == "i64"\` and routed unconditionally to \`emitTagEnumMatchExprValue\`, which then bounced every \`LiteralPat\` arm through \`matchEnumTag\` and got \`ok=false\`.

This PR closes that wall by adding a dedicated dispatch slot for the literal-pattern shape, mirroring the existing tag-enum path's two-tier select/chain emitter structure.

## Reproducer (was failing)

\`\`\`osty
fn label(n: Int) -> String {
    match n {
        0 -> "zero",
        1 -> "one",
        _ -> "many",
    }
}
\`\`\`

Pre-fix wall: \`LLVM013 expression: match arm must be a payload-free enum variant\`.

Post-fix IR (the select-chain shape):
\`\`\`llvm
define ptr @label(i64 %n) {
entry:
  %t0 = icmp eq i64 %n, 1
  %t1 = select i1 %t0, ptr @.str1, ptr @.str0   ; "one" else "many"
  %t2 = icmp eq i64 %n, 0
  %t3 = select i1 %t2, ptr @.str2, ptr %t1      ; "zero" else previous
  ret ptr %t3
}
\`\`\`

## What changed

- New dispatch arm in \`emitMatchExprValue\`: when \`scrutinee.typ == "i64"\` and every non-wildcard arm is a \`LiteralPat\`, route to \`emitPrimitiveLiteralMatchExprValue\` instead of the tag-enum path.
- New emitter family in [internal/llvmgen/expr.go](internal/llvmgen/expr.go):
  - \`isPrimitiveLiteralMatchArms\` — shape predicate (every arm is \`WildcardPat\` or \`LiteralPat\`, at least one is a literal).
  - \`emitPrimitiveLiteralMatchSelectValue\` — reverse-iterates and builds a chain of \`select (icmp eq scrutinee, lit), armValue, current\` instructions when every arm body is select-safe (literal / ident / field / single-expr block). Wildcard, when present, must be last and seeds \`current\`.
  - \`emitPrimitiveLiteralMatchChainValue\` — falls back to nested if-then-else with \`phi\` for arm bodies that are not select-safe (multi-statement blocks, side-effecting calls).
- Both emitters reject literal/scrutinee type mismatches as a defensive check (front-end should already enforce).

## Tests

- \`TestGenerateIntLiteralMatchExpressionEmitsSelectChain\` — locks the 3-arm shape (icmp + select per arm, ret).
- \`TestGenerateIntLiteralMatchTwoArmsUsesSelect\` — confirms the small-arm case stays on the select path (no phi).
- \`TestGenerateIntLiteralMatchNonSelectSafeUsesIfPhi\` — verifies block-bodied arms route through the chain emitter (icmp + phi).

No regressions: same 7 pre-existing short-suite failures before and after, all unrelated to match expression lowering.

## Scope

Limited to \`i64\` scrutinees (Int + payload-free enum tag) for now. Bool/Char/Byte/Float/String literal-match are left for follow-up — they each need their own scrutinee-type dispatch slot and don't currently surface as a probe wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)