### PR TITLE
refactor: runCheckPackageLegacy extraction + DIR astbridge baseline test

### DIFF
--- a/cmd/osty/check_legacy_baseline_test.go
+++ b/cmd/osty/check_legacy_baseline_test.go
@@ -99,6 +99,56 @@ func TestRunCheckFileLegacyAstbridgeBaseline(t *testing.T) {
 	}
 }
 
+// TestRunCheckPackageLegacyAstbridgeBaseline is the DIR sibling of
+// TestRunCheckFileLegacyAstbridgeBaseline: every file in the package
+// gets its *ast.File materialized during resolve.LoadPackage, so the
+// warm-path cost scales linearly with file count. A two-file package
+// bumps the counter exactly twice. Any change here (caching,
+// deferred lowering, batched parsing) will flag a shift in the
+// legacy DIR pipeline's per-file cost.
+//
+// Pair with TestRunCheckPackageNativeIsAstbridgeFree (which asserts
+// 0 for the same two-file shape) to measure the delta between the
+// legacy and native DIR paths.
+func TestRunCheckPackageLegacyAstbridgeBaseline(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	flags := cliFlags{noColor: true}
+
+	// Warm the stdlib/canonical/checker caches once so the
+	// measurement reflects per-invocation cost only (same rationale
+	// as warmStdlibCachesForBaseline for the FILE path).
+	captureStdouterr(t, func() {
+		_ = runCheckPackageLegacy(dir, flags)
+	})
+
+	selfhost.ResetAstbridgeLowerCount()
+	var exit int
+	captureStdouterr(t, func() {
+		exit = runCheckPackageLegacy(dir, flags)
+	})
+	if exit != 0 {
+		t.Fatalf("runCheckPackageLegacy exit = %d, want 0", exit)
+	}
+	const want = 2 // two source files, one *ast.File lowering each
+	if got := selfhost.AstbridgeLowerCount(); got != want {
+		t.Fatalf("AstbridgeLowerCount after warm runCheckPackageLegacy = %d, want %d (one *ast.File per package file via resolve.LoadPackageWithTransform)", got, want)
+	}
+}
+
 // TestRunTypecheckFileLegacyAstbridgeBaseline is the typecheck
 // sibling. Same warm-cache expectation as the check baseline — one
 // bump for the user file, zero for stdlib because those are

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -673,6 +673,19 @@ func runCheckPackage(dir string, flags cliFlags) {
 		runCheckWorkspace(dir, flags)
 		return
 	}
+	if code := runCheckPackageLegacy(dir, flags); code != 0 {
+		os.Exit(code)
+	}
+}
+
+// runCheckPackageLegacy is the extracted single-package body of
+// runCheckPackage (the non-native branch, after manifest + workspace
+// dispatching). Returns an exit code instead of calling os.Exit so
+// the legacy DIR path is exercisable in-process alongside
+// runCheckPackageNative — symmetric to runCheckFileLegacy (#639).
+// Callers that previously relied on os.Exit semantics should
+// propagate the returned code.
+func runCheckPackageLegacy(dir string, flags cliFlags) int {
 	// Single-package path: enable the native-checker cache anchored
 	// at the best manifest root we can find, falling back to dir.
 	cacheRoot := dir
@@ -683,7 +696,7 @@ func runCheckPackage(dir string, flags cliFlags) {
 	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("check"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	chk := check.Package(pkg, res, checkOpts())
@@ -696,8 +709,9 @@ func runCheckPackage(dir string, flags cliFlags) {
 		dumpNativeDiagsFor(dir, chk)
 	}
 	if hasError(diags) {
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 // manifestLookupNear reports whether an osty.toml is reachable from


### PR DESCRIPTION
## Summary

Extends the FILE baseline work from [#639](https://github.com/choiceoh/osty/pull/639) to the DIR path. The single-package (non-workspace) body of `runCheckPackage` is now a named function that returns an exit code, symmetric to `runCheckPackageNative`, so the legacy DIR pipeline's astbridge cost can be pinned in-process alongside the native version's 0-bump guarantee.

## What changed

- `runCheckPackageLegacy(dir, flags) int` — extracted from the post-workspace block of `runCheckPackage`. Returns an exit code instead of calling `os.Exit`. The manifest + workspace dispatching stays in `runCheckPackage` so the caller-observed CLI flow is unchanged.
- `TestRunCheckPackageLegacyAstbridgeBaseline` — two-file package, warm caches once, asserts `AstbridgeLowerCount == 2` after a warm invocation (one `*ast.File` per package file via `resolve.LoadPackageWithTransform`). Pairs with `TestRunCheckPackageNativeIsAstbridgeFree` (which asserts 0 for the same shape) to track the legacy-vs-native DIR delta.

## Why

#639 pinned the FILE baseline matrix (legacy = 1, native = 0) for both `check` and `typecheck`. The DIR path was still asymmetric: native pinned at 0, legacy unmeasured. Any accidental reduction in loader parsing, or silent growth from a second pass, would slip past existing tests.

This PR closes that gap so the legacy DIR pipeline has the same regression floor as the FILE path. Combined matrix:

| Path | Warm astbridge bumps |
|---|---|
| `runCheckFileLegacy` | 1 |
| `runCheckFileNative` | 0 |
| `runTypecheckFileLegacy` | 1 |
| `runTypecheckFileNative` | 0 |
| `runCheckPackageLegacy` (N=2) | 2 |
| `runCheckPackageNative` (N=2) | 0 |

## Proof

```
TestRunCheckPackageLegacyAstbridgeBaseline   PASS  (warm 2-file = 2)
TestRunCheckPackageNativeIsAstbridgeFree     PASS  (warm 2-file = 0)
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] Both baseline + native counter tests green

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- The extraction is behavior-preserving. `runCheckPackage` still handles manifest validation, workspace detection, and `--native` dispatch up front; only the tail block (the actual single-package check) is extracted. Existing CLI tests pass unchanged.
- The baseline assertion is `warm == 2`, not `cold == something`. Cold runs on the legacy DIR path see stdlib module lowerings bubble up (same rationale as the FILE path in #639). The warm count is what moves when the check pipeline's shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)