### PR TITLE
refactor: MIR printer 나머지 함수도 List<String>+strings.join 패턴으로

### DIFF
--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -1340,18 +1340,18 @@ pub fn mirPrintModule(m: MirModule) -> String {
 /// mirPrintFunction renders one function using the same format as
 /// mirPrintModule.
 pub fn mirPrintFunction(func: MirFunction) -> String {
-    let mut out = ""
-    out = out + "fn " + func.name + "("
+    let mut parts: List<String> = []
+    parts.push("fn {func.name}(")
     let mut first = true
     for paramId in func.params {
         if !(first) {
-            out = out + ", "
+            parts.push(", ")
         }
         first = false
         let loc = mirFunctionLocal(func, paramId)
-        out = out + "_" + mirIntToString(loc.id) + ": " + loc.typ
+        parts.push("_{mirIntToString(loc.id)}: {loc.typ}")
     }
-    out = out + ") -> " + func.returnType + " \{\n"
+    parts.push(") -> {func.returnType} \{\n")
     // Locals declaration block (skip parameters; they are in the signature)
     for loc in func.locals {
         if loc.isParam {
@@ -1359,17 +1359,15 @@ pub fn mirPrintFunction(func: MirFunction) -> String {
         }
         let annot = mirLocalAnnotation(loc)
         let displayName = if loc.name == "" { "_" } else { loc.name }
-        out = out + mirIndent(1) + "let" + annot + " _"
-            + mirIntToString(loc.id) + ": " + loc.typ
-            + "  // " + displayName + "\n"
+        parts.push("{mirIndent(1)}let{annot} _{mirIntToString(loc.id)}: {loc.typ}  // {displayName}\n")
     }
     if !(func.isExternal) {
         for bb in func.blocks {
-            out = out + "\n" + mirPrintBlock(bb, func)
+            parts.push("\n{mirPrintBlock(bb, func)}")
         }
     }
-    out = out + "\}\n"
-    out
+    parts.push("\}\n")
+    strings.join(parts, "")
 }
 
 fn mirLocalAnnotation(loc: MirLocal) -> String {
@@ -1404,16 +1402,17 @@ fn mirPrintGlobal(g: MirGlobal) -> String {
 }
 
 fn mirPrintBlock(bb: MirBasicBlock, func: MirFunction) -> String {
-    let mut out = mirIndent(1) + "bb" + mirIntToString(bb.id) + ":\n"
+    let mut parts: List<String> = []
+    parts.push("{mirIndent(1)}bb{mirIntToString(bb.id)}:\n")
     for instr in bb.instrs {
-        out = out + mirIndent(2) + mirPrintInstr(instr, func) + "\n"
+        parts.push("{mirIndent(2)}{mirPrintInstr(instr, func)}\n")
     }
     if bb.hasTerm {
-        out = out + mirIndent(2) + mirPrintTerm(bb.term, func) + "\n"
+        parts.push("{mirIndent(2)}{mirPrintTerm(bb.term, func)}\n")
     } else {
-        out = out + mirIndent(2) + "<missing terminator>\n"
+        parts.push("{mirIndent(2)}<missing terminator>\n")
     }
-    out
+    strings.join(parts, "")
 }
 
 fn mirPrintInstr(i: MirInstr, func: MirFunction) -> String {
@@ -1450,21 +1449,14 @@ fn mirPrintTerm(t: MirTerm, func: MirFunction) -> String {
             + " -> [true: bb" + mirIntToString(t.thenBlock)
             + ", false: bb" + mirIntToString(t.elseBlock) + "]",
         MirTermSwitchInt -> {
-            let mut arms = ""
-            let mut first = true
+            let mut armParts: List<String> = []
             for c in t.cases {
-                if !(first) {
-                    arms = arms + ", "
-                }
-                first = false
                 let label = if c.label == "" { mirIntToString(c.value) } else { c.label }
-                arms = arms + label + " -> bb" + mirIntToString(c.target)
+                armParts.push("{label} -> bb{mirIntToString(c.target)}")
             }
-            if !(first) {
-                arms = arms + ", "
-            }
-            arms = arms + "_ -> bb" + mirIntToString(t.target)
-            "switchInt " + mirPrintOperand(t.cond, func) + " -> [" + arms + "]"
+            armParts.push("_ -> bb{mirIntToString(t.target)}")
+            let arms = strings.join(armParts, ", ")
+            "switchInt {mirPrintOperand(t.cond, func)} -> [{arms}]"
         },
         MirTermReturn -> "return",
         MirTermUnreachable -> "unreachable",
@@ -1473,11 +1465,12 @@ fn mirPrintTerm(t: MirTerm, func: MirFunction) -> String {
 }
 
 fn mirPrintPlace(p: MirPlace, func: MirFunction) -> String {
-    let mut out = "_" + mirIntToString(p.local)
+    let mut parts: List<String> = []
+    parts.push("_{mirIntToString(p.local)}")
     for proj in p.projections {
-        out = out + mirPrintProjection(proj, func)
+        parts.push(mirPrintProjection(proj, func))
     }
-    out
+    strings.join(parts, "")
 }
 
 fn mirPrintProjection(proj: MirProjection, func: MirFunction) -> String {
@@ -1519,16 +1512,11 @@ fn mirPrintOperand(op: MirOperand, func: MirFunction) -> String {
 }
 
 fn mirPrintOperandList(ops: List<MirOperand>, func: MirFunction) -> String {
-    let mut out = ""
-    let mut first = true
+    let mut parts: List<String> = []
     for op in ops {
-        if !(first) {
-            out = out + ", "
-        }
-        first = false
-        out = out + mirPrintOperand(op, func)
+        parts.push(mirPrintOperand(op, func))
     }
-    out
+    strings.join(parts, ", ")
 }
 
 fn mirPrintConst(c: MirConst) -> String {

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -26,6 +26,8 @@
 // the flat struct keyed by the kind. Readers must check `kind` before
 // interpreting kind-specific fields.
 
+use std.strings as strings
+
 // ====================================================================
 // Enum kinds
 // ====================================================================
@@ -1321,18 +1323,18 @@ pub fn mirCountReachable(func: MirFunction) -> Int {
 /// close to Rust MIR dumps. Used by tests and when inspecting backend
 /// output during development.
 pub fn mirPrintModule(m: MirModule) -> String {
-    let mut out = ""
-    out = out + "module \"" + m.packageName + "\"\n"
+    let mut parts: List<String> = []
+    parts.push("module \"{m.packageName}\"\n")
     for u in m.uses {
-        out = out + mirIndent(1) + mirPrintUse(u) + "\n"
+        parts.push("{mirIndent(1)}{mirPrintUse(u)}\n")
     }
     for g in m.globals {
-        out = out + "\n" + mirPrintGlobal(g)
+        parts.push("\n{mirPrintGlobal(g)}")
     }
     for func in m.functions {
-        out = out + "\n" + mirPrintFunction(func)
+        parts.push("\n{mirPrintFunction(func)}")
     }
-    out
+    strings.join(parts, "")
 }
 
 /// mirPrintFunction renders one function using the same format as


### PR DESCRIPTION
## 요약

[#517](https://github.com/choiceoh/osty/pull/517)의 follow-up. 같은 파일(`toolchain/mir.osty`) 안의 나머지 printer 함수들에도 canonical 패턴을 적용해서 두 스타일(`out = out + ...` vs `List<String>`+`strings.join`)이 공존하지 않도록 정리.

## 대상

- `mirPrintFunction` — params / locals / blocks 3중 루프
- `mirPrintBlock` — instrs 루프
- `mirPrintTerm` (switchInt arm) — arms 루프. `first` sentinel 제거하고 `strings.join(armParts, ", ")`로 단순화
- `mirPrintPlace` — projections 루프
- `mirPrintOperandList` — ops 루프. `first` sentinel 제거

## 건드리지 않은 곳 (의도적)

- `mirPrintGlobal` — 루프 없음, 고정 concat 개수
- `mirIndent` — `level` 루프이지만 호출 시 level=1~2로 bounded
- `mirIntToString` — `digits` 루프, Int64 자릿수 상한

## 검증

- `osty check toolchain/mir.osty` → 0 error
- `just front` → 전 패키지 pass
- 출력은 원본과 **바이트 단위 동일** — trailing `\n` 배치 보존, separator는 multi-line 조각은 `""`로, `", "` 결합 필요한 곳만 `strings.join(parts, ", ")`

## 배경

- [#517](https://github.com/choiceoh/osty/pull/517)에서 유저가 지적한 `mirPrintModule`만 우선 정리 (CLAUDE.md 스코프 규율 준수)
- 이 PR은 같은 파일 내 일관성 회복을 위한 후속 작업
- stdlib `strings.join` 자체가 O(n²)인 점은 별도 사안 (mutable `Bytes` primitive 또는 intrinsic 경로로 해결)

## Base

[#517](https://github.com/choiceoh/osty/pull/517)이 먼저 머지되어야 충돌 없이 적용됩니다. 둘 다 `toolchain/mir.osty`만 수정하므로 머지 순서만 맞으면 됨.

## Test plan

- [x] `just front` 전 패키지 pass
- [x] `osty check toolchain/mir.osty` clean
- [x] 수동 byte-by-byte diff 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)