### PR TITLE
fix(llvmgen): resolve nested _ZTS args in surfaceBuiltinArgsMatch

### DIFF
--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -309,6 +309,13 @@ func specializedBuiltinMangledForSurface(surface ast.Type) (string, bool) {
 // the built-in shapes we care about (primitive idents like `Int` /
 // `String` / `Bool`, plus nested NamedType references). Nested
 // generic args recurse so Map<String, List<Int>> round-trips cleanly.
+//
+// When an IR arg is itself a mangled `_ZTSN…` specialization — the
+// inner `List<String>` of `List<List<String>>`, for example — look
+// its surface entry back up in `currentSpecializedBuiltinSurfaces`
+// and compare at that level. The AST side only ever carries the
+// surface form (`List<String>`), so a literal string compare would
+// miss every nested stdlib specialization.
 func surfaceBuiltinArgsMatch(irArgs []ostyir.Type, astArgs []ast.Type) bool {
 	if len(irArgs) != len(astArgs) {
 		return false
@@ -318,6 +325,19 @@ func surfaceBuiltinArgsMatch(irArgs []ostyir.Type, astArgs []ast.Type) bool {
 		astNamed, ok := astArgs[i].(*ast.NamedType)
 		if !ok || len(astNamed.Path) != 1 {
 			return false
+		}
+		if strings.HasPrefix(irName, "_ZTS") {
+			surf, ok := currentSpecializedBuiltinSurfaces[irName]
+			if !ok {
+				return false
+			}
+			if surf.Source != astNamed.Path[0] {
+				return false
+			}
+			if !surfaceBuiltinArgsMatch(surf.Args, astNamed.Args) {
+				return false
+			}
+			continue
 		}
 		if irName != astNamed.Path[0] {
 			return false


### PR DESCRIPTION
## Summary

Unblocks specialized `List<List<T>>.fold` (and any other nested stdlib container) FieldExpr dispatch under `OSTY_STDLIB_BODY_LOWER=1`. `specializedBuiltinMangledForSurface` could not match `List<List<String>>` to its mangled owner because the IR arg for the inner `List<String>` is itself a `_ZTSN4main4ListISsEE` NamedType, while the AST surface carries the unmangled `List<String>` form. `surfaceBuiltinArgsMatch` then walks the two sides name-by-name and bails on `_ZTSN...` != `List`.

## How

Teach the comparison to resolve mangled IR args back through `currentSpecializedBuiltinSurfaces`: when the IR side is a `_ZTSN...` NamedType, look up its `{Source, Args}` entry and recurse at that level. Map / Set / List / Result / Option — every stdlib specialization the injection pipeline emits — is already registered in the surface index, so this lookup is total for all shapes that reach this code.

## Regression impact

`OSTY_STDLIB_BODY_LOWER=1` serial backend suite (clean cache): **7 → 6 failures**. Recovered: `TestLLVMBackendBinaryPtrBackedListToSetAndBoolPrint` — the canonical `List<List<String>>.toSet()` shape that exercises nested container specialization.

Baseline injection tests still pass: `TestLLVMBackendEmitStringsCompareFlagOn`, `TestPrepareEntryInjectsStdlibWhenFlagOn`, `TestInjectedMapTypeMonomorphizes`.

## Remaining flag-on blockers

- `TestLLVMBackendBinaryBuiltinResultConstructorsTrackLocalContext` / `TestLLVMBackendBinaryBuiltinResultFieldConstructors` — specialized `Result<T, Error>` stored in a struct field dispatches match on ptr-backed scrutinee without loading the enum tag.
- `TestLLVMBackendBinaryManagedAggregateContainersSurvivePressureGC` — `Map<K, AggregateStruct>` internal `List<(K, V)>.push` tuple shape mismatch (ptr payload vs. specialized tuple).
- `TestLLVMBackendBinaryCollectionsUseRuntimeContainers` — pre-existing baseline.

Each is a separate follow-up before the default flag can safely flip.

## Test plan

- [x] `go test ./internal/llvmgen/ -short -timeout 300s` — no new regressions (one pre-existing `TestGenerateMapGetBoolValueUses1ByteBox` unchanged)
- [x] `go test ./internal/backend/ -run 'TestLLVMBackendEmitStringsCompareFlagOn|TestPrepareEntryInjectsStdlibWhenFlagOn|TestInjectedMapTypeMonomorphizes'` — all pass
- [x] `go test ./internal/backend/ -count=1 -p 1 -timeout 600s` under `OSTY_STDLIB_BODY_LOWER=1` — 7 → 6 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)