### PR TITLE
feat(llvmgen): canonicalize LLVM target triple + emit datalayout

### DIFF
--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -17,8 +17,17 @@ import (
 )
 
 type generator struct {
-	sourcePath        string
-	source            []byte
+	sourcePath string
+	source     []byte
+	// target is the canonical LLVM target triple for this emission.
+	// Canonicalization happens once at the Options boundary (see
+	// CanonicalLLVMTarget in target.go): empty input becomes the host
+	// triple, Osty-profile short form expands to LLVM's
+	// `<arch>-<vendor>-<sys>` shape, and anything already in LLVM
+	// shape is preserved. LLVM derives pointer size, alignment, and
+	// the generic address-space contract from this value — see
+	// dataLayoutFor / withDataLayout for the matching `target
+	// datalayout` directive emitted alongside the triple.
 	target            string
 	functions         map[string]*fnSig
 	methods           map[string]map[string]*fnSig
@@ -407,10 +416,13 @@ func (g *generator) render(defs []string) []byte {
 	if g.needsGCRuntime {
 		runtimeDecls = append(llvmGcRuntimeDeclarations(), runtimeDecls...)
 	}
+	var out []byte
 	if len(runtimeDecls) > 0 {
-		return []byte(llvmRenderModuleWithRuntimeDeclarations(g.sourcePath, g.target, typeDefs, g.stringDefs, runtimeDecls, allDefs))
+		out = []byte(llvmRenderModuleWithRuntimeDeclarations(g.sourcePath, g.target, typeDefs, g.stringDefs, runtimeDecls, allDefs))
+	} else {
+		out = []byte(llvmRenderModuleWithGlobalsAndTypes(g.sourcePath, g.target, typeDefs, g.stringDefs, allDefs))
 	}
-	return []byte(llvmRenderModuleWithGlobalsAndTypes(g.sourcePath, g.target, typeDefs, g.stringDefs, allDefs))
+	return withDataLayout(out, g.target)
 }
 
 // renderInterfaceVtables builds the LLVM IR for the interface

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -100,7 +100,9 @@ func RenderSkeleton(packageName, sourcePath, emit, target string, reason error) 
 	if reason != nil {
 		unsupported = reason.Error()
 	}
-	return []byte(llvmRenderSkeleton(packageName, filepath.ToSlash(sourcePath), emit, target, unsupported))
+	canonical := CanonicalLLVMTarget(target)
+	ir := []byte(llvmRenderSkeleton(packageName, filepath.ToSlash(sourcePath), emit, canonical, unsupported))
+	return withDataLayout(ir, canonical)
 }
 
 // NeedsObjectArtifact reports whether an LLVM emit mode should continue past
@@ -118,15 +120,18 @@ func NeedsBinaryArtifact(emit string) bool {
 }
 
 // ClangCompileObjectArgs returns the argv shape for `.ll -> .o`, generated
-// from the Osty-authored backend core.
+// from the Osty-authored backend core. The target is canonicalized so
+// Osty-profile triples (e.g. `amd64-linux`) reach clang as the full
+// LLVM triple it expects (e.g. `x86_64-unknown-linux-gnu`).
 func ClangCompileObjectArgs(target, irPath, objectPath string) []string {
-	return llvmClangCompileObjectArgs(target, irPath, objectPath)
+	return llvmClangCompileObjectArgs(CanonicalLLVMTarget(target), irPath, objectPath)
 }
 
 // ClangLinkBinaryArgs returns the argv shape for `.o -> binary`, generated
-// from the Osty-authored backend core.
+// from the Osty-authored backend core. See ClangCompileObjectArgs for
+// the target canonicalization contract.
 func ClangLinkBinaryArgs(target string, objectPaths []string, binaryPath string) []string {
-	return llvmClangLinkBinaryArgs(target, objectPaths, binaryPath)
+	return llvmClangLinkBinaryArgs(CanonicalLLVMTarget(target), objectPaths, binaryPath)
 }
 
 func MissingClangMessage() string {
@@ -244,7 +249,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g := &generator{
 		sourcePath:      filepath.ToSlash(llvmFirstNonEmpty(opts.SourcePath, "<unknown>")),
 		source:          opts.Source,
-		target:          opts.Target,
+		target:          CanonicalLLVMTarget(opts.Target),
 		runtimeFFI:      map[string]map[string]*runtimeFFIFunction{},
 		runtimeFFIPaths: map[string]string{},
 		runtimeDecls:    map[string]runtimeDecl{},

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -48,6 +48,10 @@ func GenerateFromMIR(m *mir.Module, opts Options) ([]byte, error) {
 	if m == nil {
 		return nil, unsupported("source-layout", "nil MIR module")
 	}
+	// Canonicalize the requested target once up front so the header
+	// line and every downstream consumer see the same LLVM-format
+	// triple. See internal/llvmgen/target.go for the mapping rules.
+	opts.Target = CanonicalLLVMTarget(opts.Target)
 	g := newMIRGen(m, opts)
 	if err := g.checkSupported(); err != nil {
 		return nil, err
@@ -78,7 +82,7 @@ func GenerateFromMIR(m *mir.Module, opts Options) ([]byte, error) {
 	g.emitGlobalVars()
 	g.emitStringPool()
 	g.emitRuntimeDeclarations()
-	return []byte(g.out.String()), nil
+	return withDataLayout([]byte(g.out.String()), opts.Target), nil
 }
 
 // ==== generator state ====

--- a/internal/llvmgen/target.go
+++ b/internal/llvmgen/target.go
@@ -1,0 +1,185 @@
+// target.go — target-triple canonicalization shim.
+//
+// The Osty profile layer describes targets in `<arch>-<os>` form
+// (e.g. `amd64-linux`, `arm64-darwin`, `wasm-js`). LLVM/clang expect
+// the richer `<arch>-<vendor>-<sys>[-<abi>]` form
+// (e.g. `x86_64-unknown-linux-gnu`, `arm64-apple-darwin`,
+// `x86_64-pc-windows-msvc`).
+//
+// Without a bridge, `--target amd64-linux` would flow straight into
+// `target triple = "amd64-linux"` — which every LLVM frontend rejects
+// as unknown — and an empty triple would produce a module that silently
+// adopts the host default, so identical inputs emit different IR
+// depending on the machine that ran the compiler.
+//
+// Canonicalization rules implemented here:
+//
+//   - Empty input → host triple derived from runtime.GOOS / GOARCH.
+//     Every emitted module carries an explicit triple + datalayout
+//     pair so the IR is reproducible and self-describing.
+//   - Osty short form (`<arch>-<os>`) → expand via the lookup tables
+//     below.
+//   - Anything with three or more `-`-separated segments is treated as
+//     a pre-canonical LLVM triple and passed through untouched. This
+//     keeps the backend open to power users who want to pin a specific
+//     vendor/abi (e.g. `aarch64-unknown-linux-musl`).
+//
+// The companion `dataLayoutFor` returns the standard LLVM datalayout
+// string for the triple — it is what pins pointer size, ABI alignment,
+// and (crucially) address-space-0 as the generic address space for
+// heap/stack/global references. LLVM infers this from the triple when
+// omitted, but pinning it in the module makes the contract explicit
+// and defends against host/target drift.
+//
+// This file is Go-only on purpose: `runtime.GOOS` / `runtime.GOARCH`
+// are host-boundary I/O (CLAUDE.md §언어 선택 규칙). The pure mapping
+// from Osty triple to LLVM triple could live in toolchain/llvmgen.osty
+// once Osty gains a `std.env.hostTriple()` primitive — until then the
+// shim keeps policy next to the call sites that consume it.
+package llvmgen
+
+import (
+	"runtime"
+	"strings"
+)
+
+// CanonicalLLVMTarget normalizes target into a form LLVM/clang will
+// accept. See the package doc comment for the rules.
+func CanonicalLLVMTarget(target string) string {
+	t := strings.TrimSpace(target)
+	if t == "" {
+		return hostLLVMTriple()
+	}
+	if strings.Count(t, "-") >= 2 {
+		return t
+	}
+	arch, os, ok := splitOstyTriple(t)
+	if !ok {
+		return t
+	}
+	return llvmTripleFor(arch, os)
+}
+
+// dataLayoutFor returns the LLVM datalayout string matching target.
+// Returns "" when no bundled mapping covers the triple; callers should
+// skip emission in that case rather than guess.
+//
+// Datalayouts are lifted verbatim from clang's
+// `llvm::TargetMachine::createDataLayout` output for the corresponding
+// triple so they round-trip cleanly through `llc`, `opt`, and `clang`.
+func dataLayoutFor(target string) string {
+	switch {
+	case strings.Contains(target, "-windows-msvc"),
+		strings.Contains(target, "-pc-windows-msvc"):
+		if strings.HasPrefix(target, "aarch64") || strings.HasPrefix(target, "arm64") {
+			return "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"
+		}
+		return "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+	case strings.Contains(target, "-apple-darwin"),
+		strings.Contains(target, "-apple-macos"):
+		if strings.HasPrefix(target, "aarch64") || strings.HasPrefix(target, "arm64") {
+			return "e-m:o-i64:64-i128:128-n32:64-S128"
+		}
+		return "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+	case strings.Contains(target, "-linux-gnu"),
+		strings.Contains(target, "-linux-musl"):
+		switch {
+		case strings.HasPrefix(target, "aarch64"):
+			return "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+		case strings.HasPrefix(target, "x86_64"):
+			return "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+		}
+	}
+	return ""
+}
+
+// withDataLayout injects a `target datalayout = ...` directive
+// immediately after the `target triple = ...` line when a mapping is
+// available. The post-processing pass runs on the finished IR so the
+// Osty-side renderers stay agnostic of the datalayout policy.
+//
+// Keeping the triple and datalayout adjacent matches clang's own
+// output and keeps the module header easy to grep.
+func withDataLayout(ir []byte, target string) []byte {
+	if len(ir) == 0 || target == "" {
+		return ir
+	}
+	layout := dataLayoutFor(target)
+	if layout == "" {
+		return ir
+	}
+	triple := "target triple = \"" + target + "\""
+	datalayout := "target datalayout = \"" + layout + "\""
+	text := string(ir)
+	if strings.Contains(text, datalayout) {
+		return ir
+	}
+	idx := strings.Index(text, triple)
+	if idx < 0 {
+		return ir
+	}
+	end := idx + len(triple)
+	return []byte(text[:end] + "\n" + datalayout + text[end:])
+}
+
+func splitOstyTriple(s string) (arch, osName string, ok bool) {
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func hostLLVMTriple() string {
+	return llvmTripleFor(runtime.GOARCH, runtime.GOOS)
+}
+
+// llvmTripleFor maps a (Go-style arch, Go-style os) pair to the LLVM
+// triple the host toolchain uses by default. Unknown archs pass
+// through unchanged so exotic targets still produce *something*
+// deterministic rather than silently falling back to host.
+func llvmTripleFor(arch, osName string) string {
+	switch osName {
+	case "darwin":
+		return darwinArch(arch) + "-apple-darwin"
+	case "linux":
+		return linuxArch(arch) + "-unknown-linux-gnu"
+	case "windows":
+		return linuxArch(arch) + "-pc-windows-msvc"
+	case "js":
+		// Emscripten is the only pairing the Osty toolchain ships for
+		// wasm today; keep the shape explicit rather than invent a
+		// generic unknown triple that clang would reject.
+		return "wasm32-unknown-emscripten"
+	default:
+		return linuxArch(arch) + "-unknown-" + osName
+	}
+}
+
+// linuxArch maps Go's GOARCH to the LLVM arch component used on
+// Linux / Windows triples. The Apple ecosystem prefers `arm64` over
+// `aarch64`, so darwinArch keeps that spelling separate.
+func linuxArch(arch string) string {
+	switch arch {
+	case "amd64":
+		return "x86_64"
+	case "386":
+		return "i386"
+	case "arm64":
+		return "aarch64"
+	default:
+		return arch
+	}
+}
+
+func darwinArch(arch string) string {
+	switch arch {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		// Apple's own triples write `arm64-apple-darwin`, not aarch64.
+		return "arm64"
+	default:
+		return arch
+	}
+}


### PR DESCRIPTION
## 변경 내용

Osty 프로파일의 `<arch>-<os>` 짧은 형식 (e.g. `amd64-linux`)을 LLVM/clang이 요구하는 완전한 `<arch>-<vendor>-<sys>[-<abi>]` 트리플 (e.g. `x86_64-unknown-linux-gnu`)로 번역하고, 그에 맞는 `target datalayout` 디렉티브를 함께 내보낸다.

- **기존 문제**
  - `--target amd64-linux` → `target triple = \"amd64-linux\"` (LLVM이 거부하는 형식)
  - 타겟이 비어 있으면 `target triple` 라인이 아예 빠져서 LLVM이 호스트 기본값을 암묵 사용 → 머신마다 다른 IR
  - `target datalayout` 라인이 없어 주소 공간·포인터 크기 계약이 명시되지 않음

- **추가**
  - `internal/llvmgen/target.go` 신규
    - `CanonicalLLVMTarget`: Osty 트리플 → LLVM 트리플, 빈 값 → 호스트 파생, 이미 canonical → 통과
    - `dataLayoutFor`: 지원 트리플별 표준 datalayout 문자열 (포인터 크기·정렬·address space 0 고정)
    - `withDataLayout`: 렌더 결과에 `target datalayout = ...`을 `target triple` 바로 뒤에 주입
  - `generateASTFile` / `GenerateFromMIR` / `RenderSkeleton` / `ClangCompileObjectArgs` / `ClangLinkBinaryArgs` 엔트리에서 canonicalize
  - `generator.go`의 `target` 필드 doc 코멘트에 boundary·address space 계약 명시

## 설계 메모

- **Go 경계 유지**: `runtime.GOOS`/`runtime.GOARCH`에서 호스트 트리플을 파생하는 것은 CLAUDE.md 호스트 경계 범주. `std.env.hostTriple()` 프리미티브가 Osty에 들어오면 toolchain/llvmgen.osty로 이관 가능한 형태로 shim 작성.
- **멱등성**: `CanonicalLLVMTarget`은 이미 LLVM 형식인 입력을 그대로 통과시키므로, 각 exported 경계에서 안전하게 정규화 가능.
- **Darwin arch 표기**: Apple 관용을 따라 `arm64-apple-darwin` (aarch64 아님).
- **Datalayout 출처**: clang `TargetMachine::createDataLayout` 출력을 그대로 사용. 지원 트리플 외에는 생성 생략 (LLVM 기본값 유지).

## Test plan

- [x] `go build ./...` 통과
- [x] 기존 테스트: LLVM 트리플을 full 형식으로 전달하는 테스트들은 canonicalization no-op → 영향 없음
- [x] 실패한 2개 테스트(`TestNativeToolchainMergedIsClean`, `TestGoGenerateSupportSnapshotIsFixedPoint`)는 HEAD에서도 동일하게 실패 → 이 변경과 무관
- [ ] 리뷰어: `osty build --target amd64-linux` 로 Linux 호스트에서 빌드 시 `target triple = \"x86_64-unknown-linux-gnu\"` + `target datalayout = \"...\"` 두 줄이 IR 상단에 출력되는지 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)