### PR TITLE
refactor: runCheckFileLegacy + runTypecheckFileLegacy extraction with astbridge baseline tests

### DIFF
--- a/cmd/osty/check_legacy_baseline_test.go
+++ b/cmd/osty/check_legacy_baseline_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// captureStdouterr redirects os.Stdout + os.Stderr to io.Discard for
+// the duration of fn, so subcommand bodies that call printDiags /
+// printTypes don't pollute go test output when the test only cares
+// about the astbridge counter.
+func captureStdouterr(t *testing.T, fn func()) {
+	t.Helper()
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
+	fn()
+	_ = wout.Close()
+	_ = werr.Close()
+	<-drained
+	<-drained
+}
+
+// warmStdlibCachesForBaseline is the shared pre-step for the legacy
+// baseline assertions: run the legacy path once before taking a
+// measurement so stdlib/canonical/checker caches stabilize. On a
+// cold process the first run bumps the astbridge counter for every
+// lazily-parsed stdlib module (hundreds of bumps on a trivial
+// source); subsequent runs see those already-parsed and only lower
+// the user-file AST. Measuring the warm state is what "baseline" is
+// supposed to capture.
+func warmStdlibCachesForBaseline(t *testing.T, path string, src []byte, flags cliFlags) {
+	t.Helper()
+	formatter := newFormatter(path, src, flags)
+	captureStdouterr(t, func() {
+		_ = runCheckFileLegacy(path, src, formatter, flags)
+		_ = runTypecheckFileLegacy(path, src, formatter, flags)
+	})
+}
+
+// TestRunCheckFileLegacyAstbridgeBaseline documents the CURRENT
+// warm-cache astbridge cost of the non-native `osty check FILE`
+// path. A cold first run bumps the counter dozens to hundreds of
+// times because stdlib modules lower lazily through the Go checker;
+// once those caches are warm, each subsequent check lowers exactly
+// the user's own file.
+//
+// This is a regression floor for the warm path: native bumps 0,
+// legacy bumps exactly 1 per call. The contrast is the migration
+// signal — if the legacy number grows, something started
+// re-lowering per call; if the native number becomes non-zero,
+// something leaked an astbridge detour into the arena pipeline.
+func TestRunCheckFileLegacyAstbridgeBaseline(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true}
+	warmStdlibCachesForBaseline(t, path, src, flags)
+
+	formatter := newFormatter(path, src, flags)
+	selfhost.ResetAstbridgeLowerCount()
+	var exit int
+	captureStdouterr(t, func() {
+		exit = runCheckFileLegacy(path, src, formatter, flags)
+	})
+	if exit != 0 {
+		t.Fatalf("runCheckFileLegacy exit = %d, want 0", exit)
+	}
+	const want = 1
+	if got := selfhost.AstbridgeLowerCount(); got != want {
+		t.Fatalf("AstbridgeLowerCount after warm runCheckFileLegacy = %d, want %d (legacy warm-path = one *ast.File lowering per user file via parser.ParseDetailed)", got, want)
+	}
+}
+
+// TestRunTypecheckFileLegacyAstbridgeBaseline is the typecheck
+// sibling. Same warm-cache expectation as the check baseline — one
+// bump for the user file, zero for stdlib because those are
+// lower-and-cached once per process.
+func TestRunTypecheckFileLegacyAstbridgeBaseline(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true}
+	warmStdlibCachesForBaseline(t, path, src, flags)
+
+	formatter := newFormatter(path, src, flags)
+	selfhost.ResetAstbridgeLowerCount()
+	var exit int
+	captureStdouterr(t, func() {
+		exit = runTypecheckFileLegacy(path, src, formatter, flags)
+	})
+	if exit != 0 {
+		t.Fatalf("runTypecheckFileLegacy exit = %d, want 0", exit)
+	}
+	const want = 1
+	if got := selfhost.AstbridgeLowerCount(); got != want {
+		t.Fatalf("AstbridgeLowerCount after warm runTypecheckFileLegacy = %d, want %d", got, want)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -523,19 +523,7 @@ func main() {
 			}
 			return
 		}
-		parsed := parser.ParseDetailed(src)
-		file, diags := parsed.File, parsed.Diagnostics
-		res := resolveFile(file)
-		chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
-		all := append(append(append([]*diag.Diagnostic{}, diags...), res.Diags...), chk.Diags...)
-		printDiags(formatter, all, flags)
-		if flags.inspect {
-			runInspect(file, chk, flags)
-		}
-		if flags.dumpNativeDiags {
-			dumpNativeDiagsFor(path, chk)
-		}
-		if hasError(all) {
+		if runCheckFileLegacy(path, src, formatter, flags) != 0 {
 			os.Exit(1)
 		}
 	case "typecheck":
@@ -549,14 +537,7 @@ func main() {
 			}
 			return
 		}
-		parsed := parser.ParseDetailed(src)
-		file, diags := parsed.File, parsed.Diagnostics
-		res := resolveFile(file)
-		chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
-		all := append(append(append([]*diag.Diagnostic{}, diags...), res.Diags...), chk.Diags...)
-		printDiags(formatter, all, flags)
-		printTypes(chk)
-		if hasError(all) {
+		if runTypecheckFileLegacy(path, src, formatter, flags) != 0 {
 			os.Exit(1)
 		}
 	case "resolve":
@@ -1222,6 +1203,51 @@ func byteOffsetLineCol(src []byte, offset int) (int, int) {
 		col++
 	}
 	return line, col
+}
+
+// runCheckFileLegacy is the extracted `osty check FILE` body (the
+// path taken when --native is NOT set). It calls parser.ParseDetailed
+// (which lowers *ast.File via astbridge — one AstbridgeLowerCount
+// bump per call), then runs the Go-native resolver + check.File
+// pair, renders diagnostics, and optionally runs --inspect /
+// --dump-native-diags. Extracted alongside runCheckFileNative so
+// baseline counter tests can exercise the legacy path in-process
+// and pin its current astbridge cost as a regression floor.
+func runCheckFileLegacy(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
+	parsed := parser.ParseDetailed(src)
+	file, diags := parsed.File, parsed.Diagnostics
+	res := resolveFile(file)
+	chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
+	all := append(append(append([]*diag.Diagnostic{}, diags...), res.Diags...), chk.Diags...)
+	printDiags(formatter, all, flags)
+	if flags.inspect {
+		runInspect(file, chk, flags)
+	}
+	if flags.dumpNativeDiags {
+		dumpNativeDiagsFor(path, chk)
+	}
+	if hasError(all) {
+		return 1
+	}
+	return 0
+}
+
+// runTypecheckFileLegacy is the extracted `osty typecheck FILE` body
+// (non-native path). Same astbridge cost profile as
+// runCheckFileLegacy — one bump from parser.ParseDetailed — plus the
+// Go-native printTypes pass over check.Result.Types.
+func runTypecheckFileLegacy(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
+	parsed := parser.ParseDetailed(src)
+	file, diags := parsed.File, parsed.Diagnostics
+	res := resolveFile(file)
+	chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
+	all := append(append(append([]*diag.Diagnostic{}, diags...), res.Diags...), chk.Diags...)
+	printDiags(formatter, all, flags)
+	printTypes(chk)
+	if hasError(all) {
+		return 1
+	}
+	return 0
 }
 
 // runCheckFileNative drives `osty check --native FILE` end-to-end on


### PR DESCRIPTION
## Summary

Mirrors the earlier extractions of `runResolveFile` ([#628](https://github.com/choiceoh/osty/pull/628)) and `runCheckFileNative` ([#632](https://github.com/choiceoh/osty/pull/632)): the non-native `case \"check\"` / `case \"typecheck\"` bodies are now named functions that return an exit code, so they can be exercised in-process and pinned by counter assertions. Combined with the existing `*Native` tests, we now have matching baseline numbers for both the legacy and native paths — future changes in either direction fail loudly.

## What changed

- `runCheckFileLegacy(path, src, formatter, flags) int` — extracted from `case \"check\"` (non-native branch). Same `parser.ParseDetailed` → `resolveFile` → `check.File` → `printDiags` pipeline. Returns exit code instead of calling `os.Exit`.
- `runTypecheckFileLegacy(path, src, formatter, flags) int` — the typecheck sibling; adds `printTypes` on top.
- `TestRunCheckFileLegacyAstbridgeBaseline` + typecheck sibling: warm the stdlib/canonical/checker caches once (per-process lazy lowerings would otherwise dominate cold-run counts and mask genuine regressions), then assert exactly **1** astbridge lowering per subsequent call — the user file's own `*ast.File` through `parser.ParseDetailed`.
- `warmStdlibCachesForBaseline` helper — documented shared pre-step so the cold-vs-warm distinction is explicit in the test file.

## Why

Every PR in the `--native` wedge series has pinned the native path at `AstbridgeLowerCount == 0`. That's half of a useful regression net: the other half is knowing what the **legacy** path costs, so accidental movement shows up.

Without a baseline assertion, someone could:
- Introduce a second parse pass in the Go-native check path and not notice (the legacy number would double silently).
- Accidentally wire `run.File()` into the native CLI body (the native number would match legacy, which is \"passing\" if you only look at the delta).

With this PR, the matrix is:

| Path | Warm astbridge bumps |
|---|---|
| `runCheckFileLegacy` | 1 |
| `runCheckFileNative` | 0 |
| `runTypecheckFileLegacy` | 1 |
| `runTypecheckFileNative` | 0 |

Any movement in any cell fails a test, making the cost/benefit of each refactor immediately visible.

## Proof

```
TestRunCheckFileLegacyAstbridgeBaseline      PASS   (warm = 1)
TestRunTypecheckFileLegacyAstbridgeBaseline  PASS   (warm = 1)
TestRunCheckFileNativeIsAstbridgeFree        PASS   (warm = 0)
TestRunTypecheckFileNativeIsAstbridgeFree    PASS   (warm = 0)
```

The `warmStdlibCachesForBaseline` helper pre-runs the legacy pipeline once so subsequent measurements only count the user file. Cold-run counts on the legacy path currently hit ~300 bumps (lazy stdlib module lowerings) — those are a separate, process-lifetime cost we can't attribute to any single subcommand run.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] All 4 baseline + native counter tests green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- The extraction is behavior-preserving — `case \"check\"` / `case \"typecheck\"` are now one-line wrappers that forward to the extracted function and call `os.Exit(1)` on non-zero. Existing subprocess tests (`TestCheckCLINative*`, etc.) still pass unchanged.
- The cold-path bump count reflects the Go checker's lazy stdlib loading (modules get parsed + lowered on first access per process). That's a meaningful but orthogonal cost — this PR intentionally doesn't try to characterize it because (a) it varies with fixture set, (b) it's a one-time-per-process cost, and (c) the warm-path measurement is what actually changes when someone alters the check pipeline's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)