### PR TITLE
feat(llvmgen): real Map intrinsics + per-map lock + snapshot iteration

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -70,6 +70,14 @@ typedef struct osty_rt_map {
     osty_rt_trace_slot_fn value_trace;
     unsigned char *keys;
     unsigned char *values;
+    // Per-map recursive mutex. Guarantees that all public map ops are
+    // mutually exclusive on a single instance so concurrent mutation
+    // can't realloc the slot arrays mid-read, drop the len mid-walk,
+    // or interleave an insert's memmove. Recursive so that `update`
+    // callbacks that touch the same map from within the lock don't
+    // self-deadlock.
+    pthread_mutex_t mu;
+    int mu_init;
 } osty_rt_map;
 
 typedef struct osty_rt_set {
@@ -448,6 +456,10 @@ static void osty_rt_map_destroy(void *payload) {
     if (map != NULL) {
         free(map->keys);
         free(map->values);
+        if (map->mu_init) {
+            pthread_mutex_destroy(&map->mu);
+            map->mu_init = 0;
+        }
     }
 }
 
@@ -1659,7 +1671,37 @@ void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, 
     map->value_kind = value_kind;
     map->value_size = (size_t)value_size;
     map->value_trace = value_trace;
+    {
+        pthread_mutexattr_t attr;
+        if (pthread_mutexattr_init(&attr) != 0) {
+            osty_rt_abort("map lock: mutexattr_init failed");
+        }
+        if (pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) != 0) {
+            osty_rt_abort("map lock: mutexattr_settype failed");
+        }
+        if (pthread_mutex_init(&map->mu, &attr) != 0) {
+            osty_rt_abort("map lock: mutex_init failed");
+        }
+        pthread_mutexattr_destroy(&attr);
+        map->mu_init = 1;
+    }
     return map;
+}
+
+// Public lock/unlock for composite ops (update) that must hold the
+// lock across get + callback + insert. Recursive mutex so calls from
+// a user callback into the same map (e.g. counts.len()) re-acquire
+// instead of self-deadlocking.
+void osty_rt_map_lock(void *raw_map) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    if (map == NULL || !map->mu_init) return;
+    pthread_mutex_lock(&map->mu);
+}
+
+void osty_rt_map_unlock(void *raw_map) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    if (map == NULL || !map->mu_init) return;
+    pthread_mutex_unlock(&map->mu);
 }
 
 static bool osty_rt_map_contains_raw(void *raw_map, const void *key) {
@@ -1720,12 +1762,53 @@ static void osty_rt_map_get_or_abort_raw(void *raw_map, const void *key, void *o
     memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
 }
 
+// Option-returning get: fills *out_value and returns true when the key
+// is present, returns false otherwise (and leaves out_value untouched).
+// This is the real intrinsic backing `Map.get(key) -> V?` — callers at
+// the LLVM layer use the return to construct an Option<V>, then feed
+// it into `??`, `match`, `.isSome()`, etc. without needing per-helper
+// special-case lowering.
+static bool osty_rt_map_get_raw(void *raw_map, const void *key, void *out_value) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    int64_t index;
+    if (map == NULL || key == NULL || out_value == NULL) {
+        return false;
+    }
+    index = osty_rt_map_find_index(map, key);
+    if (index < 0) {
+        return false;
+    }
+    memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
+    return true;
+}
+
+// Value-at-slot (V-type-agnostic): memcpy the V stored at slot i
+// into *out_value. Backs the for-(k, v)-in-m iteration path — key
+// accessors are macro-generated per K suffix below.
+void osty_rt_map_value_at(void *raw_map, int64_t index, void *out_value) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    if (map == NULL || out_value == NULL) {
+        osty_rt_abort("invalid map value_at");
+    }
+    osty_rt_map_lock(raw_map);
+    if (index < 0 || index >= map->len) {
+        osty_rt_map_unlock(raw_map);
+        osty_rt_abort("map value_at index out of bounds");
+    }
+    memcpy(out_value, osty_rt_map_value_slot(map, index), map->value_size);
+    osty_rt_map_unlock(raw_map);
+}
+
 int64_t osty_rt_map_len(void *raw_map) {
     osty_rt_map *map = (osty_rt_map *)raw_map;
+    int64_t n;
     if (map == NULL) {
         osty_rt_abort("map is null");
     }
-    return map->len;
+    osty_rt_map_lock(raw_map);
+    n = map->len;
+    osty_rt_map_unlock(raw_map);
+    return n;
 }
 
 void *osty_rt_map_keys(void *raw_map) {
@@ -1735,6 +1818,7 @@ void *osty_rt_map_keys(void *raw_map) {
     if (map == NULL) {
         osty_rt_abort("map is null");
     }
+    osty_rt_map_lock(raw_map);
     for (i = 0; i < map->len; i++) {
         switch (map->key_kind) {
         case OSTY_RT_ABI_I64: {
@@ -1766,14 +1850,60 @@ void *osty_rt_map_keys(void *raw_map) {
             osty_rt_abort("unsupported map key list kind");
         }
     }
+    osty_rt_map_unlock(raw_map);
     return out;
 }
 
+// Every public keyed op takes the per-map lock, runs the raw op, and
+// releases. Recursive so that `update`'s outer lock + a re-entrant op
+// from a user callback (e.g. counts.len() inside f) don't deadlock.
+// key_at snapshots the key under the lock — the return is by-value so
+// the caller doesn't hold any reference past unlock.
 #define OSTY_RT_DEFINE_MAP_KEY_OPS(suffix, ctype) \
-bool osty_rt_map_contains_##suffix(void *raw_map, ctype key) { return osty_rt_map_contains_raw(raw_map, &key); } \
-void osty_rt_map_insert_##suffix(void *raw_map, ctype key, const void *value) { osty_rt_map_insert_raw(raw_map, &key, value); } \
-bool osty_rt_map_remove_##suffix(void *raw_map, ctype key) { return osty_rt_map_remove_raw(raw_map, &key); } \
-void osty_rt_map_get_or_abort_##suffix(void *raw_map, ctype key, void *out_value) { osty_rt_map_get_or_abort_raw(raw_map, &key, out_value); }
+bool osty_rt_map_contains_##suffix(void *raw_map, ctype key) { \
+    bool r; \
+    osty_rt_map_lock(raw_map); \
+    r = osty_rt_map_contains_raw(raw_map, &key); \
+    osty_rt_map_unlock(raw_map); \
+    return r; \
+} \
+void osty_rt_map_insert_##suffix(void *raw_map, ctype key, const void *value) { \
+    osty_rt_map_lock(raw_map); \
+    osty_rt_map_insert_raw(raw_map, &key, value); \
+    osty_rt_map_unlock(raw_map); \
+} \
+bool osty_rt_map_remove_##suffix(void *raw_map, ctype key) { \
+    bool r; \
+    osty_rt_map_lock(raw_map); \
+    r = osty_rt_map_remove_raw(raw_map, &key); \
+    osty_rt_map_unlock(raw_map); \
+    return r; \
+} \
+void osty_rt_map_get_or_abort_##suffix(void *raw_map, ctype key, void *out_value) { \
+    osty_rt_map_lock(raw_map); \
+    osty_rt_map_get_or_abort_raw(raw_map, &key, out_value); \
+    osty_rt_map_unlock(raw_map); \
+} \
+bool osty_rt_map_get_##suffix(void *raw_map, ctype key, void *out_value) { \
+    bool r; \
+    osty_rt_map_lock(raw_map); \
+    r = osty_rt_map_get_raw(raw_map, &key, out_value); \
+    osty_rt_map_unlock(raw_map); \
+    return r; \
+} \
+ctype osty_rt_map_key_at_##suffix(void *raw_map, int64_t index) { \
+    osty_rt_map *map = (osty_rt_map *)raw_map; \
+    ctype out; \
+    if (map == NULL) osty_rt_abort("map is null"); \
+    osty_rt_map_lock(raw_map); \
+    if (index < 0 || index >= map->len) { \
+        osty_rt_map_unlock(raw_map); \
+        osty_rt_abort("map key_at out of bounds"); \
+    } \
+    memcpy(&out, osty_rt_map_key_slot(map, index), sizeof(ctype)); \
+    osty_rt_map_unlock(raw_map); \
+    return out; \
+}
 
 OSTY_RT_DEFINE_MAP_KEY_OPS(i64, int64_t)
 OSTY_RT_DEFINE_MAP_KEY_OPS(i1, bool)

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2792,6 +2792,14 @@ func (g *generator) emitMapMethodCall(call *ast.CallExpr) (value, bool, error) {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, 0", cmp, lenVal.name))
 		g.takeOstyEmitter(emitter)
 		return value{typ: "i1", ref: cmp}, true, nil
+	case "get":
+		return g.emitMapGet(call, base, keyTyp, keyString)
+	case "getOr":
+		return g.emitMapGetOr(call, base, keyTyp, keyString)
+	case "mergeWith":
+		return g.emitMapMergeWith(call, base, keyTyp, keyString)
+	case "mapValues":
+		return g.emitMapMapValues(call, base, keyTyp, keyString)
 	case "containsKey":
 		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 			return value{}, true, unsupported("call", "map.containsKey requires one positional argument")
@@ -2850,6 +2858,540 @@ func (g *generator) emitMapMethodCall(call *ast.CallExpr) (value, bool, error) {
 	default:
 		return value{}, false, nil
 	}
+}
+
+// mapScalarValueByteSize returns the GC-alloc byte size for a scalar V
+// box used by `Map.get` / `Map.getOr` when V is not already ptr. Only
+// the set of V types supported by the map-key runtime macros is
+// recognised; anything else routes to the unsupported diagnostic.
+func mapScalarValueByteSize(valTyp string) (int, bool) {
+	switch valTyp {
+	case "i64", "double":
+		return 8, true
+	case "i1":
+		return 1, true
+	}
+	return 0, false
+}
+
+// emitMapGet lowers `m.get(key) -> V?` as the real Option-returning
+// intrinsic. This replaces the "contains + get_or_abort" special cases
+// that every bodied helper used to reimplement, so once `get` lands,
+// stdlib bodies like `self.get(key) ?? default` (getOr) and
+// `self.get(key).isSome()` (containsKey) can compose naturally.
+//
+// ABI: the C runtime helper is
+//   bool osty_rt_map_get_<K>(void *map, K key, void *out_slot)
+// It returns true and memcpys V into *out_slot when the key is present;
+// otherwise returns false and leaves *out_slot alone.
+//
+// Option<V> at the LLVM layer is always a ptr:
+//   - V = ptr  →  the map value slot holds a pointer; we pre-zero the
+//                 slot and rely on `load ptr` producing null on miss and
+//                 the stored payload on hit. No branch needed.
+//   - V = scalar (i64 / i1 / double) →  GC-alloc a box in the present
+//                 branch and phi ptr-to-box vs null. Matches the
+//                 boxed-Option ABI consumed by `??`.
+func (g *generator) emitMapGet(call *ast.CallExpr, base value, keyTyp string, keyString bool) (value, bool, error) {
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, true, unsupported("call", "map.get requires one positional argument")
+	}
+	key, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	if key.typ != keyTyp {
+		return value{}, true, unsupportedf("type-system", "map.get key type %s, want %s", key.typ, keyTyp)
+	}
+	loadedKey, err := g.loadIfPointer(key)
+	if err != nil {
+		return value{}, true, err
+	}
+	out, err := g.emitMapGetCore(base, loadedKey, keyTyp, keyString)
+	if err != nil {
+		return value{}, true, err
+	}
+	return out, true, nil
+}
+
+// emitMapGetCore is the pre-emitted-args variant of emitMapGet. Used
+// by getOr/update which already lowered the base and key and need to
+// reuse the same Option<V> materialisation without re-evaluating the
+// receiver expression.
+func (g *generator) emitMapGetCore(base value, loadedKey value, keyTyp string, keyString bool) (value, error) {
+	getSym := mapRuntimeGetSymbol(keyTyp, keyString)
+	g.declareRuntimeSymbol(getSym, "i1", []paramInfo{{typ: "ptr"}, {typ: keyTyp}, {typ: "ptr"}})
+
+	valTyp := base.mapValueTyp
+	if valTyp == "ptr" {
+		// Fast path: V is already ptr. Pre-zero the slot so a miss
+		// produces null (= None), a hit overwrites with the payload
+		// ptr (= Some). No branch needed.
+		emitter := g.toOstyEmitter()
+		slot := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr", slot))
+		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr null, ptr %s", slot))
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  %s = call i1 @%s(%s)",
+			llvmNextTemp(emitter),
+			getSym,
+			llvmCallArgs([]*LlvmValue{toOstyValue(base), toOstyValue(loadedKey), {typ: "ptr", name: slot}}),
+		))
+		out := g.loadValueFromAddress(emitter, "ptr", slot)
+		g.takeOstyEmitter(emitter)
+		out.gcManaged = true
+		out.rootPaths = g.rootPathsForType("ptr")
+		return out, nil
+	}
+
+	byteSize, ok := mapScalarValueByteSize(valTyp)
+	if !ok {
+		return value{}, unsupportedf(
+			"call",
+			"map.get on Map<%s, %s>: Option<%s> lowering not yet wired for this V (scalar V supports i64/i1/double; V=ptr is direct)",
+			keyTyp, valTyp, valTyp,
+		)
+	}
+
+	// Scalar V: alloca temp slot, call helper, branch on present.
+	//   present=true  → GC-alloc a V-sized box, copy slot→box, Some = box ptr
+	//   present=false → null ptr (None)
+	// Merged via phi at end; result is the boxed-Option ptr consumed
+	// unchanged by ?? / match / .isSome().
+	emitter := g.toOstyEmitter()
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, valTyp))
+	present := llvmCall(emitter, "i1", getSym, []*LlvmValue{
+		toOstyValue(base),
+		toOstyValue(loadedKey),
+		{typ: "ptr", name: slot},
+	})
+	labels := llvmIfExprStart(emitter, present)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	// Present branch: GC-alloc box + copy payload.
+	emitter = g.toOstyEmitter()
+	box := llvmGcAlloc(emitter, 1, byteSize, "map.get.box."+valTyp)
+	payload := llvmLoad(emitter, &LlvmValue{typ: valTyp, name: slot, pointer: true})
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", valTyp, payload.name, box.name))
+	g.takeOstyEmitter(emitter)
+	g.needsGCRuntime = true
+	someVal := value{typ: "ptr", ref: box.name, gcManaged: true}
+	thenPred := g.currentBlock
+
+	// Absent branch: null ptr.
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	noneVal := value{typ: "ptr", ref: "null"}
+	elsePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, thenPred, elsePred, someVal, noneVal)
+	if err != nil {
+		return value{}, err
+	}
+	out.gcManaged = true
+	out.rootPaths = g.rootPathsForType("ptr")
+	return out, nil
+}
+
+// emitMapIterate emits a snapshot-based walk: it first calls
+// `osty_rt_map_keys(m)` to freeze the K set at the moment of the call
+// (that runtime helper copies all current keys into a fresh List<K>
+// under the per-map lock), then iterates that list, calling
+// `m.get(k)` per key to fetch the current V. If the key was removed
+// by a concurrent mutator since the snapshot, get returns None and
+// the body is skipped; if the value was replaced, body sees the new
+// V. This is the weakly-consistent iteration semantics (a la Go's
+// sync.Map.Range): no out-of-bounds panic under mutation, no
+// guarantee of seeing entries added after the snapshot.
+//
+// `labelPrefix` keeps temp names distinct when callers compose
+// multiple iterations back-to-back. body MUST handle the case where
+// iterating over self while self is mutated (e.g. retainIf collects
+// victim keys and defers removal to a second pass).
+func (g *generator) emitMapIterate(mapVal value, keyTyp, valTyp string, keyString bool, labelPrefix string, body func(k, v value) error) error {
+	// Snapshot keys under the per-map lock — this returns a
+	// freshly-allocated List<K>.
+	g.declareRuntimeSymbol(mapRuntimeKeysSymbol(), "ptr", []paramInfo{{typ: "ptr"}})
+	mapLoaded, err := g.loadIfPointer(mapVal)
+	if err != nil {
+		return err
+	}
+	emitter := g.toOstyEmitter()
+	keysList := llvmCall(emitter, "ptr", mapRuntimeKeysSymbol(), []*LlvmValue{toOstyValue(mapLoaded)})
+	g.takeOstyEmitter(emitter)
+	keysVal := fromOstyValue(keysList)
+	keysVal.gcManaged = true
+	keysVal.listElemTyp = keyTyp
+	keysVal.listElemString = keyString
+	keysVal = g.protectManagedTemporary(labelPrefix+".keys", keysVal)
+
+	g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+	keysLoaded, err := g.loadIfPointer(keysVal)
+	if err != nil {
+		return err
+	}
+	emitter = g.toOstyEmitter()
+	keysLen := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(keysLoaded)})
+	loop := llvmRangeStart(emitter, labelPrefix+"_i", llvmIntLiteral(0), keysLen, false)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.bodyLabel)
+	cont := g.nextNamedLabel(labelPrefix + ".cont")
+	g.pushLoop(loopContext{continueLabel: cont, breakLabel: loop.endLabel, scopeDepth: len(g.locals)})
+
+	keysLoaded, err = g.loadIfPointer(keysVal)
+	if err != nil {
+		g.popLoop()
+		return err
+	}
+	mapLoaded, err = g.loadIfPointer(mapVal)
+	if err != nil {
+		g.popLoop()
+		return err
+	}
+
+	// k = keysList[i]
+	listGetSym := listRuntimeGetSymbol(keyTyp)
+	g.declareRuntimeSymbol(listGetSym, keyTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter = g.toOstyEmitter()
+	kCall := llvmCall(emitter, keyTyp, listGetSym, []*LlvmValue{toOstyValue(keysLoaded), llvmI64(loop.current)})
+	g.takeOstyEmitter(emitter)
+	kVal := fromOstyValue(kCall)
+	kVal.gcManaged = keyTyp == "ptr"
+	kVal.rootPaths = g.rootPathsForType(keyTyp)
+
+	// opt_v = map.get(k) — returns Option<V> (ptr). If null, the key
+	// was removed between snapshot and here; skip the body.
+	kLoaded, err := g.loadIfPointer(kVal)
+	if err != nil {
+		g.popLoop()
+		return err
+	}
+	optV, err := g.emitMapGetCore(mapVal, kLoaded, keyTyp, keyString)
+	if err != nil {
+		g.popLoop()
+		return err
+	}
+	// if opt is null → skip; else → unwrap and run body.
+	emitter = g.toOstyEmitter()
+	isNil := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, optV.ref))
+	labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
+	g.takeOstyEmitter(emitter)
+	// then = none (skip)
+	g.currentBlock = labels.thenLabel
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	// else = some (body)
+	g.currentBlock = labels.elseLabel
+	var vUnwrapped value
+	if valTyp == "ptr" {
+		vUnwrapped = optV
+	} else {
+		emitter = g.toOstyEmitter()
+		payload := llvmLoad(emitter, &LlvmValue{typ: valTyp, name: optV.ref, pointer: true})
+		g.takeOstyEmitter(emitter)
+		vUnwrapped = value{typ: valTyp, ref: payload.name}
+	}
+	vUnwrapped.gcManaged = valTyp == "ptr"
+	vUnwrapped.rootPaths = g.rootPathsForType(valTyp)
+
+	if err := body(kVal, vUnwrapped); err != nil {
+		g.popLoop()
+		return err
+	}
+
+	// Merge branches at labels.endLabel.
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.endLabel
+
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(cont)
+	}
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", cont))
+	g.emitGCSafepoint(emitter)
+	llvmRangeEnd(emitter, loop)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.endLabel)
+	return nil
+}
+
+// emitMapNewFor constructs an empty map with the given K/V types,
+// wiring the ABI kind tags + value size + GC trace callback exactly
+// like the `{:}` literal path.
+func (g *generator) emitMapNewFor(keyTyp, valTyp string, keyString bool) (value, error) {
+	traceSymbol := g.traceCallbackSymbol(valTyp, g.rootPathsForType(valTyp))
+	g.declareRuntimeSymbol(mapRuntimeNewSymbol(), "ptr", []paramInfo{{typ: "i64"}, {typ: "i64"}, {typ: "i64"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	valueSize := g.emitTypeSize(emitter, valTyp)
+	out := llvmCall(emitter, "ptr", mapRuntimeNewSymbol(), []*LlvmValue{
+		llvmI64(strconv.Itoa(containerAbiKind(keyTyp, keyString))),
+		llvmI64(strconv.Itoa(containerAbiKind(valTyp, false))),
+		valueSize,
+		{typ: "ptr", name: llvmPointerOperand(traceSymbol)},
+	})
+	g.takeOstyEmitter(emitter)
+	mapValue := fromOstyValue(out)
+	mapValue.gcManaged = true
+	mapValue.mapKeyTyp = keyTyp
+	mapValue.mapValueTyp = valTyp
+	mapValue.mapKeyString = keyString
+	mapValue.rootPaths = g.rootPathsForType("ptr")
+	return mapValue, nil
+}
+
+// emitMapMergeWith lowers `m.mergeWith(other, combine) -> Map<K, V>`.
+// Stdlib bodied form: `out = {:}; copy self; for other entries either
+// insert or combine(existing, v) + insert`. All three operations
+// compose on the intrinsic stack (map iter + map get + map insert +
+// fn-value indirect call).
+func (g *generator) emitMapMergeWith(call *ast.CallExpr, base value, keyTyp string, keyString bool) (value, bool, error) {
+	if len(call.Args) != 2 ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, true, unsupported("call", "map.mergeWith requires two positional arguments")
+	}
+	valTyp := base.mapValueTyp
+	other, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	if other.typ != "ptr" || other.mapKeyTyp != keyTyp || other.mapValueTyp != valTyp {
+		return value{}, true, unsupportedf("type-system", "map.mergeWith 'other' map types don't match receiver")
+	}
+	combine, err := g.emitExpr(call.Args[1].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	if combine.typ != "ptr" || combine.fnSigRef == nil {
+		return value{}, true, unsupportedf("call", "map.mergeWith combine must be a fn value")
+	}
+	sig := combine.fnSigRef
+	if len(sig.params) != 2 || sig.ret != valTyp {
+		return value{}, true, unsupportedf("call", "map.mergeWith combine must be fn(V, V) -> V")
+	}
+
+	base = g.protectManagedTemporary("mergewith.self", base)
+	other = g.protectManagedTemporary("mergewith.other", other)
+	combineHeld := g.protectManagedTemporary("mergewith.combine", combine)
+
+	outMap, err := g.emitMapNewFor(keyTyp, valTyp, keyString)
+	if err != nil {
+		return value{}, true, err
+	}
+	outMap = g.protectManagedTemporary("mergewith.out", outMap)
+
+	// Pass 1: copy every (k, v) from self into out.
+	if err := g.emitMapIterate(base, keyTyp, valTyp, keyString, "mw1", func(k, v value) error {
+		return g.emitMapInsert(outMap, k, v)
+	}); err != nil {
+		return value{}, true, err
+	}
+
+	// Pass 2: iterate other; if key exists in out call combine.
+	err = g.emitMapIterate(other, keyTyp, valTyp, keyString, "mw2", func(k, v value) error {
+		loadedKey, err := g.loadIfPointer(k)
+		if err != nil {
+			return err
+		}
+		existingOpt, err := g.emitMapGetCore(outMap, loadedKey, keyTyp, keyString)
+		if err != nil {
+			return err
+		}
+		// branch on opt null-ness
+		emitter := g.toOstyEmitter()
+		isNil := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, existingOpt.ref))
+		labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
+		g.takeOstyEmitter(emitter)
+
+		// then = no existing: insert v directly
+		g.currentBlock = labels.thenLabel
+		if err := g.emitMapInsert(outMap, k, v); err != nil {
+			return err
+		}
+		emitter = g.toOstyEmitter()
+		llvmIfExprElse(emitter, labels)
+		g.takeOstyEmitter(emitter)
+
+		// else = existing: combine(existing, v) → insert
+		g.currentBlock = labels.elseLabel
+		var existing value
+		if valTyp == "ptr" {
+			existing = existingOpt
+		} else {
+			emitter = g.toOstyEmitter()
+			payload := llvmLoad(emitter, &LlvmValue{typ: valTyp, name: existingOpt.ref, pointer: true})
+			g.takeOstyEmitter(emitter)
+			existing = value{typ: valTyp, ref: payload.name}
+		}
+		combineLoaded, err := g.loadIfPointer(combineHeld)
+		if err != nil {
+			return err
+		}
+		combined, err := g.emitFnValueIndirectCall(combineLoaded, sig, []*LlvmValue{
+			{typ: valTyp, name: existing.ref},
+			{typ: valTyp, name: v.ref},
+		})
+		if err != nil {
+			return err
+		}
+		if err := g.emitMapInsert(outMap, k, combined); err != nil {
+			return err
+		}
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		g.takeOstyEmitter(emitter)
+		g.currentBlock = labels.endLabel
+		return nil
+	})
+	if err != nil {
+		return value{}, true, err
+	}
+
+	outLoaded, err := g.loadIfPointer(outMap)
+	if err != nil {
+		return value{}, true, err
+	}
+	return outLoaded, true, nil
+}
+
+// emitMapMapValues lowers `m.mapValues(f) -> Map<K, R>` where
+// R = f's return type. Builds a fresh Map<K, R> and inserts f(v) per
+// entry. Simpler than mergeWith because there's no per-key combine —
+// each entry goes through f once.
+func (g *generator) emitMapMapValues(call *ast.CallExpr, base value, keyTyp string, keyString bool) (value, bool, error) {
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return value{}, true, unsupported("call", "map.mapValues requires one positional argument")
+	}
+	f, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	if f.typ != "ptr" || f.fnSigRef == nil {
+		return value{}, true, unsupportedf("call", "map.mapValues f must be a fn value")
+	}
+	sig := f.fnSigRef
+	if len(sig.params) != 1 || sig.params[0].typ != base.mapValueTyp {
+		return value{}, true, unsupportedf("call", "map.mapValues f must take single V argument")
+	}
+	rTyp := sig.ret
+	if rTyp == "" {
+		return value{}, true, unsupportedf("call", "map.mapValues f must return a value")
+	}
+
+	base = g.protectManagedTemporary("mapvalues.self", base)
+	fHeld := g.protectManagedTemporary("mapvalues.f", f)
+
+	outMap, err := g.emitMapNewFor(keyTyp, rTyp, keyString)
+	if err != nil {
+		return value{}, true, err
+	}
+	outMap = g.protectManagedTemporary("mapvalues.out", outMap)
+
+	err = g.emitMapIterate(base, keyTyp, base.mapValueTyp, keyString, "mv", func(k, v value) error {
+		fLoaded, err := g.loadIfPointer(fHeld)
+		if err != nil {
+			return err
+		}
+		rVal, err := g.emitFnValueIndirectCall(fLoaded, sig, []*LlvmValue{{typ: v.typ, name: v.ref}})
+		if err != nil {
+			return err
+		}
+		return g.emitMapInsert(outMap, k, rVal)
+	})
+	if err != nil {
+		return value{}, true, err
+	}
+
+	outLoaded, err := g.loadIfPointer(outMap)
+	if err != nil {
+		return value{}, true, err
+	}
+	return outLoaded, true, nil
+}
+
+// emitMapGetOr lowers `m.getOr(key, default) -> V` as the stdlib bodied
+// form `self.get(key) ?? default`. It composes the real `get` intrinsic
+// (Option<V>) with the ptr-backed coalesce shape: icmp eq ptr null →
+// branch → phi. For scalar V the some branch also loads the payload
+// out of the boxed Option so the phi produces V, not ptr.
+func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, keyString bool) (value, bool, error) {
+	if len(call.Args) != 2 ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return value{}, true, unsupported("call", "map.getOr requires two positional arguments")
+	}
+	key, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	if key.typ != keyTyp {
+		return value{}, true, unsupportedf("type-system", "map.getOr key type %s, want %s", key.typ, keyTyp)
+	}
+	loadedKey, err := g.loadIfPointer(key)
+	if err != nil {
+		return value{}, true, err
+	}
+	optVal, err := g.emitMapGetCore(base, loadedKey, keyTyp, keyString)
+	if err != nil {
+		return value{}, true, err
+	}
+
+	def, err := g.emitExpr(call.Args[1].Value)
+	if err != nil {
+		return value{}, true, err
+	}
+	valTyp := base.mapValueTyp
+	if def.typ != valTyp {
+		return value{}, true, unsupportedf("type-system", "map.getOr default type %s, want %s", def.typ, valTyp)
+	}
+
+	emitter := g.toOstyEmitter()
+	isNil := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, optVal.ref))
+	labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
+	g.takeOstyEmitter(emitter)
+
+	// then = none: fall back to default.
+	g.currentBlock = labels.thenLabel
+	nonePred := g.currentBlock
+	noneVal := def
+
+	// else = some: for V=ptr the opt value IS the payload; for scalar
+	// V we load it out of the GC box.
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	var someVal value
+	if valTyp == "ptr" {
+		someVal = optVal
+	} else {
+		emitter = g.toOstyEmitter()
+		payload := llvmLoad(emitter, &LlvmValue{typ: valTyp, name: optVal.ref, pointer: true})
+		g.takeOstyEmitter(emitter)
+		someVal = value{typ: valTyp, ref: payload.name}
+	}
+	somePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, nonePred, somePred, noneVal, someVal)
+	if err != nil {
+		return value{}, true, err
+	}
+	out.gcManaged = valTyp == "ptr"
+	out.rootPaths = g.rootPathsForType(valTyp)
+	return out, true, nil
 }
 
 func (g *generator) emitSetMethodCall(call *ast.CallExpr) (value, bool, error) {

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -625,3 +625,448 @@ fn main() {
 		}
 	}
 }
+
+// TestGenerateMapGetLowersAsOptionReturningIntrinsic locks the root-cause
+// fix: Map.get(key) -> V? now goes through the real
+// osty_rt_map_get_<K> runtime helper (bool return + out-param), with
+// V=ptr using the pre-zeroed-slot fast path so a miss yields a null
+// Option without branching. This is the intrinsic future bodied
+// helpers (getOr, containsKey, update, ...) compose on top of.
+func TestGenerateMapGetLowersAsOptionReturningIntrinsic(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn lookup(m: Map<String, String>, k: String) -> String? {
+    m.get(k)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_get.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)",
+		"alloca ptr",
+		"store ptr null, ptr",
+		"call i1 @osty_rt_map_get_string(",
+		"load ptr, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	// The old contains+get_or_abort special case must not reappear.
+	if strings.Contains(got, "osty_rt_map_contains_string") ||
+		strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("map.get wrongly routed through legacy contains/get_or_abort helpers:\n%s", got)
+	}
+}
+
+// TestGenerateMapGetOrComposesOnGetAndCoalesce verifies Map.getOr is now
+// lowered as the stdlib bodied shape: `self.get(key) ?? default` — i.e.
+// Map.get intrinsic producing Option<V>, then a ptr-backed coalesce.
+// Replaces the earlier contains+get_or_abort+phi hack so future
+// canonical helpers (update, mergeWith, ...) inherit the same
+// composable stack.
+func TestGenerateMapGetOrComposesOnGetAndCoalesce(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn lookup(m: Map<String, String>, k: String, d: String) -> String {
+    m.getOr(k, d)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_getor.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)",
+		"call i1 @osty_rt_map_get_string(",
+		"icmp eq ptr",
+		"br i1 ",
+		"= phi ptr [",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "osty_rt_map_contains_string") ||
+		strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("map.getOr still routes through legacy helpers:\n%s", got)
+	}
+}
+
+// TestGenerateMapGetScalarValueBoxLowering verifies the V=scalar path
+// of Map.get: the helper writes i64 into a stack slot, the present
+// branch GC-allocs a box, copies the payload in, and the phi merges
+// ptr-to-box vs null. Consumers see the boxed-Option ABI (ptr) with
+// a valid `load i64, ptr` in the unwrap path — confirmed later by
+// the getOr scalar test.
+func TestGenerateMapGetScalarValueBoxLowering(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn lookup(m: Map<String, Int>, k: String) -> Int? {
+    m.get(k)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_get_int.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare i1 @osty_rt_map_get_string(ptr, ptr, ptr)",
+		"alloca i64",
+		"call i1 @osty_rt_map_get_string(",
+		// Present branch GC-allocs an 8-byte box for i64.
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
+		"store i64 ",
+		"= phi ptr [",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateMapGetOrScalarValueUnwrapsBox verifies Map.getOr for
+// scalar V: the getOr composition loads the i64 payload out of the
+// boxed Option in the some branch and phis it against the scalar
+// default, producing `phi i64` (not `phi ptr`).
+func TestGenerateMapGetOrScalarValueUnwrapsBox(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn count(m: Map<String, Int>, k: String) -> Int {
+    m.getOr(k, 0)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_getor_int.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call i1 @osty_rt_map_get_string(",
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
+		"icmp eq ptr",
+		"load i64, ptr",
+		"= phi i64 [",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "osty_rt_map_contains_string") ||
+		strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("scalar getOr still routes through legacy helpers:\n%s", got)
+	}
+}
+
+// TestGenerateMapUpdateComposesOnGetAndInsert covers the most-used
+// canonical helper (CLAUDE.md §B.9.1.64.1): `m.update(k, f)` with
+// f: fn(V?) -> V. The lowering is get intrinsic + fn-value indirect
+// call + insert intrinsic — no iteration, no special-case inline.
+// Using a top-level fn as f keeps the test focused on the composition
+// rather than closure capture.
+func TestGenerateMapUpdateComposesOnGetAndInsert(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn bump(n: Int?) -> Int {
+    (n ?? 0) + 1
+}
+
+fn tally(m: Map<String, Int>, k: String) {
+    m.update(k, bump)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_update.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call i1 @osty_rt_map_get_string(",
+		// fn-value thunk for `bump`.
+		"define private i64 @__osty_closure_thunk_bump(ptr %env, ptr %arg0)",
+		// Indirect call ABI: ret (ptr, arg-type) through loaded fn ptr.
+		"= call i64 (ptr, ptr)",
+		// Insert after callback returns new V.
+		"call void @osty_rt_map_insert_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("update wrongly routed through legacy get_or_abort:\n%s", got)
+	}
+}
+
+// TestGenerateMapMergeWithCombinesOnCollision locks the mergeWith
+// shape: new map allocation, two-pass snapshot iteration (copy self,
+// then merge other with combine-on-collision), and the get+branch-on-
+// null per-key decision. combine is called only on collision.
+// Iteration goes through osty_rt_map_keys (snapshot) + per-key get —
+// NOT the raw key_at/value_at walk, so concurrent mutation of self
+// or other can't trip out-of-bounds.
+func TestGenerateMapMergeWithCombinesOnCollision(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn addCombine(a: Int, b: Int) -> Int {
+    a + b
+}
+
+fn merge(a: Map<String, Int>, b: Map<String, Int>) -> Map<String, Int> {
+    a.mergeWith(b, addCombine)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_mergewith.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_map_new(",
+		"call ptr @osty_rt_map_keys(",      // snapshot keys, not key_at index walk
+		"call i1 @osty_rt_map_get_string(", // per-key get (atomic under lock)
+		"= call i64 (ptr, i64, i64)",       // combine indirect call
+		"call void @osty_rt_map_insert_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	// Snapshot iteration must NOT use key_at/value_at (index walk is
+	// unsafe under concurrent mutation).
+	if strings.Contains(got, "osty_rt_map_key_at_string") ||
+		strings.Contains(got, "osty_rt_map_value_at") {
+		t.Fatalf("mergeWith still uses index walk key_at/value_at — snapshot regressed:\n%s", got)
+	}
+}
+
+// TestGenerateMapMapValuesRebuildsWithNewValueType verifies mapValues
+// constructs a new map whose V type is the callback's return type
+// (R), routes every entry through the indirect fn call, and uses the
+// snapshot iterator so concurrent mutation is safe.
+func TestGenerateMapMapValuesRebuildsWithNewValueType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn stringify(n: Int) -> String {
+    "{n}"
+}
+
+fn labels(m: Map<String, Int>) -> Map<String, String> {
+    m.mapValues(stringify)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_mapvalues.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_map_new(",
+		"call ptr @osty_rt_map_keys(",      // snapshot, not index walk
+		"call i1 @osty_rt_map_get_string(", // per-key lookup
+		// fn-value indirect call: (ptr env, i64 v) -> ptr
+		"= call ptr (ptr, i64)",
+		"call void @osty_rt_map_insert_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "osty_rt_map_key_at_string") ||
+		strings.Contains(got, "osty_rt_map_value_at") {
+		t.Fatalf("mapValues regressed to index walk:\n%s", got)
+	}
+}
+
+// TestGenerateMapUpdateRunsUnderLock verifies the update composition
+// (get + callback + insert) is wrapped in a per-map lock/unlock pair.
+// The lock is the root-cause fix for the "observation-then-mutation"
+// race — without it, a concurrent insert could slip between the get
+// and the insert, silently losing data.
+func TestGenerateMapUpdateRunsUnderLock(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn bump(n: Int?) -> Int {
+    (n ?? 0) + 1
+}
+
+fn tally(m: Map<String, Int>, k: String) {
+    m.update(k, bump)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_update_locked.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare void @osty_rt_map_lock(ptr)",
+		"declare void @osty_rt_map_unlock(ptr)",
+		"call void @osty_rt_map_lock(",
+		"call void @osty_rt_map_unlock(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("update must be wrapped in map_lock/unlock, missing %q:\n%s", want, got)
+		}
+	}
+	// Sanity: lock must precede unlock in the IR stream.
+	lockIdx := strings.Index(got, "call void @osty_rt_map_lock(")
+	unlockIdx := strings.Index(got, "call void @osty_rt_map_unlock(")
+	if lockIdx < 0 || unlockIdx < 0 || unlockIdx < lockIdx {
+		t.Fatalf("unlock (%d) must appear after lock (%d):\n%s", unlockIdx, lockIdx, got)
+	}
+}
+
+// TestGenerateMapRetainIfUsesSnapshotIteration verifies retainIf no
+// longer uses index-based key_at/value_at (which races against
+// concurrent mutators that could change map length mid-walk). It
+// iterates the keys snapshot returned by osty_rt_map_keys + per-key
+// get, matching the stdlib body's safe semantics.
+func TestGenerateMapRetainIfUsesSnapshotIteration(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn keepPositive(k: String, v: Int) -> Bool {
+    v > 0
+}
+
+fn prune(m: Map<String, Int>) {
+    m.retainIf(keepPositive)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_retainif_snapshot.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_map_keys(",
+		"call i1 @osty_rt_map_get_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("retainIf should iterate snapshot, missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "osty_rt_map_key_at_string") ||
+		strings.Contains(got, "osty_rt_map_value_at") {
+		t.Fatalf("retainIf still uses index walk key_at/value_at:\n%s", got)
+	}
+}
+
+// TestGenerateMapRetainIfTwoPass verifies `m.retainIf(pred)` emits the
+// collect-then-remove shape: pass 1 walks a frozen keys snapshot,
+// invokes pred, and pushes failing keys into a victim List<K>; pass
+// 2 iterates victims and calls map_remove. Two passes because map
+// mutation during iteration is undefined; snapshot iteration because
+// a concurrent mutator can't be allowed to break the walk.
+func TestGenerateMapRetainIfTwoPass(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn keepPositive(k: String, v: Int) -> Bool {
+    v > 0
+}
+
+fn prune(m: Map<String, Int>) {
+    m.retainIf(keepPositive)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_retainif.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_map_keys(",      // snapshot keys for pass 1
+		"call i1 @osty_rt_map_get_string(", // per-key get under lock
+		// fn-value thunk for pred.
+		"define private i1 @__osty_closure_thunk_keepPositive(ptr %env, ptr %arg0, i64 %arg1)",
+		"= call i1 (ptr, ptr, i64)",
+		"call ptr @osty_rt_list_new()",
+		"call void @osty_rt_list_push_ptr(",
+		// Second pass calls map_remove per victim.
+		"call i1 @osty_rt_map_remove_string(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateMapForInLowersAsIndexedWalk locks map iteration
+// infrastructure: `for (k, v) in m` over Map<String, Int> lowers as
+// map_len + index loop + key_at + value_at slot accessors. This is the
+// primitive `retainIf`/`mergeWith`/`mapValues` compose on top of — it
+// MUST work on arbitrary user code, not just stdlib helpers.
+func TestGenerateMapForInLowersAsIndexedWalk(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn sum(m: Map<String, Int>) -> Int {
+    let mut total = 0
+    for (k, v) in m {
+        total = total + v
+    }
+    total
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_for_in.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare i64 @osty_rt_map_len(ptr)",
+		"declare ptr @osty_rt_map_key_at_string(ptr, i64)",
+		"declare void @osty_rt_map_value_at(ptr, i64, ptr)",
+		"call i64 @osty_rt_map_len(",
+		"call ptr @osty_rt_map_key_at_string(",
+		"call void @osty_rt_map_value_at(",
+		"alloca i64",
+		"load i64, ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateMapGetBoolValueUses1ByteBox exercises i1 V: byte size
+// drops to 1, but otherwise the same branch+box shape applies.
+func TestGenerateMapGetBoolValueUses1ByteBox(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn flag(m: Map<String, Bool>, k: String) -> Bool {
+    m.getOr(k, false)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_getor_bool.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 1,",
+		"alloca i1",
+		"load i1, ptr",
+		"= phi i1 [",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -355,6 +355,40 @@ func mapRuntimeGetOrAbortSymbol(keyTyp string, keyString bool) string {
 	return llvmMapRuntimeGetOrAbortSymbol(keyTyp, keyString)
 }
 
+// mapRuntimeGetSymbol backs the Option-returning `Map.get(key) -> V?`
+// intrinsic. The runtime helper returns i1 (present) and writes V into
+// an out-param, so the backend can lift it into the Option<V> ABI
+// (null ptr = None, boxed payload ptr = Some) without inlining the
+// stdlib body per callsite.
+func mapRuntimeGetSymbol(keyTyp string, keyString bool) string {
+	return "osty_rt_map_get_" + llvmMapKeySuffix(keyTyp, keyString)
+}
+
+// mapRuntimeKeyAtSymbol returns the K-at-slot accessor used by
+// `for (k, v) in m` iteration. `osty_rt_map_key_at_<ksuf>(map, i) -> K`.
+func mapRuntimeKeyAtSymbol(keyTyp string, keyString bool) string {
+	return "osty_rt_map_key_at_" + llvmMapKeySuffix(keyTyp, keyString)
+}
+
+// mapRuntimeValueAtSymbol returns the V-at-slot accessor — V-agnostic,
+// takes an out-pointer. `osty_rt_map_value_at(map, i, out_ptr)`.
+func mapRuntimeValueAtSymbol() string {
+	return "osty_rt_map_value_at"
+}
+
+// mapRuntimeLockSymbol / mapRuntimeUnlockSymbol expose the per-map
+// recursive mutex as a pair. Emitted by `update` so the get + callback
+// + insert composition is a single critical section; recursive so the
+// callback can re-enter the same map (e.g. read self.len()) without
+// self-deadlock.
+func mapRuntimeLockSymbol() string {
+	return "osty_rt_map_lock"
+}
+
+func mapRuntimeUnlockSymbol() string {
+	return "osty_rt_map_unlock"
+}
+
 func mapRuntimeKeysSymbol() string {
 	return llvmMapRuntimeKeysSymbol()
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -539,6 +539,24 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	if stmt.Pattern == nil {
 		return g.emitWhileFor(stmt)
 	}
+	// `for (k, v) in m` — map iteration. Detect before the
+	// ident-pattern reduction since identPatternName would reject the
+	// tuple.
+	if tuplePat, ok := stmt.Pattern.(*ast.TuplePat); ok && len(tuplePat.Elems) == 2 {
+		if iterInfo, ok := g.staticExprInfo(stmt.Iter); ok &&
+			iterInfo.typ == "ptr" &&
+			iterInfo.mapKeyTyp != "" && iterInfo.mapValueTyp != "" {
+			kName, err := identPatternName(tuplePat.Elems[0])
+			if err != nil {
+				return err
+			}
+			vName, err := identPatternName(tuplePat.Elems[1])
+			if err != nil {
+				return err
+			}
+			return g.emitMapFor(stmt, kName, vName, iterInfo.mapKeyTyp, iterInfo.mapValueTyp, iterInfo.mapKeyString)
+		}
+	}
 	iterName, err := identPatternName(stmt.Pattern)
 	if err != nil {
 		return err
@@ -1664,12 +1682,18 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	if field.Name != "insert" && field.Name != "remove" {
+	if field.Name != "insert" && field.Name != "remove" && field.Name != "update" && field.Name != "retainIf" {
 		return false, nil
 	}
 	base, err := g.emitExpr(field.X)
 	if err != nil {
 		return true, err
+	}
+	if field.Name == "update" {
+		return true, g.emitMapUpdateStmt(call, base, keyTyp, keyString)
+	}
+	if field.Name == "retainIf" {
+		return true, g.emitMapRetainIfStmt(call, base, keyTyp, keyString)
 	}
 	if field.Name == "insert" {
 		if len(call.Args) != 2 || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
@@ -1710,6 +1734,219 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	return true, nil
 }
 
+// emitMapUpdateStmt lowers `m.update(key, f)` — stdlib bodied form is
+//   let current = self.get(key)
+//   self.insert(key, f(current))
+// The three steps run inside a single `osty_rt_map_lock/unlock`
+// critical section so concurrent mutators can't race between read and
+// write. The per-map mutex is recursive (see osty_runtime.c), so the
+// callback can re-enter the same map (e.g. read self.len()) without
+// self-deadlock.
+func (g *generator) emitMapUpdateStmt(call *ast.CallExpr, base value, keyTyp string, keyString bool) error {
+	if len(call.Args) != 2 ||
+		call.Args[0].Name != "" || call.Args[1].Name != "" ||
+		call.Args[0].Value == nil || call.Args[1].Value == nil {
+		return unsupported("call", "map.update requires two positional arguments")
+	}
+	key, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return err
+	}
+	if key.typ != keyTyp {
+		return unsupportedf("type-system", "map.update key type %s, want %s", key.typ, keyTyp)
+	}
+	loadedKey, err := g.loadIfPointer(key)
+	if err != nil {
+		return err
+	}
+	fnVal, err := g.emitExpr(call.Args[1].Value)
+	if err != nil {
+		return err
+	}
+	if fnVal.typ != "ptr" || fnVal.fnSigRef == nil {
+		return unsupportedf("call", "map.update callback must be a fn value (got typ=%s, sig=%v)", fnVal.typ, fnVal.fnSigRef != nil)
+	}
+	sig := fnVal.fnSigRef
+	if len(sig.params) != 1 {
+		return unsupportedf("call", "map.update callback arity must be 1 (got %d)", len(sig.params))
+	}
+
+	// Take the per-map lock so the get + callback + insert sequence is
+	// atomic w.r.t. other mutators. Recursive so the user callback can
+	// safely touch the same map.
+	g.declareRuntimeSymbol(mapRuntimeLockSymbol(), "void", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(mapRuntimeUnlockSymbol(), "void", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  call void @%s(%s)",
+		mapRuntimeLockSymbol(),
+		llvmCallArgs([]*LlvmValue{toOstyValue(base)}),
+	))
+	g.takeOstyEmitter(emitter)
+
+	// Materialise Option<V> for the current value.
+	optVal, err := g.emitMapGetCore(base, loadedKey, keyTyp, keyString)
+	if err != nil {
+		return err
+	}
+
+	// f(env, opt) -> V via the indirect-call ABI.
+	newVal, err := g.emitFnValueIndirectCall(fnVal, sig, []*LlvmValue{toOstyValue(optVal)})
+	if err != nil {
+		return err
+	}
+	if newVal.typ != base.mapValueTyp {
+		return unsupportedf("type-system", "map.update callback return %s, want %s", newVal.typ, base.mapValueTyp)
+	}
+
+	// Insert under the same lock.
+	if err := g.emitMapInsert(base, value{typ: keyTyp, ref: loadedKey.ref}, newVal); err != nil {
+		return err
+	}
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  call void @%s(%s)",
+		mapRuntimeUnlockSymbol(),
+		llvmCallArgs([]*LlvmValue{toOstyValue(base)}),
+	))
+	g.takeOstyEmitter(emitter)
+	return nil
+}
+
+// emitMapRetainIfStmt lowers `m.retainIf(pred)` on top of the
+// snapshot-keys iterator (`emitMapIterate`) + victim-collect + second
+// remove pass. Even under concurrent mutation of m, the snapshot
+// approach guarantees we never trip an out-of-bounds during the walk:
+// keys is a frozen List<K> taken once, and per-key get() is atomic
+// under the per-map lock. Keys removed by a concurrent thread appear
+// as None in get() and are silently skipped.
+func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp string, keyString bool) error {
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return unsupported("call", "map.retainIf requires one positional argument")
+	}
+	predVal, err := g.emitExpr(call.Args[0].Value)
+	if err != nil {
+		return err
+	}
+	if predVal.typ != "ptr" || predVal.fnSigRef == nil {
+		return unsupportedf("call", "map.retainIf callback must be a fn value")
+	}
+	sig := predVal.fnSigRef
+	if len(sig.params) != 2 || sig.ret != "i1" {
+		return unsupportedf("call", "map.retainIf pred arity/ret mismatch (want fn(K,V)->Bool)")
+	}
+	valTyp := base.mapValueTyp
+
+	baseVal := g.protectManagedTemporary("retainif.map", base)
+	predHeld := g.protectManagedTemporary("retainif.pred", predVal)
+
+	// victims = list_new()
+	g.declareRuntimeSymbol(listRuntimeNewSymbol(), "ptr", nil)
+	emitter := g.toOstyEmitter()
+	victims := llvmCall(emitter, "ptr", listRuntimeNewSymbol(), nil)
+	g.takeOstyEmitter(emitter)
+	victimsVal := fromOstyValue(victims)
+	victimsVal.gcManaged = true
+	victimsVal.listElemTyp = keyTyp
+	victimsVal.listElemString = keyString
+	victimsVal = g.protectManagedTemporary("retainif.victims", victimsVal)
+
+	// Pass 1: snapshot-iterate, collect victim keys where pred returns false.
+	err = g.emitMapIterate(baseVal, keyTyp, valTyp, keyString, "retainif", func(k, v value) error {
+		predLoaded, err := g.loadIfPointer(predHeld)
+		if err != nil {
+			return err
+		}
+		cond, err := g.emitFnValueIndirectCall(predLoaded, sig, []*LlvmValue{
+			{typ: keyTyp, name: k.ref},
+			{typ: valTyp, name: v.ref},
+		})
+		if err != nil {
+			return err
+		}
+		emitter := g.toOstyEmitter()
+		notCond := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = xor i1 %s, true", notCond, cond.ref))
+		labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: notCond})
+		g.takeOstyEmitter(emitter)
+		g.currentBlock = labels.thenLabel
+
+		victimsLoaded, err := g.loadIfPointer(victimsVal)
+		if err != nil {
+			return err
+		}
+		pushSym := listRuntimePushSymbol(keyTyp)
+		g.declareRuntimeSymbol(pushSym, "void", []paramInfo{{typ: "ptr"}, {typ: keyTyp}})
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			pushSym,
+			llvmCallArgs([]*LlvmValue{toOstyValue(victimsLoaded), {typ: keyTyp, name: k.ref}}),
+		))
+		llvmIfExprElse(emitter, labels)
+		g.takeOstyEmitter(emitter)
+		g.currentBlock = labels.elseLabel
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", labels.endLabel))
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", labels.endLabel))
+		g.takeOstyEmitter(emitter)
+		g.currentBlock = labels.endLabel
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Pass 2: remove each victim key. Each remove is atomic under
+	// the per-map lock; double-remove or remove-of-already-gone is a
+	// no-op (osty_rt_map_remove_raw returns false and leaves the map
+	// alone).
+	g.declareRuntimeSymbol(listRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+	victimsLoaded, err := g.loadIfPointer(victimsVal)
+	if err != nil {
+		return err
+	}
+	emitter = g.toOstyEmitter()
+	vlen := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(victimsLoaded)})
+	loop2 := llvmRangeStart(emitter, "retainif_j", llvmIntLiteral(0), vlen, false)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop2.bodyLabel)
+	cont2 := g.nextNamedLabel("retainif.cont2")
+	g.pushLoop(loopContext{continueLabel: cont2, breakLabel: loop2.endLabel, scopeDepth: len(g.locals)})
+
+	victimsLoaded, err = g.loadIfPointer(victimsVal)
+	if err != nil {
+		g.popLoop()
+		return err
+	}
+	mapLoaded, err := g.loadIfPointer(baseVal)
+	if err != nil {
+		g.popLoop()
+		return err
+	}
+	getSym := listRuntimeGetSymbol(keyTyp)
+	g.declareRuntimeSymbol(getSym, keyTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter = g.toOstyEmitter()
+	vk := llvmCall(emitter, keyTyp, getSym, []*LlvmValue{toOstyValue(victimsLoaded), llvmI64(loop2.current)})
+	removeSym := mapRuntimeRemoveSymbol(keyTyp, keyString)
+	g.declareRuntimeSymbol(removeSym, "i1", []paramInfo{{typ: "ptr"}, {typ: keyTyp}})
+	llvmCall(emitter, "i1", removeSym, []*LlvmValue{toOstyValue(mapLoaded), vk})
+	g.takeOstyEmitter(emitter)
+
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(cont2)
+	}
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", cont2))
+	g.emitGCSafepoint(emitter)
+	llvmRangeEnd(emitter, loop2)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop2.endLabel)
+
+	return nil
+}
+
 func (g *generator) emitSetMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	field, elemTyp, elemString, found := g.setMethodInfo(call)
 	if !found || field.Name != "insert" {
@@ -1739,6 +1976,112 @@ func (g *generator) emitSetMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(loaded)})
 	g.takeOstyEmitter(emitter)
 	return true, nil
+}
+
+// emitMapFor lowers `for (k, v) in m { body }` as an index-based walk:
+//
+//   %len = call i64 @osty_rt_map_len(%m)
+//   for %i = 0; %i < %len; %i++:
+//     %k = call <K> @osty_rt_map_key_at_<ksuf>(%m, %i)
+//     alloca %vslot (width by V), call @osty_rt_map_value_at(%m, %i, %vslot), load
+//     body(k, v)
+//
+// This is the infra piece that unlocks `retainIf`, `mergeWith`,
+// `mapValues`, and any user-written map iteration. Matches the stdlib
+// semantics of a stable-order walk (map preserves insertion order) and
+// leaves in-iteration mutation undefined (users collect keys first
+// the way `retainIf` does).
+func (g *generator) emitMapFor(stmt *ast.ForStmt, kName, vName, keyTyp, valTyp string, keyString bool) error {
+	g.pushScope()
+	defer g.popScope()
+	iterable, err := g.emitExpr(stmt.Iter)
+	if err != nil {
+		return err
+	}
+	if iterable.typ != "ptr" {
+		return unsupportedf("type-system", "for-(k,v) iterable type %s", iterable.typ)
+	}
+	iterable = g.protectManagedTemporary("for.map", iterable)
+	g.declareRuntimeSymbol(mapRuntimeLenSymbol(), "i64", []paramInfo{{typ: "ptr"}})
+	iterableValue, err := g.loadIfPointer(iterable)
+	if err != nil {
+		return err
+	}
+	emitter := g.toOstyEmitter()
+	lenValue := llvmCall(emitter, "i64", mapRuntimeLenSymbol(), []*LlvmValue{toOstyValue(iterableValue)})
+	loop := llvmRangeStart(emitter, kName+"_idx", llvmIntLiteral(0), lenValue, false)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.bodyLabel)
+	continueLabel := g.nextNamedLabel("for.cont")
+	g.pushLoop(loopContext{
+		continueLabel: continueLabel,
+		breakLabel:    loop.endLabel,
+		scopeDepth:    len(g.locals),
+	})
+	scopeDepth := len(g.locals)
+	g.pushScope()
+
+	iterableValue, err = g.loadIfPointer(iterable)
+	if err != nil {
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
+		return err
+	}
+	indexValue := value{typ: "i64", ref: loop.current}
+
+	// Load the key via typed accessor.
+	keyAtSym := mapRuntimeKeyAtSymbol(keyTyp, keyString)
+	g.declareRuntimeSymbol(keyAtSym, keyTyp, []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter = g.toOstyEmitter()
+	keyLoaded := llvmCall(emitter, keyTyp, keyAtSym, []*LlvmValue{toOstyValue(iterableValue), toOstyValue(indexValue)})
+	g.takeOstyEmitter(emitter)
+	keyVal := fromOstyValue(keyLoaded)
+	keyVal.gcManaged = keyTyp == "ptr"
+	keyVal.rootPaths = g.rootPathsForType(keyTyp)
+	g.bindLocal(kName, keyVal)
+
+	// Load the value via V-agnostic slot accessor + load.
+	valueAtSym := mapRuntimeValueAtSymbol()
+	g.declareRuntimeSymbol(valueAtSym, "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}})
+	emitter = g.toOstyEmitter()
+	vslot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", vslot, valTyp))
+	emitter.body = append(emitter.body, fmt.Sprintf(
+		"  call void @%s(%s)",
+		valueAtSym,
+		llvmCallArgs([]*LlvmValue{toOstyValue(iterableValue), toOstyValue(indexValue), {typ: "ptr", name: vslot}}),
+	))
+	g.takeOstyEmitter(emitter)
+	emitter = g.toOstyEmitter()
+	valLoaded := g.loadValueFromAddress(emitter, valTyp, vslot)
+	g.takeOstyEmitter(emitter)
+	valLoaded.gcManaged = valTyp == "ptr"
+	valLoaded.rootPaths = g.rootPathsForType(valTyp)
+	g.bindLocal(vName, valLoaded)
+
+	if err := g.emitBlock(stmt.Body.Stmts); err != nil {
+		if len(g.locals) > scopeDepth {
+			g.popScope()
+		}
+		g.popLoop()
+		return err
+	}
+	if len(g.locals) > scopeDepth {
+		g.popScope()
+	}
+	g.popLoop()
+	if g.currentReachable {
+		g.branchTo(continueLabel)
+	}
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
+	g.emitGCSafepoint(emitter)
+	llvmRangeEnd(emitter, loop)
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(loop.endLabel)
+	return nil
 }
 
 func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) error {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -998,7 +998,7 @@ func (g *generator) mapMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, s
 		return nil, "", "", false, false
 	}
 	switch field.Name {
-	case "containsKey", "insert", "remove", "keys", "len", "isEmpty":
+	case "containsKey", "insert", "remove", "keys", "len", "isEmpty", "get", "getOr", "update", "retainIf", "mergeWith", "mapValues":
 	default:
 		return nil, "", "", false, false
 	}


### PR DESCRIPTION
## Summary

Replaces the per-callsite `contains + get_or_abort` hacks for `Map<K, V>` helpers with a real intrinsic stack, adds per-map recursive mutex + snapshot-based iteration, and lands the full §B.9.1.64 canonical helper set (`get`, `getOr`, `update`, `retainIf`, `mergeWith`, `mapValues`).

## What changed

**C runtime** (`internal/backend/runtime/osty_runtime.c`)
- New `osty_rt_map_get_<K>` — Option-returning accessor (`bool` + out-param).
- New `osty_rt_map_value_at(map, i, out)` and macro-generated `osty_rt_map_key_at_<K>(map, i)` — slot accessors for iteration.
- Per-map `PTHREAD_MUTEX_RECURSIVE` guarding every public op (insert / remove / get / get_or_abort / contains / len / keys / key_at / value_at). Init in `map_new`, destroy in the GC finalizer. Recursive so `update` callbacks can re-enter the same map without self-deadlock.
- Public `osty_rt_map_lock` / `osty_rt_map_unlock` for composite critical sections.

**Backend** (`internal/llvmgen/{expr,stmt,type,runtime_ffi}.go`)
- `Map.get(k) -> V?` lowering:
  - V=ptr → pre-zeroed slot, no branch (fast path).
  - V=scalar (i64/i1/double) → GC-alloc'd box + branch + phi. Produces the boxed-Option ABI that `??` / match / `.isSome()` already consume.
- `Map.getOr(k, d)` composes `get + ??` — retires the old contains+get_or_abort special case.
- `Map.update(k, f)` (stmt) wraps `get + fn-value call + insert` in a `map_lock/unlock` critical section.
- `Map.retainIf` / `mergeWith` / `mapValues` lower via a shared `emitMapIterate` that snapshots keys (`osty_rt_map_keys`) and walks the snapshot with per-key `get()`. Concurrent deletions appear as None and are silently skipped; concurrent inserts are not observed (weakly-consistent iteration, same model as Go's `sync.Map.Range`). Index-walk (`key_at`/`value_at` in sequence) would race against length changes — removed from these helpers.
- `for (k, v) in m` lowering in `emitFor` — general-purpose tuple-pattern map iteration for user code (index-based walk; callers responsible for their own serialization).

## Why this shape

The previous `Map.getOr` lowering special-cased the contains+get_or_abort shape per callsite — each new helper (`update`, `mergeWith`, …) would have meant another Go special case. Landing a real `Map.get` intrinsic closes the root gap: every bodied stdlib helper that's written as `self.get(k) ?? …` or `self.get(k).isSome()` now composes on the real ABI instead of being rewritten in Go.

Per-map locking came from the honest "single-threaded assumption" disclaimer on the earlier iteration. With per-op lock + snapshot iteration, these helpers no longer corrupt memory under concurrent mutation — out-of-bounds from a shrinking `len`, realloc-during-read, and memmove-during-read are all eliminated.

## Scope boundaries (honest)

- **Scalar `Some(42)` construction** remains unsupported — only the `Map.get` box path is wired. Full scalar Option construction is separate work.
- **Built-in generic method monomorphization is NOT implemented**. These helpers are still hand-emitted Go in the backend. The "path" is improved (intrinsics + shared iterator + lock), but the ultimate "stdlib body compiles as a normal function" goal is future work.
- **C runtime changes unverified by clang/gcc** in this worktree (neither compiler in PATH). IR-string assertions only. A downstream runtime-build CI will catch any typo.
- **List / Set have the same helper gaps** — out of scope here.
- **Pre-existing failure** `TestGenerateModuleExtendedListSortedAndToSet` (TurbofishExpr panic in `staticCollectionMethodResult`) is unrelated and was already failing on main — kept skipped.

## Test plan

- [x] llvmgen short suite passes (`-skip TestGenerateModuleExtendedListSortedAndToSet`)
- [x] `just front` passes (lexer / parser / resolve / check / diag / format)
- [x] 13 new `TestGenerateMap*` regression cases covering V=ptr + V=scalar, Option box ABI, snapshot iteration, lock wrapping, canonical §B.9.1.64 helpers
- [x] Legacy `osty_rt_map_contains_<K>` + `osty_rt_map_get_or_abort_<K>` assertions removed — new tests actively prohibit the old shape from reappearing
- [ ] Runtime C compiles under clang/gcc + links + runs — **needs downstream CI verification** (no C toolchain in this worktree)
- [ ] End-to-end `osty run` over a program that hammers `counts.update(w, |n| (n ?? 0) + 1)` from `taskGroup` workers — not covered by current tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)