### PR TITLE
perf(selfhost): extend O(1) len/at patches across toolchain List hot paths

### DIFF
--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -227,11 +227,56 @@ func patchGenerated(path string) error {
 		{name: "coreArenaNodeCount", body: coreArenaNodeCountReplacement},
 		{name: "coreArenaNodeAt", body: coreArenaNodeAtReplacement},
 		{name: "opErrorCount", body: opErrorCountReplacement},
+		{name: "checkIntListLenLocal", body: checkIntListLenLocalReplacement},
+		{name: "checkIntListAtLocal", body: checkIntListAtLocalReplacement},
+		{name: "checkIntListLenHelper", body: checkIntListLenHelperReplacement},
+		{name: "checkIntListAt", body: checkIntListAtReplacement},
+		{name: "checkStringListLenHelper", body: checkStringListLenHelperReplacement},
+		{name: "checkVariantListLen", body: checkVariantListLenReplacement},
+		{name: "pmWitnessesCount", body: pmWitnessesCountReplacement},
+		{name: "checkFieldListLen", body: checkFieldListLenReplacement},
+		{name: "checkListOfRowsLen", body: checkListOfRowsLenReplacement},
+		{name: "checkCtorListLen", body: checkCtorListLenReplacement},
+		{name: "frontCheckResultTypedNodeCount", body: frontCheckResultTypedNodeCountReplacement},
+		{name: "frontCheckResultInstantiationCount", body: frontCheckResultInstantiationCountReplacement},
+		{name: "selfResolveDiagnosticCount", body: selfResolveDiagnosticCountReplacement},
+		{name: "srAstChildAt", body: srAstChildAtReplacement},
+		{name: "srAstListCount", body: srAstListCountReplacement},
+		{name: "srIntListAt", body: srIntListAtReplacement},
+		{name: "srStringListAt", body: srStringListAtReplacement},
+		{name: "frontLexTokenCount", body: frontLexTokenCountReplacement},
+		{name: "frontLexDiagnosticCount", body: frontLexDiagnosticCountReplacement},
+		{name: "frontCommentCount", body: frontCommentCountReplacement},
+		{name: "frontStringPartCount", body: frontStringPartCountReplacement},
+		{name: "frontInterpolationTokenCount", body: frontInterpolationTokenCountReplacement},
 		{name: "frontLexTokenAt", body: frontLexTokenAtReplacement},
 		{name: "frontLexDiagnosticAt", body: frontLexDiagnosticAtReplacement},
 		{name: "frontCommentAt", body: frontCommentAtReplacement},
 		{name: "frontStringPartAt", body: frontStringPartAtReplacement},
 		{name: "frontInterpolationTokenAt", body: frontInterpolationTokenAtReplacement},
+		{name: "stringUnitCount", body: stringUnitCountReplacement},
+		{name: "ostyLexStringPartCount", body: ostyLexStringPartCountReplacement},
+		{name: "ostyStringListCount", body: ostyStringListCountReplacement},
+		{name: "ostyStringAt", body: ostyStringAtReplacement},
+		{name: "ostyLexResultTokenCount", body: ostyLexResultTokenCountReplacement},
+		{name: "ostyLexResultErrorCount", body: ostyLexResultErrorCountReplacement},
+		{name: "ostyLexResultCommentCount", body: ostyLexResultCommentCountReplacement},
+		{name: "ostyLexResultTokenAt", body: ostyLexResultTokenAtReplacement},
+		{name: "astFileDeclCount", body: astFileDeclCountReplacement},
+		{name: "astFileErrorCount", body: astFileErrorCountReplacement},
+		{name: "astFileDeclAt", body: astFileDeclAtReplacement},
+		{name: "astFileErrorAt", body: astFileErrorAtReplacement},
+		{name: "checkDiagCount", body: checkDiagCountReplacement},
+		{name: "coreIntLen", body: coreIntLenReplacement},
+		{name: "coreDiagCount", body: coreDiagCountReplacement},
+		{name: "solveIntLen", body: solveIntLenReplacement},
+		{name: "selfLintDiagnosticCount", body: selfLintDiagnosticCountReplacement},
+		{name: "selfLintFixCount", body: selfLintFixCountReplacement},
+		{name: "selfLintEditListCount", body: selfLintEditListCountReplacement},
+		{name: "selfLintEditAt", body: selfLintEditAtReplacement},
+		{name: "astLowerTokenCount", body: astLowerTokenCountReplacement},
+		{name: "astLowerIntListCount", body: astLowerIntListCountReplacement},
+		{name: "astLowerIntListAt", body: astLowerIntListAtReplacement},
 	} {
 		var err error
 		src, err = replaceGeneratedFunction(src, fn.name, fn.body)
@@ -423,6 +468,131 @@ const opErrorCountReplacement = `func opErrorCount(p *OstyParser) int {
 }
 `
 
+const checkIntListLenLocalReplacement = `func checkIntListLenLocal(xs []int) int {
+	return len(xs)
+}
+`
+
+const checkIntListAtLocalReplacement = `func checkIntListAtLocal(xs []int, idx int) int {
+	if idx < 0 || idx >= len(xs) {
+		return -1
+	}
+	return xs[idx]
+}
+`
+
+const checkIntListLenHelperReplacement = `func checkIntListLenHelper(xs []int) int {
+	return len(xs)
+}
+`
+
+const checkIntListAtReplacement = `func checkIntListAt(xs []int, idx int) int {
+	if idx < 0 || idx >= len(xs) {
+		return -1
+	}
+	return xs[idx]
+}
+`
+
+const checkStringListLenHelperReplacement = `func checkStringListLenHelper(xs []string) int {
+	return len(xs)
+}
+`
+
+const checkVariantListLenReplacement = `func checkVariantListLen(xs []*CheckVariantSig) int {
+	return len(xs)
+}
+`
+
+const pmWitnessesCountReplacement = `func pmWitnessesCount(xs []string) int {
+	return len(xs)
+}
+`
+
+const checkFieldListLenReplacement = `func checkFieldListLen(xs []*CheckFieldSig) int {
+	return len(xs)
+}
+`
+
+const checkListOfRowsLenReplacement = `func checkListOfRowsLen(xs [][]int) int {
+	return len(xs)
+}
+`
+
+const checkCtorListLenReplacement = `func checkCtorListLen(xs []*PmCtor) int {
+	return len(xs)
+}
+`
+
+const frontCheckResultTypedNodeCountReplacement = `func frontCheckResultTypedNodeCount(result *FrontCheckResult) int {
+	return len(result.typedNodes)
+}
+`
+
+const frontCheckResultInstantiationCountReplacement = `func frontCheckResultInstantiationCount(result *FrontCheckResult) int {
+	return len(result.instantiations)
+}
+`
+
+const selfResolveDiagnosticCountReplacement = `func selfResolveDiagnosticCount(result *SelfResolveResult) int {
+	return len(result.diagnostics)
+}
+`
+
+const srAstChildAtReplacement = `func srAstChildAt(children []int, target int) int {
+	if target < 0 || target >= len(children) {
+		return -1
+	}
+	return children[target]
+}
+`
+
+const srAstListCountReplacement = `func srAstListCount(items []int) int {
+	return len(items)
+}
+`
+
+const srIntListAtReplacement = `func srIntListAt(items []int, target int) int {
+	if target < 0 || target >= len(items) {
+		return -1
+	}
+	return items[target]
+}
+`
+
+const srStringListAtReplacement = `func srStringListAt(items []string, target int) string {
+	if target < 0 || target >= len(items) {
+		return ""
+	}
+	return items[target]
+}
+`
+
+const frontLexTokenCountReplacement = `func frontLexTokenCount(stream *FrontLexStream) int {
+	return len(stream.tokens)
+}
+`
+
+const frontLexDiagnosticCountReplacement = `func frontLexDiagnosticCount(stream *FrontLexStream) int {
+	return len(stream.diagnostics)
+}
+`
+
+const frontCommentCountReplacement = `func frontCommentCount(stream *FrontLexStream) int {
+	return len(stream.comments)
+}
+`
+
+const frontStringPartCountReplacement = `func frontStringPartCount(stream *FrontLexStream) int {
+	return len(stream.stringParts)
+}
+`
+
+const frontInterpolationTokenCountReplacement = `func frontInterpolationTokenCount(stream *FrontLexStream) int {
+	return len(stream.interpolationTokens)
+}
+`
+
 const frontLexTokenAtReplacement = `func frontLexTokenAt(stream *FrontLexStream, target int) *FrontLexToken {
 	if target < 0 || target >= len(stream.tokens) {
 		return emptyFrontLexToken()
@@ -460,5 +630,138 @@ const frontInterpolationTokenAtReplacement = `func frontInterpolationTokenAt(str
 		return emptyFrontInterpolationToken()
 	}
 	return stream.interpolationTokens[target]
+}
+`
+
+const stringUnitCountReplacement = `func stringUnitCount(text string) int {
+	return len(strings.Split(text, ""))
+}
+`
+
+const ostyLexStringPartCountReplacement = `func ostyLexStringPartCount(parts []*OstyLexStringPart) int {
+	return len(parts)
+}
+`
+
+const ostyStringListCountReplacement = `func ostyStringListCount(items []string) int {
+	return len(items)
+}
+`
+
+const ostyStringAtReplacement = `func ostyStringAt(items []string, target int) string {
+	if target < 0 || target >= len(items) {
+		return ""
+	}
+	return items[target]
+}
+`
+
+const ostyLexResultTokenCountReplacement = `func ostyLexResultTokenCount(result *OstyLexResult) int {
+	return len(result.tokens)
+}
+`
+
+const ostyLexResultErrorCountReplacement = `func ostyLexResultErrorCount(result *OstyLexResult) int {
+	return len(result.errors)
+}
+`
+
+const ostyLexResultCommentCountReplacement = `func ostyLexResultCommentCount(result *OstyLexResult) int {
+	return len(result.comments)
+}
+`
+
+const ostyLexResultTokenAtReplacement = `func ostyLexResultTokenAt(result *OstyLexResult, idx int) *OstyRichToken {
+	if idx < 0 || idx >= len(result.tokens) {
+		return &OstyRichToken{kind: FrontTokenKind(&FrontTokenKind_FrontEOF{}), text: "", startOffset: 0, startLine: 0, startCol: 0, endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0}
+	}
+	return result.tokens[idx]
+}
+`
+
+const astFileDeclCountReplacement = `func astFileDeclCount(file *AstFile) int {
+	return len(file.arena.decls)
+}
+`
+
+const astFileErrorCountReplacement = `func astFileErrorCount(file *AstFile) int {
+	return len(file.arena.errors)
+}
+`
+
+const astFileDeclAtReplacement = `func astFileDeclAt(file *AstFile, idx int) *AstNode {
+	if idx < 0 || idx >= len(file.arena.decls) {
+		return emptyAstNode(AstNodeKind(&AstNodeKind_AstNError{}))
+	}
+	return astArenaNodeAt(file.arena, file.arena.decls[idx])
+}
+`
+
+const astFileErrorAtReplacement = `func astFileErrorAt(file *AstFile, idx int) *AstParseError {
+	if idx < 0 || idx >= len(file.arena.errors) {
+		return &AstParseError{message: "", tokenIndex: 0, hint: "", note: "", code: ""}
+	}
+	return file.arena.errors[idx]
+}
+`
+
+const checkDiagCountReplacement = `func checkDiagCount(xs []*CheckDiagnostic) int {
+	return len(xs)
+}
+`
+
+const coreIntLenReplacement = `func coreIntLen(xs []int) int {
+	return len(xs)
+}
+`
+
+const coreDiagCountReplacement = `func coreDiagCount(xs []*CheckDiagnostic) int {
+	return len(xs)
+}
+`
+
+const solveIntLenReplacement = `func solveIntLen(xs []int) int {
+	return len(xs)
+}
+`
+
+const selfLintDiagnosticCountReplacement = `func selfLintDiagnosticCount(report *SelfLintReport) int {
+	return len(report.diagnostics)
+}
+`
+
+const selfLintFixCountReplacement = `func selfLintFixCount(diag *SelfLintDiagnostic) int {
+	return len(diag.fixes)
+}
+`
+
+const selfLintEditListCountReplacement = `func selfLintEditListCount(edits []*SelfLintEdit) int {
+	return len(edits)
+}
+`
+
+const selfLintEditAtReplacement = `func selfLintEditAt(edits []*SelfLintEdit, target int) *SelfLintEdit {
+	if target < 0 || target >= len(edits) {
+		return selfLintInvalidEdit()
+	}
+	return edits[target]
+}
+`
+
+const astLowerTokenCountReplacement = `func astLowerTokenCount(toks []astbridge.Token) int {
+	return len(toks)
+}
+`
+
+const astLowerIntListCountReplacement = `func astLowerIntListCount(xs []int) int {
+	return len(xs)
+}
+`
+
+const astLowerIntListAtReplacement = `func astLowerIntListAt(xs []int, target int) int {
+	if target < 0 || target >= len(xs) {
+		return -1
+	}
+	return xs[target]
 }
 `

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -854,29 +854,7 @@ func allAsciiDigits(text string) bool {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:354:5
-func stringUnitCount(text string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:355:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:356:5
-	for _, unit := range strings.Split(text, "") {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:357:9
-		_ = unit
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:358:9
-		func() {
-			var _cur26 int = count
-			var _rhs27 int = 1
-			if _rhs27 > 0 && _cur26 > math.MaxInt-_rhs27 {
-				panic("integer overflow")
-			}
-			if _rhs27 < 0 && _cur26 < math.MinInt-_rhs27 {
-				panic("integer overflow")
-			}
-			count = _cur26 + _rhs27
-		}()
-	}
-	return count
-}
+func stringUnitCount(text string) int { return len(strings.Split(text, "")) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:364:5
 func isSemIdentUnit(unit string) bool {
@@ -5085,127 +5063,27 @@ func frontLineHasIndent(units []string, start int, end int, indent int) bool {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2143:5
 func frontLexTokenCount(stream *FrontLexStream) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2144:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2145:5
-	for _, tok := range stream.tokens {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2146:9
-		_ = tok
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2147:9
-		func() {
-			var _cur386 int = count
-			var _rhs387 int = 1
-			if _rhs387 > 0 && _cur386 > math.MaxInt-_rhs387 {
-				panic("integer overflow")
-			}
-			if _rhs387 < 0 && _cur386 < math.MinInt-_rhs387 {
-				panic("integer overflow")
-			}
-			count = _cur386 + _rhs387
-		}()
-	}
-	return count
+	return len(stream.tokens)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2152:5
 func frontLexDiagnosticCount(stream *FrontLexStream) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2153:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2154:5
-	for _, diag := range stream.diagnostics {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2155:9
-		_ = diag
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2156:9
-		func() {
-			var _cur388 int = count
-			var _rhs389 int = 1
-			if _rhs389 > 0 && _cur388 > math.MaxInt-_rhs389 {
-				panic("integer overflow")
-			}
-			if _rhs389 < 0 && _cur388 < math.MinInt-_rhs389 {
-				panic("integer overflow")
-			}
-			count = _cur388 + _rhs389
-		}()
-	}
-	return count
+	return len(stream.diagnostics)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2161:5
 func frontCommentCount(stream *FrontLexStream) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2162:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2163:5
-	for _, comment := range stream.comments {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2164:9
-		_ = comment
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2165:9
-		func() {
-			var _cur390 int = count
-			var _rhs391 int = 1
-			if _rhs391 > 0 && _cur390 > math.MaxInt-_rhs391 {
-				panic("integer overflow")
-			}
-			if _rhs391 < 0 && _cur390 < math.MinInt-_rhs391 {
-				panic("integer overflow")
-			}
-			count = _cur390 + _rhs391
-		}()
-	}
-	return count
+	return len(stream.comments)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2170:5
 func frontStringPartCount(stream *FrontLexStream) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2171:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2172:5
-	for _, part := range stream.stringParts {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2173:9
-		_ = part
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2174:9
-		func() {
-			var _cur392 int = count
-			var _rhs393 int = 1
-			if _rhs393 > 0 && _cur392 > math.MaxInt-_rhs393 {
-				panic("integer overflow")
-			}
-			if _rhs393 < 0 && _cur392 < math.MinInt-_rhs393 {
-				panic("integer overflow")
-			}
-			count = _cur392 + _rhs393
-		}()
-	}
-	return count
+	return len(stream.stringParts)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2179:5
 func frontInterpolationTokenCount(stream *FrontLexStream) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2180:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2181:5
-	for _, token := range stream.interpolationTokens {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2182:9
-		_ = token
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2183:9
-		func() {
-			var _cur394 int = count
-			var _rhs395 int = 1
-			if _rhs395 > 0 && _cur394 > math.MaxInt-_rhs395 {
-				panic("integer overflow")
-			}
-			if _rhs395 < 0 && _cur394 < math.MinInt-_rhs395 {
-				panic("integer overflow")
-			}
-			count = _cur394 + _rhs395
-		}()
-	}
-	return count
+	return len(stream.interpolationTokens)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:2188:5
@@ -17905,81 +17783,17 @@ func ostyDropSuffixUnits(text string, count int) string {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6536:1
-func ostyLexStringPartCount(parts []*OstyLexStringPart) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6537:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6538:5
-	for _, part := range parts {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6539:9
-		_ = part
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6540:9
-		func() {
-			var _cur1733 int = count
-			var _rhs1734 int = 1
-			if _rhs1734 > 0 && _cur1733 > math.MaxInt-_rhs1734 {
-				panic("integer overflow")
-			}
-			if _rhs1734 < 0 && _cur1733 < math.MinInt-_rhs1734 {
-				panic("integer overflow")
-			}
-			count = _cur1733 + _rhs1734
-		}()
-	}
-	return count
-}
+func ostyLexStringPartCount(parts []*OstyLexStringPart) int { return len(parts) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6545:1
-func ostyStringListCount(items []string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6546:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6547:5
-	for _, item := range items {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6548:9
-		_ = item
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6549:9
-		func() {
-			var _cur1735 int = count
-			var _rhs1736 int = 1
-			if _rhs1736 > 0 && _cur1735 > math.MaxInt-_rhs1736 {
-				panic("integer overflow")
-			}
-			if _rhs1736 < 0 && _cur1735 < math.MinInt-_rhs1736 {
-				panic("integer overflow")
-			}
-			count = _cur1735 + _rhs1736
-		}()
-	}
-	return count
-}
+func ostyStringListCount(items []string) int { return len(items) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6554:1
 func ostyStringAt(items []string, target int) string {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6555:5
-	idx := 0
-	_ = idx
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6556:5
-	for _, item := range items {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6557:9
-		if idx == target {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6558:13
-			return item
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6560:9
-		func() {
-			var _cur1737 int = idx
-			var _rhs1738 int = 1
-			if _rhs1738 > 0 && _cur1737 > math.MaxInt-_rhs1738 {
-				panic("integer overflow")
-			}
-			if _rhs1738 < 0 && _cur1737 < math.MinInt-_rhs1738 {
-				panic("integer overflow")
-			}
-			idx = _cur1737 + _rhs1738
-		}()
+	if target < 0 || target >= len(items) {
+		return ""
 	}
-	return ""
+	return items[target]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6571:5
@@ -18049,106 +17863,23 @@ func ostyJoinDocLines(units []string, stream *FrontLexStream, tok *FrontLexToken
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6602:5
-func ostyLexResultTokenCount(result *OstyLexResult) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6603:5
-	c := 0
-	_ = c
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6604:5
-	for _, t := range result.tokens {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6605:9
-		_ = t
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6606:9
-		func() {
-			var _cur1743 int = c
-			var _rhs1744 int = 1
-			if _rhs1744 > 0 && _cur1743 > math.MaxInt-_rhs1744 {
-				panic("integer overflow")
-			}
-			if _rhs1744 < 0 && _cur1743 < math.MinInt-_rhs1744 {
-				panic("integer overflow")
-			}
-			c = _cur1743 + _rhs1744
-		}()
-	}
-	return c
-}
+func ostyLexResultTokenCount(result *OstyLexResult) int { return len(result.tokens) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6611:5
-func ostyLexResultErrorCount(result *OstyLexResult) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6612:5
-	c := 0
-	_ = c
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6613:5
-	for _, e := range result.errors {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6614:9
-		_ = e
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6615:9
-		func() {
-			var _cur1745 int = c
-			var _rhs1746 int = 1
-			if _rhs1746 > 0 && _cur1745 > math.MaxInt-_rhs1746 {
-				panic("integer overflow")
-			}
-			if _rhs1746 < 0 && _cur1745 < math.MinInt-_rhs1746 {
-				panic("integer overflow")
-			}
-			c = _cur1745 + _rhs1746
-		}()
-	}
-	return c
-}
+func ostyLexResultErrorCount(result *OstyLexResult) int { return len(result.errors) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6620:5
-func ostyLexResultCommentCount(result *OstyLexResult) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6621:5
-	c := 0
-	_ = c
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6622:5
-	for _, co := range result.comments {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6623:9
-		_ = co
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6624:9
-		func() {
-			var _cur1747 int = c
-			var _rhs1748 int = 1
-			if _rhs1748 > 0 && _cur1747 > math.MaxInt-_rhs1748 {
-				panic("integer overflow")
-			}
-			if _rhs1748 < 0 && _cur1747 < math.MinInt-_rhs1748 {
-				panic("integer overflow")
-			}
-			c = _cur1747 + _rhs1748
-		}()
-	}
-	return c
-}
+func ostyLexResultCommentCount(result *OstyLexResult) int { return len(result.comments) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6629:5
 func ostyLexResultTokenAt(result *OstyLexResult, idx int) *OstyRichToken {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6630:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6631:5
-	for _, t := range result.tokens {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6632:9
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6633:13
-			return t
+	if idx < 0 || idx >= len(result.tokens) {
+		return &OstyRichToken{
+			kind: FrontTokenKind(&FrontTokenKind_FrontEOF{}), text: "", startOffset: 0, startLine: 0, startCol: 0,
+			endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0,
 		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6635:9
-		func() {
-			var _cur1749 int = i
-			var _rhs1750 int = 1
-			if _rhs1750 > 0 && _cur1749 > math.MaxInt-_rhs1750 {
-				panic("integer overflow")
-			}
-			if _rhs1750 < 0 && _cur1749 < math.MinInt-_rhs1750 {
-				panic("integer overflow")
-			}
-			i = _cur1749 + _rhs1750
-		}()
 	}
-	return &OstyRichToken{kind: FrontTokenKind(&FrontTokenKind_FrontEOF{}), text: "", startOffset: 0, startLine: 0, startCol: 0, endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0}
+	return result.tokens[idx]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:6647:5
@@ -22938,29 +22669,7 @@ func astParseSummary(source string) *FrontParseSummary {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8622:5
-func astFileDeclCount(file *AstFile) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8622:49
-	c := 0
-	_ = c
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8623:1
-	for _, d := range file.arena.decls {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8623:29
-		_ = d
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8624:1
-		func() {
-			var _cur1792 int = c
-			var _rhs1793 int = 1
-			if _rhs1793 > 0 && _cur1792 > math.MaxInt-_rhs1793 {
-				panic("integer overflow")
-			}
-			if _rhs1793 < 0 && _cur1792 < math.MinInt-_rhs1793 {
-				panic("integer overflow")
-			}
-			c = _cur1792 + _rhs1793
-		}()
-	}
-	return c
-}
+func astFileDeclCount(file *AstFile) int { return len(file.arena.decls) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8626:5
 func astFileNodeCount(file *AstFile) int {
@@ -22968,84 +22677,22 @@ func astFileNodeCount(file *AstFile) int {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8627:5
-func astFileErrorCount(file *AstFile) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8627:50
-	c := 0
-	_ = c
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8628:1
-	for _, e := range file.arena.errors {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8628:30
-		_ = e
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8629:1
-		func() {
-			var _cur1794 int = c
-			var _rhs1795 int = 1
-			if _rhs1795 > 0 && _cur1794 > math.MaxInt-_rhs1795 {
-				panic("integer overflow")
-			}
-			if _rhs1795 < 0 && _cur1794 < math.MinInt-_rhs1795 {
-				panic("integer overflow")
-			}
-			c = _cur1794 + _rhs1795
-		}()
-	}
-	return c
-}
+func astFileErrorCount(file *AstFile) int { return len(file.arena.errors) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8632:5
 func astFileDeclAt(file *AstFile, idx int) *AstNode {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8633:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8634:5
-	for _, d := range file.arena.decls {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8634:33
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8634:47
-			return astArenaNodeAt(file.arena, d)
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8635:5
-		func() {
-			var _cur1796 int = i
-			var _rhs1797 int = 1
-			if _rhs1797 > 0 && _cur1796 > math.MaxInt-_rhs1797 {
-				panic("integer overflow")
-			}
-			if _rhs1797 < 0 && _cur1796 < math.MinInt-_rhs1797 {
-				panic("integer overflow")
-			}
-			i = _cur1796 + _rhs1797
-		}()
+	if idx < 0 || idx >= len(file.arena.decls) {
+		return emptyAstNode(AstNodeKind(&AstNodeKind_AstNError{}))
 	}
-	return emptyAstNode(AstNodeKind(&AstNodeKind_AstNError{}))
+	return astArenaNodeAt(file.arena, file.arena.decls[idx])
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8639:5
 func astFileErrorAt(file *AstFile, idx int) *AstParseError {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8640:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8641:5
-	for _, e := range file.arena.errors {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8641:34
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8641:48
-			return e
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8642:5
-		func() {
-			var _cur1798 int = i
-			var _rhs1799 int = 1
-			if _rhs1799 > 0 && _cur1798 > math.MaxInt-_rhs1799 {
-				panic("integer overflow")
-			}
-			if _rhs1799 < 0 && _cur1798 < math.MinInt-_rhs1799 {
-				panic("integer overflow")
-			}
-			i = _cur1798 + _rhs1799
-		}()
+	if idx < 0 || idx >= len(file.arena.errors) {
+		return &AstParseError{message: "", tokenIndex: 0, hint: "", note: "", code: ""}
 	}
-	return &AstParseError{message: "", tokenIndex: 0, hint: "", note: "", code: ""}
+	return file.arena.errors[idx]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:8646:5
@@ -25913,29 +25560,7 @@ func checkDiagCountErrors(xs []*CheckDiagnostic) int {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10081:5
-func checkDiagCount(xs []*CheckDiagnostic) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10082:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10083:5
-	for _, d := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10084:9
-		_ = d
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10085:9
-		func() {
-			var _cur1955 int = n
-			var _rhs1956 int = 1
-			if _rhs1956 > 0 && _cur1955 > math.MaxInt-_rhs1956 {
-				panic("integer overflow")
-			}
-			if _rhs1956 < 0 && _cur1955 < math.MinInt-_rhs1956 {
-				panic("integer overflow")
-			}
-			n = _cur1955 + _rhs1956
-		}()
-	}
-	return n
-}
+func checkDiagCount(xs []*CheckDiagnostic) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:10092:5
 func checkDiagRender(d *CheckDiagnostic) string {
@@ -30726,54 +30351,10 @@ func corePrintTypeArgs(tys *TyArena, args []int) string {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12685:1
-func coreIntLen(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12686:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12687:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12688:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12689:9
-		func() {
-			var _cur2034 int = n
-			var _rhs2035 int = 1
-			if _rhs2035 > 0 && _cur2034 > math.MaxInt-_rhs2035 {
-				panic("integer overflow")
-			}
-			if _rhs2035 < 0 && _cur2034 < math.MinInt-_rhs2035 {
-				panic("integer overflow")
-			}
-			n = _cur2034 + _rhs2035
-		}()
-	}
-	return n
-}
+func coreIntLen(xs []int) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12694:1
-func coreDiagCount(xs []*CheckDiagnostic) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12695:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12696:5
-	for _, d := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12697:9
-		_ = d
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12698:9
-		func() {
-			var _cur2036 int = n
-			var _rhs2037 int = 1
-			if _rhs2037 > 0 && _cur2036 > math.MaxInt-_rhs2037 {
-				panic("integer overflow")
-			}
-			if _rhs2037 < 0 && _cur2036 < math.MinInt-_rhs2037 {
-				panic("integer overflow")
-			}
-			n = _cur2036 + _rhs2037
-		}()
-	}
-	return n
-}
+func coreDiagCount(xs []*CheckDiagnostic) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:12727:5
 type CheckBinding struct {
@@ -33171,29 +32752,7 @@ func checkGenericBoundSatisfied(env *CheckEnv, solver *Solver, concreteTy int, i
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14117:1
-func solveIntLen(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14118:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14119:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14120:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14121:9
-		func() {
-			var _cur2104 int = n
-			var _rhs2105 int = 1
-			if _rhs2105 > 0 && _cur2104 > math.MaxInt-_rhs2105 {
-				panic("integer overflow")
-			}
-			if _rhs2105 < 0 && _cur2104 < math.MinInt-_rhs2105 {
-				panic("integer overflow")
-			}
-			n = _cur2104 + _rhs2105
-		}()
-	}
-	return n
-}
+func solveIntLen(xs []int) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:14166:5
 type ElabResult struct {
@@ -35143,57 +34702,14 @@ func elabPoisonResult(cx *ElabCx, start int, end int) *ElabResult {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15024:1
-func checkIntListLenHelper(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15025:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15026:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15027:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15028:9
-		func() {
-			var _cur2121 int = n
-			var _rhs2122 int = 1
-			if _rhs2122 > 0 && _cur2121 > math.MaxInt-_rhs2122 {
-				panic("integer overflow")
-			}
-			if _rhs2122 < 0 && _cur2121 < math.MinInt-_rhs2122 {
-				panic("integer overflow")
-			}
-			n = _cur2121 + _rhs2122
-		}()
-	}
-	return n
-}
+func checkIntListLenHelper(xs []int) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15033:1
 func checkIntListAt(xs []int, idx int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15034:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15035:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15036:9
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15037:13
-			return x
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15039:9
-		func() {
-			var _cur2123 int = i
-			var _rhs2124 int = 1
-			if _rhs2124 > 0 && _cur2123 > math.MaxInt-_rhs2124 {
-				panic("integer overflow")
-			}
-			if _rhs2124 < 0 && _cur2123 < math.MinInt-_rhs2124 {
-				panic("integer overflow")
-			}
-			i = _cur2123 + _rhs2124
-		}()
+	if idx < 0 || idx >= len(xs) {
+		return -1
 	}
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15041:5
-	return -1
+	return xs[idx]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15056:1
@@ -36052,29 +35568,7 @@ func elabInferField(cx *ElabCx, node *AstNode) *ElabResult {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15448:1
-func checkStringListLenHelper(xs []string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15449:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15450:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15451:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15452:9
-		func() {
-			var _cur2144 int = n
-			var _rhs2145 int = 1
-			if _rhs2145 > 0 && _cur2144 > math.MaxInt-_rhs2145 {
-				panic("integer overflow")
-			}
-			if _rhs2145 < 0 && _cur2144 < math.MinInt-_rhs2145 {
-				panic("integer overflow")
-			}
-			n = _cur2144 + _rhs2145
-		}()
-	}
-	return n
-}
+func checkStringListLenHelper(xs []string) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:15457:1
 func parseTupleIndex(text string) int {
@@ -39027,29 +38521,7 @@ func allVariantsForOwner(env *CheckEnv, owner string) []*CheckVariantSig {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16996:1
-func checkVariantListLen(xs []*CheckVariantSig) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16997:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16998:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:16999:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17000:9
-		func() {
-			var _cur2176 int = n
-			var _rhs2177 int = 1
-			if _rhs2177 > 0 && _cur2176 > math.MaxInt-_rhs2177 {
-				panic("integer overflow")
-			}
-			if _rhs2177 < 0 && _cur2176 < math.MinInt-_rhs2177 {
-				panic("integer overflow")
-			}
-			n = _cur2176 + _rhs2177
-		}()
-	}
-	return n
-}
+func checkVariantListLen(xs []*CheckVariantSig) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17005:1
 func lastPathSegment(s string) string {
@@ -39551,29 +39023,7 @@ func pmExhaustivenessWitnessAt(cx *ElabCx, rows [][]int, colTys []int, depth int
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17346:1
-func pmWitnessesCount(xs []string) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17347:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17348:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17349:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17350:9
-		func() {
-			var _cur2182 int = n
-			var _rhs2183 int = 1
-			if _rhs2183 > 0 && _cur2182 > math.MaxInt-_rhs2183 {
-				panic("integer overflow")
-			}
-			if _rhs2183 < 0 && _cur2182 < math.MinInt-_rhs2183 {
-				panic("integer overflow")
-			}
-			n = _cur2182 + _rhs2183
-		}()
-	}
-	return n
-}
+func pmWitnessesCount(xs []string) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17355:1
 func pmPrependWitnesses(prefix string, ws []string, startSeen int) []string {
@@ -39991,29 +39441,7 @@ func pmStructFieldsForOwner(env *CheckEnv, owner string) []*CheckFieldSig {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17587:1
-func checkFieldListLen(xs []*CheckFieldSig) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17588:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17589:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17590:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17591:9
-		func() {
-			var _cur2186 int = n
-			var _rhs2187 int = 1
-			if _rhs2187 > 0 && _cur2186 > math.MaxInt-_rhs2187 {
-				panic("integer overflow")
-			}
-			if _rhs2187 < 0 && _cur2186 < math.MinInt-_rhs2187 {
-				panic("integer overflow")
-			}
-			n = _cur2186 + _rhs2187
-		}()
-	}
-	return n
-}
+func checkFieldListLen(xs []*CheckFieldSig) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17596:1
 func pmVariantCtor(cx *ElabCx, v *CheckVariantSig, colTy int) *PmCtor {
@@ -40599,54 +40027,10 @@ func intListConcat(a []int, b []int) []int {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17875:1
-func checkListOfRowsLen(xs [][]int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17876:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17877:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17878:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17879:9
-		func() {
-			var _cur2204 int = n
-			var _rhs2205 int = 1
-			if _rhs2205 > 0 && _cur2204 > math.MaxInt-_rhs2205 {
-				panic("integer overflow")
-			}
-			if _rhs2205 < 0 && _cur2204 < math.MinInt-_rhs2205 {
-				panic("integer overflow")
-			}
-			n = _cur2204 + _rhs2205
-		}()
-	}
-	return n
-}
+func checkListOfRowsLen(xs [][]int) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17884:1
-func checkCtorListLen(xs []*PmCtor) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17885:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17886:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17887:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17888:9
-		func() {
-			var _cur2206 int = n
-			var _rhs2207 int = 1
-			if _rhs2207 > 0 && _cur2206 > math.MaxInt-_rhs2207 {
-				panic("integer overflow")
-			}
-			if _rhs2207 < 0 && _cur2206 < math.MinInt-_rhs2207 {
-				panic("integer overflow")
-			}
-			n = _cur2206 + _rhs2207
-		}()
-	}
-	return n
-}
+func checkCtorListLen(xs []*PmCtor) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:17898:5
 type PmIntParse struct {
@@ -42194,56 +41578,14 @@ func astTypeToTyInCollect(cx *ElabCx, idx int) int {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18592:1
-func checkIntListLenLocal(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18593:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18594:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18595:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18596:9
-		func() {
-			var _cur2238 int = n
-			var _rhs2239 int = 1
-			if _rhs2239 > 0 && _cur2238 > math.MaxInt-_rhs2239 {
-				panic("integer overflow")
-			}
-			if _rhs2239 < 0 && _cur2238 < math.MinInt-_rhs2239 {
-				panic("integer overflow")
-			}
-			n = _cur2238 + _rhs2239
-		}()
-	}
-	return n
-}
+func checkIntListLenLocal(xs []int) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18601:1
 func checkIntListAtLocal(xs []int, idx int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18602:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18603:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18604:9
-		if i == idx {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18605:13
-			return x
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18607:9
-		func() {
-			var _cur2240 int = i
-			var _rhs2241 int = 1
-			if _rhs2241 > 0 && _cur2240 > math.MaxInt-_rhs2241 {
-				panic("integer overflow")
-			}
-			if _rhs2241 < 0 && _cur2240 < math.MinInt-_rhs2241 {
-				panic("integer overflow")
-			}
-			i = _cur2240 + _rhs2241
-		}()
+	if idx < 0 || idx >= len(xs) {
+		return -1
 	}
-	return -1
+	return xs[idx]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18612:1
@@ -42437,29 +41779,7 @@ func serializeCheckResult(cx *ElabCx) *FrontCheckResult {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18747:5
-func frontCheckResultTypedNodeCount(result *FrontCheckResult) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18748:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18749:5
-	for _, x := range result.typedNodes {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18750:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18751:9
-		func() {
-			var _cur2243 int = n
-			var _rhs2244 int = 1
-			if _rhs2244 > 0 && _cur2243 > math.MaxInt-_rhs2244 {
-				panic("integer overflow")
-			}
-			if _rhs2244 < 0 && _cur2243 < math.MinInt-_rhs2244 {
-				panic("integer overflow")
-			}
-			n = _cur2243 + _rhs2244
-		}()
-	}
-	return n
-}
+func frontCheckResultTypedNodeCount(result *FrontCheckResult) int { return len(result.typedNodes) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18756:5
 func frontCheckResultBindingType(result *FrontCheckResult, name string) string {
@@ -42505,27 +41825,7 @@ func frontCheckResultSymbolCount(result *FrontCheckResult, kind string) int {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18776:5
 func frontCheckResultInstantiationCount(result *FrontCheckResult) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18777:5
-	n := 0
-	_ = n
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18778:5
-	for _, x := range result.instantiations {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18779:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18780:9
-		func() {
-			var _cur2247 int = n
-			var _rhs2248 int = 1
-			if _rhs2248 > 0 && _cur2247 > math.MaxInt-_rhs2248 {
-				panic("integer overflow")
-			}
-			if _rhs2248 < 0 && _cur2247 < math.MinInt-_rhs2248 {
-				panic("integer overflow")
-			}
-			n = _cur2247 + _rhs2248
-		}()
-	}
-	return n
+	return len(result.instantiations)
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18788:5
@@ -42620,29 +41920,7 @@ func selfResolveAstFile(file *AstFile) *SelfResolveResult {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18922:5
-func selfResolveDiagnosticCount(result *SelfResolveResult) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18923:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18924:5
-	for _, diag := range result.diagnostics {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18925:9
-		_ = diag
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18926:9
-		func() {
-			var _cur2249 int = count
-			var _rhs2250 int = 1
-			if _rhs2250 > 0 && _cur2249 > math.MaxInt-_rhs2250 {
-				panic("integer overflow")
-			}
-			if _rhs2250 < 0 && _cur2249 < math.MinInt-_rhs2250 {
-				panic("integer overflow")
-			}
-			count = _cur2249 + _rhs2250
-		}()
-	}
-	return count
-}
+func selfResolveDiagnosticCount(result *SelfResolveResult) int { return len(result.diagnostics) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:18931:5
 func selfResolveCodeCount(result *SelfResolveResult, code string) int {
@@ -44785,111 +44063,29 @@ func srAstNode(file *AstFile, idx int) *AstNode {
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20314:1
 func srAstChildAt(children []int, target int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20315:5
-	idx := 0
-	_ = idx
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20316:5
-	for _, child := range children {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20317:9
-		if idx == target {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20318:13
-			return child
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20320:9
-		func() {
-			var _cur2291 int = idx
-			var _rhs2292 int = 1
-			if _rhs2292 > 0 && _cur2291 > math.MaxInt-_rhs2292 {
-				panic("integer overflow")
-			}
-			if _rhs2292 < 0 && _cur2291 < math.MinInt-_rhs2292 {
-				panic("integer overflow")
-			}
-			idx = _cur2291 + _rhs2292
-		}()
+	if target < 0 || target >= len(children) {
+		return -1
 	}
-	return -1
+	return children[target]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20325:1
-func srAstListCount(items []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20326:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20327:5
-	for _, item := range items {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20328:9
-		_ = item
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20329:9
-		func() {
-			var _cur2293 int = count
-			var _rhs2294 int = 1
-			if _rhs2294 > 0 && _cur2293 > math.MaxInt-_rhs2294 {
-				panic("integer overflow")
-			}
-			if _rhs2294 < 0 && _cur2293 < math.MinInt-_rhs2294 {
-				panic("integer overflow")
-			}
-			count = _cur2293 + _rhs2294
-		}()
-	}
-	return count
-}
+func srAstListCount(items []int) int { return len(items) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20334:1
 func srIntListAt(items []int, target int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20335:5
-	idx := 0
-	_ = idx
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20336:5
-	for _, item := range items {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20337:9
-		if idx == target {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20338:13
-			return item
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20340:9
-		func() {
-			var _cur2295 int = idx
-			var _rhs2296 int = 1
-			if _rhs2296 > 0 && _cur2295 > math.MaxInt-_rhs2296 {
-				panic("integer overflow")
-			}
-			if _rhs2296 < 0 && _cur2295 < math.MinInt-_rhs2296 {
-				panic("integer overflow")
-			}
-			idx = _cur2295 + _rhs2296
-		}()
+	if target < 0 || target >= len(items) {
+		return -1
 	}
-	return -1
+	return items[target]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20345:1
 func srStringListAt(items []string, target int) string {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20346:5
-	idx := 0
-	_ = idx
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20347:5
-	for _, item := range items {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20348:9
-		if idx == target {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20349:13
-			return item
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20351:9
-		func() {
-			var _cur2297 int = idx
-			var _rhs2298 int = 1
-			if _rhs2298 > 0 && _cur2297 > math.MaxInt-_rhs2298 {
-				panic("integer overflow")
-			}
-			if _rhs2298 < 0 && _cur2297 < math.MinInt-_rhs2298 {
-				panic("integer overflow")
-			}
-			idx = _cur2297 + _rhs2298
-		}()
+	if target < 0 || target >= len(items) {
+		return ""
 	}
-	return ""
+	return items[target]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20356:1
@@ -45607,29 +44803,7 @@ func selfLintResolvedAstSource(source string, file *AstFile, resolved *SelfResol
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20749:5
-func selfLintDiagnosticCount(report *SelfLintReport) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20750:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20751:5
-	for _, diag := range report.diagnostics {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20752:9
-		_ = diag
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20753:9
-		func() {
-			var _cur2349 int = count
-			var _rhs2350 int = 1
-			if _rhs2350 > 0 && _cur2349 > math.MaxInt-_rhs2350 {
-				panic("integer overflow")
-			}
-			if _rhs2350 < 0 && _cur2349 < math.MinInt-_rhs2350 {
-				panic("integer overflow")
-			}
-			count = _cur2349 + _rhs2350
-		}()
-	}
-	return count
-}
+func selfLintDiagnosticCount(report *SelfLintReport) int { return len(report.diagnostics) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20758:5
 func selfLintCodeCount(report *SelfLintReport, code string) int {
@@ -45668,29 +44842,7 @@ func selfLintFirstDiagnostic(report *SelfLintReport) *SelfLintDiagnostic {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20775:5
-func selfLintFixCount(diag *SelfLintDiagnostic) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20776:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20777:5
-	for _, fix := range diag.fixes {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20778:9
-		_ = fix
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20779:9
-		func() {
-			var _cur2353 int = count
-			var _rhs2354 int = 1
-			if _rhs2354 > 0 && _cur2353 > math.MaxInt-_rhs2354 {
-				panic("integer overflow")
-			}
-			if _rhs2354 < 0 && _cur2353 < math.MinInt-_rhs2354 {
-				panic("integer overflow")
-			}
-			count = _cur2353 + _rhs2354
-		}()
-	}
-	return count
-}
+func selfLintFixCount(diag *SelfLintDiagnostic) int { return len(diag.fixes) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20784:5
 func selfLintFirstFix(diag *SelfLintDiagnostic) *SelfLintFix {
@@ -46031,56 +45183,14 @@ func selfLintInvalidEdit() *SelfLintEdit {
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20925:1
-func selfLintEditListCount(edits []*SelfLintEdit) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20926:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20927:5
-	for _, edit := range edits {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20928:9
-		_ = edit
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20929:9
-		func() {
-			var _cur2375 int = count
-			var _rhs2376 int = 1
-			if _rhs2376 > 0 && _cur2375 > math.MaxInt-_rhs2376 {
-				panic("integer overflow")
-			}
-			if _rhs2376 < 0 && _cur2375 < math.MinInt-_rhs2376 {
-				panic("integer overflow")
-			}
-			count = _cur2375 + _rhs2376
-		}()
-	}
-	return count
-}
+func selfLintEditListCount(edits []*SelfLintEdit) int { return len(edits) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20934:1
 func selfLintEditAt(edits []*SelfLintEdit, target int) *SelfLintEdit {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20935:5
-	idx := 0
-	_ = idx
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20936:5
-	for _, edit := range edits {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20937:9
-		if idx == target {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20938:13
-			return edit
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20940:9
-		func() {
-			var _cur2377 int = idx
-			var _rhs2378 int = 1
-			if _rhs2378 > 0 && _cur2377 > math.MaxInt-_rhs2378 {
-				panic("integer overflow")
-			}
-			if _rhs2378 < 0 && _cur2377 < math.MinInt-_rhs2378 {
-				panic("integer overflow")
-			}
-			idx = _cur2377 + _rhs2378
-		}()
+	if target < 0 || target >= len(edits) {
+		return selfLintInvalidEdit()
 	}
-	return selfLintInvalidEdit()
+	return edits[target]
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:20945:1
@@ -49055,29 +48165,7 @@ func astLowerUseDecls(arena *AstArena, toks []astbridge.Token, n *AstNode) []ast
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:23257:1
-func astLowerTokenCount(toks []astbridge.Token) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:23258:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:23259:5
-	for _, tok := range toks {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:23260:9
-		_ = tok
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:23261:9
-		func() {
-			var _cur2441 int = count
-			var _rhs2442 int = 1
-			if _rhs2442 > 0 && _cur2441 > math.MaxInt-_rhs2442 {
-				panic("integer overflow")
-			}
-			if _rhs2442 < 0 && _cur2441 < math.MinInt-_rhs2442 {
-				panic("integer overflow")
-			}
-			count = _cur2441 + _rhs2442
-		}()
-	}
-	return count
-}
+func astLowerTokenCount(toks []astbridge.Token) int { return len(toks) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:23266:1
 func astLowerInterpolatedTokensToExpr(toks []astbridge.Token) astbridge.Expr {
@@ -52421,54 +51509,12 @@ func astLowerLiteralPatternExpr(toks []astbridge.Token, n *AstNode) astbridge.Ex
 }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24674:1
-func astLowerIntListCount(xs []int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24675:5
-	count := 0
-	_ = count
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24676:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24677:9
-		_ = x
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24678:9
-		func() {
-			var _cur2601 int = count
-			var _rhs2602 int = 1
-			if _rhs2602 > 0 && _cur2601 > math.MaxInt-_rhs2602 {
-				panic("integer overflow")
-			}
-			if _rhs2602 < 0 && _cur2601 < math.MinInt-_rhs2602 {
-				panic("integer overflow")
-			}
-			count = _cur2601 + _rhs2602
-		}()
-	}
-	return count
-}
+func astLowerIntListCount(xs []int) int { return len(xs) }
 
 // Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24683:1
 func astLowerIntListAt(xs []int, target int) int {
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24684:5
-	i := 0
-	_ = i
-	// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24685:5
-	for _, x := range xs {
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24686:9
-		if i == target {
-			// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24687:13
-			return x
-		}
-		// Osty: /var/folders/v6/9b6yvrb973q8xs8yynkdchyr0000gn/T/osty-bootstrap-gen-2859141425/selfhost_merged.osty:24689:9
-		func() {
-			var _cur2603 int = i
-			var _rhs2604 int = 1
-			if _rhs2604 > 0 && _cur2603 > math.MaxInt-_rhs2604 {
-				panic("integer overflow")
-			}
-			if _rhs2604 < 0 && _cur2603 < math.MinInt-_rhs2604 {
-				panic("integer overflow")
-			}
-			i = _cur2603 + _rhs2604
-		}()
+	if target < 0 || target >= len(xs) {
+		return -1
 	}
-	return -1
+	return xs[target]
 }

--- a/toolchain/ast_lower.osty
+++ b/toolchain/ast_lower.osty
@@ -309,12 +309,7 @@ fn astLowerPublicFile(arena: AstArena, toks: List<astbridge.Token>) -> astbridge
 }
 
 fn astLowerTokenCount(toks: List<astbridge.Token>) -> Int {
-    let mut count = 0
-    for tok in toks {
-        let _ = tok
-        count = count + 1
-    }
-    count
+    toks.len()
 }
 
 fn astLowerInterpolatedTokensToExpr(toks: List<astbridge.Token>) -> astbridge.Expr {
@@ -1668,21 +1663,10 @@ fn astLowerLiteralPatternExpr(toks: List<astbridge.Token>, n: AstNode) -> astbri
 }
 
 fn astLowerIntListCount(xs: List<Int>) -> Int {
-    let mut count = 0
-    for x in xs {
-        let _ = x
-        count = count + 1
-    }
-    count
+    xs.len()
 }
 
 fn astLowerIntListAt(xs: List<Int>, target: Int) -> Int {
-    let mut i = 0
-    for x in xs {
-        if i == target {
-            return x
-        }
-        i = i + 1
-    }
-    -1
+    if target < 0 || target >= xs.len() { return -1 }
+    xs[target]
 }

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -939,23 +939,12 @@ fn astTypeToTyInCollect(cx: ElabCx, idx: Int) -> Int {
 }
 
 fn checkIntListLenLocal(xs: List<Int>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn checkIntListAtLocal(xs: List<Int>, idx: Int) -> Int {
-    let mut i = 0
-    for x in xs {
-        if i == idx {
-            return x
-        }
-        i = i + 1
-    }
-    -1
+    if idx < 0 || idx >= xs.len() { return -1 }
+    xs[idx]
 }
 
 fn topLevelLetBindingName(cx: ElabCx, node: AstNode) -> String {
@@ -1094,12 +1083,7 @@ fn serializeCheckResult(cx: ElabCx) -> FrontCheckResult {
 // ---------------------------------------------------------------------
 
 pub fn frontCheckResultTypedNodeCount(result: FrontCheckResult) -> Int {
-    let mut n = 0
-    for x in result.typedNodes {
-        let _ = x
-        n = n + 1
-    }
-    n
+    result.typedNodes.len()
 }
 
 pub fn frontCheckResultBindingType(result: FrontCheckResult, name: String) -> String {
@@ -1123,10 +1107,5 @@ pub fn frontCheckResultSymbolCount(result: FrontCheckResult, kind: String) -> In
 }
 
 pub fn frontCheckResultInstantiationCount(result: FrontCheckResult) -> Int {
-    let mut n = 0
-    for x in result.instantiations {
-        let _ = x
-        n = n + 1
-    }
-    n
+    result.instantiations.len()
 }

--- a/toolchain/check_diag.osty
+++ b/toolchain/check_diag.osty
@@ -489,14 +489,8 @@ fn checkDiagLevenshteinBounded(left: String, right: String, limit: Int) -> Int {
 }
 
 fn checkDiagStringListAt(items: List<String>, target: Int) -> String {
-    let mut idx = 0
-    for item in items {
-        if idx == target {
-            return item
-        }
-        idx = idx + 1
-    }
-    ""
+    if target < 0 || target >= items.len() { return "" }
+    items[target]
 }
 
 // ---------------------------------------------------------------------
@@ -527,12 +521,7 @@ pub fn checkDiagCountErrors(xs: List<CheckDiagnostic>) -> Int {
 }
 
 pub fn checkDiagCount(xs: List<CheckDiagnostic>) -> Int {
-    let mut n = 0
-    for d in xs {
-        let _ = d
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 /// checkDiagRender produces a single-line preview of a diagnostic

--- a/toolchain/ci.osty
+++ b/toolchain/ci.osty
@@ -519,12 +519,7 @@ pub fn ciCheckPassed(diags: List<CiDiagCore>, strict: Bool) -> Bool {
 }
 
 pub fn ciDiagCount(diags: List<CiDiagCore>) -> Int {
-    let mut count = 0
-    for d in diags {
-        let _ = d
-        count = count + 1
-    }
-    count
+    diags.len()
 }
 
 pub fn ciSkippedNote() -> String {
@@ -793,12 +788,7 @@ fn dependencyCoreFromRow(row: String) -> CiDependencyCore {
 }
 
 fn packageCount(packages: List<host.ResolvePackage?>) -> Int {
-    let mut count = 0
-    for pkg in packages {
-        let _ = pkg
-        count = count + 1
-    }
-    count
+    packages.len()
 }
 
 fn ciBreakingSeverity(breakingIsError: Bool) -> String {
@@ -1010,12 +1000,7 @@ fn ciAllAsciiDigits(text: String) -> Bool {
 }
 
 fn ciStringUnitCount(text: String) -> Int {
-    let mut count = 0
-    for unit in ciStrings.split(text, "") {
-        let _ = unit
-        count = count + 1
-    }
-    count
+    ciStrings.split(text, "").len()
 }
 
 fn ciParseSemNumber(text: String) -> Int {

--- a/toolchain/core.osty
+++ b/toolchain/core.osty
@@ -1764,19 +1764,9 @@ fn corePrintTypeArgs(tys: TyArena, args: List<Int>) -> String {
 }
 
 fn coreIntLen(xs: List<Int>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn coreDiagCount(xs: List<CheckDiagnostic>) -> Int {
-    let mut n = 0
-    for d in xs {
-        let _ = d
-        n = n + 1
-    }
-    n
+    xs.len()
 }

--- a/toolchain/core_test.osty
+++ b/toolchain/core_test.osty
@@ -132,12 +132,7 @@ fn testCoreForStmtVarietyFlag() {
 }
 
 fn coreIntListLen(xs: List<Int>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 /// tFn is a thin wrapper used only in this test file — mirrors the

--- a/toolchain/docgen.osty
+++ b/toolchain/docgen.osty
@@ -591,30 +591,15 @@ pub fn selfDocPackageHasDecl(pkg: SelfDocPackage, name: String, kind: String) ->
 }
 
 pub fn selfDocFieldCount(fields: List<SelfDocField>) -> Int {
-    let mut count = 0
-    for field in fields {
-        let _ = field
-        count = count + 1
-    }
-    count
+    fields.len()
 }
 
 pub fn selfDocMethodCount(methods: List<SelfDocMethod>) -> Int {
-    let mut count = 0
-    for method in methods {
-        let _ = method
-        count = count + 1
-    }
-    count
+    methods.len()
 }
 
 pub fn selfDocVariantCount(variants: List<SelfDocVariant>) -> Int {
-    let mut count = 0
-    for variant in variants {
-        let _ = variant
-        count = count + 1
-    }
-    count
+    variants.len()
 }
 
 pub fn selfDocPackageDeclNamed(pkg: SelfDocPackage, name: String) -> SelfDocDecl {
@@ -1665,48 +1650,23 @@ fn selfDocHTMLStylesheet() -> String {
 }
 
 fn selfDocDeclListCount(decls: List<SelfDocDecl>) -> Int {
-    let mut count = 0
-    for decl in decls {
-        let _ = decl
-        count = count + 1
-    }
-    count
+    decls.len()
 }
 
 fn selfDocPackageListCount(packages: List<SelfDocPackage>) -> Int {
-    let mut count = 0
-    for pkg in packages {
-        let _ = pkg
-        count = count + 1
-    }
-    count
+    packages.len()
 }
 
 fn selfDocParamDocCount(params: List<SelfDocParamDoc>) -> Int {
-    let mut count = 0
-    for param in params {
-        let _ = param
-        count = count + 1
-    }
-    count
+    params.len()
 }
 
 fn selfDocStringListCount(items: List<String>) -> Int {
-    let mut count = 0
-    for item in items {
-        let _ = item
-        count = count + 1
-    }
-    count
+    items.len()
 }
 
 fn selfDocIntListCount(items: List<Int>) -> Int {
-    let mut count = 0
-    for item in items {
-        let _ = item
-        count = count + 1
-    }
-    count
+    items.len()
 }
 
 fn selfDocEmptyInfo() -> SelfDocInfo {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1156,23 +1156,12 @@ fn elabPoisonResult(cx: ElabCx, start: Int, end: Int) -> ElabResult {
 }
 
 fn checkIntListLenHelper(xs: List<Int>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn checkIntListAt(xs: List<Int>, idx: Int) -> Int {
-    let mut i = 0
-    for x in xs {
-        if i == idx {
-            return x
-        }
-        i = i + 1
-    }
-    return -1
+    if idx < 0 || idx >= xs.len() { return -1 }
+    xs[idx]
 }
 
 // =====================================================================
@@ -1832,12 +1821,7 @@ fn elabInferField(cx: ElabCx, node: AstNode) -> ElabResult {
 }
 
 fn checkStringListLenHelper(xs: List<String>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn parseTupleIndex(text: String) -> Int {
@@ -3436,12 +3420,7 @@ fn allVariantsForOwner(env: CheckEnv, owner: String) -> List<CheckVariantSig> {
 }
 
 fn checkVariantListLen(xs: List<CheckVariantSig>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn lastPathSegment(s: String) -> String {
@@ -3806,12 +3785,7 @@ fn pmExhaustivenessWitnessAt(cx: ElabCx, rows: List<List<Int>>, colTys: List<Int
 }
 
 fn pmWitnessesCount(xs: List<String>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn pmPrependWitnesses(prefix: String, ws: List<String>, startSeen: Int) -> List<String> {
@@ -4047,12 +4021,7 @@ fn pmStructFieldsForOwner(env: CheckEnv, owner: String) -> List<CheckFieldSig> {
 }
 
 fn checkFieldListLen(xs: List<CheckFieldSig>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn pmVariantCtor(cx: ElabCx, v: CheckVariantSig, colTy: Int) -> PmCtor {
@@ -4335,21 +4304,11 @@ fn intListConcat(a: List<Int>, b: List<Int>) -> List<Int> {
 }
 
 fn checkListOfRowsLen(xs: List<List<Int>>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 fn checkCtorListLen(xs: List<PmCtor>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }
 
 // =====================================================================

--- a/toolchain/frontend.osty
+++ b/toolchain/frontend.osty
@@ -1760,103 +1760,48 @@ pub fn frontLineHasIndent(units: List<String>, start: Int, end: Int, indent: Int
 }
 
 pub fn frontLexTokenCount(stream: FrontLexStream) -> Int {
-    let mut count = 0
-    for tok in stream.tokens {
-        let _ = tok
-        count = count + 1
-    }
-    count
+    stream.tokens.len()
 }
 
 pub fn frontLexDiagnosticCount(stream: FrontLexStream) -> Int {
-    let mut count = 0
-    for diag in stream.diagnostics {
-        let _ = diag
-        count = count + 1
-    }
-    count
+    stream.diagnostics.len()
 }
 
 pub fn frontCommentCount(stream: FrontLexStream) -> Int {
-    let mut count = 0
-    for comment in stream.comments {
-        let _ = comment
-        count = count + 1
-    }
-    count
+    stream.comments.len()
 }
 
 pub fn frontStringPartCount(stream: FrontLexStream) -> Int {
-    let mut count = 0
-    for part in stream.stringParts {
-        let _ = part
-        count = count + 1
-    }
-    count
+    stream.stringParts.len()
 }
 
 pub fn frontInterpolationTokenCount(stream: FrontLexStream) -> Int {
-    let mut count = 0
-    for token in stream.interpolationTokens {
-        let _ = token
-        count = count + 1
-    }
-    count
+    stream.interpolationTokens.len()
 }
 
 pub fn frontLexTokenAt(stream: FrontLexStream, target: Int) -> FrontLexToken {
-    let mut idx = 0
-    for tok in stream.tokens {
-        if idx == target {
-            return tok
-        }
-        idx = idx + 1
-    }
-    emptyFrontLexToken()
+    if target < 0 || target >= stream.tokens.len() { return emptyFrontLexToken() }
+    stream.tokens[target]
 }
 
 pub fn frontLexDiagnosticAt(stream: FrontLexStream, target: Int) -> FrontLexDiagnostic {
-    let mut idx = 0
-    for diag in stream.diagnostics {
-        if idx == target {
-            return diag
-        }
-        idx = idx + 1
-    }
-    emptyFrontLexDiagnostic()
+    if target < 0 || target >= stream.diagnostics.len() { return emptyFrontLexDiagnostic() }
+    stream.diagnostics[target]
 }
 
 pub fn frontCommentAt(stream: FrontLexStream, target: Int) -> FrontComment {
-    let mut idx = 0
-    for comment in stream.comments {
-        if idx == target {
-            return comment
-        }
-        idx = idx + 1
-    }
-    emptyFrontComment()
+    if target < 0 || target >= stream.comments.len() { return emptyFrontComment() }
+    stream.comments[target]
 }
 
 pub fn frontStringPartAt(stream: FrontLexStream, target: Int) -> FrontStringPart {
-    let mut idx = 0
-    for part in stream.stringParts {
-        if idx == target {
-            return part
-        }
-        idx = idx + 1
-    }
-    emptyFrontStringPart()
+    if target < 0 || target >= stream.stringParts.len() { return emptyFrontStringPart() }
+    stream.stringParts[target]
 }
 
 pub fn frontInterpolationTokenAt(stream: FrontLexStream, target: Int) -> FrontInterpolationToken {
-    let mut idx = 0
-    for token in stream.interpolationTokens {
-        if idx == target {
-            return token
-        }
-        idx = idx + 1
-    }
-    emptyFrontInterpolationToken()
+    if target < 0 || target >= stream.interpolationTokens.len() { return emptyFrontInterpolationToken() }
+    stream.interpolationTokens[target]
 }
 
 pub fn frontendParseLexedSummary(source: String) -> FrontParseSummary {

--- a/toolchain/ir.osty
+++ b/toolchain/ir.osty
@@ -718,21 +718,11 @@ fn irRefreshSemanticCounters(module: IrModule) {
 }
 
 pub fn irScopeCount(semantic: IrSemantic) -> Int {
-    let mut count = 0
-    for scope in semantic.scopes {
-        let _ = scope
-        count = count + 1
-    }
-    count
+    semantic.scopes.len()
 }
 
 pub fn irSymbolCount(semantic: IrSemantic) -> Int {
-    let mut count = 0
-    for symbol in semantic.symbols {
-        let _ = symbol
-        count = count + 1
-    }
-    count
+    semantic.symbols.len()
 }
 
 pub fn irSymbolAt(semantic: IrSemantic, id: Int) -> IrSymbol {
@@ -1013,12 +1003,7 @@ pub fn irSummarize(module: IrModule) -> IrSummary {
 }
 
 pub fn irDiagnosticCount(module: IrModule) -> Int {
-    let mut count = 0
-    for diag in module.diagnostics {
-        let _ = diag
-        count = count + 1
-    }
-    count
+    module.diagnostics.len()
 }
 
 pub fn irChildCount(module: IrModule, idx: Int) -> Int {
@@ -1030,12 +1015,7 @@ pub fn irDeclCount(module: IrModule) -> Int {
 }
 
 pub fn irListCount(items: List<Int>) -> Int {
-    let mut count = 0
-    for item in items {
-        let _ = item
-        count = count + 1
-    }
-    count
+    items.len()
 }
 
 pub fn irInvalidParentCount(module: IrModule) -> Int {

--- a/toolchain/lexer.osty
+++ b/toolchain/lexer.osty
@@ -507,32 +507,16 @@ fn ostyDropSuffixUnits(text: String, count: Int) -> String {
 }
 
 fn ostyLexStringPartCount(parts: List<OstyLexStringPart>) -> Int {
-    let mut count = 0
-    for part in parts {
-        let _ = part
-        count = count + 1
-    }
-    count
+    parts.len()
 }
 
 fn ostyStringListCount(items: List<String>) -> Int {
-    let mut count = 0
-    for item in items {
-        let _ = item
-        count = count + 1
-    }
-    count
+    items.len()
 }
 
 fn ostyStringAt(items: List<String>, target: Int) -> String {
-    let mut idx = 0
-    for item in items {
-        if idx == target {
-            return item
-        }
-        idx = idx + 1
-    }
-    ""
+    if target < 0 || target >= items.len() { return "" }
+    items[target]
 }
 
 // ===================================================================
@@ -573,44 +557,25 @@ fn ostyJoinDocLines(units: List<String>, stream: FrontLexStream, tok: FrontLexTo
 // ===================================================================
 
 pub fn ostyLexResultTokenCount(result: OstyLexResult) -> Int {
-    let mut c = 0
-    for t in result.tokens {
-        let _ = t
-        c = c + 1
-    }
-    c
+    result.tokens.len()
 }
 
 pub fn ostyLexResultErrorCount(result: OstyLexResult) -> Int {
-    let mut c = 0
-    for e in result.errors {
-        let _ = e
-        c = c + 1
-    }
-    c
+    result.errors.len()
 }
 
 pub fn ostyLexResultCommentCount(result: OstyLexResult) -> Int {
-    let mut c = 0
-    for co in result.comments {
-        let _ = co
-        c = c + 1
-    }
-    c
+    result.comments.len()
 }
 
 pub fn ostyLexResultTokenAt(result: OstyLexResult, idx: Int) -> OstyRichToken {
-    let mut i = 0
-    for t in result.tokens {
-        if i == idx {
-            return t
+    if idx < 0 || idx >= result.tokens.len() {
+        return OstyRichToken {
+            kind: FrontEOF, text: "", startOffset: 0, startLine: 0, startCol: 0,
+            endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0,
         }
-        i = i + 1
     }
-    OstyRichToken {
-        kind: FrontEOF, text: "", startOffset: 0, startLine: 0, startCol: 0,
-        endOffset: 0, endLine: 0, endCol: 0, leadingDoc: "", triple: false, partCount: 0,
-    }
+    result.tokens[idx]
 }
 
 // ===================================================================

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -165,12 +165,7 @@ pub fn selfLintResolvedAstSource(
 }
 
 pub fn selfLintDiagnosticCount(report: SelfLintReport) -> Int {
-    let mut count = 0
-    for diag in report.diagnostics {
-        let _ = diag
-        count = count + 1
-    }
-    count
+    report.diagnostics.len()
 }
 
 pub fn selfLintCodeCount(report: SelfLintReport, code: String) -> Int {
@@ -191,12 +186,7 @@ pub fn selfLintFirstDiagnostic(report: SelfLintReport) -> SelfLintDiagnostic {
 }
 
 pub fn selfLintFixCount(diag: SelfLintDiagnostic) -> Int {
-    let mut count = 0
-    for fix in diag.fixes {
-        let _ = fix
-        count = count + 1
-    }
-    count
+    diag.fixes.len()
 }
 
 pub fn selfLintFirstFix(diag: SelfLintDiagnostic) -> SelfLintFix {
@@ -341,23 +331,12 @@ fn selfLintInvalidEdit() -> SelfLintEdit {
 }
 
 fn selfLintEditListCount(edits: List<SelfLintEdit>) -> Int {
-    let mut count = 0
-    for edit in edits {
-        let _ = edit
-        count = count + 1
-    }
-    count
+    edits.len()
 }
 
 fn selfLintEditAt(edits: List<SelfLintEdit>, target: Int) -> SelfLintEdit {
-    let mut idx = 0
-    for edit in edits {
-        if idx == target {
-            return edit
-        }
-        idx = idx + 1
-    }
-    selfLintInvalidEdit()
+    if target < 0 || target >= edits.len() { return selfLintInvalidEdit() }
+    edits[target]
 }
 
 fn selfLintHighestStartEditIndex(edits: List<SelfLintEdit>) -> Int {

--- a/toolchain/lossless_lex.osty
+++ b/toolchain/lossless_lex.osty
@@ -285,12 +285,7 @@ fn losslessLexemeFromUnits(units: List<String>, start: Int, length: Int) -> Stri
 }
 
 fn losslessUnitCountOfList(units: List<String>) -> Int {
-    let mut count = 0
-    for u in units {
-        let _ = u
-        count = count + 1
-    }
-    count
+    units.len()
 }
 
 // -------------------------------------------------------------------
@@ -498,34 +493,17 @@ fn losslessBuildTokens(
 }
 
 fn losslessTriviaCount(trivia: List<LosslessTrivia>) -> Int {
-    let mut count = 0
-    for t in trivia {
-        let _ = t
-        count = count + 1
-    }
-    count
+    trivia.len()
 }
 
 fn losslessStringAt(items: List<String>, target: Int) -> String {
-    let mut idx = 0
-    for item in items {
-        if idx == target {
-            return item
-        }
-        idx = idx + 1
-    }
-    ""
+    if target < 0 || target >= items.len() { return "" }
+    items[target]
 }
 
 fn losslessIntAt(items: List<Int>, target: Int) -> Int {
-    let mut idx = 0
-    for item in items {
-        if idx == target {
-            return item
-        }
-        idx = idx + 1
-    }
-    0
+    if target < 0 || target >= items.len() { return 0 }
+    items[target]
 }
 
 // -------------------------------------------------------------------
@@ -1069,12 +1047,7 @@ pub fn losslessTokenAt(stream: LosslessStream, target: Int) -> LosslessToken {
 }
 
 pub fn losslessDiagnosticCount(stream: LosslessStream) -> Int {
-    let mut c = 0
-    for d in stream.diagnostics {
-        let _ = d
-        c = c + 1
-    }
-    c
+    stream.diagnostics.len()
 }
 
 pub fn losslessLeadingTrivia(stream: LosslessStream, tokenIdx: Int) -> List<LosslessTrivia> {

--- a/toolchain/lossless_lex_test.osty
+++ b/toolchain/lossless_lex_test.osty
@@ -228,12 +228,7 @@ fn testModeStackOnStringToken() {
     }
     testing.assert(stringIdx >= 0)
     let frames = losslessModeStackAt(stream, stringIdx)
-    let mut frameCount = 0
-    for f in frames {
-        let _ = f
-        frameCount = frameCount + 1
-    }
-    testing.assertEq(frameCount, 1)
+    testing.assertEq(frames.len(), 1)
     let _ = tokenCount
 }
 
@@ -331,12 +326,7 @@ fn testCompatBridgeTokenKinds() {
     let stream = losslessLex(src)
     let fronts = losslessToFrontTokens(stream)
     let losslessCount = losslessTokenCount(stream)
-    let mut bridgeCount = 0
-    for t in fronts {
-        let _ = t
-        bridgeCount = bridgeCount + 1
-    }
-    testing.assertEq(losslessCount, bridgeCount)
+    testing.assertEq(losslessCount, fronts.len())
 }
 
 // -------------------------------------------------------------------

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -2149,28 +2149,22 @@ pub fn astParse(source: String) -> AstFile {
 pub fn astParseSummary(source: String) -> FrontParseSummary { let file = astParse(source)
 astCountSummary(file) }
 
-pub fn astFileDeclCount(file: AstFile) -> Int { let mut c = 0
-for d in file.arena.decls { let _ = d
-c = c + 1 }
-c }
+pub fn astFileDeclCount(file: AstFile) -> Int { file.arena.decls.len() }
 pub fn astFileNodeCount(file: AstFile) -> Int { astArenaNodeCount(file.arena) }
-pub fn astFileErrorCount(file: AstFile) -> Int { let mut c = 0
-for e in file.arena.errors { let _ = e
-c = c + 1 }
-c }
+pub fn astFileErrorCount(file: AstFile) -> Int { file.arena.errors.len() }
 
 pub fn astFileDeclAt(file: AstFile, idx: Int) -> AstNode {
-    let mut i = 0
-    for d in file.arena.decls { if i == idx { return astArenaNodeAt(file.arena, d) }
-    i = i + 1 }
-    emptyAstNode(AstNError)
+    if idx < 0 || idx >= file.arena.decls.len() {
+        return emptyAstNode(AstNError)
+    }
+    astArenaNodeAt(file.arena, file.arena.decls[idx])
 }
 
 pub fn astFileErrorAt(file: AstFile, idx: Int) -> AstParseError {
-    let mut i = 0
-    for e in file.arena.errors { if i == idx { return e }
-    i = i + 1 }
-    AstParseError { message: "", tokenIndex: 0, hint: "", note: "", code: "" }
+    if idx < 0 || idx >= file.arena.errors.len() {
+        return AstParseError { message: "", tokenIndex: 0, hint: "", note: "", code: "" }
+    }
+    file.arena.errors[idx]
 }
 
 pub fn astCountNodeKind(file: AstFile, kind: AstNodeKind) -> Int { let mut c = 0

--- a/toolchain/pipeline.osty
+++ b/toolchain/pipeline.osty
@@ -88,12 +88,7 @@ pub fn toolchainPipelineBlockingErrorCount(report: ToolchainPipelineReport) -> I
 }
 
 fn toolchainPipelineSymbolCount(result: SelfResolveResult) -> Int {
-    let mut count = 0
-    for symbol in result.symbols {
-        let _ = symbol
-        count = count + 1
-    }
-    count
+    result.symbols.len()
 }
 
 fn toolchainPipelineDiagnosticOutput(

--- a/toolchain/pkgmgr.osty
+++ b/toolchain/pkgmgr.osty
@@ -379,12 +379,7 @@ pub fn selfPkgMarshalLock(packages: List<SelfPkgLockPackage>) -> String {
 }
 
 fn selfPkgLockDependencyCount(dependencies: List<SelfPkgLockDependency>) -> Int {
-    let mut count = 0
-    for dep in dependencies {
-        let _ = dep
-        count = count + 1
-    }
-    count
+    dependencies.len()
 }
 
 /// selfPkgSortLockPackages sorts by name then version text.
@@ -722,12 +717,7 @@ fn selfPkgFirstUnits(text: String, limit: Int) -> String {
 }
 
 fn selfPkgStringUnitCount(text: String) -> Int {
-    let mut count = 0
-    for unit in pkgStrings.split(text, "") {
-        let _ = unit
-        count = count + 1
-    }
-    count
+    pkgStrings.split(text, "").len()
 }
 
 /// selfPkgLockChange constructs a lock diff item.
@@ -924,32 +914,17 @@ pub fn selfPkgGraphNode(
 
 /// selfPkgGraphErrorCount counts graph errors.
 pub fn selfPkgGraphErrorCount(graph: SelfPkgGraph) -> Int {
-    let mut count = 0
-    for item in graph.errors {
-        let _ = item
-        count = count + 1
-    }
-    count
+    graph.errors.len()
 }
 
 /// selfPkgGraphNodeCount counts graph nodes.
 pub fn selfPkgGraphNodeCount(graph: SelfPkgGraph) -> Int {
-    let mut count = 0
-    for item in graph.nodes {
-        let _ = item
-        count = count + 1
-    }
-    count
+    graph.nodes.len()
 }
 
 /// selfPkgGraphOrderCount counts ordered graph node names.
 pub fn selfPkgGraphOrderCount(graph: SelfPkgGraph) -> Int {
-    let mut count = 0
-    for item in graph.order {
-        let _ = item
-        count = count + 1
-    }
-    count
+    graph.order.len()
 }
 
 fn emptySelfPkgGraphNode() -> SelfPkgGraphNode {
@@ -1243,10 +1218,5 @@ fn selfPkgLastPathSegment(path: String) -> String {
 }
 
 fn selfPkgStringListCount(items: List<String>) -> Int {
-    let mut count = 0
-    for item in items {
-        let _ = item
-        count = count + 1
-    }
-    count
+    items.len()
 }

--- a/toolchain/profile_flags_test.osty
+++ b/toolchain/profile_flags_test.osty
@@ -52,31 +52,16 @@ fn testParseFeatureListDropsEmpty() {
 
 fn testParseFeatureListEmptyInputReturnsEmpty() {
     let feats = parseFeatureList("")
-    let mut count = 0
-    for f in feats {
-        let _ = f
-        count = count + 1
-    }
-    testing.assertEq(count, 0)
+    testing.assertEq(feats.len(), 0)
 }
 
 fn testParseFeatureListSingleElement() {
     let feats = parseFeatureList("a")
     testing.assertEq(feats[0], "a")
-    let mut count = 0
-    for f in feats {
-        let _ = f
-        count = count + 1
-    }
-    testing.assertEq(count, 1)
+    testing.assertEq(feats.len(), 1)
 }
 
 fn testParseFeatureListWhitespaceOnlyIsEmpty() {
     let feats = parseFeatureList("  ")
-    let mut count = 0
-    for f in feats {
-        let _ = f
-        count = count + 1
-    }
-    testing.assertEq(count, 0)
+    testing.assertEq(feats.len(), 0)
 }

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -136,12 +136,7 @@ pub fn selfResolveAstFile(file: AstFile) -> SelfResolveResult {
 }
 
 pub fn selfResolveDiagnosticCount(result: SelfResolveResult) -> Int {
-    let mut count = 0
-    for diag in result.diagnostics {
-        let _ = diag
-        count = count + 1
-    }
-    count
+    result.diagnostics.len()
 }
 
 pub fn selfResolveCodeCount(result: SelfResolveResult, code: String) -> Int {
@@ -1524,45 +1519,22 @@ fn srAstNode(file: AstFile, idx: Int) -> AstNode {
 }
 
 fn srAstChildAt(children: List<Int>, target: Int) -> Int {
-    let mut idx = 0
-    for child in children {
-        if idx == target {
-            return child
-        }
-        idx = idx + 1
-    }
-    -1
+    if target < 0 || target >= children.len() { return -1 }
+    children[target]
 }
 
 fn srAstListCount(items: List<Int>) -> Int {
-    let mut count = 0
-    for item in items {
-        let _ = item
-        count = count + 1
-    }
-    count
+    items.len()
 }
 
 fn srIntListAt(items: List<Int>, target: Int) -> Int {
-    let mut idx = 0
-    for item in items {
-        if idx == target {
-            return item
-        }
-        idx = idx + 1
-    }
-    -1
+    if target < 0 || target >= items.len() { return -1 }
+    items[target]
 }
 
 fn srStringListAt(items: List<String>, target: Int) -> String {
-    let mut idx = 0
-    for item in items {
-        if idx == target {
-            return item
-        }
-        idx = idx + 1
-    }
-    ""
+    if target < 0 || target >= items.len() { return "" }
+    items[target]
 }
 
 fn srSymbolListCopy(items: List<SelfSymbol>) -> List<SelfSymbol> {

--- a/toolchain/semver_parse.osty
+++ b/toolchain/semver_parse.osty
@@ -203,12 +203,7 @@ pub fn allAsciiDigits(text: String) -> Bool {
 
 /// stringUnitCount counts ASCII-oriented split units.
 pub fn stringUnitCount(text: String) -> Int {
-    let mut count = 0
-    for unit in strings.split(text, "") {
-        let _ = unit
-        count = count + 1
-    }
-    count
+    strings.split(text, "").len()
 }
 
 /// isSemIdentUnit accepts the SemVer identifier character class.

--- a/toolchain/solve.osty
+++ b/toolchain/solve.osty
@@ -391,10 +391,5 @@ pub fn checkGenericBoundSatisfied(env: CheckEnv, solver: Solver, concreteTy: Int
 }
 
 fn solveIntLen(xs: List<Int>) -> Int {
-    let mut n = 0
-    for x in xs {
-        let _ = x
-        n = n + 1
-    }
-    n
+    xs.len()
 }


### PR DESCRIPTION
## Summary

- Extend #459's pattern (hand-rolled List count/index scans → `.len()` / `[idx]`) from the 4 parser-hot-path files to the remaining 19 toolchain `.osty` files plus 35 more sibling functions in `generated.go`.
- Every checker, linter, docgen, pkgmgr, and lossless-lex helper that computed its own length or indexed by linear scan was still O(N), so the combined end-to-end was O(N²) even after #459.

## Why

#459 only patched `astArenaNodeCount/At`, `coreArenaNodeCount/At`, `frontTokenListCount/At`, `frontLex*At`, `opErrorCount`, `opIntList*`. The same pattern — `let mut c = 0; for x in xs { let _ = x; c = c + 1 }` and `let mut i = 0; for x in xs { if i == target { return x } i = i + 1 }` — was still present in 21 other files across the toolchain, both for Int/String lists and for lex-stream `*Count` variants that #459 explicitly left slow. This PR closes that gap.

## What changed

- **Osty sources (21 files, 54 helpers)**: rewrite pure len/at helpers to use `xs.len()` / bounds-checked `xs[i]`. Files: `ast_lower`, `check`, `check_diag`, `ci`, `core`, `core_test`, `docgen`, `elab`, `frontend` (lex-stream `*Count` added to the fast path), `ir`, `lexer`, `lint`, `lossless_lex`, `lossless_lex_test`, `parser` (tail helpers), `pipeline`, `pkgmgr`, `profile_flags_test`, `resolve`, `semver_parse`, `solve`.
- **`internal/selfhost/gen_selfhost.go`**: add 35 new entries to the `patchGenerated` replacement table so the next bootstrap regen keeps the O(1) forms.
- **`internal/selfhost/generated.go`**: mirror the same 35 replacements directly, same policy as #459 — the shipping Go bridge picks up the fix without waiting on a regen.

## Verification

- `just front`: `internal/check` drops **9.265s → 7.485s (~20%)** on a warm machine; `internal/diag` drops **2.4s → 1.5s**. All green.
- `go test -count=1 ./internal/selfhost/...`: passes.
- `gofmt` / `go vet`: clean.

Net diff: **+482 / −1554** lines — mostly deletions as hand-rolled loops collapse to intrinsic calls.

## Test plan

- [ ] CI `just prepush` / `just full` passes
- [ ] No regression in the native checker walls tracked by `TestProbeNativeToolchainMerged`
- [ ] Reviewer spot-checks that replacement bodies match Osty semantics (sentinel for out-of-range indices preserved: `-1` for Int, `""` for String, typed empty for node kinds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)