### PR TITLE
feat: native-merged toolchain probe is CLEAN — Tier A self-host milestone

### DIFF
--- a/internal/llvmgen/native_toolchain_clean_test.go
+++ b/internal/llvmgen/native_toolchain_clean_test.go
@@ -1,0 +1,60 @@
+package llvmgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/parser"
+)
+
+// TestNativeToolchainMergedIsClean locks the milestone reached when
+// the envEntryKey Option<Int> refactor landed: every non-bootstrap
+// toolchain/*.osty file, concatenated into a single buffer, lowers
+// to LLVM IR without a backend wall. This is the Tier A self-host
+// milestone — if a future change re-introduces a wall, the test fails
+// with the offending error so the regression surfaces immediately
+// rather than hiding inside the info-only TestProbeNativeToolchainMerged.
+//
+// Paired with TestProbeNativeToolchainMerged: the probe is info-only
+// and always passes (logs the first wall); this test is authoritative
+// and fails on any wall.
+func TestNativeToolchainMergedIsClean(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow (~10s); skipped in -short")
+	}
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		if isBootstrapOnlyOstyFile(src) {
+			continue
+		}
+		files = append(files, name)
+	}
+	merged := mergeToolchainSources(t, root, files)
+	file, _ := parser.ParseDiagnostics(merged)
+	if file == nil {
+		t.Fatalf("merged parse returned nil (%d files, %d bytes)", len(files), len(merged))
+	}
+	_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/toolchain_native_merged.osty"})
+	if err != nil {
+		t.Fatalf("expected clean merged lowering, got wall: %v", err)
+	}
+}

--- a/toolchain/runner.osty
+++ b/toolchain/runner.osty
@@ -176,10 +176,15 @@ fn envOverridesEmpty(overrides: List<EnvEntry>) -> Bool {
 }
 
 fn envEntryKey(kv: String) -> String {
-    match strings.indexOf(kv, "=") {
-        Some(at) -> strings.slice(kv, 0, at),
-        None -> "",
+    // Use split instead of indexOf to avoid Option<Int> — the native
+    // backend has no boxed Option<scalar> yet. Semantics are
+    // equivalent: if "=" is absent return "", else return the prefix
+    // before the first "=".
+    if !strings.contains(kv, "=") {
+        return ""
     }
+    let parts = strings.split(kv, "=")
+    parts[0]
 }
 
 fn envSeen(seen: List<String>, key: String) -> Bool {


### PR DESCRIPTION
## Summary

**Milestone: every non-bootstrap toolchain/*.osty file lowers cleanly when merged.** Follow-up to [#484](https://github.com/choiceoh/osty/pull/484).

## The last wall

```
NATIVE TOOLCHAIN first wall:
  before: LLVM002 runtime-ffi — strings.indexOf needs native runtime lowering
  after:  CLEAN
```

Root cause: the merge order places `lsp.osty`'s `use runtime.strings as strings { fn split(...) }` ahead of `runner.osty`'s `use std.strings as strings`, so `strings.indexOf(...)` from runner.osty routes through the runtime-FFI resolver and trips on the missing `indexOf` declaration. Real single-file compilation doesn't hit this because each file owns its own alias.

## Fix

Rather than widen the backend's `Option<scalar>` support (boxed i64 via `gc.alloc_v1`, scalar-payload match binding) for one call site, rewrite `envEntryKey` to avoid `Option<Int>`:

```osty
// before
match strings.indexOf(kv, \"=\") {
    Some(at) -> strings.slice(kv, 0, at),
    None -> \"\",
}

// after
if !strings.contains(kv, \"=\") { return \"\" }
strings.split(kv, \"=\")[0]
```

Semantics unchanged; both `contains` and `split` are already on the `std.strings → C-runtime` shim, so the refactor doesn't need any new backend work.

## Regression lock

`TestNativeToolchainMergedIsClean` pairs with the existing info-only `TestProbeNativeToolchainMerged`: the probe logs the first wall (doesn't fail), the new test is authoritative and fails on any regression. Skipped under `-short` (~12s to run).

## Test plan

- [x] `go test -count=1 -vet=off -run \"TestNativeToolchainMergedIsClean\" ./internal/llvmgen` → PASS
- [x] `go test -count=1 -vet=off -short -skip \"TestGenerateModuleExtendedListSortedAndToSet|TestProbeSmallTailLower\" ./internal/llvmgen` (the skipped tests fail on main too — unrelated)
- [x] `go test -count=1 -vet=off ./internal/backend ./internal/diag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)