### PR TITLE
refactor(stdlib): 미완성 포팅 정리 + url.osty 순수 Osty 구현

### DIFF
--- a/internal/backend/stdlib_url_check_test.go
+++ b/internal/backend/stdlib_url_check_test.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestStdlibCheckResultUrl pins that the pure-Osty implementation in
+// url.osty type-checks cleanly against the native selfhost checker.
+// A regression here usually means a new language-surface dependency
+// slipped in (e.g. `if let` pattern, `!c.isDigit()`) that the native
+// checker doesn't yet understand. Either refactor the url.osty body
+// back to a supported idiom or extend the native checker.
+func TestStdlibCheckResultUrl(t *testing.T) {
+	reg := stdlib.LoadCached()
+	chk := stdlibCheckResult(reg, "url")
+	if chk == nil {
+		t.Fatalf("stdlibCheckResult(url) = nil, want non-nil *check.Result")
+	}
+	var errs []string
+	for _, d := range chk.Diags {
+		if d != nil && strings.Contains(d.Error(), "error") {
+			errs = append(errs, d.Error())
+		}
+	}
+	if len(errs) > 0 {
+		t.Fatalf("url module check produced %d error diagnostic(s):\n%s",
+			len(errs), strings.Join(errs, "\n"))
+	}
+}

--- a/internal/stdlib/modules/compress.osty
+++ b/internal/stdlib/modules/compress.osty
@@ -1,13 +1,11 @@
-// std.compress — compression codecs.
+// std.compress — compression codecs (spec §10.19).
+//
+// Body-less signature stubs: the backend lowers each call to the real
+// gzip codec runtime.
 
 pub struct Gzip {
-    pub fn encode(self, data: Bytes) -> Bytes {
-        data
-    }
-
-    pub fn decode(self, data: Bytes) -> Result<Bytes, Error> {
-        Ok(data)
-    }
+    pub fn encode(self, data: Bytes) -> Bytes
+    pub fn decode(self, data: Bytes) -> Result<Bytes, Error>
 }
 
 pub let gzip: Gzip = Gzip {}

--- a/internal/stdlib/modules/crypto.osty
+++ b/internal/stdlib/modules/crypto.osty
@@ -1,37 +1,23 @@
-// std.crypto — hashes, HMAC, and secure random bytes.
+// std.crypto — hashes, HMAC, and secure random bytes (spec §10.12).
+//
+// Body-less signature stubs: hashes, HMAC, CSPRNG, and constant-time
+// equality all live behind the runtime bridge.
 
 pub struct Hmac {
-    pub fn sha256(self, key: Bytes, message: Bytes) -> Bytes {
-        message
-    }
-
-    pub fn sha512(self, key: Bytes, message: Bytes) -> Bytes {
-        message
-    }
+    pub fn sha256(self, key: Bytes, message: Bytes) -> Bytes
+    pub fn sha512(self, key: Bytes, message: Bytes) -> Bytes
 }
 
 pub let hmac: Hmac = Hmac {}
 
-pub fn sha256(data: Bytes) -> Bytes {
-    data
-}
+pub fn sha256(data: Bytes) -> Bytes
 
-pub fn sha512(data: Bytes) -> Bytes {
-    data
-}
+pub fn sha512(data: Bytes) -> Bytes
 
-pub fn sha1(data: Bytes) -> Bytes {
-    data
-}
+pub fn sha1(data: Bytes) -> Bytes
 
-pub fn md5(data: Bytes) -> Bytes {
-    data
-}
+pub fn md5(data: Bytes) -> Bytes
 
-pub fn randomBytes(n: Int) -> Bytes {
-    randomBytes(n)
-}
+pub fn randomBytes(n: Int) -> Bytes
 
-pub fn constantTimeEq(a: Bytes, b: Bytes) -> Bool {
-    false
-}
+pub fn constantTimeEq(a: Bytes, b: Bytes) -> Bool

--- a/internal/stdlib/modules/encoding.osty
+++ b/internal/stdlib/modules/encoding.osty
@@ -1,24 +1,30 @@
-// std.encoding — binary-to-text encodings.
+// std.encoding — binary-to-text encodings (spec §10.11).
+//
+// Body-less signature stubs: the backend lowers each call to the real
+// codec runtime. A pure-Osty implementation is gated on the native
+// checker learning the `Bytes.len/get/from` primitive surface — today
+// those methods aren't visible to the selfhost type-checker, so any
+// Osty body would fail to type-check cleanly.
 
 pub struct Base64Url {
-    pub fn encode(self, data: Bytes) -> String { "" }
-    pub fn decode(self, text: String) -> Result<Bytes, Error> { self.decode(text) }
+    pub fn encode(self, data: Bytes) -> String
+    pub fn decode(self, text: String) -> Result<Bytes, Error>
 }
 
 pub struct Base64 {
     pub url: Base64Url
-    pub fn encode(self, data: Bytes) -> String { "" }
-    pub fn decode(self, text: String) -> Result<Bytes, Error> { self.decode(text) }
+    pub fn encode(self, data: Bytes) -> String
+    pub fn decode(self, text: String) -> Result<Bytes, Error>
 }
 
 pub struct Hex {
-    pub fn encode(self, data: Bytes) -> String { "" }
-    pub fn decode(self, text: String) -> Result<Bytes, Error> { self.decode(text) }
+    pub fn encode(self, data: Bytes) -> String
+    pub fn decode(self, text: String) -> Result<Bytes, Error>
 }
 
 pub struct UrlEncoding {
-    pub fn encode(self, text: String) -> String { text }
-    pub fn decode(self, text: String) -> Result<String, Error> { Ok(text) }
+    pub fn encode(self, text: String) -> String
+    pub fn decode(self, text: String) -> Result<String, Error>
 }
 
 pub let base64: Base64 = Base64 { url: Base64Url {} }

--- a/internal/stdlib/modules/env.osty
+++ b/internal/stdlib/modules/env.osty
@@ -1,33 +1,20 @@
 // std.env — process environment and command-line arguments.
+//
+// Body-less signature stubs: the backend lowers each call to the OS
+// environment runtime.
 
-pub fn args() -> List<String> {
-    []
-}
+pub fn args() -> List<String>
 
-pub fn get(name: String) -> String? {
-    None
-}
+pub fn get(name: String) -> String?
 
-pub fn require(name: String) -> Result<String, Error> {
-    Ok("")
-}
+pub fn require(name: String) -> Result<String, Error>
 
-pub fn set(name: String, value: String) -> Result<(), Error> {
-    Ok(())
-}
+pub fn set(name: String, value: String) -> Result<(), Error>
 
-pub fn unset(name: String) -> Result<(), Error> {
-    Ok(())
-}
+pub fn unset(name: String) -> Result<(), Error>
 
-pub fn vars() -> Map<String, String> {
-    {:}
-}
+pub fn vars() -> Map<String, String>
 
-pub fn currentDir() -> Result<String, Error> {
-    Ok("")
-}
+pub fn currentDir() -> Result<String, Error>
 
-pub fn setCurrentDir(path: String) -> Result<(), Error> {
-    Ok(())
-}
+pub fn setCurrentDir(path: String) -> Result<(), Error>

--- a/internal/stdlib/modules/http.osty
+++ b/internal/stdlib/modules/http.osty
@@ -1,4 +1,9 @@
 // std.http — minimal HTTP client/server signature surface.
+//
+// Transport primitives (`request`, `get`, `serve`) are body-less — the
+// backend routes each to the HTTP runtime. `post`, `Response.text`,
+// and `Response.json` keep real bodies since they derive from the
+// primitives.
 
 use std.json
 
@@ -36,13 +41,9 @@ pub struct Response {
     }
 }
 
-pub fn request(req: Request) -> Result<Response, Error> {
-    request(req)
-}
+pub fn request(req: Request) -> Result<Response, Error>
 
-pub fn get(url: String, headers: Headers = {:}) -> Result<Response, Error> {
-    get(url, headers)
-}
+pub fn get(url: String, headers: Headers = {:}) -> Result<Response, Error>
 
 pub fn post(url: String, body: Bytes, headers: Headers = {:}) -> Result<Response, Error> {
     request(Request {
@@ -53,6 +54,4 @@ pub fn post(url: String, body: Bytes, headers: Headers = {:}) -> Result<Response
     })
 }
 
-pub fn serve(addr: String, handler: Handler) -> Result<(), Error> {
-    Ok(())
-}
+pub fn serve(addr: String, handler: Handler) -> Result<(), Error>

--- a/internal/stdlib/modules/math.osty
+++ b/internal/stdlib/modules/math.osty
@@ -1,4 +1,7 @@
-// std.math — mathematical constants and Float functions.
+// std.math — mathematical constants and Float functions (spec §10.17).
+//
+// Constants are `let` bindings; every function is body-less so the
+// backend lowers each call to libm.
 
 pub let PI: Float = 3.141592653589793
 pub let E: Float = 2.718281828459045
@@ -6,34 +9,34 @@ pub let TAU: Float = 6.283185307179586
 pub let INFINITY: Float = 1.0 / 0.0
 pub let NAN: Float = 0.0 / 0.0
 
-pub fn sin(x: Float) -> Float { x }
-pub fn cos(x: Float) -> Float { x }
-pub fn tan(x: Float) -> Float { x }
+pub fn sin(x: Float) -> Float
+pub fn cos(x: Float) -> Float
+pub fn tan(x: Float) -> Float
 
-pub fn asin(x: Float) -> Float { x }
-pub fn acos(x: Float) -> Float { x }
-pub fn atan(x: Float) -> Float { x }
-pub fn atan2(y: Float, x: Float) -> Float { y }
+pub fn asin(x: Float) -> Float
+pub fn acos(x: Float) -> Float
+pub fn atan(x: Float) -> Float
+pub fn atan2(y: Float, x: Float) -> Float
 
-pub fn sinh(x: Float) -> Float { x }
-pub fn cosh(x: Float) -> Float { x }
-pub fn tanh(x: Float) -> Float { x }
+pub fn sinh(x: Float) -> Float
+pub fn cosh(x: Float) -> Float
+pub fn tanh(x: Float) -> Float
 
-pub fn exp(x: Float) -> Float { x }
-pub fn log(x: Float, base: Float = 0.0) -> Float { x }
-pub fn log2(x: Float) -> Float { x }
-pub fn log10(x: Float) -> Float { x }
+pub fn exp(x: Float) -> Float
+pub fn log(x: Float, base: Float = 0.0) -> Float
+pub fn log2(x: Float) -> Float
+pub fn log10(x: Float) -> Float
 
-pub fn sqrt(x: Float) -> Float { x }
-pub fn cbrt(x: Float) -> Float { x }
-pub fn pow(x: Float, y: Float) -> Float { x }
+pub fn sqrt(x: Float) -> Float
+pub fn cbrt(x: Float) -> Float
+pub fn pow(x: Float, y: Float) -> Float
 
-pub fn floor(x: Float) -> Float { x }
-pub fn ceil(x: Float) -> Float { x }
-pub fn round(x: Float) -> Float { x }
-pub fn trunc(x: Float) -> Float { x }
+pub fn floor(x: Float) -> Float
+pub fn ceil(x: Float) -> Float
+pub fn round(x: Float) -> Float
+pub fn trunc(x: Float) -> Float
 
-pub fn abs(x: Float) -> Float { x }
-pub fn min(a: Float, b: Float) -> Float { a }
-pub fn max(a: Float, b: Float) -> Float { a }
-pub fn hypot(a: Float, b: Float) -> Float { a }
+pub fn abs(x: Float) -> Float
+pub fn min(a: Float, b: Float) -> Float
+pub fn max(a: Float, b: Float) -> Float
+pub fn hypot(a: Float, b: Float) -> Float

--- a/internal/stdlib/modules/os.osty
+++ b/internal/stdlib/modules/os.osty
@@ -1,25 +1,21 @@
 // std.os — process, environment, signals, and path helpers.
+//
+// `Path` primitives and process-control entries are body-less; the
+// backend lowers each call to the host-OS runtime. `basename` is a
+// pure derivation from `split` and stays as Osty code.
 
 use std.strings
 
 pub let path: Path = Path {}
 
 pub struct Path {
-    pub fn join(self, parts: List<String>) -> String {
-        ""
-    }
+    pub fn join(self, parts: List<String>) -> String
 
-    pub fn split(self, p: String) -> List<String> {
-        []
-    }
+    pub fn split(self, p: String) -> List<String>
 
-    pub fn extension(self, p: String) -> String {
-        ""
-    }
+    pub fn extension(self, p: String) -> String
 
-    pub fn dirname(self, p: String) -> String {
-        "."
-    }
+    pub fn dirname(self, p: String) -> String
 
     pub fn basename(self, p: String) -> String {
         let parts = self.split(p)
@@ -30,21 +26,13 @@ pub struct Path {
         }
     }
 
-    pub fn absolute(self, p: String) -> Result<String, Error> {
-        Ok(p)
-    }
+    pub fn absolute(self, p: String) -> Result<String, Error>
 
-    pub fn canonical(self, p: String) -> Result<String, Error> {
-        Ok(p)
-    }
+    pub fn canonical(self, p: String) -> Result<String, Error>
 
-    pub fn isAbsolute(self, p: String) -> Bool {
-        false
-    }
+    pub fn isAbsolute(self, p: String) -> Bool
 
-    pub fn separator(self) -> String {
-        "/"
-    }
+    pub fn separator(self) -> String
 }
 
 pub struct Output {
@@ -59,24 +47,14 @@ pub enum Signal {
     Hangup,
 }
 
-pub fn exec(cmd: String, args: List<String> = []) -> Result<Output, Error> {
-    Ok(Output { exitCode: 0, stdout: "", stderr: "" })
-}
+pub fn exec(cmd: String, args: List<String> = []) -> Result<Output, Error>
 
-pub fn execShell(cmd: String) -> Result<Output, Error> {
-    Ok(Output { exitCode: 0, stdout: "", stderr: "" })
-}
+pub fn execShell(cmd: String) -> Result<Output, Error>
 
-pub fn exit(code: Int) -> Never {
-    exit(code)
-}
+pub fn exit(code: Int) -> Never
 
-pub fn pid() -> Int {
-    0
-}
+pub fn pid() -> Int
 
-pub fn hostname() -> Result<String, Error> {
-    Ok("")
-}
+pub fn hostname() -> Result<String, Error>
 
-pub fn onSignal(signal: Signal, handler: fn(Signal) -> ()) {}
+pub fn onSignal(signal: Signal, handler: fn(Signal) -> ())

--- a/internal/stdlib/modules/process.osty
+++ b/internal/stdlib/modules/process.osty
@@ -1,21 +1,16 @@
 // std.process — abort, unreachable, todo, ignoreError, logError.
 //
 // `abort`, `unreachable`, and `todo` return `Never` (the bottom type),
-// so calling any of them unifies with any expected result type.
-// `ignoreError` and `logError` are the canonical helpers for `defer`
-// bodies that can't propagate a Result.
+// so calling any of them unifies with any expected result type. They
+// are body-less; the backend lowers each to the runtime panic entry
+// point. `ignoreError` and `logError` are the canonical helpers for
+// `defer` bodies that can't propagate a Result.
 
-pub fn abort(msg: String) -> Never {
-    abort(msg)
-}
+pub fn abort(msg: String) -> Never
 
-pub fn unreachable() -> Never {
-    unreachable()
-}
+pub fn unreachable() -> Never
 
-pub fn todo(msg: String) -> Never {
-    todo(msg)
-}
+pub fn todo(msg: String) -> Never
 
 pub fn ignoreError<T, E>(result: Result<T, E>) {
     let _ = result

--- a/internal/stdlib/modules/random.osty
+++ b/internal/stdlib/modules/random.osty
@@ -1,14 +1,16 @@
-// std.random — non-cryptographic pseudorandom numbers.
+// std.random — non-cryptographic pseudorandom numbers (spec §10.14).
 //
-// This is the checker-visible signature surface for spec §10.14. The
-// generator supplies the executable Go bridge for the basic RNG runtime.
+// Primitive methods and constructors are body-less; the backend lowers
+// them to the runtime RNG bridge. `choice` is a derived helper with a
+// real Osty body that composes over the primitive surface.
 
 pub struct Rng {
-    pub fn int(self, min: Int, max: Int) -> Int { 0 }
-    pub fn intInclusive(self, min: Int, max: Int) -> Int { 0 }
-    pub fn float(self) -> Float { 0.0 }
-    pub fn bool(self) -> Bool { false }
-    pub fn bytes(self, n: Int) -> Bytes { self.bytes(n) }
+    pub fn int(self, min: Int, max: Int) -> Int
+    pub fn intInclusive(self, min: Int, max: Int) -> Int
+    pub fn float(self) -> Float
+    pub fn bool(self) -> Bool
+    pub fn bytes(self, n: Int) -> Bytes
+
     pub fn choice<T>(self, items: List<T>) -> T? {
         if items.isEmpty() {
             None
@@ -16,13 +18,10 @@ pub struct Rng {
             Some(items[self.int(0, items.len())])
         }
     }
-    pub fn shuffle<T>(self, items: List<T>) {}
+
+    pub fn shuffle<T>(self, items: List<T>)
 }
 
-pub fn default() -> Rng {
-    Rng {}
-}
+pub fn default() -> Rng
 
-pub fn seeded(seed: Int64) -> Rng {
-    Rng {}
-}
+pub fn seeded(seed: Int64) -> Rng

--- a/internal/stdlib/modules/ref.osty
+++ b/internal/stdlib/modules/ref.osty
@@ -3,8 +3,7 @@
 // `same(a, b)` reports whether two values refer to the same allocation.
 // Primitives and small immutable values are always considered distinct
 // by identity; the comparison is only meaningful for reference-typed
-// values (strings, collections, structs).
+// values (strings, collections, structs). Body-less — the backend
+// lowers the call to the runtime identity-compare.
 
-pub fn same<T>(a: T, b: T) -> Bool {
-    false
-}
+pub fn same<T>(a: T, b: T) -> Bool

--- a/internal/stdlib/modules/regex.osty
+++ b/internal/stdlib/modules/regex.osty
@@ -1,37 +1,25 @@
-// std.regex — RE2 regular expressions.
+// std.regex — RE2 regular expressions (spec §10.9).
+//
+// Match / find / replace / split primitives are body-less — the backend
+// lowers each call to the RE2 runtime. One-shot free functions at the
+// bottom are real Osty wrappers that compile + apply in one call.
 
 pub struct Regex {
-    pub fn matches(self, text: String) -> Bool {
-        false
-    }
+    pub fn matches(self, text: String) -> Bool
 
-    pub fn find(self, text: String) -> Match? {
-        None
-    }
+    pub fn find(self, text: String) -> Match?
 
-    pub fn findAll(self, text: String) -> List<Match> {
-        []
-    }
+    pub fn findAll(self, text: String) -> List<Match>
 
-    pub fn captures(self, text: String) -> Captures? {
-        None
-    }
+    pub fn captures(self, text: String) -> Captures?
 
-    pub fn capturesAll(self, text: String) -> List<Captures> {
-        []
-    }
+    pub fn capturesAll(self, text: String) -> List<Captures>
 
-    pub fn replace(self, text: String, replacement: String) -> String {
-        text
-    }
+    pub fn replace(self, text: String, replacement: String) -> String
 
-    pub fn replaceAll(self, text: String, replacement: String) -> String {
-        text
-    }
+    pub fn replaceAll(self, text: String, replacement: String) -> String
 
-    pub fn split(self, text: String) -> List<String> {
-        []
-    }
+    pub fn split(self, text: String) -> List<String>
 }
 
 pub struct RegexError {
@@ -45,18 +33,12 @@ pub struct Match {
 }
 
 pub struct Captures {
-    pub fn get(self, i: Int) -> String? {
-        None
-    }
+    pub fn get(self, i: Int) -> String?
 
-    pub fn named(self, name: String) -> String? {
-        None
-    }
+    pub fn named(self, name: String) -> String?
 }
 
-pub fn compile(pattern: String) -> Result<Regex, RegexError> {
-    Ok(Regex {})
-}
+pub fn compile(pattern: String) -> Result<Regex, RegexError>
 
 // One-shot helpers: compile + apply in a single call. Fine for infrequent use;
 // if the same pattern runs against many inputs, compile() once and reuse the

--- a/internal/stdlib/modules/sync.osty
+++ b/internal/stdlib/modules/sync.osty
@@ -1,11 +1,15 @@
 // std.sync — synchronization primitives.
+//
+// Lock-acquire entries (`Mutex.lock`, `RwLock.read`, `RwLock.write`)
+// are body-less; the backend lowers each to the real acquire runtime.
+// Per-guard accessors (`get`, `set`, `unlock`) keep Osty bodies:
+// `unlock` is a no-op so dropping a guard is always safe at the Osty
+// level while the backend overlays the release call.
 
 pub struct Mutex<T> {
     value: T,
 
-    pub fn lock(self) -> Locked<T> {
-        self.lock()
-    }
+    pub fn lock(self) -> Locked<T>
 }
 
 pub struct Locked<T> {
@@ -21,13 +25,9 @@ pub struct Locked<T> {
 pub struct RwLock<T> {
     value: T,
 
-    pub fn read(self) -> ReadLocked<T> {
-        self.read()
-    }
+    pub fn read(self) -> ReadLocked<T>
 
-    pub fn write(self) -> WriteLocked<T> {
-        self.write()
-    }
+    pub fn write(self) -> WriteLocked<T>
 }
 
 pub struct ReadLocked<T> {

--- a/internal/stdlib/modules/thread.osty
+++ b/internal/stdlib/modules/thread.osty
@@ -1,17 +1,18 @@
 // std.thread — task, channel, cancellation, and select surface.
+//
+// Scheduler primitives (spawn / race / channel / sleep / cancellation
+// queries) are body-less; the backend lowers them to the scheduler
+// runtime. `collectAll` is a real Osty helper over `Group.spawn` +
+// `Handle.join`.
 
 pub struct Duration {}
 
 pub struct Group {
-    pub fn spawn<T>(self, body: fn() -> T) -> Handle<T> {
-        thread.spawn(body)
-    }
+    pub fn spawn<T>(self, body: fn() -> T) -> Handle<T>
 
     pub fn cancel(self) {}
 
-    pub fn isCancelled(self) -> Bool {
-        false
-    }
+    pub fn isCancelled(self) -> Bool
 }
 
 pub struct Select {
@@ -32,9 +33,7 @@ pub struct Select {
     }
 }
 
-pub fn spawn<T>(body: fn() -> T) -> Handle<T> {
-    spawn(body)
-}
+pub fn spawn<T>(body: fn() -> T) -> Handle<T>
 
 pub fn collectAll<T>(body: fn(Group) -> List<Handle<T>>) -> List<Result<T, Error>> {
     let handles = body(Group {})
@@ -45,26 +44,16 @@ pub fn collectAll<T>(body: fn(Group) -> List<Handle<T>>) -> List<Result<T, Error
     out
 }
 
-pub fn race<T>(body: fn(Group) -> List<Handle<T>>) -> Result<T, Error> {
-    race::<T>(body)
-}
+pub fn race<T>(body: fn(Group) -> List<Handle<T>>) -> Result<T, Error>
 
-pub fn chan<T>(capacity: Int = 0) -> Channel<T> {
-    thread.chan::<T>(capacity)
-}
+pub fn chan<T>(capacity: Int = 0) -> Channel<T>
 
-pub fn sleep(duration: Duration) -> Result<(), Error> {
-    Ok(())
-}
+pub fn sleep(duration: Duration) -> Result<(), Error>
 
 pub fn yield() {}
 
-pub fn isCancelled() -> Bool {
-    false
-}
+pub fn isCancelled() -> Bool
 
-pub fn checkCancelled() -> Result<(), Error> {
-    Ok(())
-}
+pub fn checkCancelled() -> Result<(), Error>
 
 pub fn select(body: fn(Select) -> ()) {}

--- a/internal/stdlib/modules/time.osty
+++ b/internal/stdlib/modules/time.osty
@@ -1,4 +1,9 @@
 // std.time — instants, durations, zones, and formatting constants.
+//
+// Wall-clock access, zone lookup, calendar decomposition, and string
+// formatting are body-less; the backend lowers each call to the time
+// runtime. Pure arithmetic on `Instant` / `Duration` stays as Osty
+// code.
 
 pub let ISO_8601: String = "2006-01-02T15:04:05Z07:00"
 pub let RFC_3339: String = "2006-01-02T15:04:05Z07:00"
@@ -7,13 +12,9 @@ pub let RFC_2822: String = "Mon, 02 Jan 2006 15:04:05 -0700"
 pub struct Duration {
     pub nanoseconds: Int64,
 
-    pub fn abs(self) -> Duration {
-        self
-    }
+    pub fn abs(self) -> Duration
 
-    pub fn toString(self) -> String {
-        ""
-    }
+    pub fn toString(self) -> String
 }
 
 pub struct Instant {
@@ -27,9 +28,7 @@ pub struct Instant {
         Duration { nanoseconds: self.unixNanos - other.unixNanos }
     }
 
-    pub fn format(self, layout: String) -> String {
-        self.unixNanos.toString()
-    }
+    pub fn format(self, layout: String) -> String
 
     pub fn inZone(self, zone: Zone) -> ZonedTime {
         ZonedTime { instant: self, zone: zone }
@@ -56,71 +55,35 @@ pub struct ZonedTime {
     pub instant: Instant,
     pub zone: Zone,
 
-    pub fn year(self) -> Int {
-        0
-    }
+    pub fn year(self) -> Int
 
-    pub fn month(self) -> Int {
-        0
-    }
+    pub fn month(self) -> Int
 
-    pub fn day(self) -> Int {
-        0
-    }
+    pub fn day(self) -> Int
 
-    pub fn hour(self) -> Int {
-        0
-    }
+    pub fn hour(self) -> Int
 
-    pub fn minute(self) -> Int {
-        0
-    }
+    pub fn minute(self) -> Int
 
-    pub fn second(self) -> Int {
-        0
-    }
+    pub fn second(self) -> Int
 
-    pub fn nanosecond(self) -> Int {
-        0
-    }
+    pub fn nanosecond(self) -> Int
 
-    pub fn weekday(self) -> Weekday {
-        Mon
-    }
+    pub fn weekday(self) -> Weekday
 
     pub fn format(self, layout: String) -> String {
         self.instant.format(layout)
     }
 }
 
-pub fn now() -> Instant {
-    Instant { unixNanos: 0 }
-}
+pub fn now() -> Instant
 
-pub fn parse(text: String, layout: String) -> Result<Instant, Error> {
-    Ok(Instant { unixNanos: 0 })
-}
+pub fn parse(text: String, layout: String) -> Result<Instant, Error>
 
-pub fn sleep(duration: Duration) -> Result<(), Error> {
-    Ok(())
-}
+pub fn sleep(duration: Duration) -> Result<(), Error>
 
-pub fn zone(name: String) -> Result<Zone, Error> {
-    Ok(Zone { name: name, offset: Duration { nanoseconds: 0 }, isFixed: true })
-}
+pub fn zone(name: String) -> Result<Zone, Error>
 
-pub fn local() -> Zone {
-    Zone {
-        name: "local",
-        offset: Duration { nanoseconds: 0 },
-        isFixed: false,
-    }
-}
+pub fn local() -> Zone
 
-pub fn utc() -> Zone {
-    Zone {
-        name: "UTC",
-        offset: Duration { nanoseconds: 0 },
-        isFixed: true,
-    }
-}
+pub fn utc() -> Zone

--- a/internal/stdlib/modules/url.osty
+++ b/internal/stdlib/modules/url.osty
@@ -1,7 +1,15 @@
-// std.url — URL parsing and building.
+// std.url — URL parsing and building (spec §10.16).
 //
-// This module exposes the parsed Url shape from spec §10.16. Runtime
-// parsing/joining is bridged by the Go generator.
+// Pure-Osty parsing: scheme / host / port / path / query / fragment are
+// decomposed via `strings.splitN`. IPv6 literal hosts (`[::1]:8080`) are
+// not yet supported — the scheme expects a flat `host[:port]` authority,
+// matching the spec's §10.16 example. `join` implements a minimal
+// relative-reference merge: absolute refs (with scheme) replace the
+// base entirely, root-relative refs ("/x") keep the base authority, and
+// otherwise the relative path is appended to the base path's directory.
+
+use std.strings
+use std.error
 
 pub struct Url {
     pub scheme: String,
@@ -11,14 +19,174 @@ pub struct Url {
     pub query: Map<String, String>,
     pub fragment: String?,
 
-    pub fn toString(self) -> String { "" }
-    pub fn queryValues(self, key: String) -> List<String> { [] }
+    pub fn toString(self) -> String {
+        let mut out = "{self.scheme}://{self.host}"
+        out = match self.port {
+            Some(p) -> "{out}:{p}",
+            None    -> out,
+        }
+        out = "{out}{self.path}"
+        if self.query.isEmpty() == false {
+            out = "{out}?{encodeQuery(self.query)}"
+        }
+        out = match self.fragment {
+            Some(f) -> "{out}#{f}",
+            None    -> out,
+        }
+        out
+    }
+
+    pub fn queryValues(self, key: String) -> List<String> {
+        match self.query.get(key) {
+            Some(v) -> [v],
+            None    -> [],
+        }
+    }
 }
 
 pub fn parse(text: String) -> Result<Url, Error> {
-    Ok(Url { scheme: "", host: "", port: None, path: "", query: {:}, fragment: None })
+    let schemeParts = strings.splitN(text, "://", 2)
+    if schemeParts.len() != 2 {
+        return Err(error.new("url: missing scheme in {text}"))
+    }
+    let scheme = schemeParts[0]
+    if scheme.isEmpty() {
+        return Err(error.new("url: empty scheme in {text}"))
+    }
+    let rest = schemeParts[1]
+
+    let fragSplit = strings.splitN(rest, "#", 2)
+    let beforeFragment = fragSplit[0]
+    let fragment: String? = if fragSplit.len() == 2 { Some(fragSplit[1]) } else { None }
+
+    let querySplit = strings.splitN(beforeFragment, "?", 2)
+    let beforeQuery = querySplit[0]
+    let query: Map<String, String> = if querySplit.len() == 2 {
+        parseQuery(querySplit[1])
+    } else {
+        {:}
+    }
+
+    let pathSplit = strings.splitN(beforeQuery, "/", 2)
+    let authority = pathSplit[0]
+    let path = if pathSplit.len() == 2 { "/{pathSplit[1]}" } else { "" }
+
+    let (host, port) = parseAuthority(authority)?
+
+    Ok(Url {
+        scheme: scheme,
+        host: host,
+        port: port,
+        path: path,
+        query: query,
+        fragment: fragment,
+    })
 }
 
 pub fn join(base: String, relative: String) -> Result<String, Error> {
-    Ok("")
+    if relative.isEmpty() {
+        return Ok(base)
+    }
+    if strings.contains(relative, "://") {
+        return Ok(relative)
+    }
+    let baseUrl = parse(base)?
+    let relativeChars = relative.chars()
+    if relativeChars.len() > 0 && relativeChars[0] == '/' {
+        let merged = Url {
+            scheme: baseUrl.scheme,
+            host: baseUrl.host,
+            port: baseUrl.port,
+            path: relative,
+            query: {:},
+            fragment: None,
+        }
+        return Ok(merged.toString())
+    }
+    let dir = dirnameOf(baseUrl.path)
+    let merged = Url {
+        scheme: baseUrl.scheme,
+        host: baseUrl.host,
+        port: baseUrl.port,
+        path: "{dir}{relative}",
+        query: {:},
+        fragment: None,
+    }
+    Ok(merged.toString())
+}
+
+fn parseAuthority(authority: String) -> Result<(String, Int?), Error> {
+    if authority.isEmpty() {
+        return Ok(("", None))
+    }
+    let parts = strings.splitN(authority, ":", 2)
+    if parts.len() == 1 {
+        return Ok((parts[0], None))
+    }
+    let host = parts[0]
+    let portStr = parts[1]
+    if portStr.isEmpty() {
+        return Ok((host, None))
+    }
+    let port = parsePort(portStr)?
+    Ok((host, Some(port)))
+}
+
+fn parsePort(s: String) -> Result<Int, Error> {
+    if s.isEmpty() {
+        return Err(error.new("url: empty port"))
+    }
+    let chars = s.chars()
+    let mut n = 0
+    let mut i = 0
+    for i < chars.len() {
+        let c = chars[i]
+        if c >= '0' && c <= '9' {
+            n = n * 10 + (c.toInt() - '0'.toInt())
+        } else {
+            return Err(error.new("url: invalid port {s}"))
+        }
+        i = i + 1
+    }
+    if n > 65535 {
+        return Err(error.new("url: port out of range: {s}"))
+    }
+    Ok(n)
+}
+
+fn parseQuery(s: String) -> Map<String, String> {
+    let mut out: Map<String, String> = {:}
+    if s.isEmpty() {
+        return out
+    }
+    for pair in strings.split(s, "&") {
+        if pair.isEmpty() {
+            continue
+        }
+        let kv = strings.splitN(pair, "=", 2)
+        let key = kv[0]
+        let value = if kv.len() == 2 { kv[1] } else { "" }
+        out.insert(key, value)
+    }
+    out
+}
+
+fn encodeQuery(q: Map<String, String>) -> String {
+    let mut parts: List<String> = []
+    for (k, v) in q {
+        parts.push("{k}={v}")
+    }
+    strings.join(parts, "&")
+}
+
+fn dirnameOf(path: String) -> String {
+    let chars = path.chars()
+    let mut i = chars.len() - 1
+    for i >= 0 {
+        if chars[i] == '/' {
+            return path[0..i + 1]
+        }
+        i = i - 1
+    }
+    ""
 }


### PR DESCRIPTION
## 배경

stdlib 모듈 상당수가 `uuid.osty` / `fs.osty` 스타일 — "body-less declaration → backend 가 runtime bridge 로 lowering" — 에 이르지 못하고 잘못된 placeholder 바디를 들고 있었다:

- **자기재귀** (호출 즉시 stack overflow): `crypto.randomBytes(n) { randomBytes(n) }`, `encoding.*.decode { self.decode(text) }`, `http.request`/`get`, `sync.Mutex.lock`, `sync.RwLock.read`/`write`, `thread.spawn`/`race`/`chan`, `process.abort`/`unreachable`/`todo`, `random.Rng.bytes`.
- **잘못된 fallback** (런타임에 silently wrong 결과): `math.sin(x) { x }`, `crypto.sha256(data) { data }`, `url.parse → 빈 Url`, `time.ZonedTime.{year,month,...} → 0`, `env` 전 함수가 `None`/`""`, `regex` 전 메서드가 `false`/`None`/`[]` 등.

## 변경

### Phase 1 — broken-placeholder 제거 (15개 모듈)

`encoding`, `crypto`, `random`, `url`, `http`, `sync`, `thread`, `math`, `compress`, `ref`, `regex`, `time`, `env`, `os`, `process` 를 전부 `uuid.osty` 스타일의 body-less 선언으로 전환. 파생 바디는 유지:
- `http.post → request`, `Response.text`/`json`
- `os.Path.basename → split`
- `random.Rng.choice → int`
- `regex` one-shot 헬퍼 (`compile → apply`)
- `Instant.add`/`sub`, `Locked.get`/`unlock`

### Phase 2 — url.osty 실제 Osty 구현

`url.osty` 는 순수 문자열 파싱이라 런타임 bridge 없이 Osty 로 닫을 수 있음. `strings.splitN` 기반으로:
- `parse(text)`: scheme / host / port / path / query / fragment 분해
- `join(base, relative)`: 절대 / 루트-상대 / 상대 병합
- `Url.toString()` / `queryValues()`: Option 필드 재조립 + 키 조회
- helper: `parseAuthority`, `parsePort`, `parseQuery`, `encodeQuery`, `dirnameOf`

네이티브 selfhost 체커 한계 회피:
- `if let Some(x) = ...` → `match` (네이티브 체커가 if-let 미지원)
- `!c.isDigit()` → `c >= '0' && c <= '9'` 범위 체크 ([net.osty](internal/stdlib/modules/net.osty) 와 동일한 `isDigit` 한계 우회)

### encoding.osty 는 보류

hex / base64 / URL 인코딩은 `Bytes` 바이트 순회를 필요로 하지만 현재 네이티브 체커가 `Bytes.len`/`get`/`from` 을 모름 (E0703) + `Int.toByte()` 리턴 타입이 stub (`Result<Byte, Error>`) ↔ 네이티브 체커 (`Byte`) 사이에서 드리프트. 네이티브 체커가 `Bytes` primitive 서피스를 학습하기 전까지 body-less 유지.

### 회귀 방지

[internal/backend/stdlib_url_check_test.go](internal/backend/stdlib_url_check_test.go) 로 `url.osty` 를 네이티브 체커에 통과시키는 스모크 테스트 핀. 향후 `if let` 같이 체커가 모르는 구문을 다시 넣으면 즉시 실패.

## Test plan

- [x] `go test ./internal/stdlib/...` (26s)
- [x] `go test ./internal/check/...` (75s)
- [x] `go test ./internal/resolve/...` (3s)
- [x] `go test ./internal/speccorpus/...` (19s)
- [x] `go test ./internal/backend/...` (132s, 신규 url smoke test 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)