### PR TITLE
refactor(toolchain): port GC Phase A policy + IR assembly to Osty

### DIFF
--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -19,6 +19,17 @@ import (
 	"github.com/osty/osty/internal/ast"
 )
 
+// closureThunkParamTypes extracts the LLVM IR types of a fnSig's
+// parameters in source order. The thunk consumes these verbatim:
+// `ptr %env` plus `P_i %arg_i` for each original param.
+func closureThunkParamTypes(sig *fnSig) []string {
+	out := make([]string, 0, len(sig.params))
+	for _, p := range sig.params {
+		out = append(out, llvmParamIRType(p))
+	}
+	return out
+}
+
 func fnValueThunkSymbol(realSymbol string) string {
 	return "__osty_closure_thunk_" + realSymbol
 }
@@ -38,32 +49,9 @@ func (g *generator) ensureFnValueThunk(sig *fnSig) string {
 	if _, ok := g.fnValueThunkDefs[symbol]; ok {
 		return symbol
 	}
-	retLLVM := sig.ret
-	if retLLVM == "" {
-		retLLVM = "void"
-	}
-	// Build param list for the thunk: `ptr %env, <P0> %arg0, ...`.
-	paramParts := make([]string, 0, 1+len(sig.params))
-	paramParts = append(paramParts, "ptr %env")
-	argParts := make([]string, 0, len(sig.params))
-	for i, p := range sig.params {
-		pLLVM := llvmParamIRType(p)
-		paramParts = append(paramParts, fmt.Sprintf("%s %%arg%d", pLLVM, i))
-		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", pLLVM, i))
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "define private %s @%s(%s) {\n",
-		retLLVM, symbol, strings.Join(paramParts, ", "))
-	b.WriteString("entry:\n")
-	if retLLVM == "void" {
-		fmt.Fprintf(&b, "  call void @%s(%s)\n  ret void\n",
-			sig.irName, strings.Join(argParts, ", "))
-	} else {
-		fmt.Fprintf(&b, "  %%__ret = call %s @%s(%s)\n  ret %s %%__ret\n",
-			retLLVM, sig.irName, strings.Join(argParts, ", "), retLLVM)
-	}
-	b.WriteString("}\n")
-	g.fnValueThunkDefs[symbol] = b.String()
+	g.fnValueThunkDefs[symbol] = llvmRenderClosureThunk(
+		sig.ret, symbol, closureThunkParamTypes(sig), sig.irName,
+	)
 	g.fnValueThunkOrder = append(g.fnValueThunkOrder, symbol)
 	return symbol
 }
@@ -75,14 +63,14 @@ func (g *generator) ensureFnValueThunk(sig *fnSig) string {
 // future direct `osty.gc.alloc_v1` callers; the closure allocation
 // path itself uses `osty.rt.closure_env_alloc_v1` which installs the
 // capture-tracing callback at construction.
-const fnValueEnvKind = 1029
+var fnValueEnvKind = llvmClosureEnvGcKind()
 
 // fnValuePhase1CaptureCount is the capture count the current lowering
 // emits for every closure env. Phase 1 closures have no captures yet;
 // Phase 4 will drive this from the closure AST. The constant lives at
 // this boundary so the call-site change is one-line when captures
 // land.
-const fnValuePhase1CaptureCount = 0
+var fnValuePhase1CaptureCount = llvmClosureEnvPhase1CaptureCount()
 
 // emitFnValueEnv materialises a closure env holding the thunk pointer
 // for the given top-level fn. Returns a `ptr`-typed value tagged with
@@ -116,17 +104,12 @@ func (g *generator) emitFnValueEnv(sig *fnSig) (value, error) {
 	})
 	emitter := g.toOstyEmitter()
 	site := llvmStringLiteral(emitter, "runtime.closure.env.ptr")
-	envTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf(
-		"  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %d, ptr %s)",
-		envTemp, fnValuePhase1CaptureCount, site.name,
-	))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunk, envTemp))
+	env := llvmEmitClosureEnvAllocRuntime(emitter, fnValuePhase1CaptureCount, site.name, thunk)
 	g.takeOstyEmitter(emitter)
 	g.needsGCRuntime = true
 	return value{
 		typ:       "ptr",
-		ref:       envTemp,
+		ref:       env.name,
 		fnSigRef:  sig,
 		gcManaged: true,
 	}, nil

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -194,18 +194,19 @@ func (g *generator) releaseGCRoots(emitter *LlvmEmitter) {
 
 // safepointKind classifies why a safepoint poll was emitted. The low 56
 // bits of the id passed to `osty.gc.safepoint_v1` hold the per-module
-// serial; the top 8 bits hold one of these values. See
-// `RUNTIME_GC_DELTA.md` §10.1 and the C runtime enum
-// `OSTY_GC_SAFEPOINT_KIND_*` which must stay numerically aligned.
+// serial; the top 8 bits hold one of these values. The numeric values
+// are owned by `toolchain/llvmgen.osty` and must stay aligned with the
+// C runtime enum `OSTY_GC_SAFEPOINT_KIND_*` (`RUNTIME_GC_DELTA.md`
+// §10.1).
 type safepointKind uint8
 
-const (
-	safepointKindUnspecified safepointKind = 0
-	safepointKindEntry       safepointKind = 1
-	safepointKindCall        safepointKind = 2
-	safepointKindLoop        safepointKind = 3
-	safepointKindAlloc       safepointKind = 4
-	safepointKindYield       safepointKind = 5
+var (
+	safepointKindUnspecified = safepointKind(llvmSafepointKindUnspecified())
+	safepointKindEntry       = safepointKind(llvmSafepointKindEntry())
+	safepointKindCall        = safepointKind(llvmSafepointKindCall())
+	safepointKindLoop        = safepointKind(llvmSafepointKindLoop())
+	safepointKindAlloc       = safepointKind(llvmSafepointKindAlloc())
+	safepointKindYield       = safepointKind(llvmSafepointKindYield())
 )
 
 // encodeSafepointID packs kind (high 8 bits) and serial (low 56 bits)
@@ -214,8 +215,7 @@ const (
 // the encoding forward for future kinds does not break older runtimes
 // shipped alongside this LLVM output.
 func encodeSafepointID(kind safepointKind, serial int) int64 {
-	const serialMask int64 = (int64(1) << 56) - 1
-	return (int64(kind) << 56) | (int64(serial) & serialMask)
+	return llvmEncodeSafepointId(int(kind), serial)
 }
 
 // safepointRootChunkSize bounds the number of root slots emitted into a
@@ -225,11 +225,10 @@ func encodeSafepointID(kind safepointKind, serial int) int64 {
 // — so no single `alloca ptr, i64 N` can grow the LLVM-level C stack
 // beyond a bounded frame. The runtime's
 // `OSTY_GC_SAFEPOINT_MAX_ROOTS = 65536` guard aborts anything larger, so
-// the chunk size is kept well below that cap to leave head-room.
-//
-// The package-private `var` form (rather than a const) lets tests lower
-// the bound and drive the splitting path on modest fixtures.
-var safepointRootChunkSize = 4096
+// the chunk size is kept well below that cap to leave head-room. The
+// `var` form (rather than a const) lets tests lower the bound and drive
+// the splitting path on modest fixtures.
+var safepointRootChunkSize = llvmSafepointDefaultRootChunkSize()
 
 // emitGCSafepoint emits a safepoint poll at an unspecified site — kept
 // for callers that have not been classified yet. New call sites should
@@ -249,11 +248,7 @@ func (g *generator) emitGCSafepointKind(emitter *LlvmEmitter, kind safepointKind
 	if len(roots) == 0 {
 		serial := g.nextSafepoint
 		g.nextSafepoint++
-		id := encodeSafepointID(kind, serial)
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @osty.gc.safepoint_v1(i64 %d, ptr null, i64 0)",
-			id,
-		))
+		llvmEmitSafepointEmpty(emitter, encodeSafepointID(kind, serial))
 		g.needsGCRuntime = true
 		return
 	}
@@ -274,22 +269,13 @@ func (g *generator) emitGCSafepointKind(emitter *LlvmEmitter, kind safepointKind
 			end = len(roots)
 		}
 		chunk := roots[start:end]
+		addresses := make([]string, len(chunk))
+		for i, root := range chunk {
+			addresses[i] = g.safepointRootAddress(emitter, root)
+		}
 		serial := g.nextSafepoint
 		g.nextSafepoint++
-		id := encodeSafepointID(kind, serial)
-		slotsPtr := llvmNextTemp(emitter)
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr, i64 %d", slotsPtr, len(chunk)))
-		for i, root := range chunk {
-			slotPtr := llvmNextTemp(emitter)
-			emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr ptr, ptr %s, i64 %d", slotPtr, slotsPtr, i))
-			emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", g.safepointRootAddress(emitter, root), slotPtr))
-		}
-		emitter.body = append(emitter.body, fmt.Sprintf(
-			"  call void @osty.gc.safepoint_v1(i64 %d, ptr %s, i64 %d)",
-			id,
-			slotsPtr,
-			len(chunk),
-		))
+		llvmEmitSafepointWithRoots(emitter, encodeSafepointID(kind, serial), addresses)
 	}
 	g.needsGCRuntime = true
 }

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1029,10 +1029,8 @@ func (g *mirGen) emitGCSafepointKind(kind safepointKind) {
 	g.declareSafepoint()
 	serial := g.nextSafepoint
 	g.nextSafepoint++
-	id := encodeSafepointID(kind, serial)
-	g.fnBuf.WriteString("  call void @osty.gc.safepoint_v1(i64 ")
-	g.fnBuf.WriteString(strconv.FormatInt(id, 10))
-	g.fnBuf.WriteString(", ptr null, i64 0)\n")
+	g.fnBuf.WriteString(llvmRenderSafepointEmpty(encodeSafepointID(kind, serial)))
+	g.fnBuf.WriteByte('\n')
 }
 
 // declareSafepoint registers @osty.gc.safepoint_v1 — split from

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -455,6 +455,71 @@ func llvmGcRootRelease(emitter *LlvmEmitter, value *LlvmValue) {
 	llvmCallVoid(emitter, "osty.gc.root_release_v1", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:455:5
+func llvmSafepointKindUnspecified() int { return 0 }
+
+// Osty: toolchain/llvmgen.osty:457:5
+func llvmSafepointKindEntry() int { return 1 }
+
+// Osty: toolchain/llvmgen.osty:459:5
+func llvmSafepointKindCall() int { return 2 }
+
+// Osty: toolchain/llvmgen.osty:461:5
+func llvmSafepointKindLoop() int { return 3 }
+
+// Osty: toolchain/llvmgen.osty:463:5
+func llvmSafepointKindAlloc() int { return 4 }
+
+// Osty: toolchain/llvmgen.osty:465:5
+func llvmSafepointKindYield() int { return 5 }
+
+// Osty: toolchain/llvmgen.osty:472:5
+func llvmEncodeSafepointId(kind int, serial int) int64 {
+	const mask int64 = (int64(1) << 56) - 1
+	return (int64(kind) << 56) | (int64(serial) & mask)
+}
+
+// Osty: toolchain/llvmgen.osty:487:5
+func llvmSafepointDefaultRootChunkSize() int { return 4096 }
+
+// Osty: toolchain/llvmgen.osty:498:5
+func llvmClosureEnvGcKind() int { return 1029 }
+
+// Osty: toolchain/llvmgen.osty:505:5
+func llvmClosureEnvPhase1CaptureCount() int { return 0 }
+
+// Osty: toolchain/llvmgen.osty:514:5
+func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string) *LlvmValue {
+	envTemp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %d, ptr %s)", envTemp, captureCount, siteName))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunkSymbol, envTemp))
+	return &LlvmValue{typ: "ptr", name: envTemp, pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:513:5
+func llvmRenderSafepointEmpty(id int64) string {
+	return fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr null, i64 0)", id)
+}
+
+// Osty: toolchain/llvmgen.osty:521:5
+func llvmEmitSafepointEmpty(emitter *LlvmEmitter, id int64) {
+	emitter.body = append(emitter.body, llvmRenderSafepointEmpty(id))
+}
+
+// Osty: toolchain/llvmgen.osty:523:5
+func llvmEmitSafepointWithRoots(emitter *LlvmEmitter, id int64, rootAddresses []string) {
+	count := len(rootAddresses)
+	slotsPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr, i64 %d", slotsPtr, count))
+	for i := 0; i < count; i++ {
+		slotPtr := llvmNextTemp(emitter)
+		addr := rootAddresses[i]
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr ptr, ptr %s, i64 %d", slotPtr, slotsPtr, i))
+		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", addr, slotPtr))
+	}
+	emitter.body = append(emitter.body, fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr %s, i64 %d)", id, slotsPtr, count))
+}
+
 // Osty: toolchain/llvmgen.osty:327:5
 func llvmStructTypeDef(name string, fieldTypes []string) string {
 	// Osty: toolchain/llvmgen.osty:328:5
@@ -1060,6 +1125,37 @@ func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []str
 }
 
 // Osty: toolchain/llvmgen.osty:688:5
+func llvmRenderClosureThunk(retType string, thunkSymbol string, paramTypes []string, realSymbol string) string {
+	ret := retType
+	if ret == "" {
+		ret = "void"
+	}
+	paramParts := []string{"ptr %env"}
+	argParts := make([]string, 0, len(paramTypes))
+	for i := 0; i < len(paramTypes); i++ {
+		pt := paramTypes[i]
+		paramParts = append(paramParts, fmt.Sprintf("%s %%arg%d", pt, i))
+		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", pt, i))
+	}
+	params := llvmStrings.Join(paramParts, ", ")
+	args := llvmStrings.Join(argParts, ", ")
+	lines := []string{fmt.Sprintf("define private %s @%s(%s) {", ret, thunkSymbol, params), "entry:"}
+	if ret == "void" {
+		lines = append(lines,
+			fmt.Sprintf("  call void @%s(%s)", realSymbol, args),
+			"  ret void",
+		)
+	} else {
+		lines = append(lines,
+			fmt.Sprintf("  %%__ret = call %s @%s(%s)", ret, realSymbol, args),
+			fmt.Sprintf("  ret %s %%__ret", ret),
+		)
+	}
+	lines = append(lines, "}")
+	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
+}
+
+// Osty: toolchain/llvmgen.osty:740:5
 func llvmNeedsObjectArtifact(emit string) bool {
 	return emit == "object" || emit == "binary"
 }

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -443,6 +443,130 @@ pub fn llvmGcRootRelease(emitter: LlvmEmitter, value: LlvmValue) {
     llvmCallVoid(emitter, "osty.gc.root_release_v1", [value])
 }
 
+/// Phase A5 safepoint kind taxonomy (`RUNTIME_GC_DELTA.md` §10.1).
+///
+/// The id passed to `osty.gc.safepoint_v1` packs a kind tag in the high
+/// 8 bits and a per-module serial in the low 56 bits. These accessors
+/// own the kind enum values so the Osty emitter core, the
+/// `support_snapshot.go` Go bridge, and the C runtime
+/// (`OSTY_GC_SAFEPOINT_KIND_*` in `internal/backend/runtime/osty_runtime.c`)
+/// all read the same numeric namespace. Ordering matches the runtime
+/// enum — adding a new kind means extending all three in lock-step.
+pub fn llvmSafepointKindUnspecified() -> Int { 0 }
+
+pub fn llvmSafepointKindEntry() -> Int { 1 }
+
+pub fn llvmSafepointKindCall() -> Int { 2 }
+
+pub fn llvmSafepointKindLoop() -> Int { 3 }
+
+pub fn llvmSafepointKindAlloc() -> Int { 4 }
+
+pub fn llvmSafepointKindYield() -> Int { 5 }
+
+/// Packs a Phase A5 safepoint `kind` (high 8 bits) and per-module
+/// `serial` (low 56 bits) into the single i64 the runtime entrypoint
+/// consumes. The runtime tolerates unknown kinds by falling back to
+/// UNSPECIFIED, so rolling the encoding forward for future kinds does
+/// not break older runtimes shipped alongside this LLVM output.
+pub fn llvmEncodeSafepointId(kind: Int, serial: Int) -> Int {
+    let mask = (1 << 56) - 1
+    (kind << 56) | (serial & mask)
+}
+
+/// Phase A6 stackmap overflow guard (`RUNTIME_GC_DELTA.md` §10.2).
+///
+/// Bounds the number of root slots emitted into a single safepoint's
+/// alloca array. When a frame exposes more managed roots than this,
+/// the Go-side emitter splits the poll into multiple calls — each
+/// inheriting the original kind tag but bumping the serial — so no
+/// single `alloca ptr, i64 N` can grow the LLVM-level C stack beyond
+/// a bounded frame. The runtime's
+/// `OSTY_GC_SAFEPOINT_MAX_ROOTS = 65536` guard aborts anything larger,
+/// so the default sits well below that cap to leave head-room.
+pub fn llvmSafepointDefaultRootChunkSize() -> Int { 4096 }
+
+/// Phase A4 closure env GC kind tag (`RUNTIME_GC_DELTA.md` §2.4).
+///
+/// Points at the dedicated `OSTY_GC_KIND_CLOSURE_ENV = 1029`
+/// reservation in the runtime. The closure allocation path itself
+/// uses `osty.rt.closure_env_alloc_v1`, which installs the
+/// capture-tracing callback at construction; this constant is
+/// retained for heap-dump / `osty_gc_stats` categorisation and as
+/// the pivot for any direct `osty.gc.alloc_v1` caller that wants to
+/// tag an env-shaped allocation.
+pub fn llvmClosureEnvGcKind() -> Int { 1029 }
+
+/// Phase A4 closure capture count the current legacy emitter bakes
+/// into every closure env. Phase 1 closures have no captures yet;
+/// Phase 4 will drive this from the closure AST. The constant lives
+/// at this boundary so the call-site change is one place when
+/// capture-aware lowering lands.
+pub fn llvmClosureEnvPhase1CaptureCount() -> Int { 0 }
+
+/// Phase A4 closure env allocation + thunk install. Calls
+/// `osty.rt.closure_env_alloc_v1` with the supplied capture count
+/// (currently always `llvmClosureEnvPhase1CaptureCount()`) and a
+/// diagnostic site, then stores the thunk symbol at slot 0 so
+/// subsequent indirect calls can dispatch through the env. Returns
+/// the env pointer as a `ptr`-typed LlvmValue. The runtime helper
+/// attaches the capture-tracing GC callback at construction so any
+/// managed pointers a Phase 4 lowering drops into capture slots are
+/// immediately reachable from mark (`RUNTIME_GC_DELTA.md` §2.4).
+pub fn llvmEmitClosureEnvAllocRuntime(
+    emitter: LlvmEmitter,
+    captureCount: Int,
+    siteName: String,
+    thunkSymbol: String,
+) -> LlvmValue {
+    let envTemp = llvmNextTemp(emitter)
+    emitter.body.push(
+        "  {envTemp} = call ptr @osty.rt.closure_env_alloc_v1(i64 {captureCount}, ptr {siteName})",
+    )
+    emitter.body.push("  store ptr @{thunkSymbol}, ptr {envTemp}")
+    LlvmValue { typ: "ptr", name: envTemp, pointer: false }
+}
+
+/// Render the single-line IR for an empty-roots safepoint poll. The
+/// pure form exists so emitters backed by a non-Osty buffer (e.g. the
+/// MIR emitter's `strings.Builder`) can consume the format string
+/// without adapting to the Osty `LlvmEmitter` shape.
+pub fn llvmRenderSafepointEmpty(id: Int) -> String {
+    "  call void @osty.gc.safepoint_v1(i64 {id}, ptr null, i64 0)"
+}
+
+/// Emit the ABI-only form of a safepoint poll — no root slots. Used
+/// as the zero-roots fast path for the legacy emitter; MIR reaches
+/// the same IR through `llvmRenderSafepointEmpty` + its own buffer.
+pub fn llvmEmitSafepointEmpty(emitter: LlvmEmitter, id: Int) {
+    emitter.body.push(llvmRenderSafepointEmpty(id))
+}
+
+/// Emit a safepoint poll whose `rootAddresses` (each already rendered
+/// as an LLVM operand like `%t12` or `@global_slot`) are stored into a
+/// single `alloca ptr, i64 N` slot array and handed to the runtime.
+/// Callers that need to respect `llvmSafepointDefaultRootChunkSize`
+/// must chunk `rootAddresses` before each call so every individual
+/// `alloca` stays bounded (`RUNTIME_GC_DELTA.md` §10.2).
+pub fn llvmEmitSafepointWithRoots(
+    emitter: LlvmEmitter,
+    id: Int,
+    rootAddresses: List<String>,
+) {
+    let count = rootAddresses.len()
+    let slotsPtr = llvmNextTemp(emitter)
+    emitter.body.push("  {slotsPtr} = alloca ptr, i64 {count}")
+    for i in 0..count {
+        let slotPtr = llvmNextTemp(emitter)
+        let addr = rootAddresses[i]
+        emitter.body.push("  {slotPtr} = getelementptr ptr, ptr {slotsPtr}, i64 {i}")
+        emitter.body.push("  store ptr {addr}, ptr {slotPtr}")
+    }
+    emitter.body.push(
+        "  call void @osty.gc.safepoint_v1(i64 {id}, ptr {slotsPtr}, i64 {count})",
+    )
+}
+
 pub fn llvmStructTypeDef(name: String, fieldTypes: List<String>) -> String {
     let fields = llvmStrings.join(fieldTypes, ", ")
     "%{name} = type \{ {fields} \}"
@@ -930,6 +1054,45 @@ pub fn llvmRenderFunction(
     let mut lines = ["define {ret} @{name}({llvmParams(params)}) \{", "entry:"]
     for line in body {
         lines.push(line)
+    }
+    lines.push("\}")
+    llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")
+}
+
+/// Phase A4 fn-value thunk template. Renders the IR body of a private
+/// delegating function that accepts `ptr %env` as its implicit first
+/// argument, discards the env, and forwards the remaining args to
+/// `realSymbol`. The resulting IR is what the legacy emitter caches
+/// in `g.fnValueThunkDefs` so top-level fn references can be wrapped
+/// in a fn-value-compatible ABI (`{ ptr fn, ... }` env layout) without
+/// touching the defining symbol. An empty `retType` is normalised to
+/// `void` so call sites may forward the checker's unit return type
+/// verbatim.
+pub fn llvmRenderClosureThunk(
+    retType: String,
+    thunkSymbol: String,
+    paramTypes: List<String>,
+    realSymbol: String,
+) -> String {
+    let ret = if retType == "" { "void" } else { retType }
+    let mut paramParts: List<String> = ["ptr %env"]
+    let mut argParts: List<String> = []
+    for i in 0..paramTypes.len() {
+        let pt = paramTypes[i]
+        paramParts.push("{pt} %arg{i}")
+        argParts.push("{pt} %arg{i}")
+    }
+    let params = llvmStrings.join(paramParts, ", ")
+    let args = llvmStrings.join(argParts, ", ")
+    let mut lines: List<String> = []
+    lines.push("define private {ret} @{thunkSymbol}({params}) \{")
+    lines.push("entry:")
+    if ret == "void" {
+        lines.push("  call void @{realSymbol}({args})")
+        lines.push("  ret void")
+    } else {
+        lines.push("  %__ret = call {ret} @{realSymbol}({args})")
+        lines.push("  ret {ret} %__ret")
     }
     lines.push("\}")
     llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -1286,3 +1286,102 @@ fn testLlvmSmokeMapBasicIsOstyOwned() {
     assertLlvmContains(ir, "= call i64 @osty_rt_map_len(ptr %t0)")
     assertLlvmContains(ir, "ret i32 0")
 }
+
+fn testLlvmSafepointKindValuesAreOstyOwned() {
+    testing.assertEq(llvmSafepointKindUnspecified(), 0)
+    testing.assertEq(llvmSafepointKindEntry(), 1)
+    testing.assertEq(llvmSafepointKindCall(), 2)
+    testing.assertEq(llvmSafepointKindLoop(), 3)
+    testing.assertEq(llvmSafepointKindAlloc(), 4)
+    testing.assertEq(llvmSafepointKindYield(), 5)
+}
+
+fn testLlvmEncodeSafepointIdPacksKindAndSerial() {
+    // CALL kind in the top byte, serial in the bottom.
+    testing.assertEq(
+        llvmEncodeSafepointId(llvmSafepointKindCall(), 42),
+        (2 << 56) | 42,
+    )
+    // Kind round-trips through the high 8 bits.
+    testing.assertEq(
+        (llvmEncodeSafepointId(llvmSafepointKindLoop(), 7) >> 56) & 0xff,
+        3,
+    )
+    // Serial round-trips through the 56-bit mask.
+    let mask = (1 << 56) - 1
+    testing.assertEq(
+        llvmEncodeSafepointId(llvmSafepointKindEntry(), 17) & mask,
+        17,
+    )
+    // Unspecified encodes the bare serial.
+    testing.assertEq(
+        llvmEncodeSafepointId(llvmSafepointKindUnspecified(), 9),
+        9,
+    )
+}
+
+fn testLlvmGcPhaseAConstantsAreOstyOwned() {
+    testing.assertEq(llvmSafepointDefaultRootChunkSize(), 4096)
+    testing.assertEq(llvmClosureEnvGcKind(), 1029)
+    testing.assertEq(llvmClosureEnvPhase1CaptureCount(), 0)
+}
+
+fn testLlvmEmitSafepointEmptyIsOstyOwned() {
+    let emitter = llvmEmitter()
+    llvmEmitSafepointEmpty(emitter, 42)
+    let ir = llvmTestStrings.join(emitter.body, "\n")
+    assertLlvmContains(ir, "call void @osty.gc.safepoint_v1(i64 42, ptr null, i64 0)")
+}
+
+fn testLlvmEmitSafepointWithRootsIsOstyOwned() {
+    let emitter = llvmEmitter()
+    let addresses = ["%root0", "%root1"]
+    llvmEmitSafepointWithRoots(emitter, 7, addresses)
+    let ir = llvmTestStrings.join(emitter.body, "\n")
+
+    assertLlvmContains(ir, "%t0 = alloca ptr, i64 2")
+    assertLlvmContains(ir, "%t1 = getelementptr ptr, ptr %t0, i64 0")
+    assertLlvmContains(ir, "store ptr %root0, ptr %t1")
+    assertLlvmContains(ir, "%t2 = getelementptr ptr, ptr %t0, i64 1")
+    assertLlvmContains(ir, "store ptr %root1, ptr %t2")
+    assertLlvmContains(ir, "call void @osty.gc.safepoint_v1(i64 7, ptr %t0, i64 2)")
+}
+
+fn testLlvmRenderClosureThunkVoidReturn() {
+    let ir = llvmRenderClosureThunk("void", "__osty_closure_thunk_foo", [], "foo")
+
+    assertLlvmContains(ir, "define private void @__osty_closure_thunk_foo(ptr %env) \{")
+    assertLlvmContains(ir, "entry:")
+    assertLlvmContains(ir, "  call void @foo()")
+    assertLlvmContains(ir, "  ret void")
+    assertLlvmContains(ir, "\}")
+}
+
+fn testLlvmRenderClosureThunkValueReturnWithParams() {
+    let ir = llvmRenderClosureThunk("i64", "__osty_closure_thunk_add", ["i64", "i64"], "add")
+
+    assertLlvmContains(ir, "define private i64 @__osty_closure_thunk_add(ptr %env, i64 %arg0, i64 %arg1) \{")
+    assertLlvmContains(ir, "  %__ret = call i64 @add(i64 %arg0, i64 %arg1)")
+    assertLlvmContains(ir, "  ret i64 %__ret")
+}
+
+fn testLlvmRenderClosureThunkEmptyReturnNormalisesToVoid() {
+    // Checker hands us `""` for unit-return fns; the template must
+    // normalise that to `void` so the generated thunk is well-formed.
+    let ir = llvmRenderClosureThunk("", "__osty_closure_thunk_sink", ["ptr"], "sink")
+
+    assertLlvmContains(ir, "define private void @__osty_closure_thunk_sink(ptr %env, ptr %arg0) \{")
+    assertLlvmContains(ir, "  call void @sink(ptr %arg0)")
+    assertLlvmContains(ir, "  ret void")
+}
+
+fn testLlvmEmitClosureEnvAllocRuntimeIsOstyOwned() {
+    let emitter = llvmEmitter()
+    let env = llvmEmitClosureEnvAllocRuntime(emitter, 0, "@.str0", "__osty_closure_thunk_foo")
+    let ir = llvmTestStrings.join(emitter.body, "\n")
+
+    testing.assertEq(env.typ, "ptr")
+    testing.assertEq(env.name, "%t0")
+    assertLlvmContains(ir, "%t0 = call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr @.str0)")
+    assertLlvmContains(ir, "store ptr @__osty_closure_thunk_foo, ptr %t0")
+}


### PR DESCRIPTION
## Summary

Ports GC Phase A llvmgen bits from Go to \`toolchain/llvmgen.osty\` per the CLAUDE.md Osty-first rule. Addresses the \`RUNTIME_GC_DELTA.md\` "Go 측 위반 여전" note (A4/A5/A6 depth passes that landed in \`generator.go\` / \`fn_value.go\` / \`mir_generator.go\`).

Net: +262 lines Osty, −75 lines Go. Policy and IR-assembly templates now own their source in Osty; the Go consumers shrank to state management + snapshot calls.

## What moved

**Policy constants** (\`toolchain/llvmgen.osty\`):
- A5 safepoint kind taxonomy: \`llvmSafepointKind{Unspecified,Entry,Call,Loop,Alloc,Yield}()\` + \`llvmEncodeSafepointId(kind, serial)\`
- A6 stackmap overflow guard default: \`llvmSafepointDefaultRootChunkSize()\` (4096)
- A4 closure env tags: \`llvmClosureEnvGcKind()\` (1029), \`llvmClosureEnvPhase1CaptureCount()\` (0)

**IR assembly templates**:
- \`llvmRenderSafepointEmpty(id)\` + \`llvmEmitSafepointEmpty(emitter, id)\` — zero-roots poll; MIR emitter reuses the render helper so both emitters share one format
- \`llvmEmitSafepointWithRoots(emitter, id, rootAddresses)\` — single-chunk poll (alloca + N × gep/store + safepoint_v1 call)
- \`llvmRenderClosureThunk(retType, thunkSymbol, paramTypes, realSymbol)\` — entire Phase A4 closure thunk body (\`define private ... entry: ... ret ... }\`); normalises empty \`retType\` → \`void\`
- \`llvmEmitClosureEnvAllocRuntime(emitter, captureCount, siteName, thunkSymbol)\` — \`call osty.rt.closure_env_alloc_v1\` + thunk pointer store

**Go consumers** now thin:
- \`generator.go\`: \`safepointKind*\` become \`var\`s backed by snapshot, \`encodeSafepointID\` delegates, \`safepointRootChunkSize\` init reads snapshot, \`emitGCSafepointKind\` loops over chunks and calls the Osty helper per slot
- \`fn_value.go\`: \`fnValueEnvKind\` / \`fnValuePhase1CaptureCount\` sourced from snapshot; \`ensureFnValueThunk\` reduced to cache mgmt + \`closureThunkParamTypes\` + \`llvmRenderClosureThunk\` call; \`emitFnValueEnv\` delegates the two-line emit to \`llvmEmitClosureEnvAllocRuntime\`
- \`mir_generator.go\`: \`emitGCSafepointKind\` uses the shared \`llvmRenderSafepointEmpty\` render helper

## Why

CLAUDE.md "언어 선택 규칙": Osty로 작성 가능한 로직을 Go로 두지 말 것. Phase A 랜딩 당시 IR 조립 문자열과 정책 상수가 Go에 박혀 있었고 \`RUNTIME_GC_DELTA.md\`도 후속 정리 필요를 명시했다. 이 PR은 그 빚을 갚는다.

## Still in Go (follow-up)

- Chunk-splitting loop in \`emitGCSafepointKind\` — generator state deps (\`g.nextSafepoint\`, \`g.visibleSafepointRoots\`, \`g.safepointRootAddress\`) need to move first.
- \`emitFnValueIndirectCall\` load/call sequence — depends on \`value\` metadata + \`fnSig\` type.

## Test plan

- [x] \`go test ./internal/llvmgen/ -short\` (136s, ok)
- [x] \`go test ./internal/backend/ -run 'TestBundledRuntime(Safepoint|Validate|Stats|MarkWorkQueue|ClosureEnv|Minor|Promotes|Nursery|SATB|Incremental)'\` (22s, ok) — Phase A/B/C GC runtime suite
- [x] Focused \`TestGenerateFromAST*Safepoint*\` / \`TestFieldCallDispatch*\` / \`TestGeneratedGc*\` / \`TestProbeToolchain*\` all pass
- [x] New Osty tests in \`toolchain/llvmgen_test.osty\` cover: safepoint kind values, encodeSafepointId round-trip, Phase A constants, empty/with-roots safepoint IR, closure thunk (void / value / empty-ret normalised), closure env alloc IR

Pre-existing \`cmd/osty\` failures (\`TestAIRepairLearnJSONRanksCoveredResidualPriority\`, \`TestRunTestMainAIRepairAllowsForeignSyntaxBeforeDiscovery\`) reproduce on clean HEAD — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)