### PR TITLE
feat: 셀프호스팅 리졸버 annotation 검증 (E0400/E0607/E0609)

### DIFF
--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -417,16 +417,20 @@ fn srAstCollectDecl(file: AstFile, idx: Int, result: SelfResolveResult) -> SelfR
         }
     } else if node.kind == AstNFnDecl {
         out = srAstAddFunctionSymbol(file, idx, out)
+        out = srCheckDeclAnnotations(file, node.extra, srAnnotTargetTopLevel(), out)
     } else if node.kind == AstNStructDecl || node.kind == AstNInterfaceDecl || node.kind == AstNTypeAlias {
         out = srAddSymbol(
             out,
             selfSymbolAtNode(node.text, "type", "", 0, 0, node.start, node.end, node.flags == 1, idx),
         )
+        out = srCheckDeclAnnotations(file, node.extra, srAnnotTargetTopLevel(), out)
+        out = srCheckTypeMemberAnnotations(file, node, out)
     } else if node.kind == AstNEnumDecl {
         out = srAddSymbol(
             out,
             selfSymbolAtNode(node.text, "type", "", 0, 0, node.start, node.end, node.flags == 1, idx),
         )
+        out = srCheckDeclAnnotations(file, node.extra, srAnnotTargetTopLevel(), out)
         for memberIdx in node.children {
             let member = srAstNode(file, memberIdx)
             if member.kind == AstNVariant {
@@ -444,6 +448,9 @@ fn srAstCollectDecl(file: AstFile, idx: Int, result: SelfResolveResult) -> SelfR
                         memberIdx,
                     ),
                 )
+                out = srCheckDeclAnnotations(file, member.extra, srAnnotTargetVariant(), out)
+            } else if member.kind == AstNFnDecl {
+                out = srCheckDeclAnnotations(file, member.extra, srAnnotTargetMethod(), out)
             }
         }
     } else if node.kind == AstNLet {
@@ -453,6 +460,33 @@ fn srAstCollectDecl(file: AstFile, idx: Int, result: SelfResolveResult) -> SelfR
                 out,
                 selfSymbolAtNode(item.name, "value", srAstLetTypeName(file, node), 0, 0, item.start, item.end, false, item.node),
             )
+        }
+        out = srCheckDeclAnnotations(file, node.extra, srAnnotTargetTopLevel(), out)
+    }
+    out
+}
+
+fn srCheckTypeMemberAnnotations(
+    file: AstFile,
+    node: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    if node.kind == AstNStructDecl {
+        for memberIdx in node.children {
+            let member = srAstNode(file, memberIdx)
+            if member.kind == AstNField_ {
+                out = srCheckDeclAnnotations(file, member.extra, srAnnotTargetField(), out)
+            } else if member.kind == AstNFnDecl {
+                out = srCheckDeclAnnotations(file, member.extra, srAnnotTargetMethod(), out)
+            }
+        }
+    } else if node.kind == AstNInterfaceDecl {
+        for memberIdx in node.children {
+            let member = srAstNode(file, memberIdx)
+            if member.kind == AstNFnDecl {
+                out = srCheckDeclAnnotations(file, member.extra, srAnnotTargetMethod(), out)
+            }
         }
     }
     out
@@ -1856,4 +1890,168 @@ fn srIsUpperName(name: String) -> Bool {
 
 fn srIsDiscardName(name: String) -> Bool {
     name == "_" || strings.hasPrefix(name, "_")
+}
+
+// Annotation target bitmask. Matches the Go resolver's
+// `ast.AnnotationTarget` values (internal/ast/ast.go:79) so the
+// self-hosted checker can reuse the same allow-list logic.
+fn srAnnotTargetField() -> Int { 1 }
+fn srAnnotTargetTopLevel() -> Int { 2 }
+fn srAnnotTargetMethod() -> Int { 4 }
+fn srAnnotTargetVariant() -> Int { 8 }
+
+/// srAnnotAllowedTargets returns the bitmask of valid targets for a
+/// permitted annotation, or 0 for unknown names. Keep in sync with
+/// `annotationRules` in internal/ast/ast.go:93.
+fn srAnnotAllowedTargets(name: String) -> Int {
+    if name == "json" { return srAnnotTargetField() | srAnnotTargetVariant() }
+    if name == "deprecated" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "allow" {
+        return srAnnotTargetTopLevel() | srAnnotTargetMethod() | srAnnotTargetField() | srAnnotTargetVariant()
+    }
+    if name == "intrinsic_methods" { return srAnnotTargetTopLevel() }
+    if name == "requires" { return srAnnotTargetMethod() }
+    if name == "no_alloc" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "intrinsic" { return srAnnotTargetTopLevel() | srAnnotTargetMethod() }
+    if name == "c_abi" { return srAnnotTargetTopLevel() }
+    if name == "export" { return srAnnotTargetTopLevel() }
+    if name == "pod" { return srAnnotTargetTopLevel() }
+    if name == "repr" { return srAnnotTargetTopLevel() }
+    if name == "cfg" {
+        return srAnnotTargetTopLevel() | srAnnotTargetMethod() | srAnnotTargetField() | srAnnotTargetVariant()
+    }
+    if name == "op" { return srAnnotTargetMethod() }
+    if name == "test" { return srAnnotTargetTopLevel() }
+    0
+}
+
+fn srIsAllowedAnnotation(name: String) -> Bool {
+    srAnnotAllowedTargets(name) != 0
+}
+
+fn srAnnotationAllowedAt(name: String, target: Int) -> Bool {
+    let allowed = srAnnotAllowedTargets(name)
+    allowed != 0 && (allowed & target) != 0
+}
+
+fn srAnnotationTargetString(name: String) -> String {
+    let allowed = srAnnotAllowedTargets(name)
+    if allowed == 0 {
+        return "(unknown)"
+    }
+    let mut parts: List<String> = []
+    if (allowed & srAnnotTargetField()) != 0 { parts.push("struct fields") }
+    if (allowed & srAnnotTargetTopLevel()) != 0 { parts.push("top-level declarations") }
+    if (allowed & srAnnotTargetMethod()) != 0 { parts.push("methods") }
+    if (allowed & srAnnotTargetVariant()) != 0 { parts.push("enum variants") }
+    srJoinWithAnd(parts)
+}
+
+fn srJoinWithAnd(parts: List<String>) -> String {
+    let n = parts.len()
+    if n == 0 { return "" }
+    if n == 1 { return parts[0] }
+    if n == 2 { return parts[0] + " and " + parts[1] }
+    let mut out = ""
+    let mut idx = 0
+    for p in parts {
+        if idx == 0 {
+            out = p
+        } else if idx == n - 1 {
+            out = out + ", and " + p
+        } else {
+            out = out + ", " + p
+        }
+        idx = idx + 1
+    }
+    out
+}
+
+/// srCollectAnnotationNodes unpacks a decl's `extra` field into the flat
+/// list of AstNAnnotation nodes that hang off it. The parser packs 0, 1,
+/// or N annotations differently (-1 / direct idx / "__group" wrapper);
+/// this helper hides the shape difference.
+fn srCollectAnnotationNodes(file: AstFile, extraIdx: Int) -> List<AstNode> {
+    let mut anns: List<AstNode> = []
+    if extraIdx < 0 {
+        return anns
+    }
+    let ann = srAstNode(file, extraIdx)
+    if ann.kind != AstNAnnotation {
+        return anns
+    }
+    if ann.text == "__group" {
+        for childIdx in ann.children {
+            let child = srAstNode(file, childIdx)
+            if child.kind == AstNAnnotation {
+                anns.push(child)
+            }
+        }
+    } else {
+        anns.push(ann)
+    }
+    anns
+}
+
+/// srCheckDeclAnnotations validates the annotations attached to a single
+/// declaration (or member) against v0.4 §18.1:
+///   - unknown names → E0400
+///   - wrong target kind → E0607
+///   - same name twice on one target → E0609
+fn srCheckDeclAnnotations(
+    file: AstFile,
+    extraIdx: Int,
+    target: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    // Most decls carry no annotations; skip the unpack call (and its
+    // list allocation) in the common case.
+    if extraIdx < 0 {
+        return result
+    }
+    let anns = srCollectAnnotationNodes(file, extraIdx)
+    let mut out = result
+    let mut seen: List<String> = []
+    for ann in anns {
+        let name = ann.text
+        if !srIsAllowedAnnotation(name) {
+            out.diagnostics.push(selfResolveDiagnostic(
+                "E0400",
+                "unknown annotation `#[" + name + "]`",
+                name,
+                ann.start,
+                ann.end,
+            ))
+            continue
+        }
+        if !srAnnotationAllowedAt(name, target) {
+            out.diagnostics.push(selfResolveDiagnosticHintAtNode(
+                "E0607",
+                "annotation `#[" + name + "]` is not allowed here",
+                name,
+                ann.start,
+                ann.end,
+                -1,
+                "`#[" + name + "]` is permitted on " + srAnnotationTargetString(name),
+            ))
+        }
+        let mut isDup = false
+        for prev in seen {
+            if prev == name {
+                isDup = true
+            }
+        }
+        if isDup {
+            out.diagnostics.push(selfResolveDiagnostic(
+                "E0609",
+                "annotation `#[" + name + "]` is repeated on the same target",
+                name,
+                ann.start,
+                ann.end,
+            ))
+            continue
+        }
+        seen.push(name)
+    }
+    out
 }

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -458,3 +458,84 @@ fn testSelfResolverAcceptsReturnInClosure() {
     testing.assertEq(selfResolveCodeCount(result, "E0602"), 0)
     testing.assertEq(selfResolveCodeCount(result, "E0603"), 0)
 }
+
+fn testSelfResolverRejectsUnknownAnnotation() {
+    let result = selfResolveSource(
+        r"""
+            #[bogus]
+            fn main() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+}
+
+fn testSelfResolverRejectsAnnotationOnWrongTarget() {
+    // `#[json]` attaches only to struct fields and enum variants. Putting
+    // it on a top-level fn is E0607. The name is valid (no E0400).
+    let result = selfResolveSource(
+        r"""
+            #[json(key = "x")]
+            fn main() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0607"), 1)
+}
+
+fn testSelfResolverRejectsDuplicateAnnotation() {
+    let result = selfResolveSource(
+        r"""
+            #[deprecated]
+            #[deprecated]
+            fn main() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0609"), 1)
+}
+
+fn testSelfResolverAcceptsValidAnnotations() {
+    // Structural sanity: a well-formed decl with one valid annotation per
+    // target class produces no annotation diagnostics.
+    let result = selfResolveSource(
+        r"""
+            #[deprecated(since = "0.5")]
+            pub fn legacy() {}
+
+            #[cfg(os = "linux")]
+            struct Linux {
+                #[json(key = "id")]
+                id: Int,
+            }
+
+            enum Color {
+                #[json(key = "r")]
+                Red,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0607"), 0)
+    testing.assertEq(selfResolveCodeCount(result, "E0609"), 0)
+}
+
+fn testSelfResolverChecksAnnotationsOnStructMembers() {
+    // `#[json]` on a method is wrong target (methods aren't in json's
+    // allow-set). `#[op]` on a field is wrong target too.
+    let result = selfResolveSource(
+        r"""
+            struct Bad {
+                #[op]
+                value: Int,
+
+                #[json(key = "x")]
+                fn get(self) -> Int { self.value }
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0607"), 2)
+}


### PR DESCRIPTION
## 무엇

셀프호스팅 리졸버(`toolchain/resolve.osty`)에 `#[...]` annotation 검증을 추가합니다. Go 리졸버의 `checkAnnotations` ([internal/resolve/resolve.go:494](internal/resolve/resolve.go:494)) 와 동일한 규칙.

- `E0400` — unknown annotation 이름 (`#[bogus]` 등)
- `E0607` — target 불일치 (`#[json]` on fn, `#[op]` on field)
- `E0609` — 같은 target 에 동일 annotation 반복

## 왜

기존 셀프호스팅 리졸버는 `#[...]` 을 완전히 무시했습니다. 파서가 packed `extra` 필드로 annotation 노드를 넣어주지만 리졸버가 한 번도 꺼내보지 않았죠. 그 결과 네이티브 체커 경로에서 오타/잘못 붙인 annotation 이 silently 통과되었습니다.

## 어떻게

**인프라 (toolchain/resolve.osty 파일 끝에 추가):**
- `srAnnotTargetField/TopLevel/Method/Variant()` — [ast.AnnotationTarget](internal/ast/ast.go:79) 의 1/2/4/8 비트마스크와 동기
- `srAnnotAllowedTargets(name)` — 15개 허용 annotation 의 target bitmask. [annotationRules](internal/ast/ast.go:93) 와 키-바이-키 일치 (json/deprecated/allow/intrinsic_methods/requires/no_alloc/intrinsic/c_abi/export/pod/repr/cfg/op/test)
- `srCollectAnnotationNodes` — 파서의 3가지 포장 형태(`-1` / single idx / `__group` wrapper) 를 flat List 로 풀어줌
- `srCheckDeclAnnotations(file, extraIdx, target, result)` — 세 diag emit. extra<0 이면 early-return (대부분의 decl)

**호출 지점 (srAstCollectDecl):**
- top-level: fn / struct / enum / interface / type alias / let
- enum variants → `srAnnotTargetVariant()`
- enum methods → `srAnnotTargetMethod()`
- struct fields → `srAnnotTargetField()`
- struct/interface methods → `srAnnotTargetMethod()`

## 테스트

`toolchain/resolve_test.osty` 에 5개 포커스 테스트:
- `testSelfResolverRejectsUnknownAnnotation` — E0400
- `testSelfResolverRejectsAnnotationOnWrongTarget` — E0607 (`#[json]` on fn)
- `testSelfResolverRejectsDuplicateAnnotation` — E0609
- `testSelfResolverAcceptsValidAnnotations` — 정상 케이스 (E0400/E0607/E0609 모두 0)
- `testSelfResolverChecksAnnotationsOnStructMembers` — struct field + method target (E0607 ×2)

## 검증

- [x] `just front` — Go 리졸버 스펙 코퍼스 회귀 없음
- [x] `TestToolchainCheckerSourcesTranspile` — bootstrap-gen 을 통한 `resolve.osty` 트랜스파일 통과
- [ ] `osty test toolchain/resolve_test.osty` — 사전 존재하는 IR lowering panic([internal/ir/lower.go:1043](internal/ir/lower.go:1043)) 으로 불가. 이번 PR 범위 외

## 참고 — commit history

`2e84f64d` 는 [#568](https://github.com/choiceoh/osty/pull/568) 이 squash-merge 되기 전 rebase 시점에 남은 중복 커밋입니다. 내용은 이미 main 의 `ca3605a1` 에 있으므로 이 PR 의 실질 diff 는 annotation 작업만 포함합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)