### PR TITLE
[codex] Remove legacy llvmgen gate

### DIFF
--- a/cmd/osty/build.go
+++ b/cmd/osty/build.go
@@ -231,8 +231,8 @@ func isOstySource(name string) bool {
 
 // countLowerableFiles reports how many of pkg.Files actually carry a
 // parsed AST. PackageFile entries with a nil File slip through resolve
-// when parse fails fatally; ir.LowerPackage skips them, so we count the
-// same predicate when deciding between PrepareEntry and PreparePackage.
+// when parse fails fatally; ir.LowerPackage skips them, and the gen path
+// uses the same predicate to decide whether package lowering is viable.
 func countLowerableFiles(pkg *resolve.Package) int {
 	if pkg == nil {
 		return 0
@@ -524,23 +524,8 @@ func emitAndBuild(root string, m *manifest.Manifest, pkg *resolve.Package, pr *r
 			}
 		}
 	}
-	// Package lowering is the default live build path; only degenerate
-	// empty-package callers fall back to a direct single-file entry.
-	var (
-		entry    backend.Entry
-		entryErr error
-	)
-	if pkg != nil && countLowerableFiles(pkg) > 0 {
-		entry, entryErr = backend.PreparePackage("main", entryAbs, pkg, entryFile, chk)
-	} else {
-		res := &resolve.Result{
-			Refs:      entryFile.Refs,
-			TypeRefs:  entryFile.TypeRefs,
-			FileScope: entryFile.FileScope,
-		}
-		entry, entryErr = backend.PrepareEntry("main", entryAbs, entryFile.File, res, chk)
-	}
-	if err := entryErr; err != nil {
+	entry, err := backend.PreparePackage("main", entryAbs, pkg, entryFile, chk)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty build: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/osty/run.go
+++ b/cmd/osty/run.go
@@ -167,9 +167,7 @@ func runRun(args []string, cliF cliFlags) {
 		os.Exit(1)
 	}
 
-	// Locate the AST + resolve/check results for the entry file so we
-	// can pass them to gen. The entry is in the root package; find
-	// the matching PackageFile.
+	// Locate the root package entry file for package lowering.
 	var entryFile *resolve.PackageFile
 	entryAbs, _ := filepath.Abs(entry)
 	for _, pf := range rootPkg.Files {
@@ -182,12 +180,6 @@ func runRun(args []string, cliF cliFlags) {
 		fmt.Fprintf(os.Stderr, "osty run: entry %s not part of the root package\n", entry)
 		os.Exit(1)
 	}
-	res := &resolve.Result{
-		Refs:      entryFile.Refs,
-		TypeRefs:  entryFile.TypeRefs,
-		FileScope: entryFile.FileScope,
-	}
-	file := entryFile.File
 	chk := checks[""]
 	if chk == nil {
 		chk = &check.Result{}
@@ -227,18 +219,8 @@ func runRun(args []string, cliF cliFlags) {
 			return
 		}
 	}
-	// Package lowering is the default live run path; only degenerate
-	// empty-package callers fall back to a direct single-file entry.
-	var (
-		backendEntry backend.Entry
-		entryErr     error
-	)
-	if rootPkg != nil && countLowerableFiles(rootPkg) > 0 {
-		backendEntry, entryErr = backend.PreparePackage("main", entryAbs, rootPkg, entryFile, chk)
-	} else {
-		backendEntry, entryErr = backend.PrepareEntry("main", entryAbs, file, res, chk)
-	}
-	if err := entryErr; err != nil {
+	backendEntry, err := backend.PreparePackage("main", entryAbs, rootPkg, entryFile, chk)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty run: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -713,10 +713,9 @@ MIR tests isolated from front-end churn.
   - **Dispatcher gate.** `llvmgen.Options.UseMIR` selects the path.
     The backend dispatcher (`internal/backend/llvm.go`) now prefers
     `GenerateFromMIR(entry.MIR, opts)` by default on raw `llvm-ir`
-    emission, lets requests opt back into the legacy bridge with the
-    `legacy-llvmgen` feature, and still allows explicit opt-in on
-    object/binary emission via `mir-backend`. On `ErrUnsupported` the
-    dispatcher catches the sentinel and falls back to
+    emission, and still allows explicit opt-in on object/binary
+    emission via `mir-backend`. On `ErrUnsupported` the dispatcher
+    catches the sentinel and falls back to
     `GenerateModule(entry.IR, opts)` automatically, so coverage
     regressions are impossible while parity lands.
   - **MVP coverage.** Primitive types (Int / UInt / Byte / Bool /
@@ -917,10 +916,9 @@ MIR tests isolated from front-end churn.
 
 - **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
   backend now prefers the MIR-direct emitter by default for raw
-  `llvm-ir` output. The legacy HIR→AST bridge remains callable under
-  the `legacy-llvmgen` feature, object/binary emission can still opt in
-  explicitly with `mir-backend`, and the dispatcher falls back
-  automatically on `ErrUnsupported`.
+  `llvm-ir` output. Object/binary emission can still opt in explicitly
+  with `mir-backend`, and the dispatcher falls back automatically on
+  `ErrUnsupported`.
 
 - **Stage 3.9 (landed — concurrency intrinsic runtime mapping).**
   All MIR concurrency intrinsics emitted by the MIR lowerer now

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -167,11 +167,9 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	// backend does not consume directly any more.
 	//
 	// After the native-owned fast path declines coverage, raw `llvm-ir`
-	// still prefers MIR by default. Requests can opt back into the
-	// legacy HIR→AST bridge with `legacy-llvmgen`, or force MIR on every
-	// emit mode with `mir-backend`. On MIR-emitter refusal we still fall
-	// back automatically, so enabling the new path cannot reduce
-	// coverage.
+	// still prefers MIR by default, and `mir-backend` can force MIR on
+	// every emit mode. On MIR-emitter refusal we still fall back
+	// automatically, so enabling the new path cannot reduce coverage.
 	var (
 		irOut  []byte
 		genErr error
@@ -269,38 +267,24 @@ func runClang(ctx context.Context, action string, args []string) error {
 	return fmt.Errorf("%s: %w", llvmgen.ClangFailureMessage(action, command, msg), err)
 }
 
-// featureEnabled reports whether `name` appears in the features
-// slice.
-func featureEnabled(features []string, name string) bool {
-	for _, f := range features {
-		if f == name {
-			return true
-		}
-	}
-	return false
-}
-
 // useMIRBackend reports whether LLVM emission should prefer the
 // MIR-direct path. Raw `llvm-ir` emission is MIR-first by default;
-// callers can opt back into the legacy HIR→AST bridge with the
-// `legacy-llvmgen` feature, or opt further in on object/binary
-// emission with `mir-backend` while parity stabilizes.
+// callers can opt further in on object/binary emission with
+// `mir-backend` while parity stabilizes.
 func useMIRBackend(features []string, emit EmitMode) bool {
-	if featureEnabled(features, "legacy-llvmgen") {
-		return false
-	}
-	if featureEnabled(features, "mir-backend") {
-		return true
+	for _, f := range features {
+		if f == "mir-backend" {
+			return true
+		}
 	}
 	return emit == EmitLLVMIR
 }
 
 func useNativeOwnedLLVMIR(features []string, emit EmitMode) bool {
-	if featureEnabled(features, "legacy-llvmgen") {
-		return false
-	}
-	if featureEnabled(features, "mir-backend") {
-		return false
+	for _, f := range features {
+		if f == "mir-backend" {
+			return false
+		}
 	}
 	switch emit {
 	case EmitLLVMIR, EmitObject, EmitBinary:

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -610,28 +610,14 @@ func TestUseNativeOwnedLLVMIRDefaultsEnabled(t *testing.T) {
 	}
 }
 
-func TestUseMIRBackendLegacyFeatureDisables(t *testing.T) {
-	t.Parallel()
-
-	if useMIRBackend([]string{"legacy-llvmgen"}, EmitLLVMIR) {
-		t.Fatal("useMIRBackend(legacy-llvmgen, EmitLLVMIR) = true, want false")
-	}
-	if useMIRBackend([]string{"mir-backend", "legacy-llvmgen"}, EmitBinary) {
-		t.Fatal("legacy-llvmgen should win when both features are present")
-	}
-}
-
 func TestUseNativeOwnedLLVMIRFeatureOverrides(t *testing.T) {
 	t.Parallel()
 
-	if useNativeOwnedLLVMIR([]string{"legacy-llvmgen"}, EmitBinary) {
-		t.Fatal("useNativeOwnedLLVMIR(legacy-llvmgen, EmitBinary) = true, want false")
-	}
 	if useNativeOwnedLLVMIR([]string{"mir-backend"}, EmitLLVMIR) {
 		t.Fatal("useNativeOwnedLLVMIR(mir-backend, EmitLLVMIR) = true, want false")
 	}
-	if useNativeOwnedLLVMIR([]string{"mir-backend", "legacy-llvmgen"}, EmitObject) {
-		t.Fatal("feature override should disable native fast path when either feature is present")
+	if useNativeOwnedLLVMIR([]string{"mir-backend"}, EmitObject) {
+		t.Fatal("useNativeOwnedLLVMIR(mir-backend, EmitObject) = true, want false")
 	}
 }
 


### PR DESCRIPTION
## What changed
- removed the `legacy-llvmgen` feature gate from the LLVM backend dispatch helpers and tests
- deleted dead `PrepareEntry` fallback branches in `osty build` and `osty run` so live callers always use package lowering
- updated MIR design docs to match the current dispatcher behavior

## Why
The live callers already run native-first LLVM emission and no longer need the old opt-back gate. Keeping the gate and its dead branches around added code without serving any remaining runtime path.

## Impact
- simplifies backend feature handling
- reduces dead code in build/run dispatch
- keeps uncovered-shape fallback behavior intact while removing the obsolete feature knob

## Validation
- `go test -count=1 -vet=off ./internal/backend -run 'Test(PreparePackage(SingleFileKeepsEntryFileAndDecl|MergesMultiFileDecls|PicksFirstNonNilFileWhenEntryUnset)|EmitPrebuiltLLVMIRBuildsArtifactsFromProvidedIR|TryEmitNativeOwnedLLVMIRText(CoversPrimitiveSlice|ReturnsNotCovered)|EmitLLVMIRText(MatchesBackendArtifactOutput|PrefersNativeOwnedFastPathWhenCovered|FallsBackWhenNativeOwnedUncovered|MirBackendOverridesNativeFastPath)|LLVMBackendEmitBinary(PrefersNativeOwnedFastPathWhenCovered|FallsBackWhenNativeOwnedUncovered)|Use(MIRBackendDefaultsEnabled|NativeOwnedLLVMIRDefaultsEnabled|NativeOwnedLLVMIRFeatureOverrides))'`
- `go test -count=1 -vet=off ./cmd/osty -run 'Test(TryExternalPackageLLVMArtifacts(UsesCoveredExternalIR|SkipsWhenFeatureOverridesNativePath)|BuildCLIUsesManagedNativeLLVMGenForObject|RunCLIUsesManagedNativeLLVMGenForBinary|EmitGenArtifactUsesManagedNativeLLVMGenWhenCovered|EmitGenArtifactUsesNativeOwnedFastPathWhenCovered|EmitGenArtifactFallsBackForUncoveredNativeOwnedModule|PrepareGenBackendEntryUsesPackageLoweringForSiblingFiles|PrepareGenBackendEntryUsesPackageLoweringForSingleFile|GenCLIMultiFilePackageEmitsLLVMIR|CompileNativeTestBundleUsesManagedNativeLLVMGenWhenCovered|RunTestMainPassesNativeLLVMTest)'`