### PR TITLE
fix(ir): backfill nil Closure param Types from inferred FnType

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1732,6 +1732,28 @@ func (l *lowerer) lowerClosure(c *ast.ClosureExpr) Expr {
 	for _, p := range c.Params {
 		out.Params = append(out.Params, l.lowerParam(p))
 	}
+	// Inline closures (`|acc, n| ...`) leave the per-param AST Type
+	// nil because the user didn't annotate them — the checker's
+	// inference picks them up via the call-site context (e.g.
+	// `xs.fold(0, |acc, n| ...)` resolves to fn(Int, Int) -> Int).
+	// `lowerParam` faithfully forwards the nil, but downstream IR
+	// validation rejects nil param types ("Closure: param[i] nil
+	// Type"). The checker's inferred FnType is in out.T already, so
+	// backfill missing param types from there.
+	//
+	// Closure return is filled the same way when no explicit
+	// annotation is present and the inferred FnType has a Return.
+	if fnT, ok := out.T.(*FnType); ok && fnT != nil {
+		for i, p := range out.Params {
+			if p == nil || p.Type != nil || i >= len(fnT.Params) {
+				continue
+			}
+			p.Type = fnT.Params[i]
+		}
+		if c.ReturnType == nil && fnT.Return != nil && out.Return == TUnit {
+			out.Return = fnT.Return
+		}
+	}
 	// Body is always an expression. Wrap non-block bodies in a synthetic
 	// block with the expression as the Result.
 	if blk, ok := c.Body.(*ast.Block); ok {

--- a/internal/ir/lower_closure_test.go
+++ b/internal/ir/lower_closure_test.go
@@ -1,0 +1,86 @@
+package ir
+
+import (
+	"testing"
+)
+
+// Inline closures (`|x| x + 1`) leave their per-param AST Type nil
+// because the user didn't annotate them — the checker's inference
+// picks them up via the call-site context (e.g. `xs.fold(0, |acc, n|
+// acc + n)` resolves to `fn(Int, Int) -> Int`). `lowerParam`
+// faithfully forwards the nil, but downstream IR validation rejects
+// nil param types ("Closure: param[i] nil Type").
+//
+// `lowerClosure` backfills any nil per-param Type from the closure's
+// inferred FnType (out.T), which the checker has already populated.
+// Verifies via a stdlib call site that exercises the path
+// end-to-end: `xs.fold(0, |acc, n| acc + n)`.
+func TestLowerClosureBackfillsNilParamTypesFromInferredFnType(t *testing.T) {
+	src := `
+fn main() {
+    let xs: List<Int> = [1, 2, 3]
+    let _ = xs.fold(0, |acc, n| acc + n)
+}
+`
+	mod := lowerSrc(t, src)
+	var found bool
+	Inspect(mod, func(n Node) bool {
+		c, ok := n.(*Closure)
+		if !ok {
+			return true
+		}
+		if len(c.Params) != 2 {
+			return true
+		}
+		found = true
+		for i, p := range c.Params {
+			if p == nil {
+				t.Errorf("closure param[%d] nil pointer", i)
+				continue
+			}
+			if p.Type == nil {
+				t.Errorf("closure param[%d] (%q) Type still nil after backfill", i, p.Name)
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("no 2-param Closure found in lowered module — fold call site missing?")
+	}
+	// Validate the whole module: the nil-Type wall would surface here
+	// without the backfill.
+	if errs := Validate(mod); len(errs) != 0 {
+		t.Fatalf("module Validate failed after closure backfill: %v", errs)
+	}
+}
+
+// A closure with EXPLICIT param types must keep them — the backfill
+// only fires when the AST type is nil. Locks against a regression
+// where the backfill loop accidentally overwrites annotated types.
+func TestLowerClosurePreservesExplicitParamTypes(t *testing.T) {
+	src := `
+fn apply(f: fn(Int) -> Int, x: Int) -> Int {
+    f(x)
+}
+
+fn main() {
+    let _ = apply(|n: Int| n * 2, 5)
+}
+`
+	mod := lowerSrc(t, src)
+	var checked bool
+	Inspect(mod, func(n Node) bool {
+		c, ok := n.(*Closure)
+		if !ok || len(c.Params) != 1 {
+			return true
+		}
+		checked = true
+		if c.Params[0].Type == nil {
+			t.Errorf("explicitly typed closure param has nil Type")
+		}
+		return true
+	})
+	if !checked {
+		t.Fatalf("no 1-param explicit-type Closure found")
+	}
+}


### PR DESCRIPTION
## Summary

Inline closures (`|acc, n| acc + n`) leave per-param AST Type nil because the user didn't annotate them — the checker's inference picks them up via call-site context. `lowerParam` faithfully forwards the nil; downstream IR validation then rejects with `Closure: param[i] nil Type`. This blocked any stdlib body that takes a closure (`collections.fold` / `map` / `filter` / `find` / `scan` / …) under `OSTY_STDLIB_BODY_LOWER=1`, surfacing the moment the injected body is validated against user code like `xs.fold(0, |acc, n| acc + n)`.

## What changed

The checker's inferred `FnType` is already attached to the Closure (`out.T`). `lowerClosure` now backfills any nil per-param Type from `fnT.Params[i]`. Also fills the closure's Return when (a) the user wrote no `-> T` annotation and (b) the inferred `FnType` has a non-nil Return — keeps unit-typed closures from being treated as "return Unit explicitly" later.

Explicit annotations are preserved: the backfill loop only touches params whose Type is nil.

## Why

Surfaced while testing deeper stdlib body injection chains under `OSTY_STDLIB_BODY_LOWER=1`. `xs.fold(0, |acc, n| acc + n)` walls before reaching the LLVM backend at all — the IR validator catches the nil Type during the post-inject `ir.Validate(mod)` call. With this fix, the Validate gate clears and the program proceeds to the next wall (LLVM013 `*ast.ClosureExpr` codegen, deferred to a separate PR).

## Test plan

Two new tests in `lower_closure_test.go`:

- **`TestLowerClosureBackfillsNilParamTypesFromInferredFnType`** — drives `xs.fold(0, |acc, n| acc + n)` through the full parse + check + lower pipeline (via the existing `lowerSrc` helper), walks the lowered IR for the resulting Closure, and asserts each param's Type is non-nil. Also runs `Validate(mod)` end-to-end so the previous nil-Type wall would surface here without the fix.
- **`TestLowerClosurePreservesExplicitParamTypes`** — `apply(|n: Int| n * 2, 5)` keeps its annotated param type after lowering. Locks against a regression where the backfill loop accidentally overwrites annotated types.

Plus regression coverage:
- [x] `go test ./internal/ir/` (full suite) — pass
- [x] `go test ./internal/backend/ -run 'TestStdlibInject|TestRewrite|TestReachable|TestInjectReachable'` — pass
- [x] `just front` (lexer/parser/resolve/check/diag/format/lint/pipeline) regression-free

## Walls remaining for end-to-end injection of `collections.fold`

- **LLVM013** closure expression lowering — the legacy expression emitter doesn't handle `*ast.ClosureExpr` at all yet. Substantial work (capture environment, indirect calls).
- **List<T> method dispatch** through the monomorphized struct — distinct from free-fn injection. `xs.contains(3)` still walls with `LLVM015 call target *ast.FieldExpr (xs.contains)`.

Both deferred to follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)