### PR TITLE
[codex] Stabilize backend selfhost monomorph

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -307,8 +307,9 @@ fn main() {}
 		for _, o := range offenders {
 			t.Logf("  - %s", o)
 		}
+		t.Fatalf("stale TypeArgs leaked past monomorph; expected 0 offenders")
 	} else {
-		t.Logf("no stale TypeArgs — TurbofishExpr must arise from a different AST bridge path")
+		t.Logf("no stale TypeArgs remain after monomorph")
 	}
 }
 

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -823,21 +823,70 @@ func mergeEnv(receiver, method SubstEnv) SubstEnv {
 	return out
 }
 
-// extractOwnerNominal peels Optional wrappers off a Type to find the
-// enclosing NamedType name. Returns "" for types that don't resolve to
-// a nominal owner (function pointers, tuples, etc.) — callers should
-// treat that as "not a method-on-nominal" and bail.
+// extractOwnerNominal recovers the source-level nominal owner for a
+// method receiver type. OptionalType is the surface form of Option<T>,
+// so its owner is `Option` rather than the wrapped inner type. Returns
+// "" for types that don't resolve to a nominal owner (function
+// pointers, tuples, etc.) — callers should treat that as "not a
+// method-on-nominal" and bail.
 func extractOwnerNominal(t Type) string {
-	for {
-		switch x := t.(type) {
-		case *NamedType:
-			return x.Name
-		case *OptionalType:
-			t = x.Inner
-		default:
-			return ""
-		}
+	switch x := t.(type) {
+	case *NamedType:
+		return x.Name
+	case *OptionalType:
+		return "Option"
+	default:
+		return ""
 	}
+}
+
+// builtinReceiverTypeArgArity reports the source-level generic arity of
+// builtin receiver types when checker metadata attached the receiver's
+// concrete type args directly to a nongeneric method call. This lets
+// monomorph clear stale TypeArgs even when the owner template itself
+// was not injected into the module (e.g. List.push in a specialized Map
+// body, or Option.isSome on an OptionalType receiver).
+func builtinReceiverTypeArgArity(t Type) int {
+	switch x := t.(type) {
+	case *NamedType:
+		switch x.Name {
+		case "List", "Set", "Option":
+			return 1
+		case "Map", "Result":
+			return 2
+		}
+	case *OptionalType:
+		return 1
+	}
+	return 0
+}
+
+var builtinNonGenericMethods = map[string]map[string]bool{
+	"List": {
+		"push":   true,
+		"pop":    true,
+		"insert": true,
+		"clear":  true,
+	},
+	"Option": {
+		"isSome": true,
+		"isNone": true,
+	},
+}
+
+func builtinMethodCarriesReceiverTypeArgsOnly(receiver Type, method string, got int) bool {
+	if got == 0 {
+		return false
+	}
+	owner := extractOwnerNominal(receiver)
+	if owner == "" {
+		return false
+	}
+	methods := builtinNonGenericMethods[owner]
+	if !methods[method] {
+		return false
+	}
+	return builtinReceiverTypeArgArity(receiver) == got
 }
 
 // resolveOwner turns an owner nominal (either the mangled `_ZTSN…E`
@@ -912,6 +961,9 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 	}
 	kind, ownerMangled, origStruct, origEnum, receiverEnv, ok := s.resolveOwner(nominal)
 	if !ok {
+		if builtinMethodCarriesReceiverTypeArgsOnly(c.Receiver.Type(), c.Name, len(c.TypeArgs)) {
+			c.TypeArgs = nil
+		}
 		return
 	}
 	var origMethods []*FnDecl
@@ -926,8 +978,14 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 		return
 	}
 	if len(origMethod.Generics) == 0 {
-		// Call had type args but the declared method has no method-local
-		// generics. Let the existing non-generic path through.
+		// Checker-instantiation metadata on a method call can carry the
+		// owner's concrete receiver args even when the method itself has
+		// no method-local generics (e.g. `Map<String, Int>.containsKey`).
+		// Once the receiver type has been rewritten to the concrete owner
+		// specialization, those TypeArgs are semantically redundant and
+		// must be cleared so downstream AST lowering doesn't reintroduce a
+		// bogus turbofish node.
+		c.TypeArgs = nil
 		return
 	}
 	if !MonomorphShouldInstantiate(len(c.TypeArgs), len(origMethod.Generics)) {

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -1710,6 +1710,119 @@ func TestMonomorphizeMethodLocalGenericOnGenericOwner(t *testing.T) {
 	}
 }
 
+func TestMonomorphizeGenericOwnerNonGenericMethodClearsReceiverTypeArgs(t *testing.T) {
+	// Checker instantiation metadata can attach the owner's concrete
+	// args to a nongeneric method call on a generic owner. Monomorph
+	// should clear those stale TypeArgs once the receiver type has been
+	// rewritten to the concrete owner specialization.
+	tvT := &TypeVar{Name: "T"}
+	vec := &StructDecl{
+		Name:     "Vec",
+		Generics: []*TypeParam{{Name: "T"}},
+		Fields:   []*Field{{Name: "head", Type: tvT}},
+		Methods: []*FnDecl{{
+			Name: "headVal",
+			Params: []*Param{
+				{Name: "self", Type: &NamedType{Name: "Vec", Args: []Type{tvT}}},
+			},
+			Return: tvT,
+			Body:   &Block{Result: &FieldExpr{X: &Ident{Name: "self", Kind: IdentParam, T: &NamedType{Name: "Vec", Args: []Type{tvT}}}, Name: "head", T: tvT}},
+		}},
+	}
+	vecInt := &NamedType{Name: "Vec", Args: []Type{TInt}}
+	call := &MethodCall{
+		Receiver: &Ident{Name: "v", Kind: IdentLocal, T: vecInt},
+		Name:     "headVal",
+		TypeArgs: []Type{TInt},
+		T:        TInt,
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "v", Type: vecInt,
+				Value: &StructLit{TypeName: "Vec", T: vecInt,
+					Fields: []StructLitField{{Name: "head", Value: intLit("1")}}}},
+			&ExprStmt{X: call},
+		}},
+	}
+	out, errs := Monomorphize(&Module{Package: "main", Decls: []Decl{vec, main}})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	var mainCp *FnDecl
+	for _, d := range out.Decls {
+		if fn, ok := d.(*FnDecl); ok && fn.Name == "main" {
+			mainCp = fn
+			break
+		}
+	}
+	if mainCp == nil {
+		t.Fatalf("main missing from output decls: %+v", out.Decls)
+	}
+	callCp := mainCp.Body.Stmts[1].(*ExprStmt).X.(*MethodCall)
+	if len(callCp.TypeArgs) != 0 {
+		t.Fatalf("nongeneric method call should shed receiver TypeArgs after monomorph, got %+v", callCp.TypeArgs)
+	}
+}
+
+func TestMonomorphizeBuiltinListMethodFallbackClearsReceiverTypeArgs(t *testing.T) {
+	// Some stdlib-bodied specializations (notably Map helpers) call
+	// builtin generic owners like List.push without that owner template
+	// being present in the module. Monomorph should still clear the
+	// checker-carried receiver args on known nongeneric builtin methods
+	// instead of leaving stale turbofish metadata behind.
+	listInt := &NamedType{Name: "List", Args: []Type{TInt}}
+	call := &MethodCall{
+		Receiver: &Ident{Name: "xs", Kind: IdentLocal, T: listInt},
+		Name:     "push",
+		TypeArgs: []Type{TInt},
+		Args:     []Arg{{Value: intLit("1")}},
+		T:        TUnit,
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "xs", Type: listInt},
+			&ExprStmt{X: call},
+		}},
+	}
+	out, errs := Monomorphize(&Module{Package: "main", Decls: []Decl{main}})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	mainCp := out.Decls[0].(*FnDecl)
+	callCp := mainCp.Body.Stmts[1].(*ExprStmt).X.(*MethodCall)
+	if len(callCp.TypeArgs) != 0 {
+		t.Fatalf("builtin List.push fallback should clear stale receiver TypeArgs, got %+v", callCp.TypeArgs)
+	}
+}
+
+func TestMonomorphizeBuiltinOptionalMethodFallbackClearsReceiverTypeArgs(t *testing.T) {
+	optInt := &OptionalType{Inner: TInt}
+	call := &MethodCall{
+		Receiver: &Ident{Name: "x", Kind: IdentLocal, T: optInt},
+		Name:     "isSome",
+		TypeArgs: []Type{TInt},
+		T:        TBool,
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "x", Type: optInt},
+			&ExprStmt{X: call},
+		}},
+	}
+	out, errs := Monomorphize(&Module{Package: "main", Decls: []Decl{main}})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	mainCp := out.Decls[0].(*FnDecl)
+	callCp := mainCp.Body.Stmts[1].(*ExprStmt).X.(*MethodCall)
+	if len(callCp.TypeArgs) != 0 {
+		t.Fatalf("builtin Option.isSome fallback should clear stale receiver TypeArgs, got %+v", callCp.TypeArgs)
+	}
+}
+
 func TestMonomorphizeMethodLocalGenericArityMismatch(t *testing.T) {
 	box := genericBoxNonGenericOwner()
 	// get<U> — pass two type args

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -632,6 +632,44 @@ fn main() {
 	}
 }
 
+// Statement-position twin of the higher-order path above: a fn-typed
+// parameter returning unit still has to dispatch through the indirect
+// call ABI. This is the exact shape specialized Map.forEach bodies hit
+// after monomorphization (`f(key, value)`).
+func TestGenerateFnTypedParameterStmtIndirectCall(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn apply2(f: fn(Int, Int)) {
+    f(1, 2)
+}
+
+fn printPair(a: Int, b: Int) {
+    println(a)
+    println(b)
+}
+
+fn main() {
+    apply2(printPair)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/fn_typed_param_stmt.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"define void @apply2(ptr %f)",
+		"call void (ptr, i64, i64)",
+		"call ptr @osty.rt.closure_env_alloc_v1(i64 0, ptr",
+		"define private void @__osty_closure_thunk_printPair(ptr %env, i64 %arg0, i64 %arg1)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestGenerateMapGetLowersAsOptionReturningIntrinsic locks the root-cause
 // fix: Map.get(key) -> V? now goes through the real
 // osty_rt_map_get_<K> runtime helper (bool return + out-param), with

--- a/internal/llvmgen/match_stmt_test.go
+++ b/internal/llvmgen/match_stmt_test.go
@@ -110,3 +110,34 @@ fn main() {
 		t.Fatalf("expected match.end label so control flow converges:\n%s", got)
 	}
 }
+
+// ptr-backed optional matches show up in specialized stdlib bodies like
+// `Map.mergeWith`, where `match out.get(key)` branches on Option<V> in
+// statement position. This regression net keeps that path open for both
+// the null-check and the scalar payload load.
+func TestMatchStmtOptionalFromMapGet(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn main() {
+    let mut m: Map<String, Int> = {:}
+    m.insert("a", 7)
+    match m.get("a") {
+        Some(v) -> println(v),
+        None -> println(0),
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/match_stmt_option.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call i1 @osty_rt_map_get_string(",
+		"icmp eq ptr",
+		"load i64, ptr",
+		"match.end",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -845,6 +845,12 @@ func (g *generator) emitExprStmt(expr ast.Expr) error {
 	if emitted, err := g.emitUserCallStmt(call); emitted || err != nil {
 		return err
 	}
+	if emitted, err := g.emitIndirectUserCallStmt(call); emitted || err != nil {
+		return err
+	}
+	if id, ok := call.Fn.(*ast.Ident); ok && id.Name == "println" {
+		return g.emitPrintln(call)
+	}
 	return g.emitPrintln(call)
 }
 
@@ -1950,10 +1956,189 @@ func (g *generator) emitMatchStmt(expr *ast.MatchExpr) error {
 	if err != nil {
 		return err
 	}
+	if sourceType, ok := g.staticExprSourceType(expr.Scrutinee); ok {
+		resolved, resolveErr := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{})
+		if resolveErr == nil {
+			if opt, ok := resolved.(*ast.OptionalType); ok && scrutinee.typ == "ptr" {
+				return g.emitOptionalMatchStmt(scrutinee, opt.Inner, expr.Arms)
+			}
+		}
+	}
 	if scrutinee.typ != "i64" {
 		return unsupportedf("statement", "match statement scrutinee type %s (only tag-enum i64 supported as statement for now)", scrutinee.typ)
 	}
 	return g.emitTagEnumMatchStmt(scrutinee, expr.Arms)
+}
+
+type optionalMatchPatternInfo struct {
+	isSome      bool
+	isNone      bool
+	isWildcard  bool
+	payloadName string
+}
+
+func matchOptionalPattern(pattern ast.Pattern) (optionalMatchPatternInfo, bool, error) {
+	switch p := pattern.(type) {
+	case *ast.WildcardPat:
+		return optionalMatchPatternInfo{isWildcard: true}, true, nil
+	case *ast.IdentPat:
+		switch p.Name {
+		case "None":
+			return optionalMatchPatternInfo{isNone: true}, true, nil
+		case "Some":
+			return optionalMatchPatternInfo{}, true, unsupported("statement", "optional Some arm must bind or wildcard its payload")
+		default:
+			return optionalMatchPatternInfo{}, false, nil
+		}
+	case *ast.VariantPat:
+		if len(p.Path) == 0 || len(p.Path) > 2 {
+			return optionalMatchPatternInfo{}, false, nil
+		}
+		name := p.Path[len(p.Path)-1]
+		switch name {
+		case "None":
+			if len(p.Args) != 0 {
+				return optionalMatchPatternInfo{}, true, unsupported("statement", "None arm cannot bind a payload")
+			}
+			return optionalMatchPatternInfo{isNone: true}, true, nil
+		case "Some":
+			if len(p.Args) != 1 {
+				return optionalMatchPatternInfo{}, true, unsupported("statement", "Some arm must bind exactly one payload")
+			}
+			switch arg := p.Args[0].(type) {
+			case *ast.IdentPat:
+				return optionalMatchPatternInfo{isSome: true, payloadName: arg.Name}, true, nil
+			case *ast.WildcardPat:
+				return optionalMatchPatternInfo{isSome: true}, true, nil
+			default:
+				return optionalMatchPatternInfo{}, true, unsupportedf("statement", "optional Some payload pattern %T", arg)
+			}
+		default:
+			return optionalMatchPatternInfo{}, false, nil
+		}
+	default:
+		return optionalMatchPatternInfo{}, false, nil
+	}
+}
+
+func (g *generator) bindOptionalMatchPayload(scrutinee value, innerSource ast.Type, pattern optionalMatchPatternInfo) error {
+	if pattern.payloadName == "" {
+		return nil
+	}
+	innerTyp, err := llvmType(innerSource, g.typeEnv())
+	if err != nil {
+		return err
+	}
+	payload := value{typ: innerTyp}
+	if innerTyp == "ptr" {
+		payload.ref = scrutinee.ref
+	} else {
+		emitter := g.toOstyEmitter()
+		payload = g.loadValueFromAddress(emitter, innerTyp, scrutinee.ref)
+		g.takeOstyEmitter(emitter)
+	}
+	payload.sourceType = innerSource
+	if listElemTyp, listElemString, ok, err := llvmListElementInfo(innerSource, g.typeEnv()); err == nil && ok {
+		payload.listElemTyp = listElemTyp
+		payload.listElemString = listElemString
+	}
+	if mapKeyTyp, mapValueTyp, mapKeyString, ok, err := llvmMapTypes(innerSource, g.typeEnv()); err == nil && ok {
+		payload.mapKeyTyp = mapKeyTyp
+		payload.mapValueTyp = mapValueTyp
+		payload.mapKeyString = mapKeyString
+	}
+	if setElemTyp, setElemString, ok, err := llvmSetElementType(innerSource, g.typeEnv()); err == nil && ok {
+		payload.setElemTyp = setElemTyp
+		payload.setElemString = setElemString
+	}
+	payload.gcManaged = valueNeedsManagedRoot(payload)
+	payload.rootPaths = g.rootPathsForType(payload.typ)
+	g.bindNamedLocal(pattern.payloadName, payload, false)
+	return nil
+}
+
+func (g *generator) emitOptionalMatchStmt(scrutinee value, innerSource ast.Type, arms []*ast.MatchArm) error {
+	emitter := g.toOstyEmitter()
+	endLabel := llvmNextLabel(emitter, "match.end")
+	isNil := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, scrutinee.ref))
+	g.takeOstyEmitter(emitter)
+
+	anyReached := false
+	for i, arm := range arms {
+		if arm == nil {
+			return unsupported("statement", "nil match arm")
+		}
+		if arm.Guard != nil {
+			return unsupported("statement", "guarded optional match arms are not yet supported as statements")
+		}
+		pattern, ok, err := matchOptionalPattern(arm.Pattern)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return unsupportedf("statement", "optional match arm must be Some/None/wildcard, got %T", arm.Pattern)
+		}
+		isLast := i == len(arms)-1
+		if pattern.isWildcard {
+			if !isLast {
+				return unsupported("statement", "wildcard match arm must be last")
+			}
+			baseState := g.captureScopeState()
+			if err := g.emitMatchArmBodyAsStmt(arm.Body); err != nil {
+				return err
+			}
+			if g.currentReachable {
+				g.branchTo(endLabel)
+				anyReached = true
+			}
+			g.restoreScopeState(baseState)
+			continue
+		}
+
+		emitter := g.toOstyEmitter()
+		armLabel := llvmNextLabel(emitter, "match.arm")
+		nextLabel := llvmNextLabel(emitter, "match.next")
+		if pattern.isSome {
+			emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil, nextLabel, armLabel))
+		} else {
+			emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil, armLabel, nextLabel))
+		}
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", armLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(armLabel)
+
+		baseState := g.captureScopeState()
+		if pattern.isSome {
+			if err := g.bindOptionalMatchPayload(scrutinee, innerSource, pattern); err != nil {
+				return err
+			}
+		}
+		if err := g.emitMatchArmBodyAsStmt(arm.Body); err != nil {
+			return err
+		}
+		if g.currentReachable {
+			g.branchTo(endLabel)
+			anyReached = true
+		}
+		g.restoreScopeState(baseState)
+
+		emitter = g.toOstyEmitter()
+		emitter.body = append(emitter.body, fmt.Sprintf("%s:", nextLabel))
+		g.takeOstyEmitter(emitter)
+		g.enterBlock(nextLabel)
+	}
+
+	if g.currentReachable {
+		g.branchTo(endLabel)
+		anyReached = true
+	}
+	emitter = g.toOstyEmitter()
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(endLabel)
+	g.currentReachable = anyReached
+	return nil
 }
 
 func (g *generator) emitTagEnumMatchStmt(scrutinee value, arms []*ast.MatchArm) error {
@@ -2303,8 +2488,10 @@ func (g *generator) emitMapMethodCallStmt(call *ast.CallExpr) (bool, error) {
 }
 
 // emitMapUpdateStmt lowers `m.update(key, f)` — stdlib bodied form is
-//   let current = self.get(key)
-//   self.insert(key, f(current))
+//
+//	let current = self.get(key)
+//	self.insert(key, f(current))
+//
 // The three steps run inside a single `osty_rt_map_lock/unlock`
 // critical section so concurrent mutators can't race between read and
 // write. The per-map mutex is recursive (see osty_runtime.c), so the
@@ -2548,11 +2735,11 @@ func (g *generator) emitSetMethodCallStmt(call *ast.CallExpr) (bool, error) {
 
 // emitMapFor lowers `for (k, v) in m { body }` as an index-based walk:
 //
-//   %len = call i64 @osty_rt_map_len(%m)
-//   for %i = 0; %i < %len; %i++:
-//     %k = call <K> @osty_rt_map_key_at_<ksuf>(%m, %i)
-//     alloca %vslot (width by V), call @osty_rt_map_value_at(%m, %i, %vslot), load
-//     body(k, v)
+//	%len = call i64 @osty_rt_map_len(%m)
+//	for %i = 0; %i < %len; %i++:
+//	  %k = call <K> @osty_rt_map_key_at_<ksuf>(%m, %i)
+//	  alloca %vslot (width by V), call @osty_rt_map_value_at(%m, %i, %vslot), load
+//	  body(k, v)
 //
 // This is the infra piece that unlocks `retainIf`, `mergeWith`,
 // `mapValues`, and any user-written map iteration. Matches the stdlib
@@ -2819,4 +3006,9 @@ func (g *generator) emitUserCallStmt(call *ast.CallExpr) (bool, error) {
 	g.takeOstyEmitter(emitter)
 	g.popScope()
 	return true, nil
+}
+
+func (g *generator) emitIndirectUserCallStmt(call *ast.CallExpr) (bool, error) {
+	_, found, err := g.emitIndirectUserCall(call)
+	return found, err
 }


### PR DESCRIPTION
## What changed
- allow statement-position indirect fn-value calls so specialized `Map.forEach` bodies can lower `f(key, value)`
- support statement `match` on ptr-backed optionals from `Map.get()` including `Some`/`None` arms and payload binding
- clear stale receiver-side `MethodCall.TypeArgs` after monomorph, including builtin fallback paths for `List.push` and `Option.isSome`
- tighten the Phase 2c backend regression so stale `TypeArgs` now fail the test instead of only logging

## Why
- the selfhost monomorph branch was still carrying stale turbofish metadata through specialized builtin bodies
- that left the backend vulnerable to `TurbofishExpr` leakage and blocked the specialized Map path from stabilizing end-to-end

## Impact
- `TestPhase2MonomorphMapReachesGenerateModule` stays green
- the stale `TypeArgs` diagnosis now reports zero offenders
- specialized Map bodies keep working through indirect calls and optional matches without falling back to the old blocker

## Validation
- `go test -count=1 -vet=off -run 'TestPhase2cDiagnoseTurbofishSource|TestPhase2MonomorphMapReachesGenerateModule' ./internal/backend`
- `go test -count=1 -vet=off -run 'TestMonomorphizeBuiltinListMethodFallbackClearsReceiverTypeArgs|TestMonomorphizeBuiltinOptionalMethodFallbackClearsReceiverTypeArgs|TestMonomorphizeGenericOwnerNonGenericMethodClearsReceiverTypeArgs' ./internal/ir`
- `go test -count=1 -vet=off -run 'TestGenerateFnTypedParameterStmtIndirectCall|TestMatchStmtOptionalFromMapGet' ./internal/llvmgen`
- `go test -count=1 -vet=off -run TestInjectReachableStdlibTypesSkipsUnusedTypes ./internal/backend`
- `just verify-selfhost`