### PR TITLE
[codex] Fix native merged toolchain clean probe

### DIFF
--- a/internal/llvmgen/multifile_probe_helper_test.go
+++ b/internal/llvmgen/multifile_probe_helper_test.go
@@ -1,0 +1,26 @@
+package llvmgen
+
+import "testing"
+
+func TestIsBootstrapOnlyOstyFile(t *testing.T) {
+	t.Run("detects real use go ffi", func(t *testing.T) {
+		src := []byte("use go \"strings\" as strings {\n    pub fn trimSpace(s: String) -> String\n}\n")
+		if !isBootstrapOnlyOstyFile(src) {
+			t.Fatalf("expected real use-go file to be classified as bootstrap-only")
+		}
+	})
+
+	t.Run("detects real runtime golegacy ffi", func(t *testing.T) {
+		src := []byte("use runtime.golegacy.astbridge as astbridge {\n    pub fn pos() -> Int\n}\n")
+		if !isBootstrapOnlyOstyFile(src) {
+			t.Fatalf("expected runtime.golegacy file to be classified as bootstrap-only")
+		}
+	})
+
+	t.Run("ignores comments mentioning bootstrap syntax", func(t *testing.T) {
+		src := []byte("// `use go \"...\" { ... }` stays in comments only.\n// `use runtime.golegacy.foo` is also documentation here.\npub fn keep() -> Int { 1 }\n")
+		if isBootstrapOnlyOstyFile(src) {
+			t.Fatalf("expected comment-only mentions to stay in the native merged set")
+		}
+	})
+}

--- a/internal/llvmgen/multifile_probe_test.go
+++ b/internal/llvmgen/multifile_probe_test.go
@@ -158,9 +158,17 @@ func TestProbeWholeToolchainMerged(t *testing.T) {
 // native-path whole-toolchain probe. See LLVM_MIGRATION_PLAN.md
 // § "astbridge bootstrap-only adapter" for the migration path.
 func isBootstrapOnlyOstyFile(src []byte) bool {
-	s := string(src)
-	return strings.Contains(s, "use runtime.golegacy.") ||
-		strings.Contains(s, "use go \"")
+	for _, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "use runtime.golegacy.") ||
+			strings.HasPrefix(trimmed, "use go \"") {
+			return true
+		}
+	}
+	return false
 }
 
 // TestProbeNativeToolchainMerged is the whole-toolchain probe with

--- a/toolchain/mir_optimize.osty
+++ b/toolchain/mir_optimize.osty
@@ -276,9 +276,8 @@ fn mirRewriteRValueOperands(rv: MirRValue, known: List<MirConst>) -> Bool {
 /// form to a constant-indexed form. `proj` is a function parameter, so
 /// field assignments here lower through the parameter path rather
 /// than the chained-IndexExpr path the LLVM codegen rejects (LLVM012).
-fn mirProjFoldIndexToConst(target: MirProjection, constIndex: Int) {
-    target.indexLocal = -1
-    target.indexConst = constIndex
+fn mirProjFoldIndexToConst(target: MirProjection, constIndex: Int) -> MirProjection {
+    mirIndexProjConst(constIndex, target.typ)
 }
 
 /// mirRewritePlaceProjections rewrites IndexProj operands in a place's
@@ -293,7 +292,7 @@ fn mirRewritePlaceProjections(p: MirPlace, known: List<MirConst>) -> Bool {
             if proj.indexLocal < known.len() {
                 let bound = known[proj.indexLocal]
                 if bound.kind == MirConstInt {
-                    mirProjFoldIndexToConst(p.projections[i], bound.intValue)
+                    p.projections[i] = mirProjFoldIndexToConst(proj, bound.intValue)
                     changed = true
                 }
             }
@@ -430,8 +429,8 @@ fn mirCollapseEmptyGotos(func: MirFunction) -> Bool {
 /// Factored into a helper for the same reason as `mirInstrClearDest`:
 /// LLVM codegen rejects field assignments whose base is a chained
 /// IndexExpr.
-fn mirSwitchCaseSetTarget(c: MirSwitchCase, tgt: Int) {
-    c.target = tgt
+fn mirSwitchCaseSetTarget(c: MirSwitchCase, tgt: Int) -> MirSwitchCase {
+    mirSwitchCase(c.value, tgt, c.label)
 }
 
 /// mirCollapseBlockEdges rewrites one block's outgoing edges so they
@@ -474,7 +473,7 @@ fn mirCollapseBlockEdges(bb: MirBasicBlock, func: MirFunction) -> Bool {
                 let curTarget = bb.term.cases[ci].target
                 let newTarget = mirResolveEmptyGoto(func, curTarget)
                 if newTarget != curTarget {
-                    mirSwitchCaseSetTarget(bb.term.cases[ci], newTarget)
+                    bb.term.cases[ci] = mirSwitchCaseSetTarget(bb.term.cases[ci], newTarget)
                     changed = true
                 }
                 ci = ci + 1
@@ -558,9 +557,11 @@ fn mirDeadAssignElim(func: MirFunction) -> Bool {
 /// not yet lower field assignments whose base is an IndexExpr (e.g.
 /// `list[i].field = x`) — callers pass the indexed element as an
 /// argument, and mutation happens through the parameter (addressable).
-fn mirInstrClearDest(instr: MirInstr) {
-    instr.hasDest = false
-    instr.dest = mirPlace(-1)
+fn mirInstrClearDest(instr: MirInstr) -> MirInstr {
+    let mut out = instr
+    out.hasDest = false
+    out.dest = mirPlace(-1)
+    out
 }
 
 /// mirDeadAssignElimBlock runs the dead-assign pass on one block. `bb`
@@ -587,7 +588,7 @@ fn mirDeadAssignElimBlock(bb: MirBasicBlock, func: MirFunction, reads: List<Int>
                 let destLocal = bb.instrs[ii].dest.local
                 let hasProj = mirPlaceHasProjections(bb.instrs[ii].dest)
                 if hasDest && !(hasProj) && mirLocalIsDead(func, destLocal, reads) {
-                    mirInstrClearDest(bb.instrs[ii])
+                    bb.instrs[ii] = mirInstrClearDest(bb.instrs[ii])
                     changed = true
                 }
             },
@@ -596,7 +597,7 @@ fn mirDeadAssignElimBlock(bb: MirBasicBlock, func: MirFunction, reads: List<Int>
                 let destLocal = bb.instrs[ii].dest.local
                 let hasProj = mirPlaceHasProjections(bb.instrs[ii].dest)
                 if hasDest && !(hasProj) && mirLocalIsDead(func, destLocal, reads) {
-                    mirInstrClearDest(bb.instrs[ii])
+                    bb.instrs[ii] = mirInstrClearDest(bb.instrs[ii])
                     changed = true
                 }
             },


### PR DESCRIPTION
## Summary
- fix the native merged toolchain probe so bootstrap-only filtering only matches real `use go` / `use runtime.golegacy` declarations, not comment text
- add a regression test covering real bootstrap FFIs versus comment-only mentions
- rewrite `toolchain/mir_optimize.osty` helpers to return rebuilt values instead of mutating helper parameters in place, clearing the remaining LLVM012 walls on the native merged path

## Root cause
The native merged clean test was excluding `check_gates.osty` because the bootstrap-only probe matched `use go "..."` inside a comment. Once that false positive was removed, the next native wall was helper-level field mutation in `mir_optimize.osty`, which still lowered to non-addressable field assignments.

## Validation
- `go test -count=1 -run '^(TestIsBootstrapOnlyOstyFile|TestProbeNativeToolchainMerged|TestNativeToolchainMergedIsClean)$' -v ./internal/llvmgen`
- `TestProbeNativeToolchainMerged`: `NATIVE TOOLCHAIN first wall: CLEAN`