### PR TITLE
feat(lint): add L0046 unnecessary_wrap — fn returns Result/Option but never errors

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1516,7 +1516,7 @@ enum Color { red, Green }   // warning on `red`
 
 ---
 
-## Lint — redundant forms (L0040–L0045)
+## Lint — redundant forms (L0040–L0046)
 
 ### L0040 — `CodeRedundantBool`
 
@@ -1567,6 +1567,20 @@ let x = !true      // warning: use `false` directly
 ```
 
 **Fix**: replace with the opposite literal.
+
+### L0046 — `CodeUnnecessaryWrap`
+
+A function declared `-> Result<T, E>` or `-> Option<T>` whose body only ever exits via `Ok(...)` or `Some(...)` — the wrapping is pure noise at every call site.
+
+fn parse(s: String) -> Int { s.len() }
+
+```osty
+fn parse(s: String) -> Result<Int, Error> {
+    Ok(s.len())              // warning: fn never returns Err
+}
+```
+
+**Fix**: drop the wrapping and declare the plain return type:
 
 ---
 

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1375,6 +1375,18 @@ const (
 	// Fix: replace with the opposite literal.
 	CodeNegatedBoolLiteral = "L0045"
 
+	// A function declared `-> Result<T, E>` or `-> Option<T>` whose body
+	// only ever exits via `Ok(...)` or `Some(...)` — the wrapping is
+	// pure noise at every call site.
+	//
+	// Example:
+	//   fn parse(s: String) -> Result<Int, Error> {
+	//       Ok(s.len())              // warning: fn never returns Err
+	//   }
+	// Fix: drop the wrapping and declare the plain return type:
+	//   fn parse(s: String) -> Int { s.len() }
+	CodeUnnecessaryWrap = "L0046"
+
 	// Lint — complexity.
 
 	// A function declares too many parameters (> 7 by default).

--- a/internal/lint/registry.go
+++ b/internal/lint/registry.go
@@ -214,6 +214,12 @@ var allRules = []Rule{
 		Description: "Use the opposite literal directly.",
 		Fixable:     true,
 	},
+	{
+		Code: diag.CodeUnnecessaryWrap, Name: "unnecessary_wrap",
+		Category: CategorySimplify, DefaultSeverity: diag.Warning,
+		Summary:     "function returns Result/Option but never errors",
+		Description: "A function declared `-> Result<T, E>` or `-> Option<T>` whose body only exits through `Ok(...)` or `Some(...)` (no `Err`, `None`, or `?` propagation) forces every caller to unwrap for no reason. Drop the wrapping and declare the plain return type.",
+	},
 
 	// ---- Complexity (L0050-L0069) ----
 	{

--- a/toolchain/diag_examples.osty
+++ b/toolchain/diag_examples.osty
@@ -52,5 +52,6 @@ pub fn diagHarvestCases() -> List<DiagHarvestCase> {
         DiagHarvestCase { code: "L0031", example: "fn LoadConfig() \{ \}          // warning: should be `loadConfig`\nfn f(User_Id: Int) \{\}        // warning: should be `userId`", phase: "lint" },
         DiagHarvestCase { code: "L0032", example: "enum Color \{ red, Green \}   // warning on `red`", phase: "lint" },
         DiagHarvestCase { code: "L0045", example: "let x = !true      // warning: use `false` directly", phase: "lint" },
+        DiagHarvestCase { code: "L0046", example: "fn parse(s: String) -> Result<Int, Error> \{\n    Ok(s.len())              // warning: fn never returns Err\n\}", phase: "lint" },
     ]
 }

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -196,13 +196,14 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     if code == "L0030" { return FamilyLint }
     if code == "L0031" { return FamilyLint }
     if code == "L0032" { return FamilyLint }
-    // Lint — redundant forms (L0040–L0045)
+    // Lint — redundant forms (L0040–L0046)
     if code == "L0040" { return FamilyLint }
     if code == "L0041" { return FamilyLint }
     if code == "L0042" { return FamilyLint }
     if code == "L0043" { return FamilyLint }
     if code == "L0044" { return FamilyLint }
     if code == "L0045" { return FamilyLint }
+    if code == "L0046" { return FamilyLint }
     // Lint — complexity (L0050–L0053)
     if code == "L0050" { return FamilyLint }
     if code == "L0052" { return FamilyLint }

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -203,6 +203,7 @@ fn selfLintFullPipeline(
     report.resolveErrors = selfResolveDiagnosticCount(resolved)
     report = selfLintAstFile(file, resolved, report)
     report = selfLintAstCheckUnusedMembersWith(file, access, report)
+    report = selfLintAstCheckUnnecessaryWrap(file, report)
     if hints.enabled {
         report = selfLintAstCheckIgnoredResult(file, hints, report)
     }
@@ -3139,6 +3140,7 @@ pub fn selfLintAllRules() -> List<SelfLintRuleInfo> {
     rules.push(selfLintMakeRule("L0043", "double_negation", "simplify", "!! collapses to the inner expression", true))
     rules.push(selfLintMakeRule("L0044", "bool_literal_compare", "simplify", "compare against bool literal can be simplified", true))
     rules.push(selfLintMakeRule("L0045", "negated_bool_literal", "simplify", "!true / !false can be written directly", false))
+    rules.push(selfLintMakeRule("L0046", "unnecessary_wrap", "simplify", "function returns Result/Option but never errors", false))
     rules.push(selfLintMakeRule("L0050", "too_many_params", "complexity", "function takes too many parameters", false))
     rules.push(selfLintMakeRule("L0052", "function_too_long", "complexity", "function body is too long", false))
     rules.push(selfLintMakeRule("L0053", "deep_nesting", "complexity", "control flow is nested too deeply", false))
@@ -3400,6 +3402,185 @@ fn selfLintDiagIsAllowed(diag: SelfLintDiagnostic, scopes: List<SelfLintAllowSco
             return true
         }
         if selfLintStringListContains(scope.codes, diag.code) {
+            return true
+        }
+    }
+    false
+}
+
+// ============================================================
+// L0046 unnecessary_wrap
+// ============================================================
+//
+// A fn declared `-> Result<T, E>` or `-> Option<T>` whose body cannot
+// return `Err(...)` / `None` and does not propagate via `?` is wrapping
+// for no reason — every caller has to unwrap. Flag it so the author can
+// drop the wrapper and declare the plain return type.
+//
+// Heuristic (AST-only): skip when the body uses `?` or directly
+// constructs `Err(...)` / `None`; emit only when at least one exit path
+// actually wraps via `Ok(...)` / `Some(...)`. Callers that never reach
+// the end of the body (e.g. `for {}` infinite loop) never show a wrap
+// and therefore never trip the rule.
+
+fn selfLintAstCheckUnnecessaryWrap(
+    file: AstFile,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintUnnecessaryWrapDecl(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintUnnecessaryWrapDecl(
+    file: AstFile,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNFnDecl {
+        return selfLintUnnecessaryWrapCheckFn(file, idx, node, report)
+    }
+    if node.kind == AstNStructDecl
+        || node.kind == AstNEnumDecl
+        || node.kind == AstNInterfaceDecl {
+        let mut out = report
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl {
+                out = selfLintUnnecessaryWrapCheckFn(file, memberIdx, member, out)
+            }
+        }
+        return out
+    }
+    report
+}
+
+fn selfLintUnnecessaryWrapCheckFn(
+    file: AstFile,
+    idx: Int,
+    node: AstNode,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if node.right < 0 || node.left < 0 {
+        return report
+    }
+    let retType = selfLintAstNode(file, node.left)
+    let kind = selfLintReturnWrapKind(retType)
+    if kind == "" {
+        return report
+    }
+    if selfLintBodyHasFallibleExit(file, node.right, kind) {
+        return report
+    }
+    if !(selfLintBodyWrapsExit(file, node.right, kind)) {
+        return report
+    }
+    let mut message = "function always returns Some(...) — drop the Option wrapping"
+    if kind == "result" {
+        message = "function always returns Ok(...) — drop the Result wrapping"
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0046",
+        message,
+        node.text,
+        node.start,
+        node.end,
+        idx,
+    )
+}
+
+fn selfLintReturnWrapKind(typeNode: AstNode) -> String {
+    if typeNode.kind != AstNType {
+        return ""
+    }
+    if typeNode.text == "Result" {
+        return "result"
+    }
+    if typeNode.text == "Option" || typeNode.text == "optional" {
+        return "option"
+    }
+    ""
+}
+
+fn selfLintBodyHasFallibleExit(file: AstFile, idx: Int, kind: String) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNQuestion {
+        return true
+    }
+    if node.kind == AstNCall && node.left >= 0 {
+        let callee = selfLintAstNode(file, node.left)
+        if callee.kind == AstNIdent {
+            if kind == "result" && callee.text == "Err" {
+                return true
+            }
+            if kind == "option" && callee.text == "None" {
+                return true
+            }
+        }
+    }
+    if node.kind == AstNIdent {
+        if kind == "option" && node.text == "None" {
+            return true
+        }
+    }
+    if selfLintBodyHasFallibleExit(file, node.left, kind) {
+        return true
+    }
+    if selfLintBodyHasFallibleExit(file, node.right, kind) {
+        return true
+    }
+    for child in node.children {
+        if selfLintBodyHasFallibleExit(file, child, kind) {
+            return true
+        }
+    }
+    for child in node.children2 {
+        if selfLintBodyHasFallibleExit(file, child, kind) {
+            return true
+        }
+    }
+    false
+}
+
+fn selfLintBodyWrapsExit(file: AstFile, idx: Int, kind: String) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNCall && node.left >= 0 {
+        let callee = selfLintAstNode(file, node.left)
+        if callee.kind == AstNIdent {
+            if kind == "result" && callee.text == "Ok" {
+                return true
+            }
+            if kind == "option" && callee.text == "Some" {
+                return true
+            }
+        }
+    }
+    if selfLintBodyWrapsExit(file, node.left, kind) {
+        return true
+    }
+    if selfLintBodyWrapsExit(file, node.right, kind) {
+        return true
+    }
+    for child in node.children {
+        if selfLintBodyWrapsExit(file, child, kind) {
+            return true
+        }
+    }
+    for child in node.children2 {
+        if selfLintBodyWrapsExit(file, child, kind) {
             return true
         }
     }

--- a/toolchain/lint_test.osty
+++ b/toolchain/lint_test.osty
@@ -887,6 +887,84 @@ fn testSelfLintAllowSuppressesSpecificCode() {
     testing.assertEq(selfLintCodeCount(withAllow, "L0002"), 1)
 }
 
+fn testSelfLintFindsUnnecessaryResultWrap() {
+    let report = selfLintSource(
+        r"""
+            fn parseLen(s: String) -> Result<Int, Error> {
+                Ok(s.len())
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0046"), 1)
+}
+
+fn testSelfLintFindsUnnecessaryOptionWrap() {
+    let report = selfLintSource(
+        r"""
+            fn maybeLen(s: String) -> Option<Int> {
+                Some(s.len())
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0046"), 1)
+}
+
+fn testSelfLintSkipsWrapWhenBodyPropagatesWithQuestion() {
+    let report = selfLintSource(
+        r"""
+            fn load(path: String) -> Result<Int, Error> {
+                let n = parse(path)?
+                Ok(n)
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0046"), 0)
+}
+
+fn testSelfLintSkipsWrapWhenBodyReturnsErr() {
+    let report = selfLintSource(
+        r"""
+            fn maybeDo(flag: Bool) -> Result<Int, Error> {
+                if flag {
+                    Ok(1)
+                } else {
+                    Err(SomeError.Boom)
+                }
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0046"), 0)
+}
+
+fn testSelfLintSkipsWrapWhenBodyReturnsNone() {
+    let report = selfLintSource(
+        r"""
+            fn maybeLen(s: String) -> Option<Int> {
+                if s.len() == 0 { None } else { Some(s.len()) }
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0046"), 0)
+}
+
+fn testSelfLintWrapRespectsAllow() {
+    let report = selfLintSource(
+        r"""
+            #[allow(L0046)]
+            fn parseLen(s: String) -> Result<Int, Error> {
+                Ok(s.len())
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0046"), 0)
+}
+
 fn testSelfLintAllowAcceptsRuleAlias() {
     let report = selfLintSource(
         r"""


### PR DESCRIPTION
## Summary
레버리지 3건 중 3번(체커 결과 → 린터 타입 브리지 확장) 첫 걸음. PR #481에서 만든 `SelfLintTypeHints`/`selfLintCheckedAstSource` 인프라 위에 실용적인 타입(형-기반) 규칙을 하나 얹습니다. 이 규칙은 순수 AST만으로도 동작하지만, 향후 타입 정보로 정밀화할 여지를 남긴 형태.

## L0046 `unnecessary_wrap`
- **대상**: `fn foo() -> Result<T, E>` 또는 `-> Option<T>` (또는 `-> T?`) 로 선언된 함수
- **조건**: body가
  - `?` 전파를 쓰지 않고
  - `Err(...)` 호출이 없고
  - bare `None` 식별자가 없고
  - 최소 한 경로가 `Ok(...)` / `Some(...)`로 wrap
- **메시지**: `function always returns Ok(...) — drop the Result wrapping` (또는 Option 버전)
- **제안**: 반환 타입을 벗기고 평문 `T`로 선언

### 왜 유용한가
- 모든 호출자가 무의미한 unwrap을 쓰도록 강요하는 API smell을 잡음
- Clippy의 `clippy::unnecessary_wraps`와 동일 철학 — Rust 진영에서 검증된 rule

## 구현
- Go: `diag.CodeUnnecessaryWrap = "L0046"` + `internal/lint/registry.go` 엔트리 추가
- Osty: `selfLintAstCheckUnnecessaryWrap`가 파이프라인 중간에서 fn decl을 순회
  - `AstNFnDecl`의 `node.left`(return type)가 `AstNType` 이고 `text`가 `"Result"` / `"Option"` / `"optional"` 일 때만 검사
  - body 재귀 스캔: `AstNQuestion`, `AstNCall(callee AstNIdent "Err")`, `AstNIdent "None"` 중 하나라도 있으면 skip
  - `AstNCall(callee AstNIdent "Ok"/"Some")` 하나라도 있어야 emit
- `selfLintAllRules()`에 메타데이터 추가
- `ERROR_CODES.md` + `toolchain/diag_manifest.osty` + `toolchain/diag_examples.osty` 자동 재생성

## 테스트 (toolchain/lint_test.osty, 6건)
- `testSelfLintFindsUnnecessaryResultWrap` — `Ok(...)`만 있는 Result fn
- `testSelfLintFindsUnnecessaryOptionWrap` — `Some(...)`만 있는 Option fn
- `testSelfLintSkipsWrapWhenBodyPropagatesWithQuestion` — `?`가 있으면 skip
- `testSelfLintSkipsWrapWhenBodyReturnsErr` — `Err(...)` 분기가 있으면 skip
- `testSelfLintSkipsWrapWhenBodyReturnsNone` — `None` 분기가 있으면 skip
- `testSelfLintWrapRespectsAllow` — `#[allow(L0046)]`로 억제 가능

## Test plan
- [x] `just front` 전부 통과
- [ ] CI에서 `generated.go` 재생성 후 selfhost 측 6개 테스트 통과 확인

## Out of scope (다음 PR 후보)
- Type-bridge를 실제로 사용하는 rule: `useless_cast` (Osty는 `as` 없음이라 N/A), `question_on_infallible` (이미 E0xxx로 타입 에러)
- `Never` 타입을 이용한 L0020 dead-code 정밀화

🤖 Generated with [Claude Code](https://claude.com/claude-code)