### PR TITLE
[codex] Cache LSP semantic token payloads

### DIFF
--- a/internal/lsp/semtok.go
+++ b/internal/lsp/semtok.go
@@ -56,31 +56,43 @@ func (s *Server) handleSemanticTokens(req *rpcRequest) {
 		return
 	}
 	doc := s.docs.get(params.TextDocument.URI)
-	if doc == nil {
+	if doc == nil || doc.analysis == nil {
 		replyJSON(s.conn, req.ID, &SemanticTokens{Data: []uint32{}})
 		return
 	}
+	replyJSON(s.conn, req.ID, &SemanticTokens{Data: doc.analysis.semanticTokens()})
+}
 
-	l := lexer.New(doc.src)
-	toks := l.Lex()
-	li := doc.analysis.lines
-	idx := doc.analysis.identIndex
-	var sems []semToken
-	for _, tok := range toks {
-		if tok.Kind == token.EOF || tok.Kind == token.NEWLINE || tok.Kind == token.ILLEGAL {
-			continue
-		}
-		st, ok := classifyToken(tok, idx)
-		if !ok {
-			continue
-		}
-		sems = append(sems, fillPosition(st, li, tok.Pos, tok.End))
+// semanticTokens returns the encoded semantic-token payload for one
+// analysis result, computing it at most once. A fresh docAnalysis is
+// built on every didOpen/didChange refresh, so the cache naturally
+// invalidates with the document's semantic state.
+func (a *docAnalysis) semanticTokens() []uint32 {
+	if a == nil || a.lines == nil {
+		return nil
 	}
-	for _, c := range l.Comments() {
-		sems = append(sems, commentSemToken(li, c))
-	}
-
-	replyJSON(s.conn, req.ID, &SemanticTokens{Data: encodeSemTokens(sems)})
+	a.semanticTokenOnce.Do(func() {
+		src := a.lines.src
+		l := lexer.New(src)
+		toks := l.Lex()
+		comments := l.Comments()
+		sems := make([]semToken, 0, len(toks)+len(comments))
+		for _, tok := range toks {
+			if tok.Kind == token.EOF || tok.Kind == token.NEWLINE || tok.Kind == token.ILLEGAL {
+				continue
+			}
+			st, ok := classifyToken(tok, a.identIndex)
+			if !ok {
+				continue
+			}
+			sems = append(sems, fillPosition(st, a.lines, tok.Pos, tok.End))
+		}
+		for _, c := range comments {
+			sems = append(sems, commentSemToken(a.lines, c))
+		}
+		a.semanticTokenData = encodeSemTokens(sems)
+	})
+	return a.semanticTokenData
 }
 
 // classifyToken maps one token.Token to its (type, modifiers) pair through

--- a/internal/lsp/semtok_test.go
+++ b/internal/lsp/semtok_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
@@ -111,5 +112,46 @@ func TestEncodeSemTokensUsesSelfHostedDeltaEncoding(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("encoded = %#v, want %#v", got, want)
+	}
+}
+
+func TestDocAnalysisSemanticTokensMemoizesEncodedPayload(t *testing.T) {
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+	a := s.analyzeSingleFile([]byte("pub fn main() { let value = 1 }\n"))
+
+	first := a.semanticTokens()
+	second := a.semanticTokens()
+
+	if len(first) == 0 {
+		t.Fatal("semanticTokens() returned no data")
+	}
+	if len(second) == 0 {
+		t.Fatal("semanticTokens() returned no data on second call")
+	}
+	if &first[0] != &second[0] {
+		t.Fatal("semanticTokens() recomputed instead of reusing cached payload")
+	}
+}
+
+func TestDocAnalysisSemanticTokensRefreshOnReanalysis(t *testing.T) {
+	s := NewServer(bytes.NewReader(nil), &bytes.Buffer{}, &bytes.Buffer{})
+
+	firstAnalysis := s.analyzeSingleFileViaEngine("untitled:SemanticTokens-1.osty", []byte("pub fn main() { }\n"))
+	first := firstAnalysis.semanticTokens()
+
+	secondAnalysis := s.analyzeSingleFileViaEngine("untitled:SemanticTokens-1.osty", []byte("pub fn main() { let value = 1 }\n"))
+	second := secondAnalysis.semanticTokens()
+
+	if len(first) == 0 || len(second) == 0 {
+		t.Fatal("semanticTokens() returned no data")
+	}
+	if firstAnalysis == secondAnalysis {
+		t.Fatal("reanalysis reused the old docAnalysis")
+	}
+	if &first[0] == &second[0] {
+		t.Fatal("reanalysis reused stale semantic token cache storage")
+	}
+	if reflect.DeepEqual(first, second) {
+		t.Fatal("reanalysis did not update semantic token payload")
 	}
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -319,6 +319,13 @@ type docAnalysis struct {
 	// offset-keyed lookups don't have to scan `resolve.Refs` in
 	// O(n) per query.
 	identIndex map[int]*resolve.Symbol
+	// semanticTokenData memoizes the encoded reply payload for
+	// textDocument/semanticTokens/full. Editors often request this
+	// repeatedly for an unchanged buffer, so caching avoids re-lexing
+	// and re-encoding until the next analysis refresh replaces the
+	// whole docAnalysis.
+	semanticTokenOnce sync.Once
+	semanticTokenData []uint32
 }
 
 // buildIdentIndex walks the file-level Refs/TypeRefs and inverts them


### PR DESCRIPTION
## What changed
- memoized the encoded `textDocument/semanticTokens/full` payload on `docAnalysis`
- routed the semantic-token handler through the cached payload instead of re-lexing and re-encoding on repeated requests
- added tests covering cache reuse and invalidation after reanalysis

## Why
Editors can request semantic tokens repeatedly for an unchanged buffer. The previous path re-lexed and re-encoded every time, which added avoidable LSP work on a hot path.

## Impact
- repeated semantic-token requests for the same analysis now reuse cached data
- cache invalidates naturally when a new `docAnalysis` is created on document refresh

## Validation
- `go test -count=1 -vet=off ./internal/lsp`