### PR TITLE
[codex] Prefer structured file-mode selfhost checks

### DIFF
--- a/internal/check/host_boundary.go
+++ b/internal/check/host_boundary.go
@@ -441,11 +441,29 @@ func applySelfhostFileResult(result *Result, file *ast.File, rr *resolve.Result,
 		))
 		return
 	}
-	checkedSrc := selfhostFileSource(file, rr, src, stdlib)
-	if dump := os.Getenv("OSTY_NATIVE_CHECKER_SOURCE_DUMP"); dump != "" {
-		_ = os.WriteFile(dump, checkedSrc.source, 0o644)
+	var (
+		checked    nativeCheckResult
+		checkedSrc selfhostCheckedSource
+		err        error
+	)
+	switch r := runner.(type) {
+	case nativePackageChecker:
+		// File-mode callers already hold the parsed public AST, so prefer the
+		// structured package request: it reuses the package checker's direct
+		// public-AST -> selfhost-AstArena lowering and avoids routing single-file
+		// checks back through the astbridge/public-AST adapter path.
+		checkedSrc = selfhostFileStructuredSource(file, rr, src)
+		if dump := os.Getenv("OSTY_NATIVE_CHECKER_SOURCE_DUMP"); dump != "" {
+			_ = os.WriteFile(dump, checkedSrc.source, 0o644)
+		}
+		checked, err = r.CheckPackageStructured(selfhostSingleFileCheckInput(file, src, stdlib))
+	default:
+		checkedSrc = selfhostFileSource(file, rr, src, stdlib)
+		if dump := os.Getenv("OSTY_NATIVE_CHECKER_SOURCE_DUMP"); dump != "" {
+			_ = os.WriteFile(dump, checkedSrc.source, 0o644)
+		}
+		checked, err = runner.CheckSourceStructured(checkedSrc.source)
 	}
-	checked, err := runner.CheckSourceStructured(checkedSrc.source)
 	if err != nil {
 		result.Diags = append(result.Diags, checkerUnavailableDiag(
 			"file",
@@ -1593,6 +1611,31 @@ func selfhostFileSource(file *ast.File, rr *resolve.Result, src []byte, stdlib r
 			scope:     scope,
 			refs:      refs,
 			base:      base,
+			sourceMap: canonicalMap,
+		}},
+	}
+}
+
+func selfhostFileStructuredSource(file *ast.File, rr *resolve.Result, src []byte) selfhostCheckedSource {
+	var canonicalMap *sourcemap.Map
+	if file != nil {
+		if canonicalSrc, sm := canonical.SourceWithMap(src, file); len(canonicalSrc) > 0 && bytes.Equal(canonicalSrc, src) {
+			canonicalMap = sm
+		}
+	}
+	var scope *resolve.Scope
+	var refs map[*ast.Ident]*resolve.Symbol
+	if rr != nil {
+		scope = rr.FileScope
+		refs = rr.Refs
+	}
+	return selfhostCheckedSource{
+		source: append([]byte(nil), src...),
+		files: []selfhostFileSegment{{
+			file:      file,
+			scope:     scope,
+			refs:      refs,
+			base:      0,
 			sourceMap: canonicalMap,
 		}},
 	}

--- a/internal/check/host_boundary_test.go
+++ b/internal/check/host_boundary_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 )
 
@@ -21,6 +22,97 @@ type fakeNativeChecker struct {
 
 func (f fakeNativeChecker) CheckSourceStructured([]byte) (nativeCheckResult, error) {
 	return f.result, f.err
+}
+
+type fakeNativePackageChecker struct {
+	t            *testing.T
+	result       nativeCheckResult
+	err          error
+	sourceCalls  int
+	packageCalls int
+	imports      []selfhost.PackageCheckImport
+}
+
+func (f *fakeNativePackageChecker) CheckSourceStructured([]byte) (nativeCheckResult, error) {
+	f.sourceCalls++
+	if f.t != nil {
+		f.t.Fatalf("file-mode checker unexpectedly used raw source path")
+	}
+	return nativeCheckResult{}, fmt.Errorf("unexpected raw source path")
+}
+
+func (f *fakeNativePackageChecker) CheckPackageStructured(input selfhost.PackageCheckInput) (nativeCheckResult, error) {
+	f.packageCalls++
+	f.imports = append([]selfhost.PackageCheckImport(nil), input.Imports...)
+	return f.result, f.err
+}
+
+func TestNativeBoundaryPrefersStructuredPackageCheckerForFileMode(t *testing.T) {
+	src := []byte(`fn main() {
+    let value = 1
+}
+`)
+	file, res := parseResolvedFile(t, src)
+	letStmt := file.Decls[0].(*ast.FnDecl).Body.Stmts[0].(*ast.LetStmt)
+
+	fake := &fakeNativePackageChecker{
+		t: t,
+		result: nativeCheckResult{
+			Summary: nativeCheckSummary{Assignments: 1, Accepted: 1, Errors: 0},
+			Bindings: []nativeCheckedBinding{{
+				Name:     "value",
+				TypeName: "UntypedInt",
+				Start:    letStmt.Pattern.Pos().Offset,
+				End:      letStmt.Pattern.End().Offset,
+			}},
+		},
+	}
+
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) { return fake, "" }
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	chk := File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+	if fake.packageCalls != 1 {
+		t.Fatalf("packageCalls = %d, want 1", fake.packageCalls)
+	}
+	if fake.sourceCalls != 0 {
+		t.Fatalf("sourceCalls = %d, want 0", fake.sourceCalls)
+	}
+	if got := chk.LetTypes[letStmt]; got == nil || got.String() != "untyped-int" {
+		t.Fatalf("binding type = %v, want untyped-int", got)
+	}
+}
+
+func TestNativeBoundaryBuildsImportSurfacesForStructuredFileMode(t *testing.T) {
+	src := []byte(`use std.strings as strings
+
+fn main() {
+    let joined = strings.join(["a"], ",")
+}
+`)
+	file, res := parseResolvedFile(t, src)
+
+	fake := &fakeNativePackageChecker{t: t}
+	oldFactory := nativeCheckerFactory
+	nativeCheckerFactory = func() (nativeChecker, string) { return fake, "" }
+	t.Cleanup(func() { nativeCheckerFactory = oldFactory })
+
+	_ = File(file, res, Opts{Source: src, Stdlib: stdlib.LoadCached()})
+
+	if fake.packageCalls != 1 {
+		t.Fatalf("packageCalls = %d, want 1", fake.packageCalls)
+	}
+	foundStrings := false
+	for _, imp := range fake.imports {
+		if imp.Alias == "strings" && (len(imp.Functions) > 0 || len(imp.Fields) > 0 || len(imp.TypeDecls) > 0) {
+			foundStrings = true
+			break
+		}
+	}
+	if !foundStrings {
+		t.Fatalf("structured file-mode imports = %#v, want populated std.strings surface", fake.imports)
+	}
 }
 
 func TestNativeBoundaryOverlaysStructuredCheckResult(t *testing.T) {

--- a/internal/check/package_input.go
+++ b/internal/check/package_input.go
@@ -45,35 +45,60 @@ func selfhostPackageCheckInput(pkg *resolve.Package, ws *resolve.Workspace, stdl
 	return input
 }
 
+func selfhostSingleFileCheckInput(file *ast.File, src []byte, stdlib resolve.StdlibProvider) selfhost.PackageCheckInput {
+	input := selfhost.PackageCheckInput{
+		Imports: selfhostUsesImportSurfaces(fileUses(file), nil, stdlib),
+	}
+	if len(src) == 0 {
+		return input
+	}
+	input.Files = append(input.Files, selfhost.PackageCheckFile{
+		Source: append([]byte(nil), src...),
+		File:   file,
+		Base:   0,
+	})
+	return input
+}
+
 func selfhostPackageImportSurfaces(pkg *resolve.Package, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
+	return selfhostUsesImportSurfaces(selfhostPackageUses(pkg), ws, stdlib)
+}
+
+func selfhostPackageUses(pkg *resolve.Package) []*ast.UseDecl {
 	if pkg == nil {
 		return nil
 	}
-	seen := map[string]string{}
-	var out []selfhost.PackageCheckImport
+	var uses []*ast.UseDecl
 	for _, pf := range pkg.Files {
 		if pf == nil || pf.File == nil {
 			continue
 		}
-		for _, use := range pf.File.Uses {
-			target := selfhostLookupPackageImport(use, ws, stdlib)
-			if target == nil {
-				continue
-			}
-			alias := selfhostUseAlias(use)
-			if alias == "" {
-				continue
-			}
-			key := strings.Join(use.Path, ".")
-			if prev, ok := seen[alias]; ok {
-				if prev == key {
-					continue
-				}
-				continue
-			}
-			seen[alias] = key
-			out = append(out, selfhostBuildImportSurface(alias, target))
+		uses = append(uses, pf.File.Uses...)
+	}
+	return uses
+}
+
+func selfhostUsesImportSurfaces(uses []*ast.UseDecl, ws *resolve.Workspace, stdlib resolve.StdlibProvider) []selfhost.PackageCheckImport {
+	seen := map[string]string{}
+	var out []selfhost.PackageCheckImport
+	for _, use := range uses {
+		target := selfhostLookupPackageImport(use, ws, stdlib)
+		if target == nil {
+			continue
 		}
+		alias := selfhostUseAlias(use)
+		if alias == "" {
+			continue
+		}
+		key := strings.Join(use.Path, ".")
+		if prev, ok := seen[alias]; ok {
+			if prev == key {
+				continue
+			}
+			continue
+		}
+		seen[alias] = key
+		out = append(out, selfhostBuildImportSurface(alias, target))
 	}
 	return out
 }

--- a/internal/selfhost/generated.go
+++ b/internal/selfhost/generated.go
@@ -35019,12 +35019,15 @@ func checkInstallBuiltinMethods(env *CheckEnv) {
 	// Osty: /tmp/selfhost_merged.osty:15673:5
 	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "String", receiverTy: tString_, retTy: tyNamed(tys, "Result", []int{tInt(tys), tyNamed(tys, "Error", make([]int, 0, 1))}), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15674:5
-	checkRegisterFn(env, &CheckFnSig{name: "from", owner: "Bytes", receiverTy: -1, retTy: tBytes_, paramNames: []string{"items"}, paramTys: []int{tListByte}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	tBytes_ := tBytes(tys)
+	_ = tBytes_
 	// Osty: /tmp/selfhost_merged.osty:15675:5
-	checkRegisterFn(env, &CheckFnSig{name: "len", owner: "Bytes", receiverTy: tBytes_, retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "from", owner: "Bytes", receiverTy: -1, retTy: tBytes_, paramNames: []string{"items"}, paramTys: []int{tListByte}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15676:5
-	checkRegisterFn(env, &CheckFnSig{name: "isEmpty", owner: "Bytes", receiverTy: tBytes_, retTy: tBool(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	checkRegisterFn(env, &CheckFnSig{name: "len", owner: "Bytes", receiverTy: tBytes_, retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15677:5
+	checkRegisterFn(env, &CheckFnSig{name: "isEmpty", owner: "Bytes", receiverTy: tBytes_, retTy: tBool(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
+	// Osty: /tmp/selfhost_merged.osty:15678:5
 	checkRegisterFn(env, &CheckFnSig{name: "get", owner: "Bytes", receiverTy: tBytes_, retTy: tyOptional(tys, tByte(tys)), paramNames: []string{"index"}, paramTys: []int{tInt(tys)}, generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})
 	// Osty: /tmp/selfhost_merged.osty:15681:5
 	checkRegisterFn(env, &CheckFnSig{name: "toInt", owner: "Char", receiverTy: tChar(tys), retTy: tInt(tys), paramNames: make([]string, 0, 1), paramTys: make([]int, 0, 1), generics: make([]string, 0, 1), genericBounds: make([]*CheckGenericBound, 0, 1)})


### PR DESCRIPTION
## What changed
- prefer structured `CheckPackageStructured` requests for file-mode native checking when the checker supports package input
- build single-file import surfaces through the same structured package adapter path instead of falling back to raw source mode
- keep the checked-in selfhost bridge compiling by restoring the local `Bytes` type helper in `generated.go`
- add regressions that lock file-mode onto the structured path and verify import surfaces are populated

## Why
- this trims live `astbridge` dependence from the native checker file-mode path by reusing the existing public-AST to selfhost-AstArena lowering
- it also keeps the current selfhost bridge healthy so the repo still regenerates and tests cleanly while the larger bootstrap retirement remains in flight

## Impact
- single-file native checking now prefers the structured package boundary when available
- embedded and external native checker flows continue to surface the same typed results back into Go
- no public CLI surface changes

## Root cause
- file-mode native checking still routed through raw source strings, which kept it on the older adapter path even though package-mode already had a direct public-AST lowering
- the checked-in selfhost bundle also had a broken local `Bytes` helper reference that prevented `internal/selfhost` from compiling

## Validation
- `go test -count=1 ./internal/selfhost ./internal/check`
