### PR TITLE
[codex] Fix native LLVM coverage regressions

### DIFF
--- a/cmd/osty-native-llvmgen/main_test.go
+++ b/cmd/osty-native-llvmgen/main_test.go
@@ -7,6 +7,23 @@ import (
 	"testing"
 )
 
+func runLLVMGenSource(t *testing.T, path string, source string) llvmgenResponse {
+	t.Helper()
+	reqBody, err := json.Marshal(llvmgenRequest{Path: path, Source: source})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := run(bytes.NewReader(reqBody), &stdout); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	var resp llvmgenResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
 func TestRunEmitsNativeOwnedLLVMIRForSource(t *testing.T) {
 	var stdout bytes.Buffer
 	stdin := strings.NewReader(`{"path":"main.osty","source":"fn pick(flag: Bool) -> Int { if flag { 42 } else { 0 } }\nfn main() { let mut i = 0 let mut sum = 0 for i < 3 { sum = sum + pick(i == 2) i = i + 1 } println(sum) }\n"}`)
@@ -146,6 +163,95 @@ func TestRunUsesNativeOwnedExportAndCABIShape(t *testing.T) {
 	}
 	if !strings.Contains(resp.LLVMIR, "@osty.gc.native_entry_v1 = dso_local alias ptr, ptr @native_entry_v1") {
 		t.Fatalf("llvmIr missing export alias:\n%s", resp.LLVMIR)
+	}
+}
+
+func TestRunCoversRuntimeStringsSplitAndListToSet(t *testing.T) {
+	resp := runLLVMGenSource(t, "main.osty", `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+
+fn main() {
+    let items = strings.Split("pear,apple", ",")
+    let seen = items.toSet()
+    println(seen.contains("pear"))
+}
+`)
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	for _, want := range []string{
+		"declare ptr @osty_rt_strings_Split(ptr, ptr)",
+		"call ptr @osty_rt_strings_Split(",
+		"declare ptr @osty_rt_list_to_set_string(ptr)",
+		"call i1 @osty_rt_set_contains_string(",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("llvmIr missing %q:\n%s", want, resp.LLVMIR)
+		}
+	}
+}
+
+func TestRunCoversStdTestingHelpers(t *testing.T) {
+	resp := runLLVMGenSource(t, "main.osty", `use std.testing
+
+enum CalcError {
+    DivideByZero,
+}
+
+fn div(a: Int, b: Int) -> Result<Int, CalcError> {
+    if b == 0 { Err(DivideByZero) } else { Ok(a / b) }
+}
+
+fn main() {
+    let q = testing.expectOk(div(10, 2))
+    testing.assertEq(q, 5)
+    testing.expectError(div(1, 0))
+}
+`)
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	for _, want := range []string{
+		"declare void @exit(i32)",
+		"extractvalue %Result.",
+		"testing.expectOk failed",
+		"testing.expectError failed",
+		"testing.assertEq failed",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("llvmIr missing %q:\n%s", want, resp.LLVMIR)
+		}
+	}
+}
+
+func TestRunCoversNestedStructBindingPattern(t *testing.T) {
+	resp := runLLVMGenSource(t, "main.osty", `struct Inner {
+    x: Int
+}
+
+struct Outer {
+    inner: Inner
+}
+
+fn main() {
+    let outer @ Outer { inner: Inner { x } } = Outer { inner: Inner { x: 7 } }
+    println(x)
+    println(outer.inner.x)
+}
+`)
+	if !resp.Covered {
+		t.Fatalf("covered = false, want true")
+	}
+	for _, want := range []string{
+		"%Inner = type { i64 }",
+		"%Outer = type { %Inner }",
+		"extractvalue %Outer",
+		"extractvalue %Inner",
+	} {
+		if !strings.Contains(resp.LLVMIR, want) {
+			t.Fatalf("llvmIr missing %q:\n%s", want, resp.LLVMIR)
+		}
 	}
 }
 

--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -176,15 +176,15 @@ func (l *lowerer) lowerFnDecl(fn *ast.FnDecl) *FnDecl {
 	unrollEnable, unrollCount := extractUnrollArgs(fn.Annotations)
 	noVec := hasNamedAnnotation(fn.Annotations, "no_vectorize")
 	out := &FnDecl{
-		Name:               fn.Name,
-		Return:             l.lowerType(fn.ReturnType),
-		ReceiverMut:        fn.Recv != nil && fn.Recv.Mut,
-		Exported:           fn.Pub,
-		SpanV:              nodeSpan(fn),
-		ExportSymbol:       extractExportSymbol(fn.Annotations),
-		CABI:               hasNamedAnnotation(fn.Annotations, "c_abi"),
-		IsIntrinsic:        hasNamedAnnotation(fn.Annotations, "intrinsic"),
-		NoAlloc:            hasNamedAnnotation(fn.Annotations, "no_alloc"),
+		Name:         fn.Name,
+		Return:       l.lowerType(fn.ReturnType),
+		ReceiverMut:  fn.Recv != nil && fn.Recv.Mut,
+		Exported:     fn.Pub,
+		SpanV:        nodeSpan(fn),
+		ExportSymbol: extractExportSymbol(fn.Annotations),
+		CABI:         hasNamedAnnotation(fn.Annotations, "c_abi"),
+		IsIntrinsic:  hasNamedAnnotation(fn.Annotations, "intrinsic"),
+		NoAlloc:      hasNamedAnnotation(fn.Annotations, "no_alloc"),
 		// v0.6 A5.2: vectorize is default-on. `#[no_vectorize]` is
 		// the sole way to opt out.
 		Vectorize:          !noVec,
@@ -704,6 +704,12 @@ func (l *lowerer) lowerNamedType(nt *ast.NamedType) Type {
 	}
 
 	// No resolver data available — best effort on the source name.
+	if pkg == "" {
+		switch name {
+		case "List", "Map", "Set", "Option", "Result":
+			return &NamedType{Package: "", Name: name, Args: args, Builtin: true}
+		}
+	}
 	return &NamedType{Package: pkg, Name: name, Args: args}
 }
 
@@ -1476,11 +1482,11 @@ func recoverBinaryType(op BinOp, left, right Expr) Type {
 //
 //   - List<T>[i]      → T    (direct element access, the dominant case)
 //   - Map<K, V>[k]    → V    (index form that panics on miss; matches
-//                              the native backend's intrinsic dispatch)
+//     the native backend's intrinsic dispatch)
 //   - Bytes[i]        → Byte
 //   - String[i]       → Char (semantically a code-point read, though
-//                              real Osty source uses .chars() / .bytes()
-//                              and almost never String[i] directly)
+//     real Osty source uses .chars() / .bytes()
+//     and almost never String[i] directly)
 //
 // Returns ErrTypeVal when the base itself is un-typed or non-indexable
 // — leaving the cascade behaviour from before the recovery.
@@ -1711,6 +1717,20 @@ func recoverCallReturnType(callee Expr) Type {
 	return ErrTypeVal
 }
 
+// recoverMethodCallType patches the one method-call shape that the
+// generic callee-return recovery cannot see: `recv.downcast::<T>()`.
+// The IR method form stores only the receiver + method name, so the
+// synthetic checker signature (`Error.downcast::<T>() -> T?`) is not
+// available as a first-class FnType on the lowered node. When the
+// checker/native-checker boundary drops the call's own type but still
+// records the turbofish args, recover the spec-mandated `T?` surface.
+func recoverMethodCallType(name string, typeArgs []Type) Type {
+	if name == "downcast" && len(typeArgs) == 1 && typeArgs[0] != nil && typeArgs[0] != ErrTypeVal {
+		return &OptionalType{Inner: typeArgs[0]}
+	}
+	return ErrTypeVal
+}
+
 // lowerArg lowers a single call argument, preserving its keyword name
 // when present.
 func (l *lowerer) lowerArg(a *ast.Arg) Arg {
@@ -1875,13 +1895,16 @@ func (l *lowerer) lowerMethodCall(e *ast.CallExpr, fx *ast.FieldExpr, typeArgs [
 	recv := l.lowerExpr(fx.X)
 	t := l.exprType(e)
 	if t == ErrTypeVal || t == nil {
+		if recovered := recoverMethodCallType(fx.Name, typeArgs); recovered != ErrTypeVal {
+			t = recovered
+		}
 		// Recover from builtin method signatures when the checker
 		// left the call type unpopulated. Covers the common shapes
 		// from List / Map / Set / String / Bytes: `.len()`, `.isEmpty()`,
 		// `.contains(x)`, `.startsWith(s)`, etc. Without this, one
 		// `.len()` call with a checker-skipped receiver poisons
 		// every enclosing expression to ErrType and blocks MIR.
-		if recovered := recoverMethodReturnType(fx.Name, recv); recovered != nil {
+		if recovered := recoverMethodReturnType(fx.Name, recv); (t == nil || t == ErrTypeVal) && recovered != nil {
 			t = recovered
 		}
 	}
@@ -2430,7 +2453,6 @@ func recoverMatchType(arms []*MatchArm) Type {
 	}
 	return candidate
 }
-
 
 // typesEquivalent is a narrow equality suitable for match-arm
 // unification. It's intentionally strict: primitive kinds must match

--- a/internal/ir/lower_test.go
+++ b/internal/ir/lower_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 
 	"github.com/osty/osty/internal/ast"
+	"github.com/osty/osty/internal/check"
+	"github.com/osty/osty/internal/parser"
 	"github.com/osty/osty/internal/resolve"
+	"github.com/osty/osty/internal/stdlib"
 )
 
 func TestLowerClassifiesTopLevelLetRefsAsGlobal(t *testing.T) {
@@ -147,5 +150,144 @@ func TestLowerStatementMatchBecomesMatchStmt(t *testing.T) {
 	}
 	if got := len(stmt.Arms); got != 2 {
 		t.Fatalf("match arms = %d, want 2", got)
+	}
+}
+
+func TestLowerMethodCallRecoversDowncastOptionalType(t *testing.T) {
+	src := `interface Printable {
+    fn show(self) -> String
+}
+
+struct Note {
+    pub msg: String,
+
+    pub fn show(self) -> String {
+        self.msg
+    }
+}
+
+fn probe(p: Printable) -> Note? {
+    return p.downcast::<Note>()
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse: %v", parseDiags)
+	}
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+
+	probe, ok := file.Decls[len(file.Decls)-1].(*ast.FnDecl)
+	if !ok || probe == nil || probe.Body == nil {
+		t.Fatalf("probe decl = %T, want *ast.FnDecl with body", file.Decls[len(file.Decls)-1])
+	}
+	if len(probe.Body.Stmts) != 1 {
+		t.Fatalf("probe body stmts = %d, want 1", len(probe.Body.Stmts))
+	}
+	retStmt, ok := probe.Body.Stmts[0].(*ast.ReturnStmt)
+	if !ok || retStmt == nil {
+		t.Fatalf("probe stmt = %T, want *ast.ReturnStmt", probe.Body.Stmts[0])
+	}
+	call, ok := retStmt.Value.(*ast.CallExpr)
+	if !ok || call == nil {
+		t.Fatalf("probe return value = %T, want *ast.CallExpr", retStmt.Value)
+	}
+	delete(chk.Types, call)
+
+	mod, issues := Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+
+	var irProbe *FnDecl
+	for _, decl := range mod.Decls {
+		if fn, ok := decl.(*FnDecl); ok && fn.Name == "probe" {
+			irProbe = fn
+			break
+		}
+	}
+	if irProbe == nil || irProbe.Body == nil {
+		t.Fatal("lowered probe function missing body")
+	}
+	if len(irProbe.Body.Stmts) != 1 {
+		t.Fatalf("lowered probe stmts = %d, want 1", len(irProbe.Body.Stmts))
+	}
+	irRet, ok := irProbe.Body.Stmts[0].(*ReturnStmt)
+	if !ok || irRet == nil {
+		t.Fatalf("lowered probe stmt = %T, want *ReturnStmt", irProbe.Body.Stmts[0])
+	}
+	mc, ok := irRet.Value.(*MethodCall)
+	if !ok {
+		t.Fatalf("probe return value = %T, want *MethodCall", irRet.Value)
+	}
+	opt, ok := mc.T.(*OptionalType)
+	if !ok {
+		t.Fatalf("method call type = %T (%v), want *OptionalType", mc.T, mc.T)
+	}
+	named, ok := opt.Inner.(*NamedType)
+	if !ok {
+		t.Fatalf("optional inner = %T (%v), want *NamedType", opt.Inner, opt.Inner)
+	}
+	if named.Name != "Note" {
+		t.Fatalf("optional inner name = %q, want %q", named.Name, "Note")
+	}
+}
+
+func TestLowerUseDeclRecoversBuiltinGenericTypesWithoutResolverTypeRefs(t *testing.T) {
+	src := `use runtime.strings as strings {
+    fn Split(s: String, sep: String) -> List<String>
+}
+`
+	file, parseDiags := parser.ParseDiagnostics([]byte(src))
+	if len(parseDiags) != 0 {
+		t.Fatalf("parse: %v", parseDiags)
+	}
+	res := resolve.FileWithStdlib(file, resolve.NewPrelude(), stdlib.LoadCached())
+	reg := stdlib.LoadCached()
+	chk := check.File(file, res, check.Opts{
+		UseGolegacy:   true,
+		Stdlib:        reg,
+		Primitives:    reg.Primitives,
+		ResultMethods: reg.ResultMethods,
+		Source:        []byte(src),
+	})
+
+	mod, issues := Lower("main", file, res, chk)
+	if len(issues) != 0 {
+		t.Fatalf("Lower() issues = %v, want none", issues)
+	}
+	if len(mod.Decls) != 1 {
+		t.Fatalf("decls = %d, want 1", len(mod.Decls))
+	}
+	use, ok := mod.Decls[0].(*UseDecl)
+	if !ok || use == nil {
+		t.Fatalf("decl = %T, want *UseDecl", mod.Decls[0])
+	}
+	if got, want := len(use.GoBody), 1; got != want {
+		t.Fatalf("use.GoBody len = %d, want %d", got, want)
+	}
+	fn, ok := use.GoBody[0].(*FnDecl)
+	if !ok || fn == nil {
+		t.Fatalf("use.GoBody[0] = %T, want *FnDecl", use.GoBody[0])
+	}
+	ret, ok := fn.Return.(*NamedType)
+	if !ok || ret == nil {
+		t.Fatalf("fn return = %T (%v), want *NamedType", fn.Return, fn.Return)
+	}
+	if !ret.Builtin || ret.Name != "List" {
+		t.Fatalf("fn return = %#v, want builtin List", ret)
+	}
+	if got, want := len(ret.Args), 1; got != want {
+		t.Fatalf("return args = %d, want %d", got, want)
+	}
+	if ret.Args[0] != TString {
+		t.Fatalf("return inner = %v, want TString", ret.Args[0])
 	}
 }

--- a/internal/llvmgen/ir_native_entry.go
+++ b/internal/llvmgen/ir_native_entry.go
@@ -38,8 +38,8 @@ type nativeEnumVariantInfo struct {
 // can route variant construction and pattern matches back to the
 // same storage.
 type nativeEnumInfo struct {
-	def             *llvmNativeEnum
-	variantsByName  map[string]*nativeEnumVariantInfo
+	def            *llvmNativeEnum
+	variantsByName map[string]*nativeEnumVariantInfo
 }
 
 type nativeTupleInfo struct {
@@ -51,25 +51,25 @@ type nativeTupleInfo struct {
 // captures. `liftedName` is the synthesized top-level fn
 // (`@__osty_closure_<N>`); `thunkName` is its env-ABI trampoline
 // (`@__osty_closure_thunk_<liftedName>`). Capture params are
-// appended after the original closure params on the lifted fn —
+// appended after the original closure params on the lifted fn -
 // the thunk loads them from env slots and forwards everything.
 //
 // Env layout: `ptr` fn slot at offset 0, `ptr` GC-trace slot at
 // offset 8, captures in declaration order at offset 16 + i*8 (each
 // capture occupies one 8-byte slot, even when the LLVM type is
-// smaller — matches legacy emit).
+// smaller - matches legacy emit).
 type nativeClosureInfo struct {
-	id            int
-	liftedName    string
-	thunkName     string
-	paramNames    []string
-	paramLLVMs    []string
-	captureNames  []string
-	captureLLVMs  []string
-	returnLLVM    string
-	body          *ostyir.Block
-	params        []*ostyir.Param
-	returnIR      ostyir.Type
+	id           int
+	liftedName   string
+	thunkName    string
+	paramNames   []string
+	paramLLVMs   []string
+	captureNames []string
+	captureLLVMs []string
+	returnLLVM   string
+	body         *ostyir.Block
+	params       []*ostyir.Param
+	returnIR     ostyir.Type
 }
 
 // nativeResultInfo records one specialization of the built-in
@@ -86,6 +86,17 @@ type nativeResultInfo struct {
 	llvmType  string
 	okIRType  ostyir.Type
 	errIRType ostyir.Type
+	okType    string
+	errType   string
+	okIR      ostyir.Type
+	errIR     ostyir.Type
+}
+
+type nativeRuntimeFFIFunction struct {
+	path     string
+	symbol   string
+	retType  string
+	paramTys []string
 }
 
 // nativeInterfaceMethod captures a single interface method's
@@ -129,11 +140,12 @@ type nativeProjectionCtx struct {
 	structsByName         map[string]*nativeStructInfo
 	enumsByName           map[string]*nativeEnumInfo
 	interfacesByName      map[string]*nativeInterfaceInfo
+	resultsByName         map[string]*nativeResultInfo
+	resultsByLLVMType     map[string]*nativeResultInfo
 	interfaceOrder        []string // declaration order for deterministic emission
 	structOrder           []string // declaration order for deterministic emission
 	tuplesByLLVMType      map[string]*nativeTupleInfo
 	tupleOrder            []string
-	resultsByLLVMType     map[string]*nativeResultInfo
 	resultOrder           []string
 	closures              map[*ostyir.Closure]*nativeClosureInfo
 	closuresByID          []*nativeClosureInfo
@@ -142,6 +154,10 @@ type nativeProjectionCtx struct {
 	methodsByOwner        map[string]map[string]nativeMethodInfo
 	globalConsts          map[string]nativeConstValue
 	mutableGlobals        map[string]bool
+	runtimeFFI            map[string]map[string]*nativeRuntimeFFIFunction
+	testingAliases        map[string]bool
+	runtimeDecls          []string
+	runtimeDeclSet        map[string]bool
 	scopes                []map[string]nativeExprInfo
 	needsListRT           bool
 	needsMapRT            bool
@@ -150,6 +166,8 @@ type nativeProjectionCtx struct {
 	stringGlobals         []*LlvmStringGlobal
 	nextStringID          int
 	currentReturnLLVMType string
+	sourcePath            string
+	source                []byte
 	// tempCounter mints monotone fresh names for synthetic locals
 	// spilled from one-to-many statement expansions (e.g. tuple
 	// destructuring, for-in over a list). The name prefix is
@@ -235,6 +253,20 @@ func (ctx *nativeProjectionCtx) lookupScopeName(name string) (nativeExprInfo, bo
 	return nativeExprInfo{}, false
 }
 
+func (ctx *nativeProjectionCtx) addRuntimeDecl(decl string) {
+	if ctx == nil || decl == "" {
+		return
+	}
+	if ctx.runtimeDeclSet == nil {
+		ctx.runtimeDeclSet = map[string]bool{}
+	}
+	if ctx.runtimeDeclSet[decl] {
+		return
+	}
+	ctx.runtimeDeclSet[decl] = true
+	ctx.runtimeDecls = append(ctx.runtimeDecls, decl)
+}
+
 type nativeMethodInfo struct {
 	irName      string
 	receiverMut bool
@@ -286,12 +318,18 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		structsByName:     map[string]*nativeStructInfo{},
 		enumsByName:       map[string]*nativeEnumInfo{},
 		interfacesByName:  map[string]*nativeInterfaceInfo{},
-		tuplesByLLVMType:  map[string]*nativeTupleInfo{},
+		resultsByName:     map[string]*nativeResultInfo{},
 		resultsByLLVMType: map[string]*nativeResultInfo{},
+		tuplesByLLVMType:  map[string]*nativeTupleInfo{},
 		closures:          map[*ostyir.Closure]*nativeClosureInfo{},
 		methodsByOwner:    map[string]map[string]nativeMethodInfo{},
 		globalConsts:      map[string]nativeConstValue{},
 		mutableGlobals:    map[string]bool{},
+		runtimeFFI:        map[string]map[string]*nativeRuntimeFFIFunction{},
+		testingAliases:    map[string]bool{},
+		runtimeDeclSet:    map[string]bool{},
+		sourcePath:        firstNonEmpty(opts.SourcePath, "<unknown>"),
+		source:            append([]byte(nil), opts.Source...),
 	}
 	out := &llvmNativeModule{
 		sourcePath:    firstNonEmpty(opts.SourcePath, "<unknown>"),
@@ -308,8 +346,17 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 		case nil:
 			continue
 		case *ostyir.UseDecl:
-			if d.IsFFI() {
+			if d.IsGoFFI {
 				return nil, false
+			}
+			if d.IsRuntimeFFI {
+				if !llvmIsKnownRuntimeFfiPath(d.RuntimePath) || !nativeRegisterRuntimeFFIUse(ctx, d) {
+					return nil, false
+				}
+				continue
+			}
+			if nativeIsStdTestingUse(d) {
+				ctx.testingAliases[nativeUseAlias(d)] = true
 			}
 		case *ostyir.StructDecl:
 			info, ok := nativeRegisterStructDecl(d)
@@ -347,6 +394,12 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 			ctx.interfaceOrder = append(ctx.interfaceOrder, d.Name)
 		case *ostyir.EnumDecl:
 			if d == nil {
+				continue
+			}
+			if d.BuiltinSource == "Result" {
+				if _, ok := nativeRegisterBuiltinResultDecl(ctx, d); !ok {
+					return nil, false
+				}
 				continue
 			}
 			// Generic templates survive monomorphization alongside
@@ -398,6 +451,9 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 				out.functions = append(out.functions, fn)
 			}
 		case *ostyir.EnumDecl:
+			if d.BuiltinSource == "Result" {
+				continue
+			}
 			// Enum declarations are fully projected during the
 			// registration phase above; nothing to populate here.
 			// The explicit case keeps enum decls from falling into
@@ -464,6 +520,7 @@ func nativeModuleFromIR(mod *ostyir.Module, opts Options) (*llvmNativeModule, bo
 	out.needsSetRuntime = ctx.needsSetRT
 	out.needsStringRuntime = ctx.needsStringRT
 	out.projectionCtx = ctx
+	out.extraRuntimeDecls = append(out.extraRuntimeDecls, ctx.runtimeDecls...)
 	return out, true
 }
 
@@ -530,7 +587,7 @@ func collectNativeInterfaceImpls(mod *ostyir.Module) []nativeInterfaceImpl {
 		interfacesByName:  map[string]*nativeInterfaceInfo{},
 		tuplesByLLVMType:  map[string]*nativeTupleInfo{},
 		resultsByLLVMType: map[string]*nativeResultInfo{},
-		methodsByOwner:   map[string]map[string]nativeMethodInfo{},
+		methodsByOwner:    map[string]map[string]nativeMethodInfo{},
 	}
 	structOrder := make([]string, 0)
 	structDecls := map[string]*ostyir.StructDecl{}
@@ -925,6 +982,147 @@ func sortedStringKeys[V any](m map[string]V) []string {
 	return out
 }
 
+func nativeUseAlias(use *ostyir.UseDecl) string {
+	if use == nil {
+		return ""
+	}
+	if use.Alias != "" {
+		return use.Alias
+	}
+	if n := len(use.Path); n != 0 {
+		return use.Path[n-1]
+	}
+	return ""
+}
+
+func nativeIsStdTestingUse(use *ostyir.UseDecl) bool {
+	return use != nil && !use.IsFFI() && len(use.Path) == 2 && use.Path[0] == "std" && use.Path[1] == "testing"
+}
+
+func nativeRegisterRuntimeFFIUse(ctx *nativeProjectionCtx, use *ostyir.UseDecl) bool {
+	if ctx == nil || use == nil || !use.IsRuntimeFFI {
+		return false
+	}
+	alias := nativeUseAlias(use)
+	if alias == "" {
+		return false
+	}
+	funcs := ctx.runtimeFFI[alias]
+	if funcs == nil {
+		funcs = map[string]*nativeRuntimeFFIFunction{}
+		ctx.runtimeFFI[alias] = funcs
+	}
+	for _, decl := range use.GoBody {
+		fn, ok := decl.(*ostyir.FnDecl)
+		if !ok || fn == nil || fn.Name == "" || fn.ReceiverMut || len(fn.Generics) != 0 {
+			continue
+		}
+		retType, ok := nativeLLVMTypeFromIR(ctx, fn.Return)
+		if !ok {
+			return false
+		}
+		sig := &nativeRuntimeFFIFunction{
+			path:     use.RuntimePath,
+			symbol:   llvmRuntimeFfiSymbol(use.RuntimePath, fn.Name),
+			retType:  retType,
+			paramTys: make([]string, 0, len(fn.Params)),
+		}
+		for _, param := range fn.Params {
+			if param == nil || param.IsDestructured() || param.Default != nil {
+				return false
+			}
+			typ, ok := nativeLLVMTypeFromIR(ctx, param.Type)
+			if !ok || typ == "void" {
+				return false
+			}
+			sig.paramTys = append(sig.paramTys, typ)
+		}
+		funcs[fn.Name] = sig
+	}
+	return true
+}
+
+func nativeRegisterBuiltinResultDecl(ctx *nativeProjectionCtx, decl *ostyir.EnumDecl) (*nativeResultInfo, bool) {
+	if ctx == nil || decl == nil || decl.BuiltinSource != "Result" || len(decl.BuiltinSourceArgs) != 2 {
+		return nil, false
+	}
+	return nativeRegisterBuiltinResultType(ctx, decl.Name, decl.BuiltinSourceArgs[0], decl.BuiltinSourceArgs[1])
+}
+
+func nativeRegisterBuiltinResultType(ctx *nativeProjectionCtx, name string, okIR, errIR ostyir.Type) (*nativeResultInfo, bool) {
+	if ctx == nil || okIR == nil || errIR == nil {
+		return nil, false
+	}
+	okType, ok := nativeLLVMTypeFromIR(ctx, okIR)
+	if !ok || okType == "void" {
+		return nil, false
+	}
+	errType, ok := nativeLLVMTypeFromIR(ctx, errIR)
+	if !ok || errType == "void" {
+		return nil, false
+	}
+	llvmType := llvmResultTypeName(okType, errType)
+	if info := ctx.resultsByLLVMType[llvmType]; info != nil {
+		if info.okType == "" {
+			info.okType = okType
+			info.errType = errType
+			info.okIR = okIR
+			info.errIR = errIR
+		}
+		if info.okLLVM == "" {
+			info.okLLVM = okType
+			info.errLLVM = errType
+			info.llvmType = llvmType
+			info.okIRType = okIR
+			info.errIRType = errIR
+		}
+		if name != "" {
+			ctx.resultsByName[name] = info
+		}
+		return info, true
+	}
+	if name == "" {
+		name = strings.TrimPrefix(llvmType, "%")
+	}
+	info := &nativeResultInfo{
+		def: &llvmNativeStruct{
+			name:     name,
+			llvmType: llvmType,
+			fields: []*llvmNativeStructField{
+				{name: "disc", llvmType: "i64"},
+				{name: "ok", llvmType: okType},
+				{name: "err", llvmType: errType},
+			},
+		},
+		okLLVM:    okType,
+		errLLVM:   errType,
+		llvmType:  llvmType,
+		okIRType:  okIR,
+		errIRType: errIR,
+		okType:    okType,
+		errType:   errType,
+		okIR:      okIR,
+		errIR:     errIR,
+	}
+	ctx.resultsByName[name] = info
+	ctx.resultsByLLVMType[llvmType] = info
+	ctx.resultOrder = append(ctx.resultOrder, llvmType)
+	return info, true
+}
+
+func nativeResultInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (*nativeResultInfo, bool) {
+	named, ok := t.(*ostyir.NamedType)
+	if !ok || named == nil {
+		return nil, false
+	}
+	if named.Builtin && named.Name == "Result" && len(named.Args) == 2 {
+		info, ok := nativeRegisterBuiltinResultType(ctx, "", named.Args[0], named.Args[1])
+		return info, ok
+	}
+	info := ctx.resultsByName[named.Name]
+	return info, info != nil
+}
+
 // nativeRegisterInterfaceDecl captures a non-generic interface's
 // method shape set. Each method signature is reduced to its
 // LLVM-level return + non-self parameter types so the finalization
@@ -1316,10 +1514,13 @@ func nativeBlockFromStmts(ctx *nativeProjectionCtx, stmts []ostyir.Stmt, fnRetur
 func nativeStmtsFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType string) ([]*llvmNativeStmt, bool) {
 	switch s := stmt.(type) {
 	case *ostyir.LetStmt:
+		if testing, ok := nativeTestingExpectLetStmts(ctx, s); ok {
+			return testing, true
+		}
 		switch s.Pattern.(type) {
 		case *ostyir.TuplePat:
 			return nativeLetTupleDestructureStmts(ctx, s)
-		case *ostyir.StructPat:
+		case *ostyir.StructPat, *ostyir.BindingPat:
 			return nativeLetStructDestructureStmts(ctx, s)
 		}
 	case *ostyir.ForStmt:
@@ -1524,20 +1725,129 @@ func nativeLetTupleDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt)
 	return out, true
 }
 
-// nativeLetStructDestructureStmts lowers
-// `let Foo { name, age, .. } = rhs` (and the rename shorthand
-// `let Foo { name: n, age }`) into a sequence of native `let`s —
-// one optional spill for the RHS, one per named field. Only
-// plain-ident field bindings are covered; nested sub-patterns,
-// wildcards, and mut bindings defer to the legacy bridge. The
-// pattern must name every field the emitted destructure extracts;
-// `Rest = true` (trailing `..`) is fine and means the struct has
-// more fields we don't read.
+func nativeBindScopedName(ctx *nativeProjectionCtx, name string, irType ostyir.Type, llvmType string) {
+	if ctx == nil || name == "" {
+		return
+	}
+	if info, ok := nativeExprInfoFromType(ctx, irType); ok {
+		ctx.bindScopeName(name, info)
+		return
+	}
+	ctx.bindScopeName(name, nativeExprInfoFromLLVMType(llvmType))
+}
+
+func nativeUnwrapStructPattern(p ostyir.Pattern, aliases *[]string) (*ostyir.StructPat, bool) {
+	switch pat := p.(type) {
+	case *ostyir.StructPat:
+		return pat, pat != nil
+	case *ostyir.BindingPat:
+		if pat == nil || pat.Name == "" {
+			return nil, false
+		}
+		*aliases = append(*aliases, pat.Name)
+		return nativeUnwrapStructPattern(pat.Pattern, aliases)
+	default:
+		return nil, false
+	}
+}
+
+func nativeStructPatternBindings(
+	ctx *nativeProjectionCtx,
+	pat *ostyir.StructPat,
+	baseName string,
+	info *nativeStructInfo,
+	baseType ostyir.Type,
+) ([]*llvmNativeStmt, bool) {
+	if ctx == nil || pat == nil || baseName == "" || info == nil {
+		return nil, false
+	}
+	out := make([]*llvmNativeStmt, 0, len(pat.Fields))
+	for _, f := range pat.Fields {
+		if f.Name == "" {
+			return nil, false
+		}
+		structField, ok := info.byName[f.Name]
+		if !ok {
+			return nil, false
+		}
+		base := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: info.def.llvmType, name: baseName}
+		fieldExpr := &llvmNativeExpr{
+			kind:       llvmNativeExprField,
+			llvmType:   structField.llvmType,
+			fieldIndex: structField.index,
+			childExprs: []*llvmNativeExpr{base},
+		}
+		switch sub := f.Pattern.(type) {
+		case nil:
+			out = append(out, &llvmNativeStmt{
+				kind:       llvmNativeStmtLet,
+				name:       f.Name,
+				childExprs: []*llvmNativeExpr{fieldExpr},
+			})
+			nativeBindScopedName(ctx, f.Name, structField.irType, structField.llvmType)
+		case *ostyir.IdentPat:
+			if sub == nil || sub.Name == "" || sub.Mut {
+				return nil, false
+			}
+			out = append(out, &llvmNativeStmt{
+				kind:       llvmNativeStmtLet,
+				name:       sub.Name,
+				childExprs: []*llvmNativeExpr{fieldExpr},
+			})
+			nativeBindScopedName(ctx, sub.Name, structField.irType, structField.llvmType)
+		case *ostyir.BindingPat, *ostyir.StructPat:
+			nestedAliases := []string{}
+			nestedPat, ok := nativeUnwrapStructPattern(sub, &nestedAliases)
+			if !ok {
+				return nil, false
+			}
+			nestedInfo, ok := nativeStructInfoFromType(ctx, structField.irType)
+			if !ok && nestedPat.TypeName != "" {
+				nestedInfo = ctx.structsByName[nestedPat.TypeName]
+				ok = nestedInfo != nil
+			}
+			if !ok || nestedInfo == nil {
+				return nil, false
+			}
+			tempName := ctx.freshTempName("__osty_native_s")
+			out = append(out, &llvmNativeStmt{
+				kind:       llvmNativeStmtLet,
+				name:       tempName,
+				childExprs: []*llvmNativeExpr{fieldExpr},
+			})
+			nativeBindScopedName(ctx, tempName, structField.irType, structField.llvmType)
+			tempIdent := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: structField.llvmType, name: tempName}
+			for _, alias := range nestedAliases {
+				out = append(out, &llvmNativeStmt{
+					kind:       llvmNativeStmtLet,
+					name:       alias,
+					childExprs: []*llvmNativeExpr{tempIdent},
+				})
+				nativeBindScopedName(ctx, alias, structField.irType, structField.llvmType)
+			}
+			nested, ok := nativeStructPatternBindings(ctx, nestedPat, tempName, nestedInfo, structField.irType)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, nested...)
+		default:
+			return nil, false
+		}
+	}
+	return out, true
+}
+
+// nativeLetStructDestructureStmts lowers struct-shaped let patterns,
+// including `binding @ Foo { ... }` and nested struct sub-patterns.
+// Complex leaves still defer to the legacy bridge; covered leaves are
+// shorthand binds, explicit ident binds, and nested struct/binding
+// patterns.
 func nativeLetStructDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt) ([]*llvmNativeStmt, bool) {
 	if ctx == nil || s == nil || s.Value == nil {
 		return nil, false
 	}
-	pat, ok := s.Pattern.(*ostyir.StructPat)
+	rootAliases := []string{}
+	pat, ok := nativeUnwrapStructPattern(s.Pattern, &rootAliases)
 	if !ok || pat == nil {
 		return nil, false
 	}
@@ -1549,46 +1859,12 @@ func nativeLetStructDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt
 	if !ok || info == nil {
 		return nil, false
 	}
-	// Resolve each pattern field to a bare binder name and the
-	// struct field it maps to. Field-level shorthand (`{ name }`)
-	// binds to a local with the same name; `name: n` binds to `n`.
-	type binding struct {
-		binderName string
-		fieldIdx   int
-		fieldLLVM  string
-	}
-	bindings := make([]binding, 0, len(pat.Fields))
-	for _, f := range pat.Fields {
-		if f.Name == "" {
-			return nil, false
-		}
-		structField, ok := info.byName[f.Name]
-		if !ok {
-			return nil, false
-		}
-		binderName := f.Name
-		if f.Pattern != nil {
-			id, ok := f.Pattern.(*ostyir.IdentPat)
-			if !ok || id == nil || id.Name == "" || id.Mut {
-				return nil, false
-			}
-			binderName = id.Name
-		}
-		bindings = append(bindings, binding{
-			binderName: binderName,
-			fieldIdx:   structField.index,
-			fieldLLVM:  structField.llvmType,
-		})
-	}
 	value, ok := nativeExprFromIR(ctx, s.Value)
-	if !ok {
+	if !ok || value.llvmType != info.def.llvmType {
 		return nil, false
 	}
-	if value.llvmType != info.def.llvmType {
-		return nil, false
-	}
-	out := make([]*llvmNativeStmt, 0, len(bindings)+1)
-	var baseName string
+	out := make([]*llvmNativeStmt, 0, len(pat.Fields)+1+len(rootAliases))
+	baseName := ""
 	if value.kind == llvmNativeExprIdent && value.name != "" {
 		baseName = value.name
 	} else {
@@ -1598,28 +1874,306 @@ func nativeLetStructDestructureStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt
 			name:       baseName,
 			childExprs: []*llvmNativeExpr{value},
 		})
-		ctx.bindScopeName(baseName, nativeExprInfoFromLLVMType(info.def.llvmType))
+		nativeBindScopedName(ctx, baseName, s.Value.Type(), info.def.llvmType)
 	}
-	for _, b := range bindings {
-		base := &llvmNativeExpr{
-			kind:     llvmNativeExprIdent,
-			llvmType: info.def.llvmType,
-			name:     baseName,
-		}
-		field := &llvmNativeExpr{
-			kind:       llvmNativeExprField,
-			llvmType:   b.fieldLLVM,
-			fieldIndex: b.fieldIdx,
-			childExprs: []*llvmNativeExpr{base},
-		}
+	baseIdent := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: info.def.llvmType, name: baseName}
+	for _, alias := range rootAliases {
 		out = append(out, &llvmNativeStmt{
 			kind:       llvmNativeStmtLet,
-			name:       b.binderName,
-			childExprs: []*llvmNativeExpr{field},
+			name:       alias,
+			childExprs: []*llvmNativeExpr{baseIdent},
 		})
-		ctx.bindScopeName(b.binderName, nativeExprInfoFromLLVMType(b.fieldLLVM))
+		nativeBindScopedName(ctx, alias, s.Value.Type(), info.def.llvmType)
 	}
+	fields, ok := nativeStructPatternBindings(ctx, pat, baseName, info, s.Value.Type())
+	if !ok {
+		return nil, false
+	}
+	out = append(out, fields...)
 	return out, true
+}
+
+func nativeTestingCallMethod(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (string, bool) {
+	alias, name, ok := nativeQualifiedAliasCall(call)
+	if !ok || ctx == nil || !ctx.testingAliases[alias] {
+		return "", false
+	}
+	return name, true
+}
+
+func nativeSourceSpanText(ctx *nativeProjectionCtx, n ostyir.Node) string {
+	if ctx == nil || n == nil || len(ctx.source) == 0 {
+		return ""
+	}
+	span := n.At()
+	start, end := span.Start.Offset, span.End.Offset
+	if start < 0 || end < start || end > len(ctx.source) {
+		return ""
+	}
+	return strings.TrimSpace(string(ctx.source[start:end]))
+}
+
+func nativeTestingFailureMessage(ctx *nativeProjectionCtx, method string, n ostyir.Node, exprText string) string {
+	label := firstNonEmpty(ctx.sourcePath, "<test>")
+	if n != nil && n.At().Start.Line > 0 {
+		label = fmt.Sprintf("%s:%d", label, n.At().Start.Line)
+	}
+	msg := fmt.Sprintf("testing.%s failed at %s", method, label)
+	if exprText != "" && (method == "expectOk" || method == "expectError") {
+		msg += fmt.Sprintf("; expr=`%s`", exprText)
+	}
+	return msg
+}
+
+func nativeTestingFailureBlock(ctx *nativeProjectionCtx, message string) *llvmNativeBlock {
+	ctx.addRuntimeDecl("declare void @exit(i32)")
+	return &llvmNativeBlock{
+		stmts: []*llvmNativeStmt{
+			{
+				kind: llvmNativeStmtExpr,
+				childExprs: []*llvmNativeExpr{{
+					kind:       llvmNativeExprPrintln,
+					llvmType:   "void",
+					childExprs: []*llvmNativeExpr{nativeStringLiteralExpr(message)},
+				}},
+			},
+			{
+				kind: llvmNativeStmtExpr,
+				childExprs: []*llvmNativeExpr{{
+					kind:     llvmNativeExprCall,
+					llvmType: "void",
+					name:     "exit",
+					childExprs: []*llvmNativeExpr{{
+						kind:     llvmNativeExprInt,
+						llvmType: "i32",
+						text:     "1",
+					}},
+				}},
+			},
+		},
+	}
+}
+
+func nativeTestingFailureValueBlock(ctx *nativeProjectionCtx, message string, llvmType string) *llvmNativeBlock {
+	block := nativeTestingFailureBlock(ctx, message)
+	if block == nil {
+		return nil
+	}
+	block.hasResult = true
+	block.result = nativeZeroExprForLLVMType(llvmType)
+	return block
+}
+
+func nativeTestingResultExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*llvmNativeExpr, bool) {
+	method, ok := nativeTestingCallMethod(ctx, call)
+	if !ok || (method != "expectOk" && method != "expectError") {
+		return nil, false
+	}
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return nil, false
+	}
+	resultInfo, ok := nativeResultInfoFromType(ctx, call.Args[0].Value.Type())
+	if !ok {
+		return nil, false
+	}
+	resultExpr, ok := nativeExprFromIR(ctx, call.Args[0].Value)
+	if !ok || resultExpr.llvmType != resultInfo.def.llvmType {
+		return nil, false
+	}
+	wantTag := "0"
+	payloadIndex := 1
+	payloadType := resultInfo.okType
+	if method == "expectError" {
+		wantTag = "1"
+		payloadIndex = 2
+		payloadType = resultInfo.errType
+	}
+	cond := &llvmNativeExpr{
+		kind:     llvmNativeExprBinary,
+		llvmType: "i1",
+		op:       "==",
+		childExprs: []*llvmNativeExpr{
+			{kind: llvmNativeExprField, llvmType: "i64", fieldIndex: 0, childExprs: []*llvmNativeExpr{resultExpr}},
+			{kind: llvmNativeExprInt, llvmType: "i64", text: wantTag},
+		},
+	}
+	payload := &llvmNativeExpr{
+		kind:       llvmNativeExprField,
+		llvmType:   payloadType,
+		fieldIndex: payloadIndex,
+		childExprs: []*llvmNativeExpr{resultExpr},
+	}
+	return &llvmNativeExpr{
+		kind:     llvmNativeExprIf,
+		llvmType: payloadType,
+		childExprs: []*llvmNativeExpr{
+			cond,
+		},
+		childBlocks: []*llvmNativeBlock{
+			{hasResult: true, result: payload},
+			nativeTestingFailureValueBlock(ctx, nativeTestingFailureMessage(ctx, method, call, nativeSourceSpanText(ctx, call.Args[0].Value)), payloadType),
+		},
+	}, true
+}
+
+func nativeTestingExpectLetStmts(ctx *nativeProjectionCtx, s *ostyir.LetStmt) ([]*llvmNativeStmt, bool) {
+	if ctx == nil || s == nil || s.Pattern != nil || s.Value == nil {
+		return nil, false
+	}
+	call, ok := s.Value.(*ostyir.CallExpr)
+	if !ok {
+		return nil, false
+	}
+	method, ok := nativeTestingCallMethod(ctx, call)
+	if !ok || (method != "expectOk" && method != "expectError") {
+		return nil, false
+	}
+	if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+		return nil, false
+	}
+	resultInfo, ok := nativeResultInfoFromType(ctx, call.Args[0].Value.Type())
+	if !ok {
+		return nil, false
+	}
+	resultExpr, ok := nativeExprFromIR(ctx, call.Args[0].Value)
+	if !ok || resultExpr.llvmType != resultInfo.def.llvmType {
+		return nil, false
+	}
+	tempName := ctx.freshTempName("__osty_native_result")
+	out := []*llvmNativeStmt{{
+		kind:       llvmNativeStmtLet,
+		name:       tempName,
+		childExprs: []*llvmNativeExpr{resultExpr},
+	}}
+	nativeBindScopedName(ctx, tempName, call.Args[0].Value.Type(), resultInfo.def.llvmType)
+	wantTag := "0"
+	payloadIndex := 1
+	payloadType := resultInfo.okType
+	payloadIR := resultInfo.okIR
+	if method == "expectError" {
+		wantTag = "1"
+		payloadIndex = 2
+		payloadType = resultInfo.errType
+		payloadIR = resultInfo.errIR
+	}
+	tempIdent := &llvmNativeExpr{kind: llvmNativeExprIdent, llvmType: resultInfo.def.llvmType, name: tempName}
+	cond := &llvmNativeExpr{
+		kind:     llvmNativeExprBinary,
+		llvmType: "i1",
+		op:       "==",
+		childExprs: []*llvmNativeExpr{
+			{kind: llvmNativeExprField, llvmType: "i64", fieldIndex: 0, childExprs: []*llvmNativeExpr{tempIdent}},
+			{kind: llvmNativeExprInt, llvmType: "i64", text: wantTag},
+		},
+	}
+	out = append(out, &llvmNativeStmt{
+		kind:       llvmNativeStmtIf,
+		childExprs: []*llvmNativeExpr{cond},
+		childBlocks: []*llvmNativeBlock{
+			{},
+			nativeTestingFailureBlock(ctx, nativeTestingFailureMessage(ctx, method, call, nativeSourceSpanText(ctx, call.Args[0].Value))),
+		},
+	})
+	payload := &llvmNativeExpr{
+		kind:       llvmNativeExprField,
+		llvmType:   payloadType,
+		fieldIndex: payloadIndex,
+		childExprs: []*llvmNativeExpr{tempIdent},
+	}
+	kind := llvmNativeStmtLet
+	if s.Mut {
+		kind = llvmNativeStmtMutLet
+	}
+	out = append(out, &llvmNativeStmt{
+		kind:       kind,
+		name:       s.Name,
+		childExprs: []*llvmNativeExpr{payload},
+	})
+	nativeBindScopedName(ctx, s.Name, firstNonNilType(s.Type, payloadIR), payloadType)
+	return out, true
+}
+
+func nativeTestingCallStmtFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*llvmNativeStmt, bool) {
+	method, ok := nativeTestingCallMethod(ctx, call)
+	if !ok {
+		return nil, false
+	}
+	switch method {
+	case "expectOk", "expectError":
+		if len(call.Args) != 1 || call.Args[0].Name != "" || call.Args[0].Value == nil {
+			return nil, false
+		}
+		resultInfo, ok := nativeResultInfoFromType(ctx, call.Args[0].Value.Type())
+		if !ok {
+			return nil, false
+		}
+		resultExpr, ok := nativeExprFromIR(ctx, call.Args[0].Value)
+		if !ok || resultExpr.llvmType != resultInfo.def.llvmType {
+			return nil, false
+		}
+		wantTag := "0"
+		if method == "expectError" {
+			wantTag = "1"
+		}
+		cond := &llvmNativeExpr{
+			kind:     llvmNativeExprBinary,
+			llvmType: "i1",
+			op:       "==",
+			childExprs: []*llvmNativeExpr{
+				{kind: llvmNativeExprField, llvmType: "i64", fieldIndex: 0, childExprs: []*llvmNativeExpr{resultExpr}},
+				{kind: llvmNativeExprInt, llvmType: "i64", text: wantTag},
+			},
+		}
+		return &llvmNativeStmt{
+			kind:       llvmNativeStmtIf,
+			childExprs: []*llvmNativeExpr{cond},
+			childBlocks: []*llvmNativeBlock{
+				{},
+				nativeTestingFailureBlock(ctx, nativeTestingFailureMessage(ctx, method, call, nativeSourceSpanText(ctx, call.Args[0].Value))),
+			},
+		}, true
+	case "assertEq":
+		if len(call.Args) != 2 || call.Args[0].Name != "" || call.Args[1].Name != "" || call.Args[0].Value == nil || call.Args[1].Value == nil {
+			return nil, false
+		}
+		leftInfo, ok := nativeExprTypeInfo(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		rightInfo, ok := nativeExprTypeInfo(ctx, call.Args[1].Value)
+		if !ok || leftInfo.kind != nativeExprInfoScalar || rightInfo.kind != nativeExprInfoScalar || leftInfo.llvmType != rightInfo.llvmType {
+			return nil, false
+		}
+		switch leftInfo.llvmType {
+		case "i1", "i8", "i32", "i64", "double":
+		default:
+			return nil, false
+		}
+		left, ok := nativeExprFromIR(ctx, call.Args[0].Value)
+		if !ok {
+			return nil, false
+		}
+		right, ok := nativeExprFromIR(ctx, call.Args[1].Value)
+		if !ok {
+			return nil, false
+		}
+		cond := &llvmNativeExpr{
+			kind:       llvmNativeExprBinary,
+			llvmType:   "i1",
+			op:         "==",
+			childExprs: []*llvmNativeExpr{left, right},
+		}
+		return &llvmNativeStmt{
+			kind:       llvmNativeStmtIf,
+			childExprs: []*llvmNativeExpr{cond},
+			childBlocks: []*llvmNativeBlock{
+				{},
+				nativeTestingFailureBlock(ctx, nativeTestingFailureMessage(ctx, method, call, "")),
+			},
+		}, true
+	default:
+		return nil, false
+	}
 }
 
 func nativeStmtFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType string) (*llvmNativeStmt, bool) {
@@ -1691,6 +2245,11 @@ func nativeStmtFromIR(ctx *nativeProjectionCtx, stmt ostyir.Stmt, fnReturnType s
 			childExprs: []*llvmNativeExpr{value},
 		}, true
 	case *ostyir.ExprStmt:
+		if call, ok := s.X.(*ostyir.CallExpr); ok {
+			if testing, ok := nativeTestingCallStmtFromIR(ctx, call); ok {
+				return testing, true
+			}
+		}
 		if ifLet, ok := s.X.(*ostyir.IfLetExpr); ok {
 			if stmt, ok := nativeIfLetVariantStmt(ctx, ifLet, fnReturnType); ok {
 				return stmt, true
@@ -2635,6 +3194,12 @@ func nativeExprFromIR(ctx *nativeProjectionCtx, expr ostyir.Expr) (*llvmNativeEx
 			childExprs:          []*llvmNativeExpr{left, right},
 		}, true
 	case *ostyir.CallExpr:
+		if testingExpr, ok := nativeTestingResultExprFromIR(ctx, e); ok {
+			return testingExpr, true
+		}
+		if runtimeCall, ok := nativeRuntimeFFICallExprFromIR(ctx, e); ok {
+			return runtimeCall, true
+		}
 		callee, ok := e.Callee.(*ostyir.Ident)
 		if !ok || len(e.TypeArgs) != 0 {
 			return nil, false
@@ -3048,9 +3613,18 @@ func nativeExprInfoFromType(ctx *nativeProjectionCtx, t ostyir.Type) (nativeExpr
 					return nativeExprInfo{}, false
 				}
 				return nativeExprInfoWithSource(nativeSetExprInfo(elemType, nativeTypeIsString(tt.Args[0])), t), true
+			case "Result":
+				llvmType, ok := nativeLLVMTypeFromIR(ctx, tt)
+				if !ok {
+					return nativeExprInfo{}, false
+				}
+				return nativeExprInfoWithSource(nativeExprInfoFromLLVMType(llvmType), t), true
 			default:
 				return nativeExprInfo{}, false
 			}
+		}
+		if info := ctx.resultsByName[tt.Name]; info != nil {
+			return nativeExprInfoWithSource(nativeExprInfoFromLLVMType(info.def.llvmType), t), true
 		}
 		info, ok := nativeStructInfoFromType(ctx, tt)
 		if !ok {
@@ -3453,14 +4027,14 @@ func nativeResultConstructorExprFromIR(ctx *nativeProjectionCtx, e *ostyir.Metho
 		return nil, false
 	}
 	var (
-		tag          = "0"
-		payloadLLVM  = info.okLLVM
-		zeroLLVM     = info.errLLVM
-		okChild      *llvmNativeExpr
-		errChild     *llvmNativeExpr
-		payloadSlot  = 1
-		zeroSlot     = 2
-		payloadIR    = info.okIRType
+		tag         = "0"
+		payloadLLVM = info.okLLVM
+		zeroLLVM    = info.errLLVM
+		okChild     *llvmNativeExpr
+		errChild    *llvmNativeExpr
+		payloadSlot = 1
+		zeroSlot    = 2
+		payloadIR   = info.okIRType
 	)
 	if e.Name == "Err" {
 		tag = "1"
@@ -4277,6 +4851,49 @@ func nativeExprFromIRWithHint(ctx *nativeProjectionCtx, expr ostyir.Expr, hintLL
 	}
 }
 
+func nativeQualifiedAliasCall(call *ostyir.CallExpr) (alias string, name string, ok bool) {
+	if call == nil {
+		return "", "", false
+	}
+	field, ok := call.Callee.(*ostyir.FieldExpr)
+	if !ok || field == nil || field.Optional {
+		return "", "", false
+	}
+	base, ok := field.X.(*ostyir.Ident)
+	if !ok || base == nil {
+		return "", "", false
+	}
+	return base.Name, field.Name, true
+}
+
+func nativeRuntimeFFICallExprFromIR(ctx *nativeProjectionCtx, call *ostyir.CallExpr) (*llvmNativeExpr, bool) {
+	alias, name, ok := nativeQualifiedAliasCall(call)
+	if !ok {
+		return nil, false
+	}
+	funcs := ctx.runtimeFFI[alias]
+	if funcs == nil {
+		return nil, false
+	}
+	sig := funcs[name]
+	if sig == nil {
+		return nil, false
+	}
+	args, ok := nativePositionalArgsFromIRWithHints(ctx, call.Args, sig.paramTys)
+	if !ok {
+		return nil, false
+	}
+	if sig.path == "runtime.strings" {
+		ctx.needsStringRT = true
+	}
+	return &llvmNativeExpr{
+		kind:       llvmNativeExprCall,
+		llvmType:   sig.retType,
+		name:       sig.symbol,
+		childExprs: args,
+	}, true
+}
+
 // nativeVariantLitFromIR lowers `Maybe.Some(42)` / `Maybe.None` into
 // a native struct literal over the monomorphized enum's storage
 // type `{ i64 tag, <payloadSlotType> }`. The emitter reuses the
@@ -4296,6 +4913,38 @@ func nativeExprFromIRWithHint(ctx *nativeProjectionCtx, expr ostyir.Expr, hintLL
 func nativeVariantLitFromIR(ctx *nativeProjectionCtx, lit *ostyir.VariantLit) (*llvmNativeExpr, bool) {
 	if ctx == nil || lit == nil {
 		return nil, false
+	}
+	if resultInfo, ok := nativeResultInfoFromType(ctx, lit.Type()); ok {
+		if len(lit.Args) != 1 || lit.Args[0].Name != "" {
+			return nil, false
+		}
+		fields := []*llvmNativeExpr{
+			nativeIntLiteralExpr("0"),
+			nativeZeroExprForLLVMType(resultInfo.okType),
+			nativeZeroExprForLLVMType(resultInfo.errType),
+		}
+		payloadIndex := 1
+		payloadType := resultInfo.okType
+		switch lit.Variant {
+		case "Ok":
+			fields[0] = nativeIntLiteralExpr("0")
+		case "Err":
+			fields[0] = nativeIntLiteralExpr("1")
+			payloadIndex = 2
+			payloadType = resultInfo.errType
+		default:
+			return nil, false
+		}
+		value, ok := nativeExprFromIRWithHint(ctx, lit.Args[0].Value, payloadType)
+		if !ok || value.llvmType != payloadType {
+			return nil, false
+		}
+		fields[payloadIndex] = value
+		return &llvmNativeExpr{
+			kind:       llvmNativeExprStructLit,
+			llvmType:   resultInfo.def.llvmType,
+			childExprs: fields,
+		}, true
 	}
 	info, ok := nativeEnumInfoFromType(ctx, lit.Type())
 	if !ok {
@@ -4395,6 +5044,9 @@ func nativeZeroExprForLLVMType(llvmType string) *llvmNativeExpr {
 	case "ptr":
 		return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: "ptr", text: "null"}
 	default:
+		if strings.HasPrefix(llvmType, "%") {
+			return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: llvmType, text: "zeroinitializer"}
+		}
 		return &llvmNativeExpr{kind: llvmNativeExprInt, llvmType: llvmType, text: "0"}
 	}
 }
@@ -4550,16 +5202,21 @@ func nativeLLVMTypeFromIR(ctx *nativeProjectionCtx, t ostyir.Type) (string, bool
 			case "List", "Map", "Set":
 				return "ptr", true
 			case "Result":
-				if len(tt.Args) == 2 {
-					if name, ok := nativeRegisterResultType(ctx, tt.Args[0], tt.Args[1]); ok {
-						return name, true
-					}
+				if len(tt.Args) != 2 {
+					return "", false
 				}
-				return "", false
+				info, ok := nativeRegisterBuiltinResultType(ctx, "", tt.Args[0], tt.Args[1])
+				if !ok {
+					return "", false
+				}
+				return info.def.llvmType, true
 			}
 			return "", false
 		}
 		if info, ok := nativeStructInfoFromType(ctx, tt); ok {
+			return info.def.llvmType, true
+		}
+		if info := ctx.resultsByName[tt.Name]; info != nil {
 			return info.def.llvmType, true
 		}
 		if info, ok := nativeEnumInfoFromType(ctx, tt); ok {

--- a/internal/llvmgen/ir_native_struct_destructure_test.go
+++ b/internal/llvmgen/ir_native_struct_destructure_test.go
@@ -112,11 +112,12 @@ fn main() {
 	}
 }
 
-// TestNativeLetStructDestructureRejectsNestedPattern — stage-1
-// coverage only handles plain-ident sub-patterns. Nested struct
-// pattern bindings (`let Foo { inner: Bar { x } } = ...`) must
-// defer to the legacy bridge.
-func TestNativeLetStructDestructureRejectsNestedPattern(t *testing.T) {
+// TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern
+// locks the recursive pattern lowering shape:
+// `let outer @ Outer { inner: Inner { x } } = ...` must cover the
+// top-level binding alias and the nested field destructure without
+// falling back to the legacy bridge.
+func TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern(t *testing.T) {
 	src := `struct Inner {
     x: Int,
 }
@@ -126,20 +127,29 @@ struct Outer {
 }
 
 fn main() {
-    let o = Outer { inner: Inner { x: 7 } }
-    let Outer { inner: Inner { x } } = o
+    let outer @ Outer { inner: Inner { x } } = Outer { inner: Inner { x: 7 } }
     println(x)
+    println(outer.inner.x)
 }
 `
 	mod := lowerNativeEntryModule(t, src)
-	_, ok, err := TryGenerateNativeOwnedModule(mod, Options{
+	out, ok, err := TryGenerateNativeOwnedModule(mod, Options{
 		PackageName: "main",
 		SourcePath:  "/tmp/native_struct_destructure_nested.osty",
 	})
 	if err != nil {
 		t.Fatalf("TryGenerateNativeOwnedModule errored: %v", err)
 	}
-	if ok {
-		t.Fatal("TryGenerateNativeOwnedModule unexpectedly covered nested struct destructure — stage-1 should defer")
+	if !ok {
+		t.Fatal("TryGenerateNativeOwnedModule reported uncovered for nested struct destructure + binding")
+	}
+	got := string(out)
+	for _, want := range []string{
+		"extractvalue %Outer",
+		"extractvalue %Inner",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("native-owned IR missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/internal/llvmgen/native_entry_snapshot.go
+++ b/internal/llvmgen/native_entry_snapshot.go
@@ -211,7 +211,8 @@ type llvmNativeModule struct {
 	// emit per-module post-processing surfaces (closure thunks,
 	// future batches). Not present in the Osty mirror — the
 	// snapshot regen script drops unknown fields anyway.
-	projectionCtx *nativeProjectionCtx
+	projectionCtx     *nativeProjectionCtx
+	extraRuntimeDecls []string
 }
 
 type llvmNativeRenderedFunction struct {
@@ -309,6 +310,7 @@ func llvmNativeRuntimeDeclarations(mod *llvmNativeModule) []string {
 	if mod.needsStringRuntime {
 		out = append(out, llvmStringRuntimeDeclarations()...)
 	}
+	out = append(out, mod.extraRuntimeDecls...)
 	return out
 }
 


### PR DESCRIPTION
## What changed
- recover `downcast::<T>()` method-call IR typing as `OptionalType<T>` instead of falling back to `ErrType`
- preserve builtin generic types in lowered runtime FFI signatures so `runtime.strings` helpers like `Split` and `Join` stay native-fast-path compatible
- extend native LLVM entry lowering to cover runtime FFI alias calls, builtin `Result` shapes, `std.testing` helpers, and nested/binding struct destructuring
- add CLI/native regression tests for `runtime.strings`, `std.testing`, and nested struct binding patterns

## Why
The native-owned LLVM fast path was incorrectly dropping coverage for a few high-value cases:
- interface `downcast::<T>()` could lose its optional result type across checker/native boundaries
- runtime FFI headers with builtin generic types like `List<String>` were lowered without builtin metadata and then rejected by native codegen
- `std.testing` calls and nested struct pattern destructuring still fell back to uncovered paths in the CLI/native entry flow

## Impact
- fixes `InterfaceDowncast`
- accepts the `runtime.strings` / `std.testing` whitelist cases in native codegen
- covers `PtrBackedListToSet`, `StdTesting`, and `LetStructPattern` in the native fast path

## Validation
- `go test -count=1 -vet=off ./internal/ir -run 'TestLowerMethodCallRecoversDowncastOptionalType|TestLowerUseDeclRecoversBuiltinGenericTypesWithoutResolverTypeRefs'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestTryGenerateNativeOwnedModuleCoversNestedStructBindingPattern'`
- `go test -count=1 -vet=off ./cmd/osty-native-llvmgen -run 'TestRunCoversRuntimeStringsSplitAndListToSet|TestRunCoversStdTestingHelpers|TestRunCoversNestedStructBindingPattern'`