### PR TITLE
refactor: astbridge-free CheckSourceStructured + CheckPackageStructured via arena gate

### DIFF
--- a/internal/selfhost/check_adapter_test.go
+++ b/internal/selfhost/check_adapter_test.go
@@ -98,11 +98,88 @@ func TestCheckStructuredFromRunIsAstbridgeFree(t *testing.T) {
 	}
 }
 
+// TestCheckSourceStructuredIsAstbridgeFree extends the zero-astbridge
+// guarantee to CheckSourceStructured: after porting the gate adapter
+// (selfhostAppendIntrinsicBodyGateForSource) to the AstArena walker,
+// the full source-based check path — lex, parse, native check, gate —
+// runs without triggering astLowerPublicFile. Regression net against
+// the gate adapter silently falling back to *ast.File.
+func TestCheckSourceStructuredIsAstbridgeFree(t *testing.T) {
+	src := []byte(`#[intrinsic]
+fn bad() -> Int {
+    42
+}
+
+fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`)
+	ResetAstbridgeLowerCount()
+
+	_ = CheckSourceStructured(src)
+	if got := AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("CheckSourceStructured: AstbridgeLowerCount = %d, want 0 (arena gate must not touch astbridge)", got)
+	}
+
+	_ = CheckSourceStructured(src)
+	if got := AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("second CheckSourceStructured: AstbridgeLowerCount = %d, want 0", got)
+	}
+}
+
+// TestCheckPackageStructuredIsAstbridgeFree is the multi-file analogue.
+// The gate adapter re-parses each file's source into a fresh arena
+// (selfhostAppendIntrinsicBodyGateForPackage uses Run per file), so
+// no *ast.File lowering happens even with the Direct-path input.
+func TestCheckPackageStructuredIsAstbridgeFree(t *testing.T) {
+	aSrc := []byte(`pub fn helper() -> Int { 1 }
+`)
+	bSrc := []byte(`#[intrinsic]
+fn bad() -> Int {
+    42
+}
+
+fn main() {
+    let _ = helper()
+}
+`)
+	input := PackageCheckInput{
+		Files: []PackageCheckFile{
+			{Source: aSrc, Name: "a.osty", Path: "a.osty", Base: 0},
+			{Source: bSrc, Name: "b.osty", Path: "b.osty", Base: len(aSrc) + 1},
+		},
+	}
+
+	ResetAstbridgeLowerCount()
+
+	result, err := CheckPackageStructured(input)
+	if err != nil {
+		t.Fatalf("CheckPackageStructured: %v", err)
+	}
+	if got := AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("CheckPackageStructured: AstbridgeLowerCount = %d, want 0", got)
+	}
+
+	// Sanity: the intrinsic violation in b.osty surfaces as a
+	// diagnostic, proving the gate walker actually ran.
+	foundIntrinsic := false
+	for _, d := range result.Diagnostics {
+		if d.Code == "E0773" { // diag.CodeIntrinsicNonEmptyBody
+			foundIntrinsic = true
+			break
+		}
+	}
+	if !foundIntrinsic {
+		t.Fatalf("expected CodeIntrinsicNonEmptyBody diagnostic, got %#v", result.Diagnostics)
+	}
+}
+
 // TestCheckStructuredFromRunIntrinsicGateEquivalence cross-checks the
-// arena gate walker against the legacy *ast.File walker. Both must
-// flag the same `#[intrinsic]` non-empty-body violation with identical
-// code, offsets, and notes, even in the presence of methods, use-go
-// bodies, and multi-annotation groups.
+// Run-based and source-based gate adapters produce identical output
+// across representative shapes: both now walk AstArena, so the
+// invariant is that they stay synchronized.
 func TestCheckStructuredFromRunIntrinsicGateEquivalence(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/selfhost/gate_adapter.go
+++ b/internal/selfhost/gate_adapter.go
@@ -3,7 +3,6 @@ package selfhost
 import (
 	"strings"
 
-	"github.com/osty/osty/internal/ast"
 	"github.com/osty/osty/internal/diag"
 )
 
@@ -17,11 +16,15 @@ func selfhostAppendIntrinsicBodyGateForSource(result *CheckResult, src []byte) {
 	if result == nil || len(src) == 0 {
 		return
 	}
-	file, parseDiags := Parse(src)
-	if file == nil || selfhostHasErrorDiagnostics(parseDiags) {
+	run := Run(src)
+	if selfhostHasErrorDiagnostics(run.Diagnostics()) {
 		return
 	}
-	selfhostMergeDiagnosticRecords(result, selfhostIntrinsicBodyDiagnostics(file, 0, "")...)
+	if run.parser == nil || run.parser.arena == nil {
+		return
+	}
+	records := selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, 0, "")
+	selfhostMergeDiagnosticRecords(result, records...)
 }
 
 // selfhostAppendIntrinsicBodyGateForRun is the FrontendRun-aware
@@ -185,11 +188,14 @@ func selfhostAppendIntrinsicBodyGateForPackage(result *CheckResult, input Packag
 		if len(file.Source) == 0 {
 			continue
 		}
-		parsed, parseDiags := Parse(file.Source)
-		if parsed == nil || selfhostHasErrorDiagnostics(parseDiags) {
+		run := Run(file.Source)
+		if selfhostHasErrorDiagnostics(run.Diagnostics()) {
 			continue
 		}
-		records = append(records, selfhostIntrinsicBodyDiagnostics(parsed, file.Base, file.Path)...)
+		if run.parser == nil || run.parser.arena == nil {
+			continue
+		}
+		records = append(records, selfhostIntrinsicBodyDiagnosticsFromArena(run.parser.arena, run.rt, run.stream, file.Base, file.Path)...)
 	}
 	selfhostMergeDiagnosticRecords(result, records...)
 }
@@ -197,85 +203,6 @@ func selfhostAppendIntrinsicBodyGateForPackage(result *CheckResult, input Packag
 func selfhostHasErrorDiagnostics(diags []*diag.Diagnostic) bool {
 	for _, d := range diags {
 		if d != nil && d.Severity == diag.Error {
-			return true
-		}
-	}
-	return false
-}
-
-func selfhostIntrinsicBodyDiagnostics(file *ast.File, base int, path string) []CheckDiagnosticRecord {
-	if file == nil {
-		return nil
-	}
-	var out []CheckDiagnosticRecord
-	for _, decl := range file.Decls {
-		switch d := decl.(type) {
-		case *ast.FnDecl:
-			if rec := selfhostIntrinsicBodyRecord(d, base, path); rec != nil {
-				out = append(out, *rec)
-			}
-		case *ast.StructDecl:
-			selfhostAppendIntrinsicBodyMethodRecords(&out, d.Methods, base, path)
-		case *ast.EnumDecl:
-			selfhostAppendIntrinsicBodyMethodRecords(&out, d.Methods, base, path)
-		case *ast.UseDecl:
-			for _, member := range d.GoBody {
-				switch m := member.(type) {
-				case *ast.FnDecl:
-					if rec := selfhostIntrinsicBodyRecord(m, base, path); rec != nil {
-						out = append(out, *rec)
-					}
-				case *ast.StructDecl:
-					selfhostAppendIntrinsicBodyMethodRecords(&out, m.Methods, base, path)
-				case *ast.EnumDecl:
-					selfhostAppendIntrinsicBodyMethodRecords(&out, m.Methods, base, path)
-				}
-			}
-		}
-	}
-	return out
-}
-
-func selfhostAppendIntrinsicBodyMethodRecords(out *[]CheckDiagnosticRecord, methods []*ast.FnDecl, base int, path string) {
-	if out == nil {
-		return
-	}
-	for _, method := range methods {
-		if rec := selfhostIntrinsicBodyRecord(method, base, path); rec != nil {
-			*out = append(*out, *rec)
-		}
-	}
-}
-
-func selfhostIntrinsicBodyRecord(fn *ast.FnDecl, base int, path string) *CheckDiagnosticRecord {
-	if fn == nil || !selfhostHasAnnotation(fn.Annotations, "intrinsic") {
-		return nil
-	}
-	if fn.Body == nil || len(fn.Body.Stmts) == 0 {
-		return nil
-	}
-	start := base + fn.Body.Pos().Offset
-	end := base + fn.Body.End().Offset
-	if end < start {
-		end = start
-	}
-	return &CheckDiagnosticRecord{
-		Code:     diag.CodeIntrinsicNonEmptyBody,
-		Severity: "error",
-		Message:  "`#[intrinsic]` function `" + fn.Name + "` must have an empty body",
-		Start:    start,
-		End:      end,
-		File:     path,
-		Notes: []string{
-			"LANG_SPEC §19.6: intrinsic implementations are supplied by the lowering layer; the source body is ignored",
-			"hint: keep the signature and drop the body, or use `{}`",
-		},
-	}
-}
-
-func selfhostHasAnnotation(annots []*ast.Annotation, name string) bool {
-	for _, annot := range annots {
-		if annot != nil && annot.Name == name {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to [#623](https://github.com/choiceoh/osty/pull/623). The single-source and package-scoped check entry points now route their intrinsic-body gate through the AstArena walker (`selfhostIntrinsicBodyDiagnosticsFromArena`) instead of the legacy `*ast.File` walker. Result: **every public native check entry point** — `CheckSourceStructured`, `CheckStructuredFromRun`, `CheckPackageStructured` — produces zero astbridge (`runtime.golegacy.astbridge`) lowerings on clean input.

## What changed

- `selfhostAppendIntrinsicBodyGateForSource` — switches from `Parse(src)` (which forced one astbridge lowering per call via `run.File()`) to `Run(src)` + the arena walker. Same two-pass cost as before minus the `.File()` trigger.
- `selfhostAppendIntrinsicBodyGateForPackage` — does the same per file. An N-file package previously bumped the counter N times; now it bumps zero.
- Legacy `*ast.File`-based helpers deleted (no callers remain):
  - `selfhostIntrinsicBodyDiagnostics`
  - `selfhostAppendIntrinsicBodyMethodRecords`
  - `selfhostIntrinsicBodyRecord`
  - `selfhostHasAnnotation`
- Unused `internal/ast` import removed.

## Why

PR #623 closed `CheckStructuredFromRun`'s last astbridge bump (the intrinsic-body gate that walked `*ast.File`). The source-based and package-based siblings (`CheckSourceStructured`, `CheckPackageStructured`) were still on the legacy walker and still bumped the counter — 1 per call for source, N per call for package. This PR brings them onto the same arena walker so the whole native check surface is astbridge-free in a single, uniform way.

After this PR, every `*ast.File` lowering in the compiler comes from explicit consumers that genuinely need the Go AST (`check.File`, `lint.File`, `bootstrap/gen`, LSP) or from loader fallbacks (`pkg.EnsureFiles()`), not from the native-check bootstrap path.

## Proof

Counter-based regression tests pin the invariant:

```
// single-source, with #[intrinsic] + plain fn
CheckSourceStructured(src)               → AstbridgeLowerCount == 0  ✓
CheckSourceStructured(src) again         → AstbridgeLowerCount == 0  ✓

// multi-file package, intrinsic violation in b.osty
CheckPackageStructured({a.osty, b.osty}) → AstbridgeLowerCount == 0  ✓
  + sanity: E0773 diagnostic still surfaces (gate walker actually ran)
```

Existing equivalence tests (top-level intrinsic, struct method, empty body, non-intrinsic) cross-check `CheckStructuredFromRun` against `CheckSourceStructured` byte-for-byte — both sides now on the arena path.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/selfhost/ ./internal/check/... ./internal/resolve/... ./cmd/osty/`
- [x] New: `TestCheckSourceStructuredIsAstbridgeFree`, `TestCheckPackageStructuredIsAstbridgeFree`
- [x] Existing: `TestCheckStructuredFromRunMatchesCheckSourceStructured`, `TestCheckStructuredFromRunIsAstbridgeFree`, `TestCheckStructuredFromRunIntrinsicGateEquivalence` all green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)