### PR TITLE
perf: fast-path scalar list indexing

### DIFF
--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -434,6 +434,39 @@ func TestTryEmitNativeOwnedLLVMIRTextCoversListIndex(t *testing.T) {
 	}
 }
 
+func TestTryEmitNativeOwnedLLVMIRTextVectorizedScalarListParamUsesRawDataFastPath(t *testing.T) {
+	t.Parallel()
+
+	req := newBackendRequest(t, EmitLLVMIR, `#[vectorize]
+fn dot(xs: List<Int>, ys: List<Int>) -> Int {
+    let n = if xs.len() < ys.len() { xs.len() } else { ys.len() }
+    let mut sum = 0
+    for i in 0..n {
+        sum = sum + xs[i] * ys[i]
+    }
+    sum
+}
+`)
+
+	got, ok, _, err := TryEmitNativeOwnedLLVMIRText(req.Entry, "")
+	if err != nil {
+		t.Fatalf("TryEmitNativeOwnedLLVMIRText returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryEmitNativeOwnedLLVMIRText reported not covered for vectorized scalar list params")
+	}
+	ir := string(got)
+	if !strings.Contains(ir, "declare ptr @osty_rt_list_data_i64(ptr)") {
+		t.Fatalf("native-owned IR missing list data declaration:\n%s", ir)
+	}
+	if gotCount := strings.Count(ir, "call ptr @osty_rt_list_data_i64(ptr "); gotCount != 2 {
+		t.Fatalf("list data cache call count = %d, want 2\n%s", gotCount, ir)
+	}
+	if !strings.Contains(ir, "getelementptr inbounds i64, ptr ") {
+		t.Fatalf("native-owned IR missing raw i64 GEP:\n%s", ir)
+	}
+}
+
 func TestEmitLLVMIRTextPrefersNativeOwnedFastPathWhenCovered(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -4182,6 +4182,24 @@ double osty_rt_list_get_f64(void *raw_list, int64_t index) {
     return value;
 }
 
+void *osty_rt_list_data_i64(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, sizeof(int64_t), NULL);
+    return list->data;
+}
+
+void *osty_rt_list_data_i1(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, sizeof(bool), NULL);
+    return list->data;
+}
+
+void *osty_rt_list_data_f64(void *raw_list) {
+    osty_rt_list *list = osty_rt_list_cast(raw_list);
+    osty_rt_list_ensure_layout(list, sizeof(double), NULL);
+    return list->data;
+}
+
 void *osty_rt_list_get_ptr(void *raw_list, int64_t index) {
     void *value;
     memcpy(&value, osty_rt_list_get_raw(raw_list, index, sizeof(value), osty_gc_mark_slot_v1), sizeof(value));

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -348,6 +348,7 @@ func nativeFunctionFromIR(ctx *nativeProjectionCtx, fn *ostyir.FnDecl) (*llvmNat
 		name:       fn.Name,
 		returnType: retType,
 		params:     make([]*llvmNativeParam, 0, len(fn.Params)),
+		vectorize:  fn.Vectorize,
 	}
 	for _, param := range fn.Params {
 		if param == nil || param.IsDestructured() || param.Default != nil {
@@ -357,10 +358,14 @@ func nativeFunctionFromIR(ctx *nativeProjectionCtx, fn *ostyir.FnDecl) (*llvmNat
 		if !ok || llvmType == "void" {
 			return nil, false
 		}
-		out.params = append(out.params, &llvmNativeParam{
+		nativeParam := &llvmNativeParam{
 			name:     param.Name,
 			llvmType: llvmType,
-		})
+		}
+		if info, ok := nativeExprInfoFromType(ctx, param.Type); ok && info.kind == nativeExprInfoList {
+			nativeParam.listElemLLVMType = info.listElemType
+		}
+		out.params = append(out.params, nativeParam)
 		ctx.bindScopeName(param.Name, nativeExprInfoFromLLVMType(llvmType))
 		if info, ok := nativeExprInfoFromType(ctx, param.Type); ok {
 			ctx.bindScopeName(param.Name, info)
@@ -414,6 +419,7 @@ func nativeMethodFunctionFromIR(
 			irType:   llvmMethodReceiverIRType(ownerInfo.def.llvmType, fn.ReceiverMut),
 			byRef:    fn.ReceiverMut,
 		}},
+		vectorize: fn.Vectorize,
 	}
 	ctx.bindScopeName("self", nativeExprInfo{
 		kind:       nativeExprInfoStruct,
@@ -428,10 +434,14 @@ func nativeMethodFunctionFromIR(
 		if !ok || llvmType == "void" {
 			return nil, false
 		}
-		out.params = append(out.params, &llvmNativeParam{
+		nativeParam := &llvmNativeParam{
 			name:     param.Name,
 			llvmType: llvmType,
-		})
+		}
+		if info, ok := nativeExprInfoFromType(ctx, param.Type); ok && info.kind == nativeExprInfoList {
+			nativeParam.listElemLLVMType = info.listElemType
+		}
+		out.params = append(out.params, nativeParam)
 		ctx.bindScopeName(param.Name, nativeExprInfoFromLLVMType(llvmType))
 		if info, ok := nativeExprInfoFromType(ctx, param.Type); ok {
 			ctx.bindScopeName(param.Name, info)

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -165,6 +165,12 @@ type mirGen struct {
 	// to that load/store as `!llvm.access !N` and referenced from the
 	// loop-level `!"llvm.loop.parallel_accesses", !N` property.
 	parallelAccessGroupRef string
+	// vectorListData / vectorListLens cache scalar list-param snapshots
+	// for the conservative raw-buffer fast path used by vectorized,
+	// call-free loops. Keys are root local IDs of eligible `List<Int>` /
+	// `List<Bool>` / `List<Float>` params.
+	vectorListData map[mir.LocalID]string
+	vectorListLens map[mir.LocalID]string
 	// loopMDDefs accumulates every metadata-node definition (loop
 	// hint chains + access groups) for the whole translation unit.
 	// Module-scoped numbering keeps IDs unique; flushed at module
@@ -787,6 +793,106 @@ func isSetPtrType(t mir.Type) bool {
 	return false
 }
 
+func vectorListElemType(t mir.Type) mir.Type {
+	if nt, ok := t.(*ir.NamedType); ok && nt.Name == "List" && nt.Builtin && len(nt.Args) > 0 {
+		return nt.Args[0]
+	}
+	return nil
+}
+
+func mirOperandRootLocal(op mir.Operand) (mir.LocalID, bool) {
+	switch o := op.(type) {
+	case *mir.CopyOp:
+		return o.Place.Local, true
+	case *mir.MoveOp:
+		return o.Place.Local, true
+	default:
+		return 0, false
+	}
+}
+
+func mirFunctionHasBackedge(fn *mir.Function) bool {
+	for _, bb := range fn.Blocks {
+		if bb == nil || bb.Term == nil {
+			continue
+		}
+		switch term := bb.Term.(type) {
+		case *mir.GotoTerm:
+			if term.Target <= bb.ID {
+				return true
+			}
+		case *mir.BranchTerm:
+			if term.Then <= bb.ID || term.Else <= bb.ID {
+				return true
+			}
+		case *mir.SwitchIntTerm:
+			if term.Default <= bb.ID {
+				return true
+			}
+			for _, c := range term.Cases {
+				if c.Target <= bb.ID {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func mirIntrinsicSafeForVectorListFastPath(k mir.IntrinsicKind) bool {
+	switch k {
+	case mir.IntrinsicListLen, mir.IntrinsicListIsEmpty:
+		return true
+	default:
+		return false
+	}
+}
+
+func (g *mirGen) eligibleVectorListParams(fn *mir.Function) map[mir.LocalID]string {
+	eligible := map[mir.LocalID]string{}
+	if !g.vectorizeHint || !mirFunctionHasBackedge(fn) {
+		return eligible
+	}
+	for _, pid := range fn.Params {
+		loc := fn.Local(pid)
+		if loc == nil {
+			continue
+		}
+		elemT := vectorListElemType(loc.Type)
+		if elemT == nil {
+			continue
+		}
+		elemLLVM := g.llvmType(elemT)
+		if listUsesRawDataFastPath(elemLLVM) {
+			eligible[pid] = elemLLVM
+		}
+	}
+	if len(eligible) == 0 {
+		return eligible
+	}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, inst := range bb.Instrs {
+			switch x := inst.(type) {
+			case *mir.CallInstr:
+				return map[mir.LocalID]string{}
+			case *mir.IntrinsicInstr:
+				if !mirIntrinsicSafeForVectorListFastPath(x.Kind) {
+					return map[mir.LocalID]string{}
+				}
+			case *mir.AssignInstr:
+				delete(eligible, x.Dest.Local)
+			}
+			if len(eligible) == 0 {
+				return eligible
+			}
+		}
+	}
+	return eligible
+}
+
 func (g *mirGen) checkRValueSupported(fn *mir.Function, rv mir.RValue) error {
 	switch r := rv.(type) {
 	case *mir.UseRV, *mir.UnaryRV, *mir.BinaryRV,
@@ -1180,6 +1286,8 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	g.unrollHint = fn.Unroll
 	g.unrollCount = fn.UnrollCount
 	g.parallelAccessGroupRef = ""
+	g.vectorListData = map[mir.LocalID]string{}
+	g.vectorListLens = map[mir.LocalID]string{}
 	if g.parallelHint {
 		// Allocate the per-function access group eagerly so every
 		// load/store site can reference it without branching on lazy
@@ -1280,6 +1388,7 @@ func (g *mirGen) emitFunction(fn *mir.Function) error {
 	// Register managed-ptr locals as GC roots and take a safepoint at
 	// the function entry. No-op unless opts.EmitGC is set.
 	g.emitGCEntry(fn)
+	g.emitVectorListPreamble(fn)
 
 	// Emit each block in ID order. The entry block was already opened
 	// (its label is implicit in LLVM, but we still emit it for clarity
@@ -1422,6 +1531,152 @@ func (g *mirGen) emitAllocaPreamble(fn *mir.Function) {
 	} else {
 		g.loopSafepointSlot = ""
 	}
+}
+
+func (g *mirGen) emitVectorListPreamble(fn *mir.Function) {
+	eligible := g.eligibleVectorListParams(fn)
+	if len(eligible) == 0 {
+		return
+	}
+	ids := make([]int, 0, len(eligible))
+	for pid := range eligible {
+		ids = append(ids, int(pid))
+	}
+	sort.Ints(ids)
+	for _, rawID := range ids {
+		pid := mir.LocalID(rawID)
+		elemLLVM := eligible[pid]
+		slot := g.localSlots[pid]
+		if slot == "" {
+			continue
+		}
+		listReg := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(listReg)
+		g.fnBuf.WriteString(" = load ptr, ptr ")
+		g.fnBuf.WriteString(slot)
+		g.fnBuf.WriteByte('\n')
+
+		dataSym := listRuntimeDataSymbol(elemLLVM)
+		g.declareRuntime(dataSym, "declare ptr @"+dataSym+"(ptr)")
+		dataReg := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(dataReg)
+		g.fnBuf.WriteString(" = call ptr @")
+		g.fnBuf.WriteString(dataSym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(listReg)
+		g.fnBuf.WriteString(")\n")
+		g.vectorListData[pid] = dataReg
+
+		lenSym := listRuntimeLenSymbol()
+		g.declareRuntime(lenSym, "declare i64 @"+lenSym+"(ptr)")
+		lenReg := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(lenReg)
+		g.fnBuf.WriteString(" = call i64 @")
+		g.fnBuf.WriteString(lenSym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(listReg)
+		g.fnBuf.WriteString(")\n")
+		g.vectorListLens[pid] = lenReg
+	}
+}
+
+func (g *mirGen) emitVectorListFastLoad(local mir.LocalID, idxVal, elemLLVM string) (string, bool) {
+	dataReg := g.vectorListData[local]
+	lenReg := g.vectorListLens[local]
+	slot := g.localSlots[local]
+	if dataReg == "" || lenReg == "" || slot == "" {
+		return "", false
+	}
+	inBounds := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(inBounds)
+	g.fnBuf.WriteString(" = icmp ult i64 ")
+	g.fnBuf.WriteString(idxVal)
+	g.fnBuf.WriteString(", ")
+	g.fnBuf.WriteString(lenReg)
+	g.fnBuf.WriteByte('\n')
+
+	fastLabel := g.freshLabel("list.fast")
+	slowLabel := g.freshLabel("list.slow")
+	mergeLabel := g.freshLabel("list.merge")
+	g.fnBuf.WriteString("  br i1 ")
+	g.fnBuf.WriteString(inBounds)
+	g.fnBuf.WriteString(", label %")
+	g.fnBuf.WriteString(fastLabel)
+	g.fnBuf.WriteString(", label %")
+	g.fnBuf.WriteString(slowLabel)
+	g.fnBuf.WriteByte('\n')
+
+	g.fnBuf.WriteString(fastLabel)
+	g.fnBuf.WriteString(":\n")
+	elemPtr := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(elemPtr)
+	g.fnBuf.WriteString(" = getelementptr inbounds ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(dataReg)
+	g.fnBuf.WriteString(", i64 ")
+	g.fnBuf.WriteString(idxVal)
+	g.fnBuf.WriteByte('\n')
+	fastVal := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(fastVal)
+	g.fnBuf.WriteString(" = load ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteString(", ptr ")
+	g.fnBuf.WriteString(elemPtr)
+	g.fnBuf.WriteByte('\n')
+	g.fnBuf.WriteString("  br label %")
+	g.fnBuf.WriteString(mergeLabel)
+	g.fnBuf.WriteByte('\n')
+
+	slowSym := listRuntimeGetSymbol(elemLLVM)
+	g.declareRuntime(slowSym, "declare "+elemLLVM+" @"+slowSym+"(ptr, i64)")
+	g.fnBuf.WriteString(slowLabel)
+	g.fnBuf.WriteString(":\n")
+	listReg := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(" = load ptr, ptr ")
+	g.fnBuf.WriteString(slot)
+	g.fnBuf.WriteByte('\n')
+	slowVal := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(slowVal)
+	g.fnBuf.WriteString(" = call ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteString(" @")
+	g.fnBuf.WriteString(slowSym)
+	g.fnBuf.WriteString("(ptr ")
+	g.fnBuf.WriteString(listReg)
+	g.fnBuf.WriteString(", i64 ")
+	g.fnBuf.WriteString(idxVal)
+	g.fnBuf.WriteString(")\n")
+	g.fnBuf.WriteString("  br label %")
+	g.fnBuf.WriteString(mergeLabel)
+	g.fnBuf.WriteByte('\n')
+
+	g.fnBuf.WriteString(mergeLabel)
+	g.fnBuf.WriteString(":\n")
+	merged := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(merged)
+	g.fnBuf.WriteString(" = phi ")
+	g.fnBuf.WriteString(elemLLVM)
+	g.fnBuf.WriteString(" [")
+	g.fnBuf.WriteString(fastVal)
+	g.fnBuf.WriteString(", %")
+	g.fnBuf.WriteString(fastLabel)
+	g.fnBuf.WriteString("], [")
+	g.fnBuf.WriteString(slowVal)
+	g.fnBuf.WriteString(", %")
+	g.fnBuf.WriteString(slowLabel)
+	g.fnBuf.WriteString("]\n")
+	return merged, true
 }
 
 // ==== GC instrumentation ====
@@ -2116,6 +2371,11 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		return g.emitListPushOperand(listReg, i.Args[1], elemT)
 	case mir.IntrinsicListLen:
+		if local, ok := mirOperandRootLocal(listOp); ok {
+			if cached := g.vectorListLens[local]; cached != "" {
+				return g.storeIntrinsicResult(i, &LlvmValue{typ: "i64", name: cached})
+			}
+		}
 		sym := listRuntimeLenSymbol()
 		g.declareRuntime(sym, "declare i64 @"+sym+"(ptr)")
 		em := g.ostyEmitter()
@@ -2136,6 +2396,11 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 			return err
 		}
 		if listUsesTypedRuntime(elemLLVM) {
+			if local, ok := mirOperandRootLocal(listOp); ok && listUsesRawDataFastPath(elemLLVM) {
+				if fast, ok := g.emitVectorListFastLoad(local, idxReg, elemLLVM); ok {
+					return g.storeIntrinsicResult(i, &LlvmValue{typ: elemLLVM, name: fast})
+				}
+			}
 			sym := listRuntimeGetSymbol(elemLLVM)
 			g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
 			em := g.ostyEmitter()
@@ -5137,6 +5402,14 @@ func (g *mirGen) emitLoad(place mir.Place, t mir.Type) (string, error) {
 				return "", err
 			}
 			if listUsesTypedRuntime(elemLLVM) {
+				if i == 0 && listUsesRawDataFastPath(elemLLVM) {
+					if fast, ok := g.emitVectorListFastLoad(place.Local, idxVal, elemLLVM); ok {
+						curReg = fast
+						curLLVM = elemLLVM
+						curT = elemT
+						continue
+					}
+				}
 				sym := "osty_rt_list_get_" + listRuntimeSymbolSuffix(elemLLVM)
 				g.declareRuntime(sym, "declare "+elemLLVM+" @"+sym+"(ptr, i64)")
 				next := g.fresh()

--- a/internal/llvmgen/mir_generator_test.go
+++ b/internal/llvmgen/mir_generator_test.go
@@ -1475,6 +1475,46 @@ func TestGenerateFromMIRListIndexReadPtrElem(t *testing.T) {
 	}
 }
 
+func TestGenerateFromMIRVectorizedScalarListParamUsesRawDataFastPath(t *testing.T) {
+	src := `fn sumDot(xs: List<Int>, ys: List<Int>, n: Int) -> Int {
+    let mut acc = 0
+    for i in 0..n {
+        acc = acc + xs[i] * ys[i]
+    }
+    acc
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	hir, issues := ir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	m := buildMIRModuleFromHIR(t, hir)
+	out, err := GenerateFromMIR(m, Options{PackageName: "main", SourcePath: "/tmp/sumdot.osty"})
+	if err != nil {
+		t.Fatalf("GenerateFromMIR: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "declare ptr @osty_rt_list_data_i64(ptr)") {
+		t.Fatalf("expected raw-data helper declaration in:\n%s", got)
+	}
+	if gotCount := strings.Count(got, "call ptr @osty_rt_list_data_i64(ptr "); gotCount != 2 {
+		t.Fatalf("expected two raw-data cache calls (xs + ys), got %d in:\n%s", gotCount, got)
+	}
+	if !strings.Contains(got, "getelementptr inbounds i64, ptr ") {
+		t.Fatalf("expected scalar list fast path GEP in:\n%s", got)
+	}
+}
+
 // ==== Stage 3.6: composite list element types (bytes ABI) ====
 
 func TestGenerateFromMIRListStructPushAndRead(t *testing.T) {

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -95,10 +95,11 @@ type llvmNativeBlock struct {
 }
 
 type llvmNativeParam struct {
-	name     string
-	llvmType string
-	irType   string
-	byRef    bool
+	name             string
+	llvmType         string
+	irType           string
+	byRef            bool
+	listElemLLVMType string
 }
 
 type llvmNativeGlobal struct {
@@ -125,6 +126,7 @@ type llvmNativeFunction struct {
 	returnType string
 	params     []*llvmNativeParam
 	body       *llvmNativeBlock
+	vectorize  bool
 }
 
 type llvmNativeModule struct {
@@ -215,10 +217,133 @@ func llvmNativeRuntimeDeclarations(mod *llvmNativeModule) []string {
 	return out
 }
 
+func llvmNativeCallPreservesScalarListParam(expr *llvmNativeExpr, paramName string) bool {
+	if expr == nil || paramName == "" {
+		return false
+	}
+	if expr.name != llvmListRuntimeLenSymbol() || len(expr.childExprs) != 1 {
+		return false
+	}
+	arg := expr.childExprs[0]
+	return arg != nil && arg.kind == llvmNativeExprIdent && arg.name == paramName
+}
+
+func llvmNativePruneScalarListParamsInExpr(expr *llvmNativeExpr, eligible map[string]string) {
+	if expr == nil || len(eligible) == 0 {
+		return
+	}
+	if expr.kind == llvmNativeExprCall {
+		for _, arg := range expr.childExprs {
+			if arg == nil || arg.kind != llvmNativeExprIdent {
+				continue
+			}
+			if _, ok := eligible[arg.name]; ok && !llvmNativeCallPreservesScalarListParam(expr, arg.name) {
+				delete(eligible, arg.name)
+			}
+		}
+	}
+	for _, child := range expr.childExprs {
+		llvmNativePruneScalarListParamsInExpr(child, eligible)
+	}
+	for _, block := range expr.childBlocks {
+		llvmNativePruneScalarListParamsInBlock(block, eligible)
+	}
+}
+
+func llvmNativePruneScalarListParamsInStmt(stmt *llvmNativeStmt, eligible map[string]string) {
+	if stmt == nil || len(eligible) == 0 {
+		return
+	}
+	if stmt.name != "" {
+		delete(eligible, stmt.name)
+	}
+	for _, expr := range stmt.childExprs {
+		llvmNativePruneScalarListParamsInExpr(expr, eligible)
+	}
+	for _, block := range stmt.childBlocks {
+		llvmNativePruneScalarListParamsInBlock(block, eligible)
+	}
+}
+
+func llvmNativePruneScalarListParamsInBlock(block *llvmNativeBlock, eligible map[string]string) {
+	if block == nil || len(eligible) == 0 {
+		return
+	}
+	for _, stmt := range block.stmts {
+		llvmNativePruneScalarListParamsInStmt(stmt, eligible)
+	}
+	if block.result != nil {
+		llvmNativePruneScalarListParamsInExpr(block.result, eligible)
+	}
+}
+
+func llvmNativeEligibleScalarListParams(fn *llvmNativeFunction) map[string]string {
+	eligible := map[string]string{}
+	if fn == nil {
+		return eligible
+	}
+	for _, param := range fn.params {
+		if param == nil || param.byRef || !listUsesRawDataFastPath(param.listElemLLVMType) {
+			continue
+		}
+		eligible[param.name] = param.listElemLLVMType
+	}
+	if len(eligible) == 0 {
+		return eligible
+	}
+	llvmNativePruneScalarListParamsInBlock(fn.body, eligible)
+	return eligible
+}
+
+func llvmNativePrimeScalarListParamFastPath(emitter *LlvmEmitter, paramName, elemLLVM string) {
+	if emitter == nil || paramName == "" || elemLLVM == "" {
+		return
+	}
+	list := llvmIdent(emitter, paramName)
+	if list == nil || list.typ != "ptr" {
+		return
+	}
+	emitter.nativeListData[paramName] = llvmListData(emitter, list, elemLLVM)
+	emitter.nativeListLens[paramName] = llvmListLen(emitter, list)
+}
+
+func llvmNativeFastScalarListIndex(emitter *LlvmEmitter, paramName string, index *LlvmValue, elemLLVM string) *LlvmValue {
+	if emitter == nil || paramName == "" || index == nil || index.typ != "i64" || !listUsesRawDataFastPath(elemLLVM) {
+		return nil
+	}
+	data := emitter.nativeListData[paramName]
+	length := emitter.nativeListLens[paramName]
+	list := llvmIdent(emitter, paramName)
+	if data == nil || length == nil || list == nil || list.typ != "ptr" {
+		return nil
+	}
+	nonNegative := llvmCompare(emitter, "sge", index, llvmIntLiteral(0))
+	beforeEnd := llvmCompare(emitter, "slt", index, length)
+	inBounds := llvmLogicalI1(emitter, llvmLogicalInstruction("&&"), nonNegative, beforeEnd)
+	fastLabel := llvmNextLabel(emitter, "list.raw.fast")
+	slowLabel := llvmNextLabel(emitter, "list.raw.slow")
+	endLabel := llvmNextLabel(emitter, "list.raw.end")
+	emitter.body = append(emitter.body, fmt.Sprintf("  br i1 %s, label %%%s, label %%%s", inBounds.name, fastLabel, slowLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", fastLabel))
+	elemPtr := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i64 %s", elemPtr, elemLLVM, data.name, index.name))
+	fastValue := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", fastValue, elemLLVM, elemPtr))
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", slowLabel))
+	slowValue := llvmListGet(emitter, list, index, elemLLVM)
+	emitter.body = append(emitter.body, fmt.Sprintf("  br label %%%s", endLabel))
+	emitter.body = append(emitter.body, fmt.Sprintf("%s:", endLabel))
+	phi := llvmNextTemp(emitter)
+	emitter.body = append(emitter.body, fmt.Sprintf("  %s = phi %s [ %s, %%%s ], [ %s, %%%s ]", phi, elemLLVM, fastValue, fastLabel, slowValue.name, slowLabel))
+	return &LlvmValue{typ: elemLLVM, name: phi, pointer: false}
+}
+
 func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal, startStringID int) llvmNativeRenderedFunction {
 	emitter := llvmEmitter()
 	emitter.stringId = startStringID
 	llvmNativeBindGlobals(emitter, globals)
+	eligibleScalarListParams := llvmNativeEligibleScalarListParams(fn)
 	params := make([]*LlvmParam, 0, len(fn.params))
 	for _, param := range fn.params {
 		paramIRType := param.llvmType
@@ -238,6 +363,9 @@ func llvmNativeEmitFunction(fn *llvmNativeFunction, globals []*llvmNativeGlobal,
 				name:    "%" + param.name,
 				pointer: false,
 			})
+		}
+		if elemLLVM := eligibleScalarListParams[param.name]; elemLLVM != "" {
+			llvmNativePrimeScalarListParamFastPath(emitter, param.name, elemLLVM)
 		}
 	}
 	block := llvmNativeEmitBlock(emitter, fn.body)
@@ -492,6 +620,12 @@ func llvmNativeEvalMapLit(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue
 func llvmNativeEvalListIndex(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmValue {
 	if len(expr.childExprs) < 2 {
 		return llvmNativeZeroValue(expr.llvmType)
+	}
+	if base := expr.childExprs[0]; base != nil && base.kind == llvmNativeExprIdent && llvmListUsesTypedRuntime(expr.elemLLVMType) {
+		index := llvmNativeEvalExpr(emitter, expr.childExprs[1])
+		if fast := llvmNativeFastScalarListIndex(emitter, base.name, index, expr.elemLLVMType); fast != nil {
+			return fast
+		}
 	}
 	list := llvmNativeEvalExpr(emitter, expr.childExprs[0])
 	index := llvmNativeEvalExpr(emitter, expr.childExprs[1])

--- a/internal/llvmgen/runtime_ffi.go
+++ b/internal/llvmgen/runtime_ffi.go
@@ -299,6 +299,10 @@ func listRuntimeLenSymbol() string {
 	return llvmListRuntimeLenSymbol()
 }
 
+func listRuntimeDataSymbol(elemTyp string) string {
+	return "osty_rt_list_data_" + llvmListElementSuffix(elemTyp)
+}
+
 func listRuntimePopDiscardSymbol() string {
 	return "osty_rt_list_pop_discard"
 }
@@ -467,6 +471,15 @@ func mapSetKeySuffix(typ string, isString bool) string {
 
 func listUsesTypedRuntime(elemTyp string) bool {
 	return llvmListUsesTypedRuntime(elemTyp)
+}
+
+func listUsesRawDataFastPath(elemTyp string) bool {
+	switch elemTyp {
+	case "i64", "i1", "double":
+		return true
+	default:
+		return false
+	}
 }
 
 func listRuntimeSymbolSuffix(typ string) string {

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -69,12 +69,14 @@ type LlvmCString struct {
 
 // Osty: toolchain/llvmgen.osty:47:5
 type LlvmEmitter struct {
-	temp          int
-	label         int
-	stringId      int
-	body          []string
-	locals        []*LlvmBinding
-	stringGlobals []*LlvmStringGlobal
+	temp           int
+	label          int
+	stringId       int
+	body           []string
+	locals         []*LlvmBinding
+	stringGlobals  []*LlvmStringGlobal
+	nativeListData map[string]*LlvmValue
+	nativeListLens map[string]*LlvmValue
 }
 
 // Osty: toolchain/llvmgen.osty:56:5
@@ -110,7 +112,16 @@ type LlvmUnsupportedDiagnostic struct {
 
 // Osty: toolchain/llvmgen.osty:83:5
 func llvmEmitter() *LlvmEmitter {
-	return &LlvmEmitter{temp: 0, label: 0, stringId: 0, body: make([]string, 0, 1), locals: make([]*LlvmBinding, 0, 1), stringGlobals: make([]*LlvmStringGlobal, 0, 1)}
+	return &LlvmEmitter{
+		temp:           0,
+		label:          0,
+		stringId:       0,
+		body:           make([]string, 0, 1),
+		locals:         make([]*LlvmBinding, 0, 1),
+		stringGlobals:  make([]*LlvmStringGlobal, 0, 1),
+		nativeListData: map[string]*LlvmValue{},
+		nativeListLens: map[string]*LlvmValue{},
+	}
 }
 
 // Osty: toolchain/llvmgen.osty:94:5
@@ -2242,7 +2253,40 @@ func llvmListElementSuffix(typ string) string {
 
 // Osty: toolchain/llvmgen.osty:1819:5
 func llvmListRuntimeDeclarations() []string {
-	return []string{"declare ptr @osty_rt_list_new()", "declare i64 @osty_rt_list_len(ptr)", "declare void @osty_rt_list_push_i64(ptr, i64)", "declare void @osty_rt_list_push_i1(ptr, i1)", "declare void @osty_rt_list_push_f64(ptr, double)", "declare void @osty_rt_list_push_ptr(ptr, ptr)", "declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)", "declare void @osty_rt_list_insert_i64(ptr, i64, i64)", "declare void @osty_rt_list_insert_i1(ptr, i64, i1)", "declare void @osty_rt_list_insert_f64(ptr, i64, double)", "declare void @osty_rt_list_insert_ptr(ptr, i64, ptr)", "declare i64 @osty_rt_list_get_i64(ptr, i64)", "declare i1 @osty_rt_list_get_i1(ptr, i64)", "declare double @osty_rt_list_get_f64(ptr, i64)", "declare ptr @osty_rt_list_get_ptr(ptr, i64)", "declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)", "declare void @osty_rt_list_set_i64(ptr, i64, i64)", "declare void @osty_rt_list_set_i1(ptr, i64, i1)", "declare void @osty_rt_list_set_f64(ptr, i64, double)", "declare void @osty_rt_list_set_ptr(ptr, i64, ptr)", "declare ptr @osty_rt_list_sorted_i64(ptr)", "declare ptr @osty_rt_list_sorted_i1(ptr)", "declare ptr @osty_rt_list_sorted_f64(ptr)", "declare ptr @osty_rt_list_sorted_string(ptr)", "declare ptr @osty_rt_list_to_set_i64(ptr)", "declare ptr @osty_rt_list_to_set_i1(ptr)", "declare ptr @osty_rt_list_to_set_f64(ptr)", "declare ptr @osty_rt_list_to_set_ptr(ptr)", "declare ptr @osty_rt_list_to_set_string(ptr)"}
+	return []string{
+		"declare ptr @osty_rt_list_new()",
+		"declare i64 @osty_rt_list_len(ptr)",
+		"declare void @osty_rt_list_push_i64(ptr, i64)",
+		"declare void @osty_rt_list_push_i1(ptr, i1)",
+		"declare void @osty_rt_list_push_f64(ptr, double)",
+		"declare void @osty_rt_list_push_ptr(ptr, ptr)",
+		"declare void @osty_rt_list_push_bytes_v1(ptr, ptr, i64)",
+		"declare void @osty_rt_list_insert_i64(ptr, i64, i64)",
+		"declare void @osty_rt_list_insert_i1(ptr, i64, i1)",
+		"declare void @osty_rt_list_insert_f64(ptr, i64, double)",
+		"declare void @osty_rt_list_insert_ptr(ptr, i64, ptr)",
+		"declare i64 @osty_rt_list_get_i64(ptr, i64)",
+		"declare i1 @osty_rt_list_get_i1(ptr, i64)",
+		"declare double @osty_rt_list_get_f64(ptr, i64)",
+		"declare ptr @osty_rt_list_get_ptr(ptr, i64)",
+		"declare ptr @osty_rt_list_data_i64(ptr)",
+		"declare ptr @osty_rt_list_data_i1(ptr)",
+		"declare ptr @osty_rt_list_data_f64(ptr)",
+		"declare void @osty_rt_list_get_bytes_v1(ptr, i64, ptr, i64)",
+		"declare void @osty_rt_list_set_i64(ptr, i64, i64)",
+		"declare void @osty_rt_list_set_i1(ptr, i64, i1)",
+		"declare void @osty_rt_list_set_f64(ptr, i64, double)",
+		"declare void @osty_rt_list_set_ptr(ptr, i64, ptr)",
+		"declare ptr @osty_rt_list_sorted_i64(ptr)",
+		"declare ptr @osty_rt_list_sorted_i1(ptr)",
+		"declare ptr @osty_rt_list_sorted_f64(ptr)",
+		"declare ptr @osty_rt_list_sorted_string(ptr)",
+		"declare ptr @osty_rt_list_to_set_i64(ptr)",
+		"declare ptr @osty_rt_list_to_set_i1(ptr)",
+		"declare ptr @osty_rt_list_to_set_f64(ptr)",
+		"declare ptr @osty_rt_list_to_set_ptr(ptr)",
+		"declare ptr @osty_rt_list_to_set_string(ptr)",
+	}
 }
 
 // Osty: toolchain/llvmgen.osty:1856:5
@@ -2294,6 +2338,10 @@ func llvmListGet(emitter *LlvmEmitter, list *LlvmValue, index *LlvmValue, elemTy
 	symbol := llvmListRuntimeGetSymbol(llvmListElementSuffix(elemTyp))
 	_ = symbol
 	return llvmCall(emitter, elemTyp, symbol, []*LlvmValue{list, index})
+}
+
+func llvmListData(emitter *LlvmEmitter, list *LlvmValue, elemTyp string) *LlvmValue {
+	return llvmCall(emitter, "ptr", listRuntimeDataSymbol(elemTyp), []*LlvmValue{list})
 }
 
 // Osty: toolchain/llvmgen.osty:1905:5

--- a/internal/toolchain/native_llvmgen.go
+++ b/internal/toolchain/native_llvmgen.go
@@ -2,6 +2,7 @@ package toolchain
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,15 @@ var (
 	nativeLLVMGenBuildMu sync.Mutex
 	installNativeLLVMGen = buildNativeLLVMGen
 )
+
+var nativeLLVMGenSourceInputs = []string{
+	"cmd/osty-native-llvmgen",
+	"internal/backend",
+	"internal/llvmgen",
+	"internal/nativellvmgen",
+	"go.mod",
+	"go.sum",
+}
 
 func NativeLLVMGenBinaryName() string {
 	name := "osty-native-llvmgen"
@@ -35,14 +45,22 @@ func EnsureNativeLLVMGen(start string) (string, error) {
 		return "", err
 	}
 	path := ManagedNativeLLVMGenPath(root)
-	if fileExists(path) {
+	stale, err := nativeLLVMGenNeedsRebuild(path)
+	if err != nil {
+		return "", err
+	}
+	if !stale {
 		return path, nil
 	}
 
 	nativeLLVMGenBuildMu.Lock()
 	defer nativeLLVMGenBuildMu.Unlock()
 
-	if fileExists(path) {
+	stale, err = nativeLLVMGenNeedsRebuild(path)
+	if err != nil {
+		return "", err
+	}
+	if !stale {
 		return path, nil
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -52,6 +70,65 @@ func EnsureNativeLLVMGen(start string) (string, error) {
 		return "", err
 	}
 	return path, nil
+}
+
+func nativeLLVMGenNeedsRebuild(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("stat managed llvmgen: %w", err)
+	}
+	if info.IsDir() {
+		return true, nil
+	}
+	root, err := sourceRepoRootFunc()
+	if err != nil {
+		return false, err
+	}
+	managedModTime := info.ModTime()
+	for _, rel := range nativeLLVMGenSourceInputs {
+		sourcePath := filepath.Join(root, rel)
+		sourceInfo, err := os.Stat(sourcePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("stat native llvmgen source %q: %w", sourcePath, err)
+		}
+		if !sourceInfo.IsDir() {
+			if sourceInfo.ModTime().After(managedModTime) {
+				return true, nil
+			}
+			continue
+		}
+		var newer bool
+		walkErr := filepath.WalkDir(sourcePath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			fileInfo, err := d.Info()
+			if err != nil {
+				return err
+			}
+			if fileInfo.ModTime().After(managedModTime) {
+				newer = true
+				return fs.SkipAll
+			}
+			return nil
+		})
+		if walkErr != nil && walkErr != fs.SkipAll {
+			return false, fmt.Errorf("walk native llvmgen sources %q: %w", sourcePath, walkErr)
+		}
+		if newer {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func buildNativeLLVMGen(dest string) error {

--- a/internal/toolchain/native_llvmgen_test.go
+++ b/internal/toolchain/native_llvmgen_test.go
@@ -4,18 +4,22 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestEnsureNativeLLVMGenBuildsManagedArtifactOnce(t *testing.T) {
 	root := t.TempDir()
 	oldProjectRoot := managedProjectRootFunc
+	oldSourceRoot := sourceRepoRootFunc
 	oldInstaller := installNativeLLVMGen
 	t.Cleanup(func() {
 		managedProjectRootFunc = oldProjectRoot
+		sourceRepoRootFunc = oldSourceRoot
 		installNativeLLVMGen = oldInstaller
 	})
 
 	managedProjectRootFunc = func(string) (string, error) { return root, nil }
+	sourceRepoRootFunc = func() (string, error) { return t.TempDir(), nil }
 	calls := 0
 	installNativeLLVMGen = func(dest string) error {
 		calls++
@@ -52,5 +56,64 @@ func TestManagedNativeLLVMGenPathIncludesVersionedToolchainDir(t *testing.T) {
 	want := filepath.Join(root, ".osty", "toolchain", Version(), NativeLLVMGenBinaryName())
 	if got != want {
 		t.Fatalf("ManagedNativeLLVMGenPath = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureNativeLLVMGenRebuildsWhenSourcesAreNewer(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	oldProjectRoot := managedProjectRootFunc
+	oldSourceRoot := sourceRepoRootFunc
+	oldInstaller := installNativeLLVMGen
+	t.Cleanup(func() {
+		managedProjectRootFunc = oldProjectRoot
+		sourceRepoRootFunc = oldSourceRoot
+		installNativeLLVMGen = oldInstaller
+	})
+
+	managedProjectRootFunc = func(string) (string, error) { return root, nil }
+	sourceRepoRootFunc = func() (string, error) { return repo, nil }
+	for _, rel := range []string{
+		"cmd/osty-native-llvmgen/main.go",
+		"internal/backend/llvm.go",
+		"internal/llvmgen/generator.go",
+		"internal/nativellvmgen/exec.go",
+		"go.mod",
+	} {
+		path := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte("fresh source"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+	path := ManagedNativeLLVMGenPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("stale llvmgen"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	oldTime := time.Unix(1, 0)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatalf("Chtimes(%q): %v", path, err)
+	}
+
+	calls := 0
+	installNativeLLVMGen = func(dest string) error {
+		calls++
+		return os.WriteFile(dest, []byte("rebuilt llvmgen"), 0o755)
+	}
+
+	got, err := EnsureNativeLLVMGen(".")
+	if err != nil {
+		t.Fatalf("EnsureNativeLLVMGen error: %v", err)
+	}
+	if got != path {
+		t.Fatalf("path = %q, want %q", got, path)
+	}
+	if calls != 1 {
+		t.Fatalf("installer calls = %d, want 1", calls)
 	}
 }


### PR DESCRIPTION
## Summary
- add a raw-buffer fast path for scalar `List<Int>` / `List<Bool>` / `List<Float>` indexing in both the native-owned LLVM path and MIR path
- expose `osty_rt_list_data_*` runtime helpers so hot loops can reuse list data/len snapshots instead of routing every access through `osty_rt_list_get_*`
- rebuild managed `osty-native-llvmgen` automatically when backend sources are newer so local runs pick up the latest codegen changes

## Validation
- `go test -count=1 -vet=off ./internal/toolchain -run 'TestEnsureNativeLLVMGenBuildsManagedArtifactOnce|TestEnsureNativeLLVMGenRebuildsWhenSourcesAreNewer'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestTryEmitNativeOwnedLLVMIRTextCoversListIndex|TestTryEmitNativeOwnedLLVMIRTextVectorizedScalarListParamUsesRawDataFastPath'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateFromMIRVectorizedScalarListParamUsesRawDataFastPath|TestGenerateFromMIRListIndexRead|TestGenerateFromMIRListIndexReadPtrElem'`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `just build`

## Measurement
- `simd_stats` direct `osty-vs-go`: Osty `~1.06ms/op` on latest remeasure (`go` median still noisy)
- direct LLVM IR now shows cached `osty_rt_list_data_i64` entry calls plus `getelementptr inbounds i64` loads in `analyzeSimdStats`
- direct Osty benches after the change: `lane_route ~462us/op`, `simd_stats ~1.44ms/op`, `record_pipeline ~285us/op`