### PR TITLE
fix: native-merged MIR pipeline gate 회귀 2건 수복

### DIFF
--- a/toolchain/ci.osty
+++ b/toolchain/ci.osty
@@ -219,15 +219,16 @@ pub struct Runner {
             rep.Checks.push(skipped(CheckSemver))
         }
 
-        let mut i = 0
-        for c in rep.Checks {
-            if c.Skipped {
-                let _ = c
-            } else {
-                rep.Checks[i] = Check { ..c, Passed: ciCheckHostPassed(c.Diags, self.Opts.Strict) }
-            }
-            i = i + 1
-        }
+        // Index-based rewrite (`rep.Checks[i] = Check { ..c, ... }`)
+        // walls the LLVM native-owned path with a spurious LLVM011
+        // "struct Runner field rep type error" ghost-field
+        // diagnostic — method-local struct literals written back into
+        // a field of a `mut rep` local get mis-resolved as a
+        // hypothetical field of the enclosing `Runner` struct.
+        // Delegating the rebuild to a top-level helper bypasses that
+        // scope confusion and keeps the merged native-toolchain MIR
+        // pipeline gate CLEAN.
+        rep.Checks = ciFinalizeChecks(rep.Checks, self.Opts.Strict)
         rep.FinishedAt = host.NowUTC()
         rep
     }
@@ -709,6 +710,39 @@ fn skipped(name: CheckName) -> Check {
         Note: ciSkippedNote(),
         Diags: host.EmptyDiagnostics(),
     }
+}
+
+// ciFinalizeChecks rebuilds a Check list with the Passed flag
+// resolved per non-Skipped element. Lives at top level (not as a
+// Runner method) because the in-method rebuild shape — e.g.
+// `rep.Checks[i] = Check { ..c, Passed: ... }` — triggers a
+// spurious LLVM011 "struct Runner field rep type error" ghost-field
+// diagnostic on the native-owned LLVM path. Keeping the helper
+// outside Runner's scope sidesteps that resolver/checker confusion
+// so the merged native-toolchain MIR pipeline gate stays CLEAN.
+//
+// Uses explicit per-field copies (no `..c` spread) because the
+// multi-line struct-spread form still trips an E0204 parser state
+// in the current toolchain; the spec allows it but the parser path
+// exercised by the merged probe does not handle the newline-split
+// shape yet.
+fn ciFinalizeChecks(checks: List<Check>, strict: Bool) -> List<Check> {
+    let mut out: List<Check> = []
+    for c in checks {
+        if c.Skipped {
+            out.push(c)
+        } else {
+            let finalized = Check {
+                Name: c.Name,
+                Passed: ciCheckHostPassed(c.Diags, strict),
+                Skipped: c.Skipped,
+                Note: c.Note,
+                Diags: c.Diags,
+            }
+            out.push(finalized)
+        }
+    }
+    return out
 }
 
 fn checkFromHostResult(name: CheckName, result: CheckResult) -> Check {

--- a/toolchain/llvmgen.osty
+++ b/toolchain/llvmgen.osty
@@ -100,6 +100,8 @@ pub fn llvmEmitter() -> LlvmEmitter {
         body: [],
         locals: [],
         stringGlobals: [],
+        nativeBoundedLens: {:},
+        nativeSafeIndices: {:},
     }
 }
 


### PR DESCRIPTION
## Summary

`TestNativeToolchainMergedMIRPipelineIsClean` — Tier A self-host 권위 게이트 — 가 업스트림 HEAD에서 두 건의 독립적인 회귀로 깨져 있던 상태를 복구합니다.

- **LLVM013 wall** on `LlvmEmitter`: `221f2b8 perf: skip list bounds-check`가 struct에 `nativeBoundedLens` / `nativeSafeIndices` 필드를 추가했지만 같은 파일의 `llvmEmitter()` 초기자를 갱신하지 않아 merged probe가 `missing literal field`로 walls.
- **LLVM011 ghost field wall** on `ci.osty`: `8cd5639 fix: ci.osty Report.Checks Passed 갱신 손실`이 `rep.Checks[i] = Check { ..c, Passed: ... }` 형태로 값-복사 버그를 고쳤지만, 네이티브-owned LLVM 경로가 method-local `rep` 바인딩을 가상의 `Runner.rep` 필드로 오인하는 리졸버 경로에 걸려 `struct "Runner" field "rep": type "error"`를 뱉음.

## Changes

**`toolchain/llvmgen.osty`** (+2)
- `llvmEmitter()` 초기자에 `nativeBoundedLens: {:}`, `nativeSafeIndices: {:}` 추가.

**`toolchain/ci.osty`** (+45/-9)
- `Runner.Run`의 `for c in rep.Checks { rep.Checks[i] = Check { ..c, ... } }` 를 top-level 자유 함수 `ciFinalizeChecks`로 위임. Runner 스코프 밖에서 재빌드해 ghost-field 진단 회피.
- 헬퍼는 `..c` 스프레드 대신 **명시적 필드 복사**를 사용. 멀티라인 struct-spread 형이 현재 parser 경로에서 E0204를 트리거하는 별개 제약 때문.

## Test plan

- [x] `go test ./internal/llvmgen -run TestNativeToolchainMergedMIRPipelineIsClean -count=1` — **PASS** (69s)
- [x] `go test ./internal/llvmgen -run TestProbeNativeToolchainMerged$` — **CLEAN** (이전 LLVM013 wall)
- [x] `go test -short ./internal/llvmgen` — OK (사전 회귀 없음)
- [x] `go test -short ./internal/backend ./cmd/osty` — 3건 FAIL은 rebase 전부터 존재하는 pre-existing 이슈 (native-owned coalesce fallback 커버리지 테스트), 이 PR 범위 밖.

## Reviewer notes

- ghost-field LLVM011 은 근본적으로는 `internal/resolve` 또는 `internal/check`가 method-local mutable struct 리터럴 바인딩을 자신의 owner struct 필드로 오인하는 리졸버 버그로 보임. 이 PR은 증상 회피만 하고 근본 원인은 별도 이슈로 남긴다.
- 멀티라인 struct-spread E0204 도 분리된 parser 경로 이슈. `elab_test.osty` 등의 단일-라인 `P { ..p, x: p.x + 1 }` 형은 통과하지만 내가 시도한 다중-라인 `P { ..p,\n    x: ...\n}` 형에서 fail.
- `ciFinalizeChecks` 가 명시적 필드를 모두 나열하므로 `Check` 구조가 확장되면 함께 업데이트 필요 (주석에 명시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)