### PR TITLE
refactor: migrate ci.osty off use go onto runtime.cihost

### DIFF
--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -1920,7 +1920,7 @@ func llvmIsKnownRuntimeFfiPath(path string) bool {
 		// Osty: toolchain/llvmgen.osty:1549:9
 		return true
 	}
-	return path == "runtime.strings" || path == "runtime.path.filepath"
+	return path == "runtime.strings" || path == "runtime.path.filepath" || path == "runtime.cihost"
 }
 
 // Osty: toolchain/llvmgen.osty:1554:5

--- a/toolchain/ci.osty
+++ b/toolchain/ci.osty
@@ -1,4 +1,68 @@
-use go "github.com/osty/osty/internal/cihost" as host {
+// Opaque host handles — real shapes live in `internal/cihost` (Go).
+// Declared here at file scope so signatures in the `use runtime.cihost`
+// stanza (fn-only per LANG_SPEC §12.8) can reference them by name.
+struct Time {}
+struct Diagnostic {}
+struct Manifest {}
+struct ResolveWorkspace {}
+struct ResolvePackage {}
+struct PackageResult {}
+
+struct LoadResult {
+    Root: String,
+    Manifest: Manifest?,
+    Workspace: ResolveWorkspace?,
+    Packages: List<ResolvePackage?>,
+    Results: List<PackageResult?>,
+    Error: String,
+}
+
+struct CheckResult {
+    Note: String,
+    Diagnostics: List<Diagnostic?>,
+}
+
+struct ManifestCore {
+    HasPackage: Bool,
+    Name: String,
+    Version: String,
+    Edition: String,
+    License: String,
+    Description: String,
+}
+
+struct Symbol {
+    Name: String,
+    Kind: String,
+    Sig: String,
+}
+
+struct Snapshot {
+    Schema: Int,
+    Package: String,
+    Version: String,
+    Edition: String,
+    Symbols: List<Symbol>,
+    Packages: Map<String, List<Symbol>>,
+}
+
+struct SymbolRef {
+    Pkg: String,
+    Symbol: Symbol,
+}
+
+struct Diff {
+    Removed: List<SymbolRef>,
+    Added: List<SymbolRef>,
+    Changed: List<SymbolRef>,
+}
+
+struct SnapshotReadResult {
+    Snapshot: Snapshot,
+    Error: String,
+}
+
+use runtime.cihost as host {
     fn KeepAlive() -> Bool
     fn NowUTC() -> Time
     fn DiagnosticSeverity(d: Diagnostic?) -> String
@@ -40,67 +104,6 @@ use go "github.com/osty/osty/internal/cihost" as host {
     ) -> Snapshot
     fn CapturePackageHost(pkg: ResolvePackage?) -> List<Symbol>
     fn CompareSnapshots(baseline: Snapshot, current: Snapshot) -> Diff
-
-    struct Time {}
-    struct Diagnostic {}
-    struct Manifest {}
-    struct ResolveWorkspace {}
-    struct ResolvePackage {}
-    struct PackageResult {}
-
-    struct LoadResult {
-        Root: String,
-        Manifest: Manifest?,
-        Workspace: ResolveWorkspace?,
-        Packages: List<ResolvePackage?>,
-        Results: List<PackageResult?>,
-        Error: String,
-    }
-
-    struct CheckResult {
-        Note: String,
-        Diagnostics: List<Diagnostic?>,
-    }
-
-    struct ManifestCore {
-        HasPackage: Bool,
-        Name: String,
-        Version: String,
-        Edition: String,
-        License: String,
-        Description: String,
-    }
-
-    struct Snapshot {
-        Schema: Int,
-        Package: String,
-        Version: String,
-        Edition: String,
-        Symbols: List<Symbol>,
-        Packages: Map<String, List<Symbol>>,
-    }
-
-    struct Symbol {
-        Name: String,
-        Kind: String,
-        Sig: String,
-    }
-
-    struct Diff {
-        Removed: List<SymbolRef>,
-        Added: List<SymbolRef>,
-        Changed: List<SymbolRef>,
-    }
-
-    struct SymbolRef {
-        Pkg: String,
-        Symbol: Symbol,
-    }
-
-    struct SnapshotReadResult {
-        Snapshot: Snapshot,
-        Error: String,
-    }
 }
 use std.strings as ciStrings
 
@@ -133,14 +136,14 @@ pub struct Check {
     pub Passed: Bool,
     pub Skipped: Bool,
     pub Note: String,
-    pub Diags: List<host.Diagnostic?>,
+    pub Diags: List<Diagnostic?>,
 }
 
 /// Report is the aggregated outcome of one `osty ci` run.
 pub struct Report {
     pub ProjectRoot: String,
-    pub StartedAt: host.Time,
-    pub FinishedAt: host.Time,
+    pub StartedAt: Time,
+    pub FinishedAt: Time,
     pub Checks: List<Check>,
 
     pub fn AllPassed(self) -> Bool {
@@ -159,10 +162,10 @@ pub struct Report {
 pub struct Runner {
     pub Root: String,
     pub Opts: Options,
-    pub Manifest: host.Manifest?,
-    pub Workspace: host.ResolveWorkspace?,
-    pub Packages: List<host.ResolvePackage?>,
-    pub Results: List<host.PackageResult?>,
+    pub Manifest: Manifest?,
+    pub Workspace: ResolveWorkspace?,
+    pub Packages: List<ResolvePackage?>,
+    pub Results: List<PackageResult?>,
 
     pub fn Load(mut self) -> String {
         let loaded = host.LoadRunnerState(self.Root, self.Manifest)
@@ -422,31 +425,31 @@ pub fn NewRunner(root: String, opts: Options) -> Runner {
     }
 }
 
-pub fn CapturePackage(pkg: host.ResolvePackage?) -> List<host.Symbol> {
+pub fn CapturePackage(pkg: ResolvePackage?) -> List<Symbol> {
     host.CapturePackageHost(pkg)
 }
 
-pub fn NewSingleSnapshot(pkg: host.ResolvePackage?, version: String, edition: String) -> host.Snapshot {
+pub fn NewSingleSnapshot(pkg: ResolvePackage?, version: String, edition: String) -> Snapshot {
     host.NewSingleSnapshotHost(pkg, version, edition)
 }
 
 pub fn NewWorkspaceSnapshot(
-    packages: List<host.ResolvePackage?>,
+    packages: List<ResolvePackage?>,
     version: String,
     edition: String,
-) -> host.Snapshot {
+) -> Snapshot {
     host.NewWorkspaceSnapshotHost(packages, version, edition)
 }
 
-pub fn WriteSnapshot(path: String, snap: host.Snapshot) -> String {
+pub fn WriteSnapshot(path: String, snap: Snapshot) -> String {
     host.WriteSnapshotHost(path, snap)
 }
 
-pub fn ReadSnapshot(path: String) -> host.SnapshotReadResult {
+pub fn ReadSnapshot(path: String) -> SnapshotReadResult {
     host.ReadSnapshotHost(path)
 }
 
-pub fn Compare(baseline: host.Snapshot, current: host.Snapshot) -> host.Diff {
+pub fn Compare(baseline: Snapshot, current: Snapshot) -> Diff {
     host.CompareSnapshots(baseline, current)
 }
 
@@ -706,7 +709,7 @@ fn skipped(name: CheckName) -> Check {
     }
 }
 
-fn checkFromHostResult(name: CheckName, result: host.CheckResult) -> Check {
+fn checkFromHostResult(name: CheckName, result: CheckResult) -> Check {
     Check {
         Name: name,
         Passed: false,
@@ -716,7 +719,7 @@ fn checkFromHostResult(name: CheckName, result: host.CheckResult) -> Check {
     }
 }
 
-fn pushHostDiagnostics(c: Check, diags: List<host.Diagnostic?>) {
+fn pushHostDiagnostics(c: Check, diags: List<Diagnostic?>) {
     for d in diags {
         c.Diags.push(d)
     }
@@ -728,7 +731,7 @@ fn pushCoreDiagnostics(c: Check, diags: List<CiDiagCore>) {
     }
 }
 
-fn ciCheckHostPassed(diags: List<host.Diagnostic?>, strict: Bool) -> Bool {
+fn ciCheckHostPassed(diags: List<Diagnostic?>, strict: Bool) -> Bool {
     for d in diags {
         let severity = host.DiagnosticSeverity(d)
         if severity == "error" {
@@ -741,7 +744,7 @@ fn ciCheckHostPassed(diags: List<host.Diagnostic?>, strict: Bool) -> Bool {
     true
 }
 
-fn coreToCiManifest(m: host.ManifestCore) -> CiManifestCore {
+fn coreToCiManifest(m: ManifestCore) -> CiManifestCore {
     CiManifestCore {
         hasPackage: m.HasPackage,
         name: m.Name,
@@ -752,7 +755,7 @@ fn coreToCiManifest(m: host.ManifestCore) -> CiManifestCore {
     }
 }
 
-fn releaseCore(manifest: host.Manifest?) -> CiReleaseCore {
+fn releaseCore(manifest: Manifest?) -> CiReleaseCore {
     let m = host.ManifestCoreOf(manifest)
     let mut deps: List<CiDependencyCore> = []
     for row in host.DependencyCoreRows(manifest) {
@@ -787,7 +790,7 @@ fn dependencyCoreFromRow(row: String) -> CiDependencyCore {
     }
 }
 
-fn packageCount(packages: List<host.ResolvePackage?>) -> Int {
+fn packageCount(packages: List<ResolvePackage?>) -> Int {
     packages.len()
 }
 
@@ -799,7 +802,7 @@ fn ciBreakingSeverity(breakingIsError: Bool) -> String {
     }
 }
 
-fn qualifiedSymbol(ref: host.SymbolRef) -> String {
+fn qualifiedSymbol(ref: SymbolRef) -> String {
     if ref.Pkg == "" {
         ref.Symbol.Name
     } else {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -2384,7 +2384,7 @@ pub fn llvmIsKnownRuntimeFfiPath(path: String) -> Bool {
     if path.startsWith("runtime.cabi.") || path == "runtime.cabi" {
         return true
     }
-    path == "runtime.strings" || path == "runtime.path.filepath"
+    path == "runtime.strings" || path == "runtime.path.filepath" || path == "runtime.cihost"
 }
 
 pub fn llvmRuntimeFfiAlias(explicitAlias: String, lastPath: String, runtimePath: String) -> String {


### PR DESCRIPTION
## Summary

- Rewrites `toolchain/ci.osty`'s FFI stanza from `use go "github.com/osty/osty/internal/cihost"` to `use runtime.cihost as host { fn-only }`, extracting the 14 host types (`Time`, `Diagnostic`, `Manifest`, `ResolveWorkspace`, `ResolvePackage`, `PackageResult`, `LoadResult`, `CheckResult`, `ManifestCore`, `Symbol`, `Snapshot`, `SymbolRef`, `Diff`, `SnapshotReadResult`) to file-scope struct decls (runtime FFI bodies are fn-only per LANG_SPEC §12.8).
- Registers `runtime.cihost` in `llvmIsKnownRuntimeFfiPath` (`toolchain/llvmgen.osty:2387` + its `internal/llvmgen/support_snapshot.go:1923` mirror).
- ci.osty was the last remaining bootstrap-only toolchain file per `LLVM_MIGRATION_PLAN.md` § "Bootstrap-only 호스트 어댑터".

## Probe wall progression

Before → after, as measured by `TestProbeWholeToolchainMerged` / `TestProbeNativeToolchainMerged`:

| Stage | Wall |
|---|---|
| Before this PR | LLVM001 `foreign-ffi: use go "github.com/osty/osty/internal/cihost"` |
| After stanza rewrite only | LLVM002 `runtime-ffi: runtime.cihost needs native runtime lowering` |
| After `runtime.cihost` registration | **LLVM012** `field assignment on non-addressable binding "c"` |

Post-PR state: `TestProbeNativeToolchainMerged` logs _"no bootstrap-only files detected; this probe is equivalent to TestProbeWholeToolchainMerged"_ — the two probes converge.

The new LLVM012 wall is a **pre-existing** ci.osty code pattern at `toolchain/ci.osty:226` (`c.Passed = ciCheckHostPassed(...)` inside `for c in rep.Checks`) that was never visible before because ci.osty was bootstrap-filtered. Not FFI-related; unblocks on a separate backend improvement (for-loop var ptr slot) or ci.osty refactor.

## What didn't change

- `internal/cihost/host.go` (the Go implementation) — untouched.
- `internal/ci/core_snapshot.go` — still imports `host "github.com/osty/osty/internal/cihost"` via the normal Go path. `TestCoreSnapshotParityWithOsty` still passes because the 14 extracted host structs are intentionally non-pub (drift test only indexes `pub` decls).
- `runtimeFFIGoImport` in `internal/bootstrap/gen/decl.go` — not updated; ci.osty is not in `bundle.toolchainCheckerFiles`, so bootstrap-gen doesn't process it.
- No `osty_rt_cihost_*` C runtime shim added. Not needed for probe CLEAN (the AST/MIR emitter only generates `declare` statements for extern FFI; linking is a separate concern that would require CGO bridging since cihost wraps Go code in `internal/check`/`resolve`/etc.).

## Test plan

- [x] `just front` — lexer/parser/resolve/check/diag/format/lint/pipeline all pass
- [x] `TestCoreSnapshotParityWithOsty` (ci drift test) passes
- [x] `TestIsBootstrapOnlyOstyFile` classifier test passes
- [x] `TestProbeWholeToolchainMerged` + `TestProbeNativeToolchainMerged` converge on same first wall
- [x] `TestProbeNativeToolchainMergedMIR` still green (2 check diags, same LLVM000 class as before)
- [x] `osty fmt --check toolchain/ci.osty` clean
- [x] `TestGenerateUnknownRuntimeFFIStillReportsLLVM002` still passes (registration didn't weaken the negative-path gate)

## Gotcha for reviewers

The `host.X` type-stripping used `replace_all` per type name. One prefix-overlap victim was caught late: `host.Diagnostic` is a prefix of `host.DiagnosticSeverity`, so the first pass over-stripped a call site at `ci.osty:736`. Fixed in the same commit. (`host.Manifest` vs `host.ManifestCore(Of)` and `host.Snapshot` vs `host.SnapshotReadResult` were handled by long-first ordering.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)