### PR TITLE
feat(ir+mir-gen): String intrinsic whitelist + method/field type recovery

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1872,17 +1872,92 @@ func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs [
 	if len(typeArgs) == 0 {
 		typeArgs = l.instantiationArgs(e)
 	}
+	recv := l.lowerExpr(fx.X)
+	t := l.exprType(e)
+	if t == ErrTypeVal || t == nil {
+		// Recover from builtin method signatures when the checker
+		// left the call type unpopulated. Covers the common shapes
+		// from List / Map / Set / String / Bytes: `.len()`, `.isEmpty()`,
+		// `.contains(x)`, `.startsWith(s)`, etc. Without this, one
+		// `.len()` call with a checker-skipped receiver poisons
+		// every enclosing expression to ErrType and blocks MIR.
+		if recovered := recoverMethodReturnType(fx.Name, recv); recovered != nil {
+			t = recovered
+		}
+	}
 	out := &MethodCall{
-		Receiver: l.lowerExpr(fx.X),
+		Receiver: recv,
 		Name:     fx.Name,
 		TypeArgs: typeArgs,
-		T:        l.exprType(e),
+		T:        t,
 		SpanV:    nodeSpan(e),
 	}
 	for _, a := range e.Args {
 		out.Args = append(out.Args, l.lowerArg(a))
 	}
 	return out
+}
+
+// recoverMethodReturnType derives the return type of a receiver-and-
+// method pair for the subset of stdlib intrinsics where the return
+// shape is fixed by the name alone. Used as a fallback when the
+// Go-hosted checker didn't populate `Types[e]` for the call. Mirrors
+// the routing in internal/mir/lower.go:methodToIntrinsic.
+func recoverMethodReturnType(name string, recv Expr) Type {
+	if recv == nil {
+		return nil
+	}
+	rt := recv.Type()
+	if rt == nil || rt == ErrTypeVal {
+		return nil
+	}
+	// Common name-based shortcuts that don't depend on the receiver's
+	// concrete generic args.
+	switch name {
+	case "len":
+		if isBuiltinContainer(rt) || isPrim(rt, PrimString) || isPrim(rt, PrimBytes) {
+			return TInt
+		}
+	case "isEmpty":
+		if isBuiltinContainer(rt) || isPrim(rt, PrimString) || isPrim(rt, PrimBytes) {
+			return TBool
+		}
+	case "contains", "hasPrefix", "hasSuffix", "startsWith", "endsWith":
+		if isPrim(rt, PrimString) || isPrim(rt, PrimBytes) || isBuiltinContainer(rt) {
+			return TBool
+		}
+	case "toUpper", "toLower", "trim", "trimSpace", "trimLeft", "trimRight":
+		if isPrim(rt, PrimString) {
+			return TString
+		}
+	}
+	// Element-type returns: List<T>.first / .last / .get → T?, .push → Unit.
+	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {
+		switch name {
+		case "first", "last":
+			return &OptionalType{Inner: nt.Args[0]}
+		case "push":
+			return TUnit
+		case "sorted":
+			return nt
+		}
+	}
+	return nil
+}
+
+// isBuiltinContainer reports whether t is one of the builtin
+// homogeneous collections whose len/isEmpty/contains return types
+// can be derived from the method name alone.
+func isBuiltinContainer(t Type) bool {
+	nt, ok := t.(*NamedType)
+	if !ok || !nt.Builtin {
+		return false
+	}
+	switch nt.Name {
+	case "List", "Map", "Set":
+		return true
+	}
+	return false
 }
 
 // lowerVariantCall builds a VariantLit from a call whose callee is a
@@ -2101,13 +2176,60 @@ func (l *lowerer) lowerFieldExpr(e *ast.FieldExpr) Expr {
 			SpanV: nodeSpan(e),
 		}
 	}
+	x := l.lowerExpr(e.X)
+	t := l.exprType(e)
+	if t == ErrTypeVal || t == nil {
+		// Recover from the struct declaration when the checker didn't
+		// record a type for this field access. Without this, a single
+		// checker-skipped FieldExpr propagates ErrType to every
+		// `.locals.len()` or `.name + something` chain downstream.
+		if recovered := l.recoverFieldType(x.Type(), e.Name); recovered != nil {
+			t = recovered
+		}
+	}
 	return &FieldExpr{
-		X:        l.lowerExpr(e.X),
+		X:        x,
 		Name:     e.Name,
 		Optional: e.IsOptional,
-		T:        l.exprType(e),
+		T:        t,
 		SpanV:    nodeSpan(e),
 	}
+}
+
+// recoverFieldType resolves a field access `receiverType.fieldName`
+// back to the declared field type by consulting the resolver's type
+// decl for receiverType. Only handles user structs today —
+// enums/interfaces/tuples use different access shapes that do not
+// flow through lowerFieldExpr in the same way.
+func (l *lowerer) recoverFieldType(receiverType Type, fieldName string) Type {
+	if receiverType == nil || receiverType == ErrTypeVal {
+		return nil
+	}
+	nt, ok := receiverType.(*NamedType)
+	if !ok || nt.Builtin {
+		return nil
+	}
+	if l.res == nil {
+		return nil
+	}
+	sym := l.res.FileScope.Lookup(nt.Name)
+	if sym == nil || sym.Decl == nil {
+		return nil
+	}
+	sd, ok := sym.Decl.(*ast.StructDecl)
+	if !ok || sd == nil {
+		return nil
+	}
+	for _, f := range sd.Fields {
+		if f == nil || f.Name != fieldName {
+			continue
+		}
+		if f.Type == nil {
+			return nil
+		}
+		return l.lowerType(f.Type)
+	}
+	return nil
 }
 
 // tupleIndex parses a field name like "0" or "12" as a tuple index.

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1048,7 +1048,9 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	case mir.IntrinsicStringConcat, mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
 		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty,
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
-		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat:
+		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
+		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
+		mir.IntrinsicStringEndsWith:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -2412,7 +2414,9 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 	case mir.IntrinsicStringConcat, mir.IntrinsicStringChars, mir.IntrinsicStringBytes,
 		mir.IntrinsicStringLen, mir.IntrinsicStringIsEmpty,
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
-		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat:
+		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
+		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
+		mir.IntrinsicStringEndsWith:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
@@ -3569,8 +3573,39 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringParseResultIntrinsic(i, strReg, "osty_rt_strings_IsValidInt", "osty_rt_strings_ToInt", "i64")
 	case mir.IntrinsicStringToFloat:
 		return g.emitStringParseResultIntrinsic(i, strReg, "osty_rt_strings_IsValidFloat", "osty_rt_strings_ToFloat", "double")
+	case mir.IntrinsicStringStartsWith:
+		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeHasPrefixSymbol())
+	case mir.IntrinsicStringEndsWith:
+		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeHasSuffixSymbol())
+	case mir.IntrinsicStringContains:
+		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeContainsSymbol())
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
+}
+
+// emitStringBinaryBoolIntrinsic dispatches `.startsWith(s)` /
+// `.endsWith(s)` / `.contains(s)` style checks: `(str, arg) -> i1`.
+// Both operands must already resolve as String ptrs — the receiver
+// comes in as strReg (evaluated by emitStringIntrinsic), the single
+// arg is evaluated here. Binds the runtime symbol if not already
+// declared, then emits the call and stores the Bool result.
+func (g *mirGen) emitStringBinaryBoolIntrinsic(i *mir.IntrinsicInstr, strReg, sym string) error {
+	if len(i.Args) < 2 {
+		return unsupported("mir-mvp", fmt.Sprintf("%s with no arg", sym))
+	}
+	arg := i.Args[1]
+	if !isStringLLVMType(arg.Type()) {
+		return unsupported("mir-mvp", fmt.Sprintf("%s arg type %s", sym, mirTypeString(arg.Type())))
+	}
+	argReg, err := g.evalOperand(arg, arg.Type())
+	if err != nil {
+		return err
+	}
+	g.declareRuntime(sym, "declare i1 @"+sym+"(ptr, ptr)")
+	em := g.ostyEmitter()
+	result := llvmCall(em, "i1", sym, []*LlvmValue{{typ: "ptr", name: strReg}, {typ: "ptr", name: argReg}})
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, result)
 }
 
 func (g *mirGen) emitStringParseResultIntrinsic(i *mir.IntrinsicInstr, strReg, validateSym, parseSym, parseLLVM string) error {


### PR DESCRIPTION
## Summary

Three compounded advances push the native-merged MIR probe through three walls in this PR. Theme: the Go-hosted checker leaves a lot of method-call / field-access expression types unpopulated on large toolchain sources, and each gap poisons every downstream consumer. This PR covers the two most common shapes (method calls, field accesses) and unblocks the string-intrinsic hot path.

## What changed

### `internal/llvmgen/mir_generator.go` — String intrinsics

- `IntrinsicStringContains` / `IntrinsicStringStartsWith` / `IntrinsicStringEndsWith` added to `isSupportedIntrinsic` and `emitIntrinsic` dispatch.
- New helper `emitStringBinaryBoolIntrinsic` emits the `(ptr, ptr) -> i1` pattern shared by the three — binds the corresponding `osty_rt_strings_HasPrefix` / `osty_rt_strings_HasSuffix` / `osty_rt_strings_Contains` runtime symbol and emits the call.

### `internal/ir/lower.go` — type recovery

- **`recoverMethodReturnType(name, recv)`** runs when `exprType(e) == ErrTypeVal` on a `MethodCall`. Handles `.len()`, `.isEmpty()`, `.contains(x)`, `.startsWith(s)`, `.endsWith(s)`, `.hasPrefix(s)`, `.hasSuffix(s)`, `.toUpper()`, `.toLower()`, and the `.first()` / `.last()` / `.push()` / `.sorted()` fast paths for `List<T>`. Mirrors `internal/mir/lower.go:methodToIntrinsic` so IR doesn't know anything MIR doesn't already route.
- **`recoverFieldType(receiverType, fieldName)`** runs when `exprType(e) == ErrTypeVal` on a `FieldExpr`. Looks up the receiver's `StructDecl` through `res.FileScope.Lookup` and returns the declared field type. Enables `func.locals.len()` / `func.params.len()` chains to stay off ErrType even when the checker skips the intermediate field expr.

## Probe progression

| State | First wall |
|---|---|
| Before (#659 merged) | `intrinsic kind=56 not yet supported in paramDefaultCount` (StringStartsWith) |
| After string whitelist | `<error> len call in mirValidateFunction` |
| After method + field recovery (this PR) | `Range<Int> unsupported in opStripUseCQuotes (assign; src=UseRV)` |

`Range<Int>` is a different category (missing LayoutTable entry / type surface, not ErrType propagation) — follow-up.

Whole-toolchain + native-toolchain AST probes remain CLEAN.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/ir/... ./internal/mir/... ./internal/llvmgen/ ./internal/check/...` all green

## Notes for reviewers

- The recovery logic is consistent with previous PRs in this series (#655 qualified-call return, #659 literal + match): it only fires when the checker failed, so tightening the checker later makes these paths naturally inert.
- `recoverMethodReturnType` intentionally stays narrow — only names whose return type is fixed by the receiver's kind (`List<T>.len() -> Int` always, regardless of `T`). Anything requiring per-method type-arg substitution stays ErrType; the match is exact so MIR routing keeps its authority for the shapes we DO handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)