### PR TITLE
refactor: sanitizeNativeTestName을 List<String>+strings.join 패턴으로

### DIFF
--- a/toolchain/test_runner.osty
+++ b/toolchain/test_runner.osty
@@ -74,14 +74,15 @@ pub fn sanitizeNativeTestName(name: String) -> String {
     if name == "" {
         return "osty_test"
     }
-    let mut out = ""
+    let mut parts: List<String> = []
     for unit in strings.split(name, "") {
         if (unit >= "a" && unit <= "z") || (unit >= "A" && unit <= "Z") || (unit >= "0" && unit <= "9") {
-            out = out + unit
+            parts.push(unit)
         } else {
-            out = out + "_"
+            parts.push("_")
         }
     }
+    let out = strings.join(parts, "")
     if out == "" {
         return "osty_test"
     }


### PR DESCRIPTION
## 요약

`toolchain/test_runner.osty`의 `sanitizeNativeTestName`에서 문자 단위 `out = out + ...` 누적 패턴을 `List<String>` + `strings.join(parts, "")` canonical 패턴으로 교체.

[#517](https://github.com/choiceoh/osty/pull/517) / [#518](https://github.com/choiceoh/osty/pull/518)와 같은 테마의 마무리 — `mir.osty` 정리에 이어서 `toolchain/` 전반 일관성 회복.

## 변경

`sanitizeNativeTestName(name: String) -> String`:

```diff
-    let mut out = ""
+    let mut parts: List<String> = []
     for unit in strings.split(name, "") {
         if (unit >= "a" && unit <= "z") || ... {
-            out = out + unit
+            parts.push(unit)
         } else {
-            out = out + "_"
+            parts.push("_")
         }
     }
+    let out = strings.join(parts, "")
```

## 검증

- `osty check toolchain/test_runner.osty` → 0 error
- `just front` → 전 패키지 pass
- `testing.assertEq` 기반 기존 테스트 3개 케이스가 byte-equivalence 커버:
  - alphanumeric 패스스루: `"testFoo123"` → `"testFoo123"`
  - 특수문자 collapse: `"test.foo-bar baz"` → `"test_foo_bar_baz"`
  - 빈 입력 fallback: `""` → `"osty_test"`

## Impact

실질적 성능 영향은 작습니다 — 테스트 이름은 짧음. 목적은 toolchain 전반에서 O(n²) concat 패턴을 제거하고 canonical 스타일로 수렴시키는 것 ([#517](https://github.com/choiceoh/osty/pull/517) follow-up들과 같은 테마).

## Base

`main` 직접 타깃. `toolchain/test_runner.osty`만 건드리므로 [#517](https://github.com/choiceoh/osty/pull/517) / [#518](https://github.com/choiceoh/osty/pull/518)(둘 다 `mir.osty`)와 독립적으로 머지 가능.

## Test plan

- [x] `just front` 전 패키지 pass
- [x] `osty check toolchain/test_runner.osty` clean
- [x] 기존 3 테스트 케이스 byte-equivalence 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)