### PR TITLE
feat: selfhost.CheckDiagnosticsAsDiag converter for native check output

### DIFF
--- a/internal/selfhost/check_diag_convert.go
+++ b/internal/selfhost/check_diag_convert.go
@@ -1,0 +1,107 @@
+package selfhost
+
+import (
+	"strings"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/token"
+)
+
+// CheckDiagnosticsAsDiag converts every CheckDiagnosticRecord in
+// result into a *diag.Diagnostic using src to recover 1-based
+// line/column positions from the byte offsets the native checker
+// produced. Records with empty code AND empty message are dropped
+// (they are signal-only placeholders). Severity, code, file, notes,
+// and the primary span are preserved verbatim so downstream renderers
+// and policy gates see the same shape whether they consumed the
+// native CheckResult directly or went through the Go check.Result
+// bridge.
+//
+// Callers that want per-record control should use
+// CheckDiagnosticRecordAsDiag instead and filter before conversion.
+func CheckDiagnosticsAsDiag(src []byte, records []CheckDiagnosticRecord) []*diag.Diagnostic {
+	out := make([]*diag.Diagnostic, 0, len(records))
+	for _, rec := range records {
+		if converted := CheckDiagnosticRecordAsDiag(src, rec); converted != nil {
+			out = append(out, converted)
+		}
+	}
+	return out
+}
+
+// CheckDiagnosticRecordAsDiag lifts one record into a *diag.Diagnostic.
+// Returns nil when both Code and Message are empty (so the caller's
+// filtered slice stays compact without a dedicated skip branch).
+//
+// Byte offsets outside src are clamped to the valid range — the
+// native checker occasionally reports a past-EOF end when the
+// originating token is the trailing EOF marker, and we'd rather emit
+// a clamped span than drop the diagnostic. Line/column come from a
+// single linear scan of src (no rune table needed; the native
+// checker's offsets are already byte-accurate).
+func CheckDiagnosticRecordAsDiag(src []byte, rec CheckDiagnosticRecord) *diag.Diagnostic {
+	if rec.Code == "" && rec.Message == "" {
+		return nil
+	}
+	severity := diag.Error
+	switch strings.ToLower(strings.TrimSpace(rec.Severity)) {
+	case "warning", "warn":
+		severity = diag.Warning
+	}
+	b := diag.New(severity, rec.Message)
+	if rec.Code != "" {
+		b = b.Code(rec.Code)
+	}
+	if rec.File != "" {
+		b = b.File(rec.File)
+	}
+	b = b.Primary(byteRangeSpanForDiag(src, rec.Start, rec.End), "")
+	for _, note := range rec.Notes {
+		if strings.TrimSpace(note) == "" {
+			continue
+		}
+		b = b.Note(note)
+	}
+	return b.Build()
+}
+
+// byteRangeSpanForDiag builds a diag.Span over the [start, end) byte
+// range in src. Mirrors internal/check/host_boundary.go:byteRangeSpan
+// so both entry points produce identical spans for equivalent input
+// — keep the two in sync.
+func byteRangeSpanForDiag(src []byte, start, end int) diag.Span {
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+	if len(src) == 0 {
+		p := token.Pos{Line: 1, Column: 1, Offset: 0}
+		return diag.Span{Start: p, End: p}
+	}
+	if start > len(src) {
+		start = len(src)
+	}
+	if end > len(src) {
+		end = len(src)
+	}
+	return diag.Span{
+		Start: positionAtOffsetForDiag(src, start),
+		End:   positionAtOffsetForDiag(src, end),
+	}
+}
+
+func positionAtOffsetForDiag(src []byte, offset int) token.Pos {
+	line := 1
+	col := 1
+	for i := 0; i < offset && i < len(src); i++ {
+		if src[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return token.Pos{Line: line, Column: col, Offset: offset}
+}

--- a/internal/selfhost/check_diag_convert_test.go
+++ b/internal/selfhost/check_diag_convert_test.go
@@ -1,0 +1,140 @@
+package selfhost_test
+
+import (
+	"testing"
+
+	"github.com/osty/osty/internal/diag"
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestCheckDiagnosticsAsDiagSurfacesIntrinsicViolation verifies the
+// end-to-end shape: running CheckSourceStructured on a source with an
+// `#[intrinsic]` non-empty-body violation produces a record that, after
+// conversion, renders as an *diag.Diagnostic with the expected code,
+// severity, primary span, and notes. This is the CLI-side contract
+// that future `osty check --native` wiring relies on.
+func TestCheckDiagnosticsAsDiagSurfacesIntrinsicViolation(t *testing.T) {
+	src := []byte(`#[intrinsic]
+fn bad() -> Int {
+    42
+}
+`)
+	checked := selfhost.CheckSourceStructured(src)
+	diags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
+	if len(diags) == 0 {
+		t.Fatalf("expected at least one diagnostic for intrinsic violation; got none (source diagnostics=%#v)", checked.Diagnostics)
+	}
+	var gate *diag.Diagnostic
+	for _, d := range diags {
+		if d != nil && d.Code == "E0773" {
+			gate = d
+			break
+		}
+	}
+	if gate == nil {
+		codes := make([]string, 0, len(diags))
+		for _, d := range diags {
+			if d != nil {
+				codes = append(codes, d.Code)
+			}
+		}
+		t.Fatalf("expected E0773 in converted diagnostics; got codes=%v", codes)
+	}
+	if gate.Severity != diag.Error {
+		t.Fatalf("E0773 severity = %v, want Error", gate.Severity)
+	}
+	if len(gate.Spans) == 0 {
+		t.Fatalf("E0773 has no spans; want primary span pointing at fn body")
+	}
+	// Body starts on line 2 (`fn bad() -> Int {`) per the source above;
+	// primary span should land somewhere inside the body block.
+	primary := gate.Spans[0]
+	if primary.Span.Start.Line < 2 {
+		t.Fatalf("primary span start line = %d, want ≥ 2 (fn body region)", primary.Span.Start.Line)
+	}
+	if len(gate.Notes) == 0 {
+		t.Fatalf("E0773 has no notes; want LANG_SPEC §19.6 note + hint")
+	}
+}
+
+// TestCheckDiagnosticsAsDiagDropsEmptyRecords documents the filter:
+// records with empty Code AND empty Message are signal-only and must
+// not produce a diagnostic. A well-formed record with only a Message
+// survives.
+func TestCheckDiagnosticsAsDiagDropsEmptyRecords(t *testing.T) {
+	records := []selfhost.CheckDiagnosticRecord{
+		{}, // empty — should be dropped
+		{Message: "message only"},
+		{Code: "Exxxx"}, // code only — survives
+	}
+	diags := selfhost.CheckDiagnosticsAsDiag([]byte("fn main() {}\n"), records)
+	if len(diags) != 2 {
+		t.Fatalf("got %d diagnostics, want 2 (empty record should be dropped)\n%#v", len(diags), diags)
+	}
+	if diags[0].Message != "message only" {
+		t.Fatalf("diags[0].Message = %q, want %q", diags[0].Message, "message only")
+	}
+	if diags[1].Code != "Exxxx" {
+		t.Fatalf("diags[1].Code = %q, want %q", diags[1].Code, "Exxxx")
+	}
+}
+
+// TestCheckDiagnosticsAsDiagIsAstbridgeFree pins the invariant that
+// record-to-diagnostic conversion — purely byte-offset → line/column
+// math plus struct shaping — never walks into astbridge. Combined
+// with the existing CheckSourceStructured / CheckStructuredFromRun
+// astbridge-free guarantees, this proves a future native CLI path
+// (parse → check → convert → print) stays at count == 0.
+func TestCheckDiagnosticsAsDiagIsAstbridgeFree(t *testing.T) {
+	src := []byte(`#[intrinsic]
+fn bad() -> Int { 42 }
+`)
+	checked := selfhost.CheckSourceStructured(src)
+
+	selfhost.ResetAstbridgeLowerCount()
+	diags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("CheckDiagnosticsAsDiag: AstbridgeLowerCount = %d, want 0", got)
+	}
+	if len(diags) == 0 {
+		t.Fatalf("expected at least one converted diagnostic")
+	}
+}
+
+// TestCheckDiagnosticRecordAsDiagSeverityMapping checks the severity
+// case-folding handles the self-host-emitted lowercase + the
+// convenience variants.
+func TestCheckDiagnosticRecordAsDiagSeverityMapping(t *testing.T) {
+	src := []byte("x")
+	cases := []struct {
+		severity string
+		want     diag.Severity
+	}{
+		{"error", diag.Error},
+		{"Error", diag.Error},
+		{"ERROR", diag.Error},
+		{"warning", diag.Warning},
+		{"warn", diag.Warning},
+		{"WARN", diag.Warning},
+		{"", diag.Error},    // default
+		{"info", diag.Error}, // unrecognized → default to Error (not silently downgraded)
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.severity, func(t *testing.T) {
+			got := selfhost.CheckDiagnosticRecordAsDiag(src, selfhost.CheckDiagnosticRecord{
+				Code:     "Exxxx",
+				Severity: tc.severity,
+				Message:  "m",
+				Start:    0,
+				End:      1,
+			})
+			if got == nil {
+				t.Fatalf("nil result")
+			}
+			if got.Severity != tc.want {
+				t.Fatalf("severity for %q = %v, want %v", tc.severity, got.Severity, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the missing piece for future `osty check --native` wiring: a public converter that lifts `selfhost.CheckDiagnosticRecord` values (what the native checker emits) into `*diag.Diagnostic` values (what the CLI formatter consumes).

Previously the equivalent conversion lived only inside `internal/check/host_boundary.go:convertNativeDiag` as an unexported helper, so any Osty→Go caller that wanted to print native diagnostics had to re-implement the byte-offset → line/column math and severity mapping. After this PR, a future CLI wedge can go **parse → native check → convert → print** with three existing helpers and stay astbridge-free end-to-end.

## What changed

- `selfhost.CheckDiagnosticsAsDiag(src []byte, records []CheckDiagnosticRecord) []*diag.Diagnostic` — batch converter. Skips records with empty Code AND empty Message.
- `selfhost.CheckDiagnosticRecordAsDiag(src []byte, rec CheckDiagnosticRecord) *diag.Diagnostic` — per-record entry point for callers that want custom filtering.
- `byteRangeSpanForDiag` / `positionAtOffsetForDiag` — local byte-offset → `token.Pos` math, mirroring `internal/check/host_boundary.go:byteRangeSpan` / `positionAtOffset`.

## Why

PRs [#621](https://github.com/choiceoh/osty/pull/621), [#623](https://github.com/choiceoh/osty/pull/623), [#626](https://github.com/choiceoh/osty/pull/626), and [#628](https://github.com/choiceoh/osty/pull/628) made every native resolve + check public API astbridge-free and extracted `runResolveFile` so the CLI resolve path is covered by an in-process counter test.

The natural next wedge is `osty check --native`: a CLI flag that drives check end-to-end through the arena (ParseRun → CheckStructuredFromRun → emit diagnostics). That was blocked on a public diagnostic converter — now unblocked.

## Proof

```
// intrinsic violation test
CheckSourceStructured(src where `#[intrinsic]` fn has a body)
  → checked.Diagnostics contains E0773 record
  → CheckDiagnosticsAsDiag(src, records) produces E0773 *diag.Diagnostic
     with Error severity, primary span inside fn body, LANG_SPEC §19.6 notes

// astbridge-free
CheckDiagnosticsAsDiag: AstbridgeLowerCount == 0  ✓

// filter correctness
empty record  → dropped
message-only  → kept
code-only     → kept

// severity mapping (8 sub-cases)
\"error\" / \"Error\" / \"ERROR\"   → diag.Error
\"warning\" / \"warn\" / \"WARN\"   → diag.Warning
\"\" (empty) / \"info\" (unknown)   → diag.Error (safe default)
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/selfhost/ ./internal/check/... ./internal/resolve/... ./cmd/osty/`
- [x] New: `TestCheckDiagnosticsAsDiagSurfacesIntrinsicViolation`, `TestCheckDiagnosticsAsDiagDropsEmptyRecords`, `TestCheckDiagnosticsAsDiagIsAstbridgeFree`, `TestCheckDiagnosticRecordAsDiagSeverityMapping` (8 sub-cases)

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

The converter intentionally duplicates — rather than delegates to — `internal/check/host_boundary.go:convertNativeDiag`. That function is package-private and tied to `nativeCheckDiagnostic` (same fields, different type). Unifying them would require moving the converter or the `nativeCheckDiagnostic` type across package boundaries, which is a bigger refactor than this PR's scope. A doc comment on `byteRangeSpanForDiag` flags the twin for future maintainers to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)