### PR TITLE
refactor: mirPrintModule을 List<String>+strings.join canonical 패턴으로

### DIFF
--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -26,6 +26,8 @@
 // the flat struct keyed by the kind. Readers must check `kind` before
 // interpreting kind-specific fields.
 
+use std.strings as strings
+
 // ====================================================================
 // Enum kinds
 // ====================================================================
@@ -1321,18 +1323,18 @@ pub fn mirCountReachable(func: MirFunction) -> Int {
 /// close to Rust MIR dumps. Used by tests and when inspecting backend
 /// output during development.
 pub fn mirPrintModule(m: MirModule) -> String {
-    let mut out = ""
-    out = out + "module \"" + m.packageName + "\"\n"
+    let mut parts: List<String> = []
+    parts.push("module \"{m.packageName}\"\n")
     for u in m.uses {
-        out = out + mirIndent(1) + mirPrintUse(u) + "\n"
+        parts.push("{mirIndent(1)}{mirPrintUse(u)}\n")
     }
     for g in m.globals {
-        out = out + "\n" + mirPrintGlobal(g)
+        parts.push("\n{mirPrintGlobal(g)}")
     }
     for func in m.functions {
-        out = out + "\n" + mirPrintFunction(func)
+        parts.push("\n{mirPrintFunction(func)}")
     }
-    out
+    strings.join(parts, "")
 }
 
 /// mirPrintFunction renders one function using the same format as


### PR DESCRIPTION
## 요약

`toolchain/mir.osty`의 `mirPrintModule`에서 `out = out + ...` 누적 패턴(문자열 concat O(n²))을 제거하고, `core.osty:1513` `corePrintModule`이 사용하는 `List<String>` + `strings.join` canonical 패턴으로 맞췄습니다.

## 배경

- PR #479 ("kill remaining O(n^2) string concat")에서 정리했던 동일 패턴이 새 포팅분(MIR 프린터)에 재발
- `corePrintModule` (toolchain/core.osty:1513~1533)이 이미 canonical 패턴으로 작성되어 있고, `docgen.osty` / `ast_lower.osty` / `frontend.osty` / `parser.osty` / `formatter_ast.osty` 등 다수 파일이 같은 스타일
- 관련 가이드: `feedback_stdlib_rhythm.md` — stdlib 리듬 보존

## 변경 내용

- `toolchain/mir.osty` 상단에 `use std.strings as strings` 추가
- `mirPrintModule` 본문을 `List<String>` + `strings.push()` + `strings.join(parts, "")` 형태로 재작성
- 출력은 원본과 **바이트 단위로 동일** — 기존 문자열 조각의 trailing `\n`을 그대로 보존하므로 separator는 빈 문자열 사용 (core는 단일 라인이라 `"\n"` separator 사용, mir은 multi-line 조각이라 `""`가 올바른 선택)

## 검증

- `just front` — 프론트엔드 전체 통과 (lexer/parser/resolve/check/diag/format/lint/pipeline)
- `.bin/osty check toolchain/mir.osty` — 0 error
- `mir_test.osty`의 기존 `stringContains` 기반 어서션은 출력이 바이트 단위로 동일하므로 영향 없음 (해당 파일에 남아 있는 `mirModuleLookupFunction` 미정의 에러는 이 PR과 무관한 병렬 작업 상태)

## 스코프

`mirPrintFunction` / `mirPrintBlock` / `mirPrintInstr` / `mirPrintTerm`(switchInt) / `mirPrintOperandList`에도 같은 `out = out + ...` 패턴이 남아 있습니다. CLAUDE.md의 "bug fix doesn't need surrounding cleanup" 원칙에 따라 이번 PR에서는 **유저가 명시적으로 지적한 `mirPrintModule`만** 정리했습니다. 후속으로 별도 PR에서 나머지 printer 함수들을 같은 패턴으로 정렬할 수 있습니다.

> 참고: stdlib `strings.join` 자체도 현재 O(n²) 구현(`out = "{out}{sep}{parts[i]}"` 루프, `internal/stdlib/modules/strings.osty:984`)입니다. 이 PR은 call-site를 canonical 패턴으로 맞추는 alignment 작업이며, 실제 O(n²) 제거는 mutable `Bytes` primitive 또는 `strings.join` intrinsic 경로로 별도 해결할 사안입니다.

## Test plan

- [x] `just front` 전 패키지 pass
- [x] `osty check toolchain/mir.osty` clean
- [x] 수동 byte-by-byte diff 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)