### PR TITLE
refactor: astbridge-free resolve path for osty resolve (FILE + DIR)

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -493,37 +493,52 @@ func main() {
 			os.Exit(1)
 		}
 	case "resolve":
-		parsed := parser.ParseDetailed(src)
-		file, parseDiags := parsed.File, parsed.Diagnostics
-		var res *resolve.Result
-		all := append([]*diag.Diagnostic{}, parseDiags...)
-		if nativeDiags, err := nativeResolveSingleFileDiagnostics(path, src, file); err == nil {
-			all = append(all, nativeDiags...)
-		} else {
-			res = resolveFile(file)
-			all = append(all, res.Diags...)
+		// Happy path: parse into a FrontendRun and drive resolve
+		// entirely through the self-host arena. The *ast.File lowering
+		// (and therefore the astbridge adapter) is only triggered when
+		// a fallback path needs it — --show-scopes still walks the Go
+		// resolver's Scope tree, so it lazily lowers via run.File()
+		// when asked.
+		run := parser.ParseRun(src)
+		parseDiags := run.Diagnostics()
+		var (
+			res  *resolve.Result
+			file *ast.File
+		)
+		ensureLoweredFile := func() *ast.File {
+			if file == nil {
+				file = run.File()
+			}
+			return file
 		}
+		ensureGoResolve := func() *resolve.Result {
+			if res == nil {
+				res = resolveFile(ensureLoweredFile())
+			}
+			return res
+		}
+		all := append([]*diag.Diagnostic{}, parseDiags...)
+		nativeDiags := nativeResolveFromRunDiagnostics(run, src, path)
+		all = append(all, nativeDiags...)
 		printDiags(formatter, all, flags)
-		if rows, err := nativeResolveSingleFileRows(path, src, file); err == nil && len(rows) > 0 {
+		if rows := nativeResolveFromRunRows(run, src, path); len(rows) > 0 {
 			printNativeResolutionRows(rows)
 		} else {
-			if res == nil {
-				res = resolveFile(file)
-			}
-			printResolution(file, res)
+			// Native pass produced no rows — fall back to the Go
+			// resolver for printResolution so empty-source or
+			// resolver-disagreement cases stay visible.
+			printResolution(ensureLoweredFile(), ensureGoResolve())
 		}
 		if flags.showScopes {
-			if res == nil {
-				res = resolveFile(file)
-			}
+			r := ensureGoResolve()
 			// File scope's parent is the package scope (a child of the
 			// prelude). Rooting the dump at the package scope hides
 			// noisy prelude builtins while still showing every
 			// user-declared symbol.
-			if pkgScope := res.FileScope.Parent(); pkgScope != nil {
+			if pkgScope := r.FileScope.Parent(); pkgScope != nil {
 				printScopeTree(pkgScope)
 			} else {
-				printScopeTree(res.FileScope)
+				printScopeTree(r.FileScope)
 			}
 		}
 		if hasError(all) {
@@ -902,27 +917,43 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 
 // runResolvePackage is runCheckPackage plus a resolution dump per file.
 func runResolvePackage(dir string, flags cliFlags) {
-	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("resolve"), os.Stderr, flags))
+	// Happy path: LoadPackageForNative produces selfhost FrontendRuns
+	// per file and leaves pf.File nil, so the astbridge-based *ast.File
+	// lowering is not triggered unless a fallback explicitly needs it
+	// (--show-scopes, or the Go-native resolver printing branch). The
+	// Go-native fallback is kept so that printResolutionRefs /
+	// printScopeTree still work when callers rely on them — each
+	// EnsureFile*() call materializes the *ast.File lazily and caches
+	// it for subsequent passes.
+	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("resolve"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
 		os.Exit(1)
 	}
 	var res *resolve.PackageResult
+	ensureGoResolve := func() *resolve.PackageResult {
+		if res != nil {
+			return res
+		}
+		// Go-native resolver reads pf.File directly; materialize
+		// before calling so Run-only loaded files are lowered once.
+		pkg.EnsureFiles()
+		res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
+		return res
+	}
 	diags := []*diag.Diagnostic(nil)
 	if nativeDiags, err := nativeResolvePackageDiagnostics(pkg); err == nil {
 		diags = append(packageParseDiags(pkg), nativeDiags...)
 	} else {
-		res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
-		diags = res.Diags
+		r := ensureGoResolve()
+		diags = r.Diags
 	}
 	printPackageDiags(pkg, diags, flags)
 	if nativeRowsUsed := false; true {
 		for _, f := range pkg.Files {
 			rows, err := nativeResolvePackageRows(pkg, f.Path)
 			if err != nil || len(rows) == 0 {
-				if res == nil {
-					res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
-				}
+				ensureGoResolve()
 				if len(f.Refs) == 0 {
 					continue
 				}
@@ -945,9 +976,7 @@ func runResolvePackage(dir string, flags cliFlags) {
 		}
 	}
 	if flags.showScopes {
-		if res == nil {
-			res = resolve.ResolvePackage(pkg, resolve.NewPrelude())
-		}
+		ensureGoResolve()
 		// Package scope's children are the file scopes, which in turn
 		// host fn / block / closure / match-arm scopes — the full
 		// nested tree for every file in the package.

--- a/cmd/osty/resolve_native.go
+++ b/cmd/osty/resolve_native.go
@@ -2,28 +2,16 @@ package main
 
 import (
 	"fmt"
+	"sort"
 
-	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/selfhost"
+	"github.com/osty/osty/internal/token"
 )
-
-func nativeResolveSingleFileRows(path string, src []byte, file *ast.File) ([]resolve.NativeResolutionRow, error) {
-	if file == nil {
-		return nil, fmt.Errorf("native resolve: missing parsed file")
-	}
-	return resolve.NativeResolutionRowsForSource(path, src, file)
-}
 
 func nativeResolvePackageRows(pkg *resolve.Package, path string) ([]resolve.NativeResolutionRow, error) {
 	return resolve.NativeResolutionRows(pkg, path)
-}
-
-func nativeResolveSingleFileDiagnostics(path string, src []byte, file *ast.File) ([]*diag.Diagnostic, error) {
-	if file == nil {
-		return nil, fmt.Errorf("native resolve: missing parsed file")
-	}
-	return resolve.NativeDiagnosticsForSource(path, src, file)
 }
 
 func nativeResolvePackageDiagnostics(pkg *resolve.Package) ([]*diag.Diagnostic, error) {
@@ -34,4 +22,148 @@ func printNativeResolutionRows(rows []resolve.NativeResolutionRow) {
 	for _, row := range rows {
 		fmt.Printf("%d:%d\t%-20s\t%-12s\t->%s\n", row.Line, row.Column, row.Name, row.Kind, row.Def)
 	}
+}
+
+// nativeResolveFromRunRows is the astbridge-free single-file resolve
+// row builder. Given a parsed FrontendRun and the raw source, it runs
+// the native resolver directly on the parser arena (no *ast.File
+// round-trip) and formats the result into the same
+// resolve.NativeResolutionRow shape printNativeResolutionRows expects.
+func nativeResolveFromRunRows(run *selfhost.FrontendRun, src []byte, path string) []resolve.NativeResolutionRow {
+	if run == nil {
+		return nil
+	}
+	resolved := selfhost.ResolveStructuredFromRunForPath(run, path)
+	lineStarts := computeLineStartsBytes(src)
+	kindByNode := map[int]string{}
+	for _, sym := range resolved.Symbols {
+		kindByNode[sym.Node] = resolveSymbolKindLabel(sym.Kind)
+	}
+	rows := make([]resolve.NativeResolutionRow, 0, len(resolved.Refs))
+	for _, ref := range resolved.Refs {
+		if ref.File != path {
+			continue
+		}
+		line, col, ok := offsetToLineCol(lineStarts, src, ref.Start)
+		if !ok {
+			continue
+		}
+		def := "<builtin>"
+		if ref.TargetFile != "" {
+			if dl, dc, dok := offsetToLineCol(lineStarts, src, ref.TargetStart); dok {
+				def = fmt.Sprintf("%d:%d", dl, dc)
+			}
+		}
+		kind := kindByNode[ref.TargetNode]
+		if kind == "" {
+			kind = "builtin"
+		}
+		rows = append(rows, resolve.NativeResolutionRow{
+			Line:   line,
+			Column: col,
+			Name:   ref.Name,
+			Kind:   kind,
+			Def:    def,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Line != rows[j].Line {
+			return rows[i].Line < rows[j].Line
+		}
+		if rows[i].Column != rows[j].Column {
+			return rows[i].Column < rows[j].Column
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	return rows
+}
+
+// nativeResolveFromRunDiagnostics converts the native resolver's
+// structured diagnostics into *diag.Diagnostic, preserving the code +
+// primary span + hint shape callers expect. Pair with ParseRun to keep
+// the resolve pass free of the astbridge *ast.File lowering.
+func nativeResolveFromRunDiagnostics(run *selfhost.FrontendRun, src []byte, path string) []*diag.Diagnostic {
+	if run == nil {
+		return nil
+	}
+	resolved := selfhost.ResolveStructuredFromRunForPath(run, path)
+	lineStarts := computeLineStartsBytes(src)
+	out := make([]*diag.Diagnostic, 0, len(resolved.Diagnostics))
+	for _, record := range resolved.Diagnostics {
+		builder := diag.New(diag.Error, record.Message).Code(record.Code).File(record.File)
+		if span, ok := offsetsToSpan(lineStarts, src, record.Start, record.End); ok {
+			builder.Primary(span, "")
+		}
+		if record.Hint != "" {
+			builder.Hint(record.Hint)
+		}
+		out = append(out, builder.Build())
+	}
+	return out
+}
+
+func computeLineStartsBytes(src []byte) []int {
+	starts := []int{0}
+	for i, b := range src {
+		if b == '\n' {
+			starts = append(starts, i+1)
+		}
+	}
+	return starts
+}
+
+func offsetToLineCol(lineStarts []int, src []byte, offset int) (int, int, bool) {
+	if offset < 0 || offset > len(src) {
+		return 0, 0, false
+	}
+	idx := sort.SearchInts(lineStarts, offset+1) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	line := idx + 1
+	col := offset - lineStarts[idx] + 1
+	return line, col, true
+}
+
+func offsetsToSpan(lineStarts []int, src []byte, start, end int) (diag.Span, bool) {
+	if end < start {
+		end = start
+	}
+	sl, sc, ok := offsetToLineCol(lineStarts, src, start)
+	if !ok {
+		return diag.Span{}, false
+	}
+	el, ec, ok := offsetToLineCol(lineStarts, src, end)
+	if !ok {
+		el, ec = sl, sc
+	}
+	return diag.Span{
+		Start: token.Pos{Offset: start, Line: sl, Column: sc},
+		End:   token.Pos{Offset: end, Line: el, Column: ec},
+	}, true
+}
+
+// resolveSymbolKindLabel mirrors the package-internal
+// resolve.nativeResolveKindLabel so cmd/osty can render the same row
+// Kind strings as the existing Package-path without needing a new
+// exported helper. Keep in sync with
+// internal/resolve/native_adapter.go:nativeResolveKindLabel.
+func resolveSymbolKindLabel(kind string) string {
+	switch kind {
+	case "fn":
+		return "function"
+	case "value":
+		return "binding"
+	case "type":
+		return "type"
+	case "variant":
+		return "variant"
+	case "package":
+		return "package"
+	case "generic":
+		return "type parameter"
+	case "":
+		return "builtin"
+	}
+	return kind
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5,6 +5,7 @@ package parser
 import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // Error is retained as an alias for back-compat. New code should use
@@ -58,4 +59,15 @@ func ParseCanonical(src []byte) (*ast.File, []*diag.Diagnostic) {
 func ParseDiagnostics(src []byte) (*ast.File, []*diag.Diagnostic) {
 	result := ParseDetailed(src)
 	return result.File, result.Diagnostics
+}
+
+// ParseRun lexes and parses src and returns the underlying selfhost
+// FrontendRun without lowering the result to the *ast.File semantic AST.
+// Callers that only need the Osty-native parser arena (native resolver,
+// native checker, native llvmgen) should use this entry point so the
+// astbridge-based *ast.File lowering is not triggered. Calling
+// run.File() afterwards remains valid if the *ast.File is eventually
+// needed — it is computed lazily on first access.
+func ParseRun(src []byte) *selfhost.FrontendRun {
+	return selfhost.Run(src)
 }

--- a/internal/resolve/loader.go
+++ b/internal/resolve/loader.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 
 	"github.com/osty/osty/internal/canonical"
+	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/selfhost"
 )
 
 // SourceTransform lets callers rewrite raw source bytes before the
@@ -108,6 +110,68 @@ func loadPackagePaths(paths []string, dir, name string, transform SourceTransfor
 			File:            parsed.File,
 			ParseDiags:      parsed.Diagnostics,
 			ParseProvenance: parsed.Provenance,
+		})
+	}
+	return pkg, nil
+}
+
+// LoadPackageForNative is the astbridge-free sibling of LoadPackage: it
+// discovers every `.osty` file under dir (non-recursive, test files
+// excluded) and parses each into a selfhost FrontendRun, but does NOT
+// lower the arena to *ast.File and does NOT compute CanonicalSource.
+// Use this from call sites that intend to drive resolve / check /
+// llvmgen through the native Osty toolchain (toolchain/resolve.osty
+// etc.) and only need *ast.File as a lazy fallback — pf.EnsureFile()
+// on demand triggers exactly one astbridge lowering per file.
+func LoadPackageForNative(dir string) (*Package, error) {
+	return LoadPackageForNativeWithTransform(dir, nil)
+}
+
+// LoadPackageForNativeWithTransform is LoadPackageForNative plus an
+// optional pre-parse source transform.
+func LoadPackageForNativeWithTransform(dir string, transform SourceTransform) (*Package, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", abs, err)
+	}
+	var paths []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".osty") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.osty") {
+			continue
+		}
+		paths = append(paths, filepath.Join(abs, name))
+	}
+	sort.Strings(paths)
+	return loadPackageNativePaths(paths, abs, filepath.Base(abs), transform)
+}
+
+func loadPackageNativePaths(paths []string, dir, name string, transform SourceTransform) (*Package, error) {
+	pkg := &Package{Dir: dir, Name: name}
+	for _, p := range paths {
+		src, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		if transform != nil {
+			src = transform(p, src)
+		}
+		run := selfhost.Run(src)
+		pkg.Files = append(pkg.Files, &PackageFile{
+			Path:       p,
+			Source:     src,
+			Run:        run,
+			ParseDiags: append([]*diag.Diagnostic(nil), run.Diagnostics()...),
 		})
 	}
 	return pkg, nil

--- a/internal/resolve/native_adapter.go
+++ b/internal/resolve/native_adapter.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/canonical"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/selfhost"
@@ -68,40 +67,6 @@ func NativeDiagnostics(pkg *Package) ([]*diag.Diagnostic, error) {
 	return nativeResolveDiagnosticsFromArtifacts(result, files), nil
 }
 
-// NativeResolutionRowsForSource wraps one parsed source file in a synthetic
-// package and returns the selfhost resolve rows for that file.
-func NativeResolutionRowsForSource(path string, src []byte, file *ast.File) ([]NativeResolutionRow, error) {
-	if file == nil {
-		return nil, fmt.Errorf("native resolve: missing parsed file")
-	}
-	pkg := &Package{
-		Name: "<file>",
-		Files: []*PackageFile{{
-			Path:   path,
-			Source: append([]byte(nil), src...),
-			File:   file,
-		}},
-	}
-	return NativeResolutionRows(pkg, path)
-}
-
-// NativeDiagnosticsForSource wraps one parsed source file in a synthetic
-// package and returns the selfhost resolve diagnostics for that file.
-func NativeDiagnosticsForSource(path string, src []byte, file *ast.File) ([]*diag.Diagnostic, error) {
-	if file == nil {
-		return nil, fmt.Errorf("native resolve: missing parsed file")
-	}
-	pkg := &Package{
-		Name: "<file>",
-		Files: []*PackageFile{{
-			Path:   path,
-			Source: append([]byte(nil), src...),
-			File:   file,
-		}},
-	}
-	return NativeDiagnostics(pkg)
-}
-
 func nativeResolveArtifacts(pkg *Package) (selfhost.ResolveResult, []nativeResolveFileInfo, error) {
 	if pkg == nil {
 		return selfhost.ResolveResult{}, nil, fmt.Errorf("native resolve: nil package")
@@ -140,9 +105,12 @@ func nativeResolveInput(pkg *Package) (selfhost.PackageResolveInput, []nativeRes
 		if len(src) == 0 {
 			continue
 		}
-		if pf.File == nil {
-			return selfhost.PackageResolveInput{}, nil, fmt.Errorf("native resolve: package file %s missing AST", pf.Path)
-		}
+		// File is required by the Direct lowering path in
+		// selfhostBuildPackageAstDirect. When pf was loaded via
+		// LoadPackageForNative it is nil; passing nil here makes
+		// ResolvePackageStructured take the non-Direct path, which
+		// re-parses Source via the self-host lexer + parser (no
+		// astbridge).
 		input.Files = append(input.Files, selfhost.PackageResolveFile{
 			Source:    append([]byte(nil), src...),
 			File:      pf.File,
@@ -174,7 +142,13 @@ func nativeResolveSourceForFile(pf *PackageFile) ([]byte, error) {
 		return nil, nil
 	}
 	if pf.File == nil {
-		return nil, fmt.Errorf("native resolve: package file %s missing AST", pf.Path)
+		// LoadPackageForNative-loaded files carry raw Source only
+		// (no canonicalization). parser.osty accepts the same
+		// grammar as the canonical form, so the native resolver's
+		// re-parse in selfhostBuildPackageAst handles the input
+		// identically. Return a defensive copy so downstream
+		// mutation of input.Files does not corrupt pf.Source.
+		return append([]byte(nil), pf.Source...), nil
 	}
 	src, _ := canonical.SourceWithMap(pf.Source, pf.File)
 	return src, nil

--- a/internal/resolve/native_adapter_test.go
+++ b/internal/resolve/native_adapter_test.go
@@ -4,7 +4,87 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
 )
+
+// TestLoadPackageForNativeMultiFileIsAstbridgeFree pins the PR6 wedge:
+// running the package resolve path via LoadPackageForNative +
+// NativeResolutionRows / NativeDiagnostics over a multi-file package
+// must not trigger the astbridge-based *ast.File lowering. The counter
+// stays at zero throughout; calling EnsureFiles afterwards bumps it by
+// exactly one per file, proving the lazy lowering is wired correctly
+// for the fallback paths (--show-scopes, printResolutionRefs).
+func TestLoadPackageForNativeMultiFileIsAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	selfhost.ResetAstbridgeLowerCount()
+
+	pkg, err := LoadPackageForNative(dir)
+	if err != nil {
+		t.Fatalf("LoadPackageForNative: %v", err)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after LoadPackageForNative: AstbridgeLowerCount = %d, want 0", got)
+	}
+	for _, pf := range pkg.Files {
+		if pf.File != nil {
+			t.Fatalf("LoadPackageForNative populated pf.File for %s (expected nil until EnsureFile)", pf.Path)
+		}
+		if pf.Run == nil {
+			t.Fatalf("LoadPackageForNative left pf.Run nil for %s", pf.Path)
+		}
+	}
+
+	diags, err := NativeDiagnostics(pkg)
+	if err != nil {
+		t.Fatalf("NativeDiagnostics: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("clean package produced diagnostics: %#v", diags)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after NativeDiagnostics: AstbridgeLowerCount = %d, want 0", got)
+	}
+
+	rows, err := NativeResolutionRows(pkg, bPath)
+	if err != nil {
+		t.Fatalf("NativeResolutionRows: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("expected helper ref rows from b.osty, got none")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("after NativeResolutionRows: AstbridgeLowerCount = %d, want 0", got)
+	}
+
+	pkg.EnsureFiles()
+	if got := selfhost.AstbridgeLowerCount(); got != int64(len(pkg.Files)) {
+		t.Fatalf("after EnsureFiles: AstbridgeLowerCount = %d, want %d (one lowering per file)", got, len(pkg.Files))
+	}
+	for _, pf := range pkg.Files {
+		if pf.File == nil {
+			t.Fatalf("EnsureFiles did not materialize pf.File for %s", pf.Path)
+		}
+	}
+
+	pkg.EnsureFiles()
+	if got := selfhost.AstbridgeLowerCount(); got != int64(len(pkg.Files)) {
+		t.Fatalf("second EnsureFiles re-lowered: AstbridgeLowerCount = %d, want %d (cached)", got, len(pkg.Files))
+	}
+}
 
 func TestNativeResolutionRowsCrossFile(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/resolve/package.go
+++ b/internal/resolve/package.go
@@ -4,6 +4,7 @@ import (
 	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/parser"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/sourcemap"
 )
 
@@ -60,9 +61,22 @@ type PackageFile struct {
 	// spans carried by the parsed AST. Nil when the canonical source is a direct
 	// passthrough or no map was produced.
 	CanonicalMap *sourcemap.Map
-	// File is the parsed AST. Never nil, even when Parse reported errors;
-	// best-effort partial trees support multi-error reporting.
+	// File is the parsed AST. Normally non-nil, even when Parse reported
+	// errors (best-effort partial trees support multi-error reporting).
+	// Packages loaded via LoadPackageForNative defer File materialization
+	// — they populate Run instead and leave this nil until EnsureFile is
+	// called. All Go-native passes (resolve.ResolvePackage,
+	// check.File, lint, bootstrap/gen) still require File, so callers
+	// that may hit those paths should EnsureFile first.
 	File *ast.File
+	// Run is the self-host FrontendRun that produced this file's
+	// arena. Populated by LoadPackageForNative (and by
+	// LoadPackageWithTransform when File is also eagerly computed) so
+	// the native resolver / checker / llvmgen can consume the arena
+	// directly, skipping the astbridge *ast.File round-trip. Nil on
+	// synthetic packages built from already-parsed ASTs that were not
+	// produced by the self-host front end.
+	Run *selfhost.FrontendRun
 	// ParseDiags are diagnostics produced during lex + parse of this
 	// file. They are merged with resolver diagnostics by the package
 	// walker.
@@ -90,6 +104,36 @@ func (pf *PackageFile) CheckerSource() []byte {
 		return pf.CanonicalSource
 	}
 	return pf.Source
+}
+
+// EnsureFile materializes the *ast.File for this PackageFile. Packages
+// loaded via LoadPackageForNative populate Run but leave File nil to
+// skip the astbridge-based lowering; calling EnsureFile triggers that
+// lowering on demand (exactly one astLowerPublicFile per file, cached
+// thereafter). Returns the File, or nil if neither File nor Run is set.
+func (pf *PackageFile) EnsureFile() *ast.File {
+	if pf == nil {
+		return nil
+	}
+	if pf.File != nil {
+		return pf.File
+	}
+	if pf.Run != nil {
+		pf.File = pf.Run.File()
+	}
+	return pf.File
+}
+
+// EnsureFiles forces File materialization on every PackageFile in pkg.
+// Call this before any code path that reads pf.File directly (the
+// Go-native resolver, checker, linter, bootstrap/gen).
+func (pkg *Package) EnsureFiles() {
+	if pkg == nil {
+		return
+	}
+	for _, pf := range pkg.Files {
+		pf.EnsureFile()
+	}
 }
 
 // PackageResult is returned by ResolvePackage. It contains one

--- a/internal/selfhost/adapter.go
+++ b/internal/selfhost/adapter.go
@@ -1,14 +1,40 @@
 package selfhost
 
 import (
-	"github.com/osty/osty/internal/ast"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"unicode/utf8"
 
+	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 	"github.com/osty/osty/internal/token"
 )
+
+// astbridgeLowerCount records every time a FrontendRun materializes
+// the *ast.File via the astbridge-based astLowerPublicFile adapter.
+// It is the single source of truth for "did this code path touch the
+// runtime.golegacy.astbridge bootstrap bridge?" — tests use it to pin
+// astbridge-free code paths (e.g., the native resolve wedge) and to
+// detect regressions when a would-be-native path silently falls back
+// to the Go AST. Counter is package-global because FrontendRun.File()
+// is the only astbridge entry point for the resolve/check/llvmgen
+// callers. See ResolveStructuredFromRun / cmd/osty case "resolve" for
+// the intended zero-bump usage.
+var astbridgeLowerCount int64
+
+// AstbridgeLowerCount returns the total number of astbridge-based
+// *ast.File lowerings performed since process start (or since the
+// last ResetAstbridgeLowerCount call).
+func AstbridgeLowerCount() int64 {
+	return atomic.LoadInt64(&astbridgeLowerCount)
+}
+
+// ResetAstbridgeLowerCount zeros the counter. Intended for tests that
+// want to measure astbridge activity over a specific code window.
+func ResetAstbridgeLowerCount() {
+	atomic.StoreInt64(&astbridgeLowerCount, 0)
+}
 
 // Lex runs the bootstrapped pure-Osty lexer and adapts its stream to the
 // compiler's public token surface.
@@ -172,12 +198,31 @@ func (r *FrontendRun) Comments() []token.Comment {
 }
 
 // File returns the lowered semantic AST for this front-end pass.
+//
+// First call materializes the *ast.File via astLowerPublicFile — the
+// single astbridge (`runtime.golegacy.astbridge`) entry point on the
+// resolve / check / llvmgen side of the compiler. Subsequent calls
+// return the cached result without touching astbridge again, so each
+// FrontendRun contributes at most one lowering to
+// AstbridgeLowerCount regardless of how many callers poke it.
 func (r *FrontendRun) File() *ast.File {
 	if r.file != nil {
 		return r.file
 	}
+	atomic.AddInt64(&astbridgeLowerCount, 1)
 	r.file = astLowerPublicFile(r.parser.arena, r.Tokens())
 	return r.file
+}
+
+// astFile wraps the parser arena in the self-host AstFile handle without
+// going through the astbridge *ast.File round-trip. Downstream native passes
+// (resolve/check/llvmgen) consume AstArena directly, so this is the
+// no-detour entry point.
+func (r *FrontendRun) astFile() *AstFile {
+	if r.parser == nil {
+		return nil
+	}
+	return &AstFile{arena: r.parser.arena}
 }
 
 // LexDiagnostics returns lexer-only diagnostics.

--- a/internal/selfhost/resolve_adapter.go
+++ b/internal/selfhost/resolve_adapter.go
@@ -112,6 +112,62 @@ func ResolveSourceStructured(src []byte) ResolveResult {
 	)
 }
 
+// ResolveStructuredFromRun runs the self-host resolver directly on the
+// arena produced by an existing FrontendRun, skipping both the secondary
+// lex/parse pass done by ResolveSourceStructured and the *ast.File →
+// AstArena round-trip done by ResolvePackageStructured. Output matches
+// ResolveSourceStructured(src) for the same source. Callers that already
+// hold a FrontendRun should prefer this entry point so the astbridge
+// detour becomes dead code for the resolve pass.
+func ResolveStructuredFromRun(run *FrontendRun) ResolveResult {
+	if run == nil {
+		return ResolveResult{}
+	}
+	file := run.astFile()
+	if file == nil {
+		return ResolveResult{}
+	}
+	rt := run.rt
+	stream := run.stream
+	return adaptResolveResult(
+		selfResolveAstFile(file),
+		file,
+		func(start, end int) (int, int) {
+			return checkNodeOffsets(rt, stream, start, end)
+		},
+	)
+}
+
+// ResolveStructuredFromRunForPath is ResolveStructuredFromRun plus
+// single-file annotation: Symbols / Refs / TypeRefs / Diagnostics all
+// carry path, and each Ref's TargetFile is set to path when the resolver
+// found a declared (non-builtin) target. Use this when the caller
+// already knows the source file path and wants the same File /
+// TargetFile fields that ResolvePackageStructured produces for the
+// single-file case, without going through the *ast.File round-trip.
+func ResolveStructuredFromRunForPath(run *FrontendRun, path string) ResolveResult {
+	result := ResolveStructuredFromRun(run)
+	if path == "" {
+		return result
+	}
+	for i := range result.Symbols {
+		result.Symbols[i].File = path
+	}
+	for i := range result.Refs {
+		result.Refs[i].File = path
+		if result.Refs[i].TargetNode >= 0 {
+			result.Refs[i].TargetFile = path
+		}
+	}
+	for i := range result.TypeRefs {
+		result.TypeRefs[i].File = path
+	}
+	for i := range result.Diagnostics {
+		result.Diagnostics[i].File = path
+	}
+	return result
+}
+
 // ResolvePackageStructured lowers one structured package input into a
 // synthetic selfhost AST and runs the self-host resolver over the merged
 // package namespace.

--- a/internal/selfhost/resolve_adapter_test.go
+++ b/internal/selfhost/resolve_adapter_test.go
@@ -2,6 +2,7 @@ package selfhost_test
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/osty/osty/internal/selfhost"
@@ -151,6 +152,109 @@ func TestResolvePackageStructuredDuplicateUsesOwningFilePath(t *testing.T) {
 	}
 	if resolved.Summary.Duplicates != 1 {
 		t.Fatalf("duplicates = %d, want 1 (summary=%#v)", resolved.Summary.Duplicates, resolved.Summary)
+	}
+}
+
+// TestResolveStructuredFromRunIsAstbridgeFree pins the core wedge
+// promise: calling Run + Diagnostics + ResolveStructuredFromRun on a
+// clean single-file source must not trigger astLowerPublicFile, i.e.
+// AstbridgeLowerCount stays at zero. The same test then calls
+// run.File() and verifies the counter bumps exactly once, confirming
+// that astbridge is still reachable for fallbacks (for example the
+// --show-scopes path in `osty resolve`) and that the counter is wired
+// to the right site. This is the regression net for future wedges:
+// any new native path that accidentally re-introduces an *ast.File
+// detour will bump the counter and fail this test.
+func TestResolveStructuredFromRunIsAstbridgeFree(t *testing.T) {
+	src := []byte(`fn helper(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let value = helper(1)
+}
+`)
+	selfhost.ResetAstbridgeLowerCount()
+
+	run := selfhost.Run(src)
+	_ = run.Diagnostics()
+	resolved := selfhost.ResolveStructuredFromRun(run)
+
+	if resolved.Summary.Diagnostics != 0 {
+		t.Fatalf("clean source produced diagnostics: %#v", resolved.Diagnostics)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after Run + Diagnostics + ResolveStructuredFromRun = %d, want 0 (the arena path must not touch astbridge)", got)
+	}
+
+	if file := run.File(); file == nil {
+		t.Fatalf("run.File() returned nil")
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 1 {
+		t.Fatalf("AstbridgeLowerCount after run.File() = %d, want 1 (counter should be wired to the sole astbridge entry point)", got)
+	}
+
+	_ = run.File()
+	if got := selfhost.AstbridgeLowerCount(); got != 1 {
+		t.Fatalf("AstbridgeLowerCount after cached run.File() = %d, want 1 (re-calling File() should not re-lower)", got)
+	}
+}
+
+// TestResolveStructuredFromRunMatchesResolveSourceStructured pins the
+// invariant that feeds the astbridge removal wedge: running the native
+// resolver on a FrontendRun's parser arena directly must produce the
+// same ResolveResult as the legacy path that re-lexes/re-parses the
+// source. When this holds, downstream CLI call sites can switch from
+// ResolveSourceStructured / ResolvePackageStructured (both of which
+// still participate in the *ast.File round-trip for multi-file inputs)
+// to ResolveStructuredFromRun without any observable change.
+func TestResolveStructuredFromRunMatchesResolveSourceStructured(t *testing.T) {
+	cases := []struct {
+		name string
+		src  []byte
+	}{
+		{
+			name: "helper+main with ref",
+			src: []byte(`fn helper(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let value = helper(1)
+}
+`),
+		},
+		{
+			name: "use body with struct decl",
+			src: []byte(`use std.fs as fs
+
+pub struct User {
+    pub name: String,
+    pub age: Int,
+}
+
+fn main() {
+    let u = User { name: "a", age: 1 }
+}
+`),
+		},
+		{
+			name: "unresolved ref produces diagnostic",
+			src: []byte(`fn main() {
+    let x = missing()
+}
+`),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := selfhost.ResolveSourceStructured(tc.src)
+			fresh := selfhost.ResolveStructuredFromRun(selfhost.Run(tc.src))
+			if !reflect.DeepEqual(legacy, fresh) {
+				t.Fatalf("ResolveStructuredFromRun diverges from ResolveSourceStructured\nlegacy=%#v\nfresh=%#v", legacy, fresh)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `FrontendRun.File()` is the single astbridge (`runtime.golegacy.astbridge`) entry point on the resolve / check / llvmgen side. This PR wires the `osty resolve` happy path through the self-host arena directly, so a clean source produces **zero** astbridge lowerings; `*ast.File` materialization is deferred to fallback paths only.
- Same treatment for both `osty resolve FILE` and `osty resolve DIR` (packages). No behavior change for user-visible output; CLI golden tests are green.
- Adds a package-global `AstbridgeLowerCount` counter so any future wedge can self-verify with `got := selfhost.AstbridgeLowerCount()` and refuse silent regressions.

## What changed

**selfhost**
- `ResolveStructuredFromRun(*FrontendRun)` / `...ForPath` — run the native resolver on an existing parser arena, skipping both the re-lex/re-parse of `ResolveSourceStructured` and the `*ast.File → AstArena` round-trip of `ResolvePackageStructured`.
- `AstbridgeLowerCount()` / `ResetAstbridgeLowerCount()` — instrument the single astbridge call site (`FrontendRun.File`).

**parser**
- `ParseRun(src) *selfhost.FrontendRun` — arena-only parse entry point. `run.File()` still works lazily on demand.

**resolve**
- `PackageFile.Run *selfhost.FrontendRun` + `PackageFile.EnsureFile()` + `Package.EnsureFiles()` — lazy *ast.File materialization.
- `LoadPackageForNative` / `...WithTransform` — sibling of `LoadPackage` that populates Run and leaves File nil. Native resolver runs without triggering any astbridge lowering.
- `nativeResolveInput` / `nativeResolveSourceForFile` tolerate File=nil (non-Direct `selfhostBuildPackageAst` re-parse path) and use raw Source when CanonicalSource is absent.

**cmd/osty**
- `case \"resolve\"` uses `ParseRun` + `ResolveStructuredFromRunForPath` + local row/diag formatters; `run.File()` only invoked for `--show-scopes` / Go-resolver fallback.
- `runResolvePackage` uses `LoadPackageForNative` + `EnsureFiles()` on fallback paths.
- Unused legacy helpers `NativeResolutionRowsForSource` / `NativeDiagnosticsForSource` / `nativeResolveSingleFileRows` / `nativeResolveSingleFileDiagnostics` deleted.

## Why

Whole-toolchain probe identified `runtime.golegacy.astbridge` as the last wall for true self-host on the resolve/check/llvmgen side. Rather than a big-bang removal — which would require the `resolve.Result` pointer-identity map API to be completely reshaped (survey: ~90% of 54 call sites across check/lint/ir/LSP depend on `*ast.Ident` / `*ast.NamedType` pointer keys) — this lands the **wedge**: one subcommand at a time migrates to the arena-direct path. `osty resolve` is the first subcommand where both single-file and package paths now skip astbridge on the happy path.

Future PRs can use the same pattern for `check` / `lint` (harder — `check.File` requires `*ast.File`) and the `resolve.Result` identity model redesign.

## Proof

Counter-based regression tests pin the invariant:

```
// single-file
Run + Diagnostics + ResolveStructuredFromRun → AstbridgeLowerCount == 0  ✓
run.File()                                   → AstbridgeLowerCount == 1  ✓
run.File() again                             → AstbridgeLowerCount == 1  ✓ (cached)

// package
LoadPackageForNative(2-file dir)             → AstbridgeLowerCount == 0  ✓
NativeDiagnostics(pkg)                       → AstbridgeLowerCount == 0  ✓
NativeResolutionRows(pkg, path)              → AstbridgeLowerCount == 0  ✓
pkg.EnsureFiles()                            → AstbridgeLowerCount == 2  ✓
pkg.EnsureFiles() again                      → AstbridgeLowerCount == 2  ✓ (cached)
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short ./cmd/osty/ ./internal/resolve/... ./internal/selfhost/ ./internal/parser/... ./internal/check/... ./internal/lint/... ./internal/ir/...`
- [x] `TestResolveCLISingleFilePrintsNativeResolutionRows`, `TestResolveCLIPackagePrintsNativeCrossFileResolutionRows`, `TestResolveCLISingleFilePrintsNativeDiagnostics` green
- [x] New `TestResolveStructuredFromRunIsAstbridgeFree`, `TestResolveStructuredFromRunMatchesResolveSourceStructured`, `TestLoadPackageForNativeMultiFileIsAstbridgeFree` green

Pre-existing failures reproduce on main (`git stash`-verified) and are not caused by this change:
`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`, `TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered`, `TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)