### PR TITLE
feat(llvmgen): Option<T>.unwrap() + OptionalType TypeArgs strip

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -3942,7 +3942,7 @@ func (g *generator) emitOptionMethodCall(call *ast.CallExpr) (value, bool, error
 	if !ok || field.IsOptional {
 		return value{}, false, nil
 	}
-	if field.Name != "isSome" && field.Name != "isNone" {
+	if field.Name != "isSome" && field.Name != "isNone" && field.Name != "unwrap" {
 		return value{}, false, nil
 	}
 	if len(call.Args) != 0 {
@@ -3952,7 +3952,8 @@ func (g *generator) emitOptionMethodCall(call *ast.CallExpr) (value, bool, error
 	if !ok {
 		return value{}, false, nil
 	}
-	if _, isOpt := baseSrc.(*ast.OptionalType); !isOpt {
+	optType, isOpt := baseSrc.(*ast.OptionalType)
+	if !isOpt {
 		return value{}, false, nil
 	}
 	base, err := g.emitExpr(field.X)
@@ -3961,6 +3962,9 @@ func (g *generator) emitOptionMethodCall(call *ast.CallExpr) (value, bool, error
 	}
 	if base.typ != "ptr" {
 		return value{}, true, unsupportedf("type-system", "Option.%s receiver type %s, want ptr", field.Name, base.typ)
+	}
+	if field.Name == "unwrap" {
+		return g.emitOptionUnwrap(base, optType, call)
 	}
 	emitter := g.toOstyEmitter()
 	cmp := llvmNextTemp(emitter)
@@ -3971,6 +3975,44 @@ func (g *generator) emitOptionMethodCall(call *ast.CallExpr) (value, bool, error
 	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s ptr %s, null", cmp, op, base.ref))
 	g.takeOstyEmitter(emitter)
 	return value{typ: "i1", ref: cmp}, true, nil
+}
+
+// emitOptionUnwrap lowers `opt.unwrap()` for a ptr-backed `Option<T>`:
+// if the receiver is non-null the payload ptr is the result; null
+// aborts with a "called unwrap on None" message (matching the spec's
+// panic shape). Uses the same print+exit+unreachable contract as
+// `emitTestingAbortWithEmitter` so the abort path is visible in
+// stderr without pulling in the full testing harness.
+//
+// Scalar Option (Option<Int>, Option<Bool>, …) still routes through
+// the caller's generic fallback — ptr-backed is where the injection
+// pipeline (`List<T>.first(self) -> T?`, `self.indexOf(k).isSome()`
+// chains, …) needs unwrap first.
+func (g *generator) emitOptionUnwrap(base value, optType *ast.OptionalType, call *ast.CallExpr) (value, bool, error) {
+	emitter := g.toOstyEmitter()
+	isNone := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNone, base.ref))
+	someLabel := llvmNextLabel(emitter, "unwrap.some")
+	noneLabel := llvmNextLabel(emitter, "unwrap.none")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNone, noneLabel, someLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(noneLabel)
+
+	emitter = g.toOstyEmitter()
+	msg := fmt.Sprintf("unwrap on None at %s", g.sourceLineLabel(call.Pos().Line, "<unwrap>"))
+	msgPtr := llvmStringLiteral(emitter, msg)
+	llvmPrintlnString(emitter, msgPtr)
+	g.declareRuntimeSymbol("exit", "void", []paramInfo{{typ: "i32"}})
+	emitter.body = append(emitter.body, "  call void @exit(i32 1)")
+	emitter.body = append(emitter.body, "  unreachable")
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	g.takeOstyEmitter(emitter)
+	g.enterBlock(someLabel)
+
+	out := base
+	out.sourceType = optType.Inner
+	return out, true, nil
 }
 
 func (g *generator) emitSetMethodCall(call *ast.CallExpr) (value, bool, error) {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -1455,8 +1455,20 @@ func legacyMethodCallFromIR(expr *ostyir.MethodCall) (ast.Expr, error) {
 	// (already encoded by the specialized receiver type) but trip
 	// the legacy emitter with LLVM015 when wrapped in TurbofishExpr.
 	// Drop them here when the receiver is a specialized built-in.
+	//
+	// The receiver type can be:
+	//   - `*ir.NamedType` with a `_ZTS…` mangled name for specialized
+	//     struct/enum owners (Map, List, Set, specialized Result),
+	//   - `*ir.OptionalType` — surface form for `Option<T>`, which
+	//     keeps the unmangled shape because `T?` has a direct LLVM
+	//     representation as a nullable ptr. Method calls on it
+	//     (`x.unwrap()`, `x.isSome()`) are still specialized-builtin
+	//     dispatches and carry the same redundant owner-level args.
 	if len(typeArgs) != 0 && expr.Receiver != nil {
-		if named, ok := expr.Receiver.Type().(*ostyir.NamedType); ok && strings.HasPrefix(named.Name, "_ZTS") {
+		rt := expr.Receiver.Type()
+		if opt, ok := rt.(*ostyir.OptionalType); ok && opt != nil {
+			typeArgs = nil
+		} else if named, ok := rt.(*ostyir.NamedType); ok && strings.HasPrefix(named.Name, "_ZTS") {
 			typeArgs = nil
 		}
 	}


### PR DESCRIPTION
## Summary

Two aligned fixes unblock the `OSTY_STDLIB_BODY_LOWER=1` path for every injected body that touches `Option<T>.unwrap()` or `x.isSome()` through an `OptionalType`-typed receiver. Drops the flag-on regression count **21 → 15** (6 tests recovered).

## Why

With injection on, two residual walls kept surfacing:

1. `LLVM015 call: call target *ast.TurbofishExpr` — injected bodies like `x.unwrap()` (where `x: Option<String>` inside a specialized `Option<String>` body) still carried the owner-level `[String]` TypeArgs. `legacyMethodCallFromIR`'s existing redundant-typearg strip only handled `_ZTS…` mangled nominal receivers; `OptionalType`-typed receivers slipped through and got wrapped in a stray `TurbofishExpr` that no dispatcher recognised.
2. `LLVM015 call: call target *ast.FieldExpr (x.unwrap)` — once the Turbofish wrapping was gone, `emitOptionMethodCall` only knew `isSome` / `isNone`, so `unwrap` fell through to the generic fallback.

## Changes

### `internal/llvmgen/ir_module.go`
Extend the redundant-typearg strip to recognise `*ir.OptionalType` receivers. `Option<T>` keeps its unmangled surface because `T?` has a direct LLVM representation (nullable ptr), so method calls on it are still specialized-builtin dispatches with redundant owner-level args. Clearing them routes the call through the plain FieldExpr dispatch that `emitOptionMethodCall` handles.

### `internal/llvmgen/expr.go`
`emitOptionMethodCall` now handles `unwrap` alongside `isSome` / `isNone` for ptr-backed Option. The happy path is a null check on the receiver ptr; the None branch prints `"unwrap on None at <path>:<line>"` then `exit(1)` + `unreachable`, matching `emitTestingAbortWithEmitter`'s contract so the abort is stderr-visible without pulling in the full testing harness.

Scalar `Option<Int>` / `Option<Bool>` still falls through to the caller — same deferral as `emitListGetCall`; both need the shared scalar-Option boxing codegen that the follow-up will add.

## Regression impact

`OSTY_STDLIB_BODY_LOWER=1` full backend suite: **21 → 15 failures**. Recovered tests:
- `TestLLVMBackendBinaryLetStructPatternDestructuring`
- `TestLLVMBackendBinaryManagedListLoopBreakAndContinueSurvivePressure`
- `TestLLVMBackendBinaryManagedTemporaryCallArgSurvivesPressure`
- `TestLLVMBackendBinaryForInOverTemporaryManagedListSurvivesPressure`
- `TestLLVMBackendBinaryAutoCollectsOnPressure`
- `TestLLVMBackendBinarySafepointsKeepManagedRootsAlive`

Baseline tests still pass: `TestLLVMBackendEmitStringsCompareFlagOn`, `TestPrepareEntryInjectsStdlibWhenFlagOn`, `TestPhase2gUserCallsiteDispatchesToSpecializedMethod`, `TestInjectedMapTypeMonomorphizes`.

## Scope — remaining flag-on blockers

- Scalar-Option boxing (`list.get on List<Int>`, `x.unwrap()` where `T = Int/Bool/Float`)
- `Result<T, Error>` enum-payload support (current llvmgen supports Int / Float / String only)
- Specialized `List<T>.fold` dispatch (mangled `fold_ZI…` symbols don't yet resolve through FieldExpr)
- MIR-path runtime assertions (pre-existing, unrelated to injection)

Each is a separate follow-up before the default flag can safely flip.

## Test plan

- [x] `go test ./internal/{ir,llvmgen,backend} -short -timeout 300s` — no new regressions
- [x] `go test ./internal/backend/ -run 'TestInjectedMapTypeMonomorphizes|TestLLVMBackendEmitStringsCompareFlagOn|TestPrepareEntryInjectsStdlibWhenFlagOn|TestPhase2gUserCallsiteDispatchesToSpecializedMethod'` — all pass
- [x] Confirmed 6-test recovery under `OSTY_STDLIB_BODY_LOWER=1`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)