### PR TITLE
feat(backend): multi-file package emit/link — lower every file into one ir.Module (Tier A-5)

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -223,6 +223,23 @@ func isOstySource(name string) bool {
 	return filepath.Ext(name) == ".osty"
 }
 
+// countLowerableFiles reports how many of pkg.Files actually carry a
+// parsed AST. PackageFile entries with a nil File slip through resolve
+// when parse fails fatally; ir.LowerPackage skips them, so we count the
+// same predicate when deciding between PrepareEntry and PreparePackage.
+func countLowerableFiles(pkg *resolve.Package) int {
+	if pkg == nil {
+		return 0
+	}
+	n := 0
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.File != nil {
+			n++
+		}
+	}
+	return n
+}
+
 // toolVersion returns a stamp used to invalidate the cache when the
 // compiler itself changes. Today it's a compile-time constant;
 // future wiring (set via -ldflags during release builds) will
@@ -445,12 +462,17 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 		os.Exit(1)
 	}
 	// 4. Transpile. Unsupported lowering shapes produce TODO markers;
-	// we log the warning but proceed so simple programs build.
+	// we log the warning but proceed so simple programs build. The
+	// per-file resolve handle is built but only consumed through the
+	// PrepareEntry single-file fallback below — when more than one
+	// .osty file lives in the package we route through PreparePackage
+	// so every sibling's top-level decls reach the merged ir.Module.
 	res := &resolve.Result{
 		Refs:      entryFile.Refs,
 		TypeRefs:  entryFile.TypeRefs,
 		FileScope: entryFile.FileScope,
 	}
+	_ = res // retained as fallback path below
 	if chk == nil {
 		chk = &check.Result{}
 	}
@@ -475,8 +497,20 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 		binName = runner.BuildBinaryName(binBaseOverride, pkgName, triple, targetOS, runtime.GOOS)
 	}
 	selectedBackend := backendFromCLI("build", backendID)
-	entry, err := backend.PrepareEntry("main", entryAbs, entryFile.File, res, chk)
-	if err != nil {
+	// Pick the multi-file path whenever the package has more than one
+	// source file. Single-file packages keep the historical
+	// PrepareEntry shape so backend tests that hand-build a one-file
+	// Package keep behaving identically.
+	var (
+		entry    backend.Entry
+		entryErr error
+	)
+	if pkg != nil && countLowerableFiles(pkg) > 1 {
+		entry, entryErr = backend.PreparePackage("main", entryAbs, pkg, entryFile, chk)
+	} else {
+		entry, entryErr = backend.PrepareEntry("main", entryAbs, entryFile.File, res, chk)
+	}
+	if err := entryErr; err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -213,8 +213,20 @@ func runRun(args []string, cliF cliFlags) {
 	}
 	binName := runner.BinaryNameFor(binBaseOverride, pkgName, runtime.GOOS)
 	selectedBackend := backendFromCLI("run", backendID)
-	backendEntry, err := backend.PrepareEntry("main", entryAbs, file, res, chk)
-	if err != nil {
+	// Multi-file packages must merge every sibling .osty file into one
+	// ir.Module before the backend runs; single-file packages keep the
+	// historical PrepareEntry path. countLowerableFiles lives in
+	// build.go alongside the analogous build-side dispatch.
+	var (
+		backendEntry backend.Entry
+		entryErr     error
+	)
+	if rootPkg != nil && countLowerableFiles(rootPkg) > 1 {
+		backendEntry, entryErr = backend.PreparePackage("main", entryAbs, rootPkg, entryFile, chk)
+	} else {
+		backendEntry, entryErr = backend.PrepareEntry("main", entryAbs, file, res, chk)
+	}
+	if err := entryErr; err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/backend/entry.go
+++ b/internal/backend/entry.go
@@ -36,6 +36,11 @@ func stdlibBodyLoweringEnabled() bool {
 // migrated can consume `Entry.MIR` directly. MIR validation issues are
 // recorded on the entry as non-fatal warnings — they do not short-circuit
 // the backend dispatch, because MIR is opt-in at this stage.
+//
+// PrepareEntry handles the single-file path. For a multi-file package
+// where every sibling .osty file should contribute its top-level
+// declarations to the same emitted module, use PreparePackage so the
+// full Decls slice reaches the backend in one shot.
 func PrepareEntry(packageName, sourcePath string, file *ast.File, res *resolve.Result, chk *check.Result) (Entry, error) {
 	entry := Entry{
 		PackageName: packageName,
@@ -49,56 +54,7 @@ func PrepareEntry(packageName, sourcePath string, file *ast.File, res *resolve.R
 	}
 	mod, issues := ir.Lower(packageName, file, res, chk)
 	entry.IRIssues = append(entry.IRIssues, issues...)
-	// Inject bodied stdlib functions reached from the user module before
-	// monomorphization runs, so any stdlib-owned generic body participates
-	// in the same mono pass. Rewriting callsites after injection rebinds
-	// `strings.foo(...)` to the mangled symbol the injected decl carries.
-	// Gated behind OSTY_STDLIB_BODY_LOWER during rollout.
-	if stdlibBodyLoweringEnabled() {
-		injected, injectionErrs := injectReachableStdlibBodies(mod, stdlib.LoadCached())
-		entry.IRIssues = append(entry.IRIssues, injectionErrs...)
-		mod.Decls = append(mod.Decls, injected...)
-	}
-	// Monomorphize generic free functions in-place on the lowered module.
-	// The backend contract is "no TypeVar leaves IR once it reaches the
-	// emitter", so we run this transform before validation rather than
-	// leaving it to each backend. A nil input produces a nil output; keep
-	// the original module in that pathological case so the validator can
-	// still report its own issues below.
-	if monoMod, monoErrs := ir.Monomorphize(mod); monoMod != nil {
-		mod = monoMod
-		entry.IRIssues = append(entry.IRIssues, monoErrs...)
-	}
-	entry.IR = mod
-	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
-		entry.IRIssues = append(entry.IRIssues, validateErrs...)
-		return entry, errors.Join(validateErrs...)
-	}
-	// Produce MIR alongside the HIR module. MIR consumes the monomorphic
-	// HIR; lowerer-reported issues become entry.MIRIssues and the structural
-	// validator adds any post-condition failures. MIR is not yet a
-	// backend-blocking contract — callers that consume it should check for
-	// nil and fall back to the HIR path.
-	//
-	// After lowering we run `mir.Optimize` in-place. The pass is
-	// conservative (cross-block const propagation, dead-assign /
-	// dead-call-dest / orphan-storage elimination, empty-goto collapse,
-	// constant-fold on terminators) and by construction preserves
-	// validator invariants, so it runs before `mir.Validate`. A
-	// `OSTY_MIR_OPTIMIZE=0` escape hatch is honoured so callers can
-	// bisect regressions.
-	mirMod := mir.Lower(mod)
-	if mirMod != nil {
-		if mirOptimizeEnabled() {
-			mir.Optimize(mirMod)
-		}
-		entry.MIRIssues = append(entry.MIRIssues, mirMod.Issues...)
-		if mirValidateErrs := mir.Validate(mirMod); len(mirValidateErrs) != 0 {
-			entry.MIRIssues = append(entry.MIRIssues, mirValidateErrs...)
-		}
-		entry.MIR = mirMod
-	}
-	return entry, nil
+	return finalizeEntryModule(entry, mod)
 }
 
 // mirOptimizeEnabled reports whether `PrepareEntry` should call
@@ -112,4 +68,88 @@ func mirOptimizeEnabled() bool {
 		return false
 	}
 	return true
+}
+
+// PreparePackage is the multi-file analogue of PrepareEntry. It lowers
+// every file in a resolved package into one merged ir.Module, then runs
+// the same stdlib injection / monomorphize / validate / MIR pipeline as
+// the single-file path.
+//
+// pkg supplies the full set of files plus per-file resolve handles
+// (`pf.Refs`, `pf.TypeRefs`, `pf.FileScope`); chk is the package-level
+// `check.Result` returned by `check.Package`. entryFile, when non-nil,
+// is the file the build orchestrator picked as "the" source for
+// diagnostic purposes (typically `main.osty` for binaries) and is what
+// the resulting Entry.File / Entry.Resolve point at — the IR itself
+// already carries every file's contributions, so backends do not need
+// the AST of the non-entry files.
+//
+// When entryFile is nil the first file in pkg.Files acts as the
+// diagnostic anchor.
+func PreparePackage(packageName, sourcePath string, pkg *resolve.Package, entryFile *resolve.PackageFile, chk *check.Result) (Entry, error) {
+	if pkg == nil {
+		return Entry{}, fmt.Errorf("backend: nil package")
+	}
+	if entryFile == nil {
+		for _, pf := range pkg.Files {
+			if pf != nil && pf.File != nil {
+				entryFile = pf
+				break
+			}
+		}
+	}
+	entry := Entry{
+		PackageName: packageName,
+		SourcePath:  sourcePath,
+		Check:       chk,
+	}
+	if entryFile != nil {
+		entry.File = entryFile.File
+		entry.Source = entryFile.Source
+		entry.Resolve = &resolve.Result{
+			Refs:      entryFile.Refs,
+			TypeRefs:  entryFile.TypeRefs,
+			FileScope: entryFile.FileScope,
+		}
+	}
+	mod, issues := ir.LowerPackage(packageName, pkg, chk)
+	entry.IRIssues = append(entry.IRIssues, issues...)
+	if mod == nil {
+		return entry, fmt.Errorf("backend: ir.LowerPackage returned nil module")
+	}
+	return finalizeEntryModule(entry, mod)
+}
+
+// finalizeEntryModule runs the post-lowering pipeline (stdlib injection
+// gate, monomorphize, validate, MIR lowering + optional optimize +
+// validate) shared by PrepareEntry and PreparePackage. Splitting this
+// out keeps the two entry points in lock-step: any new pass added here
+// applies to both single-file and multi-file builds at the same time.
+func finalizeEntryModule(entry Entry, mod *ir.Module) (Entry, error) {
+	if stdlibBodyLoweringEnabled() {
+		injected, injectionErrs := injectReachableStdlibBodies(mod, stdlib.LoadCached())
+		entry.IRIssues = append(entry.IRIssues, injectionErrs...)
+		mod.Decls = append(mod.Decls, injected...)
+	}
+	if monoMod, monoErrs := ir.Monomorphize(mod); monoMod != nil {
+		mod = monoMod
+		entry.IRIssues = append(entry.IRIssues, monoErrs...)
+	}
+	entry.IR = mod
+	if validateErrs := ir.Validate(mod); len(validateErrs) != 0 {
+		entry.IRIssues = append(entry.IRIssues, validateErrs...)
+		return entry, errors.Join(validateErrs...)
+	}
+	mirMod := mir.Lower(mod)
+	if mirMod != nil {
+		if mirOptimizeEnabled() {
+			mir.Optimize(mirMod)
+		}
+		entry.MIRIssues = append(entry.MIRIssues, mirMod.Issues...)
+		if mirValidateErrs := mir.Validate(mirMod); len(mirValidateErrs) != 0 {
+			entry.MIRIssues = append(entry.MIRIssues, mirValidateErrs...)
+		}
+		entry.MIR = mirMod
+	}
+	return entry, nil
 }

--- a/internal/backend/prepare_package_test.go
+++ b/internal/backend/prepare_package_test.go
@@ -1,0 +1,102 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// TestPreparePackageMergesMultiFileDecls verifies the headline
+// multi-file build contract: every file's top-level fns reach the
+// emitted ir.Module in pkg.Files order. This is what allows
+// `osty build` on a real on-disk package containing more than one
+// `.osty` file to produce a single binary that calls across files.
+func TestPreparePackageMergesMultiFileDecls(t *testing.T) {
+	fileA := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "fromA", Body: &ast.Block{}},
+	}}
+	fileB := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "fromB", Body: &ast.Block{}},
+	}}
+	pkg := &resolve.Package{
+		Name: "multi",
+		Files: []*resolve.PackageFile{
+			{Path: "/a.osty", File: fileA},
+			{Path: "/b.osty", File: fileB},
+		},
+	}
+
+	entry, err := PreparePackage("main", "/a.osty", pkg, pkg.Files[0], nil)
+	if err != nil {
+		t.Fatalf("PreparePackage returned error: %v", err)
+	}
+	if entry.IR == nil {
+		t.Fatalf("Entry.IR is nil")
+	}
+
+	gotNames := make([]string, 0)
+	for _, d := range entry.IR.Decls {
+		fn, ok := d.(*ir.FnDecl)
+		if !ok {
+			continue
+		}
+		gotNames = append(gotNames, fn.Name)
+	}
+	want := []string{"fromA", "fromB"}
+	if strings.Join(gotNames, ",") != strings.Join(want, ",") {
+		t.Fatalf("merged fn order = %v, want %v", gotNames, want)
+	}
+
+	// Entry.File should still point at the explicit entryFile (fileA)
+	// so diagnostic tooling and the legacy AST bridge keep working
+	// against the binary's primary source.
+	if entry.File != fileA {
+		t.Fatalf("Entry.File != fileA")
+	}
+}
+
+// TestPreparePackageNilPackage rejects the obviously-bad input so a
+// regression in the build orchestrator surfaces here instead of as
+// a nil-deref deeper in the lowerer.
+func TestPreparePackageNilPackage(t *testing.T) {
+	_, err := PreparePackage("main", "/x.osty", nil, nil, nil)
+	if err == nil {
+		t.Fatalf("PreparePackage(nil) returned no error, want one")
+	}
+}
+
+// TestPreparePackagePicksFirstNonNilFileWhenEntryUnset verifies that
+// callers without a designated entry file (e.g. the IR-direct gen
+// path) still get a sensible Entry.File so downstream diagnostics
+// have something to anchor source positions against.
+func TestPreparePackagePicksFirstNonNilFileWhenEntryUnset(t *testing.T) {
+	fileA := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "fromA", Body: &ast.Block{}},
+	}}
+	fileB := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "fromB", Body: &ast.Block{}},
+	}}
+	pkg := &resolve.Package{
+		Name: "pick",
+		Files: []*resolve.PackageFile{
+			nil,                                // resolver may emit a nil slot
+			{Path: "/skip.osty", File: nil},    // parse-failed slot
+			{Path: "/a.osty", File: fileA},     // first viable
+			{Path: "/b.osty", File: fileB},
+		},
+	}
+
+	entry, err := PreparePackage("main", "/auto.osty", pkg, nil, nil)
+	if err != nil {
+		t.Fatalf("PreparePackage returned error: %v", err)
+	}
+	if entry.File != fileA {
+		t.Fatalf("Entry.File = %p, want fileA = %p (first viable)", entry.File, fileA)
+	}
+	if entry.IR == nil || len(entry.IR.Decls) != 2 {
+		t.Fatalf("Entry.IR.Decls len = %d, want 2", len(entry.IR.Decls))
+	}
+}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -49,6 +49,51 @@ func Lower(pkgName string, file *ast.File, res *resolve.Result, chk *check.Resul
 	return l.run()
 }
 
+// LowerPackage lowers every file in a resolved package into a single
+// Module. Top-level declarations from each file are concatenated in
+// `pkg.Files` discovery order (lexicographic by path) so the merged
+// module's `Decls` slice mirrors the package's source layout
+// deterministically.
+//
+// pkgName names the resulting module — typically `pkg.Name` or "main"
+// for binary packages. chk is the package-level check.Result (which
+// already covers every file's expressions); each file's per-file
+// resolve handles (`pf.Refs`, `pf.TypeRefs`, `pf.FileScope`) are
+// reconstructed into a `resolve.Result` on the fly so the lowerer's
+// existing per-file machinery keeps working.
+//
+// The Module's Span comes from the first file's span; non-fatal issues
+// from every file are concatenated. A nil package returns a nil module
+// and a single descriptive error so callers can distinguish "no work"
+// from "successful empty lower". An empty Files slice returns an empty
+// (but valid) module so the validator and downstream emitters can run.
+func LowerPackage(pkgName string, pkg *resolve.Package, chk *check.Result) (*Module, []error) {
+	if pkg == nil {
+		return nil, []error{fmt.Errorf("ir.LowerPackage: nil package")}
+	}
+	mod := &Module{Package: pkgName}
+	var issues []error
+	for i, pf := range pkg.Files {
+		if pf == nil || pf.File == nil {
+			continue
+		}
+		res := &resolve.Result{
+			Refs:      pf.Refs,
+			TypeRefs:  pf.TypeRefs,
+			FileScope: pf.FileScope,
+		}
+		l := &lowerer{pkgName: pkgName, file: pf.File, res: res, chk: chk}
+		fileMod, fileIssues := l.run()
+		if i == 0 {
+			mod.SpanV = fileMod.SpanV
+		}
+		mod.Decls = append(mod.Decls, fileMod.Decls...)
+		mod.Script = append(mod.Script, fileMod.Script...)
+		issues = append(issues, fileIssues...)
+	}
+	return mod, issues
+}
+
 // lowerer holds per-file state for one Lower call.
 type lowerer struct {
 	pkgName string

--- a/internal/ir/lower_package_test.go
+++ b/internal/ir/lower_package_test.go
@@ -1,0 +1,118 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/resolve"
+)
+
+// TestLowerPackageMergesDeclsFromEveryFile is the headline guarantee
+// for ir.LowerPackage: a multi-file package with one fn per file
+// produces a single Module whose Decls slice is the concatenation of
+// each file's top-level fns, in pkg.Files order. This is the contract
+// `cmd/osty/build.go` relies on for multi-file native builds.
+func TestLowerPackageMergesDeclsFromEveryFile(t *testing.T) {
+	fileA := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "alpha", Body: &ast.Block{}},
+	}}
+	fileB := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "beta", Body: &ast.Block{}},
+		&ast.FnDecl{Name: "gamma", Body: &ast.Block{}},
+	}}
+	pkg := &resolve.Package{
+		Name: "two_files",
+		Files: []*resolve.PackageFile{
+			{Path: "/a.osty", File: fileA},
+			{Path: "/b.osty", File: fileB},
+		},
+	}
+
+	mod, issues := LowerPackage("two_files", pkg, nil)
+	if len(issues) != 0 {
+		t.Fatalf("LowerPackage() issues = %v, want none", issues)
+	}
+	if mod == nil {
+		t.Fatalf("LowerPackage() returned nil module")
+	}
+	if mod.Package != "two_files" {
+		t.Fatalf("Module.Package = %q, want %q", mod.Package, "two_files")
+	}
+	gotNames := make([]string, 0, len(mod.Decls))
+	for _, d := range mod.Decls {
+		fn, ok := d.(*FnDecl)
+		if !ok {
+			t.Fatalf("decl %T, want *FnDecl", d)
+		}
+		gotNames = append(gotNames, fn.Name)
+	}
+	want := []string{"alpha", "beta", "gamma"}
+	if len(gotNames) != len(want) {
+		t.Fatalf("got %d decls (%v), want %d (%v)", len(gotNames), gotNames, len(want), want)
+	}
+	for i, w := range want {
+		if gotNames[i] != w {
+			t.Fatalf("decl[%d] = %q, want %q (full order: %v)", i, gotNames[i], w, gotNames)
+		}
+	}
+}
+
+// TestLowerPackageHandlesEmptyAndNilFiles guards the two pathological
+// inputs that real packages can present: a PackageFile with a nil File
+// (parse failed mid-load) and an empty Files slice (resolve found
+// nothing). Both must return a non-nil module so the validator and
+// downstream emitters keep running.
+func TestLowerPackageHandlesEmptyAndNilFiles(t *testing.T) {
+	pkg := &resolve.Package{
+		Name: "edge",
+		Files: []*resolve.PackageFile{
+			nil,
+			{Path: "/b.osty", File: nil},
+			{Path: "/c.osty", File: &ast.File{Decls: []ast.Decl{
+				&ast.FnDecl{Name: "only", Body: &ast.Block{}},
+			}}},
+		},
+	}
+
+	mod, issues := LowerPackage("edge", pkg, nil)
+	if len(issues) != 0 {
+		t.Fatalf("LowerPackage() issues = %v, want none", issues)
+	}
+	if mod == nil || len(mod.Decls) != 1 {
+		t.Fatalf("Module = %+v, want exactly one decl from the only viable file", mod)
+	}
+	fn, ok := mod.Decls[0].(*FnDecl)
+	if !ok || fn.Name != "only" {
+		t.Fatalf("Module.Decls[0] = %+v, want FnDecl{Name:\"only\"}", mod.Decls[0])
+	}
+}
+
+// TestLowerPackageRejectsNilPackage protects callers from accidentally
+// silent zero-module builds when the resolver upstream returned nil.
+func TestLowerPackageRejectsNilPackage(t *testing.T) {
+	mod, issues := LowerPackage("nope", nil, nil)
+	if mod != nil {
+		t.Fatalf("LowerPackage(nil) module = %+v, want nil", mod)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("LowerPackage(nil) issues = %v, want exactly one", issues)
+	}
+}
+
+// TestLowerPackageEmptyFilesProducesEmptyModule verifies the "package
+// resolved but had no files" case: we still return a non-nil module
+// (so Validate / GenerateModule can run normally) and produce no
+// issues — an empty Decls slice is a valid module shape.
+func TestLowerPackageEmptyFilesProducesEmptyModule(t *testing.T) {
+	pkg := &resolve.Package{Name: "empty"}
+	mod, issues := LowerPackage("empty", pkg, nil)
+	if len(issues) != 0 {
+		t.Fatalf("LowerPackage(empty) issues = %v, want none", issues)
+	}
+	if mod == nil {
+		t.Fatalf("LowerPackage(empty) module = nil, want non-nil")
+	}
+	if len(mod.Decls) != 0 {
+		t.Fatalf("Module.Decls = %v, want empty", mod.Decls)
+	}
+}


### PR DESCRIPTION
## Summary

\`osty build\` on a multi-file package was discarding every sibling .osty file. \`resolve.LoadPackage()\` walked the directory and \`resolve\` + \`check\` ran across all files (so cross-file \`pub fn double()\` looked fine to the front-end), but \`emitAndBuild\` then handed only the entry file's \`*ast.File\` to \`backend.PrepareEntry\`, which called \`ir.Lower\` on that one file. Helper fns from sibling files never reached IR; the backend then walled on \`LLVM015 call: call target *ast.Ident (double)\` once \`main\` called them.

This is the [LLVM_MIGRATION_PLAN.md](LLVM_MIGRATION_PLAN.md) Tier A-5 unblock — \"Multi-file package emit + link\".

## Reproducer

\`\`\`
package multipkg/
  helper.osty:  pub fn double(n: Int) -> Int { n + n }
  main.osty:    fn main() { println(double(21)) }
\`\`\`

**Pre-fix:**
\`\`\`
$ osty build --backend=llvm --emit=llvm-ir multipkg
osty build: llvm backend: code generation is not implemented yet
; unsupported: LLVM015 call: call target *ast.Ident (double) — not a known fn,
;             fn-value binding, or recognized intrinsic
\`\`\`

**Post-fix:** the same package emits a single module containing both definitions and the call resolves directly:
\`\`\`llvm
define i64 @double(i64 %arg0) { ... }
define void @main() {
  %t0 = call i64 @double(i64 21)
  ...
}
\`\`\`

## Changes

### \`internal/ir/lower.go\` — \`ir.LowerPackage(pkgName, pkg, chk)\`

Walks every \`pkg.Files\` entry, builds a per-file \`resolve.Result\` on the fly (\`pf.Refs / pf.TypeRefs / pf.FileScope\`), runs the existing \`lowerer.run()\`, and concatenates the resulting Decls + Script slices in discovery order. Span comes from the first file's span; non-fatal issues from every file are concatenated. Empty / nil-file slots are skipped (matching how resolve handles them upstream); a nil package returns one descriptive error so callers don't silently produce zero-decl modules.

### \`internal/backend/entry.go\` — \`backend.PreparePackage\` + shared \`finalizeEntryModule\`

The multi-file analogue of PrepareEntry. Routes through \`ir.LowerPackage\` and reuses the existing stdlib injection / monomorphize / validate / MIR pipeline via a new shared \`finalizeEntryModule\` helper. The per-stage MIR/HIR contract is identical to the single-file path — by construction, since both call the same finalize step. \`entryFile\` (when supplied) becomes \`Entry.File\` / \`Entry.Source\` / \`Entry.Resolve\` so diagnostic tooling and the legacy AST bridge keep anchoring against the binary's primary source. When \`entryFile\` is nil, \`PreparePackage\` picks the first non-nil-File slot.

### \`cmd/osty/{build,run}.go\` — dispatch

\`emitAndBuild\` and the run-side equivalent now call \`countLowerableFiles(pkg)\` and route through \`PreparePackage\` for multi-file packages, falling back to \`PrepareEntry\` when the package holds exactly one viable file (so backend tests that hand-build a one-file Package keep behaving identically).

## Tests (7 new)

| Test | What it locks |
| --- | --- |
| \`ir.TestLowerPackageMergesDeclsFromEveryFile\` | Headline cross-file Decls concatenation in pkg.Files order |
| \`ir.TestLowerPackageHandlesEmptyAndNilFiles\` | nil PackageFile + parse-failed (nil File) slots |
| \`ir.TestLowerPackageRejectsNilPackage\` | Nil-pkg guard surfaces caller bugs instead of silent zero-decl modules |
| \`ir.TestLowerPackageEmptyFilesProducesEmptyModule\` | Empty package returns valid empty module so Validate / GenerateModule still run |
| \`backend.TestPreparePackageMergesMultiFileDecls\` | End-to-end at backend layer; Entry.File still anchors at caller-designated entry |
| \`backend.TestPreparePackageNilPackage\` | Nil-pkg guard at backend boundary |
| \`backend.TestPreparePackagePicksFirstNonNilFileWhenEntryUnset\` | Entry.File defaulting when caller doesn't designate one |

End-to-end multi-file IR also verified manually via the reproducer above.

## Out of scope

- \`osty gen\` keeps its single-file contract — it's the file-specific inspection tool, not a package builder.
- \`osty test\` (\`test_native.go\`) still uses \`PrepareEntry\`; the harness drives one test fn at a time and rebuilds per-test, so the merged module isn't the right shape for it. A follow-up can teach the harness to share a compiled package across its discovered tests.

## Regressions

Zero. Same short-suite failure set across \`internal/ir\`, \`internal/backend\`, \`internal/llvmgen\` before and after (verified by stash + re-run with new tests excluded from the baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)