### PR TITLE
feat(llvmgen): accept interface / struct / container enum payloads via runtime ABI fallback

### DIFF
--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -191,17 +191,31 @@ func llvmEnumPayloadType(t ast.Type, env typeEnv) (string, error) {
 		named = resolvedNamed
 		ok = true
 	}
-	if !ok {
-		return "", unsupported("type-system", "LLVM enum payloads currently support Int or Float only")
+	if ok {
+		name := ""
+		if len(named.Path) == 1 {
+			name = named.Path[0]
+		}
+		if typ := llvmEnumPayloadNamedType(name, len(named.Path), len(named.Args)); typ != "" {
+			return typ, nil
+		}
 	}
-	name := ""
-	if len(named.Path) == 1 {
-		name = named.Path[0]
+	// Fall through to the runtime-ABI mapping so interface, struct,
+	// enum, and container payload types all get a well-defined LLVM
+	// representation. Canonical motivating case: `Result<T, Error>`
+	// after `injectReachableStdlibTypes` — `Err` carries an `Error`
+	// interface payload which the primitive table doesn't list but
+	// the rest of the backend already passes around as
+	// `%osty.iface`. Tuples / Optional / Fn types fold into `ptr` the
+	// same way a runtime-ABI boundary treats them.
+	abi, err := llvmRuntimeABIType(resolved, env)
+	if err != nil {
+		return "", err
 	}
-	if typ := llvmEnumPayloadNamedType(name, len(named.Path), len(named.Args)); typ != "" {
-		return typ, nil
+	if abi == "" || abi == "void" {
+		return "", unsupported("type-system", "LLVM enum payloads currently support primitives (Int / Float / Char / Byte / String), interfaces, structs, enums, and container / tuple / Optional / Fn types — got an empty runtime-ABI projection")
 	}
-	return "", unsupported("type-system", "LLVM enum payloads currently support Int, Float, or String only")
+	return abi, nil
 }
 
 func (g *generator) structInfoForExpr(expr ast.Expr) (*structInfo, string, error) {


### PR DESCRIPTION
## Summary

`llvmEnumPayloadType` hard-coded a primitive whitelist (Int / Float / Char / Byte / String); every other payload tripped `LLVM011 enum payloads currently support Int, Float, or String only`. Stdlib-body injection surfaced the canonical gap: specializing `Result<T, Error>` under `OSTY_STDLIB_BODY_LOWER=1` queues an `Err` variant carrying the `Error` interface — which the primitive table can't spell, yet the rest of the backend already passes interface values around as `%osty.iface` fat pointers.

## How

Fall back to `llvmRuntimeABIType` after the primitive lookup misses. That mapping already resolves interfaces to `%osty.iface`, user structs / enums to their `%Name` struct type, and Optional / Tuple / Fn types to `ptr`. The existing emission pipeline (payload slot typing, variant ordering, Phase 2 boxing) picks the new type up without further changes — it already handled heterogeneous payloads through the `isBoxed` path when slot types disagreed.

## Regression impact

`OSTY_STDLIB_BODY_LOWER=1` serial backend suite (clean cache): **12 → 7 failures**. Tests that pass now (either from this fix directly or because reduced flakiness lets pre-existing runtime cases complete within the serial window):

- `TestStdlibCheckResultUrl`
- `TestLLVMBackendEmitBinaryBuildsBundledRuntime`
- `TestLLVMBackendBinaryRunsBundledRuntime`
- `TestLLVMBackendBinarySafepointsKeepManagedRootsAlive`
- `TestLLVMBackendBinaryExtendedListSortedAndToSet`
- `TestLLVMBackendBinaryMIRBackendStringCharsBytes`
- `TestBundledRuntimeSchedulerRace`
- `TestBundledRuntimeSchedulerCollectAll`
- `TestBundledRuntimeSTWAbortsDuringIncremental`

Baseline flag-on tests still pass: `TestLLVMBackendEmitStringsCompareFlagOn`, `TestPrepareEntryInjectsStdlibWhenFlagOn`, `TestInjectedMapTypeMonomorphizes`.

## Remaining flag-on blockers

- `TestLLVMBackendBinaryBuiltinResultFieldConstructors` / `TestLLVMBackendBinaryBuiltinResultConstructorsTrackLocalContext` — now hit the next wall: `LLVM011 match scrutinee type ptr, want enum tag`. The specialized `Result<Int, Error>` is stored as a ptr when it appears as a struct field / call-site return; match dispatch needs to load the enum tag through that indirection.
- `TestLLVMBackendBinaryManagedAggregateContainersSurvivePressureGC` — aggregate struct pass-by-value in fn args.
- `TestLLVMBackendBinaryPtrBackedListToSetAndBoolPrint` — deferred specialized `List<T>.fold` FieldExpr dispatch.
- `TestLLVMBackendBinaryCollectionsUseRuntimeContainers` — pre-existing baseline failure.

Each is a separate follow-up before the default flag can safely flip.

## Test plan

- [x] `go test ./internal/llvmgen/ -short -timeout 300s` — no new regressions (one pre-existing `TestGenerateMapGetBoolValueUses1ByteBox` unchanged)
- [x] `go test ./internal/backend/ -run 'TestLLVMBackendEmitStringsCompareFlagOn|TestPrepareEntryInjectsStdlibWhenFlagOn|TestInjectedMapTypeMonomorphizes'` — all pass
- [x] `go test ./internal/backend/ -count=1 -p 1 -timeout 600s` under `OSTY_STDLIB_BODY_LOWER=1` — 12 → 7 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)