### PR TITLE
feat(llvmgen): match-as-expression for Option<scalar>

### DIFF
--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -1617,7 +1617,124 @@ func (g *generator) emitMatchExprValue(expr *ast.MatchExpr) (value, error) {
 	if info, ok := g.resultTypes[scrutinee.typ]; ok {
 		return g.emitResultMatchExprValue(scrutinee, info, expr.Arms)
 	}
+	// Optional match-as-expression: `match opt { Some(x) -> a, None -> b }`
+	// where opt has source type T?. The scrutinee LLVM type is "ptr"
+	// (boxed Option ABI: null = None, non-null = Some(x)), which the
+	// generic enum-tag fallback can't distinguish from a raw pointer.
+	// Mirrors the optional-source-type detection used by emitMatchStmt.
+	if scrutinee.typ == "ptr" {
+		if sourceType, ok := g.staticExprSourceType(expr.Scrutinee); ok {
+			resolved, resolveErr := llvmResolveAliasType(sourceType, g.typeEnv(), map[string]bool{})
+			if resolveErr == nil {
+				if opt, ok := resolved.(*ast.OptionalType); ok {
+					return g.emitOptionalMatchExprValue(scrutinee, opt.Inner, expr.Arms)
+				}
+			}
+		}
+	}
 	return value{}, unsupportedf("type-system", "match scrutinee type %s, want enum tag", scrutinee.typ)
+}
+
+// emitOptionalMatchExprValue lowers `match opt { Some(x) -> a, None -> b }`
+// in value position. Mirrors emitOptionalMatchStmt's branch shape but
+// uses emitIfExprPhi to merge the two arm values, so the match
+// participates as an expression in let / fn-return / nested call
+// position.
+//
+// Constraints (deliberately tight, matching the statement path):
+//   - exactly two productive arms covering Some + None (a wildcard
+//     fills in for either)
+//   - no guards (those still wall — same as the statement path)
+//   - both arms produce the same LLVM type (emitIfExprPhi enforces)
+//
+// The Some payload is bound via bindOptionalMatchPayload, which
+// already handles ptr / scalar / aggregate via loadValueFromAddress,
+// so this routine doesn't touch the boxing/unboxing surface.
+func (g *generator) emitOptionalMatchExprValue(scrutinee value, innerSource ast.Type, arms []*ast.MatchArm) (value, error) {
+	if len(arms) == 0 {
+		return value{}, unsupported("expression", "optional match has no arms")
+	}
+	type optionalArmExpr struct {
+		pat  optionalMatchPatternInfo
+		body ast.Expr
+	}
+	parsed := make([]optionalArmExpr, 0, len(arms))
+	for _, arm := range arms {
+		if arm == nil {
+			return value{}, unsupported("expression", "nil match arm")
+		}
+		if arm.Guard != nil {
+			return value{}, unsupported("expression", "guarded optional match arms not yet supported in expression position")
+		}
+		pat, ok, err := matchOptionalPattern(arm.Pattern)
+		if err != nil {
+			return value{}, err
+		}
+		if !ok {
+			return value{}, unsupportedf("expression", "optional match arm must be Some/None/wildcard, got %T", arm.Pattern)
+		}
+		parsed = append(parsed, optionalArmExpr{pat: pat, body: arm.Body})
+	}
+	// Resolve which parsed arm covers Some and which covers None, with
+	// a wildcard filling in either slot. The first matching arm wins
+	// (mirrors source-order arm preference).
+	var someArm, noneArm, wildcardArm *optionalArmExpr
+	for i := range parsed {
+		switch {
+		case parsed[i].pat.isSome && someArm == nil:
+			someArm = &parsed[i]
+		case parsed[i].pat.isNone && noneArm == nil:
+			noneArm = &parsed[i]
+		case parsed[i].pat.isWildcard && wildcardArm == nil:
+			wildcardArm = &parsed[i]
+		}
+	}
+	if someArm == nil {
+		someArm = wildcardArm
+	}
+	if noneArm == nil {
+		noneArm = wildcardArm
+	}
+	if someArm == nil || noneArm == nil {
+		return value{}, unsupported("expression", "optional match must cover both Some and None (a wildcard counts for the missing side)")
+	}
+
+	emitter := g.toOstyEmitter()
+	isNil := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq ptr %s, null", isNil, scrutinee.ref))
+	// `cond=true` selects the then-label per llvmIfExprStart; isNil=true
+	// → the None arm runs in `then`, the Some arm in `else`.
+	labels := llvmIfExprStart(emitter, &LlvmValue{typ: "i1", name: isNil})
+	g.takeOstyEmitter(emitter)
+
+	g.currentBlock = labels.thenLabel
+	g.pushScope()
+	noneValue, err := g.emitMatchArmBodyValue(noneArm.body)
+	g.popScope()
+	if err != nil {
+		return value{}, err
+	}
+	nonePred := g.currentBlock
+
+	emitter = g.toOstyEmitter()
+	llvmIfExprElse(emitter, labels)
+	g.takeOstyEmitter(emitter)
+	g.currentBlock = labels.elseLabel
+	g.pushScope()
+	if someArm.pat.isSome {
+		if err := g.bindOptionalMatchPayload(scrutinee, innerSource, someArm.pat); err != nil {
+			g.popScope()
+			return value{}, err
+		}
+	}
+	someValue, err := g.emitMatchArmBodyValue(someArm.body)
+	g.popScope()
+	if err != nil {
+		return value{}, err
+	}
+	somePred := g.currentBlock
+
+	return g.emitIfExprPhi(labels, nonePred, somePred, noneValue, someValue)
 }
 
 // resultPatternInfo describes a single arm of a Result match: which

--- a/internal/llvmgen/option_match_expr_test.go
+++ b/internal/llvmgen/option_match_expr_test.go
@@ -1,0 +1,119 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// match-as-EXPRESSION on Option<scalar> walled with LLVM011
+// "match scrutinee type ptr, want enum tag" — the value-yielding
+// form (let / fn-return / nested call) walked a different lowering
+// route than the statement form, and that route had no Optional
+// dispatch.
+//
+// emitOptionalMatchExprValue mirrors emitOptionalMatchStmt's branch
+// shape but uses emitIfExprPhi to merge None / Some arm values, so
+// `let x = match opt { Some(n) -> n, None -> -1 }` lowers cleanly.
+//
+// The Some payload reuses bindOptionalMatchPayload, which already
+// handles ptr / scalar / aggregate via loadValueFromAddress (set up
+// by PR #576's scalar-Option boxing on the producer side); the new
+// expr path is a thin wrapper around it.
+func TestOptionIntMatchExprRoundTrip(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn describe(n: Int?) -> Int {
+    match n {
+        Some(x) -> x,
+        None -> -1,
+    }
+}
+
+fn main() {
+    let _ = describe(Some(42))
+    let _ = describe(None)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/option_int_match_expr.osty"})
+	if err != nil {
+		t.Fatalf("Option<Int> match-expr errored: %v", err)
+	}
+	got := string(ir)
+	// Producer side: gc.alloc_v1 for Some(42) (already shipped in #576).
+	if !strings.Contains(got, "call ptr @osty.gc.alloc_v1") {
+		t.Fatalf("Some(42) did not box via gc.alloc_v1:\n%s", got)
+	}
+	// Phi merging None (-1) and Some (loaded i64) into the function's
+	// return value — the value-yielding contract of emitIfExprPhi.
+	if !strings.Contains(got, "phi i64") {
+		t.Fatalf("match-expr did not emit phi i64 for joined arms:\n%s", got)
+	}
+	// Some arm loads the boxed scalar back — same load helper the
+	// statement path uses.
+	if !strings.Contains(got, "load i64") {
+		t.Fatalf("Some arm did not load i64 from box:\n%s", got)
+	}
+	// isNil branch on the receiver ptr — the dispatch the new
+	// expr-value path adds.
+	if !strings.Contains(got, "icmp eq ptr ") {
+		t.Fatalf("match-expr did not branch on null-ptr check:\n%s", got)
+	}
+}
+
+// Wildcard arm fills the missing side. `match opt { None -> 0, _ -> 1 }`
+// (or symmetrically `_ -> -1, Some(x) -> x`) both lower; the
+// arm-resolution loop consults wildcardArm whenever Some or None is
+// missing so the call site doesn't have to spell both out
+// exhaustively.
+func TestOptionIntMatchExprWildcardCoversSome(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn describe(n: Int?) -> Int {
+    match n {
+        None -> 0,
+        _ -> 1,
+    }
+}
+
+fn main() {
+    let _ = describe(Some(7))
+    let _ = describe(None)
+}
+`)
+	if _, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/option_int_match_wild.osty"}); err != nil {
+		t.Fatalf("Option<Int> match-expr with wildcard errored: %v", err)
+	}
+}
+
+// Round-trip on List<Int>.get inside a match-expression: producer
+// boxes (PR #576), source type advertised as `Int?` by
+// staticListMethodSourceType (this PR), match-expr dispatch fires
+// (this PR), consumer loads i64 from the box (existing).
+//
+// Without staticListMethodSourceType the call's source type is
+// unknown so the new match-expr branch wouldn't fire, falling back
+// to the LLVM011 wall. The hook is the load-bearing piece.
+func TestOptionIntMatchExprOnListGet(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn first(xs: List<Int>) -> Int {
+    match xs.get(0) {
+        Some(n) -> n,
+        None -> -1,
+    }
+}
+
+fn main() {
+    let xs: List<Int> = [10, 20, 30]
+    let _ = first(xs)
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/option_list_get_match.osty"})
+	if err != nil {
+		t.Fatalf("match xs.get(0) errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"call i64 @osty_rt_list_get_i64",
+		"phi i64",
+		"load i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in IR:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -428,6 +428,9 @@ func (g *generator) staticExprSourceType(expr ast.Expr) (ast.Type, bool) {
 		if src, ok := g.staticMapMethodSourceType(e); ok {
 			return src, true
 		}
+		if src, ok := g.staticListMethodSourceType(e); ok {
+			return src, true
+		}
 		if id, ok := e.Fn.(*ast.Ident); ok {
 			if sig := g.functions[id.Name]; sig != nil && sig.returnSourceType != nil {
 				return sig.returnSourceType, true
@@ -948,6 +951,47 @@ func (g *generator) staticMapMethodSourceType(call *ast.CallExpr) (ast.Type, boo
 		return &ast.OptionalType{Inner: valAST}, true
 	case "keys":
 		return &ast.NamedType{Path: []string{"List"}, Args: []ast.Type{keyAST}}, true
+	}
+	return nil, false
+}
+
+// staticListMethodSourceType recovers the source-level return type of
+// a List intrinsic method call. The most important consumer is the
+// Optional match-as-expression dispatch, which needs to see `T?` for
+// `xs.get(i)` so a downstream `match xs.get(0) { Some(x) -> a, None
+// -> b }` routes to emitOptionalMatchExprValue rather than walling
+// with "match scrutinee type ptr, want enum tag".
+//
+// Method → source-type map:
+//
+//	len        → Int
+//	isEmpty    → Bool
+//	get(Int)   → T?
+func (g *generator) staticListMethodSourceType(call *ast.CallExpr) (ast.Type, bool) {
+	field, _, _, found := g.listMethodInfo(call)
+	if !found {
+		return nil, false
+	}
+	baseSrc, ok := g.staticExprSourceType(field.X)
+	if !ok {
+		return nil, false
+	}
+	resolved, err := llvmResolveAliasType(baseSrc, g.typeEnv(), map[string]bool{})
+	if err != nil {
+		return nil, false
+	}
+	named, ok := resolved.(*ast.NamedType)
+	if !ok || len(named.Path) != 1 || named.Path[0] != "List" || len(named.Args) != 1 {
+		return nil, false
+	}
+	elemAST := named.Args[0]
+	switch field.Name {
+	case "len":
+		return &ast.NamedType{Path: []string{"Int"}}, true
+	case "isEmpty":
+		return &ast.NamedType{Path: []string{"Bool"}}, true
+	case "get":
+		return &ast.OptionalType{Inner: elemAST}, true
 	}
 	return nil, false
 }


### PR DESCRIPTION
## Summary

PR #576 lifted the producer-side LLVM011 wall (`Some(x)` boxing) and the consumer-side ones for `?` / `unwrap()` / `match` **statement**. The value-yielding form of `match` — `let x = match opt { Some(n) -> n, None -> -1 }` — still walled with `LLVM011: match scrutinee type ptr, want enum tag`, because `emitMatchExprValue` had no Optional dispatch. This PR closes that last gap.

## What changed

**`emitOptionalMatchExprValue`** (in `expr.go`) — mirrors `emitOptionalMatchStmt`'s branch shape but uses `emitIfExprPhi` to merge None / Some arm values, so the match participates as an expression in let / fn-return / nested call position. Validates arms, resolves Some/None/wildcard slots in source order (a wildcard fills the missing side), branches on `isNil`, emits each arm body under `bindOptionalMatchPayload`, joins via phi.

The Some payload binder already handles ptr / scalar / aggregate via `loadValueFromAddress` (set up by #576), so this routine doesn't touch the boxing/unboxing surface — it's a pure dispatch wiring.

**`staticListMethodSourceType`** (in `type.go`) — the load-bearing hook. Without it, `xs.get(0)` doesn't advertise an `Int?` source type and the new match-expr branch never fires, falling back to the old wall. Mirrors `staticMapMethodSourceType` in shape; wired into `staticExprSourceType` next to its Map sibling.

Method → source-type map:
- `len → Int`
- `isEmpty → Bool`
- `get(Int) → T?`

## Why

Without this PR, idiomatic Osty patterns like:

```osty
fn first(xs: List<Int>) -> Int {
    match xs.get(0) {
        Some(n) -> n,
        None -> -1,
    }
}
```

still wall under LLVM. With it, the producer (#576) and consumer (this PR) compose end-to-end through the static-source-type hook, and `OSTY_STDLIB_BODY_LOWER=1` no longer trips on injected stdlib bodies that pattern-match a `T?` return.

## Test plan

Three new tests in `option_match_expr_test.go`:

- **`TestOptionIntMatchExprRoundTrip`** — bare `match opt { Some(x) -> x, None -> -1 }` lowers to `gc.alloc_v1` (Some side) + `phi i64` (arm join) + `load i64` (Some payload) + `icmp eq ptr` (isNil branch).
- **`TestOptionIntMatchExprWildcardCoversSome`** — `match opt { None -> 0, _ -> 1 }` lowers cleanly via the wildcard fill-in path.
- **`TestOptionIntMatchExprOnListGet`** — the typical end-to-end case: `match xs.get(0) { Some(n) -> n, None -> -1 }` confirms producer (#576) + consumer (this PR) compose through the static-source-type hook (`staticListMethodSourceType`).

Plus regression coverage:
- [x] `go test ./internal/llvmgen/ -run 'TestOption|TestListGet|TestMatch'` (skipping the pre-existing `TestGoGenerate` / `TestProbeNative` / `TestToolchain` slow/broken tests) all pass.
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint) regression-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)