### PR TITLE
fix(llvmgen): load aggregate ptr argument in list.push

### DIFF
--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2511,12 +2511,24 @@ func (g *generator) emitListMethodCallStmt(call *ast.CallExpr) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	if arg.typ != elemTyp {
-		return true, unsupportedf("type-system", "list.push arg type %s, want %s", arg.typ, elemTyp)
-	}
 	argValue, err := g.loadIfPointer(arg)
 	if err != nil {
 		return true, err
+	}
+	// Aggregate element types (`%Struct`, `%Tuple.*`) reach here as a
+	// ptr pointing at the aggregate's slot — e.g. a stack-spilled
+	// literal produced by `Bucket { ... }` or an `emitListAggregateGet`
+	// out-parameter. Load through the ptr so the push path receives
+	// the actual aggregate value that matches `elemTyp`. Scalar / ptr
+	// elements already arrive at the right width.
+	if argValue.typ != elemTyp && argValue.typ == "ptr" && strings.HasPrefix(elemTyp, "%") {
+		emitter := g.toOstyEmitter()
+		loaded := llvmLoad(emitter, &LlvmValue{typ: elemTyp, name: argValue.ref, pointer: true})
+		g.takeOstyEmitter(emitter)
+		argValue = fromOstyValue(loaded)
+	}
+	if argValue.typ != elemTyp {
+		return true, unsupportedf("type-system", "list.push arg type %s, want %s", argValue.typ, elemTyp)
 	}
 	if g.usesAggregateListABI(elemTyp) {
 		return true, g.emitListAggregatePush(baseValue, argValue)


### PR DESCRIPTION
## Summary

Small but targeted fix: `xs.push(b)` where `xs: List<Struct>` and `b` is a struct-typed local reached `emitListMethodCallStmt` with `arg.typ == "ptr"` (local is a stack-allocated aggregate holding its address). The type check fired before `loadIfPointer` had a chance to dereference, so the push walled on `LLVM011 list.push arg type ptr, want %Struct` — even though the ptr pointed at a valid aggregate slot.

## How

Reorder the dispatch: take `loadIfPointer` on `arg` first, then when the loaded width still reads as `ptr` but `elemTyp` is an aggregate (`%Struct`, `%Tuple.*`), emit an explicit `load <elemTyp>, ptr` so the push path receives the actual aggregate value. Scalar and ptr-backed elements are unaffected.

Unlocks single-element aggregate push inside injected stdlib bodies — the canonical shape `xs.push(Struct { … })` now lowers through `emitListAggregatePush` cleanly.

## Known follow-ups (not in this PR)

- Downstream `Map<K, AggregateStruct>` tests still wall on a separate tuple-specialization mismatch (`%Tuple.ptr.ptr` vs `%Tuple.ptr._Bucket`). The backend constructs the entries-list tuple from a generic `(ptr, ptr)` representation while the specialized Map expects the inlined `(ptr, %Bucket)` shape. That needs a dedicated monomorphize-side tuple-shape fix and is separate work.
- `TestLLVMBackendBinaryKeepsMapKeysSortedAliveUnderGC` shows the same shape with a primitive V.

## Regression impact

No test-count delta in the `OSTY_STDLIB_BODY_LOWER=1` serial suite (next wall still blocks the `Map<K, AggregateStruct>` cases) but the warning shape now points at the real downstream gap rather than a fixable-at-this-layer issue. Baseline flag-off stays green; llvmgen short-tests unchanged.

## Test plan

- [x] `go test ./internal/llvmgen/ -short -timeout 300s` — clean
- [x] `go test ./internal/backend/ -count=1 -p 1 -timeout 600s` (flag on) — same 5 failures (2 sanity + 3 tuple-specialization)
- [x] `go test ./internal/backend/ -count=1 -p 1 -timeout 600s` (flag off) — 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)