### PR TITLE
fix(bootstrap/gen): close PR #457 remaining tuple-early-return gap via retHintType hint

### DIFF
--- a/internal/bootstrap/gen/expr.go
+++ b/internal/bootstrap/gen/expr.go
@@ -3622,6 +3622,15 @@ func (g *gen) emitRangeExpr(r *ast.RangeExpr) {
 // whole tuple (the common case) we decompose its Tuple.Elems so each
 // field gets the same Go type every sibling sees, even when a bool
 // literal or variable in one arm is left individually untyped.
+//
+// When the checker dropped both the outer tuple type and per-element
+// types (happens for `return (false, zero)` in the deeply nested else
+// arm of an outer if/else when the then-arm terminates with its own
+// early return), we consult retHintType — emitReturn sets it to the
+// enclosing function's declared return type. If that is a TupleType
+// with matching arity, we lower each field through goTypeExpr so the
+// Go struct shape matches the sibling tuples that the checker did
+// type.
 func (g *gen) emitTupleExpr(tup *ast.TupleExpr) {
 	types_ := make([]string, len(tup.Elems))
 	var tupleElemTypes []types.Type
@@ -3630,11 +3639,19 @@ func (g *gen) emitTupleExpr(tup *ast.TupleExpr) {
 			tupleElemTypes = tt.Elems
 		}
 	}
+	var hintElems []ast.Type
+	if tupleElemTypes == nil {
+		if tt, ok := g.retHintType.(*ast.TupleType); ok && len(tt.Elems) == len(tup.Elems) {
+			hintElems = tt.Elems
+		}
+	}
 	for i, e := range tup.Elems {
 		if t := g.typeOf(e); t != nil {
 			types_[i] = g.goType(t)
 		} else if i < len(tupleElemTypes) && tupleElemTypes[i] != nil {
 			types_[i] = g.goType(tupleElemTypes[i])
+		} else if i < len(hintElems) && hintElems[i] != nil {
+			types_[i] = g.goTypeExpr(hintElems[i])
 		} else {
 			types_[i] = "any"
 		}


### PR DESCRIPTION
## Summary

- Extends `emitTupleExpr` with a `retHintType` fallback so `return (false, zero)` in the deeply nested else arm of `pmLiteralRangeAsInt` gets the same `struct{F0 bool; F1 *PmInterval}` shape as its sibling early returns.
- Resolves the 2 compile errors ([apps#38702, apps#38741]) left open by [#457](https://github.com/choiceoh/osty/pull/457) — `go generate ./internal/selfhost/...` now completes cleanly.

## Context

[#457](https://github.com/choiceoh/osty/pull/457) closed 3 of 5 compile errors by decomposing `typeOf(tup).(*types.Tuple).Elems` when per-element typeOf failed. The remaining two were `(false, zero)` sites where the **outer tuple itself** was left untyped by the checker, so the Tuple.Elems-based path couldn't recover F0.

This patch adds a third fallback: `emitReturn` already pushes the enclosing function's declared return type onto `retHintType`. When the AST type is a `*ast.TupleType` with matching arity, lower each field through `goTypeExpr` so sibling tuples derive their Go struct shape from the same AST node.

## Test plan

- [x] `go generate ./internal/selfhost/...` — 2 errors → 0
- [x] `just front` — all green (lexer / parser / resolve / check / diag / format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)