### PR TITLE
feat(ir): qualified-call return-type fallback + richer MIR ErrType diagnostic

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1664,6 +1664,31 @@ func (l *lowerer) lowerQualifiedCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArg
 	if t == ErrTypeVal {
 		t = recoverCallReturnType(callee)
 	}
+	// The Go-hosted checker doesn't register `use X { fn Y(...) -> R
+	// }` member signatures on the package symbol, so `host.Y` ends up
+	// as <error> in both the checker types map and the callee's
+	// FnType. Fall back to reading the UseDecl body (for inline FFI
+	// signatures) or the resolved package scope (for stdlib /
+	// workspace modules) directly: the AST already has the signature,
+	// we just need to lower it. Without this, MIR's typeSupported
+	// rejects the synthetic result temp with `unsupported local type
+	// <error>` for every runtime / stdlib module call site.
+	if t == ErrTypeVal || t == nil {
+		if id, ok := fx.X.(*ast.Ident); ok {
+			if sym := l.symbol(id); sym != nil && sym.Kind == resolve.SymPackage {
+				if ud, ok := sym.Decl.(*ast.UseDecl); ok && ud != nil {
+					if ret := l.lookupUseDeclFnReturn(ud, fx.Name); ret != nil {
+						t = ret
+					}
+				}
+				if (t == ErrTypeVal || t == nil) && sym.Package != nil {
+					if ret := l.lookupPackageFnReturn(sym.Package, fx.Name); ret != nil {
+						t = ret
+					}
+				}
+			}
+		}
+	}
 	out := &CallExpr{
 		Callee:   callee,
 		TypeArgs: typeArgs,
@@ -1674,6 +1699,55 @@ func (l *lowerer) lowerQualifiedCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArg
 		out.Args = append(out.Args, l.lowerArg(a))
 	}
 	return out
+}
+
+// lookupUseDeclFnReturn scans a `use X { ... }` body for an fn named
+// fnName and returns its lowered return type (TUnit when the source
+// declared no return type). Returns nil when no matching fn is found.
+// This is the fallback path used by lowerQualifiedCall when the
+// checker left the call's result type as <error>.
+func (l *lowerer) lookupUseDeclFnReturn(ud *ast.UseDecl, fnName string) Type {
+	if ud == nil {
+		return nil
+	}
+	for _, d := range ud.GoBody {
+		fn, ok := d.(*ast.FnDecl)
+		if !ok || fn == nil || fn.Name != fnName {
+			continue
+		}
+		if fn.ReturnType == nil {
+			return TUnit
+		}
+		return l.lowerType(fn.ReturnType)
+	}
+	return nil
+}
+
+// lookupPackageFnReturn finds a top-level public fn named fnName in
+// the resolved package and returns its lowered return type. Used by
+// lowerQualifiedCall as the fallback when the UseDecl is a bare
+// `use std.strings as X` (no inline FFI body) — the fn lives in the
+// package's PkgScope, and its AST is on the resolved package file.
+func (l *lowerer) lookupPackageFnReturn(pkg *resolve.Package, fnName string) Type {
+	if pkg == nil {
+		return nil
+	}
+	for _, pf := range pkg.Files {
+		if pf == nil || pf.File == nil {
+			continue
+		}
+		for _, decl := range pf.File.Decls {
+			fn, ok := decl.(*ast.FnDecl)
+			if !ok || fn == nil || fn.Name != fnName {
+				continue
+			}
+			if fn.ReturnType == nil {
+				return TUnit
+			}
+			return l.lowerType(fn.ReturnType)
+		}
+	}
+	return nil
 }
 
 func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs []Type) Expr {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -419,7 +419,11 @@ func (g *mirGen) checkSupported() error {
 				continue
 			}
 			if !g.typeSupported(loc.Type) {
-				return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s", mirTypeString(loc.Type), fn.Name))
+				hint := localDefiningSiteHint(fn, loc.ID)
+			if hint != "" {
+				return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d; %s)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID, hint))
+			}
+			return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID))
 			}
 		}
 		if fn.ReturnType != nil && !g.typeSupported(fn.ReturnType) {
@@ -475,7 +479,11 @@ func (g *mirGen) checkFunctionSupported(fn *mir.Function) error {
 			continue
 		}
 		if !g.typeSupported(loc.Type) {
-			return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s", mirTypeString(loc.Type), fn.Name))
+			hint := localDefiningSiteHint(fn, loc.ID)
+			if hint != "" {
+				return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d; %s)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID, hint))
+			}
+			return unsupported("mir-mvp", fmt.Sprintf("unsupported local type %s in %s (local %s id=%d)", mirTypeString(loc.Type), fn.Name, localDisplayName(loc), loc.ID))
 		}
 	}
 	if fn.ReturnType != nil && !g.typeSupported(fn.ReturnType) {
@@ -557,6 +565,72 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		return true
 	}
 	return false
+}
+
+// localDisplayName returns a human-readable tag for an ErrType diag
+// so "unsupported local type <error>" points at the specific binding.
+// When the local is a synthetic temp (no Name), append the first
+// instruction that *writes* the temp — that's usually the expression
+// whose checker-inferred type leaked through as <error>.
+func localDisplayName(loc *mir.Local) string {
+	if loc == nil {
+		return "<nil>"
+	}
+	if loc.Name == "" {
+		return "<temp>"
+	}
+	return loc.Name
+}
+
+// localDefiningSiteHint walks fn's blocks to find the first
+// instruction that assigns to loc.ID, returning a short textual hint
+// suitable for embedding in an "unsupported local type <error>"
+// diagnostic. Returns "" when no writer is found.
+func localDefiningSiteHint(fn *mir.Function, id mir.LocalID) string {
+	if fn == nil {
+		return ""
+	}
+	for _, bb := range fn.Blocks {
+		if bb == nil {
+			continue
+		}
+		for _, inst := range bb.Instrs {
+			switch x := inst.(type) {
+			case *mir.AssignInstr:
+				if placeReferencesLocal(x.Dest, id) {
+					return fmt.Sprintf("written by assign at %d:%d", x.SpanV.Start.Line, x.SpanV.Start.Column)
+				}
+			case *mir.CallInstr:
+				if x.Dest != nil && placeReferencesLocal(*x.Dest, id) {
+					callee := "?"
+					if x.Callee != nil {
+						callee = mirCalleeDebugString(x.Callee)
+					}
+					return fmt.Sprintf("written by call `%s` at %d:%d", callee, x.SpanV.Start.Line, x.SpanV.Start.Column)
+				}
+			case *mir.IntrinsicInstr:
+				if x.Dest != nil && placeReferencesLocal(*x.Dest, id) {
+					return fmt.Sprintf("written by intrinsic kind=%d at %d:%d", int(x.Kind), x.SpanV.Start.Line, x.SpanV.Start.Column)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// mirCalleeDebugString returns a short identifier for a MIR callee
+// suitable for use in a diagnostic hint. Keeps the dependency surface
+// shallow (no reflection on unknown callee variants) — unknown shapes
+// collapse to their Go type name.
+func mirCalleeDebugString(c mir.Callee) string {
+	if c == nil {
+		return "?"
+	}
+	switch v := c.(type) {
+	case *mir.FnRef:
+		return v.Symbol
+	}
+	return fmt.Sprintf("%T", c)
 }
 
 func allowUnusedErrLocal(fn *mir.Function, loc *mir.Local) bool {


### PR DESCRIPTION
## Summary

Advances the native-merged MIR toolchain probe past two more walls. The Go-hosted checker doesn't register `use X as alias { fn Y(...) -> R }` inline FFI signatures or stdlib-module public fns on the package symbol, so `alias.Y(...)` call expressions inherit an `<error>` type for their result — which MIR's `typeSupported` then rejects.

## What changed

### `internal/ir/lower.go` — qualified-call return-type fallback

`lowerQualifiedCall` gains a two-tier fallback when `exprType(e) == ErrTypeVal`:

1. **`lookupUseDeclFnReturn(UseDecl, fnName)`** — scan the inline FFI body (`use runtime.cihost as host { fn HasManifest(...) -> Bool, ... }`) for the matching fn and lower its return type. Handles runtime / go FFI modules.
2. **`lookupPackageFnReturn(resolve.Package, fnName)`** — scan the resolved package's top-level FnDecls for the matching public fn and lower its return type. Handles stdlib (`use std.strings as ciStrings`) and workspace packages where the resolver attached `sym.Package`.

The AST already carries these signatures — the fallback is purely compensatory for the checker's package-member-type gap, not a new type-inference layer.

### `internal/llvmgen/mir_generator.go` — richer ErrType diagnostic

Enriches the `unsupported local type <error>` diagnostic so the local name (or `<temp>` for synthetic locals) and the writing instruction are included:

```
unsupported local type <error> in Runner__checkPolicy
  (local <temp> id=6; written by call `runtime.cihost.HasManifest` at 5380:14)
```

Without this, every MIR wall showed up as a generic \"local has error type in $fn\" and tracking the offending expression required reading the full MIR dump. Adds `localDisplayName`, `localDefiningSiteHint`, and `mirCalleeDebugString` helpers.

## Probe progression

| State | First wall |
|---|---|
| Before | `<error> in Runner__checkPolicy (call runtime.cihost.HasManifest)` |
| After runtime FFI fallback | `<error> in ciPreIdentValid (call std.strings.hasPrefix)` |
| After package-scope fallback (this PR) | `<error> in corePrintNodeBody (assign at 1:60)` |

Whole-toolchain + native-toolchain AST probes remain CLEAN. The next MIR wall (`corePrintNodeBody`) is a different shape — probably a struct-field or match-arm issue — tracked as a follow-up.

## Why

Fast progress toward true self-hosting. Each wall this PR knocks over unblocks a family of call sites (all `runtime.cihost.*` calls, all `std.strings.*` calls, etc.), not just one. The enriched diagnostic pays itself back on the next wall investigation too.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/ir/... ./internal/mir/... ./internal/llvmgen/ ./internal/check/...` all green
- [x] `TestProbeWholeToolchainMerged` + `TestProbeNativeToolchainMerged` remain CLEAN
- [x] `TestProbeNativeToolchainMergedMIR` advances past the two fallback walls

## Notes for reviewers

- The fallback is deliberately call-site-local (only fires when the checker already returned `<error>`). If the checker gets tightened and populates these types at the source, the fallback becomes inert — no behavioral change.
- The diagnostic enrichment changes only the error-path text. No new failures emerge from code paths that were already passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)