### PR TITLE
[codex] Prune dead MIR safepoint roots

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -107,10 +107,14 @@ type mirGen struct {
 	// slot addresses are passed to each safepoint poll. This keeps the
 	// live-set precise without function-long root_bind pinning, so Phase D
 	// compaction can still relocate movable objects between polls.
+	// gcRootChunks caches the chunked slot-address arrays prepared at
+	// function entry; subsequent safepoints reuse them instead of
+	// re-emitting alloca/GEP/store scaffolding at each poll site.
 	// curBlockID tracks the block we're currently emitting so GotoTerm
 	// can detect loop back-edges (goto whose target block ID is <= the
 	// current block's ID) and emit a safepoint.
 	gcRoots           []mir.LocalID
+	gcRootChunks      []mirGCRootChunk
 	curBlockID        mir.BlockID
 	loopSafepointSlot string
 
@@ -166,6 +170,11 @@ type mirGen struct {
 	// Module-scoped numbering keeps IDs unique; flushed at module
 	// tail via emitLoopMetadata.
 	loopMDDefs []string
+}
+
+type mirGCRootChunk struct {
+	slotsPtr string
+	count    int
 }
 
 // mirFnSig caches a function's LLVM signature so call sites can render
@@ -986,6 +995,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	g.localSlots = map[mir.LocalID]string{}
 	g.fnBuf.Reset()
 	g.gcRoots = g.gcRoots[:0]
+	g.gcRootChunks = g.gcRootChunks[:0]
 	// v0.6 A5.2: fn.Vectorize is already default-true unless
 	// `#[no_vectorize]` was present (ir.Lower sets it). Mirror here
 	// verbatim — the per-fn state machine doesn't need to re-derive
@@ -1306,6 +1316,7 @@ func (g *mirGen) emitGCEntry(fn *mir.Function) {
 		g.fnBuf.WriteString(g.localSlots[id])
 		g.fnBuf.WriteByte('\n')
 	}
+	g.prepareGCSafepointRootChunks()
 	// Entry safepoint.
 	g.emitGCSafepointKind(safepointKindEntry)
 }
@@ -1324,6 +1335,52 @@ func (g *mirGen) visibleGCSafepointRoots() []string {
 		}
 	}
 	return out
+}
+
+func (g *mirGen) prepareGCSafepointRootChunks() {
+	roots := g.visibleGCSafepointRoots()
+	start := 0
+
+	g.gcRootChunks = g.gcRootChunks[:0]
+	if len(roots) == 0 {
+		return
+	}
+	if safepointRootChunkSize <= 0 {
+		safepointRootChunkSize = 1
+	}
+	for start < len(roots) {
+		end := start + safepointRootChunkSize
+		if end > len(roots) {
+			end = len(roots)
+		}
+		window := roots[start:end]
+		slotsPtr := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(slotsPtr)
+		g.fnBuf.WriteString(" = alloca ptr, i64 ")
+		g.fnBuf.WriteString(strconv.Itoa(len(window)))
+		g.fnBuf.WriteByte('\n')
+		for i, addr := range window {
+			slotPtr := g.fresh()
+			g.fnBuf.WriteString("  ")
+			g.fnBuf.WriteString(slotPtr)
+			g.fnBuf.WriteString(" = getelementptr ptr, ptr ")
+			g.fnBuf.WriteString(slotsPtr)
+			g.fnBuf.WriteString(", i64 ")
+			g.fnBuf.WriteString(strconv.Itoa(i))
+			g.fnBuf.WriteByte('\n')
+			g.fnBuf.WriteString("  store ptr ")
+			g.fnBuf.WriteString(addr)
+			g.fnBuf.WriteString(", ptr ")
+			g.fnBuf.WriteString(slotPtr)
+			g.fnBuf.WriteByte('\n')
+		}
+		g.gcRootChunks = append(g.gcRootChunks, mirGCRootChunk{
+			slotsPtr: slotsPtr,
+			count:    len(window),
+		})
+		start = end
+	}
 }
 
 // emitGCSafepoint emits a single safepoint poll at an unclassified site.
@@ -1345,23 +1402,24 @@ func (g *mirGen) emitGCSafepointKind(kind safepointKind) {
 		return
 	}
 	g.declareSafepoint()
-	roots := g.visibleGCSafepointRoots()
-	if len(roots) == 0 {
+	if len(g.gcRootChunks) == 0 {
 		serial := g.nextSafepoint
 		g.nextSafepoint++
 		g.fnBuf.WriteString(llvmRenderSafepointEmpty(encodeSafepointID(kind, serial)))
 		g.fnBuf.WriteByte('\n')
 		return
 	}
-	plan := llvmPlanSafepointChunks(int(kind), g.nextSafepoint, len(roots), safepointRootChunkSize)
+	plan := llvmPlanSafepointChunks(int(kind), g.nextSafepoint, len(g.gcRoots), safepointRootChunkSize)
 	g.nextSafepoint += len(plan)
-	for _, chunk := range plan {
-		emitter := llvmEmitter()
-		llvmEmitSafepointWithRoots(emitter, chunk.id, roots[chunk.start:chunk.end])
-		for _, line := range emitter.body {
-			g.fnBuf.WriteString(line)
-			g.fnBuf.WriteByte('\n')
-		}
+	for i, chunk := range plan {
+		rootChunk := g.gcRootChunks[i]
+		g.fnBuf.WriteString("  call void @osty.gc.safepoint_v1(i64 ")
+		g.fnBuf.WriteString(strconv.Itoa(chunk.id))
+		g.fnBuf.WriteString(", ptr ")
+		g.fnBuf.WriteString(rootChunk.slotsPtr)
+		g.fnBuf.WriteString(", i64 ")
+		g.fnBuf.WriteString(strconv.Itoa(rootChunk.count))
+		g.fnBuf.WriteString(")\n")
 	}
 }
 
@@ -1442,10 +1500,33 @@ func (g *mirGen) emitInstr(inst mir.Instr) error {
 		return g.emitCall(x)
 	case *mir.IntrinsicInstr:
 		return g.emitIntrinsic(x)
-	case *mir.StorageLiveInstr, *mir.StorageDeadInstr:
+	case *mir.StorageLiveInstr:
 		return nil
+	case *mir.StorageDeadInstr:
+		return g.emitStorageDead(x)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("instruction %T", inst))
+}
+
+func (g *mirGen) emitStorageDead(dead *mir.StorageDeadInstr) error {
+	if dead == nil || !g.opts.EmitGC {
+		return nil
+	}
+	loc := g.fn.Local(dead.Local)
+	if !g.isManagedLocal(loc) {
+		return nil
+	}
+	slot := g.localSlots[dead.Local]
+	if slot == "" {
+		return nil
+	}
+	// The safepoint root arrays cache slot addresses, not values. Nulling
+	// the managed slot on StorageDead retires that root without rebuilding
+	// the array scaffolding at each poll site.
+	g.fnBuf.WriteString("  store ptr null, ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteByte('\n')
+	return nil
 }
 
 func (g *mirGen) emitAssign(a *mir.AssignInstr) error {

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -2102,6 +2102,167 @@ func TestGenerateFromMIREmitGCChunksSafepointRoots(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMIRReusesSafepointRootArrays(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "count",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name:  "i",
+					Type:  ir.TInt,
+					Mut:   true,
+					Value: &ir.IntLit{Text: "0", T: ir.TInt},
+				},
+				&ir.ForStmt{
+					Kind: ir.ForWhile,
+					Cond: &ir.BinaryExpr{
+						Op:    ir.BinLt,
+						Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+						Right: &ir.IntLit{Text: "2", T: ir.TInt},
+						T:     ir.TBool,
+					},
+					Body: &ir.Block{
+						Stmts: []ir.Stmt{
+							&ir.AssignStmt{
+								Op:      ir.AssignEq,
+								Targets: []ir.Expr{&ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt}},
+								Value: &ir.BinaryExpr{
+									Op:    ir.BinAdd,
+									Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+									Right: &ir.IntLit{Text: "1", T: ir.TInt},
+									T:     ir.TInt,
+								},
+							},
+						},
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-root-array-reuse.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if gotCount := strings.Count(got, "alloca ptr, i64 2"); gotCount != 1 {
+		t.Fatalf("expected one reused safepoint root array alloca, got %d in:\n%s", gotCount, got)
+	}
+	if gotCount := strings.Count(got, "call void @osty.gc.safepoint_v1(i64"); gotCount != 2 {
+		t.Fatalf("expected entry + loop safepoints, got %d in:\n%s", gotCount, got)
+	}
+	callRe := regexp.MustCompile(`call void @osty\.gc\.safepoint_v1\(i64 \d+, ptr (%t\d+), i64 2\)`)
+	matches := callRe.FindAllStringSubmatch(got, -1)
+	if len(matches) != 2 {
+		t.Fatalf("expected two safepoint calls sharing a root array pointer in:\n%s", got)
+	}
+	if matches[0][1] != matches[1][1] {
+		t.Fatalf("expected safepoints to reuse the same root array pointer, got %q and %q in:\n%s", matches[0][1], matches[1][1], got)
+	}
+}
+
+func TestGenerateFromMIRNullsManagedDeadLocalsBeforeLoopSafepoint(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "keep",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.LetStmt{
+					Name:  "i",
+					Type:  ir.TInt,
+					Mut:   true,
+					Value: &ir.IntLit{Text: "0", T: ir.TInt},
+				},
+				&ir.ForStmt{
+					Kind: ir.ForWhile,
+					Cond: &ir.BinaryExpr{
+						Op:    ir.BinLt,
+						Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+						Right: &ir.IntLit{Text: "1", T: ir.TInt},
+						T:     ir.TBool,
+					},
+					Body: &ir.Block{
+						Stmts: []ir.Stmt{
+							&ir.Block{
+								Stmts: []ir.Stmt{
+									&ir.LetStmt{
+										Name:  "t",
+										Type:  ir.TString,
+										Value: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+									},
+								},
+							},
+							&ir.AssignStmt{
+								Op:      ir.AssignEq,
+								Targets: []ir.Expr{&ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt}},
+								Value: &ir.BinaryExpr{
+									Op:    ir.BinAdd,
+									Left:  &ir.Ident{Name: "i", Kind: ir.IdentLocal, T: ir.TInt},
+									Right: &ir.IntLit{Text: "1", T: ir.TInt},
+									T:     ir.TInt,
+								},
+							},
+						},
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+		},
+	}
+	hir := &ir.Module{Package: "main", Decls: []ir.Decl{fn}}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/gc-dead-local-null.osty",
+		EmitGC:      true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if gotCount := strings.Count(got, "call void @osty.gc.safepoint_v1(i64"); gotCount != 2 {
+		t.Fatalf("expected entry + loop safepoints, got %d in:\n%s", gotCount, got)
+	}
+	nullMatches := regexp.MustCompile(`store ptr null, ptr (%l\d+)`).FindAllStringSubmatchIndex(got, -1)
+	if len(nullMatches) < 3 {
+		t.Fatalf("expected entry zero-init plus storage-dead nulling in:\n%s", got)
+	}
+	nullCounts := map[string]int{}
+	nullPos := map[string][]int{}
+	for _, match := range nullMatches {
+		slot := got[match[2]:match[3]]
+		nullCounts[slot]++
+		nullPos[slot] = append(nullPos[slot], match[0])
+	}
+	var deadSlot string
+	for slot, count := range nullCounts {
+		if count == 2 {
+			deadSlot = slot
+			break
+		}
+	}
+	if deadSlot == "" {
+		t.Fatalf("expected one managed local slot to be nulled twice (entry + storage_dead) in:\n%s", got)
+	}
+	firstPoll := strings.Index(got, "call void @osty.gc.safepoint_v1(i64")
+	lastPoll := strings.LastIndex(got, "call void @osty.gc.safepoint_v1(i64")
+	if firstPoll < 0 || lastPoll <= firstPoll {
+		t.Fatalf("expected distinct entry and loop safepoints in:\n%s", got)
+	}
+	if !(nullPos[deadSlot][1] > firstPoll && nullPos[deadSlot][1] < lastPoll) {
+		t.Fatalf("expected storage-dead nulling for %s between entry and loop safepoints in:\n%s", deadSlot, got)
+	}
+}
+
 // TestGenerateFromMIREmitGCLoopSafepoint — A while-loop lowers to a
 // cond block whose branch terminator targets the loop body and the
 // exit. The back-edge from the body to the cond block must carry a

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -390,9 +390,9 @@ type bodyState struct {
 	fn  *Function
 	cur BlockID
 
-	// locals maps HIR-visible names to MIR local IDs. Pushed on let
-	// binding, popped at the end of scopes.
-	locals []map[string]LocalID
+	// locals maps HIR-visible names to MIR local IDs and tracks the
+	// scope-owned locals that should receive StorageDead on scope exit.
+	locals []scopeFrame
 
 	// paramLocals is a cached view of fn.Params for quick access.
 	paramLocals []LocalID
@@ -417,6 +417,11 @@ type ownerContext struct {
 	localID  LocalID
 }
 
+type scopeFrame struct {
+	names  map[string]LocalID
+	locals []LocalID
+}
+
 type loopFrame struct {
 	breakBlock    BlockID
 	continueBlock BlockID
@@ -425,6 +430,10 @@ type loopFrame struct {
 	// *inclusive* of this one — every iteration enters the body
 	// scope fresh, so the body's defers run on both exit paths.
 	deferDepth int
+	// scopeDepth records the local-scope depth of the loop body so
+	// break/continue can retire loop-body locals before control jumps
+	// to the header/step/exit blocks.
+	scopeDepth int
 }
 
 func newBodyState(l *lowerer, fn *Function) *bodyState {
@@ -438,7 +447,7 @@ func newBodyState(l *lowerer, fn *Function) *bodyState {
 	for i, p := range fn.Params {
 		loc := fn.Locals[p]
 		if loc != nil && loc.Name != "" {
-			bs.locals[0][loc.Name] = p
+			bs.locals[0].names[loc.Name] = p
 		}
 		bs.paramLocals = append(bs.paramLocals, p)
 		_ = i
@@ -447,13 +456,14 @@ func newBodyState(l *lowerer, fn *Function) *bodyState {
 }
 
 func (bs *bodyState) pushScope() {
-	bs.locals = append(bs.locals, map[string]LocalID{})
+	bs.locals = append(bs.locals, scopeFrame{names: map[string]LocalID{}})
 }
 
 func (bs *bodyState) popScope() {
 	if len(bs.locals) == 0 {
 		return
 	}
+	bs.emitStorageDeadForScope(&bs.locals[len(bs.locals)-1])
 	bs.locals = bs.locals[:len(bs.locals)-1]
 }
 
@@ -461,16 +471,66 @@ func (bs *bodyState) bind(name string, id LocalID) {
 	if name == "" {
 		return
 	}
-	bs.locals[len(bs.locals)-1][name] = id
+	bs.locals[len(bs.locals)-1].names[name] = id
 }
 
 func (bs *bodyState) lookup(name string) (LocalID, bool) {
 	for i := len(bs.locals) - 1; i >= 0; i-- {
-		if id, ok := bs.locals[i][name]; ok {
+		if id, ok := bs.locals[i].names[name]; ok {
 			return id, true
 		}
 	}
 	return 0, false
+}
+
+func (bs *bodyState) registerScopeLocal(id LocalID) {
+	if len(bs.locals) == 0 {
+		return
+	}
+	loc := bs.fn.Local(id)
+	if loc == nil || loc.IsParam || loc.IsReturn {
+		return
+	}
+	bs.locals[len(bs.locals)-1].locals = append(bs.locals[len(bs.locals)-1].locals, id)
+}
+
+func (bs *bodyState) currentScopeDepth() int {
+	return len(bs.locals) - 1
+}
+
+func (bs *bodyState) emitStorageDeadFromDepth(depth int) {
+	if depth < 0 {
+		depth = 0
+	}
+	for i := len(bs.locals) - 1; i >= depth; i-- {
+		bs.emitStorageDeadForScope(&bs.locals[i])
+	}
+}
+
+func (bs *bodyState) emitStorageDeadForScope(scope *scopeFrame) {
+	if scope == nil || len(scope.locals) == 0 {
+		return
+	}
+	bb := bs.currentBlock()
+	if bb == nil || bb.Term != nil {
+		scope.locals = nil
+		return
+	}
+	for i := len(scope.locals) - 1; i >= 0; i-- {
+		id := scope.locals[i]
+		sp := Span{}
+		if loc := bs.fn.Local(id); loc != nil {
+			sp = loc.SpanV
+		}
+		bs.emit(&StorageDeadInstr{Local: id, SpanV: sp})
+	}
+	scope.locals = nil
+}
+
+func (bs *bodyState) newLocal(name string, t Type, mut bool, sp Span) LocalID {
+	id := bs.fn.NewLocal(name, t, mut, sp)
+	bs.registerScopeLocal(id)
+	return id
 }
 
 // ==== cursor + block helpers ====
@@ -596,7 +656,7 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 	case let.Pattern != nil:
 		bs.lowerLetPattern(let.Pattern, let.Value, t, let.SpanV)
 	case let.Name != "":
-		id := bs.fn.NewLocal(let.Name, t, let.Mut, let.SpanV)
+		id := bs.newLocal(let.Name, t, let.Mut, let.SpanV)
 		bs.emit(&StorageLiveInstr{Local: id, SpanV: let.SpanV})
 		if let.Value != nil {
 			bs.lowerExprInto(let.Value, id, t)
@@ -608,7 +668,7 @@ func (bs *bodyState) lowerLet(let *ir.LetStmt) {
 }
 
 func (bs *bodyState) lowerLetPattern(pat ir.Pattern, value ir.Expr, valueType Type, sp Span) {
-	scratch := bs.fn.NewLocal("_scratch", valueType, false, sp)
+	scratch := bs.newLocal("_scratch", valueType, false, sp)
 	bs.emit(&StorageLiveInstr{Local: scratch, SpanV: sp})
 	if value != nil {
 		bs.lowerExprInto(value, scratch, valueType)
@@ -629,7 +689,7 @@ func (bs *bodyState) bindPattern(pat ir.Pattern, scrutinee Place, scrutineeT Typ
 	case *ir.WildPat:
 		return
 	case *ir.IdentPat:
-		id := bs.fn.NewLocal(p.Name, scrutineeT, p.Mut, p.SpanV)
+		id := bs.newLocal(p.Name, scrutineeT, p.Mut, p.SpanV)
 		bs.emit(&StorageLiveInstr{Local: id, SpanV: p.SpanV})
 		bs.emit(&AssignInstr{
 			Dest:  Place{Local: id},
@@ -639,7 +699,7 @@ func (bs *bodyState) bindPattern(pat ir.Pattern, scrutinee Place, scrutineeT Typ
 		bs.bind(p.Name, id)
 	case *ir.BindingPat:
 		// Bind the whole scrutinee to the outer name, then recurse.
-		id := bs.fn.NewLocal(p.Name, scrutineeT, false, p.SpanV)
+		id := bs.newLocal(p.Name, scrutineeT, false, p.SpanV)
 		bs.emit(&StorageLiveInstr{Local: id, SpanV: p.SpanV})
 		bs.emit(&AssignInstr{
 			Dest:  Place{Local: id},
@@ -664,7 +724,7 @@ func (bs *bodyState) bindPattern(pat ir.Pattern, scrutinee Place, scrutineeT Typ
 			if f.Pattern != nil {
 				bs.bindPattern(f.Pattern, child, ft, p.SpanV)
 			} else {
-				id := bs.fn.NewLocal(f.Name, ft, false, p.SpanV)
+				id := bs.newLocal(f.Name, ft, false, p.SpanV)
 				bs.emit(&StorageLiveInstr{Local: id, SpanV: p.SpanV})
 				bs.emit(&AssignInstr{
 					Dest:  Place{Local: id},
@@ -768,7 +828,7 @@ func (bs *bodyState) lowerCompoundAssign(a *ir.AssignStmt) {
 // TupleProj into that scratch.
 func (bs *bodyState) lowerMultiAssign(a *ir.AssignStmt) {
 	rhsT := a.Value.Type()
-	scratch := bs.fn.NewLocal("_mtuple", rhsT, false, a.SpanV)
+	scratch := bs.newLocal("_mtuple", rhsT, false, a.SpanV)
 	bs.emit(&StorageLiveInstr{Local: scratch, SpanV: a.SpanV})
 	bs.lowerExprInto(a.Value, scratch, rhsT)
 	elemTs := tupleElementTypes(rhsT)
@@ -941,6 +1001,7 @@ func (bs *bodyState) lowerBreak(b *ir.BreakStmt) {
 	}
 	top := bs.loopStack[len(bs.loopStack)-1]
 	bs.replayDefersFromDepth(top.deferDepth, b.SpanV)
+	bs.emitStorageDeadFromDepth(top.scopeDepth)
 	bs.terminate(&GotoTerm{Target: top.breakBlock, SpanV: b.SpanV})
 }
 
@@ -951,6 +1012,7 @@ func (bs *bodyState) lowerContinue(c *ir.ContinueStmt) {
 	}
 	top := bs.loopStack[len(bs.loopStack)-1]
 	bs.replayDefersFromDepth(top.deferDepth, c.SpanV)
+	bs.emitStorageDeadFromDepth(top.scopeDepth)
 	bs.terminate(&GotoTerm{Target: top.continueBlock, SpanV: c.SpanV})
 }
 
@@ -995,6 +1057,7 @@ func (bs *bodyState) lowerIfStmt(st *ir.IfStmt) {
 }
 
 func (bs *bodyState) lowerForStmt(f *ir.ForStmt) {
+	bs.pushScope()
 	switch f.Kind {
 	case ir.ForInfinite:
 		bs.lowerForInfinite(f)
@@ -1007,6 +1070,7 @@ func (bs *bodyState) lowerForStmt(f *ir.ForStmt) {
 	default:
 		bs.l.noteIssue("unsupported for kind %d", f.Kind)
 	}
+	bs.popScope()
 }
 
 func (bs *bodyState) lowerForInfinite(f *ir.ForStmt) {
@@ -1020,7 +1084,7 @@ func (bs *bodyState) lowerForInfinite(f *ir.ForStmt) {
 	bs.pushScope()
 	bs.pushDeferScope()
 	bs.loopStack = append(bs.loopStack, &loopFrame{
-		breakBlock: exit, continueBlock: header, deferDepth: len(bs.deferFrames) - 1,
+		breakBlock: exit, continueBlock: header, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
 	})
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
@@ -1045,7 +1109,7 @@ func (bs *bodyState) lowerForWhile(f *ir.ForStmt) {
 	bs.pushScope()
 	bs.pushDeferScope()
 	bs.loopStack = append(bs.loopStack, &loopFrame{
-		breakBlock: exit, continueBlock: header, deferDepth: len(bs.deferFrames) - 1,
+		breakBlock: exit, continueBlock: header, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
 	})
 	for _, s := range f.Body.Stmts {
 		bs.lowerStmt(s)
@@ -1061,10 +1125,10 @@ func (bs *bodyState) lowerForWhile(f *ir.ForStmt) {
 // ==== range / in loop lowering ====
 
 func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
-	idx := bs.fn.NewLocal(f.Var, TInt, true, f.SpanV)
+	idx := bs.newLocal(f.Var, TInt, true, f.SpanV)
 	bs.emit(&StorageLiveInstr{Local: idx, SpanV: f.SpanV})
 	bs.lowerExprInto(f.Start, idx, TInt)
-	end := bs.fn.NewLocal("_end", TInt, false, f.SpanV)
+	end := bs.newLocal("_end", TInt, false, f.SpanV)
 	bs.lowerExprInto(f.End, end, TInt)
 	bs.bind(f.Var, idx)
 	header := bs.newBlock(f.SpanV)
@@ -1098,7 +1162,7 @@ func (bs *bodyState) lowerForRange(f *ir.ForStmt) {
 	bs.pushScope()
 	bs.pushDeferScope()
 	bs.loopStack = append(bs.loopStack, &loopFrame{
-		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1,
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
 	})
 	bs.bind(f.Var, idx)
 	for _, s := range f.Body.Stmts {
@@ -1139,16 +1203,16 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 		elemT = ir.ErrTypeVal
 	}
 	// capture iterable into a temp so we can re-read length and index
-	iter := bs.fn.NewLocal("_iter", iterT, false, f.SpanV)
+	iter := bs.newLocal("_iter", iterT, false, f.SpanV)
 	bs.emit(&StorageLiveInstr{Local: iter, SpanV: f.SpanV})
 	bs.lowerExprInto(f.Iter, iter, iterT)
-	lenLocal := bs.fn.NewLocal("_len", TInt, false, f.SpanV)
+	lenLocal := bs.newLocal("_len", TInt, false, f.SpanV)
 	bs.emit(&AssignInstr{
 		Dest:  Place{Local: lenLocal},
 		Src:   &LenRV{Place: Place{Local: iter}, T: TInt},
 		SpanV: f.SpanV,
 	})
-	idx := bs.fn.NewLocal("_idx", TInt, true, f.SpanV)
+	idx := bs.newLocal("_idx", TInt, true, f.SpanV)
 	bs.emit(&AssignInstr{
 		Dest:  Place{Local: idx},
 		Src:   &UseRV{Op: &ConstOp{Const: &IntConst{Value: 0, T: TInt}, T: TInt}},
@@ -1181,10 +1245,10 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 	bs.pushScope()
 	bs.pushDeferScope()
 	bs.loopStack = append(bs.loopStack, &loopFrame{
-		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1,
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
 	})
 	// load current element: elem = iter[idx]
-	elemLocal := bs.fn.NewLocal("_elem", elemT, false, f.SpanV)
+	elemLocal := bs.newLocal("_elem", elemT, false, f.SpanV)
 	elemPlace := Place{Local: iter, Projections: []Projection{
 		&IndexProj{
 			Index:    &CopyOp{Place: Place{Local: idx}, T: TInt},
@@ -1232,7 +1296,7 @@ func (bs *bodyState) lowerForIn(f *ir.ForStmt) {
 func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
 	elemT := channelElementType(iterT)
 	optT := &ir.OptionalType{Inner: elemT}
-	iter := bs.fn.NewLocal("_chan", iterT, false, f.SpanV)
+	iter := bs.newLocal("_chan", iterT, false, f.SpanV)
 	bs.emit(&StorageLiveInstr{Local: iter, SpanV: f.SpanV})
 	bs.lowerExprInto(f.Iter, iter, iterT)
 
@@ -1244,7 +1308,7 @@ func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
 
 	bs.cur = header
 	// opt := chan_recv(iter); switch opt { Some => body, None => exit }
-	opt := bs.fn.NewLocal("_recv", optT, false, f.SpanV)
+	opt := bs.newLocal("_recv", optT, false, f.SpanV)
 	bs.emit(&IntrinsicInstr{
 		Dest:  &Place{Local: opt},
 		Kind:  IntrinsicChanRecv,
@@ -1268,10 +1332,10 @@ func (bs *bodyState) lowerForInChannel(f *ir.ForStmt, iterT Type) {
 	bs.pushScope()
 	bs.pushDeferScope()
 	bs.loopStack = append(bs.loopStack, &loopFrame{
-		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1,
+		breakBlock: exit, continueBlock: step, deferDepth: len(bs.deferFrames) - 1, scopeDepth: bs.currentScopeDepth(),
 	})
 	// Unwrap the payload into a named local.
-	elemLocal := bs.fn.NewLocal("_elem", elemT, false, f.SpanV)
+	elemLocal := bs.newLocal("_elem", elemT, false, f.SpanV)
 	payloadProj := &VariantProj{
 		Variant:  int(someTagOf(optT)),
 		Name:     "Some",
@@ -1316,11 +1380,12 @@ func (bs *bodyState) lowerMatchExprInto(m *ir.MatchExpr, dest LocalID, destT Typ
 
 // lowerMatch drives match lowering using an optional decision tree.
 func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.DecisionNode, sp Span, dest *LocalID, destT Type) {
+	bs.pushScope()
 	scrutT := scrutinee.Type()
 	if scrutT == nil {
 		scrutT = ir.ErrTypeVal
 	}
-	scrutLocal := bs.fn.NewLocal("_scrut", scrutT, false, sp)
+	scrutLocal := bs.newLocal("_scrut", scrutT, false, sp)
 	bs.emit(&StorageLiveInstr{Local: scrutLocal, SpanV: sp})
 	bs.lowerExprInto(scrutinee, scrutLocal, scrutT)
 
@@ -1378,6 +1443,7 @@ func (bs *bodyState) lowerMatch(scrutinee ir.Expr, arms []*ir.MatchArm, tree ir.
 	}
 
 	bs.cur = merge
+	bs.popScope()
 }
 
 type matchContext struct {
@@ -1410,7 +1476,7 @@ func (mc *matchContext) lowerTree(node ir.DecisionNode) {
 			projType = n.T
 		}
 		place := projectionToPlace(bs.l, mc.scrutLocal, mc.scrutT, n.Proj)
-		id := bs.fn.NewLocal(n.Name, projType, false, mc.sp)
+		id := bs.newLocal(n.Name, projType, false, mc.sp)
 		bs.emit(&StorageLiveInstr{Local: id, SpanV: mc.sp})
 		bs.emit(&AssignInstr{
 			Dest:  Place{Local: id},
@@ -2020,9 +2086,10 @@ func (bs *bodyState) lowerBlockExprInto(be *ir.BlockExpr, dest Place, destT Type
 // It lowers into a discriminant test + payload binding for Option /
 // enum variants, and falls back to an unsupported note otherwise.
 func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Type) {
+	bs.pushScope()
 	scrut := ife.Scrutinee
 	scrutT := scrut.Type()
-	scrutLocal := bs.fn.NewLocal("_iflet", scrutT, false, ife.SpanV)
+	scrutLocal := bs.newLocal("_iflet", scrutT, false, ife.SpanV)
 	bs.emit(&StorageLiveInstr{Local: scrutLocal, SpanV: ife.SpanV})
 	bs.lowerExprInto(scrut, scrutLocal, scrutT)
 
@@ -2043,6 +2110,7 @@ func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Typ
 			bs.popDeferScope()
 			bs.popScope()
 		}
+		bs.popScope()
 		return
 	}
 	varIdx := bs.l.variantIndexByName(scrutT, vp.Variant)
@@ -2098,6 +2166,7 @@ func (bs *bodyState) lowerIfLetExprInto(ife *ir.IfLetExpr, dest Place, destT Typ
 	}
 	bs.terminate(&GotoTerm{Target: merge, SpanV: ife.SpanV})
 	bs.cur = merge
+	bs.popScope()
 }
 
 // lowerMatchExprIntoPlace routes through the generic matcher.
@@ -2108,7 +2177,7 @@ func (bs *bodyState) lowerMatchExprIntoPlace(m *ir.MatchExpr, dest Place, destT 
 	if t == nil {
 		t = m.T
 	}
-	local := bs.fn.NewLocal("_match", t, false, m.SpanV)
+	local := bs.newLocal("_match", t, false, m.SpanV)
 	bs.emit(&StorageLiveInstr{Local: local, SpanV: m.SpanV})
 	bs.lowerMatch(m.Scrutinee, m.Arms, m.Tree, m.SpanV, &local, t)
 	bs.emit(&AssignInstr{
@@ -2120,8 +2189,9 @@ func (bs *bodyState) lowerMatchExprIntoPlace(m *ir.MatchExpr, dest Place, destT 
 
 // lowerCoalesceInto handles `left ?? right`.
 func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Type) {
+	bs.pushScope()
 	leftT := c.Left.Type()
-	leftLocal := bs.fn.NewLocal("_coalesce", leftT, false, c.SpanV)
+	leftLocal := bs.newLocal("_coalesce", leftT, false, c.SpanV)
 	bs.emit(&StorageLiveInstr{Local: leftLocal, SpanV: c.SpanV})
 	bs.lowerExprInto(c.Left, leftLocal, leftT)
 	disc := bs.freshTemp(TInt, c.SpanV)
@@ -2151,6 +2221,7 @@ func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Typ
 	bs.lowerExprIntoPlace(c.Right, dest, destT)
 	bs.terminate(&GotoTerm{Target: merge, SpanV: c.SpanV})
 	bs.cur = merge
+	bs.popScope()
 }
 
 // lowerQuestionInto handles `e?`. The receiver must be Option<T> or
@@ -2164,8 +2235,9 @@ func (bs *bodyState) lowerCoalesceInto(c *ir.CoalesceExpr, dest Place, destT Typ
 // error path is just "None of the return type" — materialised via
 // NullaryRV{NullaryNone}.
 func (bs *bodyState) lowerQuestionInto(q *ir.QuestionExpr, dest Place, destT Type) {
+	bs.pushScope()
 	xT := q.X.Type()
-	tmp := bs.fn.NewLocal("_q", xT, false, q.SpanV)
+	tmp := bs.newLocal("_q", xT, false, q.SpanV)
 	bs.emit(&StorageLiveInstr{Local: tmp, SpanV: q.SpanV})
 	bs.lowerExprInto(q.X, tmp, xT)
 	disc := bs.freshTemp(TInt, q.SpanV)
@@ -2198,6 +2270,7 @@ func (bs *bodyState) lowerQuestionInto(q *ir.QuestionExpr, dest Place, destT Typ
 		Src:   &UseRV{Op: &CopyOp{Place: Place{Local: tmp}.Project(payloadProj), T: destT}},
 		SpanV: q.SpanV,
 	})
+	bs.popScope()
 }
 
 // rebuildErrorIntoReturn materialises the error value for a `?`
@@ -2311,7 +2384,7 @@ func typesMatch(a, b Type) bool {
 // lowerOptionalFieldInto handles `x?.field`.
 func (bs *bodyState) lowerOptionalFieldInto(fe *ir.FieldExpr, dest Place, destT Type) {
 	recvT := fe.X.Type()
-	recvLocal := bs.fn.NewLocal("_opt", recvT, false, fe.SpanV)
+	recvLocal := bs.newLocal("_opt", recvT, false, fe.SpanV)
 	bs.emit(&StorageLiveInstr{Local: recvLocal, SpanV: fe.SpanV})
 	bs.lowerExprInto(fe.X, recvLocal, recvT)
 	disc := bs.freshTemp(TInt, fe.SpanV)
@@ -3405,7 +3478,7 @@ func (l *lowerer) nextClosureSymbol(parent string) string {
 // ==== misc helpers ====
 
 func (bs *bodyState) freshTemp(t Type, sp Span) LocalID {
-	return bs.fn.NewLocal("", t, false, sp)
+	return bs.newLocal("", t, false, sp)
 }
 
 // finishNoReturn ensures the current block ends in a terminator. For

--- a/internal/mir/mir_test.go
+++ b/internal/mir/mir_test.go
@@ -202,8 +202,8 @@ func TestLowerIfExpr(t *testing.T) {
 	fn := mkFn("abs", ir.TInt, &ir.Block{
 		Stmts: []ir.Stmt{
 			&ir.LetStmt{
-				Name: "n",
-				Type: ir.TInt,
+				Name:  "n",
+				Type:  ir.TInt,
 				Value: &ir.IntLit{Text: "-5", T: ir.TInt},
 			},
 		},
@@ -754,11 +754,11 @@ func TestValidateAcceptsExternalFunction(t *testing.T) {
 // table unchanged.
 func TestLowerPreservesUseDecls(t *testing.T) {
 	useDecl := &ir.UseDecl{
-		Path:        []string{"runtime", "strings"},
-		RawPath:     "runtime.strings",
-		Alias:       "strings",
+		Path:         []string{"runtime", "strings"},
+		RawPath:      "runtime.strings",
+		Alias:        "strings",
 		IsRuntimeFFI: true,
-		RuntimePath: "strings",
+		RuntimePath:  "strings",
 	}
 	mod := &ir.Module{Package: "main", Decls: []ir.Decl{useDecl}}
 	out := Lower(mod)
@@ -1665,6 +1665,38 @@ func TestLowerDeferInLoopReplaysOnContinue(t *testing.T) {
 	}
 }
 
+func TestLowerBlockScopedManagedLocalEmitsStorageDead(t *testing.T) {
+	fn := &ir.FnDecl{
+		Name:   "keep",
+		Return: ir.TString,
+		Params: []*ir.Param{{Name: "s", Type: ir.TString}},
+		Body: &ir.Block{
+			Stmts: []ir.Stmt{
+				&ir.Block{
+					Stmts: []ir.Stmt{
+						&ir.LetStmt{
+							Name:  "t",
+							Type:  ir.TString,
+							Value: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+						},
+					},
+				},
+			},
+			Result: &ir.Ident{Name: "s", Kind: ir.IdentParam, T: ir.TString},
+		},
+	}
+	mod := lowerHIR(t, fn)
+	text := Print(mod)
+	live := strings.Index(text, "storage_live _2")
+	dead := strings.Index(text, "storage_dead _2")
+	if live < 0 || dead < 0 {
+		t.Fatalf("expected block-scoped managed local to get storage markers:\n%s", text)
+	}
+	if live >= dead {
+		t.Fatalf("expected storage_dead after storage_live, got %d >= %d:\n%s", live, dead, text)
+	}
+}
+
 // TestLowerDeferInnerBlockDoesNotLeakToOuterReturn proves the fix for
 // the Stage 2a limitation: a defer in an inner block must NOT also
 // re-run at the function's return. If it did, the "inner" marker
@@ -1803,12 +1835,12 @@ func TestLowerSelectTimeoutAndDefaultArms(t *testing.T) {
 // stdlibMethodTest is a tiny driver: build a method call on receiverT,
 // lower it, and assert the rendered output contains want.
 type stdlibMethodTest struct {
-	name       string
-	receiverT  ir.Type
-	method     string
-	args       []ir.Arg
-	retT       ir.Type
-	want       string // substring the printer output must contain
+	name      string
+	receiverT ir.Type
+	method    string
+	args      []ir.Arg
+	retT      ir.Type
+	want      string // substring the printer output must contain
 }
 
 func runStdlibMethodTest(t *testing.T, tc stdlibMethodTest) {


### PR DESCRIPTION
## Summary
- emit real `StorageDead` markers for scope-owned MIR locals, including loop exit paths
- lower MIR `StorageDead` into managed-slot nulling so reused safepoint root arrays stop retaining dead roots
- add MIR and llvmgen regressions covering scoped managed locals and dead-root nulling before loop safepoints

## Why
The previous safepoint-root-array reuse removed repeated array scaffolding, but dead managed locals could still remain visible to later safepoints because the MIR lowerer did not retire them and the LLVM emitter ignored `StorageDead`. This keeps the safepoint root set precise without rebuilding root arrays at each poll.

## Validation
- `git diff --check`
- `go test -count=1 -vet=off ./internal/mir`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIR'`