### PR TITLE
feat(llvmgen): box struct-typed Option payloads

### DIFF
--- a/internal/llvmgen/option_struct_test.go
+++ b/internal/llvmgen/option_struct_test.go
@@ -1,0 +1,86 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// Option<Struct> — `Some(StructLit { ... })` with an aggregate payload
+// used to wall LLVM011 "Some payload type %T requires boxed Option;
+// only ptr-backed Some(...) is lowered". The toolchain's
+// crossCompileGuard in runner.osty hit this on the native probe.
+//
+// The backend now boxes struct-typed payloads into a GC-managed heap
+// cell (osty.gc.alloc_v1 + store) so None stays null-ptr and Some(s)
+// lowers to a managed ptr. None and `?`-based presence checks keep
+// working unchanged.
+func TestOptionStructSomeLowersToGcAlloc(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Diag {
+    severity: String,
+    message: String,
+}
+
+fn make(ok: Bool) -> Diag? {
+    if ok {
+        None
+    } else {
+        Some(Diag { severity: "error", message: "boom" })
+    }
+}
+
+fn main() {
+    let _ = make(true)
+    let _ = make(false)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/option_struct.osty"})
+	if err != nil {
+		t.Fatalf("Some<struct> errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty.gc.alloc_v1",
+		"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Some<struct> did not invoke osty.gc.alloc_v1: missing %q:\n%s", want, got)
+		}
+	}
+	// The box store for the struct value — one insertion per field
+	// goes through `insertvalue` first, then the final struct value is
+	// stored into the box via `store %Diag ...`.
+	if !strings.Contains(got, "store %Diag ") {
+		t.Fatalf("Some<struct> did not store struct bytes into box:\n%s", got)
+	}
+}
+
+// None on an Option<Struct> context stays a null ptr; the aggregate
+// path shouldn't fire on the None branch. Otherwise presence checks
+// `x != None` / `?` propagation would see a bogus allocation.
+func TestOptionStructNoneStaysNull(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Diag {
+    message: String,
+}
+
+fn empty() -> Diag? {
+    None
+}
+
+fn main() {
+    let _ = empty()
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/option_struct_none.osty"})
+	if err != nil {
+		t.Fatalf("None<struct> errored: %v", err)
+	}
+	got := string(ir)
+	// No actual gc.alloc CALL for the None path — the module still
+	// declares the symbol (declare ptr @...) but must not invoke it.
+	if strings.Contains(got, "call ptr @osty.gc.alloc_v1") {
+		t.Fatalf("None<struct> unexpectedly emitted gc.alloc_v1 call:\n%s", got)
+	}
+	if !strings.Contains(got, "ret ptr null") {
+		t.Fatalf("None<struct> did not return null ptr:\n%s", got)
+	}
+}

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -17,6 +17,9 @@
 package llvmgen
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/osty/osty/internal/ast"
 )
 
@@ -414,9 +417,20 @@ func (g *generator) emitBuiltinOptionNone(name string) (value, bool, error) {
 	return out, true, nil
 }
 
-// emitBuiltinOptionSomeCall handles `Some(x)` calls in a ptr-backed Option
-// context. x must already be a ptr; the backend pass-throughs since T? and T
-// share the `ptr` LLVM type (scalar Option<Int> stays unsupported).
+// emitBuiltinOptionSomeCall handles `Some(x)` calls in a ptr-backed
+// Option context. For ptr-typed payloads (String, List, etc.) the
+// backend passes through — T? and T share the `ptr` LLVM type. For
+// aggregate struct payloads (`%StructName`) we box the value into a
+// GC-managed heap cell: allocate sizeof(T) via osty.gc.alloc_v1,
+// memcpy the struct bytes in, return the heap pointer. None stays
+// null ptr so downstream null-check / `?.` paths work unchanged.
+//
+// NOTE (GC hazard): the box uses OSTY_GC_KIND_GENERIC with no tracer.
+// Managed pointers embedded in the struct aren't marked when reached
+// only through this Option, so they could be collected if no other
+// root holds them. In practice toolchain usage (`CrossCompileOutcome`
+// etc.) keeps those strings alive via the construction-site locals,
+// but a proper tracer is a follow-up (see TODO in runtime).
 func (g *generator) emitBuiltinOptionSomeCall(call *ast.CallExpr) (value, bool, error) {
 	if call == nil {
 		return value{}, false, nil
@@ -440,9 +454,31 @@ func (g *generator) emitBuiltinOptionSomeCall(call *ast.CallExpr) (value, bool, 
 	if err != nil {
 		return value{}, true, err
 	}
-	if loaded.typ != "ptr" {
-		return value{}, true, unsupportedf("type-system", "Some payload type %s requires boxed Option; only ptr-backed Some(...) is lowered", loaded.typ)
+	if loaded.typ == "ptr" {
+		loaded.sourceType = ctx.sourceType
+		return loaded, true, nil
 	}
-	loaded.sourceType = ctx.sourceType
-	return loaded, true, nil
+	// Aggregate struct payload: box it on the GC heap.
+	if strings.HasPrefix(loaded.typ, "%") {
+		emitter := g.toOstyEmitter()
+		size := g.emitAggregateByteSize(emitter, loaded.typ)
+		siteName := "runtime.option.some." + strings.TrimPrefix(loaded.typ, "%")
+		sitePtr := llvmStringLiteral(emitter, siteName)
+		box := llvmCall(emitter, "ptr", "osty.gc.alloc_v1", []*LlvmValue{
+			toOstyValue(value{typ: "i64", ref: "1"}), // OSTY_GC_KIND_GENERIC
+			toOstyValue(size),
+			sitePtr,
+		})
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  store %s %s, ptr %s",
+			loaded.typ, loaded.ref, box.name,
+		))
+		g.takeOstyEmitter(emitter)
+		g.needsGCRuntime = true
+		out := fromOstyValue(box)
+		out.gcManaged = true
+		out.sourceType = ctx.sourceType
+		return out, true, nil
+	}
+	return value{}, true, unsupportedf("type-system", "Some payload type %s requires boxed Option; only ptr-backed or aggregate-struct Some(...) is lowered", loaded.typ)
 }


### PR DESCRIPTION
## Summary

`emitBuiltinOptionSomeCall` previously rejected every non-ptr `Some(...)` payload with `LLVM011` *requires boxed Option; only ptr-backed Some(...) is lowered*. That walled `runner.osty`'s `Some(RunnerDiag { ... })` on the native toolchain probe.

For aggregate struct payloads (LLVM `typ` starts with `%`), `Some` now boxes: allocate `sizeof(struct)` via `osty.gc.alloc_v1(KIND_GENERIC)` + memcpy the struct bytes into the box + return the heap pointer. `None` stays null ptr so downstream null-check / `?.` paths work unchanged.

## Known limitation

`KIND_GENERIC` carries no tracer, so managed pointers embedded in the struct (e.g. the four `String` fields of `RunnerDiag`) aren't marked when reached only through this `Option`. In practice toolchain usage keeps those alive via construction-site locals, but a proper tracer is a follow-up — the trace callback needs access to per-struct-type GC offsets, which the current `osty_gc_alloc_v1` signature doesn't plumb. Documented in a comment.

## Wall movement

```
NATIVE TOOLCHAIN first wall:
  before: LLVM011 [other] — Some payload type %RunnerDiag requires
          boxed Option; only ptr-backed Some(...) is lowered
  after:  LLVM002 runtime-ffi — Osty runtime FFI import
          runtime.strings.indexOf needs native runtime lowering
```

The next wall is a different runtime-FFI surface (`strings.indexOf` not declared in the `lsp.osty` `use runtime.strings` stanza); this PR doesn't tackle it.

## Test plan

- [x] New: `TestOptionStructSomeLowersToGcAlloc` — `Some(Diag { ... })` emits `call ptr @osty.gc.alloc_v1` + `store %Diag`
- [x] New: `TestOptionStructNoneStaysNull` — `None` branch keeps null-ptr, no spurious alloc
- [x] `go test -count=1 -vet=off -short -skip \"TestGenerateModuleExtendedListSortedAndToSet|TestProbeSmallTailLower\" ./internal/llvmgen` (the skipped tests fail on main too — unrelated to this PR)
- [x] `go test -count=1 -vet=off ./internal/backend ./internal/diag`
- [x] `TestProbeNativeToolchainMerged` wall has advanced from LLVM011 `%RunnerDiag` to LLVM002 `runtime.strings.indexOf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)