### PR TITLE
feat: osty check --native CLI path (astbridge-free check pipeline)

### DIFF
--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestCheckCLINativeCleanSourceExitsZero is the subprocess-level smoke
+// test: `osty check --native FILE` on well-typed input succeeds with
+// exit 0 and produces no error output. Validates end-to-end
+// invocation (flag parsing, dispatch, conversion, exit code) without
+// depending on the in-process counter.
+func TestCheckCLINativeCleanSourceExitsZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	got := runOstyCLI(t, "check", "--native", path)
+	if got.exit != 0 {
+		t.Fatalf("osty check --native exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[") {
+		t.Fatalf("stderr contained error output on clean source:\n%s", got.stderr)
+	}
+}
+
+// TestCheckCLINativeSurfacesIntrinsicViolation confirms the native
+// CLI path actually surfaces the `#[intrinsic]` non-empty-body gate
+// to stderr with the correct stable code (E0773). Exit code is 1.
+func TestCheckCLINativeSurfacesIntrinsicViolation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`#[intrinsic]
+fn bad() -> Int {
+    42
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	got := runOstyCLI(t, "check", "--native", path)
+	if got.exit != 1 {
+		t.Fatalf("osty check --native exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "error[E0773]") {
+		t.Fatalf("stderr missing E0773:\n%s", got.stderr)
+	}
+	if !strings.Contains(got.stderr, "intrinsic") {
+		t.Fatalf("stderr missing `intrinsic` in message:\n%s", got.stderr)
+	}
+}
+
+// TestCheckCLINativeRejectsInspectAndDumpFlags pins the flag
+// compatibility contract. --inspect / --dump-native-diags both probe
+// the Go check.Result shape, which --native never materializes, so
+// combining them is explicitly rejected at the dispatch site with
+// exit code 2.
+func TestCheckCLINativeRejectsInspectAndDumpFlags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	// --inspect and --dump-native-diags are declared as global flags
+	// in parseFlags(), so Go's flag package only recognizes them
+	// before the subcommand. Pre-subcommand placement is the normal
+	// user ergonomic for those flags; combining them with --native
+	// must still be rejected at the dispatch site.
+	for _, incompatible := range []string{"--inspect", "--dump-native-diags"} {
+		incompatible := incompatible
+		t.Run(incompatible, func(t *testing.T) {
+			got := runOstyCLI(t, incompatible, "check", "--native", path)
+			if got.exit != 2 {
+				t.Fatalf("exit = %d, want 2 (flag-incompatibility rejection)\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+			}
+			if !strings.Contains(got.stderr, "incompatible") {
+				t.Fatalf("stderr missing `incompatible` explanation:\n%s", got.stderr)
+			}
+		})
+	}
+}
+
+// TestRunCheckFileNativeIsAstbridgeFree is the in-process counter
+// test analog of TestRunResolveFileHappyPathIsAstbridgeFree. Proves
+// the --native CLI path produces zero astLowerPublicFile calls
+// end-to-end, including through CheckStructuredFromRun and the
+// CheckDiagnosticsAsDiag converter. Stdout redirected to discard so
+// printDiags output doesn't pollute test logs; the counter assertion
+// is the actual invariant.
+func TestRunCheckFileNativeIsAstbridgeFree(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true, native: true}
+	formatter := newFormatter(path, src, flags)
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+	origStderr := os.Stderr
+	re, we, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = we
+	t.Cleanup(func() { os.Stderr = origStderr })
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, r); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, re); drained <- struct{}{} }()
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runCheckFileNative(path, src, formatter, flags)
+	_ = w.Close()
+	_ = we.Close()
+	<-drained
+	<-drained
+
+	if exit != 0 {
+		t.Fatalf("runCheckFileNative exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runCheckFileNative = %d, want 0 (--native CLI path regressed into a *ast.File detour)", got)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -65,6 +65,7 @@ import (
 	"github.com/osty/osty/internal/resolve"
 	"github.com/osty/osty/internal/runner"
 	"github.com/osty/osty/internal/scaffold"
+	"github.com/osty/osty/internal/selfhost"
 	"github.com/osty/osty/internal/stdlib"
 	"github.com/osty/osty/internal/token"
 	"github.com/osty/osty/internal/types"
@@ -91,6 +92,14 @@ type cliFlags struct {
 	// once the native-checker boundary has been invoked. Off by default;
 	// nil-safe when the native checker was unavailable.
 	dumpNativeDiags bool
+	// native routes `check` through the self-host arena pipeline
+	// (ParseRun → CheckStructuredFromRun → CheckDiagnosticsAsDiag)
+	// instead of the Go-hosted resolve + check.File pair. The happy
+	// path never materializes *ast.File, so
+	// selfhost.AstbridgeLowerCount stays at 0 for the whole
+	// subcommand. Incompatible with --inspect / --dump-native-diags,
+	// which both probe the Go check.Result shape.
+	native bool
 	// suppressSummary silences the `N error(s), M warning(s)` trailer
 	// inside a single printDiags call. The package-diagnostic walker sets
 	// this per-file bucket and then prints one consolidated summary
@@ -300,6 +309,16 @@ func main() {
 			runCi(rest, flags)
 			return
 		}
+		// Allow `--native` after the subcommand so users can type
+		// `osty check --native FILE` (subcommand-local flag
+		// placement, matching how `lint` accepts `--fix` /
+		// `--strict`). Strip it from args so the downstream file-
+		// required check and subcommand dispatch still see
+		// positional-only input.
+		if rest, present := takeBoolFlag(args[1:], "--native"); present {
+			flags.native = true
+			args = append([]string{"check"}, rest...)
+		}
 	}
 	// explain looks up a diagnostic or lint code and prints its doc.
 	// Handled before the generic "file required" check because it
@@ -466,6 +485,16 @@ func main() {
 			os.Exit(1)
 		}
 	case "check":
+		if flags.native {
+			if flags.inspect || flags.dumpNativeDiags {
+				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+				os.Exit(2)
+			}
+			if runCheckFileNative(path, src, formatter, flags) != 0 {
+				os.Exit(1)
+			}
+			return
+		}
 		parsed := parser.ParseDetailed(src)
 		file, diags := parsed.File, parsed.Diagnostics
 		res := resolveFile(file)
@@ -568,6 +597,7 @@ func parseFlags() cliFlags {
 	flag.BoolVar(&f.explain, "explain", false, "after diagnostics, print the `osty explain CODE` text for each unique code")
 	flag.BoolVar(&f.inspect, "inspect", false, "check: emit one record per expression showing the inference rule, type, and hint (see LANG_SPEC_v0.5/02a-type-inference.md)")
 	flag.BoolVar(&f.dumpNativeDiags, "dump-native-diags", false, "check: after the run, print the native checker's per-context error histogram to stderr")
+	flag.BoolVar(&f.native, "native", false, "check: route through the self-host arena pipeline (astbridge-free); incompatible with --inspect and --dump-native-diags")
 	flag.Usage = usage
 	flag.Parse()
 	return f
@@ -877,6 +907,35 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 // surfaces. Extracting this keeps the subcommand body testable in-
 // process so the astbridge counter can pin the end-to-end CLI
 // invariant (not just the library primitives).
+// runCheckFileNative drives `osty check --native FILE` end-to-end on
+// the self-host arena pipeline: parser.ParseRun produces the
+// FrontendRun without lowering *ast.File, selfhost.CheckStructuredFromRun
+// runs the native checker directly on the arena (arena-direct gate
+// included), and selfhost.CheckDiagnosticsAsDiag lifts the structured
+// records into the CLI's usual diag.Diagnostic shape. Zero astbridge
+// lowerings on the happy path — the counter stays at 0 throughout,
+// pinned by TestRunCheckFileNativeIsAstbridgeFree. Returns the
+// subcommand's exit code (0 clean / 1 on any error-severity
+// diagnostic).
+func runCheckFileNative(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
+	run := parser.ParseRun(src)
+	parseDiags := run.Diagnostics()
+	checked := selfhost.CheckStructuredFromRun(run)
+	checkDiags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
+	for _, d := range checkDiags {
+		if d != nil && d.File == "" {
+			d.File = path
+		}
+	}
+	all := append([]*diag.Diagnostic{}, parseDiags...)
+	all = append(all, checkDiags...)
+	printDiags(formatter, all, flags)
+	if hasError(all) {
+		return 1
+	}
+	return 0
+}
+
 func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
 	run := parser.ParseRun(src)
 	parseDiags := run.Diagnostics()


### PR DESCRIPTION
## Summary

First user-facing consumer of `selfhost.CheckDiagnosticsAsDiag` (shipped in [#631](https://github.com/choiceoh/osty/pull/631)): adds a `--native` flag to `osty check FILE` that routes the subcommand entirely through the self-host arena pipeline. The happy path never materializes `*ast.File`, so `selfhost.AstbridgeLowerCount` stays at 0 for the entire run.

Pipeline:

```
parser.ParseRun(src)
  → selfhost.CheckStructuredFromRun(run)
    → selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
      → printDiags
```

## What changed

- `cliFlags.native` + `--native` flag registration in `parseFlags`.
- Subcommand-local flag placement: `osty check --native FILE` accepted via `takeBoolFlag`, matching the pattern `lint` already uses for `--fix` / `--strict`.
- `runCheckFileNative(path, src, formatter, flags) int` — the arena-pipeline CLI body. Stamps `d.File = path` on any diagnostic that arrived without a file, so renderers show the right location.
- `case \"check\"` dispatches to the native path when `flags.native` is set. Explicitly rejects `--inspect` and `--dump-native-diags` combinations (they probe the `check.Result` shape, which `--native` never builds) with exit code 2.

Legacy `osty check FILE` (without `--native`) is unchanged — still goes through the Go-native resolve + `check.File` pair. Users get the native path as an opt-in and can compare output before we flip any defaults.

## Why

PRs #621 / #623 / #626 / #628 / #631 built the arena-direct resolve + check primitives and the diagnostic converter. All the pieces were in place for a CLI consumer, but no user-facing path actually exercised them end-to-end. This PR lands that path: any user can now type `osty check --native FILE` and get a check run with zero astbridge traffic.

The `--native` flag also gives us an in-production anchor for the counter invariant — if a future refactor accidentally leaks `run.File()` into the check pipeline, `TestRunCheckFileNativeIsAstbridgeFree` fails immediately.

## Proof

**Subprocess tests** (end-to-end CLI behavior):

| Test | Input | Expected |
|---|---|---|
| `TestCheckCLINativeCleanSourceExitsZero` | clean `fn main()` body | exit 0, no error on stderr |
| `TestCheckCLINativeSurfacesIntrinsicViolation` | `#[intrinsic] fn bad() { 42 }` | `error[E0773]` on stderr, exit 1 |
| `TestCheckCLINativeRejectsInspectAndDumpFlags/--inspect` | `osty --inspect check --native FILE` | exit 2, \"incompatible\" in stderr |
| `TestCheckCLINativeRejectsInspectAndDumpFlags/--dump-native-diags` | same for the other flag | exit 2, \"incompatible\" in stderr |

**In-process counter test**:

```
selfhost.ResetAstbridgeLowerCount()
exit := runCheckFileNative(...)         // exit == 0
selfhost.AstbridgeLowerCount() == 0     ✓
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] All 5 new tests (3 subprocess + 1 in-process + 1 sub-case expansion) green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- `--native` accepts both global (`osty --native check FILE`) and subcommand-local (`osty check --native FILE`) placement. The test suite uses subcommand-local for the happy-path cases and global for the incompatibility cases (because `--inspect`/`--dump-native-diags` are declared only as global flags).
- This is a pure addition. No existing CLI behavior changes.
- Package mode (`osty check --native DIR`) is intentionally deferred — `runCheckPackage` has cross-file resolve + stdlib injection that needs a per-file rewire analogous to `runResolvePackage`'s `LoadPackageForNative` path. Targeted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)