### PR TITLE
feat(mir-gen): accept Range<T> as supported local type

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -528,6 +528,18 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 			switch x.Name {
 			case "List", "Map", "Set", "ClosureEnv":
 				return true
+			case "Range":
+				// Range<Int> values only materialize via the
+				// placeholder UseRV(UnitConst) path in
+				// internal/mir/lower.go — there's no real value-
+				// position handling yet. Accepting the type here
+				// lets the MIR generator walk past functions that
+				// assign `0..n` to a temp (e.g. the string-slice
+				// receivers in parser.osty's opStripUseCQuotes)
+				// without tripping the supported-type check. When
+				// backends grow real Range lowering the payload
+				// shape (start/end/inclusive) can take over.
+				return true
 			}
 		}
 		// Concurrency runtime types are opaque pointers — the emitter
@@ -535,6 +547,16 @@ func (g *mirGen) typeSupported(t mir.Type) bool {
 		// the runtime ABI hands back from chan_make / spawn / etc.
 		switch x.Name {
 		case "Channel", "Handle", "Group", "TaskGroup", "Select", "Duration":
+			return true
+		case "Range":
+			// Range<T> is a prelude type but the Go-side resolver
+			// doesn't always flag its Symbol as SymBuiltin (the
+			// self-host checker's prelude registers Range, but the
+			// Go resolver isn't always in sync on the same Sym
+			// pointer). Accept it here whether Builtin is set or
+			// not — the MIR lowerer emits RangeLit as a placeholder
+			// UseRV(UnitConst) anyway, so the concrete shape is
+			// irrelevant until real lowering arrives.
 			return true
 		}
 		if g.mod != nil && g.mod.Layouts != nil {


### PR DESCRIPTION
## Summary

Advances the native-merged MIR probe past the `unsupported local type Range<Int> in opStripUseCQuotes` wall. `opStripUseCQuotes` (toolchain/parser.osty) uses `raw[0..1]` / `raw[n-1..n]` for string slicing; the `0..1` subexpression gets assigned to a temp whose IR type is `Range<Int>`. MIR's `typeSupported` rejected any NamedType whose name wasn't in the explicit whitelist, so every function with a Range temp tripped the check even though MIR's `lowerExpr` already treats `RangeLit` value position as a harmless `UseRV(UnitConst)` placeholder.

## What changed

- `typeSupported` now accepts `*ir.NamedType{Name: \"Range\"}` whether or not `Builtin` is set. The Go-side resolver's prelude doesn't register Range as SymBuiltin in every path (the self-host checker's prelude does), so relying on the Builtin flag misses the case where the Sym pointer comes from a non-Builtin source. A comment inline documents the lowering asymmetry.

## Probe progression

| State | First wall |
|---|---|
| Before (#660 merged) | `unsupported local type Range<Int> in opStripUseCQuotes (assign; src=UseRV)` |
| After (this PR) | `call to unresolved symbol std.strings.split` (different category: intrinsic-routing gap) |

Whole-toolchain + native-toolchain AST probes remain CLEAN.

## Why

Small, focused fix. `Range<T>` appears throughout the toolchain for string slicing (`s[i..j]`) and for-loops (`for x in 0..n`); accepting it here unblocks every function that creates an intermediate Range temp in value position. Runtime behavior is unchanged — the MIR emitter still emits `UnitConst` placeholders for Range values, which is what the non-native backend was already doing.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/ir/... ./internal/mir/... ./internal/llvmgen/ ./internal/check/...` all green

## Notes for reviewers

- The \"Range as opaque\" story ends once real Range lowering arrives (e.g. concrete `{start, end, inclusive}` layout). At that point this acceptance becomes a no-op — the type would satisfy the normal layout check via `Layouts.Structs[\"Range\"]` — so no migration debt is incurred by accepting it opportunistically today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)