### PR TITLE
feat: 셀프호스팅 리졸버 컨트롤-플로우 검증 (E0600-E0603)

### DIFF
--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -308,14 +308,27 @@ fn selfResolveName(name: String, start: Int, end: Int, node: Int) -> SelfResolve
 /// SelfResolveScope is the self-hosted resolver's compact lexical scope. It
 /// stores the currently visible symbols as a flat list and uses `depth` to
 /// distinguish same-scope duplicates from legal child-scope shadowing.
+///
+/// `inFn`/`inLoop` track the flow context that gates `return`/`defer` and
+/// `break`/`continue`. A closure starts a fresh fn context with `inLoop=false`
+/// so that `for { || { break } }` is correctly rejected: the loop doesn't
+/// leak through the closure barrier. These mirror the Go resolver's flowCtx.
 struct SelfResolveScope {
     symbols: List<SelfSymbol>,
     depth: Int,
     ifaceDefault: Bool,
+    inFn: Bool,
+    inLoop: Bool,
 }
 
 fn srRootScope(result: SelfResolveResult) -> SelfResolveScope {
-    SelfResolveScope { symbols: srSymbolListCopy(result.symbols), depth: 0, ifaceDefault: false }
+    SelfResolveScope {
+        symbols: srSymbolListCopy(result.symbols),
+        depth: 0,
+        ifaceDefault: false,
+        inFn: false,
+        inLoop: false,
+    }
 }
 
 fn srChildScope(parent: SelfResolveScope) -> SelfResolveScope {
@@ -323,14 +336,28 @@ fn srChildScope(parent: SelfResolveScope) -> SelfResolveScope {
         symbols: srSymbolListCopy(parent.symbols),
         depth: parent.depth + 1,
         ifaceDefault: parent.ifaceDefault,
+        inFn: parent.inFn,
+        inLoop: parent.inLoop,
     }
 }
 
-fn srChildScopeWithIfaceDefault(parent: SelfResolveScope, ifaceDefault: Bool) -> SelfResolveScope {
+fn srFnChildScope(parent: SelfResolveScope, ifaceDefault: Bool) -> SelfResolveScope {
     SelfResolveScope {
         symbols: srSymbolListCopy(parent.symbols),
         depth: parent.depth + 1,
         ifaceDefault,
+        inFn: true,
+        inLoop: false,
+    }
+}
+
+fn srLoopChildScope(parent: SelfResolveScope) -> SelfResolveScope {
+    SelfResolveScope {
+        symbols: srSymbolListCopy(parent.symbols),
+        depth: parent.depth + 1,
+        ifaceDefault: parent.ifaceDefault,
+        inFn: parent.inFn,
+        inLoop: true,
     }
 }
 
@@ -590,7 +617,7 @@ fn srAstResolveFunction(
 ) -> SelfResolveResult {
     let node = srAstNode(file, idx)
     let mut out = result
-    let fnScope = srChildScope(scope)
+    let fnScope = srFnChildScope(scope, ifaceDefault)
     out = srAstDeclareGenerics(file, node.children2, fnScope, out)
     for paramIdx in node.children {
         let param = srAstNode(file, paramIdx)
@@ -601,7 +628,7 @@ fn srAstResolveFunction(
         out = srAstResolveParamBindings(file, paramIdx, fnScope, owner, out)
     }
     out = srAstResolveType(file, node.left, fnScope, owner, out)
-    let bodyScope = srChildScopeWithIfaceDefault(fnScope, ifaceDefault)
+    let bodyScope = srChildScope(fnScope)
     srAstResolveBlock(file, node.right, bodyScope, out)
 }
 
@@ -648,7 +675,59 @@ fn srAstResolveStmt(
     if node.kind == AstNFor {
         return srAstResolveFor(file, node, scope, out)
     }
-    if node.kind == AstNReturn || node.kind == AstNDefer || node.kind == AstNExprStmt {
+    if node.kind == AstNReturn {
+        if !scope.inFn {
+            out = srPushFlowDiag(
+                out,
+                "E0602",
+                "`return` is only valid inside a function body",
+                node.start,
+                node.end,
+                idx,
+            )
+        }
+        return srAstResolveExpr(file, node.left, scope, out)
+    }
+    if node.kind == AstNDefer {
+        if !scope.inFn {
+            out = srPushFlowDiag(
+                out,
+                "E0603",
+                "`defer` is only valid inside a function body",
+                node.start,
+                node.end,
+                idx,
+            )
+        }
+        return srAstResolveExpr(file, node.left, scope, out)
+    }
+    if node.kind == AstNBreak {
+        if !scope.inLoop {
+            out = srPushFlowDiag(
+                out,
+                "E0600",
+                "`break` is only valid inside a `for` loop",
+                node.start,
+                node.end,
+                idx,
+            )
+        }
+        return out
+    }
+    if node.kind == AstNContinue {
+        if !scope.inLoop {
+            out = srPushFlowDiag(
+                out,
+                "E0601",
+                "`continue` is only valid inside a `for` loop",
+                node.start,
+                node.end,
+                idx,
+            )
+        }
+        return out
+    }
+    if node.kind == AstNExprStmt {
         return srAstResolveExpr(file, node.left, scope, out)
     }
     if node.kind == AstNAssign || node.kind == AstNChanSend {
@@ -656,6 +735,19 @@ fn srAstResolveStmt(
         return srAstResolveExpr(file, node.right, scope, out)
     }
     srAstResolveExpr(file, idx, scope, out)
+}
+
+fn srPushFlowDiag(
+    result: SelfResolveResult,
+    code: String,
+    message: String,
+    start: Int,
+    end: Int,
+    node: Int,
+) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnosticAtNode(code, message, "", start, end, node))
+    out
 }
 
 fn srAstResolveFor(
@@ -671,7 +763,7 @@ fn srAstResolveFor(
     let loopScope = srChildScope(scope)
     let patIdx = srAstChildAt(node.children, 0)
     out = srAstResolvePattern(file, patIdx, loopScope, out)
-    let bodyScope = srChildScope(loopScope)
+    let bodyScope = srLoopChildScope(loopScope)
     srAstResolveBlock(file, node.right, bodyScope, out)
 }
 
@@ -892,7 +984,7 @@ fn srAstResolveClosure(
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
-    let closureScope = srChildScopeWithIfaceDefault(scope, false)
+    let closureScope = srFnChildScope(scope, false)
     for paramIdx in node.children {
         let param = srAstNode(file, paramIdx)
         out = srAstResolveType(file, param.right, closureScope, "", out)

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -395,3 +395,66 @@ fn testSelfResolverSuggestsNearbyNames() {
     testing.assertEq(selfResolveCodeCount(result, "E0500"), 1)
     testing.assertEq(result.diagnostics[0].hint, "did you mean `value`?")
 }
+
+fn testSelfResolverAcceptsControlFlowInContext() {
+    let result = selfResolveSource(
+        r"""
+            fn work(xs: List<Int>) -> Int {
+                defer cleanup()
+                for x in xs {
+                    if x < 0 { continue }
+                    if x > 100 { break }
+                }
+                return 0
+            }
+
+            fn cleanup() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0600"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0601"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0602"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0603"), 0)
+}
+
+fn testSelfResolverRejectsBreakContinueInClosure() {
+    // A closure starts a fresh fn context; the enclosing loop doesn't
+    // leak through. This matches the Go resolver's enterFn(false) reset
+    // and is what prevents users from smuggling `break` across a `||`.
+    let result = selfResolveSource(
+        r"""
+            fn run() {
+                for x in [1, 2, 3] {
+                    let f = || { break }
+                    let g = || { continue }
+                    f()
+                    g()
+                }
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0600"), 1)
+    testing.assertEq(selfResolveCodeCount(result, "E0601"), 1)
+}
+
+fn testSelfResolverAcceptsReturnInClosure() {
+    // `return` inside a closure is legal — the closure body IS a function
+    // body. Only `break`/`continue` care about `inLoop`.
+    let result = selfResolveSource(
+        r"""
+            fn run() {
+                let f = || { return 42 }
+                let g = || { defer teardown() }
+                f()
+                g()
+            }
+
+            fn teardown() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0602"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0603"), 0)
+}


### PR DESCRIPTION
## 무엇

셀프호스팅 리졸버(`toolchain/resolve.osty`)가 Go 리퍼런스 리졸버와 달리 컨트롤-플로우 오용을 조용히 삼키던 갭을 메꿨습니다.

- `E0600` — loop 밖의 `break`
- `E0601` — loop 밖의 `continue`
- `E0602` — fn body 밖의 `return`
- `E0603` — fn body 밖의 `defer`

## 왜

`toolchain/resolve.osty` 는 Go 리졸버(`internal/resolve/resolve.go`)를 셀프호스트 방향으로 이식한 버전이지만, 컨트롤-플로우 검증(`flowCtx.inFn`/`inLoop`) 이 누락되어 있었습니다. 그 결과 네이티브 체커를 돌릴 때 파서 에러 복구로 `break`/`continue`/`return`/`defer` 가 엉뚱한 자리에 남아도 리졸버가 경고를 내보내지 않았습니다.

## 어떻게

- `SelfResolveScope` 에 `inFn: Bool`, `inLoop: Bool` 추가
- `srFnChildScope(parent, ifaceDefault)` — fn 진입. `inFn=true`, `inLoop=false` (closure barrier)
- `srLoopChildScope(parent)` — for 본문. `inLoop=true`
- `srChildScopeWithIfaceDefault` 제거 (`srFnChildScope` 로 대체)
- `srAstResolveStmt` 에서 `AstNReturn`/`AstNDefer`/`AstNBreak`/`AstNContinue` 각각 분기해 diag emit
- `srPushFlowDiag` 진단 헬퍼 추가

### Closure barrier

Go 리졸버의 `enterFn(false)` 시맨틱과 일치:
- `for { || { break } }` → **E0600** (loop 컨텍스트가 `||` 를 타고 새지 않음)
- `|| { return 42 }` → OK (클로저 자체가 fn body)

## 테스트

`toolchain/resolve_test.osty` 에 3개 포커스 테스트 추가:
- `testSelfResolverAcceptsControlFlowInContext` — 정상 컨텍스트에서 diag 0
- `testSelfResolverRejectsBreakContinueInClosure` — closure barrier 검증
- `testSelfResolverAcceptsReturnInClosure` — return/defer in closure OK

## 검증

- [x] `just front` — Go 리졸버 스펙 코퍼스 회귀 없음
- [x] `go test -run TestToolchainChecker ./internal/selfhost` — bootstrap-gen 을 통한 트랜스파일 smoke 통과
- [ ] `osty test toolchain/resolve_test.osty` — 사전 존재하는 IR lowering panic (string interpolation nil Expr, `internal/ir/lower.go:1043`) 으로 이번 PR 범위 외. stash 후에도 동일 panic 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)