### PR TITLE
[codex] add longer osty-vs-go runtime workloads

### DIFF
--- a/benchmarks/osty-vs-go/README.md
+++ b/benchmarks/osty-vs-go/README.md
@@ -19,6 +19,15 @@ benchmarks/osty-vs-go/
 ├── loop_sum/
 │   ├── go/      # package loopsumbench — BenchmarkSumTo100
 │   └── osty/    # benchSumTo100
+├── record_pipeline/
+│   ├── go/      # package recordpipelinebench — BenchmarkRecordPipeline
+│   └── osty/    # benchRecordPipeline
+├── lane_route/
+│   ├── go/      # package laneroutebench — BenchmarkLaneRoute
+│   └── osty/    # benchLaneRoute
+├── simd_stats/
+│   ├── go/      # package simdstatsbench — BenchmarkSimdStats
+│   └── osty/    # benchSimdStats
 └── fib/
     ├── go/      # package fibbench — BenchmarkFib15
     └── osty/    # benchFib15
@@ -28,6 +37,16 @@ One bench per workload, named the same on both sides: Go's
 `BenchmarkFoo` pairs with Osty's `benchFoo`. Adding a new pair is just
 a new top-level directory that follows the same layout — the runner
 discovers it automatically.
+
+Current workload mix:
+
+- `arith`: tiny scalar arithmetic / call overhead.
+- `fib`: recursive call-heavy control flow.
+- `loop_sum`: tight scalar loop (good for loop + vectorization regressions).
+- `word_freq`: collections + sort + string-heavy single-threaded aggregation.
+- `record_pipeline`: struct-heavy filtering + grouping + sorted-key aggregation.
+- `lane_route`: branchy one-dimensional dynamic programming / route relaxation.
+- `simd_stats`: long integer-array passes that stress vector-friendly hot loops.
 
 ## Running
 

--- a/benchmarks/osty-vs-go/lane_route/go/lane_route.go
+++ b/benchmarks/osty-vs-go/lane_route/go/lane_route.go
@@ -1,0 +1,42 @@
+package laneroutebench
+
+func buildLaneCosts(n int) []int {
+	costs := make([]int, n)
+	for i := 0; i < n; i++ {
+		costs[i] = ((i*19 + i/3*7) % 41) + 3
+	}
+	return costs
+}
+
+var laneRouteCosts = buildLaneCosts(4096)
+
+func min2(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+//go:noinline
+func AnalyzeLaneRoute(costs []int) int {
+	laneA, laneB, laneC := 0, 7, 13
+	checksum := 0
+	for i, cost := range costs {
+		nextA := min2(laneA, laneB+3) + cost
+		nextB := min2(min2(laneA+2, laneB), laneC+2) + cost/2 + (i % 7)
+		nextC := min2(laneB+3, laneC) + (cost*2)/3 + (i % 5)
+		laneA, laneB, laneC = nextA, nextB, nextC
+		checksum += (nextA + nextB + nextC) % 97
+	}
+	tail := []int{laneA, laneB, laneC}
+	if tail[1] < tail[0] {
+		tail[0], tail[1] = tail[1], tail[0]
+	}
+	if tail[2] < tail[1] {
+		tail[1], tail[2] = tail[2], tail[1]
+	}
+	if tail[1] < tail[0] {
+		tail[0], tail[1] = tail[1], tail[0]
+	}
+	return checksum + tail[0] + tail[1]*2 + tail[2]*3
+}

--- a/benchmarks/osty-vs-go/lane_route/go/lane_route_test.go
+++ b/benchmarks/osty-vs-go/lane_route/go/lane_route_test.go
@@ -1,0 +1,11 @@
+package laneroutebench
+
+import "testing"
+
+var laneRouteSink int
+
+func BenchmarkLaneRoute(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		laneRouteSink = AnalyzeLaneRoute(laneRouteCosts)
+	}
+}

--- a/benchmarks/osty-vs-go/lane_route/osty/lane_route.osty
+++ b/benchmarks/osty-vs-go/lane_route/osty/lane_route.osty
@@ -1,0 +1,35 @@
+fn buildLaneCosts(n: Int) -> List<Int> {
+    let mut costs: List<Int> = []
+    for i in 0..n {
+        costs.push(((i * 19 + (i / 3) * 7) % 41) + 3)
+    }
+    costs
+}
+
+fn min2(a: Int, b: Int) -> Int {
+    if b < a {
+        return b
+    }
+    a
+}
+
+pub fn analyzeLaneRoute(costs: List<Int>) -> Int {
+    let mut laneA = 0
+    let mut laneB = 7
+    let mut laneC = 13
+    let mut checksum = 0
+    let mut i = 0
+    for i < costs.len() {
+        let cost = costs[i]
+        let nextA = min2(laneA, laneB + 3) + cost
+        let nextB = min2(min2(laneA + 2, laneB), laneC + 2) + (cost / 2) + (i % 7)
+        let nextC = min2(laneB + 3, laneC) + ((cost * 2) / 3) + (i % 5)
+        laneA = nextA
+        laneB = nextB
+        laneC = nextC
+        checksum = checksum + ((nextA + nextB + nextC) % 97)
+        i = i + 1
+    }
+    let tail = [laneA, laneB, laneC].sorted()
+    checksum + tail[0] + tail[1] * 2 + tail[2] * 3
+}

--- a/benchmarks/osty-vs-go/lane_route/osty/lane_route_test.osty
+++ b/benchmarks/osty-vs-go/lane_route/osty/lane_route_test.osty
@@ -1,0 +1,9 @@
+use std.testing
+
+fn benchLaneRoute() {
+    let costs = buildLaneCosts(4096)
+    testing.benchmark(20, || {
+        let _ = analyzeLaneRoute(costs)
+        Ok(())
+    })
+}

--- a/benchmarks/osty-vs-go/record_pipeline/go/record_pipeline.go
+++ b/benchmarks/osty-vs-go/record_pipeline/go/record_pipeline.go
@@ -1,0 +1,61 @@
+package recordpipelinebench
+
+import "sort"
+
+type record struct {
+	Service string
+	Region  string
+	Level   string
+	Latency int
+	Hot     bool
+	Burst   bool
+}
+
+var pipelineRecords = buildPipelineRecords()
+
+func buildPipelineRecords() []record {
+	services := []string{"compiler", "runtime", "lsp", "checker"}
+	regions := []string{"apac", "us", "eu"}
+	levels := []string{"info", "warn", "error"}
+
+	rows := make([]record, 0, 192)
+	for i := 0; i < 192; i++ {
+		rows = append(rows, record{
+			Service: services[(i*5+i/3)%len(services)],
+			Region:  regions[(i*7+i/5)%len(regions)],
+			Level:   levels[(i*11+i/7)%len(levels)],
+			Latency: 10 + ((i*17 + i/2) % 29),
+			Hot:     i%5 != 2,
+			Burst:   i%8 == 0,
+		})
+	}
+	return rows
+}
+
+//go:noinline
+func AnalyzeRecordPipeline(rows []record) int {
+	totals := make(map[string]int, 32)
+	for _, row := range rows {
+		if !row.Hot || row.Latency < 18 {
+			continue
+		}
+		key := row.Service + "/" + row.Region + "/" + row.Level
+		score := row.Latency + len(row.Service) + len(row.Region)
+		if row.Burst {
+			score += 11
+		}
+		totals[key] += score
+	}
+
+	keys := make([]string, 0, len(totals))
+	for key := range totals {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	checksum := len(keys) * 17
+	for _, key := range keys {
+		checksum += totals[key] + len(key)
+	}
+	return checksum
+}

--- a/benchmarks/osty-vs-go/record_pipeline/go/record_pipeline_test.go
+++ b/benchmarks/osty-vs-go/record_pipeline/go/record_pipeline_test.go
@@ -1,0 +1,11 @@
+package recordpipelinebench
+
+import "testing"
+
+var recordPipelineSink int
+
+func BenchmarkRecordPipeline(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		recordPipelineSink = AnalyzeRecordPipeline(pipelineRecords)
+	}
+}

--- a/benchmarks/osty-vs-go/record_pipeline/osty/record_pipeline.osty
+++ b/benchmarks/osty-vs-go/record_pipeline/osty/record_pipeline.osty
@@ -1,0 +1,54 @@
+pub struct Record {
+    pub service: String,
+    pub region: String,
+    pub level: String,
+    pub latency: Int,
+    pub hot: Bool,
+    pub burst: Bool,
+}
+
+fn buildPipelineRecords() -> List<Record> {
+    let services = ["compiler", "runtime", "lsp", "checker"]
+    let regions = ["apac", "us", "eu"]
+    let levels = ["info", "warn", "error"]
+
+    let mut rows: List<Record> = []
+    for i in 0..192 {
+        rows.push(Record {
+            service: services[(i * 5 + i / 3) % services.len()],
+            region: regions[(i * 7 + i / 5) % regions.len()],
+            level: levels[(i * 11 + i / 7) % levels.len()],
+            latency: 10 + ((i * 17 + i / 2) % 29),
+            hot: i % 5 != 2,
+            burst: i % 8 == 0,
+        })
+    }
+    rows
+}
+
+pub fn analyzeRecordPipeline(rows: List<Record>) -> Int {
+    let mut totals: Map<String, Int> = {:}
+    for row in rows {
+        if !row.hot || row.latency < 18 {
+            continue
+        }
+        let key = "{row.service}/{row.region}/{row.level}"
+        let mut score = row.latency + row.service.len() + row.region.len()
+        if row.burst {
+            score = score + 11
+        }
+        let next = if totals.containsKey(key) {
+            totals.getOr(key, 0) + score
+        } else {
+            score
+        }
+        totals.insert(key, next)
+    }
+
+    let keys = totals.keys().sorted()
+    let mut checksum = keys.len() * 17
+    for key in keys {
+        checksum = checksum + totals.getOr(key, 0) + key.len()
+    }
+    checksum
+}

--- a/benchmarks/osty-vs-go/record_pipeline/osty/record_pipeline_test.osty
+++ b/benchmarks/osty-vs-go/record_pipeline/osty/record_pipeline_test.osty
@@ -1,0 +1,9 @@
+use std.testing
+
+fn benchRecordPipeline() {
+    let rows = buildPipelineRecords()
+    testing.benchmark(10, || {
+        let _ = analyzeRecordPipeline(rows)
+        Ok(())
+    })
+}

--- a/benchmarks/osty-vs-go/simd_stats/go/simd_stats.go
+++ b/benchmarks/osty-vs-go/simd_stats/go/simd_stats.go
@@ -1,0 +1,55 @@
+package simdstatsbench
+
+func buildSIMDData(n int) ([]int, []int) {
+	values := make([]int, n)
+	weights := make([]int, n)
+	for i := 0; i < n; i++ {
+		values[i] = ((i * 17) % 97) - 45 + (i % 7)
+		weights[i] = ((i * 29) % 89) + 25
+	}
+	return values, weights
+}
+
+var simdValues, simdWeights = buildSIMDData(2048)
+
+//go:noinline
+func AnalyzeSimdStats(values, weights []int) int {
+	n := len(values)
+	if len(weights) < n {
+		n = len(weights)
+	}
+
+	dot := 0
+	energy := 0
+	peak := -1 << 30
+	hits := 0
+
+	for i := 0; i < n; i++ {
+		mixed := values[i]*weights[i] + values[i]*4 - weights[i]
+		dot += mixed
+		energy += mixed * mixed
+		if mixed > 1500 {
+			hits++
+		}
+	}
+
+	for i := 0; i+7 < n; i++ {
+		window := values[i]*weights[i]*3 +
+			values[i+1]*weights[i+1]*5 +
+			values[i+2]*weights[i+2]*7 +
+			values[i+3]*weights[i+3]*11 +
+			values[i+4]*weights[i+4]*13 +
+			values[i+5]*weights[i+5]*17 +
+			values[i+6]*weights[i+6]*19 +
+			values[i+7]*weights[i+7]*23
+		if window > peak {
+			peak = window
+		}
+	}
+
+	out := dot + energy/97 + hits*31 + peak/11
+	if out < 0 {
+		out = -out
+	}
+	return out
+}

--- a/benchmarks/osty-vs-go/simd_stats/go/simd_stats_test.go
+++ b/benchmarks/osty-vs-go/simd_stats/go/simd_stats_test.go
@@ -1,0 +1,11 @@
+package simdstatsbench
+
+import "testing"
+
+var simdStatsSink int
+
+func BenchmarkSimdStats(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		simdStatsSink = AnalyzeSimdStats(simdValues, simdWeights)
+	}
+}

--- a/benchmarks/osty-vs-go/simd_stats/osty/simd_stats.osty
+++ b/benchmarks/osty-vs-go/simd_stats/osty/simd_stats.osty
@@ -1,0 +1,56 @@
+fn buildSimdValues(n: Int) -> List<Int> {
+    let mut values: List<Int> = []
+    for i in 0..n {
+        values.push(((i * 17) % 97) - 45 + (i % 7))
+    }
+    values
+}
+
+fn buildSimdWeights(n: Int) -> List<Int> {
+    let mut weights: List<Int> = []
+    for i in 0..n {
+        weights.push(((i * 29) % 89) + 25)
+    }
+    weights
+}
+
+#[vectorize]
+pub fn analyzeSimdStats(values: List<Int>, weights: List<Int>) -> Int {
+    let n = if values.len() < weights.len() { values.len() } else { weights.len() }
+    let mut dot = 0
+    let mut energy = 0
+    let mut peak = -1000000000
+    let mut hits = 0
+
+    for i in 0..n {
+        let mixed = values[i] * weights[i] + values[i] * 4 - weights[i]
+        dot = dot + mixed
+        energy = energy + mixed * mixed
+        if mixed > 1500 {
+            hits = hits + 1
+        }
+    }
+
+    if n > 7 {
+        for i in 0..(n - 7) {
+            let window =
+                values[i] * weights[i] * 3 +
+                values[i + 1] * weights[i + 1] * 5 +
+                values[i + 2] * weights[i + 2] * 7 +
+                values[i + 3] * weights[i + 3] * 11 +
+                values[i + 4] * weights[i + 4] * 13 +
+                values[i + 5] * weights[i + 5] * 17 +
+                values[i + 6] * weights[i + 6] * 19 +
+                values[i + 7] * weights[i + 7] * 23
+            if window > peak {
+                peak = window
+            }
+        }
+    }
+
+    let mut out = dot + (energy / 97) + hits * 31 + (peak / 11)
+    if out < 0 {
+        out = 0 - out
+    }
+    out
+}

--- a/benchmarks/osty-vs-go/simd_stats/osty/simd_stats_test.osty
+++ b/benchmarks/osty-vs-go/simd_stats/osty/simd_stats_test.osty
@@ -1,0 +1,10 @@
+use std.testing
+
+fn benchSimdStats() {
+    let values = buildSimdValues(2048)
+    let weights = buildSimdWeights(2048)
+    testing.benchmark(20, || {
+        let _ = analyzeSimdStats(values, weights)
+        Ok(())
+    })
+}


### PR DESCRIPTION
## Summary
- add three longer `osty-vs-go` workload pairs: `record_pipeline`, `lane_route`, and `simd_stats`
- cover struct-heavy collection pipelines, branchy dynamic-programming style loops, and vector-friendly numeric passes in both Go and Osty
- document the expanded workload mix in the benchmark README

## Why
The existing `arith` / `fib` / `loop_sum` microbenches are useful for regressions, but they do not give us a broad view of longer mixed-runtime behavior. These new pairs make it easier to compare Go and Osty on workloads that exercise collections, control flow, and vectorizable loops.

## Impact
- `osty-vs-go` can now compare longer-form workloads with the same top-level layout as the existing pairs
- SIMD and collection/runtime work can be evaluated against a wider benchmark set
- the README now lists the current workload mix so it is easier to understand what each pair is measuring

## Validation
- `go test -count=1 -vet=off ./benchmarks/osty-vs-go/record_pipeline/go ./benchmarks/osty-vs-go/lane_route/go ./benchmarks/osty-vs-go/simd_stats/go`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `./.bin/osty test --bench --serial --benchtime=200ms benchmarks/osty-vs-go/record_pipeline/osty`
- `./.bin/osty test --bench --serial --benchtime=200ms benchmarks/osty-vs-go/lane_route/osty`
- `./.bin/osty test --bench --serial --benchtime=200ms benchmarks/osty-vs-go/simd_stats/osty`
- `go run ./cmd/osty-vs-go --filter '^(record_pipeline|lane_route|simd_stats)$' --benchtime 200ms --go-count 3 --go-cpu 1 --label long-runtime-benchmarks`

## Latest comparison snapshot
- `lane_route`: Go `29682 ns/op`, Osty `636679 ns/op`, `21.45x`
- `record_pipeline`: Go `10656 ns/op`, Osty `363500 ns/op`, `34.11x`
- `simd_stats`: Go `13998 ns/op`, Osty `2055579 ns/op`, `146.85x`
- geomean: `47.54x`
