### PR TITLE
[codex] Recognize Bytes helpers in native checker

### DIFF
--- a/internal/check/native_checker_exec_test.go
+++ b/internal/check/native_checker_exec_test.go
@@ -127,6 +127,53 @@ fn main() {}
 	}
 }
 
+func TestNativeBoundaryExecRecognizesBytesIntrinsics(t *testing.T) {
+	src := []byte(`fn main() {
+    let a: Byte = 65
+    let b: Byte = 66
+    let data = Bytes.from([a, b])
+    let size = data.len()
+    let first = data.get(0)
+    let sameSize = Bytes.len(data)
+    let second = Bytes.get(data, 1)
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	mainDecl := file.Decls[0].(*ast.FnDecl)
+	dataLet := mainDecl.Body.Stmts[2].(*ast.LetStmt)
+	sizeLet := mainDecl.Body.Stmts[3].(*ast.LetStmt)
+	firstLet := mainDecl.Body.Stmts[4].(*ast.LetStmt)
+	sameSizeLet := mainDecl.Body.Stmts[5].(*ast.LetStmt)
+	secondLet := mainDecl.Body.Stmts[6].(*ast.LetStmt)
+
+	bin := buildRepoNativeChecker(t)
+	t.Setenv(nativeCheckerEnv, bin)
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = defaultNativeChecker
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if len(chk.Diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %v", chk.Diags)
+	}
+	if got := chk.LetTypes[dataLet]; got == nil || got.String() != "Bytes" {
+		t.Fatalf("data type = %v, want Bytes", got)
+	}
+	if got := chk.LetTypes[sizeLet]; got == nil || got.String() != "Int" {
+		t.Fatalf("size type = %v, want Int", got)
+	}
+	if got := chk.LetTypes[firstLet]; got == nil || got.String() != "Byte?" {
+		t.Fatalf("first type = %v, want Byte?", got)
+	}
+	if got := chk.LetTypes[sameSizeLet]; got == nil || got.String() != "Int" {
+		t.Fatalf("sameSize type = %v, want Int", got)
+	}
+	if got := chk.LetTypes[secondLet]; got == nil || got.String() != "Byte?" {
+		t.Fatalf("second type = %v, want Byte?", got)
+	}
+}
+
 func TestNativeBoundaryExecChecksStructuredPackageInput(t *testing.T) {
 	fileA := []byte("fn helper() -> Int { 1 }\n")
 	fileB := []byte("fn main() { let value = helper() }\n")

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -34569,6 +34569,8 @@ func checkInstallPrelude(env *CheckEnv) {
 	checkRegisterType(env, &CheckTypeSig{name: "Result", generics: []string{"T", "E"}, genericBounds: make([]*CheckGenericBound, 0, 1), kind: "enum"})
 	// Osty: /tmp/selfhost_merged.osty:14979:5
 	checkRegisterType(env, &CheckTypeSig{name: "Range", generics: []string{"T"}, genericBounds: make([]*CheckGenericBound, 0, 1), kind: "struct"})
+	// Osty: /tmp/selfhost_merged.osty:14980:5
+	checkRegisterType(env, &CheckTypeSig{name: "Bytes", generics: make([]string, 0), genericBounds: make([]*CheckGenericBound, 0, 1), kind: "struct"})
 	// Osty: /tmp/selfhost_merged.osty:14982:5
 	checkRegisterVariant(env, &CheckVariantSig{owner: "Option", name: "Some", fieldTys: []int{tyNamed(env.tys, "T", make([]int, 0, 1))}, generics: []string{"T"}})
 	// Osty: /tmp/selfhost_merged.osty:14988:5
@@ -35016,6 +35018,14 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	checkRegisterFn(env, &CheckFnSig{name: "trimSuffix", owner: "String", receiverTy: tString_, retTy: tString_, paramNames: []string{"suffix"}, paramTys: []int{tString_}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15673:5
 	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "String", receiverTy: tString_, retTy: tyNamed(tys, "Result", []int{tInt(tys), tyNamed(tys, "Error", make([]int, 0, 1))}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /tmp/selfhost_merged.osty:15674:5
+	checkRegisterFn(env, &CheckFnSig{name: "from", owner: "Bytes", receiverTy: -1, retTy: tBytes_, paramNames: []string{"items"}, paramTys: []int{tListByte}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /tmp/selfhost_merged.osty:15675:5
+	checkRegisterFn(env, &CheckFnSig{name: "len", owner: "Bytes", receiverTy: tBytes_, retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /tmp/selfhost_merged.osty:15676:5
+	checkRegisterFn(env, &CheckFnSig{name: "isEmpty", owner: "Bytes", receiverTy: tBytes_, retTy: tBool(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /tmp/selfhost_merged.osty:15677:5
+	checkRegisterFn(env, &CheckFnSig{name: "get", owner: "Bytes", receiverTy: tBytes_, retTy: tyOptional(tys, tByte(tys)), paramNames: []string{"index"}, paramTys: []int{tInt(tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15681:5
 	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "Char", receiverTy: tChar(tys), retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15686:5
@@ -38002,62 +38012,103 @@ func elabInferVariantCall(cx *ElabCx, callIdx int, node *AstNode, baseCallee *As
 
 // Osty: /tmp/selfhost_merged.osty:17500:1
 func elabInferStaticMethodCall(cx *ElabCx, callIdx int, node *AstNode, fieldNode *AstNode, argIdxs []int, ownerName string, sig *CheckFnSig, explicitArgs []int, expected int) *ElabResult {
-	// Osty: /tmp/selfhost_merged.osty:17511:5
+	if sig.receiverTy != -1 {
+		totalArgs := checkIntListLenHelper(argIdxs)
+		_ = totalArgs
+		if totalArgs == 0 {
+			cx.env.diagnostics = append(cx.env.diagnostics, diagArgCount(fmt.Sprintf("%s.%s", ostyToString(ownerName), ostyToString(sig.name)), 1+checkIntListLenHelper(sig.paramTys), totalArgs, node.start, node.end))
+			return elabPoisonResult(cx, node.start, node.end)
+		}
+		recv := elabInfer(cx, checkIntListAt(argIdxs, 0))
+		_ = recv
+		recvResolved := checkResolveAliasDeep(cx.env, recv.ty)
+		_ = recvResolved
+		if tyIsBad(cx.env.tys, recvResolved) {
+			return elabPoisonResult(cx, node.start, node.end)
+		}
+		_ = checkExpectAssignable(cx.env, sig.receiverTy, recvResolved, node.start, node.end)
+		methodArgIdxs := make([]int, 0, 1)
+		_ = methodArgIdxs
+		i := 0
+		_ = i
+		for _, argIdx := range argIdxs {
+			if i > 0 {
+				methodArgIdxs = append(methodArgIdxs, argIdx)
+			}
+			i = i + 1
+		}
+		if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
+			coreArgs := elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, methodArgIdxs, node.start, node.end)
+			_ = coreArgs
+			retTy := sig.retTy
+			_ = retTy
+			if !(tyIsBad(cx.env.tys, expected)) {
+				_ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
+			}
+			mcall := coreMethodCall(cx.core, recv.node, sig.name, ownerName, coreArgs, make([]int, 0, 1), retTy, node.start, node.end)
+			_ = mcall
+			return &ElabResult{node: mcall, ty: retTy}
+		}
+		inst := instBegin(cx, sig.generics, fmt.Sprintf("%s.%s", ostyToString(ownerName), ostyToString(sig.name)))
+		_ = inst
+		typeSig := checkLookupType(cx.env, ownerName)
+		_ = typeSig
+		ownerArgs := tyArgsAt(cx.env.tys, recvResolved)
+		_ = ownerArgs
+		instSeedOwnerArgs(cx, inst, typeSig.generics, ownerArgs)
+		instSeedExpectedRet(cx, inst, sig.retTy, expected)
+		instSeedPositionalArgs(cx, inst, explicitArgs)
+		coreArgs := elabCallArgs(cx, inst.solver, sig, inst.freshs, methodArgIdxs, node.start, node.end)
+		_ = coreArgs
+		retSubstituted := instSubstitute(cx, inst, sig.retTy)
+		_ = retSubstituted
+		retTy := instZonk(cx, inst, retSubstituted)
+		_ = retTy
+		elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, node.start, node.end)
+		instCheckBounds(cx, inst, sig.genericBounds, node.start, node.end)
+		typeArgsConcrete := instConcreteArgs(cx, inst)
+		_ = typeArgsConcrete
+		if checkIntListLenHelper(typeArgsConcrete) > 0 {
+			checkRecordInstantiation(cx.env, callIdx, fmt.Sprintf("%s.%s", ostyToString(ownerName), ostyToString(sig.name)), typeArgsConcrete, retTy, node.start, node.end)
+		}
+		mcall := coreMethodCall(cx.core, recv.node, sig.name, ownerName, coreArgs, typeArgsConcrete, retTy, node.start, node.end)
+		_ = mcall
+		return &ElabResult{node: mcall, ty: retTy}
+	}
 	_ = ownerName
-	// Osty: /tmp/selfhost_merged.osty:17512:5
 	if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
-		// Osty: /tmp/selfhost_merged.osty:17513:9
 		coreFn := coreIdent(cx.core, sig.name, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), fieldNode.start, fieldNode.end)
 		_ = coreFn
-		// Osty: /tmp/selfhost_merged.osty:17514:9
 		coreArgs := elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, argIdxs, node.start, node.end)
 		_ = coreArgs
-		// Osty: /tmp/selfhost_merged.osty:17515:9
 		retTy := sig.retTy
 		_ = retTy
-		// Osty: /tmp/selfhost_merged.osty:17516:9
 		if !(tyIsBad(cx.env.tys, expected)) {
-			// Osty: /tmp/selfhost_merged.osty:17517:13
 			_ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
 		}
-		// Osty: /tmp/selfhost_merged.osty:17519:9
 		coreCallNode := coreCall(cx.core, coreFn, coreArgs, make([]int, 0, 1), retTy, node.start, node.end)
 		_ = coreCallNode
-		// Osty: /tmp/selfhost_merged.osty:17520:9
 		return &ElabResult{node: coreCallNode, ty: retTy}
 	}
-	// Osty: /tmp/selfhost_merged.osty:17523:5
 	inst := instBegin(cx, sig.generics, sig.name)
 	_ = inst
-	// Osty: /tmp/selfhost_merged.osty:17524:5
 	instSeedExpectedRet(cx, inst, sig.retTy, expected)
-	// Osty: /tmp/selfhost_merged.osty:17525:5
 	instSeedPositionalArgs(cx, inst, explicitArgs)
-	// Osty: /tmp/selfhost_merged.osty:17527:5
 	coreFn := coreIdent(cx.core, sig.name, IdentKind(&IdentKind_IkFn{}), fnSigToTy(cx.env, sig), fieldNode.start, fieldNode.end)
 	_ = coreFn
-	// Osty: /tmp/selfhost_merged.osty:17528:5
 	coreArgs := elabCallArgs(cx, inst.solver, sig, inst.freshs, argIdxs, node.start, node.end)
 	_ = coreArgs
-	// Osty: /tmp/selfhost_merged.osty:17530:5
 	retSubstituted := instSubstitute(cx, inst, sig.retTy)
 	_ = retSubstituted
-	// Osty: /tmp/selfhost_merged.osty:17531:5
 	retTy := instZonk(cx, inst, retSubstituted)
 	_ = retTy
-	// Osty: /tmp/selfhost_merged.osty:17533:5
 	elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, node.start, node.end)
-	// Osty: /tmp/selfhost_merged.osty:17534:5
 	instCheckBounds(cx, inst, sig.genericBounds, node.start, node.end)
-	// Osty: /tmp/selfhost_merged.osty:17536:5
 	typeArgsConcrete := instConcreteArgs(cx, inst)
 	_ = typeArgsConcrete
-	// Osty: /tmp/selfhost_merged.osty:17537:5
 	if checkIntListLenHelper(typeArgsConcrete) > 0 {
-		// Osty: /tmp/selfhost_merged.osty:17538:9
 		checkRecordInstantiation(cx.env, callIdx, sig.name, typeArgsConcrete, retTy, node.start, node.end)
 	}
-	// Osty: /tmp/selfhost_merged.osty:17541:5
 	coreCallNode := coreCall(cx.core, coreFn, coreArgs, typeArgsConcrete, retTy, node.start, node.end)
 	_ = coreCallNode
 	return &ElabResult{node: coreCallNode, ty: retTy}

--- a/toolchain/check_env.osty
+++ b/toolchain/check_env.osty
@@ -1334,12 +1334,15 @@ pub fn checkInstallPrelude(env: CheckEnv) {
     checkRegisterInterface(env, "Hashable")
 
     // Register stdlib types that carry generics so alias/bound
-    // substitution has the arity information it needs.
+    // substitution has the arity information it needs. Primitive
+    // namespaces with static helpers (`Bytes.from(...)`) also need a
+    // type entry so type-qualified calls can resolve the owner name.
     checkRegisterType(env, CheckTypeSig { name: "List", generics: ["T"], genericBounds: [], kind: "struct" })
     checkRegisterType(env, CheckTypeSig { name: "Map", generics: ["K", "V"], genericBounds: [], kind: "struct" })
     checkRegisterType(env, CheckTypeSig { name: "Option", generics: ["T"], genericBounds: [], kind: "enum" })
     checkRegisterType(env, CheckTypeSig { name: "Result", generics: ["T", "E"], genericBounds: [], kind: "enum" })
     checkRegisterType(env, CheckTypeSig { name: "Range", generics: ["T"], genericBounds: [], kind: "struct" })
+    checkRegisterType(env, CheckTypeSig { name: "Bytes", generics: [], genericBounds: [], kind: "struct" })
 
     // Option / Result variants.
     checkRegisterVariant(env, CheckVariantSig {
@@ -1641,7 +1644,7 @@ fn checkInstallChannelIntrinsics(env: CheckEnv) {
 }
 
 /// checkInstallBuiltinMethods registers the intrinsic methods spec
-/// §10.6 gives `List<T>` / `Map<K, V>` / `String`. These are not
+/// §10.6 gives `List<T>` / `Map<K, V>` / `String` / `Bytes`. These are not
 /// user-written — the backend lowers them directly — but the checker
 /// still needs a signature to type the call.
 ///
@@ -1662,6 +1665,7 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
     let tListChar = tyNamed(tys, "List", [tChar(tys)])
     let tListByte = tyNamed(tys, "List", [tByte(tys)])
     let tMapKV = tyNamed(tys, "Map", [tK, tV])
+    let tBytes_ = tBytes(tys)
     let tOptT = tyOptional(tys, tT)
     let tOptV = tyOptional(tys, tV)
 
@@ -2037,6 +2041,28 @@ fn checkInstallBuiltinMethods(env: CheckEnv) {
         name: "toInt", owner: "String", receiverTy: tString_,
         retTy: tyNamed(tys, "Result", [tInt(tys), tyNamed(tys, "Error", [])]),
         paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+
+    // ----- Bytes intrinsics -----
+    checkRegisterFn(env, CheckFnSig {
+        name: "from", owner: "Bytes", receiverTy: -1, retTy: tBytes_,
+        paramNames: ["items"], paramTys: [tListByte],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "len", owner: "Bytes", receiverTy: tBytes_, retTy: tInt(tys),
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "isEmpty", owner: "Bytes", receiverTy: tBytes_, retTy: tBool(tys),
+        paramNames: [], paramTys: [],
+        generics: [], genericBounds: [],
+    })
+    checkRegisterFn(env, CheckFnSig {
+        name: "get", owner: "Bytes", receiverTy: tBytes_, retTy: tyOptional(tys, tByte(tys)),
+        paramNames: ["index"], paramTys: [tInt(tys)],
         generics: [], genericBounds: [],
     })
 

--- a/toolchain/elab.osty
+++ b/toolchain/elab.osty
@@ -1372,7 +1372,87 @@ fn elabInferStaticMethodCall(
     explicitArgs: List<Int>,
     expected: Int,
 ) -> ElabResult {
-    let _ = ownerName
+    if sig.receiverTy != -1 {
+        let totalArgs = checkIntListLenHelper(argIdxs)
+        if totalArgs == 0 {
+            cx.env.diagnostics.push(diagArgCount(
+                "{ownerName}.{sig.name}",
+                1 + checkIntListLenHelper(sig.paramTys),
+                totalArgs,
+                node.start,
+                node.end,
+            ))
+            return elabPoisonResult(cx, node.start, node.end)
+        }
+        let recv = elabInfer(cx, checkIntListAt(argIdxs, 0))
+        let recvResolved = checkResolveAliasDeep(cx.env, recv.ty)
+        if tyIsBad(cx.env.tys, recvResolved) {
+            return elabPoisonResult(cx, node.start, node.end)
+        }
+        let _ = checkExpectAssignable(cx.env, sig.receiverTy, recvResolved, node.start, node.end)
+
+        let mut methodArgIdxs: List<Int> = []
+        let mut i = 0
+        for argIdx in argIdxs {
+            if i > 0 {
+                methodArgIdxs.push(argIdx)
+            }
+            i = i + 1
+        }
+
+        if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
+            let coreArgs = elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, methodArgIdxs, node.start, node.end)
+            let retTy = sig.retTy
+            if !(tyIsBad(cx.env.tys, expected)) {
+                let _ = checkExpectAssignable(cx.env, expected, retTy, node.start, node.end)
+            }
+            let mcall = coreMethodCall(
+                cx.core,
+                recv.node,
+                sig.name,
+                ownerName,
+                coreArgs,
+                [],
+                retTy,
+                node.start,
+                node.end,
+            )
+            return ElabResult { node: mcall, ty: retTy }
+        }
+
+        let inst = instBegin(cx, sig.generics, "{ownerName}.{sig.name}")
+        let typeSig = checkLookupType(cx.env, ownerName)
+        let ownerArgs = tyArgsAt(cx.env.tys, recvResolved)
+        instSeedOwnerArgs(cx, inst, typeSig.generics, ownerArgs)
+        instSeedExpectedRet(cx, inst, sig.retTy, expected)
+        instSeedPositionalArgs(cx, inst, explicitArgs)
+
+        let coreArgs = elabCallArgs(cx, inst.solver, sig, inst.freshs, methodArgIdxs, node.start, node.end)
+        let retSubstituted = instSubstitute(cx, inst, sig.retTy)
+        let retTy = instZonk(cx, inst, retSubstituted)
+
+        elabReportUnresolvedGenerics(cx, inst.solver, sig, inst.freshs, node.start, node.end)
+        instCheckBounds(cx, inst, sig.genericBounds, node.start, node.end)
+
+        let typeArgsConcrete = instConcreteArgs(cx, inst)
+        if checkIntListLenHelper(typeArgsConcrete) > 0 {
+            checkRecordInstantiation(cx.env, callIdx, "{ownerName}.{sig.name}", typeArgsConcrete, retTy, node.start, node.end)
+        }
+
+        let mcall = coreMethodCall(
+            cx.core,
+            recv.node,
+            sig.name,
+            ownerName,
+            coreArgs,
+            typeArgsConcrete,
+            retTy,
+            node.start,
+            node.end,
+        )
+        return ElabResult { node: mcall, ty: retTy }
+    }
+
     if checkStringListLenHelper(sig.generics) == 0 && checkIntListLenHelper(explicitArgs) == 0 {
         let coreFn = coreIdent(cx.core, sig.name, IkFn, fnSigToTy(cx.env, sig), fieldNode.start, fieldNode.end)
         let coreArgs = elabCallArgsMonomorphicWithNames(cx, sig.name, sig.paramNames, sig.paramTys, argIdxs, node.start, node.end)


### PR DESCRIPTION
## What changed
- taught the native checker prelude to register `Bytes` as a type namespace so `Bytes.from(...)` resolves
- added `Bytes` intrinsic signatures for `from`, `len`, `isEmpty`, and `get`
- updated static-call elaboration so `Bytes.len(data)` and `Bytes.get(data, i)` lower like method calls on a `Bytes` receiver
- refreshed the selfhost-generated bridge and added an exec-level regression test for the native checker binary

## Why
The native checker recognized `data.len()`-style calls only partially and did not correctly handle the `Bytes` namespace helpers `Bytes.from`, `Bytes.len`, and `Bytes.get`.

## Impact
- native checker now accepts both method and namespace forms for the affected `Bytes` helpers
- regression coverage protects the real `osty-native-checker` binary path

## Validation
- `go test -count=1 -vet=off ./internal/check -run 'TestNativeBoundaryExecRecognizesBytesIntrinsics|TestNativeBoundaryExecutesRepoCheckerBinary'`
- `go test -count=1 -vet=off ./internal/selfhost -run 'TestCheckSourceStructuredRegistersPreludeFunctions'`