### PR TITLE
chore(selfhost): normalize per-decl source-map paths in generated.go

### DIFF
--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -252,14 +252,35 @@ func patchGenerated(path string) error {
 	return nil
 }
 
+// normalizeGeneratedSourceComment rewrites both the top-level
+// `// Osty source: …` header and the per-declaration
+// `// Osty: …selfhost_merged.osty:LINE:COL` markers so the generated
+// file is byte-stable across platforms. Without this pass the source
+// paths inherit the host tmpdir — `/var/folders/…` on macOS,
+// `C:\Users\…\AppData\Local\Temp\…` on Windows — producing a ~thousand-
+// line diff on every cross-platform regen. The canonical placeholder is
+// `/tmp/selfhost_merged.osty`; line/column suffixes are preserved.
 func normalizeGeneratedSourceComment(src string) string {
-	const prefix = "// Osty source: "
+	const (
+		topPrefix  = "// Osty source: "
+		declPrefix = "// Osty: "
+		mergedFile = "selfhost_merged.osty"
+		canonical  = "/tmp/" + mergedFile
+	)
 	lines := strings.Split(src, "\n")
 	for i, line := range lines {
-		if strings.HasPrefix(line, prefix) && strings.HasSuffix(line, "selfhost_merged.osty") {
-			lines[i] = prefix + "/tmp/selfhost_merged.osty"
-			break
+		if strings.HasPrefix(line, topPrefix) && strings.HasSuffix(line, mergedFile) {
+			lines[i] = topPrefix + canonical
+			continue
 		}
+		if !strings.HasPrefix(line, declPrefix) {
+			continue
+		}
+		idx := strings.Index(line, mergedFile)
+		if idx < 0 {
+			continue
+		}
+		lines[i] = declPrefix + canonical + line[idx+len(mergedFile):]
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary

- `normalizeGeneratedSourceComment` only rewrote the top-level `// Osty source: …` header; the ~1400 per-decl `// Osty: …selfhost_merged.osty:LINE:COL` markers stayed at the raw tmpdir the host produced.
- Because bootstrap-gen uses `os.MkdirTemp` (`/var/folders/…` on macOS, `C:\Users\…\AppData\Local\Temp\…` on Windows), every cross-platform `go generate ./internal/selfhost` run emits ~1400 spurious diff lines against committed output — blocking contributions from anyone not on the host that produced the committed regen.
- Extend the normalization pass to rewrite both top-level and per-decl comments to a canonical `/tmp/selfhost_merged.osty[:LINE:COL]` form. Line/column suffixes are preserved so the markers remain useful as source-map anchors.

## Context

Discovered while trying to add a checker signature for `Map.getOr` (Tier A-2 Phase 1). A `go generate ./internal/selfhost` on Windows produced ~42k-line diff purely from source-map path noise, which made it impossible to land a small `toolchain/check_env.osty` edit as a reviewable change.

This PR is the narrow, no-behavior-change prerequisite. It unblocks future Tier A-2 work (registering Osty-bodied collection helpers like `getOr`, `update`, `mergeWith`, `retainIf`, `mapValues` in the self-hosted checker) so the actual signature-addition diffs stay small.

## Out of scope (deferred)

While investigating, I noticed committed `internal/selfhost/generated.go` has independent drift relative to current `toolchain/*.osty` — a fresh regen also picks up new stdlib symbols (`ostyStringsConcat`, `ostyStringsChars`), a new `FrontLexDiagnosticCode_FrontDiagBadNumericSeparator` enum variant, and bootstrap-gen's integer-overflow-guard simplification. A straight regen on top of this PR triggers two latent test failures (`TestRuntimeFixtureUsesRuntimeRawStdlib`, `TestFormatUseCRoundTrips`) that existed in the raw regen output even without my `check_env.osty` edit. Those are unrelated to this change and belong in a separate "catch up generated.go drift" PR — likely needing the macOS maintainer since that's where the committed baseline was produced.

## Test plan

- [x] `just front` — all packages green
- [x] Local regen on Windows now produces `/tmp/selfhost_merged.osty:…` markers (confirmed via `head -3 internal/selfhost/generated.go`)
- [ ] (reviewer) regen on macOS should also produce the same canonical markers; committed file should become byte-stable across hosts once re-generated through this new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)