### PR TITLE
perf: skip list bounds-check on provably-safe loop accesses

### DIFF
--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -307,7 +307,7 @@ func llvmNativePrimeScalarListParamFastPath(emitter *LlvmEmitter, paramName, ele
 	emitter.nativeListLens[paramName] = llvmListLen(emitter, list)
 }
 
-func llvmNativeFastScalarListIndex(emitter *LlvmEmitter, paramName string, index *LlvmValue, elemLLVM string) *LlvmValue {
+func llvmNativeFastScalarListIndex(emitter *LlvmEmitter, paramName, idxName string, idxAddend int, index *LlvmValue, elemLLVM string) *LlvmValue {
 	if emitter == nil || paramName == "" || index == nil || index.typ != "i64" || !listUsesRawDataFastPath(elemLLVM) {
 		return nil
 	}
@@ -316,6 +316,20 @@ func llvmNativeFastScalarListIndex(emitter *LlvmEmitter, paramName string, index
 	list := llvmIdent(emitter, paramName)
 	if data == nil || length == nil || list == nil || list.typ != "ptr" {
 		return nil
+	}
+	// Proven-safe path: bounds analysis (see helpers above) has shown
+	// that `paramName[idxName + idxAddend]` cannot go out of bounds
+	// inside the enclosing loop. Emit a plain GEP+load — no
+	// per-iteration check, no slow-path call. This is the shape
+	// LLVM's LoopVectorizer requires; clang -O2 then collapses the
+	// surrounding scalar loop into vector ops on simd-friendly
+	// bodies.
+	if llvmNativeIsSafeListAccess(emitter, paramName, idxName, idxAddend) {
+		elemPtr := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = getelementptr inbounds %s, ptr %s, i64 %s", elemPtr, elemLLVM, data.name, index.name))
+		fastValue := llvmNextTemp(emitter)
+		emitter.body = append(emitter.body, fmt.Sprintf("  %s = load %s, ptr %s", fastValue, elemLLVM, elemPtr))
+		return &LlvmValue{typ: elemLLVM, name: fastValue, pointer: false}
 	}
 	nonNegative := llvmCompare(emitter, "sge", index, llvmIntLiteral(0))
 	beforeEnd := llvmCompare(emitter, "slt", index, length)
@@ -429,10 +443,12 @@ func llvmNativeEmitStmt(emitter *LlvmEmitter, stmt *llvmNativeStmt) {
 		}
 	case llvmNativeStmtLet:
 		if len(stmt.childExprs) > 0 {
+			llvmNativeRecordBoundedLen(emitter, stmt.name, stmt.childExprs[0])
 			llvmImmutableLet(emitter, stmt.name, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
 		}
 	case llvmNativeStmtMutLet:
 		if len(stmt.childExprs) > 0 {
+			llvmNativeRecordBoundedLen(emitter, stmt.name, stmt.childExprs[0])
 			llvmMutableLet(emitter, stmt.name, llvmNativeEvalExpr(emitter, stmt.childExprs[0]))
 		}
 	case llvmNativeStmtAssign:
@@ -481,6 +497,18 @@ func llvmNativeEmitStmt(emitter *LlvmEmitter, stmt *llvmNativeStmt) {
 		}
 		start := llvmNativeEvalExpr(emitter, stmt.childExprs[0])
 		end := llvmNativeEvalExpr(emitter, stmt.childExprs[1])
+		// Bounds-analysis hook: when this loop's upper bound is
+		// derivable from `list.len()` for one or more list params (and
+		// the start is a non-negative literal), publish the (loopVar,
+		// list) pairs as safe so the body's `list[loopVar]` accesses
+		// can skip the runtime bounds-check branch. Inclusive (..=)
+		// loops let `i == N`, so they are excluded — only `..` is
+		// safe for indexing.
+		var safeForLists map[string]int
+		if !stmt.inclusive && llvmNativeRangeStartIsNonNegative(stmt.childExprs[0]) {
+			safeForLists = llvmNativeBoundedLensFor(emitter, stmt.childExprs[1])
+		}
+		llvmNativePushSafeIndices(emitter, stmt.name, safeForLists)
 		var loop *LlvmRangeLoop
 		if stmt.inclusive {
 			loop = llvmInclusiveRangeStart(emitter, stmt.name, start, end)
@@ -489,7 +517,314 @@ func llvmNativeEmitStmt(emitter *LlvmEmitter, stmt *llvmNativeStmt) {
 		}
 		_ = llvmNativeEmitBlock(emitter, stmt.childBlocks[0])
 		llvmRangeEnd(emitter, loop)
+		llvmNativePopSafeIndices(emitter, stmt.name)
 	}
+}
+
+// ==== bounds-analysis helpers ====
+//
+// Goal: prove that a particular `list[i]` access inside a `for i in
+// 0..N { ... }` loop body is in-bounds, so the per-iteration
+// bounds-check + slow-path call in llvmNativeFastScalarListIndex can
+// be skipped. The slow-path call is what blocks LLVM's LoopVectorizer
+// ("loop not vectorized: call instruction cannot be vectorized").
+//
+// The analysis is intentionally narrow — it pattern-matches two
+// shapes that cover the canonical numeric loops:
+//
+//   1. `for i in 0..list.len() { ... list[i] ... }`
+//
+//   2. `let n = if a.len() < b.len() { a.len() } else { b.len() }`
+//      `for i in 0..n { ... a[i]; b[i] ... }`  (canonical
+//      `min(a.len(), b.len())`).
+//
+// Anything more elaborate keeps the existing branched fast-path with
+// the runtime fallback so correctness is preserved.
+
+// llvmNativeRangeStartIsNonNegative reports whether the loop start
+// expression is provably ≥ 0. Today we accept literal integers — the
+// common `for i in 0..N` shape.
+func llvmNativeRangeStartIsNonNegative(expr *llvmNativeExpr) bool {
+	if expr == nil {
+		return false
+	}
+	if expr.kind != llvmNativeExprInt {
+		return false
+	}
+	return !strings.HasPrefix(strings.TrimSpace(expr.text), "-")
+}
+
+// llvmNativeBoundedLensFor returns, for each list-param name that
+// the expression's value is provably `<=` `name + k` of, the maximum
+// such `k`. nil means "no proven bound".
+func llvmNativeBoundedLensFor(emitter *LlvmEmitter, expr *llvmNativeExpr) map[string]int {
+	if expr == nil {
+		return nil
+	}
+	if list := llvmNativeListLenSource(expr); list != "" {
+		if _, ok := emitter.nativeListLens[list]; ok {
+			return map[string]int{list: 0}
+		}
+		return nil
+	}
+	if expr.kind == llvmNativeExprIdent {
+		if set := emitter.nativeBoundedLens[expr.name]; len(set) > 0 {
+			return cloneOffsetMap(set)
+		}
+		return nil
+	}
+	// `bound - K` (K a non-negative int literal): if `name` is
+	// `bounded by L with offset off` then `name - K` is bounded by
+	// `L with offset off + K`. Subtraction by a non-negative
+	// constant only ever makes the value smaller, never larger, so
+	// the inequality continues to hold.
+	if expr.kind == llvmNativeExprBinary && expr.op == "-" && len(expr.childExprs) == 2 {
+		k, ok := llvmNativeIntLiteralValue(expr.childExprs[1])
+		if !ok || k < 0 {
+			return nil
+		}
+		base := llvmNativeBoundedLensFor(emitter, expr.childExprs[0])
+		if len(base) == 0 {
+			return nil
+		}
+		out := make(map[string]int, len(base))
+		for l, off := range base {
+			out[l] = off + k
+		}
+		return out
+	}
+	return nil
+}
+
+// llvmNativeListLenSource returns the list-param name when expr is
+// `list.len()` for some param (i.e., a call to the runtime length
+// helper whose receiver is a plain ident). Returns "" otherwise.
+func llvmNativeListLenSource(expr *llvmNativeExpr) string {
+	if expr == nil || expr.kind != llvmNativeExprCall {
+		return ""
+	}
+	if expr.name != listRuntimeLenSymbol() {
+		return ""
+	}
+	if len(expr.childExprs) != 1 {
+		return ""
+	}
+	recv := expr.childExprs[0]
+	if recv == nil || recv.kind != llvmNativeExprIdent {
+		return ""
+	}
+	return recv.name
+}
+
+// llvmNativeRecordBoundedLen examines a `let name = expr` RHS for
+// one of the supported boundedness shapes and updates
+// emitter.nativeBoundedLens. Recognised shapes: direct
+// `list.len()`, identifier copy, subtraction-by-constant, and the
+// if-min diamond.
+func llvmNativeRecordBoundedLen(emitter *LlvmEmitter, name string, expr *llvmNativeExpr) {
+	if name == "" || expr == nil {
+		return
+	}
+	// First try the recursive helper that already knows how to read
+	// `list.len()`, ident copies, and `bound - K`. It returns a
+	// fully resolved offset map when applicable.
+	if bounded := llvmNativeBoundedLensFor(emitter, expr); len(bounded) > 0 {
+		emitter.nativeBoundedLens[name] = bounded
+		return
+	}
+	// `if cond { thenExpr } else { elseExpr }` where cond is an
+	// inequality between two `len(L1)` / `len(L2)` calls and each
+	// arm is one of those calls — the canonical min/max diamond.
+	// The result is `<= min(L1.len, L2.len)` which is `<=` both,
+	// with offset 0 for each.
+	if expr.kind != llvmNativeExprIf {
+		return
+	}
+	if len(expr.childExprs) < 1 || len(expr.childBlocks) < 2 {
+		return
+	}
+	cond := expr.childExprs[0]
+	thenLists := llvmNativeBlockResultLenSources(expr.childBlocks[0])
+	elseLists := llvmNativeBlockResultLenSources(expr.childBlocks[1])
+	if len(thenLists) == 0 || len(elseLists) == 0 {
+		return
+	}
+	condLists := llvmNativeCondLenSources(cond)
+	if len(condLists) < 2 {
+		return
+	}
+	condSet := map[string]bool{}
+	for _, l := range condLists {
+		condSet[l] = true
+	}
+	allDrawn := func(arm []string) bool {
+		for _, l := range arm {
+			if !condSet[l] {
+				return false
+			}
+		}
+		return len(arm) > 0
+	}
+	if !allDrawn(thenLists) || !allDrawn(elseLists) {
+		return
+	}
+	bounded := map[string]int{}
+	for l := range condSet {
+		bounded[l] = 0
+	}
+	emitter.nativeBoundedLens[name] = bounded
+}
+
+// llvmNativeBlockResultLenSources returns the list-param names whose
+// `.len()` produces the block's tail expression. Used to recognise
+// each arm of the if-min diamond.
+func llvmNativeBlockResultLenSources(block *llvmNativeBlock) []string {
+	if block == nil || !block.hasResult {
+		return nil
+	}
+	if list := llvmNativeListLenSource(block.result); list != "" {
+		return []string{list}
+	}
+	return nil
+}
+
+// llvmNativeCondLenSources extracts both list-param names from a
+// branch condition shaped as `len(L1) <op> len(L2)` for `<op>` in
+// {<, <=, >, >=}.
+func llvmNativeCondLenSources(expr *llvmNativeExpr) []string {
+	if expr == nil || expr.kind != llvmNativeExprBinary {
+		return nil
+	}
+	switch expr.op {
+	case "<", "<=", ">", ">=":
+	default:
+		return nil
+	}
+	if len(expr.childExprs) != 2 {
+		return nil
+	}
+	left := llvmNativeListLenSource(expr.childExprs[0])
+	right := llvmNativeListLenSource(expr.childExprs[1])
+	if left == "" || right == "" {
+		return nil
+	}
+	return []string{left, right}
+}
+
+// llvmNativePushSafeIndices marks (idxName, list) pairs as bounds-
+// safe for the body emission that follows. The map's value is the
+// maximum addend `k` for which `list[idxName + k]` is still proven
+// in-bounds; values can be 0. Pass nil to mean "no safety
+// established for this loop" — still call the matching pop so the
+// symbol is restored to its prior state cleanly.
+func llvmNativePushSafeIndices(emitter *LlvmEmitter, idxName string, lists map[string]int) {
+	if idxName == "" {
+		return
+	}
+	if len(lists) == 0 {
+		// Still record an empty entry so pop doesn't restore stale
+		// safety from an outer loop with the same loop-var name.
+		emitter.nativeSafeIndices[idxName] = nil
+		return
+	}
+	emitter.nativeSafeIndices[idxName] = cloneOffsetMap(lists)
+}
+
+// llvmNativePopSafeIndices clears the safe-index entry for the given
+// loop variable. The native AST has no nested scoping for loop names
+// in our current shape — peeling on body-end is sufficient.
+func llvmNativePopSafeIndices(emitter *LlvmEmitter, idxName string) {
+	if idxName == "" {
+		return
+	}
+	delete(emitter.nativeSafeIndices, idxName)
+}
+
+// llvmNativeIsSafeListAccess reports whether `paramName[idxName +
+// addend]` is proven in-bounds by the analysis above. idxName == ""
+// means the caller couldn't pin the index back to a source-level
+// identifier (e.g. an expression that isn't `loopvar` or
+// `loopvar + constant`); those keep the runtime check.
+func llvmNativeIsSafeListAccess(emitter *LlvmEmitter, paramName, idxName string, addend int) bool {
+	if paramName == "" || idxName == "" || addend < 0 {
+		return false
+	}
+	set := emitter.nativeSafeIndices[idxName]
+	maxOff, ok := set[paramName]
+	if !ok {
+		return false
+	}
+	return addend <= maxOff
+}
+
+// llvmNativeIntLiteralValue extracts the int value from a literal
+// integer expression. Used to recognise constant addends and
+// constant subtrahends.
+func llvmNativeIntLiteralValue(expr *llvmNativeExpr) (int, bool) {
+	if expr == nil || expr.kind != llvmNativeExprInt {
+		return 0, false
+	}
+	text := strings.ReplaceAll(strings.TrimSpace(expr.text), "_", "")
+	if text == "" {
+		return 0, false
+	}
+	// Handle a leading `+` for symmetry; reject `-` because callers
+	// want non-negative addends/subtrahends.
+	if text[0] == '+' {
+		text = text[1:]
+	}
+	if text == "" || text[0] == '-' {
+		return 0, false
+	}
+	var v int
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		v = v*10 + int(c-'0')
+	}
+	return v, true
+}
+
+// llvmNativeIndexIdentAndAddend deconstructs the index expression of
+// `list[idx]` into the source-level loop variable (if any) plus a
+// constant addend. Returns ("", 0, false) for shapes the analysis
+// can't lift safely. Recognised shapes:
+//
+//   - `i`               → ("i", 0, true)
+//   - `i + K`           → ("i", K, true) for K a non-negative int literal
+//   - `K + i`           → ("i", K, true)
+func llvmNativeIndexIdentAndAddend(expr *llvmNativeExpr) (string, int, bool) {
+	if expr == nil {
+		return "", 0, false
+	}
+	if expr.kind == llvmNativeExprIdent {
+		return expr.name, 0, true
+	}
+	if expr.kind != llvmNativeExprBinary || expr.op != "+" || len(expr.childExprs) != 2 {
+		return "", 0, false
+	}
+	left, right := expr.childExprs[0], expr.childExprs[1]
+	if left != nil && left.kind == llvmNativeExprIdent {
+		if k, ok := llvmNativeIntLiteralValue(right); ok {
+			return left.name, k, true
+		}
+	}
+	if right != nil && right.kind == llvmNativeExprIdent {
+		if k, ok := llvmNativeIntLiteralValue(left); ok {
+			return right.name, k, true
+		}
+	}
+	return "", 0, false
+}
+
+func cloneOffsetMap(in map[string]int) map[string]int {
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func llvmNativeAssignValue(emitter *LlvmEmitter, stmt *llvmNativeStmt) *LlvmValue {
@@ -622,8 +957,15 @@ func llvmNativeEvalListIndex(emitter *LlvmEmitter, expr *llvmNativeExpr) *LlvmVa
 		return llvmNativeZeroValue(expr.llvmType)
 	}
 	if base := expr.childExprs[0]; base != nil && base.kind == llvmNativeExprIdent && llvmListUsesTypedRuntime(expr.elemLLVMType) {
-		index := llvmNativeEvalExpr(emitter, expr.childExprs[1])
-		if fast := llvmNativeFastScalarListIndex(emitter, base.name, index, expr.elemLLVMType); fast != nil {
+		idxExpr := expr.childExprs[1]
+		// Decompose the index into `loopvar [+ constant]` so the
+		// fast-path can consult llvmNativeIsSafeListAccess(base,
+		// loopvar, addend) — covers `list[i]`, `list[i + 1]`,
+		// `list[i + 7]`, ... when the analysis has shown the loop's
+		// upper bound leaves room for that addend.
+		idxName, idxAddend, _ := llvmNativeIndexIdentAndAddend(idxExpr)
+		index := llvmNativeEvalExpr(emitter, idxExpr)
+		if fast := llvmNativeFastScalarListIndex(emitter, base.name, idxName, idxAddend, index, expr.elemLLVMType); fast != nil {
 			return fast
 		}
 	}

--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -77,6 +77,27 @@ type LlvmEmitter struct {
 	stringGlobals  []*LlvmStringGlobal
 	nativeListData map[string]*LlvmValue
 	nativeListLens map[string]*LlvmValue
+	// nativeBoundedLens records the offset slack `k` such that
+	// `name + k <= len(list_param)` for each (name, list_param) pair
+	// the analyser has proven a bound on. The unit is "scalar
+	// elements", matching the index space of `list[i]`. Single direct
+	// `let n = list.len()` populates `{list: 0}` (i.e. `n <=
+	// list.len()`); `let m = n - 7` then propagates to
+	// `{list: 7}` (i.e. `m + 7 <= list.len()`); the canonical
+	// `if a.len() < b.len() { a.len() } else { b.len() }` diamond
+	// populates both lists with offset 0.
+	//
+	// Consumed by the loop emitter: `for i in 0..bound` makes
+	// `safeOffset[i][L] = nativeBoundedLens[bound][L]`, which the
+	// list-index emitter uses to decide whether `L[i + k]` for a
+	// constant `k` is provably in-bounds.
+	nativeBoundedLens map[string]map[string]int
+	// nativeSafeIndices is the per-loop-body view of
+	// nativeBoundedLens: for each in-flight loop variable `i`,
+	// `nativeSafeIndices[i][L] = k` means `L[i + addend]` is safe
+	// for any constant `addend` in `[0, k]`. Cleared on loop-body
+	// exit.
+	nativeSafeIndices map[string]map[string]int
 }
 
 // Osty: toolchain/llvmgen.osty:56:5
@@ -113,14 +134,16 @@ type LlvmUnsupportedDiagnostic struct {
 // Osty: toolchain/llvmgen.osty:83:5
 func llvmEmitter() *LlvmEmitter {
 	return &LlvmEmitter{
-		temp:           0,
-		label:          0,
-		stringId:       0,
-		body:           make([]string, 0, 1),
-		locals:         make([]*LlvmBinding, 0, 1),
-		stringGlobals:  make([]*LlvmStringGlobal, 0, 1),
-		nativeListData: map[string]*LlvmValue{},
-		nativeListLens: map[string]*LlvmValue{},
+		temp:              0,
+		label:             0,
+		stringId:          0,
+		body:              make([]string, 0, 1),
+		locals:            make([]*LlvmBinding, 0, 1),
+		stringGlobals:     make([]*LlvmStringGlobal, 0, 1),
+		nativeListData:    map[string]*LlvmValue{},
+		nativeListLens:    map[string]*LlvmValue{},
+		nativeBoundedLens: map[string]map[string]int{},
+		nativeSafeIndices: map[string]map[string]int{},
 	}
 }
 
@@ -1488,11 +1511,24 @@ func llvmClangCompileObjectArgs(target string, irPath string, objectPath string)
 		// Osty: toolchain/llvmgen.osty:1178:9
 		func() struct{} { args = append(args, target); return struct{}{} }()
 	}
-	// Osty: toolchain/llvmgen.osty:1179:5 — baseline -O2 for production
-	// IR compilation. -O0 (the previous default) stranded every
+	// Osty: toolchain/llvmgen.osty:1179:5 — -O3 for production IR
+	// compilation. -O0 (the previous default) stranded every
 	// alloca/load/store emitted by the backend and disabled
-	// vectorization, adding ~100x on simd-friendly benches.
-	func() struct{} { args = append(args, "-O2"); return struct{}{} }()
+	// vectorization. -O3 over -O2 unlocks more aggressive
+	// vectorization on the cleaned-up bounds-check-free fast path.
+	func() struct{} { args = append(args, "-O3"); return struct{}{} }()
+	// x86-64-v3 (Haswell-era / AVX2 / FMA / BMI2) is the broadly-
+	// available baseline that LLVM's vectorizer can target with 4-wide
+	// i64 / 8-wide i32 SIMD. Without it the cost model defaults to
+	// SSE2 (width 2 for i64), leaving the bounds-check-free hot
+	// loops well below their potential. Targets that aren't x86-64
+	// (e.g. arm64) ignore this flag because LLVM only applies it to
+	// the matching backend; we still gate on target containing
+	// "x86_64" / "amd64" to avoid passing flags an unrelated backend
+	// might warn about.
+	if llvmStrings.Contains(target, "x86_64") || llvmStrings.Contains(target, "amd64") {
+		func() struct{} { args = append(args, "-march=x86-64-v3"); return struct{}{} }()
+	}
 	// Osty: toolchain/llvmgen.osty:1180:5
 	func() struct{} { args = append(args, "-c"); return struct{}{} }()
 	// Osty: toolchain/llvmgen.osty:1181:5

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -46,6 +46,23 @@ pub struct LlvmEmitter {
     pub body: List<String>,
     pub locals: List<LlvmBinding>,
     pub stringGlobals: List<LlvmStringGlobal>,
+    /// nativeBoundedLens records the offset slack `k` such that
+    /// `name + k <= len(list_param)` for each (name, list_param) pair
+    /// the analyser has proven a bound on. Single direct
+    /// `let n = list.len()` populates `{list: 0}`; `let m = n - 7`
+    /// then propagates to `{list: 7}`; the canonical
+    /// `if a.len() < b.len() { a.len() } else { b.len() }` diamond
+    /// populates both lists with offset 0. See
+    /// internal/llvmgen/native_entry_snapshot.go for the consuming
+    /// emitter helpers.
+    pub nativeBoundedLens: Map<String, Map<String, Int>>,
+    /// nativeSafeIndices is the per-loop-body view of
+    /// nativeBoundedLens: for each in-flight loop variable `i`,
+    /// `nativeSafeIndices[i][L] = k` means `L[i + addend]` is safe
+    /// for any constant `addend` in `[0, k]`. The list-index emitter
+    /// consults this to skip the runtime bounds-check branch — that
+    /// branch's slow-path call is what blocks LLVM's LoopVectorizer.
+    pub nativeSafeIndices: Map<String, Map<String, Int>>,
 }
 
 pub struct LlvmIfLabels {


### PR DESCRIPTION
## Summary

native-owned LLVM 백엔드는 매 list 인덱싱 사이트마다 per-iteration bounds-check + slow-path call (`osty_rt_list_get_*`) 분기를 emit 했는데, slow-path의 call이 LLVM `LoopVectorizer`를 차단합니다 (clang `-Rpass-analysis=loop-vectorize`: *"loop not vectorized: call instruction cannot be vectorized"*). 결과로 `#[vectorize]`가 default-on인 v0.6에서도 numeric 워크로드의 hot loop가 scalar로 머무릅니다.

이 PR: emitter에 보수적 loop-bound 추적 + per-loop safe-index 맵 추가. 분석이 안전하다고 증명한 `(list, idx)` pair만 plain `getelementptr inbounds` + `load`로 emit, 그 외는 기존 bounded path 유지.

## Recognised patterns

1. **단순 `for`-len 루프**: `for i in 0..list.len()` → `list[i]` 안전.
2. **Sliding window**: `for i in 0..(list.len() - K)` (K가 non-negative literal) → `list[i + 0]`, `list[i + 1]`, ..., `list[i + K]` 모두 안전.
3. **Min-diamond**: `let n = if a.len() < b.len() { a.len() } else { b.len() }` → `for i in 0..n` 에서 `a[i]`와 `b[i]` 둘 다 안전.
4. 위의 구성: `let m = n - 7`로 offset 누적 + ident 복사 forwarding.

데이터 표현은 `map[loopvar][listparam] = max safe addend k`. `let m = n - K` → `m`의 모든 list에 offset += K (subtraction-by-positive-const은 boundedness만 강화).

## IR effect on `simd_stats/analyzeSimdStats`

| 측정 | before | after |
|---|---|---|
| `list.raw.fast/slow` 분기 수 | 80 | 0 |
| LoopVectorizer 결과 (`-O3 -march=x86-64-v3`) | 1번째 루프만 width 2 | 두 루프 모두 width 4, interleave 2/1 |

## Bench (Windows, `--benchtime 500ms`)

| pair | go ns/op | osty ns/op | osty/go |
|---|---|---|---|
| lane_route | 11335 | 138200 | 12.19x |
| record_pipeline | 4738 | 83792 | 17.69x |
| simd_stats | 6912 | 518267 | 74.98x |

geomean osty/go: **25.85x → 25.18x** (이전 PR #619 -O2 baseline 대비).

## Additional change: -O3 + AVX2 baseline

clang IR 컴파일에 `-O2` → `-O3`, x86-64 타겟에 `-march=x86-64-v3` (AVX2/FMA/BMI2, broadly-available baseline) 추가. 이전 -O2 + SSE2 default는 i64 vectorization을 width 2로 제한했음. arm64 등은 영향 없음 (target string check로 게이트).

## Why simd_stats 시간이 평탄한가

bounds-check 80→0 + 벡터화 활성화에도 불구하고 simd_stats 절대 시간은 ~530µs에서 거의 안 변함. 함수 진입의 `osty_rt_list_data_i64` / `osty_rt_list_len` 호출 + GC 셋업 오버헤드가 cleaned-up inner loop보다 큰 것으로 보임. 본 PR은 향후 그 경로 개선 작업의 *전제조건* — bounds 분기가 inner loop을 막던 시절에는 어떤 외부 최적화도 효과를 못 봤음.

## Policy note

`native_entry_snapshot.go` 의 emit 코드는 hand-written Go (PR #616 기원). 동일 Osty 원본 없음. 이 PR은 Go 구현을 source-of-truth로 하고 `toolchain/llvmgen.osty`의 `LlvmEmitter` 필드 정의에 spec mirror만 추가. 다음 osty-bootstrap-gen 회수 사이클에서 helper 본문을 Osty로 흡수 예정.

## Out of scope

- runtime helper readonly attribute 추가 (`osty_rt_list_get_*`은 GC marking 으로 인해 readonly가 거짓말이라 부적합)
- 함수 진입 시 `list_data`/`list_len` 호출의 LICM/CSE 활성화 (별도 패스)
- 더 일반적인 range analysis (induction variable, multi-step propagation)

## Test plan

- [x] `go test ./internal/llvmgen/ -short` green
- [x] `osty gen --emit llvm-ir benchmarks/osty-vs-go/simd_stats/osty/simd_stats.osty` 출력에 `list.raw.fast/slow` 0건 확인
- [x] `clang -O3 -march=x86-64-v3 -Rpass=loop-vectorize` 두 loop 모두 vectorized 확인
- [x] osty-vs-go 3 longer 워크로드 정상 동작
- [ ] Linux/macOS 측정 (Windows-only fix 아님)
- [ ] 더 큰 코퍼스에서 회귀 없는지 (특히 unsafe 케이스 — 분석이 안전하지 않다고 판단해야 하는 패턴들)

🤖 Generated with [Claude Code](https://claude.com/claude-code)