### PR TITLE
fix: ci.osty Report.Checks Passed 갱신 손실

### DIFF
--- a/toolchain/ci.osty
+++ b/toolchain/ci.osty
@@ -216,12 +216,14 @@ pub struct Runner {
             rep.Checks.push(skipped(CheckSemver))
         }
 
+        let mut i = 0
         for c in rep.Checks {
             if c.Skipped {
                 let _ = c
             } else {
-                c.Passed = ciCheckHostPassed(c.Diags, self.Opts.Strict)
+                rep.Checks[i] = Check { ..c, Passed: ciCheckHostPassed(c.Diags, self.Opts.Strict) }
             }
+            i = i + 1
         }
         rep.FinishedAt = host.NowUTC()
         rep


### PR DESCRIPTION
## Summary
- `Runner.Run` 에서 `for c in rep.Checks { c.Passed = ... }` 로 strict 모드 Passed 판정을 썼지만, Osty 루프 변수는 값 복사라 `rep.Checks` 원본은 갱신되지 않아 Report 에 반영되지 않았다.
- Index 카운터로 `rep.Checks[i] = Check { ..c, Passed: ciCheckHostPassed(...) }` 스프레드 치환으로 바꿔 실제 값이 쓰이게 수정.

## Scope
Repo 전체 `.osty` 를 스캔했을 때 이 `for VAR in COLL { VAR.field = ... }` 안티패턴은 [toolchain/ci.osty:223](https://github.com/choiceoh/osty/blob/ostcode/agitated-williamson-c84176/toolchain/ci.osty#L223) 한 곳뿐이었고, 이 PR 은 그 한 지점만 수정한다.

## Test plan
- [x] `just front` (lexer / parser / resolve / check / diag / format / lint / pipeline) 통과
- [ ] (follow-up) `osty ci --strict` 엔드-투-엔드 실행에서 실패 케이스가 실제로 Passed=false 로 보고되는지 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)