### PR TITLE
feat(runtime): ship testing.snapshot + structural diff for assertEq

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -430,6 +430,15 @@ markers, common package/import explanations, and a rerunnable Go command.
 - **Fuzz** (`FuzzLex`, `FuzzParse`) both seeded with real Osty
   snippets and malformed inputs.
 - **Golden snapshots** for diagnostic rendering.
+- **User-visible snapshot tests** (`testing.snapshot(name, output)`
+  per LANG_SPEC §11.5) intercepted by
+  [`internal/llvmgen/stmt.go`](internal/llvmgen/stmt.go) and lowered
+  to a runtime helper in
+  [`internal/backend/runtime/osty_runtime.c`](internal/backend/runtime/osty_runtime.c).
+  Goldens live at `<source_dir>/__snapshots__/<name>.snap`;
+  `osty test --update-snapshots` accepts the current output. Golden
+  mismatches surface as a trim-prefix / trim-suffix line diff that
+  reuses the same runtime helper as `assertEq` on `String` values.
 
 ## Open questions
 

--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -46,6 +46,30 @@ bodies exist so the stub checker accepts imports.
 - **Inline `#[test]`** discovery rejects `#[test]` on parameterised
   functions (silently skipped) and on a function literally named
   `testing`.
+- **`testing.snapshot(name, output)`** — golden-file testing. LLVM
+  lowers the call to `osty_rt_test_snapshot` which resolves
+  `<source_dir>/__snapshots__/<sanitize(name)>.snap` and either
+  creates the file (first run), passes silently (match), or prints a
+  line-level diff and exits 1 (mismatch). Run
+  `osty test --update-snapshots` to accept current output and
+  overwrite every golden in the run; set `OSTY_SNAPSHOT_DIR=<path>`
+  to redirect writes out of the repo (used by the runtime's own
+  test harness). Implementation:
+  [`internal/backend/runtime/osty_runtime.c`](./internal/backend/runtime/osty_runtime.c)
+  (runtime helper + diff),
+  [`internal/llvmgen/stmt.go`](./internal/llvmgen/stmt.go) (call
+  intercept), and [`cmd/osty/test_native.go`](./cmd/osty/test_native.go)
+  (CLI flag).
+- **Structural diff on `testing.assertEq`** — on failure, the
+  emitted message now includes a line-level diff (`- left` / `+ right`
+  with up to 3 context lines) whenever both operands share a
+  diffable shape. Shipped coverage: two `String` values (direct
+  diff) and two `List<T>` values with the same primitive `T` in
+  `{Int, Float, Bool, String}` (rendered to a multi-line literal
+  first, then diffed). Runtime helpers: `osty_rt_strings_DiffLines`,
+  `osty_rt_list_primitive_to_string`. Structs, enums, Maps, and
+  `List<composite>` still fall back to source-text rendering — they
+  need `ToString` protocol dispatch and are tracked separately.
 
 ### Diagnostic codes
 

--- a/LANG_SPEC_v0.5/11-testing.md
+++ b/LANG_SPEC_v0.5/11-testing.md
@@ -43,6 +43,26 @@ generates detailed failure output including:
 - Runtime values (formatted structurally)
 - A structural diff for composite values
 
+**Structural diff (shipped).** When both sides of `assertEq` share
+a diffable shape, the failure message appends a trim-prefix /
+trim-suffix line diff with up to 3 lines of shared context. Lines
+that differ are prefixed with `- left` or `+ right`; shared context
+lines are prefixed with two spaces. The diff is only computed on the
+failure path — passing asserts pay zero. Today's diff coverage:
+
+- Two `String` values — compared directly, line by line.
+- Two `List<T>` values with the same primitive `T` (`Int`, `Float`,
+  `Bool`, `String`) — each list is rendered as a multi-line literal
+  (`[\n  elem,\n  ...\n]`) via `osty_rt_list_primitive_to_string`
+  before the diff runs, so an element-level divergence surfaces as
+  a single-line `-`/`+` pair.
+
+**Still deferred.** Structs, enums, Maps, Sets, Lists of composite
+elements (`List<Struct>`, `List<Map<K, V>>`), and Lists parameterised
+by `Char` or `Byte` fall back to source-text-only rendering. A full
+solution needs `ToString` protocol dispatch and per-shape format
+rules in the backend.
+
 For example:
 
 ```osty
@@ -123,8 +143,34 @@ fn testRenderOutput() {
 }
 ```
 
-First run writes the snapshot file; subsequent runs compare. Update
-with `osty test --update-snapshots`.
+**Location.** The golden file lives at
+`<source_dir>/__snapshots__/<sanitize(name)>.snap`, where
+`source_dir` is the directory of the test source file and `sanitize`
+follows the rule from [§11.7](#117-test-order) (letters, digits,
+underscore pass through; everything else collapses to `_`; empty or
+all-sanitized names fall back to the stem `snapshot`). The source
+path is pinned at compile time so snapshot resolution is independent
+of the process working directory.
+
+**Lifecycle.**
+
+| Golden state | Result |
+|---|---|
+| Missing | Write `output` to the golden; pass with `snapshot: created <path>` on stdout. |
+| Matches `output` byte-for-byte | Pass silently. |
+| Differs from `output` | Print `testing.snapshot(<name>) mismatch: <path>` + a line-level diff (same shape as §11.2) to stdout and exit 1 — same observable outcome as any failing assertion. |
+
+**Accepting new output.** `osty test --update-snapshots` (which sets
+`OSTY_UPDATE_SNAPSHOTS=1` for the emitted test binaries) overwrites
+every golden encountered during the run and prints
+`snapshot: updated <path>` for each — tests still pass.
+
+**Test-harness override.** The runtime honors
+`OSTY_SNAPSHOT_DIR=<path>` as a drop-in replacement for the source
+directory when resolving the golden's location. This is only intended
+for test harnesses that exercise the snapshot machinery itself and
+want to isolate writes into a tempdir; production `osty test` runs
+leave it unset.
 
 ### 11.6 Parallel Execution
 

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -42,7 +42,7 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [--airepair=false] [--airepair-mode MODE] [--seed HEX] [--serial] [--jobs N] [--doc] [PATH|FILTER...]")
+		fmt.Fprintln(stderr, "usage: osty test [--offline | --locked | --frozen] [--backend NAME] [--emit MODE] [--airepair=false] [--airepair-mode MODE] [--seed HEX] [--serial] [--jobs N] [--doc] [--update-snapshots] [PATH|FILTER...]")
 	}
 	var offline, locked, frozen bool
 	fs.BoolVar(&offline, "offline", false, "do not fetch dependencies; fail if caches are missing")
@@ -62,6 +62,8 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	fs.IntVar(&jobs, "jobs", 0, "max concurrent tests when parallel (0 = runtime.NumCPU())")
 	var docTests bool
 	fs.BoolVar(&docTests, "doc", false, "v0.5 G32: extract `osty-fenced examples from /// doc comments and run each as an additional test")
+	var updateSnapshots bool
+	fs.BoolVar(&updateSnapshots, "update-snapshots", false, "accept current `testing.snapshot` output by overwriting each golden file (sets OSTY_UPDATE_SNAPSHOTS for the test child processes)")
 	var pf profileFlags
 	pf.register(fs)
 	if err := fs.Parse(args); err != nil {
@@ -82,6 +84,19 @@ func runTestMain(args []string, flags cliFlags, stdout, stderr io.Writer) int {
 	_ = locked
 	_ = frozen
 	_ = pf
+
+	// --update-snapshots propagates to the emitted test binaries via
+	// the environment, since osty_rt_test_snapshot reads it with
+	// getenv. Setting it on the parent is sufficient because the
+	// exec.Command children inherit the parent's env by default. The
+	// Go process itself ignores the var — it only controls the C
+	// runtime's behavior inside the compiled test binaries.
+	if updateSnapshots {
+		if err := os.Setenv("OSTY_UPDATE_SNAPSHOTS", "1"); err != nil {
+			fmt.Fprintf(stderr, "osty test: %v\n", err)
+			return 2
+		}
+	}
 
 	backendID, emitMode := resolveBackendAndEmitFlags("test", backendName, emitName)
 	pkgDir, filters, err := resolveTestTarget(fs.Args())

--- a/cmd/osty/test_snapshot_e2e_test.go
+++ b/cmd/osty/test_snapshot_e2e_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunTestMainAssertEqListIntShowsStructuralDiff is the end-to-end
+// proof that assertEq on two `List<Int>` surfaces a line-level diff
+// through the full `osty test` pipeline — parse, resolve, check, IR
+// lower, LLVM codegen, clang compile, exec, runner capture. Before
+// this change the message stopped at `left=...source-text...` with
+// no value capture because the backend had no runtime formatter for
+// composite types.
+func TestRunTestMainAssertEqListIntShowsStructuralDiff(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing as t
+
+fn testListIntDiverges() {
+    let a: List<Int> = [1, 2, 3]
+    let b: List<Int> = [1, 99, 3]
+    t.assertEq(a, b)
+}
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runTestMain() exit = %d, want 1 (assertEq should fail)\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	combined := stdout.String() + stderr.String()
+	// The list formatter's 2-space element indent sits inside the
+	// diff-line prefix, so the rendered marker is `-   2,` (diff `- `
+	// + list `  2,`). Match against the combined shape to avoid an
+	// off-by-2 when the indent policy shifts.
+	for _, want := range []string{
+		"FAIL\ttestListIntDiverges",
+		"diff (- left, + right):",
+		"-   2,",
+		"+   99,",
+	} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("List<Int> assertEq failure missing %q in runner output:\nstdout:\n%s\nstderr:\n%s", want, stdout.String(), stderr.String())
+		}
+	}
+}
+
+// TestRunTestMainSnapshotFirstRunCreatesGolden drives a fresh
+// `testing.snapshot` call through the full `osty test` pipeline and
+// asserts the happy path: the test passes, the golden gets written
+// under `__snapshots__/`, and the "snapshot: created" line surfaces
+// in the runner's per-test stdout. Redirects snapshot writes into
+// the tempdir via OSTY_SNAPSHOT_DIR so no stray files land in the
+// worktree even if the test blows up.
+func TestRunTestMainSnapshotFirstRunCreatesGolden(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	snapRoot := filepath.Join(dir, "snap-root")
+	if err := os.Mkdir(snapRoot, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", snapRoot, err)
+	}
+	t.Setenv("OSTY_SNAPSHOT_DIR", snapRoot)
+	t.Setenv("OSTY_UPDATE_SNAPSHOTS", "")
+
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing as t
+
+fn testSnapshotFirstRun() {
+    t.snapshot("greeting", "hello\nworld\n")
+}
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTestMain() exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	// On pass, the runner only forwards the per-test `ok` line; the
+	// child's `snapshot: created` stdout is intentionally quiet. The
+	// observable side-effect is the golden file on disk.
+	if !strings.Contains(stdout.String(), "ok\ttestSnapshotFirstRun") {
+		t.Fatalf("stdout missing passing line:\n%s", stdout.String())
+	}
+	golden := filepath.Join(snapRoot, "__snapshots__", "greeting.snap")
+	saved, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("golden not written at %q: %v", golden, err)
+	}
+	if got := string(saved); got != "hello\nworld\n" {
+		t.Fatalf("golden content = %q, want %q", got, "hello\nworld\n")
+	}
+}
+
+// TestRunTestMainSnapshotMismatchFailsWithDiff writes a golden that
+// disagrees with the test's output and confirms the runner surfaces
+// both the failure and the line-level diff to the user. The update
+// hint must appear so callers discover --update-snapshots without
+// reading source.
+func TestRunTestMainSnapshotMismatchFailsWithDiff(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	snapRoot := filepath.Join(dir, "snap-root")
+	snapDir := filepath.Join(snapRoot, "__snapshots__")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", snapDir, err)
+	}
+	// Pre-seed a disagreeing golden so the test sees a mismatch.
+	if err := os.WriteFile(filepath.Join(snapDir, "greeting.snap"), []byte("hello\nold world\n"), 0o644); err != nil {
+		t.Fatalf("seed golden: %v", err)
+	}
+	t.Setenv("OSTY_SNAPSHOT_DIR", snapRoot)
+	t.Setenv("OSTY_UPDATE_SNAPSHOTS", "")
+
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing as t
+
+fn testSnapshotDiverges() {
+    t.snapshot("greeting", "hello\nnew world\n")
+}
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := runTestMain([]string{dir}, cliFlags{}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runTestMain() exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	combined := stdout.String() + stderr.String()
+	for _, want := range []string{
+		"FAIL\ttestSnapshotDiverges",
+		"mismatch",
+		"OSTY_UPDATE_SNAPSHOTS=1",
+		"- new world",
+		"+ old world",
+	} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("missing %q in runner output:\nstdout:\n%s\nstderr:\n%s", want, stdout.String(), stderr.String())
+		}
+	}
+}
+
+// TestRunTestMainUpdateSnapshotsFlag confirms the --update-snapshots
+// CLI flag converts a would-be mismatch into a pass by overwriting
+// the golden. This locks in that the flag actually propagates the
+// OSTY_UPDATE_SNAPSHOTS env var to the child test binaries.
+func TestRunTestMainUpdateSnapshotsFlag(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	snapRoot := filepath.Join(dir, "snap-root")
+	snapDir := filepath.Join(snapRoot, "__snapshots__")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", snapDir, err)
+	}
+	goldenPath := filepath.Join(snapDir, "greeting.snap")
+	if err := os.WriteFile(goldenPath, []byte("stale content\n"), 0o644); err != nil {
+		t.Fatalf("seed golden: %v", err)
+	}
+	t.Setenv("OSTY_SNAPSHOT_DIR", snapRoot)
+	// Ensure a stray outer setting doesn't mask the flag's effect.
+	t.Setenv("OSTY_UPDATE_SNAPSHOTS", "")
+
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing as t
+
+fn testSnapshotUpdates() {
+    t.snapshot("greeting", "fresh content\n")
+}
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := runTestMain([]string{"--update-snapshots", dir}, cliFlags{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTestMain() --update-snapshots exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	// The observable side-effect of --update-snapshots is the golden
+	// file being replaced — the child's `snapshot: updated` stdout is
+	// swallowed on the passing path.
+	saved, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read updated golden: %v", err)
+	}
+	if got := string(saved); got != "fresh content\n" {
+		t.Fatalf("golden content after update = %q, want fresh content", got)
+	}
+}

--- a/internal/backend/llvm_runtime_snapshot_test.go
+++ b/internal/backend/llvm_runtime_snapshot_test.go
@@ -1,0 +1,363 @@
+package backend
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBundledRuntimeSnapshotLifecycle exercises the three legs of
+// osty_rt_test_snapshot through the real C runtime compiled by clang:
+//
+//  1. First call with no existing golden → writes the file + prints a
+//     "created" line to stdout + exits 0.
+//  2. Second call with a matching payload → no output, exits 0.
+//  3. Third call with a different payload → prints "mismatch" + a
+//     line-level diff + exits 1.
+//
+// The test redirects snapshot writes via OSTY_SNAPSHOT_DIR so nothing
+// pollutes the repo; the runtime still applies the sanitize +
+// __snapshots__ subdir rules the same way as a real test binary.
+func TestBundledRuntimeSnapshotLifecycle(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_snapshot_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_snapshot_harness")
+	snapshotRoot := filepath.Join(dir, "snap-root")
+	if err := os.Mkdir(snapshotRoot, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", snapshotRoot, err)
+	}
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	// Harness drives the public snapshot entry point with whatever
+	// payload argv[1] contains. argv[2] sets the snapshot name so we
+	// can exercise the filename sanitizer separately. We can't easily
+	// test "exit(1) on mismatch" from a single run, so the test
+	// orchestrates multiple invocations from Go.
+	harness := `#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+const char *osty_rt_strings_DiffLines(const char *actual, const char *expected);
+void osty_rt_test_snapshot(const char *name, const char *output, const char *source_path);
+
+int main(int argc, char **argv) {
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s MODE NAME PAYLOAD\n", argv[0]);
+        return 2;
+    }
+    const char *mode = argv[1];
+    const char *name = argv[2];
+    const char *payload = argv[3];
+    const char *source = "/synthetic/source/file.osty";
+    if (strcmp(mode, "snapshot") == 0) {
+        osty_rt_test_snapshot(name, payload, source);
+        return 0;
+    }
+    if (strcmp(mode, "diff") == 0) {
+        if (argc < 5) {
+            fprintf(stderr, "diff mode needs two payloads\n");
+            return 2;
+        }
+        const char *diff = osty_rt_strings_DiffLines(argv[3], argv[4]);
+        printf("%s", diff == NULL ? "" : diff);
+        return 0;
+    }
+    fprintf(stderr, "unknown mode %s\n", mode);
+    return 2;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+
+	buildOutput, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+
+	run := func(env []string, args ...string) (string, string, int) {
+		t.Helper()
+		cmd := exec.Command(binaryPath, args...)
+		cmd.Env = append(os.Environ(), env...)
+		stdout, err := cmd.Output()
+		stderr := ""
+		exitCode := 0
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+			exitCode = ee.ExitCode()
+		} else if err != nil {
+			t.Fatalf("running %q: %v", binaryPath, err)
+		}
+		return string(stdout), stderr, exitCode
+	}
+
+	env := []string{"OSTY_SNAPSHOT_DIR=" + snapshotRoot}
+
+	// Leg 1: first call creates the golden.
+	stdout, stderr, code := run(env, "snapshot", "hello", "alpha\nbeta\ngamma\n")
+	if code != 0 {
+		t.Fatalf("first snapshot call exited %d; stderr=%q", code, stderr)
+	}
+	if !strings.HasPrefix(stdout, "snapshot: created ") {
+		t.Fatalf("first call stdout = %q, want created line", stdout)
+	}
+	snapPath := filepath.Join(snapshotRoot, "__snapshots__", "hello.snap")
+	saved, err := os.ReadFile(snapPath)
+	if err != nil {
+		t.Fatalf("snapshot file not written to %q: %v", snapPath, err)
+	}
+	if got := string(saved); got != "alpha\nbeta\ngamma\n" {
+		t.Fatalf("saved snapshot = %q, want %q", got, "alpha\nbeta\ngamma\n")
+	}
+
+	// Leg 2: matching second call is silent and passes.
+	stdout, stderr, code = run(env, "snapshot", "hello", "alpha\nbeta\ngamma\n")
+	if code != 0 {
+		t.Fatalf("matching snapshot call exited %d; stderr=%q stdout=%q", code, stderr, stdout)
+	}
+	if stdout != "" {
+		t.Fatalf("matching snapshot call produced stdout %q, want empty", stdout)
+	}
+
+	// Leg 3: diverging payload fails with diff.
+	stdout, stderr, code = run(env, "snapshot", "hello", "alpha\nBETA\ngamma\n")
+	if code != 1 {
+		t.Fatalf("mismatch snapshot call exited %d; want 1. stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "mismatch") {
+		t.Fatalf("mismatch stdout missing 'mismatch': %q", stdout)
+	}
+	if !strings.Contains(stdout, "OSTY_UPDATE_SNAPSHOTS=1") {
+		t.Fatalf("mismatch stdout missing update hint: %q", stdout)
+	}
+	// The diff should mark the bad actual line with `-` and the good
+	// expected line with `+`. (The runtime treats the first argument
+	// as "actual" for symmetry with assertEq's left/right labels.)
+	if !strings.Contains(stdout, "- alpha\nBETA\ngamma") && !strings.Contains(stdout, "- BETA") {
+		t.Fatalf("mismatch stdout missing `- BETA` line: %q", stdout)
+	}
+	if !strings.Contains(stdout, "+ beta") {
+		t.Fatalf("mismatch stdout missing `+ beta` line: %q", stdout)
+	}
+
+	// Leg 4: OSTY_UPDATE_SNAPSHOTS overwrites regardless of prior content.
+	updateEnv := append(append([]string{}, env...), "OSTY_UPDATE_SNAPSHOTS=1")
+	stdout, stderr, code = run(updateEnv, "snapshot", "hello", "brand\nnew\ncontent\n")
+	if code != 0 {
+		t.Fatalf("update snapshot call exited %d; stderr=%q", code, stderr)
+	}
+	if !strings.HasPrefix(stdout, "snapshot: updated ") {
+		t.Fatalf("update call stdout = %q, want updated line", stdout)
+	}
+	saved, err = os.ReadFile(snapPath)
+	if err != nil {
+		t.Fatalf("snapshot file missing after update: %v", err)
+	}
+	if got := string(saved); got != "brand\nnew\ncontent\n" {
+		t.Fatalf("updated snapshot = %q, want new content", got)
+	}
+
+	// Leg 5: sanitizer collapses unsafe characters in the name.
+	stdout, _, code = run(env, "snapshot", "tricky/name with.chars!", "ok\n")
+	if code != 0 {
+		t.Fatalf("sanitized snapshot exited %d", code)
+	}
+	// 'tricky/name with.chars!' → 'tricky_name_with_chars_'
+	sanitizedPath := filepath.Join(snapshotRoot, "__snapshots__", "tricky_name_with_chars_.snap")
+	if _, err := os.Stat(sanitizedPath); err != nil {
+		t.Fatalf("sanitizer did not produce expected path %q: %v", sanitizedPath, err)
+	}
+	if !strings.Contains(stdout, "tricky_name_with_chars_.snap") {
+		t.Fatalf("sanitizer stdout missing expected path: %q", stdout)
+	}
+}
+
+// TestBundledRuntimeListPrimitiveToString drives
+// osty_rt_list_primitive_to_string against the typed list runtime —
+// push → format → compare — for each supported element kind
+// (Int/Float/Bool/String) plus the empty-list edge. Validates the
+// output shape `[\n  elem,\n  ...\n]` that the structural-diff path
+// relies on to produce meaningful line-level diffs.
+func TestBundledRuntimeListPrimitiveToString(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_list_fmt_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_list_fmt_harness")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	harness := `#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+void *osty_rt_list_new(void);
+void osty_rt_list_push_i64(void *, int64_t);
+void osty_rt_list_push_f64(void *, double);
+void osty_rt_list_push_i1(void *, bool);
+void osty_rt_list_push_ptr(void *, void *);
+const char *osty_rt_list_primitive_to_string(void *list, int64_t elem_kind);
+
+int main(int argc, char **argv) {
+    if (argc != 2) return 2;
+    const char *mode = argv[1];
+    if (strcmp(mode, "int") == 0) {
+        void *xs = osty_rt_list_new();
+        osty_rt_list_push_i64(xs, 1);
+        osty_rt_list_push_i64(xs, 2);
+        osty_rt_list_push_i64(xs, 3);
+        fputs(osty_rt_list_primitive_to_string(xs, 1), stdout);
+    } else if (strcmp(mode, "float") == 0) {
+        void *xs = osty_rt_list_new();
+        osty_rt_list_push_f64(xs, 0.5);
+        osty_rt_list_push_f64(xs, -1.25);
+        fputs(osty_rt_list_primitive_to_string(xs, 2), stdout);
+    } else if (strcmp(mode, "bool") == 0) {
+        void *xs = osty_rt_list_new();
+        osty_rt_list_push_i1(xs, true);
+        osty_rt_list_push_i1(xs, false);
+        osty_rt_list_push_i1(xs, true);
+        fputs(osty_rt_list_primitive_to_string(xs, 3), stdout);
+    } else if (strcmp(mode, "string") == 0) {
+        void *xs = osty_rt_list_new();
+        osty_rt_list_push_ptr(xs, (void *)"alpha");
+        osty_rt_list_push_ptr(xs, (void *)"beta");
+        fputs(osty_rt_list_primitive_to_string(xs, 4), stdout);
+    } else if (strcmp(mode, "empty") == 0) {
+        void *xs = osty_rt_list_new();
+        fputs(osty_rt_list_primitive_to_string(xs, 1), stdout);
+    } else if (strcmp(mode, "null") == 0) {
+        fputs(osty_rt_list_primitive_to_string(NULL, 1), stdout);
+    } else {
+        return 2;
+    }
+    return 0;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	if out, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, out)
+	}
+
+	fmt := func(mode string) string {
+		out, err := exec.Command(binaryPath, mode).Output()
+		if err != nil {
+			t.Fatalf("%s mode: %v", mode, err)
+		}
+		return string(out)
+	}
+
+	if got := fmt("int"); got != "[\n  1,\n  2,\n  3,\n]" {
+		t.Fatalf("int format = %q", got)
+	}
+	// Float formatter uses %.17g so exactly-representable fractions
+	// round-trip without noise. 0.5 is exact; -1.25 is exact.
+	if got := fmt("float"); got != "[\n  0.5,\n  -1.25,\n]" {
+		t.Fatalf("float format = %q", got)
+	}
+	if got := fmt("bool"); got != "[\n  true,\n  false,\n  true,\n]" {
+		t.Fatalf("bool format = %q", got)
+	}
+	if got := fmt("string"); got != "[\n  \"alpha\",\n  \"beta\",\n]" {
+		t.Fatalf("string format = %q", got)
+	}
+	if got := fmt("empty"); got != "[]" {
+		t.Fatalf("empty format = %q", got)
+	}
+	if got := fmt("null"); got != "[]" {
+		t.Fatalf("null format = %q", got)
+	}
+}
+
+// TestBundledRuntimeDiffLines exercises osty_rt_strings_DiffLines
+// directly without going through the snapshot helper. Covers the edge
+// cases the in-process diff must get right: byte-equal inputs produce
+// no output, all-different inputs produce all `-`/`+` lines, and an
+// interior change produces a trimmed diff block with surrounding
+// context lines.
+func TestBundledRuntimeDiffLines(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_diff_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_diff_harness")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	harness := `#include <stdio.h>
+const char *osty_rt_strings_DiffLines(const char *actual, const char *expected);
+int main(int argc, char **argv) {
+    if (argc != 3) return 2;
+    const char *d = osty_rt_strings_DiffLines(argv[1], argv[2]);
+    printf("%s", d == NULL ? "" : d);
+    return 0;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	if out, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, out)
+	}
+
+	diff := func(a, b string) string {
+		out, err := exec.Command(binaryPath, a, b).Output()
+		if err != nil {
+			t.Fatalf("diff harness %q vs %q: %v", a, b, err)
+		}
+		return string(out)
+	}
+
+	// Equal inputs — empty diff.
+	if got := diff("abc\n", "abc\n"); got != "" {
+		t.Fatalf("equal inputs produced diff %q", got)
+	}
+
+	// Interior single-line change: context lines on both sides.
+	got := diff("alpha\nbeta\ngamma\n", "alpha\nBETA\ngamma\n")
+	// trim-prefix: "alpha" equal → context.
+	// divergent block: `- beta` / `+ BETA`.
+	// trim-suffix: "gamma" equal → context.
+	wantLines := []string{"  alpha", "- beta", "+ BETA", "  gamma"}
+	for _, w := range wantLines {
+		if !strings.Contains(got, w) {
+			t.Fatalf("diff missing %q in:\n%s", w, got)
+		}
+	}
+
+	// Complete divergence — no common prefix/suffix.
+	got = diff("one\ntwo\n", "uno\ndos\n")
+	for _, w := range []string{"- one", "- two", "+ uno", "+ dos"} {
+		if !strings.Contains(got, w) {
+			t.Fatalf("full-diverge diff missing %q in:\n%s", w, got)
+		}
+	}
+
+	// Empty actual produces only `+` lines.
+	got = diff("", "only\nexpected\n")
+	if strings.Contains(got, "- ") {
+		t.Fatalf("empty-actual diff should have no `- ` lines: %q", got)
+	}
+	for _, w := range []string{"+ only", "+ expected"} {
+		if !strings.Contains(got, w) {
+			t.Fatalf("empty-actual diff missing %q in:\n%s", w, got)
+		}
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -21,6 +21,19 @@
 #include <string.h>
 #include <time.h>
 
+/* Snapshot / file-IO primitives — mkdir is spelled differently on Win32
+ * vs. POSIX, so we funnel the one-directory-level call through
+ * osty_rt_mkdir_one. Everything else (fopen/fread/fwrite/getenv) is
+ * already cross-platform in the C standard library. */
+#if defined(_WIN32)
+#  include <direct.h>
+#  define OSTY_RT_MKDIR_ONE(path) _mkdir(path)
+#else
+#  include <sys/stat.h>
+#  include <sys/types.h>
+#  define OSTY_RT_MKDIR_ONE(path) mkdir((path), 0755)
+#endif
+
 /* ============================================================
  * Platform threading abstraction
  *
@@ -5858,4 +5871,535 @@ void *osty_rt_parallel(void *items, int64_t concurrency, void *f_env) {
     free(envs);
     free(handles);
     return out;
+}
+
+/* ============================================================
+ * Snapshot / structural-diff helpers
+ *
+ * `osty_rt_strings_DiffLines` and `osty_rt_test_snapshot` implement
+ * `testing.assertEq`'s String-vs-String diff and `testing.snapshot`
+ * respectively. Both live in the runtime so the compiler only needs
+ * to emit a single call instruction — no per-test boilerplate, and
+ * the OSTY_UPDATE_SNAPSHOTS switch works without recompiling.
+ * ============================================================ */
+
+#define OSTY_UPDATE_SNAPSHOTS_ENV "OSTY_UPDATE_SNAPSHOTS"
+#define OSTY_SNAPSHOT_DIR_ENV     "OSTY_SNAPSHOT_DIR"
+#define OSTY_SNAPSHOT_SUBDIR      "__snapshots__"
+#define OSTY_SNAPSHOT_SUFFIX      ".snap"
+#define OSTY_SNAPSHOT_DEFAULT_STEM "snapshot"
+
+/* osty_rt_xmalloc is the local OOM-or-abort shape used by the
+ * snapshot helpers so each call site stays a single line. `site`
+ * tags the abort for debuggability and matches the naming
+ * convention of osty_rt_string_dup_site. */
+static void *osty_rt_xmalloc(size_t n, const char *site) {
+    void *p = malloc(n);
+    if (p == NULL) {
+        osty_rt_abort(site);
+    }
+    return p;
+}
+
+typedef struct osty_rt_diff_scratch {
+    char  *data;
+    size_t len;
+    size_t cap;
+} osty_rt_diff_scratch;
+
+static void osty_rt_diff_scratch_init(osty_rt_diff_scratch *s) {
+    s->data = NULL;
+    s->len = 0;
+    s->cap = 0;
+}
+
+static void osty_rt_diff_scratch_reserve(osty_rt_diff_scratch *s, size_t want) {
+    if (s->cap >= want + 1) {
+        return;
+    }
+    size_t cap = s->cap == 0 ? 64 : s->cap * 2;
+    while (cap < want + 1) {
+        cap *= 2;
+    }
+    char *next = (char *)realloc(s->data, cap);
+    if (next == NULL) {
+        osty_rt_abort("diff scratch: out of memory");
+    }
+    s->data = next;
+    s->cap = cap;
+}
+
+static void osty_rt_diff_scratch_append(osty_rt_diff_scratch *s, const char *src, size_t n) {
+    if (n == 0) {
+        return;
+    }
+    osty_rt_diff_scratch_reserve(s, s->len + n);
+    memcpy(s->data + s->len, src, n);
+    s->len += n;
+}
+
+static void osty_rt_diff_scratch_append_cstr(osty_rt_diff_scratch *s, const char *src) {
+    if (src == NULL) {
+        return;
+    }
+    osty_rt_diff_scratch_append(s, src, strlen(src));
+}
+
+/* Split a '\n'-terminated string into (offset, length) pairs. A
+ * trailing newline does NOT spawn a synthetic empty line, matching
+ * how `diff` and Unified Patch render. Offsets are kept so the
+ * suffix-trim walk stays O(n) rather than O(n²) via running-sum
+ * recomputation. Caller frees both arrays. */
+static void osty_rt_diff_grow_pair(size_t **offs, size_t **lens, size_t *cap) {
+    *cap *= 2;
+    size_t *grown_offs = (size_t *)realloc(*offs, *cap * sizeof(**offs));
+    size_t *grown_lens = (size_t *)realloc(*lens, *cap * sizeof(**lens));
+    if (grown_offs == NULL || grown_lens == NULL) {
+        free(grown_offs != NULL ? grown_offs : *offs);
+        free(grown_lens != NULL ? grown_lens : *lens);
+        osty_rt_abort("diff split: grow failed");
+    }
+    *offs = grown_offs;
+    *lens = grown_lens;
+}
+
+static void osty_rt_diff_split_lines(const char *s, size_t **out_offs, size_t **out_lens, size_t *out_count) {
+    size_t n = (s == NULL) ? 0 : strlen(s);
+    size_t cap = 16;
+    size_t *offs = (size_t *)osty_rt_xmalloc(cap * sizeof(*offs), "diff split: out of memory");
+    size_t *lens = (size_t *)osty_rt_xmalloc(cap * sizeof(*lens), "diff split: out of memory");
+    size_t count = 0;
+    size_t start = 0;
+    for (size_t i = 0; i <= n; i++) {
+        if (i == n || s[i] == '\n') {
+            if (i == n && start == n) {
+                break;
+            }
+            if (count == cap) {
+                osty_rt_diff_grow_pair(&offs, &lens, &cap);
+            }
+            offs[count] = start;
+            lens[count] = i - start;
+            count++;
+            start = i + 1;
+        }
+    }
+    *out_offs = offs;
+    *out_lens = lens;
+    *out_count = count;
+}
+
+static bool osty_rt_diff_line_equal(const char *a, size_t a_off, size_t a_len, const char *b, size_t b_off, size_t b_len) {
+    if (a_len != b_len) {
+        return false;
+    }
+    if (a_len == 0) {
+        return true;
+    }
+    return memcmp(a + a_off, b + b_off, a_len) == 0;
+}
+
+static void osty_rt_diff_emit_line(osty_rt_diff_scratch *s, const char *tag, const char *src, size_t off, size_t len) {
+    osty_rt_diff_scratch_append_cstr(s, tag);
+    osty_rt_diff_scratch_append(s, src + off, len);
+    osty_rt_diff_scratch_append(s, "\n", 1);
+}
+
+/* osty_rt_strings_DiffLines renders a trim-prefix/suffix line diff
+ * with up to 3 lines of shared context on either side. Returns "" if
+ * the inputs are byte-equal (prefix consumes everything). NULL
+ * inputs normalize to "". */
+const char *osty_rt_strings_DiffLines(const char *actual, const char *expected) {
+    const char *a = (actual == NULL) ? "" : actual;
+    const char *e = (expected == NULL) ? "" : expected;
+
+    size_t *a_off = NULL;
+    size_t *a_len = NULL;
+    size_t a_count = 0;
+    size_t *e_off = NULL;
+    size_t *e_len = NULL;
+    size_t e_count = 0;
+    osty_rt_diff_split_lines(a, &a_off, &a_len, &a_count);
+    osty_rt_diff_split_lines(e, &e_off, &e_len, &e_count);
+
+    size_t prefix = 0;
+    while (prefix < a_count && prefix < e_count &&
+           osty_rt_diff_line_equal(a, a_off[prefix], a_len[prefix], e, e_off[prefix], e_len[prefix])) {
+        prefix++;
+    }
+    size_t suffix = 0;
+    while (suffix + prefix < a_count && suffix + prefix < e_count &&
+           osty_rt_diff_line_equal(a, a_off[a_count - 1 - suffix], a_len[a_count - 1 - suffix],
+                                   e, e_off[e_count - 1 - suffix], e_len[e_count - 1 - suffix])) {
+        suffix++;
+    }
+
+    osty_rt_diff_scratch scratch;
+    osty_rt_diff_scratch_init(&scratch);
+
+    /* No divergence → return "" so callers treat as "no diff". Equal
+     * inputs (prefix consumed both sides) land here too. */
+    bool has_diff = (prefix + suffix < a_count) || (prefix + suffix < e_count);
+    if (!has_diff) {
+        free(a_off);
+        free(a_len);
+        free(e_off);
+        free(e_len);
+        return osty_rt_string_dup_site("", 0, "runtime.test.diff.empty");
+    }
+
+    const size_t context = 3;
+    size_t lead_start = prefix > context ? prefix - context : 0;
+    for (size_t i = lead_start; i < prefix; i++) {
+        osty_rt_diff_emit_line(&scratch, "  ", a, a_off[i], a_len[i]);
+    }
+    for (size_t i = prefix; i + suffix < a_count; i++) {
+        osty_rt_diff_emit_line(&scratch, "- ", a, a_off[i], a_len[i]);
+    }
+    for (size_t i = prefix; i + suffix < e_count; i++) {
+        osty_rt_diff_emit_line(&scratch, "+ ", e, e_off[i], e_len[i]);
+    }
+    size_t tail_count = suffix < context ? suffix : context;
+    for (size_t i = 0; i < tail_count; i++) {
+        size_t idx = a_count - suffix + i;
+        osty_rt_diff_emit_line(&scratch, "  ", a, a_off[idx], a_len[idx]);
+    }
+
+    free(a_off);
+    free(a_len);
+    free(e_off);
+    free(e_len);
+
+    /* Strip the trailing newline so callers can splice a header like
+     * "diff:\n" in front without an extra blank line at the bottom. */
+    while (scratch.len > 0 && scratch.data[scratch.len - 1] == '\n') {
+        scratch.len--;
+    }
+
+    const char *out = osty_rt_string_dup_site(scratch.data == NULL ? "" : scratch.data, scratch.len, "runtime.test.diff");
+    free(scratch.data);
+    return out;
+}
+
+/* osty_rt_strndup copies `n` bytes of `src` into a fresh malloc
+ * buffer + NUL terminator. OOM aborts via the shared `site` tag. */
+static char *osty_rt_strndup(const char *src, size_t n, const char *site) {
+    char *out = (char *)osty_rt_xmalloc(n + 1, site);
+    if (n != 0) {
+        memcpy(out, src, n);
+    }
+    out[n] = '\0';
+    return out;
+}
+
+/* osty_rt_list_primitive_to_string renders a List<T> with a primitive
+ * element type as a multi-line String — one element per line so the
+ * trim-prefix/suffix diff in osty_rt_strings_DiffLines surfaces the
+ * divergence meaningfully:
+ *
+ *     [
+ *       1,
+ *       2,
+ *       3,
+ *     ]
+ *
+ * elem_kind:
+ *   1 = Int    (i64,    osty_rt_list_get_i64)
+ *   2 = Float  (double, osty_rt_list_get_f64)
+ *   3 = Bool   (i1,     osty_rt_list_get_i1)
+ *   4 = String (ptr,    osty_rt_list_get_ptr)
+ *
+ * Char (i32) and Byte (i8) go through the generic bytes path and are
+ * intentionally omitted — they are rare in assertions and would bloat
+ * this helper's dispatch without a proportional payoff. */
+#define OSTY_LIST_KIND_INT    1
+#define OSTY_LIST_KIND_FLOAT  2
+#define OSTY_LIST_KIND_BOOL   3
+#define OSTY_LIST_KIND_STRING 4
+
+const char *osty_rt_list_primitive_to_string(void *list, int64_t elem_kind) {
+    if (list == NULL) {
+        return osty_rt_string_dup_site("[]", 2, "runtime.list.to_string.empty");
+    }
+    int64_t n = osty_rt_list_len(list);
+    if (n == 0) {
+        return osty_rt_string_dup_site("[]", 2, "runtime.list.to_string.empty");
+    }
+
+    osty_rt_diff_scratch s;
+    osty_rt_diff_scratch_init(&s);
+    osty_rt_diff_scratch_append(&s, "[\n", 2);
+    char buf[64];
+    for (int64_t i = 0; i < n; i++) {
+        osty_rt_diff_scratch_append(&s, "  ", 2);
+        switch (elem_kind) {
+        case OSTY_LIST_KIND_INT: {
+            int64_t v = osty_rt_list_get_i64(list, i);
+            int w = snprintf(buf, sizeof(buf), "%lld", (long long)v);
+            if (w > 0) osty_rt_diff_scratch_append(&s, buf, (size_t)w);
+            break;
+        }
+        case OSTY_LIST_KIND_FLOAT: {
+            double v = osty_rt_list_get_f64(list, i);
+            int w = snprintf(buf, sizeof(buf), "%.17g", v);
+            if (w > 0) osty_rt_diff_scratch_append(&s, buf, (size_t)w);
+            break;
+        }
+        case OSTY_LIST_KIND_BOOL: {
+            bool v = osty_rt_list_get_i1(list, i);
+            osty_rt_diff_scratch_append_cstr(&s, v ? "true" : "false");
+            break;
+        }
+        case OSTY_LIST_KIND_STRING: {
+            const char *v = (const char *)osty_rt_list_get_ptr(list, i);
+            osty_rt_diff_scratch_append(&s, "\"", 1);
+            osty_rt_diff_scratch_append_cstr(&s, v == NULL ? "" : v);
+            osty_rt_diff_scratch_append(&s, "\"", 1);
+            break;
+        }
+        default:
+            osty_rt_diff_scratch_append_cstr(&s, "<?>");
+            break;
+        }
+        osty_rt_diff_scratch_append(&s, ",\n", 2);
+    }
+    osty_rt_diff_scratch_append(&s, "]", 1);
+
+    const char *out = osty_rt_string_dup_site(s.data == NULL ? "" : s.data, s.len, "runtime.list.to_string");
+    free(s.data);
+    return out;
+}
+
+/* Sanitize a snapshot name into a filesystem-safe stem. Mirrors
+ * `sanitizeNativeTestName` in toolchain/test_runner.osty: letters,
+ * digits, underscore pass through; everything else collapses to `_`.
+ * Empty/all-sanitized input falls back to OSTY_SNAPSHOT_DEFAULT_STEM
+ * so the output path never ends up as `.snap`. Caller frees. */
+static char *osty_rt_snapshot_sanitize(const char *name) {
+    size_t n = (name == NULL) ? 0 : strlen(name);
+    if (n == 0) {
+        return osty_rt_strndup(OSTY_SNAPSHOT_DEFAULT_STEM, sizeof(OSTY_SNAPSHOT_DEFAULT_STEM) - 1, "snapshot sanitize: out of memory");
+    }
+    char *out = (char *)osty_rt_xmalloc(n + 1, "snapshot sanitize: out of memory");
+    size_t j = 0;
+    for (size_t i = 0; i < n; i++) {
+        unsigned char c = (unsigned char)name[i];
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+            out[j++] = (char)c;
+        } else {
+            out[j++] = '_';
+        }
+    }
+    out[j] = '\0';
+    if (j == 0) {
+        free(out);
+        return osty_rt_strndup(OSTY_SNAPSHOT_DEFAULT_STEM, sizeof(OSTY_SNAPSHOT_DEFAULT_STEM) - 1, "snapshot sanitize: out of memory");
+    }
+    return out;
+}
+
+/* osty_rt_snapshot_dirname returns a malloc'd copy of the directory
+ * component of `path` (everything up to the last `/` or `\`).
+ * Returns "." on empty input or when `path` has no separator — that's
+ * the right default for `osty test` runs where the source file is in
+ * the test's working directory. A root-relative path like "/foo"
+ * collapses to the single leading separator. Caller frees. */
+static char *osty_rt_snapshot_dirname(const char *path) {
+    size_t n = (path == NULL) ? 0 : strlen(path);
+    size_t last = (size_t)-1;
+    for (size_t i = 0; i < n; i++) {
+        if (path[i] == '/' || path[i] == '\\') {
+            last = i;
+        }
+    }
+    if (last == (size_t)-1) {
+        return osty_rt_strndup(".", 1, "snapshot dirname: out of memory");
+    }
+    if (last == 0) {
+        return osty_rt_strndup(path, 1, "snapshot dirname: out of memory");
+    }
+    return osty_rt_strndup(path, last, "snapshot dirname: out of memory");
+}
+
+/* osty_rt_snapshot_mkdir_p creates `path` and every missing parent
+ * segment. mkdir is best-effort — EEXIST, perm errors, or an
+ * intermediate path that's actually a file all fall through to the
+ * subsequent fopen in write_all, which reports the real error with
+ * the offending path. */
+static void osty_rt_snapshot_mkdir_p(const char *path) {
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+    size_t n = strlen(path);
+    char *buf = osty_rt_strndup(path, n, "snapshot mkdir_p: out of memory");
+    for (size_t i = 1; i < n; i++) {
+        char c = buf[i];
+        if (c == '/' || c == '\\') {
+            buf[i] = '\0';
+            (void)OSTY_RT_MKDIR_ONE(buf);
+            buf[i] = c;
+        }
+    }
+    (void)OSTY_RT_MKDIR_ONE(buf);
+    free(buf);
+}
+
+/* Read the entire file into a malloc'd, NUL-terminated buffer. On
+ * success returns 0 and sets *out / *out_len. Missing file → 1.
+ * Any other I/O error → -1. The three exit codes let the caller
+ * distinguish "first run" from a real filesystem problem. */
+static int osty_rt_snapshot_read_all(const char *path, char **out, size_t *out_len) {
+    FILE *f = fopen(path, "rb");
+    if (f == NULL) {
+        *out = NULL;
+        *out_len = 0;
+        return 1;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return -1;
+    }
+    long sz = ftell(f);
+    if (sz < 0 || fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return -1;
+    }
+    char *buf = (char *)osty_rt_xmalloc((size_t)sz + 1, "snapshot read: out of memory");
+    size_t got = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    if (got != (size_t)sz) {
+        free(buf);
+        return -1;
+    }
+    buf[sz] = '\0';
+    *out = buf;
+    *out_len = (size_t)sz;
+    return 0;
+}
+
+static int osty_rt_snapshot_write_all(const char *path, const char *data, size_t len) {
+    FILE *f = fopen(path, "wb");
+    if (f == NULL) {
+        return -1;
+    }
+    if (len != 0) {
+        size_t wrote = fwrite(data, 1, len, f);
+        if (wrote != len) {
+            fclose(f);
+            return -1;
+        }
+    }
+    if (fclose(f) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/* Mirrors the truthy rule used by `osty_gc_incremental_auto_now`: an
+ * unset / empty / "0" / "false" / "FALSE" value reads as false,
+ * anything else is true. Keep in sync with that site. */
+static bool osty_rt_env_truthy(const char *name) {
+    const char *v = getenv(name);
+    if (v == NULL || v[0] == '\0' ||
+        strcmp(v, "0") == 0 || strcmp(v, "false") == 0 || strcmp(v, "FALSE") == 0) {
+        return false;
+    }
+    return true;
+}
+
+/* Build the `<dir>/__snapshots__/<stem>.snap` path for a given source
+ * file + snapshot name. Honors OSTY_SNAPSHOT_DIR as an override used
+ * by the test harness to redirect writes into a tempdir. Caller
+ * frees. */
+static char *osty_rt_snapshot_resolve_path(const char *source_path, const char *name) {
+    const char *override_dir = getenv(OSTY_SNAPSHOT_DIR_ENV);
+    char *base_dir = (override_dir != NULL && override_dir[0] != '\0')
+        ? osty_rt_strndup(override_dir, strlen(override_dir), "snapshot path: out of memory")
+        : osty_rt_snapshot_dirname(source_path);
+
+    char *stem = osty_rt_snapshot_sanitize(name);
+    const char *sep = "/" OSTY_SNAPSHOT_SUBDIR "/";
+    size_t dir_len = strlen(base_dir);
+    size_t sep_len = strlen(sep);
+    size_t stem_len = strlen(stem);
+    size_t sfx_len = sizeof(OSTY_SNAPSHOT_SUFFIX) - 1;
+    char *out = (char *)osty_rt_xmalloc(dir_len + sep_len + stem_len + sfx_len + 1, "snapshot path: out of memory");
+    size_t pos = 0;
+    memcpy(out + pos, base_dir, dir_len); pos += dir_len;
+    memcpy(out + pos, sep, sep_len);       pos += sep_len;
+    memcpy(out + pos, stem, stem_len);     pos += stem_len;
+    memcpy(out + pos, OSTY_SNAPSHOT_SUFFIX, sfx_len); pos += sfx_len;
+    out[pos] = '\0';
+
+    free(base_dir);
+    free(stem);
+    return out;
+}
+
+/* Fatal-exit shape shared by the three "cannot read / cannot write"
+ * branches in osty_rt_test_snapshot. `existing` may be NULL when the
+ * failure happens before the golden is read. */
+static void osty_rt_snapshot_fatal(const char *verb, const char *name, char *snap_path, char *existing) {
+    fprintf(stderr, "testing.snapshot(%s): cannot %s %s\n", name, verb, snap_path);
+    free(existing);
+    free(snap_path);
+    exit(1);
+}
+
+/* osty_rt_test_snapshot is called from emitted code whenever a test
+ * runs `testing.snapshot(name, output)`. `source_path` is hard-coded
+ * at emit time so snapshot discovery is independent of the process
+ * working directory. */
+void osty_rt_test_snapshot(const char *name, const char *output, const char *source_path) {
+    const char *name_s = (name == NULL) ? "" : name;
+    const char *output_s = (output == NULL) ? "" : output;
+    const char *src_s = (source_path == NULL) ? "" : source_path;
+
+    char *snap_path = osty_rt_snapshot_resolve_path(src_s, name_s);
+    char *snap_dir = osty_rt_snapshot_dirname(snap_path);
+    osty_rt_snapshot_mkdir_p(snap_dir);
+    free(snap_dir);
+
+    size_t output_len = strlen(output_s);
+
+    if (osty_rt_env_truthy(OSTY_UPDATE_SNAPSHOTS_ENV)) {
+        if (osty_rt_snapshot_write_all(snap_path, output_s, output_len) != 0) {
+            osty_rt_snapshot_fatal("write", name_s, snap_path, NULL);
+        }
+        fprintf(stdout, "snapshot: updated %s\n", snap_path);
+        free(snap_path);
+        return;
+    }
+
+    char *existing = NULL;
+    size_t existing_len = 0;
+    int rd = osty_rt_snapshot_read_all(snap_path, &existing, &existing_len);
+    if (rd == 1) {
+        if (osty_rt_snapshot_write_all(snap_path, output_s, output_len) != 0) {
+            osty_rt_snapshot_fatal("write", name_s, snap_path, NULL);
+        }
+        fprintf(stdout, "snapshot: created %s\n", snap_path);
+        free(snap_path);
+        return;
+    }
+    if (rd != 0) {
+        osty_rt_snapshot_fatal("read", name_s, snap_path, existing);
+    }
+
+    bool equal = (existing_len == output_len) && (output_len == 0 || memcmp(existing, output_s, output_len) == 0);
+    if (equal) {
+        free(existing);
+        free(snap_path);
+        return;
+    }
+
+    const char *diff = osty_rt_strings_DiffLines(output_s, existing);
+    fprintf(stdout, "testing.snapshot(%s) mismatch: %s\n", name_s, snap_path);
+    fprintf(stdout, "hint: re-run with " OSTY_UPDATE_SNAPSHOTS_ENV "=1 to accept the new output\n");
+    if (diff != NULL && diff[0] != '\0') {
+        fprintf(stdout, "%s\n", diff);
+    }
+    free(existing);
+    free(snap_path);
+    exit(1);
 }

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -902,9 +902,57 @@ func (g *generator) emitTestingCallStmt(call *ast.CallExpr) (bool, error) {
 	case "expectError":
 		_, err := g.emitTestingExpect(call, true)
 		return true, err
+	case "snapshot":
+		return true, g.emitTestingSnapshot(call)
 	default:
 		return true, unsupportedf("call", "testing.%s is not supported by LLVM yet", method)
 	}
+}
+
+// emitTestingSnapshot lowers `testing.snapshot(name, output)` into a
+// call to the runtime helper osty_rt_test_snapshot, which handles the
+// golden file lifecycle (create / compare / emit diff + exit). The
+// generator pins the test source path at compile time so snapshot
+// discovery does not depend on the process working directory — each
+// test binary hard-codes its own origin file.
+func (g *generator) emitTestingSnapshot(call *ast.CallExpr) error {
+	if len(call.Args) != 2 {
+		return unsupportedf("call", "testing.snapshot requires two positional arguments")
+	}
+	for _, arg := range call.Args {
+		if arg == nil || arg.Name != "" || arg.Value == nil {
+			return unsupportedf("call", "testing.snapshot requires positional arguments")
+		}
+	}
+	name, err := g.emitTestingStringArg(call.Args[0].Value, "testing.snapshot name")
+	if err != nil {
+		return err
+	}
+	output, err := g.emitTestingStringArg(call.Args[1].Value, "testing.snapshot output")
+	if err != nil {
+		return err
+	}
+	g.declareRuntimeSymbol("osty_rt_test_snapshot", "void", []paramInfo{{typ: "ptr"}, {typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	sourceLit := llvmStringLiteral(emitter, g.sourcePath)
+	llvmCallVoid(emitter, "osty_rt_test_snapshot", []*LlvmValue{toOstyValue(name), toOstyValue(output), sourceLit})
+	g.takeOstyEmitter(emitter)
+	return nil
+}
+
+// emitTestingStringArg evaluates a String-typed argument to one of
+// the testing helpers and enforces the ptr check once — shared by
+// emitTestingSnapshot and emitRuntimeStringDiff so both surface the
+// same diagnostic shape when a non-String sneaks through.
+func (g *generator) emitTestingStringArg(expr ast.Expr, field string) (value, error) {
+	v, err := g.emitExpr(expr)
+	if err != nil {
+		return value{}, err
+	}
+	if v.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "%s must be String, got %s", field, v.typ)
+	}
+	return v, nil
 }
 
 func (g *generator) testingCallMethod(call *ast.CallExpr) (string, bool) {
@@ -1136,7 +1184,107 @@ func (g *generator) buildAssertCompareMessage(call *ast.CallExpr, name, leftText
 	if rightHasVal {
 		parts = append(parts, staticAssertPart(" = "), dynamicAssertPart(rightStr))
 	}
+	// Structural diff: append a line-level diff for assertEq on types
+	// that have a multi-line friendly string form — two Strings, or
+	// two Lists of the same primitive element. assertNe failures only
+	// happen on byte-equal inputs where a diff would be empty, so we
+	// skip them. Structs, Maps, and List<struct> are deferred: they
+	// need ToString protocol dispatch and per-shape format rules.
+	if name == "assertEq" {
+		leftDiff, rightDiff, ok, err := g.stringifyForStructuralDiff(left, isStringLeft, right, isStringRight)
+		if err != nil {
+			return value{}, err
+		}
+		if ok {
+			diff, err := g.emitRuntimeStringDiff(leftDiff, rightDiff)
+			if err != nil {
+				return value{}, err
+			}
+			parts = append(parts, staticAssertPart("\ndiff (- left, + right):\n"), dynamicAssertPart(diff))
+		}
+	}
 	return g.foldAssertionMessage(parts...)
+}
+
+// listPrimitiveKindID maps an LLVM element type to the elem_kind
+// argument accepted by osty_rt_list_primitive_to_string. Returns 0
+// when the element type is not a supported primitive (struct, enum,
+// Map payload, nested list) — caller falls back to no-diff rendering.
+func listPrimitiveKindID(elemTyp string, elemIsString bool) int {
+	switch elemTyp {
+	case "i64":
+		return 1
+	case "double":
+		return 2
+	case "i1":
+		return 3
+	case "ptr":
+		if elemIsString {
+			return 4
+		}
+	}
+	return 0
+}
+
+// stringifyForStructuralDiff returns (leftStr, rightStr, true) when
+// both operands of an assertEq share a "diffable" shape — today that
+// means either both are Strings or both are Lists of the same
+// primitive element kind (Int / Float / Bool / String). Anything else
+// (mixed shapes, unsupported element types, struct-typed receivers)
+// returns ok=false so the caller skips the diff section.
+func (g *generator) stringifyForStructuralDiff(left value, isStringLeft bool, right value, isStringRight bool) (value, value, bool, error) {
+	if isStringLeft && isStringRight {
+		return left, right, true, nil
+	}
+	kindLeft := listPrimitiveKindID(left.listElemTyp, left.listElemString)
+	kindRight := listPrimitiveKindID(right.listElemTyp, right.listElemString)
+	if kindLeft == 0 || kindRight == 0 || kindLeft != kindRight {
+		return value{}, value{}, false, nil
+	}
+	leftStr, err := g.emitRuntimeListPrimitiveToString(left, kindLeft)
+	if err != nil {
+		return value{}, value{}, false, err
+	}
+	rightStr, err := g.emitRuntimeListPrimitiveToString(right, kindRight)
+	if err != nil {
+		return value{}, value{}, false, err
+	}
+	return leftStr, rightStr, true, nil
+}
+
+// emitRuntimeListPrimitiveToString lowers a call to
+// osty_rt_list_primitive_to_string, which formats a List<T> with
+// primitive T as a multi-line String so the line-diff surfaces
+// element-level divergences.
+func (g *generator) emitRuntimeListPrimitiveToString(v value, kind int) (value, error) {
+	if v.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "osty_rt_list_primitive_to_string expects a ptr (List<T>), got %s", v.typ)
+	}
+	g.declareRuntimeSymbol("osty_rt_list_primitive_to_string", "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	kindLit := llvmIntLiteral(kind)
+	out := llvmCall(emitter, "ptr", "osty_rt_list_primitive_to_string", []*LlvmValue{toOstyValue(v), kindLit})
+	g.takeOstyEmitter(emitter)
+	outV := fromOstyValue(out)
+	outV.gcManaged = true
+	return outV, nil
+}
+
+// emitRuntimeStringDiff lowers a call to osty_rt_strings_DiffLines,
+// which returns a managed String containing a trim-prefix/suffix line
+// diff. An empty result means the two inputs are byte-equal — callers
+// that only invoke this under a failing assertion can ignore that case.
+func (g *generator) emitRuntimeStringDiff(left, right value) (value, error) {
+	if left.typ != "ptr" || right.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "osty_rt_strings_DiffLines expects two String (ptr) values, got %s and %s", left.typ, right.typ)
+	}
+	g.declareRuntimeSymbol("osty_rt_strings_DiffLines", "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", "osty_rt_strings_DiffLines", []*LlvmValue{toOstyValue(left), toOstyValue(right)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	return v, nil
 }
 
 // buildAssertCondMessage composes the failure message for

--- a/internal/llvmgen/testing_snapshot_codegen_test.go
+++ b/internal/llvmgen/testing_snapshot_codegen_test.go
@@ -1,0 +1,160 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTestingSnapshotLowersToRuntimeHelper locks in that
+// `testing.snapshot(name, output)` is intercepted by the LLVM
+// dispatcher and lowered to a call into `osty_rt_test_snapshot`. The
+// generator also hard-codes the test source path as a string literal
+// so the runtime can locate the golden file without consulting the
+// process working directory. Without the intercept the call would
+// fall through to the "testing.X is not supported" diagnostic.
+func TestTestingSnapshotLowersToRuntimeHelper(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.testing as testing
+
+fn main() {
+    testing.snapshot("golden", "hello\nworld\n")
+}
+`)
+	src := `use std.testing as testing
+
+fn main() {
+    testing.snapshot("golden", "hello\nworld\n")
+}
+`
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/testing_snapshot_probe.osty",
+		Source:      []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare void @osty_rt_test_snapshot(ptr, ptr, ptr)",
+		"call void @osty_rt_test_snapshot(",
+		"/tmp/testing_snapshot_probe.osty",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestTestingAssertEqStringsEmitsStructuralDiff confirms that an
+// assertEq comparison between two String values now calls
+// osty_rt_strings_DiffLines on the failure path so the emitted
+// failure message includes a line-level diff. Non-string assertEq
+// (Int/Int, Bool/Bool) must NOT pay the diff cost — the runtime
+// intrinsic is only declared when at least one call site needs it.
+func TestTestingAssertEqStringsEmitsStructuralDiff(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.testing as testing
+
+fn main() {
+    let a = "alpha\nbeta\n"
+    let b = "alpha\nBETA\n"
+    testing.assertEq(a, b)
+}
+`)
+	src := `use std.testing as testing
+
+fn main() {
+    let a = "alpha\nbeta\n"
+    let b = "alpha\nBETA\n"
+    testing.assertEq(a, b)
+}
+`
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/testing_asserteq_strings.osty",
+		Source:      []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_DiffLines(ptr, ptr)",
+		"call ptr @osty_rt_strings_DiffLines(",
+		"diff (- left, + right):",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestTestingAssertEqListIntEmitsStructuralDiff confirms the diff
+// path now extends beyond String/String: two List<Int> values route
+// through osty_rt_list_primitive_to_string first (elem_kind=1) and
+// then feed the stringified forms to osty_rt_strings_DiffLines. Past
+// releases stopped at `= [...]` source-text-only because there was
+// no runtime formatter for lists; the helper closes that gap.
+func TestTestingAssertEqListIntEmitsStructuralDiff(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.testing as testing
+
+fn main() {
+    let a: List<Int> = [1, 2, 3]
+    let b: List<Int> = [1, 99, 3]
+    testing.assertEq(a, b)
+}
+`)
+	src := `use std.testing as testing
+
+fn main() {
+    let a: List<Int> = [1, 2, 3]
+    let b: List<Int> = [1, 99, 3]
+    testing.assertEq(a, b)
+}
+`
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/testing_asserteq_list_int.osty",
+		Source:      []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_primitive_to_string(ptr, i64)",
+		"call ptr @osty_rt_list_primitive_to_string(",
+		"declare ptr @osty_rt_strings_DiffLines(ptr, ptr)",
+		"call ptr @osty_rt_strings_DiffLines(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("List<Int> assertEq IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestTestingAssertEqIntegersSkipsDiff(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.testing as testing
+
+fn main() {
+    testing.assertEq(1, 2)
+}
+`)
+	src := `use std.testing as testing
+
+fn main() {
+    testing.assertEq(1, 2)
+}
+`
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/testing_asserteq_ints.osty",
+		Source:      []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	if strings.Contains(got, "osty_rt_strings_DiffLines") {
+		t.Fatalf("Int/Int assertEq should not pull in DiffLines; IR leaked it:\n%s", got)
+	}
+}

--- a/internal/stdlib/modules/testing.osty
+++ b/internal/stdlib/modules/testing.osty
@@ -46,7 +46,24 @@ pub fn benchmark(iterations: Int, body: fn() -> Result<(), Error>) {
     body()
 }
 
+/// `snapshot(name, output)` compares `output` against a golden file
+/// stored at `<source_dir>/__snapshots__/<sanitize(name)>.snap`.
+///
+///   - First run (or file missing): the golden is written and the
+///     test passes with `snapshot: created <path>` on stdout.
+///   - Match: the test passes silently.
+///   - Mismatch: the test prints the location + a line-level diff
+///     (trim prefix/suffix with up to 3 context lines) and exits 1,
+///     just like `assertEq`.
+///
+/// Re-run `osty test --update-snapshots` (or set
+/// `OSTY_UPDATE_SNAPSHOTS=1`) to accept the new output and overwrite
+/// every golden in the run. The LLVM backend intercepts this call
+/// and emits a direct runtime helper — the stub body below exists
+/// only to satisfy the type checker.
 pub fn snapshot(name: String, output: String) {
+    let _ = name
+    let _ = output
 }
 
 // ---------- property-based testing (v0.5 G33) ----------


### PR DESCRIPTION
## Summary

Closes the §11.2 structural-diff and §11.5 snapshot gaps from LANG_SPEC_v0.5's testing chapter:

- **`testing.snapshot(name, output)`** records and replays goldens. First run writes `<source_dir>/__snapshots__/<sanitize(name)>.snap`; subsequent runs compare and, on mismatch, print a line-level diff and exit 1 (same observable shape as a failing `assertEq`). `osty test --update-snapshots` accepts the current output.
- **Structural diff on `assertEq`** failures now shipped for two shapes:
  1. `String` vs `String` — direct line diff with up to 3 lines of shared context.
  2. `List<T>` vs `List<T>` with `T ∈ {Int, Float, Bool, String}` — each list is rendered as a multi-line literal via `osty_rt_list_primitive_to_string` before the diff runs, so element-level divergences surface as single-line `-`/`+` pairs.

## What's in the change

### Runtime (`internal/backend/runtime/osty_runtime.c`)
- `osty_rt_strings_DiffLines(actual, expected)` — trim-prefix / trim-suffix line diff, returns `""` for byte-equal inputs.
- `osty_rt_test_snapshot(name, output, source_path)` — golden file lifecycle. Honors `OSTY_UPDATE_SNAPSHOTS=1` (overwrite) and `OSTY_SNAPSHOT_DIR=<path>` (test-harness redirect).
- `osty_rt_list_primitive_to_string(list, elem_kind)` — `[\n  elem,\n  ...\n]` formatter dispatching on `elem_kind`.
- Small shared helpers (`xmalloc`, `strndup`, `diff_scratch`, `env_truthy` matching the existing GC env idiom) to keep each new call site one line.

### Codegen (`internal/llvmgen/stmt.go`)
- `emitTestingSnapshot` intercepts the call at emit time and passes `g.sourcePath` as a compile-time string literal — snapshot discovery is independent of the process working directory.
- `stringifyForStructuralDiff` routes Strings/Strings and matching `List<primitive>` pairs into `osty_rt_strings_DiffLines`; everything else (struct, enum, Map, Set, `List<composite>`, `List<Char>`, `List<Byte>`) falls back to the existing source-text message.

### CLI (`cmd/osty/test_native.go`)
- `--update-snapshots` flag sets `OSTY_UPDATE_SNAPSHOTS=1` for the child test binaries so users don't have to discover the env var. The parent process sets it once; `exec.Command` children inherit.

### Docs
- `LANG_SPEC_v0.5/11-testing.md` §11.2 + §11.5 rewritten with shipped-vs-deferred tables.
- `ARCHITECTURE.md` testing strategy section calls out user-visible snapshot tests.
- `CHANGELOG_v0.5.md` lists both features.
- `internal/stdlib/modules/testing.osty` snapshot docstring replaces the placeholder with real semantics.

### Tests (all new)
- `internal/backend/llvm_runtime_snapshot_test.go` — clang-driven harnesses covering: snapshot lifecycle (create / match / mismatch / update / name sanitizer), `DiffLines` edge cases (equal / interior diff / full divergence / empty actual), and the List formatter across 6 modes (Int / Float / Bool / String / empty / NULL).
- `internal/llvmgen/testing_snapshot_codegen_test.go` — IR-shape tests for the snapshot call intercept, String diff, `List<Int>` diff, and Int/Int no-diff opt-out.
- `cmd/osty/test_snapshot_e2e_test.go` — full `osty test` pipeline tests for snapshot create, mismatch+diff output, `--update-snapshots` flag, and `assertEq(List<Int>, List<Int>)` structural diff.

## Still deferred

Structs, enums, Maps, Sets, `List<composite>`, and `List<Char/Byte>` structural diff all need `ToString` protocol dispatch in the backend. Marked as planned in §11.2 so the next author hits a signpost instead of a wall.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/backend/... ./internal/llvmgen/... ./cmd/osty/...` clean
- [x] 3 new runtime tests pass: `TestBundledRuntimeSnapshotLifecycle`, `TestBundledRuntimeDiffLines`, `TestBundledRuntimeListPrimitiveToString`
- [x] 4 new codegen tests pass: `TestTestingSnapshotLowersToRuntimeHelper`, `TestTestingAssertEqStringsEmitsStructuralDiff`, `TestTestingAssertEqListIntEmitsStructuralDiff`, `TestTestingAssertEqIntegersSkipsDiff`
- [x] 4 new E2E tests pass: `TestRunTestMainSnapshotFirstRunCreatesGolden`, `TestRunTestMainSnapshotMismatchFailsWithDiff`, `TestRunTestMainUpdateSnapshotsFlag`, `TestRunTestMainAssertEqListIntShowsStructuralDiff`
- [x] Existing native runner tests still pass (`TestRunTestMainPassesNativeLLVMTest`, `TestRunTestMainReportsNativeLLVMFailure`)
- [x] Frontend pipeline unaffected (`./internal/speccorpus/...`, `./internal/stdlib/...`, `./internal/check/...` all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)