### PR TITLE
refactor: useMIRBackend 제약 해제 — object/binary도 MIR-first

### DIFF
--- a/docs/mir_design.md
+++ b/docs/mir_design.md
@@ -711,11 +711,10 @@ MIR tests isolated from front-end churn.
     and emits textual LLVM IR via an alloca-per-local SSA scheme
     (LLVM's mem2reg pass promotes to register form during opt).
   - **Dispatcher gate.** `llvmgen.Options.UseMIR` selects the path.
-    The backend dispatcher (`internal/backend/llvm.go`) now prefers
-    `GenerateFromMIR(entry.MIR, opts)` by default on raw `llvm-ir`
-    emission, and still allows explicit opt-in on object/binary
-    emission via `mir-backend`. On `ErrUnsupported` the dispatcher
-    catches the sentinel and falls back to
+    The backend dispatcher (`internal/backend/llvm.go`) prefers
+    `GenerateFromMIR(entry.MIR, opts)` by default on every emit
+    mode — raw `llvm-ir`, object, binary. On `ErrUnsupported` the
+    dispatcher catches the sentinel and falls back to
     `GenerateModule(entry.IR, opts)` automatically, so coverage
     regressions are impossible while parity lands.
   - **MVP coverage.** Primitive types (Int / UInt / Byte / Bool /
@@ -915,10 +914,9 @@ MIR tests isolated from front-end churn.
     / map-style callbacks consumed in-frame) work without heap.
 
 - **Stage 4 (partially landed — MIR-first IR emission).** The LLVM
-  backend now prefers the MIR-direct emitter by default for raw
-  `llvm-ir` output. Object/binary emission can still opt in explicitly
-  with `mir-backend`, and the dispatcher falls back automatically on
-  `ErrUnsupported`.
+  backend prefers the MIR-direct emitter by default on every emit
+  mode — raw `llvm-ir`, object, binary. The dispatcher falls back
+  automatically on `ErrUnsupported`, so coverage never regresses.
 
 - **Stage 3.9 (landed — concurrency intrinsic runtime mapping).**
   All MIR concurrency intrinsics emitted by the MIR lowerer now

--- a/internal/backend/llvm.go
+++ b/internal/backend/llvm.go
@@ -166,10 +166,10 @@ func generateLLVMIR(entry Entry, target string, features []string, emit EmitMode
 	// for entry.File — the AST is a front-end artifact that the LLVM
 	// backend does not consume directly any more.
 	//
-	// After the native-owned fast path declines coverage, raw `llvm-ir`
-	// still prefers MIR by default, and `mir-backend` can force MIR on
-	// every emit mode. On MIR-emitter refusal we still fall back
-	// automatically, so enabling the new path cannot reduce coverage.
+	// After the native-owned fast path declines coverage, every emit
+	// mode — raw `llvm-ir`, object, binary — prefers the MIR-direct
+	// emitter. On MIR-emitter refusal we fall back automatically to
+	// the HIR path, so MIR-first cannot reduce coverage.
 	var (
 		irOut  []byte
 		genErr error
@@ -272,16 +272,11 @@ func runClang(ctx context.Context, action string, args []string) error {
 }
 
 // useMIRBackend reports whether LLVM emission should prefer the
-// MIR-direct path. Raw `llvm-ir` emission is MIR-first by default;
-// callers can opt further in on object/binary emission with
-// `mir-backend` while parity stabilizes.
-func useMIRBackend(features []string, emit EmitMode) bool {
-	for _, f := range features {
-		if f == "mir-backend" {
-			return true
-		}
-	}
-	return emit == EmitLLVMIR
+// MIR-direct path. Every emit mode — raw `llvm-ir`, object, binary —
+// is MIR-first; the dispatcher falls back to the HIR emitter on
+// `ErrUnsupported`, so coverage never regresses.
+func useMIRBackend(_ []string, _ EmitMode) bool {
+	return true
 }
 
 func useNativeOwnedLLVMIR(features []string, emit EmitMode) bool {

--- a/internal/backend/llvm_test.go
+++ b/internal/backend/llvm_test.go
@@ -786,8 +786,11 @@ func TestUseMIRBackendDefaultsEnabled(t *testing.T) {
 	if !useMIRBackend(nil, EmitLLVMIR) {
 		t.Fatal("useMIRBackend(nil, EmitLLVMIR) = false, want true")
 	}
-	if useMIRBackend(nil, EmitBinary) {
-		t.Fatal("useMIRBackend(nil, EmitBinary) = true, want false")
+	if !useMIRBackend(nil, EmitObject) {
+		t.Fatal("useMIRBackend(nil, EmitObject) = false, want true")
+	}
+	if !useMIRBackend(nil, EmitBinary) {
+		t.Fatal("useMIRBackend(nil, EmitBinary) = false, want true")
 	}
 	if !useMIRBackend([]string{"mir-backend"}, EmitBinary) {
 		t.Fatal("useMIRBackend(mir-backend, EmitBinary) = false, want true")
@@ -897,7 +900,7 @@ func TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics(t *testing.T) {
 }
 
 // TestLLVMBackendBinaryMIRBackendStringCharsBytes — Stage 5 prep
-// parity check. With `mir-backend` opted in on object/binary emission,
+// parity check. On binary emission (MIR-first by default),
 // `.chars()` / `.bytes()` / `.len()` / `.isEmpty()` on a String must
 // lower through the MIR-direct emitter (no silent fallback to the
 // legacy AST bridge). The emitted IR header is the only stable tell of

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -946,7 +946,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	// Stage 5 prep — string → List<Char> / List<Byte> expansions that
 	// the legacy emitter routes through `osty_rt_strings_*`. Accepting
 	// them here lets `.chars()` / `.bytes()` reach the MIR emitter on
-	// `mir-backend` object/binary emission instead of falling back.
+	// object/binary emission instead of falling back.
 	case mir.IntrinsicStringConcat, mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
 		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty,
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,


### PR DESCRIPTION
## Summary

- `useMIRBackend`가 emit mode/feature flag와 무관하게 항상 `true`를 반환하도록 단순화. 기존엔 raw `llvm-ir`만 MIR-first였고 `EmitObject`/`EmitBinary`는 `mir-backend` feature opt-in이 필요했는데, 이제 세 emit mode 모두 기본 MIR-direct 디스패치.
- 안전성은 기존 fallback 메커니즘에 기댐: `generateLLVMIR`이 `ErrUnsupported` 시 `GenerateModule`(HIR 경로)로 자동 폴백 — 커버리지 회귀 불가능.
- 관련 주석/문서([docs/mir_design.md](docs/mir_design.md) Stage 4 서술, [internal/llvmgen/mir_generator.go:949](internal/llvmgen/mir_generator.go:949)의 Stage 5 prep 주석)와 `TestUseMIRBackendDefaultsEnabled` 단언을 새 기본값에 맞춰 정리. `mir-backend` feature는 이제 `useNativeOwnedLLVMIR`에서 native-owned fast path를 강제 skip 하는 용도로만 남음.

## Why

MIR-direct 디스패처는 `internal/backend/llvm.go:177-183`에서 이미 end-to-end로 동작하며 `ErrUnsupported` 자동 fallback이 걸려 있다 (memory `project_osty_native_merged_clean.md` 참조). Raw `llvm-ir`에만 제한하던 gate는 parity 불안정 시기의 보수적 설정이었고, 이제는 object/binary도 동일한 경로를 타는 편이 디스패치 일관성 + 최적화 파이프라인 단일화에 유리.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/backend/ -run TestUseMIRBackendDefaultsEnabled` PASS (세 emit mode 모두 true 단언)
- [x] `go test ./internal/backend/ -run TestUseNativeOwnedLLVMIRDefaultsEnabled` PASS
- [x] `go test ./internal/backend/ -run TestLLVMBackendEmitLLVMIRMIRBackendStringIntrinsics` PASS
- [x] `go test ./internal/llvmgen/ -short` PASS

## Notes for reviewer

`TestEmitLLVMIRTextFallsBackWhenNativeOwnedUncovered` / `TestLLVMBackendEmitBinaryFallsBackWhenNativeOwnedUncovered` / `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule` 세 건은 base branch에서도 재현되는 pre-existing `TryEmitNativeOwnedLLVMIRText` coalesce-coverage 실패로, 이번 변경과 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)