### PR TITLE
[codex] use explicit MIR safepoint roots

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -103,12 +103,13 @@ type mirGen struct {
 	fnBuf       strings.Builder
 
 	// GC instrumentation state (per-function, populated only when
-	// opts.EmitGC is set). gcRoots lists the managed-ptr locals in
-	// the order root_bind_v1 was emitted for them; emitter sites use
-	// the same order in reverse for root_release_v1 on return.
-	// curBlockID tracks the block we're currently emitting so
-	// GotoTerm can detect loop back-edges (goto whose target block
-	// ID is <= the current block's ID) and emit a safepoint.
+	// opts.EmitGC is set). gcRoots lists the managed-ptr locals whose
+	// slot addresses are passed to each safepoint poll. This keeps the
+	// live-set precise without function-long root_bind pinning, so Phase D
+	// compaction can still relocate movable objects between polls.
+	// curBlockID tracks the block we're currently emitting so GotoTerm
+	// can detect loop back-edges (goto whose target block ID is <= the
+	// current block's ID) and emit a safepoint.
 	gcRoots           []mir.LocalID
 	curBlockID        mir.BlockID
 	loopSafepointSlot string
@@ -1134,16 +1135,12 @@ func (g *mirGen) emitAllocaPreamble(fn *mir.Function) {
 // Only emitted when opts.EmitGC is set. The ABI matches the legacy
 // AST emitter (see internal/llvmgen/generator.go):
 //
-//   declare void @osty.gc.root_bind_v1(ptr)
-//   declare void @osty.gc.root_release_v1(ptr)
 //   declare void @osty.gc.safepoint_v1(i64, ptr, i64)
 //
-// The runtime keeps a per-thread root list populated by
-// `root_bind_v1` for each ptr-sized local; `safepoint_v1` is a poll
-// point that can scan the bound-root list. We don't pass an explicit
-// root vector at each safepoint — that's an optimisation the legacy
-// emitter uses for precise scanning, but the bound-root tracking is
-// sufficient for the MVP.
+// MIR now follows the legacy emitter's precise safepoint shape: each
+// poll receives an explicit vector of managed local slot addresses.
+// That keeps the live set precise without function-long pinning, so the
+// Phase D compactor can relocate movable objects between safepoints.
 
 // isManagedLocal reports whether a local should be tracked as a GC
 // root. A local is managed when it lowers to an LLVM ptr AND the MIR
@@ -1162,18 +1159,18 @@ func (g *mirGen) isManagedLocal(loc *mir.Local) bool {
 	return g.llvmType(loc.Type) == "ptr"
 }
 
-// emitGCEntry registers every managed local of the current function
-// as a GC root and emits a safepoint at function entry. Parameter
-// slots are bound after their arg value is stored; non-param slots
-// are null-initialised before binding so the GC never scans undef
-// memory.
+// emitGCEntry records every managed local of the current function and
+// emits a safepoint at function entry. Non-param managed slots are
+// null-initialised before the first poll so the GC never scans undef
+// memory. Unlike the old root_bind path, the roots are supplied
+// explicitly at each safepoint as slot addresses, which avoids
+// function-long pinning and lets compaction move objects between polls.
 func (g *mirGen) emitGCEntry(fn *mir.Function) {
 	if !g.opts.EmitGC {
 		return
 	}
-	// Collect managed locals in ID order. Params are listed first
-	// (their IDs are the lowest) so release-on-return unwinds in
-	// reverse bind order naturally.
+	// Collect managed locals in ID order so the emitted safepoint root
+	// arrays stay deterministic across builds.
 	for _, loc := range fn.Locals {
 		if !g.isManagedLocal(loc) {
 			continue
@@ -1186,7 +1183,7 @@ func (g *mirGen) emitGCEntry(fn *mir.Function) {
 		g.emitGCSafepointKind(safepointKindEntry)
 		return
 	}
-	// Zero non-param managed slots before binding. Param slots
+	// Zero non-param managed slots before the first safepoint. Param slots
 	// already hold the incoming arg from the preamble's store loop.
 	for _, id := range g.gcRoots {
 		loc := fn.Local(id)
@@ -1197,30 +1194,24 @@ func (g *mirGen) emitGCEntry(fn *mir.Function) {
 		g.fnBuf.WriteString(g.localSlots[id])
 		g.fnBuf.WriteByte('\n')
 	}
-	// Bind each managed slot as a root.
-	g.declareRootBindRelease()
-	for _, id := range g.gcRoots {
-		g.fnBuf.WriteString("  call void @osty.gc.root_bind_v1(ptr ")
-		g.fnBuf.WriteString(g.localSlots[id])
-		g.fnBuf.WriteString(")\n")
-	}
 	// Entry safepoint.
 	g.emitGCSafepointKind(safepointKindEntry)
 }
 
-// emitGCReleaseRoots releases every bound root in reverse bind order.
-// Called before every ret / unreachable terminator.
+// emitGCReleaseRoots is a legacy hook kept for call-site stability.
+// MIR GC lowering now uses explicit safepoint root arrays, so there is
+// no function-exit release work left to do.
 func (g *mirGen) emitGCReleaseRoots() {
-	if !g.opts.EmitGC || len(g.gcRoots) == 0 {
-		return
+}
+
+func (g *mirGen) visibleGCSafepointRoots() []string {
+	out := make([]string, 0, len(g.gcRoots))
+	for _, id := range g.gcRoots {
+		if slot := g.localSlots[id]; slot != "" {
+			out = append(out, slot)
+		}
 	}
-	g.declareRootBindRelease()
-	for i := len(g.gcRoots) - 1; i >= 0; i-- {
-		slot := g.localSlots[g.gcRoots[i]]
-		g.fnBuf.WriteString("  call void @osty.gc.root_release_v1(ptr ")
-		g.fnBuf.WriteString(slot)
-		g.fnBuf.WriteString(")\n")
-	}
+	return out
 }
 
 // emitGCSafepoint emits a single safepoint poll at an unclassified site.
@@ -1234,18 +1225,32 @@ func (g *mirGen) emitGCSafepoint() {
 // emitGCSafepointKind emits a safepoint poll tagged with the given kind.
 // The kind is packed into the high byte of the id the runtime receives;
 // the low 56 bits hold the per-module serial (see encodeSafepointID in
-// the legacy emitter). The ABI remains `safepoint_v1(i64 id, ptr roots,
-// i64 nroots)` — roots stay null/0 because root_bind_v1 already
-// registered the live set.
+// the legacy emitter). Managed MIR locals are passed as an explicit array
+// of slot addresses so the runtime can trace the live set without
+// pinning it for the entire function.
 func (g *mirGen) emitGCSafepointKind(kind safepointKind) {
 	if !g.opts.EmitGC {
 		return
 	}
 	g.declareSafepoint()
-	serial := g.nextSafepoint
-	g.nextSafepoint++
-	g.fnBuf.WriteString(llvmRenderSafepointEmpty(encodeSafepointID(kind, serial)))
-	g.fnBuf.WriteByte('\n')
+	roots := g.visibleGCSafepointRoots()
+	if len(roots) == 0 {
+		serial := g.nextSafepoint
+		g.nextSafepoint++
+		g.fnBuf.WriteString(llvmRenderSafepointEmpty(encodeSafepointID(kind, serial)))
+		g.fnBuf.WriteByte('\n')
+		return
+	}
+	plan := llvmPlanSafepointChunks(int(kind), g.nextSafepoint, len(roots), safepointRootChunkSize)
+	g.nextSafepoint += len(plan)
+	for _, chunk := range plan {
+		emitter := llvmEmitter()
+		llvmEmitSafepointWithRoots(emitter, chunk.id, roots[chunk.start:chunk.end])
+		for _, line := range emitter.body {
+			g.fnBuf.WriteString(line)
+			g.fnBuf.WriteByte('\n')
+		}
+	}
 }
 
 func (g *mirGen) emitLoopSafepointKind() {
@@ -1309,18 +1314,10 @@ func (g *mirGen) emitLoopSafepointKind() {
 }
 
 // declareSafepoint registers @osty.gc.safepoint_v1 — split from
-// root_bind/root_release so pointer-free functions don't pull in
-// unused root declarations.
+// the explicit-root machinery so pointer-free functions don't pull in
+// any unused GC declarations.
 func (g *mirGen) declareSafepoint() {
 	g.declareRuntime("osty.gc.safepoint_v1", "declare void @osty.gc.safepoint_v1(i64, ptr, i64)")
-}
-
-// declareRootBindRelease registers the bind/release pair in a single
-// call so their order in the runtime-declaration block is stable
-// regardless of whether bind or release emits first.
-func (g *mirGen) declareRootBindRelease() {
-	g.declareRuntime("osty.gc.root_bind_v1", "declare void @osty.gc.root_bind_v1(ptr)")
-	g.declareRuntime("osty.gc.root_release_v1", "declare void @osty.gc.root_release_v1(ptr)")
 }
 
 // ==== instructions ====
@@ -3244,9 +3241,9 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 			return nil
 		}
 		if g.fn.ReturnType == nil || isUnitType(g.fn.ReturnType) {
-			// Release bound roots BEFORE ret so the GC doesn't
-			// scan dead slots for in-flight tail calls on other
-			// threads.
+			// Explicit safepoint roots need no function-exit cleanup, but
+			// keep the hook in place so return lowering stays uniform if we
+			// grow per-function GC epilog work later.
 			g.emitGCReleaseRoots()
 			g.fnBuf.WriteString("  ret void\n")
 			return nil
@@ -3261,9 +3258,9 @@ func (g *mirGen) emitTerm(t mir.Terminator) error {
 		g.fnBuf.WriteString(", ptr ")
 		g.fnBuf.WriteString(retSlot)
 		g.fnBuf.WriteByte('\n')
-		// Release roots after we've loaded the return value but
-		// before the ret — the value is now in an SSA register so
-		// it's safe for the slot to drop out of the root list.
+		// Keep the legacy hook between load and ret for symmetry with the
+		// unit-return path; explicit safepoint roots mean this is currently
+		// a no-op.
 		g.emitGCReleaseRoots()
 		g.fnBuf.WriteString("  ret ")
 		g.fnBuf.WriteString(llvmT)

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2,6 +2,7 @@ package llvmgen
 
 import (
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -1920,8 +1921,9 @@ func TestGenerateFromMIREmitGCDefaultOff(t *testing.T) {
 }
 
 // TestGenerateFromMIREmitGCManagedParam — A function with a
-// managed-ptr param (String) should bind the param slot as a root,
-// take an entry safepoint, and release the root before ret.
+// managed-ptr param (String) should surface the param slot in the
+// entry safepoint root array rather than function-long root_bind
+// pinning.
 func TestGenerateFromMIREmitGCManagedParam(t *testing.T) {
 	// fn identity(s: String) -> String { s }
 	fn := &ir.FnDecl{
@@ -1944,39 +1946,39 @@ func TestGenerateFromMIREmitGCManagedParam(t *testing.T) {
 	}
 	got := string(out)
 	for _, want := range []string{
-		// Runtime declarations.
-		"declare void @osty.gc.root_bind_v1(ptr)",
-		"declare void @osty.gc.root_release_v1(ptr)",
 		"declare void @osty.gc.safepoint_v1(i64, ptr, i64)",
-		// Entry safepoint carries kind=ENTRY (1) in the high byte and
-		// serial 0 in the low 56 bits → 1<<56.
-		"call void @osty.gc.safepoint_v1(i64 72057594037927936, ptr null, i64 0)",
-		// Param slot is bound as a root.
-		"call void @osty.gc.root_bind_v1(ptr %p",
-		// Release on the return path.
-		"call void @osty.gc.root_release_v1(ptr %p",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in:\n%s", want, got)
 		}
 	}
-	// The return value load must happen before root_release so the
-	// live value is in an SSA register when the slot drops out of
-	// the root list.
-	loadIdx := strings.Index(got, "load ptr, ptr %p")
-	releaseIdx := strings.Index(got, "call void @osty.gc.root_release_v1")
-	retIdx := strings.Index(got, "ret ptr")
-	if loadIdx < 0 || releaseIdx < 0 || retIdx < 0 {
-		t.Fatalf("ordering markers missing in:\n%s", got)
+	for _, forbidden := range []string{
+		"osty.gc.root_bind_v1",
+		"osty.gc.root_release_v1",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("unexpected legacy root-binding symbol %q in:\n%s", forbidden, got)
+		}
 	}
-	if !(loadIdx < releaseIdx && releaseIdx < retIdx) {
-		t.Fatalf("expected load → release → ret ordering in:\n%s", got)
+	if !strings.Contains(got, "alloca ptr, i64 2") {
+		t.Fatalf("expected entry safepoint array for return slot + param slot in:\n%s", got)
+	}
+	for _, want := range []string{
+		"store ptr %l0, ptr %t1",
+		"store ptr %p1, ptr %t2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected safepoint root array to contain %q in:\n%s", want, got)
+		}
+	}
+	if !regexp.MustCompile(`call void @osty\.gc\.safepoint_v1\(i64 72057594037927936, ptr %t\d+, i64 2\)`).MatchString(got) {
+		t.Fatalf("expected entry safepoint to receive two explicit roots in:\n%s", got)
 	}
 }
 
 // TestGenerateFromMIREmitGCNonParamLocalZeroInit — A non-param
-// managed local must be null-initialised before root_bind so the GC
-// never scans undef memory.
+// managed local must be null-initialised before the first safepoint so
+// the GC never scans undef memory.
 func TestGenerateFromMIREmitGCNonParamLocalZeroInit(t *testing.T) {
 	// fn first(xs: List<Int>) -> List<Int> { let y = xs; y }
 	listInt := &ir.NamedType{Name: "List", Args: []ir.Type{ir.TInt}, Builtin: true}
@@ -2009,15 +2011,15 @@ func TestGenerateFromMIREmitGCNonParamLocalZeroInit(t *testing.T) {
 	if !strings.Contains(got, "store ptr null, ptr %l") {
 		t.Fatalf("expected non-param local to be null-initialised in:\n%s", got)
 	}
-	// The null-init must happen before the bind so the GC sees a
+	// The null-init must happen before the first safepoint so the GC sees a
 	// valid (null) pointer at every safepoint.
 	zeroIdx := strings.Index(got, "store ptr null, ptr %l")
-	bindIdx := strings.Index(got, "call void @osty.gc.root_bind_v1(ptr %l")
-	if zeroIdx < 0 || bindIdx < 0 {
-		t.Fatalf("zero-init / bind markers missing in:\n%s", got)
+	safepointIdx := strings.Index(got, "call void @osty.gc.safepoint_v1(i64 72057594037927936")
+	if zeroIdx < 0 || safepointIdx < 0 {
+		t.Fatalf("zero-init / safepoint markers missing in:\n%s", got)
 	}
-	if !(zeroIdx < bindIdx) {
-		t.Fatalf("expected zero-init before root_bind in:\n%s", got)
+	if !(zeroIdx < safepointIdx) {
+		t.Fatalf("expected zero-init before the first safepoint in:\n%s", got)
 	}
 }
 
@@ -2052,6 +2054,51 @@ func TestGenerateFromMIREmitGCNoManagedLocals(t *testing.T) {
 	}
 	if strings.Contains(got, "osty.gc.root_release_v1") {
 		t.Fatalf("unexpected root_release in pointer-free function:\n%s", got)
+	}
+}
+
+func TestGenerateFromMIREmitGCChunksSafepointRoots(t *testing.T) {
+	oldChunkSize := safepointRootChunkSize
+	safepointRootChunkSize = 4
+	defer func() { safepointRootChunkSize = oldChunkSize }()
+
+	params := []*ir.Param{
+		{Name: "a", Type: ir.TString},
+		{Name: "b", Type: ir.TString},
+		{Name: "c", Type: ir.TString},
+		{Name: "d", Type: ir.TString},
+		{Name: "e", Type: ir.TString},
+		{Name: "f", Type: ir.TString},
+		{Name: "g", Type: ir.TString},
+	}
+	fn := &ir.FnDecl{
+		Name:   "head",
+		Return: ir.TString,
+		Params: params,
+		Body: &ir.Block{
+			Result: &ir.Ident{Name: "a", Kind: ir.IdentParam, T: ir.TString},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-chunks.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	allocas := regexp.MustCompile(`alloca ptr, i64 (\d+)`).FindAllStringSubmatch(got, -1)
+	if len(allocas) != 2 {
+		t.Fatalf("expected two safepoint root allocas, got %d in:\n%s", len(allocas), got)
+	}
+	if allocas[0][1] != "4" || allocas[1][1] != "4" {
+		t.Fatalf("expected safepoint root chunk sizes [4 4], got [%s %s] in:\n%s", allocas[0][1], allocas[1][1], got)
+	}
+	if gotCount := strings.Count(got, "call void @osty.gc.safepoint_v1(i64"); gotCount != 2 {
+		t.Fatalf("expected two chunked safepoint calls, got %d in:\n%s", gotCount, got)
 	}
 }
 


### PR DESCRIPTION
## What changed
- switch MIR GC lowering from function-long `root_bind_v1` / `root_release_v1` bookkeeping to explicit safepoint root-slot vectors
- keep non-param managed locals zero-initialized before the first safepoint
- chunk large MIR root sets through the existing safepoint chunk planner
- update MIR GC tests to assert the explicit-root safepoint shape instead of legacy root-bind calls

## Why
The old MIR path pinned every managed local for the full function, which fought against the Phase D compactor and diverged from the legacy AST emitter's precise safepoint-root model. Passing slot addresses directly at each poll keeps the live set precise while allowing movable objects to relocate between safepoints.

## Impact
- MIR-generated code no longer emits legacy `root_bind_v1` / `root_release_v1` calls for normal GC polling
- safepoints now expose the exact managed local slots the runtime should scan
- large root sets keep the bounded-stack chunking behavior already used by the AST emitter

## Validation
- `git diff --check`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIREmitGC(DefaultOff|ManagedParam|NonParamLocalZeroInit|NoManagedLocals|ChunksSafepointRoots|LoopSafepoint)'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIR'`