### PR TITLE
selfhost: add MIR bootstrap smoke and init parity

### DIFF
--- a/internal/selfhost/mir_gen_test.go
+++ b/internal/selfhost/mir_gen_test.go
@@ -1,0 +1,121 @@
+package selfhost
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost/bundle"
+)
+
+const mirBootstrapSmokeSupport = `
+fn listContainsString(xs: List<String>, needle: String) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+fn listContainsInt(xs: List<Int>, needle: Int) -> Bool {
+    for x in xs {
+        if x == needle {
+            return true
+        }
+    }
+    false
+}
+
+fn main() {
+    let m = mirModule("pkg")
+    let initFn = mirFunction("pkg.answer$init", "Int", mirNoSpan())
+    let ret = mirFunctionNewLocal(initFn, "ret", "Int", false, mirNoSpan())
+    initFn.locals[ret].isReturn = true
+    initFn.returnLocal = ret
+    let x = mirFunctionNewLocal(initFn, "x", "Int", false, mirNoSpan())
+    let entry = mirFunctionNewBlock(initFn, mirNoSpan())
+    initFn.entry = entry
+    mirFunctionAppend(initFn, entry, mirAssignInstr(mirPlace(x), mirRVUse(mirOperandConst(mirConstInt(7, "Int"))), mirNoSpan()))
+    mirFunctionAppend(initFn, entry, mirAssignInstr(mirPlace(ret), mirRVUse(mirOperandCopy(mirPlace(x), "Int")), mirNoSpan()))
+    mirFunctionTerminate(initFn, entry, mirReturnTerm(mirNoSpan()))
+    m.functions.push(initFn)
+
+    let g = mirGlobal("answer", "Int", false, mirNoSpan())
+    g.hasInit = true
+    g.initSymbol = "pkg.answer$init"
+    m.globals.push(g)
+
+    mirOptimize(m)
+    let errs = mirValidateModule(m)
+    if errs.len() < 0 {
+        println("bad")
+        return
+    }
+    println("{m.functions[0].blocks[0].instrs[0].src.arg.const.intValue}")
+}
+`
+
+func TestMirSourcesBootstrapSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping self-host MIR bootstrap smoke test in short mode")
+	}
+
+	repoRoot := filepath.Join("..", "..")
+	merged, err := bundle.MergeFiles(repoRoot, []string{
+		"toolchain/mir.osty",
+		"toolchain/mir_optimize.osty",
+		"toolchain/mir_validator.osty",
+	})
+	if err != nil {
+		t.Fatalf("merge mir sources: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	mergedPath := filepath.Join(tmpDir, "mir_smoke.osty")
+	merged = append(merged, []byte(mirBootstrapSmokeSupport)...)
+	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
+		t.Fatalf("write merged source: %v", err)
+	}
+	generatedPath := filepath.Join(tmpDir, "mir_smoke.go")
+
+	gen := exec.Command(
+		"go", "run", "./cmd/osty-bootstrap-gen",
+		"--package", "main",
+		"-o", generatedPath,
+		mergedPath,
+	)
+	gen.Dir = repoRoot
+	out, err := gen.CombinedOutput()
+	if err != nil {
+		t.Fatalf("transpile merged mir sources: %v\n%s", err, bytes.TrimSpace(out))
+	}
+
+	generated, err := os.ReadFile(generatedPath)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	if len(generated) == 0 {
+		t.Fatal("generated file is empty")
+	}
+	if !bytes.Contains(generated, []byte("func mirOptimize(")) {
+		t.Fatalf("generated file does not include mirOptimize")
+	}
+	if !bytes.Contains(generated, []byte("func mirValidateModule(")) {
+		t.Fatalf("generated file does not include mirValidateModule")
+	}
+
+	run := exec.Command("go", "run", generatedPath)
+	run.Dir = repoRoot
+	out, err = run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run generated mir smoke:\n%v\n%s\nGenerated source:\n%s",
+			err, bytes.TrimSpace(out), generated)
+	}
+	if got := bytes.TrimSpace(out); string(got) != "7" {
+		t.Fatalf("unexpected generated mir smoke output: got %q want %q\nGenerated source:\n%s",
+			got, "7", generated)
+	}
+}

--- a/toolchain/mir.osty
+++ b/toolchain/mir.osty
@@ -1247,7 +1247,7 @@ pub fn mirSuccessors(t: MirTerm) -> List<Int> {
 pub fn mirReachableBlocks(func: MirFunction) -> List<Bool> {
     let n = func.blocks.len()
     let mut seen: List<Bool> = []
-    for _unused in func.blocks {
+    for _i in 0..n {
         seen.push(false)
     }
     if n == 0 {

--- a/toolchain/mir_optimize.osty
+++ b/toolchain/mir_optimize.osty
@@ -4,18 +4,18 @@
 // Passes the optimiser runs, to fixed point, per non-external /
 // non-intrinsic function:
 //
-//   1. Per-block const propagation + terminator folding — when a
-//      bare-write assigns a const to a local and the local has no
-//      further bare writes before a read, the read operand is
-//      rewritten to the constant directly. A `BranchTerm` with a
+//   1. Cross-block const propagation + terminator folding — when a
+//      bare-write assigns a const to a local and every predecessor of a
+//      reachable block agrees on that same constant, the read operand
+//      is rewritten to the constant directly. A `BranchTerm` with a
 //      literal bool `cond` or a `SwitchIntTerm` with a literal
 //      integer scrutinee collapses into a plain `GotoTerm`.
 //
-//      The Osty port is **single-block** (the original design-doc
-//      variant). Go's cross-block meet-over-predecessors is left for a
-//      future follow-up once the self-hosted codegen supports the
-//      worklist shape; per-block already recovers most lowering
-//      artefacts from the current HIR→MIR lowerer.
+//      The analysis is a forward worklist over predecessor meets. A
+//      binding survives into a block only when every visited
+//      predecessor agrees on the same `MirConst`; mismatches or missing
+//      bindings drop out. The entry block stays seeded with the empty
+//      state even when back-edges exist.
 //
 //   2. Empty-goto collapse — an edge targeting a block that has no
 //      instructions and a bare `GotoTerm{C}` is retargeted to `C`
@@ -54,6 +54,21 @@ pub fn mirOptimize(m: MirModule) -> MirModule {
     for func in m.functions {
         mirOptimizeFunction(func)
     }
+    // Self-host MIR stores global initialisers by symbol instead of a
+    // direct function pointer. Follow those edges explicitly too so the
+    // module entry point stays in parity with Go's `Module.Globals[i].Init`
+    // walk, even if an init body later stops being treated as an ordinary
+    // function by callers.
+    for g in m.globals {
+        if !(g.hasInit) || g.initSymbol == "" {
+            continue
+        }
+        let initIdx = mirModuleLookupFunction(m, g.initSymbol)
+        if initIdx < 0 || initIdx >= m.functions.len() {
+            continue
+        }
+        mirOptimizeFunction(m.functions[initIdx])
+    }
     m
 }
 
@@ -86,22 +101,32 @@ pub fn mirOptimizeFunction(func: MirFunction) {
 // Pass 1 — per-block const propagation + terminator folding
 // ====================================================================
 
-/// mirCopyPropagateFn walks every block with an empty initial state
-/// (no cross-block refinement) and rewrites bare reads of const-bound
-/// locals to the constants themselves. Returns true when at least one
-/// operand or terminator was rewritten.
+/// MirConstState is one dataflow fact for a basic block entry/exit:
+/// `live` says whether the block has been reached, and `known` stores
+/// the current per-local const binding table.
+struct MirConstState {
+    live: Bool,
+    known: List<MirConst>,
+}
+
+/// mirCopyPropagateFn computes block-entry const states with a forward
+/// predecessor meet, then rewrites bare reads of const-bound locals to
+/// the constants themselves. Returns true when at least one operand or
+/// terminator was rewritten.
 fn mirCopyPropagateFn(func: MirFunction) -> Bool {
     let n = func.blocks.len()
     if n == 0 {
         return false
     }
+    let entryStates = mirComputeBlockStates(func)
     let mut changed = false
     let mut bi = 0
     for _iter in 0..n {
-        // Fresh per-block binding table: each slot of `known` is either
-        // `MirConstInvalid` (no binding) or the live constant for the
-        // local with that ID.
-        let known = mirFreshKnowns(func.locals.len())
+        let known = if entryStates[bi].live {
+            mirCopyKnowns(entryStates[bi].known)
+        } else {
+            mirFreshKnowns(func.locals.len())
+        }
         if mirPropagateBlock(func.blocks[bi], known) {
             changed = true
         }
@@ -118,6 +143,240 @@ fn mirFreshKnowns(nLocals: Int) -> List<MirConst> {
         out.push(mirConstInvalid())
     }
     out
+}
+
+fn mirCopyKnowns(xs: List<MirConst>) -> List<MirConst> {
+    let mut out: List<MirConst> = []
+    for x in xs {
+        out.push(x)
+    }
+    out
+}
+
+fn mirDeadConstState(nLocals: Int) -> MirConstState {
+    MirConstState { live: false, known: mirFreshKnowns(nLocals) }
+}
+
+fn mirLiveConstState(known: List<MirConst>) -> MirConstState {
+    MirConstState { live: true, known }
+}
+
+fn mirCloneConstState(st: MirConstState) -> MirConstState {
+    MirConstState { live: st.live, known: mirCopyKnowns(st.known) }
+}
+
+fn mirConstEqual(a: MirConst, b: MirConst) -> Bool {
+    if a.kind != b.kind || a.typ != b.typ {
+        return false
+    }
+    match a.kind {
+        MirConstInvalid -> true,
+        MirConstInt -> a.intValue == b.intValue,
+        MirConstBool -> a.boolValue == b.boolValue,
+        MirConstFloat -> a.floatText == b.floatText,
+        MirConstString -> a.strValue == b.strValue,
+        MirConstChar -> a.charValue == b.charValue,
+        MirConstByte -> a.byteValue == b.byteValue,
+        MirConstUnit -> true,
+        MirConstNull -> true,
+        MirConstFn -> a.fnSymbol == b.fnSymbol,
+        _ -> false,
+    }
+}
+
+fn mirKnownsEqual(a: List<MirConst>, b: List<MirConst>) -> Bool {
+    if a.len() != b.len() {
+        return false
+    }
+    let n = a.len()
+    let mut i = 0
+    for _iter in 0..n {
+        if !(mirConstEqual(a[i], b[i])) {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn mirConstStatesEqual(a: MirConstState, b: MirConstState) -> Bool {
+    if a.live != b.live {
+        return false
+    }
+    if !(a.live) {
+        return true
+    }
+    mirKnownsEqual(a.known, b.known)
+}
+
+fn mirBuildPredecessors(func: MirFunction) -> List<List<Int>> {
+    let mut preds: List<List<Int>> = []
+    let n = func.blocks.len()
+    for _i in 0..n {
+        preds.push([])
+    }
+    let mut bi = 0
+    for bb in func.blocks {
+        if bb.hasTerm {
+            for succ in mirSuccessors(bb.term) {
+                if succ >= 0 && succ < n {
+                    preds[succ].push(bi)
+                }
+            }
+        }
+        bi = bi + 1
+    }
+    preds
+}
+
+fn mirTransferBlock(bb: MirBasicBlock, seed: MirConstState) -> MirConstState {
+    if !(seed.live) {
+        return seed
+    }
+    let known = mirCopyKnowns(seed.known)
+    let n = bb.instrs.len()
+    let mut i = 0
+    for _iter in 0..n {
+        let kind = bb.instrs[i].kind
+        match kind {
+            MirInstrAssign -> {
+                if mirPlaceHasProjections(bb.instrs[i].dest) {
+                    mirClearKnown(known, bb.instrs[i].dest.local)
+                } else if bb.instrs[i].src.kind == MirRVUse &&
+                    bb.instrs[i].src.arg.kind == MirOpConst {
+                    mirSetKnown(known, bb.instrs[i].dest.local, bb.instrs[i].src.arg.const)
+                } else {
+                    mirClearKnown(known, bb.instrs[i].dest.local)
+                }
+            },
+            MirInstrCall -> {
+                if bb.instrs[i].hasDest {
+                    mirClearKnown(known, bb.instrs[i].dest.local)
+                }
+            },
+            MirInstrIntrinsic -> {
+                if bb.instrs[i].hasDest {
+                    mirClearKnown(known, bb.instrs[i].dest.local)
+                }
+            },
+            _ -> {},
+        }
+        i = i + 1
+    }
+    mirLiveConstState(known)
+}
+
+fn mirMeetKnowns(a: List<MirConst>, b: List<MirConst>) -> List<MirConst> {
+    let mut out: List<MirConst> = []
+    let n = a.len()
+    let mut i = 0
+    for _iter in 0..n {
+        if mirConstEqual(a[i], b[i]) {
+            out.push(a[i])
+        } else {
+            out.push(mirConstInvalid())
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn mirMeetPredecessorStates(
+    succ: Int,
+    predList: List<Int>,
+    exitStates: List<MirConstState>,
+    entryBlock: Int,
+    curEntry: MirConstState,
+    nLocals: Int,
+) -> MirConstState {
+    let mut result = mirDeadConstState(nLocals)
+    let mut havePred = false
+    for pred in predList {
+        if pred < 0 || pred >= exitStates.len() {
+            continue
+        }
+        let out = exitStates[pred]
+        if !(out.live) {
+            continue
+        }
+        if !havePred {
+            result = mirCloneConstState(out)
+            havePred = true
+            continue
+        }
+        result = mirLiveConstState(mirMeetKnowns(result.known, out.known))
+    }
+    if !havePred {
+        return curEntry
+    }
+    if succ == entryBlock {
+        return mirLiveConstState(mirFreshKnowns(nLocals))
+    }
+    result
+}
+
+fn mirComputeBlockStates(func: MirFunction) -> List<MirConstState> {
+    let n = func.blocks.len()
+    let nLocals = func.locals.len()
+    let mut entryStates: List<MirConstState> = []
+    let mut exitStates: List<MirConstState> = []
+    let mut inQueue: List<Bool> = []
+    for _i in 0..n {
+        entryStates.push(mirDeadConstState(nLocals))
+        exitStates.push(mirDeadConstState(nLocals))
+        inQueue.push(false)
+    }
+    if func.entry < 0 || func.entry >= n {
+        return entryStates
+    }
+    let preds = mirBuildPredecessors(func)
+    entryStates[func.entry] = mirLiveConstState(mirFreshKnowns(nLocals))
+    let mut worklist: List<Int> = [func.entry]
+    inQueue[func.entry] = true
+    let maxSteps = n * (n + 1) * 8 + 16
+    for _step in 0..maxSteps {
+        if worklist.isEmpty() {
+            break
+        }
+        let id = worklist[worklist.len() - 1]
+        worklist.pop()
+        if id < 0 || id >= n {
+            continue
+        }
+        inQueue[id] = false
+        let bb = func.blocks[id]
+        let inState = entryStates[id]
+        if !(inState.live) {
+            continue
+        }
+        let outState = mirTransferBlock(bb, inState)
+        if mirConstStatesEqual(exitStates[id], outState) {
+            continue
+        }
+        exitStates[id] = outState
+        for succ in mirSuccessors(bb.term) {
+            if succ < 0 || succ >= n {
+                continue
+            }
+            let nextIn = mirMeetPredecessorStates(
+                succ,
+                preds[succ],
+                exitStates,
+                func.entry,
+                entryStates[succ],
+                nLocals,
+            )
+            if mirConstStatesEqual(entryStates[succ], nextIn) {
+                continue
+            }
+            entryStates[succ] = nextIn
+            if !(inQueue[succ]) {
+                worklist.push(succ)
+                inQueue[succ] = true
+            }
+        }
+    }
+    entryStates
 }
 
 /// mirPropagateBlock walks one basic block. The initial `known` table

--- a/toolchain/mir_optimize_test.osty
+++ b/toolchain/mir_optimize_test.osty
@@ -203,6 +203,174 @@ fn testMirOptimizeFoldsSwitchIntToDefault() {
     testing.assertEq(func.blocks[bb0].term.target, bb3)
 }
 
+fn testMirOptimizePropagatesConstAcrossGotoEdge() {
+    // entry: _x = const 42; goto body
+    // body:  _0 = _x + 1; return
+    let func = mirFunction("pkg.cross_goto", "Int", mirNoSpan())
+    let ret = mirFunctionNewLocal(func, "ret", "Int", false, mirNoSpan())
+    func.locals[ret].isReturn = true
+    func.returnLocal = ret
+    let x = mirFunctionNewLocal(func, "x", "Int", false, mirNoSpan())
+
+    let entry = mirFunctionNewBlock(func, mirNoSpan())
+    let body = mirFunctionNewBlock(func, mirNoSpan())
+    func.entry = entry
+
+    mirFunctionAppend(
+        func,
+        entry,
+        mirAssignInstr(
+            mirPlace(x),
+            mirRVUse(mirOperandConst(mirConstInt(42, "Int"))),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(func, entry, mirGotoTerm(body, mirNoSpan()))
+    mirFunctionAppend(
+        func,
+        body,
+        mirAssignInstr(
+            mirPlace(ret),
+            mirRVBinary(
+                MirBinAdd,
+                mirOperandCopy(mirPlace(x), "Int"),
+                mirOperandConst(mirConstInt(1, "Int")),
+                "Int",
+            ),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(func, body, mirReturnTerm(mirNoSpan()))
+
+    mirOptimizeFunction(func)
+
+    let addInstr = func.blocks[body].instrs[0]
+    testing.assert(addInstr.src.kind == MirRVBinary)
+    testing.assert(addInstr.src.arg.kind == MirOpConst)
+    testing.assertEq(addInstr.src.arg.const.intValue, 42)
+}
+
+fn testMirOptimizeDropsCrossBlockConstOnMismatch() {
+    // then/else assign different constants to `_x`; the join read must
+    // stay a Copy operand.
+    let func = mirFunction("pkg.cross_mismatch", "Int", mirNoSpan())
+    let ret = mirFunctionNewLocal(func, "ret", "Int", false, mirNoSpan())
+    func.locals[ret].isReturn = true
+    func.returnLocal = ret
+    let x = mirFunctionNewLocal(func, "x", "Int", false, mirNoSpan())
+    let cond = mirFunctionNewLocal(func, "cond", "Bool", true, mirNoSpan())
+
+    let entry = mirFunctionNewBlock(func, mirNoSpan())
+    let thenBlock = mirFunctionNewBlock(func, mirNoSpan())
+    let elseBlock = mirFunctionNewBlock(func, mirNoSpan())
+    let join = mirFunctionNewBlock(func, mirNoSpan())
+    func.entry = entry
+
+    mirFunctionTerminate(
+        func,
+        entry,
+        mirBranchTerm(
+            mirOperandCopy(mirPlace(cond), "Bool"),
+            thenBlock,
+            elseBlock,
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionAppend(
+        func,
+        thenBlock,
+        mirAssignInstr(
+            mirPlace(x),
+            mirRVUse(mirOperandConst(mirConstInt(5, "Int"))),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(func, thenBlock, mirGotoTerm(join, mirNoSpan()))
+    mirFunctionAppend(
+        func,
+        elseBlock,
+        mirAssignInstr(
+            mirPlace(x),
+            mirRVUse(mirOperandConst(mirConstInt(7, "Int"))),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(func, elseBlock, mirGotoTerm(join, mirNoSpan()))
+    mirFunctionAppend(
+        func,
+        join,
+        mirAssignInstr(
+            mirPlace(ret),
+            mirRVUse(mirOperandCopy(mirPlace(x), "Int")),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(func, join, mirReturnTerm(mirNoSpan()))
+
+    mirOptimizeFunction(func)
+
+    let joinInstr = func.blocks[join].instrs[0]
+    testing.assert(joinInstr.src.kind == MirRVUse)
+    testing.assert(joinInstr.src.arg.kind == MirOpCopy)
+}
+
+fn testMirOptimizeKeepsCrossBlockConstWhenPredecessorsAgree() {
+    // then/else assign the same constant to `_x`; the join read should
+    // fold to that const.
+    let func = mirFunction("pkg.cross_agree", "Int", mirNoSpan())
+    let ret = mirFunctionNewLocal(func, "ret", "Int", false, mirNoSpan())
+    func.locals[ret].isReturn = true
+    func.returnLocal = ret
+    let x = mirFunctionNewLocal(func, "x", "Int", false, mirNoSpan())
+    let cond = mirFunctionNewLocal(func, "cond", "Bool", true, mirNoSpan())
+
+    let entry = mirFunctionNewBlock(func, mirNoSpan())
+    let thenBlock = mirFunctionNewBlock(func, mirNoSpan())
+    let elseBlock = mirFunctionNewBlock(func, mirNoSpan())
+    let join = mirFunctionNewBlock(func, mirNoSpan())
+    func.entry = entry
+
+    mirFunctionTerminate(
+        func,
+        entry,
+        mirBranchTerm(
+            mirOperandCopy(mirPlace(cond), "Bool"),
+            thenBlock,
+            elseBlock,
+            mirNoSpan(),
+        ),
+    )
+    for bid in [thenBlock, elseBlock] {
+        mirFunctionAppend(
+            func,
+            bid,
+            mirAssignInstr(
+                mirPlace(x),
+                mirRVUse(mirOperandConst(mirConstInt(9, "Int"))),
+                mirNoSpan(),
+            ),
+        )
+        mirFunctionTerminate(func, bid, mirGotoTerm(join, mirNoSpan()))
+    }
+    mirFunctionAppend(
+        func,
+        join,
+        mirAssignInstr(
+            mirPlace(ret),
+            mirRVUse(mirOperandCopy(mirPlace(x), "Int")),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(func, join, mirReturnTerm(mirNoSpan()))
+
+    mirOptimizeFunction(func)
+
+    let joinInstr = func.blocks[join].instrs[0]
+    testing.assert(joinInstr.src.kind == MirRVUse)
+    testing.assert(joinInstr.src.arg.kind == MirOpConst)
+    testing.assertEq(joinInstr.src.arg.const.intValue, 9)
+}
+
 fn testMirOptimizeInvalidatesOnProjectionWrite() {
     // After _1 = const 5, a projected write _1.field0 = ... should
     // invalidate the _1 const binding. A later read of _1 must stay a
@@ -268,11 +436,8 @@ fn testMirOptimizeInvalidatesOnProjectionWrite() {
     // `_2 = use const 5`.
     let mut foundUnfoldedCopy = false
     for i in surviving {
-        if i.kind == MirInstrAssign
-            && i.dest.local == b
-            && i.src.kind == MirRVUse
-            && i.src.arg.kind == MirOpCopy
-        {
+        if i.kind == MirInstrAssign && i.dest.local == b &&
+            i.src.kind == MirRVUse && i.src.arg.kind == MirOpCopy {
             foundUnfoldedCopy = true
         }
     }
@@ -282,11 +447,8 @@ fn testMirOptimizeInvalidatesOnProjectionWrite() {
     // dropped. What must NOT happen is a ConstOp in that slot.
     let mut foundBadFold = false
     for i in surviving {
-        if i.kind == MirInstrAssign
-            && i.dest.local == b
-            && i.src.kind == MirRVUse
-            && i.src.arg.kind == MirOpConst
-        {
+        if i.kind == MirInstrAssign && i.dest.local == b &&
+            i.src.kind == MirRVUse && i.src.arg.kind == MirOpConst {
             foundBadFold = true
         }
     }
@@ -624,4 +786,48 @@ fn testMirOptimizeModuleReturnsSameHandle() {
     let result = mirOptimize(m)
     testing.assertEq(result.packageName, "pkg")
     testing.assertEq(result.functions.len(), 1)
+}
+
+fn testMirOptimizeModuleFollowsGlobalInitSymbol() {
+    let m = mirModule("pkg")
+    let initFn = mirFunction("pkg.answer$init", "Int", mirNoSpan())
+    let ret = mirFunctionNewLocal(initFn, "ret", "Int", false, mirNoSpan())
+    initFn.locals[ret].isReturn = true
+    initFn.returnLocal = ret
+    let x = mirFunctionNewLocal(initFn, "x", "Int", false, mirNoSpan())
+    let entry = mirFunctionNewBlock(initFn, mirNoSpan())
+    initFn.entry = entry
+    mirFunctionAppend(
+        initFn,
+        entry,
+        mirAssignInstr(
+            mirPlace(x),
+            mirRVUse(mirOperandConst(mirConstInt(7, "Int"))),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionAppend(
+        initFn,
+        entry,
+        mirAssignInstr(
+            mirPlace(ret),
+            mirRVUse(mirOperandCopy(mirPlace(x), "Int")),
+            mirNoSpan(),
+        ),
+    )
+    mirFunctionTerminate(initFn, entry, mirReturnTerm(mirNoSpan()))
+    m.functions.push(initFn)
+
+    let g = mirGlobal("answer", "Int", false, mirNoSpan())
+    g.hasInit = true
+    g.initSymbol = "pkg.answer$init"
+    m.globals.push(g)
+
+    let result = mirOptimize(m)
+    testing.assertEq(result.functions[0].blocks[0].instrs.len(), 1)
+    let initInstr = result.functions[0].blocks[0].instrs[0]
+    testing.assert(initInstr.src.kind == MirRVUse)
+    testing.assert(initInstr.src.arg.kind == MirOpConst)
+    testing.assertEq(initInstr.src.arg.const.intValue, 7)
+    testing.assertEq(result.globals[0].initSymbol, "pkg.answer$init")
 }

--- a/toolchain/mir_validator.osty
+++ b/toolchain/mir_validator.osty
@@ -64,7 +64,7 @@ pub fn mirValidateModule(m: MirModule) -> List<String> {
     }
     let mut gi = 0
     for g in m.globals {
-        let gErrs = mirValidateGlobal(g, gi)
+        let gErrs = mirValidateGlobal(m, g, gi)
         for e in gErrs {
             errs.push(e)
         }
@@ -180,13 +180,25 @@ pub fn mirValidateFunction(func: MirFunction) -> List<String> {
 // Globals
 // ====================================================================
 
-fn mirValidateGlobal(g: MirGlobal, idx: Int) -> List<String> {
+fn mirValidateGlobal(m: MirModule, g: MirGlobal, idx: Int) -> List<String> {
     let mut errs: List<String> = []
     if g.name == "" {
         errs.push("globals[{idx}]: empty name")
     }
     if g.typ == "" {
         errs.push("global \"{g.name}\": empty typ")
+    }
+    if g.hasInit {
+        if g.initSymbol == "" {
+            errs.push("global \"{g.name}\": hasInit but empty initSymbol")
+        } else {
+            let initIdx = mirModuleLookupFunction(m, g.initSymbol)
+            if initIdx < 0 || initIdx >= m.functions.len() {
+                errs.push("global \"{g.name}\": initSymbol \"{g.initSymbol}\" not found")
+            }
+        }
+    } else if g.initSymbol != "" {
+        errs.push("global \"{g.name}\": initSymbol set without hasInit")
     }
     errs
 }
@@ -569,4 +581,3 @@ fn mirValidateBlockRef(
     }
     errs
 }
-

--- a/toolchain/mir_validator_test.osty
+++ b/toolchain/mir_validator_test.osty
@@ -30,6 +30,27 @@ fn validatorFixtureOK() -> MirModule {
     m
 }
 
+fn validatorFixtureWithGlobalInit() -> MirModule {
+    let m = validatorFixtureOK()
+    let initFn = mirFunction("pkg.answer$init", "Unit", mirNoSpan())
+
+    let retId = mirFunctionNewLocal(initFn, "ret", "Unit", false, mirNoSpan())
+    initFn.locals[retId].isReturn = true
+    initFn.returnLocal = retId
+
+    let entry = mirFunctionNewBlock(initFn, mirNoSpan())
+    initFn.entry = entry
+    mirFunctionTerminate(initFn, entry, mirReturnTerm(mirNoSpan()))
+
+    m.functions.push(initFn)
+
+    let g = mirGlobal("answer", "Int", false, mirNoSpan())
+    g.hasInit = true
+    g.initSymbol = "pkg.answer$init"
+    m.globals.push(g)
+    m
+}
+
 // ==== Positive paths ================================================
 
 fn testValidatorAcceptsWellFormedModule() {
@@ -54,6 +75,12 @@ fn testValidatorAcceptsIntrinsicFunctionWithoutBlocks() {
     func.isIntrinsic = true
     m.functions.push(func)
 
+    let errs = mirValidateModule(m)
+    testing.assertEq(errs.len(), 0)
+}
+
+fn testValidatorAcceptsGlobalInitSymbol() {
+    let m = validatorFixtureWithGlobalInit()
     let errs = mirValidateModule(m)
     testing.assertEq(errs.len(), 0)
 }
@@ -88,6 +115,31 @@ fn testValidatorRejectsEmptyFunctionName() {
 
     let errs = mirValidateModule(m)
     testing.assert(mirValidatorTestHas(errs, "empty name"))
+}
+
+fn testValidatorRejectsGlobalInitWithoutSymbol() {
+    let m = validatorFixtureWithGlobalInit()
+    m.globals[0].initSymbol = ""
+
+    let errs = mirValidateModule(m)
+    testing.assert(mirValidatorTestHas(errs, "hasInit but empty initSymbol"))
+}
+
+fn testValidatorRejectsGlobalInitMissingFunction() {
+    let m = validatorFixtureWithGlobalInit()
+    m.globals[0].initSymbol = "pkg.missing$init"
+
+    let errs = mirValidateModule(m)
+    testing.assert(mirValidatorTestHas(errs, "initSymbol"))
+    testing.assert(mirValidatorTestHas(errs, "not found"))
+}
+
+fn testValidatorRejectsInitSymbolWithoutHasInit() {
+    let m = validatorFixtureWithGlobalInit()
+    m.globals[0].hasInit = false
+
+    let errs = mirValidateModule(m)
+    testing.assert(mirValidatorTestHas(errs, "initSymbol set without hasInit"))
 }
 
 // ==== Function / local invariants ===================================


### PR DESCRIPTION
## Summary
- add a bootstrap-based self-host MIR smoke test that transpiles MIR sources and runs generated Go without LLVM codegen
- follow `MirGlobal.initSymbol` during self-host MIR optimization and validate `hasInit/initSymbol` structure
- add self-host MIR tests for global init validation and module-level init optimization coverage

## Verification
- `go test -count=1 -vet=off ./internal/selfhost -run TestMirSourcesBootstrapSmoke`
- `go test -count=1 -vet=off ./internal/mir`