### PR TITLE
feat(llvmgen): Option B Phase 2f — intrinsic null-check for Option.isSome / isNone

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -72,6 +72,38 @@ fn main() {}
 	}
 }
 
+// TestPhase2fOptionIsSomeLowersAsNullCheck locks the Phase 2f fix:
+// `.isSome()` / `.isNone()` calls on a receiver whose source type
+// is `T?` (OptionalType) now lower directly to an LLVM null check,
+// no matter what T is. This unblocks the stdlib body of
+// `Map.containsKey` — `self.get(key).isSome()` — inside specialized
+// Map method bodies, where `self.get(key)` feeds through the
+// Phase 2e staticMapMethodSourceType into isSome's intrinsic path.
+func TestPhase2fOptionIsSomeLowersAsNullCheck(t *testing.T) {
+	src := `fn check(x: Int?) -> Bool { x.isSome() }
+fn checkNone(x: String?) -> Bool { x.isNone() }
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2f_isSome.osty",
+		Source:      []byte(src),
+	}
+	out, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil {
+		t.Fatalf("isSome/isNone lowering failed: %v", err)
+	}
+	ir := string(out)
+	// Both isSome (ne) and isNone (eq) null checks must appear.
+	if !strings.Contains(ir, "icmp ne ptr") {
+		t.Errorf("expected `icmp ne ptr ... , null` for isSome, IR:\n%s", ir)
+	}
+	if !strings.Contains(ir, "icmp eq ptr") {
+		t.Errorf("expected `icmp eq ptr ... , null` for isNone, IR:\n%s", ir)
+	}
+}
+
 // TestPhase2eCoalesceSourceTypeRecoveredForMapGet locks the Phase
 // 2e fix: `self.get(k) ?? default` inside specialized Map method
 // bodies (notably Map.getOr) now reports `Option<V>` as the left

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -3588,6 +3588,58 @@ func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, 
 	return out, true, nil
 }
 
+// emitOptionMethodCall lowers `opt.isSome()` and `opt.isNone()` as a
+// ptr-null check when `opt` statically resolves to an Option<T>
+// value (i.e. the receiver's source type is `*ast.OptionalType`, or
+// the expression returns one — e.g. `self.get(k).isSome()` inside
+// a specialized Map method body, where `self.get(k)` advertises
+// `V?` as its source type via staticMapMethodSourceType).
+//
+// This is the Phase 2f intrinsic that lets `Map.containsKey`'s
+// stdlib body compose through the specialized stack without needing
+// a monomorphized Option<V> enum with its own isSome method
+// dispatch. At the LLVM layer, Option<T> for every T is already
+// represented as `ptr` (null = None, non-null = Some), so the
+// check is uniformly a null-comparison regardless of V.
+func (g *generator) emitOptionMethodCall(call *ast.CallExpr) (value, bool, error) {
+	if call == nil {
+		return value{}, false, nil
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional {
+		return value{}, false, nil
+	}
+	if field.Name != "isSome" && field.Name != "isNone" {
+		return value{}, false, nil
+	}
+	if len(call.Args) != 0 {
+		return value{}, false, nil
+	}
+	baseSrc, ok := g.staticExprSourceType(field.X)
+	if !ok {
+		return value{}, false, nil
+	}
+	if _, isOpt := baseSrc.(*ast.OptionalType); !isOpt {
+		return value{}, false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	if base.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Option.%s receiver type %s, want ptr", field.Name, base.typ)
+	}
+	emitter := g.toOstyEmitter()
+	cmp := llvmNextTemp(emitter)
+	op := "ne"
+	if field.Name == "isNone" {
+		op = "eq"
+	}
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s ptr %s, null", cmp, op, base.ref))
+	g.takeOstyEmitter(emitter)
+	return value{typ: "i1", ref: cmp}, true, nil
+}
+
 func (g *generator) emitSetMethodCall(call *ast.CallExpr) (value, bool, error) {
 	field, elemTyp, elemString, found := g.setMethodInfo(call)
 	if !found {
@@ -3976,6 +4028,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		return v, err
 	}
 	if v, found, err := g.emitSetMethodCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitOptionMethodCall(call); found || err != nil {
 		return v, err
 	}
 	if v, found, err := g.emitPrimitiveToStringCall(call); found || err != nil {


### PR DESCRIPTION
## Summary

Sixth peel of Option B's Phase 2 walls. Advances the end-to-end probe past `LLVM015 call: call target *ast.FieldExpr (*ast.CallExpr.isSome)` inside specialized Map method bodies (notably `Map.containsKey`'s `self.get(key).isSome()`). Next-blocker: Phase 2g — a generic Ident call site deep in a stdlib body that the legacy emitter doesn't classify.

Sequence so far:
- [#483](https://github.com/choiceoh/osty/pull/483) — Phase 1
- [#494](https://github.com/choiceoh/osty/pull/494) — Phase 2a/b
- [#499](https://github.com/choiceoh/osty/pull/499) — Phase 2c
- [#504](https://github.com/choiceoh/osty/pull/504) — Phase 2d
- [#505](https://github.com/choiceoh/osty/pull/505) — Phase 2e
- **this PR** — Phase 2f

## What landed

`internal/llvmgen/expr.go`: new `emitOptionMethodCall` lowers `.isSome()` / `.isNone()` directly as null-comparisons when the receiver's static source type is `*ast.OptionalType`. At the LLVM layer every `Option<T>` is already a `ptr` (null = None, non-null = Some), so the dispatch is uniform regardless of T.

Wired into the method-call dispatch chain immediately after the List / Map / Set emitters, before the primitive-toString / char-byte-conversion / string fallbacks so an `Option<String>.isSome()` doesn't accidentally dive into string-method territory.

## Regression test

`TestPhase2fOptionIsSomeLowersAsNullCheck` covers both the `icmp ne ptr` (isSome) and `icmp eq ptr` (isNone) emissions on `Int?` and `String?` receivers respectively.

## Not in this PR (Phase 2g)

Specialized Map body still hits `LLVM015 call: only println calls are supported (got *ast.Ident at 346:13)` — some Ident call inside a stdlib method body the legacy emitter can't resolve to a known fn / fn-value / intrinsic. Offset 10261 puts it deep in a specialized Map helper's body (likely a `mergeWith` or similar helper-calling-helper site in a shape the dispatch doesn't yet recognize).

## Test plan

- [x] `go test ./internal/backend -run TestPhase2 -count=1 -v` — all green (7 PASS, 1 documented-skip)
- [x] `go test ./internal/ir -count=1 -short`
- [x] `go test ./internal/llvmgen -count=1 -short` (skipping two pre-existing unrelated failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)