### PR TITLE
feat(check): register remaining Map/Set bodied helper signatures

### DIFF
--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1742,6 +1742,61 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         paramNames: ["f"], paramTys: [tFnV_R_map],
         generics: ["K", "V", "R"], genericBounds: [],
     })
+    // Pure-Osty Map helpers (collections.osty §B.9.1) not covered by
+    // the #470 intrinsic set. These are Osty-bodied today but become
+    // real IR functions once Option B Phase 1 (#483) graduates their
+    // stdlib template through `injectReachableStdlibTypes`. Register
+    // the signatures now so callers type-check; backend lowering
+    // flips from "no method" to "stdlib body" as the pipeline fills in.
+    let tPairKV = tyTuple(tys, [tK, tV])
+    let tListPairKV = tyNamed(tys, "List", [tPairKV])
+    let tOptPairKV = tyOptional(tys, tPairKV)
+    let tFnKV_Unit = tyFn(tys, [tK, tV], tUnit(tys))
+    checkRegisterFn(env, CheckFnSig {
+        name: "entries", owner: "Map", receiverTy: tMapKV, retTy: tListPairKV,
+        paramNames: [], paramTys: [],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "forEach", owner: "Map", receiverTy: tMapKV, retTy: tUnit(tys),
+        paramNames: ["f"], paramTys: [tFnKV_Unit],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "any", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys),
+        paramNames: ["pred"], paramTys: [tFnKV_Bool],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "all", owner: "Map", receiverTy: tMapKV, retTy: tBool(tys),
+        paramNames: ["pred"], paramTys: [tFnKV_Bool],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "count", owner: "Map", receiverTy: tMapKV, retTy: tInt(tys),
+        paramNames: ["pred"], paramTys: [tFnKV_Bool],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "find", owner: "Map", receiverTy: tMapKV, retTy: tOptPairKV,
+        paramNames: ["pred"], paramTys: [tFnKV_Bool],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "filter", owner: "Map", receiverTy: tMapKV, retTy: tMapKV,
+        paramNames: ["pred"], paramTys: [tFnKV_Bool],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "merge", owner: "Map", receiverTy: tMapKV, retTy: tMapKV,
+        paramNames: ["other"], paramTys: [tMapKV],
+        generics: ["K", "V"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "insertAll", owner: "Map", receiverTy: tMapKV, retTy: tUnit(tys),
+        paramNames: ["other"], paramTys: [tMapKV],
+        generics: ["K", "V"], genericBounds: [],
+    })
 
     // ----- Set<T> intrinsics (spec §10.6) -----
     let tSetT = tyNamed(tys, "Set", [tT])
@@ -1778,6 +1833,22 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     checkRegisterFn(env, CheckFnSig {
         name: "toList", owner: "Set", receiverTy: tSetT, retTy: tListT,
         paramNames: [], paramTys: [],
+        generics: ["T"], genericBounds: [],
+    })
+    // Pure-Osty Set helpers (collections.osty §B.9.1).
+    checkRegisterFn(env, CheckFnSig {
+        name: "union", owner: "Set", receiverTy: tSetT, retTy: tSetT,
+        paramNames: ["other"], paramTys: [tSetT],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "intersect", owner: "Set", receiverTy: tSetT, retTy: tSetT,
+        paramNames: ["other"], paramTys: [tSetT],
+        generics: ["T"], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "difference", owner: "Set", receiverTy: tSetT, retTy: tSetT,
+        paramNames: ["other"], paramTys: [tSetT],
         generics: ["T"], genericBounds: [],
     })
 


### PR DESCRIPTION
## Summary

Follow-up to [#485](https://github.com/choiceoh/osty/pull/485) which registered the five Map helpers covered by the #470 runtime intrinsics (`getOr`/`update`/`retainIf`/`mergeWith`/`mapValues`). The remaining collections §B.9.1 helpers — still Osty-bodied, pending Option B Phase 1 ([#483](https://github.com/choiceoh/osty/pull/483))'s stdlib type-template injection flipping them into real IR functions — were not callable from user code because the checker didn't know their shape and failed with E0703.

## What's registered

### Map (9 additions)

| Method | Signature |
|---|---|
| `entries` | `(self) -> List<(K, V)>` |
| `forEach` | `(self, fn(K, V))` |
| `any` / `all` | `(self, fn(K, V) -> Bool) -> Bool` |
| `count` | `(self, fn(K, V) -> Bool) -> Int` |
| `find` | `(self, fn(K, V) -> Bool) -> (K, V)?` |
| `filter` | `(self, fn(K, V) -> Bool) -> Map<K, V>` |
| `merge` | `(self, Map<K, V>) -> Map<K, V>` |
| `insertAll` | `(mut self, Map<K, V>)` |

New type helpers: `tPairKV = tyTuple([tK, tV])`, `tListPairKV`, `tOptPairKV`, `tFnKV_Unit`. Reuses `tFnKV_Bool` introduced in #485.

### Set (3 additions)

| Method | Signature |
|---|---|
| `union` / `intersect` / `difference` | `(self, Set<T>) -> Set<T>` |

## Regen note

Windows `go generate ./internal/selfhost` currently trips on a pre-existing drift in `toolchain/semver.osty` (99595ca refactored `signString` to call `strings.compare`, which bootstrap-gen has no routing entry for — it emits `strings.compare(a, b)` literal and Go rejects because the stdlib has capitalized `strings.Compare`). This blocks `installWithBuildGate` from writing a fresh `generated.go`, so the on-disk file stays at its macOS-committed state.

Same pattern as #485: Go-side `just front` passes with the stale `generated.go`; the new signatures take effect for `osty check` users once macOS regen lands on top. Filing as-is rather than carrying a temporary `strings.compare` → inline workaround because the drift is orthogonal to the helper registration.

## Test plan

- [x] `just front` — all green
- [ ] (macOS reviewer) `go generate ./internal/selfhost` lands a clean regen on top of this commit so the runtime checker binary picks up the new signatures
- [ ] (macOS reviewer) verify `m.entries()`, `m.forEach(|k, v| ...)`, `m.any(|k, v| ...)`, `s.union(other)`, etc. type-check end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)