### PR TITLE
feat(lint): extend osty lint --fix to package and workspace mode

### DIFF
--- a/cmd/osty/lint_fix_test.go
+++ b/cmd/osty/lint_fix_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFixManifest scaffolds a minimal package manifest so package-mode
+// lint resolves. Used by all --fix package tests.
+func writeFixManifest(t *testing.T, dir string) {
+	t.Helper()
+	manifest := strings.Join([]string{
+		`[package]`,
+		`name = "fixdemo"`,
+		`version = "0.1.0"`,
+		`edition = "0.3"`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "osty.toml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// TestLintFixSingleFileRewritesUnusedBinding exercises the pre-existing
+// single-file --fix path. L0001 carries a rename-to-_prefix fix; after
+// --fix the file should name the binding `_noisy`.
+func TestLintFixSingleFileRewritesUnusedBinding(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixManifest(t, dir)
+	src := "fn main() {\n    let noisy = 1\n}\n"
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "lint", "--fix", path)
+	if got.exit != 0 {
+		t.Fatalf("exit = %d, want 0\nstderr:\n%s", got.exit, got.stderr)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read post-fix: %v", err)
+	}
+	if !strings.Contains(string(data), "_noisy") {
+		t.Fatalf("post-fix file = %q, want the L0001 rename to `_noisy`", string(data))
+	}
+	if !strings.Contains(got.stderr, "applied") {
+		t.Fatalf("stderr = %q, want summary line reporting applied fixes", got.stderr)
+	}
+}
+
+// TestLintFixPackageModeRewritesEveryFile verifies the package-mode
+// --fix path added alongside this test. Two files each have a distinct
+// unused binding; both should be rewritten in a single invocation.
+func TestLintFixPackageModeRewritesEveryFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixManifest(t, dir)
+	aSrc := "fn alpha() {\n    let droppedA = 1\n}\n"
+	bSrc := "fn beta() {\n    let droppedB = 2\n}\n"
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	for path, body := range map[string]string{aPath: aSrc, bPath: bSrc} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	got := runOstyCLI(t, "lint", "--fix", dir)
+	if got.exit != 0 {
+		t.Fatalf("exit = %d, want 0\nstderr:\n%s", got.exit, got.stderr)
+	}
+	aAfter, _ := os.ReadFile(aPath)
+	bAfter, _ := os.ReadFile(bPath)
+	if !strings.Contains(string(aAfter), "_droppedA") {
+		t.Fatalf("a.osty post-fix = %q, want rename to `_droppedA`", string(aAfter))
+	}
+	if !strings.Contains(string(bAfter), "_droppedB") {
+		t.Fatalf("b.osty post-fix = %q, want rename to `_droppedB`", string(bAfter))
+	}
+	if !strings.Contains(got.stderr, "applied 2 fix") {
+		t.Fatalf("stderr = %q, want summary to mention both fixes applied", got.stderr)
+	}
+}
+
+// TestLintFixDryRunLeavesFilesUnchanged verifies that --fix-dry-run
+// prints the post-fix text to stdout but does NOT write back to disk.
+func TestLintFixDryRunLeavesFilesUnchanged(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixManifest(t, dir)
+	src := "fn main() {\n    let noisy = 1\n}\n"
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "lint", "--fix-dry-run", path)
+	if got.exit != 0 {
+		t.Fatalf("exit = %d, want 0\nstderr:\n%s", got.exit, got.stderr)
+	}
+	after, _ := os.ReadFile(path)
+	if string(after) != src {
+		t.Fatalf("source mutated under --fix-dry-run: got %q, want %q", string(after), src)
+	}
+	if !strings.Contains(got.stdout, "_noisy") {
+		t.Fatalf("stdout = %q, want post-fix preview mentioning `_noisy`", got.stdout)
+	}
+	if !strings.Contains(got.stderr, "would apply") {
+		t.Fatalf("stderr = %q, want dry-run summary line", got.stderr)
+	}
+}
+
+// TestLintFixPackageDryRunHeadsEachFile verifies the dry-run preview
+// prefixes each changed file with a `// ==== path ====` header so users
+// can diff per-file in a multi-file package.
+func TestLintFixPackageDryRunHeadsEachFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixManifest(t, dir)
+	aSrc := "fn alpha() {\n    let droppedA = 1\n}\n"
+	bSrc := "fn beta() {\n    let droppedB = 2\n}\n"
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	for path, body := range map[string]string{aPath: aSrc, bPath: bSrc} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	got := runOstyCLI(t, "lint", "--fix-dry-run", dir)
+	if got.exit != 0 {
+		t.Fatalf("exit = %d, want 0\nstderr:\n%s", got.exit, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "// ==== ") {
+		t.Fatalf("stdout = %q, want per-file header markers", got.stdout)
+	}
+	if !strings.Contains(got.stdout, "a.osty") || !strings.Contains(got.stdout, "b.osty") {
+		t.Fatalf("stdout = %q, want both filenames in the dry-run preview", got.stdout)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -797,7 +797,74 @@ func runLintLoadedPackage(
 	}
 	all := append(append(append([]*diag.Diagnostic{}, res.Diags...), chk.Diags...), lr.Diags...)
 	printPackageDiags(pkg, all, flags)
+	if flags.fix || flags.fixDryRun {
+		applyPackageFixes(pkg, lr.Diags, flags)
+	}
 	return lintPackageOutcome{anyErr: hasError(all), anyWarn: hasWarning(all)}
+}
+
+// applyPackageFixes runs lint.ApplyFixes on each file in the package
+// using only diagnostics stamped for that file, then either rewrites the
+// files in place (--fix) or dumps a concatenated dry-run preview
+// (--fix-dry-run). Emits a final summary line counting fixes applied
+// and overlaps skipped across the whole package.
+//
+// Diagnostics whose File is empty are attached to the package's first
+// file — package-mode lint.Package does stamp File on every lint diag,
+// but the fallback keeps this robust against downstream regressions.
+func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cliFlags) {
+	if pkg == nil || len(pkg.Files) == 0 {
+		return
+	}
+	byFile := map[string][]*diag.Diagnostic{}
+	for _, d := range diags {
+		path := d.File
+		if path == "" {
+			path = pkg.Files[0].Path
+		}
+		byFile[path] = append(byFile[path], d)
+	}
+	totalApplied, totalSkipped := 0, 0
+	mode := "osty lint"
+	for _, f := range pkg.Files {
+		ds := byFile[f.Path]
+		if len(ds) == 0 {
+			continue
+		}
+		newSrc, applied, skipped := lint.ApplyFixes(f.Source, ds)
+		totalApplied += applied
+		totalSkipped += skipped
+		switch {
+		case flags.fixDryRun:
+			if applied == 0 {
+				continue
+			}
+			// Prefix each file's post-fix content with a header so the
+			// user can diff it against the original per file.
+			fmt.Fprintf(os.Stdout, "// ==== %s ====\n", f.Path)
+			if _, err := os.Stdout.Write(newSrc); err != nil {
+				fmt.Fprintf(os.Stderr, "%s --fix-dry-run: %v\n", mode, err)
+				os.Exit(1)
+			}
+			if len(newSrc) > 0 && newSrc[len(newSrc)-1] != '\n' {
+				fmt.Fprintln(os.Stdout)
+			}
+		case flags.fix:
+			if applied == 0 {
+				continue
+			}
+			if err := os.WriteFile(f.Path, newSrc, 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "%s --fix: %v\n", mode, err)
+				os.Exit(1)
+			}
+		}
+	}
+	switch {
+	case flags.fixDryRun:
+		fmt.Fprintf(os.Stderr, "%s --fix-dry-run: %d fix(es) would apply, %d overlap(s) would be skipped\n", mode, totalApplied, totalSkipped)
+	case flags.fix:
+		fmt.Fprintf(os.Stderr, "%s --fix: applied %d fix(es), skipped %d overlap(s)\n", mode, totalApplied, totalSkipped)
+	}
 }
 
 // runResolvePackage is runCheckPackage plus a resolution dump per file.


### PR DESCRIPTION
## Summary
레버리지 3건 중 2번 (`osty lint --fix` CLI) 착수. 기존 `--fix` / `--fix-dry-run`은 **단일 파일 경로에서만** 작동했고, `osty lint DIR`이나 workspace 모드에서는 플래그가 조용히 무시되고 있었음 — fixable 진단이 보여도 적용 수단이 없어서 사용자가 파일별로 호출하거나 손으로 고쳐야 했던 갭.

## 구현
`runLintLoadedPackage`가 진단 렌더링 직후 신규 `applyPackageFixes`를 호출:

- `diag.File` 기준으로 lint 진단을 파일별로 버킷팅 (stamp 누락 시 `pkg.Files[0].Path`로 fallback — 쓰기 대상 모호성 제거)
- 파일별 `f.Source`에 `lint.ApplyFixes` 실행
- `--fix` → 파일별 in-place rewrite
- `--fix-dry-run` → 각 변경 파일을 `// ==== path ====` 헤더 아래에 stdout으로 스트리밍. 파일별 diff 가능
- summary line 한 줄로 전체 집계 출력 (applied N, skipped M 또는 would apply N, would skip M)

Workspace 모드(`osty lint`의 dir-of-packages)는 `runLintWorkspace → runLintLoadedPackage`로 동일 경로를 타므로 트리 전체가 한 호출로 고쳐짐.

## 테스트 (cmd/osty/lint_fix_test.go, 4건)
- `TestLintFixSingleFileRewritesUnusedBinding` — 단일 파일 경로 회귀 방지
- `TestLintFixPackageModeRewritesEveryFile` — 2파일 패키지가 한 번에 모두 rewrite
- `TestLintFixDryRunLeavesFilesUnchanged` — dry-run이 디스크에 쓰지 않고 미리보기만
- `TestLintFixPackageDryRunHeadsEachFile` — 다중 파일 dry-run이 파일별 헤더 마커 포함

## Test plan
- [x] `just front` + `go test ./cmd/osty` — 전부 통과
- [x] 새로운 4개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)