### PR TITLE
feat(ir): FFI-alias qualified call + struct field type recovery

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1676,6 +1676,41 @@ func (l *lowerer) lowerCall(e *ast.CallExpr) Expr {
 	return out
 }
 
+// recoverQualifiedCallReturn pulls the declared return type off the
+// item-block signature that a `use` FFI alias introduces. Targets
+// the specific gap where the native checker skips a call like
+// `host.HasManifest(self.Manifest)` inside a method body — the
+// callee FieldExpr and the wrapping CallExpr both land with
+// ErrType, and the normal `recoverCallReturnType(callee)` path
+// cannot fire because callee.T itself is still ErrType. Returns nil
+// when the qualifier is not an FFI alias or no matching fn-block
+// signature exists, letting the caller's cascade behaviour stand.
+func (l *lowerer) recoverQualifiedCallReturn(fx *ast.FieldExpr) Type {
+	if fx == nil || l.file == nil {
+		return nil
+	}
+	aliasIdent, ok := fx.X.(*ast.Ident)
+	if !ok || aliasIdent.Name == "" || fx.Name == "" {
+		return nil
+	}
+	for _, u := range l.file.Uses {
+		if u == nil || !u.IsFFI() || u.Alias != aliasIdent.Name {
+			continue
+		}
+		for _, inner := range u.GoBody {
+			fn, ok := inner.(*ast.FnDecl)
+			if !ok || fn == nil || fn.Name != fx.Name {
+				continue
+			}
+			if fn.ReturnType == nil {
+				return &PrimType{Kind: PrimUnit}
+			}
+			return l.lowerType(fn.ReturnType)
+		}
+	}
+	return nil
+}
+
 // recoverCallReturnType pulls the return type off the callee's FnType
 // when the checker did not record a type for the call expression. The
 // resolver seeds symbol types for top-level fns and `use`-imported
@@ -1766,6 +1801,17 @@ func (l *lowerer) lowerQualifiedCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArg
 	t := l.exprType(e)
 	if t == ErrTypeVal {
 		t = recoverCallReturnType(callee)
+	}
+	if t == ErrTypeVal {
+		// Second-chance recovery: when the qualifier is a `use` FFI
+		// alias (e.g. `use runtime.cihost as host { fn HasManifest(…)
+		// -> Bool … }`), the native checker does not seed Types[fx]
+		// and the callee's own FnType is still ErrType. Walk the
+		// alias's item block in the current file's Uses to pull the
+		// declared return type straight from the AST.
+		if rec := l.recoverQualifiedCallReturn(fx); rec != nil && rec != ErrTypeVal {
+			t = rec
+		}
 	}
 	out := &CallExpr{
 		Callee:   callee,
@@ -2012,13 +2058,56 @@ func (l *lowerer) lowerFieldExpr(e *ast.FieldExpr) Expr {
 			SpanV: nodeSpan(e),
 		}
 	}
+	loweredX := l.lowerExpr(e.X)
+	t := l.exprType(e)
+	if t == ErrTypeVal {
+		if rec := l.recoverFieldType(loweredX, e.Name); rec != nil && rec != ErrTypeVal {
+			t = rec
+		}
+	}
 	return &FieldExpr{
-		X:        l.lowerExpr(e.X),
+		X:        loweredX,
 		Name:     e.Name,
 		Optional: e.IsOptional,
-		T:        l.exprType(e),
+		T:        t,
 		SpanV:    nodeSpan(e),
 	}
+}
+
+// recoverFieldType derives a field expression's result type by
+// looking up the field on the receiver's declared struct. Mirrors
+// the other operand-based recovery helpers (recoverBinaryType /
+// recoverBlockType / recoverCallReturnType / recoverIndexType) and
+// targets the native-checker gap where the walker skips expressions
+// nested inside string interpolation parts — leaving
+// `node.text` / `node.name` / `node.value` FieldExpr nodes
+// untyped, cascading ErrType through the enclosing MIR temps.
+//
+// The lookup is intentionally narrow: only `NamedType` receivers
+// whose name matches a `StructDecl` in the current file's top-level
+// declarations. Generics and cross-package types stay at ErrType
+// — the caller's prior cascade behaviour covers those.
+func (l *lowerer) recoverFieldType(base Expr, fieldName string) Type {
+	if base == nil || fieldName == "" || l.file == nil {
+		return nil
+	}
+	bt := base.Type()
+	nt, ok := bt.(*NamedType)
+	if !ok || nt.Name == "" {
+		return nil
+	}
+	for _, d := range l.file.Decls {
+		sd, ok := d.(*ast.StructDecl)
+		if !ok || sd == nil || sd.Name != nt.Name {
+			continue
+		}
+		for _, f := range sd.Fields {
+			if f != nil && f.Name == fieldName && f.Type != nil {
+				return l.lowerType(f.Type)
+			}
+		}
+	}
+	return nil
 }
 
 // tupleIndex parses a field name like "0" or "12" as a tuple index.


### PR DESCRIPTION
## Summary

Two more operand-based type recovery helpers in \`internal/ir/lower.go\` that shrink the merged-native-toolchain ErrType local count from 36 → 30 (6 fns cleared). Continues the pattern from \`20abb10\` / #646 / #653.

## Why

The native checker leaves ErrType on expressions it skips walking. Previous PRs closed the \`checkHashKey\` (recoverBinary/Block/CallReturn) and \`checkIntKey\` (identTypeFromDecl/recoverIndexType) gaps. The MIR probe's next wall landed on \`Runner__checkPolicy\` — an \`host.HasManifest(self.Manifest)\` call against an FFI alias (\`use runtime.cihost as host\`) that the checker did not stamp and \`recoverCallReturnType(callee)\` could not reach because the callee FieldExpr itself had ErrType.

## Changes

**\`internal/ir/lower.go\`** (+91/-2)

- \`recoverQualifiedCallReturn(fx) Type\` — second-chance recovery for \`host.fn(args)\` qualified calls. Walks the FFI alias's item block in the current file's \`Uses\` to find the matching \`FnDecl\` and pulls \`ReturnType\` directly from the AST. Returns nil when the qualifier is not an FFI alias or no matching signature exists.
- \`recoverFieldType(base, name) Type\` — fallback in \`lowerFieldExpr\` that finds the receiver's \`StructDecl\` in the current file and returns the declared field type. Targets struct-field reads inside string interpolation parts.

Both helpers are narrow: unknown shapes return nil and the pre-recovery cascade stands.

## Test plan

- [x] \`go test ./internal/llvmgen -run TestNativeToolchainMergedMIRPipelineIsClean\` — **PASS** (authoritative Tier A gate holds).
- [x] \`go test ./internal/llvmgen -run TestNativeToolchainMergedMIRErrTypeFloor\` — **PASS** (30 well under the 40 floor).
- [x] \`go test ./internal/llvmgen -run TestProbeNativeToolchainMergedMIR\` — MIR first wall moves off \`Runner__checkPolicy\` to \`ciPreIdentValid\` (next checker-coverage leak in a different shape).
- [x] \`go test -short ./internal/ir ./internal/llvmgen\` — no new regressions.

## Reviewer notes

- The \`recoverFieldType\` helper did not fire on the current merged probe (the 475 FieldExpr ErrTypes are all qualified-callee shape, which is intentional — their FnType lives on the enclosing CallExpr, not the FieldExpr itself). Kept as forward-looking coverage for struct-field reads in future code.
- FFI fallback returns \`PrimUnit\` when the FFI fn has no declared return type. This matches how regular \`fn ()\` is lowered.
- Next target when this lands: \`ciPreIdentValid\`'s 1 ErrType local — probably a different shape again (not FFI). The \`corePrintNodeBody\` hotspot (12 locals) is bigger but stems from a different class of gaps and needs its own pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)