### PR TITLE
fix: incremental GC finish path now runs Phase D compaction

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -4478,6 +4479,104 @@ int main(void) {
 	}
 	if got, want := string(runOutput), "1 1 1 1\n1 1\n1 1\n"; got != want {
 		t.Fatalf("phase-D global-root harness stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBundledRuntimeIncrementalFinishCompactsPhaseD verifies that the
+// incremental major path runs Phase D compaction on finish — before
+// this landed, `osty.gc.collect_incremental_finish` only swept, so
+// `OSTY_GC_INCREMENTAL=1` callers silently skipped evacuation and
+// forwarding-table rebuild. The harness drives start → step → finish
+// manually, then checks the stack root was remapped, `load_v1` follows
+// the forwarding of the pre-compact payload, and the compaction
+// counter incremented exactly once.
+func TestBundledRuntimeIncrementalFinishCompactsPhaseD(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_phase_d_incremental_finish_harness.c")
+	binaryName := "runtime_gc_phase_d_incremental_finish_harness"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(dir, binaryName)
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+void *osty_gc_load_v1(void *value) __asm__(OSTY_GC_SYMBOL("osty.gc.load_v1"));
+
+void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+bool osty_gc_collect_incremental_step(int64_t budget);
+void osty_gc_collect_incremental_finish_with_stack_roots(void *const *root_slots, int64_t root_slot_count);
+
+int64_t osty_gc_debug_stable_id(void *payload);
+void *osty_gc_debug_payload_for_stable_id(int64_t stable_id);
+int64_t osty_gc_debug_compaction_count_total(void);
+int64_t osty_gc_debug_forwarded_objects_last(void);
+int64_t osty_gc_debug_forwarding_count(void);
+int64_t osty_gc_debug_load_forwarded_count(void);
+void *osty_rt_list_new(void);
+void osty_rt_list_push_ptr(void *list, void *value);
+void *osty_rt_list_get_ptr(void *list, int64_t index);
+
+int main(void) {
+    void *list = osty_rt_list_new();
+    void *saved_list = list;
+    void *child = osty_gc_alloc_v1(7, 32, "child");
+    void *saved_child = child;
+    int64_t list_id = osty_gc_debug_stable_id(list);
+    int64_t child_id = osty_gc_debug_stable_id(child);
+    osty_rt_list_push_ptr(list, child);
+
+    void *root = list;
+    void *root_slots[1] = { &root };
+
+    osty_gc_collect_incremental_start_with_stack_roots(root_slots, 1);
+    while (osty_gc_collect_incremental_step(100)) {}
+    osty_gc_collect_incremental_finish_with_stack_roots(root_slots, 1);
+
+    printf("%d %d %d\n",
+        root != saved_list,
+        osty_gc_load_v1(saved_list) == root,
+        osty_gc_debug_stable_id(root) == list_id);
+    printf("%d %d %d\n",
+        osty_rt_list_get_ptr(saved_list, 0) == osty_gc_load_v1(saved_child),
+        osty_gc_debug_stable_id(osty_rt_list_get_ptr(saved_list, 0)) == child_id,
+        osty_gc_debug_payload_for_stable_id(child_id) == osty_gc_load_v1(saved_child));
+    printf("%d %d %d\n",
+        osty_gc_debug_compaction_count_total() == 1,
+        osty_gc_debug_forwarded_objects_last() == 2,
+        osty_gc_debug_forwarding_count() == 2);
+    printf("%d\n", osty_gc_debug_load_forwarded_count() >= 2);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	got := strings.ReplaceAll(string(runOutput), "\r\n", "\n")
+	if want := "1 1 1\n1 1 1\n1 1 1\n1\n"; got != want {
+		t.Fatalf("phase-D incremental-finish harness stdout = %q, want %q", got, want)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -3271,15 +3271,30 @@ static int64_t osty_gc_compact_minor_with_stack_roots(
     return moved;
 }
 
-/* Phase A2 depth: monotonic timing helper. Falls back to 0 on systems
- * where `clock_gettime` is unavailable — callers must treat zero as
- * "no measurement" (still strictly monotonic inside a single run). */
+/* Phase A2 depth: monotonic timing helper. Uses the same split as
+ * `osty_rt_monotonic_ns` — Win32 `QueryPerformanceCounter` vs. POSIX
+ * `clock_gettime(CLOCK_MONOTONIC)` — so the runtime compiles cleanly
+ * on both platforms. Falls back to 0 when the underlying source
+ * returns an error; callers must treat zero as "no measurement"
+ * (still strictly monotonic inside a single run). */
 static int64_t osty_gc_now_nanos(void) {
+#if defined(_WIN32)
+    LARGE_INTEGER freq;
+    LARGE_INTEGER counter;
+    if (!QueryPerformanceFrequency(&freq) || freq.QuadPart == 0) {
+        return 0;
+    }
+    if (!QueryPerformanceCounter(&counter)) {
+        return 0;
+    }
+    return (int64_t)((counter.QuadPart * 1000000000LL) / freq.QuadPart);
+#else
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
         return 0;
     }
     return (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
+#endif
 }
 
 /* Phase B remembered set maintenance after a minor collection.
@@ -3623,6 +3638,14 @@ static void osty_gc_auto_drive_incremental(void *const *root_slots, int64_t root
             /* Cycle done — finish it inline. */
             osty_gc_state = OSTY_GC_STATE_SWEEPING;
             osty_gc_incremental_sweep();
+            /* Phase D: after sweep, evacuate movable survivors and
+             * remap stack/global/object slots so an incremental major
+             * delivers the same forwarding semantics as the STW major
+             * path at line 3388. Without this, OSTY_GC_INCREMENTAL=1
+             * silently bypasses Phase D compaction — a regression the
+             * doc-claim ✅ did not actually deliver. */
+            (void)osty_gc_compact_major_with_stack_roots(
+                root_slots, root_slot_count);
             osty_gc_collection_count += 1;
             osty_gc_major_count += 1;
             osty_gc_allocated_since_collect = 0;
@@ -3766,19 +3789,36 @@ bool osty_gc_collect_incremental_step(int64_t budget) {
     return has_more;
 }
 
-void osty_gc_collect_incremental_finish(void) {
-    int64_t t_start = osty_gc_now_nanos();
-    osty_gc_acquire();
-    if (osty_gc_state == OSTY_GC_STATE_IDLE) {
-        osty_gc_release();
-        return;
-    }
+/* Shared finish body for the incremental major path. Drains any leftover
+ * greys, runs the sweep, and (when `compact` is true) evacuates movable
+ * survivors with the caller-supplied stack roots for remap. Runs under
+ * `osty_gc_lock`.
+ *
+ * Why the `compact` flag exists: the concurrent scheduler drives a
+ * finish without exposing the mutators' frame descriptors (they are
+ * parked at safepoints across many threads). Remapping global / object
+ * slots without also remapping those stack frames would leave dangling
+ * pointers on every parked thread's stack. Compaction is therefore only
+ * safe when the caller knows every live managed stack slot — today that
+ * means the single-threaded test / LLVM-emitted path via
+ * `osty_gc_collect_incremental_finish_with_stack_roots`. */
+static void osty_gc_collect_incremental_finish_locked(
+    void *const *root_slots, int64_t root_slot_count, bool compact) {
     /* Drain any remaining greys so the sweep sees a consistent
      * colouring. The incremental barrier (SATB pre_write) could have
      * dropped new greys on us between the last step and this call. */
     (void)osty_gc_mark_drain_budget(0);
     osty_gc_state = OSTY_GC_STATE_SWEEPING;
     osty_gc_incremental_sweep();
+    if (compact) {
+        /* Phase D: incremental major matches STW major — evacuate
+         * movable survivors and remap every slot the STW path would
+         * remap. Safety: SWEEPING state plus the lock, no mutator
+         * barrier mid-flight, compact_major never re-enters the
+         * mark queue. */
+        (void)osty_gc_compact_major_with_stack_roots(
+            root_slots, root_slot_count);
+    }
     osty_gc_collection_count += 1;
     osty_gc_major_count += 1;
     osty_gc_allocated_since_collect = 0;
@@ -3787,6 +3827,48 @@ void osty_gc_collect_incremental_finish(void) {
     osty_gc_collection_requested_major = false;
     osty_gc_barrier_logs_clear();
     osty_gc_state = OSTY_GC_STATE_IDLE;
+}
+
+void osty_gc_collect_incremental_finish(void) {
+    int64_t t_start = osty_gc_now_nanos();
+    osty_gc_acquire();
+    if (osty_gc_state == OSTY_GC_STATE_IDLE) {
+        osty_gc_release();
+        return;
+    }
+    /* No-stack-roots path: skip compaction (see rationale in
+     * `osty_gc_collect_incremental_finish_locked`). Callers that own
+     * their frame descriptors should prefer the `_with_stack_roots`
+     * variant so Phase D compaction runs. */
+    osty_gc_collect_incremental_finish_locked(NULL, 0, false);
+    osty_gc_release();
+
+    int64_t t_end = osty_gc_now_nanos();
+    if (t_start != 0 && t_end >= t_start) {
+        int64_t elapsed = t_end - t_start;
+        osty_gc_collection_nanos_last = elapsed;
+        osty_gc_collection_nanos_total += elapsed;
+        osty_gc_major_nanos_total += elapsed;
+        if (elapsed > osty_gc_collection_nanos_max) {
+            osty_gc_collection_nanos_max = elapsed;
+        }
+    }
+}
+
+/* Phase D addition: callers that have live managed stack slots at the
+ * finish point can drive an incremental major that also compacts and
+ * remaps those slots, matching `osty_gc_collect_major_with_stack_roots`.
+ * Symmetrical to `osty_gc_collect_incremental_start_with_stack_roots`. */
+void osty_gc_collect_incremental_finish_with_stack_roots(
+    void *const *root_slots, int64_t root_slot_count) {
+    int64_t t_start = osty_gc_now_nanos();
+    osty_gc_acquire();
+    if (osty_gc_state == OSTY_GC_STATE_IDLE) {
+        osty_gc_release();
+        return;
+    }
+    osty_gc_collect_incremental_finish_locked(
+        root_slots, root_slot_count, true);
     osty_gc_release();
 
     int64_t t_end = osty_gc_now_nanos();


### PR DESCRIPTION
## Summary

- `RUNTIME_GC_DELTA.md` marks Phase D (compaction + forwarding) ✅, but the incremental finish path was only sweeping. `OSTY_GC_INCREMENTAL=1` silently skipped evacuation and the forwarding-table rebuild that the STW major path produces — same sweep, no remap.
- This PR closes that real-vs-declared gap by wiring Phase D compaction into the two incremental finish sites, adds a focused test that asserts it, and fixes an incidental Windows/MSVC build break (`clock_gettime` is POSIX-only).

## What changed

- **`osty_gc_collect_incremental_finish_with_stack_roots(...)`** — new entry point for callers that own their frame descriptors (tests, LLVM-emitted code). Runs drain → sweep → `osty_gc_compact_major_with_stack_roots`.
- **Zero-arg `osty_gc_collect_incremental_finish(void)`** — deliberately kept non-compacting. The concurrent scheduler invokes it without exposing parked mutator stacks; remapping globals/objects without those stacks would leave stale pointers on every parked thread. That path should migrate to the `_with_stack_roots` variant when stackmaps are published per-thread.
- **Auto-dispatcher inline finish** — already holds the safepoint's `root_slots`, so it now forwards them to `osty_gc_compact_major_with_stack_roots` after the inline sweep. `OSTY_GC_INCREMENTAL=1` users finally get evacuation.
- **`osty_gc_collect_incremental_finish_locked(root_slots, count, compact)`** — shared body so both entries reuse the drain/sweep/reset flow.
- **`osty_gc_now_nanos`** — Win32 `QueryPerformanceCounter` branch added. Previously the unconditional `clock_gettime(CLOCK_MONOTONIC, …)` failed to compile under MSVC UCRT.

## Why this way

Splitting the public API into a no-stack-roots form (old behavior, preserved for the concurrent scheduler) and a `_with_stack_roots` form (new Phase D compaction) is the minimal safe change: compaction needs every live managed stack slot or it produces dangling pointers in frames it didn't see. Making the zero-arg form auto-compact would have broken the concurrent scheduler at `osty_runtime.c:9997`.

## Test plan

- [x] `go test ./internal/backend/ -run TestBundledRuntimeIncrementalFinishCompactsPhaseD` — new test drives start → step → `finish_with_stack_roots` and asserts `compaction_count_total == 1`, `forwarded_objects_last == 2`, stack root remapped, `load_v1` canonicalizes the old payload, `load_forwarded_count >= 2`. Passes.
- [x] `go build ./internal/backend/...` and `go vet ./internal/backend/...` clean.
- [x] `go test ./internal/backend/ -short` — only pre-existing failures (`TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered`, `TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered`) confirmed via `git stash` baseline. No new regressions.
- [x] Windows clang build of the runtime now compiles past `osty_gc_now_nanos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)