### PR TITLE
docs: sync top-level docs with current implementation state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture
 
 High-level map of the Osty front-end. For spec decisions see
-`OSTY_GRAMMAR_v0.4.md`; this document covers **implementation** layout.
+`OSTY_GRAMMAR_v0.5.md`; this document covers **implementation** layout.
 
 ## Pipeline
 
@@ -25,8 +25,9 @@ High-level map of the Osty front-end. For spec decisions see
                                                                        │   check  │ ───┐
                                                                        └──────────┘    │
                                                                                        ▼
-                                                                                ┌──────────┐   Go source
-                                                                                │   gen    │   warnings (L0xxx)
+                                                                                ┌──────────┐   LLVM IR / object / binary
+                                                                                │ ir / mir │   warnings (L0xxx)
+                                                                                │ llvmgen  │   Osty-hosted diag policy
                                                                                 │   lint   │
                                                                                 └──────────┘
 ```
@@ -125,16 +126,21 @@ Structured diagnostics plus the renderer.
 Name resolution. Three entry points: `File` (single-file), `Package`
 (directory of files sharing a namespace, loaded via `LoadPackage` +
 `ResolvePackage`), and `Workspace` (tree of packages connected by `use`
-edges, driven by `NewWorkspace` + `ResolveAll`). Each file goes through
-a 3-pass design:
+edges, driven by `NewWorkspace` + `ResolveAll`). These are scope
+boundaries, not temporal passes — the resolver runs **two passes** over
+whichever scope the caller chose, and `Workspace.ResolveAll` fans the
+same two passes across every package so cross-package lookups always
+see populated scopes:
 
-1. **`declareUse`** registers `use` aliases.
-2. **`declareTopLevel`** inserts every top-level `fn`/`struct`/
-   `enum`/`interface`/`type`/`pub let` symbol, enabling forward
-   references between them.
-3. **`resolveDecl`** walks each body, opening child scopes for
-   generics, parameters, let bindings, closure params, and match
-   arms.
+1. **`declarePass`** (`resolve.go:133`) — walks every file, registers
+   `use` aliases into the file scope, and inserts every top-level
+   `fn`/`struct`/`enum`/`interface`/`type`/`pub let` symbol into the
+   package scope. Forward references and cross-package lookups both
+   work after this pass.
+2. **`bodyPass`** (`resolve.go:149`) — walks declaration bodies and
+   top-level statements, opening child scopes for generics,
+   parameters, let bindings, closure params, and match arms. Circular
+   imports are detected before this pass runs and reported as E0506.
 
 `methodCtx{selfType, inMethod, selfSym}` bundles the three related
 bits of state that control `self` / `Self`. Callers push a new context
@@ -167,7 +173,8 @@ bodies producing per-expression types in `Result.Types` plus
 per-symbol types in `Result.SymTypes`. Entry points mirror
 `resolve`: `File`, `Package`, `Workspace`.
 
-The main v0.4 front-end static guarantee hooks are wired here:
+The main front-end static guarantee hooks (v0.4 baseline + v0.5
+additions) are wired here:
 
 - generic call sites are recorded in `Result.Instantiations`; the IR
   lowerer forwards these onto `ir.CallExpr.TypeArgs` and leaves struct
@@ -194,8 +201,15 @@ The main v0.4 front-end static guarantee hooks are wired here:
 - structural interface satisfaction checks composed interfaces,
   `Self`-typed signatures, generic receiver substitution, params, and
   generic bounds,
-- match exhaustiveness emits `E0731` and synthesizes witnesses for
-  closed product/sum shapes, with `E0740` for unreachable arms,
+- match exhaustiveness runs a Maranget usefulness pass
+  (`pmCheckMatch` / `pmUseful` / `pmExhaustivenessWitness` in
+  `toolchain/elab.osty`) that emits `E0731` with up to three concrete
+  missing witnesses (including nested tuple / struct / enum payload
+  shapes, depth-capped at 6 for recursive ADTs) and flags unreachable
+  arms as `E0740`; G14 generic-value references are rejected as
+  `E0742` with focus tests, and G15 function-value calls are pinned
+  positional + exact-arity (`E0701`) so defaults / keywords never
+  survive erasure,
 - auto-derived `default()`, `builder()`, `toBuilder()`, setter chains,
   and `build()` obligations are checked in `builder.go`,
 - method references (`obj.method` as a value) lower to receiver-free
@@ -206,9 +220,12 @@ The main v0.4 front-end static guarantee hooks are wired here:
 - closure parameter destructuring binds irrefutable tuple/struct
   patterns and rejects refutable patterns with a stable diagnostic.
 
-The v0.4 language-decision sweep is closed in `SPEC_GAPS.md`; remaining
-work is implementation backlog rather than broad checker architecture
-gaps.
+The v0.4 and v0.5 language-decision sweeps are closed in
+`SPEC_GAPS.md` (zero open G-numbers); remaining work is implementation
+backlog — the host-side legacy checker boundary
+(`internal/check/host_boundary.go`) still acts as a fallback under the
+native checker, and retiring it is the main architectural cleanup
+tracked outside spec gaps.
 
 #### Type inference algorithm
 
@@ -234,9 +251,14 @@ switches the output to NDJSON.
 Built-in prelude symbols injected into every file before resolution.
 `NewPrelude` returns the root scope; individual modules are Osty
 source files under `modules/` with primitive method stubs under
-`primitives/`. Tier 1 is loadable by the front-end; the v0.4 sweep is
-about moving more §10 protocol prose into checked `.osty` stubs and
-pinning any edge cases that fall out of that exercise.
+`primitives/`. Tier 1 is loadable by the front-end; Tier 2 stubs are
+checked `.osty` bodies that parse / resolve / check cleanly. 36
+modules ship today (fs, json, io, strings, fmt, thread, time, url,
+uuid, collections, …), and the Map helper family (`update`, `getOr`,
+`mergeWith`, `groupBy`, `mapValues`, `retainIf`) ships as bodied Osty
+per the §B.9.1 contract — runtime execution of those bodied helpers
+currently blocks on the `LLVM015` Map-method lowering gap documented
+in `docs/toolchain_llvm_status.md`.
 
 ### `internal/format`
 Canonical-style formatter. `format.Source` reparses → pretty-prints →
@@ -249,23 +271,48 @@ per spec §13.3. Wired as `osty fmt` with `--check` / `--write`.
 ### `internal/lint`
 Style and correctness warnings over a resolved tree. Every diagnostic
 is `diag.Warning` severity with an `Lxxxx` code; nothing blocks
-compilation. Rules implemented today:
+compilation. Rules implemented today (28 codes, grouped by category):
 
 | Code | Rule |
 |---|---|
 | L0001 | unused `let` binding |
 | L0002 | unused fn / closure parameter |
 | L0003 | unused `use` alias (package-aware) |
+| L0004 | unused `mut` annotation |
+| L0005 | unused struct field |
+| L0006 | unused method |
+| L0007 | ignored `Result` / `Option` return |
+| L0008 | dead store (write never read) |
 | L0010 | inner binding shadows outer |
 | L0020 | statement after terminating return/break/continue |
+| L0021 | redundant `else` after early return |
+| L0022 | constant condition |
+| L0023 | empty `if` / `else` branch |
+| L0024 | needless `return` on last expression |
+| L0025 | identical branches |
+| L0026 | empty loop body |
 | L0030 | type name not UpperCamelCase |
 | L0031 | fn / let / param name not lowerCamelCase |
 | L0032 | enum variant name not UpperCamelCase |
+| L0040 | redundant boolean expression |
+| L0041 | self-comparison (`x == x`) |
+| L0042 | self-assignment (`x = x`) |
+| L0043 | double negation (`!!x`) |
+| L0044 | comparison against boolean literal |
+| L0045 | negated boolean literal |
+| L0050 | function takes too many parameters |
+| L0052 | function body too long |
+| L0053 | nesting too deep |
+| L0070 | missing doc comment on `pub` declaration |
 
-`File`, `Package`, and workspace-driven usage are all supported so
-cross-file references to a `use` alias don't look unused locally.
-Wired as `osty lint` with `--strict` (CI mode: exit 1 on any
-warning).
+Policy (allow / deny / exclude per code, rule alias, category alias,
+or wildcard) is sourced from `[lint]` in `osty.toml`; `deny` always
+wins over `allow`. Machine-applicable fixes are emitted for the unused
+/ simplify families and consumed by `osty lint --fix` /
+`--fix-dry-run`. `File`, `Package`, and workspace-driven usage are all
+supported so cross-file references to a `use` alias don't look unused
+locally. Wired as `osty lint` with `--strict` (CI mode: exit 1 on any
+warning). Rule-level policy logic lives in `toolchain/diag_policy.osty`.
 
 ### `internal/bootstrap/gen`
 Developer-only Osty→Go transpiler used exclusively to regenerate
@@ -292,11 +339,15 @@ outline/workspace symbol kind selection and sorting, cursor/range checks,
 signature-label rendering, diagnostic payload projection, code-action
 filtering, URI/reference-location ordering, organize-import helper policy, and
 fix-all overlap resolution is authored in
-`toolchain/lsp.osty` and exposed through the checked-in host boundary. Each
-document change re-runs the full front-end (`parser.ParseDiagnostics` →
-`resolve.File` → `check.File`); caching is by source identity, not incremental
-— the front-end is fast enough that re-analysis is cheaper than
-change-tracking at this stage. Wired as `osty lsp`.
+`toolchain/lsp.osty` and exposed through the checked-in host boundary.
+File-mode analysis flows through a Salsa-style incremental query engine
+(`internal/query/osty`, exposed as `ostyquery.Engine`): the server's
+default path for a single dirty buffer is `analyzeSingleFileViaEngine`,
+so repeated edits to the same file benefit from query-level reuse of
+parse / resolve / check results. Package- and workspace-mode analysis
+still re-runs the eager per-file path while that migration catches up,
+so cross-file refactors read fresh state on each request. Wired as
+`osty lsp`.
 
 ### `internal/manifest`
 Project manifest (`osty.toml`) reader, validator, and writer (spec
@@ -392,7 +443,14 @@ Cross-file resolution used to live here as a gap; it's now done via
 cross-file partial-method name collisions are covered by package tests.
 
 Spec-level open items are tracked in `SPEC_GAPS.md` (currently: zero
-open gaps for v0.4). Structured-concurrency escape rules, generic
+open gaps for v0.5). Structured-concurrency escape rules, generic
 method turbofish semantics, callable arity after function/default
-metadata erasure, closure parameter patterns, nested witness policy, and
-stdlib protocol stubs were closed as v0.4 decisions.
+metadata erasure, closure parameter patterns, and nested witness
+policy were closed as v0.4 decisions; v0.5 layered on 16 additive
+surface extensions (G20–G35) plus implementation closes for G14
+generic callable reference (`E0742`), G15 function-value arity lock,
+struct spread correctness, and the `std.strings` chapter. G17
+exhaustiveness is now implemented as a full Maranget usefulness pass
+(`pmCheckMatch` / `pmUseful` / `pmExhaustivenessWitness` in
+`toolchain/elab.osty`) with up to three witnesses per match and a
+depth cap of six for recursive ADTs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ source → lexer → parser → resolve → check → (format / lint / ir / back
 - `internal/ast` — 모든 노드가 `ast.Node` 인터페이스 구현 (`Pos()`, `End()`)
 - `internal/parser` — recursive-descent + Pratt. 에러 복구 (`syncStmt`, `syncDecl`)
 - `internal/diag` — `Diagnostic{Severity, Code, Message, Spans, Notes, Hint}` + 렌더러
-- `internal/resolve` — 3-pass 네임 리졸루션 (`File` / `Package` / `Workspace`)
+- `internal/resolve` — 2-pass 네임 리졸루션 (`declarePass` → `bodyPass`, 워크스페이스 전역으로 확산). `File` / `Package` / `Workspace` 는 scope 단위이지 pass 가 아님
 - `internal/types` — 시맨틱 타입. 순수 데이터, 로직은 `compat.go`만
 - `internal/check` — 2-pass 타입체커 (collect → expr/stmt)
 - `internal/stdlib` — prelude + `modules/*.osty` + `primitives/`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ compiler path is now native-only through the LLVM backend.
 | Name resolution (single + multi-file, workspace, typo suggestions) | done |
 | Formatter (`internal/format`) | done |
 | Type checker (`internal/check`) | done for the shipped v0.4 front-end core — generic instantiation, structural interface checks, exhaustiveness, builder protocol, function-value arity, closure pattern params. Algorithm: bidirectional + local unification, spec in [`LANG_SPEC_v0.5/02a-type-inference.md`](./LANG_SPEC_v0.5/02a-type-inference.md); `osty check --inspect` observes it at runtime |
-| Linter (`internal/lint`, L0001–L0042, `--fix` / `--fix-dry-run`) | done |
+| Linter (`internal/lint`, 28 codes across L0001–L0070 spanning unused / dead-code / naming / simplify / complexity / docs, `--fix` / `--fix-dry-run`, policy via `[lint]` in `osty.toml`) | done |
 | Multi-file packages (`resolve` loader/package/workspace) | done |
 | LSP (`internal/lsp`, wired as `osty lsp`) | done — hover, definition, formatting, documentSymbol, lint diagnostics, editor policy backed by toolchain sources |
 | Native LLVM backend (`internal/backend`, `internal/llvmgen`) | public backend path; scalar/control-flow/string smoke subset emits LLVM IR/object/binary, later phase 64-73 value/control-flow smoke expansion is documented, unsupported shapes report Osty-authored LLVM diagnostics |
@@ -46,7 +46,7 @@ compiler path is now native-only through the LLVM backend.
 | CI quality tooling (`internal/ci`, `osty ci`) | done — Osty-authored generated CI core, signature-aware snapshots, workspace coverage, JSON reports |
 | Pipeline visualizer (`osty pipeline`) | done — per-stage timing, workspace mode, backend-aware gen, baseline diff, LSP trace, `--explain` |
 | Profiles / targets / features / cache (`internal/profile`, `osty profiles` / `targets` / `features` / `cache`) | done — built-in and manifest profiles, cross-target env, feature closure + file pragmas, backend-aware fingerprints |
-| LLVM backend (`internal/backend`, `internal/llvmgen`, `--backend llvm`) | early executable slice — textual IR/object/binary for scalar/control-flow/Bool/String and `Float`/String payload enum smoke programs, plus simple struct aggregates and enum matches (payload-free + single-`Int` and phase-54-63 payload generalization), then phase 64-73 value/control-flow smoke expansion, host `clang` driver, inspectable skeleton + categorized diagnostics for unsupported source shapes |
+| LLVM backend (`internal/backend`, `internal/llvmgen`, `--backend llvm`) | executable — textual IR / object / binary through `clang` for scalar / control-flow / Bool / String (ASCII + multi-byte UTF-8), all four payload-free/single-scalar/struct/enum-payload `Result<T, E>` shapes with `?` propagation (phase 54-63 + phase 74 closed), match-as-expression and match-as-statement over bare-variant and wildcard arms, nested field assignment, `Char`/`Byte` parameter + return lowering with width/sign conversions, interface vtable dispatch with generic monomorphization, list / map / set literals and intrinsics (`isEmpty`, `pop` discard, nested `IndexExpr`, source-type tracked list literals), payload-free enum match and `Float` / String payload enums, simple struct aggregates and method calls, host `clang` driver, and categorized `LLVM00x` / `LLVM01x` Osty-authored diagnostics for source shapes that still skeletonize (currently the `String.bytes` / `String.chars` → `List<Byte>` / `List<Char>` lowering path and heterogeneous `list_mixed_ptr` literals outside the tracked-source-type path) |
 | Package registry backend / `osty registry serve` | done — file-backed HTTP server for index/search/download/publish/yank, with ETag index responses and bearer-token write auth |
 | Package registry / `osty add` / `osty update` / `osty run` | done (resolve + vendor + lockfile-honoring re-resolves, ETag-cached registry index, copy fallback for symlink-less filesystems; CLI: `add`, `remove`/`rm`, `update`, `run`, `fetch`, `publish`, `search`, `info`, `yank`/`unyank`, `login`/`logout`; `--locked` / `--frozen` CI guards) |
 | Package manager (`osty add` / `osty update`, path + git + registry sources, SemVer resolver, deterministic lockfile) | wired — `add` mutates `osty.toml` and re-vendors; `update` re-resolves selectively or in full |
@@ -69,10 +69,18 @@ unavailable, and `go generate ./internal/selfhost` still shells out to
 `cmd/osty-bootstrap-gen` to refresh `internal/selfhost/generated.go`. The
 whole-toolchain LLVM probe still first-walls on the bootstrap-only
 `runtime.golegacy.astbridge` bridge; when those bootstrap-only files are
-excluded, the current native probe first-walls on `Char` parameter lowering
-(`lspUtf16UnitsForChar`). Collections, `Result<T, E>` propagation, and MIR
-closure env emission are partially implemented today, so the remaining work is
-uneven runtime/backend surface coverage rather than a single missing subsystem.
+excluded, the current native probe first-walls on `LLVM011 [other]
+String.bytes requires Byte/List<Byte> lowering`. The earlier `Char` parameter
+lowering (`lspUtf16UnitsForChar`), `list_mixed_ptr`, non-ASCII string literal,
+match-as-statement, and nested-field assignment walls are all closed. The C
+runtime already ships `osty_rt_strings_Chars` / `osty_rt_strings_Bytes` with
+full UTF-8 coverage (including maximal-subpart recovery on ill-formed input);
+what remains is wiring `String.chars()` / `String.bytes()` lowering to those
+symbols so pure Osty `std.strings` bodies no longer depend on the runtime
+shim. `Result<T, E>` `?` propagation is wired; collection literals and a
+substantial slice of collection methods lower; MIR capturing-closure env
+emission has landed with tests — so the remaining work is a narrow
+runtime/backend parity queue rather than a single missing subsystem.
 
 The front-end (lex → parse → resolve → type-check) is **coverage-complete
 for the v0.4 core**: spec blocks parse, package/workspace resolution is
@@ -378,14 +386,24 @@ newline-separated `else`.
 - `-o PATH` / `--out PATH` — write the generated artifact to `PATH` instead of stdout
 - `--package NAME` — backend package/module name for the emitted file (default: `main`)
 - `--backend NAME` — code generation backend (`llvm`; default: `llvm`;
-  `llvm` emits textual `.ll` for the early scalar/control-flow/plain/escaped
-  string subset, including immutable/mutable string locals and simple String
-  function boundaries plus simple struct aggregate values and enum
-  tags/match expressions (payload-free + single-`Int` with `{ i64, i64 }`
-  payload), plus Phase 54-63 payload enum generalization (`Float` return/param/mut/reversed/wildcard,
-  String payload return/param/mut/reversed/wildcard). Unsupported shapes still
-  prepare skeleton artifacts and report structured diagnostics from the
-  toolchain backend policy)
+  `llvm` emits textual `.ll` covering scalar / control-flow / String
+  (ASCII + multi-byte UTF-8 via per-byte `\HH` escapes) / immutable and
+  mutable String locals / simple String function boundaries / simple
+  struct aggregate values and fields / enum tags and match expressions
+  (payload-free + single-scalar + struct payload + tag-and-ptr payload)
+  with `?` propagation over any shape (phase 54-63 + phase 74 closed),
+  match-as-statement with bare-variant/wildcard arms, nested field
+  assignment, `Char`/`Byte` parameter and return lowering with width
+  and sign conversions, interface vtable dispatch under generic
+  monomorphization, list / map / set literals plus intrinsics
+  (`isEmpty`, `pop` discard, nested `IndexExpr`), source-type tagged
+  list literals, and a root-tracked native runtime that provides
+  String / List / Map / Set / GC / scheduler / channel ABIs.
+  Unsupported shapes still prepare skeleton artifacts and report
+  `LLVM00x` / `LLVM01x` diagnostics authored by the toolchain backend
+  policy — the current first-walls are `String.bytes` / `String.chars`
+  → `List<Byte>` / `List<Char>` lowering and heterogeneous
+  `list_mixed_ptr` literals outside the tracked source-type path)
 - `--emit MODE` — requested text artifact. `llvm-ir` emits LLVM IR.
 
 `pipeline --gen` accepts the same source-artifact backend selection:
@@ -439,17 +457,18 @@ pins `edition = "0.4"`.
 `build` / `run` / `test` backend flags (after the subcommand):
 
 - `--backend NAME` — code generation backend (`llvm`; default: `llvm`;
-  `llvm` can write textual IR for the early scalar/control-flow/plain/escaped
-  string subset, including immutable/mutable string locals and simple String
-  function boundaries plus simple struct aggregate values and enum tags/match
-  expressions (payload-free + single-`Int` with `{ i64, i64 }` payload), plus
-  the Phase 54-63 payload enum generalization (`Float` return/param/mut/reversed/wildcard,
-  String payload return/param/mut/reversed/wildcard) path. `clang`-driven
-  object/binary emission now bundles a root-tracked LLVM native runtime for
-  String/List/GC ABI symbols, including explicit-collect managed-heap smoke
-  coverage, and generated-source diagnostics are available for supported programs;
-  unsupported shapes still prepare skeleton artifacts and report missing lowering
-  through structured diagnostics from the toolchain backend policy.
+  `llvm` writes textual IR / object / binary through `clang` covering
+  the scalar / control-flow / String (ASCII + multi-byte UTF-8) /
+  struct / enum / `Result<T, E>` with `?` propagation (phase 54-63 +
+  phase 74 closed) / match-as-expression and match-as-statement /
+  nested field assignment / `Char`/`Byte` width+sign conversions /
+  interface vtable dispatch under generic monomorphization / list /
+  map / set literal and intrinsic surface described above, bundling a
+  root-tracked LLVM native runtime that supplies String / List / Map /
+  Set / GC / scheduler / channel ABIs; unsupported shapes still
+  prepare skeleton artifacts and report missing lowering through
+  `LLVM00x` / `LLVM01x` diagnostics from the Osty-authored backend
+  policy.
 - `--emit MODE` — requested artifact mode (`llvm-ir`, `object`, or
   `binary`). `build --backend llvm --emit object|binary` uses `clang`; `run`
   requires `binary` because it executes the result. `osty test` uses the same

--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -1,9 +1,12 @@
 # MIR design (Osty compiler)
 
-Status: Stage 1 — scaffolding, lowering for the currently green LLVM subset,
-no backend rewiring yet. The existing `internal/llvmgen` IR→AST bridge stays
-in place; MIR is introduced underneath `internal/ir` as a new, backend-
-friendly layer that a future llvmgen rewrite can consume directly.
+Status: Stage 3.12 landed (composite map values + ABI fix); Stage 4 partially
+landed — MIR-first IR emission is the default for an expanding shape set while
+`internal/llvmgen`'s IR→AST bridge (`legacyFileFromModule`) stays live as the
+fallback for shapes the MIR emitter does not yet cover. Stage 5 (Go fallback
+removal) is still deferred; the gaps are tracked in the MIR emitter's
+`checkSupported` / `ProbeModule` plus the Stage 5 notes lower in this
+document.
 
 ## Why a second IR
 


### PR DESCRIPTION
## Summary

Reconcile top-level markdown docs (`README.md`, `ARCHITECTURE.md`, `CLAUDE.md`, `docs/mir_design.md`) with what the codebase actually does today. Found by evaluating each pipeline component against real source files and catching four families of drift.

## What changed

### Resolver pass model
`CLAUDE.md` and `ARCHITECTURE.md` described a 3-pass resolver with `declareUse` / `declareTopLevel` / `resolveDecl` helpers. The real resolver is **2-pass** (`declarePass` then `bodyPass`, fanned across the workspace in `ResolveAll`). `File` / `Package` / `Workspace` are scope boundaries, not temporal passes. Text now matches `resolve.go:128-149` and `workspace.go:402-424`, with E0506 circular-import detection noted.

### Linter catalog
`README.md` claimed **"L0001–L0042"**; `ARCHITECTURE.md` listed **8 rules**. The linter actually ships **28 L-codes across 7 categories** (unused, shadow, dead_code, naming, simplify, complexity, docs). `ARCHITECTURE.md` now enumerates every code and describes the `[lint]` allow/deny/exclude policy layer plus `--fix` / `--fix-dry-run`.

### LLVM backend status
Removed stale claims that `Char` parameter lowering, match-as-statement, nested field assignment, `list_mixed_ptr`, and non-ASCII string literals were first walls — all closed per `docs/toolchain_llvm_status.md`. The single remaining native-probe first wall is `String.bytes` / `String.chars` → `List<Byte>` / `List<Char>` lowering. Backend status matrix now calls out phase 54–63 + phase 74 `Result<T, E>` closure, match-as-statement, `Char`/`Byte` width+sign conversions, interface vtable dispatch under generic monomorphization, and the bundled runtime ABI (String / List / Map / Set / GC / scheduler / channel).

### LSP incremental engine
`ARCHITECTURE.md` said *"caching is by source identity, not incremental"*. The server actually wires a **Salsa-style `ostyquery.Engine`**, and `analyzeSingleFileViaEngine` is the default file-mode path (`server.go:70, 393`). Text updated; package/workspace legacy eager paths called out as the remaining migration.

### Other corrections
- `ARCHITECTURE.md`: v0.4 sweep phrasing extended to v0.5 (G20–G35 additive surface + G14/G15/G17 closes). Match exhaustiveness described as the **Maranget usefulness pass** (`pmCheckMatch` / `pmUseful` / `pmExhaustivenessWitness`) with witness cap 3 and depth cap 6 for recursive ADTs.
- `ARCHITECTURE.md`: stdlib section names the 36 modules + Map helper family (`update` / `getOr` / `mergeWith` / `groupBy` / `mapValues` / `retainIf`) + LLVM015 execution gap.
- `ARCHITECTURE.md`: grammar reference `OSTY_GRAMMAR_v0.4.md` → `v0.5.md`; pipeline diagram tail `gen/lint` → `ir/mir/llvmgen/lint`.
- `docs/mir_design.md`: status header **"Stage 1 — scaffolding"** → **"Stage 3.12 landed; Stage 4 partial default, Stage 5 deferred"**, with legacy HIR→AST bridge (`legacyFileFromModule`) described as the live fallback.

## Scope

Documentation-only. No source, tests, or generated artifacts touched.

- `ARCHITECTURE.md` — 130 lines changed
- `README.md` — 69 lines changed
- `docs/mir_design.md` — 11 lines changed
- `CLAUDE.md` — 2 lines changed

## Test plan

- [x] No code changed; no new tests required
- [x] Cross-referenced each claim against actual source files (`resolve.go`, `workspace.go`, `codes.go`, `server.go`, `elab.osty`, `osty_runtime.c`, `llvm_runtime_strings_chars_test.go`, `toolchain_llvm_status.md`)
- [ ] Reviewer spot-checks: confirm the backend status description matches their mental model of the current first wall
- [ ] Reviewer spot-checks: confirm the linter table enumeration matches `internal/diag/codes.go` (L0001–L0070 with gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)