### PR TITLE
Add native resolve path and package-aware llvm-ir emit

### DIFF
--- a/cmd/osty-native-resolver/main.go
+++ b/cmd/osty-native-resolver/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+type resolveRequest struct {
+	Source  string                        `json:"source,omitempty"`
+	Package *selfhost.PackageResolveInput `json:"package,omitempty"`
+}
+
+type resolveSummary struct {
+	Symbols           int            `json:"symbols"`
+	Refs              int            `json:"refs"`
+	TypeRefs          int            `json:"typeRefs"`
+	Diagnostics       int            `json:"diagnostics"`
+	Unresolved        int            `json:"unresolved"`
+	Duplicates        int            `json:"duplicates"`
+	SymbolsByKind     map[string]int `json:"symbolsByKind,omitempty"`
+	DiagnosticsByCode map[string]int `json:"diagnosticsByCode,omitempty"`
+}
+
+type resolvedSymbol struct {
+	Node     int    `json:"node"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	TypeName string `json:"typeName"`
+	Arity    int    `json:"arity"`
+	Depth    int    `json:"depth"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Public   bool   `json:"public"`
+	File     string `json:"file,omitempty"`
+}
+
+type resolvedRef struct {
+	Name        string `json:"name"`
+	Node        int    `json:"node"`
+	Start       int    `json:"start"`
+	End         int    `json:"end"`
+	File        string `json:"file,omitempty"`
+	TargetNode  int    `json:"targetNode"`
+	TargetStart int    `json:"targetStart"`
+	TargetEnd   int    `json:"targetEnd"`
+	TargetFile  string `json:"targetFile,omitempty"`
+}
+
+type resolvedTypeRef struct {
+	Name  string `json:"name"`
+	Node  int    `json:"node"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
+	File  string `json:"file,omitempty"`
+}
+
+type resolveDiagnostic struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Name    string `json:"name,omitempty"`
+	Hint    string `json:"hint,omitempty"`
+	Node    int    `json:"node"`
+	Start   int    `json:"start"`
+	End     int    `json:"end"`
+	File    string `json:"file,omitempty"`
+}
+
+type resolveResponse struct {
+	Summary     resolveSummary      `json:"summary"`
+	Symbols     []resolvedSymbol    `json:"symbols"`
+	Refs        []resolvedRef       `json:"refs"`
+	TypeRefs    []resolvedTypeRef   `json:"typeRefs"`
+	Diagnostics []resolveDiagnostic `json:"diagnostics,omitempty"`
+}
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(stdin io.Reader, stdout io.Writer) error {
+	var req resolveRequest
+	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
+		return fmt.Errorf("decode resolver request: %w", err)
+	}
+	var (
+		resolved selfhost.ResolveResult
+		err      error
+	)
+	if req.Package != nil {
+		resolved, err = selfhost.ResolvePackageStructured(*req.Package)
+		if err != nil {
+			return fmt.Errorf("resolve package request: %w", err)
+		}
+	} else {
+		resolved = selfhost.ResolveSourceStructured([]byte(req.Source))
+	}
+	resp := resolveResponse{
+		Summary: resolveSummary{
+			Symbols:           resolved.Summary.Symbols,
+			Refs:              resolved.Summary.Refs,
+			TypeRefs:          resolved.Summary.TypeRefs,
+			Diagnostics:       resolved.Summary.Diagnostics,
+			Unresolved:        resolved.Summary.Unresolved,
+			Duplicates:        resolved.Summary.Duplicates,
+			SymbolsByKind:     resolved.Summary.SymbolsByKind,
+			DiagnosticsByCode: resolved.Summary.DiagnosticsByCode,
+		},
+		Symbols:  make([]resolvedSymbol, 0, len(resolved.Symbols)),
+		Refs:     make([]resolvedRef, 0, len(resolved.Refs)),
+		TypeRefs: make([]resolvedTypeRef, 0, len(resolved.TypeRefs)),
+	}
+	for _, sym := range resolved.Symbols {
+		resp.Symbols = append(resp.Symbols, resolvedSymbol{
+			Node:     sym.Node,
+			Name:     sym.Name,
+			Kind:     sym.Kind,
+			TypeName: sym.TypeName,
+			Arity:    sym.Arity,
+			Depth:    sym.Depth,
+			Start:    sym.Start,
+			End:      sym.End,
+			Public:   sym.Public,
+			File:     sym.File,
+		})
+	}
+	for _, ref := range resolved.Refs {
+		resp.Refs = append(resp.Refs, resolvedRef{
+			Name:        ref.Name,
+			Node:        ref.Node,
+			Start:       ref.Start,
+			End:         ref.End,
+			File:        ref.File,
+			TargetNode:  ref.TargetNode,
+			TargetStart: ref.TargetStart,
+			TargetEnd:   ref.TargetEnd,
+			TargetFile:  ref.TargetFile,
+		})
+	}
+	for _, ref := range resolved.TypeRefs {
+		resp.TypeRefs = append(resp.TypeRefs, resolvedTypeRef{
+			Name:  ref.Name,
+			Node:  ref.Node,
+			Start: ref.Start,
+			End:   ref.End,
+			File:  ref.File,
+		})
+	}
+	if len(resolved.Diagnostics) > 0 {
+		resp.Diagnostics = make([]resolveDiagnostic, 0, len(resolved.Diagnostics))
+		for _, d := range resolved.Diagnostics {
+			resp.Diagnostics = append(resp.Diagnostics, resolveDiagnostic{
+				Code:    d.Code,
+				Message: d.Message,
+				Name:    d.Name,
+				Hint:    d.Hint,
+				Node:    d.Node,
+				Start:   d.Start,
+				End:     d.End,
+				File:    d.File,
+			})
+		}
+	}
+	return json.NewEncoder(stdout).Encode(resp)
+}

--- a/cmd/osty-native-resolver/main_test.go
+++ b/cmd/osty-native-resolver/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestRunEmitsStructuredResolveResult(t *testing.T) {
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"source":"fn helper(x: Int) -> Int { x }\nfn main() { let value = helper(1) }\n"}`)
+	if err := run(stdin, &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp resolveResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Summary.Diagnostics != 0 {
+		t.Fatalf("diagnostics = %d, want 0", resp.Summary.Diagnostics)
+	}
+	if len(resp.Symbols) == 0 {
+		t.Fatalf("symbols = %#v, want non-empty result", resp.Symbols)
+	}
+	if len(resp.Refs) == 0 {
+		t.Fatalf("refs = %#v, want non-empty result", resp.Refs)
+	}
+	if resp.Summary.SymbolsByKind["fn"] == 0 {
+		t.Fatalf("symbolsByKind = %#v, want fn bucket", resp.Summary.SymbolsByKind)
+	}
+}
+
+func TestRunRejectsInvalidJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run(strings.NewReader("{"), &stdout)
+	if err == nil || !strings.Contains(err.Error(), "decode resolver request") {
+		t.Fatalf("run error = %v, want decode error", err)
+	}
+}
+
+func TestRunResolvesPackageStructuredRequest(t *testing.T) {
+	dir := t.TempDir()
+	fileA := []byte("pub fn helper() -> Int { 1 }\n")
+	fileB := []byte("fn main() { let value = helper() }\n")
+	reqBody, err := json.Marshal(resolveRequest{
+		Package: &selfhost.PackageResolveInput{
+			Files: []selfhost.PackageResolveFile{
+				{Source: fileA, Base: 0, Name: "a.osty", Path: filepath.Join(dir, "a.osty")},
+				{Source: fileB, Base: len(fileA) + 1, Name: "b.osty", Path: filepath.Join(dir, "b.osty")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp resolveResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Summary.Diagnostics != 0 {
+		t.Fatalf("diagnostics = %d, want 0", resp.Summary.Diagnostics)
+	}
+	if len(resp.Refs) == 0 {
+		t.Fatalf("refs = %#v, want package ref data", resp.Refs)
+	}
+	found := false
+	for _, ref := range resp.Refs {
+		if ref.Name == "helper" && strings.HasSuffix(ref.File, "b.osty") && strings.HasSuffix(ref.TargetFile, "a.osty") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("refs = %#v, want cross-file helper attribution", resp.Refs)
+	}
+}

--- a/cmd/osty/gen_emit.go
+++ b/cmd/osty/gen_emit.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/osty/osty/internal/backend"
+)
+
+func prepareGenBackendEntry(pkgName string, entry *genPackageEntry) (backend.Entry, error) {
+	if entry == nil {
+		return backend.Entry{}, fmt.Errorf("missing gen entry")
+	}
+	if entry.pkg == nil {
+		return backend.Entry{}, fmt.Errorf("missing package input for gen")
+	}
+	if countLowerableFiles(entry.pkg) > 1 {
+		return backend.PreparePackage(pkgName, entry.sourcePath, entry.pkg, entry.file, entry.chk)
+	}
+	file, src, err := parseGenEmitFile(entry.pkg)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	backendEntry, err := backend.PrepareEntry(pkgName, entry.sourcePath, file, entry.fileResult(), entry.chk)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	backendEntry.Source = src
+	return backendEntry, nil
+}
+
+func emitGenArtifact(name backend.Name, mode backend.EmitMode, pkgName string, entry *genPackageEntry) ([]byte, *backend.Result, error) {
+	backendEntry, err := prepareGenBackendEntry(pkgName, entry)
+	if err != nil {
+		return nil, nil, err
+	}
+	if name == backend.NameLLVM && mode == backend.EmitLLVMIR {
+		out, warnings, emitErr := backend.EmitLLVMIRText(backendEntry, "", nil)
+		return out, &backend.Result{
+			Backend:  name,
+			Emit:     mode,
+			Warnings: warnings,
+		}, emitErr
+	}
+	return emitGenArtifactViaBackend(name, mode, backendEntry)
+}
+
+func emitGenArtifactViaBackend(name backend.Name, mode backend.EmitMode, entry backend.Entry) ([]byte, *backend.Result, error) {
+	b := backendFromCLI("gen", name)
+	tmpRoot, err := os.MkdirTemp("", "osty-gen-*")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer os.RemoveAll(tmpRoot)
+
+	result, emitErr := b.Emit(context.Background(), backend.Request{
+		Layout: backend.Layout{
+			Root:    tmpRoot,
+			Profile: "gen",
+		},
+		Emit:  mode,
+		Entry: entry,
+	})
+	if result == nil {
+		return nil, nil, emitErr
+	}
+	artifact := result.Artifacts.SourcePath()
+	if artifact == "" {
+		if emitErr != nil {
+			return nil, result, emitErr
+		}
+		return nil, result, fmt.Errorf("backend %q did not produce a source artifact", name)
+	}
+	data, readErr := os.ReadFile(artifact)
+	if readErr != nil {
+		if emitErr != nil {
+			return nil, result, emitErr
+		}
+		return nil, result, readErr
+	}
+	return data, result, emitErr
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -38,7 +38,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -399,8 +398,15 @@ func main() {
 				}
 				return
 			case "resolve":
-				printPackageDiags(selected.pkg, selected.res.Diags, flags)
-				if len(selected.file.Refs) > 0 {
+				diags := selected.res.Diags
+				if nativeDiags, err := nativeResolvePackageDiagnostics(selected.pkg); err == nil {
+					diags = append(packageParseDiags(selected.pkg), nativeDiags...)
+				}
+				printPackageDiags(selected.pkg, diags, flags)
+				if rows, err := nativeResolvePackageRows(selected.pkg, selected.file.Path); err == nil && len(rows) > 0 {
+					fmt.Printf("# %s\n", selected.file.Path)
+					printNativeResolutionRows(rows)
+				} else if len(selected.file.Refs) > 0 {
 					fmt.Printf("# %s\n", selected.file.Path)
 					printResolutionRefs(selected.file.Refs)
 				}
@@ -411,7 +417,7 @@ func main() {
 						printScopeTree(selected.file.FileScope)
 					}
 				}
-				if hasError(selected.res.Diags) {
+				if hasError(diags) {
 					os.Exit(1)
 				}
 				return
@@ -489,11 +495,27 @@ func main() {
 	case "resolve":
 		parsed := parser.ParseDetailed(src)
 		file, parseDiags := parsed.File, parsed.Diagnostics
-		res := resolveFile(file)
-		all := append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...)
+		var res *resolve.Result
+		all := append([]*diag.Diagnostic{}, parseDiags...)
+		if nativeDiags, err := nativeResolveSingleFileDiagnostics(path, src, file); err == nil {
+			all = append(all, nativeDiags...)
+		} else {
+			res = resolveFile(file)
+			all = append(all, res.Diags...)
+		}
 		printDiags(formatter, all, flags)
-		printResolution(file, res)
+		if rows, err := nativeResolveSingleFileRows(path, src, file); err == nil && len(rows) > 0 {
+			printNativeResolutionRows(rows)
+		} else {
+			if res == nil {
+				res = resolveFile(file)
+			}
+			printResolution(file, res)
+		}
 		if flags.showScopes {
+			if res == nil {
+				res = resolveFile(file)
+			}
 			// File scope's parent is the package scope (a child of the
 			// prelude). Rooting the dump at the package scope hides
 			// noisy prelude builtins while still showing every
@@ -874,22 +896,53 @@ func runResolvePackage(dir string, flags cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
-	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
-	printPackageDiags(pkg, res.Diags, flags)
-	for _, f := range pkg.Files {
-		if len(f.Refs) == 0 {
-			continue
+	var res *resolve.PackageResult
+	diags := []*diag.Diagnostic(nil)
+	if nativeDiags, err := nativeResolvePackageDiagnostics(pkg); err == nil {
+		diags = append(packageParseDiags(pkg), nativeDiags...)
+	} else {
+		res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
+		diags = res.Diags
+	}
+	printPackageDiags(pkg, diags, flags)
+	if nativeRowsUsed := false; true {
+		for _, f := range pkg.Files {
+			rows, err := nativeResolvePackageRows(pkg, f.Path)
+			if err != nil || len(rows) == 0 {
+				if res == nil {
+					res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
+				}
+				if len(f.Refs) == 0 {
+					continue
+				}
+				fmt.Printf("# %s\n", f.Path)
+				printResolutionRefs(f.Refs)
+				continue
+			}
+			nativeRowsUsed = true
+			fmt.Printf("# %s\n", f.Path)
+			printNativeResolutionRows(rows)
 		}
-		fmt.Printf("# %s\n", f.Path)
-		printResolutionRefs(f.Refs)
+		if !nativeRowsUsed {
+			for _, f := range pkg.Files {
+				if len(f.Refs) == 0 {
+					continue
+				}
+				fmt.Printf("# %s\n", f.Path)
+				printResolutionRefs(f.Refs)
+			}
+		}
 	}
 	if flags.showScopes {
+		if res == nil {
+			res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
+		}
 		// Package scope's children are the file scopes, which in turn
 		// host fn / block / closure / match-arm scopes — the full
 		// nested tree for every file in the package.
 		printScopeTree(pkg.PkgScope)
 	}
-	if hasError(res.Diags) {
+	if hasError(diags) {
 		os.Exit(1)
 	}
 }
@@ -1833,13 +1886,7 @@ func runGen(args []string, flags cliFlags) {
 	if len(deferredCheckDiags) > 0 {
 		reportDeferredGenCheck(path, deferredCheckDiags)
 	}
-	file, _, err := parseGenEmitFile(entry.pkg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "osty gen: %v\n", err)
-		os.Exit(1)
-	}
-
-	out, result, emitErr := emitGenArtifact(backendID, emitMode, pkgName, entry.sourcePath, file, entry.fileResult(), entry.chk)
+	out, result, emitErr := emitGenArtifact(backendID, emitMode, pkgName, entry)
 	if out == nil && emitErr != nil {
 		exitBackendEmitError("gen", result, emitErr)
 	}
@@ -1860,46 +1907,6 @@ func runGen(args []string, flags cliFlags) {
 		adjustGenResultForUserOutput(result, backendID, outPath)
 		exitBackendEmitError("gen", result, emitErr)
 	}
-}
-
-func emitGenArtifact(name backend.Name, mode backend.EmitMode, pkgName, sourcePath string, file *ast.File, res *resolve.Result, chk *check.Result) ([]byte, *backend.Result, error) {
-	b := backendFromCLI("gen", name)
-	tmpRoot, err := os.MkdirTemp("", "osty-gen-*")
-	if err != nil {
-		return nil, nil, err
-	}
-	defer os.RemoveAll(tmpRoot)
-	entry, err := backend.PrepareEntry(pkgName, sourcePath, file, res, chk)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	result, emitErr := b.Emit(context.Background(), backend.Request{
-		Layout: backend.Layout{
-			Root:    tmpRoot,
-			Profile: "gen",
-		},
-		Emit:  mode,
-		Entry: entry,
-	})
-	if result == nil {
-		return nil, nil, emitErr
-	}
-	artifact := result.Artifacts.SourcePath()
-	if artifact == "" {
-		if emitErr != nil {
-			return nil, result, emitErr
-		}
-		return nil, result, fmt.Errorf("backend %q did not produce a source artifact", name)
-	}
-	data, readErr := os.ReadFile(artifact)
-	if readErr != nil {
-		if emitErr != nil {
-			return nil, result, emitErr
-		}
-		return nil, result, readErr
-	}
-	return data, result, emitErr
 }
 
 func adjustGenResultForUserOutput(result *backend.Result, name backend.Name, outPath string) {

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -125,6 +125,44 @@ func TestLoadGenPackageEntryWithTransformRepairsForeignSyntax(t *testing.T) {
 	}
 }
 
+func TestPrepareGenBackendEntryUsesPackageLoweringForSiblingFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeGenTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
+	target := writeGenTestFile(t, dir, "b.osty", "fn main() -> Int { helper() }\n")
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+	backendEntry, err := prepareGenBackendEntry("main", entry)
+	if err != nil {
+		t.Fatalf("prepareGenBackendEntry() error = %v", err)
+	}
+	if backendEntry.File != entry.file.File {
+		t.Fatal("backend entry did not keep the original package entry AST")
+	}
+	if backendEntry.IR == nil || len(backendEntry.IR.Decls) != 2 {
+		t.Fatalf("backend entry decl count = %d, want 2", len(backendEntry.IR.Decls))
+	}
+}
+
+func TestGenCLIMultiFilePackageEmitsLLVMIR(t *testing.T) {
+	dir := t.TempDir()
+	writeGenTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
+	target := writeGenTestFile(t, dir, "b.osty", "fn main() -> Int { helper() }\n")
+
+	got := runOstyCLI(t, "gen", "--emit", "llvm-ir", target)
+	if got.exit != 0 {
+		t.Fatalf("osty gen exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "@helper") {
+		t.Fatalf("stdout missing helper symbol:\n%s", got.stdout)
+	}
+	if !strings.Contains(got.stdout, "@main") {
+		t.Fatalf("stdout missing main symbol:\n%s", got.stdout)
+	}
+}
+
 func writeGenTestFile(t *testing.T, dir, name, contents string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/cmd/osty/resolve_native.go
+++ b/cmd/osty/resolve_native.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func nativeResolveSingleFileRows(path string, src []byte, file *ast.File) ([]resolve.NativeResolutionRow, error) {
+	if file == nil {
+		return nil, fmt.Errorf("native resolve: missing parsed file")
+	}
+	return resolve.NativeResolutionRowsForSource(path, src, file)
+}
+
+func nativeResolvePackageRows(pkg *resolve.Package, path string) ([]resolve.NativeResolutionRow, error) {
+	return resolve.NativeResolutionRows(pkg, path)
+}
+
+func nativeResolveSingleFileDiagnostics(path string, src []byte, file *ast.File) ([]*diag.Diagnostic, error) {
+	if file == nil {
+		return nil, fmt.Errorf("native resolve: missing parsed file")
+	}
+	return resolve.NativeDiagnosticsForSource(path, src, file)
+}
+
+func nativeResolvePackageDiagnostics(pkg *resolve.Package) ([]*diag.Diagnostic, error) {
+	return resolve.NativeDiagnostics(pkg)
+}
+
+func printNativeResolutionRows(rows []resolve.NativeResolutionRow) {
+	for _, row := range rows {
+		fmt.Printf("%d:%d\t%-20s\t%-12s\t->%s\n", row.Line, row.Column, row.Name, row.Kind, row.Def)
+	}
+}

--- a/cmd/osty/resolve_native_test.go
+++ b/cmd/osty/resolve_native_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveCLISingleFilePrintsNativeResolutionRows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn helper() -> Int { 1 }
+
+fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "resolve", path)
+	if got.exit != 0 {
+		t.Fatalf("osty resolve exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "helper") {
+		t.Fatalf("stdout missing helper ref:\n%s", got.stdout)
+	}
+	if !strings.Contains(got.stdout, "function") {
+		t.Fatalf("stdout missing function kind:\n%s", got.stdout)
+	}
+	if !strings.Contains(got.stdout, "->1:1") {
+		t.Fatalf("stdout missing helper def position:\n%s", got.stdout)
+	}
+}
+
+func TestResolveCLIPackagePrintsNativeCrossFileResolutionRows(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatalf("write a.osty: %v", err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatalf("write b.osty: %v", err)
+	}
+
+	got := runOstyCLI(t, "resolve", dir)
+	if got.exit != 0 {
+		t.Fatalf("osty resolve exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "# "+bPath) {
+		t.Fatalf("stdout missing b.osty header:\n%s", got.stdout)
+	}
+	if !strings.Contains(got.stdout, "helper") {
+		t.Fatalf("stdout missing helper ref:\n%s", got.stdout)
+	}
+	if !strings.Contains(got.stdout, "->1:5") {
+		t.Fatalf("stdout missing cross-file helper def position:\n%s", got.stdout)
+	}
+}
+
+func TestResolveCLISingleFilePrintsNativeDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {
+    missing()
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got := runOstyCLI(t, "resolve", path)
+	if got.exit != 1 {
+		t.Fatalf("osty resolve exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "error[E0500]") {
+		t.Fatalf("stderr missing native resolve code:\n%s", got.stderr)
+	}
+	if !strings.Contains(got.stderr, "undefined name") {
+		t.Fatalf("stderr missing native resolve message:\n%s", got.stderr)
+	}
+}

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -49,51 +49,17 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if artifacts.LLVMIR == "" {
 		return nil, fmt.Errorf("llvm backend: missing LLVM IR artifact path")
 	}
-	if req.Entry.IR == nil {
-		return nil, fmt.Errorf("llvm backend: missing lowered IR entry")
+	irOut, warnings, genErr := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit)
+	if err := os.WriteFile(artifacts.LLVMIR, irOut, 0o644); err != nil {
+		return nil, err
 	}
-	opts := llvmgen.Options{
-		PackageName: req.Entry.PackageName,
-		SourcePath:  req.Entry.SourcePath,
-		Source:      req.Entry.Source,
-		Target:      req.Layout.Target,
-		UseMIR:      useMIRBackend(req.Features, req.Emit),
-	}
-	// IR is the sole input contract. The backend dispatcher never reaches
-	// for req.Entry.File — the AST is a front-end artifact that the LLVM
-	// backend does not consume directly any more.
-	//
-	// MIR-first dispatch now defaults on the raw `llvm-ir` emission
-	// path. Requests can opt back into the legacy HIR→AST bridge with
-	// the `legacy-llvmgen` feature, or opt further in with
-	// `mir-backend` on object/binary emission while parity continues to
-	// grow. On MIR-emitter refusal we still fall back automatically, so
-	// enabling the new path cannot reduce coverage.
-	var (
-		irOut  []byte
-		genErr error
-	)
-	if opts.UseMIR && req.Entry.MIR != nil {
-		irOut, genErr = llvmgen.GenerateFromMIR(req.Entry.MIR, opts)
-		if genErr != nil && errors.Is(genErr, llvmgen.ErrUnsupported) {
-			// MIR emitter refused — fall back to the HIR path.
-			opts.UseMIR = false
-			irOut, genErr = llvmgen.GenerateModule(req.Entry.IR, opts)
-		}
-	} else {
-		irOut, genErr = llvmgen.GenerateModule(req.Entry.IR, opts)
+	out := &Result{
+		Backend:   NameLLVM,
+		Emit:      req.Emit,
+		Artifacts: artifacts,
+		Warnings:  warnings,
 	}
 	if genErr == nil {
-		if err := os.WriteFile(artifacts.LLVMIR, irOut, 0o644); err != nil {
-			return nil, err
-		}
-		warnings := append([]error(nil), req.Entry.IRIssues...)
-		out := &Result{
-			Backend:   NameLLVM,
-			Emit:      req.Emit,
-			Artifacts: artifacts,
-			Warnings:  warnings,
-		}
 		if !llvmgen.NeedsObjectArtifact(req.Emit.String()) {
 			return out, nil
 		}
@@ -120,28 +86,65 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 		}
 		return out, nil
 	}
+	return out, genErr
+}
 
-	diag := llvmgen.UnsupportedDiagnosticForError(genErr)
-	skeleton := llvmgen.RenderSkeleton(
-		req.Entry.PackageName,
-		req.Entry.SourcePath,
-		string(req.Emit),
-		req.Layout.Target,
-		errors.New(llvmgen.UnsupportedSummary(diag)),
-	)
-	if err := os.WriteFile(artifacts.LLVMIR, skeleton, 0o644); err != nil {
-		return nil, err
+// EmitLLVMIRText runs the LLVM lowering pipeline for one prepared entry and
+// returns the textual IR bytes directly, without creating artifact paths.
+func EmitLLVMIRText(entry Entry, target string, features []string) ([]byte, []error, error) {
+	return generateLLVMIR(entry, target, features, EmitLLVMIR)
+}
+
+func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode) ([]byte, []error, error) {
+	if entry.IR == nil {
+		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
 	}
-	return &Result{
-		Backend:   NameLLVM,
-		Emit:      req.Emit,
-		Artifacts: artifacts,
-		Warnings: append(
-			append([]error(nil), req.Entry.IRIssues...),
+	opts := llvmgen.Options{
+		PackageName: entry.PackageName,
+		SourcePath:  entry.SourcePath,
+		Source:      entry.Source,
+		Target:      target,
+		UseMIR:      useMIRBackend(features, emit),
+	}
+	// IR is the sole input contract. The backend dispatcher never reaches
+	// for entry.File — the AST is a front-end artifact that the LLVM
+	// backend does not consume directly any more.
+	//
+	// MIR-first dispatch now defaults on the raw `llvm-ir` emission
+	// path. Requests can opt back into the legacy HIR→AST bridge with
+	// the `legacy-llvmgen` feature, or opt further in with
+	// `mir-backend` on object/binary emission while parity continues to
+	// grow. On MIR-emitter refusal we still fall back automatically, so
+	// enabling the new path cannot reduce coverage.
+	var (
+		irOut  []byte
+		genErr error
+	)
+	if opts.UseMIR && entry.MIR != nil {
+		irOut, genErr = llvmgen.GenerateFromMIR(entry.MIR, opts)
+		if genErr != nil && errors.Is(genErr, llvmgen.ErrUnsupported) {
+			// MIR emitter refused — fall back to the HIR path.
+			opts.UseMIR = false
+			irOut, genErr = llvmgen.GenerateModule(entry.IR, opts)
+		}
+	} else {
+		irOut, genErr = llvmgen.GenerateModule(entry.IR, opts)
+	}
+	warnings := append([]error(nil), entry.IRIssues...)
+	if genErr == nil {
+		return irOut, warnings, nil
+	}
+	diag := llvmgen.UnsupportedDiagnosticForError(genErr)
+	return llvmgen.RenderSkeleton(
+			entry.PackageName,
+			entry.SourcePath,
+			string(emit),
+			target,
+			errors.New(llvmgen.UnsupportedSummary(diag)),
+		), append(warnings,
 			errors.New(llvmgen.UnsupportedSummary(diag)),
 			ErrLLVMNotImplemented,
-		),
-	}, ErrLLVMNotImplemented
+		), ErrLLVMNotImplemented
 }
 
 func (b LLVMBackend) llvmToolchain() llvmToolchain {

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -257,6 +257,36 @@ func TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback(t *testing.T) {
 	}
 }
 
+func TestEmitLLVMIRTextMatchesBackendArtifactOutput(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    println(1)
+}
+`)
+
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	want, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("direct llvm-ir text did not match artifact output\n--- direct ---\n%s\n--- artifact ---\n%s", got, want)
+	}
+	if len(warnings) != len(result.Warnings) {
+		t.Fatalf("warning count = %d, want %d", len(warnings), len(result.Warnings))
+	}
+}
+
 func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -1,0 +1,354 @@
+package resolve
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/canonical"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/sourcemap"
+	"github.com/osty/osty/internal/token"
+)
+
+type nativeResolveCache struct {
+	once   sync.Once
+	result selfhost.ResolveResult
+	files  []nativeResolveFileInfo
+	err    error
+}
+
+type nativeResolveFileInfo struct {
+	path       string
+	base       int
+	source     []byte
+	sourceMap  *sourcemap.Map
+	lineStarts []int
+}
+
+// NativeResolutionRow is one human-readable row derived from the selfhost
+// resolver's structured ref data.
+type NativeResolutionRow struct {
+	Line   int
+	Column int
+	Name   string
+	Kind   string
+	Def    string
+}
+
+// NativeStructuredResult returns the cached selfhost structured resolve result
+// for pkg. The returned slices should be treated as read-only.
+func NativeStructuredResult(pkg *Package) (selfhost.ResolveResult, error) {
+	result, _, err := nativeResolveArtifacts(pkg)
+	return result, err
+}
+
+// NativeResolutionRows returns the cached selfhost resolve rows for one file in
+// pkg, sorted by source position.
+func NativeResolutionRows(pkg *Package, path string) ([]NativeResolutionRow, error) {
+	result, files, err := nativeResolveArtifacts(pkg)
+	if err != nil {
+		return nil, err
+	}
+	return nativeResolutionRowsFromArtifacts(path, result, files), nil
+}
+
+// NativeDiagnostics returns the cached selfhost resolve diagnostics for pkg.
+// The returned slice does not include parser diagnostics already stored on the
+// package files.
+func NativeDiagnostics(pkg *Package) ([]*diag.Diagnostic, error) {
+	result, files, err := nativeResolveArtifacts(pkg)
+	if err != nil {
+		return nil, err
+	}
+	return nativeResolveDiagnosticsFromArtifacts(result, files), nil
+}
+
+// NativeResolutionRowsForSource wraps one parsed source file in a synthetic
+// package and returns the selfhost resolve rows for that file.
+func NativeResolutionRowsForSource(path string, src []byte, file *ast.File) ([]NativeResolutionRow, error) {
+	if file == nil {
+		return nil, fmt.Errorf("native resolve: missing parsed file")
+	}
+	pkg := &Package{
+		Name: "<file>",
+		Files: []*PackageFile{{
+			Path:   path,
+			Source: append([]byte(nil), src...),
+			File:   file,
+		}},
+	}
+	return NativeResolutionRows(pkg, path)
+}
+
+// NativeDiagnosticsForSource wraps one parsed source file in a synthetic
+// package and returns the selfhost resolve diagnostics for that file.
+func NativeDiagnosticsForSource(path string, src []byte, file *ast.File) ([]*diag.Diagnostic, error) {
+	if file == nil {
+		return nil, fmt.Errorf("native resolve: missing parsed file")
+	}
+	pkg := &Package{
+		Name: "<file>",
+		Files: []*PackageFile{{
+			Path:   path,
+			Source: append([]byte(nil), src...),
+			File:   file,
+		}},
+	}
+	return NativeDiagnostics(pkg)
+}
+
+func nativeResolveArtifacts(pkg *Package) (selfhost.ResolveResult, []nativeResolveFileInfo, error) {
+	if pkg == nil {
+		return selfhost.ResolveResult{}, nil, fmt.Errorf("native resolve: nil package")
+	}
+	pkg.nativeResolve.once.Do(func() {
+		input, files, err := nativeResolveInput(pkg)
+		if err != nil {
+			pkg.nativeResolve.err = err
+			return
+		}
+		resolved, err := selfhost.ResolvePackageStructured(input)
+		if err != nil {
+			pkg.nativeResolve.err = err
+			return
+		}
+		pkg.nativeResolve.result = resolved
+		pkg.nativeResolve.files = files
+	})
+	return pkg.nativeResolve.result, pkg.nativeResolve.files, pkg.nativeResolve.err
+}
+
+func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeResolveFileInfo, error) {
+	input := selfhost.PackageResolveInput{
+		Files: make([]selfhost.PackageResolveFile, 0, len(pkg.Files)),
+	}
+	files := make([]nativeResolveFileInfo, 0, len(pkg.Files))
+	base := 0
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		src, err := nativeResolveSourceForFile(pf)
+		if err != nil {
+			return selfhost.PackageResolveInput{}, nil, err
+		}
+		if len(src) == 0 {
+			continue
+		}
+		if pf.File == nil {
+			return selfhost.PackageResolveInput{}, nil, fmt.Errorf("native resolve: package file %s missing AST", pf.Path)
+		}
+		input.Files = append(input.Files, selfhost.PackageResolveFile{
+			Source:    append([]byte(nil), src...),
+			File:      pf.File,
+			SourceMap: pf.CanonicalMap,
+			Base:      base,
+			Name:      filepath.Base(pf.Path),
+			Path:      pf.Path,
+		})
+		files = append(files, nativeResolveFileInfo{
+			path:       pf.Path,
+			base:       base,
+			source:     append([]byte(nil), src...),
+			sourceMap:  pf.CanonicalMap,
+			lineStarts: nativeResolveLineStarts(src),
+		})
+		base += len(src) + 1
+	}
+	return input, files, nil
+}
+
+func nativeResolveSourceForFile(pf *PackageFile) ([]byte, error) {
+	if pf == nil {
+		return nil, nil
+	}
+	if len(pf.CanonicalSource) > 0 {
+		return pf.CanonicalSource, nil
+	}
+	if len(pf.Source) == 0 {
+		return nil, nil
+	}
+	if pf.File == nil {
+		return nil, fmt.Errorf("native resolve: package file %s missing AST", pf.Path)
+	}
+	src, _ := canonical.SourceWithMap(pf.Source, pf.File)
+	return src, nil
+}
+
+func nativeResolveLineStarts(src []byte) []int {
+	starts := []int{0}
+	for i, b := range src {
+		if b == '\n' {
+			starts = append(starts, i+1)
+		}
+	}
+	return starts
+}
+
+func nativeResolutionRowsFromArtifacts(path string, resolved selfhost.ResolveResult, files []nativeResolveFileInfo) []NativeResolutionRow {
+	kindByNode := map[int]string{}
+	for _, sym := range resolved.Symbols {
+		kindByNode[sym.Node] = nativeResolveKindLabel(sym.Kind)
+	}
+	rows := make([]NativeResolutionRow, 0, len(resolved.Refs))
+	for _, ref := range resolved.Refs {
+		if ref.File != path {
+			continue
+		}
+		line, col, ok := nativeResolveLineCol(files, path, ref.Start, ref.End)
+		if !ok {
+			continue
+		}
+		def := "<builtin>"
+		if ref.TargetFile != "" {
+			if dl, dc, ok := nativeResolveLineCol(files, ref.TargetFile, ref.TargetStart, ref.TargetEnd); ok {
+				def = fmt.Sprintf("%d:%d", dl, dc)
+			}
+		}
+		kind := kindByNode[ref.TargetNode]
+		if kind == "" {
+			kind = "builtin"
+		}
+		rows = append(rows, NativeResolutionRow{
+			Line:   line,
+			Column: col,
+			Name:   ref.Name,
+			Kind:   kind,
+			Def:    def,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Line != rows[j].Line {
+			return rows[i].Line < rows[j].Line
+		}
+		if rows[i].Column != rows[j].Column {
+			return rows[i].Column < rows[j].Column
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	return rows
+}
+
+func nativeResolveDiagnosticsFromArtifacts(resolved selfhost.ResolveResult, files []nativeResolveFileInfo) []*diag.Diagnostic {
+	out := make([]*diag.Diagnostic, 0, len(resolved.Diagnostics))
+	for _, record := range resolved.Diagnostics {
+		builder := diag.New(diag.Error, record.Message).Code(record.Code).File(record.File)
+		if span, ok := nativeResolveSpan(files, record.File, record.Start, record.End); ok {
+			builder.Primary(span, "")
+		}
+		if record.Hint != "" {
+			builder.Hint(record.Hint)
+		}
+		out = append(out, builder.Build())
+	}
+	return out
+}
+
+func nativeResolveSpan(files []nativeResolveFileInfo, path string, start, end int) (diag.Span, bool) {
+	file, relStart, ok := nativeResolveFileOffset(files, path, start)
+	if !ok {
+		return diag.Span{}, false
+	}
+	_, relEnd, ok := nativeResolveFileOffset(files, path, end)
+	if !ok {
+		relEnd = relStart
+	}
+	if relEnd < relStart {
+		relEnd = relStart
+	}
+	if file.sourceMap != nil {
+		if remapped, ok := file.sourceMap.RemapSpan(diag.Span{
+			Start: token.Pos{Offset: relStart},
+			End:   token.Pos{Offset: relEnd},
+		}); ok {
+			return remapped, true
+		}
+	}
+	startPos, ok := nativeResolvePositionInFile(file, relStart)
+	if !ok {
+		return diag.Span{}, false
+	}
+	endPos, ok := nativeResolvePositionInFile(file, relEnd)
+	if !ok {
+		endPos = startPos
+	}
+	if endPos.Offset < startPos.Offset {
+		endPos = startPos
+	}
+	return diag.Span{Start: startPos, End: endPos}, true
+}
+
+func nativeResolveLineCol(files []nativeResolveFileInfo, path string, start, end int) (int, int, bool) {
+	span, ok := nativeResolveSpan(files, path, start, end)
+	if !ok {
+		return 0, 0, false
+	}
+	return span.Start.Line, span.Start.Column, true
+}
+
+func nativeResolvePosition(files []nativeResolveFileInfo, path string, offset int) (token.Pos, bool) {
+	file, rel, ok := nativeResolveFileOffset(files, path, offset)
+	if !ok {
+		return token.Pos{}, false
+	}
+	return nativeResolvePositionInFile(file, rel)
+}
+
+func nativeResolveFileOffset(files []nativeResolveFileInfo, path string, offset int) (nativeResolveFileInfo, int, bool) {
+	for _, file := range files {
+		if path != "" && file.path != path {
+			continue
+		}
+		rel := offset - file.base
+		if rel < 0 || rel > len(file.source) {
+			continue
+		}
+		return file, rel, true
+	}
+	return nativeResolveFileInfo{}, 0, false
+}
+
+func nativeResolvePositionInFile(file nativeResolveFileInfo, rel int) (token.Pos, bool) {
+	if rel < 0 || rel > len(file.source) {
+		return token.Pos{}, false
+	}
+	lineIdx := sort.Search(len(file.lineStarts), func(i int) bool {
+		return file.lineStarts[i] > rel
+	}) - 1
+	if lineIdx < 0 {
+		lineIdx = 0
+	}
+	lineStart := file.lineStarts[lineIdx]
+	col := 1 + utf8.RuneCount(file.source[lineStart:rel])
+	return token.Pos{
+		Offset: rel,
+		Line:   lineIdx + 1,
+		Column: col,
+	}, true
+}
+
+func nativeResolveKindLabel(kind string) string {
+	switch kind {
+	case "fn":
+		return "function"
+	case "value":
+		return "binding"
+	case "type":
+		return "type"
+	case "variant":
+		return "variant"
+	case "package":
+		return "package"
+	case "generic":
+		return "type parameter"
+	case "":
+		return "builtin"
+	default:
+		return kind
+	}
+}

--- a/internal/resolve/native_adapter_test.go
+++ b/internal/resolve/native_adapter_test.go
@@ -1,0 +1,117 @@
+package resolve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNativeResolutionRowsCrossFile(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackage(dir)
+	if err != nil {
+		t.Fatalf("LoadPackage: %v", err)
+	}
+	rows, err := NativeResolutionRows(pkg, bPath)
+	if err != nil {
+		t.Fatalf("NativeResolutionRows: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("rows = %#v, want non-empty helper ref rows", rows)
+	}
+	found := false
+	for _, row := range rows {
+		if row.Name == "helper" && row.Kind == "function" && row.Def == "1:5" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("rows = %#v, want helper -> 1:5", rows)
+	}
+}
+
+func TestNativeResolutionRowsCachesResult(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn helper() -> Int { 1 }
+
+fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackage(dir)
+	if err != nil {
+		t.Fatalf("LoadPackage: %v", err)
+	}
+	first, err := NativeResolutionRows(pkg, path)
+	if err != nil {
+		t.Fatalf("NativeResolutionRows first: %v", err)
+	}
+	pkg.Files[0].File = nil
+	pkg.Files[0].CanonicalSource = []byte("fn broken(")
+	second, err := NativeResolutionRows(pkg, path)
+	if err != nil {
+		t.Fatalf("NativeResolutionRows second: %v", err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("row count changed across cached call: first=%#v second=%#v", first, second)
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("cached rows changed at %d: first=%#v second=%#v", i, first, second)
+		}
+	}
+}
+
+func TestNativeDiagnosticsSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {
+    missing()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkg, err := LoadPackage(dir)
+	if err != nil {
+		t.Fatalf("LoadPackage: %v", err)
+	}
+	diags, err := NativeDiagnostics(pkg)
+	if err != nil {
+		t.Fatalf("NativeDiagnostics: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diag count = %d, want 1 (%#v)", len(diags), diags)
+	}
+	got := diags[0]
+	if got.Code != "E0500" {
+		t.Fatalf("code = %q, want E0500", got.Code)
+	}
+	if got.Message != "undefined name" {
+		t.Fatalf("message = %q, want undefined name", got.Message)
+	}
+	if got.File != path {
+		t.Fatalf("file = %q, want %q", got.File, path)
+	}
+	if pos := got.PrimaryPos(); pos.Line != 2 || pos.Column != 5 {
+		t.Fatalf("primary pos = %v, want 2:5", pos)
+	}
+}

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -39,6 +39,9 @@ type Package struct {
 	// when a cycle is detected mid-load. The resolver emits
 	// CodeCyclicImport against the use site that completed the cycle.
 	isCycleMarker bool
+	// nativeResolve caches the read-only selfhost resolve projection so
+	// host-side tools can reuse one native run across several queries.
+	nativeResolve nativeResolveCache
 }
 
 // PackageFile bundles one parsed source file with the resolver outputs

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -9,9 +9,11 @@ Today the public entrypoints are:
 - `internal/lexer` — thin Go facade over selfhost tokenization
 - `internal/parser` — thin Go facade over selfhost parsing plus Go-side
   compatibility lowerings
-- `internal/selfhost` — `FormatSource` / `FormatCheck` expose stable Go
-  adapters over the bootstrap-generated pure-Osty formatter for parity tests
-  and self-host drift detection without changing the CLI formatter contract
+- `internal/selfhost` — `FormatSource` / `FormatCheck` plus
+  `ResolveSourceStructured` / `ResolvePackageStructured` expose stable Go
+  adapters over the bootstrap-generated pure-Osty formatter and resolver for
+  parity tests and self-host drift detection without changing the CLI
+  formatter contract
 - `internal/check` — prefers the external native checker binary and uses the
   embedded selfhost bridge as the fallback / adaptation boundary
 

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -1,0 +1,337 @@
+package selfhost
+
+import "errors"
+
+// PackageResolveFile is the per-file input shape accepted by the structured
+// self-host resolve adapter.
+type PackageResolveFile = PackageCheckFile
+
+// PackageResolveInput batches one or more source files into a synthetic package
+// so the self-host resolver can see one shared top-level namespace.
+type PackageResolveInput struct {
+	Files []PackageResolveFile `json:"files,omitempty"`
+}
+
+// ResolveSummary is the exported Go summary for the bootstrapped Osty
+// resolver.
+type ResolveSummary struct {
+	Symbols           int
+	Refs              int
+	TypeRefs          int
+	Diagnostics       int
+	Unresolved        int
+	Duplicates        int
+	SymbolsByKind     map[string]int
+	DiagnosticsByCode map[string]int
+}
+
+// ResolvedSymbol records one symbol declared by the self-host resolver.
+type ResolvedSymbol struct {
+	Node     int
+	Name     string
+	Kind     string
+	TypeName string
+	Arity    int
+	Depth    int
+	Start    int
+	End      int
+	Public   bool
+	File     string
+}
+
+// ResolvedRef records one value/name reference plus its resolved target span
+// when available.
+type ResolvedRef struct {
+	Name        string
+	Node        int
+	Start       int
+	End         int
+	File        string
+	TargetNode  int
+	TargetStart int
+	TargetEnd   int
+	TargetFile  string
+}
+
+// ResolvedTypeRef records one resolved type-name reference.
+type ResolvedTypeRef struct {
+	Name  string
+	Node  int
+	Start int
+	End   int
+	File  string
+}
+
+// ResolveDiagnosticRecord is one structured diagnostic produced by the
+// self-host resolver.
+type ResolveDiagnosticRecord struct {
+	Code    string
+	Message string
+	Name    string
+	Hint    string
+	Node    int
+	Start   int
+	End     int
+	File    string
+}
+
+// ResolveResult is the structured Go-facing surface for the bootstrapped
+// resolver.
+type ResolveResult struct {
+	Summary     ResolveSummary
+	Symbols     []ResolvedSymbol
+	Refs        []ResolvedRef
+	TypeRefs    []ResolvedTypeRef
+	Diagnostics []ResolveDiagnosticRecord
+}
+
+// ResolveSource runs the bootstrapped Osty resolver over one source string and
+// returns only the summary counters.
+func ResolveSource(src []byte) ResolveSummary {
+	return ResolveSourceStructured(src).Summary
+}
+
+// ResolveSourceStructured runs the bootstrapped Osty resolver over one source
+// string and returns the structured result.
+func ResolveSourceStructured(src []byte) ResolveResult {
+	lexed := ostyLexSource(string(src))
+	if lexed == nil {
+		return ResolveResult{}
+	}
+	file := astParseLexedSource(lexed)
+	if file == nil {
+		return ResolveResult{}
+	}
+	rt := newRuneTable(lexed.source)
+	return adaptResolveResult(
+		selfResolveAstFile(file),
+		file,
+		func(start, end int) (int, int) {
+			return checkNodeOffsets(rt, lexed.stream, start, end)
+		},
+	)
+}
+
+// ResolvePackageStructured lowers one structured package input into a
+// synthetic selfhost AST and runs the self-host resolver over the merged
+// package namespace.
+func ResolvePackageStructured(input PackageResolveInput) (ResolveResult, error) {
+	if selfhostCanBuildPackageAstDirect(input.Files) {
+		file, _, err := selfhostBuildPackageAstDirect(input.Files)
+		if err == nil {
+			if file == nil {
+				return ResolveResult{}, nil
+			}
+			result := adaptResolveResult(
+				selfResolveAstFile(file),
+				file,
+				func(start, end int) (int, int) {
+					if end < start {
+						end = start
+					}
+					return start, end
+				},
+			)
+			selfhostAnnotateResolveFiles(&result, input.Files)
+			return result, nil
+		}
+		var unsupported *selfhostLoweringUnsupported
+		if !errors.As(err, &unsupported) {
+			return ResolveResult{}, err
+		}
+	}
+	file, layout, err := selfhostBuildPackageAst(input.Files)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	if file == nil {
+		return ResolveResult{}, nil
+	}
+	result := adaptResolveResult(
+		selfResolveAstFile(file),
+		file,
+		func(start, end int) (int, int) {
+			return checkNodeOffsetsWithTokenLayout(layout, start, end)
+		},
+	)
+	selfhostAnnotateResolveFiles(&result, input.Files)
+	return result, nil
+}
+
+func adaptResolveSummary(resolved *SelfResolveResult) ResolveSummary {
+	if resolved == nil {
+		return ResolveSummary{}
+	}
+	summary := ResolveSummary{
+		Symbols:           len(resolved.symbols),
+		Refs:              resolved.refs,
+		TypeRefs:          resolved.typeRefs,
+		Diagnostics:       len(resolved.diagnostics),
+		Unresolved:        resolved.unresolved,
+		Duplicates:        resolved.duplicates,
+		SymbolsByKind:     map[string]int{},
+		DiagnosticsByCode: map[string]int{},
+	}
+	for _, sym := range resolved.symbols {
+		if sym == nil || sym.kind == "" {
+			continue
+		}
+		summary.SymbolsByKind[sym.kind]++
+	}
+	for _, d := range resolved.diagnostics {
+		if d == nil || d.code == "" {
+			continue
+		}
+		summary.DiagnosticsByCode[d.code]++
+	}
+	if len(summary.SymbolsByKind) == 0 {
+		summary.SymbolsByKind = nil
+	}
+	if len(summary.DiagnosticsByCode) == 0 {
+		summary.DiagnosticsByCode = nil
+	}
+	return summary
+}
+
+func adaptResolveResult(resolved *SelfResolveResult, file *AstFile, offsets func(start, end int) (int, int)) ResolveResult {
+	if resolved == nil {
+		return ResolveResult{}
+	}
+	result := ResolveResult{
+		Summary:     adaptResolveSummary(resolved),
+		Symbols:     make([]ResolvedSymbol, 0, len(resolved.symbols)),
+		Refs:        make([]ResolvedRef, 0, minResolveRefCount(resolved)),
+		TypeRefs:    make([]ResolvedTypeRef, 0, minResolveTypeRefCount(resolved)),
+		Diagnostics: make([]ResolveDiagnosticRecord, 0, len(resolved.diagnostics)),
+	}
+	for _, sym := range resolved.symbols {
+		if sym == nil {
+			continue
+		}
+		start, end := offsets(sym.start, sym.end)
+		result.Symbols = append(result.Symbols, ResolvedSymbol{
+			Node:     sym.node,
+			Name:     sym.name,
+			Kind:     sym.kind,
+			TypeName: sym.typeName,
+			Arity:    sym.arity,
+			Depth:    sym.depth,
+			Start:    start,
+			End:      end,
+			Public:   sym.public,
+		})
+	}
+	for i := 0; i < minResolveRefCount(resolved); i++ {
+		start, end := selfhostResolveNodeOffsets(file, resolved.refNodes[i], offsets)
+		targetStart, targetEnd := offsets(resolved.refTargetStarts[i], resolved.refTargetEnds[i])
+		result.Refs = append(result.Refs, ResolvedRef{
+			Name:        resolved.refNames[i],
+			Node:        resolved.refNodes[i],
+			Start:       start,
+			End:         end,
+			TargetNode:  resolved.refTargets[i],
+			TargetStart: targetStart,
+			TargetEnd:   targetEnd,
+		})
+	}
+	for i := 0; i < minResolveTypeRefCount(resolved); i++ {
+		start, end := selfhostResolveNodeOffsets(file, resolved.typeRefNodes[i], offsets)
+		result.TypeRefs = append(result.TypeRefs, ResolvedTypeRef{
+			Name:  resolved.typeRefNames[i],
+			Node:  resolved.typeRefNodes[i],
+			Start: start,
+			End:   end,
+		})
+	}
+	for _, d := range resolved.diagnostics {
+		if d == nil {
+			continue
+		}
+		start, end := offsets(d.start, d.end)
+		result.Diagnostics = append(result.Diagnostics, ResolveDiagnosticRecord{
+			Code:    d.code,
+			Message: d.message,
+			Name:    d.name,
+			Hint:    d.hint,
+			Node:    d.node,
+			Start:   start,
+			End:     end,
+		})
+	}
+	return result
+}
+
+func minResolveRefCount(resolved *SelfResolveResult) int {
+	if resolved == nil {
+		return 0
+	}
+	n := len(resolved.refNames)
+	if len(resolved.refNodes) < n {
+		n = len(resolved.refNodes)
+	}
+	if len(resolved.refTargets) < n {
+		n = len(resolved.refTargets)
+	}
+	if len(resolved.refTargetStarts) < n {
+		n = len(resolved.refTargetStarts)
+	}
+	if len(resolved.refTargetEnds) < n {
+		n = len(resolved.refTargetEnds)
+	}
+	return n
+}
+
+func minResolveTypeRefCount(resolved *SelfResolveResult) int {
+	if resolved == nil {
+		return 0
+	}
+	n := len(resolved.typeRefNames)
+	if len(resolved.typeRefNodes) < n {
+		n = len(resolved.typeRefNodes)
+	}
+	return n
+}
+
+func selfhostResolveNodeOffsets(file *AstFile, node int, offsets func(start, end int) (int, int)) (int, int) {
+	if file == nil || file.arena == nil || node < 0 || node >= len(file.arena.nodes) {
+		return 0, 0
+	}
+	n := file.arena.nodes[node]
+	if n == nil {
+		return 0, 0
+	}
+	return offsets(n.start, n.end)
+}
+
+func selfhostAnnotateResolveFiles(result *ResolveResult, files []PackageResolveFile) {
+	if result == nil || len(files) == 0 {
+		return
+	}
+	for i := range result.Symbols {
+		result.Symbols[i].File = selfhostResolveFilePath(files, result.Symbols[i].Start)
+	}
+	for i := range result.Refs {
+		result.Refs[i].File = selfhostResolveFilePath(files, result.Refs[i].Start)
+		result.Refs[i].TargetFile = selfhostResolveFilePath(files, result.Refs[i].TargetStart)
+	}
+	for i := range result.TypeRefs {
+		result.TypeRefs[i].File = selfhostResolveFilePath(files, result.TypeRefs[i].Start)
+	}
+	for i := range result.Diagnostics {
+		result.Diagnostics[i].File = selfhostResolveFilePath(files, result.Diagnostics[i].Start)
+	}
+}
+
+func selfhostResolveFilePath(files []PackageResolveFile, offset int) string {
+	for _, file := range files {
+		if file.Path == "" || len(file.Source) == 0 {
+			continue
+		}
+		start := file.Base
+		end := file.Base + len(file.Source)
+		if offset >= start && offset <= end {
+			return file.Path
+		}
+	}
+	return ""
+}

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -1,0 +1,182 @@
+package selfhost_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+func TestResolveSourceStructuredRecordsSymbolAndRefCoverage(t *testing.T) {
+	resolved := selfhost.ResolveSourceStructured([]byte(`fn helper(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let value = helper(1)
+}
+`))
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("diagnostics = %d, want 0 (summary=%#v diagnostics=%#v)", resolved.Summary.Diagnostics, resolved.Summary, resolved.Diagnostics)
+	}
+	helper := findResolvedSymbol(resolved, "helper", "fn")
+	if helper == nil {
+		t.Fatalf("missing helper symbol in %#v", resolved.Symbols)
+	}
+	ref := findResolvedRef(resolved, "helper")
+	if ref == nil {
+		t.Fatalf("missing helper ref in %#v", resolved.Refs)
+	}
+	if ref.TargetNode != helper.Node {
+		t.Fatalf("helper ref target node = %d, want %d", ref.TargetNode, helper.Node)
+	}
+	if resolved.Summary.SymbolsByKind["fn"] == 0 {
+		t.Fatalf("fn symbol histogram missing: %#v", resolved.Summary.SymbolsByKind)
+	}
+}
+
+func TestResolvePackageStructuredHandlesCrossFileRefsASTNative(t *testing.T) {
+	dir := t.TempDir()
+	helperPath := filepath.Join(dir, "helper.osty")
+	mainPath := filepath.Join(dir, "main.osty")
+
+	helper := canonicalSelfhostInput(t, []byte(`pub fn helper() -> Int {
+    41
+}
+`), 0)
+	helper.Name = "helper.osty"
+	helper.Path = helperPath
+
+	main := canonicalSelfhostInput(t, []byte(`fn main() {
+    let value = helper()
+}
+`), len(helper.Source)+1)
+	main.Name = "main.osty"
+	main.Path = mainPath
+
+	resolved, err := selfhost.ResolvePackageStructured(selfhost.PackageResolveInput{
+		Files: []selfhost.PackageResolveFile{helper, main},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePackageStructured: %v", err)
+	}
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("diagnostics = %d, want 0 (summary=%#v diagnostics=%#v)", resolved.Summary.Diagnostics, resolved.Summary, resolved.Diagnostics)
+	}
+	helperSym := findResolvedSymbol(resolved, "helper", "fn")
+	if helperSym == nil {
+		t.Fatalf("missing helper symbol in %#v", resolved.Symbols)
+	}
+	ref := findResolvedRef(resolved, "helper")
+	if ref == nil {
+		t.Fatalf("missing helper ref in %#v", resolved.Refs)
+	}
+	if ref.File != mainPath {
+		t.Fatalf("ref file = %q, want %q", ref.File, mainPath)
+	}
+	if ref.TargetFile != helperPath {
+		t.Fatalf("target file = %q, want %q", ref.TargetFile, helperPath)
+	}
+	if ref.TargetNode != helperSym.Node {
+		t.Fatalf("target node = %d, want %d", ref.TargetNode, helperSym.Node)
+	}
+}
+
+func TestResolvePackageStructuredUseBodyMissingMemberASTNative(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "main.osty")
+	input := canonicalSelfhostInput(t, []byte(`use go "dep" as dep {
+    fn make() -> Int
+}
+
+fn main() {
+    dep.missing()
+}
+`), 0)
+	input.Name = "main.osty"
+	input.Path = srcPath
+
+	resolved, err := selfhost.ResolvePackageStructured(selfhost.PackageResolveInput{
+		Files: []selfhost.PackageResolveFile{input},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePackageStructured: %v", err)
+	}
+	got := findResolveDiagnostic(resolved, "E0508")
+	if got == nil {
+		t.Fatalf("expected E0508, got %#v", resolved.Diagnostics)
+	}
+	if got.File != srcPath {
+		t.Fatalf("diagnostic file = %q, want %q", got.File, srcPath)
+	}
+	if got.Name != "missing" {
+		t.Fatalf("diagnostic name = %q, want %q", got.Name, "missing")
+	}
+	if resolved.Summary.DiagnosticsByCode["E0508"] != 1 {
+		t.Fatalf("diagnostic histogram = %#v, want E0508=1", resolved.Summary.DiagnosticsByCode)
+	}
+}
+
+func TestResolvePackageStructuredDuplicateUsesOwningFilePath(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.osty")
+	secondPath := filepath.Join(dir, "second.osty")
+
+	first := canonicalSelfhostInput(t, []byte(`pub fn helper() -> Int {
+    0
+}
+`), 0)
+	first.Name = "first.osty"
+	first.Path = firstPath
+
+	second := canonicalSelfhostInput(t, []byte(`pub fn helper() -> Int {
+    1
+}
+`), len(first.Source)+1)
+	second.Name = "second.osty"
+	second.Path = secondPath
+
+	resolved, err := selfhost.ResolvePackageStructured(selfhost.PackageResolveInput{
+		Files: []selfhost.PackageResolveFile{first, second},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePackageStructured: %v", err)
+	}
+	got := findResolveDiagnostic(resolved, "E0501")
+	if got == nil {
+		t.Fatalf("expected E0501, got %#v", resolved.Diagnostics)
+	}
+	if got.File != secondPath {
+		t.Fatalf("duplicate file = %q, want %q", got.File, secondPath)
+	}
+	if resolved.Summary.Duplicates != 1 {
+		t.Fatalf("duplicates = %d, want 1 (summary=%#v)", resolved.Summary.Duplicates, resolved.Summary)
+	}
+}
+
+func findResolvedSymbol(result selfhost.ResolveResult, name string, kind string) *selfhost.ResolvedSymbol {
+	for i := range result.Symbols {
+		if result.Symbols[i].Name == name && result.Symbols[i].Kind == kind {
+			return &result.Symbols[i]
+		}
+	}
+	return nil
+}
+
+func findResolvedRef(result selfhost.ResolveResult, name string) *selfhost.ResolvedRef {
+	for i := range result.Refs {
+		if result.Refs[i].Name == name {
+			return &result.Refs[i]
+		}
+	}
+	return nil
+}
+
+func findResolveDiagnostic(result selfhost.ResolveResult, code string) *selfhost.ResolveDiagnosticRecord {
+	for i := range result.Diagnostics {
+		if result.Diagnostics[i].Code == code {
+			return &result.Diagnostics[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a native selfhost resolve adapter plus `osty-native-resolver` and wire `osty resolve` through cached native rows/diagnostics
- add a shared `internal/resolve` native adapter/cache so CLI and other read-only resolve consumers can reuse selfhost results
- make `osty gen --emit llvm-ir` package-aware and add direct text emission for LLVM IR without the temp artifact readback path

## Testing
- `go test -count=1 -vet=off ./internal/resolve -run 'TestNativeResolutionRows(CrossFile|CachesResult)|TestNativeDiagnosticsSingleFile'`
- `go test -count=1 -vet=off ./cmd/osty-native-resolver ./internal/selfhost`
- `go test -count=1 -vet=off ./cmd/osty -run 'Test(ResolveCLI(SingleFilePrintsNativeResolutionRows|PackagePrintsNativeCrossFileResolutionRows|SingleFilePrintsNativeDiagnostics)|PrepareGenBackendEntryUsesPackageLoweringForSiblingFiles|GenCLIMultiFilePackageEmitsLLVMIR|LoadGenPackageEntryLoadsSiblingFiles|ParseGenEmitFileMergesPackageSources|ParseGenEmitFileReparsesMergedSource)'`
- `go test -count=1 -vet=off ./internal/backend -run 'Test(EmitLLVMIRTextMatchesBackendArtifactOutput|LLVMBackendEmitLLVMIRSkipsToolchain|LLVMBackendEmitLLVMIRFromIRWithoutASTFallback)'`