### PR TITLE
feat(llvmgen): List<T> slicing + unblock native probe phantom RangeExpr

### DIFF
--- a/examples/selfhost-core/llvmgen.osty
+++ b/examples/selfhost-core/llvmgen.osty
@@ -614,7 +614,7 @@ pub fn llvmUnsupportedDiagnostic(kind: String, detail: String) -> LlvmUnsupporte
             code: "LLVM001",
             kind: "foreign-ffi",
             message: "Go FFI import {target} is not supported by the self-hosted native backend",
-            hint: "rewrite the binding as `use runtime.cabi.<lib> { ... }` for extern C symbols, or `use runtime.<surface> { ... }` for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)",
+            hint: "rewrite the binding as `use runtime.cabi.<lib> \{ ... \}` for extern C symbols, or `use runtime.<surface> \{ ... \}` for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)",
         }
     }
     if kind == "runtime-ffi" {

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -957,6 +957,83 @@ void *osty_rt_list_sorted_string(void *raw_list) {
     return out;
 }
 
+// osty_rt_list_slice returns a new List<T> containing elements at
+// indices [start, end) of src. Bounds are saturating — negative start
+// clamps to 0, end past len clamps to len, end < start yields an empty
+// result. This matches the String.slice semantics (s[a..b]).
+void *osty_rt_list_slice(void *raw_list, int64_t start, int64_t end) {
+    osty_rt_list *src = osty_rt_list_cast(raw_list);
+    int64_t len = src->len;
+    int64_t count;
+    void *out_raw;
+    osty_rt_list *out;
+
+    if (start < 0) {
+        start = 0;
+    }
+    if (end > len) {
+        end = len;
+    }
+    if (end < start) {
+        end = start;
+    }
+    count = end - start;
+
+    out_raw = osty_rt_list_new();
+    out = osty_rt_list_cast(out_raw);
+
+    // Propagate layout even for empty slices so downstream len/push/get
+    // calls see the same element ABI as the source list.
+    if (src->elem_size != 0) {
+        osty_rt_list_ensure_layout(out, src->elem_size, src->trace_elem);
+        if (src->gc_offset_count > 0) {
+            osty_rt_list_ensure_gc_offsets(out, src->gc_offsets, src->gc_offset_count);
+        }
+    }
+
+    if (count == 0) {
+        return out_raw;
+    }
+
+    osty_rt_list_reserve(out, count);
+    memcpy(out->data,
+           src->data + (size_t)start * src->elem_size,
+           (size_t)count * src->elem_size);
+    out->len = count;
+
+    // Emit write barriers for each embedded pointer we copied in, so
+    // incremental / generational GC tracks the new list correctly.
+    if (out->elem_size == sizeof(void *) && src->trace_elem != NULL) {
+        int64_t i;
+        for (i = 0; i < count; i++) {
+            void *child = NULL;
+            memcpy(&child,
+                   out->data + (size_t)i * out->elem_size,
+                   sizeof(child));
+            if (child != NULL) {
+                osty_gc_post_write_v1(out_raw, child, OSTY_GC_KIND_LIST);
+            }
+        }
+    } else if (out->gc_offset_count > 0) {
+        int64_t i;
+        int64_t j;
+        for (i = 0; i < count; i++) {
+            unsigned char *elem = out->data + (size_t)i * out->elem_size;
+            for (j = 0; j < out->gc_offset_count; j++) {
+                void *child = NULL;
+                memcpy(&child,
+                       elem + (size_t)out->gc_offsets[j],
+                       sizeof(child));
+                if (child != NULL) {
+                    osty_gc_post_write_v1(out_raw, child, OSTY_GC_KIND_LIST);
+                }
+            }
+        }
+    }
+
+    return out_raw;
+}
+
 bool osty_rt_strings_Equal(const char *left, const char *right) {
     if (left == NULL || right == NULL) {
         return left == right;

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -221,8 +221,25 @@ func (g *generator) emitExpr(expr ast.Expr) (value, error) {
 	case *ast.MatchExpr:
 		return g.emitMatchExprValue(e)
 	default:
-		return value{}, unsupportedf("expression", "expression %T", expr)
+		return value{}, unsupportedf("expression", "expression %T %s", expr, exprPosLabel(expr))
 	}
+}
+
+// exprPosLabel formats the AST node's source line/column and byte
+// offset for LLVMXXX wall messages. The merged-toolchain probes
+// synthesize paths like /tmp/toolchain_native_merged.osty, so file is
+// usually not useful — but line:col plus byte-offset plus `%T` lets
+// the investigator grep the merge buffer and pinpoint the offending
+// expression immediately.
+func exprPosLabel(node ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	p := node.Pos()
+	if p.Line == 0 && p.Column == 0 && p.Offset == 0 {
+		return ""
+	}
+	return fmt.Sprintf("at %s (offset %d)", p, p.Offset)
 }
 
 func (g *generator) emitIdent(name string) (value, error) {
@@ -545,7 +562,7 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 		return value{}, unsupported("expression", "nil index expression")
 	}
 	if rng, ok := expr.Index.(*ast.RangeExpr); ok {
-		return g.emitStringSliceIndex(expr, rng)
+		return g.emitSliceIndex(expr, rng)
 	}
 	base, err := g.emitExpr(expr.X)
 	if err != nil {
@@ -614,19 +631,21 @@ func (g *generator) emitIndexExpr(expr *ast.IndexExpr) (value, error) {
 	}
 }
 
-// emitStringSliceIndex lowers `s[start..end]` and `s[start..=end]` on a
-// String receiver to `osty_rt_strings_Slice`. Missing bounds default to
-// 0 and the string's byte-length respectively. Used by the toolchain's
-// string slicing in parser.osty (`raw[1..n - 1]`, `raw[0..1]`, ...).
-// Non-String index-range targets fall through to the generic index
-// path, which will surface a more specific error.
-func (g *generator) emitStringSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr) (value, error) {
+// emitSliceIndex lowers `base[a..b]` and `base[a..=b]` for both String
+// and List<T> receivers. Dispatch is driven by the base's static source
+// type — String routes to osty_rt_strings_Slice (byte-level), List
+// routes to osty_rt_list_slice (elem_size-level memcpy). Non-slicable
+// receivers surface a type-system diagnostic.
+func (g *generator) emitSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr) (value, error) {
 	base, err := g.emitExpr(expr.X)
 	if err != nil {
 		return value{}, err
 	}
+	if base.listElemTyp != "" {
+		return g.emitListSliceIndex(expr, rng, base)
+	}
 	if base.typ != "ptr" {
-		return value{}, unsupportedf("type-system", "slice indexing on %s, want String (ptr)", base.typ)
+		return value{}, unsupportedf("type-system", "slice indexing on %s, want String (ptr) or List<T>", base.typ)
 	}
 	baseIsString := false
 	if sourceType, ok := g.staticExprSourceType(expr.X); ok {
@@ -635,7 +654,7 @@ func (g *generator) emitStringSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr
 		}
 	}
 	if !baseIsString {
-		return value{}, unsupported("type-system", "slice indexing is only supported on String receivers")
+		return value{}, unsupported("type-system", "slice indexing is only supported on String or List<T> receivers")
 	}
 	base, err = g.loadIfPointer(base)
 	if err != nil {
@@ -688,6 +707,68 @@ func (g *generator) emitStringSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr
 	sliced := fromOstyValue(out)
 	sliced.gcManaged = true
 	sliced.sourceType = &ast.NamedType{Path: []string{"String"}}
+	return sliced, nil
+}
+
+// emitListSliceIndex lowers `list[a..b]` and `list[a..=b]` on a List<T>
+// receiver to osty_rt_list_slice. Bounds default to 0 and list.len —
+// runtime applies saturating clamps, matching String.slice semantics.
+// Inclusive `..=` adds 1 to the end operand before the call.
+func (g *generator) emitListSliceIndex(expr *ast.IndexExpr, rng *ast.RangeExpr, base value) (value, error) {
+	baseLoaded, err := g.loadIfPointer(base)
+	if err != nil {
+		return value{}, err
+	}
+
+	var startVal value
+	if rng.Start == nil {
+		startVal = value{typ: "i64", ref: "0"}
+	} else {
+		v, err := g.emitExpr(rng.Start)
+		if err != nil {
+			return value{}, err
+		}
+		if v.typ != "i64" {
+			return value{}, unsupportedf("type-system", "slice start type %s, want Int", v.typ)
+		}
+		startVal = v
+	}
+
+	var endVal value
+	if rng.Stop == nil {
+		g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		lenVal := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(baseLoaded)})
+		g.takeOstyEmitter(emitter)
+		endVal = fromOstyValue(lenVal)
+	} else {
+		v, err := g.emitExpr(rng.Stop)
+		if err != nil {
+			return value{}, err
+		}
+		if v.typ != "i64" {
+			return value{}, unsupportedf("type-system", "slice end type %s, want Int", v.typ)
+		}
+		endVal = v
+		if rng.Inclusive {
+			emitter := g.toOstyEmitter()
+			tmp := llvmNextTemp(emitter)
+			emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", tmp, endVal.ref))
+			g.takeOstyEmitter(emitter)
+			endVal = value{typ: "i64", ref: tmp}
+		}
+	}
+
+	g.declareRuntimeSymbol(listRuntimeSliceSymbol(), "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", listRuntimeSliceSymbol(), []*LlvmValue{toOstyValue(baseLoaded), toOstyValue(startVal), toOstyValue(endVal)})
+	g.takeOstyEmitter(emitter)
+	sliced := fromOstyValue(out)
+	sliced.gcManaged = true
+	sliced.listElemTyp = base.listElemTyp
+	sliced.listElemString = base.listElemString
+	sliced.sourceType = base.sourceType
+	sliced.rootPaths = g.rootPathsForType(base.listElemTyp)
 	return sliced, nil
 }
 

--- a/internal/llvmgen/expr_pos_label_test.go
+++ b/internal/llvmgen/expr_pos_label_test.go
@@ -1,0 +1,44 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestEmitExprDefaultWallCarriesSourcePos locks in that the emitExpr
+// fallthrough wall (LLVM013 "expression: expression %T") is tagged
+// with the offending node's line:col. The native-toolchain probe
+// (TestProbeNativeToolchainMerged) relies on this tag to point
+// investigators at the exact Tier A blocker in the merged buffer
+// without re-running a second diagnostic pass.
+//
+// Positive-position reproduction: a value-position RangeExpr. For
+// the synthetic source below the RangeExpr literal starts at line 2,
+// column 13 (`0..10`), so the wall must include `at 2:13` and the
+// corresponding byte offset.
+func TestEmitExprDefaultWallCarriesSourcePos(t *testing.T) {
+	src := []byte("fn main() {\n    let r = 0..10\n    println(r)\n}\n")
+	file, _ := parser.ParseDiagnostics(src)
+	if file == nil {
+		t.Fatalf("parse returned nil file")
+	}
+	_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/pos_probe.osty"})
+	if err == nil {
+		t.Fatalf("expected LLVM013 wall for value-position RangeExpr; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "LLVM013") {
+		t.Fatalf("expected LLVM013 wall; got: %s", msg)
+	}
+	if !strings.Contains(msg, "*ast.RangeExpr") {
+		t.Fatalf("expected wall to mention *ast.RangeExpr; got: %s", msg)
+	}
+	if !strings.Contains(msg, "at 2:13") {
+		t.Fatalf("expected wall to pin `at 2:13`; got: %s", msg)
+	}
+	if !strings.Contains(msg, "offset ") {
+		t.Fatalf("expected wall to include byte offset; got: %s", msg)
+	}
+}

--- a/internal/llvmgen/list_slice_test.go
+++ b/internal/llvmgen/list_slice_test.go
@@ -1,0 +1,111 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// List slice syntax — `xs[start..end]`, `xs[start..=end]`, `xs[..end]`,
+// `xs[start..]` — lowers to `osty_rt_list_slice`. Prior to Tier A-1
+// List-slice support the same shape tripped LLVM013 "expression
+// *ast.RangeExpr" because the RangeExpr was never dispatched out of
+// the index path for a List<T> base.
+func TestListSliceHalfOpenRange(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn take(xs: List<Int>) -> List<Int> {
+    xs[1..3]
+}
+
+fn main() {
+    let xs = [10, 20, 30, 40]
+    let ys = take(xs)
+    println(ys.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_half_open.osty"})
+	if err != nil {
+		t.Fatalf("half-open list slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_slice",
+		"declare ptr @osty_rt_list_slice(ptr, i64, i64)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Inclusive `..=` must add 1 to the upper bound so `xs[0..=1]` emits
+// elements at index 0 and 1 — same convention the String slicer uses.
+func TestListSliceInclusiveRange(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn head2(xs: List<Int>) -> List<Int> {
+    xs[0..=1]
+}
+
+fn main() {
+    let xs = [10, 20, 30]
+    println(head2(xs).len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_incl.osty"})
+	if err != nil {
+		t.Fatalf("inclusive list slice errored: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, "@osty_rt_list_slice") {
+		t.Fatalf("inclusive list slice did not call runtime slice:\n%s", got)
+	}
+	if !strings.Contains(got, "add i64") {
+		t.Fatalf("inclusive list slice missing `add i64` upper-bound adjustment:\n%s", got)
+	}
+}
+
+// Missing upper bound `xs[1..]` defaults to list.len via osty_rt_list_len,
+// mirroring the String slicer's ByteLen fallback.
+func TestListSliceOpenHigh(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn dropFirst(xs: List<Int>) -> List<Int> {
+    xs[1..]
+}
+
+fn main() {
+    let xs = [10, 20, 30]
+    println(dropFirst(xs).len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_open_high.osty"})
+	if err != nil {
+		t.Fatalf("open-high list slice errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_slice",
+		"@osty_rt_list_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("open-high list slice missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// List<String> slicing must preserve the pointer-list ABI so downstream
+// iteration (get_ptr, sorted_string) keeps working on the result.
+func TestListSliceStringElements(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn firstTwo(xs: List<String>) -> List<String> {
+    xs[0..2]
+}
+
+fn main() {
+    let xs = ["a", "b", "c"]
+    println(firstTwo(xs).len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_slice_string.osty"})
+	if err != nil {
+		t.Fatalf("list<string> slice errored: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, "@osty_rt_list_slice") {
+		t.Fatalf("list<string> slice did not call runtime slice:\n%s", got)
+	}
+}

--- a/internal/llvmgen/phantom_range_decl_test.go
+++ b/internal/llvmgen/phantom_range_decl_test.go
@@ -1,0 +1,116 @@
+package llvmgen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestToolchainHasNoPhantomRangeExpr locks the fix for the "LLVM013
+// *ast.RangeExpr at 1:16" wall that TestProbeNativeToolchainMerged
+// hit before. Root cause: `llvmUnsupportedDiagnostic`'s hint strings
+// carried unescaped `{ ... }` which the Osty lexer treats as
+// interpolation. The reparsed interpolation expression (` .. `) came
+// back as a RangeExpr with position 1:16 (offset 15) in the local
+// reparse buffer, which then surfaced as the backend's first wall.
+//
+// Regression shape: any top-level toolchain declaration that contains
+// a *ast.RangeExpr whose reported line is BEFORE the declaration's
+// own first line is necessarily phantom — it came from a reparse
+// context, not the source file.
+func TestToolchainHasNoPhantomRangeExpr(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !ostyToolchainSource(name) {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		file, _ := parser.ParseDiagnostics(src)
+		if file == nil {
+			continue
+		}
+		for _, decl := range file.Decls {
+			declPos := decl.Pos()
+			walkPhantomRange(reflect.ValueOf(decl), func(line, col, off int) {
+				if line < declPos.Line {
+					t.Errorf("%s: decl %q (line %d) has phantom RangeExpr at %d:%d (offset %d) — likely an unescaped `{ ... }` in a string literal",
+						name, declLabel(decl), declPos.Line, line, col, off)
+				}
+			})
+		}
+	}
+}
+
+func ostyToolchainSource(name string) bool {
+	if !hasSuffix(name, ".osty") {
+		return false
+	}
+	if hasSuffix(name, "_test.osty") {
+		return false
+	}
+	return true
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+func declLabel(d ast.Decl) string {
+	switch x := d.(type) {
+	case *ast.FnDecl:
+		return fmt.Sprintf("fn %s", x.Name)
+	case *ast.StructDecl:
+		return fmt.Sprintf("struct %s", x.Name)
+	case *ast.EnumDecl:
+		return fmt.Sprintf("enum %s", x.Name)
+	case *ast.UseDecl:
+		return fmt.Sprintf("use %s", x.RawPath)
+	case *ast.InterfaceDecl:
+		return fmt.Sprintf("interface %s", x.Name)
+	case *ast.TypeAliasDecl:
+		return fmt.Sprintf("type %s", x.Name)
+	}
+	return fmt.Sprintf("%T", d)
+}
+
+func walkPhantomRange(v reflect.Value, visit func(line, col, off int)) {
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Struct:
+		if v.Type().Name() == "RangeExpr" {
+			p := v.FieldByName("PosV")
+			visit(int(p.FieldByName("Line").Int()),
+				int(p.FieldByName("Column").Int()),
+				int(p.FieldByName("Offset").Int()))
+		}
+		for i := 0; i < v.NumField(); i++ {
+			walkPhantomRange(v.Field(i), visit)
+		}
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			walkPhantomRange(v.Index(i), visit)
+		}
+	}
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -335,6 +335,14 @@ func listRuntimeToSetSymbol(elemTyp string, elemString bool) string {
 	return llvmListRuntimeToSetSymbol(elemTyp, elemString)
 }
 
+// listRuntimeSliceSymbol returns the element-agnostic slice helper that
+// backs `list[a..b]` and `list[a..=b]`. Unlike get/push/sorted/to_set,
+// the slice is a pure byte-level copy — the elem_size stored on the
+// list header is enough, so one symbol covers every T.
+func listRuntimeSliceSymbol() string {
+	return "osty_rt_list_slice"
+}
+
 func mapRuntimeNewSymbol() string {
 	return llvmMapRuntimeNewSymbol()
 }

--- a/internal/llvmgen/unsupported_diag_parity_test.go
+++ b/internal/llvmgen/unsupported_diag_parity_test.go
@@ -5,8 +5,19 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 )
+
+// ostyEvaluatedHint applies the Osty string-literal escape rules that
+// matter for the diagnostic-hint parity check: `\{` / `\}` collapse to
+// literal `{` / `}` so an Osty source written with escaped braces (the
+// only safe way to embed `{ ... }` in a non-interpolated message)
+// compares equal to a Go snapshot that uses bare braces.
+func ostyEvaluatedHint(raw string) string {
+	r := strings.NewReplacer(`\{`, `{`, `\}`, `}`)
+	return r.Replace(raw)
+}
 
 // TestUnsupportedDiagnosticOstySnapshotParity pins the kind → (code, hint)
 // mapping agreement across the three places it lives:
@@ -76,7 +87,7 @@ func TestUnsupportedDiagnosticOstySnapshotParity(t *testing.T) {
 				t.Errorf("kind %q: %s has code %q, Go snapshot has %q",
 					kind, rel, br[0], snap.Code)
 			}
-			if br[1] != snap.Hint {
+			if ostyEvaluatedHint(br[1]) != snap.Hint {
 				t.Errorf("kind %q: %s hint drift\n  osty:     %q\n  snapshot: %q",
 					kind, rel, br[1], snap.Hint)
 			}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1010,7 +1010,7 @@ pub fn llvmUnsupportedDiagnostic(kind: String, detail: String) -> LlvmUnsupporte
             code: "LLVM001",
             kind: "foreign-ffi",
             message: "Go FFI import {target} is not supported by the self-hosted native backend",
-            hint: "rewrite the binding as `use runtime.cabi.<lib> { ... }` for extern C symbols, or `use runtime.<surface> { ... }` for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)",
+            hint: "rewrite the binding as `use runtime.cabi.<lib> \{ ... \}` for extern C symbols, or `use runtime.<surface> \{ ... \}` for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)",
         }
     }
     if kind == "runtime-ffi" {


### PR DESCRIPTION
## Summary

Three Tier A-1 / probe-quality increments bundled together because they landed in the same investigation pass.

### 1. `List<T>` slicing — `xs[a..b]` / `xs[a..=b]` / `xs[a..]` / `xs[..b]`

- New `osty_rt_list_slice` runtime helper: saturating bounds clamp, `elem_size`-level memcpy, GC write barriers for both pointer-element lists and structs with `gc_offsets`.
- Reshape `emitStringSliceIndex` into `emitSliceIndex` that branches on `base.listElemTyp` (List path) vs static String source type.
- Inclusive `..=` adds 1 to the upper bound, matching the existing String slicer.
- Tests cover half-open / inclusive / open-high / `List<String>`.

### 2. Source position on `emitExpr` default wall

LLVM013 `expression %T` errors now carry `at <line>:<col> (offset N)` so `TestProbeNativeToolchainMerged` and friends pinpoint the first offending expression in the merged buffer without a second pass.

### 3. Phantom RangeExpr root cause + fix

`TestProbeNativeToolchainMerged` first wall was `*ast.RangeExpr at 1:16 (offset 15)`. Traced to two unescaped ``{ ... }`` in `llvmUnsupportedDiagnostic`'s hint string — the lexer treated them as interpolation, the reparse path reconstructed the inner `` ... `` as a `RangeExpr`, and that node's reparse-buffer position (1:16, offset 15) leaked out as the backend's first wall.

- Escape to `\{ ... \}` in `toolchain/llvmgen.osty` and the `examples/selfhost-core` mirror (per `LANG_SPEC_v0.5` § interpolation escape rules).
- Teach the parity test to normalize `\{` / `\}` before comparing against the Go `support_snapshot` mirror.
- New regression `TestToolchainHasNoPhantomRangeExpr`: any toolchain decl carrying a `RangeExpr` whose reported line precedes its own start line fails the test.

## Wall movement

```
NATIVE TOOLCHAIN first wall:
  before: LLVM013 — *ast.RangeExpr at 1:16 (offset 15)
  after:  LLVM015 — call target *ast.FieldExpr (trimmed.trimPrefix)
```

The new wall is a real backend gap (`String.trimPrefix` method-call dispatch), so the next Tier A-1/A-6 increment has a clear target.

## Test plan

- [x] `go test -count=1 -vet=off -run "TestListSlice|TestStringSlice|TestEmitExprDefaultWallCarriesSourcePos|TestToolchainHasNoPhantomRangeExpr|TestUnsupportedDiagnosticOstySnapshotParity" ./internal/llvmgen`
- [x] `go test -count=1 -vet=off -short -skip "TestGenerateModuleExtendedListSortedAndToSet" ./internal/llvmgen` (the skipped panic is pre-existing on `main` — unrelated to this PR)
- [x] `go test -count=1 -vet=off ./internal/backend ./internal/diag`
- [x] `TestProbeNativeToolchainMerged` confirms wall has advanced past LLVM013

🤖 Generated with [Claude Code](https://claude.com/claude-code)