### PR TITLE
[codex] Reduce runtime poll overhead

### DIFF
--- a/internal/llvmgen/fn_value.go
+++ b/internal/llvmgen/fn_value.go
@@ -264,7 +264,7 @@ func (g *generator) emitIndirectUserCall(call *ast.CallExpr) (value, bool, error
 	// roots coming out of arg evaluation are released at the same
 	// cadence.
 	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
+	g.emitCallSafepointIfNeeded(emitter)
 	g.takeOstyEmitter(emitter)
 	g.pushScope()
 	ret, callErr := g.emitFnValueIndirectCall(envVal, sig, args)

--- a/internal/llvmgen/gc_integration_test.go
+++ b/internal/llvmgen/gc_integration_test.go
@@ -312,11 +312,13 @@ func TestGenerateFromASTSafepointKindMixCallAndLoop(t *testing.T) {
 }
 
 fn main() {
+    let values: List<Int> = [1]
     let f = work
     let mut i = 0
     while i < 3 {
         i = i + f()
     }
+    println(values.len())
     println(i)
 }
 `)
@@ -362,6 +364,36 @@ fn main() {
 	mix := safepointKindMix(t, string(ir))
 	if mix[safepointKindCall] != 0 {
 		t.Fatalf("expected no CALL-kind safepoint for direct user call, mix=%v, IR:\n%s", mix, ir)
+	}
+	if mix[safepointKindLoop] == 0 {
+		t.Fatalf("expected ≥1 LOOP-kind safepoint, mix=%v, IR:\n%s", mix, ir)
+	}
+}
+
+func TestGenerateFromASTRootlessIndirectCallSkipsCallSafepoint(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn work() -> Int {
+    1
+}
+
+fn main() {
+    let f = work
+    let mut i = 0
+    while i < 3 {
+        i = i + f()
+    }
+    println(i)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/rootless_indirect_call_safepoint.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	mix := safepointKindMix(t, string(ir))
+	if mix[safepointKindCall] != 0 {
+		t.Fatalf("expected no CALL-kind safepoint for rootless indirect call, mix=%v, IR:\n%s", mix, ir)
 	}
 	if mix[safepointKindLoop] == 0 {
 		t.Fatalf("expected ≥1 LOOP-kind safepoint, mix=%v, IR:\n%s", mix, ir)

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -244,7 +244,7 @@ var safepointRootChunkSize = llvmSafepointDefaultRootChunkSize()
 // iteration. The runtime still sees LOOP-kind safepoints regularly for
 // cancellation / GC progress; setting the stride to 1 restores the
 // historical "poll every back-edge" behavior.
-var loopSafepointStride int64 = 256
+var loopSafepointStride int64 = 1024
 
 // emitGCSafepoint emits a safepoint poll at an unspecified site — kept
 // for callers that have not been classified yet. New call sites should

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -254,6 +254,12 @@ func (g *generator) emitGCSafepoint(emitter *LlvmEmitter) {
 	g.emitGCSafepointKind(emitter, safepointKindUnspecified)
 }
 
+func (g *generator) emitCallSafepointIfNeeded(emitter *LlvmEmitter) {
+	if g.hasVisibleSafepointRoots() {
+		g.emitGCSafepointKind(emitter, safepointKindCall)
+	}
+}
+
 func (g *generator) emitGCSafepointKind(emitter *LlvmEmitter, kind safepointKind) {
 	g.declareRuntimeSymbol("osty.gc.safepoint_v1", "void", []paramInfo{
 		{typ: "i64"},

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -159,7 +159,7 @@ func (g *generator) emitRuntimeFFICall(call *ast.CallExpr) (value, bool, error) 
 		return value{}, true, unsupportedf("call", "runtime FFI %s.%s has no return value", fn.path, fn.sourceName)
 	}
 	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
+	g.emitCallSafepointIfNeeded(emitter)
 	g.takeOstyEmitter(emitter)
 	g.pushScope()
 	args, err := g.runtimeFFICallArgs(fn, call.Args)
@@ -186,7 +186,7 @@ func (g *generator) emitRuntimeFFICallStmt(call *ast.CallExpr) (bool, error) {
 		return found, err
 	}
 	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
+	g.emitCallSafepointIfNeeded(emitter)
 	g.takeOstyEmitter(emitter)
 	g.pushScope()
 	args, err := g.runtimeFFICallArgs(fn, call.Args)

--- a/internal/llvmgen/stdlib_env_shim.go
+++ b/internal/llvmgen/stdlib_env_shim.go
@@ -51,7 +51,7 @@ func (g *generator) emitStdEnvCall(call *ast.CallExpr) (value, bool, error) {
 	}
 	g.declareRuntimeSymbol(ostyRtEnvArgsSymbol, "ptr", nil)
 	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
+	g.emitCallSafepointIfNeeded(emitter)
 	out := llvmCall(emitter, "ptr", ostyRtEnvArgsSymbol, nil)
 	g.takeOstyEmitter(emitter)
 	v := fromOstyValue(out)

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2288,7 +2288,7 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	g.pushScope()
 	defer g.popScope()
 	emitter := g.toOstyEmitter()
-	g.emitGCSafepointKind(emitter, safepointKindCall)
+	g.emitCallSafepointIfNeeded(emitter)
 	g.takeOstyEmitter(emitter)
 	base, err := g.emitExpr(field.X)
 	if err != nil {


### PR DESCRIPTION
## What changed
- raise the loop back-edge safepoint stride from 256 to 1024
- skip CALL-kind safepoint polls when the current frame exposes no visible GC roots
- keep the GC integration coverage aligned so indirect calls with live managed roots still emit call safepoints

## Why
Tight runtime-heavy workloads were still paying runtime polling cost more often than necessary. In rootless frames, those polls were pure overhead because the collector had no visible roots to inspect. This change reduces that overhead without removing safepoint coverage where GC visibility actually matters.

## Impact
- lowers real runtime overhead in loop-heavy and call-heavy workloads
- keeps polling semantics for frames that still have managed roots
- gives us a cleaner base for longer-workload tuning next

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIREmitGCLoopSafepoint|TestGenerateFromASTSafepointKindMixCallAndLoop|TestGenerateFromASTDirectUserCallSkipsEmptyCallSafepoint|TestGenerateFromASTRootlessIndirectCallSkipsCallSafepoint'`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `just build`
- `go run ./cmd/osty-vs-go --filter '^(fib|loop_sum|word_freq)$' --benchtime 400ms --go-count 3 --go-cpu 1 --label runtime-poll-overhead`

Latest composite run on this branch:
- `fib`: Go `2351ns/op`, Osty `3111ns/op`, `1.32x`
- `loop_sum`: Go `57.66ns/op`, Osty `309ns/op`, `5.36x`
- `word_freq`: Go `22342ns/op`, Osty `134555ns/op`, `6.02x`
- geomean: `3.50x`
