### PR TITLE
refactor(toolchain): consolidate list-scan helpers, retire listDropLastInt

### DIFF
--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -277,15 +277,6 @@ fn isPodPrimitiveName(name: String) -> Bool {
         || name == "RawPtr"
 }
 
-fn stringListContainsName(xs: List<String>, name: String) -> Bool {
-    for s in xs {
-        if s == name {
-            return true
-        }
-    }
-    false
-}
-
 fn isPodType(arena: AstArena, typeIdx: Int, podStructs: List<String>, podGenerics: List<String>) -> Bool {
     if typeIdx < 0 {
         return false
@@ -314,10 +305,10 @@ fn isPodType(arena: AstArena, typeIdx: Int, podStructs: List<String>, podGeneric
     if isPodPrimitiveName(name) {
         return node.children.len() == 0
     }
-    if stringListContainsName(podGenerics, name) {
+    if listContainsString(podGenerics, name) {
         return node.children.len() == 0
     }
-    if stringListContainsName(podStructs, name) {
+    if listContainsString(podStructs, name) {
         // Local #[pod] struct reference — accept without re-checking
         // the referenced struct (it owns its own diagnostics).
         return true
@@ -1025,7 +1016,7 @@ fn noAllocCalleeAllowed(arena: AstArena, calleeIdx: Int, noAllocNames: List<Stri
     }
     let callee = astArenaNodeAt(arena, calleeIdx)
     if callee.kind == AstNIdent {
-        return stringListContainsName(noAllocNames, callee.text)
+        return listContainsString(noAllocNames, callee.text)
     }
     if callee.kind == AstNField {
         // `raw.*` — accept any method on a receiver named `raw`, and
@@ -1043,7 +1034,7 @@ fn noAllocCalleeAllowed(arena: AstArena, calleeIdx: Int, noAllocNames: List<Stri
             return true
         }
         if recv.text == "self" {
-            return stringListContainsName(noAllocNames, callee.text)
+            return listContainsString(noAllocNames, callee.text)
         }
         return false
     }

--- a/toolchain/core.osty
+++ b/toolchain/core.osty
@@ -1770,3 +1770,24 @@ fn coreIntLen(xs: List<Int>) -> Int {
 fn coreDiagCount(xs: List<CheckDiagnostic>) -> Int {
     xs.len()
 }
+
+// Shared list helpers (toolchain-wide). O(n) linear scans — keep caller
+// sets small or switch to a `Map<K, Bool>` keyed set.
+
+fn listContainsString(xs: List<String>, needle: String) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+fn listContainsInt(xs: List<Int>, needle: Int) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}

--- a/toolchain/core_clone.osty
+++ b/toolchain/core_clone.osty
@@ -520,11 +520,11 @@ pub fn coreCollectReachable(src: CoreArena, root: Int) -> CoreReachResult {
             break
         }
         let top = stack[stack.len() - 1]
-        stack = coreCloneListDropLast(stack)
+        stack.pop()
         if top < 0 || top >= src.nodes.len() {
             continue
         }
-        if coreCloneListContainsInt(seen, top) {
+        if listContainsInt(seen, top) {
             continue
         }
         seen.push(top)
@@ -568,27 +568,3 @@ pub fn coreCollectReachable(src: CoreArena, root: Int) -> CoreReachResult {
     CoreReachResult { indices: seen, err: "" }
 }
 
-fn coreCloneListDropLast(xs: List<Int>) -> List<Int> {
-    let mut out: List<Int> = []
-    let n = xs.len()
-    if n <= 1 {
-        return out
-    }
-    let mut i = 0
-    for x in xs {
-        if i < n - 1 {
-            out.push(x)
-        }
-        i = i + 1
-    }
-    out
-}
-
-fn coreCloneListContainsInt(xs: List<Int>, needle: Int) -> Bool {
-    for x in xs {
-        if x == needle {
-            return true
-        }
-    }
-    false
-}

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -1263,7 +1263,7 @@ pub fn mirReachableBlocks(func: MirFunction) -> List<Bool> {
             break
         }
         let top = stack[stack.len() - 1]
-        stack = mirListPopLast(stack)
+        stack.pop()
         if top < 0 || top >= n {
             continue
         }
@@ -1285,23 +1285,6 @@ pub fn mirReachableBlocks(func: MirFunction) -> List<Bool> {
     seen
 }
 
-/// mirListPopLast returns the list with its last element removed. Used
-/// by CFG helpers to avoid requiring a List<T>.pop() stdlib method.
-fn mirListPopLast(xs: List<Int>) -> List<Int> {
-    let mut out: List<Int> = []
-    let n = xs.len()
-    if n <= 1 {
-        return out
-    }
-    let mut i = 0
-    for x in xs {
-        if i < n - 1 {
-            out.push(x)
-        }
-        i = i + 1
-    }
-    out
-}
 
 /// mirCountReachable returns the number of reachable blocks in `func`.
 pub fn mirCountReachable(func: MirFunction) -> Int {

--- a/toolchain/mir_validator.osty
+++ b/toolchain/mir_validator.osty
@@ -51,7 +51,7 @@ pub fn mirValidateModule(m: MirModule) -> List<String> {
         if func.name == "" {
             errs.push("function[{i}]: empty name")
         }
-        if mirValidatorContains(seenNames, func.name) {
+        if listContainsString(seenNames, func.name) {
             errs.push("function \"{func.name}\": duplicate symbol")
         } else {
             seenNames.push(func.name)
@@ -108,7 +108,7 @@ pub fn mirValidateFunction(func: MirFunction) -> List<String> {
             pi = pi + 1
             continue
         }
-        if mirValidatorContainsInt(paramSet, pid) {
+        if listContainsInt(paramSet, pid) {
             errs.push("function \"{func.name}\": params[{pi}]=_{pid} appears more than once")
             pi = pi + 1
             continue
@@ -131,7 +131,7 @@ pub fn mirValidateFunction(func: MirFunction) -> List<String> {
         if loc.typ == "" {
             errs.push("function \"{func.name}\": locals[{li}]=_{loc.id} empty typ")
         }
-        if loc.isParam && !(mirValidatorContainsInt(paramSet, loc.id)) {
+        if loc.isParam && !(listContainsInt(paramSet, loc.id)) {
             errs.push("function \"{func.name}\": locals[{li}]=_{loc.id} marked isParam but not in fn.params")
         }
         if loc.isReturn {
@@ -538,7 +538,7 @@ fn mirValidateTerm(func: MirFunction, bb: MirBasicBlock, t: MirTerm) -> List<Str
             for c in t.cases {
                 let rErrs = mirValidateBlockRef(func, bb, c.target, "switchInt.cases[{ci}]")
                 for e in rErrs { errs.push(e) }
-                if mirValidatorContainsInt(seenVals, c.value) {
+                if listContainsInt(seenVals, c.value) {
                     errs.push("function \"{func.name}\" bb{bb.id}: switchInt.cases[{ci}] value {c.value} duplicates an earlier case")
                 } else {
                     seenVals.push(c.value)
@@ -570,24 +570,3 @@ fn mirValidateBlockRef(
     errs
 }
 
-// ====================================================================
-// Local helpers
-// ====================================================================
-
-fn mirValidatorContains(xs: List<String>, needle: String) -> Bool {
-    for x in xs {
-        if x == needle {
-            return true
-        }
-    }
-    false
-}
-
-fn mirValidatorContainsInt(xs: List<Int>, needle: Int) -> Bool {
-    for x in xs {
-        if x == needle {
-            return true
-        }
-    }
-    false
-}


### PR DESCRIPTION
## Summary

- Pulled duplicated \`for x in xs { if x == needle { return true } } false\` helpers out of \`mir_validator\`, \`core_clone\`, \`check_gates\`, and \`mir\` into two package-private helpers in \`toolchain/core.osty\` — \`listContainsString\` and \`listContainsInt\`.
- Retired the per-file drop-last-via-rebuild helpers (\`mirListPopLast\`, \`coreCloneListDropLast\`, \`mirValidatorContains*\`, \`stringListContainsName\`) in favor of the shared primitives.
- Replaced worklist \`stack = listDropLastInt(stack)\` with \`stack.pop()\` in \`coreCollectReachable\` ([core_clone.osty:523](toolchain/core_clone.osty)) and \`mirReachableBlocks\` ([mir.osty:1264](toolchain/mir.osty)). \`List<T>.pop()\` lowers to \`osty_rt_list_pop_discard\` (O(1) in-place, \`internal/llvmgen/stmt.go:1628\`), so the walks drop from O(n) per iteration to O(1) — meaningful on the 1M / 100K step caps.

## Why

Same-shape helpers had drifted across four files with four different names (\`mirValidatorContains\`, \`mirValidatorContainsInt\`, \`coreCloneListContainsInt\`, \`stringListContainsName\`). One spelling per shape keeps the \`toolchain/\` package coherent, and the \`listDropLastInt\` primitive was strictly worse than the existing \`.pop()\` intrinsic — codifying it would have been a bug magnet.

Net diff: **+32 / -82** across 5 files.

## Test plan

- [x] \`just front\` — lexer/parser/resolve/check/diag/format/lint/pipeline all green
- [x] \`osty parse\` / \`osty check\` clean on each modified file
- [ ] Follow-up (not in this PR): 9 other toolchain files still carry the same hand-rolled \`contains\` loop — flagged via a spawned task for a focused migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)