### PR TITLE
[codex] Continue gc osty fn-value port

### DIFF
--- a/RUNTIME_GC_DELTA.md
+++ b/RUNTIME_GC_DELTA.md
@@ -174,10 +174,11 @@ A5–A6는 safepoint ABI 주변 분류·가드.
   C 스택 안전. Sweep이 marked를 clear해 "outside collection == no marks"
   invariant 성립. 테스트 `TestBundledRuntimeMarkWorkQueueDeepGraph`.
 - ✅ **§2.4 A4 Closure env kind 예약** — `OSTY_GC_KIND_CLOSURE_ENV = 1029`.
-  Phase 1 closure env는 여전히 1-field · trace=NULL이지만 heap dump와
-  `osty_gc_stats`에서 일반 `osty.gc.alloc_v1` 객체와 분리 추적 가능.
-  Phase 4 capture 랜딩 시 이 kind 태그로 분기하여 per-capture trace를
-  등록한다. 호출 지점: `internal/llvmgen/fn_value.go:fnValueEnvKind`.
+  Phase 1 closure env는 dedicated allocator `osty.rt.closure_env_alloc_v1`
+  경유로 생성되고, heap dump와 `osty_gc_stats`에서 일반
+  `osty.gc.alloc_v1` 객체와 분리 추적된다. Phase 4 capture 랜딩 시 이
+  kind 태그로 분기하여 per-capture trace를 등록한다. 호출 지점:
+  `internal/llvmgen/fn_value.go:emitFnValueEnv`.
 - ✅ **§10.1 A5 Safepoint kind taxonomy** — safepoint id high byte에 kind
   인코딩 (`UNSPECIFIED/ENTRY/CALL/LOOP/ALLOC/YIELD`), 저 56비트에 per-module
   serial. 런타임이 kind별 카운터 집계 + `osty_gc_debug_safepoint_count_by_kind`.
@@ -334,10 +335,14 @@ Phase A SATB log가 passive recording에서 **live consumer**로 승격. 마킹
   guard는 추가됐지만, 혼합 워크로드 (긴 OLD scan + 빠른 YOUNG churn)에서
   가장 좋은 선택 (incremental vs STW minor)을 결정하는 정책은 아직 없음.
   단순한 tier 분리만.
-- **Go 측 위반 여전** — Phase A5/A6/A4 깊이 패스의 llvmgen 변경이
-  `generator.go`/`fn_value.go`에 Go로 들어가 있음. CLAUDE.md는 이걸
-  `toolchain/*.osty` + `support_snapshot.go` 재생성으로 가야 한다고 명시.
-  별도 cleanup task 필요.
+- **Go/Osty 경계는 축소됐지만 아직 남아 있음** — A5/A6/A4의 kind/ID
+  상수, safepoint 빈 poll / rooted poll 템플릿, closure env alloc 템플릿,
+  rooted safepoint chunk planning 정책, bare-fn thunk symbol/body template,
+  legacy fn-value indirect-call IR template은 이제
+  `toolchain/llvmgen.osty` + `support_snapshot.go`가 소유한다. 남은 Go 코드는
+  legacy emitter의 상태 의존부(visible-root 주소 materialize, thunk cache
+  소유, indirect-call callee shape 판별)라 correctness 위반이라기보다
+  점진적 cleanup 대상이다.
 
 ## 다음 단계
 

--- a/internal/llvmgen/container_metadata_test.go
+++ b/internal/llvmgen/container_metadata_test.go
@@ -1,0 +1,153 @@
+package llvmgen
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/ast"
+)
+
+func TestCollectDeclarationsPreservesContainerMetadata(t *testing.T) {
+	file := parseLLVMGenFile(t, `struct Holder {
+    names: List<String>
+    scores: Map<String, Int>
+    seen: Set<Int>
+}
+
+fn collect(names: List<String>, scores: Map<String, Int>) -> Set<Int> {}
+`)
+
+	decls, err := collectDeclarations(file)
+	if err != nil {
+		t.Fatalf("collectDeclarations returned error: %v", err)
+	}
+
+	holder := decls.structsByName["Holder"]
+	if holder == nil {
+		t.Fatal("missing Holder struct metadata")
+	}
+	if got := holder.byName["names"].listElemTyp; got != "ptr" {
+		t.Fatalf("Holder.names listElemTyp = %q, want ptr", got)
+	}
+	if !holder.byName["names"].listElemString {
+		t.Fatal("Holder.names listElemString = false, want true")
+	}
+	if got := holder.byName["scores"].mapKeyTyp; got != "ptr" {
+		t.Fatalf("Holder.scores mapKeyTyp = %q, want ptr", got)
+	}
+	if got := holder.byName["scores"].mapValueTyp; got != "i64" {
+		t.Fatalf("Holder.scores mapValueTyp = %q, want i64", got)
+	}
+	if !holder.byName["scores"].mapKeyString {
+		t.Fatal("Holder.scores mapKeyString = false, want true")
+	}
+	if got := holder.byName["seen"].setElemTyp; got != "i64" {
+		t.Fatalf("Holder.seen setElemTyp = %q, want i64", got)
+	}
+
+	sig := decls.functionsByName["collect"]
+	if sig == nil {
+		t.Fatal("missing collect signature")
+	}
+	if len(sig.params) != 2 {
+		t.Fatalf("len(sig.params) = %d, want 2", len(sig.params))
+	}
+	if got := sig.params[0].listElemTyp; got != "ptr" {
+		t.Fatalf("collect param0 listElemTyp = %q, want ptr", got)
+	}
+	if !sig.params[0].listElemString {
+		t.Fatal("collect param0 listElemString = false, want true")
+	}
+	if got := sig.params[1].mapKeyTyp; got != "ptr" {
+		t.Fatalf("collect param1 mapKeyTyp = %q, want ptr", got)
+	}
+	if got := sig.params[1].mapValueTyp; got != "i64" {
+		t.Fatalf("collect param1 mapValueTyp = %q, want i64", got)
+	}
+	if !sig.params[1].mapKeyString {
+		t.Fatal("collect param1 mapKeyString = false, want true")
+	}
+	if got := sig.retSetElemTyp; got != "i64" {
+		t.Fatalf("collect return setElemTyp = %q, want i64", got)
+	}
+}
+
+func TestSynthFnSigFromFnTypePreservesContainerMetadata(t *testing.T) {
+	ft := &ast.FnType{
+		Params: []ast.Type{
+			&ast.NamedType{Path: []string{"List"}, Args: []ast.Type{
+				&ast.NamedType{Path: []string{"String"}},
+			}},
+			&ast.NamedType{Path: []string{"Map"}, Args: []ast.Type{
+				&ast.NamedType{Path: []string{"String"}},
+				&ast.NamedType{Path: []string{"Int"}},
+			}},
+		},
+		ReturnType: &ast.NamedType{Path: []string{"Set"}, Args: []ast.Type{
+			&ast.NamedType{Path: []string{"Int"}},
+		}},
+	}
+
+	sig, err := synthFnSigFromFnType(ft, typeEnv{})
+	if err != nil {
+		t.Fatalf("synthFnSigFromFnType returned error: %v", err)
+	}
+
+	if len(sig.params) != 2 {
+		t.Fatalf("len(sig.params) = %d, want 2", len(sig.params))
+	}
+	if got := sig.params[0].listElemTyp; got != "ptr" {
+		t.Fatalf("param0 listElemTyp = %q, want ptr", got)
+	}
+	if !sig.params[0].listElemString {
+		t.Fatal("param0 listElemString = false, want true")
+	}
+	if got := sig.params[1].mapKeyTyp; got != "ptr" {
+		t.Fatalf("param1 mapKeyTyp = %q, want ptr", got)
+	}
+	if got := sig.params[1].mapValueTyp; got != "i64" {
+		t.Fatalf("param1 mapValueTyp = %q, want i64", got)
+	}
+	if !sig.params[1].mapKeyString {
+		t.Fatal("param1 mapKeyString = false, want true")
+	}
+	if got := sig.retSetElemTyp; got != "i64" {
+		t.Fatalf("return setElemTyp = %q, want i64", got)
+	}
+	if sig.returnSourceType != ft.ReturnType {
+		t.Fatal("returnSourceType not preserved on synthesized fn sig")
+	}
+}
+
+func TestSynthFnSigFromSourceTypeRecognizesFnTypeOnly(t *testing.T) {
+	listType := &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{
+		&ast.NamedType{Path: []string{"Int"}},
+	}}
+	if sig, ok, err := synthFnSigFromSourceType(listType, typeEnv{}); err != nil {
+		t.Fatalf("synthFnSigFromSourceType(non-fn) returned error: %v", err)
+	} else if ok || sig != nil {
+		t.Fatalf("synthFnSigFromSourceType(non-fn) = (%v, %v), want (nil, false)", sig, ok)
+	}
+
+	ft := &ast.FnType{
+		Params: []ast.Type{
+			&ast.NamedType{Path: []string{"Int"}},
+		},
+		ReturnType: &ast.NamedType{Path: []string{"Bool"}},
+	}
+	sig, ok, err := synthFnSigFromSourceType(ft, typeEnv{})
+	if err != nil {
+		t.Fatalf("synthFnSigFromSourceType(fn) returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("synthFnSigFromSourceType(fn) = false, want true")
+	}
+	if sig == nil {
+		t.Fatal("synthFnSigFromSourceType(fn) returned nil sig")
+	}
+	if got := sig.ret; got != "i1" {
+		t.Fatalf("sig.ret = %q, want i1", got)
+	}
+	if len(sig.params) != 1 || sig.params[0].typ != "i64" {
+		t.Fatalf("sig.params = %#v, want one i64 param", sig.params)
+	}
+}

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -95,6 +95,101 @@ type fieldInfo struct {
 	sourceType     ast.Type
 }
 
+type containerMetadata struct {
+	sourceType     ast.Type
+	listElemTyp    string
+	listElemString bool
+	mapKeyTyp      string
+	mapValueTyp    string
+	mapKeyString   bool
+	setElemTyp     string
+	setElemString  bool
+}
+
+func containerMetadataFromSourceType(sourceType ast.Type, env typeEnv) (containerMetadata, error) {
+	meta := containerMetadata{sourceType: sourceType}
+	if sourceType == nil {
+		return meta, nil
+	}
+	if listElemTyp, listElemString, ok, err := llvmListElementInfo(sourceType, env); err != nil {
+		return containerMetadata{}, err
+	} else if ok {
+		meta.listElemTyp = listElemTyp
+		meta.listElemString = listElemString
+	}
+	if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(sourceType, env); err != nil {
+		return containerMetadata{}, err
+	} else if ok {
+		meta.mapKeyTyp = mapKeyTyp
+		meta.mapValueTyp = mapValueTyp
+		meta.mapKeyString = mapKeyString
+	}
+	if setElemTyp, setElemString, ok, err := llvmSetElementType(sourceType, env); err != nil {
+		return containerMetadata{}, err
+	} else if ok {
+		meta.setElemTyp = setElemTyp
+		meta.setElemString = setElemString
+	}
+	return meta, nil
+}
+
+func (m containerMetadata) applyToParam(info *paramInfo) {
+	if info == nil {
+		return
+	}
+	info.listElemTyp = m.listElemTyp
+	info.listElemString = m.listElemString
+	info.mapKeyTyp = m.mapKeyTyp
+	info.mapValueTyp = m.mapValueTyp
+	info.mapKeyString = m.mapKeyString
+	info.setElemTyp = m.setElemTyp
+	info.setElemString = m.setElemString
+	info.sourceType = m.sourceType
+}
+
+func (m containerMetadata) applyToField(info *fieldInfo) {
+	if info == nil {
+		return
+	}
+	info.listElemTyp = m.listElemTyp
+	info.listElemString = m.listElemString
+	info.mapKeyTyp = m.mapKeyTyp
+	info.mapValueTyp = m.mapValueTyp
+	info.mapKeyString = m.mapKeyString
+	info.setElemTyp = m.setElemTyp
+	info.setElemString = m.setElemString
+	info.sourceType = m.sourceType
+}
+
+func (m containerMetadata) applyToReturn(sig *fnSig) {
+	if sig == nil {
+		return
+	}
+	sig.retListElemTyp = m.listElemTyp
+	sig.retListString = m.listElemString
+	sig.retMapKeyTyp = m.mapKeyTyp
+	sig.retMapValueTyp = m.mapValueTyp
+	sig.retMapKeyString = m.mapKeyString
+	sig.retSetElemTyp = m.setElemTyp
+	sig.retSetElemString = m.setElemString
+	sig.returnSourceType = m.sourceType
+}
+
+func (m containerMetadata) applyToValue(out *value) {
+	if out == nil {
+		return
+	}
+	out.listElemTyp = m.listElemTyp
+	out.listElemString = m.listElemString
+	out.mapKeyTyp = m.mapKeyTyp
+	out.mapValueTyp = m.mapValueTyp
+	out.mapKeyString = m.mapKeyString
+	out.setElemTyp = m.setElemTyp
+	out.setElemString = m.setElemString
+	out.sourceType = m.sourceType
+	out.gcManaged = valueNeedsManagedRoot(*out)
+}
+
 type enumInfo struct {
 	name             string
 	typ              string
@@ -165,9 +260,9 @@ type interfaceMethodSig struct {
 // interfaceImpl records a concrete type that satisfies an interface,
 // together with the symbol its vtable emits.
 type interfaceImpl struct {
-	implName   string // source name of the struct/enum
-	kind       int    // 0 = struct, 1 = enum
-	vtableSym  string // `@osty.vtable.<impl>__<iface>`
+	implName  string // source name of the struct/enum
+	kind      int    // 0 = struct, 1 = enum
+	vtableSym string // `@osty.vtable.<impl>__<iface>`
 }
 
 type typeAliasInfo struct {
@@ -834,29 +929,13 @@ func collectStructFields(info *structInfo, env typeEnv) error {
 			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, true, "")
 			return unsupported(diag.kind, diag.message)
 		}
-		fieldInfo := fieldInfo{name: field.Name, typ: typ, index: i, sourceType: field.Type}
-		if listElemTyp, listElemString, ok, err := llvmListElementInfo(field.Type, env); err != nil {
+		meta, err := containerMetadataFromSourceType(field.Type, env)
+		if err != nil {
 			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
 			return unsupported(diag.kind, diag.message)
-		} else if ok {
-			fieldInfo.listElemTyp = listElemTyp
-			fieldInfo.listElemString = listElemString
 		}
-		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(field.Type, env); err != nil {
-			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
-			return unsupported(diag.kind, diag.message)
-		} else if ok {
-			fieldInfo.mapKeyTyp = mapKeyTyp
-			fieldInfo.mapValueTyp = mapValueTyp
-			fieldInfo.mapKeyString = mapKeyString
-		}
-		if setElemTyp, setElemString, ok, err := llvmSetElementType(field.Type, env); err != nil {
-			diag := llvmStructFieldDiagnostic(info.name, field.Name, true, false, false, false, unsupportedMessage(err))
-			return unsupported(diag.kind, diag.message)
-		} else if ok {
-			fieldInfo.setElemTyp = setElemTyp
-			fieldInfo.setElemString = setElemString
-		}
+		fieldInfo := fieldInfo{name: field.Name, typ: typ, index: i}
+		meta.applyToField(&fieldInfo)
 		info.fields = append(info.fields, fieldInfo)
 		info.byName[field.Name] = fieldInfo
 	}
@@ -1055,51 +1134,20 @@ func signatureOf(fn *ast.FnDecl, ownerName string, env typeEnv) (*fnSig, error) 
 			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
 			return nil, unsupported(diag.kind, diag.message)
 		}
-		info := paramInfo{name: p.Name, typ: typ, sourceType: p.Type}
-		if listElemTyp, listElemString, ok, err := llvmListElementInfo(p.Type, env); err != nil {
+		meta, err := containerMetadataFromSourceType(p.Type, env)
+		if err != nil {
 			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
 			return nil, unsupported(diag.kind, diag.message)
-		} else if ok {
-			info.listElemTyp = listElemTyp
-			info.listElemString = listElemString
 		}
-		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(p.Type, env); err != nil {
-			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
-			return nil, unsupported(diag.kind, diag.message)
-		} else if ok {
-			info.mapKeyTyp = mapKeyTyp
-			info.mapValueTyp = mapValueTyp
-			info.mapKeyString = mapKeyString
-		}
-		if setElemTyp, setElemString, ok, err := llvmSetElementType(p.Type, env); err != nil {
-			diag := llvmFunctionParamDiagnostic(fn.Name, p.Name, false, false, true, unsupportedMessage(err))
-			return nil, unsupported(diag.kind, diag.message)
-		} else if ok {
-			info.setElemTyp = setElemTyp
-			info.setElemString = setElemString
-		}
+		info := paramInfo{name: p.Name, typ: typ}
+		meta.applyToParam(&info)
 		sig.params = append(sig.params, info)
 	}
-	sig.returnSourceType = fn.ReturnType
-	if listElemTyp, listElemString, ok, err := llvmListElementInfo(fn.ReturnType, env); err != nil {
+	retMeta, err := containerMetadataFromSourceType(fn.ReturnType, env)
+	if err != nil {
 		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
-	} else if ok {
-		sig.retListElemTyp = listElemTyp
-		sig.retListString = listElemString
 	}
-	if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(fn.ReturnType, env); err != nil {
-		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
-	} else if ok {
-		sig.retMapKeyTyp = mapKeyTyp
-		sig.retMapValueTyp = mapValueTyp
-		sig.retMapKeyString = mapKeyString
-	}
-	if setElemTyp, setElemString, ok, err := llvmSetElementType(fn.ReturnType, env); err != nil {
-		return nil, unsupportedf("type-system", "function %q return type: %s", fn.Name, unsupportedMessage(err))
-	} else if ok {
-		sig.retSetElemTyp = setElemTyp
-		sig.retSetElemString = setElemString
-	}
+	retMeta.applyToReturn(sig)
 	return sig, nil
 }
 
@@ -1208,11 +1256,9 @@ func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 		// a closure env (same uniform ABI as phase 1), so we tag the
 		// binding with a synthesised *fnSig so subsequent `p(args)`
 		// inside the body dispatches through emitIndirectUserCall.
-		if ft, ok := p.sourceType.(*ast.FnType); ok {
-			fsig, err := synthFnSigFromFnType(ft, g.typeEnv())
-			if err != nil {
-				return "", err
-			}
+		if fsig, ok, err := synthFnSigFromSourceType(p.sourceType, g.typeEnv()); err != nil {
+			return "", err
+		} else if ok {
 			v.fnSigRef = fsig
 		}
 		v.gcManaged = valueNeedsManagedRoot(v)

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -3087,17 +3087,19 @@ func mapScalarValueByteSize(valTyp string) (int, bool) {
 // `self.get(key).isSome()` (containsKey) can compose naturally.
 //
 // ABI: the C runtime helper is
-//   bool osty_rt_map_get_<K>(void *map, K key, void *out_slot)
+//
+//	bool osty_rt_map_get_<K>(void *map, K key, void *out_slot)
+//
 // It returns true and memcpys V into *out_slot when the key is present;
 // otherwise returns false and leaves *out_slot alone.
 //
 // Option<V> at the LLVM layer is always a ptr:
 //   - V = ptr  →  the map value slot holds a pointer; we pre-zero the
-//                 slot and rely on `load ptr` producing null on miss and
-//                 the stored payload on hit. No branch needed.
+//     slot and rely on `load ptr` producing null on miss and
+//     the stored payload on hit. No branch needed.
 //   - V = scalar (i64 / i1 / double) →  GC-alloc a box in the present
-//                 branch and phi ptr-to-box vs null. Matches the
-//                 boxed-Option ABI consumed by `??`.
+//     branch and phi ptr-to-box vs null. Matches the
+//     boxed-Option ABI consumed by `??`.
 func (g *generator) emitMapGet(call *ast.CallExpr, base value, keyTyp string, keyString bool) (value, bool, error) {
 	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 		return value{}, true, unsupported("call", "map.get requires one positional argument")
@@ -3378,10 +3380,10 @@ func (g *generator) emitMapMergeWith(call *ast.CallExpr, base value, keyTyp stri
 	if err != nil {
 		return value{}, true, err
 	}
-	if combine.typ != "ptr" || combine.fnSigRef == nil {
-		return value{}, true, unsupportedf("call", "map.mergeWith combine must be a fn value")
+	sig, err := requireFnValueSignature(combine, "map.mergeWith combine")
+	if err != nil {
+		return value{}, true, err
 	}
-	sig := combine.fnSigRef
 	if len(sig.params) != 2 || sig.ret != valTyp {
 		return value{}, true, unsupportedf("call", "map.mergeWith combine must be fn(V, V) -> V")
 	}
@@ -3484,10 +3486,10 @@ func (g *generator) emitMapMapValues(call *ast.CallExpr, base value, keyTyp stri
 	if err != nil {
 		return value{}, true, err
 	}
-	if f.typ != "ptr" || f.fnSigRef == nil {
-		return value{}, true, unsupportedf("call", "map.mapValues f must be a fn value")
+	sig, err := requireFnValueSignature(f, "map.mapValues f")
+	if err != nil {
+		return value{}, true, err
 	}
-	sig := f.fnSigRef
 	if len(sig.params) != 1 || sig.params[0].typ != base.mapValueTyp {
 		return value{}, true, unsupportedf("call", "map.mapValues f must take single V argument")
 	}

--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -2,9 +2,9 @@
 // emitter. Mirrors the MIR closure ABI so fn values have a single
 // uniform representation regardless of which emitter produced them:
 //
-//   fn value  ≡  `ptr` to env struct
-//   env       ≡  { ptr fn_or_thunk, cap0, cap1, ... }
-//   call      ≡  `load ptr from env[0]; call ret (ptr, P...) %fn(env, args)`
+//	fn value  ≡  `ptr` to env struct
+//	env       ≡  { ptr fn_or_thunk, cap0, cap1, ... }
+//	call      ≡  `load ptr from env[0]; call ret (ptr, P...) %fn(env, args)`
 //
 // Top-level fn references (no captures) are wrapped in a thunk that
 // takes env as an implicit first arg and delegates to the real symbol.
@@ -14,7 +14,6 @@ package llvmgen
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/osty/osty/internal/ast"
 )
@@ -30,10 +29,6 @@ func closureThunkParamTypes(sig *fnSig) []string {
 	return out
 }
 
-func fnValueThunkSymbol(realSymbol string) string {
-	return "__osty_closure_thunk_" + realSymbol
-}
-
 // ensureFnValueThunk registers a closure thunk for `sig` if not yet
 // seen and returns its LLVM symbol name. The thunk is
 // `define private <ret> @__osty_closure_thunk_<sym>(ptr %env, P0, P1, ...)`
@@ -42,28 +37,19 @@ func fnValueThunkSymbol(realSymbol string) string {
 // The thunk IR is accumulated on the generator and flushed at module
 // render time — see generator.render().
 func (g *generator) ensureFnValueThunk(sig *fnSig) string {
-	symbol := fnValueThunkSymbol(sig.irName)
+	symbol := llvmClosureThunkName(sig.irName)
 	if g.fnValueThunkDefs == nil {
 		g.fnValueThunkDefs = map[string]string{}
 	}
 	if _, ok := g.fnValueThunkDefs[symbol]; ok {
 		return symbol
 	}
-	g.fnValueThunkDefs[symbol] = llvmRenderClosureThunk(
-		sig.ret, symbol, closureThunkParamTypes(sig), sig.irName,
+	g.fnValueThunkDefs[symbol] = llvmClosureThunkDefinition(
+		sig.irName, sig.ret, closureThunkParamTypes(sig),
 	)
 	g.fnValueThunkOrder = append(g.fnValueThunkOrder, symbol)
 	return symbol
 }
-
-// fnValueEnvKind is the GC kind tag for closure envs. Points at the
-// dedicated `OSTY_GC_KIND_CLOSURE_ENV = 1029` reservation in
-// `internal/backend/runtime/osty_runtime.c` (Phase A4,
-// RUNTIME_GC_DELTA §2.4). Retained as documentation / a pivot for
-// future direct `osty.gc.alloc_v1` callers; the closure allocation
-// path itself uses `osty.rt.closure_env_alloc_v1` which installs the
-// capture-tracing callback at construction.
-var fnValueEnvKind = llvmClosureEnvGcKind()
 
 // fnValuePhase1CaptureCount is the capture count the current lowering
 // emits for every closure env. Phase 1 closures have no captures yet;
@@ -123,8 +109,8 @@ func (g *generator) emitFnValueEnv(sig *fnSig) (value, error) {
 //
 // Emitted sequence:
 //
-//   %fn = load ptr, ptr %env
-//   (%result = )? call <ret> (ptr, P...) %fn(ptr %env, args...)
+//	%fn = load ptr, ptr %env
+//	(%result = )? call <ret> (ptr, P...) %fn(ptr %env, args...)
 //
 // Returns the call's LLVM result value (or an empty value when the
 // fn has no return).
@@ -139,34 +125,19 @@ func (g *generator) emitFnValueIndirectCall(envVal value, sig *fnSig, args []*Ll
 	if retLLVM == "" {
 		retLLVM = "void"
 	}
-	// Build the LLVM call-type string: `ret (ptr, P0, P1, ...)`.
-	paramParts := make([]string, 0, 1+len(sig.params))
-	paramParts = append(paramParts, "ptr")
-	for _, p := range sig.params {
-		paramParts = append(paramParts, llvmParamIRType(p))
-	}
-	callType := retLLVM + " (" + strings.Join(paramParts, ", ") + ")"
 
 	emitter := g.toOstyEmitter()
-	fnPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, envVal.ref))
-
-	// Assemble argument list with env prefix.
-	argStrs := make([]string, 0, 1+len(args))
-	argStrs = append(argStrs, fmt.Sprintf("ptr %s", envVal.ref))
-	for _, a := range args {
-		argStrs = append(argStrs, fmt.Sprintf("%s %s", a.typ, a.name))
-	}
-
-	if retLLVM == "void" {
-		emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", callType, fnPtr, strings.Join(argStrs, ", ")))
-		g.takeOstyEmitter(emitter)
+	outValue := llvmFnValueCallIndirect(
+		emitter,
+		retLLVM,
+		&LlvmValue{typ: "ptr", name: envVal.ref, pointer: false},
+		args,
+	)
+	g.takeOstyEmitter(emitter)
+	if outValue.typ == "void" {
 		return value{}, nil
 	}
-	result := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", result, callType, fnPtr, strings.Join(argStrs, ", ")))
-	g.takeOstyEmitter(emitter)
-	out := value{typ: retLLVM, ref: result}
+	out := value{typ: outValue.typ, ref: outValue.name}
 	out.listElemTyp = sig.retListElemTyp
 	out.listElemString = sig.retListString
 	out.mapKeyTyp = sig.retMapKeyTyp
@@ -204,31 +175,16 @@ func synthFnSigFromFnType(ft *ast.FnType, env typeEnv) (*fnSig, error) {
 		if err != nil {
 			return nil, err
 		}
+		meta, err := containerMetadataFromSourceType(pt, env)
+		if err != nil {
+			return nil, err
+		}
 		info := paramInfo{
-			name:       fmt.Sprintf("arg%d", i),
-			typ:        typ,
-			irTyp:      typ,
-			sourceType: pt,
+			name:  fmt.Sprintf("arg%d", i),
+			typ:   typ,
+			irTyp: typ,
 		}
-		if listElemTyp, listElemString, ok, err := llvmListElementInfo(pt, env); err != nil {
-			return nil, err
-		} else if ok {
-			info.listElemTyp = listElemTyp
-			info.listElemString = listElemString
-		}
-		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(pt, env); err != nil {
-			return nil, err
-		} else if ok {
-			info.mapKeyTyp = mapKeyTyp
-			info.mapValueTyp = mapValueTyp
-			info.mapKeyString = mapKeyString
-		}
-		if setElemTyp, setElemString, ok, err := llvmSetElementType(pt, env); err != nil {
-			return nil, err
-		} else if ok {
-			info.setElemTyp = setElemTyp
-			info.setElemString = setElemString
-		}
+		meta.applyToParam(&info)
 		params = append(params, info)
 	}
 	retLLVM := "void"
@@ -240,30 +196,40 @@ func synthFnSigFromFnType(ft *ast.FnType, env typeEnv) (*fnSig, error) {
 		retLLVM = typ
 	}
 	sig := &fnSig{
-		ret:              retLLVM,
-		returnSourceType: ft.ReturnType,
-		params:           params,
+		ret:    retLLVM,
+		params: params,
 	}
-	if ft.ReturnType != nil {
-		if listElemTyp, listElemString, ok, err := llvmListElementInfo(ft.ReturnType, env); err != nil {
-			return nil, err
-		} else if ok {
-			sig.retListElemTyp = listElemTyp
-			sig.retListString = listElemString
-		}
-		if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(ft.ReturnType, env); err != nil {
-			return nil, err
-		} else if ok {
-			sig.retMapKeyTyp = mapKeyTyp
-			sig.retMapValueTyp = mapValueTyp
-			sig.retMapKeyString = mapKeyString
-		}
-		if setElemTyp, setElemString, ok, err := llvmSetElementType(ft.ReturnType, env); err != nil {
-			return nil, err
-		} else if ok {
-			sig.retSetElemTyp = setElemTyp
-			sig.retSetElemString = setElemString
-		}
+	retMeta, err := containerMetadataFromSourceType(ft.ReturnType, env)
+	if err != nil {
+		return nil, err
+	}
+	retMeta.applyToReturn(sig)
+	return sig, nil
+}
+
+func synthFnSigFromSourceType(sourceType ast.Type, env typeEnv) (*fnSig, bool, error) {
+	ft, ok := sourceType.(*ast.FnType)
+	if !ok {
+		return nil, false, nil
+	}
+	sig, err := synthFnSigFromFnType(ft, env)
+	if err != nil {
+		return nil, true, err
+	}
+	return sig, true, nil
+}
+
+func fnValueSignature(v value) (*fnSig, bool) {
+	if v.typ != "ptr" || v.fnSigRef == nil {
+		return nil, false
+	}
+	return v.fnSigRef, true
+}
+
+func requireFnValueSignature(v value, label string) (*fnSig, error) {
+	sig, ok := fnValueSignature(v)
+	if !ok {
+		return nil, unsupportedf("call", "%s must be a fn value (got typ=%s, sig=%v)", label, v.typ, v.fnSigRef != nil)
 	}
 	return sig, nil
 }
@@ -315,51 +281,65 @@ func (g *generator) emitIndirectUserCall(call *ast.CallExpr) (value, bool, error
 func (g *generator) indirectCallCallee(call *ast.CallExpr) (value, *fnSig, bool, error) {
 	switch fn := call.Fn.(type) {
 	case *ast.Ident:
-		slot, ok := g.lookupBinding(fn.Name)
-		if !ok || slot.fnSigRef == nil {
-			return value{}, nil, false, nil
-		}
-		envVal, err := g.loadIfPointer(slot)
-		if err != nil {
-			return value{}, nil, true, err
-		}
-		return envVal, slot.fnSigRef, true, nil
+		return g.indirectIdentCallCallee(fn)
 	case *ast.FieldExpr:
-		if fn.IsOptional {
-			return value{}, nil, false, nil
-		}
-		// Only attempt this path when the receiver's static type is
-		// a known struct and the field's source type is an FnType.
-		// Everything else (method calls, optional chains, module
-		// aliases) remains owned by the upstream hooks.
-		baseInfo, ok := g.staticExprInfo(fn.X)
-		if !ok {
-			return value{}, nil, false, nil
-		}
-		structInfo := g.structsByType[baseInfo.typ]
-		if structInfo == nil {
-			return value{}, nil, false, nil
-		}
-		field, ok := structInfo.byName[fn.Name]
-		if !ok {
-			return value{}, nil, false, nil
-		}
-		ft, ok := field.sourceType.(*ast.FnType)
-		if !ok {
-			return value{}, nil, false, nil
-		}
-		sig, err := synthFnSigFromFnType(ft, g.typeEnv())
-		if err != nil {
-			return value{}, nil, true, err
-		}
-		envVal, err := g.emitFieldExpr(fn)
-		if err != nil {
-			return value{}, nil, true, err
-		}
-		if envVal.typ != "ptr" {
-			return value{}, nil, true, unsupportedf("type-system", "fn-typed field %q.%s expected ptr env, got %s", structInfo.name, fn.Name, envVal.typ)
-		}
-		return envVal, sig, true, nil
+		return g.indirectFieldCallCallee(fn)
 	}
 	return value{}, nil, false, nil
+}
+
+func (g *generator) indirectIdentCallCallee(fn *ast.Ident) (value, *fnSig, bool, error) {
+	if fn == nil {
+		return value{}, nil, false, nil
+	}
+	slot, ok := g.lookupBinding(fn.Name)
+	if !ok {
+		return value{}, nil, false, nil
+	}
+	sig, ok := fnValueSignature(slot)
+	if !ok {
+		return value{}, nil, false, nil
+	}
+	envVal, err := g.loadIfPointer(slot)
+	if err != nil {
+		return value{}, nil, true, err
+	}
+	return envVal, sig, true, nil
+}
+
+func (g *generator) indirectFieldCallCallee(fn *ast.FieldExpr) (value, *fnSig, bool, error) {
+	if fn == nil || fn.IsOptional {
+		return value{}, nil, false, nil
+	}
+	// Only attempt this path when the receiver's static type is a
+	// known struct and the field's source type is an FnType.
+	// Everything else (method calls, optional chains, module aliases)
+	// remains owned by the upstream hooks.
+	baseInfo, ok := g.staticExprInfo(fn.X)
+	if !ok {
+		return value{}, nil, false, nil
+	}
+	structInfo := g.structsByType[baseInfo.typ]
+	if structInfo == nil {
+		return value{}, nil, false, nil
+	}
+	field, ok := structInfo.byName[fn.Name]
+	if !ok {
+		return value{}, nil, false, nil
+	}
+	sig, ok, err := synthFnSigFromSourceType(field.sourceType, g.typeEnv())
+	if err != nil {
+		return value{}, nil, true, err
+	}
+	if !ok {
+		return value{}, nil, false, nil
+	}
+	envVal, err := g.emitFieldExpr(fn)
+	if err != nil {
+		return value{}, nil, true, err
+	}
+	if envVal.typ != "ptr" {
+		return value{}, nil, true, unsupportedf("type-system", "fn-typed field %q.%s expected ptr env, got %s", structInfo.name, fn.Name, envVal.typ)
+	}
+	return envVal, sig, true, nil
 }

--- a/internal/llvmgen/fn_value_helper_test.go
+++ b/internal/llvmgen/fn_value_helper_test.go
@@ -1,0 +1,27 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFnValueSignatureRecognizesPtrWithSig(t *testing.T) {
+	sig := &fnSig{ret: "i64"}
+	got, ok := fnValueSignature(value{typ: "ptr", fnSigRef: sig})
+	if !ok {
+		t.Fatal("fnValueSignature returned ok=false, want true")
+	}
+	if got != sig {
+		t.Fatalf("fnValueSignature returned %p, want %p", got, sig)
+	}
+}
+
+func TestRequireFnValueSignatureRejectsNonFnValue(t *testing.T) {
+	_, err := requireFnValueSignature(value{typ: "i64"}, "map.update callback")
+	if err == nil {
+		t.Fatal("requireFnValueSignature returned nil error, want failure")
+	}
+	if got := err.Error(); !strings.Contains(got, "map.update callback must be a fn value") {
+		t.Fatalf("error = %q, want fn-value diagnostic", got)
+	}
+}

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -54,10 +54,10 @@ type generator struct {
 	fnValueThunkDefs  map[string]string
 	fnValueThunkOrder []string
 
-	temp              int
-	label             int
-	stringID          int
-	stringDefs        []*LlvmStringGlobal
+	temp                 int
+	label                int
+	stringID             int
+	stringDefs           []*LlvmStringGlobal
 	body                 []string
 	locals               []map[string]value
 	returnType           string
@@ -70,9 +70,9 @@ type generator struct {
 	returnSetElemTyp     string
 	returnSetElemString  bool
 	currentBlock         string
-	currentReachable  bool
-	resultContexts    []builtinResultContext
-	optionContexts    []builtinOptionContext
+	currentReachable     bool
+	resultContexts       []builtinResultContext
+	optionContexts       []builtinOptionContext
 
 	needsGCRuntime bool
 	gcRootSlots    []value
@@ -259,23 +259,15 @@ func (g *generator) emitGCSafepointKind(emitter *LlvmEmitter, kind safepointKind
 	 * tag but bumps the serial, so per-kind counters in the runtime
 	 * still reflect the logical event count without losing the
 	 * classification. */
-	chunkSize := safepointRootChunkSize
-	if chunkSize <= 0 {
-		chunkSize = len(roots)
-	}
-	for start := 0; start < len(roots); start += chunkSize {
-		end := start + chunkSize
-		if end > len(roots) {
-			end = len(roots)
-		}
-		chunk := roots[start:end]
-		addresses := make([]string, len(chunk))
-		for i, root := range chunk {
+	plan := llvmPlanSafepointChunks(int(kind), g.nextSafepoint, len(roots), safepointRootChunkSize)
+	g.nextSafepoint += len(plan)
+	for _, chunk := range plan {
+		window := roots[chunk.start:chunk.end]
+		addresses := make([]string, len(window))
+		for i, root := range window {
 			addresses[i] = g.safepointRootAddress(emitter, root)
 		}
-		serial := g.nextSafepoint
-		g.nextSafepoint++
-		llvmEmitSafepointWithRoots(emitter, encodeSafepointID(kind, serial), addresses)
+		llvmEmitSafepointWithRoots(emitter, chunk.id, addresses)
 	}
 	g.needsGCRuntime = true
 }

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -58,6 +58,58 @@ func TestGeneratedGcRuntimeAbiSmokeIR(t *testing.T) {
 	assertGeneratedIRContains(t, ir, "call void @osty.gc.root_release_v1(ptr %t0)")
 }
 
+func TestGeneratedSafepointChunkPlanIsOstyOwned(t *testing.T) {
+	chunks := llvmPlanSafepointChunks(llvmSafepointKindLoop(), 11, 7, 3)
+	if got, want := len(chunks), 3; got != want {
+		t.Fatalf("len(chunks) = %d, want %d", got, want)
+	}
+	if got, want := chunks[0].start, 0; got != want {
+		t.Fatalf("chunks[0].start = %d, want %d", got, want)
+	}
+	if got, want := chunks[0].end, 3; got != want {
+		t.Fatalf("chunks[0].end = %d, want %d", got, want)
+	}
+	if got, want := chunks[0].id, llvmEncodeSafepointId(llvmSafepointKindLoop(), 11); got != want {
+		t.Fatalf("chunks[0].id = %d, want %d", got, want)
+	}
+	if got, want := chunks[1].start, 3; got != want {
+		t.Fatalf("chunks[1].start = %d, want %d", got, want)
+	}
+	if got, want := chunks[1].end, 6; got != want {
+		t.Fatalf("chunks[1].end = %d, want %d", got, want)
+	}
+	if got, want := chunks[1].id, llvmEncodeSafepointId(llvmSafepointKindLoop(), 12); got != want {
+		t.Fatalf("chunks[1].id = %d, want %d", got, want)
+	}
+	if got, want := chunks[2].start, 6; got != want {
+		t.Fatalf("chunks[2].start = %d, want %d", got, want)
+	}
+	if got, want := chunks[2].end, 7; got != want {
+		t.Fatalf("chunks[2].end = %d, want %d", got, want)
+	}
+	if got, want := chunks[2].id, llvmEncodeSafepointId(llvmSafepointKindLoop(), 13); got != want {
+		t.Fatalf("chunks[2].id = %d, want %d", got, want)
+	}
+
+	whole := llvmPlanSafepointChunks(llvmSafepointKindCall(), 5, 4, 0)
+	if got, want := len(whole), 1; got != want {
+		t.Fatalf("len(whole) = %d, want %d", got, want)
+	}
+	if got, want := whole[0].start, 0; got != want {
+		t.Fatalf("whole[0].start = %d, want %d", got, want)
+	}
+	if got, want := whole[0].end, 4; got != want {
+		t.Fatalf("whole[0].end = %d, want %d", got, want)
+	}
+	if got, want := whole[0].id, llvmEncodeSafepointId(llvmSafepointKindCall(), 5); got != want {
+		t.Fatalf("whole[0].id = %d, want %d", got, want)
+	}
+
+	if got := len(llvmPlanSafepointChunks(llvmSafepointKindCall(), 99, 0, 3)); got != 0 {
+		t.Fatalf("empty chunk plan len = %d, want 0", got)
+	}
+}
+
 func TestGeneratedClangLinkBinaryArgsAcceptMultipleObjects(t *testing.T) {
 	args := llvmClangLinkBinaryArgs("", []string{"/tmp/main.o", "/tmp/runtime/gc_runtime.o"}, "/tmp/app")
 	got := strings.Join(args, " ")
@@ -521,6 +573,59 @@ func TestGeneratedClosureThunkDefinitionVoidReturn(t *testing.T) {
 	assertGeneratedIRContains(t, def, "ret void")
 	if strings.Contains(def, "%ret = call") {
 		t.Fatalf("void thunk should not bind a return register\nIR:\n%s", def)
+	}
+}
+
+func TestGeneratedClosureThunkDefinitionEmptyReturnNormalizesToVoid(t *testing.T) {
+	def := llvmClosureThunkDefinition("sink", "", []string{"ptr"})
+
+	assertGeneratedIRContains(t, def, "define private void @__osty_closure_thunk_sink(ptr %env, ptr %arg0)")
+	assertGeneratedIRContains(t, def, "call void @sink(ptr %arg0)")
+	assertGeneratedIRContains(t, def, "ret void")
+}
+
+func TestGeneratedFnValueCallIndirectLoadsFlatEnvSlot(t *testing.T) {
+	emitter := llvmEmitter()
+	out := llvmFnValueCallIndirect(
+		emitter,
+		"i64",
+		&LlvmValue{typ: "ptr", name: "%env", pointer: false},
+		[]*LlvmValue{{typ: "i64", name: "42", pointer: false}},
+	)
+	ir := strings.Join(emitter.body, "\n")
+
+	if got, want := out.typ, "i64"; got != want {
+		t.Fatalf("out.typ = %q, want %q", got, want)
+	}
+	if out.name == "" {
+		t.Fatalf("out.name empty, want temp register")
+	}
+	assertGeneratedIRContains(t, ir, "= load ptr, ptr %env")
+	assertGeneratedIRContains(t, ir, "= call i64 (ptr, i64) ")
+	assertGeneratedIRContains(t, ir, "(ptr %env, i64 42)")
+}
+
+func TestGeneratedFnValueCallIndirectVoidReturnOmitsResultBinding(t *testing.T) {
+	emitter := llvmEmitter()
+	out := llvmFnValueCallIndirect(
+		emitter,
+		"",
+		&LlvmValue{typ: "ptr", name: "%env", pointer: false},
+		[]*LlvmValue{{typ: "ptr", name: "%arg0", pointer: false}},
+	)
+	ir := strings.Join(emitter.body, "\n")
+
+	if got, want := out.typ, "void"; got != want {
+		t.Fatalf("out.typ = %q, want %q", got, want)
+	}
+	if got := out.name; got != "" {
+		t.Fatalf("out.name = %q, want empty", got)
+	}
+	assertGeneratedIRContains(t, ir, "= load ptr, ptr %env")
+	assertGeneratedIRContains(t, ir, "call void (ptr, ptr) ")
+	assertGeneratedIRContains(t, ir, "(ptr %env, ptr %arg0)")
+	if strings.Contains(ir, "= call void") {
+		t.Fatalf("void indirect call should not bind a result\nIR:\n%s", ir)
 	}
 }
 

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2303,8 +2303,10 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 }
 
 // emitMapUpdateStmt lowers `m.update(key, f)` — stdlib bodied form is
-//   let current = self.get(key)
-//   self.insert(key, f(current))
+//
+//	let current = self.get(key)
+//	self.insert(key, f(current))
+//
 // The three steps run inside a single `osty_rt_map_lock/unlock`
 // critical section so concurrent mutators can't race between read and
 // write. The per-map mutex is recursive (see osty_runtime.c), so the
@@ -2331,10 +2333,10 @@ func (g *generator) emitMapUpdateStmt(call *ast.CallExpr, base value, keyTyp str
 	if err != nil {
 		return err
 	}
-	if fnVal.typ != "ptr" || fnVal.fnSigRef == nil {
-		return unsupportedf("call", "map.update callback must be a fn value (got typ=%s, sig=%v)", fnVal.typ, fnVal.fnSigRef != nil)
+	sig, err := requireFnValueSignature(fnVal, "map.update callback")
+	if err != nil {
+		return err
 	}
-	sig := fnVal.fnSigRef
 	if len(sig.params) != 1 {
 		return unsupportedf("call", "map.update callback arity must be 1 (got %d)", len(sig.params))
 	}
@@ -2396,10 +2398,10 @@ func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp s
 	if err != nil {
 		return err
 	}
-	if predVal.typ != "ptr" || predVal.fnSigRef == nil {
-		return unsupportedf("call", "map.retainIf callback must be a fn value")
+	sig, err := requireFnValueSignature(predVal, "map.retainIf callback")
+	if err != nil {
+		return err
 	}
-	sig := predVal.fnSigRef
 	if len(sig.params) != 2 || sig.ret != "i1" {
 		return unsupportedf("call", "map.retainIf pred arity/ret mismatch (want fn(K,V)->Bool)")
 	}
@@ -2548,11 +2550,11 @@ func (g *generator) emitSetMethodCallStmt(call *ast.CallExpr) (bool, error) {
 
 // emitMapFor lowers `for (k, v) in m { body }` as an index-based walk:
 //
-//   %len = call i64 @osty_rt_map_len(%m)
-//   for %i = 0; %i < %len; %i++:
-//     %k = call <K> @osty_rt_map_key_at_<ksuf>(%m, %i)
-//     alloca %vslot (width by V), call @osty_rt_map_value_at(%m, %i, %vslot), load
-//     body(k, v)
+//	%len = call i64 @osty_rt_map_len(%m)
+//	for %i = 0; %i < %len; %i++:
+//	  %k = call <K> @osty_rt_map_key_at_<ksuf>(%m, %i)
+//	  alloca %vslot (width by V), call @osty_rt_map_value_at(%m, %i, %vslot), load
+//	  body(k, v)
 //
 // This is the infra piece that unlocks `retainIf`, `mergeWith`,
 // `mapValues`, and any user-written map iteration. Matches the stdlib

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -108,7 +108,14 @@ type LlvmUnsupportedDiagnostic struct {
 	hint    string
 }
 
-// Osty: toolchain/llvmgen.osty:81:5
+// Osty: toolchain/llvmgen.osty:85:5
+type LlvmSafepointChunk struct {
+	start int
+	end   int
+	id    int64
+}
+
+// Osty: toolchain/llvmgen.osty:92:5
 func llvmEmitter() *LlvmEmitter {
 	return &LlvmEmitter{temp: 0, label: 0, stringId: 0, body: make([]string, 0, 1), locals: make([]*LlvmBinding, 0, 1), stringGlobals: make([]*LlvmStringGlobal, 0, 1)}
 }
@@ -482,13 +489,42 @@ func llvmEncodeSafepointId(kind int, serial int) int64 {
 // Osty: toolchain/llvmgen.osty:487:5
 func llvmSafepointDefaultRootChunkSize() int { return 4096 }
 
-// Osty: toolchain/llvmgen.osty:498:5
+// Osty: toolchain/llvmgen.osty:510:5
+func llvmPlanSafepointChunks(kind int, firstSerial int, rootCount int, chunkSize int) []*LlvmSafepointChunk {
+	chunks := make([]*LlvmSafepointChunk, 0, 1)
+	if rootCount <= 0 {
+		return chunks
+	}
+	size := chunkSize
+	if chunkSize <= 0 {
+		size = rootCount
+	}
+	serial := firstSerial
+	for start := 0; start < rootCount; start++ {
+		if start%size != 0 {
+			continue
+		}
+		end := start + size
+		if end > rootCount {
+			end = rootCount
+		}
+		chunks = append(chunks, &LlvmSafepointChunk{
+			start: start,
+			end:   end,
+			id:    llvmEncodeSafepointId(kind, serial),
+		})
+		serial++
+	}
+	return chunks
+}
+
+// Osty: toolchain/llvmgen.osty:535:5
 func llvmClosureEnvGcKind() int { return 1029 }
 
-// Osty: toolchain/llvmgen.osty:505:5
+// Osty: toolchain/llvmgen.osty:542:5
 func llvmClosureEnvPhase1CaptureCount() int { return 0 }
 
-// Osty: toolchain/llvmgen.osty:514:5
+// Osty: toolchain/llvmgen.osty:551:5
 func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string) *LlvmValue {
 	envTemp := llvmNextTemp(emitter)
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %d, ptr %s)", envTemp, captureCount, siteName))
@@ -496,17 +532,17 @@ func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, site
 	return &LlvmValue{typ: "ptr", name: envTemp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:513:5
+// Osty: toolchain/llvmgen.osty:550:5
 func llvmRenderSafepointEmpty(id int64) string {
 	return fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr null, i64 0)", id)
 }
 
-// Osty: toolchain/llvmgen.osty:521:5
+// Osty: toolchain/llvmgen.osty:558:5
 func llvmEmitSafepointEmpty(emitter *LlvmEmitter, id int64) {
 	emitter.body = append(emitter.body, llvmRenderSafepointEmpty(id))
 }
 
-// Osty: toolchain/llvmgen.osty:523:5
+// Osty: toolchain/llvmgen.osty:560:5
 func llvmEmitSafepointWithRoots(emitter *LlvmEmitter, id int64, rootAddresses []string) {
 	count := len(rootAddresses)
 	slotsPtr := llvmNextTemp(emitter)
@@ -1121,37 +1157,6 @@ func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []str
 	}
 	// Osty: toolchain/llvmgen.osty:684:5
 	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
-	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
-}
-
-// Osty: toolchain/llvmgen.osty:688:5
-func llvmRenderClosureThunk(retType string, thunkSymbol string, paramTypes []string, realSymbol string) string {
-	ret := retType
-	if ret == "" {
-		ret = "void"
-	}
-	paramParts := []string{"ptr %env"}
-	argParts := make([]string, 0, len(paramTypes))
-	for i := 0; i < len(paramTypes); i++ {
-		pt := paramTypes[i]
-		paramParts = append(paramParts, fmt.Sprintf("%s %%arg%d", pt, i))
-		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", pt, i))
-	}
-	params := llvmStrings.Join(paramParts, ", ")
-	args := llvmStrings.Join(argParts, ", ")
-	lines := []string{fmt.Sprintf("define private %s @%s(%s) {", ret, thunkSymbol, params), "entry:"}
-	if ret == "void" {
-		lines = append(lines,
-			fmt.Sprintf("  call void @%s(%s)", realSymbol, args),
-			"  ret void",
-		)
-	} else {
-		lines = append(lines,
-			fmt.Sprintf("  %%__ret = call %s @%s(%s)", ret, realSymbol, args),
-			fmt.Sprintf("  ret %s %%__ret", ret),
-		)
-	}
-	lines = append(lines, "}")
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
@@ -2203,11 +2208,39 @@ func llvmClosureCallIndirect(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeNam
 	return &LlvmValue{typ: returnType, name: tmp, pointer: false}
 }
 
+func llvmFnValueCallIndirect(emitter *LlvmEmitter, returnType string, envPtr *LlvmValue, extraArgs []*LlvmValue) *LlvmValue {
+	ret := returnType
+	if ret == "" {
+		ret = "void"
+	}
+	fnPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, envPtr.name))
+	args := []*LlvmValue{envPtr}
+	paramTypes := []string{"ptr"}
+	for _, arg := range extraArgs {
+		args = append(args, arg)
+		paramTypes = append(paramTypes, arg.typ)
+	}
+	paramList := llvmStrings.Join(paramTypes, ", ")
+	callType := fmt.Sprintf("%s (%s)", ret, paramList)
+	if ret == "void" {
+		emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", callType, fnPtr, llvmCallArgs(args)))
+		return &LlvmValue{typ: "void", name: "", pointer: false}
+	}
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", tmp, callType, fnPtr, llvmCallArgs(args)))
+	return &LlvmValue{typ: ret, name: tmp, pointer: false}
+}
+
 func llvmClosureThunkName(symbol string) string {
 	return "__osty_closure_thunk_" + symbol
 }
 
 func llvmClosureThunkDefinition(symbol string, returnType string, paramTypes []string) string {
+	ret := returnType
+	if ret == "" {
+		ret = "void"
+	}
 	headerParts := []string{"ptr %env"}
 	argParts := make([]string, 0, len(paramTypes))
 	for i, p := range paramTypes {
@@ -2218,15 +2251,15 @@ func llvmClosureThunkDefinition(symbol string, returnType string, paramTypes []s
 	callArgs := llvmStrings.Join(argParts, ", ")
 	thunk := llvmClosureThunkName(symbol)
 	lines := []string{
-		fmt.Sprintf("define private %s @%s(%s) {", returnType, thunk, header),
+		fmt.Sprintf("define private %s @%s(%s) {", ret, thunk, header),
 		"entry:",
 	}
-	if returnType == "void" {
+	if ret == "void" {
 		lines = append(lines, fmt.Sprintf("  call void @%s(%s)", symbol, callArgs))
 		lines = append(lines, "  ret void")
 	} else {
-		lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", returnType, symbol, callArgs))
-		lines = append(lines, fmt.Sprintf("  ret %s %%ret", returnType))
+		lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", ret, symbol, callArgs))
+		lines = append(lines, fmt.Sprintf("  ret %s %%ret", ret))
 	}
 	lines = append(lines, "}")
 	return llvmStrings.Join(lines, "\n")

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -646,21 +646,9 @@ func (g *generator) decorateStaticValueFromSourceType(out value, expr ast.Expr) 
 	if !ok {
 		return out
 	}
-	out.sourceType = sourceType
-	if listElemTyp, listElemString, ok, err := llvmListElementInfo(sourceType, g.typeEnv()); err == nil && ok {
-		out.listElemTyp = listElemTyp
-		out.listElemString = listElemString
+	if meta, err := containerMetadataFromSourceType(sourceType, g.typeEnv()); err == nil {
+		meta.applyToValue(&out)
 	}
-	if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(sourceType, g.typeEnv()); err == nil && ok {
-		out.mapKeyTyp = mapKeyTyp
-		out.mapValueTyp = mapValueTyp
-		out.mapKeyString = mapKeyString
-	}
-	if setElemTyp, setElemString, ok, err := llvmSetElementType(sourceType, g.typeEnv()); err == nil && ok {
-		out.setElemTyp = setElemTyp
-		out.setElemString = setElemString
-	}
-	out.gcManaged = valueNeedsManagedRoot(out)
 	return out
 }
 

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -486,6 +486,54 @@ pub fn llvmEncodeSafepointId(kind: Int, serial: Int) -> Int {
 /// so the default sits well below that cap to leave head-room.
 pub fn llvmSafepointDefaultRootChunkSize() -> Int { 4096 }
 
+/// LlvmSafepointChunk describes one rooted safepoint poll planned from a
+/// larger visible-root set. `start`/`end` slice the caller-owned root array
+/// and `id` is the fully encoded runtime safepoint id for that chunk.
+pub struct LlvmSafepointChunk {
+    pub start: Int,
+    pub end: Int,
+    pub id: Int,
+}
+
+/// Phase A6 rooted safepoint chunk planner (`RUNTIME_GC_DELTA.md` §10.2).
+///
+/// Ownership of the splitting policy lives here even though the legacy Go
+/// emitter still materializes the actual root-slot addresses from generator
+/// state. `firstSerial` is the serial to use for the first emitted chunk;
+/// each subsequent chunk bumps it by one while preserving `kind`. `chunkSize`
+/// <= 0 means "emit one chunk covering the full root set".
+pub fn llvmPlanSafepointChunks(
+    kind: Int,
+    firstSerial: Int,
+    rootCount: Int,
+    chunkSize: Int,
+) -> List<LlvmSafepointChunk> {
+    let mut chunks: List<LlvmSafepointChunk> = []
+    if rootCount <= 0 {
+        return chunks
+    }
+    let size = if chunkSize <= 0 { rootCount } else { chunkSize }
+    let mut serial = firstSerial
+    for start in 0..rootCount {
+        if start % size != 0 {
+            continue
+        }
+        let mut end = start + size
+        if end > rootCount {
+            end = rootCount
+        }
+        chunks.push(
+            LlvmSafepointChunk {
+                start,
+                end,
+                id: llvmEncodeSafepointId(kind, serial),
+            },
+        )
+        serial = serial + 1
+    }
+    chunks
+}
+
 /// Phase A4 closure env GC kind tag (`RUNTIME_GC_DELTA.md` §2.4).
 ///
 /// Points at the dedicated `OSTY_GC_KIND_CLOSURE_ENV = 1029`
@@ -1054,45 +1102,6 @@ pub fn llvmRenderFunction(
     let mut lines = ["define {ret} @{name}({llvmParams(params)}) \{", "entry:"]
     for line in body {
         lines.push(line)
-    }
-    lines.push("\}")
-    llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")
-}
-
-/// Phase A4 fn-value thunk template. Renders the IR body of a private
-/// delegating function that accepts `ptr %env` as its implicit first
-/// argument, discards the env, and forwards the remaining args to
-/// `realSymbol`. The resulting IR is what the legacy emitter caches
-/// in `g.fnValueThunkDefs` so top-level fn references can be wrapped
-/// in a fn-value-compatible ABI (`{ ptr fn, ... }` env layout) without
-/// touching the defining symbol. An empty `retType` is normalised to
-/// `void` so call sites may forward the checker's unit return type
-/// verbatim.
-pub fn llvmRenderClosureThunk(
-    retType: String,
-    thunkSymbol: String,
-    paramTypes: List<String>,
-    realSymbol: String,
-) -> String {
-    let ret = if retType == "" { "void" } else { retType }
-    let mut paramParts: List<String> = ["ptr %env"]
-    let mut argParts: List<String> = []
-    for i in 0..paramTypes.len() {
-        let pt = paramTypes[i]
-        paramParts.push("{pt} %arg{i}")
-        argParts.push("{pt} %arg{i}")
-    }
-    let params = llvmStrings.join(paramParts, ", ")
-    let args = llvmStrings.join(argParts, ", ")
-    let mut lines: List<String> = []
-    lines.push("define private {ret} @{thunkSymbol}({params}) \{")
-    lines.push("entry:")
-    if ret == "void" {
-        lines.push("  call void @{realSymbol}({args})")
-        lines.push("  ret void")
-    } else {
-        lines.push("  %__ret = call {ret} @{realSymbol}({args})")
-        lines.push("  ret {ret} %__ret")
     }
     lines.push("\}")
     llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")
@@ -2414,6 +2423,39 @@ pub fn llvmClosureCallIndirect(
     LlvmValue { typ: returnType, name: tmp, pointer: false }
 }
 
+/// Emit an indirect call through the legacy fn-value heap env ABI used by
+/// the AST emitter. Here `envPtr` already points at slot 0 itself, so the
+/// fn-pointer load is a plain `load ptr, ptr %env` rather than a typed
+/// closure-env GEP. The call still widens the visible signature to
+/// `(ptr env, ...userArgs)` so LLVM sees the real ABI.
+pub fn llvmFnValueCallIndirect(
+    emitter: LlvmEmitter,
+    returnType: String,
+    envPtr: LlvmValue,
+    extraArgs: List<LlvmValue>,
+) -> LlvmValue {
+    let ret = if returnType == "" { "void" } else { returnType }
+    let fnPtr = llvmNextTemp(emitter)
+    emitter.body.push("  {fnPtr} = load ptr, ptr {envPtr.name}")
+    let mut args = [envPtr]
+    let mut paramTypes: List<String> = ["ptr"]
+    for arg in extraArgs {
+        args.push(arg)
+        paramTypes.push(arg.typ)
+    }
+    let paramList = llvmStrings.join(paramTypes, ", ")
+    let callType = "{ret} ({paramList})"
+    if ret == "void" {
+        emitter.body.push("  call {callType} {fnPtr}({llvmCallArgs(args)})")
+        return LlvmValue { typ: "void", name: "", pointer: false }
+    }
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push(
+        "  {tmp} = call {callType} {fnPtr}({llvmCallArgs(args)})",
+    )
+    LlvmValue { typ: ret, name: tmp, pointer: false }
+}
+
 /// Canonical symbol name for the private thunk that wraps bare
 /// function `symbol` into the closure-env ABI. Deterministic so a
 /// second reference to the same bare fn reuses the same thunk def.
@@ -2432,6 +2474,7 @@ pub fn llvmClosureThunkDefinition(
     returnType: String,
     paramTypes: List<String>,
 ) -> String {
+    let ret = if returnType == "" { "void" } else { returnType }
     let mut headerParts: List<String> = ["ptr %env"]
     let mut argParts: List<String> = []
     let mut i = 0
@@ -2444,14 +2487,14 @@ pub fn llvmClosureThunkDefinition(
     let callArgs = llvmStrings.join(argParts, ", ")
     let thunk = llvmClosureThunkName(symbol)
     let mut lines: List<String> = []
-    lines.push("define private {returnType} @{thunk}({header}) \{")
+    lines.push("define private {ret} @{thunk}({header}) \{")
     lines.push("entry:")
-    if returnType == "void" {
+    if ret == "void" {
         lines.push("  call void @{symbol}({callArgs})")
         lines.push("  ret void")
     } else {
-        lines.push("  %ret = call {returnType} @{symbol}({callArgs})")
-        lines.push("  ret {returnType} %ret")
+        lines.push("  %ret = call {ret} @{symbol}({callArgs})")
+        lines.push("  ret {ret} %ret")
     }
     lines.push("\}")
     llvmStrings.join(lines, "\n")

--- a/toolchain/llvmgen_test.osty
+++ b/toolchain/llvmgen_test.osty
@@ -1080,6 +1080,49 @@ fn testLlvmClosureThunkDefinitionVoidReturn() {
     testing.assert(!(llvmTestStrings.contains(def, "%ret = call")))
 }
 
+fn testLlvmClosureThunkDefinitionEmptyReturnNormalisesToVoid() {
+    let def = llvmClosureThunkDefinition("sink", "", ["ptr"])
+
+    assertLlvmContains(def, "define private void @__osty_closure_thunk_sink(ptr %env, ptr %arg0)")
+    assertLlvmContains(def, "call void @sink(ptr %arg0)")
+    assertLlvmContains(def, "ret void")
+}
+
+fn testLlvmFnValueCallIndirectLoadsFlatEnvSlot() {
+    let emitter = llvmEmitter()
+    let out = llvmFnValueCallIndirect(
+        emitter,
+        "i64",
+        LlvmValue { typ: "ptr", name: "%env", pointer: false },
+        [LlvmValue { typ: "i64", name: "42", pointer: false }],
+    )
+    let ir = llvmTestStrings.join(emitter.body, "\n")
+
+    testing.assertEq(out.typ, "i64")
+    testing.assert(out.name != "")
+    assertLlvmContains(ir, "= load ptr, ptr %env")
+    assertLlvmContains(ir, "= call i64 (ptr, i64) ")
+    assertLlvmContains(ir, "(ptr %env, i64 42)")
+}
+
+fn testLlvmFnValueCallIndirectVoidReturnOmitsResultBinding() {
+    let emitter = llvmEmitter()
+    let out = llvmFnValueCallIndirect(
+        emitter,
+        "",
+        LlvmValue { typ: "ptr", name: "%env", pointer: false },
+        [LlvmValue { typ: "ptr", name: "%arg0", pointer: false }],
+    )
+    let ir = llvmTestStrings.join(emitter.body, "\n")
+
+    testing.assertEq(out.typ, "void")
+    testing.assertEq(out.name, "")
+    assertLlvmContains(ir, "= load ptr, ptr %env")
+    assertLlvmContains(ir, "call void (ptr, ptr) ")
+    assertLlvmContains(ir, "(ptr %env, ptr %arg0)")
+    testing.assert(!(llvmTestStrings.contains(ir, "= call void")))
+}
+
 fn testLlvmClosureBareFnEnvTypeDefIsOneSlot() {
     testing.assertEq(llvmClosureBareFnEnvTypeDef(), "%ClosureEnv.ptr = type \{ ptr \}")
 }
@@ -1326,6 +1369,44 @@ fn testLlvmGcPhaseAConstantsAreOstyOwned() {
     testing.assertEq(llvmClosureEnvPhase1CaptureCount(), 0)
 }
 
+fn testLlvmPlanSafepointChunksSplitsAndEncodesIds() {
+    let chunks = llvmPlanSafepointChunks(llvmSafepointKindLoop(), 11, 7, 3)
+
+    testing.assertEq(chunks.len(), 3)
+    testing.assertEq(chunks[0].start, 0)
+    testing.assertEq(chunks[0].end, 3)
+    testing.assertEq(
+        chunks[0].id,
+        llvmEncodeSafepointId(llvmSafepointKindLoop(), 11),
+    )
+    testing.assertEq(chunks[1].start, 3)
+    testing.assertEq(chunks[1].end, 6)
+    testing.assertEq(
+        chunks[1].id,
+        llvmEncodeSafepointId(llvmSafepointKindLoop(), 12),
+    )
+    testing.assertEq(chunks[2].start, 6)
+    testing.assertEq(chunks[2].end, 7)
+    testing.assertEq(
+        chunks[2].id,
+        llvmEncodeSafepointId(llvmSafepointKindLoop(), 13),
+    )
+}
+
+fn testLlvmPlanSafepointChunksFallsBackToWholeFrameAndEmpty() {
+    let whole = llvmPlanSafepointChunks(llvmSafepointKindCall(), 5, 4, 0)
+    testing.assertEq(whole.len(), 1)
+    testing.assertEq(whole[0].start, 0)
+    testing.assertEq(whole[0].end, 4)
+    testing.assertEq(
+        whole[0].id,
+        llvmEncodeSafepointId(llvmSafepointKindCall(), 5),
+    )
+
+    let empty = llvmPlanSafepointChunks(llvmSafepointKindCall(), 99, 0, 3)
+    testing.assertEq(empty.len(), 0)
+}
+
 fn testLlvmEmitSafepointEmptyIsOstyOwned() {
     let emitter = llvmEmitter()
     llvmEmitSafepointEmpty(emitter, 42)
@@ -1345,34 +1426,6 @@ fn testLlvmEmitSafepointWithRootsIsOstyOwned() {
     assertLlvmContains(ir, "%t2 = getelementptr ptr, ptr %t0, i64 1")
     assertLlvmContains(ir, "store ptr %root1, ptr %t2")
     assertLlvmContains(ir, "call void @osty.gc.safepoint_v1(i64 7, ptr %t0, i64 2)")
-}
-
-fn testLlvmRenderClosureThunkVoidReturn() {
-    let ir = llvmRenderClosureThunk("void", "__osty_closure_thunk_foo", [], "foo")
-
-    assertLlvmContains(ir, "define private void @__osty_closure_thunk_foo(ptr %env) \{")
-    assertLlvmContains(ir, "entry:")
-    assertLlvmContains(ir, "  call void @foo()")
-    assertLlvmContains(ir, "  ret void")
-    assertLlvmContains(ir, "\}")
-}
-
-fn testLlvmRenderClosureThunkValueReturnWithParams() {
-    let ir = llvmRenderClosureThunk("i64", "__osty_closure_thunk_add", ["i64", "i64"], "add")
-
-    assertLlvmContains(ir, "define private i64 @__osty_closure_thunk_add(ptr %env, i64 %arg0, i64 %arg1) \{")
-    assertLlvmContains(ir, "  %__ret = call i64 @add(i64 %arg0, i64 %arg1)")
-    assertLlvmContains(ir, "  ret i64 %__ret")
-}
-
-fn testLlvmRenderClosureThunkEmptyReturnNormalisesToVoid() {
-    // Checker hands us `""` for unit-return fns; the template must
-    // normalise that to `void` so the generated thunk is well-formed.
-    let ir = llvmRenderClosureThunk("", "__osty_closure_thunk_sink", ["ptr"], "sink")
-
-    assertLlvmContains(ir, "define private void @__osty_closure_thunk_sink(ptr %env, ptr %arg0) \{")
-    assertLlvmContains(ir, "  call void @sink(ptr %arg0)")
-    assertLlvmContains(ir, "  ret void")
 }
 
 fn testLlvmEmitClosureEnvAllocRuntimeIsOstyOwned() {


### PR DESCRIPTION
## Summary
- move more legacy llvmgen fn-value/GC helper ownership into `toolchain/llvmgen.osty` and the generated support snapshot
- centralize container metadata and fn-value signature extraction so indirect calls and higher-order map callbacks share the same helper surface
- add focused Go/Osty regressions for generated thunk/indirect-call helpers, synthesized fn signatures, and callback validation, and refresh the GC delta notes

## Why
The legacy LLVM emitter still had several duplicated Go-side policy surfaces around fn-value lowering, callback dispatch, and container metadata reconstruction. This change keeps the template/policy pieces Osty-owned and narrows the remaining Go code to state-dependent dispatch.

## Impact
- less duplicated fn-value call/thunk/signature logic in `internal/llvmgen`
- more consistent callback validation across indirect calls and map higher-order helpers
- better regression coverage for the ongoing GC Osty port

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'Test(CollectDeclarationsPreservesContainerMetadata|SynthFnSigFromFnTypePreservesContainerMetadata|SynthFnSigFromSourceTypeRecognizesFnTypeOnly|Generated(ClosureThunkDefinition(ForwardsArgs|VoidReturn|EmptyReturnNormalizesToVoid)|FnValueCallIndirect(LoadsFlatEnvSlot|VoidReturnOmitsResultBinding))|GenerateFnValue(BoundLocalIndirectCall|CoexistsWithDirectCall)|GenerateFnTyped(StructFieldIndirectCall|ParameterHigherOrder)|FnValueSignatureRecognizesPtrWithSig|RequireFnValueSignatureRejectsNonFnValue|GenerateMap(UpdateComposesOnGetAndInsert|UpdateRunsUnderLock|RetainIfUsesSnapshotIteration|RetainIfTwoPass|MergeWithCombinesOnCollision|MapValuesRebuildsWithNewValueType))'`