### PR TITLE
feat(ir,llvmgen): Option B Phase 2c — strip stale TypeArgs + re-associate mangled built-ins

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -68,6 +69,114 @@ fn main() {}
 	// of what this test covers.
 	if err != nil {
 		t.Logf("later Phase 2 blocker (not the bodyless one this test covers): %v", err)
+	}
+}
+
+// TestPhase2cSpecializedBuiltinsCarryBuiltinSource verifies the
+// monomorphizer records BuiltinSource / BuiltinSourceArgs on every
+// specialized struct or enum cloned from a stdlib built-in generic
+// template. Without this marker, downstream stages can't re-associate
+// a `_ZTS…` mangled type back with its surface Map<K, V> / Option<T>
+// form, and the llvm backend's intrinsic dispatch (keyed on the
+// surface name) can't fire for methods on specialized builtins.
+func TestPhase2cSpecializedBuiltinsCarryBuiltinSource(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Bool {
+    m.containsKey(k)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+
+	foundMap := false
+	for _, d := range monoMod.Decls {
+		sd, ok := d.(*ir.StructDecl)
+		if !ok {
+			continue
+		}
+		if sd.BuiltinSource == "Map" {
+			foundMap = true
+			if len(sd.BuiltinSourceArgs) != 2 {
+				t.Errorf("Map specialization has %d BuiltinSourceArgs, want 2", len(sd.BuiltinSourceArgs))
+			}
+		}
+	}
+	if !foundMap {
+		t.Errorf("expected a Map-sourced specialization with BuiltinSource=\"Map\"")
+	}
+	// Option/Result enum tagging is covered by the EnumDecl clone +
+	// monomorph additions, but only a NamedType reference to
+	// Option<T> (not `T?` surface sugar) drives an enum
+	// specialization today. A focused Option test belongs with Phase
+	// 2d when the ?/chain handling is generalized.
+}
+
+// TestPhase2cTurbofishExprStrippedFromSpecializedBodies verifies the
+// AST bridge elides TypeArgs on MethodCalls whose receiver is a
+// `_ZTS…` mangled built-in. Stale TypeArgs there turned every
+// `self.get(k)` / `self.insert(k, v)` inside the specialized
+// Map.containsKey / Map.update / … bodies into an `*ast.TurbofishExpr`
+// that the legacy emitter can't dispatch, producing LLVM015.
+func TestPhase2cTurbofishExprStrippedFromSpecializedBodies(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Bool {
+    m.containsKey(k)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2c_turbofish.osty",
+		Source:      []byte(src),
+	}
+	_, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil && strings.Contains(err.Error(), "TurbofishExpr") {
+		t.Fatalf("TurbofishExpr leaked past the AST bridge — legacy emitter walled on stale TypeArgs: %v", err)
+	}
+	// Any other error is the next Phase 2 blocker — not what this
+	// test covers.
+	if err != nil {
+		t.Logf("later Phase 2 blocker (not the TurbofishExpr one this test covers): %v", err)
+	}
+}
+
+// TestPhase2cDiagnoseTurbofishSource probes which specialized-method
+// expression still carries TypeArgs after monomorph — that's the
+// root of the LLVM015 TurbofishExpr wall. The test lowers + injects +
+// monomorphs a simple `m.containsKey(k)` program, then walks every
+// CallExpr/MethodCall in the monomorphized IR, reporting any that
+// still have non-empty TypeArgs (which means monomorph didn't
+// substitute them out).
+func TestPhase2cDiagnoseTurbofishSource(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Bool {
+    m.containsKey(k)
+}
+
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+
+	var offenders []string
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		switch x := n.(type) {
+		case *ir.CallExpr:
+			if len(x.TypeArgs) > 0 {
+				offenders = append(offenders, fmt.Sprintf("CallExpr(callee=%T) TypeArgs=%d", x.Callee, len(x.TypeArgs)))
+			}
+		case *ir.MethodCall:
+			if len(x.TypeArgs) > 0 {
+				offenders = append(offenders, fmt.Sprintf("MethodCall(name=%q) TypeArgs=%d", x.Name, len(x.TypeArgs)))
+			}
+		}
+		return true
+	}), monoMod)
+
+	if len(offenders) > 0 {
+		t.Logf("Phase 2c diagnosis: %d call(s) still carry TypeArgs after monomorph:", len(offenders))
+		for _, o := range offenders {
+			t.Logf("  - %s", o)
+		}
+	} else {
+		t.Logf("no stale TypeArgs — TurbofishExpr must arise from a different AST bridge path")
 	}
 }
 

--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -249,6 +249,13 @@ func cloneStructDecl(s *StructDecl) *StructDecl {
 		Pod:              s.Pod,
 		ReprC:            s.ReprC,
 		BuilderDerivable: s.BuilderDerivable,
+		BuiltinSource:    s.BuiltinSource,
+	}
+	if len(s.BuiltinSourceArgs) > 0 {
+		out.BuiltinSourceArgs = make([]Type, len(s.BuiltinSourceArgs))
+		for i, t := range s.BuiltinSourceArgs {
+			out.BuiltinSourceArgs[i] = CloneType(t)
+		}
 	}
 	if len(s.BuilderRequiredFields) > 0 {
 		out.BuilderRequiredFields = append([]string(nil), s.BuilderRequiredFields...)
@@ -276,9 +283,16 @@ func cloneStructDecl(s *StructDecl) *StructDecl {
 
 func cloneEnumDecl(e *EnumDecl) *EnumDecl {
 	out := &EnumDecl{
-		Name:     e.Name,
-		Exported: e.Exported,
-		SpanV:    e.SpanV,
+		Name:          e.Name,
+		Exported:      e.Exported,
+		SpanV:         e.SpanV,
+		BuiltinSource: e.BuiltinSource,
+	}
+	if len(e.BuiltinSourceArgs) > 0 {
+		out.BuiltinSourceArgs = make([]Type, len(e.BuiltinSourceArgs))
+		for i, t := range e.BuiltinSourceArgs {
+			out.BuiltinSourceArgs[i] = CloneType(t)
+		}
 	}
 	if len(e.Variants) > 0 {
 		out.Variants = make([]*Variant, len(e.Variants))

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -404,6 +404,18 @@ type StructDecl struct {
 	Exported bool
 	SpanV    Span
 
+	// BuiltinSource, when non-empty, names the stdlib built-in
+	// generic template this struct was monomorphized from (e.g.
+	// "Map", "List", "Set"). Set by ir.Monomorphize's
+	// emitStructSpecialization when cloning a Builtin-tagged
+	// generic. BuiltinSourceArgs carries the concrete type args
+	// applied during that specialization, in the order matching the
+	// template's Generics. Consumers at the LLVM layer read these
+	// to re-associate a `_ZTS…` mangled struct back with its
+	// surface Map<K, V> / Option<T> form for intrinsic dispatch.
+	BuiltinSource     string
+	BuiltinSourceArgs []Type
+
 	// Pod is set when the struct carries `#[pod]` (LANG_SPEC §19.4).
 	// The front-end shape checker (`internal/check/podshape.go`) is
 	// the authoritative validator that the struct meets the §19.4
@@ -479,6 +491,13 @@ type EnumDecl struct {
 	Generics []*TypeParam
 	Exported bool
 	SpanV    Span
+
+	// BuiltinSource / BuiltinSourceArgs — see StructDecl for semantics.
+	// Populated by the monomorphizer when cloning stdlib built-in enum
+	// templates (Option, Result) so downstream stages can re-associate
+	// a mangled specialization back with its surface form.
+	BuiltinSource     string
+	BuiltinSourceArgs []Type
 }
 
 func (*EnumDecl) declNode()          {}

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -496,6 +496,20 @@ func (s *monoState) emitStructSpecialization(rec monoTypeInstance) {
 	clone := cloneStructDecl(rec.structDecl)
 	clone.Name = rec.mangled
 	clone.Generics = nil
+	// Option B Phase 2c: preserve the original surface name + concrete
+	// type-args so downstream stages (LLVM backend, AST bridge) can
+	// re-associate a `_ZTS…` mangled struct back with its surface
+	// Map<String, Int> / Option<T> form for intrinsic dispatch.
+	// Recorded BEFORE SubstituteTypes rewrites typeArgs in place.
+	if isStdlibBuiltinName(rec.structDecl.Name) {
+		clone.BuiltinSource = rec.structDecl.Name
+		if len(rec.typeArgs) > 0 {
+			clone.BuiltinSourceArgs = make([]Type, len(rec.typeArgs))
+			for i, ta := range rec.typeArgs {
+				clone.BuiltinSourceArgs[i] = CloneType(ta)
+			}
+		}
+	}
 	env := buildSubstEnv(rec.structDecl.Generics, rec.typeArgs)
 	SubstituteTypes(clone, env)
 	for _, f := range clone.Fields {
@@ -513,11 +527,34 @@ func (s *monoState) emitStructSpecialization(rec monoTypeInstance) {
 	s.receiverEnvOf[clone.Name] = env
 }
 
+// isStdlibBuiltinName reports whether a name identifies a stdlib
+// built-in generic template that the llvm backend's intrinsic
+// dispatch needs to re-recognize after monomorphization. Kept as a
+// focused whitelist rather than a prefix check so user types that
+// happen to share names with stdlib modules aren't accidentally
+// tagged.
+func isStdlibBuiltinName(name string) bool {
+	switch name {
+	case "Map", "List", "Set", "Option", "Result":
+		return true
+	}
+	return false
+}
+
 // emitEnumSpecialization is the enum counterpart of emitStructSpecialization.
 func (s *monoState) emitEnumSpecialization(rec monoTypeInstance) {
 	clone := cloneEnumDecl(rec.enumDecl)
 	clone.Name = rec.mangled
 	clone.Generics = nil
+	if isStdlibBuiltinName(rec.enumDecl.Name) {
+		clone.BuiltinSource = rec.enumDecl.Name
+		if len(rec.typeArgs) > 0 {
+			clone.BuiltinSourceArgs = make([]Type, len(rec.typeArgs))
+			for i, ta := range rec.typeArgs {
+				clone.BuiltinSourceArgs[i] = CloneType(ta)
+			}
+		}
+	}
 	env := buildSubstEnv(rec.enumDecl.Generics, rec.typeArgs)
 	SubstituteTypes(clone, env)
 	for _, v := range clone.Variants {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -204,7 +204,51 @@ func moduleUnsupportedDiagnostic(mod *ostyir.Module) (UnsupportedDiagnostic, boo
 	return UnsupportedDiagnostic{}, false
 }
 
+// specializedBuiltinSurface holds the {source name, concrete args}
+// recovered from a monomorphized built-in specialization's
+// BuiltinSource / BuiltinSourceArgs fields. The AST bridge uses this
+// per-module index to re-synthesize a `Map<String, Int>` surface
+// NamedType whenever it encounters a reference to a `_ZTS…` mangled
+// built-in struct/enum, so the legacy LLVM emitter's intrinsic
+// dispatch (keyed on Path[0] == "Map" / "Option" / …) keeps working.
+type specializedBuiltinSurface struct {
+	Source string
+	Args   []ostyir.Type
+}
+
+func collectSpecializedBuiltinSurfaces(mod *ostyir.Module) map[string]specializedBuiltinSurface {
+	out := map[string]specializedBuiltinSurface{}
+	if mod == nil {
+		return out
+	}
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case *ostyir.StructDecl:
+			if d == nil || d.BuiltinSource == "" {
+				continue
+			}
+			out[d.Name] = specializedBuiltinSurface{Source: d.BuiltinSource, Args: d.BuiltinSourceArgs}
+		case *ostyir.EnumDecl:
+			if d == nil || d.BuiltinSource == "" {
+				continue
+			}
+			out[d.Name] = specializedBuiltinSurface{Source: d.BuiltinSource, Args: d.BuiltinSourceArgs}
+		}
+	}
+	return out
+}
+
+// currentSpecializedBuiltinSurfaces is set by legacyFileFromModule at
+// the start of each conversion and consulted by legacyTypeFromIR when
+// a NamedType's name matches a specialized built-in. Keeping it as a
+// local (reset on each call) avoids threading the map through every
+// IR-to-AST visitor helper, while still giving the bridge the lookup
+// context it needs.
+var currentSpecializedBuiltinSurfaces map[string]specializedBuiltinSurface
+
 func legacyFileFromModule(mod *ostyir.Module) (*ast.File, error) {
+	currentSpecializedBuiltinSurfaces = collectSpecializedBuiltinSurfaces(mod)
+	defer func() { currentSpecializedBuiltinSurfaces = nil }()
 	start, end := legacySpan(mod.At())
 	file := &ast.File{PosV: start, EndV: end}
 	for _, decl := range mod.Decls {
@@ -558,6 +602,17 @@ func legacyTypeFromIR(typ ostyir.Type) ast.Type {
 		}
 		return &ast.NamedType{Path: []string{name}}
 	case *ostyir.NamedType:
+		// Phase 2c: if the name is a `_ZTS…` mangled built-in
+		// specialization, rebuild the surface `Map<String, Int>` /
+		// `Option<T>` form so the legacy emitter's intrinsic
+		// dispatch (keyed on Path[0] == "Map" / …) still fires.
+		if surf, ok := currentSpecializedBuiltinSurfaces[t.Name]; ok && surf.Source != "" {
+			out := &ast.NamedType{Path: []string{surf.Source}}
+			for _, arg := range surf.Args {
+				out.Args = append(out.Args, legacyTypeFromIR(arg))
+			}
+			return out
+		}
 		path := splitQualifiedName(t.Package)
 		path = append(path, t.Name)
 		out := &ast.NamedType{Path: path}
@@ -1200,9 +1255,22 @@ func legacyMethodCallFromIR(expr *ostyir.MethodCall) (ast.Expr, error) {
 		X:    receiver,
 		Name: expr.Name,
 	})
-	if len(expr.TypeArgs) != 0 {
+	typeArgs := expr.TypeArgs
+	// Option B Phase 2c: method calls inside a specialized built-in
+	// body (Map$String$Int.containsKey's body calling self.get(key),
+	// etc.) still carry the struct-level K/V TypeArgs after
+	// monomorph's SubstituteTypes — they're semantically redundant
+	// (already encoded by the specialized receiver type) but trip
+	// the legacy emitter with LLVM015 when wrapped in TurbofishExpr.
+	// Drop them here when the receiver is a specialized built-in.
+	if len(typeArgs) != 0 && expr.Receiver != nil {
+		if named, ok := expr.Receiver.Type().(*ostyir.NamedType); ok && strings.HasPrefix(named.Name, "_ZTS") {
+			typeArgs = nil
+		}
+	}
+	if len(typeArgs) != 0 {
 		tf := &ast.TurbofishExpr{PosV: start, EndV: end, Base: fn}
-		for _, arg := range expr.TypeArgs {
+		for _, arg := range typeArgs {
 			tf.Args = append(tf.Args, legacyTypeFromIR(arg))
 		}
 		fn = tf


### PR DESCRIPTION
## Summary

Third peel of Option B's Phase 2 walls. Advances the end-to-end probe past `LLVM015 *ast.TurbofishExpr` to the next blocker (`LLVM015 *ast.FieldExpr (self.len)`), which is a distinct "method-receiver self-binding needs surface map metadata" problem deferred to Phase 2d.

Sequence so far:
- [#483](https://github.com/choiceoh/osty/pull/483) — Phase 1: inject stdlib types + unblock Builtin short-circuit in monomorph
- [#494](https://github.com/choiceoh/osty/pull/494) — Phase 2a/b: LLVM016 (valid identifier chars) + LLVM010 (drop bodyless intrinsic methods)
- **this PR** — Phase 2c: LLVM015 TurbofishExpr + surface-form re-association

## What landed

### 1. Strip stale TypeArgs at the AST bridge for `_ZTS…` receivers
`internal/llvmgen/ir_module.go` / `legacyMethodCallFromIR`: when the method-call receiver is a mangled specialized built-in (`_ZTS…` prefix), drop the call's TypeArgs before wrapping in TurbofishExpr. After `SubstituteTypes` the args are already resolved `[String, Int]` — semantically redundant but the legacy emitter walled on the wrapper.

### 2. `BuiltinSource` / `BuiltinSourceArgs` on specialized struct & enum
- New optional fields on `ir.StructDecl` / `ir.EnumDecl`: surface name (`"Map"`, `"Option"`) + concrete type-args.
- `emitStructSpecialization` / `emitEnumSpecialization` populate them when cloning a stdlib built-in generic (Map/List/Set/Option/Result), gated by a whitelist helper `isStdlibBuiltinName` so user types that happen to share names aren't tagged.
- `cloneStructDecl` / `cloneEnumDecl` carry the fields through.

### 3. AST bridge re-synthesizes surface `NamedType`
`legacyFileFromModule` builds a per-module index (`specializedBuiltinSurfaces`) of every mangled decl carrying `BuiltinSource`. `legacyTypeFromIR` then rewrites `_ZTSN4main3MapISslEE` back to `Map<String, Int>` in AST type positions so downstream code like `llvmMapTypes` (keyed on `Path[0] == "Map"`) keeps working after monomorphization.

## Regression tests

`internal/backend/stdlib_type_e2e_test.go`:
- `TestPhase2cSpecializedBuiltinsCarryBuiltinSource` — every Map specialization carries `BuiltinSource="Map"` + 2 `BuiltinSourceArgs`.
- `TestPhase2cTurbofishExprStrippedFromSpecializedBodies` — `GenerateModule` no longer walls on TurbofishExpr.
- `TestPhase2cDiagnoseTurbofishSource` — informational: walks the monomorphized module and reports every MethodCall/CallExpr that still carries TypeArgs. Today it flags `containsKey TypeArgs=2`, `get TypeArgs=1`, `insert TypeArgs=2` — all inside specialized bodies, confirming the bridge-level strip catches them before the emitter.
- `TestPhase2MonomorphMapReachesGenerateModule` — the end-to-end probe now reports `LLVM015 *ast.FieldExpr (self.len)` as the next outermost blocker instead of TurbofishExpr.

## Not in this PR (Phase 2d)

The method receiver `self` inside a specialized Map body still binds with the mangled struct's typ, so `self.len()` dispatch at the intrinsic layer doesn't fire — `llvmMapTypes` expects the surface `Map` name in the receiver binding's paramInfo. Phase 2d must populate `mapKeyTyp` / `mapValueTyp` on the `self` paramInfo when the enclosing method's owner is a specialized built-in. Requires a pipe through AST annotations since `ast.StructDecl` has no `BuiltinSource` field.

## Test plan

- [x] `go test ./internal/backend -run TestPhase2 -count=1 -v` — 4 green, 1 documented-skip
- [x] `go test ./internal/ir -count=1 -short`
- [x] `go test ./internal/backend -count=1 -short`
- [x] `go test ./internal/llvmgen -count=1 -short` (skipping two pre-existing unrelated failures: `TestGenerateModuleExtendedListSortedAndToSet` and `TestProbeSmallTailLower/toolchain/ty.osty`)
- [x] `just front`
- [ ] Retire `emitMap{GetOr,Update,RetainIf,MergeWith,MapValues}` — deferred to Phase 5 after Phase 2d/3/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)