### PR TITLE
feat(lint): four low-cost AST rules — L0047-L0049 + L0080

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1516,7 +1516,7 @@ enum Color { red, Green }   // warning on `red`
 
 ---
 
-## Lint — redundant forms (L0040–L0046)
+## Lint — redundant forms (L0040–L0049)
 
 ### L0040 — `CodeRedundantBool`
 
@@ -1582,6 +1582,40 @@ fn parse(s: String) -> Result<Int, Error> {
 
 **Fix**: drop the wrapping and declare the plain return type:
 
+### L0047 — `CodeLetReturnSimplify`
+
+`let x = expr; x` at the tail of a block is a useless round-trip. The binding is introduced and immediately returned with no other uses — the block can just be `expr`.
+
+```osty
+fn double(n: Int) -> Int {
+    let out = n * 2     // warning: useless binding before tail return
+    out
+}
+```
+
+**Fix**: drop the let and return the expression directly.
+
+### L0048 — `CodeNeedlessParens`
+
+Parentheses wrapping an `if` / `for` / `match` condition are pure noise — they add nothing syntactic and clippy-style convention keeps conditions bare.
+
+```osty
+if (ready) { ... }        // warning: drop the parens
+for (i in 0..n) { ... }   // warning: drop the parens
+```
+
+**Fix**: unwrap the outer `(` / `)`.
+
+### L0049 — `CodeInfiniteLoopLiteral`
+
+`for true { ... }` is just `for { ... }` — an infinite loop whose literal condition adds nothing.
+
+```osty
+for true { tick() }   // warning: redundant `true`
+```
+
+**Fix**: drop the `true`.
+
 ---
 
 ## Lint — complexity (L0050–L0053)
@@ -1614,7 +1648,7 @@ extract inner branches into helpers.
 
 ---
 
-## Lint — documentation (L0070)
+## Lint — documentation (L0070–L0080)
 
 ### L0070 — `CodeMissingDoc`
 
@@ -1627,6 +1661,20 @@ pub fn hashPassword(p: String) -> String { ... }   // warning: missing doc
 ```
 
 **Fix**: add a doc comment, or drop `pub` if the item is internal.
+
+### L0080 — `CodeMissingTestAssertion`
+
+A `test_*` function has no `testing.*` call in its body — the test silently passes no matter what the code under test does. Almost certainly a scaffolding leftover or a typo in an assertion helper name.
+
+call, or rename the function so it isn't auto-discovered.
+
+```osty
+fn test_parsesEmpty() {
+    let r = parse("")          // warning: no testing assertion
+}
+```
+
+**Fix**: add a `testing.assertEq` / `testing.assert` / `testing.fail`
 
 ---
 

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -1387,6 +1387,36 @@ const (
 	//   fn parse(s: String) -> Int { s.len() }
 	CodeUnnecessaryWrap = "L0046"
 
+	// `let x = expr; x` at the tail of a block is a useless round-trip.
+	// The binding is introduced and immediately returned with no other
+	// uses — the block can just be `expr`.
+	//
+	// Example:
+	//   fn double(n: Int) -> Int {
+	//       let out = n * 2     // warning: useless binding before tail return
+	//       out
+	//   }
+	// Fix: drop the let and return the expression directly.
+	CodeLetReturnSimplify = "L0047"
+
+	// Parentheses wrapping an `if` / `for` / `match` condition are
+	// pure noise — they add nothing syntactic and clippy-style
+	// convention keeps conditions bare.
+	//
+	// Example:
+	//   if (ready) { ... }        // warning: drop the parens
+	//   for (i in 0..n) { ... }   // warning: drop the parens
+	// Fix: unwrap the outer `(` / `)`.
+	CodeNeedlessParens = "L0048"
+
+	// `for true { ... }` is just `for { ... }` — an infinite loop
+	// whose literal condition adds nothing.
+	//
+	// Example:
+	//   for true { tick() }   // warning: redundant `true`
+	// Fix: drop the `true`.
+	CodeInfiniteLoopLiteral = "L0049"
+
 	// Lint — complexity.
 
 	// A function declares too many parameters (> 7 by default).
@@ -1424,4 +1454,17 @@ const (
 	//   pub fn hashPassword(p: String) -> String { ... }   // warning: missing doc
 	// Fix: add a doc comment, or drop `pub` if the item is internal.
 	CodeMissingDoc = "L0070"
+
+	// A `test_*` function has no `testing.*` call in its body — the
+	// test silently passes no matter what the code under test does.
+	// Almost certainly a scaffolding leftover or a typo in an
+	// assertion helper name.
+	//
+	// Example:
+	//   fn test_parsesEmpty() {
+	//       let r = parse("")          // warning: no testing assertion
+	//   }
+	// Fix: add a `testing.assertEq` / `testing.assert` / `testing.fail`
+	// call, or rename the function so it isn't auto-discovered.
+	CodeMissingTestAssertion = "L0080"
 )

--- a/internal/lint/allow.go
+++ b/internal/lint/allow.go
@@ -217,6 +217,8 @@ func resolveAllowName(name string) []string {
 	case "simplify", "suspicious":
 		return []string{
 			diag.CodeRedundantBool, diag.CodeSelfCompare, diag.CodeSelfAssign,
+			diag.CodeUnnecessaryWrap, diag.CodeLetReturnSimplify,
+			diag.CodeNeedlessParens, diag.CodeInfiniteLoopLiteral,
 		}
 	}
 	// Individual rule aliases.
@@ -249,6 +251,16 @@ func resolveAllowName(name string) []string {
 		return []string{diag.CodeSelfCompare}
 	case "self_assign":
 		return []string{diag.CodeSelfAssign}
+	case "unnecessary_wrap":
+		return []string{diag.CodeUnnecessaryWrap}
+	case "let_return_simplify":
+		return []string{diag.CodeLetReturnSimplify}
+	case "needless_parens_condition":
+		return []string{diag.CodeNeedlessParens}
+	case "infinite_loop_literal":
+		return []string{diag.CodeInfiniteLoopLiteral}
+	case "missing_test_assertion":
+		return []string{diag.CodeMissingTestAssertion}
 	}
 	return nil
 }

--- a/internal/lint/registry.go
+++ b/internal/lint/registry.go
@@ -220,6 +220,27 @@ var allRules = []Rule{
 		Summary:     "function returns Result/Option but never errors",
 		Description: "A function declared `-> Result<T, E>` or `-> Option<T>` whose body only exits through `Ok(...)` or `Some(...)` (no `Err`, `None`, or `?` propagation) forces every caller to unwrap for no reason. Drop the wrapping and declare the plain return type.",
 	},
+	{
+		Code: diag.CodeLetReturnSimplify, Name: "let_return_simplify",
+		Category: CategorySimplify, DefaultSeverity: diag.Warning,
+		Summary:     "useless let binding before tail return",
+		Description: "`let x = expr; x` at the end of a block rebinds the expression only to return it unchanged. Drop the let and return the expression directly.",
+		Fixable:     true,
+	},
+	{
+		Code: diag.CodeNeedlessParens, Name: "needless_parens_condition",
+		Category: CategorySimplify, DefaultSeverity: diag.Warning,
+		Summary:     "parentheses around an if / for / match condition are redundant",
+		Description: "Condition syntax does not require outer parentheses; removing them matches the canonical style and keeps the scrutinee read-once.",
+		Fixable:     true,
+	},
+	{
+		Code: diag.CodeInfiniteLoopLiteral, Name: "infinite_loop_literal",
+		Category: CategorySimplify, DefaultSeverity: diag.Warning,
+		Summary:     "redundant literal `true` on an infinite loop",
+		Description: "`for true { ... }` is the same as `for { ... }`. Drop the literal to match the canonical infinite-loop form.",
+		Fixable:     true,
+	},
 
 	// ---- Complexity (L0050-L0069) ----
 	{
@@ -247,6 +268,14 @@ var allRules = []Rule{
 		Category: CategoryDocs, DefaultSeverity: diag.Warning,
 		Summary:     "public declaration has no doc comment",
 		Description: "Public items are the module's external contract — even a one-line `///` helps consumers use them correctly.",
+	},
+
+	// ---- Testing (L0080-L0089) ----
+	{
+		Code: diag.CodeMissingTestAssertion, Name: "missing_test_assertion",
+		Category: CategoryDocs, DefaultSeverity: diag.Warning,
+		Summary:     "test function has no testing.* assertion",
+		Description: "A `test_*` function (or `_test.osty` top-level fn prefixed `test`) with no call into the `testing` module will pass no matter what happens. That is almost always a scaffolding leftover or a typo — mark the function non-test, or call an assertion helper.",
 	},
 }
 

--- a/toolchain/diag_examples.osty
+++ b/toolchain/diag_examples.osty
@@ -53,5 +53,8 @@ pub fn diagHarvestCases() -> List<DiagHarvestCase> {
         DiagHarvestCase { code: "L0032", example: "enum Color \{ red, Green \}   // warning on `red`", phase: "lint" },
         DiagHarvestCase { code: "L0045", example: "let x = !true      // warning: use `false` directly", phase: "lint" },
         DiagHarvestCase { code: "L0046", example: "fn parse(s: String) -> Result<Int, Error> \{\n    Ok(s.len())              // warning: fn never returns Err\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0047", example: "fn double(n: Int) -> Int \{\n    let out = n * 2     // warning: useless binding before tail return\n    out\n\}", phase: "lint" },
+        DiagHarvestCase { code: "L0049", example: "for true \{ tick() \}   // warning: redundant `true`", phase: "lint" },
+        DiagHarvestCase { code: "L0080", example: "fn test_parsesEmpty() \{\n    let r = parse(\"\")          // warning: no testing assertion\n\}", phase: "lint" },
     ]
 }

--- a/toolchain/diag_manifest.osty
+++ b/toolchain/diag_manifest.osty
@@ -196,7 +196,7 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     if code == "L0030" { return FamilyLint }
     if code == "L0031" { return FamilyLint }
     if code == "L0032" { return FamilyLint }
-    // Lint — redundant forms (L0040–L0046)
+    // Lint — redundant forms (L0040–L0049)
     if code == "L0040" { return FamilyLint }
     if code == "L0041" { return FamilyLint }
     if code == "L0042" { return FamilyLint }
@@ -204,11 +204,15 @@ pub fn diagnosticFamilyForCode(code: String) -> DiagnosticFamily {
     if code == "L0044" { return FamilyLint }
     if code == "L0045" { return FamilyLint }
     if code == "L0046" { return FamilyLint }
+    if code == "L0047" { return FamilyLint }
+    if code == "L0048" { return FamilyLint }
+    if code == "L0049" { return FamilyLint }
     // Lint — complexity (L0050–L0053)
     if code == "L0050" { return FamilyLint }
     if code == "L0052" { return FamilyLint }
     if code == "L0053" { return FamilyLint }
-    // Lint — documentation (L0070)
+    // Lint — documentation (L0070–L0080)
     if code == "L0070" { return FamilyLint }
+    if code == "L0080" { return FamilyLint }
     FamilyUnknown
 }

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -204,6 +204,10 @@ fn selfLintFullPipeline(
     report = selfLintAstFile(file, resolved, report)
     report = selfLintAstCheckUnusedMembersWith(file, access, report)
     report = selfLintAstCheckUnnecessaryWrap(file, report)
+    report = selfLintAstCheckLetReturn(file, report)
+    report = selfLintAstCheckNeedlessParens(file, report)
+    report = selfLintAstCheckInfiniteLoopLiteral(file, report)
+    report = selfLintAstCheckMissingTestAssertion(file, report)
     if hints.enabled {
         report = selfLintAstCheckIgnoredResult(file, hints, report)
     }
@@ -3141,10 +3145,14 @@ pub fn selfLintAllRules() -> List<SelfLintRuleInfo> {
     rules.push(selfLintMakeRule("L0044", "bool_literal_compare", "simplify", "compare against bool literal can be simplified", true))
     rules.push(selfLintMakeRule("L0045", "negated_bool_literal", "simplify", "!true / !false can be written directly", false))
     rules.push(selfLintMakeRule("L0046", "unnecessary_wrap", "simplify", "function returns Result/Option but never errors", false))
+    rules.push(selfLintMakeRule("L0047", "let_return_simplify", "simplify", "let + tail return rebinds only to return", true))
+    rules.push(selfLintMakeRule("L0048", "needless_parens_condition", "simplify", "parentheses around an if/for condition are redundant", true))
+    rules.push(selfLintMakeRule("L0049", "infinite_loop_literal", "simplify", "`for true \{ ... \}` is just `for \{ ... \}`", true))
     rules.push(selfLintMakeRule("L0050", "too_many_params", "complexity", "function takes too many parameters", false))
     rules.push(selfLintMakeRule("L0052", "function_too_long", "complexity", "function body is too long", false))
     rules.push(selfLintMakeRule("L0053", "deep_nesting", "complexity", "control flow is nested too deeply", false))
     rules.push(selfLintMakeRule("L0070", "missing_doc", "docs", "public declaration has no doc comment", false))
+    rules.push(selfLintMakeRule("L0080", "missing_test_assertion", "docs", "test function has no testing.* assertion", false))
     rules
 }
 
@@ -3581,6 +3589,359 @@ fn selfLintBodyWrapsExit(file: AstFile, idx: Int, kind: String) -> Bool {
     }
     for child in node.children2 {
         if selfLintBodyWrapsExit(file, child, kind) {
+            return true
+        }
+    }
+    false
+}
+
+// ============================================================
+// L0047 let_return_simplify
+// ============================================================
+//
+// `let x = expr; x` at the tail of a block introduces a throwaway
+// binding only to return it unchanged. Flag it so the author can
+// collapse the block to the bare expression.
+//
+// Conservative shape: the block's penultimate statement is an immutable
+// `let NAME = expr`, and the final statement is a bare-ident reference
+// to that same NAME. We require the let to sit immediately before the
+// tail so no intermediate reads exist and rewriting is sound.
+
+fn selfLintAstCheckLetReturn(file: AstFile, report: SelfLintReport) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintLetReturnDecl(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintLetReturnDecl(
+    file: AstFile,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNFnDecl {
+        return selfLintLetReturnScan(file, node.right, report)
+    }
+    if node.kind == AstNStructDecl
+        || node.kind == AstNEnumDecl
+        || node.kind == AstNInterfaceDecl {
+        let mut out = report
+        for memberIdx in node.children {
+            let member = selfLintAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl {
+                out = selfLintLetReturnScan(file, member.right, out)
+            }
+        }
+        return out
+    }
+    report
+}
+
+fn selfLintLetReturnScan(
+    file: AstFile,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNBlock {
+        out = selfLintMaybeEmitLetReturn(file, node, out)
+    }
+    out = selfLintLetReturnScan(file, node.left, out)
+    out = selfLintLetReturnScan(file, node.right, out)
+    for child in node.children {
+        out = selfLintLetReturnScan(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintLetReturnScan(file, child, out)
+    }
+    out
+}
+
+fn selfLintMaybeEmitLetReturn(
+    file: AstFile,
+    block: AstNode,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let count = block.children.len()
+    if count < 2 {
+        return report
+    }
+    let letIdx = selfLintAstChildAt(block.children, count - 2)
+    let tailIdx = selfLintAstChildAt(block.children, count - 1)
+    if letIdx < 0 || tailIdx < 0 {
+        return report
+    }
+    let letStmt = selfLintAstNode(file, letIdx)
+    if letStmt.kind != AstNLet || letStmt.flags == 1 {
+        // Not a `let`, or it was `let mut` — don't simplify a mutable
+        // binding, its declaration may be load-bearing elsewhere.
+        return report
+    }
+    let tailStmt = selfLintAstNode(file, tailIdx)
+    let tailExpr = if tailStmt.kind == AstNExprStmt {
+        selfLintAstNode(file, tailStmt.left)
+    } else {
+        tailStmt
+    }
+    if tailExpr.kind != AstNIdent || tailExpr.text == "" {
+        return report
+    }
+    let pattern = selfLintAstNode(file, letStmt.left)
+    if !(selfLintAstPatternIsIdent(pattern)) {
+        return report
+    }
+    let patternName = selfLintAstPatternName(pattern.text, "ident:")
+    if patternName != tailExpr.text {
+        return report
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0047",
+        "useless `let` before tail return",
+        patternName,
+        letStmt.start,
+        tailStmt.end,
+        letIdx,
+    )
+}
+
+// ============================================================
+// L0048 needless_parens_condition
+// ============================================================
+//
+// Parens around an `if` / `for`-condition / `match` scrutinee are
+// redundant — drop the outer `(` / `)`. Matches on the AstNParen node
+// living at the scrutinee position, so chained selectors like
+// `(x).foo()` that contain a deliberate outer paren are unaffected.
+
+fn selfLintAstCheckNeedlessParens(
+    file: AstFile,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintNeedlessParensScan(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintNeedlessParensScan(
+    file: AstFile,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNIf {
+        out = selfLintMaybeEmitNeedlessParens(file, node.left, "if", out)
+    }
+    if node.kind == AstNFor && node.text == "cond" {
+        out = selfLintMaybeEmitNeedlessParens(file, node.left, "for", out)
+    }
+    if node.kind == AstNMatch {
+        out = selfLintMaybeEmitNeedlessParens(file, node.left, "match", out)
+    }
+    out = selfLintNeedlessParensScan(file, node.left, out)
+    out = selfLintNeedlessParensScan(file, node.right, out)
+    for child in node.children {
+        out = selfLintNeedlessParensScan(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintNeedlessParensScan(file, child, out)
+    }
+    out
+}
+
+fn selfLintMaybeEmitNeedlessParens(
+    file: AstFile,
+    exprIdx: Int,
+    keyword: String,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if exprIdx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, exprIdx)
+    if node.kind != AstNParen {
+        return report
+    }
+    let message = "parens around `{keyword}` condition are redundant"
+    selfLintEmitAtNode(report, "L0048", message, "", node.start, node.end, exprIdx)
+}
+
+// ============================================================
+// L0049 infinite_loop_literal
+// ============================================================
+//
+// `for true { ... }` is semantically the same as `for { ... }`; the
+// literal is purely noise. (The parser stores this shape as a `cond`-kind
+// AstNFor whose condition is AstNBoolLit with flags==1.)
+
+fn selfLintAstCheckInfiniteLoopLiteral(
+    file: AstFile,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintInfiniteLoopScan(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintInfiniteLoopScan(
+    file: AstFile,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    let mut out = report
+    if node.kind == AstNFor && node.text == "cond" && node.left >= 0 {
+        let cond = selfLintAstNode(file, node.left)
+        if cond.kind == AstNBoolLit && cond.flags == 1 {
+            out = selfLintEmitAtNode(
+                out,
+                "L0049",
+                "`for true \{ ... \}` is just `for \{ ... \}`",
+                "",
+                cond.start,
+                cond.end,
+                node.left,
+            )
+        }
+    }
+    out = selfLintInfiniteLoopScan(file, node.left, out)
+    out = selfLintInfiniteLoopScan(file, node.right, out)
+    for child in node.children {
+        out = selfLintInfiniteLoopScan(file, child, out)
+    }
+    for child in node.children2 {
+        out = selfLintInfiniteLoopScan(file, child, out)
+    }
+    out
+}
+
+// ============================================================
+// L0080 missing_test_assertion
+// ============================================================
+//
+// A `test_*` / `testCamel` function with no call into the `testing`
+// module passes vacuously — the runner reports green regardless of what
+// the code under test does. Detection is name-based (the test-runner
+// discovers tests by prefix) plus a body scan for any `testing.*` field
+// access. Fns taking parameters, or anything wrapping the test behind a
+// helper, don't qualify — we only flag what the runner would actually
+// dispatch as a leaf test.
+
+fn selfLintAstCheckMissingTestAssertion(
+    file: AstFile,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    let mut out = report
+    for declIdx in file.arena.decls {
+        out = selfLintMissingTestDecl(file, declIdx, out)
+    }
+    out
+}
+
+fn selfLintMissingTestDecl(
+    file: AstFile,
+    idx: Int,
+    report: SelfLintReport,
+) -> SelfLintReport {
+    if idx < 0 {
+        return report
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind != AstNFnDecl {
+        return report
+    }
+    if !(selfLintIsTestFnName(node.text)) {
+        return report
+    }
+    // Tests are conventionally zero-arg. Parametric helpers named
+    // testFoo(x: Int) don't get flagged.
+    if node.children.len() > 0 {
+        return report
+    }
+    if node.right < 0 {
+        return report
+    }
+    let block = selfLintAstNode(file, node.right)
+    if block.kind != AstNBlock || block.children.len() == 0 {
+        return report
+    }
+    if selfLintBodyUsesTestingModule(file, node.right) {
+        return report
+    }
+    selfLintEmitAtNode(
+        report,
+        "L0080",
+        "test function has no testing.* assertion — this test passes vacuously",
+        node.text,
+        node.start,
+        node.end,
+        idx,
+    )
+}
+
+fn selfLintIsTestFnName(name: String) -> Bool {
+    if !(strings.hasPrefix(name, "test")) {
+        return false
+    }
+    if name.len() <= 4 {
+        return false
+    }
+    let fifth = frontUnitAt(strings.split(name, ""), 4)
+    if fifth == "_" {
+        return true
+    }
+    // Upper-camel continuation: testX, testParsesEmpty, ...
+    if fifth >= "A" && fifth <= "Z" {
+        return true
+    }
+    false
+}
+
+fn selfLintBodyUsesTestingModule(file: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    let node = selfLintAstNode(file, idx)
+    if node.kind == AstNField && node.left >= 0 {
+        let base = selfLintAstNode(file, node.left)
+        if base.kind == AstNIdent && base.text == "testing" {
+            return true
+        }
+    }
+    if selfLintBodyUsesTestingModule(file, node.left) {
+        return true
+    }
+    if selfLintBodyUsesTestingModule(file, node.right) {
+        return true
+    }
+    for child in node.children {
+        if selfLintBodyUsesTestingModule(file, child) {
+            return true
+        }
+    }
+    for child in node.children2 {
+        if selfLintBodyUsesTestingModule(file, child) {
             return true
         }
     }

--- a/toolchain/lint_test.osty
+++ b/toolchain/lint_test.osty
@@ -1025,3 +1025,137 @@ fn testSelfLintAllowIsDeclScoped() {
     // Only the second fn should still emit L0001 — the first is suppressed.
     testing.assertEq(selfLintCodeCount(report, "L0001"), 1)
 }
+
+fn testSelfLintFindsLetReturnSimplify() {
+    let report = selfLintSource(
+        r"""
+            fn doubleN(n: Int) -> Int {
+                let out = n * 2
+                out
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0047"), 1)
+}
+
+fn testSelfLintSkipsLetReturnWhenMut() {
+    let report = selfLintSource(
+        r"""
+            fn doubleN(n: Int) -> Int {
+                let mut out = n
+                out = out * 2
+                out
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0047"), 0)
+}
+
+fn testSelfLintSkipsLetReturnWhenUsedTwice() {
+    let report = selfLintSource(
+        r"""
+            fn use(n: Int) -> Int {
+                let tmp = n + 1
+                println(tmp)
+                tmp
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0047"), 0)
+}
+
+fn testSelfLintFindsNeedlessParensInIf() {
+    let report = selfLintSource(
+        r"""
+            fn pick(flag: Bool) -> Int {
+                if (flag) { 1 } else { 0 }
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0048"), 1)
+}
+
+fn testSelfLintSkipsBareIfCondition() {
+    let report = selfLintSource(
+        r"""
+            fn pick(flag: Bool) -> Int {
+                if flag { 1 } else { 0 }
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0048"), 0)
+}
+
+fn testSelfLintFindsInfiniteLoopLiteral() {
+    let report = selfLintSource(
+        r"""
+            fn spin() {
+                for true {
+                    break
+                }
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0049"), 1)
+}
+
+fn testSelfLintSkipsBareForInfinite() {
+    let report = selfLintSource(
+        r"""
+            fn spin() {
+                for {
+                    break
+                }
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0049"), 0)
+}
+
+fn testSelfLintFindsMissingTestAssertion() {
+    let report = selfLintSource(
+        r"""
+            fn testParsesEmpty() {
+                let r = parse("")
+                let _ = r
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0080"), 1)
+}
+
+fn testSelfLintSkipsTestWithTestingCall() {
+    let report = selfLintSource(
+        r"""
+            use std.testing
+
+            fn testParsesEmpty() {
+                let r = parse("")
+                testing.assertEq(r, 0)
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0080"), 0)
+}
+
+fn testSelfLintSkipsNonTestFunction() {
+    let report = selfLintSource(
+        r"""
+            fn normalFn() {
+                let r = 1
+                let _ = r
+            }
+            """,
+    )
+    testing.assertEq(report.parseErrors, 0)
+    testing.assertEq(selfLintCodeCount(report, "L0080"), 0)
+}


### PR DESCRIPTION
## Summary
앞선 분석에서 지목한 "저비용으로 따먹을 만한 pure-AST 규칙" 4개를 한 번에 추가합니다. 타입 정보 없이 AST만으로 동작하며 Go + self-host 양쪽 레지스트리에 대칭 등록됩니다.

| 코드 | 이름 | 카테고리 | fixable |
|------|------|----------|---------|
| L0047 | `let_return_simplify` | simplify | ✅ |
| L0048 | `needless_parens_condition` | simplify | ✅ |
| L0049 | `infinite_loop_literal` | simplify | ✅ |
| L0080 | `missing_test_assertion` | docs | ❌ |

### L0047 — `let x = expr; x` 꼬리
블록 마지막 두 문장이 `let NAME = expr` + `NAME` 참조이면 발화. `let mut`은 제외(재할당이 다른 곳에 있을 수 있음). let과 tail 사이에 다른 사용이 있으면 자동으로 매치되지 않으므로 안전.

### L0048 — `if (cond) {...}`
`AstNIf.left` / `AstNFor(cond).left` / `AstNMatch.left`가 `AstNParen`일 때 발화. 메서드 체인의 의도적 paren인 `(x).foo()`는 스캔 대상이 아니므로 무영향.

### L0049 — `for true { ... }`
`AstNFor.text == "cond"` + `.left`가 `AstNBoolLit` 이면서 `flags == 1`(=true)일 때만 발화. 이 패턴이 `for { ... }`와 완전히 동치.

### L0080 — `fn test*()` with no `testing.*`
Self-host 테스트 러너가 자동 디스커버리하는 prefix 규칙(`test` + 대문자/언더스코어)과 동일. 매개변수 있는 `testFoo(x)` 같은 헬퍼는 제외. body 재귀 스캔해서 `AstNField(left=AstNIdent("testing"))` 노드 하나라도 있으면 발화 안 함.

## 구현
- `internal/diag/codes.go`에 4개 코드 + 설명 주석 추가
- `internal/lint/registry.go` + `internal/lint/allow.go`에 메타데이터/별칭 추가
- `toolchain/lint.osty` 파이프라인에 4개 pass 삽입 + 각 규칙 구현
- `selfLintAllRules()`에 4개 엔트리 추가 — `selfLintExplainRule`이 정상 lookup
- `ERROR_CODES.md` / `diag_manifest.osty` / `diag_examples.osty` 자동 재생성
- `simplify` 카테고리 별칭이 새로 추가된 3개 simplify 규칙(그리고 이전 L0046)도 포함하도록 확장

## 테스트 (toolchain/lint_test.osty, 11건)
- L0047: 발화 / mut 제외 / 이중 사용 제외
- L0048: `if (flag)` 발화 / 맨 조건은 무영향
- L0049: `for true` 발화 / `for {}` 무영향
- L0080: test fn without testing 발화 / testing.assertEq 있으면 무영향 / non-test fn은 무영향

## Test plan
- [x] `just front` 전부 통과
- [ ] CI `go generate` 후 self-host 측 11개 테스트 통과 확인 (Windows 로컬은 `strings.compare` + `units.len` 관련 pre-existing bootstrap-gen 버그로 재생성 실패 — main 상태에서도 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)