### PR TITLE
feat(stdlib-inject): transitive closure for same-module bare-Ident calls

### DIFF
--- a/internal/backend/stdlib_inject.go
+++ b/internal/backend/stdlib_inject.go
@@ -166,8 +166,26 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 	if len(reachedFns) == 0 && len(reachedMethods) == 0 {
 		return nil, nil
 	}
+	type fnKey struct{ module, name string }
+	injectedFn := map[fnKey]bool{}
+	for _, r := range reachedFns {
+		injectedFn[fnKey{module: r.Module, name: r.Fn.Name}] = true
+	}
+	type methodKey struct{ module, typeName, method string }
+	injectedMethod := map[methodKey]bool{}
+	for _, r := range reachedMethods {
+		injectedMethod[methodKey{module: r.Module, typeName: r.Type, method: r.Method}] = true
+	}
+
 	var out []ir.Decl
 	var issues []error
+	// Track lowered free fns by module so we can transitively scan them
+	// for additional same-module callees (the closure step below).
+	type loweredFromModule struct {
+		module string
+		fn     *ir.FnDecl
+	}
+	var loweredFreeFns []loweredFromModule
 	for _, r := range reachedFns {
 		res := stdlibResolveResult(reg, r.Module)
 		chk := stdlibCheckResult(reg, r.Module)
@@ -178,6 +196,7 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 		}
 		lowered.Name = StdlibSymbol(r.Module, r.Fn.Name)
 		out = append(out, lowered)
+		loweredFreeFns = append(loweredFreeFns, loweredFromModule{module: r.Module, fn: lowered})
 	}
 	for _, m := range reachedMethods {
 		res := stdlibResolveResult(reg, m.Module)
@@ -187,11 +206,115 @@ func injectReachableStdlibBodies(mod *ir.Module, reg *stdlib.Registry) ([]ir.Dec
 		if lowered == nil {
 			continue
 		}
-		out = append(out, methodToFreeFn(lowered, m.Module, m.Type, m.Method))
+		freeFn := methodToFreeFn(lowered, m.Module, m.Type, m.Method)
+		out = append(out, freeFn)
+		// Methods can call same-module free fns too; route them
+		// through the same closure step.
+		loweredFreeFns = append(loweredFreeFns, loweredFromModule{module: m.Module, fn: freeFn})
 	}
 	RewriteStdlibCallsites(mod, reachedFns)
 	RewriteStdlibMethodCallsites(mod, reachedMethods)
+
+	// Closure pass: an injected stdlib body can reference other free
+	// fns from its own module by bare Ident (e.g. `trim` calls
+	// `trimEnd(trimStart(s))`). The first-hop scan above only saw
+	// `strings.trim` from the user module — `trimStart`/`trimEnd`
+	// would slip through. Walk each newly lowered body, find bare
+	// Ident calls that resolve to same-module stdlib fns, inject
+	// those, and rewrite the call site to the mangled name. Loop to
+	// fixed point so a chain (`a → b → c`) is fully closed in one
+	// pass.
+	queue := append([]loweredFromModule(nil), loweredFreeFns...)
+	for len(queue) > 0 {
+		next := queue[0]
+		queue = queue[1:]
+		for callName := range scanBareIdentCallNames(next.fn) {
+			calleeFn := reg.LookupFnDecl(next.module, callName)
+			if calleeFn == nil {
+				continue
+			}
+			k := fnKey{module: next.module, name: callName}
+			if injectedFn[k] {
+				// Already injected — just rewrite this body's
+				// call sites for the name.
+				rewriteBareIdentCalls(next.fn, callName, StdlibSymbol(next.module, callName))
+				continue
+			}
+			injectedFn[k] = true
+			res := stdlibResolveResult(reg, next.module)
+			chk := stdlibCheckResult(reg, next.module)
+			lowered, fnIssues := ir.LowerFnDecl(mod.Package, calleeFn, res, chk)
+			issues = append(issues, fnIssues...)
+			if lowered == nil {
+				continue
+			}
+			lowered.Name = StdlibSymbol(next.module, callName)
+			out = append(out, lowered)
+			rewriteBareIdentCalls(next.fn, callName, lowered.Name)
+			queue = append(queue, loweredFromModule{module: next.module, fn: lowered})
+		}
+	}
 	return out, issues
+}
+
+// scanBareIdentCallNames returns the set of names referenced in
+// `bareName(args)` shaped call sites inside a function body — i.e.
+// `CallExpr{Callee: *Ident}`. Method calls and qualifier calls
+// (`module.fn`, `recv.method`) are intentionally excluded; those
+// have their own reach paths and rewriters.
+//
+// Used by the closure step in `injectReachableStdlibBodies` to
+// discover same-module stdlib helpers an already-injected body
+// transitively depends on (e.g. `strings.trim`'s body references
+// `trimStart` and `trimEnd` as bare Idents). The caller filters the
+// returned names against `Registry.LookupFnDecl(module, name)` to
+// keep user-defined locals / params out of the injection set.
+func scanBareIdentCallNames(fn *ir.FnDecl) map[string]struct{} {
+	out := map[string]struct{}{}
+	if fn == nil || fn.Body == nil {
+		return out
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		call, ok := n.(*ir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		ident, ok := call.Callee.(*ir.Ident)
+		if !ok || ident == nil || ident.Name == "" {
+			return true
+		}
+		out[ident.Name] = struct{}{}
+		return true
+	}), fn.Body)
+	return out
+}
+
+// rewriteBareIdentCalls walks a function body and renames any bare
+// Ident callee whose Name == old to new. Mutates the IR in place.
+// Method calls and FieldExpr callees are not affected — they have
+// their own rewriter paths.
+//
+// Used by the closure step after injecting a same-module callee:
+// the caller's body still references the callee by its short name
+// (`trimEnd(s)`), and this rewrites it to the mangled symbol
+// (`osty_std_strings__trimEnd(s)`).
+func rewriteBareIdentCalls(fn *ir.FnDecl, oldName, newName string) {
+	if fn == nil || fn.Body == nil || oldName == "" || newName == "" || oldName == newName {
+		return
+	}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		call, ok := n.(*ir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		ident, ok := call.Callee.(*ir.Ident)
+		if !ok || ident == nil || ident.Name != oldName {
+			return true
+		}
+		ident.Name = newName
+		ident.Kind = ir.IdentFn
+		return true
+	}), fn.Body)
 }
 
 // methodToFreeFn converts a lowered stdlib method declaration into a

--- a/internal/backend/stdlib_inject_e2e_test.go
+++ b/internal/backend/stdlib_inject_e2e_test.go
@@ -239,3 +239,151 @@ func TestInjectReachableStdlibBodiesMixesFnsAndMethods(t *testing.T) {
 		t.Errorf("method callsite not rewritten: stmt.X = %T", methodStmt.X)
 	}
 }
+
+// TestInjectReachableStdlibBodiesTransitiveClosure verifies the
+// closure step pulls in same-module helpers an injected body
+// references by bare Ident. `strings.trim`'s body is
+// `trimEnd(trimStart(s))` — both `trimStart` and `trimEnd` are free
+// fns in the same `strings` module, called without a `strings.`
+// qualifier. Without the closure step they'd slip through the
+// first-hop scan, leaving the injected `trim` body referencing
+// undefined symbols.
+//
+// Asserts:
+//  1. injection includes the user-called `trim` PLUS the two
+//     transitively-pulled helpers (`trimStart`, `trimEnd`)
+//  2. the injected `trim`'s body has its bare Ident calls rewritten
+//     to mangled symbols (`osty_std_strings__trimStart` /
+//     `_trimEnd`), not the short names
+//  3. each rewritten Ident has Kind=IdentFn so downstream lookups
+//     treat it as a function reference rather than a local
+func TestInjectReachableStdlibBodiesTransitiveClosure(t *testing.T) {
+	reg := stdlib.LoadCached()
+	// User code: `strings.trim(s)`.
+	call := &ir.CallExpr{
+		Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "trim"},
+		Args:   []ir.Arg{{Value: &ir.Ident{Name: "s"}}},
+	}
+	mod := &ir.Module{
+		Package: "main",
+		Script:  []ir.Stmt{&ir.ExprStmt{X: call}},
+	}
+	injected, issues := injectReachableStdlibBodies(mod, reg)
+	for _, issue := range issues {
+		t.Logf("non-fatal issue: %v", issue)
+	}
+	wantSymbols := map[string]bool{
+		"osty_std_strings__trim":      false,
+		"osty_std_strings__trimStart": false,
+		"osty_std_strings__trimEnd":   false,
+	}
+	for _, d := range injected {
+		fn, ok := d.(*ir.FnDecl)
+		if !ok {
+			continue
+		}
+		if _, want := wantSymbols[fn.Name]; want {
+			wantSymbols[fn.Name] = true
+		}
+	}
+	for sym, found := range wantSymbols {
+		if !found {
+			t.Fatalf("transitive closure did not inject %s; injected names: %v",
+				sym, fnDeclNames(injected))
+		}
+	}
+
+	// The injected `trim` body must reference the helpers by their
+	// mangled symbols (Kind=IdentFn), not by their short names.
+	var trimFn *ir.FnDecl
+	for _, d := range injected {
+		fn, ok := d.(*ir.FnDecl)
+		if !ok || fn.Name != "osty_std_strings__trim" {
+			continue
+		}
+		trimFn = fn
+		break
+	}
+	if trimFn == nil {
+		t.Fatalf("could not find lowered trim fn in injected decls")
+	}
+	mangledCalls := map[string]bool{}
+	bareCalls := []string{}
+	ir.Walk(ir.VisitorFunc(func(n ir.Node) bool {
+		c, ok := n.(*ir.CallExpr)
+		if !ok || c == nil {
+			return true
+		}
+		ident, ok := c.Callee.(*ir.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "osty_std_strings__trimStart" || ident.Name == "osty_std_strings__trimEnd" {
+			mangledCalls[ident.Name] = true
+			if ident.Kind != ir.IdentFn {
+				t.Errorf("rewritten ident %q has Kind %v, want IdentFn", ident.Name, ident.Kind)
+			}
+		}
+		if ident.Name == "trimStart" || ident.Name == "trimEnd" {
+			bareCalls = append(bareCalls, ident.Name)
+		}
+		return true
+	}), trimFn.Body)
+	if !mangledCalls["osty_std_strings__trimStart"] {
+		t.Errorf("trim body did not call mangled trimStart")
+	}
+	if !mangledCalls["osty_std_strings__trimEnd"] {
+		t.Errorf("trim body did not call mangled trimEnd")
+	}
+	if len(bareCalls) != 0 {
+		t.Errorf("trim body still has bare-Ident calls (un-rewritten): %v", bareCalls)
+	}
+}
+
+// TestInjectReachableStdlibBodiesTransitiveDedupe confirms a helper
+// reachable both directly (via a user call) and transitively (via
+// another injected fn's body) is injected exactly once. Without the
+// `injectedFn` set check the closure step would re-lower it and
+// emit a duplicate FnDecl.
+func TestInjectReachableStdlibBodiesTransitiveDedupe(t *testing.T) {
+	reg := stdlib.LoadCached()
+	// Call both `trim` (which transitively references trimStart) and
+	// `trimStart` directly.
+	mod := &ir.Module{
+		Package: "main",
+		Script: []ir.Stmt{
+			&ir.ExprStmt{X: &ir.CallExpr{
+				Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "trim"},
+				Args:   []ir.Arg{{Value: &ir.Ident{Name: "s"}}},
+			}},
+			&ir.ExprStmt{X: &ir.CallExpr{
+				Callee: &ir.FieldExpr{X: &ir.Ident{Name: "strings"}, Name: "trimStart"},
+				Args:   []ir.Arg{{Value: &ir.Ident{Name: "s"}}},
+			}},
+		},
+	}
+	injected, _ := injectReachableStdlibBodies(mod, reg)
+	count := 0
+	for _, d := range injected {
+		fn, ok := d.(*ir.FnDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name == "osty_std_strings__trimStart" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("trimStart injected %d times, want exactly 1; injected names: %v", count, fnDeclNames(injected))
+	}
+}
+
+func fnDeclNames(decls []ir.Decl) []string {
+	out := []string{}
+	for _, d := range decls {
+		if fn, ok := d.(*ir.FnDecl); ok {
+			out = append(out, fn.Name)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

`injectReachableStdlibBodies` was first-hop only: a stdlib body that called another fn in the same module by bare Ident (no `module.` qualifier) had its callees skipped. `strings.trim` is the canonical case — its body is `trimEnd(trimStart(s))` and both helpers slipped through the reach scan, leaving the injected `trim` body referencing undefined `trimStart` / `trimEnd` symbols that LLVM015'd as unknown identifiers.

## What changed

A closure pass after the first-hop injection:

1. Track each lowered free fn alongside the stdlib module it came from (methods are also routed here since their bodies can call free helpers too).
2. For each lowered body, collect the names of bare-Ident call sites via `scanBareIdentCallNames`.
3. For each name `N`: check `Registry.LookupFnDecl(module, N)`. If non-nil, lower + mangle it (skipping if already injected via dedupe set), and rewrite the caller's bare Ident to the mangled symbol.
4. Queue each newly injected body and loop until empty — handles chains (`a → b → c`) in one pass.

Two helpers kept narrow:

- `scanBareIdentCallNames` only looks at `CallExpr{Callee: *Ident}`; method calls / `FieldExpr` callees route through the existing rewriters and stay out of this surface.
- `rewriteBareIdentCalls(fn, old, new)` walks one fn body and renames matching idents in place, setting `Kind=IdentFn` so downstream lookups treat the rewritten symbol as a function reference rather than a local.

## Why

Without this PR, anything that triangulates through helper fns walls. With it, the dispatch graph is fully closed: any user-side call to a stdlib free fn (or method) pulls in the whole transitive subgraph it reaches via bare-name calls in its own module.

## E2E verification

`use std.strings; fn main() { println(strings.trim(\"   hi   \")) }` with `OSTY_STDLIB_BODY_LOWER=1`:

```
define ptr @osty_std_strings__trim(ptr %s) {
  %t0 = call ptr @osty_std_strings__trimStart(ptr %s)
  %t1 = call ptr @osty_std_strings__trimEnd(ptr %t0)
  ...
}
define ptr @osty_std_strings__trimStart(ptr %s) { ... }
define ptr @osty_std_strings__trimEnd(ptr %s) { ... }
```

All three symbols inject; the trim body's callees are mangled; LLVM015 is gone.

## Test plan

Two new tests in `stdlib_inject_e2e_test.go`:

- **`TestInjectReachableStdlibBodiesTransitiveClosure`** — drives the `strings.trim` shape end-to-end and asserts:
  - all three symbols injected (`trim`, `trimStart`, `trimEnd`)
  - trim's body has mangled callee idents (`osty_std_strings__trimStart` / `_trimEnd`)
  - no bare-name idents survive
  - rewritten idents have `Kind=IdentFn`
- **`TestInjectReachableStdlibBodiesTransitiveDedupe`** — a helper reachable both directly (via a user call) and transitively (via another injected fn's body) is injected exactly once.

Plus regression coverage:
- [x] All existing `TestInjectReachableStdlibBodies*` / `TestRewriteStdlib*` / `TestStdlib*` / `TestReachable*` pass.
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline) regression-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)