### PR TITLE
fix(runtime): rename bump_block_count_total → bump_block_count

### DIFF
--- a/internal/backend/llvm_runtime_gc_test.go
+++ b/internal/backend/llvm_runtime_gc_test.go
@@ -730,7 +730,7 @@ typedef struct osty_gc_stats {
     int64_t humongous_alloc_bytes_total;
     int64_t humongous_swept_count_total;
     int64_t humongous_swept_bytes_total;
-    int64_t bump_block_count_total;
+    int64_t bump_block_count;
     int64_t bump_block_bytes_total;
     int64_t bump_alloc_count_total;
     int64_t bump_alloc_bytes_total;
@@ -902,7 +902,7 @@ typedef struct osty_gc_stats {
     int64_t humongous_alloc_bytes_total;
     int64_t humongous_swept_count_total;
     int64_t humongous_swept_bytes_total;
-    int64_t bump_block_count_total;
+    int64_t bump_block_count;
     int64_t bump_block_bytes_total;
     int64_t bump_alloc_count_total;
     int64_t bump_alloc_bytes_total;

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -7179,6 +7179,18 @@ static void osty_rt_enum_ptr_payload_trace(void *payload) {
  * capture values (scalars that the Osty frontend stores as raw bits
  * inside the slot) are handled transparently because `mark_slot_v1`
  * filters through `find_header`.
+ *
+ * Correctness caveat: `find_header` identifies real heap payloads by
+ * pointer, so a scalar capture whose 8-byte bit pattern happens to
+ * collide with a live payload address will be treated as a reachable
+ * pointer and keep that object alive for one extra cycle. On a 64-bit
+ * host typical IEEE-754 doubles and small integers do not alias heap
+ * addresses (heap sits in the high half of user space; small doubles
+ * have exponent bits 0x3F…, small ints sit below 0x0001…), so the
+ * collision probability is effectively zero in practice — but the
+ * guarantee is probabilistic, not structural. A follow-up that stores
+ * a per-capture kind bitmap would close this to a structural
+ * guarantee; today's code chooses the simpler self-describing layout.
  */
 static void osty_rt_closure_env_trace(void *payload) {
     osty_rt_closure_env *env = (osty_rt_closure_env *)payload;
@@ -8160,7 +8172,12 @@ typedef struct osty_gc_stats {
     int64_t humongous_alloc_bytes_total;
     int64_t humongous_swept_count_total;
     int64_t humongous_swept_bytes_total;
-    int64_t bump_block_count_total;
+    /* bump_block_count is a live gauge — sum of currently allocated
+     * bump blocks across tiers. The per-tier statics decrement on
+     * recycle, so this reflects "blocks in flight", not a cumulative
+     * total. The remaining bump fields are monotonic totals (see
+     * `*_total` suffix); they only grow. */
+    int64_t bump_block_count;
     int64_t bump_block_bytes_total;
     int64_t bump_alloc_count_total;
     int64_t bump_alloc_bytes_total;
@@ -8223,7 +8240,7 @@ void osty_gc_debug_stats(osty_gc_stats *out) {
     out->humongous_alloc_bytes_total = osty_gc_humongous_alloc_bytes_total;
     out->humongous_swept_count_total = osty_gc_humongous_swept_count_total;
     out->humongous_swept_bytes_total = osty_gc_humongous_swept_bytes_total;
-    out->bump_block_count_total =
+    out->bump_block_count =
         osty_gc_bump_block_count +
         osty_gc_survivor_bump_block_count +
         osty_gc_old_bump_block_count +
@@ -8460,7 +8477,7 @@ void osty_gc_debug_stats_dump(FILE *out) {
             "  nursery:                 %lld / %lld bytes, promote_age=%lld\n"
             "  free list:               %lld chunks, %lld bytes (reused %lld / %lld B total)\n"
             "  humongous:               alloc %lld / %lld B, swept %lld / %lld B\n"
-            "  bump (all tiers):        %lld blocks, %lld B, alloc %lld / %lld B, recycled %lld blocks / %lld B\n"
+            "  bump (all tiers):        %lld blocks live, %lld B allocated for blocks (cumul), alloc %lld / %lld B, recycled %lld blocks / %lld B\n"
             "}\n",
             (long long)s.collection_count,
             (long long)s.live_count, (long long)s.live_bytes,
@@ -8492,7 +8509,7 @@ void osty_gc_debug_stats_dump(FILE *out) {
             (long long)s.humongous_alloc_bytes_total,
             (long long)s.humongous_swept_count_total,
             (long long)s.humongous_swept_bytes_total,
-            (long long)s.bump_block_count_total,
+            (long long)s.bump_block_count,
             (long long)s.bump_block_bytes_total,
             (long long)s.bump_alloc_count_total,
             (long long)s.bump_alloc_bytes_total,


### PR DESCRIPTION
## Summary

Post-merge audit of PR #624 (fragmentation stats) revealed a naming bug in the new `osty_gc_stats` fields I added. The `bump_block_count_total` field is a sum of per-tier **live** block counters, each of which decrements on recycle — so the `_total` suffix (which the rest of the struct reserves for monotonic cumulative values) misrepresents the semantics.

A consumer expecting monotonic growth would see the field shrink after a GC cycle that recycled empty blocks.

## What changed

- **Rename `bump_block_count_total` → `bump_block_count`.** The field is a live gauge, not a cumulative total. Sibling fields (`bump_block_bytes_total`, `bump_alloc_count_total`, `bump_recycled_block_count_total`, etc.) stay suffixed because those are genuinely monotonic.
- **Tighten the `osty_gc_debug_stats_dump` label** to "blocks live" vs. "B allocated for blocks (cumul)" so the reader can't misread the gauge as cumulative.
- **Update the two test harnesses** (`TestBundledRuntimeStatsSnapshot` and `TestBundledRuntimeStatsFragmentation`) that mirror the struct layout — `osty_gc_debug_stats(&s)` blits by offset, so any downstream struct must match.
- **Document a closure env trace caveat.** While auditing, I also flagged that `osty_rt_closure_env_trace` treats every capture slot as a potential managed pointer: scalar captures whose 8-byte bit pattern collides with a live heap payload would cause one-cycle false retention. On 64-bit hosts the collision probability is effectively zero (heap lives in the high half of user space; small ints / typical doubles sit elsewhere), but the guarantee is probabilistic, not structural. Comment flags a future per-capture-kind bitmap follow-up; no behavior change here.

## Why this is a fix, not a refactor

`osty_gc_stats` is an ABI: users blit the struct by offset via `osty_gc_debug_stats(&s)`. Any re-ordering breaks them. This rename changes the field name but **keeps the same offset and type**, so existing struct mirrors keep working once their field name is updated (both in-tree mirrors are updated in this PR). The change is safe because the field just landed in #624 and has no out-of-tree consumers yet.

## Test plan

- [x] `go test ./internal/backend/ -run TestBundledRuntimeStatsFragmentation` — passes.
- [x] `go build ./internal/backend/...` clean.
- [x] Pre-existing `TestBundledRuntimeStatsSnapshot` Windows `.exe` failure unchanged (orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)