### PR TITLE
feat(llvmgen): Option B Phase 2g — user m.forEach(f) dispatch routes to specialized method

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -72,6 +72,42 @@ fn main() {}
 	}
 }
 
+// TestPhase2gUserCallsiteDispatchesToSpecializedMethod locks the
+// Phase 2g fix: when user code calls `m.forEach(f)` /
+// `m.getOr(k, d)` / etc. on a `Map<String, Int>` receiver,
+// `userCallTarget` now consults `specializedBuiltinMangledForSurface`
+// to find the specialized method registered under the `_ZTSN…`
+// mangled owner type — instead of walling at the surface-typed
+// `ptr` receiver with "no methods registered". The inner wall
+// from the specialized body (f(key, value) → Ident call) is a
+// separate Phase 2h concern.
+func TestPhase2gUserCallsiteDispatchesToSpecializedMethod(t *testing.T) {
+	src := `fn printEntry(k: String, v: Int) { println(v) }
+fn walk(m: Map<String, Int>) {
+    m.forEach(printEntry)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2g_foreach.osty",
+		Source:      []byte(src),
+	}
+	_, err := llvmgen.GenerateModule(monoMod, opts)
+	// Phase 2g advances the wall past the user-side `m.forEach(…)`
+	// callsite (which previously failed at `got *ast.FieldExpr at
+	// 3:5`) into the specialized forEach body's indirect call
+	// (`got *ast.Ident at 346:13`). A regression would surface the
+	// earlier form.
+	if err != nil && strings.Contains(err.Error(), "got *ast.FieldExpr") {
+		t.Fatalf("user callsite m.forEach(f) regressed to FieldExpr wall — specialized dispatch broken: %v", err)
+	}
+	if err != nil {
+		t.Logf("Phase 2 pipeline still incomplete past user callsite (expected): %v", err)
+	}
+}
+
 // TestPhase2fOptionIsSomeLowersAsNullCheck locks the Phase 2f fix:
 // `.isSome()` / `.isNone()` calls on a receiver whose source type
 // is `T?` (OptionalType) now lower directly to an LLVM null check,

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -4514,7 +4514,22 @@ func (g *generator) userCallTarget(call *ast.CallExpr) (*fnSig, ast.Expr, bool, 
 		}
 		methods := g.methods[baseInfo.typ]
 		if methods == nil {
-			return nil, nil, false, nil
+			// Phase 2g: built-in container method dispatch.
+			// Surface-level receivers (Map<K, V>, List<T>, …)
+			// carry baseInfo.typ == "ptr" because Phase 2c
+			// re-associates the mangled specialization back to the
+			// surface form for intrinsic dispatch. That leaves the
+			// plain `methodsByType[baseInfo.typ]` lookup missing the
+			// specialized struct's bodied methods (forEach, getOr,
+			// update, …). Try the specialized owner type next.
+			if baseSrc, srcOk := g.staticExprSourceType(fn.X); srcOk {
+				if mangledTyp, ok := specializedBuiltinMangledForSurface(baseSrc); ok {
+					methods = g.methods[mangledTyp]
+				}
+			}
+			if methods == nil {
+				return nil, nil, false, nil
+			}
 		}
 		sig := methods[fn.Name]
 		if sig == nil {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -264,6 +264,88 @@ func specializedBuiltinMetaFor(ownerName string) (specializedBuiltinMeta, bool) 
 	return info, ok
 }
 
+// specializedBuiltinMangledForSurface returns the mangled struct/enum
+// name (the monomorphizer's `_ZTS…` key) matching a surface AST
+// NamedType like `Map<String, Int>`. Used by userCallTarget to
+// dispatch user-level method calls (`m.forEach(f)`, `m.getOr(...)`)
+// to the specialized method set — Phase 2c's surface re-association
+// leaves baseInfo.typ = "ptr" for runtime containers, so the usual
+// `methodsByType[baseInfo.typ]` lookup misses. Returns (ownerLLVMType,
+// true) so callers can index directly into g.methods.
+func specializedBuiltinMangledForSurface(surface ast.Type) (string, bool) {
+	if currentSpecializedBuiltinSurfaces == nil || surface == nil {
+		return "", false
+	}
+	surfaceNamed, ok := surface.(*ast.NamedType)
+	if !ok || len(surfaceNamed.Path) != 1 {
+		return "", false
+	}
+	sourceName := surfaceNamed.Path[0]
+	for mangled, surf := range currentSpecializedBuiltinSurfaces {
+		if surf.Source != sourceName {
+			continue
+		}
+		if len(surf.Args) != len(surfaceNamed.Args) {
+			continue
+		}
+		if !surfaceBuiltinArgsMatch(surf.Args, surfaceNamed.Args) {
+			continue
+		}
+		return "%" + mangled, true
+	}
+	return "", false
+}
+
+// surfaceBuiltinArgsMatch compares IR-level type args (carried on the
+// specialized struct) against an AST-level args list (pulled from the
+// user-side surface reference). A name-level match is sufficient for
+// the built-in shapes we care about (primitive idents like `Int` /
+// `String` / `Bool`, plus nested NamedType references). Nested
+// generic args recurse so Map<String, List<Int>> round-trips cleanly.
+func surfaceBuiltinArgsMatch(irArgs []ostyir.Type, astArgs []ast.Type) bool {
+	if len(irArgs) != len(astArgs) {
+		return false
+	}
+	for i := range irArgs {
+		irName := ostyirTypeName(irArgs[i])
+		astNamed, ok := astArgs[i].(*ast.NamedType)
+		if !ok || len(astNamed.Path) != 1 {
+			return false
+		}
+		if irName != astNamed.Path[0] {
+			return false
+		}
+		// Recurse into nested generics (e.g. List<Int> in Map<String, List<Int>>).
+		irNested := ostyirTypeArgs(irArgs[i])
+		if !surfaceBuiltinArgsMatch(irNested, astNamed.Args) {
+			return false
+		}
+	}
+	return true
+}
+
+// ostyirTypeName extracts the source-level name from an IR type for
+// surface comparison. Primitives come through as *ostyir.PrimType
+// (mapped via its String()), named refs via *ostyir.NamedType.
+func ostyirTypeName(t ostyir.Type) string {
+	switch x := t.(type) {
+	case *ostyir.PrimType:
+		return x.String()
+	case *ostyir.NamedType:
+		return x.Name
+	}
+	return ""
+}
+
+// ostyirTypeArgs returns the nested type-args of an IR type, or nil
+// for types without args (primitives, optional wrappers, etc.).
+func ostyirTypeArgs(t ostyir.Type) []ostyir.Type {
+	if named, ok := t.(*ostyir.NamedType); ok {
+		return named.Args
+	}
+	return nil
+}
+
 // buildSpecializedBuiltinMeta projects each mangled surface entry
 // into an llvmgen-side metadata shape. Uses the legacy type bridge to
 // turn IR type args into AST types, then classifies per source name:


### PR DESCRIPTION
## Summary

Seventh peel of Option B's Phase 2 walls. User-level method calls on a `Map<K, V>` / `List<T>` / ... receiver (e.g. `m.forEach(printEntry)`, `m.getOr(k, 0)`) now resolve to the specialized bodied method registered under the monomorphized `_ZTSN…` owner type. Previously this walled with `LLVM015 call: only println calls are supported (got *ast.FieldExpr at <user line>)` because Phase 2c's surface re-association made `baseInfo.typ == "ptr"`, leaving `methodsByType[baseInfo.typ]` empty.

End-to-end probe advances to the next wall — `LLVM015 ... got *ast.Ident at 346:13 (offset 10261)` inside the specialized `Map.forEach` body's `f(key, value)` indirect call. That's Phase 2h's scope: fn-value binding/lookup visibility inside specialized method bodies.

Sequence so far:
- [#483](https://github.com/choiceoh/osty/pull/483) — Phase 1
- [#494](https://github.com/choiceoh/osty/pull/494) — Phase 2a/b
- [#499](https://github.com/choiceoh/osty/pull/499) — Phase 2c
- [#504](https://github.com/choiceoh/osty/pull/504) — Phase 2d
- [#505](https://github.com/choiceoh/osty/pull/505) — Phase 2e
- [#508](https://github.com/choiceoh/osty/pull/508) — Phase 2f
- **this PR** — Phase 2g

## What landed

### 1. `specializedBuiltinMangledForSurface`
`internal/llvmgen/ir_module.go`: inverse of the per-module `currentSpecializedBuiltinSurfaces` lookup. Takes an AST surface type (`Map<String, Int>`) and returns the corresponding specialized owner's LLVM type (e.g. `%_ZTSN4main3MapISslEE`). Helper `surfaceBuiltinArgsMatch` compares IR-level args against the surface reference, recursing for nested generics (`Map<String, List<Int>>`).

### 2. `userCallTarget` fallback
`internal/llvmgen/expr.go`: when the straightforward `methodsByType[baseInfo.typ]` lookup returns nil for a FieldExpr call, try the specialized owner type. Bridge that makes `m.forEach(printEntry)` dispatch to `_ZTSN4main3MapISslEE__forEach` instead of walling at LLVM015.

### 3. Regression test
`TestPhase2gUserCallsiteDispatchesToSpecializedMethod` locks the fix: a regression would surface as `got *ast.FieldExpr at <user line>`, which the test gates on.

## Not in this PR (Phase 2h)

Inside specialized `Map.forEach` / `any` / `all` / etc. bodies, the fn-value parameter call `f(key, value)` still trips `got *ast.Ident at 346:13`. The `f` binding's fnSigRef is set at emit time (verified with debug instrumentation) but the call dispatch doesn't find it. Needs investigation into how the specialized method's scope is constructed vs a plain user fn — likely a bind-ordering or scope-visibility issue specific to the specialized emission path.

## Test plan

- [x] `go test ./internal/backend -run TestPhase2 -count=1 -v` — 7 PASS, 2 documented-skip
- [x] `go test ./internal/ir -count=1 -short`
- [x] `go test ./internal/llvmgen -count=1 -short` (skipping two pre-existing unrelated failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)