### PR TITLE
[codex] make file-mode selfhost checker authoritative

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -155,24 +155,8 @@ func File(f *ast.File, rr *resolve.Result, opts ...Opts) *Result {
 		diag.StampFile(d, path)
 		result.Diags = append(result.Diags, d...)
 	}
-	applyNativeFileResult(result, f, rr, opt.Source, opt.Stdlib)
+	applyNativeFileResult(result, f, rr, opt.Source, opt.Stdlib, opt.Privileged)
 	diag.StampFile(result.Diags, path)
-	if d := runPrivilegeGate(f, opt.Privileged); len(d) > 0 {
-		diag.StampFile(d, path)
-		result.Diags = append(result.Diags, d...)
-	}
-	if d := runPodShapeChecks(f); len(d) > 0 {
-		diag.StampFile(d, path)
-		result.Diags = append(result.Diags, d...)
-	}
-	if d := runNoAllocChecks(f, rr); len(d) > 0 {
-		diag.StampFile(d, path)
-		result.Diags = append(result.Diags, d...)
-	}
-	if d := runIntrinsicBodyChecks(f); len(d) > 0 {
-		diag.StampFile(d, path)
-		result.Diags = append(result.Diags, d...)
-	}
 	recordSelfhostDeclPass(opt.OnDecl, f, "collect")
 	recordSelfhostDeclPass(opt.OnDecl, f, "check")
 	return result
@@ -196,28 +180,28 @@ func Package(pkg *resolve.Package, pr *resolve.PackageResult, opts ...Opts) *Res
 			result.Diags = append(result.Diags, d...)
 		}
 	}
-	applyNativePackageResult(result, pkg, pr, nil, opt.Stdlib)
-	stampPackageDiags(result.Diags, pkg)
 	privileged := isPrivilegedPackage(pkg)
+	applyNativePackageResult(result, pkg, pr, nil, opt.Stdlib, privileged)
+	stampPackageDiags(result.Diags, pkg)
 	for _, pf := range pkg.Files {
 		if pf == nil {
 			continue
 		}
 		if d := runPrivilegeGate(pf.File, privileged); len(d) > 0 {
 			diag.StampFile(d, pf.Path)
-			result.Diags = append(result.Diags, d...)
+			result.Diags = appendMissingDiagnostics(result.Diags, d)
 		}
 		if d := runPodShapeChecks(pf.File); len(d) > 0 {
 			diag.StampFile(d, pf.Path)
-			result.Diags = append(result.Diags, d...)
+			result.Diags = appendMissingDiagnostics(result.Diags, d)
 		}
 		if d := runNoAllocChecks(pf.File, nil); len(d) > 0 {
 			diag.StampFile(d, pf.Path)
-			result.Diags = append(result.Diags, d...)
+			result.Diags = appendMissingDiagnostics(result.Diags, d)
 		}
 		if d := runIntrinsicBodyChecks(pf.File); len(d) > 0 {
 			diag.StampFile(d, pf.Path)
-			result.Diags = append(result.Diags, d...)
+			result.Diags = appendMissingDiagnostics(result.Diags, d)
 		}
 		recordSelfhostDeclPass(opt.OnDecl, pf.File, "collect")
 		recordSelfhostDeclPass(opt.OnDecl, pf.File, "check")
@@ -275,26 +259,26 @@ func Workspace(
 	for _, e := range walk {
 		pkgResult := out[e.path]
 		stampPackageDiags(pkgResult.Diags, e.pkg)
-		privileged := isPrivilegedPackagePath(e.path) || isPrivilegedPackage(e.pkg)
 		for _, pf := range e.pkg.Files {
 			if pf == nil {
 				continue
 			}
+			privileged := isPrivilegedPackagePath(e.path) || isPrivilegedPackage(e.pkg)
 			if d := runPrivilegeGate(pf.File, privileged); len(d) > 0 {
 				diag.StampFile(d, pf.Path)
-				pkgResult.Diags = append(pkgResult.Diags, d...)
+				pkgResult.Diags = appendMissingDiagnostics(pkgResult.Diags, d)
 			}
 			if d := runPodShapeChecks(pf.File); len(d) > 0 {
 				diag.StampFile(d, pf.Path)
-				pkgResult.Diags = append(pkgResult.Diags, d...)
+				pkgResult.Diags = appendMissingDiagnostics(pkgResult.Diags, d)
 			}
 			if d := runNoAllocChecks(pf.File, nil); len(d) > 0 {
 				diag.StampFile(d, pf.Path)
-				pkgResult.Diags = append(pkgResult.Diags, d...)
+				pkgResult.Diags = appendMissingDiagnostics(pkgResult.Diags, d)
 			}
 			if d := runIntrinsicBodyChecks(pf.File); len(d) > 0 {
 				diag.StampFile(d, pf.Path)
-				pkgResult.Diags = append(pkgResult.Diags, d...)
+				pkgResult.Diags = appendMissingDiagnostics(pkgResult.Diags, d)
 			}
 			recordSelfhostDeclPass(opt.OnDecl, pf.File, "collect")
 			recordSelfhostDeclPass(opt.OnDecl, pf.File, "check")
@@ -413,6 +397,57 @@ func offsetMatchesName(src []byte, offset int, name string) bool {
 		return false
 	}
 	return string(src[offset:offset+len(name)]) == name
+}
+
+func appendMissingDiagnostics(dst, extras []*diag.Diagnostic) []*diag.Diagnostic {
+	for _, extra := range extras {
+		if extra == nil || hasEquivalentDiagnostic(dst, extra) {
+			continue
+		}
+		dst = append(dst, extra)
+	}
+	return dst
+}
+
+func hasEquivalentDiagnostic(ds []*diag.Diagnostic, want *diag.Diagnostic) bool {
+	for _, got := range ds {
+		if sameDiagnostic(got, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameDiagnostic(a, b *diag.Diagnostic) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Severity != b.Severity || a.Code != b.Code || a.Message != b.Message || a.File != b.File {
+		return false
+	}
+	aPos := a.PrimaryPos()
+	bPos := b.PrimaryPos()
+	if aPos != bPos {
+		return false
+	}
+	aEnd := diagnosticPrimaryEnd(a)
+	bEnd := diagnosticPrimaryEnd(b)
+	return aEnd == bEnd
+}
+
+func diagnosticPrimaryEnd(d *diag.Diagnostic) token.Pos {
+	if d == nil {
+		return token.Pos{}
+	}
+	for _, s := range d.Spans {
+		if s.Primary {
+			return s.Span.End
+		}
+	}
+	if len(d.Spans) > 0 {
+		return d.Spans[0].Span.End
+	}
+	return token.Pos{}
 }
 
 // perFileResolveResult builds the minimal resolve.Result shape the

--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -417,11 +417,11 @@ type selfhostFileSegment struct {
 	sourceMap *sourcemap.Map
 }
 
-func applyNativeFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider) {
-	applySelfhostFileResult(result, file, rr, src, stdlib)
+func applyNativeFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider, privileged bool) {
+	applySelfhostFileResult(result, file, rr, src, stdlib, privileged)
 }
 
-func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider) {
+func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result, src []byte, stdlib resolve.StdlibProvider, privileged bool) {
 	if result == nil {
 		return
 	}
@@ -454,16 +454,17 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 		))
 		return
 	}
-	result.Diags = append(result.Diags, nativeCheckerDiags(checkedSrc.source, checked)...)
-	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked)
+	policy := nativeDiagPolicy{privileged: privileged}
+	result.Diags = append(result.Diags, nativeCheckerDiags(checkedSrc.source, checked, policy)...)
+	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	overlaySelfhostResult(result, checkedSrc, checked)
 }
 
-func applyNativePackageResult(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider) {
-	applySelfhostPackageResult(result, pkg, pr, ws, stdlib)
+func applyNativePackageResult(result *Result, pkg *resolve.Package, pr *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool) {
+	applySelfhostPackageResult(result, pkg, pr, ws, stdlib, privileged)
 }
 
-func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider) {
+func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve.PackageResult, ws *resolve.Workspace, stdlib resolve.StdlibProvider, privileged bool) {
 	if result == nil || pkg == nil {
 		return
 	}
@@ -506,8 +507,9 @@ func applySelfhostPackageResult(result *Result, pkg *resolve.Package, _ *resolve
 		))
 		return
 	}
-	result.Diags = append(result.Diags, nativeCheckerDiags(src.source, checked)...)
-	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked)
+	policy := nativeDiagPolicy{privileged: privileged}
+	result.Diags = append(result.Diags, nativeCheckerDiags(src.source, checked, policy)...)
+	result.NativeCheckerTelemetry = nativeCheckerTelemetry(checked, policy)
 	overlaySelfhostResult(result, src, checked)
 }
 
@@ -524,20 +526,26 @@ func applySelfhostWorkspaceResults(ws *resolve.Workspace, _ map[string]*resolve.
 		if isProviderStdlibPackage(ws, path, pkg) {
 			continue
 		}
-		applySelfhostPackageResult(result, pkg, nil, ws, stdlib)
+		privileged := isPrivilegedPackagePath(path) || isPrivilegedPackage(pkg)
+		applySelfhostPackageResult(result, pkg, nil, ws, stdlib, privileged)
 	}
 }
 
-func nativeCheckerTelemetry(checked nativeCheckResult) *NativeCheckerTelemetry {
-	if checked.Summary.Assignments == 0 && checked.Summary.Errors == 0 && len(checked.Summary.ErrorsByContext) == 0 {
+type nativeDiagPolicy struct {
+	privileged bool
+}
+
+func nativeCheckerTelemetry(checked nativeCheckResult, policy nativeDiagPolicy) *NativeCheckerTelemetry {
+	summary := filteredNativeSummary(checked, policy)
+	if summary.Assignments == 0 && summary.Errors == 0 && len(summary.ErrorsByContext) == 0 {
 		return nil
 	}
 	return &NativeCheckerTelemetry{
-		Assignments:     checked.Summary.Assignments,
-		Accepted:        checked.Summary.Accepted,
-		Errors:          checked.Summary.Errors,
-		ErrorsByContext: cloneStringIntMap(checked.Summary.ErrorsByContext),
-		ErrorDetails:    cloneErrorDetailMap(checked.Summary.ErrorDetails),
+		Assignments:     summary.Assignments,
+		Accepted:        summary.Accepted,
+		Errors:          summary.Errors,
+		ErrorsByContext: cloneStringIntMap(summary.ErrorsByContext),
+		ErrorDetails:    cloneErrorDetailMap(summary.ErrorDetails),
 	}
 }
 
@@ -563,32 +571,85 @@ func cloneStringIntMap(src map[string]int) map[string]int {
 	return out
 }
 
-func nativeCheckerDiags(src []byte, checked nativeCheckResult) []*diag.Diagnostic {
+func nativeCheckerDiags(src []byte, checked nativeCheckResult, policy nativeDiagPolicy) []*diag.Diagnostic {
 	out := make([]*diag.Diagnostic, 0, len(checked.Diagnostics))
 	for _, d := range checked.Diagnostics {
+		if shouldSuppressNativeDiag(d, policy) {
+			continue
+		}
 		if converted := convertNativeDiag(src, d); converted != nil {
 			out = append(out, converted)
 		}
 	}
-	if checked.Summary.Errors == 0 {
+	summary := filteredNativeSummary(checked, policy)
+	if summary.Errors == 0 {
 		return out
 	}
 	label := "native checker reported type errors"
-	if checked.Summary.Errors == 1 {
+	if summary.Errors == 1 {
 		label = "native checker reported a type error"
 	}
 	out = append(out,
-		diag.New(diag.Error, fmt.Sprintf("%s: %d error(s)", label, checked.Summary.Errors)).
+		diag.New(diag.Error, fmt.Sprintf("%s: %d error(s)", label, summary.Errors)).
 			Code(diag.CodeTypeMismatch).
 			Primary(fileStartSpan(src), "native checker summary").
 			Note(fmt.Sprintf(
 				"native checker accepted %d of %d assignment/return/call checks",
-				checked.Summary.Accepted,
-				checked.Summary.Assignments,
+				summary.Accepted,
+				summary.Assignments,
 			)).
 			Build(),
 	)
 	return out
+}
+
+func filteredNativeSummary(checked nativeCheckResult, policy nativeDiagPolicy) nativeCheckSummary {
+	summary := checked.Summary
+	if !policy.privileged {
+		return summary
+	}
+	suppressed := 0
+	for _, d := range checked.Diagnostics {
+		if shouldSuppressNativeDiag(d, policy) && nativeDiagIsError(d) {
+			suppressed++
+		}
+	}
+	if suppressed == 0 {
+		return summary
+	}
+	if summary.Errors < suppressed {
+		summary.Errors = 0
+	} else {
+		summary.Errors -= suppressed
+	}
+	if len(summary.ErrorsByContext) > 0 {
+		summary.ErrorsByContext = cloneStringIntMap(summary.ErrorsByContext)
+		delete(summary.ErrorsByContext, diag.CodeRuntimePrivilegeViolation)
+		if len(summary.ErrorsByContext) == 0 {
+			summary.ErrorsByContext = nil
+		}
+	}
+	if len(summary.ErrorDetails) > 0 {
+		summary.ErrorDetails = cloneErrorDetailMap(summary.ErrorDetails)
+		delete(summary.ErrorDetails, diag.CodeRuntimePrivilegeViolation)
+		if len(summary.ErrorDetails) == 0 {
+			summary.ErrorDetails = nil
+		}
+	}
+	return summary
+}
+
+func shouldSuppressNativeDiag(d nativeCheckDiagnostic, policy nativeDiagPolicy) bool {
+	return policy.privileged && d.Code == diag.CodeRuntimePrivilegeViolation
+}
+
+func nativeDiagIsError(d nativeCheckDiagnostic) bool {
+	switch strings.ToLower(strings.TrimSpace(d.Severity)) {
+	case "warning", "warn", "lint":
+		return false
+	default:
+		return true
+	}
 }
 
 // convertNativeDiag lifts a per-record structured diagnostic emitted by

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -189,6 +189,91 @@ func TestConvertNativeDiagPreservesFile(t *testing.T) {
 	}
 }
 
+func TestNativeBoundaryDoesNotReplayGoPolicyGates(t *testing.T) {
+	src := []byte(`#[intrinsic]
+pub fn raw_null() -> Int { 0 }
+`)
+	file, res := parseResolvedFile(t, src)
+	fn := file.Decls[0].(*ast.FnDecl)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return fakeNativeChecker{result: nativeCheckResult{
+			Summary: nativeCheckSummary{},
+			Diagnostics: []nativeCheckDiagnostic{
+				{
+					Code:     diag.CodeIntrinsicNonEmptyBody,
+					Severity: "error",
+					Message:  "`#[intrinsic]` function `raw_null` must have an empty body",
+					Start:    fn.Body.Pos().Offset,
+					End:      fn.Body.End().Offset,
+				},
+			},
+		}}, ""
+	}
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+
+	got := 0
+	for _, d := range chk.Diags {
+		if d != nil && d.Code == diag.CodeIntrinsicNonEmptyBody {
+			got++
+		}
+	}
+	if got != 1 {
+		t.Fatalf("expected exactly one native E0773 diagnostic, got %d: %#v", got, chk.Diags)
+	}
+}
+
+func TestNativeBoundarySuppressesPrivilegeDiagnosticsInPrivilegedMode(t *testing.T) {
+	src := []byte(`#[intrinsic]
+pub fn raw_null() -> Int { }
+`)
+	file, res := parseResolvedFile(t, src)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) {
+		return fakeNativeChecker{result: nativeCheckResult{
+			Summary: nativeCheckSummary{
+				Assignments:     1,
+				Accepted:        1,
+				Errors:          1,
+				ErrorsByContext: map[string]int{diag.CodeRuntimePrivilegeViolation: 1},
+				ErrorDetails: map[string]map[string]int{
+					diag.CodeRuntimePrivilegeViolation: {
+						"`#[intrinsic]` is a runtime-only annotation": 1,
+					},
+				},
+			},
+			Diagnostics: []nativeCheckDiagnostic{
+				{
+					Code:     diag.CodeRuntimePrivilegeViolation,
+					Severity: "error",
+					Message:  "`#[intrinsic]` is a runtime-only annotation",
+					Start:    0,
+					End:      0,
+				},
+			},
+		}}, ""
+	}
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached(), Privileged: true})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected privileged host boundary to suppress E0770 diagnostics, got %#v", chk.Diags)
+	}
+	if chk.NativeCheckerTelemetry == nil {
+		t.Fatal("expected native telemetry to survive filtering")
+	}
+	if chk.NativeCheckerTelemetry.Errors != 0 {
+		t.Fatalf("telemetry errors = %d, want 0", chk.NativeCheckerTelemetry.Errors)
+	}
+	if got := chk.NativeCheckerTelemetry.ErrorsByContext[diag.CodeRuntimePrivilegeViolation]; got != 0 {
+		t.Fatalf("telemetry retained privileged bucket count %d", got)
+	}
+}
+
 func TestNativeBoundaryOverlaysCanonicalSourceSpansBackToOriginalAST(t *testing.T) {
 	src := []byte(`func main() {
     let xs = [1]

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -221,6 +221,11 @@ func patchGenerated(path string) error {
 	}
 	src := string(data)
 	src = normalizeGeneratedSourceComment(src)
+	// bootstrap-gen still leaks a handful of slice-length helper calls as
+	// `units.len()` in otherwise-valid Go. Keep the post-pass narrowly
+	// scoped to the local temp variable name so diag example strings like
+	// `Ok(s.len())` stay untouched.
+	src = strings.ReplaceAll(src, "units.len()", "len(units)")
 	for _, fn := range []struct {
 		name string
 		body string

--- a/toolchain/check_gates.osty
+++ b/toolchain/check_gates.osty
@@ -12,20 +12,13 @@
 // `internal/check/*.go`; the Osty-first rule (CLAUDE.md) requires that
 // new gate logic go here instead.
 //
-// Migration status (Phase 1):
+// Migration status:
 //
-//   The gate body below is live on the Osty side and bundled into the
-//   native-checker (see `internal/selfhost/bundle/bundle.go`). The
-//   structured-diagnostics bridge (`FrontCheckResult.diagnostics`
-//   -> `selfhost.CheckResult.Diagnostics`
-//   -> `nativeCheckResult.Diagnostics`
-//   -> `*diag.Diagnostic`) is in place. Until
-//   `internal/selfhost/generated.go` regenerates cleanly (tracked
-//   separately in internal/bootstrap/gen), the embedded/native checker
-//   still runs an older bundle; the Go-side gate in
-//   `internal/check/intrinsic_body.go` therefore remains authoritative
-//   for now. When regen lands, drop the Go gate + its call sites in
-//   `internal/check/check.go` and this file becomes the source of truth.
+//   The gates below are the authoritative policy source. The host bridge maps
+//   their structured diagnostics into ordinary Go diagnostics, keeps the
+//   minimal privilege-aware filtering for `E0770`, and only leaves a temporary
+//   package/workspace fallback while the structured package adapter reaches
+//   parity with file-mode gate emission.
 //
 // Gates implemented:
 //


### PR DESCRIPTION
## Summary
- make file-mode checking trust native checker results instead of replaying Go-side policy gates
- keep package/workspace gap-fill fallback only for diagnostics still missing from the structured native path
- regenerate selfhost checker output and fix the bootstrap regen path so gate code is emitted again

## Why
The host adapter was still re-running policy gates after overlaying native results, which meant the selfhost checker was not actually authoritative in file mode. At the same time, selfhost regeneration had drifted enough that the generated checker path needed a small bootstrap fix before native gate output could be trusted again.

## Impact
File-level checks now treat the selfhost/native checker as the source of truth, privileged E0770 diagnostics stay filtered at the host boundary, and package/workspace mode keeps a narrow deduped fallback until structured native parity is complete.

## Validation
- `go generate ./internal/selfhost`
- `go test -count=1 -vet=off ./internal/check ./internal/selfhost`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestRuntimeIntrinsicTyping|TestRuntimeIntrinsicCodegen|TestCABICodegen|TestExportCodegen|TestMultifileProbe'`
- `go test -count=1 -vet=off ./internal/check -run 'TestNativeBoundaryDoesNotReplayGoPolicyGates|TestCheckPackageStampsPerFile'`