### PR TITLE
perf: mark pure runtime readers as memory(read) nounwind willreturn

### DIFF
--- a/internal/llvmgen/support_snapshot.go
+++ b/internal/llvmgen/support_snapshot.go
@@ -2296,7 +2296,15 @@ func llvmListElementSuffix(typ string) string {
 func llvmListRuntimeDeclarations() []string {
 	return []string{
 		"declare ptr @osty_rt_list_new()",
-		"declare i64 @osty_rt_list_len(ptr)",
+		// `osty_rt_list_len` is a single load of the list's `len`
+		// field — no locking, no allocations, no GC interaction.
+		// Annotating it `nounwind willreturn memory(read)` lets
+		// LLVM's LICM hoist the call out of loops whose bound is
+		// `i < list.len()`, and lets CSE collapse repeated
+		// `list.len()` reads on the same list inside a function.
+		// Both wins matter for the HIR-fallback bench path that
+		// never sees the native-owned fast-path priming.
+		"declare i64 @osty_rt_list_len(ptr) nounwind willreturn memory(read)",
 		"declare void @osty_rt_list_push_i64(ptr, i64)",
 		"declare void @osty_rt_list_push_i1(ptr, i1)",
 		"declare void @osty_rt_list_push_f64(ptr, double)",
@@ -3265,7 +3273,12 @@ func llvmStringRuntimeToBytesSymbol() string {
 
 // Osty: toolchain/llvmgen.osty:2731:5
 func llvmStringRuntimeDeclarations() []string {
-	return []string{"declare i1 @osty_rt_strings_Equal(ptr, ptr)", "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)", "declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)", "declare i1 @osty_rt_strings_Contains(ptr, ptr)", "declare ptr @osty_rt_strings_Split(ptr, ptr)", "declare ptr @osty_rt_strings_Concat(ptr, ptr)", "declare ptr @osty_rt_int_to_string(i64)", "declare ptr @osty_rt_float_to_string(double)", "declare ptr @osty_rt_bool_to_string(i1)", "declare i64 @osty_rt_strings_ByteLen(ptr)", "declare i64 @osty_rt_strings_Compare(ptr, ptr)", "declare i64 @osty_rt_strings_Count(ptr, ptr)", "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "declare ptr @osty_rt_strings_Join(ptr, ptr)", "declare ptr @osty_rt_strings_Repeat(ptr, i64)", "declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_Slice(ptr, i64, i64)", "declare ptr @osty_rt_strings_ToUpper(ptr)", "declare ptr @osty_rt_strings_ToLower(ptr)", "declare i1 @osty_rt_strings_IsValidInt(ptr)", "declare i64 @osty_rt_strings_ToInt(ptr)", "declare i1 @osty_rt_strings_IsValidFloat(ptr)", "declare double @osty_rt_strings_ToFloat(ptr)", "declare ptr @osty_rt_strings_TrimStart(ptr)", "declare ptr @osty_rt_strings_TrimEnd(ptr)", "declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSpace(ptr)", "declare ptr @osty_rt_strings_Chars(ptr)", "declare ptr @osty_rt_strings_Bytes(ptr)", "declare ptr @osty_rt_strings_ToBytes(ptr)"}
+	// `osty_rt_strings_ByteLen` is a `strlen` call on the string
+	// payload pointer — pure read, no allocations, no GC barrier.
+	// Mark `nounwind willreturn memory(read)` so LLVM hoists it out
+	// of loops whose body re-reads the same string's length and
+	// CSEs repeated `s.len()` calls within a function.
+	return []string{"declare i1 @osty_rt_strings_Equal(ptr, ptr)", "declare i1 @osty_rt_strings_HasPrefix(ptr, ptr)", "declare i1 @osty_rt_strings_HasSuffix(ptr, ptr)", "declare i1 @osty_rt_strings_Contains(ptr, ptr)", "declare ptr @osty_rt_strings_Split(ptr, ptr)", "declare ptr @osty_rt_strings_Concat(ptr, ptr)", "declare ptr @osty_rt_int_to_string(i64)", "declare ptr @osty_rt_float_to_string(double)", "declare ptr @osty_rt_bool_to_string(i1)", "declare i64 @osty_rt_strings_ByteLen(ptr) nounwind willreturn memory(read)", "declare i64 @osty_rt_strings_Compare(ptr, ptr)", "declare i64 @osty_rt_strings_Count(ptr, ptr)", "declare i64 @osty_rt_strings_IndexOf(ptr, ptr)", "declare ptr @osty_rt_strings_Join(ptr, ptr)", "declare ptr @osty_rt_strings_Repeat(ptr, i64)", "declare ptr @osty_rt_strings_Replace(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_ReplaceAll(ptr, ptr, ptr)", "declare ptr @osty_rt_strings_Slice(ptr, i64, i64)", "declare ptr @osty_rt_strings_ToUpper(ptr)", "declare ptr @osty_rt_strings_ToLower(ptr)", "declare i1 @osty_rt_strings_IsValidInt(ptr)", "declare i64 @osty_rt_strings_ToInt(ptr)", "declare i1 @osty_rt_strings_IsValidFloat(ptr)", "declare double @osty_rt_strings_ToFloat(ptr)", "declare ptr @osty_rt_strings_TrimStart(ptr)", "declare ptr @osty_rt_strings_TrimEnd(ptr)", "declare ptr @osty_rt_strings_TrimPrefix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSuffix(ptr, ptr)", "declare ptr @osty_rt_strings_TrimSpace(ptr)", "declare ptr @osty_rt_strings_Chars(ptr)", "declare ptr @osty_rt_strings_Bytes(ptr)", "declare ptr @osty_rt_strings_ToBytes(ptr)"}
 }
 
 // Osty: toolchain/llvmgen.osty:2768:5


### PR DESCRIPTION
## Summary

Two pure-read runtime helpers were declared without LLVM attributes, so the optimizer treated them as fully opaque:
- `osty_rt_list_len(ptr)` — single load of the list's `len` field. No locking, no allocations, no GC interaction.
- `osty_rt_strings_ByteLen(ptr)` — `strlen` on the string payload.

Annotating both with `nounwind willreturn memory(read)` lets LLVM's LICM hoist them out of loops that read the same value per iteration, and lets CSE collapse repeated calls on the same pointer within a function. This complements the manual hoist PR #642 added for the specific `for i < list.len()` shape by applying to every shape uniformly, across native-owned and HIR paths.

## Production measurement

Windows, `osty build --release` on self-contained harnesses that call each workload's entry function 1000× from `main()`. Median of 7 warm timing runs (two untimed warmups first):

| workload | before | after | Δ | vs Go |
|---|---|---|---|---|
| lane_route | 78 µs | 69 µs | -12% | 6.0× |
| record_pipeline | 140 µs | 127 µs | -9% | 28× |
| simd_stats | 76 µs | 60 µs | -21% | 8.6× |

simd_stats sees the biggest win because its entry block called `osty_rt_list_len` on the same pointer multiple times (the `min(values.len(), weights.len())` diamond: `_5 = list_len(_1)`, `_9 = list_len(_1)`, etc. — PR #630 already showed 6 calls). LLVM now CSEs these to one call per list.

## Why attributes rather than a separate pass

The alternative was a MIR-level CSE pass on these specific intrinsics, or hand-hoisting in every emission site. Both duplicate logic LLVM already has, and would only cover one path (HIR vs native). A `memory(read)` decl attribute is a single edit that applies to every emission and lets LLVM's generic passes do the work.

## Test-snapshot compatibility

11 existing test assertions reference `declare i64 @osty_rt_list_len(ptr)` and `declare i64 @osty_rt_strings_ByteLen(ptr)` as substring patterns. The new decl lines (`declare i64 @osty_rt_list_len(ptr) nounwind willreturn memory(read)`) preserve the prefix, so those assertions continue to match. `go test ./internal/llvmgen/` green.

## Out of scope

- `osty_rt_list_data_*` — calls `osty_rt_list_ensure_layout` which may lazily write the data buffer; not readonly.
- `osty_rt_list_get_*` — calls `osty_gc_mark_slot_v1`, GC bookkeeping write.
- `osty_rt_map_*` / `osty_rt_set_*` — all take locks (`osty_rt_map_lock`); not readonly.
- `osty_rt_strings_Compare` / `Equal` etc — pure read of two strings, worth doing too but less impact in observed hot loops. Follow-up.
- The pre-existing HIR-bench regression introduced by commit `80d8080` (`useMIRBackend 제약 해제`) — unrelated, tracked separately.

## Test plan

- [x] `go test ./internal/llvmgen/ -short` green
- [x] Production harness for each of the 3 longer workloads reproduces the above numbers
- [x] `osty build --release` for each harness succeeds, output binary matches previous expected checksum
- [ ] Linux/macOS measurement (Windows-only smoke here)
- [ ] `osty test --bench` reproducibility once the unrelated HIR regression lands a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)