### PR TITLE
Stage 5 prep: MIR-direct String intrinsics (.chars / .bytes / .len / .isEmpty)

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -304,6 +304,116 @@ func TestLLVMBackendRefusesNilIR(t *testing.T) {
 	}
 }
 
+// TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics — Stage 5 prep
+// IR-only parity check that doesn't require clang. On `mir-backend`,
+// a program using `.chars()` / `.bytes()` / `.len()` / `.isEmpty()` on
+// a String must reach the MIR-direct emitter: the backend header tag
+// is the stable tell (`osty LLVM MIR backend`), and the runtime
+// symbols must all land in the emitted text.
+//
+// Paired with TestLLVMBackendBinaryMIRBackendStringCharsBytes: that
+// one locks in the actual runtime behavior through a linked binary
+// but needs clang and may be skipped. This one always runs and
+// catches silent fallback to the legacy bridge.
+func TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    let s = "abc"
+    println(s.chars().len())
+    println(s.bytes().len())
+    println(s.len())
+    if s.isEmpty() {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	req.Features = []string{"mir-backend"}
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	irBytes, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	ir := string(irBytes)
+	if !strings.Contains(ir, "osty LLVM MIR backend") {
+		t.Fatalf("mir-backend feature did not reach MIR emitter (header missing):\n%s", ir)
+	}
+	for _, want := range []string{
+		"@osty_rt_strings_Chars",
+		"@osty_rt_strings_Bytes",
+		"@osty_rt_strings_ByteLen",
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("expected IR to contain %q, got:\n%s", want, ir)
+		}
+	}
+}
+
+// TestLLVMBackendBinaryMIRBackendStringCharsBytes — Stage 5 prep
+// parity check. With `mir-backend` opted in on object/binary emission,
+// `.chars()` / `.bytes()` / `.len()` / `.isEmpty()` on a String must
+// lower through the MIR-direct emitter (no silent fallback to the
+// legacy AST bridge). The emitted IR header is the only stable tell of
+// which path ran; this test locks in both that signal AND the linked
+// binary's output so a regression on either side surfaces immediately.
+func TestLLVMBackendBinaryMIRBackendStringCharsBytes(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	backend := LLVMBackend{}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let s = "abc"
+    println(s.chars().len())
+    println(s.bytes().len())
+    println(s.len())
+    if s.isEmpty() {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	req.Features = []string{"mir-backend"}
+
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	irBytes, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	ir := string(irBytes)
+	if !strings.Contains(ir, "osty LLVM MIR backend") {
+		t.Fatalf("mir-backend feature did not reach MIR emitter (header missing):\n%s", ir)
+	}
+	for _, want := range []string{
+		"@osty_rt_strings_Chars",
+		"@osty_rt_strings_Bytes",
+		"@osty_rt_strings_ByteLen",
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("expected IR to contain %q, got:\n%s", want, ir)
+		}
+	}
+
+	cmd := exec.Command(result.Artifacts.Binary)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", result.Artifacts.Binary, err, output)
+	}
+	if got, want := string(output), "3\n3\n3\n0\n"; got != want {
+		t.Fatalf("binary stdout = %q, want %q", got, want)
+	}
+}
+
 func TestLLVMBackendBinaryRunsBundledRuntime(t *testing.T) {
 	parallelClangBackendTest(t)
 

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -452,6 +452,13 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty:
 		return true
+	// Stage 5 prep — string → List<Char> / List<Byte> expansions that
+	// the legacy emitter routes through `osty_rt_strings_*`. Accepting
+	// them here lets `.chars()` / `.bytes()` reach the MIR emitter on
+	// `mir-backend` object/binary emission instead of falling back.
+	case mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
+		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty:
+		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
@@ -485,6 +492,14 @@ func mirIntrinsicLabel(k mir.IntrinsicKind) string {
 		return "eprint"
 	case mir.IntrinsicEprintln:
 		return "eprintln"
+	case mir.IntrinsicStringChars:
+		return "string_chars"
+	case mir.IntrinsicStringBytes:
+		return "string_bytes"
+	case mir.IntrinsicStringLen:
+		return "string_len"
+	case mir.IntrinsicStringIsEmpty:
+		return "string_is_empty"
 	case mir.IntrinsicRawNull:
 		return "raw.null"
 	}
@@ -1414,6 +1429,9 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitSetIntrinsic(i)
 	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty:
 		return g.emitBytesIntrinsic(i)
+	case mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
+		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty:
+		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
 		return g.emitChannelIntrinsic(i)
@@ -1829,6 +1847,60 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.storeIntrinsicResult(i, result)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("bytes intrinsic kind %d", i.Kind))
+}
+
+// emitStringIntrinsic dispatches String receiver intrinsics that the
+// MIR lowerer emits for stdlib method calls (`.chars()`, `.bytes()`,
+// `.len()`, `.isEmpty()`). Each maps to a runtime symbol in
+// `osty_runtime.c`'s strings family.
+//
+// The Stage 5 prep here mirrors the legacy `expr.go` dispatch: `.len`
+// calls `osty_rt_strings_ByteLen`; `.isEmpty` composes a `byte_len == 0`
+// compare instead of a dedicated runtime symbol; `.chars` / `.bytes`
+// call the list-building helpers that the runtime already ships.
+func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
+	if len(i.Args) < 1 {
+		return unsupported("mir-mvp", "string intrinsic with no receiver")
+	}
+	strOp := i.Args[0]
+	strReg, err := g.evalOperand(strOp, strOp.Type())
+	if err != nil {
+		return err
+	}
+	switch i.Kind {
+	case mir.IntrinsicStringChars:
+		sym := "osty_rt_strings_Chars"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicStringBytes:
+		sym := "osty_rt_strings_Bytes"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicStringLen:
+		sym := "osty_rt_strings_ByteLen"
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicStringIsEmpty:
+		// Runtime has no `_IsEmpty`; reuse `ByteLen` and emit an eq-0
+		// compare, matching the legacy emitter's shape.
+		sym := "osty_rt_strings_ByteLen"
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
+		em := g.ostyEmitter()
+		size := llvmCall(em, "i64", sym, []*LlvmValue{{typ: "ptr", name: strReg}})
+		result := llvmCompare(em, "eq", size, llvmIntLiteral(0))
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	}
+	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
 }
 
 // ==== concurrency intrinsics ====

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2375,6 +2375,140 @@ func TestGenerateFromMIRBytesLen(t *testing.T) {
 	}
 }
 
+// TestGenerateFromMIRStringChars verifies String.chars() dispatches
+// through `osty_rt_strings_Chars(ptr) -> ptr` — matching the legacy
+// emitter's routing so `.chars()` participates in MIR-direct object /
+// binary emission instead of forcing fallback on `mir-backend`.
+func TestGenerateFromMIRStringChars(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "toChars",
+		Return: &ir.NamedType{Name: "List", Args: []ir.Type{ir.TChar}, Builtin: true},
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+				Name:     "chars",
+				T:        &ir.NamedType{Name: "List", Args: []ir.Type{ir.TChar}, Builtin: true},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_chars.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_Chars(ptr)",
+		"call ptr @osty_rt_strings_Chars(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRStringBytes — same as StringChars but for the
+// bytes family; the runtime symbol is `osty_rt_strings_Bytes`.
+func TestGenerateFromMIRStringBytes(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "toBytes",
+		Return: &ir.NamedType{Name: "List", Args: []ir.Type{ir.TByte}, Builtin: true},
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+				Name:     "bytes",
+				T:        &ir.NamedType{Name: "List", Args: []ir.Type{ir.TByte}, Builtin: true},
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_bytes.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_Bytes(ptr)",
+		"call ptr @osty_rt_strings_Bytes(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRStringLen verifies String.len() dispatches
+// through `osty_rt_strings_ByteLen(ptr) -> i64` (matching
+// `llvmStringRuntimeByteLenSymbol()` the legacy emitter already uses).
+func TestGenerateFromMIRStringLen(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "sz",
+		Return: ir.TInt,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+				Name:     "len",
+				T:        ir.TInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_len.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_strings_ByteLen(ptr)",
+		"call i64 @osty_rt_strings_ByteLen(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRStringIsEmpty — `.isEmpty()` composes
+// `byte_len == 0` instead of a dedicated runtime symbol, matching the
+// legacy emitter in expr.go. That gives two artifacts the test can
+// lock in: the `ByteLen` call and an `icmp eq i64 %..., 0`.
+func TestGenerateFromMIRStringIsEmpty(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "blank",
+		Return: ir.TBool,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+				Name:     "isEmpty",
+				T:        ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/string_empty.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_strings_ByteLen(ptr)",
+		"call i64 @osty_rt_strings_ByteLen(",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateFromMIRBytesIsEmpty verifies Bytes.isEmpty() dispatches
 // through `osty_rt_bytes_is_empty(ptr) -> i1`.
 func TestGenerateFromMIRBytesIsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes a concrete `mir-backend` parity gap so Stage 5 (`legacyFileFromModule` removal) keeps gaining leverage. Before this change, any program calling `.chars()` / `.bytes()` / `.len()` / `.isEmpty()` on a String forced the backend dispatcher to catch `ErrUnsupported` from the MIR emitter and fall back to the legacy HIR→AST bridge — quietly, with no test signal. Toolchain code uses these methods heavily, so realistic programs running under `Features: [\"mir-backend\"]` on object / binary emission were regressing to the legacy path on the first `.chars()` call.

- **`internal/llvmgen/mir_generator.go`** — `isSupportedIntrinsic` and `mirIntrinsicLabel` learn `IntrinsicStringChars` / `IntrinsicStringBytes` / `IntrinsicStringLen` / `IntrinsicStringIsEmpty`. A new `emitStringIntrinsic` routes each to the runtime symbol the legacy emitter (`expr.go`) already uses: `osty_rt_strings_Chars` / `_Bytes` / `_ByteLen`. `.isEmpty()` composes `ByteLen == 0` via `llvmCompare(eq, len, 0)` — same shape as the legacy path, no new runtime symbol needed.
- **`internal/llvmgen/mir_generator_test.go`** — four new IR-level regressions (`TestGenerateFromMIRString{Chars,Bytes,Len,IsEmpty}`) lock in both the `declare` preamble and the `call` site so a future refactor can't silently drop the dispatch.
- **`internal/backend/llvm_test.go`** — two backend-level tests:
  - `TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics` always runs (no clang), asserts the emitted IR carries the `osty LLVM MIR backend` header (the stable tell of which path ran) and that all three runtime symbols land in the text. This is the fallback-detector: if a future change re-breaks MIR on these intrinsics, the header regression surfaces immediately instead of hiding behind silent legacy success.
  - `TestLLVMBackendBinaryMIRBackendStringCharsBytes` does a full link + exec under `Features: [\"mir-backend\"]` and checks the program prints the expected chars/bytes/len values. Requires clang; skipped otherwise, matching the existing parallel-clang test style.

## Why this gap

Re-reading `docs/mir_design.md` Stage 4 / Stage 5 notes plus `mir_generator.go`'s `isSupportedIntrinsic` whitelist: object/binary emission with `mir-backend` feature on still fell back for any String method that lowers to a `MIR IntrinsicString*`. The MIR lowerer already emits these kinds (`stringIntrinsicForMethod` in `internal/mir/lower.go`), the runtime already ships the C symbols, and the legacy emitter already knows the ABI — the only missing piece was the MIR-emitter dispatch. Four cases plus one dispatch function closes four language-level receiver methods in one shot.

`.chars()` / `.bytes()` specifically unblock `for c in s.chars() { ... }` style iteration through the MIR emitter, which is a Tier A self-host blocker (LLVM_MIGRATION_PLAN.md: \"A-3 String concat/slice/interpolation\" + \"A-6 std.strings\").

## What this does NOT do

Intentionally scoped to four intrinsics that have runtime symbols in-tree and fit the single-receiver pattern. The remaining String MIR intrinsics (`Contains` / `StartsWith` / `EndsWith` / `Split` / `Trim` / `Replace` / `Concat` / `IndexOf` / `ToUpper` / `ToLower`) are a natural next PR — `Contains` and friends need the two-arg evalOperand pattern, `Split` needs the `List<String>` return handling, and a couple have no runtime symbol yet. Separately, Option / Result intrinsics (`IsSome` / `Unwrap` etc.) are a different follow-up since their layout handling interacts with the 2-word enum convention rather than the string runtime.

## Test plan

- [x] `go test ./internal/llvmgen/ -run TestGenerateFromMIRString -count=1` — all four new IR tests pass.
- [x] `go test ./internal/backend/ -run TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics -count=1` — IR-only backend test passes, confirms MIR header + runtime symbols.
- [x] `go test -short ./internal/llvmgen/ ./internal/backend/ ./internal/mir/` — no new failures. Two pre-existing failures (`TestProbeSmallTailLower/toolchain/ty.osty`, `TestNativeToolchainMergedIsClean`) reproduce cleanly on `git stash`, so they are orthogonal to this change.
- [ ] `TestLLVMBackendBinaryMIRBackendStringCharsBytes` — requires clang on PATH; locally skipped. CI with clang should exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)