### PR TITLE
[codex] Add native llvmgen module entry slice

### DIFF
--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -13,7 +13,7 @@
 // only in-package tests can reach it. All external callers route
 // through IR.
 //
-// Supported source shapes
+// # Supported source shapes
 //
 // The current implementation is deliberately small: no-arg main
 // functions or script files, integer println expressions, plain ASCII
@@ -33,13 +33,13 @@
 //
 // Implementation note (transitional)
 //
-// GenerateModule currently bridges the IR back to an AST (see
-// ir_module.go) and then routes through the long-standing AST-driven
-// emitter. This bridge is an implementation detail that the public
-// API does not expose — callers neither construct nor observe the
-// intermediate AST. Follow-on work will rewrite the emitter to consume
-// IR directly and delete the bridge; once that lands the AST is no
-// longer present inside the package at all.
+// GenerateModule now first tries a native-owned primitive/control-flow
+// slice mirrored from `toolchain/llvmgen.osty` and falls back to the
+// legacy IR -> AST bridge only for shapes still outside that slice
+// (see ir_module.go). The bridge remains an implementation detail that
+// the public API does not expose — callers neither construct nor
+// observe the intermediate AST. Follow-on work will keep growing the
+// native path until the fallback disappears entirely.
 //
 // The active GC implementation path paired with this lowering lives
 // in `internal/backend/runtime/osty_runtime.c`.

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2451,7 +2451,7 @@ func (g *generator) emitListExprWithHint(expr *ast.ListExpr, hintedElemTyp strin
 		emittedElems = append(emittedElems, g.protectManagedTemporary("list.elem", v))
 	}
 	if elemTyp == "" {
-		return value{}, unsupported("expression", "empty list literal requires an explicit List<T> type")
+		return value{}, unsupportedf("expression", "empty list literal %s requires an explicit List<T> type", exprPosLabel(expr))
 	}
 	useAggregateABI := g.usesAggregateListABI(elemTyp)
 	g.declareRuntimeSymbol(listRuntimeNewSymbol(), "ptr", nil)

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -13,12 +13,14 @@ import (
 // It consumes the backend-neutral IR (internal/ir) and emits textual
 // LLVM IR.
 //
-// The implementation currently reifies the module back into a legacy
-// AST shape through legacyFileFromModule and then hands off to the
-// long-standing AST-driven emitter. This is a transitional detail:
-// external callers route through IR only, and the in-package test
-// helper generateFromAST is unexported. Once the emitter is rewritten
-// to consume IR directly, the bridge and the AST helper both go away.
+// The implementation now first projects a primitive/control-flow slice
+// into the native-owned entrypoint mirrored from toolchain/llvmgen.osty.
+// Remaining shapes still reify the module back into a legacy AST shape
+// through legacyFileFromModule and then hand off to the long-standing
+// AST-driven emitter. This is a transitional detail: external callers
+// route through IR only, and the in-package test helper generateFromAST
+// is unexported. Once the emitter consumes IR directly end-to-end, the
+// fallback bridge and the AST helper both go away.
 func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	if mod == nil {
 		return nil, unsupported("source-layout", "nil module")
@@ -28,6 +30,11 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 	}
 	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
 		return nil, &UnsupportedError{Diagnostic: diag}
+	}
+	if out, ok, err := tryNativeOwnedModule(mod, opts); err != nil {
+		return nil, err
+	} else if ok {
+		return finalizeLegacyFFISurface(out, mod), nil
 	}
 	file, err := legacyFileFromModule(mod)
 	if err != nil {

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -1,0 +1,573 @@
+package llvmgen
+
+import (
+	"strconv"
+	"strings"
+
+	ostyir "github.com/osty/osty/internal/ir"
+)
+
+// tryNativeOwnedModule projects the IR module into the native-owned
+// primitive/control-flow slice mirrored from toolchain/llvmgen.osty.
+// ok=false means "shape not covered yet" and callers should fall back to the
+// legacy IR -> AST bridge.
+func tryNativeOwnedModule(mod *ostyir.Module, opts Options) ([]byte, bool, error) {
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		return nil, false, nil
+	}
+	return []byte(llvmNativeEmitModule(nativeMod)), true, nil
+}
+
+func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bool) {
+	if mod == nil {
+		return nil, false
+	}
+	out := &llvmNativeModule{
+		sourcePath: firstNonEmpty(opts.SourcePath, "<unknown>"),
+		target:     opts.Target,
+		functions:  make([]*llvmNativeFunction, 0, len(mod.Decls)+1),
+	}
+	hasMain := false
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case nil:
+			continue
+		case *ostyir.UseDecl:
+			if d.IsFFI() {
+				return nil, false
+			}
+		case *ostyir.FnDecl:
+			fn, ok := nativeFunctionFromIR(d)
+			if !ok {
+				return nil, false
+			}
+			if fn.name == "main" {
+				hasMain = true
+			}
+			out.functions = append(out.functions, fn)
+		default:
+			return nil, false
+		}
+	}
+	if len(mod.Script) != 0 {
+		if hasMain {
+			return nil, false
+		}
+		mainBody, ok := nativeBlockFromStmts(mod.Script, "i32")
+		if !ok {
+			return nil, false
+		}
+		out.functions = append(out.functions, &llvmNativeFunction{
+			name:       "main",
+			returnType: "i32",
+			body:       mainBody,
+		})
+	}
+	return out, true
+}
+
+func nativeFunctionFromIR(fn *ostyir.FnDecl) (*llvmNativeFunction, bool) {
+	if fn == nil || len(fn.Generics) != 0 || fn.IsIntrinsic || fn.Body == nil {
+		return nil, false
+	}
+	retType, ok := nativeFunctionReturnType(fn)
+	if !ok {
+		return nil, false
+	}
+	out := &llvmNativeFunction{
+		name:       fn.Name,
+		returnType: retType,
+		params:     make([]*llvmNativeParam, 0, len(fn.Params)),
+	}
+	for _, param := range fn.Params {
+		if param == nil || param.IsDestructured() || param.Default != nil {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(param.Type)
+		if !ok || llvmType == "void" {
+			return nil, false
+		}
+		out.params = append(out.params, &llvmNativeParam{
+			name:     param.Name,
+			llvmType: llvmType,
+		})
+	}
+	body, ok := nativeBlockFromIR(fn.Body, retType)
+	if !ok {
+		return nil, false
+	}
+	out.body = body
+	return out, true
+}
+
+func nativeFunctionReturnType(fn *ostyir.FnDecl) (string, bool) {
+	if fn == nil {
+		return "", false
+	}
+	if fn.Name == "main" && len(fn.Params) == 0 && nativeIsUnitType(fn.Return) {
+		return "i32", true
+	}
+	return nativeLLVMTypeFromIR(fn.Return)
+}
+
+func nativeBlockFromIR(block *ostyir.Block, fnReturnType string) (*llvmNativeBlock, bool) {
+	if block == nil {
+		return &llvmNativeBlock{}, true
+	}
+	out := &llvmNativeBlock{
+		stmts: make([]*llvmNativeStmt, 0, len(block.Stmts)),
+	}
+	for _, stmt := range block.Stmts {
+		nativeStmt, ok := nativeStmtFromIR(stmt, fnReturnType)
+		if !ok {
+			return nil, false
+		}
+		if nativeStmt != nil {
+			out.stmts = append(out.stmts, nativeStmt)
+		}
+	}
+	if block.Result != nil {
+		result, ok := nativeExprFromIR(block.Result)
+		if !ok {
+			return nil, false
+		}
+		out.hasResult = true
+		out.result = result
+	}
+	return out, true
+}
+
+func nativeBlockFromStmts(stmts []ostyir.Stmt, fnReturnType string) (*llvmNativeBlock, bool) {
+	out := &llvmNativeBlock{
+		stmts: make([]*llvmNativeStmt, 0, len(stmts)),
+	}
+	for _, stmt := range stmts {
+		nativeStmt, ok := nativeStmtFromIR(stmt, fnReturnType)
+		if !ok {
+			return nil, false
+		}
+		if nativeStmt != nil {
+			out.stmts = append(out.stmts, nativeStmt)
+		}
+	}
+	return out, true
+}
+
+func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, bool) {
+	switch s := stmt.(type) {
+	case nil:
+		return nil, true
+	case *ostyir.LetStmt:
+		if s.Pattern != nil || s.Value == nil {
+			return nil, false
+		}
+		value, ok := nativeExprFromIR(s.Value)
+		if !ok {
+			return nil, false
+		}
+		kind := llvmNativeStmtLet
+		if s.Mut {
+			kind = llvmNativeStmtMutLet
+		}
+		return &llvmNativeStmt{
+			kind:       kind,
+			name:       s.Name,
+			childExprs: []*llvmNativeExpr{value},
+		}, true
+	case *ostyir.ExprStmt:
+		expr, ok := nativeExprFromIR(s.X)
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeStmt{
+			kind:       llvmNativeStmtExpr,
+			childExprs: []*llvmNativeExpr{expr},
+		}, true
+	case *ostyir.AssignStmt:
+		if len(s.Targets) != 1 {
+			return nil, false
+		}
+		target, ok := s.Targets[0].(*ostyir.Ident)
+		if !ok {
+			return nil, false
+		}
+		value, ok := nativeExprFromIR(s.Value)
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeStmt{
+			kind:       llvmNativeStmtAssign,
+			name:       target.Name,
+			op:         nativeAssignOpString(s.Op),
+			childExprs: []*llvmNativeExpr{value},
+		}, true
+	case *ostyir.ReturnStmt:
+		out := &llvmNativeStmt{
+			kind:     llvmNativeStmtReturn,
+			llvmType: fnReturnType,
+		}
+		if s.Value != nil {
+			value, ok := nativeExprFromIR(s.Value)
+			if !ok {
+				return nil, false
+			}
+			out.childExprs = []*llvmNativeExpr{value}
+		}
+		return out, true
+	case *ostyir.IfStmt:
+		cond, ok := nativeExprFromIR(s.Cond)
+		if !ok {
+			return nil, false
+		}
+		thenBlock, ok := nativeBlockFromIR(s.Then, fnReturnType)
+		if !ok {
+			return nil, false
+		}
+		out := &llvmNativeStmt{
+			kind:        llvmNativeStmtIf,
+			childExprs:  []*llvmNativeExpr{cond},
+			childBlocks: []*llvmNativeBlock{thenBlock},
+		}
+		if s.Else != nil {
+			elseBlock, ok := nativeBlockFromIR(s.Else, fnReturnType)
+			if !ok {
+				return nil, false
+			}
+			out.childBlocks = append(out.childBlocks, elseBlock)
+		}
+		return out, true
+	case *ostyir.ForStmt:
+		switch s.Kind {
+		case ostyir.ForWhile:
+			cond, ok := nativeExprFromIR(s.Cond)
+			if !ok {
+				return nil, false
+			}
+			body, ok := nativeBlockFromIR(s.Body, fnReturnType)
+			if !ok {
+				return nil, false
+			}
+			return &llvmNativeStmt{
+				kind:        llvmNativeStmtWhile,
+				childExprs:  []*llvmNativeExpr{cond},
+				childBlocks: []*llvmNativeBlock{body},
+			}, true
+		case ostyir.ForRange:
+			if s.IsDestructured() || s.Var == "" {
+				return nil, false
+			}
+			start, ok := nativeExprFromIR(s.Start)
+			if !ok {
+				return nil, false
+			}
+			end, ok := nativeExprFromIR(s.End)
+			if !ok {
+				return nil, false
+			}
+			body, ok := nativeBlockFromIR(s.Body, fnReturnType)
+			if !ok {
+				return nil, false
+			}
+			return &llvmNativeStmt{
+				kind:        llvmNativeStmtRange,
+				name:        s.Var,
+				inclusive:   s.Inclusive,
+				childExprs:  []*llvmNativeExpr{start, end},
+				childBlocks: []*llvmNativeBlock{body},
+			}, true
+		default:
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
+}
+
+func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
+	switch e := expr.(type) {
+	case nil:
+		return nil, false
+	case *ostyir.IntLit:
+		text, ok := normalizeNativeIntText(e.Text)
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: llvmType, text: text}, true
+	case *ostyir.FloatLit:
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:     llvmNativeExprFloat,
+			llvmType: llvmType,
+			text:     strings.ReplaceAll(e.Text, "_", ""),
+		}, true
+	case *ostyir.BoolLit:
+		return &llvmNativeExpr{kind: llvmNativeExprBool, llvmType: "i1", boolValue: e.Value}, true
+	case *ostyir.StringLit:
+		text, ok := nativePlainStringText(e)
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{kind: llvmNativeExprString, llvmType: "ptr", text: text}, true
+	case *ostyir.Ident:
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: llvmType, name: e.Name}, true
+	case *ostyir.UnaryExpr:
+		inner, ok := nativeExprFromIR(e.X)
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprUnary,
+			llvmType:   llvmType,
+			op:         nativeUnaryOpString(e.Op),
+			childExprs: []*llvmNativeExpr{inner},
+		}, true
+	case *ostyir.BinaryExpr:
+		left, ok := nativeExprFromIR(e.Left)
+		if !ok {
+			return nil, false
+		}
+		right, ok := nativeExprFromIR(e.Right)
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprBinary,
+			llvmType:   llvmType,
+			op:         nativeBinaryOpString(e.Op),
+			childExprs: []*llvmNativeExpr{left, right},
+		}, true
+	case *ostyir.CallExpr:
+		callee, ok := e.Callee.(*ostyir.Ident)
+		if !ok || len(e.TypeArgs) != 0 {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		out := &llvmNativeExpr{
+			kind:       llvmNativeExprCall,
+			llvmType:   llvmType,
+			name:       callee.Name,
+			childExprs: make([]*llvmNativeExpr, 0, len(e.Args)),
+		}
+		for _, arg := range e.Args {
+			if arg.IsKeyword() {
+				return nil, false
+			}
+			value, ok := nativeExprFromIR(arg.Value)
+			if !ok {
+				return nil, false
+			}
+			out.childExprs = append(out.childExprs, value)
+		}
+		return out, true
+	case *ostyir.IntrinsicCall:
+		if e.Kind != ostyir.IntrinsicPrintln || len(e.Args) != 1 || e.Args[0].IsKeyword() {
+			return nil, false
+		}
+		value, ok := nativeExprFromIR(e.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprPrintln,
+			llvmType:   "void",
+			childExprs: []*llvmNativeExpr{value},
+		}, true
+	case *ostyir.IfExpr:
+		cond, ok := nativeExprFromIR(e.Cond)
+		if !ok {
+			return nil, false
+		}
+		thenBlock, ok := nativeBlockFromIR(e.Then, "")
+		if !ok {
+			return nil, false
+		}
+		elseBlock, ok := nativeBlockFromIR(e.Else, "")
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:        llvmNativeExprIf,
+			llvmType:    llvmType,
+			childExprs:  []*llvmNativeExpr{cond},
+			childBlocks: []*llvmNativeBlock{thenBlock, elseBlock},
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func nativeLLVMTypeFromIR(t ostyir.Type) (string, bool) {
+	switch tt := t.(type) {
+	case nil:
+		return "void", true
+	case *ostyir.PrimType:
+		switch tt.Kind {
+		case ostyir.PrimUnit:
+			return "void", true
+		default:
+			name := legacyPrimTypeName(tt.Kind)
+			if name == "" {
+				return "", false
+			}
+			llvmType := llvmBuiltinType(name)
+			return llvmType, llvmType != ""
+		}
+	default:
+		return "", false
+	}
+}
+
+func nativeIsUnitType(t ostyir.Type) bool {
+	if t == nil {
+		return true
+	}
+	prim, ok := t.(*ostyir.PrimType)
+	return ok && prim.Kind == ostyir.PrimUnit
+}
+
+func nativePlainStringText(lit *ostyir.StringLit) (string, bool) {
+	if lit == nil {
+		return "", false
+	}
+	var b strings.Builder
+	for _, part := range lit.Parts {
+		if !part.IsLit {
+			return "", false
+		}
+		b.WriteString(part.Lit)
+	}
+	return b.String(), true
+}
+
+func normalizeNativeIntText(text string) (string, bool) {
+	raw := strings.ReplaceAll(text, "_", "")
+	base := 10
+	switch {
+	case strings.HasPrefix(raw, "0x") || strings.HasPrefix(raw, "0X"):
+		base, raw = 16, raw[2:]
+	case strings.HasPrefix(raw, "0o") || strings.HasPrefix(raw, "0O"):
+		base, raw = 8, raw[2:]
+	case strings.HasPrefix(raw, "0b") || strings.HasPrefix(raw, "0B"):
+		base, raw = 2, raw[2:]
+	}
+	if raw == "" {
+		return "", false
+	}
+	value, err := strconv.ParseInt(raw, base, 64)
+	if err != nil {
+		return "", false
+	}
+	return strconv.FormatInt(value, 10), true
+}
+
+func nativeUnaryOpString(op ostyir.UnOp) string {
+	switch op {
+	case ostyir.UnNeg:
+		return "-"
+	case ostyir.UnPlus:
+		return "+"
+	case ostyir.UnNot:
+		return "!"
+	default:
+		return ""
+	}
+}
+
+func nativeBinaryOpString(op ostyir.BinOp) string {
+	switch op {
+	case ostyir.BinAdd:
+		return "+"
+	case ostyir.BinSub:
+		return "-"
+	case ostyir.BinMul:
+		return "*"
+	case ostyir.BinDiv:
+		return "/"
+	case ostyir.BinMod:
+		return "%"
+	case ostyir.BinEq:
+		return "=="
+	case ostyir.BinNeq:
+		return "!="
+	case ostyir.BinLt:
+		return "<"
+	case ostyir.BinLeq:
+		return "<="
+	case ostyir.BinGt:
+		return ">"
+	case ostyir.BinGeq:
+		return ">="
+	case ostyir.BinAnd:
+		return "&&"
+	case ostyir.BinOr:
+		return "||"
+	case ostyir.BinBitAnd:
+		return "&"
+	case ostyir.BinBitOr:
+		return "|"
+	case ostyir.BinBitXor:
+		return "^"
+	case ostyir.BinShl:
+		return "<<"
+	case ostyir.BinShr:
+		return ">>"
+	default:
+		return ""
+	}
+}
+
+func nativeAssignOpString(op ostyir.AssignOp) string {
+	switch op {
+	case ostyir.AssignEq:
+		return "="
+	case ostyir.AssignAdd:
+		return "+"
+	case ostyir.AssignSub:
+		return "-"
+	case ostyir.AssignMul:
+		return "*"
+	case ostyir.AssignDiv:
+		return "/"
+	case ostyir.AssignMod:
+		return "%"
+	case ostyir.AssignAnd:
+		return "&"
+	case ostyir.AssignOr:
+		return "|"
+	case ostyir.AssignXor:
+		return "^"
+	case ostyir.AssignShl:
+		return "<<"
+	case ostyir.AssignShr:
+		return ">>"
+	default:
+		return ""
+	}
+}

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -1,0 +1,100 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ostyir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+func lowerNativeEntryModule(t *testing.T, src string) *ostyir.Module {
+	t.Helper()
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ostyir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	if validateErrs := ostyir.Validate(mod); len(validateErrs) != 0 {
+		t.Fatalf("ir.Validate errors: %v", validateErrs)
+	}
+	return mod
+}
+
+func TestNativeOwnedModuleEntryPrimitiveSlice(t *testing.T) {
+	src := `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_slice.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for primitive slice")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"define i64 @pick(i1 %flag)",
+		"phi i64",
+		"for.cond",
+		"call i64 @pick(i1",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryFallsBackForStructs(t *testing.T) {
+	src := `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let pair = Pair { left: 1, right: 2 }
+    println(pair.left)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_script.osty"}
+	if nativeMod, ok := nativeModuleFromIR(mod, opts); ok {
+		t.Fatalf("nativeModuleFromIR unexpectedly accepted struct-bearing module: %#v", nativeMod)
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule fallback failed: %v", err)
+	}
+	if !strings.Contains(string(out), "%Pair = type { i64, i64 }") {
+		t.Fatalf("legacy fallback IR missing struct definition:\n%s", string(out))
+	}
+}

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -1,0 +1,384 @@
+// native_entry_snapshot.go snapshots the native-owned primitive module-entry
+// slice from toolchain/llvmgen.osty into the bootstrap bridge. The Go side
+// projects internal/ir.Module into these LLVM-typed structs, then falls back
+// to the legacy IR -> AST bridge when a shape still sits outside this slice.
+
+package llvmgen
+
+import "strings"
+
+type llvmNativeExprKind int
+
+const (
+	llvmNativeExprInvalid llvmNativeExprKind = iota
+	llvmNativeExprInt
+	llvmNativeExprFloat
+	llvmNativeExprBool
+	llvmNativeExprString
+	llvmNativeExprIdent
+	llvmNativeExprUnary
+	llvmNativeExprBinary
+	llvmNativeExprCall
+	llvmNativeExprPrintln
+	llvmNativeExprIf
+)
+
+type llvmNativeStmtKind int
+
+const (
+	llvmNativeStmtInvalid llvmNativeStmtKind = iota
+	llvmNativeStmtExpr
+	llvmNativeStmtLet
+	llvmNativeStmtMutLet
+	llvmNativeStmtAssign
+	llvmNativeStmtReturn
+	llvmNativeStmtIf
+	llvmNativeStmtWhile
+	llvmNativeStmtRange
+)
+
+type llvmNativeExpr struct {
+	kind        llvmNativeExprKind
+	llvmType    string
+	text        string
+	name        string
+	op          string
+	boolValue   bool
+	inclusive   bool
+	childExprs  []*llvmNativeExpr
+	childBlocks []*llvmNativeBlock
+}
+
+type llvmNativeStmt struct {
+	kind        llvmNativeStmtKind
+	name        string
+	llvmType    string
+	op          string
+	inclusive   bool
+	childExprs  []*llvmNativeExpr
+	childBlocks []*llvmNativeBlock
+}
+
+type llvmNativeBlock struct {
+	stmts     []*llvmNativeStmt
+	hasResult bool
+	result    *llvmNativeExpr
+}
+
+type llvmNativeParam struct {
+	name     string
+	llvmType string
+}
+
+type llvmNativeFunction struct {
+	name       string
+	returnType string
+	params     []*llvmNativeParam
+	body       *llvmNativeBlock
+}
+
+type llvmNativeModule struct {
+	sourcePath string
+	target     string
+	functions  []*llvmNativeFunction
+}
+
+type llvmNativeRenderedFunction struct {
+	definition    string
+	stringGlobals []*LlvmStringGlobal
+	nextStringID  int
+}
+
+type llvmNativeMaybeValue struct {
+	hasValue bool
+	value    *LlvmValue
+}
+
+func llvmNativeEmitModule(mod *llvmNativeModule) string {
+	if mod == nil {
+		return llvmRenderModule("", "", nil)
+	}
+	definitions := make([]string, 0, len(mod.functions))
+	stringGlobals := make([]*LlvmStringGlobal, 0)
+	nextStringID := 0
+	for _, fn := range mod.functions {
+		rendered := llvmNativeEmitFunction(fn, nextStringID)
+		nextStringID = rendered.nextStringID
+		definitions = append(definitions, rendered.definition)
+		stringGlobals = append(stringGlobals, rendered.stringGlobals...)
+	}
+	return llvmRenderModuleWithGlobals(mod.sourcePath, mod.target, stringGlobals, definitions)
+}
+
+func llvmNativeEmitFunction(fn *llvmNativeFunction, startStringID int) llvmNativeRenderedFunction {
+	emitter := llvmEmitter()
+	emitter.stringId = startStringID
+	params := make([]*LlvmParam, 0, len(fn.params))
+	for _, param := range fn.params {
+		params = append(params, llvmParam(param.name, param.llvmType))
+		llvmBind(emitter, param.name, &LlvmValue{
+			typ:     param.llvmType,
+			name:    "%" + param.name,
+			pointer: false,
+		})
+	}
+	block := llvmNativeEmitBlock(emitter, fn.body)
+	if !llvmNativeBodyHasTerminator(emitter.body) {
+		switch {
+		case block.hasValue && fn.returnType != "" && fn.returnType != "void":
+			llvmReturn(emitter, block.value)
+		case fn.returnType == "i32" && fn.name == "main":
+			llvmReturnI32Zero(emitter)
+		case fn.returnType == "" || fn.returnType == "void":
+			emitter.body = append(emitter.body, "  ret void")
+		default:
+			llvmReturn(emitter, llvmNativeZeroValue(fn.returnType))
+		}
+	}
+	retType := fn.returnType
+	if retType == "" {
+		retType = "void"
+	}
+	return llvmNativeRenderedFunction{
+		definition:    llvmRenderFunction(retType, fn.name, params, emitter.body),
+		stringGlobals: append([]*LlvmStringGlobal(nil), emitter.stringGlobals...),
+		nextStringID:  emitter.stringId,
+	}
+}
+
+func llvmNativeEmitBlock(emitter *LlvmEmitter, block *llvmNativeBlock) llvmNativeMaybeValue {
+	if block == nil {
+		return llvmNativeMaybeValue{}
+	}
+	for _, stmt := range block.stmts {
+		llvmNativeEmitStmt(emitter, stmt)
+	}
+	if block.hasResult && block.result != nil {
+		return llvmNativeMaybeValue{hasValue: true, value: llvmNativeEvalExpr(emitter, block.result)}
+	}
+	return llvmNativeMaybeValue{}
+}
+
+func llvmNativeEmitStmt(emitter *LlvmEmitter, stmt *llvmNativeStmt) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.kind {
+	case llvmNativeStmtExpr:
+		if len(stmt.childExprs) > 0 {
+			_ = llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+		}
+	case llvmNativeStmtLet:
+		if len(stmt.childExprs) > 0 {
+			llvmImmutableLet(emitter, stmt.name, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+		}
+	case llvmNativeStmtMutLet:
+		if len(stmt.childExprs) > 0 {
+			llvmMutableLet(emitter, stmt.name, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+		}
+	case llvmNativeStmtAssign:
+		if len(stmt.childExprs) > 0 {
+			_ = llvmAssign(emitter, stmt.name, llvmNativeAssignValue(emitter, stmt))
+		}
+	case llvmNativeStmtReturn:
+		if len(stmt.childExprs) > 0 {
+			llvmReturn(emitter, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+		} else if stmt.llvmType == "i32" {
+			llvmReturnI32Zero(emitter)
+		} else {
+			emitter.body = append(emitter.body, "  ret void")
+		}
+	case llvmNativeStmtIf:
+		if len(stmt.childExprs) == 0 || len(stmt.childBlocks) == 0 {
+			return
+		}
+		labels := llvmIfStart(emitter, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+		_ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
+		llvmIfElse(emitter, labels)
+		if len(stmt.childBlocks) > 1 {
+			_ = llvmNativeEmitBlock(emitter, stmt.childBlocks[1])
+		}
+		llvmIfEnd(emitter, labels)
+	case llvmNativeStmtWhile:
+		if len(stmt.childExprs) == 0 || len(stmt.childBlocks) == 0 {
+			return
+		}
+		condLabel := llvmNextLabel(emitter, "for.cond")
+		bodyLabel := llvmNextLabel(emitter, "for.body")
+		endLabel := llvmNextLabel(emitter, "for.end")
+		emitter.body = append(emitter.body, "  br label %"+condLabel)
+		emitter.body = append(emitter.body, condLabel+":")
+		cond := llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+		emitter.body = append(emitter.body, "  br i1 "+cond.name+", label %"+bodyLabel+", label %"+endLabel)
+		emitter.body = append(emitter.body, bodyLabel+":")
+		_ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
+		emitter.body = append(emitter.body, "  br label %"+condLabel)
+		emitter.body = append(emitter.body, endLabel+":")
+	case llvmNativeStmtRange:
+		if len(stmt.childExprs) < 2 || len(stmt.childBlocks) == 0 {
+			return
+		}
+		start := llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+		end := llvmNativeEvalExpr(emitter, stmt.childExprs[1])
+		var loop *LlvmRangeLoop
+		if stmt.inclusive {
+			loop = llvmInclusiveRangeStart(emitter, stmt.name, start, end)
+		} else {
+			loop = llvmRangeStart(emitter, stmt.name, start, end, false)
+		}
+		_ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
+		llvmRangeEnd(emitter, loop)
+	}
+}
+
+func llvmNativeAssignValue(emitter *LlvmEmitter, stmt *llvmNativeStmt) *LlvmValue {
+	value := llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+	if stmt.op == "" || stmt.op == "=" {
+		return value
+	}
+	current := llvmIdent(emitter, stmt.name)
+	return llvmNativeApplyBinary(emitter, stmt.op, current, value, current.typ)
+}
+
+func llvmNativeEvalExpr(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if expr == nil {
+		return llvmNativeZeroValue("i64")
+	}
+	switch expr.kind {
+	case llvmNativeExprInt:
+		return &LlvmValue{typ: expr.llvmType, name: expr.text}
+	case llvmNativeExprFloat:
+		return &LlvmValue{typ: expr.llvmType, name: expr.text}
+	case llvmNativeExprBool:
+		name := "false"
+		if expr.boolValue {
+			name = "true"
+		}
+		return &LlvmValue{typ: expr.llvmType, name: name}
+	case llvmNativeExprString:
+		return llvmStringLiteral(emitter, expr.text)
+	case llvmNativeExprIdent:
+		return llvmIdent(emitter, expr.name)
+	case llvmNativeExprUnary:
+		return llvmNativeEvalUnary(emitter, expr)
+	case llvmNativeExprBinary:
+		return llvmNativeEvalBinary(emitter, expr)
+	case llvmNativeExprCall:
+		return llvmNativeEvalCall(emitter, expr)
+	case llvmNativeExprPrintln:
+		return llvmNativeEvalPrintln(emitter, expr)
+	case llvmNativeExprIf:
+		return llvmNativeEvalIfExpr(emitter, expr)
+	default:
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+}
+
+func llvmNativeEvalUnary(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) == 0 {
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+	value := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	switch expr.op {
+	case "+":
+		return value
+	case "!":
+		return llvmNotI1(emitter, value)
+	default:
+		if expr.llvmType == "double" {
+			return llvmBinaryF64(emitter, llvmFloatBinaryInstruction("-"), llvmNativeZeroValue("double"), value)
+		}
+		return llvmBinaryI64(emitter, llvmIntBinaryInstruction("-"), llvmNativeZeroValue(expr.llvmType), value)
+	}
+}
+
+func llvmNativeEvalBinary(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) < 2 {
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+	left := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	right := llvmNativeEvalExpr(emitter, expr.childExprs[1])
+	return llvmNativeApplyBinary(emitter, expr.op, left, right, expr.llvmType)
+}
+
+func llvmNativeApplyBinary(emitter *LlvmEmitter, op string, left, right *LlvmValue, resultType string) *LlvmValue {
+	switch op {
+	case "&&", "||":
+		return llvmLogicalI1(emitter, llvmLogicalInstruction(op), left, right)
+	}
+	switch resultType {
+	case "i1":
+		if left.typ == "double" || right.typ == "double" {
+			return llvmCompareF64(emitter, llvmFloatComparePredicate(op), left, right)
+		}
+		return llvmCompare(emitter, llvmIntComparePredicate(op), left, right)
+	case "double":
+		return llvmBinaryF64(emitter, llvmFloatBinaryInstruction(op), left, right)
+	default:
+		return llvmBinaryI64(emitter, llvmIntBinaryInstruction(op), left, right)
+	}
+}
+
+func llvmNativeEvalCall(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	args := make([]*LlvmValue, 0, len(expr.childExprs))
+	for _, arg := range expr.childExprs {
+		args = append(args, llvmNativeEvalExpr(emitter, arg))
+	}
+	if expr.llvmType == "" || expr.llvmType == "void" {
+		llvmCallVoid(emitter, expr.name, args)
+		return llvmNativeZeroValue("i64")
+	}
+	return llvmCall(emitter, expr.llvmType, expr.name, args)
+}
+
+func llvmNativeEvalPrintln(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) == 0 {
+		return llvmNativeZeroValue("i64")
+	}
+	value := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	switch value.typ {
+	case "double":
+		llvmPrintlnF64(emitter, value)
+	case "ptr":
+		llvmPrintlnString(emitter, value)
+	default:
+		llvmPrintlnI64(emitter, value)
+	}
+	return llvmNativeZeroValue("i64")
+}
+
+func llvmNativeEvalIfExpr(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) == 0 || len(expr.childBlocks) < 2 {
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+	labels := llvmIfExprStart(emitter, llvmNativeEvalExpr(emitter, expr.childExprs[0]))
+	thenValue := llvmNativeBlockValue(emitter, expr.childBlocks[0], expr.llvmType)
+	llvmIfExprElse(emitter, labels)
+	elseValue := llvmNativeBlockValue(emitter, expr.childBlocks[1], expr.llvmType)
+	return llvmIfExprEnd(emitter, expr.llvmType, thenValue, elseValue, labels)
+}
+
+func llvmNativeBlockValue(emitter *LlvmEmitter, block *llvmNativeBlock, llvmType string) *LlvmValue {
+	value := llvmNativeEmitBlock(emitter, block)
+	if value.hasValue {
+		return value.value
+	}
+	return llvmNativeZeroValue(llvmType)
+}
+
+func llvmNativeZeroValue(llvmType string) *LlvmValue {
+	switch llvmType {
+	case "", "void":
+		return llvmI64("0")
+	default:
+		return &LlvmValue{typ: llvmType, name: llvmZeroLiteral(llvmType)}
+	}
+}
+
+func llvmNativeBodyHasTerminator(body []string) bool {
+	if len(body) == 0 {
+		return false
+	}
+	last := body[len(body)-1]
+	return strings.HasPrefix(last, "  ret ") || strings.HasPrefix(last, "  br ")
+}

--- a/internal/llvmgen/runtime_ffi_test.go
+++ b/internal/llvmgen/runtime_ffi_test.go
@@ -534,6 +534,31 @@ func TestGenerateManagedListPushStmtUsesSafepoint(t *testing.T) {
 	}
 }
 
+func TestGenerateNestedListPushStmtHintsEmptyListArg(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn seed(mut preds: List<List<Int>>) {
+    preds.push([])
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "core",
+		SourcePath:  "/tmp/list_push_empty_nested.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"call ptr @osty_rt_list_new()",
+		"call void @osty_rt_list_push_ptr(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestGenerateForInOverListStringUsesRuntimeABI(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn visit(items: List<String>) {
     for item in items {

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2297,6 +2297,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if base.typ != "ptr" || elemTyp == "" {
 		return true, unsupportedf("type-system", "list receiver type %s", base.typ)
 	}
+	elemSourceType, _ := g.iterableElemSourceType(field.X)
 	base = g.protectManagedTemporary("list.base", base)
 	baseValue, err := g.loadIfPointer(base)
 	if err != nil {
@@ -2345,7 +2346,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 		if err != nil {
 			return true, err
 		}
-		arg, err := g.emitExpr(call.Args[1].Value)
+		arg, err := g.emitExprWithHintAndSourceType(call.Args[1].Value, elemSourceType, "", false, "", "", false, "", false)
 		if err != nil {
 			return true, err
 		}
@@ -2376,7 +2377,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
 		return true, unsupported("call", "list.push requires one positional argument")
 	}
-	arg, err := g.emitExpr(call.Args[0].Value)
+	arg, err := g.emitExprWithHintAndSourceType(call.Args[0].Value, elemSourceType, "", false, "", "", false, "", false)
 	if err != nil {
 		return true, err
 	}

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1107,6 +1107,477 @@ pub fn llvmRenderFunction(
     llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")
 }
 
+/// Primitive/native-owned module-entry slice. The host bridge projects the
+/// backend-neutral IR into this LLVM-typed surface first; unsupported shapes
+/// still fall back to the legacy IR -> AST bridge in Go.
+pub enum LlvmNativeExprKind {
+    LlvmNativeExprInvalid,
+    LlvmNativeExprInt,
+    LlvmNativeExprFloat,
+    LlvmNativeExprBool,
+    LlvmNativeExprString,
+    LlvmNativeExprIdent,
+    LlvmNativeExprUnary,
+    LlvmNativeExprBinary,
+    LlvmNativeExprCall,
+    LlvmNativeExprPrintln,
+    LlvmNativeExprIf,
+}
+
+pub enum LlvmNativeStmtKind {
+    LlvmNativeStmtInvalid,
+    LlvmNativeStmtExpr,
+    LlvmNativeStmtLet,
+    LlvmNativeStmtMutLet,
+    LlvmNativeStmtAssign,
+    LlvmNativeStmtReturn,
+    LlvmNativeStmtIf,
+    LlvmNativeStmtWhile,
+    LlvmNativeStmtRange,
+}
+
+pub struct LlvmNativeExpr {
+    pub kind: LlvmNativeExprKind,
+    pub llvmType: String,
+    pub text: String,
+    pub name: String,
+    pub op: String,
+    pub boolValue: Bool,
+    pub inclusive: Bool,
+    pub childExprs: List<LlvmNativeExpr>,
+    pub childBlocks: List<LlvmNativeBlock>,
+}
+
+pub struct LlvmNativeStmt {
+    pub kind: LlvmNativeStmtKind,
+    pub name: String,
+    pub llvmType: String,
+    pub op: String,
+    pub inclusive: Bool,
+    pub childExprs: List<LlvmNativeExpr>,
+    pub childBlocks: List<LlvmNativeBlock>,
+}
+
+pub struct LlvmNativeBlock {
+    pub stmts: List<LlvmNativeStmt>,
+    pub hasResult: Bool,
+    pub result: LlvmNativeExpr,
+}
+
+pub struct LlvmNativeParam {
+    pub name: String,
+    pub llvmType: String,
+}
+
+pub struct LlvmNativeFunction {
+    pub name: String,
+    pub returnType: String,
+    pub params: List<LlvmNativeParam>,
+    pub body: LlvmNativeBlock,
+}
+
+pub struct LlvmNativeModule {
+    pub sourcePath: String,
+    pub target: String,
+    pub functions: List<LlvmNativeFunction>,
+}
+
+pub struct LlvmNativeRenderedFunction {
+    pub definition: String,
+    pub stringGlobals: List<LlvmStringGlobal>,
+    pub nextStringId: Int,
+}
+
+pub struct LlvmNativeMaybeValue {
+    pub hasValue: Bool,
+    pub value: LlvmValue,
+}
+
+pub fn llvmNativeEmitModule(module: LlvmNativeModule) -> String {
+    let mut definitions: List<String> = []
+    let globalsSeed = llvmEmitter()
+    let mut stringGlobals = globalsSeed.stringGlobals
+    let mut nextStringId = 0
+    for function in module.functions {
+        let rendered = llvmNativeEmitFunction(function, nextStringId)
+        nextStringId = rendered.nextStringId
+        definitions.push(rendered.definition)
+        for global in rendered.stringGlobals {
+            stringGlobals.push(global)
+        }
+    }
+    llvmRenderModuleWithGlobals(module.sourcePath, module.target, stringGlobals, definitions)
+}
+
+pub fn llvmNativeEmitFunction(
+    function: LlvmNativeFunction,
+    startStringId: Int,
+) -> LlvmNativeRenderedFunction {
+    let emitter = llvmEmitter()
+    emitter.stringId = startStringId
+    if function.params.len() == 0 {
+        let block = llvmNativeEmitBlock(emitter, function.body)
+        if !(llvmNativeBodyHasTerminator(emitter.body)) {
+            if block.hasValue && function.returnType != "" && function.returnType != "void" {
+                llvmReturn(emitter, block.value)
+            } else if function.returnType == "i32" && function.name == "main" {
+                llvmReturnI32Zero(emitter)
+            } else if function.returnType == "" || function.returnType == "void" {
+                emitter.body.push("  ret void")
+            } else {
+                llvmReturn(emitter, llvmNativeZeroValue(function.returnType))
+            }
+        }
+        return LlvmNativeRenderedFunction {
+            definition: llvmRenderFunction(
+                if function.returnType == "" { "void" } else { function.returnType },
+                function.name,
+                [],
+                emitter.body,
+            ),
+            stringGlobals: emitter.stringGlobals,
+            nextStringId: emitter.stringId,
+        }
+    }
+    let first = function.params[0]
+    let mut params = [llvmParam(first.name, first.llvmType)]
+    llvmBind(
+        emitter,
+        first.name,
+        LlvmValue {
+            typ: first.llvmType,
+            name: "%{first.name}",
+            pointer: false,
+        },
+    )
+    for i in 1..function.params.len() {
+        let param = function.params[i]
+        params.push(llvmParam(param.name, param.llvmType))
+        llvmBind(
+            emitter,
+            param.name,
+            LlvmValue {
+                typ: param.llvmType,
+                name: "%{param.name}",
+                pointer: false,
+            },
+        )
+    }
+    let block = llvmNativeEmitBlock(emitter, function.body)
+    if !(llvmNativeBodyHasTerminator(emitter.body)) {
+        if block.hasValue && function.returnType != "" && function.returnType != "void" {
+            llvmReturn(emitter, block.value)
+        } else if function.returnType == "i32" && function.name == "main" {
+            llvmReturnI32Zero(emitter)
+        } else if function.returnType == "" || function.returnType == "void" {
+            emitter.body.push("  ret void")
+        } else {
+            llvmReturn(emitter, llvmNativeZeroValue(function.returnType))
+        }
+    }
+    return LlvmNativeRenderedFunction {
+        definition: llvmRenderFunction(
+            if function.returnType == "" { "void" } else { function.returnType },
+            function.name,
+            params,
+            emitter.body,
+        ),
+        stringGlobals: emitter.stringGlobals,
+        nextStringId: emitter.stringId,
+    }
+}
+
+fn llvmNativeEmitBlock(
+    emitter: LlvmEmitter,
+    block: LlvmNativeBlock,
+) -> LlvmNativeMaybeValue {
+    for stmt in block.stmts {
+        llvmNativeEmitStmt(emitter, stmt)
+    }
+    if block.hasResult {
+        return LlvmNativeMaybeValue {
+            hasValue: true,
+            value: llvmNativeEvalExpr(emitter, block.result),
+        }
+    }
+    LlvmNativeMaybeValue {
+        hasValue: false,
+        value: llvmI64("0"),
+    }
+}
+
+fn llvmNativeEmitStmt(emitter: LlvmEmitter, stmt: LlvmNativeStmt) {
+    match stmt.kind {
+        LlvmNativeStmtExpr -> {
+            if stmt.childExprs.len() > 0 {
+                let _ = llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+            }
+        },
+        LlvmNativeStmtLet -> {
+            if stmt.childExprs.len() > 0 {
+                llvmImmutableLet(emitter, stmt.name, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+            }
+        },
+        LlvmNativeStmtMutLet -> {
+            if stmt.childExprs.len() > 0 {
+                llvmMutableLet(emitter, stmt.name, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+            }
+        },
+        LlvmNativeStmtAssign -> {
+            if stmt.childExprs.len() > 0 {
+                let value = llvmNativeAssignValue(emitter, stmt)
+                let _ = llvmAssign(emitter, stmt.name, value)
+            }
+        },
+        LlvmNativeStmtReturn -> {
+            if stmt.childExprs.len() > 0 {
+                llvmReturn(emitter, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+            } else if stmt.llvmType == "i32" {
+                llvmReturnI32Zero(emitter)
+            } else {
+                emitter.body.push("  ret void")
+            }
+        },
+        LlvmNativeStmtIf -> {
+            if stmt.childExprs.len() == 0 || stmt.childBlocks.len() == 0 {
+                return
+            }
+            let labels = llvmIfStart(emitter, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
+            let _ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
+            llvmIfElse(emitter, labels)
+            if stmt.childBlocks.len() > 1 {
+                let _ = llvmNativeEmitBlock(emitter, stmt.childBlocks[1])
+            }
+            llvmIfEnd(emitter, labels)
+        },
+        LlvmNativeStmtWhile -> {
+            if stmt.childExprs.len() == 0 || stmt.childBlocks.len() == 0 {
+                return
+            }
+            let condLabel = llvmNextLabel(emitter, "for.cond")
+            let bodyLabel = llvmNextLabel(emitter, "for.body")
+            let endLabel = llvmNextLabel(emitter, "for.end")
+            emitter.body.push("  br label %{condLabel}")
+            emitter.body.push("{condLabel}:")
+            let cond = llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+            emitter.body.push("  br i1 {cond.name}, label %{bodyLabel}, label %{endLabel}")
+            emitter.body.push("{bodyLabel}:")
+            let _ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
+            emitter.body.push("  br label %{condLabel}")
+            emitter.body.push("{endLabel}:")
+        },
+        LlvmNativeStmtRange -> {
+            if stmt.childExprs.len() < 2 || stmt.childBlocks.len() == 0 {
+                return
+            }
+            let start = llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+            let end = llvmNativeEvalExpr(emitter, stmt.childExprs[1])
+            let loop = if stmt.inclusive {
+                llvmInclusiveRangeStart(emitter, stmt.name, start, end)
+            } else {
+                llvmRangeStart(emitter, stmt.name, start, end, false)
+            }
+            let _ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
+            llvmRangeEnd(emitter, loop)
+        },
+        _ -> {},
+    }
+}
+
+fn llvmNativeAssignValue(emitter: LlvmEmitter, stmt: LlvmNativeStmt) -> LlvmValue {
+    let value = llvmNativeEvalExpr(emitter, stmt.childExprs[0])
+    if stmt.op == "" || stmt.op == "=" {
+        return value
+    }
+    let current = llvmIdent(emitter, stmt.name)
+    llvmNativeApplyBinary(emitter, stmt.op, current, value, current.typ)
+}
+
+fn llvmNativeEvalExpr(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    match expr.kind {
+        LlvmNativeExprInt -> LlvmValue { typ: expr.llvmType, name: expr.text, pointer: false },
+        LlvmNativeExprFloat -> LlvmValue { typ: expr.llvmType, name: expr.text, pointer: false },
+        LlvmNativeExprBool -> LlvmValue {
+            typ: expr.llvmType,
+            name: if expr.boolValue { "true" } else { "false" },
+            pointer: false,
+        },
+        LlvmNativeExprString -> llvmStringLiteral(emitter, expr.text),
+        LlvmNativeExprIdent -> llvmIdent(emitter, expr.name),
+        LlvmNativeExprUnary -> llvmNativeEvalUnary(emitter, expr),
+        LlvmNativeExprBinary -> llvmNativeEvalBinary(emitter, expr),
+        LlvmNativeExprCall -> llvmNativeEvalCall(emitter, expr),
+        LlvmNativeExprPrintln -> llvmNativeEvalPrintln(emitter, expr),
+        LlvmNativeExprIf -> llvmNativeEvalIfExpr(emitter, expr),
+        _ -> llvmNativeZeroValue(expr.llvmType),
+    }
+}
+
+fn llvmNativeEvalUnary(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let value = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    if expr.op == "+" {
+        return value
+    }
+    if expr.op == "!" {
+        return llvmNotI1(emitter, value)
+    }
+    if expr.llvmType == "double" {
+        return llvmBinaryF64(
+            emitter,
+            llvmFloatBinaryInstruction("-"),
+            llvmNativeZeroValue("double"),
+            value,
+        )
+    }
+    llvmBinaryI64(
+        emitter,
+        llvmIntBinaryInstruction("-"),
+        llvmNativeZeroValue(expr.llvmType),
+        value,
+    )
+}
+
+fn llvmNativeEvalBinary(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() < 2 {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let left = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    let right = llvmNativeEvalExpr(emitter, expr.childExprs[1])
+    llvmNativeApplyBinary(emitter, expr.op, left, right, expr.llvmType)
+}
+
+fn llvmNativeApplyBinary(
+    emitter: LlvmEmitter,
+    op: String,
+    left: LlvmValue,
+    right: LlvmValue,
+    resultType: String,
+) -> LlvmValue {
+    if op == "&&" || op == "||" {
+        return llvmLogicalI1(emitter, llvmLogicalInstruction(op), left, right)
+    }
+    if resultType == "i1" {
+        if left.typ == "double" || right.typ == "double" {
+            return llvmCompareF64(emitter, llvmFloatComparePredicate(op), left, right)
+        }
+        return llvmCompare(emitter, llvmIntComparePredicate(op), left, right)
+    }
+    if resultType == "double" {
+        return llvmBinaryF64(emitter, llvmFloatBinaryInstruction(op), left, right)
+    }
+    llvmBinaryI64(emitter, llvmIntBinaryInstruction(op), left, right)
+}
+
+fn llvmNativeEvalCall(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        if expr.llvmType == "" || expr.llvmType == "void" {
+            llvmCallVoid(emitter, expr.name, [])
+            return LlvmValue { typ: "void", name: "", pointer: false }
+        }
+        return llvmCall(emitter, expr.llvmType, expr.name, [])
+    }
+    let mut args = [llvmNativeEvalExpr(emitter, expr.childExprs[0])]
+    for i in 1..expr.childExprs.len() {
+        args.push(llvmNativeEvalExpr(emitter, expr.childExprs[i]))
+    }
+    if expr.llvmType == "" || expr.llvmType == "void" {
+        llvmCallVoid(emitter, expr.name, args)
+        return LlvmValue { typ: "void", name: "", pointer: false }
+    }
+    llvmCall(emitter, expr.llvmType, expr.name, args)
+}
+
+fn llvmNativeEvalPrintln(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        return LlvmValue { typ: "void", name: "", pointer: false }
+    }
+    let value = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    if value.typ == "double" {
+        llvmPrintlnF64(emitter, value)
+    } else if value.typ == "ptr" {
+        llvmPrintlnString(emitter, value)
+    } else {
+        llvmPrintlnI64(emitter, value)
+    }
+    LlvmValue { typ: "void", name: "", pointer: false }
+}
+
+fn llvmNativeEvalIfExpr(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 || expr.childBlocks.len() < 2 {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let labels = llvmIfExprStart(emitter, llvmNativeEvalExpr(emitter, expr.childExprs[0]))
+    let thenValue = llvmNativeBlockValue(emitter, expr.childBlocks[0], expr.llvmType)
+    llvmIfExprElse(emitter, labels)
+    let elseValue = llvmNativeBlockValue(emitter, expr.childBlocks[1], expr.llvmType)
+    llvmIfExprEnd(emitter, expr.llvmType, thenValue, elseValue, labels)
+}
+
+fn llvmNativeBlockValue(
+    emitter: LlvmEmitter,
+    block: LlvmNativeBlock,
+    llvmType: String,
+) -> LlvmValue {
+    let value = llvmNativeEmitBlock(emitter, block)
+    if value.hasValue {
+        return value.value
+    }
+    llvmNativeZeroValue(llvmType)
+}
+
+fn llvmNativeZeroValue(llvmType: String) -> LlvmValue {
+    LlvmValue { typ: llvmType, name: llvmZeroLiteral(llvmType), pointer: false }
+}
+
+fn llvmNativeBodyHasTerminator(body: List<String>) -> Bool {
+    if body.len() == 0 {
+        return false
+    }
+    let last = body[body.len() - 1]
+    llvmStrings.hasPrefix(last, "  ret ") || llvmStrings.hasPrefix(last, "  br ")
+}
+
+/// Phase A4 fn-value thunk template. Renders the IR body of a private
+/// delegating function that accepts `ptr %env` as its implicit first
+/// argument, discards the env, and forwards the remaining args to
+/// `realSymbol`. The resulting IR is what the legacy emitter caches
+/// in `g.fnValueThunkDefs` so top-level fn references can be wrapped
+/// in a fn-value-compatible ABI (`{ ptr fn, ... }` env layout) without
+/// touching the defining symbol. An empty `retType` is normalised to
+/// `void` so call sites may forward the checker's unit return type
+/// verbatim.
+pub fn llvmRenderClosureThunk(
+    retType: String,
+    thunkSymbol: String,
+    paramTypes: List<String>,
+    realSymbol: String,
+) -> String {
+    let ret = if retType == "" { "void" } else { retType }
+    let mut paramParts: List<String> = ["ptr %env"]
+    let mut argParts: List<String> = []
+    for i in 0..paramTypes.len() {
+        let pt = paramTypes[i]
+        paramParts.push("{pt} %arg{i}")
+        argParts.push("{pt} %arg{i}")
+    }
+    let params = llvmStrings.join(paramParts, ", ")
+    let args = llvmStrings.join(argParts, ", ")
+    let mut lines: List<String> = []
+    lines.push("define private {ret} @{thunkSymbol}({params}) \{")
+    lines.push("entry:")
+    if ret == "void" {
+        lines.push("  call void @{realSymbol}({args})")
+        lines.push("  ret void")
+    } else {
+        lines.push("  %__ret = call {ret} @{realSymbol}({args})")
+        lines.push("  ret {ret} %__ret")
+    }
+    lines.push("\}")
+    llvmStrings.join([llvmStrings.join(lines, "\n"), "\n"], "")
+}
 pub fn llvmNeedsObjectArtifact(emit: String) -> Bool {
     emit == "object" || emit == "binary"
 }


### PR DESCRIPTION
## What changed
- add a native-owned primitive/control-flow module entry slice mirrored from `toolchain/llvmgen.osty`
- route `GenerateModule` through that native path first, with fallback to the legacy IR -> AST bridge for unsupported shapes
- teach list method statement lowering to pass element type hints so nested empty-list pushes lower cleanly again
- add focused regression coverage for the native entrypoint and nested empty-list list pushes

## Why
The repo had reached a point where `toolchain/llvmgen.osty` owned smoke/support helpers, but the actual `Module -> llvm-ir` entrypoint still lived in the Go bridge. This PR moves that entrypoint forward for the primitive/control-flow slice and restores the native merged-toolchain clean milestone that regressed on `preds.push([])`.

## Impact
- primitive/control-flow IR modules can now emit through the native-owned entrypoint directly
- unsupported shapes still fall back safely to the legacy bridge
- `TestProbeNativeToolchainMerged` and `TestNativeToolchainMergedIsClean` are green again

## Validation
- `go test ./internal/llvmgen -run 'TestNativeOwnedModuleEntry|TestGenerateModuleWhileLoopCompat|TestGenerateModuleGenericIdentityMonomorphized|TestGenerateModuleGenericStructPairMonomorphized|TestGenerateNestedListPushStmtHintsEmptyListArg|TestProbeNativeToolchainMerged$|TestNativeToolchainMergedIsClean$' -count=1 -v`
- `go test ./internal/backend -run 'TestLLVMBackendEmitLLVMIRSkipsToolchain|TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback' -count=1`