### PR TITLE
feat(llvmgen): wire List<T>.clear() — native-merged probe now CLEAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,19 @@ and falls back to the embedded selfhost bridge when that executable is
 unavailable, and `go generate ./internal/selfhost` still shells out to
 `cmd/osty-bootstrap-gen` to refresh `internal/selfhost/generated.go`. The
 whole-toolchain LLVM probe still first-walls on the bootstrap-only
-`runtime.golegacy.astbridge` bridge; when those bootstrap-only files are
-excluded, the current native probe first-walls on `LLVM011 [other]
-String.bytes requires Byte/List<Byte> lowering`. The earlier `Char` parameter
-lowering (`lspUtf16UnitsForChar`), `list_mixed_ptr`, non-ASCII string literal,
-match-as-statement, and nested-field assignment walls are all closed. The C
-runtime already ships `osty_rt_strings_Chars` / `osty_rt_strings_Bytes` with
-full UTF-8 coverage (including maximal-subpart recovery on ill-formed input);
-what remains is wiring `String.chars()` / `String.bytes()` lowering to those
-symbols so pure Osty `std.strings` bodies no longer depend on the runtime
-shim. `Result<T, E>` `?` propagation is wired; collection literals and a
+`runtime.golegacy.astbridge` bridge; the native-only merged
+probe (with bootstrap-only files skipped) now lowers CLEAN — the last
+wall (`LLVM015 [method_call_field]` on `buf.clear()` in ty.osty's
+generic-arg splitter) was closed by wiring `List<T>.clear()` through a
+new `osty_rt_list_clear` runtime helper. The earlier `Char` parameter
+lowering (`lspUtf16UnitsForChar`), `list_mixed_ptr`, non-ASCII string
+literal, match-as-statement, nested-field assignment, and
+`String.bytes()` / `String.chars()` intrinsic walls are all closed:
+`String.chars()` / `String.bytes()` dispatch at
+`internal/llvmgen/expr.go` to `osty_rt_strings_Chars` /
+`osty_rt_strings_Bytes` (full UTF-8 coverage including maximal-subpart
+recovery on ill-formed input), tagging the result list element width
+(`i32` / `i8`) so downstream iteration takes the `_bytes_v1` ABI. `Result<T, E>` `?` propagation is wired; collection literals and a
 substantial slice of collection methods lower; MIR capturing-closure env
 emission has landed with tests — so the remaining work is a narrow
 runtime/backend parity queue rather than a single missing subsystem.

--- a/docs/toolchain_llvm_status.md
+++ b/docs/toolchain_llvm_status.md
@@ -23,9 +23,16 @@ As of 2026-04-21:
 - the whole-toolchain merged LLVM probe still first-walls on the
   bootstrap-only `runtime.golegacy.astbridge` bridge
 - the native-only merged LLVM probe (with bootstrap-only files skipped)
-  now first-walls on `LLVM011 [other] type-system: String.bytes
-  requires Byte/List<Byte> lowering in legacy llvmgen` — a separate
-  `String.bytes()` intrinsic gap. The earlier `LLVM013 match arm must
+  now lowers **CLEAN** — the last wall (`LLVM015 [method_call_field]`
+  on `buf.clear()` in `toolchain/ty.osty`'s generic-arg splitter, where
+  rebinding `buf = []` would've lost bootstrap-gen's element inference
+  on Windows regen) was closed by adding `osty_rt_list_clear` to the C
+  runtime and routing `List<T>.clear()` through `emitListMethodCallStmt`.
+  The preceding `String.bytes`/`String.chars` intrinsic gap is also
+  closed: `internal/llvmgen/expr.go` dispatches both methods to
+  `osty_rt_strings_Chars` / `osty_rt_strings_Bytes` with `listElemTyp`
+  tagged `i32` / `i8` so downstream iteration takes the `_bytes_v1`
+  ABI. The earlier `LLVM013 match arm must
   be a payload-free enum variant` wall was a **source inconsistency**:
   `lexer.osty` (3 sites) and `lossless_lex.osty` (3 sites) matched on
   `FrontDiagBadNumericSeparator`, but the `FrontLexDiagnosticCode`
@@ -103,17 +110,17 @@ Current-tree observations from the code re-audit:
 |---|---|---|
 | CLI wiring | universal LLVM entry wedge | **resolved** — hello-world `osty gen --backend=llvm` exits 0 and writes `.ll` output |
 | Bootstrap bridge | merged whole-toolchain probe | first wall is still `LLVM002 runtime-ffi` on `runtime.golegacy.astbridge`; this is a bootstrap artifact, not yet a native backend parity claim |
-| Native backend surface | merged native-only probe | first wall is `LLVM011 [other] String.bytes requires Byte/List<Byte> lowering` (separate `String.bytes()` intrinsic gap) after skipping 4 bootstrap-only files. Closed walls (in order): `LLVM011 [fn_param_struct_type]` Char on `lspUtf16UnitsForChar`; `LLVM012 *ast.MatchExpr is not a call` (match-as-statement lowering); `LLVM012 field assignment base *ast.FieldExpr` (nested `a.b.c = x` via `llvmInsertValue` rebuild chain); parser precedence `(!x).y` / `!(x.y)` hoisted at stable-AST lowering; `LLVM011 [list_mixed_ptr]` source-type propagation (stdlib strings alias calls, bare `""` literals, if-expr phi branches — `staticStdStringsCallSourceType` + literal sourceType tagging + mergeContainerMetadata sameSourceType); `LLVM011 [string_non_ascii]` multi-byte UTF-8 literals (BOM / Unit Separator / Korean / emoji) now byte-escaped via `\HH` in `llvmCStringEscape`, with `llvmCString` counting UTF-8 bytes instead of runes; `LLVM013 match arm must be a payload-free enum variant` was a source inconsistency (missing `FrontDiagBadNumericSeparator` enum variant) + a latent return-path gap (hardcoded `listElemString=false` in `emitReturningBlock` / `emitReturn`). List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites also closed |
+| Native backend surface | merged native-only probe | **CLEAN** after skipping 4 bootstrap-only files (verified 2026-04-21 via `TestNativeToolchainMergedIsClean` + `TestProbeNativeToolchainMerged`). Most recently closed: `LLVM015 [method_call_field]` on `buf.clear()` in `ty.osty` — `List<T>.clear()` now dispatches through `osty_rt_list_clear` in `emitListMethodCallStmt`, with the symbol added to `listMethodInfo`'s whitelist. Preceding `String.bytes()`/`String.chars()` intrinsic gap also closed (lowers to `osty_rt_strings_Chars` / `osty_rt_strings_Bytes` with `listElemTyp` tagged `i32` / `i8`). Earlier closed walls (in order): `LLVM011 [fn_param_struct_type]` Char on `lspUtf16UnitsForChar`; `LLVM012 *ast.MatchExpr is not a call` (match-as-statement lowering); `LLVM012 field assignment base *ast.FieldExpr` (nested `a.b.c = x` via `llvmInsertValue` rebuild chain); parser precedence `(!x).y` / `!(x.y)` hoisted at stable-AST lowering; `LLVM011 [list_mixed_ptr]` source-type propagation (stdlib strings alias calls, bare `""` literals, if-expr phi branches — `staticStdStringsCallSourceType` + literal sourceType tagging + mergeContainerMetadata sameSourceType); `LLVM011 [string_non_ascii]` multi-byte UTF-8 literals (BOM / Unit Separator / Korean / emoji) now byte-escaped via `\HH` in `llvmCStringEscape`, with `llvmCString` counting UTF-8 bytes instead of runes; `LLVM013 match arm must be a payload-free enum variant` was a source inconsistency (missing `FrontDiagBadNumericSeparator` enum variant) + a latent return-path gap (hardcoded `listElemString=false` in `emitReturningBlock` / `emitReturn`). List / Map / Set `isEmpty`, nested `IndexExpr`, and `list.pop()` discard sites also closed |
 | Checker boundary | `internal/check` / `internal/toolchain` | host still manages an external `osty-native-checker` artifact and falls back to the embedded selfhost checker when it cannot be prepared |
 | Toolchain package health | `osty check --airepair=false toolchain` | current CLI surface is still an aggregate `E0700` summary (`949 error(s)`, `26811 / 27501` accepted) rather than a clean self-compile pass |
-| Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers. `Char` and `Byte` parameters/returns, literals, comparisons, and width conversions now lower; `String.chars` / `String.bytes` still block the pure native path because `List<Char>` / `List<Byte>` collection lowering is separate work |
+| Stdlib / string surface | `internal/llvmgen/stdlib_shim.go`, `expr.go` | a subset of `std.strings` is shimmed through runtime helpers. `Char` and `Byte` parameters/returns, literals, comparisons, and width conversions lower; `String.chars` / `String.bytes` lower to `osty_rt_strings_Chars` / `osty_rt_strings_Bytes` producing GC-managed lists with `listElemTyp` tagged `i32` / `i8`, and downstream iteration takes the `_bytes_v1` ABI. What remains is retiring the runtime-backed `std.strings` shim in favor of pure-Osty bodies built on those primitives |
 
 The MIR-direct emitter itself (Stages 3.1–3.11) covers a growing subset of the
 language shapes toolchain uses. The 2026-04-21 refresh narrows the story
-further: backend entry is no longer the first blocker, but the current tree is
-still not "fully self-hosted" because the bootstrap bridge, checker boundary,
-heterogeneous ptr-backed list literals, and `List<Char>` / `List<Byte>`
-string-iteration surface all remain live.
+further: backend entry is no longer the first blocker, and the native-only
+merged probe now lowers cleanly, but the current tree is still not "fully
+self-hosted" because the bootstrap bridge and the aggregate `949 / 27501`
+checker-error summary on `osty check --airepair=false toolchain` remain live.
 
 ## How the probe was run
 
@@ -138,11 +145,13 @@ Observed in the 2026-04-21 refresh:
 - `TestProbeWholeToolchainMerged` reported
   `LLVM002 runtime-ffi: ... runtime.golegacy.astbridge ...`
 - `TestProbeNativeToolchainMerged` skipped
-  `ast_lower.osty, ci.osty, docgen.osty, manifest_validation.osty`. The
-  probe now first-walls on `LLVM011 [list_mixed_ptr]`; the earlier
-  `LLVM011 [fn_param_struct_type]` Char wall, the `LLVM012 MatchExpr is
-  not a call` statement-form wall, and the `LLVM012 field assignment
-  base *ast.FieldExpr` nested-write wall are all closed
+  `ast_lower.osty, ci.osty, docgen.osty, manifest_validation.osty` and
+  reported `NATIVE TOOLCHAIN first wall: CLEAN`. The authoritative
+  `TestNativeToolchainMergedIsClean` gate passed. The earlier
+  `LLVM011 [list_mixed_ptr]`, `LLVM011 [fn_param_struct_type]` Char,
+  `LLVM012 MatchExpr is not a call`, `LLVM012 field assignment base
+  *ast.FieldExpr`, `LLVM011 [other] String.bytes`, and `LLVM015
+  [method_call_field] buf.clear()` walls are all closed
 - `/tmp/osty check --airepair=false toolchain` exited with the aggregate
   summary
   `native checker reported type errors: 949 error(s)` plus
@@ -311,31 +320,34 @@ rewire the remaining Go-hosted boundaries."
 
 ## Recommended fix order (smallest → largest unlock)
 
-1. **Treat the merged native probe as the current primary signal.**
-   The first real wall is now `LLVM011 [list_mixed_ptr]` (a single `[...]`
-   literal mixing `String` with non-`String` ptr-backed elements), not the
-   old CLI panic, not the `Char`-parameter wall (closed), and not the
-   already-fixed `def: Expr` alias issue.
+1. **Keep the native-merged clean gate authoritative.**
+   `TestNativeToolchainMergedIsClean` now locks the "no wall" state as a
+   fail-fast regression gate. Future changes that re-introduce a wall
+   surface here immediately (e.g. adding a new method or literal shape
+   the statement-form dispatcher doesn't recognize yet). When a new
+   wall appears, treat it as Tier A: resolve in a follow-up PR and
+   reference this gate.
 
 2. **Shrink the aggregate checker summary on the current tree.**
-   Re-profile the `949`-error native-checker summary into a current histogram
-   before making more claims from the 2026-04-18 sample — the drop from the
-   earlier `1700` / `3846` figures already suggests the root-cause set has
-   shifted.
+   Re-profile the `949`-error native-checker summary into a current
+   histogram before making more claims from the 2026-04-18 sample —
+   the drop from the earlier `1700` / `3846` figures already suggests
+   the root-cause set has shifted.
 
-3. **Close the ptr-backed heterogeneous-list surface, then finish
-   `Char` / `Byte` / string iteration.**
-   `Char` and `Byte` parameter/return lowering landed already; the remaining
-   string-side gap is `String.chars` / `String.bytes` → `List<Char>` /
-   `List<Byte>`, which also unblocks the `std.strings` shim's final removal.
+3. **Retire the runtime-backed `std.strings` shim.**
+   Now that `String.chars()` / `String.bytes()` lower to real
+   `List<Char>` / `List<Byte>` values, rewrite the pure-Osty
+   `std.strings` bodies to use those primitives and drop the
+   `internal/llvmgen/stdlib_shim.go` routes that remain only as a
+   bridge.
 
 4. **Retire the bootstrap-only bridge files from the critical path.**
    Whole-toolchain merged lowering still first-walls on
-   `runtime.golegacy.astbridge`, so the self-hosting story stays incomplete
-   until the CLI is rewired away from those files or they remain explicitly
-   outside the native path.
+   `runtime.golegacy.astbridge`, so the self-hosting story stays
+   incomplete until the CLI is rewired away from those files or they
+   remain explicitly outside the native path.
 
-5. **Then re-run `osty check toolchain` and per-file `osty gen --backend=llvm`
-   probes.**
-   Once the `list_mixed_ptr` / string-iteration / bootstrap wedges move, the
-   remaining tail should become a much narrower backend/runtime parity queue.
+5. **Then re-run `osty check toolchain` and per-file `osty gen
+   --backend=llvm` probes.** Once the checker summary and bootstrap
+   bridge wedges move, the remaining tail should become a much
+   narrower backend/runtime parity queue.

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1679,6 +1679,19 @@ void osty_rt_list_pop_discard(void *raw_list) {
     list->len -= 1;
 }
 
+// osty_rt_list_clear truncates the list to length 0. The backing storage
+// (data/capacity/elem_size/trace metadata) is preserved so subsequent
+// pushes keep the same element type and re-use the allocation. Pointer
+// slots past len are no longer traced (osty_rt_list_trace bounds by len),
+// so cleared elements become unreachable from this list.
+void osty_rt_list_clear(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    if (list == NULL) {
+        osty_rt_abort("list.clear on nil receiver");
+    }
+    list->len = 0;
+}
+
 void osty_rt_list_push_i64(void *raw_list, int64_t value) {
     osty_rt_list_push_raw(raw_list, &value, sizeof(value), NULL);
 }

--- a/internal/llvmgen/list_clear_test.go
+++ b/internal/llvmgen/list_clear_test.go
@@ -1,0 +1,52 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// List<T>.clear() — truncate to length 0. The toolchain native-merged
+// probe first-walled on `buf.clear()` in ty.osty's generic-arg splitter
+// (where rebinding `buf = []` would've lost bootstrap-gen's element
+// inference on Windows regen) with LLVM015 [method_call_field] /
+// "only println calls are supported" because the statement-form list
+// method dispatcher only routed push/pop/insert. This test locks the
+// new osty_rt_list_clear runtime call so the regression re-surfaces
+// immediately if a future refactor drops the dispatch.
+func TestListClearPtrElems(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut xs: List<String> = ["a", "b", "c"]
+    xs.clear()
+    println(xs.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_clear_string.osty"})
+	if err != nil {
+		t.Fatalf("list.clear<String> errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_list_clear",
+		"declare void @osty_rt_list_clear(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("list.clear<String> missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestListClearI64(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut xs: List<Int> = [1, 2, 3]
+    xs.clear()
+    println(xs.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/list_clear_i64.osty"})
+	if err != nil {
+		t.Fatalf("list.clear<Int> errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "@osty_rt_list_clear") {
+		t.Fatalf("list.clear<Int> did not invoke osty_rt_list_clear:\n%s", got)
+	}
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -303,6 +303,10 @@ func listRuntimePopDiscardSymbol() string {
 	return "osty_rt_list_pop_discard"
 }
 
+func listRuntimeClearSymbol() string {
+	return "osty_rt_list_clear"
+}
+
 func listRuntimePushBytesV1Symbol() string {
 	return "osty_rt_list_push_bytes_v1"
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1605,7 +1605,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	if field.Name != "push" && field.Name != "pop" && field.Name != "insert" {
+	if field.Name != "push" && field.Name != "pop" && field.Name != "insert" && field.Name != "clear" {
 		return false, nil
 	}
 	g.pushScope()
@@ -1634,6 +1634,20 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		emitter.body = append(emitter.body, fmt.Sprintf(
 			"  call void @%s(%s)",
 			listRuntimePopDiscardSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue)}),
+		))
+		g.takeOstyEmitter(emitter)
+		return true, nil
+	}
+	if field.Name == "clear" {
+		if len(call.Args) != 0 {
+			return true, unsupported("call", "list.clear requires no arguments")
+		}
+		g.declareRuntimeSymbol(listRuntimeClearSymbol(), "void", []paramInfo{{typ: "ptr"}})
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			listRuntimeClearSymbol(),
 			llvmCallArgs([]*LlvmValue{toOstyValue(baseValue)}),
 		))
 		g.takeOstyEmitter(emitter)

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -983,7 +983,7 @@ func (g *generator) listMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, 
 		return nil, "", false, false
 	}
 	switch field.Name {
-	case "len", "isEmpty", "pop", "push", "insert", "sorted", "toSet":
+	case "len", "isEmpty", "pop", "push", "insert", "sorted", "toSet", "clear":
 	default:
 		return nil, "", false, false
 	}


### PR DESCRIPTION
## Summary

- The native-only merged toolchain probe (`TestProbeNativeToolchainMerged`) first-walled on `buf.clear()` at [toolchain/ty.osty:877](toolchain/ty.osty) (generic-arg splitter; rebinding `buf = []` would lose bootstrap-gen's element-type inference on Windows regen). The statement-form list method dispatcher only routed `push`/`pop`/`insert`, so `clear` fell through with `LLVM015 [method_call_field]` / "only println calls are supported".
- Wires `List<T>.clear()` through a new `osty_rt_list_clear` C runtime helper plus a new dispatch branch in `emitListMethodCallStmt`, and adds `"clear"` to `listMethodInfo`'s whitelist. Runtime sets `list->len = 0`, preserving backing storage (data/capacity/elem_size/trace metadata) so subsequent pushes keep the element type; pointer slots past `len` stop being traced (`osty_rt_list_trace` bounds by `len`) so cleared elements become unreachable.
- With this in, `TestNativeToolchainMergedIsClean` (authoritative gate) passes and `TestProbeNativeToolchainMerged` reports `NATIVE TOOLCHAIN first wall: CLEAN` after skipping the 4 bootstrap-only files. Tier A self-host milestone for the native backend surface is held.

## What changed

- `internal/backend/runtime/osty_runtime.c` — add `osty_rt_list_clear`.
- `internal/llvmgen/runtime_ffi.go` — add `listRuntimeClearSymbol()`.
- `internal/llvmgen/type.go` — add `"clear"` to `listMethodInfo`'s method-name whitelist.
- `internal/llvmgen/stmt.go` — route `clear` in `emitListMethodCallStmt` (void return, ptr receiver, no args), mirroring the `pop_discard` shape.
- `internal/llvmgen/list_clear_test.go` — new regression tests for `List<String>` and `List<Int>` receivers, checking both the `@osty_rt_list_clear` call site and the `declare void @osty_rt_list_clear(ptr)` declaration.
- `README.md` + `docs/toolchain_llvm_status.md` — the stale "first wall is `String.bytes requires Byte/List<Byte> lowering`" claim was already wrong (`.bytes()` / `.chars()` dispatch at [expr.go:2857-2880](internal/llvmgen/expr.go) to `osty_rt_strings_Chars` / `osty_rt_strings_Bytes` with `listElemTyp` tagged `i32` / `i8`). Update the probe-status prose, the observations section, and the "Recommended fix order" — the next real blockers are the `runtime.golegacy.astbridge` bootstrap bridge and the aggregate `949 / 27501` `osty check --airepair=false toolchain` checker-error summary, not a backend wall.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/llvmgen -run 'TestListClear' -count=1 -v` — both new tests pass.
- [x] `go test ./internal/llvmgen -run 'TestNativeToolchainMergedIsClean' -count=1 -v` — authoritative clean gate passes.
- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — reports `NATIVE TOOLCHAIN first wall: CLEAN`.
- [x] `go test ./internal/llvmgen -run 'TestList|TestFieldCallDispatch|TestGenerateStringChars|TestGenerateStringBytes' -count=1` — no regressions in neighboring list/field/string dispatch tests.
- [x] `go test ./internal/backend -run 'TestBundledRuntime' -count=1 -short` — runtime C changes compile and link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)