### PR TITLE
[codex] Strengthen selfhost formatter coverage

### DIFF
--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -9,6 +9,9 @@ Today the public entrypoints are:
 - `internal/lexer` — thin Go facade over selfhost tokenization
 - `internal/parser` — thin Go facade over selfhost parsing plus Go-side
   compatibility lowerings
+- `internal/selfhost` — `FormatSource` / `FormatCheck` expose stable Go
+  adapters over the bootstrap-generated pure-Osty formatter for parity tests
+  and self-host drift detection without changing the CLI formatter contract
 - `internal/check` — prefers the external native checker binary and uses the
   embedded selfhost bridge as the fallback / adaptation boundary
 

--- a/internal/selfhost/format_adapter.go
+++ b/internal/selfhost/format_adapter.go
@@ -1,0 +1,74 @@
+package selfhost
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/osty/osty/internal/diag"
+)
+
+// FormatterCheckResult reports whether the self-host formatter would rewrite
+// the original source bytes and returns the canonical output.
+type FormatterCheckResult struct {
+	Changed bool
+	Output  []byte
+}
+
+// FormatSource runs the bootstrap-generated pure-Osty formatter. This exists
+// so Go-side tests and drift guards can exercise the self-host printer through
+// a stable adapter without routing user-facing formatting away from
+// internal/format.Source, which remains the canonical CLI contract.
+func FormatSource(src []byte) ([]byte, []*diag.Diagnostic, error) {
+	normalized := normalizeFormatterInput(src)
+	formatted := ostyFormatSource(string(normalized))
+	if formatted.ok {
+		return []byte(formatted.output), nil, nil
+	}
+	diags, err := formatFailure(normalized, formatted.message)
+	return nil, diags, err
+}
+
+// FormatCheck reports whether FormatSource would change the original source
+// bytes. Raw-byte comparison is intentional so BOM/CRLF normalization counts
+// as a formatting change just like the public `osty fmt --engine=osty` path.
+func FormatCheck(src []byte) (FormatterCheckResult, []*diag.Diagnostic, error) {
+	normalized := normalizeFormatterInput(src)
+	formatted := ostyFormatSource(string(normalized))
+	if formatted.ok {
+		out := []byte(formatted.output)
+		return FormatterCheckResult{
+			Changed: !bytes.Equal(src, out),
+			Output:  out,
+		}, nil, nil
+	}
+	var zero FormatterCheckResult
+	diags, err := formatFailure(normalized, formatted.message)
+	return zero, diags, err
+}
+
+func formatFailure(src []byte, message string) ([]*diag.Diagnostic, error) {
+	diags := ParseDiagnostics(src)
+	if len(diags) > 0 {
+		return diags, fmt.Errorf("cannot format file with parse errors")
+	}
+	return nil, fmt.Errorf("selfhost formatter failed: %s", message)
+}
+
+func normalizeFormatterInput(src []byte) []byte {
+	src = bytes.TrimPrefix(src, []byte{0xEF, 0xBB, 0xBF})
+	if !bytes.Contains(src, []byte{'\r'}) {
+		return src
+	}
+	out := make([]byte, 0, len(src))
+	for idx := 0; idx < len(src); idx++ {
+		if src[idx] != '\r' {
+			out = append(out, src[idx])
+			continue
+		}
+		if idx+1 < len(src) && src[idx+1] == '\n' {
+			continue
+		}
+		out = append(out, '\n')
+	}
+	return out
+}

--- a/internal/selfhost/format_adapter_test.go
+++ b/internal/selfhost/format_adapter_test.go
@@ -1,0 +1,105 @@
+package selfhost_test
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/format"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestFormatSourceMatchesHostFormatter(t *testing.T) {
+	cases := map[string][]byte{
+		"compact-fn":   []byte("fn add(a:Int,b:Int)->Int{return a+b}"),
+		"angle-depth":  []byte("fn max<T: Ordered + Hashable>(a:T,b:T)->T{if a>b{return a}else{return b}}\ntype Handler = fn(List<Int>, Map<String,List<Int>>) -> Result<(), Error?>\nfn load(json:Json,text:String)->Result<Config,Error>{let cfg=json.parse::<Config>(text)? return Ok(cfg)}"),
+		"keyword-expr": []byte("enum Maybe{Some(Int),None}\nfn f(opt:Maybe,ok:Bool)->Int{if let Some(x)=opt{return x}else{return 0} for let Some(y)=opt{return y} return if ok{1}else{2}}\nfn g(opt:Maybe)->Int{return match opt { Some(v) if v > 0 -> v, Some(v) -> v, _ -> 0 }}"),
+		"patterns":     []byte("enum Maybe{Some(Int),None}\nstruct User{name:Int,age:Int}\nfn f(v:Maybe,u:User)->Int{let User{name:n,age,..}=u return match v { Some( 1..= 3 ) | None -> 0, x @ Some( _ ) -> 1, _ -> n }}"),
+		"prefix-ops":   []byte("fn neg(n:Int)->Int{return -n}\nfn not(ok:Bool)->Bool{return !ok}\nfn flip(n:Int)->Int{return ~n}\nfn expr(ok:Bool,x:Int)->Bool{return if ok{1}else{2}< -x}"),
+	}
+
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			want, wantDiags, err := format.OstySource(src)
+			if err != nil {
+				t.Fatalf("host format.OstySource error: %v", err)
+			}
+			if len(wantDiags) != 0 {
+				t.Fatalf("host format.OstySource diagnostics = %d, want 0", len(wantDiags))
+			}
+
+			got, gotDiags, err := selfhost.FormatSource(src)
+			if err != nil {
+				t.Fatalf("selfhost.FormatSource error: %v", err)
+			}
+			if len(gotDiags) != 0 {
+				t.Fatalf("selfhost.FormatSource diagnostics = %d, want 0", len(gotDiags))
+			}
+			if string(got) != string(want) {
+				t.Fatalf("formatted output mismatch\nwant:\n%s\ngot:\n%s", want, got)
+			}
+		})
+	}
+}
+
+func TestFormatSourceNormalizesCompatibilityInputLikeHostFormatter(t *testing.T) {
+	src := append([]byte{0xEF, 0xBB, 0xBF}, []byte("fn add(a:Int,b:Int)->Int{\r\nreturn a+b\r\n}\r")...)
+
+	want, wantDiags, err := format.OstySource(src)
+	if err != nil {
+		t.Fatalf("host format.OstySource error: %v", err)
+	}
+	if len(wantDiags) != 0 {
+		t.Fatalf("host format.OstySource diagnostics = %d, want 0", len(wantDiags))
+	}
+
+	got, gotDiags, err := selfhost.FormatSource(src)
+	if err != nil {
+		t.Fatalf("selfhost.FormatSource error: %v", err)
+	}
+	if len(gotDiags) != 0 {
+		t.Fatalf("selfhost.FormatSource diagnostics = %d, want 0", len(gotDiags))
+	}
+	if string(got) != string(want) {
+		t.Fatalf("formatted output mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatCheckTreatsRawInputNormalizationAsChange(t *testing.T) {
+	src := append([]byte{0xEF, 0xBB, 0xBF}, []byte("fn add(a: Int, b: Int) -> Int {\r\n    return a + b\r\n}\r\n")...)
+
+	checked, diags, err := selfhost.FormatCheck(src)
+	if err != nil {
+		t.Fatalf("selfhost.FormatCheck error: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("selfhost.FormatCheck diagnostics = %d, want 0", len(diags))
+	}
+	if !checked.Changed {
+		t.Fatal("FormatCheck Changed = false, want true for BOM/CRLF-normalized input")
+	}
+
+	want, wantDiags, err := format.OstySource(src)
+	if err != nil {
+		t.Fatalf("host format.OstySource error: %v", err)
+	}
+	if len(wantDiags) != 0 {
+		t.Fatalf("host format.OstySource diagnostics = %d, want 0", len(wantDiags))
+	}
+	if string(checked.Output) != string(want) {
+		t.Fatalf("FormatCheck output mismatch\nwant:\n%s\ngot:\n%s", want, checked.Output)
+	}
+}
+
+func TestFormatSourceReturnsParseDiagnosticsOnFailure(t *testing.T) {
+	src := []byte("fn f(){a < b < c}")
+
+	out, diags, err := selfhost.FormatSource(src)
+	if err == nil {
+		t.Fatal("FormatSource error = nil, want parse error")
+	}
+	if out != nil {
+		t.Fatalf("FormatSource output = %q, want nil", out)
+	}
+	if len(diags) == 0 {
+		t.Fatal("FormatSource diagnostics = 0, want parse diagnostics")
+	}
+}


### PR DESCRIPTION
## What changed
- add stable `internal/selfhost` formatter adapters for formatting and format-check flows
- normalize BOM/CRLF input before invoking the bootstrap-generated formatter
- add parity and failure-path tests covering host/selfhost output matching and parse diagnostics
- document the new formatter adapter entrypoints in the selfhost README

## Why
The selfhost formatter was bundled into the bootstrap-generated bridge, but there was no stable Go-side adapter or focused regression coverage exercising it directly. That made formatter drift easier to miss than the lexer/parser/checker paths.

## Impact
- gives Go-side tests and future drift guards a supported way to call the pure-Osty formatter
- keeps the CLI formatter contract unchanged while strengthening selfhost confidence
- explicitly locks in compatibility input handling for BOM and CRLF cases

## Validation
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestFormat'`
- `just front`