### PR TITLE
feat(mir): std.strings.* free-fn intrinsic routing + StringSplit emit + concat boxing

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1072,7 +1072,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
-		mir.IntrinsicStringEndsWith:
+		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -2438,7 +2438,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
-		mir.IntrinsicStringEndsWith:
+		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
@@ -3517,7 +3517,26 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		var acc *LlvmValue
 		for idx, op := range i.Args {
 			if !isStringLLVMType(op.Type()) {
-				return unsupported("mir-mvp", fmt.Sprintf("string_concat arg %d type %s", idx+1, mirTypeString(op.Type())))
+				// String interpolation embeds non-String values
+				// (`"{n}"`) whose checker-side coercion to String
+				// doesn't always survive to the MIR arg list.
+				// Box numeric/bool parts at the emitter boundary
+				// so the concat runtime sees uniform ptr args.
+				boxed, boxErr := g.emitStringConcatBoxed(op)
+				if boxErr != nil {
+					return boxErr
+				}
+				if boxed == nil {
+					return unsupported("mir-mvp", fmt.Sprintf("string_concat arg %d type %s", idx+1, mirTypeString(op.Type())))
+				}
+				if acc == nil {
+					acc = boxed
+					continue
+				}
+				em := g.ostyEmitter()
+				acc = llvmStringConcat(em, acc, boxed)
+				g.flushOstyEmitter(em)
+				continue
 			}
 			partReg, err := g.evalOperand(op, op.Type())
 			if err != nil {
@@ -3601,8 +3620,89 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeHasSuffixSymbol())
 	case mir.IntrinsicStringContains:
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeContainsSymbol())
+	case mir.IntrinsicStringSplit:
+		return g.emitStringSplit(i, strReg)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
+}
+
+// emitStringConcatBoxed converts a non-String operand into a String
+// ptr suitable for string_concat. Handles the common coercion
+// shapes produced by string interpolation: Int / Int8..64 /
+// UInt8..64 / Byte / Bool / Float / Float32 / Float64 / Char.
+// Returns nil when the operand type isn't a known scalar, letting
+// the caller surface an unsupported-source diagnostic instead.
+func (g *mirGen) emitStringConcatBoxed(op mir.Operand) (*LlvmValue, error) {
+	t := op.Type()
+	if t == nil {
+		return nil, nil
+	}
+	prim, ok := t.(*ir.PrimType)
+	if !ok {
+		return nil, nil
+	}
+	switch prim.Kind {
+	case ir.PrimInt, ir.PrimInt8, ir.PrimInt16, ir.PrimInt32, ir.PrimInt64,
+		ir.PrimUInt8, ir.PrimUInt16, ir.PrimUInt32, ir.PrimUInt64,
+		ir.PrimByte, ir.PrimChar:
+		reg, err := g.evalOperand(op, t)
+		if err != nil {
+			return nil, err
+		}
+		sym := llvmIntRuntimeToStringSymbol()
+		g.declareRuntime(sym, "declare ptr @"+sym+"(i64)")
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i64", name: reg}})
+		g.flushOstyEmitter(em)
+		return out, nil
+	case ir.PrimBool:
+		reg, err := g.evalOperand(op, t)
+		if err != nil {
+			return nil, err
+		}
+		sym := llvmBoolRuntimeToStringSymbol()
+		g.declareRuntime(sym, "declare ptr @"+sym+"(i1)")
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "i1", name: reg}})
+		g.flushOstyEmitter(em)
+		return out, nil
+	case ir.PrimFloat, ir.PrimFloat32, ir.PrimFloat64:
+		reg, err := g.evalOperand(op, t)
+		if err != nil {
+			return nil, err
+		}
+		sym := llvmFloatRuntimeToStringSymbol()
+		g.declareRuntime(sym, "declare ptr @"+sym+"(double)")
+		em := g.ostyEmitter()
+		out := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "double", name: reg}})
+		g.flushOstyEmitter(em)
+		return out, nil
+	}
+	return nil, nil
+}
+
+// emitStringSplit emits `.split(sep)` as a call to the runtime
+// `osty_rt_strings_Split(ptr, ptr) -> ptr` helper. The runtime
+// returns a List<String> pointer; the MIR dest local has that same
+// shape, so no additional wrapping is needed.
+func (g *mirGen) emitStringSplit(i *mir.IntrinsicInstr, strReg string) error {
+	if len(i.Args) < 2 {
+		return unsupported("mir-mvp", "string_split with no sep arg")
+	}
+	sep := i.Args[1]
+	if !isStringLLVMType(sep.Type()) {
+		return unsupported("mir-mvp", fmt.Sprintf("string_split sep type %s", mirTypeString(sep.Type())))
+	}
+	sepReg, err := g.evalOperand(sep, sep.Type())
+	if err != nil {
+		return err
+	}
+	sym := llvmStringRuntimeSplitSymbol()
+	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+	em := g.ostyEmitter()
+	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: strReg}, {typ: "ptr", name: sepReg}})
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, result)
 }
 
 // emitStringBinaryBoolIntrinsic dispatches `.startsWith(s)` /

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -2490,6 +2490,19 @@ func (bs *bodyState) lowerCallExprInto(c *ir.CallExpr, dest *Place, destT Type) 
 				bs.emitRuntimeIntrinsic(kind, c.Args, dest, destT, c.SpanV)
 				return
 			}
+			// Route `std.strings.fn(x, ...)` to the equivalent
+			// String-method intrinsic with x as the receiver. Without
+			// this, the merged native-toolchain MIR probe would hit
+			// "call to unresolved symbol std.strings.split" (and
+			// friends) because the probe doesn't run stdlib body
+			// injection. The intrinsic path always works — the
+			// `osty_rt_strings_*` runtime symbols it targets don't
+			// care whether the call came from `s.split(sep)` or
+			// `strings.split(s, sep)`.
+			if kind := stdlibStringFreeFnToIntrinsic(qualifierOf(use), fx.Name); kind != IntrinsicInvalid {
+				bs.emitStringFreeFnIntrinsic(kind, c.Args, dest, destT, c.SpanV)
+				return
+			}
 		}
 	}
 	args, callee := bs.resolveCall(c)
@@ -3320,6 +3333,66 @@ func bytesIntrinsicForMethod(name string) IntrinsicKind {
 		return IntrinsicBytesSlice
 	}
 	return IntrinsicInvalid
+}
+
+// stdlibStringFreeFnToIntrinsic maps `std.strings.Y` free-function
+// calls to the receiver-based String intrinsic of the same name.
+// `std.strings.split(s, sep)` goes to IntrinsicStringSplit with
+// args = [s, sep], matching the shape the method-call path already
+// produces via `s.split(sep)`. Used by the merged native-toolchain
+// MIR probe (which skips stdlib body injection) and by anyone else
+// calling stdlib strings helpers through the module qualifier.
+func stdlibStringFreeFnToIntrinsic(qualifier, name string) IntrinsicKind {
+	if qualifier != "std.strings" {
+		return IntrinsicInvalid
+	}
+	switch name {
+	case "len":
+		return IntrinsicStringLen
+	case "isEmpty":
+		return IntrinsicStringIsEmpty
+	case "contains":
+		return IntrinsicStringContains
+	case "hasPrefix", "startsWith":
+		return IntrinsicStringStartsWith
+	case "hasSuffix", "endsWith":
+		return IntrinsicStringEndsWith
+	case "indexOf":
+		return IntrinsicStringIndexOf
+	case "split":
+		return IntrinsicStringSplit
+	case "trim":
+		return IntrinsicStringTrim
+	case "toUpper":
+		return IntrinsicStringToUpper
+	case "toLower":
+		return IntrinsicStringToLower
+	case "chars":
+		return IntrinsicStringChars
+	case "bytes":
+		return IntrinsicStringBytes
+	case "replace":
+		return IntrinsicStringReplace
+	}
+	return IntrinsicInvalid
+}
+
+// emitStringFreeFnIntrinsic lowers each arg in source order and
+// emits an IntrinsicInstr with the given String-family kind. All
+// String intrinsics put the receiver in Args[0] and any extra args
+// after it, so this is a straight pass-through — the method-call
+// path (lowerMethodCallInto) and the free-fn path share the same
+// operand layout.
+func (bs *bodyState) emitStringFreeFnIntrinsic(kind IntrinsicKind, args []ir.Arg, dest *Place, destT Type, sp Span) {
+	out := make([]Operand, len(args))
+	for i, a := range args {
+		out[i] = bs.lowerExprAsOperand(a.Value)
+	}
+	destPtr := dest
+	if destPtr != nil && isUnit(destT) {
+		destPtr = nil
+	}
+	bs.emit(&IntrinsicInstr{Dest: destPtr, Kind: kind, Args: out, SpanV: sp})
 }
 
 // qualifierOf extracts the package qualifier from a Use decl, or ""


### PR DESCRIPTION
## Summary

Three compounded advances push the native-merged MIR probe through three walls. Theme: make qualified stdlib calls like `std.strings.split(text, sep)` route through the same intrinsic path `text.split(sep)` already does, extend the emitter to lower `IntrinsicStringSplit`, and auto-box non-String arguments in `string_concat` so string interpolation survives even when the IR's implicit `toString` coercion was lost.

## What changed

### `internal/mir/lower.go` — free-fn qualified-call routing

- **`stdlibStringFreeFnToIntrinsic(qualifier, name)`** maps `std.strings.Y(s, ...)` free-function calls to the equivalent String-method intrinsic with `s` as the receiver. Covers `len / isEmpty / contains / hasPrefix / startsWith / hasSuffix / endsWith / indexOf / split / trim / toUpper / toLower / chars / bytes / replace`.
- **`emitStringFreeFnIntrinsic`** lowers each arg in source order and emits an `IntrinsicInstr` — method-call and free-fn paths share the same operand layout (receiver + extras).

### `internal/llvmgen/mir_generator.go` — StringSplit emit + concat boxing

- `IntrinsicStringSplit` added to `isSupportedIntrinsic` and `emitIntrinsic` dispatch; new `emitStringSplit` helper emits `(ptr, ptr) -> ptr` call to `osty_rt_strings_Split`.
- **`emitStringConcatBoxed`** — non-String concat arg gets boxed via the runtime's int/bool/float → string helpers (`osty_rt_int_to_string`, etc.). Handles every numeric scalar, Bool, and every Float kind.

## Probe progression

| State | First wall |
|---|---|
| Before (#666 merged) | `call to unresolved symbol std.strings.split` |
| After stdlib free-fn routing | `intrinsic kind=59 not yet supported` (StringSplit) |
| After Split emit | `string_concat arg 2 type Int` |
| After concat boxing (this PR's final) | `projection *mir.IndexProj on write` (different category) |

Whole-toolchain + native-toolchain AST probes remain CLEAN.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/ir/... ./internal/mir/... ./internal/llvmgen/ ./internal/check/...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)