### PR TITLE
feat: osty check --native DIR package path (astbridge-free)

### DIFF
--- a/cmd/osty/check_native_test.go
+++ b/cmd/osty/check_native_test.go
@@ -91,6 +91,128 @@ func TestCheckCLINativeRejectsInspectAndDumpFlags(t *testing.T) {
 	}
 }
 
+// TestCheckCLINativePackageCleanSourceExitsZero is the DIR sibling
+// of the single-file happy-path test. A two-file package (no cross-
+// file references) should pass `osty check --native DIR` with exit
+// 0 and no stderr error output.
+func TestCheckCLINativePackageCleanSourceExitsZero(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runOstyCLI(t, "check", "--native", dir)
+	if got.exit != 0 {
+		t.Fatalf("osty check --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[") {
+		t.Fatalf("stderr contained error output on clean package:\n%s", got.stderr)
+	}
+}
+
+// TestCheckCLINativePackageSurfacesPerFileIntrinsic confirms the
+// per-file diagnostic bucketing: an `#[intrinsic]` violation in the
+// second file must surface with E0773 and a span whose rendered path
+// points at b.osty (not the first file and not the bundled buffer).
+func TestCheckCLINativePackageSurfacesPerFileIntrinsic(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`#[intrinsic]
+fn bad() -> Int {
+    42
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runOstyCLI(t, "check", "--native", dir)
+	if got.exit != 1 {
+		t.Fatalf("exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "error[E0773]") {
+		t.Fatalf("stderr missing E0773:\n%s", got.stderr)
+	}
+	// printPackageDiags emits the file path in its rendered output.
+	// The intrinsic lives in b.osty only; a.osty is clean.
+	if !strings.Contains(got.stderr, "b.osty") {
+		t.Fatalf("stderr missing b.osty in diagnostic:\n%s", got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[E0773]") && strings.Contains(got.stderr, "a.osty:") {
+		t.Fatalf("stderr incorrectly attributed E0773 to a.osty:\n%s", got.stderr)
+	}
+}
+
+// TestRunCheckPackageNativeIsAstbridgeFree is the DIR in-process
+// counter test. LoadPackageForNative + CheckPackageStructured +
+// nativePackageCheckDiags + CheckDiagnosticsAsDiag must all leave
+// AstbridgeLowerCount at zero for a clean multi-file package. Pairs
+// with TestLoadPackageForNativeMultiFileIsAstbridgeFree (which only
+// covered the resolve side).
+func TestRunCheckPackageNativeIsAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	})
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runCheckPackageNative(dir, cliFlags{noColor: true, native: true})
+	_ = wout.Close()
+	_ = werr.Close()
+	<-drained
+	<-drained
+
+	if exit != 0 {
+		t.Fatalf("runCheckPackageNative exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runCheckPackageNative = %d, want 0 (DIR path regressed into *ast.File detour)", got)
+	}
+}
+
 // TestRunCheckFileNativeIsAstbridgeFree is the in-process counter
 // test analog of TestRunResolveFileHappyPathIsAstbridgeFree. Proves
 // the --native CLI path produces zero astLowerPublicFile calls

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -617,6 +617,24 @@ func parseFlags() cliFlags {
 // Diagnostics are rendered with each file's own formatter so source
 // snippets point at the right lines even when spanning packages.
 func runCheckPackage(dir string, flags cliFlags) {
+	if flags.native {
+		if flags.inspect || flags.dumpNativeDiags {
+			fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+			os.Exit(2)
+		}
+		// Workspace support under --native is deferred: it requires
+		// threading stdlib + cross-package imports into
+		// CheckPackageStructured's import surface. Single-package
+		// directories get the astbridge-free path immediately.
+		if isWorkspace(dir) {
+			fmt.Fprintf(os.Stderr, "osty: --native does not yet support workspace directories; run against a single package\n")
+			os.Exit(2)
+		}
+		if runCheckPackageNative(dir, flags) != 0 {
+			os.Exit(1)
+		}
+		return
+	}
 	// When dir (or any ancestor) contains osty.toml, validate it first:
 	// manifest errors (bad edition, empty workspace, etc.) surface
 	// before we descend into source files. A workspace manifest also
@@ -907,6 +925,101 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 // surfaces. Extracting this keeps the subcommand body testable in-
 // process so the astbridge counter can pin the end-to-end CLI
 // invariant (not just the library primitives).
+// runCheckPackageNative is the DIR sibling of runCheckFileNative.
+// Loads the package via LoadPackageForNative (no eager *ast.File
+// materialization), runs selfhost.CheckPackageStructured over the
+// arena, and converts the resulting CheckDiagnosticRecord slice into
+// per-file *diag.Diagnostic values so printPackageDiags keeps its
+// file-bucketed rendering. Workspace directories and import-surface
+// threading are not yet supported — the single-package happy path
+// runs astbridge-free end-to-end. Returns the subcommand exit code.
+func runCheckPackageNative(dir string, flags cliFlags) int {
+	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("check"), os.Stderr, flags))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
+		return 1
+	}
+	input := selfhost.PackageCheckInput{
+		Files: make([]selfhost.PackageCheckFile, 0, len(pkg.Files)),
+	}
+	base := 0
+	for _, pf := range pkg.Files {
+		if pf == nil || len(pf.Source) == 0 {
+			continue
+		}
+		name := filepath.Base(pf.Path)
+		input.Files = append(input.Files, selfhost.PackageCheckFile{
+			Source: append([]byte(nil), pf.Source...),
+			Base:   base,
+			Name:   name,
+			Path:   pf.Path,
+		})
+		base += len(pf.Source) + 1
+	}
+	checked, err := selfhost.CheckPackageStructured(input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty: native check: %v\n", err)
+		return 1
+	}
+	diags := packageParseDiags(pkg)
+	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
+	printPackageDiags(pkg, diags, flags)
+	if hasError(diags) {
+		return 1
+	}
+	return 0
+}
+
+// nativePackageCheckDiags buckets records by owning file (using the
+// layout bases CheckPackageStructured emitted against), relativizes
+// their offsets into each file's own source, and runs the per-file
+// converter so line/column numbers print against the right file —
+// not the concatenated bundle. Records that don't land inside any
+// file range (should not happen for well-formed output) are dropped
+// with their bundle offsets preserved as a defensive fallback.
+func nativePackageCheckDiags(records []selfhost.CheckDiagnosticRecord, files []selfhost.PackageCheckFile) []*diag.Diagnostic {
+	if len(records) == 0 || len(files) == 0 {
+		return nil
+	}
+	buckets := make(map[int][]selfhost.CheckDiagnosticRecord, len(files))
+	for _, rec := range records {
+		idx := findOwningFile(files, rec.Start)
+		if idx < 0 {
+			continue
+		}
+		rel := rec
+		rel.File = files[idx].Path
+		rel.Start -= files[idx].Base
+		rel.End -= files[idx].Base
+		if rel.Start < 0 {
+			rel.Start = 0
+		}
+		if rel.End < rel.Start {
+			rel.End = rel.Start
+		}
+		buckets[idx] = append(buckets[idx], rel)
+	}
+	out := make([]*diag.Diagnostic, 0, len(records))
+	for i := range files {
+		bucket, ok := buckets[i]
+		if !ok {
+			continue
+		}
+		out = append(out, selfhost.CheckDiagnosticsAsDiag(files[i].Source, bucket)...)
+	}
+	return out
+}
+
+func findOwningFile(files []selfhost.PackageCheckFile, offset int) int {
+	for i, f := range files {
+		end := f.Base + len(f.Source)
+		if offset >= f.Base && offset <= end {
+			return i
+		}
+	}
+	return -1
+}
+
 // runCheckFileNative drives `osty check --native FILE` end-to-end on
 // the self-host arena pipeline: parser.ParseRun produces the
 // FrontendRun without lowering *ast.File, selfhost.CheckStructuredFromRun


### PR DESCRIPTION
## Summary

Extends `--native` from FILE ([#632](https://github.com/choiceoh/osty/pull/632)) to DIR. Single-package directories now run the check subcommand entirely through the self-host arena pipeline: `resolve.LoadPackageForNative` loads the package without materializing `*ast.File`, `selfhost.CheckPackageStructured` runs the native checker over the merged arena, and a per-file diagnostic bucketizer relativizes bundle-space byte offsets back into each file's own source so line/column numbers render correctly.

## What changed

- `runCheckPackageNative(dir, flags) int` — the DIR sibling of `runCheckFileNative`. Builds a `PackageCheckInput` with per-file bases, runs the native checker, and converts the results through the new `nativePackageCheckDiags` helper.
- `nativePackageCheckDiags(records, files)` — buckets records by owning file via `findOwningFile` (locates the file whose `[Base, Base+len(Source)]` range covers the record's `Start`), relativizes `Start/End` to each file's own source, and runs the per-file converter so `printPackageDiags` keeps its file-bucketed rendering.
- `case \"check\"` DIR dispatch: when `flags.native` is set and the target is not a workspace, route to `runCheckPackageNative`. `--inspect` / `--dump-native-diags` combinations still exit 2 with an incompatibility message. Workspaces print an explicit \"not yet supported\" stderr — import-surface threading for cross-package `use` declarations is the follow-up.

## Why

[#632](https://github.com/choiceoh/osty/pull/632) gave `osty check` an astbridge-free single-file path but left DIR mode on the legacy `resolve.LoadPackage` + `check.Package` pair. This PR closes that gap using the `LoadPackageForNative` machinery from [#621](https://github.com/choiceoh/osty/pull/621) and the package-level native checker from prior `CheckPackageStructured` work.

After this PR both `osty check --native FILE` and `osty check --native DIR` run with zero `astLowerPublicFile` invocations end-to-end, matching the invariants already pinned for `osty resolve`.

## Proof

**Subprocess tests** (end-to-end CLI behavior):

| Test | Expected |
|---|---|
| `TestCheckCLINativePackageCleanSourceExitsZero` | two-file clean package → exit 0, no stderr error |
| `TestCheckCLINativePackageSurfacesPerFileIntrinsic` | `#[intrinsic]` in `b.osty` → `error[E0773]` attributed to `b.osty` (not `a.osty`), exit 1 |

**In-process counter test**:

```
selfhost.ResetAstbridgeLowerCount()
exit := runCheckPackageNative(dir, flags)       // exit == 0
selfhost.AstbridgeLowerCount() == 0             ✓
```

## Combined CLI coverage so far

| CLI path | Astbridge-free? |
|---|---|
| `osty resolve FILE` | ✅ |
| `osty resolve DIR` | ✅ |
| `osty check --native FILE` | ✅ |
| `osty check --native DIR` | ✅ (this PR) |
| `osty check FILE` (legacy) | ❌ (intentional) |
| `osty check --native WORKSPACE` | 🚧 (follow-up) |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] 3 new tests (2 subprocess + 1 in-process counter) green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- The per-file bucketizer is intentionally local to `cmd/osty` rather than promoted to `selfhost`. It only applies when the caller already knows the input-file layout; single-file callers use `CheckDiagnosticsAsDiag` directly. If a second consumer materializes we can factor out; for now inlined.
- Workspace support is deferred because `CheckPackageStructured`'s import-surface threading currently reads `pf.File.Decls` / `pf.File.Uses`. Porting that to the arena is meaningful work — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)