### PR TITLE
fix(injection): cascade-aware strip + owner-typearg clear for builtin specializations

### DIFF
--- a/internal/backend/stdlib_type_inject.go
+++ b/internal/backend/stdlib_type_inject.go
@@ -272,36 +272,154 @@ func genericParamNames(params []*ir.TypeParam) []string {
 	return out
 }
 
-// filterMethodsAvoidingOwnerRecursion drops methods whose param or
-// return types reintroduce owner with modified type args, and drops
-// body-less intrinsic declarations (`fn len(self) -> Int` with no
-// body) since their specializations would fail ir.Validate ("nil
-// Body") — those intrinsics are lowered by the backend directly
-// (`osty_rt_list_len` et al.), not from an injected template. The
-// returned slice preserves every safe method in its original order.
+// filterMethodsAvoidingOwnerRecursion drops methods the backend cannot
+// safely specialize from an injected template:
+//
+//  1. Owner-recursive sigs (`List<T>.chunked(self) -> List<List<T>>`) —
+//     eagerly specialising the owner would queue `List<List<Foo>>` and
+//     diverge. See methodRecursesOwner for the exact shape test.
+//
+//  2. **Dispatch cascade:** bodied methods that call a body-less
+//     intrinsic method on `self` whose dispatch the backend has not
+//     whitelisted. Their bodies would survive into the specialization
+//     but the `self.<missing>(...)` site has no lowering target, so
+//     the legacy llvmgen bridge walls on `*ast.TurbofishExpr` /
+//     `self.<missing>` when it later tries to emit them. The canonical
+//     List example: `List<T>.contains { self.indexOf(item).isSome() }`
+//     — `indexOf` is body-less and not in `listMethodInfo`, so the
+//     specialized `contains` can never resolve the call and the
+//     enclosing `.isSome()` chain loses its source type. Map's shape
+//     is the same but `mapMethodInfo` whitelists every body-less
+//     intrinsic (`get`, `insert`, …), so its bodied helpers all
+//     survive.
+//
+// Body-less declarations themselves are preserved on the specialized
+// struct — ir.Validate is loosened to allow them for builtin-source
+// specializations — so source-type propagation stays intact for any
+// remaining caller. Only the bodied methods whose emission is
+// guaranteed to fail get dropped.
+//
+// Generic methods (`List<T>.map<R>`) are preserved here unchanged;
+// monomorphize's `keepNonGenericMethods` skips generic methods anyway
+// and defers their specialization to actual call sites.
 func filterMethodsAvoidingOwnerRecursion(owner string, generics []string, methods []*ir.FnDecl) []*ir.FnDecl {
 	if len(methods) == 0 {
 		return methods
 	}
-	out := methods[:0:0]
+	// Pass 1: strip owner-recursive methods. Body-less declarations stay
+	// so their signatures remain visible for source-type propagation
+	// (e.g. `self.get(k) -> V?` feeding a later `.isSome()` dispatch).
+	ownerUndispatchable := ownerUndispatchableMethodSet(owner)
+	droppedSelfCall := map[string]bool{}
+	survived := make([]*ir.FnDecl, 0, len(methods))
 	for _, m := range methods {
 		if m == nil {
 			continue
 		}
-		if m.Body == nil {
+		if m.Body != nil && len(m.Generics) == 0 && methodRecursesOwner(owner, generics, m) {
+			droppedSelfCall[m.Name] = true
 			continue
 		}
-		// Generic methods (`List<T>.map<R>`) are preserved as templates
-		// by keepNonGenericMethods and only specialized at actual call
-		// sites, so their signatures never drive eager recursion. Only
-		// non-generic methods on the owner participate in the eager
-		// sig-scanning path, so the recursion filter runs against them.
-		if len(m.Generics) == 0 && methodRecursesOwner(owner, generics, m) {
-			continue
-		}
-		out = append(out, m)
+		survived = append(survived, m)
 	}
-	return out
+	// Pass 2: cascade-drop bodied methods whose body calls any
+	// owner-undispatchable (or already-dropped) method on `self`.
+	// Repeat until the set is stable — a bodied helper may only touch
+	// an undispatchable intrinsic via another bodied helper that we
+	// strip in this pass.
+	for {
+		before := len(droppedSelfCall)
+		next := survived[:0:0]
+		for _, m := range survived {
+			if m == nil {
+				continue
+			}
+			if m.Body != nil && methodBodyCallsUndispatchableSelfMethod(m, ownerUndispatchable, droppedSelfCall) {
+				droppedSelfCall[m.Name] = true
+				continue
+			}
+			next = append(next, m)
+		}
+		survived = next
+		if len(droppedSelfCall) == before {
+			break
+		}
+	}
+	return survived
+}
+
+// ownerUndispatchableMethodSet returns the set of **body-less
+// intrinsic** method names the backend cannot lower from a bare
+// `self.<name>(...)` call site on a specialization of `owner`. The
+// cascade only uses these as starting points — bodied methods that
+// only call dispatched intrinsics stay.
+//
+// Kept in sync with the backend's `listMethodInfo` / `mapMethodInfo` /
+// `setMethodInfo` whitelists in `internal/llvmgen/type.go`. When a new
+// dispatch lands there, drop the corresponding name here so its
+// callers stop getting cascade-stripped.
+func ownerUndispatchableMethodSet(owner string) map[string]bool {
+	switch owner {
+	case "List":
+		// Body-less declarations on List<T> (see
+		// `internal/stdlib/modules/collections.osty`): len, get,
+		// indexOf, sorted, push, pop, insert, removeAt, sort,
+		// reverse, clear. listMethodInfo whitelist covers all except
+		// indexOf / removeAt / sort / reverse.
+		return map[string]bool{
+			"indexOf":  true,
+			"removeAt": true,
+			"sort":     true,
+			"reverse":  true,
+		}
+	}
+	// Map: every body-less intrinsic (get, insert, remove, keys,
+	// entries, len, isEmpty, clear) is in mapMethodInfo.
+	// Set: every body-less intrinsic (len, isEmpty, contains, insert,
+	// remove, toList) is in setMethodInfo.
+	// Option / Result: isSome / isNone are handled via
+	// emitOptionMethodCall directly off ptr source types.
+	return nil
+}
+
+// methodBodyCallsUndispatchableSelfMethod walks m.Body for any
+// `self.<name>(...)` call whose name is in either `undispatchable`
+// (hard-coded owner gap) or `cascade` (already-dropped by a previous
+// pass). Returns true on the first match. Non-self receivers are
+// ignored; this is about the specialized owner's own dispatch surface
+// only.
+func methodBodyCallsUndispatchableSelfMethod(m *ir.FnDecl, undispatchable, cascade map[string]bool) bool {
+	if m == nil || m.Body == nil {
+		return false
+	}
+	if len(undispatchable) == 0 && len(cascade) == 0 {
+		return false
+	}
+	missing := func(name string) bool {
+		return undispatchable[name] || cascade[name]
+	}
+	found := false
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		if found {
+			return false
+		}
+		switch x := n.(type) {
+		case *ir.MethodCall:
+			if id, ok := x.Receiver.(*ir.Ident); ok && id.Name == "self" && missing(x.Name) {
+				found = true
+				return false
+			}
+		case *ir.CallExpr:
+			if fx, ok := x.Callee.(*ir.FieldExpr); ok {
+				if id, ok := fx.X.(*ir.Ident); ok && id.Name == "self" && missing(fx.Name) {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	}), m.Body)
+	return found
 }
 
 // methodRecursesOwner reports whether any param or return type of m

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -980,11 +980,13 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 	if len(origMethod.Generics) == 0 {
 		// Checker-instantiation metadata on a method call can carry the
 		// owner's concrete receiver args even when the method itself has
-		// no method-local generics (e.g. `Map<String, Int>.containsKey`).
-		// Once the receiver type has been rewritten to the concrete owner
+		// no method-local generics (e.g. `Map<String, Int>.containsKey`,
+		// `Option<String>.unwrap()` inside a specialized body). Once the
+		// receiver type has been rewritten to the concrete owner
 		// specialization, those TypeArgs are semantically redundant and
-		// must be cleared so downstream AST lowering doesn't reintroduce a
-		// bogus turbofish node.
+		// must be cleared so the IR→AST bridge doesn't wrap the call
+		// site in a stray TurbofishExpr that no llvmgen dispatcher
+		// recognises.
 		c.TypeArgs = nil
 		return
 	}

--- a/internal/ir/validate.go
+++ b/internal/ir/validate.go
@@ -79,8 +79,17 @@ func (v *validator) validateDecl(d Decl) {
 				v.validateExpr(f.Default)
 			}
 		}
+		// Builtin-source specializations (`_ZTS…` clones tagged with
+		// BuiltinSource = "List" / "Map" / …) keep body-less intrinsic
+		// method declarations so source-type propagation still works
+		// for downstream dispatch (e.g. `self.get(k).isSome()`). Their
+		// lowering happens in the backend's intrinsic dispatch
+		// (`listMethodInfo` / `mapMethodInfo` / `setMethodInfo`), not
+		// from an injected body — so accept a nil Body here rather
+		// than reporting it as a broken lowering contract.
+		allowNoBody := d.BuiltinSource != ""
 		for _, m := range d.Methods {
-			v.validateFnDecl(m, false)
+			v.validateFnDecl(m, allowNoBody)
 		}
 	case *EnumDecl:
 		seen := map[string]bool{}
@@ -100,8 +109,9 @@ func (v *validator) validateDecl(d Decl) {
 				v.validateType(p, fmt.Sprintf("enum %s variant %s payload[%d]", d.Name, vr.Name, i))
 			}
 		}
+		enumAllowNoBody := d.BuiltinSource != ""
 		for _, m := range d.Methods {
-			v.validateFnDecl(m, false)
+			v.validateFnDecl(m, enumAllowNoBody)
 		}
 	case *InterfaceDecl:
 		v.validateTypeParams("interface "+d.Name, d.Generics)


### PR DESCRIPTION
## Summary

Follow-up on the stdlib-body injection path that PRs [#552](https://github.com/choiceoh/osty/pull/552) and [#558](https://github.com/choiceoh/osty/pull/558) opened. Three aligned changes that keep specialized builtin templates sound through monomorphize without reintroducing the divergent or undispatchable corners.

## Why

With injection on, specialized `Option<T>`, `List<T>`, and `Map<K,V>` surfaced two residual walls the prior PRs didn't cover:

1. Bodied methods like `List<T>.contains { self.indexOf(item).isSome() }` tried to call body-less intrinsics (`self.indexOf`) that the backend didn't dispatch. The legacy llvmgen bridge emitted `LLVM015 call: call target *ast.TurbofishExpr` because source-type propagation couldn't reach `.isSome()`.
2. Non-generic methods on generic owners (`Option<T>.unwrap()` called from inside an `Option<String>` body) still carried the owner-level `[String]` TypeArgs. The IR→AST bridge wrapped them in a stray `TurbofishExpr` that no dispatcher recognised.

## Changes

### `internal/backend/stdlib_type_inject.go`
- Preserve body-less intrinsic declarations on the injected template. Their signatures drive source-type propagation for dispatched `.isSome()` / `.get(k)` chains.
- Cascade-drop **bodied** methods whose body calls a body-less intrinsic the backend doesn't dispatch today. Set is tiny and hard-coded to match `listMethodInfo` / `mapMethodInfo` / `setMethodInfo`:
  - `List<T>` → `indexOf`, `removeAt`, `sort`, `reverse`. The cascade drops `contains` (calls `self.indexOf`) and keeps `first` / `last` / `filter` / `reversed` which only touch dispatched helpers.
  - `Map`, `Set` → empty set; their body-less intrinsics are already fully covered, so every bodied helper (containsKey, getOr, update, union, intersect, …) survives.

### `internal/ir/validate.go`
- Tolerate body-less methods on struct/enum decls tagged with `BuiltinSource` (`List` / `Map` / … specializations). Their body-less intrinsics are lowered from runtime bridges, not from an injected body, so a nil `Body` is not a broken lowering contract for these decls.

### `internal/ir/monomorph.go`
- `rewriteGenericMethodCall`'s early return for non-generic methods now clears `c.TypeArgs`. Owner-level args are already baked into the owner specialization via `receiverEnvOf`; keeping them at the call site only confused the IR→AST bridge.

## Regression impact with `OSTY_STDLIB_BODY_LOWER=1`

- `TestInjectedMapTypeMonomorphizes` survives with **23 methods** (previously 17), including the full `containsKey` / `getOr` / `update` / `retainIf` / `mergeWith` / `mapValues` set.
- `TestLLVMBackendEmitStringsCompareFlagOn`, `TestPrepareEntryInjectsStdlibWhenFlagOn`, `TestPhase2gUserCallsiteDispatchesToSpecializedMethod` all pass.
- `go test ./internal/{ir,llvmgen,backend} -short` — no new regressions.

## Scope — remaining blockers for default flag flip

- Scalar-Option boxing: `list.get on List<Int>` still needs Option<Int> heap wrap (backend codegen work).
- `Result<T, Error>` payload type: the `Error` interface can't appear as an enum payload under current llvmgen limits (supports Int / Float / String only).
- MIR-path runtime assertions (`TestBundledRuntime*`): pre-existing, unrelated to injection.

Each is a separate follow-up before the default flag can safely flip.

## Test plan

- [x] `go test ./internal/{ir,llvmgen,backend} -short -timeout 300s` — green
- [x] Target tests (`TestInjectedMapTypeMonomorphizes`, `TestLLVMBackendEmitStringsCompareFlagOn`, `TestPrepareEntryInjectsStdlibWhenFlagOn`, `TestPhase2gUserCallsiteDispatchesToSpecializedMethod`) — all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)