### PR TITLE
feat(llvmgen): native path absorbs generic enum + tuple destructure + for-in

### DIFF
--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -20,6 +20,27 @@ type nativeStructInfo struct {
 	byName map[string]nativeStructFieldInfo
 }
 
+// nativeEnumVariantInfo captures the resolved payload type for a
+// single monomorphized enum variant. `payloadLLVMType` is "" for
+// payload-free variants (e.g. `None`).
+type nativeEnumVariantInfo struct {
+	name            string
+	tag             int
+	payloadLLVMType string
+	payloadIRTypes  []ostyir.Type
+}
+
+// nativeEnumInfo mirrors nativeStructInfo but for tagged-union
+// enums. The `def` is kept on the module side under
+// `llvmNativeModule.enums`, and projection state is carried here
+// so the IR projection layer (populated in a follow-up session)
+// can route variant construction and pattern matches back to the
+// same storage.
+type nativeEnumInfo struct {
+	def             *llvmNativeEnum
+	variantsByName  map[string]*nativeEnumVariantInfo
+}
+
 type nativeTupleInfo struct {
 	def           *llvmNativeStruct
 	elemLLVMTypes []string
@@ -27,6 +48,7 @@ type nativeTupleInfo struct {
 
 type nativeProjectionCtx struct {
 	structsByName         map[string]*nativeStructInfo
+	enumsByName           map[string]*nativeEnumInfo
 	tuplesByLLVMType      map[string]*nativeTupleInfo
 	tupleOrder            []string
 	methodsByOwner        map[string]map[string]nativeMethodInfo
@@ -40,6 +62,24 @@ type nativeProjectionCtx struct {
 	stringGlobals         []*LlvmStringGlobal
 	nextStringID          int
 	currentReturnLLVMType string
+	// tempCounter mints monotone fresh names for synthetic locals
+	// spilled from one-to-many statement expansions (e.g. tuple
+	// destructuring, for-in over a list). The name prefix is
+	// `__osty_native_t` to avoid colliding with user bindings —
+	// Osty identifiers cannot start with a double underscore.
+	tempCounter int
+}
+
+// freshTempName returns a new synthetic local name scoped to this
+// projection context. Used by the statement-fan-out helpers (tuple
+// destructure let, for-in loop) to spill intermediates without
+// clashing with user identifiers.
+func (ctx *nativeProjectionCtx) freshTempName(prefix string) string {
+	if ctx == nil {
+		return prefix
+	}
+	ctx.tempCounter++
+	return prefix + strconv.Itoa(ctx.tempCounter)
 }
 
 type nativeExprInfoKind int
@@ -153,6 +193,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 	}
 	ctx := &nativeProjectionCtx{
 		structsByName:    map[string]*nativeStructInfo{},
+		enumsByName:      map[string]*nativeEnumInfo{},
 		tuplesByLLVMType: map[string]*nativeTupleInfo{},
 		methodsByOwner:   map[string]map[string]nativeMethodInfo{},
 		globalConsts:     map[string]nativeConstValue{},
@@ -163,6 +204,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		target:        opts.Target,
 		globals:       make([]*llvmNativeGlobal, 0, len(mod.Decls)),
 		structs:       make([]*llvmNativeStruct, 0, len(mod.Decls)),
+		enums:         make([]*llvmNativeEnum, 0, len(mod.Decls)),
 		stringGlobals: make([]*LlvmStringGlobal, 0),
 		functions:     make([]*llvmNativeFunction, 0, len(mod.Decls)+1),
 	}
@@ -188,6 +230,31 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 			if !nativeRegisterStructMethodHeaders(ctx, d) {
 				return nil, false
 			}
+		case *ostyir.EnumDecl:
+			if d == nil {
+				continue
+			}
+			// Generic templates survive monomorphization alongside
+			// their specializations in the output module. The
+			// specializations carry the mangled `_ZTS…` names and
+			// hold the concrete payload types we actually lower;
+			// the templates are unreachable post-mono so we skip
+			// them here rather than refusing the whole module.
+			if len(d.Generics) != 0 {
+				continue
+			}
+			info, ok := nativeRegisterEnumDecl(ctx, d)
+			if !ok {
+				return nil, false
+			}
+			if _, exists := ctx.enumsByName[d.Name]; exists {
+				return nil, false
+			}
+			if len(d.Methods) != 0 {
+				return nil, false
+			}
+			ctx.enumsByName[d.Name] = info
+			out.enums = append(out.enums, info.def)
 		case *ostyir.LetDecl:
 			ctx.mutableGlobals[d.Name] = d.Mut
 		}
@@ -215,6 +282,12 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 				}
 				out.functions = append(out.functions, fn)
 			}
+		case *ostyir.EnumDecl:
+			// Enum declarations are fully projected during the
+			// registration phase above; nothing to populate here.
+			// The explicit case keeps enum decls from falling into
+			// the default arm that rejects the whole module.
+			continue
 		case *ostyir.FnDecl:
 			fn, ok := nativeFunctionFromIR(ctx, d)
 			if !ok {
@@ -271,6 +344,82 @@ func nativeRegisterStructDecl(decl *ostyir.StructDecl) (*nativeStructInfo, bool)
 			fields:   make([]*llvmNativeStructField, 0, len(decl.Fields)),
 		},
 		byName: map[string]nativeStructFieldInfo{},
+	}, true
+}
+
+// nativeRegisterEnumDecl projects a monomorphized enum declaration
+// into the native projection context. The resulting `*nativeEnumInfo`
+// owns a `*llvmNativeEnum` that the emitter turns into a
+// `{ i64 tag, <payload> }` storage struct, plus a
+// variant-name-to-tag/payload index the IR projection layer reads
+// when lowering variant construction (`Maybe.Some(42)`) and
+// pattern matches (`if let Maybe.Some(x) = m`).
+//
+// The routing (calling this from `nativeModuleFromIR` and wiring
+// the variant-construction / pattern-match expression lowering
+// paths) lives in a follow-up session — this helper exists so the
+// data-model half can land first. It is intentionally not yet
+// invoked; the `nativeModuleFromIR` switch still returns `nil,
+// false` for `*ostyir.EnumDecl`.
+//
+// Returns (nil, false) for generic templates: only monomorphized
+// specializations are projectable. The payload slot type is
+// synthesized from the widest variant payload — today that is
+// trivially the single `Int`-shaped slot used by `Option<Int>` /
+// `Maybe<Int>`; the follow-up session will extend this to handle
+// multi-typed and multi-field payloads by spilling into a union-
+// shaped struct.
+func nativeRegisterEnumDecl(ctx *nativeProjectionCtx, decl *ostyir.EnumDecl) (*nativeEnumInfo, bool) {
+	if ctx == nil || decl == nil || decl.Name == "" || len(decl.Generics) != 0 {
+		return nil, false
+	}
+	variants := make([]*llvmNativeEnumVariant, 0, len(decl.Variants))
+	variantInfos := make(map[string]*nativeEnumVariantInfo, len(decl.Variants))
+	payloadSlot := ""
+	for i, variant := range decl.Variants {
+		if variant == nil || variant.Name == "" {
+			return nil, false
+		}
+		payloadLLVM := ""
+		if len(variant.Payload) == 1 {
+			llvmType, ok := nativeLLVMTypeFromIR(ctx, variant.Payload[0])
+			if !ok || llvmType == "void" {
+				return nil, false
+			}
+			payloadLLVM = llvmType
+			if payloadSlot == "" {
+				payloadSlot = llvmType
+			} else if payloadSlot != llvmType {
+				// Mixed payload shapes need a union-sized slot the
+				// follow-up session will model. Bail so the legacy
+				// bridge keeps handling this case for now.
+				return nil, false
+			}
+		} else if len(variant.Payload) > 1 {
+			// Multi-field payloads require a synthesized tuple
+			// struct. Defer to the follow-up session.
+			return nil, false
+		}
+		variants = append(variants, &llvmNativeEnumVariant{
+			name:        variant.Name,
+			tag:         i,
+			payloadType: payloadLLVM,
+		})
+		variantInfos[variant.Name] = &nativeEnumVariantInfo{
+			name:            variant.Name,
+			tag:             i,
+			payloadLLVMType: payloadLLVM,
+			payloadIRTypes:  append([]ostyir.Type(nil), variant.Payload...),
+		}
+	}
+	return &nativeEnumInfo{
+		def: &llvmNativeEnum{
+			name:            decl.Name,
+			llvmType:        llvmStructTypeName(decl.Name),
+			payloadSlotType: payloadSlot,
+			variants:        variants,
+		},
+		variantsByName: variantInfos,
 	}, true
 }
 
@@ -465,21 +614,28 @@ func nativeBlockFromIR(ctx *nativeProjectionCtx, block *ostyir.Block, fnReturnTy
 	var tailResult ostyir.Expr
 	if block.Result == nil && fnReturnType != "" && fnReturnType != "void" && len(stmts) != 0 {
 		if exprStmt, ok := stmts[len(stmts)-1].(*ostyir.ExprStmt); ok && exprStmt != nil && exprStmt.X != nil {
-			tailResult = exprStmt.X
-			stmts = stmts[:len(stmts)-1]
+			// Don't promote a unit-typed tail expression to the
+			// block result — the function-emission terminator
+			// fallback (notably the `main` -> `ret i32 0` path)
+			// fills in the actual return. Promoting would force
+			// an unsupported value-coercion path for shapes like
+			// `if let` that produce unit but live as the trailing
+			// statement of `fn main()`.
+			if !nativeIsUnitType(exprStmt.X.Type()) {
+				tailResult = exprStmt.X
+				stmts = stmts[:len(stmts)-1]
+			}
 		}
 	}
 	out := &llvmNativeBlock{
 		stmts: make([]*llvmNativeStmt, 0, len(stmts)),
 	}
 	for _, stmt := range stmts {
-		nativeStmt, ok := nativeStmtFromIR(ctx, stmt, fnReturnType)
+		nativeStmts, ok := nativeStmtsFromIR(ctx, stmt, fnReturnType)
 		if !ok {
 			return nil, false
 		}
-		if nativeStmt != nil {
-			out.stmts = append(out.stmts, nativeStmt)
-		}
+		out.stmts = append(out.stmts, nativeStmts...)
 	}
 	resultExpr := block.Result
 	if resultExpr == nil {
@@ -503,13 +659,224 @@ func nativeBlockFromStmts(ctx *nativeProjectionCtx, stmts []ostyir.Stmt, fnRetur
 		stmts: make([]*llvmNativeStmt, 0, len(stmts)),
 	}
 	for _, stmt := range stmts {
-		nativeStmt, ok := nativeStmtFromIR(ctx, stmt, fnReturnType)
+		nativeStmts, ok := nativeStmtsFromIR(ctx, stmt, fnReturnType)
 		if !ok {
 			return nil, false
 		}
-		if nativeStmt != nil {
-			out.stmts = append(out.stmts, nativeStmt)
+		out.stmts = append(out.stmts, nativeStmts...)
+	}
+	return out, true
+}
+
+// nativeStmtsFromIR is the one-to-many wrapper around nativeStmtFromIR.
+// A small set of IR-level shapes (tuple-destructuring `let`, for-in
+// loops) expand into several native statements; everything else passes
+// through as a single-element slice. The block iterator calls this so
+// fan-out emissions land contiguously in the produced native block.
+func nativeStmtsFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType string) ([]*llvmNativeStmt, bool) {
+	switch s := stmt.(type) {
+	case *ostyir.LetStmt:
+		if _, ok := s.Pattern.(*ostyir.TuplePat); ok {
+			return nativeLetTupleDestructureStmts(ctx, s)
 		}
+	case *ostyir.ForStmt:
+		if s != nil && s.Kind == ostyir.ForIn {
+			return nativeForInListStmts(ctx, s, fnReturnType)
+		}
+	}
+	one, ok := nativeStmtFromIR(ctx, stmt, fnReturnType)
+	if !ok {
+		return nil, false
+	}
+	if one == nil {
+		return nil, true
+	}
+	return []*llvmNativeStmt{one}, true
+}
+
+// nativeForInListStmts lowers `for x in listExpr { body }` into a
+// RangeStmt bounded by 0..listExpr.len() with the element
+// extraction (`let x = listExpr[i]`) prepended to the body. The
+// iter expression is spilled to a synthesized `__osty_native_list<N>`
+// temp when it is not already a bare ident, so side-effects fire
+// once. Only covers `ForIn` with a plain loop-variable name;
+// destructuring heads defer to the legacy bridge until follow-up
+// coverage lands.
+func nativeForInListStmts(ctx *nativeProjectionCtx, s *ostyir.ForStmt, fnReturnType string) ([]*llvmNativeStmt, bool) {
+	if ctx == nil || s == nil || s.Kind != ostyir.ForIn {
+		return nil, false
+	}
+	if s.IsDestructured() || s.Var == "" || s.Iter == nil {
+		return nil, false
+	}
+	iterInfo, ok := nativeExprTypeInfo(ctx, s.Iter)
+	if !ok || iterInfo.kind != nativeExprInfoList || iterInfo.listElemType == "" {
+		return nil, false
+	}
+	iterExpr, ok := nativeExprFromIR(ctx, s.Iter)
+	if !ok || iterExpr.llvmType != "ptr" {
+		return nil, false
+	}
+	var listName string
+	var out []*llvmNativeStmt
+	if iterExpr.kind == llvmNativeExprIdent && iterExpr.name != "" {
+		listName = iterExpr.name
+	} else {
+		listName = ctx.freshTempName("__osty_native_list")
+		out = append(out, &llvmNativeStmt{
+			kind:       llvmNativeStmtLet,
+			name:       listName,
+			childExprs: []*llvmNativeExpr{iterExpr},
+		})
+		ctx.bindScopeName(listName, iterInfo)
+	}
+	indexName := ctx.freshTempName("__osty_native_i")
+
+	// Bind loop-index and element names in the current scope so the
+	// body's IR lowering resolves them correctly. nativeBlockFromIR
+	// pushes its own inner scope on top, so these outer bindings
+	// shadow nothing the body might introduce.
+	ctx.pushScope()
+	ctx.bindScopeName(indexName, nativeExprInfoFromLLVMType("i64"))
+	elemInfo, ok := nativeForInElemInfo(ctx, s.Iter, iterInfo)
+	if !ok {
+		ctx.popScope()
+		return nil, false
+	}
+	ctx.bindScopeName(s.Var, elemInfo)
+	bodyBlock, ok := nativeBlockFromIR(ctx, s.Body, fnReturnType)
+	ctx.popScope()
+	if !ok {
+		return nil, false
+	}
+
+	// Prepend `let s.Var = listName[indexName]` to the body.
+	listIdent := func() *llvmNativeExpr {
+		return &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: "ptr", name: listName}
+	}
+	indexIdent := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: "i64", name: indexName}
+	elemExpr := &llvmNativeExpr{
+		kind:         llvmNativeExprListIndex,
+		llvmType:     iterInfo.listElemType,
+		elemLLVMType: iterInfo.listElemType,
+		childExprs:   []*llvmNativeExpr{listIdent(), indexIdent},
+	}
+	extractStmt := &llvmNativeStmt{
+		kind:       llvmNativeStmtLet,
+		name:       s.Var,
+		childExprs: []*llvmNativeExpr{elemExpr},
+	}
+	bodyBlock.stmts = append([]*llvmNativeStmt{extractStmt}, bodyBlock.stmts...)
+
+	// Build Range 0..listName.len().
+	startExpr := &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: "i64", text: "0"}
+	ctx.needsListRT = true
+	endExpr := nativeRuntimeCallExpr("i64", llvmListRuntimeLenSymbol(), listIdent())
+	out = append(out, &llvmNativeStmt{
+		kind:        llvmNativeStmtRange,
+		name:        indexName,
+		inclusive:   false,
+		childExprs:  []*llvmNativeExpr{startExpr, endExpr},
+		childBlocks: []*llvmNativeBlock{bodyBlock},
+	})
+	return out, true
+}
+
+// nativeForInElemInfo derives the element's native expr-info from
+// the iter's list info. For scalar element lists the list info's
+// llvm type lookup suffices; for tuple / struct elements we
+// reach through to the registered info by resolving the iter's
+// IR element type.
+func nativeForInElemInfo(ctx *nativeProjectionCtx, iter ostyir.Expr, iterInfo nativeExprInfo) (nativeExprInfo, bool) {
+	if iter == nil {
+		return nativeExprInfoFromLLVMType(iterInfo.listElemType), iterInfo.listElemType != ""
+	}
+	named, ok := iter.Type().(*ostyir.NamedType)
+	if ok && named != nil && named.Builtin && named.Name == "List" && len(named.Args) == 1 {
+		if info, ok := nativeExprInfoFromType(ctx, named.Args[0]); ok {
+			return info, true
+		}
+	}
+	if iterInfo.listElemType == "" {
+		return nativeExprInfo{}, false
+	}
+	return nativeExprInfoFromLLVMType(iterInfo.listElemType), true
+}
+
+// nativeLetTupleDestructureStmts lowers `let (a, b, c, ...) = rhs`
+// into a sequence of native `let` statements — one for the spilled
+// tuple temp (when the RHS is not already a bare ident) and one per
+// destructured element. Element patterns must be plain `IdentPat`
+// bindings; nested patterns, wildcards, and mut bindings defer to
+// the legacy bridge until follow-up work extends coverage.
+func nativeLetTupleDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt) ([]*llvmNativeStmt, bool) {
+	if ctx == nil || s == nil || s.Value == nil {
+		return nil, false
+	}
+	pat, ok := s.Pattern.(*ostyir.TuplePat)
+	if !ok || pat == nil {
+		return nil, false
+	}
+	info, ok := nativeTupleInfoFromType(ctx, s.Value.Type())
+	if !ok {
+		return nil, false
+	}
+	if len(pat.Elems) != len(info.elemLLVMTypes) {
+		return nil, false
+	}
+	// Collect the element binder names up-front so we can reject any
+	// non-trivial sub-pattern before emitting partial output.
+	elemNames := make([]string, 0, len(pat.Elems))
+	for _, elem := range pat.Elems {
+		id, ok := elem.(*ostyir.IdentPat)
+		if !ok || id == nil || id.Name == "" || id.Mut {
+			return nil, false
+		}
+		elemNames = append(elemNames, id.Name)
+	}
+	value, ok := nativeExprFromIR(ctx, s.Value)
+	if !ok {
+		return nil, false
+	}
+	if value.llvmType != info.def.llvmType {
+		return nil, false
+	}
+	out := make([]*llvmNativeStmt, 0, len(elemNames)+1)
+	// If the RHS is already a plain ident we can skip the spill and
+	// reuse the source ident directly for each field access. Complex
+	// expressions spill to a synthesized temp so side-effects fire
+	// exactly once.
+	var baseName string
+	if value.kind == llvmNativeExprIdent && value.name != "" {
+		baseName = value.name
+	} else {
+		baseName = ctx.freshTempName("__osty_native_t")
+		out = append(out, &llvmNativeStmt{
+			kind:       llvmNativeStmtLet,
+			name:       baseName,
+			childExprs: []*llvmNativeExpr{value},
+		})
+		ctx.bindScopeName(baseName, nativeExprInfoFromLLVMType(info.def.llvmType))
+	}
+	for i, name := range elemNames {
+		elemLLVM := info.elemLLVMTypes[i]
+		base := &llvmNativeExpr{
+			kind:     llvmNativeExprIdent,
+			llvmType: info.def.llvmType,
+			name:     baseName,
+		}
+		field := &llvmNativeExpr{
+			kind:       llvmNativeExprField,
+			llvmType:   elemLLVM,
+			fieldIndex: i,
+			childExprs: []*llvmNativeExpr{base},
+		}
+		out = append(out, &llvmNativeStmt{
+			kind:       llvmNativeStmtLet,
+			name:       name,
+			childExprs: []*llvmNativeExpr{field},
+		})
+		ctx.bindScopeName(name, nativeExprInfoFromLLVMType(elemLLVM))
 	}
 	return out, true
 }
@@ -543,6 +910,11 @@ func nativeStmtFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType s
 			childExprs: []*llvmNativeExpr{value},
 		}, true
 	case *ostyir.ExprStmt:
+		if ifLet, ok := s.X.(*ostyir.IfLetExpr); ok {
+			if stmt, ok := nativeIfLetVariantStmt(ctx, ifLet, fnReturnType); ok {
+				return stmt, true
+			}
+		}
 		expr, ok := nativeExprFromIR(ctx, s.X)
 		if !ok {
 			return nil, false
@@ -655,6 +1027,120 @@ func nativeStmtFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType s
 	default:
 		return nil, false
 	}
+}
+
+// nativeIfLetVariantStmt lowers `if let Enum.Variant(<bindings>) =
+// scrutinee { then } else { else }` (wrapped as
+// `ExprStmt{IfLetExpr}`) into a native if statement that compares
+// the enum's tag field against the variant's discriminant and, on
+// the then-branch, synthesizes let bindings for any payload idents
+// the pattern named.
+//
+// Today the helper only covers `VariantPat` with at most one
+// `IdentPat` binding and a single-typed payload slot — the tests
+// lock the `Maybe<Int>` / `Maybe.Some(x)` / `Maybe.None` shapes.
+// Multi-binding patterns, wildcard payloads, and nested patterns
+// return (nil, false) so the caller falls back to the legacy
+// bridge (still wired via `GenerateModule`) until a follow-up
+// extends this coverage.
+func nativeIfLetVariantStmt(
+	ctx *nativeProjectionCtx,
+	ifLet *ostyir.IfLetExpr,
+	fnReturnType string,
+) (*llvmNativeStmt, bool) {
+	if ctx == nil || ifLet == nil {
+		return nil, false
+	}
+	varPat, ok := ifLet.Pattern.(*ostyir.VariantPat)
+	if !ok {
+		return nil, false
+	}
+	info, ok := nativeEnumInfoFromType(ctx, ifLet.Scrutinee.Type())
+	if !ok {
+		return nil, false
+	}
+	variant, ok := info.variantsByName[varPat.Variant]
+	if !ok {
+		return nil, false
+	}
+	// Pattern arg count must match the variant's payload arity
+	// exactly; mixed shapes defer to the legacy bridge.
+	if len(varPat.Args) != len(variant.payloadIRTypes) {
+		return nil, false
+	}
+	scrutinee, ok := nativeExprFromIR(ctx, ifLet.Scrutinee)
+	if !ok {
+		return nil, false
+	}
+	if scrutinee.llvmType != info.def.llvmType {
+		return nil, false
+	}
+	tagExpr := &llvmNativeExpr{
+		kind:       llvmNativeExprField,
+		llvmType:   "i64",
+		fieldIndex: 0,
+		childExprs: []*llvmNativeExpr{scrutinee},
+	}
+	tagConst := &llvmNativeExpr{
+		kind:     llvmNativeExprInt,
+		llvmType: "i64",
+		text:     strconv.Itoa(variant.tag),
+	}
+	cond := &llvmNativeExpr{
+		kind:       llvmNativeExprBinary,
+		llvmType:   "i1",
+		op:         "==",
+		childExprs: []*llvmNativeExpr{tagExpr, tagConst},
+	}
+
+	var bindingStmts []*llvmNativeStmt
+	ctx.pushScope()
+	if len(varPat.Args) == 1 && variant.payloadLLVMType != "" {
+		idPat, ok := varPat.Args[0].(*ostyir.IdentPat)
+		if !ok || idPat.Name == "" || idPat.Mut {
+			ctx.popScope()
+			return nil, false
+		}
+		scrutineeCopy, ok := nativeExprFromIR(ctx, ifLet.Scrutinee)
+		if !ok {
+			ctx.popScope()
+			return nil, false
+		}
+		payloadExpr := &llvmNativeExpr{
+			kind:       llvmNativeExprField,
+			llvmType:   variant.payloadLLVMType,
+			fieldIndex: 1,
+			childExprs: []*llvmNativeExpr{scrutineeCopy},
+		}
+		bindingStmts = append(bindingStmts, &llvmNativeStmt{
+			kind:       llvmNativeStmtLet,
+			name:       idPat.Name,
+			childExprs: []*llvmNativeExpr{payloadExpr},
+		})
+		ctx.bindScopeName(idPat.Name, nativeExprInfoFromLLVMType(variant.payloadLLVMType))
+	}
+	thenBlock, ok := nativeBlockFromIR(ctx, ifLet.Then, fnReturnType)
+	ctx.popScope()
+	if !ok {
+		return nil, false
+	}
+	if len(bindingStmts) != 0 {
+		thenBlock.stmts = append(bindingStmts, thenBlock.stmts...)
+	}
+
+	out := &llvmNativeStmt{
+		kind:        llvmNativeStmtIf,
+		childExprs:  []*llvmNativeExpr{cond},
+		childBlocks: []*llvmNativeBlock{thenBlock},
+	}
+	if ifLet.Else != nil {
+		elseBlock, ok := nativeBlockFromIR(ctx, ifLet.Else, fnReturnType)
+		if !ok {
+			return nil, false
+		}
+		out.childBlocks = append(out.childBlocks, elseBlock)
+	}
+	return out, true
 }
 
 func nativeFieldAssignStmtFromIR(
@@ -1135,7 +1621,20 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 			out.childExprs = append(out.childExprs, value)
 		}
 		return out, true
+	case *ostyir.VariantLit:
+		return nativeVariantLitFromIR(ctx, e)
 	case *ostyir.FieldExpr:
+		// Bare variant access on an enum type name — `Maybe.None` —
+		// lowers to a VariantLit-equivalent zero-argument variant
+		// construction. The IR represents this as
+		// `FieldExpr{X: Ident{Kind: IdentTypeName, Name: <enum>},
+		// Name: <variant>}` rather than a `VariantLit` because the
+		// surface syntax has no parens to disambiguate from a field
+		// access. Detect the shape up front and route to the same
+		// variant projector that handles `Maybe.Some(x)`.
+		if expr, ok := nativeBareVariantAccessFromIR(ctx, e); ok {
+			return expr, true
+		}
 		if e.Optional {
 			baseInfo, ok := nativeExprTypeInfo(ctx, e.X)
 			if !ok || baseInfo.kind != nativeExprInfoOptional {
@@ -1992,6 +2491,22 @@ func nativeStructInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeS
 	return info, info != nil
 }
 
+// nativeEnumInfoFromType resolves a monomorphized enum NamedType
+// (its `Name` is the mangled `_ZTS…` form post-monomorphization)
+// back to the projection-side info registered by
+// `nativeRegisterEnumDecl`.
+func nativeEnumInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeEnumInfo, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	named, ok := t.(*ostyir.NamedType)
+	if !ok || named == nil || named.Builtin || named.Package != "" || len(named.Args) != 0 {
+		return nil, false
+	}
+	info := ctx.enumsByName[named.Name]
+	return info, info != nil
+}
+
 func nativeTupleInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeTupleInfo, bool) {
 	if ctx == nil {
 		return nil, false
@@ -2539,6 +3054,128 @@ func nativeExprFromIRWithHint(ctx *nativeProjectionCtx, expr ostyir.Expr, hintLL
 	}
 }
 
+// nativeVariantLitFromIR lowers `Maybe.Some(42)` / `Maybe.None` into
+// a native struct literal over the monomorphized enum's storage
+// type `{ i64 tag, <payloadSlotType> }`. The emitter reuses the
+// struct-lit insertvalue machinery — enums have no variant-literal
+// primitive of their own.
+//
+// Payload rules:
+//
+//   - All-payload-free enums (payloadSlotType == ""): storage is
+//     `{ i64 }`; the struct lit carries only the tag.
+//   - Single-payload variant: storage is `{ i64, <payload> }`;
+//     construct with `(tag, arg)`.
+//   - Payload-free variant in a with-payload enum: pad the slot
+//     with a zero of `payloadSlotType` so the storage width is
+//     uniform and pattern matching on the payload slot remains
+//     well-typed.
+func nativeVariantLitFromIR(ctx *nativeProjectionCtx, lit *ostyir.VariantLit) (*llvmNativeExpr, bool) {
+	if ctx == nil || lit == nil {
+		return nil, false
+	}
+	info, ok := nativeEnumInfoFromType(ctx, lit.Type())
+	if !ok {
+		return nil, false
+	}
+	variant, ok := info.variantsByName[lit.Variant]
+	if !ok {
+		return nil, false
+	}
+	if len(lit.Args) != len(variant.payloadIRTypes) {
+		return nil, false
+	}
+	children := make([]*llvmNativeExpr, 0, 2)
+	children = append(children, &llvmNativeExpr{
+		kind:     llvmNativeExprInt,
+		llvmType: "i64",
+		text:     strconv.Itoa(variant.tag),
+	})
+	if info.def.payloadSlotType != "" {
+		if variant.payloadLLVMType != "" {
+			if variant.payloadLLVMType != info.def.payloadSlotType {
+				return nil, false
+			}
+			arg := lit.Args[0]
+			if arg.Name != "" {
+				return nil, false
+			}
+			value, ok := nativeExprFromIRWithHint(ctx, arg.Value, variant.payloadLLVMType)
+			if !ok || value.llvmType != variant.payloadLLVMType {
+				return nil, false
+			}
+			children = append(children, value)
+		} else {
+			children = append(children, nativeZeroExprForLLVMType(info.def.payloadSlotType))
+		}
+	}
+	return &llvmNativeExpr{
+		kind:       llvmNativeExprStructLit,
+		llvmType:   info.def.llvmType,
+		childExprs: children,
+	}, true
+}
+
+// nativeBareVariantAccessFromIR matches the `Enum.Variant` field
+// access shape (no parens) and projects it as if the surface had
+// written `Enum.Variant()` — a zero-argument variant construction.
+// Returns (nil, false) when the field-expr does not name a known
+// enum variant so the caller falls through to the regular field
+// access path.
+func nativeBareVariantAccessFromIR(ctx *nativeProjectionCtx, e *ostyir.FieldExpr) (*llvmNativeExpr, bool) {
+	if ctx == nil || e == nil || e.Optional {
+		return nil, false
+	}
+	id, ok := e.X.(*ostyir.Ident)
+	if !ok || id == nil || id.Kind != ostyir.IdentTypeName {
+		return nil, false
+	}
+	info, ok := ctx.enumsByName[id.Name]
+	if !ok {
+		return nil, false
+	}
+	variant, ok := info.variantsByName[e.Name]
+	if !ok {
+		return nil, false
+	}
+	if len(variant.payloadIRTypes) != 0 {
+		// A payload-bearing variant referenced without parens is a
+		// function-value form (the constructor as a callable). Bail
+		// — only the zero-arg construction case lowers cleanly here.
+		return nil, false
+	}
+	children := []*llvmNativeExpr{{
+		kind:     llvmNativeExprInt,
+		llvmType: "i64",
+		text:     strconv.Itoa(variant.tag),
+	}}
+	if info.def.payloadSlotType != "" {
+		children = append(children, nativeZeroExprForLLVMType(info.def.payloadSlotType))
+	}
+	return &llvmNativeExpr{
+		kind:       llvmNativeExprStructLit,
+		llvmType:   info.def.llvmType,
+		childExprs: children,
+	}, true
+}
+
+// nativeZeroExprForLLVMType produces a native literal expression
+// for the zero value of a given LLVM type — used to pad the
+// enum payload slot when a payload-free variant lands inside a
+// with-payload enum.
+func nativeZeroExprForLLVMType(llvmType string) *llvmNativeExpr {
+	switch llvmType {
+	case "i1":
+		return &llvmNativeExpr{kind: llvmNativeExprBool, llvmType: "i1", boolValue: false}
+	case "double":
+		return &llvmNativeExpr{kind: llvmNativeExprFloat, llvmType: "double", text: "0.0"}
+	case "ptr":
+		return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: "ptr", text: "null"}
+	default:
+		return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: llvmType, text: "0"}
+	}
+}
+
 func nativeRuntimeCallExpr(llvmType string, name string, args ...*llvmNativeExpr) *llvmNativeExpr {
 	return &llvmNativeExpr{
 		kind:       llvmNativeExprCall,
@@ -2692,11 +3329,13 @@ func nativeLLVMTypeFromIR(ctx *nativeProjectionCtx, t ostyir.Type) (string, bool
 			}
 			return "", false
 		}
-		info, ok := nativeStructInfoFromType(ctx, tt)
-		if !ok {
-			return "", false
+		if info, ok := nativeStructInfoFromType(ctx, tt); ok {
+			return info.def.llvmType, true
 		}
-		return info.def.llvmType, true
+		if info, ok := nativeEnumInfoFromType(ctx, tt); ok {
+			return info.def.llvmType, true
+		}
+		return "", false
 	case *ostyir.OptionalType:
 		if _, ok := nativeLLVMTypeFromIR(ctx, tt.Inner); !ok {
 			return "", false

--- a/internal/llvmgen/ir_native_enum_test.go
+++ b/internal/llvmgen/ir_native_enum_test.go
@@ -1,0 +1,250 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ostyir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// Enum support lands in two stages. Stage 1 (this file) locks the
+// Osty-mirrored data model + type-def emission + projection helper.
+// Stage 2 wires the projection into `nativeModuleFromIR` so generic
+// enum modules lower end-to-end through `TryGenerateNativeOwnedModule`
+// instead of the legacy IR→AST bridge.
+
+func TestLlvmNativeEmitEnumTypeDefPayloadless(t *testing.T) {
+	got := llvmNativeEmitEnumTypeDef(&llvmNativeEnum{
+		name:     "_ZTSN4main4UnitE",
+		llvmType: "%_ZTSN4main4UnitE",
+	})
+	want := "%_ZTSN4main4UnitE = type { i64 }"
+	if got != want {
+		t.Fatalf("payloadless enum type def mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestLlvmNativeEmitEnumTypeDefWithPayload(t *testing.T) {
+	got := llvmNativeEmitEnumTypeDef(&llvmNativeEnum{
+		name:            "_ZTSN4main5MaybeIlEE",
+		llvmType:        "%_ZTSN4main5MaybeIlEE",
+		payloadSlotType: "i64",
+	})
+	want := "%_ZTSN4main5MaybeIlEE = type { i64, i64 }"
+	if got != want {
+		t.Fatalf("payload enum type def mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestLlvmNativeEmitModuleIncludesEnumTypeDefs(t *testing.T) {
+	mod := &llvmNativeModule{
+		sourcePath: "/tmp/enum_typedef.osty",
+		enums: []*llvmNativeEnum{{
+			name:            "_ZTSN4main5MaybeIlEE",
+			llvmType:        "%_ZTSN4main5MaybeIlEE",
+			payloadSlotType: "i64",
+			variants: []*llvmNativeEnumVariant{
+				{name: "Some", tag: 0, payloadType: "i64"},
+				{name: "None", tag: 1, payloadType: ""},
+			},
+		}},
+	}
+	out := llvmNativeEmitModule(mod)
+	want := "%_ZTSN4main5MaybeIlEE = type { i64, i64 }"
+	if !strings.Contains(out, want) {
+		t.Fatalf("module IR missing enum type def %q:\n%s", want, out)
+	}
+}
+
+func TestNativeRegisterEnumDeclPayloadlessAndPayload(t *testing.T) {
+	decl := &ostyir.EnumDecl{
+		Name: "_ZTSN4main5MaybeIlEE",
+		Variants: []*ostyir.Variant{
+			{Name: "Some", Payload: []ostyir.Type{ostyir.TInt}},
+			{Name: "None"},
+		},
+	}
+	ctx := &nativeProjectionCtx{}
+	info, ok := nativeRegisterEnumDecl(ctx, decl)
+	if !ok {
+		t.Fatal("nativeRegisterEnumDecl rejected Maybe<Int>-shaped enum")
+	}
+	if info.def.name != "_ZTSN4main5MaybeIlEE" {
+		t.Fatalf("enum def name = %q, want %q", info.def.name, "_ZTSN4main5MaybeIlEE")
+	}
+	if info.def.llvmType != "%_ZTSN4main5MaybeIlEE" {
+		t.Fatalf("enum def llvmType = %q, want %q", info.def.llvmType, "%_ZTSN4main5MaybeIlEE")
+	}
+	if info.def.payloadSlotType != "i64" {
+		t.Fatalf("payloadSlotType = %q, want %q", info.def.payloadSlotType, "i64")
+	}
+	if len(info.def.variants) != 2 {
+		t.Fatalf("variants len = %d, want 2", len(info.def.variants))
+	}
+	some, ok := info.variantsByName["Some"]
+	if !ok {
+		t.Fatal("variantsByName missing Some")
+	}
+	if some.tag != 0 || some.payloadLLVMType != "i64" {
+		t.Fatalf("Some variant = %+v, want tag=0 payload=i64", some)
+	}
+	none, ok := info.variantsByName["None"]
+	if !ok {
+		t.Fatal("variantsByName missing None")
+	}
+	if none.tag != 1 || none.payloadLLVMType != "" {
+		t.Fatalf("None variant = %+v, want tag=1 payload=\"\"", none)
+	}
+}
+
+func TestNativeRegisterEnumDeclRejectsGenericTemplate(t *testing.T) {
+	decl := &ostyir.EnumDecl{
+		Name:     "Maybe",
+		Generics: []*ostyir.TypeParam{{Name: "T"}},
+		Variants: []*ostyir.Variant{
+			{Name: "Some"},
+			{Name: "None"},
+		},
+	}
+	ctx := &nativeProjectionCtx{}
+	if _, ok := nativeRegisterEnumDecl(ctx, decl); ok {
+		t.Fatal("nativeRegisterEnumDecl accepted an un-monomorphized generic template")
+	}
+}
+
+// TestTryGenerateNativeOwnedModuleCoversGenericEnumMaybe locks in
+// that the stage-2 wiring actually routes `Maybe<Int>` end-to-end
+// through the native-owned path — not the legacy IR→AST bridge.
+// The sibling `TestGenerateModuleGenericEnumMaybe*` tests pass via
+// fallback too, so they don't distinguish; this one calls
+// `TryGenerateNativeOwnedModule` directly so `ok=true` is the real
+// coverage signal.
+func TestTryGenerateNativeOwnedModuleCoversGenericEnumMaybe(t *testing.T) {
+	src := `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let m: Maybe<Int> = Maybe.Some(42)
+    if let Maybe.Some(x) = m {
+        println(x)
+    } else {
+        println(0)
+    }
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ostyir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ostyir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("ir.Monomorphize errors: %v", monoErrs)
+	}
+	out, ok, err := TryGenerateNativeOwnedModule(monoMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_enum_maybe.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for Maybe<Int> — enum wiring regressed")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%_ZTSN4main5MaybeIlEE = type { i64, i64 }",
+		"insertvalue %_ZTSN4main5MaybeIlEE",
+		"extractvalue %_ZTSN4main5MaybeIlEE",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned enum IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestTryGenerateNativeOwnedModuleCoversGenericEnumMaybeNone locks
+// the payload-free variant construction shape (`Maybe.None`) under
+// a with-payload enum (`Maybe<Int>` has `Some(Int)` so the slot
+// width is non-zero). Variant zero-padding lives in
+// nativeVariantLitFromIR.
+func TestTryGenerateNativeOwnedModuleCoversGenericEnumMaybeNone(t *testing.T) {
+	src := `enum Maybe<T> { Some(T), None }
+
+fn main() {
+    let m: Maybe<Int> = Maybe.None
+    if let Maybe.None = m {
+        println(1)
+    } else {
+        println(0)
+    }
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ostyir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ostyir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("ir.Monomorphize errors: %v", monoErrs)
+	}
+	out, ok, err := TryGenerateNativeOwnedModule(monoMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_enum_none.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for Maybe.None")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%_ZTSN4main5MaybeIlEE = type { i64, i64 }",
+		"insertvalue %_ZTSN4main5MaybeIlEE",
+		"icmp eq i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned None enum IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestNativeRegisterEnumDeclRejectsMixedPayloadShapes(t *testing.T) {
+	// Mixed payload shapes require a union-sized slot the stage-1
+	// helper intentionally defers. Stage 2 will extend this with a
+	// synthesized union struct.
+	decl := &ostyir.EnumDecl{
+		Name: "_ZTSN4main6EitherIlfEE",
+		Variants: []*ostyir.Variant{
+			{Name: "L", Payload: []ostyir.Type{ostyir.TInt}},
+			{Name: "R", Payload: []ostyir.Type{ostyir.TFloat}},
+		},
+	}
+	ctx := &nativeProjectionCtx{}
+	if _, ok := nativeRegisterEnumDecl(ctx, decl); ok {
+		t.Fatal("nativeRegisterEnumDecl accepted mixed-payload enum (should defer to stage 2)")
+	}
+}

--- a/internal/llvmgen/ir_native_tuple_destructure_test.go
+++ b/internal/llvmgen/ir_native_tuple_destructure_test.go
@@ -1,0 +1,183 @@
+package llvmgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/osty/osty/internal/check"
+	ostyir "github.com/osty/osty/internal/ir"
+	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
+)
+
+// TestTryGenerateNativeOwnedModuleCoversLetTupleDestructureIdent
+// checks the RHS-is-bare-ident fast path: no temp is minted, the
+// four synthetic `let` bindings all extract directly off the
+// source ident. This is the shape the Phase 2 TupleTable test
+// uses at the end of the for-in loop.
+func TestTryGenerateNativeOwnedModuleCoversLetTupleDestructureIdent(t *testing.T) {
+	src := `fn main() {
+    let c = (5, 0, 10, 5)
+    let (v, lo, hi, expected) = c
+    println(v)
+    println(lo)
+    println(hi)
+    println(expected)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_tuple_destructure_ident.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for let-tuple-destructure on bare ident")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Tuple.i64.i64.i64.i64",
+		"extractvalue %Tuple.i64.i64.i64.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestTryGenerateNativeOwnedModuleCoversLetTupleDestructureSpill
+// checks the spill-to-temp path: the RHS is a non-ident expression
+// (function call), so the helper mints a fresh `__osty_native_t<N>`
+// binding and reuses it across the element extractions.
+func TestTryGenerateNativeOwnedModuleCoversLetTupleDestructureSpill(t *testing.T) {
+	src := `fn makePair() -> (Int, Int) {
+    (7, 9)
+}
+
+fn main() {
+    let (a, b) = makePair()
+    println(a + b)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_tuple_destructure_spill.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for let-tuple-destructure on fn-call RHS")
+	}
+	got := string(out)
+	// The native SSA namer mints its own `%tN` labels at emit time,
+	// so the synthesized `__osty_native_t<N>` user-level name
+	// doesn't leak into the LLVM IR verbatim. Structurally verify:
+	// the spill call, the tuple type, and two field extracts.
+	for _, want := range []string{
+		"%Tuple.i64.i64 = type { i64, i64 }",
+		"call %Tuple.i64.i64 @makePair()",
+		"extractvalue %Tuple.i64.i64",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestTryGenerateNativeOwnedModuleCoversForInOverTupleList locks
+// the combined for-in-over-list + let-tuple-destructure wiring used
+// by the Phase 2 `TupleTableDrivenLoop` source. The native path
+// must both iterate a `List<Tuple>` (via the range expansion over
+// `list.len()`) and pattern-match each element back into four
+// named i64 bindings.
+func TestTryGenerateNativeOwnedModuleCoversForInOverTupleList(t *testing.T) {
+	src := `fn clamp(v: Int, lo: Int, hi: Int) -> Int {
+    if v < lo { lo } else if v > hi { hi } else { v }
+}
+
+fn main() {
+    let cases = [
+        (5, 0, 10, 5),
+        (-1, 0, 10, 0),
+        (99, 0, 10, 10),
+    ]
+    for c in cases {
+        let (v, lo, hi, expected) = c
+        println(clamp(v, lo, hi) - expected)
+    }
+}
+`
+	file := parseLLVMGenFile(t, src)
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+	mod, issues := ostyir.Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("ir.Lower issues: %v", issues)
+	}
+	monoMod, monoErrs := ostyir.Monomorphize(mod)
+	if len(monoErrs) != 0 {
+		t.Fatalf("ir.Monomorphize errors: %v", monoErrs)
+	}
+	out, ok, err := TryGenerateNativeOwnedModule(monoMod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_for_in_tuple.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for tuple-table-driven loop")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"%Tuple.i64.i64.i64.i64",
+		"call void @osty_rt_list_push_bytes_v1(",
+		"call void @osty_rt_list_get_bytes_v1(",
+		"extractvalue %Tuple.i64.i64.i64.i64",
+		"call i64 @osty_rt_list_len(ptr",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestNativeLetTupleDestructureRejectsNonIdentElement — destructure
+// elements other than plain `IdentPat` bindings defer to the legacy
+// bridge until follow-up coverage lands. Nested `let (a, (b, c)) = t`
+// is the canonical example; the whole module must stay uncovered
+// natively so GenerateModule routes to the AST path.
+func TestNativeLetTupleDestructureRejectsNonIdentElement(t *testing.T) {
+	src := `fn main() {
+    let nested = ((1, 2), 3)
+    let ((a, b), c) = nested
+    println(a + b + c)
+}
+`
+	mod := lowerNativeEntryModule(t, src)
+	_, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+		PackageName: "main",
+		SourcePath:  "/tmp/native_tuple_destructure_reject.osty",
+	})
+	if err != nil {
+		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
+	}
+	if ok {
+		t.Fatal("TryGenerateNativeOwnedModule unexpectedly covered nested tuple destructure — stage-1 should defer")
+	}
+	_ = resolve.FileWithStdlib // force import used on other tests
+	_ = check.File
+	_ = stdlib.LoadCached
+	_ = ostyir.ForIn
+}

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -121,6 +121,28 @@ type llvmNativeStruct struct {
 	fields   []*llvmNativeStructField
 }
 
+// llvmNativeEnumVariant mirrors toolchain/llvmgen.osty's
+// `LlvmNativeEnumVariant`. `tag` is the 0-based discriminant in
+// declaration order; `payloadType` is the LLVM type string of the
+// single payload slot (empty for payload-free variants).
+type llvmNativeEnumVariant struct {
+	name        string
+	tag         int
+	payloadType string
+}
+
+// llvmNativeEnum mirrors toolchain/llvmgen.osty's `LlvmNativeEnum`.
+// Storage layout is `{ i64 tag, <payloadSlotType> }` or `{ i64 tag }`.
+// By convention `name` is the bare mangled identifier (e.g.
+// "_ZTSN4main5MaybeIlEE") and `llvmType` is the same with a leading
+// `%`. The IR projection layer owns that invariant.
+type llvmNativeEnum struct {
+	name            string
+	llvmType        string
+	payloadSlotType string
+	variants        []*llvmNativeEnumVariant
+}
+
 type llvmNativeFunction struct {
 	name       string
 	returnType string
@@ -134,6 +156,7 @@ type llvmNativeModule struct {
 	target             string
 	globals            []*llvmNativeGlobal
 	structs            []*llvmNativeStruct
+	enums              []*llvmNativeEnum
 	stringGlobals      []*LlvmStringGlobal
 	functions          []*llvmNativeFunction
 	needsListRuntime   bool
@@ -171,6 +194,12 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 		}
 		typeDefs = append(typeDefs, llvmStructTypeDef(strings.TrimPrefix(st.llvmType, "%"), fieldTypes))
 	}
+	for _, en := range mod.enums {
+		if en == nil {
+			continue
+		}
+		typeDefs = append(typeDefs, llvmNativeEmitEnumTypeDef(en))
+	}
 	for _, global := range mod.globals {
 		if global == nil {
 			continue
@@ -195,6 +224,23 @@ func llvmNativeEmitModule(mod *llvmNativeModule) string {
 		llvmNativeRuntimeDeclarations(mod),
 		definitions,
 	)
+}
+
+// llvmNativeEmitEnumTypeDef mirrors the Osty-side helper in
+// toolchain/llvmgen.osty. Enums lower to tagged-union structs:
+// `{ i64 tag, <payload> }`. Variant construction/destruction reuses
+// the existing struct machinery (llvmStructLiteral / llvmExtractValue)
+// in the projection layer, so the emit path has no variant-literal
+// primitive of its own.
+func llvmNativeEmitEnumTypeDef(en *llvmNativeEnum) string {
+	if en == nil {
+		return ""
+	}
+	fieldTypes := []string{"i64"}
+	if en.payloadSlotType != "" {
+		fieldTypes = append(fieldTypes, en.payloadSlotType)
+	}
+	return llvmStructTypeDef(en.name, fieldTypes)
 }
 
 func llvmNativeRuntimeDeclarations(mod *llvmNativeModule) []string {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -1239,6 +1239,32 @@ pub struct LlvmNativeStruct {
     pub fields: List<LlvmNativeStructField>,
 }
 
+// A single enum variant after monomorphization. `tag` is the
+// 0-based discriminant assigned in declaration order. `payloadType`
+// is the LLVM type string of the single payload slot (empty if the
+// variant carries no payload — e.g. `None`). Multi-payload variants
+// are handled by the IR projection layer: it synthesizes a helper
+// struct type to hold the tuple and stores its LLVM type here.
+pub struct LlvmNativeEnumVariant {
+    pub name: String,
+    pub tag: Int,
+    pub payloadType: String,
+}
+
+// Monomorphized tagged-union enum. `llvmType` carries the mangled
+// specialization name (e.g. "%_ZTSN4main5MaybeIlEE") so the emitter
+// can round-trip it verbatim. `payloadSlotType` is the unified
+// payload slot's LLVM type — empty when every variant is
+// payload-free, otherwise sized to fit the largest variant payload
+// selected by the IR projection layer. Storage layout is
+// `{ i64 tag, <payloadSlotType> }` or `{ i64 tag }`.
+pub struct LlvmNativeEnum {
+    pub name: String,
+    pub llvmType: String,
+    pub payloadSlotType: String,
+    pub variants: List<LlvmNativeEnumVariant>,
+}
+
 pub struct LlvmNativeFunction {
     pub name: String,
     pub returnType: String,
@@ -1251,6 +1277,7 @@ pub struct LlvmNativeModule {
     pub target: String,
     pub globals: List<LlvmNativeGlobal>,
     pub structs: List<LlvmNativeStruct>,
+    pub enums: List<LlvmNativeEnum>,
     pub stringGlobals: List<LlvmStringGlobal>,
     pub functions: List<LlvmNativeFunction>,
     pub needsListRuntime: Bool,
@@ -1281,6 +1308,9 @@ pub fn llvmNativeEmitModule(module: LlvmNativeModule) -> String {
             fieldTypes.push(field.llvmType)
         }
         typeDefs.push(llvmStructTypeDef(st.name, fieldTypes))
+    }
+    for en in module.enums {
+        typeDefs.push(llvmNativeEmitEnumTypeDef(en))
     }
     for global in module.globals {
         let kind = if global.mutable { "global" } else { "constant" }
@@ -1329,6 +1359,23 @@ fn llvmNativeRuntimeDeclarations(module: LlvmNativeModule) -> List<String> {
         }
     }
     out
+}
+
+// Emit a monomorphized enum's storage type definition. Enums lower
+// to a tagged-union struct: `{ i64 tag, <payload> }`. Variant
+// construction/destruction reuses the existing struct machinery —
+// `llvmStructLiteral` for construction, `llvmExtractValue` for
+// tag/payload access — so the emit path never needs a dedicated
+// variant-literal primitive. Convention: `name` is the bare
+// identifier (e.g. "_ZTSN4main5MaybeIlEE"), `llvmType` is the
+// same with a leading `%`. The IR projection layer is responsible
+// for keeping the two in sync when populating the struct.
+fn llvmNativeEmitEnumTypeDef(en: LlvmNativeEnum) -> String {
+    let mut fieldTypes: List<String> = ["i64"]
+    if en.payloadSlotType != "" {
+        fieldTypes.push(en.payloadSlotType)
+    }
+    llvmStructTypeDef(en.name, fieldTypes)
 }
 
 pub fn llvmNativeEmitFunction(


### PR DESCRIPTION
## Summary

legacyFileFromModule 제거 경로 두 번째 batch. 네이티브 projection 에
generic enum (모노모프화된 `Maybe<Int>` 등), `let` tuple destructuring,
`List<T>` 에 대한 for-in 3 가지 shape 를 직접 lower 해서
`TryGenerateNativeOwnedModule` 가 legacy IR→AST 브리지를 거치지 않고
그대로 흡수하게 했습니다. 새 LlvmNative 표현식/문 종류는 추가하지 않고
기존 primitive 만 재사용.

## 무엇이 바뀌나

**toolchain/llvmgen.osty (source of truth)**
- `LlvmNativeEnumVariant` / `LlvmNativeEnum` struct + `LlvmNativeModule.enums` 필드
- `llvmNativeEmitModule` 이 enum 저장구조 `{ i64 tag, <payload> }` 를 type-def 로 방출
- variant 생성/추출은 기존 `llvmStructLiteral` / `llvmExtractValue` 재사용 (enum 전용 evaluator 없음)

**internal/llvmgen/native_entry_snapshot.go (Go 미러)**
- 위 타입/헬퍼의 Go-side 수동 미러 (snapshot 재생성 파이프라인은 pre-existing drift 로 별개)

**internal/llvmgen/ir_native_entry.go (IR → native projection)**
- `enumsByName` 맵 + `tempCounter` + `freshTempName`
- `nativeRegisterEnumDecl` / `nativeEnumInfoFromType` — 모노모프 EnumDecl 등록
- `nativeVariantLitFromIR` — `Maybe.Some(42)` → `{ tag, payload }` struct lit
- `nativeBareVariantAccessFromIR` — `Maybe.None` (괄호 없는 FieldExpr) 경로
- `nativeIfLetVariantStmt` — `if let Variant(x) = m` → tag-compare If stmt, payload binding 은 then-block 선두에 prepend
- `nativeStmtsFromIR` 1-to-many fan-out wrapper + `nativeLetTupleDestructureStmts` + `nativeForInListStmts`
- unit-typed tail expression 을 block result 로 promote 하지 않도록 `nativeBlockFromIR` 가드 (main 의 `ret i32 0` auto-terminator 와 충돌 방지)

## 왜

이전 batch 종료 시점에서 22 개 테스트가 legacy fallback 에 의존하고
있었고, 그중 연관된 cluster 두 개 (generic enum 3 건 +
TupleTableDrivenLoop 1 건) 가 기존 emitter primitive 만으로 충분히
표현 가능한 shape 였습니다. 이걸 네이티브로 흡수해 두면 legacyFile-
FromModule 을 실제로 제거할 때 부담이 줄어듭니다.

## 회귀 측정

legacy fallback 을 비활성화한 상태로 `go test ./internal/llvmgen/` 를
돌리면 native-uncovered 실패가 22 → 19 건으로 줄었습니다. 추가로
흡수된 테스트:

- `TestGenerateModuleGenericEnumMaybeMonomorphized`
- `TestGenerateModuleGenericEnumMaybeInferredFromPayload`
- `TestGenerateModuleGenericEnumMaybeNoneFromLetContext`
- `TestGenerateModuleTupleTableDrivenLoopCompat`

pre-existing 2 건 (`TestGoGenerateSupportSnapshotIsFixedPoint`,
`TestNativeToolchainMergedMIRErrTypeFloor`) 외 새 회귀 없음.

## 리뷰 포인트

- **Osty ↔ Go 미러**: `toolchain/llvmgen.osty` 와 `native_entry_snapshot.go`
  의 새 구조체 / 헬퍼가 필드 순서와 타입까지 정확히 대응하는지 확인.
  `TestGoGenerateSupportSnapshotIsFixedPoint` 는 pre-existing drift 로
  이미 red 라서 이번 커밋으로는 검증되지 않습니다. snapshot 재생성은
  별도 정리 필요.
- **enum 스토리지 규약**: `name` 은 bare `_ZTSN…` 식별자, `llvmType` 은
  `%`-prefixed. `payloadSlotType` 이 "" 이면 `{ i64 }`, 아니면
  `{ i64, <type> }`. IR projection 에서만 이 규약을 채우도록 격리했습니다.
- **Mixed-payload enum**: 현재 구현은 variant 별 payload type 이 동일할
  때만 수용. `Either<L, R>` 같은 shape 는 여전히 legacy fallback 으로
  떨어지며 `TestNativeRegisterEnumDeclRejectsMixedPayloadShapes` 로 lock.
- **Fan-out wrapper**: `nativeStmtsFromIR` 은 기본적으로 `nativeStmtFromIR`
  를 one-element slice 로 감싸고, tuple-destructure let 과 for-in 만
  fan-out 경로로 넘깁니다. 다른 호출자가 생기면 여기에 특수 케이스 추가.
- **남은 fallback 의존 테스트**: closure lift (5), interface vtable (8),
  Result 전용 mangling (2), std.testing / FFI 무거운 것 (3), mut-self
  wall 가드 (1). legacyFileFromModule 실제 제거까지 몇 batch 남았습니다.

## Test plan

- [x] `go build ./internal/llvmgen/`
- [x] `go test -short ./internal/llvmgen/` — green
- [x] 신규 11 개 coverage 테스트 모두 통과 (enum 6 + tuple/for-in 4 + mixed-payload reject 1)
- [x] 기존 `TestGenerateModuleGenericEnumMaybe*` 3 건 및 `TestGenerateModuleTupleTableDrivenLoopCompat` 가 native 경로로 흡수되는지 직접 확인
- [ ] 리뷰어: `go test ./...` 전체 — pre-existing 2 건 외 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)