### PR TITLE
chore(selfhost): preserve rejected regen output for post-mortem diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ node_modules/
 
 # graphify knowledge graph (local dev artifact, rebuild with /graphify)
 graphify-out/
+
+# bootstrap-gen install-gate rejected output — preserved alongside the
+# restored generated.go for post-mortem diffs (see
+# internal/selfhost/gen_selfhost.go installWithBuildGate). Never commit.
+*.broken

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -118,6 +118,14 @@ func installWithBuildGate(root, outPath string, data []byte) error {
 	if err == nil {
 		return nil
 	}
+	// Preserve the rejected output alongside the restored file so
+	// contributors can diff it against the known-good committed state
+	// and locate the Osty-source shape that tripped bootstrap-gen
+	// without re-running regen + scraping stderr. The broken dump is
+	// under `.gitignore` (`*.broken`), so it never accidentally lands
+	// in a commit.
+	brokenPath := outPath + ".broken"
+	_ = os.WriteFile(brokenPath, data, 0o644)
 	if havePrev {
 		if restoreErr := os.WriteFile(outPath, prev, 0o644); restoreErr != nil {
 			return fmt.Errorf(
@@ -129,8 +137,9 @@ func installWithBuildGate(root, outPath string, data []byte) error {
 		_ = os.Remove(outPath)
 	}
 	return fmt.Errorf(
-		"generated selfhost code does not compile; refused to install broken code at %s\n%s",
+		"generated selfhost code does not compile; refused to install broken code at %s\nrejected output preserved at %s for diff\n%s",
 		outPath,
+		brokenPath,
 		bytes.TrimSpace(output),
 	)
 }


### PR DESCRIPTION
## Summary

When `go generate ./internal/selfhost` produces a `generated.go` that doesn't compile, [`installWithBuildGate`](internal/selfhost/gen_selfhost.go) correctly rolls back to the previous known-good state — but the rejected output was thrown away, leaving the contributor with only Go compile errors as a signal. Tracking the Osty-source shape that tripped bootstrap-gen then required re-running regen with the out-of-tree `OSTY_BOOTSTRAP_DEBUG_DUMP` env hook and comparing by hand.

Preserve the rejected byte stream at `<outPath>.broken` alongside the restored `generated.go` whenever the install gate fails. The contributor can `diff internal/selfhost/generated.go{.broken,}` directly to see which transpiled shapes diverged, and the install-gate error message points at the path so the workflow is discoverable without reading the source.

## Motivation

Discovered while debugging #485/#492 follow-up Windows regens, which fail with bootstrap-gen bugs like:

```
internal\selfhost\generated.go:528:17: undefined: strings.compare (but have Compare)
internal\selfhost\generated.go:43293:13: units.len undefined (type []string has no field or method len)
```

Without the `.broken` dump, locating the offending Osty source required:
1. Re-running regen with `OSTY_BOOTSTRAP_DEBUG_DUMP=/tmp/out.go`
2. Finding the line in `/tmp/out.go`
3. Reading the source-map comment preceding it
4. Cross-referencing with the merged-toolchain tmpfile

With the `.broken` dump, contributor runs:
```
go generate ./internal/selfhost  # fails
diff internal/selfhost/generated.go internal/selfhost/generated.go.broken
```

## Test plan

- [x] Install-gate failure path creates `generated.go.broken` alongside restored `generated.go`
- [x] Error message includes the `.broken` path: `rejected output preserved at … for diff`
- [x] `git check-ignore internal/selfhost/generated.go.broken` matches (`.gitignore` `*.broken`)
- [x] `just front` — all green (no runtime-path change)

## Scope

No behavior change on the happy path. The dump is created only after `go build ./internal/selfhost/...` rejects the patched output. This does not fix any underlying bootstrap-gen bug — it only makes the existing bug visible faster so contributors can diagnose without out-of-tree tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)