### PR TITLE
feat(llvmgen): ptr identity ==/!= + fix parser.osty param mutation

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1170,6 +1170,23 @@ func (g *generator) emitCompare(op token.Kind, left, right value, isString bool)
 	case "ptr":
 		g.takeOstyEmitter(emitter)
 		if !isString {
+			// `==` / `!=` between two opaque managed pointers fall back
+			// to identity comparison — the same `icmp eq/ne ptr` shape
+			// LLVM uses for null checks. This is the only sensible
+			// semantics for non-String ptr values until structural
+			// equality is wired in. Ordering ops stay rejected; they
+			// have no meaning for identities.
+			opStr := op.String()
+			if opStr == "==" || opStr == "!=" {
+				pred := "eq"
+				if opStr == "!=" {
+					pred = "ne"
+				}
+				emitter := g.toOstyEmitter()
+				out := llvmCompare(emitter, pred, toOstyValue(left), toOstyValue(right))
+				g.takeOstyEmitter(emitter)
+				return fromOstyValue(out), nil
+			}
 			return value{}, unsupportedf("type-system", "comparison operator %q on non-String ptr values is not yet lowered", op)
 		}
 		return g.emitRuntimeStringCompare(op, left, right)

--- a/internal/llvmgen/ptr_identity_cmp_test.go
+++ b/internal/llvmgen/ptr_identity_cmp_test.go
@@ -1,0 +1,74 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// Identity comparison — `==` / `!=` on two non-String managed pointers
+// (lists, maps, structs held via ptr). Previously the backend rejected
+// every non-String ptr compare with LLVM011, which is what the native
+// toolchain probe first walled on after the List.insert / String method
+// dispatch landed. Identity semantics match every GC language's
+// pointer-equality convention and are the only sane meaning without
+// structural equality wired in.
+func TestPtrIdentityEqList(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn sameList(a: List<Int>, b: List<Int>) -> Bool {
+    a == b
+}
+
+fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    println(sameList(xs, xs))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/ptr_cmp_eq.osty"})
+	if err != nil {
+		t.Fatalf("ptr == errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "icmp eq ptr") {
+		t.Fatalf("ptr == did not lower to icmp eq ptr:\n%s", got)
+	}
+}
+
+func TestPtrIdentityNeList(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn diff(a: List<Int>, b: List<Int>) -> Bool {
+    a != b
+}
+
+fn main() {
+    let xs: List<Int> = [1]
+    let ys: List<Int> = [2]
+    println(diff(xs, ys))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/ptr_cmp_ne.osty"})
+	if err != nil {
+		t.Fatalf("ptr != errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "icmp ne ptr") {
+		t.Fatalf("ptr != did not lower to icmp ne ptr:\n%s", got)
+	}
+}
+
+// Ordering ops still reject — identity doesn't have a <-ordering, and
+// structural ordering isn't wired in yet. Lock this in so a future
+// refactor doesn't accidentally silently allow nonsense compares.
+func TestPtrOrderingStillRejected(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn less(a: List<Int>, b: List<Int>) -> Bool {
+    a < b
+}
+
+fn main() {
+    let xs: List<Int> = []
+    println(less(xs, xs))
+}
+`)
+	_, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/ptr_cmp_lt.osty"})
+	if err == nil {
+		t.Fatalf("expected LLVM011 wall for `<` on non-String ptr; got nil")
+	}
+	if !strings.Contains(err.Error(), "LLVM011") {
+		t.Fatalf("expected LLVM011 wall; got: %v", err)
+	}
+}

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -287,7 +287,14 @@ func TestGenerateStringCompareUsesRuntimeABI(t *testing.T) {
 	}
 }
 
-func TestGenerateNonStringPtrCompareRejected(t *testing.T) {
+// Non-String ptr `==` / `!=` used to be a hard LLVM011 wall. It now
+// lowers to LLVM identity `icmp eq ptr` / `icmp ne ptr`, matching the
+// GC-language convention that pointer equality means same allocation.
+// Structural equality is a separate feature; this test locks the
+// identity semantics against accidental regression to either a wall
+// or a silent structural compare. Ordering ops (<, >, <=, >=) remain
+// rejected — see TestPtrOrderingStillRejected.
+func TestGenerateNonStringPtrCompareIsIdentity(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn main() {
     let a: List<Int> = [1, 2]
     let b: List<Int> = [3, 4]
@@ -299,15 +306,15 @@ func TestGenerateNonStringPtrCompareRejected(t *testing.T) {
 }
 `)
 
-	_, err := generateFromAST(file, Options{
+	ir, err := generateFromAST(file, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/nonstr_compare.osty",
 	})
-	if err == nil {
-		t.Fatal("Generate succeeded, want unsupported diagnostic for non-String ptr ==")
+	if err != nil {
+		t.Fatalf("non-String ptr == errored: %v", err)
 	}
-	if got := err.Error(); !strings.Contains(got, "non-String ptr") {
-		t.Fatalf("error = %q, want to mention non-String ptr", got)
+	if got := string(ir); !strings.Contains(got, "icmp eq ptr") {
+		t.Fatalf("non-String ptr == did not lower to icmp eq ptr:\n%s", got)
 	}
 }
 

--- a/toolchain/parser.osty
+++ b/toolchain/parser.osty
@@ -2080,6 +2080,12 @@ pub fn astPrettyPrint(file: AstFile) -> String {
 }
 
 fn astPPNode(arena: AstArena, idx: Int, depth: Int, lines: List<String>) -> List<String> {
+    // `lines` is an immutable parameter; shadow it with a mutable
+    // binding so we can thread the recursive-call return values
+    // through without reassigning a `let`-bound name. The List is
+    // heap-managed so both `push` in place and the return value pass
+    // through the same identity.
+    let mut lines = lines
     if idx < 0 {
         return lines
     }


### PR DESCRIPTION
## Summary

Two more Tier A increments on the native-toolchain self-compile path. Follow-up to [#474](https://github.com/choiceoh/osty/pull/474).

### 1. Ptr identity comparison — `==` / `!=` on non-String ptr

`emitCompare`'s `ptr` arm used to reject every non-String pointer compare with `LLVM011`. GC-language convention is that pointer equality means same allocation, so `==` / `!=` now lower to `icmp eq ptr` / `icmp ne ptr`.

Ordering ops (`<`, `>`, `<=`, `>=`) stay rejected — identities have no order, and structural ordering isn't wired in.

- Update pre-existing `TestGenerateNonStringPtrCompareRejected` → `TestGenerateNonStringPtrCompareIsIdentity` to lock the new semantics.
- Add `TestPtrIdentityEqList` / `TestPtrIdentityNeList` / `TestPtrOrderingStillRejected`.

### 2. Fix `parser.osty:astPPNode` immutable-param reassignment

`lines: List<String>` is a parameter (immutable by default) but the function rebinds `lines = astPPNode(...)` on recursion, tripping `LLVM012` *assignment to immutable identifier*. Shadow with `let mut lines = lines` at function entry — List identity is preserved since the underlying heap object is the same.

## Wall movement

```
NATIVE TOOLCHAIN first wall:
  before: LLVM011 [other] — comparison \"!=\" on non-String ptr values
          is not yet lowered
  after:  LLVM011 [other] — Some payload type %RunnerDiag requires
          boxed Option; only ptr-backed Some(...) is lowered
```

The next wall is a different Option-lowering concern in `runner.osty`; this PR doesn't tackle it.

## Test plan

- [x] `go test -count=1 -vet=off -run \"TestPtrIdentity|TestPtrOrdering|TestGenerateNonStringPtrCompareIsIdentity\" ./internal/llvmgen`
- [x] `go test -count=1 -vet=off -short -skip \"TestGenerateModuleExtendedListSortedAndToSet\" ./internal/llvmgen` (the skipped panic is pre-existing on main — unrelated)
- [x] `go test -count=1 -vet=off ./internal/backend ./internal/diag`
- [x] `TestProbeNativeToolchainMerged` confirms wall has advanced past the ptr-cmp and immutable-param walls

🤖 Generated with [Claude Code](https://claude.com/claude-code)