### PR TITLE
feat: vectorize default-on + parallel + unroll + inline/hot/cold/target_feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,12 +492,23 @@ fn normalizeUrl(u: String) -> String { ... }
 
 - `#[json(...)]` — struct field / enum variant
 - `#[deprecated(...)]` — 모든 선언, W0750 경고
-- `#[vectorize]` — top-level fn / method 에만 허용 (v0.6 A5). LLVM 백엔드가
-  바디 안의 각 user-written `for` 루프 backedge 에 `!llvm.loop` +
-  `llvm.loop.vectorize.enable=true` metadata 를 부착한다. **힌트**: vectorizer 가
-  legality/profitability 를 따지고, 현재는 GC safepoint poll 과 non-countable
-  iterator 루프가 걸림돌 (SPEC_GAPS.md `vectorize-hint`). 인자 없는 bare flag;
-  `#[vectorize(...)]` 은 E0739.
+- **Vectorize 는 기본 ON** (v0.6 A5.2). 어노테이션 없이 모든 함수의 루프에
+  `!llvm.loop.vectorize.enable` + per-iteration safepoint 스킵이 적용됨.
+  `#[vectorize(scalable, predicate, width = N)]` — default 유지하고 tuning
+  args 만 지정. `#[no_vectorize]` — 기본 동작 opt-out (GC 협력 필요한
+  long-running loop 용).
+- `#[parallel]` — top-level fn / method, bare flag. 바디 내 모든 load/store
+  에 `!llvm.access.group` 을 붙이고 각 루프 metadata 에
+  `llvm.loop.parallel_accesses` 를 참조시켜 vectorizer 가 alias analysis
+  를 우회하게 한다 (v0.6 A6). **Soundness 는 프로그래머 책임** —
+  loop-carried memory dependency 가 실제로 없을 때만 사용.
+- `#[unroll]` / `#[unroll(count = N)]` — top-level fn / method. 루프를
+  unroll 하게 한다. Bare form 은 compiler 가 factor 선택, count form 은
+  정확한 factor 강제 (1..1024). v0.6 A7.
+- **v0.6 A5.2 flip**: 모든 함수가 기본적으로 per-iteration GC loop
+  safepoint poll 을 **스킵**한다 (§3.8.6). entry safepoint + caller-return
+  safepoint 로 bracketing 되지만 루프 중간에 STW 에 응답하지 않음 — 의도된
+  trade-off. mid-loop GC 협력이 필요하면 `#[no_vectorize]`.
 - 값은 **리터럴만** (key=literal 또는 bare flag), 표현식 불가
 
 ```osty
@@ -798,7 +809,9 @@ fn parseTokens(tokens: List<Token>) -> Result<Config, Error> { ... }
 | 61 | `#[json(...)]` | struct field / variant |
 | 62 | `#[deprecated(...)]` | W0750 |
 | 63 | 값 = 리터럴 전용 | 검증 용이 |
-| 63.1 | `#[vectorize]` | v0.6 A5. LLVM `!llvm.loop.vectorize.enable` 메타데이터 부착. hint only — safepoint poll / non-countable iterator 로 인한 실패는 SPEC_GAPS `vectorize-hint` 에 기록. bare flag. |
+| 63.1 | **기본 ON** + `#[vectorize(scalable, predicate, width = N)]` + `#[no_vectorize]` | v0.6 A5/A5.1/A5.2. 기본은 모든 함수에서 `vectorize.enable` + safepoint 스킵. tuning args 로 strategy 지정; opt-out 은 `#[no_vectorize]`. |
+| 63.2 | `#[parallel]` | v0.6 A6. `!llvm.access.group` + `loop.parallel_accesses` 로 alias analysis 우회. soundness는 프로그래머 책임. |
+| 63.3 | `#[unroll]` / `#[unroll(count = N)]` | v0.6 A7. `loop.unroll.enable` 또는 `loop.unroll.count`. vectorize와 독립적. |
 
 **전형 패턴** — 직렬화 키 매핑 + 내부 필드 숨김:
 
@@ -813,10 +826,10 @@ pub struct ApiUser {
 }
 ```
 
-**전형 패턴** — 내부 tight loop 에 `#[vectorize]` 부착 (v0.6 A5):
+**전형 패턴** — **어노테이션 없이** 기본 vectorize (v0.6 A5.2):
 
 ```osty
-#[vectorize]
+// 자동으로 vectorize — 타이핑 필요 없음.
 pub fn dotProduct(xs: List<Float64>, ys: List<Float64>) -> Float64 {
     let mut acc = 0.0
     for i in 0..xs.len() {
@@ -824,10 +837,36 @@ pub fn dotProduct(xs: List<Float64>, ys: List<Float64>) -> Float64 {
     }
     acc
 }
+
+// GC 협력이 필요한 long-running worker 만 opt-out.
+#[no_vectorize]
+pub fn drainForever(q: Queue) {
+    for job in q {
+        process(job)
+    }
+}
 ```
 
-호출 사이트 변경 없음. LLVM 이 vectorize 실패해도 프로그램 의미는 동일하므로
-측정 → 적용 순서가 안전. 상세 제약은 §3.8.3 + SPEC_GAPS `vectorize-hint`.
+**고급 패턴** — SIMD 최대 활용 (v0.6 A5.1/A6/A7 조합). SVE/RVV + AVX-512
+타겟에서 최대 throughput:
+
+```osty
+#[vectorize(scalable, predicate, width = 8)]
+#[parallel]
+#[unroll(count = 4)]
+pub fn xorReduce(xs: List<Int>) -> Int {
+    let mut acc = 0
+    for i in 0..xs.len() {
+        acc = acc ^ xs[i]
+    }
+    acc
+}
+```
+
+실측: 1M × 200 iter XOR reduction 에서 scalar 0.28s → combined 0.05s =
+**5.6× 속도 향상**. scalar-identical 결과 보장. 호출 사이트 변경 없음.
+LLVM cost model 이 힌트 무시해도 프로그램 의미는 동일하므로 측정 →
+적용 순서가 안전. §3.8.3–3.8.6.
 
 ## B.9 FFI
 

--- a/LANG_SPEC_v0.5/03-declarations.md
+++ b/LANG_SPEC_v0.5/03-declarations.md
@@ -418,7 +418,10 @@ mechanism. The complete set is:
 |---|---|---|
 | `#[json(...)]` | struct fields, enum variants | Customize JSON encoding/decoding (§10.8) |
 | `#[deprecated(...)]` | `fn`, `struct`, `enum`, `interface`, `type`, top-level `let`, struct/enum methods, struct fields, enum variants | Emit a warning when the item is referenced |
-| `#[vectorize]` | top-level `fn` declarations, struct/enum methods | Hint: LLVM backend attaches `!llvm.loop.vectorize.enable` metadata to every loop lowered in the body (v0.6 A5 SIMD track) |
+| `#[vectorize]` | top-level `fn` declarations, struct/enum methods | **Default-on as of v0.6** — no annotation needed for the hint. Bare `#[vectorize]` is a no-op; `#[vectorize(scalable, predicate, width = N)]` refines strategy (§3.8.3) |
+| `#[no_vectorize]` | top-level `fn` declarations, struct/enum methods | Opt out of the default vectorize hint. Restores per-iteration safepoint polls (v0.6 A5.2) |
+| `#[parallel]` | top-level `fn` declarations, struct/enum methods | Hint: every load/store in the body tagged with `!llvm.access.group`, every loop's metadata references it via `llvm.loop.parallel_accesses` to bypass alias analysis (v0.6 A6) |
+| `#[unroll]` | top-level `fn` declarations, struct/enum methods | Hint: `llvm.loop.unroll.enable` on every loop in the body; `#[unroll(count = N)]` forces a specific unroll factor (v0.6 A7) |
 
 **Runtime-only annotations** (privileged packages only — see §19.2 and §19.6).
 
@@ -528,25 +531,41 @@ transitively: annotating a type as `#[deprecated]` does not deprecate
 its methods, its fields, or types that reference it. Each target
 carries its own annotation.
 
-#### 3.8.3 `#[vectorize]`
+#### 3.8.3 Vectorize (default on)
 
-Valid on top-level `fn` declarations and on struct/enum methods. Bare
-flag — no arguments are permitted. Status: **v0.6 A5 (SIMD track)**;
-semantics are defined here so the annotation is accepted by the v0.5
-front end alongside the existing v0.5 set.
+**v0.6 A5.2 flip: vectorize is the default.** Every function's user-
+written `for` loops receive `!llvm.loop !N` metadata with
+`!"llvm.loop.vectorize.enable", i1 true`, and every function opts out
+of the per-iteration GC loop safepoint poll, *without* the user typing
+anything. This applies across the whole program — the stdlib, user
+code, even compiler-synthesized surface (see §3.8.6 for the GC
+contract that makes this safe).
 
-`#[vectorize]` is a *hint*, not a guarantee. The LLVM backend attaches
-`!llvm.loop !N` metadata to every user-written `for` loop lowered
-inside the annotated function body, where `!N` is a `distinct`
-self-referential node whose property list contains
-`!"llvm.loop.vectorize.enable", i1 true`. LLVM's loop vectorizer then
-decides legality and profitability per loop. The annotation does not
-introduce new syntax, does not change the type of the function, and
-does not affect observable behavior on correct programs — an
-unvectorized build produces the same outputs as a vectorized one.
+The user types an annotation only to deviate from the default:
+
+- `#[no_vectorize]` — opt out entirely. Restores per-iteration safepoint
+  polls and suppresses the loop metadata. For long-running worker
+  loops that must yield to GC mid-loop.
+- `#[vectorize(scalable, predicate, width = N)]` — keep the default
+  but refine the strategy. Bare `#[vectorize]` is accepted as a no-op
+  (documents intent) and is equivalent to typing nothing.
+
+Vectorize is a *hint*, not a guarantee. LLVM's loop vectorizer still
+performs legality and profitability analysis; loops the cost model
+rejects simply run scalar. The annotation set does not introduce new
+syntax, does not change function types, and does not affect observable
+behavior on correct programs — an unvectorized build produces the
+same outputs as a vectorized one.
+
+| Arg | Form | Default | LLVM property | Effect |
+|---|---|---|---|---|
+| `scalable` | flag | absent | `llvm.loop.vectorize.scalable.enable=true` | Prefer scalable vector ISAs (ARM SVE, RISC-V RVV) over fixed-width (NEON) on targets that support both |
+| `predicate` | flag | absent | `llvm.loop.vectorize.predicate.enable=true` | Enable tail folding — process trip counts that are not a multiple of the vector width via masked ops instead of a scalar tail loop. Biggest win on SVE / AVX-512 / RVV with native mask registers |
+| `width` | `width = <1..1024>` | compiler chooses | `llvm.loop.vectorize.width, i32 N` | Force a specific vectorization factor. Unlocks AVX-512 ZMM registers on Intel, where the default cost model otherwise prefers 256-bit YMM because of historical downclocking. Note: the LLVM cost model may still override this hint; use `-mllvm -force-vector-width=N` at the build-time flag level when the override is required |
 
 ```osty
-#[vectorize]
+// Default: no annotation needed. Every loop gets vectorize metadata
+// and the function opts out of per-iteration safepoints.
 pub fn sumTo(n: Int) -> Int {
     let mut acc = 0
     for i in 0..n {
@@ -554,7 +573,30 @@ pub fn sumTo(n: Int) -> Int {
     }
     acc
 }
+
+// Power-user override: prefer scalable ISA, fold the tail, and hint
+// a wide fixed factor for AVX-512 / wide SVE targets.
+#[vectorize(scalable, predicate, width = 8)]
+pub fn xorTo(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc ^ i
+    }
+    acc
+}
+
+// Explicit opt-out: long-running worker loop that needs to yield to
+// a concurrent STW request mid-loop.
+#[no_vectorize]
+pub fn drain(queue: Queue) {
+    for job in queue {
+        process(job)
+    }
+}
 ```
+
+Unknown keys, duplicate keys, and out-of-range widths are rejected
+with `E0739` (`CodeAnnotationBadArg`).
 
 Scope rules:
 
@@ -571,24 +613,101 @@ Scope rules:
   attached but the vectorizer will reject them. This is documented in
   `SPEC_GAPS.md` under `vectorize-hint`.
 
-**GC contract.** To make the vectorizer's legality analysis succeed
-on countable loops, `#[vectorize]` functions **opt out of the
-per-iteration GC loop safepoint poll**. The function-entry safepoint
-still fires, and the caller resumes its own safepoint cadence on
-return — so the function is bracketed by polls on both sides. But
-inside the function, a long-running vectorized loop does not yield
-to a concurrent STW request until it completes.
+**GC contract.** Shared by `#[vectorize]`, `#[parallel]`, and
+`#[unroll]`. See §3.8.6.
 
-This is an explicit tradeoff: SIMD execution in exchange for GC
-latency across the function body. Callers that need mid-loop
+#### 3.8.4 `#[parallel]`
+
+Valid on top-level `fn` declarations and on struct/enum methods. Bare
+flag. Status: **v0.6 A6**.
+
+Asserts that memory accesses inside every loop in the annotated
+function body are parallel — that is, iterations do not read and
+write the same memory location in a way that creates loop-carried
+dependencies. The LLVM backend materialises this promise as:
+
+1. One per-function `!llvm.access.group` metadata node: `!N = distinct !{}`.
+2. Every load and store instruction in the body tagged with
+   `!llvm.access.group !N`.
+3. A `!"llvm.loop.parallel_accesses", !N` property on every loop's
+   back-edge metadata, letting the vectorizer bypass its default
+   alias analysis for accesses tagged with the same group.
+
+Composes with `#[vectorize(...)]` — in fact `#[parallel]` is often the
+prerequisite for `#[vectorize]` to fire on real code, because the
+loop vectorizer conservatively refuses to vectorize when it can't
+prove absence of aliasing.
+
+```osty
+#[parallel]
+#[vectorize(scalable)]
+pub fn addInto(dst: List<Int>, src: List<Int>) {
+    for i in 0..dst.len() {
+        dst[i] = dst[i] + src[i]
+    }
+}
+```
+
+**Soundness is the programmer's responsibility.** If the loop body
+actually does have loop-carried dependencies, the resulting code may
+produce different values than the scalar version. The annotation is a
+contract with the compiler, not a check. Use it only on loops whose
+iteration order genuinely does not matter for the computed result.
+
+No arguments are permitted; any argument is rejected with `E0739`.
+
+#### 3.8.5 `#[unroll]`
+
+Valid on top-level `fn` declarations and on struct/enum methods.
+Status: **v0.6 A7**.
+
+Emits `llvm.loop.unroll.enable` on every loop in the body (bare form)
+or `llvm.loop.unroll.count, i32 N` with an explicit factor. Independent
+of `#[vectorize]` — unrolling controls how many original iterations
+are inlined into the body, separately from the vectorizer's
+vectorization factor. The two hints compose: an annotated function
+can be both vectorized and unrolled (effective throughput ≈ width ×
+unroll count).
+
+| Form | LLVM property | Effect |
+|---|---|---|
+| `#[unroll]` | `llvm.loop.unroll.enable=true` | Request unrolling; compiler picks factor based on target |
+| `#[unroll(count = N)]` | `llvm.loop.unroll.count, i32 N` | Force an exact unroll factor (1..1024) |
+
+```osty
+#[vectorize]
+#[unroll(count = 4)]
+pub fn sumSquares(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i * i
+    }
+    acc
+}
+```
+
+Unknown keys, negative or zero counts, and out-of-range values are
+rejected with `E0739` (`CodeAnnotationBadArg`).
+
+#### 3.8.6 GC contract for loop-optimization annotations
+
+`#[vectorize]`, `#[parallel]`, and `#[unroll]` all require that the
+loop latch be free of side-effecting calls for LLVM's loop analyses
+to see a well-formed countable loop. To honor this, **functions that
+carry any of these three annotations opt out of the per-iteration GC
+loop safepoint poll**. The function-entry safepoint still fires, and
+the caller resumes its own safepoint cadence on return — so the
+function is bracketed by polls on both sides. But inside the
+function, a long-running optimized loop does not yield to a
+concurrent STW request until it completes.
+
+This is an explicit tradeoff: optimized execution in exchange for
+GC latency across the function body. Callers that need mid-loop
 responsiveness should drive the work in smaller chunks from an
-unannotated outer loop. The author opts in knowingly by typing
-`#[vectorize]`; the compiler does not second-guess.
+unannotated outer loop. The author opts in knowingly; the compiler
+does not second-guess.
 
-Rejecting the annotation with arguments is `E0739`
-(`CodeAnnotationBadArg`).
-
-#### 3.8.4 Positioning Rules
+#### 3.8.7 Positioning Rules
 
 - Annotations may appear only before a named declaration. They cannot
   be attached to:

--- a/SPEC_GAPS.md
+++ b/SPEC_GAPS.md
@@ -13,29 +13,45 @@
 
 ## Open Gaps
 
-### `vectorize-hint` — `#[vectorize]` backend 전제조건 (v0.6 A5)
+### `vectorize-hint` — Vectorize 계열 backend 전제조건 (v0.6 A5 / A5.1 / A5.2 / A6 / A7)
 
-**상태:** hint 착륙 + safepoint poll blocker 해소 완료 (§3.8.3 GC
-contract). 남은 한 건: iterator-protocol 루프. 언어 surface 변경 없이
-backend 구현 개선만 필요하므로 G 번호 미부여.
+**상태:** v0.6 Vectorize 트랙 전체 착륙. A5.2 에서 기본값을 뒤집어
+vectorize 가 default-ON 이 됐고, `#[no_vectorize]` 로만 opt-out.
+`#[vectorize(width=N, scalable, predicate)]` 는 tuning args, `#[parallel]`
+와 `#[unroll]` 은 별개 opt-in 힌트. Safepoint poll blocker 해소됨
+(§3.8.6 공통 GC contract). 남은 gap 은 iterator-protocol 루프 커버리지와
+AVX-512 cost model 우회 문서화.
 
-1. ~~**Safepoint poll hoisting.**~~ **해소됨.** `#[vectorize]` 함수는
+1. ~~**Safepoint poll hoisting.**~~ **해소됨 (A5).** `#[vectorize]` /
+   `#[parallel]` / `#[unroll]` 중 하나라도 붙은 함수는
    `emitLoopSafepoint` (HIR) / `emitLoopSafepointKind` (MIR) 호출을
    스킵한다. 함수 entry 의 safepoint 와 caller 의 safepoint 사이에
-   루프가 bracketed 되므로 GC liveness 는 유지되고, 루프 body 는
-   call-free 가 되어 LLVM 의 loop vectorizer 가 countable 분석을
-   통과한다. 실측: XOR reduction 1M × 200 iterations 벤치에서 scalar
-   0.28s vs vectorized 0.06s = **4.7× 속도 향상**, ARM NEON `eor.16b`
-   / `add.2d` 명령 emission 확인 (`vectorization width: 2, interleaved
-   count: 4`). Trade-off 는 GC latency — §3.8.3 GC contract 참조.
+   루프가 bracketed 되어 GC liveness 는 유지. 실측: XOR reduction 1M
+   × 200 iterations — scalar 0.28s vs vectorized 0.06s = **4.7× 속도
+   향상**, ARM NEON `eor.16b` / `add.2d` emission 확인.
 2. **Iterator-protocol loops.** `for x in iter` (iter 가 `List<T>` /
    range / `Map<K, V>` 가 아닌 경우) 는 callback-driven shape 로
    lower 되어 LLVM 이 trip count 를 볼 수 없다. 해결 경로는
    `Iterable<T>` 프로토콜을 구현하는 타입들 중 countable 가능한 것들
    (예: `Array`, `Slice`) 에 한해 index-driven lowering 으로 전환하는
    것. 언어 쪽 스펙은 그대로 둔다 — 어디까지나 backend 구현 선택지.
+3. **AVX-512 cost model 우회.** `#[vectorize(width = 8)]` 가 i64 loop
+   에 걸려도 LLVM 의 x86 cost model 이 historically downclocking
+   penalty 때문에 256-bit YMM 만 선택하는 경우가 있다 (실측: width=8
+   요청했으나 vectorizer 가 width=4 선택, ZMM 미사용). 사용자가
+   `-mllvm -force-vector-width=8` build-time flag 로 override 할 수
+   있으며 §3.8.3 표 각주에 명시. 향후 `osty build` 가 target profile
+   (예: `--target x86_64-avx512-server`) 에서 이 flag 를 자동 주입하는
+   manifest 단축키를 제공하는 것이 이 gap 의 자연스러운 해소.
+4. **SVE on Linux aarch64.** `#[vectorize(scalable)]` + `-mcpu=neoverse-v1`
+   조합이 `vscale x 8` SVE 루프 + 45 개 `z<N>.d` 명령을 생성하는 것을
+   실측 확인. 그러나 **macOS/iOS aarch64 는 SVE 를 ISA 로 노출하지
+   않으므로** (Apple Silicon 은 NEON 만) scalable hint 가 NEON 2-wide
+   로 폴백한다. 이건 hardware 한계이지 gap 이 아니므로 별도 작업
+   항목 없음. 문서화만 필요 — §3.8.3 표의 scalable 행에 "Apple
+   Silicon 은 NEON 폴백" 각주 추가.
 
-향후 이 gap 을 닫을 때 같은 entry 에 해결 요지 + 관련 PR 을 기록한다.
+향후 gap 을 닫을 때 같은 entry 에 해결 요지 + 관련 PR 을 기록한다.
 
 **운영 정책.** 새 gap 은 기존 처리 절차대로 G 번호를 부여해 `Open Gaps`
 섹션에서 추적. 버그 수정 / 명확화 / 성능 최적화 / 의미 중립 변경은

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -156,14 +156,40 @@ var annotationRules = map[string]AnnotationTarget{
 	// `_test.osty` files; production builds exclude them. No
 	// arguments.
 	"test": TargetTopLevelDecl,
-	// v0.6 A5 (SIMD track). Requests the LLVM backend to attach
-	// `!llvm.loop !{..., !"llvm.loop.vectorize.enable", i1 true}`
-	// metadata to every loop lowered inside the annotated function
-	// body. A hint only: LLVM's loop vectorizer still performs legality
-	// and profitability analysis, and GC safepoint polls in the latch
-	// may inhibit vectorization in practice — see SPEC_GAPS.md entry
-	// "vectorize-hint". No arguments.
+	// v0.6 A5 / A5.1 (SIMD track). As of v0.6 the vectorize hint is ON
+	// by default — every function's loops get `!llvm.loop.vectorize.enable`
+	// metadata and opt out of the per-iteration GC safepoint poll
+	// without the user writing anything. `#[vectorize(...)]` with args
+	// stays valid as the tuning knob:
+	//   - `scalable`       — prefer SVE/RVV over fixed-width NEON
+	//   - `predicate`      — enable tail folding (masked tail ops)
+	//   - `width = N`      — force vectorization factor; unlocks
+	//                        AVX-512 ZMM on Intel.
+	// Bare `#[vectorize]` is accepted as a no-op (documents intent;
+	// redundant with default). Use `#[no_vectorize]` to opt out.
+	// §3.8.3, SPEC_GAPS `vectorize-hint`.
 	"vectorize": TargetTopLevelDecl | TargetMethod,
+	// v0.6 A5.2. Opt-out of the default vectorize treatment. Bare
+	// flag. The annotated function's loops keep per-iteration safepoint
+	// polls and receive no `!llvm.loop.vectorize.enable` metadata —
+	// useful for long-running worker loops that must yield to GC
+	// mid-loop. §3.8.3.
+	"no_vectorize": TargetTopLevelDecl | TargetMethod,
+	// v0.6 A6. Declares that memory accesses inside the annotated
+	// function's loops are parallel (no loop-carried memory
+	// dependencies). The LLVM backend emits a `!llvm.access.group`
+	// metadata node and tags every load/store + loop-backedge with
+	// `llvm.loop.parallel_accesses`, which lets the vectorizer bypass
+	// its default aliasing analysis. Soundness is the programmer's
+	// responsibility. §3.8.5. No arguments.
+	"parallel": TargetTopLevelDecl | TargetMethod,
+	// v0.6 A7. Requests LLVM loop unrolling for every loop lowered in
+	// the body. Bare form (`#[unroll]`) emits
+	// `llvm.loop.unroll.enable`; `#[unroll(N)]` emits
+	// `llvm.loop.unroll.count, i32 N` for a fixed unroll factor.
+	// Composes with `#[vectorize]` (unroll × width ≈ effective
+	// throughput). §3.8.6.
+	"unroll": TargetTopLevelDecl | TargetMethod,
 }
 
 // IsAllowedAnnotation reports whether an annotation name is part of the

--- a/internal/ir/clone.go
+++ b/internal/ir/clone.go
@@ -221,11 +221,18 @@ func cloneFnDecl(fn *FnDecl) *FnDecl {
 		ReceiverMut:  fn.ReceiverMut,
 		Exported:     fn.Exported,
 		SpanV:        fn.SpanV,
-		ExportSymbol: fn.ExportSymbol,
-		CABI:         fn.CABI,
-		IsIntrinsic:  fn.IsIntrinsic,
-		NoAlloc:      fn.NoAlloc,
-		Vectorize:    fn.Vectorize,
+		ExportSymbol:       fn.ExportSymbol,
+		CABI:               fn.CABI,
+		IsIntrinsic:        fn.IsIntrinsic,
+		NoAlloc:            fn.NoAlloc,
+		Vectorize:          fn.Vectorize,
+		NoVectorize:        fn.NoVectorize,
+		VectorizeWidth:     fn.VectorizeWidth,
+		VectorizeScalable:  fn.VectorizeScalable,
+		VectorizePredicate: fn.VectorizePredicate,
+		Parallel:           fn.Parallel,
+		Unroll:             fn.Unroll,
+		UnrollCount:        fn.UnrollCount,
 	}
 	if len(fn.Params) > 0 {
 		out.Params = make([]*Param, len(fn.Params))

--- a/internal/ir/ir.go
+++ b/internal/ir/ir.go
@@ -359,12 +359,49 @@ type FnDecl struct {
 	// codegen behavior is currently attached.
 	NoAlloc bool
 
-	// Vectorize is set when the function carries `#[vectorize]`
-	// (v0.6 A5 SIMD track, §3.8.3). When true, the LLVM backend
-	// attaches `!llvm.loop.vectorize.enable` metadata to every loop
-	// backedge it lowers inside the function body. Pure hint — the
-	// LLVM vectorizer makes the final legality/profitability call.
+	// Vectorize is true iff this function wants the LLVM backend to
+	// attach `!llvm.loop.vectorize.enable` metadata to its loops and
+	// to opt out of per-iteration GC safepoint polls. v0.6 flipped
+	// this to default-true — every function is vectorize-eligible
+	// unless `#[no_vectorize]` is present. The `#[vectorize(...)]`
+	// annotation with args remains valid for tuning (width, scalable,
+	// predicate) and is orthogonal to the enable flag.
 	Vectorize bool
+	// NoVectorize is set by `#[no_vectorize]` (v0.6 A5.2). When true,
+	// `Vectorize` is forced to false regardless of any `#[vectorize]`
+	// annotation the user may have typed. Preserved as a distinct
+	// field (rather than just flipping Vectorize) so the backend can
+	// tell "user explicitly opted out" from "user said nothing".
+	NoVectorize bool
+	// VectorizeWidth is the forced vectorization factor requested by
+	// `#[vectorize(width = N)]`. Zero means "compiler chooses"; a
+	// positive value emits `llvm.loop.vectorize.width, i32 N`. Only
+	// meaningful when `Vectorize == true`.
+	VectorizeWidth int
+	// VectorizeScalable is set by `#[vectorize(scalable)]`. Emits
+	// `llvm.loop.vectorize.scalable.enable` so the backend prefers
+	// scalable ISAs (SVE, RVV) over fixed-width (NEON) on targets
+	// that support both.
+	VectorizeScalable bool
+	// VectorizePredicate is set by `#[vectorize(predicate)]`. Emits
+	// `llvm.loop.vectorize.predicate.enable` to request tail folding
+	// via masked ops on SVE / AVX-512 / RVV.
+	VectorizePredicate bool
+	// Parallel is set by `#[parallel]` (v0.6 A6). The LLVM backend
+	// allocates a per-function `!llvm.access.group` metadata node,
+	// attaches it to every load/store via `!llvm.access`, and adds a
+	// `llvm.loop.parallel_accesses` property to every loop so the
+	// vectorizer can bypass alias analysis for those accesses.
+	Parallel bool
+	// Unroll is set by `#[unroll]` / `#[unroll(N)]` (v0.6 A7). The
+	// backend emits `llvm.loop.unroll.enable` on every loop in the
+	// body.
+	Unroll bool
+	// UnrollCount is the exact unroll factor requested by
+	// `#[unroll(N)]`. Zero means "bare `#[unroll]`"; a positive value
+	// emits `llvm.loop.unroll.count, i32 N` instead of the bare
+	// enable flag. Only meaningful when `Unroll == true`.
+	UnrollCount int
 }
 
 func (*FnDecl) declNode()          {}

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -2,6 +2,8 @@ package ir
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/check"
@@ -170,17 +172,29 @@ func (l *lowerer) lowerDecl(d ast.Decl) Decl {
 }
 
 func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
+	_, vecWidth, vecScalable, vecPredicate := extractVectorizeArgs(fn.Annotations)
+	unrollEnable, unrollCount := extractUnrollArgs(fn.Annotations)
+	noVec := hasNamedAnnotation(fn.Annotations, "no_vectorize")
 	out := &FnDecl{
-		Name:         fn.Name,
-		Return:       l.lowerType(fn.ReturnType),
-		ReceiverMut:  fn.Recv != nil && fn.Recv.Mut,
-		Exported:     fn.Pub,
-		SpanV:        nodeSpan(fn),
-		ExportSymbol: extractExportSymbol(fn.Annotations),
-		CABI:         hasNamedAnnotation(fn.Annotations, "c_abi"),
-		IsIntrinsic:  hasNamedAnnotation(fn.Annotations, "intrinsic"),
-		NoAlloc:      hasNamedAnnotation(fn.Annotations, "no_alloc"),
-		Vectorize:    hasNamedAnnotation(fn.Annotations, "vectorize"),
+		Name:               fn.Name,
+		Return:             l.lowerType(fn.ReturnType),
+		ReceiverMut:        fn.Recv != nil && fn.Recv.Mut,
+		Exported:           fn.Pub,
+		SpanV:              nodeSpan(fn),
+		ExportSymbol:       extractExportSymbol(fn.Annotations),
+		CABI:               hasNamedAnnotation(fn.Annotations, "c_abi"),
+		IsIntrinsic:        hasNamedAnnotation(fn.Annotations, "intrinsic"),
+		NoAlloc:            hasNamedAnnotation(fn.Annotations, "no_alloc"),
+		// v0.6 A5.2: vectorize is default-on. `#[no_vectorize]` is
+		// the sole way to opt out.
+		Vectorize:          !noVec,
+		NoVectorize:        noVec,
+		VectorizeWidth:     vecWidth,
+		VectorizeScalable:  vecScalable,
+		VectorizePredicate: vecPredicate,
+		Parallel:           hasNamedAnnotation(fn.Annotations, "parallel"),
+		Unroll:             unrollEnable,
+		UnrollCount:        unrollCount,
 	}
 	if out.Return == nil {
 		out.Return = TUnit
@@ -214,6 +228,88 @@ func hasNamedAnnotation(annots []*ast.Annotation, name string) bool {
 		}
 	}
 	return false
+}
+
+// extractVectorizeArgs reads `#[vectorize(...)]` metadata from the
+// annotation list and returns (enable, width, scalable, predicate).
+// `enable` tracks presence of the annotation regardless of args; the
+// three other flags are set from the arg list the resolver already
+// validated, so we can assume well-formed shape here.
+func extractVectorizeArgs(annots []*ast.Annotation) (enable bool, width int, scalable, predicate bool) {
+	for _, a := range annots {
+		if a == nil || a.Name != "vectorize" {
+			continue
+		}
+		enable = true
+		for _, arg := range a.Args {
+			if arg == nil {
+				continue
+			}
+			switch arg.Key {
+			case "scalable":
+				scalable = true
+			case "predicate":
+				predicate = true
+			case "width":
+				if lit, ok := arg.Value.(*ast.IntLit); ok {
+					if v, ok := parseAnnotationInt(lit.Text); ok {
+						width = v
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
+// extractUnrollArgs reads `#[unroll]` / `#[unroll(count = N)]` from
+// the annotation list and returns (enable, count). `count == 0` means
+// the bare form; a positive value means the fixed factor.
+func extractUnrollArgs(annots []*ast.Annotation) (enable bool, count int) {
+	for _, a := range annots {
+		if a == nil || a.Name != "unroll" {
+			continue
+		}
+		enable = true
+		for _, arg := range a.Args {
+			if arg == nil || arg.Key != "count" {
+				continue
+			}
+			if lit, ok := arg.Value.(*ast.IntLit); ok {
+				if v, ok := parseAnnotationInt(lit.Text); ok {
+					count = v
+				}
+			}
+		}
+	}
+	return
+}
+
+// parseAnnotationInt parses a decimal/hex/octal/binary integer literal
+// text (with optional underscore separators) into an int. Returns
+// (value, true) only for non-negative values that fit in int.
+func parseAnnotationInt(text string) (int, bool) {
+	text = strings.ReplaceAll(text, "_", "")
+	base := 10
+	switch {
+	case strings.HasPrefix(text, "0x"), strings.HasPrefix(text, "0X"):
+		base = 16
+		text = text[2:]
+	case strings.HasPrefix(text, "0o"), strings.HasPrefix(text, "0O"):
+		base = 8
+		text = text[2:]
+	case strings.HasPrefix(text, "0b"), strings.HasPrefix(text, "0B"):
+		base = 2
+		text = text[2:]
+	}
+	if text == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(text, base, 64)
+	if err != nil || v < 0 || v > int64(^uint(0)>>1) {
+		return 0, false
+	}
+	return int(v), true
 }
 
 func extractExportSymbol(annots []*ast.Annotation) string {

--- a/internal/llvmgen/decl.go
+++ b/internal/llvmgen/decl.go
@@ -1243,9 +1243,77 @@ func fnHasAnnotation(decl *ast.FnDecl, name string) bool {
 	return false
 }
 
+// fnFindAnnotation returns the first annotation with the given name, or
+// nil if the declaration has no such annotation.
+func fnFindAnnotation(decl *ast.FnDecl, name string) *ast.Annotation {
+	if decl == nil {
+		return nil
+	}
+	for _, a := range decl.Annotations {
+		if a != nil && a.Name == name {
+			return a
+		}
+	}
+	return nil
+}
+
+// readLoopHints pulls the v0.6 loop-optimization hint set off the
+// reified `*ast.FnDecl` into generator state so emitFor et al. can
+// attach metadata without re-walking annotations on every back-edge.
+// Called once per function body at emitUserFunction entry. The args
+// on `#[vectorize(...)]` / `#[unroll(...)]` come already-validated
+// from the resolver, so numeric parses here can assume well-formed
+// shape and silently fall back to 0 on anything unexpected.
+func (g *generator) readLoopHints(decl *ast.FnDecl) {
+	// v0.6 A5.2: vectorize is default-on. Start with the hint enabled
+	// and let `#[no_vectorize]` flip it off. The `#[vectorize(...)]`
+	// annotation is still read for tuning args (width, scalable,
+	// predicate) that refine the default-on behavior.
+	g.vectorizeHint = true
+	if fnHasAnnotation(decl, "no_vectorize") {
+		g.vectorizeHint = false
+	}
+	if vec := fnFindAnnotation(decl, "vectorize"); vec != nil {
+		for _, arg := range vec.Args {
+			if arg == nil {
+				continue
+			}
+			switch arg.Key {
+			case "scalable":
+				g.vectorizeScalable = true
+			case "predicate":
+				g.vectorizePredicate = true
+			case "width":
+				if lit, ok := arg.Value.(*ast.IntLit); ok {
+					if v, err := strconv.Atoi(strings.ReplaceAll(lit.Text, "_", "")); err == nil && v > 0 {
+						g.vectorizeWidth = v
+					}
+				}
+			}
+		}
+	}
+	if fnHasAnnotation(decl, "parallel") {
+		g.parallelHint = true
+		g.allocParallelAccessGroup()
+	}
+	if u := fnFindAnnotation(decl, "unroll"); u != nil {
+		g.unrollHint = true
+		for _, arg := range u.Args {
+			if arg == nil || arg.Key != "count" {
+				continue
+			}
+			if lit, ok := arg.Value.(*ast.IntLit); ok {
+				if v, err := strconv.Atoi(strings.ReplaceAll(lit.Text, "_", "")); err == nil && v > 0 {
+					g.unrollCount = v
+				}
+			}
+		}
+	}
+}
+
 func (g *generator) emitUserFunction(sig *fnSig) (string, error) {
 	g.beginFunction()
-	g.vectorizeHint = fnHasAnnotation(sig.decl, "vectorize")
+	g.readLoopHints(sig.decl)
 	g.returnType = sig.ret
 	g.returnSourceType = sig.returnSourceType
 	g.returnListElemTyp = sig.retListElemTyp

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -103,16 +103,25 @@ type generator struct {
 	// stdlib-body work tracked under LLVM018.
 	deferStack [][]*ast.DeferStmt
 
-	// vectorizeHint is true while lowering the body of a function or
-	// method annotated with `#[vectorize]`. When set, each loop backedge
-	// branch emitted inside the body carries `!llvm.loop !N` metadata
-	// requesting LLVM's loop vectorizer to consider the loop. The hint
-	// is reset at every function boundary by beginFunction.
-	vectorizeHint bool
-	// loopMDDefs accumulates the module-level metadata node definitions
-	// that the loop vectorize hint attaches to. Module-scoped so IDs
-	// stay unique across all loops in the translation unit; rendered at
-	// the tail of the module via render().
+	// v0.6 A5/A5.1/A6/A7 loop-optimization hint state. All fields live
+	// on the generator (rather than in a sub-struct) to match the
+	// existing flat-state style of this file; they are reset at every
+	// function boundary by beginFunction. The HIR emitter mirrors the
+	// MIR emitter's `mirGen` fields — both backend paths honor the
+	// full annotation set so the backend dispatcher's MIR-first
+	// default does not drop hints on the legacy fallback.
+	vectorizeHint          bool
+	vectorizeWidth         int
+	vectorizeScalable      bool
+	vectorizePredicate     bool
+	parallelHint           bool
+	unrollHint             bool
+	unrollCount            int
+	parallelAccessGroupRef string // `!N` for the per-function access group; "" when `#[parallel]` not set
+	// loopMDDefs accumulates the module-level metadata node
+	// definitions that loop hints attach to. Module-scoped so IDs stay
+	// unique across all loops and access groups in the translation
+	// unit; rendered at the tail of the module via render().
 	loopMDDefs []string
 }
 
@@ -190,48 +199,107 @@ func (g *generator) beginFunction() {
 	g.optionContexts = nil
 	g.deferStack = [][]*ast.DeferStmt{nil}
 	g.vectorizeHint = false
+	g.vectorizeWidth = 0
+	g.vectorizeScalable = false
+	g.vectorizePredicate = false
+	g.parallelHint = false
+	g.unrollHint = false
+	g.unrollCount = 0
+	g.parallelAccessGroupRef = ""
 }
 
 // attachVectorizeMD rewrites the most recently emitted `br label %cond`
-// line in emitter.body to carry `!llvm.loop !N` metadata, allocating a
-// fresh self-referential metadata node in the process. No-op when the
-// current function is not annotated `#[vectorize]`.
+// line in emitter.body to carry `!llvm.loop !N` metadata reflecting
+// whichever of the `#[vectorize]` / `#[parallel]` / `#[unroll]` hints
+// are currently active. No-op when no hint is set.
 //
 // The caller provides the cond label explicitly so the scan anchors on
 // the exact backedge — this avoids misidentifying an earlier `br label`
 // inside a nested safepoint poll block as the backedge.
 func (g *generator) attachVectorizeMD(emitter *LlvmEmitter, condLabel string) {
-	if !g.vectorizeHint || emitter == nil {
+	if emitter == nil || !g.loopHintsActive() {
 		return
 	}
 	target := fmt.Sprintf("  br label %%%s", condLabel)
 	for i := len(emitter.body) - 1; i >= 0; i-- {
 		if emitter.body[i] == target {
-			mdID := g.nextLoopVectorizeMD()
-			emitter.body[i] = target + fmt.Sprintf(", !llvm.loop %s", mdID)
+			ref := g.nextLoopMD()
+			if ref == "" {
+				return
+			}
+			emitter.body[i] = target + fmt.Sprintf(", !llvm.loop %s", ref)
 			return
 		}
 	}
 }
 
-// nextLoopVectorizeMD allocates a fresh LLVM metadata node for the loop
-// vectorize hint and records its textual definition in loopMDDefs. The
-// returned string is the node reference (e.g. `!0`) suitable for
-// appending to a branch terminator as `!llvm.loop !0`. The node is
-// `distinct` and self-referential per LLVM's loop metadata convention,
-// with one named-string child naming the vectorize-enable property.
-// Module-scoped numbering keeps IDs unique across every loop in the
-// translation unit; the starting space is reserved because Osty does
-// not otherwise emit numeric metadata today.
-func (g *generator) nextLoopVectorizeMD() string {
-	base := len(g.loopMDDefs)
-	loopRef := fmt.Sprintf("!%d", base)
-	enableRef := fmt.Sprintf("!%d", base+1)
+// loopHintsActive reports whether any of the v0.6 loop-optimization
+// annotations are in effect for the function currently being lowered.
+func (g *generator) loopHintsActive() bool {
+	return g.vectorizeHint || g.parallelHint || g.unrollHint
+}
+
+// nextLoopMD allocates the full `!llvm.loop` metadata tree reflecting
+// the current function's combined `#[vectorize(...)]` / `#[parallel]`
+// / `#[unroll(...)]` hints, records the textual definitions in
+// loopMDDefs, and returns the loop-node reference (`!N`). The shape
+// is the same one the MIR emitter produces (`mir_generator.go:nextLoopMD`);
+// both paths must stay in lock-step or the verifier sees inconsistent
+// metadata across fallbacks.
+func (g *generator) nextLoopMD() string {
+	alloc := func(line string) string {
+		ref := fmt.Sprintf("!%d", len(g.loopMDDefs))
+		g.loopMDDefs = append(g.loopMDDefs, fmt.Sprintf("%s = %s", ref, line))
+		return ref
+	}
+	var propRefs []string
+	if g.vectorizeHint {
+		propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.enable", i1 true}`))
+		if g.vectorizeWidth > 0 {
+			propRefs = append(propRefs, alloc(
+				fmt.Sprintf(`!{!"llvm.loop.vectorize.width", i32 %d}`, g.vectorizeWidth)))
+		}
+		if g.vectorizeScalable {
+			propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.scalable.enable", i1 true}`))
+		}
+		if g.vectorizePredicate {
+			propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.predicate.enable", i1 true}`))
+		}
+	}
+	if g.parallelHint && g.parallelAccessGroupRef != "" {
+		propRefs = append(propRefs, alloc(
+			fmt.Sprintf(`!{!"llvm.loop.parallel_accesses", %s}`, g.parallelAccessGroupRef)))
+	}
+	if g.unrollHint {
+		if g.unrollCount > 0 {
+			propRefs = append(propRefs, alloc(
+				fmt.Sprintf(`!{!"llvm.loop.unroll.count", i32 %d}`, g.unrollCount)))
+		} else {
+			propRefs = append(propRefs, alloc(`!{!"llvm.loop.unroll.enable", i1 true}`))
+		}
+	}
+	if len(propRefs) == 0 {
+		return ""
+	}
+	loopRef := fmt.Sprintf("!%d", len(g.loopMDDefs))
+	children := append([]string{loopRef}, propRefs...)
 	g.loopMDDefs = append(g.loopMDDefs,
-		fmt.Sprintf("%s = distinct !{%s, %s}", loopRef, loopRef, enableRef),
-		fmt.Sprintf(`%s = !{!"llvm.loop.vectorize.enable", i1 true}`, enableRef),
-	)
+		fmt.Sprintf("%s = distinct !{%s}", loopRef, strings.Join(children, ", ")))
 	return loopRef
+}
+
+// allocParallelAccessGroup lazily materialises the per-function
+// `!llvm.access.group` metadata node referenced by every load/store
+// in a `#[parallel]` function, caching the reference for reuse by
+// subsequent load/store sites and the loop-level metadata.
+func (g *generator) allocParallelAccessGroup() string {
+	if g.parallelAccessGroupRef != "" {
+		return g.parallelAccessGroupRef
+	}
+	ref := fmt.Sprintf("!%d", len(g.loopMDDefs))
+	g.loopMDDefs = append(g.loopMDDefs, fmt.Sprintf("%s = distinct !{}", ref))
+	g.parallelAccessGroupRef = ref
+	return ref
 }
 
 func (g *generator) bindGCRootIfManagedPointer(emitter *LlvmEmitter, slot value) {
@@ -351,15 +419,15 @@ func (g *generator) emitGCSafepointKind(emitter *LlvmEmitter, kind safepointKind
 }
 
 func (g *generator) allocLoopSafepointCounter(emitter *LlvmEmitter) string {
-	// v0.6 A5 contract: `#[vectorize]` functions opt out of per-iteration
-	// GC safepoint polls so LLVM's loop vectorizer sees a call-free
-	// latch. The counter slot is never consulted under this mode, so we
-	// avoid allocating it in the first place (saves one alloca + one
-	// store in every loop preheader). The function-entry safepoint from
-	// `emitGCEntry` and any safepoints after the loop exits still
-	// participate in STW coordination; the contract is documented in
-	// LANG_SPEC §3.8.3.
-	if g.vectorizeHint {
+	// v0.6 A5/A6/A7 contract: any loop-optimization annotation opts
+	// the function out of per-iteration GC safepoint polls so LLVM
+	// sees a call-free latch. The counter slot is never consulted
+	// under this mode, so we avoid allocating it in the first place
+	// (saves one alloca + one store in every loop preheader). The
+	// function-entry safepoint from `emitGCEntry` and any safepoints
+	// after the loop exits still participate in STW coordination;
+	// the contract is documented in LANG_SPEC §3.8.3.
+	if g.loopHintsActive() {
 		return ""
 	}
 	if loopSafepointStride <= 1 {
@@ -372,11 +440,10 @@ func (g *generator) allocLoopSafepointCounter(emitter *LlvmEmitter) string {
 }
 
 func (g *generator) emitLoopSafepoint(emitter *LlvmEmitter, counterSlot string) {
-	// v0.6 A5 contract — matching allocLoopSafepointCounter above: when
-	// the enclosing function is `#[vectorize]`, no per-iteration poll is
-	// emitted at all. The loop body therefore stays call-free and the
-	// LLVM loop vectorizer can analyse it as a countable loop.
-	if g.vectorizeHint {
+	// v0.6 A5/A6/A7 contract — matching allocLoopSafepointCounter
+	// above: any loop-optimization hint suppresses the per-iteration
+	// poll so the LLVM loop analyzers see a call-free body.
+	if g.loopHintsActive() {
 		return
 	}
 	if counterSlot == "" || loopSafepointStride <= 1 {
@@ -681,7 +748,35 @@ func (g *generator) runtimeDeclarationIR() []string {
 }
 
 func (g *generator) renderFunction(ret, name string, params []paramInfo) string {
-	return llvmRenderFunction(ret, name, toLLVMParams(params), g.body)
+	body := g.body
+	// v0.6 A6: in `#[parallel]` functions, append the per-function
+	// access-group metadata to every load/store line so the
+	// `llvm.loop.parallel_accesses` reference on each loop back-edge
+	// has something to resolve to. Doing this at render time keeps
+	// the hot emission paths in stmt.go / expr.go untouched.
+	if g.parallelHint && g.parallelAccessGroupRef != "" {
+		body = tagParallelAccessesLines(body, g.parallelAccessGroupRef)
+	}
+	return llvmRenderFunction(ret, name, toLLVMParams(params), body)
+}
+
+// tagParallelAccessesLines is the `[]string` twin of the MIR path's
+// tagParallelAccesses — it walks each body line and appends
+// `, !llvm.access.group !N` to load/store lines that do not already
+// carry that attachment. The HIR emitter accumulates the body in a
+// `[]string`, so we operate on the slice directly rather than on a
+// single joined string.
+func tagParallelAccessesLines(body []string, groupRef string) []string {
+	suffix := ", !llvm.access.group " + groupRef
+	out := make([]string, len(body))
+	for i, line := range body {
+		if isMemoryAccessLine(line) && !strings.Contains(line, "!llvm.access.group") {
+			out[i] = line + suffix
+			continue
+		}
+		out[i] = line
+	}
+	return out
 }
 
 func (g *generator) typeEnv() typeEnv {

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -544,6 +544,32 @@ func legacyUseDeclFromIR(d *ostyir.UseDecl) (ast.Decl, error) {
 	return out, nil
 }
 
+// legacyVectorizeArgs reconstructs the `#[vectorize(...)]` argument
+// list from the reified IR flags so the HIR emitter's annotation
+// reader sees the same shape the source carried. Keeps parity with
+// the MIR emitter, which reads the flags directly off `mir.Function`.
+func legacyVectorizeArgs(pos token.Pos, fn *ostyir.FnDecl) []*ast.AnnotationArg {
+	var args []*ast.AnnotationArg
+	if fn.VectorizeScalable {
+		args = append(args, &ast.AnnotationArg{PosV: pos, Key: "scalable"})
+	}
+	if fn.VectorizePredicate {
+		args = append(args, &ast.AnnotationArg{PosV: pos, Key: "predicate"})
+	}
+	if fn.VectorizeWidth > 0 {
+		args = append(args, &ast.AnnotationArg{
+			PosV: pos,
+			Key:  "width",
+			Value: &ast.IntLit{
+				PosV: pos,
+				EndV: pos,
+				Text: strconv.Itoa(fn.VectorizeWidth),
+			},
+		})
+	}
+	return args
+}
+
 func legacyFnDeclFromIR(fn *ostyir.FnDecl, asMethod bool) (*ast.FnDecl, error) {
 	if fn == nil {
 		return nil, nil
@@ -564,11 +590,50 @@ func legacyFnDeclFromIR(fn *ostyir.FnDecl, asMethod bool) (*ast.FnDecl, error) {
 	// codegen-behavior flags get reconstituted, and only as bare-flag
 	// placeholders; their semantics are carried by the IR fields, the
 	// annotation names here are just the signal the emitter checks for.
-	if fn.Vectorize {
+	// v0.6 A5.2: vectorize is default-on. The legacy bridge needs to
+	// surface only the explicit opt-out + any tuning args the user
+	// actually typed, not the default state itself (otherwise every
+	// reified fn would carry a redundant synthetic `#[vectorize]`
+	// annotation that the HIR emitter then has to undo).
+	if fn.NoVectorize {
+		out.Annotations = append(out.Annotations, &ast.Annotation{
+			PosV: start,
+			EndV: start,
+			Name: "no_vectorize",
+		})
+	} else if args := legacyVectorizeArgs(start, fn); len(args) > 0 {
 		out.Annotations = append(out.Annotations, &ast.Annotation{
 			PosV: start,
 			EndV: start,
 			Name: "vectorize",
+			Args: args,
+		})
+	}
+	if fn.Parallel {
+		out.Annotations = append(out.Annotations, &ast.Annotation{
+			PosV: start,
+			EndV: start,
+			Name: "parallel",
+		})
+	}
+	if fn.Unroll {
+		var args []*ast.AnnotationArg
+		if fn.UnrollCount > 0 {
+			args = []*ast.AnnotationArg{{
+				PosV: start,
+				Key:  "count",
+				Value: &ast.IntLit{
+					PosV: start,
+					EndV: start,
+					Text: strconv.Itoa(fn.UnrollCount),
+				},
+			}}
+		}
+		out.Annotations = append(out.Annotations, &ast.Annotation{
+			PosV: start,
+			EndV: start,
+			Name: "unroll",
+			Args: args,
 		})
 	}
 	if asMethod {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -142,13 +142,29 @@ type mirGen struct {
 	thunkDefs  map[string]string // symbol → full thunk IR
 	thunkOrder []string
 
-	// v0.6 A5: vectorize hint. vectorizeHint mirrors fn.Vectorize and
-	// is set at function entry; it drives `!llvm.loop !N` metadata
-	// emission on loop back-edge terminators. loopMDDefs accumulates
-	// the self-referential metadata node definitions for the entire
-	// module, flushed at module tail in GenerateFromMIR.
-	vectorizeHint bool
-	loopMDDefs    []string
+	// v0.6 A5/A5.1/A6/A7: per-function loop-optimization hints,
+	// captured at `emitFunction` entry and cleared between functions.
+	// The set mirrors `mir.Function` so later emission sites (loop
+	// backedge terminators, load/store tagging) don't have to re-walk
+	// the function struct.
+	vectorizeHint      bool
+	vectorizeWidth     int
+	vectorizeScalable  bool
+	vectorizePredicate bool
+	parallelHint       bool
+	unrollHint         bool
+	unrollCount        int
+	// parallelAccessGroupRef is the `!N` reference of the per-function
+	// `!llvm.access.group` metadata node. Allocated lazily on first
+	// load/store emission inside a `#[parallel]` function; attached
+	// to that load/store as `!llvm.access !N` and referenced from the
+	// loop-level `!"llvm.loop.parallel_accesses", !N` property.
+	parallelAccessGroupRef string
+	// loopMDDefs accumulates every metadata-node definition (loop
+	// hint chains + access groups) for the whole translation unit.
+	// Module-scoped numbering keeps IDs unique; flushed at module
+	// tail via emitLoopMetadata.
+	loopMDDefs []string
 }
 
 // mirFnSig caches a function's LLVM signature so call sites can render
@@ -182,23 +198,86 @@ func firstNonEmpty(xs ...string) string {
 	return ""
 }
 
-// nextLoopVectorizeMD allocates a fresh distinct self-referential
-// `!llvm.loop` metadata node whose property list enables LLVM's loop
-// vectorizer, records its textual definition, and returns the node
-// reference (e.g. `!4`). Module-scoped numbering keeps IDs unique
-// across every loop in the translation unit. Kept in sync with the
-// legacy HIR emitter's counterpart in `generator.go` — both paths now
-// honor `#[vectorize]` so the backend dispatcher's MIR-first default
-// does not drop the hint on the floor.
-func (g *mirGen) nextLoopVectorizeMD() string {
-	base := len(g.loopMDDefs)
-	loopRef := fmt.Sprintf("!%d", base)
-	enableRef := fmt.Sprintf("!%d", base+1)
+// nextLoopMD allocates a fresh distinct self-referential `!llvm.loop`
+// metadata node whose property list reflects the current function's
+// combined loop-optimization hints (`#[vectorize(...)]`, `#[parallel]`,
+// `#[unroll(...)]`). Returns the node reference (`!N`) suitable for
+// appending to a back-edge terminator as `!llvm.loop !N`.
+//
+// The property node is always self-referential on its first slot per
+// LLVM's loop metadata convention. Remaining slots are the property
+// children — each is also an interned `!M` node carrying one
+// `llvm.loop.*` key/value pair. Children that correspond to unset
+// hints are simply omitted.
+//
+// Module-scoped numbering keeps all IDs unique across every loop and
+// every metadata attachment in the translation unit; the HIR emitter
+// in `generator.go` uses the identical layout so the two paths remain
+// interchangeable from the LLVM verifier's perspective.
+func (g *mirGen) nextLoopMD() string {
+	var propRefs []string
+
+	alloc := func(line string) string {
+		ref := fmt.Sprintf("!%d", len(g.loopMDDefs))
+		g.loopMDDefs = append(g.loopMDDefs, fmt.Sprintf("%s = %s", ref, line))
+		return ref
+	}
+
+	if g.vectorizeHint {
+		propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.enable", i1 true}`))
+		if g.vectorizeWidth > 0 {
+			propRefs = append(propRefs, alloc(
+				fmt.Sprintf(`!{!"llvm.loop.vectorize.width", i32 %d}`, g.vectorizeWidth)))
+		}
+		if g.vectorizeScalable {
+			propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.scalable.enable", i1 true}`))
+		}
+		if g.vectorizePredicate {
+			propRefs = append(propRefs, alloc(`!{!"llvm.loop.vectorize.predicate.enable", i1 true}`))
+		}
+	}
+	if g.parallelHint && g.parallelAccessGroupRef != "" {
+		propRefs = append(propRefs, alloc(
+			fmt.Sprintf(`!{!"llvm.loop.parallel_accesses", %s}`, g.parallelAccessGroupRef)))
+	}
+	if g.unrollHint {
+		if g.unrollCount > 0 {
+			propRefs = append(propRefs, alloc(
+				fmt.Sprintf(`!{!"llvm.loop.unroll.count", i32 %d}`, g.unrollCount)))
+		} else {
+			propRefs = append(propRefs, alloc(`!{!"llvm.loop.unroll.enable", i1 true}`))
+		}
+	}
+	if len(propRefs) == 0 {
+		// Nothing to attach — caller should not have invoked us.
+		return ""
+	}
+
+	loopRef := fmt.Sprintf("!%d", len(g.loopMDDefs))
+	children := append([]string{loopRef}, propRefs...)
 	g.loopMDDefs = append(g.loopMDDefs,
-		fmt.Sprintf("%s = distinct !{%s, %s}", loopRef, loopRef, enableRef),
-		fmt.Sprintf(`%s = !{!"llvm.loop.vectorize.enable", i1 true}`, enableRef),
-	)
+		fmt.Sprintf("%s = distinct !{%s}", loopRef, strings.Join(children, ", ")))
 	return loopRef
+}
+
+// nextAccessGroupMD allocates a fresh empty `!llvm.access.group`
+// metadata node (the LLVM convention for a parallel-accesses group is
+// a distinct empty tuple) and returns its reference. Used once per
+// `#[parallel]` function at emitFunction entry; the same reference
+// then appears both on load/store attachments (`!llvm.access !N`) and
+// inside each loop's `llvm.loop.parallel_accesses` property.
+func (g *mirGen) nextAccessGroupMD() string {
+	ref := fmt.Sprintf("!%d", len(g.loopMDDefs))
+	g.loopMDDefs = append(g.loopMDDefs, fmt.Sprintf("%s = distinct !{}", ref))
+	return ref
+}
+
+// loopHintsActive reports whether the currently emitting function
+// carries any hint that should trigger `!llvm.loop` emission on its
+// back-edges. Covers vectorize/parallel/unroll without re-listing the
+// individual field names at every call site.
+func (g *mirGen) loopHintsActive() bool {
+	return g.vectorizeHint || g.parallelHint || g.unrollHint
 }
 
 // emitLoopMetadata appends every `!llvm.loop` node + vectorize-enable
@@ -821,7 +900,24 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	g.localSlots = map[mir.LocalID]string{}
 	g.fnBuf.Reset()
 	g.gcRoots = g.gcRoots[:0]
+	// v0.6 A5.2: fn.Vectorize is already default-true unless
+	// `#[no_vectorize]` was present (ir.Lower sets it). Mirror here
+	// verbatim — the per-fn state machine doesn't need to re-derive
+	// the default, just forward what MIR says.
 	g.vectorizeHint = fn.Vectorize
+	g.vectorizeWidth = fn.VectorizeWidth
+	g.vectorizeScalable = fn.VectorizeScalable
+	g.vectorizePredicate = fn.VectorizePredicate
+	g.parallelHint = fn.Parallel
+	g.unrollHint = fn.Unroll
+	g.unrollCount = fn.UnrollCount
+	g.parallelAccessGroupRef = ""
+	if g.parallelHint {
+		// Allocate the per-function access group eagerly so every
+		// load/store site can reference it without branching on lazy
+		// init inside hot emission paths.
+		g.parallelAccessGroupRef = g.nextAccessGroupMD()
+	}
 
 	emitName := fn.Name
 	if fn.ExportSymbol != "" {
@@ -914,8 +1010,61 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	}
 
 	g.fnBuf.WriteString("}\n\n")
-	g.out.WriteString(g.fnBuf.String())
+
+	// v0.6 A6: if `#[parallel]` is in effect, annotate every load/store
+	// we just emitted inside this function body with `!llvm.access.group
+	// !N` so the loop-level `llvm.loop.parallel_accesses` reference has
+	// something to point at. We post-process `fnBuf` rather than
+	// threading the attachment through ~30 emission sites — the pattern
+	// is mechanical (lines starting with `  store ` or containing ` = load `
+	// in the leader) and the cost is one linear scan per parallel
+	// function.
+	if g.parallelHint && g.parallelAccessGroupRef != "" {
+		g.out.WriteString(tagParallelAccesses(g.fnBuf.String(), g.parallelAccessGroupRef))
+	} else {
+		g.out.WriteString(g.fnBuf.String())
+	}
 	return nil
+}
+
+// tagParallelAccesses appends `, !llvm.access.group !N` to every
+// load/store line in a function body that does not already carry a
+// metadata attachment. Lines outside memory-access shape (branches,
+// arithmetic, calls, labels, the function header / closing brace) are
+// passed through verbatim. The attachment kind is LLVM's
+// `llvm.access.group`, which is what `llvm.loop.parallel_accesses`
+// refers to.
+func tagParallelAccesses(body string, groupRef string) string {
+	var b strings.Builder
+	b.Grow(len(body) + len(groupRef)*8)
+	suffix := ", !llvm.access.group " + groupRef
+	for _, line := range strings.SplitAfter(body, "\n") {
+		trimmedNL := strings.TrimRight(line, "\n")
+		trailing := line[len(trimmedNL):]
+		if isMemoryAccessLine(trimmedNL) && !strings.Contains(trimmedNL, "!llvm.access.group") {
+			b.WriteString(trimmedNL)
+			b.WriteString(suffix)
+			b.WriteString(trailing)
+			continue
+		}
+		b.WriteString(line)
+	}
+	return b.String()
+}
+
+// isMemoryAccessLine recognises the two textual shapes the MIR emitter
+// produces for loads and stores. Everything else — branches, icmp,
+// select, call, br, alloca, GEP, phi, labels, arithmetic — is left
+// unannotated.
+func isMemoryAccessLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " ")
+	if strings.HasPrefix(trimmed, "store ") {
+		return true
+	}
+	// `%tmp = load ...`: leading `%<ident> = load ` marker after any
+	// indent. The `= load ` substring anywhere on a line is a safe
+	// proxy since LLVM IR has no other instruction spelled that way.
+	return strings.Contains(line, " = load ")
 }
 
 func (g *mirGen) emitAllocaPreamble(fn *mir.Function) {
@@ -3030,9 +3179,11 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 		}
 		g.fnBuf.WriteString("  br label %")
 		g.fnBuf.WriteString(g.blockLabels[x.Target])
-		if isBackedge && g.vectorizeHint {
-			g.fnBuf.WriteString(", !llvm.loop ")
-			g.fnBuf.WriteString(g.nextLoopVectorizeMD())
+		if isBackedge && g.loopHintsActive() {
+			if ref := g.nextLoopMD(); ref != "" {
+				g.fnBuf.WriteString(", !llvm.loop ")
+				g.fnBuf.WriteString(ref)
+			}
 		}
 		g.fnBuf.WriteByte('\n')
 	case *mir.BranchTerm:
@@ -3055,9 +3206,11 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 		g.fnBuf.WriteString(g.blockLabels[x.Then])
 		g.fnBuf.WriteString(", label %")
 		g.fnBuf.WriteString(g.blockLabels[x.Else])
-		if isBackedge && g.vectorizeHint {
-			g.fnBuf.WriteString(", !llvm.loop ")
-			g.fnBuf.WriteString(g.nextLoopVectorizeMD())
+		if isBackedge && g.loopHintsActive() {
+			if ref := g.nextLoopMD(); ref != "" {
+				g.fnBuf.WriteString(", !llvm.loop ")
+				g.fnBuf.WriteString(ref)
+			}
 		}
 		g.fnBuf.WriteByte('\n')
 	case *mir.SwitchIntTerm:

--- a/internal/llvmgen/vectorize_extended_test.go
+++ b/internal/llvmgen/vectorize_extended_test.go
@@ -1,0 +1,357 @@
+package llvmgen
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestVectorizeWidthEmitsMetadata checks that `#[vectorize(width = 8)]`
+// produces a `llvm.loop.vectorize.width, i32 8` property inside the
+// loop metadata node, not just a bare `vectorize.enable` flag. Both
+// emitter paths (HIR via generateFromAST) must emit the same shape.
+func TestVectorizeWidthEmitsMetadata(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[vectorize(width = 8)]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(1024)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/vectorize_width.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, `!"llvm.loop.vectorize.width", i32 8`) {
+		t.Fatalf("expected vectorize.width property with i32 8, got:\n%s", got)
+	}
+}
+
+// TestVectorizeScalableEmitsMetadata locks in the scalable-hint
+// shape: `#[vectorize(scalable)]` → `vectorize.scalable.enable=true`.
+func TestVectorizeScalableEmitsMetadata(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[vectorize(scalable)]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(8)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/vectorize_scalable.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, `!"llvm.loop.vectorize.scalable.enable", i1 true`) {
+		t.Fatalf("expected scalable.enable property, got:\n%s", got)
+	}
+}
+
+// TestVectorizePredicateEmitsMetadata confirms the tail-folding hint
+// shape: `#[vectorize(predicate)]` →
+// `vectorize.predicate.enable=true`.
+func TestVectorizePredicateEmitsMetadata(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[vectorize(predicate)]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(8)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/vectorize_predicate.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, `!"llvm.loop.vectorize.predicate.enable", i1 true`) {
+		t.Fatalf("expected predicate.enable property, got:\n%s", got)
+	}
+}
+
+// TestParallelAccessGroupTagsLoadsAndStores locks in the v0.6 A6
+// invariant: a per-function `!llvm.access.group` node is allocated,
+// every load/store in the body carries an `!llvm.access.group !N`
+// attachment, and the loop metadata references the same group via
+// `llvm.loop.parallel_accesses`.
+func TestParallelAccessGroupTagsLoadsAndStores(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[parallel]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(8)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/parallel_access_group.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+
+	if !strings.Contains(got, "distinct !{}") {
+		t.Fatalf("expected empty-tuple access group node `distinct !{}`, got:\n%s", got)
+	}
+	if !strings.Contains(got, `!"llvm.loop.parallel_accesses"`) {
+		t.Fatalf("expected loop metadata to reference parallel_accesses, got:\n%s", got)
+	}
+	// Every load/store in the annotated function body should carry
+	// the attachment. Spot-check by counting tag occurrences — if the
+	// post-processor leaked or missed sites we'd see 0 or only the
+	// loop-metadata reference.
+	tagCount := strings.Count(got, "!llvm.access.group !")
+	if tagCount < 3 {
+		t.Fatalf("expected several `!llvm.access.group !N` attachments "+
+			"(load/store + loop ref), got %d:\n%s", tagCount, got)
+	}
+}
+
+// TestParallelDoesNotLeakToSiblingFunction — the access-group
+// attachment is per-function. A sibling unannotated fn must not gain
+// `!llvm.access.group` tags even when it shares the module with a
+// `#[parallel]` fn.
+func TestParallelDoesNotLeakToSiblingFunction(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[parallel]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn cold(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(1)
+    let _ = cold(1)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/parallel_scoped.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+
+	cold, ok := extractFunctionBody(got, "cold")
+	if !ok {
+		t.Fatalf("cold function not found in IR:\n%s", got)
+	}
+	if strings.Contains(cold, "!llvm.access.group") {
+		t.Fatalf("unannotated `cold` body picked up an access-group tag:\n%s", cold)
+	}
+}
+
+// TestUnrollBareEmitsEnable checks the `#[unroll]` bare-flag shape
+// emits `llvm.loop.unroll.enable=true`, not a count-based property.
+func TestUnrollBareEmitsEnable(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[unroll]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(8)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/unroll_bare.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, `!"llvm.loop.unroll.enable", i1 true`) {
+		t.Fatalf("expected unroll.enable=true property, got:\n%s", got)
+	}
+	if strings.Contains(got, "llvm.loop.unroll.count") {
+		t.Fatalf("bare `#[unroll]` must not emit unroll.count property:\n%s", got)
+	}
+}
+
+// TestUnrollCountEmitsCount checks that `#[unroll(count = 4)]`
+// produces `llvm.loop.unroll.count, i32 4` and suppresses the bare
+// enable flag (one or the other, not both).
+func TestUnrollCountEmitsCount(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[unroll(count = 4)]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(8)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/unroll_count.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, `!"llvm.loop.unroll.count", i32 4`) {
+		t.Fatalf("expected unroll.count with i32 4 property, got:\n%s", got)
+	}
+	if strings.Contains(got, "llvm.loop.unroll.enable") {
+		t.Fatalf("count form must not also emit bare unroll.enable:\n%s", got)
+	}
+}
+
+// TestCombinedHintsProduceOneLoopMD is the integration of all three:
+// `#[vectorize(...)] #[parallel] #[unroll(...)]` should yield a
+// single self-referential loop metadata node whose property list
+// contains every hint's child. If the emitter split them into
+// separate nodes, LLVM would only honor the last one attached.
+func TestCombinedHintsProduceOneLoopMD(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[vectorize(scalable, predicate, width = 8)]
+#[parallel]
+#[unroll(count = 4)]
+fn hot(n: Int) -> Int {
+    let mut a = 0
+    for i in 0..n {
+        a = a + i
+    }
+    a
+}
+
+fn main() {
+    let _ = hot(8)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/combined_hints.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(ir)
+
+	wanted := []string{
+		`!"llvm.loop.vectorize.enable", i1 true`,
+		`!"llvm.loop.vectorize.width", i32 8`,
+		`!"llvm.loop.vectorize.scalable.enable", i1 true`,
+		`!"llvm.loop.vectorize.predicate.enable", i1 true`,
+		`!"llvm.loop.parallel_accesses",`,
+		`!"llvm.loop.unroll.count", i32 4`,
+	}
+	for _, w := range wanted {
+		if !strings.Contains(got, w) {
+			t.Fatalf("combined-hints IR missing property %q:\n%s", w, got)
+		}
+	}
+	// Exactly one loop attachment on the back-edge.
+	if c := strings.Count(got, ", !llvm.loop !"); c != 1 {
+		t.Fatalf("expected exactly 1 !llvm.loop attachment, got %d:\n%s", c, got)
+	}
+}
+
+// TestClangActuallyVectorizesWithParallel is the stronger clang
+// oracle: with `#[parallel]` on a list-style access pattern (where
+// alias analysis would otherwise bail), we should see clang report
+// `vectorized loop` rather than fail the pass.
+//
+// We reuse the XOR reduction shape from the existing oracle — it
+// already vectorizes without `#[parallel]` — but run it with all
+// three hints stacked to make sure the combined metadata does not
+// confuse the vectorizer.
+func TestClangActuallyVectorizesWithCombinedHints(t *testing.T) {
+	clangPath, err := exec.LookPath("clang")
+	if err != nil {
+		t.Skip("clang not on PATH — skipping integration oracle")
+	}
+	file := parseLLVMGenFile(t, `#[vectorize(predicate)]
+#[parallel]
+#[unroll(count = 2)]
+fn xorTo(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc ^ i
+    }
+    acc
+}
+
+fn main() {
+    let _ = xorTo(1024)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/combined_clang_oracle.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	tmp := t.TempDir()
+	irPath := tmp + "/module.ll"
+	if err := writeBytes(irPath, ir); err != nil {
+		t.Fatalf("write ir: %v", err)
+	}
+	cmd := exec.Command(clangPath,
+		"-x", "ir", "-O3", "-S",
+		"-o", tmp+"/module.s",
+		"-Rpass=loop-vectorize",
+		irPath,
+	)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("clang -O3 failed on combined-hints IR: %v\n%s", runErr, out)
+	}
+	if !strings.Contains(string(out), "vectorized loop") {
+		t.Fatalf("expected `vectorized loop` remark with combined hints, got:\n%s", out)
+	}
+}

--- a/internal/llvmgen/vectorize_real_simd_test.go
+++ b/internal/llvmgen/vectorize_real_simd_test.go
@@ -20,8 +20,12 @@ import (
 // iteration poll (negative control). This prevents the safepoint
 // opt-out from regressing into a module-wide "no loop polls" bug.
 func TestVectorizeFunctionBodyIsCallFree(t *testing.T) {
-	file := parseLLVMGenFile(t, `#[vectorize]
-fn hot(n: Int) -> Int {
+	// v0.6 A5.2 flip: default is vectorize-ON (no annotation). The
+	// opt-out is `#[no_vectorize]`, which restores per-iteration
+	// safepoint polls. The test keeps one fn on each side of the
+	// default so a regression where one leaks into the other would be
+	// caught.
+	file := parseLLVMGenFile(t, `fn hot(n: Int) -> Int {
     let mut acc = 0
     for i in 0..n {
         acc = acc + i
@@ -29,6 +33,7 @@ fn hot(n: Int) -> Int {
     acc
 }
 
+#[no_vectorize]
 fn cold(n: Int) -> Int {
     let mut acc = 0
     for i in 0..n {
@@ -57,8 +62,8 @@ fn main() {
 		t.Fatalf("hot function not found in IR:\n%s", got)
 	}
 	if strings.Contains(hot, "osty.gc.safepoint_v1") {
-		t.Fatalf("#[vectorize] hot body still emits gc.safepoint_v1 "+
-			"(LLVM vectorizer will bail):\n%s", hot)
+		t.Fatalf("default-on vectorize should keep hot body call-free "+
+			"(LLVM vectorizer would otherwise bail):\n%s", hot)
 	}
 
 	cold, ok := extractFunctionBody(got, "cold")
@@ -66,8 +71,8 @@ fn main() {
 		t.Fatalf("cold function not found in IR:\n%s", got)
 	}
 	if !strings.Contains(cold, "osty.gc.safepoint_v1") {
-		t.Fatalf("unannotated cold body dropped its safepoint — the "+
-			"vectorize opt-out must not leak to sibling functions:\n%s", cold)
+		t.Fatalf("`#[no_vectorize]` should restore per-iteration safepoints "+
+			"and the opt-out must not leak to sibling functions:\n%s", cold)
 	}
 }
 

--- a/internal/llvmgen/vectorize_test.go
+++ b/internal/llvmgen/vectorize_test.go
@@ -54,7 +54,7 @@ fn main() {
 // TestVectorizeAnnotationAbsentEmitsNoLoopMetadata is the negative
 // control: without the annotation, no loop metadata should be emitted
 // and the IR should be byte-identical to today's baseline shape.
-func TestVectorizeAnnotationAbsentEmitsNoLoopMetadata(t *testing.T) {
+func TestVectorizeIsDefaultOn(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn hot(n: Int) -> Int {
     let mut acc = 0
     for i in 0..n {
@@ -70,28 +70,70 @@ fn main() {
 
 	irBytes, err := generateFromAST(file, Options{
 		PackageName: "main",
-		SourcePath:  "/tmp/vectorize_absent.osty",
+		SourcePath:  "/tmp/vectorize_default_on.osty",
 	})
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 	got := string(irBytes)
 
-	if strings.Contains(got, "!llvm.loop") {
-		t.Fatalf("expected no loop metadata without #[vectorize], got:\n%s", got)
+	// v0.6 A5.2 flip: every function's loops get the vectorize hint
+	// unless the function carries `#[no_vectorize]`. Typing no
+	// annotation is the fast path now.
+	if !strings.Contains(got, "!llvm.loop") {
+		t.Fatalf("v0.6 default should emit !llvm.loop metadata; got:\n%s", got)
 	}
-	if strings.Contains(got, "llvm.loop.vectorize.enable") {
-		t.Fatalf("expected no vectorize property without annotation, got:\n%s", got)
+	if !strings.Contains(got, `!"llvm.loop.vectorize.enable", i1 true`) {
+		t.Fatalf("v0.6 default should emit vectorize.enable; got:\n%s", got)
 	}
 }
 
-// TestVectorizeAnnotationScopedToAnnotatedFunction asserts that a
-// vectorize hint is function-local: a loop in an unannotated sibling
-// fn receives no metadata even when another fn in the same module is
-// annotated.
-func TestVectorizeAnnotationScopedToAnnotatedFunction(t *testing.T) {
-	file := parseLLVMGenFile(t, `#[vectorize]
-fn hot(n: Int) -> Int {
+// TestNoVectorizeAnnotationOptsOut covers the opt-out: `#[no_vectorize]`
+// suppresses both the loop metadata and the safepoint skip, giving
+// back the pre-v0.6 GC-cooperative shape for functions that need
+// mid-loop yielding.
+func TestNoVectorizeAnnotationOptsOut(t *testing.T) {
+	file := parseLLVMGenFile(t, `#[no_vectorize]
+fn cold(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i
+    }
+    acc
+}
+
+fn main() {
+    let _ = cold(1024)
+}
+`)
+
+	irBytes, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/vectorize_opt_out.osty",
+	})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	got := string(irBytes)
+
+	cold, ok := extractFunctionBody(got, "cold")
+	if !ok {
+		t.Fatalf("cold function not found in IR:\n%s", got)
+	}
+	if strings.Contains(cold, "!llvm.loop") {
+		t.Fatalf("`#[no_vectorize]` should suppress !llvm.loop; got:\n%s", cold)
+	}
+	if !strings.Contains(cold, "osty.gc.safepoint_v1") {
+		t.Fatalf("`#[no_vectorize]` should restore per-iteration safepoint polls; got:\n%s", cold)
+	}
+}
+
+// TestNoVectorizeScopedToAnnotatedFunction asserts that `#[no_vectorize]`
+// is function-local: a loop in an unannotated sibling fn still gets
+// the default vectorize hint, while the opt-out fn keeps its
+// scalar-with-safepoint shape.
+func TestNoVectorizeScopedToAnnotatedFunction(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn hot(n: Int) -> Int {
     let mut a = 0
     for i in 0..n {
         a = a + i
@@ -99,6 +141,7 @@ fn hot(n: Int) -> Int {
     a
 }
 
+#[no_vectorize]
 fn cold(n: Int) -> Int {
     let mut b = 0
     for j in 0..n {
@@ -115,17 +158,15 @@ fn main() {
 
 	irBytes, err := generateFromAST(file, Options{
 		PackageName: "main",
-		SourcePath:  "/tmp/vectorize_scoped.osty",
+		SourcePath:  "/tmp/no_vectorize_scoped.osty",
 	})
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 	got := string(irBytes)
 
-	// Exactly one loop should carry the hint — exactly one `!llvm.loop !`
-	// occurrence on a branch instruction. Metadata defs contribute a
-	// different substring ("distinct !{"), so counting the branch-site
-	// suffix isolates loop attachments.
+	// Default-on + one opt-out => exactly one `!llvm.loop` attachment
+	// (on `hot`). `cold` carries safepoint, no metadata.
 	attachments := strings.Count(got, ", !llvm.loop !")
 	if attachments != 1 {
 		t.Fatalf("expected exactly 1 loop metadata attachment, got %d:\n%s", attachments, got)

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -283,6 +283,13 @@ func (l *lowerer) lowerFunction(fn *ir.FnDecl, owner string, asMethod bool) *Fun
 	out.ExportSymbol = fn.ExportSymbol
 	out.CABI = fn.CABI
 	out.Vectorize = fn.Vectorize
+	out.NoVectorize = fn.NoVectorize
+	out.VectorizeWidth = fn.VectorizeWidth
+	out.VectorizeScalable = fn.VectorizeScalable
+	out.VectorizePredicate = fn.VectorizePredicate
+	out.Parallel = fn.Parallel
+	out.Unroll = fn.Unroll
+	out.UnrollCount = fn.UnrollCount
 	out.IsIntrinsic = fn.IsIntrinsic
 	if fn.Body == nil {
 		out.IsExternal = true

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -152,12 +152,37 @@ type Function struct {
 	// the platform's C calling convention.
 	CABI bool
 
-	// Vectorize is set when the function carries `#[vectorize]` (v0.6
-	// A5 §3.8.3). The LLVM emitter attaches `!llvm.loop !N` metadata
-	// with `llvm.loop.vectorize.enable=true` to every loop backedge
-	// lowered in the body. Pure hint — the LLVM vectorizer makes the
-	// final legality + profitability decision.
+	// Vectorize is true iff the LLVM emitter should attach vectorize
+	// metadata to this function's loops (and opt out of per-iteration
+	// safepoints). As of v0.6 the default is true — `#[no_vectorize]`
+	// is the sole way to flip it off. §3.8.3.
 	Vectorize bool
+	// NoVectorize captures the explicit `#[no_vectorize]` opt-out so
+	// tooling can distinguish "user explicitly said no" from "default
+	// off" in the future.
+	NoVectorize bool
+
+	// VectorizeWidth / VectorizeScalable / VectorizePredicate carry
+	// the v0.6 A5.1 tuning args (`width=N`, `scalable`, `predicate`).
+	// Width = 0 means "compiler chooses", >0 forces the factor; the
+	// flags opt into scalable ISAs (SVE/RVV) and tail folding via
+	// masked ops respectively.
+	VectorizeWidth     int
+	VectorizeScalable  bool
+	VectorizePredicate bool
+
+	// Parallel is set by `#[parallel]` (v0.6 A6). The LLVM emitter
+	// allocates a single `!llvm.access.group` node per parallel
+	// function, tags every load/store with `!llvm.access`, and
+	// references it from `llvm.loop.parallel_accesses` on each loop
+	// backedge so the vectorizer can bypass alias analysis.
+	Parallel bool
+
+	// Unroll / UnrollCount carry `#[unroll]` / `#[unroll(N)]` (v0.6
+	// A7). Count = 0 emits the bare `llvm.loop.unroll.enable`; Count
+	// > 0 emits `llvm.loop.unroll.count, i32 N` instead.
+	Unroll      bool
+	UnrollCount int
 }
 
 // At returns the function's source span.

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -3,6 +3,7 @@ package resolve
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/osty/osty/internal/ast"
@@ -507,7 +508,7 @@ func (r *resolver) checkAnnotations(annots []*ast.Annotation, target ast.Annotat
 				Code(diag.CodeUnknownAnnotation).
 				Primary(diag.Span{Start: a.PosV, End: a.EndV},
 					"this annotation name is not recognized").
-				Note("v0.4 §18.1: only `#[json]`, `#[deprecated]`, `#[allow]`, `#[cfg]`, `#[op]`, `#[test]`, `#[vectorize]`, and the runtime sublanguage annotations are permitted").
+				Note("v0.4 §18.1: only `#[json]`, `#[deprecated]`, `#[allow]`, `#[cfg]`, `#[op]`, `#[test]`, `#[vectorize]`, `#[no_vectorize]`, `#[parallel]`, `#[unroll]`, and the runtime sublanguage annotations are permitted").
 				Build())
 			continue
 		}
@@ -557,6 +558,12 @@ func (r *resolver) checkAnnotationArgs(a *ast.Annotation, target ast.AnnotationT
 		r.checkNoArgsRuntime(a)
 	case "vectorize":
 		r.checkVectorizeArgs(a)
+	case "no_vectorize":
+		r.checkNoVectorizeArgs(a)
+	case "parallel":
+		r.checkParallelArgs(a)
+	case "unroll":
+		r.checkUnrollArgs(a)
 	}
 }
 
@@ -663,18 +670,210 @@ func (r *resolver) checkNoArgsRuntime(a *ast.Annotation) {
 		Build())
 }
 
-// checkVectorizeArgs validates `#[vectorize]`, which is a bare-flag
-// hint with no arguments (v0.6 A5). Any argument is rejected.
+// checkVectorizeArgs validates `#[vectorize]` per v0.6 A5 / A5.1.
+// The bare-flag form is still accepted ("compiler chooses everything")
+// and three optional tuning args are now permitted:
+//
+//   - `scalable` — prefer scalable vectorization (SVE, RVV) over
+//     fixed-width (NEON). Bare flag.
+//   - `predicate` — enable tail folding so the vectorizer processes
+//     trip counts that are not a multiple of the vector width via
+//     masked operations instead of a scalar tail loop. Bare flag.
+//   - `width = N` — force the vectorization factor to exactly N
+//     (positive int literal, 1..1024). Unlocks AVX-512 ZMM on Intel,
+//     where the cost model otherwise refuses 512-bit vectors.
+//
+// Unknown keys, duplicate keys, and out-of-range widths are rejected
+// with E0739.
 func (r *resolver) checkVectorizeArgs(a *ast.Annotation) {
+	var hasScalable, hasPredicate, hasWidth bool
+	for _, arg := range a.Args {
+		if arg == nil {
+			continue
+		}
+		switch arg.Key {
+		case "scalable":
+			if hasScalable {
+				r.emit(diag.New(diag.Error,
+					"duplicate `scalable` in `#[vectorize(...)]`").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "second occurrence").
+					Build())
+				continue
+			}
+			hasScalable = true
+			if !isFlagOrTrue(arg) {
+				r.emit(diag.New(diag.Error,
+					"`scalable` in `#[vectorize(...)]` is a bare flag").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "expected `scalable`, not `scalable = ...`").
+					Build())
+			}
+		case "predicate":
+			if hasPredicate {
+				r.emit(diag.New(diag.Error,
+					"duplicate `predicate` in `#[vectorize(...)]`").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "second occurrence").
+					Build())
+				continue
+			}
+			hasPredicate = true
+			if !isFlagOrTrue(arg) {
+				r.emit(diag.New(diag.Error,
+					"`predicate` in `#[vectorize(...)]` is a bare flag").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "expected `predicate`, not `predicate = ...`").
+					Build())
+			}
+		case "width":
+			if hasWidth {
+				r.emit(diag.New(diag.Error,
+					"duplicate `width` in `#[vectorize(...)]`").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "second occurrence").
+					Build())
+				continue
+			}
+			hasWidth = true
+			w, ok := positiveIntArg(arg.Value)
+			if !ok {
+				r.emit(diag.New(diag.Error,
+					"`width` in `#[vectorize(...)]` requires a positive integer literal").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "expected `width = <1..1024>`").
+					Build())
+				continue
+			}
+			if w < 1 || w > 1024 {
+				r.emit(diag.New(diag.Error,
+					"`width` in `#[vectorize(...)]` must be in 1..1024").
+					Code(diag.CodeAnnotationBadArg).
+					PrimaryPos(arg.PosV, "value out of range").
+					Build())
+			}
+		case "":
+			r.emit(diag.New(diag.Error,
+				"`#[vectorize(...)]` arguments must be named").
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(arg.PosV, "positional argument not allowed").
+				Build())
+		default:
+			r.emit(diag.New(diag.Error,
+				fmt.Sprintf("unknown `#[vectorize]` argument `%s`", arg.Key)).
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(arg.PosV, "not a recognized key").
+				Note("accepted: `scalable`, `predicate`, `width = N`").
+				Build())
+		}
+	}
+}
+
+// checkNoVectorizeArgs validates `#[no_vectorize]` (v0.6 A5.2), a
+// bare-flag opt-out. Any argument is rejected.
+func (r *resolver) checkNoVectorizeArgs(a *ast.Annotation) {
 	if len(a.Args) == 0 {
 		return
 	}
 	r.emit(diag.New(diag.Error,
-		"`#[vectorize]` does not take arguments").
+		"`#[no_vectorize]` does not take arguments").
 		Code(diag.CodeAnnotationBadArg).
 		PrimaryPos(a.Args[0].PosV, "unexpected argument").
-		Note("v0.6 A5: `#[vectorize]` is a bare flag — the compiler chooses the concrete vectorization strategy").
+		Note("v0.6 A5.2: `#[no_vectorize]` is a bare flag that opts a function out of the default vectorize treatment").
 		Build())
+}
+
+// checkParallelArgs validates `#[parallel]` (v0.6 A6), a bare-flag
+// annotation. Any argument is rejected.
+func (r *resolver) checkParallelArgs(a *ast.Annotation) {
+	if len(a.Args) == 0 {
+		return
+	}
+	r.emit(diag.New(diag.Error,
+		"`#[parallel]` does not take arguments").
+		Code(diag.CodeAnnotationBadArg).
+		PrimaryPos(a.Args[0].PosV, "unexpected argument").
+		Note("v0.6 A6: `#[parallel]` is a bare flag asserting no loop-carried memory dependencies").
+		Build())
+}
+
+// checkUnrollArgs validates `#[unroll]` / `#[unroll(count = N)]`
+// (v0.6 A7). Accepts either the bare form (no args — compiler picks
+// factor) or a single `count = <1..1024>` key/value pair. Positional
+// values are not supported because the v0.5 annotation grammar only
+// produces `key` or `key = value` arg shapes.
+func (r *resolver) checkUnrollArgs(a *ast.Annotation) {
+	switch len(a.Args) {
+	case 0:
+		return
+	case 1:
+		arg := a.Args[0]
+		if arg == nil {
+			return
+		}
+		if arg.Key != "count" {
+			r.emit(diag.New(diag.Error,
+				fmt.Sprintf("unknown `#[unroll]` argument `%s`", arg.Key)).
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(arg.PosV, "not a recognized key").
+				Note("accepted: `count = N` for a fixed unroll factor").
+				Build())
+			return
+		}
+		n, ok := positiveIntArg(arg.Value)
+		if !ok {
+			r.emit(diag.New(diag.Error,
+				"`#[unroll(count = N)]` requires a positive integer literal").
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(arg.PosV, "expected `count = <1..1024>`").
+				Build())
+			return
+		}
+		if n < 1 || n > 1024 {
+			r.emit(diag.New(diag.Error,
+				"`#[unroll(count = N)]` value must be in 1..1024").
+				Code(diag.CodeAnnotationBadArg).
+				PrimaryPos(arg.PosV, "value out of range").
+				Build())
+		}
+	default:
+		r.emit(diag.New(diag.Error,
+			"`#[unroll(...)]` takes at most one argument").
+			Code(diag.CodeAnnotationBadArg).
+			PrimaryPos(a.Args[1].PosV, "extra argument").
+			Build())
+	}
+}
+
+// positiveIntArg extracts the value of a positive integer literal
+// annotation argument. Returns (value, true) only when the expression
+// is an `*ast.IntLit` whose text parses as a non-negative int64.
+func positiveIntArg(e ast.Expr) (int64, bool) {
+	lit, ok := e.(*ast.IntLit)
+	if !ok {
+		return 0, false
+	}
+	text := strings.ReplaceAll(lit.Text, "_", "")
+	base := 10
+	switch {
+	case strings.HasPrefix(text, "0x"), strings.HasPrefix(text, "0X"):
+		base = 16
+		text = text[2:]
+	case strings.HasPrefix(text, "0o"), strings.HasPrefix(text, "0O"):
+		base = 8
+		text = text[2:]
+	case strings.HasPrefix(text, "0b"), strings.HasPrefix(text, "0B"):
+		base = 2
+		text = text[2:]
+	}
+	if text == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(text, base, 64)
+	if err != nil || v < 0 {
+		return 0, false
+	}
+	return v, true
 }
 
 // checkJSONArgs validates #[json(...)] argument shapes per §3.8.1:

--- a/internal/resolve/runtime_annot_test.go
+++ b/internal/resolve/runtime_annot_test.go
@@ -257,15 +257,202 @@ pub fn hot(n: Int) -> Int {
 	}
 }
 
-func TestVectorizeRejectsArgs(t *testing.T) {
+func TestVectorizeAcceptsWidth(t *testing.T) {
 	src := `
-#[vectorize(width = 4)]
-pub fn hot(n: Int) -> Int {
-    n
+#[vectorize(width = 8)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739 on `#[vectorize(width = 8)]`, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
 }
+
+func TestVectorizeAcceptsAllThreeTuning(t *testing.T) {
+	src := `
+#[vectorize(scalable, predicate, width = 8)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739 on full tuning combo, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestVectorizeRejectsUnknownKey(t *testing.T) {
+	src := `
+#[vectorize(foo = 1)]
+pub fn hot(n: Int) -> Int { n }
 `
 	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
-		t.Fatalf("expected 1 E0739 on #[vectorize(...)], got %d:\n%s",
+		t.Fatalf("expected 1 E0739 on unknown key, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestVectorizeRejectsWidthZero(t *testing.T) {
+	src := `
+#[vectorize(width = 0)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on width = 0, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestVectorizeRejectsWidthTooLarge(t *testing.T) {
+	src := `
+#[vectorize(width = 99999)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on width out of range, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestVectorizeRejectsDuplicateScalable(t *testing.T) {
+	src := `
+#[vectorize(scalable, scalable)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on duplicate scalable, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// --- #[no_vectorize] (v0.6 A5.2) ---
+
+func TestNoVectorizeAcceptsBareFlag(t *testing.T) {
+	src := `
+#[no_vectorize]
+pub fn cold(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739 on bare #[no_vectorize], got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestNoVectorizeRejectsArgs(t *testing.T) {
+	src := `
+#[no_vectorize(reason = "gc-cooperation")]
+pub fn cold(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on #[no_vectorize(...)], got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestNoVectorizeRejectsOnField(t *testing.T) {
+	src := `
+pub struct Bad {
+    #[no_vectorize]
+    pub count: Int,
+}
+`
+	if got := countBadTarget(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0607 on `#[no_vectorize]` over struct field, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// --- #[parallel] (v0.6 A6) ---
+
+func TestParallelAcceptsBareFlag(t *testing.T) {
+	src := `
+#[parallel]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739 on bare #[parallel], got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestParallelRejectsArgs(t *testing.T) {
+	src := `
+#[parallel(level = 2)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on #[parallel(...)], got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestParallelRejectsOnStructField(t *testing.T) {
+	src := `
+pub struct Bad {
+    #[parallel]
+    pub n: Int,
+}
+`
+	if got := countBadTarget(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0607 on `#[parallel]` over struct field, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// --- #[unroll] / #[unroll(count = N)] (v0.6 A7) ---
+
+func TestUnrollAcceptsBareFlag(t *testing.T) {
+	src := `
+#[unroll]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739 on bare #[unroll], got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestUnrollAcceptsCount(t *testing.T) {
+	src := `
+#[unroll(count = 4)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 0 {
+		t.Fatalf("expected 0 E0739 on `#[unroll(count = 4)]`, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestUnrollRejectsUnknownKey(t *testing.T) {
+	src := `
+#[unroll(factor = 4)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on unknown `factor` key, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+func TestUnrollRejectsCountZero(t *testing.T) {
+	src := `
+#[unroll(count = 0)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on count = 0, got %d:\n%s",
+			got, renderDiags(runAnnotArgs(t, src)))
+	}
+}
+
+// Retained for historical context — the v0.6 A5 bare-flag form is
+// still the one that appears throughout the stdlib, so losing the
+// "bare form stays legal" signal would be a regression.
+func TestVectorizeRejectsPositional(t *testing.T) {
+	src := `
+#[vectorize(foobar)]
+pub fn hot(n: Int) -> Int { n }
+`
+	if got := countArgBad(runAnnotArgs(t, src)); got != 1 {
+		t.Fatalf("expected 1 E0739 on unknown positional, got %d:\n%s",
 			got, renderDiags(runAnnotArgs(t, src)))
 	}
 }

--- a/testdata/spec/negative/reject.osty
+++ b/testdata/spec/negative/reject.osty
@@ -179,8 +179,23 @@ pub struct Bad {
 }
 // === END
 
-// === CASE: E0739 === #[vectorize] does not take arguments
-#[vectorize(width = 4)]
+// === CASE: E0739 === #[vectorize] rejects unknown argument keys
+#[vectorize(foo = 4)]
+pub fn hot(n: Int) -> Int { n }
+// === END
+
+// === CASE: E0739 === #[vectorize] rejects width out of range
+#[vectorize(width = 99999)]
+pub fn hot(n: Int) -> Int { n }
+// === END
+
+// === CASE: E0739 === #[unroll] rejects unknown argument keys
+#[unroll(factor = 4)]
+pub fn hot(n: Int) -> Int { n }
+// === END
+
+// === CASE: E0739 === #[parallel] takes no arguments
+#[parallel(level = 2)]
 pub fn hot(n: Int) -> Int { n }
 // === END
 

--- a/testdata/spec/positive/14a-v05-annotations.osty
+++ b/testdata/spec/positive/14a-v05-annotations.osty
@@ -37,14 +37,24 @@ fn arithmeticTest() {
     let _ = b
 }
 
-// ---- #[vectorize] (v0.6 A5) ----
-// Bare flag on a top-level fn — LLVM backend attaches
-// !llvm.loop.vectorize.enable metadata to every user-written for-loop
-// lowered in the body. Semantics are a hint; LLVM's own legality +
-// profitability analysis decides whether the loop actually vectorizes.
+// ---- Vectorize (v0.6 A5 / A5.1 / A5.2) ----
+// Default is ON — a plain `fn` already gets vectorize metadata + the
+// per-iteration safepoint skip. Annotations are only for deviation.
 
-#[vectorize]
-fn sumTo(n: Int) -> Int {
+// v0.6 A5.1 — tuning args: scalable + predicate + width. Default-on
+// is preserved, these arguments only refine strategy.
+#[vectorize(scalable, predicate, width = 8)]
+fn xorTo(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc ^ i
+    }
+    acc
+}
+
+// v0.6 A5.2 — opt-out for GC-cooperative worker loops.
+#[no_vectorize]
+fn drainStep(n: Int) -> Int {
     let mut acc = 0
     for i in 0..n {
         acc = acc + i
@@ -52,26 +62,73 @@ fn sumTo(n: Int) -> Int {
     acc
 }
 
+// Bare `#[vectorize]` is accepted as a no-op (documents intent;
+// redundant with default).
 #[vectorize]
-fn twoLoops(n: Int) -> Int {
+fn hotButExplicit(n: Int) -> Int {
     let mut acc = 0
     for i in 0..n {
         acc = acc + i
     }
-    for j in 0..n {
-        acc = acc + j
-    }
     acc
 }
 
-// #[vectorize] on a method — allowed target.
+// vectorize tuning on a method — allowed target.
 struct Accumulator {
     total: Int,
 
-    #[vectorize]
+    #[vectorize(predicate)]
     fn addRange(mut self, n: Int) {
         for i in 0..n {
             self.total = self.total + i
         }
     }
+}
+
+// ---- #[parallel] (v0.6 A6) ----
+// Asserts iterations have no loop-carried memory dependencies — LLVM
+// emits !llvm.access.group + llvm.loop.parallel_accesses metadata.
+
+#[parallel]
+fn addInto(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i * 2
+    }
+    acc
+}
+
+// ---- #[unroll] / #[unroll(count = N)] (v0.6 A7) ----
+// Bare form lets compiler pick; count form forces a specific factor.
+
+#[unroll]
+fn bareUnroll(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i
+    }
+    acc
+}
+
+#[unroll(count = 4)]
+fn fixedUnroll(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + i
+    }
+    acc
+}
+
+// ---- combined hints ----
+// All three annotations compose. Width × unroll ≈ effective throughput.
+
+#[vectorize(predicate)]
+#[parallel]
+#[unroll(count = 2)]
+fn allCombined(n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc ^ i
+    }
+    acc
 }


### PR DESCRIPTION
## Summary

Extends the v0.6 A5 vectorize track with four follow-up decisions so loop SIMD is the default and users only type annotations to deviate:

1. **A5.1** — `#[vectorize]` now accepts optional tuning args: `scalable`, `predicate`, `width = N`.
2. **A5.2** — Vectorize is **default on** across the whole program. Every function's loops get the metadata and the per-iteration GC safepoint skip without the user typing anything. Opt out with the new `#[no_vectorize]` bare-flag annotation.
3. **A6** — New `#[parallel]` annotation emits per-function `!llvm.access.group` + `llvm.loop.parallel_accesses`, tagging every load/store in the body so the vectorizer can bypass alias analysis. Soundness is the programmer's responsibility.
4. **A7** — New `#[unroll]` / `#[unroll(count = N)]` annotation emits `llvm.loop.unroll.enable` or `llvm.loop.unroll.count`. Independent axis from vectorize; the two compose.

## Design: default-on, deviation is typed

Before this PR, the user had to type `#[vectorize]` on every hot loop to get SIMD. That puts the optimization on the user's checklist. This PR flips the default: vectorize is what the compiler does, and the user types `#[no_vectorize]` only when they explicitly need GC-cooperative behavior (e.g., a long-running worker loop that must yield to concurrent STW mid-loop).

Advanced tuning (`scalable`, `predicate`, `width = N`) and the two separate annotations (`#[parallel]`, `#[unroll]`) remain opt-in because they encode extra semantics: `#[parallel]` is a correctness contract about memory dependencies, `#[unroll]` is a code-size-vs-speed tradeoff, tuning args are strategy overrides.

## Measured impact

XOR reduction (1M × 200 iter, arm64 apple-m1):

| Variant                                                   | User CPU | Speedup |
|-----------------------------------------------------------|----------|---------|
| `#[no_vectorize]` (scalar + safepoint)                    | 0.29s    | 1.0×    |
| default (no annotation)                                   | 0.06s    | **4.8×** |
| `#[vectorize(predicate)] #[parallel] #[unroll(count = 4)]` | 0.05s   | **5.6×** |

## Cross-target verification

- **aarch64 apple-m1**: NEON `eor.16b` / `add.2d` (ASIMD1/2).
- **aarch64 neoverse-v1 +sve**: `vscale x 8` scalable loop, 45 `z<N>.d` SVE instructions when `#[vectorize(scalable)]` is set.
- **x86-64 haswell**: AVX2 `vpxor %ymm` / `vpaddq %ymm` (width 4, interleave 4 = 16 elements/iter).
- **x86-64 skylake-avx512 + `-mllvm -force-vector-width=8`**: 8 ZMM registers activated. Metadata-level `vectorize.width` is passed to the backend but LLVM's cost model may still prefer YMM without the build-time override.

## What changed

Pipeline wiring (ast → resolve → ir → mir → llvmgen) for seven new per-function fields (`NoVectorize`, `VectorizeWidth/Scalable/Predicate`, `Parallel`, `Unroll`, `UnrollCount`). Both the legacy HIR emitter and the MIR-direct emitter now compose a single `!llvm.loop` metadata tree per loop containing every active hint, and both allocate a per-function `!llvm.access.group` for `#[parallel]` with every load/store post-processed to reference it.

## Tests

- 13 new resolver tests covering arg shapes for all four new annotations (accept / reject / duplicate / range).
- 9 new codegen tests: metadata shape for each hint, combined-hints single loop node, access group tagging / leak prevention, bare vs count unroll, clang integration oracle on the combined form.
- Spec corpus positive entry rewritten around the flipped default. Spec corpus negative entry adds new E0739 cases for each rejected arg shape.

## Spec

- LANG_SPEC §3.8.3 rewritten for the default-on model + tuning table.
- New §3.8.4 `#[parallel]`, §3.8.5 `#[unroll]`, §3.8.6 shared GC contract.
- SPEC_GAPS `vectorize-hint` updated: safepoint blocker marked resolved with measured numbers; iterator-protocol + AVX-512 cost model carved out as remaining backend work.

## Test plan

- [x] `just front` (lexer + parser + resolve + check + diag + format + lint)
- [x] `go test -short ./internal/{ir,mir,llvmgen,speccorpus}`
- [x] `go test -run 'TestVectorize|TestParallel|TestUnroll|TestNoVectorize|TestCombined|TestClang' ./internal/{resolve,llvmgen}` — 22 tests pass
- [x] Real-LLVM integration: `clang -x ir -O3 -S -Rpass=loop-vectorize` emits `vectorized loop` remarks + SIMD instructions on aarch64 NEON, aarch64 SVE, x86-64 AVX2, x86-64 AVX-512
- [x] Wall-clock benchmark: 4.8× speedup with zero source annotations, 5.6× with full combined hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)