### PR TITLE
perf(selfhost): drop O(n²) arena/token scans in parser hot path

### DIFF
--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -224,6 +224,9 @@ func patchGenerated(path string) error {
 		{name: "frontTokenAtList", body: frontTokenAtListReplacement},
 		{name: "astArenaNodeCount", body: astArenaNodeCountReplacement},
 		{name: "astArenaNodeAt", body: astArenaNodeAtReplacement},
+		{name: "coreArenaNodeCount", body: coreArenaNodeCountReplacement},
+		{name: "coreArenaNodeAt", body: coreArenaNodeAtReplacement},
+		{name: "opErrorCount", body: opErrorCountReplacement},
 		{name: "frontLexTokenAt", body: frontLexTokenAtReplacement},
 		{name: "frontLexDiagnosticAt", body: frontLexDiagnosticAtReplacement},
 		{name: "frontCommentAt", body: frontCommentAtReplacement},
@@ -399,6 +402,24 @@ const astArenaNodeAtReplacement = `func astArenaNodeAt(arena *AstArena, idx int)
 		return emptyAstNode(AstNodeKind(&AstNodeKind_AstNError{}))
 	}
 	return arena.nodes[idx]
+}
+`
+
+const coreArenaNodeCountReplacement = `func coreArenaNodeCount(arena *CoreArena) int {
+	return len(arena.nodes)
+}
+`
+
+const coreArenaNodeAtReplacement = `func coreArenaNodeAt(arena *CoreArena, idx int) *CoreNode {
+	if idx < 0 || idx >= len(arena.nodes) {
+		return emptyCoreNode(CoreKind(&CoreKind_CkErr{}))
+	}
+	return arena.nodes[idx]
+}
+`
+
+const opErrorCountReplacement = `func opErrorCount(p *OstyParser) int {
+	return len(p.arena.errors)
 }
 `
 

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -19007,29 +19007,8 @@ func opSyncStmt(p *OstyParser) {
 	}
 }
 
-// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6993:1
 func opErrorCount(p *OstyParser) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6994:5
-	c := 0
-	_ = c
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6995:5
-	for _, e := range p.arena.errors {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6995:31
-		_ = e
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6996:5
-		func() {
-			var _cur1767 int = c
-			var _rhs1768 int = 1
-			if _rhs1768 > 0 && _cur1767 > math.MaxInt-_rhs1768 {
-				panic("integer overflow")
-			}
-			if _rhs1768 < 0 && _cur1767 < math.MinInt-_rhs1768 {
-				panic("integer overflow")
-			}
-			c = _cur1767 + _rhs1768
-		}()
-	}
-	return c
+	return len(p.arena.errors)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:7000:1
@@ -27877,29 +27856,8 @@ func emptyCoreArena() *CoreArena {
 	return &CoreArena{nodes: make([]*CoreNode, 0, 1)}
 }
 
-// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11134:5
 func coreArenaNodeCount(arena *CoreArena) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11135:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11136:5
-	for _, n := range arena.nodes {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11137:9
-		_ = n
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11138:9
-		func() {
-			var _cur1985 int = count
-			var _rhs1986 int = 1
-			if _rhs1986 > 0 && _cur1985 > math.MaxInt-_rhs1986 {
-				panic("integer overflow")
-			}
-			if _rhs1986 < 0 && _cur1985 < math.MinInt-_rhs1986 {
-				panic("integer overflow")
-			}
-			count = _cur1985 + _rhs1986
-		}()
-	}
-	return count
+	return len(arena.nodes)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11143:1
@@ -27912,11 +27870,8 @@ func coreArenaAdd(arena *CoreArena, node *CoreNode) int {
 	return idx
 }
 
-// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11149:5
 func coreArenaNodeAt(arena *CoreArena, idx int) *CoreNode {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11150:5
-	if idx < 0 {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:11151:9
+	if idx < 0 || idx >= len(arena.nodes) {
 		return emptyCoreNode(CoreKind(&CoreKind_CkErr{}))
 	}
 	return arena.nodes[idx]

--- a/toolchain/core.osty
+++ b/toolchain/core.osty
@@ -218,16 +218,11 @@ pub fn emptyCoreArena() -> CoreArena {
 }
 
 pub fn coreArenaNodeCount(arena: CoreArena) -> Int {
-    let mut count = 0
-    for n in arena.nodes {
-        let _ = n
-        count = count + 1
-    }
-    count
+    arena.nodes.len()
 }
 
 fn coreArenaAdd(arena: CoreArena, node: CoreNode) -> Int {
-    let idx = coreArenaNodeCount(arena)
+    let idx = arena.nodes.len()
     arena.nodes.push(node)
     idx
 }

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -3296,23 +3296,12 @@ pub fn frontendParseRichSummary(source: String) -> FrontParseSummary {
 }
 
 pub fn frontTokenListCount(tokens: List<FrontToken>) -> Int {
-    let mut count = 0
-    for tok in tokens {
-        let _ = tok
-        count = count + 1
-    }
-    count
+    tokens.len()
 }
 
 pub fn frontTokenAtList(tokens: List<FrontToken>, target: Int) -> FrontToken {
-    let mut idx = 0
-    for tok in tokens {
-        if idx == target {
-            return tok
-        }
-        idx = idx + 1
-    }
-    frontEOF()
+    if target < 0 || target >= tokens.len() { return frontEOF() }
+    tokens[target]
 }
 
 pub fn frontLeadingDocAttachmentCount(stream: FrontLexStream) -> Int {

--- a/toolchain/ir.osty
+++ b/toolchain/ir.osty
@@ -268,29 +268,20 @@ pub fn emptyIrSummary() -> IrSummary {
 }
 
 pub fn irArenaAdd(arena: IrArena, node: IrNode) -> Int {
-    let idx = irArenaNodeCount(arena)
+    let idx = arena.nodes.len()
     arena.nodes.push(node)
     idx
 }
 
 pub fn irArenaNodeCount(arena: IrArena) -> Int {
-    let mut count = 0
-    for node in arena.nodes {
-        let _ = node
-        count = count + 1
-    }
-    count
+    arena.nodes.len()
 }
 
 pub fn irArenaNodeAt(arena: IrArena, idx: Int) -> IrNode {
-    let mut i = 0
-    for node in arena.nodes {
-        if i == idx {
-            return node
-        }
-        i = i + 1
+    if idx < 0 || idx >= arena.nodes.len() {
+        return emptyIrNode(IrNodeError)
     }
-    emptyIrNode(IrNodeError)
+    arena.nodes[idx]
 }
 
 pub fn irLowerSource(packageName: String, source: String) -> IrModule {

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -152,29 +152,20 @@ pub fn astUseDeclIsGroup(n: AstNode) -> Bool {
 }
 
 pub fn astArenaAdd(arena: AstArena, node: AstNode) -> Int {
-    let idx = astArenaNodeCount(arena)
+    let idx = arena.nodes.len()
     arena.nodes.push(node)
     idx
 }
 
 pub fn astArenaNodeCount(arena: AstArena) -> Int {
-    let mut count = 0
-    for n in arena.nodes {
-        let _ = n
-        count = count + 1
-    }
-    count
+    arena.nodes.len()
 }
 
 pub fn astArenaNodeAt(arena: AstArena, idx: Int) -> AstNode {
-    let mut i = 0
-    for n in arena.nodes {
-        if i == idx {
-            return n
-        }
-        i = i + 1
+    if idx < 0 || idx >= arena.nodes.len() {
+        return emptyAstNode(AstNError)
     }
-    emptyAstNode(AstNError)
+    arena.nodes[idx]
 }
 
 // ===================================================================
@@ -315,21 +306,12 @@ fn opError(p: OstyParser, msg: String) { opErrorFull(p, msg, "", "", "") }
 fn opAddNode(p: OstyParser, node: AstNode) -> Int { astArenaAdd(p.arena, node) }
 
 fn opIntListCount(xs: List<Int>) -> Int {
-    let mut c = 0
-    for x in xs {
-        let _ = x
-        c = c + 1
-    }
-    c
+    xs.len()
 }
 
 fn opIntListAt(xs: List<Int>, target: Int) -> Int {
-    let mut i = 0
-    for x in xs {
-        if i == target { return x }
-        i = i + 1
-    }
-    -1
+    if target < 0 || target >= xs.len() { return -1 }
+    xs[target]
 }
 
 fn opIsLiteralDefaultAt(p: OstyParser, idx: Int) -> Bool {
@@ -394,17 +376,12 @@ fn opSyncStmt(p: OstyParser) {
 }
 
 fn opErrorCount(p: OstyParser) -> Int {
-    let mut c = 0
-    for e in p.arena.errors { let _ = e
-    c = c + 1 }
-    c
+    p.arena.errors.len()
 }
 
 fn opTruncateErrors(p: OstyParser, target: Int) {
-    let mut cur = opErrorCount(p)
-    for cur > target {
+    for p.arena.errors.len() > target {
         let _ = p.arena.errors.pop()
-        cur = cur - 1
     }
 }
 


### PR DESCRIPTION
## Summary

셀프호스팅 파서의 핫패스가 `List<T>`를 for-루프로 순회해 count/index를 계산하는 패턴이라 아레나/토큰 접근이 전부 O(n)이었다. 결과적으로 파싱과 core-IR 구축이 토큰/노드 수 대비 O(n²)로 돌았다.

- `toolchain/parser.osty` / `frontend.osty` / `core.osty` / `ir.osty`에서 for-루프 기반 `Count`/`At`/`Add` 헬퍼를 `list.len()` / `list[idx]` 인트린식으로 교체 (spec §10.6)
- `coreArenaNodeCount`, `coreArenaNodeAt`, `opErrorCount`를 `internal/selfhost/gen_selfhost.go`의 `patchGenerated` 치환 테이블에 추가하고, 커밋된 `generated.go`에도 같은 O(1) 본문을 직접 적용
  - 기존 `astArenaNodeCount`/`AtList`와 동일한 패치 메커니즘을 확장한 것
  - 선행 `bootstrap-gen` 버그(튜플 `(Bool, T)` 리턴의 `Bool` 추론 실패)가 풀 regen을 막고 있어서 브릿지만 선행 반영

## Why

- 체커의 Core IR arena는 패키지당 수만 노드 규모 — O(n²)의 영향이 체감됨
- `internal/check` 전체 스위트: **6.4s → 5.8s** (로컬 측정, `just front`)
- `opErrorCount`는 모든 에러 복구 경로에서 호출되는 핫패스 — 에러가 많은 파일에서 누적 비용이 큼

## Test plan

- [x] `just front` (lexer / parser / resolve / check / diag / format / lint / pipeline) 통과
- [x] `go test ./internal/selfhost/...` 46s 통과
- [x] llvmgen의 `TestGenerateModuleExtendedListSortedAndToSet` 패닉은 **clean HEAD에서도 재현**되는 기존 이슈 (`TurbofishExpr`↔`FieldExpr` 인터페이스 변환 패닉, 이 변경과 무관)
- [ ] 후속: `bootstrap-gen`의 튜플 타입 추론 버그가 고쳐지면 `go generate ./internal/selfhost`로 풀 regen 후 브릿지 직접 패치분 제거 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)