### PR TITLE
[codex] close GC Phase D allocator tail

### DIFF
--- a/RUNTIME_GC_DELTA.md
+++ b/RUNTIME_GC_DELTA.md
@@ -38,11 +38,11 @@ a spec. New implementation effort should land in the LLVM lowering/runtime path;
 | #   | 기능                                         | 시뮬 | 실  | 델타                                                 | P  | 참조                                                 |
 | --- | -------------------------------------------- | ---- | --- | ---------------------------------------------------- | -- | ---------------------------------------------------- |
 | 1.1 | ~~오브젝트 헤더~~                            | ✅   | ✅  | age + generation 추가 (Phase B1). pin/forwarding은 Phase D에서 | ✅ B1 | `osty_runtime.c:osty_gc_header`              |
-| 1.2 | 지역별 힙 (Eden/Survivor/Old/Humongous/Pinned) | ✅ | 🟡 | YOUNG/OLD 논리 구분 + young alloc / old evacuation bump region 분리 landed. old evac region은 empty-block recycle까지 포함, Survivor/TLAB/pinned 전용 region은 아직 없음 | P3 | `osty_runtime.c:osty_gc_link` (generation 분기)      |
-| 1.3 | Bump allocator                               | ✅   | 🟡  | young small-object bump block + major compaction old bump clone path landed. old evac region은 empty-block recycle 가능, young small-object는 minimal per-thread TLAB current block까지 포함 | P3 | `lib.osty:127-147` / `osty_runtime.c:osty_gc_bump_take_from_region`                                   |
+| 1.2 | 지역별 힙 (Eden/Survivor/Old/Humongous/Pinned) | ✅ | 🟡 | YOUNG alloc + minor survivor from/to copy region + major old evacuation bump region + explicit `alloc_pinned_v1` pinned region landed. survivor/old/pinned region은 empty-block recycle 포함, lowering은 아직 pinned alloc path를 자동 emit하지 않음 | P3 | `osty_runtime.c:osty_gc_link` (generation 분기)      |
+| 1.3 | Bump allocator                               | ✅   | 🟡  | young/survivor/old/pinned bump block landed. 모든 bump region은 forwarding-aware empty-block recycle, per-thread TLS current block refill까지 포함 | P3 | `lib.osty:127-147` / `osty_runtime.c:osty_gc_bump_take_from_region`                                   |
 | 1.4 | Free list (tenured / humongous)              | ✅   | 🟡  | sweep-dead header reuse + size-class bin landed. humongous는 direct alloc/free 경로로 분리 | P3 | `lib.osty:122-147` / `osty_runtime.c:osty_gc_free_list_take`                                   |
 | 1.5 | Size class / large object threshold          | ✅   | 🟡 | 16-byte size-class bin + humongous threshold landed. bump/region 전략은 아직 동일 | P3 | `lib.osty:709-764` / `osty_runtime.c:osty_gc_size_class_index_for_total_size`                                   |
-| 1.6 | TLAB (스레드별 할당 버퍼)                    | ✅   | 🟡  | young small-object bump current block만 per-thread TLS로 분리. Survivor/old/pinned region 전용 TLAB는 아직 없음 | P3 | `lib.osty:111-120` / `osty_runtime.c:osty_gc_tlab_current`                                   |
+| 1.6 | TLAB (스레드별 할당 버퍼)                    | ✅   | 🟡  | young/survivor/old/pinned bump current block이 per-thread TLS로 분리됐다. 다만 mutator-local retire policy / budgeted refill 같은 full TLAB policy는 아직 최소형 | P3 | `lib.osty:111-120` / `osty_runtime.c:osty_gc_tlab_current`                                   |
 | 1.7 | Stable object identity (movable와 분리)      | ✅   | ✅  | monotonic `stable_id` + reverse index + forwarding-aware debug/load path landed | ✅ D1 | `lib.osty:94-108` / `osty_runtime.c:osty_gc_header` |
 
 ## 2. 루트
@@ -89,7 +89,7 @@ a spec. New implementation effort should land in the LLVM lowering/runtime path;
 | #   | 기능                                  | 시뮬 | 실  | 델타 | P  |
 | --- | ------------------------------------- | ---- | --- | ---- | -- |
 | 5.1 | ~~Nursery / Eden~~                    | ✅   | 🟡  | 논리 구분만 (물리적 Eden/Survivor 분리는 Phase D), YOUNG 할당 경로는 완성 | ✅ B2 |
-| 5.2 | Survivor space + budget               | ✅   | ❌  | age 기반 in-place 승격으로 대체 — from/to 분리는 compaction 시 | P3 |
+| 5.2 | Survivor space + budget               | ✅   | 🟡  | minor GC가 survivor from/to bump region으로 copy하고 promote-age에서 old로 승격한다. survivor budget / spill policy는 아직 coarse | P3 |
 | 5.3 | ~~Tenured (old)~~                     | ✅   | ✅  | OLD bucket + 카운터 + in-place 승격 | ✅ B2/B3 |
 | 5.4 | ~~승격 정책 (age 비트, 임계)~~         | ✅   | ✅  | `OSTY_GC_PROMOTE_AGE_DEFAULT=3`, env override, age는 u8 | ✅ B3 |
 | 5.5 | ~~Minor GC 트리거 (nurseryLimit)~~    | ✅   | ✅  | `OSTY_GC_NURSERY_BYTES` + dispatcher 2-tier 선택 | ✅ B3/B5 |
@@ -102,8 +102,8 @@ post_write log가 소유하고, minor GC가 일관되게 소비한다.
 | #   | 기능                                   | 시뮬 | 실  | 델타                               | P  | 참조                          |
 | --- | -------------------------------------- | ---- | --- | ---------------------------------- | -- | ----------------------------- |
 | 6.1 | Mark-sweep 전체 heap                   | ✅   | ✅  | —                                  | —  | `osty_runtime.c:389-400`      |
-| 6.2 | Compaction / forwarding table          | ✅   | ✅  | major GC 후 STW forwarding/remap + repeated compaction alias retention landed | ✅ D4 | `lib.osty:215-222` / `osty_runtime.c:osty_gc_compact_major_with_stack_roots`            |
-| 6.3 | Evacuation (region 이전, pinned skip)  | ✅   | 🟡  | list/set/string/closure-env + typed channel + map payload (composite-inline value 포함) evacuate | P3 | `lib.osty:224-230` / `osty_runtime.c:osty_gc_header_is_movable`            |
+| 6.2 | Compaction / forwarding table          | ✅   | ✅  | major GC STW forwarding/remap + minor survivor forwarding/remap + repeated compaction alias retention landed | ✅ D4 | `lib.osty:215-222` / `osty_runtime.c:osty_gc_compact_major_with_stack_roots`            |
+| 6.3 | Evacuation (region 이전, pinned skip)  | ✅   | 🟡  | list/set/string/closure-env + typed channel + map payload (composite-inline value 포함) evacuate. minor는 movable young survivor를 survivor/old bump로 copy하고, explicit pinned alloc / pinned headers는 skip | P3 | `lib.osty:224-230` / `osty_runtime.c:osty_gc_header_is_movable`            |
 | 6.4 | Destructor callback                    | ✅   | ✅  | —                                  | —  | `osty_runtime.c:393-395`      |
 | 6.5 | 프래그멘테이션 계측                    | ✅   | ❌  | 진단용                             | P3 | `lib.osty:71-92`              |
 
@@ -120,7 +120,7 @@ post_write log가 소유하고, minor GC가 일관되게 소비한다.
 | --- | -------------------------------------- | ---- | --- | -------------------------------------- | --- |
 | 8.1 | Pin bit (evacuation 제외)              | ✅   | ✅  | header `pin_count` + pinned counters landed                | ✅ D3  |
 | 8.2 | pin / unpin API                        | ✅   | ✅  | `osty.gc.pin_v1` / `osty.gc.unpin_v1` export                                      | ✅ D3  |
-| 8.3 | LLVM pinned handle ref (FFI)           | ✅   | 🟡 | `root_bind`로 의미는 동치, API 격차   | P2  |
+| 8.3 | LLVM pinned handle ref (FFI)           | ✅   | 🟡 | 런타임은 `osty.gc.alloc_pinned_v1`까지 export하지만 lowering은 아직 `root_bind` 중심이라 born-pinned 경로를 자동 선택하지 않음 | P2  |
 | 8.4 | 유저 파이널라이저                      | ❌   | ❌  | 설계상 없음                            | N/A |
 | 8.5 | 런타임 내부 destroy 콜백               | ✅   | ✅  | —                                      | —   |
 
@@ -364,9 +364,11 @@ API → §1.3-1.6 region heap (bump/freelist/TLAB/size class).
   payload alias를 stable-id 기준으로 최신 header에 재결합한다.
 - ✅ **D3 pin API** — `pin_count`와 `osty.gc.pin_v1` /
   `osty.gc.unpin_v1`를 추가해서 evacuation 제외 대상을 명시할 수 있다.
-- 🟡 **남은 Phase D tail** — Survivor/from-to space /
-  survivor-old-pinned 전용 TLAB depth / young compaction-safe recycle /
-  pinned region-local recycle 분리는 아직 후속이다.
+- ✅ **Phase D allocator tail closed** — survivor/old/pinned TLAB current
+  block, explicit pinned region alloc, pinned/young/old/survivor
+  region-local recycle까지 런타임에 landed. 남는 건 Phase D tail이 아니라
+  후속 최적화(더 정교한 TLAB policy, 멀티스레드 mutator, lowering-side
+  born-pinned emission)다.
 
 ## 유지 규칙
 

--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -3415,7 +3415,7 @@ int main(void) {
 	}
 }
 
-func TestBundledRuntimeFreeListReusesSweptMajorSlotsPhaseD(t *testing.T) {
+func TestBundledRuntimeYoungBumpRecyclesSweptMajorSlotsPhaseD(t *testing.T) {
 	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
@@ -3439,25 +3439,26 @@ void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site)
 void osty_gc_debug_collect(void);
 int64_t osty_gc_debug_collection_count(void);
 int64_t osty_gc_debug_live_count(void);
-int64_t osty_gc_debug_free_list_count(void);
-int64_t osty_gc_debug_free_list_reused_count_total(void);
+int64_t osty_gc_debug_bump_block_count(void);
+int64_t osty_gc_debug_bump_recycled_block_count_total(void);
 
 int main(void) {
-    void *dead = osty_gc_alloc_v1(7, 24, "dead");
     void *reused = NULL;
+
+    (void)osty_gc_alloc_v1(7, 24, "dead");
 
     osty_gc_debug_collect();
     printf("%d %d %d\n",
         osty_gc_debug_collection_count() == 1,
         osty_gc_debug_live_count() == 0,
-        osty_gc_debug_free_list_count() == 1);
+        osty_gc_debug_bump_block_count() == 0);
     reused = osty_gc_alloc_v1(8, 24, "reused");
     printf("%d %d %d\n",
-        reused == dead,
+        reused != NULL,
         osty_gc_debug_live_count() == 1,
-        osty_gc_debug_free_list_count() == 0);
+        osty_gc_debug_bump_block_count() == 1);
     printf("%d %d %d\n",
-        osty_gc_debug_free_list_reused_count_total() == 1,
+        osty_gc_debug_bump_recycled_block_count_total() == 1,
         osty_gc_debug_collection_count() == 1,
         reused != NULL);
     return 0;
@@ -3476,11 +3477,11 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n"; got != want {
-		t.Fatalf("phase-D freelist-major harness stdout = %q, want %q", got, want)
+		t.Fatalf("phase-D young-bump-major harness stdout = %q, want %q", got, want)
 	}
 }
 
-func TestBundledRuntimeFreeListReusesSweptMinorSlotsPhaseD(t *testing.T) {
+func TestBundledRuntimeYoungBumpRecyclesSweptMinorSlotsPhaseD(t *testing.T) {
 	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
@@ -3504,25 +3505,26 @@ void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site)
 void osty_gc_debug_collect_minor(void);
 int64_t osty_gc_debug_minor_count(void);
 int64_t osty_gc_debug_live_count(void);
-int64_t osty_gc_debug_free_list_count(void);
-int64_t osty_gc_debug_free_list_reused_count_total(void);
+int64_t osty_gc_debug_bump_block_count(void);
+int64_t osty_gc_debug_bump_recycled_block_count_total(void);
 
 int main(void) {
-    void *dead = osty_gc_alloc_v1(7, 24, "dead");
     void *reused = NULL;
+
+    (void)osty_gc_alloc_v1(7, 24, "dead");
 
     osty_gc_debug_collect_minor();
     printf("%d %d %d\n",
         osty_gc_debug_minor_count() == 1,
         osty_gc_debug_live_count() == 0,
-        osty_gc_debug_free_list_count() == 1);
+        osty_gc_debug_bump_block_count() == 0);
     reused = osty_gc_alloc_v1(8, 24, "reused");
     printf("%d %d %d\n",
-        reused == dead,
+        reused != NULL,
         osty_gc_debug_live_count() == 1,
-        osty_gc_debug_free_list_count() == 0);
+        osty_gc_debug_bump_block_count() == 1);
     printf("%d %d %d\n",
-        osty_gc_debug_free_list_reused_count_total() == 1,
+        osty_gc_debug_bump_recycled_block_count_total() == 1,
         osty_gc_debug_minor_count() == 1,
         reused != NULL);
     return 0;
@@ -3541,11 +3543,11 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n"; got != want {
-		t.Fatalf("phase-D freelist-minor harness stdout = %q, want %q", got, want)
+		t.Fatalf("phase-D young-bump-minor harness stdout = %q, want %q", got, want)
 	}
 }
 
-func TestBundledRuntimeSizeClassesSeparateFreeListReusePhaseD(t *testing.T) {
+func TestBundledRuntimeYoungBumpKeepsFreeListColdAcrossSizeClassesPhaseD(t *testing.T) {
 	parallelClangBackendTest(t)
 
 	dir := t.TempDir()
@@ -3570,29 +3572,30 @@ void osty_gc_debug_collect(void);
 int64_t osty_gc_debug_live_count(void);
 int64_t osty_gc_debug_free_list_count(void);
 int64_t osty_gc_debug_free_list_reused_count_total(void);
+int64_t osty_gc_debug_bump_block_count(void);
 
 int main(void) {
-    void *small = osty_gc_alloc_v1(7, 24, "small");
+    (void)osty_gc_alloc_v1(7, 24, "small");
     void *other = NULL;
     void *same = NULL;
 
     osty_gc_debug_collect();
     printf("%d %d %d\n",
         osty_gc_debug_live_count() == 0,
-        osty_gc_debug_free_list_count() == 1,
+        osty_gc_debug_free_list_count() == 0,
         osty_gc_debug_free_list_reused_count_total() == 0);
 
     other = osty_gc_alloc_v1(8, 120, "other");
     printf("%d %d %d\n",
-        other != small,
+        other != NULL,
         osty_gc_debug_live_count() == 1,
-        osty_gc_debug_free_list_count() == 1);
+        osty_gc_debug_bump_block_count() == 1);
 
     same = osty_gc_alloc_v1(9, 24, "same");
     printf("%d %d %d\n",
-        same == small,
+        same != NULL,
         osty_gc_debug_live_count() == 2,
-        osty_gc_debug_free_list_reused_count_total() == 1);
+        osty_gc_debug_free_list_reused_count_total() == 0);
     return 0;
 }
 `), 0o644); err != nil {
@@ -3609,7 +3612,7 @@ int main(void) {
 		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
 	}
 	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n"; got != want {
-		t.Fatalf("phase-D size-class harness stdout = %q, want %q", got, want)
+		t.Fatalf("phase-D young-bump-size-class harness stdout = %q, want %q", got, want)
 	}
 }
 
@@ -3901,6 +3904,185 @@ int main(void) {
 	}
 }
 
+func TestBundledRuntimeYoungBumpRecycleWaitsForForwardingCleanupPhaseD(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_phase_d_young_recycle_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_phase_d_young_recycle_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t root_slot_count) __asm__(OSTY_GC_SYMBOL("osty.gc.safepoint_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_bump_block_count(void);
+int64_t osty_gc_debug_bump_recycled_block_count_total(void);
+int64_t osty_gc_debug_compaction_count_total(void);
+int64_t osty_gc_debug_forwarding_count(void);
+
+int main(void) {
+    void *obj = osty_gc_alloc_v1(7, 24, "obj");
+    void *saved = obj;
+    void *root = obj;
+    void *root_slots[1] = { &root };
+
+    osty_gc_safepoint_v1(1, root_slots, 1);
+    printf("%d %d %d\n",
+        root != saved,
+        osty_gc_debug_compaction_count_total() == 1,
+        osty_gc_load_v1(saved) == root);
+    printf("%d %d %d\n",
+        osty_gc_debug_bump_block_count() == 1,
+        osty_gc_debug_bump_recycled_block_count_total() == 0,
+        osty_gc_debug_forwarding_count() == 1);
+
+    root = NULL;
+    {
+        void *garbage = osty_gc_alloc_v1(8, 8, "garbage");
+        (void)garbage;
+    }
+    osty_gc_safepoint_v1(2, root_slots, 1);
+    printf("%d %d %d\n",
+        osty_gc_debug_live_count() == 0,
+        osty_gc_debug_bump_block_count() == 0,
+        osty_gc_debug_bump_recycled_block_count_total() == 1);
+    printf("%d %d %d\n",
+        osty_gc_debug_forwarding_count() == 0,
+        osty_gc_load_v1(saved) == saved,
+        1);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_THRESHOLD_BYTES=1")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n1 1 1\n"; got != want {
+		t.Fatalf("phase-D young-recycle harness stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBundledRuntimeMinorCopiesYoungSurvivorsIntoSurvivorRegionPhaseD(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_phase_d_survivor_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_phase_d_survivor_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void osty_gc_global_root_register_v1(void *slot) __asm__(OSTY_GC_SYMBOL("osty.gc.global_root_register_v1"));
+void osty_gc_global_root_unregister_v1(void *slot) __asm__(OSTY_GC_SYMBOL("osty.gc.global_root_unregister_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+
+void osty_gc_debug_collect_minor(void);
+void osty_gc_debug_collect_major(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_generation_of(void *payload);
+int64_t osty_gc_debug_age_of(void *payload);
+int64_t osty_gc_debug_compaction_count_total(void);
+int64_t osty_gc_debug_survivor_bump_block_count(void);
+int64_t osty_gc_debug_survivor_bump_alloc_count_total(void);
+int64_t osty_gc_debug_survivor_tlab_refill_count_total(void);
+int64_t osty_gc_debug_survivor_bump_recycled_block_count_total(void);
+
+static void *g_slot = NULL;
+
+int main(void) {
+    void *saved0 = NULL;
+    void *saved1 = NULL;
+    void *saved2 = NULL;
+
+    g_slot = osty_gc_alloc_v1(7, 24, "obj");
+    saved0 = g_slot;
+    osty_gc_global_root_register_v1(&g_slot);
+
+    osty_gc_debug_collect_minor();
+    saved1 = g_slot;
+    printf("%d %d %d\n",
+        saved1 != saved0,
+        osty_gc_load_v1(saved0) == saved1,
+        osty_gc_debug_survivor_bump_block_count() == 1);
+    printf("%d %d %d\n",
+        osty_gc_debug_survivor_bump_alloc_count_total() == 1,
+        osty_gc_debug_compaction_count_total() == 1,
+        osty_gc_debug_survivor_tlab_refill_count_total() == 1 &&
+            osty_gc_debug_generation_of(g_slot) == 0 &&
+            osty_gc_debug_age_of(g_slot) == 1);
+
+    osty_gc_debug_collect_minor();
+    saved2 = g_slot;
+    printf("%d %d %d\n",
+        saved2 != saved1,
+        osty_gc_load_v1(saved0) == saved2,
+        osty_gc_load_v1(saved1) == saved2);
+    printf("%d %d %d\n",
+        osty_gc_debug_survivor_bump_block_count() == 2,
+        osty_gc_debug_survivor_bump_alloc_count_total() == 2,
+        osty_gc_debug_survivor_tlab_refill_count_total() == 2 &&
+            osty_gc_debug_generation_of(g_slot) == 0 &&
+            osty_gc_debug_age_of(g_slot) == 2);
+
+    osty_gc_global_root_unregister_v1(&g_slot);
+    osty_gc_debug_collect_major();
+    printf("%d %d %d\n",
+        osty_gc_debug_live_count() == 0,
+        osty_gc_debug_survivor_bump_block_count() == 0,
+        osty_gc_debug_survivor_bump_recycled_block_count_total() == 2);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runCmd.Env = append(os.Environ(), "OSTY_GC_PROMOTE_AGE=3")
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n1 1 1\n1 1 1\n"; got != want {
+		t.Fatalf("phase-D survivor harness stdout = %q, want %q", got, want)
+	}
+}
+
 func TestBundledRuntimeCompactionUsesOldBumpRegionPhaseD(t *testing.T) {
 	parallelClangBackendTest(t)
 
@@ -3933,6 +4115,7 @@ int64_t osty_gc_debug_old_bump_block_count(void);
 int64_t osty_gc_debug_old_bump_block_bytes_total(void);
 int64_t osty_gc_debug_old_bump_alloc_count_total(void);
 int64_t osty_gc_debug_old_bump_alloc_bytes_total(void);
+int64_t osty_gc_debug_old_tlab_refill_count_total(void);
 
 int main(void) {
     void *obj = osty_gc_alloc_v1(7, 24, "obj");
@@ -3954,7 +4137,7 @@ int main(void) {
     printf("%d %d %d\n",
         osty_gc_debug_old_bump_block_count() == 1,
         osty_gc_debug_old_bump_block_bytes_total() >= osty_gc_debug_bump_block_bytes(),
-        osty_gc_debug_old_bump_alloc_bytes_total() > 0 &&
+        osty_gc_debug_old_tlab_refill_count_total() == 1 &&
             osty_gc_debug_live_count() == 1);
     return 0;
 }
@@ -4049,6 +4232,179 @@ int main(void) {
 	}
 	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n"; got != want {
 		t.Fatalf("phase-D old-bump-recycle harness stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBundledRuntimePinnedAllocatorUsesPinnedRegionPhaseD(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_phase_d_pinned_region_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_phase_d_pinned_region_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_pinned_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_pinned_v1"));
+void osty_gc_unpin_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.unpin_v1"));
+
+void osty_gc_debug_collect_major(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_generation_of(void *payload);
+int64_t osty_gc_debug_pin_count_of(void *payload);
+int64_t osty_gc_debug_pinned_count(void);
+int64_t osty_gc_debug_compaction_count_total(void);
+int64_t osty_gc_debug_pinned_bump_block_count(void);
+int64_t osty_gc_debug_pinned_bump_alloc_count_total(void);
+int64_t osty_gc_debug_pinned_tlab_refill_count_total(void);
+int64_t osty_gc_debug_pinned_bump_recycled_block_count_total(void);
+
+int main(void) {
+    void *obj = osty_gc_alloc_pinned_v1(7, 24, "pinned");
+
+    printf("%d %d %d\n",
+        obj != NULL,
+        osty_gc_debug_pin_count_of(obj) == 1,
+        osty_gc_debug_pinned_count() == 1);
+    printf("%d %d %d\n",
+        osty_gc_debug_generation_of(obj) == 1,
+        osty_gc_debug_pinned_bump_block_count() == 1,
+        osty_gc_debug_pinned_bump_alloc_count_total() == 1);
+    printf("%d %d %d\n",
+        osty_gc_debug_pinned_tlab_refill_count_total() == 1,
+        osty_gc_debug_live_count() == 1,
+        osty_gc_debug_compaction_count_total() == 0);
+
+    osty_gc_debug_collect_major();
+    printf("%d %d %d\n",
+        osty_gc_debug_live_count() == 1,
+        osty_gc_debug_pinned_count() == 1,
+        osty_gc_debug_pinned_bump_block_count() == 1);
+
+    osty_gc_unpin_v1(obj);
+    osty_gc_debug_collect_major();
+    printf("%d %d %d\n",
+        osty_gc_debug_live_count() == 0,
+        osty_gc_debug_pinned_count() == 0,
+        osty_gc_debug_pinned_bump_block_count() == 0 &&
+            osty_gc_debug_pinned_bump_recycled_block_count_total() == 1);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n1 1 1\n1 1 1\n"; got != want {
+		t.Fatalf("phase-D pinned-region harness stdout = %q, want %q", got, want)
+	}
+}
+
+func TestBundledRuntimePinnedAllocatorThreadLocalTlabPhaseD(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_phase_d_pinned_tlab_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_gc_phase_d_pinned_tlab_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+#include <pthread.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_pinned_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_pinned_v1"));
+void osty_gc_unpin_v1(void *root) __asm__(OSTY_GC_SYMBOL("osty.gc.unpin_v1"));
+
+void osty_gc_debug_collect_major(void);
+int64_t osty_gc_debug_live_count(void);
+int64_t osty_gc_debug_bump_block_bytes(void);
+int64_t osty_gc_debug_pinned_bump_block_count(void);
+int64_t osty_gc_debug_pinned_bump_alloc_count_total(void);
+int64_t osty_gc_debug_pinned_tlab_refill_count_total(void);
+int64_t osty_gc_debug_pinned_bump_recycled_block_count_total(void);
+
+static void *worker_alloc(void *arg) {
+    (void)arg;
+    return osty_gc_alloc_pinned_v1(8, 24, "worker");
+}
+
+int main(void) {
+    pthread_t tid;
+    void *a = osty_gc_alloc_pinned_v1(7, 24, "main.a");
+    void *b = NULL;
+    void *c = NULL;
+    uintptr_t dac = 0;
+
+    if (pthread_create(&tid, NULL, worker_alloc, NULL) != 0) {
+        printf("0 0 0\n0 0 0\n0 0 0\n");
+        return 0;
+    }
+    if (pthread_join(tid, &b) != 0) {
+        printf("0 0 0\n0 0 0\n0 0 0\n");
+        return 0;
+    }
+    c = osty_gc_alloc_pinned_v1(9, 24, "main.c");
+    dac = (uintptr_t)c - (uintptr_t)a;
+
+    printf("%d %d %d\n",
+        osty_gc_debug_pinned_bump_block_count() == 2,
+        osty_gc_debug_pinned_tlab_refill_count_total() == 2,
+        osty_gc_debug_pinned_bump_alloc_count_total() == 3);
+    printf("%d %d %d\n",
+        dac > 0,
+        (int64_t)dac < osty_gc_debug_bump_block_bytes(),
+        osty_gc_debug_live_count() == 3 && a != NULL && b != NULL && c != NULL);
+
+    osty_gc_unpin_v1(a);
+    osty_gc_unpin_v1(b);
+    osty_gc_unpin_v1(c);
+    osty_gc_debug_collect_major();
+    printf("%d %d %d\n",
+        osty_gc_debug_live_count() == 0,
+        osty_gc_debug_pinned_bump_block_count() == 0,
+        osty_gc_debug_pinned_bump_recycled_block_count_total() == 2);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runCmd := exec.Command(binaryPath)
+	runOutput, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	if got, want := string(runOutput), "1 1 1\n1 1 1\n1 1 1\n"; got != want {
+		t.Fatalf("phase-D pinned-tlab harness stdout = %q, want %q", got, want)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -490,7 +490,9 @@ enum {
 enum {
     OSTY_GC_STORAGE_DIRECT = 0,
     OSTY_GC_STORAGE_BUMP_YOUNG = 1,
-    OSTY_GC_STORAGE_BUMP_OLD = 2,
+    OSTY_GC_STORAGE_BUMP_SURVIVOR = 2,
+    OSTY_GC_STORAGE_BUMP_OLD = 3,
+    OSTY_GC_STORAGE_BUMP_PINNED = 4,
 };
 
 /* Closure environment payload. The thunk ABI is preserved — the LLVM
@@ -556,6 +558,17 @@ static int64_t osty_gc_bump_block_bytes_total = 0;
 static int64_t osty_gc_bump_alloc_count_total = 0;
 static int64_t osty_gc_bump_alloc_bytes_total = 0;
 static int64_t osty_gc_tlab_refill_count_total = 0;
+static int64_t osty_gc_bump_recycled_block_count_total = 0;
+static int64_t osty_gc_bump_recycled_bytes_total = 0;
+static osty_gc_bump_block *osty_gc_survivor_bump_blocks = NULL;
+static osty_gc_bump_block *osty_gc_survivor_bump_current = NULL;
+static int64_t osty_gc_survivor_bump_block_count = 0;
+static int64_t osty_gc_survivor_bump_block_bytes_total = 0;
+static int64_t osty_gc_survivor_bump_alloc_count_total = 0;
+static int64_t osty_gc_survivor_bump_alloc_bytes_total = 0;
+static int64_t osty_gc_survivor_bump_recycled_block_count_total = 0;
+static int64_t osty_gc_survivor_bump_recycled_bytes_total = 0;
+static int64_t osty_gc_survivor_tlab_refill_count_total = 0;
 static osty_gc_bump_block *osty_gc_old_bump_blocks = NULL;
 static osty_gc_bump_block *osty_gc_old_bump_current = NULL;
 static int64_t osty_gc_old_bump_block_count = 0;
@@ -564,6 +577,16 @@ static int64_t osty_gc_old_bump_alloc_count_total = 0;
 static int64_t osty_gc_old_bump_alloc_bytes_total = 0;
 static int64_t osty_gc_old_bump_recycled_block_count_total = 0;
 static int64_t osty_gc_old_bump_recycled_bytes_total = 0;
+static int64_t osty_gc_old_tlab_refill_count_total = 0;
+static osty_gc_bump_block *osty_gc_pinned_bump_blocks = NULL;
+static osty_gc_bump_block *osty_gc_pinned_bump_current = NULL;
+static int64_t osty_gc_pinned_bump_block_count = 0;
+static int64_t osty_gc_pinned_bump_block_bytes_total = 0;
+static int64_t osty_gc_pinned_bump_alloc_count_total = 0;
+static int64_t osty_gc_pinned_bump_alloc_bytes_total = 0;
+static int64_t osty_gc_pinned_bump_recycled_block_count_total = 0;
+static int64_t osty_gc_pinned_bump_recycled_bytes_total = 0;
+static int64_t osty_gc_pinned_tlab_refill_count_total = 0;
 static int64_t osty_gc_humongous_alloc_count_total = 0;
 static int64_t osty_gc_humongous_alloc_bytes_total = 0;
 static int64_t osty_gc_humongous_swept_count_total = 0;
@@ -621,6 +644,9 @@ static bool osty_gc_minor_in_progress = false;
  * safepoint turns this into an immediate major. */
 static bool osty_gc_collection_requested_major = false;
 static OSTY_RT_TLS osty_gc_bump_block *osty_gc_tlab_current = NULL;
+static OSTY_RT_TLS osty_gc_bump_block *osty_gc_survivor_tlab_current = NULL;
+static OSTY_RT_TLS osty_gc_bump_block *osty_gc_old_tlab_current = NULL;
+static OSTY_RT_TLS osty_gc_bump_block *osty_gc_pinned_tlab_current = NULL;
 
 /* Phase C incremental collection state (RUNTIME_GC_DELTA §4.3).
  *
@@ -1009,6 +1035,7 @@ static void osty_gc_index_grow(int64_t new_capacity) {
 static void osty_gc_index_insert(void *payload, osty_gc_header *header) {
     size_t mask;
     size_t idx;
+    size_t first_tombstone = SIZE_MAX;
     /* Keep load factor ≤ 0.75 including tombstones so probes stay
      * short. Capacity is always a power of two — start at 128. */
     if (osty_gc_index_slots == NULL ||
@@ -1019,11 +1046,19 @@ static void osty_gc_index_insert(void *payload, osty_gc_header *header) {
     }
     mask = (size_t)(osty_gc_index_capacity - 1);
     idx = osty_gc_index_hash(payload) & mask;
-    while (osty_gc_index_slots[idx].payload != NULL &&
-           osty_gc_index_slots[idx].payload != OSTY_GC_INDEX_TOMBSTONE) {
+    while (osty_gc_index_slots[idx].payload != NULL) {
+        if (osty_gc_index_slots[idx].payload == OSTY_GC_INDEX_TOMBSTONE) {
+            if (first_tombstone == SIZE_MAX) {
+                first_tombstone = idx;
+            }
+        } else if (osty_gc_index_slots[idx].payload == payload) {
+            osty_gc_index_slots[idx].header = header;
+            return;
+        }
         idx = (idx + 1) & mask;
     }
-    if (osty_gc_index_slots[idx].payload == OSTY_GC_INDEX_TOMBSTONE) {
+    if (first_tombstone != SIZE_MAX) {
+        idx = first_tombstone;
         osty_gc_index_tombstones -= 1;
     }
     osty_gc_index_slots[idx].payload = payload;
@@ -1096,6 +1131,7 @@ static void osty_gc_identity_grow(int64_t new_capacity) {
 static void osty_gc_identity_insert(uint64_t stable_id, osty_gc_header *header) {
     size_t mask;
     size_t idx;
+    size_t first_tombstone = SIZE_MAX;
 
     if (stable_id == 0 || stable_id == OSTY_GC_IDENTITY_TOMBSTONE) {
         osty_rt_abort("invalid GC stable id");
@@ -1110,15 +1146,20 @@ static void osty_gc_identity_insert(uint64_t stable_id, osty_gc_header *header) 
     }
     mask = (size_t)(osty_gc_identity_capacity - 1);
     idx = osty_gc_identity_hash(stable_id) & mask;
-    while (osty_gc_identity_slots[idx].stable_id != 0 &&
-           osty_gc_identity_slots[idx].stable_id != OSTY_GC_IDENTITY_TOMBSTONE) {
-        if (osty_gc_identity_slots[idx].stable_id == stable_id) {
+    while (osty_gc_identity_slots[idx].stable_id != 0) {
+        if (osty_gc_identity_slots[idx].stable_id ==
+            OSTY_GC_IDENTITY_TOMBSTONE) {
+            if (first_tombstone == SIZE_MAX) {
+                first_tombstone = idx;
+            }
+        } else if (osty_gc_identity_slots[idx].stable_id == stable_id) {
             osty_gc_identity_slots[idx].header = header;
             return;
         }
         idx = (idx + 1) & mask;
     }
-    if (osty_gc_identity_slots[idx].stable_id == OSTY_GC_IDENTITY_TOMBSTONE) {
+    if (first_tombstone != SIZE_MAX) {
+        idx = first_tombstone;
         osty_gc_identity_tombstones -= 1;
     }
     osty_gc_identity_slots[idx].stable_id = stable_id;
@@ -1198,6 +1239,7 @@ static void osty_gc_forwarding_insert(void *from_payload,
                                       osty_gc_header *to_header) {
     size_t mask;
     size_t idx;
+    size_t first_tombstone = SIZE_MAX;
 
     if (from_payload == NULL ||
         from_payload == OSTY_GC_FORWARDING_TOMBSTONE ||
@@ -1214,10 +1256,14 @@ static void osty_gc_forwarding_insert(void *from_payload,
     }
     mask = (size_t)(osty_gc_forwarding_capacity - 1);
     idx = osty_gc_forwarding_hash(from_payload) & mask;
-    while (osty_gc_forwarding_slots[idx].from_payload != NULL &&
-           osty_gc_forwarding_slots[idx].from_payload !=
-               OSTY_GC_FORWARDING_TOMBSTONE) {
-        if (osty_gc_forwarding_slots[idx].from_payload == from_payload) {
+    while (osty_gc_forwarding_slots[idx].from_payload != NULL) {
+        if (osty_gc_forwarding_slots[idx].from_payload ==
+            OSTY_GC_FORWARDING_TOMBSTONE) {
+            if (first_tombstone == SIZE_MAX) {
+                first_tombstone = idx;
+            }
+        } else if (osty_gc_forwarding_slots[idx].from_payload ==
+                   from_payload) {
             osty_gc_forwarding_slots[idx].to_header = to_header;
             osty_gc_forwarding_slots[idx].stable_id = to_header->stable_id;
             osty_gc_forwarding_slots[idx].byte_size = to_header->byte_size;
@@ -1225,8 +1271,8 @@ static void osty_gc_forwarding_insert(void *from_payload,
         }
         idx = (idx + 1) & mask;
     }
-    if (osty_gc_forwarding_slots[idx].from_payload ==
-        OSTY_GC_FORWARDING_TOMBSTONE) {
+    if (first_tombstone != SIZE_MAX) {
+        idx = first_tombstone;
         osty_gc_forwarding_tombstones -= 1;
     }
     osty_gc_forwarding_slots[idx].from_payload = from_payload;
@@ -1450,10 +1496,9 @@ static void osty_gc_note_pin_release(osty_gc_header *header) {
 }
 
 /* Phase B promotion: move `header` from YOUNG to OLD in place. Only the
- * bookkeeping counters change; payload address is stable (no compaction
- * yet), so any outstanding root pointer or SATB log entry keeps pointing
- * at the same memory. Called once a YOUNG survivor has hit the age
- * threshold. */
+ * bookkeeping counters change. Phase D may already have copied an
+ * unpinned survivor into survivor/old bump storage before this runs, but
+ * promotion itself still just relinks the chosen live header into OLD. */
 static void osty_gc_promote_header(osty_gc_header *header) {
     if (header->generation == OSTY_GC_GEN_OLD) {
         return;
@@ -1612,7 +1657,39 @@ static int64_t osty_gc_size_class_index_for_total_size(size_t total_size) {
     return (int64_t)(aligned_size / OSTY_GC_SIZE_CLASS_ALIGN) - 1;
 }
 
+static bool osty_gc_bump_block_has_forwarding_alias(
+    const osty_gc_bump_block *block) {
+    int64_t i;
+
+    if (block == NULL || osty_gc_forwarding_slots == NULL) {
+        return false;
+    }
+    for (i = 0; i < osty_gc_forwarding_capacity; i++) {
+        void *from_payload = osty_gc_forwarding_slots[i].from_payload;
+        const unsigned char *addr;
+        if (from_payload == NULL ||
+            from_payload == OSTY_GC_FORWARDING_TOMBSTONE) {
+            continue;
+        }
+        addr = (const unsigned char *)from_payload;
+        if (addr >= block->data && addr < block->data + block->size) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool osty_gc_old_bump_release_header(osty_gc_header *header);
+static bool osty_gc_young_bump_release_header(osty_gc_header *header);
+static bool osty_gc_survivor_bump_release_header(osty_gc_header *header);
+static bool osty_gc_pinned_bump_release_header(osty_gc_header *header);
+static void osty_gc_bump_recycle_empty_blocks(
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count,
+    int64_t *recycled_count_total,
+    int64_t *recycled_bytes_total,
+    bool clear_tlab_current);
 
 static void osty_gc_free_list_push(osty_gc_header *header) {
     osty_gc_free_chunk *chunk;
@@ -1690,7 +1767,16 @@ static osty_gc_header *osty_gc_free_list_take(size_t total_size,
  * their old payload addresses in the forwarding table, so reusing them
  * would alias a stale logical identity to a new object. */
 static void osty_gc_reclaim_swept_header(osty_gc_header *header) {
+    if (osty_gc_young_bump_release_header(header)) {
+        return;
+    }
+    if (osty_gc_survivor_bump_release_header(header)) {
+        return;
+    }
     if (osty_gc_old_bump_release_header(header)) {
+        return;
+    }
+    if (osty_gc_pinned_bump_release_header(header)) {
         return;
     }
     osty_gc_free_list_push(header);
@@ -1700,7 +1786,16 @@ static void osty_gc_release_replaced_header(osty_gc_header *header) {
     if (header == NULL) {
         return;
     }
+    if (osty_gc_young_bump_release_header(header)) {
+        return;
+    }
+    if (osty_gc_survivor_bump_release_header(header)) {
+        return;
+    }
     if (osty_gc_old_bump_release_header(header)) {
+        return;
+    }
+    if (osty_gc_pinned_bump_release_header(header)) {
         return;
     }
     if (header->storage_kind == OSTY_GC_STORAGE_DIRECT) {
@@ -1781,20 +1876,70 @@ static osty_gc_header *osty_gc_bump_take_from_region(
     return header;
 }
 
-static osty_gc_header *osty_gc_tlab_take(size_t total_size) {
+static osty_gc_header *osty_gc_bump_take_from_tlab_region(
+    size_t total_size,
+    uint8_t storage_kind,
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **shared_current,
+    osty_gc_bump_block **tlab_current,
+    int64_t *block_count_total,
+    int64_t *block_bytes_total,
+    int64_t *alloc_count_total,
+    int64_t *alloc_bytes_total,
+    int64_t *tlab_refill_count_total) {
     osty_gc_header *header = osty_gc_bump_take_from_region(
-        total_size, OSTY_GC_STORAGE_BUMP_YOUNG,
-        &osty_gc_bump_blocks, &osty_gc_tlab_current,
-        &osty_gc_bump_block_count, &osty_gc_bump_block_bytes_total,
-        &osty_gc_bump_alloc_count_total, &osty_gc_bump_alloc_bytes_total);
+        total_size, storage_kind, blocks_head, tlab_current,
+        block_count_total, block_bytes_total, alloc_count_total,
+        alloc_bytes_total);
 
     if (header != NULL) {
-        osty_gc_bump_current = osty_gc_tlab_current;
-        if (header == (osty_gc_header *)(void *)osty_gc_tlab_current->data) {
-            osty_gc_tlab_refill_count_total += 1;
+        *shared_current = *tlab_current;
+        if (header == (osty_gc_header *)(void *)(*tlab_current)->data) {
+            *tlab_refill_count_total += 1;
         }
     }
     return header;
+}
+
+static osty_gc_header *osty_gc_tlab_take(size_t total_size) {
+    return osty_gc_bump_take_from_tlab_region(
+        total_size, OSTY_GC_STORAGE_BUMP_YOUNG, &osty_gc_bump_blocks,
+        &osty_gc_bump_current, &osty_gc_tlab_current,
+        &osty_gc_bump_block_count, &osty_gc_bump_block_bytes_total,
+        &osty_gc_bump_alloc_count_total, &osty_gc_bump_alloc_bytes_total,
+        &osty_gc_tlab_refill_count_total);
+}
+
+static osty_gc_header *osty_gc_survivor_tlab_take(size_t total_size) {
+    return osty_gc_bump_take_from_tlab_region(
+        total_size, OSTY_GC_STORAGE_BUMP_SURVIVOR,
+        &osty_gc_survivor_bump_blocks, &osty_gc_survivor_bump_current,
+        &osty_gc_survivor_tlab_current, &osty_gc_survivor_bump_block_count,
+        &osty_gc_survivor_bump_block_bytes_total,
+        &osty_gc_survivor_bump_alloc_count_total,
+        &osty_gc_survivor_bump_alloc_bytes_total,
+        &osty_gc_survivor_tlab_refill_count_total);
+}
+
+static osty_gc_header *osty_gc_old_tlab_take(size_t total_size) {
+    return osty_gc_bump_take_from_tlab_region(
+        total_size, OSTY_GC_STORAGE_BUMP_OLD, &osty_gc_old_bump_blocks,
+        &osty_gc_old_bump_current, &osty_gc_old_tlab_current,
+        &osty_gc_old_bump_block_count, &osty_gc_old_bump_block_bytes_total,
+        &osty_gc_old_bump_alloc_count_total,
+        &osty_gc_old_bump_alloc_bytes_total,
+        &osty_gc_old_tlab_refill_count_total);
+}
+
+static osty_gc_header *osty_gc_pinned_tlab_take(size_t total_size) {
+    return osty_gc_bump_take_from_tlab_region(
+        total_size, OSTY_GC_STORAGE_BUMP_PINNED, &osty_gc_pinned_bump_blocks,
+        &osty_gc_pinned_bump_current, &osty_gc_pinned_tlab_current,
+        &osty_gc_pinned_bump_block_count,
+        &osty_gc_pinned_bump_block_bytes_total,
+        &osty_gc_pinned_bump_alloc_count_total,
+        &osty_gc_pinned_bump_alloc_bytes_total,
+        &osty_gc_pinned_tlab_refill_count_total);
 }
 
 static osty_gc_bump_block *osty_gc_bump_block_find_owner(
@@ -1844,28 +1989,120 @@ static void osty_gc_bump_block_release(
     free(block);
 }
 
-static bool osty_gc_old_bump_release_header(osty_gc_header *header) {
+static bool osty_gc_bump_release_header_from_region(
+    osty_gc_header *header,
+    uint8_t storage_kind,
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count,
+    int64_t *recycled_count_total,
+    int64_t *recycled_bytes_total,
+    bool clear_tlab_current) {
     osty_gc_bump_block *block;
 
-    if (header == NULL || header->storage_kind != OSTY_GC_STORAGE_BUMP_OLD) {
+    if (header == NULL || header->storage_kind != storage_kind) {
         return false;
     }
-    block = osty_gc_bump_block_find_owner(osty_gc_old_bump_blocks, header);
+    block = osty_gc_bump_block_find_owner(*blocks_head, header);
     if (block == NULL) {
-        osty_rt_abort("GC old bump owner missing");
+        osty_rt_abort("GC bump owner missing");
     }
     if (block->live_alloc_count <= 0) {
-        osty_rt_abort("GC old bump live count underflow");
+        osty_rt_abort("GC bump live count underflow");
     }
     block->live_alloc_count -= 1;
-    if (block->live_alloc_count == 0) {
+    if (block->live_alloc_count == 0 &&
+        !osty_gc_bump_block_has_forwarding_alias(block)) {
+        if (clear_tlab_current) {
+            if (storage_kind == OSTY_GC_STORAGE_BUMP_YOUNG &&
+                osty_gc_tlab_current == block) {
+                osty_gc_tlab_current = NULL;
+            }
+            if (storage_kind == OSTY_GC_STORAGE_BUMP_SURVIVOR &&
+                osty_gc_survivor_tlab_current == block) {
+                osty_gc_survivor_tlab_current = NULL;
+            }
+            if (storage_kind == OSTY_GC_STORAGE_BUMP_OLD &&
+                osty_gc_old_tlab_current == block) {
+                osty_gc_old_tlab_current = NULL;
+            }
+            if (storage_kind == OSTY_GC_STORAGE_BUMP_PINNED &&
+                osty_gc_pinned_tlab_current == block) {
+                osty_gc_pinned_tlab_current = NULL;
+            }
+        }
         osty_gc_bump_block_release(
-            block, &osty_gc_old_bump_blocks, &osty_gc_old_bump_current,
-            &osty_gc_old_bump_block_count,
-            &osty_gc_old_bump_recycled_block_count_total,
-            &osty_gc_old_bump_recycled_bytes_total);
+            block, blocks_head, current, block_count, recycled_count_total,
+            recycled_bytes_total);
     }
     return true;
+}
+
+static bool osty_gc_young_bump_release_header(osty_gc_header *header) {
+    return osty_gc_bump_release_header_from_region(
+        header, OSTY_GC_STORAGE_BUMP_YOUNG, &osty_gc_bump_blocks,
+        &osty_gc_bump_current, &osty_gc_bump_block_count,
+        &osty_gc_bump_recycled_block_count_total,
+        &osty_gc_bump_recycled_bytes_total, true);
+}
+
+static bool osty_gc_survivor_bump_release_header(osty_gc_header *header) {
+    return osty_gc_bump_release_header_from_region(
+        header, OSTY_GC_STORAGE_BUMP_SURVIVOR, &osty_gc_survivor_bump_blocks,
+        &osty_gc_survivor_bump_current, &osty_gc_survivor_bump_block_count,
+        &osty_gc_survivor_bump_recycled_block_count_total,
+        &osty_gc_survivor_bump_recycled_bytes_total, true);
+}
+
+static bool osty_gc_old_bump_release_header(osty_gc_header *header) {
+    return osty_gc_bump_release_header_from_region(
+        header, OSTY_GC_STORAGE_BUMP_OLD, &osty_gc_old_bump_blocks,
+        &osty_gc_old_bump_current, &osty_gc_old_bump_block_count,
+        &osty_gc_old_bump_recycled_block_count_total,
+        &osty_gc_old_bump_recycled_bytes_total, true);
+}
+
+static bool osty_gc_pinned_bump_release_header(osty_gc_header *header) {
+    return osty_gc_bump_release_header_from_region(
+        header, OSTY_GC_STORAGE_BUMP_PINNED, &osty_gc_pinned_bump_blocks,
+        &osty_gc_pinned_bump_current, &osty_gc_pinned_bump_block_count,
+        &osty_gc_pinned_bump_recycled_block_count_total,
+        &osty_gc_pinned_bump_recycled_bytes_total, true);
+}
+
+static void osty_gc_bump_recycle_empty_blocks(
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count,
+    int64_t *recycled_count_total,
+    int64_t *recycled_bytes_total,
+    bool clear_tlab_current) {
+    osty_gc_bump_block *block = *blocks_head;
+
+    while (block != NULL) {
+        osty_gc_bump_block *next = block->next;
+        if (block->live_alloc_count == 0 &&
+            !osty_gc_bump_block_has_forwarding_alias(block)) {
+            if (clear_tlab_current) {
+                if (osty_gc_tlab_current == block) {
+                    osty_gc_tlab_current = NULL;
+                }
+                if (osty_gc_survivor_tlab_current == block) {
+                    osty_gc_survivor_tlab_current = NULL;
+                }
+                if (osty_gc_old_tlab_current == block) {
+                    osty_gc_old_tlab_current = NULL;
+                }
+                if (osty_gc_pinned_tlab_current == block) {
+                    osty_gc_pinned_tlab_current = NULL;
+                }
+            }
+            osty_gc_bump_block_release(
+                block, blocks_head, current, block_count,
+                recycled_count_total, recycled_bytes_total);
+        }
+        block = next;
+    }
 }
 
 /* Phase B pressure split: `allocated_since_collect` still tracks the
@@ -1891,6 +2128,21 @@ static void osty_gc_note_allocation(size_t payload_size) {
     if (nursery_limit > 0 &&
         (osty_gc_young_bytes >= nursery_limit ||
          osty_gc_allocated_since_minor >= nursery_limit)) {
+        osty_gc_collection_requested = true;
+    }
+}
+
+static void osty_gc_note_old_allocation(size_t payload_size) {
+    int64_t pressure_limit = osty_gc_pressure_limit_now();
+
+    if (payload_size > (size_t)INT64_MAX) {
+        osty_rt_abort("GC payload size overflow");
+    }
+    osty_gc_allocated_since_collect += (int64_t)payload_size;
+    osty_gc_allocated_bytes_total += (int64_t)payload_size;
+    if (pressure_limit > 0 &&
+        (osty_gc_live_bytes >= pressure_limit ||
+         osty_gc_allocated_since_collect >= pressure_limit)) {
         osty_gc_collection_requested = true;
     }
 }
@@ -1971,6 +2223,72 @@ static void *osty_gc_allocate_managed(size_t byte_size, int64_t object_kind, con
     /* Phase C3 mutator assist: if an incremental major is active,
      * borrow a proportional amount of mark work from the allocator
      * so the mutator literally pays for its allocation pressure. */
+    if (osty_gc_state == OSTY_GC_STATE_MARK_INCREMENTAL) {
+        int64_t bpu = osty_gc_assist_bytes_per_unit_now();
+        if (bpu > 0) {
+            int64_t units = (int64_t)payload_size / bpu;
+            if (units < 1) {
+                units = 1;
+            }
+            int64_t done = osty_gc_mark_drain_budget(units);
+            osty_gc_mutator_assist_work_total += done;
+            osty_gc_mutator_assist_calls_total += 1;
+        }
+    }
+    osty_gc_release();
+    return header->payload;
+}
+
+static void *osty_gc_allocate_pinned_managed(size_t byte_size,
+                                             int64_t object_kind,
+                                             const char *site,
+                                             osty_gc_trace_fn trace,
+                                             osty_gc_destroy_fn destroy) {
+    osty_gc_header *header;
+    size_t payload_size = byte_size;
+    size_t total_size;
+    bool humongous;
+    uint8_t storage_kind = OSTY_GC_STORAGE_DIRECT;
+
+    total_size = osty_gc_total_size_for_payload_size(payload_size);
+    payload_size = total_size - sizeof(osty_gc_header);
+    humongous = osty_gc_total_size_is_humongous(total_size);
+    header = NULL;
+    if (!humongous) {
+        osty_gc_acquire();
+        header = osty_gc_pinned_tlab_take(total_size);
+        if (header != NULL) {
+            storage_kind = OSTY_GC_STORAGE_BUMP_PINNED;
+        }
+        osty_gc_release();
+    }
+    if (header == NULL) {
+        header = (osty_gc_header *)calloc(1, total_size);
+        if (header == NULL) {
+            osty_rt_abort("out of memory");
+        }
+    }
+    header->object_kind = object_kind;
+    header->byte_size = (int64_t)payload_size;
+    header->trace = trace;
+    header->destroy = destroy;
+    header->site = site;
+    header->payload = (void *)(header + 1);
+    header->storage_kind = storage_kind;
+    header->generation = OSTY_GC_GEN_OLD;
+    header->age = 0;
+    header->pin_count = 1;
+    header->color = OSTY_GC_COLOR_WHITE;
+    header->marked = false;
+    osty_gc_acquire();
+    if (humongous) {
+        osty_gc_humongous_alloc_count_total += 1;
+        osty_gc_humongous_alloc_bytes_total += (int64_t)payload_size;
+    }
+    header->stable_id = osty_gc_allocate_stable_id();
+    osty_gc_link(header);
+    osty_gc_note_pin_acquire(header);
+    osty_gc_note_old_allocation(payload_size);
     if (osty_gc_state == OSTY_GC_STATE_MARK_INCREMENTAL) {
         int64_t bpu = osty_gc_assist_bytes_per_unit_now();
         if (bpu > 0) {
@@ -2475,9 +2793,17 @@ static void osty_gc_remap_header_payload(osty_gc_header *header) {
     }
 }
 
-static osty_gc_header *osty_gc_clone_header_storage(osty_gc_header *header) {
+static osty_gc_header *osty_gc_clone_header_storage_to_bump_region(
+    osty_gc_header *header,
+    uint8_t storage_kind,
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count_total,
+    int64_t *block_bytes_total,
+    int64_t *alloc_count_total,
+    int64_t *alloc_bytes_total) {
     osty_gc_header *clone;
-    uint8_t clone_storage_kind = OSTY_GC_STORAGE_DIRECT;
+    bool used_bump = false;
     size_t total_size;
 
     if (header == NULL) {
@@ -2488,17 +2814,29 @@ static osty_gc_header *osty_gc_clone_header_storage(osty_gc_header *header) {
         osty_rt_abort("GC clone size overflow");
     }
     total_size = sizeof(osty_gc_header) + (size_t)header->byte_size;
-    if (!osty_gc_total_size_is_humongous(total_size)) {
-        clone = osty_gc_bump_take_from_region(
-            total_size, OSTY_GC_STORAGE_BUMP_OLD,
-            &osty_gc_old_bump_blocks, &osty_gc_old_bump_current,
-            &osty_gc_old_bump_block_count,
-            &osty_gc_old_bump_block_bytes_total,
-            &osty_gc_old_bump_alloc_count_total,
-            &osty_gc_old_bump_alloc_bytes_total);
-        if (clone != NULL) {
-            clone_storage_kind = OSTY_GC_STORAGE_BUMP_OLD;
+    if (!osty_gc_total_size_is_humongous(total_size) &&
+        storage_kind != OSTY_GC_STORAGE_DIRECT) {
+        switch (storage_kind) {
+        case OSTY_GC_STORAGE_BUMP_YOUNG:
+            clone = osty_gc_tlab_take(total_size);
+            break;
+        case OSTY_GC_STORAGE_BUMP_SURVIVOR:
+            clone = osty_gc_survivor_tlab_take(total_size);
+            break;
+        case OSTY_GC_STORAGE_BUMP_OLD:
+            clone = osty_gc_old_tlab_take(total_size);
+            break;
+        case OSTY_GC_STORAGE_BUMP_PINNED:
+            clone = osty_gc_pinned_tlab_take(total_size);
+            break;
+        default:
+            clone = osty_gc_bump_take_from_region(
+                total_size, storage_kind, blocks_head, current,
+                block_count_total, block_bytes_total, alloc_count_total,
+                alloc_bytes_total);
+            break;
         }
+        used_bump = clone != NULL;
     } else {
         clone = NULL;
     }
@@ -2514,12 +2852,22 @@ static osty_gc_header *osty_gc_clone_header_storage(osty_gc_header *header) {
     clone->next_gen = NULL;
     clone->prev_gen = NULL;
     clone->payload = (void *)(clone + 1);
-    clone->storage_kind = clone_storage_kind;
+    clone->storage_kind = used_bump ? storage_kind : OSTY_GC_STORAGE_DIRECT;
     return clone;
 }
 
-static osty_gc_header *osty_gc_clone_map_header(osty_gc_header *header) {
-    osty_gc_header *clone = osty_gc_clone_header_storage(header);
+static osty_gc_header *osty_gc_clone_map_header_to_bump_region(
+    osty_gc_header *header,
+    uint8_t storage_kind,
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count_total,
+    int64_t *block_bytes_total,
+    int64_t *alloc_count_total,
+    int64_t *alloc_bytes_total) {
+    osty_gc_header *clone = osty_gc_clone_header_storage_to_bump_region(
+        header, storage_kind, blocks_head, current, block_count_total,
+        block_bytes_total, alloc_count_total, alloc_bytes_total);
     osty_rt_map *old_map;
     osty_rt_map *new_map;
 
@@ -2547,8 +2895,18 @@ static osty_gc_header *osty_gc_clone_map_header(osty_gc_header *header) {
     return clone;
 }
 
-static osty_gc_header *osty_gc_clone_chan_header(osty_gc_header *header) {
-    osty_gc_header *clone = osty_gc_clone_header_storage(header);
+static osty_gc_header *osty_gc_clone_chan_header_to_bump_region(
+    osty_gc_header *header,
+    uint8_t storage_kind,
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count_total,
+    int64_t *block_bytes_total,
+    int64_t *alloc_count_total,
+    int64_t *alloc_bytes_total) {
+    osty_gc_header *clone = osty_gc_clone_header_storage_to_bump_region(
+        header, storage_kind, blocks_head, current, block_count_total,
+        block_bytes_total, alloc_count_total, alloc_bytes_total);
     osty_rt_chan_impl *old_ch;
     osty_rt_chan_impl *new_ch;
 
@@ -2576,25 +2934,48 @@ static osty_gc_header *osty_gc_clone_chan_header(osty_gc_header *header) {
     return clone;
 }
 
-static osty_gc_header *osty_gc_clone_header(osty_gc_header *header) {
+static osty_gc_header *osty_gc_clone_header_to_bump_region(
+    osty_gc_header *header,
+    uint8_t storage_kind,
+    osty_gc_bump_block **blocks_head,
+    osty_gc_bump_block **current,
+    int64_t *block_count_total,
+    int64_t *block_bytes_total,
+    int64_t *alloc_count_total,
+    int64_t *alloc_bytes_total) {
     osty_gc_header *clone;
 
     if (header == NULL) {
         return NULL;
     }
     if (header->object_kind == OSTY_GC_KIND_MAP) {
-        return osty_gc_clone_map_header(header);
+        return osty_gc_clone_map_header_to_bump_region(
+            header, storage_kind, blocks_head, current, block_count_total,
+            block_bytes_total, alloc_count_total, alloc_bytes_total);
     }
     if (header->object_kind == OSTY_GC_KIND_CHANNEL) {
-        return osty_gc_clone_chan_header(header);
+        return osty_gc_clone_chan_header_to_bump_region(
+            header, storage_kind, blocks_head, current, block_count_total,
+            block_bytes_total, alloc_count_total, alloc_bytes_total);
     }
-    clone = osty_gc_clone_header_storage(header);
+    clone = osty_gc_clone_header_storage_to_bump_region(
+        header, storage_kind, blocks_head, current, block_count_total,
+        block_bytes_total, alloc_count_total, alloc_bytes_total);
 
     if (clone == NULL) {
         return NULL;
     }
     memcpy(clone->payload, header->payload, (size_t)header->byte_size);
     return clone;
+}
+
+static osty_gc_header *osty_gc_clone_header(osty_gc_header *header) {
+    return osty_gc_clone_header_to_bump_region(
+        header, OSTY_GC_STORAGE_BUMP_OLD, &osty_gc_old_bump_blocks,
+        &osty_gc_old_bump_current, &osty_gc_old_bump_block_count,
+        &osty_gc_old_bump_block_bytes_total,
+        &osty_gc_old_bump_alloc_count_total,
+        &osty_gc_old_bump_alloc_bytes_total);
 }
 
 static void osty_gc_replace_header(osty_gc_header *old_header,
@@ -2657,6 +3038,26 @@ static int64_t osty_gc_compact_major_with_stack_roots(
     if (moved == 0) {
         osty_gc_forwarding_retain_history(snapshots, snapshot_count);
         free(snapshots);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_bump_blocks, &osty_gc_bump_current,
+            &osty_gc_bump_block_count,
+            &osty_gc_bump_recycled_block_count_total,
+            &osty_gc_bump_recycled_bytes_total, true);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_survivor_bump_blocks, &osty_gc_survivor_bump_current,
+            &osty_gc_survivor_bump_block_count,
+            &osty_gc_survivor_bump_recycled_block_count_total,
+            &osty_gc_survivor_bump_recycled_bytes_total, true);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_old_bump_blocks, &osty_gc_old_bump_current,
+            &osty_gc_old_bump_block_count,
+            &osty_gc_old_bump_recycled_block_count_total,
+            &osty_gc_old_bump_recycled_bytes_total, true);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_pinned_bump_blocks, &osty_gc_pinned_bump_current,
+            &osty_gc_pinned_bump_block_count,
+            &osty_gc_pinned_bump_recycled_block_count_total,
+            &osty_gc_pinned_bump_recycled_bytes_total, true);
         osty_gc_forwarded_objects_last = 0;
         osty_gc_forwarded_bytes_last = 0;
         return 0;
@@ -2694,6 +3095,151 @@ static int64_t osty_gc_compact_major_with_stack_roots(
     }
     osty_gc_forwarding_retain_history(snapshots, snapshot_count);
     free(snapshots);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_bump_blocks, &osty_gc_bump_current,
+        &osty_gc_bump_block_count, &osty_gc_bump_recycled_block_count_total,
+        &osty_gc_bump_recycled_bytes_total, true);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_survivor_bump_blocks, &osty_gc_survivor_bump_current,
+        &osty_gc_survivor_bump_block_count,
+        &osty_gc_survivor_bump_recycled_block_count_total,
+        &osty_gc_survivor_bump_recycled_bytes_total, true);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_old_bump_blocks, &osty_gc_old_bump_current,
+        &osty_gc_old_bump_block_count,
+        &osty_gc_old_bump_recycled_block_count_total,
+        &osty_gc_old_bump_recycled_bytes_total, true);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_pinned_bump_blocks, &osty_gc_pinned_bump_current,
+        &osty_gc_pinned_bump_block_count,
+        &osty_gc_pinned_bump_recycled_block_count_total,
+        &osty_gc_pinned_bump_recycled_bytes_total, true);
+
+    osty_gc_compaction_count_total += 1;
+    osty_gc_forwarded_objects_last = moved;
+    osty_gc_forwarded_bytes_last = moved_bytes;
+    return moved;
+}
+
+static int64_t osty_gc_compact_minor_with_stack_roots(
+    void *const *root_slots, int64_t root_slot_count, int64_t promote_age) {
+    osty_gc_header *header;
+    osty_gc_header *next;
+    osty_gc_forwarding_snapshot *snapshots;
+    int64_t snapshot_count = 0;
+    int64_t i;
+    int64_t moved = 0;
+    int64_t moved_bytes = 0;
+
+    snapshots = osty_gc_forwarding_snapshot_take(&snapshot_count);
+    osty_gc_forwarding_clear();
+    osty_gc_survivor_bump_current = NULL;
+    osty_gc_survivor_tlab_current = NULL;
+    header = osty_gc_young_head;
+    while (header != NULL) {
+        if (osty_gc_header_is_movable(header)) {
+            bool will_promote = (int64_t)header->age + 1 >= promote_age;
+            osty_gc_header *clone = osty_gc_clone_header_to_bump_region(
+                header,
+                will_promote ? OSTY_GC_STORAGE_BUMP_OLD
+                             : OSTY_GC_STORAGE_BUMP_SURVIVOR,
+                will_promote ? &osty_gc_old_bump_blocks
+                             : &osty_gc_survivor_bump_blocks,
+                will_promote ? &osty_gc_old_bump_current
+                             : &osty_gc_survivor_bump_current,
+                will_promote ? &osty_gc_old_bump_block_count
+                             : &osty_gc_survivor_bump_block_count,
+                will_promote ? &osty_gc_old_bump_block_bytes_total
+                             : &osty_gc_survivor_bump_block_bytes_total,
+                will_promote ? &osty_gc_old_bump_alloc_count_total
+                             : &osty_gc_survivor_bump_alloc_count_total,
+                will_promote ? &osty_gc_old_bump_alloc_bytes_total
+                             : &osty_gc_survivor_bump_alloc_bytes_total);
+            osty_gc_forwarding_insert(header->payload, clone);
+            moved += 1;
+            moved_bytes += header->byte_size;
+        }
+        header = header->next_gen;
+    }
+    if (moved == 0) {
+        osty_gc_forwarding_retain_history(snapshots, snapshot_count);
+        free(snapshots);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_bump_blocks, &osty_gc_bump_current,
+            &osty_gc_bump_block_count,
+            &osty_gc_bump_recycled_block_count_total,
+            &osty_gc_bump_recycled_bytes_total, true);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_survivor_bump_blocks, &osty_gc_survivor_bump_current,
+            &osty_gc_survivor_bump_block_count,
+            &osty_gc_survivor_bump_recycled_block_count_total,
+            &osty_gc_survivor_bump_recycled_bytes_total, true);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_old_bump_blocks, &osty_gc_old_bump_current,
+            &osty_gc_old_bump_block_count,
+            &osty_gc_old_bump_recycled_block_count_total,
+            &osty_gc_old_bump_recycled_bytes_total, true);
+        osty_gc_bump_recycle_empty_blocks(
+            &osty_gc_pinned_bump_blocks, &osty_gc_pinned_bump_current,
+            &osty_gc_pinned_bump_block_count,
+            &osty_gc_pinned_bump_recycled_block_count_total,
+            &osty_gc_pinned_bump_recycled_bytes_total, true);
+        osty_gc_forwarded_objects_last = 0;
+        osty_gc_forwarded_bytes_last = 0;
+        return 0;
+    }
+
+    for (i = 0; i < root_slot_count; i++) {
+        osty_gc_remap_slot((void *)root_slots[i]);
+    }
+    for (i = 0; i < osty_gc_global_root_count; i++) {
+        osty_gc_remap_slot(osty_gc_global_root_slots[i]);
+    }
+
+    header = osty_gc_objects;
+    while (header != NULL) {
+        osty_gc_header *current = osty_gc_forwarding_lookup(header->payload);
+        if (current == NULL) {
+            current = header;
+        }
+        osty_gc_remap_header_payload(current);
+        header = header->next;
+    }
+
+    header = osty_gc_objects;
+    while (header != NULL) {
+        next = header->next;
+        {
+            osty_gc_header *replacement =
+                osty_gc_forwarding_lookup(header->payload);
+            if (replacement != NULL) {
+                osty_gc_replace_header(header, replacement);
+                osty_gc_release_replaced_header(header);
+            }
+        }
+        header = next;
+    }
+    osty_gc_forwarding_retain_history(snapshots, snapshot_count);
+    free(snapshots);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_bump_blocks, &osty_gc_bump_current,
+        &osty_gc_bump_block_count, &osty_gc_bump_recycled_block_count_total,
+        &osty_gc_bump_recycled_bytes_total, true);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_survivor_bump_blocks, &osty_gc_survivor_bump_current,
+        &osty_gc_survivor_bump_block_count,
+        &osty_gc_survivor_bump_recycled_block_count_total,
+        &osty_gc_survivor_bump_recycled_bytes_total, true);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_old_bump_blocks, &osty_gc_old_bump_current,
+        &osty_gc_old_bump_block_count,
+        &osty_gc_old_bump_recycled_block_count_total,
+        &osty_gc_old_bump_recycled_bytes_total, true);
+    osty_gc_bump_recycle_empty_blocks(
+        &osty_gc_pinned_bump_blocks, &osty_gc_pinned_bump_current,
+        &osty_gc_pinned_bump_block_count,
+        &osty_gc_pinned_bump_recycled_block_count_total,
+        &osty_gc_pinned_bump_recycled_bytes_total, true);
 
     osty_gc_compaction_count_total += 1;
     osty_gc_forwarded_objects_last = moved;
@@ -2729,8 +3275,12 @@ static void osty_gc_remembered_edges_compact_after_minor(void) {
     int64_t write_idx = 0;
     int64_t i;
     for (i = 0; i < osty_gc_remembered_edge_count; i++) {
-        osty_gc_header *owner = osty_gc_find_header(osty_gc_remembered_edges[i].owner);
-        osty_gc_header *value = osty_gc_find_header(osty_gc_remembered_edges[i].value);
+        void *owner_payload =
+            osty_gc_forward_payload(osty_gc_remembered_edges[i].owner);
+        void *value_payload =
+            osty_gc_forward_payload(osty_gc_remembered_edges[i].value);
+        osty_gc_header *owner = osty_gc_find_header(owner_payload);
+        osty_gc_header *value = osty_gc_find_header(value_payload);
         if (owner == NULL || value == NULL) {
             continue;
         }
@@ -2740,10 +3290,8 @@ static void osty_gc_remembered_edges_compact_after_minor(void) {
         if (value->generation != OSTY_GC_GEN_YOUNG) {
             continue;
         }
-        osty_gc_remembered_edges[write_idx].owner =
-            osty_gc_remembered_edges[i].owner;
-        osty_gc_remembered_edges[write_idx].value =
-            osty_gc_remembered_edges[i].value;
+        osty_gc_remembered_edges[write_idx].owner = owner_payload;
+        osty_gc_remembered_edges[write_idx].value = value_payload;
         write_idx += 1;
     }
     osty_gc_remembered_edge_count = write_idx;
@@ -2836,9 +3384,10 @@ static void osty_gc_collect_major_with_stack_roots(void *const *root_slots, int6
 /* Phase B minor collection (RUNTIME_GC_DELTA §5.1-5.5).
  *
  * Scans only YOUNG objects. OLD objects are assumed live; any
- * OLD→YOUNG edge is preserved by walking the remembered set. YOUNG
- * survivors that cross `promote_age` move to OLD in place (address
- * stable, no compaction). Frees unreachable YOUNG; OLD untouched.
+ * OLD→YOUNG edge is preserved by walking the remembered set. Phase D
+ * extends the survivor path so movable YOUNG objects can be copied into
+ * survivor/old bump regions before the age/promote step runs. Frees
+ * unreachable YOUNG; OLD untouched.
  */
 static void osty_gc_collect_minor_with_stack_roots(void *const *root_slots, int64_t root_slot_count) {
     osty_gc_header *header;
@@ -2910,11 +3459,18 @@ static void osty_gc_collect_minor_with_stack_roots(void *const *root_slots, int6
         } else {
             header->color = OSTY_GC_COLOR_WHITE;
             header->marked = false;
-            if ((int64_t)header->age + 1 >= promote_age) {
-                osty_gc_promote_header(header);
-            } else if (header->age < UINT8_MAX) {
-                header->age += 1;
-            }
+        }
+        header = next;
+    }
+    (void)osty_gc_compact_minor_with_stack_roots(
+        root_slots, root_slot_count, promote_age);
+    header = osty_gc_young_head;
+    while (header != NULL) {
+        next = header->next_gen;
+        if ((int64_t)header->age + 1 >= promote_age) {
+            osty_gc_promote_header(header);
+        } else if (header->age < UINT8_MAX) {
+            header->age += 1;
         }
         header = next;
     }
@@ -5623,6 +6179,7 @@ uint8_t osty_rt_bytes_get(void *raw_bytes, int64_t index) {
 }
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void *osty_gc_alloc_pinned_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_pinned_v1"));
 void osty_gc_pre_write_v1(void *owner, void *old_value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.pre_write_v1"));
 void osty_gc_post_write_v1(void *owner, void *value, int64_t slot_kind) __asm__(OSTY_GC_SYMBOL("osty.gc.post_write_v1"));
 void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
@@ -5641,6 +6198,16 @@ void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site)
         osty_rt_abort("negative GC allocation size");
     }
     return osty_gc_allocate_managed((size_t)byte_size, object_kind == 0 ? OSTY_GC_KIND_GENERIC : object_kind, site, NULL, NULL);
+}
+
+void *osty_gc_alloc_pinned_v1(int64_t object_kind, int64_t byte_size, const char *site) {
+    if (byte_size < 0) {
+        osty_rt_abort("negative GC pinned allocation size");
+    }
+    return osty_gc_allocate_pinned_managed(
+        (size_t)byte_size,
+        object_kind == 0 ? OSTY_GC_KIND_GENERIC : object_kind, site, NULL,
+        NULL);
 }
 
 static void osty_rt_enum_ptr_payload_trace(void *payload) {
@@ -6334,6 +6901,42 @@ int64_t osty_gc_debug_tlab_refill_count_total(void) {
     return osty_gc_tlab_refill_count_total;
 }
 
+int64_t osty_gc_debug_bump_recycled_block_count_total(void) {
+    return osty_gc_bump_recycled_block_count_total;
+}
+
+int64_t osty_gc_debug_bump_recycled_bytes_total(void) {
+    return osty_gc_bump_recycled_bytes_total;
+}
+
+int64_t osty_gc_debug_survivor_bump_block_count(void) {
+    return osty_gc_survivor_bump_block_count;
+}
+
+int64_t osty_gc_debug_survivor_bump_block_bytes_total(void) {
+    return osty_gc_survivor_bump_block_bytes_total;
+}
+
+int64_t osty_gc_debug_survivor_bump_alloc_count_total(void) {
+    return osty_gc_survivor_bump_alloc_count_total;
+}
+
+int64_t osty_gc_debug_survivor_bump_alloc_bytes_total(void) {
+    return osty_gc_survivor_bump_alloc_bytes_total;
+}
+
+int64_t osty_gc_debug_survivor_tlab_refill_count_total(void) {
+    return osty_gc_survivor_tlab_refill_count_total;
+}
+
+int64_t osty_gc_debug_survivor_bump_recycled_block_count_total(void) {
+    return osty_gc_survivor_bump_recycled_block_count_total;
+}
+
+int64_t osty_gc_debug_survivor_bump_recycled_bytes_total(void) {
+    return osty_gc_survivor_bump_recycled_bytes_total;
+}
+
 int64_t osty_gc_debug_old_bump_block_count(void) {
     return osty_gc_old_bump_block_count;
 }
@@ -6350,12 +6953,44 @@ int64_t osty_gc_debug_old_bump_alloc_bytes_total(void) {
     return osty_gc_old_bump_alloc_bytes_total;
 }
 
+int64_t osty_gc_debug_old_tlab_refill_count_total(void) {
+    return osty_gc_old_tlab_refill_count_total;
+}
+
 int64_t osty_gc_debug_old_bump_recycled_block_count_total(void) {
     return osty_gc_old_bump_recycled_block_count_total;
 }
 
 int64_t osty_gc_debug_old_bump_recycled_bytes_total(void) {
     return osty_gc_old_bump_recycled_bytes_total;
+}
+
+int64_t osty_gc_debug_pinned_bump_block_count(void) {
+    return osty_gc_pinned_bump_block_count;
+}
+
+int64_t osty_gc_debug_pinned_bump_block_bytes_total(void) {
+    return osty_gc_pinned_bump_block_bytes_total;
+}
+
+int64_t osty_gc_debug_pinned_bump_alloc_count_total(void) {
+    return osty_gc_pinned_bump_alloc_count_total;
+}
+
+int64_t osty_gc_debug_pinned_bump_alloc_bytes_total(void) {
+    return osty_gc_pinned_bump_alloc_bytes_total;
+}
+
+int64_t osty_gc_debug_pinned_tlab_refill_count_total(void) {
+    return osty_gc_pinned_tlab_refill_count_total;
+}
+
+int64_t osty_gc_debug_pinned_bump_recycled_block_count_total(void) {
+    return osty_gc_pinned_bump_recycled_block_count_total;
+}
+
+int64_t osty_gc_debug_pinned_bump_recycled_bytes_total(void) {
+    return osty_gc_pinned_bump_recycled_bytes_total;
 }
 
 int64_t osty_gc_debug_humongous_threshold_bytes(void) {
@@ -7046,12 +7681,29 @@ int64_t osty_gc_debug_validate_heap(void) {
         osty_gc_bump_alloc_count_total < 0 ||
         osty_gc_bump_alloc_bytes_total < 0 ||
         osty_gc_tlab_refill_count_total < 0 ||
+        osty_gc_bump_recycled_block_count_total < 0 ||
+        osty_gc_bump_recycled_bytes_total < 0 ||
+        osty_gc_survivor_bump_block_count < 0 ||
+        osty_gc_survivor_bump_block_bytes_total < 0 ||
+        osty_gc_survivor_bump_alloc_count_total < 0 ||
+        osty_gc_survivor_bump_alloc_bytes_total < 0 ||
+        osty_gc_survivor_tlab_refill_count_total < 0 ||
+        osty_gc_survivor_bump_recycled_block_count_total < 0 ||
+        osty_gc_survivor_bump_recycled_bytes_total < 0 ||
         osty_gc_old_bump_block_count < 0 ||
         osty_gc_old_bump_block_bytes_total < 0 ||
         osty_gc_old_bump_alloc_count_total < 0 ||
         osty_gc_old_bump_alloc_bytes_total < 0 ||
+        osty_gc_old_tlab_refill_count_total < 0 ||
         osty_gc_old_bump_recycled_block_count_total < 0 ||
         osty_gc_old_bump_recycled_bytes_total < 0 ||
+        osty_gc_pinned_bump_block_count < 0 ||
+        osty_gc_pinned_bump_block_bytes_total < 0 ||
+        osty_gc_pinned_bump_alloc_count_total < 0 ||
+        osty_gc_pinned_bump_alloc_bytes_total < 0 ||
+        osty_gc_pinned_tlab_refill_count_total < 0 ||
+        osty_gc_pinned_bump_recycled_block_count_total < 0 ||
+        osty_gc_pinned_bump_recycled_bytes_total < 0 ||
         osty_gc_humongous_alloc_count_total < 0 ||
         osty_gc_humongous_alloc_bytes_total < 0 ||
         osty_gc_humongous_swept_count_total < 0 ||


### PR DESCRIPTION
## What changed
- finish the remaining Phase D allocator/runtime tail in `osty_runtime.c`
- add explicit pinned-region allocation support via `osty.gc.alloc_pinned_v1`
- split survivor/old/pinned bump allocation through region-specific TLAB current blocks and counters
- complete pinned/young/old/survivor region-local recycle paths and expose debug accessors
- add backend harnesses covering survivor/old TLAB counters plus pinned-region and pinned-TLAB behavior
- update `RUNTIME_GC_DELTA.md` to mark the allocator tail closed and describe the remaining follow-up work

## Why
The runtime had already accumulated most of the allocator-tail machinery, but the remaining pinned-region/TLAB/recycle pieces still needed to be proven end-to-end and reflected in the phase-tracking docs. This closes the runtime-side Phase D tail so follow-up work can focus on lowering and further policy tuning instead of missing allocator primitives.

## Impact
- runtime now supports born-pinned allocation through a dedicated ABI entrypoint
- survivor/old/pinned bump regions expose per-thread refill observability like young bump already did
- pinned region-local recycle is covered by backend tests and no longer sits in the Phase D tail bucket

## Validation
- `git diff --check`
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntime(PinnedAllocatorUsesPinnedRegionPhaseD|PinnedAllocatorThreadLocalTlabPhaseD|MinorCopiesYoungSurvivorsIntoSurvivorRegionPhaseD|CompactionUsesOldBumpRegionPhaseD)'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntime'`