### PR TITLE
feat: 셀프호스팅 리졸버 — E0739 복구 + did-you-mean 힌트

### DIFF
--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -2074,6 +2074,237 @@ fn srCheckDeclAnnotations(
             continue
         }
         seen.push(name)
+        out = srCheckAnnotationArgs(file, ann, target, out)
     }
     out
+}
+
+/// SrAnnotArgView normalizes the three shapes the parser emits for
+/// annotation args into one record. `#[json(key = "x")]` produces
+/// AstNField_ (keyed value); `#[json(skip)]` produces AstNIdent (bare
+/// flag); `#[export("name")]` produces the raw expression. See
+/// toolchain/parser.osty:1647 `opParseAnnotationArg`.
+struct SrAnnotArgView {
+    key: String,
+    valueIdx: Int,
+    isFlag: Bool,
+    start: Int,
+    end: Int,
+}
+
+fn srAnnotArgView(file: AstFile, argIdx: Int) -> SrAnnotArgView {
+    let arg = srAstNode(file, argIdx)
+    if arg.kind == AstNField_ {
+        return SrAnnotArgView { key: arg.text, valueIdx: arg.left, isFlag: false, start: arg.start, end: arg.end }
+    }
+    if arg.kind == AstNIdent {
+        return SrAnnotArgView { key: arg.text, valueIdx: -1, isFlag: true, start: arg.start, end: arg.end }
+    }
+    SrAnnotArgView { key: "", valueIdx: argIdx, isFlag: false, start: arg.start, end: arg.end }
+}
+
+fn srIsStringLitAtIdx(file: AstFile, idx: Int) -> Bool {
+    if idx < 0 {
+        return false
+    }
+    srAstNode(file, idx).kind == AstNStringLit
+}
+
+fn srIsFlagOrTrue(file: AstFile, view: SrAnnotArgView) -> Bool {
+    if view.isFlag {
+        return true
+    }
+    if view.valueIdx < 0 {
+        return true
+    }
+    let v = srAstNode(file, view.valueIdx)
+    v.kind == AstNBoolLit && v.flags == 1
+}
+
+fn srPushBadArg(
+    result: SelfResolveResult,
+    message: String,
+    start: Int,
+    end: Int,
+) -> SelfResolveResult {
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnostic("E0739", message, "", start, end))
+    out
+}
+
+fn srPushUnknownArg(
+    result: SelfResolveResult,
+    message: String,
+    name: String,
+    start: Int,
+    end: Int,
+) -> SelfResolveResult {
+    // Matches the Go resolver's quirk: unknown annotation-arg keys are
+    // emitted as E0400 (CodeUnknownAnnotation), not E0739. See
+    // internal/resolve/resolve.go:711.
+    let mut out = result
+    out.diagnostics.push(selfResolveDiagnostic("E0400", message, name, start, end))
+    out
+}
+
+/// srCheckAnnotationArgs dispatches to the per-annotation argument
+/// validator. Only runs on allowed + non-duplicate annotations. Mirrors
+/// the Go resolver's `checkAnnotationArgs` (internal/resolve/resolve.go:546).
+fn srCheckAnnotationArgs(
+    file: AstFile,
+    ann: AstNode,
+    target: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if ann.text == "json" { return srCheckJSONArgs(file, ann, target, result) }
+    if ann.text == "deprecated" { return srCheckDeprecatedArgs(file, ann, result) }
+    if ann.text == "repr" { return srCheckReprArgs(file, ann, result) }
+    if ann.text == "export" { return srCheckExportArgs(file, ann, result) }
+    if ann.text == "intrinsic" || ann.text == "pod" || ann.text == "c_abi" || ann.text == "no_alloc" {
+        return srCheckNoArgsRuntime(file, ann, result)
+    }
+    result
+}
+
+fn srCheckJSONArgs(
+    file: AstFile,
+    ann: AstNode,
+    target: Int,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let mut hasKey = false
+    let mut hasSkip = false
+    let mut hasOptional = false
+    for argIdx in ann.children {
+        let view = srAnnotArgView(file, argIdx)
+        if view.key == "key" {
+            hasKey = true
+            if !srIsStringLitAtIdx(file, view.valueIdx) {
+                out = srPushBadArg(out, "`#[json(key = ...)]` requires a string literal", view.start, view.end)
+            }
+        } else if view.key == "skip" {
+            hasSkip = true
+            if !srIsFlagOrTrue(file, view) {
+                out = srPushBadArg(out, "`#[json(skip)]` takes no value or `skip = true`", view.start, view.end)
+            }
+        } else if view.key == "optional" {
+            hasOptional = true
+            if target != srAnnotTargetField() {
+                out = srPushBadArg(out, "`#[json(optional)]` is only valid on struct fields", view.start, view.end)
+            }
+            if !srIsFlagOrTrue(file, view) {
+                out = srPushBadArg(out, "`#[json(optional)]` takes no value or `optional = true`", view.start, view.end)
+            }
+        } else {
+            out = srPushUnknownArg(out, "`#[json]` does not accept argument `" + view.key + "`", view.key, view.start, view.end)
+        }
+    }
+    if hasSkip && (hasKey || hasOptional) {
+        out = srPushBadArg(out, "`skip` is mutually exclusive with `key` and `optional`", ann.start, ann.end)
+    }
+    out
+}
+
+fn srCheckDeprecatedArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    for argIdx in ann.children {
+        let view = srAnnotArgView(file, argIdx)
+        if view.key == "since" || view.key == "use" || view.key == "message" {
+            if view.valueIdx < 0 || !srIsStringLitAtIdx(file, view.valueIdx) {
+                out = srPushUnknownArg(
+                    out,
+                    "`#[deprecated(" + view.key + " = ...)]` requires a string literal",
+                    view.key,
+                    view.start,
+                    view.end,
+                )
+            }
+        } else {
+            out = srPushUnknownArg(
+                out,
+                "`#[deprecated]` does not accept argument `" + view.key + "`",
+                view.key,
+                view.start,
+                view.end,
+            )
+        }
+    }
+    out
+}
+
+fn srCheckReprArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let args = ann.children
+    let n = args.len()
+    if n == 0 {
+        return srPushBadArg(out, "`#[repr]` requires a layout argument", ann.start, ann.end)
+    }
+    if n > 1 {
+        let extra = srAnnotArgView(file, args[1])
+        out = srPushBadArg(out, "`#[repr]` accepts exactly one argument", extra.start, extra.end)
+    }
+    let view = srAnnotArgView(file, args[0])
+    if !view.isFlag {
+        return srPushBadArg(out, "`#[repr]` takes a bare-flag argument, not a value", view.start, view.end)
+    }
+    if view.key != "c" {
+        out = srPushBadArg(out, "`#[repr(" + view.key + ")]` is not a recognized layout", view.start, view.end)
+    }
+    out
+}
+
+fn srCheckExportArgs(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    let mut out = result
+    let args = ann.children
+    let n = args.len()
+    if n == 0 {
+        return srPushBadArg(out, "`#[export]` requires a symbol-name argument", ann.start, ann.end)
+    }
+    if n > 1 {
+        let extra = srAnnotArgView(file, args[1])
+        out = srPushBadArg(out, "`#[export]` accepts exactly one argument", extra.start, extra.end)
+    }
+    let view = srAnnotArgView(file, args[0])
+    if view.key != "" {
+        return srPushBadArg(
+            out,
+            "`#[export]` takes a positional string literal, not a key-value argument",
+            view.start,
+            view.end,
+        )
+    }
+    if !srIsStringLitAtIdx(file, view.valueIdx) {
+        return srPushBadArg(out, "`#[export]` requires a string literal argument", view.start, view.end)
+    }
+    out
+}
+
+fn srCheckNoArgsRuntime(
+    file: AstFile,
+    ann: AstNode,
+    result: SelfResolveResult,
+) -> SelfResolveResult {
+    if ann.children.len() == 0 {
+        return result
+    }
+    let first = srAnnotArgView(file, ann.children[0])
+    srPushBadArg(
+        result,
+        "`#[" + ann.text + "]` does not take arguments",
+        first.start,
+        first.end,
+    )
 }

--- a/toolchain/resolve.osty
+++ b/toolchain/resolve.osty
@@ -1752,24 +1752,11 @@ fn srUndefinedHint(scope: SelfResolveScope, name: String) -> String {
 }
 
 fn srSuggestSimilar(scope: SelfResolveScope, name: String) -> String {
-    let mut best = ""
-    let mut bestDist = 3
-    let nameLen = srStringUnitCount(name)
+    let mut names: List<String> = []
     for sym in scope.symbols {
-        let diff = srStringUnitCount(sym.name) - nameLen
-        if diff > bestDist - 1 || 0 - diff > bestDist - 1 {
-            continue
-        }
-        let dist = srLevenshteinBounded(name, sym.name, bestDist)
-        if dist < bestDist {
-            best = sym.name
-            bestDist = dist
-            if bestDist == 1 {
-                return best
-            }
-        }
+        names.push(sym.name)
     }
-    best
+    srSuggestFromList(name, names)
 }
 
 fn srLevenshteinBounded(left: String, right: String, limit: Int) -> Int {
@@ -2017,7 +2004,7 @@ fn srCollectAnnotationNodes(file: AstFile, extraIdx: Int) -> List<AstNode> {
 
 /// srCheckDeclAnnotations validates the annotations attached to a single
 /// declaration (or member) against v0.4 §18.1:
-///   - unknown names → E0400
+///   - unknown names → E0400 (with did-you-mean hint)
 ///   - wrong target kind → E0607
 ///   - same name twice on one target → E0609
 fn srCheckDeclAnnotations(
@@ -2037,12 +2024,14 @@ fn srCheckDeclAnnotations(
     for ann in anns {
         let name = ann.text
         if !srIsAllowedAnnotation(name) {
-            out.diagnostics.push(selfResolveDiagnostic(
+            out.diagnostics.push(selfResolveDiagnosticHintAtNode(
                 "E0400",
                 "unknown annotation `#[" + name + "]`",
                 name,
                 ann.start,
                 ann.end,
+                -1,
+                srDidYouMeanHint(name, srAnnotationNameList()),
             ))
             continue
         }
@@ -2138,12 +2127,23 @@ fn srPushUnknownArg(
     name: String,
     start: Int,
     end: Int,
+    hint: String,
 ) -> SelfResolveResult {
     // Matches the Go resolver's quirk: unknown annotation-arg keys are
     // emitted as E0400 (CodeUnknownAnnotation), not E0739. See
-    // internal/resolve/resolve.go:711.
+    // internal/resolve/resolve.go:711. The `hint` field carries the
+    // did-you-mean suggestion (empty if none) — this is a strict
+    // improvement over Go, which emits no suggestion.
     let mut out = result
-    out.diagnostics.push(selfResolveDiagnostic("E0400", message, name, start, end))
+    out.diagnostics.push(selfResolveDiagnosticHintAtNode(
+        "E0400",
+        message,
+        name,
+        start,
+        end,
+        -1,
+        hint,
+    ))
     out
 }
 
@@ -2197,7 +2197,14 @@ fn srCheckJSONArgs(
                 out = srPushBadArg(out, "`#[json(optional)]` takes no value or `optional = true`", view.start, view.end)
             }
         } else {
-            out = srPushUnknownArg(out, "`#[json]` does not accept argument `" + view.key + "`", view.key, view.start, view.end)
+            out = srPushUnknownArg(
+                out,
+                "`#[json]` does not accept argument `" + view.key + "`",
+                view.key,
+                view.start,
+                view.end,
+                srDidYouMeanHint(view.key, srJSONArgKeys()),
+            )
         }
     }
     if hasSkip && (hasKey || hasOptional) {
@@ -2222,6 +2229,7 @@ fn srCheckDeprecatedArgs(
                     view.key,
                     view.start,
                     view.end,
+                    "",
                 )
             }
         } else {
@@ -2231,6 +2239,7 @@ fn srCheckDeprecatedArgs(
                 view.key,
                 view.start,
                 view.end,
+                srDidYouMeanHint(view.key, srDeprecatedArgKeys()),
             )
         }
     }
@@ -2307,4 +2316,69 @@ fn srCheckNoArgsRuntime(
         first.start,
         first.end,
     )
+}
+
+/// srAnnotationNameList returns the 14 permitted annotation names as a
+/// flat list for did-you-mean suggestions. Keep in sync with the
+/// `srAnnotAllowedTargets` switch.
+fn srAnnotationNameList() -> List<String> {
+    [
+        "json",
+        "deprecated",
+        "allow",
+        "intrinsic_methods",
+        "requires",
+        "no_alloc",
+        "intrinsic",
+        "c_abi",
+        "export",
+        "pod",
+        "repr",
+        "cfg",
+        "op",
+        "test",
+    ]
+}
+
+fn srJSONArgKeys() -> List<String> {
+    ["key", "skip", "optional"]
+}
+
+fn srDeprecatedArgKeys() -> List<String> {
+    ["since", "use", "message"]
+}
+
+/// srSuggestFromList finds the closest candidate (Levenshtein distance
+/// < 3) from a fixed list. Returns "" if nothing is within reach. This
+/// is the typo-suggestion primitive for annotation names and arg keys —
+/// unlike Go's resolver, which emits unknown-annotation errors with no
+/// spelling hints, the self-hosted version nudges the user toward the
+/// right spelling.
+fn srSuggestFromList(name: String, candidates: List<String>) -> String {
+    let mut best = ""
+    let mut bestDist = 3
+    let nameLen = srStringUnitCount(name)
+    for candidate in candidates {
+        let diff = srStringUnitCount(candidate) - nameLen
+        if diff > bestDist - 1 || 0 - diff > bestDist - 1 {
+            continue
+        }
+        let dist = srLevenshteinBounded(name, candidate, bestDist)
+        if dist < bestDist {
+            best = candidate
+            bestDist = dist
+            if bestDist == 1 {
+                return best
+            }
+        }
+    }
+    best
+}
+
+fn srDidYouMeanHint(name: String, candidates: List<String>) -> String {
+    let suggestion = srSuggestFromList(name, candidates)
+    if suggestion == "" {
+        return ""
+    }
+    "did you mean `{suggestion}`?"
 }

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -577,3 +577,128 @@ fn testSelfResolverAcceptsWildcardInPattern() {
 
     testing.assertEq(selfResolveCodeCount(result, "E0604"), 0)
 }
+
+fn testSelfResolverRejectsJSONBadKeyType() {
+    // `#[json(key = 123)]` — value must be a string literal. E0739.
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(key = 123)]
+                x: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsJSONUnknownArg() {
+    // Unknown arg keys in `#[json]` are reported as E0400 to match the
+    // Go resolver's existing quirk (CodeUnknownAnnotation for arg keys).
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(bogus = "x")]
+                x: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+}
+
+fn testSelfResolverRejectsJSONMutuallyExclusive() {
+    // `skip` plus `key`/`optional` is a spec violation. E0739.
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(skip, key = "x")]
+                internal: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsJSONOptionalOnVariant() {
+    // `optional` is struct-field-only. On an enum variant it's E0739.
+    let result = selfResolveSource(
+        r"""
+            enum Color {
+                #[json(optional)]
+                Red,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsReprMissingArg() {
+    let result = selfResolveSource(
+        r"""
+            #[repr]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsReprUnknownLayout() {
+    let result = selfResolveSource(
+        r"""
+            #[repr(packed)]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverAcceptsReprC() {
+    let result = selfResolveSource(
+        r"""
+            #[repr(c)]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 0)
+}
+
+fn testSelfResolverRejectsExportWithoutSymbol() {
+    let result = selfResolveSource(
+        r"""
+            #[export]
+            fn entry() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsExportWithKey() {
+    // `#[export(name = "x")]` is wrong — export takes a positional string.
+    let result = selfResolveSource(
+        r"""
+            #[export(name = "sym")]
+            fn entry() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}
+
+fn testSelfResolverRejectsNoArgsRuntimeWithArgs() {
+    // `#[pod]` and friends are bare flags; any argument is E0739.
+    let result = selfResolveSource(
+        r"""
+            #[pod(c)]
+            struct Raw { x: Int }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
+}

--- a/toolchain/resolve_test.osty
+++ b/toolchain/resolve_test.osty
@@ -702,3 +702,80 @@ fn testSelfResolverRejectsNoArgsRuntimeWithArgs() {
 
     testing.assertEq(selfResolveCodeCount(result, "E0739"), 1)
 }
+
+fn testSelfResolverSuggestsAnnotationName() {
+    // `#[deprcated]` — one-char typo for `deprecated`. Go emits E0400
+    // with no hint; self-hosted adds a did-you-mean suggestion.
+    let result = selfResolveSource(
+        r"""
+            #[deprcated]
+            fn old() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+    let mut sawHint = false
+    for diag in result.diagnostics {
+        if diag.code == "E0400" && diag.hint == "did you mean `deprecated`?" {
+            sawHint = true
+        }
+    }
+    testing.assert(sawHint)
+}
+
+fn testSelfResolverSuggestsJSONArgKey() {
+    // `ky` typo for `key` — hint should point to the correct spelling.
+    let result = selfResolveSource(
+        r"""
+            struct Point {
+                #[json(ky = "x")]
+                x: Int,
+            }
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+    let mut sawHint = false
+    for diag in result.diagnostics {
+        if diag.code == "E0400" && diag.hint == "did you mean `key`?" {
+            sawHint = true
+        }
+    }
+    testing.assert(sawHint)
+}
+
+fn testSelfResolverSuggestsDeprecatedArgKey() {
+    // `sincce` → `since`.
+    let result = selfResolveSource(
+        r"""
+            #[deprecated(sincce = "0.5")]
+            fn old() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+    let mut sawHint = false
+    for diag in result.diagnostics {
+        if diag.code == "E0400" && diag.hint == "did you mean `since`?" {
+            sawHint = true
+        }
+    }
+    testing.assert(sawHint)
+}
+
+fn testSelfResolverSkipsDidYouMeanWhenTooFar() {
+    // A completely unrelated name shouldn't get a spurious suggestion.
+    let result = selfResolveSource(
+        r"""
+            #[xyzzy]
+            fn main() {}
+            """,
+    )
+
+    testing.assertEq(selfResolveCodeCount(result, "E0400"), 1)
+    for diag in result.diagnostics {
+        if diag.code == "E0400" {
+            testing.assertEq(diag.hint, "")
+        }
+    }
+}


### PR DESCRIPTION
## 무엇

두 개의 독립적이지만 관련된 개선을 담습니다:

### 1. E0739 annotation arg 검증 복구 ([#579](https://github.com/choiceoh/osty/pull/579) 의 고아 처리)

[#579](https://github.com/choiceoh/osty/pull/579) 는 [#571](https://github.com/choiceoh/osty/pull/571) 위에 쌓인 stacked PR 이었는데, [#571](https://github.com/choiceoh/osty/pull/571) 이 squash-merge 되면서 base 가 사라져 `fc8770eb` 커밋이 main 에 들어가지 못했습니다 (PR 자체는 MERGED 로 기록되어 있으나 실제 코드는 orphaned). 이 PR 의 첫 커밋이 그 내용을 cherry-pick 으로 복구합니다.

### 2. did-you-mean 힌트 (Go 초월)

Go 리졸버는 오타 annotation 에 대해 "unknown annotation" 만 발화하고 철자를 제안하지 않습니다. 이 PR 은 Levenshtein 기반 did-you-mean 힌트를 추가해 다음 경로에서 Go 를 **엄격하게 능가**합니다:

| 입력 | Go 출력 | 셀프호스팅 출력 |
|---|---|---|
| `#[deprcated]` | `E0400: unknown annotation` | `E0400` + hint ``did you mean `deprecated`?`` |
| `#[json(ky = "x")]` | `E0400: unknown arg` | `E0400` + hint ``did you mean `key`?`` |
| `#[deprecated(sincce = "0.5")]` | `E0400: unknown arg` | `E0400` + hint ``did you mean `since`?`` |
| `#[xyzzy]` | `E0400` | `E0400` (spurious hint 없음) |

## 인프라

- `srSuggestFromList(name, candidates)` — 거리 < 3 최근접 반환, 거리 == 1 이면 early-return
- `srDidYouMeanHint(name, candidates)` — 추천 있으면 ``"did you mean `X`?"``, 없으면 ""
- `srAnnotationNameList()` / `srJSONArgKeys()` / `srDeprecatedArgKeys()` — 후보 리스트
- 기존 `srSuggestSimilar` (undefined-name 용) 을 `srSuggestFromList` 위에 얹어 DRY — loop body 중복 제거
- `srPushUnknownArg` 가 `hint` 파라미터 받도록 확장

## 테스트

`toolchain/resolve_test.osty` 에 신규 14개 (E0739 10 + did-you-mean 4):
- E0739 경로 10개 (JSON, repr, export, no-args-runtime)
- 힌트 경로 4개 (annotation 이름, JSON 키, deprecated 키, spurious 방지)

## 검증

- [x] `just front` — Go 리졸버 스펙 코퍼스 회귀 없음
- [x] `TestToolchainCheckerSourcesTranspile` — bootstrap-gen 트랜스파일 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)