### PR TITLE
fix(selfhost): close more example gaps (165 → 143 errs)

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -1376,6 +1376,14 @@ func writeSelfhostPackageImport(b *bytes.Buffer, alias string, pkg *resolve.Pack
 					name = fmt.Sprintf("arg%d", i)
 				}
 				fmt.Fprintf(&body, "%s: %s", name, selfhostTypeSource(param.Type))
+				// Preserve default-availability for the arity check. The
+				// concrete literal value doesn't matter — collectFnDecl
+				// only looks at paramNode.left >= 0 to set the "?"
+				// paramName prefix. `= ()` is a valid literal default
+				// (spec §R18) across all param types.
+				if param.Default != nil {
+					body.WriteString(" = ()")
+				}
 			}
 			body.WriteByte(')')
 			if ret := selfhostTypeSource(fn.ReturnType); ret != "()" {

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -301,6 +301,7 @@ func selfhostBuildImportedFn(
 	scopeGenerics := selfhostGenericSet(combinedGenerics)
 	paramNames := make([]string, 0, len(fn.Params))
 	paramTypes := make([]string, 0, len(fn.Params))
+	paramDefaults := make([]bool, 0, len(fn.Params))
 	for i, param := range fn.Params {
 		if param == nil {
 			continue
@@ -309,8 +310,16 @@ func selfhostBuildImportedFn(
 		if name == "" {
 			name = fmt.Sprintf("arg%d", i)
 		}
+		// Encode default-availability into the name with a leading "?"
+		// so the checker's arity check can treat missing trailing args as
+		// satisfied by defaults without threading a parallel List<Bool>
+		// through every CheckFnSig constructor.
+		if param.Default != nil {
+			name = "?" + name
+		}
 		paramNames = append(paramNames, name)
 		paramTypes = append(paramTypes, selfhostImportedTypeSource(localTypes, scopeGenerics, param.Type))
+		paramDefaults = append(paramDefaults, param.Default != nil)
 	}
 	bounds := append([]selfhost.PackageCheckGenericBound(nil), ownerBounds...)
 	bounds = append(bounds, selfhostGenericBounds(localTypes, combinedGenerics, fn.Generics)...)
@@ -325,6 +334,7 @@ func selfhostBuildImportedFn(
 		ReturnType:    selfhostImportedTypeSource(localTypes, scopeGenerics, fn.ReturnType),
 		ParamNames:    paramNames,
 		ParamTypes:    paramTypes,
+		ParamDefaults: paramDefaults,
 		Generics:      combinedGenerics,
 		GenericBounds: bounds,
 	}

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -29084,6 +29084,11 @@ func checkInstallPrelude(env *CheckEnv) {
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:14813:5
 	tFnGroupListHandle := tyFn(env.tys, []int{tGroup}, tListHandleT)
 	_ = tFnGroupListHandle
+	// Spec §B.6 canonical shape: `taskGroup(|g| { ...; Ok(value) })`.
+	// Body returns `Result<T, Error>`. Mirrored from
+	// toolchain/check_env.osty pending a regen fix.
+	tFnGroupResult := tyFn(env.tys, []int{tGroup}, tResultT)
+	_ = tFnGroupResult
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:14814:5
 	tFnT := tyFn(env.tys, make([]int, 0, 1), tT)
 	_ = tFnT
@@ -29096,7 +29101,7 @@ func checkInstallPrelude(env *CheckEnv) {
 	var gT []string = []string{"T"}
 	_ = gT
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:14818:5
-	checkRegisterFn(env, &CheckFnSig{name: "taskGroup", owner: "", receiverTy: -1, retTy: tResultT, paramNames: []string{"body"}, paramTys: []int{tFnGroupListHandle}, generics: gT, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "taskGroup", owner: "", receiverTy: -1, retTy: tResultT, paramNames: []string{"body"}, paramTys: []int{tFnGroupResult}, generics: gT, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:14824:5
 	checkRegisterFn(env, &CheckFnSig{name: "spawn", owner: "", receiverTy: -1, retTy: tHandleT, paramNames: []string{"body"}, paramTys: []int{tFnT}, generics: gT, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:14830:5
@@ -29220,6 +29225,25 @@ func checkInstallChannelIntrinsics(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "isClosed", owner: "Channel", receiverTy: tChanT, retTy: tBool(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: gT, genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:14959:5
 	checkRegisterFn(env, &CheckFnSig{name: "join", owner: "Handle", receiverTy: tHandleT, retTy: tT, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: gT, genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// SelectBuilder / Duration — spec §B.6 select builder and duration
+	// literals. Mirrored from toolchain/check_env.osty pending a regen
+	// fix.
+	bounds := func() []*CheckGenericBound { return make([]*CheckGenericBound, 0) }
+	checkRegisterType(env, &CheckTypeSig{name: "SelectBuilder", generics: []string{}, genericBounds: bounds(), kind: "struct"})
+	checkRegisterType(env, &CheckTypeSig{name: "Duration", generics: []string{}, genericBounds: bounds(), kind: "struct"})
+	tSelectBuilder := tyNamed(tys, "SelectBuilder", []int{})
+	tDuration_ := tyNamed(tys, "Duration", []int{})
+	tChanTy := tyNamed(tys, "Channel", []int{tT})
+	tFnUnitT := tyFn(tys, []int{}, tT)
+	tFnResT := tyFn(tys, []int{tT}, tT)
+	checkRegisterFn(env, &CheckFnSig{name: "recv", owner: "SelectBuilder", receiverTy: tSelectBuilder, retTy: tUnit(tys), paramNames: []string{"ch", "handler"}, paramTys: []int{tChanTy, tFnResT}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "send", owner: "SelectBuilder", receiverTy: tSelectBuilder, retTy: tUnit(tys), paramNames: []string{"ch", "value", "handler"}, paramTys: []int{tChanTy, tT, tFnUnitT}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "timeout", owner: "SelectBuilder", receiverTy: tSelectBuilder, retTy: tUnit(tys), paramNames: []string{"duration", "handler"}, paramTys: []int{tDuration_, tFnUnitT}, generics: gT, genericBounds: bounds()})
+	checkRegisterFn(env, &CheckFnSig{name: "default", owner: "SelectBuilder", receiverTy: tSelectBuilder, retTy: tUnit(tys), paramNames: []string{"handler"}, paramTys: []int{tFnUnitT}, generics: gT, genericBounds: bounds()})
+	tIntTy := tInt(tys)
+	for _, suffix := range []string{"s", "ms", "us", "ns"} {
+		checkRegisterFn(env, &CheckFnSig{name: suffix, owner: "Int", receiverTy: tIntTy, retTy: tDuration_, paramNames: []string{}, paramTys: []int{}, generics: []string{}, genericBounds: bounds()})
+	}
 }
 
 // Osty: /tmp/selfhost_merged.osty:14977:1
@@ -32303,7 +32327,7 @@ func elabInferCall(cx *ElabCx, callIdx int, node *AstNode, expected int) *ElabRe
 		coreFn := coreIdent(cx.core, baseCallee.text, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
 		_ = coreFn
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17017:9
-		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
+		coreArgs := elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, argIdxs, node.start, node.end)
 		_ = coreArgs
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17018:9
 		retTy := sig.retTy
@@ -32407,7 +32431,7 @@ func elabInferStaticMethodCall(cx *ElabCx, callIdx int, node *AstNode, fieldNode
 		coreFn := coreIdent(cx.core, sig.name, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), fieldNode.start, fieldNode.end)
 		_ = coreFn
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17129:9
-		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
+		coreArgs := elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, argIdxs, node.start, node.end)
 		_ = coreArgs
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17130:9
 		retTy := sig.retTy
@@ -32609,7 +32633,7 @@ func elabInferMethodCall(cx *ElabCx, callNode *AstNode, fieldNode *AstNode, expe
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17227:5
 	if checkStringListLenHelper(sig.generics) == 0 {
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17228:9
-		coreArgs := elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, callNode.children, callNode.start, callNode.end)
+		coreArgs := elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, callNode.children, callNode.start, callNode.end)
 		_ = coreArgs
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17229:9
 		retTy := sig.retTy
@@ -32761,9 +32785,13 @@ func elabCallArgs(cx *ElabCx, solver *Solver, sig *CheckFnSig, freshs []int, arg
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17340:5
 	gotCount := checkIntListLenHelper(argIdxs)
 	_ = gotCount
-	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17341:5
-	if wantCount != gotCount {
-		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17342:9
+	// Trailing params whose names start with "?" are marked as having
+	// defaults by selfhostBuildImportedFn / collectFnDecl. An
+	// under-arity call satisfied by defaults does not emit E0701.
+	// Mirrored from toolchain/elab.osty pending a regen fix.
+	defaultCount := paramDefaultCount(sig.paramNames)
+	minArity := wantCount - defaultCount
+	if gotCount > wantCount || gotCount < minArity {
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagArgCount(sig.name, wantCount, gotCount, start, end))
 			return struct{}{}
@@ -32808,9 +32836,14 @@ func elabCallArgs(cx *ElabCx, solver *Solver, sig *CheckFnSig, freshs []int, arg
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17355:9
 		hint := zonk(cx.env, solver, specialisedWant)
 		_ = hint
-		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17356:9
+		// Closure arguments: if the hint is `fn(P..) -> R` with params
+		// fully resolved (even if R is still open), pass it so the
+		// closure can seed param slots from P. Mirrored from
+		// toolchain/elab.osty pending a regen fix.
+		hintIsFnWithConcreteParams := ostyEqual(tyKindAt(cx.env.tys, hint), TyKind(&TyKind_TkFn{})) &&
+			allFullyResolved(cx.env, solver, tyArgsAt(cx.env.tys, hint))
 		r := func() *ElabResult {
-			if isFullyResolved(cx.env, solver, hint) {
+			if isFullyResolved(cx.env, solver, hint) || hintIsFnWithConcreteParams {
 				return elabCheck(cx, argIdx, hint)
 			} else {
 				return elabInfer(cx, argIdx)
@@ -32844,15 +32877,20 @@ func elabIsToStringFormatter(name string) bool {
 
 // Osty: /tmp/selfhost_merged.osty:17377:1
 func elabCallArgsMonomorphic(cx *ElabCx, callee string, paramTys []int, argIdxs []int, start int, end int) []int {
-	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17385:5
+	return elabCallArgsMonomorphicWithNames(cx, callee, nil, paramTys, argIdxs, start, end)
+}
+
+// elabCallArgsMonomorphicWithNames lets the non-generic call path take
+// default-carrying params into account. paramNames may carry the "?"
+// prefix marking trailing defaults; an under-arity call satisfied by
+// defaults is accepted without an E0701 diag. Mirrored from
+// toolchain/elab.osty pending a regen fix.
+func elabCallArgsMonomorphicWithNames(cx *ElabCx, callee string, paramNames []string, paramTys []int, argIdxs []int, start int, end int) []int {
 	wantCount := checkIntListLenHelper(paramTys)
-	_ = wantCount
-	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17386:5
 	gotCount := checkIntListLenHelper(argIdxs)
-	_ = gotCount
-	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17387:5
-	if wantCount != gotCount {
-		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:17388:9
+	defaultCount := paramDefaultCount(paramNames)
+	minArity := wantCount - defaultCount
+	if gotCount > wantCount || gotCount < minArity {
 		func() struct{} {
 			cx.env.diagnostics = append(cx.env.diagnostics, diagArgCount(callee, wantCount, gotCount, start, end))
 			return struct{}{}
@@ -32910,6 +32948,22 @@ func elabCallArgsMonomorphic(cx *ElabCx, callee string, paramTys []int, argIdxs 
 		}()
 	}
 	return coreArgs
+}
+
+// paramDefaultCount counts trailing paramNames whose text starts with
+// "?" — the default-availability marker injected by
+// selfhostBuildImportedFn / collectFnDecl. Mirrored from
+// toolchain/elab.osty pending a regen fix.
+func paramDefaultCount(names []string) int {
+	total := 0
+	for i := len(names) - 1; i >= 0; i-- {
+		if len(names[i]) > 0 && names[i][0] == '?' {
+			total++
+		} else {
+			break
+		}
+	}
+	return total
 }
 
 // Osty: /tmp/selfhost_merged.osty:17407:1
@@ -34178,9 +34232,16 @@ func elabInferClosure(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:18029:5
 	bodyIdx := node.left
 	_ = bodyIdx
-	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:18030:5
+	// When expected is `fn(T) -> TyVar(R)` — e.g. `xs.map(|r| body)`
+	// with R open — using elabCheck on the body would route through
+	// checkExpectAssignable which does not treat TyVar as a wildcard
+	// and would emit a spurious mismatch. Fall back to elabInfer when
+	// expectedRet is a bare TyVar; the outer elabCallArgs unify still
+	// binds R from the closure's inferred type. Mirrored from
+	// toolchain/elab.osty pending a regen fix.
+	expectedRetIsVar := ostyEqual(tyKindAt(tys, expectedRet), TyKind(&TyKind_TkVar{}))
 	body := func() *ElabResult {
-		if !(tyIsBad(tys, expectedRet)) {
+		if !(tyIsBad(tys, expectedRet)) && !expectedRetIsVar {
 			return elabCheck(cx, bodyIdx, expectedRet)
 		} else {
 			return elabInfer(cx, bodyIdx)
@@ -38906,6 +38967,10 @@ func registerStdThreadAliasFns(env *CheckEnv, alias string) {
 	checkRegisterFn(env, &CheckFnSig{name: "yield", owner: alias, receiverTy: -1, retTy: tUnit_, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:20928:5
 	checkRegisterFn(env, &CheckFnSig{name: "isCancelled", owner: alias, receiverTy: -1, retTy: tBool_, paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// thread.select<T>(body: fn(SelectBuilder) -> T) -> T — spec §B.6
+	// canonical form. Mirrored from toolchain/check.osty pending a regen fix.
+	tSelectBuilder := tyNamed(tys, "SelectBuilder", nil)
+	checkRegisterFn(env, &CheckFnSig{name: "select", owner: alias, receiverTy: -1, retTy: tT, paramNames: []string{"body"}, paramTys: []int{tyFn(tys, []int{tSelectBuilder}, tT)}, generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0)})
 }
 
 // Osty: /tmp/selfhost_merged.osty:20936:1
@@ -39060,8 +39125,15 @@ func collectFnDecl(cx *ElabCx, declIdx int, node *AstNode, owner string, ownerGe
 			// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:21021:13
 			continue
 		}
-		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:21023:9
-		func() struct{} { paramNames = append(paramNames, paramNode.text); return struct{}{} }()
+		// Prefix default-carrying params with "?" so the arity check
+		// (paramDefaultCount) can count trailing defaults. Default
+		// expression is stored in paramNode.left by opParseFnDecl.
+		// Mirrored from toolchain/check.osty pending a regen fix.
+		storedParamName := paramNode.text
+		if paramNode.left >= 0 {
+			storedParamName = "?" + storedParamName
+		}
+		func() struct{} { paramNames = append(paramNames, storedParamName); return struct{}{} }()
 		// Osty: C:\Users\user\AppData\Local\Temp\osty-bootstrap-gen-2705222029\selfhost_merged.osty:21024:9
 		declared := astTypeToTyInCollect(cx, paramNode.right)
 		_ = declared

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -33,6 +33,7 @@ type PackageCheckFn struct {
 	ReturnType    string                     `json:"returnType,omitempty"`
 	ParamNames    []string                   `json:"paramNames,omitempty"`
 	ParamTypes    []string                   `json:"paramTypes,omitempty"`
+	ParamDefaults []bool                     `json:"paramDefaults,omitempty"`
 	Generics      []string                   `json:"generics,omitempty"`
 	GenericBounds []PackageCheckGenericBound `json:"genericBounds,omitempty"`
 }

--- a/toolchain/check.osty
+++ b/toolchain/check.osty
@@ -541,6 +541,17 @@ fn registerStdThreadAliasFns(env: CheckEnv, alias: String) {
         paramNames: [], paramTys: [],
         generics: [], genericBounds: [],
     })
+    // thread.select(body: fn(SelectBuilder) -> T) -> T — spec §B.6
+    // canonical form. SelectBuilder takes care of recv/send/timeout/
+    // default branches; here we only need the outer signature to
+    // satisfy the checker. The builder type name is registered
+    // inside checkInstallChannelIntrinsics so `s.recv(...)` dispatches.
+    let tSelectBuilder = tyNamed(tys, "SelectBuilder", [])
+    checkRegisterFn(env, CheckFnSig {
+        name: "select", owner: alias, receiverTy: -1, retTy: tT,
+        paramNames: ["body"], paramTys: [tyFn(tys, [tSelectBuilder], tT)],
+        generics: gT, genericBounds: [],
+    })
 }
 
 /// registerStdIoAliasFns — print helpers when imported via alias.
@@ -631,7 +642,14 @@ fn collectFnDecl(
         if paramNode.text == "self" {
             continue
         }
-        paramNames.push(paramNode.text)
+        // Prefix default-carrying params with "?" so the arity check
+        // (see paramDefaultCount in elab.osty) can count trailing
+        // defaults without threading a parallel List<Bool> through
+        // every CheckFnSig constructor.
+        let hasDefault = paramNode.left >= 0
+        let rawName = paramNode.text
+        let storedName = if hasDefault { "?" + rawName } else { rawName }
+        paramNames.push(storedName)
         let declared = astTypeToTyInCollect(cx, paramNode.right)
         paramTys.push(if declared >= 0 { declared } else { tErr(cx.env.tys) })
     }

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1438,10 +1438,12 @@ pub fn checkInstallPrelude(env: CheckEnv) {
     let tT = tyNamed(env.tys, "T", [])
     let tGroup = tyNamed(env.tys, "Group", [])
     let tHandleT = tyNamed(env.tys, "Handle", [tT])
-    let tListHandleT = tyNamed(env.tys, "List", [tHandleT])
     let tListItemT = tyNamed(env.tys, "List", [tT])
     let tResultT = tyNamed(env.tys, "Result", [tT, tyNamed(env.tys, "Error", [])])
-    let tFnGroupListHandle = tyFn(env.tys, [tGroup], tListHandleT)
+    // Spec §B.6 canonical shape: `taskGroup(|g| { ...; Ok(value) })`.
+    // Body returns `Result<T, Error>`, and `taskGroup` passes it through
+    // so T flows from the final Ok expression to the outer return.
+    let tFnGroupResult = tyFn(env.tys, [tGroup], tResultT)
     let tFnT = tyFn(env.tys, [], tT)
     let tFnTToR = tyFn(env.tys, [tT], tyNamed(env.tys, "R", []))
     let _ = tFnTToR
@@ -1449,7 +1451,7 @@ pub fn checkInstallPrelude(env: CheckEnv) {
     checkRegisterFn(env, CheckFnSig {
         name: "taskGroup", owner: "", receiverTy: -1,
         retTy: tResultT,
-        paramNames: ["body"], paramTys: [tFnGroupListHandle],
+        paramNames: ["body"], paramTys: [tFnGroupResult],
         generics: gT, genericBounds: [],
     })
     checkRegisterFn(env, CheckFnSig {
@@ -1547,6 +1549,59 @@ fn checkInstallChannelIntrinsics(env: CheckEnv) {
     checkRegisterType(env, CheckTypeSig { name: "Channel", generics: ["T"], genericBounds: [], kind: "struct" })
     checkRegisterType(env, CheckTypeSig { name: "Handle", generics: ["T"], genericBounds: [], kind: "struct" })
     checkRegisterType(env, CheckTypeSig { name: "Group", generics: [], genericBounds: [], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "SelectBuilder", generics: [], genericBounds: [], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Duration", generics: [], genericBounds: [], kind: "struct" })
+    // SelectBuilder.recv/send/timeout/default — spec §B.6 canonical
+    // `thread.select(|s| { s.recv(...); s.timeout(...); s.default(...) })`.
+    let tSelectBuilder = tyNamed(env.tys, "SelectBuilder", [])
+    let tDuration_ = tyNamed(env.tys, "Duration", [])
+    let tFnResT = tyFn(env.tys, [tT], tT)
+    let tFnUnitT = tyFn(env.tys, [], tT)
+    checkRegisterFn(env, CheckFnSig {
+        name: "recv", owner: "SelectBuilder", receiverTy: tSelectBuilder,
+        retTy: tUnit(env.tys),
+        paramNames: ["ch", "handler"],
+        paramTys: [tyNamed(env.tys, "Channel", [tT]), tFnResT],
+        generics: gT, genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "send", owner: "SelectBuilder", receiverTy: tSelectBuilder,
+        retTy: tUnit(env.tys),
+        paramNames: ["ch", "value", "handler"],
+        paramTys: [tyNamed(env.tys, "Channel", [tT]), tT, tyFn(env.tys, [], tT)],
+        generics: gT, genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "timeout", owner: "SelectBuilder", receiverTy: tSelectBuilder,
+        retTy: tUnit(env.tys),
+        paramNames: ["duration", "handler"],
+        paramTys: [tDuration_, tFnUnitT],
+        generics: gT, genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "default", owner: "SelectBuilder", receiverTy: tSelectBuilder,
+        retTy: tUnit(env.tys),
+        paramNames: ["handler"],
+        paramTys: [tFnUnitT],
+        generics: gT, genericBounds: [],
+    })
+    // Int duration suffixes: `5.s`, `30.ms`, `100.us`, `1000.ns`.
+    // Spec exercises these as postfix-dot property chains; register
+    // them as zero-arg methods on Int returning Duration.
+    let tIntTy = tInt(env.tys)
+    let durationFromInt = CheckFnSig {
+        name: "s", owner: "Int", receiverTy: tIntTy, retTy: tDuration_,
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    }
+    let _ = durationFromInt
+    for suffix in ["s", "ms", "us", "ns"] {
+        checkRegisterFn(env, CheckFnSig {
+            name: suffix, owner: "Int", receiverTy: tIntTy, retTy: tDuration_,
+            paramNames: [], paramTys: [],
+            generics: [], genericBounds: [],
+        })
+    }
     // Group.spawn(body: fn() -> T) -> Handle<T> — structural concurrency
     // helper that spawns a scoped task inside a `taskGroup(|g| { ... })`
     // body. Spec §B.6 canonical pattern.

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1263,7 +1263,7 @@ fn elabInferCall(cx: ElabCx, callIdx: Int, node: AstNode, expected: Int) -> Elab
 
     if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
         let coreFn = coreIdent(cx.core, baseCallee.text, IkFn, fnSigToTy(cx.env, sig), baseCallee.start, baseCallee.end)
-        let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
+        let coreArgs = elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, argIdxs, node.start, node.end)
         let retTy = sig.retTy
         if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
@@ -1375,7 +1375,7 @@ fn elabInferStaticMethodCall(
     let _ = ownerName
     if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
         let coreFn = coreIdent(cx.core, sig.name, IkFn, fnSigToTy(cx.env, sig), fieldNode.start, fieldNode.end)
-        let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, argIdxs, node.start, node.end)
+        let coreArgs = elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, argIdxs, node.start, node.end)
         let retTy = sig.retTy
         if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
@@ -1474,7 +1474,7 @@ fn elabInferMethodCall(cx: ElabCx, callNode: AstNode, fieldNode: AstNode, expect
     }
 
     if checkStringListLenHelper(sig.generics) == 0 {
-        let coreArgs = elabCallArgsMonomorphic(cx, sig.name, sig.paramTys, callNode.children, callNode.start, callNode.end)
+        let coreArgs = elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, callNode.children, callNode.start, callNode.end)
         let retTy = sig.retTy
         if !(tyIsBad(cx.env.tys, expected)) {
             let _ = checkExpectAssignable(cx.env, expected, retTy, callNode.start, callNode.end)
@@ -1587,7 +1587,13 @@ fn elabCallArgs(
 ) -> List<Int> {
     let wantCount = checkIntListLenHelper(sig.paramTys)
     let gotCount = checkIntListLenHelper(argIdxs)
-    if wantCount != gotCount {
+    // Trailing params whose names start with "?" are marked as having
+    // defaults (encoded by selfhostBuildImportedFn for imported fns).
+    // An under-arity call with `gotCount >= wantCount - defaultCount`
+    // is satisfied by defaults and does NOT emit E0701.
+    let defaultCount = paramDefaultCount(sig.paramNames)
+    let minArity = wantCount - defaultCount
+    if gotCount > wantCount || gotCount < minArity {
         cx.env.diagnostics.push(diagArgCount(sig.name, wantCount, gotCount, start, end))
     }
     let mut coreArgs: List<Int> = []
@@ -1602,7 +1608,18 @@ fn elabCallArgs(
         let rawWant = checkIntListAt(sig.paramTys, i)
         let specialisedWant = checkSubstituteTy(cx.env, rawWant, sig.generics, freshs)
         let hint = zonk(cx.env, solver, specialisedWant)
-        let r = if isFullyResolved(cx.env, solver, hint) {
+        // Closure arguments: if the hint is `fn(P..) -> R` with params
+        // fully resolved (even if R is still open), pass it so the
+        // closure can seed its param slots from P. `results.map(|r| ..)`
+        // is the canonical case: T is bound from the receiver, so P is
+        // concrete, but R is still open until the body is inferred.
+        // Arity mismatches with unresolved param TyVars stay on the
+        // elabInfer path — the outer unify still flags a failure but
+        // without a spurious closure-arity diag against a TyVar-based
+        // shape.
+        let hintIsFnWithConcreteParams = tyKindAt(cx.env.tys, hint) == TkFn
+            && allFullyResolved(cx.env, solver, tyArgsAt(cx.env.tys, hint))
+        let r = if isFullyResolved(cx.env, solver, hint) || hintIsFnWithConcreteParams {
             elabCheck(cx, argIdx, hint)
         } else {
             elabInfer(cx, argIdx)
@@ -1612,6 +1629,28 @@ fn elabCallArgs(
         i = i + 1
     }
     coreArgs
+}
+
+/// paramDefaultCount counts trailing paramNames whose text starts with
+/// a "?" marker. The `?` prefix is injected by the Osty→selfhost import
+/// surface for params that carry default expressions; it lets the
+/// arity check treat missing trailing args as satisfied without
+/// threading a List<Bool> through every CheckFnSig constructor.
+///
+/// Forward-walk with reset-on-break: every non-"?" name resets the
+/// running total, so the final value is the length of the contiguous
+/// "?"-prefixed suffix. This avoids needing reverse indexing on
+/// List<String>.
+fn paramDefaultCount(names: List<String>) -> Int {
+    let mut running = 0
+    for name in names {
+        if name.startsWith("?") {
+            running = running + 1
+        } else {
+            running = 0
+        }
+    }
+    running
 }
 
 /// elabIsToStringFormatter returns true when `callee` is one of the
@@ -1631,9 +1670,23 @@ fn elabCallArgsMonomorphic(
     start: Int,
     end: Int,
 ) -> List<Int> {
+    elabCallArgsMonomorphicWithNames(cx, callee, [], paramTys, argIdxs, start, end)
+}
+
+fn elabCallArgsMonomorphicWithNames(
+    cx: ElabCx,
+    callee: String,
+    paramNames: List<String>,
+    paramTys: List<Int>,
+    argIdxs: List<Int>,
+    start: Int,
+    end: Int,
+) -> List<Int> {
     let wantCount = checkIntListLenHelper(paramTys)
     let gotCount = checkIntListLenHelper(argIdxs)
-    if wantCount != gotCount {
+    let defaultCount = paramDefaultCount(paramNames)
+    let minArity = wantCount - defaultCount
+    if gotCount > wantCount || gotCount < minArity {
         cx.env.diagnostics.push(diagArgCount(callee, wantCount, gotCount, start, end))
     }
     let skipParamCheck = elabIsToStringFormatter(callee)
@@ -2276,7 +2329,15 @@ fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     }
 
     let bodyIdx = node.left
-    let body = if !(tyIsBad(tys, expectedRet)) {
+    // When expected is `fn(T) -> TyVar(R)` — e.g. `xs.map(|r| body)`
+    // with the outer solver still open — using elabCheck on the body
+    // would route through elabCheckViaInfer's `checkExpectAssignable`
+    // which does not treat TyVar as a wildcard and would emit a
+    // spurious mismatch. Fall back to elabInfer when the expected
+    // return is a bare TyVar; the outer elabCallArgs `unify` still
+    // binds R from the closure's inferred type.
+    let expectedRetIsVar = tyKindAt(tys, expectedRet) == TkVar
+    let body = if !(tyIsBad(tys, expectedRet)) && !expectedRetIsVar {
         elabCheck(cx, bodyIdx, expectedRet)
     } else {
         elabInfer(cx, bodyIdx)

--- a/toolchain/solve.osty
+++ b/toolchain/solve.osty
@@ -365,7 +365,7 @@ pub fn isFullyResolved(env: CheckEnv, solver: Solver, ty: Int) -> Bool {
     }
 }
 
-fn allFullyResolved(env: CheckEnv, solver: Solver, xs: List<Int>) -> Bool {
+pub fn allFullyResolved(env: CheckEnv, solver: Solver, xs: List<Int>) -> Bool {
     for x in xs {
         if !(isFullyResolved(env, solver, x)) {
             return false


### PR DESCRIPTION
## Summary

Follow-up to [#465](https://github.com/choiceoh/osty/pull/465) chipping further at the remaining `examples/` checker gaps. Net: **165 → 143 errors**, with **fmt_e2e 25 → 1** and **ai_demo_eval 1 → 0**.

## What changed

### 1. Closure param inference across generic method args

`results.map(|r| body)` previously emitted E0752 on `r` because `elabCallArgs` only forwarded the hint to `elabCheck` when fully resolved, and `fn(Result<..>, TyVar(R))` isn't (R is open until the body is inferred). Now the hint is forwarded whenever its param slots are concrete, even if the return slot is still a TyVar. `elabInferClosure` falls back to `elabInfer` on the body when `expectedRet` is a bare TyVar — the outer solver still unifies R from the closure's inferred return type.

### 2. Default parameters in imported fns (fmt_e2e: 25 → 1)

Three pieces:

- `writeSelfhostPackageImport` emits `= ()` as a marker literal after every defaulted param, so the concatenated source's parser preserves `paramNode.left >= 0`.
- `collectFnDecl` prefixes such param names with `?` before storing on `CheckFnSig.paramNames` — a single-bit signal that survives every existing constructor without breaking them.
- `paramDefaultCount` reads the trailing `?` prefix to compute `minArity = wantCount - defaultCount`, which the arity check now compares against. `elabCallArgs` and `elabCallArgsMonomorphic` share the logic via a new `elabCallArgsMonomorphicWithNames` variant.

### 3. taskGroup body signature matches spec §B.6

Previously registered as `fn(Group) -> List<Handle<T>>`; spec §B.6 canonical form is `fn(Group) -> Result<T, Error>` with `Ok(value)` as the body's final expression. The adjustment lets T flow from the body's `Ok(...)` up to the outer `taskGroup(...)` return.

### 4. Select / Duration / Int duration suffixes

Registered `thread.select<T>(body: fn(SelectBuilder) -> T) -> T` plus `SelectBuilder.recv/send/timeout/default`, the `Duration` type, and `Int.{s,ms,us,ns}` zero-arg methods so the crawler's `s.timeout(30.s, || ...)` shape resolves.

## Per-target

| target | before | after |
|---|---|---|
| ai_demo_config.osty | 70 | 73 |
| gc | 56 | 56 |
| fmt_e2e/fmt_test.osty | 25 | **1** |
| ai_demo_eval.osty | 1 | **0** |
| ai_demo_crawler.osty | 7 | 8 |
| concurrency | 5 | 5 |
| workspace/cli | 0 | 0 |
| **TOTAL** | **164** | **143** |

The small ai_demo_config +3 regression is new "cannot find self" spans surfaced by a different categorisation; the net across categories is still −21. Crawler +1 is a new `cannot infer T of timeout` — surfaced because the previous unregistered select masked downstream inference issues.

## Test plan

- [x] `just front`
- [x] `just spec`
- [x] `internal/selfhost` + `cmd/osty`
- [x] `TestProbeNativeToolchainMerged` — unchanged first wall (LLVM015 method_call_field)

## Mirror protocol

Source of truth in `toolchain/{check,check_env,elab,solve}.osty`; `internal/selfhost/generated.go` carries matching hunks with the usual `// Mirrored from ... pending a regen fix` comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)