### PR TITLE
perf(lint): name classifier에서 불필요한 split/linear-scan 제거

### DIFF
--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -2468,7 +2468,10 @@ fn selfLintIsLowerCamel(name: String) -> Bool {
 }
 
 fn selfLintFirstUnit(name: String) -> String {
-    frontUnitAt(strings.split(name, ""), 0)
+    if name.isEmpty() {
+        return ""
+    }
+    strings.slice(name, 0, 1)
 }
 
 /// selfLintAstCheckMissingDocs walks every decl (and every `pub` method
@@ -3387,12 +3390,12 @@ fn selfLintIsLintCode(name: String) -> Bool {
         return false
     }
     let units = strings.split(name, "")
-    if frontUnitAt(units, 0) != "L" {
+    if units[0] != "L" {
         return false
     }
     let mut i = 1
-    for i < name.len() {
-        let u = frontUnitAt(units, i)
+    for i < units.len() {
+        let u = units[i]
         if u < "0" || u > "9" {
             return false
         }
@@ -3907,7 +3910,7 @@ fn selfLintIsTestFnName(name: String) -> Bool {
     if name.len() <= 4 {
         return false
     }
-    let fifth = frontUnitAt(strings.split(name, ""), 4)
+    let fifth = strings.slice(name, 4, 5)
     if fifth == "_" {
         return true
     }


### PR DESCRIPTION
## 요약

셀프 lint가 모든 identifier에 대해 호출하는 name classifier 3개에서, 단일 문자를 보기 위해 전체 문자열을 `List<String>`으로 쪼개고 `frontUnitAt`(linear scan)으로 훑던 패턴을 제거.

## 변경

| 함수 | Before | After | 복잡도 변화 |
|---|---|---|---|
| [`selfLintFirstUnit`](toolchain/lint.osty:2470) | `frontUnitAt(split(name,""), 0)` | `strings.slice(name, 0, 1)` + empty guard | O(N) alloc + O(1) → **O(1)** |
| [`selfLintIsTestFnName`](toolchain/lint.osty:3910) | `frontUnitAt(split(name,""), 4)` | `strings.slice(name, 4, 5)` (이미 `len>4` guard) | O(N) alloc + O(4) → **O(1)** |
| [`selfLintIsLintCode`](toolchain/lint.osty:3385) | `frontUnitAt(units, i)` 루프 | `units[i]` 직접 인덱싱 | **O(N²) → O(N)** |

## Why

- `frontUnitAt(xs, i)`는 `for unit in xs { idx++ ... }`로 **매번 linear scan** ([`frontend.osty:2059`](toolchain/frontend.osty:2059))
- `strings.split(s, "")`는 `s.chars()`를 돌아 각 char를 `"{c}"`로 interpolate해서 `List<String>` 생성 — O(N) allocation
- 첫 두 헬퍼는 **단 한 문자**를 보려고 위 둘을 다 지불하고 있었음
- `selfLintIsLintCode`는 split은 합당하지만, 내부 루프가 `frontUnitAt(units, i)`라 인덱스마다 또 스캔 → O(N²)

identifier 수 M, 평균 이름 길이 N에 대해:
- 기존: 첫 두 헬퍼 O(M·N) allocation + `selfLintIsLintCode` O(M·N²)
- 변경: O(M)

lint은 모든 식별자마다 실행되므로, 큰 파일에서 실측 차이가 드러남.

## Safety

Osty identifier는 ASCII-only (letters + digits + `_`), 따라서:
- `strings.slice(s, 0, 1)` (byte-level)과 `split(s, "")[0]` (char-level)이 byte-equivalent
- `units[i]` 직접 인덱싱도 `frontUnitAt(units, i)`와 동일한 값 반환 (range within bounds — 진입 전에 `name.len() < 2` / `i < units.len()` 가드 확인)
- 빈 입력 가드: `selfLintFirstUnit`에 `name.isEmpty()` 체크 추가 (기존 `split("", "")` = `[]` → `frontUnitAt([], 0)` = `""` 동작 보존)

## 검증

- `osty check toolchain/lint.osty` → 0 error
- `just front` → 전 패키지 pass (`internal/lint` 포함)
- `lint_test.osty`의 L0070/L0071/... 어서션 범위에서 byte-equivalence 유지 (name classifier 출력이 달라지면 lint code 분포가 달라짐)

## Test plan

- [x] `just front` 전 패키지 pass
- [x] `osty check toolchain/lint.osty` clean
- [x] byte-equivalence 수동 검증 (ASCII identifier 가정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)