### PR TITLE
feat(ir,llvmgen): Option B Phase 2 — mangler + AST bridge for specialized built-ins

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -1,0 +1,182 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/llvmgen"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestPhase2MangledNamesAreValidLLVMIdentifiers locks in the Phase 2
+// fix for LLVM016: `Map<String, V>` now mangles to a name built from
+// valid identifier characters (`Ss` for String, `By` for Bytes),
+// instead of `?` placeholders that llvmIsIdent rejects. Without this
+// the whole `GenerateModule` entry point fails before reaching the
+// interesting method-emission code.
+func TestPhase2MangledNamesAreValidLLVMIdentifiers(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>) -> Int { m.len() }
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	for _, d := range monoMod.Decls {
+		sd, ok := d.(*ir.StructDecl)
+		if !ok || len(sd.Generics) != 0 {
+			continue
+		}
+		if !strings.Contains(sd.Name, "Map") {
+			continue
+		}
+		if strings.ContainsRune(sd.Name, '?') ||
+			strings.ContainsRune(sd.Name, '<') ||
+			strings.ContainsRune(sd.Name, '>') ||
+			strings.ContainsRune(sd.Name, ' ') {
+			t.Fatalf("specialized Map name %q contains illegal LLVM identifier chars — mangler regressed on String/Bytes", sd.Name)
+		}
+	}
+}
+
+// TestPhase2SpecializedBuiltinBodylessMethodsAreDropped locks in the
+// Phase 2 fix for LLVM010: the AST bridge
+// (legacyStructDeclFromIR) strips bodyless intrinsic methods from
+// `_ZTS…` specialized structs so the legacy emitter doesn't wall on
+// "function has no body". The runtime backs those calls at dispatch
+// time via osty_rt_map_* helpers, so the LLVM layer never needs the
+// empty definitions.
+func TestPhase2SpecializedBuiltinBodylessMethodsAreDropped(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>) -> Int { m.len() }
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2_bodyless.osty",
+		Source:      []byte(src),
+	}
+	_, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil && strings.Contains(err.Error(), "LLVM010") && strings.Contains(err.Error(), "has no body") {
+		t.Fatalf("bodyless intrinsic method leaked into LLVM emission: %v", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "LLVM016") {
+		t.Fatalf("mangled specialized name still failing ASCII-identifier check: %v", err)
+	}
+	// Any other error is the next Phase 2 blocker — not a regression
+	// of what this test covers.
+	if err != nil {
+		t.Logf("later Phase 2 blocker (not the bodyless one this test covers): %v", err)
+	}
+}
+
+// TestPhase2MonomorphMapReachesGenerateModule is the smallest viable
+// end-to-end probe for Option B's Phase 2 gap: after Phase 1's
+// monomorphization produces `Map$String$Int` with 22 methods, does
+// llvmgen.GenerateModule survive consuming that module?
+//
+// This test drives the full pipeline in-process (parse → resolve →
+// check → ir.Lower → inject stdlib types → monomorphize → llvmgen)
+// and records what the backend does with the specialized Map.
+// Failures here are informational — they pin down which llvmgen
+// subsystem needs to learn about specialized builtin types, so the
+// Phase 2 fix can target that subsystem directly.
+func TestPhase2MonomorphMapReachesGenerateModule(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Bool {
+    m.containsKey(k)
+}
+
+fn main() {}
+`
+	file, parseDiags := parser.ParseCanonical([]byte(src))
+	for _, d := range parseDiags {
+		if d.Severity == 0 {
+			t.Fatalf("parse error: %v", d)
+		}
+	}
+	reg := stdlib.LoadCached()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{
+		Source: []byte(src),
+		Stdlib: reg,
+	})
+	mod, _ := ir.Lower("main", file, res, chk)
+	if mod == nil {
+		t.Fatalf("ir.Lower returned nil")
+	}
+
+	// Phase 1: inject + monomorph.
+	injected, _ := injectReachableStdlibTypes(mod, reg)
+	mod.Decls = append(mod.Decls, injected...)
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if monoMod == nil {
+		t.Fatalf("Monomorphize returned nil: %v", monoErrs)
+	}
+
+	// Phase 2 probe: feed to the LLVM backend.
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2.osty",
+		Source:      []byte(src),
+	}
+	irOut, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil {
+		// Document the next-blocker shape without failing CI. Each
+		// Phase 2 PR peels one layer; this test reports the current
+		// outermost wall so the next iteration can target it
+		// precisely.
+		t.Logf("Phase 2 next-blocker: llvmgen.GenerateModule walls on monomorphized Map<String,Int>: %v", err)
+		t.Skipf("Phase 2 pipeline not yet complete; see log above for the current outermost failure")
+	}
+	got := string(irOut)
+	t.Logf("Phase 2 observation: LLVM IR size = %d bytes", len(got))
+
+	// Does the emission include any `_ZTSN...Map...` symbol? That
+	// would prove the specialized method actually made it into the
+	// textual LLVM output, which is what we'd retire the hand-emit
+	// onto in Phase 5.
+	seesSpecialized := strings.Contains(got, "_ZTSN") && strings.Contains(got, "Map")
+	if !seesSpecialized {
+		t.Logf("observation: no Map$... symbol in generated IR — likely the existing emitMapMethodCall intercept still fired on 'Map' source name")
+	} else {
+		t.Logf("observation: specialized Map symbol present in IR")
+	}
+
+	// Also record whether the existing `osty_rt_map_contains_*`
+	// intrinsic still shows — if so, the old path is still in use.
+	if strings.Contains(got, "osty_rt_map_contains_") {
+		t.Logf("observation: legacy contains intrinsic symbol present — hand-emit path is winning over the specialized method")
+	}
+}
+
+// pipelineThroughMonomorph runs parse → resolve → check → ir.Lower →
+// inject stdlib types → monomorphize and returns the resulting IR
+// module. Shared by the Phase 2 probe tests so each focuses on one
+// assertion rather than repeating the pipeline boilerplate.
+func pipelineThroughMonomorph(t *testing.T, src string) *ir.Module {
+	t.Helper()
+	file, parseDiags := parser.ParseCanonical([]byte(src))
+	for _, d := range parseDiags {
+		if d.Severity == 0 {
+			t.Fatalf("parse error: %v", d)
+		}
+	}
+	reg := stdlib.LoadCached()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{
+		Source: []byte(src),
+		Stdlib: reg,
+	})
+	mod, _ := ir.Lower("main", file, res, chk)
+	if mod == nil {
+		t.Fatalf("ir.Lower returned nil")
+	}
+	injected, _ := injectReachableStdlibTypes(mod, reg)
+	mod.Decls = append(mod.Decls, injected...)
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if monoMod == nil {
+		t.Fatalf("Monomorphize returned nil: %v", monoErrs)
+	}
+	return monoMod
+}

--- a/internal/ir/monomorph_snapshot.go
+++ b/internal/ir/monomorph_snapshot.go
@@ -122,6 +122,17 @@ func MonomorphPrimCode(name string) string {
 	if name == "Unit" {
 		return "v"
 	}
+	// Osty `String` and `Bytes` are opaque aggregates at IR level but
+	// their mangled forms must be valid LLVM identifier chars so a
+	// specialized `Map<String, V>` passes llvmIsIdent. "Ss" and "By"
+	// are Itanium-style extended identifiers that stay unique from
+	// the single-letter primitive codes above.
+	if name == "String" {
+		return "Ss"
+	}
+	if name == "Bytes" {
+		return "By"
+	}
 	return ""
 }
 

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -380,7 +380,19 @@ func legacyStructDeclFromIR(sd *ostyir.StructDecl) (*ast.StructDecl, error) {
 		}
 		out.Fields = append(out.Fields, legacyField)
 	}
+	specializedBuiltin := isSpecializedBuiltinStructName(sd.Name)
 	for _, method := range sd.Methods {
+		// Option B Phase 2: specialized built-in structs (Map$String$Int,
+		// Option$Int, …) inherit bodyless intrinsic methods from the
+		// stdlib template (Map.len / Map.get / Map.insert / …). These
+		// are served by runtime helpers (osty_rt_map_len etc.), not by
+		// user-level LLVM functions. Dropping them here avoids LLVM010
+		// "function has no body" at emit time; the method-call
+		// dispatch in emitMapMethodCall still routes to the runtime
+		// via the original source-type intrinsic recognition.
+		if specializedBuiltin && method != nil && method.Body == nil {
+			continue
+		}
 		legacyMethod, err := legacyFnDeclFromIR(method, true)
 		if err != nil {
 			return nil, err
@@ -388,6 +400,17 @@ func legacyStructDeclFromIR(sd *ostyir.StructDecl) (*ast.StructDecl, error) {
 		out.Methods = append(out.Methods, legacyMethod)
 	}
 	return out, nil
+}
+
+// isSpecializedBuiltinStructName reports whether name is an
+// Itanium-mangled specialization produced by the monomorphizer for a
+// stdlib built-in template (Map, List, Set, Option, Result). All such
+// names start with the `_ZTS` Itanium type-info prefix; user structs
+// keep their source name unless explicitly specialized via the same
+// mangler, and in that case they are equally free of bodyless
+// methods (user structs don't carry intrinsic placeholders).
+func isSpecializedBuiltinStructName(name string) bool {
+	return strings.HasPrefix(name, "_ZTS")
 }
 
 func legacyFieldFromIR(field *ostyir.Field) (*ast.Field, error) {

--- a/toolchain/monomorph.osty
+++ b/toolchain/monomorph.osty
@@ -93,6 +93,18 @@ pub fn monomorphPrimCode(name: String) -> String {
     if name == "Unit" {
         return "v"
     }
+    // Osty string & byte slice are opaque aggregates at the IR level.
+    // The LLVM bridge needs their codes to be valid identifier chars
+    // (no `?` / `<` / `>`), otherwise a specialized Map<String, V>'s
+    // mangled name fails llvmIsIdent at emit time. Using the
+    // Itanium-style two-char identifiers keeps them unique from the
+    // single-letter primitive set.
+    if name == "String" {
+        return "Ss"
+    }
+    if name == "Bytes" {
+        return "By"
+    }
     ""
 }
 


### PR DESCRIPTION
## Summary

Option B Phase 1 ([#483](https://github.com/choiceoh/osty/pull/483)) produced `Map<String, Int>` specializations through the IR monomorphizer; this PR peels the first two walls on the path from there to actual LLVM emission. The remaining wall (LLVM015 `*ast.TurbofishExpr` in specialized method bodies) is documented by a skipped probe test so the next Phase 2 iteration targets it precisely.

## What landed

### 1. LLVM016 — valid LLVM identifier chars in mangled names

`toolchain/monomorph.osty` + `internal/ir/monomorph_snapshot.go`: `monomorphPrimCode` now maps `String → Ss` and `Bytes → By` (Itanium-style extended identifiers, unique from the single-letter primitive codes). Without these, `Map<String, Int>` mangled to `_ZTSN4main3MapI?lEE` — the `?` placeholder from an unknown primitive tripped `llvmIsIdent` at emission.

### 2. LLVM010 — drop bodyless intrinsic methods from specialized built-in structs

`internal/llvmgen/ir_module.go`: `legacyStructDeclFromIR` now strips bodyless methods from specialized built-in structs (detected by the `_ZTS` Itanium prefix). Map's `len` / `get` / `insert` / `remove` are intrinsic surfaces — served by runtime helpers (`osty_rt_map_*`) at call-site dispatch, never as user-level LLVM definitions. Without the drop, the specialized `Map$String$Int` dragged these into the legacy emitter which walled on `function "len" has no body`.

### 3. Regression tests

`internal/backend/stdlib_type_e2e_test.go` (new):
- `TestPhase2MangledNamesAreValidLLVMIdentifiers` — asserts no `?` / `<` / `>` / space in specialized struct names for `Map<String, Int>`.
- `TestPhase2SpecializedBuiltinBodylessMethodsAreDropped` — asserts `llvmgen.GenerateModule` doesn't wall on `LLVM010 ... has no body`.
- `TestPhase2MonomorphMapReachesGenerateModule` — end-to-end probe that logs the current outermost Phase 2 wall and skips. Today it reports `LLVM015 call: call target *ast.TurbofishExpr`.

Shared `pipelineThroughMonomorph(t, src)` helper avoids duplicating parse → resolve → check → ir.Lower → inject → monomorph boilerplate.

## Not in this PR (Phase 2c)

Specialized method bodies still carry method-local turbofish `TypeArgs` that the legacy AST emitter can't handle. Fix options:
- Substitute-out the `TypeArgs` during IR monomorphization so specialized bodies arrive at the backend with concrete call targets, or
- Teach `legacyCallExprFromIR` / `legacyMethodCallFromIR` to elide `TypeArgs` already resolved by the specialization env.

The Phase 2 probe surfaces this as a visible `t.Skip`, so the next iteration starts with a precise target rather than a blanket "doesn't work."

## Test plan

- [x] `go test ./internal/backend -run TestPhase2 -count=1 -v` — 2 green, 1 documented-skip
- [x] `go test ./internal/backend -count=1 -short` — all green
- [x] `go test ./internal/ir -count=1 -short` — all green
- [x] `go test ./internal/llvmgen -count=1 -short -skip TestGenerateModuleExtendedListSortedAndToSet` — pre-existing `TestProbeSmallTailLower/toolchain/ty.osty` failure reproduces identically on the stashed HEAD; not a regression of this PR
- [ ] `just front` — pending
- [ ] Retire `emitMap{GetOr,Update,RetainIf,MergeWith,MapValues}` hand-emits — deferred to Phase 5 after Phases 2c / 3 / 4 land

🤖 Generated with [Claude Code](https://claude.com/claude-code)