### PR TITLE
[codex] Bridge native E0773 diagnostics

### DIFF
--- a/cmd/osty-native-checker/main.go
+++ b/cmd/osty-native-checker/main.go
@@ -64,6 +64,7 @@ type checkDiagnostic struct {
 	Message  string   `json:"message"`
 	Start    int      `json:"start"`
 	End      int      `json:"end"`
+	File     string   `json:"file,omitempty"`
 	Notes    []string `json:"notes,omitempty"`
 }
 
@@ -162,6 +163,7 @@ func run(stdin io.Reader, stdout io.Writer) error {
 				Message:  d.Message,
 				Start:    d.Start,
 				End:      d.End,
+				File:     d.File,
 				Notes:    append([]string(nil), d.Notes...),
 			})
 		}

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -92,6 +92,7 @@ type nativeCheckDiagnostic struct {
 	Message  string   `json:"message"`
 	Start    int      `json:"start"`
 	End      int      `json:"end"`
+	File     string   `json:"file,omitempty"`
 	Notes    []string `json:"notes,omitempty"`
 }
 
@@ -216,6 +217,7 @@ func adaptEmbeddedCheckResult(checked selfhost.CheckResult) nativeCheckResult {
 				Message:  d.Message,
 				Start:    d.Start,
 				End:      d.End,
+				File:     d.File,
 				Notes:    append([]string(nil), d.Notes...),
 			})
 		}
@@ -610,6 +612,9 @@ func convertNativeDiag(src []byte, d nativeCheckDiagnostic) *diag.Diagnostic {
 	b := diag.New(severity, d.Message)
 	if d.Code != "" {
 		b = b.Code(d.Code)
+	}
+	if d.File != "" {
+		b = b.File(d.File)
 	}
 	b = b.Primary(byteRangeSpan(src, d.Start, d.End), "")
 	for _, note := range d.Notes {

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/canonical"
+	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
@@ -168,6 +169,23 @@ fn main() {}
 	}
 	if got := chk.LookupSymType(paramSym); got == nil || got.String() != "Int" {
 		t.Fatalf("unused param type = %v, want Int", got)
+	}
+}
+
+func TestConvertNativeDiagPreservesFile(t *testing.T) {
+	got := convertNativeDiag([]byte("fn main() {}\n"), nativeCheckDiagnostic{
+		Code:     diag.CodeIntrinsicNonEmptyBody,
+		Severity: "error",
+		Message:  "`#[intrinsic]` function `violator` must have an empty body",
+		Start:    0,
+		End:      0,
+		File:     "/tmp/bad.osty",
+	})
+	if got == nil {
+		t.Fatal("convertNativeDiag returned nil")
+	}
+	if got.File != "/tmp/bad.osty" {
+		t.Fatalf("diag.File = %q, want /tmp/bad.osty", got.File)
 	}
 }
 

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -38,6 +38,7 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 			SourceMap: pf.CanonicalMap,
 			Base:      base,
 			Name:      name,
+			Path:      pf.Path,
 		})
 		segmentIdx++
 	}

--- a/internal/selfhost/check_adapter.go
+++ b/internal/selfhost/check_adapter.go
@@ -72,6 +72,7 @@ type CheckDiagnosticRecord struct {
 	Message  string
 	Start    int
 	End      int
+	File     string
 	Notes    []string
 }
 
@@ -100,7 +101,9 @@ func CheckSourceStructured(src []byte) CheckResult {
 	if checked == nil {
 		return CheckResult{}
 	}
-	return adaptCheckResult(checked, lexed)
+	result := adaptCheckResult(checked, lexed)
+	selfhostAppendIntrinsicBodyGateForSource(&result, src)
+	return result
 }
 
 func adaptCheckSummary(checked *FrontCheckSummary) CheckSummary {
@@ -227,6 +230,7 @@ func adaptCheckResult(checked *FrontCheckResult, lexed *OstyLexedSource) CheckRe
 			Message:  d.message,
 			Start:    start,
 			End:      end,
+			File:     "",
 			Notes:    append([]string(nil), d.notes...),
 		})
 	}

--- a/internal/selfhost/gate_adapter.go
+++ b/internal/selfhost/gate_adapter.go
@@ -1,0 +1,206 @@
+package selfhost
+
+import (
+	"strings"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+)
+
+// Until internal/selfhost/generated.go regenerates cleanly with
+// toolchain/check_gates.osty folded in, synthesize the subset of gate
+// diagnostics that native package/file callers already rely on. The merge
+// helper dedupes against newer generated bundles, so this stays safe once the
+// selfhost output catches up.
+
+func selfhostAppendIntrinsicBodyGateForSource(result *CheckResult, src []byte) {
+	if result == nil || len(src) == 0 {
+		return
+	}
+	file, parseDiags := Parse(src)
+	if file == nil || selfhostHasErrorDiagnostics(parseDiags) {
+		return
+	}
+	selfhostMergeDiagnosticRecords(result, selfhostIntrinsicBodyDiagnostics(file, 0, "")...)
+}
+
+func selfhostAppendIntrinsicBodyGateForPackage(result *CheckResult, input PackageCheckInput) {
+	if result == nil || len(input.Files) == 0 {
+		return
+	}
+	var records []CheckDiagnosticRecord
+	for _, file := range input.Files {
+		if len(file.Source) == 0 {
+			continue
+		}
+		parsed, parseDiags := Parse(file.Source)
+		if parsed == nil || selfhostHasErrorDiagnostics(parseDiags) {
+			continue
+		}
+		records = append(records, selfhostIntrinsicBodyDiagnostics(parsed, file.Base, file.Path)...)
+	}
+	selfhostMergeDiagnosticRecords(result, records...)
+}
+
+func selfhostHasErrorDiagnostics(diags []*diag.Diagnostic) bool {
+	for _, d := range diags {
+		if d != nil && d.Severity == diag.Error {
+			return true
+		}
+	}
+	return false
+}
+
+func selfhostIntrinsicBodyDiagnostics(file *ast.File, base int, path string) []CheckDiagnosticRecord {
+	if file == nil {
+		return nil
+	}
+	var out []CheckDiagnosticRecord
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FnDecl:
+			if rec := selfhostIntrinsicBodyRecord(d, base, path); rec != nil {
+				out = append(out, *rec)
+			}
+		case *ast.StructDecl:
+			selfhostAppendIntrinsicBodyMethodRecords(&out, d.Methods, base, path)
+		case *ast.EnumDecl:
+			selfhostAppendIntrinsicBodyMethodRecords(&out, d.Methods, base, path)
+		case *ast.UseDecl:
+			for _, member := range d.GoBody {
+				switch m := member.(type) {
+				case *ast.FnDecl:
+					if rec := selfhostIntrinsicBodyRecord(m, base, path); rec != nil {
+						out = append(out, *rec)
+					}
+				case *ast.StructDecl:
+					selfhostAppendIntrinsicBodyMethodRecords(&out, m.Methods, base, path)
+				case *ast.EnumDecl:
+					selfhostAppendIntrinsicBodyMethodRecords(&out, m.Methods, base, path)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func selfhostAppendIntrinsicBodyMethodRecords(out *[]CheckDiagnosticRecord, methods []*ast.FnDecl, base int, path string) {
+	if out == nil {
+		return
+	}
+	for _, method := range methods {
+		if rec := selfhostIntrinsicBodyRecord(method, base, path); rec != nil {
+			*out = append(*out, *rec)
+		}
+	}
+}
+
+func selfhostIntrinsicBodyRecord(fn *ast.FnDecl, base int, path string) *CheckDiagnosticRecord {
+	if fn == nil || !selfhostHasAnnotation(fn.Annotations, "intrinsic") {
+		return nil
+	}
+	if fn.Body == nil || len(fn.Body.Stmts) == 0 {
+		return nil
+	}
+	start := base + fn.Body.Pos().Offset
+	end := base + fn.Body.End().Offset
+	if end < start {
+		end = start
+	}
+	return &CheckDiagnosticRecord{
+		Code:     diag.CodeIntrinsicNonEmptyBody,
+		Severity: "error",
+		Message:  "`#[intrinsic]` function `" + fn.Name + "` must have an empty body",
+		Start:    start,
+		End:      end,
+		File:     path,
+		Notes: []string{
+			"LANG_SPEC §19.6: intrinsic implementations are supplied by the lowering layer; the source body is ignored",
+			"hint: keep the signature and drop the body, or use `{}`",
+		},
+	}
+}
+
+func selfhostHasAnnotation(annots []*ast.Annotation, name string) bool {
+	for _, annot := range annots {
+		if annot != nil && annot.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func selfhostMergeDiagnosticRecords(result *CheckResult, records ...CheckDiagnosticRecord) {
+	if result == nil || len(records) == 0 {
+		return
+	}
+	for _, record := range records {
+		if idx := selfhostFindDiagnosticRecord(result.Diagnostics, record); idx >= 0 {
+			existing := &result.Diagnostics[idx]
+			if existing.File == "" {
+				existing.File = record.File
+			}
+			existing.Notes = selfhostMergeNotes(existing.Notes, record.Notes)
+			continue
+		}
+		result.Diagnostics = append(result.Diagnostics, record)
+		selfhostTallyDiagnosticRecord(&result.Summary, record)
+	}
+}
+
+func selfhostFindDiagnosticRecord(records []CheckDiagnosticRecord, want CheckDiagnosticRecord) int {
+	for i, record := range records {
+		if record.Code != want.Code || record.Severity != want.Severity || record.Message != want.Message {
+			continue
+		}
+		if record.Start != want.Start || record.End != want.End {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+func selfhostMergeNotes(existing []string, extra []string) []string {
+	if len(extra) == 0 {
+		return existing
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, note := range existing {
+		seen[note] = struct{}{}
+	}
+	for _, note := range extra {
+		if _, ok := seen[note]; ok {
+			continue
+		}
+		existing = append(existing, note)
+		seen[note] = struct{}{}
+	}
+	return existing
+}
+
+func selfhostTallyDiagnosticRecord(summary *CheckSummary, record CheckDiagnosticRecord) {
+	if summary == nil || !strings.EqualFold(record.Severity, "error") {
+		return
+	}
+	summary.Errors++
+	ctx := strings.TrimSpace(record.Code)
+	if ctx == "" {
+		ctx = "error"
+	}
+	if summary.ErrorsByContext == nil {
+		summary.ErrorsByContext = map[string]int{}
+	}
+	summary.ErrorsByContext[ctx]++
+	detail := strings.TrimSpace(record.Message)
+	if detail == "" {
+		return
+	}
+	if summary.ErrorDetails == nil {
+		summary.ErrorDetails = map[string]map[string]int{}
+	}
+	if summary.ErrorDetails[ctx] == nil {
+		summary.ErrorDetails[ctx] = map[string]int{}
+	}
+	summary.ErrorDetails[ctx][detail]++
+}

--- a/internal/selfhost/package_adapter.go
+++ b/internal/selfhost/package_adapter.go
@@ -19,6 +19,10 @@ type PackageCheckFile struct {
 	// a basename like `user.osty`). Empty when unknown; the telemetry suffix
 	// falls back to `@Lnn:Cnn` without a filename prefix in that case.
 	Name string `json:"name,omitempty"`
+	// Path is the owning source path when known. Package-mode diagnostics carry
+	// this through the native checker boundary so multi-file callers do not
+	// need to guess which file owned a given span.
+	Path string `json:"path,omitempty"`
 }
 
 type PackageCheckGenericBound struct {
@@ -100,7 +104,9 @@ func CheckPackageStructured(input PackageCheckInput) (CheckResult, error) {
 			cx := newElabCx(file, emptyTyArena())
 			selfhostInstallImportSurfaces(cx.env, input.Imports)
 			elabFile(cx)
-			return adaptCheckResultWithByteLayout(serializeCheckResult(cx), layout), nil
+			result := adaptCheckResultWithByteLayout(serializeCheckResult(cx), layout)
+			selfhostAppendIntrinsicBodyGateForPackage(&result, input)
+			return result, nil
 		}
 		var unsupported *selfhostLoweringUnsupported
 		if !errors.As(err, &unsupported) {
@@ -117,7 +123,9 @@ func CheckPackageStructured(input PackageCheckInput) (CheckResult, error) {
 	cx := newElabCx(file, emptyTyArena())
 	selfhostInstallImportSurfaces(cx.env, input.Imports)
 	elabFile(cx)
-	return adaptCheckResultWithTokenLayout(serializeCheckResult(cx), layout), nil
+	result := adaptCheckResultWithTokenLayout(serializeCheckResult(cx), layout)
+	selfhostAppendIntrinsicBodyGateForPackage(&result, input)
+	return result, nil
 }
 
 type selfhostPackageTokenLayout struct {

--- a/internal/selfhost/package_adapter_test.go
+++ b/internal/selfhost/package_adapter_test.go
@@ -1,6 +1,7 @@
 package selfhost_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/osty/osty/internal/canonical"
@@ -151,6 +152,51 @@ fn helper() -> dep.Item {
 	}
 }
 
+func TestCheckSourceStructuredReportsIntrinsicBodyViolation(t *testing.T) {
+	checked := selfhost.CheckSourceStructured([]byte(`#[intrinsic]
+pub fn violator() -> Int { 42 }
+`))
+	if got := findDiagnosticCode(checked, "E0773"); got == nil {
+		t.Fatalf("expected E0773, got diagnostics %#v", checked.Diagnostics)
+	}
+	if got := checked.Summary.ErrorsByContext["E0773"]; got != 1 {
+		t.Fatalf("summary E0773 count = %d, want 1 (summary=%#v)", got, checked.Summary)
+	}
+}
+
+func TestCheckPackageStructuredReportsIntrinsicBodyViolationWithPath(t *testing.T) {
+	dir := t.TempDir()
+	goodPath := filepath.Join(dir, "good.osty")
+	badPath := filepath.Join(dir, "bad.osty")
+	good := canonicalSelfhostSource(t, []byte(`pub fn ok() -> Int { 0 }
+`))
+	bad := canonicalSelfhostSource(t, []byte(`#[intrinsic]
+pub fn violator() -> Int { 42 }
+`))
+	checked, err := selfhost.CheckPackageStructured(selfhost.PackageCheckInput{
+		Files: []selfhost.PackageCheckFile{
+			{Source: good, Base: 0, Name: "good.osty", Path: goodPath},
+			{Source: bad, Base: len(good) + 1, Name: "bad.osty", Path: badPath},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CheckPackageStructured: %v", err)
+	}
+	got := findDiagnosticCode(checked, "E0773")
+	if got == nil {
+		t.Fatalf("expected E0773, got diagnostics %#v", checked.Diagnostics)
+	}
+	if got.File != badPath {
+		t.Fatalf("diagnostic file = %q, want %q", got.File, badPath)
+	}
+	if want := len(good) + 1; got.Start < want {
+		t.Fatalf("diagnostic start = %d, want >= %d so second-file base survives", got.Start, want)
+	}
+	if got := checked.Summary.ErrorsByContext["E0773"]; got != 1 {
+		t.Fatalf("summary E0773 count = %d, want 1 (summary=%#v)", got, checked.Summary)
+	}
+}
+
 func findCheckedBindingType(result selfhost.CheckResult, name string) string {
 	for _, binding := range result.Bindings {
 		if binding.Name == name {
@@ -158,6 +204,15 @@ func findCheckedBindingType(result selfhost.CheckResult, name string) string {
 		}
 	}
 	return ""
+}
+
+func findDiagnosticCode(result selfhost.CheckResult, code string) *selfhost.CheckDiagnosticRecord {
+	for i := range result.Diagnostics {
+		if result.Diagnostics[i].Code == code {
+			return &result.Diagnostics[i]
+		}
+	}
+	return nil
 }
 
 func canonicalSelfhostSource(t *testing.T, src []byte) []byte {


### PR DESCRIPTION
## What changed
- carry diagnostic `file` metadata through the native checker JSON boundary and preserve it when adapting native diagnostics
- add a temporary selfhost-side `E0773` intrinsic-body fallback so package and source checks still report the gate until regenerated native/selfhost output emits it directly
- cover the behavior with focused package/source and native-boundary regression tests

## Why
The host path was already reduced to the privileged `E0770` filter, but package-mode callers still depended on `E0773` being emitted with per-file ownership. Removing the Go-side gate entirely broke `TestCheckPackageStampsPerFile`, so we need to honor native diagnostics when present and fill only the current gap without duplicating diagnostics.

## Impact
- native diagnostics now preserve owning file paths across the checker boundary
- package-mode native/selfhost checks keep a single visible `E0773` result with the correct file when generated output has not caught up yet
- the fallback dedupes against newer generated bundles so it can be removed cleanly after regeneration catches up

## Validation
- `just build-checker`
- `go test -count=1 -vet=off ./internal/check ./internal/selfhost ./cmd/osty-native-checker`