### PR TITLE
refactor(toolchain): migrate 9 more call sites to shared listContains helpers

### DIFF
--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1115,7 +1115,7 @@ fn checkCollectInterfaceMethods(env: CheckEnv, owner: String, out: List<CheckFnS
     let mut nextOut: List<CheckFnSig> = out
     let mut nextSeen: List<String> = seen
     for sig in env.fns {
-        if sig.owner == owner && !(checkStringListContainsLocal(nextSeen, sig.name)) {
+        if sig.owner == owner && !(listContainsString(nextSeen, sig.name)) {
             nextOut.push(sig)
             nextSeen.push(sig.name)
         }
@@ -1133,7 +1133,7 @@ fn checkCollectInterfaceMethods(env: CheckEnv, owner: String, out: List<CheckFnS
 fn checkFnSigNames(xs: List<CheckFnSig>) -> List<String> {
     let mut out: List<String> = []
     for sig in xs {
-        if !(checkStringListContainsLocal(out, sig.name)) {
+        if !(listContainsString(out, sig.name)) {
             out.push(sig.name)
         }
     }
@@ -1208,15 +1208,6 @@ fn checkStringKey(xs: List<String>) -> String {
     strings.join(xs, ",")
 }
 
-fn checkStringListContainsLocal(xs: List<String>, needle: String) -> Bool {
-    for x in xs {
-        if x == needle {
-            return true
-        }
-    }
-    false
-}
-
 /// checkVisibleBindingNames collects the identifiers reachable at the
 /// current elaboration point — all active lexical bindings plus every
 /// registered top-level free function. This is the candidate pool the
@@ -1224,12 +1215,12 @@ fn checkStringListContainsLocal(xs: List<String>, needle: String) -> Bool {
 pub fn checkVisibleBindingNames(env: CheckEnv) -> List<String> {
     let mut out: List<String> = []
     for b in env.bindings {
-        if !(checkStringListContainsLocal(out, b.name)) {
+        if !(listContainsString(out, b.name)) {
             out.push(b.name)
         }
     }
     for sig in env.fns {
-        if sig.owner == "" && !(checkStringListContainsLocal(out, sig.name)) {
+        if sig.owner == "" && !(listContainsString(out, sig.name)) {
             out.push(sig.name)
         }
     }
@@ -1244,7 +1235,7 @@ pub fn checkFieldNamesOf(env: CheckEnv, owner: String) -> List<String> {
         return out
     }
     for f in env.fields {
-        if f.owner == owner && !(checkStringListContainsLocal(out, f.name)) {
+        if f.owner == owner && !(listContainsString(out, f.name)) {
             out.push(f.name)
         }
     }
@@ -1266,7 +1257,7 @@ fn checkCollectMethodNames(env: CheckEnv, owner: String, acc: List<String>) -> L
     }
     let mut out = acc
     for sig in env.fns {
-        if sig.owner == owner && !(checkStringListContainsLocal(out, sig.name)) {
+        if sig.owner == owner && !(listContainsString(out, sig.name)) {
             out.push(sig.name)
         }
     }
@@ -1287,7 +1278,7 @@ pub fn checkVariantNamesOf(env: CheckEnv, owner: String) -> List<String> {
     let mut out: List<String> = []
     for v in env.variants {
         let matches = owner == "" || v.owner == owner
-        if matches && !(checkStringListContainsLocal(out, v.name)) {
+        if matches && !(listContainsString(out, v.name)) {
             out.push(v.name)
         }
     }

--- a/toolchain/diag_harvest.osty
+++ b/toolchain/diag_harvest.osty
@@ -47,15 +47,6 @@ pub fn diagHarvestLintCodes(source: String) -> List<String> {
     codes
 }
 
-fn diagHarvestContains(codes: List<String>, needle: String) -> Bool {
-    for c in codes {
-        if c == needle {
-            return true
-        }
-    }
-    false
-}
-
 /// diagHarvestRun routes a single case through the correct self-host
 /// phase and records what fired. Cases tagged `phase: "skip"` return
 /// with `skipped: true` and no codes — the test scopes out
@@ -79,7 +70,7 @@ pub fn diagHarvestRun(case: DiagHarvestCase) -> DiagHarvestOutcome {
     }
     DiagHarvestOutcome {
         expectedCode: case.code,
-        matched: diagHarvestContains(codes, case.code),
+        matched: listContainsString(codes, case.code),
         emittedCodes: codes,
         phase: case.phase,
         skipped: false,

--- a/toolchain/docgen.osty
+++ b/toolchain/docgen.osty
@@ -1410,15 +1410,6 @@ fn selfDocIndexAnchor(refs: List<SelfDocRef>, name: String) -> String {
     ""
 }
 
-fn selfDocStringListContains(items: List<String>, name: String) -> Bool {
-    for item in items {
-        if item == name {
-            return true
-        }
-    }
-    false
-}
-
 fn selfDocAddRefsFromText(
     existing: List<String>,
     text: String,
@@ -1439,7 +1430,7 @@ fn selfDocAddRefsFromText(
                 idx = idx + 1
             }
             let anchor = selfDocIndexAnchor(refs, word)
-            if anchor != "" && word != exclude && !(selfDocStringListContains(out, word)) {
+            if anchor != "" && word != exclude && !(listContainsString(out, word)) {
                 out.push(word)
             }
         } else {

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -2230,7 +2230,7 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
             ))
             continue
         }
-        if stringListContains(seenNames, fieldName) {
+        if listContainsString(seenNames, fieldName) {
             cx.env.diagnostics.push(diagDuplicateField(owner, fieldName, fieldNode.start, fieldNode.end))
         }
         seenNames.push(fieldName)
@@ -2246,8 +2246,8 @@ fn elabInferStructLit(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     // owner, so we skip fields supplied either explicitly or via spread.
     for f in cx.env.fields {
         if f.owner == owner
-           && !(stringListContains(seenNames, f.name))
-           && !(stringListContains(spreadSupplied, f.name))
+           && !(listContainsString(seenNames, f.name))
+           && !(listContainsString(spreadSupplied, f.name))
            && !(f.hasDefault) {
             cx.env.diagnostics.push(diagMissingField(owner, f.name, node.start, node.end))
         }
@@ -2274,15 +2274,6 @@ fn structLitOwnerName(cx: ElabCx, node: AstNode) -> String {
         return ownerNode.text
     }
     node.text
-}
-
-fn stringListContains(xs: List<String>, needle: String) -> Bool {
-    for x in xs {
-        if x == needle {
-            return true
-        }
-    }
-    false
 }
 
 // ---------------------------------------------------------------------
@@ -3267,7 +3258,7 @@ fn armCoveredByIntCoverage(cx: ElabCx, patIdx: Int, coveredLits: List<String>, c
     if k == astPatternLiteralKind() {
         let t = patLiteralTextOf(cx, p)
         if t == "" { return false }
-        if stringListContains(coveredLits, t) {
+        if listContainsString(coveredLits, t) {
             return true
         }
         let parsed = pmParseIntLit(t)
@@ -3314,7 +3305,7 @@ fn collectArmIntCoverage(cx: ElabCx, patIdx: Int, outLits: List<String>, outInte
     let k = p.extra
     if k == astPatternLiteralKind() {
         let t = patLiteralTextOf(cx, p)
-        if t != "" && !(stringListContains(outLits, t)) {
+        if t != "" && !(listContainsString(outLits, t)) {
             outLits.push(t)
         }
         return
@@ -3381,7 +3372,7 @@ fn armCoveredByEnum(cx: ElabCx, patIdx: Int, scrutTy: Int, covered: List<String>
     }
     let k = patKindOf(p)
     if k == astPatternVariantKind() {
-        return stringListContains(covered, lastPathSegment(p.text))
+        return listContainsString(covered, lastPathSegment(p.text))
     }
     if k == astPatternIdentKind() {
         // zero-arity variant-shadow ident
@@ -3390,7 +3381,7 @@ fn armCoveredByEnum(cx: ElabCx, patIdx: Int, scrutTy: Int, covered: List<String>
         if hit.name == "" {
             return false
         }
-        return stringListContains(covered, p.text)
+        return listContainsString(covered, p.text)
     }
     if k == astPatternOrKind() {
         return armCoveredByEnum(cx, p.left, scrutTy, covered)
@@ -3414,7 +3405,7 @@ fn armCoveredByScalarLits(cx: ElabCx, patIdx: Int, scrutTy: Int, covered: List<S
     if k == astPatternLiteralKind() {
         let t = patLiteralTextOf(cx, p)
         if t == "" { return false }
-        return stringListContains(covered, t)
+        return listContainsString(covered, t)
     }
     if k == astPatternOrKind() {
         return armCoveredByScalarLits(cx, p.left, scrutTy, covered)
@@ -3440,7 +3431,7 @@ fn collectArmVariantNames(cx: ElabCx, patIdx: Int, scrutTy: Int, out: List<Strin
     let k = patKindOf(p)
     if k == astPatternVariantKind() {
         let vname = lastPathSegment(p.text)
-        if !(stringListContains(out, vname)) {
+        if !(listContainsString(out, vname)) {
             out.push(vname)
         }
         return
@@ -3448,7 +3439,7 @@ fn collectArmVariantNames(cx: ElabCx, patIdx: Int, scrutTy: Int, out: List<Strin
     if k == astPatternIdentKind() {
         let owner = tyHeadAt(cx.env.tys, scrutTy)
         let hit = checkLookupVariantInOwner(cx.env, owner, p.text)
-        if hit.name != "" && !(stringListContains(out, p.text)) {
+        if hit.name != "" && !(listContainsString(out, p.text)) {
             out.push(p.text)
         }
         return
@@ -3474,7 +3465,7 @@ fn collectArmScalarLits(cx: ElabCx, patIdx: Int, out: List<String>) {
     let k = patKindOf(p)
     if k == astPatternLiteralKind() {
         let t = patLiteralTextOf(cx, p)
-        if t != "" && !(stringListContains(out, t)) {
+        if t != "" && !(listContainsString(out, t)) {
             out.push(t)
         }
         return

--- a/toolchain/lint.osty
+++ b/toolchain/lint.osty
@@ -841,7 +841,7 @@ fn selfLintAstCheckFunctionScopes(
         let paramNames = selfLintAstParamNames(file, param)
         for item in paramNames {
             if !(selfLintIsIntentionalDiscard(item.name)) && item.name != "self" {
-                if selfLintStringListContains(names, item.name) {
+                if listContainsString(names, item.name) {
                     out = selfLintEmitAtNode(
                         out,
                         "L0010",
@@ -971,7 +971,7 @@ fn selfLintAstCheckExprScopes(
             let paramNames = selfLintAstParamNames(file, param)
             for item in paramNames {
                 if !(selfLintIsIntentionalDiscard(item.name)) {
-                    if selfLintStringListContains(closureNames, item.name) {
+                    if listContainsString(closureNames, item.name) {
                         out = selfLintEmitAtNode(
                             out,
                             "L0010",
@@ -1010,7 +1010,7 @@ fn selfLintAstCheckPatternShadowing(
     let mut local = selfLintStringListCopy(visible)
     for item in names {
         if !(selfLintIsIntentionalDiscard(item.name)) {
-            if selfLintStringListContains(local, item.name) {
+            if listContainsString(local, item.name) {
                 out = selfLintEmitAtNode(
                     out,
                     "L0010",
@@ -2435,15 +2435,6 @@ fn selfLintMutatingMethodName(name: String) -> Bool {
     name == "push" || name == "pop" || name == "insert" || name == "remove" || name == "clear" || name == "close" || name == "shuffle"
 }
 
-fn selfLintStringListContains(items: List<String>, target: String) -> Bool {
-    for item in items {
-        if item == target {
-            return true
-        }
-    }
-    false
-}
-
 fn selfLintIsIntentionalDiscard(name: String) -> Bool {
     name == "_" || strings.hasPrefix(name, "_")
 }
@@ -2615,7 +2606,7 @@ fn selfLintMemberAccessAddField(
     if name == "" {
         return acc
     }
-    if selfLintStringListContains(acc.fields, name) {
+    if listContainsString(acc.fields, name) {
         return acc
     }
     let mut out = acc
@@ -2630,7 +2621,7 @@ fn selfLintMemberAccessAddMethod(
     if name == "" {
         return acc
     }
-    if selfLintStringListContains(acc.methods, name) {
+    if listContainsString(acc.methods, name) {
         return acc
     }
     let mut out = acc
@@ -2828,7 +2819,7 @@ fn selfLintMaybeEmitUnusedField(
     if typePub || member.flags == 1 {
         return report
     }
-    if selfLintStringListContains(access.fields, member.text) {
+    if listContainsString(access.fields, member.text) {
         return report
     }
     selfLintEmitAtNode(
@@ -2855,7 +2846,7 @@ fn selfLintMaybeEmitUnusedMethod(
     if typePub || member.flags == 1 {
         return report
     }
-    if selfLintStringListContains(access.methods, member.text) {
+    if listContainsString(access.methods, member.text) {
         return report
     }
     selfLintEmitAtNode(
@@ -3412,7 +3403,7 @@ fn selfLintDiagIsAllowed(diag: SelfLintDiagnostic, scopes: List<SelfLintAllowSco
         if scope.wildcard {
             return true
         }
-        if selfLintStringListContains(scope.codes, diag.code) {
+        if listContainsString(scope.codes, diag.code) {
             return true
         }
     }

--- a/toolchain/manifest_validation.osty
+++ b/toolchain/manifest_validation.osty
@@ -800,7 +800,7 @@ fn manifestProfileCycleVisit(
     if manifestBuiltinProfile(name) {
         return false
     }
-    if manifestStringListContains(stack, name) {
+    if listContainsString(stack, name) {
         return true
     }
     for profile in profiles {
@@ -815,15 +815,6 @@ fn manifestProfileCycleVisit(
                 return false
             }
             return manifestProfileCycleVisit(profile.inherits, profiles, manifestStringListAppended(stack, name))
-        }
-    }
-    false
-}
-
-fn manifestStringListContains(items: List<String>, target: String) -> Bool {
-    for item in items {
-        if item == target {
-            return true
         }
     }
     false

--- a/toolchain/pkgmgr.osty
+++ b/toolchain/pkgmgr.osty
@@ -1076,7 +1076,7 @@ fn selfPkgTopoVisit(
     nodes: List<SelfPkgGraphNode>,
     out: List<String>,
 ) -> List<String> {
-    if selfPkgStringListHas(out, name) {
+    if listContainsString(out, name) {
         return out
     }
     let lookup = selfPkgFindGraphNode(name, nodes)
@@ -1091,7 +1091,7 @@ fn selfPkgTopoVisit(
     for dep in deps {
         next = selfPkgTopoVisit(dep, nodes, next)
     }
-    if !(selfPkgStringListHas(next, name)) {
+    if !(listContainsString(next, name)) {
         next.push(name)
     }
     next
@@ -1109,19 +1109,10 @@ fn selfPkgInsertStringSorted(items: List<String>, item: String) -> List<String> 
             out.push(existing)
         }
     }
-    if !(inserted) && !(selfPkgStringListHas(out, item)) {
+    if !(inserted) && !(listContainsString(out, item)) {
         out.push(item)
     }
     out
-}
-
-fn selfPkgStringListHas(items: List<String>, item: String) -> Bool {
-    for existing in items {
-        if existing == item {
-            return true
-        }
-    }
-    false
 }
 
 /// selfPkgDepLookupItem constructs an import lookup row.

--- a/toolchain/runner.osty
+++ b/toolchain/runner.osty
@@ -158,7 +158,7 @@ pub fn mergeEnv(parent: List<String>, overrides: List<EnvEntry>) -> List<String>
         let key = envEntryKey(kv)
         if key == "" {
             out.push(kv)
-        } else if envSeen(seen, key) {
+        } else if listContainsString(seen, key) {
             let _ = key
         } else {
             out.push(kv)
@@ -185,15 +185,6 @@ fn envEntryKey(kv: String) -> String {
     }
     let parts = strings.split(kv, "=")
     parts[0]
-}
-
-fn envSeen(seen: List<String>, key: String) -> Bool {
-    for k in seen {
-        if k == key {
-            return true
-        }
-    }
-    false
 }
 
 fn joinPath(dir: String, rest: String, sep: String) -> String {


### PR DESCRIPTION
## Summary

[#519](https://github.com/choiceoh/osty/pull/519)에서 `listContainsString` / `listContainsInt`를 `toolchain/core.osty`에 넣은 뒤 리뷰에서 플래그된 남은 9 call site를 정리. 동일한 `for x in xs { if x == needle { return true } } false` 셰이프를 들고 있던 로컬 헬퍼 8개를 제거하고 호출부를 공유 헬퍼로 치환.

## Migrated

- `toolchain/elab.osty` — `stringListContains` (11 call sites)
- `toolchain/manifest_validation.osty` — `manifestStringListContains`
- `toolchain/docgen.osty` — `selfDocStringListContains`
- `toolchain/lint.osty` — `selfLintStringListContains` (9 call sites)
- `toolchain/check_env.osty` — `checkStringListContainsLocal` (7 call sites)
- `toolchain/diag_harvest.osty` — `diagHarvestContains`
- `toolchain/pkgmgr.osty` — `selfPkgStringListHas` (3 call sites)
- `toolchain/runner.osty` — `envSeen` (grep sweep 중 추가 발견)

## Skipped (의도적)

`ir.osty:516 irIndexOfChild` 와 `resolve.osty:1587 srStringListIndex` 는 원래 작업 목록에 있었지만 **indexOf** (Int 반환) 이고 호출부가 인덱스 값에 의존함:
- `ir.osty:489` — `if pos <= 0` 로 "not found OR 첫 child" 를 구분해서 이전 sibling 순회 결정
- `resolve.osty:1279` — `counts[existing] += 1` 로 인덱스 값을 count 테이블에 사용

`listContainsInt`/`listContainsString` 은 Bool만 돌려주므로 교체하면 behavior 변경. 남긴다. 필요하면 `listIndexOfInt`/`listIndexOfString` 을 `core.osty`에 신설하는 형태로 후속 정리.

## Net

- 8 files changed, 33 insertions, 105 deletions
- Behavior 변경 없음 (drop-in replacement of identical O(n) scan)

## Test plan

- [x] `just front` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)