### PR TITLE
feat(selfhost): add L0005/L0006 unused field/method rules

### DIFF
--- a/examples/selfhost-core/lint.osty
+++ b/examples/selfhost-core/lint.osty
@@ -167,6 +167,7 @@ pub fn selfLintResolvedAstSource(
     let mut report = emptySelfLintReport(frontLexDiagnosticCount(stream) + astFileErrorCount(file))
     report.resolveErrors = selfResolveDiagnosticCount(resolved)
     report = selfLintAstFile(file, resolved, report)
+    report = selfLintAstCheckUnusedMembers(file, report)
     selfLintAstCheckMissingDocs(file, stream, report)
 }
 
@@ -2509,4 +2510,240 @@ fn selfLintIsDeclPrefixTokenKind(kind: FrontTokenKind) -> Bool {
         || kind == FrontNewline
         || kind == FrontLParen
         || kind == FrontRParen
+}
+
+struct SelfLintMemberAccess {
+    fields: List<String>,
+    methods: List<String>,
+}
+
+fn selfLintEmptyMemberAccess() -> SelfLintMemberAccess {
+    SelfLintMemberAccess { fields: [], methods: [] }
+}
+
+fn selfLintMemberAccessAddField(
+    acc: SelfLintMemberAccess,
+    name: String,
+) -> SelfLintMemberAccess {
+    if name == "" {
+        return acc
+    }
+    if selfLintStringListContains(acc.fields, name) {
+        return acc
+    }
+    let mut out = acc
+    out.fields.push(name)
+    out
+}
+
+fn selfLintMemberAccessAddMethod(
+    acc: SelfLintMemberAccess,
+    name: String,
+) -> SelfLintMemberAccess {
+    if name == "" {
+        return acc
+    }
+    if selfLintStringListContains(acc.methods, name) {
+        return acc
+    }
+    let mut out = acc
+    out.methods.push(name)
+    out
+}
+
+fn selfLintCollectMemberAccess(file: AstFile) -> SelfLintMemberAccess {
+    let mut out = selfLintEmptyMemberAccess()
+    for declIdx in file.arena.decls {
+        out = selfLintMemberAccessDecl(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintMemberAccessDecl(
+    file: AstFile,
+    idx: Int,
+    acc: SelfLintMemberAccess,
+) -> SelfLintMemberAccess {
+    if idx < 0 {
+        return acc
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNFnDecl {
+        return selfLintMemberAccessAny(file, node.right, acc)
+    }
+    if node.kind == AstNStructDecl
+        || node.kind == AstNEnumDecl
+        || node.kind == AstNInterfaceDecl {
+        let mut out = acc
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl && member.right >= 0 {
+                out = selfLintMemberAccessAny(file, member.right, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNLet && node.right >= 0 {
+        return selfLintMemberAccessAny(file, node.right, acc)
+    }
+    acc
+}
+
+fn selfLintMemberAccessAny(
+    file: AstFile,
+    idx: Int,
+    acc: SelfLintMemberAccess,
+) -> SelfLintMemberAccess {
+    if idx < 0 {
+        return acc
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = acc
+    if node.kind == AstNCall {
+        if node.left >= 0 {
+            let callee = selfLintAstNode(file, node.left)
+            if callee.kind == AstNField {
+                out = selfLintMemberAccessAddMethod(out, callee.text)
+                out = selfLintMemberAccessAny(file, callee.left, out)
+            } else {
+                out = selfLintMemberAccessAny(file, node.left, out)
+            }
+        }
+        for child in node.children {
+            out = selfLintMemberAccessAny(file, child, out)
+        }
+        return out
+    }
+    if node.kind == AstNField {
+        out = selfLintMemberAccessAddField(out, node.text)
+        return selfLintMemberAccessAny(file, node.left, out)
+    }
+    if node.kind == AstNStructLit {
+        out = selfLintMemberAccessAny(file, node.left, out)
+        out = selfLintMemberAccessAny(file, node.right, out)
+        for child in node.children {
+            let fNode = selfLintAstNode(file, child)
+            if fNode.kind == AstNField_ {
+                out = selfLintMemberAccessAddField(out, fNode.text)
+                out = selfLintMemberAccessAny(file, fNode.left, out)
+            } else {
+                out = selfLintMemberAccessAny(file, child, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNPattern && node.extra == selfLintAstPatternFieldKind() {
+        out = selfLintMemberAccessAddField(out, node.text)
+        return selfLintMemberAccessAny(file, node.left, out)
+    }
+    out = selfLintMemberAccessAny(file, node.left, out)
+    out = selfLintMemberAccessAny(file, node.right, out)
+    for child in node.children {
+        out = selfLintMemberAccessAny(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintMemberAccessAny(file, child, out)
+    }
+    out
+}
+
+fn selfLintAstCheckUnusedMembers(
+    file: AstFile,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let access = selfLintCollectMemberAccess(file)
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintAstCheckUnusedMembersDecl(file, declIdx, access, out)
+    }
+    out
+}
+
+fn selfLintAstCheckUnusedMembersDecl(
+    file: AstFile,
+    idx: Int,
+    access: SelfLintMemberAccess,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let typePub = node.flags == 1
+    let mut out = report
+    if node.kind == AstNStructDecl {
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNField_ {
+                out = selfLintMaybeEmitUnusedField(member, memberIdx, typePub, access, out)
+            } else if member.kind == AstNFnDecl {
+                out = selfLintMaybeEmitUnusedMethod(member, memberIdx, typePub, access, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNEnumDecl {
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl {
+                out = selfLintMaybeEmitUnusedMethod(member, memberIdx, typePub, access, out)
+            }
+        }
+        return out
+    }
+    out
+}
+
+fn selfLintMaybeEmitUnusedField(
+    member: AstNode,
+    idx: Int,
+    typePub: Bool,
+    access: SelfLintMemberAccess,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if member.text == "" || selfLintIsIntentionalDiscard(member.text) {
+        return report
+    }
+    if typePub || member.flags == 1 {
+        return report
+    }
+    if selfLintStringListContains(access.fields, member.text) {
+        return report
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0005",
+        "field is never read",
+        member.text,
+        member.start,
+        member.end,
+        idx,
+    )
+}
+
+fn selfLintMaybeEmitUnusedMethod(
+    member: AstNode,
+    idx: Int,
+    typePub: Bool,
+    access: SelfLintMemberAccess,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if member.text == "" || selfLintIsIntentionalDiscard(member.text) {
+        return report
+    }
+    if typePub || member.flags == 1 {
+        return report
+    }
+    if selfLintStringListContains(access.methods, member.text) {
+        return report
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0006",
+        "method is never called",
+        member.text,
+        member.start,
+        member.end,
+        idx,
+    )
 }

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -161,6 +161,7 @@ pub fn selfLintResolvedAstSource(
     let mut report = emptySelfLintReport(frontLexDiagnosticCount(stream) + astFileErrorCount(file))
     report.resolveErrors = selfResolveDiagnosticCount(resolved)
     report = selfLintAstFile(file, resolved, report)
+    report = selfLintAstCheckUnusedMembers(file, report)
     selfLintAstCheckMissingDocs(file, stream, report)
 }
 
@@ -2475,4 +2476,259 @@ fn selfLintIsDeclPrefixTokenKind(kind: FrontTokenKind) -> Bool {
         || kind == FrontNewline
         || kind == FrontLParen
         || kind == FrontRParen
+}
+
+/// SelfLintMemberAccess is the name-level index of every field read and
+/// method call reachable from the file's top-level declarations. It drives
+/// L0005 (unused field) and L0006 (unused method) — a conservative,
+/// name-only heuristic mirroring the Go-side linter: two structs sharing a
+/// field name are both treated as used if either is referenced, and
+/// reflection / FFI accesses are not modelled.
+struct SelfLintMemberAccess {
+    fields: List<String>,
+    methods: List<String>,
+}
+
+fn selfLintEmptyMemberAccess() -> SelfLintMemberAccess {
+    SelfLintMemberAccess { fields: [], methods: [] }
+}
+
+fn selfLintMemberAccessAddField(
+    acc: SelfLintMemberAccess,
+    name: String,
+) -> SelfLintMemberAccess {
+    if name == "" {
+        return acc
+    }
+    if selfLintStringListContains(acc.fields, name) {
+        return acc
+    }
+    let mut out = acc
+    out.fields.push(name)
+    out
+}
+
+fn selfLintMemberAccessAddMethod(
+    acc: SelfLintMemberAccess,
+    name: String,
+) -> SelfLintMemberAccess {
+    if name == "" {
+        return acc
+    }
+    if selfLintStringListContains(acc.methods, name) {
+        return acc
+    }
+    let mut out = acc
+    out.methods.push(name)
+    out
+}
+
+/// selfLintCollectMemberAccess walks every top-level declaration in `file`
+/// and records the names of fields read and methods called. The walk
+/// descends into function bodies, struct/enum/interface method bodies, and
+/// top-level `let` initializers.
+fn selfLintCollectMemberAccess(file: AstFile) -> SelfLintMemberAccess {
+    let mut out = selfLintEmptyMemberAccess()
+    for declIdx in file.arena.decls {
+        out = selfLintMemberAccessDecl(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintMemberAccessDecl(
+    file: AstFile,
+    idx: Int,
+    acc: SelfLintMemberAccess,
+) -> SelfLintMemberAccess {
+    if idx < 0 {
+        return acc
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNFnDecl {
+        return selfLintMemberAccessAny(file, node.right, acc)
+    }
+    if node.kind == AstNStructDecl
+        || node.kind == AstNEnumDecl
+        || node.kind == AstNInterfaceDecl {
+        let mut out = acc
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl && member.right >= 0 {
+                out = selfLintMemberAccessAny(file, member.right, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNLet && node.right >= 0 {
+        return selfLintMemberAccessAny(file, node.right, acc)
+    }
+    acc
+}
+
+/// selfLintMemberAccessAny is the recursive walker that records member
+/// references. It special-cases a handful of node shapes so method calls
+/// (`x.m(args)`) do not also get counted as field reads on `m`, and so
+/// struct literal / struct pattern field names are recorded without
+/// double-walking the surrounding tuple helpers.
+fn selfLintMemberAccessAny(
+    file: AstFile,
+    idx: Int,
+    acc: SelfLintMemberAccess,
+) -> SelfLintMemberAccess {
+    if idx < 0 {
+        return acc
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = acc
+    if node.kind == AstNCall {
+        if node.left >= 0 {
+            let callee = selfLintAstNode(file, node.left)
+            if callee.kind == AstNField {
+                out = selfLintMemberAccessAddMethod(out, callee.text)
+                out = selfLintMemberAccessAny(file, callee.left, out)
+            } else {
+                out = selfLintMemberAccessAny(file, node.left, out)
+            }
+        }
+        for child in node.children {
+            out = selfLintMemberAccessAny(file, child, out)
+        }
+        return out
+    }
+    if node.kind == AstNField {
+        out = selfLintMemberAccessAddField(out, node.text)
+        return selfLintMemberAccessAny(file, node.left, out)
+    }
+    if node.kind == AstNStructLit {
+        out = selfLintMemberAccessAny(file, node.left, out)
+        out = selfLintMemberAccessAny(file, node.right, out)
+        for child in node.children {
+            let fNode = selfLintAstNode(file, child)
+            if fNode.kind == AstNField_ {
+                out = selfLintMemberAccessAddField(out, fNode.text)
+                out = selfLintMemberAccessAny(file, fNode.left, out)
+            } else {
+                out = selfLintMemberAccessAny(file, child, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNPattern && node.extra == selfLintAstPatternFieldKind() {
+        out = selfLintMemberAccessAddField(out, node.text)
+        return selfLintMemberAccessAny(file, node.left, out)
+    }
+    out = selfLintMemberAccessAny(file, node.left, out)
+    out = selfLintMemberAccessAny(file, node.right, out)
+    for child in node.children {
+        out = selfLintMemberAccessAny(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintMemberAccessAny(file, child, out)
+    }
+    out
+}
+
+/// selfLintAstCheckUnusedMembers emits L0005 for non-pub struct fields and
+/// L0006 for non-pub struct/enum methods whose names never appear anywhere
+/// in the file's member-access index. Public types and public members are
+/// exempt (external consumers are assumed).
+fn selfLintAstCheckUnusedMembers(
+    file: AstFile,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let access = selfLintCollectMemberAccess(file)
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintAstCheckUnusedMembersDecl(file, declIdx, access, out)
+    }
+    out
+}
+
+fn selfLintAstCheckUnusedMembersDecl(
+    file: AstFile,
+    idx: Int,
+    access: SelfLintMemberAccess,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let typePub = node.flags == 1
+    let mut out = report
+    if node.kind == AstNStructDecl {
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNField_ {
+                out = selfLintMaybeEmitUnusedField(member, memberIdx, typePub, access, out)
+            } else if member.kind == AstNFnDecl {
+                out = selfLintMaybeEmitUnusedMethod(member, memberIdx, typePub, access, out)
+            }
+        }
+        return out
+    }
+    if node.kind == AstNEnumDecl {
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl {
+                out = selfLintMaybeEmitUnusedMethod(member, memberIdx, typePub, access, out)
+            }
+        }
+        return out
+    }
+    out
+}
+
+fn selfLintMaybeEmitUnusedField(
+    member: AstNode,
+    idx: Int,
+    typePub: Bool,
+    access: SelfLintMemberAccess,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if member.text == "" || selfLintIsIntentionalDiscard(member.text) {
+        return report
+    }
+    if typePub || member.flags == 1 {
+        return report
+    }
+    if selfLintStringListContains(access.fields, member.text) {
+        return report
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0005",
+        "field is never read",
+        member.text,
+        member.start,
+        member.end,
+        idx,
+    )
+}
+
+fn selfLintMaybeEmitUnusedMethod(
+    member: AstNode,
+    idx: Int,
+    typePub: Bool,
+    access: SelfLintMemberAccess,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if member.text == "" || selfLintIsIntentionalDiscard(member.text) {
+        return report
+    }
+    if typePub || member.flags == 1 {
+        return report
+    }
+    if selfLintStringListContains(access.methods, member.text) {
+        return report
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0006",
+        "method is never called",
+        member.text,
+        member.start,
+        member.end,
+        idx,
+    )
 }

--- a/toolchain/lint_test.osty
+++ b/toolchain/lint_test.osty
@@ -608,6 +608,162 @@ fn testSelfLintFindsDeadStoreAcrossNestedBlockReads() {
     testing.assertEq(selfLintCodeCount(report, "L0008"), 0)
 }
 
+fn testSelfLintFindsUnusedFieldOnNonPubStruct() {
+    let report = selfLintSource(
+        r"""
+            struct Point {
+                x: Int,
+                y: Int,
+            }
+
+            fn build() -> Point {
+                let p = Point { x: 1, y: 2 }
+                p
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0005"), 0)
+}
+
+fn testSelfLintFindsUnusedFieldWhenNeverRead() {
+    let report = selfLintSource(
+        r"""
+            struct Counter {
+                value: Int,
+                spare: Int,
+            }
+
+            fn use(c: Counter) -> Int {
+                c.value
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0005"), 1)
+}
+
+fn testSelfLintSkipsUnusedFieldOnPubStruct() {
+    let report = selfLintSource(
+        r"""
+            pub struct Counter {
+                pub value: Int,
+                spare: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0005"), 0)
+}
+
+fn testSelfLintSkipsUnusedFieldWhenFieldIsPub() {
+    let report = selfLintSource(
+        r"""
+            struct Counter {
+                pub spare: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0005"), 0)
+}
+
+fn testSelfLintCountsStructPatternAsFieldRead() {
+    let report = selfLintSource(
+        r"""
+            struct User {
+                name: String,
+                age: Int,
+            }
+
+            fn render(u: User) -> String {
+                let User { name, age } = u
+                name
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0005"), 0)
+}
+
+fn testSelfLintFindsUnusedPrivateMethodOnNonPubStruct() {
+    let report = selfLintSource(
+        r"""
+            struct Counter {
+                value: Int,
+
+                fn bump(self) -> Int { self.value + 1 }
+            }
+
+            fn build(c: Counter) -> Int {
+                c.value
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0006"), 1)
+}
+
+fn testSelfLintSkipsUnusedMethodWhenMethodIsPub() {
+    let report = selfLintSource(
+        r"""
+            struct Counter {
+                value: Int,
+
+                pub fn bump(self) -> Int { self.value + 1 }
+            }
+
+            fn build(c: Counter) -> Int {
+                c.value
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0006"), 0)
+}
+
+fn testSelfLintSkipsUnusedMethodOnPubEnum() {
+    let report = selfLintSource(
+        r"""
+            pub enum Color {
+                Red,
+                Green,
+
+                fn label(self) -> String { "c" }
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0006"), 0)
+}
+
+fn testSelfLintCountsMethodCallAsUsed() {
+    let report = selfLintSource(
+        r"""
+            struct Counter {
+                value: Int,
+
+                fn bump(self) -> Int { self.value + 1 }
+            }
+
+            fn run(c: Counter) -> Int {
+                c.bump()
+            }
+            """,
+    )
+
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0006"), 0)
+}
+
 fn assertLintFirstFix(
     report: SelfLintReport,
     code: String,


### PR DESCRIPTION
## Summary
- 셀프호스팅 린터(`examples/selfhost-core/lint.osty`, `toolchain/lint.osty`)에 **L0005** (`field is never read`) / **L0006** (`method is never called`) 추가 — Go 측 `internal/lint/unused_member.go`의 이름 기반 휴리스틱과 정확히 대칭
- 파일 전체를 한 번 순회하며 `AstNCall` / `AstNField` / `AstNStructLit` / 구조체 패턴에서 멤버 참조를 수집한 뒤, 비-pub 타입의 비-pub 멤버 중 인덱스에 없는 이름에 대해 경고 발행
- `x.m(...)`는 메서드로만 기록하고 필드로 재기록하지 않아 Go 쪽과 동일한 false-positive 면제 프로파일을 유지
- pub 타입 / pub 멤버는 외부 소비자 존재 가정으로 면제
- `toolchain/lint_test.osty`에 9개 포커스 케이스 추가 (구조체 패턴이 읽기로 잡히는지, pub enum 메서드 면제, 메서드 호출 추적 등)

## Test plan
- [x] `just front` — 프론트엔드 패키지 전부 통과
- [ ] CI가 `generated.go`를 재생성해야 실제 L0005/L0006이 `selfhost.LintDiagnostics`에 노출됨 (Windows 로컬에서는 bootstrap-gen이 파서/포맷 테스트를 깨는 출력을 내어 재생성을 로컬에서 커밋하지 않음 — 내 변경과 무관한 플랫폼 이슈)
- [ ] Mac CI에서 `go generate ./internal/selfhost/...` 후 `toolchain/lint_test.osty`의 새 케이스 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)