### PR TITLE
[codex] Expand native llvmgen IR coverage

### DIFF
--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -61,9 +61,58 @@ func TestRunEmitsNativeOwnedLLVMIRForPackage(t *testing.T) {
 	}
 }
 
-func TestRunReportsNotCoveredForUnsupportedSource(t *testing.T) {
+func TestRunEmitsNativeOwnedLLVMIRForStructFieldAssign(t *testing.T) {
 	var stdout bytes.Buffer
 	stdin := strings.NewReader(`{"path":"main.osty","source":"struct Pair { left: Int, right: Int }\nfn main() { let mut pair = Pair { left: 1, right: 2 } pair.left = 3 println(pair.left) }\n"}`)
+	if err := run(stdin, &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	for _, want := range []string{
+		"%Pair = type { i64, i64 }",
+		"extractvalue %Pair",
+		"insertvalue %Pair",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("llvmIr missing %q:\n%s", want, resp.LLVMIR)
+		}
+	}
+}
+
+func TestRunEmitsNativeOwnedLLVMIRForListIndex(t *testing.T) {
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"path":"main.osty","source":"fn main() { let xs = [1, 2] println(xs[0]) }\n"}`)
+	if err := run(stdin, &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_new()",
+		"call ptr @osty_rt_list_new()",
+		"call void @osty_rt_list_push_i64(",
+		"call i64 @osty_rt_list_get_i64(",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("llvmIr missing %q:\n%s", want, resp.LLVMIR)
+		}
+	}
+}
+
+func TestRunReportsNotCoveredForUnsupportedSource(t *testing.T) {
+	var stdout bytes.Buffer
+	stdin := strings.NewReader(`{"path":"main.osty","source":"struct Pair { left: Int, right: Int }\nfn main() { let xs = [Pair { left: 1, right: 2 }] println(xs[0].left) }\n"}`)
 	if err := run(stdin, &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
 	}

--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -112,7 +112,7 @@ func TestRunEmitsNativeOwnedLLVMIRForListIndex(t *testing.T) {
 
 func TestRunReportsNotCoveredForUnsupportedSource(t *testing.T) {
 	var stdout bytes.Buffer
-	stdin := strings.NewReader(`{"path":"main.osty","source":"struct Pair { left: Int, right: Int }\nfn main() { let xs = [Pair { left: 1, right: 2 }] println(xs[0].left) }\n"}`)
+	stdin := strings.NewReader(`{"path":"main.osty","source":"fn resolve(name: String?) -> String {\n    name ?? \"anonymous\"\n}\n\nfn main() {}\n"}`)
 	if err := run(stdin, &stdout); err != nil {
 		t.Fatalf("run error: %v", err)
 	}

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -252,7 +252,7 @@ func TestEmitGenArtifactUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
 	}
 }
 
-func TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule(t *testing.T) {
+func TestEmitGenArtifactUsesNativeOwnedFastPathForStructFieldAssign(t *testing.T) {
 	dir := t.TempDir()
 	target := writeGenTestFile(t, dir, "main.osty", `struct Pair { left: Int, right: Int }
 
@@ -276,10 +276,12 @@ fn main() {
 	if err != nil {
 		t.Fatalf("prepareGenBackendEntry() error = %v", err)
 	}
-	if _, ok, _, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, ""); err != nil {
+	want, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, "")
+	if err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
-	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered struct field assignment")
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() reported not covered for struct field assignment")
 	}
 
 	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
@@ -289,8 +291,96 @@ fn main() {
 	if result == nil {
 		t.Fatal("emitGenArtifact() result is nil")
 	}
-	if !strings.Contains(string(got), "%Pair = type { i64, i64 }") {
-		t.Fatalf("fallback llvm-ir missing Pair type:\n%s", got)
+	if string(got) != string(want) {
+		t.Fatalf("gen llvm-ir did not use native struct-field fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(result.Warnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	}
+}
+
+func TestEmitGenArtifactUsesNativeOwnedFastPathForListIndex(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", `fn main() {
+    let xs = [1, 2]
+    println(xs[0])
+}
+`)
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+	oldTry := tryExternalGenLLVMIR
+	tryExternalGenLLVMIR = func(*genPackageEntry) ([]byte, bool, []error, error) {
+		return nil, false, nil, nil
+	}
+	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
+	backendEntry, err := prepareGenBackendEntry("main", entry)
+	if err != nil {
+		t.Fatalf("prepareGenBackendEntry() error = %v", err)
+	}
+	want, ok, warnings, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() reported not covered for list index")
+	}
+
+	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
+	if err != nil {
+		t.Fatalf("emitGenArtifact() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("emitGenArtifact() result is nil")
+	}
+	if string(got) != string(want) {
+		t.Fatalf("gen llvm-ir did not use native list fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(result.Warnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	}
+}
+
+func TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule(t *testing.T) {
+	dir := t.TempDir()
+	target := writeGenTestFile(t, dir, "main.osty", `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let xs = [Pair { left: 1, right: 2 }]
+    println(xs[0].left)
+}
+`)
+
+	entry, err := loadGenPackageEntry(target)
+	if err != nil {
+		t.Fatalf("loadGenPackageEntry() error = %v", err)
+	}
+	oldTry := tryExternalGenLLVMIR
+	tryExternalGenLLVMIR = func(*genPackageEntry) ([]byte, bool, []error, error) {
+		return nil, false, nil, nil
+	}
+	t.Cleanup(func() { tryExternalGenLLVMIR = oldTry })
+	backendEntry, err := prepareGenBackendEntry("main", entry)
+	if err != nil {
+		t.Fatalf("prepareGenBackendEntry() error = %v", err)
+	}
+	if _, ok, _, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
+	} else if ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered composite list index")
+	}
+
+	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
+	if err != nil {
+		t.Fatalf("emitGenArtifact() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("emitGenArtifact() result is nil")
+	}
+	if !strings.Contains(string(got), "@osty_rt_list_get_bytes_v1") {
+		t.Fatalf("fallback llvm-ir missing bytes list get runtime call:\n%s", got)
 	}
 }
 

--- a/cmd/osty/main_gen_test.go
+++ b/cmd/osty/main_gen_test.go
@@ -345,11 +345,11 @@ func TestEmitGenArtifactUsesNativeOwnedFastPathForListIndex(t *testing.T) {
 
 func TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule(t *testing.T) {
 	dir := t.TempDir()
-	target := writeGenTestFile(t, dir, "main.osty", `struct Pair { left: Int, right: Int }
+	target := writeGenTestFile(t, dir, "main.osty", `fn resolve(name: String?) -> String {
+    name ?? "anonymous"
+}
 
 fn main() {
-    let xs = [Pair { left: 1, right: 2 }]
-    println(xs[0].left)
 }
 `)
 
@@ -369,7 +369,7 @@ fn main() {
 	if _, ok, _, err := backend.TryEmitNativeOwnedLLVMIRText(backendEntry, ""); err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText() error = %v", err)
 	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered composite list index")
+		t.Fatal("TryEmitNativeOwnedLLVMIRText() unexpectedly covered coalesce fallback")
 	}
 
 	got, result, err := emitGenArtifact(backend.NameLLVM, backend.EmitLLVMIR, "main", entry)
@@ -379,8 +379,8 @@ fn main() {
 	if result == nil {
 		t.Fatal("emitGenArtifact() result is nil")
 	}
-	if !strings.Contains(string(got), "@osty_rt_list_get_bytes_v1") {
-		t.Fatalf("fallback llvm-ir missing bytes list get runtime call:\n%s", got)
+	if !strings.Contains(string(got), "coalesce.none") || !strings.Contains(string(got), "phi ptr") {
+		t.Fatalf("fallback llvm-ir missing coalesce shape:\n%s", got)
 	}
 }
 

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -370,7 +370,7 @@ fn main() {
 	}
 }
 
-func TestTryEmitNativeOwnedLLVMIRTextReturnsNotCovered(t *testing.T) {
+func TestTryEmitNativeOwnedLLVMIRTextCoversStructFieldAssign(t *testing.T) {
 	t.Parallel()
 
 	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
@@ -386,11 +386,48 @@ fn main() {
 	if err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
 	}
-	if ok {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText unexpectedly covered struct field assignment:\n%s", string(got))
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for struct field assignment")
 	}
-	if len(got) != 0 {
-		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned IR for uncovered source:\n%s", string(got))
+	for _, want := range []string{
+		"%Pair = type { i64, i64 }",
+		"extractvalue %Pair",
+		"insertvalue %Pair",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, string(got))
+		}
+	}
+	if len(warnings) != len(req.Entry.IRIssues) {
+		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
+	}
+}
+
+func TestTryEmitNativeOwnedLLVMIRTextCoversListIndex(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    let xs = [1, 2]
+    println(xs[0])
+}
+`)
+
+	got, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for list index")
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_new()",
+		"call ptr @osty_rt_list_new()",
+		"call void @osty_rt_list_push_i64(",
+		"call i64 @osty_rt_list_get_i64(",
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, string(got))
+		}
 	}
 	if len(warnings) != len(req.Entry.IRIssues) {
 		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
@@ -438,7 +475,7 @@ fn main() {
 	}
 }
 
-func TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+func TestEmitLLVMIRTextPrefersNativeOwnedFastPathForStructFieldAssign(t *testing.T) {
 	t.Parallel()
 
 	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
@@ -450,20 +487,50 @@ fn main() {
 }
 `)
 
-	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered struct field assignment")
 	}
-	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for struct field assignment")
+	}
+	got, gotWarnings, err := EmitLLVMIRText(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
-	if !strings.Contains(string(got), "%Pair = type { i64, i64 }") {
-		t.Fatalf("EmitLLVMIRText fallback IR missing Pair type:\n%s", got)
+	if string(got) != string(want) {
+		t.Fatalf("EmitLLVMIRText did not use native struct-field fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
-	if len(warnings) != len(req.Entry.IRIssues) {
-		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
+	if len(gotWarnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(gotWarnings), len(warnings))
+	}
+}
+
+func TestEmitLLVMIRTextPrefersNativeOwnedFastPathForListIndex(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `fn main() {
+    let xs = [1, 2]
+    println(xs[0])
+}
+`)
+
+	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for list index")
+	}
+	got, gotWarnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("EmitLLVMIRText did not use native list fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(gotWarnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(gotWarnings), len(warnings))
 	}
 }
 
@@ -514,7 +581,7 @@ fn main() {
 	}
 }
 
-func TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForStructFieldAssign(t *testing.T) {
 	t.Parallel()
 
 	tc := &fakeLLVMToolchain{}
@@ -528,10 +595,12 @@ fn main() {
 }
 `)
 
-	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
-	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered struct field assignment")
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for struct field assignment")
 	}
 	result, err := backend.Emit(context.Background(), req)
 	if err != nil {
@@ -541,8 +610,104 @@ fn main() {
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
 	}
-	if !strings.Contains(string(got), "%Pair = type { i64, i64 }") {
-		t.Fatalf("Emit binary fallback IR missing Pair type:\n%s", got)
+	if string(got) != string(want) {
+		t.Fatalf("Emit binary did not use native struct-field fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(result.Warnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	}
+}
+
+func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForListIndex(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, `fn main() {
+    let xs = [1, 2]
+    println(xs[0])
+}
+`)
+
+	want, ok, warnings, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for list index")
+	}
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	got, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Emit binary did not use native list fast path output\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	if len(result.Warnings) != len(warnings) {
+		t.Fatalf("warning count = %d, want %d", len(result.Warnings), len(warnings))
+	}
+}
+
+func TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let xs = [Pair { left: 1, right: 2 }]
+    println(xs[0].left)
+}
+`)
+
+	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	} else if ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered composite list index")
+	}
+	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
+	if err != nil {
+		t.Fatalf("EmitLLVMIRText returned error: %v", err)
+	}
+	if !strings.Contains(string(got), "@osty_rt_list_get_bytes_v1") {
+		t.Fatalf("EmitLLVMIRText fallback IR missing bytes list get runtime call:\n%s", got)
+	}
+	if len(warnings) != len(req.Entry.IRIssues) {
+		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
+	}
+}
+
+func TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered(t *testing.T) {
+	t.Parallel()
+
+	tc := &fakeLLVMToolchain{}
+	backend := LLVMBackend{toolchain: tc}
+	req := newBackendRequest(t, EmitBinary, `struct Pair { left: Int, right: Int }
+
+fn main() {
+    let xs = [Pair { left: 1, right: 2 }]
+    println(xs[0].left)
+}
+`)
+
+	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	} else if ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered composite list index")
+	}
+	result, err := backend.Emit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+	got, readErr := os.ReadFile(result.Artifacts.LLVMIR)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
+	}
+	if !strings.Contains(string(got), "@osty_rt_list_get_bytes") {
+		t.Fatalf("Emit binary fallback IR missing bytes list get runtime call:\n%s", got)
 	}
 }
 

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -655,25 +655,25 @@ func TestLLVMBackendEmitBinaryPrefersNativeOwnedFastPathForListIndex(t *testing.
 func TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered(t *testing.T) {
 	t.Parallel()
 
-	req := newBackendRequest(t, EmitLLVMIR, `struct Pair { left: Int, right: Int }
+	req := newBackendRequest(t, EmitLLVMIR, `fn resolve(name: String?) -> String {
+    name ?? "anonymous"
+}
 
 fn main() {
-    let xs = [Pair { left: 1, right: 2 }]
-    println(xs[0].left)
 }
 `)
 
 	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
 	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered composite list index")
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered coalesce fallback")
 	}
 	got, warnings, err := EmitLLVMIRText(req.Entry, "", nil)
 	if err != nil {
 		t.Fatalf("EmitLLVMIRText returned error: %v", err)
 	}
-	if !strings.Contains(string(got), "@osty_rt_list_get_bytes_v1") {
-		t.Fatalf("EmitLLVMIRText fallback IR missing bytes list get runtime call:\n%s", got)
+	if !strings.Contains(string(got), "coalesce.none") || !strings.Contains(string(got), "phi ptr") {
+		t.Fatalf("EmitLLVMIRText fallback IR missing coalesce shape:\n%s", got)
 	}
 	if len(warnings) != len(req.Entry.IRIssues) {
 		t.Fatalf("warning count = %d, want %d", len(warnings), len(req.Entry.IRIssues))
@@ -685,18 +685,18 @@ func TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered(t *testing.T) {
 
 	tc := &fakeLLVMToolchain{}
 	backend := LLVMBackend{toolchain: tc}
-	req := newBackendRequest(t, EmitBinary, `struct Pair { left: Int, right: Int }
+	req := newBackendRequest(t, EmitBinary, `fn resolve(name: String?) -> String {
+    name ?? "anonymous"
+}
 
 fn main() {
-    let xs = [Pair { left: 1, right: 2 }]
-    println(xs[0].left)
 }
 `)
 
 	if _, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, ""); err != nil {
 		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
 	} else if ok {
-		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered composite list index")
+		t.Fatal("TryEmitNativeOwnedLLVMIRText unexpectedly covered coalesce fallback")
 	}
 	result, err := backend.Emit(context.Background(), req)
 	if err != nil {
@@ -706,8 +706,8 @@ fn main() {
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q): %v", result.Artifacts.LLVMIR, readErr)
 	}
-	if !strings.Contains(string(got), "@osty_rt_list_get_bytes") {
-		t.Fatalf("Emit binary fallback IR missing bytes list get runtime call:\n%s", got)
+	if !strings.Contains(string(got), "coalesce.none") || !strings.Contains(string(got), "phi ptr") {
+		t.Fatalf("Emit binary fallback IR missing coalesce shape:\n%s", got)
 	}
 }
 

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -1018,7 +1018,7 @@ fn main() {
 	}
 }
 
-func TestTryGenerateNativeOwnedModuleReturnsNotCoveredForStructFieldAssign(t *testing.T) {
+func TestTryGenerateNativeOwnedModuleCoversStructFieldAssign(t *testing.T) {
 	src := `struct Pair { left: Int, right: Int }
 
 fn main() {
@@ -1033,11 +1033,80 @@ fn main() {
 	if err != nil {
 		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
 	}
-	if ok {
-		t.Fatalf("TryGenerateNativeOwnedModule unexpectedly covered struct field assignment:\n%s", string(out))
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported not covered for struct field assignment")
 	}
-	if len(out) != 0 {
-		t.Fatalf("TryGenerateNativeOwnedModule returned IR for uncovered module:\n%s", string(out))
+	got := string(out)
+	for _, want := range []string{
+		"%Pair = type { i64, i64 }",
+		"extractvalue %Pair",
+		"insertvalue %Pair",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestTryGenerateNativeOwnedModuleCoversNestedStructFieldAssign(t *testing.T) {
+	src := `struct Inner { value: Int }
+
+struct Outer { inner: Inner, flag: Int }
+
+fn main() {
+    let mut outer = Outer { inner: Inner { value: 1 }, flag: 2 }
+    outer.inner.value = 3
+    println(outer.inner.value)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_try_nested_struct_assign.osty"}
+	out, ok, err := TryGenerateNativeOwnedModule(mod, opts)
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported not covered for nested struct field assignment")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Inner = type { i64 }",
+		"%Outer = type { %Inner, i64 }",
+		"extractvalue %Outer",
+		"insertvalue %Inner",
+		"insertvalue %Outer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("nested native-owned IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestTryGenerateNativeOwnedModuleCoversListLiteralAndIndex(t *testing.T) {
+	src := `fn main() {
+    let xs = [1, 2]
+    println(xs[0])
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_try_list_index.osty"}
+	out, ok, err := TryGenerateNativeOwnedModule(mod, opts)
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported not covered for list index")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"declare ptr @osty_rt_list_new()",
+		"call ptr @osty_rt_list_new()",
+		"call void @osty_rt_list_push_i64(",
+		"call i64 @osty_rt_list_get_i64(",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("list native-owned IR missing %q:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed
- extended the native-owned llvmgen projection to cover struct field assignment rewrites and typed `List` literal/index reads
- taught the native snapshot emitter to render list runtime usage directly, including list runtime declarations when needed
- updated backend, CLI, and external `osty-native-llvmgen` tests so covered cases now prefer the native fast path and composite list elements remain the fallback sentinel

## Why
After opening the native llvmgen boundary, these shapes were still forcing live callers back through the legacy path. Expanding coverage here removes another real fallback reason from `gen` and the managed native runner.

## Impact
- `pair.left = 3` and nested struct-field assignment now stay on the native fast path
- primitive/string list literal + index reads now stay on the native fast path
- composite list element access still falls back, preserving a clear uncovered boundary

## Validation
- `go test -count=1 -vet=off ./internal/llvmgen -run 'Test(NativeOwnedModuleEntry(PrimitiveSlice|StructSlice|StructFieldAssignSlice)|TryGenerateNativeOwnedModule(PrimitiveSlice|CoversNestedStructFieldAssign|CoversListLiteralAndIndex|ReturnsNotCoveredForCompositeListIndex|AppliesExportAndCABI))'`
- `go test -count=1 -vet=off ./internal/backend -run 'Test(TryEmitNativeOwnedLLVMIRText(CoversPrimitiveSlice|CoversStructFieldAssign|CoversListIndex)|EmitLLVMIRText(PrefersNativeOwnedFastPathWhenCovered|PrefersNativeOwnedFastPathForStructFieldAssign|PrefersNativeOwnedFastPathForListIndex|FallsBackWhenNativeOwnedUncovered)|LLVMBackendEmitBinary(PrefersNativeOwnedFastPathWhenCovered|PrefersNativeOwnedFastPathForStructFieldAssign|PrefersNativeOwnedFastPathForListIndex|FallsBackWhenNativeOwnedUncovered)|Use(MIRBackendDefaultsEnabled|NativeOwnedLLVMIRDefaultsEnabled|NativeOwnedLLVMIRFeatureOverrides))'`
- `go test -count=1 -vet=off ./cmd/osty -run 'Test(EmitGenArtifactUsesNativeOwnedFastPathWhenCovered|EmitGenArtifactUsesNativeOwnedFastPathForStructFieldAssign|EmitGenArtifactUsesNativeOwnedFastPathForListIndex|EmitGenArtifactFallsBackForUncoveredNativeOwnedModule|PrepareGenBackendEntryUsesPackageLoweringForSiblingFiles|PrepareGenBackendEntryUsesPackageLoweringForSingleFile|GenCLIMultiFilePackageEmitsLLVMIR)'`
- `go test -count=1 -vet=off ./cmd/osty-native-llvmgen -run 'TestRun(EmitsNativeOwnedLLVMIRForSource|EmitsNativeOwnedLLVMIRForPackage|EmitsNativeOwnedLLVMIRForStructFieldAssign|EmitsNativeOwnedLLVMIRForListIndex|ReportsNotCoveredForUnsupportedSource|UsesNativeOwnedExportAndCABIShape)'`