### PR TITLE
fix(selfhost): normalize CRLF at Lex/Run + MIR-path probe twin

### DIFF
--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/mir"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 // mergeToolchainSources concatenates toolchain files in order into a
@@ -210,6 +215,95 @@ func TestProbeNativeToolchainMerged(t *testing.T) {
 	}
 	_, err = generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/toolchain_native_merged.osty"})
 	t.Logf("NATIVE TOOLCHAIN first wall: %s", formatWall(err))
+}
+
+// TestProbeNativeToolchainMergedMIR is the MIR-path twin of
+// TestProbeNativeToolchainMerged. The AST-only probe uses
+// `generateFromAST`, which bypasses the IR→MIR lowering and measures the
+// legacy HIR→AST bridge surface. The real backend
+// (internal/backend/llvm.go) dispatches MIR-first and only falls back to
+// the legacy path on ErrUnsupported, so the AST probe's wall is
+// systematically more pessimistic than the self-host critical path.
+//
+// This probe runs the merged native toolchain through the full
+// parse → resolve → check → ir.Lower → ir.Monomorphize → mir.Lower →
+// GenerateFromMIR pipeline and reports the first stage that walls
+// (along with its message). Info-only.
+//
+// NOTE: the toolchain currently has ~949 checker errors, so ir.Lower /
+// Monomorphize will produce issues; the probe logs the count and keeps
+// going so we can see where the MIR emitter itself walls.
+func TestProbeNativeToolchainMergedMIR(t *testing.T) {
+	if testing.Short() {
+		t.Skip("info-only; slow; skipped in -short")
+	}
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs root: %v", err)
+	}
+	dir := filepath.Join(root, "toolchain")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read toolchain: %v", err)
+	}
+	var files []string
+	var skipped []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") || strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		if isBootstrapOnlyOstyFile(src) {
+			skipped = append(skipped, name)
+			continue
+		}
+		files = append(files, name)
+	}
+	if len(skipped) > 0 {
+		t.Logf("bootstrap-only files skipped (%d): %s", len(skipped), strings.Join(skipped, ", "))
+	}
+	merged := mergeToolchainSources(t, root, files)
+	file, _ := parser.ParseDiagnostics(merged)
+	if file == nil {
+		t.Fatalf("native-toolchain merged parse returned nil (%d files, %d bytes)", len(files), len(merged))
+	}
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        merged,
+		Privileged:    true,
+	})
+	if chk != nil {
+		t.Logf("check: %d diag(s)", len(chk.Diags))
+	}
+	mod, irIssues := ir.Lower("main", file, res, chk)
+	if len(irIssues) > 0 {
+		t.Logf("ir.Lower: %d issue(s); first = %v", len(irIssues), irIssues[0])
+	}
+	if mod == nil {
+		t.Fatalf("ir.Lower returned nil module")
+	}
+	monoMod, monoErrs := ir.Monomorphize(mod)
+	if len(monoErrs) > 0 {
+		t.Logf("ir.Monomorphize: %d err(s); first = %v", len(monoErrs), monoErrs[0])
+	}
+	if monoMod == nil {
+		t.Fatalf("ir.Monomorphize returned nil module")
+	}
+	mirMod := mir.Lower(monoMod)
+	if mirMod == nil {
+		t.Fatalf("mir.Lower returned nil module")
+	}
+	_, err = GenerateFromMIR(mirMod, Options{PackageName: "main", SourcePath: "/tmp/toolchain_native_merged_mir.osty"})
+	t.Logf("NATIVE TOOLCHAIN (MIR) first wall: %s", formatWall(err))
 }
 
 // TestProbeDiagnosticMergedWithLexer checks whether the LLVM011 wall on

--- a/internal/llvmgen/small_tail_probe_test.go
+++ b/internal/llvmgen/small_tail_probe_test.go
@@ -38,7 +38,13 @@ func TestProbeSmallTailLower(t *testing.T) {
 		{"toolchain/scaffold_policy.osty", ""},
 		{"toolchain/semver.osty", ""},
 		{"toolchain/test_runner.osty", ""},
-		{"toolchain/ty.osty", ""},
+		// ty.osty calls checkHashKey (defined in check_env.osty), so a
+		// single-file probe walls on LLVM015 cross-module scope. The
+		// previous "clean" status was a false positive from CRLF
+		// mis-lexing; once selfhost.Lex / Run normalize \r\n the call
+		// appears with its real *ast.Ident shape and the emitter
+		// reports the unresolved callee honestly.
+		{"toolchain/ty.osty", "LLVM015"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -13,10 +13,23 @@ import (
 // Lex runs the bootstrapped pure-Osty lexer and adapts its stream to the
 // compiler's public token surface.
 func Lex(src []byte) ([]token.Token, []*diag.Diagnostic, []token.Comment) {
-	text := string(src)
+	text := normalizeSourceNewlines(string(src))
 	rt := newRuneTable(text)
 	stream := frontendLexStream(text)
 	return adaptLexStream(rt, stream, ostyLexFactsFromStream(text, stream))
+}
+
+// normalizeSourceNewlines rewrites \r\n and lone \r to \n, mirroring
+// the self-hosted ostyNormalizeSource wrapper so offsets reported by
+// the Go-facing Lex/Run entry points match what the Osty-authored
+// front-end normalizer would have produced.
+func normalizeSourceNewlines(text string) string {
+	if !strings.ContainsRune(text, '\r') {
+		return text
+	}
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return text
 }
 
 // FrontendRun is one complete self-hosted front-end pass over a source file.
@@ -44,7 +57,7 @@ func Run(src []byte) *FrontendRun {
 }
 
 func runFrontend(src []byte, adaptTokens bool) *FrontendRun {
-	text := string(src)
+	text := normalizeSourceNewlines(string(src))
 	rt := newRuneTable(text)
 	stream := frontendLexStream(text)
 	frontToks := frontTokensFromSource(text, stream)


### PR DESCRIPTION
## Summary

- **CRLF normalization**: `selfhost.Lex` and `selfhost.runFrontend` now rewrite `\r\n` and lone `\r` to `\n` before lexing, matching what the Osty-authored `ostyNormalizeSource` wrapper already does for the rich-token flow. All 76 `toolchain/*.osty` files on this tree are CRLF; without normalization the public token stream disagreed with the checker's view of the source, and IR lowering silently fell back to `ErrType` for if-expression temps. `parseAiRepairMode` alone had 11 `<error>`-typed locals despite zero checker diagnostics.
- **MIR-path probe**: adds `TestProbeNativeToolchainMergedMIR` as the twin of `TestProbeNativeToolchainMerged`. The AST-only probe uses `generateFromAST`, which skips `ir.Lower` → `ir.Monomorphize` → `mir.Lower`; the real backend (`internal/backend/llvm.go`) is MIR-first with automatic fallback on `ErrUnsupported`. Having both probes surface walls on the same merged source separates "legacy HIR→AST coverage gap" from "MIR-direct coverage gap."
- **Ratchet update**: `toolchain/ty.osty` drops from CLEAN to `LLVM015` in `TestProbeSmallTailLower`. It calls `checkHashKey` (defined in `check_env.osty`), so the single-file probe can't resolve the callee. Previous CLEAN status was a CRLF artifact.

## Why

The MIR-path probe first walled on `LLVM000 unsupported local type <error> in parseAiRepairMode` — a function with zero checker diagnostics. Isolating the minimal reproducer showed the exact same source inline (LF) produced 0 `<error>` locals, while loading the same bytes from disk (CRLF) produced 4. Root cause: `selfhost.Lex` / `runFrontend` never normalized CRLF even though `ostyLexSource` (used by the Osty-authored rich-token flow) does. Offsets and token boundaries from the public adapter drifted, silently poisoning the checker→IR type map.

After the fix the MIR probe wall advances to `rvalue *mir.LenRV not yet supported in collectDecls` — a real MIR-gen coverage gap that's now the legitimate next target.

## Test plan

- [x] `just front` passes (lexer, parser, resolve, check, diag, format, lint)
- [x] `TestProbeNativeToolchainMergedMIR` reports the LenRV wall (not the `<error>` artifact)
- [x] `TestProbeSmallTailLower` ratchet passes with updated `ty.osty` expectation
- [x] Minimal LF vs CRLF reproducer confirms fix clears the `<error>` cascade
- [ ] Backend-heavy tests (`internal/backend/...`) — not run in this PR; skipping per the session's fast-iteration brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)