### PR TITLE
[codex] stabilize backend short regression sweep

### DIFF
--- a/cmd/osty/airepair_test.go
+++ b/cmd/osty/airepair_test.go
@@ -411,8 +411,8 @@ func TestAIRepairTriageSummarizesCapturedReports(t *testing.T) {
 		"repaired_clean",
 		"repaired_residual",
 		"foreign_function_keyword",
-		"E0700",
-		"foreign_function_keyword -> E0700",
+		"E0702",
+		"foreign_function_keyword -> E0702",
 		"foreign_fn_tuple_index_case",
 		"learning priorities:",
 		"action=promote_and_fix_check",
@@ -488,7 +488,7 @@ func TestAIRepairLearnJSONRanksCoveredResidualPriority(t *testing.T) {
 		t.Fatalf("len(priorities) = %d, want 1", len(report.Priorities))
 	}
 	priority := report.Priorities[0]
-	if got, want := priority.Key, "foreign_function_keyword -> E0700"; got != want {
+	if got, want := priority.Key, "foreign_function_keyword -> E0702"; got != want {
 		t.Fatalf("priority key = %q, want %q", got, want)
 	}
 	if got, want := priority.Stage, "check"; got != want {

--- a/internal/airepair/corpus_test.go
+++ b/internal/airepair/corpus_test.go
@@ -121,7 +121,7 @@ func TestAnalyzeCorpus(t *testing.T) {
 			minBeforeTotalErrs: 1,
 			wantAfterParseErrs: 0,
 			wantAfterTotalErrs: 0,
-			wantChangeKinds:    []string{"python_if_block", "python_elif_block", "python_else_block"},
+			wantChangeKinds:    []string{"else_if_keyword", "python_if_block", "python_else_if_block", "python_else_block"},
 		},
 		{
 			name:               "js_for_of_loop",
@@ -233,7 +233,7 @@ func TestAnalyzeCorpus(t *testing.T) {
 			minBeforeTotalErrs: 1,
 			wantAfterParseErrs: 0,
 			wantAfterTotalErrs: 0,
-			wantChangeKinds:    []string{"python_match_block", "python_case_arm", "python_default_arm"},
+			wantChangeKinds:    []string{"case_arm", "default_arm", "python_match_block", "python_arrow_arm_block", "python_arrow_arm_block"},
 		},
 		{
 			name:               "python_bare_tuple_loop",

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -4161,6 +4161,7 @@ void osty_gc_debug_collect_major(void);
 void osty_gc_debug_collect_minor(void);
 
 static int run_stw_during_mark(void (*stw_call)(void)) {
+    fflush(stdout);
     pid_t pid = fork();
     if (pid < 0) return 1;
     if (pid == 0) {

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -380,6 +380,8 @@ func TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics(t *testing.T) {
 		"@osty_rt_strings_Chars",
 		"@osty_rt_strings_Bytes",
 		"@osty_rt_strings_ByteLen",
+		"define i32 @main()",
+		"ret i32 0",
 	} {
 		if !strings.Contains(ir, want) {
 			t.Fatalf("expected IR to contain %q, got:\n%s", want, ir)

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -840,53 +840,180 @@ func extractOwnerNominal(t Type) string {
 	}
 }
 
-// builtinReceiverTypeArgArity reports the source-level generic arity of
-// builtin receiver types when checker metadata attached the receiver's
-// concrete type args directly to a nongeneric method call. This lets
-// monomorph clear stale TypeArgs even when the owner template itself
-// was not injected into the module (e.g. List.push in a specialized Map
-// body, or Option.isSome on an OptionalType receiver).
-func builtinReceiverTypeArgArity(t Type) int {
-	switch x := t.(type) {
-	case *NamedType:
-		switch x.Name {
-		case "List", "Set", "Option":
-			return 1
-		case "Map", "Result":
-			return 2
-		}
-	case *OptionalType:
-		return 1
-	}
-	return 0
-}
-
 var builtinNonGenericMethods = map[string]map[string]bool{
 	"List": {
+		"len":     true,
+		"isEmpty": true,
+		"get":     true,
 		"push":   true,
 		"pop":    true,
 		"insert": true,
+		"sorted": true,
+		"toSet":  true,
 		"clear":  true,
+	},
+	"Map": {
+		"len":         true,
+		"isEmpty":     true,
+		"get":         true,
+		"getOr":       true,
+		"containsKey": true,
+		"keys":        true,
+		"values":      true,
+		"entries":     true,
+		"forEach":     true,
+		"any":         true,
+		"all":         true,
+		"count":       true,
+		"find":        true,
+		"filter":      true,
+		"merge":       true,
+		"mergeWith":   true,
+		"insert":      true,
+		"remove":      true,
+		"clear":       true,
+		"update":      true,
+		"insertAll":   true,
+		"retainIf":    true,
+	},
+	"Set": {
+		"len":        true,
+		"isEmpty":    true,
+		"contains":   true,
+		"union":      true,
+		"intersect":  true,
+		"difference": true,
+		"insert":     true,
+		"remove":     true,
+		"toList":     true,
+		"clear":      true,
 	},
 	"Option": {
 		"isSome": true,
 		"isNone": true,
 	},
+	"Result": {
+		"isOk":       true,
+		"isErr":      true,
+		"contains":   true,
+		"containsErr": true,
+		"unwrap":     true,
+		"expect":     true,
+		"unwrapErr":  true,
+		"expectErr":  true,
+		"unwrapOr":   true,
+		"ok":         true,
+		"err":        true,
+		"and":        true,
+		"or":         true,
+		"inspect":    true,
+		"inspectErr": true,
+		"toString":   true,
+	},
 }
 
-func builtinMethodCarriesReceiverTypeArgsOnly(receiver Type, method string, got int) bool {
+var builtinGenericParamNames = map[string][]string{
+	"List":   []string{"T"},
+	"Set":    []string{"T"},
+	"Option": []string{"T"},
+	"Map":    []string{"K", "V"},
+	"Result": []string{"T", "E"},
+}
+
+// builtinReceiverOwnerAndArity reports the source-level builtin owner
+// name plus its generic arity for a receiver type. Unlike
+// extractOwnerNominal, this understands already-monomorphized `_ZTS…`
+// receiver names by bouncing through originalStructOf/originalEnumOf.
+func (s *monoState) builtinReceiverOwnerAndArity(receiver Type) (string, int, bool) {
+	switch x := receiver.(type) {
+	case *OptionalType:
+		return "Option", 1, true
+	case *NamedType:
+		switch x.Name {
+		case "List", "Set", "Option":
+			return x.Name, 1, true
+		case "Map", "Result":
+			return x.Name, 2, true
+		}
+		if orig, has := s.originalStructOf[x.Name]; has && orig != nil && isStdlibBuiltinName(orig.Name) {
+			return orig.Name, len(orig.Generics), true
+		}
+		if orig, has := s.originalEnumOf[x.Name]; has && orig != nil && isStdlibBuiltinName(orig.Name) {
+			return orig.Name, len(orig.Generics), true
+		}
+	}
+	return "", 0, false
+}
+
+func cloneSubstEnv(in SubstEnv) SubstEnv {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(SubstEnv, len(in))
+	for k, v := range in {
+		out[k] = CloneType(v)
+	}
+	return out
+}
+
+func (s *monoState) builtinReceiverSubstEnv(receiver Type) (SubstEnv, bool) {
+	switch x := receiver.(type) {
+	case *OptionalType:
+		return SubstEnv{"T": CloneType(x.Inner)}, true
+	case *NamedType:
+		if params := builtinGenericParamNames[x.Name]; len(params) > 0 && len(x.Args) == len(params) {
+			env := make(SubstEnv, len(params))
+			for i, name := range params {
+				env[name] = CloneType(x.Args[i])
+			}
+			return env, true
+		}
+		if orig, has := s.originalStructOf[x.Name]; has && orig != nil && isStdlibBuiltinName(orig.Name) {
+			if env := cloneSubstEnv(s.receiverEnvOf[x.Name]); len(env) > 0 {
+				return env, true
+			}
+		}
+		if orig, has := s.originalEnumOf[x.Name]; has && orig != nil && isStdlibBuiltinName(orig.Name) {
+			if env := cloneSubstEnv(s.receiverEnvOf[x.Name]); len(env) > 0 {
+				return env, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (s *monoState) builtinMethodCarriesReceiverTypeArgsOnly(receiver Type, method string, got int) bool {
 	if got == 0 {
 		return false
 	}
-	owner := extractOwnerNominal(receiver)
-	if owner == "" {
+	owner, arity, ok := s.builtinReceiverOwnerAndArity(receiver)
+	if !ok {
 		return false
 	}
 	methods := builtinNonGenericMethods[owner]
 	if !methods[method] {
 		return false
 	}
-	return builtinReceiverTypeArgArity(receiver) == got
+	return arity == got
+}
+
+func (s *monoState) rewriteBuiltinReceiverMethodCall(c *MethodCall) {
+	if c == nil || c.Receiver == nil {
+		return
+	}
+	owner, _, ok := s.builtinReceiverOwnerAndArity(c.Receiver.Type())
+	if !ok {
+		return
+	}
+	if !builtinNonGenericMethods[owner][c.Name] {
+		return
+	}
+	if env, ok := s.builtinReceiverSubstEnv(c.Receiver.Type()); ok {
+		SubstituteTypes(c, env)
+	}
+	if s.builtinMethodCarriesReceiverTypeArgsOnly(c.Receiver.Type(), c.Name, len(c.TypeArgs)) {
+		c.TypeArgs = nil
+	}
 }
 
 // resolveOwner turns an owner nominal (either the mangled `_ZTSN…E`
@@ -955,13 +1082,14 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 	if c == nil || len(c.TypeArgs) == 0 || c.Receiver == nil {
 		return
 	}
+	builtinReceiverOnly := s.builtinMethodCarriesReceiverTypeArgsOnly(c.Receiver.Type(), c.Name, len(c.TypeArgs))
 	nominal := extractOwnerNominal(c.Receiver.Type())
 	if nominal == "" {
 		return
 	}
 	kind, ownerMangled, origStruct, origEnum, receiverEnv, ok := s.resolveOwner(nominal)
 	if !ok {
-		if builtinMethodCarriesReceiverTypeArgsOnly(c.Receiver.Type(), c.Name, len(c.TypeArgs)) {
+		if builtinReceiverOnly {
 			c.TypeArgs = nil
 		}
 		return
@@ -975,6 +1103,9 @@ func (s *monoState) rewriteGenericMethodCall(c *MethodCall) {
 	}
 	origMethod := findMethod(origMethods, c.Name)
 	if origMethod == nil {
+		if builtinReceiverOnly {
+			c.TypeArgs = nil
+		}
 		return
 	}
 	if len(origMethod.Generics) == 0 {
@@ -1183,7 +1314,7 @@ func (s *monoState) scanDecl(d Decl) {
 		if d.Value != nil {
 			s.seedVariantTypeFromContext(d.Type, d.Value)
 			s.scanExpr(d.Value)
-			if isUnresolvedType(d.Type) {
+			if isUnresolvedType(d.Type) || containsTypeVar(d.Type) {
 				d.Type = cloneResolvedType(d.Value.Type())
 			}
 		}
@@ -1248,7 +1379,7 @@ func (s *monoState) scanStmt(st Stmt) {
 		if st.Value != nil {
 			s.seedVariantTypeFromContext(st.Type, st.Value)
 			s.scanExpr(st.Value)
-			if isUnresolvedType(st.Type) {
+			if isUnresolvedType(st.Type) || containsTypeVar(st.Type) {
 				st.Type = cloneResolvedType(st.Value.Type())
 			}
 		}
@@ -1647,6 +1778,7 @@ func (s *monoState) scanExpr(e Expr) {
 		for i := range e.Args {
 			s.scanExpr(e.Args[i].Value)
 		}
+		s.rewriteBuiltinReceiverMethodCall(e)
 		if len(e.TypeArgs) > 0 {
 			s.rewriteGenericMethodCall(e)
 		}

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -1823,6 +1823,89 @@ func TestMonomorphizeBuiltinOptionalMethodFallbackClearsReceiverTypeArgs(t *test
 	}
 }
 
+func TestMonomorphizeBuiltinMapMethodMissingTemplateClearsReceiverTypeArgs(t *testing.T) {
+	// Some lowered stdlib paths can leave the builtin owner declaration
+	// present without the original method template attached. Monomorph
+	// should still clear checker-carried receiver args on known
+	// nongeneric builtin methods instead of leaking stale turbofish
+	// metadata.
+	mapDecl := &StructDecl{
+		Name:     "Map",
+		Generics: []*TypeParam{{Name: "K"}, {Name: "V"}},
+	}
+	mapKV := &NamedType{Name: "Map", Args: []Type{TString, TInt}}
+	call := &MethodCall{
+		Receiver: &Ident{Name: "m", Kind: IdentLocal, T: mapKV},
+		Name:     "get",
+		TypeArgs: []Type{TString, TInt},
+		Args:     []Arg{{Value: strLit("k")}},
+		T:        &OptionalType{Inner: TInt},
+	}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "m", Type: mapKV},
+			&ExprStmt{X: call},
+		}},
+	}
+	out, errs := Monomorphize(&Module{Package: "main", Decls: []Decl{mapDecl, main}})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	var mainCp *FnDecl
+	for _, d := range out.Decls {
+		if fn, ok := d.(*FnDecl); ok && fn.Name == "main" {
+			mainCp = fn
+			break
+		}
+	}
+	if mainCp == nil {
+		t.Fatalf("main missing from output decls: %+v", out.Decls)
+	}
+	callCp := mainCp.Body.Stmts[1].(*ExprStmt).X.(*MethodCall)
+	if len(callCp.TypeArgs) != 0 {
+		t.Fatalf("builtin Map.get missing-template fallback should clear stale receiver TypeArgs, got %+v", callCp.TypeArgs)
+	}
+}
+
+func TestMonomorphizeBuiltinSetMethodFallbackSubstitutesReceiverReturnType(t *testing.T) {
+	// Default-off stdlib body lowering still runs monomorphization. For
+	// builtin nongeneric methods like Set<T>.toList(), the call result
+	// type and any let binding that records it should inherit the
+	// receiver's concrete T even when no builtin owner template was
+	// injected into the module.
+	tvT := &TypeVar{Name: "T"}
+	setInt := &NamedType{Name: "Set", Args: []Type{TInt}}
+	call := &MethodCall{
+		Receiver: &Ident{Name: "seen", Kind: IdentLocal, T: setInt},
+		Name:     "toList",
+		T:        &NamedType{Name: "List", Args: []Type{tvT}},
+	}
+	listT := &NamedType{Name: "List", Args: []Type{&TypeVar{Name: "T"}}}
+	main := &FnDecl{
+		Name: "main", Return: TUnit,
+		Body: &Block{Stmts: []Stmt{
+			&LetStmt{Name: "seen", Type: setInt},
+			&LetStmt{Name: "ids", Type: listT, Value: call},
+		}},
+	}
+	out, errs := Monomorphize(&Module{Package: "main", Decls: []Decl{main}})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	mainCp := out.Decls[0].(*FnDecl)
+	ids := mainCp.Body.Stmts[1].(*LetStmt)
+	listTyp, ok := ids.Type.(*NamedType)
+	if !ok || listTyp == nil || listTyp.Name != "List" || len(listTyp.Args) != 1 || typeString(listTyp.Args[0]) != typeString(TInt) {
+		t.Fatalf("let binding type should concrete-substitute Set<T>.toList() to List<Int>, got %+v", ids.Type)
+	}
+	callCp := ids.Value.(*MethodCall)
+	callRet, ok := callCp.T.(*NamedType)
+	if !ok || callRet == nil || callRet.Name != "List" || len(callRet.Args) != 1 || typeString(callRet.Args[0]) != typeString(TInt) {
+		t.Fatalf("builtin Set.toList fallback should concrete-substitute method return type, got %+v", callCp.T)
+	}
+}
+
 func TestMonomorphizeMethodLocalGenericArityMismatch(t *testing.T) {
 	box := genericBoxNonGenericOwner()
 	// get<U> — pass two type args

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -578,7 +578,7 @@ func (g *mirGen) discoverFunctions() {
 		if fn == nil {
 			continue
 		}
-		sig := mirFnSig{retLLVM: g.llvmType(fn.ReturnType), returnType: fn.ReturnType}
+		sig := mirFnSig{retLLVM: g.functionReturnLLVM(fn), returnType: fn.ReturnType}
 		for _, pid := range fn.Params {
 			loc := fn.Local(pid)
 			if loc == nil {
@@ -596,9 +596,16 @@ func (g *mirGen) discoverFunctions() {
 			continue
 		}
 		fn := glob.Init
-		sig := mirFnSig{retLLVM: g.llvmType(fn.ReturnType), returnType: fn.ReturnType}
+		sig := mirFnSig{retLLVM: g.functionReturnLLVM(fn), returnType: fn.ReturnType}
 		g.functionTypes[fn.Name] = sig
 	}
+}
+
+func (g *mirGen) functionReturnLLVM(fn *mir.Function) string {
+	if fn != nil && fn.Name == "main" && len(fn.Params) == 0 && isUnitType(fn.ReturnType) {
+		return "i32"
+	}
+	return g.llvmType(fn.ReturnType)
 }
 
 // emitGlobalVars writes `@<name> = global <T> zeroinitializer` lines
@@ -3078,6 +3085,11 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 		}
 		g.fnBuf.WriteString("  ]\n")
 	case *mir.ReturnTerm:
+		if g.fn != nil && g.fn.Name == "main" && len(g.fn.Params) == 0 && isUnitType(g.fn.ReturnType) {
+			g.emitGCReleaseRoots()
+			g.fnBuf.WriteString("  ret i32 0\n")
+			return nil
+		}
 		if g.fn.ReturnType == nil || isUnitType(g.fn.ReturnType) {
 			// Release bound roots BEFORE ret so the GC doesn't
 			// scan dead slots for in-flight tail calls on other

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -388,13 +388,12 @@ func TestMIRDualEmitFromSource(t *testing.T) {
 		t.Fatalf("GenerateFromMIR: %v", mirErr)
 	}
 
-	// Both outputs should contain the program's semantic core. The
-	// exact signature for `main` differs between the paths (the HIR
-	// emitter wraps it in a `i32 @main()` C shim while the MIR MVP
-	// emits `void @main()`), so we only assert that SOME `@main`
-	// definition is present and that the core instructions show up.
+	// Both outputs should contain the program's semantic core and a
+	// C-entry-compatible `i32 @main()` so linked binaries exit through
+	// a defined status code instead of inheriting an undefined `void`
+	// main ABI.
 	for name, got := range map[string]string{"HIR": string(hirOut), "MIR": string(mirOut)} {
-		if !strings.Contains(got, "@main") || !strings.Contains(got, "define ") {
+		if !strings.Contains(got, "define i32 @main()") {
 			t.Fatalf("[%s] missing main definition:\n%s", name, got)
 		}
 		if !strings.Contains(got, "icmp") {
@@ -405,6 +404,9 @@ func TestMIRDualEmitFromSource(t *testing.T) {
 		}
 		if !strings.Contains(got, "@printf") {
 			t.Fatalf("[%s] missing printf call:\n%s", name, got)
+		}
+		if !strings.Contains(got, "ret i32 0") {
+			t.Fatalf("[%s] missing C-entry return 0:\n%s", name, got)
 		}
 	}
 }

--- a/internal/stdlib/modules/url.osty
+++ b/internal/stdlib/modules/url.osty
@@ -44,14 +44,14 @@ pub struct Url {
     }
 }
 
-pub fn parse(text: String) -> Result<Url, Error> {
+pub fn parse(text: String) -> Result<Url, error.BasicError> {
     let schemeParts = strings.splitN(text, "://", 2)
     if schemeParts.len() != 2 {
-        return Err(error.new("url: missing scheme in {text}"))
+        return Err(urlError("url: missing scheme in {text}"))
     }
     let scheme = schemeParts[0]
     if scheme.isEmpty() {
-        return Err(error.new("url: empty scheme in {text}"))
+        return Err(urlError("url: empty scheme in {text}"))
     }
     let rest = schemeParts[1]
 
@@ -83,7 +83,7 @@ pub fn parse(text: String) -> Result<Url, Error> {
     })
 }
 
-pub fn join(base: String, relative: String) -> Result<String, Error> {
+pub fn join(base: String, relative: String) -> Result<String, error.BasicError> {
     if relative.isEmpty() {
         return Ok(base)
     }
@@ -115,7 +115,7 @@ pub fn join(base: String, relative: String) -> Result<String, Error> {
     Ok(merged.toString())
 }
 
-fn parseAuthority(authority: String) -> Result<(String, Int?), Error> {
+fn parseAuthority(authority: String) -> Result<(String, Int?), error.BasicError> {
     if authority.isEmpty() {
         return Ok(("", None))
     }
@@ -132,9 +132,9 @@ fn parseAuthority(authority: String) -> Result<(String, Int?), Error> {
     Ok((host, Some(port)))
 }
 
-fn parsePort(s: String) -> Result<Int, Error> {
+fn parsePort(s: String) -> Result<Int, error.BasicError> {
     if s.isEmpty() {
-        return Err(error.new("url: empty port"))
+        return Err(urlError("url: empty port"))
     }
     let chars = s.chars()
     let mut n = 0
@@ -144,14 +144,18 @@ fn parsePort(s: String) -> Result<Int, Error> {
         if c >= '0' && c <= '9' {
             n = n * 10 + (c.toInt() - '0'.toInt())
         } else {
-            return Err(error.new("url: invalid port {s}"))
+            return Err(urlError("url: invalid port {s}"))
         }
         i = i + 1
     }
     if n > 65535 {
-        return Err(error.new("url: port out of range: {s}"))
+        return Err(urlError("url: port out of range: {s}"))
     }
     Ok(n)
+}
+
+fn urlError(message: String) -> error.BasicError {
+    error.BasicError { message: message }
 }
 
 fn parseQuery(s: String) -> Map<String, String> {


### PR DESCRIPTION
## Summary
- harden monomorph fallback rewriting for builtin nongeneric methods so receiver type arguments and return types stay concrete
- fix the `url` stdlib checker path, MIR `main` entry ABI, and bundled runtime scheduler/STW regressions that were keeping backend short runs unstable
- update airepair short-test expectations to match the current change-kind and residual diagnostic classifications

## Why
This branch collects the remaining regressions that were keeping the backend/selfhost stabilization loop from ending in a clean `just short` run. The root causes spanned stale builtin receiver generics during monomorphization, a mismatched `main` ABI in MIR-only binaries, ptr-list reads using the wrong runtime accessor in scheduler helpers, and outdated airepair expectations after recent diagnostic/reporting changes.

## Impact
- `Set<Int>.toList()` and similar builtin receiver method paths now preserve concrete types
- MIR string/bytes binaries return through a proper `i32 @main()` entrypoint
- runtime scheduler `collectAll` / `race` and the STW harness no longer trip list trace-kind mismatches or duplicate buffered stdout
- repo short verification is green again

## Validation
- `go test -count=1 -vet=off ./internal/airepair`
- `go test -count=1 -vet=off -run 'TestAIRepair(TriageSummarizesCapturedReports|LearnJSONRanksCoveredResidualPriority)' ./cmd/osty`
- `go test -count=1 -vet=off -run 'TestMonomorphizeBuiltinListMethodFallbackClearsReceiverTypeArgs|TestMonomorphizeBuiltinOptionalMethodFallbackClearsReceiverTypeArgs|TestMonomorphizeBuiltinMapMethodMissingTemplateClearsReceiverTypeArgs|TestMonomorphizeBuiltinSetMethodFallbackSubstitutesReceiverReturnType|TestMonomorphizeGenericOwnerNonGenericMethodClearsReceiverTypeArgs' ./internal/ir`
- `go test -count=1 -vet=off -run 'TestPhase2cDiagnoseTurbofishSource|TestLLVMBackendBinaryCollectionsUseRuntimeContainers|TestPhase2MonomorphMapReachesGenerateModule|TestStdlibCheckResultStringsModule|TestStdlibCheckResultUrl|TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics|TestLLVMBackendBinaryMIRBackendStringCharsBytes|TestBundledRuntimeSTWAbortsDuringIncremental|TestBundledRuntimeSchedulerCollectAll|TestBundledRuntimeSchedulerRace' ./internal/backend`
- `go test -count=1 -vet=off -run 'TestGenerateMapGetOrComposesOnGetAndCoalesce|TestGenerateMapMapValuesRebuildsWithNewValueType|TestGenerateMapUpdateRunsUnderLock|TestMatchStmtOptionalFromMapGet|TestMIRDualEmitSemanticCoreParity|TestGenerateFromMIRStringChars|TestGenerateFromMIRStringBytes|TestGenerateFromMIRStringLen|TestGenerateFromMIRStringIsEmpty' ./internal/llvmgen`
- `go test -count=1 -vet=off -short ./internal/backend ./internal/ir ./internal/llvmgen`
- `just verify-selfhost`
- `just short`