### PR TITLE
Route live llvmgen callers through managed native boundary

### DIFF
--- a/cmd/osty-native-llvmgen/main.go
+++ b/cmd/osty-native-llvmgen/main.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/nativellvmgen"
+	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+type llvmgenRequest = nativellvmgen.Request
+type llvmgenPackageInput = nativellvmgen.PackageInput
+type llvmgenPackageFile = nativellvmgen.PackageFile
+type llvmgenResponse = nativellvmgen.Response
+
+func main() {
+	if err := run(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(stdin io.Reader, stdout io.Writer) error {
+	var req llvmgenRequest
+	if err := json.NewDecoder(stdin).Decode(&req); err != nil {
+		return fmt.Errorf("decode llvmgen request: %w", err)
+	}
+	var (
+		entry backend.Entry
+		err   error
+	)
+	if req.Package != nil {
+		entry, err = preparePackageEntry(req)
+	} else {
+		entry, err = prepareSourceEntry(req)
+	}
+	if err != nil {
+		return err
+	}
+	ir, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(entry, "")
+	if err != nil {
+		return fmt.Errorf("emit native llvm-ir: %w", err)
+	}
+	resp := llvmgenResponse{
+		Covered:  ok,
+		Warnings: renderWarnings(warnings),
+	}
+	if ok {
+		resp.LLVMIR = string(ir)
+	}
+	return json.NewEncoder(stdout).Encode(resp)
+}
+
+func prepareSourceEntry(req llvmgenRequest) (backend.Entry, error) {
+	src := []byte(req.Source)
+	file, diags := parser.ParseDiagnostics(src)
+	if err := firstErrorDiagnostic(diags); err != nil {
+		return backend.Entry{}, err
+	}
+	if file == nil {
+		return backend.Entry{}, fmt.Errorf("prepare llvmgen source: parse produced no AST")
+	}
+	reg := stdlib.LoadCached()
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), reg)
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        src,
+		Path:          req.Path,
+	})
+	sourcePath := req.Path
+	if sourcePath == "" {
+		sourcePath = "<input>"
+	}
+	entry, err := backend.PrepareEntry("main", sourcePath, file, res, chk)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	entry.Source = append([]byte(nil), src...)
+	return entry, nil
+}
+
+func preparePackageEntry(req llvmgenRequest) (backend.Entry, error) {
+	root, entryPath, err := writePackageRequest(req)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	defer os.RemoveAll(root)
+
+	ws, err := resolve.NewWorkspace(root)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	ws.Stdlib = stdlib.LoadCached()
+	if _, err := ws.LoadPackage(""); err != nil {
+		return backend.Entry{}, err
+	}
+	results := ws.ResolveAll()
+	checks := check.Workspace(ws, results, check.Opts{
+		UseGolegacy: true,
+		Stdlib:      ws.Stdlib,
+	})
+	pkg := ws.Packages[""]
+	if pkg == nil {
+		return backend.Entry{}, fmt.Errorf("%s: no package sources were loaded", root)
+	}
+	var entryFile *resolve.PackageFile
+	for _, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		fp, err := filepath.Abs(pf.Path)
+		if err != nil {
+			continue
+		}
+		if fp == entryPath {
+			entryFile = pf
+			break
+		}
+	}
+	if entryFile == nil {
+		return backend.Entry{}, fmt.Errorf("%s is not part of the generated package rooted at %s", entryPath, root)
+	}
+	chk := checks[""]
+	if chk == nil {
+		chk = &check.Result{}
+	}
+	return backend.PreparePackage("main", entryPath, pkg, entryFile, chk)
+}
+
+func writePackageRequest(req llvmgenRequest) (string, string, error) {
+	root, err := os.MkdirTemp("", "osty-native-llvmgen-*")
+	if err != nil {
+		return "", "", err
+	}
+	files := req.Package.Files
+	if len(files) == 0 {
+		return "", "", fmt.Errorf("prepare llvmgen package: no files provided")
+	}
+	entryName := packageEntryName(req)
+	if entryName == "" {
+		entryName = packageFileName(files[0], 0)
+	}
+	entryPath := ""
+	for i, file := range files {
+		name := packageFileName(file, i)
+		dst := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			os.RemoveAll(root)
+			return "", "", err
+		}
+		if err := os.WriteFile(dst, []byte(file.Source), 0o644); err != nil {
+			os.RemoveAll(root)
+			return "", "", err
+		}
+		if filepath.Base(name) == entryName {
+			entryPath = dst
+		}
+	}
+	if entryPath == "" {
+		entryPath = filepath.Join(root, packageFileName(files[0], 0))
+	}
+	absEntry, err := filepath.Abs(entryPath)
+	if err != nil {
+		os.RemoveAll(root)
+		return "", "", err
+	}
+	return root, absEntry, nil
+}
+
+func packageEntryName(req llvmgenRequest) string {
+	if req.Path == "" {
+		return ""
+	}
+	return filepath.Base(req.Path)
+}
+
+func packageFileName(file llvmgenPackageFile, idx int) string {
+	if file.Name != "" {
+		return filepath.Base(file.Name)
+	}
+	if file.Path != "" {
+		return filepath.Base(file.Path)
+	}
+	return fmt.Sprintf("file%d.osty", idx)
+}
+
+func renderWarnings(warnings []error) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		if warning == nil {
+			continue
+		}
+		out = append(out, warning.Error())
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func firstErrorDiagnostic(diags []*diag.Diagnostic) error {
+	for _, d := range diags {
+		if d != nil && d.Severity == diag.Error {
+			return d
+		}
+	}
+	return nil
+}

--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRunEmitsNativeOwnedLLVMIRForSource(t *testing.T) {
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"path":"main.osty","source":"fn pick(flag: Bool) -> Int { if flag { 42 } else { 0 } }\nfn main() { let mut i = 0 let mut sum = 0 for i < 3 { sum = sum + pick(i == 2) i = i + 1 } println(sum) }\n"}`)
+	if err := run(stdin, &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	if !strings.Contains(resp.LLVMIR, "define i64 @pick(i1 %flag)") {
+		t.Fatalf("llvmIr missing pick definition:\n%s", resp.LLVMIR)
+	}
+	if !strings.Contains(resp.LLVMIR, "for.cond") {
+		t.Fatalf("llvmIr missing loop label:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunEmitsNativeOwnedLLVMIRForPackage(t *testing.T) {
+	reqBody, err := json.Marshal(llvmgenRequest{
+		Path: "b.osty",
+		Package: &llvmgenPackageInput{
+			Files: []llvmgenPackageFile{
+				{Name: "a.osty", Source: "pub fn helper() -> Int { 1 }\n"},
+				{Name: "b.osty", Source: "fn main() { println(helper()) }\n"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	if !strings.Contains(resp.LLVMIR, "@helper") {
+		t.Fatalf("llvmIr missing helper symbol:\n%s", resp.LLVMIR)
+	}
+	if !strings.Contains(resp.LLVMIR, "@main") {
+		t.Fatalf("llvmIr missing main symbol:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunReportsNotCoveredForUnsupportedSource(t *testing.T) {
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"path":"main.osty","source":"struct Pair { left: Int, right: Int }\nfn main() { let mut pair = Pair { left: 1, right: 2 } pair.left = 3 println(pair.left) }\n"}`)
+	if err := run(stdin, &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Covered {
+		t.Fatalf("covered = true, want false\nllvmIr:\n%s", resp.LLVMIR)
+	}
+	if resp.LLVMIR != "" {
+		t.Fatalf("llvmIr = %q, want empty output for uncovered source", resp.LLVMIR)
+	}
+}
+
+func TestRunUsesNativeOwnedExportAndCABIShape(t *testing.T) {
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"path":"main.osty","source":"#[export(\"osty.gc.native_entry_v1\")]\n#[c_abi]\npub fn native_entry_v1() -> Int { 0 }\n"}`)
+	if err := run(stdin, &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	if !strings.Contains(resp.LLVMIR, "define ccc i64 @native_entry_v1()") {
+		t.Fatalf("llvmIr missing C ABI function definition:\n%s", resp.LLVMIR)
+	}
+	if !strings.Contains(resp.LLVMIR, "@osty.gc.native_entry_v1 = dso_local alias ptr, ptr @native_entry_v1") {
+		t.Fatalf("llvmIr missing export alias:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunRejectsInvalidJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run(strings.NewReader("{"), &stdout)
+	if err == nil || !strings.Contains(err.Error(), "decode llvmgen request") {
+		t.Fatalf("run error = %v, want decode error", err)
+	}
+}

--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -468,17 +468,9 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 		os.Exit(1)
 	}
 	// 4. Transpile. Unsupported lowering shapes produce TODO markers;
-	// we log the warning but proceed so simple programs build. The
-	// per-file resolve handle is built but only consumed through the
-	// PrepareEntry single-file fallback below — when more than one
-	// .osty file lives in the package we route through PreparePackage
-	// so every sibling's top-level decls reach the merged ir.Module.
-	res := &resolve.Result{
-		Refs:      entryFile.Refs,
-		TypeRefs:  entryFile.TypeRefs,
-		FileScope: entryFile.FileScope,
-	}
-	_ = res // retained as fallback path below
+	// we log the warning but proceed so simple programs build. Package
+	// lowering is now the default even for single-file packages so the
+	// build path has one consistent backend entry contract.
 	if chk == nil {
 		chk = &check.Result{}
 	}
@@ -503,17 +495,49 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 		binName = runner.BuildBinaryName(binBaseOverride, pkgName, triple, targetOS, runtime.GOOS)
 	}
 	selectedBackend := backendFromCLI("build", backendID)
-	// Pick the multi-file path whenever the package has more than one
-	// source file. Single-file packages keep the historical
-	// PrepareEntry shape so backend tests that hand-build a one-file
-	// Package keep behaving identically.
+	layout := backend.Layout{
+		Root:    root,
+		Profile: profileName,
+		Target:  triple,
+	}
+	if backendID == backend.NameLLVM {
+		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, resolved.Features, entryAbs, pkg); usedExternal {
+			if err != nil {
+				exitBackendEmitError("build", emitResult, err)
+			}
+			switch emitMode {
+			case backend.EmitBinary:
+				if emitResult.Artifacts.Binary != "" {
+					fmt.Printf("Built %s (%s)\n", emitResult.Artifacts.Binary, profileName)
+					return emitResult
+				}
+			case backend.EmitObject:
+				if emitResult.Artifacts.Object != "" {
+					fmt.Printf("Generated %s (%s)\n", emitResult.Artifacts.Object, profileName)
+					return emitResult
+				}
+			case backend.EmitLLVMIR:
+				if artifact := emitResult.Artifacts.SourcePath(); artifact != "" {
+					fmt.Printf("Generated %s (%s)\n", artifact, profileName)
+					return emitResult
+				}
+			}
+		}
+	}
+	// Package lowering is the default live build path; only degenerate
+	// empty-package callers fall back to a direct single-file entry.
 	var (
 		entry    backend.Entry
 		entryErr error
 	)
-	if pkg != nil && countLowerableFiles(pkg) > 1 {
+	if pkg != nil && countLowerableFiles(pkg) > 0 {
 		entry, entryErr = backend.PreparePackage("main", entryAbs, pkg, entryFile, chk)
 	} else {
+		res := &resolve.Result{
+			Refs:      entryFile.Refs,
+			TypeRefs:  entryFile.TypeRefs,
+			FileScope: entryFile.FileScope,
+		}
 		entry, entryErr = backend.PrepareEntry("main", entryAbs, entryFile.File, res, chk)
 	}
 	if err := entryErr; err != nil {
@@ -521,11 +545,7 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 		os.Exit(1)
 	}
 	emitResult, err := selectedBackend.Emit(context.Background(), backend.Request{
-		Layout: backend.Layout{
-			Root:    root,
-			Profile: profileName,
-			Target:  triple,
-		},
+		Layout:     layout,
 		Emit:       emitMode,
 		Entry:      entry,
 		BinaryName: binName,

--- a/cmd/osty/build_run_external_test.go
+++ b/cmd/osty/build_run_external_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildCLIUsesManagedNativeLLVMGenForObject(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "osty.toml", "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"0.4\"\n")
+	target := writeNativeTestFile(t, dir, "main.osty", "fn main() { println(1) }\n")
+	fake := buildFakeExternalLLVMGenCLI(t)
+	capture := filepath.Join(t.TempDir(), "request.json")
+
+	t.Setenv("OSTY_NATIVE_LLVMGEN_BIN", fake)
+	t.Setenv("FAKE_EXTERNAL_LLVMGEN_CAPTURE", capture)
+	t.Setenv("FAKE_EXTERNAL_LLVMGEN_RESPONSE", `{"covered":true,"llvmIr":"source_filename = \"fake\"\ndefine i32 @main() { ret i32 0 }\n"}`)
+
+	got := runOstyCLI(t, "build", "--emit", "object", target)
+	if got.exit != 0 {
+		t.Fatalf("osty build exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, ".o (debug)") {
+		t.Fatalf("stdout = %q, want object artifact summary", got.stdout)
+	}
+
+	var req externalLLVMGenRequest
+	readCapturedExternalLLVMGenRequest(t, capture, &req)
+	if req.Path != target {
+		t.Fatalf("request path = %q, want %q", req.Path, target)
+	}
+	if req.Package == nil || len(req.Package.Files) != 1 {
+		t.Fatalf("package request = %#v, want single-file package", req.Package)
+	}
+	if req.Package.Files[0].Source != "fn main() { println(1) }\n" {
+		t.Fatalf("request source = %q, want original package source", req.Package.Files[0].Source)
+	}
+}
+
+func TestRunCLIUsesManagedNativeLLVMGenForBinary(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "osty.toml", "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"0.4\"\n")
+	target := writeNativeTestFile(t, dir, "main.osty", "fn main() { println(1) }\n")
+	fake := buildFakeExternalLLVMGenCLI(t)
+	capture := filepath.Join(t.TempDir(), "request.json")
+
+	t.Setenv("OSTY_NATIVE_LLVMGEN_BIN", fake)
+	t.Setenv("FAKE_EXTERNAL_LLVMGEN_CAPTURE", capture)
+	t.Setenv("FAKE_EXTERNAL_LLVMGEN_RESPONSE", `{"covered":true,"llvmIr":"source_filename = \"fake\"\ndefine i32 @main() { ret i32 0 }\n"}`)
+
+	got := runOstyCLIInDir(t, dir, "run")
+	if got.exit != 0 {
+		t.Fatalf("osty run exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.TrimSpace(got.stdout) != "" {
+		t.Fatalf("stdout = %q, want empty output from fake native llvmgen binary", got.stdout)
+	}
+
+	var req externalLLVMGenRequest
+	readCapturedExternalLLVMGenRequest(t, capture, &req)
+	if req.Path != target {
+		t.Fatalf("request path = %q, want %q", req.Path, target)
+	}
+	if req.Package == nil || len(req.Package.Files) != 1 {
+		t.Fatalf("package request = %#v, want single-file package", req.Package)
+	}
+}
+
+type externalLLVMGenRequest struct {
+	Path    string                   `json:"path,omitempty"`
+	Source  string                   `json:"source,omitempty"`
+	Package *externalLLVMGenPkgInput `json:"package,omitempty"`
+}
+
+type externalLLVMGenPkgInput struct {
+	Files []externalLLVMGenPackageFile `json:"files,omitempty"`
+}
+
+type externalLLVMGenPackageFile struct {
+	Path   string `json:"path,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+func buildFakeExternalLLVMGenCLI(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte(fakeExternalLLVMGenProgram), 0o644); err != nil {
+		t.Fatalf("write fake external llvmgen: %v", err)
+	}
+	name := "fake-external-llvmgen"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build fake external llvmgen: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func runOstyCLIInDir(t *testing.T, dir string, args ...string) cliRunResult {
+	t.Helper()
+	bin := buildOstyCLI(t)
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	result := cliRunResult{}
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("run osty %v in %s: %v", args, dir, err)
+		}
+		result.exit = exitErr.ExitCode()
+	}
+	result.stdout = stdout.String()
+	result.stderr = stderr.String()
+	return result
+}
+
+func readCapturedExternalLLVMGenRequest(t *testing.T, path string, out any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+const fakeExternalLLVMGenProgram = `package main
+
+import (
+	"io"
+	"os"
+)
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	if capture := os.Getenv("FAKE_EXTERNAL_LLVMGEN_CAPTURE"); capture != "" {
+		if err := os.WriteFile(capture, data, 0o644); err != nil {
+			panic(err)
+		}
+	}
+	_, _ = os.Stdout.WriteString(os.Getenv("FAKE_EXTERNAL_LLVMGEN_RESPONSE"))
+}
+`

--- a/cmd/osty/gen_emit.go
+++ b/cmd/osty/gen_emit.go
@@ -6,7 +6,15 @@ import (
 	"os"
 
 	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/nativellvmgen"
 )
+
+var tryExternalGenLLVMIR = func(entry *genPackageEntry) ([]byte, bool, []error, error) {
+	if entry == nil || entry.pkg == nil {
+		return nil, false, nil, nil
+	}
+	return nativellvmgen.TryPackage(".", entry.sourcePath, entry.pkg)
+}
 
 func prepareGenBackendEntry(pkgName string, entry *genPackageEntry) (backend.Entry, error) {
 	if entry == nil {
@@ -15,7 +23,7 @@ func prepareGenBackendEntry(pkgName string, entry *genPackageEntry) (backend.Ent
 	if entry.pkg == nil {
 		return backend.Entry{}, fmt.Errorf("missing package input for gen")
 	}
-	if countLowerableFiles(entry.pkg) > 1 {
+	if countLowerableFiles(entry.pkg) > 0 {
 		return backend.PreparePackage(pkgName, entry.sourcePath, entry.pkg, entry.file, entry.chk)
 	}
 	file, src, err := parseGenEmitFile(entry.pkg)
@@ -36,7 +44,7 @@ func emitGenArtifact(name backend.Name, mode backend.EmitMode, pkgName string, e
 		return nil, nil, err
 	}
 	if name == backend.NameLLVM && mode == backend.EmitLLVMIR {
-		out, warnings, emitErr := backend.EmitLLVMIRText(backendEntry, "", nil)
+		out, warnings, emitErr := emitGenLLVMIR(backendEntry, entry)
 		return out, &backend.Result{
 			Backend:  name,
 			Emit:     mode,
@@ -44,6 +52,16 @@ func emitGenArtifact(name backend.Name, mode backend.EmitMode, pkgName string, e
 		}, emitErr
 	}
 	return emitGenArtifactViaBackend(name, mode, backendEntry)
+}
+
+func emitGenLLVMIR(entry backend.Entry, pkgEntry *genPackageEntry) ([]byte, []error, error) {
+	if out, ok, warnings, err := tryExternalGenLLVMIR(pkgEntry); err == nil && ok {
+		return out, warnings, nil
+	}
+	if out, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(entry, ""); err == nil && ok {
+		return out, warnings, nil
+	}
+	return backend.EmitLLVMIRText(entry, "", nil)
 }
 
 func emitGenArtifactViaBackend(name backend.Name, mode backend.EmitMode, entry backend.Entry) ([]byte, *backend.Result, error) {

--- a/cmd/osty/llvm_external_emit.go
+++ b/cmd/osty/llvm_external_emit.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/nativellvmgen"
+	"github.com/osty/osty/internal/resolve"
+)
+
+var tryExternalPackageLLVMIR = func(entryPath string, pkg *resolve.Package) ([]byte, bool, []error, error) {
+	if pkg == nil {
+		return nil, false, nil, nil
+	}
+	return nativellvmgen.TryPackage(".", entryPath, pkg)
+}
+
+var emitPrebuiltLLVMIR = backend.EmitPrebuiltLLVMIR
+
+func tryExternalPackageLLVMArtifacts(ctx context.Context, emitMode backend.EmitMode, layout backend.Layout, binaryName string, features []string, entryPath string, pkg *resolve.Package) (*backend.Result, bool, error) {
+	if pkg == nil || !backend.UseNativeOwnedLLVMIR(features, emitMode) {
+		return nil, false, nil
+	}
+	out, ok, warnings, err := tryExternalPackageLLVMIR(entryPath, pkg)
+	if err != nil || !ok {
+		return nil, false, nil
+	}
+	result, err := emitPrebuiltLLVMIR(ctx, backend.Request{
+		Layout:     layout,
+		Emit:       emitMode,
+		BinaryName: binaryName,
+		Features:   features,
+	}, out, warnings)
+	return result, true, err
+}

--- a/cmd/osty/llvm_external_emit_test.go
+++ b/cmd/osty/llvm_external_emit_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestTryExternalPackageLLVMArtifactsUsesCoveredExternalIR(t *testing.T) {
+	pkg := &resolve.Package{
+		Dir:  t.TempDir(),
+		Name: "demo",
+	}
+
+	oldTry := tryExternalPackageLLVMIR
+	oldEmit := emitPrebuiltLLVMIR
+	t.Cleanup(func() {
+		tryExternalPackageLLVMIR = oldTry
+		emitPrebuiltLLVMIR = oldEmit
+	})
+
+	tryExternalPackageLLVMIR = func(entryPath string, gotPkg *resolve.Package) ([]byte, bool, []error, error) {
+		if entryPath != "/tmp/main.osty" {
+			t.Fatalf("entryPath = %q, want /tmp/main.osty", entryPath)
+		}
+		if gotPkg != pkg {
+			t.Fatal("got unexpected package pointer")
+		}
+		return []byte("; external ir"), true, []error{os.ErrExist}, nil
+	}
+	emitPrebuiltLLVMIR = func(_ context.Context, req backend.Request, irOut []byte, warnings []error) (*backend.Result, error) {
+		if req.Emit != backend.EmitObject {
+			t.Fatalf("emit mode = %q, want object", req.Emit)
+		}
+		if req.Layout.Profile != "debug" {
+			t.Fatalf("profile = %q, want debug", req.Layout.Profile)
+		}
+		if req.BinaryName != "app" {
+			t.Fatalf("binary name = %q, want app", req.BinaryName)
+		}
+		if string(irOut) != "; external ir" {
+			t.Fatalf("ir = %q, want external ir", irOut)
+		}
+		if len(warnings) != 1 || warnings[0] != os.ErrExist {
+			t.Fatalf("warnings = %#v, want propagated warning", warnings)
+		}
+		return &backend.Result{
+			Backend: backend.NameLLVM,
+			Emit:    req.Emit,
+			Artifacts: backend.Artifacts{
+				Object: filepath.Join(req.Layout.Root, ".osty", "out", req.Layout.Key(), "llvm", "main.o"),
+			},
+		}, nil
+	}
+
+	result, used, err := tryExternalPackageLLVMArtifacts(context.Background(), backend.EmitObject, backend.Layout{
+		Root:    pkg.Dir,
+		Profile: "debug",
+	}, "app", nil, "/tmp/main.osty", pkg)
+	if err != nil {
+		t.Fatalf("tryExternalPackageLLVMArtifacts() error = %v", err)
+	}
+	if !used {
+		t.Fatal("used = false, want true")
+	}
+	if result == nil || filepath.Base(result.Artifacts.Object) != "main.o" {
+		t.Fatalf("result = %#v, want object artifact", result)
+	}
+}
+
+func TestTryExternalPackageLLVMArtifactsSkipsWhenFeatureOverridesNativePath(t *testing.T) {
+	pkg := &resolve.Package{Dir: t.TempDir(), Name: "demo"}
+
+	oldTry := tryExternalPackageLLVMIR
+	t.Cleanup(func() { tryExternalPackageLLVMIR = oldTry })
+
+	called := false
+	tryExternalPackageLLVMIR = func(string, *resolve.Package) ([]byte, bool, []error, error) {
+		called = true
+		return nil, false, nil, nil
+	}
+
+	result, used, err := tryExternalPackageLLVMArtifacts(context.Background(), backend.EmitBinary, backend.Layout{
+		Root:    pkg.Dir,
+		Profile: "debug",
+	}, "app", []string{"mir-backend"}, "/tmp/main.osty", pkg)
+	if err != nil {
+		t.Fatalf("tryExternalPackageLLVMArtifacts() error = %v", err)
+	}
+	if used {
+		t.Fatal("used = true, want false")
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil", result)
+	}
+	if called {
+		t.Fatal("external runner should not be called when mir-backend disables native-owned path")
+	}
+}

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/airepair"
+	"github.com/osty/osty/internal/backend"
 	"github.com/osty/osty/internal/diag"
 )
 
@@ -143,6 +145,152 @@ func TestPrepareGenBackendEntryUsesPackageLoweringForSiblingFiles(t *testing.T) 
 	}
 	if backendEntry.IR == nil || len(backendEntry.IR.Decls) != 2 {
 		t.Fatalf("backend entry decl count = %d, want 2", len(backendEntry.IR.Decls))
+	}
+}
+
+func TestPrepareGenBackendEntryUsesPackageLoweringForSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", "fn main() { println(1) }\n")
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+	backendEntry, err := prepareGenBackendEntry("main", entry)
+	if err != nil {
+		t.Fatalf("prepareGenBackendEntry() error = %v", err)
+	}
+	if backendEntry.File != entry.file.File {
+		t.Fatal("backend entry did not keep the original single-file package AST")
+	}
+	if got := len(backendEntry.IR.Decls); got != 1 {
+		t.Fatalf("backend entry decl count = %d, want 1", got)
+	}
+}
+
+func TestEmitGenArtifactUsesNativeOwnedFastPathWhenCovered(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+	oldTry := tryExternalGenLLVMIR
+	tryExternalGenLLVMIR = func(*genPackageEntry) ([]byte, bool, []error, error) {
+		return nil, false, nil, nil
+	}
+	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
+	backendEntry, err := prepareGenBackendEntry("main", entry)
+	if err != nil {
+		t.Fatalf("prepareGenBackendEntry() error = %v", err)
+	}
+	want, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() reported not covered for primitive slice")
+	}
+
+	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
+	if err != nil {
+		t.Fatalf("emitGenArtifact() error = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("gen llvm-ir did not use native fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if result == nil {
+		t.Fatal("emitGenArtifact() result is nil")
+	}
+	if len(result.Warnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	}
+}
+
+func TestEmitGenArtifactUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", "fn main() { println(1) }\n")
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+
+	oldTry := tryExternalGenLLVMIR
+	tryExternalGenLLVMIR = func(*genPackageEntry) ([]byte, bool, []error, error) {
+		return []byte("; external llvm ir"), true, []error{errors.New("external warning")}, nil
+	}
+	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
+
+	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
+	if err != nil {
+		t.Fatalf("emitGenArtifact() error = %v", err)
+	}
+	if string(got) != "; external llvm ir" {
+		t.Fatalf("llvm ir = %q, want external output", got)
+	}
+	if result == nil || len(result.Warnings) != 1 || result.Warnings[0].Error() != "external warning" {
+		t.Fatalf("warnings = %#v, want external warning", result)
+	}
+}
+
+func TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let mut pair = Pair { left: 1, right: 2 }
+    pair.left = 3
+    println(pair.left)
+}
+`)
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+	oldTry := tryExternalGenLLVMIR
+	tryExternalGenLLVMIR = func(*genPackageEntry) ([]byte, bool, []error, error) {
+		return nil, false, nil, nil
+	}
+	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
+	backendEntry, err := prepareGenBackendEntry("main", entry)
+	if err != nil {
+		t.Fatalf("prepareGenBackendEntry() error = %v", err)
+	}
+	if _, ok, _, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
+	} else if ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered struct field assignment")
+	}
+
+	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
+	if err != nil {
+		t.Fatalf("emitGenArtifact() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("emitGenArtifact() result is nil")
+	}
+	if !strings.Contains(string(got), "%Pair = type { i64, i64 }") {
+		t.Fatalf("fallback llvm-ir missing Pair type:\n%s", got)
 	}
 }
 

--- a/cmd/osty/pipeline.go
+++ b/cmd/osty/pipeline.go
@@ -26,8 +26,8 @@ import (
 //
 // DIR: load → resolve → check → lint over every `.osty` file in the
 // directory as one package (workspaces aren't supported here — point at
-// a leaf package). --gen is logged as skipped because the per-file
-// backend gen doesn't aggregate to package output yet.
+// a leaf package). When --gen is set, multi-file packages lower once as
+// one backend module so sibling declarations share one output artifact.
 //
 // --per-decl threads check.Opts.OnDecl through, so the table grows a
 // per-declaration timing breakdown sorted by total time descending.

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -32,11 +32,7 @@ import (
 //  5. Execute the native backend binary, passing through the
 //     user-supplied arguments after `--`.
 //
-// Limitations (current emitter):
-//
-//   - Multi-file packages aren't fully emitted by the backend yet; run executes
-//     the selected entry file. Complex unsupported lowering shapes may
-//     still produce an unsupported-backend diagnostic.
+// Limitations:
 //
 //   - Registry / git dep code is vendored but NOT yet emitted
 //     together with the entry file — the Workspace loader sees them
@@ -217,15 +213,27 @@ func runRun(args []string, cliF cliFlags) {
 	}
 	binName := runner.BinaryNameFor(binBaseOverride, pkgName, runtime.GOOS)
 	selectedBackend := backendFromCLI("run", backendID)
-	// Multi-file packages must merge every sibling .osty file into one
-	// ir.Module before the backend runs; single-file packages keep the
-	// historical PrepareEntry path. countLowerableFiles lives in
-	// build.go alongside the analogous build-side dispatch.
+	layout := backend.Layout{
+		Root:    root,
+		Profile: resolved.Profile.Name,
+		Target:  triple,
+	}
+	if backendID == backend.NameLLVM {
+		if emitResult, usedExternal, err := tryExternalPackageLLVMArtifacts(context.Background(), emitMode, layout, binName, resolved.Features, entryAbs, rootPkg); usedExternal {
+			if err != nil {
+				exitBackendEmitError("run", emitResult, err)
+			}
+			runNativeBinary(emitResult.Artifacts.Binary, runArgs, runDir)
+			return
+		}
+	}
+	// Package lowering is the default live run path; only degenerate
+	// empty-package callers fall back to a direct single-file entry.
 	var (
 		backendEntry backend.Entry
 		entryErr     error
 	)
-	if rootPkg != nil && countLowerableFiles(rootPkg) > 1 {
+	if rootPkg != nil && countLowerableFiles(rootPkg) > 0 {
 		backendEntry, entryErr = backend.PreparePackage("main", entryAbs, rootPkg, entryFile, chk)
 	} else {
 		backendEntry, entryErr = backend.PrepareEntry("main", entryAbs, file, res, chk)
@@ -235,11 +243,7 @@ func runRun(args []string, cliF cliFlags) {
 		os.Exit(1)
 	}
 	emitResult, err := selectedBackend.Emit(context.Background(), backend.Request{
-		Layout: backend.Layout{
-			Root:    root,
-			Profile: resolved.Profile.Name,
-			Target:  triple,
-		},
+		Layout:     layout,
 		Emit:       emitMode,
 		Entry:      backendEntry,
 		BinaryName: binName,
@@ -274,4 +278,3 @@ func runNativeBinary(binPath string, args []string, dir string) {
 		os.Exit(1)
 	}
 }
-

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -642,6 +642,22 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 		binName = "osty_test_bundle_probe"
 	}
 	layoutRoot := filepath.Join(tmpRoot, "bundle-"+binName)
+	if result, usedExternal, err := tryExternalPackageLLVMArtifacts(ctx, backend.EmitObject, backend.Layout{
+		Root:    layoutRoot,
+		Profile: "test",
+	}, "", nil, sourcePath, pkg); usedExternal {
+		if err != nil {
+			return nativeTestBundleAssets{}, err
+		}
+		runtimeObject, err := backend.EnsureRuntimeObject(ctx, result.Artifacts, "")
+		if err != nil {
+			return nativeTestBundleAssets{}, err
+		}
+		return nativeTestBundleAssets{
+			ObjectPath:        result.Artifacts.Object,
+			RuntimeObjectPath: runtimeObject,
+		}, nil
+	}
 	entry, err := backend.PrepareEntry("main", sourcePath, file, res, chk)
 	if err != nil {
 		return nativeTestBundleAssets{}, err

--- a/cmd/osty/test_native_test.go
+++ b/cmd/osty/test_native_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/osty/osty/internal/backend"
+	"github.com/osty/osty/internal/resolve"
 )
 
 func TestRunTestMainPassesNativeLLVMTest(t *testing.T) {
@@ -38,6 +42,66 @@ fn testAdd() {
 	}
 	if got := stderr.String(); strings.TrimSpace(got) != "" {
 		t.Fatalf("stderr = %q, want empty stderr", got)
+	}
+}
+
+func TestCompileNativeTestBundleUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
+	dir := t.TempDir()
+	path := writeNativeTestFile(t, dir, "lib_test.osty", `fn testAdd() {}
+`)
+	pkg := &resolve.Package{
+		Dir:  dir,
+		Name: "demo",
+		Files: []*resolve.PackageFile{
+			{Path: path, Source: []byte("fn testAdd() {}\n")},
+		},
+	}
+
+	oldTryIR := tryExternalPackageLLVMIR
+	oldEmit := emitPrebuiltLLVMIR
+	t.Cleanup(func() {
+		tryExternalPackageLLVMIR = oldTryIR
+		emitPrebuiltLLVMIR = oldEmit
+	})
+
+	objectPath := filepath.Join(t.TempDir(), "bundle.o")
+	tryExternalPackageLLVMIR = func(entryPath string, gotPkg *resolve.Package) ([]byte, bool, []error, error) {
+		if entryPath != path {
+			t.Fatalf("entryPath = %q, want %q", entryPath, path)
+		}
+		if gotPkg != pkg {
+			t.Fatal("got unexpected package pointer")
+		}
+		return []byte("; external ir"), true, nil, nil
+	}
+	emitPrebuiltLLVMIR = func(_ context.Context, req backend.Request, irOut []byte, warnings []error) (*backend.Result, error) {
+		if req.Emit != backend.EmitObject {
+			t.Fatalf("emit mode = %q, want object", req.Emit)
+		}
+		if req.BinaryName != "" {
+			t.Fatalf("binaryName = %q, want empty", req.BinaryName)
+		}
+		if string(irOut) != "; external ir" {
+			t.Fatalf("irOut = %q, want external ir", irOut)
+		}
+		return &backend.Result{
+			Backend: backend.NameLLVM,
+			Emit:    backend.EmitObject,
+			Artifacts: backend.Artifacts{
+				Object: objectPath,
+			},
+		}, nil
+	}
+
+	assets, err := compileNativeTestBundle(context.Background(), backend.LLVMBackend{}, t.TempDir(), pkg, nativeTestBundle{SourcePath: path})
+	if err != nil {
+		t.Fatalf("compileNativeTestBundle() error = %v", err)
+	}
+	if assets.ObjectPath != objectPath {
+		t.Fatalf("object path = %q, want %q", assets.ObjectPath, objectPath)
+	}
+	if assets.RuntimeObjectPath != "" {
+		t.Fatalf("runtime object path = %q, want empty when external result has no runtime dir", assets.RuntimeObjectPath)
 	}
 }
 

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -37,6 +37,90 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if err := ValidateEmit(NameLLVM, req.Emit); err != nil {
 		return nil, err
 	}
+	irOut, warnings, genErr := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit)
+	if genErr == nil {
+		return b.emitPrebuiltIR(ctx, req, irOut, warnings)
+	}
+	out, err := b.preparePrebuiltIRResult(req, irOut, warnings)
+	if err != nil {
+		return nil, err
+	}
+	return out, genErr
+}
+
+// EmitLLVMIRText runs the LLVM lowering pipeline for one prepared entry and
+// returns the textual IR bytes directly, without creating artifact paths.
+func EmitLLVMIRText(entry Entry, target string, features []string) ([]byte, []error, error) {
+	return generateLLVMIR(entry, target, features, EmitLLVMIR)
+}
+
+// TryEmitNativeOwnedLLVMIRText runs only the native-owned llvmgen fast path
+// mirrored from toolchain/llvmgen.osty. It returns ok=false when the entry's
+// IR module is still outside that slice and the caller should choose a
+// fallback path.
+func TryEmitNativeOwnedLLVMIRText(entry Entry, target string) ([]byte, bool, []error, error) {
+	if entry.IR == nil {
+		return nil, false, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
+	}
+	out, ok, err := llvmgen.TryGenerateNativeOwnedModule(entry.IR, llvmgen.Options{
+		PackageName: entry.PackageName,
+		SourcePath:  entry.SourcePath,
+		Source:      entry.Source,
+		Target:      target,
+	})
+	warnings := append([]error(nil), entry.IRIssues...)
+	if err != nil || !ok {
+		return out, ok, warnings, err
+	}
+	return out, true, warnings, nil
+}
+
+// EmitPrebuiltLLVMIR materializes already-generated LLVM IR into the standard
+// backend artifact layout and optionally compiles/links it for object/binary
+// requests.
+func EmitPrebuiltLLVMIR(ctx context.Context, req Request, irOut []byte, warnings []error) (*Result, error) {
+	return LLVMBackend{}.emitPrebuiltIR(ctx, req, irOut, warnings)
+}
+
+func (b LLVMBackend) emitPrebuiltIR(ctx context.Context, req Request, irOut []byte, warnings []error) (*Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out, err := b.preparePrebuiltIRResult(req, irOut, warnings)
+	if err != nil {
+		return nil, err
+	}
+	if !llvmgen.NeedsObjectArtifact(req.Emit.String()) {
+		return out, nil
+	}
+	tc := b.llvmToolchain()
+	if err := tc.CompileObject(ctx, out.Artifacts.LLVMIR, out.Artifacts.Object, req.Layout.Target); err != nil {
+		return out, err
+	}
+	if !llvmgen.NeedsBinaryArtifact(req.Emit.String()) {
+		return out, nil
+	}
+	if out.Artifacts.Binary == "" {
+		return out, fmt.Errorf("%s", llvmgen.MissingBinaryArtifactMessage())
+	}
+	runtimeObject, err := ensureLocalGCRuntimeObject(ctx, tc, out.Artifacts, req.Layout.Target)
+	if err != nil {
+		return out, err
+	}
+	linkObjects := []string{out.Artifacts.Object}
+	if runtimeObject != "" {
+		linkObjects = append(linkObjects, runtimeObject)
+	}
+	if err := tc.LinkBinary(ctx, linkObjects, out.Artifacts.Binary, req.Layout.Target); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (b LLVMBackend) preparePrebuiltIRResult(req Request, irOut []byte, warnings []error) (*Result, error) {
+	if err := ValidateEmit(NameLLVM, req.Emit); err != nil {
+		return nil, err
+	}
 	artifacts := req.Artifacts(NameLLVM)
 	if err := os.MkdirAll(artifacts.OutputDir, 0o755); err != nil {
 		return nil, err
@@ -49,55 +133,27 @@ func (b LLVMBackend) Emit(ctx context.Context, req Request) (*Result, error) {
 	if artifacts.LLVMIR == "" {
 		return nil, fmt.Errorf("llvm backend: missing LLVM IR artifact path")
 	}
-	irOut, warnings, genErr := generateLLVMIR(req.Entry, req.Layout.Target, req.Features, req.Emit)
 	if err := os.WriteFile(artifacts.LLVMIR, irOut, 0o644); err != nil {
 		return nil, err
 	}
-	out := &Result{
+	return &Result{
 		Backend:   NameLLVM,
 		Emit:      req.Emit,
 		Artifacts: artifacts,
-		Warnings:  warnings,
-	}
-	if genErr == nil {
-		if !llvmgen.NeedsObjectArtifact(req.Emit.String()) {
-			return out, nil
-		}
-		tc := b.llvmToolchain()
-		if err := tc.CompileObject(ctx, artifacts.LLVMIR, artifacts.Object, req.Layout.Target); err != nil {
-			return out, err
-		}
-		if !llvmgen.NeedsBinaryArtifact(req.Emit.String()) {
-			return out, nil
-		}
-		if artifacts.Binary == "" {
-			return out, fmt.Errorf("%s", llvmgen.MissingBinaryArtifactMessage())
-		}
-		runtimeObject, err := ensureLocalGCRuntimeObject(ctx, tc, artifacts, req.Layout.Target)
-		if err != nil {
-			return out, err
-		}
-		linkObjects := []string{artifacts.Object}
-		if runtimeObject != "" {
-			linkObjects = append(linkObjects, runtimeObject)
-		}
-		if err := tc.LinkBinary(ctx, linkObjects, artifacts.Binary, req.Layout.Target); err != nil {
-			return out, err
-		}
-		return out, nil
-	}
-	return out, genErr
-}
-
-// EmitLLVMIRText runs the LLVM lowering pipeline for one prepared entry and
-// returns the textual IR bytes directly, without creating artifact paths.
-func EmitLLVMIRText(entry Entry, target string, features []string) ([]byte, []error, error) {
-	return generateLLVMIR(entry, target, features, EmitLLVMIR)
+		Warnings:  append([]error(nil), warnings...),
+	}, nil
 }
 
 func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode) ([]byte, []error, error) {
 	if entry.IR == nil {
 		return nil, nil, fmt.Errorf("llvm backend: missing lowered IR entry")
+	}
+	if useNativeOwnedLLVMIR(features, emit) {
+		if out, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(entry, target); err != nil {
+			return nil, warnings, err
+		} else if ok {
+			return out, warnings, nil
+		}
 	}
 	opts := llvmgen.Options{
 		PackageName: entry.PackageName,
@@ -110,12 +166,12 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	// for entry.File — the AST is a front-end artifact that the LLVM
 	// backend does not consume directly any more.
 	//
-	// MIR-first dispatch now defaults on the raw `llvm-ir` emission
-	// path. Requests can opt back into the legacy HIR→AST bridge with
-	// the `legacy-llvmgen` feature, or opt further in with
-	// `mir-backend` on object/binary emission while parity continues to
-	// grow. On MIR-emitter refusal we still fall back automatically, so
-	// enabling the new path cannot reduce coverage.
+	// After the native-owned fast path declines coverage, raw `llvm-ir`
+	// still prefers MIR by default. Requests can opt back into the
+	// legacy HIR→AST bridge with `legacy-llvmgen`, or force MIR on every
+	// emit mode with `mir-backend`. On MIR-emitter refusal we still fall
+	// back automatically, so enabling the new path cannot reduce
+	// coverage.
 	var (
 		irOut  []byte
 		genErr error
@@ -237,4 +293,26 @@ func useMIRBackend(features []string, emit EmitMode) bool {
 		return true
 	}
 	return emit == EmitLLVMIR
+}
+
+func useNativeOwnedLLVMIR(features []string, emit EmitMode) bool {
+	if featureEnabled(features, "legacy-llvmgen") {
+		return false
+	}
+	if featureEnabled(features, "mir-backend") {
+		return false
+	}
+	switch emit {
+	case EmitLLVMIR, EmitObject, EmitBinary:
+		return true
+	default:
+		return false
+	}
+}
+
+// UseNativeOwnedLLVMIR reports whether the backend's default dispatch would
+// prefer the native-owned llvmgen fast path for the given feature set and emit
+// mode.
+func UseNativeOwnedLLVMIR(features []string, emit EmitMode) bool {
+	return useNativeOwnedLLVMIR(features, emit)
 }

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -287,6 +287,301 @@ func TestEmitLLVMIRTextMatchesBackendArtifactOutput(t *testing.T) {
 	}
 }
 
+func TestEmitPrebuiltLLVMIRBuildsArtifactsFromProvidedIR(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	root := t.TempDir()
+	req := Request{
+		Layout: Layout{
+			Root:    root,
+			Profile: "debug",
+		},
+		Emit:       EmitBinary,
+		BinaryName: "app",
+	}
+	warnings := []error{os.ErrExist}
+	result, err := backend.emitPrebuiltIR(context.Background(), req, []byte("source_filename = \"fake\"\ndefine i32 @main() { ret i32 0 }\n"), warnings)
+	if err != nil {
+		t.Fatalf("emitPrebuiltIR returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("emitPrebuiltIR returned nil result")
+	}
+	got, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	if want := "source_filename = \"fake\"\ndefine i32 @main() { ret i32 0 }\n"; string(got) != want {
+		t.Fatalf("llvm ir = %q, want %q", got, want)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0] != os.ErrExist {
+		t.Fatalf("warnings = %#v, want propagated warnings", result.Warnings)
+	}
+	if len(tc.irCompiles) != 1 {
+		t.Fatalf("ir compile count = %d, want 1", len(tc.irCompiles))
+	}
+	if len(tc.cCompiles) != 1 {
+		t.Fatalf("runtime compile count = %d, want 1", len(tc.cCompiles))
+	}
+	if len(tc.links) != 1 {
+		t.Fatalf("link count = %d, want 1", len(tc.links))
+	}
+}
+
+func TestTryEmitNativeOwnedLLVMIRTextCoversPrimitiveSlice(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	got, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for primitive slice")
+	}
+	if !strings.Contains(string(got), "define i64 @pick(i1 %flag)") {
+		t.Fatalf("native-owned IR missing pick definition:\n%s", string(got))
+	}
+	if !strings.Contains(string(got), "for.cond") {
+		t.Fatalf("native-owned IR missing loop label:\n%s", string(got))
+	}
+	if len(warnings) != len(req.Entry.IRIssues) {
+		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
+	}
+}
+
+func TestTryEmitNativeOwnedLLVMIRTextReturnsNotCovered(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let mut pair = Pair { left: 1, right: 2 }
+    pair.left = 3
+    println(pair.left)
+}
+`)
+
+	got, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText unexpectedly covered struct field assignment:\n%s", string(got))
+	}
+	if len(got) != 0 {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned IR for uncovered source:\n%s", string(got))
+	}
+	if len(warnings) != len(req.Entry.IRIssues) {
+		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
+	}
+}
+
+func TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for primitive slice")
+	}
+	got, gotWarnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("EmitLLVMIRText did not use native fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(gotWarnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(gotWarnings), len(warnings))
+	}
+}
+
+func TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let mut pair = Pair { left: 1, right: 2 }
+    pair.left = 3
+    println(pair.left)
+}
+`)
+
+	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	} else if ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered struct field assignment")
+	}
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !strings.Contains(string(got), "%Pair = type { i64, i64 }") {
+		t.Fatalf("EmitLLVMIRText fallback IR missing Pair type:\n%s", got)
+	}
+	if len(warnings) != len(req.Entry.IRIssues) {
+		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
+	}
+}
+
+func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathWhenCovered(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for primitive slice")
+	}
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	got, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Emit binary did not use native fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(result.Warnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	}
+}
+
+func TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let mut pair = Pair { left: 1, right: 2 }
+    pair.left = 3
+    println(pair.left)
+}
+`)
+
+	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	} else if ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered struct field assignment")
+	}
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	got, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	if !strings.Contains(string(got), "%Pair = type { i64, i64 }") {
+		t.Fatalf("Emit binary fallback IR missing Pair type:\n%s", got)
+	}
+}
+
+func TestEmitLLVMIRTextMirBackendOverridesNativeFastPath(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`)
+
+	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	} else if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for primitive slice")
+	}
+	got, _, err := EmitLLVMIRText(req.Entry, "", []string{"mir-backend"})
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !strings.Contains(string(got), "osty LLVM MIR backend") {
+		t.Fatalf("mir-backend feature did not override native fast path:\n%s", got)
+	}
+}
+
 func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -301,6 +596,20 @@ func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
 	}
 }
 
+func TestUseNativeOwnedLLVMIRDefaultsEnabled(t *testing.T) {
+	t.Parallel()
+
+	if !useNativeOwnedLLVMIR(nil, EmitLLVMIR) {
+		t.Fatal("useNativeOwnedLLVMIR(nil, EmitLLVMIR) = false, want true")
+	}
+	if !useNativeOwnedLLVMIR(nil, EmitBinary) {
+		t.Fatal("useNativeOwnedLLVMIR(nil, EmitBinary) = false, want true")
+	}
+	if !useNativeOwnedLLVMIR(nil, EmitObject) {
+		t.Fatal("useNativeOwnedLLVMIR(nil, EmitObject) = false, want true")
+	}
+}
+
 func TestUseMIRBackendLegacyFeatureDisables(t *testing.T) {
 	t.Parallel()
 
@@ -309,6 +618,20 @@ func TestUseMIRBackendLegacyFeatureDisables(t *testing.T) {
 	}
 	if useMIRBackend([]string{"mir-backend", "legacy-llvmgen"}, EmitBinary) {
 		t.Fatal("legacy-llvmgen should win when both features are present")
+	}
+}
+
+func TestUseNativeOwnedLLVMIRFeatureOverrides(t *testing.T) {
+	t.Parallel()
+
+	if useNativeOwnedLLVMIR([]string{"legacy-llvmgen"}, EmitBinary) {
+		t.Fatal("useNativeOwnedLLVMIR(legacy-llvmgen, EmitBinary) = true, want false")
+	}
+	if useNativeOwnedLLVMIR([]string{"mir-backend"}, EmitLLVMIR) {
+		t.Fatal("useNativeOwnedLLVMIR(mir-backend, EmitLLVMIR) = true, want false")
+	}
+	if useNativeOwnedLLVMIR([]string{"mir-backend", "legacy-llvmgen"}, EmitObject) {
+		t.Fatal("feature override should disable native fast path when either feature is present")
 	}
 }
 

--- a/internal/backend/prepare_package_test.go
+++ b/internal/backend/prepare_package_test.go
@@ -58,6 +58,32 @@ func TestPreparePackageMergesMultiFileDecls(t *testing.T) {
 	}
 }
 
+func TestPreparePackageSingleFileKeepsEntryFileAndDecl(t *testing.T) {
+	file := &ast.File{Decls: []ast.Decl{
+		&ast.FnDecl{Name: "main", Body: &ast.Block{}},
+	}}
+	pkg := &resolve.Package{
+		Name: "single",
+		Files: []*resolve.PackageFile{
+			{Path: "/main.osty", File: file},
+		},
+	}
+
+	entry, err := PreparePackage("main", "/main.osty", pkg, pkg.Files[0], nil)
+	if err != nil {
+		t.Fatalf("PreparePackage returned error: %v", err)
+	}
+	if entry.File != file {
+		t.Fatalf("Entry.File = %p, want %p", entry.File, file)
+	}
+	if entry.IR == nil || len(entry.IR.Decls) != 1 {
+		t.Fatalf("Entry.IR.Decls len = %d, want 1", len(entry.IR.Decls))
+	}
+	if fn, ok := entry.IR.Decls[0].(*ir.FnDecl); !ok || fn.Name != "main" {
+		t.Fatalf("Entry.IR.Decls[0] = %#v, want ir.FnDecl main", entry.IR.Decls[0])
+	}
+}
+
 // TestPreparePackageNilPackage rejects the obviously-bad input so a
 // regression in the build orchestrator surfaces here instead of as
 // a nil-deref deeper in the lowerer.
@@ -82,9 +108,9 @@ func TestPreparePackagePicksFirstNonNilFileWhenEntryUnset(t *testing.T) {
 	pkg := &resolve.Package{
 		Name: "pick",
 		Files: []*resolve.PackageFile{
-			nil,                                // resolver may emit a nil slot
-			{Path: "/skip.osty", File: nil},    // parse-failed slot
-			{Path: "/a.osty", File: fileA},     // first viable
+			nil,                             // resolver may emit a nil slot
+			{Path: "/skip.osty", File: nil}, // parse-failed slot
+			{Path: "/a.osty", File: fileA},  // first viable
 			{Path: "/b.osty", File: fileB},
 		},
 	}

--- a/internal/llvmgen/doc.go
+++ b/internal/llvmgen/doc.go
@@ -2,9 +2,13 @@
 //
 // Public API surface (IR-only)
 //
-//   - GenerateModule(*ir.Module, Options) ([]byte, error) — the sole
-//     entry point for code generation. Consumes the backend-neutral
-//     IR produced by `internal/ir`.
+//   - GenerateModule(*ir.Module, Options) ([]byte, error) — the
+//     primary entry point for code generation. Consumes the
+//     backend-neutral IR produced by `internal/ir`.
+//   - TryGenerateNativeOwnedModule(*ir.Module, Options)
+//     ([]byte, bool, error) — native-owned primitive/control-flow
+//     fast path only. Returns ok=false when the module still needs the
+//     transitional legacy fallback.
 //
 // The package previously exposed Generate(*ast.File, Options) as an
 // alternate entry point. That AST route has been removed: the LLVM
@@ -36,8 +40,9 @@
 // GenerateModule now first tries a native-owned primitive/control-flow
 // slice mirrored from `toolchain/llvmgen.osty` and falls back to the
 // legacy IR -> AST bridge only for shapes still outside that slice
-// (see ir_module.go). The bridge remains an implementation detail that
-// the public API does not expose — callers neither construct nor
+// (see ir_module.go). TryGenerateNativeOwnedModule exposes just that
+// native-owned slice without taking the fallback. The bridge remains a
+// transitional implementation detail: callers never construct nor
 // observe the intermediate AST. Follow-on work will keep growing the
 // native path until the fallback disappears entirely.
 //

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -22,19 +22,10 @@ import (
 // is unexported. Once the emitter consumes IR directly end-to-end, the
 // fallback bridge and the AST helper both go away.
 func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
-	if mod == nil {
-		return nil, unsupported("source-layout", "nil module")
-	}
-	if err := validateLegacyFFISurface(mod); err != nil {
-		return nil, err
-	}
-	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
-		return nil, &UnsupportedError{Diagnostic: diag}
-	}
-	if out, ok, err := tryNativeOwnedModule(mod, opts); err != nil {
+	if out, ok, err := TryGenerateNativeOwnedModule(mod, opts); err != nil {
 		return nil, err
 	} else if ok {
-		return finalizeLegacyFFISurface(out, mod), nil
+		return out, nil
 	}
 	file, err := legacyFileFromModule(mod)
 	if err != nil {
@@ -59,6 +50,19 @@ func GenerateModule(mod *ostyir.Module, opts Options) ([]byte, error) {
 		return nil, err
 	}
 	return finalizeLegacyFFISurface(out, mod), nil
+}
+
+func prepareModuleGeneration(mod *ostyir.Module) error {
+	if mod == nil {
+		return unsupported("source-layout", "nil module")
+	}
+	if err := validateLegacyFFISurface(mod); err != nil {
+		return err
+	}
+	if diag, ok := moduleUnsupportedDiagnostic(mod); ok {
+		return &UnsupportedError{Diagnostic: diag}
+	}
+	return nil
 }
 
 // validateLegacyFFISurface rejects FFI-only contracts the legacy

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -22,6 +22,24 @@ type nativeProjectionCtx struct {
 	structsByName map[string]*nativeStructInfo
 }
 
+// TryGenerateNativeOwnedModule emits textual LLVM IR only through the
+// native-owned primitive/control-flow slice mirrored from
+// toolchain/llvmgen.osty.
+//
+// ok=false means "shape not covered yet" and callers should choose a
+// fallback path themselves. Unlike GenerateModule, this helper never
+// falls back to the transitional IR -> AST bridge.
+func TryGenerateNativeOwnedModule(mod *ostyir.Module, opts Options) ([]byte, bool, error) {
+	if err := prepareModuleGeneration(mod); err != nil {
+		return nil, false, err
+	}
+	out, ok, err := tryNativeOwnedModule(mod, opts)
+	if err != nil || !ok {
+		return out, ok, err
+	}
+	return finalizeLegacyFFISurface(out, mod), true, nil
+}
+
 // tryNativeOwnedModule projects the IR module into the native-owned
 // primitive/control-flow slice mirrored from toolchain/llvmgen.osty.
 // ok=false means "shape not covered yet" and callers should fall back to the

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -77,6 +77,53 @@ fn main() {
 	}
 }
 
+func TestTryGenerateNativeOwnedModulePrimitiveSlice(t *testing.T) {
+	src := `fn pick(flag: Bool) -> Int {
+    if flag {
+        42
+    } else {
+        0
+    }
+}
+
+fn main() {
+    let mut i = 0
+    let mut sum = 0
+    for i < 3 {
+        sum = sum + pick(i == 2)
+        i = i + 1
+    }
+    println(sum)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_try.osty"}
+	out, ok, err := TryGenerateNativeOwnedModule(mod, opts)
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported not covered for primitive slice")
+	}
+	for _, want := range []string{
+		"define i64 @pick(i1 %flag)",
+		"phi i64",
+		"for.cond",
+		"call i64 @pick(i1",
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("native-owned helper IR missing %q:\n%s", want, string(out))
+		}
+	}
+	generated, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(generated) != string(out) {
+		t.Fatalf("TryGenerateNativeOwnedModule diverged from GenerateModule\n--- try ---\n%s\n--- generate ---\n%s", string(out), string(generated))
+	}
+}
+
 func TestNativeOwnedModuleEntryStructSlice(t *testing.T) {
 	src := `struct Pair { left: Int, right: Int }
 
@@ -130,5 +177,62 @@ fn main() {
 	}
 	if !strings.Contains(string(out), "%Pair = type { i64, i64 }") {
 		t.Fatalf("legacy fallback IR missing struct definition:\n%s", string(out))
+	}
+}
+
+func TestTryGenerateNativeOwnedModuleReturnsNotCoveredForStructFieldAssign(t *testing.T) {
+	src := `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let mut pair = Pair { left: 1, right: 2 }
+    pair.left = 3
+    println(pair.left)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_try_struct_assign.osty"}
+	out, ok, err := TryGenerateNativeOwnedModule(mod, opts)
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("TryGenerateNativeOwnedModule unexpectedly covered struct field assignment:\n%s", string(out))
+	}
+	if len(out) != 0 {
+		t.Fatalf("TryGenerateNativeOwnedModule returned IR for uncovered module:\n%s", string(out))
+	}
+}
+
+func TestTryGenerateNativeOwnedModuleAppliesExportAndCABI(t *testing.T) {
+	mod := &ostyir.Module{
+		Package: "main",
+		Decls: []ostyir.Decl{
+			&ostyir.FnDecl{
+				Name:         "native_entry_v1",
+				ExportSymbol: "osty.gc.native_entry_v1",
+				CABI:         true,
+				Return:       &ostyir.PrimType{Kind: ostyir.PrimInt},
+				Body: &ostyir.Block{
+					Result: &ostyir.IntLit{Text: "0"},
+				},
+			},
+		},
+	}
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_entry_export_cabi.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported not covered for exported C ABI function")
+	}
+	got := string(out)
+	if !strings.Contains(got, "define ccc i64 @native_entry_v1()") {
+		t.Fatalf("native-owned helper IR missing C ABI calling convention:\n%s", got)
+	}
+	if !strings.Contains(got, "@osty.gc.native_entry_v1 = dso_local alias ptr, ptr @native_entry_v1") {
+		t.Fatalf("native-owned helper IR missing export alias:\n%s", got)
 	}
 }

--- a/internal/llvmgen/toolchain_support_bundle.go
+++ b/internal/llvmgen/toolchain_support_bundle.go
@@ -1,86 +1,20 @@
 package llvmgen
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
+	"github.com/osty/osty/internal/selfhost/bundle"
 )
 
-var toolchainSupportFiles = []string{
-	"toolchain/llvmgen.osty",
-}
-
-const llvmgenStringsPrelude = `use go "strings" as llvmStrings {
-    fn Contains(s: String, substr: String) -> Bool
-    fn HasPrefix(s: String, prefix: String) -> Bool
-    fn Join(elems: List<String>, sep: String) -> String
-    fn Split(s: String, sep: String) -> List<String>
-    fn TrimPrefix(s: String, prefix: String) -> String
-}
-
-fn ostyStringsContains(s: String, substr: String) -> Bool { llvmStrings.Contains(s, substr) }
-fn ostyStringsHasPrefix(s: String, prefix: String) -> Bool { llvmStrings.HasPrefix(s, prefix) }
-`
-
 // ToolchainSupportFiles returns the Osty-authored llvmgen helper sources that
-// can be transpiled through the bootstrap path today.
+// can be transpiled through the bootstrap path today. The canonical file list
+// now lives in internal/selfhost/bundle so the future selfhost llvmgen bridge
+// and the current support snapshot regen share one merge contract.
 func ToolchainSupportFiles() []string {
-	return append([]string(nil), toolchainSupportFiles...)
+	return bundle.ToolchainLLVMGenFiles()
 }
 
 // MergeToolchainSupport prepends the minimal Go-hosted strings surface the
 // bootstrap transpiler needs, then concatenates the llvmgen helper sources into
 // one standalone .osty file.
 func MergeToolchainSupport(root string) ([]byte, error) {
-	var b strings.Builder
-	b.WriteString(llvmgenStringsPrelude)
-	b.WriteByte('\n')
-
-	for _, rel := range toolchainSupportFiles {
-		path := filepath.Join(root, filepath.FromSlash(rel))
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", rel, err)
-		}
-		b.WriteString("// ---- ")
-		b.WriteString(rel)
-		b.WriteString(" ----\n")
-		trimmed := stripLeadingLlvmgenStringsUse(string(data))
-		trimmed = normalizeLlvmgenStdStringsCalls(trimmed)
-		b.WriteString(trimmed)
-		if !strings.HasSuffix(trimmed, "\n") {
-			b.WriteByte('\n')
-		}
-		b.WriteByte('\n')
-	}
-
-	return []byte(b.String()), nil
-}
-
-func stripLeadingLlvmgenStringsUse(src string) string {
-	const prefix = "use std.strings as llvmStrings"
-
-	lines := strings.SplitAfter(src, "\n")
-	for i, line := range lines {
-		if strings.TrimSpace(line) != prefix {
-			continue
-		}
-		return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
-	}
-	return src
-}
-
-func normalizeLlvmgenStdStringsCalls(src string) string {
-	for _, pair := range [][2]string{
-		{"llvmStrings.join(", "llvmStrings.Join("},
-		{"llvmStrings.split(", "llvmStrings.Split("},
-		{"llvmStrings.trimPrefix(", "llvmStrings.TrimPrefix("},
-		{"target.contains(", "ostyStringsContains(target, "},
-		{"path.startsWith(", "ostyStringsHasPrefix(path, "},
-		{"trimmed.startsWith(", "ostyStringsHasPrefix(trimmed, "},
-	} {
-		src = strings.ReplaceAll(src, pair[0], pair[1])
-	}
-	return src
+	return bundle.MergeToolchainLLVMGen(root)
 }

--- a/internal/nativellvmgen/exec.go
+++ b/internal/nativellvmgen/exec.go
@@ -1,0 +1,149 @@
+package nativellvmgen
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/toolchain"
+)
+
+const Env = "OSTY_NATIVE_LLVMGEN_BIN"
+
+type Request struct {
+	Path    string        `json:"path,omitempty"`
+	Source  string        `json:"source,omitempty"`
+	Package *PackageInput `json:"package,omitempty"`
+}
+
+type PackageInput struct {
+	Files []PackageFile `json:"files,omitempty"`
+}
+
+type PackageFile struct {
+	Path   string `json:"path,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+type Response struct {
+	Covered  bool     `json:"covered"`
+	LLVMIR   string   `json:"llvmIr,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+var ensureManagedBinary = func(start string) (string, error) {
+	return toolchain.EnsureNativeLLVMGen(start)
+}
+
+func ResolveBinary(start string) (string, error) {
+	if override := strings.TrimSpace(os.Getenv(Env)); override != "" {
+		return override, nil
+	}
+	return ensureManagedBinary(start)
+}
+
+func Run(start string, req Request) (Response, error) {
+	path, err := ResolveBinary(start)
+	if err != nil {
+		return Response{}, err
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("marshal native llvmgen request: %w", err)
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(payload)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = "<no output>"
+		}
+		return Response{}, fmt.Errorf("exec %s: %w (%s)", path, err, msg)
+	}
+	var resp Response
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return Response{}, fmt.Errorf("decode native llvmgen response: %w", err)
+	}
+	return resp, nil
+}
+
+func TrySource(start, path string, src []byte) ([]byte, bool, []error, error) {
+	resp, err := Run(start, Request{
+		Path:   path,
+		Source: string(src),
+	})
+	if err != nil {
+		return nil, false, nil, err
+	}
+	return []byte(resp.LLVMIR), resp.Covered, warningErrors(resp.Warnings), nil
+}
+
+func TryPackage(start, entryPath string, pkg *resolve.Package) ([]byte, bool, []error, error) {
+	req, err := RequestFromPackage(entryPath, pkg)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	resp, err := Run(start, req)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	return []byte(resp.LLVMIR), resp.Covered, warningErrors(resp.Warnings), nil
+}
+
+func RequestFromPackage(entryPath string, pkg *resolve.Package) (Request, error) {
+	if pkg == nil {
+		return Request{}, fmt.Errorf("missing package input for native llvmgen")
+	}
+	files := make([]PackageFile, 0, len(pkg.Files))
+	for i, pf := range pkg.Files {
+		if pf == nil {
+			continue
+		}
+		name := strings.TrimSpace(filepath.Base(pf.Path))
+		if name == "." || name == string(filepath.Separator) {
+			name = ""
+		}
+		if name == "" {
+			name = fmt.Sprintf("file%d.osty", i)
+		}
+		files = append(files, PackageFile{
+			Path:   pf.Path,
+			Name:   name,
+			Source: string(pf.Source),
+		})
+	}
+	if len(files) == 0 {
+		return Request{}, fmt.Errorf("native llvmgen package has no source files")
+	}
+	return Request{
+		Path: entryPath,
+		Package: &PackageInput{
+			Files: files,
+		},
+	}, nil
+}
+
+func warningErrors(warnings []string) []error {
+	if len(warnings) == 0 {
+		return nil
+	}
+	out := make([]error, 0, len(warnings))
+	for _, warning := range warnings {
+		if strings.TrimSpace(warning) == "" {
+			continue
+		}
+		out = append(out, errors.New(warning))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/nativellvmgen/exec_test.go
+++ b/internal/nativellvmgen/exec_test.go
@@ -1,0 +1,164 @@
+package nativellvmgen
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestTrySourceUsesEnvBinaryAndDecodesResponse(t *testing.T) {
+	bin := buildFakeNativeLLVMGen(t)
+	capture := filepath.Join(t.TempDir(), "request.json")
+
+	t.Setenv(Env, bin)
+	t.Setenv("FAKE_NATIVE_LLVMGEN_CAPTURE", capture)
+	t.Setenv("FAKE_NATIVE_LLVMGEN_RESPONSE", `{"covered":true,"llvmIr":"define i64 @main()","warnings":["from-external"]}`)
+
+	oldEnsure := ensureManagedBinary
+	ensureManagedBinary = func(string) (string, error) {
+		t.Fatal("ensureManagedBinary should not be called when env override is set")
+		return "", nil
+	}
+	t.Cleanup(func() { ensureManagedBinary = oldEnsure })
+
+	ir, ok, warnings, err := TrySource(".", "main.osty", []byte("fn main() {}\n"))
+	if err != nil {
+		t.Fatalf("TrySource error: %v", err)
+	}
+	if !ok {
+		t.Fatal("covered = false, want true")
+	}
+	if got, want := string(ir), "define i64 @main()"; got != want {
+		t.Fatalf("llvm ir = %q, want %q", got, want)
+	}
+	if len(warnings) != 1 || warnings[0].Error() != "from-external" {
+		t.Fatalf("warnings = %#v, want external warning", warnings)
+	}
+
+	var req Request
+	decodeCapturedRequest(t, capture, &req)
+	if req.Path != "main.osty" {
+		t.Fatalf("request path = %q, want main.osty", req.Path)
+	}
+	if req.Source != "fn main() {}\n" {
+		t.Fatalf("request source = %q, want original source", req.Source)
+	}
+	if req.Package != nil {
+		t.Fatalf("request package = %#v, want nil", req.Package)
+	}
+}
+
+func TestTryPackageUsesManagedBinaryWhenEnvUnset(t *testing.T) {
+	bin := buildFakeNativeLLVMGen(t)
+	capture := filepath.Join(t.TempDir(), "request.json")
+
+	t.Setenv(Env, "")
+	t.Setenv("FAKE_NATIVE_LLVMGEN_CAPTURE", capture)
+	t.Setenv("FAKE_NATIVE_LLVMGEN_RESPONSE", `{"covered":true,"llvmIr":"define i64 @helper()","warnings":["pkg-warning"]}`)
+
+	oldEnsure := ensureManagedBinary
+	ensureManagedBinary = func(string) (string, error) { return bin, nil }
+	t.Cleanup(func() { ensureManagedBinary = oldEnsure })
+
+	pkg := &resolve.Package{
+		Dir:  "/tmp/demo",
+		Name: "demo",
+		Files: []*resolve.PackageFile{
+			{Path: "/tmp/demo/a.osty", Source: []byte("pub fn helper() -> Int { 1 }\n")},
+			{Path: "/tmp/demo/b.osty", Source: []byte("fn main() { println(helper()) }\n")},
+		},
+	}
+
+	ir, ok, warnings, err := TryPackage(".", "/tmp/demo/b.osty", pkg)
+	if err != nil {
+		t.Fatalf("TryPackage error: %v", err)
+	}
+	if !ok {
+		t.Fatal("covered = false, want true")
+	}
+	if got, want := string(ir), "define i64 @helper()"; got != want {
+		t.Fatalf("llvm ir = %q, want %q", got, want)
+	}
+	if len(warnings) != 1 || warnings[0].Error() != "pkg-warning" {
+		t.Fatalf("warnings = %#v, want pkg-warning", warnings)
+	}
+
+	var req Request
+	decodeCapturedRequest(t, capture, &req)
+	if req.Path != "/tmp/demo/b.osty" {
+		t.Fatalf("request path = %q, want entry path", req.Path)
+	}
+	if req.Package == nil || len(req.Package.Files) != 2 {
+		t.Fatalf("package files = %#v, want 2 files", req.Package)
+	}
+	if got := req.Package.Files[0].Path; got != "/tmp/demo/a.osty" {
+		t.Fatalf("file[0].path = %q, want /tmp/demo/a.osty", got)
+	}
+	if got := req.Package.Files[1].Name; got != "b.osty" {
+		t.Fatalf("file[1].name = %q, want b.osty", got)
+	}
+}
+
+func buildFakeNativeLLVMGen(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte(fakeNativeLLVMGenProgram), 0o644); err != nil {
+		t.Fatalf("write fake native llvmgen: %v", err)
+	}
+	name := "fake-native-llvmgen"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(dir, name)
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build fake native llvmgen: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func decodeCapturedRequest(t *testing.T, path string, out any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+const fakeNativeLLVMGenProgram = `package main
+
+import (
+	"io"
+	"os"
+)
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	if capture := os.Getenv("FAKE_NATIVE_LLVMGEN_CAPTURE"); capture != "" {
+		if err := os.WriteFile(capture, data, 0o644); err != nil {
+			panic(err)
+		}
+	}
+	if stderr := os.Getenv("FAKE_NATIVE_LLVMGEN_STDERR"); stderr != "" {
+		_, _ = os.Stderr.WriteString(stderr)
+	}
+	if code := os.Getenv("FAKE_NATIVE_LLVMGEN_EXIT"); code != "" && code != "0" {
+		os.Exit(1)
+	}
+	_, _ = os.Stdout.WriteString(os.Getenv("FAKE_NATIVE_LLVMGEN_RESPONSE"))
+}
+`

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -4,9 +4,10 @@
 // subcommand and the `--trace` global flag — both want the same
 // numbers, just rendered differently.
 //
-// Single-file mode only. The package isn't trying to subsume the
-// manifest-driven build orchestrator; for multi-file packages call
-// resolve.LoadPackage / check.Package directly.
+// The core Run/RunWithConfig entry points operate on a single source
+// buffer. Package/workspace helpers live here too for CLI tracing and
+// package-aware `--gen`, but this package still stops short of the
+// manifest-driven build orchestrator.
 package pipeline
 
 import (
@@ -25,12 +26,20 @@ import (
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/lexer"
 	"github.com/osty/osty/internal/lint"
+	"github.com/osty/osty/internal/nativellvmgen"
 	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
 )
+
+var tryExternalPipelineLLVMIR = func(entryPath string, pkg *resolve.Package) ([]byte, bool, []error, error) {
+	if pkg == nil {
+		return nil, false, nil, nil
+	}
+	return nativellvmgen.TryPackage(".", entryPath, pkg)
+}
 
 // declName returns the user-visible name of a top-level declaration,
 // or a placeholder when the AST node has no Name field. Used by the
@@ -252,25 +261,26 @@ func genHeader(name backend.Name, path string) string {
 	return fmt.Sprintf("\n; ---- %s ----\n", path)
 }
 
-func emitConfiguredGen(cfg Config, pkgName string, file *ast.File, res *resolve.Result, chk *check.Result, sourcePath string) ([]byte, error) {
-	name := configuredGenBackend(cfg)
-	mode := configuredGenEmit(cfg, name)
+func emitConfiguredGenPrepared(name backend.Name, mode backend.EmitMode, entry backend.Entry) ([]byte, error) {
+	if name == backend.NameLLVM && mode == backend.EmitLLVMIR {
+		out, warnings, emitErr := backend.EmitLLVMIRText(entry, "", nil)
+		if emitErr != nil {
+			return out, emitErr
+		}
+		if len(warnings) > 0 {
+			return out, warnings[0]
+		}
+		return out, nil
+	}
 	b, err := backend.New(name)
 	if err != nil {
 		return nil, err
-	}
-	if sourcePath == "" {
-		sourcePath = "<pipeline>"
 	}
 	tmpRoot, err := os.MkdirTemp("", "osty-pipeline-gen-*")
 	if err != nil {
 		return nil, err
 	}
 	defer os.RemoveAll(tmpRoot)
-	entry, err := backend.PrepareEntry(pkgName, sourcePath, file, res, chk)
-	if err != nil {
-		return nil, err
-	}
 
 	result, emitErr := b.Emit(context.Background(), backend.Request{
 		Layout: backend.Layout{
@@ -304,6 +314,73 @@ func emitConfiguredGen(cfg Config, pkgName string, file *ast.File, res *resolve.
 		return out, result.Warnings[0]
 	}
 	return out, nil
+}
+
+func emitConfiguredGen(cfg Config, pkgName string, file *ast.File, res *resolve.Result, chk *check.Result, sourcePath string) ([]byte, error) {
+	name := configuredGenBackend(cfg)
+	mode := configuredGenEmit(cfg, name)
+	if sourcePath == "" {
+		sourcePath = "<pipeline>"
+	}
+	entry, err := backend.PrepareEntry(pkgName, sourcePath, file, res, chk)
+	if err != nil {
+		return nil, err
+	}
+	return emitConfiguredGenPrepared(name, mode, entry)
+}
+
+func countLowerableFiles(pkg *resolve.Package) int {
+	if pkg == nil {
+		return 0
+	}
+	n := 0
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.File != nil {
+			n++
+		}
+	}
+	return n
+}
+
+func packageEntryFile(pkg *resolve.Package) *resolve.PackageFile {
+	if pkg == nil {
+		return nil
+	}
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.File != nil {
+			return pf
+		}
+	}
+	return nil
+}
+
+func emitConfiguredGenPackage(cfg Config, pkgName string, pkg *resolve.Package, chk *check.Result) ([]byte, error) {
+	if pkg == nil {
+		return nil, fmt.Errorf("missing package input for pipeline gen")
+	}
+	entryFile := packageEntryFile(pkg)
+	if entryFile == nil {
+		return nil, nil
+	}
+	name := configuredGenBackend(cfg)
+	mode := configuredGenEmit(cfg, name)
+	if name == backend.NameLLVM && mode == backend.EmitLLVMIR {
+		if out, ok, warnings, err := tryExternalPipelineLLVMIR(entryFile.Path, pkg); err == nil && ok {
+			if len(warnings) > 0 {
+				return out, warnings[0]
+			}
+			return out, nil
+		}
+	}
+	sourcePath := entryFile.Path
+	if sourcePath == "" {
+		sourcePath = "<pipeline>"
+	}
+	entry, err := backend.PreparePackage(pkgName, sourcePath, pkg, entryFile, chk)
+	if err != nil {
+		return nil, err
+	}
+	return emitConfiguredGenPrepared(name, mode, entry)
 }
 
 // Run executes lex → parse → resolve → check → lint over src with
@@ -622,46 +699,27 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 		Counts:   map[string]int{"findings": len(lintDiags)},
 	})
 
-	// gen (optional, per-file aggregated). Backend emission is per-file;
-	// in package mode we run it once per file with that file's
-	// resolve view but the shared check.Result, then sum bytes-out
-	// and surface the first fatal error. Output bytes are concatenated
-	// into r.GenBytes with file headers so a downstream consumer can
-	// still reconstruct per-file boundaries.
+	// gen (optional, package-aware). Multi-file packages now lower once
+	// through backend.PreparePackage so sibling declarations share a
+	// single module; single-file packages keep the historical path.
 	if cfg.RunGen {
 		t0 = time.Now()
 		pkgName := genPackageName(cfg.GenPackageName, pkg.Name)
 		name := configuredGenBackend(cfg)
 		mode := configuredGenEmit(cfg, name)
-		var genBuf []byte
-		var firstErr error
+		out, err := emitConfiguredGenPackage(cfg, pkgName, pkg, chk)
+		r.GenBytes = out
+		r.GenError = err
 		genErrs := 0
-		for _, pf := range pkg.Files {
-			if pf.File == nil {
-				continue
-			}
-			fileRes := &resolve.Result{
-				Refs:      pf.Refs,
-				TypeRefs:  pf.TypeRefs,
-				FileScope: pf.FileScope,
-			}
-			out, err := emitConfiguredGen(cfg, pkgName, pf.File, fileRes, chk, pf.Path)
-			genBuf = append(genBuf, []byte(genHeader(name, pf.Path))...)
-			genBuf = append(genBuf, out...)
-			if err != nil {
-				genErrs++
-				if firstErr == nil {
-					firstErr = err
-				}
-			}
+		if err != nil {
+			genErrs = 1
 		}
-		r.GenBytes = genBuf
-		r.GenError = firstErr
+		lowerableFiles := countLowerableFiles(pkg)
 		label := genArtifactLabel(name, mode)
-		summary := fmt.Sprintf("%d bytes %s (across %d files)", len(genBuf), label, len(pkg.Files))
-		if firstErr != nil {
-			summary = fmt.Sprintf("%d bytes %s, %d file error(s); first: %v",
-				len(genBuf), label, genErrs, firstErr)
+		summary := fmt.Sprintf("%d bytes %s (package module from %d files)", len(out), label, lowerableFiles)
+		if err != nil {
+			summary = fmt.Sprintf("%d bytes %s (package module from %d files; error: %v)",
+				len(out), label, lowerableFiles, err)
 		}
 		emit(Stage{
 			Name:     "gen",
@@ -670,8 +728,8 @@ func RunLoadedPackage(pkg *resolve.Package, stream io.Writer, cfg Config) Result
 			Errors:   genErrs,
 			Warnings: 0,
 			Counts: map[string]int{
-				"bytes":       len(genBuf),
-				"files":       len(pkg.Files),
+				"bytes":       len(out),
+				"files":       lowerableFiles,
 				"file_errors": genErrs,
 			},
 		})
@@ -866,7 +924,7 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 		Counts:   map[string]int{"findings": len(lintDiags)},
 	})
 
-	// --- gen (workspace-wide aggregation) ---
+	// --- gen (workspace-wide package aggregation) ---
 	if cfg.RunGen {
 		t0 = time.Now()
 		name := configuredGenBackend(cfg)
@@ -882,23 +940,13 @@ func RunWorkspace(dir string, stream io.Writer, cfg Config) (Result, error) {
 			}
 			pkgName := cfg.GenPackageName
 			pkgName = genPackageName(pkgName, pkg.Name)
-			for _, pf := range pkg.Files {
-				if pf.File == nil {
-					continue
-				}
-				fileRes := &resolve.Result{
-					Refs:      pf.Refs,
-					TypeRefs:  pf.TypeRefs,
-					FileScope: pf.FileScope,
-				}
-				out, err := emitConfiguredGen(cfg, pkgName, pf.File, fileRes, cr, pf.Path)
-				genBuf = append(genBuf, []byte(genHeader(name, pf.Path))...)
-				genBuf = append(genBuf, out...)
-				if err != nil {
-					genErrs++
-					if firstErr == nil {
-						firstErr = err
-					}
+			out, err := emitConfiguredGenPackage(cfg, pkgName, pkg, cr)
+			genBuf = append(genBuf, []byte(genHeader(name, pkg.Dir))...)
+			genBuf = append(genBuf, out...)
+			if err != nil {
+				genErrs++
+				if firstErr == nil {
+					firstErr = err
 				}
 			}
 		}

--- a/internal/pipeline/pipeline_gen_test.go
+++ b/internal/pipeline/pipeline_gen_test.go
@@ -1,0 +1,138 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/resolve"
+)
+
+func TestRunLoadedPackageGenUsesPackageLoweringForSiblingFiles(t *testing.T) {
+	dir := t.TempDir()
+	writePipelineTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
+	writePipelineTestFile(t, dir, "b.osty", "fn main() { println(helper()) }\n")
+
+	pkg, err := resolve.LoadPackage(dir)
+	if err != nil {
+		t.Fatalf("LoadPackage() error = %v", err)
+	}
+	got := RunLoadedPackage(pkg, nil, Config{RunGen: true})
+	if got.GenError != nil {
+		t.Fatalf("RunLoadedPackage() gen error = %v\n%s", got.GenError, got.GenBytes)
+	}
+	text := string(got.GenBytes)
+	if strings.Contains(text, "; ---- ") {
+		t.Fatalf("package gen output kept per-file headers:\n%s", text)
+	}
+	if !strings.Contains(text, "define i64 @helper(") {
+		t.Fatalf("package gen output missing helper definition:\n%s", text)
+	}
+	if !strings.Contains(text, "@main(") {
+		t.Fatalf("package gen output missing main definition:\n%s", text)
+	}
+}
+
+func TestRunWorkspaceGenAggregatesPerPackageModules(t *testing.T) {
+	root := t.TempDir()
+	alpha := filepath.Join(root, "alpha")
+	beta := filepath.Join(root, "beta")
+	if err := os.MkdirAll(alpha, 0o755); err != nil {
+		t.Fatalf("MkdirAll(alpha): %v", err)
+	}
+	if err := os.MkdirAll(beta, 0o755); err != nil {
+		t.Fatalf("MkdirAll(beta): %v", err)
+	}
+	writePipelineTestFile(t, alpha, "a.osty", "pub fn helper() -> Int { 1 }\n")
+	writePipelineTestFile(t, alpha, "b.osty", "fn main() { println(helper()) }\n")
+	writePipelineTestFile(t, beta, "main.osty", "fn main() { println(7) }\n")
+
+	got, err := RunWorkspace(root, nil, Config{RunGen: true})
+	if err != nil {
+		t.Fatalf("RunWorkspace() error = %v", err)
+	}
+	if got.GenError != nil {
+		t.Fatalf("RunWorkspace() gen error = %v\n%s", got.GenError, got.GenBytes)
+	}
+	text := string(got.GenBytes)
+	if strings.Count(text, "; ---- ") != 2 {
+		t.Fatalf("workspace gen header count = %d, want 2 package headers\n%s", strings.Count(text, "; ---- "), text)
+	}
+	if !strings.Contains(text, alpha) || !strings.Contains(text, beta) {
+		t.Fatalf("workspace gen output missing package headers:\n%s", text)
+	}
+	if strings.Contains(text, "; ---- "+filepath.Join(alpha, "a.osty")+" ----") || strings.Contains(text, "; ---- "+filepath.Join(alpha, "b.osty")+" ----") {
+		t.Fatalf("workspace gen output still uses per-file headers:\n%s", text)
+	}
+}
+
+func TestRunLoadedPackageGenUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
+	dir := t.TempDir()
+	writePipelineTestFile(t, dir, "a.osty", "pub fn helper() -> Int { 1 }\n")
+	writePipelineTestFile(t, dir, "b.osty", "fn main() { println(helper()) }\n")
+
+	pkg, err := resolve.LoadPackage(dir)
+	if err != nil {
+		t.Fatalf("LoadPackage() error = %v", err)
+	}
+
+	oldTry := tryExternalPipelineLLVMIR
+	tryExternalPipelineLLVMIR = func(entryPath string, gotPkg *resolve.Package) ([]byte, bool, []error, error) {
+		if filepath.Base(entryPath) != "a.osty" {
+			t.Fatalf("entry path = %q, want first lowerable file a.osty", entryPath)
+		}
+		if gotPkg != pkg {
+			t.Fatal("pipeline passed an unexpected package pointer")
+		}
+		return []byte("; external pipeline llvm ir"), true, nil, nil
+	}
+	t.Cleanup(func() { tryExternalPipelineLLVMIR = oldTry })
+
+	got := RunLoadedPackage(pkg, nil, Config{RunGen: true})
+	if got.GenError != nil {
+		t.Fatalf("RunLoadedPackage() gen error = %v\n%s", got.GenError, got.GenBytes)
+	}
+	if string(got.GenBytes) != "; external pipeline llvm ir" {
+		t.Fatalf("gen bytes = %q, want external output", got.GenBytes)
+	}
+}
+
+func TestRunLoadedPackageGenSingleFileUsesManagedNativeLLVMGen(t *testing.T) {
+	dir := t.TempDir()
+	writePipelineTestFile(t, dir, "main.osty", "fn main() { println(1) }\n")
+
+	pkg, err := resolve.LoadPackage(dir)
+	if err != nil {
+		t.Fatalf("LoadPackage() error = %v", err)
+	}
+
+	oldTry := tryExternalPipelineLLVMIR
+	tryExternalPipelineLLVMIR = func(entryPath string, gotPkg *resolve.Package) ([]byte, bool, []error, error) {
+		if filepath.Base(entryPath) != "main.osty" {
+			t.Fatalf("entry path = %q, want main.osty", entryPath)
+		}
+		if gotPkg != pkg {
+			t.Fatal("pipeline passed an unexpected package pointer")
+		}
+		return []byte("; external single-file llvm ir"), true, nil, nil
+	}
+	t.Cleanup(func() { tryExternalPipelineLLVMIR = oldTry })
+
+	got := RunLoadedPackage(pkg, nil, Config{RunGen: true})
+	if got.GenError != nil {
+		t.Fatalf("RunLoadedPackage() gen error = %v\n%s", got.GenError, got.GenBytes)
+	}
+	if string(got.GenBytes) != "; external single-file llvm ir" {
+		t.Fatalf("gen bytes = %q, want external single-file output", got.GenBytes)
+	}
+}
+
+func writePipelineTestFile(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}

--- a/internal/selfhost/README.md
+++ b/internal/selfhost/README.md
@@ -22,6 +22,9 @@ The exact merged Osty inputs live in
 
 - `ToolchainCheckerFiles()` feeds both the native checker binary and the
   `internal/selfhost/generated.go` regeneration path (via `gen_selfhost.go`)
+- `ToolchainLLVMGenFiles()` / `MergeToolchainLLVMGen()` expose the current
+  bootstrap-transpilable `toolchain/llvmgen.osty` bundle used by llvmgen
+  snapshot/selfhost smoke tests and future native llvmgen bridge work
 
 Notable inputs currently include:
 

--- a/internal/selfhost/bundle/bundle_test.go
+++ b/internal/selfhost/bundle/bundle_test.go
@@ -95,6 +95,9 @@ func TestMergeFilesNormalizesWhileLoopsForBootstrap(t *testing.T) {
 func writeBundleFile(t *testing.T, root, rel, contents string) {
 	t.Helper()
 	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}

--- a/internal/selfhost/bundle/llvmgen_bundle.go
+++ b/internal/selfhost/bundle/llvmgen_bundle.go
@@ -1,0 +1,87 @@
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var toolchainLLVMGenFiles = []string{
+	"toolchain/llvmgen.osty",
+}
+
+const llvmgenStringsPrelude = `use go "strings" as llvmStrings {
+    fn Contains(s: String, substr: String) -> Bool
+    fn HasPrefix(s: String, prefix: String) -> Bool
+    fn Join(elems: List<String>, sep: String) -> String
+    fn Split(s: String, sep: String) -> List<String>
+    fn TrimPrefix(s: String, prefix: String) -> String
+}
+
+fn ostyStringsContains(s: String, substr: String) -> Bool { llvmStrings.Contains(s, substr) }
+fn ostyStringsHasPrefix(s: String, prefix: String) -> Bool { llvmStrings.HasPrefix(s, prefix) }
+`
+
+// ToolchainLLVMGenFiles returns the Osty-authored llvmgen helper sources that
+// can already travel through the bootstrap transpiler unchanged.
+func ToolchainLLVMGenFiles() []string {
+	return append([]string(nil), toolchainLLVMGenFiles...)
+}
+
+// MergeToolchainLLVMGen prepends the minimal Go-hosted strings surface the
+// bootstrap transpiler needs, then concatenates the llvmgen helper sources into
+// one standalone .osty file.
+func MergeToolchainLLVMGen(root string) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString(llvmgenStringsPrelude)
+	b.WriteByte('\n')
+
+	for _, rel := range toolchainLLVMGenFiles {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		b.WriteString("// ---- ")
+		b.WriteString(rel)
+		b.WriteString(" ----\n")
+		trimmed := stripLeadingLLVMGenStringsUse(string(data))
+		trimmed = normalizeLLVMGenStdStringsCalls(trimmed)
+		b.WriteString(trimmed)
+		if !strings.HasSuffix(trimmed, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+	}
+
+	return []byte(b.String()), nil
+}
+
+func stripLeadingLLVMGenStringsUse(src string) string {
+	const prefix = "use std.strings as llvmStrings"
+
+	lines := strings.SplitAfter(src, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) != prefix {
+			continue
+		}
+		return strings.Join(lines[:i], "") + strings.Join(lines[i+1:], "")
+	}
+	return src
+}
+
+func normalizeLLVMGenStdStringsCalls(src string) string {
+	for _, pair := range [][2]string{
+		{"llvmStrings.hasPrefix(", "llvmStrings.HasPrefix("},
+		{"llvmStrings.join(", "llvmStrings.Join("},
+		{"llvmStrings.split(", "llvmStrings.Split("},
+		{"llvmStrings.trimPrefix(", "llvmStrings.TrimPrefix("},
+		{"target.contains(", "ostyStringsContains(target, "},
+		{"path.startsWith(", "ostyStringsHasPrefix(path, "},
+		{"trimmed.startsWith(", "ostyStringsHasPrefix(trimmed, "},
+	} {
+		src = strings.ReplaceAll(src, pair[0], pair[1])
+	}
+	return src
+}

--- a/internal/selfhost/bundle/llvmgen_bundle_test.go
+++ b/internal/selfhost/bundle/llvmgen_bundle_test.go
@@ -1,0 +1,62 @@
+package bundle
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToolchainLLVMGenBundleIncludesToolchainLLVMGen(t *testing.T) {
+	files := ToolchainLLVMGenFiles()
+	if !contains(files, "toolchain/llvmgen.osty") {
+		t.Fatalf("llvmgen bundle missing toolchain llvmgen source: %#v", files)
+	}
+}
+
+func TestMergeToolchainLLVMGenNormalizesStringsUsage(t *testing.T) {
+	root := t.TempDir()
+	writeBundleFile(t, root, "toolchain/llvmgen.osty", `use std.strings as llvmStrings
+
+fn demo(target: String, path: String, trimmed: String) -> String {
+    if target.contains("x") {
+        return llvmStrings.join(llvmStrings.split(path, "/"), llvmStrings.trimPrefix(trimmed, "x"))
+    }
+    path
+}
+`)
+
+	merged, err := MergeToolchainLLVMGen(root)
+	if err != nil {
+		t.Fatalf("MergeToolchainLLVMGen() error = %v", err)
+	}
+	got := string(merged)
+	if !strings.HasPrefix(got, llvmgenStringsPrelude+"\n") {
+		t.Fatalf("merged source missing llvmgen strings prelude:\n%s", got)
+	}
+	if strings.Contains(got, "use std.strings as llvmStrings") {
+		t.Fatalf("merged source kept per-file std.strings import:\n%s", got)
+	}
+	for _, unwanted := range []string{
+		"llvmStrings.join(",
+		"llvmStrings.split(",
+		"llvmStrings.trimPrefix(",
+		"target.contains(",
+		"path.startsWith(",
+		"trimmed.startsWith(",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("merged source kept unnormalized llvmgen helper call %q:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "llvmStrings.Join(") {
+		t.Fatalf("merged source missing PascalCase Join rewrite:\n%s", got)
+	}
+	if !strings.Contains(got, "llvmStrings.Split(") {
+		t.Fatalf("merged source missing PascalCase Split rewrite:\n%s", got)
+	}
+	if !strings.Contains(got, "llvmStrings.TrimPrefix(") {
+		t.Fatalf("merged source missing PascalCase TrimPrefix rewrite:\n%s", got)
+	}
+	if !strings.Contains(got, "ostyStringsContains(target, ") {
+		t.Fatalf("merged source missing contains shim rewrite:\n%s", got)
+	}
+}

--- a/internal/selfhost/llvmgen_gen_test.go
+++ b/internal/selfhost/llvmgen_gen_test.go
@@ -1,0 +1,76 @@
+package selfhost
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost/bundle"
+)
+
+func TestToolchainLLVMGenSourcesTranspile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping self-host llvmgen transpile smoke test in short mode")
+	}
+
+	repoRoot := filepath.Join("..", "..")
+	merged, err := bundle.MergeToolchainLLVMGen(repoRoot)
+	if err != nil {
+		t.Fatalf("merge toolchain llvmgen sources: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	mergedPath := filepath.Join(tmpDir, "toolchain_llvmgen_merged.osty")
+	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
+		t.Fatalf("write merged source: %v", err)
+	}
+	generatedPath := filepath.Join(tmpDir, "toolchain_llvmgen_generated.go")
+	goModPath := filepath.Join(tmpDir, "go.mod")
+
+	cmd := exec.Command(
+		"go", "run", "./cmd/osty-bootstrap-gen",
+		"--package", "llvmgenselfhostsmoke",
+		"-o", generatedPath,
+		mergedPath,
+	)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("transpile merged toolchain llvmgen: %v\n%s", err, bytes.TrimSpace(out))
+	}
+
+	generated, err := os.ReadFile(generatedPath)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	if len(generated) == 0 {
+		t.Fatal("generated file is empty")
+	}
+	if !bytes.Contains(generated, []byte("func llvmRenderModule(")) {
+		t.Fatal("generated file does not include llvm module render helpers")
+	}
+	if !bytes.Contains(generated, []byte("func llvmUnsupportedDiagnostic(")) {
+		t.Fatal("generated file does not include unsupported diagnostic helpers")
+	}
+	if !bytes.Contains(generated, []byte("func llvmSmokeMinimalPrintIR(")) {
+		t.Fatal("generated file does not include llvm smoke IR helpers")
+	}
+	if bytes.Contains(generated, []byte("llvmStrings.join(")) ||
+		bytes.Contains(generated, []byte("llvmStrings.split(")) ||
+		bytes.Contains(generated, []byte("llvmStrings.trimPrefix(")) ||
+		bytes.Contains(generated, []byte("llvmStrings.hasPrefix(")) {
+		t.Fatal("generated file still contains unlowered std.strings helper calls")
+	}
+
+	if err := os.WriteFile(goModPath, []byte("module llvmgenselfhostsmoke\n\ngo 1.20\n"), 0o644); err != nil {
+		t.Fatalf("write temp go.mod: %v", err)
+	}
+	buildCmd := exec.Command("go", "test", ".")
+	buildCmd.Dir = tmpDir
+	buildOut, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compile generated llvmgen smoke bridge: %v\n%s", err, bytes.TrimSpace(buildOut))
+	}
+}

--- a/internal/toolchain/native_llvmgen.go
+++ b/internal/toolchain/native_llvmgen.go
@@ -1,0 +1,91 @@
+package toolchain
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	nativeLLVMGenBuildMu sync.Mutex
+	installNativeLLVMGen = buildNativeLLVMGen
+)
+
+func NativeLLVMGenBinaryName() string {
+	name := "osty-native-llvmgen"
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+func ManagedNativeLLVMGenPath(projectRoot string) string {
+	return filepath.Join(projectRoot, toolchainDirName, Version(), NativeLLVMGenBinaryName())
+}
+
+// EnsureNativeLLVMGen returns the managed llvmgen artifact for the current
+// project/worktree, building it into .osty/toolchain/<version>/ on first use.
+func EnsureNativeLLVMGen(start string) (string, error) {
+	root, err := managedProjectRootFunc(start)
+	if err != nil {
+		return "", err
+	}
+	path := ManagedNativeLLVMGenPath(root)
+	if fileExists(path) {
+		return path, nil
+	}
+
+	nativeLLVMGenBuildMu.Lock()
+	defer nativeLLVMGenBuildMu.Unlock()
+
+	if fileExists(path) {
+		return path, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create managed llvmgen dir: %w", err)
+	}
+	if err := installNativeLLVMGen(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func buildNativeLLVMGen(dest string) error {
+	root, err := sourceRepoRootFunc()
+	if err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp(filepath.Dir(dest), "osty-native-llvmgen-*")
+	if err != nil {
+		return fmt.Errorf("create native llvmgen temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpPath := filepath.Join(tmpDir, NativeLLVMGenBinaryName())
+	cmd := exec.Command("go", "build", "-o", tmpPath, "./cmd/osty-native-llvmgen")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = "<no output>"
+		}
+		return fmt.Errorf("build managed osty-native-llvmgen: %w (%s)", err, msg)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tmpPath, 0o755); err != nil {
+			return fmt.Errorf("chmod managed osty-native-llvmgen: %w", err)
+		}
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		if fileExists(dest) {
+			return nil
+		}
+		return fmt.Errorf("install managed osty-native-llvmgen: %w", err)
+	}
+	return nil
+}

--- a/internal/toolchain/native_llvmgen_test.go
+++ b/internal/toolchain/native_llvmgen_test.go
@@ -1,0 +1,56 @@
+package toolchain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureNativeLLVMGenBuildsManagedArtifactOnce(t *testing.T) {
+	root := t.TempDir()
+	oldProjectRoot := managedProjectRootFunc
+	oldInstaller := installNativeLLVMGen
+	t.Cleanup(func() {
+		managedProjectRootFunc = oldProjectRoot
+		installNativeLLVMGen = oldInstaller
+	})
+
+	managedProjectRootFunc = func(string) (string, error) { return root, nil }
+	calls := 0
+	installNativeLLVMGen = func(dest string) error {
+		calls++
+		return os.WriteFile(dest, []byte("managed llvmgen"), 0o755)
+	}
+
+	path, err := EnsureNativeLLVMGen(".")
+	if err != nil {
+		t.Fatalf("EnsureNativeLLVMGen error: %v", err)
+	}
+	want := filepath.Join(root, ".osty", "toolchain", Version(), NativeLLVMGenBinaryName())
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	if calls != 1 {
+		t.Fatalf("installer calls = %d, want 1", calls)
+	}
+
+	path2, err := EnsureNativeLLVMGen(".")
+	if err != nil {
+		t.Fatalf("second EnsureNativeLLVMGen error: %v", err)
+	}
+	if path2 != want {
+		t.Fatalf("second path = %q, want %q", path2, want)
+	}
+	if calls != 1 {
+		t.Fatalf("installer calls after second ensure = %d, want 1", calls)
+	}
+}
+
+func TestManagedNativeLLVMGenPathIncludesVersionedToolchainDir(t *testing.T) {
+	root := t.TempDir()
+	got := ManagedNativeLLVMGenPath(root)
+	want := filepath.Join(root, ".osty", "toolchain", Version(), NativeLLVMGenBinaryName())
+	if got != want {
+		t.Fatalf("ManagedNativeLLVMGenPath = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a managed `osty-native-llvmgen` toolchain boundary plus shared request/exec helpers
- route `gen`, `build`, `run`, `test`, and `pipeline --gen` through the external native llvmgen path first, with native/legacy fallback preserved
- clean up the remaining single-file legacy package-lowering branches and lock the new behavior with focused regressions

## Verification
- `go test -count=1 -vet=off ./internal/backend -run 'Test(PreparePackage(SingleFileKeepsEntryFileAndDecl|MergesMultiFileDecls|PicksFirstNonNilFileWhenEntryUnset)|EmitPrebuiltLLVMIRBuildsArtifactsFromProvidedIR|TryEmitNativeOwnedLLVMIRText(CoversPrimitiveSlice|ReturnsNotCovered)|EmitLLVMIRText(MatchesBackendArtifactOutput|PrefersNativeOwnedFastPathWhenCovered|FallsBackWhenNativeOwnedUncovered|MirBackendOverridesNativeFastPath)|LLVMBackendEmitBinary(PrefersNativeOwnedFastPathWhenCovered|FallsBackWhenNativeOwnedUncovered)|Use(MIRBackendDefaultsEnabled|NativeOwnedLLVMIRDefaultsEnabled|MIRBackendLegacyFeatureDisables|NativeOwnedLLVMIRFeatureOverrides))'`
- `go test -count=1 -vet=off ./internal/pipeline -run 'TestRun(LoadedPackageGenUsesPackageLoweringForSiblingFiles|WorkspaceGenAggregatesPerPackageModules|LoadedPackageGenUsesManagedNativeLLVMGenWhenCovered|LoadedPackageGenSingleFileUsesManagedNativeLLVMGen)'`
- `go test -count=1 -vet=off ./cmd/osty -run 'Test(TryExternalPackageLLVMArtifacts(UsesCoveredExternalIR|SkipsWhenFeatureOverridesNativePath)|BuildCLIUsesManagedNativeLLVMGenForObject|RunCLIUsesManagedNativeLLVMGenForBinary|EmitGenArtifactUsesManagedNativeLLVMGenWhenCovered|EmitGenArtifactUsesNativeOwnedFastPathWhenCovered|EmitGenArtifactFallsBackForUncoveredNativeOwnedModule|PrepareGenBackendEntryUsesPackageLoweringForSiblingFiles|PrepareGenBackendEntryUsesPackageLoweringForSingleFile|GenCLIMultiFilePackageEmitsLLVMIR|CompileNativeTestBundleUsesManagedNativeLLVMGenWhenCovered|RunTestMainPassesNativeLLVMTest)'`
- `go test -count=1 -vet=off ./cmd/osty-native-llvmgen ./internal/toolchain ./internal/nativellvmgen`