### PR TITLE
fix: monomorph divergence on injected stdlib templates + tBytes_ build break

### DIFF
--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -207,16 +207,166 @@ func lowerStdlibTypesFromRegistry(reg *stdlib.Registry) map[string]ir.Decl {
 			switch x := d.(type) {
 			case *ir.StructDecl:
 				if len(x.Generics) > 0 && isInjectableTypeName(x.Name) {
-					out[x.Name] = x
+					out[x.Name] = stripMethodsForInjection(x)
 				}
 			case *ir.EnumDecl:
 				if len(x.Generics) > 0 && isInjectableTypeName(x.Name) {
-					out[x.Name] = x
+					out[x.Name] = stripMethodsForInjection(x)
 				}
 			}
 		}
 	}
 	return out
+}
+
+// stripMethodsForInjection drops methods whose signatures would drive
+// monomorphization into an unbounded spec chain. The culprit shape is
+// any `owner<X>` reference in a param or return type where X is not
+// exactly the owner's own generic parameters (as TypeVars) — once X
+// differs, specializing `owner<Foo>` queues `owner<F(Foo)>`, whose own
+// method queues `owner<F(F(Foo))>`, ad infinitum.
+//
+// Canonical triggers from stdlib collections:
+//
+//   - `List<T>.chunked(self) -> List<List<T>>`
+//     Args [List<T>] ≠ [T] → strip.
+//   - `List<T>.enumerate(self) -> List<(Int, T)>`
+//     Args [(Int, T)] ≠ [T] → strip.
+//   - `List<T>.windowed(...) -> List<List<T>>`, same shape as chunked.
+//
+// Safe shapes: methods whose every `owner<...>` occurrence has Args
+// that match the owner's declared generics verbatim (TypeVars by name
+// in order) — `filter(pred) -> List<T>`, `concat(other: List<T>) ->
+// List<T>`, `len() -> Int`, `Map.containsKey(k: K) -> Bool`, … all
+// survive, so the backend's bodied-helper specialization path keeps
+// working for them.
+//
+// Generic methods (`List<T>.map<R>`) are preserved here unchanged;
+// monomorphize's `keepNonGenericMethods` skips generic methods anyway,
+// deferring their specialization to actual call sites.
+//
+// Making monomorphize demand-driven per method would let the skipped
+// methods come back; that's a larger refactor than required to unblock
+// stdlib-body injection for user code that does not touch the
+// structurally-recursive helpers.
+func stripMethodsForInjection(d ir.Decl) ir.Decl {
+	switch x := d.(type) {
+	case *ir.StructDecl:
+		x.Methods = filterMethodsAvoidingOwnerRecursion(x.Name, genericParamNames(x.Generics), x.Methods)
+	case *ir.EnumDecl:
+		x.Methods = filterMethodsAvoidingOwnerRecursion(x.Name, genericParamNames(x.Generics), x.Methods)
+	}
+	return d
+}
+
+func genericParamNames(params []*ir.TypeParam) []string {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make([]string, len(params))
+	for i, p := range params {
+		if p != nil {
+			out[i] = p.Name
+		}
+	}
+	return out
+}
+
+// filterMethodsAvoidingOwnerRecursion drops methods whose param or
+// return types reintroduce owner with modified type args, and drops
+// body-less intrinsic declarations (`fn len(self) -> Int` with no
+// body) since their specializations would fail ir.Validate ("nil
+// Body") — those intrinsics are lowered by the backend directly
+// (`osty_rt_list_len` et al.), not from an injected template. The
+// returned slice preserves every safe method in its original order.
+func filterMethodsAvoidingOwnerRecursion(owner string, generics []string, methods []*ir.FnDecl) []*ir.FnDecl {
+	if len(methods) == 0 {
+		return methods
+	}
+	out := methods[:0:0]
+	for _, m := range methods {
+		if m == nil {
+			continue
+		}
+		if m.Body == nil {
+			continue
+		}
+		// Generic methods (`List<T>.map<R>`) are preserved as templates
+		// by keepNonGenericMethods and only specialized at actual call
+		// sites, so their signatures never drive eager recursion. Only
+		// non-generic methods on the owner participate in the eager
+		// sig-scanning path, so the recursion filter runs against them.
+		if len(m.Generics) == 0 && methodRecursesOwner(owner, generics, m) {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// methodRecursesOwner reports whether any param or return type of m
+// contains a `owner<...>` occurrence whose type args are not the
+// identity form `<T, U, …>` for owner's declared generics.
+func methodRecursesOwner(owner string, generics []string, m *ir.FnDecl) bool {
+	if m == nil {
+		return false
+	}
+	for _, p := range m.Params {
+		if p != nil && typeRecursesOwner(p.Type, owner, generics) {
+			return true
+		}
+	}
+	return typeRecursesOwner(m.Return, owner, generics)
+}
+
+func typeRecursesOwner(t ir.Type, owner string, generics []string) bool {
+	switch x := t.(type) {
+	case *ir.NamedType:
+		if x.Name == owner && !argsAreIdentityGenerics(x.Args, generics) {
+			return true
+		}
+		for _, a := range x.Args {
+			if typeRecursesOwner(a, owner, generics) {
+				return true
+			}
+		}
+		return false
+	case *ir.OptionalType:
+		return typeRecursesOwner(x.Inner, owner, generics)
+	case *ir.TupleType:
+		for _, e := range x.Elems {
+			if typeRecursesOwner(e, owner, generics) {
+				return true
+			}
+		}
+		return false
+	case *ir.FnType:
+		for _, p := range x.Params {
+			if typeRecursesOwner(p, owner, generics) {
+				return true
+			}
+		}
+		return typeRecursesOwner(x.Return, owner, generics)
+	}
+	return false
+}
+
+// argsAreIdentityGenerics reports whether args is exactly the identity
+// form for the owner's declared generics: each Args[i] is a TypeVar
+// whose Name matches generics[i]. A match means the `owner<...>`
+// reference is just the method's self-type, which specializes to the
+// already-queued concrete owner and terminates.
+func argsAreIdentityGenerics(args []ir.Type, generics []string) bool {
+	if len(args) != len(generics) {
+		return false
+	}
+	for i, a := range args {
+		tv, ok := a.(*ir.TypeVar)
+		if !ok || tv.Name != generics[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // lowerStdlibModule runs ir.Lower on one stdlib module's file, reusing

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -930,20 +930,41 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 		// generics. Let the existing non-generic path through.
 		return
 	}
-	if !MonomorphShouldInstantiate(len(c.TypeArgs), len(origMethod.Generics)) {
+	// The checker's Instantiations table records the full call-site
+	// substitution. For generic owners (e.g. `List<T>.fold<A>` called
+	// from inside a `List<String>` body) the recorded args include the
+	// owner-level prefix (`[String, A]`) while the method decl carries
+	// only method-local generics (`[A]`). The receiver-level env is
+	// already applied via receiverEnvOf when the clone is emitted, so
+	// the trailing `len(method.Generics)` entries are what this spec
+	// actually needs. Only trim when the shape matches
+	// `owner.Generics + method.Generics` — a raw mismatch (pure user
+	// turbofish error) still fails the arity check below.
+	methodTypeArgs := c.TypeArgs
+	ownerGenericCount := 0
+	switch {
+	case origStruct != nil:
+		ownerGenericCount = len(origStruct.Generics)
+	case origEnum != nil:
+		ownerGenericCount = len(origEnum.Generics)
+	}
+	if ownerGenericCount > 0 && len(methodTypeArgs) == ownerGenericCount+len(origMethod.Generics) {
+		methodTypeArgs = methodTypeArgs[ownerGenericCount:]
+	}
+	if !MonomorphShouldInstantiate(len(methodTypeArgs), len(origMethod.Generics)) {
 		s.addErr("monomorph: arity mismatch for method %s.%s: %d type args vs %d generics",
 			ownerMangled, origMethod.Name, len(c.TypeArgs), len(origMethod.Generics))
 		return
 	}
-	for i, ta := range c.TypeArgs {
+	for i, ta := range methodTypeArgs {
 		if containsTypeVar(ta) {
 			s.addErr("monomorph: type arg %d of method %s.%s still contains a type variable (%s)",
 				i, ownerMangled, origMethod.Name, typeString(ta))
 			return
 		}
 	}
-	typeArgCodes := make([]string, len(c.TypeArgs))
-	for i, ta := range c.TypeArgs {
+	typeArgCodes := make([]string, len(methodTypeArgs))
+	for i, ta := range methodTypeArgs {
 		typeArgCodes[i] = typeCodeOf(ta, s.pkg)
 	}
 	key := MonomorphMethodDedupeKey(ownerMangled, origMethod.Name, typeArgCodes)
@@ -957,7 +978,7 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 			ownerMangled:      ownerMangled,
 			origMethod:        origMethod,
 			mangledMethodName: mangledMethod,
-			methodEnv:         buildSubstEnv(origMethod.Generics, c.TypeArgs),
+			methodEnv:         buildSubstEnv(origMethod.Generics, methodTypeArgs),
 		})
 	}
 	_ = receiverEnv // receiverEnv is resolved at emit time via receiverEnvOf


### PR DESCRIPTION
## Summary

Two monomorph fixes that together unblock most of the `OSTY_STDLIB_BODY_LOWER=1` injection path. The default flag flip still has one outstanding LLVM backend gap (FieldExpr dispatch of stripped intrinsics) — tracked as follow-up.

### Commit 1 — monomorph divergence filter
`OSTY_STDLIB_BODY_LOWER=1` + a trivial `strings.compare("a", "b")` call hung `ir.Monomorphize` indefinitely (63k+ `emitStructSpecialization(List, ...)` calls in 90s with mangled names growing 19 → 376+ bytes).

**Root cause:** `List<T>.chunked(self) -> List<List<T>>`, `List<T>.enumerate(self) -> List<(Int, T)>`, and similar method sigs reintroduce the owner with modified type args. Eagerly specializing `List<Char>` queues `List<List<Char>>`, whose own `chunked` queues `List<List<List<Char>>>`, ad infinitum.

**Fix:** `stdlib_type_inject.go:stripMethodsForInjection` drops methods whose sigs contain `owner<X>` where `X` is not the identity form of the owner's declared generics, plus body-less intrinsic declarations (backend provides runtime bridges like `osty_rt_list_len`). Safe shapes like `List<T>.filter -> List<T>` and `Map<K,V>.getOr(k: K, d: V) -> V` survive.

### Commit 2 — method type-args trimming
With stdlib types injected, generic method calls from inside owner bodies (`self.fold(init, f)` inside another `List<T>` method) surfaced `monomorph: arity mismatch for method _ZTSN4main4ListISsEE.fold: 2 type args vs 1 generics`.

**Root cause:** the checker's Instantiations table records the full substitution `[owner_T, method_A]` but the method decl only declares `[method_A]`. `rewriteGenericMethodCall` fed all recorded args into `MonomorphShouldInstantiate`, tripping the arity check.

**Fix:** when the recorded args match the shape `owner.Generics + method.Generics`, drop the owner-level prefix. The receiver-level env is already applied via `receiverEnvOf` when the method clone is emitted. Non-generic owners (canonical user-error turbofish) still trip the arity check — covered by the existing `TestMonomorphizeMethodLocalGenericArityMismatch`.

## Scope — what's NOT in this PR

- **Flag default flip** (`OSTY_STDLIB_BODY_LOWER=0` → on): blocked on one remaining gap — `LLVM015 call: call target *ast.FieldExpr (self.get)` when injected bodies (e.g. `List<T>.first(self) -> T?` with body `self.get(0)`) are specialized. llvmgen's AST-bridge doesn't route `self.get` FieldExpr on a bare `self` ident into the list-intrinsic dispatch path. Needs a separate llvmgen change before flag flip is safe.
- **`std.strings` runtime shim retirement**: depends on the default flip. Addressed in closed PR [#545](https://github.com/choiceoh/osty/pull/545) — will reopen once the flag defaults on.

## Test plan

- [x] `go test ./internal/backend/ -run TestLLVMBackendEmitStringsCompareFlagOn -timeout 60s` — passes in ~2s (was >6m)
- [x] `go test ./internal/backend/ -run "TestPrepareEntryInjectsStdlibWhenFlagOn|TestPhase2gUserCallsiteDispatchesToSpecializedMethod|TestInjectedMapTypeMonomorphizes"` — all pass
- [x] `go test ./internal/ir/ -short` — existing `TestMonomorphizeMethodLocalGenericArityMismatch` + `TestMonomorphizeMethodLocalGenericPreservedGenericsDropped` still pass
- [x] `go test ./internal/{ir,llvmgen,backend} -short -timeout 300s` — no new regressions (5 pre-existing failures remain on main: `TestBundledRuntime*` x3, `TestLLVMBackendBinaryMIRBackendStringCharsBytes`, `TestLLVMBackendBinaryCollectionsUseRuntimeContainers`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)