### PR TITLE
feat: osty typecheck --native DIR with per-file type dump

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -380,6 +380,28 @@ func main() {
 		case "lint":
 			runLintPackage(path, flags)
 			return
+		case "typecheck":
+			// Legacy typecheck is FILE-only. --native introduces DIR
+			// support because the native pipeline already has
+			// runCheckPackageNative (#633) and adding a per-file type
+			// dump on top is the minimal delta.
+			if !flags.native {
+				fmt.Fprintf(os.Stderr,
+					"osty: typecheck does not accept a directory without --native (expected a file)\n")
+				os.Exit(2)
+			}
+			if flags.inspect || flags.dumpNativeDiags {
+				fmt.Fprintf(os.Stderr, "osty: --native is incompatible with --inspect / --dump-native-diags\n")
+				os.Exit(2)
+			}
+			if isWorkspace(path) {
+				fmt.Fprintf(os.Stderr, "osty: --native does not yet support workspace directories; run against a single package\n")
+				os.Exit(2)
+			}
+			if runTypecheckPackageNative(path, flags) != 0 {
+				os.Exit(1)
+			}
+			return
 		default:
 			fmt.Fprintf(os.Stderr,
 				"osty: %s does not accept a directory (expected a file)\n", cmd)
@@ -941,6 +963,91 @@ func applyPackageFixes(pkg *resolve.Package, diags []*diag.Diagnostic, flags cli
 // surfaces. Extracting this keeps the subcommand body testable in-
 // process so the astbridge counter can pin the end-to-end CLI
 // invariant (not just the library primitives).
+// runTypecheckPackageNative is the DIR sibling of
+// runTypecheckFileNative and the typecheck sibling of
+// runCheckPackageNative. After the package check runs astbridge-free
+// over the merged arena, it emits a per-file type dump with each
+// file's header so `osty typecheck --native DIR` output stays
+// readable for packages with more than one source file. Returns the
+// subcommand exit code.
+func runTypecheckPackageNative(dir string, flags cliFlags) int {
+	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("typecheck"), os.Stderr, flags))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
+		return 1
+	}
+	input := selfhost.PackageCheckInput{
+		Files: make([]selfhost.PackageCheckFile, 0, len(pkg.Files)),
+	}
+	base := 0
+	for _, pf := range pkg.Files {
+		if pf == nil || len(pf.Source) == 0 {
+			continue
+		}
+		name := filepath.Base(pf.Path)
+		input.Files = append(input.Files, selfhost.PackageCheckFile{
+			Source: append([]byte(nil), pf.Source...),
+			Base:   base,
+			Name:   name,
+			Path:   pf.Path,
+		})
+		base += len(pf.Source) + 1
+	}
+	checked, err := selfhost.CheckPackageStructured(input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "osty: native check: %v\n", err)
+		return 1
+	}
+	diags := packageParseDiags(pkg)
+	diags = append(diags, nativePackageCheckDiags(checked.Diagnostics, input.Files)...)
+	printPackageDiags(pkg, diags, flags)
+	printNativePackageTypes(checked, input.Files)
+	if hasError(diags) {
+		return 1
+	}
+	return 0
+}
+
+// printNativePackageTypes is the DIR renderer for --native typecheck:
+// buckets TypedNodes by owning file (same findOwningFile walker used
+// for diagnostics), relativizes byte offsets, and emits a
+// `# <path>` header followed by the single-file printNativeTypes
+// rows for each file that has at least one typed node. Files with
+// no typed nodes are silently skipped so the dump stays compact.
+func printNativePackageTypes(result selfhost.CheckResult, files []selfhost.PackageCheckFile) {
+	if len(result.TypedNodes) == 0 || len(files) == 0 {
+		return
+	}
+	buckets := make(map[int][]selfhost.CheckedNode, len(files))
+	for _, n := range result.TypedNodes {
+		if n.TypeName == "" {
+			continue
+		}
+		idx := findOwningFile(files, n.Start)
+		if idx < 0 {
+			continue
+		}
+		rel := n
+		rel.Start -= files[idx].Base
+		rel.End -= files[idx].Base
+		if rel.Start < 0 {
+			rel.Start = 0
+		}
+		if rel.End < rel.Start {
+			rel.End = rel.Start
+		}
+		buckets[idx] = append(buckets[idx], rel)
+	}
+	for i, f := range files {
+		bucket, ok := buckets[i]
+		if !ok || len(bucket) == 0 {
+			continue
+		}
+		fmt.Printf("# %s\n", f.Path)
+		printNativeTypes(f.Source, selfhost.CheckResult{TypedNodes: bucket})
+	}
+}
+
 // runCheckPackageNative is the DIR sibling of runCheckFileNative.
 // Loads the package via LoadPackageForNative (no eager *ast.File
 // materialization), runs selfhost.CheckPackageStructured over the

--- a/cmd/osty/typecheck_native_test.go
+++ b/cmd/osty/typecheck_native_test.go
@@ -84,6 +84,117 @@ func TestTypecheckCLINativeRejectsInspectAndDumpFlags(t *testing.T) {
 	}
 }
 
+// TestTypecheckCLINativePackageCleanSourcePrintsPerFileTypes confirms
+// the DIR rendering: each file's type dump is prefixed with a
+// `# <path>` header so downstream consumers can split by file. A
+// clean two-file package exits 0 and emits both file headers.
+func TestTypecheckCLINativePackageCleanSourcePrintsPerFileTypes(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runOstyCLI(t, "typecheck", "--native", dir)
+	if got.exit != 0 {
+		t.Fatalf("osty typecheck --native DIR exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stdout, "# "+bPath) {
+		t.Fatalf("stdout missing `# %s` header:\n%s", bPath, got.stdout)
+	}
+	// b.osty has scalar Int expressions that should show up in the
+	// typed-node dump.
+	if !strings.Contains(got.stdout, "Int") {
+		t.Fatalf("stdout missing Int type row:\n%s", got.stdout)
+	}
+}
+
+// TestTypecheckCLINativePackageRejectedWithoutNative pins the legacy
+// contract: `osty typecheck DIR` without --native is still rejected
+// with exit 2 (the pre-existing "does not accept a directory"
+// error), so this PR's DIR addition doesn't silently change legacy
+// semantics.
+func TestTypecheckCLINativePackageRejectedWithoutNative(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.osty")
+	if err := os.WriteFile(path, []byte(`fn main() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := runOstyCLI(t, "typecheck", dir)
+	if got.exit != 2 {
+		t.Fatalf("exit = %d, want 2\nstdout:\n%s\nstderr:\n%s", got.exit, got.stdout, got.stderr)
+	}
+	if !strings.Contains(got.stderr, "typecheck does not accept a directory") {
+		t.Fatalf("stderr missing legacy rejection message:\n%s", got.stderr)
+	}
+}
+
+// TestRunTypecheckPackageNativeIsAstbridgeFree is the DIR in-process
+// counter test: runTypecheckPackageNative's full pipeline
+// (LoadPackageForNative → CheckPackageStructured →
+// nativePackageCheckDiags → printNativePackageTypes) must produce
+// AstbridgeLowerCount == 0.
+func TestRunTypecheckPackageNativeIsAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	})
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runTypecheckPackageNative(dir, cliFlags{noColor: true, native: true})
+	_ = wout.Close()
+	_ = werr.Close()
+	<-drained
+	<-drained
+
+	if exit != 0 {
+		t.Fatalf("runTypecheckPackageNative exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runTypecheckPackageNative = %d, want 0", got)
+	}
+}
+
 // TestRunTypecheckFileNativeIsAstbridgeFree is the in-process counter
 // test. Verifies the typecheck --native CLI body leaves
 // AstbridgeLowerCount at zero — including the type dump (which


### PR DESCRIPTION
## Summary

Extends `--native` typecheck to DIR, building on [#635](https://github.com/choiceoh/osty/pull/635) (`typecheck --native FILE`) and the package pipeline from [#633](https://github.com/choiceoh/osty/pull/633) (`check --native DIR`). Legacy `osty typecheck DIR` remains rejected (preserves the pre-existing \"typecheck does not accept a directory\" contract); `--native DIR` is the new opt-in capability that makes type inspection possible across an entire package.

## What changed

- `runTypecheckPackageNative(dir, flags) int` — combines the `LoadPackageForNative` + `CheckPackageStructured` + `nativePackageCheckDiags` pipeline from `runCheckPackageNative` with a per-file type dump. Returns the subcommand exit code.
- `printNativePackageTypes(result, files)` — buckets `TypedNodes` by owning file via `findOwningFile` (reused from the DIR diagnostic path), relativizes byte offsets into each file's own source, and emits `# <path>` headers followed by the usual single-file `printNativeTypes` rows. Files with no typed nodes are silently skipped so the dump stays compact.
- Dispatch updated: `osty typecheck DIR` now either runs `runTypecheckPackageNative` (when `--native` is set) or prints the legacy rejection message (without `--native`). `--native` forbids workspace directories + `--inspect` / `--dump-native-diags` with the same exit-2 contract as `check --native`.

## Why

[#635](https://github.com/choiceoh/osty/pull/635) brought `osty typecheck --native FILE` up to parity with the `check --native` wedge. The obvious gap was package inspection — \"what types does the checker infer across this entire package?\" — which the legacy `typecheck` doesn't support and which the native pipeline is well-positioned to answer. This PR closes that gap.

Output format follows the multi-file convention `resolve DIR` already uses: a `# <path>` header delineates each file, so downstream consumers can split the dump on header boundaries.

## Proof

**Subprocess tests**:

| Test | Expected |
|---|---|
| `TestTypecheckCLINativePackageCleanSourcePrintsPerFileTypes` | two-file package → exit 0, `# b.osty` header present, `Int` type rows emitted |
| `TestTypecheckCLINativePackageRejectedWithoutNative` | `osty typecheck DIR` (no `--native`) → exit 2 with legacy rejection message |

**In-process counter**:

```
selfhost.ResetAstbridgeLowerCount()
exit := runTypecheckPackageNative(dir, flags)   // exit == 0
selfhost.AstbridgeLowerCount() == 0             ✓
```

## Combined CLI coverage

| CLI path | Astbridge-free? |
|---|---|
| `osty resolve FILE` | ✅ |
| `osty resolve DIR` | ✅ |
| `osty check --native FILE` | ✅ |
| `osty check --native DIR` | ✅ |
| `osty typecheck --native FILE` | ✅ |
| `osty typecheck --native DIR` | ✅ (this PR) |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] 3 new tests (2 subprocess + 1 in-process counter) green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- Legacy `osty typecheck` is single-file by design (the Go-side `printTypes` has no multi-file rendering). Adding DIR under `--native` is a new capability rather than a behavior change — the legacy rejection test pins that.
- The bucketizing / header-emission logic is a thin wrapper around primitives already landed in earlier PRs (`findOwningFile`, `printNativeTypes`). If a third consumer of the per-file pattern appears we can factor out; two usages sharing the same helper set is below the threshold for premature abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)