### PR TITLE
[codex] stabilize llvmgen support snapshot drift

### DIFF
--- a/internal/llvmgen/field_call_dispatch_test.go
+++ b/internal/llvmgen/field_call_dispatch_test.go
@@ -1092,9 +1092,11 @@ func TestGenerateMapForInLowersAsIndexedWalk(t *testing.T) {
 	}
 }
 
-// TestGenerateMapGetBoolValueUses1ByteBox exercises i1 V: byte size
-// drops to 1, but otherwise the same branch+box shape applies.
-func TestGenerateMapGetBoolValueUses1ByteBox(t *testing.T) {
+// TestGenerateMapGetBoolValueUses1ByteStackSlot exercises the scalar
+// getOr fast path for i1 V: the lookup writes into a 1-byte stack slot,
+// the hit branch loads the bool, and the miss branch falls back to the
+// literal default without allocating an Option box.
+func TestGenerateMapGetBoolValueUses1ByteStackSlot(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn flag(m: Map<String, Bool>, k: String) -> Bool {
     m.getOr(k, false)
 }
@@ -1108,7 +1110,7 @@ func TestGenerateMapGetBoolValueUses1ByteBox(t *testing.T) {
 	}
 	got := string(ir)
 	for _, want := range []string{
-		"call ptr @osty.gc.alloc_v1(i64 1, i64 1,",
+		"call i1 @osty_rt_map_get_string(",
 		"alloca i1",
 		"load i1, ptr",
 		"= phi i1 [",
@@ -1116,5 +1118,12 @@ func TestGenerateMapGetBoolValueUses1ByteBox(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "call ptr @osty.gc.alloc_v1") {
+		t.Fatalf("bool getOr should not allocate an Option box:\n%s", got)
+	}
+	if strings.Contains(got, "osty_rt_map_contains_string") ||
+		strings.Contains(got, "osty_rt_map_get_or_abort_string") {
+		t.Fatalf("bool getOr still routes through legacy helpers:\n%s", got)
 	}
 }

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -347,7 +347,7 @@ var (
 // tolerates unknown kinds by falling back to UNSPECIFIED, so rolling
 // the encoding forward for future kinds does not break older runtimes
 // shipped alongside this LLVM output.
-func encodeSafepointID(kind safepointKind, serial int) int64 {
+func encodeSafepointID(kind safepointKind, serial int) int {
 	return llvmEncodeSafepointId(int(kind), serial)
 }
 

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -24,50 +24,50 @@ func ostyToString(v any) string {
 	return fmt.Sprint(v)
 }
 
-// Osty: toolchain/llvmgen.osty:11:5
+// Osty: toolchain/llvmgen.osty:9:5
 type LlvmValue struct {
 	typ     string
 	name    string
 	pointer bool
 }
 
-// Osty: toolchain/llvmgen.osty:17:5
+// Osty: toolchain/llvmgen.osty:15:5
 type LlvmParam struct {
 	name string
 	typ  string
 }
 
-// Osty: toolchain/llvmgen.osty:22:5
+// Osty: toolchain/llvmgen.osty:20:5
 type LlvmBinding struct {
 	name  string
 	value *LlvmValue
 }
 
-// Osty: toolchain/llvmgen.osty:27:5
+// Osty: toolchain/llvmgen.osty:25:5
 type LlvmLookup struct {
 	found bool
 	value *LlvmValue
 }
 
-// Osty: toolchain/llvmgen.osty:32:5
+// Osty: toolchain/llvmgen.osty:30:5
 type LlvmStringGlobal struct {
 	name    string
 	encoded string
 	byteLen int
 }
 
-// Osty: toolchain/llvmgen.osty:38:5
+// Osty: toolchain/llvmgen.osty:36:5
 type LlvmStructField struct {
 	typ string
 }
 
-// Osty: toolchain/llvmgen.osty:42:5
+// Osty: toolchain/llvmgen.osty:40:5
 type LlvmCString struct {
 	encoded string
 	byteLen int
 }
 
-// Osty: toolchain/llvmgen.osty:47:5
+// Osty: toolchain/llvmgen.osty:45:5
 type LlvmEmitter struct {
 	temp          int
 	label         int
@@ -77,14 +77,14 @@ type LlvmEmitter struct {
 	stringGlobals []*LlvmStringGlobal
 }
 
-// Osty: toolchain/llvmgen.osty:56:5
+// Osty: toolchain/llvmgen.osty:54:5
 type LlvmIfLabels struct {
 	thenLabel string
 	elseLabel string
 	endLabel  string
 }
 
-// Osty: toolchain/llvmgen.osty:62:5
+// Osty: toolchain/llvmgen.osty:60:5
 type LlvmRangeLoop struct {
 	condLabel string
 	bodyLabel string
@@ -93,14 +93,14 @@ type LlvmRangeLoop struct {
 	current   string
 }
 
-// Osty: toolchain/llvmgen.osty:70:5
+// Osty: toolchain/llvmgen.osty:68:5
 type LlvmSmokeExecutableCase struct {
 	name    string
 	fixture string
 	stdout  string
 }
 
-// Osty: toolchain/llvmgen.osty:76:5
+// Osty: toolchain/llvmgen.osty:74:5
 type LlvmUnsupportedDiagnostic struct {
 	code    string
 	kind    string
@@ -108,129 +108,124 @@ type LlvmUnsupportedDiagnostic struct {
 	hint    string
 }
 
-// Osty: toolchain/llvmgen.osty:83:5
+// Osty: toolchain/llvmgen.osty:85:5
+type LlvmSafepointChunk struct {
+	start int
+	end   int
+	id    int
+}
+
+// Osty: toolchain/llvmgen.osty:92:5
 func llvmEmitter() *LlvmEmitter {
 	return &LlvmEmitter{temp: 0, label: 0, stringId: 0, body: make([]string, 0, 1), locals: make([]*LlvmBinding, 0, 1), stringGlobals: make([]*LlvmStringGlobal, 0, 1)}
 }
 
-// Osty: toolchain/llvmgen.osty:94:5
+// Osty: toolchain/llvmgen.osty:92:5
 func llvmI64(name string) *LlvmValue {
 	return &LlvmValue{typ: "i64", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:98:5
+// Osty: toolchain/llvmgen.osty:96:5
 func llvmI1(name string) *LlvmValue {
 	return &LlvmValue{typ: "i1", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:102:5
+// Osty: toolchain/llvmgen.osty:100:5
 func llvmF64(name string) *LlvmValue {
 	return &LlvmValue{typ: "double", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:106:5
+// Osty: toolchain/llvmgen.osty:104:5
 func llvmIntLiteral(value int) *LlvmValue {
 	return llvmI64(fmt.Sprintf("%s", ostyToString(value)))
 }
 
-// Osty: toolchain/llvmgen.osty:110:5
+// Osty: toolchain/llvmgen.osty:108:5
 func llvmFloatLiteral(value string) *LlvmValue {
 	return llvmF64(fmt.Sprintf("%s", ostyToString(value)))
 }
 
-// Osty: toolchain/llvmgen.osty:114:5
+// Osty: toolchain/llvmgen.osty:112:5
 func llvmEnumVariant(enumName string, tag int) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:115:5
+	// Osty: toolchain/llvmgen.osty:113:5
 	_ = enumName
 	return llvmI64(fmt.Sprintf("%s", ostyToString(tag)))
 }
 
-// Osty: toolchain/llvmgen.osty:119:5
+// Osty: toolchain/llvmgen.osty:117:5
 func llvmEnumPayloadVariant(emitter *LlvmEmitter, typ string, tag int, payload *LlvmValue) *LlvmValue {
 	return llvmStructLiteral(emitter, typ, []*LlvmValue{llvmEnumVariant(typ, tag), payload})
 }
 
-// Osty: toolchain/llvmgen.osty:135:5
 func llvmEnumBoxedPayloadVariant(emitter *LlvmEmitter, enumTyp string, tag int, payload *LlvmValue, site string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:142:5
-	symbol := func() string {
-		if payload.typ == "ptr" {
-			return "osty.rt.enum_alloc_ptr_v1"
-		} else {
-			return "osty.rt.enum_alloc_scalar_v1"
-		}
-	}()
-	_ = symbol
-	// Osty: toolchain/llvmgen.osty:147:5
+	symbol := "osty.rt.enum_alloc_scalar_v1"
+	if payload.typ == "ptr" {
+		symbol = "osty.rt.enum_alloc_ptr_v1"
+	}
 	heapPtr := llvmCall(emitter, "ptr", symbol, []*LlvmValue{llvmStringLiteral(emitter, site)})
-	_ = heapPtr
-	// Osty: toolchain/llvmgen.osty:153:5
 	llvmStore(emitter, heapPtr, payload)
 	return llvmStructLiteral(emitter, enumTyp, []*LlvmValue{llvmEnumVariant(enumTyp, tag), heapPtr})
 }
 
-// Osty: toolchain/llvmgen.osty:160:5
 func llvmEnumBoxedBareVariant(emitter *LlvmEmitter, enumTyp string, tag int) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:165:5
 	nullPtr := &LlvmValue{typ: "ptr", name: "null", pointer: false}
-	_ = nullPtr
 	return llvmStructLiteral(emitter, enumTyp, []*LlvmValue{llvmEnumVariant(enumTyp, tag), nullPtr})
 }
 
-// Osty: toolchain/llvmgen.osty:169:5
+// Osty: toolchain/llvmgen.osty:126:5
 func llvmParam(name string, typ string) *LlvmParam {
 	return &LlvmParam{name: name, typ: typ}
 }
 
-// Osty: toolchain/llvmgen.osty:173:5
+// Osty: toolchain/llvmgen.osty:130:5
 func llvmBind(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:174:5
+	// Osty: toolchain/llvmgen.osty:131:5
 	func() struct{} {
 		emitter.locals = append(emitter.locals, &LlvmBinding{name: name, value: value})
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:177:5
+// Osty: toolchain/llvmgen.osty:134:5
 func llvmLookup(emitter *LlvmEmitter, name string) *LlvmLookup {
-	// Osty: toolchain/llvmgen.osty:178:5
+	// Osty: toolchain/llvmgen.osty:135:5
 	out := &LlvmLookup{found: false, value: llvmI64("0")}
 	_ = out
-	// Osty: toolchain/llvmgen.osty:179:5
+	// Osty: toolchain/llvmgen.osty:136:5
 	for _, binding := range emitter.locals {
-		// Osty: toolchain/llvmgen.osty:180:9
+		// Osty: toolchain/llvmgen.osty:137:9
 		if binding.name == name {
-			// Osty: toolchain/llvmgen.osty:181:13
+			// Osty: toolchain/llvmgen.osty:138:13
 			out = &LlvmLookup{found: true, value: binding.value}
 		}
 	}
 	return out
 }
 
-// Osty: toolchain/llvmgen.osty:187:5
+// Osty: toolchain/llvmgen.osty:144:5
 func llvmIdent(emitter *LlvmEmitter, name string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:188:5
+	// Osty: toolchain/llvmgen.osty:145:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: toolchain/llvmgen.osty:189:5
+	// Osty: toolchain/llvmgen.osty:146:5
 	if !(lookup.found) {
-		// Osty: toolchain/llvmgen.osty:190:9
+		// Osty: toolchain/llvmgen.osty:147:9
 		return llvmI64("0")
 	}
-	// Osty: toolchain/llvmgen.osty:192:5
+	// Osty: toolchain/llvmgen.osty:149:5
 	if lookup.value.pointer {
-		// Osty: toolchain/llvmgen.osty:193:9
+		// Osty: toolchain/llvmgen.osty:150:9
 		return llvmLoad(emitter, lookup.value)
 	}
 	return lookup.value
 }
 
-// Osty: toolchain/llvmgen.osty:198:5
+// Osty: toolchain/llvmgen.osty:155:5
 func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:199:5
+	// Osty: toolchain/llvmgen.osty:156:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:200:5
+	// Osty: toolchain/llvmgen.osty:157:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(slot.typ), ostyToString(slot.name)))
 		return struct{}{}
@@ -238,137 +233,102 @@ func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
 	return &LlvmValue{typ: slot.typ, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:204:5
-func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:209:5
-	ptr := llvmNextTemp(emitter)
-	_ = ptr
-	// Osty: toolchain/llvmgen.osty:210:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(ptr), ostyToString(initial.typ)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:211:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(initial.typ), ostyToString(initial.name), ostyToString(ptr)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:212:5
-	slot := &LlvmValue{typ: initial.typ, name: ptr, pointer: true}
-	_ = slot
-	// Osty: toolchain/llvmgen.osty:213:5
-	llvmBind(emitter, name, slot)
-	return slot
-}
-
-// Osty: toolchain/llvmgen.osty:217:5
-func llvmMutableLet(emitter *LlvmEmitter, name string, initial *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:218:5
-	_slot := llvmMutableLetSlot(emitter, name, initial)
-	_ = _slot
-}
-
-// Osty: toolchain/llvmgen.osty:221:5
-func llvmStore(emitter *LlvmEmitter, slot *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:222:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(slot.name)))
-		return struct{}{}
-	}()
-}
-
-// Osty: toolchain/llvmgen.osty:230:5
+// Osty: toolchain/llvmgen.osty:161:5
 func llvmSlotAsPtr(slot *LlvmValue) *LlvmValue {
 	return &LlvmValue{typ: "ptr", name: slot.name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:238:5
 func llvmAllocaSlot(emitter *LlvmEmitter, llvmType string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:239:5
 	slot := llvmNextTemp(emitter)
-	_ = slot
-	// Osty: toolchain/llvmgen.osty:240:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(slot), ostyToString(llvmType)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, llvmType))
 	return &LlvmValue{typ: "ptr", name: slot, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:248:5
 func llvmSpillToSlot(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:249:5
 	slot := llvmAllocaSlot(emitter, value.typ)
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", value.typ, value.name, slot.name))
+	return slot
+}
+
+func llvmLoadFromSlot(emitter *LlvmEmitter, slot *LlvmValue, llvmType string) *LlvmValue {
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, llvmType, slot.name))
+	return &LlvmValue{typ: llvmType, name: tmp, pointer: false}
+}
+
+func llvmSizeOf(emitter *LlvmEmitter, llvmType string) *LlvmValue {
+	gep := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", gep, llvmType))
+	size := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", size, gep))
+	return &LlvmValue{typ: "i64", name: size, pointer: false}
+}
+
+func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:166:5
+	ptr := llvmNextTemp(emitter)
+	_ = ptr
+	// Osty: toolchain/llvmgen.osty:167:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(ptr), ostyToString(initial.typ)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:168:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(initial.typ), ostyToString(initial.name), ostyToString(ptr)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:169:5
+	slot := &LlvmValue{typ: initial.typ, name: ptr, pointer: true}
 	_ = slot
-	// Osty: toolchain/llvmgen.osty:250:5
+	// Osty: toolchain/llvmgen.osty:170:5
+	llvmBind(emitter, name, slot)
+	return slot
+}
+
+// Osty: toolchain/llvmgen.osty:174:5
+func llvmMutableLet(emitter *LlvmEmitter, name string, initial *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:175:5
+	_slot := llvmMutableLetSlot(emitter, name, initial)
+	_ = _slot
+}
+
+// Osty: toolchain/llvmgen.osty:178:5
+func llvmStore(emitter *LlvmEmitter, slot *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:179:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(slot.name)))
 		return struct{}{}
 	}()
-	return slot
 }
 
-// Osty: toolchain/llvmgen.osty:258:5
-func llvmLoadFromSlot(emitter *LlvmEmitter, slot *LlvmValue, llvmType string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:263:5
-	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:264:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(llvmType), ostyToString(slot.name)))
-		return struct{}{}
-	}()
-	return &LlvmValue{typ: llvmType, name: tmp, pointer: false}
-}
-
-// Osty: toolchain/llvmgen.osty:273:5
-func llvmSizeOf(emitter *LlvmEmitter, llvmType string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:274:5
-	gep := llvmNextTemp(emitter)
-	_ = gep
-	// Osty: toolchain/llvmgen.osty:275:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", ostyToString(gep), ostyToString(llvmType)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:276:5
-	size := llvmNextTemp(emitter)
-	_ = size
-	// Osty: toolchain/llvmgen.osty:277:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", ostyToString(size), ostyToString(gep)))
-		return struct{}{}
-	}()
-	return &LlvmValue{typ: "i64", name: size, pointer: false}
-}
-
-// Osty: toolchain/llvmgen.osty:281:5
+// Osty: toolchain/llvmgen.osty:182:5
 func llvmAssign(emitter *LlvmEmitter, name string, value *LlvmValue) bool {
-	// Osty: toolchain/llvmgen.osty:282:5
+	// Osty: toolchain/llvmgen.osty:183:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: toolchain/llvmgen.osty:283:5
+	// Osty: toolchain/llvmgen.osty:184:5
 	if !(lookup.found) || !(lookup.value.pointer) || lookup.value.typ != value.typ {
-		// Osty: toolchain/llvmgen.osty:284:9
+		// Osty: toolchain/llvmgen.osty:185:9
 		return false
 	}
-	// Osty: toolchain/llvmgen.osty:286:5
+	// Osty: toolchain/llvmgen.osty:187:5
 	llvmStore(emitter, lookup.value, value)
 	return true
 }
 
-// Osty: toolchain/llvmgen.osty:290:5
+// Osty: toolchain/llvmgen.osty:191:5
 func llvmImmutableLet(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:291:5
+	// Osty: toolchain/llvmgen.osty:192:5
 	llvmBind(emitter, name, value)
 }
 
-// Osty: toolchain/llvmgen.osty:298:5
+// Osty: toolchain/llvmgen.osty:199:5
 func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:304:5
+	// Osty: toolchain/llvmgen.osty:205:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:305:5
+	// Osty: toolchain/llvmgen.osty:206:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i64 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -376,12 +336,12 @@ func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI64(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:309:5
+// Osty: toolchain/llvmgen.osty:210:5
 func llvmBinaryF64(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:315:5
+	// Osty: toolchain/llvmgen.osty:216:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:316:5
+	// Osty: toolchain/llvmgen.osty:217:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s double %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -389,12 +349,12 @@ func llvmBinaryF64(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmF64(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:320:5
+// Osty: toolchain/llvmgen.osty:221:5
 func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:326:5
+	// Osty: toolchain/llvmgen.osty:227:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:327:5
+	// Osty: toolchain/llvmgen.osty:228:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s %s %s, %s", ostyToString(tmp), ostyToString(pred), ostyToString(left.typ), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -402,12 +362,12 @@ func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:331:5
+// Osty: toolchain/llvmgen.osty:232:5
 func llvmCompareF64(emitter *LlvmEmitter, pred string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:337:5
+	// Osty: toolchain/llvmgen.osty:238:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:338:5
+	// Osty: toolchain/llvmgen.osty:239:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = fcmp %s double %s, %s", ostyToString(tmp), ostyToString(pred), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -415,12 +375,12 @@ func llvmCompareF64(emitter *LlvmEmitter, pred string, left *LlvmValue, right *L
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:342:5
+// Osty: toolchain/llvmgen.osty:243:5
 func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:343:5
+	// Osty: toolchain/llvmgen.osty:244:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:344:5
+	// Osty: toolchain/llvmgen.osty:245:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = xor i1 %s, true", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
@@ -428,12 +388,12 @@ func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:348:5
+// Osty: toolchain/llvmgen.osty:249:5
 func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:354:5
+	// Osty: toolchain/llvmgen.osty:255:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:355:5
+	// Osty: toolchain/llvmgen.osty:256:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i1 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -441,12 +401,12 @@ func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:359:5
+// Osty: toolchain/llvmgen.osty:260:5
 func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:365:5
+	// Osty: toolchain/llvmgen.osty:266:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:366:5
+	// Osty: toolchain/llvmgen.osty:267:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s @%s(%s)", ostyToString(tmp), ostyToString(ret), ostyToString(name), ostyToString(llvmCallArgs(args))))
 		return struct{}{}
@@ -454,320 +414,198 @@ func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) 
 	return &LlvmValue{typ: ret, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:370:5
+// Osty: toolchain/llvmgen.osty:271:5
 func llvmCallVoid(emitter *LlvmEmitter, name string, args []*LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:371:5
+	// Osty: toolchain/llvmgen.osty:272:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", ostyToString(name), ostyToString(llvmCallArgs(args))))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:374:5
+// Osty: toolchain/llvmgen.osty:275:5
 func llvmGcRuntimeDeclarations() []string {
 	return []string{"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)", "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)", "declare void @osty.gc.post_write_v1(ptr, ptr, i64)", "declare ptr @osty.gc.load_v1(ptr)", "declare void @osty.gc.root_bind_v1(ptr)", "declare void @osty.gc.root_release_v1(ptr)", "declare ptr @osty.rt.enum_alloc_ptr_v1(ptr)", "declare ptr @osty.rt.enum_alloc_scalar_v1(ptr)"}
 }
 
-// Osty: toolchain/llvmgen.osty:387:5
+// Osty: toolchain/llvmgen.osty:284:5
 func llvmGcAlloc(emitter *LlvmEmitter, objectKind int, byteSize int, site string) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty.gc.alloc_v1", []*LlvmValue{llvmIntLiteral(objectKind), llvmIntLiteral(byteSize), llvmStringLiteral(emitter, site)})
 }
 
-// Osty: toolchain/llvmgen.osty:405:5
+// Osty: toolchain/llvmgen.osty:302:5
 func llvmGcPostWrite(emitter *LlvmEmitter, owner *LlvmValue, value *LlvmValue, slotKind int) {
-	// Osty: toolchain/llvmgen.osty:411:5
+	// Osty: toolchain/llvmgen.osty:308:5
 	llvmCallVoid(emitter, "osty.gc.post_write_v1", []*LlvmValue{owner, value, llvmIntLiteral(slotKind)})
 }
 
-// Osty: toolchain/llvmgen.osty:422:5
+// Osty: toolchain/llvmgen.osty:319:5
 func llvmGcPreWrite(emitter *LlvmEmitter, owner *LlvmValue, value *LlvmValue, slotKind int) {
-	// Osty: toolchain/llvmgen.osty:428:5
+	// Osty: toolchain/llvmgen.osty:325:5
 	llvmCallVoid(emitter, "osty.gc.pre_write_v1", []*LlvmValue{owner, value, llvmIntLiteral(slotKind)})
 }
 
-// Osty: toolchain/llvmgen.osty:439:5
+// Osty: toolchain/llvmgen.osty:336:5
 func llvmGcLoad(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty.gc.load_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:443:5
+// Osty: toolchain/llvmgen.osty:340:5
 func llvmGcRootBind(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:444:5
+	// Osty: toolchain/llvmgen.osty:341:5
 	llvmCallVoid(emitter, "osty.gc.root_bind_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:447:5
+// Osty: toolchain/llvmgen.osty:344:5
 func llvmGcRootRelease(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:448:5
+	// Osty: toolchain/llvmgen.osty:345:5
 	llvmCallVoid(emitter, "osty.gc.root_release_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:460:5
-func llvmSafepointKindUnspecified() int {
-	return 0
-}
+// Osty: toolchain/llvmgen.osty:455:5
+func llvmSafepointKindUnspecified() int { return 0 }
 
-// Osty: toolchain/llvmgen.osty:462:5
-func llvmSafepointKindEntry() int {
-	return 1
-}
+// Osty: toolchain/llvmgen.osty:457:5
+func llvmSafepointKindEntry() int { return 1 }
 
-// Osty: toolchain/llvmgen.osty:464:5
-func llvmSafepointKindCall() int {
-	return 2
-}
+// Osty: toolchain/llvmgen.osty:459:5
+func llvmSafepointKindCall() int { return 2 }
 
-// Osty: toolchain/llvmgen.osty:466:5
-func llvmSafepointKindLoop() int {
-	return 3
-}
+// Osty: toolchain/llvmgen.osty:461:5
+func llvmSafepointKindLoop() int { return 3 }
 
-// Osty: toolchain/llvmgen.osty:468:5
-func llvmSafepointKindAlloc() int {
-	return 4
-}
+// Osty: toolchain/llvmgen.osty:463:5
+func llvmSafepointKindAlloc() int { return 4 }
 
-// Osty: toolchain/llvmgen.osty:470:5
-func llvmSafepointKindYield() int {
-	return 5
-}
+// Osty: toolchain/llvmgen.osty:465:5
+func llvmSafepointKindYield() int { return 5 }
 
-// Osty: toolchain/llvmgen.osty:477:5
+// Osty: toolchain/llvmgen.osty:472:5
 func llvmEncodeSafepointId(kind int, serial int) int {
-	// Osty: toolchain/llvmgen.osty:478:5
-	mask := func() int {
-		var _p1 int = (1 << 56)
-		var _rhs2 int = 1
-		if _rhs2 < 0 && _p1 > math.MaxInt+_rhs2 {
-			panic("integer overflow")
-		}
-		if _rhs2 > 0 && _p1 < math.MinInt+_rhs2 {
-			panic("integer overflow")
-		}
-		return _p1 - _rhs2
-	}()
-	_ = mask
-	return (kind << 56) | (serial & mask)
+	const mask int64 = (int64(1) << 56) - 1
+	return int((int64(kind) << 56) | (int64(serial) & mask))
 }
 
-// Osty: toolchain/llvmgen.osty:492:5
-func llvmSafepointDefaultRootChunkSize() int {
-	return 4096
-}
-
-// Osty: toolchain/llvmgen.osty:497:5
-type LlvmSafepointChunk struct {
-	start int
-	end   int
-	id    int
-}
+// Osty: toolchain/llvmgen.osty:487:5
+func llvmSafepointDefaultRootChunkSize() int { return 4096 }
 
 // Osty: toolchain/llvmgen.osty:510:5
 func llvmPlanSafepointChunks(kind int, firstSerial int, rootCount int, chunkSize int) []*LlvmSafepointChunk {
-	// Osty: toolchain/llvmgen.osty:516:5
-	var chunks []*LlvmSafepointChunk = make([]*LlvmSafepointChunk, 0, 1)
-	_ = chunks
-	// Osty: toolchain/llvmgen.osty:517:5
+	chunks := make([]*LlvmSafepointChunk, 0, 1)
 	if rootCount <= 0 {
-		// Osty: toolchain/llvmgen.osty:518:9
 		return chunks
 	}
-	// Osty: toolchain/llvmgen.osty:520:5
-	size := func() int {
-		if chunkSize <= 0 {
-			return rootCount
-		} else {
-			return chunkSize
-		}
-	}()
-	_ = size
-	// Osty: toolchain/llvmgen.osty:521:5
+	size := chunkSize
+	if chunkSize <= 0 {
+		size = rootCount
+	}
 	serial := firstSerial
-	_ = serial
-	// Osty: toolchain/llvmgen.osty:522:5
 	for start := 0; start < rootCount; start++ {
-		// Osty: toolchain/llvmgen.osty:523:9
-		if func() int {
-			var _p3 int = start
-			var _rhs4 int = size
-			if _rhs4 == 0 {
-				panic("integer modulo by zero")
-			}
-			if _p3 == math.MinInt && _rhs4 == int(-1) {
-				panic("integer overflow")
-			}
-			return _p3 % _rhs4
-		}() != 0 {
-			// Osty: toolchain/llvmgen.osty:524:13
+		if start%size != 0 {
 			continue
 		}
-		// Osty: toolchain/llvmgen.osty:526:9
-		end := func() int {
-			var _p5 int = start
-			var _rhs6 int = size
-			if _rhs6 > 0 && _p5 > math.MaxInt-_rhs6 {
-				panic("integer overflow")
-			}
-			if _rhs6 < 0 && _p5 < math.MinInt-_rhs6 {
-				panic("integer overflow")
-			}
-			return _p5 + _rhs6
-		}()
-		_ = end
-		// Osty: toolchain/llvmgen.osty:527:9
+		end := start + size
 		if end > rootCount {
-			// Osty: toolchain/llvmgen.osty:528:13
 			end = rootCount
 		}
-		// Osty: toolchain/llvmgen.osty:530:9
-		func() struct{} {
-			chunks = append(chunks, &LlvmSafepointChunk{start: start, end: end, id: llvmEncodeSafepointId(kind, serial)})
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:537:9
-		func() {
-			var _cur7 int = serial
-			var _rhs8 int = 1
-			if _rhs8 > 0 && _cur7 > math.MaxInt-_rhs8 {
-				panic("integer overflow")
-			}
-			if _rhs8 < 0 && _cur7 < math.MinInt-_rhs8 {
-				panic("integer overflow")
-			}
-			serial = _cur7 + _rhs8
-		}()
+		chunks = append(chunks, &LlvmSafepointChunk{
+			start: start,
+			end:   end,
+			id:    llvmEncodeSafepointId(kind, serial),
+		})
+		serial++
 	}
 	return chunks
 }
 
+// Osty: toolchain/llvmgen.osty:535:5
+func llvmClosureEnvGcKind() int { return 1029 }
+
+// Osty: toolchain/llvmgen.osty:542:5
+func llvmClosureEnvPhase1CaptureCount() int { return 0 }
+
 // Osty: toolchain/llvmgen.osty:551:5
-func llvmClosureEnvGcKind() int {
-	return 1029
-}
-
-// Osty: toolchain/llvmgen.osty:558:5
-func llvmClosureEnvPhase1CaptureCount() int {
-	return 0
-}
-
-// Osty: toolchain/llvmgen.osty:569:5
 func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:575:5
 	envTemp := llvmNextTemp(emitter)
-	_ = envTemp
-	// Osty: toolchain/llvmgen.osty:576:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %s, ptr %s)", ostyToString(envTemp), ostyToString(captureCount), ostyToString(siteName)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:579:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", ostyToString(thunkSymbol), ostyToString(envTemp)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %d, ptr %s)", envTemp, captureCount, siteName))
+	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunkSymbol, envTemp))
 	return &LlvmValue{typ: "ptr", name: envTemp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:587:5
+// Osty: toolchain/llvmgen.osty:550:5
 func llvmRenderSafepointEmpty(id int) string {
-	return fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %s, ptr null, i64 0)", ostyToString(id))
+	return fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr null, i64 0)", id)
 }
 
-// Osty: toolchain/llvmgen.osty:594:5
+// Osty: toolchain/llvmgen.osty:558:5
 func llvmEmitSafepointEmpty(emitter *LlvmEmitter, id int) {
-	// Osty: toolchain/llvmgen.osty:595:5
-	func() struct{} { emitter.body = append(emitter.body, llvmRenderSafepointEmpty(id)); return struct{}{} }()
+	emitter.body = append(emitter.body, llvmRenderSafepointEmpty(id))
 }
 
-// Osty: toolchain/llvmgen.osty:604:5
+// Osty: toolchain/llvmgen.osty:560:5
 func llvmEmitSafepointWithRoots(emitter *LlvmEmitter, id int, rootAddresses []string) {
-	// Osty: toolchain/llvmgen.osty:609:5
 	count := len(rootAddresses)
-	_ = count
-	// Osty: toolchain/llvmgen.osty:610:5
 	slotsPtr := llvmNextTemp(emitter)
-	_ = slotsPtr
-	// Osty: toolchain/llvmgen.osty:611:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr, i64 %s", ostyToString(slotsPtr), ostyToString(count)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:612:5
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr, i64 %d", slotsPtr, count))
 	for i := 0; i < count; i++ {
-		// Osty: toolchain/llvmgen.osty:613:9
 		slotPtr := llvmNextTemp(emitter)
-		_ = slotPtr
-		// Osty: toolchain/llvmgen.osty:614:9
 		addr := rootAddresses[i]
-		_ = addr
-		// Osty: toolchain/llvmgen.osty:615:9
-		func() struct{} {
-			emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr ptr, ptr %s, i64 %s", ostyToString(slotPtr), ostyToString(slotsPtr), ostyToString(i)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:616:9
-		func() struct{} {
-			emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", ostyToString(addr), ostyToString(slotPtr)))
-			return struct{}{}
-		}()
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr ptr, ptr %s, i64 %d", slotPtr, slotsPtr, i))
+		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", addr, slotPtr))
 	}
-	// Osty: toolchain/llvmgen.osty:618:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %s, ptr %s, i64 %s)", ostyToString(id), ostyToString(slotsPtr), ostyToString(count)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr %s, i64 %d)", id, slotsPtr, count))
 }
 
-// Osty: toolchain/llvmgen.osty:623:5
+// Osty: toolchain/llvmgen.osty:327:5
 func llvmStructTypeDef(name string, fieldTypes []string) string {
-	// Osty: toolchain/llvmgen.osty:624:5
+	// Osty: toolchain/llvmgen.osty:328:5
 	fields := llvmStrings.Join(fieldTypes, ", ")
 	_ = fields
 	return fmt.Sprintf("%%%s = type { %s }", ostyToString(name), ostyToString(fields))
 }
 
-// Osty: toolchain/llvmgen.osty:628:5
+// Osty: toolchain/llvmgen.osty:332:5
 func llvmStructLiteral(emitter *LlvmEmitter, typ string, fields []*LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:633:5
+	// Osty: toolchain/llvmgen.osty:337:5
 	current := "undef"
 	_ = current
-	// Osty: toolchain/llvmgen.osty:634:5
+	// Osty: toolchain/llvmgen.osty:338:5
 	fieldIndex := 0
 	_ = fieldIndex
-	// Osty: toolchain/llvmgen.osty:635:5
+	// Osty: toolchain/llvmgen.osty:339:5
 	for _, field := range fields {
-		// Osty: toolchain/llvmgen.osty:636:9
+		// Osty: toolchain/llvmgen.osty:340:9
 		tmp := llvmNextTemp(emitter)
 		_ = tmp
-		// Osty: toolchain/llvmgen.osty:637:9
+		// Osty: toolchain/llvmgen.osty:341:9
 		func() struct{} {
 			emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %s %s, %s %s, %s", ostyToString(tmp), ostyToString(typ), ostyToString(current), ostyToString(field.typ), ostyToString(field.name), ostyToString(fieldIndex)))
 			return struct{}{}
 		}()
-		// Osty: toolchain/llvmgen.osty:640:9
+		// Osty: toolchain/llvmgen.osty:344:9
 		current = tmp
-		// Osty: toolchain/llvmgen.osty:641:9
+		// Osty: toolchain/llvmgen.osty:345:9
 		func() {
-			var _cur9 int = fieldIndex
-			var _rhs10 int = 1
-			if _rhs10 > 0 && _cur9 > math.MaxInt-_rhs10 {
+			var _cur1 int = fieldIndex
+			var _rhs2 int = 1
+			if _rhs2 > 0 && _cur1 > math.MaxInt-_rhs2 {
 				panic("integer overflow")
 			}
-			if _rhs10 < 0 && _cur9 < math.MinInt-_rhs10 {
+			if _rhs2 < 0 && _cur1 < math.MinInt-_rhs2 {
 				panic("integer overflow")
 			}
-			fieldIndex = _cur9 + _rhs10
+			fieldIndex = _cur1 + _rhs2
 		}()
 	}
 	return &LlvmValue{typ: typ, name: current, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:646:5
+// Osty: toolchain/llvmgen.osty:350:5
 func llvmExtractValue(emitter *LlvmEmitter, aggregate *LlvmValue, fieldType string, fieldIndex int) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:652:5
+	// Osty: toolchain/llvmgen.osty:356:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:653:5
+	// Osty: toolchain/llvmgen.osty:357:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %s %s, %s", ostyToString(tmp), ostyToString(aggregate.typ), ostyToString(aggregate.name), ostyToString(fieldIndex)))
 		return struct{}{}
@@ -775,12 +613,10 @@ func llvmExtractValue(emitter *LlvmEmitter, aggregate *LlvmValue, fieldType stri
 	return &LlvmValue{typ: fieldType, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:657:5
+// Osty: toolchain/llvmgen.osty:363:5
 func llvmInsertValue(emitter *LlvmEmitter, aggregate *LlvmValue, field *LlvmValue, fieldIndex int) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:663:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:664:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %s %s, %s %s, %s", ostyToString(tmp), ostyToString(aggregate.typ), ostyToString(aggregate.name), ostyToString(field.typ), ostyToString(field.name), ostyToString(fieldIndex)))
 		return struct{}{}
@@ -788,71 +624,71 @@ func llvmInsertValue(emitter *LlvmEmitter, aggregate *LlvmValue, field *LlvmValu
 	return &LlvmValue{typ: aggregate.typ, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:670:5
+// Osty: toolchain/llvmgen.osty:376:5
 func llvmPrintlnI64(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:671:5
+	// Osty: toolchain/llvmgen.osty:364:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:672:5
+	// Osty: toolchain/llvmgen.osty:365:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:675:5
+// Osty: toolchain/llvmgen.osty:368:5
 func llvmPrintlnF64(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:676:5
+	// Osty: toolchain/llvmgen.osty:369:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:677:5
+	// Osty: toolchain/llvmgen.osty:370:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_f64, double %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:680:5
+// Osty: toolchain/llvmgen.osty:372:5
 func llvmPrintlnBool(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:681:5
+	// Osty: toolchain/llvmgen.osty:373:5
 	text := llvmNextTemp(emitter)
 	_ = text
-	// Osty: toolchain/llvmgen.osty:682:5
+	// Osty: toolchain/llvmgen.osty:374:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, ptr @.bool_true, ptr @.bool_false", ostyToString(text), ostyToString(value.name)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:683:5
+	// Osty: toolchain/llvmgen.osty:375:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:684:5
+	// Osty: toolchain/llvmgen.osty:376:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %s)", ostyToString(tmp), ostyToString(text)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:687:5
+// Osty: toolchain/llvmgen.osty:373:5
 func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:688:5
+	// Osty: toolchain/llvmgen.osty:374:5
 	name := fmt.Sprintf("@.str%s", ostyToString(emitter.stringId))
 	_ = name
-	// Osty: toolchain/llvmgen.osty:689:12
+	// Osty: toolchain/llvmgen.osty:375:12
 	emitter.stringId = func() int {
-		var _p11 int = emitter.stringId
-		var _rhs12 int = 1
-		if _rhs12 > 0 && _p11 > math.MaxInt-_rhs12 {
+		var _p3 int = emitter.stringId
+		var _rhs4 int = 1
+		if _rhs4 > 0 && _p3 > math.MaxInt-_rhs4 {
 			panic("integer overflow")
 		}
-		if _rhs12 < 0 && _p11 < math.MinInt-_rhs12 {
+		if _rhs4 < 0 && _p3 < math.MinInt-_rhs4 {
 			panic("integer overflow")
 		}
-		return _p11 + _rhs12
+		return _p3 + _rhs4
 	}()
-	// Osty: toolchain/llvmgen.osty:690:5
+	// Osty: toolchain/llvmgen.osty:376:5
 	cstring := llvmCString(text)
 	_ = cstring
-	// Osty: toolchain/llvmgen.osty:691:5
+	// Osty: toolchain/llvmgen.osty:377:5
 	func() struct{} {
 		emitter.stringGlobals = append(emitter.stringGlobals, &LlvmStringGlobal{name: name, encoded: cstring.encoded, byteLen: cstring.byteLen})
 		return struct{}{}
@@ -860,117 +696,71 @@ func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
 	return &LlvmValue{typ: "ptr", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:697:5
+// Osty: toolchain/llvmgen.osty:383:5
+//
+// `byteLen` counts bytes (not runes) so LLVM IR globals sized as
+// `[N x i8]` stay correct for multi-byte UTF-8 text. The previous
+// `strings.Split(text, "")` path returned rune count, which was a
+// silent truncation for anything above U+007F.
 func llvmCString(text string) *LlvmCString {
-	// Osty: toolchain/llvmgen.osty:702:5
 	encoded := fmt.Sprintf("%s\\00", ostyToString(llvmCStringEscape(text)))
 	_ = encoded
-	// Osty: toolchain/llvmgen.osty:703:5
-	byteLen := func() int {
-		var _p13 int = len([]byte(text))
-		var _rhs14 int = 1
-		if _rhs14 > 0 && _p13 > math.MaxInt-_rhs14 {
-			panic("integer overflow")
-		}
-		if _rhs14 < 0 && _p13 < math.MinInt-_rhs14 {
-			panic("integer overflow")
-		}
-		return _p13 + _rhs14
-	}()
+	byteLen := len(text) + 1
 	_ = byteLen
 	return &LlvmCString{encoded: encoded, byteLen: byteLen}
 }
 
-// Osty: toolchain/llvmgen.osty:722:5
+// Osty: toolchain/llvmgen.osty:389:5
+//
+// Encodes `text` for an LLVM `c"..."` constant. Iterates over raw
+// bytes (not runes) so multi-byte UTF-8 code points emit one `\HH`
+// escape per byte — LLVM IR string globals are byte arrays, so that's
+// the right shape for downstream `getelementptr` + `printf`/runtime
+// helpers. Printable ASCII passes through verbatim; `"` and `\`
+// always escape; everything else (including 0x00–0x1F, 0x7F, and all
+// high bytes 0x80–0xFF) goes through `\HH`.
 func llvmCStringEscape(text string) string {
-	// Osty: toolchain/llvmgen.osty:726:5
-	var parts []string = make([]string, 0, 1)
-	_ = parts
-	// Osty: toolchain/llvmgen.osty:727:5
-	for _, b := range []byte(text) {
-		// Osty: toolchain/llvmgen.osty:728:9
-		func() struct{} { parts = append(parts, "\\"); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:729:9
-		func() struct{} { parts = append(parts, llvmHexByte(int(b))); return struct{}{} }()
+	var b llvmStrings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		switch {
+		case c == '"':
+			b.WriteString(`\22`)
+		case c == '\\':
+			b.WriteString(`\5C`)
+		case c >= 0x20 && c <= 0x7E:
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, `\%02X`, c)
+		}
 	}
-	return llvmStrings.Join(parts, "")
+	return b.String()
 }
 
-// Osty: toolchain/llvmgen.osty:734:1
-func llvmHexByte(n int) string {
-	// Osty: toolchain/llvmgen.osty:735:5
-	hi := func() int {
-		var _p15 int = (n / 16)
-		var _rhs16 int = 16
-		if _rhs16 == 0 {
-			panic("integer modulo by zero")
-		}
-		if _p15 == math.MinInt && _rhs16 == int(-1) {
-			panic("integer overflow")
-		}
-		return _p15 % _rhs16
-	}()
-	_ = hi
-	// Osty: toolchain/llvmgen.osty:736:5
-	lo := func() int {
-		var _p17 int = n
-		var _rhs18 int = 16
-		if _rhs18 == 0 {
-			panic("integer modulo by zero")
-		}
-		if _p17 == math.MinInt && _rhs18 == int(-1) {
-			panic("integer overflow")
-		}
-		return _p17 % _rhs18
-	}()
-	_ = lo
-	return fmt.Sprintf("%s%s", ostyToString(llvmHexDigit(hi)), ostyToString(llvmHexDigit(lo)))
-}
-
-// Osty: toolchain/llvmgen.osty:740:1
-func llvmHexDigit(n int) string {
-	return func() string {
-		if n < 10 {
-			return fmt.Sprintf("%s", ostyToString(n))
-		} else if n == 10 {
-			return "A"
-		} else if n == 11 {
-			return "B"
-		} else if n == 12 {
-			return "C"
-		} else if n == 13 {
-			return "D"
-		} else if n == 14 {
-			return "E"
-		} else {
-			return "F"
-		}
-	}()
-}
-
-// Osty: toolchain/llvmgen.osty:758:5
+// Osty: toolchain/llvmgen.osty:409:5
 func llvmPrintlnString(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:759:5
+	// Osty: toolchain/llvmgen.osty:410:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:760:5
+	// Osty: toolchain/llvmgen.osty:411:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:763:5
+// Osty: toolchain/llvmgen.osty:414:5
 func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: toolchain/llvmgen.osty:764:5
+	// Osty: toolchain/llvmgen.osty:415:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.then"), elseLabel: llvmNextLabel(emitter, "if.else"), endLabel: llvmNextLabel(emitter, "if.end")}
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:769:5
+	// Osty: toolchain/llvmgen.osty:420:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:770:5
+	// Osty: toolchain/llvmgen.osty:421:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -978,45 +768,45 @@ func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: toolchain/llvmgen.osty:774:5
+// Osty: toolchain/llvmgen.osty:425:5
 func llvmIfElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: toolchain/llvmgen.osty:775:5
+	// Osty: toolchain/llvmgen.osty:426:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:776:5
+	// Osty: toolchain/llvmgen.osty:427:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:779:5
+// Osty: toolchain/llvmgen.osty:430:5
 func llvmIfEnd(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: toolchain/llvmgen.osty:780:5
+	// Osty: toolchain/llvmgen.osty:431:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:781:5
+	// Osty: toolchain/llvmgen.osty:432:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:784:5
+// Osty: toolchain/llvmgen.osty:435:5
 func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: toolchain/llvmgen.osty:785:5
+	// Osty: toolchain/llvmgen.osty:436:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.expr.then"), elseLabel: llvmNextLabel(emitter, "if.expr.else"), endLabel: llvmNextLabel(emitter, "if.expr.end")}
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:790:5
+	// Osty: toolchain/llvmgen.osty:441:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:791:5
+	// Osty: toolchain/llvmgen.osty:442:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -1024,36 +814,36 @@ func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: toolchain/llvmgen.osty:795:5
+// Osty: toolchain/llvmgen.osty:446:5
 func llvmIfExprElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: toolchain/llvmgen.osty:796:5
+	// Osty: toolchain/llvmgen.osty:447:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:797:5
+	// Osty: toolchain/llvmgen.osty:448:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:800:5
+// Osty: toolchain/llvmgen.osty:451:5
 func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseValue *LlvmValue, labels *LlvmIfLabels) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:807:5
+	// Osty: toolchain/llvmgen.osty:458:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:808:5
+	// Osty: toolchain/llvmgen.osty:459:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:809:5
+	// Osty: toolchain/llvmgen.osty:460:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:810:5
+	// Osty: toolchain/llvmgen.osty:461:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]", ostyToString(tmp), ostyToString(typ), ostyToString(thenValue.name), ostyToString(labels.thenLabel), ostyToString(elseValue.name), ostyToString(labels.elseLabel)))
 		return struct{}{}
@@ -1061,287 +851,292 @@ func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseV
 	return &LlvmValue{typ: typ, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:816:5
+// Osty: toolchain/llvmgen.osty:467:5
 func llvmInclusiveRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue) *LlvmRangeLoop {
 	return llvmRangeStart(emitter, iterName, start, stop, true)
 }
 
-// Osty: toolchain/llvmgen.osty:825:5
+// Osty: toolchain/llvmgen.osty:476:5
 func llvmRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue, inclusive bool) *LlvmRangeLoop {
-	// Osty: toolchain/llvmgen.osty:832:5
+	// Osty: toolchain/llvmgen.osty:483:5
 	iterPtr := llvmNextTemp(emitter)
 	_ = iterPtr
-	// Osty: toolchain/llvmgen.osty:833:5
+	// Osty: toolchain/llvmgen.osty:484:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:834:5
+	// Osty: toolchain/llvmgen.osty:485:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(start.name), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:836:5
+	// Osty: toolchain/llvmgen.osty:487:5
 	loop := &LlvmRangeLoop{condLabel: llvmNextLabel(emitter, "for.cond"), bodyLabel: llvmNextLabel(emitter, "for.body"), endLabel: llvmNextLabel(emitter, "for.end"), iterPtr: iterPtr, current: ""}
 	_ = loop
-	// Osty: toolchain/llvmgen.osty:843:5
+	// Osty: toolchain/llvmgen.osty:494:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:844:5
+	// Osty: toolchain/llvmgen.osty:495:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:846:5
+	// Osty: toolchain/llvmgen.osty:497:5
 	current := llvmNextTemp(emitter)
 	_ = current
-	// Osty: toolchain/llvmgen.osty:847:5
+	// Osty: toolchain/llvmgen.osty:498:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", ostyToString(current), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:848:5
+	// Osty: toolchain/llvmgen.osty:499:5
 	cmp := llvmNextTemp(emitter)
 	_ = cmp
-	// Osty: toolchain/llvmgen.osty:849:5
+	// Osty: toolchain/llvmgen.osty:500:5
 	pred := "slt"
 	_ = pred
-	// Osty: toolchain/llvmgen.osty:850:5
+	// Osty: toolchain/llvmgen.osty:501:5
 	if inclusive {
-		// Osty: toolchain/llvmgen.osty:851:9
+		// Osty: toolchain/llvmgen.osty:502:9
 		pred = "sle"
 	}
-	// Osty: toolchain/llvmgen.osty:853:5
+	// Osty: toolchain/llvmgen.osty:504:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s i64 %s, %s", ostyToString(cmp), ostyToString(pred), ostyToString(current), ostyToString(stop.name)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:854:5
+	// Osty: toolchain/llvmgen.osty:505:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cmp), ostyToString(loop.bodyLabel), ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:855:5
+	// Osty: toolchain/llvmgen.osty:506:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.bodyLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:856:5
+	// Osty: toolchain/llvmgen.osty:507:5
 	llvmBind(emitter, iterName, llvmI64(current))
 	return &LlvmRangeLoop{condLabel: loop.condLabel, bodyLabel: loop.bodyLabel, endLabel: loop.endLabel, iterPtr: loop.iterPtr, current: current}
 }
 
-// Osty: toolchain/llvmgen.osty:867:5
+// Osty: toolchain/llvmgen.osty:518:5
 func llvmRangeEnd(emitter *LlvmEmitter, loop *LlvmRangeLoop) {
-	// Osty: toolchain/llvmgen.osty:868:5
+	// Osty: toolchain/llvmgen.osty:519:5
 	next := llvmNextTemp(emitter)
 	_ = next
-	// Osty: toolchain/llvmgen.osty:869:5
+	// Osty: toolchain/llvmgen.osty:520:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", ostyToString(next), ostyToString(loop.current)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:870:5
+	// Osty: toolchain/llvmgen.osty:521:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(next), ostyToString(loop.iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:871:5
+	// Osty: toolchain/llvmgen.osty:522:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:872:5
+	// Osty: toolchain/llvmgen.osty:523:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:875:5
+// Osty: toolchain/llvmgen.osty:526:5
 func llvmReturn(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:876:5
+	// Osty: toolchain/llvmgen.osty:527:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  ret %s %s", ostyToString(value.typ), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:879:5
+// Osty: toolchain/llvmgen.osty:530:5
 func llvmReturnI32Zero(emitter *LlvmEmitter) {
-	// Osty: toolchain/llvmgen.osty:880:5
+	// Osty: toolchain/llvmgen.osty:531:5
 	func() struct{} { emitter.body = append(emitter.body, "  ret i32 0"); return struct{}{} }()
 }
 
-// Osty: toolchain/llvmgen.osty:883:5
+// Osty: toolchain/llvmgen.osty:534:5
 func llvmRenderModule(sourcePath string, target string, definitions []string) string {
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, make([]string, 0, 1), make([]*LlvmStringGlobal, 0, 1), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:887:5
+// Osty: toolchain/llvmgen.osty:538:5
 func llvmRenderModuleWithGlobals(sourcePath string, target string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, make([]string, 0, 1), stringGlobals, definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:896:5
+// Osty: toolchain/llvmgen.osty:547:5
 func llvmRenderModuleWithGlobalsAndTypes(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, make([]string, 0, 1), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:913:5
+// Osty: toolchain/llvmgen.osty:564:5
 func llvmRenderModuleWithGcRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmGcRuntimeDeclarations(), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:930:5
 func llvmRenderModuleWithListRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmListRuntimeDeclarations(), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:947:5
 func llvmRenderModuleWithMapRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmMapRuntimeDeclarations(), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:964:5
 func llvmRenderModuleWithSetRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmSetRuntimeDeclarations(), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:981:5
-func llvmRenderModuleWithChannelRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
-	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmChanRuntimeDeclarations(), definitions)
-}
-
-// Osty: toolchain/llvmgen.osty:998:5
 func llvmRenderModuleWithStringRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmStringRuntimeDeclarations(), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:1015:1
+func llvmRenderModuleWithChannelRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmChanRuntimeDeclarations(), definitions)
+}
+
+// Osty: toolchain/llvmgen.osty:581:1
 func llvmRenderModuleWithRuntimeDeclarations(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, runtimeDeclarations []string, definitions []string) string {
-	// Osty: toolchain/llvmgen.osty:1023:5
+	// Osty: toolchain/llvmgen.osty:589:5
 	lines := []string{"; Code generated by osty LLVM backend. DO NOT EDIT.", fmt.Sprintf("; Osty: %s", ostyToString(sourcePath)), llvmStrings.Join([]string{"source_filename = \"", sourcePath, "\""}, "")}
 	_ = lines
-	// Osty: toolchain/llvmgen.osty:1028:5
+	// Osty: toolchain/llvmgen.osty:594:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:1029:9
+		// Osty: toolchain/llvmgen.osty:595:9
 		func() struct{} {
 			lines = append(lines, llvmStrings.Join([]string{"target triple = \"", target, "\""}, ""))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:1031:5
+	// Osty: toolchain/llvmgen.osty:597:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1032:5
+	// Osty: toolchain/llvmgen.osty:598:5
 	for _, typeDef := range typeDefs {
-		// Osty: toolchain/llvmgen.osty:1033:9
+		// Osty: toolchain/llvmgen.osty:599:9
 		func() struct{} { lines = append(lines, typeDef); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1035:5
+	// Osty: toolchain/llvmgen.osty:601:5
 	if len(typeDefs) > 0 {
-		// Osty: toolchain/llvmgen.osty:1036:9
+		// Osty: toolchain/llvmgen.osty:602:9
 		func() struct{} { lines = append(lines, ""); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1038:5
+	// Osty: toolchain/llvmgen.osty:604:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_i64 = private unnamed_addr constant [5 x i8] c\"%ld\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:1039:5
+	// Osty: toolchain/llvmgen.osty:605:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_f64 = private unnamed_addr constant [6 x i8] c\"%.6f\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:1040:5
+	// Osty: toolchain/llvmgen.osty:606:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:1041:5
+	// Osty: toolchain/llvmgen.osty:607:5
+	func() struct{} {
+		lines = append(lines, "@.bool_true = private unnamed_addr constant [5 x i8] c\"true\\00\"")
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:608:5
+	func() struct{} {
+		lines = append(lines, "@.bool_false = private unnamed_addr constant [6 x i8] c\"false\\00\"")
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:607:5
 	for _, global := range stringGlobals {
-		// Osty: toolchain/llvmgen.osty:1042:9
+		// Osty: toolchain/llvmgen.osty:608:9
 		func() struct{} {
 			lines = append(lines, llvmStrings.Join([]string{global.name, " = private unnamed_addr constant [", fmt.Sprintf("%s", ostyToString(global.byteLen)), " x i8] c\"", global.encoded, "\""}, ""))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:1056:5
+	// Osty: toolchain/llvmgen.osty:622:5
 	func() struct{} { lines = append(lines, "declare i32 @printf(ptr, ...)"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1057:5
+	// Osty: toolchain/llvmgen.osty:623:5
 	for _, runtimeDeclaration := range runtimeDeclarations {
-		// Osty: toolchain/llvmgen.osty:1058:9
+		// Osty: toolchain/llvmgen.osty:624:9
 		func() struct{} { lines = append(lines, runtimeDeclaration); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1060:5
+	// Osty: toolchain/llvmgen.osty:626:5
 	firstDefinition := true
 	_ = firstDefinition
-	// Osty: toolchain/llvmgen.osty:1061:5
+	// Osty: toolchain/llvmgen.osty:627:5
 	for _, definition := range definitions {
-		// Osty: toolchain/llvmgen.osty:1062:9
+		// Osty: toolchain/llvmgen.osty:628:9
 		if firstDefinition {
-			// Osty: toolchain/llvmgen.osty:1063:13
+			// Osty: toolchain/llvmgen.osty:629:13
 			func() struct{} { lines = append(lines, ""); return struct{}{} }()
-			// Osty: toolchain/llvmgen.osty:1064:13
+			// Osty: toolchain/llvmgen.osty:630:13
 			firstDefinition = false
 		}
-		// Osty: toolchain/llvmgen.osty:1066:9
+		// Osty: toolchain/llvmgen.osty:632:9
 		func() struct{} { lines = append(lines, definition); return struct{}{} }()
 	}
 	return llvmStrings.Join(lines, "\n")
 }
 
-// Osty: toolchain/llvmgen.osty:1071:5
+// Osty: toolchain/llvmgen.osty:637:5
 func llvmRenderSkeleton(packageName string, sourcePath string, emit string, target string, unsupported string) string {
-	// Osty: toolchain/llvmgen.osty:1078:5
+	// Osty: toolchain/llvmgen.osty:644:5
 	pkg := packageName
 	_ = pkg
-	// Osty: toolchain/llvmgen.osty:1079:5
+	// Osty: toolchain/llvmgen.osty:645:5
 	if pkg == "" {
-		// Osty: toolchain/llvmgen.osty:1080:9
+		// Osty: toolchain/llvmgen.osty:646:9
 		pkg = "main"
 	}
-	// Osty: toolchain/llvmgen.osty:1082:5
+	// Osty: toolchain/llvmgen.osty:648:5
 	source := sourcePath
 	_ = source
-	// Osty: toolchain/llvmgen.osty:1083:5
+	// Osty: toolchain/llvmgen.osty:649:5
 	if source == "" {
-		// Osty: toolchain/llvmgen.osty:1084:9
+		// Osty: toolchain/llvmgen.osty:650:9
 		source = "<unknown>"
 	}
-	// Osty: toolchain/llvmgen.osty:1087:5
+	// Osty: toolchain/llvmgen.osty:653:5
 	lines := []string{"; Osty LLVM backend skeleton", fmt.Sprintf("; package: %s", ostyToString(pkg)), fmt.Sprintf("; source: %s", ostyToString(source)), fmt.Sprintf("; emit: %s", ostyToString(emit))}
 	_ = lines
-	// Osty: toolchain/llvmgen.osty:1093:5
+	// Osty: toolchain/llvmgen.osty:659:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:1094:9
+		// Osty: toolchain/llvmgen.osty:660:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; target: %s", ostyToString(target)))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:1096:5
+	// Osty: toolchain/llvmgen.osty:662:5
 	if unsupported != "" {
-		// Osty: toolchain/llvmgen.osty:1097:9
+		// Osty: toolchain/llvmgen.osty:663:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; unsupported: %s", ostyToString(unsupported)))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:1099:5
+	// Osty: toolchain/llvmgen.osty:665:5
 	func() struct{} { lines = append(lines, "; code generation is not implemented yet"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1100:5
+	// Osty: toolchain/llvmgen.osty:666:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1101:5
+	// Osty: toolchain/llvmgen.osty:667:5
 	func() struct{} {
 		lines = append(lines, llvmStrings.Join([]string{"source_filename = \"", source, "\""}, ""))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:1102:5
+	// Osty: toolchain/llvmgen.osty:668:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:1103:9
+		// Osty: toolchain/llvmgen.osty:669:9
 		func() struct{} {
 			lines = append(lines, llvmStrings.Join([]string{"target triple = \"", target, "\""}, ""))
 			return struct{}{}
@@ -1350,4195 +1145,3449 @@ func llvmRenderSkeleton(packageName string, sourcePath string, emit string, targ
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: toolchain/llvmgen.osty:1108:5
+// Osty: toolchain/llvmgen.osty:674:5
 func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []string) string {
-	// Osty: toolchain/llvmgen.osty:1114:5
+	// Osty: toolchain/llvmgen.osty:680:5
 	lines := []string{fmt.Sprintf("define %s @%s(%s) {", ostyToString(ret), ostyToString(name), ostyToString(llvmParams(params))), "entry:"}
 	_ = lines
-	// Osty: toolchain/llvmgen.osty:1115:5
+	// Osty: toolchain/llvmgen.osty:681:5
 	for _, line := range body {
-		// Osty: toolchain/llvmgen.osty:1116:9
+		// Osty: toolchain/llvmgen.osty:682:9
 		func() struct{} { lines = append(lines, line); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1118:5
+	// Osty: toolchain/llvmgen.osty:684:5
 	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: toolchain/llvmgen.osty:1134:5
-func llvmRenderClosureThunk(retType string, thunkSymbol string, paramTypes []string, realSymbol string) string {
-	// Osty: toolchain/llvmgen.osty:1140:5
-	ret := func() string {
-		if retType == "" {
-			return "void"
-		} else {
-			return retType
-		}
-	}()
-	_ = ret
-	// Osty: toolchain/llvmgen.osty:1141:5
-	var paramParts []string = []string{"ptr %env"}
-	_ = paramParts
-	// Osty: toolchain/llvmgen.osty:1142:5
-	var argParts []string = make([]string, 0, 1)
-	_ = argParts
-	// Osty: toolchain/llvmgen.osty:1143:5
-	for i := 0; i < len(paramTypes); i++ {
-		// Osty: toolchain/llvmgen.osty:1144:9
-		pt := paramTypes[i]
-		_ = pt
-		// Osty: toolchain/llvmgen.osty:1145:9
-		func() struct{} {
-			paramParts = append(paramParts, fmt.Sprintf("%s %%arg%s", ostyToString(pt), ostyToString(i)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:1146:9
-		func() struct{} {
-			argParts = append(argParts, fmt.Sprintf("%s %%arg%s", ostyToString(pt), ostyToString(i)))
-			return struct{}{}
-		}()
-	}
-	// Osty: toolchain/llvmgen.osty:1148:5
-	params := llvmStrings.Join(paramParts, ", ")
-	_ = params
-	// Osty: toolchain/llvmgen.osty:1149:5
-	args := llvmStrings.Join(argParts, ", ")
-	_ = args
-	// Osty: toolchain/llvmgen.osty:1150:5
-	var lines []string = make([]string, 0, 1)
-	_ = lines
-	// Osty: toolchain/llvmgen.osty:1151:5
-	func() struct{} {
-		lines = append(lines, fmt.Sprintf("define private %s @%s(%s) {", ostyToString(ret), ostyToString(thunkSymbol), ostyToString(params)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:1152:5
-	func() struct{} { lines = append(lines, "entry:"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1153:5
-	if ret == "void" {
-		// Osty: toolchain/llvmgen.osty:1154:9
-		func() struct{} {
-			lines = append(lines, fmt.Sprintf("  call void @%s(%s)", ostyToString(realSymbol), ostyToString(args)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:1155:9
-		func() struct{} { lines = append(lines, "  ret void"); return struct{}{} }()
-	} else {
-		// Osty: toolchain/llvmgen.osty:1157:9
-		func() struct{} {
-			lines = append(lines, fmt.Sprintf("  %%__ret = call %s @%s(%s)", ostyToString(ret), ostyToString(realSymbol), ostyToString(args)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:1158:9
-		func() struct{} {
-			lines = append(lines, fmt.Sprintf("  ret %s %%__ret", ostyToString(ret)))
-			return struct{}{}
-		}()
-	}
-	// Osty: toolchain/llvmgen.osty:1160:5
-	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
-	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
-}
-
-// Osty: toolchain/llvmgen.osty:1163:5
+// Osty: toolchain/llvmgen.osty:740:5
 func llvmNeedsObjectArtifact(emit string) bool {
 	return emit == "object" || emit == "binary"
 }
 
-// Osty: toolchain/llvmgen.osty:1167:5
+// Osty: toolchain/llvmgen.osty:692:5
 func llvmNeedsBinaryArtifact(emit string) bool {
 	return emit == "binary"
 }
 
-// Osty: toolchain/llvmgen.osty:1171:5
+// Osty: toolchain/llvmgen.osty:696:5
 func llvmClangCompileObjectArgs(target string, irPath string, objectPath string) []string {
-	// Osty: toolchain/llvmgen.osty:1176:5
+	// Osty: toolchain/llvmgen.osty:701:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: toolchain/llvmgen.osty:1177:5
+	// Osty: toolchain/llvmgen.osty:702:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:1178:9
+		// Osty: toolchain/llvmgen.osty:703:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:1179:9
+		// Osty: toolchain/llvmgen.osty:704:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1181:5
+	// Osty: toolchain/llvmgen.osty:706:5
 	func() struct{} { args = append(args, "-c"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1182:5
+	// Osty: toolchain/llvmgen.osty:707:5
 	func() struct{} { args = append(args, irPath); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1183:5
+	// Osty: toolchain/llvmgen.osty:708:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1184:5
+	// Osty: toolchain/llvmgen.osty:709:5
 	func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	return args
 }
 
-// Osty: toolchain/llvmgen.osty:1188:5
+// Osty: toolchain/llvmgen.osty:713:5
 func llvmClangLinkBinaryArgs(target string, objectPaths []string, binaryPath string) []string {
-	// Osty: toolchain/llvmgen.osty:1193:5
+	// Osty: toolchain/llvmgen.osty:718:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: toolchain/llvmgen.osty:1194:5
+	// Osty: toolchain/llvmgen.osty:719:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:1195:9
+		// Osty: toolchain/llvmgen.osty:720:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:1196:9
+		// Osty: toolchain/llvmgen.osty:721:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1198:5
+	// Osty: toolchain/llvmgen.osty:723:5
 	for _, objectPath := range objectPaths {
-		// Osty: toolchain/llvmgen.osty:1199:9
+		// Osty: toolchain/llvmgen.osty:724:9
 		func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1205:5
+	// `-pthread` pulls libpthread / libSystem threading symbols, needed
+	// by the bundled runtime's POSIX task / channel implementations.
+	// Windows targets use Win32 primitives from kernel32 (default-linked)
+	// and must NOT be passed -pthread (clang-msvc rejects the flag).
 	if !llvmStrings.Contains(target, "windows") {
-		// Osty: toolchain/llvmgen.osty:1206:9
 		func() struct{} { args = append(args, "-pthread"); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1208:5
+	// Osty: toolchain/llvmgen.osty:726:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:1209:5
+	// Osty: toolchain/llvmgen.osty:727:5
 	func() struct{} { args = append(args, binaryPath); return struct{}{} }()
 	return args
 }
 
-// Osty: toolchain/llvmgen.osty:1213:5
+// Osty: toolchain/llvmgen.osty:731:5
 func llvmMissingClangMessage() string {
 	return "llvm backend: clang not found on PATH; install clang or use --emit=llvm-ir"
 }
 
-// Osty: toolchain/llvmgen.osty:1217:5
+// Osty: toolchain/llvmgen.osty:735:5
 func llvmMissingBinaryArtifactMessage() string {
 	return "llvm backend: missing binary artifact path"
 }
 
-// Osty: toolchain/llvmgen.osty:1221:5
+// Osty: toolchain/llvmgen.osty:739:5
 func llvmClangFailureMessage(action string, command string, output string) string {
 	return llvmStrings.Join([]string{"llvm backend: clang ", action, " failed\ncommand: ", command, "\n", output}, "")
 }
 
-// Osty: toolchain/llvmgen.osty:1235:5
+// Osty: toolchain/llvmgen.osty:746:5
 func llvmUnsupportedBackendErrorMessage() string {
 	return "llvm backend: code generation is not implemented yet"
 }
 
-// Osty: toolchain/llvmgen.osty:1239:5
+// Osty: toolchain/llvmgen.osty:750:5
 func llvmUnsupportedDiagnostic(kind string, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:1240:5
+	// Osty: toolchain/llvmgen.osty:751:5
 	if kind == "go-ffi" {
-		// Osty: toolchain/llvmgen.osty:1241:9
+		// Osty: toolchain/llvmgen.osty:752:9
 		target := detail
 		_ = target
-		// Osty: toolchain/llvmgen.osty:1242:9
+		// Osty: toolchain/llvmgen.osty:753:9
 		if target == "" {
-			// Osty: toolchain/llvmgen.osty:1243:13
+			// Osty: toolchain/llvmgen.osty:754:13
 			target = "<unknown>"
 		}
-		// Osty: toolchain/llvmgen.osty:1245:9
+		// Osty: toolchain/llvmgen.osty:756:9
 		return &LlvmUnsupportedDiagnostic{code: "LLVM001", kind: "foreign-ffi", message: fmt.Sprintf("Go FFI import %s is not supported by the self-hosted native backend", ostyToString(target)), hint: "rewrite the binding as `use runtime.cabi.<lib>` with an item block for extern C symbols, or `use runtime.<surface>` with an item block for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)"}
 	}
-	// Osty: toolchain/llvmgen.osty:1252:5
+	// Osty: toolchain/llvmgen.osty:763:5
 	if kind == "runtime-ffi" {
-		// Osty: toolchain/llvmgen.osty:1253:9
+		// Osty: toolchain/llvmgen.osty:764:9
 		target := detail
 		_ = target
-		// Osty: toolchain/llvmgen.osty:1254:9
+		// Osty: toolchain/llvmgen.osty:765:9
 		if target == "" {
-			// Osty: toolchain/llvmgen.osty:1255:13
+			// Osty: toolchain/llvmgen.osty:766:13
 			target = "<unknown>"
 		}
-		// Osty: toolchain/llvmgen.osty:1257:9
+		// Osty: toolchain/llvmgen.osty:768:9
 		return &LlvmUnsupportedDiagnostic{code: "LLVM002", kind: "runtime-ffi", message: fmt.Sprintf("Osty runtime FFI import %s needs native runtime lowering", ostyToString(target)), hint: "add the runtime ABI shim and lowering before compiling this source natively"}
 	}
-	// Osty: toolchain/llvmgen.osty:1265:5
+	// Osty: toolchain/llvmgen.osty:776:5
 	if kind == "source-layout" {
-		// Osty: toolchain/llvmgen.osty:1266:9
+		// Osty: toolchain/llvmgen.osty:777:9
 		return llvmUnsupportedDiagnosticWith("LLVM010", kind, detail, "reshape the file around the current LLVM subset: script statements or a simple main function")
 	}
-	// Osty: toolchain/llvmgen.osty:1273:5
+	// Osty: toolchain/llvmgen.osty:784:5
 	if kind == "type-system" {
-		// Osty: toolchain/llvmgen.osty:1274:9
+		// Osty: toolchain/llvmgen.osty:785:9
 		return llvmUnsupportedDiagnosticWith("LLVM011", kind, detail, "use Int or Bool values until the LLVM runtime type surface grows")
 	}
-	// Osty: toolchain/llvmgen.osty:1281:5
+	// Osty: toolchain/llvmgen.osty:792:5
 	if kind == "statement" {
-		// Osty: toolchain/llvmgen.osty:1282:9
+		// Osty: toolchain/llvmgen.osty:793:9
 		return llvmUnsupportedDiagnosticWith("LLVM012", kind, detail, "reduce the statement to let, assignment, if, range-for, return, or println")
 	}
-	// Osty: toolchain/llvmgen.osty:1289:5
+	// Osty: toolchain/llvmgen.osty:800:5
 	if kind == "expression" {
-		// Osty: toolchain/llvmgen.osty:1290:9
+		// Osty: toolchain/llvmgen.osty:801:9
 		return llvmUnsupportedDiagnosticWith("LLVM013", kind, detail, "reduce the expression to Int, Bool, arithmetic, comparison, call, or value-if forms")
 	}
-	// Osty: toolchain/llvmgen.osty:1297:5
+	// Osty: toolchain/llvmgen.osty:808:5
 	if kind == "control-flow" {
-		// Osty: toolchain/llvmgen.osty:1298:9
+		// Osty: toolchain/llvmgen.osty:809:9
 		return llvmUnsupportedDiagnosticWith("LLVM014", kind, detail, "use plain if/else or closed Int range loops for the current LLVM backend")
 	}
-	// Osty: toolchain/llvmgen.osty:1305:5
+	// Osty: toolchain/llvmgen.osty:816:5
 	if kind == "call" {
-		// Osty: toolchain/llvmgen.osty:1306:9
+		// Osty: toolchain/llvmgen.osty:817:9
 		return llvmUnsupportedDiagnosticWith("LLVM015", kind, detail, "call an Osty function with positional Int/Bool arguments or use println as a statement")
 	}
-	// Osty: toolchain/llvmgen.osty:1313:5
+	// Osty: toolchain/llvmgen.osty:824:5
 	if kind == "name" {
-		// Osty: toolchain/llvmgen.osty:1314:9
+		// Osty: toolchain/llvmgen.osty:825:9
 		return llvmUnsupportedDiagnosticWith("LLVM016", kind, detail, "use simple ASCII identifiers that the LLVM bridge can map directly")
 	}
-	// Osty: toolchain/llvmgen.osty:1321:5
+	// Osty: toolchain/llvmgen.osty:832:5
 	if kind == "function-signature" {
-		// Osty: toolchain/llvmgen.osty:1322:9
+		// Osty: toolchain/llvmgen.osty:833:9
 		return llvmUnsupportedDiagnosticWith("LLVM017", kind, detail, "use non-generic functions with identifier parameters and Int/Bool types")
 	}
-	// Osty: toolchain/llvmgen.osty:1329:5
+	// Osty: toolchain/llvmgen.osty:840:5
 	if kind == "stdlib-body" {
-		// Osty: toolchain/llvmgen.osty:1330:9
+		// Osty: toolchain/llvmgen.osty:841:9
 		return llvmUnsupportedDiagnosticWith("LLVM018", kind, detail, "call stdlib functions whose bodies the LLVM backend can currently lower, or add a runtime shim for this symbol")
 	}
-	// Osty: toolchain/llvmgen.osty:1338:5
+	// Osty: toolchain/llvmgen.osty:849:5
 	reason := detail
 	_ = reason
-	// Osty: toolchain/llvmgen.osty:1339:5
+	// Osty: toolchain/llvmgen.osty:842:5
 	if reason == "" {
-		// Osty: toolchain/llvmgen.osty:1340:9
+		// Osty: toolchain/llvmgen.osty:843:9
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: "LLVM000", kind: "unsupported-source", message: reason, hint: "reduce the program to the LLVM smoke subset while the self-hosted native backend grows"}
 }
 
-// Osty: toolchain/llvmgen.osty:1350:5
+// Osty: toolchain/llvmgen.osty:853:5
 func llvmUnsupportedDiagnosticWith(code string, kind string, detail string, hint string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:1356:5
+	// Osty: toolchain/llvmgen.osty:859:5
 	reason := detail
 	_ = reason
-	// Osty: toolchain/llvmgen.osty:1357:5
+	// Osty: toolchain/llvmgen.osty:860:5
 	if reason == "" {
-		// Osty: toolchain/llvmgen.osty:1358:9
+		// Osty: toolchain/llvmgen.osty:861:9
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: code, kind: kind, message: reason, hint: hint}
 }
 
-// Osty: toolchain/llvmgen.osty:1368:5
+// Osty: toolchain/llvmgen.osty:871:5
 func llvmUnsupportedSummary(diag *LlvmUnsupportedDiagnostic) string {
 	return fmt.Sprintf("%s %s: %s; hint: %s", ostyToString(diag.code), ostyToString(diag.kind), ostyToString(diag.message), ostyToString(diag.hint))
 }
 
-// Osty: toolchain/llvmgen.osty:1372:5
 func llvmIsCompareOp(op string) bool {
 	return op == "==" || op == "!=" || op == "<" || op == ">" || op == "<=" || op == ">="
 }
 
-// Osty: toolchain/llvmgen.osty:1376:5
 func llvmIntComparePredicate(op string) string {
-	// Osty: toolchain/llvmgen.osty:1377:5
-	if op == "==" {
-		// Osty: toolchain/llvmgen.osty:1378:9
+	switch op {
+	case "==":
 		return "eq"
-	}
-	// Osty: toolchain/llvmgen.osty:1380:5
-	if op == "!=" {
-		// Osty: toolchain/llvmgen.osty:1381:9
+	case "!=":
 		return "ne"
-	}
-	// Osty: toolchain/llvmgen.osty:1383:5
-	if op == "<" {
-		// Osty: toolchain/llvmgen.osty:1384:9
+	case "<":
 		return "slt"
-	}
-	// Osty: toolchain/llvmgen.osty:1386:5
-	if op == ">" {
-		// Osty: toolchain/llvmgen.osty:1387:9
+	case ">":
 		return "sgt"
-	}
-	// Osty: toolchain/llvmgen.osty:1389:5
-	if op == "<=" {
-		// Osty: toolchain/llvmgen.osty:1390:9
+	case "<=":
 		return "sle"
-	}
-	// Osty: toolchain/llvmgen.osty:1392:5
-	if op == ">=" {
-		// Osty: toolchain/llvmgen.osty:1393:9
+	case ">=":
 		return "sge"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1402:5
+// llvmUnsignedIntComparePredicate returns LLVM `icmp` predicates with
+// unsigned ordering for Char/Byte compares. Char codepoints fit in
+// non-negative i32 so signed would coincidentally work, but Byte values
+// 128..255 are negative under signed ordering which would break
+// `b'\x80' > b'\x00'`. Using unsigned predicates makes both surfaces
+// correct uniformly.
 func llvmUnsignedIntComparePredicate(op string) string {
-	// Osty: toolchain/llvmgen.osty:1403:5
-	if op == "==" {
-		// Osty: toolchain/llvmgen.osty:1404:9
+	switch op {
+	case "==":
 		return "eq"
-	}
-	// Osty: toolchain/llvmgen.osty:1406:5
-	if op == "!=" {
-		// Osty: toolchain/llvmgen.osty:1407:9
+	case "!=":
 		return "ne"
-	}
-	// Osty: toolchain/llvmgen.osty:1409:5
-	if op == "<" {
-		// Osty: toolchain/llvmgen.osty:1410:9
+	case "<":
 		return "ult"
-	}
-	// Osty: toolchain/llvmgen.osty:1412:5
-	if op == ">" {
-		// Osty: toolchain/llvmgen.osty:1413:9
+	case ">":
 		return "ugt"
-	}
-	// Osty: toolchain/llvmgen.osty:1415:5
-	if op == "<=" {
-		// Osty: toolchain/llvmgen.osty:1416:9
+	case "<=":
 		return "ule"
-	}
-	// Osty: toolchain/llvmgen.osty:1418:5
-	if op == ">=" {
-		// Osty: toolchain/llvmgen.osty:1419:9
+	case ">=":
 		return "uge"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1424:5
 func llvmFloatComparePredicate(op string) string {
-	// Osty: toolchain/llvmgen.osty:1425:5
-	if op == "==" {
-		// Osty: toolchain/llvmgen.osty:1426:9
+	switch op {
+	case "==":
 		return "oeq"
-	}
-	// Osty: toolchain/llvmgen.osty:1428:5
-	if op == "!=" {
-		// Osty: toolchain/llvmgen.osty:1429:9
+	case "!=":
 		return "one"
-	}
-	// Osty: toolchain/llvmgen.osty:1431:5
-	if op == "<" {
-		// Osty: toolchain/llvmgen.osty:1432:9
+	case "<":
 		return "olt"
-	}
-	// Osty: toolchain/llvmgen.osty:1434:5
-	if op == ">" {
-		// Osty: toolchain/llvmgen.osty:1435:9
+	case ">":
 		return "ogt"
-	}
-	// Osty: toolchain/llvmgen.osty:1437:5
-	if op == "<=" {
-		// Osty: toolchain/llvmgen.osty:1438:9
+	case "<=":
 		return "ole"
-	}
-	// Osty: toolchain/llvmgen.osty:1440:5
-	if op == ">=" {
-		// Osty: toolchain/llvmgen.osty:1441:9
+	case ">=":
 		return "oge"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1446:5
 func llvmIntBinaryInstruction(op string) string {
-	// Osty: toolchain/llvmgen.osty:1447:5
-	if op == "+" {
-		// Osty: toolchain/llvmgen.osty:1448:9
+	switch op {
+	case "+":
 		return "add"
-	}
-	// Osty: toolchain/llvmgen.osty:1450:5
-	if op == "-" {
-		// Osty: toolchain/llvmgen.osty:1451:9
+	case "-":
 		return "sub"
-	}
-	// Osty: toolchain/llvmgen.osty:1453:5
-	if op == "*" {
-		// Osty: toolchain/llvmgen.osty:1454:9
+	case "*":
 		return "mul"
-	}
-	// Osty: toolchain/llvmgen.osty:1456:5
-	if op == "/" {
-		// Osty: toolchain/llvmgen.osty:1457:9
+	case "/":
 		return "sdiv"
-	}
-	// Osty: toolchain/llvmgen.osty:1459:5
-	if op == "%" {
-		// Osty: toolchain/llvmgen.osty:1460:9
+	case "%":
 		return "srem"
-	}
-	// Osty: toolchain/llvmgen.osty:1462:5
-	if op == "&" {
-		// Osty: toolchain/llvmgen.osty:1463:9
+	case "&":
 		return "and"
-	}
-	// Osty: toolchain/llvmgen.osty:1465:5
-	if op == "|" {
-		// Osty: toolchain/llvmgen.osty:1466:9
+	case "|":
 		return "or"
-	}
-	// Osty: toolchain/llvmgen.osty:1468:5
-	if op == "^" {
-		// Osty: toolchain/llvmgen.osty:1469:9
+	case "^":
 		return "xor"
-	}
-	// Osty: toolchain/llvmgen.osty:1471:5
-	if op == "<<" {
-		// Osty: toolchain/llvmgen.osty:1472:9
+	case "<<":
 		return "shl"
-	}
-	// Osty: toolchain/llvmgen.osty:1474:5
-	if op == ">>" {
-		// Osty: toolchain/llvmgen.osty:1475:9
+	case ">>":
 		return "ashr"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1480:5
 func llvmFloatBinaryInstruction(op string) string {
-	// Osty: toolchain/llvmgen.osty:1481:5
-	if op == "+" {
-		// Osty: toolchain/llvmgen.osty:1482:9
+	switch op {
+	case "+":
 		return "fadd"
-	}
-	// Osty: toolchain/llvmgen.osty:1484:5
-	if op == "-" {
-		// Osty: toolchain/llvmgen.osty:1485:9
+	case "-":
 		return "fsub"
-	}
-	// Osty: toolchain/llvmgen.osty:1487:5
-	if op == "*" {
-		// Osty: toolchain/llvmgen.osty:1488:9
+	case "*":
 		return "fmul"
-	}
-	// Osty: toolchain/llvmgen.osty:1490:5
-	if op == "/" {
-		// Osty: toolchain/llvmgen.osty:1491:9
+	case "/":
 		return "fdiv"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1496:5
 func llvmLogicalInstruction(op string) string {
-	// Osty: toolchain/llvmgen.osty:1497:5
-	if op == "&&" {
-		// Osty: toolchain/llvmgen.osty:1498:9
+	switch op {
+	case "&&":
 		return "and"
-	}
-	// Osty: toolchain/llvmgen.osty:1500:5
-	if op == "||" {
-		// Osty: toolchain/llvmgen.osty:1501:9
+	case "||":
 		return "or"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1515:5
+// llvmIsAsciiStringText gates which plain String literals the
+// LLVM backend accepts directly. Since `llvmCStringEscape` now
+// byte-escapes any non-printable / non-ASCII character via `\HH`,
+// the gate only needs to reject text that can't be encoded as a
+// byte sequence at all — i.e. nothing; every Go `string` is a
+// byte sequence. The legacy name is kept for call-site stability;
+// a future rename to `llvmCanEmitStringLiteral` or similar is a
+// pure-cleanup follow-up.
 func llvmIsAsciiStringText(text string) bool {
-	// Osty: toolchain/llvmgen.osty:1516:5
 	_ = text
 	return true
 }
 
-// Osty: toolchain/llvmgen.osty:1520:5
 func llvmIsIdent(name string) bool {
-	// Osty: toolchain/llvmgen.osty:1521:5
 	if name == "" {
-		// Osty: toolchain/llvmgen.osty:1522:9
 		return false
 	}
-	// Osty: toolchain/llvmgen.osty:1524:5
-	chars := []rune(name)
-	_ = chars
-	// Osty: toolchain/llvmgen.osty:1525:5
-	for i := 0; i < len(chars); i++ {
-		// Osty: toolchain/llvmgen.osty:1526:9
-		c := chars[i]
-		_ = c
-		// Osty: toolchain/llvmgen.osty:1527:9
-		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
-			// Osty: toolchain/llvmgen.osty:1528:13
+	for i, c := range name {
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') {
 			continue
 		}
-		// Osty: toolchain/llvmgen.osty:1530:9
-		if i > 0 && c >= '0' && c <= '9' {
-			// Osty: toolchain/llvmgen.osty:1531:13
+		if i > 0 && '0' <= c && c <= '9' {
 			continue
 		}
-		// Osty: toolchain/llvmgen.osty:1533:9
 		return false
 	}
 	return true
 }
 
-// Osty: toolchain/llvmgen.osty:1538:5
-func llvmFirstNonEmpty(a string, b string) string {
-	// Osty: toolchain/llvmgen.osty:1539:5
+func llvmFirstNonEmpty(a, b string) string {
 	if a != "" {
-		// Osty: toolchain/llvmgen.osty:1540:9
 		return a
 	}
 	return b
 }
 
-// Osty: toolchain/llvmgen.osty:1545:5
 func llvmIsKnownRuntimeFfiPath(path string) bool {
-	// Osty: toolchain/llvmgen.osty:1546:5
 	if llvmStrings.HasPrefix(path, "runtime.package.") {
-		// Osty: toolchain/llvmgen.osty:1547:9
 		return true
 	}
-	// Osty: toolchain/llvmgen.osty:1549:5
 	if llvmStrings.HasPrefix(path, "runtime.cabi.") || path == "runtime.cabi" {
-		// Osty: toolchain/llvmgen.osty:1550:9
 		return true
 	}
 	return path == "runtime.strings" || path == "runtime.path.filepath"
 }
 
-// Osty: toolchain/llvmgen.osty:1555:5
 func llvmRuntimeFfiAlias(explicitAlias string, lastPath string, runtimePath string) string {
-	// Osty: toolchain/llvmgen.osty:1556:5
 	if explicitAlias != "" {
-		// Osty: toolchain/llvmgen.osty:1557:9
 		return explicitAlias
 	}
-	// Osty: toolchain/llvmgen.osty:1559:5
 	if lastPath != "" {
-		// Osty: toolchain/llvmgen.osty:1560:9
 		return lastPath
 	}
-	// Osty: toolchain/llvmgen.osty:1562:5
 	parts := llvmStrings.Split(runtimePath, ".")
-	_ = parts
-	// Osty: toolchain/llvmgen.osty:1563:5
 	if len(parts) == 0 {
-		// Osty: toolchain/llvmgen.osty:1564:9
 		return ""
 	}
-	return parts[func() int {
-		var _p19 int = len(parts)
-		var _rhs20 int = 1
-		if _rhs20 < 0 && _p19 > math.MaxInt+_rhs20 {
-			panic("integer overflow")
-		}
-		if _rhs20 > 0 && _p19 < math.MinInt+_rhs20 {
-			panic("integer overflow")
-		}
-		return _p19 - _rhs20
-	}()]
+	return parts[len(parts)-1]
 }
 
-// Osty: toolchain/llvmgen.osty:1569:5
 func llvmRuntimeFfiSymbol(path string, name string) string {
-	// Osty: toolchain/llvmgen.osty:1575:5
+	// `runtime.cabi[.libname]` paths bypass the `osty_rt_` runtime
+	// namespace and emit the function name as the literal extern C
+	// symbol. Callers link the providing library via their build
+	// system; the segment after `runtime.cabi.` is descriptive only.
 	if path == "runtime.cabi" || llvmStrings.HasPrefix(path, "runtime.cabi.") {
-		// Osty: toolchain/llvmgen.osty:1576:9
 		return name
 	}
-	// Osty: toolchain/llvmgen.osty:1578:5
 	trimmed := path
-	_ = trimmed
-	// Osty: toolchain/llvmgen.osty:1579:5
 	if llvmStrings.HasPrefix(trimmed, "runtime.") {
-		// Osty: toolchain/llvmgen.osty:1580:9
 		trimmed = llvmStrings.TrimPrefix(trimmed, "runtime.")
 	}
-	// Osty: toolchain/llvmgen.osty:1582:5
 	out := "osty_rt_"
-	_ = out
-	// Osty: toolchain/llvmgen.osty:1583:5
-	for _, c := range []rune(trimmed) {
-		// Osty: toolchain/llvmgen.osty:1584:9
+	for _, c := range trimmed {
 		if c == '.' || c == '/' || c == '-' {
-			// Osty: toolchain/llvmgen.osty:1585:13
-			out = fmt.Sprintf("%s_", ostyToString(out))
-			// Osty: toolchain/llvmgen.osty:1586:13
+			out += "_"
 			continue
 		}
-		// Osty: toolchain/llvmgen.osty:1588:9
-		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
-			// Osty: toolchain/llvmgen.osty:1589:13
-			out = fmt.Sprintf("%s%s", ostyToString(out), string(c))
-			// Osty: toolchain/llvmgen.osty:1590:13
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
+			out += string(c)
 			continue
 		}
-		// Osty: toolchain/llvmgen.osty:1592:9
-		out = fmt.Sprintf("%s_", ostyToString(out))
+		out += "_"
 	}
-	return fmt.Sprintf("%s_%s", ostyToString(out), ostyToString(name))
+	return out + "_" + name
 }
 
-// Osty: toolchain/llvmgen.osty:1603:5
+// Osty: toolchain/llvmgen.osty:1092:1
 func llvmListRuntimeNewSymbol() string {
 	return "osty_rt_list_new"
 }
 
-// Osty: toolchain/llvmgen.osty:1607:5
+// Osty: toolchain/llvmgen.osty:1096:1
 func llvmListRuntimeLenSymbol() string {
 	return "osty_rt_list_len"
 }
 
-// Osty: toolchain/llvmgen.osty:1611:5
+// Osty: toolchain/llvmgen.osty:1100:1
 func llvmListRuntimeSortedI64Symbol() string {
 	return "osty_rt_list_sorted_i64"
 }
 
-// Osty: toolchain/llvmgen.osty:1615:5
+// Osty: toolchain/llvmgen.osty:1104:1
 func llvmListRuntimeToSetI64Symbol() string {
 	return "osty_rt_list_to_set_i64"
 }
 
-// Osty: toolchain/llvmgen.osty:1622:5
+// Osty: toolchain/llvmgen.osty (parametric push symbol builder)
 func llvmListRuntimePushSymbol(suffix string) string {
-	return fmt.Sprintf("osty_rt_list_push_%s", ostyToString(suffix))
+	return "osty_rt_list_push_" + suffix
 }
 
-// Osty: toolchain/llvmgen.osty:1626:5
 func llvmListRuntimeGetSymbol(suffix string) string {
-	return fmt.Sprintf("osty_rt_list_get_%s", ostyToString(suffix))
+	return "osty_rt_list_get_" + suffix
 }
 
-// Osty: toolchain/llvmgen.osty:1630:5
 func llvmListRuntimeSetSymbol(suffix string) string {
-	return fmt.Sprintf("osty_rt_list_set_%s", ostyToString(suffix))
+	return "osty_rt_list_set_" + suffix
 }
 
-// Osty: toolchain/llvmgen.osty:1634:5
 func llvmListRuntimeInsertSymbol(suffix string) string {
-	return fmt.Sprintf("osty_rt_list_insert_%s", ostyToString(suffix))
+	return "osty_rt_list_insert_" + suffix
 }
 
-// Osty: toolchain/llvmgen.osty:1643:5
 func llvmListRuntimeSortedSymbol(elemTyp string, isString bool) string {
-	// Osty: toolchain/llvmgen.osty:1644:5
 	if isString {
-		// Osty: toolchain/llvmgen.osty:1645:9
 		return "osty_rt_list_sorted_string"
 	}
-	// Osty: toolchain/llvmgen.osty:1647:5
-	if elemTyp == "i64" {
-		// Osty: toolchain/llvmgen.osty:1648:9
+	switch elemTyp {
+	case "i64":
 		return "osty_rt_list_sorted_i64"
-	}
-	// Osty: toolchain/llvmgen.osty:1650:5
-	if elemTyp == "i1" {
-		// Osty: toolchain/llvmgen.osty:1651:9
+	case "i1":
 		return "osty_rt_list_sorted_i1"
-	}
-	// Osty: toolchain/llvmgen.osty:1653:5
-	if elemTyp == "double" {
-		// Osty: toolchain/llvmgen.osty:1654:9
+	case "double":
 		return "osty_rt_list_sorted_f64"
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1663:5
 func llvmListRuntimeToSetSymbol(elemTyp string, isString bool) string {
-	// Osty: toolchain/llvmgen.osty:1664:5
 	if isString {
-		// Osty: toolchain/llvmgen.osty:1665:9
 		return "osty_rt_list_to_set_string"
 	}
-	// Osty: toolchain/llvmgen.osty:1667:5
-	if elemTyp == "i64" {
-		// Osty: toolchain/llvmgen.osty:1668:9
+	switch elemTyp {
+	case "i64":
 		return "osty_rt_list_to_set_i64"
-	}
-	// Osty: toolchain/llvmgen.osty:1670:5
-	if elemTyp == "i1" {
-		// Osty: toolchain/llvmgen.osty:1671:9
+	case "i1":
 		return "osty_rt_list_to_set_i1"
-	}
-	// Osty: toolchain/llvmgen.osty:1673:5
-	if elemTyp == "double" {
-		// Osty: toolchain/llvmgen.osty:1674:9
+	case "double":
 		return "osty_rt_list_to_set_f64"
-	}
-	// Osty: toolchain/llvmgen.osty:1676:5
-	if elemTyp == "ptr" {
-		// Osty: toolchain/llvmgen.osty:1677:9
+	case "ptr":
 		return "osty_rt_list_to_set_ptr"
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1682:5
+// Osty: toolchain/llvmgen.osty:1108:1
 func llvmMapRuntimeNewSymbol() string {
 	return "osty_rt_map_new"
 }
 
-// Osty: toolchain/llvmgen.osty:1686:5
+// Osty: toolchain/llvmgen.osty:1112:1
 func llvmMapRuntimeKeysSymbol() string {
 	return "osty_rt_map_keys"
 }
 
-// Osty: toolchain/llvmgen.osty:1690:5
 func llvmMapRuntimeLenSymbol() string {
 	return "osty_rt_map_len"
 }
 
-// Osty: toolchain/llvmgen.osty:1698:5
 func llvmMapKeySuffix(typ string, isString bool) string {
-	// Osty: toolchain/llvmgen.osty:1699:5
 	if isString {
-		// Osty: toolchain/llvmgen.osty:1700:9
 		return "string"
 	}
-	// Osty: toolchain/llvmgen.osty:1702:5
-	if typ == "i64" {
-		// Osty: toolchain/llvmgen.osty:1703:9
+	switch typ {
+	case "i64":
 		return "i64"
-	}
-	// Osty: toolchain/llvmgen.osty:1705:5
-	if typ == "i1" {
-		// Osty: toolchain/llvmgen.osty:1706:9
+	case "i1":
 		return "i1"
-	}
-	// Osty: toolchain/llvmgen.osty:1708:5
-	if typ == "double" {
-		// Osty: toolchain/llvmgen.osty:1709:9
+	case "double":
 		return "f64"
-	}
-	// Osty: toolchain/llvmgen.osty:1711:5
-	if typ == "ptr" {
-		// Osty: toolchain/llvmgen.osty:1712:9
+	case "ptr":
 		return "ptr"
 	}
 	return "bytes"
 }
 
-// Osty: toolchain/llvmgen.osty:1717:5
 func llvmMapRuntimeContainsSymbol(keyTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_map_contains_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
+	return "osty_rt_map_contains_" + llvmMapKeySuffix(keyTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1721:5
 func llvmMapRuntimeInsertSymbol(keyTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_map_insert_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
+	return "osty_rt_map_insert_" + llvmMapKeySuffix(keyTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1725:5
 func llvmMapRuntimeRemoveSymbol(keyTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_map_remove_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
+	return "osty_rt_map_remove_" + llvmMapKeySuffix(keyTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1729:5
 func llvmMapRuntimeGetOrAbortSymbol(keyTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_map_get_or_abort_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
+	return "osty_rt_map_get_or_abort_" + llvmMapKeySuffix(keyTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1733:5
+// Osty: toolchain/llvmgen.osty:1116:1
 func llvmSetRuntimeNewSymbol() string {
 	return "osty_rt_set_new"
 }
 
-// Osty: toolchain/llvmgen.osty:1737:5
+// Osty: toolchain/llvmgen.osty:1120:1
 func llvmSetRuntimeLenSymbol() string {
 	return "osty_rt_set_len"
 }
 
-// Osty: toolchain/llvmgen.osty:1741:5
+// Osty: toolchain/llvmgen.osty:1124:1
 func llvmSetRuntimeToListSymbol() string {
 	return "osty_rt_set_to_list"
 }
 
-// Osty: toolchain/llvmgen.osty:1750:5
 func llvmSetRuntimeContainsSymbol(elemTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_set_contains_%s", ostyToString(llvmMapKeySuffix(elemTyp, isString)))
+	return "osty_rt_set_contains_" + llvmMapKeySuffix(elemTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1754:5
 func llvmSetRuntimeInsertSymbol(elemTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_set_insert_%s", ostyToString(llvmMapKeySuffix(elemTyp, isString)))
+	return "osty_rt_set_insert_" + llvmMapKeySuffix(elemTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1758:5
 func llvmSetRuntimeRemoveSymbol(elemTyp string, isString bool) string {
-	return fmt.Sprintf("osty_rt_set_remove_%s", ostyToString(llvmMapKeySuffix(elemTyp, isString)))
+	return "osty_rt_set_remove_" + llvmMapKeySuffix(elemTyp, isString)
 }
 
-// Osty: toolchain/llvmgen.osty:1764:5
+// Osty: toolchain/llvmgen.osty:1130:1
 func llvmContainerAbiKind(typ string, isString bool) int {
-	// Osty: toolchain/llvmgen.osty:1765:5
 	if isString {
-		// Osty: toolchain/llvmgen.osty:1766:9
 		return 5
 	}
-	// Osty: toolchain/llvmgen.osty:1768:5
-	if typ == "i64" {
-		// Osty: toolchain/llvmgen.osty:1769:9
+	switch typ {
+	case "i64":
 		return 1
-	}
-	// Osty: toolchain/llvmgen.osty:1771:5
-	if typ == "i1" {
-		// Osty: toolchain/llvmgen.osty:1772:9
+	case "i1":
 		return 2
-	}
-	// Osty: toolchain/llvmgen.osty:1774:5
-	if typ == "double" {
-		// Osty: toolchain/llvmgen.osty:1775:9
+	case "double":
 		return 3
-	}
-	// Osty: toolchain/llvmgen.osty:1777:5
-	if typ == "ptr" {
-		// Osty: toolchain/llvmgen.osty:1778:9
+	case "ptr":
 		return 4
+	default:
+		return 6
 	}
-	return 6
 }
 
-// Osty: toolchain/llvmgen.osty:1787:5
 func llvmListUsesTypedRuntime(elemTyp string) bool {
 	return elemTyp == "i64" || elemTyp == "i1" || elemTyp == "double" || elemTyp == "ptr"
 }
 
-// Osty: toolchain/llvmgen.osty:1796:5
 func llvmListElementSuffix(typ string) string {
-	// Osty: toolchain/llvmgen.osty:1797:5
-	if typ == "i64" || typ == "i1" || typ == "ptr" {
-		// Osty: toolchain/llvmgen.osty:1798:9
+	switch typ {
+	case "i64", "i1", "ptr":
 		return typ
-	}
-	// Osty: toolchain/llvmgen.osty:1800:5
-	if typ == "double" {
-		// Osty: toolchain/llvmgen.osty:1801:9
+	case "double":
 		return "f64"
 	}
-	// Osty: toolchain/llvmgen.osty:1803:5
 	out := ""
-	_ = out
-	// Osty: toolchain/llvmgen.osty:1804:5
-	for _, c := range []rune(typ) {
-		// Osty: toolchain/llvmgen.osty:1805:9
-		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
-			// Osty: toolchain/llvmgen.osty:1806:13
-			out = fmt.Sprintf("%s%s", ostyToString(out), string(c))
-			// Osty: toolchain/llvmgen.osty:1807:13
+	for _, c := range typ {
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
+			out += string(c)
 			continue
 		}
-		// Osty: toolchain/llvmgen.osty:1809:9
-		out = fmt.Sprintf("%s_", ostyToString(out))
+		out += "_"
 	}
-	// Osty: toolchain/llvmgen.osty:1811:5
 	if out == "" {
-		// Osty: toolchain/llvmgen.osty:1812:9
 		return "ptr"
 	}
 	return out
 }
 
-// Osty: toolchain/llvmgen.osty:1820:5
 func llvmListRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty_rt_list_new()", "declare i64 @osty_rt_list_len(ptr)", "declare void @osty_rt_list_push_i64(ptr, i64)", "declare void @osty_rt_list_push_i1(ptr, i1)", "declare void @osty_rt_list_push_f64(ptr, double)", "declare void @osty_rt_list_push_ptr(ptr, ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "declare i1 @osty_rt_list_get_i1(ptr, i64)", "declare double @osty_rt_list_get_f64(ptr, i64)", "declare ptr @osty_rt_list_get_ptr(ptr, i64)", "declare void @osty_rt_list_set_i64(ptr, i64, i64)", "declare void @osty_rt_list_set_i1(ptr, i64, i1)", "declare void @osty_rt_list_set_f64(ptr, i64, double)", "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)"}
+	return []string{
+		"declare ptr @osty_rt_list_new()",
+		"declare i64 @osty_rt_list_len(ptr)",
+		"declare void @osty_rt_list_push_i64(ptr, i64)",
+		"declare void @osty_rt_list_push_i1(ptr, i1)",
+		"declare void @osty_rt_list_push_f64(ptr, double)",
+		"declare void @osty_rt_list_push_ptr(ptr, ptr)",
+		"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+		"declare i1 @osty_rt_list_get_i1(ptr, i64)",
+		"declare double @osty_rt_list_get_f64(ptr, i64)",
+		"declare ptr @osty_rt_list_get_ptr(ptr, i64)",
+		"declare void @osty_rt_list_set_i64(ptr, i64, i64)",
+		"declare void @osty_rt_list_set_i1(ptr, i64, i1)",
+		"declare void @osty_rt_list_set_f64(ptr, i64, double)",
+		"declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
+	}
 }
 
-// Osty: toolchain/llvmgen.osty:1842:5
 func llvmListNew(emitter *LlvmEmitter) *LlvmValue {
-	return llvmCall(emitter, "ptr", "osty_rt_list_new", make([]*LlvmValue, 0, 1))
+	return llvmCall(emitter, "ptr", "osty_rt_list_new", make([]*LlvmValue, 0))
 }
 
-// Osty: toolchain/llvmgen.osty:1846:5
 func llvmListLen(emitter *LlvmEmitter, list *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_list_len", []*LlvmValue{list})
 }
 
-// Osty: toolchain/llvmgen.osty:1850:5
 func llvmListPushI64(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1851:5
 	llvmCallVoid(emitter, "osty_rt_list_push_i64", []*LlvmValue{list, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1854:5
 func llvmListPushI1(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1855:5
 	llvmCallVoid(emitter, "osty_rt_list_push_i1", []*LlvmValue{list, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1858:5
 func llvmListPushF64(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1859:5
 	llvmCallVoid(emitter, "osty_rt_list_push_f64", []*LlvmValue{list, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1862:5
 func llvmListPushPtr(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1863:5
 	llvmCallVoid(emitter, "osty_rt_list_push_ptr", []*LlvmValue{list, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1871:5
 func llvmListPush(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1872:5
 	symbol := llvmListRuntimePushSymbol(llvmListElementSuffix(value.typ))
-	_ = symbol
-	// Osty: toolchain/llvmgen.osty:1873:5
 	llvmCallVoid(emitter, symbol, []*LlvmValue{list, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1881:5
 func llvmListGet(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, elemTyp string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:1887:5
 	symbol := llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
-	_ = symbol
 	return llvmCall(emitter, elemTyp, symbol, []*LlvmValue{list, index})
 }
 
-// Osty: toolchain/llvmgen.osty:1891:5
 func llvmListGetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_list_get_i64", []*LlvmValue{list, index})
 }
 
-// Osty: toolchain/llvmgen.osty:1895:5
 func llvmListGetI1(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_list_get_i1", []*LlvmValue{list, index})
 }
 
-// Osty: toolchain/llvmgen.osty:1899:5
 func llvmListGetF64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "double", "osty_rt_list_get_f64", []*LlvmValue{list, index})
 }
 
-// Osty: toolchain/llvmgen.osty:1903:5
 func llvmListGetPtr(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_list_get_ptr", []*LlvmValue{list, index})
 }
 
-// Osty: toolchain/llvmgen.osty:1907:5
 func llvmListSetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1908:5
 	llvmCallVoid(emitter, "osty_rt_list_set_i64", []*LlvmValue{list, index, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1911:5
 func llvmListSetI1(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1912:5
 	llvmCallVoid(emitter, "osty_rt_list_set_i1", []*LlvmValue{list, index, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1915:5
 func llvmListSetF64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1916:5
 	llvmCallVoid(emitter, "osty_rt_list_set_f64", []*LlvmValue{list, index, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1919:5
 func llvmListSetPtr(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1920:5
 	llvmCallVoid(emitter, "osty_rt_list_set_ptr", []*LlvmValue{list, index, value})
 }
 
-// Osty: toolchain/llvmgen.osty:1929:5
 func llvmMapRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty_rt_map_new()", "declare i64 @osty_rt_map_len(ptr)", "declare ptr @osty_rt_map_keys(ptr)", "declare i1 @osty_rt_map_contains_i64(ptr, i64)", "declare i1 @osty_rt_map_contains_i1(ptr, i1)", "declare i1 @osty_rt_map_contains_f64(ptr, double)", "declare i1 @osty_rt_map_contains_ptr(ptr, ptr)", "declare i1 @osty_rt_map_contains_string(ptr, ptr)", "declare void @osty_rt_map_insert_i64(ptr, i64, ptr)", "declare void @osty_rt_map_insert_i1(ptr, i1, ptr)", "declare void @osty_rt_map_insert_f64(ptr, double, ptr)", "declare void @osty_rt_map_insert_ptr(ptr, ptr, ptr)", "declare void @osty_rt_map_insert_string(ptr, ptr, ptr)", "declare i1 @osty_rt_map_remove_i64(ptr, i64)", "declare i1 @osty_rt_map_remove_i1(ptr, i1)", "declare i1 @osty_rt_map_remove_f64(ptr, double)", "declare i1 @osty_rt_map_remove_ptr(ptr, ptr)", "declare i1 @osty_rt_map_remove_string(ptr, ptr)", "declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)", "declare void @osty_rt_map_get_or_abort_i1(ptr, i1, ptr)", "declare void @osty_rt_map_get_or_abort_f64(ptr, double, ptr)", "declare void @osty_rt_map_get_or_abort_ptr(ptr, ptr, ptr)", "declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)"}
+	return []string{
+		"declare ptr @osty_rt_map_new()",
+		"declare i64 @osty_rt_map_len(ptr)",
+		"declare ptr @osty_rt_map_keys(ptr)",
+		"declare i1 @osty_rt_map_contains_i64(ptr, i64)",
+		"declare i1 @osty_rt_map_contains_i1(ptr, i1)",
+		"declare i1 @osty_rt_map_contains_f64(ptr, double)",
+		"declare i1 @osty_rt_map_contains_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_map_contains_string(ptr, ptr)",
+		"declare void @osty_rt_map_insert_i64(ptr, i64, ptr)",
+		"declare void @osty_rt_map_insert_i1(ptr, i1, ptr)",
+		"declare void @osty_rt_map_insert_f64(ptr, double, ptr)",
+		"declare void @osty_rt_map_insert_ptr(ptr, ptr, ptr)",
+		"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
+		"declare i1 @osty_rt_map_remove_i64(ptr, i64)",
+		"declare i1 @osty_rt_map_remove_i1(ptr, i1)",
+		"declare i1 @osty_rt_map_remove_f64(ptr, double)",
+		"declare i1 @osty_rt_map_remove_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_map_remove_string(ptr, ptr)",
+		"declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)",
+		"declare void @osty_rt_map_get_or_abort_i1(ptr, i1, ptr)",
+		"declare void @osty_rt_map_get_or_abort_f64(ptr, double, ptr)",
+		"declare void @osty_rt_map_get_or_abort_ptr(ptr, ptr, ptr)",
+		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
+	}
 }
 
-// Osty: toolchain/llvmgen.osty:1957:5
 func llvmMapNew(emitter *LlvmEmitter) *LlvmValue {
-	return llvmCall(emitter, "ptr", "osty_rt_map_new", make([]*LlvmValue, 0, 1))
+	return llvmCall(emitter, "ptr", "osty_rt_map_new", make([]*LlvmValue, 0))
 }
 
-// Osty: toolchain/llvmgen.osty:1961:5
-func llvmMapLen(emitter *LlvmEmitter, map_ *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i64", "osty_rt_map_len", []*LlvmValue{map_})
+func llvmMapLen(emitter *LlvmEmitter, m *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_map_len", []*LlvmValue{m})
 }
 
-// Osty: toolchain/llvmgen.osty:1965:5
-func llvmMapKeys(emitter *LlvmEmitter, map_ *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "ptr", "osty_rt_map_keys", []*LlvmValue{map_})
+func llvmMapKeys(emitter *LlvmEmitter, m *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_map_keys", []*LlvmValue{m})
 }
 
-// Osty: toolchain/llvmgen.osty:1969:5
-func llvmMapContainsI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_i64", []*LlvmValue{map_, key})
+func llvmMapContainsI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_i64", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:1973:5
-func llvmMapContainsI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_i1", []*LlvmValue{map_, key})
+func llvmMapContainsI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_i1", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:1977:5
-func llvmMapContainsF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_f64", []*LlvmValue{map_, key})
+func llvmMapContainsF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_f64", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:1981:5
-func llvmMapContainsPtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_ptr", []*LlvmValue{map_, key})
+func llvmMapContainsPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_ptr", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:1985:5
-func llvmMapContainsString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_string", []*LlvmValue{map_, key})
+func llvmMapContainsString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_string", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:1993:5
-func llvmMapInsertI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1994:5
-	llvmCallVoid(emitter, "osty_rt_map_insert_i64", []*LlvmValue{map_, key, valueSlot})
+func llvmMapInsertI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_i64", []*LlvmValue{m, key, valueSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:1997:5
-func llvmMapInsertI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:1998:5
-	llvmCallVoid(emitter, "osty_rt_map_insert_i1", []*LlvmValue{map_, key, valueSlot})
+func llvmMapInsertI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_i1", []*LlvmValue{m, key, valueSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2001:5
-func llvmMapInsertF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2002:5
-	llvmCallVoid(emitter, "osty_rt_map_insert_f64", []*LlvmValue{map_, key, valueSlot})
+func llvmMapInsertF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_f64", []*LlvmValue{m, key, valueSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2005:5
-func llvmMapInsertPtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2006:5
-	llvmCallVoid(emitter, "osty_rt_map_insert_ptr", []*LlvmValue{map_, key, valueSlot})
+func llvmMapInsertPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_ptr", []*LlvmValue{m, key, valueSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2009:5
-func llvmMapInsertString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2010:5
-	llvmCallVoid(emitter, "osty_rt_map_insert_string", []*LlvmValue{map_, key, valueSlot})
+func llvmMapInsertString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_insert_string", []*LlvmValue{m, key, valueSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2013:5
-func llvmMapRemoveI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_i64", []*LlvmValue{map_, key})
+func llvmMapRemoveI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_i64", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2017:5
-func llvmMapRemoveI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_i1", []*LlvmValue{map_, key})
+func llvmMapRemoveI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_i1", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2021:5
-func llvmMapRemoveF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_f64", []*LlvmValue{map_, key})
+func llvmMapRemoveF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_f64", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2025:5
-func llvmMapRemovePtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_ptr", []*LlvmValue{map_, key})
+func llvmMapRemovePtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_ptr", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2029:5
-func llvmMapRemoveString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_string", []*LlvmValue{map_, key})
+func llvmMapRemoveString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_string", []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2036:5
-func llvmMapGetOrAbortI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2037:5
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i64", []*LlvmValue{map_, key, outSlot})
+func llvmMapGetOrAbortI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i64", []*LlvmValue{m, key, outSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2040:5
-func llvmMapGetOrAbortI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2041:5
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i1", []*LlvmValue{map_, key, outSlot})
+func llvmMapGetOrAbortI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i1", []*LlvmValue{m, key, outSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2044:5
-func llvmMapGetOrAbortF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2045:5
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_f64", []*LlvmValue{map_, key, outSlot})
+func llvmMapGetOrAbortF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_f64", []*LlvmValue{m, key, outSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2048:5
-func llvmMapGetOrAbortPtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2049:5
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_ptr", []*LlvmValue{map_, key, outSlot})
+func llvmMapGetOrAbortPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_ptr", []*LlvmValue{m, key, outSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2052:5
-func llvmMapGetOrAbortString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2053:5
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", []*LlvmValue{map_, key, outSlot})
+func llvmMapGetOrAbortString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", []*LlvmValue{m, key, outSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2060:5
-func llvmMapContains(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2066:5
+func llvmMapContains(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
 	symbol := llvmMapRuntimeContainsSymbol(key.typ, isString)
-	_ = symbol
-	return llvmCall(emitter, "i1", symbol, []*LlvmValue{map_, key})
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2074:5
-func llvmMapInsert(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue, isString bool) {
-	// Osty: toolchain/llvmgen.osty:2081:5
+func llvmMapInsert(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue, isString bool) {
 	symbol := llvmMapRuntimeInsertSymbol(key.typ, isString)
-	_ = symbol
-	// Osty: toolchain/llvmgen.osty:2082:5
-	llvmCallVoid(emitter, symbol, []*LlvmValue{map_, key, valueSlot})
+	llvmCallVoid(emitter, symbol, []*LlvmValue{m, key, valueSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2087:5
-func llvmMapRemove(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2093:5
+func llvmMapRemove(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
 	symbol := llvmMapRuntimeRemoveSymbol(key.typ, isString)
-	_ = symbol
-	return llvmCall(emitter, "i1", symbol, []*LlvmValue{map_, key})
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{m, key})
 }
 
-// Osty: toolchain/llvmgen.osty:2100:5
-func llvmMapGetOrAbort(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue, isString bool) {
-	// Osty: toolchain/llvmgen.osty:2107:5
+func llvmMapGetOrAbort(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue, isString bool) {
 	symbol := llvmMapRuntimeGetOrAbortSymbol(key.typ, isString)
-	_ = symbol
-	// Osty: toolchain/llvmgen.osty:2108:5
-	llvmCallVoid(emitter, symbol, []*LlvmValue{map_, key, outSlot})
+	llvmCallVoid(emitter, symbol, []*LlvmValue{m, key, outSlot})
 }
 
-// Osty: toolchain/llvmgen.osty:2116:5
 func llvmSetRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty_rt_set_new(i64)", "declare i64 @osty_rt_set_len(ptr)", "declare ptr @osty_rt_set_to_list(ptr)", "declare i1 @osty_rt_set_contains_i64(ptr, i64)", "declare i1 @osty_rt_set_contains_i1(ptr, i1)", "declare i1 @osty_rt_set_contains_f64(ptr, double)", "declare i1 @osty_rt_set_contains_ptr(ptr, ptr)", "declare i1 @osty_rt_set_contains_string(ptr, ptr)", "declare i1 @osty_rt_set_insert_i64(ptr, i64)", "declare i1 @osty_rt_set_insert_i1(ptr, i1)", "declare i1 @osty_rt_set_insert_f64(ptr, double)", "declare i1 @osty_rt_set_insert_ptr(ptr, ptr)", "declare i1 @osty_rt_set_insert_string(ptr, ptr)", "declare i1 @osty_rt_set_remove_i64(ptr, i64)", "declare i1 @osty_rt_set_remove_i1(ptr, i1)", "declare i1 @osty_rt_set_remove_f64(ptr, double)", "declare i1 @osty_rt_set_remove_ptr(ptr, ptr)", "declare i1 @osty_rt_set_remove_string(ptr, ptr)"}
+	return []string{
+		"declare ptr @osty_rt_set_new(i64)",
+		"declare i64 @osty_rt_set_len(ptr)",
+		"declare ptr @osty_rt_set_to_list(ptr)",
+		"declare i1 @osty_rt_set_contains_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_contains_i1(ptr, i1)",
+		"declare i1 @osty_rt_set_contains_f64(ptr, double)",
+		"declare i1 @osty_rt_set_contains_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_set_contains_string(ptr, ptr)",
+		"declare i1 @osty_rt_set_insert_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_insert_i1(ptr, i1)",
+		"declare i1 @osty_rt_set_insert_f64(ptr, double)",
+		"declare i1 @osty_rt_set_insert_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_set_insert_string(ptr, ptr)",
+		"declare i1 @osty_rt_set_remove_i64(ptr, i64)",
+		"declare i1 @osty_rt_set_remove_i1(ptr, i1)",
+		"declare i1 @osty_rt_set_remove_f64(ptr, double)",
+		"declare i1 @osty_rt_set_remove_ptr(ptr, ptr)",
+		"declare i1 @osty_rt_set_remove_string(ptr, ptr)",
+	}
 }
 
-// Osty: toolchain/llvmgen.osty:2142:5
 func llvmSetNew(emitter *LlvmEmitter, elemKind int) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_set_new", []*LlvmValue{llvmIntLiteral(elemKind)})
 }
 
-// Osty: toolchain/llvmgen.osty:2146:5
 func llvmSetLen(emitter *LlvmEmitter, set *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_set_len", []*LlvmValue{set})
 }
 
-// Osty: toolchain/llvmgen.osty:2150:5
 func llvmSetToList(emitter *LlvmEmitter, set *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_set_to_list", []*LlvmValue{set})
 }
 
-// Osty: toolchain/llvmgen.osty:2154:5
 func llvmSetContainsI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_i64", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2158:5
 func llvmSetContainsI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_i1", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2162:5
 func llvmSetContainsF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_f64", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2166:5
 func llvmSetContainsPtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_ptr", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2170:5
 func llvmSetContainsString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_string", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2174:5
 func llvmSetInsertI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_i64", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2178:5
 func llvmSetInsertI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_i1", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2182:5
 func llvmSetInsertF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_f64", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2186:5
 func llvmSetInsertPtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_ptr", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2190:5
 func llvmSetInsertString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_string", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2194:5
 func llvmSetRemoveI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_i64", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2198:5
 func llvmSetRemoveI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_i1", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2202:5
 func llvmSetRemoveF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_f64", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2206:5
 func llvmSetRemovePtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_ptr", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2210:5
 func llvmSetRemoveString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_string", []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2216:5
 func llvmSetContains(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2222:5
 	symbol := llvmSetRuntimeContainsSymbol(item.typ, isString)
-	_ = symbol
 	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2228:5
 func llvmSetInsert(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2234:5
 	symbol := llvmSetRuntimeInsertSymbol(item.typ, isString)
-	_ = symbol
 	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2240:5
 func llvmSetRemove(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2246:5
 	symbol := llvmSetRuntimeRemoveSymbol(item.typ, isString)
-	_ = symbol
 	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
 }
 
-// Osty: toolchain/llvmgen.osty:2254:5
 func llvmChanElementSuffix(elemTyp string) string {
-	// Osty: toolchain/llvmgen.osty:2255:5
 	if llvmListUsesTypedRuntime(elemTyp) {
-		// Osty: toolchain/llvmgen.osty:2256:9
 		return llvmListElementSuffix(elemTyp)
 	}
 	return "bytes_v1"
 }
 
-// Osty: toolchain/llvmgen.osty:2261:5
 func llvmChanRuntimeMakeSymbol() string {
 	return "osty_rt_thread_chan_make"
 }
 
-// Osty: toolchain/llvmgen.osty:2265:5
 func llvmChanRuntimeSendSymbol(suffix string) string {
-	return fmt.Sprintf("osty_rt_thread_chan_send_%s", ostyToString(suffix))
+	return "osty_rt_thread_chan_send_" + suffix
 }
 
-// Osty: toolchain/llvmgen.osty:2269:5
 func llvmChanRuntimeSendBytesSymbol() string {
 	return "osty_rt_thread_chan_send_bytes_v1"
 }
 
-// Osty: toolchain/llvmgen.osty:2273:5
 func llvmChanRuntimeRecvSymbol(suffix string) string {
-	return fmt.Sprintf("osty_rt_thread_chan_recv_%s", ostyToString(suffix))
+	return "osty_rt_thread_chan_recv_" + suffix
 }
 
-// Osty: toolchain/llvmgen.osty:2277:5
 func llvmChanRuntimeCloseSymbol() string {
 	return "osty_rt_thread_chan_close"
 }
 
-// Osty: toolchain/llvmgen.osty:2281:5
 func llvmChanRuntimeIsClosedSymbol() string {
 	return "osty_rt_thread_chan_is_closed"
 }
 
-// Osty: toolchain/llvmgen.osty:2291:5
 func llvmChanRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty_rt_thread_chan_make(i64)", "declare void @osty_rt_thread_chan_close(ptr)", "declare i1 @osty_rt_thread_chan_is_closed(ptr)", "declare void @osty_rt_thread_chan_send_i64(ptr, i64)", "declare void @osty_rt_thread_chan_send_i1(ptr, i1)", "declare void @osty_rt_thread_chan_send_f64(ptr, double)", "declare void @osty_rt_thread_chan_send_ptr(ptr, ptr)", "declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)", "declare { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_i1(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_f64(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_ptr(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_bytes_v1(ptr)"}
+	return []string{
+		"declare ptr @osty_rt_thread_chan_make(i64)",
+		"declare void @osty_rt_thread_chan_close(ptr)",
+		"declare i1 @osty_rt_thread_chan_is_closed(ptr)",
+		"declare void @osty_rt_thread_chan_send_i64(ptr, i64)",
+		"declare void @osty_rt_thread_chan_send_i1(ptr, i1)",
+		"declare void @osty_rt_thread_chan_send_f64(ptr, double)",
+		"declare void @osty_rt_thread_chan_send_ptr(ptr, ptr)",
+		"declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_i1(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_f64(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_ptr(ptr)",
+		"declare { i64, i64 } @osty_rt_thread_chan_recv_bytes_v1(ptr)",
+	}
 }
 
-// Osty: toolchain/llvmgen.osty:2310:5
 func llvmChanMake(emitter *LlvmEmitter, capacity *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", llvmChanRuntimeMakeSymbol(), []*LlvmValue{capacity})
 }
 
-// Osty: toolchain/llvmgen.osty:2318:5
 func llvmChanSend(emitter *LlvmEmitter, channel *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2319:5
 	symbol := llvmChanRuntimeSendSymbol(llvmListElementSuffix(value.typ))
-	_ = symbol
-	// Osty: toolchain/llvmgen.osty:2320:5
 	llvmCallVoid(emitter, symbol, []*LlvmValue{channel, value})
 }
 
-// Osty: toolchain/llvmgen.osty:2327:5
 func llvmChanSendBytes(emitter *LlvmEmitter, channel *LlvmValue, slot *LlvmValue, size *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2333:5
 	llvmCallVoid(emitter, llvmChanRuntimeSendBytesSymbol(), []*LlvmValue{channel, slot, size})
 }
 
-// Osty: toolchain/llvmgen.osty:2340:5
 func llvmChanRecv(emitter *LlvmEmitter, channel *LlvmValue, elemTyp string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2341:5
 	symbol := llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemTyp))
-	_ = symbol
 	return llvmCall(emitter, "{ i64, i64 }", symbol, []*LlvmValue{channel})
 }
 
-// Osty: toolchain/llvmgen.osty:2346:5
 func llvmChanClose(emitter *LlvmEmitter, channel *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2347:5
 	llvmCallVoid(emitter, llvmChanRuntimeCloseSymbol(), []*LlvmValue{channel})
 }
 
-// Osty: toolchain/llvmgen.osty:2352:5
 func llvmChanIsClosed(emitter *LlvmEmitter, channel *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", llvmChanRuntimeIsClosedSymbol(), []*LlvmValue{channel})
 }
 
-// Osty: toolchain/llvmgen.osty:2362:5
 func llvmClosureEnvTypeName(elemTags []string) string {
-	// Osty: toolchain/llvmgen.osty:2363:5
-	joined := llvmStrings.Join(elemTags, ".")
-	_ = joined
-	return fmt.Sprintf("ClosureEnv.%s", ostyToString(joined))
+	return "ClosureEnv." + llvmStrings.Join(elemTags, ".")
 }
 
-// Osty: toolchain/llvmgen.osty:2371:5
 func llvmClosureEnvTypeDef(name string, elemTypes []string) string {
 	return llvmStructTypeDef(name, elemTypes)
 }
 
-// Osty: toolchain/llvmgen.osty:2380:5
 func llvmClosureEnvAlloc(emitter *LlvmEmitter, envTypeName string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2381:5
 	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:2382:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", ostyToString(tmp), ostyToString(envTypeName)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", tmp, envTypeName))
 	return &LlvmValue{typ: "ptr", name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:2386:1
 func llvmClosureEnvSlotGep(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int) string {
-	// Osty: toolchain/llvmgen.osty:2392:5
 	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:2393:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %%%s, ptr %s, i32 0, i32 %s", ostyToString(tmp), ostyToString(envTypeName), ostyToString(envPtr.name), ostyToString(slotIndex)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %%%s, ptr %s, i32 0, i32 %d", tmp, envTypeName, envPtr.name, slotIndex))
 	return tmp
 }
 
-// Osty: toolchain/llvmgen.osty:2402:5
 func llvmClosureEnvStoreFn(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, fnSymbol string) {
-	// Osty: toolchain/llvmgen.osty:2408:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
-	_ = gep
-	// Osty: toolchain/llvmgen.osty:2409:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", ostyToString(fnSymbol), ostyToString(gep)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", fnSymbol, gep))
 }
 
-// Osty: toolchain/llvmgen.osty:2415:5
 func llvmClosureEnvStoreCapture(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:2422:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
-	_ = gep
-	// Osty: toolchain/llvmgen.osty:2423:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(gep)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", value.typ, value.name, gep))
 }
 
-// Osty: toolchain/llvmgen.osty:2427:5
 func llvmClosureEnvLoadFn(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2432:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
-	_ = gep
-	// Osty: toolchain/llvmgen.osty:2433:5
 	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:2434:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", ostyToString(tmp), ostyToString(gep)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", tmp, gep))
 	return &LlvmValue{typ: "ptr", name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:2441:5
 func llvmClosureEnvLoadCapture(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int, captureType string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2448:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
-	_ = gep
-	// Osty: toolchain/llvmgen.osty:2449:5
 	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:2450:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(captureType), ostyToString(gep)))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, captureType, gep))
 	return &LlvmValue{typ: captureType, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:2460:5
 func llvmClosureCallIndirect(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, returnType string, extraArgs []*LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2467:5
 	fnPtr := llvmClosureEnvLoadFn(emitter, envPtr, envTypeName)
-	_ = fnPtr
-	// Osty: toolchain/llvmgen.osty:2468:5
 	args := []*LlvmValue{envPtr}
-	_ = args
-	// Osty: toolchain/llvmgen.osty:2469:5
-	var paramTypes []string = []string{"ptr"}
-	_ = paramTypes
-	// Osty: toolchain/llvmgen.osty:2470:5
-	for _, arg := range extraArgs {
-		// Osty: toolchain/llvmgen.osty:2471:9
-		func() struct{} { args = append(args, arg); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:2472:9
-		func() struct{} { paramTypes = append(paramTypes, arg.typ); return struct{}{} }()
+	paramTypes := []string{"ptr"}
+	for _, a := range extraArgs {
+		args = append(args, a)
+		paramTypes = append(paramTypes, a.typ)
 	}
-	// Osty: toolchain/llvmgen.osty:2474:5
-	paramList := llvmStrings.Join(paramTypes, ", ")
-	_ = paramList
-	// Osty: toolchain/llvmgen.osty:2475:5
-	callType := fmt.Sprintf("%s (%s)", ostyToString(returnType), ostyToString(paramList))
-	_ = callType
-	// Osty: toolchain/llvmgen.osty:2476:5
+	callType := returnType + " (" + llvmStrings.Join(paramTypes, ", ") + ")"
 	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:2477:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", ostyToString(tmp), ostyToString(callType), ostyToString(fnPtr.name), ostyToString(llvmCallArgs(args))))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", tmp, callType, fnPtr.name, llvmCallArgs(args)))
 	return &LlvmValue{typ: returnType, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:2488:5
 func llvmFnValueCallIndirect(emitter *LlvmEmitter, returnType string, envPtr *LlvmValue, extraArgs []*LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2494:5
-	ret := func() string {
-		if returnType == "" {
-			return "void"
-		} else {
-			return returnType
-		}
-	}()
-	_ = ret
-	// Osty: toolchain/llvmgen.osty:2495:5
-	fnPtr := llvmNextTemp(emitter)
-	_ = fnPtr
-	// Osty: toolchain/llvmgen.osty:2496:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", ostyToString(fnPtr), ostyToString(envPtr.name)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:2497:5
-	args := []*LlvmValue{envPtr}
-	_ = args
-	// Osty: toolchain/llvmgen.osty:2498:5
-	var paramTypes []string = []string{"ptr"}
-	_ = paramTypes
-	// Osty: toolchain/llvmgen.osty:2499:5
-	for _, arg := range extraArgs {
-		// Osty: toolchain/llvmgen.osty:2500:9
-		func() struct{} { args = append(args, arg); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:2501:9
-		func() struct{} { paramTypes = append(paramTypes, arg.typ); return struct{}{} }()
+	ret := returnType
+	if ret == "" {
+		ret = "void"
 	}
-	// Osty: toolchain/llvmgen.osty:2503:5
+	fnPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, envPtr.name))
+	args := []*LlvmValue{envPtr}
+	paramTypes := []string{"ptr"}
+	for _, arg := range extraArgs {
+		args = append(args, arg)
+		paramTypes = append(paramTypes, arg.typ)
+	}
 	paramList := llvmStrings.Join(paramTypes, ", ")
-	_ = paramList
-	// Osty: toolchain/llvmgen.osty:2504:5
-	callType := fmt.Sprintf("%s (%s)", ostyToString(ret), ostyToString(paramList))
-	_ = callType
-	// Osty: toolchain/llvmgen.osty:2505:5
+	callType := fmt.Sprintf("%s (%s)", ret, paramList)
 	if ret == "void" {
-		// Osty: toolchain/llvmgen.osty:2506:9
-		func() struct{} {
-			emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", ostyToString(callType), ostyToString(fnPtr), ostyToString(llvmCallArgs(args))))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:2507:9
+		emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", callType, fnPtr, llvmCallArgs(args)))
 		return &LlvmValue{typ: "void", name: "", pointer: false}
 	}
-	// Osty: toolchain/llvmgen.osty:2509:5
 	tmp := llvmNextTemp(emitter)
-	_ = tmp
-	// Osty: toolchain/llvmgen.osty:2510:5
-	func() struct{} {
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", ostyToString(tmp), ostyToString(callType), ostyToString(fnPtr), ostyToString(llvmCallArgs(args))))
-		return struct{}{}
-	}()
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", tmp, callType, fnPtr, llvmCallArgs(args)))
 	return &LlvmValue{typ: ret, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:2519:5
 func llvmClosureThunkName(symbol string) string {
-	return fmt.Sprintf("__osty_closure_thunk_%s", ostyToString(symbol))
+	return "__osty_closure_thunk_" + symbol
 }
 
-// Osty: toolchain/llvmgen.osty:2529:5
 func llvmClosureThunkDefinition(symbol string, returnType string, paramTypes []string) string {
-	// Osty: toolchain/llvmgen.osty:2534:5
-	ret := func() string {
-		if returnType == "" {
-			return "void"
-		} else {
-			return returnType
-		}
-	}()
-	_ = ret
-	// Osty: toolchain/llvmgen.osty:2535:5
-	var headerParts []string = []string{"ptr %env"}
-	_ = headerParts
-	// Osty: toolchain/llvmgen.osty:2536:5
-	var argParts []string = make([]string, 0, 1)
-	_ = argParts
-	// Osty: toolchain/llvmgen.osty:2537:5
-	i := 0
-	_ = i
-	// Osty: toolchain/llvmgen.osty:2538:5
-	for _, paramType := range paramTypes {
-		// Osty: toolchain/llvmgen.osty:2539:9
-		func() struct{} {
-			headerParts = append(headerParts, fmt.Sprintf("%s %%arg%s", ostyToString(paramType), ostyToString(i)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:2540:9
-		func() struct{} {
-			argParts = append(argParts, fmt.Sprintf("%s %%arg%s", ostyToString(paramType), ostyToString(i)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:2541:9
-		func() {
-			var _cur21 int = i
-			var _rhs22 int = 1
-			if _rhs22 > 0 && _cur21 > math.MaxInt-_rhs22 {
-				panic("integer overflow")
-			}
-			if _rhs22 < 0 && _cur21 < math.MinInt-_rhs22 {
-				panic("integer overflow")
-			}
-			i = _cur21 + _rhs22
-		}()
+	ret := returnType
+	if ret == "" {
+		ret = "void"
 	}
-	// Osty: toolchain/llvmgen.osty:2543:5
+	headerParts := []string{"ptr %env"}
+	argParts := make([]string, 0, len(paramTypes))
+	for i, p := range paramTypes {
+		headerParts = append(headerParts, fmt.Sprintf("%s %%arg%d", p, i))
+		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", p, i))
+	}
 	header := llvmStrings.Join(headerParts, ", ")
-	_ = header
-	// Osty: toolchain/llvmgen.osty:2544:5
 	callArgs := llvmStrings.Join(argParts, ", ")
-	_ = callArgs
-	// Osty: toolchain/llvmgen.osty:2545:5
 	thunk := llvmClosureThunkName(symbol)
-	_ = thunk
-	// Osty: toolchain/llvmgen.osty:2546:5
-	var lines []string = make([]string, 0, 1)
-	_ = lines
-	// Osty: toolchain/llvmgen.osty:2547:5
-	func() struct{} {
-		lines = append(lines, fmt.Sprintf("define private %s @%s(%s) {", ostyToString(ret), ostyToString(thunk), ostyToString(header)))
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:2548:5
-	func() struct{} { lines = append(lines, "entry:"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:2549:5
-	if ret == "void" {
-		// Osty: toolchain/llvmgen.osty:2550:9
-		func() struct{} {
-			lines = append(lines, fmt.Sprintf("  call void @%s(%s)", ostyToString(symbol), ostyToString(callArgs)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:2551:9
-		func() struct{} { lines = append(lines, "  ret void"); return struct{}{} }()
-	} else {
-		// Osty: toolchain/llvmgen.osty:2553:9
-		func() struct{} {
-			lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", ostyToString(ret), ostyToString(symbol), ostyToString(callArgs)))
-			return struct{}{}
-		}()
-		// Osty: toolchain/llvmgen.osty:2554:9
-		func() struct{} {
-			lines = append(lines, fmt.Sprintf("  ret %s %%ret", ostyToString(ret)))
-			return struct{}{}
-		}()
+	lines := []string{
+		fmt.Sprintf("define private %s @%s(%s) {", ret, thunk, header),
+		"entry:",
 	}
-	// Osty: toolchain/llvmgen.osty:2556:5
-	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
+	if ret == "void" {
+		lines = append(lines, fmt.Sprintf("  call void @%s(%s)", symbol, callArgs))
+		lines = append(lines, "  ret void")
+	} else {
+		lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", ret, symbol, callArgs))
+		lines = append(lines, fmt.Sprintf("  ret %s %%ret", ret))
+	}
+	lines = append(lines, "}")
 	return llvmStrings.Join(lines, "\n")
 }
 
-// Osty: toolchain/llvmgen.osty:2565:5
 func llvmClosureBareFnEnv(emitter *LlvmEmitter, symbol string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2566:5
 	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
-	_ = envTypeName
-	// Osty: toolchain/llvmgen.osty:2567:5
 	env := llvmClosureEnvAlloc(emitter, envTypeName)
-	_ = env
-	// Osty: toolchain/llvmgen.osty:2568:5
 	llvmClosureEnvStoreFn(emitter, env, envTypeName, llvmClosureThunkName(symbol))
 	return env
 }
 
-// Osty: toolchain/llvmgen.osty:2575:5
 func llvmClosureBareFnEnvTypeDef() string {
 	return llvmClosureEnvTypeDef(llvmClosureEnvTypeName([]string{"ptr"}), []string{"ptr"})
 }
 
-// Osty: toolchain/llvmgen.osty:2579:5
 func llvmStringRuntimeEqualSymbol() string {
 	return "osty_rt_strings_Equal"
 }
 
-// Osty: toolchain/llvmgen.osty:2583:5
 func llvmStringRuntimeHasPrefixSymbol() string {
 	return "osty_rt_strings_HasPrefix"
 }
 
-// Osty: toolchain/llvmgen.osty:2587:5
 func llvmStringRuntimeHasSuffixSymbol() string {
 	return "osty_rt_strings_HasSuffix"
 }
 
-// Osty: toolchain/llvmgen.osty:2591:5
 func llvmStringRuntimeContainsSymbol() string {
 	return "osty_rt_strings_Contains"
 }
 
-// Osty: toolchain/llvmgen.osty:2595:5
 func llvmStringRuntimeSplitSymbol() string {
 	return "osty_rt_strings_Split"
 }
 
-// Osty: toolchain/llvmgen.osty:2599:5
 func llvmStringRuntimeSplitNSymbol() string {
 	return "osty_rt_strings_SplitN"
 }
 
-// Osty: toolchain/llvmgen.osty:2603:5
 func llvmStringRuntimeConcatSymbol() string {
 	return "osty_rt_strings_Concat"
 }
 
-// Osty: toolchain/llvmgen.osty:2607:5
 func llvmIntRuntimeToStringSymbol() string {
 	return "osty_rt_int_to_string"
 }
 
-// Osty: toolchain/llvmgen.osty:2611:5
 func llvmFloatRuntimeToStringSymbol() string {
 	return "osty_rt_float_to_string"
 }
 
-// Osty: toolchain/llvmgen.osty:2615:5
 func llvmBoolRuntimeToStringSymbol() string {
 	return "osty_rt_bool_to_string"
 }
 
-// Osty: toolchain/llvmgen.osty:2619:5
 func llvmStringRuntimeByteLenSymbol() string {
 	return "osty_rt_strings_ByteLen"
 }
 
-// Osty: toolchain/llvmgen.osty:2623:5
-func llvmStringRuntimeCountSymbol() string {
-	return "osty_rt_strings_Count"
-}
-
-// Osty: toolchain/llvmgen.osty:2627:5
-func llvmStringRuntimeIndexOfSymbol() string {
-	return "osty_rt_strings_IndexOf"
-}
-
-// Osty: toolchain/llvmgen.osty:2631:5
 func llvmStringRuntimeCompareSymbol() string {
 	return "osty_rt_strings_Compare"
 }
 
-// Osty: toolchain/llvmgen.osty:2635:5
+func llvmStringRuntimeCountSymbol() string {
+	return "osty_rt_strings_Count"
+}
+
+func llvmStringRuntimeIndexOfSymbol() string {
+	return "osty_rt_strings_IndexOf"
+}
+
 func llvmStringRuntimeJoinSymbol() string {
 	return "osty_rt_strings_Join"
 }
 
-// Osty: toolchain/llvmgen.osty:2639:5
 func llvmStringRuntimeRepeatSymbol() string {
 	return "osty_rt_strings_Repeat"
 }
 
-// Osty: toolchain/llvmgen.osty:2643:5
 func llvmStringRuntimeReplaceSymbol() string {
 	return "osty_rt_strings_Replace"
 }
 
-// Osty: toolchain/llvmgen.osty:2647:5
 func llvmStringRuntimeReplaceAllSymbol() string {
 	return "osty_rt_strings_ReplaceAll"
 }
 
-// Osty: toolchain/llvmgen.osty:2651:5
 func llvmStringRuntimeSliceSymbol() string {
 	return "osty_rt_strings_Slice"
 }
 
-// Osty: toolchain/llvmgen.osty:2655:5
 func llvmStringRuntimeTrimStartSymbol() string {
 	return "osty_rt_strings_TrimStart"
 }
 
-// Osty: toolchain/llvmgen.osty:2659:5
 func llvmStringRuntimeTrimEndSymbol() string {
 	return "osty_rt_strings_TrimEnd"
 }
 
-// Osty: toolchain/llvmgen.osty:2663:5
 func llvmStringRuntimeTrimPrefixSymbol() string {
 	return "osty_rt_strings_TrimPrefix"
 }
 
-// Osty: toolchain/llvmgen.osty:2667:5
 func llvmStringRuntimeTrimSuffixSymbol() string {
 	return "osty_rt_strings_TrimSuffix"
 }
 
-// Osty: toolchain/llvmgen.osty:2671:5
 func llvmStringRuntimeTrimSpaceSymbol() string {
 	return "osty_rt_strings_TrimSpace"
 }
 
-// Osty: toolchain/llvmgen.osty:2675:5
 func llvmStringRuntimeCharsSymbol() string {
 	return "osty_rt_strings_Chars"
 }
 
-// Osty: toolchain/llvmgen.osty:2679:5
 func llvmStringRuntimeBytesSymbol() string {
 	return "osty_rt_strings_Bytes"
 }
 
-// Osty: toolchain/llvmgen.osty:2683:5
 func llvmStringRuntimeToBytesSymbol() string {
 	return "osty_rt_strings_ToBytes"
 }
 
-// Osty: toolchain/llvmgen.osty:2693:5
 func llvmStringRuntimeDeclarations() []string {
-	return []string{"declare i1 @osty_rt_strings_Equal(ptr, ptr)", "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)", "declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)", "declare i1 @osty_rt_strings_Contains(ptr, ptr)", "declare ptr @osty_rt_strings_Split(ptr, ptr)", "declare ptr @osty_rt_strings_Concat(ptr, ptr)", "declare ptr @osty_rt_int_to_string(i64)", "declare ptr @osty_rt_float_to_string(double)", "declare ptr @osty_rt_bool_to_string(i1)", "declare i64 @osty_rt_strings_ByteLen(ptr)", "declare i64 @osty_rt_strings_Count(ptr, ptr)", "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "declare i64 @osty_rt_strings_Compare(ptr, ptr)", "declare ptr @osty_rt_strings_Join(ptr, ptr)", "declare ptr @osty_rt_strings_Repeat(ptr, i64)", "declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_Slice(ptr, i64, i64)", "declare ptr @osty_rt_strings_TrimStart(ptr)", "declare ptr @osty_rt_strings_TrimEnd(ptr)", "declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSpace(ptr)", "declare ptr @osty_rt_strings_Chars(ptr)", "declare ptr @osty_rt_strings_Bytes(ptr)", "declare ptr @osty_rt_strings_ToBytes(ptr)"}
+	return []string{
+		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
+		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
+		"declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)",
+		"declare i1 @osty_rt_strings_Contains(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
+		"declare ptr @osty_rt_int_to_string(i64)",
+		"declare ptr @osty_rt_float_to_string(double)",
+		"declare ptr @osty_rt_bool_to_string(i1)",
+		"declare i64 @osty_rt_strings_ByteLen(ptr)",
+		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
+		"declare i64 @osty_rt_strings_Count(ptr, ptr)",
+		"declare i64 @osty_rt_strings_IndexOf(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Join(ptr, ptr)",
+		"declare ptr @osty_rt_strings_Repeat(ptr, i64)",
+		"declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)",
+		"declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)",
+		"declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
+		"declare ptr @osty_rt_strings_TrimStart(ptr)",
+		"declare ptr @osty_rt_strings_TrimEnd(ptr)",
+		"declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)",
+		"declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)",
+		"declare ptr @osty_rt_strings_TrimSpace(ptr)",
+		"declare ptr @osty_rt_strings_Chars(ptr)",
+		"declare ptr @osty_rt_strings_Bytes(ptr)",
+		"declare ptr @osty_rt_strings_ToBytes(ptr)",
+	}
 }
 
-// Osty: toolchain/llvmgen.osty:2724:5
 func llvmStringEqual(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_strings_Equal", []*LlvmValue{left, right})
 }
 
-// Osty: toolchain/llvmgen.osty:2728:5
 func llvmStringHasPrefix(emitter *LlvmEmitter, value *LlvmValue, prefix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_strings_HasPrefix", []*LlvmValue{value, prefix})
 }
 
-// Osty: toolchain/llvmgen.osty:2732:5
 func llvmStringHasSuffix(emitter *LlvmEmitter, value *LlvmValue, suffix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_strings_HasSuffix", []*LlvmValue{value, suffix})
 }
 
-// Osty: toolchain/llvmgen.osty:2736:5
 func llvmStringSplit(emitter *LlvmEmitter, value *LlvmValue, sep *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Split", []*LlvmValue{value, sep})
 }
 
-// Osty: toolchain/llvmgen.osty:2740:5
 func llvmStringConcat(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Concat", []*LlvmValue{left, right})
 }
 
-// Osty: toolchain/llvmgen.osty:2744:5
 func llvmIntRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_int_to_string", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2748:5
 func llvmFloatRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_float_to_string", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2752:5
 func llvmBoolRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_bool_to_string", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2756:5
 func llvmStringCompare(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:2762:5
 	if op == "==" {
-		// Osty: toolchain/llvmgen.osty:2763:9
 		return llvmStringEqual(emitter, left, right)
 	}
-	// Osty: toolchain/llvmgen.osty:2765:5
 	if op == "!=" {
-		// Osty: toolchain/llvmgen.osty:2766:9
 		return llvmNotI1(emitter, llvmStringEqual(emitter, left, right))
 	}
-	// Osty: toolchain/llvmgen.osty:2768:5
 	cmp := llvmStringRuntimeCompare(emitter, left, right)
-	_ = cmp
 	return llvmCompare(emitter, llvmIntComparePredicate(op), cmp, llvmIntLiteral(0))
 }
 
-// Osty: toolchain/llvmgen.osty:2772:5
 func llvmStringByteLen(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2776:5
-func llvmStringRuntimeCount(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i64", "osty_rt_strings_Count", []*LlvmValue{value, substr})
-}
-
-// Osty: toolchain/llvmgen.osty:2784:5
-func llvmStringRuntimeIndexOf(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i64", "osty_rt_strings_IndexOf", []*LlvmValue{value, substr})
-}
-
-// Osty: toolchain/llvmgen.osty:2792:5
 func llvmStringRuntimeCompare(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_strings_Compare", []*LlvmValue{left, right})
 }
 
-// Osty: toolchain/llvmgen.osty:2800:5
+func llvmStringRuntimeCount(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_strings_Count", []*LlvmValue{value, substr})
+}
+
+func llvmStringRuntimeIndexOf(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_strings_IndexOf", []*LlvmValue{value, substr})
+}
+
 func llvmStringRuntimeJoin(emitter *LlvmEmitter, parts *LlvmValue, sep *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Join", []*LlvmValue{parts, sep})
 }
 
-// Osty: toolchain/llvmgen.osty:2808:5
 func llvmStringRuntimeRepeat(emitter *LlvmEmitter, value *LlvmValue, n *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Repeat", []*LlvmValue{value, n})
 }
 
-// Osty: toolchain/llvmgen.osty:2816:5
 func llvmStringRuntimeReplace(emitter *LlvmEmitter, value *LlvmValue, old *LlvmValue, newValue *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Replace", []*LlvmValue{value, old, newValue})
 }
 
-// Osty: toolchain/llvmgen.osty:2825:5
 func llvmStringRuntimeReplaceAll(emitter *LlvmEmitter, value *LlvmValue, old *LlvmValue, newValue *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_ReplaceAll", []*LlvmValue{value, old, newValue})
 }
 
-// Osty: toolchain/llvmgen.osty:2834:5
 func llvmStringRuntimeSlice(emitter *LlvmEmitter, value *LlvmValue, start *LlvmValue, end *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Slice", []*LlvmValue{value, start, end})
 }
 
-// Osty: toolchain/llvmgen.osty:2843:5
 func llvmStringRuntimeTrimStart(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimStart", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2847:5
 func llvmStringRuntimeTrimEnd(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimEnd", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2851:5
 func llvmStringRuntimeTrimPrefix(emitter *LlvmEmitter, value *LlvmValue, prefix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimPrefix", []*LlvmValue{value, prefix})
 }
 
-// Osty: toolchain/llvmgen.osty:2859:5
 func llvmStringRuntimeTrimSuffix(emitter *LlvmEmitter, value *LlvmValue, suffix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimSuffix", []*LlvmValue{value, suffix})
 }
 
-// Osty: toolchain/llvmgen.osty:2867:5
 func llvmStringRuntimeTrimSpace(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimSpace", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2871:5
 func llvmStringChars(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Chars", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2875:5
 func llvmStringBytes(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Bytes", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2879:5
 func llvmStringToBytes(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_ToBytes", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:2883:5
 func llvmBuiltinType(name string) string {
-	// Osty: toolchain/llvmgen.osty:2884:5
-	if name == "Int" {
-		// Osty: toolchain/llvmgen.osty:2885:9
+	switch name {
+	case "Int":
 		return "i64"
-	}
-	// Osty: toolchain/llvmgen.osty:2887:5
-	if name == "Float" {
-		// Osty: toolchain/llvmgen.osty:2888:9
+	case "Float":
 		return "double"
-	}
-	// Osty: toolchain/llvmgen.osty:2890:5
-	if name == "Bool" {
-		// Osty: toolchain/llvmgen.osty:2891:9
+	case "Bool":
 		return "i1"
-	}
-	// Osty: toolchain/llvmgen.osty:2893:5
-	if name == "Char" {
-		// Osty: toolchain/llvmgen.osty:2894:9
+	case "Char":
 		return "i32"
-	}
-	// Osty: toolchain/llvmgen.osty:2896:5
-	if name == "Byte" {
-		// Osty: toolchain/llvmgen.osty:2897:9
+	case "Byte":
 		return "i8"
-	}
-	// Osty: toolchain/llvmgen.osty:2899:5
-	if name == "String" || name == "Bytes" || name == "Error" {
-		// Osty: toolchain/llvmgen.osty:2900:9
+	case "String", "Bytes", "Error":
 		return "ptr"
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:2905:5
 func llvmRuntimeAbiBuiltinType(name string) string {
-	// Osty: toolchain/llvmgen.osty:2906:5
-	if name == "Int" || name == "Float" || name == "Bool" || name == "Char" || name == "Byte" || name == "String" {
-		// Osty: toolchain/llvmgen.osty:2907:9
+	switch name {
+	case "Int", "Float", "Bool", "Char", "Byte", "String":
 		return llvmBuiltinType(name)
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:2912:5
 func llvmEnumPayloadBuiltinType(name string) string {
-	// Osty: toolchain/llvmgen.osty:2913:5
-	if name == "Int" || name == "Float" || name == "Char" || name == "Byte" || name == "String" {
-		// Osty: toolchain/llvmgen.osty:2914:9
+	switch name {
+	case "Int", "Float", "Char", "Byte", "String":
 		return llvmBuiltinType(name)
+	default:
+		return ""
 	}
-	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:2919:5
 func llvmZeroLiteral(typ string) string {
-	// Osty: toolchain/llvmgen.osty:2920:5
-	if typ == "double" {
-		// Osty: toolchain/llvmgen.osty:2921:9
+	switch typ {
+	case "double":
 		return "0.0"
-	}
-	// Osty: toolchain/llvmgen.osty:2923:5
-	if typ == "ptr" {
-		// Osty: toolchain/llvmgen.osty:2924:9
+	case "ptr":
 		return "null"
+	default:
+		return "0"
 	}
-	return "0"
 }
 
-// Osty: toolchain/llvmgen.osty:2929:5
 func llvmStructTypeName(name string) string {
-	return fmt.Sprintf("%%%s", ostyToString(name))
+	return "%" + name
 }
 
-// Osty: toolchain/llvmgen.osty:2933:5
 func llvmEnumStorageType(name string, hasPayload bool) string {
-	// Osty: toolchain/llvmgen.osty:2934:5
 	if hasPayload {
-		// Osty: toolchain/llvmgen.osty:2935:9
 		return llvmStructTypeName(name)
 	}
 	return "i64"
 }
 
-// Osty: toolchain/llvmgen.osty:2940:5
 func llvmSignatureParamName(name string, index int) string {
-	// Osty: toolchain/llvmgen.osty:2941:5
 	if name != "" {
-		// Osty: toolchain/llvmgen.osty:2942:9
 		return name
 	}
-	return fmt.Sprintf("arg%s", ostyToString(index))
+	return fmt.Sprintf("arg%d", index)
 }
 
-// Osty: toolchain/llvmgen.osty:2947:5
 func llvmAllowsMainSignature(paramCount int, hasReturnType bool) bool {
-	return paramCount == 0 && !(hasReturnType)
+	return paramCount == 0 && !hasReturnType
 }
 
-// Osty: toolchain/llvmgen.osty:2951:5
 func llvmNamedType(name string, pathLen int, argLen int, structType string, enumType string) string {
-	// Osty: toolchain/llvmgen.osty:2958:5
 	if pathLen != 1 || argLen != 0 {
-		// Osty: toolchain/llvmgen.osty:2959:9
 		return "ptr"
 	}
-	// Osty: toolchain/llvmgen.osty:2961:5
-	builtin := llvmBuiltinType(name)
-	_ = builtin
-	// Osty: toolchain/llvmgen.osty:2962:5
-	if builtin != "" {
-		// Osty: toolchain/llvmgen.osty:2963:9
+	if builtin := llvmBuiltinType(name); builtin != "" {
 		return builtin
 	}
-	// Osty: toolchain/llvmgen.osty:2965:5
 	if structType != "" {
-		// Osty: toolchain/llvmgen.osty:2966:9
 		return structType
 	}
-	// Osty: toolchain/llvmgen.osty:2968:5
 	if enumType != "" {
-		// Osty: toolchain/llvmgen.osty:2969:9
 		return enumType
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:2974:5
 func llvmRuntimeAbiNamedType(name string, pathLen int, argLen int, structType string, enumType string) string {
-	// Osty: toolchain/llvmgen.osty:2981:5
 	if pathLen == 1 && argLen == 0 {
-		// Osty: toolchain/llvmgen.osty:2982:9
-		builtin := llvmRuntimeAbiBuiltinType(name)
-		_ = builtin
-		// Osty: toolchain/llvmgen.osty:2983:9
-		if builtin != "" {
-			// Osty: toolchain/llvmgen.osty:2984:13
+		if builtin := llvmRuntimeAbiBuiltinType(name); builtin != "" {
 			return builtin
 		}
-		// Osty: toolchain/llvmgen.osty:2986:9
 		if structType != "" {
-			// Osty: toolchain/llvmgen.osty:2987:13
 			return structType
 		}
-		// Osty: toolchain/llvmgen.osty:2989:9
 		if enumType != "" {
-			// Osty: toolchain/llvmgen.osty:2990:13
 			return enumType
 		}
 	}
 	return "ptr"
 }
 
-// Osty: toolchain/llvmgen.osty:2996:5
 func llvmEnumPayloadNamedType(name string, pathLen int, argLen int) string {
-	// Osty: toolchain/llvmgen.osty:2997:5
 	if pathLen != 1 || argLen != 0 {
-		// Osty: toolchain/llvmgen.osty:2998:9
 		return ""
 	}
 	return llvmEnumPayloadBuiltinType(name)
 }
 
-// Osty: toolchain/llvmgen.osty:3003:5
 func llvmNominalDeclHeaderDiagnostic(kind string, name string, identOk bool, genericCount int, methodCount int) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3010:5
-	if !(identOk) {
-		// Osty: toolchain/llvmgen.osty:3011:9
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("%s name \"%s\"", ostyToString(kind), ostyToString(name)))
+	if !identOk {
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("%s name %q", kind, name))
 	}
-	// Osty: toolchain/llvmgen.osty:3013:5
 	if genericCount != 0 {
-		// Osty: toolchain/llvmgen.osty:3014:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("generic %s \"%s\" is not supported", ostyToString(kind), ostyToString(name)))
-	}
-	// Osty: toolchain/llvmgen.osty:3019:5
-	if methodCount != 0 {
-		// Osty: toolchain/llvmgen.osty:3020:9
-		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("%s \"%s\" methods are not supported", ostyToString(kind), ostyToString(name)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("generic %s %q is not supported", kind, name))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3028:5
 func llvmFunctionHeaderDiagnostic(name string, identOk bool, hasRecv bool, genericCount int, hasBody bool, isMain bool, paramCount int, hasReturnType bool) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3038:5
-	if !(identOk) {
-		// Osty: toolchain/llvmgen.osty:3039:9
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("function name \"%s\"", ostyToString(name)))
+	if !identOk {
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("function name %q", name))
 	}
-	// Osty: toolchain/llvmgen.osty:3041:5
-	if hasRecv {
-		// Osty: toolchain/llvmgen.osty:3042:9
-		return llvmUnsupportedDiagnostic("function-signature", "methods are not supported")
-	}
-	// Osty: toolchain/llvmgen.osty:3044:5
 	if genericCount != 0 {
-		// Osty: toolchain/llvmgen.osty:3045:9
 		return llvmUnsupportedDiagnostic("function-signature", "generic functions are not supported")
 	}
-	// Osty: toolchain/llvmgen.osty:3050:5
-	if !(hasBody) {
-		// Osty: toolchain/llvmgen.osty:3051:9
-		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("function \"%s\" has no body", ostyToString(name)))
+	if !hasBody {
+		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("function %q has no body", name))
 	}
-	// Osty: toolchain/llvmgen.osty:3053:5
-	if isMain && !(llvmAllowsMainSignature(paramCount, hasReturnType)) {
-		// Osty: toolchain/llvmgen.osty:3054:9
+	if isMain && !llvmAllowsMainSignature(paramCount, hasReturnType) {
 		return llvmUnsupportedDiagnostic("function-signature", "LLVM main must have no params and no return type")
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3062:5
 func llvmIsRuntimeAbiListType(name string, pathLen int, argLen int) bool {
 	return name == "List" && pathLen == 1 && argLen == 1
 }
 
-// Osty: toolchain/llvmgen.osty:3066:5
 func llvmStructFieldDiagnostic(structName string, fieldName string, identOk bool, hasDefault bool, duplicate bool, recursive bool, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3075:5
-	if !(identOk) {
-		// Osty: toolchain/llvmgen.osty:3076:9
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("struct \"%s\" field name \"%s\"", ostyToString(structName), ostyToString(fieldName)))
+	if !identOk {
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("struct %q field name %q", structName, fieldName))
 	}
-	// Osty: toolchain/llvmgen.osty:3081:5
 	if hasDefault {
-		// Osty: toolchain/llvmgen.osty:3082:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct \"%s\" field \"%s\" has a default value", ostyToString(structName), ostyToString(fieldName)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct %q field %q has a default value", structName, fieldName))
 	}
-	// Osty: toolchain/llvmgen.osty:3087:5
 	if duplicate {
-		// Osty: toolchain/llvmgen.osty:3088:9
-		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("struct \"%s\" duplicate field \"%s\"", ostyToString(structName), ostyToString(fieldName)))
+		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("struct %q duplicate field %q", structName, fieldName))
 	}
-	// Osty: toolchain/llvmgen.osty:3093:5
 	if detail != "" {
-		// Osty: toolchain/llvmgen.osty:3094:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct \"%s\" field \"%s\": %s", ostyToString(structName), ostyToString(fieldName), ostyToString(detail)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct %q field %q: %s", structName, fieldName, detail))
 	}
-	// Osty: toolchain/llvmgen.osty:3099:5
 	if recursive {
-		// Osty: toolchain/llvmgen.osty:3100:9
-		return llvmUnsupportedDiagnosticWith("LLVM011", "type-system", fmt.Sprintf("struct \"%s\" recursive field \"%s\" requires indirection", ostyToString(structName), ostyToString(fieldName)), "break the cycle via an arena index (Int id) or List<T> handle until the LLVM backend grows recursive-struct support")
+		return llvmUnsupportedDiagnosticWith(
+			"LLVM011",
+			"type-system",
+			fmt.Sprintf("struct %q recursive field %q requires indirection", structName, fieldName),
+			"break the cycle via an arena index (Int id) or List<T> handle until the LLVM backend grows recursive-struct support",
+		)
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3110:5
 func llvmEnumVariantHeaderDiagnostic(enumName string, variantName string, identOk bool, payloadCount int, duplicate bool) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3117:5
-	if !(identOk) {
-		// Osty: toolchain/llvmgen.osty:3118:9
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("enum \"%s\" variant name \"%s\"", ostyToString(enumName), ostyToString(variantName)))
+	if !identOk {
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("enum %q variant name %q", enumName, variantName))
 	}
-	// Osty: toolchain/llvmgen.osty:3123:5
 	if duplicate {
-		// Osty: toolchain/llvmgen.osty:3124:9
-		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("enum \"%s\" duplicate variant \"%s\"", ostyToString(enumName), ostyToString(variantName)))
+		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("enum %q duplicate variant %q", enumName, variantName))
 	}
-	// Osty: toolchain/llvmgen.osty:3129:5
 	_ = payloadCount
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3133:5
 func llvmEnumBoxedMultiFieldDiagnostic(enumName string, variantName string, payloadCount int) *LlvmUnsupportedDiagnostic {
-	return llvmUnsupportedDiagnosticWith("LLVM011", "type-system", fmt.Sprintf("enum \"%s\" variant \"%s\" has %s payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet", ostyToString(enumName), ostyToString(variantName), ostyToString(payloadCount)), "keep a single boxed payload per variant, or make all variant payloads share one scalar/pointer type so the inline multi-slot layout can be used")
+	return llvmUnsupportedDiagnosticWith(
+		"LLVM011",
+		"type-system",
+		fmt.Sprintf("enum %q variant %q has %d payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet", enumName, variantName, payloadCount),
+		"keep a single boxed payload per variant, or make all variant payloads share one scalar/pointer type so the inline multi-slot layout can be used",
+	)
 }
 
-// Osty: toolchain/llvmgen.osty:3146:5
 func llvmEnumPayloadDiagnostic(enumName string, variantName string, detail string, expectedType string, actualType string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3153:5
 	if detail != "" {
-		// Osty: toolchain/llvmgen.osty:3154:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum \"%s\" variant \"%s\" payload: %s", ostyToString(enumName), ostyToString(variantName), ostyToString(detail)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q variant %q payload: %s", enumName, variantName, detail))
 	}
-	// Osty: toolchain/llvmgen.osty:3159:5
 	if expectedType != "" && actualType != "" && expectedType != actualType {
-		// Osty: toolchain/llvmgen.osty:3160:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum \"%s\" mixes payload types %s and %s; heterogeneous-payload enums require boxed representation (deferred)", ostyToString(enumName), ostyToString(expectedType), ostyToString(actualType)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q mixes payload types %s and %s; heterogeneous-payload enums require boxed representation (deferred)", enumName, expectedType, actualType))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3168:5
 func llvmRuntimeFfiHeaderUnsupported(hasRecv bool, genericCount int) string {
-	// Osty: toolchain/llvmgen.osty:3169:5
 	if hasRecv {
-		// Osty: toolchain/llvmgen.osty:3170:9
 		return "methods are not supported"
 	}
-	// Osty: toolchain/llvmgen.osty:3172:5
 	if genericCount != 0 {
-		// Osty: toolchain/llvmgen.osty:3173:9
 		return "generic functions are not supported"
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:3178:5
 func llvmRuntimeFfiReturnUnsupported(detail string) string {
-	// Osty: toolchain/llvmgen.osty:3179:5
 	if detail != "" {
-		// Osty: toolchain/llvmgen.osty:3180:9
-		return fmt.Sprintf("return type: %s", ostyToString(detail))
+		return "return type: " + detail
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:3185:5
 func llvmRuntimeFfiParamUnsupported(name string, nilParam bool, hasPatternOrDefault bool, detail string) string {
-	// Osty: toolchain/llvmgen.osty:3191:5
 	if nilParam {
-		// Osty: toolchain/llvmgen.osty:3192:9
 		return "nil parameter"
 	}
-	// Osty: toolchain/llvmgen.osty:3194:5
 	if hasPatternOrDefault {
-		// Osty: toolchain/llvmgen.osty:3195:9
 		return "pattern/default parameters are not supported"
 	}
-	// Osty: toolchain/llvmgen.osty:3197:5
 	if detail != "" {
-		// Osty: toolchain/llvmgen.osty:3198:9
-		return fmt.Sprintf("parameter \"%s\": %s", ostyToString(name), ostyToString(detail))
+		return fmt.Sprintf("parameter %q: %s", name, detail)
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:3203:5
 func llvmFunctionReturnDiagnostic(name string, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3204:5
 	if detail != "" {
-		// Osty: toolchain/llvmgen.osty:3205:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function \"%s\" return type: %s", ostyToString(name), ostyToString(detail)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function %q return type: %s", name, detail))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3210:5
 func llvmFunctionParamDiagnostic(fnName string, paramName string, missingOrPattern bool, hasDefault bool, identOk bool, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:3218:5
 	if missingOrPattern {
-		// Osty: toolchain/llvmgen.osty:3219:9
-		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function \"%s\" has non-identifier parameter", ostyToString(fnName)))
+		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function %q has non-identifier parameter", fnName))
 	}
-	// Osty: toolchain/llvmgen.osty:3224:5
 	if hasDefault {
-		// Osty: toolchain/llvmgen.osty:3225:9
-		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function \"%s\" has default parameter values", ostyToString(fnName)))
+		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function %q has default parameter values", fnName))
 	}
-	// Osty: toolchain/llvmgen.osty:3230:5
-	if !(identOk) {
-		// Osty: toolchain/llvmgen.osty:3231:9
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("parameter name \"%s\"", ostyToString(paramName)))
+	if !identOk {
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("parameter name %q", paramName))
 	}
-	// Osty: toolchain/llvmgen.osty:3233:5
 	if detail != "" {
-		// Osty: toolchain/llvmgen.osty:3234:9
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function \"%s\" parameter \"%s\": %s", ostyToString(fnName), ostyToString(paramName), ostyToString(detail)))
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function %q parameter %q: %s", fnName, paramName, detail))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:3242:5
+// Osty: toolchain/llvmgen.osty:875:5
 func llvmSmokeExecutableCorpus() []*LlvmSmokeExecutableCase {
 	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}, &LlvmSmokeExecutableCase{name: "string-return", fixture: "string_return_print.osty", stdout: "from function\n"}, &LlvmSmokeExecutableCase{name: "string-param", fixture: "string_param_print.osty", stdout: "param string\n"}, &LlvmSmokeExecutableCase{name: "string-mut", fixture: "string_mut_print.osty", stdout: "after\n"}, &LlvmSmokeExecutableCase{name: "struct-field", fixture: "struct_field_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-return", fixture: "struct_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-param", fixture: "struct_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-mut", fixture: "struct_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-variant", fixture: "enum_variant_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-return", fixture: "enum_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-param", fixture: "enum_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-mut", fixture: "enum_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match", fixture: "enum_match_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match-return", fixture: "enum_match_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match-param", fixture: "enum_match_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match-mut", fixture: "enum_match_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload", fixture: "enum_payload_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload-return", fixture: "enum_payload_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload-param", fixture: "enum_payload_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload-mut", fixture: "enum_payload_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "float-print", fixture: "float_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-arithmetic", fixture: "float_arithmetic_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-return", fixture: "float_return_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-param", fixture: "float_param_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-mutable", fixture: "float_mut_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-compare", fixture: "float_compare_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-struct", fixture: "float_struct_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-enum-payload", fixture: "float_enum_payload_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-return", fixture: "float_payload_return_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-param", fixture: "float_payload_param_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-mut", fixture: "float_payload_mut_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-reversed", fixture: "float_payload_reversed_match_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-wildcard", fixture: "float_payload_wildcard_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "string-payload-return", fixture: "string_payload_return_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-param", fixture: "string_payload_param_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-mut", fixture: "string_payload_mut_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-reversed", fixture: "string_payload_reversed_match_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-wildcard", fixture: "string_payload_wildcard_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "int-if-expr", fixture: "int_if_expr_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "string-if-expr", fixture: "string_if_expr_print.osty", stdout: "chosen string\n"}, &LlvmSmokeExecutableCase{name: "float-if-expr", fixture: "float_if_expr_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "bool-param-return", fixture: "bool_param_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "int-range-exclusive", fixture: "int_range_exclusive_print.osty", stdout: "21\n"}, &LlvmSmokeExecutableCase{name: "int-unary", fixture: "int_unary_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "int-modulo", fixture: "int_modulo_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-string-field", fixture: "struct_string_field_print.osty", stdout: "struct string\n"}, &LlvmSmokeExecutableCase{name: "struct-bool-field", fixture: "struct_bool_field_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "bool-mut", fixture: "bool_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "result-question-int", fixture: "result_question_int_print.osty", stdout: "42\n"}}
 }
 
-// Osty: toolchain/llvmgen.osty:3522:5
+// Osty: toolchain/llvmgen.osty:1150:5
 func llvmSmokeMinimalPrintIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3523:5
+	// Osty: toolchain/llvmgen.osty:1151:5
 	emitter := llvmEmitter()
 	_ = emitter
-	// Osty: toolchain/llvmgen.osty:3524:5
+	// Osty: toolchain/llvmgen.osty:1152:5
 	value := llvmBinaryI64(emitter, "add", llvmIntLiteral(40), llvmIntLiteral(2))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:3525:5
+	// Osty: toolchain/llvmgen.osty:1153:5
 	llvmPrintlnI64(emitter, value)
-	// Osty: toolchain/llvmgen.osty:3526:5
+	// Osty: toolchain/llvmgen.osty:1154:5
 	llvmReturnI32Zero(emitter)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), emitter.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3536:5
+// Osty: toolchain/llvmgen.osty:1164:5
 func llvmSmokeGcRuntimeAbiIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3537:5
+	// Osty: toolchain/llvmgen.osty:1165:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3538:5
+	// Osty: toolchain/llvmgen.osty:1166:5
 	object := llvmGcAlloc(main, 1, 32, "llvm.gc.object")
 	_ = object
-	// Osty: toolchain/llvmgen.osty:3539:5
+	// Osty: toolchain/llvmgen.osty:1167:5
 	llvmGcRootBind(main, object)
-	// Osty: toolchain/llvmgen.osty:3540:5
+	// Osty: toolchain/llvmgen.osty:1168:5
 	child := llvmGcAlloc(main, 2, 16, "llvm.gc.child")
 	_ = child
-	// Osty: toolchain/llvmgen.osty:3541:5
+	// Osty: toolchain/llvmgen.osty:1169:5
 	llvmGcPreWrite(main, object, child, 0)
-	// Osty: toolchain/llvmgen.osty:3542:5
+	// Osty: toolchain/llvmgen.osty:1170:5
 	loaded := llvmGcLoad(main, child)
 	_ = loaded
-	// Osty: toolchain/llvmgen.osty:3543:5
+	// Osty: toolchain/llvmgen.osty:1171:5
 	llvmGcPostWrite(main, object, loaded, 0)
-	// Osty: toolchain/llvmgen.osty:3544:5
+	// Osty: toolchain/llvmgen.osty:1172:5
 	llvmGcRootRelease(main, object)
-	// Osty: toolchain/llvmgen.osty:3545:5
+	// Osty: toolchain/llvmgen.osty:1173:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGcRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3565:5
-func llvmSmokeClosureThunkIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3566:5
-	doubleBody := llvmEmitter()
-	_ = doubleBody
-	// Osty: toolchain/llvmgen.osty:3567:5
-	llvmBind(doubleBody, "x", &LlvmValue{typ: "i64", name: "%x", pointer: false})
-	// Osty: toolchain/llvmgen.osty:3568:5
-	doubled := llvmBinaryI64(doubleBody, "mul", llvmIdent(doubleBody, "x"), llvmIntLiteral(2))
-	_ = doubled
-	// Osty: toolchain/llvmgen.osty:3574:5
-	llvmReturn(doubleBody, doubled)
-	// Osty: toolchain/llvmgen.osty:3576:5
-	main := llvmEmitter()
-	_ = main
-	// Osty: toolchain/llvmgen.osty:3577:5
-	env := llvmClosureBareFnEnv(main, "double_val")
-	_ = env
-	// Osty: toolchain/llvmgen.osty:3578:5
-	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
-	_ = envTypeName
-	// Osty: toolchain/llvmgen.osty:3579:5
-	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{llvmIntLiteral(21)})
-	_ = result
-	// Osty: toolchain/llvmgen.osty:3586:5
-	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:3587:5
-	llvmReturnI32Zero(main)
-	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmClosureBareFnEnvTypeDef()}, main.stringGlobals, []string{llvmRenderFunction("i64", "double_val", []*LlvmParam{llvmParam("x", "i64")}, doubleBody.body), llvmClosureThunkDefinition("double_val", "i64", []string{"i64"}), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
-}
-
-// Osty: toolchain/llvmgen.osty:3614:5
-func llvmSmokeClosureBasicIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3615:5
-	envTypeName := llvmClosureEnvTypeName([]string{"ptr", "i64"})
-	_ = envTypeName
-	// Osty: toolchain/llvmgen.osty:3616:5
-	typeDef := llvmClosureEnvTypeDef(envTypeName, []string{"ptr", "i64"})
-	_ = typeDef
-	// Osty: toolchain/llvmgen.osty:3618:5
-	body := llvmEmitter()
-	_ = body
-	// Osty: toolchain/llvmgen.osty:3619:5
-	llvmBind(body, "env", &LlvmValue{typ: "ptr", name: "%env", pointer: false})
-	// Osty: toolchain/llvmgen.osty:3620:5
-	envArg := llvmIdent(body, "env")
-	_ = envArg
-	// Osty: toolchain/llvmgen.osty:3621:5
-	captured := llvmClosureEnvLoadCapture(body, envArg, envTypeName, 1, "i64")
-	_ = captured
-	// Osty: toolchain/llvmgen.osty:3622:5
-	llvmReturn(body, captured)
-	// Osty: toolchain/llvmgen.osty:3624:5
-	main := llvmEmitter()
-	_ = main
-	// Osty: toolchain/llvmgen.osty:3625:5
-	env := llvmClosureEnvAlloc(main, envTypeName)
-	_ = env
-	// Osty: toolchain/llvmgen.osty:3626:5
-	llvmClosureEnvStoreFn(main, env, envTypeName, "closure_body")
-	// Osty: toolchain/llvmgen.osty:3627:5
-	llvmClosureEnvStoreCapture(main, env, envTypeName, 1, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:3628:5
-	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", make([]*LlvmValue, 0, 1))
-	_ = result
-	// Osty: toolchain/llvmgen.osty:3629:5
-	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:3630:5
-	llvmReturnI32Zero(main)
-	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{typeDef}, main.stringGlobals, []string{llvmRenderFunction("i64", "closure_body", []*LlvmParam{llvmParam("env", "ptr")}, body.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
-}
-
-// Osty: toolchain/llvmgen.osty:3654:5
-func llvmSmokeSetBasicIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3655:5
-	main := llvmEmitter()
-	_ = main
-	// Osty: toolchain/llvmgen.osty:3656:5
-	set := llvmSetNew(main, llvmContainerAbiKind("i64", false))
-	_ = set
-	// Osty: toolchain/llvmgen.osty:3657:5
-	_a := llvmSetInsertI64(main, set, llvmIntLiteral(10))
-	_ = _a
-	// Osty: toolchain/llvmgen.osty:3658:5
-	_b := llvmSetInsertI64(main, set, llvmIntLiteral(20))
-	_ = _b
-	// Osty: toolchain/llvmgen.osty:3659:5
-	_c := llvmSetInsertI64(main, set, llvmIntLiteral(30))
-	_ = _c
-	// Osty: toolchain/llvmgen.osty:3660:5
-	_present := llvmSetContainsI64(main, set, llvmIntLiteral(20))
-	_ = _present
-	// Osty: toolchain/llvmgen.osty:3661:5
-	_removed := llvmSetRemoveI64(main, set, llvmIntLiteral(20))
-	_ = _removed
-	// Osty: toolchain/llvmgen.osty:3662:5
-	llvmPrintlnI64(main, llvmSetLen(main, set))
-	// Osty: toolchain/llvmgen.osty:3663:5
-	_keys := llvmSetToList(main, set)
-	_ = _keys
-	// Osty: toolchain/llvmgen.osty:3664:5
-	llvmReturnI32Zero(main)
-	return llvmRenderModuleWithSetRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
-}
-
-// Osty: toolchain/llvmgen.osty:3682:5
-func llvmSmokeStringConcatIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3683:5
-	main := llvmEmitter()
-	_ = main
-	// Osty: toolchain/llvmgen.osty:3684:5
-	left := llvmStringLiteral(main, "hello, ")
-	_ = left
-	// Osty: toolchain/llvmgen.osty:3685:5
-	right := llvmStringLiteral(main, "osty")
-	_ = right
-	// Osty: toolchain/llvmgen.osty:3686:5
-	joined := llvmStringConcat(main, left, right)
-	_ = joined
-	// Osty: toolchain/llvmgen.osty:3687:5
-	prefixed := llvmStringHasPrefix(main, joined, left)
-	_ = prefixed
-	// Osty: toolchain/llvmgen.osty:3688:5
-	_unused := prefixed
-	_ = _unused
-	// Osty: toolchain/llvmgen.osty:3689:5
-	length := llvmStringByteLen(main, joined)
-	_ = length
-	// Osty: toolchain/llvmgen.osty:3690:5
-	llvmPrintlnI64(main, length)
-	// Osty: toolchain/llvmgen.osty:3691:5
-	llvmPrintlnString(main, joined)
-	// Osty: toolchain/llvmgen.osty:3692:5
-	llvmReturnI32Zero(main)
-	return llvmRenderModuleWithStringRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
-}
-
-// Osty: toolchain/llvmgen.osty:3710:5
-func llvmSmokeMapBasicIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3711:5
-	main := llvmEmitter()
-	_ = main
-	// Osty: toolchain/llvmgen.osty:3712:5
-	map_ := llvmMapNew(main)
-	_ = map_
-	// Osty: toolchain/llvmgen.osty:3713:5
-	valueSlot := llvmMutableLetSlot(main, "value", llvmIntLiteral(42))
-	_ = valueSlot
-	// Osty: toolchain/llvmgen.osty:3714:5
-	llvmMapInsertI64(main, map_, llvmIntLiteral(7), llvmSlotAsPtr(valueSlot))
-	// Osty: toolchain/llvmgen.osty:3715:5
-	_present := llvmMapContainsI64(main, map_, llvmIntLiteral(7))
-	_ = _present
-	// Osty: toolchain/llvmgen.osty:3716:5
-	outSlot := llvmMutableLetSlot(main, "out", llvmIntLiteral(0))
-	_ = outSlot
-	// Osty: toolchain/llvmgen.osty:3717:5
-	llvmMapGetOrAbortI64(main, map_, llvmIntLiteral(7), llvmSlotAsPtr(outSlot))
-	// Osty: toolchain/llvmgen.osty:3718:5
-	llvmPrintlnI64(main, llvmLoad(main, outSlot))
-	// Osty: toolchain/llvmgen.osty:3719:5
-	llvmPrintlnI64(main, llvmMapLen(main, map_))
-	// Osty: toolchain/llvmgen.osty:3720:5
-	llvmReturnI32Zero(main)
-	return llvmRenderModuleWithMapRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
-}
-
-// Osty: toolchain/llvmgen.osty:3737:5
+// Osty: toolchain/llvmgen.osty (llvmSmokeListBasicIR)
 func llvmSmokeListBasicIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3738:5
 	main := llvmEmitter()
-	_ = main
-	// Osty: toolchain/llvmgen.osty:3739:5
 	list := llvmListNew(main)
-	_ = list
-	// Osty: toolchain/llvmgen.osty:3740:5
 	llvmListPushI64(main, list, llvmIntLiteral(10))
-	// Osty: toolchain/llvmgen.osty:3741:5
 	llvmListPushI64(main, list, llvmIntLiteral(20))
-	// Osty: toolchain/llvmgen.osty:3742:5
 	llvmListPushI64(main, list, llvmIntLiteral(30))
-	// Osty: toolchain/llvmgen.osty:3743:5
-	len := llvmListLen(main, list)
-	_ = len
-	// Osty: toolchain/llvmgen.osty:3744:5
-	llvmPrintlnI64(main, len)
-	// Osty: toolchain/llvmgen.osty:3745:5
+	length := llvmListLen(main, list)
+	llvmPrintlnI64(main, length)
 	second := llvmListGetI64(main, list, llvmIntLiteral(1))
-	_ = second
-	// Osty: toolchain/llvmgen.osty:3746:5
 	llvmPrintlnI64(main, second)
-	// Osty: toolchain/llvmgen.osty:3747:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithListRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3760:5
+// Osty: toolchain/llvmgen.osty (llvmSmokeClosureThunkIR)
+func llvmSmokeClosureThunkIR(sourcePath string) string {
+	doubleBody := llvmEmitter()
+	llvmBind(doubleBody, "x", &LlvmValue{typ: "i64", name: "%x", pointer: false})
+	doubled := llvmBinaryI64(doubleBody, "mul", llvmIdent(doubleBody, "x"), llvmIntLiteral(2))
+	llvmReturn(doubleBody, doubled)
+
+	main := llvmEmitter()
+	env := llvmClosureBareFnEnv(main, "double_val")
+	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
+	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{llvmIntLiteral(21)})
+	llvmPrintlnI64(main, result)
+	llvmReturnI32Zero(main)
+
+	return llvmRenderModuleWithGlobalsAndTypes(
+		sourcePath,
+		"",
+		[]string{llvmClosureBareFnEnvTypeDef()},
+		main.stringGlobals,
+		[]string{
+			llvmRenderFunction("i64", "double_val", []*LlvmParam{llvmParam("x", "i64")}, doubleBody.body),
+			llvmClosureThunkDefinition("double_val", "i64", []string{"i64"}),
+			llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body),
+		},
+	)
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeClosureBasicIR)
+func llvmSmokeClosureBasicIR(sourcePath string) string {
+	envTypeName := llvmClosureEnvTypeName([]string{"ptr", "i64"})
+	typeDef := llvmClosureEnvTypeDef(envTypeName, []string{"ptr", "i64"})
+
+	body := llvmEmitter()
+	llvmBind(body, "env", &LlvmValue{typ: "ptr", name: "%env", pointer: false})
+	envArg := llvmIdent(body, "env")
+	captured := llvmClosureEnvLoadCapture(body, envArg, envTypeName, 1, "i64")
+	llvmReturn(body, captured)
+
+	main := llvmEmitter()
+	env := llvmClosureEnvAlloc(main, envTypeName)
+	llvmClosureEnvStoreFn(main, env, envTypeName, "closure_body")
+	llvmClosureEnvStoreCapture(main, env, envTypeName, 1, llvmIntLiteral(42))
+	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{})
+	llvmPrintlnI64(main, result)
+	llvmReturnI32Zero(main)
+
+	return llvmRenderModuleWithGlobalsAndTypes(
+		sourcePath,
+		"",
+		[]string{typeDef},
+		main.stringGlobals,
+		[]string{
+			llvmRenderFunction("i64", "closure_body", []*LlvmParam{llvmParam("env", "ptr")}, body.body),
+			llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body),
+		},
+	)
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeSetBasicIR)
+func llvmSmokeSetBasicIR(sourcePath string) string {
+	main := llvmEmitter()
+	set := llvmSetNew(main, llvmContainerAbiKind("i64", false))
+	_ = llvmSetInsertI64(main, set, llvmIntLiteral(10))
+	_ = llvmSetInsertI64(main, set, llvmIntLiteral(20))
+	_ = llvmSetInsertI64(main, set, llvmIntLiteral(30))
+	_ = llvmSetContainsI64(main, set, llvmIntLiteral(20))
+	_ = llvmSetRemoveI64(main, set, llvmIntLiteral(20))
+	llvmPrintlnI64(main, llvmSetLen(main, set))
+	_ = llvmSetToList(main, set)
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithSetRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeStringConcatIR)
+func llvmSmokeStringConcatIR(sourcePath string) string {
+	main := llvmEmitter()
+	left := llvmStringLiteral(main, "hello, ")
+	right := llvmStringLiteral(main, "osty")
+	joined := llvmStringConcat(main, left, right)
+	_ = llvmStringHasPrefix(main, joined, left)
+	length := llvmStringByteLen(main, joined)
+	llvmPrintlnI64(main, length)
+	llvmPrintlnString(main, joined)
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithStringRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty (llvmSmokeMapBasicIR)
+func llvmSmokeMapBasicIR(sourcePath string) string {
+	main := llvmEmitter()
+	m := llvmMapNew(main)
+	valueSlot := llvmMutableLetSlot(main, "value", llvmIntLiteral(42))
+	llvmMapInsertI64(main, m, llvmIntLiteral(7), llvmSlotAsPtr(valueSlot))
+	_ = llvmMapContainsI64(main, m, llvmIntLiteral(7))
+	outSlot := llvmMutableLetSlot(main, "out", llvmIntLiteral(0))
+	llvmMapGetOrAbortI64(main, m, llvmIntLiteral(7), llvmSlotAsPtr(outSlot))
+	llvmPrintlnI64(main, llvmLoad(main, outSlot))
+	llvmPrintlnI64(main, llvmMapLen(main, m))
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithMapRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty:1184:5
 func llvmSmokeScalarArithmeticIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3761:5
+	// Osty: toolchain/llvmgen.osty:1185:5
 	add := llvmEmitter()
 	_ = add
-	// Osty: toolchain/llvmgen.osty:3762:5
+	// Osty: toolchain/llvmgen.osty:1186:5
 	llvmBind(add, "a", llvmI64("%a"))
-	// Osty: toolchain/llvmgen.osty:3763:5
+	// Osty: toolchain/llvmgen.osty:1187:5
 	llvmBind(add, "b", llvmI64("%b"))
-	// Osty: toolchain/llvmgen.osty:3764:5
+	// Osty: toolchain/llvmgen.osty:1188:5
 	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:3765:5
+	// Osty: toolchain/llvmgen.osty:1189:5
 	llvmReturn(add, sum)
-	// Osty: toolchain/llvmgen.osty:3767:5
+	// Osty: toolchain/llvmgen.osty:1191:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3768:5
+	// Osty: toolchain/llvmgen.osty:1192:5
 	value := llvmCall(main, "i64", "add", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:3769:5
+	// Osty: toolchain/llvmgen.osty:1193:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:3770:5
+	// Osty: toolchain/llvmgen.osty:1194:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "value"), llvmIntLiteral(42))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:3771:5
+	// Osty: toolchain/llvmgen.osty:1195:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:3772:5
+	// Osty: toolchain/llvmgen.osty:1196:5
 	llvmPrintlnI64(main, llvmIdent(main, "value"))
-	// Osty: toolchain/llvmgen.osty:3773:5
+	// Osty: toolchain/llvmgen.osty:1197:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:3774:5
+	// Osty: toolchain/llvmgen.osty:1198:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:3775:5
+	// Osty: toolchain/llvmgen.osty:1199:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:3776:5
+	// Osty: toolchain/llvmgen.osty:1200:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "add", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, add.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3796:5
+// Osty: toolchain/llvmgen.osty:1220:5
 func llvmSmokeControlFlowIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3797:5
+	// Osty: toolchain/llvmgen.osty:1221:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: toolchain/llvmgen.osty:3798:5
+	// Osty: toolchain/llvmgen.osty:1222:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: toolchain/llvmgen.osty:3799:5
+	// Osty: toolchain/llvmgen.osty:1223:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:3800:5
+	// Osty: toolchain/llvmgen.osty:1224:5
 	loop := llvmInclusiveRangeStart(sumTo, "i", llvmIntLiteral(1), llvmIdent(sumTo, "n"))
 	_ = loop
-	// Osty: toolchain/llvmgen.osty:3801:5
+	// Osty: toolchain/llvmgen.osty:1225:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: toolchain/llvmgen.osty:3802:5
+	// Osty: toolchain/llvmgen.osty:1226:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: toolchain/llvmgen.osty:3803:5
+	// Osty: toolchain/llvmgen.osty:1227:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: toolchain/llvmgen.osty:3804:5
+	// Osty: toolchain/llvmgen.osty:1228:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: toolchain/llvmgen.osty:3806:5
+	// Osty: toolchain/llvmgen.osty:1230:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3807:5
+	// Osty: toolchain/llvmgen.osty:1231:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(5)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:3808:5
+	// Osty: toolchain/llvmgen.osty:1232:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:3809:5
+	// Osty: toolchain/llvmgen.osty:1233:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3821:5
+// Osty: toolchain/llvmgen.osty:1245:5
 func llvmSmokeBooleansIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3822:5
+	// Osty: toolchain/llvmgen.osty:1246:5
 	choose := llvmEmitter()
 	_ = choose
-	// Osty: toolchain/llvmgen.osty:3823:5
+	// Osty: toolchain/llvmgen.osty:1247:5
 	llvmBind(choose, "a", llvmI64("%a"))
-	// Osty: toolchain/llvmgen.osty:3824:5
+	// Osty: toolchain/llvmgen.osty:1248:5
 	llvmBind(choose, "b", llvmI64("%b"))
-	// Osty: toolchain/llvmgen.osty:3825:5
+	// Osty: toolchain/llvmgen.osty:1249:5
 	lt := llvmCompare(choose, "slt", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = lt
-	// Osty: toolchain/llvmgen.osty:3826:5
+	// Osty: toolchain/llvmgen.osty:1250:5
 	eqZero := llvmCompare(choose, "eq", llvmIdent(choose, "a"), llvmIntLiteral(0))
 	_ = eqZero
-	// Osty: toolchain/llvmgen.osty:3827:5
+	// Osty: toolchain/llvmgen.osty:1251:5
 	nonZero := llvmNotI1(choose, eqZero)
 	_ = nonZero
-	// Osty: toolchain/llvmgen.osty:3828:5
+	// Osty: toolchain/llvmgen.osty:1252:5
 	cond := llvmLogicalI1(choose, "and", lt, nonZero)
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:3829:5
+	// Osty: toolchain/llvmgen.osty:1253:5
 	labels := llvmIfExprStart(choose, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:3830:5
+	// Osty: toolchain/llvmgen.osty:1254:5
 	thenValue := llvmBinaryI64(choose, "sub", llvmIdent(choose, "b"), llvmIdent(choose, "a"))
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:3831:5
+	// Osty: toolchain/llvmgen.osty:1255:5
 	llvmIfExprElse(choose, labels)
-	// Osty: toolchain/llvmgen.osty:3832:5
+	// Osty: toolchain/llvmgen.osty:1256:5
 	elseValue := llvmBinaryI64(choose, "add", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:3833:5
+	// Osty: toolchain/llvmgen.osty:1257:5
 	result := llvmIfExprEnd(choose, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:3834:5
+	// Osty: toolchain/llvmgen.osty:1258:5
 	llvmReturn(choose, result)
-	// Osty: toolchain/llvmgen.osty:3836:5
+	// Osty: toolchain/llvmgen.osty:1260:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3837:5
+	// Osty: toolchain/llvmgen.osty:1261:5
 	value := llvmCall(main, "i64", "choose", []*LlvmValue{llvmIntLiteral(3), llvmIntLiteral(10)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:3838:5
+	// Osty: toolchain/llvmgen.osty:1262:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:3839:5
+	// Osty: toolchain/llvmgen.osty:1263:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "choose", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, choose.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3859:5
+// Osty: toolchain/llvmgen.osty:1283:5
 func llvmSmokeStringPrintIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3860:5
+	// Osty: toolchain/llvmgen.osty:1284:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3861:5
+	// Osty: toolchain/llvmgen.osty:1285:5
 	line := llvmStringLiteral(main, "hello, osty")
 	_ = line
-	// Osty: toolchain/llvmgen.osty:3862:5
+	// Osty: toolchain/llvmgen.osty:1286:5
 	llvmPrintlnString(main, line)
-	// Osty: toolchain/llvmgen.osty:3863:5
+	// Osty: toolchain/llvmgen.osty:1287:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3875:5
+// Osty: toolchain/llvmgen.osty:1299:5
 func llvmSmokeStringEscapeIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3876:5
+	// Osty: toolchain/llvmgen.osty:1300:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3877:5
+	// Osty: toolchain/llvmgen.osty:1301:5
 	line := llvmStringLiteral(main, "line one\nquote \" slash \\")
 	_ = line
-	// Osty: toolchain/llvmgen.osty:3878:5
+	// Osty: toolchain/llvmgen.osty:1302:5
 	llvmPrintlnString(main, line)
-	// Osty: toolchain/llvmgen.osty:3879:5
+	// Osty: toolchain/llvmgen.osty:1303:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3891:5
+// Osty: toolchain/llvmgen.osty:1315:5
 func llvmSmokeStringLetIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3892:5
+	// Osty: toolchain/llvmgen.osty:1316:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3893:5
+	// Osty: toolchain/llvmgen.osty:1317:5
 	msg := llvmStringLiteral(main, "stored string")
 	_ = msg
-	// Osty: toolchain/llvmgen.osty:3894:5
+	// Osty: toolchain/llvmgen.osty:1318:5
 	llvmImmutableLet(main, "msg", msg)
-	// Osty: toolchain/llvmgen.osty:3895:5
+	// Osty: toolchain/llvmgen.osty:1319:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: toolchain/llvmgen.osty:3896:5
+	// Osty: toolchain/llvmgen.osty:1320:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3908:5
+// Osty: toolchain/llvmgen.osty:1332:5
 func llvmSmokeStringReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3909:5
+	// Osty: toolchain/llvmgen.osty:1333:5
 	greet := llvmEmitter()
 	_ = greet
-	// Osty: toolchain/llvmgen.osty:3910:5
+	// Osty: toolchain/llvmgen.osty:1334:5
 	llvmReturn(greet, llvmStringLiteral(greet, "from function"))
-	// Osty: toolchain/llvmgen.osty:3912:5
+	// Osty: toolchain/llvmgen.osty:1336:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3913:5
+	// Osty: toolchain/llvmgen.osty:1337:5
 	llvmPrintlnString(main, llvmCall(main, "ptr", "greet", make([]*LlvmValue, 0, 1)))
-	// Osty: toolchain/llvmgen.osty:3914:5
+	// Osty: toolchain/llvmgen.osty:1338:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", greet.stringGlobals, []string{llvmRenderFunction("ptr", "greet", make([]*LlvmParam, 0, 1), greet.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3927:5
+// Osty: toolchain/llvmgen.osty:1351:5
 func llvmSmokeStringParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3928:5
+	// Osty: toolchain/llvmgen.osty:1352:5
 	echo := llvmEmitter()
 	_ = echo
-	// Osty: toolchain/llvmgen.osty:3929:5
+	// Osty: toolchain/llvmgen.osty:1353:5
 	llvmBind(echo, "msg", &LlvmValue{typ: "ptr", name: "%msg", pointer: false})
-	// Osty: toolchain/llvmgen.osty:3930:5
+	// Osty: toolchain/llvmgen.osty:1354:5
 	llvmReturn(echo, llvmIdent(echo, "msg"))
-	// Osty: toolchain/llvmgen.osty:3932:5
+	// Osty: toolchain/llvmgen.osty:1356:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3933:5
+	// Osty: toolchain/llvmgen.osty:1357:5
 	value := llvmCall(main, "ptr", "echo", []*LlvmValue{llvmStringLiteral(main, "param string")})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:3934:5
+	// Osty: toolchain/llvmgen.osty:1358:5
 	llvmPrintlnString(main, value)
-	// Osty: toolchain/llvmgen.osty:3935:5
+	// Osty: toolchain/llvmgen.osty:1359:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("ptr", "echo", []*LlvmParam{llvmParam("msg", "ptr")}, echo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3948:5
+// Osty: toolchain/llvmgen.osty:1372:5
 func llvmSmokeStringMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3949:5
+	// Osty: toolchain/llvmgen.osty:1373:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3950:5
+	// Osty: toolchain/llvmgen.osty:1374:5
 	llvmMutableLet(main, "msg", llvmStringLiteral(main, "before"))
-	// Osty: toolchain/llvmgen.osty:3951:5
+	// Osty: toolchain/llvmgen.osty:1375:5
 	_ = llvmAssign(main, "msg", llvmStringLiteral(main, "after"))
-	// Osty: toolchain/llvmgen.osty:3952:5
+	// Osty: toolchain/llvmgen.osty:1376:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: toolchain/llvmgen.osty:3953:5
+	// Osty: toolchain/llvmgen.osty:1377:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3965:5
+// Osty: toolchain/llvmgen.osty:1389:5
 func llvmSmokeStructFieldIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3966:5
+	// Osty: toolchain/llvmgen.osty:1390:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3967:5
+	// Osty: toolchain/llvmgen.osty:1391:5
 	point := llvmStructLiteral(main, "%Point", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = point
-	// Osty: toolchain/llvmgen.osty:3968:5
+	// Osty: toolchain/llvmgen.osty:1392:5
 	llvmImmutableLet(main, "point", point)
-	// Osty: toolchain/llvmgen.osty:3969:5
+	// Osty: toolchain/llvmgen.osty:1393:5
 	sum := llvmBinaryI64(main, "add", llvmExtractValue(main, llvmIdent(main, "point"), "i64", 0), llvmExtractValue(main, llvmIdent(main, "point"), "i64", 1))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:3975:5
+	// Osty: toolchain/llvmgen.osty:1399:5
 	llvmPrintlnI64(main, sum)
-	// Osty: toolchain/llvmgen.osty:3976:5
+	// Osty: toolchain/llvmgen.osty:1400:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Point", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:3991:5
+// Osty: toolchain/llvmgen.osty:1413:5
 func llvmSmokeStructReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:3992:5
+	// Osty: toolchain/llvmgen.osty:1414:5
 	makePair := llvmEmitter()
 	_ = makePair
-	// Osty: toolchain/llvmgen.osty:3993:5
+	// Osty: toolchain/llvmgen.osty:1415:5
 	pair := llvmStructLiteral(makePair, "%Pair", []*LlvmValue{llvmIntLiteral(10), llvmIntLiteral(32)})
 	_ = pair
-	// Osty: toolchain/llvmgen.osty:3994:5
+	// Osty: toolchain/llvmgen.osty:1416:5
 	llvmReturn(makePair, pair)
-	// Osty: toolchain/llvmgen.osty:3996:5
+	// Osty: toolchain/llvmgen.osty:1418:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:3997:5
+	// Osty: toolchain/llvmgen.osty:1419:5
 	returned := llvmCall(main, "%Pair", "makePair", make([]*LlvmValue, 0, 1))
 	_ = returned
-	// Osty: toolchain/llvmgen.osty:3998:5
+	// Osty: toolchain/llvmgen.osty:1420:5
 	llvmImmutableLet(main, "pair", returned)
-	// Osty: toolchain/llvmgen.osty:3999:5
+	// Osty: toolchain/llvmgen.osty:1421:5
 	sum := llvmBinaryI64(main, "add", llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 0), llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 1))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:4005:5
+	// Osty: toolchain/llvmgen.osty:1427:5
 	llvmPrintlnI64(main, sum)
-	// Osty: toolchain/llvmgen.osty:4006:5
+	// Osty: toolchain/llvmgen.osty:1428:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Pair", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Pair", "makePair", make([]*LlvmParam, 0, 1), makePair.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4022:5
+// Osty: toolchain/llvmgen.osty:1442:5
 func llvmSmokeStructParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4023:5
+	// Osty: toolchain/llvmgen.osty:1443:5
 	total := llvmEmitter()
 	_ = total
-	// Osty: toolchain/llvmgen.osty:4024:5
+	// Osty: toolchain/llvmgen.osty:1444:5
 	llvmBind(total, "score", &LlvmValue{typ: "%Score", name: "%score", pointer: false})
-	// Osty: toolchain/llvmgen.osty:4025:5
+	// Osty: toolchain/llvmgen.osty:1445:5
 	sum := llvmBinaryI64(total, "add", llvmExtractValue(total, llvmIdent(total, "score"), "i64", 0), llvmExtractValue(total, llvmIdent(total, "score"), "i64", 1))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:4031:5
+	// Osty: toolchain/llvmgen.osty:1451:5
 	llvmReturn(total, sum)
-	// Osty: toolchain/llvmgen.osty:4033:5
+	// Osty: toolchain/llvmgen.osty:1453:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4034:5
+	// Osty: toolchain/llvmgen.osty:1454:5
 	score := llvmStructLiteral(main, "%Score", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4035:5
+	// Osty: toolchain/llvmgen.osty:1455:5
 	out := llvmCall(main, "i64", "total", []*LlvmValue{score})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4036:5
+	// Osty: toolchain/llvmgen.osty:1456:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:4037:5
+	// Osty: toolchain/llvmgen.osty:1457:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Score", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i64", "total", []*LlvmParam{llvmParam("score", "%Score")}, total.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4053:5
+// Osty: toolchain/llvmgen.osty:1471:5
 func llvmSmokeStructMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4054:5
+	// Osty: toolchain/llvmgen.osty:1472:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4055:5
+	// Osty: toolchain/llvmgen.osty:1473:5
 	llvmMutableLet(main, "box", llvmStructLiteral(main, "%Box", []*LlvmValue{llvmIntLiteral(1)}))
-	// Osty: toolchain/llvmgen.osty:4056:5
+	// Osty: toolchain/llvmgen.osty:1474:5
 	_ = llvmAssign(main, "box", llvmStructLiteral(main, "%Box", []*LlvmValue{llvmIntLiteral(42)}))
-	// Osty: toolchain/llvmgen.osty:4057:5
+	// Osty: toolchain/llvmgen.osty:1475:5
 	llvmPrintlnI64(main, llvmExtractValue(main, llvmIdent(main, "box"), "i64", 0))
-	// Osty: toolchain/llvmgen.osty:4058:5
+	// Osty: toolchain/llvmgen.osty:1476:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Box", []string{"i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4073:5
+// Osty: toolchain/llvmgen.osty:1489:5
 func llvmSmokeEnumVariantIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4074:5
+	// Osty: toolchain/llvmgen.osty:1490:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4075:5
+	// Osty: toolchain/llvmgen.osty:1491:5
 	llvmImmutableLet(main, "light", llvmEnumVariant("Light", 1))
-	// Osty: toolchain/llvmgen.osty:4076:5
+	// Osty: toolchain/llvmgen.osty:1492:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "light"), llvmEnumVariant("Light", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4077:5
+	// Osty: toolchain/llvmgen.osty:1493:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4078:5
+	// Osty: toolchain/llvmgen.osty:1494:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:4079:5
+	// Osty: toolchain/llvmgen.osty:1495:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4080:5
+	// Osty: toolchain/llvmgen.osty:1496:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:4081:5
+	// Osty: toolchain/llvmgen.osty:1497:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:4082:5
+	// Osty: toolchain/llvmgen.osty:1498:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4093:5
+// Osty: toolchain/llvmgen.osty:1509:5
 func llvmSmokeEnumReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4094:5
+	// Osty: toolchain/llvmgen.osty:1510:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:4095:5
+	// Osty: toolchain/llvmgen.osty:1511:5
 	llvmReturn(pick, llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:4097:5
+	// Osty: toolchain/llvmgen.osty:1513:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4098:5
+	// Osty: toolchain/llvmgen.osty:1514:5
 	state := llvmCall(main, "i64", "pick", make([]*LlvmValue, 0, 1))
 	_ = state
-	// Osty: toolchain/llvmgen.osty:4099:5
+	// Osty: toolchain/llvmgen.osty:1515:5
 	cond := llvmCompare(main, "eq", state, llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4100:5
+	// Osty: toolchain/llvmgen.osty:1516:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4101:5
+	// Osty: toolchain/llvmgen.osty:1517:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:4102:5
+	// Osty: toolchain/llvmgen.osty:1518:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4103:5
+	// Osty: toolchain/llvmgen.osty:1519:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:4104:5
+	// Osty: toolchain/llvmgen.osty:1520:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:4105:5
+	// Osty: toolchain/llvmgen.osty:1521:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4117:5
+// Osty: toolchain/llvmgen.osty:1533:5
 func llvmSmokeEnumParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4118:5
+	// Osty: toolchain/llvmgen.osty:1534:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4119:5
+	// Osty: toolchain/llvmgen.osty:1535:5
 	llvmBind(score, "state", llvmI64("%state"))
-	// Osty: toolchain/llvmgen.osty:4120:5
+	// Osty: toolchain/llvmgen.osty:1536:5
 	cond := llvmCompare(score, "eq", llvmIdent(score, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4121:5
+	// Osty: toolchain/llvmgen.osty:1537:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4122:5
+	// Osty: toolchain/llvmgen.osty:1538:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4123:5
+	// Osty: toolchain/llvmgen.osty:1539:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4124:5
+	// Osty: toolchain/llvmgen.osty:1540:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4125:5
+	// Osty: toolchain/llvmgen.osty:1541:5
 	out := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4126:5
+	// Osty: toolchain/llvmgen.osty:1542:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:4128:5
+	// Osty: toolchain/llvmgen.osty:1544:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4129:5
+	// Osty: toolchain/llvmgen.osty:1545:5
 	result := llvmCall(main, "i64", "score", []*LlvmValue{llvmEnumVariant("Switch", 1)})
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4130:5
+	// Osty: toolchain/llvmgen.osty:1546:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:4131:5
+	// Osty: toolchain/llvmgen.osty:1547:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("state", "i64")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4143:5
+// Osty: toolchain/llvmgen.osty:1559:5
 func llvmSmokeEnumMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4144:5
+	// Osty: toolchain/llvmgen.osty:1560:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4145:5
+	// Osty: toolchain/llvmgen.osty:1561:5
 	llvmMutableLet(main, "state", llvmEnumVariant("Switch", 0))
-	// Osty: toolchain/llvmgen.osty:4146:5
+	// Osty: toolchain/llvmgen.osty:1562:5
 	_ = llvmAssign(main, "state", llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:4147:5
+	// Osty: toolchain/llvmgen.osty:1563:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4148:5
+	// Osty: toolchain/llvmgen.osty:1564:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4149:5
+	// Osty: toolchain/llvmgen.osty:1565:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:4150:5
+	// Osty: toolchain/llvmgen.osty:1566:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4151:5
+	// Osty: toolchain/llvmgen.osty:1567:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:4152:5
+	// Osty: toolchain/llvmgen.osty:1568:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:4153:5
+	// Osty: toolchain/llvmgen.osty:1569:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4164:5
+// Osty: toolchain/llvmgen.osty:1580:5
 func llvmSmokeEnumMatchIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4165:5
+	// Osty: toolchain/llvmgen.osty:1581:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4166:5
+	// Osty: toolchain/llvmgen.osty:1582:5
 	llvmImmutableLet(main, "state", llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:4167:5
+	// Osty: toolchain/llvmgen.osty:1583:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4168:5
+	// Osty: toolchain/llvmgen.osty:1584:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4169:5
+	// Osty: toolchain/llvmgen.osty:1585:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4170:5
+	// Osty: toolchain/llvmgen.osty:1586:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4171:5
+	// Osty: toolchain/llvmgen.osty:1587:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4172:5
+	// Osty: toolchain/llvmgen.osty:1588:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4173:5
+	// Osty: toolchain/llvmgen.osty:1589:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:4174:5
+	// Osty: toolchain/llvmgen.osty:1590:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4185:5
+// Osty: toolchain/llvmgen.osty:1601:5
 func llvmSmokeEnumMatchReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4186:5
+	// Osty: toolchain/llvmgen.osty:1602:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:4187:5
+	// Osty: toolchain/llvmgen.osty:1603:5
 	llvmReturn(pick, llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:4189:5
+	// Osty: toolchain/llvmgen.osty:1605:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4190:5
+	// Osty: toolchain/llvmgen.osty:1606:5
 	state := llvmCall(score, "i64", "pick", make([]*LlvmValue, 0, 1))
 	_ = state
-	// Osty: toolchain/llvmgen.osty:4191:5
+	// Osty: toolchain/llvmgen.osty:1607:5
 	cond := llvmCompare(score, "eq", state, llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4192:5
+	// Osty: toolchain/llvmgen.osty:1608:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4193:5
+	// Osty: toolchain/llvmgen.osty:1609:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4194:5
+	// Osty: toolchain/llvmgen.osty:1610:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4195:5
+	// Osty: toolchain/llvmgen.osty:1611:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4196:5
+	// Osty: toolchain/llvmgen.osty:1612:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4197:5
+	// Osty: toolchain/llvmgen.osty:1613:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:4199:5
+	// Osty: toolchain/llvmgen.osty:1615:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4200:5
+	// Osty: toolchain/llvmgen.osty:1616:5
 	out := llvmCall(main, "i64", "score", make([]*LlvmValue, 0, 1))
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4201:5
+	// Osty: toolchain/llvmgen.osty:1617:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:4202:5
+	// Osty: toolchain/llvmgen.osty:1618:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i64", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4215:5
+// Osty: toolchain/llvmgen.osty:1631:5
 func llvmSmokeEnumMatchParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4216:5
+	// Osty: toolchain/llvmgen.osty:1632:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4217:5
+	// Osty: toolchain/llvmgen.osty:1633:5
 	llvmBind(score, "state", llvmI64("%state"))
-	// Osty: toolchain/llvmgen.osty:4218:5
+	// Osty: toolchain/llvmgen.osty:1634:5
 	cond := llvmCompare(score, "eq", llvmIdent(score, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4219:5
+	// Osty: toolchain/llvmgen.osty:1635:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4220:5
+	// Osty: toolchain/llvmgen.osty:1636:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4221:5
+	// Osty: toolchain/llvmgen.osty:1637:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4222:5
+	// Osty: toolchain/llvmgen.osty:1638:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4223:5
+	// Osty: toolchain/llvmgen.osty:1639:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4224:5
+	// Osty: toolchain/llvmgen.osty:1640:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:4226:5
+	// Osty: toolchain/llvmgen.osty:1642:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4227:5
+	// Osty: toolchain/llvmgen.osty:1643:5
 	out := llvmCall(main, "i64", "score", []*LlvmValue{llvmEnumVariant("Switch", 1)})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4228:5
+	// Osty: toolchain/llvmgen.osty:1644:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:4229:5
+	// Osty: toolchain/llvmgen.osty:1645:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("state", "i64")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4241:5
+// Osty: toolchain/llvmgen.osty:1657:5
 func llvmSmokeEnumMatchMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4242:5
+	// Osty: toolchain/llvmgen.osty:1658:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4243:5
+	// Osty: toolchain/llvmgen.osty:1659:5
 	llvmMutableLet(main, "state", llvmEnumVariant("Switch", 0))
-	// Osty: toolchain/llvmgen.osty:4244:5
+	// Osty: toolchain/llvmgen.osty:1660:5
 	_ = llvmAssign(main, "state", llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:4245:5
+	// Osty: toolchain/llvmgen.osty:1661:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4246:5
+	// Osty: toolchain/llvmgen.osty:1662:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4247:5
+	// Osty: toolchain/llvmgen.osty:1663:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4248:5
+	// Osty: toolchain/llvmgen.osty:1664:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4249:5
+	// Osty: toolchain/llvmgen.osty:1665:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4250:5
+	// Osty: toolchain/llvmgen.osty:1666:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4251:5
+	// Osty: toolchain/llvmgen.osty:1667:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:4252:5
+	// Osty: toolchain/llvmgen.osty:1668:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4263:5
+// Osty: toolchain/llvmgen.osty:1679:5
 func llvmSmokeEnumPayloadIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4264:5
+	// Osty: toolchain/llvmgen.osty:1680:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4265:5
+	// Osty: toolchain/llvmgen.osty:1681:5
 	llvmImmutableLet(main, "value", llvmEnumPayloadVariant(main, "%Maybe", 0, llvmIntLiteral(42)))
-	// Osty: toolchain/llvmgen.osty:4266:5
+	// Osty: toolchain/llvmgen.osty:1682:5
 	state := llvmIdent(main, "value")
 	_ = state
-	// Osty: toolchain/llvmgen.osty:4267:5
+	// Osty: toolchain/llvmgen.osty:1683:5
 	tag := llvmExtractValue(main, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4268:5
+	// Osty: toolchain/llvmgen.osty:1684:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4269:5
+	// Osty: toolchain/llvmgen.osty:1685:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4270:5
+	// Osty: toolchain/llvmgen.osty:1686:5
 	thenValue := llvmExtractValue(main, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4271:5
+	// Osty: toolchain/llvmgen.osty:1687:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4272:5
+	// Osty: toolchain/llvmgen.osty:1688:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4273:5
+	// Osty: toolchain/llvmgen.osty:1689:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4274:5
+	// Osty: toolchain/llvmgen.osty:1690:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:4275:5
+	// Osty: toolchain/llvmgen.osty:1691:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4290:5
+// Osty: toolchain/llvmgen.osty:1704:5
 func llvmSmokeEnumPayloadReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4291:5
+	// Osty: toolchain/llvmgen.osty:1705:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:4292:5
+	// Osty: toolchain/llvmgen.osty:1706:5
 	llvmReturn(pick, llvmEnumPayloadVariant(pick, "%Maybe", 0, llvmIntLiteral(42)))
-	// Osty: toolchain/llvmgen.osty:4294:5
+	// Osty: toolchain/llvmgen.osty:1708:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4295:5
+	// Osty: toolchain/llvmgen.osty:1709:5
 	state := llvmCall(score, "%Maybe", "pick", make([]*LlvmValue, 0, 1))
 	_ = state
-	// Osty: toolchain/llvmgen.osty:4296:5
+	// Osty: toolchain/llvmgen.osty:1710:5
 	tag := llvmExtractValue(score, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4297:5
+	// Osty: toolchain/llvmgen.osty:1711:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4298:5
+	// Osty: toolchain/llvmgen.osty:1712:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4299:5
+	// Osty: toolchain/llvmgen.osty:1713:5
 	thenValue := llvmExtractValue(score, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4300:5
+	// Osty: toolchain/llvmgen.osty:1714:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4301:5
+	// Osty: toolchain/llvmgen.osty:1715:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4302:5
+	// Osty: toolchain/llvmgen.osty:1716:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4303:5
+	// Osty: toolchain/llvmgen.osty:1717:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:4305:5
+	// Osty: toolchain/llvmgen.osty:1719:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4306:5
+	// Osty: toolchain/llvmgen.osty:1720:5
 	out := llvmCall(main, "i64", "score", make([]*LlvmValue, 0, 1))
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4307:5
+	// Osty: toolchain/llvmgen.osty:1721:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:4308:5
+	// Osty: toolchain/llvmgen.osty:1722:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Maybe", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i64", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4325:5
+// Osty: toolchain/llvmgen.osty:1737:5
 func llvmSmokeEnumPayloadParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4326:5
+	// Osty: toolchain/llvmgen.osty:1738:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4327:5
+	// Osty: toolchain/llvmgen.osty:1739:5
 	llvmBind(score, "value", &LlvmValue{typ: "%Maybe", name: "%value", pointer: false})
-	// Osty: toolchain/llvmgen.osty:4328:5
+	// Osty: toolchain/llvmgen.osty:1740:5
 	state := llvmIdent(score, "value")
 	_ = state
-	// Osty: toolchain/llvmgen.osty:4329:5
+	// Osty: toolchain/llvmgen.osty:1741:5
 	tag := llvmExtractValue(score, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4330:5
+	// Osty: toolchain/llvmgen.osty:1742:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4331:5
+	// Osty: toolchain/llvmgen.osty:1743:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4332:5
+	// Osty: toolchain/llvmgen.osty:1744:5
 	thenValue := llvmExtractValue(score, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4333:5
+	// Osty: toolchain/llvmgen.osty:1745:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4334:5
+	// Osty: toolchain/llvmgen.osty:1746:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4335:5
+	// Osty: toolchain/llvmgen.osty:1747:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4336:5
+	// Osty: toolchain/llvmgen.osty:1748:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:4338:5
+	// Osty: toolchain/llvmgen.osty:1750:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4339:5
+	// Osty: toolchain/llvmgen.osty:1751:5
 	arg := llvmEnumPayloadVariant(main, "%Maybe", 0, llvmIntLiteral(42))
 	_ = arg
-	// Osty: toolchain/llvmgen.osty:4340:5
+	// Osty: toolchain/llvmgen.osty:1752:5
 	out := llvmCall(main, "i64", "score", []*LlvmValue{arg})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4341:5
+	// Osty: toolchain/llvmgen.osty:1753:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:4342:5
+	// Osty: toolchain/llvmgen.osty:1754:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("value", "%Maybe")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4358:5
+// Osty: toolchain/llvmgen.osty:1768:5
 func llvmSmokeEnumPayloadMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4359:5
+	// Osty: toolchain/llvmgen.osty:1769:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4360:5
+	// Osty: toolchain/llvmgen.osty:1770:5
 	llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%Maybe", 1, llvmIntLiteral(0)))
-	// Osty: toolchain/llvmgen.osty:4361:5
+	// Osty: toolchain/llvmgen.osty:1771:5
 	_ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%Maybe", 0, llvmIntLiteral(42)))
-	// Osty: toolchain/llvmgen.osty:4362:5
+	// Osty: toolchain/llvmgen.osty:1772:5
 	state := llvmIdent(main, "value")
 	_ = state
-	// Osty: toolchain/llvmgen.osty:4363:5
+	// Osty: toolchain/llvmgen.osty:1773:5
 	tag := llvmExtractValue(main, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4364:5
+	// Osty: toolchain/llvmgen.osty:1774:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4365:5
+	// Osty: toolchain/llvmgen.osty:1775:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4366:5
+	// Osty: toolchain/llvmgen.osty:1776:5
 	thenValue := llvmExtractValue(main, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4367:5
+	// Osty: toolchain/llvmgen.osty:1777:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4368:5
+	// Osty: toolchain/llvmgen.osty:1778:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4369:5
+	// Osty: toolchain/llvmgen.osty:1779:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:4370:5
+	// Osty: toolchain/llvmgen.osty:1780:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:4371:5
+	// Osty: toolchain/llvmgen.osty:1781:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4386:5
+// Osty: toolchain/llvmgen.osty:1794:5
 func llvmSmokeFloatPrintIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4387:5
+	// Osty: toolchain/llvmgen.osty:1795:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4388:5
+	// Osty: toolchain/llvmgen.osty:1796:5
 	llvmPrintlnF64(main, llvmFloatLiteral("42.0"))
-	// Osty: toolchain/llvmgen.osty:4389:5
+	// Osty: toolchain/llvmgen.osty:1797:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4400:5
+// Osty: toolchain/llvmgen.osty:1806:5
 func llvmSmokeFloatArithmeticIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4401:5
+	// Osty: toolchain/llvmgen.osty:1807:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4402:5
+	// Osty: toolchain/llvmgen.osty:1808:5
 	add := llvmBinaryF64(main, "fadd", llvmFloatLiteral("40.0"), llvmFloatLiteral("2.0"))
 	_ = add
-	// Osty: toolchain/llvmgen.osty:4403:5
+	// Osty: toolchain/llvmgen.osty:1809:5
 	sub := llvmBinaryF64(main, "fsub", add, llvmFloatLiteral("0.0"))
 	_ = sub
-	// Osty: toolchain/llvmgen.osty:4404:5
+	// Osty: toolchain/llvmgen.osty:1810:5
 	mul := llvmBinaryF64(main, "fmul", sub, llvmFloatLiteral("2.5"))
 	_ = mul
-	// Osty: toolchain/llvmgen.osty:4405:5
+	// Osty: toolchain/llvmgen.osty:1811:5
 	div := llvmBinaryF64(main, "fdiv", mul, llvmFloatLiteral("2.5"))
 	_ = div
-	// Osty: toolchain/llvmgen.osty:4406:5
+	// Osty: toolchain/llvmgen.osty:1812:5
 	llvmPrintlnF64(main, div)
-	// Osty: toolchain/llvmgen.osty:4407:5
+	// Osty: toolchain/llvmgen.osty:1813:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4418:5
+// Osty: toolchain/llvmgen.osty:1822:5
 func llvmSmokeFloatReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4419:5
+	// Osty: toolchain/llvmgen.osty:1823:5
 	value := llvmEmitter()
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4420:5
+	// Osty: toolchain/llvmgen.osty:1824:5
 	llvmReturn(value, llvmFloatLiteral("42.0"))
-	// Osty: toolchain/llvmgen.osty:4422:5
+	// Osty: toolchain/llvmgen.osty:1826:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4423:5
+	// Osty: toolchain/llvmgen.osty:1827:5
 	out := llvmCall(main, "double", "value", make([]*LlvmValue, 0, 1))
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4424:5
+	// Osty: toolchain/llvmgen.osty:1828:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4425:5
+	// Osty: toolchain/llvmgen.osty:1829:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("double", "value", make([]*LlvmParam, 0, 1), value.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4437:5
+// Osty: toolchain/llvmgen.osty:1841:5
 func llvmSmokeFloatParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4438:5
+	// Osty: toolchain/llvmgen.osty:1842:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4439:5
+	// Osty: toolchain/llvmgen.osty:1843:5
 	llvmBind(score, "value", llvmF64("%value"))
-	// Osty: toolchain/llvmgen.osty:4440:5
+	// Osty: toolchain/llvmgen.osty:1844:5
 	llvmReturn(score, llvmIdent(score, "value"))
-	// Osty: toolchain/llvmgen.osty:4442:5
+	// Osty: toolchain/llvmgen.osty:1846:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4443:5
+	// Osty: toolchain/llvmgen.osty:1847:5
 	out := llvmCall(main, "double", "score", []*LlvmValue{llvmFloatLiteral("42.0")})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4444:5
+	// Osty: toolchain/llvmgen.osty:1848:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4445:5
+	// Osty: toolchain/llvmgen.osty:1849:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("double", "score", []*LlvmParam{llvmParam("value", "double")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4457:5
+// Osty: toolchain/llvmgen.osty:1861:5
 func llvmSmokeFloatMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4458:5
+	// Osty: toolchain/llvmgen.osty:1862:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4459:5
+	// Osty: toolchain/llvmgen.osty:1863:5
 	llvmMutableLet(main, "value", llvmFloatLiteral("0.0"))
-	// Osty: toolchain/llvmgen.osty:4460:5
+	// Osty: toolchain/llvmgen.osty:1864:5
 	_ = llvmAssign(main, "value", llvmFloatLiteral("42.0"))
-	// Osty: toolchain/llvmgen.osty:4461:5
+	// Osty: toolchain/llvmgen.osty:1865:5
 	llvmPrintlnF64(main, llvmIdent(main, "value"))
-	// Osty: toolchain/llvmgen.osty:4462:5
+	// Osty: toolchain/llvmgen.osty:1866:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4473:5
+// Osty: toolchain/llvmgen.osty:1877:5
 func llvmSmokeFloatCompareIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4474:5
+	// Osty: toolchain/llvmgen.osty:1878:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4475:5
+	// Osty: toolchain/llvmgen.osty:1879:5
 	value := llvmFloatLiteral("42.0")
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4476:5
+	// Osty: toolchain/llvmgen.osty:1880:5
 	eq := llvmCompareF64(main, "oeq", value, llvmFloatLiteral("42.0"))
 	_ = eq
-	// Osty: toolchain/llvmgen.osty:4477:5
+	// Osty: toolchain/llvmgen.osty:1881:5
 	ne := llvmCompareF64(main, "one", value, llvmFloatLiteral("41.0"))
 	_ = ne
-	// Osty: toolchain/llvmgen.osty:4478:5
+	// Osty: toolchain/llvmgen.osty:1882:5
 	lt := llvmCompareF64(main, "olt", value, llvmFloatLiteral("100.0"))
 	_ = lt
-	// Osty: toolchain/llvmgen.osty:4479:5
+	// Osty: toolchain/llvmgen.osty:1883:5
 	gt := llvmCompareF64(main, "ogt", value, llvmFloatLiteral("0.0"))
 	_ = gt
-	// Osty: toolchain/llvmgen.osty:4480:5
+	// Osty: toolchain/llvmgen.osty:1884:5
 	le := llvmCompareF64(main, "ole", value, llvmFloatLiteral("42.0"))
 	_ = le
-	// Osty: toolchain/llvmgen.osty:4481:5
+	// Osty: toolchain/llvmgen.osty:1885:5
 	ge := llvmCompareF64(main, "oge", value, llvmFloatLiteral("42.0"))
 	_ = ge
-	// Osty: toolchain/llvmgen.osty:4482:5
+	// Osty: toolchain/llvmgen.osty:1886:5
 	cond := llvmLogicalI1(main, "and", llvmLogicalI1(main, "and", llvmLogicalI1(main, "and", eq, ne), llvmLogicalI1(main, "and", lt, gt)), llvmLogicalI1(main, "and", le, ge))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4493:5
+	// Osty: toolchain/llvmgen.osty:1892:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4494:5
+	// Osty: toolchain/llvmgen.osty:1893:5
 	llvmPrintlnF64(main, value)
-	// Osty: toolchain/llvmgen.osty:4495:5
+	// Osty: toolchain/llvmgen.osty:1894:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4496:5
+	// Osty: toolchain/llvmgen.osty:1895:5
 	llvmPrintlnF64(main, llvmFloatLiteral("0.0"))
-	// Osty: toolchain/llvmgen.osty:4497:5
+	// Osty: toolchain/llvmgen.osty:1896:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:4498:5
+	// Osty: toolchain/llvmgen.osty:1897:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4509:5
+// Osty: toolchain/llvmgen.osty:1906:5
 func llvmSmokeFloatStructIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4510:5
+	// Osty: toolchain/llvmgen.osty:1907:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4511:5
+	// Osty: toolchain/llvmgen.osty:1908:5
 	value := llvmStructLiteral(main, "%MaybeF", []*LlvmValue{llvmIntLiteral(7), llvmFloatLiteral("42.0")})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4512:5
+	// Osty: toolchain/llvmgen.osty:1909:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:4513:5
+	// Osty: toolchain/llvmgen.osty:1910:5
 	llvmPrintlnF64(main, llvmExtractValue(main, llvmIdent(main, "value"), "double", 1))
-	// Osty: toolchain/llvmgen.osty:4514:5
+	// Osty: toolchain/llvmgen.osty:1911:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("MaybeF", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4529:5
+// Osty: toolchain/llvmgen.osty:1924:5
 func llvmSmokeFloatEnumPayloadIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4530:5
+	// Osty: toolchain/llvmgen.osty:1925:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4531:5
+	// Osty: toolchain/llvmgen.osty:1926:5
 	value := llvmEnumPayloadVariant(main, "%MaybeF", 0, llvmFloatLiteral("42.0"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4532:5
+	// Osty: toolchain/llvmgen.osty:1927:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:4533:5
+	// Osty: toolchain/llvmgen.osty:1928:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4534:5
+	// Osty: toolchain/llvmgen.osty:1929:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4535:5
+	// Osty: toolchain/llvmgen.osty:1930:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("MaybeF", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4536:5
+	// Osty: toolchain/llvmgen.osty:1931:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4537:5
+	// Osty: toolchain/llvmgen.osty:1932:5
 	thenValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4538:5
+	// Osty: toolchain/llvmgen.osty:1933:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4539:5
+	// Osty: toolchain/llvmgen.osty:1934:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4540:5
+	// Osty: toolchain/llvmgen.osty:1935:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4541:5
+	// Osty: toolchain/llvmgen.osty:1936:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4542:5
+	// Osty: toolchain/llvmgen.osty:1937:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("MaybeF", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4557:5
+// Osty: toolchain/llvmgen.osty:1950:5
 func llvmSmokeFloatPayloadReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4558:5
+	// Osty: toolchain/llvmgen.osty:1951:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:4559:5
+	// Osty: toolchain/llvmgen.osty:1952:5
 	llvmReturn(pick, llvmEnumPayloadVariant(pick, "%FloatMaybe", 0, llvmFloatLiteral("42.0")))
-	// Osty: toolchain/llvmgen.osty:4561:5
+	// Osty: toolchain/llvmgen.osty:1954:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4562:5
+	// Osty: toolchain/llvmgen.osty:1955:5
 	valueRef := llvmCall(score, "%FloatMaybe", "pick", make([]*LlvmValue, 0, 1))
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4563:5
+	// Osty: toolchain/llvmgen.osty:1956:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4564:5
+	// Osty: toolchain/llvmgen.osty:1957:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4565:5
+	// Osty: toolchain/llvmgen.osty:1958:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4566:5
+	// Osty: toolchain/llvmgen.osty:1959:5
 	thenValue := llvmExtractValue(score, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4567:5
+	// Osty: toolchain/llvmgen.osty:1960:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4568:5
+	// Osty: toolchain/llvmgen.osty:1961:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4569:5
+	// Osty: toolchain/llvmgen.osty:1962:5
 	out := llvmIfExprEnd(score, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4570:5
+	// Osty: toolchain/llvmgen.osty:1963:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:4572:5
+	// Osty: toolchain/llvmgen.osty:1965:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4573:5
+	// Osty: toolchain/llvmgen.osty:1966:5
 	value := llvmCall(main, "double", "score", make([]*LlvmValue, 0, 1))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4574:5
+	// Osty: toolchain/llvmgen.osty:1967:5
 	llvmPrintlnF64(main, value)
-	// Osty: toolchain/llvmgen.osty:4575:5
+	// Osty: toolchain/llvmgen.osty:1968:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%FloatMaybe", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("double", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4592:5
+// Osty: toolchain/llvmgen.osty:1983:5
 func llvmSmokeFloatPayloadParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4593:5
+	// Osty: toolchain/llvmgen.osty:1984:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4594:5
+	// Osty: toolchain/llvmgen.osty:1985:5
 	llvmBind(score, "value", &LlvmValue{typ: "%FloatMaybe", name: "%value", pointer: false})
-	// Osty: toolchain/llvmgen.osty:4595:5
+	// Osty: toolchain/llvmgen.osty:1986:5
 	valueRef := llvmIdent(score, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4596:5
+	// Osty: toolchain/llvmgen.osty:1987:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4597:5
+	// Osty: toolchain/llvmgen.osty:1988:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4598:5
+	// Osty: toolchain/llvmgen.osty:1989:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4599:5
+	// Osty: toolchain/llvmgen.osty:1990:5
 	thenValue := llvmExtractValue(score, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4600:5
+	// Osty: toolchain/llvmgen.osty:1991:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4601:5
+	// Osty: toolchain/llvmgen.osty:1992:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4602:5
+	// Osty: toolchain/llvmgen.osty:1993:5
 	out := llvmIfExprEnd(score, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4603:5
+	// Osty: toolchain/llvmgen.osty:1994:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:4605:5
+	// Osty: toolchain/llvmgen.osty:1996:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4606:5
+	// Osty: toolchain/llvmgen.osty:1997:5
 	arg := llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0"))
 	_ = arg
-	// Osty: toolchain/llvmgen.osty:4607:5
+	// Osty: toolchain/llvmgen.osty:1998:5
 	mainOut := llvmCall(main, "double", "score", []*LlvmValue{arg})
 	_ = mainOut
-	// Osty: toolchain/llvmgen.osty:4608:5
+	// Osty: toolchain/llvmgen.osty:1999:5
 	llvmPrintlnF64(main, mainOut)
-	// Osty: toolchain/llvmgen.osty:4609:5
+	// Osty: toolchain/llvmgen.osty:2000:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("double", "score", []*LlvmParam{llvmParam("value", "%FloatMaybe")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4625:5
+// Osty: toolchain/llvmgen.osty:2014:5
 func llvmSmokeFloatPayloadMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4626:5
+	// Osty: toolchain/llvmgen.osty:2015:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4627:5
+	// Osty: toolchain/llvmgen.osty:2016:5
 	llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%FloatMaybe", 1, llvmFloatLiteral("0.0")))
-	// Osty: toolchain/llvmgen.osty:4632:5
+	// Osty: toolchain/llvmgen.osty:2017:5
 	_ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0")))
-	// Osty: toolchain/llvmgen.osty:4637:5
+	// Osty: toolchain/llvmgen.osty:2018:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4638:5
+	// Osty: toolchain/llvmgen.osty:2019:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4639:5
+	// Osty: toolchain/llvmgen.osty:2020:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4640:5
+	// Osty: toolchain/llvmgen.osty:2021:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4641:5
+	// Osty: toolchain/llvmgen.osty:2022:5
 	thenValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4642:5
+	// Osty: toolchain/llvmgen.osty:2023:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4643:5
+	// Osty: toolchain/llvmgen.osty:2024:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4644:5
+	// Osty: toolchain/llvmgen.osty:2025:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4645:5
+	// Osty: toolchain/llvmgen.osty:2026:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4646:5
+	// Osty: toolchain/llvmgen.osty:2027:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4661:5
+// Osty: toolchain/llvmgen.osty:2040:5
 func llvmSmokeFloatPayloadReversedMatchIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4662:5
+	// Osty: toolchain/llvmgen.osty:2041:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4663:5
+	// Osty: toolchain/llvmgen.osty:2042:5
 	value := llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4664:5
+	// Osty: toolchain/llvmgen.osty:2043:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:4665:5
+	// Osty: toolchain/llvmgen.osty:2044:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4666:5
+	// Osty: toolchain/llvmgen.osty:2045:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4667:5
+	// Osty: toolchain/llvmgen.osty:2046:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4668:5
+	// Osty: toolchain/llvmgen.osty:2047:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4669:5
+	// Osty: toolchain/llvmgen.osty:2048:5
 	thenValue := llvmFloatLiteral("0.0")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4670:5
+	// Osty: toolchain/llvmgen.osty:2049:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4671:5
+	// Osty: toolchain/llvmgen.osty:2050:5
 	elseValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4672:5
+	// Osty: toolchain/llvmgen.osty:2051:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4673:5
+	// Osty: toolchain/llvmgen.osty:2052:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4674:5
+	// Osty: toolchain/llvmgen.osty:2053:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4689:5
+// Osty: toolchain/llvmgen.osty:2066:5
 func llvmSmokeFloatPayloadWildcardIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4690:5
+	// Osty: toolchain/llvmgen.osty:2067:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4691:5
+	// Osty: toolchain/llvmgen.osty:2068:5
 	value := llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4692:5
+	// Osty: toolchain/llvmgen.osty:2069:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:4693:5
+	// Osty: toolchain/llvmgen.osty:2070:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4694:5
+	// Osty: toolchain/llvmgen.osty:2071:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4695:5
+	// Osty: toolchain/llvmgen.osty:2072:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4696:5
+	// Osty: toolchain/llvmgen.osty:2073:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4697:5
+	// Osty: toolchain/llvmgen.osty:2074:5
 	thenValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4698:5
+	// Osty: toolchain/llvmgen.osty:2075:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4699:5
+	// Osty: toolchain/llvmgen.osty:2076:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4700:5
+	// Osty: toolchain/llvmgen.osty:2077:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4701:5
+	// Osty: toolchain/llvmgen.osty:2078:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4702:5
+	// Osty: toolchain/llvmgen.osty:2079:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4717:5
+// Osty: toolchain/llvmgen.osty:2092:5
 func llvmSmokeStringPayloadReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4718:5
+	// Osty: toolchain/llvmgen.osty:2093:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:4719:5
+	// Osty: toolchain/llvmgen.osty:2094:5
 	llvmReturn(pick, llvmEnumPayloadVariant(pick, "%Label", 0, llvmStringLiteral(pick, "payload string")))
-	// Osty: toolchain/llvmgen.osty:4724:5
+	// Osty: toolchain/llvmgen.osty:2096:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4725:5
+	// Osty: toolchain/llvmgen.osty:2097:5
 	valueRef := llvmCall(score, "%Label", "pick", make([]*LlvmValue, 0, 1))
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4726:5
+	// Osty: toolchain/llvmgen.osty:2098:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4727:5
+	// Osty: toolchain/llvmgen.osty:2099:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4728:5
+	// Osty: toolchain/llvmgen.osty:2100:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4729:5
+	// Osty: toolchain/llvmgen.osty:2101:5
 	thenValue := llvmExtractValue(score, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4730:5
+	// Osty: toolchain/llvmgen.osty:2102:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4731:5
+	// Osty: toolchain/llvmgen.osty:2103:5
 	elseValue := llvmStringLiteral(score, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4732:5
+	// Osty: toolchain/llvmgen.osty:2104:5
 	out := llvmIfExprEnd(score, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4733:5
+	// Osty: toolchain/llvmgen.osty:2105:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:4735:5
+	// Osty: toolchain/llvmgen.osty:2107:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4736:5
+	// Osty: toolchain/llvmgen.osty:2108:5
 	value := llvmCall(main, "ptr", "score", make([]*LlvmValue, 0, 1))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4737:5
+	// Osty: toolchain/llvmgen.osty:2109:5
 	llvmPrintlnString(main, value)
-	// Osty: toolchain/llvmgen.osty:4738:5
+	// Osty: toolchain/llvmgen.osty:2110:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Label", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("ptr", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4755:5
+// Osty: toolchain/llvmgen.osty:2125:5
 func llvmSmokeStringPayloadParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4756:5
+	// Osty: toolchain/llvmgen.osty:2126:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:4757:5
+	// Osty: toolchain/llvmgen.osty:2127:5
 	llvmBind(score, "value", &LlvmValue{typ: "%Label", name: "%value", pointer: false})
-	// Osty: toolchain/llvmgen.osty:4758:5
+	// Osty: toolchain/llvmgen.osty:2128:5
 	valueRef := llvmIdent(score, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4759:5
+	// Osty: toolchain/llvmgen.osty:2129:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4760:5
+	// Osty: toolchain/llvmgen.osty:2130:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4761:5
+	// Osty: toolchain/llvmgen.osty:2131:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4762:5
+	// Osty: toolchain/llvmgen.osty:2132:5
 	thenValue := llvmExtractValue(score, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4763:5
+	// Osty: toolchain/llvmgen.osty:2133:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:4764:5
+	// Osty: toolchain/llvmgen.osty:2134:5
 	elseValue := llvmStringLiteral(score, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4765:5
+	// Osty: toolchain/llvmgen.osty:2135:5
 	out := llvmIfExprEnd(score, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4766:5
+	// Osty: toolchain/llvmgen.osty:2136:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:4768:5
+	// Osty: toolchain/llvmgen.osty:2138:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4769:5
+	// Osty: toolchain/llvmgen.osty:2139:5
 	arg := llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string"))
 	_ = arg
-	// Osty: toolchain/llvmgen.osty:4770:5
+	// Osty: toolchain/llvmgen.osty:2140:5
 	value := llvmCall(main, "ptr", "score", []*LlvmValue{arg})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4771:5
+	// Osty: toolchain/llvmgen.osty:2141:5
 	llvmPrintlnString(main, value)
-	// Osty: toolchain/llvmgen.osty:4772:5
+	// Osty: toolchain/llvmgen.osty:2142:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("ptr", "score", []*LlvmParam{llvmParam("value", "%Label")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4788:5
+// Osty: toolchain/llvmgen.osty:2156:5
 func llvmSmokeStringPayloadMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4789:5
+	// Osty: toolchain/llvmgen.osty:2157:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4790:5
+	// Osty: toolchain/llvmgen.osty:2158:5
 	llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%Label", 1, llvmStringLiteral(main, "no payload")))
-	// Osty: toolchain/llvmgen.osty:4795:5
+	// Osty: toolchain/llvmgen.osty:2159:5
 	_ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string")))
-	// Osty: toolchain/llvmgen.osty:4800:5
+	// Osty: toolchain/llvmgen.osty:2160:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4801:5
+	// Osty: toolchain/llvmgen.osty:2161:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4802:5
+	// Osty: toolchain/llvmgen.osty:2162:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4803:5
+	// Osty: toolchain/llvmgen.osty:2163:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4804:5
+	// Osty: toolchain/llvmgen.osty:2164:5
 	thenValue := llvmExtractValue(main, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4805:5
+	// Osty: toolchain/llvmgen.osty:2165:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4806:5
+	// Osty: toolchain/llvmgen.osty:2166:5
 	elseValue := llvmStringLiteral(main, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4807:5
+	// Osty: toolchain/llvmgen.osty:2167:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4808:5
+	// Osty: toolchain/llvmgen.osty:2168:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:4809:5
+	// Osty: toolchain/llvmgen.osty:2169:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4824:5
+// Osty: toolchain/llvmgen.osty:2182:5
 func llvmSmokeStringPayloadReversedMatchIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4825:5
+	// Osty: toolchain/llvmgen.osty:2183:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4826:5
+	// Osty: toolchain/llvmgen.osty:2184:5
 	value := llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4827:5
+	// Osty: toolchain/llvmgen.osty:2185:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:4828:5
+	// Osty: toolchain/llvmgen.osty:2186:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4829:5
+	// Osty: toolchain/llvmgen.osty:2187:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4830:5
+	// Osty: toolchain/llvmgen.osty:2188:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4831:5
+	// Osty: toolchain/llvmgen.osty:2189:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4832:5
+	// Osty: toolchain/llvmgen.osty:2190:5
 	thenValue := llvmStringLiteral(main, "no payload")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4833:5
+	// Osty: toolchain/llvmgen.osty:2191:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4834:5
+	// Osty: toolchain/llvmgen.osty:2192:5
 	elseValue := llvmExtractValue(main, valueRef, "ptr", 1)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4835:5
+	// Osty: toolchain/llvmgen.osty:2193:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4836:5
+	// Osty: toolchain/llvmgen.osty:2194:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:4837:5
+	// Osty: toolchain/llvmgen.osty:2195:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4852:5
+// Osty: toolchain/llvmgen.osty:2208:5
 func llvmSmokeStringPayloadWildcardIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4853:5
+	// Osty: toolchain/llvmgen.osty:2209:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4854:5
+	// Osty: toolchain/llvmgen.osty:2210:5
 	value := llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4855:5
+	// Osty: toolchain/llvmgen.osty:2211:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:4856:5
+	// Osty: toolchain/llvmgen.osty:2212:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:4857:5
+	// Osty: toolchain/llvmgen.osty:2213:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:4858:5
+	// Osty: toolchain/llvmgen.osty:2214:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:4859:5
+	// Osty: toolchain/llvmgen.osty:2215:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4860:5
+	// Osty: toolchain/llvmgen.osty:2216:5
 	thenValue := llvmExtractValue(main, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4861:5
+	// Osty: toolchain/llvmgen.osty:2217:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4862:5
+	// Osty: toolchain/llvmgen.osty:2218:5
 	elseValue := llvmStringLiteral(main, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4863:5
+	// Osty: toolchain/llvmgen.osty:2219:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4864:5
+	// Osty: toolchain/llvmgen.osty:2220:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:4865:5
+	// Osty: toolchain/llvmgen.osty:2221:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4880:5
+// Osty: toolchain/llvmgen.osty:2234:5
 func llvmSmokeIntIfExprIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4881:5
+	// Osty: toolchain/llvmgen.osty:2235:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4882:5
+	// Osty: toolchain/llvmgen.osty:2236:5
 	labels := llvmIfExprStart(main, llvmI1("true"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4883:5
+	// Osty: toolchain/llvmgen.osty:2237:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4884:5
+	// Osty: toolchain/llvmgen.osty:2238:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4885:5
+	// Osty: toolchain/llvmgen.osty:2239:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4886:5
+	// Osty: toolchain/llvmgen.osty:2240:5
 	out := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4887:5
+	// Osty: toolchain/llvmgen.osty:2241:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:4888:5
+	// Osty: toolchain/llvmgen.osty:2242:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4899:5
+// Osty: toolchain/llvmgen.osty:2253:5
 func llvmSmokeStringIfExprIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4900:5
+	// Osty: toolchain/llvmgen.osty:2254:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4901:5
+	// Osty: toolchain/llvmgen.osty:2255:5
 	labels := llvmIfExprStart(main, llvmI1("true"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4902:5
+	// Osty: toolchain/llvmgen.osty:2256:5
 	thenValue := llvmStringLiteral(main, "chosen string")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4903:5
+	// Osty: toolchain/llvmgen.osty:2257:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4904:5
+	// Osty: toolchain/llvmgen.osty:2258:5
 	elseValue := llvmStringLiteral(main, "fallback")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4905:5
+	// Osty: toolchain/llvmgen.osty:2259:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4906:5
+	// Osty: toolchain/llvmgen.osty:2260:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:4907:5
+	// Osty: toolchain/llvmgen.osty:2261:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4919:5
+// Osty: toolchain/llvmgen.osty:2273:5
 func llvmSmokeFloatIfExprIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4920:5
+	// Osty: toolchain/llvmgen.osty:2274:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4921:5
+	// Osty: toolchain/llvmgen.osty:2275:5
 	labels := llvmIfExprStart(main, llvmI1("true"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4922:5
+	// Osty: toolchain/llvmgen.osty:2276:5
 	thenValue := llvmFloatLiteral("42.0")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4923:5
+	// Osty: toolchain/llvmgen.osty:2277:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:4924:5
+	// Osty: toolchain/llvmgen.osty:2278:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4925:5
+	// Osty: toolchain/llvmgen.osty:2279:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4926:5
+	// Osty: toolchain/llvmgen.osty:2280:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:4927:5
+	// Osty: toolchain/llvmgen.osty:2281:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4938:5
+// Osty: toolchain/llvmgen.osty:2292:5
 func llvmSmokeBoolParamReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4939:5
+	// Osty: toolchain/llvmgen.osty:2293:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:4940:5
+	// Osty: toolchain/llvmgen.osty:2294:5
 	llvmBind(pick, "flag", llvmI1("%flag"))
-	// Osty: toolchain/llvmgen.osty:4941:5
+	// Osty: toolchain/llvmgen.osty:2295:5
 	labels := llvmIfExprStart(pick, llvmIdent(pick, "flag"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:4942:5
+	// Osty: toolchain/llvmgen.osty:2296:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:4943:5
+	// Osty: toolchain/llvmgen.osty:2297:5
 	llvmIfExprElse(pick, labels)
-	// Osty: toolchain/llvmgen.osty:4944:5
+	// Osty: toolchain/llvmgen.osty:2298:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:4945:5
+	// Osty: toolchain/llvmgen.osty:2299:5
 	out := llvmIfExprEnd(pick, "i64", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:4946:5
+	// Osty: toolchain/llvmgen.osty:2300:5
 	llvmReturn(pick, out)
-	// Osty: toolchain/llvmgen.osty:4948:5
+	// Osty: toolchain/llvmgen.osty:2302:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4949:5
+	// Osty: toolchain/llvmgen.osty:2303:5
 	value := llvmCall(main, "i64", "pick", []*LlvmValue{llvmI1("true")})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4950:5
+	// Osty: toolchain/llvmgen.osty:2304:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:4951:5
+	// Osty: toolchain/llvmgen.osty:2305:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", []*LlvmParam{llvmParam("flag", "i1")}, pick.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4963:5
+// Osty: toolchain/llvmgen.osty:2317:5
 func llvmSmokeIntRangeExclusiveIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4964:5
+	// Osty: toolchain/llvmgen.osty:2318:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: toolchain/llvmgen.osty:4965:5
+	// Osty: toolchain/llvmgen.osty:2319:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: toolchain/llvmgen.osty:4966:5
+	// Osty: toolchain/llvmgen.osty:2320:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:4967:5
+	// Osty: toolchain/llvmgen.osty:2321:5
 	loop := llvmRangeStart(sumTo, "i", llvmIntLiteral(0), llvmIdent(sumTo, "n"), false)
 	_ = loop
-	// Osty: toolchain/llvmgen.osty:4968:5
+	// Osty: toolchain/llvmgen.osty:2322:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: toolchain/llvmgen.osty:4969:5
+	// Osty: toolchain/llvmgen.osty:2323:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: toolchain/llvmgen.osty:4970:5
+	// Osty: toolchain/llvmgen.osty:2324:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: toolchain/llvmgen.osty:4971:5
+	// Osty: toolchain/llvmgen.osty:2325:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: toolchain/llvmgen.osty:4973:5
+	// Osty: toolchain/llvmgen.osty:2327:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4974:5
+	// Osty: toolchain/llvmgen.osty:2328:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(7)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4975:5
+	// Osty: toolchain/llvmgen.osty:2329:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:4976:5
+	// Osty: toolchain/llvmgen.osty:2330:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:4988:5
+// Osty: toolchain/llvmgen.osty:2342:5
 func llvmSmokeIntUnaryIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:4989:5
+	// Osty: toolchain/llvmgen.osty:2343:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:4990:5
+	// Osty: toolchain/llvmgen.osty:2344:5
 	diff := llvmBinaryI64(main, "sub", llvmIntLiteral(40), llvmIntLiteral(82))
 	_ = diff
-	// Osty: toolchain/llvmgen.osty:4991:5
+	// Osty: toolchain/llvmgen.osty:2345:5
 	value := llvmBinaryI64(main, "sub", llvmIntLiteral(0), diff)
 	_ = value
-	// Osty: toolchain/llvmgen.osty:4992:5
+	// Osty: toolchain/llvmgen.osty:2346:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:4993:5
+	// Osty: toolchain/llvmgen.osty:2347:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:5004:5
+// Osty: toolchain/llvmgen.osty:2358:5
 func llvmSmokeIntModuloIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:5005:5
+	// Osty: toolchain/llvmgen.osty:2359:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:5006:5
+	// Osty: toolchain/llvmgen.osty:2360:5
 	value := llvmBinaryI64(main, "srem", llvmIntLiteral(85), llvmIntLiteral(43))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:5007:5
+	// Osty: toolchain/llvmgen.osty:2361:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:5008:5
+	// Osty: toolchain/llvmgen.osty:2362:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:5019:5
+// Osty: toolchain/llvmgen.osty:2373:5
 func llvmSmokeStructStringFieldIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:5020:5
+	// Osty: toolchain/llvmgen.osty:2374:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:5021:5
+	// Osty: toolchain/llvmgen.osty:2375:5
 	msg := llvmStructLiteral(main, "%Message", []*LlvmValue{llvmStringLiteral(main, "struct string")})
 	_ = msg
-	// Osty: toolchain/llvmgen.osty:5022:5
+	// Osty: toolchain/llvmgen.osty:2376:5
 	llvmImmutableLet(main, "msg", msg)
-	// Osty: toolchain/llvmgen.osty:5023:5
+	// Osty: toolchain/llvmgen.osty:2377:5
 	llvmPrintlnString(main, llvmExtractValue(main, llvmIdent(main, "msg"), "ptr", 0))
-	// Osty: toolchain/llvmgen.osty:5024:5
+	// Osty: toolchain/llvmgen.osty:2378:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Message", []string{"ptr"})}, main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:5039:5
+// Osty: toolchain/llvmgen.osty:2391:5
 func llvmSmokeStructBoolFieldIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:5040:5
+	// Osty: toolchain/llvmgen.osty:2392:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:5041:5
+	// Osty: toolchain/llvmgen.osty:2393:5
 	gate := llvmStructLiteral(main, "%Gate", []*LlvmValue{llvmI1("true")})
 	_ = gate
-	// Osty: toolchain/llvmgen.osty:5042:5
+	// Osty: toolchain/llvmgen.osty:2394:5
 	llvmImmutableLet(main, "gate", gate)
-	// Osty: toolchain/llvmgen.osty:5043:5
+	// Osty: toolchain/llvmgen.osty:2395:5
 	cond := llvmExtractValue(main, llvmIdent(main, "gate"), "i1", 0)
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:5044:5
+	// Osty: toolchain/llvmgen.osty:2396:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:5045:5
+	// Osty: toolchain/llvmgen.osty:2397:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:5046:5
+	// Osty: toolchain/llvmgen.osty:2398:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:5047:5
+	// Osty: toolchain/llvmgen.osty:2399:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:5048:5
+	// Osty: toolchain/llvmgen.osty:2400:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:5049:5
+	// Osty: toolchain/llvmgen.osty:2401:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Gate", []string{"i1"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:5064:5
+// Osty: toolchain/llvmgen.osty:2414:5
 func llvmSmokeBoolMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:5065:5
+	// Osty: toolchain/llvmgen.osty:2415:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:5066:5
+	// Osty: toolchain/llvmgen.osty:2416:5
 	llvmMutableLet(main, "flag", llvmI1("false"))
-	// Osty: toolchain/llvmgen.osty:5067:5
+	// Osty: toolchain/llvmgen.osty:2417:5
 	_ = llvmAssign(main, "flag", llvmI1("true"))
-	// Osty: toolchain/llvmgen.osty:5068:5
+	// Osty: toolchain/llvmgen.osty:2418:5
 	cond := llvmIdent(main, "flag")
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:5069:5
+	// Osty: toolchain/llvmgen.osty:2419:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:5070:5
+	// Osty: toolchain/llvmgen.osty:2420:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:5071:5
+	// Osty: toolchain/llvmgen.osty:2421:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:5072:5
+	// Osty: toolchain/llvmgen.osty:2422:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:5073:5
+	// Osty: toolchain/llvmgen.osty:2423:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:5074:5
+	// Osty: toolchain/llvmgen.osty:2424:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:5085:1
+// Osty: toolchain/llvmgen.osty:2435:1
 func llvmCallArgs(args []*LlvmValue) string {
-	// Osty: toolchain/llvmgen.osty:5086:5
+	// Osty: toolchain/llvmgen.osty:2436:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: toolchain/llvmgen.osty:5087:5
+	// Osty: toolchain/llvmgen.osty:2437:5
 	for _, arg := range args {
-		// Osty: toolchain/llvmgen.osty:5088:9
+		// Osty: toolchain/llvmgen.osty:2438:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %s", ostyToString(arg.typ), ostyToString(arg.name)))
 			return struct{}{}
@@ -5547,14 +4596,14 @@ func llvmCallArgs(args []*LlvmValue) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: toolchain/llvmgen.osty:5093:1
+// Osty: toolchain/llvmgen.osty:2443:1
 func llvmParams(params []*LlvmParam) string {
-	// Osty: toolchain/llvmgen.osty:5094:5
+	// Osty: toolchain/llvmgen.osty:2444:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: toolchain/llvmgen.osty:5095:5
+	// Osty: toolchain/llvmgen.osty:2445:5
 	for _, param := range params {
-		// Osty: toolchain/llvmgen.osty:5096:9
+		// Osty: toolchain/llvmgen.osty:2446:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %%%s", ostyToString(param.typ), ostyToString(param.name)))
 			return struct{}{}
@@ -5563,42 +4612,42 @@ func llvmParams(params []*LlvmParam) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: toolchain/llvmgen.osty:5101:1
+// Osty: toolchain/llvmgen.osty:2451:1
 func llvmNextTemp(emitter *LlvmEmitter) string {
-	// Osty: toolchain/llvmgen.osty:5102:5
+	// Osty: toolchain/llvmgen.osty:2452:5
 	name := fmt.Sprintf("%%t%s", ostyToString(emitter.temp))
 	_ = name
-	// Osty: toolchain/llvmgen.osty:5103:12
+	// Osty: toolchain/llvmgen.osty:2453:12
 	emitter.temp = func() int {
-		var _p23 int = emitter.temp
-		var _rhs24 int = 1
-		if _rhs24 > 0 && _p23 > math.MaxInt-_rhs24 {
+		var _p7 int = emitter.temp
+		var _rhs8 int = 1
+		if _rhs8 > 0 && _p7 > math.MaxInt-_rhs8 {
 			panic("integer overflow")
 		}
-		if _rhs24 < 0 && _p23 < math.MinInt-_rhs24 {
+		if _rhs8 < 0 && _p7 < math.MinInt-_rhs8 {
 			panic("integer overflow")
 		}
-		return _p23 + _rhs24
+		return _p7 + _rhs8
 	}()
 	return name
 }
 
-// Osty: toolchain/llvmgen.osty:5107:1
+// Osty: toolchain/llvmgen.osty:2457:1
 func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
-	// Osty: toolchain/llvmgen.osty:5108:5
+	// Osty: toolchain/llvmgen.osty:2458:5
 	name := fmt.Sprintf("%s%s", ostyToString(prefix), ostyToString(emitter.label))
 	_ = name
-	// Osty: toolchain/llvmgen.osty:5109:12
+	// Osty: toolchain/llvmgen.osty:2459:12
 	emitter.label = func() int {
-		var _p25 int = emitter.label
-		var _rhs26 int = 1
-		if _rhs26 > 0 && _p25 > math.MaxInt-_rhs26 {
+		var _p9 int = emitter.label
+		var _rhs10 int = 1
+		if _rhs10 > 0 && _p9 > math.MaxInt-_rhs10 {
 			panic("integer overflow")
 		}
-		if _rhs26 < 0 && _p25 < math.MinInt-_rhs26 {
+		if _rhs10 < 0 && _p9 < math.MinInt-_rhs10 {
 			panic("integer overflow")
 		}
-		return _p25 + _rhs26
+		return _p9 + _rhs10
 	}()
 	return name
 }

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -24,50 +24,50 @@ func ostyToString(v any) string {
 	return fmt.Sprint(v)
 }
 
-// Osty: toolchain/llvmgen.osty:9:5
+// Osty: toolchain/llvmgen.osty:11:5
 type LlvmValue struct {
 	typ     string
 	name    string
 	pointer bool
 }
 
-// Osty: toolchain/llvmgen.osty:15:5
+// Osty: toolchain/llvmgen.osty:17:5
 type LlvmParam struct {
 	name string
 	typ  string
 }
 
-// Osty: toolchain/llvmgen.osty:20:5
+// Osty: toolchain/llvmgen.osty:22:5
 type LlvmBinding struct {
 	name  string
 	value *LlvmValue
 }
 
-// Osty: toolchain/llvmgen.osty:25:5
+// Osty: toolchain/llvmgen.osty:27:5
 type LlvmLookup struct {
 	found bool
 	value *LlvmValue
 }
 
-// Osty: toolchain/llvmgen.osty:30:5
+// Osty: toolchain/llvmgen.osty:32:5
 type LlvmStringGlobal struct {
 	name    string
 	encoded string
 	byteLen int
 }
 
-// Osty: toolchain/llvmgen.osty:36:5
+// Osty: toolchain/llvmgen.osty:38:5
 type LlvmStructField struct {
 	typ string
 }
 
-// Osty: toolchain/llvmgen.osty:40:5
+// Osty: toolchain/llvmgen.osty:42:5
 type LlvmCString struct {
 	encoded string
 	byteLen int
 }
 
-// Osty: toolchain/llvmgen.osty:45:5
+// Osty: toolchain/llvmgen.osty:47:5
 type LlvmEmitter struct {
 	temp          int
 	label         int
@@ -77,14 +77,14 @@ type LlvmEmitter struct {
 	stringGlobals []*LlvmStringGlobal
 }
 
-// Osty: toolchain/llvmgen.osty:54:5
+// Osty: toolchain/llvmgen.osty:56:5
 type LlvmIfLabels struct {
 	thenLabel string
 	elseLabel string
 	endLabel  string
 }
 
-// Osty: toolchain/llvmgen.osty:60:5
+// Osty: toolchain/llvmgen.osty:62:5
 type LlvmRangeLoop struct {
 	condLabel string
 	bodyLabel string
@@ -93,14 +93,14 @@ type LlvmRangeLoop struct {
 	current   string
 }
 
-// Osty: toolchain/llvmgen.osty:68:5
+// Osty: toolchain/llvmgen.osty:70:5
 type LlvmSmokeExecutableCase struct {
 	name    string
 	fixture string
 	stdout  string
 }
 
-// Osty: toolchain/llvmgen.osty:74:5
+// Osty: toolchain/llvmgen.osty:76:5
 type LlvmUnsupportedDiagnostic struct {
 	code    string
 	kind    string
@@ -108,124 +108,129 @@ type LlvmUnsupportedDiagnostic struct {
 	hint    string
 }
 
-// Osty: toolchain/llvmgen.osty:85:5
-type LlvmSafepointChunk struct {
-	start int
-	end   int
-	id    int64
-}
-
-// Osty: toolchain/llvmgen.osty:92:5
+// Osty: toolchain/llvmgen.osty:83:5
 func llvmEmitter() *LlvmEmitter {
 	return &LlvmEmitter{temp: 0, label: 0, stringId: 0, body: make([]string, 0, 1), locals: make([]*LlvmBinding, 0, 1), stringGlobals: make([]*LlvmStringGlobal, 0, 1)}
 }
 
-// Osty: toolchain/llvmgen.osty:92:5
+// Osty: toolchain/llvmgen.osty:94:5
 func llvmI64(name string) *LlvmValue {
 	return &LlvmValue{typ: "i64", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:96:5
+// Osty: toolchain/llvmgen.osty:98:5
 func llvmI1(name string) *LlvmValue {
 	return &LlvmValue{typ: "i1", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:100:5
+// Osty: toolchain/llvmgen.osty:102:5
 func llvmF64(name string) *LlvmValue {
 	return &LlvmValue{typ: "double", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:104:5
+// Osty: toolchain/llvmgen.osty:106:5
 func llvmIntLiteral(value int) *LlvmValue {
 	return llvmI64(fmt.Sprintf("%s", ostyToString(value)))
 }
 
-// Osty: toolchain/llvmgen.osty:108:5
+// Osty: toolchain/llvmgen.osty:110:5
 func llvmFloatLiteral(value string) *LlvmValue {
 	return llvmF64(fmt.Sprintf("%s", ostyToString(value)))
 }
 
-// Osty: toolchain/llvmgen.osty:112:5
+// Osty: toolchain/llvmgen.osty:114:5
 func llvmEnumVariant(enumName string, tag int) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:113:5
+	// Osty: toolchain/llvmgen.osty:115:5
 	_ = enumName
 	return llvmI64(fmt.Sprintf("%s", ostyToString(tag)))
 }
 
-// Osty: toolchain/llvmgen.osty:117:5
+// Osty: toolchain/llvmgen.osty:119:5
 func llvmEnumPayloadVariant(emitter *LlvmEmitter, typ string, tag int, payload *LlvmValue) *LlvmValue {
 	return llvmStructLiteral(emitter, typ, []*LlvmValue{llvmEnumVariant(typ, tag), payload})
 }
 
+// Osty: toolchain/llvmgen.osty:135:5
 func llvmEnumBoxedPayloadVariant(emitter *LlvmEmitter, enumTyp string, tag int, payload *LlvmValue, site string) *LlvmValue {
-	symbol := "osty.rt.enum_alloc_scalar_v1"
-	if payload.typ == "ptr" {
-		symbol = "osty.rt.enum_alloc_ptr_v1"
-	}
+	// Osty: toolchain/llvmgen.osty:142:5
+	symbol := func() string {
+		if payload.typ == "ptr" {
+			return "osty.rt.enum_alloc_ptr_v1"
+		} else {
+			return "osty.rt.enum_alloc_scalar_v1"
+		}
+	}()
+	_ = symbol
+	// Osty: toolchain/llvmgen.osty:147:5
 	heapPtr := llvmCall(emitter, "ptr", symbol, []*LlvmValue{llvmStringLiteral(emitter, site)})
+	_ = heapPtr
+	// Osty: toolchain/llvmgen.osty:153:5
 	llvmStore(emitter, heapPtr, payload)
 	return llvmStructLiteral(emitter, enumTyp, []*LlvmValue{llvmEnumVariant(enumTyp, tag), heapPtr})
 }
 
+// Osty: toolchain/llvmgen.osty:160:5
 func llvmEnumBoxedBareVariant(emitter *LlvmEmitter, enumTyp string, tag int) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:165:5
 	nullPtr := &LlvmValue{typ: "ptr", name: "null", pointer: false}
+	_ = nullPtr
 	return llvmStructLiteral(emitter, enumTyp, []*LlvmValue{llvmEnumVariant(enumTyp, tag), nullPtr})
 }
 
-// Osty: toolchain/llvmgen.osty:126:5
+// Osty: toolchain/llvmgen.osty:169:5
 func llvmParam(name string, typ string) *LlvmParam {
 	return &LlvmParam{name: name, typ: typ}
 }
 
-// Osty: toolchain/llvmgen.osty:130:5
+// Osty: toolchain/llvmgen.osty:173:5
 func llvmBind(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:131:5
+	// Osty: toolchain/llvmgen.osty:174:5
 	func() struct{} {
 		emitter.locals = append(emitter.locals, &LlvmBinding{name: name, value: value})
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:134:5
+// Osty: toolchain/llvmgen.osty:177:5
 func llvmLookup(emitter *LlvmEmitter, name string) *LlvmLookup {
-	// Osty: toolchain/llvmgen.osty:135:5
+	// Osty: toolchain/llvmgen.osty:178:5
 	out := &LlvmLookup{found: false, value: llvmI64("0")}
 	_ = out
-	// Osty: toolchain/llvmgen.osty:136:5
+	// Osty: toolchain/llvmgen.osty:179:5
 	for _, binding := range emitter.locals {
-		// Osty: toolchain/llvmgen.osty:137:9
+		// Osty: toolchain/llvmgen.osty:180:9
 		if binding.name == name {
-			// Osty: toolchain/llvmgen.osty:138:13
+			// Osty: toolchain/llvmgen.osty:181:13
 			out = &LlvmLookup{found: true, value: binding.value}
 		}
 	}
 	return out
 }
 
-// Osty: toolchain/llvmgen.osty:144:5
+// Osty: toolchain/llvmgen.osty:187:5
 func llvmIdent(emitter *LlvmEmitter, name string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:145:5
+	// Osty: toolchain/llvmgen.osty:188:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: toolchain/llvmgen.osty:146:5
+	// Osty: toolchain/llvmgen.osty:189:5
 	if !(lookup.found) {
-		// Osty: toolchain/llvmgen.osty:147:9
+		// Osty: toolchain/llvmgen.osty:190:9
 		return llvmI64("0")
 	}
-	// Osty: toolchain/llvmgen.osty:149:5
+	// Osty: toolchain/llvmgen.osty:192:5
 	if lookup.value.pointer {
-		// Osty: toolchain/llvmgen.osty:150:9
+		// Osty: toolchain/llvmgen.osty:193:9
 		return llvmLoad(emitter, lookup.value)
 	}
 	return lookup.value
 }
 
-// Osty: toolchain/llvmgen.osty:155:5
+// Osty: toolchain/llvmgen.osty:198:5
 func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:156:5
+	// Osty: toolchain/llvmgen.osty:199:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:157:5
+	// Osty: toolchain/llvmgen.osty:200:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(slot.typ), ostyToString(slot.name)))
 		return struct{}{}
@@ -233,102 +238,137 @@ func llvmLoad(emitter *LlvmEmitter, slot *LlvmValue) *LlvmValue {
 	return &LlvmValue{typ: slot.typ, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:161:5
-func llvmSlotAsPtr(slot *LlvmValue) *LlvmValue {
-	return &LlvmValue{typ: "ptr", name: slot.name, pointer: false}
-}
-
-func llvmAllocaSlot(emitter *LlvmEmitter, llvmType string) *LlvmValue {
-	slot := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", slot, llvmType))
-	return &LlvmValue{typ: "ptr", name: slot, pointer: false}
-}
-
-func llvmSpillToSlot(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
-	slot := llvmAllocaSlot(emitter, value.typ)
-	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", value.typ, value.name, slot.name))
-	return slot
-}
-
-func llvmLoadFromSlot(emitter *LlvmEmitter, slot *LlvmValue, llvmType string) *LlvmValue {
-	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, llvmType, slot.name))
-	return &LlvmValue{typ: llvmType, name: tmp, pointer: false}
-}
-
-func llvmSizeOf(emitter *LlvmEmitter, llvmType string) *LlvmValue {
-	gep := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", gep, llvmType))
-	size := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", size, gep))
-	return &LlvmValue{typ: "i64", name: size, pointer: false}
-}
-
+// Osty: toolchain/llvmgen.osty:204:5
 func llvmMutableLetSlot(emitter *LlvmEmitter, name string, initial *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:166:5
+	// Osty: toolchain/llvmgen.osty:209:5
 	ptr := llvmNextTemp(emitter)
 	_ = ptr
-	// Osty: toolchain/llvmgen.osty:167:5
+	// Osty: toolchain/llvmgen.osty:210:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(ptr), ostyToString(initial.typ)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:168:5
+	// Osty: toolchain/llvmgen.osty:211:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(initial.typ), ostyToString(initial.name), ostyToString(ptr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:169:5
+	// Osty: toolchain/llvmgen.osty:212:5
 	slot := &LlvmValue{typ: initial.typ, name: ptr, pointer: true}
 	_ = slot
-	// Osty: toolchain/llvmgen.osty:170:5
+	// Osty: toolchain/llvmgen.osty:213:5
 	llvmBind(emitter, name, slot)
 	return slot
 }
 
-// Osty: toolchain/llvmgen.osty:174:5
+// Osty: toolchain/llvmgen.osty:217:5
 func llvmMutableLet(emitter *LlvmEmitter, name string, initial *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:175:5
+	// Osty: toolchain/llvmgen.osty:218:5
 	_slot := llvmMutableLetSlot(emitter, name, initial)
 	_ = _slot
 }
 
-// Osty: toolchain/llvmgen.osty:178:5
+// Osty: toolchain/llvmgen.osty:221:5
 func llvmStore(emitter *LlvmEmitter, slot *LlvmValue, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:179:5
+	// Osty: toolchain/llvmgen.osty:222:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(slot.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:182:5
+// Osty: toolchain/llvmgen.osty:230:5
+func llvmSlotAsPtr(slot *LlvmValue) *LlvmValue {
+	return &LlvmValue{typ: "ptr", name: slot.name, pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:238:5
+func llvmAllocaSlot(emitter *LlvmEmitter, llvmType string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:239:5
+	slot := llvmNextTemp(emitter)
+	_ = slot
+	// Osty: toolchain/llvmgen.osty:240:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %s", ostyToString(slot), ostyToString(llvmType)))
+		return struct{}{}
+	}()
+	return &LlvmValue{typ: "ptr", name: slot, pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:248:5
+func llvmSpillToSlot(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:249:5
+	slot := llvmAllocaSlot(emitter, value.typ)
+	_ = slot
+	// Osty: toolchain/llvmgen.osty:250:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(slot.name)))
+		return struct{}{}
+	}()
+	return slot
+}
+
+// Osty: toolchain/llvmgen.osty:258:5
+func llvmLoadFromSlot(emitter *LlvmEmitter, slot *LlvmValue, llvmType string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:263:5
+	tmp := llvmNextTemp(emitter)
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:264:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(llvmType), ostyToString(slot.name)))
+		return struct{}{}
+	}()
+	return &LlvmValue{typ: llvmType, name: tmp, pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:273:5
+func llvmSizeOf(emitter *LlvmEmitter, llvmType string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:274:5
+	gep := llvmNextTemp(emitter)
+	_ = gep
+	// Osty: toolchain/llvmgen.osty:275:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %s, ptr null, i32 1", ostyToString(gep), ostyToString(llvmType)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:276:5
+	size := llvmNextTemp(emitter)
+	_ = size
+	// Osty: toolchain/llvmgen.osty:277:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = ptrtoint ptr %s to i64", ostyToString(size), ostyToString(gep)))
+		return struct{}{}
+	}()
+	return &LlvmValue{typ: "i64", name: size, pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:281:5
 func llvmAssign(emitter *LlvmEmitter, name string, value *LlvmValue) bool {
-	// Osty: toolchain/llvmgen.osty:183:5
+	// Osty: toolchain/llvmgen.osty:282:5
 	lookup := llvmLookup(emitter, name)
 	_ = lookup
-	// Osty: toolchain/llvmgen.osty:184:5
+	// Osty: toolchain/llvmgen.osty:283:5
 	if !(lookup.found) || !(lookup.value.pointer) || lookup.value.typ != value.typ {
-		// Osty: toolchain/llvmgen.osty:185:9
+		// Osty: toolchain/llvmgen.osty:284:9
 		return false
 	}
-	// Osty: toolchain/llvmgen.osty:187:5
+	// Osty: toolchain/llvmgen.osty:286:5
 	llvmStore(emitter, lookup.value, value)
 	return true
 }
 
-// Osty: toolchain/llvmgen.osty:191:5
+// Osty: toolchain/llvmgen.osty:290:5
 func llvmImmutableLet(emitter *LlvmEmitter, name string, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:192:5
+	// Osty: toolchain/llvmgen.osty:291:5
 	llvmBind(emitter, name, value)
 }
 
-// Osty: toolchain/llvmgen.osty:199:5
+// Osty: toolchain/llvmgen.osty:298:5
 func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:205:5
+	// Osty: toolchain/llvmgen.osty:304:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:206:5
+	// Osty: toolchain/llvmgen.osty:305:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i64 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -336,12 +376,12 @@ func llvmBinaryI64(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI64(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:210:5
+// Osty: toolchain/llvmgen.osty:309:5
 func llvmBinaryF64(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:216:5
+	// Osty: toolchain/llvmgen.osty:315:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:217:5
+	// Osty: toolchain/llvmgen.osty:316:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s double %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -349,12 +389,12 @@ func llvmBinaryF64(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmF64(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:221:5
+// Osty: toolchain/llvmgen.osty:320:5
 func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:227:5
+	// Osty: toolchain/llvmgen.osty:326:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:228:5
+	// Osty: toolchain/llvmgen.osty:327:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s %s %s, %s", ostyToString(tmp), ostyToString(pred), ostyToString(left.typ), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -362,12 +402,12 @@ func llvmCompare(emitter *LlvmEmitter, pred string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:232:5
+// Osty: toolchain/llvmgen.osty:331:5
 func llvmCompareF64(emitter *LlvmEmitter, pred string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:238:5
+	// Osty: toolchain/llvmgen.osty:337:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:239:5
+	// Osty: toolchain/llvmgen.osty:338:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = fcmp %s double %s, %s", ostyToString(tmp), ostyToString(pred), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -375,12 +415,12 @@ func llvmCompareF64(emitter *LlvmEmitter, pred string, left *LlvmValue, right *L
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:243:5
+// Osty: toolchain/llvmgen.osty:342:5
 func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:244:5
+	// Osty: toolchain/llvmgen.osty:343:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:245:5
+	// Osty: toolchain/llvmgen.osty:344:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = xor i1 %s, true", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
@@ -388,12 +428,12 @@ func llvmNotI1(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:249:5
+// Osty: toolchain/llvmgen.osty:348:5
 func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:255:5
+	// Osty: toolchain/llvmgen.osty:354:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:256:5
+	// Osty: toolchain/llvmgen.osty:355:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = %s i1 %s, %s", ostyToString(tmp), ostyToString(op), ostyToString(left.name), ostyToString(right.name)))
 		return struct{}{}
@@ -401,12 +441,12 @@ func llvmLogicalI1(emitter *LlvmEmitter, op string, left *LlvmValue, right *Llvm
 	return llvmI1(tmp)
 }
 
-// Osty: toolchain/llvmgen.osty:260:5
+// Osty: toolchain/llvmgen.osty:359:5
 func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:266:5
+	// Osty: toolchain/llvmgen.osty:365:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:267:5
+	// Osty: toolchain/llvmgen.osty:366:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s @%s(%s)", ostyToString(tmp), ostyToString(ret), ostyToString(name), ostyToString(llvmCallArgs(args))))
 		return struct{}{}
@@ -414,198 +454,320 @@ func llvmCall(emitter *LlvmEmitter, ret string, name string, args []*LlvmValue) 
 	return &LlvmValue{typ: ret, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:271:5
+// Osty: toolchain/llvmgen.osty:370:5
 func llvmCallVoid(emitter *LlvmEmitter, name string, args []*LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:272:5
+	// Osty: toolchain/llvmgen.osty:371:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  call void @%s(%s)", ostyToString(name), ostyToString(llvmCallArgs(args))))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:275:5
+// Osty: toolchain/llvmgen.osty:374:5
 func llvmGcRuntimeDeclarations() []string {
 	return []string{"declare ptr @osty.gc.alloc_v1(i64, i64, ptr)", "declare void @osty.gc.pre_write_v1(ptr, ptr, i64)", "declare void @osty.gc.post_write_v1(ptr, ptr, i64)", "declare ptr @osty.gc.load_v1(ptr)", "declare void @osty.gc.root_bind_v1(ptr)", "declare void @osty.gc.root_release_v1(ptr)", "declare ptr @osty.rt.enum_alloc_ptr_v1(ptr)", "declare ptr @osty.rt.enum_alloc_scalar_v1(ptr)"}
 }
 
-// Osty: toolchain/llvmgen.osty:284:5
+// Osty: toolchain/llvmgen.osty:387:5
 func llvmGcAlloc(emitter *LlvmEmitter, objectKind int, byteSize int, site string) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty.gc.alloc_v1", []*LlvmValue{llvmIntLiteral(objectKind), llvmIntLiteral(byteSize), llvmStringLiteral(emitter, site)})
 }
 
-// Osty: toolchain/llvmgen.osty:302:5
+// Osty: toolchain/llvmgen.osty:405:5
 func llvmGcPostWrite(emitter *LlvmEmitter, owner *LlvmValue, value *LlvmValue, slotKind int) {
-	// Osty: toolchain/llvmgen.osty:308:5
+	// Osty: toolchain/llvmgen.osty:411:5
 	llvmCallVoid(emitter, "osty.gc.post_write_v1", []*LlvmValue{owner, value, llvmIntLiteral(slotKind)})
 }
 
-// Osty: toolchain/llvmgen.osty:319:5
+// Osty: toolchain/llvmgen.osty:422:5
 func llvmGcPreWrite(emitter *LlvmEmitter, owner *LlvmValue, value *LlvmValue, slotKind int) {
-	// Osty: toolchain/llvmgen.osty:325:5
+	// Osty: toolchain/llvmgen.osty:428:5
 	llvmCallVoid(emitter, "osty.gc.pre_write_v1", []*LlvmValue{owner, value, llvmIntLiteral(slotKind)})
 }
 
-// Osty: toolchain/llvmgen.osty:336:5
+// Osty: toolchain/llvmgen.osty:439:5
 func llvmGcLoad(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty.gc.load_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:340:5
+// Osty: toolchain/llvmgen.osty:443:5
 func llvmGcRootBind(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:341:5
+	// Osty: toolchain/llvmgen.osty:444:5
 	llvmCallVoid(emitter, "osty.gc.root_bind_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:344:5
+// Osty: toolchain/llvmgen.osty:447:5
 func llvmGcRootRelease(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:345:5
+	// Osty: toolchain/llvmgen.osty:448:5
 	llvmCallVoid(emitter, "osty.gc.root_release_v1", []*LlvmValue{value})
 }
 
-// Osty: toolchain/llvmgen.osty:455:5
-func llvmSafepointKindUnspecified() int { return 0 }
-
-// Osty: toolchain/llvmgen.osty:457:5
-func llvmSafepointKindEntry() int { return 1 }
-
-// Osty: toolchain/llvmgen.osty:459:5
-func llvmSafepointKindCall() int { return 2 }
-
-// Osty: toolchain/llvmgen.osty:461:5
-func llvmSafepointKindLoop() int { return 3 }
-
-// Osty: toolchain/llvmgen.osty:463:5
-func llvmSafepointKindAlloc() int { return 4 }
-
-// Osty: toolchain/llvmgen.osty:465:5
-func llvmSafepointKindYield() int { return 5 }
-
-// Osty: toolchain/llvmgen.osty:472:5
-func llvmEncodeSafepointId(kind int, serial int) int64 {
-	const mask int64 = (int64(1) << 56) - 1
-	return (int64(kind) << 56) | (int64(serial) & mask)
+// Osty: toolchain/llvmgen.osty:460:5
+func llvmSafepointKindUnspecified() int {
+	return 0
 }
 
-// Osty: toolchain/llvmgen.osty:487:5
-func llvmSafepointDefaultRootChunkSize() int { return 4096 }
+// Osty: toolchain/llvmgen.osty:462:5
+func llvmSafepointKindEntry() int {
+	return 1
+}
+
+// Osty: toolchain/llvmgen.osty:464:5
+func llvmSafepointKindCall() int {
+	return 2
+}
+
+// Osty: toolchain/llvmgen.osty:466:5
+func llvmSafepointKindLoop() int {
+	return 3
+}
+
+// Osty: toolchain/llvmgen.osty:468:5
+func llvmSafepointKindAlloc() int {
+	return 4
+}
+
+// Osty: toolchain/llvmgen.osty:470:5
+func llvmSafepointKindYield() int {
+	return 5
+}
+
+// Osty: toolchain/llvmgen.osty:477:5
+func llvmEncodeSafepointId(kind int, serial int) int {
+	// Osty: toolchain/llvmgen.osty:478:5
+	mask := func() int {
+		var _p1 int = (1 << 56)
+		var _rhs2 int = 1
+		if _rhs2 < 0 && _p1 > math.MaxInt+_rhs2 {
+			panic("integer overflow")
+		}
+		if _rhs2 > 0 && _p1 < math.MinInt+_rhs2 {
+			panic("integer overflow")
+		}
+		return _p1 - _rhs2
+	}()
+	_ = mask
+	return (kind << 56) | (serial & mask)
+}
+
+// Osty: toolchain/llvmgen.osty:492:5
+func llvmSafepointDefaultRootChunkSize() int {
+	return 4096
+}
+
+// Osty: toolchain/llvmgen.osty:497:5
+type LlvmSafepointChunk struct {
+	start int
+	end   int
+	id    int
+}
 
 // Osty: toolchain/llvmgen.osty:510:5
 func llvmPlanSafepointChunks(kind int, firstSerial int, rootCount int, chunkSize int) []*LlvmSafepointChunk {
-	chunks := make([]*LlvmSafepointChunk, 0, 1)
+	// Osty: toolchain/llvmgen.osty:516:5
+	var chunks []*LlvmSafepointChunk = make([]*LlvmSafepointChunk, 0, 1)
+	_ = chunks
+	// Osty: toolchain/llvmgen.osty:517:5
 	if rootCount <= 0 {
+		// Osty: toolchain/llvmgen.osty:518:9
 		return chunks
 	}
-	size := chunkSize
-	if chunkSize <= 0 {
-		size = rootCount
-	}
+	// Osty: toolchain/llvmgen.osty:520:5
+	size := func() int {
+		if chunkSize <= 0 {
+			return rootCount
+		} else {
+			return chunkSize
+		}
+	}()
+	_ = size
+	// Osty: toolchain/llvmgen.osty:521:5
 	serial := firstSerial
+	_ = serial
+	// Osty: toolchain/llvmgen.osty:522:5
 	for start := 0; start < rootCount; start++ {
-		if start%size != 0 {
+		// Osty: toolchain/llvmgen.osty:523:9
+		if func() int {
+			var _p3 int = start
+			var _rhs4 int = size
+			if _rhs4 == 0 {
+				panic("integer modulo by zero")
+			}
+			if _p3 == math.MinInt && _rhs4 == int(-1) {
+				panic("integer overflow")
+			}
+			return _p3 % _rhs4
+		}() != 0 {
+			// Osty: toolchain/llvmgen.osty:524:13
 			continue
 		}
-		end := start + size
+		// Osty: toolchain/llvmgen.osty:526:9
+		end := func() int {
+			var _p5 int = start
+			var _rhs6 int = size
+			if _rhs6 > 0 && _p5 > math.MaxInt-_rhs6 {
+				panic("integer overflow")
+			}
+			if _rhs6 < 0 && _p5 < math.MinInt-_rhs6 {
+				panic("integer overflow")
+			}
+			return _p5 + _rhs6
+		}()
+		_ = end
+		// Osty: toolchain/llvmgen.osty:527:9
 		if end > rootCount {
+			// Osty: toolchain/llvmgen.osty:528:13
 			end = rootCount
 		}
-		chunks = append(chunks, &LlvmSafepointChunk{
-			start: start,
-			end:   end,
-			id:    llvmEncodeSafepointId(kind, serial),
-		})
-		serial++
+		// Osty: toolchain/llvmgen.osty:530:9
+		func() struct{} {
+			chunks = append(chunks, &LlvmSafepointChunk{start: start, end: end, id: llvmEncodeSafepointId(kind, serial)})
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:537:9
+		func() {
+			var _cur7 int = serial
+			var _rhs8 int = 1
+			if _rhs8 > 0 && _cur7 > math.MaxInt-_rhs8 {
+				panic("integer overflow")
+			}
+			if _rhs8 < 0 && _cur7 < math.MinInt-_rhs8 {
+				panic("integer overflow")
+			}
+			serial = _cur7 + _rhs8
+		}()
 	}
 	return chunks
 }
 
-// Osty: toolchain/llvmgen.osty:535:5
-func llvmClosureEnvGcKind() int { return 1029 }
-
-// Osty: toolchain/llvmgen.osty:542:5
-func llvmClosureEnvPhase1CaptureCount() int { return 0 }
-
 // Osty: toolchain/llvmgen.osty:551:5
-func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string) *LlvmValue {
-	envTemp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %d, ptr %s)", envTemp, captureCount, siteName))
-	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", thunkSymbol, envTemp))
-	return &LlvmValue{typ: "ptr", name: envTemp, pointer: false}
-}
-
-// Osty: toolchain/llvmgen.osty:550:5
-func llvmRenderSafepointEmpty(id int64) string {
-	return fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr null, i64 0)", id)
+func llvmClosureEnvGcKind() int {
+	return 1029
 }
 
 // Osty: toolchain/llvmgen.osty:558:5
-func llvmEmitSafepointEmpty(emitter *LlvmEmitter, id int64) {
-	emitter.body = append(emitter.body, llvmRenderSafepointEmpty(id))
+func llvmClosureEnvPhase1CaptureCount() int {
+	return 0
 }
 
-// Osty: toolchain/llvmgen.osty:560:5
-func llvmEmitSafepointWithRoots(emitter *LlvmEmitter, id int64, rootAddresses []string) {
+// Osty: toolchain/llvmgen.osty:569:5
+func llvmEmitClosureEnvAllocRuntime(emitter *LlvmEmitter, captureCount int, siteName string, thunkSymbol string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:575:5
+	envTemp := llvmNextTemp(emitter)
+	_ = envTemp
+	// Osty: toolchain/llvmgen.osty:576:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call ptr @osty.rt.closure_env_alloc_v1(i64 %s, ptr %s)", ostyToString(envTemp), ostyToString(captureCount), ostyToString(siteName)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:579:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", ostyToString(thunkSymbol), ostyToString(envTemp)))
+		return struct{}{}
+	}()
+	return &LlvmValue{typ: "ptr", name: envTemp, pointer: false}
+}
+
+// Osty: toolchain/llvmgen.osty:587:5
+func llvmRenderSafepointEmpty(id int) string {
+	return fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %s, ptr null, i64 0)", ostyToString(id))
+}
+
+// Osty: toolchain/llvmgen.osty:594:5
+func llvmEmitSafepointEmpty(emitter *LlvmEmitter, id int) {
+	// Osty: toolchain/llvmgen.osty:595:5
+	func() struct{} { emitter.body = append(emitter.body, llvmRenderSafepointEmpty(id)); return struct{}{} }()
+}
+
+// Osty: toolchain/llvmgen.osty:604:5
+func llvmEmitSafepointWithRoots(emitter *LlvmEmitter, id int, rootAddresses []string) {
+	// Osty: toolchain/llvmgen.osty:609:5
 	count := len(rootAddresses)
+	_ = count
+	// Osty: toolchain/llvmgen.osty:610:5
 	slotsPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr, i64 %d", slotsPtr, count))
+	_ = slotsPtr
+	// Osty: toolchain/llvmgen.osty:611:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca ptr, i64 %s", ostyToString(slotsPtr), ostyToString(count)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:612:5
 	for i := 0; i < count; i++ {
+		// Osty: toolchain/llvmgen.osty:613:9
 		slotPtr := llvmNextTemp(emitter)
+		_ = slotPtr
+		// Osty: toolchain/llvmgen.osty:614:9
 		addr := rootAddresses[i]
-		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr ptr, ptr %s, i64 %d", slotPtr, slotsPtr, i))
-		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", addr, slotPtr))
+		_ = addr
+		// Osty: toolchain/llvmgen.osty:615:9
+		func() struct{} {
+			emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr ptr, ptr %s, i64 %s", ostyToString(slotPtr), ostyToString(slotsPtr), ostyToString(i)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:616:9
+		func() struct{} {
+			emitter.body = append(emitter.body, fmt.Sprintf("  store ptr %s, ptr %s", ostyToString(addr), ostyToString(slotPtr)))
+			return struct{}{}
+		}()
 	}
-	emitter.body = append(emitter.body, fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %d, ptr %s, i64 %d)", id, slotsPtr, count))
+	// Osty: toolchain/llvmgen.osty:618:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  call void @osty.gc.safepoint_v1(i64 %s, ptr %s, i64 %s)", ostyToString(id), ostyToString(slotsPtr), ostyToString(count)))
+		return struct{}{}
+	}()
 }
 
-// Osty: toolchain/llvmgen.osty:327:5
+// Osty: toolchain/llvmgen.osty:623:5
 func llvmStructTypeDef(name string, fieldTypes []string) string {
-	// Osty: toolchain/llvmgen.osty:328:5
+	// Osty: toolchain/llvmgen.osty:624:5
 	fields := llvmStrings.Join(fieldTypes, ", ")
 	_ = fields
 	return fmt.Sprintf("%%%s = type { %s }", ostyToString(name), ostyToString(fields))
 }
 
-// Osty: toolchain/llvmgen.osty:332:5
+// Osty: toolchain/llvmgen.osty:628:5
 func llvmStructLiteral(emitter *LlvmEmitter, typ string, fields []*LlvmValue) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:337:5
+	// Osty: toolchain/llvmgen.osty:633:5
 	current := "undef"
 	_ = current
-	// Osty: toolchain/llvmgen.osty:338:5
+	// Osty: toolchain/llvmgen.osty:634:5
 	fieldIndex := 0
 	_ = fieldIndex
-	// Osty: toolchain/llvmgen.osty:339:5
+	// Osty: toolchain/llvmgen.osty:635:5
 	for _, field := range fields {
-		// Osty: toolchain/llvmgen.osty:340:9
+		// Osty: toolchain/llvmgen.osty:636:9
 		tmp := llvmNextTemp(emitter)
 		_ = tmp
-		// Osty: toolchain/llvmgen.osty:341:9
+		// Osty: toolchain/llvmgen.osty:637:9
 		func() struct{} {
 			emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %s %s, %s %s, %s", ostyToString(tmp), ostyToString(typ), ostyToString(current), ostyToString(field.typ), ostyToString(field.name), ostyToString(fieldIndex)))
 			return struct{}{}
 		}()
-		// Osty: toolchain/llvmgen.osty:344:9
+		// Osty: toolchain/llvmgen.osty:640:9
 		current = tmp
-		// Osty: toolchain/llvmgen.osty:345:9
+		// Osty: toolchain/llvmgen.osty:641:9
 		func() {
-			var _cur1 int = fieldIndex
-			var _rhs2 int = 1
-			if _rhs2 > 0 && _cur1 > math.MaxInt-_rhs2 {
+			var _cur9 int = fieldIndex
+			var _rhs10 int = 1
+			if _rhs10 > 0 && _cur9 > math.MaxInt-_rhs10 {
 				panic("integer overflow")
 			}
-			if _rhs2 < 0 && _cur1 < math.MinInt-_rhs2 {
+			if _rhs10 < 0 && _cur9 < math.MinInt-_rhs10 {
 				panic("integer overflow")
 			}
-			fieldIndex = _cur1 + _rhs2
+			fieldIndex = _cur9 + _rhs10
 		}()
 	}
 	return &LlvmValue{typ: typ, name: current, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:350:5
+// Osty: toolchain/llvmgen.osty:646:5
 func llvmExtractValue(emitter *LlvmEmitter, aggregate *LlvmValue, fieldType string, fieldIndex int) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:356:5
+	// Osty: toolchain/llvmgen.osty:652:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:357:5
+	// Osty: toolchain/llvmgen.osty:653:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = extractvalue %s %s, %s", ostyToString(tmp), ostyToString(aggregate.typ), ostyToString(aggregate.name), ostyToString(fieldIndex)))
 		return struct{}{}
@@ -613,10 +775,12 @@ func llvmExtractValue(emitter *LlvmEmitter, aggregate *LlvmValue, fieldType stri
 	return &LlvmValue{typ: fieldType, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:363:5
+// Osty: toolchain/llvmgen.osty:657:5
 func llvmInsertValue(emitter *LlvmEmitter, aggregate *LlvmValue, field *LlvmValue, fieldIndex int) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:663:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
+	// Osty: toolchain/llvmgen.osty:664:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = insertvalue %s %s, %s %s, %s", ostyToString(tmp), ostyToString(aggregate.typ), ostyToString(aggregate.name), ostyToString(field.typ), ostyToString(field.name), ostyToString(fieldIndex)))
 		return struct{}{}
@@ -624,71 +788,71 @@ func llvmInsertValue(emitter *LlvmEmitter, aggregate *LlvmValue, field *LlvmValu
 	return &LlvmValue{typ: aggregate.typ, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:376:5
+// Osty: toolchain/llvmgen.osty:670:5
 func llvmPrintlnI64(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:364:5
+	// Osty: toolchain/llvmgen.osty:671:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:365:5
+	// Osty: toolchain/llvmgen.osty:672:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64 %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:368:5
+// Osty: toolchain/llvmgen.osty:675:5
 func llvmPrintlnF64(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:369:5
+	// Osty: toolchain/llvmgen.osty:676:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:370:5
+	// Osty: toolchain/llvmgen.osty:677:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_f64, double %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:372:5
+// Osty: toolchain/llvmgen.osty:680:5
 func llvmPrintlnBool(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:373:5
+	// Osty: toolchain/llvmgen.osty:681:5
 	text := llvmNextTemp(emitter)
 	_ = text
-	// Osty: toolchain/llvmgen.osty:374:5
+	// Osty: toolchain/llvmgen.osty:682:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = select i1 %s, ptr @.bool_true, ptr @.bool_false", ostyToString(text), ostyToString(value.name)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:375:5
+	// Osty: toolchain/llvmgen.osty:683:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:376:5
+	// Osty: toolchain/llvmgen.osty:684:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %s)", ostyToString(tmp), ostyToString(text)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:373:5
+// Osty: toolchain/llvmgen.osty:687:5
 func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:374:5
+	// Osty: toolchain/llvmgen.osty:688:5
 	name := fmt.Sprintf("@.str%s", ostyToString(emitter.stringId))
 	_ = name
-	// Osty: toolchain/llvmgen.osty:375:12
+	// Osty: toolchain/llvmgen.osty:689:12
 	emitter.stringId = func() int {
-		var _p3 int = emitter.stringId
-		var _rhs4 int = 1
-		if _rhs4 > 0 && _p3 > math.MaxInt-_rhs4 {
+		var _p11 int = emitter.stringId
+		var _rhs12 int = 1
+		if _rhs12 > 0 && _p11 > math.MaxInt-_rhs12 {
 			panic("integer overflow")
 		}
-		if _rhs4 < 0 && _p3 < math.MinInt-_rhs4 {
+		if _rhs12 < 0 && _p11 < math.MinInt-_rhs12 {
 			panic("integer overflow")
 		}
-		return _p3 + _rhs4
+		return _p11 + _rhs12
 	}()
-	// Osty: toolchain/llvmgen.osty:376:5
+	// Osty: toolchain/llvmgen.osty:690:5
 	cstring := llvmCString(text)
 	_ = cstring
-	// Osty: toolchain/llvmgen.osty:377:5
+	// Osty: toolchain/llvmgen.osty:691:5
 	func() struct{} {
 		emitter.stringGlobals = append(emitter.stringGlobals, &LlvmStringGlobal{name: name, encoded: cstring.encoded, byteLen: cstring.byteLen})
 		return struct{}{}
@@ -696,71 +860,117 @@ func llvmStringLiteral(emitter *LlvmEmitter, text string) *LlvmValue {
 	return &LlvmValue{typ: "ptr", name: name, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:383:5
-//
-// `byteLen` counts bytes (not runes) so LLVM IR globals sized as
-// `[N x i8]` stay correct for multi-byte UTF-8 text. The previous
-// `strings.Split(text, "")` path returned rune count, which was a
-// silent truncation for anything above U+007F.
+// Osty: toolchain/llvmgen.osty:697:5
 func llvmCString(text string) *LlvmCString {
+	// Osty: toolchain/llvmgen.osty:702:5
 	encoded := fmt.Sprintf("%s\\00", ostyToString(llvmCStringEscape(text)))
 	_ = encoded
-	byteLen := len(text) + 1
+	// Osty: toolchain/llvmgen.osty:703:5
+	byteLen := func() int {
+		var _p13 int = len([]byte(text))
+		var _rhs14 int = 1
+		if _rhs14 > 0 && _p13 > math.MaxInt-_rhs14 {
+			panic("integer overflow")
+		}
+		if _rhs14 < 0 && _p13 < math.MinInt-_rhs14 {
+			panic("integer overflow")
+		}
+		return _p13 + _rhs14
+	}()
 	_ = byteLen
 	return &LlvmCString{encoded: encoded, byteLen: byteLen}
 }
 
-// Osty: toolchain/llvmgen.osty:389:5
-//
-// Encodes `text` for an LLVM `c"..."` constant. Iterates over raw
-// bytes (not runes) so multi-byte UTF-8 code points emit one `\HH`
-// escape per byte — LLVM IR string globals are byte arrays, so that's
-// the right shape for downstream `getelementptr` + `printf`/runtime
-// helpers. Printable ASCII passes through verbatim; `"` and `\`
-// always escape; everything else (including 0x00–0x1F, 0x7F, and all
-// high bytes 0x80–0xFF) goes through `\HH`.
+// Osty: toolchain/llvmgen.osty:722:5
 func llvmCStringEscape(text string) string {
-	var b llvmStrings.Builder
-	b.Grow(len(text))
-	for i := 0; i < len(text); i++ {
-		c := text[i]
-		switch {
-		case c == '"':
-			b.WriteString(`\22`)
-		case c == '\\':
-			b.WriteString(`\5C`)
-		case c >= 0x20 && c <= 0x7E:
-			b.WriteByte(c)
-		default:
-			fmt.Fprintf(&b, `\%02X`, c)
-		}
+	// Osty: toolchain/llvmgen.osty:726:5
+	var parts []string = make([]string, 0, 1)
+	_ = parts
+	// Osty: toolchain/llvmgen.osty:727:5
+	for _, b := range []byte(text) {
+		// Osty: toolchain/llvmgen.osty:728:9
+		func() struct{} { parts = append(parts, "\\"); return struct{}{} }()
+		// Osty: toolchain/llvmgen.osty:729:9
+		func() struct{} { parts = append(parts, llvmHexByte(int(b))); return struct{}{} }()
 	}
-	return b.String()
+	return llvmStrings.Join(parts, "")
 }
 
-// Osty: toolchain/llvmgen.osty:409:5
+// Osty: toolchain/llvmgen.osty:734:1
+func llvmHexByte(n int) string {
+	// Osty: toolchain/llvmgen.osty:735:5
+	hi := func() int {
+		var _p15 int = (n / 16)
+		var _rhs16 int = 16
+		if _rhs16 == 0 {
+			panic("integer modulo by zero")
+		}
+		if _p15 == math.MinInt && _rhs16 == int(-1) {
+			panic("integer overflow")
+		}
+		return _p15 % _rhs16
+	}()
+	_ = hi
+	// Osty: toolchain/llvmgen.osty:736:5
+	lo := func() int {
+		var _p17 int = n
+		var _rhs18 int = 16
+		if _rhs18 == 0 {
+			panic("integer modulo by zero")
+		}
+		if _p17 == math.MinInt && _rhs18 == int(-1) {
+			panic("integer overflow")
+		}
+		return _p17 % _rhs18
+	}()
+	_ = lo
+	return fmt.Sprintf("%s%s", ostyToString(llvmHexDigit(hi)), ostyToString(llvmHexDigit(lo)))
+}
+
+// Osty: toolchain/llvmgen.osty:740:1
+func llvmHexDigit(n int) string {
+	return func() string {
+		if n < 10 {
+			return fmt.Sprintf("%s", ostyToString(n))
+		} else if n == 10 {
+			return "A"
+		} else if n == 11 {
+			return "B"
+		} else if n == 12 {
+			return "C"
+		} else if n == 13 {
+			return "D"
+		} else if n == 14 {
+			return "E"
+		} else {
+			return "F"
+		}
+	}()
+}
+
+// Osty: toolchain/llvmgen.osty:758:5
 func llvmPrintlnString(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:410:5
+	// Osty: toolchain/llvmgen.osty:759:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:411:5
+	// Osty: toolchain/llvmgen.osty:760:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr %s)", ostyToString(tmp), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:414:5
+// Osty: toolchain/llvmgen.osty:763:5
 func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: toolchain/llvmgen.osty:415:5
+	// Osty: toolchain/llvmgen.osty:764:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.then"), elseLabel: llvmNextLabel(emitter, "if.else"), endLabel: llvmNextLabel(emitter, "if.end")}
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:420:5
+	// Osty: toolchain/llvmgen.osty:769:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:421:5
+	// Osty: toolchain/llvmgen.osty:770:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -768,45 +978,45 @@ func llvmIfStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: toolchain/llvmgen.osty:425:5
+// Osty: toolchain/llvmgen.osty:774:5
 func llvmIfElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: toolchain/llvmgen.osty:426:5
+	// Osty: toolchain/llvmgen.osty:775:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:427:5
+	// Osty: toolchain/llvmgen.osty:776:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:430:5
+// Osty: toolchain/llvmgen.osty:779:5
 func llvmIfEnd(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: toolchain/llvmgen.osty:431:5
+	// Osty: toolchain/llvmgen.osty:780:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:432:5
+	// Osty: toolchain/llvmgen.osty:781:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:435:5
+// Osty: toolchain/llvmgen.osty:784:5
 func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
-	// Osty: toolchain/llvmgen.osty:436:5
+	// Osty: toolchain/llvmgen.osty:785:5
 	labels := &LlvmIfLabels{thenLabel: llvmNextLabel(emitter, "if.expr.then"), elseLabel: llvmNextLabel(emitter, "if.expr.else"), endLabel: llvmNextLabel(emitter, "if.expr.end")}
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:441:5
+	// Osty: toolchain/llvmgen.osty:790:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cond.name), ostyToString(labels.thenLabel), ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:442:5
+	// Osty: toolchain/llvmgen.osty:791:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.thenLabel)))
 		return struct{}{}
@@ -814,36 +1024,36 @@ func llvmIfExprStart(emitter *LlvmEmitter, cond *LlvmValue) *LlvmIfLabels {
 	return labels
 }
 
-// Osty: toolchain/llvmgen.osty:446:5
+// Osty: toolchain/llvmgen.osty:795:5
 func llvmIfExprElse(emitter *LlvmEmitter, labels *LlvmIfLabels) {
-	// Osty: toolchain/llvmgen.osty:447:5
+	// Osty: toolchain/llvmgen.osty:796:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:448:5
+	// Osty: toolchain/llvmgen.osty:797:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.elseLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:451:5
+// Osty: toolchain/llvmgen.osty:800:5
 func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseValue *LlvmValue, labels *LlvmIfLabels) *LlvmValue {
-	// Osty: toolchain/llvmgen.osty:458:5
+	// Osty: toolchain/llvmgen.osty:807:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:459:5
+	// Osty: toolchain/llvmgen.osty:808:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(labels.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:460:5
+	// Osty: toolchain/llvmgen.osty:809:5
 	tmp := llvmNextTemp(emitter)
 	_ = tmp
-	// Osty: toolchain/llvmgen.osty:461:5
+	// Osty: toolchain/llvmgen.osty:810:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]", ostyToString(tmp), ostyToString(typ), ostyToString(thenValue.name), ostyToString(labels.thenLabel), ostyToString(elseValue.name), ostyToString(labels.elseLabel)))
 		return struct{}{}
@@ -851,292 +1061,287 @@ func llvmIfExprEnd(emitter *LlvmEmitter, typ string, thenValue *LlvmValue, elseV
 	return &LlvmValue{typ: typ, name: tmp, pointer: false}
 }
 
-// Osty: toolchain/llvmgen.osty:467:5
+// Osty: toolchain/llvmgen.osty:816:5
 func llvmInclusiveRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue) *LlvmRangeLoop {
 	return llvmRangeStart(emitter, iterName, start, stop, true)
 }
 
-// Osty: toolchain/llvmgen.osty:476:5
+// Osty: toolchain/llvmgen.osty:825:5
 func llvmRangeStart(emitter *LlvmEmitter, iterName string, start *LlvmValue, stop *LlvmValue, inclusive bool) *LlvmRangeLoop {
-	// Osty: toolchain/llvmgen.osty:483:5
+	// Osty: toolchain/llvmgen.osty:832:5
 	iterPtr := llvmNextTemp(emitter)
 	_ = iterPtr
-	// Osty: toolchain/llvmgen.osty:484:5
+	// Osty: toolchain/llvmgen.osty:833:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca i64", ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:485:5
+	// Osty: toolchain/llvmgen.osty:834:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(start.name), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:487:5
+	// Osty: toolchain/llvmgen.osty:836:5
 	loop := &LlvmRangeLoop{condLabel: llvmNextLabel(emitter, "for.cond"), bodyLabel: llvmNextLabel(emitter, "for.body"), endLabel: llvmNextLabel(emitter, "for.end"), iterPtr: iterPtr, current: ""}
 	_ = loop
-	// Osty: toolchain/llvmgen.osty:494:5
+	// Osty: toolchain/llvmgen.osty:843:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:495:5
+	// Osty: toolchain/llvmgen.osty:844:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:497:5
+	// Osty: toolchain/llvmgen.osty:846:5
 	current := llvmNextTemp(emitter)
 	_ = current
-	// Osty: toolchain/llvmgen.osty:498:5
+	// Osty: toolchain/llvmgen.osty:847:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load i64, ptr %s", ostyToString(current), ostyToString(iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:499:5
+	// Osty: toolchain/llvmgen.osty:848:5
 	cmp := llvmNextTemp(emitter)
 	_ = cmp
-	// Osty: toolchain/llvmgen.osty:500:5
+	// Osty: toolchain/llvmgen.osty:849:5
 	pred := "slt"
 	_ = pred
-	// Osty: toolchain/llvmgen.osty:501:5
+	// Osty: toolchain/llvmgen.osty:850:5
 	if inclusive {
-		// Osty: toolchain/llvmgen.osty:502:9
+		// Osty: toolchain/llvmgen.osty:851:9
 		pred = "sle"
 	}
-	// Osty: toolchain/llvmgen.osty:504:5
+	// Osty: toolchain/llvmgen.osty:853:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = icmp %s i64 %s, %s", ostyToString(cmp), ostyToString(pred), ostyToString(current), ostyToString(stop.name)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:505:5
+	// Osty: toolchain/llvmgen.osty:854:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", ostyToString(cmp), ostyToString(loop.bodyLabel), ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:506:5
+	// Osty: toolchain/llvmgen.osty:855:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.bodyLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:507:5
+	// Osty: toolchain/llvmgen.osty:856:5
 	llvmBind(emitter, iterName, llvmI64(current))
 	return &LlvmRangeLoop{condLabel: loop.condLabel, bodyLabel: loop.bodyLabel, endLabel: loop.endLabel, iterPtr: loop.iterPtr, current: current}
 }
 
-// Osty: toolchain/llvmgen.osty:518:5
+// Osty: toolchain/llvmgen.osty:867:5
 func llvmRangeEnd(emitter *LlvmEmitter, loop *LlvmRangeLoop) {
-	// Osty: toolchain/llvmgen.osty:519:5
+	// Osty: toolchain/llvmgen.osty:868:5
 	next := llvmNextTemp(emitter)
 	_ = next
-	// Osty: toolchain/llvmgen.osty:520:5
+	// Osty: toolchain/llvmgen.osty:869:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  %s = add i64 %s, 1", ostyToString(next), ostyToString(loop.current)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:521:5
+	// Osty: toolchain/llvmgen.osty:870:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  store i64 %s, ptr %s", ostyToString(next), ostyToString(loop.iterPtr)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:522:5
+	// Osty: toolchain/llvmgen.osty:871:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", ostyToString(loop.condLabel)))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:523:5
+	// Osty: toolchain/llvmgen.osty:872:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("%s:", ostyToString(loop.endLabel)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:526:5
+// Osty: toolchain/llvmgen.osty:875:5
 func llvmReturn(emitter *LlvmEmitter, value *LlvmValue) {
-	// Osty: toolchain/llvmgen.osty:527:5
+	// Osty: toolchain/llvmgen.osty:876:5
 	func() struct{} {
 		emitter.body = append(emitter.body, fmt.Sprintf("  ret %s %s", ostyToString(value.typ), ostyToString(value.name)))
 		return struct{}{}
 	}()
 }
 
-// Osty: toolchain/llvmgen.osty:530:5
+// Osty: toolchain/llvmgen.osty:879:5
 func llvmReturnI32Zero(emitter *LlvmEmitter) {
-	// Osty: toolchain/llvmgen.osty:531:5
+	// Osty: toolchain/llvmgen.osty:880:5
 	func() struct{} { emitter.body = append(emitter.body, "  ret i32 0"); return struct{}{} }()
 }
 
-// Osty: toolchain/llvmgen.osty:534:5
+// Osty: toolchain/llvmgen.osty:883:5
 func llvmRenderModule(sourcePath string, target string, definitions []string) string {
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, make([]string, 0, 1), make([]*LlvmStringGlobal, 0, 1), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:538:5
+// Osty: toolchain/llvmgen.osty:887:5
 func llvmRenderModuleWithGlobals(sourcePath string, target string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, target, make([]string, 0, 1), stringGlobals, definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:547:5
+// Osty: toolchain/llvmgen.osty:896:5
 func llvmRenderModuleWithGlobalsAndTypes(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, make([]string, 0, 1), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:564:5
+// Osty: toolchain/llvmgen.osty:913:5
 func llvmRenderModuleWithGcRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmGcRuntimeDeclarations(), definitions)
 }
 
+// Osty: toolchain/llvmgen.osty:930:5
 func llvmRenderModuleWithListRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmListRuntimeDeclarations(), definitions)
 }
 
+// Osty: toolchain/llvmgen.osty:947:5
 func llvmRenderModuleWithMapRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmMapRuntimeDeclarations(), definitions)
 }
 
+// Osty: toolchain/llvmgen.osty:964:5
 func llvmRenderModuleWithSetRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmSetRuntimeDeclarations(), definitions)
 }
 
-func llvmRenderModuleWithStringRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
-	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmStringRuntimeDeclarations(), definitions)
-}
-
+// Osty: toolchain/llvmgen.osty:981:5
 func llvmRenderModuleWithChannelRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
 	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmChanRuntimeDeclarations(), definitions)
 }
 
-// Osty: toolchain/llvmgen.osty:581:1
+// Osty: toolchain/llvmgen.osty:998:5
+func llvmRenderModuleWithStringRuntime(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, definitions []string) string {
+	return llvmRenderModuleWithRuntimeDeclarations(sourcePath, target, typeDefs, stringGlobals, llvmStringRuntimeDeclarations(), definitions)
+}
+
+// Osty: toolchain/llvmgen.osty:1015:1
 func llvmRenderModuleWithRuntimeDeclarations(sourcePath string, target string, typeDefs []string, stringGlobals []*LlvmStringGlobal, runtimeDeclarations []string, definitions []string) string {
-	// Osty: toolchain/llvmgen.osty:589:5
+	// Osty: toolchain/llvmgen.osty:1023:5
 	lines := []string{"; Code generated by osty LLVM backend. DO NOT EDIT.", fmt.Sprintf("; Osty: %s", ostyToString(sourcePath)), llvmStrings.Join([]string{"source_filename = \"", sourcePath, "\""}, "")}
 	_ = lines
-	// Osty: toolchain/llvmgen.osty:594:5
+	// Osty: toolchain/llvmgen.osty:1028:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:595:9
+		// Osty: toolchain/llvmgen.osty:1029:9
 		func() struct{} {
 			lines = append(lines, llvmStrings.Join([]string{"target triple = \"", target, "\""}, ""))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:597:5
+	// Osty: toolchain/llvmgen.osty:1031:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:598:5
+	// Osty: toolchain/llvmgen.osty:1032:5
 	for _, typeDef := range typeDefs {
-		// Osty: toolchain/llvmgen.osty:599:9
+		// Osty: toolchain/llvmgen.osty:1033:9
 		func() struct{} { lines = append(lines, typeDef); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:601:5
+	// Osty: toolchain/llvmgen.osty:1035:5
 	if len(typeDefs) > 0 {
-		// Osty: toolchain/llvmgen.osty:602:9
+		// Osty: toolchain/llvmgen.osty:1036:9
 		func() struct{} { lines = append(lines, ""); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:604:5
+	// Osty: toolchain/llvmgen.osty:1038:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_i64 = private unnamed_addr constant [5 x i8] c\"%ld\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:605:5
+	// Osty: toolchain/llvmgen.osty:1039:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_f64 = private unnamed_addr constant [6 x i8] c\"%.6f\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:606:5
+	// Osty: toolchain/llvmgen.osty:1040:5
 	func() struct{} {
 		lines = append(lines, "@.fmt_str = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"")
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:607:5
-	func() struct{} {
-		lines = append(lines, "@.bool_true = private unnamed_addr constant [5 x i8] c\"true\\00\"")
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:608:5
-	func() struct{} {
-		lines = append(lines, "@.bool_false = private unnamed_addr constant [6 x i8] c\"false\\00\"")
-		return struct{}{}
-	}()
-	// Osty: toolchain/llvmgen.osty:607:5
+	// Osty: toolchain/llvmgen.osty:1041:5
 	for _, global := range stringGlobals {
-		// Osty: toolchain/llvmgen.osty:608:9
+		// Osty: toolchain/llvmgen.osty:1042:9
 		func() struct{} {
 			lines = append(lines, llvmStrings.Join([]string{global.name, " = private unnamed_addr constant [", fmt.Sprintf("%s", ostyToString(global.byteLen)), " x i8] c\"", global.encoded, "\""}, ""))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:622:5
+	// Osty: toolchain/llvmgen.osty:1056:5
 	func() struct{} { lines = append(lines, "declare i32 @printf(ptr, ...)"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:623:5
+	// Osty: toolchain/llvmgen.osty:1057:5
 	for _, runtimeDeclaration := range runtimeDeclarations {
-		// Osty: toolchain/llvmgen.osty:624:9
+		// Osty: toolchain/llvmgen.osty:1058:9
 		func() struct{} { lines = append(lines, runtimeDeclaration); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:626:5
+	// Osty: toolchain/llvmgen.osty:1060:5
 	firstDefinition := true
 	_ = firstDefinition
-	// Osty: toolchain/llvmgen.osty:627:5
+	// Osty: toolchain/llvmgen.osty:1061:5
 	for _, definition := range definitions {
-		// Osty: toolchain/llvmgen.osty:628:9
+		// Osty: toolchain/llvmgen.osty:1062:9
 		if firstDefinition {
-			// Osty: toolchain/llvmgen.osty:629:13
+			// Osty: toolchain/llvmgen.osty:1063:13
 			func() struct{} { lines = append(lines, ""); return struct{}{} }()
-			// Osty: toolchain/llvmgen.osty:630:13
+			// Osty: toolchain/llvmgen.osty:1064:13
 			firstDefinition = false
 		}
-		// Osty: toolchain/llvmgen.osty:632:9
+		// Osty: toolchain/llvmgen.osty:1066:9
 		func() struct{} { lines = append(lines, definition); return struct{}{} }()
 	}
 	return llvmStrings.Join(lines, "\n")
 }
 
-// Osty: toolchain/llvmgen.osty:637:5
+// Osty: toolchain/llvmgen.osty:1071:5
 func llvmRenderSkeleton(packageName string, sourcePath string, emit string, target string, unsupported string) string {
-	// Osty: toolchain/llvmgen.osty:644:5
+	// Osty: toolchain/llvmgen.osty:1078:5
 	pkg := packageName
 	_ = pkg
-	// Osty: toolchain/llvmgen.osty:645:5
+	// Osty: toolchain/llvmgen.osty:1079:5
 	if pkg == "" {
-		// Osty: toolchain/llvmgen.osty:646:9
+		// Osty: toolchain/llvmgen.osty:1080:9
 		pkg = "main"
 	}
-	// Osty: toolchain/llvmgen.osty:648:5
+	// Osty: toolchain/llvmgen.osty:1082:5
 	source := sourcePath
 	_ = source
-	// Osty: toolchain/llvmgen.osty:649:5
+	// Osty: toolchain/llvmgen.osty:1083:5
 	if source == "" {
-		// Osty: toolchain/llvmgen.osty:650:9
+		// Osty: toolchain/llvmgen.osty:1084:9
 		source = "<unknown>"
 	}
-	// Osty: toolchain/llvmgen.osty:653:5
+	// Osty: toolchain/llvmgen.osty:1087:5
 	lines := []string{"; Osty LLVM backend skeleton", fmt.Sprintf("; package: %s", ostyToString(pkg)), fmt.Sprintf("; source: %s", ostyToString(source)), fmt.Sprintf("; emit: %s", ostyToString(emit))}
 	_ = lines
-	// Osty: toolchain/llvmgen.osty:659:5
+	// Osty: toolchain/llvmgen.osty:1093:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:660:9
+		// Osty: toolchain/llvmgen.osty:1094:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; target: %s", ostyToString(target)))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:662:5
+	// Osty: toolchain/llvmgen.osty:1096:5
 	if unsupported != "" {
-		// Osty: toolchain/llvmgen.osty:663:9
+		// Osty: toolchain/llvmgen.osty:1097:9
 		func() struct{} {
 			lines = append(lines, fmt.Sprintf("; unsupported: %s", ostyToString(unsupported)))
 			return struct{}{}
 		}()
 	}
-	// Osty: toolchain/llvmgen.osty:665:5
+	// Osty: toolchain/llvmgen.osty:1099:5
 	func() struct{} { lines = append(lines, "; code generation is not implemented yet"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:666:5
+	// Osty: toolchain/llvmgen.osty:1100:5
 	func() struct{} { lines = append(lines, ""); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:667:5
+	// Osty: toolchain/llvmgen.osty:1101:5
 	func() struct{} {
 		lines = append(lines, llvmStrings.Join([]string{"source_filename = \"", source, "\""}, ""))
 		return struct{}{}
 	}()
-	// Osty: toolchain/llvmgen.osty:668:5
+	// Osty: toolchain/llvmgen.osty:1102:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:669:9
+		// Osty: toolchain/llvmgen.osty:1103:9
 		func() struct{} {
 			lines = append(lines, llvmStrings.Join([]string{"target triple = \"", target, "\""}, ""))
 			return struct{}{}
@@ -1145,3449 +1350,4195 @@ func llvmRenderSkeleton(packageName string, sourcePath string, emit string, targ
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: toolchain/llvmgen.osty:674:5
+// Osty: toolchain/llvmgen.osty:1108:5
 func llvmRenderFunction(ret string, name string, params []*LlvmParam, body []string) string {
-	// Osty: toolchain/llvmgen.osty:680:5
+	// Osty: toolchain/llvmgen.osty:1114:5
 	lines := []string{fmt.Sprintf("define %s @%s(%s) {", ostyToString(ret), ostyToString(name), ostyToString(llvmParams(params))), "entry:"}
 	_ = lines
-	// Osty: toolchain/llvmgen.osty:681:5
+	// Osty: toolchain/llvmgen.osty:1115:5
 	for _, line := range body {
-		// Osty: toolchain/llvmgen.osty:682:9
+		// Osty: toolchain/llvmgen.osty:1116:9
 		func() struct{} { lines = append(lines, line); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:684:5
+	// Osty: toolchain/llvmgen.osty:1118:5
 	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
 	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
 }
 
-// Osty: toolchain/llvmgen.osty:740:5
+// Osty: toolchain/llvmgen.osty:1134:5
+func llvmRenderClosureThunk(retType string, thunkSymbol string, paramTypes []string, realSymbol string) string {
+	// Osty: toolchain/llvmgen.osty:1140:5
+	ret := func() string {
+		if retType == "" {
+			return "void"
+		} else {
+			return retType
+		}
+	}()
+	_ = ret
+	// Osty: toolchain/llvmgen.osty:1141:5
+	var paramParts []string = []string{"ptr %env"}
+	_ = paramParts
+	// Osty: toolchain/llvmgen.osty:1142:5
+	var argParts []string = make([]string, 0, 1)
+	_ = argParts
+	// Osty: toolchain/llvmgen.osty:1143:5
+	for i := 0; i < len(paramTypes); i++ {
+		// Osty: toolchain/llvmgen.osty:1144:9
+		pt := paramTypes[i]
+		_ = pt
+		// Osty: toolchain/llvmgen.osty:1145:9
+		func() struct{} {
+			paramParts = append(paramParts, fmt.Sprintf("%s %%arg%s", ostyToString(pt), ostyToString(i)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:1146:9
+		func() struct{} {
+			argParts = append(argParts, fmt.Sprintf("%s %%arg%s", ostyToString(pt), ostyToString(i)))
+			return struct{}{}
+		}()
+	}
+	// Osty: toolchain/llvmgen.osty:1148:5
+	params := llvmStrings.Join(paramParts, ", ")
+	_ = params
+	// Osty: toolchain/llvmgen.osty:1149:5
+	args := llvmStrings.Join(argParts, ", ")
+	_ = args
+	// Osty: toolchain/llvmgen.osty:1150:5
+	var lines []string = make([]string, 0, 1)
+	_ = lines
+	// Osty: toolchain/llvmgen.osty:1151:5
+	func() struct{} {
+		lines = append(lines, fmt.Sprintf("define private %s @%s(%s) {", ostyToString(ret), ostyToString(thunkSymbol), ostyToString(params)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:1152:5
+	func() struct{} { lines = append(lines, "entry:"); return struct{}{} }()
+	// Osty: toolchain/llvmgen.osty:1153:5
+	if ret == "void" {
+		// Osty: toolchain/llvmgen.osty:1154:9
+		func() struct{} {
+			lines = append(lines, fmt.Sprintf("  call void @%s(%s)", ostyToString(realSymbol), ostyToString(args)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:1155:9
+		func() struct{} { lines = append(lines, "  ret void"); return struct{}{} }()
+	} else {
+		// Osty: toolchain/llvmgen.osty:1157:9
+		func() struct{} {
+			lines = append(lines, fmt.Sprintf("  %%__ret = call %s @%s(%s)", ostyToString(ret), ostyToString(realSymbol), ostyToString(args)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:1158:9
+		func() struct{} {
+			lines = append(lines, fmt.Sprintf("  ret %s %%__ret", ostyToString(ret)))
+			return struct{}{}
+		}()
+	}
+	// Osty: toolchain/llvmgen.osty:1160:5
+	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
+	return llvmStrings.Join([]string{llvmStrings.Join(lines, "\n"), "\n"}, "")
+}
+
+// Osty: toolchain/llvmgen.osty:1163:5
 func llvmNeedsObjectArtifact(emit string) bool {
 	return emit == "object" || emit == "binary"
 }
 
-// Osty: toolchain/llvmgen.osty:692:5
+// Osty: toolchain/llvmgen.osty:1167:5
 func llvmNeedsBinaryArtifact(emit string) bool {
 	return emit == "binary"
 }
 
-// Osty: toolchain/llvmgen.osty:696:5
+// Osty: toolchain/llvmgen.osty:1171:5
 func llvmClangCompileObjectArgs(target string, irPath string, objectPath string) []string {
-	// Osty: toolchain/llvmgen.osty:701:5
+	// Osty: toolchain/llvmgen.osty:1176:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: toolchain/llvmgen.osty:702:5
+	// Osty: toolchain/llvmgen.osty:1177:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:703:9
+		// Osty: toolchain/llvmgen.osty:1178:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:704:9
+		// Osty: toolchain/llvmgen.osty:1179:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:706:5
+	// Osty: toolchain/llvmgen.osty:1181:5
 	func() struct{} { args = append(args, "-c"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:707:5
+	// Osty: toolchain/llvmgen.osty:1182:5
 	func() struct{} { args = append(args, irPath); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:708:5
+	// Osty: toolchain/llvmgen.osty:1183:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:709:5
+	// Osty: toolchain/llvmgen.osty:1184:5
 	func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	return args
 }
 
-// Osty: toolchain/llvmgen.osty:713:5
+// Osty: toolchain/llvmgen.osty:1188:5
 func llvmClangLinkBinaryArgs(target string, objectPaths []string, binaryPath string) []string {
-	// Osty: toolchain/llvmgen.osty:718:5
+	// Osty: toolchain/llvmgen.osty:1193:5
 	var args []string = make([]string, 0, 1)
 	_ = args
-	// Osty: toolchain/llvmgen.osty:719:5
+	// Osty: toolchain/llvmgen.osty:1194:5
 	if target != "" {
-		// Osty: toolchain/llvmgen.osty:720:9
+		// Osty: toolchain/llvmgen.osty:1195:9
 		func() struct{} { args = append(args, "-target"); return struct{}{} }()
-		// Osty: toolchain/llvmgen.osty:721:9
+		// Osty: toolchain/llvmgen.osty:1196:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:723:5
+	// Osty: toolchain/llvmgen.osty:1198:5
 	for _, objectPath := range objectPaths {
-		// Osty: toolchain/llvmgen.osty:724:9
+		// Osty: toolchain/llvmgen.osty:1199:9
 		func() struct{} { args = append(args, objectPath); return struct{}{} }()
 	}
-	// `-pthread` pulls libpthread / libSystem threading symbols, needed
-	// by the bundled runtime's POSIX task / channel implementations.
-	// Windows targets use Win32 primitives from kernel32 (default-linked)
-	// and must NOT be passed -pthread (clang-msvc rejects the flag).
+	// Osty: toolchain/llvmgen.osty:1205:5
 	if !llvmStrings.Contains(target, "windows") {
+		// Osty: toolchain/llvmgen.osty:1206:9
 		func() struct{} { args = append(args, "-pthread"); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:726:5
+	// Osty: toolchain/llvmgen.osty:1208:5
 	func() struct{} { args = append(args, "-o"); return struct{}{} }()
-	// Osty: toolchain/llvmgen.osty:727:5
+	// Osty: toolchain/llvmgen.osty:1209:5
 	func() struct{} { args = append(args, binaryPath); return struct{}{} }()
 	return args
 }
 
-// Osty: toolchain/llvmgen.osty:731:5
+// Osty: toolchain/llvmgen.osty:1213:5
 func llvmMissingClangMessage() string {
 	return "llvm backend: clang not found on PATH; install clang or use --emit=llvm-ir"
 }
 
-// Osty: toolchain/llvmgen.osty:735:5
+// Osty: toolchain/llvmgen.osty:1217:5
 func llvmMissingBinaryArtifactMessage() string {
 	return "llvm backend: missing binary artifact path"
 }
 
-// Osty: toolchain/llvmgen.osty:739:5
+// Osty: toolchain/llvmgen.osty:1221:5
 func llvmClangFailureMessage(action string, command string, output string) string {
 	return llvmStrings.Join([]string{"llvm backend: clang ", action, " failed\ncommand: ", command, "\n", output}, "")
 }
 
-// Osty: toolchain/llvmgen.osty:746:5
+// Osty: toolchain/llvmgen.osty:1235:5
 func llvmUnsupportedBackendErrorMessage() string {
 	return "llvm backend: code generation is not implemented yet"
 }
 
-// Osty: toolchain/llvmgen.osty:750:5
+// Osty: toolchain/llvmgen.osty:1239:5
 func llvmUnsupportedDiagnostic(kind string, detail string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:751:5
+	// Osty: toolchain/llvmgen.osty:1240:5
 	if kind == "go-ffi" {
-		// Osty: toolchain/llvmgen.osty:752:9
+		// Osty: toolchain/llvmgen.osty:1241:9
 		target := detail
 		_ = target
-		// Osty: toolchain/llvmgen.osty:753:9
+		// Osty: toolchain/llvmgen.osty:1242:9
 		if target == "" {
-			// Osty: toolchain/llvmgen.osty:754:13
+			// Osty: toolchain/llvmgen.osty:1243:13
 			target = "<unknown>"
 		}
-		// Osty: toolchain/llvmgen.osty:756:9
+		// Osty: toolchain/llvmgen.osty:1245:9
 		return &LlvmUnsupportedDiagnostic{code: "LLVM001", kind: "foreign-ffi", message: fmt.Sprintf("Go FFI import %s is not supported by the self-hosted native backend", ostyToString(target)), hint: "rewrite the binding as `use runtime.cabi.<lib>` with an item block for extern C symbols, or `use runtime.<surface>` with an item block for an osty_rt_* runtime ABI helper (LANG_SPEC_v0.5 §12.8)"}
 	}
-	// Osty: toolchain/llvmgen.osty:763:5
+	// Osty: toolchain/llvmgen.osty:1252:5
 	if kind == "runtime-ffi" {
-		// Osty: toolchain/llvmgen.osty:764:9
+		// Osty: toolchain/llvmgen.osty:1253:9
 		target := detail
 		_ = target
-		// Osty: toolchain/llvmgen.osty:765:9
+		// Osty: toolchain/llvmgen.osty:1254:9
 		if target == "" {
-			// Osty: toolchain/llvmgen.osty:766:13
+			// Osty: toolchain/llvmgen.osty:1255:13
 			target = "<unknown>"
 		}
-		// Osty: toolchain/llvmgen.osty:768:9
+		// Osty: toolchain/llvmgen.osty:1257:9
 		return &LlvmUnsupportedDiagnostic{code: "LLVM002", kind: "runtime-ffi", message: fmt.Sprintf("Osty runtime FFI import %s needs native runtime lowering", ostyToString(target)), hint: "add the runtime ABI shim and lowering before compiling this source natively"}
 	}
-	// Osty: toolchain/llvmgen.osty:776:5
+	// Osty: toolchain/llvmgen.osty:1265:5
 	if kind == "source-layout" {
-		// Osty: toolchain/llvmgen.osty:777:9
+		// Osty: toolchain/llvmgen.osty:1266:9
 		return llvmUnsupportedDiagnosticWith("LLVM010", kind, detail, "reshape the file around the current LLVM subset: script statements or a simple main function")
 	}
-	// Osty: toolchain/llvmgen.osty:784:5
+	// Osty: toolchain/llvmgen.osty:1273:5
 	if kind == "type-system" {
-		// Osty: toolchain/llvmgen.osty:785:9
+		// Osty: toolchain/llvmgen.osty:1274:9
 		return llvmUnsupportedDiagnosticWith("LLVM011", kind, detail, "use Int or Bool values until the LLVM runtime type surface grows")
 	}
-	// Osty: toolchain/llvmgen.osty:792:5
+	// Osty: toolchain/llvmgen.osty:1281:5
 	if kind == "statement" {
-		// Osty: toolchain/llvmgen.osty:793:9
+		// Osty: toolchain/llvmgen.osty:1282:9
 		return llvmUnsupportedDiagnosticWith("LLVM012", kind, detail, "reduce the statement to let, assignment, if, range-for, return, or println")
 	}
-	// Osty: toolchain/llvmgen.osty:800:5
+	// Osty: toolchain/llvmgen.osty:1289:5
 	if kind == "expression" {
-		// Osty: toolchain/llvmgen.osty:801:9
+		// Osty: toolchain/llvmgen.osty:1290:9
 		return llvmUnsupportedDiagnosticWith("LLVM013", kind, detail, "reduce the expression to Int, Bool, arithmetic, comparison, call, or value-if forms")
 	}
-	// Osty: toolchain/llvmgen.osty:808:5
+	// Osty: toolchain/llvmgen.osty:1297:5
 	if kind == "control-flow" {
-		// Osty: toolchain/llvmgen.osty:809:9
+		// Osty: toolchain/llvmgen.osty:1298:9
 		return llvmUnsupportedDiagnosticWith("LLVM014", kind, detail, "use plain if/else or closed Int range loops for the current LLVM backend")
 	}
-	// Osty: toolchain/llvmgen.osty:816:5
+	// Osty: toolchain/llvmgen.osty:1305:5
 	if kind == "call" {
-		// Osty: toolchain/llvmgen.osty:817:9
+		// Osty: toolchain/llvmgen.osty:1306:9
 		return llvmUnsupportedDiagnosticWith("LLVM015", kind, detail, "call an Osty function with positional Int/Bool arguments or use println as a statement")
 	}
-	// Osty: toolchain/llvmgen.osty:824:5
+	// Osty: toolchain/llvmgen.osty:1313:5
 	if kind == "name" {
-		// Osty: toolchain/llvmgen.osty:825:9
+		// Osty: toolchain/llvmgen.osty:1314:9
 		return llvmUnsupportedDiagnosticWith("LLVM016", kind, detail, "use simple ASCII identifiers that the LLVM bridge can map directly")
 	}
-	// Osty: toolchain/llvmgen.osty:832:5
+	// Osty: toolchain/llvmgen.osty:1321:5
 	if kind == "function-signature" {
-		// Osty: toolchain/llvmgen.osty:833:9
+		// Osty: toolchain/llvmgen.osty:1322:9
 		return llvmUnsupportedDiagnosticWith("LLVM017", kind, detail, "use non-generic functions with identifier parameters and Int/Bool types")
 	}
-	// Osty: toolchain/llvmgen.osty:840:5
+	// Osty: toolchain/llvmgen.osty:1329:5
 	if kind == "stdlib-body" {
-		// Osty: toolchain/llvmgen.osty:841:9
+		// Osty: toolchain/llvmgen.osty:1330:9
 		return llvmUnsupportedDiagnosticWith("LLVM018", kind, detail, "call stdlib functions whose bodies the LLVM backend can currently lower, or add a runtime shim for this symbol")
 	}
-	// Osty: toolchain/llvmgen.osty:849:5
+	// Osty: toolchain/llvmgen.osty:1338:5
 	reason := detail
 	_ = reason
-	// Osty: toolchain/llvmgen.osty:842:5
+	// Osty: toolchain/llvmgen.osty:1339:5
 	if reason == "" {
-		// Osty: toolchain/llvmgen.osty:843:9
+		// Osty: toolchain/llvmgen.osty:1340:9
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: "LLVM000", kind: "unsupported-source", message: reason, hint: "reduce the program to the LLVM smoke subset while the self-hosted native backend grows"}
 }
 
-// Osty: toolchain/llvmgen.osty:853:5
+// Osty: toolchain/llvmgen.osty:1350:5
 func llvmUnsupportedDiagnosticWith(code string, kind string, detail string, hint string) *LlvmUnsupportedDiagnostic {
-	// Osty: toolchain/llvmgen.osty:859:5
+	// Osty: toolchain/llvmgen.osty:1356:5
 	reason := detail
 	_ = reason
-	// Osty: toolchain/llvmgen.osty:860:5
+	// Osty: toolchain/llvmgen.osty:1357:5
 	if reason == "" {
-		// Osty: toolchain/llvmgen.osty:861:9
+		// Osty: toolchain/llvmgen.osty:1358:9
 		reason = "source shape is not supported by the current LLVM backend"
 	}
 	return &LlvmUnsupportedDiagnostic{code: code, kind: kind, message: reason, hint: hint}
 }
 
-// Osty: toolchain/llvmgen.osty:871:5
+// Osty: toolchain/llvmgen.osty:1368:5
 func llvmUnsupportedSummary(diag *LlvmUnsupportedDiagnostic) string {
 	return fmt.Sprintf("%s %s: %s; hint: %s", ostyToString(diag.code), ostyToString(diag.kind), ostyToString(diag.message), ostyToString(diag.hint))
 }
 
+// Osty: toolchain/llvmgen.osty:1372:5
 func llvmIsCompareOp(op string) bool {
 	return op == "==" || op == "!=" || op == "<" || op == ">" || op == "<=" || op == ">="
 }
 
+// Osty: toolchain/llvmgen.osty:1376:5
 func llvmIntComparePredicate(op string) string {
-	switch op {
-	case "==":
+	// Osty: toolchain/llvmgen.osty:1377:5
+	if op == "==" {
+		// Osty: toolchain/llvmgen.osty:1378:9
 		return "eq"
-	case "!=":
+	}
+	// Osty: toolchain/llvmgen.osty:1380:5
+	if op == "!=" {
+		// Osty: toolchain/llvmgen.osty:1381:9
 		return "ne"
-	case "<":
+	}
+	// Osty: toolchain/llvmgen.osty:1383:5
+	if op == "<" {
+		// Osty: toolchain/llvmgen.osty:1384:9
 		return "slt"
-	case ">":
+	}
+	// Osty: toolchain/llvmgen.osty:1386:5
+	if op == ">" {
+		// Osty: toolchain/llvmgen.osty:1387:9
 		return "sgt"
-	case "<=":
+	}
+	// Osty: toolchain/llvmgen.osty:1389:5
+	if op == "<=" {
+		// Osty: toolchain/llvmgen.osty:1390:9
 		return "sle"
-	case ">=":
+	}
+	// Osty: toolchain/llvmgen.osty:1392:5
+	if op == ">=" {
+		// Osty: toolchain/llvmgen.osty:1393:9
 		return "sge"
-	default:
-		return ""
 	}
+	return ""
 }
 
-// llvmUnsignedIntComparePredicate returns LLVM `icmp` predicates with
-// unsigned ordering for Char/Byte compares. Char codepoints fit in
-// non-negative i32 so signed would coincidentally work, but Byte values
-// 128..255 are negative under signed ordering which would break
-// `b'\x80' > b'\x00'`. Using unsigned predicates makes both surfaces
-// correct uniformly.
+// Osty: toolchain/llvmgen.osty:1402:5
 func llvmUnsignedIntComparePredicate(op string) string {
-	switch op {
-	case "==":
+	// Osty: toolchain/llvmgen.osty:1403:5
+	if op == "==" {
+		// Osty: toolchain/llvmgen.osty:1404:9
 		return "eq"
-	case "!=":
+	}
+	// Osty: toolchain/llvmgen.osty:1406:5
+	if op == "!=" {
+		// Osty: toolchain/llvmgen.osty:1407:9
 		return "ne"
-	case "<":
+	}
+	// Osty: toolchain/llvmgen.osty:1409:5
+	if op == "<" {
+		// Osty: toolchain/llvmgen.osty:1410:9
 		return "ult"
-	case ">":
+	}
+	// Osty: toolchain/llvmgen.osty:1412:5
+	if op == ">" {
+		// Osty: toolchain/llvmgen.osty:1413:9
 		return "ugt"
-	case "<=":
+	}
+	// Osty: toolchain/llvmgen.osty:1415:5
+	if op == "<=" {
+		// Osty: toolchain/llvmgen.osty:1416:9
 		return "ule"
-	case ">=":
+	}
+	// Osty: toolchain/llvmgen.osty:1418:5
+	if op == ">=" {
+		// Osty: toolchain/llvmgen.osty:1419:9
 		return "uge"
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:1424:5
 func llvmFloatComparePredicate(op string) string {
-	switch op {
-	case "==":
+	// Osty: toolchain/llvmgen.osty:1425:5
+	if op == "==" {
+		// Osty: toolchain/llvmgen.osty:1426:9
 		return "oeq"
-	case "!=":
+	}
+	// Osty: toolchain/llvmgen.osty:1428:5
+	if op == "!=" {
+		// Osty: toolchain/llvmgen.osty:1429:9
 		return "one"
-	case "<":
+	}
+	// Osty: toolchain/llvmgen.osty:1431:5
+	if op == "<" {
+		// Osty: toolchain/llvmgen.osty:1432:9
 		return "olt"
-	case ">":
+	}
+	// Osty: toolchain/llvmgen.osty:1434:5
+	if op == ">" {
+		// Osty: toolchain/llvmgen.osty:1435:9
 		return "ogt"
-	case "<=":
+	}
+	// Osty: toolchain/llvmgen.osty:1437:5
+	if op == "<=" {
+		// Osty: toolchain/llvmgen.osty:1438:9
 		return "ole"
-	case ">=":
+	}
+	// Osty: toolchain/llvmgen.osty:1440:5
+	if op == ">=" {
+		// Osty: toolchain/llvmgen.osty:1441:9
 		return "oge"
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:1446:5
 func llvmIntBinaryInstruction(op string) string {
-	switch op {
-	case "+":
+	// Osty: toolchain/llvmgen.osty:1447:5
+	if op == "+" {
+		// Osty: toolchain/llvmgen.osty:1448:9
 		return "add"
-	case "-":
+	}
+	// Osty: toolchain/llvmgen.osty:1450:5
+	if op == "-" {
+		// Osty: toolchain/llvmgen.osty:1451:9
 		return "sub"
-	case "*":
+	}
+	// Osty: toolchain/llvmgen.osty:1453:5
+	if op == "*" {
+		// Osty: toolchain/llvmgen.osty:1454:9
 		return "mul"
-	case "/":
+	}
+	// Osty: toolchain/llvmgen.osty:1456:5
+	if op == "/" {
+		// Osty: toolchain/llvmgen.osty:1457:9
 		return "sdiv"
-	case "%":
+	}
+	// Osty: toolchain/llvmgen.osty:1459:5
+	if op == "%" {
+		// Osty: toolchain/llvmgen.osty:1460:9
 		return "srem"
-	case "&":
+	}
+	// Osty: toolchain/llvmgen.osty:1462:5
+	if op == "&" {
+		// Osty: toolchain/llvmgen.osty:1463:9
 		return "and"
-	case "|":
+	}
+	// Osty: toolchain/llvmgen.osty:1465:5
+	if op == "|" {
+		// Osty: toolchain/llvmgen.osty:1466:9
 		return "or"
-	case "^":
+	}
+	// Osty: toolchain/llvmgen.osty:1468:5
+	if op == "^" {
+		// Osty: toolchain/llvmgen.osty:1469:9
 		return "xor"
-	case "<<":
+	}
+	// Osty: toolchain/llvmgen.osty:1471:5
+	if op == "<<" {
+		// Osty: toolchain/llvmgen.osty:1472:9
 		return "shl"
-	case ">>":
+	}
+	// Osty: toolchain/llvmgen.osty:1474:5
+	if op == ">>" {
+		// Osty: toolchain/llvmgen.osty:1475:9
 		return "ashr"
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:1480:5
 func llvmFloatBinaryInstruction(op string) string {
-	switch op {
-	case "+":
+	// Osty: toolchain/llvmgen.osty:1481:5
+	if op == "+" {
+		// Osty: toolchain/llvmgen.osty:1482:9
 		return "fadd"
-	case "-":
+	}
+	// Osty: toolchain/llvmgen.osty:1484:5
+	if op == "-" {
+		// Osty: toolchain/llvmgen.osty:1485:9
 		return "fsub"
-	case "*":
+	}
+	// Osty: toolchain/llvmgen.osty:1487:5
+	if op == "*" {
+		// Osty: toolchain/llvmgen.osty:1488:9
 		return "fmul"
-	case "/":
+	}
+	// Osty: toolchain/llvmgen.osty:1490:5
+	if op == "/" {
+		// Osty: toolchain/llvmgen.osty:1491:9
 		return "fdiv"
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:1496:5
 func llvmLogicalInstruction(op string) string {
-	switch op {
-	case "&&":
+	// Osty: toolchain/llvmgen.osty:1497:5
+	if op == "&&" {
+		// Osty: toolchain/llvmgen.osty:1498:9
 		return "and"
-	case "||":
-		return "or"
-	default:
-		return ""
 	}
+	// Osty: toolchain/llvmgen.osty:1500:5
+	if op == "||" {
+		// Osty: toolchain/llvmgen.osty:1501:9
+		return "or"
+	}
+	return ""
 }
 
-// llvmIsAsciiStringText gates which plain String literals the
-// LLVM backend accepts directly. Since `llvmCStringEscape` now
-// byte-escapes any non-printable / non-ASCII character via `\HH`,
-// the gate only needs to reject text that can't be encoded as a
-// byte sequence at all — i.e. nothing; every Go `string` is a
-// byte sequence. The legacy name is kept for call-site stability;
-// a future rename to `llvmCanEmitStringLiteral` or similar is a
-// pure-cleanup follow-up.
+// Osty: toolchain/llvmgen.osty:1515:5
 func llvmIsAsciiStringText(text string) bool {
+	// Osty: toolchain/llvmgen.osty:1516:5
 	_ = text
 	return true
 }
 
+// Osty: toolchain/llvmgen.osty:1520:5
 func llvmIsIdent(name string) bool {
+	// Osty: toolchain/llvmgen.osty:1521:5
 	if name == "" {
+		// Osty: toolchain/llvmgen.osty:1522:9
 		return false
 	}
-	for i, c := range name {
-		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') {
+	// Osty: toolchain/llvmgen.osty:1524:5
+	chars := []rune(name)
+	_ = chars
+	// Osty: toolchain/llvmgen.osty:1525:5
+	for i := 0; i < len(chars); i++ {
+		// Osty: toolchain/llvmgen.osty:1526:9
+		c := chars[i]
+		_ = c
+		// Osty: toolchain/llvmgen.osty:1527:9
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			// Osty: toolchain/llvmgen.osty:1528:13
 			continue
 		}
-		if i > 0 && '0' <= c && c <= '9' {
+		// Osty: toolchain/llvmgen.osty:1530:9
+		if i > 0 && c >= '0' && c <= '9' {
+			// Osty: toolchain/llvmgen.osty:1531:13
 			continue
 		}
+		// Osty: toolchain/llvmgen.osty:1533:9
 		return false
 	}
 	return true
 }
 
-func llvmFirstNonEmpty(a, b string) string {
+// Osty: toolchain/llvmgen.osty:1538:5
+func llvmFirstNonEmpty(a string, b string) string {
+	// Osty: toolchain/llvmgen.osty:1539:5
 	if a != "" {
+		// Osty: toolchain/llvmgen.osty:1540:9
 		return a
 	}
 	return b
 }
 
+// Osty: toolchain/llvmgen.osty:1545:5
 func llvmIsKnownRuntimeFfiPath(path string) bool {
+	// Osty: toolchain/llvmgen.osty:1546:5
 	if llvmStrings.HasPrefix(path, "runtime.package.") {
+		// Osty: toolchain/llvmgen.osty:1547:9
 		return true
 	}
+	// Osty: toolchain/llvmgen.osty:1549:5
 	if llvmStrings.HasPrefix(path, "runtime.cabi.") || path == "runtime.cabi" {
+		// Osty: toolchain/llvmgen.osty:1550:9
 		return true
 	}
 	return path == "runtime.strings" || path == "runtime.path.filepath"
 }
 
+// Osty: toolchain/llvmgen.osty:1555:5
 func llvmRuntimeFfiAlias(explicitAlias string, lastPath string, runtimePath string) string {
+	// Osty: toolchain/llvmgen.osty:1556:5
 	if explicitAlias != "" {
+		// Osty: toolchain/llvmgen.osty:1557:9
 		return explicitAlias
 	}
+	// Osty: toolchain/llvmgen.osty:1559:5
 	if lastPath != "" {
+		// Osty: toolchain/llvmgen.osty:1560:9
 		return lastPath
 	}
+	// Osty: toolchain/llvmgen.osty:1562:5
 	parts := llvmStrings.Split(runtimePath, ".")
+	_ = parts
+	// Osty: toolchain/llvmgen.osty:1563:5
 	if len(parts) == 0 {
+		// Osty: toolchain/llvmgen.osty:1564:9
 		return ""
 	}
-	return parts[len(parts)-1]
+	return parts[func() int {
+		var _p19 int = len(parts)
+		var _rhs20 int = 1
+		if _rhs20 < 0 && _p19 > math.MaxInt+_rhs20 {
+			panic("integer overflow")
+		}
+		if _rhs20 > 0 && _p19 < math.MinInt+_rhs20 {
+			panic("integer overflow")
+		}
+		return _p19 - _rhs20
+	}()]
 }
 
+// Osty: toolchain/llvmgen.osty:1569:5
 func llvmRuntimeFfiSymbol(path string, name string) string {
-	// `runtime.cabi[.libname]` paths bypass the `osty_rt_` runtime
-	// namespace and emit the function name as the literal extern C
-	// symbol. Callers link the providing library via their build
-	// system; the segment after `runtime.cabi.` is descriptive only.
+	// Osty: toolchain/llvmgen.osty:1575:5
 	if path == "runtime.cabi" || llvmStrings.HasPrefix(path, "runtime.cabi.") {
+		// Osty: toolchain/llvmgen.osty:1576:9
 		return name
 	}
+	// Osty: toolchain/llvmgen.osty:1578:5
 	trimmed := path
+	_ = trimmed
+	// Osty: toolchain/llvmgen.osty:1579:5
 	if llvmStrings.HasPrefix(trimmed, "runtime.") {
+		// Osty: toolchain/llvmgen.osty:1580:9
 		trimmed = llvmStrings.TrimPrefix(trimmed, "runtime.")
 	}
+	// Osty: toolchain/llvmgen.osty:1582:5
 	out := "osty_rt_"
-	for _, c := range trimmed {
+	_ = out
+	// Osty: toolchain/llvmgen.osty:1583:5
+	for _, c := range []rune(trimmed) {
+		// Osty: toolchain/llvmgen.osty:1584:9
 		if c == '.' || c == '/' || c == '-' {
-			out += "_"
+			// Osty: toolchain/llvmgen.osty:1585:13
+			out = fmt.Sprintf("%s_", ostyToString(out))
+			// Osty: toolchain/llvmgen.osty:1586:13
 			continue
 		}
-		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
-			out += string(c)
+		// Osty: toolchain/llvmgen.osty:1588:9
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			// Osty: toolchain/llvmgen.osty:1589:13
+			out = fmt.Sprintf("%s%s", ostyToString(out), string(c))
+			// Osty: toolchain/llvmgen.osty:1590:13
 			continue
 		}
-		out += "_"
+		// Osty: toolchain/llvmgen.osty:1592:9
+		out = fmt.Sprintf("%s_", ostyToString(out))
 	}
-	return out + "_" + name
+	return fmt.Sprintf("%s_%s", ostyToString(out), ostyToString(name))
 }
 
-// Osty: toolchain/llvmgen.osty:1092:1
+// Osty: toolchain/llvmgen.osty:1603:5
 func llvmListRuntimeNewSymbol() string {
 	return "osty_rt_list_new"
 }
 
-// Osty: toolchain/llvmgen.osty:1096:1
+// Osty: toolchain/llvmgen.osty:1607:5
 func llvmListRuntimeLenSymbol() string {
 	return "osty_rt_list_len"
 }
 
-// Osty: toolchain/llvmgen.osty:1100:1
+// Osty: toolchain/llvmgen.osty:1611:5
 func llvmListRuntimeSortedI64Symbol() string {
 	return "osty_rt_list_sorted_i64"
 }
 
-// Osty: toolchain/llvmgen.osty:1104:1
+// Osty: toolchain/llvmgen.osty:1615:5
 func llvmListRuntimeToSetI64Symbol() string {
 	return "osty_rt_list_to_set_i64"
 }
 
-// Osty: toolchain/llvmgen.osty (parametric push symbol builder)
+// Osty: toolchain/llvmgen.osty:1622:5
 func llvmListRuntimePushSymbol(suffix string) string {
-	return "osty_rt_list_push_" + suffix
+	return fmt.Sprintf("osty_rt_list_push_%s", ostyToString(suffix))
 }
 
+// Osty: toolchain/llvmgen.osty:1626:5
 func llvmListRuntimeGetSymbol(suffix string) string {
-	return "osty_rt_list_get_" + suffix
+	return fmt.Sprintf("osty_rt_list_get_%s", ostyToString(suffix))
 }
 
+// Osty: toolchain/llvmgen.osty:1630:5
 func llvmListRuntimeSetSymbol(suffix string) string {
-	return "osty_rt_list_set_" + suffix
+	return fmt.Sprintf("osty_rt_list_set_%s", ostyToString(suffix))
 }
 
+// Osty: toolchain/llvmgen.osty:1634:5
 func llvmListRuntimeInsertSymbol(suffix string) string {
-	return "osty_rt_list_insert_" + suffix
+	return fmt.Sprintf("osty_rt_list_insert_%s", ostyToString(suffix))
 }
 
+// Osty: toolchain/llvmgen.osty:1643:5
 func llvmListRuntimeSortedSymbol(elemTyp string, isString bool) string {
+	// Osty: toolchain/llvmgen.osty:1644:5
 	if isString {
+		// Osty: toolchain/llvmgen.osty:1645:9
 		return "osty_rt_list_sorted_string"
 	}
-	switch elemTyp {
-	case "i64":
+	// Osty: toolchain/llvmgen.osty:1647:5
+	if elemTyp == "i64" {
+		// Osty: toolchain/llvmgen.osty:1648:9
 		return "osty_rt_list_sorted_i64"
-	case "i1":
+	}
+	// Osty: toolchain/llvmgen.osty:1650:5
+	if elemTyp == "i1" {
+		// Osty: toolchain/llvmgen.osty:1651:9
 		return "osty_rt_list_sorted_i1"
-	case "double":
+	}
+	// Osty: toolchain/llvmgen.osty:1653:5
+	if elemTyp == "double" {
+		// Osty: toolchain/llvmgen.osty:1654:9
 		return "osty_rt_list_sorted_f64"
 	}
 	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:1663:5
 func llvmListRuntimeToSetSymbol(elemTyp string, isString bool) string {
+	// Osty: toolchain/llvmgen.osty:1664:5
 	if isString {
+		// Osty: toolchain/llvmgen.osty:1665:9
 		return "osty_rt_list_to_set_string"
 	}
-	switch elemTyp {
-	case "i64":
+	// Osty: toolchain/llvmgen.osty:1667:5
+	if elemTyp == "i64" {
+		// Osty: toolchain/llvmgen.osty:1668:9
 		return "osty_rt_list_to_set_i64"
-	case "i1":
+	}
+	// Osty: toolchain/llvmgen.osty:1670:5
+	if elemTyp == "i1" {
+		// Osty: toolchain/llvmgen.osty:1671:9
 		return "osty_rt_list_to_set_i1"
-	case "double":
+	}
+	// Osty: toolchain/llvmgen.osty:1673:5
+	if elemTyp == "double" {
+		// Osty: toolchain/llvmgen.osty:1674:9
 		return "osty_rt_list_to_set_f64"
-	case "ptr":
+	}
+	// Osty: toolchain/llvmgen.osty:1676:5
+	if elemTyp == "ptr" {
+		// Osty: toolchain/llvmgen.osty:1677:9
 		return "osty_rt_list_to_set_ptr"
 	}
 	return ""
 }
 
-// Osty: toolchain/llvmgen.osty:1108:1
+// Osty: toolchain/llvmgen.osty:1682:5
 func llvmMapRuntimeNewSymbol() string {
 	return "osty_rt_map_new"
 }
 
-// Osty: toolchain/llvmgen.osty:1112:1
+// Osty: toolchain/llvmgen.osty:1686:5
 func llvmMapRuntimeKeysSymbol() string {
 	return "osty_rt_map_keys"
 }
 
+// Osty: toolchain/llvmgen.osty:1690:5
 func llvmMapRuntimeLenSymbol() string {
 	return "osty_rt_map_len"
 }
 
+// Osty: toolchain/llvmgen.osty:1698:5
 func llvmMapKeySuffix(typ string, isString bool) string {
+	// Osty: toolchain/llvmgen.osty:1699:5
 	if isString {
+		// Osty: toolchain/llvmgen.osty:1700:9
 		return "string"
 	}
-	switch typ {
-	case "i64":
+	// Osty: toolchain/llvmgen.osty:1702:5
+	if typ == "i64" {
+		// Osty: toolchain/llvmgen.osty:1703:9
 		return "i64"
-	case "i1":
+	}
+	// Osty: toolchain/llvmgen.osty:1705:5
+	if typ == "i1" {
+		// Osty: toolchain/llvmgen.osty:1706:9
 		return "i1"
-	case "double":
+	}
+	// Osty: toolchain/llvmgen.osty:1708:5
+	if typ == "double" {
+		// Osty: toolchain/llvmgen.osty:1709:9
 		return "f64"
-	case "ptr":
+	}
+	// Osty: toolchain/llvmgen.osty:1711:5
+	if typ == "ptr" {
+		// Osty: toolchain/llvmgen.osty:1712:9
 		return "ptr"
 	}
 	return "bytes"
 }
 
+// Osty: toolchain/llvmgen.osty:1717:5
 func llvmMapRuntimeContainsSymbol(keyTyp string, isString bool) string {
-	return "osty_rt_map_contains_" + llvmMapKeySuffix(keyTyp, isString)
+	return fmt.Sprintf("osty_rt_map_contains_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
 }
 
+// Osty: toolchain/llvmgen.osty:1721:5
 func llvmMapRuntimeInsertSymbol(keyTyp string, isString bool) string {
-	return "osty_rt_map_insert_" + llvmMapKeySuffix(keyTyp, isString)
+	return fmt.Sprintf("osty_rt_map_insert_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
 }
 
+// Osty: toolchain/llvmgen.osty:1725:5
 func llvmMapRuntimeRemoveSymbol(keyTyp string, isString bool) string {
-	return "osty_rt_map_remove_" + llvmMapKeySuffix(keyTyp, isString)
+	return fmt.Sprintf("osty_rt_map_remove_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
 }
 
+// Osty: toolchain/llvmgen.osty:1729:5
 func llvmMapRuntimeGetOrAbortSymbol(keyTyp string, isString bool) string {
-	return "osty_rt_map_get_or_abort_" + llvmMapKeySuffix(keyTyp, isString)
+	return fmt.Sprintf("osty_rt_map_get_or_abort_%s", ostyToString(llvmMapKeySuffix(keyTyp, isString)))
 }
 
-// Osty: toolchain/llvmgen.osty:1116:1
+// Osty: toolchain/llvmgen.osty:1733:5
 func llvmSetRuntimeNewSymbol() string {
 	return "osty_rt_set_new"
 }
 
-// Osty: toolchain/llvmgen.osty:1120:1
+// Osty: toolchain/llvmgen.osty:1737:5
 func llvmSetRuntimeLenSymbol() string {
 	return "osty_rt_set_len"
 }
 
-// Osty: toolchain/llvmgen.osty:1124:1
+// Osty: toolchain/llvmgen.osty:1741:5
 func llvmSetRuntimeToListSymbol() string {
 	return "osty_rt_set_to_list"
 }
 
+// Osty: toolchain/llvmgen.osty:1750:5
 func llvmSetRuntimeContainsSymbol(elemTyp string, isString bool) string {
-	return "osty_rt_set_contains_" + llvmMapKeySuffix(elemTyp, isString)
+	return fmt.Sprintf("osty_rt_set_contains_%s", ostyToString(llvmMapKeySuffix(elemTyp, isString)))
 }
 
+// Osty: toolchain/llvmgen.osty:1754:5
 func llvmSetRuntimeInsertSymbol(elemTyp string, isString bool) string {
-	return "osty_rt_set_insert_" + llvmMapKeySuffix(elemTyp, isString)
+	return fmt.Sprintf("osty_rt_set_insert_%s", ostyToString(llvmMapKeySuffix(elemTyp, isString)))
 }
 
+// Osty: toolchain/llvmgen.osty:1758:5
 func llvmSetRuntimeRemoveSymbol(elemTyp string, isString bool) string {
-	return "osty_rt_set_remove_" + llvmMapKeySuffix(elemTyp, isString)
+	return fmt.Sprintf("osty_rt_set_remove_%s", ostyToString(llvmMapKeySuffix(elemTyp, isString)))
 }
 
-// Osty: toolchain/llvmgen.osty:1130:1
+// Osty: toolchain/llvmgen.osty:1764:5
 func llvmContainerAbiKind(typ string, isString bool) int {
+	// Osty: toolchain/llvmgen.osty:1765:5
 	if isString {
+		// Osty: toolchain/llvmgen.osty:1766:9
 		return 5
 	}
-	switch typ {
-	case "i64":
+	// Osty: toolchain/llvmgen.osty:1768:5
+	if typ == "i64" {
+		// Osty: toolchain/llvmgen.osty:1769:9
 		return 1
-	case "i1":
-		return 2
-	case "double":
-		return 3
-	case "ptr":
-		return 4
-	default:
-		return 6
 	}
+	// Osty: toolchain/llvmgen.osty:1771:5
+	if typ == "i1" {
+		// Osty: toolchain/llvmgen.osty:1772:9
+		return 2
+	}
+	// Osty: toolchain/llvmgen.osty:1774:5
+	if typ == "double" {
+		// Osty: toolchain/llvmgen.osty:1775:9
+		return 3
+	}
+	// Osty: toolchain/llvmgen.osty:1777:5
+	if typ == "ptr" {
+		// Osty: toolchain/llvmgen.osty:1778:9
+		return 4
+	}
+	return 6
 }
 
+// Osty: toolchain/llvmgen.osty:1787:5
 func llvmListUsesTypedRuntime(elemTyp string) bool {
 	return elemTyp == "i64" || elemTyp == "i1" || elemTyp == "double" || elemTyp == "ptr"
 }
 
+// Osty: toolchain/llvmgen.osty:1796:5
 func llvmListElementSuffix(typ string) string {
-	switch typ {
-	case "i64", "i1", "ptr":
+	// Osty: toolchain/llvmgen.osty:1797:5
+	if typ == "i64" || typ == "i1" || typ == "ptr" {
+		// Osty: toolchain/llvmgen.osty:1798:9
 		return typ
-	case "double":
+	}
+	// Osty: toolchain/llvmgen.osty:1800:5
+	if typ == "double" {
+		// Osty: toolchain/llvmgen.osty:1801:9
 		return "f64"
 	}
+	// Osty: toolchain/llvmgen.osty:1803:5
 	out := ""
-	for _, c := range typ {
-		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') {
-			out += string(c)
+	_ = out
+	// Osty: toolchain/llvmgen.osty:1804:5
+	for _, c := range []rune(typ) {
+		// Osty: toolchain/llvmgen.osty:1805:9
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			// Osty: toolchain/llvmgen.osty:1806:13
+			out = fmt.Sprintf("%s%s", ostyToString(out), string(c))
+			// Osty: toolchain/llvmgen.osty:1807:13
 			continue
 		}
-		out += "_"
+		// Osty: toolchain/llvmgen.osty:1809:9
+		out = fmt.Sprintf("%s_", ostyToString(out))
 	}
+	// Osty: toolchain/llvmgen.osty:1811:5
 	if out == "" {
+		// Osty: toolchain/llvmgen.osty:1812:9
 		return "ptr"
 	}
 	return out
 }
 
+// Osty: toolchain/llvmgen.osty:1820:5
 func llvmListRuntimeDeclarations() []string {
-	return []string{
-		"declare ptr @osty_rt_list_new()",
-		"declare i64 @osty_rt_list_len(ptr)",
-		"declare void @osty_rt_list_push_i64(ptr, i64)",
-		"declare void @osty_rt_list_push_i1(ptr, i1)",
-		"declare void @osty_rt_list_push_f64(ptr, double)",
-		"declare void @osty_rt_list_push_ptr(ptr, ptr)",
-		"declare i64 @osty_rt_list_get_i64(ptr, i64)",
-		"declare i1 @osty_rt_list_get_i1(ptr, i64)",
-		"declare double @osty_rt_list_get_f64(ptr, i64)",
-		"declare ptr @osty_rt_list_get_ptr(ptr, i64)",
-		"declare void @osty_rt_list_set_i64(ptr, i64, i64)",
-		"declare void @osty_rt_list_set_i1(ptr, i64, i1)",
-		"declare void @osty_rt_list_set_f64(ptr, i64, double)",
-		"declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
-	}
+	return []string{"declare ptr @osty_rt_list_new()", "declare i64 @osty_rt_list_len(ptr)", "declare void @osty_rt_list_push_i64(ptr, i64)", "declare void @osty_rt_list_push_i1(ptr, i1)", "declare void @osty_rt_list_push_f64(ptr, double)", "declare void @osty_rt_list_push_ptr(ptr, ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "declare i1 @osty_rt_list_get_i1(ptr, i64)", "declare double @osty_rt_list_get_f64(ptr, i64)", "declare ptr @osty_rt_list_get_ptr(ptr, i64)", "declare void @osty_rt_list_set_i64(ptr, i64, i64)", "declare void @osty_rt_list_set_i1(ptr, i64, i1)", "declare void @osty_rt_list_set_f64(ptr, i64, double)", "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)"}
 }
 
+// Osty: toolchain/llvmgen.osty:1842:5
 func llvmListNew(emitter *LlvmEmitter) *LlvmValue {
-	return llvmCall(emitter, "ptr", "osty_rt_list_new", make([]*LlvmValue, 0))
+	return llvmCall(emitter, "ptr", "osty_rt_list_new", make([]*LlvmValue, 0, 1))
 }
 
+// Osty: toolchain/llvmgen.osty:1846:5
 func llvmListLen(emitter *LlvmEmitter, list *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_list_len", []*LlvmValue{list})
 }
 
+// Osty: toolchain/llvmgen.osty:1850:5
 func llvmListPushI64(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1851:5
 	llvmCallVoid(emitter, "osty_rt_list_push_i64", []*LlvmValue{list, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1854:5
 func llvmListPushI1(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1855:5
 	llvmCallVoid(emitter, "osty_rt_list_push_i1", []*LlvmValue{list, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1858:5
 func llvmListPushF64(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1859:5
 	llvmCallVoid(emitter, "osty_rt_list_push_f64", []*LlvmValue{list, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1862:5
 func llvmListPushPtr(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1863:5
 	llvmCallVoid(emitter, "osty_rt_list_push_ptr", []*LlvmValue{list, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1871:5
 func llvmListPush(emitter *LlvmEmitter, list *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1872:5
 	symbol := llvmListRuntimePushSymbol(llvmListElementSuffix(value.typ))
+	_ = symbol
+	// Osty: toolchain/llvmgen.osty:1873:5
 	llvmCallVoid(emitter, symbol, []*LlvmValue{list, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1881:5
 func llvmListGet(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, elemTyp string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:1887:5
 	symbol := llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
+	_ = symbol
 	return llvmCall(emitter, elemTyp, symbol, []*LlvmValue{list, index})
 }
 
+// Osty: toolchain/llvmgen.osty:1891:5
 func llvmListGetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_list_get_i64", []*LlvmValue{list, index})
 }
 
+// Osty: toolchain/llvmgen.osty:1895:5
 func llvmListGetI1(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_list_get_i1", []*LlvmValue{list, index})
 }
 
+// Osty: toolchain/llvmgen.osty:1899:5
 func llvmListGetF64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "double", "osty_rt_list_get_f64", []*LlvmValue{list, index})
 }
 
+// Osty: toolchain/llvmgen.osty:1903:5
 func llvmListGetPtr(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_list_get_ptr", []*LlvmValue{list, index})
 }
 
+// Osty: toolchain/llvmgen.osty:1907:5
 func llvmListSetI64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1908:5
 	llvmCallVoid(emitter, "osty_rt_list_set_i64", []*LlvmValue{list, index, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1911:5
 func llvmListSetI1(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1912:5
 	llvmCallVoid(emitter, "osty_rt_list_set_i1", []*LlvmValue{list, index, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1915:5
 func llvmListSetF64(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1916:5
 	llvmCallVoid(emitter, "osty_rt_list_set_f64", []*LlvmValue{list, index, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1919:5
 func llvmListSetPtr(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1920:5
 	llvmCallVoid(emitter, "osty_rt_list_set_ptr", []*LlvmValue{list, index, value})
 }
 
+// Osty: toolchain/llvmgen.osty:1929:5
 func llvmMapRuntimeDeclarations() []string {
-	return []string{
-		"declare ptr @osty_rt_map_new()",
-		"declare i64 @osty_rt_map_len(ptr)",
-		"declare ptr @osty_rt_map_keys(ptr)",
-		"declare i1 @osty_rt_map_contains_i64(ptr, i64)",
-		"declare i1 @osty_rt_map_contains_i1(ptr, i1)",
-		"declare i1 @osty_rt_map_contains_f64(ptr, double)",
-		"declare i1 @osty_rt_map_contains_ptr(ptr, ptr)",
-		"declare i1 @osty_rt_map_contains_string(ptr, ptr)",
-		"declare void @osty_rt_map_insert_i64(ptr, i64, ptr)",
-		"declare void @osty_rt_map_insert_i1(ptr, i1, ptr)",
-		"declare void @osty_rt_map_insert_f64(ptr, double, ptr)",
-		"declare void @osty_rt_map_insert_ptr(ptr, ptr, ptr)",
-		"declare void @osty_rt_map_insert_string(ptr, ptr, ptr)",
-		"declare i1 @osty_rt_map_remove_i64(ptr, i64)",
-		"declare i1 @osty_rt_map_remove_i1(ptr, i1)",
-		"declare i1 @osty_rt_map_remove_f64(ptr, double)",
-		"declare i1 @osty_rt_map_remove_ptr(ptr, ptr)",
-		"declare i1 @osty_rt_map_remove_string(ptr, ptr)",
-		"declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)",
-		"declare void @osty_rt_map_get_or_abort_i1(ptr, i1, ptr)",
-		"declare void @osty_rt_map_get_or_abort_f64(ptr, double, ptr)",
-		"declare void @osty_rt_map_get_or_abort_ptr(ptr, ptr, ptr)",
-		"declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)",
-	}
+	return []string{"declare ptr @osty_rt_map_new()", "declare i64 @osty_rt_map_len(ptr)", "declare ptr @osty_rt_map_keys(ptr)", "declare i1 @osty_rt_map_contains_i64(ptr, i64)", "declare i1 @osty_rt_map_contains_i1(ptr, i1)", "declare i1 @osty_rt_map_contains_f64(ptr, double)", "declare i1 @osty_rt_map_contains_ptr(ptr, ptr)", "declare i1 @osty_rt_map_contains_string(ptr, ptr)", "declare void @osty_rt_map_insert_i64(ptr, i64, ptr)", "declare void @osty_rt_map_insert_i1(ptr, i1, ptr)", "declare void @osty_rt_map_insert_f64(ptr, double, ptr)", "declare void @osty_rt_map_insert_ptr(ptr, ptr, ptr)", "declare void @osty_rt_map_insert_string(ptr, ptr, ptr)", "declare i1 @osty_rt_map_remove_i64(ptr, i64)", "declare i1 @osty_rt_map_remove_i1(ptr, i1)", "declare i1 @osty_rt_map_remove_f64(ptr, double)", "declare i1 @osty_rt_map_remove_ptr(ptr, ptr)", "declare i1 @osty_rt_map_remove_string(ptr, ptr)", "declare void @osty_rt_map_get_or_abort_i64(ptr, i64, ptr)", "declare void @osty_rt_map_get_or_abort_i1(ptr, i1, ptr)", "declare void @osty_rt_map_get_or_abort_f64(ptr, double, ptr)", "declare void @osty_rt_map_get_or_abort_ptr(ptr, ptr, ptr)", "declare void @osty_rt_map_get_or_abort_string(ptr, ptr, ptr)"}
 }
 
+// Osty: toolchain/llvmgen.osty:1957:5
 func llvmMapNew(emitter *LlvmEmitter) *LlvmValue {
-	return llvmCall(emitter, "ptr", "osty_rt_map_new", make([]*LlvmValue, 0))
+	return llvmCall(emitter, "ptr", "osty_rt_map_new", make([]*LlvmValue, 0, 1))
 }
 
-func llvmMapLen(emitter *LlvmEmitter, m *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i64", "osty_rt_map_len", []*LlvmValue{m})
+// Osty: toolchain/llvmgen.osty:1961:5
+func llvmMapLen(emitter *LlvmEmitter, map_ *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_map_len", []*LlvmValue{map_})
 }
 
-func llvmMapKeys(emitter *LlvmEmitter, m *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "ptr", "osty_rt_map_keys", []*LlvmValue{m})
+// Osty: toolchain/llvmgen.osty:1965:5
+func llvmMapKeys(emitter *LlvmEmitter, map_ *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "ptr", "osty_rt_map_keys", []*LlvmValue{map_})
 }
 
-func llvmMapContainsI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_i64", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:1969:5
+func llvmMapContainsI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_i64", []*LlvmValue{map_, key})
 }
 
-func llvmMapContainsI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_i1", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:1973:5
+func llvmMapContainsI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_i1", []*LlvmValue{map_, key})
 }
 
-func llvmMapContainsF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_f64", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:1977:5
+func llvmMapContainsF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_f64", []*LlvmValue{map_, key})
 }
 
-func llvmMapContainsPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_ptr", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:1981:5
+func llvmMapContainsPtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_ptr", []*LlvmValue{map_, key})
 }
 
-func llvmMapContainsString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_contains_string", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:1985:5
+func llvmMapContainsString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_contains_string", []*LlvmValue{map_, key})
 }
 
-func llvmMapInsertI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_insert_i64", []*LlvmValue{m, key, valueSlot})
+// Osty: toolchain/llvmgen.osty:1993:5
+func llvmMapInsertI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1994:5
+	llvmCallVoid(emitter, "osty_rt_map_insert_i64", []*LlvmValue{map_, key, valueSlot})
 }
 
-func llvmMapInsertI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_insert_i1", []*LlvmValue{m, key, valueSlot})
+// Osty: toolchain/llvmgen.osty:1997:5
+func llvmMapInsertI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:1998:5
+	llvmCallVoid(emitter, "osty_rt_map_insert_i1", []*LlvmValue{map_, key, valueSlot})
 }
 
-func llvmMapInsertF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_insert_f64", []*LlvmValue{m, key, valueSlot})
+// Osty: toolchain/llvmgen.osty:2001:5
+func llvmMapInsertF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2002:5
+	llvmCallVoid(emitter, "osty_rt_map_insert_f64", []*LlvmValue{map_, key, valueSlot})
 }
 
-func llvmMapInsertPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_insert_ptr", []*LlvmValue{m, key, valueSlot})
+// Osty: toolchain/llvmgen.osty:2005:5
+func llvmMapInsertPtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2006:5
+	llvmCallVoid(emitter, "osty_rt_map_insert_ptr", []*LlvmValue{map_, key, valueSlot})
 }
 
-func llvmMapInsertString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_insert_string", []*LlvmValue{m, key, valueSlot})
+// Osty: toolchain/llvmgen.osty:2009:5
+func llvmMapInsertString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2010:5
+	llvmCallVoid(emitter, "osty_rt_map_insert_string", []*LlvmValue{map_, key, valueSlot})
 }
 
-func llvmMapRemoveI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_i64", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:2013:5
+func llvmMapRemoveI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_i64", []*LlvmValue{map_, key})
 }
 
-func llvmMapRemoveI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_i1", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:2017:5
+func llvmMapRemoveI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_i1", []*LlvmValue{map_, key})
 }
 
-func llvmMapRemoveF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_f64", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:2021:5
+func llvmMapRemoveF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_f64", []*LlvmValue{map_, key})
 }
 
-func llvmMapRemovePtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_ptr", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:2025:5
+func llvmMapRemovePtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_ptr", []*LlvmValue{map_, key})
 }
 
-func llvmMapRemoveString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i1", "osty_rt_map_remove_string", []*LlvmValue{m, key})
+// Osty: toolchain/llvmgen.osty:2029:5
+func llvmMapRemoveString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i1", "osty_rt_map_remove_string", []*LlvmValue{map_, key})
 }
 
-func llvmMapGetOrAbortI64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i64", []*LlvmValue{m, key, outSlot})
+// Osty: toolchain/llvmgen.osty:2036:5
+func llvmMapGetOrAbortI64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2037:5
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i64", []*LlvmValue{map_, key, outSlot})
 }
 
-func llvmMapGetOrAbortI1(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i1", []*LlvmValue{m, key, outSlot})
+// Osty: toolchain/llvmgen.osty:2040:5
+func llvmMapGetOrAbortI1(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2041:5
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_i1", []*LlvmValue{map_, key, outSlot})
 }
 
-func llvmMapGetOrAbortF64(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_f64", []*LlvmValue{m, key, outSlot})
+// Osty: toolchain/llvmgen.osty:2044:5
+func llvmMapGetOrAbortF64(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2045:5
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_f64", []*LlvmValue{map_, key, outSlot})
 }
 
-func llvmMapGetOrAbortPtr(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_ptr", []*LlvmValue{m, key, outSlot})
+// Osty: toolchain/llvmgen.osty:2048:5
+func llvmMapGetOrAbortPtr(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2049:5
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_ptr", []*LlvmValue{map_, key, outSlot})
 }
 
-func llvmMapGetOrAbortString(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
-	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", []*LlvmValue{m, key, outSlot})
+// Osty: toolchain/llvmgen.osty:2052:5
+func llvmMapGetOrAbortString(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2053:5
+	llvmCallVoid(emitter, "osty_rt_map_get_or_abort_string", []*LlvmValue{map_, key, outSlot})
 }
 
-func llvmMapContains(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
+// Osty: toolchain/llvmgen.osty:2060:5
+func llvmMapContains(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2066:5
 	symbol := llvmMapRuntimeContainsSymbol(key.typ, isString)
-	return llvmCall(emitter, "i1", symbol, []*LlvmValue{m, key})
+	_ = symbol
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{map_, key})
 }
 
-func llvmMapInsert(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, valueSlot *LlvmValue, isString bool) {
+// Osty: toolchain/llvmgen.osty:2074:5
+func llvmMapInsert(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, valueSlot *LlvmValue, isString bool) {
+	// Osty: toolchain/llvmgen.osty:2081:5
 	symbol := llvmMapRuntimeInsertSymbol(key.typ, isString)
-	llvmCallVoid(emitter, symbol, []*LlvmValue{m, key, valueSlot})
+	_ = symbol
+	// Osty: toolchain/llvmgen.osty:2082:5
+	llvmCallVoid(emitter, symbol, []*LlvmValue{map_, key, valueSlot})
 }
 
-func llvmMapRemove(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
+// Osty: toolchain/llvmgen.osty:2087:5
+func llvmMapRemove(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, isString bool) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2093:5
 	symbol := llvmMapRuntimeRemoveSymbol(key.typ, isString)
-	return llvmCall(emitter, "i1", symbol, []*LlvmValue{m, key})
+	_ = symbol
+	return llvmCall(emitter, "i1", symbol, []*LlvmValue{map_, key})
 }
 
-func llvmMapGetOrAbort(emitter *LlvmEmitter, m *LlvmValue, key *LlvmValue, outSlot *LlvmValue, isString bool) {
+// Osty: toolchain/llvmgen.osty:2100:5
+func llvmMapGetOrAbort(emitter *LlvmEmitter, map_ *LlvmValue, key *LlvmValue, outSlot *LlvmValue, isString bool) {
+	// Osty: toolchain/llvmgen.osty:2107:5
 	symbol := llvmMapRuntimeGetOrAbortSymbol(key.typ, isString)
-	llvmCallVoid(emitter, symbol, []*LlvmValue{m, key, outSlot})
+	_ = symbol
+	// Osty: toolchain/llvmgen.osty:2108:5
+	llvmCallVoid(emitter, symbol, []*LlvmValue{map_, key, outSlot})
 }
 
+// Osty: toolchain/llvmgen.osty:2116:5
 func llvmSetRuntimeDeclarations() []string {
-	return []string{
-		"declare ptr @osty_rt_set_new(i64)",
-		"declare i64 @osty_rt_set_len(ptr)",
-		"declare ptr @osty_rt_set_to_list(ptr)",
-		"declare i1 @osty_rt_set_contains_i64(ptr, i64)",
-		"declare i1 @osty_rt_set_contains_i1(ptr, i1)",
-		"declare i1 @osty_rt_set_contains_f64(ptr, double)",
-		"declare i1 @osty_rt_set_contains_ptr(ptr, ptr)",
-		"declare i1 @osty_rt_set_contains_string(ptr, ptr)",
-		"declare i1 @osty_rt_set_insert_i64(ptr, i64)",
-		"declare i1 @osty_rt_set_insert_i1(ptr, i1)",
-		"declare i1 @osty_rt_set_insert_f64(ptr, double)",
-		"declare i1 @osty_rt_set_insert_ptr(ptr, ptr)",
-		"declare i1 @osty_rt_set_insert_string(ptr, ptr)",
-		"declare i1 @osty_rt_set_remove_i64(ptr, i64)",
-		"declare i1 @osty_rt_set_remove_i1(ptr, i1)",
-		"declare i1 @osty_rt_set_remove_f64(ptr, double)",
-		"declare i1 @osty_rt_set_remove_ptr(ptr, ptr)",
-		"declare i1 @osty_rt_set_remove_string(ptr, ptr)",
-	}
+	return []string{"declare ptr @osty_rt_set_new(i64)", "declare i64 @osty_rt_set_len(ptr)", "declare ptr @osty_rt_set_to_list(ptr)", "declare i1 @osty_rt_set_contains_i64(ptr, i64)", "declare i1 @osty_rt_set_contains_i1(ptr, i1)", "declare i1 @osty_rt_set_contains_f64(ptr, double)", "declare i1 @osty_rt_set_contains_ptr(ptr, ptr)", "declare i1 @osty_rt_set_contains_string(ptr, ptr)", "declare i1 @osty_rt_set_insert_i64(ptr, i64)", "declare i1 @osty_rt_set_insert_i1(ptr, i1)", "declare i1 @osty_rt_set_insert_f64(ptr, double)", "declare i1 @osty_rt_set_insert_ptr(ptr, ptr)", "declare i1 @osty_rt_set_insert_string(ptr, ptr)", "declare i1 @osty_rt_set_remove_i64(ptr, i64)", "declare i1 @osty_rt_set_remove_i1(ptr, i1)", "declare i1 @osty_rt_set_remove_f64(ptr, double)", "declare i1 @osty_rt_set_remove_ptr(ptr, ptr)", "declare i1 @osty_rt_set_remove_string(ptr, ptr)"}
 }
 
+// Osty: toolchain/llvmgen.osty:2142:5
 func llvmSetNew(emitter *LlvmEmitter, elemKind int) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_set_new", []*LlvmValue{llvmIntLiteral(elemKind)})
 }
 
+// Osty: toolchain/llvmgen.osty:2146:5
 func llvmSetLen(emitter *LlvmEmitter, set *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_set_len", []*LlvmValue{set})
 }
 
+// Osty: toolchain/llvmgen.osty:2150:5
 func llvmSetToList(emitter *LlvmEmitter, set *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_set_to_list", []*LlvmValue{set})
 }
 
+// Osty: toolchain/llvmgen.osty:2154:5
 func llvmSetContainsI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_i64", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2158:5
 func llvmSetContainsI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_i1", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2162:5
 func llvmSetContainsF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_f64", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2166:5
 func llvmSetContainsPtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_ptr", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2170:5
 func llvmSetContainsString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_contains_string", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2174:5
 func llvmSetInsertI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_i64", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2178:5
 func llvmSetInsertI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_i1", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2182:5
 func llvmSetInsertF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_f64", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2186:5
 func llvmSetInsertPtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_ptr", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2190:5
 func llvmSetInsertString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_insert_string", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2194:5
 func llvmSetRemoveI64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_i64", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2198:5
 func llvmSetRemoveI1(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_i1", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2202:5
 func llvmSetRemoveF64(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_f64", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2206:5
 func llvmSetRemovePtr(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_ptr", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2210:5
 func llvmSetRemoveString(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_set_remove_string", []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2216:5
 func llvmSetContains(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2222:5
 	symbol := llvmSetRuntimeContainsSymbol(item.typ, isString)
+	_ = symbol
 	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2228:5
 func llvmSetInsert(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2234:5
 	symbol := llvmSetRuntimeInsertSymbol(item.typ, isString)
+	_ = symbol
 	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2240:5
 func llvmSetRemove(emitter *LlvmEmitter, set *LlvmValue, item *LlvmValue, isString bool) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2246:5
 	symbol := llvmSetRuntimeRemoveSymbol(item.typ, isString)
+	_ = symbol
 	return llvmCall(emitter, "i1", symbol, []*LlvmValue{set, item})
 }
 
+// Osty: toolchain/llvmgen.osty:2254:5
 func llvmChanElementSuffix(elemTyp string) string {
+	// Osty: toolchain/llvmgen.osty:2255:5
 	if llvmListUsesTypedRuntime(elemTyp) {
+		// Osty: toolchain/llvmgen.osty:2256:9
 		return llvmListElementSuffix(elemTyp)
 	}
 	return "bytes_v1"
 }
 
+// Osty: toolchain/llvmgen.osty:2261:5
 func llvmChanRuntimeMakeSymbol() string {
 	return "osty_rt_thread_chan_make"
 }
 
+// Osty: toolchain/llvmgen.osty:2265:5
 func llvmChanRuntimeSendSymbol(suffix string) string {
-	return "osty_rt_thread_chan_send_" + suffix
+	return fmt.Sprintf("osty_rt_thread_chan_send_%s", ostyToString(suffix))
 }
 
+// Osty: toolchain/llvmgen.osty:2269:5
 func llvmChanRuntimeSendBytesSymbol() string {
 	return "osty_rt_thread_chan_send_bytes_v1"
 }
 
+// Osty: toolchain/llvmgen.osty:2273:5
 func llvmChanRuntimeRecvSymbol(suffix string) string {
-	return "osty_rt_thread_chan_recv_" + suffix
+	return fmt.Sprintf("osty_rt_thread_chan_recv_%s", ostyToString(suffix))
 }
 
+// Osty: toolchain/llvmgen.osty:2277:5
 func llvmChanRuntimeCloseSymbol() string {
 	return "osty_rt_thread_chan_close"
 }
 
+// Osty: toolchain/llvmgen.osty:2281:5
 func llvmChanRuntimeIsClosedSymbol() string {
 	return "osty_rt_thread_chan_is_closed"
 }
 
+// Osty: toolchain/llvmgen.osty:2291:5
 func llvmChanRuntimeDeclarations() []string {
-	return []string{
-		"declare ptr @osty_rt_thread_chan_make(i64)",
-		"declare void @osty_rt_thread_chan_close(ptr)",
-		"declare i1 @osty_rt_thread_chan_is_closed(ptr)",
-		"declare void @osty_rt_thread_chan_send_i64(ptr, i64)",
-		"declare void @osty_rt_thread_chan_send_i1(ptr, i1)",
-		"declare void @osty_rt_thread_chan_send_f64(ptr, double)",
-		"declare void @osty_rt_thread_chan_send_ptr(ptr, ptr)",
-		"declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)",
-		"declare { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr)",
-		"declare { i64, i64 } @osty_rt_thread_chan_recv_i1(ptr)",
-		"declare { i64, i64 } @osty_rt_thread_chan_recv_f64(ptr)",
-		"declare { i64, i64 } @osty_rt_thread_chan_recv_ptr(ptr)",
-		"declare { i64, i64 } @osty_rt_thread_chan_recv_bytes_v1(ptr)",
-	}
+	return []string{"declare ptr @osty_rt_thread_chan_make(i64)", "declare void @osty_rt_thread_chan_close(ptr)", "declare i1 @osty_rt_thread_chan_is_closed(ptr)", "declare void @osty_rt_thread_chan_send_i64(ptr, i64)", "declare void @osty_rt_thread_chan_send_i1(ptr, i1)", "declare void @osty_rt_thread_chan_send_f64(ptr, double)", "declare void @osty_rt_thread_chan_send_ptr(ptr, ptr)", "declare void @osty_rt_thread_chan_send_bytes_v1(ptr, ptr, i64)", "declare { i64, i64 } @osty_rt_thread_chan_recv_i64(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_i1(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_f64(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_ptr(ptr)", "declare { i64, i64 } @osty_rt_thread_chan_recv_bytes_v1(ptr)"}
 }
 
+// Osty: toolchain/llvmgen.osty:2310:5
 func llvmChanMake(emitter *LlvmEmitter, capacity *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", llvmChanRuntimeMakeSymbol(), []*LlvmValue{capacity})
 }
 
+// Osty: toolchain/llvmgen.osty:2318:5
 func llvmChanSend(emitter *LlvmEmitter, channel *LlvmValue, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2319:5
 	symbol := llvmChanRuntimeSendSymbol(llvmListElementSuffix(value.typ))
+	_ = symbol
+	// Osty: toolchain/llvmgen.osty:2320:5
 	llvmCallVoid(emitter, symbol, []*LlvmValue{channel, value})
 }
 
+// Osty: toolchain/llvmgen.osty:2327:5
 func llvmChanSendBytes(emitter *LlvmEmitter, channel *LlvmValue, slot *LlvmValue, size *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2333:5
 	llvmCallVoid(emitter, llvmChanRuntimeSendBytesSymbol(), []*LlvmValue{channel, slot, size})
 }
 
+// Osty: toolchain/llvmgen.osty:2340:5
 func llvmChanRecv(emitter *LlvmEmitter, channel *LlvmValue, elemTyp string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2341:5
 	symbol := llvmChanRuntimeRecvSymbol(llvmChanElementSuffix(elemTyp))
+	_ = symbol
 	return llvmCall(emitter, "{ i64, i64 }", symbol, []*LlvmValue{channel})
 }
 
+// Osty: toolchain/llvmgen.osty:2346:5
 func llvmChanClose(emitter *LlvmEmitter, channel *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2347:5
 	llvmCallVoid(emitter, llvmChanRuntimeCloseSymbol(), []*LlvmValue{channel})
 }
 
+// Osty: toolchain/llvmgen.osty:2352:5
 func llvmChanIsClosed(emitter *LlvmEmitter, channel *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", llvmChanRuntimeIsClosedSymbol(), []*LlvmValue{channel})
 }
 
+// Osty: toolchain/llvmgen.osty:2362:5
 func llvmClosureEnvTypeName(elemTags []string) string {
-	return "ClosureEnv." + llvmStrings.Join(elemTags, ".")
+	// Osty: toolchain/llvmgen.osty:2363:5
+	joined := llvmStrings.Join(elemTags, ".")
+	_ = joined
+	return fmt.Sprintf("ClosureEnv.%s", ostyToString(joined))
 }
 
+// Osty: toolchain/llvmgen.osty:2371:5
 func llvmClosureEnvTypeDef(name string, elemTypes []string) string {
 	return llvmStructTypeDef(name, elemTypes)
 }
 
+// Osty: toolchain/llvmgen.osty:2380:5
 func llvmClosureEnvAlloc(emitter *LlvmEmitter, envTypeName string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2381:5
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", tmp, envTypeName))
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:2382:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = alloca %%%s", ostyToString(tmp), ostyToString(envTypeName)))
+		return struct{}{}
+	}()
 	return &LlvmValue{typ: "ptr", name: tmp, pointer: false}
 }
 
+// Osty: toolchain/llvmgen.osty:2386:1
 func llvmClosureEnvSlotGep(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int) string {
+	// Osty: toolchain/llvmgen.osty:2392:5
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %%%s, ptr %s, i32 0, i32 %d", tmp, envTypeName, envPtr.name, slotIndex))
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:2393:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr %%%s, ptr %s, i32 0, i32 %s", ostyToString(tmp), ostyToString(envTypeName), ostyToString(envPtr.name), ostyToString(slotIndex)))
+		return struct{}{}
+	}()
 	return tmp
 }
 
+// Osty: toolchain/llvmgen.osty:2402:5
 func llvmClosureEnvStoreFn(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, fnSymbol string) {
+	// Osty: toolchain/llvmgen.osty:2408:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
-	emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", fnSymbol, gep))
+	_ = gep
+	// Osty: toolchain/llvmgen.osty:2409:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  store ptr @%s, ptr %s", ostyToString(fnSymbol), ostyToString(gep)))
+		return struct{}{}
+	}()
 }
 
+// Osty: toolchain/llvmgen.osty:2415:5
 func llvmClosureEnvStoreCapture(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int, value *LlvmValue) {
+	// Osty: toolchain/llvmgen.osty:2422:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
-	emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", value.typ, value.name, gep))
+	_ = gep
+	// Osty: toolchain/llvmgen.osty:2423:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  store %s %s, ptr %s", ostyToString(value.typ), ostyToString(value.name), ostyToString(gep)))
+		return struct{}{}
+	}()
 }
 
+// Osty: toolchain/llvmgen.osty:2427:5
 func llvmClosureEnvLoadFn(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2432:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, 0)
+	_ = gep
+	// Osty: toolchain/llvmgen.osty:2433:5
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", tmp, gep))
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:2434:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", ostyToString(tmp), ostyToString(gep)))
+		return struct{}{}
+	}()
 	return &LlvmValue{typ: "ptr", name: tmp, pointer: false}
 }
 
+// Osty: toolchain/llvmgen.osty:2441:5
 func llvmClosureEnvLoadCapture(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, slotIndex int, captureType string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2448:5
 	gep := llvmClosureEnvSlotGep(emitter, envPtr, envTypeName, slotIndex)
+	_ = gep
+	// Osty: toolchain/llvmgen.osty:2449:5
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", tmp, captureType, gep))
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:2450:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", ostyToString(tmp), ostyToString(captureType), ostyToString(gep)))
+		return struct{}{}
+	}()
 	return &LlvmValue{typ: captureType, name: tmp, pointer: false}
 }
 
+// Osty: toolchain/llvmgen.osty:2460:5
 func llvmClosureCallIndirect(emitter *LlvmEmitter, envPtr *LlvmValue, envTypeName string, returnType string, extraArgs []*LlvmValue) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2467:5
 	fnPtr := llvmClosureEnvLoadFn(emitter, envPtr, envTypeName)
+	_ = fnPtr
+	// Osty: toolchain/llvmgen.osty:2468:5
 	args := []*LlvmValue{envPtr}
-	paramTypes := []string{"ptr"}
-	for _, a := range extraArgs {
-		args = append(args, a)
-		paramTypes = append(paramTypes, a.typ)
+	_ = args
+	// Osty: toolchain/llvmgen.osty:2469:5
+	var paramTypes []string = []string{"ptr"}
+	_ = paramTypes
+	// Osty: toolchain/llvmgen.osty:2470:5
+	for _, arg := range extraArgs {
+		// Osty: toolchain/llvmgen.osty:2471:9
+		func() struct{} { args = append(args, arg); return struct{}{} }()
+		// Osty: toolchain/llvmgen.osty:2472:9
+		func() struct{} { paramTypes = append(paramTypes, arg.typ); return struct{}{} }()
 	}
-	callType := returnType + " (" + llvmStrings.Join(paramTypes, ", ") + ")"
+	// Osty: toolchain/llvmgen.osty:2474:5
+	paramList := llvmStrings.Join(paramTypes, ", ")
+	_ = paramList
+	// Osty: toolchain/llvmgen.osty:2475:5
+	callType := fmt.Sprintf("%s (%s)", ostyToString(returnType), ostyToString(paramList))
+	_ = callType
+	// Osty: toolchain/llvmgen.osty:2476:5
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", tmp, callType, fnPtr.name, llvmCallArgs(args)))
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:2477:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", ostyToString(tmp), ostyToString(callType), ostyToString(fnPtr.name), ostyToString(llvmCallArgs(args))))
+		return struct{}{}
+	}()
 	return &LlvmValue{typ: returnType, name: tmp, pointer: false}
 }
 
+// Osty: toolchain/llvmgen.osty:2488:5
 func llvmFnValueCallIndirect(emitter *LlvmEmitter, returnType string, envPtr *LlvmValue, extraArgs []*LlvmValue) *LlvmValue {
-	ret := returnType
-	if ret == "" {
-		ret = "void"
-	}
+	// Osty: toolchain/llvmgen.osty:2494:5
+	ret := func() string {
+		if returnType == "" {
+			return "void"
+		} else {
+			return returnType
+		}
+	}()
+	_ = ret
+	// Osty: toolchain/llvmgen.osty:2495:5
 	fnPtr := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", fnPtr, envPtr.name))
+	_ = fnPtr
+	// Osty: toolchain/llvmgen.osty:2496:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load ptr, ptr %s", ostyToString(fnPtr), ostyToString(envPtr.name)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:2497:5
 	args := []*LlvmValue{envPtr}
-	paramTypes := []string{"ptr"}
+	_ = args
+	// Osty: toolchain/llvmgen.osty:2498:5
+	var paramTypes []string = []string{"ptr"}
+	_ = paramTypes
+	// Osty: toolchain/llvmgen.osty:2499:5
 	for _, arg := range extraArgs {
-		args = append(args, arg)
-		paramTypes = append(paramTypes, arg.typ)
+		// Osty: toolchain/llvmgen.osty:2500:9
+		func() struct{} { args = append(args, arg); return struct{}{} }()
+		// Osty: toolchain/llvmgen.osty:2501:9
+		func() struct{} { paramTypes = append(paramTypes, arg.typ); return struct{}{} }()
 	}
+	// Osty: toolchain/llvmgen.osty:2503:5
 	paramList := llvmStrings.Join(paramTypes, ", ")
-	callType := fmt.Sprintf("%s (%s)", ret, paramList)
+	_ = paramList
+	// Osty: toolchain/llvmgen.osty:2504:5
+	callType := fmt.Sprintf("%s (%s)", ostyToString(ret), ostyToString(paramList))
+	_ = callType
+	// Osty: toolchain/llvmgen.osty:2505:5
 	if ret == "void" {
-		emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", callType, fnPtr, llvmCallArgs(args)))
+		// Osty: toolchain/llvmgen.osty:2506:9
+		func() struct{} {
+			emitter.body = append(emitter.body, fmt.Sprintf("  call %s %s(%s)", ostyToString(callType), ostyToString(fnPtr), ostyToString(llvmCallArgs(args))))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:2507:9
 		return &LlvmValue{typ: "void", name: "", pointer: false}
 	}
+	// Osty: toolchain/llvmgen.osty:2509:5
 	tmp := llvmNextTemp(emitter)
-	emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", tmp, callType, fnPtr, llvmCallArgs(args)))
+	_ = tmp
+	// Osty: toolchain/llvmgen.osty:2510:5
+	func() struct{} {
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = call %s %s(%s)", ostyToString(tmp), ostyToString(callType), ostyToString(fnPtr), ostyToString(llvmCallArgs(args))))
+		return struct{}{}
+	}()
 	return &LlvmValue{typ: ret, name: tmp, pointer: false}
 }
 
+// Osty: toolchain/llvmgen.osty:2519:5
 func llvmClosureThunkName(symbol string) string {
-	return "__osty_closure_thunk_" + symbol
+	return fmt.Sprintf("__osty_closure_thunk_%s", ostyToString(symbol))
 }
 
+// Osty: toolchain/llvmgen.osty:2529:5
 func llvmClosureThunkDefinition(symbol string, returnType string, paramTypes []string) string {
-	ret := returnType
-	if ret == "" {
-		ret = "void"
+	// Osty: toolchain/llvmgen.osty:2534:5
+	ret := func() string {
+		if returnType == "" {
+			return "void"
+		} else {
+			return returnType
+		}
+	}()
+	_ = ret
+	// Osty: toolchain/llvmgen.osty:2535:5
+	var headerParts []string = []string{"ptr %env"}
+	_ = headerParts
+	// Osty: toolchain/llvmgen.osty:2536:5
+	var argParts []string = make([]string, 0, 1)
+	_ = argParts
+	// Osty: toolchain/llvmgen.osty:2537:5
+	i := 0
+	_ = i
+	// Osty: toolchain/llvmgen.osty:2538:5
+	for _, paramType := range paramTypes {
+		// Osty: toolchain/llvmgen.osty:2539:9
+		func() struct{} {
+			headerParts = append(headerParts, fmt.Sprintf("%s %%arg%s", ostyToString(paramType), ostyToString(i)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:2540:9
+		func() struct{} {
+			argParts = append(argParts, fmt.Sprintf("%s %%arg%s", ostyToString(paramType), ostyToString(i)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:2541:9
+		func() {
+			var _cur21 int = i
+			var _rhs22 int = 1
+			if _rhs22 > 0 && _cur21 > math.MaxInt-_rhs22 {
+				panic("integer overflow")
+			}
+			if _rhs22 < 0 && _cur21 < math.MinInt-_rhs22 {
+				panic("integer overflow")
+			}
+			i = _cur21 + _rhs22
+		}()
 	}
-	headerParts := []string{"ptr %env"}
-	argParts := make([]string, 0, len(paramTypes))
-	for i, p := range paramTypes {
-		headerParts = append(headerParts, fmt.Sprintf("%s %%arg%d", p, i))
-		argParts = append(argParts, fmt.Sprintf("%s %%arg%d", p, i))
-	}
+	// Osty: toolchain/llvmgen.osty:2543:5
 	header := llvmStrings.Join(headerParts, ", ")
+	_ = header
+	// Osty: toolchain/llvmgen.osty:2544:5
 	callArgs := llvmStrings.Join(argParts, ", ")
+	_ = callArgs
+	// Osty: toolchain/llvmgen.osty:2545:5
 	thunk := llvmClosureThunkName(symbol)
-	lines := []string{
-		fmt.Sprintf("define private %s @%s(%s) {", ret, thunk, header),
-		"entry:",
-	}
+	_ = thunk
+	// Osty: toolchain/llvmgen.osty:2546:5
+	var lines []string = make([]string, 0, 1)
+	_ = lines
+	// Osty: toolchain/llvmgen.osty:2547:5
+	func() struct{} {
+		lines = append(lines, fmt.Sprintf("define private %s @%s(%s) {", ostyToString(ret), ostyToString(thunk), ostyToString(header)))
+		return struct{}{}
+	}()
+	// Osty: toolchain/llvmgen.osty:2548:5
+	func() struct{} { lines = append(lines, "entry:"); return struct{}{} }()
+	// Osty: toolchain/llvmgen.osty:2549:5
 	if ret == "void" {
-		lines = append(lines, fmt.Sprintf("  call void @%s(%s)", symbol, callArgs))
-		lines = append(lines, "  ret void")
+		// Osty: toolchain/llvmgen.osty:2550:9
+		func() struct{} {
+			lines = append(lines, fmt.Sprintf("  call void @%s(%s)", ostyToString(symbol), ostyToString(callArgs)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:2551:9
+		func() struct{} { lines = append(lines, "  ret void"); return struct{}{} }()
 	} else {
-		lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", ret, symbol, callArgs))
-		lines = append(lines, fmt.Sprintf("  ret %s %%ret", ret))
+		// Osty: toolchain/llvmgen.osty:2553:9
+		func() struct{} {
+			lines = append(lines, fmt.Sprintf("  %%ret = call %s @%s(%s)", ostyToString(ret), ostyToString(symbol), ostyToString(callArgs)))
+			return struct{}{}
+		}()
+		// Osty: toolchain/llvmgen.osty:2554:9
+		func() struct{} {
+			lines = append(lines, fmt.Sprintf("  ret %s %%ret", ostyToString(ret)))
+			return struct{}{}
+		}()
 	}
-	lines = append(lines, "}")
+	// Osty: toolchain/llvmgen.osty:2556:5
+	func() struct{} { lines = append(lines, "}"); return struct{}{} }()
 	return llvmStrings.Join(lines, "\n")
 }
 
+// Osty: toolchain/llvmgen.osty:2565:5
 func llvmClosureBareFnEnv(emitter *LlvmEmitter, symbol string) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2566:5
 	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
+	_ = envTypeName
+	// Osty: toolchain/llvmgen.osty:2567:5
 	env := llvmClosureEnvAlloc(emitter, envTypeName)
+	_ = env
+	// Osty: toolchain/llvmgen.osty:2568:5
 	llvmClosureEnvStoreFn(emitter, env, envTypeName, llvmClosureThunkName(symbol))
 	return env
 }
 
+// Osty: toolchain/llvmgen.osty:2575:5
 func llvmClosureBareFnEnvTypeDef() string {
 	return llvmClosureEnvTypeDef(llvmClosureEnvTypeName([]string{"ptr"}), []string{"ptr"})
 }
 
+// Osty: toolchain/llvmgen.osty:2579:5
 func llvmStringRuntimeEqualSymbol() string {
 	return "osty_rt_strings_Equal"
 }
 
+// Osty: toolchain/llvmgen.osty:2583:5
 func llvmStringRuntimeHasPrefixSymbol() string {
 	return "osty_rt_strings_HasPrefix"
 }
 
+// Osty: toolchain/llvmgen.osty:2587:5
 func llvmStringRuntimeHasSuffixSymbol() string {
 	return "osty_rt_strings_HasSuffix"
 }
 
+// Osty: toolchain/llvmgen.osty:2591:5
 func llvmStringRuntimeContainsSymbol() string {
 	return "osty_rt_strings_Contains"
 }
 
+// Osty: toolchain/llvmgen.osty:2595:5
 func llvmStringRuntimeSplitSymbol() string {
 	return "osty_rt_strings_Split"
 }
 
+// Osty: toolchain/llvmgen.osty:2599:5
 func llvmStringRuntimeSplitNSymbol() string {
 	return "osty_rt_strings_SplitN"
 }
 
+// Osty: toolchain/llvmgen.osty:2603:5
 func llvmStringRuntimeConcatSymbol() string {
 	return "osty_rt_strings_Concat"
 }
 
+// Osty: toolchain/llvmgen.osty:2607:5
 func llvmIntRuntimeToStringSymbol() string {
 	return "osty_rt_int_to_string"
 }
 
+// Osty: toolchain/llvmgen.osty:2611:5
 func llvmFloatRuntimeToStringSymbol() string {
 	return "osty_rt_float_to_string"
 }
 
+// Osty: toolchain/llvmgen.osty:2615:5
 func llvmBoolRuntimeToStringSymbol() string {
 	return "osty_rt_bool_to_string"
 }
 
+// Osty: toolchain/llvmgen.osty:2619:5
 func llvmStringRuntimeByteLenSymbol() string {
 	return "osty_rt_strings_ByteLen"
 }
 
-func llvmStringRuntimeCompareSymbol() string {
-	return "osty_rt_strings_Compare"
-}
-
+// Osty: toolchain/llvmgen.osty:2623:5
 func llvmStringRuntimeCountSymbol() string {
 	return "osty_rt_strings_Count"
 }
 
+// Osty: toolchain/llvmgen.osty:2627:5
 func llvmStringRuntimeIndexOfSymbol() string {
 	return "osty_rt_strings_IndexOf"
 }
 
+// Osty: toolchain/llvmgen.osty:2631:5
+func llvmStringRuntimeCompareSymbol() string {
+	return "osty_rt_strings_Compare"
+}
+
+// Osty: toolchain/llvmgen.osty:2635:5
 func llvmStringRuntimeJoinSymbol() string {
 	return "osty_rt_strings_Join"
 }
 
+// Osty: toolchain/llvmgen.osty:2639:5
 func llvmStringRuntimeRepeatSymbol() string {
 	return "osty_rt_strings_Repeat"
 }
 
+// Osty: toolchain/llvmgen.osty:2643:5
 func llvmStringRuntimeReplaceSymbol() string {
 	return "osty_rt_strings_Replace"
 }
 
+// Osty: toolchain/llvmgen.osty:2647:5
 func llvmStringRuntimeReplaceAllSymbol() string {
 	return "osty_rt_strings_ReplaceAll"
 }
 
+// Osty: toolchain/llvmgen.osty:2651:5
 func llvmStringRuntimeSliceSymbol() string {
 	return "osty_rt_strings_Slice"
 }
 
+// Osty: toolchain/llvmgen.osty:2655:5
 func llvmStringRuntimeTrimStartSymbol() string {
 	return "osty_rt_strings_TrimStart"
 }
 
+// Osty: toolchain/llvmgen.osty:2659:5
 func llvmStringRuntimeTrimEndSymbol() string {
 	return "osty_rt_strings_TrimEnd"
 }
 
+// Osty: toolchain/llvmgen.osty:2663:5
 func llvmStringRuntimeTrimPrefixSymbol() string {
 	return "osty_rt_strings_TrimPrefix"
 }
 
+// Osty: toolchain/llvmgen.osty:2667:5
 func llvmStringRuntimeTrimSuffixSymbol() string {
 	return "osty_rt_strings_TrimSuffix"
 }
 
+// Osty: toolchain/llvmgen.osty:2671:5
 func llvmStringRuntimeTrimSpaceSymbol() string {
 	return "osty_rt_strings_TrimSpace"
 }
 
+// Osty: toolchain/llvmgen.osty:2675:5
 func llvmStringRuntimeCharsSymbol() string {
 	return "osty_rt_strings_Chars"
 }
 
+// Osty: toolchain/llvmgen.osty:2679:5
 func llvmStringRuntimeBytesSymbol() string {
 	return "osty_rt_strings_Bytes"
 }
 
+// Osty: toolchain/llvmgen.osty:2683:5
 func llvmStringRuntimeToBytesSymbol() string {
 	return "osty_rt_strings_ToBytes"
 }
 
+// Osty: toolchain/llvmgen.osty:2693:5
 func llvmStringRuntimeDeclarations() []string {
-	return []string{
-		"declare i1 @osty_rt_strings_Equal(ptr, ptr)",
-		"declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)",
-		"declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)",
-		"declare i1 @osty_rt_strings_Contains(ptr, ptr)",
-		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
-		"declare ptr @osty_rt_strings_Concat(ptr, ptr)",
-		"declare ptr @osty_rt_int_to_string(i64)",
-		"declare ptr @osty_rt_float_to_string(double)",
-		"declare ptr @osty_rt_bool_to_string(i1)",
-		"declare i64 @osty_rt_strings_ByteLen(ptr)",
-		"declare i64 @osty_rt_strings_Compare(ptr, ptr)",
-		"declare i64 @osty_rt_strings_Count(ptr, ptr)",
-		"declare i64 @osty_rt_strings_IndexOf(ptr, ptr)",
-		"declare ptr @osty_rt_strings_Join(ptr, ptr)",
-		"declare ptr @osty_rt_strings_Repeat(ptr, i64)",
-		"declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)",
-		"declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)",
-		"declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
-		"declare ptr @osty_rt_strings_TrimStart(ptr)",
-		"declare ptr @osty_rt_strings_TrimEnd(ptr)",
-		"declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)",
-		"declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)",
-		"declare ptr @osty_rt_strings_TrimSpace(ptr)",
-		"declare ptr @osty_rt_strings_Chars(ptr)",
-		"declare ptr @osty_rt_strings_Bytes(ptr)",
-		"declare ptr @osty_rt_strings_ToBytes(ptr)",
-	}
+	return []string{"declare i1 @osty_rt_strings_Equal(ptr, ptr)", "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)", "declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)", "declare i1 @osty_rt_strings_Contains(ptr, ptr)", "declare ptr @osty_rt_strings_Split(ptr, ptr)", "declare ptr @osty_rt_strings_Concat(ptr, ptr)", "declare ptr @osty_rt_int_to_string(i64)", "declare ptr @osty_rt_float_to_string(double)", "declare ptr @osty_rt_bool_to_string(i1)", "declare i64 @osty_rt_strings_ByteLen(ptr)", "declare i64 @osty_rt_strings_Count(ptr, ptr)", "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "declare i64 @osty_rt_strings_Compare(ptr, ptr)", "declare ptr @osty_rt_strings_Join(ptr, ptr)", "declare ptr @osty_rt_strings_Repeat(ptr, i64)", "declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_Slice(ptr, i64, i64)", "declare ptr @osty_rt_strings_TrimStart(ptr)", "declare ptr @osty_rt_strings_TrimEnd(ptr)", "declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSpace(ptr)", "declare ptr @osty_rt_strings_Chars(ptr)", "declare ptr @osty_rt_strings_Bytes(ptr)", "declare ptr @osty_rt_strings_ToBytes(ptr)"}
 }
 
+// Osty: toolchain/llvmgen.osty:2724:5
 func llvmStringEqual(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_strings_Equal", []*LlvmValue{left, right})
 }
 
+// Osty: toolchain/llvmgen.osty:2728:5
 func llvmStringHasPrefix(emitter *LlvmEmitter, value *LlvmValue, prefix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_strings_HasPrefix", []*LlvmValue{value, prefix})
 }
 
+// Osty: toolchain/llvmgen.osty:2732:5
 func llvmStringHasSuffix(emitter *LlvmEmitter, value *LlvmValue, suffix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i1", "osty_rt_strings_HasSuffix", []*LlvmValue{value, suffix})
 }
 
+// Osty: toolchain/llvmgen.osty:2736:5
 func llvmStringSplit(emitter *LlvmEmitter, value *LlvmValue, sep *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Split", []*LlvmValue{value, sep})
 }
 
+// Osty: toolchain/llvmgen.osty:2740:5
 func llvmStringConcat(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Concat", []*LlvmValue{left, right})
 }
 
+// Osty: toolchain/llvmgen.osty:2744:5
 func llvmIntRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_int_to_string", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2748:5
 func llvmFloatRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_float_to_string", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2752:5
 func llvmBoolRuntimeToString(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_bool_to_string", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2756:5
 func llvmStringCompare(emitter *LlvmEmitter, op string, left *LlvmValue, right *LlvmValue) *LlvmValue {
+	// Osty: toolchain/llvmgen.osty:2762:5
 	if op == "==" {
+		// Osty: toolchain/llvmgen.osty:2763:9
 		return llvmStringEqual(emitter, left, right)
 	}
+	// Osty: toolchain/llvmgen.osty:2765:5
 	if op == "!=" {
+		// Osty: toolchain/llvmgen.osty:2766:9
 		return llvmNotI1(emitter, llvmStringEqual(emitter, left, right))
 	}
+	// Osty: toolchain/llvmgen.osty:2768:5
 	cmp := llvmStringRuntimeCompare(emitter, left, right)
+	_ = cmp
 	return llvmCompare(emitter, llvmIntComparePredicate(op), cmp, llvmIntLiteral(0))
 }
 
+// Osty: toolchain/llvmgen.osty:2772:5
 func llvmStringByteLen(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", []*LlvmValue{value})
 }
 
-func llvmStringRuntimeCompare(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
-	return llvmCall(emitter, "i64", "osty_rt_strings_Compare", []*LlvmValue{left, right})
-}
-
+// Osty: toolchain/llvmgen.osty:2776:5
 func llvmStringRuntimeCount(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_strings_Count", []*LlvmValue{value, substr})
 }
 
+// Osty: toolchain/llvmgen.osty:2784:5
 func llvmStringRuntimeIndexOf(emitter *LlvmEmitter, value *LlvmValue, substr *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "i64", "osty_rt_strings_IndexOf", []*LlvmValue{value, substr})
 }
 
+// Osty: toolchain/llvmgen.osty:2792:5
+func llvmStringRuntimeCompare(emitter *LlvmEmitter, left *LlvmValue, right *LlvmValue) *LlvmValue {
+	return llvmCall(emitter, "i64", "osty_rt_strings_Compare", []*LlvmValue{left, right})
+}
+
+// Osty: toolchain/llvmgen.osty:2800:5
 func llvmStringRuntimeJoin(emitter *LlvmEmitter, parts *LlvmValue, sep *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Join", []*LlvmValue{parts, sep})
 }
 
+// Osty: toolchain/llvmgen.osty:2808:5
 func llvmStringRuntimeRepeat(emitter *LlvmEmitter, value *LlvmValue, n *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Repeat", []*LlvmValue{value, n})
 }
 
+// Osty: toolchain/llvmgen.osty:2816:5
 func llvmStringRuntimeReplace(emitter *LlvmEmitter, value *LlvmValue, old *LlvmValue, newValue *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Replace", []*LlvmValue{value, old, newValue})
 }
 
+// Osty: toolchain/llvmgen.osty:2825:5
 func llvmStringRuntimeReplaceAll(emitter *LlvmEmitter, value *LlvmValue, old *LlvmValue, newValue *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_ReplaceAll", []*LlvmValue{value, old, newValue})
 }
 
+// Osty: toolchain/llvmgen.osty:2834:5
 func llvmStringRuntimeSlice(emitter *LlvmEmitter, value *LlvmValue, start *LlvmValue, end *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Slice", []*LlvmValue{value, start, end})
 }
 
+// Osty: toolchain/llvmgen.osty:2843:5
 func llvmStringRuntimeTrimStart(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimStart", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2847:5
 func llvmStringRuntimeTrimEnd(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimEnd", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2851:5
 func llvmStringRuntimeTrimPrefix(emitter *LlvmEmitter, value *LlvmValue, prefix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimPrefix", []*LlvmValue{value, prefix})
 }
 
+// Osty: toolchain/llvmgen.osty:2859:5
 func llvmStringRuntimeTrimSuffix(emitter *LlvmEmitter, value *LlvmValue, suffix *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimSuffix", []*LlvmValue{value, suffix})
 }
 
+// Osty: toolchain/llvmgen.osty:2867:5
 func llvmStringRuntimeTrimSpace(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_TrimSpace", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2871:5
 func llvmStringChars(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Chars", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2875:5
 func llvmStringBytes(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_Bytes", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2879:5
 func llvmStringToBytes(emitter *LlvmEmitter, value *LlvmValue) *LlvmValue {
 	return llvmCall(emitter, "ptr", "osty_rt_strings_ToBytes", []*LlvmValue{value})
 }
 
+// Osty: toolchain/llvmgen.osty:2883:5
 func llvmBuiltinType(name string) string {
-	switch name {
-	case "Int":
+	// Osty: toolchain/llvmgen.osty:2884:5
+	if name == "Int" {
+		// Osty: toolchain/llvmgen.osty:2885:9
 		return "i64"
-	case "Float":
+	}
+	// Osty: toolchain/llvmgen.osty:2887:5
+	if name == "Float" {
+		// Osty: toolchain/llvmgen.osty:2888:9
 		return "double"
-	case "Bool":
+	}
+	// Osty: toolchain/llvmgen.osty:2890:5
+	if name == "Bool" {
+		// Osty: toolchain/llvmgen.osty:2891:9
 		return "i1"
-	case "Char":
+	}
+	// Osty: toolchain/llvmgen.osty:2893:5
+	if name == "Char" {
+		// Osty: toolchain/llvmgen.osty:2894:9
 		return "i32"
-	case "Byte":
+	}
+	// Osty: toolchain/llvmgen.osty:2896:5
+	if name == "Byte" {
+		// Osty: toolchain/llvmgen.osty:2897:9
 		return "i8"
-	case "String", "Bytes", "Error":
+	}
+	// Osty: toolchain/llvmgen.osty:2899:5
+	if name == "String" || name == "Bytes" || name == "Error" {
+		// Osty: toolchain/llvmgen.osty:2900:9
 		return "ptr"
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:2905:5
 func llvmRuntimeAbiBuiltinType(name string) string {
-	switch name {
-	case "Int", "Float", "Bool", "Char", "Byte", "String":
+	// Osty: toolchain/llvmgen.osty:2906:5
+	if name == "Int" || name == "Float" || name == "Bool" || name == "Char" || name == "Byte" || name == "String" {
+		// Osty: toolchain/llvmgen.osty:2907:9
 		return llvmBuiltinType(name)
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:2912:5
 func llvmEnumPayloadBuiltinType(name string) string {
-	switch name {
-	case "Int", "Float", "Char", "Byte", "String":
+	// Osty: toolchain/llvmgen.osty:2913:5
+	if name == "Int" || name == "Float" || name == "Char" || name == "Byte" || name == "String" {
+		// Osty: toolchain/llvmgen.osty:2914:9
 		return llvmBuiltinType(name)
-	default:
-		return ""
 	}
+	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:2919:5
 func llvmZeroLiteral(typ string) string {
-	switch typ {
-	case "double":
+	// Osty: toolchain/llvmgen.osty:2920:5
+	if typ == "double" {
+		// Osty: toolchain/llvmgen.osty:2921:9
 		return "0.0"
-	case "ptr":
-		return "null"
-	default:
-		return "0"
 	}
+	// Osty: toolchain/llvmgen.osty:2923:5
+	if typ == "ptr" {
+		// Osty: toolchain/llvmgen.osty:2924:9
+		return "null"
+	}
+	return "0"
 }
 
+// Osty: toolchain/llvmgen.osty:2929:5
 func llvmStructTypeName(name string) string {
-	return "%" + name
+	return fmt.Sprintf("%%%s", ostyToString(name))
 }
 
+// Osty: toolchain/llvmgen.osty:2933:5
 func llvmEnumStorageType(name string, hasPayload bool) string {
+	// Osty: toolchain/llvmgen.osty:2934:5
 	if hasPayload {
+		// Osty: toolchain/llvmgen.osty:2935:9
 		return llvmStructTypeName(name)
 	}
 	return "i64"
 }
 
+// Osty: toolchain/llvmgen.osty:2940:5
 func llvmSignatureParamName(name string, index int) string {
+	// Osty: toolchain/llvmgen.osty:2941:5
 	if name != "" {
+		// Osty: toolchain/llvmgen.osty:2942:9
 		return name
 	}
-	return fmt.Sprintf("arg%d", index)
+	return fmt.Sprintf("arg%s", ostyToString(index))
 }
 
+// Osty: toolchain/llvmgen.osty:2947:5
 func llvmAllowsMainSignature(paramCount int, hasReturnType bool) bool {
-	return paramCount == 0 && !hasReturnType
+	return paramCount == 0 && !(hasReturnType)
 }
 
+// Osty: toolchain/llvmgen.osty:2951:5
 func llvmNamedType(name string, pathLen int, argLen int, structType string, enumType string) string {
+	// Osty: toolchain/llvmgen.osty:2958:5
 	if pathLen != 1 || argLen != 0 {
+		// Osty: toolchain/llvmgen.osty:2959:9
 		return "ptr"
 	}
-	if builtin := llvmBuiltinType(name); builtin != "" {
+	// Osty: toolchain/llvmgen.osty:2961:5
+	builtin := llvmBuiltinType(name)
+	_ = builtin
+	// Osty: toolchain/llvmgen.osty:2962:5
+	if builtin != "" {
+		// Osty: toolchain/llvmgen.osty:2963:9
 		return builtin
 	}
+	// Osty: toolchain/llvmgen.osty:2965:5
 	if structType != "" {
+		// Osty: toolchain/llvmgen.osty:2966:9
 		return structType
 	}
+	// Osty: toolchain/llvmgen.osty:2968:5
 	if enumType != "" {
+		// Osty: toolchain/llvmgen.osty:2969:9
 		return enumType
 	}
 	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:2974:5
 func llvmRuntimeAbiNamedType(name string, pathLen int, argLen int, structType string, enumType string) string {
+	// Osty: toolchain/llvmgen.osty:2981:5
 	if pathLen == 1 && argLen == 0 {
-		if builtin := llvmRuntimeAbiBuiltinType(name); builtin != "" {
+		// Osty: toolchain/llvmgen.osty:2982:9
+		builtin := llvmRuntimeAbiBuiltinType(name)
+		_ = builtin
+		// Osty: toolchain/llvmgen.osty:2983:9
+		if builtin != "" {
+			// Osty: toolchain/llvmgen.osty:2984:13
 			return builtin
 		}
+		// Osty: toolchain/llvmgen.osty:2986:9
 		if structType != "" {
+			// Osty: toolchain/llvmgen.osty:2987:13
 			return structType
 		}
+		// Osty: toolchain/llvmgen.osty:2989:9
 		if enumType != "" {
+			// Osty: toolchain/llvmgen.osty:2990:13
 			return enumType
 		}
 	}
 	return "ptr"
 }
 
+// Osty: toolchain/llvmgen.osty:2996:5
 func llvmEnumPayloadNamedType(name string, pathLen int, argLen int) string {
+	// Osty: toolchain/llvmgen.osty:2997:5
 	if pathLen != 1 || argLen != 0 {
+		// Osty: toolchain/llvmgen.osty:2998:9
 		return ""
 	}
 	return llvmEnumPayloadBuiltinType(name)
 }
 
+// Osty: toolchain/llvmgen.osty:3003:5
 func llvmNominalDeclHeaderDiagnostic(kind string, name string, identOk bool, genericCount int, methodCount int) *LlvmUnsupportedDiagnostic {
-	if !identOk {
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("%s name %q", kind, name))
+	// Osty: toolchain/llvmgen.osty:3010:5
+	if !(identOk) {
+		// Osty: toolchain/llvmgen.osty:3011:9
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("%s name \"%s\"", ostyToString(kind), ostyToString(name)))
 	}
+	// Osty: toolchain/llvmgen.osty:3013:5
 	if genericCount != 0 {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("generic %s %q is not supported", kind, name))
+		// Osty: toolchain/llvmgen.osty:3014:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("generic %s \"%s\" is not supported", ostyToString(kind), ostyToString(name)))
+	}
+	// Osty: toolchain/llvmgen.osty:3019:5
+	if methodCount != 0 {
+		// Osty: toolchain/llvmgen.osty:3020:9
+		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("%s \"%s\" methods are not supported", ostyToString(kind), ostyToString(name)))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
+// Osty: toolchain/llvmgen.osty:3028:5
 func llvmFunctionHeaderDiagnostic(name string, identOk bool, hasRecv bool, genericCount int, hasBody bool, isMain bool, paramCount int, hasReturnType bool) *LlvmUnsupportedDiagnostic {
-	if !identOk {
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("function name %q", name))
+	// Osty: toolchain/llvmgen.osty:3038:5
+	if !(identOk) {
+		// Osty: toolchain/llvmgen.osty:3039:9
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("function name \"%s\"", ostyToString(name)))
 	}
+	// Osty: toolchain/llvmgen.osty:3041:5
+	if hasRecv {
+		// Osty: toolchain/llvmgen.osty:3042:9
+		return llvmUnsupportedDiagnostic("function-signature", "methods are not supported")
+	}
+	// Osty: toolchain/llvmgen.osty:3044:5
 	if genericCount != 0 {
+		// Osty: toolchain/llvmgen.osty:3045:9
 		return llvmUnsupportedDiagnostic("function-signature", "generic functions are not supported")
 	}
-	if !hasBody {
-		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("function %q has no body", name))
+	// Osty: toolchain/llvmgen.osty:3050:5
+	if !(hasBody) {
+		// Osty: toolchain/llvmgen.osty:3051:9
+		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("function \"%s\" has no body", ostyToString(name)))
 	}
-	if isMain && !llvmAllowsMainSignature(paramCount, hasReturnType) {
+	// Osty: toolchain/llvmgen.osty:3053:5
+	if isMain && !(llvmAllowsMainSignature(paramCount, hasReturnType)) {
+		// Osty: toolchain/llvmgen.osty:3054:9
 		return llvmUnsupportedDiagnostic("function-signature", "LLVM main must have no params and no return type")
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
+// Osty: toolchain/llvmgen.osty:3062:5
 func llvmIsRuntimeAbiListType(name string, pathLen int, argLen int) bool {
 	return name == "List" && pathLen == 1 && argLen == 1
 }
 
+// Osty: toolchain/llvmgen.osty:3066:5
 func llvmStructFieldDiagnostic(structName string, fieldName string, identOk bool, hasDefault bool, duplicate bool, recursive bool, detail string) *LlvmUnsupportedDiagnostic {
-	if !identOk {
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("struct %q field name %q", structName, fieldName))
+	// Osty: toolchain/llvmgen.osty:3075:5
+	if !(identOk) {
+		// Osty: toolchain/llvmgen.osty:3076:9
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("struct \"%s\" field name \"%s\"", ostyToString(structName), ostyToString(fieldName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3081:5
 	if hasDefault {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct %q field %q has a default value", structName, fieldName))
+		// Osty: toolchain/llvmgen.osty:3082:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct \"%s\" field \"%s\" has a default value", ostyToString(structName), ostyToString(fieldName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3087:5
 	if duplicate {
-		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("struct %q duplicate field %q", structName, fieldName))
+		// Osty: toolchain/llvmgen.osty:3088:9
+		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("struct \"%s\" duplicate field \"%s\"", ostyToString(structName), ostyToString(fieldName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3093:5
 	if detail != "" {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct %q field %q: %s", structName, fieldName, detail))
+		// Osty: toolchain/llvmgen.osty:3094:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("struct \"%s\" field \"%s\": %s", ostyToString(structName), ostyToString(fieldName), ostyToString(detail)))
 	}
+	// Osty: toolchain/llvmgen.osty:3099:5
 	if recursive {
-		return llvmUnsupportedDiagnosticWith(
-			"LLVM011",
-			"type-system",
-			fmt.Sprintf("struct %q recursive field %q requires indirection", structName, fieldName),
-			"break the cycle via an arena index (Int id) or List<T> handle until the LLVM backend grows recursive-struct support",
-		)
+		// Osty: toolchain/llvmgen.osty:3100:9
+		return llvmUnsupportedDiagnosticWith("LLVM011", "type-system", fmt.Sprintf("struct \"%s\" recursive field \"%s\" requires indirection", ostyToString(structName), ostyToString(fieldName)), "break the cycle via an arena index (Int id) or List<T> handle until the LLVM backend grows recursive-struct support")
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
+// Osty: toolchain/llvmgen.osty:3110:5
 func llvmEnumVariantHeaderDiagnostic(enumName string, variantName string, identOk bool, payloadCount int, duplicate bool) *LlvmUnsupportedDiagnostic {
-	if !identOk {
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("enum %q variant name %q", enumName, variantName))
+	// Osty: toolchain/llvmgen.osty:3117:5
+	if !(identOk) {
+		// Osty: toolchain/llvmgen.osty:3118:9
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("enum \"%s\" variant name \"%s\"", ostyToString(enumName), ostyToString(variantName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3123:5
 	if duplicate {
-		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("enum %q duplicate variant %q", enumName, variantName))
+		// Osty: toolchain/llvmgen.osty:3124:9
+		return llvmUnsupportedDiagnostic("source-layout", fmt.Sprintf("enum \"%s\" duplicate variant \"%s\"", ostyToString(enumName), ostyToString(variantName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3129:5
 	_ = payloadCount
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
+// Osty: toolchain/llvmgen.osty:3133:5
 func llvmEnumBoxedMultiFieldDiagnostic(enumName string, variantName string, payloadCount int) *LlvmUnsupportedDiagnostic {
-	return llvmUnsupportedDiagnosticWith(
-		"LLVM011",
-		"type-system",
-		fmt.Sprintf("enum %q variant %q has %d payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet", enumName, variantName, payloadCount),
-		"keep a single boxed payload per variant, or make all variant payloads share one scalar/pointer type so the inline multi-slot layout can be used",
-	)
+	return llvmUnsupportedDiagnosticWith("LLVM011", "type-system", fmt.Sprintf("enum \"%s\" variant \"%s\" has %s payload fields with heterogeneous types across variants; boxed multi-field payloads are not supported yet", ostyToString(enumName), ostyToString(variantName), ostyToString(payloadCount)), "keep a single boxed payload per variant, or make all variant payloads share one scalar/pointer type so the inline multi-slot layout can be used")
 }
 
+// Osty: toolchain/llvmgen.osty:3146:5
 func llvmEnumPayloadDiagnostic(enumName string, variantName string, detail string, expectedType string, actualType string) *LlvmUnsupportedDiagnostic {
+	// Osty: toolchain/llvmgen.osty:3153:5
 	if detail != "" {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q variant %q payload: %s", enumName, variantName, detail))
+		// Osty: toolchain/llvmgen.osty:3154:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum \"%s\" variant \"%s\" payload: %s", ostyToString(enumName), ostyToString(variantName), ostyToString(detail)))
 	}
+	// Osty: toolchain/llvmgen.osty:3159:5
 	if expectedType != "" && actualType != "" && expectedType != actualType {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum %q mixes payload types %s and %s; heterogeneous-payload enums require boxed representation (deferred)", enumName, expectedType, actualType))
+		// Osty: toolchain/llvmgen.osty:3160:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("enum \"%s\" mixes payload types %s and %s; heterogeneous-payload enums require boxed representation (deferred)", ostyToString(enumName), ostyToString(expectedType), ostyToString(actualType)))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
+// Osty: toolchain/llvmgen.osty:3168:5
 func llvmRuntimeFfiHeaderUnsupported(hasRecv bool, genericCount int) string {
+	// Osty: toolchain/llvmgen.osty:3169:5
 	if hasRecv {
+		// Osty: toolchain/llvmgen.osty:3170:9
 		return "methods are not supported"
 	}
+	// Osty: toolchain/llvmgen.osty:3172:5
 	if genericCount != 0 {
+		// Osty: toolchain/llvmgen.osty:3173:9
 		return "generic functions are not supported"
 	}
 	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:3178:5
 func llvmRuntimeFfiReturnUnsupported(detail string) string {
+	// Osty: toolchain/llvmgen.osty:3179:5
 	if detail != "" {
-		return "return type: " + detail
+		// Osty: toolchain/llvmgen.osty:3180:9
+		return fmt.Sprintf("return type: %s", ostyToString(detail))
 	}
 	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:3185:5
 func llvmRuntimeFfiParamUnsupported(name string, nilParam bool, hasPatternOrDefault bool, detail string) string {
+	// Osty: toolchain/llvmgen.osty:3191:5
 	if nilParam {
+		// Osty: toolchain/llvmgen.osty:3192:9
 		return "nil parameter"
 	}
+	// Osty: toolchain/llvmgen.osty:3194:5
 	if hasPatternOrDefault {
+		// Osty: toolchain/llvmgen.osty:3195:9
 		return "pattern/default parameters are not supported"
 	}
+	// Osty: toolchain/llvmgen.osty:3197:5
 	if detail != "" {
-		return fmt.Sprintf("parameter %q: %s", name, detail)
+		// Osty: toolchain/llvmgen.osty:3198:9
+		return fmt.Sprintf("parameter \"%s\": %s", ostyToString(name), ostyToString(detail))
 	}
 	return ""
 }
 
+// Osty: toolchain/llvmgen.osty:3203:5
 func llvmFunctionReturnDiagnostic(name string, detail string) *LlvmUnsupportedDiagnostic {
+	// Osty: toolchain/llvmgen.osty:3204:5
 	if detail != "" {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function %q return type: %s", name, detail))
+		// Osty: toolchain/llvmgen.osty:3205:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function \"%s\" return type: %s", ostyToString(name), ostyToString(detail)))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
+// Osty: toolchain/llvmgen.osty:3210:5
 func llvmFunctionParamDiagnostic(fnName string, paramName string, missingOrPattern bool, hasDefault bool, identOk bool, detail string) *LlvmUnsupportedDiagnostic {
+	// Osty: toolchain/llvmgen.osty:3218:5
 	if missingOrPattern {
-		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function %q has non-identifier parameter", fnName))
+		// Osty: toolchain/llvmgen.osty:3219:9
+		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function \"%s\" has non-identifier parameter", ostyToString(fnName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3224:5
 	if hasDefault {
-		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function %q has default parameter values", fnName))
+		// Osty: toolchain/llvmgen.osty:3225:9
+		return llvmUnsupportedDiagnostic("function-signature", fmt.Sprintf("function \"%s\" has default parameter values", ostyToString(fnName)))
 	}
-	if !identOk {
-		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("parameter name %q", paramName))
+	// Osty: toolchain/llvmgen.osty:3230:5
+	if !(identOk) {
+		// Osty: toolchain/llvmgen.osty:3231:9
+		return llvmUnsupportedDiagnostic("name", fmt.Sprintf("parameter name \"%s\"", ostyToString(paramName)))
 	}
+	// Osty: toolchain/llvmgen.osty:3233:5
 	if detail != "" {
-		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function %q parameter %q: %s", fnName, paramName, detail))
+		// Osty: toolchain/llvmgen.osty:3234:9
+		return llvmUnsupportedDiagnostic("type-system", fmt.Sprintf("function \"%s\" parameter \"%s\": %s", ostyToString(fnName), ostyToString(paramName), ostyToString(detail)))
 	}
 	return llvmUnsupportedDiagnosticWith("", "", "", "")
 }
 
-// Osty: toolchain/llvmgen.osty:875:5
+// Osty: toolchain/llvmgen.osty:3242:5
 func llvmSmokeExecutableCorpus() []*LlvmSmokeExecutableCase {
 	return []*LlvmSmokeExecutableCase{&LlvmSmokeExecutableCase{name: "minimal", fixture: "minimal_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "scalar", fixture: "scalar_arithmetic.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "control", fixture: "control_flow.osty", stdout: "15\n"}, &LlvmSmokeExecutableCase{name: "booleans", fixture: "booleans.osty", stdout: "7\n"}, &LlvmSmokeExecutableCase{name: "string", fixture: "string_print.osty", stdout: "hello, osty\n"}, &LlvmSmokeExecutableCase{name: "string-escape", fixture: "string_escape_print.osty", stdout: "line one\nquote \" slash \\\n"}, &LlvmSmokeExecutableCase{name: "string-let", fixture: "string_let_print.osty", stdout: "stored string\n"}, &LlvmSmokeExecutableCase{name: "string-return", fixture: "string_return_print.osty", stdout: "from function\n"}, &LlvmSmokeExecutableCase{name: "string-param", fixture: "string_param_print.osty", stdout: "param string\n"}, &LlvmSmokeExecutableCase{name: "string-mut", fixture: "string_mut_print.osty", stdout: "after\n"}, &LlvmSmokeExecutableCase{name: "struct-field", fixture: "struct_field_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-return", fixture: "struct_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-param", fixture: "struct_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-mut", fixture: "struct_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-variant", fixture: "enum_variant_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-return", fixture: "enum_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-param", fixture: "enum_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-mut", fixture: "enum_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match", fixture: "enum_match_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match-return", fixture: "enum_match_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match-param", fixture: "enum_match_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-match-mut", fixture: "enum_match_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload", fixture: "enum_payload_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload-return", fixture: "enum_payload_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload-param", fixture: "enum_payload_param_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "enum-payload-mut", fixture: "enum_payload_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "float-print", fixture: "float_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-arithmetic", fixture: "float_arithmetic_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-return", fixture: "float_return_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-param", fixture: "float_param_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-mutable", fixture: "float_mut_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-compare", fixture: "float_compare_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-struct", fixture: "float_struct_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-enum-payload", fixture: "float_enum_payload_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-return", fixture: "float_payload_return_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-param", fixture: "float_payload_param_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-mut", fixture: "float_payload_mut_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-reversed", fixture: "float_payload_reversed_match_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "float-payload-wildcard", fixture: "float_payload_wildcard_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "string-payload-return", fixture: "string_payload_return_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-param", fixture: "string_payload_param_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-mut", fixture: "string_payload_mut_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-reversed", fixture: "string_payload_reversed_match_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "string-payload-wildcard", fixture: "string_payload_wildcard_print.osty", stdout: "payload string\n"}, &LlvmSmokeExecutableCase{name: "int-if-expr", fixture: "int_if_expr_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "string-if-expr", fixture: "string_if_expr_print.osty", stdout: "chosen string\n"}, &LlvmSmokeExecutableCase{name: "float-if-expr", fixture: "float_if_expr_print.osty", stdout: "42.000000\n"}, &LlvmSmokeExecutableCase{name: "bool-param-return", fixture: "bool_param_return_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "int-range-exclusive", fixture: "int_range_exclusive_print.osty", stdout: "21\n"}, &LlvmSmokeExecutableCase{name: "int-unary", fixture: "int_unary_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "int-modulo", fixture: "int_modulo_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "struct-string-field", fixture: "struct_string_field_print.osty", stdout: "struct string\n"}, &LlvmSmokeExecutableCase{name: "struct-bool-field", fixture: "struct_bool_field_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "bool-mut", fixture: "bool_mut_print.osty", stdout: "42\n"}, &LlvmSmokeExecutableCase{name: "result-question-int", fixture: "result_question_int_print.osty", stdout: "42\n"}}
 }
 
-// Osty: toolchain/llvmgen.osty:1150:5
+// Osty: toolchain/llvmgen.osty:3522:5
 func llvmSmokeMinimalPrintIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1151:5
+	// Osty: toolchain/llvmgen.osty:3523:5
 	emitter := llvmEmitter()
 	_ = emitter
-	// Osty: toolchain/llvmgen.osty:1152:5
+	// Osty: toolchain/llvmgen.osty:3524:5
 	value := llvmBinaryI64(emitter, "add", llvmIntLiteral(40), llvmIntLiteral(2))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1153:5
+	// Osty: toolchain/llvmgen.osty:3525:5
 	llvmPrintlnI64(emitter, value)
-	// Osty: toolchain/llvmgen.osty:1154:5
+	// Osty: toolchain/llvmgen.osty:3526:5
 	llvmReturnI32Zero(emitter)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), emitter.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1164:5
+// Osty: toolchain/llvmgen.osty:3536:5
 func llvmSmokeGcRuntimeAbiIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1165:5
+	// Osty: toolchain/llvmgen.osty:3537:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1166:5
+	// Osty: toolchain/llvmgen.osty:3538:5
 	object := llvmGcAlloc(main, 1, 32, "llvm.gc.object")
 	_ = object
-	// Osty: toolchain/llvmgen.osty:1167:5
+	// Osty: toolchain/llvmgen.osty:3539:5
 	llvmGcRootBind(main, object)
-	// Osty: toolchain/llvmgen.osty:1168:5
+	// Osty: toolchain/llvmgen.osty:3540:5
 	child := llvmGcAlloc(main, 2, 16, "llvm.gc.child")
 	_ = child
-	// Osty: toolchain/llvmgen.osty:1169:5
+	// Osty: toolchain/llvmgen.osty:3541:5
 	llvmGcPreWrite(main, object, child, 0)
-	// Osty: toolchain/llvmgen.osty:1170:5
+	// Osty: toolchain/llvmgen.osty:3542:5
 	loaded := llvmGcLoad(main, child)
 	_ = loaded
-	// Osty: toolchain/llvmgen.osty:1171:5
+	// Osty: toolchain/llvmgen.osty:3543:5
 	llvmGcPostWrite(main, object, loaded, 0)
-	// Osty: toolchain/llvmgen.osty:1172:5
+	// Osty: toolchain/llvmgen.osty:3544:5
 	llvmGcRootRelease(main, object)
-	// Osty: toolchain/llvmgen.osty:1173:5
+	// Osty: toolchain/llvmgen.osty:3545:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGcRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty (llvmSmokeListBasicIR)
-func llvmSmokeListBasicIR(sourcePath string) string {
-	main := llvmEmitter()
-	list := llvmListNew(main)
-	llvmListPushI64(main, list, llvmIntLiteral(10))
-	llvmListPushI64(main, list, llvmIntLiteral(20))
-	llvmListPushI64(main, list, llvmIntLiteral(30))
-	length := llvmListLen(main, list)
-	llvmPrintlnI64(main, length)
-	second := llvmListGetI64(main, list, llvmIntLiteral(1))
-	llvmPrintlnI64(main, second)
-	llvmReturnI32Zero(main)
-	return llvmRenderModuleWithListRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
-}
-
-// Osty: toolchain/llvmgen.osty (llvmSmokeClosureThunkIR)
+// Osty: toolchain/llvmgen.osty:3565:5
 func llvmSmokeClosureThunkIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3566:5
 	doubleBody := llvmEmitter()
+	_ = doubleBody
+	// Osty: toolchain/llvmgen.osty:3567:5
 	llvmBind(doubleBody, "x", &LlvmValue{typ: "i64", name: "%x", pointer: false})
+	// Osty: toolchain/llvmgen.osty:3568:5
 	doubled := llvmBinaryI64(doubleBody, "mul", llvmIdent(doubleBody, "x"), llvmIntLiteral(2))
+	_ = doubled
+	// Osty: toolchain/llvmgen.osty:3574:5
 	llvmReturn(doubleBody, doubled)
-
+	// Osty: toolchain/llvmgen.osty:3576:5
 	main := llvmEmitter()
+	_ = main
+	// Osty: toolchain/llvmgen.osty:3577:5
 	env := llvmClosureBareFnEnv(main, "double_val")
+	_ = env
+	// Osty: toolchain/llvmgen.osty:3578:5
 	envTypeName := llvmClosureEnvTypeName([]string{"ptr"})
+	_ = envTypeName
+	// Osty: toolchain/llvmgen.osty:3579:5
 	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{llvmIntLiteral(21)})
+	_ = result
+	// Osty: toolchain/llvmgen.osty:3586:5
 	llvmPrintlnI64(main, result)
+	// Osty: toolchain/llvmgen.osty:3587:5
 	llvmReturnI32Zero(main)
-
-	return llvmRenderModuleWithGlobalsAndTypes(
-		sourcePath,
-		"",
-		[]string{llvmClosureBareFnEnvTypeDef()},
-		main.stringGlobals,
-		[]string{
-			llvmRenderFunction("i64", "double_val", []*LlvmParam{llvmParam("x", "i64")}, doubleBody.body),
-			llvmClosureThunkDefinition("double_val", "i64", []string{"i64"}),
-			llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body),
-		},
-	)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmClosureBareFnEnvTypeDef()}, main.stringGlobals, []string{llvmRenderFunction("i64", "double_val", []*LlvmParam{llvmParam("x", "i64")}, doubleBody.body), llvmClosureThunkDefinition("double_val", "i64", []string{"i64"}), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty (llvmSmokeClosureBasicIR)
+// Osty: toolchain/llvmgen.osty:3614:5
 func llvmSmokeClosureBasicIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3615:5
 	envTypeName := llvmClosureEnvTypeName([]string{"ptr", "i64"})
+	_ = envTypeName
+	// Osty: toolchain/llvmgen.osty:3616:5
 	typeDef := llvmClosureEnvTypeDef(envTypeName, []string{"ptr", "i64"})
-
+	_ = typeDef
+	// Osty: toolchain/llvmgen.osty:3618:5
 	body := llvmEmitter()
+	_ = body
+	// Osty: toolchain/llvmgen.osty:3619:5
 	llvmBind(body, "env", &LlvmValue{typ: "ptr", name: "%env", pointer: false})
+	// Osty: toolchain/llvmgen.osty:3620:5
 	envArg := llvmIdent(body, "env")
+	_ = envArg
+	// Osty: toolchain/llvmgen.osty:3621:5
 	captured := llvmClosureEnvLoadCapture(body, envArg, envTypeName, 1, "i64")
+	_ = captured
+	// Osty: toolchain/llvmgen.osty:3622:5
 	llvmReturn(body, captured)
-
+	// Osty: toolchain/llvmgen.osty:3624:5
 	main := llvmEmitter()
+	_ = main
+	// Osty: toolchain/llvmgen.osty:3625:5
 	env := llvmClosureEnvAlloc(main, envTypeName)
+	_ = env
+	// Osty: toolchain/llvmgen.osty:3626:5
 	llvmClosureEnvStoreFn(main, env, envTypeName, "closure_body")
+	// Osty: toolchain/llvmgen.osty:3627:5
 	llvmClosureEnvStoreCapture(main, env, envTypeName, 1, llvmIntLiteral(42))
-	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", []*LlvmValue{})
+	// Osty: toolchain/llvmgen.osty:3628:5
+	result := llvmClosureCallIndirect(main, env, envTypeName, "i64", make([]*LlvmValue, 0, 1))
+	_ = result
+	// Osty: toolchain/llvmgen.osty:3629:5
 	llvmPrintlnI64(main, result)
+	// Osty: toolchain/llvmgen.osty:3630:5
 	llvmReturnI32Zero(main)
-
-	return llvmRenderModuleWithGlobalsAndTypes(
-		sourcePath,
-		"",
-		[]string{typeDef},
-		main.stringGlobals,
-		[]string{
-			llvmRenderFunction("i64", "closure_body", []*LlvmParam{llvmParam("env", "ptr")}, body.body),
-			llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body),
-		},
-	)
+	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{typeDef}, main.stringGlobals, []string{llvmRenderFunction("i64", "closure_body", []*LlvmParam{llvmParam("env", "ptr")}, body.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty (llvmSmokeSetBasicIR)
+// Osty: toolchain/llvmgen.osty:3654:5
 func llvmSmokeSetBasicIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3655:5
 	main := llvmEmitter()
+	_ = main
+	// Osty: toolchain/llvmgen.osty:3656:5
 	set := llvmSetNew(main, llvmContainerAbiKind("i64", false))
-	_ = llvmSetInsertI64(main, set, llvmIntLiteral(10))
-	_ = llvmSetInsertI64(main, set, llvmIntLiteral(20))
-	_ = llvmSetInsertI64(main, set, llvmIntLiteral(30))
-	_ = llvmSetContainsI64(main, set, llvmIntLiteral(20))
-	_ = llvmSetRemoveI64(main, set, llvmIntLiteral(20))
+	_ = set
+	// Osty: toolchain/llvmgen.osty:3657:5
+	_a := llvmSetInsertI64(main, set, llvmIntLiteral(10))
+	_ = _a
+	// Osty: toolchain/llvmgen.osty:3658:5
+	_b := llvmSetInsertI64(main, set, llvmIntLiteral(20))
+	_ = _b
+	// Osty: toolchain/llvmgen.osty:3659:5
+	_c := llvmSetInsertI64(main, set, llvmIntLiteral(30))
+	_ = _c
+	// Osty: toolchain/llvmgen.osty:3660:5
+	_present := llvmSetContainsI64(main, set, llvmIntLiteral(20))
+	_ = _present
+	// Osty: toolchain/llvmgen.osty:3661:5
+	_removed := llvmSetRemoveI64(main, set, llvmIntLiteral(20))
+	_ = _removed
+	// Osty: toolchain/llvmgen.osty:3662:5
 	llvmPrintlnI64(main, llvmSetLen(main, set))
-	_ = llvmSetToList(main, set)
+	// Osty: toolchain/llvmgen.osty:3663:5
+	_keys := llvmSetToList(main, set)
+	_ = _keys
+	// Osty: toolchain/llvmgen.osty:3664:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithSetRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty (llvmSmokeStringConcatIR)
+// Osty: toolchain/llvmgen.osty:3682:5
 func llvmSmokeStringConcatIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3683:5
 	main := llvmEmitter()
+	_ = main
+	// Osty: toolchain/llvmgen.osty:3684:5
 	left := llvmStringLiteral(main, "hello, ")
+	_ = left
+	// Osty: toolchain/llvmgen.osty:3685:5
 	right := llvmStringLiteral(main, "osty")
+	_ = right
+	// Osty: toolchain/llvmgen.osty:3686:5
 	joined := llvmStringConcat(main, left, right)
-	_ = llvmStringHasPrefix(main, joined, left)
+	_ = joined
+	// Osty: toolchain/llvmgen.osty:3687:5
+	prefixed := llvmStringHasPrefix(main, joined, left)
+	_ = prefixed
+	// Osty: toolchain/llvmgen.osty:3688:5
+	_unused := prefixed
+	_ = _unused
+	// Osty: toolchain/llvmgen.osty:3689:5
 	length := llvmStringByteLen(main, joined)
+	_ = length
+	// Osty: toolchain/llvmgen.osty:3690:5
 	llvmPrintlnI64(main, length)
+	// Osty: toolchain/llvmgen.osty:3691:5
 	llvmPrintlnString(main, joined)
+	// Osty: toolchain/llvmgen.osty:3692:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithStringRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty (llvmSmokeMapBasicIR)
+// Osty: toolchain/llvmgen.osty:3710:5
 func llvmSmokeMapBasicIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3711:5
 	main := llvmEmitter()
-	m := llvmMapNew(main)
+	_ = main
+	// Osty: toolchain/llvmgen.osty:3712:5
+	map_ := llvmMapNew(main)
+	_ = map_
+	// Osty: toolchain/llvmgen.osty:3713:5
 	valueSlot := llvmMutableLetSlot(main, "value", llvmIntLiteral(42))
-	llvmMapInsertI64(main, m, llvmIntLiteral(7), llvmSlotAsPtr(valueSlot))
-	_ = llvmMapContainsI64(main, m, llvmIntLiteral(7))
+	_ = valueSlot
+	// Osty: toolchain/llvmgen.osty:3714:5
+	llvmMapInsertI64(main, map_, llvmIntLiteral(7), llvmSlotAsPtr(valueSlot))
+	// Osty: toolchain/llvmgen.osty:3715:5
+	_present := llvmMapContainsI64(main, map_, llvmIntLiteral(7))
+	_ = _present
+	// Osty: toolchain/llvmgen.osty:3716:5
 	outSlot := llvmMutableLetSlot(main, "out", llvmIntLiteral(0))
-	llvmMapGetOrAbortI64(main, m, llvmIntLiteral(7), llvmSlotAsPtr(outSlot))
+	_ = outSlot
+	// Osty: toolchain/llvmgen.osty:3717:5
+	llvmMapGetOrAbortI64(main, map_, llvmIntLiteral(7), llvmSlotAsPtr(outSlot))
+	// Osty: toolchain/llvmgen.osty:3718:5
 	llvmPrintlnI64(main, llvmLoad(main, outSlot))
-	llvmPrintlnI64(main, llvmMapLen(main, m))
+	// Osty: toolchain/llvmgen.osty:3719:5
+	llvmPrintlnI64(main, llvmMapLen(main, map_))
+	// Osty: toolchain/llvmgen.osty:3720:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithMapRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1184:5
-func llvmSmokeScalarArithmeticIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1185:5
-	add := llvmEmitter()
-	_ = add
-	// Osty: toolchain/llvmgen.osty:1186:5
-	llvmBind(add, "a", llvmI64("%a"))
-	// Osty: toolchain/llvmgen.osty:1187:5
-	llvmBind(add, "b", llvmI64("%b"))
-	// Osty: toolchain/llvmgen.osty:1188:5
-	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
-	_ = sum
-	// Osty: toolchain/llvmgen.osty:1189:5
-	llvmReturn(add, sum)
-	// Osty: toolchain/llvmgen.osty:1191:5
+// Osty: toolchain/llvmgen.osty:3737:5
+func llvmSmokeListBasicIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3738:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1192:5
+	// Osty: toolchain/llvmgen.osty:3739:5
+	list := llvmListNew(main)
+	_ = list
+	// Osty: toolchain/llvmgen.osty:3740:5
+	llvmListPushI64(main, list, llvmIntLiteral(10))
+	// Osty: toolchain/llvmgen.osty:3741:5
+	llvmListPushI64(main, list, llvmIntLiteral(20))
+	// Osty: toolchain/llvmgen.osty:3742:5
+	llvmListPushI64(main, list, llvmIntLiteral(30))
+	// Osty: toolchain/llvmgen.osty:3743:5
+	len := llvmListLen(main, list)
+	_ = len
+	// Osty: toolchain/llvmgen.osty:3744:5
+	llvmPrintlnI64(main, len)
+	// Osty: toolchain/llvmgen.osty:3745:5
+	second := llvmListGetI64(main, list, llvmIntLiteral(1))
+	_ = second
+	// Osty: toolchain/llvmgen.osty:3746:5
+	llvmPrintlnI64(main, second)
+	// Osty: toolchain/llvmgen.osty:3747:5
+	llvmReturnI32Zero(main)
+	return llvmRenderModuleWithListRuntime(sourcePath, "", make([]string, 0, 1), main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
+}
+
+// Osty: toolchain/llvmgen.osty:3760:5
+func llvmSmokeScalarArithmeticIR(sourcePath string) string {
+	// Osty: toolchain/llvmgen.osty:3761:5
+	add := llvmEmitter()
+	_ = add
+	// Osty: toolchain/llvmgen.osty:3762:5
+	llvmBind(add, "a", llvmI64("%a"))
+	// Osty: toolchain/llvmgen.osty:3763:5
+	llvmBind(add, "b", llvmI64("%b"))
+	// Osty: toolchain/llvmgen.osty:3764:5
+	sum := llvmBinaryI64(add, "add", llvmIdent(add, "a"), llvmIdent(add, "b"))
+	_ = sum
+	// Osty: toolchain/llvmgen.osty:3765:5
+	llvmReturn(add, sum)
+	// Osty: toolchain/llvmgen.osty:3767:5
+	main := llvmEmitter()
+	_ = main
+	// Osty: toolchain/llvmgen.osty:3768:5
 	value := llvmCall(main, "i64", "add", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1193:5
+	// Osty: toolchain/llvmgen.osty:3769:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:1194:5
+	// Osty: toolchain/llvmgen.osty:3770:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "value"), llvmIntLiteral(42))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1195:5
+	// Osty: toolchain/llvmgen.osty:3771:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1196:5
+	// Osty: toolchain/llvmgen.osty:3772:5
 	llvmPrintlnI64(main, llvmIdent(main, "value"))
-	// Osty: toolchain/llvmgen.osty:1197:5
+	// Osty: toolchain/llvmgen.osty:3773:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1198:5
+	// Osty: toolchain/llvmgen.osty:3774:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:1199:5
+	// Osty: toolchain/llvmgen.osty:3775:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:1200:5
+	// Osty: toolchain/llvmgen.osty:3776:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "add", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, add.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1220:5
+// Osty: toolchain/llvmgen.osty:3796:5
 func llvmSmokeControlFlowIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1221:5
+	// Osty: toolchain/llvmgen.osty:3797:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: toolchain/llvmgen.osty:1222:5
+	// Osty: toolchain/llvmgen.osty:3798:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: toolchain/llvmgen.osty:1223:5
+	// Osty: toolchain/llvmgen.osty:3799:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:1224:5
+	// Osty: toolchain/llvmgen.osty:3800:5
 	loop := llvmInclusiveRangeStart(sumTo, "i", llvmIntLiteral(1), llvmIdent(sumTo, "n"))
 	_ = loop
-	// Osty: toolchain/llvmgen.osty:1225:5
+	// Osty: toolchain/llvmgen.osty:3801:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: toolchain/llvmgen.osty:1226:5
+	// Osty: toolchain/llvmgen.osty:3802:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: toolchain/llvmgen.osty:1227:5
+	// Osty: toolchain/llvmgen.osty:3803:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: toolchain/llvmgen.osty:1228:5
+	// Osty: toolchain/llvmgen.osty:3804:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: toolchain/llvmgen.osty:1230:5
+	// Osty: toolchain/llvmgen.osty:3806:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1231:5
+	// Osty: toolchain/llvmgen.osty:3807:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(5)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1232:5
+	// Osty: toolchain/llvmgen.osty:3808:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:1233:5
+	// Osty: toolchain/llvmgen.osty:3809:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1245:5
+// Osty: toolchain/llvmgen.osty:3821:5
 func llvmSmokeBooleansIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1246:5
+	// Osty: toolchain/llvmgen.osty:3822:5
 	choose := llvmEmitter()
 	_ = choose
-	// Osty: toolchain/llvmgen.osty:1247:5
+	// Osty: toolchain/llvmgen.osty:3823:5
 	llvmBind(choose, "a", llvmI64("%a"))
-	// Osty: toolchain/llvmgen.osty:1248:5
+	// Osty: toolchain/llvmgen.osty:3824:5
 	llvmBind(choose, "b", llvmI64("%b"))
-	// Osty: toolchain/llvmgen.osty:1249:5
+	// Osty: toolchain/llvmgen.osty:3825:5
 	lt := llvmCompare(choose, "slt", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = lt
-	// Osty: toolchain/llvmgen.osty:1250:5
+	// Osty: toolchain/llvmgen.osty:3826:5
 	eqZero := llvmCompare(choose, "eq", llvmIdent(choose, "a"), llvmIntLiteral(0))
 	_ = eqZero
-	// Osty: toolchain/llvmgen.osty:1251:5
+	// Osty: toolchain/llvmgen.osty:3827:5
 	nonZero := llvmNotI1(choose, eqZero)
 	_ = nonZero
-	// Osty: toolchain/llvmgen.osty:1252:5
+	// Osty: toolchain/llvmgen.osty:3828:5
 	cond := llvmLogicalI1(choose, "and", lt, nonZero)
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1253:5
+	// Osty: toolchain/llvmgen.osty:3829:5
 	labels := llvmIfExprStart(choose, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1254:5
+	// Osty: toolchain/llvmgen.osty:3830:5
 	thenValue := llvmBinaryI64(choose, "sub", llvmIdent(choose, "b"), llvmIdent(choose, "a"))
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1255:5
+	// Osty: toolchain/llvmgen.osty:3831:5
 	llvmIfExprElse(choose, labels)
-	// Osty: toolchain/llvmgen.osty:1256:5
+	// Osty: toolchain/llvmgen.osty:3832:5
 	elseValue := llvmBinaryI64(choose, "add", llvmIdent(choose, "a"), llvmIdent(choose, "b"))
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1257:5
+	// Osty: toolchain/llvmgen.osty:3833:5
 	result := llvmIfExprEnd(choose, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1258:5
+	// Osty: toolchain/llvmgen.osty:3834:5
 	llvmReturn(choose, result)
-	// Osty: toolchain/llvmgen.osty:1260:5
+	// Osty: toolchain/llvmgen.osty:3836:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1261:5
+	// Osty: toolchain/llvmgen.osty:3837:5
 	value := llvmCall(main, "i64", "choose", []*LlvmValue{llvmIntLiteral(3), llvmIntLiteral(10)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1262:5
+	// Osty: toolchain/llvmgen.osty:3838:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:1263:5
+	// Osty: toolchain/llvmgen.osty:3839:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "choose", []*LlvmParam{llvmParam("a", "i64"), llvmParam("b", "i64")}, choose.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1283:5
+// Osty: toolchain/llvmgen.osty:3859:5
 func llvmSmokeStringPrintIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1284:5
+	// Osty: toolchain/llvmgen.osty:3860:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1285:5
+	// Osty: toolchain/llvmgen.osty:3861:5
 	line := llvmStringLiteral(main, "hello, osty")
 	_ = line
-	// Osty: toolchain/llvmgen.osty:1286:5
+	// Osty: toolchain/llvmgen.osty:3862:5
 	llvmPrintlnString(main, line)
-	// Osty: toolchain/llvmgen.osty:1287:5
+	// Osty: toolchain/llvmgen.osty:3863:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1299:5
+// Osty: toolchain/llvmgen.osty:3875:5
 func llvmSmokeStringEscapeIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1300:5
+	// Osty: toolchain/llvmgen.osty:3876:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1301:5
+	// Osty: toolchain/llvmgen.osty:3877:5
 	line := llvmStringLiteral(main, "line one\nquote \" slash \\")
 	_ = line
-	// Osty: toolchain/llvmgen.osty:1302:5
+	// Osty: toolchain/llvmgen.osty:3878:5
 	llvmPrintlnString(main, line)
-	// Osty: toolchain/llvmgen.osty:1303:5
+	// Osty: toolchain/llvmgen.osty:3879:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1315:5
+// Osty: toolchain/llvmgen.osty:3891:5
 func llvmSmokeStringLetIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1316:5
+	// Osty: toolchain/llvmgen.osty:3892:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1317:5
+	// Osty: toolchain/llvmgen.osty:3893:5
 	msg := llvmStringLiteral(main, "stored string")
 	_ = msg
-	// Osty: toolchain/llvmgen.osty:1318:5
+	// Osty: toolchain/llvmgen.osty:3894:5
 	llvmImmutableLet(main, "msg", msg)
-	// Osty: toolchain/llvmgen.osty:1319:5
+	// Osty: toolchain/llvmgen.osty:3895:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: toolchain/llvmgen.osty:1320:5
+	// Osty: toolchain/llvmgen.osty:3896:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1332:5
+// Osty: toolchain/llvmgen.osty:3908:5
 func llvmSmokeStringReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1333:5
+	// Osty: toolchain/llvmgen.osty:3909:5
 	greet := llvmEmitter()
 	_ = greet
-	// Osty: toolchain/llvmgen.osty:1334:5
+	// Osty: toolchain/llvmgen.osty:3910:5
 	llvmReturn(greet, llvmStringLiteral(greet, "from function"))
-	// Osty: toolchain/llvmgen.osty:1336:5
+	// Osty: toolchain/llvmgen.osty:3912:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1337:5
+	// Osty: toolchain/llvmgen.osty:3913:5
 	llvmPrintlnString(main, llvmCall(main, "ptr", "greet", make([]*LlvmValue, 0, 1)))
-	// Osty: toolchain/llvmgen.osty:1338:5
+	// Osty: toolchain/llvmgen.osty:3914:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", greet.stringGlobals, []string{llvmRenderFunction("ptr", "greet", make([]*LlvmParam, 0, 1), greet.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1351:5
+// Osty: toolchain/llvmgen.osty:3927:5
 func llvmSmokeStringParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1352:5
+	// Osty: toolchain/llvmgen.osty:3928:5
 	echo := llvmEmitter()
 	_ = echo
-	// Osty: toolchain/llvmgen.osty:1353:5
+	// Osty: toolchain/llvmgen.osty:3929:5
 	llvmBind(echo, "msg", &LlvmValue{typ: "ptr", name: "%msg", pointer: false})
-	// Osty: toolchain/llvmgen.osty:1354:5
+	// Osty: toolchain/llvmgen.osty:3930:5
 	llvmReturn(echo, llvmIdent(echo, "msg"))
-	// Osty: toolchain/llvmgen.osty:1356:5
+	// Osty: toolchain/llvmgen.osty:3932:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1357:5
+	// Osty: toolchain/llvmgen.osty:3933:5
 	value := llvmCall(main, "ptr", "echo", []*LlvmValue{llvmStringLiteral(main, "param string")})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1358:5
+	// Osty: toolchain/llvmgen.osty:3934:5
 	llvmPrintlnString(main, value)
-	// Osty: toolchain/llvmgen.osty:1359:5
+	// Osty: toolchain/llvmgen.osty:3935:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("ptr", "echo", []*LlvmParam{llvmParam("msg", "ptr")}, echo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1372:5
+// Osty: toolchain/llvmgen.osty:3948:5
 func llvmSmokeStringMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1373:5
+	// Osty: toolchain/llvmgen.osty:3949:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1374:5
+	// Osty: toolchain/llvmgen.osty:3950:5
 	llvmMutableLet(main, "msg", llvmStringLiteral(main, "before"))
-	// Osty: toolchain/llvmgen.osty:1375:5
+	// Osty: toolchain/llvmgen.osty:3951:5
 	_ = llvmAssign(main, "msg", llvmStringLiteral(main, "after"))
-	// Osty: toolchain/llvmgen.osty:1376:5
+	// Osty: toolchain/llvmgen.osty:3952:5
 	llvmPrintlnString(main, llvmIdent(main, "msg"))
-	// Osty: toolchain/llvmgen.osty:1377:5
+	// Osty: toolchain/llvmgen.osty:3953:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1389:5
+// Osty: toolchain/llvmgen.osty:3965:5
 func llvmSmokeStructFieldIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1390:5
+	// Osty: toolchain/llvmgen.osty:3966:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1391:5
+	// Osty: toolchain/llvmgen.osty:3967:5
 	point := llvmStructLiteral(main, "%Point", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = point
-	// Osty: toolchain/llvmgen.osty:1392:5
+	// Osty: toolchain/llvmgen.osty:3968:5
 	llvmImmutableLet(main, "point", point)
-	// Osty: toolchain/llvmgen.osty:1393:5
+	// Osty: toolchain/llvmgen.osty:3969:5
 	sum := llvmBinaryI64(main, "add", llvmExtractValue(main, llvmIdent(main, "point"), "i64", 0), llvmExtractValue(main, llvmIdent(main, "point"), "i64", 1))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:1399:5
+	// Osty: toolchain/llvmgen.osty:3975:5
 	llvmPrintlnI64(main, sum)
-	// Osty: toolchain/llvmgen.osty:1400:5
+	// Osty: toolchain/llvmgen.osty:3976:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Point", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1413:5
+// Osty: toolchain/llvmgen.osty:3991:5
 func llvmSmokeStructReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1414:5
+	// Osty: toolchain/llvmgen.osty:3992:5
 	makePair := llvmEmitter()
 	_ = makePair
-	// Osty: toolchain/llvmgen.osty:1415:5
+	// Osty: toolchain/llvmgen.osty:3993:5
 	pair := llvmStructLiteral(makePair, "%Pair", []*LlvmValue{llvmIntLiteral(10), llvmIntLiteral(32)})
 	_ = pair
-	// Osty: toolchain/llvmgen.osty:1416:5
+	// Osty: toolchain/llvmgen.osty:3994:5
 	llvmReturn(makePair, pair)
-	// Osty: toolchain/llvmgen.osty:1418:5
+	// Osty: toolchain/llvmgen.osty:3996:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1419:5
+	// Osty: toolchain/llvmgen.osty:3997:5
 	returned := llvmCall(main, "%Pair", "makePair", make([]*LlvmValue, 0, 1))
 	_ = returned
-	// Osty: toolchain/llvmgen.osty:1420:5
+	// Osty: toolchain/llvmgen.osty:3998:5
 	llvmImmutableLet(main, "pair", returned)
-	// Osty: toolchain/llvmgen.osty:1421:5
+	// Osty: toolchain/llvmgen.osty:3999:5
 	sum := llvmBinaryI64(main, "add", llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 0), llvmExtractValue(main, llvmIdent(main, "pair"), "i64", 1))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:1427:5
+	// Osty: toolchain/llvmgen.osty:4005:5
 	llvmPrintlnI64(main, sum)
-	// Osty: toolchain/llvmgen.osty:1428:5
+	// Osty: toolchain/llvmgen.osty:4006:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Pair", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Pair", "makePair", make([]*LlvmParam, 0, 1), makePair.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1442:5
+// Osty: toolchain/llvmgen.osty:4022:5
 func llvmSmokeStructParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1443:5
+	// Osty: toolchain/llvmgen.osty:4023:5
 	total := llvmEmitter()
 	_ = total
-	// Osty: toolchain/llvmgen.osty:1444:5
+	// Osty: toolchain/llvmgen.osty:4024:5
 	llvmBind(total, "score", &LlvmValue{typ: "%Score", name: "%score", pointer: false})
-	// Osty: toolchain/llvmgen.osty:1445:5
+	// Osty: toolchain/llvmgen.osty:4025:5
 	sum := llvmBinaryI64(total, "add", llvmExtractValue(total, llvmIdent(total, "score"), "i64", 0), llvmExtractValue(total, llvmIdent(total, "score"), "i64", 1))
 	_ = sum
-	// Osty: toolchain/llvmgen.osty:1451:5
+	// Osty: toolchain/llvmgen.osty:4031:5
 	llvmReturn(total, sum)
-	// Osty: toolchain/llvmgen.osty:1453:5
+	// Osty: toolchain/llvmgen.osty:4033:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1454:5
+	// Osty: toolchain/llvmgen.osty:4034:5
 	score := llvmStructLiteral(main, "%Score", []*LlvmValue{llvmIntLiteral(40), llvmIntLiteral(2)})
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1455:5
+	// Osty: toolchain/llvmgen.osty:4035:5
 	out := llvmCall(main, "i64", "total", []*LlvmValue{score})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1456:5
+	// Osty: toolchain/llvmgen.osty:4036:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:1457:5
+	// Osty: toolchain/llvmgen.osty:4037:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Score", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i64", "total", []*LlvmParam{llvmParam("score", "%Score")}, total.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1471:5
+// Osty: toolchain/llvmgen.osty:4053:5
 func llvmSmokeStructMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1472:5
+	// Osty: toolchain/llvmgen.osty:4054:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1473:5
+	// Osty: toolchain/llvmgen.osty:4055:5
 	llvmMutableLet(main, "box", llvmStructLiteral(main, "%Box", []*LlvmValue{llvmIntLiteral(1)}))
-	// Osty: toolchain/llvmgen.osty:1474:5
+	// Osty: toolchain/llvmgen.osty:4056:5
 	_ = llvmAssign(main, "box", llvmStructLiteral(main, "%Box", []*LlvmValue{llvmIntLiteral(42)}))
-	// Osty: toolchain/llvmgen.osty:1475:5
+	// Osty: toolchain/llvmgen.osty:4057:5
 	llvmPrintlnI64(main, llvmExtractValue(main, llvmIdent(main, "box"), "i64", 0))
-	// Osty: toolchain/llvmgen.osty:1476:5
+	// Osty: toolchain/llvmgen.osty:4058:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Box", []string{"i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1489:5
+// Osty: toolchain/llvmgen.osty:4073:5
 func llvmSmokeEnumVariantIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1490:5
+	// Osty: toolchain/llvmgen.osty:4074:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1491:5
+	// Osty: toolchain/llvmgen.osty:4075:5
 	llvmImmutableLet(main, "light", llvmEnumVariant("Light", 1))
-	// Osty: toolchain/llvmgen.osty:1492:5
+	// Osty: toolchain/llvmgen.osty:4076:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "light"), llvmEnumVariant("Light", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1493:5
+	// Osty: toolchain/llvmgen.osty:4077:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1494:5
+	// Osty: toolchain/llvmgen.osty:4078:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:1495:5
+	// Osty: toolchain/llvmgen.osty:4079:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1496:5
+	// Osty: toolchain/llvmgen.osty:4080:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:1497:5
+	// Osty: toolchain/llvmgen.osty:4081:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:1498:5
+	// Osty: toolchain/llvmgen.osty:4082:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1509:5
+// Osty: toolchain/llvmgen.osty:4093:5
 func llvmSmokeEnumReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1510:5
+	// Osty: toolchain/llvmgen.osty:4094:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:1511:5
+	// Osty: toolchain/llvmgen.osty:4095:5
 	llvmReturn(pick, llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:1513:5
+	// Osty: toolchain/llvmgen.osty:4097:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1514:5
+	// Osty: toolchain/llvmgen.osty:4098:5
 	state := llvmCall(main, "i64", "pick", make([]*LlvmValue, 0, 1))
 	_ = state
-	// Osty: toolchain/llvmgen.osty:1515:5
+	// Osty: toolchain/llvmgen.osty:4099:5
 	cond := llvmCompare(main, "eq", state, llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1516:5
+	// Osty: toolchain/llvmgen.osty:4100:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1517:5
+	// Osty: toolchain/llvmgen.osty:4101:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:1518:5
+	// Osty: toolchain/llvmgen.osty:4102:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1519:5
+	// Osty: toolchain/llvmgen.osty:4103:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:1520:5
+	// Osty: toolchain/llvmgen.osty:4104:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:1521:5
+	// Osty: toolchain/llvmgen.osty:4105:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1533:5
+// Osty: toolchain/llvmgen.osty:4117:5
 func llvmSmokeEnumParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1534:5
+	// Osty: toolchain/llvmgen.osty:4118:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1535:5
+	// Osty: toolchain/llvmgen.osty:4119:5
 	llvmBind(score, "state", llvmI64("%state"))
-	// Osty: toolchain/llvmgen.osty:1536:5
+	// Osty: toolchain/llvmgen.osty:4120:5
 	cond := llvmCompare(score, "eq", llvmIdent(score, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1537:5
+	// Osty: toolchain/llvmgen.osty:4121:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1538:5
+	// Osty: toolchain/llvmgen.osty:4122:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1539:5
+	// Osty: toolchain/llvmgen.osty:4123:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1540:5
+	// Osty: toolchain/llvmgen.osty:4124:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1541:5
+	// Osty: toolchain/llvmgen.osty:4125:5
 	out := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1542:5
+	// Osty: toolchain/llvmgen.osty:4126:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:1544:5
+	// Osty: toolchain/llvmgen.osty:4128:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1545:5
+	// Osty: toolchain/llvmgen.osty:4129:5
 	result := llvmCall(main, "i64", "score", []*LlvmValue{llvmEnumVariant("Switch", 1)})
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1546:5
+	// Osty: toolchain/llvmgen.osty:4130:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:1547:5
+	// Osty: toolchain/llvmgen.osty:4131:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("state", "i64")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1559:5
+// Osty: toolchain/llvmgen.osty:4143:5
 func llvmSmokeEnumMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1560:5
+	// Osty: toolchain/llvmgen.osty:4144:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1561:5
+	// Osty: toolchain/llvmgen.osty:4145:5
 	llvmMutableLet(main, "state", llvmEnumVariant("Switch", 0))
-	// Osty: toolchain/llvmgen.osty:1562:5
+	// Osty: toolchain/llvmgen.osty:4146:5
 	_ = llvmAssign(main, "state", llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:1563:5
+	// Osty: toolchain/llvmgen.osty:4147:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1564:5
+	// Osty: toolchain/llvmgen.osty:4148:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1565:5
+	// Osty: toolchain/llvmgen.osty:4149:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:1566:5
+	// Osty: toolchain/llvmgen.osty:4150:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1567:5
+	// Osty: toolchain/llvmgen.osty:4151:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:1568:5
+	// Osty: toolchain/llvmgen.osty:4152:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:1569:5
+	// Osty: toolchain/llvmgen.osty:4153:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1580:5
+// Osty: toolchain/llvmgen.osty:4164:5
 func llvmSmokeEnumMatchIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1581:5
+	// Osty: toolchain/llvmgen.osty:4165:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1582:5
+	// Osty: toolchain/llvmgen.osty:4166:5
 	llvmImmutableLet(main, "state", llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:1583:5
+	// Osty: toolchain/llvmgen.osty:4167:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1584:5
+	// Osty: toolchain/llvmgen.osty:4168:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1585:5
+	// Osty: toolchain/llvmgen.osty:4169:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1586:5
+	// Osty: toolchain/llvmgen.osty:4170:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1587:5
+	// Osty: toolchain/llvmgen.osty:4171:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1588:5
+	// Osty: toolchain/llvmgen.osty:4172:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1589:5
+	// Osty: toolchain/llvmgen.osty:4173:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:1590:5
+	// Osty: toolchain/llvmgen.osty:4174:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1601:5
+// Osty: toolchain/llvmgen.osty:4185:5
 func llvmSmokeEnumMatchReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1602:5
+	// Osty: toolchain/llvmgen.osty:4186:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:1603:5
+	// Osty: toolchain/llvmgen.osty:4187:5
 	llvmReturn(pick, llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:1605:5
+	// Osty: toolchain/llvmgen.osty:4189:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1606:5
+	// Osty: toolchain/llvmgen.osty:4190:5
 	state := llvmCall(score, "i64", "pick", make([]*LlvmValue, 0, 1))
 	_ = state
-	// Osty: toolchain/llvmgen.osty:1607:5
+	// Osty: toolchain/llvmgen.osty:4191:5
 	cond := llvmCompare(score, "eq", state, llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1608:5
+	// Osty: toolchain/llvmgen.osty:4192:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1609:5
+	// Osty: toolchain/llvmgen.osty:4193:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1610:5
+	// Osty: toolchain/llvmgen.osty:4194:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1611:5
+	// Osty: toolchain/llvmgen.osty:4195:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1612:5
+	// Osty: toolchain/llvmgen.osty:4196:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1613:5
+	// Osty: toolchain/llvmgen.osty:4197:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:1615:5
+	// Osty: toolchain/llvmgen.osty:4199:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1616:5
+	// Osty: toolchain/llvmgen.osty:4200:5
 	out := llvmCall(main, "i64", "score", make([]*LlvmValue, 0, 1))
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1617:5
+	// Osty: toolchain/llvmgen.osty:4201:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:1618:5
+	// Osty: toolchain/llvmgen.osty:4202:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i64", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1631:5
+// Osty: toolchain/llvmgen.osty:4215:5
 func llvmSmokeEnumMatchParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1632:5
+	// Osty: toolchain/llvmgen.osty:4216:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1633:5
+	// Osty: toolchain/llvmgen.osty:4217:5
 	llvmBind(score, "state", llvmI64("%state"))
-	// Osty: toolchain/llvmgen.osty:1634:5
+	// Osty: toolchain/llvmgen.osty:4218:5
 	cond := llvmCompare(score, "eq", llvmIdent(score, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1635:5
+	// Osty: toolchain/llvmgen.osty:4219:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1636:5
+	// Osty: toolchain/llvmgen.osty:4220:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1637:5
+	// Osty: toolchain/llvmgen.osty:4221:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1638:5
+	// Osty: toolchain/llvmgen.osty:4222:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1639:5
+	// Osty: toolchain/llvmgen.osty:4223:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1640:5
+	// Osty: toolchain/llvmgen.osty:4224:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:1642:5
+	// Osty: toolchain/llvmgen.osty:4226:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1643:5
+	// Osty: toolchain/llvmgen.osty:4227:5
 	out := llvmCall(main, "i64", "score", []*LlvmValue{llvmEnumVariant("Switch", 1)})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1644:5
+	// Osty: toolchain/llvmgen.osty:4228:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:1645:5
+	// Osty: toolchain/llvmgen.osty:4229:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("state", "i64")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1657:5
+// Osty: toolchain/llvmgen.osty:4241:5
 func llvmSmokeEnumMatchMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1658:5
+	// Osty: toolchain/llvmgen.osty:4242:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1659:5
+	// Osty: toolchain/llvmgen.osty:4243:5
 	llvmMutableLet(main, "state", llvmEnumVariant("Switch", 0))
-	// Osty: toolchain/llvmgen.osty:1660:5
+	// Osty: toolchain/llvmgen.osty:4244:5
 	_ = llvmAssign(main, "state", llvmEnumVariant("Switch", 1))
-	// Osty: toolchain/llvmgen.osty:1661:5
+	// Osty: toolchain/llvmgen.osty:4245:5
 	cond := llvmCompare(main, "eq", llvmIdent(main, "state"), llvmEnumVariant("Switch", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1662:5
+	// Osty: toolchain/llvmgen.osty:4246:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1663:5
+	// Osty: toolchain/llvmgen.osty:4247:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1664:5
+	// Osty: toolchain/llvmgen.osty:4248:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1665:5
+	// Osty: toolchain/llvmgen.osty:4249:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1666:5
+	// Osty: toolchain/llvmgen.osty:4250:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1667:5
+	// Osty: toolchain/llvmgen.osty:4251:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:1668:5
+	// Osty: toolchain/llvmgen.osty:4252:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1679:5
+// Osty: toolchain/llvmgen.osty:4263:5
 func llvmSmokeEnumPayloadIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1680:5
+	// Osty: toolchain/llvmgen.osty:4264:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1681:5
+	// Osty: toolchain/llvmgen.osty:4265:5
 	llvmImmutableLet(main, "value", llvmEnumPayloadVariant(main, "%Maybe", 0, llvmIntLiteral(42)))
-	// Osty: toolchain/llvmgen.osty:1682:5
+	// Osty: toolchain/llvmgen.osty:4266:5
 	state := llvmIdent(main, "value")
 	_ = state
-	// Osty: toolchain/llvmgen.osty:1683:5
+	// Osty: toolchain/llvmgen.osty:4267:5
 	tag := llvmExtractValue(main, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1684:5
+	// Osty: toolchain/llvmgen.osty:4268:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1685:5
+	// Osty: toolchain/llvmgen.osty:4269:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1686:5
+	// Osty: toolchain/llvmgen.osty:4270:5
 	thenValue := llvmExtractValue(main, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1687:5
+	// Osty: toolchain/llvmgen.osty:4271:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1688:5
+	// Osty: toolchain/llvmgen.osty:4272:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1689:5
+	// Osty: toolchain/llvmgen.osty:4273:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1690:5
+	// Osty: toolchain/llvmgen.osty:4274:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:1691:5
+	// Osty: toolchain/llvmgen.osty:4275:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1704:5
+// Osty: toolchain/llvmgen.osty:4290:5
 func llvmSmokeEnumPayloadReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1705:5
+	// Osty: toolchain/llvmgen.osty:4291:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:1706:5
+	// Osty: toolchain/llvmgen.osty:4292:5
 	llvmReturn(pick, llvmEnumPayloadVariant(pick, "%Maybe", 0, llvmIntLiteral(42)))
-	// Osty: toolchain/llvmgen.osty:1708:5
+	// Osty: toolchain/llvmgen.osty:4294:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1709:5
+	// Osty: toolchain/llvmgen.osty:4295:5
 	state := llvmCall(score, "%Maybe", "pick", make([]*LlvmValue, 0, 1))
 	_ = state
-	// Osty: toolchain/llvmgen.osty:1710:5
+	// Osty: toolchain/llvmgen.osty:4296:5
 	tag := llvmExtractValue(score, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1711:5
+	// Osty: toolchain/llvmgen.osty:4297:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1712:5
+	// Osty: toolchain/llvmgen.osty:4298:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1713:5
+	// Osty: toolchain/llvmgen.osty:4299:5
 	thenValue := llvmExtractValue(score, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1714:5
+	// Osty: toolchain/llvmgen.osty:4300:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1715:5
+	// Osty: toolchain/llvmgen.osty:4301:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1716:5
+	// Osty: toolchain/llvmgen.osty:4302:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1717:5
+	// Osty: toolchain/llvmgen.osty:4303:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:1719:5
+	// Osty: toolchain/llvmgen.osty:4305:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1720:5
+	// Osty: toolchain/llvmgen.osty:4306:5
 	out := llvmCall(main, "i64", "score", make([]*LlvmValue, 0, 1))
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1721:5
+	// Osty: toolchain/llvmgen.osty:4307:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:1722:5
+	// Osty: toolchain/llvmgen.osty:4308:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Maybe", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("i64", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1737:5
+// Osty: toolchain/llvmgen.osty:4325:5
 func llvmSmokeEnumPayloadParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1738:5
+	// Osty: toolchain/llvmgen.osty:4326:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1739:5
+	// Osty: toolchain/llvmgen.osty:4327:5
 	llvmBind(score, "value", &LlvmValue{typ: "%Maybe", name: "%value", pointer: false})
-	// Osty: toolchain/llvmgen.osty:1740:5
+	// Osty: toolchain/llvmgen.osty:4328:5
 	state := llvmIdent(score, "value")
 	_ = state
-	// Osty: toolchain/llvmgen.osty:1741:5
+	// Osty: toolchain/llvmgen.osty:4329:5
 	tag := llvmExtractValue(score, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1742:5
+	// Osty: toolchain/llvmgen.osty:4330:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1743:5
+	// Osty: toolchain/llvmgen.osty:4331:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1744:5
+	// Osty: toolchain/llvmgen.osty:4332:5
 	thenValue := llvmExtractValue(score, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1745:5
+	// Osty: toolchain/llvmgen.osty:4333:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1746:5
+	// Osty: toolchain/llvmgen.osty:4334:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1747:5
+	// Osty: toolchain/llvmgen.osty:4335:5
 	result := llvmIfExprEnd(score, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1748:5
+	// Osty: toolchain/llvmgen.osty:4336:5
 	llvmReturn(score, result)
-	// Osty: toolchain/llvmgen.osty:1750:5
+	// Osty: toolchain/llvmgen.osty:4338:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1751:5
+	// Osty: toolchain/llvmgen.osty:4339:5
 	arg := llvmEnumPayloadVariant(main, "%Maybe", 0, llvmIntLiteral(42))
 	_ = arg
-	// Osty: toolchain/llvmgen.osty:1752:5
+	// Osty: toolchain/llvmgen.osty:4340:5
 	out := llvmCall(main, "i64", "score", []*LlvmValue{arg})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1753:5
+	// Osty: toolchain/llvmgen.osty:4341:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:1754:5
+	// Osty: toolchain/llvmgen.osty:4342:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i64", "score", []*LlvmParam{llvmParam("value", "%Maybe")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1768:5
+// Osty: toolchain/llvmgen.osty:4358:5
 func llvmSmokeEnumPayloadMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1769:5
+	// Osty: toolchain/llvmgen.osty:4359:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1770:5
+	// Osty: toolchain/llvmgen.osty:4360:5
 	llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%Maybe", 1, llvmIntLiteral(0)))
-	// Osty: toolchain/llvmgen.osty:1771:5
+	// Osty: toolchain/llvmgen.osty:4361:5
 	_ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%Maybe", 0, llvmIntLiteral(42)))
-	// Osty: toolchain/llvmgen.osty:1772:5
+	// Osty: toolchain/llvmgen.osty:4362:5
 	state := llvmIdent(main, "value")
 	_ = state
-	// Osty: toolchain/llvmgen.osty:1773:5
+	// Osty: toolchain/llvmgen.osty:4363:5
 	tag := llvmExtractValue(main, state, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1774:5
+	// Osty: toolchain/llvmgen.osty:4364:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Maybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1775:5
+	// Osty: toolchain/llvmgen.osty:4365:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1776:5
+	// Osty: toolchain/llvmgen.osty:4366:5
 	thenValue := llvmExtractValue(main, state, "i64", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1777:5
+	// Osty: toolchain/llvmgen.osty:4367:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1778:5
+	// Osty: toolchain/llvmgen.osty:4368:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1779:5
+	// Osty: toolchain/llvmgen.osty:4369:5
 	result := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = result
-	// Osty: toolchain/llvmgen.osty:1780:5
+	// Osty: toolchain/llvmgen.osty:4370:5
 	llvmPrintlnI64(main, result)
-	// Osty: toolchain/llvmgen.osty:1781:5
+	// Osty: toolchain/llvmgen.osty:4371:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Maybe", []string{"i64", "i64"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1794:5
+// Osty: toolchain/llvmgen.osty:4386:5
 func llvmSmokeFloatPrintIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1795:5
+	// Osty: toolchain/llvmgen.osty:4387:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1796:5
+	// Osty: toolchain/llvmgen.osty:4388:5
 	llvmPrintlnF64(main, llvmFloatLiteral("42.0"))
-	// Osty: toolchain/llvmgen.osty:1797:5
+	// Osty: toolchain/llvmgen.osty:4389:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1806:5
+// Osty: toolchain/llvmgen.osty:4400:5
 func llvmSmokeFloatArithmeticIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1807:5
+	// Osty: toolchain/llvmgen.osty:4401:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1808:5
+	// Osty: toolchain/llvmgen.osty:4402:5
 	add := llvmBinaryF64(main, "fadd", llvmFloatLiteral("40.0"), llvmFloatLiteral("2.0"))
 	_ = add
-	// Osty: toolchain/llvmgen.osty:1809:5
+	// Osty: toolchain/llvmgen.osty:4403:5
 	sub := llvmBinaryF64(main, "fsub", add, llvmFloatLiteral("0.0"))
 	_ = sub
-	// Osty: toolchain/llvmgen.osty:1810:5
+	// Osty: toolchain/llvmgen.osty:4404:5
 	mul := llvmBinaryF64(main, "fmul", sub, llvmFloatLiteral("2.5"))
 	_ = mul
-	// Osty: toolchain/llvmgen.osty:1811:5
+	// Osty: toolchain/llvmgen.osty:4405:5
 	div := llvmBinaryF64(main, "fdiv", mul, llvmFloatLiteral("2.5"))
 	_ = div
-	// Osty: toolchain/llvmgen.osty:1812:5
+	// Osty: toolchain/llvmgen.osty:4406:5
 	llvmPrintlnF64(main, div)
-	// Osty: toolchain/llvmgen.osty:1813:5
+	// Osty: toolchain/llvmgen.osty:4407:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1822:5
+// Osty: toolchain/llvmgen.osty:4418:5
 func llvmSmokeFloatReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1823:5
+	// Osty: toolchain/llvmgen.osty:4419:5
 	value := llvmEmitter()
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1824:5
+	// Osty: toolchain/llvmgen.osty:4420:5
 	llvmReturn(value, llvmFloatLiteral("42.0"))
-	// Osty: toolchain/llvmgen.osty:1826:5
+	// Osty: toolchain/llvmgen.osty:4422:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1827:5
+	// Osty: toolchain/llvmgen.osty:4423:5
 	out := llvmCall(main, "double", "value", make([]*LlvmValue, 0, 1))
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1828:5
+	// Osty: toolchain/llvmgen.osty:4424:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:1829:5
+	// Osty: toolchain/llvmgen.osty:4425:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("double", "value", make([]*LlvmParam, 0, 1), value.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1841:5
+// Osty: toolchain/llvmgen.osty:4437:5
 func llvmSmokeFloatParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1842:5
+	// Osty: toolchain/llvmgen.osty:4438:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1843:5
+	// Osty: toolchain/llvmgen.osty:4439:5
 	llvmBind(score, "value", llvmF64("%value"))
-	// Osty: toolchain/llvmgen.osty:1844:5
+	// Osty: toolchain/llvmgen.osty:4440:5
 	llvmReturn(score, llvmIdent(score, "value"))
-	// Osty: toolchain/llvmgen.osty:1846:5
+	// Osty: toolchain/llvmgen.osty:4442:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1847:5
+	// Osty: toolchain/llvmgen.osty:4443:5
 	out := llvmCall(main, "double", "score", []*LlvmValue{llvmFloatLiteral("42.0")})
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1848:5
+	// Osty: toolchain/llvmgen.osty:4444:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:1849:5
+	// Osty: toolchain/llvmgen.osty:4445:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("double", "score", []*LlvmParam{llvmParam("value", "double")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1861:5
+// Osty: toolchain/llvmgen.osty:4457:5
 func llvmSmokeFloatMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1862:5
+	// Osty: toolchain/llvmgen.osty:4458:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1863:5
+	// Osty: toolchain/llvmgen.osty:4459:5
 	llvmMutableLet(main, "value", llvmFloatLiteral("0.0"))
-	// Osty: toolchain/llvmgen.osty:1864:5
+	// Osty: toolchain/llvmgen.osty:4460:5
 	_ = llvmAssign(main, "value", llvmFloatLiteral("42.0"))
-	// Osty: toolchain/llvmgen.osty:1865:5
+	// Osty: toolchain/llvmgen.osty:4461:5
 	llvmPrintlnF64(main, llvmIdent(main, "value"))
-	// Osty: toolchain/llvmgen.osty:1866:5
+	// Osty: toolchain/llvmgen.osty:4462:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1877:5
+// Osty: toolchain/llvmgen.osty:4473:5
 func llvmSmokeFloatCompareIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1878:5
+	// Osty: toolchain/llvmgen.osty:4474:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1879:5
+	// Osty: toolchain/llvmgen.osty:4475:5
 	value := llvmFloatLiteral("42.0")
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1880:5
+	// Osty: toolchain/llvmgen.osty:4476:5
 	eq := llvmCompareF64(main, "oeq", value, llvmFloatLiteral("42.0"))
 	_ = eq
-	// Osty: toolchain/llvmgen.osty:1881:5
+	// Osty: toolchain/llvmgen.osty:4477:5
 	ne := llvmCompareF64(main, "one", value, llvmFloatLiteral("41.0"))
 	_ = ne
-	// Osty: toolchain/llvmgen.osty:1882:5
+	// Osty: toolchain/llvmgen.osty:4478:5
 	lt := llvmCompareF64(main, "olt", value, llvmFloatLiteral("100.0"))
 	_ = lt
-	// Osty: toolchain/llvmgen.osty:1883:5
+	// Osty: toolchain/llvmgen.osty:4479:5
 	gt := llvmCompareF64(main, "ogt", value, llvmFloatLiteral("0.0"))
 	_ = gt
-	// Osty: toolchain/llvmgen.osty:1884:5
+	// Osty: toolchain/llvmgen.osty:4480:5
 	le := llvmCompareF64(main, "ole", value, llvmFloatLiteral("42.0"))
 	_ = le
-	// Osty: toolchain/llvmgen.osty:1885:5
+	// Osty: toolchain/llvmgen.osty:4481:5
 	ge := llvmCompareF64(main, "oge", value, llvmFloatLiteral("42.0"))
 	_ = ge
-	// Osty: toolchain/llvmgen.osty:1886:5
+	// Osty: toolchain/llvmgen.osty:4482:5
 	cond := llvmLogicalI1(main, "and", llvmLogicalI1(main, "and", llvmLogicalI1(main, "and", eq, ne), llvmLogicalI1(main, "and", lt, gt)), llvmLogicalI1(main, "and", le, ge))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1892:5
+	// Osty: toolchain/llvmgen.osty:4493:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1893:5
+	// Osty: toolchain/llvmgen.osty:4494:5
 	llvmPrintlnF64(main, value)
-	// Osty: toolchain/llvmgen.osty:1894:5
+	// Osty: toolchain/llvmgen.osty:4495:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1895:5
+	// Osty: toolchain/llvmgen.osty:4496:5
 	llvmPrintlnF64(main, llvmFloatLiteral("0.0"))
-	// Osty: toolchain/llvmgen.osty:1896:5
+	// Osty: toolchain/llvmgen.osty:4497:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:1897:5
+	// Osty: toolchain/llvmgen.osty:4498:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1906:5
+// Osty: toolchain/llvmgen.osty:4509:5
 func llvmSmokeFloatStructIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1907:5
+	// Osty: toolchain/llvmgen.osty:4510:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1908:5
+	// Osty: toolchain/llvmgen.osty:4511:5
 	value := llvmStructLiteral(main, "%MaybeF", []*LlvmValue{llvmIntLiteral(7), llvmFloatLiteral("42.0")})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1909:5
+	// Osty: toolchain/llvmgen.osty:4512:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:1910:5
+	// Osty: toolchain/llvmgen.osty:4513:5
 	llvmPrintlnF64(main, llvmExtractValue(main, llvmIdent(main, "value"), "double", 1))
-	// Osty: toolchain/llvmgen.osty:1911:5
+	// Osty: toolchain/llvmgen.osty:4514:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("MaybeF", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1924:5
+// Osty: toolchain/llvmgen.osty:4529:5
 func llvmSmokeFloatEnumPayloadIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1925:5
+	// Osty: toolchain/llvmgen.osty:4530:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1926:5
+	// Osty: toolchain/llvmgen.osty:4531:5
 	value := llvmEnumPayloadVariant(main, "%MaybeF", 0, llvmFloatLiteral("42.0"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1927:5
+	// Osty: toolchain/llvmgen.osty:4532:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:1928:5
+	// Osty: toolchain/llvmgen.osty:4533:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:1929:5
+	// Osty: toolchain/llvmgen.osty:4534:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1930:5
+	// Osty: toolchain/llvmgen.osty:4535:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("MaybeF", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1931:5
+	// Osty: toolchain/llvmgen.osty:4536:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1932:5
+	// Osty: toolchain/llvmgen.osty:4537:5
 	thenValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1933:5
+	// Osty: toolchain/llvmgen.osty:4538:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:1934:5
+	// Osty: toolchain/llvmgen.osty:4539:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1935:5
+	// Osty: toolchain/llvmgen.osty:4540:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1936:5
+	// Osty: toolchain/llvmgen.osty:4541:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:1937:5
+	// Osty: toolchain/llvmgen.osty:4542:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("MaybeF", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1950:5
+// Osty: toolchain/llvmgen.osty:4557:5
 func llvmSmokeFloatPayloadReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1951:5
+	// Osty: toolchain/llvmgen.osty:4558:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:1952:5
+	// Osty: toolchain/llvmgen.osty:4559:5
 	llvmReturn(pick, llvmEnumPayloadVariant(pick, "%FloatMaybe", 0, llvmFloatLiteral("42.0")))
-	// Osty: toolchain/llvmgen.osty:1954:5
+	// Osty: toolchain/llvmgen.osty:4561:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1955:5
+	// Osty: toolchain/llvmgen.osty:4562:5
 	valueRef := llvmCall(score, "%FloatMaybe", "pick", make([]*LlvmValue, 0, 1))
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:1956:5
+	// Osty: toolchain/llvmgen.osty:4563:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1957:5
+	// Osty: toolchain/llvmgen.osty:4564:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1958:5
+	// Osty: toolchain/llvmgen.osty:4565:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1959:5
+	// Osty: toolchain/llvmgen.osty:4566:5
 	thenValue := llvmExtractValue(score, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1960:5
+	// Osty: toolchain/llvmgen.osty:4567:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1961:5
+	// Osty: toolchain/llvmgen.osty:4568:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1962:5
+	// Osty: toolchain/llvmgen.osty:4569:5
 	out := llvmIfExprEnd(score, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1963:5
+	// Osty: toolchain/llvmgen.osty:4570:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:1965:5
+	// Osty: toolchain/llvmgen.osty:4572:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1966:5
+	// Osty: toolchain/llvmgen.osty:4573:5
 	value := llvmCall(main, "double", "score", make([]*LlvmValue, 0, 1))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:1967:5
+	// Osty: toolchain/llvmgen.osty:4574:5
 	llvmPrintlnF64(main, value)
-	// Osty: toolchain/llvmgen.osty:1968:5
+	// Osty: toolchain/llvmgen.osty:4575:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%FloatMaybe", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("double", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:1983:5
+// Osty: toolchain/llvmgen.osty:4592:5
 func llvmSmokeFloatPayloadParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:1984:5
+	// Osty: toolchain/llvmgen.osty:4593:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:1985:5
+	// Osty: toolchain/llvmgen.osty:4594:5
 	llvmBind(score, "value", &LlvmValue{typ: "%FloatMaybe", name: "%value", pointer: false})
-	// Osty: toolchain/llvmgen.osty:1986:5
+	// Osty: toolchain/llvmgen.osty:4595:5
 	valueRef := llvmIdent(score, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:1987:5
+	// Osty: toolchain/llvmgen.osty:4596:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:1988:5
+	// Osty: toolchain/llvmgen.osty:4597:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:1989:5
+	// Osty: toolchain/llvmgen.osty:4598:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:1990:5
+	// Osty: toolchain/llvmgen.osty:4599:5
 	thenValue := llvmExtractValue(score, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:1991:5
+	// Osty: toolchain/llvmgen.osty:4600:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:1992:5
+	// Osty: toolchain/llvmgen.osty:4601:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:1993:5
+	// Osty: toolchain/llvmgen.osty:4602:5
 	out := llvmIfExprEnd(score, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:1994:5
+	// Osty: toolchain/llvmgen.osty:4603:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:1996:5
+	// Osty: toolchain/llvmgen.osty:4605:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:1997:5
+	// Osty: toolchain/llvmgen.osty:4606:5
 	arg := llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0"))
 	_ = arg
-	// Osty: toolchain/llvmgen.osty:1998:5
+	// Osty: toolchain/llvmgen.osty:4607:5
 	mainOut := llvmCall(main, "double", "score", []*LlvmValue{arg})
 	_ = mainOut
-	// Osty: toolchain/llvmgen.osty:1999:5
+	// Osty: toolchain/llvmgen.osty:4608:5
 	llvmPrintlnF64(main, mainOut)
-	// Osty: toolchain/llvmgen.osty:2000:5
+	// Osty: toolchain/llvmgen.osty:4609:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("double", "score", []*LlvmParam{llvmParam("value", "%FloatMaybe")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2014:5
+// Osty: toolchain/llvmgen.osty:4625:5
 func llvmSmokeFloatPayloadMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2015:5
+	// Osty: toolchain/llvmgen.osty:4626:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2016:5
+	// Osty: toolchain/llvmgen.osty:4627:5
 	llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%FloatMaybe", 1, llvmFloatLiteral("0.0")))
-	// Osty: toolchain/llvmgen.osty:2017:5
+	// Osty: toolchain/llvmgen.osty:4632:5
 	_ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0")))
-	// Osty: toolchain/llvmgen.osty:2018:5
+	// Osty: toolchain/llvmgen.osty:4637:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2019:5
+	// Osty: toolchain/llvmgen.osty:4638:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2020:5
+	// Osty: toolchain/llvmgen.osty:4639:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2021:5
+	// Osty: toolchain/llvmgen.osty:4640:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2022:5
+	// Osty: toolchain/llvmgen.osty:4641:5
 	thenValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2023:5
+	// Osty: toolchain/llvmgen.osty:4642:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2024:5
+	// Osty: toolchain/llvmgen.osty:4643:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2025:5
+	// Osty: toolchain/llvmgen.osty:4644:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2026:5
+	// Osty: toolchain/llvmgen.osty:4645:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:2027:5
+	// Osty: toolchain/llvmgen.osty:4646:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2040:5
+// Osty: toolchain/llvmgen.osty:4661:5
 func llvmSmokeFloatPayloadReversedMatchIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2041:5
+	// Osty: toolchain/llvmgen.osty:4662:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2042:5
+	// Osty: toolchain/llvmgen.osty:4663:5
 	value := llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2043:5
+	// Osty: toolchain/llvmgen.osty:4664:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:2044:5
+	// Osty: toolchain/llvmgen.osty:4665:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2045:5
+	// Osty: toolchain/llvmgen.osty:4666:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2046:5
+	// Osty: toolchain/llvmgen.osty:4667:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2047:5
+	// Osty: toolchain/llvmgen.osty:4668:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2048:5
+	// Osty: toolchain/llvmgen.osty:4669:5
 	thenValue := llvmFloatLiteral("0.0")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2049:5
+	// Osty: toolchain/llvmgen.osty:4670:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2050:5
+	// Osty: toolchain/llvmgen.osty:4671:5
 	elseValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2051:5
+	// Osty: toolchain/llvmgen.osty:4672:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2052:5
+	// Osty: toolchain/llvmgen.osty:4673:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:2053:5
+	// Osty: toolchain/llvmgen.osty:4674:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2066:5
+// Osty: toolchain/llvmgen.osty:4689:5
 func llvmSmokeFloatPayloadWildcardIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2067:5
+	// Osty: toolchain/llvmgen.osty:4690:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2068:5
+	// Osty: toolchain/llvmgen.osty:4691:5
 	value := llvmEnumPayloadVariant(main, "%FloatMaybe", 0, llvmFloatLiteral("42.0"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2069:5
+	// Osty: toolchain/llvmgen.osty:4692:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:2070:5
+	// Osty: toolchain/llvmgen.osty:4693:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2071:5
+	// Osty: toolchain/llvmgen.osty:4694:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2072:5
+	// Osty: toolchain/llvmgen.osty:4695:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("FloatMaybe", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2073:5
+	// Osty: toolchain/llvmgen.osty:4696:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2074:5
+	// Osty: toolchain/llvmgen.osty:4697:5
 	thenValue := llvmExtractValue(main, valueRef, "double", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2075:5
+	// Osty: toolchain/llvmgen.osty:4698:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2076:5
+	// Osty: toolchain/llvmgen.osty:4699:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2077:5
+	// Osty: toolchain/llvmgen.osty:4700:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2078:5
+	// Osty: toolchain/llvmgen.osty:4701:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:2079:5
+	// Osty: toolchain/llvmgen.osty:4702:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("FloatMaybe", []string{"i64", "double"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2092:5
+// Osty: toolchain/llvmgen.osty:4717:5
 func llvmSmokeStringPayloadReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2093:5
+	// Osty: toolchain/llvmgen.osty:4718:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:2094:5
+	// Osty: toolchain/llvmgen.osty:4719:5
 	llvmReturn(pick, llvmEnumPayloadVariant(pick, "%Label", 0, llvmStringLiteral(pick, "payload string")))
-	// Osty: toolchain/llvmgen.osty:2096:5
+	// Osty: toolchain/llvmgen.osty:4724:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:2097:5
+	// Osty: toolchain/llvmgen.osty:4725:5
 	valueRef := llvmCall(score, "%Label", "pick", make([]*LlvmValue, 0, 1))
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2098:5
+	// Osty: toolchain/llvmgen.osty:4726:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2099:5
+	// Osty: toolchain/llvmgen.osty:4727:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2100:5
+	// Osty: toolchain/llvmgen.osty:4728:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2101:5
+	// Osty: toolchain/llvmgen.osty:4729:5
 	thenValue := llvmExtractValue(score, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2102:5
+	// Osty: toolchain/llvmgen.osty:4730:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:2103:5
+	// Osty: toolchain/llvmgen.osty:4731:5
 	elseValue := llvmStringLiteral(score, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2104:5
+	// Osty: toolchain/llvmgen.osty:4732:5
 	out := llvmIfExprEnd(score, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2105:5
+	// Osty: toolchain/llvmgen.osty:4733:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:2107:5
+	// Osty: toolchain/llvmgen.osty:4735:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2108:5
+	// Osty: toolchain/llvmgen.osty:4736:5
 	value := llvmCall(main, "ptr", "score", make([]*LlvmValue, 0, 1))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2109:5
+	// Osty: toolchain/llvmgen.osty:4737:5
 	llvmPrintlnString(main, value)
-	// Osty: toolchain/llvmgen.osty:2110:5
+	// Osty: toolchain/llvmgen.osty:4738:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("%Label", "pick", make([]*LlvmParam, 0, 1), pick.body), llvmRenderFunction("ptr", "score", make([]*LlvmParam, 0, 1), score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2125:5
+// Osty: toolchain/llvmgen.osty:4755:5
 func llvmSmokeStringPayloadParamIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2126:5
+	// Osty: toolchain/llvmgen.osty:4756:5
 	score := llvmEmitter()
 	_ = score
-	// Osty: toolchain/llvmgen.osty:2127:5
+	// Osty: toolchain/llvmgen.osty:4757:5
 	llvmBind(score, "value", &LlvmValue{typ: "%Label", name: "%value", pointer: false})
-	// Osty: toolchain/llvmgen.osty:2128:5
+	// Osty: toolchain/llvmgen.osty:4758:5
 	valueRef := llvmIdent(score, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2129:5
+	// Osty: toolchain/llvmgen.osty:4759:5
 	tag := llvmExtractValue(score, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2130:5
+	// Osty: toolchain/llvmgen.osty:4760:5
 	cond := llvmCompare(score, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2131:5
+	// Osty: toolchain/llvmgen.osty:4761:5
 	labels := llvmIfExprStart(score, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2132:5
+	// Osty: toolchain/llvmgen.osty:4762:5
 	thenValue := llvmExtractValue(score, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2133:5
+	// Osty: toolchain/llvmgen.osty:4763:5
 	llvmIfExprElse(score, labels)
-	// Osty: toolchain/llvmgen.osty:2134:5
+	// Osty: toolchain/llvmgen.osty:4764:5
 	elseValue := llvmStringLiteral(score, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2135:5
+	// Osty: toolchain/llvmgen.osty:4765:5
 	out := llvmIfExprEnd(score, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2136:5
+	// Osty: toolchain/llvmgen.osty:4766:5
 	llvmReturn(score, out)
-	// Osty: toolchain/llvmgen.osty:2138:5
+	// Osty: toolchain/llvmgen.osty:4768:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2139:5
+	// Osty: toolchain/llvmgen.osty:4769:5
 	arg := llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string"))
 	_ = arg
-	// Osty: toolchain/llvmgen.osty:2140:5
+	// Osty: toolchain/llvmgen.osty:4770:5
 	value := llvmCall(main, "ptr", "score", []*LlvmValue{arg})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2141:5
+	// Osty: toolchain/llvmgen.osty:4771:5
 	llvmPrintlnString(main, value)
-	// Osty: toolchain/llvmgen.osty:2142:5
+	// Osty: toolchain/llvmgen.osty:4772:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("ptr", "score", []*LlvmParam{llvmParam("value", "%Label")}, score.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2156:5
+// Osty: toolchain/llvmgen.osty:4788:5
 func llvmSmokeStringPayloadMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2157:5
+	// Osty: toolchain/llvmgen.osty:4789:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2158:5
+	// Osty: toolchain/llvmgen.osty:4790:5
 	llvmMutableLet(main, "value", llvmEnumPayloadVariant(main, "%Label", 1, llvmStringLiteral(main, "no payload")))
-	// Osty: toolchain/llvmgen.osty:2159:5
+	// Osty: toolchain/llvmgen.osty:4795:5
 	_ = llvmAssign(main, "value", llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string")))
-	// Osty: toolchain/llvmgen.osty:2160:5
+	// Osty: toolchain/llvmgen.osty:4800:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2161:5
+	// Osty: toolchain/llvmgen.osty:4801:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2162:5
+	// Osty: toolchain/llvmgen.osty:4802:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2163:5
+	// Osty: toolchain/llvmgen.osty:4803:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2164:5
+	// Osty: toolchain/llvmgen.osty:4804:5
 	thenValue := llvmExtractValue(main, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2165:5
+	// Osty: toolchain/llvmgen.osty:4805:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2166:5
+	// Osty: toolchain/llvmgen.osty:4806:5
 	elseValue := llvmStringLiteral(main, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2167:5
+	// Osty: toolchain/llvmgen.osty:4807:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2168:5
+	// Osty: toolchain/llvmgen.osty:4808:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:2169:5
+	// Osty: toolchain/llvmgen.osty:4809:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2182:5
+// Osty: toolchain/llvmgen.osty:4824:5
 func llvmSmokeStringPayloadReversedMatchIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2183:5
+	// Osty: toolchain/llvmgen.osty:4825:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2184:5
+	// Osty: toolchain/llvmgen.osty:4826:5
 	value := llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2185:5
+	// Osty: toolchain/llvmgen.osty:4827:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:2186:5
+	// Osty: toolchain/llvmgen.osty:4828:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2187:5
+	// Osty: toolchain/llvmgen.osty:4829:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2188:5
+	// Osty: toolchain/llvmgen.osty:4830:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 1))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2189:5
+	// Osty: toolchain/llvmgen.osty:4831:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2190:5
+	// Osty: toolchain/llvmgen.osty:4832:5
 	thenValue := llvmStringLiteral(main, "no payload")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2191:5
+	// Osty: toolchain/llvmgen.osty:4833:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2192:5
+	// Osty: toolchain/llvmgen.osty:4834:5
 	elseValue := llvmExtractValue(main, valueRef, "ptr", 1)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2193:5
+	// Osty: toolchain/llvmgen.osty:4835:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2194:5
+	// Osty: toolchain/llvmgen.osty:4836:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:2195:5
+	// Osty: toolchain/llvmgen.osty:4837:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2208:5
+// Osty: toolchain/llvmgen.osty:4852:5
 func llvmSmokeStringPayloadWildcardIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2209:5
+	// Osty: toolchain/llvmgen.osty:4853:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2210:5
+	// Osty: toolchain/llvmgen.osty:4854:5
 	value := llvmEnumPayloadVariant(main, "%Label", 0, llvmStringLiteral(main, "payload string"))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2211:5
+	// Osty: toolchain/llvmgen.osty:4855:5
 	llvmImmutableLet(main, "value", value)
-	// Osty: toolchain/llvmgen.osty:2212:5
+	// Osty: toolchain/llvmgen.osty:4856:5
 	valueRef := llvmIdent(main, "value")
 	_ = valueRef
-	// Osty: toolchain/llvmgen.osty:2213:5
+	// Osty: toolchain/llvmgen.osty:4857:5
 	tag := llvmExtractValue(main, valueRef, "i64", 0)
 	_ = tag
-	// Osty: toolchain/llvmgen.osty:2214:5
+	// Osty: toolchain/llvmgen.osty:4858:5
 	cond := llvmCompare(main, "eq", tag, llvmEnumVariant("Label", 0))
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2215:5
+	// Osty: toolchain/llvmgen.osty:4859:5
 	labels := llvmIfExprStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2216:5
+	// Osty: toolchain/llvmgen.osty:4860:5
 	thenValue := llvmExtractValue(main, valueRef, "ptr", 1)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2217:5
+	// Osty: toolchain/llvmgen.osty:4861:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2218:5
+	// Osty: toolchain/llvmgen.osty:4862:5
 	elseValue := llvmStringLiteral(main, "no payload")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2219:5
+	// Osty: toolchain/llvmgen.osty:4863:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2220:5
+	// Osty: toolchain/llvmgen.osty:4864:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:2221:5
+	// Osty: toolchain/llvmgen.osty:4865:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Label", []string{"i64", "ptr"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2234:5
+// Osty: toolchain/llvmgen.osty:4880:5
 func llvmSmokeIntIfExprIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2235:5
+	// Osty: toolchain/llvmgen.osty:4881:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2236:5
+	// Osty: toolchain/llvmgen.osty:4882:5
 	labels := llvmIfExprStart(main, llvmI1("true"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2237:5
+	// Osty: toolchain/llvmgen.osty:4883:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2238:5
+	// Osty: toolchain/llvmgen.osty:4884:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2239:5
+	// Osty: toolchain/llvmgen.osty:4885:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2240:5
+	// Osty: toolchain/llvmgen.osty:4886:5
 	out := llvmIfExprEnd(main, "i64", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2241:5
+	// Osty: toolchain/llvmgen.osty:4887:5
 	llvmPrintlnI64(main, out)
-	// Osty: toolchain/llvmgen.osty:2242:5
+	// Osty: toolchain/llvmgen.osty:4888:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2253:5
+// Osty: toolchain/llvmgen.osty:4899:5
 func llvmSmokeStringIfExprIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2254:5
+	// Osty: toolchain/llvmgen.osty:4900:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2255:5
+	// Osty: toolchain/llvmgen.osty:4901:5
 	labels := llvmIfExprStart(main, llvmI1("true"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2256:5
+	// Osty: toolchain/llvmgen.osty:4902:5
 	thenValue := llvmStringLiteral(main, "chosen string")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2257:5
+	// Osty: toolchain/llvmgen.osty:4903:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2258:5
+	// Osty: toolchain/llvmgen.osty:4904:5
 	elseValue := llvmStringLiteral(main, "fallback")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2259:5
+	// Osty: toolchain/llvmgen.osty:4905:5
 	out := llvmIfExprEnd(main, "ptr", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2260:5
+	// Osty: toolchain/llvmgen.osty:4906:5
 	llvmPrintlnString(main, out)
-	// Osty: toolchain/llvmgen.osty:2261:5
+	// Osty: toolchain/llvmgen.osty:4907:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobals(sourcePath, "", main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2273:5
+// Osty: toolchain/llvmgen.osty:4919:5
 func llvmSmokeFloatIfExprIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2274:5
+	// Osty: toolchain/llvmgen.osty:4920:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2275:5
+	// Osty: toolchain/llvmgen.osty:4921:5
 	labels := llvmIfExprStart(main, llvmI1("true"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2276:5
+	// Osty: toolchain/llvmgen.osty:4922:5
 	thenValue := llvmFloatLiteral("42.0")
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2277:5
+	// Osty: toolchain/llvmgen.osty:4923:5
 	llvmIfExprElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2278:5
+	// Osty: toolchain/llvmgen.osty:4924:5
 	elseValue := llvmFloatLiteral("0.0")
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2279:5
+	// Osty: toolchain/llvmgen.osty:4925:5
 	out := llvmIfExprEnd(main, "double", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2280:5
+	// Osty: toolchain/llvmgen.osty:4926:5
 	llvmPrintlnF64(main, out)
-	// Osty: toolchain/llvmgen.osty:2281:5
+	// Osty: toolchain/llvmgen.osty:4927:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2292:5
+// Osty: toolchain/llvmgen.osty:4938:5
 func llvmSmokeBoolParamReturnIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2293:5
+	// Osty: toolchain/llvmgen.osty:4939:5
 	pick := llvmEmitter()
 	_ = pick
-	// Osty: toolchain/llvmgen.osty:2294:5
+	// Osty: toolchain/llvmgen.osty:4940:5
 	llvmBind(pick, "flag", llvmI1("%flag"))
-	// Osty: toolchain/llvmgen.osty:2295:5
+	// Osty: toolchain/llvmgen.osty:4941:5
 	labels := llvmIfExprStart(pick, llvmIdent(pick, "flag"))
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2296:5
+	// Osty: toolchain/llvmgen.osty:4942:5
 	thenValue := llvmIntLiteral(42)
 	_ = thenValue
-	// Osty: toolchain/llvmgen.osty:2297:5
+	// Osty: toolchain/llvmgen.osty:4943:5
 	llvmIfExprElse(pick, labels)
-	// Osty: toolchain/llvmgen.osty:2298:5
+	// Osty: toolchain/llvmgen.osty:4944:5
 	elseValue := llvmIntLiteral(0)
 	_ = elseValue
-	// Osty: toolchain/llvmgen.osty:2299:5
+	// Osty: toolchain/llvmgen.osty:4945:5
 	out := llvmIfExprEnd(pick, "i64", thenValue, elseValue, labels)
 	_ = out
-	// Osty: toolchain/llvmgen.osty:2300:5
+	// Osty: toolchain/llvmgen.osty:4946:5
 	llvmReturn(pick, out)
-	// Osty: toolchain/llvmgen.osty:2302:5
+	// Osty: toolchain/llvmgen.osty:4948:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2303:5
+	// Osty: toolchain/llvmgen.osty:4949:5
 	value := llvmCall(main, "i64", "pick", []*LlvmValue{llvmI1("true")})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2304:5
+	// Osty: toolchain/llvmgen.osty:4950:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:2305:5
+	// Osty: toolchain/llvmgen.osty:4951:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "pick", []*LlvmParam{llvmParam("flag", "i1")}, pick.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2317:5
+// Osty: toolchain/llvmgen.osty:4963:5
 func llvmSmokeIntRangeExclusiveIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2318:5
+	// Osty: toolchain/llvmgen.osty:4964:5
 	sumTo := llvmEmitter()
 	_ = sumTo
-	// Osty: toolchain/llvmgen.osty:2319:5
+	// Osty: toolchain/llvmgen.osty:4965:5
 	llvmBind(sumTo, "n", llvmI64("%n"))
-	// Osty: toolchain/llvmgen.osty:2320:5
+	// Osty: toolchain/llvmgen.osty:4966:5
 	llvmMutableLet(sumTo, "total", llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:2321:5
+	// Osty: toolchain/llvmgen.osty:4967:5
 	loop := llvmRangeStart(sumTo, "i", llvmIntLiteral(0), llvmIdent(sumTo, "n"), false)
 	_ = loop
-	// Osty: toolchain/llvmgen.osty:2322:5
+	// Osty: toolchain/llvmgen.osty:4968:5
 	nextTotal := llvmBinaryI64(sumTo, "add", llvmIdent(sumTo, "total"), llvmIdent(sumTo, "i"))
 	_ = nextTotal
-	// Osty: toolchain/llvmgen.osty:2323:5
+	// Osty: toolchain/llvmgen.osty:4969:5
 	_ = llvmAssign(sumTo, "total", nextTotal)
-	// Osty: toolchain/llvmgen.osty:2324:5
+	// Osty: toolchain/llvmgen.osty:4970:5
 	llvmRangeEnd(sumTo, loop)
-	// Osty: toolchain/llvmgen.osty:2325:5
+	// Osty: toolchain/llvmgen.osty:4971:5
 	llvmReturn(sumTo, llvmIdent(sumTo, "total"))
-	// Osty: toolchain/llvmgen.osty:2327:5
+	// Osty: toolchain/llvmgen.osty:4973:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2328:5
+	// Osty: toolchain/llvmgen.osty:4974:5
 	value := llvmCall(main, "i64", "sumTo", []*LlvmValue{llvmIntLiteral(7)})
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2329:5
+	// Osty: toolchain/llvmgen.osty:4975:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:2330:5
+	// Osty: toolchain/llvmgen.osty:4976:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i64", "sumTo", []*LlvmParam{llvmParam("n", "i64")}, sumTo.body), llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2342:5
+// Osty: toolchain/llvmgen.osty:4988:5
 func llvmSmokeIntUnaryIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2343:5
+	// Osty: toolchain/llvmgen.osty:4989:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2344:5
+	// Osty: toolchain/llvmgen.osty:4990:5
 	diff := llvmBinaryI64(main, "sub", llvmIntLiteral(40), llvmIntLiteral(82))
 	_ = diff
-	// Osty: toolchain/llvmgen.osty:2345:5
+	// Osty: toolchain/llvmgen.osty:4991:5
 	value := llvmBinaryI64(main, "sub", llvmIntLiteral(0), diff)
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2346:5
+	// Osty: toolchain/llvmgen.osty:4992:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:2347:5
+	// Osty: toolchain/llvmgen.osty:4993:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2358:5
+// Osty: toolchain/llvmgen.osty:5004:5
 func llvmSmokeIntModuloIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2359:5
+	// Osty: toolchain/llvmgen.osty:5005:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2360:5
+	// Osty: toolchain/llvmgen.osty:5006:5
 	value := llvmBinaryI64(main, "srem", llvmIntLiteral(85), llvmIntLiteral(43))
 	_ = value
-	// Osty: toolchain/llvmgen.osty:2361:5
+	// Osty: toolchain/llvmgen.osty:5007:5
 	llvmPrintlnI64(main, value)
-	// Osty: toolchain/llvmgen.osty:2362:5
+	// Osty: toolchain/llvmgen.osty:5008:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2373:5
+// Osty: toolchain/llvmgen.osty:5019:5
 func llvmSmokeStructStringFieldIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2374:5
+	// Osty: toolchain/llvmgen.osty:5020:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2375:5
+	// Osty: toolchain/llvmgen.osty:5021:5
 	msg := llvmStructLiteral(main, "%Message", []*LlvmValue{llvmStringLiteral(main, "struct string")})
 	_ = msg
-	// Osty: toolchain/llvmgen.osty:2376:5
+	// Osty: toolchain/llvmgen.osty:5022:5
 	llvmImmutableLet(main, "msg", msg)
-	// Osty: toolchain/llvmgen.osty:2377:5
+	// Osty: toolchain/llvmgen.osty:5023:5
 	llvmPrintlnString(main, llvmExtractValue(main, llvmIdent(main, "msg"), "ptr", 0))
-	// Osty: toolchain/llvmgen.osty:2378:5
+	// Osty: toolchain/llvmgen.osty:5024:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Message", []string{"ptr"})}, main.stringGlobals, []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2391:5
+// Osty: toolchain/llvmgen.osty:5039:5
 func llvmSmokeStructBoolFieldIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2392:5
+	// Osty: toolchain/llvmgen.osty:5040:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2393:5
+	// Osty: toolchain/llvmgen.osty:5041:5
 	gate := llvmStructLiteral(main, "%Gate", []*LlvmValue{llvmI1("true")})
 	_ = gate
-	// Osty: toolchain/llvmgen.osty:2394:5
+	// Osty: toolchain/llvmgen.osty:5042:5
 	llvmImmutableLet(main, "gate", gate)
-	// Osty: toolchain/llvmgen.osty:2395:5
+	// Osty: toolchain/llvmgen.osty:5043:5
 	cond := llvmExtractValue(main, llvmIdent(main, "gate"), "i1", 0)
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2396:5
+	// Osty: toolchain/llvmgen.osty:5044:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2397:5
+	// Osty: toolchain/llvmgen.osty:5045:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:2398:5
+	// Osty: toolchain/llvmgen.osty:5046:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2399:5
+	// Osty: toolchain/llvmgen.osty:5047:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:2400:5
+	// Osty: toolchain/llvmgen.osty:5048:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:2401:5
+	// Osty: toolchain/llvmgen.osty:5049:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModuleWithGlobalsAndTypes(sourcePath, "", []string{llvmStructTypeDef("Gate", []string{"i1"})}, make([]*LlvmStringGlobal, 0, 1), []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2414:5
+// Osty: toolchain/llvmgen.osty:5064:5
 func llvmSmokeBoolMutableIR(sourcePath string) string {
-	// Osty: toolchain/llvmgen.osty:2415:5
+	// Osty: toolchain/llvmgen.osty:5065:5
 	main := llvmEmitter()
 	_ = main
-	// Osty: toolchain/llvmgen.osty:2416:5
+	// Osty: toolchain/llvmgen.osty:5066:5
 	llvmMutableLet(main, "flag", llvmI1("false"))
-	// Osty: toolchain/llvmgen.osty:2417:5
+	// Osty: toolchain/llvmgen.osty:5067:5
 	_ = llvmAssign(main, "flag", llvmI1("true"))
-	// Osty: toolchain/llvmgen.osty:2418:5
+	// Osty: toolchain/llvmgen.osty:5068:5
 	cond := llvmIdent(main, "flag")
 	_ = cond
-	// Osty: toolchain/llvmgen.osty:2419:5
+	// Osty: toolchain/llvmgen.osty:5069:5
 	labels := llvmIfStart(main, cond)
 	_ = labels
-	// Osty: toolchain/llvmgen.osty:2420:5
+	// Osty: toolchain/llvmgen.osty:5070:5
 	llvmPrintlnI64(main, llvmIntLiteral(42))
-	// Osty: toolchain/llvmgen.osty:2421:5
+	// Osty: toolchain/llvmgen.osty:5071:5
 	llvmIfElse(main, labels)
-	// Osty: toolchain/llvmgen.osty:2422:5
+	// Osty: toolchain/llvmgen.osty:5072:5
 	llvmPrintlnI64(main, llvmIntLiteral(0))
-	// Osty: toolchain/llvmgen.osty:2423:5
+	// Osty: toolchain/llvmgen.osty:5073:5
 	llvmIfEnd(main, labels)
-	// Osty: toolchain/llvmgen.osty:2424:5
+	// Osty: toolchain/llvmgen.osty:5074:5
 	llvmReturnI32Zero(main)
 	return llvmRenderModule(sourcePath, "", []string{llvmRenderFunction("i32", "main", make([]*LlvmParam, 0, 1), main.body)})
 }
 
-// Osty: toolchain/llvmgen.osty:2435:1
+// Osty: toolchain/llvmgen.osty:5085:1
 func llvmCallArgs(args []*LlvmValue) string {
-	// Osty: toolchain/llvmgen.osty:2436:5
+	// Osty: toolchain/llvmgen.osty:5086:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: toolchain/llvmgen.osty:2437:5
+	// Osty: toolchain/llvmgen.osty:5087:5
 	for _, arg := range args {
-		// Osty: toolchain/llvmgen.osty:2438:9
+		// Osty: toolchain/llvmgen.osty:5088:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %s", ostyToString(arg.typ), ostyToString(arg.name)))
 			return struct{}{}
@@ -4596,14 +5547,14 @@ func llvmCallArgs(args []*LlvmValue) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: toolchain/llvmgen.osty:2443:1
+// Osty: toolchain/llvmgen.osty:5093:1
 func llvmParams(params []*LlvmParam) string {
-	// Osty: toolchain/llvmgen.osty:2444:5
+	// Osty: toolchain/llvmgen.osty:5094:5
 	var parts []string = make([]string, 0, 1)
 	_ = parts
-	// Osty: toolchain/llvmgen.osty:2445:5
+	// Osty: toolchain/llvmgen.osty:5095:5
 	for _, param := range params {
-		// Osty: toolchain/llvmgen.osty:2446:9
+		// Osty: toolchain/llvmgen.osty:5096:9
 		func() struct{} {
 			parts = append(parts, fmt.Sprintf("%s %%%s", ostyToString(param.typ), ostyToString(param.name)))
 			return struct{}{}
@@ -4612,42 +5563,42 @@ func llvmParams(params []*LlvmParam) string {
 	return llvmStrings.Join(parts, ", ")
 }
 
-// Osty: toolchain/llvmgen.osty:2451:1
+// Osty: toolchain/llvmgen.osty:5101:1
 func llvmNextTemp(emitter *LlvmEmitter) string {
-	// Osty: toolchain/llvmgen.osty:2452:5
+	// Osty: toolchain/llvmgen.osty:5102:5
 	name := fmt.Sprintf("%%t%s", ostyToString(emitter.temp))
 	_ = name
-	// Osty: toolchain/llvmgen.osty:2453:12
+	// Osty: toolchain/llvmgen.osty:5103:12
 	emitter.temp = func() int {
-		var _p7 int = emitter.temp
-		var _rhs8 int = 1
-		if _rhs8 > 0 && _p7 > math.MaxInt-_rhs8 {
+		var _p23 int = emitter.temp
+		var _rhs24 int = 1
+		if _rhs24 > 0 && _p23 > math.MaxInt-_rhs24 {
 			panic("integer overflow")
 		}
-		if _rhs8 < 0 && _p7 < math.MinInt-_rhs8 {
+		if _rhs24 < 0 && _p23 < math.MinInt-_rhs24 {
 			panic("integer overflow")
 		}
-		return _p7 + _rhs8
+		return _p23 + _rhs24
 	}()
 	return name
 }
 
-// Osty: toolchain/llvmgen.osty:2457:1
+// Osty: toolchain/llvmgen.osty:5107:1
 func llvmNextLabel(emitter *LlvmEmitter, prefix string) string {
-	// Osty: toolchain/llvmgen.osty:2458:5
+	// Osty: toolchain/llvmgen.osty:5108:5
 	name := fmt.Sprintf("%s%s", ostyToString(prefix), ostyToString(emitter.label))
 	_ = name
-	// Osty: toolchain/llvmgen.osty:2459:12
+	// Osty: toolchain/llvmgen.osty:5109:12
 	emitter.label = func() int {
-		var _p9 int = emitter.label
-		var _rhs10 int = 1
-		if _rhs10 > 0 && _p9 > math.MaxInt-_rhs10 {
+		var _p25 int = emitter.label
+		var _rhs26 int = 1
+		if _rhs26 > 0 && _p25 > math.MaxInt-_rhs26 {
 			panic("integer overflow")
 		}
-		if _rhs10 < 0 && _p9 < math.MinInt-_rhs10 {
+		if _rhs26 < 0 && _p25 < math.MinInt-_rhs26 {
 			panic("integer overflow")
 		}
-		return _p9 + _rhs10
+		return _p25 + _rhs26
 	}()
 	return name
 }

--- a/internal/llvmgen/toolchain_support_bundle.go
+++ b/internal/llvmgen/toolchain_support_bundle.go
@@ -1,6 +1,8 @@
 package llvmgen
 
 import (
+	"strings"
+
 	"github.com/osty/osty/internal/selfhost/bundle"
 )
 
@@ -12,9 +14,29 @@ func ToolchainSupportFiles() []string {
 	return bundle.ToolchainLLVMGenFiles()
 }
 
-// MergeToolchainSupport prepends the minimal Go-hosted strings surface the
-// bootstrap transpiler needs, then concatenates the llvmgen helper sources into
-// one standalone .osty file.
+// MergeToolchainSupport reuses the shared llvmgen support merger, then strips
+// the native-owned entry slice so the transpiled support bundle does not
+// redeclare helpers that already live in native_entry_snapshot.go.
 func MergeToolchainSupport(root string) ([]byte, error) {
-	return bundle.MergeToolchainLLVMGen(root)
+	merged, err := bundle.MergeToolchainLLVMGen(root)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(stripLlvmNativeEntrySlice(string(merged))), nil
+}
+
+func stripLlvmNativeEntrySlice(src string) string {
+	const startMarker = "pub enum LlvmNativeExprKind {"
+	const endMarker = "/// Phase A4 fn-value thunk template."
+
+	start := strings.Index(src, startMarker)
+	if start < 0 {
+		return src
+	}
+	end := strings.Index(src[start:], endMarker)
+	if end < 0 {
+		return src
+	}
+	end += start
+	return src[:start] + src[end:]
 }

--- a/internal/llvmgen/toolchain_support_gen_test.go
+++ b/internal/llvmgen/toolchain_support_gen_test.go
@@ -24,6 +24,9 @@ func TestToolchainLlvmgenSupportSourcesTranspile(t *testing.T) {
 	if err := os.WriteFile(mergedPath, merged, 0o644); err != nil {
 		t.Fatalf("write merged source: %v", err)
 	}
+	if bytes.Contains(merged, []byte("pub fn llvmNativeEmitModule(")) {
+		t.Fatal("merged llvmgen support still contains the native entry slice")
+	}
 	generatedPath := filepath.Join(tmpDir, "llvmgen_support_generated.go")
 	goModPath := filepath.Join(tmpDir, "go.mod")
 

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -672,6 +672,13 @@ pub fn llvmPrintlnF64(emitter: LlvmEmitter, value: LlvmValue) {
     emitter.body.push("  {tmp} = call i32 (ptr, ...) @printf(ptr @.fmt_f64, double {value.name})")
 }
 
+pub fn llvmPrintlnBool(emitter: LlvmEmitter, value: LlvmValue) {
+    let text = llvmNextTemp(emitter)
+    emitter.body.push("  {text} = select i1 {value.name}, ptr @.bool_true, ptr @.bool_false")
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push("  {tmp} = call i32 (ptr, ...) @printf(ptr @.fmt_str, ptr {text})")
+}
+
 pub fn llvmStringLiteral(emitter: LlvmEmitter, text: String) -> LlvmValue {
     let name = "@.str{emitter.stringId}"
     emitter.stringId = emitter.stringId + 1
@@ -2093,6 +2100,10 @@ pub fn llvmListRuntimeSetSymbol(suffix: String) -> String {
     "osty_rt_list_set_{suffix}"
 }
 
+pub fn llvmListRuntimeInsertSymbol(suffix: String) -> String {
+    "osty_rt_list_insert_{suffix}"
+}
+
 /// Pick the `osty_rt_list_sorted_*` entry point for an element LLVM
 /// type. Returns `""` when no typed runtime exists — callers use the
 /// empty string as the "unsupported element type" signal and emit a
@@ -3054,6 +3065,10 @@ pub fn llvmStringRuntimeSplitSymbol() -> String {
     "osty_rt_strings_Split"
 }
 
+pub fn llvmStringRuntimeSplitNSymbol() -> String {
+    "osty_rt_strings_SplitN"
+}
+
 pub fn llvmStringRuntimeConcatSymbol() -> String {
     "osty_rt_strings_Concat"
 }
@@ -3074,12 +3089,44 @@ pub fn llvmStringRuntimeByteLenSymbol() -> String {
     "osty_rt_strings_ByteLen"
 }
 
+pub fn llvmStringRuntimeCountSymbol() -> String {
+    "osty_rt_strings_Count"
+}
+
+pub fn llvmStringRuntimeIndexOfSymbol() -> String {
+    "osty_rt_strings_IndexOf"
+}
+
 pub fn llvmStringRuntimeCompareSymbol() -> String {
     "osty_rt_strings_Compare"
 }
 
 pub fn llvmStringRuntimeJoinSymbol() -> String {
     "osty_rt_strings_Join"
+}
+
+pub fn llvmStringRuntimeRepeatSymbol() -> String {
+    "osty_rt_strings_Repeat"
+}
+
+pub fn llvmStringRuntimeReplaceSymbol() -> String {
+    "osty_rt_strings_Replace"
+}
+
+pub fn llvmStringRuntimeReplaceAllSymbol() -> String {
+    "osty_rt_strings_ReplaceAll"
+}
+
+pub fn llvmStringRuntimeSliceSymbol() -> String {
+    "osty_rt_strings_Slice"
+}
+
+pub fn llvmStringRuntimeTrimStartSymbol() -> String {
+    "osty_rt_strings_TrimStart"
+}
+
+pub fn llvmStringRuntimeTrimEndSymbol() -> String {
+    "osty_rt_strings_TrimEnd"
 }
 
 pub fn llvmStringRuntimeTrimPrefixSymbol() -> String {
@@ -3102,6 +3149,10 @@ pub fn llvmStringRuntimeBytesSymbol() -> String {
     "osty_rt_strings_Bytes"
 }
 
+pub fn llvmStringRuntimeToBytesSymbol() -> String {
+    "osty_rt_strings_ToBytes"
+}
+
 /// LLVM forward declarations for the string runtime surface plus the
 /// scalar `Int`/`Float` -> `String` helpers used by interpolation.
 /// All string values cross the ABI as null-terminated `ptr`, and
@@ -3120,13 +3171,22 @@ pub fn llvmStringRuntimeDeclarations() -> List<String> {
         "declare ptr @osty_rt_float_to_string(double)",
         "declare ptr @osty_rt_bool_to_string(i1)",
         "declare i64 @osty_rt_strings_ByteLen(ptr)",
+        "declare i64 @osty_rt_strings_Count(ptr, ptr)",
+        "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)",
         "declare i64 @osty_rt_strings_Compare(ptr, ptr)",
         "declare ptr @osty_rt_strings_Join(ptr, ptr)",
+        "declare ptr @osty_rt_strings_Repeat(ptr, i64)",
+        "declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)",
+        "declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)",
+        "declare ptr @osty_rt_strings_Slice(ptr, i64, i64)",
+        "declare ptr @osty_rt_strings_TrimStart(ptr)",
+        "declare ptr @osty_rt_strings_TrimEnd(ptr)",
         "declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)",
         "declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)",
         "declare ptr @osty_rt_strings_TrimSpace(ptr)",
         "declare ptr @osty_rt_strings_Chars(ptr)",
         "declare ptr @osty_rt_strings_Bytes(ptr)",
+        "declare ptr @osty_rt_strings_ToBytes(ptr)",
     ]
 }
 
@@ -3182,6 +3242,22 @@ pub fn llvmStringByteLen(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "i64", "osty_rt_strings_ByteLen", [value])
 }
 
+pub fn llvmStringRuntimeCount(
+    emitter: LlvmEmitter,
+    value: LlvmValue,
+    substr: LlvmValue,
+) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_strings_Count", [value, substr])
+}
+
+pub fn llvmStringRuntimeIndexOf(
+    emitter: LlvmEmitter,
+    value: LlvmValue,
+    substr: LlvmValue,
+) -> LlvmValue {
+    llvmCall(emitter, "i64", "osty_rt_strings_IndexOf", [value, substr])
+}
+
 pub fn llvmStringRuntimeCompare(
     emitter: LlvmEmitter,
     left: LlvmValue,
@@ -3196,6 +3272,49 @@ pub fn llvmStringRuntimeJoin(
     sep: LlvmValue,
 ) -> LlvmValue {
     llvmCall(emitter, "ptr", "osty_rt_strings_Join", [parts, sep])
+}
+
+pub fn llvmStringRuntimeRepeat(
+    emitter: LlvmEmitter,
+    value: LlvmValue,
+    n: LlvmValue,
+) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_Repeat", [value, n])
+}
+
+pub fn llvmStringRuntimeReplace(
+    emitter: LlvmEmitter,
+    value: LlvmValue,
+    old: LlvmValue,
+    newValue: LlvmValue,
+) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_Replace", [value, old, newValue])
+}
+
+pub fn llvmStringRuntimeReplaceAll(
+    emitter: LlvmEmitter,
+    value: LlvmValue,
+    old: LlvmValue,
+    newValue: LlvmValue,
+) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_ReplaceAll", [value, old, newValue])
+}
+
+pub fn llvmStringRuntimeSlice(
+    emitter: LlvmEmitter,
+    value: LlvmValue,
+    start: LlvmValue,
+    end: LlvmValue,
+) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_Slice", [value, start, end])
+}
+
+pub fn llvmStringRuntimeTrimStart(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_TrimStart", [value])
+}
+
+pub fn llvmStringRuntimeTrimEnd(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_TrimEnd", [value])
 }
 
 pub fn llvmStringRuntimeTrimPrefix(
@@ -3224,6 +3343,10 @@ pub fn llvmStringChars(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
 
 pub fn llvmStringBytes(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
     llvmCall(emitter, "ptr", "osty_rt_strings_Bytes", [value])
+}
+
+pub fn llvmStringToBytes(emitter: LlvmEmitter, value: LlvmValue) -> LlvmValue {
+    llvmCall(emitter, "ptr", "osty_rt_strings_ToBytes", [value])
 }
 
 pub fn llvmBuiltinType(name: String) -> String {


### PR DESCRIPTION
## Summary
- fix llvmgen support merging so generated support strips the native-entry slice while preserving shared bundle normalization
- restore missing toolchain llvmgen helpers needed by generated snapshots and align safepoint helper signatures with current callers
- update the stale bool `Map.getOr` regression to assert the current direct-lookup fast path instead of the old boxed Option path

## Why
`internal/llvmgen` had drift between the checked-in snapshot, the toolchain source of truth, and the merged support bundle used by regeneration tests. That drift showed up as duplicate native-entry helpers, missing string/list helpers in generated snapshots, and a stale bool `getOr` expectation.

## Impact
- `go generate ./internal/llvmgen` is idempotent and compiles again in a fresh worktree
- merged llvmgen support transpiles without redeclaring the native entry slice
- llvmgen’s full package test sweep stays green after the snapshot/toolchain adjustments

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen`
- `go test -count=1 -vet=off -run 'TestGenerateMapGetBoolValueUses1ByteStackSlot|TestToolchainLlvmgenSupportSourcesTranspile|TestGoGenerateSupportSnapshotIsFixedPoint' ./internal/llvmgen`