### PR TITLE
[codex] perf: throttle loop safepoint polls

### DIFF
--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -54,10 +54,10 @@ type generator struct {
 	fnValueThunkDefs  map[string]string
 	fnValueThunkOrder []string
 
-	temp              int
-	label             int
-	stringID          int
-	stringDefs        []*LlvmStringGlobal
+	temp                 int
+	label                int
+	stringID             int
+	stringDefs           []*LlvmStringGlobal
 	body                 []string
 	locals               []map[string]value
 	returnType           string
@@ -70,9 +70,9 @@ type generator struct {
 	returnSetElemTyp     string
 	returnSetElemString  bool
 	currentBlock         string
-	currentReachable  bool
-	resultContexts    []builtinResultContext
-	optionContexts    []builtinOptionContext
+	currentReachable     bool
+	resultContexts       []builtinResultContext
+	optionContexts       []builtinOptionContext
 
 	needsGCRuntime bool
 	gcRootSlots    []value
@@ -230,6 +230,13 @@ func encodeSafepointID(kind safepointKind, serial int) int64 {
 // the splitting path on modest fixtures.
 var safepointRootChunkSize = llvmSafepointDefaultRootChunkSize()
 
+// loopSafepointStride throttles loop back-edge polls so tight
+// pointer-free arithmetic loops do not pay a full runtime call on every
+// iteration. The runtime still sees LOOP-kind safepoints regularly for
+// cancellation / GC progress; setting the stride to 1 restores the
+// historical "poll every back-edge" behavior.
+var loopSafepointStride int64 = 256
+
 // emitGCSafepoint emits a safepoint poll at an unspecified site — kept
 // for callers that have not been classified yet. New call sites should
 // invoke `emitGCSafepointKind` directly with a specific kind so Phase
@@ -278,6 +285,39 @@ func (g *generator) emitGCSafepointKind(emitter *LlvmEmitter, kind safepointKind
 		llvmEmitSafepointWithRoots(emitter, encodeSafepointID(kind, serial), addresses)
 	}
 	g.needsGCRuntime = true
+}
+
+func (g *generator) allocLoopSafepointCounter(emitter *LlvmEmitter) string {
+	if loopSafepointStride <= 1 {
+		return ""
+	}
+	slot := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", slot))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 0, ptr %s", slot))
+	return slot
+}
+
+func (g *generator) emitLoopSafepoint(emitter *LlvmEmitter, counterSlot string) {
+	if counterSlot == "" || loopSafepointStride <= 1 {
+		g.emitGCSafepointKind(emitter, safepointKindLoop)
+		return
+	}
+	count := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", count, counterSlot))
+	next := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", next, count))
+	shouldPoll := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i64 %s, %d", shouldPoll, next, loopSafepointStride))
+	stored := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i64 0, i64 %s", stored, shouldPoll, next))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", stored, counterSlot))
+	pollLabel := llvmNextLabel(emitter, "gc.loop.poll")
+	afterLabel := llvmNextLabel(emitter, "gc.loop.after")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", shouldPoll, pollLabel, afterLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", pollLabel))
+	g.emitGCSafepointKind(emitter, safepointKindLoop)
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", afterLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", afterLabel))
 }
 
 func llvmZeroValue(typ string) value {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -104,8 +104,9 @@ type mirGen struct {
 	// curBlockID tracks the block we're currently emitting so
 	// GotoTerm can detect loop back-edges (goto whose target block
 	// ID is <= the current block's ID) and emit a safepoint.
-	gcRoots    []mir.LocalID
-	curBlockID mir.BlockID
+	gcRoots           []mir.LocalID
+	curBlockID        mir.BlockID
+	loopSafepointSlot string
 
 	// Module-scoped safepoint counter — matches the AST emitter's
 	// safepoint-v1 ABI so each call site has a stable numeric id.
@@ -133,7 +134,7 @@ type mirGen struct {
 	// Under the uniform env ABI every closure call takes an env as
 	// implicit first arg; top-level fns have no env, so the thunk
 	// ignores env and delegates to the real fn.
-	thunkDefs map[string]string // symbol → full thunk IR
+	thunkDefs  map[string]string // symbol → full thunk IR
 	thunkOrder []string
 }
 
@@ -912,6 +913,17 @@ func (g *mirGen) emitAllocaPreamble(fn *mir.Function) {
 		g.fnBuf.WriteString(slot)
 		g.fnBuf.WriteByte('\n')
 	}
+	if g.opts.EmitGC && loopSafepointStride > 1 {
+		g.loopSafepointSlot = "%gc.loop.poll"
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(g.loopSafepointSlot)
+		g.fnBuf.WriteString(" = alloca i64\n")
+		g.fnBuf.WriteString("  store i64 0, ptr ")
+		g.fnBuf.WriteString(g.loopSafepointSlot)
+		g.fnBuf.WriteByte('\n')
+	} else {
+		g.loopSafepointSlot = ""
+	}
 }
 
 // ==== GC instrumentation ====
@@ -1031,6 +1043,66 @@ func (g *mirGen) emitGCSafepointKind(kind safepointKind) {
 	g.nextSafepoint++
 	g.fnBuf.WriteString(llvmRenderSafepointEmpty(encodeSafepointID(kind, serial)))
 	g.fnBuf.WriteByte('\n')
+}
+
+func (g *mirGen) emitLoopSafepointKind() {
+	if !g.opts.EmitGC {
+		return
+	}
+	if g.loopSafepointSlot == "" || loopSafepointStride <= 1 {
+		g.emitGCSafepointKind(safepointKindLoop)
+		return
+	}
+	count := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(count)
+	g.fnBuf.WriteString(" = load i64, ptr ")
+	g.fnBuf.WriteString(g.loopSafepointSlot)
+	g.fnBuf.WriteByte('\n')
+	next := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(next)
+	g.fnBuf.WriteString(" = add i64 ")
+	g.fnBuf.WriteString(count)
+	g.fnBuf.WriteString(", 1\n")
+	shouldPoll := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(shouldPoll)
+	g.fnBuf.WriteString(" = icmp eq i64 ")
+	g.fnBuf.WriteString(next)
+	g.fnBuf.WriteString(", ")
+	g.fnBuf.WriteString(strconv.FormatInt(loopSafepointStride, 10))
+	g.fnBuf.WriteByte('\n')
+	stored := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(stored)
+	g.fnBuf.WriteString(" = select i1 ")
+	g.fnBuf.WriteString(shouldPoll)
+	g.fnBuf.WriteString(", i64 0, i64 ")
+	g.fnBuf.WriteString(next)
+	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString("  store i64 ")
+	g.fnBuf.WriteString(stored)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(g.loopSafepointSlot)
+	g.fnBuf.WriteByte('\n')
+	pollLabel := g.freshLabel("gc.loop.poll")
+	afterLabel := g.freshLabel("gc.loop.after")
+	g.fnBuf.WriteString("  br i1 ")
+	g.fnBuf.WriteString(shouldPoll)
+	g.fnBuf.WriteString(", label %")
+	g.fnBuf.WriteString(pollLabel)
+	g.fnBuf.WriteString(", label %")
+	g.fnBuf.WriteString(afterLabel)
+	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString(pollLabel)
+	g.fnBuf.WriteString(":\n")
+	g.emitGCSafepointKind(safepointKindLoop)
+	g.fnBuf.WriteString("  br label %")
+	g.fnBuf.WriteString(afterLabel)
+	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString(afterLabel)
+	g.fnBuf.WriteString(":\n")
 }
 
 // declareSafepoint registers @osty.gc.safepoint_v1 — split from
@@ -2593,24 +2665,25 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 	switch x := t.(type) {
 	case *mir.GotoTerm:
 		// Loop back-edges — a goto whose target is at or before the
-		// current block in CFG order — get a safepoint poll. This
-		// matches the legacy emitter's "safepoint at loop headers"
-		// convention and keeps cancellation responsive in tight
-		// loops. Forward gotos (if/else joins, fall-throughs) do
-		// not need extra polls because the function already took
-		// one at entry.
+		// current block in CFG order — advance the throttled loop
+		// safepoint counter. This matches the legacy emitter's
+		// loop-header polling convention while avoiding a full runtime
+		// call on every tight-loop iteration. Forward gotos (if/else
+		// joins, fall-throughs) do not need extra polls because the
+		// function already took one at entry.
 		if g.opts.EmitGC && x.Target <= g.curBlockID {
-			g.emitGCSafepointKind(safepointKindLoop)
+			g.emitLoopSafepointKind()
 		}
 		g.fnBuf.WriteString("  br label %")
 		g.fnBuf.WriteString(g.blockLabels[x.Target])
 		g.fnBuf.WriteByte('\n')
 	case *mir.BranchTerm:
-		// Same back-edge rule applied to conditional branches —
-		// covers `while cond { ... }` style loops where the cond
-		// block has a conditional branch back to its own body.
+		// Same throttled back-edge rule applied to conditional
+		// branches — covers `while cond { ... }` style loops where
+		// the cond block has a conditional branch back to its own
+		// body.
 		if g.opts.EmitGC && (x.Then <= g.curBlockID || x.Else <= g.curBlockID) {
-			g.emitGCSafepointKind(safepointKindLoop)
+			g.emitLoopSafepointKind()
 		}
 		cond, err := g.evalOperand(x.Cond, mir.TBool)
 		if err != nil {
@@ -4367,6 +4440,12 @@ func (g *mirGen) fresh() string {
 	name := fmt.Sprintf("%%t%d", g.tempSeq)
 	g.tempSeq++
 	return name
+}
+
+func (g *mirGen) freshLabel(prefix string) string {
+	label := fmt.Sprintf("%s.%d", prefix, g.tempSeq)
+	g.tempSeq++
+	return label
 }
 
 // ostyEmitter returns an LlvmEmitter whose temp counter is seeded from

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -583,6 +583,7 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 		return unsupported("type-system", "range bounds must be Int")
 	}
 	emitter := g.toOstyEmitter()
+	loopSafepointSlot := g.allocLoopSafepointCounter(emitter)
 	loop := llvmRangeStart(emitter, iterName, toOstyValue(start), toOstyValue(stop), rng.Inclusive)
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(loop.bodyLabel)
@@ -611,7 +612,7 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 	}
 	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
-	g.emitGCSafepointKind(emitter, safepointKindLoop)
+	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(loop.endLabel)
@@ -620,6 +621,7 @@ func (g *generator) emitFor(stmt *ast.ForStmt) error {
 
 func (g *generator) emitWhileFor(stmt *ast.ForStmt) error {
 	emitter := g.toOstyEmitter()
+	loopSafepointSlot := g.allocLoopSafepointCounter(emitter)
 	condLabel := llvmNextLabel(emitter, "for.cond")
 	bodyLabel := llvmNextLabel(emitter, "for.body")
 	continueLabel := llvmNextLabel(emitter, "for.cont")
@@ -681,7 +683,7 @@ func (g *generator) emitWhileFor(stmt *ast.ForStmt) error {
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(continueLabel)
 	emitter = g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindLoop)
+	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
 	g.takeOstyEmitter(emitter)
@@ -700,6 +702,7 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 		return unsupported("control-flow", "for-let requires an iterator expression")
 	}
 	emitter := g.toOstyEmitter()
+	loopSafepointSlot := g.allocLoopSafepointCounter(emitter)
 	condLabel := llvmNextLabel(emitter, "for.cond")
 	bodyLabel := llvmNextLabel(emitter, "for.body")
 	continueLabel := llvmNextLabel(emitter, "for.cont")
@@ -758,7 +761,7 @@ func (g *generator) emitForLet(stmt *ast.ForStmt) error {
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(continueLabel)
 	emitter = g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindLoop)
+	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", condLabel))
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
 	g.takeOstyEmitter(emitter)
@@ -2670,6 +2673,7 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 		return err
 	}
 	emitter := g.toOstyEmitter()
+	loopSafepointSlot := g.allocLoopSafepointCounter(emitter)
 	lenValue := llvmCall(emitter, "i64", listRuntimeLenSymbol(), []*LlvmValue{toOstyValue(iterableValue)})
 	loop := llvmRangeStart(emitter, iterName+"_idx", llvmIntLiteral(0), lenValue, false)
 	g.takeOstyEmitter(emitter)
@@ -2747,7 +2751,7 @@ func (g *generator) emitListFor(stmt *ast.ForStmt, iterName, elemTyp string) err
 	}
 	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
-	g.emitGCSafepointKind(emitter, safepointKindLoop)
+	g.emitLoopSafepoint(emitter, loopSafepointSlot)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(loop.endLabel)


### PR DESCRIPTION
## What changed

This PR reduces loop back-edge GC poll frequency in both LLVM emitters.

- add a shared `loopSafepointStride` policy in `internal/llvmgen/generator.go`
- throttle legacy AST-emitter loop safepoints in range `for`, `while`, `for let`, and list iteration paths
- apply the same throttled loop safepoint policy to the MIR emitter so `mir-backend` stays aligned

## Why it changed

The previous code emitted a full `osty.gc.safepoint_v1(...)` runtime call on every loop back-edge. That made tight integer loops pay a runtime-call tax on every iteration, even when the loop body itself was otherwise simple. This was a real language-runtime cost, not just benchmark noise.

This change keeps LOOP-kind safepoints for cancellation / GC progress, but moves them from every back-edge to every 256 back-edges.

## Impact

This is meant to improve actual generated-program runtime, especially tight arithmetic loops.

Using the same `osty-vs-go` harness shape on `loop_sum` with `--benchtime 3s`:

- `origin/main` (`3be010f0`): Go `244.40 ns/op`, Osty `7453.0 ns/op`, `30.50x`
- this branch (`09bb2670`): Go `340.70 ns/op`, Osty `3428.0 ns/op`, `10.06x`

The Go side is still noisy, but the Osty-side runtime cost drops materially under the same benchmark setup.

## Scope note

I intentionally kept this PR focused on the runtime-side loop optimization only. Earlier bench-harness experiments like sample-cap tuning are not included here.

## Validation

- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIREmitGCLoopSafepoint|TestGenerateFromASTSafepointKindMixCallAndLoop|TestGenerateSafepointKeepsImmutableManagedLocalsAndAggregateFields'`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `just build`
- `go run ./cmd/osty-vs-go --filter '^loop_sum$' --benchtime 3s --label pr-loop-compare-stable`

## Follow-up

I agree the next step should be broader and more stable benchmarking:

- add longer, more composite workloads instead of relying mostly on microbenches
- stabilize the Go-side baseline with repeated runs / quieter harness settings
- keep prioritizing root-cause runtime wins over benchmark-only improvements