### PR TITLE
[codex] expand native llvmgen optional batch

### DIFF
--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -26,19 +26,20 @@ type nativeTupleInfo struct {
 }
 
 type nativeProjectionCtx struct {
-	structsByName    map[string]*nativeStructInfo
-	tuplesByLLVMType map[string]*nativeTupleInfo
-	tupleOrder       []string
-	methodsByOwner   map[string]map[string]nativeMethodInfo
-	globalConsts     map[string]nativeConstValue
-	mutableGlobals   map[string]bool
-	scopes           []map[string]nativeExprInfo
-	needsListRT      bool
-	needsMapRT       bool
-	needsSetRT       bool
-	needsStringRT    bool
-	stringGlobals    []*LlvmStringGlobal
-	nextStringID     int
+	structsByName         map[string]*nativeStructInfo
+	tuplesByLLVMType      map[string]*nativeTupleInfo
+	tupleOrder            []string
+	methodsByOwner        map[string]map[string]nativeMethodInfo
+	globalConsts          map[string]nativeConstValue
+	mutableGlobals        map[string]bool
+	scopes                []map[string]nativeExprInfo
+	needsListRT           bool
+	needsMapRT            bool
+	needsSetRT            bool
+	needsStringRT         bool
+	stringGlobals         []*LlvmStringGlobal
+	nextStringID          int
+	currentReturnLLVMType string
 }
 
 type nativeExprInfoKind int
@@ -51,21 +52,23 @@ const (
 	nativeExprInfoMap
 	nativeExprInfoSet
 	nativeExprInfoStruct
+	nativeExprInfoOptional
 )
 
 type nativeExprInfo struct {
-	kind           nativeExprInfoKind
-	llvmType       string
-	sourceType     ostyir.Type
-	structName     string
-	listElemType   string
-	listElemString bool
-	listElemBytes  bool
-	mapKeyType     string
-	mapValueType   string
-	mapKeyString   bool
-	setElemType    string
-	setElemString  bool
+	kind            nativeExprInfoKind
+	llvmType        string
+	sourceType      ostyir.Type
+	structName      string
+	listElemType    string
+	listElemString  bool
+	listElemBytes   bool
+	mapKeyType      string
+	mapValueType    string
+	mapKeyString    bool
+	setElemType     string
+	setElemString   bool
+	optionInnerType string
 }
 
 func (ctx *nativeProjectionCtx) pushScope() {
@@ -235,9 +238,12 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		if hasMain {
 			return nil, false
 		}
+		prevReturnType := ctx.currentReturnLLVMType
+		ctx.currentReturnLLVMType = "i32"
 		ctx.pushScope()
 		mainBody, ok := nativeBlockFromStmts(ctx, mod.Script, "i32")
 		ctx.popScope()
+		ctx.currentReturnLLVMType = prevReturnType
 		if !ok {
 			return nil, false
 		}
@@ -335,6 +341,9 @@ func nativeFunctionFromIR(ctx *nativeProjectionCtx, fn *ostyir.FnDecl) (*llvmNat
 	if !ok {
 		return nil, false
 	}
+	prevReturnType := ctx.currentReturnLLVMType
+	ctx.currentReturnLLVMType = retType
+	defer func() { ctx.currentReturnLLVMType = prevReturnType }()
 	out := &llvmNativeFunction{
 		name:       fn.Name,
 		returnType: retType,
@@ -393,6 +402,9 @@ func nativeMethodFunctionFromIR(
 	if !ok {
 		return nil, false
 	}
+	prevReturnType := ctx.currentReturnLLVMType
+	ctx.currentReturnLLVMType = retType
+	defer func() { ctx.currentReturnLLVMType = prevReturnType }()
 	out := &llvmNativeFunction{
 		name:       llvmMethodIRName(owner.Name, fn.Name),
 		returnType: retType,
@@ -439,10 +451,18 @@ func nativeBlockFromIR(ctx *nativeProjectionCtx, block *ostyir.Block, fnReturnTy
 	}
 	ctx.pushScope()
 	defer ctx.popScope()
-	out := &llvmNativeBlock{
-		stmts: make([]*llvmNativeStmt, 0, len(block.Stmts)),
+	stmts := block.Stmts
+	var tailResult ostyir.Expr
+	if block.Result == nil && fnReturnType != "" && fnReturnType != "void" && len(stmts) != 0 {
+		if exprStmt, ok := stmts[len(stmts)-1].(*ostyir.ExprStmt); ok && exprStmt != nil && exprStmt.X != nil {
+			tailResult = exprStmt.X
+			stmts = stmts[:len(stmts)-1]
+		}
 	}
-	for _, stmt := range block.Stmts {
+	out := &llvmNativeBlock{
+		stmts: make([]*llvmNativeStmt, 0, len(stmts)),
+	}
+	for _, stmt := range stmts {
 		nativeStmt, ok := nativeStmtFromIR(ctx, stmt, fnReturnType)
 		if !ok {
 			return nil, false
@@ -451,8 +471,12 @@ func nativeBlockFromIR(ctx *nativeProjectionCtx, block *ostyir.Block, fnReturnTy
 			out.stmts = append(out.stmts, nativeStmt)
 		}
 	}
-	if block.Result != nil {
-		result, ok := nativeExprFromIR(ctx, block.Result)
+	resultExpr := block.Result
+	if resultExpr == nil {
+		resultExpr = tailResult
+	}
+	if resultExpr != nil {
+		result, ok := nativeExprFromIR(ctx, resultExpr)
 		if !ok {
 			return nil, false
 		}
@@ -1103,7 +1127,34 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 		return out, true
 	case *ostyir.FieldExpr:
 		if e.Optional {
-			return nil, false
+			baseInfo, ok := nativeExprTypeInfo(ctx, e.X)
+			if !ok || baseInfo.kind != nativeExprInfoOptional {
+				return nil, false
+			}
+			baseSource, ok := unwrapOptionalIRType(nativeSourceTypeFromExprOrInfo(e.X, baseInfo))
+			if !ok {
+				return nil, false
+			}
+			info, ok := nativeStructInfoFromType(ctx, baseSource)
+			if !ok {
+				return nil, false
+			}
+			field, ok := info.byName[e.Name]
+			if !ok || field.llvmType != "ptr" {
+				return nil, false
+			}
+			base, ok := nativeExprFromIR(ctx, e.X)
+			if !ok {
+				return nil, false
+			}
+			return &llvmNativeExpr{
+				kind:                llvmNativeExprOptionalField,
+				llvmType:            "ptr",
+				fieldIndex:          field.index,
+				baseLLVMType:        info.def.llvmType,
+				optionInnerLLVMType: field.llvmType,
+				childExprs:          []*llvmNativeExpr{base},
+			}, true
 		}
 		baseInfo, ok := nativeExprTypeInfo(ctx, e.X)
 		if !ok || baseInfo.kind != nativeExprInfoStruct || baseInfo.structName == "" {
@@ -1239,6 +1290,59 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 			llvmType:   llvmType,
 			op:         nativeBinaryOpString(e.Op),
 			childExprs: []*llvmNativeExpr{left, right},
+		}, true
+	case *ostyir.QuestionExpr:
+		if ctx == nil || ctx.currentReturnLLVMType != "ptr" {
+			return nil, false
+		}
+		baseInfo, ok := nativeExprTypeInfo(ctx, e.X)
+		if !ok || baseInfo.kind != nativeExprInfoOptional {
+			return nil, false
+		}
+		base, ok := nativeExprFromIR(ctx, e.X)
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
+		if !ok {
+			llvmType = firstNonEmpty(baseInfo.optionInnerType, "")
+			ok = llvmType != ""
+		}
+		if !ok || llvmType == "" || (baseInfo.optionInnerType != "" && baseInfo.optionInnerType != llvmType) {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:                llvmNativeExprQuestion,
+			llvmType:            llvmType,
+			optionInnerLLVMType: firstNonEmpty(baseInfo.optionInnerType, llvmType),
+			childExprs:          []*llvmNativeExpr{base},
+		}, true
+	case *ostyir.CoalesceExpr:
+		leftInfo, ok := nativeExprTypeInfo(ctx, e.Left)
+		if !ok || leftInfo.kind != nativeExprInfoOptional {
+			return nil, false
+		}
+		left, ok := nativeExprFromIR(ctx, e.Left)
+		if !ok {
+			return nil, false
+		}
+		llvmType, ok := nativeLLVMTypeFromIR(ctx, e.Type())
+		if !ok {
+			llvmType = firstNonEmpty(leftInfo.optionInnerType, "")
+			ok = llvmType != ""
+		}
+		if !ok || llvmType == "" || (leftInfo.optionInnerType != "" && leftInfo.optionInnerType != llvmType) {
+			return nil, false
+		}
+		right, ok := nativeExprFromIRWithHint(ctx, e.Right, llvmType)
+		if !ok || right.llvmType != llvmType {
+			return nil, false
+		}
+		return &llvmNativeExpr{
+			kind:                llvmNativeExprCoalesce,
+			llvmType:            llvmType,
+			optionInnerLLVMType: firstNonEmpty(leftInfo.optionInnerType, llvmType),
+			childExprs:          []*llvmNativeExpr{left, right},
 		}, true
 	case *ostyir.CallExpr:
 		callee, ok := e.Callee.(*ostyir.Ident)
@@ -1596,6 +1700,17 @@ func nativeExprInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (nativeExpr
 			sourceType: t,
 			structName: tt.Name,
 		}, true
+	case *ostyir.OptionalType:
+		innerType, ok := nativeLLVMTypeFromIR(ctx, tt.Inner)
+		if !ok || innerType == "" || innerType == "void" {
+			return nativeExprInfo{}, false
+		}
+		return nativeExprInfo{
+			kind:            nativeExprInfoOptional,
+			llvmType:        "ptr",
+			sourceType:      t,
+			optionInnerType: innerType,
+		}, true
 	default:
 		return nativeExprInfo{}, false
 	}
@@ -1706,6 +1821,36 @@ func nativeExprTypeInfo(ctx *nativeProjectionCtx, expr ostyir.Expr) (nativeExprI
 			return nativeExprInfo{}, false
 		}
 		return nativeExprInfoFromLLVMType(info.elemLLVMTypes[e.Index]), true
+	case *ostyir.QuestionExpr:
+		baseInfo, ok := nativeExprTypeInfo(ctx, e.X)
+		if !ok || baseInfo.kind != nativeExprInfoOptional {
+			return nativeExprInfo{}, false
+		}
+		innerSource, ok := unwrapOptionalIRType(nativeSourceTypeFromExprOrInfo(e.X, baseInfo))
+		if ok {
+			if info, ok := nativeExprInfoFromType(ctx, innerSource); ok {
+				return info, true
+			}
+		}
+		if baseInfo.optionInnerType == "" {
+			return nativeExprInfo{}, false
+		}
+		return nativeExprInfoFromLLVMType(baseInfo.optionInnerType), true
+	case *ostyir.CoalesceExpr:
+		leftInfo, ok := nativeExprTypeInfo(ctx, e.Left)
+		if !ok || leftInfo.kind != nativeExprInfoOptional {
+			return nativeExprInfo{}, false
+		}
+		innerSource, ok := unwrapOptionalIRType(nativeSourceTypeFromExprOrInfo(e.Left, leftInfo))
+		if ok {
+			if info, ok := nativeExprInfoFromType(ctx, innerSource); ok {
+				return info, true
+			}
+		}
+		if leftInfo.optionInnerType == "" {
+			return nativeExprInfo{}, false
+		}
+		return nativeExprInfoFromLLVMType(leftInfo.optionInnerType), true
 	case *ostyir.MethodCall:
 		return nativeBuiltinMethodReturnInfo(ctx, e)
 	default:
@@ -1714,8 +1859,36 @@ func nativeExprTypeInfo(ctx *nativeProjectionCtx, expr ostyir.Expr) (nativeExprI
 }
 
 func nativeFieldExprInfo(ctx *nativeProjectionCtx, expr *ostyir.FieldExpr) (nativeExprInfo, bool) {
-	if ctx == nil || expr == nil || expr.Optional {
+	if ctx == nil || expr == nil {
 		return nativeExprInfo{}, false
+	}
+	if expr.Optional {
+		baseInfo, ok := nativeExprTypeInfo(ctx, expr.X)
+		if !ok || baseInfo.kind != nativeExprInfoOptional {
+			return nativeExprInfo{}, false
+		}
+		baseSource, ok := unwrapOptionalIRType(nativeSourceTypeFromExprOrInfo(expr.X, baseInfo))
+		if !ok {
+			return nativeExprInfo{}, false
+		}
+		structInfo, ok := nativeStructInfoFromType(ctx, baseSource)
+		if !ok {
+			return nativeExprInfo{}, false
+		}
+		fieldInfo, ok := structInfo.byName[expr.Name]
+		if !ok || fieldInfo.llvmType != "ptr" {
+			return nativeExprInfo{}, false
+		}
+		optionalField := wrapOptionalIRType(fieldInfo.irType)
+		if info, ok := nativeExprInfoFromType(ctx, optionalField); ok {
+			return info, true
+		}
+		return nativeExprInfo{
+			kind:            nativeExprInfoOptional,
+			llvmType:        "ptr",
+			sourceType:      optionalField,
+			optionInnerType: fieldInfo.llvmType,
+		}, true
 	}
 	baseInfo, ok := nativeExprTypeInfo(ctx, expr.X)
 	if !ok || baseInfo.kind != nativeExprInfoStruct || baseInfo.structName == "" {
@@ -1741,6 +1914,11 @@ func nativeBuiltinMethodReturnInfo(ctx *nativeProjectionCtx, e *ostyir.MethodCal
 	}
 	if receiverInfo, ok := nativeExprTypeInfo(ctx, e.Receiver); ok {
 		switch receiverInfo.kind {
+		case nativeExprInfoOptional:
+			switch e.Name {
+			case "isSome", "isNone":
+				return nativeExprInfoFromLLVMType("i1"), true
+			}
 		case nativeExprInfoString:
 			switch e.Name {
 			case "len", "count", "charCount":
@@ -1854,6 +2032,9 @@ func nativeBuiltinMethodExprFromIR(ctx *nativeProjectionCtx, e *ostyir.MethodCal
 	if ctx == nil || e == nil || e.Receiver == nil {
 		return nil, false
 	}
+	if expr, ok := nativeOptionMethodExprFromIR(ctx, e); ok {
+		return expr, true
+	}
 	if expr, ok := nativeStringMethodExprFromIR(ctx, e); ok {
 		return expr, true
 	}
@@ -1867,6 +2048,38 @@ func nativeBuiltinMethodExprFromIR(ctx *nativeProjectionCtx, e *ostyir.MethodCal
 		return expr, true
 	}
 	return nil, false
+}
+
+func nativeOptionMethodExprFromIR(ctx *nativeProjectionCtx, e *ostyir.MethodCall) (*llvmNativeExpr, bool) {
+	receiverInfo, ok := nativeExprTypeInfo(ctx, e.Receiver)
+	if !ok || receiverInfo.kind != nativeExprInfoOptional {
+		return nil, false
+	}
+	if len(e.Args) != 0 {
+		return nil, false
+	}
+	receiver, ok := nativeExprFromIR(ctx, e.Receiver)
+	if !ok {
+		return nil, false
+	}
+	switch e.Name {
+	case "isSome":
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprOptionCheck,
+			llvmType:   "i1",
+			boolValue:  true,
+			childExprs: []*llvmNativeExpr{receiver},
+		}, true
+	case "isNone":
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprOptionCheck,
+			llvmType:   "i1",
+			boolValue:  false,
+			childExprs: []*llvmNativeExpr{receiver},
+		}, true
+	default:
+		return nil, false
+	}
 }
 
 func nativeStringMethodExprFromIR(ctx *nativeProjectionCtx, e *ostyir.MethodCall) (*llvmNativeExpr, bool) {
@@ -2392,6 +2605,21 @@ func nativeSetMethodInfo(ctx *nativeProjectionCtx, t ostyir.Type) (elemType stri
 	return elemType, nativeTypeIsString(named.Args[0]), true
 }
 
+func unwrapOptionalIRType(t ostyir.Type) (ostyir.Type, bool) {
+	opt, ok := t.(*ostyir.OptionalType)
+	if !ok || opt == nil || opt.Inner == nil {
+		return nil, false
+	}
+	return opt.Inner, true
+}
+
+func wrapOptionalIRType(t ostyir.Type) ostyir.Type {
+	if t == nil {
+		return nil
+	}
+	return &ostyir.OptionalType{Inner: t}
+}
+
 func listElementType(t ostyir.Type) ostyir.Type {
 	named, ok := t.(*ostyir.NamedType)
 	if !ok || named == nil || !named.Builtin || named.Name != "List" || len(named.Args) != 1 {
@@ -2459,6 +2687,11 @@ func nativeLLVMTypeFromIR(ctx *nativeProjectionCtx, t ostyir.Type) (string, bool
 			return "", false
 		}
 		return info.def.llvmType, true
+	case *ostyir.OptionalType:
+		if _, ok := nativeLLVMTypeFromIR(ctx, tt.Inner); !ok {
+			return "", false
+		}
+		return "ptr", true
 	case *ostyir.TupleType:
 		return nativeRegisterTupleType(ctx, tt)
 	default:

--- a/internal/llvmgen/ir_native_entry_test.go
+++ b/internal/llvmgen/ir_native_entry_test.go
@@ -1143,3 +1143,198 @@ func TestTryGenerateNativeOwnedModuleAppliesExportAndCABI(t *testing.T) {
 		t.Fatalf("native-owned helper IR missing export alias:\n%s", got)
 	}
 }
+
+func TestNativeOwnedModuleEntryOptionalMethodBatch(t *testing.T) {
+	src := `fn flags(name: String?) -> Bool {
+    name.isSome() && !name.isNone()
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_methods.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for optional method batch")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"define i1 @flags(ptr %name)",
+		"icmp ne ptr",
+		"icmp eq ptr",
+		"xor i1",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned optional-method IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned optional-method entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryOptionalCoalesceStringBatch(t *testing.T) {
+	src := `fn display(name: String?) -> String {
+    name ?? "anon"
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_coalesce_string.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for optional string coalesce batch")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"define ptr @display(ptr %name)",
+		"icmp eq ptr",
+		"phi ptr",
+		"@.str0 = private unnamed_addr constant",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned optional-string-coalesce IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned optional-string-coalesce entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryOptionalCoalesceScalarBatch(t *testing.T) {
+	src := `fn score(value: Int?) -> Int {
+    value ?? 7
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_coalesce_scalar.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for optional scalar coalesce batch")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"define i64 @score(ptr %value)",
+		"icmp eq ptr",
+		"load i64, ptr %t",
+		"phi i64",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned optional-scalar-coalesce IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned optional-scalar-coalesce entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryOptionalQuestionScalarBatch(t *testing.T) {
+	src := `fn requireScore(score: Int?) -> String? {
+    let value = score?
+    println(value)
+    "ok"
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_question_scalar.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for optional scalar question batch")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"define ptr @requireScore(ptr %score)",
+		"ret ptr null",
+		"load i64, ptr %t",
+		"call i32 (ptr, ...) @printf(ptr @.fmt_i64, i64",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned optional-scalar-question IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned optional-scalar-question entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryOptionalQuestionStructBatch(t *testing.T) {
+	src := `struct Profile { name: String }
+
+fn requireName(profile: Profile?) -> String? {
+    let value = profile?
+    value.name
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_question_struct.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for optional struct question batch")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"%Profile = type { ptr }",
+		"define ptr @requireName(ptr %profile)",
+		"ret ptr null",
+		"load %Profile, ptr %t",
+		"extractvalue %Profile",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned optional-struct-question IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned optional-struct-question entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}
+
+func TestNativeOwnedModuleEntryOptionalFieldBatch(t *testing.T) {
+	src := `struct Profile { name: String }
+
+fn maybeName(profile: Profile?) -> String? {
+    profile?.name
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	opts := Options{PackageName: "main", SourcePath: "/tmp/native_entry_optional_field.osty"}
+	nativeMod, ok := nativeModuleFromIR(mod, opts)
+	if !ok {
+		t.Fatal("nativeModuleFromIR returned unsupported for optional field batch")
+	}
+	direct := llvmNativeEmitModule(nativeMod)
+	for _, want := range []string{
+		"%Profile = type { ptr }",
+		"define ptr @maybeName(ptr %profile)",
+		"load %Profile, ptr %t",
+		"extractvalue %Profile",
+		"phi ptr",
+	} {
+		if !strings.Contains(direct, want) {
+			t.Fatalf("native-owned optional-field IR missing %q:\n%s", want, direct)
+		}
+	}
+	out, err := GenerateModule(mod, opts)
+	if err != nil {
+		t.Fatalf("GenerateModule returned error: %v", err)
+	}
+	if string(out) != direct {
+		t.Fatalf("GenerateModule diverged from native-owned optional-field entrypoint\n--- direct ---\n%s\n--- generate ---\n%s", direct, string(out))
+	}
+}

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -5,7 +5,10 @@
 
 package llvmgen
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type llvmNativeExprKind int
 
@@ -27,6 +30,10 @@ const (
 	llvmNativeExprCall
 	llvmNativeExprPrintln
 	llvmNativeExprIf
+	llvmNativeExprOptionCheck
+	llvmNativeExprCoalesce
+	llvmNativeExprQuestion
+	llvmNativeExprOptionalField
 )
 
 type llvmNativeStmtKind int
@@ -45,22 +52,24 @@ const (
 )
 
 type llvmNativeExpr struct {
-	kind            llvmNativeExprKind
-	llvmType        string
-	text            string
-	name            string
-	op              string
-	fieldIndex      int
-	elemLLVMType    string
-	mapKeyLLVMType  string
-	mapKeyIsString  bool
-	firstArgByRef   bool
-	receiverPath    []*llvmNativeFieldPath
-	spillArgIndices []int
-	boolValue       bool
-	inclusive       bool
-	childExprs      []*llvmNativeExpr
-	childBlocks     []*llvmNativeBlock
+	kind                llvmNativeExprKind
+	llvmType            string
+	text                string
+	name                string
+	op                  string
+	fieldIndex          int
+	baseLLVMType        string
+	elemLLVMType        string
+	mapKeyLLVMType      string
+	mapKeyIsString      bool
+	optionInnerLLVMType string
+	firstArgByRef       bool
+	receiverPath        []*llvmNativeFieldPath
+	spillArgIndices     []int
+	boolValue           bool
+	inclusive           bool
+	childExprs          []*llvmNativeExpr
+	childBlocks         []*llvmNativeBlock
 }
 
 type llvmNativeFieldPath struct {
@@ -441,6 +450,14 @@ func llvmNativeEvalExpr(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
 		return llvmNativeEvalPrintln(emitter, expr)
 	case llvmNativeExprIf:
 		return llvmNativeEvalIfExpr(emitter, expr)
+	case llvmNativeExprOptionCheck:
+		return llvmNativeEvalOptionCheck(emitter, expr)
+	case llvmNativeExprCoalesce:
+		return llvmNativeEvalCoalesce(emitter, expr)
+	case llvmNativeExprQuestion:
+		return llvmNativeEvalQuestion(emitter, expr)
+	case llvmNativeExprOptionalField:
+		return llvmNativeEvalOptionalField(emitter, expr)
 	default:
 		return llvmNativeZeroValue(expr.llvmType)
 	}
@@ -634,6 +651,86 @@ func llvmNativeEvalIfExpr(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue
 	llvmIfExprElse(emitter, labels)
 	elseValue := llvmNativeBlockValue(emitter, expr.childBlocks[1], expr.llvmType)
 	return llvmIfExprEnd(emitter, expr.llvmType, thenValue, elseValue, labels)
+}
+
+func llvmNativeEvalOptionCheck(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) == 0 {
+		return llvmNativeZeroValue("i1")
+	}
+	base := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	pred := "eq"
+	if expr.boolValue {
+		pred = "ne"
+	}
+	return llvmCompare(emitter, pred, base, llvmNativeZeroValue("ptr"))
+}
+
+func llvmNativeEvalCoalesce(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) < 2 {
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+	left := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	isNil := llvmCompare(emitter, "eq", left, llvmNativeZeroValue("ptr"))
+	someLabel := llvmNextLabel(emitter, "coalesce.some")
+	noneLabel := llvmNextLabel(emitter, "coalesce.none")
+	endLabel := llvmNextLabel(emitter, "coalesce.end")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, noneLabel, someLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	innerType := firstNonEmpty(expr.optionInnerLLVMType, expr.llvmType)
+	someValue := left
+	if innerType != "ptr" {
+		someValue = llvmLoadFromSlot(emitter, left, innerType)
+	}
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	noneValue := llvmNativeEvalExpr(emitter, expr.childExprs[1])
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]", tmp, expr.llvmType, someValue.name, someLabel, noneValue.name, noneLabel))
+	return &LlvmValue{typ: expr.llvmType, name: tmp}
+}
+
+func llvmNativeEvalQuestion(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) == 0 {
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+	base := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	isNil := llvmCompare(emitter, "eq", base, llvmNativeZeroValue("ptr"))
+	nilLabel := llvmNextLabel(emitter, "optional.return")
+	contLabel := llvmNextLabel(emitter, "optional.cont")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, nilLabel, contLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", nilLabel))
+	emitter.body = append(emitter.body, "  ret ptr null")
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", contLabel))
+	innerType := firstNonEmpty(expr.optionInnerLLVMType, expr.llvmType)
+	if innerType == "ptr" {
+		return base
+	}
+	return llvmLoadFromSlot(emitter, base, innerType)
+}
+
+func llvmNativeEvalOptionalField(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
+	if len(expr.childExprs) == 0 || expr.baseLLVMType == "" {
+		return llvmNativeZeroValue(expr.llvmType)
+	}
+	base := llvmNativeEvalExpr(emitter, expr.childExprs[0])
+	isNil := llvmCompare(emitter, "eq", base, llvmNativeZeroValue("ptr"))
+	someLabel := llvmNextLabel(emitter, "optional.field.some")
+	noneLabel := llvmNextLabel(emitter, "optional.field.none")
+	endLabel := llvmNextLabel(emitter, "optional.field.end")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", isNil.name, noneLabel, someLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", someLabel))
+	fieldType := firstNonEmpty(expr.optionInnerLLVMType, expr.llvmType)
+	loadedBase := llvmLoadFromSlot(emitter, base, expr.baseLLVMType)
+	someValue := llvmExtractValue(emitter, loadedBase, fieldType, expr.fieldIndex)
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", noneLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	tmp := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi ptr [ %s, %%%s ], [ null, %%%s ]", tmp, someValue.name, someLabel, noneLabel))
+	return &LlvmValue{typ: "ptr", name: tmp}
 }
 
 func llvmNativeBlockValue(emitter *LlvmEmitter, block *llvmNativeBlock, llvmType string) *LlvmValue {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1135,6 +1135,10 @@ pub enum LlvmNativeExprKind {
     LlvmNativeExprCall,
     LlvmNativeExprPrintln,
     LlvmNativeExprIf,
+    LlvmNativeExprOptionCheck,
+    LlvmNativeExprCoalesce,
+    LlvmNativeExprQuestion,
+    LlvmNativeExprOptionalField,
 }
 
 pub enum LlvmNativeStmtKind {
@@ -1157,9 +1161,11 @@ pub struct LlvmNativeExpr {
     pub name: String,
     pub op: String,
     pub fieldIndex: Int,
+    pub baseLLVMType: String,
     pub elemLLVMType: String,
     pub mapKeyLLVMType: String,
     pub mapKeyIsString: Bool,
+    pub optionInnerLLVMType: String,
     pub firstArgByRef: Bool,
     pub receiverPath: List<LlvmNativeFieldPath>,
     pub spillArgIndices: List<Int>,
@@ -1591,6 +1597,10 @@ fn llvmNativeEvalExpr(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
         LlvmNativeExprCall -> llvmNativeEvalCall(emitter, expr),
         LlvmNativeExprPrintln -> llvmNativeEvalPrintln(emitter, expr),
         LlvmNativeExprIf -> llvmNativeEvalIfExpr(emitter, expr),
+        LlvmNativeExprOptionCheck -> llvmNativeEvalOptionCheck(emitter, expr),
+        LlvmNativeExprCoalesce -> llvmNativeEvalCoalesce(emitter, expr),
+        LlvmNativeExprQuestion -> llvmNativeEvalQuestion(emitter, expr),
+        LlvmNativeExprOptionalField -> llvmNativeEvalOptionalField(emitter, expr),
         _ -> llvmNativeZeroValue(expr.llvmType),
     }
 }
@@ -1825,6 +1835,95 @@ fn llvmNativeEvalIfExpr(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue
     llvmIfExprElse(emitter, labels)
     let elseValue = llvmNativeBlockValue(emitter, expr.childBlocks[1], expr.llvmType)
     llvmIfExprEnd(emitter, expr.llvmType, thenValue, elseValue, labels)
+}
+
+fn llvmNativeEvalOptionCheck(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        return llvmNativeZeroValue("i1")
+    }
+    let base = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    let pred = if expr.boolValue { "ne" } else { "eq" }
+    llvmCompare(emitter, pred, base, llvmNativeZeroValue("ptr"))
+}
+
+fn llvmNativeEvalCoalesce(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() < 2 {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let left = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    let isNil = llvmCompare(emitter, "eq", left, llvmNativeZeroValue("ptr"))
+    let someLabel = llvmNextLabel(emitter, "coalesce.some")
+    let noneLabel = llvmNextLabel(emitter, "coalesce.none")
+    let endLabel = llvmNextLabel(emitter, "coalesce.end")
+    emitter.body.push("  br i1 {isNil.name}, label %{noneLabel}, label %{someLabel}")
+    emitter.body.push("{someLabel}:")
+    let mut innerType = expr.optionInnerLLVMType
+    if innerType == "" {
+        innerType = expr.llvmType
+    }
+    let someValue = if innerType == "ptr" {
+        left
+    } else {
+        llvmLoadFromSlot(emitter, left, innerType)
+    }
+    emitter.body.push("  br label %{endLabel}")
+    emitter.body.push("{noneLabel}:")
+    let noneValue = llvmNativeEvalExpr(emitter, expr.childExprs[1])
+    emitter.body.push("  br label %{endLabel}")
+    emitter.body.push("{endLabel}:")
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push(
+        "  {tmp} = phi {expr.llvmType} [ {someValue.name}, %{someLabel} ], [ {noneValue.name}, %{noneLabel} ]",
+    )
+    LlvmValue { typ: expr.llvmType, name: tmp, pointer: false }
+}
+
+fn llvmNativeEvalQuestion(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let base = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    let isNil = llvmCompare(emitter, "eq", base, llvmNativeZeroValue("ptr"))
+    let nilLabel = llvmNextLabel(emitter, "optional.return")
+    let contLabel = llvmNextLabel(emitter, "optional.cont")
+    emitter.body.push("  br i1 {isNil.name}, label %{nilLabel}, label %{contLabel}")
+    emitter.body.push("{nilLabel}:")
+    emitter.body.push("  ret ptr null")
+    emitter.body.push("{contLabel}:")
+    let mut innerType = expr.optionInnerLLVMType
+    if innerType == "" {
+        innerType = expr.llvmType
+    }
+    if innerType == "ptr" {
+        return base
+    }
+    llvmLoadFromSlot(emitter, base, innerType)
+}
+
+fn llvmNativeEvalOptionalField(emitter: LlvmEmitter, expr: LlvmNativeExpr) -> LlvmValue {
+    if expr.childExprs.len() == 0 || expr.baseLLVMType == "" {
+        return llvmNativeZeroValue(expr.llvmType)
+    }
+    let base = llvmNativeEvalExpr(emitter, expr.childExprs[0])
+    let isNil = llvmCompare(emitter, "eq", base, llvmNativeZeroValue("ptr"))
+    let someLabel = llvmNextLabel(emitter, "optional.field.some")
+    let noneLabel = llvmNextLabel(emitter, "optional.field.none")
+    let endLabel = llvmNextLabel(emitter, "optional.field.end")
+    emitter.body.push("  br i1 {isNil.name}, label %{noneLabel}, label %{someLabel}")
+    emitter.body.push("{someLabel}:")
+    let mut fieldType = expr.optionInnerLLVMType
+    if fieldType == "" {
+        fieldType = expr.llvmType
+    }
+    let loadedBase = llvmLoadFromSlot(emitter, base, expr.baseLLVMType)
+    let someValue = llvmExtractValue(emitter, loadedBase, fieldType, expr.fieldIndex)
+    emitter.body.push("  br label %{endLabel}")
+    emitter.body.push("{noneLabel}:")
+    emitter.body.push("  br label %{endLabel}")
+    emitter.body.push("{endLabel}:")
+    let tmp = llvmNextTemp(emitter)
+    emitter.body.push("  {tmp} = phi ptr [ {someValue.name}, %{someLabel} ], [ null, %{noneLabel} ]")
+    LlvmValue { typ: "ptr", name: tmp, pointer: false }
 }
 
 fn llvmNativeBlockValue(


### PR DESCRIPTION
## Summary
- expand native-owned llvmgen entry coverage for `OptionalType`, including `??`, `?`, `?.`, and `isSome`/`isNone`
- mirror the new optional evaluators into the native snapshot and `toolchain/llvmgen.osty`
- add optional batch regression coverage and salvage tail `ExprStmt` results for non-void native blocks

## Validation
- `go test ./internal/llvmgen -run 'TestNativeOwnedModuleEntry|TestProbeNativeToolchainMerged$|TestNativeToolchainMergedIsClean$' -count=1 -v`
- `go test ./internal/backend -run 'TestLLVMBackendEmitLLVMIRSkipsToolchain|TestLLVMBackendEmitLLVMIRFromIRWithoutASTFallback' -count=1`
