### PR TITLE
feat: 셀프호스팅 리졸버 annotation arg 검증 (E0739)

### DIFF
--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2052,6 +2052,237 @@ fn srCheckDeclAnnotations(
             continue
         }
         seen.push(name)
+        out = srCheckAnnotationArgs(file, ann, target, out)
     }
     out
+}
+
+/// SrAnnotArgView normalizes the three shapes the parser emits for
+/// annotation args into one record. `#[json(key = "x")]` produces
+/// AstNField_ (keyed value); `#[json(skip)]` produces AstNIdent (bare
+/// flag); `#[export("name")]` produces the raw expression. See
+/// toolchain/parser.osty:1647 `opParseAnnotationArg`.
+struct SrAnnotArgView {
+    key: String,
+    valueIdx: Int,
+    isFlag: Bool,
+    start: Int,
+    end: Int,
+}
+
+fn srAnnotArgView(file: AstFile, argIdx: Int) -> SrAnnotArgView {
+    let arg = srAstNode(file, argIdx)
+    if arg.kind == AstNField_ {
+        return SrAnnotArgView { key: arg.text, valueIdx: arg.left, isFlag: false, start: arg.start, end: arg.end }
+    }
+    if arg.kind == AstNIdent {
+        return SrAnnotArgView { key: arg.text, valueIdx: -1, isFlag: true, start: arg.start, end: arg.end }
+    }
+    SrAnnotArgView { key: "", valueIdx: argIdx, isFlag: false, start: arg.start, end: arg.end }
+}
+
+fn srIsStringLitAtIdx(file: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    srAstNode(file, idx).kind == AstNStringLit
+}
+
+fn srIsFlagOrTrue(file: AstFile, view: SrAnnotArgView) -> Bool {
+    if view.isFlag {
+        return true
+    }
+    if view.valueIdx < 0 {
+        return true
+    }
+    let v = srAstNode(file, view.valueIdx)
+    v.kind == AstNBoolLit && v.flags == 1
+}
+
+fn srPushBadArg(
+    result: SelfResolveResult,
+    message: String,
+    start: Int,
+    end: Int,
+) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnostic("E0739", message, "", start, end))
+    out
+}
+
+fn srPushUnknownArg(
+    result: SelfResolveResult,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfResolveResult {
+    // Matches the Go resolver's quirk: unknown annotation-arg keys are
+    // emitted as E0400 (CodeUnknownAnnotation), not E0739. See
+    // internal/resolve/resolve.go:711.
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnostic("E0400", message, name, start, end))
+    out
+}
+
+/// srCheckAnnotationArgs dispatches to the per-annotation argument
+/// validator. Only runs on allowed + non-duplicate annotations. Mirrors
+/// the Go resolver's `checkAnnotationArgs` (internal/resolve/resolve.go:546).
+fn srCheckAnnotationArgs(
+    file: AstFile,
+    ann: AstNode,
+    target: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if ann.text == "json" { return srCheckJSONArgs(file, ann, target, result) }
+    if ann.text == "deprecated" { return srCheckDeprecatedArgs(file, ann, result) }
+    if ann.text == "repr" { return srCheckReprArgs(file, ann, result) }
+    if ann.text == "export" { return srCheckExportArgs(file, ann, result) }
+    if ann.text == "intrinsic" || ann.text == "pod" || ann.text == "c_abi" || ann.text == "no_alloc" {
+        return srCheckNoArgsRuntime(file, ann, result)
+    }
+    result
+}
+
+fn srCheckJSONArgs(
+    file: AstFile,
+    ann: AstNode,
+    target: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let mut hasKey = false
+    let mut hasSkip = false
+    let mut hasOptional = false
+    for argIdx in ann.children {
+        let view = srAnnotArgView(file, argIdx)
+        if view.key == "key" {
+            hasKey = true
+            if !srIsStringLitAtIdx(file, view.valueIdx) {
+                out = srPushBadArg(out, "`#[json(key = ...)]` requires a string literal", view.start, view.end)
+            }
+        } else if view.key == "skip" {
+            hasSkip = true
+            if !srIsFlagOrTrue(file, view) {
+                out = srPushBadArg(out, "`#[json(skip)]` takes no value or `skip = true`", view.start, view.end)
+            }
+        } else if view.key == "optional" {
+            hasOptional = true
+            if target != srAnnotTargetField() {
+                out = srPushBadArg(out, "`#[json(optional)]` is only valid on struct fields", view.start, view.end)
+            }
+            if !srIsFlagOrTrue(file, view) {
+                out = srPushBadArg(out, "`#[json(optional)]` takes no value or `optional = true`", view.start, view.end)
+            }
+        } else {
+            out = srPushUnknownArg(out, "`#[json]` does not accept argument `" + view.key + "`", view.key, view.start, view.end)
+        }
+    }
+    if hasSkip && (hasKey || hasOptional) {
+        out = srPushBadArg(out, "`skip` is mutually exclusive with `key` and `optional`", ann.start, ann.end)
+    }
+    out
+}
+
+fn srCheckDeprecatedArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    for argIdx in ann.children {
+        let view = srAnnotArgView(file, argIdx)
+        if view.key == "since" || view.key == "use" || view.key == "message" {
+            if view.valueIdx < 0 || !srIsStringLitAtIdx(file, view.valueIdx) {
+                out = srPushUnknownArg(
+                    out,
+                    "`#[deprecated(" + view.key + " = ...)]` requires a string literal",
+                    view.key,
+                    view.start,
+                    view.end,
+                )
+            }
+        } else {
+            out = srPushUnknownArg(
+                out,
+                "`#[deprecated]` does not accept argument `" + view.key + "`",
+                view.key,
+                view.start,
+                view.end,
+            )
+        }
+    }
+    out
+}
+
+fn srCheckReprArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let args = ann.children
+    let n = args.len()
+    if n == 0 {
+        return srPushBadArg(out, "`#[repr]` requires a layout argument", ann.start, ann.end)
+    }
+    if n > 1 {
+        let extra = srAnnotArgView(file, args[1])
+        out = srPushBadArg(out, "`#[repr]` accepts exactly one argument", extra.start, extra.end)
+    }
+    let view = srAnnotArgView(file, args[0])
+    if !view.isFlag {
+        return srPushBadArg(out, "`#[repr]` takes a bare-flag argument, not a value", view.start, view.end)
+    }
+    if view.key != "c" {
+        out = srPushBadArg(out, "`#[repr(" + view.key + ")]` is not a recognized layout", view.start, view.end)
+    }
+    out
+}
+
+fn srCheckExportArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let args = ann.children
+    let n = args.len()
+    if n == 0 {
+        return srPushBadArg(out, "`#[export]` requires a symbol-name argument", ann.start, ann.end)
+    }
+    if n > 1 {
+        let extra = srAnnotArgView(file, args[1])
+        out = srPushBadArg(out, "`#[export]` accepts exactly one argument", extra.start, extra.end)
+    }
+    let view = srAnnotArgView(file, args[0])
+    if view.key != "" {
+        return srPushBadArg(
+            out,
+            "`#[export]` takes a positional string literal, not a key-value argument",
+            view.start,
+            view.end,
+        )
+    }
+    if !srIsStringLitAtIdx(file, view.valueIdx) {
+        return srPushBadArg(out, "`#[export]` requires a string literal argument", view.start, view.end)
+    }
+    out
+}
+
+fn srCheckNoArgsRuntime(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if ann.children.len() == 0 {
+        return result
+    }
+    let first = srAnnotArgView(file, ann.children[0])
+    srPushBadArg(
+        result,
+        "`#[" + ann.text + "]` does not take arguments",
+        first.start,
+        first.end,
+    )
 }

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -539,3 +539,128 @@ fn testSelfResolverChecksAnnotationsOnStructMembers() {
 
     testing.assertEq(selfResolveCodeCount(result, "E0607"), 2)
 }
+
+fn testSelfResolverRejectsJSONBadKeyType() {
+    // `#[json(key = 123)]` — value must be a string literal. E0739.
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(key = 123)]
+                x: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsJSONUnknownArg() {
+    // Unknown arg keys in `#[json]` are reported as E0400 to match the
+    // Go resolver's existing quirk (CodeUnknownAnnotation for arg keys).
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(bogus = "x")]
+                x: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+}
+
+fn testSelfResolverRejectsJSONMutuallyExclusive() {
+    // `skip` plus `key`/`optional` is a spec violation. E0739.
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(skip, key = "x")]
+                internal: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsJSONOptionalOnVariant() {
+    // `optional` is struct-field-only. On an enum variant it's E0739.
+    let result = selfResolveSource(
+        r"""
+            enum Color {
+                #[json(optional)]
+                Red,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsReprMissingArg() {
+    let result = selfResolveSource(
+        r"""
+            #[repr]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsReprUnknownLayout() {
+    let result = selfResolveSource(
+        r"""
+            #[repr(packed)]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverAcceptsReprC() {
+    let result = selfResolveSource(
+        r"""
+            #[repr(c)]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 0)
+}
+
+fn testSelfResolverRejectsExportWithoutSymbol() {
+    let result = selfResolveSource(
+        r"""
+            #[export]
+            fn entry() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsExportWithKey() {
+    // `#[export(name = "x")]` is wrong — export takes a positional string.
+    let result = selfResolveSource(
+        r"""
+            #[export(name = "sym")]
+            fn entry() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsNoArgsRuntimeWithArgs() {
+    // `#[pod]` and friends are bare flags; any argument is E0739.
+    let result = selfResolveSource(
+        r"""
+            #[pod(c)]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}


### PR DESCRIPTION
## 무엇

[#571](https://github.com/choiceoh/osty/pull/571) 이 annotation 이름/target/중복을 잡았다면, 이 PR 은 **arg 쉐입**까지 Go 리졸버의 `checkAnnotationArgs` ([internal/resolve/resolve.go:546](internal/resolve/resolve.go:546)) 와 동기합니다.

- `E0739` (annotation-bad-arg) 경로 전반

## 왜

`#[json(key = 123)]`, `#[repr(packed)]`, `#[export(name = "x")]` 같은 잘못된 arg 는 지금까지 셀프호스팅 리졸버를 조용히 통과했습니다. Go 리졸버는 ~200 LOC 에 걸쳐 per-annotation 으로 검증하는데, 이 PR 이 같은 규칙을 셀프호스트 쪽에 가져옵니다.

## 검증 규칙

| Annotation | 규칙 |
|---|---|
| `#[json]` | `key="<str>"`, `skip`/`optional` 플래그, `optional` 은 struct field 전용, `skip` 은 `key`/`optional` 와 상호배타. 알 수 없는 arg 키는 E0400 (Go quirk 미러) |
| `#[deprecated]` | `since`/`use`/`message` 모두 옵셔널, 각각 string literal |
| `#[repr]` | 정확히 1개의 bare flag `c` |
| `#[export]` | 정확히 1개의 positional string literal |
| `#[intrinsic]` / `#[pod]` / `#[c_abi]` / `#[no_alloc]` | 인자 없음 |

## 인프라

- `SrAnnotArgView` — 파서의 3가지 arg 쉐입(AstNField_ keyed / AstNIdent bare flag / 순수 expr positional) 을 하나의 뷰로 정규화
- `srIsStringLitAtIdx` / `srIsFlagOrTrue` — 타입 가드
- `srCheckAnnotationArgs(file, ann, target, result)` — `ann.text` 에 따라 5개 validator 로 dispatch. 기존 `srCheckDeclAnnotations` 가 allowed + non-dup 로 통과한 annotation 에 한해서만 호출

## 테스트

`toolchain/resolve_test.osty` 에 10개 포커스 테스트:
- json: bad key type, unknown arg, mutually exclusive, optional on variant
- repr: missing arg, unknown layout, valid `#[repr(c)]`
- export: missing symbol, keyed form
- no-args-runtime: `#[pod(c)]` → E0739

## 베이스 브랜치

이 PR 은 [#571](https://github.com/choiceoh/osty/pull/571) 위에 쌓입니다 (같은 `srCheckDeclAnnotations` 인프라를 확장). `#571` 이 main 으로 머지되면 base 를 main 으로 다시 가리키겠습니다.

## 검증

- [x] `just front` — Go 리졸버 스펙 코퍼스 회귀 없음
- [x] `TestToolchainCheckerSourcesTranspile` — bootstrap-gen 트랜스파일 통과
- [ ] `osty test toolchain/resolve_test.osty` — 사전 존재하는 IR lowering panic ([internal/ir/lower.go:1043](internal/ir/lower.go:1043)) 으로 불가 — 이 PR 범위 외

🤖 Generated with [Claude Code](https://claude.com/claude-code)