### PR TITLE
feat(llvmgen): wire Map<K,V>.clear() — mirror List.clear for GC collector resets

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3329,6 +3329,23 @@ int64_t osty_rt_map_len(void *raw_map) {
     return n;
 }
 
+// osty_rt_map_clear truncates the map to zero entries. Backing storage
+// (keys/values/capacity/kind metadata) is preserved so subsequent
+// inserts keep the same key/value kinds and re-use the allocation.
+// Key and value slots past len are no longer traced (osty_rt_map_trace
+// bounds by len), so cleared entries become unreachable from this map.
+// Runs under the map's recursive mutex so the zero-out is atomic with
+// respect to concurrent readers / iterators.
+void osty_rt_map_clear(void *raw_map) {
+    osty_rt_map *map = (osty_rt_map *)raw_map;
+    if (map == NULL) {
+        osty_rt_abort("map.clear on nil receiver");
+    }
+    osty_rt_map_lock(raw_map);
+    map->len = 0;
+    osty_rt_map_unlock(raw_map);
+}
+
 void *osty_rt_map_keys(void *raw_map) {
     osty_rt_map *map = (osty_rt_map *)raw_map;
     void *out = osty_rt_list_new();

--- a/internal/llvmgen/map_clear_test.go
+++ b/internal/llvmgen/map_clear_test.go
@@ -1,0 +1,52 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// Map<K,V>.clear() — truncate to zero entries. The GC example's
+// collector reset paths (`self.forwarding.clear()` on a
+// Map<Int, GcForwardingEntry> at examples/gc/lib.osty:2506 / :4510)
+// walled the same way buf.clear() did on ty.osty — statement-form
+// map dispatcher only routed insert/remove/update/retainIf. Locks in
+// the new osty_rt_map_clear runtime call.
+func TestMapClearI64Int(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut m: Map<Int, Int> = {:}
+    m.insert(1, 2)
+    m.clear()
+    println(m.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/map_clear_i64_i64.osty"})
+	if err != nil {
+		t.Fatalf("Map<Int,Int>.clear errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_map_clear",
+		"declare void @osty_rt_map_clear(ptr)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Map.clear missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestMapClearStringPtr(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 1)
+    m.clear()
+    println(m.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/map_clear_string_int.osty"})
+	if err != nil {
+		t.Fatalf("Map<String,Int>.clear errored: %v", err)
+	}
+	if got := string(ir); !strings.Contains(got, "@osty_rt_map_clear") {
+		t.Fatalf("Map<String,Int>.clear did not invoke osty_rt_map_clear:\n%s", got)
+	}
+}

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -421,6 +421,10 @@ func mapRuntimeLenSymbol() string {
 	return llvmMapRuntimeLenSymbol()
 }
 
+func mapRuntimeClearSymbol() string {
+	return "osty_rt_map_clear"
+}
+
 func setRuntimeNewSymbol() string {
 	return llvmSetRuntimeNewSymbol()
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -1743,7 +1743,7 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	if field.Name != "insert" && field.Name != "remove" && field.Name != "update" && field.Name != "retainIf" {
+	if field.Name != "insert" && field.Name != "remove" && field.Name != "update" && field.Name != "retainIf" && field.Name != "clear" {
 		return false, nil
 	}
 	base, err := g.emitExpr(field.X)
@@ -1755,6 +1755,24 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	}
 	if field.Name == "retainIf" {
 		return true, g.emitMapRetainIfStmt(call, base, keyTyp, keyString)
+	}
+	if field.Name == "clear" {
+		if len(call.Args) != 0 {
+			return true, unsupported("call", "map.clear requires no arguments")
+		}
+		baseLoaded, err := g.loadIfPointer(base)
+		if err != nil {
+			return true, err
+		}
+		g.declareRuntimeSymbol(mapRuntimeClearSymbol(), "void", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf(
+			"  call void @%s(%s)",
+			mapRuntimeClearSymbol(),
+			llvmCallArgs([]*LlvmValue{toOstyValue(baseLoaded)}),
+		))
+		g.takeOstyEmitter(emitter)
+		return true, nil
 	}
 	if field.Name == "insert" {
 		if len(call.Args) != 2 || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -1056,7 +1056,7 @@ func (g *generator) mapMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, string, s
 		return nil, "", "", false, false
 	}
 	switch field.Name {
-	case "containsKey", "insert", "remove", "keys", "len", "isEmpty", "get", "getOr", "update", "retainIf", "mergeWith", "mapValues":
+	case "containsKey", "insert", "remove", "keys", "len", "isEmpty", "get", "getOr", "update", "retainIf", "mergeWith", "mapValues", "clear":
 	default:
 		return nil, "", "", false, false
 	}


### PR DESCRIPTION
## Summary

- GC Phase C's [examples/gc/lib.osty](examples/gc/lib.osty) exercises `Map<K,V>.clear()` in the collector reset paths — `self.forwarding.clear()` on a `Map<Int, GcForwardingEntry>` at lines 2506 and 4510 — which walled identically to the `List.clear` case that [#506](https://github.com/choiceoh/osty/pull/506) just fixed: `emitMapMethodCallStmt` only routed `insert`/`remove`/`update`/`retainIf`, so `clear` fell through with `LLVM015 [method_call_field]` / "only println calls are supported".
- Wires `Map<K,V>.clear()` through a new `osty_rt_map_clear` C runtime helper + new dispatch branch in `emitMapMethodCallStmt`, and adds `"clear"` to `mapMethodInfo`'s whitelist. The runtime takes the map's recursive mutex, sets `map->len = 0`, and releases — keys/values/capacity/kind metadata are preserved so subsequent inserts keep the same kinds and re-use the allocation; entries past `len` are no longer traced (`osty_rt_map_trace` bounds by `len`).
- `Set<T>.clear()` remains walled behind a **separate** set-literal parsing issue (`{}` parses as a `Block`, not a `Set` literal) — out of scope for this change.
- Native-only merged toolchain probe (`TestProbeNativeToolchainMerged`) stays `CLEAN` and `TestNativeToolchainMergedIsClean` passes.

## What changed

- `internal/backend/runtime/osty_runtime.c` — add `osty_rt_map_clear` next to `osty_rt_map_len`, under the map's recursive mutex.
- `internal/llvmgen/runtime_ffi.go` — add `mapRuntimeClearSymbol()`.
- `internal/llvmgen/type.go` — add `"clear"` to `mapMethodInfo`'s method-name whitelist.
- `internal/llvmgen/stmt.go` — route `clear` in `emitMapMethodCallStmt` (void return, ptr receiver, no args), mirroring the `List.clear` shape landed in [#506](https://github.com/choiceoh/osty/pull/506).
- `internal/llvmgen/map_clear_test.go` — new regression tests for `Map<Int,Int>` and `Map<String,Int>` receivers, checking both the `@osty_rt_map_clear` call site and the `declare void @osty_rt_map_clear(ptr)` declaration.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/llvmgen -run 'TestMapClear' -count=1 -v` — both new tests pass.
- [x] `go test ./internal/llvmgen -run 'TestNativeToolchainMergedIsClean' -count=1 -v` — authoritative clean gate passes.
- [x] `go test ./internal/llvmgen -run 'TestProbeNativeToolchainMerged' -count=1 -v` — still reports `NATIVE TOOLCHAIN first wall: CLEAN`.
- [x] `go test ./internal/llvmgen -run 'TestListClear|TestFieldCallDispatch' -count=1` — neighboring list/field dispatch tests still pass, no whitelist regressions.
- [x] `go test ./internal/backend -run 'TestBundledRuntime' -count=1 -short` — runtime C changes compile and link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)