### PR TITLE
[codex] Prefer specialized map helper dispatch

### DIFF
--- a/internal/backend/stdlib_type_e2e_test.go
+++ b/internal/backend/stdlib_type_e2e_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -12,6 +13,14 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 )
+
+func requireIRCallsSpecializedMethod(t *testing.T, irText, method string) {
+	t.Helper()
+	pattern := regexp.MustCompile(`call [^@]+@[^[:space:]]*__` + regexp.QuoteMeta(method) + `[^[:space:]]*\(`)
+	if !pattern.MatchString(irText) {
+		t.Fatalf("expected a call to specialized method %q in generated IR:\n%s", method, irText)
+	}
+}
 
 // TestPhase2MangledNamesAreValidLLVMIdentifiers locks in the Phase 2
 // fix for LLVM016: `Map<String, V>` now mangles to a name built from
@@ -105,6 +114,107 @@ fn main() {}
 	}
 	if err != nil {
 		t.Logf("Phase 2 pipeline still incomplete past user callsite (expected): %v", err)
+	}
+}
+
+// TestPhase2gContainsKeyUserCallsiteUsesSpecializedMethod locks the
+// follow-up to Phase 2g: once a specialized Map.containsKey body is
+// available, the user callsite should no longer hit the legacy
+// `osty_rt_map_contains_*` shortcut. Instead it must dispatch to the
+// specialized method body (`self.get(key).isSome()`), which keeps the
+// monomorphized helper stack authoritative end-to-end.
+func TestPhase2gContainsKeyUserCallsiteUsesSpecializedMethod(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Bool {
+    m.containsKey(k)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2g_containskey.osty",
+		Source:      []byte(src),
+	}
+	irOut, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil {
+		t.Fatalf("containsKey specialized dispatch failed: %v", err)
+	}
+	got := string(irOut)
+	if strings.Contains(got, "osty_rt_map_contains_") {
+		t.Fatalf("containsKey user callsite still routed through legacy intrinsic:\n%s", got)
+	}
+	requireIRCallsSpecializedMethod(t, got, "containsKey")
+}
+
+func TestPhase2gGetOrUserCallsiteUsesSpecializedMethod(t *testing.T) {
+	src := `fn touch(m: Map<String, Int>, k: String) -> Int {
+    m.getOr(k, 0)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2g_getor.osty",
+		Source:      []byte(src),
+	}
+	irOut, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil {
+		t.Fatalf("getOr specialized dispatch failed: %v", err)
+	}
+	requireIRCallsSpecializedMethod(t, string(irOut), "getOr")
+}
+
+func TestPhase2gMapValuesUserCallsiteUsesSpecializedMethod(t *testing.T) {
+	src := `fn stringify(n: Int) -> String { "{n}" }
+fn touch(m: Map<String, Int>) -> Map<String, String> {
+    m.mapValues(stringify)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2g_mapvalues.osty",
+		Source:      []byte(src),
+	}
+	irOut, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil {
+		t.Fatalf("mapValues specialized dispatch failed: %v", err)
+	}
+	requireIRCallsSpecializedMethod(t, string(irOut), "mapValues")
+}
+
+// Statement-position mutators intentionally keep their dedicated
+// lowering even when a specialized stdlib body exists: update's
+// hand-emit wraps get + callback + insert in one recursive per-map
+// critical section so no concurrent mutator can slip between the read
+// and the write. Specialized user-call dispatch must not bypass that.
+func TestPhase2gUpdateUserCallsiteKeepsLockedLowering(t *testing.T) {
+	src := `fn bump(n: Int?) -> Int { (n ?? 0) + 1 }
+fn touch(m: Map<String, Int>, k: String) {
+    m.update(k, bump)
+}
+fn main() {}
+`
+	monoMod := pipelineThroughMonomorph(t, src)
+	opts := llvmgen.Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/phase2g_update.osty",
+		Source:      []byte(src),
+	}
+	irOut, err := llvmgen.GenerateModule(monoMod, opts)
+	if err != nil {
+		t.Fatalf("update lowering failed: %v", err)
+	}
+	got := string(irOut)
+	for _, want := range []string{
+		"call void @osty_rt_map_lock(",
+		"call void @osty_rt_map_unlock(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("update must preserve locked lowering, missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -3287,6 +3287,11 @@ func (g *generator) emitMapMethodCall(call *ast.CallExpr) (value, bool, error) {
 	if !found {
 		return value{}, false, nil
 	}
+	if preferSpecialized, err := g.specializedBuiltinUserMethodAvailable(call); err != nil {
+		return value{}, true, err
+	} else if preferSpecialized {
+		return value{}, false, nil
+	}
 	base, err := g.emitExpr(field.X)
 	if err != nil {
 		return value{}, true, err
@@ -4877,6 +4882,31 @@ func (g *generator) userCallTarget(call *ast.CallExpr) (*fnSig, ast.Expr, bool, 
 	default:
 		return nil, nil, false, nil
 	}
+}
+
+// specializedBuiltinUserMethodAvailable reports whether `call` targets a
+// specialized stdlib built-in method body registered under the mangled
+// owner type (Map<String, Int> -> %_ZTS...). Intrinsic interceptors use
+// this as an escape hatch so monomorphized helper bodies can win over
+// legacy hand-emit paths at user callsites, while the plain AST path
+// continues to fall back to the runtime-backed helpers.
+func (g *generator) specializedBuiltinUserMethodAvailable(call *ast.CallExpr) (bool, error) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field == nil || field.IsOptional || field.X == nil {
+		return false, nil
+	}
+	baseSource, ok := g.staticExprSourceType(field.X)
+	if !ok {
+		return false, nil
+	}
+	if _, ok := specializedBuiltinMangledForSurface(baseSource); !ok {
+		return false, nil
+	}
+	sig, _, found, err := g.userCallTarget(call)
+	if err != nil {
+		return false, err
+	}
+	return found && sig != nil, nil
 }
 
 func (g *generator) emitEnumVariantCall(call *ast.CallExpr) (value, bool, error) {


### PR DESCRIPTION
## What changed
- prefer specialized method dispatch over the legacy map intrinsic shortcut for user callsites that now have a monomorphized helper body
- keep that preference focused on expression-position helpers such as `containsKey`, `getOr`, and `mapValues`
- preserve the dedicated statement-position lowering for `update` so the per-map lock/unlock critical section remains in force
- add backend e2e regression coverage that asserts the generated IR actually calls specialized helper symbols for `containsKey`, `getOr`, and `mapValues`, while `update` still emits the locked lowering

## Why
- after the previous stabilization work, specialized Map helper bodies were present in IR but some user callsites could still be intercepted by the older hand-emitted path
- `containsKey` was the visible example, and the same dispatch surface needed a broader regression net for helper methods that should now route through specialized bodies
- `update` is intentionally different because its hand-emitted lowering carries concurrency safety that the plain specialized body does not yet preserve

## Impact
- user callsites for `containsKey`, `getOr`, and `mapValues` now exercise the specialized monomorphized helper path end-to-end
- the old `osty_rt_map_contains_*` shortcut no longer wins when a specialized `containsKey` body exists
- `update` remains on the locked path, protecting the existing safety guarantees

## Validation
- `go test -count=1 -vet=off -run 'TestPhase2gContainsKeyUserCallsiteUsesSpecializedMethod|TestPhase2gGetOrUserCallsiteUsesSpecializedMethod|TestPhase2gMapValuesUserCallsiteUsesSpecializedMethod|TestPhase2gUpdateUserCallsiteKeepsLockedLowering|TestPhase2MonomorphMapReachesGenerateModule' ./internal/backend`
- `go test -count=1 -vet=off -run 'TestGenerateMapGetOrComposesOnGetAndCoalesce|TestGenerateMapMapValuesRebuildsWithNewValueType|TestGenerateMapUpdateRunsUnderLock' ./internal/llvmgen`