### PR TITLE
[codex] Improve long-workload map hot paths

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -373,6 +373,8 @@ typedef struct osty_rt_list {
     unsigned char *data;
 } osty_rt_list;
 
+#define OSTY_RT_MAP_INLINE_INDEX_CAP 64
+
 typedef struct osty_rt_map {
     int64_t len;
     int64_t cap;
@@ -382,6 +384,14 @@ typedef struct osty_rt_map {
     osty_rt_trace_slot_fn value_trace;
     unsigned char *keys;
     unsigned char *values;
+    // Lookup side index: open-addressed hash table storing slot+1 so
+    // `Map` keeps its insertion-ordered key/value arrays while get /
+    // contains / insert avoid an O(n) scan once the map grows past the
+    // tiny-list regime.
+    int64_t index_cap;
+    int64_t index_len;
+    int64_t *index_slots;
+    int64_t index_inline[OSTY_RT_MAP_INLINE_INDEX_CAP];
     // Per-map recursive mutex. Guarantees that all public map ops are
     // mutually exclusive on a single instance so concurrent mutation
     // can't realloc the slot arrays mid-read, drop the len mid-walk,
@@ -1276,6 +1286,57 @@ static size_t osty_rt_kind_size(int64_t kind) {
     }
 }
 
+static uint64_t osty_rt_hash_mix64(uint64_t h) {
+    h ^= h >> 33;
+    h *= 0xff51afd7ed558ccdULL;
+    h ^= h >> 33;
+    h *= 0xc4ceb9fe1a85ec53ULL;
+    h ^= h >> 33;
+    return h;
+}
+
+static size_t osty_rt_hash_bytes(const unsigned char *bytes, size_t len) {
+    uint64_t h = 1469598103934665603ULL;
+    size_t i;
+    for (i = 0; i < len; i++) {
+        h ^= (uint64_t)bytes[i];
+        h *= 1099511628211ULL;
+    }
+    return (size_t)osty_rt_hash_mix64(h);
+}
+
+static size_t osty_rt_map_key_hash(int64_t kind, const void *key) {
+    switch (kind) {
+    case OSTY_RT_ABI_I64:
+    case OSTY_RT_ABI_F64: {
+        uint64_t bits = 0;
+        memcpy(&bits, key, sizeof(bits));
+        return (size_t)osty_rt_hash_mix64(bits);
+    }
+    case OSTY_RT_ABI_I1: {
+        bool value = false;
+        memcpy(&value, key, sizeof(value));
+        return (size_t)osty_rt_hash_mix64(value ? 0x9e3779b97f4a7c15ULL : 0ULL);
+    }
+    case OSTY_RT_ABI_PTR: {
+        void *value = NULL;
+        memcpy(&value, key, sizeof(value));
+        return (size_t)osty_rt_hash_mix64((uint64_t)(uintptr_t)value);
+    }
+    case OSTY_RT_ABI_STRING: {
+        const char *value = NULL;
+        memcpy(&value, key, sizeof(value));
+        if (value == NULL) {
+            return (size_t)osty_rt_hash_mix64(0ULL);
+        }
+        return osty_rt_hash_bytes((const unsigned char *)value, strlen(value));
+    }
+    default:
+        osty_rt_abort("unsupported map key hash kind");
+        return 0;
+    }
+}
+
 static void osty_rt_map_trace(void *payload) {
     osty_rt_map *map = (osty_rt_map *)payload;
     int64_t i;
@@ -1300,6 +1361,9 @@ static void osty_rt_map_trace(void *payload) {
 static void osty_rt_map_destroy(void *payload) {
     osty_rt_map *map = (osty_rt_map *)payload;
     if (map != NULL) {
+        if (map->index_slots != NULL && map->index_slots != map->index_inline) {
+            free(map->index_slots);
+        }
         free(map->keys);
         free(map->values);
         if (map->mu_init) {
@@ -3357,6 +3421,70 @@ static void *osty_rt_map_key_slot(osty_rt_map *map, int64_t index) {
     return (void *)(map->keys + ((size_t)index * osty_rt_kind_size(map->key_kind)));
 }
 
+static void osty_rt_map_index_clear(osty_rt_map *map) {
+    if (map->index_slots != NULL && map->index_slots != map->index_inline) {
+        free(map->index_slots);
+    }
+    map->index_slots = NULL;
+    map->index_cap = 0;
+    map->index_len = 0;
+}
+
+static void osty_rt_map_index_insert_slot(osty_rt_map *map, int64_t slot) {
+    uint64_t mask = (uint64_t)(map->index_cap - 1);
+    uint64_t idx = (uint64_t)osty_rt_map_key_hash(map->key_kind, osty_rt_map_key_slot(map, slot)) & mask;
+    while (map->index_slots[idx] != 0) {
+        idx = (idx + 1) & mask;
+    }
+    map->index_slots[idx] = slot + 1;
+    map->index_len += 1;
+}
+
+static void osty_rt_map_index_rebuild(osty_rt_map *map, int64_t live_len) {
+    int64_t cap = 8;
+    int64_t i;
+
+    if (live_len < 8) {
+        osty_rt_map_index_clear(map);
+        return;
+    }
+    while (cap < live_len * 2) {
+        if (cap > INT64_MAX / 2) {
+            cap = live_len * 2;
+            break;
+        }
+        cap *= 2;
+    }
+    if (cap <= 0) {
+        osty_rt_abort("map index capacity overflow");
+    }
+    if (cap <= OSTY_RT_MAP_INLINE_INDEX_CAP) {
+        if (map->index_slots != NULL && map->index_slots != map->index_inline) {
+            free(map->index_slots);
+        }
+        map->index_slots = map->index_inline;
+        memset(map->index_slots, 0, (size_t)cap * sizeof(int64_t));
+        map->index_cap = cap;
+    } else {
+        if (map->index_cap != cap || map->index_slots == NULL || map->index_slots == map->index_inline) {
+            if (map->index_slots != NULL && map->index_slots != map->index_inline) {
+                free(map->index_slots);
+            }
+            map->index_slots = (int64_t *)calloc((size_t)cap, sizeof(int64_t));
+            if (map->index_slots == NULL) {
+                osty_rt_abort("out of memory");
+            }
+            map->index_cap = cap;
+        } else {
+            memset(map->index_slots, 0, (size_t)map->index_cap * sizeof(int64_t));
+        }
+    }
+    map->index_len = 0;
+    for (i = 0; i < map->len; i++) {
+        osty_rt_map_index_insert_slot(map, i);
+    }
+}
+
 static void osty_rt_map_reserve(osty_rt_map *map, int64_t min_cap) {
     int64_t next_cap = map->cap;
     size_t key_bytes;
@@ -3385,7 +3513,7 @@ static void osty_rt_map_reserve(osty_rt_map *map, int64_t min_cap) {
     map->cap = next_cap;
 }
 
-static int64_t osty_rt_map_find_index(osty_rt_map *map, const void *key) {
+static int64_t osty_rt_map_find_index_linear(osty_rt_map *map, const void *key) {
     int64_t i;
     size_t key_size = osty_rt_kind_size(map->key_kind);
     for (i = 0; i < map->len; i++) {
@@ -3394,6 +3522,33 @@ static int64_t osty_rt_map_find_index(osty_rt_map *map, const void *key) {
         }
     }
     return -1;
+}
+
+static int64_t osty_rt_map_find_index_indexed(osty_rt_map *map, const void *key) {
+    size_t key_size = osty_rt_kind_size(map->key_kind);
+    uint64_t mask = (uint64_t)(map->index_cap - 1);
+    uint64_t idx = (uint64_t)osty_rt_map_key_hash(map->key_kind, key) & mask;
+
+    for (;;) {
+        int64_t entry = map->index_slots[idx];
+        int64_t slot;
+        if (entry == 0) {
+            return -1;
+        }
+        slot = entry - 1;
+        if (slot >= 0 && slot < map->len &&
+            osty_rt_value_equals(osty_rt_map_key_slot(map, slot), key, key_size, map->key_kind)) {
+            return slot;
+        }
+        idx = (idx + 1) & mask;
+    }
+}
+
+static int64_t osty_rt_map_find_index(osty_rt_map *map, const void *key) {
+    if (map->index_cap > 0 && map->index_slots != NULL) {
+        return osty_rt_map_find_index_indexed(map, key);
+    }
+    return osty_rt_map_find_index_linear(map, key);
 }
 
 void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, osty_rt_trace_slot_fn value_trace) {
@@ -3409,6 +3564,9 @@ void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, 
     map->value_kind = value_kind;
     map->value_size = (size_t)value_size;
     map->value_trace = value_trace;
+    map->index_cap = 0;
+    map->index_len = 0;
+    map->index_slots = NULL;
     {
         pthread_mutexattr_t attr;
         if (pthread_mutexattr_init(&attr) != 0) {
@@ -3451,6 +3609,7 @@ static void osty_rt_map_insert_raw(void *raw_map, const void *key, const void *v
     osty_rt_map *map = (osty_rt_map *)raw_map;
     int64_t index;
     size_t key_size;
+    bool inserted = false;
     if (map == NULL || key == NULL || value == NULL) {
         osty_rt_abort("invalid map insert");
     }
@@ -3460,9 +3619,20 @@ static void osty_rt_map_insert_raw(void *raw_map, const void *key, const void *v
         osty_rt_map_reserve(map, map->len + 1);
         index = map->len;
         map->len += 1;
+        inserted = true;
     }
     memcpy(osty_rt_map_key_slot(map, index), key, key_size);
     memcpy(osty_rt_map_value_slot(map, index), value, map->value_size);
+    if (inserted) {
+        if (map->len >= 8) {
+            if (map->index_cap == 0 || map->index_slots == NULL ||
+                (map->index_len + 1) * 10 >= map->index_cap * 7) {
+                osty_rt_map_index_rebuild(map, map->len);
+            } else {
+                osty_rt_map_index_insert_slot(map, index);
+            }
+        }
+    }
 }
 
 static bool osty_rt_map_remove_raw(void *raw_map, const void *key) {
@@ -3484,6 +3654,9 @@ static bool osty_rt_map_remove_raw(void *raw_map, const void *key) {
         memmove(osty_rt_map_value_slot(map, index), osty_rt_map_value_slot(map, index + 1), (size_t)(map->len - index - 1) * value_size);
     }
     map->len -= 1;
+    if (map->index_cap != 0 || map->index_slots != NULL) {
+        osty_rt_map_index_rebuild(map, map->len);
+    }
     return true;
 }
 
@@ -3563,6 +3736,7 @@ void osty_rt_map_clear(void *raw_map) {
     }
     osty_rt_map_lock(raw_map);
     map->len = 0;
+    osty_rt_map_index_clear(map);
     osty_rt_map_unlock(raw_map);
 }
 

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -3852,7 +3852,8 @@ func (g *generator) emitMapMapValues(call *ast.CallExpr, base value, keyTyp stri
 // form `self.get(key) ?? default`. It composes the real `get` intrinsic
 // (Option<V>) with the ptr-backed coalesce shape: icmp eq ptr null →
 // branch → phi. For scalar V the some branch also loads the payload
-// out of the boxed Option so the phi produces V, not ptr.
+// out of a stack slot so hot getOr loops avoid allocating an Option box
+// per successful lookup.
 func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, keyString bool) (value, bool, error) {
 	if len(call.Args) != 2 ||
 		call.Args[0].Name != "" || call.Args[1].Name != "" ||
@@ -3870,10 +3871,6 @@ func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, 
 	if err != nil {
 		return value{}, true, err
 	}
-	optVal, err := g.emitMapGetCore(base, loadedKey, keyTyp, keyString)
-	if err != nil {
-		return value{}, true, err
-	}
 
 	def, err := g.emitExpr(call.Args[1].Value)
 	if err != nil {
@@ -3882,6 +3879,48 @@ func (g *generator) emitMapGetOr(call *ast.CallExpr, base value, keyTyp string, 
 	valTyp := base.mapValueTyp
 	if def.typ != valTyp {
 		return value{}, true, unsupportedf("type-system", "map.getOr default type %s, want %s", def.typ, valTyp)
+	}
+	if valTyp != "ptr" {
+		getSym := mapRuntimeGetSymbol(keyTyp, keyString)
+		g.declareRuntimeSymbol(getSym, "i1", []paramInfo{{typ: "ptr"}, {typ: keyTyp}, {typ: "ptr"}})
+
+		emitter := g.toOstyEmitter()
+		slot := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, valTyp))
+		present := llvmCall(emitter, "i1", getSym, []*LlvmValue{
+			toOstyValue(base),
+			toOstyValue(loadedKey),
+			{typ: "ptr", name: slot},
+		})
+		labels := llvmIfExprStart(emitter, present)
+		g.takeOstyEmitter(emitter)
+
+		// then = hit: load the scalar payload from the temp slot.
+		g.currentBlock = labels.thenLabel
+		emitter = g.toOstyEmitter()
+		payload := llvmLoad(emitter, &LlvmValue{typ: valTyp, name: slot, pointer: true})
+		g.takeOstyEmitter(emitter)
+		hitPred := g.currentBlock
+		hitVal := value{typ: valTyp, ref: payload.name}
+
+		// else = miss: fall back to the default.
+		emitter = g.toOstyEmitter()
+		llvmIfExprElse(emitter, labels)
+		g.takeOstyEmitter(emitter)
+		g.currentBlock = labels.elseLabel
+		missPred := g.currentBlock
+		missVal := def
+
+		out, err := g.emitIfExprPhi(labels, hitPred, missPred, hitVal, missVal)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	}
+
+	optVal, err := g.emitMapGetCore(base, loadedKey, keyTyp, keyString)
+	if err != nil {
+		return value{}, true, err
 	}
 
 	emitter := g.toOstyEmitter()

--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -777,10 +777,11 @@ func TestGenerateMapGetScalarValueBoxLowering(t *testing.T) {
 	}
 }
 
-// TestGenerateMapGetOrScalarValueUnwrapsBox verifies Map.getOr for
-// scalar V: the getOr composition loads the i64 payload out of the
-// boxed Option in the some branch and phis it against the scalar
-// default, producing `phi i64` (not `phi ptr`).
+// TestGenerateMapGetOrScalarValueUsesDirectLookup verifies Map.getOr
+// for scalar V uses the bool-returning map_get runtime directly: a
+// stack slot receives the payload on hit, the hit branch loads it, and
+// the miss branch falls back to the scalar default without allocating
+// an Option box.
 func TestGenerateMapGetOrScalarValueUnwrapsBox(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn count(m: Map<String, Int>, k: String) -> Int {
     m.getOr(k, 0)
@@ -796,14 +797,17 @@ func TestGenerateMapGetOrScalarValueUnwrapsBox(t *testing.T) {
 	got := string(ir)
 	for _, want := range []string{
 		"call i1 @osty_rt_map_get_string(",
-		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
-		"icmp eq ptr",
+		"alloca i64",
+		"br i1 ",
 		"load i64, ptr",
 		"= phi i64 [",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "call ptr @osty.gc.alloc_v1") {
+		t.Fatalf("scalar getOr should not allocate an Option box:\n%s", got)
 	}
 	if strings.Contains(got, "osty_rt_map_contains_string") ||
 		strings.Contains(got, "osty_rt_map_get_or_abort_string") {


### PR DESCRIPTION
## What changed
- add a small-map side index in the bundled runtime so `Map` keeps insertion order while `containsKey` / `get` / `getOr` / `insert` stop paying a full linear scan once maps grow past the tiny-list regime
- lower scalar `Map.getOr` without building a boxed `Option`, using the bool-returning `map_get` runtime directly with a stack slot fast path
- update llvmgen coverage so the scalar `getOr` IR shape stays on the non-boxing path

## Why
The longer `word_freq`-style workload spends most of its time in repeated `Map<String, Int>` lookups and updates. Even after earlier polling work, that path still paid for linear lookup plus scalar `getOr` boxing in hot loops. This PR targets those runtime costs directly instead of changing the benchmark harness.

## Impact
- improves long-workload `Map<String, Int>` lookup/update paths
- preserves insertion-order semantics for `Map`
- removes per-hit boxing overhead from scalar `getOr`

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateMapGetOrScalarValueUnwrapsBox|TestGenerateMapGetOrComposesOnGetAndCoalesce|TestGenerateMapGetScalarValueBoxesOption'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestLLVMBackendEmitBinaryBuildsBundledRuntime|TestPhase2eCoalesceSourceTypeRecoveredForMapGet|TestPhase2MonomorphMapReachesGenerateModule'`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `just build`
- `.bin/osty test --bench --serial --benchtime=1s benchmarks/osty-vs-go/word_freq/osty`

## Benchmark note
The direct `word_freq` bench on this machine still shows visible variance across reruns, so this PR is framed around the runtime-path change rather than a single headline number. In isolated runs during development, the long workload improved from roughly `105.9us` on `main` to the low-`80us` range on this branch, while noisier reruns landed higher.
