### PR TITLE
feat(llvmgen): wire env.args() through the LLVM backend

### DIFF
--- a/CHANGELOG_v0.5.md
+++ b/CHANGELOG_v0.5.md
@@ -78,6 +78,17 @@ bodies exist so the stub checker accepts imports.
   [`internal/llvmgen/stmt.go`](./internal/llvmgen/stmt.go) (call
   intercept), and [`cmd/osty/test_native.go`](./cmd/osty/test_native.go)
   (CLI flag).
+- **`env.args()` end-to-end through the LLVM backend** — `use std.env`
+  + `let args = env.args()` now compiles to a real argv lookup instead
+  of the LLVM015 "call target *ast.FieldExpr (env.args)" wall.
+  [`internal/llvmgen/stdlib_env_shim.go`](./internal/llvmgen/stdlib_env_shim.go)
+  routes the call to `osty_rt_env_args`, and
+  [`internal/llvmgen/decl.go`](./internal/llvmgen/decl.go) widens `main`
+  to `(i32 argc, ptr argv)` with an `osty_rt_env_args_init` prologue
+  whenever the package imports `std.env`. Each `env.args()` invocation
+  returns a fresh GC-managed `List<String>` (copies of process argv, so
+  the result is safe to mutate). Packages that don't import `std.env`
+  keep the bare `define i32 @main()` signature.
 - **Structural diff on `testing.assertEq`** — on failure, the
   emitted message now includes a line-level diff (`- left` / `+ right`
   with up to 3 context lines) whenever both operands share a

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -6501,3 +6501,38 @@ void osty_rt_test_snapshot(const char *name, const char *output, const char *sou
     free(snap_path);
     exit(1);
 }
+
+/* std.env command-line argument surface.
+ *
+ * The emitter (see internal/llvmgen/stdlib_env_shim.go) routes the Osty
+ * call `env.args()` to `osty_rt_env_args`, and when a script/binary's
+ * package imports `std.env` the generated `main` is widened to
+ * (i32 argc, ptr argv) and begins with a call to `osty_rt_env_args_init`.
+ * The init call hands us the raw C argv; each `env.args()` invocation
+ * materializes a fresh GC-managed List<String> by duplicating every
+ * argv entry through the string allocator. Freshness matters because
+ * the returned list is mutable from Osty and must not alias process
+ * argv storage. */
+static int64_t osty_rt_env_stored_argc = 0;
+static char *const *osty_rt_env_stored_argv = NULL;
+
+void osty_rt_env_args_init(int64_t argc, void *argv) {
+    osty_rt_env_stored_argc = argc < 0 ? 0 : argc;
+    osty_rt_env_stored_argv = (char *const *)argv;
+}
+
+void *osty_rt_env_args(void) {
+    void *out = osty_rt_list_new();
+    int64_t i;
+    for (i = 0; i < osty_rt_env_stored_argc; i++) {
+        const char *raw = (osty_rt_env_stored_argv != NULL)
+            ? osty_rt_env_stored_argv[i]
+            : NULL;
+        if (raw == NULL) {
+            raw = "";
+        }
+        char *copy = osty_rt_string_dup_site(raw, strlen(raw), "runtime.env.args.entry");
+        osty_rt_list_push_ptr(out, copy);
+    }
+    return out;
+}

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -1105,6 +1105,7 @@ func signatureOf(fn *ast.FnDecl, ownerName string, env typeEnv) (*fnSig, error) 
 
 func (g *generator) emitScriptMain(stmts []ast.Stmt) (string, error) {
 	g.beginFunction()
+	g.emitEnvArgsPrologue()
 	if err := g.emitBlock(stmts); err != nil {
 		return "", err
 	}
@@ -1119,11 +1120,12 @@ func (g *generator) emitScriptMain(stmts []ast.Stmt) (string, error) {
 		llvmReturnI32Zero(emitter)
 		g.takeOstyEmitter(emitter)
 	}
-	return g.renderFunction("i32", "main", nil), nil
+	return g.renderFunction("i32", "main", g.mainEntryParams()), nil
 }
 
 func (g *generator) emitMainFunction(sig *fnSig) (string, error) {
 	g.beginFunction()
+	g.emitEnvArgsPrologue()
 	if err := g.emitBlock(sig.decl.Body.Stmts); err != nil {
 		return "", err
 	}
@@ -1138,7 +1140,44 @@ func (g *generator) emitMainFunction(sig *fnSig) (string, error) {
 		llvmReturnI32Zero(emitter)
 		g.takeOstyEmitter(emitter)
 	}
-	return g.renderFunction("i32", "main", nil), nil
+	return g.renderFunction("i32", "main", g.mainEntryParams()), nil
+}
+
+const (
+	ostyEnvArgsArgcParam = "osty_env_argc"
+	ostyEnvArgsArgvParam = "osty_env_argv"
+)
+
+// mainEntryParams widens `main` to `(i32 argc, ptr argv)` when a
+// package imports `std.env` so the prologue can hand raw argv to the
+// env runtime. Without the import we keep the bare signature so
+// smoke-test IR snapshots stay stable.
+func (g *generator) mainEntryParams() []paramInfo {
+	if len(g.stdEnvAliases) == 0 {
+		return nil
+	}
+	return []paramInfo{
+		{name: ostyEnvArgsArgcParam, typ: "i32", irTyp: "i32"},
+		{name: ostyEnvArgsArgvParam, typ: "ptr", irTyp: "ptr"},
+	}
+}
+
+// emitEnvArgsPrologue runs right after beginFunction so the
+// osty_rt_env_args_init call precedes any user statement that could
+// reach env.args(). The sext to i64 bridges C's `int argc` to the
+// runtime ABI declared below.
+func (g *generator) emitEnvArgsPrologue() {
+	if len(g.stdEnvAliases) == 0 {
+		return
+	}
+	g.declareRuntimeSymbol(ostyRtEnvArgsInitSymbol, "void", []paramInfo{
+		{typ: "i64"}, {typ: "ptr"},
+	})
+	argcI64 := fmt.Sprintf("%%%s.i64", ostyEnvArgsArgcParam)
+	g.body = append(g.body,
+		fmt.Sprintf("  %s = sext i32 %%%s to i64", argcI64, ostyEnvArgsArgcParam),
+		fmt.Sprintf("  call void @%s(i64 %s, ptr %%%s)", ostyRtEnvArgsInitSymbol, argcI64, ostyEnvArgsArgvParam),
+	)
 }
 
 func (g *generator) emitUserFunction(sig *fnSig) (string, error) {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -4017,6 +4017,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitStdStringsCall(call); found || err != nil {
 		return v, err
 	}
+	if v, found, err := g.emitStdEnvCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitRuntimeFFICall(call); found || err != nil {
 		return v, err
 	}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -39,6 +39,7 @@ type generator struct {
 	runtimeFFIPaths   map[string]string
 	testingAliases    map[string]bool
 	stdStringsAliases map[string]bool
+	stdEnvAliases     map[string]bool
 	runtimeDecls      map[string]runtimeDecl
 	runtimeDeclOrder  []string
 	traceHelpers      map[string]string

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -263,6 +263,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.resultTypes = collectBuiltinResultTypes(file, env)
 		g.testingAliases = collectStdTestingAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
+		g.stdEnvAliases = collectStdEnvAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
 		if err != nil {
 			return nil, err
@@ -291,6 +292,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
 	g.testingAliases = collectStdTestingAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
+	g.stdEnvAliases = collectStdEnvAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {
 		return nil, err
 	}

--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -1,0 +1,103 @@
+// stdlib_env_shim.go — backend shim for `std.env` surface.
+//
+// The pure-Osty stdlib body in internal/stdlib/modules/env.osty is a
+// placeholder returning an empty list; this shim bypasses it so real
+// argv reaches the program. Only `env.args()` is covered — other
+// std.env surface (get, require, vars, currentDir, …) still falls
+// through to LLVM015 and needs its own runtime helper + switch arm.
+package llvmgen
+
+import (
+	"github.com/osty/osty/internal/ast"
+)
+
+const ostyRtEnvArgsSymbol = "osty_rt_env_args"
+const ostyRtEnvArgsInitSymbol = "osty_rt_env_args_init"
+
+// Shared across every env.args() call site so type inference doesn't
+// re-allocate an identical `List<String>` AST tree per reference.
+var stdEnvArgsSourceTypeSingleton ast.Type = &ast.NamedType{
+	Path: []string{"List"},
+	Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
+}
+
+func collectStdEnvAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "env" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "env"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func (g *generator) emitStdEnvCall(call *ast.CallExpr) (value, bool, error) {
+	if !g.isStdEnvArgsCall(call) {
+		return value{}, false, nil
+	}
+	if len(call.Args) != 0 {
+		return value{}, true, unsupportedf("call", "env.args takes no arguments, got %d", len(call.Args))
+	}
+	g.declareRuntimeSymbol(ostyRtEnvArgsSymbol, "ptr", nil)
+	emitter := g.toOstyEmitter()
+	g.emitGCSafepointKind(emitter, safepointKindCall)
+	out := llvmCall(emitter, "ptr", ostyRtEnvArgsSymbol, nil)
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.listElemTyp = "ptr"
+	v.listElemString = true
+	v.sourceType = stdEnvArgsSourceTypeSingleton
+	v.rootPaths = g.rootPathsForType(v.typ)
+	return v, true, nil
+}
+
+func (g *generator) stdEnvCallStaticResult(call *ast.CallExpr) (value, bool) {
+	if !g.isStdEnvArgsCall(call) {
+		return value{}, false
+	}
+	return value{
+		typ:            "ptr",
+		gcManaged:      true,
+		listElemTyp:    "ptr",
+		listElemString: true,
+		sourceType:     stdEnvArgsSourceTypeSingleton,
+	}, true
+}
+
+// staticStdEnvCallSourceType recovers the source-level `List<String>`
+// so `args.get(i) ?? "x"` reaches the Option<String> the `??` emitter
+// demands. Without it the coalesce path bails with
+// "?? left source type unknown".
+func (g *generator) staticStdEnvCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	if !g.isStdEnvArgsCall(call) {
+		return nil, false
+	}
+	return stdEnvArgsSourceTypeSingleton, true
+}
+
+func (g *generator) isStdEnvArgsCall(call *ast.CallExpr) bool {
+	if call == nil || len(g.stdEnvAliases) == 0 {
+		return false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdEnvAliases[alias.Name] {
+		return false
+	}
+	return field.Name == "args"
+}

--- a/internal/llvmgen/stdlib_env_shim_test.go
+++ b/internal/llvmgen/stdlib_env_shim_test.go
@@ -1,0 +1,66 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// `use std.env` + `env.args()` must widen `main` to (argc, argv), emit
+// the init prologue, and lower the call to the runtime helper. Losing
+// any one silently hands the program an empty argv at runtime.
+func TestStdEnvArgsRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.env
+
+fn main() {
+    let xs = env.args()
+    println(xs.len())
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_env_args.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_env_args()",
+		"declare void @osty_rt_env_args_init(i64, ptr)",
+		"call ptr @osty_rt_env_args()",
+		"define i32 @main(i32 %osty_env_argc, ptr %osty_env_argv)",
+		"call void @osty_rt_env_args_init(i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Packages without `std.env` must keep the bare `i32 @main()` so
+// existing smoke-test IR snapshots and downstream linker expectations
+// don't break on an unrelated param widening.
+func TestMainSignatureStableWithoutStdEnv(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    println(1)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/no_env_main.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	if !strings.Contains(got, "define i32 @main()") {
+		t.Fatalf("expected bare `define i32 @main()` without std.env import; got:\n%s", got)
+	}
+	if strings.Contains(got, "osty_rt_env_args_init") {
+		t.Fatalf("unexpected env init prologue in main without std.env:\n%s", got)
+	}
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -394,6 +394,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStdStringsCallSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticStdEnvCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticMapMethodSourceType(e); ok {
 			return src, true
 		}
@@ -595,6 +598,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 			return value{typ: fn.ret, listElemTyp: fn.listElemTyp, gcManaged: fn.listElemTyp != ""}, true
 		}
 		if out, ok := g.stdStringsCallStaticResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.stdEnvCallStaticResult(e); ok {
 			return out, true
 		}
 	case *ast.FieldExpr:


### PR DESCRIPTION
## Summary

- `use std.env; let args = env.args()` now compiles and runs end-to-end through `osty run` instead of walling with `LLVM015 call: call target *ast.FieldExpr (env.args)`.
- When a package imports `std.env`, the generated `main` widens to `(i32 argc, ptr argv)` and prepends `@osty_rt_env_args_init(argc, argv)`. Packages without the import keep the bare `define i32 @main()` so existing smoke-test IR snapshots stay stable.
- Each `env.args()` call returns a fresh GC-managed `List<String>` (copies of process argv, so the result is safe to mutate from Osty).

## Why

Dispatch-style scripts (`let args = env.args(); if args[1] == "hello" { ... }`) couldn't build at all before — the shim layer only covered `std.strings`. Any script with top-level argv dispatch hit LLVM015 immediately.

## What changed

- **`internal/llvmgen/stdlib_env_shim.go`** (new): `collectStdEnvAliases` + `emitStdEnvCall` route `env.args()` to `@osty_rt_env_args`, and `stdEnvCallStaticResult` / `staticStdEnvCallSourceType` publish the `List<String>` source type so downstream inference (`args.get(i) ?? "x"`, `args.len()`) stays correct. Uses a package-level singleton for the AST type to avoid re-allocating per call site.
- **`internal/llvmgen/decl.go`**: `mainEntryParams` + `emitEnvArgsPrologue` conditionally widen `main` and emit the init call.
- **`internal/llvmgen/expr.go` / `type.go` / `generator.go` / `llvmgen.go`**: wire the shim into `emitCall`, `staticExprInfo`, `staticExprSourceType`, and alias collection (mirroring the `std.strings` shim layering).
- **`internal/backend/runtime/osty_runtime.c`**: `osty_rt_env_args_init` stores argc/argv in module-level statics; `osty_rt_env_args` materializes a fresh list via `osty_rt_string_dup_site` + `osty_rt_list_push_ptr`. Freshness is a correctness requirement (the returned list is mutable from Osty and must not alias read-only process argv).
- **`CHANGELOG_v0.5.md`**: entry under "Shipped in the compiler".

## Notes for reviewers

- **Scope**: only `env.args()` is covered. Other `std.env` surface (`get`, `require`, `vars`, `currentDir`) still falls through to the placeholder body and hits LLVM015 — adding each one is a runtime helper + switch arm away.
- **Still open** (unrelated to this PR): `args.get(i) ?? "default"` still trips LLVM011 because `List<T>.get` source-type propagation isn't wired yet. Indexing (`args[i]`) works. The dispatch-runner idiom covered by this PR uses indexing.
- Memory note `project_llvm_backend_limits.md` updated to reflect the closed gap.

## Test plan

- [x] `go test ./internal/llvmgen/ -run '^TestStdEnv|^TestMainSignatureStableWithoutStdEnv'` — new regression tests pass, pin argc/argv widening + init prologue + runtime call.
- [x] Broader `go test ./internal/llvmgen/...` (excluding pre-existing flaky `TestProbeNativeToolchainMergedMIR`, which also times out on clean `main`) — clean.
- [x] End-to-end `osty run -- hello` / `-- count a b c` / `-- echo foo bar baz` / no-args on a dispatch-style `main.osty` all behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)