### PR TITLE
refactor: lint FILE + DIR extraction with astbridge baseline tests

### DIFF
--- a/cmd/osty/lint_legacy_baseline_test.go
+++ b/cmd/osty/lint_legacy_baseline_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osty/osty/internal/selfhost"
+)
+
+// TestRunLintFileLegacyAstbridgeBaseline completes the FILE legacy
+// matrix: lint shares the same parser.ParseDetailed + resolveFile +
+// check.File pipeline that runCheckFileLegacy already instruments,
+// then adds the lint engine on top of the same *ast.File. No extra
+// lowerings expected beyond the one the parse pass already does —
+// lint.File walks the existing tree.
+//
+// Warm-path baseline: 1 bump per user-file invocation.
+func TestRunLintFileLegacyAstbridgeBaseline(t *testing.T) {
+	src := []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`)
+	path := filepath.Join(t.TempDir(), "main.osty")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	flags := cliFlags{noColor: true}
+	formatter := newFormatter(path, src, flags)
+
+	// Warm stdlib/checker caches so the measurement reflects the
+	// per-invocation cost only (same rationale as
+	// warmStdlibCachesForBaseline in check_legacy_baseline_test.go).
+	captureStdouterr(t, func() {
+		_ = runLintFileLegacy(path, src, formatter, flags)
+	})
+
+	selfhost.ResetAstbridgeLowerCount()
+	var exit int
+	captureStdouterr(t, func() {
+		exit = runLintFileLegacy(path, src, formatter, flags)
+	})
+	if exit != 0 {
+		t.Fatalf("runLintFileLegacy exit = %d, want 0", exit)
+	}
+	const want = 1
+	if got := selfhost.AstbridgeLowerCount(); got != want {
+		t.Fatalf("AstbridgeLowerCount after warm runLintFileLegacy = %d, want %d (lint shares check's one parse lowering — lint.File walks the existing *ast.File)", got, want)
+	}
+}
+
+// TestRunLintPackageLegacyAstbridgeBaseline is the DIR lint sibling.
+// Same cost shape as runCheckPackageLegacy: one *ast.File lowering
+// per package file via resolve.LoadPackageWithTransform; the lint
+// engine reuses those trees for its rules.
+//
+// Warm-path baseline: N bumps for an N-file package.
+func TestRunLintPackageLegacyAstbridgeBaseline(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.osty")
+	bPath := filepath.Join(dir, "b.osty")
+	if err := os.WriteFile(aPath, []byte(`pub fn helper() -> Int { 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(`fn main() {
+    let x = 1
+    let y = x + 2
+    y
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	flags := cliFlags{noColor: true}
+
+	captureStdouterr(t, func() {
+		_ = runLintPackageLegacy(dir, flags)
+	})
+
+	selfhost.ResetAstbridgeLowerCount()
+	var exit int
+	captureStdouterr(t, func() {
+		exit = runLintPackageLegacy(dir, flags)
+	})
+	if exit != 0 {
+		t.Fatalf("runLintPackageLegacy exit = %d, want 0", exit)
+	}
+	const want = 2 // two source files, one *ast.File lowering each
+	if got := selfhost.AstbridgeLowerCount(); got != want {
+		t.Fatalf("AstbridgeLowerCount after warm runLintPackageLegacy = %d, want %d", got, want)
+	}
+}

--- a/cmd/osty/main.go
+++ b/cmd/osty/main.go
@@ -556,42 +556,8 @@ func main() {
 				return
 			}
 		}
-		parsed := parser.ParseDetailed(src)
-		file, parseDiags := parsed.File, parsed.Diagnostics
-		res := resolveFile(file)
-		chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
-		lr := runLintEngine(file, res, chk)
-		if cfg, ok := loadLintConfigNear(path); ok {
-			lr = cfg.Apply(lr)
-		}
-		all := append(append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...), chk.Diags...)
-		all = append(all, lr.Diags...)
-		printDiags(formatter, all, flags)
-		if flags.fix || flags.fixDryRun {
-			newSrc, applied, skipped := lint.ApplyFixes(src, lr.Diags)
-			mode := "osty lint"
-			switch {
-			case flags.fixDryRun:
-				// Write the would-be-applied source to stdout so users
-				// can pipe it through `diff` / `less` before committing
-				// to a real --fix pass. The file on disk is untouched.
-				if _, err := os.Stdout.Write(newSrc); err != nil {
-					fmt.Fprintf(os.Stderr, "%s --fix-dry-run: %v\n", mode, err)
-					os.Exit(1)
-				}
-				fmt.Fprintf(os.Stderr, "%s --fix-dry-run: %d fix(es) would apply, %d overlap(s) would be skipped\n", mode, applied, skipped)
-			case flags.fix:
-				if applied > 0 {
-					if err := os.WriteFile(path, newSrc, 0o644); err != nil {
-						fmt.Fprintf(os.Stderr, "%s --fix: %v\n", mode, err)
-						os.Exit(1)
-					}
-				}
-				fmt.Fprintf(os.Stderr, "%s --fix: applied %d fix(es), skipped %d overlap(s)\n", mode, applied, skipped)
-			}
-		}
-		if hasError(all) || (flags.strict && hasWarning(all)) {
-			os.Exit(1)
+		if code := runLintFileLegacy(path, src, formatter, flags); code != 0 {
+			os.Exit(code)
 		}
 	default:
 		usage()
@@ -807,18 +773,32 @@ func runLintPackage(dir string, flags cliFlags) {
 		runLintWorkspace(dir, flags)
 		return
 	}
+	if code := runLintPackageLegacy(dir, flags); code != 0 {
+		os.Exit(code)
+	}
+}
+
+// runLintPackageLegacy is the extracted single-package body of
+// runLintPackage (after the workspace check). Returns an exit code
+// so the lint DIR pipeline is exercisable in-process alongside the
+// check / typecheck / resolve legacy extractions. The parse + resolve
+// + check + lint pipeline is unchanged — parser.ParseDetailed runs
+// lazily through resolve.LoadPackageWithTransform, so every file in
+// the package gets its *ast.File lowered exactly once.
+func runLintPackageLegacy(dir string, flags cliFlags) int {
 	pkg, err := resolve.LoadPackageWithTransform(dir, aiRepairSourceTransform(aiRepairPrefix("lint"), os.Stderr, flags))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "osty: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
 	chk := check.Package(pkg, res, checkOpts())
 	cfg, cfgBase, hasCfg := loadLintConfigWithBase(dir)
 	outcome := runLintLoadedPackage(pkg, res, chk, flags, cfg, cfgBase, hasCfg)
 	if outcome.anyErr || (flags.strict && outcome.anyWarn) {
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 // runLintWorkspace lints each package inside dir, aggregating diagnostics
@@ -1217,6 +1197,55 @@ func byteOffsetLineCol(src []byte, offset int) (int, int) {
 		col++
 	}
 	return line, col
+}
+
+// runLintFileLegacy is the extracted `osty lint FILE` body (minus the
+// exclude-config early-return, which stays in the caller so the "skip"
+// message fires before parse work begins). Same
+// parser.ParseDetailed → resolveFile → check.File → lint engine
+// pipeline the inline body ran, now returning an exit code so the
+// lint legacy path is exercisable in-process alongside the check /
+// typecheck legacy baselines (#639, #640, #641). Handles --fix /
+// --fix-dry-run stdout/disk side-effects inside the function.
+func runLintFileLegacy(path string, src []byte, formatter *diag.Formatter, flags cliFlags) int {
+	parsed := parser.ParseDetailed(src)
+	file, parseDiags := parsed.File, parsed.Diagnostics
+	res := resolveFile(file)
+	chk := check.File(file, res, checkOptsForFile(path, canonical.Source(src, file)))
+	lr := runLintEngine(file, res, chk)
+	if cfg, ok := loadLintConfigNear(path); ok {
+		lr = cfg.Apply(lr)
+	}
+	all := append(append(append([]*diag.Diagnostic{}, parseDiags...), res.Diags...), chk.Diags...)
+	all = append(all, lr.Diags...)
+	printDiags(formatter, all, flags)
+	if flags.fix || flags.fixDryRun {
+		newSrc, applied, skipped := lint.ApplyFixes(src, lr.Diags)
+		mode := "osty lint"
+		switch {
+		case flags.fixDryRun:
+			// Write the would-be-applied source to stdout so users
+			// can pipe it through `diff` / `less` before committing
+			// to a real --fix pass. The file on disk is untouched.
+			if _, err := os.Stdout.Write(newSrc); err != nil {
+				fmt.Fprintf(os.Stderr, "%s --fix-dry-run: %v\n", mode, err)
+				return 1
+			}
+			fmt.Fprintf(os.Stderr, "%s --fix-dry-run: %d fix(es) would apply, %d overlap(s) would be skipped\n", mode, applied, skipped)
+		case flags.fix:
+			if applied > 0 {
+				if err := os.WriteFile(path, newSrc, 0o644); err != nil {
+					fmt.Fprintf(os.Stderr, "%s --fix: %v\n", mode, err)
+					return 1
+				}
+			}
+			fmt.Fprintf(os.Stderr, "%s --fix: applied %d fix(es), skipped %d overlap(s)\n", mode, applied, skipped)
+		}
+	}
+	if hasError(all) || (flags.strict && hasWarning(all)) {
+		return 1
+	}
+	return 0
 }
 
 // runCheckFileLegacy is the extracted `osty check FILE` body (the


### PR DESCRIPTION
## Summary

Completes the legacy-path extraction pattern started in [#639](https://github.com/choiceoh/osty/pull/639), [#640](https://github.com/choiceoh/osty/pull/640), [#641](https://github.com/choiceoh/osty/pull/641) for the lint subcommand. Both `case \"lint\"` (FILE) and `runLintPackage` (DIR) now route through named functions that return an exit code, so the lint pipeline's per-invocation astbridge cost is pinned alongside check, typecheck, and resolve.

## What changed

- `runLintFileLegacy(path, src, formatter, flags) int` — the FILE extraction. Keeps the `[lint] exclude` early-return in the caller so the \"skipping\" message fires before any parse work. Handles `--fix` / `--fix-dry-run` stdout/disk side effects inside the function and returns 1 when those I/O operations fail.
- `runLintPackageLegacy(dir, flags) int` — the DIR extraction. The workspace dispatch (`runLintWorkspace`) stays in `runLintPackage` so the extraction is symmetric with `runCheckPackageLegacy` (#640).
- `TestRunLintFileLegacyAstbridgeBaseline` — warm-path bump count for lint FILE is exactly 1 (`lint.File` walks the existing `*ast.File` produced by `parser.ParseDetailed` — no extra lowerings).
- `TestRunLintPackageLegacyAstbridgeBaseline` — warm-path bump count for lint DIR is N (one per package file; `lint.Package` walks the already-loaded trees).

## Why

Every other subcommand (check, typecheck, resolve) now has a counter baseline for both its legacy and native paths. Lint was the last gap in that matrix. Without a baseline assertion, future changes to the lint engine's parse/check handling could silently alter the per-invocation astbridge cost.

## Completed matrix

| Path | Warm astbridge bumps |
|---|---|
| `runCheckFileLegacy` | 1 |
| `runCheckFileNative` | 0 |
| `runTypecheckFileLegacy` | 1 |
| `runTypecheckFileNative` | 0 |
| `runCheckPackageLegacy` (N=2) | 2 |
| `runCheckPackageNative` (N=2) | 0 |
| `runLintFileLegacy` | **1** (this PR) |
| `runLintPackageLegacy` (N=2) | **2** (this PR) |
| `runResolveFile` | 0 |
| `runResolvePackageInner` (N=2) | 0 |

Every subcommand now has a baseline cell. Any unintended movement — cost creeping up in a legacy path, a fallback leaking into a native path — fails a counter assertion immediately.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./cmd/osty/ ./internal/selfhost/ ./internal/check/... ./internal/resolve/... ./internal/lint/...`
- [x] Both new baseline tests green (FILE=1, DIR=2)

Pre-existing failures (`TestParseSnapshot`, `TestEmitGenArtifactFallsBackForUncoveredNativeOwnedModule`) reproduce on main — not caused by this change.

## Notes for reviewers

- The extractions are behavior-preserving. `case \"lint\"` still emits the `[lint] exclude` skip message before any parse work (that branch stayed in the caller); the extracted body picks up from the parse step. Workspace lint still delegates through the unchanged `runLintWorkspace`.
- No `--native` lint path yet — the lint engine consumes `*resolve.Result` by pointer identity and would require the identity-model refactor before going astbridge-free. This PR just gives the existing pipeline a counter baseline so we'd notice if the cost creeps up during that future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)