### PR TITLE
feat(llvmgen): String method-call dispatch + List<T>.insert

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1279,6 +1279,43 @@ void osty_rt_list_push_i64(void *raw_list, int64_t value) {
     osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }
 
+// osty_rt_list_insert_raw shifts list[index..len] right by one slot
+// and writes value into slot `index`. Bounds: index in [0, len].
+// Mirrors osty_rt_list_push_raw's layout/reserve discipline so the
+// element ABI stays consistent.
+static void osty_rt_list_insert_raw(void *raw_list, int64_t index, const void *value, size_t elem_size, osty_rt_trace_slot_fn trace_elem) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    if (index < 0 || index > list->len) {
+        osty_rt_abort("list.insert index out of range");
+    }
+    osty_rt_list_ensure_layout(list, elem_size, trace_elem);
+    osty_rt_list_reserve(list, list->len + 1);
+    if (index < list->len) {
+        memmove(list->data + (size_t)(index + 1) * elem_size,
+                list->data + (size_t)index * elem_size,
+                (size_t)(list->len - index) * elem_size);
+    }
+    memcpy(list->data + (size_t)index * elem_size, value, elem_size);
+    list->len += 1;
+}
+
+void osty_rt_list_insert_i64(void *raw_list, int64_t index, int64_t value) {
+    osty_rt_list_insert_raw(raw_list, index, &value, sizeof(value), NULL);
+}
+
+void osty_rt_list_insert_i1(void *raw_list, int64_t index, bool value) {
+    osty_rt_list_insert_raw(raw_list, index, &value, sizeof(value), NULL);
+}
+
+void osty_rt_list_insert_f64(void *raw_list, int64_t index, double value) {
+    osty_rt_list_insert_raw(raw_list, index, &value, sizeof(value), NULL);
+}
+
+void osty_rt_list_insert_ptr(void *raw_list, int64_t index, void *value) {
+    osty_rt_list_insert_raw(raw_list, index, &value, sizeof(value), osty_gc_mark_slot_v1);
+    osty_gc_post_write_v1(raw_list, value, OSTY_GC_KIND_LIST);
+}
+
 void osty_rt_list_push_i1(void *raw_list, bool value) {
     osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }
@@ -1322,6 +1359,39 @@ void osty_rt_list_push_bytes_roots_v1(void *raw_list, const void *value, int64_t
     osty_rt_list_ensure_layout(list, (size_t)elem_size, NULL);
     osty_rt_list_ensure_gc_offsets(list, gc_offsets, gc_offset_count);
     osty_rt_list_push_bytes(raw_list, value, (size_t)elem_size, NULL);
+    for (i = 0; i < gc_offset_count; i++) {
+        void *child = NULL;
+        memcpy(&child, ((const unsigned char *)value) + (size_t)gc_offsets[i], sizeof(child));
+        if (child != NULL) {
+            osty_gc_post_write_v1(raw_list, child, OSTY_GC_KIND_LIST);
+        }
+    }
+}
+
+// osty_rt_list_insert_bytes_v1 mirrors push_bytes_v1 but at an
+// arbitrary index — shifts list[index..len] right by one slot and
+// writes the byte payload into slot `index`. Used by the aggregate /
+// struct list-insert path; pointer-element struct fields go through
+// the *_roots variant below so GC sees the new edges.
+void osty_rt_list_insert_bytes_v1(void *raw_list, int64_t index, const void *value, int64_t elem_size) {
+    if (elem_size < 0) {
+        osty_rt_abort("negative list element size");
+    }
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, (size_t)elem_size, NULL);
+    osty_rt_list_ensure_gc_offsets(list, NULL, 0);
+    osty_rt_list_insert_raw(raw_list, index, value, (size_t)elem_size, NULL);
+}
+
+void osty_rt_list_insert_bytes_roots_v1(void *raw_list, int64_t index, const void *value, int64_t elem_size, const int64_t *gc_offsets, int64_t gc_offset_count) {
+    if (elem_size < 0) {
+        osty_rt_abort("negative list element size");
+    }
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, (size_t)elem_size, NULL);
+    osty_rt_list_ensure_gc_offsets(list, gc_offsets, gc_offset_count);
+    osty_rt_list_insert_raw(raw_list, index, value, (size_t)elem_size, NULL);
+    int64_t i;
     for (i = 0; i < gc_offset_count; i++) {
         void *child = NULL;
         memcpy(&child, ((const unsigned char *)value) + (size_t)gc_offsets[i], sizeof(child));

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2339,6 +2339,44 @@ func (g *generator) emitListAggregatePush(listValue, elem value) error {
 	return nil
 }
 
+// emitListAggregateInsert mirrors emitListAggregatePush but for an
+// arbitrary index — the underlying runtime memmoves the tail right by
+// one slot and copies the value bytes into slot `index`. Pointer-bearing
+// struct fields go through the *_roots variant so GC sees the new edges.
+func (g *generator) emitListAggregateInsert(listValue, idx, elem value) error {
+	emitter := g.toOstyEmitter()
+	slot := g.emitAggregateScratchSlot(emitter, elem.typ, elem.ref)
+	size := g.emitAggregateByteSize(emitter, elem.typ)
+	offsetsPtr, offsetCount, err := g.emitAggregateRootOffsets(emitter, elem.typ)
+	if err != nil {
+		return err
+	}
+	if offsetCount == 0 {
+		g.declareRuntimeSymbol(listRuntimeInsertBytesV1Symbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimeInsertBytesV1Symbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(listValue), toOstyValue(idx), toOstyValue(value{typ: "ptr", ref: slot.ref}), toOstyValue(size)}),
+		))
+	} else {
+		g.declareRuntimeSymbol(listRuntimeInsertBytesRootsSymbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimeInsertBytesRootsSymbol(),
+			llvmCallArgs([]*LlvmValue{
+				toOstyValue(listValue),
+				toOstyValue(idx),
+				toOstyValue(value{typ: "ptr", ref: slot.ref}),
+				toOstyValue(size),
+				toOstyValue(offsetsPtr),
+				toOstyValue(value{typ: "i64", ref: strconv.Itoa(offsetCount)}),
+			}),
+		))
+	}
+	g.takeOstyEmitter(emitter)
+	return nil
+}
+
 func (g *generator) emitListAggregateGet(listValue value, index value, elemTyp string) (value, error) {
 	g.declareRuntimeSymbol(listRuntimeGetBytesV1Symbol(), "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: "ptr"}, {typ: "i64"}})
 	emitter := g.toOstyEmitter()
@@ -2707,6 +2745,64 @@ func (g *generator) emitStringMethodCall(call *ast.CallExpr) (value, bool, error
 		out := llvmStringHasPrefix(emitter, toOstyValue(base), toOstyValue(prefix))
 		g.takeOstyEmitter(emitter)
 		return fromOstyValue(out), true, nil
+	case "endsWith":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "String.endsWith requires one positional argument")
+		}
+		suffix, err := g.emitStdStringsArg(call.Args[0], "endsWith", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeHasSuffixSymbol(), "i1", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", llvmStringRuntimeHasSuffixSymbol(), []*LlvmValue{toOstyValue(base), toOstyValue(suffix)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "contains":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "String.contains requires one positional argument")
+		}
+		needle, err := g.emitStdStringsArg(call.Args[0], "contains", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeContainsSymbol(), "i1", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", llvmStringRuntimeContainsSymbol(), []*LlvmValue{toOstyValue(base), toOstyValue(needle)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "trimPrefix":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "String.trimPrefix requires one positional argument")
+		}
+		prefix, err := g.emitStdStringsArg(call.Args[0], "trimPrefix", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeTrimPrefixSymbol(), "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "ptr", llvmStringRuntimeTrimPrefixSymbol(), []*LlvmValue{toOstyValue(base), toOstyValue(prefix)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.sourceType = &ast.NamedType{Path: []string{"String"}}
+		return v, true, nil
+	case "trimSuffix":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "String.trimSuffix requires one positional argument")
+		}
+		suffix, err := g.emitStdStringsArg(call.Args[0], "trimSuffix", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeTrimSuffixSymbol(), "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "ptr", llvmStringRuntimeTrimSuffixSymbol(), []*LlvmValue{toOstyValue(base), toOstyValue(suffix)})
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.sourceType = &ast.NamedType{Path: []string{"String"}}
+		return v, true, nil
 	case "split":
 		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
 			return value{}, true, unsupported("call", "String.split requires one positional argument")

--- a/internal/llvmgen/list_insert_test.go
+++ b/internal/llvmgen/list_insert_test.go
@@ -1,0 +1,79 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// List<T>.insert(index, value) — ordered insert via shift-right. The
+// LSP self-host (`sorted.insert(i, tagged)` in lsp.osty) tripped
+// LLVM015 [method_call_field] / "only println calls are supported"
+// because the statement-form list method dispatcher only routed
+// `push` and `pop`. This test locks the new osty_rt_list_insert_*
+// runtime call.
+func TestListInsertI64(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut xs: List<Int> = [10, 30]
+    xs.insert(1, 20)
+    println(xs.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_insert_i64.osty"})
+	if err != nil {
+		t.Fatalf("list.insert<Int> errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_insert_i64",
+		"declare void @osty_rt_list_insert_i64(ptr, i64, i64)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("list.insert<Int> missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Aggregate-element insert — `list.insert(i, struct_value)` for a
+// struct type that uses the aggregate (bytes-based) list ABI.
+// LSP's `sorted.insert(i, tagged)` where `tagged: LspIndexedSymbolSortKey`
+// is the canonical reproducer.
+func TestListInsertAggregateStruct(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Point {
+    x: Int,
+    y: Int,
+}
+
+fn main() {
+    let mut xs: List<Point> = [Point { x: 0, y: 0 }, Point { x: 2, y: 2 }]
+    xs.insert(1, Point { x: 1, y: 1 })
+    println(xs.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_insert_struct.osty"})
+	if err != nil {
+		t.Fatalf("list.insert<struct> errored: %v", err)
+	}
+	got := string(ir)
+	// Either bytes_v1 (no pointer roots) or bytes_roots_v1 (with roots);
+	// for an Int-only struct it'll be the v1 path.
+	if !strings.Contains(got, "@osty_rt_list_insert_bytes_v1") &&
+		!strings.Contains(got, "@osty_rt_list_insert_bytes_roots_v1") {
+		t.Fatalf("list.insert<struct> did not invoke aggregate insert helper:\n%s", got)
+	}
+}
+
+func TestListInsertString(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut xs: List<String> = ["a", "c"]
+    xs.insert(1, "b")
+    println(xs.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_insert_string.osty"})
+	if err != nil {
+		t.Fatalf("list.insert<String> errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "@osty_rt_list_insert_ptr") {
+		t.Fatalf("list.insert<String> did not invoke insert_ptr:\n%s", got)
+	}
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -327,6 +327,18 @@ func listRuntimeSetSymbol(elemTyp string) string {
 	return llvmListRuntimeSetSymbol(llvmListElementSuffix(elemTyp))
 }
 
+func listRuntimeInsertSymbol(elemTyp string) string {
+	return llvmListRuntimeInsertSymbol(llvmListElementSuffix(elemTyp))
+}
+
+func listRuntimeInsertBytesV1Symbol() string {
+	return "osty_rt_list_insert_bytes_v1"
+}
+
+func listRuntimeInsertBytesRootsSymbol() string {
+	return "osty_rt_list_insert_bytes_roots_v1"
+}
+
 func listRuntimeSortedSymbol(elemTyp string, elemString bool) string {
 	return llvmListRuntimeSortedSymbol(elemTyp, elemString)
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1569,7 +1569,11 @@ func (g *generator) emitMatchArmBodyAsStmt(body ast.Expr) error {
 func (g *generator) emitPrintln(call *ast.CallExpr) error {
 	id, ok := call.Fn.(*ast.Ident)
 	if !ok || id.Name != "println" {
-		return unsupportedf("call", "only println calls are supported (got %T at %s)", call.Fn, call.Pos().String())
+		// Tag with the offending call's source position + Fn type so
+		// merged-toolchain probes can grep the buffer immediately.
+		// Without a category like FieldExpr/Ident the bare wall is
+		// invisible in the histogram (see classifyLLVM015 → "other").
+		return unsupportedf("call", "only println calls are supported (got %T %s)", call.Fn, exprPosLabel(call))
 	}
 	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 		return unsupported("call", "println requires one positional argument")
@@ -1601,7 +1605,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	if field.Name != "push" && field.Name != "pop" {
+	if field.Name != "push" && field.Name != "pop" && field.Name != "insert" {
 		return false, nil
 	}
 	g.pushScope()
@@ -1631,6 +1635,49 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 			"  call void @%s(%s)",
 			listRuntimePopDiscardSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue)}),
+		))
+		g.takeOstyEmitter(emitter)
+		return true, nil
+	}
+	if field.Name == "insert" {
+		if len(call.Args) != 2 || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return true, unsupported("call", "list.insert requires two positional arguments (index, value)")
+		}
+		idx, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return true, err
+		}
+		if idx.typ != "i64" {
+			return true, unsupportedf("type-system", "list.insert index type %s, want Int", idx.typ)
+		}
+		idxValue, err := g.loadIfPointer(idx)
+		if err != nil {
+			return true, err
+		}
+		arg, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return true, err
+		}
+		if arg.typ != elemTyp {
+			return true, unsupportedf("type-system", "list.insert value type %s, want %s", arg.typ, elemTyp)
+		}
+		argValue, err := g.loadIfPointer(arg)
+		if err != nil {
+			return true, err
+		}
+		if g.usesAggregateListABI(elemTyp) {
+			return true, g.emitListAggregateInsert(baseValue, idxValue, argValue)
+		}
+		if !listUsesTypedRuntime(elemTyp) {
+			return true, unsupportedf("call", "list.insert is currently supported on List<T> with typed-runtime or aggregate element ABI; got element type %s", elemTyp)
+		}
+		insertSymbol := listRuntimeInsertSymbol(elemTyp)
+		g.declareRuntimeSymbol(insertSymbol, "void", []paramInfo{{typ: "ptr"}, {typ: "i64"}, {typ: elemTyp}})
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			insertSymbol,
+			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue), toOstyValue(idxValue), toOstyValue(argValue)}),
 		))
 		g.takeOstyEmitter(emitter)
 		return true, nil

--- a/internal/llvmgen/string_method_dispatch_test.go
+++ b/internal/llvmgen/string_method_dispatch_test.go
@@ -1,0 +1,119 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// String method-call dispatch — `s.trimPrefix(p)`, `s.trimSuffix(p)`,
+// `s.contains(n)`, `s.endsWith(p)` — must lower to the same runtime
+// helpers that the free-function `strings.*` forms already use. Prior
+// to this commit the toolchain's `trimmed.trimPrefix("runtime.")` call
+// in llvmgen.osty tripped LLVM015 because only `startsWith` was
+// dispatched; the rest fell through to the "not a known fn" wall.
+func TestStringTrimPrefixMethodCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn drop(prefix: String, s: String) -> String {
+    s.trimPrefix(prefix)
+}
+
+fn main() {
+    println(drop("runtime.", "runtime.strings"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_trim_prefix_method.osty"})
+	if err != nil {
+		t.Fatalf("trimPrefix method call errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_TrimPrefix",
+		"declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("trimPrefix method call missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStringTrimSuffixMethodCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn drop(suffix: String, s: String) -> String {
+    s.trimSuffix(suffix)
+}
+
+fn main() {
+    println(drop(".osty", "lexer.osty"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_trim_suffix_method.osty"})
+	if err != nil {
+		t.Fatalf("trimSuffix method call errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "@osty_rt_strings_TrimSuffix") {
+		t.Fatalf("trimSuffix method call did not invoke runtime helper:\n%s", got)
+	}
+}
+
+func TestStringContainsMethodCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn has(s: String, n: String) -> Bool {
+    s.contains(n)
+}
+
+fn main() {
+    println(has("hello, world", "world"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_contains_method.osty"})
+	if err != nil {
+		t.Fatalf("contains method call errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "@osty_rt_strings_Contains") {
+		t.Fatalf("contains method call did not invoke runtime helper:\n%s", got)
+	}
+}
+
+func TestStringEndsWithMethodCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn endsTest(s: String, suffix: String) -> Bool {
+    s.endsWith(suffix)
+}
+
+fn main() {
+    println(endsTest("foo.osty", ".osty"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_ends_with_method.osty"})
+	if err != nil {
+		t.Fatalf("endsWith method call errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "@osty_rt_strings_HasSuffix") {
+		t.Fatalf("endsWith method call did not invoke HasSuffix runtime helper:\n%s", got)
+	}
+}
+
+// Chained method calls — `s.trimPrefix(a).trimSuffix(b).contains(n)` —
+// must keep flowing through the String dispatcher rather than dropping
+// the source-type hint after the first call. This locks in the
+// `sourceType: String` propagation on trimPrefix / trimSuffix outputs.
+func TestStringMethodChain(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn pipeline(s: String) -> Bool {
+    s.trimPrefix("[").trimSuffix("]").contains(",")
+}
+
+fn main() {
+    println(pipeline("[a,b]"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_method_chain.osty"})
+	if err != nil {
+		t.Fatalf("chained string methods errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_TrimPrefix",
+		"@osty_rt_strings_TrimSuffix",
+		"@osty_rt_strings_Contains",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("chain missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1485,6 +1485,10 @@ func llvmListRuntimeSetSymbol(suffix string) string {
 	return "osty_rt_list_set_" + suffix
 }
 
+func llvmListRuntimeInsertSymbol(suffix string) string {
+	return "osty_rt_list_insert_" + suffix
+}
+
 func llvmListRuntimeSortedSymbol(elemTyp string, isString bool) string {
 	if isString {
 		return "osty_rt_list_sorted_string"

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -793,14 +793,14 @@ func (g *generator) staticStringMethodSourceType(call *ast.CallExpr) (ast.Type, 
 	switch field.Name {
 	case "len":
 		return &ast.NamedType{Path: []string{"Int"}}, true
-	case "isEmpty", "startsWith":
+	case "isEmpty", "startsWith", "endsWith", "contains":
 		return &ast.NamedType{Path: []string{"Bool"}}, true
 	case "split":
 		return &ast.NamedType{
 			Path: []string{"List"},
 			Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
 		}, true
-	case "trim", "toString":
+	case "trim", "trimPrefix", "trimSuffix", "toString":
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case "chars":
 		return &ast.NamedType{
@@ -864,12 +864,12 @@ func (g *generator) staticStringMethodResult(call *ast.CallExpr) (value, bool) {
 	switch field.Name {
 	case "len":
 		return value{typ: "i64"}, true
-	case "isEmpty", "startsWith":
+	case "isEmpty", "startsWith", "endsWith", "contains":
 		return value{typ: "i1"}, true
 	case "split":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true}, true
-	case "trim", "toString":
-		return value{typ: "ptr", gcManaged: true}, true
+	case "trim", "trimPrefix", "trimSuffix", "toString":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
 	case "chars":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "i32"}, true
 	case "bytes":
@@ -893,7 +893,9 @@ func (g *generator) stringMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) 
 		return nil, false
 	}
 	switch field.Name {
-	case "len", "isEmpty", "startsWith", "split", "trim", "toString", "chars", "bytes":
+	case "len", "isEmpty", "startsWith", "endsWith", "contains",
+		"trimPrefix", "trimSuffix",
+		"split", "trim", "toString", "chars", "bytes":
 		return field, true
 	default:
 		return nil, false
@@ -981,7 +983,7 @@ func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, 
 		return nil, "", false, false
 	}
 	switch field.Name {
-	case "len", "isEmpty", "pop", "push", "sorted", "toSet":
+	case "len", "isEmpty", "pop", "push", "insert", "sorted", "toSet":
 	default:
 		return nil, "", false, false
 	}


### PR DESCRIPTION
## Summary

Two Tier A increments that advance the native-toolchain self-compile probe past two consecutive walls. Builds on [#462](https://github.com/choiceoh/osty/pull/462).

### 1. String method-call dispatch — `trimPrefix` / `trimSuffix` / `contains` / `endsWith`

These methods were already registered in the toolchain's `check_env`, but the codegen only routed `startsWith`. The toolchain's `trimmed.trimPrefix(\"runtime.\")` in `llvmgen.osty` tripped `LLVM015 [method_call_field]`.

- Extend `stringMethodInfo` whitelist + emit branches calling the existing `osty_rt_strings_{TrimPrefix,TrimSuffix,Contains,HasSuffix}` runtime helpers.
- Carry `sourceType: String` through `trim` / `trimPrefix` / `trimSuffix` results so chained calls (`s.trimPrefix(a).trimSuffix(b).contains(n)`) keep flowing through the dispatcher.

### 2. `List<T>.insert(index, value)` — typed + aggregate

The statement-form list method dispatcher only routed `push` and `pop`. LSP self-host's `sorted.insert(i, tagged)` (where `tagged` is a struct) tripped `LLVM015 [other]` / *only println calls are supported*.

- Add `osty_rt_list_insert_raw` static helper + typed `insert_{i64,i1,f64,ptr}` + `insert_bytes_v1` + `insert_bytes_roots_v1` runtime helpers (saturating GC write barriers for both pointer-element lists and structs with `gc_offsets`).
- Wire `listRuntimeInsertSymbol` + `listRuntimeInsertBytes(Roots)Symbol`.
- Extend `listMethodInfo` whitelist; route stmt-form `insert` through three tiers: typed-runtime, aggregate (struct via bytes/roots), unsupported.
- Add `emitListAggregateInsert` mirror of `emitListAggregatePush`.

Also tags the *only println calls are supported* wall with `%T + source position` so future probes don't have to re-isolate via offset.

## Wall movement

```
NATIVE TOOLCHAIN first wall:
  before (post-#462):     LLVM015 [method_call_field] — trimmed.trimPrefix
  after String methods:   LLVM015 [other] — only println calls are supported
                          (sorted.insert(i, tagged))
  after list.insert:      LLVM011 [other] — comparison \"!=\" on non-String
                          ptr values is not yet lowered
```

## Test plan

- [x] `go test -count=1 -vet=off -run \"TestListInsert|TestStringTrimPrefix|TestStringContains|TestStringEndsWith|TestStringTrimSuffix|TestStringMethodChain\" ./internal/llvmgen` (8/8 PASS)
- [x] `go test -count=1 -vet=off -short -skip \"TestGenerateModuleExtendedListSortedAndToSet\" ./internal/llvmgen` (the skipped panic is pre-existing on main — unrelated)
- [x] `go test -count=1 -vet=off ./internal/backend ./internal/diag`
- [x] `TestProbeNativeToolchainMerged` confirms wall has advanced from LLVM015 to LLVM011

🤖 Generated with [Claude Code](https://claude.com/claude-code)