### PR TITLE
feat(llvmgen): Char ASCII predicates + case conversion dispatchers

### DIFF
--- a/internal/llvmgen/char_predicate_test.go
+++ b/internal/llvmgen/char_predicate_test.go
@@ -1,0 +1,148 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// Char predicates and case conversion (`c.isDigit()`, `c.toUpper()`,
+// etc.) declared as `#[intrinsic_methods]` placeholders in
+// primitives/char.osty had no LLVM dispatcher, so any injected stdlib
+// body that used them (e.g. `strings.toUpper(s)` walks each char with
+// `c.toUpper()`) tripped LLVM015 "call target *ast.FieldExpr".
+//
+// emitCharPredicateCall lowers the ASCII fast path entirely in IR:
+// `c - low <u count` for is-checks (`(c-'A') <u 26` is `c >= 'A' &&
+// c < 'A'+26`), `select` for the case shifts. No new C runtime
+// symbols — Unicode case folding is a separate follow-up.
+
+func TestCharIsDigitLowersToAsciiRangeCheck(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn check(c: Char) -> Bool {
+    c.isDigit()
+}
+
+fn main() {
+    let _ = check('5')
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_isdigit.osty"})
+	if err != nil {
+		t.Fatalf("Char.isDigit errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"sub i32 ",  // c - '0'
+		"icmp ult i32 ",  // <u 10
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Char.isDigit missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestCharIsAlphaLowersAsOrOfTwoRanges(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn check(c: Char) -> Bool {
+    c.isAlpha()
+}
+
+fn main() {
+    let _ = check('A')
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_isalpha.osty"})
+	if err != nil {
+		t.Fatalf("Char.isAlpha errored: %v", err)
+	}
+	got := string(ir)
+	if !strings.Contains(got, "or i1 ") {
+		t.Fatalf("Char.isAlpha did not emit `or i1` for upper||lower:\n%s", got)
+	}
+	// Two unsigned-range checks (one for 'A'..'Z', one for 'a'..'z').
+	if strings.Count(got, "icmp ult i32 ") < 2 {
+		t.Fatalf("Char.isAlpha did not emit two unsigned range checks:\n%s", got)
+	}
+}
+
+func TestCharIsWhitespaceLowersAsFourEqChecks(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn check(c: Char) -> Bool {
+    c.isWhitespace()
+}
+
+fn main() {
+    let _ = check(' ')
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_iswhitespace.osty"})
+	if err != nil {
+		t.Fatalf("Char.isWhitespace errored: %v", err)
+	}
+	got := string(ir)
+	if strings.Count(got, "icmp eq i32 ") < 4 {
+		t.Fatalf("Char.isWhitespace did not emit four eq checks (SP/TAB/LF/CR):\n%s", got)
+	}
+}
+
+func TestCharToLowerUsesSelectShift(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn lower(c: Char) -> Char {
+    c.toLower()
+}
+
+fn main() {
+    let _ = lower('A')
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_tolower.osty"})
+	if err != nil {
+		t.Fatalf("Char.toLower errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"icmp ult i32 ", // upper-range check
+		"add i32 ",      // c + 32
+		"select i1 ",    // pick shifted vs original
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Char.toLower missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+func TestCharToUpperUsesSelectShiftBackwards(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn upper(c: Char) -> Char {
+    c.toUpper()
+}
+
+fn main() {
+    let _ = upper('a')
+}
+`)
+	ir, err := generateFromAST(file, Options{PackageName: "main", SourcePath: "/tmp/char_toupper.osty"})
+	if err != nil {
+		t.Fatalf("Char.toUpper errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		"icmp ult i32 ",
+		"sub i32 ", // c - 32 (the shift down for lower → upper)
+		"select i1 ",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Char.toUpper missing %q in IR:\n%s", want, got)
+		}
+	}
+}
+
+// End-to-end injection (the case that actually motivated this PR —
+// `strings.toUpper(s)`'s body walks chars and calls `c.toUpper()`)
+// is exercised at the backend layer where PrepareEntry runs the
+// stdlib injection pipeline; the llvmgen layer only sees the
+// already-lowered body. The e2e contract is locked in by
+// TestPrepareEntryInjectsStdlibWhenFlagOn under internal/backend.
+//
+// The unit tests above cover this PR's actual surface: every Char
+// predicate / case method now lowers to its expected LLVM IR shape.
+// Verified manually via `osty build --backend llvm --emit llvm-ir`
+// on a `use std.strings; strings.toUpper("hello world")` program —
+// the resulting main.ll contains both
+// `define ptr @osty_std_strings__toUpper(ptr %s)` and the inner
+// `select i1 %t16, i32 %t17, i32 %t13` from `c.toUpper()`.

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -2803,6 +2803,132 @@ func (g *generator) emitCharByteConversionCall(call *ast.CallExpr) (value, bool,
 	return value{}, false, nil
 }
 
+// emitCharPredicateCall lowers the Char ASCII predicates and case
+// conversion methods declared in primitives/char.osty as intrinsic
+// placeholder bodies (`{ false }` / `{ '\0' }`). The injected stdlib
+// bodies that bring these into play (e.g. `strings.toUpper(s)` walks
+// each char with `c.toUpper()`) trip LLVM015 without a backend
+// dispatcher because the placeholder body has no callable shape.
+//
+// Scope: ASCII fast path. Non-ASCII codepoints pass through
+// unchanged from the case-conversion methods and report `false` from
+// every is-predicate. Unicode case folding tables are a follow-up
+// (RFC §2.1 leaves the wider behavior open). The methods covered
+// here are the ones the stdlib bodies actually call:
+//
+//	c.isDigit() / c.isAlpha() / c.isAlphanumeric()
+//	c.isWhitespace() / c.isUpper() / c.isLower()
+//	c.toUpper() / c.toLower()
+//
+// All operate on the Char's i32 codepoint scalar; `c.toInt()` and
+// `c.toString()` go through emitCharByteConversionCall and
+// emitPrimitiveToStringCall respectively.
+func (g *generator) emitCharPredicateCall(call *ast.CallExpr) (value, bool, error) {
+	field, ok := call.Fn.(*ast.FieldExpr)
+	if !ok || field.IsOptional {
+		return value{}, false, nil
+	}
+	if len(call.Args) != 0 {
+		return value{}, false, nil
+	}
+	switch field.Name {
+	case "isDigit", "isAlpha", "isAlphanumeric", "isWhitespace", "isUpper", "isLower", "toUpper", "toLower":
+	default:
+		return value{}, false, nil
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok || baseInfo.typ != "i32" {
+		return value{}, false, nil
+	}
+	base, err := g.emitExpr(field.X)
+	if err != nil {
+		return value{}, true, err
+	}
+	if base.typ != "i32" {
+		return value{}, true, unsupportedf("type-system", "Char.%s receiver type %s, want i32", field.Name, base.typ)
+	}
+	emitter := g.toOstyEmitter()
+	defer g.takeOstyEmitter(emitter)
+	switch field.Name {
+	case "isDigit":
+		// `c - '0' < 10` as unsigned comparison handles ASCII digits in
+		// one branch-free check.
+		out := llvmCharAsciiRangeCheck(emitter, base.ref, '0', 10)
+		return value{typ: "i1", ref: out}, true, nil
+	case "isUpper":
+		out := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
+		return value{typ: "i1", ref: out}, true, nil
+	case "isLower":
+		out := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
+		return value{typ: "i1", ref: out}, true, nil
+	case "isAlpha":
+		// isUpper || isLower
+		up := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
+		lo := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
+		out := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", out, up, lo))
+		return value{typ: "i1", ref: out}, true, nil
+	case "isAlphanumeric":
+		// isDigit || isUpper || isLower
+		dg := llvmCharAsciiRangeCheck(emitter, base.ref, '0', 10)
+		up := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
+		lo := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
+		al := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", al, up, lo))
+		out := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", out, dg, al))
+		return value{typ: "i1", ref: out}, true, nil
+	case "isWhitespace":
+		// Spec-relevant ASCII whitespace: SPACE / TAB / LF / CR.
+		// (FF / VT are intentionally excluded — they don't appear in
+		// any current stdlib body and matching libc isspace() too
+		// closely is a Unicode follow-up concern.)
+		eqSp := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 32", eqSp, base.ref))
+		eqTab := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 9", eqTab, base.ref))
+		eqLf := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 10", eqLf, base.ref))
+		eqCr := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp eq i32 %s, 13", eqCr, base.ref))
+		o1 := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", o1, eqSp, eqTab))
+		o2 := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", o2, eqLf, eqCr))
+		out := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = or i1 %s, %s", out, o1, o2))
+		return value{typ: "i1", ref: out}, true, nil
+	case "toLower":
+		// if c is ASCII upper, c + 32; else c. select form keeps it
+		// branch-free (downstream phi avoidance).
+		isUp := llvmCharAsciiRangeCheck(emitter, base.ref, 'A', 26)
+		shifted := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i32 %s, 32", shifted, base.ref))
+		out := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i32 %s, i32 %s", out, isUp, shifted, base.ref))
+		return value{typ: "i32", ref: out}, true, nil
+	case "toUpper":
+		isLo := llvmCharAsciiRangeCheck(emitter, base.ref, 'a', 26)
+		shifted := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i32 %s, 32", shifted, base.ref))
+		out := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, i32 %s, i32 %s", out, isLo, shifted, base.ref))
+		return value{typ: "i32", ref: out}, true, nil
+	}
+	return value{}, false, nil
+}
+
+// llvmCharAsciiRangeCheck emits `(c - low) <u count` — branch-free
+// half-open range check `low <= c < low+count` via a single unsigned
+// compare against the count. Returns the i1 temp name.
+func llvmCharAsciiRangeCheck(emitter *LlvmEmitter, charRef string, low int, count int) string {
+	shifted := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = sub i32 %s, %d", shifted, charRef, low))
+	cmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp ult i32 %s, %d", cmp, shifted, count))
+	return cmp
+}
+
 // stdlib primitives/{int,float,bool}.osty declare toString as
 // `#[intrinsic_methods]` placeholders with empty bodies, which would
 // otherwise lower to dead IR; this dispatcher routes to the same
@@ -5303,6 +5429,9 @@ func (g *generator) emitCall(call *ast.CallExpr) (value, error) {
 		return v, err
 	}
 	if v, found, err := g.emitCharByteConversionCall(call); found || err != nil {
+		return v, err
+	}
+	if v, found, err := g.emitCharPredicateCall(call); found || err != nil {
 		return v, err
 	}
 	if v, found, err := g.emitStringMethodCall(call); found || err != nil {

--- a/internal/llvmgen/type.go
+++ b/internal/llvmgen/type.go
@@ -594,6 +594,9 @@ func (g *generator) staticExprInfo(expr ast.Expr) (value, bool) {
 		if out, ok := g.staticCharByteConversionResult(e); ok {
 			return out, true
 		}
+		if out, ok := g.staticCharPredicateResult(e); ok {
+			return out, true
+		}
 		if out, found, ok := g.staticCollectionMethodResult(e); found {
 			return out, ok
 		}
@@ -1069,6 +1072,34 @@ func (g *generator) staticCharByteConversionResult(call *ast.CallExpr) (value, b
 		// receiver to i8 and the eq/<= comparisons that follow type
 		// through emitBinary without an extra unwrap.
 		return value{typ: "i8"}, true
+	}
+	return value{}, false
+}
+
+// staticCharPredicateResult mirrors staticCharByteConversionResult but
+// for the Char predicate / case-conversion methods. Without this hook
+// the `c.isDigit()` / `c.toUpper()` calls inside an injected stdlib
+// body don't get a static return type and downstream type-driven
+// dispatch (e.g. interpolation deciding whether to call
+// emitRuntimeBoolToString vs emitRuntimeCharToString) can't pick the
+// right path.
+func (g *generator) staticCharPredicateResult(call *ast.CallExpr) (value, bool) {
+	if call == nil || len(call.Args) != 0 {
+		return value{}, false
+	}
+	field, ok := fieldExprOfCallFn(call)
+	if !ok || field.IsOptional || field.X == nil {
+		return value{}, false
+	}
+	baseInfo, ok := g.staticExprInfo(field.X)
+	if !ok || baseInfo.typ != "i32" {
+		return value{}, false
+	}
+	switch field.Name {
+	case "isDigit", "isAlpha", "isAlphanumeric", "isWhitespace", "isUpper", "isLower":
+		return value{typ: "i1"}, true
+	case "toUpper", "toLower":
+		return value{typ: "i32"}, true
 	}
 	return value{}, false
 }


### PR DESCRIPTION
## Summary

`primitives/char.osty` declares `isDigit` / `isAlpha` / `isAlphanumeric` / `isWhitespace` / `isUpper` / `isLower` / `toUpper` / `toLower` as `#[intrinsic_methods]` placeholders with empty bodies (`{ false }`, `{ '\0' }`). Without backend dispatchers, the placeholder bodies lower to dead IR — so any injected stdlib body that walks chars and calls one of these (`strings.toUpper(s)` does `for c in s.chars() { out = "{out}{c.toUpper()}" }`) tripped `LLVM015 call target *ast.FieldExpr (c.toUpper)` under `OSTY_STDLIB_BODY_LOWER=1`.

This PR closes that gap with branch-free ASCII fast-path lowerings.

## What changed

`emitCharPredicateCall` lowers each method to a tight LLVM IR shape:

| Method | LLVM shape |
|---|---|
| `isDigit` / `isUpper` / `isLower` | `(c - low) <u count` via `sub i32` + `icmp ult i32` |
| `isAlpha` | `or i1` of the two letter ranges |
| `isAlphanumeric` | `or` of digit + letter checks |
| `isWhitespace` | four `icmp eq i32` for SP / TAB / LF / CR ored together |
| `toLower` / `toUpper` | `select i1 isInRange, c±32, c` — no branch, no alloca |

`staticCharPredicateResult` mirrors `staticCharByteConversionResult` so the type system advertises the right return type (i1 for predicates, i32 for case shifts). Without it, downstream type-driven dispatch (interpolation picking `emitRuntimeBoolToString` vs `emitRuntimeCharToString`, compound-binary type checks, etc.) mis-routes when one of these feeds an interpolation slot.

## Why

Non-ASCII codepoints pass through unchanged from the case-conversion methods and report `false` from every is-predicate. Unicode case folding is intentionally out of scope: it needs new C runtime helpers and is best designed alongside the rest of the Unicode surface (`String.charCount` correctness, `String.normalize`, etc.). The ASCII path is what every current stdlib body actually exercises.

## E2E verification

Built `use std.strings; fn main() { let upper = strings.toUpper(\"hello world\"); println(upper) }` with `OSTY_STDLIB_BODY_LOWER=1`:

```
$ OSTY_STDLIB_BODY_LOWER=1 osty build --backend llvm --emit llvm-ir
Generated main.ll
$ grep -E 'osty_std_strings__toUpper|select i1' main.ll
define ptr @osty_std_strings__toUpper(ptr %s) {
  %t18 = select i1 %t16, i32 %t17, i32 %t13   ; ← c.toUpper() inside the body
  %t0 = call ptr @osty_std_strings__toUpper(ptr @.str1)
```

Both the injected body and the dispatcher-emitted `select` show up — the chain is end-to-end functional.

## Test plan

Five new unit tests in `char_predicate_test.go`:

- `TestCharIsDigitLowersToAsciiRangeCheck` — `sub i32` + `icmp ult i32` shape
- `TestCharIsAlphaLowersAsOrOfTwoRanges` — two range checks ored
- `TestCharIsWhitespaceLowersAsFourEqChecks` — four eq checks
- `TestCharToLowerUsesSelectShift` — range check + `add i32` + `select i1`
- `TestCharToUpperUsesSelectShiftBackwards` — range check + `sub i32` + `select i1`

Plus regression coverage:
- [x] `go test ./internal/llvmgen/ -run 'TestChar'` all pass
- [x] llvmgen targeted sweeps `^Test[A-D]` regression-free (skipping the pre-existing `TestGoGenerate` / `TestProbeNative` / `TestToolchain` slow/broken tests)
- [x] `^Test[E-O]` only failure is `TestGenerateMapGetBoolValueUses1ByteBox` which reproduces identically on `main`
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline) regression-free

The end-to-end injection contract is locked in by `TestPrepareEntryInjectsStdlibWhenFlagOn` under `internal/backend` (already in main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)