### PR TITLE
[codex] strengthen HIR selfhost support

### DIFF
--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -39723,24 +39723,27 @@ func elabInferClosure(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 	var paramTys []int = make([]int, 0, 1)
 	_ = paramTys
 	// Osty: /tmp/selfhost_merged.osty:18409:5
+	var prefixLets []int = make([]int, 0, 1)
+	_ = prefixLets
+	// Osty: /tmp/selfhost_merged.osty:18410:5
 	i := 0
 	_ = i
-	// Osty: /tmp/selfhost_merged.osty:18410:5
+	// Osty: /tmp/selfhost_merged.osty:18411:5
 	for _, paramIdx := range paramIdxs {
-		// Osty: /tmp/selfhost_merged.osty:18411:9
+		// Osty: /tmp/selfhost_merged.osty:18412:9
 		paramNode := astArenaNodeAt(cx.ast.arena, paramIdx)
 		_ = paramNode
-		// Osty: /tmp/selfhost_merged.osty:18412:9
+		// Osty: /tmp/selfhost_merged.osty:18413:9
 		declaredTy := astTypeToTy(cx, paramNode.right)
 		_ = declaredTy
-		// Osty: /tmp/selfhost_merged.osty:18413:9
+		// Osty: /tmp/selfhost_merged.osty:18414:9
 		paramTy := func() int {
 			if declaredTy >= 0 {
 				return declaredTy
 			} else if expectedIsFn && i < checkIntListLenHelper(expectedParams) {
 				return checkIntListAt(expectedParams, i)
 			} else {
-				// Osty: /tmp/selfhost_merged.osty:18418:13
+				// Osty: /tmp/selfhost_merged.osty:18419:13
 				func() struct{} {
 					cx.env.diagnostics = append(cx.env.diagnostics, diagClosureAnnotationRequired(paramNode.start, paramNode.end))
 					return struct{}{}
@@ -39749,22 +39752,65 @@ func elabInferClosure(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 			}
 		}()
 		_ = paramTy
-		// Osty: /tmp/selfhost_merged.osty:18421:9
+		// Osty: /tmp/selfhost_merged.osty:18422:9
 		paramName := paramNode.text
 		_ = paramName
-		// Osty: /tmp/selfhost_merged.osty:18422:9
-		if paramName != "" {
-			// Osty: /tmp/selfhost_merged.osty:18423:13
-			checkBindSpan(cx.env, paramName, paramTy, true, paramNode.start, paramNode.end)
+		// Osty: /tmp/selfhost_merged.osty:18423:9
+		hasPattern := paramNode.left >= 0 && paramName == ""
+		_ = hasPattern
+		// Osty: /tmp/selfhost_merged.osty:18424:9
+		storedParamName := func() string {
+			if hasPattern {
+				// Osty: /tmp/selfhost_merged.osty:18425:13
+				fresh := fmt.Sprintf("__closure_param%s", ostyToString(i))
+				_ = fresh
+				return func() string {
+					if checkLookup(cx.env, fresh) < 0 {
+						return fresh
+					} else {
+						return fmt.Sprintf("__closure_param%s_%s", ostyToString(i), ostyToString(paramNode.start))
+					}
+				}()
+			} else {
+				return paramName
+			}
+		}()
+		_ = storedParamName
+		// Osty: /tmp/selfhost_merged.osty:18434:9
+		if storedParamName != "" {
+			// Osty: /tmp/selfhost_merged.osty:18435:13
+			checkBindSpan(cx.env, storedParamName, paramTy, true, paramNode.start, paramNode.end)
 		}
-		// Osty: /tmp/selfhost_merged.osty:18425:9
+		// Osty: /tmp/selfhost_merged.osty:18437:9
+		if hasPattern {
+			// Osty: /tmp/selfhost_merged.osty:18438:13
+			if !(tyIsBad(tys, paramTy)) && !(patIsIrrefutable(cx, paramNode.left, paramTy)) {
+				// Osty: /tmp/selfhost_merged.osty:18439:17
+				func() struct{} {
+					cx.env.diagnostics = append(cx.env.diagnostics, diagRefutablePattern("closure parameter", paramNode.start, paramNode.end))
+					return struct{}{}
+				}()
+			}
+			// Osty: /tmp/selfhost_merged.osty:18441:13
+			patNode := elabBindPattern(cx, paramNode.left, paramTy, true)
+			_ = patNode
+			// Osty: /tmp/selfhost_merged.osty:18442:13
+			tempRef := coreIdent(cx.core, storedParamName, IdentKind(&IdentKind_IkParam{}), paramTy, paramNode.start, paramNode.end)
+			_ = tempRef
+			// Osty: /tmp/selfhost_merged.osty:18443:13
+			func() struct{} {
+				prefixLets = append(prefixLets, coreLetStmt(cx.core, patNode, tempRef, false, paramTy, paramNode.start, paramNode.end))
+				return struct{}{}
+			}()
+		}
+		// Osty: /tmp/selfhost_merged.osty:18445:9
 		func() struct{} { paramTys = append(paramTys, paramTy); return struct{}{} }()
-		// Osty: /tmp/selfhost_merged.osty:18426:9
+		// Osty: /tmp/selfhost_merged.osty:18446:9
 		func() struct{} {
-			coreParams = append(coreParams, coreParam(cx.core, paramName, paramTy, -1, paramNode.start, paramNode.end))
+			coreParams = append(coreParams, coreParam(cx.core, storedParamName, paramTy, -1, paramNode.start, paramNode.end))
 			return struct{}{}
 		}()
-		// Osty: /tmp/selfhost_merged.osty:18427:9
+		// Osty: /tmp/selfhost_merged.osty:18447:9
 		func() {
 			var _cur2178 int = i
 			var _rhs2179 int = 1
@@ -39792,21 +39838,60 @@ func elabInferClosure(cx *ElabCx, node *AstNode, expected int) *ElabResult {
 		}
 	}()
 	_ = body
-	// Osty: /tmp/selfhost_merged.osty:18444:5
+	// Osty: /tmp/selfhost_merged.osty:18464:5
 	retTy := body.ty
 	_ = retTy
-	// Osty: /tmp/selfhost_merged.osty:18446:5
+	// Osty: /tmp/selfhost_merged.osty:18465:5
+	bodyCore := elabClosureBodyWithPrefix(cx, body, prefixLets, node.start, node.end)
+	_ = bodyCore
+	// Osty: /tmp/selfhost_merged.osty:18467:5
 	checkScopeDrop(cx.env, mark)
-	// Osty: /tmp/selfhost_merged.osty:18448:5
+	// Osty: /tmp/selfhost_merged.osty:18469:5
 	closureTy := tyFn(tys, paramTys, retTy)
 	_ = closureTy
-	// Osty: /tmp/selfhost_merged.osty:18449:5
-	coreIdx := coreClosure(cx.core, coreParams, body.node, closureTy, node.start, node.end)
+	// Osty: /tmp/selfhost_merged.osty:18470:5
+	coreIdx := coreClosure(cx.core, coreParams, bodyCore, closureTy, node.start, node.end)
 	_ = coreIdx
 	return &ElabResult{node: coreIdx, ty: closureTy}
 }
 
-// Osty: /tmp/selfhost_merged.osty:18457:1
+// Osty: /tmp/selfhost_merged.osty:18474:1
+func elabClosureBodyWithPrefix(cx *ElabCx, body *ElabResult, prefixLets []int, start int, end int) int {
+	// Osty: /tmp/selfhost_merged.osty:18475:5
+	if checkIntListLenHelper(prefixLets) == 0 {
+		// Osty: /tmp/selfhost_merged.osty:18476:9
+		return body.node
+	}
+	// Osty: /tmp/selfhost_merged.osty:18478:5
+	if body.node >= 0 {
+		// Osty: /tmp/selfhost_merged.osty:18479:9
+		bodyNode := coreArenaNodeAt(cx.core, body.node)
+		_ = bodyNode
+		// Osty: /tmp/selfhost_merged.osty:18480:9
+		if ostyEqual(bodyNode.kind, CoreKind(&CoreKind_CkBlock{})) {
+			// Osty: /tmp/selfhost_merged.osty:18481:13
+			var stmts []int = make([]int, 0, 1)
+			_ = stmts
+			// Osty: /tmp/selfhost_merged.osty:18482:13
+			for _, stmt := range prefixLets {
+				// Osty: /tmp/selfhost_merged.osty:18483:17
+				func() struct{} { stmts = append(stmts, stmt); return struct{}{} }()
+			}
+			// Osty: /tmp/selfhost_merged.osty:18485:13
+			for _, stmt := range bodyNode.children {
+				// Osty: /tmp/selfhost_merged.osty:18486:17
+				func() struct{} { stmts = append(stmts, stmt); return struct{}{} }()
+			}
+			// Osty: /tmp/selfhost_merged.osty:18488:13
+			return coreBlock(cx.core, stmts, bodyNode.left, body.ty, bodyNode.start, bodyNode.end)
+		}
+		// Osty: /tmp/selfhost_merged.osty:18490:9
+		return coreBlock(cx.core, prefixLets, body.node, body.ty, bodyNode.start, bodyNode.end)
+	}
+	return coreBlock(cx.core, prefixLets, -1, body.ty, start, end)
+}
+
+// Osty: /tmp/selfhost_merged.osty:18499:1
 func elabInferRange(cx *ElabCx, node *AstNode) *ElabResult {
 	// Osty: /tmp/selfhost_merged.osty:18458:5
 	tys := cx.env.tys

--- a/internal/selfhost/package_adapter_test.go
+++ b/internal/selfhost/package_adapter_test.go
@@ -164,6 +164,74 @@ pub fn violator() -> Int { 42 }
 	}
 }
 
+func TestCheckSourceStructuredClosurePatternParam(t *testing.T) {
+	src := canonicalSelfhostSource(t, []byte(`fn main() {
+    let f: fn((Int, Int)) -> Int = |(a, b): (Int, Int)| a + b
+    let total = f((1, 2))
+}
+`))
+	checked := selfhost.CheckSourceStructured(src)
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0 (contexts=%v details=%v diagnostics=%#v)", checked.Summary.Errors, checked.Summary.ErrorsByContext, checked.Summary.ErrorDetails, checked.Diagnostics)
+	}
+	if got := findCheckedBindingType(checked, "a"); got != "Int" {
+		t.Fatalf("binding type for a = %q, want Int", got)
+	}
+	if got := findCheckedBindingType(checked, "b"); got != "Int" {
+		t.Fatalf("binding type for b = %q, want Int", got)
+	}
+	if got := findCheckedBindingType(checked, "total"); got != "Int" {
+		t.Fatalf("binding type for total = %q, want Int", got)
+	}
+}
+
+func TestCheckPackageStructuredClosurePatternParamASTNative(t *testing.T) {
+	input := canonicalSelfhostInput(t, []byte(`fn main() {
+    let f: fn((Int, Int)) -> Int = |(a, b): (Int, Int)| a + b
+    let total = f((1, 2))
+}
+`), 0)
+	checked, err := selfhost.CheckPackageStructured(selfhost.PackageCheckInput{
+		Files: []selfhost.PackageCheckFile{input},
+	})
+	if err != nil {
+		t.Fatalf("CheckPackageStructured: %v", err)
+	}
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0 (contexts=%v details=%v diagnostics=%#v)", checked.Summary.Errors, checked.Summary.ErrorsByContext, checked.Summary.ErrorDetails, checked.Diagnostics)
+	}
+	if got := findCheckedBindingType(checked, "a"); got != "Int" {
+		t.Fatalf("binding type for a = %q, want Int", got)
+	}
+	if got := findCheckedBindingType(checked, "b"); got != "Int" {
+		t.Fatalf("binding type for b = %q, want Int", got)
+	}
+	if got := findCheckedBindingType(checked, "total"); got != "Int" {
+		t.Fatalf("binding type for total = %q, want Int", got)
+	}
+}
+
+func TestCheckPackageStructuredScriptTopLevelLetsASTNative(t *testing.T) {
+	input := canonicalSelfhostInput(t, []byte(`let seed = 1
+let total = seed
+`), 0)
+	checked, err := selfhost.CheckPackageStructured(selfhost.PackageCheckInput{
+		Files: []selfhost.PackageCheckFile{input},
+	})
+	if err != nil {
+		t.Fatalf("CheckPackageStructured: %v", err)
+	}
+	if checked.Summary.Errors != 0 {
+		t.Fatalf("summary errors = %d, want 0 (contexts=%v details=%v diagnostics=%#v)", checked.Summary.Errors, checked.Summary.ErrorsByContext, checked.Summary.ErrorDetails, checked.Diagnostics)
+	}
+	if got := findCheckedBindingType(checked, "seed"); got != "UntypedInt" {
+		t.Fatalf("binding type for seed = %q, want UntypedInt", got)
+	}
+	if got := findCheckedBindingType(checked, "total"); got != "UntypedInt" {
+		t.Fatalf("binding type for total = %q, want UntypedInt", got)
+	}
+}
+
 func TestCheckPackageStructuredReportsIntrinsicBodyViolationWithPath(t *testing.T) {
 	dir := t.TempDir()
 	goodPath := filepath.Join(dir, "good.osty")

--- a/internal/selfhost/package_ast_lower.go
+++ b/internal/selfhost/package_ast_lower.go
@@ -221,11 +221,59 @@ func (l *selfhostPackageFileLowerer) lowerFile(file *ast.File) error {
 	if file == nil {
 		return nil
 	}
-	if len(file.Stmts) > 0 {
-		return &selfhostLoweringUnsupported{reason: "script top-level statements"}
-	}
+	items := make([]struct {
+		pos  int
+		ord  int
+		decl ast.Decl
+		stmt ast.Stmt
+	}, 0, len(file.Decls)+len(file.Stmts))
+	ord := 0
 	for _, decl := range file.Decls {
-		idx, err := l.lowerDecl(decl)
+		if decl == nil {
+			continue
+		}
+		items = append(items, struct {
+			pos  int
+			ord  int
+			decl ast.Decl
+			stmt ast.Stmt
+		}{
+			pos:  decl.Pos().Offset,
+			ord:  ord,
+			decl: decl,
+		})
+		ord++
+	}
+	for _, stmt := range file.Stmts {
+		if stmt == nil {
+			continue
+		}
+		items = append(items, struct {
+			pos  int
+			ord  int
+			decl ast.Decl
+			stmt ast.Stmt
+		}{
+			pos:  stmt.Pos().Offset,
+			ord:  ord,
+			stmt: stmt,
+		})
+		ord++
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].pos != items[j].pos {
+			return items[i].pos < items[j].pos
+		}
+		return items[i].ord < items[j].ord
+	})
+	for _, item := range items {
+		idx := -1
+		var err error
+		if item.decl != nil {
+			idx, err = l.lowerDecl(item.decl)
+		} else {
+			idx, err = l.lowerStmt(item.stmt)
+		}
 		if err != nil {
 			return err
 		}
@@ -459,12 +507,23 @@ func (l *selfhostPackageFileLowerer) lowerParam(param *ast.Param) (int, error) {
 	if param == nil {
 		return -1, nil
 	}
-	if param.Pattern != nil {
-		return -1, &selfhostLoweringUnsupported{reason: "closure destructuring params"}
-	}
 	node, err := l.nodeForPublic(AstNodeKind(&AstNodeKind_AstNParam{}), param)
 	if err != nil {
 		return -1, err
+	}
+	if param.Pattern != nil {
+		if param.Default != nil {
+			return -1, &selfhostLoweringUnsupported{reason: "closure pattern param default"}
+		}
+		node.left, err = l.lowerPattern(param.Pattern)
+		if err != nil {
+			return -1, err
+		}
+		node.right, err = l.lowerType(param.Type)
+		if err != nil {
+			return -1, err
+		}
+		return astArenaAdd(l.arena, node), nil
 	}
 	node.text = param.Name
 	node.right, err = l.lowerType(param.Type)

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -2298,6 +2298,7 @@ fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
     let mark = checkScopeMark(cx.env)
     let mut coreParams: List<Int> = []
     let mut paramTys: List<Int> = []
+    let mut prefixLets: List<Int> = []
     let mut i = 0
     for paramIdx in paramIdxs {
         let paramNode = astArenaNodeAt(cx.ast.arena, paramIdx)
@@ -2311,11 +2312,30 @@ fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
             tErr(tys)
         }
         let paramName = paramNode.text
-        if paramName != "" {
-            checkBindSpan(cx.env, paramName, paramTy, true, paramNode.start, paramNode.end)
+        let hasPattern = paramNode.left >= 0 && paramName == ""
+        let storedParamName = if hasPattern {
+            let fresh = "__closure_param{i}"
+            if checkLookup(cx.env, fresh) < 0 {
+                fresh
+            } else {
+                "__closure_param{i}_{paramNode.start}"
+            }
+        } else {
+            paramName
+        }
+        if storedParamName != "" {
+            checkBindSpan(cx.env, storedParamName, paramTy, true, paramNode.start, paramNode.end)
+        }
+        if hasPattern {
+            if !(tyIsBad(tys, paramTy)) && !(patIsIrrefutable(cx, paramNode.left, paramTy)) {
+                cx.env.diagnostics.push(diagRefutablePattern("closure parameter", paramNode.start, paramNode.end))
+            }
+            let patNode = elabBindPattern(cx, paramNode.left, paramTy, true)
+            let tempRef = coreIdent(cx.core, storedParamName, IkParam, paramTy, paramNode.start, paramNode.end)
+            prefixLets.push(coreLetStmt(cx.core, patNode, tempRef, false, paramTy, paramNode.start, paramNode.end))
         }
         paramTys.push(paramTy)
-        coreParams.push(coreParam(cx.core, paramName, paramTy, -1, paramNode.start, paramNode.end))
+        coreParams.push(coreParam(cx.core, storedParamName, paramTy, -1, paramNode.start, paramNode.end))
         i = i + 1
     }
 
@@ -2334,12 +2354,34 @@ fn elabInferClosure(cx: ElabCx, node: AstNode, expected: Int) -> ElabResult {
         elabInfer(cx, bodyIdx)
     }
     let retTy = body.ty
+    let bodyCore = elabClosureBodyWithPrefix(cx, body, prefixLets, node.start, node.end)
 
     checkScopeDrop(cx.env, mark)
 
     let closureTy = tyFn(tys, paramTys, retTy)
-    let coreIdx = coreClosure(cx.core, coreParams, body.node, closureTy, node.start, node.end)
+    let coreIdx = coreClosure(cx.core, coreParams, bodyCore, closureTy, node.start, node.end)
     ElabResult { node: coreIdx, ty: closureTy }
+}
+
+fn elabClosureBodyWithPrefix(cx: ElabCx, body: ElabResult, prefixLets: List<Int>, start: Int, end: Int) -> Int {
+    if checkIntListLenHelper(prefixLets) == 0 {
+        return body.node
+    }
+    if body.node >= 0 {
+        let bodyNode = coreArenaNodeAt(cx.core, body.node)
+        if bodyNode.kind == CkBlock {
+            let mut stmts: List<Int> = []
+            for stmt in prefixLets {
+                stmts.push(stmt)
+            }
+            for stmt in bodyNode.children {
+                stmts.push(stmt)
+            }
+            return coreBlock(cx.core, stmts, bodyNode.left, body.ty, bodyNode.start, bodyNode.end)
+        }
+        return coreBlock(cx.core, prefixLets, body.node, body.ty, bodyNode.start, bodyNode.end)
+    }
+    coreBlock(cx.core, prefixLets, -1, body.ty, start, end)
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## What changed
- taught selfhost elaboration to bind closure destructuring parameters and materialize the pattern binds in the closure body
- extended AST-native package lowering to accept script top-level statements and closure pattern parameters
- added focused selfhost adapter tests for closure pattern params and script top-level `let` bindings
- synced the generated selfhost Go output for the elaboration change

## Why
HIR self-hosting still had gaps on real input shapes that the parser and resolver already understood. Closure destructuring params were parsed but not actually bound during selfhost elaboration, and AST-native lowering still rejected script-style top-level statements.

## Impact
This makes the selfhost checker accept more HIR source shapes end-to-end, especially closure destructuring and script-style top-level bindings, and adds regression coverage for both paths.

## Validation
- `go test ./internal/selfhost -run 'StructuredClosurePatternParam|ScriptTopLevelLets' -count=1`
- `just front`

## Notes
- full `go generate ./internal/selfhost` is still blocked by unrelated bootstrap generation regressions, so the required `generated.go` section was synced directly for this change