### PR TITLE
feat: 셀프호스팅 리졸버 wildcard-in-expr 검증 (E0604)

### DIFF
--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -1037,6 +1037,14 @@ fn srResolveOneAstIdent(
     result: SelfResolveResult,
 ) -> SelfResolveResult {
     let mut out = result
+    if name == "_" {
+        // `_` is a pattern wildcard; in an expression it is never a value.
+        // The parser rejects it at the token level too (E0604), but we
+        // emit here to match Go's resolver contract and to suppress the
+        // misleading "undefined name `_`" that the normal lookup path
+        // would otherwise produce.
+        return srWildcardInExprAtNode(out, start, end, node)
+    }
     if srIsBuiltinName(name) {
         return out
     }
@@ -1186,6 +1194,20 @@ fn srSelfOutsideAtNode(result: SelfResolveResult, start: Int, end: Int, node: In
 fn srSelfTypeOutsideAtNode(result: SelfResolveResult, start: Int, end: Int, node: Int) -> SelfResolveResult {
     let mut out = result
     out.diagnostics.push(selfResolveDiagnosticAtNode("E0504", "`Self` outside type body", "Self", start, end, node))
+    out
+}
+
+fn srWildcardInExprAtNode(result: SelfResolveResult, start: Int, end: Int, node: Int) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnosticHintAtNode(
+        "E0604",
+        "`_` is only valid as a pattern wildcard, not as an expression",
+        "_",
+        start,
+        end,
+        node,
+        "use `let _ = expr` to ignore a value",
+    ))
     out
 }
 

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -539,3 +539,41 @@ fn testSelfResolverChecksAnnotationsOnStructMembers() {
 
     testing.assertEq(selfResolveCodeCount(result, "E0607"), 2)
 }
+
+fn testSelfResolverRejectsWildcardInExpr() {
+    // `_` as a value is E0604 — the wildcard belongs in pattern position.
+    // Also verifies we suppress the misleading "undefined name `_`"
+    // (E0500) that the normal lookup path would otherwise produce.
+    let result = selfResolveSource(
+        r"""
+            fn main() -> Int {
+                let x = _ + 1
+                x
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0604"), 1)
+    testing.assertEq(selfResolveCodeCount(result, "E0500"), 0)
+}
+
+fn testSelfResolverAcceptsWildcardInPattern() {
+    // `_` in pattern position — `let _ =` and match arm — is legal.
+    // Parser encodes these as AstNPattern/wildcardKind, so the ident
+    // resolver never sees them.
+    let result = selfResolveSource(
+        r"""
+            fn main() {
+                let _ = compute()
+                match tag() {
+                    _ -> (),
+                }
+            }
+
+            fn compute() -> Int { 42 }
+            fn tag() -> Int { 0 }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0604"), 0)
+}


### PR DESCRIPTION
## 무엇

Go 리졸버의 [resolveIdent](internal/resolve/resolve.go:1389) 가 잡는 `_` in expression position 을 셀프호스팅 리졸버에도 동기합니다.

- `E0604` (wildcard-in-expr) — `let x = _ + 1` 류를 정확한 메시지로 잡음

## 왜

이전까지 셀프호스팅 리졸버는 `let x = _ + 1` 같은 코드를 만나면 일반 lookup 경로로 빠져 ``E0500: undefined name `_` `` 을 발화했습니다. 이는 사용자에게 오도성 있는 메시지 — 문제는 "undefined" 가 아니라 "wildcard 를 value 로 쓸 수 없음" 입니다.

Go 리졸버는 `resolveIdent` 진입 지점에서 `_` 를 가로채 E0604 와 hint (`` use `let _ = expr` to ignore a value ``) 를 emit 하는데, 셀프호스팅 쪽은 이 체크가 누락되어 있었습니다.

## 어떻게

`srResolveOneAstIdent` 초입에 `if name == "_"` 체크 추가 → `srWildcardInExprAtNode` 로 E0604 + hint 를 push 하고 early-return.

패턴 와일드카드는 파서가 `AstNPattern` + `astPatternWildcardKind()` 로 인코딩하므로 이 ident 경로를 타지 않아 오발동 위험 없음 — 테스트로 확인.

## 테스트

`toolchain/resolve_test.osty` 에 2개:
- `testSelfResolverRejectsWildcardInExpr` — `let x = _ + 1` → E0604 ×1, E0500 ×0 (기존 오도성 메시지가 뜨지 않음을 재확인)
- `testSelfResolverAcceptsWildcardInPattern` — `let _ = f()` 와 `match ... { _ -> ... }` → E0604 ×0

## 검증

- [x] `just front` — Go 리졸버 스펙 코퍼스 회귀 없음
- [x] `TestToolchainCheckerSourcesTranspile` — bootstrap-gen 트랜스파일 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)