### PR TITLE
chore(selfhost): strip CRLF from merged toolchain source before bootstrap-gen

### DIFF
--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -43,6 +43,13 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	// `text=auto` in .gitattributes checks `toolchain/*.osty` out with
+	// CRLF on Windows. The Osty lexer treats `\r` inside a string as
+	// an unterminated-string error, so a raw merged source breaks
+	// bootstrap-gen's resolve pass with ~100 false positives. Strip
+	// CR unconditionally — the in-tree files are canonical LF, and
+	// this keeps the regen pipeline portable across hosts.
+	merged = bytes.ReplaceAll(merged, []byte("\r\n"), []byte("\n"))
 	mergedPath := filepath.Join(tmpDir, "selfhost_merged.osty")
 	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
 		return fmt.Errorf("write merged selfhost source: %w", err)


### PR DESCRIPTION
## Summary

- `.gitattributes` has `* text=auto`, so `toolchain/*.osty` checks out with CRLF line endings on Windows.
- The Osty lexer treats a stray `\r` inside a string literal as an unterminated-string error, so `go generate ./internal/selfhost` on Windows surfaces ~100 `osty-bootstrap-gen: resolve: unterminated string literal` diagnostics before `patchGenerated` runs.
- Normalize `\r\n` → `\n` in the merged source buffer before it reaches bootstrap-gen's tmpdir. In-tree Osty files are canonical LF; the CRLF is purely a checkout artifact.

## Context

Follow-up to [#467](https://github.com/choiceoh/osty/pull/467). While continuing Tier A-2 work on Windows I hit a wall of "unterminated string literal" errors from bootstrap-gen, which were swallowed by stdout and left `generate selfhost parser: exit status 1` as the only user-visible signal. This PR eliminates that class of noise so future cross-platform regens produce actionable output.

## Out of scope

A separate Windows-vs-macOS content divergence further down the regen pipeline remains — a clean Windows regen now runs without resolve errors but still produces a `generated.go` that breaks two tests (`TestRuntimeFixtureUsesRuntimeRawStdlib`, `TestFormatUseCRoundTrips`). I don't yet have the data to isolate that; it's likely a platform-specific ordering or filesystem behavior in bootstrap-gen itself, orthogonal to the CRLF issue fixed here. Tracking that gap separately.

## Test plan

- [x] `just front` — all packages green (no behavior change, pure pipeline fix)
- [x] `go generate ./internal/selfhost` on Windows no longer emits `unterminated string literal` errors
- [ ] (reviewer) `go generate ./internal/selfhost` on macOS/Linux continues to work (the `\r\n` → `\n` replacement is a no-op on LF input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)