### PR TITLE
[codex] expand string and bytes backend support

### DIFF
--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -1204,8 +1204,16 @@ const char *osty_rt_strings_TrimEnd(const char *value);
 const char *osty_rt_strings_TrimPrefix(const char *value, const char *prefix);
 const char *osty_rt_strings_TrimSuffix(const char *value, const char *suffix);
 const char *osty_rt_strings_TrimSpace(const char *value);
+void *osty_rt_strings_ToBytes(const char *value);
 void *osty_rt_strings_Chars(const char *value);
 void *osty_rt_strings_Bytes(const char *value);
+void *osty_rt_bytes_from_list(void *raw_list);
+void *osty_rt_bytes_concat(void *raw_left, void *raw_right);
+void *osty_rt_bytes_repeat(void *raw_bytes, int64_t n);
+int64_t osty_rt_bytes_index_of(void *raw_bytes, void *raw_sub);
+bool osty_rt_bytes_is_valid_utf8(void *raw_bytes);
+const char *osty_rt_bytes_to_string(void *raw_bytes);
+uint8_t osty_rt_bytes_get(void *raw_bytes, int64_t index);
 bool osty_rt_set_insert_i64(void *raw_set, int64_t item);
 bool osty_rt_set_insert_i1(void *raw_set, bool item);
 bool osty_rt_set_insert_f64(void *raw_set, double item);
@@ -3413,6 +3421,28 @@ const char *osty_rt_strings_TrimSpace(const char *value) {
     return out;
 }
 
+void *osty_rt_strings_ToBytes(const char *value) {
+    size_t len;
+    size_t total;
+    osty_rt_bytes *out;
+    unsigned char *data;
+
+    value = (value == NULL) ? "" : value;
+    len = strlen(value);
+    if (len > SIZE_MAX - sizeof(osty_rt_bytes)) {
+        osty_rt_abort("runtime.strings.to_bytes: size overflow");
+    }
+    total = sizeof(osty_rt_bytes) + len;
+    out = (osty_rt_bytes *)osty_gc_allocate_managed(total, OSTY_GC_KIND_BYTES, "runtime.strings.to_bytes", NULL, NULL);
+    data = (unsigned char *)(out + 1);
+    out->data = data;
+    out->len = (int64_t)len;
+    if (len != 0) {
+        memcpy(data, value, len);
+    }
+    return out;
+}
+
 static void *osty_rt_map_value_slot(osty_rt_map *map, int64_t index) {
     return (void *)(map->values + ((size_t)index * map->value_size));
 }
@@ -4038,11 +4068,235 @@ OSTY_RT_DEFINE_SET_KEY_OPS(string, const char *)
 
 /*
  * Bytes primitive ABI. Values flow as `osty_rt_bytes *` — an opaque
- * pointer to a `{unsigned char *data; int64_t len}` struct. Only the
- * length / emptiness queries are wired up at the LLVM layer right now;
- * construction (literals, string.bytes(), etc.) is not yet surfaced,
- * but the ABI is fixed so future call sites can link against it.
+ * pointer to a `{unsigned char *data; int64_t len}` struct. Length /
+ * emptiness queries, concatenation, indexed loads, and UTF-8
+ * String-conversion helpers are wired up at the LLVM layer.
+ * String.toBytes() constructs the value through the strings runtime
+ * family, and Bytes.from(List<Byte>) copies the list payload into the
+ * same owned layout.
  */
+static bool osty_rt_bytes_validate_utf8_data(const unsigned char *data, size_t len) {
+    size_t i = 0;
+
+    while (i < len) {
+        unsigned char b1 = data[i];
+        int continuations = 0;
+        unsigned char min2 = 0x80;
+        unsigned char max2 = 0xBF;
+
+        /* Osty Strings are NUL-terminated C strings, so embedded NUL
+         * bytes would truncate the value if we accepted them here. */
+        if (b1 == 0) {
+            return false;
+        }
+        if (b1 < 0x80) {
+            i++;
+            continue;
+        }
+
+        if (b1 >= 0xC2 && b1 <= 0xDF) {
+            continuations = 1;
+        } else if (b1 == 0xE0) {
+            continuations = 2;
+            min2 = 0xA0;
+        } else if ((b1 >= 0xE1 && b1 <= 0xEC) || b1 == 0xEE || b1 == 0xEF) {
+            continuations = 2;
+        } else if (b1 == 0xED) {
+            continuations = 2;
+            max2 = 0x9F;
+        } else if (b1 == 0xF0) {
+            continuations = 3;
+            min2 = 0x90;
+        } else if (b1 >= 0xF1 && b1 <= 0xF3) {
+            continuations = 3;
+        } else if (b1 == 0xF4) {
+            continuations = 3;
+            max2 = 0x8F;
+        } else {
+            return false;
+        }
+
+        if ((size_t)continuations > len - i - 1) {
+            return false;
+        }
+        for (int j = 0; j < continuations; j++) {
+            unsigned char bn = data[i + 1 + (size_t)j];
+            unsigned char lo = (j == 0) ? min2 : 0x80;
+            unsigned char hi = (j == 0) ? max2 : 0xBF;
+            if (bn < lo || bn > hi) {
+                return false;
+            }
+        }
+        i += (size_t)(continuations + 1);
+    }
+
+    return true;
+}
+
+void *osty_rt_bytes_from_list(void *raw_list) {
+    osty_rt_list *list = (osty_rt_list *)raw_list;
+    size_t len;
+    size_t total;
+    osty_rt_bytes *out;
+    unsigned char *data;
+
+    if (list == NULL || list->len <= 0) {
+        len = 0;
+    } else {
+        if (list->len < 0) {
+            osty_rt_abort("runtime.bytes.from_list: negative length");
+        }
+        if (list->elem_size != 0 && list->elem_size != sizeof(uint8_t)) {
+            osty_rt_abort("runtime.bytes.from_list: list element size is not Byte");
+        }
+        len = (size_t)list->len;
+    }
+    if (len > SIZE_MAX - sizeof(osty_rt_bytes)) {
+        osty_rt_abort("runtime.bytes.from_list: size overflow");
+    }
+    total = sizeof(osty_rt_bytes) + len;
+    out = (osty_rt_bytes *)osty_gc_allocate_managed(total, OSTY_GC_KIND_BYTES, "runtime.bytes.from_list", NULL, NULL);
+    data = (unsigned char *)(out + 1);
+    out->data = data;
+    out->len = (int64_t)len;
+    if (len != 0) {
+        if (list->data == NULL) {
+            osty_rt_abort("runtime.bytes.from_list: missing list storage");
+        }
+        memcpy(data, list->data, len);
+    }
+    return out;
+}
+
+void *osty_rt_bytes_concat(void *raw_left, void *raw_right) {
+    osty_rt_bytes *left = (osty_rt_bytes *)raw_left;
+    osty_rt_bytes *right = (osty_rt_bytes *)raw_right;
+    size_t left_len = 0;
+    size_t right_len = 0;
+    size_t total_len;
+    size_t total;
+    osty_rt_bytes *out;
+    unsigned char *data;
+
+    if (left != NULL) {
+        if (left->len < 0) {
+            osty_rt_abort("runtime.bytes.concat: negative left length");
+        }
+        left_len = (size_t)left->len;
+    }
+    if (right != NULL) {
+        if (right->len < 0) {
+            osty_rt_abort("runtime.bytes.concat: negative right length");
+        }
+        right_len = (size_t)right->len;
+    }
+    if (left_len > SIZE_MAX - right_len || left_len + right_len > SIZE_MAX - sizeof(osty_rt_bytes)) {
+        osty_rt_abort("runtime.bytes.concat: size overflow");
+    }
+    total_len = left_len + right_len;
+    total = sizeof(osty_rt_bytes) + total_len;
+    out = (osty_rt_bytes *)osty_gc_allocate_managed(total, OSTY_GC_KIND_BYTES, "runtime.bytes.concat", NULL, NULL);
+    data = (unsigned char *)(out + 1);
+    out->data = data;
+    out->len = (int64_t)total_len;
+    if (left_len != 0) {
+        if (left->data == NULL) {
+            osty_rt_abort("runtime.bytes.concat: missing left storage");
+        }
+        memcpy(data, left->data, left_len);
+    }
+    if (right_len != 0) {
+        if (right->data == NULL) {
+            osty_rt_abort("runtime.bytes.concat: missing right storage");
+        }
+        memcpy(data + left_len, right->data, right_len);
+    }
+    return out;
+}
+
+void *osty_rt_bytes_repeat(void *raw_bytes, int64_t n) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    size_t value_len = 0;
+    size_t total_len;
+    size_t total;
+    osty_rt_bytes *out;
+    unsigned char *data;
+    unsigned char *cursor;
+    int64_t i;
+
+    if (b != NULL) {
+        if (b->len < 0) {
+            osty_rt_abort("runtime.bytes.repeat: negative length");
+        }
+        value_len = (size_t)b->len;
+    }
+    if (n <= 0 || value_len == 0) {
+        total_len = 0;
+    } else {
+        if (b->data == NULL) {
+            osty_rt_abort("runtime.bytes.repeat: missing storage");
+        }
+        if ((uint64_t)n > (uint64_t)(SIZE_MAX - sizeof(osty_rt_bytes)) / (uint64_t)value_len) {
+            osty_rt_abort("runtime.bytes.repeat: size overflow");
+        }
+        total_len = value_len * (size_t)n;
+    }
+
+    total = sizeof(osty_rt_bytes) + total_len;
+    out = (osty_rt_bytes *)osty_gc_allocate_managed(total, OSTY_GC_KIND_BYTES, "runtime.bytes.repeat", NULL, NULL);
+    data = (unsigned char *)(out + 1);
+    out->data = data;
+    out->len = (int64_t)total_len;
+    if (total_len == 0) {
+        return out;
+    }
+    cursor = data;
+    for (i = 0; i < n; i++) {
+        memcpy(cursor, b->data, value_len);
+        cursor += value_len;
+    }
+    return out;
+}
+
+int64_t osty_rt_bytes_index_of(void *raw_bytes, void *raw_sub) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    osty_rt_bytes *sub = (osty_rt_bytes *)raw_sub;
+    size_t value_len = 0;
+    size_t sub_len = 0;
+    size_t i;
+
+    if (b != NULL) {
+        if (b->len < 0) {
+            osty_rt_abort("runtime.bytes.index_of: negative value length");
+        }
+        value_len = (size_t)b->len;
+    }
+    if (sub != NULL) {
+        if (sub->len < 0) {
+            osty_rt_abort("runtime.bytes.index_of: negative sub length");
+        }
+        sub_len = (size_t)sub->len;
+    }
+    if (sub_len == 0) {
+        return 0;
+    }
+    if (sub_len > value_len) {
+        return -1;
+    }
+    if (b->data == NULL) {
+        osty_rt_abort("runtime.bytes.index_of: missing value storage");
+    }
+    if (sub->data == NULL) {
+        osty_rt_abort("runtime.bytes.index_of: missing sub storage");
+    }
+    for (i = 0; i + sub_len <= value_len; i++) {
+        if (memcmp(b->data + i, sub->data, sub_len) == 0) {
+            return (int64_t)i;
+        }
+    }
+    return -1;
+}
+
 int64_t osty_rt_bytes_len(void *raw_bytes) {
     osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
     if (b == NULL) {
@@ -4057,6 +4311,67 @@ bool osty_rt_bytes_is_empty(void *raw_bytes) {
         return true;
     }
     return b->len == 0;
+}
+
+bool osty_rt_bytes_is_valid_utf8(void *raw_bytes) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    size_t len = 0;
+
+    if (b != NULL) {
+        if (b->len < 0) {
+            osty_rt_abort("runtime.bytes.is_valid_utf8: negative length");
+        }
+        len = (size_t)b->len;
+    }
+    if (len == 0) {
+        return true;
+    }
+    if (b->data == NULL) {
+        osty_rt_abort("runtime.bytes.is_valid_utf8: missing storage");
+    }
+    return osty_rt_bytes_validate_utf8_data(b->data, len);
+}
+
+const char *osty_rt_bytes_to_string(void *raw_bytes) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    size_t len = 0;
+    char *out;
+
+    if (b != NULL) {
+        if (b->len < 0) {
+            osty_rt_abort("runtime.bytes.to_string: negative length");
+        }
+        len = (size_t)b->len;
+    }
+    if (len == 0) {
+        out = (char *)osty_gc_allocate_managed(1, OSTY_GC_KIND_STRING, "runtime.bytes.to_string.empty", NULL, NULL);
+        out[0] = '\0';
+        return out;
+    }
+    if (b->data == NULL) {
+        osty_rt_abort("runtime.bytes.to_string: missing storage");
+    }
+    if (!osty_rt_bytes_validate_utf8_data(b->data, len)) {
+        osty_rt_abort("runtime.bytes.to_string: invalid UTF-8");
+    }
+    if (len == SIZE_MAX) {
+        osty_rt_abort("runtime.bytes.to_string: size overflow");
+    }
+    out = (char *)osty_gc_allocate_managed(len + 1, OSTY_GC_KIND_STRING, "runtime.bytes.to_string", NULL, NULL);
+    memcpy(out, b->data, len);
+    out[len] = '\0';
+    return out;
+}
+
+uint8_t osty_rt_bytes_get(void *raw_bytes, int64_t index) {
+    osty_rt_bytes *b = (osty_rt_bytes *)raw_bytes;
+    if (b == NULL) {
+        osty_rt_abort("runtime.bytes.get: nil bytes");
+    }
+    if (index < 0 || index >= b->len) {
+        osty_rt_abort("runtime.bytes.get: index out of range");
+    }
+    return b->data[index];
 }
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2213,6 +2213,16 @@ func builtinResultPayloadSourceType(sourceType ast.Type, constructor string) ast
 	return named.Args[0]
 }
 
+func bytesToStringResultSourceType() ast.Type {
+	return &ast.NamedType{
+		Path: []string{"Result"},
+		Args: []ast.Type{
+			&ast.NamedType{Path: []string{"String"}},
+			&ast.NamedType{Path: []string{"Error"}},
+		},
+	}
+}
+
 func (g *generator) emitExprWithHintAndSourceType(expr ast.Expr, sourceType ast.Type, listElemTyp string, listElemString bool, mapKeyTyp string, mapValueTyp string, mapKeyString bool, setElemTyp string, setElemString bool) (value, error) {
 	if sourceType != nil {
 		if elemTyp, elemString, ok, err := llvmListElementInfo(sourceType, g.typeEnv()); err != nil {
@@ -3061,6 +3071,18 @@ func (g *generator) emitStringMethodCall(call *ast.CallExpr) (value, bool, error
 		v.gcManaged = true
 		v.listElemTyp = "i8"
 		return v, true, nil
+	case "toBytes":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "String.toBytes requires no arguments")
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeToBytesSymbol(), "ptr", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmStringToBytes(emitter, toOstyValue(base))
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+		return v, true, nil
 	default:
 		return value{}, true, unsupportedf("call", "String.%s is not supported by legacy llvmgen yet", field.Name)
 	}
@@ -3119,6 +3141,630 @@ func (g *generator) emitStringReplaceRuntime(base value, old value, newValue val
 	replaced.gcManaged = true
 	replaced.sourceType = &ast.NamedType{Path: []string{"String"}}
 	return replaced, nil
+}
+
+func (g *generator) emitBytesMethodCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.bytesMethodInfo(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	if field.X == nil {
+		return value{}, true, unsupported("call", "Bytes method receiver is missing")
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	base, err = g.loadIfPointer(base)
+	if err != nil {
+		return value{}, true, err
+	}
+	if base.typ != "ptr" {
+		return value{}, true, unsupportedf("type-system", "Bytes receiver type %s, want ptr", base.typ)
+	}
+
+	switch field.Name {
+	case "len":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "Bytes.len requires no arguments")
+		}
+		symbol := "osty_rt_bytes_len"
+		g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "isEmpty":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "Bytes.isEmpty requires no arguments")
+		}
+		symbol := "osty_rt_bytes_is_empty"
+		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "get":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.get requires one positional argument")
+		}
+		index, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		index, err = g.loadIfPointer(index)
+		if err != nil {
+			return value{}, true, err
+		}
+		if index.typ != "i64" {
+			return value{}, true, unsupportedf("type-system", "Bytes.get arg 1 type %s, want Int", index.typ)
+		}
+		out, err := g.emitBytesGetRuntime(base, index)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "contains":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.contains requires one positional argument")
+		}
+		needle, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		needle, err = g.loadIfPointer(needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		if needle.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.contains arg 1 type %s, want Bytes", needle.typ)
+		}
+		out, err := g.emitBytesContainsRuntime(base, needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "startsWith":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.startsWith requires one positional argument")
+		}
+		prefix, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		prefix, err = g.loadIfPointer(prefix)
+		if err != nil {
+			return value{}, true, err
+		}
+		if prefix.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.startsWith arg 1 type %s, want Bytes", prefix.typ)
+		}
+		out, err := g.emitBytesStartsWithRuntime(base, prefix)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "indexOf":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.indexOf requires one positional argument")
+		}
+		needle, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		needle, err = g.loadIfPointer(needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		if needle.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.indexOf arg 1 type %s, want Bytes", needle.typ)
+		}
+		out, err := g.emitBytesIndexOfRuntime(base, needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "concat":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.concat requires one positional argument")
+		}
+		other, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		other, err = g.loadIfPointer(other)
+		if err != nil {
+			return value{}, true, err
+		}
+		if other.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.concat arg 1 type %s, want Bytes", other.typ)
+		}
+		out, err := g.emitBytesConcatRuntime(base, other)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "repeat":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.repeat requires one positional argument")
+		}
+		n, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		n, err = g.loadIfPointer(n)
+		if err != nil {
+			return value{}, true, err
+		}
+		if n.typ != "i64" {
+			return value{}, true, unsupportedf("type-system", "Bytes.repeat arg 1 type %s, want Int", n.typ)
+		}
+		out, err := g.emitBytesRepeatRuntime(base, n)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "toString":
+		if len(call.Args) != 0 {
+			return value{}, true, unsupported("call", "Bytes.toString requires no arguments")
+		}
+		out, err := g.emitBytesToStringResult(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	default:
+		return value{}, true, unsupportedf("call", "Bytes.%s is not supported by legacy llvmgen yet", field.Name)
+	}
+}
+
+func (g *generator) emitBytesGetRuntime(base, index value) (value, error) {
+	lenSymbol := "osty_rt_bytes_len"
+	getSymbol := "osty_rt_bytes_get"
+	g.declareRuntimeSymbol(lenSymbol, "i64", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(getSymbol, "i8", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	length := llvmCall(emitter, "i64", lenSymbol, []*LlvmValue{toOstyValue(base)})
+	nonNegative := llvmCompare(emitter, "sge", toOstyValue(index), llvmIntLiteral(0))
+	beforeEnd := llvmCompare(emitter, "slt", toOstyValue(index), length)
+	inRange := llvmLogicalI1(emitter, "and", nonNegative, beforeEnd)
+	labels := llvmIfExprStart(emitter, inRange)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	emitter = g.toOstyEmitter()
+	item := llvmCall(emitter, "i8", getSymbol, []*LlvmValue{toOstyValue(base), toOstyValue(index)})
+	box := llvmGcAlloc(emitter, 1, 1, "bytes.get.byte")
+	emitter.body = append(emitter.body, fmt.Sprintf("  store i8 %s, ptr %s", item.name, box.name))
+	g.takeOstyEmitter(emitter)
+	g.needsGCRuntime = true
+	someVal := value{typ: "ptr", ref: box.name, gcManaged: true}
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	noneVal := value{typ: "ptr", ref: "null"}
+	elsePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, thenPred, elsePred, someVal, noneVal)
+	if err != nil {
+		return value{}, err
+	}
+	out.gcManaged = true
+	out.rootPaths = g.rootPathsForType("ptr")
+	out.sourceType = &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Byte"}}}
+	return out, nil
+}
+
+func (g *generator) emitBytesIndexOfRuntime(base, needle value) (value, error) {
+	symbol := "osty_rt_bytes_index_of"
+	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(needle)})
+	g.takeOstyEmitter(emitter)
+	return g.emitOptionalBoxedI64(fromOstyValue(index), "bytes.index_of.int")
+}
+
+func (g *generator) emitBytesContainsRuntime(base, needle value) (value, error) {
+	symbol := "osty_rt_bytes_index_of"
+	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(needle)})
+	out := llvmCompare(emitter, "sge", index, llvmIntLiteral(0))
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), nil
+}
+
+func (g *generator) emitBytesStartsWithRuntime(base, prefix value) (value, error) {
+	symbol := "osty_rt_bytes_index_of"
+	g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	index := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(prefix)})
+	out := llvmCompare(emitter, "eq", index, llvmIntLiteral(0))
+	g.takeOstyEmitter(emitter)
+	return fromOstyValue(out), nil
+}
+
+func (g *generator) emitBytesFromListRuntime(items value) (value, error) {
+	symbol := "osty_rt_bytes_from_list"
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(items)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+	return v, nil
+}
+
+func (g *generator) emitBytesConcatRuntime(left, right value) (value, error) {
+	symbol := "osty_rt_bytes_concat"
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(left), toOstyValue(right)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+	return v, nil
+}
+
+func (g *generator) emitBytesRepeatRuntime(base, n value) (value, error) {
+	symbol := "osty_rt_bytes_repeat"
+	g.declareRuntimeSymbol(symbol, "ptr", []paramInfo{{typ: "ptr"}, {typ: "i64"}})
+	emitter := g.toOstyEmitter()
+	out := llvmCall(emitter, "ptr", symbol, []*LlvmValue{toOstyValue(base), toOstyValue(n)})
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+	return v, nil
+}
+
+func (g *generator) emitBytesToStringResult(base value) (value, error) {
+	sourceType := bytesToStringResultSourceType()
+	info, ok := builtinResultTypeFromAST(sourceType, g.typeEnv())
+	if !ok {
+		return value{}, unsupported("type-system", "Bytes.toString Result<String, Error> type is unavailable")
+	}
+	validateSymbol := "osty_rt_bytes_is_valid_utf8"
+	toStringSymbol := "osty_rt_bytes_to_string"
+	g.declareRuntimeSymbol(validateSymbol, "i1", []paramInfo{{typ: "ptr"}})
+	g.declareRuntimeSymbol(toStringSymbol, "ptr", []paramInfo{{typ: "ptr"}})
+
+	emitter := g.toOstyEmitter()
+	valid := llvmCall(emitter, "i1", validateSymbol, []*LlvmValue{toOstyValue(base)})
+	labels := llvmIfExprStart(emitter, valid)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.thenLabel
+
+	emitter = g.toOstyEmitter()
+	text := llvmCall(emitter, "ptr", toStringSymbol, []*LlvmValue{toOstyValue(base)})
+	okResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "0"}),
+		text,
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	g.takeOstyEmitter(emitter)
+	thenValue := value{
+		typ:        info.typ,
+		ref:        okResult.name,
+		sourceType: sourceType,
+		rootPaths:  g.rootPathsForType(info.typ),
+	}
+	thenPred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+
+	emitter = g.toOstyEmitter()
+	errResult := llvmStructLiteral(emitter, info.typ, []*LlvmValue{
+		toOstyValue(value{typ: "i64", ref: "1"}),
+		toOstyValue(llvmZeroValue(info.okTyp)),
+		toOstyValue(llvmZeroValue(info.errTyp)),
+	})
+	g.takeOstyEmitter(emitter)
+	elseValue := value{
+		typ:        info.typ,
+		ref:        errResult.name,
+		sourceType: sourceType,
+		rootPaths:  g.rootPathsForType(info.typ),
+	}
+	elsePred := g.currentBlock
+
+	out, err := g.emitIfExprPhi(labels, thenPred, elsePred, thenValue, elseValue)
+	if err != nil {
+		return value{}, err
+	}
+	out.sourceType = sourceType
+	out.rootPaths = g.rootPathsForType(info.typ)
+	return out, nil
+}
+
+func (g *generator) emitBytesNamespaceCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := g.bytesNamespaceCallInfo(call)
+	if !ok {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "from":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.from requires one positional argument")
+		}
+		if !g.staticExprListElemIsByte(call.Args[0].Value) {
+			return value{}, true, unsupported("type-system", "Bytes.from arg 1 must be List<Byte>")
+		}
+		items, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		items, err = g.loadIfPointer(items)
+		if err != nil {
+			return value{}, true, err
+		}
+		if items.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.from arg 1 type %s, want List<Byte>", items.typ)
+		}
+		out, err := g.emitBytesFromListRuntime(items)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "len":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.len requires one positional argument")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.len arg 1 type %s, want Bytes", base.typ)
+		}
+		symbol := "osty_rt_bytes_len"
+		g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "isEmpty":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.isEmpty requires one positional argument")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.isEmpty arg 1 type %s, want Bytes", base.typ)
+		}
+		symbol := "osty_rt_bytes_is_empty"
+		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(base)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "get":
+		if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.get requires two positional arguments")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.get arg 1 type %s, want Bytes", base.typ)
+		}
+		index, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		index, err = g.loadIfPointer(index)
+		if err != nil {
+			return value{}, true, err
+		}
+		if index.typ != "i64" {
+			return value{}, true, unsupportedf("type-system", "Bytes.get arg 2 type %s, want Int", index.typ)
+		}
+		out, err := g.emitBytesGetRuntime(base, index)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "contains":
+		if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.contains requires two positional arguments")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.contains arg 1 type %s, want Bytes", base.typ)
+		}
+		needle, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		needle, err = g.loadIfPointer(needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		if needle.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.contains arg 2 type %s, want Bytes", needle.typ)
+		}
+		out, err := g.emitBytesContainsRuntime(base, needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "startsWith":
+		if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.startsWith requires two positional arguments")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.startsWith arg 1 type %s, want Bytes", base.typ)
+		}
+		prefix, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		prefix, err = g.loadIfPointer(prefix)
+		if err != nil {
+			return value{}, true, err
+		}
+		if prefix.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.startsWith arg 2 type %s, want Bytes", prefix.typ)
+		}
+		out, err := g.emitBytesStartsWithRuntime(base, prefix)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "indexOf":
+		if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.indexOf requires two positional arguments")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.indexOf arg 1 type %s, want Bytes", base.typ)
+		}
+		needle, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		needle, err = g.loadIfPointer(needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		if needle.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.indexOf arg 2 type %s, want Bytes", needle.typ)
+		}
+		out, err := g.emitBytesIndexOfRuntime(base, needle)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "concat":
+		if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.concat requires two positional arguments")
+		}
+		left, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		left, err = g.loadIfPointer(left)
+		if err != nil {
+			return value{}, true, err
+		}
+		if left.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.concat arg 1 type %s, want Bytes", left.typ)
+		}
+		right, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		right, err = g.loadIfPointer(right)
+		if err != nil {
+			return value{}, true, err
+		}
+		if right.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.concat arg 2 type %s, want Bytes", right.typ)
+		}
+		out, err := g.emitBytesConcatRuntime(left, right)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "repeat":
+		if len(call.Args) != 2 || call.Args[0] == nil || call.Args[1] == nil || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.repeat requires two positional arguments")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.repeat arg 1 type %s, want Bytes", base.typ)
+		}
+		n, err := g.emitExpr(call.Args[1].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		n, err = g.loadIfPointer(n)
+		if err != nil {
+			return value{}, true, err
+		}
+		if n.typ != "i64" {
+			return value{}, true, unsupportedf("type-system", "Bytes.repeat arg 2 type %s, want Int", n.typ)
+		}
+		out, err := g.emitBytesRepeatRuntime(base, n)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "toString":
+		if len(call.Args) != 1 || call.Args[0] == nil || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return value{}, true, unsupported("call", "Bytes.toString requires one positional argument")
+		}
+		base, err := g.emitExpr(call.Args[0].Value)
+		if err != nil {
+			return value{}, true, err
+		}
+		base, err = g.loadIfPointer(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		if base.typ != "ptr" {
+			return value{}, true, unsupportedf("type-system", "Bytes.toString arg 1 type %s, want Bytes", base.typ)
+		}
+		out, err := g.emitBytesToStringResult(base)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	default:
+		return value{}, true, unsupportedf("call", "Bytes.%s is not supported by legacy llvmgen yet", field.Name)
+	}
 }
 
 func (g *generator) emitListMethodCall(call *ast.CallExpr) (value, bool, error) {
@@ -4412,10 +5058,16 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 	if v, found, err := g.emitEnumVariantCall(call); found || err != nil {
 		return v, err
 	}
-	// Alias-qualified dispatchers (std.strings / runtime.*) — run before
+	// Alias-qualified dispatchers (std.bytes / std.strings / runtime.*) — run before
 	// emitInterfaceMethodCall and the *MethodCall family, which eagerly
 	// lower the receiver via emitExpr and would otherwise fail with
 	// LLVM016 when the receiver is a module alias rather than a binding.
+	if v, found, err := g.emitStdBytesCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitBytesNamespaceCall(call); found || err != nil {
+		return v, err
+	}
 	if v, found, err := g.emitStdStringsCall(call); found || err != nil {
 		return v, err
 	}
@@ -4448,6 +5100,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		return v, err
 	}
 	if v, found, err := g.emitOptionMethodCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitBytesMethodCall(call); found || err != nil {
 		return v, err
 	}
 	if v, found, err := g.emitPrimitiveToStringCall(call); found || err != nil {

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -47,6 +47,7 @@ type generator struct {
 	runtimeFFI        map[string]map[string]*runtimeFFIFunction
 	runtimeFFIPaths   map[string]string
 	testingAliases    map[string]bool
+	stdBytesAliases   map[string]bool
 	stdStringsAliases map[string]bool
 	stdEnvAliases     map[string]bool
 	runtimeDecls      map[string]runtimeDecl

--- a/internal/llvmgen/llvmgen.go
+++ b/internal/llvmgen/llvmgen.go
@@ -267,6 +267,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 		g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
 		g.resultTypes = collectBuiltinResultTypes(file, env)
 		g.testingAliases = collectStdTestingAliases(file)
+		g.stdBytesAliases = collectStdBytesAliases(file)
 		g.stdStringsAliases = collectStdStringsAliases(file)
 		g.stdEnvAliases = collectStdEnvAliases(file)
 		mainIR, err := g.emitScriptMain(file.Stmts)
@@ -296,6 +297,7 @@ func generateASTFile(file *ast.File, opts Options) ([]byte, error) {
 	g.runtimeFFI = collectRuntimeFFI(file, g.typeEnv())
 	g.runtimeFFIPaths = collectRuntimeFFIPaths(file)
 	g.testingAliases = collectStdTestingAliases(file)
+	g.stdBytesAliases = collectStdBytesAliases(file)
 	g.stdStringsAliases = collectStdStringsAliases(file)
 	g.stdEnvAliases = collectStdEnvAliases(file)
 	if err := g.emitGlobalLets(decls.globalsOrdered); err != nil {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -497,7 +497,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
 		return true
-	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty:
+	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty, mir.IntrinsicBytesGet, mir.IntrinsicBytesContains, mir.IntrinsicBytesStartsWith, mir.IntrinsicBytesIndexOf, mir.IntrinsicBytesConcat, mir.IntrinsicBytesRepeat:
 		return true
 	// Stage 5 prep — string → List<Char> / List<Byte> expansions that
 	// the legacy emitter routes through `osty_rt_strings_*`. Accepting
@@ -1544,7 +1544,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 	case mir.IntrinsicSetInsert, mir.IntrinsicSetContains, mir.IntrinsicSetLen,
 		mir.IntrinsicSetToList, mir.IntrinsicSetRemove:
 		return g.emitSetIntrinsic(i)
-	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty:
+	case mir.IntrinsicBytesLen, mir.IntrinsicBytesIsEmpty, mir.IntrinsicBytesGet, mir.IntrinsicBytesContains, mir.IntrinsicBytesStartsWith, mir.IntrinsicBytesIndexOf, mir.IntrinsicBytesConcat, mir.IntrinsicBytesRepeat:
 		return g.emitBytesIntrinsic(i)
 	case mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
 		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty:
@@ -1960,6 +1960,300 @@ func (g *mirGen) emitBytesIntrinsic(i *mir.IntrinsicInstr) error {
 		g.declareRuntime(sym, "declare i1 @"+sym+"(ptr)")
 		em := g.ostyEmitter()
 		result := llvmCall(em, "i1", sym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicBytesGet:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "bytes_get arity")
+		}
+		if i.Dest == nil {
+			return nil
+		}
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return fmt.Errorf("mir-mvp: bytes_get dest %d", i.Dest.Local)
+		}
+		optT, ok := destLoc.Type.(*ir.OptionalType)
+		if !ok {
+			return unsupported("mir-mvp", "bytes_get dest is not optional")
+		}
+		idxReg, err := g.evalOperand(i.Args[1], mir.TInt)
+		if err != nil {
+			return err
+		}
+		lenSym := "osty_rt_bytes_len"
+		getSym := "osty_rt_bytes_get"
+		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr)")
+		g.declareRuntime(getSym, "declare i8 @"+getSym+"(ptr, i64)")
+		em := g.ostyEmitter()
+		length := llvmCall(em, "i64", lenSym, []*LlvmValue{{typ: "ptr", name: bytesReg}})
+		nonNegative := llvmCompare(em, "sge", &LlvmValue{typ: "i64", name: idxReg}, llvmIntLiteral(0))
+		beforeEnd := llvmCompare(em, "slt", &LlvmValue{typ: "i64", name: idxReg}, length)
+		inRange := llvmLogicalI1(em, "and", nonNegative, beforeEnd)
+		g.flushOstyEmitter(em)
+
+		someLabel := g.freshLabel("bytes.get.some")
+		noneLabel := g.freshLabel("bytes.get.none")
+		mergeLabel := g.freshLabel("bytes.get.merge")
+		g.fnBuf.WriteString("  br i1 ")
+		g.fnBuf.WriteString(inRange.name)
+		g.fnBuf.WriteString(", label %")
+		g.fnBuf.WriteString(someLabel)
+		g.fnBuf.WriteString(", label %")
+		g.fnBuf.WriteString(noneLabel)
+		g.fnBuf.WriteByte('\n')
+
+		optLLVM := g.llvmType(optT)
+
+		g.fnBuf.WriteString(someLabel)
+		g.fnBuf.WriteString(":\n")
+		em = g.ostyEmitter()
+		item := llvmCall(em, "i8", getSym, []*LlvmValue{{typ: "ptr", name: bytesReg}, {typ: "i64", name: idxReg}})
+		g.flushOstyEmitter(em)
+		payload, err := g.toI64Slot(item.name, optT.Inner)
+		if err != nil {
+			return err
+		}
+		someStep1 := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(someStep1)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteString(" undef, i64 1, 0\n")
+		someValue := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(someValue)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(someStep1)
+		g.fnBuf.WriteString(", i64 ")
+		g.fnBuf.WriteString(payload)
+		g.fnBuf.WriteString(", 1\n")
+		g.fnBuf.WriteString("  br label %")
+		g.fnBuf.WriteString(mergeLabel)
+		g.fnBuf.WriteByte('\n')
+
+		g.fnBuf.WriteString(noneLabel)
+		g.fnBuf.WriteString(":\n")
+		noneStep1 := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(noneStep1)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteString(" undef, i64 0, 0\n")
+		noneValue := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(noneValue)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(noneStep1)
+		g.fnBuf.WriteString(", i64 0, 1\n")
+		g.fnBuf.WriteString("  br label %")
+		g.fnBuf.WriteString(mergeLabel)
+		g.fnBuf.WriteByte('\n')
+
+		g.fnBuf.WriteString(mergeLabel)
+		g.fnBuf.WriteString(":\n")
+		result := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(result)
+		g.fnBuf.WriteString(" = phi ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteString(" [ ")
+		g.fnBuf.WriteString(someValue)
+		g.fnBuf.WriteString(", %")
+		g.fnBuf.WriteString(someLabel)
+		g.fnBuf.WriteString(" ], [ ")
+		g.fnBuf.WriteString(noneValue)
+		g.fnBuf.WriteString(", %")
+		g.fnBuf.WriteString(noneLabel)
+		g.fnBuf.WriteString(" ]\n")
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(result)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+		g.fnBuf.WriteByte('\n')
+		return nil
+	case mir.IntrinsicBytesContains:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "bytes_contains arity")
+		}
+		needleReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_bytes_index_of"
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		em := g.ostyEmitter()
+		index := llvmCall(em, "i64", sym, []*LlvmValue{
+			{typ: "ptr", name: bytesReg},
+			{typ: "ptr", name: needleReg},
+		})
+		result := llvmCompare(em, "sge", index, llvmIntLiteral(0))
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicBytesStartsWith:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "bytes_starts_with arity")
+		}
+		prefixReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_bytes_index_of"
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		em := g.ostyEmitter()
+		index := llvmCall(em, "i64", sym, []*LlvmValue{
+			{typ: "ptr", name: bytesReg},
+			{typ: "ptr", name: prefixReg},
+		})
+		result := llvmCompare(em, "eq", index, llvmIntLiteral(0))
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicBytesIndexOf:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "bytes_index_of arity")
+		}
+		if i.Dest == nil {
+			return nil
+		}
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return fmt.Errorf("mir-mvp: bytes_index_of dest %d", i.Dest.Local)
+		}
+		optT, ok := destLoc.Type.(*ir.OptionalType)
+		if !ok {
+			return unsupported("mir-mvp", "bytes_index_of dest is not optional")
+		}
+		needleReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_bytes_index_of"
+		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr, ptr)")
+		em := g.ostyEmitter()
+		index := llvmCall(em, "i64", sym, []*LlvmValue{
+			{typ: "ptr", name: bytesReg},
+			{typ: "ptr", name: needleReg},
+		})
+		present := llvmCompare(em, "sge", index, llvmIntLiteral(0))
+		g.flushOstyEmitter(em)
+
+		someLabel := g.freshLabel("bytes.index_of.some")
+		noneLabel := g.freshLabel("bytes.index_of.none")
+		mergeLabel := g.freshLabel("bytes.index_of.merge")
+		g.fnBuf.WriteString("  br i1 ")
+		g.fnBuf.WriteString(present.name)
+		g.fnBuf.WriteString(", label %")
+		g.fnBuf.WriteString(someLabel)
+		g.fnBuf.WriteString(", label %")
+		g.fnBuf.WriteString(noneLabel)
+		g.fnBuf.WriteByte('\n')
+
+		optLLVM := g.llvmType(optT)
+
+		g.fnBuf.WriteString(someLabel)
+		g.fnBuf.WriteString(":\n")
+		someStep1 := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(someStep1)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteString(" undef, i64 1, 0\n")
+		someValue := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(someValue)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(someStep1)
+		g.fnBuf.WriteString(", i64 ")
+		g.fnBuf.WriteString(index.name)
+		g.fnBuf.WriteString(", 1\n")
+		g.fnBuf.WriteString("  br label %")
+		g.fnBuf.WriteString(mergeLabel)
+		g.fnBuf.WriteByte('\n')
+
+		g.fnBuf.WriteString(noneLabel)
+		g.fnBuf.WriteString(":\n")
+		noneStep1 := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(noneStep1)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteString(" undef, i64 0, 0\n")
+		noneValue := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(noneValue)
+		g.fnBuf.WriteString(" = insertvalue ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(noneStep1)
+		g.fnBuf.WriteString(", i64 0, 1\n")
+		g.fnBuf.WriteString("  br label %")
+		g.fnBuf.WriteString(mergeLabel)
+		g.fnBuf.WriteByte('\n')
+
+		g.fnBuf.WriteString(mergeLabel)
+		g.fnBuf.WriteString(":\n")
+		result := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(result)
+		g.fnBuf.WriteString(" = phi ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteString(" [ ")
+		g.fnBuf.WriteString(someValue)
+		g.fnBuf.WriteString(", %")
+		g.fnBuf.WriteString(someLabel)
+		g.fnBuf.WriteString(" ], [ ")
+		g.fnBuf.WriteString(noneValue)
+		g.fnBuf.WriteString(", %")
+		g.fnBuf.WriteString(noneLabel)
+		g.fnBuf.WriteString(" ]\n")
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(optLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(result)
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(g.localSlots[i.Dest.Local])
+		g.fnBuf.WriteByte('\n')
+		return nil
+	case mir.IntrinsicBytesConcat:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "bytes_concat arity")
+		}
+		rightReg, err := g.evalOperand(i.Args[1], i.Args[1].Type())
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_bytes_concat"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{
+			{typ: "ptr", name: bytesReg},
+			{typ: "ptr", name: rightReg},
+		})
+		g.flushOstyEmitter(em)
+		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicBytesRepeat:
+		if len(i.Args) != 2 {
+			return unsupported("mir-mvp", "bytes_repeat arity")
+		}
+		countReg, err := g.evalOperand(i.Args[1], mir.TInt)
+		if err != nil {
+			return err
+		}
+		sym := "osty_rt_bytes_repeat"
+		g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64)")
+		em := g.ostyEmitter()
+		result := llvmCall(em, "ptr", sym, []*LlvmValue{
+			{typ: "ptr", name: bytesReg},
+			{typ: "i64", name: countReg},
+		})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
 	}

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -164,9 +164,9 @@ func TestGenerateFromMIRWhileLoop(t *testing.T) {
 				Body: &ir.Block{
 					Stmts: []ir.Stmt{
 						&ir.LetStmt{
-							Name: "i",
-							Type: ir.TInt,
-							Mut:  true,
+							Name:  "i",
+							Type:  ir.TInt,
+							Mut:   true,
 							Value: &ir.IntLit{Text: "0", T: ir.TInt},
 						},
 						&ir.ForStmt{
@@ -2534,6 +2534,231 @@ func TestGenerateFromMIRBytesIsEmpty(t *testing.T) {
 	for _, want := range []string{
 		"declare i1 @osty_rt_bytes_is_empty(ptr)",
 		"call i1 @osty_rt_bytes_is_empty(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesGet verifies Bytes.get() lowers through the
+// bytes runtime helpers and rebuilds `Byte?` as the standard optional
+// aggregate shape.
+func TestGenerateFromMIRBytesGet(t *testing.T) {
+	optByte := &ir.OptionalType{Inner: ir.TByte}
+	fn := &ir.FnDecl{
+		Name:   "second",
+		Return: optByte,
+		Params: []*ir.Param{{Name: "b", Type: ir.TBytes}},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "get",
+				Args:     []ir.Arg{{Value: &ir.IntLit{Text: "1", T: ir.TInt}}},
+				T:        optByte,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_get.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_bytes_len(ptr)",
+		"declare i8 @osty_rt_bytes_get(ptr, i64)",
+		"call i8 @osty_rt_bytes_get(",
+		"%Option.i8 = type { i64, i64 }",
+		"phi %Option.i8",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesContains verifies Bytes.contains() lowers
+// through `osty_rt_bytes_index_of(ptr, ptr) -> i64` plus a `>= 0`
+// comparison to produce Bool.
+func TestGenerateFromMIRBytesContains(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "has",
+		Return: ir.TBool,
+		Params: []*ir.Param{
+			{Name: "a", Type: ir.TBytes},
+			{Name: "b", Type: ir.TBytes},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "contains",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes}}},
+				T:        ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_contains.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_bytes_index_of(ptr, ptr)",
+		"call i64 @osty_rt_bytes_index_of(",
+		"icmp sge i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesStartsWith verifies Bytes.startsWith()
+// lowers through `osty_rt_bytes_index_of(ptr, ptr) -> i64` plus an
+// `== 0` comparison to produce Bool.
+func TestGenerateFromMIRBytesStartsWith(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "hasPrefix",
+		Return: ir.TBool,
+		Params: []*ir.Param{
+			{Name: "a", Type: ir.TBytes},
+			{Name: "b", Type: ir.TBytes},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "startsWith",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes}}},
+				T:        ir.TBool,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_starts_with.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_bytes_index_of(ptr, ptr)",
+		"call i64 @osty_rt_bytes_index_of(",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesIndexOf verifies Bytes.indexOf() lowers
+// through `osty_rt_bytes_index_of(ptr, ptr) -> i64` and rebuilds the
+// standard `Int?` aggregate.
+func TestGenerateFromMIRBytesIndexOf(t *testing.T) {
+	optInt := &ir.OptionalType{Inner: ir.TInt}
+	fn := &ir.FnDecl{
+		Name:   "find",
+		Return: optInt,
+		Params: []*ir.Param{
+			{Name: "a", Type: ir.TBytes},
+			{Name: "b", Type: ir.TBytes},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "indexOf",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes}}},
+				T:        optInt,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_index_of.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare i64 @osty_rt_bytes_index_of(ptr, ptr)",
+		"call i64 @osty_rt_bytes_index_of(",
+		"%Option.i64 = type { i64, i64 }",
+		"phi %Option.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesConcat verifies Bytes.concat() dispatches
+// through `osty_rt_bytes_concat(ptr, ptr) -> ptr`.
+func TestGenerateFromMIRBytesConcat(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "join",
+		Return: ir.TBytes,
+		Params: []*ir.Param{
+			{Name: "a", Type: ir.TBytes},
+			{Name: "b", Type: ir.TBytes},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "concat",
+				Args:     []ir.Arg{{Value: &ir.Ident{Name: "b", Kind: ir.IdentParam, T: ir.TBytes}}},
+				T:        ir.TBytes,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_concat.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_concat(ptr, ptr)",
+		"call ptr @osty_rt_bytes_concat(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerateFromMIRBytesRepeat verifies Bytes.repeat() dispatches
+// through `osty_rt_bytes_repeat(ptr, i64) -> ptr`.
+func TestGenerateFromMIRBytesRepeat(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "echo",
+		Return: ir.TBytes,
+		Params: []*ir.Param{
+			{Name: "a", Type: ir.TBytes},
+		},
+		Body: &ir.Block{
+			Result: &ir.MethodCall{
+				Receiver: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TBytes},
+				Name:     "repeat",
+				Args:     []ir.Arg{{Value: &ir.IntLit{Text: "3", T: ir.TInt}}},
+				T:        ir.TBytes,
+			},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/bytes_repeat.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_repeat(ptr, i64)",
+		"call ptr @osty_rt_bytes_repeat(",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)

--- a/internal/llvmgen/osty_generated_test.go
+++ b/internal/llvmgen/osty_generated_test.go
@@ -850,6 +850,7 @@ func TestGeneratedStringRuntimeSymbolsAreOstyOwned(t *testing.T) {
 		{"trimSuffix", llvmStringRuntimeTrimSuffixSymbol(), "osty_rt_strings_TrimSuffix"},
 		{"chars", llvmStringRuntimeCharsSymbol(), "osty_rt_strings_Chars"},
 		{"bytes", llvmStringRuntimeBytesSymbol(), "osty_rt_strings_Bytes"},
+		{"toBytes", llvmStringRuntimeToBytesSymbol(), "osty_rt_strings_ToBytes"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {
@@ -883,6 +884,7 @@ func TestGeneratedStringRuntimeDeclarationsAreOstyOwned(t *testing.T) {
 		"declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)",
 		"declare ptr @osty_rt_strings_Chars(ptr)",
 		"declare ptr @osty_rt_strings_Bytes(ptr)",
+		"declare ptr @osty_rt_strings_ToBytes(ptr)",
 	}
 	for _, w := range want {
 		assertGeneratedIRContains(t, decls, w)

--- a/internal/llvmgen/stdlib_shim.go
+++ b/internal/llvmgen/stdlib_shim.go
@@ -1,10 +1,11 @@
 // stdlib_shim.go — targeted backend shims for Osty surface the pure-Osty
 // lowering path can't yet handle.
 //
-//  1. Qualified calls through `use std.strings as X` routed to the
-//     `osty_rt_strings_*` C runtime helpers. The pure Osty bodies (see
-//     internal/stdlib/modules/strings.osty) depend on Char iteration /
-//     List<Char> indexing which the backend doesn't lower yet.
+//  1. Qualified calls through `use std.strings as X` / `use std.bytes
+//     as X` routed to the runtime helpers the backend already knows how
+//     to lower. The pure Osty bodies (see internal/stdlib/modules) lean
+//     on method surfaces the legacy backend still only partially
+//     handles.
 //
 //  2. Bare `None` / `Some(x)` construction for ptr-backed Option<T>. The
 //     backend already encodes `T?` as a nullable `ptr` for every `T` (see
@@ -42,6 +43,216 @@ func collectStdStringsAliases(file *ast.File) map[string]bool {
 		out[alias] = true
 	}
 	return out
+}
+
+func collectStdBytesAliases(file *ast.File) map[string]bool {
+	out := map[string]bool{}
+	if file == nil {
+		return out
+	}
+	for _, use := range file.Uses {
+		if use == nil || use.IsFFI() {
+			continue
+		}
+		if len(use.Path) != 2 || use.Path[0] != "std" || use.Path[1] != "bytes" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" {
+			alias = "bytes"
+		}
+		out[alias] = true
+	}
+	return out
+}
+
+func (g *generator) emitStdBytesCall(call *ast.CallExpr) (value, bool, error) {
+	if call == nil || len(g.stdBytesAliases) == 0 {
+		return value{}, false, nil
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return value{}, false, nil
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdBytesAliases[alias.Name] {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "from":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "bytes.from expects 1 argument, got %d", len(call.Args))
+		}
+		items, err := g.emitStdBytesListArg(call.Args[0], "from", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesFromListRuntime(items)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "concat":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "bytes.concat expects 2 arguments, got %d", len(call.Args))
+		}
+		left, err := g.emitStdBytesArg(call.Args[0], "concat", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		right, err := g.emitStdBytesArg(call.Args[1], "concat", 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesConcatRuntime(left, right)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "repeat":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "bytes.repeat expects 2 arguments, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "repeat", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		n, err := g.emitStdBytesIntArg(call.Args[1], "repeat", 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesRepeatRuntime(b, n)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "contains":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "bytes.contains expects 2 arguments, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "contains", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		sub, err := g.emitStdBytesArg(call.Args[1], "contains", 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesContainsRuntime(b, sub)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "startsWith":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "bytes.startsWith expects 2 arguments, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "startsWith", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		prefix, err := g.emitStdBytesArg(call.Args[1], "startsWith", 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesStartsWithRuntime(b, prefix)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "indexOf":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "bytes.indexOf expects 2 arguments, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "indexOf", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		sub, err := g.emitStdBytesArg(call.Args[1], "indexOf", 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesIndexOfRuntime(b, sub)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "toString":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "bytes.toString expects 1 argument, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "toString", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesToStringResult(b)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "len":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "bytes.len expects 1 argument, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "len", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		symbol := "osty_rt_bytes_len"
+		g.declareRuntimeSymbol(symbol, "i64", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i64", symbol, []*LlvmValue{toOstyValue(b)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "isEmpty":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "bytes.isEmpty expects 1 argument, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "isEmpty", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		symbol := "osty_rt_bytes_is_empty"
+		g.declareRuntimeSymbol(symbol, "i1", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmCall(emitter, "i1", symbol, []*LlvmValue{toOstyValue(b)})
+		g.takeOstyEmitter(emitter)
+		return fromOstyValue(out), true, nil
+	case "get":
+		if len(call.Args) != 2 {
+			return value{}, true, unsupportedf("call", "bytes.get expects 2 arguments, got %d", len(call.Args))
+		}
+		b, err := g.emitStdBytesArg(call.Args[0], "get", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		index, err := g.emitStdBytesIntArg(call.Args[1], "get", 1)
+		if err != nil {
+			return value{}, true, err
+		}
+		out, err := g.emitBytesGetRuntime(b, index)
+		if err != nil {
+			return value{}, true, err
+		}
+		return out, true, nil
+	case "fromString":
+		if len(call.Args) != 1 {
+			return value{}, true, unsupportedf("call", "bytes.fromString expects 1 argument, got %d", len(call.Args))
+		}
+		s, err := g.emitStdBytesStringArg(call.Args[0], "fromString", 0)
+		if err != nil {
+			return value{}, true, err
+		}
+		g.declareRuntimeSymbol(llvmStringRuntimeToBytesSymbol(), "ptr", []paramInfo{{typ: "ptr"}})
+		emitter := g.toOstyEmitter()
+		out := llvmStringToBytes(emitter, toOstyValue(s))
+		g.takeOstyEmitter(emitter)
+		v := fromOstyValue(out)
+		v.gcManaged = true
+		v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+		return v, true, nil
+	}
+	return value{}, false, nil
 }
 
 func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) {
@@ -99,6 +310,9 @@ func (g *generator) emitStdStringsCall(call *ast.CallExpr) (value, bool, error) 
 	case "slice":
 		v, err := g.emitStdStringsSlice(call)
 		return v, true, err
+	case "toBytes":
+		v, err := g.emitStdStringsToBytes(call)
+		return v, true, err
 	case "trimPrefix":
 		v, err := g.emitStdStringsBinaryString(call, "trimPrefix", llvmStringRuntimeTrimPrefixSymbol())
 		return v, true, err
@@ -150,10 +364,62 @@ func (g *generator) stdStringsCallStaticResult(call *ast.CallExpr) (value, bool)
 		}, true
 	case "contains", "hasPrefix", "hasSuffix":
 		return value{typ: "i1"}, true
+	case "toBytes":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
 	case "concat", "join", "repeat", "replace", "replaceAll", "slice", "trim", "trimSpace", "trimStart", "trimEnd", "trimPrefix", "trimSuffix":
 		return value{typ: "ptr", gcManaged: true}, true
 	case "split", "splitN":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true}, true
+	}
+	return value{}, false
+}
+
+func (g *generator) stdBytesCallStaticResult(call *ast.CallExpr) (value, bool) {
+	if call == nil || len(g.stdBytesAliases) == 0 {
+		return value{}, false
+	}
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok {
+		return value{}, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdBytesAliases[alias.Name] {
+		return value{}, false
+	}
+	switch field.Name {
+	case "len":
+		return value{typ: "i64"}, true
+	case "isEmpty":
+		return value{typ: "i1"}, true
+	case "contains", "startsWith":
+		return value{typ: "i1"}, true
+	case "indexOf":
+		return value{
+			typ:       "ptr",
+			gcManaged: true,
+			sourceType: &ast.OptionalType{
+				Inner: &ast.NamedType{Path: []string{"Int"}},
+			},
+		}, true
+	case "get":
+		return value{
+			typ:       "ptr",
+			gcManaged: true,
+			sourceType: &ast.OptionalType{
+				Inner: &ast.NamedType{Path: []string{"Byte"}},
+			},
+		}, true
+	case "fromString":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
+	case "from":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
+	case "concat", "repeat":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
+	case "toString":
+		if info, ok := builtinResultTypeFromAST(bytesToStringResultSourceType(), g.typeEnv()); ok {
+			return value{typ: info.typ, sourceType: bytesToStringResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+		}
+		return value{}, false
 	}
 	return value{}, false
 }
@@ -332,6 +598,24 @@ func (g *generator) emitStdStringsReplace(call *ast.CallExpr) (value, error) {
 	return g.emitStringReplaceRuntime(s, old, newValue)
 }
 
+func (g *generator) emitStdStringsToBytes(call *ast.CallExpr) (value, error) {
+	if len(call.Args) != 1 {
+		return value{}, unsupportedf("call", "strings.toBytes expects 1 argument, got %d", len(call.Args))
+	}
+	s, err := g.emitStdStringsArg(call.Args[0], "toBytes", 0)
+	if err != nil {
+		return value{}, err
+	}
+	g.declareRuntimeSymbol(llvmStringRuntimeToBytesSymbol(), "ptr", []paramInfo{{typ: "ptr"}})
+	emitter := g.toOstyEmitter()
+	out := llvmStringToBytes(emitter, toOstyValue(s))
+	g.takeOstyEmitter(emitter)
+	v := fromOstyValue(out)
+	v.gcManaged = true
+	v.sourceType = &ast.NamedType{Path: []string{"Bytes"}}
+	return v, nil
+}
+
 func (g *generator) emitStdStringsReplaceAll(call *ast.CallExpr) (value, error) {
 	if len(call.Args) != 3 {
 		return value{}, unsupportedf("call", "strings.replaceAll expects 3 arguments, got %d", len(call.Args))
@@ -444,6 +728,97 @@ func (g *generator) emitStdStringsIntArg(arg *ast.Arg, name string, index int) (
 	}
 	if loaded.typ != "i64" {
 		return value{}, unsupportedf("type-system", "strings.%s arg %d type %s, want Int", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdBytesArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "bytes.%s requires positional arguments", name)
+	}
+	src, ok := g.staticExprSourceType(arg.Value)
+	if !ok {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d source type unknown, want Bytes", name, index+1)
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsBytes(resolved) {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d source type is not Bytes", name, index+1)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d type %s, want Bytes", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdBytesListArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "bytes.%s requires positional arguments", name)
+	}
+	if !g.staticExprListElemIsByte(arg.Value) {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d source type is not List<Byte>", name, index+1)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d type %s, want List<Byte>", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdBytesStringArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "bytes.%s requires positional arguments", name)
+	}
+	src, ok := g.staticExprSourceType(arg.Value)
+	if !ok {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d source type unknown, want String", name, index+1)
+	}
+	resolved, err := llvmResolveAliasType(src, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsString(resolved) {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d source type is not String", name, index+1)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "ptr" {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d type %s, want String", name, index+1, loaded.typ)
+	}
+	return loaded, nil
+}
+
+func (g *generator) emitStdBytesIntArg(arg *ast.Arg, name string, index int) (value, error) {
+	if arg == nil || arg.Name != "" || arg.Value == nil {
+		return value{}, unsupportedf("call", "bytes.%s requires positional arguments", name)
+	}
+	v, err := g.emitExpr(arg.Value)
+	if err != nil {
+		return value{}, err
+	}
+	loaded, err := g.loadIfPointer(v)
+	if err != nil {
+		return value{}, err
+	}
+	if loaded.typ != "i64" {
+		return value{}, unsupportedf("type-system", "bytes.%s arg %d type %s, want Int", name, index+1, loaded.typ)
 	}
 	return loaded, nil
 }

--- a/internal/llvmgen/stdlib_shim_test.go
+++ b/internal/llvmgen/stdlib_shim_test.go
@@ -222,6 +222,29 @@ fn main() {
 	}
 }
 
+func TestStdStringsToBytesRoutesToRuntimeAndBytesMethodsCompose(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.strings as strings
+
+fn main() {
+    let n = strings.toBytes("abc").len()
+    println(n)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_strings_to_bytes.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_ToBytes(ptr)",
+		"call ptr @osty_rt_strings_ToBytes",
+		"call i64 @osty_rt_bytes_len",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
 func TestStdStringsReplaceAllRoutesToRuntime(t *testing.T) {
 	file := parseLLVMGenFile(t, `use std.strings as strings
 
@@ -454,6 +477,60 @@ fn main() {
 	}
 }
 
+func TestStdBytesContainsRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    if bytes.contains(bytes.from([b'a', b'b', b'c']), bytes.from([b'b'])) {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_bytes_contains.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"declare i64 @osty_rt_bytes_index_of(ptr, ptr)",
+		"call i64 @osty_rt_bytes_index_of",
+		"icmp sge i64",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
+func TestStdBytesStartsWithRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    if bytes.startsWith(bytes.from([b'a', b'b', b'c']), bytes.from([b'a', b'b'])) {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_bytes_starts_with.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"declare i64 @osty_rt_bytes_index_of(ptr, ptr)",
+		"call i64 @osty_rt_bytes_index_of",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
 func TestCollectStdStringsAliasesIgnoresRuntimeFFI(t *testing.T) {
 	file := parseLLVMGenFile(t, `use runtime.strings as strings {
     fn HasPrefix(s: String, prefix: String) -> Bool
@@ -468,6 +545,225 @@ fn main() {
 	aliases := collectStdStringsAliases(file)
 	if len(aliases) != 0 {
 		t.Fatalf("expected no std.strings aliases from runtime FFI use, got %v", aliases)
+	}
+}
+
+func TestStdBytesFromStringComposeWithLen(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    let n = bytes.fromString("abc").len()
+    println(n)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_bytes_from_string_len.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_ToBytes(ptr)",
+		"call ptr @osty_rt_strings_ToBytes",
+		"call i64 @osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdBytesAliasRespectsRenameAndOptionalByteComposes(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bin
+
+fn main() {
+    let ok = bin.get(bin.fromString("abc"), 1).isSome()
+    println(ok)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_bytes_alias_get.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_ToBytes",
+		"@osty_rt_bytes_get",
+		"icmp ne ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdBytesFromListComposeWithLen(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    let n = bytes.from([b'A', b'B']).len()
+    println(n)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_bytes_from_list_len.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"call ptr @osty_rt_bytes_from_list",
+		"call i64 @osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdBytesIndexOfRoutesToRuntimeAndOptionIntComposes(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    let at = bytes.indexOf(bytes.from([b'a', b'b', b'c']), bytes.from([b'b'])) ?? -1
+    println(at)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/std_bytes_index_of.osty"})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"declare i64 @osty_rt_bytes_index_of(ptr, ptr)",
+		"call i64 @osty_rt_bytes_index_of",
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
+		"load i64, ptr",
+		"phi i64",
+	} {
+		if !strings.Contains(string(ir), want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, string(ir))
+		}
+	}
+}
+
+func TestStdBytesConcatComposeWithLen(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    let n = bytes.concat(bytes.from([b'A']), bytes.from([b'B'])).len()
+    println(n)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_bytes_concat_len.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"declare ptr @osty_rt_bytes_concat(ptr, ptr)",
+		"call ptr @osty_rt_bytes_concat",
+		"call i64 @osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdBytesRepeatComposeWithLen(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn main() {
+    let n = bytes.repeat(bytes.from([b'A']), 3).len()
+    println(n)
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_bytes_repeat_len.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"declare ptr @osty_rt_bytes_repeat(ptr, i64)",
+		"call ptr @osty_rt_bytes_repeat",
+		"call i64 @osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStdBytesToStringQuestionPreservesStringSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `use std.bytes as bytes
+
+fn decodeLen() -> Result<Int, Error> {
+    let s = bytes.toString(bytes.from([b'a', b'b']))?
+    Ok(s.len())
+}
+`)
+
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/std_bytes_to_string_question.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+
+	got := string(ir)
+	for _, want := range []string{
+		"declare ptr @osty_rt_bytes_from_list(ptr)",
+		"declare i1 @osty_rt_bytes_is_valid_utf8(ptr)",
+		"declare ptr @osty_rt_bytes_to_string(ptr)",
+		"call ptr @osty_rt_bytes_to_string",
+		"call i64 @osty_rt_strings_ByteLen",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestCollectStdBytesAliasesIgnoresRuntimeFFI(t *testing.T) {
+	file := parseLLVMGenFile(t, `use runtime.bytes as bytes {
+    fn Len(b: Bytes) -> Int
+}
+
+fn main() {
+    println(bytes.Len("abc".toBytes()))
+}
+`)
+	aliases := collectStdBytesAliases(file)
+	if len(aliases) != 0 {
+		t.Fatalf("expected no std.bytes aliases from runtime FFI use, got %v", aliases)
 	}
 }
 

--- a/internal/llvmgen/string_method_dispatch_test.go
+++ b/internal/llvmgen/string_method_dispatch_test.go
@@ -360,6 +360,475 @@ fn main() {
 	}
 }
 
+func TestStringToBytesMethodCarriesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn size(s: String) -> Int {
+    s.toBytes().len()
+}
+
+fn main() {
+    println(size("abc"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_to_bytes_len.osty"})
+	if err != nil {
+		t.Fatalf("toBytes().len() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_ToBytes",
+		"@osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("toBytes().len() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStringToBytesMethodPreservesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn empty(s: String) -> Bool {
+    s.toBytes().isEmpty()
+}
+
+fn main() {
+    println(empty(""))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_to_bytes_is_empty.osty"})
+	if err != nil {
+		t.Fatalf("toBytes().isEmpty() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_ToBytes",
+		"@osty_rt_bytes_is_empty",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("toBytes().isEmpty() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesGetMethodReturnsOptionalByte(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn second(b: Bytes) -> Byte? {
+    b.get(1)
+}
+
+fn main() {
+    let b = "abc".toBytes()
+    println(second(b).isSome())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_get_method.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.get() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_len",
+		"@osty_rt_bytes_get",
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 1,",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.get() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStringToBytesGetMethodPreservesOptionalByteSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasFirst(s: String) -> Bool {
+    s.toBytes().get(0).isSome()
+}
+
+fn main() {
+    println(hasFirst("abc"))
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/string_to_bytes_get_is_some.osty"})
+	if err != nil {
+		t.Fatalf("toBytes().get().isSome() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_strings_ToBytes",
+		"@osty_rt_bytes_get",
+		"icmp ne ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("toBytes().get().isSome() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticLenDispatchesThroughRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn size() -> Int {
+    Bytes.len(Bytes.from([b'A', b'B']))
+}
+
+fn main() {
+    println(size())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_len.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.len(Bytes.from(...)) errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.len(Bytes.from(...)) missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticGetPreservesOptionalByteSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasSecond() -> Bool {
+    Bytes.get(Bytes.from([b'A', b'B']), 1).isSome()
+}
+
+fn main() {
+    println(hasSecond())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_get_is_some.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.get(Bytes.from(...)).isSome() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_get",
+		"icmp ne ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.get(Bytes.from(...)).isSome() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesFromMethodChainPreservesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasSecond() -> Bool {
+    Bytes.from([b'A', b'B']).get(1).isSome()
+}
+
+fn main() {
+    println(hasSecond())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_from_method_chain.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.from(...).get().isSome() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_get",
+		"icmp ne ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.from(...).get().isSome() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesIndexOfMethodReturnsOptionalInt(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn posOrMinusOne() -> Int {
+    Bytes.from([b'a', b'b', b'c']).indexOf(Bytes.from([b'b'])) ?? -1
+}
+
+fn main() {
+    println(posOrMinusOne())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_index_of_method.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.indexOf method call errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_index_of",
+		"call ptr @osty.gc.alloc_v1(i64 1, i64 8,",
+		"load i64, ptr",
+		"phi i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.indexOf method call missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesContainsMethodRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasNeedle() -> Bool {
+    Bytes.from([b'a', b'b', b'c']).contains(Bytes.from([b'b']))
+}
+
+fn main() {
+    println(hasNeedle())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_contains_method.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.contains method call errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_index_of",
+		"icmp sge i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.contains method call missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticContainsRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasNeedle() -> Bool {
+    Bytes.contains(Bytes.from([b'a', b'b', b'c']), Bytes.from([b'b']))
+}
+
+fn main() {
+    println(hasNeedle())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_contains.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.contains(...) errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_index_of",
+		"icmp sge i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.contains(...) missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStartsWithMethodRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasPrefix() -> Bool {
+    Bytes.from([b'a', b'b', b'c']).startsWith(Bytes.from([b'a', b'b']))
+}
+
+fn main() {
+    println(hasPrefix())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_starts_with_method.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.startsWith method call errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_index_of",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.startsWith method call missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticStartsWithRoutesToRuntime(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasPrefix() -> Bool {
+    Bytes.startsWith(Bytes.from([b'a', b'b', b'c']), Bytes.from([b'a', b'b']))
+}
+
+fn main() {
+    println(hasPrefix())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_starts_with.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.startsWith(...) errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_index_of",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.startsWith(...) missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticIndexOfPreservesOptionalIntSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hasNeedle() -> Bool {
+    Bytes.indexOf(Bytes.from([b'a', b'b', b'c']), Bytes.from([b'b'])).isSome()
+}
+
+fn main() {
+    println(hasNeedle())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_index_of_is_some.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.indexOf(...).isSome() errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_index_of",
+		"icmp ne ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.indexOf(...).isSome() missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesConcatMethodChainPreservesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn size() -> Int {
+    Bytes.from([b'A']).concat(Bytes.from([b'B'])).len()
+}
+
+fn main() {
+    println(size())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_concat_method_len.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.concat method chain errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_concat",
+		"@osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.concat method chain missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticConcatCarriesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn size() -> Int {
+    Bytes.concat(Bytes.from([b'A']), Bytes.from([b'B'])).len()
+}
+
+fn main() {
+    println(size())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_concat_len.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.concat static helper errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_concat",
+		"@osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.concat static helper missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesRepeatMethodChainPreservesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn size() -> Int {
+    Bytes.from([b'A']).repeat(3).len()
+}
+
+fn main() {
+    println(size())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_repeat_method_len.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.repeat method chain errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_repeat",
+		"@osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.repeat method chain missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticRepeatCarriesBytesSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn size() -> Int {
+    Bytes.repeat(Bytes.from([b'A']), 3).len()
+}
+
+fn main() {
+    println(size())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_repeat_len.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.repeat static helper errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_from_list",
+		"@osty_rt_bytes_repeat",
+		"@osty_rt_bytes_len",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.repeat static helper missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesToStringMethodQuestionPreservesStringSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn decodeLen() -> Result<Int, Error> {
+    let s = "ab".toBytes().toString()?
+    Ok(s.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_to_string_method_question.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.toString()? method chain errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_is_valid_utf8",
+		"@osty_rt_bytes_to_string",
+		"@osty_rt_strings_ByteLen",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.toString()? method chain missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBytesStaticToStringQuestionPreservesStringSourceType(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn decodeLen() -> Result<Int, Error> {
+    let s = Bytes.toString("ab".toBytes())?
+    Ok(s.len())
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/bytes_static_to_string_question.osty"})
+	if err != nil {
+		t.Fatalf("Bytes.toString(...)? static helper errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"@osty_rt_bytes_is_valid_utf8",
+		"@osty_rt_bytes_to_string",
+		"@osty_rt_strings_ByteLen",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Bytes.toString(...)? static helper missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // Chained method calls — `s.trimPrefix(a).trimSuffix(b).contains(n)` —
 // must keep flowing through the String dispatcher rather than dropping
 // the source-type hint after the first call. This locks in the

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2380,6 +2380,10 @@ func llvmStringRuntimeBytesSymbol() string {
 	return "osty_rt_strings_Bytes"
 }
 
+func llvmStringRuntimeToBytesSymbol() string {
+	return "osty_rt_strings_ToBytes"
+}
+
 func llvmStringRuntimeDeclarations() []string {
 	return []string{
 		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
@@ -2407,6 +2411,7 @@ func llvmStringRuntimeDeclarations() []string {
 		"declare ptr @osty_rt_strings_TrimSpace(ptr)",
 		"declare ptr @osty_rt_strings_Chars(ptr)",
 		"declare ptr @osty_rt_strings_Bytes(ptr)",
+		"declare ptr @osty_rt_strings_ToBytes(ptr)",
 	}
 }
 
@@ -2515,6 +2520,10 @@ func llvmStringChars(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 
 func llvmStringBytes(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Bytes", []*LlvmValue{value})
+}
+
+func llvmStringToBytes(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_strings_ToBytes", []*LlvmValue{value})
 }
 
 func llvmBuiltinType(name string) string {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -176,6 +176,11 @@ func llvmNamedTypeIsBytes(t ast.Type) bool {
 	return ok && len(named.Path) == 1 && named.Path[0] == "Bytes" && len(named.Args) == 0
 }
 
+func llvmNamedTypeIsByte(t ast.Type) bool {
+	named, ok := t.(*ast.NamedType)
+	return ok && len(named.Path) == 1 && named.Path[0] == "Byte" && len(named.Args) == 0
+}
+
 func llvmEnumPayloadType(t ast.Type, env typeEnv) (string, error) {
 	resolved, err := llvmResolveAliasType(t, env, map[string]bool{})
 	if err != nil {
@@ -391,6 +396,15 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticStringMethodSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticBytesMethodSourceType(e); ok {
+			return src, true
+		}
+		if src, ok := g.staticBytesNamespaceCallSourceType(e); ok {
+			return src, true
+		}
+		if src, ok := g.staticStdBytesCallSourceType(e); ok {
+			return src, true
+		}
 		if src, ok := g.staticStdStringsCallSourceType(e); ok {
 			return src, true
 		}
@@ -554,6 +568,12 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		if out, ok := g.staticStringMethodResult(e); ok {
 			return out, true
 		}
+		if out, ok := g.staticBytesMethodResult(e); ok {
+			return out, true
+		}
+		if out, ok := g.staticBytesNamespaceCallResult(e); ok {
+			return out, true
+		}
 		if out, ok := g.staticCharByteConversionResult(e); ok {
 			return out, true
 		}
@@ -596,6 +616,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		}
 		if fn, found, err := g.runtimeFFICallTarget(e); found && err == nil && fn.ret != "" && fn.ret != "void" {
 			return value{typ: fn.ret, listElemTyp: fn.listElemTyp, gcManaged: fn.listElemTyp != ""}, true
+		}
+		if out, ok := g.stdBytesCallStaticResult(e); ok {
+			return out, true
 		}
 		if out, ok := g.stdStringsCallStaticResult(e); ok {
 			return out, true
@@ -749,6 +772,27 @@ func (g *generator) staticExprListElemIsBytes(expr ast.Expr) bool {
 	return llvmNamedTypeIsBytes(elemResolved)
 }
 
+func (g *generator) staticExprListElemIsByte(expr ast.Expr) bool {
+	sourceType, ok := g.staticExprSourceType(expr)
+	if ok {
+		resolved, err := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{})
+		if err == nil {
+			named, ok := resolved.(*ast.NamedType)
+			if ok && len(named.Path) == 1 && named.Path[0] == "List" && len(named.Args) == 1 {
+				elemResolved, err := llvmResolveAliasType(named.Args[0], g.typeEnv(), map[string]bool{})
+				if err == nil && llvmNamedTypeIsByte(elemResolved) {
+					return true
+				}
+			}
+		}
+	}
+	info, ok := g.staticExprInfo(expr)
+	if !ok {
+		return false
+	}
+	return info.typ == "ptr" && info.listElemTyp == "i8" && !info.listElemString
+}
+
 // staticStdStringsCallSourceType recovers the source-level return type
 // for `strings.<method>(...)` alias-qualified calls (`use std.strings
 // as strings`). Keeps the dispatch layer (`stdStringsCallStaticResult`)
@@ -774,12 +818,69 @@ func (g *generator) staticStdStringsCallSourceType(call *ast.CallExpr) (ast.Type
 		return &ast.NamedType{Path: []string{"Int"}}, true
 	case "indexOf":
 		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Int"}}}, true
+	case "toBytes":
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
 	case "contains", "hasPrefix", "hasSuffix":
 		return &ast.NamedType{Path: []string{"Bool"}}, true
 	case "concat", "join", "repeat", "replace", "replaceAll", "slice", "trim", "trimSpace", "trimStart", "trimEnd", "trimPrefix", "trimSuffix":
 		return stringT, true
 	case "split", "splitN":
 		return &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{stringT}}, true
+	}
+	return nil, false
+}
+
+func (g *generator) staticStdBytesCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	if call == nil || len(g.stdBytesAliases) == 0 {
+		return nil, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok {
+		return nil, false
+	}
+	alias, ok := field.X.(*ast.Ident)
+	if !ok || !g.stdBytesAliases[alias.Name] {
+		return nil, false
+	}
+	switch field.Name {
+	case "len":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "isEmpty":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "contains", "startsWith":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "indexOf":
+		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Int"}}}, true
+	case "get":
+		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Byte"}}}, true
+	case "fromString", "from", "concat", "repeat":
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
+	case "toString":
+		return bytesToStringResultSourceType(), true
+	}
+	return nil, false
+}
+
+func (g *generator) staticBytesNamespaceCallSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.bytesNamespaceCallInfo(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "len":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "isEmpty":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "contains", "startsWith":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "indexOf":
+		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Int"}}}, true
+	case "get":
+		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Byte"}}}, true
+	case "from", "concat", "repeat":
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
+	case "toString":
+		return bytesToStringResultSourceType(), true
 	}
 	return nil, false
 }
@@ -856,6 +957,8 @@ func (g *generator) staticStringMethodSourceType(call *ast.CallExpr) (ast.Type, 
 			Path: []string{"List"},
 			Args: []ast.Type{&ast.NamedType{Path: []string{"String"}}},
 		}, true
+	case "toBytes":
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
 	case "trim", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toString", "join", "replace", "repeat":
 		return &ast.NamedType{Path: []string{"String"}}, true
 	case "chars":
@@ -940,6 +1043,8 @@ func (g *generator) staticStringMethodResult(call *ast.CallExpr) (value, bool) {
 		}, true
 	case "split", "lines":
 		return value{typ: "ptr", gcManaged: true, listElemTyp: "ptr", listElemString: true}, true
+	case "toBytes":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
 	case "trim", "trimStart", "trimEnd", "trimPrefix", "trimSuffix", "toString", "join", "replace", "repeat":
 		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"String"}}}, true
 	case "chars":
@@ -969,7 +1074,149 @@ func (g *generator) stringMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) 
 		"indexOf",
 		"get",
 		"trimStart", "trimEnd", "trimPrefix", "trimSuffix",
-		"split", "lines", "join", "trim", "replace", "repeat", "toString", "chars", "bytes":
+		"split", "lines", "join", "trim", "replace", "repeat", "toString", "chars", "bytes", "toBytes":
+		return field, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) staticBytesMethodSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, ok := g.bytesMethodInfo(call)
+	if !ok {
+		return nil, false
+	}
+	switch field.Name {
+	case "len":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "isEmpty":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "contains", "startsWith":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "indexOf":
+		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Int"}}}, true
+	case "get":
+		return &ast.OptionalType{Inner: &ast.NamedType{Path: []string{"Byte"}}}, true
+	case "concat", "repeat":
+		return &ast.NamedType{Path: []string{"Bytes"}}, true
+	case "toString":
+		return bytesToStringResultSourceType(), true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) staticBytesMethodResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.bytesMethodInfo(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "len":
+		return value{typ: "i64"}, true
+	case "isEmpty":
+		return value{typ: "i1"}, true
+	case "contains", "startsWith":
+		return value{typ: "i1"}, true
+	case "indexOf":
+		return value{
+			typ:       "ptr",
+			gcManaged: true,
+			sourceType: &ast.OptionalType{
+				Inner: &ast.NamedType{Path: []string{"Int"}},
+			},
+		}, true
+	case "get":
+		return value{
+			typ:       "ptr",
+			gcManaged: true,
+			sourceType: &ast.OptionalType{
+				Inner: &ast.NamedType{Path: []string{"Byte"}},
+			},
+		}, true
+	case "concat", "repeat":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
+	case "toString":
+		if info, ok := builtinResultTypeFromAST(bytesToStringResultSourceType(), g.typeEnv()); ok {
+			return value{typ: info.typ, sourceType: bytesToStringResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+		}
+		return value{}, false
+	default:
+		return value{}, false
+	}
+}
+
+func (g *generator) bytesMethodInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional || field.X == nil {
+		return nil, false
+	}
+	sourceType, ok := g.staticExprSourceType(field.X)
+	if !ok {
+		return nil, false
+	}
+	resolved, err := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{})
+	if err != nil || !llvmNamedTypeIsBytes(resolved) {
+		return nil, false
+	}
+	switch field.Name {
+	case "len", "isEmpty", "get", "contains", "startsWith", "indexOf", "concat", "repeat", "toString":
+		return field, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *generator) staticBytesNamespaceCallResult(call *ast.CallExpr) (value, bool) {
+	field, ok := g.bytesNamespaceCallInfo(call)
+	if !ok {
+		return value{}, false
+	}
+	switch field.Name {
+	case "len":
+		return value{typ: "i64"}, true
+	case "isEmpty":
+		return value{typ: "i1"}, true
+	case "contains", "startsWith":
+		return value{typ: "i1"}, true
+	case "indexOf":
+		return value{
+			typ:       "ptr",
+			gcManaged: true,
+			sourceType: &ast.OptionalType{
+				Inner: &ast.NamedType{Path: []string{"Int"}},
+			},
+		}, true
+	case "get":
+		return value{
+			typ:       "ptr",
+			gcManaged: true,
+			sourceType: &ast.OptionalType{
+				Inner: &ast.NamedType{Path: []string{"Byte"}},
+			},
+		}, true
+	case "from", "concat", "repeat":
+		return value{typ: "ptr", gcManaged: true, sourceType: &ast.NamedType{Path: []string{"Bytes"}}}, true
+	case "toString":
+		if info, ok := builtinResultTypeFromAST(bytesToStringResultSourceType(), g.typeEnv()); ok {
+			return value{typ: info.typ, sourceType: bytesToStringResultSourceType(), rootPaths: g.rootPathsForType(info.typ)}, true
+		}
+		return value{}, false
+	}
+	return value{}, false
+}
+
+func (g *generator) bytesNamespaceCallInfo(call *ast.CallExpr) (*ast.FieldExpr, bool) {
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional || field.X == nil {
+		return nil, false
+	}
+	owner, ok := field.X.(*ast.Ident)
+	if !ok || owner.Name != "Bytes" {
+		return nil, false
+	}
+	switch field.Name {
+	case "from", "len", "isEmpty", "get", "contains", "startsWith", "indexOf", "concat", "repeat", "toString":
 		return field, true
 	default:
 		return nil, false

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3159,6 +3159,16 @@ func bytesIntrinsicForMethod(name string) IntrinsicKind {
 		return IntrinsicBytesIsEmpty
 	case "get":
 		return IntrinsicBytesGet
+	case "contains":
+		return IntrinsicBytesContains
+	case "startsWith":
+		return IntrinsicBytesStartsWith
+	case "indexOf":
+		return IntrinsicBytesIndexOf
+	case "concat":
+		return IntrinsicBytesConcat
+	case "repeat":
+		return IntrinsicBytesRepeat
 	}
 	return IntrinsicInvalid
 }

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -264,8 +264,8 @@ type AssignInstr struct {
 	SpanV Span
 }
 
-func (*AssignInstr) instrNode()  {}
-func (a *AssignInstr) At() Span  { return a.SpanV }
+func (*AssignInstr) instrNode() {}
+func (a *AssignInstr) At() Span { return a.SpanV }
 
 // CallInstr is a direct or indirect call. Dest is nil when the return
 // value is discarded or when the function returns unit.
@@ -502,6 +502,16 @@ const (
 	IntrinsicBytesIsEmpty
 	// IntrinsicBytesGet returns Byte?. Args: [bytes, idx].
 	IntrinsicBytesGet
+	// IntrinsicBytesContains returns Bool. Args: [bytes, needle].
+	IntrinsicBytesContains
+	// IntrinsicBytesStartsWith returns Bool. Args: [bytes, prefix].
+	IntrinsicBytesStartsWith
+	// IntrinsicBytesIndexOf returns Int?. Args: [bytes, needle].
+	IntrinsicBytesIndexOf
+	// IntrinsicBytesConcat returns Bytes. Args: [left, right].
+	IntrinsicBytesConcat
+	// IntrinsicBytesRepeat returns Bytes. Args: [bytes, n].
+	IntrinsicBytesRepeat
 
 	// ---- stdlib: Option / Result ----
 
@@ -599,7 +609,7 @@ type BranchTerm struct {
 	SpanV Span
 }
 
-func (*BranchTerm) termNode() {}
+func (*BranchTerm) termNode()  {}
 func (b *BranchTerm) At() Span { return b.SpanV }
 
 // SwitchIntTerm dispatches on an integer scrutinee. Cases are tried
@@ -611,7 +621,7 @@ type SwitchIntTerm struct {
 	SpanV     Span
 }
 
-func (*SwitchIntTerm) termNode() {}
+func (*SwitchIntTerm) termNode()  {}
 func (s *SwitchIntTerm) At() Span { return s.SpanV }
 
 // SwitchCase is one match arm of a SwitchIntTerm.
@@ -637,7 +647,7 @@ type UnreachableTerm struct {
 	SpanV Span
 }
 
-func (*UnreachableTerm) termNode() {}
+func (*UnreachableTerm) termNode()  {}
 func (u *UnreachableTerm) At() Span { return u.SpanV }
 
 // ==== Places / projections ====
@@ -730,8 +740,8 @@ type CopyOp struct {
 	T     Type
 }
 
-func (*CopyOp) operandNode()   {}
-func (o *CopyOp) Type() Type   { return o.T }
+func (*CopyOp) operandNode() {}
+func (o *CopyOp) Type() Type { return o.T }
 
 // MoveOp is a destructive read. Under the current GC-managed runtime
 // MoveOp and CopyOp behave identically; the distinction exists for
@@ -955,8 +965,8 @@ func (*LenRV) rvalueNode() {}
 type CastKind int
 
 const (
-	CastInvalid     CastKind = iota
-	CastIntResize            // widen/narrow between integer widths
+	CastInvalid   CastKind = iota
+	CastIntResize          // widen/narrow between integer widths
 	CastIntToFloat
 	CastFloatToInt
 	CastFloatResize
@@ -1399,6 +1409,16 @@ func (k IntrinsicKind) String() string {
 		return "bytes_is_empty"
 	case IntrinsicBytesGet:
 		return "bytes_get"
+	case IntrinsicBytesContains:
+		return "bytes_contains"
+	case IntrinsicBytesStartsWith:
+		return "bytes_starts_with"
+	case IntrinsicBytesIndexOf:
+		return "bytes_index_of"
+	case IntrinsicBytesConcat:
+		return "bytes_concat"
+	case IntrinsicBytesRepeat:
+		return "bytes_repeat"
 	case IntrinsicOptionIsSome:
 		return "option_is_some"
 	case IntrinsicOptionIsNone:

--- a/internal/stdlib/primitives/bytes.osty
+++ b/internal/stdlib/primitives/bytes.osty
@@ -8,6 +8,10 @@ pub struct __BytesMethods {
     pub fn len(self) -> Int { 0 }
     pub fn isEmpty(self) -> Bool { false }
     pub fn get(self, i: Int) -> Byte? { None }
+    pub fn contains(self, sub: Bytes) -> Bool { false }
+    pub fn startsWith(self, prefix: Bytes) -> Bool { false }
+    pub fn indexOf(self, sub: Bytes) -> Int? { None }
     pub fn concat(self, other: Bytes) -> Bytes { self.concat(other) }
+    pub fn repeat(self, n: Int) -> Bytes { self.repeat(n) }
     pub fn toString(self) -> Result<String, Error> { Ok("") }
 }


### PR DESCRIPTION
## What changed
- expanded legacy llvmgen backend support for additional `String` and `Bytes` methods, including chained method/static helper lowering
- extended `std.bytes` alias-qualified dispatch and static source-type tracking so method chains keep composing correctly
- added MIR direct lowering coverage for the new `Bytes` intrinsics and aligned runtime-backed tests
- added runtime helpers needed for new byte-sequence operations and updated primitive method surface definitions

## Why
- the backend still had a number of unsupported `String`/`Bytes` operations, which blocked normal stdlib usage and method chaining
- these gaps also caused the MIR path and legacy path to diverge for the same surface APIs

## Impact
- more `String`/`Bytes` stdlib surface now lowers directly through the backend without falling back or erroring
- alias-qualified `std.bytes` calls and chained expressions now preserve the right source types across lowering

## Validation
- `go test ./internal/llvmgen -run 'Bytes|String|Std(Bytes|Strings)|GeneratedStringRuntime' -count=1`
- `clang -fsyntax-only -std=c11 internal/backend/runtime/osty_runtime.c`