### PR TITLE
refactor: extract runResolveFile + in-process astbridge CLI counter test

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -493,55 +493,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "resolve":
-		// Happy path: parse into a FrontendRun and drive resolve
-		// entirely through the self-host arena. The *ast.File lowering
-		// (and therefore the astbridge adapter) is only triggered when
-		// a fallback path needs it — --show-scopes still walks the Go
-		// resolver's Scope tree, so it lazily lowers via run.File()
-		// when asked.
-		run := parser.ParseRun(src)
-		parseDiags := run.Diagnostics()
-		var (
-			res  *resolve.Result
-			file *ast.File
-		)
-		ensureLoweredFile := func() *ast.File {
-			if file == nil {
-				file = run.File()
-			}
-			return file
-		}
-		ensureGoResolve := func() *resolve.Result {
-			if res == nil {
-				res = resolveFile(ensureLoweredFile())
-			}
-			return res
-		}
-		all := append([]*diag.Diagnostic{}, parseDiags...)
-		nativeDiags := nativeResolveFromRunDiagnostics(run, src, path)
-		all = append(all, nativeDiags...)
-		printDiags(formatter, all, flags)
-		if rows := nativeResolveFromRunRows(run, src, path); len(rows) > 0 {
-			printNativeResolutionRows(rows)
-		} else {
-			// Native pass produced no rows — fall back to the Go
-			// resolver for printResolution so empty-source or
-			// resolver-disagreement cases stay visible.
-			printResolution(ensureLoweredFile(), ensureGoResolve())
-		}
-		if flags.showScopes {
-			r := ensureGoResolve()
-			// File scope's parent is the package scope (a child of the
-			// prelude). Rooting the dump at the package scope hides
-			// noisy prelude builtins while still showing every
-			// user-declared symbol.
-			if pkgScope := r.FileScope.Parent(); pkgScope != nil {
-				printScopeTree(pkgScope)
-			} else {
-				printScopeTree(r.FileScope)
-			}
-		}
-		if hasError(all) {
+		if runResolveFile(path, src, formatter, flags) != 0 {
 			os.Exit(1)
 		}
 	case "lint":
@@ -913,6 +865,65 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 	case flags.fix:
 		fmt.Fprintf(os.Stderr, "%s --fix: applied %d fix(es), skipped %d overlap(s)\n", mode, totalApplied, totalSkipped)
 	}
+}
+
+// runResolveFile is the extracted body of `osty resolve FILE`. It
+// drives the single-file resolve happy path entirely through the
+// self-host arena (ParseRun → ResolveStructuredFromRun); `run.File()`
+// — the sole astbridge entry point on this side of the compiler — is
+// only materialized lazily when a fallback needs it (printResolution
+// with no native rows, or --show-scopes). Returns the subcommand's
+// exit code: 0 on clean input, 1 when any error-severity diagnostic
+// surfaces. Extracting this keeps the subcommand body testable in-
+// process so the astbridge counter can pin the end-to-end CLI
+// invariant (not just the library primitives).
+func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
+	run := parser.ParseRun(src)
+	parseDiags := run.Diagnostics()
+	var (
+		res  *resolve.Result
+		file *ast.File
+	)
+	ensureLoweredFile := func() *ast.File {
+		if file == nil {
+			file = run.File()
+		}
+		return file
+	}
+	ensureGoResolve := func() *resolve.Result {
+		if res == nil {
+			res = resolveFile(ensureLoweredFile())
+		}
+		return res
+	}
+	all := append([]*diag.Diagnostic{}, parseDiags...)
+	nativeDiags := nativeResolveFromRunDiagnostics(run, src, path)
+	all = append(all, nativeDiags...)
+	printDiags(formatter, all, flags)
+	if rows := nativeResolveFromRunRows(run, src, path); len(rows) > 0 {
+		printNativeResolutionRows(rows)
+	} else {
+		// Native pass produced no rows — fall back to the Go
+		// resolver for printResolution so empty-source or
+		// resolver-disagreement cases stay visible.
+		printResolution(ensureLoweredFile(), ensureGoResolve())
+	}
+	if flags.showScopes {
+		r := ensureGoResolve()
+		// File scope's parent is the package scope (a child of the
+		// prelude). Rooting the dump at the package scope hides
+		// noisy prelude builtins while still showing every
+		// user-declared symbol.
+		if pkgScope := r.FileScope.Parent(); pkgScope != nil {
+			printScopeTree(pkgScope)
+		} else {
+			printScopeTree(r.FileScope)
+		}
+	}
+	if hasError(all) {
+		return 1
+	}
+	return 0
 }
 
 // runResolvePackage is runCheckPackage plus a resolution dump per file.

--- a/cmd/osty/resolve_native_test.go
+++ b/cmd/osty/resolve_native_test.go
@@ -1,11 +1,68 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
 )
+
+// TestRunResolveFileHappyPathIsAstbridgeFree pins the end-to-end CLI
+// invariant: the extracted runResolveFile body that powers `osty
+// resolve FILE` must not trigger a single astLowerPublicFile call on
+// clean input. This catches CLI-layer regressions that the library
+// primitive tests (ResolveStructuredFromRun, LoadPackageForNative)
+// cannot see on their own — any accidentally-added run.File() inside
+// the subcommand body would fail this test.
+//
+// Stdout is redirected to discard so the subcommand's normal ref/diag
+// rendering doesn't pollute go test output; the counter assertion is
+// the actual invariant under test.
+func TestRunResolveFileHappyPathIsAstbridgeFree(t *testing.T) {
+	src := []byte(`fn helper(x: Int) -> Int {
+    x
+}
+
+fn main() {
+    let value = helper(1)
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	flags := cliFlags{noColor: true}
+	formatter := newFormatter(path, src, flags)
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		_, _ = io.Copy(io.Discard, r)
+	}()
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runResolveFile(path, src, formatter, flags)
+	_ = w.Close()
+	<-drained
+
+	if exit != 0 {
+		t.Fatalf("runResolveFile exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runResolveFile happy path = %d, want 0 (any non-zero means the CLI body regressed into a *ast.File detour)", got)
+	}
+}
 
 func TestResolveCLISingleFilePrintsNativeResolutionRows(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

The library-level counter tests (`ResolveStructuredFromRun`, `LoadPackageForNative`, `CheckSourceStructured`) pin the primitive guarantees, but they don't cover the CLI routing itself. Any accidental `run.File()` slipped into the `case \"resolve\"` body would quietly regress the astbridge-free invariant while every existing test still passes. This PR extracts the subcommand body into a testable `runResolveFile` function and adds the first **in-process** CLI counter assertion.

## What changed

- `cmd/osty/main.go:runResolveFile(path, src, formatter, flags) int` — exact same logic as the previous inline `case \"resolve\"` body, returning an exit code (0 clean / 1 on error-severity diagnostic) instead of calling `os.Exit`. The `case \"resolve\"` site shrinks to a thin wrapper that still exits on non-zero.
- `cmd/osty/resolve_native_test.go:TestRunResolveFileHappyPathIsAstbridgeFree` — clean multi-decl source, calls `runResolveFile` in-process with stdout redirected to `io.Discard`, asserts `selfhost.AstbridgeLowerCount() == 0` after the call.

The previous subprocess-based `TestResolveCLI*` tests still pass unchanged — they validate stdout/stderr output and exit codes, while the new in-process test specifically pins the astbridge counter invariant.

## Why

PRs [#621](https://github.com/choiceoh/osty/pull/621), [#623](https://github.com/choiceoh/osty/pull/623), and [#626](https://github.com/choiceoh/osty/pull/626) made the underlying library primitives astbridge-free (0 `astLowerPublicFile` bumps). But the counter tests live inside `internal/selfhost` and `internal/resolve` — they exercise the library, not the CLI. There was a visibility gap: a regression in the CLI wiring (e.g., adding a `run.File()` call to `case \"resolve\"`) would not trip any existing test, even though it would reintroduce astbridge traffic end-to-end.

Extracting the subcommand body into a normal function closes that gap — the new test imports `selfhost.AstbridgeLowerCount` and asserts directly on the CLI path. Future CLI wedges (`osty check --native`, etc.) will reuse the same pattern.

## Proof

```
// new in-process test
runResolveFile(path, src, formatter, flags) exit = 0  ✓
AstbridgeLowerCount() == 0 after runResolveFile      ✓

// existing subprocess tests unchanged
TestResolveCLISingleFilePrintsNativeResolutionRows   ✓
TestResolveCLIPackagePrintsNativeCrossFileResolutionRows ✓
TestResolveCLISingleFilePrintsNativeDiagnostics      ✓
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/resolve/...`
- [x] New: `TestRunResolveFileHappyPathIsAstbridgeFree`
- [x] Existing: all three `TestResolveCLI*` tests still green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)