### PR TITLE
feat: osty typecheck --native CLI path (astbridge-free + type dump)

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -320,6 +320,12 @@ func main() {
 			args = append([]string{"check"}, rest...)
 		}
 	}
+	if cmd == "typecheck" {
+		if rest, present := takeBoolFlag(args[1:], "--native"); present {
+			flags.native = true
+			args = append([]string{"typecheck"}, rest...)
+		}
+	}
 	// explain looks up a diagnostic or lint code and prints its doc.
 	// Handled before the generic "file required" check because it
 	// takes a code (or nothing, to list every code) — never a path.
@@ -511,6 +517,16 @@ func main() {
 			os.Exit(1)
 		}
 	case "typecheck":
+		if flags.native {
+			if flags.inspect || flags.dumpNativeDiags {
+				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+				os.Exit(2)
+			}
+			if runTypecheckFileNative(path, src, formatter, flags) != 0 {
+				os.Exit(1)
+			}
+			return
+		}
 		parsed := parser.ParseDetailed(src)
 		file, diags := parsed.File, parsed.Diagnostics
 		res := resolveFile(file)
@@ -1018,6 +1034,87 @@ func findOwningFile(files []selfhost.PackageCheckFile, offset int) int {
 		}
 	}
 	return -1
+}
+
+// runTypecheckFileNative is runCheckFileNative plus the type dump.
+// After the check runs on the arena, prints every typed-node range
+// selfhost.CheckResult.TypedNodes recorded — one row per node with
+// line/column span and the inferred type. Zero astbridge lowerings
+// on the happy path (same counter invariant as runCheckFileNative).
+func runTypecheckFileNative(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
+	run := parser.ParseRun(src)
+	parseDiags := run.Diagnostics()
+	checked := selfhost.CheckStructuredFromRun(run)
+	checkDiags := selfhost.CheckDiagnosticsAsDiag(src, checked.Diagnostics)
+	for _, d := range checkDiags {
+		if d != nil && d.File == "" {
+			d.File = path
+		}
+	}
+	all := append([]*diag.Diagnostic{}, parseDiags...)
+	all = append(all, checkDiags...)
+	printDiags(formatter, all, flags)
+	printNativeTypes(src, checked)
+	if hasError(all) {
+		return 1
+	}
+	return 0
+}
+
+// printNativeTypes is the --native sibling of printTypes: it renders
+// selfhost.CheckResult.TypedNodes (node.Start, node.End are byte
+// offsets produced by the native checker) as
+// `line:col-line:col\tTypeName` rows sorted by start position. Rows
+// with empty TypeName (the checker's signal-only placeholders) are
+// dropped so output stays compact.
+func printNativeTypes(src []byte, result selfhost.CheckResult) {
+	type row struct {
+		start, end int
+		text       string
+	}
+	rows := make([]row, 0, len(result.TypedNodes))
+	for _, n := range result.TypedNodes {
+		if n.TypeName == "" {
+			continue
+		}
+		rows = append(rows, row{start: n.Start, end: n.End, text: n.TypeName})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].start != rows[j].start {
+			return rows[i].start < rows[j].start
+		}
+		return rows[i].end < rows[j].end
+	})
+	for _, r := range rows {
+		sl, sc := byteOffsetLineCol(src, r.start)
+		el, ec := byteOffsetLineCol(src, r.end)
+		fmt.Printf("%d:%d-%d:%d\t%s\n", sl, sc, el, ec, r.text)
+	}
+}
+
+// byteOffsetLineCol is a single-pass scan equivalent of the
+// positionAtOffset helper that lives inside selfhost for the
+// diagnostic converter. Promoted to cmd/osty because the typed-node
+// renderer needs it inline — keep the two scanners in sync with
+// internal/selfhost/check_diag_convert.go:positionAtOffsetForDiag.
+func byteOffsetLineCol(src []byte, offset int) (int, int) {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if src[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 // runCheckFileNative drives `osty check --native FILE` end-to-end on

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestTypecheckCLINativeCleanSourcePrintsTypes confirms `osty
+// typecheck --native FILE` on clean input exits 0 AND emits at least
+// one `line:col-line:col\tType` row per printNativeTypes. The exact
+// node set depends on the native checker's recording, so we only
+// assert the presence of the `Int` type for the scalar bindings
+// instead of an exact snapshot.
+func TestTypecheckCLINativeCleanSourcePrintsTypes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	got := runOstyCLI(t, "typecheck", "--native", path)
+	if got.exit != 0 {
+		t.Fatalf("osty typecheck --native exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if strings.Contains(got.stderr, "error[") {
+		t.Fatalf("stderr contained error output on clean source:\n%s", got.stderr)
+	}
+	if !strings.Contains(got.stdout, "Int") {
+		t.Fatalf("stdout missing `Int` type row — printNativeTypes silent or empty\nstdout:\n%s", got.stdout)
+	}
+}
+
+// TestTypecheckCLINativeSurfacesTypeError pins that a clear type
+// mismatch (Int binding initialized with String) still surfaces a
+// typed-check diagnostic on stderr under --native.
+func TestTypecheckCLINativeSurfacesTypeError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {
+    let n: Int = "not an int"
+}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	got := runOstyCLI(t, "typecheck", "--native", path)
+	if got.exit != 1 {
+		t.Fatalf("osty typecheck --native exit = %d, want 1\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "error[") {
+		t.Fatalf("stderr missing error[ prefix:\n%s", got.stderr)
+	}
+}
+
+// TestTypecheckCLINativeRejectsInspectAndDumpFlags mirrors the check
+// path incompatibility contract: --inspect / --dump-native-diags both
+// probe the Go check.Result shape, which --native never materializes.
+func TestTypecheckCLINativeRejectsInspectAndDumpFlags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {}
+`), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	for _, incompatible := range []string{"--inspect", "--dump-native-diags"} {
+		incompatible := incompatible
+		t.Run(incompatible, func(t *testing.T) {
+			got := runOstyCLI(t, incompatible, "typecheck", "--native", path)
+			if got.exit != 2 {
+				t.Fatalf("exit = %d, want 2\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+			}
+			if !strings.Contains(got.stderr, "incompatible") {
+				t.Fatalf("stderr missing `incompatible` explanation:\n%s", got.stderr)
+			}
+		})
+	}
+}
+
+// TestRunTypecheckFileNativeIsAstbridgeFree is the in-process counter
+// test. Verifies the typecheck --native CLI body leaves
+// AstbridgeLowerCount at zero — including the type dump (which
+// iterates TypedNodes, not AST nodes, and should not trigger any
+// *ast.File lowering).
+func TestRunTypecheckFileNativeIsAstbridgeFree(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true, native: true}
+	formatter := newFormatter(path, src, flags)
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	})
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runTypecheckFileNative(path, src, formatter, flags)
+	_ = wout.Close()
+	_ = werr.Close()
+	<-drained
+	<-drained
+
+	if exit != 0 {
+		t.Fatalf("runTypecheckFileNative exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runTypecheckFileNative = %d, want 0 (typecheck --native regressed into *ast.File detour)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Extends `--native` to `osty typecheck FILE`. Routes the subcommand through the self-host arena pipeline like `check --native` ([#632](https://github.com/choiceoh/osty/pull/632)), and adds a `printNativeTypes` renderer that mirrors the Go-native `printTypes`: one row per typed expression (`line:col-line:col` + inferred type) produced from `selfhost.CheckResult.TypedNodes`. Zero astbridge lowerings on the happy path.

## What changed

- `runTypecheckFileNative(path, src, formatter, flags) int` — the typecheck sibling of `runCheckFileNative`. Same `ParseRun → CheckStructuredFromRun → CheckDiagnosticsAsDiag → printDiags` prefix, then prints the type table via `printNativeTypes`.
- `printNativeTypes(src, result)` — sorts `TypedNodes` by start offset, skips signal-only records with empty `TypeName`, renders `line:col-line:col\tType` for each.
- `byteOffsetLineCol(src, offset)` — single-pass scan used by the renderer. Mirrors `positionAtOffsetForDiag` inside selfhost; kept local to cmd/osty because only this renderer needs it inline.
- `case \"typecheck\"` dispatches to the native path when `flags.native` is set, with the same incompatibility contract (`--inspect` / `--dump-native-diags` exit 2 with an explanation).
- Subcommand-local flag placement: `osty typecheck --native FILE` parses via `takeBoolFlag`, matching `check --native` ergonomics.

## Why

[#632](https://github.com/choiceoh/osty/pull/632) and [#633](https://github.com/choiceoh/osty/pull/633) gave `osty check` astbridge-free FILE and DIR paths. `typecheck` is the natural sibling — same pipeline prefix, plus the type dump. The existing `selfhost.CheckResult.TypedNodes` slice has everything `printTypes` needs (start/end byte offsets, inferred type name), so the renderer is a single sorted loop.

After this PR the resolve / check / typecheck subcommands all have astbridge-free single-file paths; `osty lint` is the last remaining `--native` sibling but needs lint engine work that goes well beyond the astbridge wedge.

## Proof

**Subprocess tests**:

| Test | Expected |
|---|---|
| `TestTypecheckCLINativeCleanSourcePrintsTypes` | clean source → exit 0, stdout contains `Int` type row |
| `TestTypecheckCLINativeSurfacesTypeError` | `let n: Int = \"...\"` → stderr has `error[`, exit 1 |
| `TestTypecheckCLINativeRejectsInspectAndDumpFlags/--inspect` | exit 2, \"incompatible\" in stderr |
| `TestTypecheckCLINativeRejectsInspectAndDumpFlags/--dump-native-diags` | same for the other flag |

**In-process counter**:

```
selfhost.ResetAstbridgeLowerCount()
exit := runTypecheckFileNative(...)       // exit == 0
selfhost.AstbridgeLowerCount() == 0       ✓
```

## Combined CLI coverage

| CLI path | Astbridge-free? |
|---|---|
| `osty resolve FILE` | ✅ |
| `osty resolve DIR` | ✅ |
| `osty check --native FILE` | ✅ |
| `osty check --native DIR` | ✅ |
| `osty typecheck --native FILE` | ✅ (this PR) |
| `osty typecheck --native DIR` | 🚧 (type dump per-file design decision) |
| `osty lint --native` | 🚧 (lint engine identity-model work) |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] All 5 new tests (3 subprocess + 1 in-process counter + 2 sub-cases) green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- Legacy `osty typecheck FILE` (without `--native`) is unchanged — still goes through the Go-native resolve + `check.File` + `printTypes` path.
- Package (DIR) mode is intentionally deferred: `printTypes` only makes sense per-file, so adding it to the DIR path is an output-format question separate from the astbridge wedge.
- The local `byteOffsetLineCol` helper duplicates `internal/selfhost/check_diag_convert.go:positionAtOffsetForDiag` to avoid exporting a package-internal utility. The duplication is three lines of obvious math; both are single-source-of-truth-equivalent by construction. If a third caller appears we can promote once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)