### PR TITLE
feat(llvmgen): Option B Phase 2d — self-binding intrinsic dispatch on specialized built-ins

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -72,6 +72,40 @@ fn main() {}
 	}
 }
 
+// TestPhase2dSelfBindingRoutesIntrinsicDispatch locks the Phase 2d
+// fix: inside a specialized Map method body, `self.len()` / `self.get(k)`
+// / `self.insert(k, v)` intrinsic dispatch now fires via the
+// surface-level mapKeyTyp / mapValueTyp populated on the receiver
+// paramInfo. Before this fix, the receiver carried only the mangled
+// struct type (e.g. `%_ZTSN4main3MapISslEE`) and failed the
+// `mapMethodInfo` base-type check, falling through to user method
+// dispatch which can't find the stripped intrinsic methods.
+func TestPhase2dSelfBindingRoutesIntrinsicDispatch(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>) -> Int { m.len() }
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2d_self_intrinsic.osty",
+		Source:      []byte(src),
+	}
+	_, err := llvmgen.GenerateModule(monoMod, opts)
+	// Before Phase 2d: the emitter walled on
+	// `LLVM015 call: call target *ast.FieldExpr (self.len)` from
+	// within Map.isEmpty / Map.getOr / ... bodies. Phase 2d moves
+	// the wall past that point. The exact next-blocker shape is
+	// pinned by TestPhase2MonomorphMapReachesGenerateModule; all
+	// this test asserts is that `self.len` is no longer the
+	// outermost failure.
+	if err != nil && strings.Contains(err.Error(), "self.len") {
+		t.Fatalf("self-binding intrinsic dispatch regressed — receiver-type override to ptr didn't take effect: %v", err)
+	}
+	if err != nil {
+		t.Logf("Phase 2 pipeline still incomplete past self.len (expected): %v", err)
+	}
+}
+
 // TestPhase2cSpecializedBuiltinsCarryBuiltinSource verifies the
 // monomorphizer records BuiltinSource / BuiltinSourceArgs on every
 // specialized struct or enum cloned from a stdlib built-in generic

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -986,13 +986,44 @@ func signatureOf(fn *ast.FnDecl, ownerName string, env typeEnv) (*fnSig, error) 
 		sig.irName = llvmMethodIRName(ownerName, fn.Name)
 		sig.receiverType = ownerType
 		sig.receiverMut = fn.Recv.Mut
-		sig.params = append(sig.params, paramInfo{
+		selfInfo := paramInfo{
 			name:    "self",
 			typ:     ownerType,
 			irTyp:   llvmMethodReceiverIRType(ownerType, fn.Recv.Mut),
 			mutable: fn.Recv.Mut,
 			byRef:   fn.Recv.Mut,
-		})
+		}
+		// Option B Phase 2d: when the owner struct/enum is a
+		// specialized stdlib built-in (Map / List / Set / Option /
+		// Result), the `self` binding must carry the surface-level
+		// map/list/set metadata so intrinsic dispatch inside the
+		// method body (self.len(), self.get(k), self.insert(k, v),
+		// …) recognizes the receiver and routes to the osty_rt_*
+		// runtime helpers. Without this, those calls fall through
+		// to user method dispatch on the mangled struct name and
+		// fail because the intrinsic methods were stripped by the
+		// Phase 2b AST bridge.
+		if info, ok := specializedBuiltinMetaFor(ownerName); ok {
+			selfInfo.sourceType = info.sourceType
+			selfInfo.listElemTyp = info.listElemTyp
+			selfInfo.listElemString = info.listElemString
+			selfInfo.mapKeyTyp = info.mapKeyTyp
+			selfInfo.mapValueTyp = info.mapValueTyp
+			selfInfo.mapKeyString = info.mapKeyString
+			selfInfo.setElemTyp = info.setElemTyp
+			selfInfo.setElemString = info.setElemString
+			// Specialized built-in containers are runtime aggregates
+			// (opaque ptr to an osty_rt_map / list / set handle), not
+			// LLVM struct values. Override the receiver's LLVM type
+			// to "ptr" so intrinsic dispatch (which requires
+			// baseInfo.typ == "ptr") fires for self.len(), self.get(k),
+			// etc. The original %_ZTS… struct type would block that
+			// check even though at the runtime ABI level the
+			// container is already a ptr.
+			selfInfo.typ = "ptr"
+			selfInfo.irTyp = "ptr"
+		}
+		sig.params = append(sig.params, selfInfo)
 	}
 	if fn.Name == "main" {
 		return sig, nil

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -31,8 +31,22 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	}
 	file, err := legacyFileFromModule(mod)
 	if err != nil {
+		// legacyFileFromModule populated the specialized-builtin
+		// side channel but we're bailing early; clear it so a
+		// subsequent unrelated GenerateModule call doesn't see
+		// stale state.
+		currentSpecializedBuiltinSurfaces = nil
+		currentSpecializedBuiltinMeta = nil
 		return nil, err
 	}
+	// Defer cleanup until AFTER generateASTFile consumes the side
+	// channel. Nulling it at legacyFileFromModule return would clear
+	// the map before signatureOf and staticExprInfo (called from
+	// generateASTFile) can read it.
+	defer func() {
+		currentSpecializedBuiltinSurfaces = nil
+		currentSpecializedBuiltinMeta = nil
+	}()
 	out, err := generateASTFile(file, opts)
 	if err != nil {
 		return nil, err
@@ -216,6 +230,90 @@ type specializedBuiltinSurface struct {
 	Args   []ostyir.Type
 }
 
+// specializedBuiltinMeta is the llvmgen-side shape of a specialized
+// built-in's surface-level identity. Used by signatureOf's `self`
+// binding and by staticExprInfo to tag receiver values with the map /
+// list / set metadata the intrinsic dispatch reads.
+type specializedBuiltinMeta struct {
+	sourceType     ast.Type
+	listElemTyp    string
+	listElemString bool
+	mapKeyTyp      string
+	mapValueTyp    string
+	mapKeyString   bool
+	setElemTyp     string
+	setElemString  bool
+}
+
+// currentSpecializedBuiltinMeta maps mangled owner names (the
+// `ownerName` passed into signatureOf) to their surface-level map /
+// list / set metadata. Populated alongside
+// currentSpecializedBuiltinSurfaces at the start of each bridge
+// conversion; read by llvmgen's signatureOf to populate `self`
+// paramInfo.
+var currentSpecializedBuiltinMeta map[string]specializedBuiltinMeta
+
+// specializedBuiltinMetaFor returns the metadata for a specialized
+// built-in owner name, or (zero, false) if the name is unknown or
+// unregistered.
+func specializedBuiltinMetaFor(ownerName string) (specializedBuiltinMeta, bool) {
+	if currentSpecializedBuiltinMeta == nil {
+		return specializedBuiltinMeta{}, false
+	}
+	info, ok := currentSpecializedBuiltinMeta[ownerName]
+	return info, ok
+}
+
+// buildSpecializedBuiltinMeta projects each mangled surface entry
+// into an llvmgen-side metadata shape. Uses the legacy type bridge to
+// turn IR type args into AST types, then classifies per source name:
+// Map<K, V> populates mapKeyTyp / mapValueTyp, List<T> populates
+// listElemTyp, etc. Callers pass the surface map produced by
+// collectSpecializedBuiltinSurfaces.
+func buildSpecializedBuiltinMeta(surfaces map[string]specializedBuiltinSurface) map[string]specializedBuiltinMeta {
+	out := map[string]specializedBuiltinMeta{}
+	for mangled, surf := range surfaces {
+		if surf.Source == "" {
+			continue
+		}
+		astArgs := make([]ast.Type, 0, len(surf.Args))
+		for _, a := range surf.Args {
+			astArgs = append(astArgs, legacyTypeFromIR(a))
+		}
+		meta := specializedBuiltinMeta{
+			sourceType: &ast.NamedType{Path: []string{surf.Source}, Args: astArgs},
+		}
+		switch surf.Source {
+		case "Map":
+			if len(astArgs) == 2 {
+				if k, err := llvmRuntimeABIType(astArgs[0], typeEnv{}); err == nil {
+					meta.mapKeyTyp = k
+				}
+				if v, err := llvmRuntimeABIType(astArgs[1], typeEnv{}); err == nil {
+					meta.mapValueTyp = v
+				}
+				meta.mapKeyString = llvmNamedTypeIsString(astArgs[0])
+			}
+		case "List":
+			if len(astArgs) == 1 {
+				if e, err := llvmRuntimeABIType(astArgs[0], typeEnv{}); err == nil {
+					meta.listElemTyp = e
+				}
+				meta.listElemString = llvmNamedTypeIsString(astArgs[0])
+			}
+		case "Set":
+			if len(astArgs) == 1 {
+				if e, err := llvmRuntimeABIType(astArgs[0], typeEnv{}); err == nil {
+					meta.setElemTyp = e
+				}
+				meta.setElemString = llvmNamedTypeIsString(astArgs[0])
+			}
+		}
+		out[mangled] = meta
+	}
+	return out
+}
+
 func collectSpecializedBuiltinSurfaces(mod *ostyir.Module) map[string]specializedBuiltinSurface {
 	out := map[string]specializedBuiltinSurface{}
 	if mod == nil {
@@ -248,7 +346,12 @@ var currentSpecializedBuiltinSurfaces map[string]specializedBuiltinSurface
 
 func legacyFileFromModule(mod *ostyir.Module) (*ast.File, error) {
 	currentSpecializedBuiltinSurfaces = collectSpecializedBuiltinSurfaces(mod)
-	defer func() { currentSpecializedBuiltinSurfaces = nil }()
+	currentSpecializedBuiltinMeta = buildSpecializedBuiltinMeta(currentSpecializedBuiltinSurfaces)
+	// NOTE: callers (GenerateModule) are responsible for clearing
+	// currentSpecializedBuiltinSurfaces / currentSpecializedBuiltinMeta
+	// after `generateASTFile` consumes them. A deferred clear here
+	// would nil them before the downstream signatureOf /
+	// staticExprInfo paths can read the metadata off the built AST.
 	start, end := legacySpan(mod.At())
 	file := &ast.File{PosV: start, EndV: end}
 	for _, decl := range mod.Decls {


### PR DESCRIPTION
## Summary

Fourth peel of Option B's Phase 2 walls. Advances the end-to-end probe past `LLVM015 *ast.FieldExpr (self.len)` inside specialized Map method bodies; next-blocker is now `LLVM011 ?? left source type unknown` in `Map.getOr`'s body — a distinct Phase 2e concern about Option source-type propagation through coalesce lowering.

Sequence so far:
- [#483](https://github.com/choiceoh/osty/pull/483) — Phase 1: inject stdlib types + unblock Builtin short-circuit
- [#494](https://github.com/choiceoh/osty/pull/494) — Phase 2a/b: LLVM016 + LLVM010
- [#499](https://github.com/choiceoh/osty/pull/499) — Phase 2c: TurbofishExpr + BuiltinSource re-association
- **this PR** — Phase 2d: `self` binding surface map metadata + `ptr` override

## What landed

### 1. `currentSpecializedBuiltinMeta` side-channel
`internal/llvmgen/ir_module.go`: populated at `legacyFileFromModule` entry, derived from the BuiltinSource / BuiltinSourceArgs that Phase 2c plumbed onto `ir.StructDecl` / `ir.EnumDecl`. New helper `buildSpecializedBuiltinMeta` classifies surface args per source name:
- `Map` → `mapKeyTyp`, `mapValueTyp`, `mapKeyString`
- `List` → `listElemTyp`, `listElemString`
- `Set` → `setElemTyp`, `setElemString`

Uses the real `llvmRuntimeABIType` so String → ptr, Int → i64, matching what the existing intrinsic dispatch already expects.

Cleanup moved to `GenerateModule`'s outer defer — previously the deferred-in-`legacyFileFromModule` nulled the map before `generateASTFile` read it.

### 2. `signatureOf` threads metadata onto `self` paramInfo
`internal/llvmgen/decl.go`: when the owner name is a specialized built-in (`specializedBuiltinMetaFor(ownerName)` hit), copy metadata onto `self` paramInfo **and** override `self.typ` / `self.irTyp` to `ptr`. The override is the key — specialized built-ins are zero-field runtime aggregates (opaque ptr to an `osty_rt_map` / `list` / `set` handle), so treating them as `ptr` matches runtime reality and unblocks the `mapMethodInfo` base-type-is-ptr check.

### 3. Regression test
`TestPhase2dSelfBindingRoutesIntrinsicDispatch` asserts `self.len` is no longer the outermost wall. The existing Phase 2 end-to-end probe reports the new next-blocker shape instead.

## Not in this PR (Phase 2e)

`self.get(k) ?? default` inside `Map.getOr`'s body walls with `LLVM011 type-system: ?? left source type unknown`. `self.get(k)` returns `Option<Int>` but the coalesce emitter can't find a concrete source-type annotation on the `MethodCall`. Fix requires either:
- **(a)** the IR lowerer tagging post-substitution MethodCall return source types, or
- **(b)** the coalesce emitter inferring the source type from the method's signature.

## Test plan

- [x] `go test ./internal/backend -run TestPhase2 -count=1 -v` — all green (5 PASS, 1 documented-skip)
- [x] `go test ./internal/ir -count=1 -short`
- [x] `go test ./internal/backend -count=1 -short`
- [x] `go test ./internal/llvmgen -count=1 -short` (skipping two pre-existing unrelated failures)
- [x] `just front`
- [ ] Retire `emitMap{GetOr,Update,RetainIf,MergeWith,MapValues}` — deferred to Phase 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)