### PR TITLE
[codex] Extend native llvmgen struct entry slice

### DIFF
--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -7,6 +7,21 @@ import (
 	ostyir "github.com/osty/osty/internal/ir"
 )
 
+type nativeStructFieldInfo struct {
+	name     string
+	llvmType string
+	index    int
+}
+
+type nativeStructInfo struct {
+	def    *llvmNativeStruct
+	byName map[string]nativeStructFieldInfo
+}
+
+type nativeProjectionCtx struct {
+	structsByName map[string]*nativeStructInfo
+}
+
 // tryNativeOwnedModule projects the IR module into the native-owned
 // primitive/control-flow slice mirrored from toolchain/llvmgen.osty.
 // ok=false means "shape not covered yet" and callers should fall back to the
@@ -23,9 +38,11 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 	if mod == nil {
 		return nil, false
 	}
+	ctx := &nativeProjectionCtx{structsByName: map[string]*nativeStructInfo{}}
 	out := &llvmNativeModule{
 		sourcePath: firstNonEmpty(opts.SourcePath, "<unknown>"),
 		target:     opts.Target,
+		structs:    make([]*llvmNativeStruct, 0, len(mod.Decls)),
 		functions:  make([]*llvmNativeFunction, 0, len(mod.Decls)+1),
 	}
 	hasMain := false
@@ -37,8 +54,30 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 			if d.IsFFI() {
 				return nil, false
 			}
+		case *ostyir.StructDecl:
+			info, ok := nativeRegisterStructDecl(d)
+			if !ok {
+				return nil, false
+			}
+			if _, exists := ctx.structsByName[d.Name]; exists {
+				return nil, false
+			}
+			ctx.structsByName[d.Name] = info
+			out.structs = append(out.structs, info.def)
+		}
+	}
+	for _, decl := range mod.Decls {
+		switch d := decl.(type) {
+		case nil:
+			continue
+		case *ostyir.UseDecl:
+			continue
+		case *ostyir.StructDecl:
+			if !nativePopulateStructDecl(ctx, d) {
+				return nil, false
+			}
 		case *ostyir.FnDecl:
-			fn, ok := nativeFunctionFromIR(d)
+			fn, ok := nativeFunctionFromIR(ctx, d)
 			if !ok {
 				return nil, false
 			}
@@ -54,7 +93,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		if hasMain {
 			return nil, false
 		}
-		mainBody, ok := nativeBlockFromStmts(mod.Script, "i32")
+		mainBody, ok := nativeBlockFromStmts(ctx, mod.Script, "i32")
 		if !ok {
 			return nil, false
 		}
@@ -67,11 +106,57 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 	return out, true
 }
 
-func nativeFunctionFromIR(fn *ostyir.FnDecl) (*llvmNativeFunction, bool) {
+func nativeRegisterStructDecl(decl *ostyir.StructDecl) (*nativeStructInfo, bool) {
+	if decl == nil || decl.Name == "" || len(decl.Generics) != 0 || len(decl.Methods) != 0 {
+		return nil, false
+	}
+	return &nativeStructInfo{
+		def: &llvmNativeStruct{
+			name:     decl.Name,
+			llvmType: llvmStructTypeName(decl.Name),
+			fields:   make([]*llvmNativeStructField, 0, len(decl.Fields)),
+		},
+		byName: map[string]nativeStructFieldInfo{},
+	}, true
+}
+
+func nativePopulateStructDecl(ctx *nativeProjectionCtx, decl *ostyir.StructDecl) bool {
+	if ctx == nil || decl == nil {
+		return false
+	}
+	info := ctx.structsByName[decl.Name]
+	if info == nil || len(info.def.fields) != 0 {
+		return info != nil
+	}
+	for i, field := range decl.Fields {
+		if field == nil || field.Name == "" || field.Default != nil {
+			return false
+		}
+		if _, exists := info.byName[field.Name]; exists {
+			return false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, field.Type)
+		if !ok || llvmType == "void" || llvmType == info.def.llvmType {
+			return false
+		}
+		info.def.fields = append(info.def.fields, &llvmNativeStructField{
+			name:     field.Name,
+			llvmType: llvmType,
+		})
+		info.byName[field.Name] = nativeStructFieldInfo{
+			name:     field.Name,
+			llvmType: llvmType,
+			index:    i,
+		}
+	}
+	return true
+}
+
+func nativeFunctionFromIR(ctx *nativeProjectionCtx, fn *ostyir.FnDecl) (*llvmNativeFunction, bool) {
 	if fn == nil || len(fn.Generics) != 0 || fn.IsIntrinsic || fn.Body == nil {
 		return nil, false
 	}
-	retType, ok := nativeFunctionReturnType(fn)
+	retType, ok := nativeFunctionReturnType(ctx, fn)
 	if !ok {
 		return nil, false
 	}
@@ -84,7 +169,7 @@ func nativeFunctionFromIR(fn *ostyir.FnDecl) (*llvmNativeFunction, bool) {
 		if param == nil || param.IsDestructured() || param.Default != nil {
 			return nil, false
 		}
-		llvmType, ok := nativeLLVMTypeFromIR(param.Type)
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, param.Type)
 		if !ok || llvmType == "void" {
 			return nil, false
 		}
@@ -93,7 +178,7 @@ func nativeFunctionFromIR(fn *ostyir.FnDecl) (*llvmNativeFunction, bool) {
 			llvmType: llvmType,
 		})
 	}
-	body, ok := nativeBlockFromIR(fn.Body, retType)
+	body, ok := nativeBlockFromIR(ctx, fn.Body, retType)
 	if !ok {
 		return nil, false
 	}
@@ -101,17 +186,17 @@ func nativeFunctionFromIR(fn *ostyir.FnDecl) (*llvmNativeFunction, bool) {
 	return out, true
 }
 
-func nativeFunctionReturnType(fn *ostyir.FnDecl) (string, bool) {
+func nativeFunctionReturnType(ctx *nativeProjectionCtx, fn *ostyir.FnDecl) (string, bool) {
 	if fn == nil {
 		return "", false
 	}
 	if fn.Name == "main" && len(fn.Params) == 0 && nativeIsUnitType(fn.Return) {
 		return "i32", true
 	}
-	return nativeLLVMTypeFromIR(fn.Return)
+	return nativeLLVMTypeFromIR(ctx, fn.Return)
 }
 
-func nativeBlockFromIR(block *ostyir.Block, fnReturnType string) (*llvmNativeBlock, bool) {
+func nativeBlockFromIR(ctx *nativeProjectionCtx, block *ostyir.Block, fnReturnType string) (*llvmNativeBlock, bool) {
 	if block == nil {
 		return &llvmNativeBlock{}, true
 	}
@@ -119,7 +204,7 @@ func nativeBlockFromIR(block *ostyir.Block, fnReturnType string) (*llvmNativeBlo
 		stmts: make([]*llvmNativeStmt, 0, len(block.Stmts)),
 	}
 	for _, stmt := range block.Stmts {
-		nativeStmt, ok := nativeStmtFromIR(stmt, fnReturnType)
+		nativeStmt, ok := nativeStmtFromIR(ctx, stmt, fnReturnType)
 		if !ok {
 			return nil, false
 		}
@@ -128,7 +213,7 @@ func nativeBlockFromIR(block *ostyir.Block, fnReturnType string) (*llvmNativeBlo
 		}
 	}
 	if block.Result != nil {
-		result, ok := nativeExprFromIR(block.Result)
+		result, ok := nativeExprFromIR(ctx, block.Result)
 		if !ok {
 			return nil, false
 		}
@@ -138,12 +223,12 @@ func nativeBlockFromIR(block *ostyir.Block, fnReturnType string) (*llvmNativeBlo
 	return out, true
 }
 
-func nativeBlockFromStmts(stmts []ostyir.Stmt, fnReturnType string) (*llvmNativeBlock, bool) {
+func nativeBlockFromStmts(ctx *nativeProjectionCtx, stmts []ostyir.Stmt, fnReturnType string) (*llvmNativeBlock, bool) {
 	out := &llvmNativeBlock{
 		stmts: make([]*llvmNativeStmt, 0, len(stmts)),
 	}
 	for _, stmt := range stmts {
-		nativeStmt, ok := nativeStmtFromIR(stmt, fnReturnType)
+		nativeStmt, ok := nativeStmtFromIR(ctx, stmt, fnReturnType)
 		if !ok {
 			return nil, false
 		}
@@ -154,7 +239,7 @@ func nativeBlockFromStmts(stmts []ostyir.Stmt, fnReturnType string) (*llvmNative
 	return out, true
 }
 
-func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, bool) {
+func nativeStmtFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, bool) {
 	switch s := stmt.(type) {
 	case nil:
 		return nil, true
@@ -162,7 +247,7 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 		if s.Pattern != nil || s.Value == nil {
 			return nil, false
 		}
-		value, ok := nativeExprFromIR(s.Value)
+		value, ok := nativeExprFromIR(ctx, s.Value)
 		if !ok {
 			return nil, false
 		}
@@ -176,7 +261,7 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 			childExprs: []*llvmNativeExpr{value},
 		}, true
 	case *ostyir.ExprStmt:
-		expr, ok := nativeExprFromIR(s.X)
+		expr, ok := nativeExprFromIR(ctx, s.X)
 		if !ok {
 			return nil, false
 		}
@@ -192,7 +277,7 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 		if !ok {
 			return nil, false
 		}
-		value, ok := nativeExprFromIR(s.Value)
+		value, ok := nativeExprFromIR(ctx, s.Value)
 		if !ok {
 			return nil, false
 		}
@@ -208,7 +293,7 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 			llvmType: fnReturnType,
 		}
 		if s.Value != nil {
-			value, ok := nativeExprFromIR(s.Value)
+			value, ok := nativeExprFromIR(ctx, s.Value)
 			if !ok {
 				return nil, false
 			}
@@ -216,11 +301,11 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 		}
 		return out, true
 	case *ostyir.IfStmt:
-		cond, ok := nativeExprFromIR(s.Cond)
+		cond, ok := nativeExprFromIR(ctx, s.Cond)
 		if !ok {
 			return nil, false
 		}
-		thenBlock, ok := nativeBlockFromIR(s.Then, fnReturnType)
+		thenBlock, ok := nativeBlockFromIR(ctx, s.Then, fnReturnType)
 		if !ok {
 			return nil, false
 		}
@@ -230,7 +315,7 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 			childBlocks: []*llvmNativeBlock{thenBlock},
 		}
 		if s.Else != nil {
-			elseBlock, ok := nativeBlockFromIR(s.Else, fnReturnType)
+			elseBlock, ok := nativeBlockFromIR(ctx, s.Else, fnReturnType)
 			if !ok {
 				return nil, false
 			}
@@ -240,11 +325,11 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 	case *ostyir.ForStmt:
 		switch s.Kind {
 		case ostyir.ForWhile:
-			cond, ok := nativeExprFromIR(s.Cond)
+			cond, ok := nativeExprFromIR(ctx, s.Cond)
 			if !ok {
 				return nil, false
 			}
-			body, ok := nativeBlockFromIR(s.Body, fnReturnType)
+			body, ok := nativeBlockFromIR(ctx, s.Body, fnReturnType)
 			if !ok {
 				return nil, false
 			}
@@ -257,15 +342,15 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 			if s.IsDestructured() || s.Var == "" {
 				return nil, false
 			}
-			start, ok := nativeExprFromIR(s.Start)
+			start, ok := nativeExprFromIR(ctx, s.Start)
 			if !ok {
 				return nil, false
 			}
-			end, ok := nativeExprFromIR(s.End)
+			end, ok := nativeExprFromIR(ctx, s.End)
 			if !ok {
 				return nil, false
 			}
-			body, ok := nativeBlockFromIR(s.Body, fnReturnType)
+			body, ok := nativeBlockFromIR(ctx, s.Body, fnReturnType)
 			if !ok {
 				return nil, false
 			}
@@ -284,7 +369,7 @@ func nativeStmtFromIR(stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, b
 	}
 }
 
-func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
+func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeExpr, bool) {
 	switch e := expr.(type) {
 	case nil:
 		return nil, false
@@ -293,13 +378,13 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 		if !ok {
 			return nil, false
 		}
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
 		return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: llvmType, text: text}, true
 	case *ostyir.FloatLit:
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
@@ -317,17 +402,80 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 		}
 		return &llvmNativeExpr{kind: llvmNativeExprString, llvmType: "ptr", text: text}, true
 	case *ostyir.Ident:
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
 		return &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: llvmType, name: e.Name}, true
-	case *ostyir.UnaryExpr:
-		inner, ok := nativeExprFromIR(e.X)
+	case *ostyir.StructLit:
+		info, ok := nativeStructInfoFromType(ctx, e.Type())
+		if !ok || e.Spread != nil {
+			return nil, false
+		}
+		fieldsByName := make(map[string]ostyir.StructLitField, len(e.Fields))
+		for _, field := range e.Fields {
+			if field.Name == "" {
+				return nil, false
+			}
+			if _, exists := fieldsByName[field.Name]; exists {
+				return nil, false
+			}
+			fieldsByName[field.Name] = field
+		}
+		out := &llvmNativeExpr{
+			kind:       llvmNativeExprStructLit,
+			llvmType:   info.def.llvmType,
+			childExprs: make([]*llvmNativeExpr, 0, len(info.def.fields)),
+		}
+		for _, field := range info.def.fields {
+			entry, ok := fieldsByName[field.name]
+			if !ok {
+				return nil, false
+			}
+			if entry.Value == nil {
+				out.childExprs = append(out.childExprs, &llvmNativeExpr{
+					kind:     llvmNativeExprIdent,
+					llvmType: field.llvmType,
+					name:     field.name,
+				})
+				continue
+			}
+			value, ok := nativeExprFromIR(ctx, entry.Value)
+			if !ok || value.llvmType != field.llvmType {
+				return nil, false
+			}
+			out.childExprs = append(out.childExprs, value)
+		}
+		return out, true
+	case *ostyir.FieldExpr:
+		if e.Optional {
+			return nil, false
+		}
+		info, ok := nativeStructInfoFromType(ctx, e.X.Type())
 		if !ok {
 			return nil, false
 		}
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		field, ok := info.byName[e.Name]
+		if !ok {
+			return nil, false
+		}
+		base, ok := nativeExprFromIR(ctx, e.X)
+		if !ok {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprField,
+			llvmType:   field.llvmType,
+			name:       field.name,
+			fieldIndex: field.index,
+			childExprs: []*llvmNativeExpr{base},
+		}, true
+	case *ostyir.UnaryExpr:
+		inner, ok := nativeExprFromIR(ctx, e.X)
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
@@ -338,15 +486,15 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 			childExprs: []*llvmNativeExpr{inner},
 		}, true
 	case *ostyir.BinaryExpr:
-		left, ok := nativeExprFromIR(e.Left)
+		left, ok := nativeExprFromIR(ctx, e.Left)
 		if !ok {
 			return nil, false
 		}
-		right, ok := nativeExprFromIR(e.Right)
+		right, ok := nativeExprFromIR(ctx, e.Right)
 		if !ok {
 			return nil, false
 		}
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
@@ -361,7 +509,7 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 		if !ok || len(e.TypeArgs) != 0 {
 			return nil, false
 		}
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
@@ -375,7 +523,7 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 			if arg.IsKeyword() {
 				return nil, false
 			}
-			value, ok := nativeExprFromIR(arg.Value)
+			value, ok := nativeExprFromIR(ctx, arg.Value)
 			if !ok {
 				return nil, false
 			}
@@ -386,7 +534,7 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 		if e.Kind != ostyir.IntrinsicPrintln || len(e.Args) != 1 || e.Args[0].IsKeyword() {
 			return nil, false
 		}
-		value, ok := nativeExprFromIR(e.Args[0].Value)
+		value, ok := nativeExprFromIR(ctx, e.Args[0].Value)
 		if !ok {
 			return nil, false
 		}
@@ -396,19 +544,19 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 			childExprs: []*llvmNativeExpr{value},
 		}, true
 	case *ostyir.IfExpr:
-		cond, ok := nativeExprFromIR(e.Cond)
+		cond, ok := nativeExprFromIR(ctx, e.Cond)
 		if !ok {
 			return nil, false
 		}
-		thenBlock, ok := nativeBlockFromIR(e.Then, "")
+		thenBlock, ok := nativeBlockFromIR(ctx, e.Then, "")
 		if !ok {
 			return nil, false
 		}
-		elseBlock, ok := nativeBlockFromIR(e.Else, "")
+		elseBlock, ok := nativeBlockFromIR(ctx, e.Else, "")
 		if !ok {
 			return nil, false
 		}
-		llvmType, ok := nativeLLVMTypeFromIR(e.Type())
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
 		if !ok {
 			return nil, false
 		}
@@ -423,7 +571,19 @@ func nativeExprFromIR(expr ostyir.Expr) (*llvmNativeExpr, bool) {
 	}
 }
 
-func nativeLLVMTypeFromIR(t ostyir.Type) (string, bool) {
+func nativeStructInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeStructInfo, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	named, ok := t.(*ostyir.NamedType)
+	if !ok || named == nil || named.Builtin || named.Package != "" || len(named.Args) != 0 {
+		return nil, false
+	}
+	info := ctx.structsByName[named.Name]
+	return info, info != nil
+}
+
+func nativeLLVMTypeFromIR(ctx *nativeProjectionCtx, t ostyir.Type) (string, bool) {
 	switch tt := t.(type) {
 	case nil:
 		return "void", true
@@ -439,6 +599,12 @@ func nativeLLVMTypeFromIR(t ostyir.Type) (string, bool) {
 			llvmType := llvmBuiltinType(name)
 			return llvmType, llvmType != ""
 		}
+	case *ostyir.NamedType:
+		info, ok := nativeStructInfoFromType(ctx, tt)
+		if !ok {
+			return "", false
+		}
+		return info.def.llvmType, true
 	default:
 		return "", false
 	}

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -77,7 +77,7 @@ fn main() {
 	}
 }
 
-func TestNativeOwnedModuleEntryFallsBackForStructs(t *testing.T) {
+func TestNativeOwnedModuleEntryStructSlice(t *testing.T) {
 	src := `struct Pair { left: Int, right: Int }
 
 fn main() {
@@ -87,8 +87,42 @@ fn main() {
 `
 	mod := lowerNativeEntryModule(t, src)
 	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_script.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for plain struct slice")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"%Pair = type { i64, i64 }",
+		"insertvalue %Pair",
+		"extractvalue %Pair",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned struct IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned struct entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryFallsBackForStructFieldAssign(t *testing.T) {
+	src := `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let mut pair = Pair { left: 1, right: 2 }
+    pair.left = 3
+    println(pair.left)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_struct_assign.osty"}
 	if nativeMod, ok := nativeModuleFromIR(mod, opts); ok {
-		t.Fatalf("nativeModuleFromIR unexpectedly accepted struct-bearing module: %#v", nativeMod)
+		t.Fatalf("nativeModuleFromIR unexpectedly accepted struct field assignment: %#v", nativeMod)
 	}
 	out, err := GenerateModule(mod, opts)
 	if err != nil {

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -16,6 +16,8 @@ const (
 	llvmNativeExprBool
 	llvmNativeExprString
 	llvmNativeExprIdent
+	llvmNativeExprStructLit
+	llvmNativeExprField
 	llvmNativeExprUnary
 	llvmNativeExprBinary
 	llvmNativeExprCall
@@ -43,6 +45,7 @@ type llvmNativeExpr struct {
 	text        string
 	name        string
 	op          string
+	fieldIndex  int
 	boolValue   bool
 	inclusive   bool
 	childExprs  []*llvmNativeExpr
@@ -70,6 +73,17 @@ type llvmNativeParam struct {
 	llvmType string
 }
 
+type llvmNativeStructField struct {
+	name     string
+	llvmType string
+}
+
+type llvmNativeStruct struct {
+	name     string
+	llvmType string
+	fields   []*llvmNativeStructField
+}
+
 type llvmNativeFunction struct {
 	name       string
 	returnType string
@@ -80,6 +94,7 @@ type llvmNativeFunction struct {
 type llvmNativeModule struct {
 	sourcePath string
 	target     string
+	structs    []*llvmNativeStruct
 	functions  []*llvmNativeFunction
 }
 
@@ -98,16 +113,27 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 	if mod == nil {
 		return llvmRenderModule("", "", nil)
 	}
+	typeDefs := make([]string, 0, len(mod.structs))
 	definitions := make([]string, 0, len(mod.functions))
 	stringGlobals := make([]*LlvmStringGlobal, 0)
 	nextStringID := 0
+	for _, st := range mod.structs {
+		if st == nil {
+			continue
+		}
+		fieldTypes := make([]string, 0, len(st.fields))
+		for _, field := range st.fields {
+			fieldTypes = append(fieldTypes, field.llvmType)
+		}
+		typeDefs = append(typeDefs, llvmStructTypeDef(strings.TrimPrefix(st.llvmType, "%"), fieldTypes))
+	}
 	for _, fn := range mod.functions {
 		rendered := llvmNativeEmitFunction(fn, nextStringID)
 		nextStringID = rendered.nextStringID
 		definitions = append(definitions, rendered.definition)
 		stringGlobals = append(stringGlobals, rendered.stringGlobals...)
 	}
-	return llvmRenderModuleWithGlobals(mod.sourcePath, mod.target, stringGlobals, definitions)
+	return llvmRenderModuleWithGlobalsAndTypes(mod.sourcePath, mod.target, typeDefs, stringGlobals, definitions)
 }
 
 func llvmNativeEmitFunction(fn *llvmNativeFunction, startStringID int) llvmNativeRenderedFunction {
@@ -259,6 +285,18 @@ func llvmNativeEvalExpr(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
 		return llvmStringLiteral(emitter, expr.text)
 	case llvmNativeExprIdent:
 		return llvmIdent(emitter, expr.name)
+	case llvmNativeExprStructLit:
+		fields := make([]*LlvmValue, 0, len(expr.childExprs))
+		for _, child := range expr.childExprs {
+			fields = append(fields, llvmNativeEvalExpr(emitter, child))
+		}
+		return llvmStructLiteral(emitter, expr.llvmType, fields)
+	case llvmNativeExprField:
+		if len(expr.childExprs) == 0 {
+			return llvmNativeZeroValue(expr.llvmType)
+		}
+		base := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+		return llvmExtractValue(emitter, base, expr.llvmType, expr.fieldIndex)
 	case llvmNativeExprUnary:
 		return llvmNativeEvalUnary(emitter, expr)
 	case llvmNativeExprBinary:

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1117,6 +1117,8 @@ pub enum LlvmNativeExprKind {
     LlvmNativeExprBool,
     LlvmNativeExprString,
     LlvmNativeExprIdent,
+    LlvmNativeExprStructLit,
+    LlvmNativeExprField,
     LlvmNativeExprUnary,
     LlvmNativeExprBinary,
     LlvmNativeExprCall,
@@ -1142,6 +1144,7 @@ pub struct LlvmNativeExpr {
     pub text: String,
     pub name: String,
     pub op: String,
+    pub fieldIndex: Int,
     pub boolValue: Bool,
     pub inclusive: Bool,
     pub childExprs: List<LlvmNativeExpr>,
@@ -1169,6 +1172,17 @@ pub struct LlvmNativeParam {
     pub llvmType: String,
 }
 
+pub struct LlvmNativeStructField {
+    pub name: String,
+    pub llvmType: String,
+}
+
+pub struct LlvmNativeStruct {
+    pub name: String,
+    pub llvmType: String,
+    pub fields: List<LlvmNativeStructField>,
+}
+
 pub struct LlvmNativeFunction {
     pub name: String,
     pub returnType: String,
@@ -1179,6 +1193,7 @@ pub struct LlvmNativeFunction {
 pub struct LlvmNativeModule {
     pub sourcePath: String,
     pub target: String,
+    pub structs: List<LlvmNativeStruct>,
     pub functions: List<LlvmNativeFunction>,
 }
 
@@ -1194,10 +1209,18 @@ pub struct LlvmNativeMaybeValue {
 }
 
 pub fn llvmNativeEmitModule(module: LlvmNativeModule) -> String {
+    let mut typeDefs: List<String> = []
     let mut definitions: List<String> = []
     let globalsSeed = llvmEmitter()
     let mut stringGlobals = globalsSeed.stringGlobals
     let mut nextStringId = 0
+    for st in module.structs {
+        let mut fieldTypes: List<String> = []
+        for field in st.fields {
+            fieldTypes.push(field.llvmType)
+        }
+        typeDefs.push(llvmStructTypeDef(st.name, fieldTypes))
+    }
     for function in module.functions {
         let rendered = llvmNativeEmitFunction(function, nextStringId)
         nextStringId = rendered.nextStringId
@@ -1206,7 +1229,7 @@ pub fn llvmNativeEmitModule(module: LlvmNativeModule) -> String {
             stringGlobals.push(global)
         }
     }
-    llvmRenderModuleWithGlobals(module.sourcePath, module.target, stringGlobals, definitions)
+    llvmRenderModuleWithGlobalsAndTypes(module.sourcePath, module.target, typeDefs, stringGlobals, definitions)
 }
 
 pub fn llvmNativeEmitFunction(
@@ -1404,6 +1427,8 @@ fn llvmNativeEvalExpr(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
         },
         LlvmNativeExprString -> llvmStringLiteral(emitter, expr.text),
         LlvmNativeExprIdent -> llvmIdent(emitter, expr.name),
+        LlvmNativeExprStructLit -> llvmNativeEvalStructLit(emitter, expr),
+        LlvmNativeExprField -> llvmNativeEvalField(emitter, expr),
         LlvmNativeExprUnary -> llvmNativeEvalUnary(emitter, expr),
         LlvmNativeExprBinary -> llvmNativeEvalBinary(emitter, expr),
         LlvmNativeExprCall -> llvmNativeEvalCall(emitter, expr),
@@ -1411,6 +1436,25 @@ fn llvmNativeEvalExpr(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
         LlvmNativeExprIf -> llvmNativeEvalIfExpr(emitter, expr),
         _ -> llvmNativeZeroValue(expr.llvmType),
     }
+}
+
+fn llvmNativeEvalStructLit(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        return llvmStructLiteral(emitter, expr.llvmType, [])
+    }
+    let mut fields = [llvmNativeEvalExpr(emitter, expr.childExprs[0])]
+    for i in 1..expr.childExprs.len() {
+        fields.push(llvmNativeEvalExpr(emitter, expr.childExprs[i]))
+    }
+    llvmStructLiteral(emitter, expr.llvmType, fields)
+}
+
+fn llvmNativeEvalField(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let base = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    llvmExtractValue(emitter, base, expr.llvmType, expr.fieldIndex)
 }
 
 fn llvmNativeEvalUnary(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {


### PR DESCRIPTION
## Summary
- extend the native-owned llvmgen module entry path to support plain struct declarations, literals, and field access
- keep struct field assignment on the legacy fallback boundary for now
- mirror the native snapshot/toolchain emitter changes and add focused regression coverage

## Verification
- `go test ./internal/llvmgen -run 'TestNativeOwnedModuleEntry|TestGenerateModuleWhileLoopCompat|TestGenerateModuleGenericIdentityMonomorphized|TestGenerateModuleGenericStructPairMonomorphized|TestNativeToolchainMergedIsClean$|TestProbeNativeToolchainMerged$' -count=1 -v`
- `go test ./internal/backend -run 'TestLLVMBackendEmitLLVMIRSkipsToolchain|TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback' -count=1`