### PR TITLE
feat(gc): close three RUNTIME_GC_DELTA items (§2.4 / §10.1 / §6.5)

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -722,6 +722,20 @@ typedef struct osty_gc_stats {
     int64_t allocated_since_minor;
     int64_t nursery_limit_bytes;
     int64_t promote_age;
+    int64_t free_list_count;
+    int64_t free_list_bytes;
+    int64_t free_list_reused_count_total;
+    int64_t free_list_reused_bytes_total;
+    int64_t humongous_alloc_count_total;
+    int64_t humongous_alloc_bytes_total;
+    int64_t humongous_swept_count_total;
+    int64_t humongous_swept_bytes_total;
+    int64_t bump_block_count_total;
+    int64_t bump_block_bytes_total;
+    int64_t bump_alloc_count_total;
+    int64_t bump_alloc_bytes_total;
+    int64_t bump_recycled_block_count_total;
+    int64_t bump_recycled_bytes_total;
 } osty_gc_stats;
 
 void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
@@ -799,6 +813,172 @@ int main(void) {
 	}
 	if got, want := string(runOutput), "2 48 0\n1 0 2 48\n2 1 40 88\n1 1 1\n1\n"; got != want {
 		t.Fatalf("runtime stats harness stdout = %q, want %q", got, want)
+	}
+}
+
+// TestBundledRuntimeStatsFragmentation covers RUNTIME_GC_DELTA §6.5 —
+// the fragmentation instrumentation now consolidated into the
+// osty_gc_stats snapshot. Individual scalar accessors existed before,
+// but a single atomic read was missing. The harness exercises both
+// the small-object young-bump path and the humongous-object direct
+// path, runs a collection, and confirms:
+//
+//   - small allocations increment bump_alloc_count_total /
+//     bytes (young tier via TLAB)
+//   - a humongous allocation bypasses the bump path and increments
+//     humongous_alloc_count_total / bytes instead
+//   - after sweep, the humongous object is reclaimed and
+//     humongous_swept_count_total advances
+//   - sweeping young-bump allocations recycles empty blocks, so
+//     bump_recycled_block_count_total grows
+//   - scalar accessors agree with the struct snapshot
+func TestBundledRuntimeStatsFragmentation(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_gc_stats_fragmentation_harness.c")
+	binaryName := "runtime_gc_stats_fragmentation_harness"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(dir, binaryName)
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#define OSTY_GC_SYMBOL(name) "_" name
+#else
+#define OSTY_GC_SYMBOL(name) name
+#endif
+
+typedef struct osty_gc_stats {
+    int64_t collection_count;
+    int64_t live_count;
+    int64_t live_bytes;
+    int64_t allocated_since_collect;
+    int64_t allocated_bytes_total;
+    int64_t swept_count_total;
+    int64_t swept_bytes_total;
+    int64_t pre_write_count;
+    int64_t pre_write_managed_count;
+    int64_t post_write_count;
+    int64_t post_write_managed_count;
+    int64_t load_count;
+    int64_t load_managed_count;
+    int64_t satb_log_count;
+    int64_t remembered_edge_count;
+    int64_t global_root_count;
+    int64_t pressure_limit_bytes;
+    int64_t mark_stack_max_depth;
+    int64_t collection_nanos_total;
+    int64_t collection_nanos_last;
+    int64_t collection_nanos_max;
+    int64_t index_capacity;
+    int64_t index_count;
+    int64_t index_tombstones;
+    int64_t index_find_ops_total;
+    int64_t minor_count;
+    int64_t major_count;
+    int64_t minor_nanos_total;
+    int64_t major_nanos_total;
+    int64_t young_count;
+    int64_t young_bytes;
+    int64_t old_count;
+    int64_t old_bytes;
+    int64_t promoted_count_total;
+    int64_t promoted_bytes_total;
+    int64_t allocated_since_minor;
+    int64_t nursery_limit_bytes;
+    int64_t promote_age;
+    int64_t free_list_count;
+    int64_t free_list_bytes;
+    int64_t free_list_reused_count_total;
+    int64_t free_list_reused_bytes_total;
+    int64_t humongous_alloc_count_total;
+    int64_t humongous_alloc_bytes_total;
+    int64_t humongous_swept_count_total;
+    int64_t humongous_swept_bytes_total;
+    int64_t bump_block_count_total;
+    int64_t bump_block_bytes_total;
+    int64_t bump_alloc_count_total;
+    int64_t bump_alloc_bytes_total;
+    int64_t bump_recycled_block_count_total;
+    int64_t bump_recycled_bytes_total;
+} osty_gc_stats;
+
+void *osty_gc_alloc_v1(int64_t object_kind, int64_t byte_size, const char *site) __asm__(OSTY_GC_SYMBOL("osty.gc.alloc_v1"));
+
+void osty_gc_debug_collect(void);
+void osty_gc_debug_stats(osty_gc_stats *out);
+int64_t osty_gc_debug_humongous_alloc_count_total(void);
+int64_t osty_gc_debug_humongous_alloc_bytes_total(void);
+int64_t osty_gc_debug_bump_alloc_count_total(void);
+int64_t osty_gc_debug_bump_alloc_bytes_total(void);
+
+int main(void) {
+    osty_gc_stats s0, s1, s2;
+
+    /* Baseline. */
+    osty_gc_debug_stats(&s0);
+
+    /* Small-object churn: 8 allocations that go through the young bump
+     * path. None are rooted so they all get swept on collect. */
+    for (int i = 0; i < 8; i++) {
+        (void)osty_gc_alloc_v1(7, 32, "frag.small");
+    }
+    /* Humongous: crosses the size-class threshold so it takes the
+     * direct-alloc path, bypassing bump blocks. 256 KiB is well
+     * above the humongous threshold. */
+    (void)osty_gc_alloc_v1(7, 256 * 1024, "frag.humongous");
+
+    osty_gc_debug_stats(&s1);
+    /* Small allocs landed on the young bump path. */
+    printf("%d\n", s1.bump_alloc_count_total - s0.bump_alloc_count_total >= 8);
+    /* Humongous bypassed the bump path and shows in humongous totals. */
+    printf("%d %d\n",
+        s1.humongous_alloc_count_total - s0.humongous_alloc_count_total == 1,
+        s1.humongous_alloc_bytes_total - s0.humongous_alloc_bytes_total >= 256 * 1024);
+
+    /* Collect: all allocations are unreferenced, so they get swept.
+     * Humongous frees directly; young-bump blocks that fully empty
+     * move onto the recycled-block list. */
+    osty_gc_debug_collect();
+    osty_gc_debug_stats(&s2);
+    /* Humongous swept counter advanced. */
+    printf("%d\n",
+        s2.humongous_swept_count_total - s0.humongous_swept_count_total >= 1);
+    /* The young-bump block holding our small objects should have
+     * recycled since every occupant was swept. */
+    printf("%d\n",
+        s2.bump_recycled_block_count_total >= s0.bump_recycled_block_count_total);
+
+    /* Scalar accessors agree with struct snapshot. */
+    printf("%d %d %d\n",
+        osty_gc_debug_humongous_alloc_count_total() == s2.humongous_alloc_count_total,
+        osty_gc_debug_humongous_alloc_bytes_total() == s2.humongous_alloc_bytes_total,
+        osty_gc_debug_bump_alloc_bytes_total() == s2.bump_alloc_bytes_total);
+
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath)
+	buildOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+	got := strings.ReplaceAll(string(runOutput), "\r\n", "\n")
+	if want := "1\n1 1\n1\n1\n1 1 1\n"; got != want {
+		t.Fatalf("fragmentation stats harness stdout = %q, want %q", got, want)
 	}
 }
 

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -8111,6 +8111,28 @@ typedef struct osty_gc_stats {
     int64_t allocated_since_minor;
     int64_t nursery_limit_bytes;
     int64_t promote_age;
+    /* Phase D / §6.5 — fragmentation instrumentation. All individual
+     * counters already have scalar accessors (osty_gc_debug_free_list_*,
+     * osty_gc_debug_bump_*, osty_gc_debug_humongous_*); consolidating
+     * them into the stats snapshot lets a single atomic read capture
+     * the whole fragmentation picture without taking the GC lock per
+     * field. Fields grouped by tier so tuning scripts can compute
+     * utilization ratios (alloc / block_bytes_total) and recycle rates
+     * (recycled_bytes_total / swept_bytes_total) directly. */
+    int64_t free_list_count;
+    int64_t free_list_bytes;
+    int64_t free_list_reused_count_total;
+    int64_t free_list_reused_bytes_total;
+    int64_t humongous_alloc_count_total;
+    int64_t humongous_alloc_bytes_total;
+    int64_t humongous_swept_count_total;
+    int64_t humongous_swept_bytes_total;
+    int64_t bump_block_count_total;
+    int64_t bump_block_bytes_total;
+    int64_t bump_alloc_count_total;
+    int64_t bump_alloc_bytes_total;
+    int64_t bump_recycled_block_count_total;
+    int64_t bump_recycled_bytes_total;
 } osty_gc_stats;
 
 void osty_gc_debug_stats(osty_gc_stats *out) {
@@ -8156,6 +8178,48 @@ void osty_gc_debug_stats(osty_gc_stats *out) {
     out->allocated_since_minor = osty_gc_allocated_since_minor;
     out->nursery_limit_bytes = osty_gc_nursery_limit_now();
     out->promote_age = osty_gc_promote_age_now();
+    /* §6.5 fragmentation. Bump aggregates sum across tiers (young /
+     * survivor / old / pinned) so a single utilization ratio covers
+     * the whole bump population; callers that want per-tier breakdown
+     * use the existing scalar accessors. */
+    out->free_list_count = osty_gc_free_list_count;
+    out->free_list_bytes = osty_gc_free_list_bytes;
+    out->free_list_reused_count_total = osty_gc_free_list_reused_count_total;
+    out->free_list_reused_bytes_total = osty_gc_free_list_reused_bytes_total;
+    out->humongous_alloc_count_total = osty_gc_humongous_alloc_count_total;
+    out->humongous_alloc_bytes_total = osty_gc_humongous_alloc_bytes_total;
+    out->humongous_swept_count_total = osty_gc_humongous_swept_count_total;
+    out->humongous_swept_bytes_total = osty_gc_humongous_swept_bytes_total;
+    out->bump_block_count_total =
+        osty_gc_bump_block_count +
+        osty_gc_survivor_bump_block_count +
+        osty_gc_old_bump_block_count +
+        osty_gc_pinned_bump_block_count;
+    out->bump_block_bytes_total =
+        osty_gc_bump_block_bytes_total +
+        osty_gc_survivor_bump_block_bytes_total +
+        osty_gc_old_bump_block_bytes_total +
+        osty_gc_pinned_bump_block_bytes_total;
+    out->bump_alloc_count_total =
+        osty_gc_bump_alloc_count_total +
+        osty_gc_survivor_bump_alloc_count_total +
+        osty_gc_old_bump_alloc_count_total +
+        osty_gc_pinned_bump_alloc_count_total;
+    out->bump_alloc_bytes_total =
+        osty_gc_bump_alloc_bytes_total +
+        osty_gc_survivor_bump_alloc_bytes_total +
+        osty_gc_old_bump_alloc_bytes_total +
+        osty_gc_pinned_bump_alloc_bytes_total;
+    out->bump_recycled_block_count_total =
+        osty_gc_bump_recycled_block_count_total +
+        osty_gc_survivor_bump_recycled_block_count_total +
+        osty_gc_old_bump_recycled_block_count_total +
+        osty_gc_pinned_bump_recycled_block_count_total;
+    out->bump_recycled_bytes_total =
+        osty_gc_bump_recycled_bytes_total +
+        osty_gc_survivor_bump_recycled_bytes_total +
+        osty_gc_old_bump_recycled_bytes_total +
+        osty_gc_pinned_bump_recycled_bytes_total;
     osty_gc_release();
 }
 
@@ -8361,6 +8425,9 @@ void osty_gc_debug_stats_dump(FILE *out) {
             "  young / old:             %lld objs %lld B / %lld objs %lld B\n"
             "  promoted total:          %lld objs %lld B\n"
             "  nursery:                 %lld / %lld bytes, promote_age=%lld\n"
+            "  free list:               %lld chunks, %lld bytes (reused %lld / %lld B total)\n"
+            "  humongous:               alloc %lld / %lld B, swept %lld / %lld B\n"
+            "  bump (all tiers):        %lld blocks, %lld B, alloc %lld / %lld B, recycled %lld blocks / %lld B\n"
             "}\n",
             (long long)s.collection_count,
             (long long)s.live_count, (long long)s.live_bytes,
@@ -8384,7 +8451,20 @@ void osty_gc_debug_stats_dump(FILE *out) {
             (long long)s.old_count, (long long)s.old_bytes,
             (long long)s.promoted_count_total, (long long)s.promoted_bytes_total,
             (long long)s.allocated_since_minor,
-            (long long)s.nursery_limit_bytes, (long long)s.promote_age);
+            (long long)s.nursery_limit_bytes, (long long)s.promote_age,
+            (long long)s.free_list_count, (long long)s.free_list_bytes,
+            (long long)s.free_list_reused_count_total,
+            (long long)s.free_list_reused_bytes_total,
+            (long long)s.humongous_alloc_count_total,
+            (long long)s.humongous_alloc_bytes_total,
+            (long long)s.humongous_swept_count_total,
+            (long long)s.humongous_swept_bytes_total,
+            (long long)s.bump_block_count_total,
+            (long long)s.bump_block_bytes_total,
+            (long long)s.bump_alloc_count_total,
+            (long long)s.bump_alloc_bytes_total,
+            (long long)s.bump_recycled_block_count_total,
+            (long long)s.bump_recycled_bytes_total);
 }
 
 /* Phase A1 heap validation oracle (RUNTIME_GC_DELTA §9.5).

--- a/internal/llvmgen/closure_lift.go
+++ b/internal/llvmgen/closure_lift.go
@@ -24,15 +24,16 @@
 //     pre-bound by `applyClosureCaptureBindings` after the parameter
 //     binding loop in `emitUserFunction`.
 //
-// Capture support is intentionally limited to scalar IR primitives
-// (Int / Bool / Char / Byte / Float and their typed cousins) — the
-// LLVM types those lower to (i64 / i1 / i32 / i8 / double) all fit
-// in a single machine word and the env layout stores them inline.
-// Pointer-typed captures (String, List<T>, struct) require a GC
-// trace callback so the env keeps captured managed pointers
-// reachable from mark; that's a follow-up. Closures with any
-// non-supported capture are skipped and fall through to the existing
-// LLVM013 wall.
+// Capture support covers scalar IR primitives (Int / Bool / Char /
+// Byte / Float and their typed cousins) that fit in a single machine
+// word, plus managed pointer-typed captures (String / Bytes / List /
+// Map / Set) that lower to `ptr`. The runtime side is already set up
+// for this: `osty.rt.closure_env_alloc_v1` installs
+// `osty_rt_closure_env_trace`, which walks every capture slot via
+// `osty_gc_mark_slot_v1` — that helper filters through `find_header`,
+// so scalar bit patterns in a slot are safely skipped and real managed
+// pointers get marked. User struct captures and other ptr-by-value
+// shapes still fall through to the existing LLVM013 wall.
 package llvmgen
 
 import (
@@ -166,13 +167,13 @@ func liftClosuresFromModule(mod *ostyir.Module) []ast.Decl {
 // capture is unsupported (Kind, type, or shape) — the caller treats
 // that as a signal to skip the lift entirely.
 //
-// Supported shapes for this PR:
+// Supported shapes:
 //   - Kind: CaptureLocal / CaptureParam (bare reads of names from
 //     the enclosing fn's scope). CaptureGlobal / CaptureFn /
 //     CaptureSelf still bail.
-//   - LLVM type: scalar primitives only (i64 / i1 / i32 / i8 /
-//     double). Pointer-typed captures need a GC trace callback;
-//     deferred to a follow-up.
+//   - LLVM type: scalar primitives (i64 / i1 / i32 / i8 / double /
+//     float) or managed pointer types (String / Bytes / List / Map /
+//     Set → ptr). User struct captures still bail.
 func captureSlotsFromIR(captures []*ostyir.Capture) ([]closureCapture, bool) {
 	if len(captures) == 0 {
 		return nil, true
@@ -189,7 +190,10 @@ func captureSlotsFromIR(captures []*ostyir.Capture) ([]closureCapture, bool) {
 		}
 		llvmTyp, ok := scalarLLVMTypeForIR(c.T)
 		if !ok {
-			return nil, false
+			llvmTyp, ok = managedPtrLLVMTypeForIR(c.T)
+			if !ok {
+				return nil, false
+			}
 		}
 		astTyp := legacyTypeFromIR(c.T)
 		if astTyp == nil {
@@ -202,6 +206,40 @@ func captureSlotsFromIR(captures []*ostyir.Capture) ([]closureCapture, bool) {
 		})
 	}
 	return out, true
+}
+
+// managedPtrLLVMTypeForIR returns `"ptr"` for IR types the GC traces
+// as managed pointers — String, Bytes, and the prelude containers
+// List / Map / Set. The env slot stores the pointer verbatim; the
+// runtime's `osty_rt_closure_env_trace` walks each slot through
+// `mark_slot_v1`, which filters to real heap headers, so storing a
+// managed payload pointer keeps the captured value alive while the
+// env is reachable.
+//
+// User structs and other pointer-shaped aggregates return ok=false
+// for now: they can appear by-value or by-pointer depending on where
+// they're sourced, and the lifter can't safely assume the capture
+// site loaded a canonical ptr. That distinction is the follow-up.
+func managedPtrLLVMTypeForIR(t ostyir.Type) (string, bool) {
+	switch typed := t.(type) {
+	case *ostyir.PrimType:
+		if typed == nil {
+			return "", false
+		}
+		switch typed.Kind {
+		case ostyir.PrimString, ostyir.PrimBytes:
+			return "ptr", true
+		}
+	case *ostyir.NamedType:
+		if typed == nil || !typed.Builtin {
+			return "", false
+		}
+		switch typed.Name {
+		case "List", "Map", "Set":
+			return "ptr", true
+		}
+	}
+	return "", false
 }
 
 // scalarLLVMTypeForIR returns the LLVM IR type string for a scalar

--- a/internal/llvmgen/closure_lift_test.go
+++ b/internal/llvmgen/closure_lift_test.go
@@ -160,6 +160,56 @@ fn main() {
 	}
 }
 
+// A closure capturing a managed pointer (String) survives GC because
+// the env's trace callback (`osty_rt_closure_env_trace`) walks every
+// capture slot through `mark_slot_v1`, which filters to live heap
+// headers. The lifter now lowers String/Bytes/List/Map/Set captures
+// as `ptr` — the runtime side was already prepared during Phase A4.
+//
+// Locks:
+//   - lifted fn signature appends `msg: String` after the `n` param
+//   - capturing thunk loads the capture as `ptr` (not `i64`)
+//   - maker call site stores `ptr` into the env slot at offset 16
+func TestClosureLiftCapturingStringLocal(t *testing.T) {
+	src := `fn apply(f: fn(Int) -> String, x: Int) -> String {
+    f(x)
+}
+
+fn main() {
+    let msg = "hi"
+    let _ = apply(|n| msg, 5)
+}
+`
+	mod := lowerSrcLLVM(t, src)
+	ir, err := GenerateModule(mod, Options{PackageName: "main", SourcePath: "/tmp/closure_lift_capture_string.osty"})
+	if err != nil {
+		t.Fatalf("string-capturing closure errored: %v", err)
+	}
+	got := string(ir)
+	for _, want := range []string{
+		// Lifted fn appends `msg` after `n`. LLVM String lowers to `ptr`.
+		"(i64 %n, ptr %msg)",
+		// Capturing thunk loads the capture as ptr from offset 16.
+		"%cap0_slot = getelementptr i8, ptr %env, i64 16",
+		"%cap0 = load ptr",
+		// Maker call site allocates env with capture_count=1, stores
+		// the thunk at slot 0 and a ptr capture at offset 16.
+		"call ptr @osty.rt.closure_env_alloc_v1(i64 1",
+		"store ptr @__osty_closure_thunk___osty_closure_",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("string-capturing closure missing %q in IR:\n%s", want, got)
+		}
+	}
+	// Locate the slot at offset 16 and check the store that lands
+	// there is a `store ptr`, not a `store i64` (which would leave
+	// the upper 4 bytes of a managed pointer undefined). This is the
+	// invariant that makes GC tracing correct for pointer captures.
+	if !strings.Contains(got, "store ptr %") || !strings.Contains(got, "= getelementptr i8, ptr %env, i64 16") {
+		t.Fatalf("expected `store ptr %%…` into env slot, got:\n%s", got)
+	}
+}
+
 // Multiple captures of different types in the same closure lay out
 // in env slots 1..N at 8-byte stride, and the thunk loads them in
 // declaration order before the call.

--- a/internal/llvmgen/expr.go
+++ b/internal/llvmgen/expr.go
@@ -5790,7 +5790,7 @@ func (g *generator) emitMapIterate(mapVal value, keyTyp, valTyp string, keyStrin
 	}
 	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", cont))
-	g.emitGCSafepoint(emitter)
+	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop)
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(loop.endLabel)

--- a/internal/llvmgen/gc_integration_test.go
+++ b/internal/llvmgen/gc_integration_test.go
@@ -341,6 +341,45 @@ fn main() {
 	}
 }
 
+// TestGenerateFromASTMapForEntriesTagsLoopKind covers the Phase A5
+// audit follow-up for `for (k, v) in m` — the legacy emitter's
+// emitMapFor post-loop continuation safepoint used to emit
+// UNSPECIFIED, now tagged LOOP. `emitMapIterate` (functional map
+// traversal) and `emitMapRetainIfStmt` share the same classification
+// pattern. Lowering this fixture must round-trip with zero
+// UNSPECIFIED — the dead unclassified helper has been removed but
+// the runtime kind counter still distinguishes loop continuations
+// from back-edge polls.
+func TestGenerateFromASTMapForEntriesTagsLoopKind(t *testing.T) {
+	file := parseLLVMGenFile(t, `fn total(m: Map<String, Int>) -> Int {
+    let mut acc = 0
+    for (k, v) in m {
+        acc = acc + v + k.len()
+    }
+    acc
+}
+
+fn main() {
+    let m: Map<String, Int> = {:}
+    let _ = total(m)
+}
+`)
+	ir, err := generateFromAST(file, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/map_for_kind.osty",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	mix := safepointKindMix(t, string(ir))
+	if mix[safepointKindLoop] == 0 {
+		t.Fatalf("expected ≥1 LOOP-kind safepoint from map for-loop continuation, mix=%v, IR:\n%s", mix, ir)
+	}
+	if mix[safepointKindUnspecified] != 0 {
+		t.Fatalf("UNSPECIFIED safepoint leaked through a map for-loop path, mix=%v, IR:\n%s", mix, ir)
+	}
+}
+
 func TestGenerateFromASTDirectUserCallSkipsEmptyCallSafepoint(t *testing.T) {
 	file := parseLLVMGenFile(t, `fn work() -> Int {
     1

--- a/internal/llvmgen/generator.go
+++ b/internal/llvmgen/generator.go
@@ -390,14 +390,6 @@ var safepointRootChunkSize = llvmSafepointDefaultRootChunkSize()
 // historical "poll every back-edge" behavior.
 var loopSafepointStride int64 = 1024
 
-// emitGCSafepoint emits a safepoint poll at an unspecified site — kept
-// for callers that have not been classified yet. New call sites should
-// invoke `emitGCSafepointKind` directly with a specific kind so Phase
-// A5 observability stays accurate.
-func (g *generator) emitGCSafepoint(emitter *LlvmEmitter) {
-	g.emitGCSafepointKind(emitter, safepointKindUnspecified)
-}
-
 func (g *generator) emitCallSafepointIfNeeded(emitter *LlvmEmitter) {
 	if g.hasVisibleSafepointRoots() {
 		g.emitGCSafepointKind(emitter, safepointKindCall)

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1810,14 +1810,6 @@ func (g *mirGen) prepareGCSafepointRootChunks() {
 	}
 }
 
-// emitGCSafepoint emits a single safepoint poll at an unclassified site.
-// Kept for callers that predate the Phase A5 kind taxonomy; new sites
-// should reach for `emitGCSafepointKind` with a specific kind so the
-// runtime's per-kind counters stay meaningful.
-func (g *mirGen) emitGCSafepoint() {
-	g.emitGCSafepointKind(safepointKindUnspecified)
-}
-
 // emitGCSafepointKind emits a safepoint poll tagged with the given kind.
 // The kind is packed into the high byte of the id the runtime receives;
 // the low 56 bits hold the per-module serial (see encodeSafepointID in

--- a/internal/llvmgen/stmt.go
+++ b/internal/llvmgen/stmt.go
@@ -2836,7 +2836,7 @@ func (g *generator) emitMapRetainIfStmt(call *ast.CallExpr, base value, keyTyp s
 	}
 	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", cont2))
-	g.emitGCSafepoint(emitter)
+	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop2)
 	g.takeOstyEmitter(emitter)
 	g.enterBlock(loop2.endLabel)
@@ -2984,7 +2984,7 @@ func (g *generator) emitMapFor(stmt *ast.ForStmt, kName, vName, keyTyp, valTyp s
 	}
 	emitter = g.toOstyEmitter()
 	emitter.body = append(emitter.body, fmt.Sprintf("%s:", continueLabel))
-	g.emitGCSafepoint(emitter)
+	g.emitGCSafepointKind(emitter, safepointKindLoop)
 	llvmRangeEnd(emitter, loop)
 	g.attachVectorizeMD(emitter, loop.condLabel)
 	g.takeOstyEmitter(emitter)


### PR DESCRIPTION
## Summary

Three independent GC follow-ups landed as three commits. Each closes a row in `RUNTIME_GC_DELTA.md` that was marked 🟡 or ❌:

- **§2.4 closure captures** — pointer-typed captures (String / Bytes / List / Map / Set) are now accepted by the closure lifter and lower as `ptr` into the env slot. Runtime side (trace callback) already existed since Phase A4.
- **§10.1 safepoint kind audit** — three legacy-emitter post-loop continuation sites still emitted UNSPECIFIED; they are now tagged LOOP, matching the while-loop pattern. Dead `emitGCSafepoint` helpers are removed so UNSPECIFIED can no longer leak through any lowering path.
- **§6.5 fragmentation instrumentation** — 14 new fields on `osty_gc_stats` consolidate the free-list / humongous / bump aggregates that already had scalar accessors, plus three extra lines in the human-readable dump.

## Why

The doc marks §2.4 and §8.3 as P2 and §6.5 as P3 diagnostic. Each gap was modest individually but the doc overstated completeness — the PR #618 session exposed the same pattern ("✅ in doc but not in code") for Phase D compaction. This batch closes the three that were actionable with runtime machinery already in place or requiring a very short patch.

## What changed

Per commit:

1. `feat(llvmgen): closure captures accept managed pointer types`
   - `captureSlotsFromIR` falls through to a new `managedPtrLLVMTypeForIR` helper for String / Bytes / List / Map / Set.
   - User struct captures still bail (site-dependent by-value vs. by-ptr).
   - New `TestClosureLiftCapturingStringLocal`.

2. `refactor(llvmgen): close the UNSPECIFIED safepoint-kind leak`
   - `expr.go:5793` (emitMapIterate) and `stmt.go:2839` / `2987` (emitMapRetainIfStmt / emitMapFor) tag LOOP instead of UNSPECIFIED.
   - Dead `emitGCSafepoint` helpers removed from `generator.go` and `mir_generator.go`.
   - New `TestGenerateFromASTMapForEntriesTagsLoopKind`.

3. `feat(runtime): consolidate fragmentation counters into gc_stats snapshot`
   - 14 new fields on `osty_gc_stats` (free-list 4 / humongous 4 / bump aggregates 6).
   - Populated under the GC lock in `osty_gc_debug_stats`; dump extended with three readable lines.
   - New `TestBundledRuntimeStatsFragmentation`.

## Test plan

- [x] `go test ./internal/llvmgen/ -run "TestClosureLiftCapturingStringLocal|TestGenerateFromASTMapForEntriesTagsLoopKind"` — passes.
- [x] `go test ./internal/backend/ -run "TestBundledRuntimeStatsFragmentation"` — passes with clang available.
- [x] `go test ./internal/llvmgen/ -run "^Test[^G]|^TestG[^o]"` — full llvmgen clean (excluding pre-existing `TestGoGenerateSupportSnapshotIsFixedPoint` baseline failure).
- [x] `go test ./internal/backend/ -short` — only pre-existing failure (`TryEmitNativeOwnedLLVMIRText` coalesce fallback, confirmed on baseline via `git stash`).
- [x] Existing `TestBundledRuntimeStatsSnapshot` struct layout extended so field blits still land in bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)