### PR TITLE
fix: drop spurious Go-fallback in resolve DIR for empty native rows

### DIFF
--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -1344,18 +1344,23 @@ func runResolveFile(path string, src []byte, formatter *diag.Formatter, flags cl
 
 // runResolvePackage is runCheckPackage plus a resolution dump per file.
 func runResolvePackage(dir string, flags cliFlags) {
-	// Happy path: LoadPackageForNative produces selfhost FrontendRuns
-	// per file and leaves pf.File nil, so the astbridge-based *ast.File
-	// lowering is not triggered unless a fallback explicitly needs it
-	// (--show-scopes, or the Go-native resolver printing branch). The
-	// Go-native fallback is kept so that printResolutionRefs /
-	// printScopeTree still work when callers rely on them — each
-	// EnsureFile*() call materializes the *ast.File lazily and caches
-	// it for subsequent passes.
+	if code := runResolvePackageInner(dir, flags); code != 0 {
+		os.Exit(code)
+	}
+}
+
+// runResolvePackageInner is the extracted body of runResolvePackage,
+// returning an exit code instead of calling os.Exit so the DIR
+// resolve happy path is exercisable in-process for astbridge counter
+// assertions. Same behavior as the previous inline body —
+// LoadPackageForNative produces FrontendRuns per file and leaves
+// pf.File nil until a fallback (--show-scopes / Go-native resolver
+// printing branch) calls EnsureFile lazily.
+func runResolvePackageInner(dir string, flags cliFlags) int {
 	pkg, err := resolve.LoadPackageForNativeWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("resolve"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	var res *resolve.PackageResult
 	ensureGoResolve := func() *resolve.PackageResult {
@@ -1376,30 +1381,46 @@ func runResolvePackage(dir string, flags cliFlags) {
 		diags = r.Diags
 	}
 	printPackageDiags(pkg, diags, flags)
-	if nativeRowsUsed := false; true {
-		for _, f := range pkg.Files {
-			rows, err := nativeResolvePackageRows(pkg, f.Path)
-			if err != nil || len(rows) == 0 {
-				ensureGoResolve()
-				if len(f.Refs) == 0 {
-					continue
-				}
-				fmt.Printf("# %s\n", f.Path)
-				printResolutionRefs(f.Refs)
+	nativeRowsUsed := false
+	nativeErrored := false
+	for _, f := range pkg.Files {
+		rows, err := nativeResolvePackageRows(pkg, f.Path)
+		if err != nil {
+			// Only a hard error in the native row builder justifies
+			// forcing the Go fallback (which would trigger
+			// EnsureFiles and therefore per-file astbridge
+			// lowerings). An empty row slice from a clean file is
+			// legitimate output — declaration-only files genuinely
+			// have no refs to print — and must NOT drag the rest of
+			// the package through *ast.File.
+			nativeErrored = true
+			ensureGoResolve()
+			if len(f.Refs) == 0 {
 				continue
 			}
-			nativeRowsUsed = true
 			fmt.Printf("# %s\n", f.Path)
-			printNativeResolutionRows(rows)
+			printResolutionRefs(f.Refs)
+			continue
 		}
-		if !nativeRowsUsed {
-			for _, f := range pkg.Files {
-				if len(f.Refs) == 0 {
-					continue
-				}
-				fmt.Printf("# %s\n", f.Path)
-				printResolutionRefs(f.Refs)
+		if len(rows) == 0 {
+			// No refs in this file — declaration-only, skip silently.
+			continue
+		}
+		nativeRowsUsed = true
+		fmt.Printf("# %s\n", f.Path)
+		printNativeResolutionRows(rows)
+	}
+	if nativeErrored && !nativeRowsUsed {
+		// Native row generation failed for every file we tried —
+		// fall back to the Go resolver's Refs so the output is not
+		// silently empty. EnsureFiles has already been called by
+		// the loop above in this branch.
+		for _, f := range pkg.Files {
+			if len(f.Refs) == 0 {
+				continue
 			}
+			fmt.Printf("# %s\n", f.Path)
+			printResolutionRefs(f.Refs)
 		}
 	}
 	if flags.showScopes {
@@ -1410,8 +1431,9 @@ func runResolvePackage(dir string, flags cliFlags) {
 		printScopeTree(pkg.PkgScope)
 	}
 	if hasError(diags) {
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 // printPackageDiags groups diagnostics by source file so each one is

--- a/cmd/osty/resolve_native_test.go
+++ b/cmd/osty/resolve_native_test.go
@@ -64,6 +64,69 @@ fn main() {
 	}
 }
 
+// TestRunResolvePackageHappyPathIsAstbridgeFree is the DIR sibling of
+// TestRunResolveFileHappyPathIsAstbridgeFree. A two-file clean
+// package should round-trip through runResolvePackageInner with zero
+// astbridge lowerings — LoadPackageForNative gives us FrontendRuns
+// per file, native diagnostics + native rows don't need *ast.File,
+// and the EnsureFiles fallback should never fire on this input
+// (native rows are always available for resolvable refs).
+//
+// Any non-zero count means the DIR CLI body regressed: either a
+// fallback triggered unnecessarily (ensureGoResolve ran when it
+// shouldn't), or a new call site leaked run.File() in. Pairs with
+// the library-level TestLoadPackageForNativeMultiFileIsAstbridgeFree
+// to cover the entire stack from loader to printer.
+func TestRunResolvePackageHappyPathIsAstbridgeFree(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let value = helper()
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	rout, wout, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rerr, werr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wout
+	os.Stderr = werr
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	})
+	drained := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(io.Discard, rout); drained <- struct{}{} }()
+	go func() { _, _ = io.Copy(io.Discard, rerr); drained <- struct{}{} }()
+
+	selfhost.ResetAstbridgeLowerCount()
+	exit := runResolvePackageInner(dir, cliFlags{noColor: true})
+	_ = wout.Close()
+	_ = werr.Close()
+	<-drained
+	<-drained
+
+	if exit != 0 {
+		t.Fatalf("runResolvePackageInner exit = %d, want 0", exit)
+	}
+	if got := selfhost.AstbridgeLowerCount(); got != 0 {
+		t.Fatalf("AstbridgeLowerCount after runResolvePackageInner = %d, want 0 (DIR resolve CLI body regressed into a *ast.File fallback)", got)
+	}
+}
+
 func TestResolveCLISingleFilePrintsNativeResolutionRows(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.osty")


### PR DESCRIPTION
## Summary

`runResolvePackage` was calling `ensureGoResolve()` — which force-materializes every `PackageFile`'s `*ast.File` via `pkg.EnsureFiles()` — whenever `nativeResolvePackageRows` returned zero rows, even when the native row builder had no error. Declaration-only files (pure `pub fn helper() -> Int { 1 }`) legitimately emit zero rows, so this path was routinely dragging the entire package through the astbridge adapter just to confirm \"yes, there really are no refs.\" Every two-file clean package was paying two per-invocation astbridge lowerings for no observable output change.

Found by writing `TestRunResolvePackageHappyPathIsAstbridgeFree` — a DIR counterpart to `TestRunResolveFileHappyPathIsAstbridgeFree` that asserts the resolve CLI body produces `AstbridgeLowerCount == 0` end-to-end. The test failed at count 2, which traced to the loop-level fallback firing on empty (but valid) native output.

## What changed

- Split the fallback trigger in `runResolvePackageInner`:
  - `ensureGoResolve()` fires only on an actual error from `nativeResolvePackageRows`.
  - Empty rows from a clean file are accepted as valid output (the file had no refs); loop continues silently.
- Global post-loop fallback (print Go refs when nothing was printed via native) now runs only when at least one file *errored* during native row generation, not merely because every file happened to be declaration-only.
- Extracted `runResolvePackage` body into `runResolvePackageInner` returning an exit code (symmetric to `runCheckPackageLegacy` in [#640](https://github.com/choiceoh/osty/pull/640)). The caller preserves `os.Exit(1)` semantics on non-zero return.
- `TestRunResolvePackageHappyPathIsAstbridgeFree` — two-file package (one declaration-only, one with a ref), asserts the DIR CLI body produces `AstbridgeLowerCount == 0` end-to-end.

## Combined matrix after this PR

| Path | Warm astbridge bumps |
|---|---|
| `runCheckFileLegacy` | 1 |
| `runCheckFileNative` | 0 |
| `runTypecheckFileLegacy` | 1 |
| `runTypecheckFileNative` | 0 |
| `runCheckPackageLegacy` (N=2) | 2 |
| `runCheckPackageNative` (N=2) | 0 |
| `runResolveFile` | 0 |
| `runResolvePackageInner` (N=2) | **0** (this PR) |

Every resolve + check CLI path now has a counter-pinned bump cost, and both the native and Go-native paths are measured so drift in either direction surfaces immediately.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/...`
- [x] New counter test `TestRunResolvePackageHappyPathIsAstbridgeFree` green
- [x] Existing subprocess tests (`TestResolveCLISingleFilePrintsNativeResolutionRows`, `TestResolveCLIPackagePrintsNativeCrossFileResolutionRows`, `TestResolveCLISingleFilePrintsNativeDiagnostics`) still green — observable output on clean packages is identical (the Go fallback was emitting nothing anyway because `len(f.Refs) == 0 → continue`)

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- This is a behavior-preserving fix: declaration-only files already produced no visible rendering in either path. The only difference is that we no longer pay the astbridge cost to confirm the obvious.
- The Go-fallback still exists as a safety net for genuine native errors (a crash, a schema mismatch). Production error-handling intent is preserved.
- The `nativeErrored && !nativeRowsUsed` condition on the post-loop block is intentionally stricter than the previous `!nativeRowsUsed` alone: the old version would dump Go refs whenever nothing got printed via native, even on a package that genuinely has no refs. The new version only dumps Go refs when there was an actual native error that didn't complete the file's rendering — which is the only case where the Go data adds information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)