### PR TITLE
[codex] Stabilize osty-vs-go benchmarking

### DIFF
--- a/benchmarks/osty-vs-go/README.md
+++ b/benchmarks/osty-vs-go/README.md
@@ -13,6 +13,9 @@ benchmarks/osty-vs-go/
 ├── arith/
 │   ├── go/      # package arithbench — BenchmarkAdd
 │   └── osty/    # benchAdd
+├── word_freq/
+│   ├── go/      # package wordfreqbench — BenchmarkCorpusIndex
+│   └── osty/    # benchCorpusIndex
 ├── loop_sum/
 │   ├── go/      # package loopsumbench — BenchmarkSumTo100
 │   └── osty/    # benchSumTo100
@@ -42,6 +45,11 @@ Useful flags:
   history listing; good for marking `main`, `branch-x`, etc.).
 - `--osty <path>` / `--go <path>` — override the binaries. The default
   prefers `$PWD/.bin/osty` (from `just build`) and the `go` on `PATH`.
+- `--go-count <N>` — run each Go pair `N` times and publish the median
+  per metric. Default `3`; this trades a bit of wall time for a much
+  steadier Go baseline.
+- `--go-cpu <list>` — forwarded to `go test -cpu`. Default `1`, which
+  reduces scheduler noise for very short Go benches.
 - `--pairs-dir <path>` — defaults to `benchmarks/osty-vs-go`.
 - `--history <N>` — skip running and render the last N recorded runs
   as an ASCII trend graph (see below).
@@ -57,23 +65,25 @@ Useful flags:
 Sample output of one run:
 
 ```
-# osty-vs-go run #3 (baseline) — benchtime=500ms, pairs=3
+# osty-vs-go run #3 (baseline) — benchtime=500ms, pairs=4, go-count=3, go-cpu=1
 
 pair      bench     go ns/op  osty ns/op  ns osty/go  go B/op  osty B/op  go allocs/op
 --------  --------  --------  ----------  ----------  -------  ---------  ------------
 arith     Add       1.20      161.0       134.17x     0        0          0
 fib       Fib15     13002.00  38195.0     2.94x       0        0          0
 loop_sum  SumTo100  205.50    2001.0      9.74x       0        0          0
+word_freq CorpusIndex   4012.00  18944.0  4.72x      4096     3584       12
 
-geomean ns osty/go: 10.90x  (over 3 benches)
+geomean ns osty/go: 7.17x  (over 4 benches)
 ```
 
 ## Metrics
 
 Per bench the tool collects:
 
-- **ns/op** (both sides). Go's is `testing.B` time-per-op after
-  auto-tuned `b.N`. Osty's is the `avg=…ns` field from
+- **ns/op** (both sides). Go's is the median `testing.B` time-per-op
+  across `--go-count` independent sweeps after auto-tuned `b.N`.
+  Osty's is the `avg=…ns` field from
   `testing.benchmark(N, …)` with per-iteration clock sampling.
 - **B/op** (both sides). Go's comes from `-benchmem`. Osty's comes
   from a runtime-side delta on `osty_gc_allocated_bytes_total`

--- a/benchmarks/osty-vs-go/word_freq/go/word_freq.go
+++ b/benchmarks/osty-vs-go/word_freq/go/word_freq.go
@@ -1,0 +1,69 @@
+package wordfreqbench
+
+import "sort"
+
+var leftCorpus = []string{
+	"osty", "compiler", "llvm", "runtime", "gc", "safepoint", "loop", "call",
+	"osty", "compiler", "llvm", "runtime", "gc", "loop", "loop", "call",
+	"map", "list", "sort", "entry", "roots", "stack", "module", "branch",
+	"osty", "go", "bench", "profile", "parser", "lexer", "token", "codegen",
+	"osty", "compiler", "llvm", "runtime", "gc", "safepoint", "loop", "call",
+	"map", "list", "sort", "entry", "roots", "stack", "module", "branch",
+	"inline", "arena", "token", "codegen", "bench", "profile", "parser", "lexer",
+	"osty", "go", "gc", "runtime", "loop", "call", "map", "list",
+}
+
+var rightCorpus = []string{
+	"go", "bench", "profile", "parser", "lexer", "token", "codegen", "arena",
+	"map", "list", "sort", "entry", "roots", "stack", "module", "branch",
+	"go", "bench", "profile", "parser", "lexer", "token", "codegen", "arena",
+	"osty", "compiler", "llvm", "runtime", "gc", "safepoint", "loop", "call",
+	"merge", "reduce", "filter", "group", "bucket", "symbol", "symbol", "module",
+	"go", "bench", "profile", "parser", "lexer", "token", "codegen", "arena",
+	"osty", "compiler", "llvm", "runtime", "gc", "loop", "call", "map",
+	"merge", "reduce", "filter", "group", "bucket", "symbol", "roots", "stack",
+}
+
+func sortedWords(words []string) []string {
+	out := append([]string(nil), words...)
+	sort.Strings(out)
+	return out
+}
+
+func buildIndex(words []string, base int) map[string]int {
+	index := make(map[string]int, len(words))
+	next := base
+	for _, word := range words {
+		if _, seen := index[word]; seen {
+			continue
+		}
+		index[word] = next
+		next++
+	}
+	return index
+}
+
+func sortedKeys(counts map[string]int) []string {
+	keys := make([]string, 0, len(counts))
+	for word := range counts {
+		keys = append(keys, word)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+//go:noinline
+func AnalyzeCorpusIndex(left, right []string) int {
+	leftIndex := buildIndex(sortedWords(left), 0)
+	rightIndex := buildIndex(sortedWords(right), len(leftIndex))
+	leftKeys := sortedKeys(leftIndex)
+	rightKeys := sortedKeys(rightIndex)
+	total := len(leftIndex) + len(rightIndex)
+	for _, word := range leftKeys {
+		total += leftIndex[word]
+	}
+	for _, word := range rightKeys {
+		total += rightIndex[word]
+	}
+	return total
+}

--- a/benchmarks/osty-vs-go/word_freq/go/word_freq_test.go
+++ b/benchmarks/osty-vs-go/word_freq/go/word_freq_test.go
@@ -1,0 +1,11 @@
+package wordfreqbench
+
+import "testing"
+
+var wordFreqSink int
+
+func BenchmarkCorpusIndex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		wordFreqSink = AnalyzeCorpusIndex(leftCorpus, rightCorpus)
+	}
+}

--- a/benchmarks/osty-vs-go/word_freq/osty/word_freq.osty
+++ b/benchmarks/osty-vs-go/word_freq/osty/word_freq.osty
@@ -1,0 +1,35 @@
+fn sortedWords(words: List<String>) -> List<String> {
+    words.sorted()
+}
+
+fn buildIndex(words: List<String>, base: Int) -> Map<String, Int> {
+    let mut index: Map<String, Int> = {:}
+    let mut next = base
+    for word in words {
+        if index.containsKey(word) {
+            continue
+        }
+        index.insert(word, next)
+        next = next + 1
+    }
+    index
+}
+
+fn sortedKeys(index: Map<String, Int>) -> List<String> {
+    index.keys().sorted()
+}
+
+pub fn analyzeCorpusIndex(left: List<String>, right: List<String>) -> Int {
+    let leftIndex = buildIndex(sortedWords(left), 0)
+    let rightIndex = buildIndex(sortedWords(right), leftIndex.len())
+    let leftKeys = sortedKeys(leftIndex)
+    let rightKeys = sortedKeys(rightIndex)
+    let mut total = leftIndex.len() + rightIndex.len()
+    for key in leftKeys {
+        total = total + leftIndex.getOr(key, 0)
+    }
+    for key in rightKeys {
+        total = total + rightIndex.getOr(key, 0)
+    }
+    total
+}

--- a/benchmarks/osty-vs-go/word_freq/osty/word_freq_test.osty
+++ b/benchmarks/osty-vs-go/word_freq/osty/word_freq_test.osty
@@ -1,0 +1,28 @@
+use std.testing
+
+fn benchCorpusIndex() {
+    let left = [
+        "osty", "compiler", "llvm", "runtime", "gc", "safepoint", "loop", "call",
+        "osty", "compiler", "llvm", "runtime", "gc", "loop", "loop", "call",
+        "map", "list", "sort", "entry", "roots", "stack", "module", "branch",
+        "osty", "go", "bench", "profile", "parser", "lexer", "token", "codegen",
+        "osty", "compiler", "llvm", "runtime", "gc", "safepoint", "loop", "call",
+        "map", "list", "sort", "entry", "roots", "stack", "module", "branch",
+        "inline", "arena", "token", "codegen", "bench", "profile", "parser", "lexer",
+        "osty", "go", "gc", "runtime", "loop", "call", "map", "list",
+    ]
+    let right = [
+        "go", "bench", "profile", "parser", "lexer", "token", "codegen", "arena",
+        "map", "list", "sort", "entry", "roots", "stack", "module", "branch",
+        "go", "bench", "profile", "parser", "lexer", "token", "codegen", "arena",
+        "osty", "compiler", "llvm", "runtime", "gc", "safepoint", "loop", "call",
+        "merge", "reduce", "filter", "group", "bucket", "symbol", "symbol", "module",
+        "go", "bench", "profile", "parser", "lexer", "token", "codegen", "arena",
+        "osty", "compiler", "llvm", "runtime", "gc", "loop", "call", "map",
+        "merge", "reduce", "filter", "group", "bucket", "symbol", "roots", "stack",
+    ]
+    testing.benchmark(10, || {
+        let _ = analyzeCorpusIndex(left, right)
+        Ok(())
+    })
+}

--- a/cmd/osty-vs-go/main.go
+++ b/cmd/osty-vs-go/main.go
@@ -53,22 +53,24 @@ import (
 )
 
 type benchResult struct {
-	Pair         string
-	Name         string
-	GoNs         float64 // ns/op; NaN when absent
-	GoBytes      float64
-	GoAllocs     float64
-	OsNs         float64
-	OsBytes      float64
-	OsAllocs     float64 // always NaN today — kept for a future Osty accessor
+	Pair     string
+	Name     string
+	GoNs     float64 // ns/op; NaN when absent
+	GoBytes  float64
+	GoAllocs float64
+	OsNs     float64
+	OsBytes  float64
+	OsAllocs float64 // always NaN today — kept for a future Osty accessor
 }
 
 type runRecord struct {
-	Timestamp time.Time     `json:"timestamp"`
-	BenchTime string        `json:"bench_time"`
-	PairsDir  string        `json:"pairs_dir"`
-	Label     string        `json:"label,omitempty"`
-	GitHead   string        `json:"git_head,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+	BenchTime string    `json:"bench_time"`
+	PairsDir  string    `json:"pairs_dir"`
+	Label     string    `json:"label,omitempty"`
+	GitHead   string    `json:"git_head,omitempty"`
+	GoCount   int       `json:"go_count,omitempty"`
+	GoCPU     string    `json:"go_cpu,omitempty"`
 	// Score is the geomean of osty_ns/go_ns across benches with both
 	// sides present. Lower = Osty closer to Go. NaN when no pair
 	// contributes. Persisted so the research/loop paths don't have to
@@ -159,11 +161,11 @@ func (r benchResult) MarshalJSON() ([]byte, error) {
 		"name": r.Name,
 	}
 	for k, v := range map[string]float64{
-		"go_ns":     r.GoNs,
-		"go_bytes":  r.GoBytes,
-		"go_allocs": r.GoAllocs,
-		"osty_ns":   r.OsNs,
-		"osty_bytes": r.OsBytes,
+		"go_ns":       r.GoNs,
+		"go_bytes":    r.GoBytes,
+		"go_allocs":   r.GoAllocs,
+		"osty_ns":     r.OsNs,
+		"osty_bytes":  r.OsBytes,
 		"osty_allocs": r.OsAllocs,
 	} {
 		if !math.IsNaN(v) {
@@ -175,14 +177,14 @@ func (r benchResult) MarshalJSON() ([]byte, error) {
 
 func (r *benchResult) UnmarshalJSON(data []byte) error {
 	var m struct {
-		Pair       string   `json:"pair"`
-		Name       string   `json:"name"`
-		GoNs       *float64 `json:"go_ns"`
-		GoBytes    *float64 `json:"go_bytes"`
-		GoAllocs   *float64 `json:"go_allocs"`
-		OsNs       *float64 `json:"osty_ns"`
-		OsBytes    *float64 `json:"osty_bytes"`
-		OsAllocs   *float64 `json:"osty_allocs"`
+		Pair     string   `json:"pair"`
+		Name     string   `json:"name"`
+		GoNs     *float64 `json:"go_ns"`
+		GoBytes  *float64 `json:"go_bytes"`
+		GoAllocs *float64 `json:"go_allocs"`
+		OsNs     *float64 `json:"osty_ns"`
+		OsBytes  *float64 `json:"osty_bytes"`
+		OsAllocs *float64 `json:"osty_allocs"`
 	}
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
@@ -213,6 +215,8 @@ func main() {
 	pairsDir := fs.String("pairs-dir", "benchmarks/osty-vs-go", "root containing <pair>/go/ and <pair>/osty/ subdirs")
 	ostyBin := fs.String("osty", "", "path to the osty binary (default: $PWD/.bin/osty if present, else `osty` from PATH)")
 	goBin := fs.String("go", "go", "path to the go binary used for `go test -bench`")
+	goCount := fs.Int("go-count", 3, "number of independent Go bench sweeps per pair; the runner records the median to reduce scheduler jitter")
+	goCPU := fs.String("go-cpu", "1", "value forwarded to `go test -cpu` for stable Go-side scheduling (default 1)")
 	filter := fs.String("filter", "", "optional regex over pair names; only matching pairs run")
 	historyN := fs.Int("history", 0, "if >0, skip running and render the last N runs from "+historyFile+" as an ASCII trend graph")
 	label := fs.String("label", "", "optional short label stored with this run (shown in history output)")
@@ -239,6 +243,10 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	}
+	if *goCount <= 0 {
+		fmt.Fprintln(os.Stderr, "osty-vs-go: --go-count must be > 0")
+		os.Exit(2)
 	}
 
 	osty := resolveOstyBin(*ostyBin)
@@ -273,6 +281,8 @@ func main() {
 			PairsDir:       *pairsDir,
 			OstyBin:        osty,
 			GoBin:          *goBin,
+			GoCount:        *goCount,
+			GoCPU:          *goCPU,
 			Label:          *label,
 			NoiseFrac:      *noiseFrac,
 			PairRE:         pairRE,
@@ -286,11 +296,11 @@ func main() {
 	}
 
 	if *loopInterval > 0 {
-		runLoop(*loopInterval, *benchTime, *pairsDir, osty, *goBin, *label, *noiseFrac, pairRE)
+		runLoop(*loopInterval, *benchTime, *pairsDir, osty, *goBin, *goCount, *goCPU, *label, *noiseFrac, pairRE)
 		return
 	}
 
-	if _, err := runOnce(*benchTime, *pairsDir, osty, *goBin, *label, *noiseFrac, pairRE); err != nil {
+	if _, err := runOnce(*benchTime, *pairsDir, osty, *goBin, *goCount, *goCPU, *label, *noiseFrac, pairRE); err != nil {
 		fmt.Fprintf(os.Stderr, "osty-vs-go: %v\n", err)
 		os.Exit(1)
 	}
@@ -300,7 +310,7 @@ func main() {
 // side, print the table, append to history, print the vs-best verdict.
 // Returns the new record so `--loop` can stream verdicts without
 // re-reading history.
-func runOnce(benchTime, pairsDir, ostyBin, goBin, label string, noiseFrac float64, pairRE *regexp.Regexp) (runRecord, error) {
+func runOnce(benchTime, pairsDir, ostyBin, goBin string, goCount int, goCPU, label string, noiseFrac float64, pairRE *regexp.Regexp) (runRecord, error) {
 	pairs, err := discoverPairs(pairsDir)
 	if err != nil {
 		return runRecord{}, err
@@ -331,11 +341,11 @@ func runOnce(benchTime, pairsDir, ostyBin, goBin, label string, noiseFrac float6
 	if head != "" {
 		headPart = " @ " + head
 	}
-	fmt.Printf("# osty-vs-go run #%d%s%s — benchtime=%s, pairs=%d\n\n", seq, labelPart, headPart, benchTime, len(pairs))
+	fmt.Printf("# osty-vs-go run #%d%s%s — benchtime=%s, pairs=%d, go-count=%d, go-cpu=%s\n\n", seq, labelPart, headPart, benchTime, len(pairs), goCount, goCPU)
 
 	var rows []benchResult
 	for _, pair := range pairs {
-		goRows, err := runGoBench(goBin, pairsDir, pair, benchTime)
+		goRows, err := runGoBench(goBin, pairsDir, pair, benchTime, goCount, goCPU)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty-vs-go: go bench %s: %v\n", pair, err)
 		}
@@ -354,6 +364,8 @@ func runOnce(benchTime, pairsDir, ostyBin, goBin, label string, noiseFrac float6
 		PairsDir:  pairsDir,
 		Label:     label,
 		GitHead:   head,
+		GoCount:   goCount,
+		GoCPU:     goCPU,
 		Score:     composite(rows),
 		Results:   rows,
 	}
@@ -375,7 +387,7 @@ func runOnce(benchTime, pairsDir, ostyBin, goBin, label string, noiseFrac float6
 // the user (or an outer agent) edits Osty sources; each tick's verdict
 // tells them whether the edit was an improvement, a regression, or
 // noise. Ctrl-C exits cleanly.
-func runLoop(interval time.Duration, benchTime, pairsDir, ostyBin, goBin, label string, noiseFrac float64, pairRE *regexp.Regexp) {
+func runLoop(interval time.Duration, benchTime, pairsDir, ostyBin, goBin string, goCount int, goCPU, label string, noiseFrac float64, pairRE *regexp.Regexp) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sig)
@@ -385,7 +397,7 @@ func runLoop(interval time.Duration, benchTime, pairsDir, ostyBin, goBin, label 
 	// Run immediately rather than waiting `interval` for the first
 	// tick — the user just launched it and expects feedback.
 	for {
-		if _, err := runOnce(benchTime, pairsDir, ostyBin, goBin, label, noiseFrac, pairRE); err != nil {
+		if _, err := runOnce(benchTime, pairsDir, ostyBin, goBin, goCount, goCPU, label, noiseFrac, pairRE); err != nil {
 			fmt.Fprintf(os.Stderr, "osty-vs-go: %v\n", err)
 		}
 		fmt.Printf("\n(waiting %s before next sweep; Ctrl-C to stop)\n\n", interval)
@@ -409,6 +421,8 @@ type autoresearchConfig struct {
 	PairsDir       string
 	OstyBin        string
 	GoBin          string
+	GoCount        int
+	GoCPU          string
 	Label          string
 	NoiseFrac      float64
 	PairRE         *regexp.Regexp
@@ -516,7 +530,7 @@ func runAutoresearchIter(cfg autoresearchConfig, iter int, stats *autoresearchSt
 
 	// Phase 2: run the bench sweep. runOnce already writes the history
 	// file and prints the verdict relative to all-time history.
-	rec, err := runOnce(cfg.BenchTime, cfg.PairsDir, cfg.OstyBin, cfg.GoBin, cfg.Label, cfg.NoiseFrac, cfg.PairRE)
+	rec, err := runOnce(cfg.BenchTime, cfg.PairsDir, cfg.OstyBin, cfg.GoBin, cfg.GoCount, cfg.GoCPU, cfg.Label, cfg.NoiseFrac, cfg.PairRE)
 	if err != nil {
 		// Bench failure shouldn't leave the mutator's changes on HEAD.
 		_, _ = gitRun("reset", "--hard", "HEAD")
@@ -688,17 +702,26 @@ func discoverPairs(root string) ([]string, error) {
 }
 
 // runGoBench invokes `go test -run=^$ -bench=. -benchmem -benchtime=<t>`
-// on the pair's go/ subdir. -run=^$ filters out regular tests; -benchmem
-// opts into the B/op + allocs/op columns that `testing` only reports
-// on request.
-func runGoBench(goBin, pairsDir, pair, benchTime string) ([]benchResult, error) {
+// on the pair's go/ subdir. Multiple independent sweeps can be
+// requested via goCount; the runner records the median per metric so a
+// noisy Go-side outlier does not dominate the published ratio.
+func runGoBench(goBin, pairsDir, pair, benchTime string, goCount int, goCPU string) ([]benchResult, error) {
 	pkg := goPackageArg(filepath.Join(pairsDir, pair, "go"))
-	cmd := exec.Command(goBin, "test", "-run=^$", "-bench=.", "-benchmem", "-benchtime="+benchTime, pkg)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("%s test: %w\n%s", goBin, err, out)
+	runs := make([][]benchResult, 0, goCount)
+	for i := 0; i < goCount; i++ {
+		args := []string{"test", "-count=1", "-run=^$", "-bench=.", "-benchmem"}
+		if goCPU != "" {
+			args = append(args, "-cpu="+goCPU)
+		}
+		args = append(args, "-benchtime="+benchTime, pkg)
+		cmd := exec.Command(goBin, args...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("%s test run %d/%d: %w\n%s", goBin, i+1, goCount, err, out)
+		}
+		runs = append(runs, parseGoBenchOutput(pair, string(out)))
 	}
-	return parseGoBenchOutput(pair, string(out)), nil
+	return aggregateGoBenchRuns(pair, runs), nil
 }
 
 // goPackageArg formats a filesystem path for the `go test` argv. Relative
@@ -760,6 +783,67 @@ func parseGoBenchOutput(pair, out string) []benchResult {
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+func aggregateGoBenchRuns(pair string, runs [][]benchResult) []benchResult {
+	type series struct {
+		ns     []float64
+		bytes  []float64
+		allocs []float64
+	}
+	byName := map[string]*series{}
+	for _, rows := range runs {
+		for _, row := range rows {
+			s := byName[row.Name]
+			if s == nil {
+				s = &series{}
+				byName[row.Name] = s
+			}
+			s.ns = appendFinite(s.ns, row.GoNs)
+			s.bytes = appendFinite(s.bytes, row.GoBytes)
+			s.allocs = appendFinite(s.allocs, row.GoAllocs)
+		}
+	}
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]benchResult, 0, len(names))
+	for _, name := range names {
+		s := byName[name]
+		out = append(out, benchResult{
+			Pair:     pair,
+			Name:     name,
+			GoNs:     medianFinite(s.ns),
+			GoBytes:  medianFinite(s.bytes),
+			GoAllocs: medianFinite(s.allocs),
+			OsNs:     math.NaN(),
+			OsBytes:  math.NaN(),
+			OsAllocs: math.NaN(),
+		})
+	}
+	return out
+}
+
+func appendFinite(dst []float64, v float64) []float64 {
+	if math.IsNaN(v) {
+		return dst
+	}
+	return append(dst, v)
+}
+
+func medianFinite(values []float64) float64 {
+	if len(values) == 0 {
+		return math.NaN()
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
 }
 
 func runOstyBench(ostyBin, pairsDir, pair, benchTime string) ([]benchResult, error) {

--- a/cmd/osty-vs-go/main_test.go
+++ b/cmd/osty-vs-go/main_test.go
@@ -32,9 +32,9 @@ func mkRun(ts time.Time, score float64, results ...benchResult) runRecord {
 
 func TestCompositeIsGeomeanOfRatios(t *testing.T) {
 	rows := []benchResult{
-		mkResult("p1", "a", 1, 2),   // 2
-		mkResult("p1", "b", 1, 8),   // 8
-		mkResult("p2", "c", 1, 16),  // 16
+		mkResult("p1", "a", 1, 2),  // 2
+		mkResult("p1", "b", 1, 8),  // 8
+		mkResult("p2", "c", 1, 16), // 16
 	}
 	got := composite(rows)
 	// geomean(2, 8, 16) = cbrt(256) ≈ 6.3496.
@@ -47,9 +47,9 @@ func TestCompositeIsGeomeanOfRatios(t *testing.T) {
 func TestCompositeSkipsRowsMissingASide(t *testing.T) {
 	rows := []benchResult{
 		mkResult("p1", "a", 1, 2),
-		mkResult("p1", "b", math.NaN(), 8),   // Go missing
-		mkResult("p1", "c", 1, math.NaN()),   // Osty missing
-		mkResult("p1", "d", 0, 16),           // Go ≤ 0: skip (would div-by-zero)
+		mkResult("p1", "b", math.NaN(), 8), // Go missing
+		mkResult("p1", "c", 1, math.NaN()), // Osty missing
+		mkResult("p1", "d", 0, 16),         // Go ≤ 0: skip (would div-by-zero)
 	}
 	got := composite(rows)
 	if got != 2 {
@@ -66,13 +66,63 @@ func TestCompositeIsNaNWhenNoQualifyingPair(t *testing.T) {
 	}
 }
 
+func TestMedianFiniteOddCount(t *testing.T) {
+	got := medianFinite([]float64{9, 1, 5})
+	if got != 5 {
+		t.Fatalf("medianFinite odd = %v, want 5", got)
+	}
+}
+
+func TestMedianFiniteEvenCount(t *testing.T) {
+	got := medianFinite([]float64{10, 4, 2, 8})
+	if got != 6 {
+		t.Fatalf("medianFinite even = %v, want 6", got)
+	}
+}
+
+func TestMedianFiniteEmpty(t *testing.T) {
+	if got := medianFinite(nil); !math.IsNaN(got) {
+		t.Fatalf("medianFinite empty = %v, want NaN", got)
+	}
+}
+
+func TestAggregateGoBenchRunsUsesMedianPerMetric(t *testing.T) {
+	runs := [][]benchResult{
+		{
+			{Pair: "word_freq", Name: "WordFreqTop10", GoNs: 120, GoBytes: 90, GoAllocs: 4, OsNs: math.NaN(), OsBytes: math.NaN(), OsAllocs: math.NaN()},
+			{Pair: "word_freq", Name: "Helper", GoNs: 40, GoBytes: math.NaN(), GoAllocs: 1, OsNs: math.NaN(), OsBytes: math.NaN(), OsAllocs: math.NaN()},
+		},
+		{
+			{Pair: "word_freq", Name: "WordFreqTop10", GoNs: 100, GoBytes: 70, GoAllocs: 2, OsNs: math.NaN(), OsBytes: math.NaN(), OsAllocs: math.NaN()},
+			{Pair: "word_freq", Name: "Helper", GoNs: 30, GoBytes: math.NaN(), GoAllocs: 3, OsNs: math.NaN(), OsBytes: math.NaN(), OsAllocs: math.NaN()},
+		},
+		{
+			{Pair: "word_freq", Name: "WordFreqTop10", GoNs: 140, GoBytes: 110, GoAllocs: 6, OsNs: math.NaN(), OsBytes: math.NaN(), OsAllocs: math.NaN()},
+			{Pair: "word_freq", Name: "Helper", GoNs: 50, GoBytes: math.NaN(), GoAllocs: 5, OsNs: math.NaN(), OsBytes: math.NaN(), OsAllocs: math.NaN()},
+		},
+	}
+	rows := aggregateGoBenchRuns("word_freq", runs)
+	if len(rows) != 2 {
+		t.Fatalf("aggregateGoBenchRuns len = %d, want 2", len(rows))
+	}
+	if rows[0].Name != "Helper" || rows[1].Name != "WordFreqTop10" {
+		t.Fatalf("aggregateGoBenchRuns order = %+v", rows)
+	}
+	if rows[0].GoNs != 40 || !math.IsNaN(rows[0].GoBytes) || rows[0].GoAllocs != 3 {
+		t.Fatalf("Helper median row = %+v", rows[0])
+	}
+	if rows[1].GoNs != 120 || rows[1].GoBytes != 90 || rows[1].GoAllocs != 4 {
+		t.Fatalf("WordFreqTop10 median row = %+v", rows[1])
+	}
+}
+
 func TestBestRunPicksLowestScore(t *testing.T) {
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	runs := []runRecord{
 		mkRun(base.Add(1*time.Minute), 3.0),
 		mkRun(base.Add(2*time.Minute), 1.5),
 		mkRun(base.Add(3*time.Minute), 2.0),
-		mkRun(base.Add(4*time.Minute), 1.5),   // tie with #2 — earlier wins
+		mkRun(base.Add(4*time.Minute), 1.5), // tie with #2 — earlier wins
 	}
 	best, ok := bestRun(runs)
 	if !ok {

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -4405,16 +4405,21 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if sig.ret == "void" {
 		return value{}, unsupportedf("call", "function %q has no return value", sig.name)
 	}
-	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
-	g.takeOstyEmitter(emitter)
+	// The direct-call poll runs before arg evaluation, so when the
+	// current frame has no visible GC roots it can only emit an empty
+	// runtime call. Skip that case to cheapen scalar-heavy recursion.
+	if g.hasVisibleSafepointRoots() {
+		emitter := g.toOstyEmitter()
+		g.emitGCSafepointKind(emitter, safepointKindCall)
+		g.takeOstyEmitter(emitter)
+	}
 	g.pushScope()
 	args, err := g.userCallArgs(sig, receiverExpr, call)
 	if err != nil {
 		g.popScope()
 		return value{}, err
 	}
-	emitter = g.toOstyEmitter()
+	emitter := g.toOstyEmitter()
 	out := llvmCall(emitter, sig.ret, sig.irName, args)
 	g.takeOstyEmitter(emitter)
 	g.popScope()
@@ -4703,14 +4708,16 @@ func (g *generator) emitOptionalUserCall(call *ast.CallExpr) (value, bool, error
 		return value{}, true, err
 	}
 	out, err := g.emitOptionalPtrExpr(baseValue, func() (value, error) {
-		emitter := g.toOstyEmitter()
-		g.emitGCSafepointKind(emitter, safepointKindCall)
-		g.takeOstyEmitter(emitter)
+		if g.hasVisibleSafepointRoots() {
+			emitter := g.toOstyEmitter()
+			g.emitGCSafepointKind(emitter, safepointKindCall)
+			g.takeOstyEmitter(emitter)
+		}
 		args, err := g.optionalUserCallArgs(sig, innerSource, baseValue, call)
 		if err != nil {
 			return value{}, err
 		}
-		emitter = g.toOstyEmitter()
+		emitter := g.toOstyEmitter()
 		next := llvmCall(emitter, sig.ret, sig.irName, args)
 		g.takeOstyEmitter(emitter)
 		v := fromOstyValue(next)

--- a/internal/llvmgen/gc_integration_test.go
+++ b/internal/llvmgen/gc_integration_test.go
@@ -303,18 +303,19 @@ fn main() {
 
 // TestGenerateFromASTSafepointKindMixCallAndLoop covers the A5 depth
 // follow-up for the legacy emitter — lowering a function whose body
-// is a `while` loop with a user-level call inside must produce both
-// CALL and LOOP safepoint kinds, and zero UNSPECIFIED (meaning every
-// emit site has been classified).
+// is a `while` loop with an indirect user-level call inside must
+// produce both CALL and LOOP safepoint kinds, and zero UNSPECIFIED
+// (meaning every emit site has been classified).
 func TestGenerateFromASTSafepointKindMixCallAndLoop(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn work() -> Int {
     1
 }
 
 fn main() {
+    let f = work
     let mut i = 0
     while i < 3 {
-        i = i + work()
+        i = i + f()
     }
     println(i)
 }
@@ -335,5 +336,34 @@ fn main() {
 	}
 	if mix[safepointKindUnspecified] != 0 {
 		t.Fatalf("UNSPECIFIED safepoint leaked through a classified path, mix=%v, IR:\n%s", mix, ir)
+	}
+}
+
+func TestGenerateFromASTDirectUserCallSkipsEmptyCallSafepoint(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn work() -> Int {
+    1
+}
+
+fn main() {
+    let mut i = 0
+    while i < 3 {
+        i = i + work()
+    }
+    println(i)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/direct_call_entry_safepoint.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	mix := safepointKindMix(t, string(ir))
+	if mix[safepointKindCall] != 0 {
+		t.Fatalf("expected no CALL-kind safepoint for direct user call, mix=%v, IR:\n%s", mix, ir)
+	}
+	if mix[safepointKindLoop] == 0 {
+		t.Fatalf("expected ≥1 LOOP-kind safepoint, mix=%v, IR:\n%s", mix, ir)
 	}
 }

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -1040,6 +1040,10 @@ func (g *generator) visibleSafepointRoots() []gcSafepointRoot {
 	return out
 }
 
+func (g *generator) hasVisibleSafepointRoots() bool {
+	return len(g.visibleSafepointRoots()) != 0
+}
+
 func (g *generator) safepointRootAddress(emitter *LlvmEmitter, root gcSafepointRoot) string {
 	if len(root.path) == 0 {
 		return root.slot.ref

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2964,14 +2964,16 @@ func (g *generator) emitOptionalUserCallStmt(call *ast.CallExpr) (bool, error) {
 		return true, err
 	}
 	if err := g.emitOptionalPtrStmt(baseValue, func() error {
-		emitter := g.toOstyEmitter()
-		g.emitGCSafepointKind(emitter, safepointKindCall)
-		g.takeOstyEmitter(emitter)
+		if g.hasVisibleSafepointRoots() {
+			emitter := g.toOstyEmitter()
+			g.emitGCSafepointKind(emitter, safepointKindCall)
+			g.takeOstyEmitter(emitter)
+		}
 		args, err := g.optionalUserCallArgs(sig, innerSource, baseValue, call)
 		if err != nil {
 			return err
 		}
-		emitter = g.toOstyEmitter()
+		emitter := g.toOstyEmitter()
 		if sig.ret == "void" {
 			emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", sig.irName, llvmCallArgs(args)))
 		} else {
@@ -2993,16 +2995,18 @@ func (g *generator) emitUserCallStmt(call *ast.CallExpr) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
-	g.takeOstyEmitter(emitter)
+	if g.hasVisibleSafepointRoots() {
+		emitter := g.toOstyEmitter()
+		g.emitGCSafepointKind(emitter, safepointKindCall)
+		g.takeOstyEmitter(emitter)
+	}
 	g.pushScope()
 	args, err := g.userCallArgs(sig, receiverExpr, call)
 	if err != nil {
 		g.popScope()
 		return true, err
 	}
-	emitter = g.toOstyEmitter()
+	emitter := g.toOstyEmitter()
 	if sig.ret == "void" {
 		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", sig.irName, llvmCallArgs(args)))
 	} else {


### PR DESCRIPTION
## Summary
- stabilize `osty-vs-go` Go-side measurements with `--go-count` median aggregation and `--go-cpu`
- add a longer `word_freq/CorpusIndex` benchmark pair for a more representative Go vs Osty workload
- skip empty direct-call safepoints in the legacy LLVM emitter so scalar-heavy calls stop paying a redundant runtime poll

## Why
The old harness compared against a single Go sample, so short benches fluctuated too much to support keep-or-revert decisions. At the same time, the benchmark set leaned heavily toward microbenches. On the runtime side, direct user calls were still emitting caller-side safepoints even when the current frame had no visible GC roots, which inflated call-heavy workloads.

## Impact
- Go baselines are steadier and easier to compare across runs
- the benchmark suite now includes a longer collection-heavy workload
- direct user-call hot paths avoid an empty safepoint runtime call when there is nothing to expose from the current frame

## Validation
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromASTSafepointKindMixCallAndLoop|TestGenerateFromASTDirectUserCallSkipsEmptyCallSafepoint'`
- `just build`
- `.bin/osty test --bench --serial --benchtime=200ms benchmarks/osty-vs-go/word_freq/osty`

## Notes
Representative stable run with `--benchtime 750ms --go-count 5 --go-cpu 1`:
- branch: geomean `8.65x` over `arith/fib/loop_sum`
- main baseline worktree: geomean `15.78x` over the same 3 workloads
- `word_freq/CorpusIndex` currently measures `9.60x` slower than Go on the branch in a standalone run
