### PR TITLE
[codex] optimize selfhost lex fact hot paths

### DIFF
--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -105,6 +105,43 @@ func matchTextUnits(units []string, start int, text string) bool {
 	return true
 }
 
+func collectLeadingDocs(units []string, stream *FrontLexStream) []string {
+	leadingDocs := make([]string, 0, len(stream.tokens))
+	commentIdx := 0
+	commentCount := len(stream.comments)
+
+	for _, tok := range stream.tokens {
+		for commentIdx < commentCount && stream.comments[commentIdx].end.line < tok.start.line {
+			commentIdx++
+		}
+		if tok.leadingDocLines <= 0 {
+			leadingDocs = append(leadingDocs, "")
+			continue
+		}
+
+		docStartLine := tok.start.line - tok.leadingDocLines
+		docIdx := commentIdx
+		for docIdx > 0 && stream.comments[docIdx-1].end.line >= docStartLine {
+			docIdx--
+		}
+
+		var doc strings.Builder
+		for idx := docIdx; idx < commentIdx; idx++ {
+			c := stream.comments[idx]
+			if !ostyEqual(c.kind, FrontCommentKind(&FrontCommentKind_FrontCommentDoc{})) {
+				continue
+			}
+			if doc.Len() > 0 {
+				doc.WriteByte('\n')
+			}
+			doc.WriteString(strings.TrimSpace(ostyCommentText(units, c)))
+		}
+		leadingDocs = append(leadingDocs, doc.String())
+	}
+
+	return leadingDocs
+}
+
 // Tokens returns the public token stream, including EOF.
 func (r *FrontendRun) Tokens() []token.Token {
 	r.ensureLexAdapted()

--- a/internal/selfhost/gen_selfhost.go
+++ b/internal/selfhost/gen_selfhost.go
@@ -226,6 +226,115 @@ func patchGenerated(path string) error {
 	// scoped to the local temp variable name so diag example strings like
 	// `Ok(s.len())` stay untouched.
 	src = strings.ReplaceAll(src, "units.len()", "len(units)")
+	for _, snippet := range []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{
+			name: "FrontLexStream units field",
+			old: `type FrontLexStream struct {
+	tokens                []*FrontLexToken
+	diagnostics           []*FrontLexDiagnostic
+	comments              []*FrontComment
+	stringParts           []*FrontStringPart
+	interpolationTokens   []*FrontInterpolationToken
+	shebangs              int
+	bomStripped           int
+	sourceUnits           int
+	normalizedTripleUnits int
+	tripleIndentErrors    int
+	escapeErrors          int
+}`,
+			new: `type FrontLexStream struct {
+	tokens                []*FrontLexToken
+	diagnostics           []*FrontLexDiagnostic
+	comments              []*FrontComment
+	stringParts           []*FrontStringPart
+	interpolationTokens   []*FrontInterpolationToken
+	shebangs              int
+	bomStripped           int
+	sourceUnits           int
+	normalizedTripleUnits int
+	tripleIndentErrors    int
+	escapeErrors          int
+	units                 []string
+}`,
+		},
+		{
+			name: "frontendLexStream cached units",
+			old: `func frontendLexStream(source string) *FrontLexStream {
+	// Osty: /tmp/selfhost_merged.osty:1067:5
+	units := strings.Split(source, "")
+	_ = units
+	// Osty: /tmp/selfhost_merged.osty:1069:5
+	unitCount := stringUnitCount(source)
+	_ = unitCount`,
+			new: `func frontendLexStream(source string) *FrontLexStream {
+	// Osty: /tmp/selfhost_merged.osty:1067:5
+	units := strings.Split(source, "")
+	_ = units
+	// Osty: /tmp/selfhost_merged.osty:1069:5
+	unitCount := len(units)
+	_ = unitCount`,
+		},
+		{
+			name: "frontendLexStream return units",
+			old:  `return &FrontLexStream{tokens: tokens, diagnostics: diagnostics, comments: comments, stringParts: stringParts, interpolationTokens: interpolationTokens, shebangs: shebangs, bomStripped: bomStripped, sourceUnits: unitCount, normalizedTripleUnits: normalizedTripleUnits, tripleIndentErrors: tripleIndentErrors, escapeErrors: escapeErrors}`,
+			new:  `return &FrontLexStream{tokens: tokens, diagnostics: diagnostics, comments: comments, stringParts: stringParts, interpolationTokens: interpolationTokens, shebangs: shebangs, bomStripped: bomStripped, sourceUnits: unitCount, normalizedTripleUnits: normalizedTripleUnits, tripleIndentErrors: tripleIndentErrors, escapeErrors: escapeErrors, units: units}`,
+		},
+		{
+			name: "ostyLexFactsFromStream cached units",
+			old: `func ostyLexFactsFromStream(source string, stream *FrontLexStream) *OstyLexFacts {
+	// Osty: /tmp/selfhost_merged.osty:6240:5
+	units := strings.Split(source, "")
+	_ = units`,
+			new: `func ostyLexFactsFromStream(source string, stream *FrontLexStream) *OstyLexFacts {
+	// Osty: /tmp/selfhost_merged.osty:6240:5
+	units := stream.units
+	if units == nil {
+		units = strings.Split(source, "")
+	}
+	_ = units`,
+		},
+		{
+			name: "ostyLexFactsFromStream leading docs",
+			old: `	// Osty: /tmp/selfhost_merged.osty:6284:5
+	var leadingDocs []string = make([]string, 0, 1)
+	_ = leadingDocs
+	// Osty: /tmp/selfhost_merged.osty:6285:5
+	li := 0
+	_ = li
+	// Osty: /tmp/selfhost_merged.osty:6286:5
+	for li < tokenCount {
+		// Osty: /tmp/selfhost_merged.osty:6287:9
+		func() struct{} {
+			leadingDocs = append(leadingDocs, ostyJoinDocLines(units, stream, frontLexTokenAt(stream, li)))
+			return struct{}{}
+		}()
+		// Osty: /tmp/selfhost_merged.osty:6288:9
+		func() {
+			var _cur1635 int = li
+			var _rhs1636 int = 1
+			if _rhs1636 > 0 && _cur1635 > math.MaxInt-_rhs1636 {
+				panic("integer overflow")
+			}
+			if _rhs1636 < 0 && _cur1635 < math.MinInt-_rhs1636 {
+				panic("integer overflow")
+			}
+			li = _cur1635 + _rhs1636
+		}()
+	}`,
+			new: `	// Osty: /tmp/selfhost_merged.osty:6284:5
+	leadingDocs := collectLeadingDocs(units, stream)
+	_ = leadingDocs`,
+		},
+	} {
+		src, err = replaceGeneratedSnippet(src, snippet.name, snippet.old, snippet.new)
+		if err != nil {
+			return err
+		}
+	}
 	for _, fn := range []struct {
 		name string
 		body string
@@ -326,6 +435,13 @@ func normalizeGeneratedSourceComment(src string) string {
 
 func replaceGeneratedFunction(src, name, replacement string) (string, error) {
 	return genpatch.ReplaceGeneratedFunction(src, name, replacement)
+}
+
+func replaceGeneratedSnippet(src, name, old, replacement string) (string, error) {
+	if !strings.Contains(src, old) {
+		return "", fmt.Errorf("replace %s: snippet not found", name)
+	}
+	return strings.Replace(src, old, replacement, 1), nil
 }
 
 const frontPositionAtReplacement = `type frontPositionCacheState struct {

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -1439,6 +1439,7 @@ type FrontLexStream struct {
 	normalizedTripleUnits int
 	tripleIndentErrors    int
 	escapeErrors          int
+	units                 []string
 }
 
 // Osty: /tmp/selfhost_merged.osty:680:5
@@ -1976,7 +1977,7 @@ func frontendLexStream(source string) *FrontLexStream {
 	units := strings.Split(source, "")
 	_ = units
 	// Osty: /tmp/selfhost_merged.osty:1069:5
-	unitCount := stringUnitCount(source)
+	unitCount := len(units)
 	_ = unitCount
 	// Osty: /tmp/selfhost_merged.osty:1070:5
 	var tokens []*FrontLexToken = make([]*FrontLexToken, 0, 1)
@@ -3156,7 +3157,7 @@ func frontendLexStream(source string) *FrontLexStream {
 		}
 		tokenIndex = _cur156 + _rhs157
 	}()
-	return &FrontLexStream{tokens: tokens, diagnostics: diagnostics, comments: comments, stringParts: stringParts, interpolationTokens: interpolationTokens, shebangs: shebangs, bomStripped: bomStripped, sourceUnits: unitCount, normalizedTripleUnits: normalizedTripleUnits, tripleIndentErrors: tripleIndentErrors, escapeErrors: escapeErrors}
+	return &FrontLexStream{tokens: tokens, diagnostics: diagnostics, comments: comments, stringParts: stringParts, interpolationTokens: interpolationTokens, shebangs: shebangs, bomStripped: bomStripped, sourceUnits: unitCount, normalizedTripleUnits: normalizedTripleUnits, tripleIndentErrors: tripleIndentErrors, escapeErrors: escapeErrors, units: units}
 }
 
 // Osty: /tmp/selfhost_merged.osty:1536:5
@@ -16839,7 +16840,10 @@ func ostyLex(source string) *OstyLexResult {
 // Osty: /tmp/selfhost_merged.osty:6239:5
 func ostyLexFactsFromStream(source string, stream *FrontLexStream) *OstyLexFacts {
 	// Osty: /tmp/selfhost_merged.osty:6240:5
-	units := strings.Split(source, "")
+	units := stream.units
+	if units == nil {
+		units = strings.Split(source, "")
+	}
 	_ = units
 	// Osty: /tmp/selfhost_merged.osty:6242:5
 	var errors []*OstyLexError = make([]*OstyLexError, 0, 1)
@@ -16978,31 +16982,8 @@ func ostyLexFactsFromStream(source string, stream *FrontLexStream) *OstyLexFacts
 		}()
 	}
 	// Osty: /tmp/selfhost_merged.osty:6284:5
-	var leadingDocs []string = make([]string, 0, 1)
+	leadingDocs := collectLeadingDocs(units, stream)
 	_ = leadingDocs
-	// Osty: /tmp/selfhost_merged.osty:6285:5
-	li := 0
-	_ = li
-	// Osty: /tmp/selfhost_merged.osty:6286:5
-	for li < tokenCount {
-		// Osty: /tmp/selfhost_merged.osty:6287:9
-		func() struct{} {
-			leadingDocs = append(leadingDocs, ostyJoinDocLines(units, stream, frontLexTokenAt(stream, li)))
-			return struct{}{}
-		}()
-		// Osty: /tmp/selfhost_merged.osty:6288:9
-		func() {
-			var _cur1635 int = li
-			var _rhs1636 int = 1
-			if _rhs1636 > 0 && _cur1635 > math.MaxInt-_rhs1636 {
-				panic("integer overflow")
-			}
-			if _rhs1636 < 0 && _cur1635 < math.MinInt-_rhs1636 {
-				panic("integer overflow")
-			}
-			li = _cur1635 + _rhs1636
-		}()
-	}
 	return &OstyLexFacts{errors: errors, comments: comments, stringParts: stringParts, leadingDocs: leadingDocs}
 }
 


### PR DESCRIPTION
## Summary
- reuse the cached selfhost unit slice instead of splitting the source again in `ostyLexFactsFromStream`
- build leading doc strings with a single forward pass over comments instead of rescanning every comment for every token
- keep the post-generation patching in `gen_selfhost.go` aligned so regen preserves both optimizations

## Why
The selfhost lexer facts path was still paying for duplicate source splitting and an O(tokens * comments) doc collection pass. Both showed up in profiling as hot allocation paths during parser benchmarks.

## Impact
This trims lexer/facts allocations and reduces parser benchmark time on the selfhost frontend hot path without changing public behavior.

## Validation
- `just front`
- `go test -count=1 -vet=off ./internal/selfhost/...`
- `go test -count=1 -vet=off ./internal/parser -bench=BenchmarkParseBaseline -benchmem -run '^$' -benchtime=3s`
