### PR TITLE
feat(llvmgen): Option B Phase 2e — recover Option<V> source type for Map intrinsic returns

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -72,6 +72,36 @@ fn main() {}
 	}
 }
 
+// TestPhase2eCoalesceSourceTypeRecoveredForMapGet locks the Phase
+// 2e fix: `self.get(k) ?? default` inside specialized Map method
+// bodies (notably Map.getOr) now reports `Option<V>` as the left
+// source type through the new staticMapMethodSourceType pathway.
+// Before this, the coalesce emitter walled on
+// `LLVM011 ?? left source type unknown` because `self.get(k)`'s
+// return type wasn't visible through `staticExprSourceType`'s
+// CallExpr dispatch — Map's intrinsic methods aren't registered in
+// `g.methods` the way user-defined ones are.
+func TestPhase2eCoalesceSourceTypeRecoveredForMapGet(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Int { m.getOr(k, 0) }
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2e_coalesce.osty",
+		Source:      []byte(src),
+	}
+	_, err := llvmgen.GenerateModule(monoMod, opts)
+	// Phase 2e turns the outermost wall from LLVM011 ?? source-type
+	// into LLVM015 *ast.CallExpr.isSome (next Phase 2f concern).
+	if err != nil && strings.Contains(err.Error(), "?? left source type unknown") {
+		t.Fatalf("`??` source-type recovery regressed for Map.get(k): %v", err)
+	}
+	if err != nil {
+		t.Logf("Phase 2 pipeline still incomplete past the coalesce wall (expected): %v", err)
+	}
+}
+
 // TestPhase2dSelfBindingRoutesIntrinsicDispatch locks the Phase 2d
 // fix: inside a specialized Map method body, `self.len()` / `self.get(k)`
 // / `self.insert(k, v)` intrinsic dispatch now fires via the

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -394,6 +394,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdStringsCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticMapMethodSourceType(e); ok {
+			return src, true
+		}
 		if id, ok := e.Fn.(*ast.Ident); ok {
 			if sig := g.functions[id.Name]; sig != nil && sig.returnSourceType != nil {
 				return sig.returnSourceType, true
@@ -781,6 +784,59 @@ func (g *generator) staticStdStringsCallSourceType(call *ast.CallExpr) (ast.Type
 		return stringT, true
 	case "split", "splitN":
 		return &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{stringT}}, true
+	}
+	return nil, false
+}
+
+// staticMapMethodSourceType recovers the source-level return type of
+// a Map intrinsic method call so downstream passes (notably the
+// `??` coalesce emitter that demands an Option<V> source type)
+// can reason about `self.get(k) ?? default` inside specialized
+// Map method bodies. Returns `(nil, false)` unless the call is a
+// FieldExpr on a receiver with mapKey/mapValue metadata.
+//
+// Method → source-type map:
+//
+//	len              → Int
+//	isEmpty          → Bool
+//	containsKey(K)   → Bool
+//	get(K)           → V?           (Option<V>, what feeds `??`)
+//	keys()           → List<K>
+//
+// Other map methods (getOr / update / retainIf / mergeWith /
+// mapValues / …) are either bodied (their source type flows from the
+// body) or not yet exercised at this layer.
+func (g *generator) staticMapMethodSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, keyTyp, valTyp, _, found := g.mapMethodInfo(call)
+	if !found {
+		return nil, false
+	}
+	_ = keyTyp
+	_ = valTyp
+	baseSrc, ok := g.staticExprSourceType(field.X)
+	if !ok {
+		return nil, false
+	}
+	resolved, err := llvmResolveAliasType(baseSrc, g.typeEnv(), map[string]bool{})
+	if err != nil {
+		return nil, false
+	}
+	named, ok := resolved.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "Map" || len(named.Args) != 2 {
+		return nil, false
+	}
+	keyAST := named.Args[0]
+	valAST := named.Args[1]
+	switch field.Name {
+	case "len":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "isEmpty", "containsKey":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "get":
+		// V? — wraps the Map's value type.
+		return &ast.OptionalType{Inner: valAST}, true
+	case "keys":
+		return &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{keyAST}}, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
## Summary

Fifth peel of Option B's Phase 2 walls. Advances the end-to-end probe past `LLVM011 type-system: ?? left source type unknown`; the next wall is `LLVM015 *ast.FieldExpr (*ast.CallExpr.isSome)` — a distinct Phase 2f concern about dispatching `Option.isSome()` on a specialized Option enum.

Sequence so far:
- [#483](https://github.com/choiceoh/osty/pull/483) — Phase 1
- [#494](https://github.com/choiceoh/osty/pull/494) — Phase 2a/b
- [#499](https://github.com/choiceoh/osty/pull/499) — Phase 2c
- [#504](https://github.com/choiceoh/osty/pull/504) — Phase 2d
- **this PR** — Phase 2e

## What landed

`internal/llvmgen/type.go`: new `staticMapMethodSourceType` mirrors the existing `staticStringMethodSourceType` pattern for Map intrinsic methods. For a FieldExpr CallExpr whose receiver carries `Map<K, V>` surface metadata it returns the concrete return type:

| Method | Source type returned |
| --- | --- |
| `len` | `Int` |
| `isEmpty` | `Bool` |
| `containsKey` | `Bool` |
| `get(K)` | `V?` (Option<V>, what feeds `??`) |
| `keys()` | `List<K>` |

Wired into `staticExprSourceType`'s CallExpr dispatch alongside the string-method hook. Without this pathway, the coalesce emitter saw `self.get(key)` as a CallExpr with no recoverable source type (Map's intrinsic methods aren't in `g.methods` the way user-defined ones are), failing its `Option<T>` requirement.

## Regression test

`TestPhase2eCoalesceSourceTypeRecoveredForMapGet` covers `m.getOr(k, 0)` on `Map<String, Int>` — the bodied `getOr` implementation `self.get(key) ?? default` now gets past the coalesce emitter. The end-to-end probe reports the next outermost wall instead.

## Not in this PR (Phase 2f)

`Map.containsKey`'s stdlib body is `self.get(key).isSome()`. Phase 2e makes `self.get(key)`'s source type visible as `Option<Int>`, but `.isSome()` then dispatches on that Option — which needs:
- the Option enum specialized for Int (currently Option is not injected because user code only uses `Int?` sugar, not an explicit `Option<Int>`), and
- its `self` binding to route through an Option intrinsic (match-on-null at LLVM layer).

That's Phase 2f scope.

## Test plan

- [x] `go test ./internal/backend -run TestPhase2 -count=1 -v` — all green (6 PASS, 1 documented-skip)
- [x] `go test ./internal/ir -count=1 -short`
- [x] `go test ./internal/llvmgen -count=1 -short` (skipping two pre-existing unrelated failures)
- [ ] Retire `emitMap{GetOr,Update,RetainIf,MergeWith,MapValues}` — deferred to Phase 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)