### PR TITLE
[codex] Improve native bench support and runtime speed

### DIFF
--- a/benchmarks/osty-vs-go/README.md
+++ b/benchmarks/osty-vs-go/README.md
@@ -67,6 +67,9 @@ Useful flags:
 - `--go-count <N>` — run each Go pair `N` times and publish the median
   per metric. Default `3`; this trades a bit of wall time for a much
   steadier Go baseline.
+  In `--loop` / `--autoresearch`, unchanged Go workloads are cached
+  per session, so long pairs such as `record_pipeline` and
+  `simd_stats` don't keep re-running the same Go baseline every tick.
 - `--go-cpu <list>` — forwarded to `go test -cpu`. Default `1`, which
   reduces scheduler noise for very short Go benches.
 - `--pairs-dir <path>` — defaults to `benchmarks/osty-vs-go`.
@@ -78,6 +81,8 @@ Useful flags:
 - `--loop <dur>` — keep re-running on a fixed cadence until Ctrl-C;
   every tick prints a vs-best verdict so you can iterate on the
   compiler in a tight edit → measure → decide loop.
+  The session reuses Go-side results until the pair's `go/` inputs or
+  module files change.
 - `--noise <frac>` — band under which a vs-best delta is classified
   as "within noise" rather than a regression. Default `0.02` (±2%).
 
@@ -236,6 +241,9 @@ go run ./cmd/osty-vs-go --loop 5m --benchtime 500ms --label "inline-probe"
 This is the closest port of Karpathy's actual loop: the caller plugs
 a **mutator** (any executable that edits the working tree), the
 orchestrator runs mutate → bench → keep-or-revert without asking.
+Go baseline sweeps are memoized within the autoresearch session and
+are refreshed automatically if the workload's Go sources or module
+files change, which keeps long-workload search loops much faster.
 
 ```sh
 just build

--- a/cmd/osty-vs-go/main.go
+++ b/cmd/osty-vs-go/main.go
@@ -36,9 +36,14 @@ package main
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"hash"
+	"io"
+	"io/fs"
 	"math"
 	"os"
 	"os/exec"
@@ -209,6 +214,150 @@ func ptrOrNaN(p *float64) float64 {
 
 const historyFile = ".osty-vs-go-history.jsonl"
 
+type goBenchRunner func(goBin, pairsDir, pair, benchTime string, goCount int, goCPU string) ([]benchResult, error)
+
+type goBenchCache struct {
+	entries map[goBenchCacheKey][]benchResult
+}
+
+type goBenchCacheKey struct {
+	PairsDir    string
+	Pair        string
+	GoBin       string
+	BenchTime   string
+	GoCount     int
+	GoCPU       string
+	Fingerprint string
+}
+
+func newGoBenchCache() *goBenchCache {
+	return &goBenchCache{entries: map[goBenchCacheKey][]benchResult{}}
+}
+
+func runGoBenchCached(cache *goBenchCache, runner goBenchRunner, goBin, pairsDir, pair, benchTime string, goCount int, goCPU string) ([]benchResult, error) {
+	if cache == nil {
+		return runner(goBin, pairsDir, pair, benchTime, goCount, goCPU)
+	}
+	if cache.entries == nil {
+		cache.entries = map[goBenchCacheKey][]benchResult{}
+	}
+	key, err := goBenchCacheKeyFor(goBin, pairsDir, pair, benchTime, goCount, goCPU)
+	if err != nil {
+		return nil, err
+	}
+	if cached, ok := cache.entries[key]; ok {
+		return cloneBenchResults(cached), nil
+	}
+	rows, err := runner(goBin, pairsDir, pair, benchTime, goCount, goCPU)
+	if err != nil {
+		return nil, err
+	}
+	cache.entries[key] = cloneBenchResults(rows)
+	return cloneBenchResults(rows), nil
+}
+
+func cloneBenchResults(rows []benchResult) []benchResult {
+	if len(rows) == 0 {
+		return nil
+	}
+	return append([]benchResult(nil), rows...)
+}
+
+func goBenchCacheKeyFor(goBin, pairsDir, pair, benchTime string, goCount int, goCPU string) (goBenchCacheKey, error) {
+	fingerprint, err := goBenchInputsFingerprint(filepath.Join(pairsDir, pair, "go"))
+	if err != nil {
+		return goBenchCacheKey{}, err
+	}
+	return goBenchCacheKey{
+		PairsDir:    filepath.Clean(pairsDir),
+		Pair:        pair,
+		GoBin:       goBin,
+		BenchTime:   benchTime,
+		GoCount:     goCount,
+		GoCPU:       goCPU,
+		Fingerprint: fingerprint,
+	}, nil
+}
+
+func goBenchInputsFingerprint(pairDir string) (string, error) {
+	absPairDir, err := filepath.Abs(pairDir)
+	if err != nil {
+		return "", fmt.Errorf("abs pair dir %s: %w", pairDir, err)
+	}
+	h := sha256.New()
+	if err := hashDirTree(h, "pair", absPairDir); err != nil {
+		return "", err
+	}
+	if modRoot, ok := findGoModRoot(absPairDir); ok {
+		for _, name := range []string{"go.mod", "go.sum", "go.work", "go.work.sum"} {
+			if err := hashOptionalFile(h, name, filepath.Join(modRoot, name)); err != nil {
+				return "", err
+			}
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func findGoModRoot(start string) (string, bool) {
+	dir := start
+	for {
+		if info, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil && !info.IsDir() {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+func hashDirTree(h hash.Hash, label, root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		return hashFile(h, label+"/"+filepath.ToSlash(rel), path)
+	})
+}
+
+func hashOptionalFile(h hash.Hash, logicalName, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	return hashFile(h, logicalName, path)
+}
+
+func hashFile(h hash.Hash, logicalName, path string) error {
+	if _, err := io.WriteString(h, logicalName+"\n"); err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	_, err = io.WriteString(h, "\n")
+	return err
+}
+
 func main() {
 	fs := flag.NewFlagSet("osty-vs-go", flag.ExitOnError)
 	benchTime := fs.String("benchtime", "500ms", "per-bench duration target for both Go (-benchtime) and Osty (--benchtime)")
@@ -287,6 +436,7 @@ func main() {
 			NoiseFrac:      *noiseFrac,
 			PairRE:         pairRE,
 			Interval:       *loopInterval,
+			GoCache:        newGoBenchCache(),
 		}
 		if err := runAutoresearch(cfg); err != nil {
 			fmt.Fprintf(os.Stderr, "osty-vs-go: %v\n", err)
@@ -300,7 +450,7 @@ func main() {
 		return
 	}
 
-	if _, err := runOnce(*benchTime, *pairsDir, osty, *goBin, *goCount, *goCPU, *label, *noiseFrac, pairRE); err != nil {
+	if _, err := runOnce(*benchTime, *pairsDir, osty, *goBin, *goCount, *goCPU, *label, *noiseFrac, pairRE, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "osty-vs-go: %v\n", err)
 		os.Exit(1)
 	}
@@ -310,7 +460,7 @@ func main() {
 // side, print the table, append to history, print the vs-best verdict.
 // Returns the new record so `--loop` can stream verdicts without
 // re-reading history.
-func runOnce(benchTime, pairsDir, ostyBin, goBin string, goCount int, goCPU, label string, noiseFrac float64, pairRE *regexp.Regexp) (runRecord, error) {
+func runOnce(benchTime, pairsDir, ostyBin, goBin string, goCount int, goCPU, label string, noiseFrac float64, pairRE *regexp.Regexp, goCache *goBenchCache) (runRecord, error) {
 	pairs, err := discoverPairs(pairsDir)
 	if err != nil {
 		return runRecord{}, err
@@ -345,7 +495,7 @@ func runOnce(benchTime, pairsDir, ostyBin, goBin string, goCount int, goCPU, lab
 
 	var rows []benchResult
 	for _, pair := range pairs {
-		goRows, err := runGoBench(goBin, pairsDir, pair, benchTime, goCount, goCPU)
+		goRows, err := runGoBenchCached(goCache, runGoBench, goBin, pairsDir, pair, benchTime, goCount, goCPU)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "osty-vs-go: go bench %s: %v\n", pair, err)
 		}
@@ -394,10 +544,11 @@ func runLoop(interval time.Duration, benchTime, pairsDir, ostyBin, goBin string,
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	goCache := newGoBenchCache()
 	// Run immediately rather than waiting `interval` for the first
 	// tick — the user just launched it and expects feedback.
 	for {
-		if _, err := runOnce(benchTime, pairsDir, ostyBin, goBin, goCount, goCPU, label, noiseFrac, pairRE); err != nil {
+		if _, err := runOnce(benchTime, pairsDir, ostyBin, goBin, goCount, goCPU, label, noiseFrac, pairRE, goCache); err != nil {
 			fmt.Fprintf(os.Stderr, "osty-vs-go: %v\n", err)
 		}
 		fmt.Printf("\n(waiting %s before next sweep; Ctrl-C to stop)\n\n", interval)
@@ -427,6 +578,7 @@ type autoresearchConfig struct {
 	NoiseFrac      float64
 	PairRE         *regexp.Regexp
 	Interval       time.Duration
+	GoCache        *goBenchCache
 }
 
 // runAutoresearch is the closest faithful take on karpathy/autoresearch
@@ -530,7 +682,7 @@ func runAutoresearchIter(cfg autoresearchConfig, iter int, stats *autoresearchSt
 
 	// Phase 2: run the bench sweep. runOnce already writes the history
 	// file and prints the verdict relative to all-time history.
-	rec, err := runOnce(cfg.BenchTime, cfg.PairsDir, cfg.OstyBin, cfg.GoBin, cfg.GoCount, cfg.GoCPU, cfg.Label, cfg.NoiseFrac, cfg.PairRE)
+	rec, err := runOnce(cfg.BenchTime, cfg.PairsDir, cfg.OstyBin, cfg.GoBin, cfg.GoCount, cfg.GoCPU, cfg.Label, cfg.NoiseFrac, cfg.PairRE, cfg.GoCache)
 	if err != nil {
 		// Bench failure shouldn't leave the mutator's changes on HEAD.
 		_, _ = gitRun("reset", "--hard", "HEAD")

--- a/cmd/osty-vs-go/main_test.go
+++ b/cmd/osty-vs-go/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -113,6 +115,86 @@ func TestAggregateGoBenchRunsUsesMedianPerMetric(t *testing.T) {
 	}
 	if rows[1].GoNs != 120 || rows[1].GoBytes != 90 || rows[1].GoAllocs != 4 {
 		t.Fatalf("WordFreqTop10 median row = %+v", rows[1])
+	}
+}
+
+func TestRunGoBenchCachedReusesGoBaselineWhenInputsStayStable(t *testing.T) {
+	root := t.TempDir()
+	pairsDir := filepath.Join(root, "benchmarks")
+	pairDir := filepath.Join(pairsDir, "simd_stats", "go")
+	if err := os.MkdirAll(pairDir, 0o755); err != nil {
+		t.Fatalf("mkdir pair dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/bench\n\ngo 1.26.2\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pairDir, "simd_stats_test.go"), []byte("package simdstatsbench\n"), 0o644); err != nil {
+		t.Fatalf("write pair file: %v", err)
+	}
+
+	cache := newGoBenchCache()
+	calls := 0
+	runner := func(goBin, pairsDir, pair, benchTime string, goCount int, goCPU string) ([]benchResult, error) {
+		calls++
+		return []benchResult{mkResult(pair, "SimdStats", float64(calls), math.NaN())}, nil
+	}
+
+	first, err := runGoBenchCached(cache, runner, "go", pairsDir, "simd_stats", "2s", 3, "1")
+	if err != nil {
+		t.Fatalf("first cached run: %v", err)
+	}
+	second, err := runGoBenchCached(cache, runner, "go", pairsDir, "simd_stats", "2s", 3, "1")
+	if err != nil {
+		t.Fatalf("second cached run: %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("runner calls = %d, want 1 (cache hit on second run)", calls)
+	}
+	if len(second) != 1 || second[0].GoNs != first[0].GoNs {
+		t.Fatalf("cached rows = %+v, want %+v", second, first)
+	}
+}
+
+func TestRunGoBenchCachedInvalidatesWhenGoInputsChange(t *testing.T) {
+	root := t.TempDir()
+	pairsDir := filepath.Join(root, "benchmarks")
+	pairDir := filepath.Join(pairsDir, "record_pipeline", "go")
+	if err := os.MkdirAll(pairDir, 0o755); err != nil {
+		t.Fatalf("mkdir pair dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/bench\n\ngo 1.26.2\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	goFile := filepath.Join(pairDir, "record_pipeline_test.go")
+	if err := os.WriteFile(goFile, []byte("package recordpipelinebench\n"), 0o644); err != nil {
+		t.Fatalf("write pair file: %v", err)
+	}
+
+	cache := newGoBenchCache()
+	calls := 0
+	runner := func(goBin, pairsDir, pair, benchTime string, goCount int, goCPU string) ([]benchResult, error) {
+		calls++
+		return []benchResult{mkResult(pair, "RecordPipeline", float64(calls), math.NaN())}, nil
+	}
+
+	first, err := runGoBenchCached(cache, runner, "go", pairsDir, "record_pipeline", "2s", 3, "1")
+	if err != nil {
+		t.Fatalf("first cached run: %v", err)
+	}
+	if err := os.WriteFile(goFile, []byte("package recordpipelinebench\n// change\n"), 0o644); err != nil {
+		t.Fatalf("rewrite pair file: %v", err)
+	}
+	second, err := runGoBenchCached(cache, runner, "go", pairsDir, "record_pipeline", "2s", 3, "1")
+	if err != nil {
+		t.Fatalf("second cached run after change: %v", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("runner calls = %d, want 2 after input change", calls)
+	}
+	if len(second) != 1 || len(first) != 1 || second[0].GoNs == first[0].GoNs {
+		t.Fatalf("invalidated rows = %+v, first = %+v", second, first)
 	}
 }
 

--- a/cmd/osty/test_native.go
+++ b/cmd/osty/test_native.go
@@ -631,12 +631,6 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 	if sourcePath == "" {
 		sourcePath = filepath.Join(pkg.Dir, "__osty_test__.osty")
 	}
-	file, src, err := parseGenEmitFile(pkg)
-	if err != nil {
-		return nativeTestBundleAssets{}, err
-	}
-	res := resolveFile(file)
-	chk := check.File(file, res, checkOptsForSource(src))
 	binName := sanitizeNativeTestName(filepath.Base(sourcePath))
 	if binName == "osty_test" {
 		binName = "osty_test_bundle_probe"
@@ -658,11 +652,10 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 			RuntimeObjectPath: runtimeObject,
 		}, nil
 	}
-	entry, err := backend.PrepareEntry("main", sourcePath, file, res, chk)
+	entry, err := prepareNativeTestBackendEntry(sourcePath, pkg)
 	if err != nil {
 		return nativeTestBundleAssets{}, err
 	}
-	entry.Source = src
 	req := backend.Request{
 		Layout: backend.Layout{
 			Root:    layoutRoot,
@@ -683,6 +676,36 @@ func compileNativeTestBundle(ctx context.Context, b backend.Backend, tmpRoot str
 		ObjectPath:        result.Artifacts.Object,
 		RuntimeObjectPath: runtimeObject,
 	}, nil
+}
+
+func prepareNativeTestBackendEntry(sourcePath string, pkg *resolve.Package) (backend.Entry, error) {
+	if pkg == nil {
+		return backend.Entry{}, fmt.Errorf("missing package for native test bundle")
+	}
+	var entryFile *resolve.PackageFile
+	for _, pf := range pkg.Files {
+		if pf != nil && pf.Path == sourcePath {
+			entryFile = pf
+			break
+		}
+	}
+	if countLowerableFiles(pkg) > 0 {
+		res := resolve.ResolvePackage(pkg, resolve.NewPrelude())
+		chk := check.Package(pkg, res, checkOpts())
+		return backend.PreparePackage("main", sourcePath, pkg, entryFile, chk)
+	}
+	file, src, err := parseGenEmitFile(pkg)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	res := resolveFile(file)
+	chk := check.File(file, res, checkOptsForSource(src))
+	entry, err := backend.PrepareEntry("main", sourcePath, file, res, chk)
+	if err != nil {
+		return backend.Entry{}, err
+	}
+	entry.Source = src
+	return entry, nil
 }
 
 func linkNativeTestBinary(ctx context.Context, assets nativeTestBundleAssets, tmpRoot string, tc nativeTestCase) (string, error) {

--- a/cmd/osty/test_native_test.go
+++ b/cmd/osty/test_native_test.go
@@ -45,6 +45,54 @@ fn testAdd() {
 	}
 }
 
+func TestRunTestMainBenchSupportsMultiFilePackageLowering(t *testing.T) {
+	requireClangForNativeTest(t)
+
+	dir := t.TempDir()
+	writeNativeTestFile(t, dir, "lib.osty", `pub fn accumulate(rows: List<String>) -> Int {
+    let mut totals: Map<String, Int> = {:}
+    for row in rows {
+        let next = if totals.containsKey(row) {
+            totals.getOr(row, 0) + 1
+        } else {
+            1
+        }
+        totals.insert(row, next)
+    }
+
+    let keys = totals.keys().sorted()
+    let mut checksum = 0
+    for key in keys {
+        checksum = checksum + totals.getOr(key, 0) + key.len()
+    }
+    checksum
+}
+`)
+	writeNativeTestFile(t, dir, "lib_test.osty", `use std.testing
+
+fn benchAccumulate() {
+    let rows = ["compiler", "runtime", "compiler", "lsp"]
+    testing.benchmark(5, || {
+        let _ = accumulate(rows)
+        Ok(())
+    })
+}
+`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runTestMain([]string{"--bench", "--serial", dir}, cliFlags{}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTestMain() bench exit = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "ok\tbenchAccumulate") || !strings.Contains(got, "ok\t1 benchmarks passed") {
+		t.Fatalf("stdout = %q, want passing benchmark summary", got)
+	}
+	if got := stderr.String(); strings.TrimSpace(got) != "" {
+		t.Fatalf("stderr = %q, want empty stderr", got)
+	}
+}
+
 func TestCompileNativeTestBundleUsesManagedNativeLLVMGenWhenCovered(t *testing.T) {
 	dir := t.TempDir()
 	path := writeNativeTestFile(t, dir, "lib_test.osty", `fn testAdd() {}

--- a/internal/backend/llvm_runtime_sched_test.go
+++ b/internal/backend/llvm_runtime_sched_test.go
@@ -2265,3 +2265,100 @@ int main(void) {
 		t.Fatalf("STW total regressed beyond 1s: start=%d finish=%d", startNs, finishNs)
 	}
 }
+
+func TestBundledRuntimeMapLockElidesUntilConcurrencyAndProtectsAfterSpawn(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_map_lock_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_map_lock_harness")
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+	if err := os.WriteFile(harnessPath, []byte(`#include <stdint.h>
+#include <stdio.h>
+
+void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, void *value_trace);
+void osty_rt_map_insert_i64(void *raw_map, int64_t key, const void *value);
+void osty_rt_map_get_or_abort_i64(void *raw_map, int64_t key, void *out_value);
+void osty_rt_map_lock(void *raw_map);
+void osty_rt_map_unlock(void *raw_map);
+
+void *osty_rt_task_spawn(void *body_env);
+int64_t osty_rt_task_handle_join(void *handle);
+void osty_rt_thread_yield(void);
+
+enum {
+    OSTY_RT_ABI_I64 = 1,
+    N_WORKERS = 4,
+    N_ITERS = 4000,
+};
+
+typedef struct map_inc_env {
+    void *fn;
+    void *map;
+    int64_t iters;
+} map_inc_env;
+
+static int64_t body_increment_shared_map(void *env) {
+    map_inc_env *e = (map_inc_env *)env;
+    for (int64_t i = 0; i < e->iters; i++) {
+        int64_t value = 0;
+        osty_rt_map_lock(e->map);
+        osty_rt_map_get_or_abort_i64(e->map, 1, &value);
+        value += 1;
+        osty_rt_map_insert_i64(e->map, 1, &value);
+        osty_rt_map_unlock(e->map);
+        if ((i & 63) == 0) {
+            osty_rt_thread_yield();
+        }
+    }
+    return 0;
+}
+
+int main(void) {
+    void *map = osty_rt_map_new(OSTY_RT_ABI_I64, OSTY_RT_ABI_I64,
+                                (int64_t)sizeof(int64_t), NULL);
+    int64_t zero = 0;
+    int64_t total = 0;
+    void *handles[N_WORKERS];
+    map_inc_env envs[N_WORKERS];
+    map_inc_env main_env = { (void *)body_increment_shared_map, map, N_ITERS };
+
+    /* Single-threaded fast path: lock/unlock should be a safe no-op
+     * before concurrency has ever been activated. */
+    osty_rt_map_lock(map);
+    osty_rt_map_insert_i64(map, 1, &zero);
+    osty_rt_map_unlock(map);
+
+    for (int i = 0; i < N_WORKERS; i++) {
+        envs[i].fn = (void *)body_increment_shared_map;
+        envs[i].map = map;
+        envs[i].iters = N_ITERS;
+        handles[i] = osty_rt_task_spawn((void *)&envs[i]);
+    }
+    (void)body_increment_shared_map((void *)&main_env);
+    for (int i = 0; i < N_WORKERS; i++) {
+        (void)osty_rt_task_handle_join(handles[i]);
+    }
+
+    osty_rt_map_get_or_abort_i64(map, 1, &total);
+    printf("%lld\n", (long long)total);
+    return 0;
+}
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+	cmd := exec.Command("clang", "-O2", "-std=c11", "-pthread", runtimePath, harnessPath, "-o", binaryPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, out)
+	}
+	out, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, out)
+	}
+	if got, want := string(out), "20000\n"; got != want {
+		t.Fatalf("runtime map-lock harness stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -406,12 +406,12 @@ typedef struct osty_rt_map {
     int64_t index_len;
     int64_t *index_slots;
     int64_t index_inline[OSTY_RT_MAP_INLINE_INDEX_CAP];
-    // Per-map recursive mutex. Guarantees that all public map ops are
-    // mutually exclusive on a single instance so concurrent mutation
-    // can't realloc the slot arrays mid-read, drop the len mid-walk,
-    // or interleave an insert's memmove. Recursive so that `update`
-    // callbacks that touch the same map from within the lock don't
-    // self-deadlock.
+    // Per-map recursive mutex. Public ops elide it while the runtime
+    // is still single-threaded, then enable it permanently on first
+    // task spawn so concurrent mutation can't realloc the slot arrays
+    // mid-read, drop the len mid-walk, or interleave an insert's
+    // memmove. Recursive so that `update` callbacks that touch the
+    // same map from within the lock don't self-deadlock.
     osty_rt_rmu_t mu;
     int mu_init;
 } osty_rt_map;
@@ -947,6 +947,20 @@ static uint64_t osty_gc_allocate_stable_id(void) {
 static osty_rt_once_t osty_gc_lock_once = OSTY_RT_ONCE_INIT;
 static osty_rt_rmu_t osty_gc_lock;
 static int64_t osty_concurrent_workers = 0;
+static int osty_runtime_has_concurrency = 0;
+
+static inline int64_t osty_rt_concurrent_workers_load(void) {
+    return __atomic_load_n(&osty_concurrent_workers, __ATOMIC_ACQUIRE);
+}
+
+static inline bool osty_rt_runtime_has_concurrency(void) {
+    return __atomic_load_n(&osty_runtime_has_concurrency,
+                           __ATOMIC_ACQUIRE) != 0;
+}
+
+static inline void osty_rt_enable_concurrency_runtime(void) {
+    __atomic_store_n(&osty_runtime_has_concurrency, 1, __ATOMIC_RELEASE);
+}
 
 static void osty_gc_lock_init(void) {
     if (osty_rt_rmu_init(&osty_gc_lock) != 0) {
@@ -965,17 +979,17 @@ static void osty_gc_release(void) {
 
 static void osty_sched_workers_inc(void) {
     osty_gc_acquire();
-    osty_concurrent_workers += 1;
+    (void)__atomic_add_fetch(&osty_concurrent_workers, 1, __ATOMIC_ACQ_REL);
     osty_gc_release();
 }
 
 static void osty_sched_workers_dec(void) {
     osty_gc_acquire();
-    if (osty_concurrent_workers <= 0) {
+    if (osty_rt_concurrent_workers_load() <= 0) {
         osty_gc_release();
         osty_rt_abort("scheduler: worker counter underflow");
     }
-    osty_concurrent_workers -= 1;
+    (void)__atomic_sub_fetch(&osty_concurrent_workers, 1, __ATOMIC_ACQ_REL);
     osty_gc_release();
 }
 
@@ -3744,7 +3758,7 @@ void osty_gc_collect_incremental_start_with_stack_roots(void *const *root_slots,
         osty_gc_release();
         osty_rt_abort("incremental start called while collection already in progress");
     }
-    if (osty_concurrent_workers > 0) {
+    if (osty_rt_concurrent_workers_load() > 0) {
         osty_gc_release();
         return;
     }
@@ -5694,12 +5708,14 @@ void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, 
 // a user callback into the same map (e.g. counts.len()) re-acquire
 // instead of self-deadlocking.
 void osty_rt_map_lock(void *raw_map) {
+    if (!osty_rt_runtime_has_concurrency()) return;
     osty_rt_map *map = osty_rt_map_cast(raw_map);
     if (map == NULL || !map->mu_init) return;
     osty_rt_rmu_lock(&map->mu);
 }
 
 void osty_rt_map_unlock(void *raw_map) {
+    if (!osty_rt_runtime_has_concurrency()) return;
     osty_rt_map *map = osty_rt_map_cast(raw_map);
     if (map == NULL || !map->mu_init) return;
     osty_rt_rmu_unlock(&map->mu);
@@ -7611,7 +7627,7 @@ void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t
      * threads still reference. Defer until workers drain; a concurrent
      * collector is Phase 3. */
     osty_gc_acquire();
-    if (osty_concurrent_workers > 0) {
+    if (osty_rt_concurrent_workers_load() > 0) {
         osty_gc_release();
         return;
     }
@@ -7621,7 +7637,7 @@ void osty_gc_safepoint_v1(int64_t safepoint_id, void *const *root_slots, int64_t
 
 void osty_gc_debug_collect(void) {
     osty_gc_acquire();
-    if (osty_concurrent_workers > 0) {
+    if (osty_rt_concurrent_workers_load() > 0) {
         /* Same cross-thread root safety gate as safepoint_v1. */
         osty_gc_release();
         return;
@@ -7637,7 +7653,7 @@ void osty_gc_debug_collect(void) {
  * the tier explicitly regardless of pressure state. */
 void osty_gc_debug_collect_minor(void) {
     osty_gc_acquire();
-    if (osty_concurrent_workers > 0) {
+    if (osty_rt_concurrent_workers_load() > 0) {
         osty_gc_release();
         return;
     }
@@ -7647,7 +7663,7 @@ void osty_gc_debug_collect_minor(void) {
 
 void osty_gc_debug_collect_major(void) {
     osty_gc_acquire();
-    if (osty_concurrent_workers > 0) {
+    if (osty_rt_concurrent_workers_load() > 0) {
         osty_gc_release();
         return;
     }
@@ -9737,6 +9753,7 @@ static void *osty_rt_task_spawn_internal(void *group, void *body_env) {
     if (body_env == NULL) {
         osty_rt_abort("task_spawn: null body env");
     }
+    osty_rt_enable_concurrency_runtime();
     osty_sched_pool_lazy_init();
 
     osty_rt_task_handle_impl *h = osty_sched_alloc_handle();

--- a/internal/ir/monomorph.go
+++ b/internal/ir/monomorph.go
@@ -845,12 +845,12 @@ var builtinNonGenericMethods = map[string]map[string]bool{
 		"len":     true,
 		"isEmpty": true,
 		"get":     true,
-		"push":   true,
-		"pop":    true,
-		"insert": true,
-		"sorted": true,
-		"toSet":  true,
-		"clear":  true,
+		"push":    true,
+		"pop":     true,
+		"insert":  true,
+		"sorted":  true,
+		"toSet":   true,
+		"clear":   true,
 	},
 	"Map": {
 		"len":         true,
@@ -893,22 +893,22 @@ var builtinNonGenericMethods = map[string]map[string]bool{
 		"isNone": true,
 	},
 	"Result": {
-		"isOk":       true,
-		"isErr":      true,
-		"contains":   true,
+		"isOk":        true,
+		"isErr":       true,
+		"contains":    true,
 		"containsErr": true,
-		"unwrap":     true,
-		"expect":     true,
-		"unwrapErr":  true,
-		"expectErr":  true,
-		"unwrapOr":   true,
-		"ok":         true,
-		"err":        true,
-		"and":        true,
-		"or":         true,
-		"inspect":    true,
-		"inspectErr": true,
-		"toString":   true,
+		"unwrap":      true,
+		"expect":      true,
+		"unwrapErr":   true,
+		"expectErr":   true,
+		"unwrapOr":    true,
+		"ok":          true,
+		"err":         true,
+		"and":         true,
+		"or":          true,
+		"inspect":     true,
+		"inspectErr":  true,
+		"toString":    true,
 	},
 }
 
@@ -1764,6 +1764,16 @@ func (s *monoState) scanExpr(e Expr) {
 		// Rewrite generic call to mangled specialization.
 		if len(e.TypeArgs) > 0 {
 			s.rewriteGenericCall(e)
+			// After monomorphization the backend contract is fully
+			// concrete: any remaining CallExpr.TypeArgs are just
+			// checker-side instantiation metadata on a call shape the
+			// monomorphizer does not specialize itself (for example a
+			// module-qualified stdlib helper like `testing.assertEq`).
+			// Keeping them around makes the IR->AST bridge wrap the
+			// callee in a TurbofishExpr, which downstream LLVM testing /
+			// stdlib dispatch does not expect. Retain the concrete
+			// result/arg types, but strip the stale type-arg wrapper.
+			e.TypeArgs = nil
 		}
 		s.scanExpr(e.Callee)
 		for i := range e.Args {

--- a/internal/ir/monomorph_test.go
+++ b/internal/ir/monomorph_test.go
@@ -132,6 +132,50 @@ func TestMonomorphizeSingleFreeFnSpecialization(t *testing.T) {
 	}
 }
 
+func TestMonomorphizeQualifiedCallClearsResidualTypeArgs(t *testing.T) {
+	// Package-qualified generic helpers like `testing.assertEq` do not
+	// participate in user-code monomorphization. Their concrete
+	// argument/result types already live on the call node, so any
+	// leftover TypeArgs are just stale checker metadata that would make
+	// the IR->AST bridge emit a TurbofishExpr wrapper.
+	call := &CallExpr{
+		Callee: &FieldExpr{
+			X:    &Ident{Name: "testing"},
+			Name: "assertEq",
+			T: &FnType{
+				Params: []Type{TInt, TInt},
+				Return: TUnit,
+			},
+		},
+		TypeArgs: []Type{TInt},
+		Args: []Arg{
+			{Value: intLit("1")},
+			{Value: intLit("1")},
+		},
+		T: TUnit,
+	}
+	in := &Module{
+		Package: "main",
+		Decls: []Decl{&FnDecl{
+			Name:   "main",
+			Return: TUnit,
+			Body:   &Block{Stmts: []Stmt{&ExprStmt{X: call}}},
+		}},
+	}
+
+	out, errs := Monomorphize(in)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	callCp := out.Decls[0].(*FnDecl).Body.Stmts[0].(*ExprStmt).X.(*CallExpr)
+	if len(callCp.TypeArgs) != 0 {
+		t.Fatalf("qualified call should shed stale TypeArgs after monomorph, got %+v", callCp.TypeArgs)
+	}
+	if _, ok := callCp.Callee.(*FieldExpr); !ok {
+		t.Fatalf("qualified callee shape changed: got %T, want *FieldExpr", callCp.Callee)
+	}
+}
+
 // ==== Dedup ====
 
 func TestMonomorphizeDedupesSameTypeArgs(t *testing.T) {

--- a/internal/llvmgen/closure_lift.go
+++ b/internal/llvmgen/closure_lift.go
@@ -125,10 +125,18 @@ func liftClosuresFromModule(mod *ostyir.Module) []ast.Decl {
 	if mod == nil {
 		return nil
 	}
+	keepLiteral := testingInlineClosuresFromModule(mod)
 	var lifted []ast.Decl
 	ostyir.Walk(ostyir.VisitorFunc(func(n ostyir.Node) bool {
 		c, ok := n.(*ostyir.Closure)
 		if !ok || c == nil {
+			return true
+		}
+		if _, ok := keepLiteral[c]; ok {
+			// `testing.context` / `testing.benchmark` inline the closure
+			// body directly, so those sites must keep a literal
+			// ClosureExpr through the IR->AST bridge instead of being
+			// rewritten to a lifted function value.
 			return true
 		}
 		captures, ok := captureSlotsFromIR(c.Captures)
@@ -160,6 +168,66 @@ func liftClosuresFromModule(mod *ostyir.Module) []ast.Decl {
 		return true
 	}), mod)
 	return lifted
+}
+
+func testingInlineClosuresFromModule(mod *ostyir.Module) map[*ostyir.Closure]struct{} {
+	out := map[*ostyir.Closure]struct{}{}
+	if mod == nil {
+		return out
+	}
+	aliases := testingAliasesFromModule(mod)
+	if len(aliases) == 0 {
+		return out
+	}
+	ostyir.Walk(ostyir.VisitorFunc(func(n ostyir.Node) bool {
+		call, ok := n.(*ostyir.CallExpr)
+		if !ok || call == nil {
+			return true
+		}
+		if len(call.Args) < 2 || call.Args[1].Name != "" || call.Args[1].Value == nil {
+			return true
+		}
+		field, ok := call.Callee.(*ostyir.FieldExpr)
+		if !ok || field == nil || field.Optional {
+			return true
+		}
+		alias, ok := field.X.(*ostyir.Ident)
+		if !ok || alias == nil || !aliases[alias.Name] {
+			return true
+		}
+		switch field.Name {
+		case "context", "benchmark":
+			if closure, ok := call.Args[1].Value.(*ostyir.Closure); ok && closure != nil {
+				out[closure] = struct{}{}
+			}
+		}
+		return true
+	}), mod)
+	return out
+}
+
+func testingAliasesFromModule(mod *ostyir.Module) map[string]bool {
+	out := map[string]bool{}
+	if mod == nil {
+		return out
+	}
+	for _, decl := range mod.Decls {
+		use, ok := decl.(*ostyir.UseDecl)
+		if !ok || use == nil || use.IsFFI() {
+			continue
+		}
+		if use.RawPath != "std.testing" {
+			continue
+		}
+		alias := use.Alias
+		if alias == "" && len(use.Path) > 0 {
+			alias = use.Path[len(use.Path)-1]
+		}
+		if alias != "" {
+			out[alias] = true
+		}
+	}
+	return out
 }
 
 // captureSlotsFromIR projects an IR closure's Captures into the

--- a/internal/llvmgen/ir_module.go
+++ b/internal/llvmgen/ir_module.go
@@ -1821,7 +1821,7 @@ func legacyClosureFromIR(expr *ostyir.Closure) (ast.Expr, error) {
 	out := &ast.ClosureExpr{
 		PosV:       start,
 		EndV:       end,
-		ReturnType: legacyTypeFromIR(expr.Return),
+		ReturnType: legacyClosureReturnType(expr.Return),
 	}
 	for _, param := range expr.Params {
 		legacyParam, err := legacyParamFromIR(param)
@@ -1836,6 +1836,13 @@ func legacyClosureFromIR(expr *ostyir.Closure) (ast.Expr, error) {
 	}
 	out.Body = body
 	return out, nil
+}
+
+func legacyClosureReturnType(t ostyir.Type) ast.Type {
+	if prim, ok := t.(*ostyir.PrimType); ok && prim != nil && prim.Kind == ostyir.PrimUnit {
+		return nil
+	}
+	return legacyTypeFromIR(t)
 }
 
 func legacyVariantLitFromIR(expr *ostyir.VariantLit) (ast.Expr, error) {

--- a/internal/llvmgen/ir_module_test.go
+++ b/internal/llvmgen/ir_module_test.go
@@ -261,6 +261,7 @@ fn main() {
 //   - a `@osty.vtable.<impl>__<iface>` constant global whose function
 //     pointers reference the concrete methods in interface-declaration
 //     order.
+//
 // Boxing and method-dispatch paths stay out of scope for this phase —
 // the smoke only verifies that the vtable *exists*.
 func TestGenerateModuleInterfaceVtableEmitted(t *testing.T) {
@@ -550,10 +551,10 @@ func TestRenderInterfaceShimVoidReturn(t *testing.T) {
 	}
 	m := interfaceMethodSig{name: "clear", slot: 0}
 	sig := &fnSig{
-		name:    "clear",
-		irName:  "Bin__clear",
-		ret:     "void",
-		params:  []paramInfo{{name: "self", typ: "%Bin"}},
+		name:   "clear",
+		irName: "Bin__clear",
+		ret:    "void",
+		params: []paramInfo{{name: "self", typ: "%Bin"}},
 	}
 	sym, def := renderInterfaceShim(iface, impl, m, sig, "%Bin")
 	if sym == "" || def == "" {
@@ -739,6 +740,55 @@ fn main() {
 		"%Result.i64.i64 = type { i64, i64, i64 }",
 		"extractvalue %Result.i64.i64",
 		"call %Result.i64.i64 @div(i64 10, i64 2)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateModuleStdTestingContextClosureCompat(t *testing.T) {
+	src := `use std.testing as t
+
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+
+fn main() {
+    t.context("simple", || {
+        t.assertEq(add(1, 2), 3)
+    })
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_testing_context_ir.osty")
+	for _, want := range []string{
+		"call i64 @add(i64 1, i64 2)",
+		"define i32 @main()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated IR missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestGenerateModuleStdTestingBenchmarkClosureCompat(t *testing.T) {
+	src := `use std.testing
+
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+
+fn main() {
+    testing.benchmark(5, || {
+        let _ = add(1, 2)
+        Ok(())
+    })
+}
+`
+	got := runMonoLowerPipeline(t, src, "/tmp/phase2_testing_benchmark_ir.osty")
+	for _, want := range []string{
+		"call i64 @add(i64 1, i64 2)",
+		"@osty_rt_bench_target_ns",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated IR missing %q:\n%s", want, got)

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -5143,6 +5143,15 @@ func (g *mirGen) aggregateElementTypes(aggT mir.Type, rv *mir.AggregateRV) ([]mi
 	case mir.AggTuple:
 		tt, ok := aggT.(*ir.TupleType)
 		if !ok {
+			if isUnitType(aggT) {
+				// MIR still models some unit-producing paths (notably
+				// bench/test Result<(), E> helpers) as AggTuple over the
+				// unit type. That's a real MIR coverage gap, not an
+				// internal correctness failure; surface it as
+				// ErrUnsupported so the LLVM backend can fall back to the
+				// HIR path, which already handles the shape.
+				return nil, unsupportedf("mir-mvp", "tuple aggregate type %s", mirTypeString(aggT))
+			}
 			return nil, fmt.Errorf("mir-mvp: tuple aggregate type %s", mirTypeString(aggT))
 		}
 		return append([]mir.Type(nil), tt.Elems...), nil


### PR DESCRIPTION
## What changed
- fixed the native test bundle path so multi-file benchmark packages lower through the managed native LLVM pipeline instead of failing on covered workloads
- added runtime and lowering compatibility fixes around monomorphization, closure lifting, IR bridging, and MIR fallback so long native benchmark packages execute end-to-end
- cached Go baseline benchmark runs in `osty-vs-go` autoresearch to avoid re-running unchanged Go workloads every iteration
- sped up single-threaded Osty runtime `Map` hot paths by eliding per-map locking until concurrency is actually activated, while preserving locking after `task_spawn`
- added runtime harness coverage for the map lock fast path and post-spawn safety

## Why
- the root issue was that native benchmark coverage for multi-file packages was incomplete, which blocked the real long workloads from running in native mode
- once those workloads ran, the next obvious bottleneck was runtime `Map` overhead in single-threaded benchmark-heavy programs such as `word_freq` and `record_pipeline`
- autoresearch caching was kept alongside the runtime work because it reduces iteration latency while comparing Osty against Go

## Impact
- multi-file native benchmark packages now compile and run under `./.bin/osty test --bench`
- long workloads such as `record_pipeline` and `simd_stats` are unblocked in native mode
- measured runtime improvement with the rebuilt binary at `--benchtime 200ms`:
  - `word_freq`: `26748ns -> 24017ns` avg (~10.2% faster)
  - `record_pipeline`: `34330ns -> 30919ns` avg (~9.9% faster)

## Validation
- `go test -count=1 -vet=off ./internal/ir -run 'TestMonomorphizeQualifiedCallClearsResidualTypeArgs|TestMonomorphizeSingleFreeFnSpecialization'`
- `go test -count=1 -vet=off ./internal/llvmgen -run 'TestGenerateModuleStdTesting(ContextClosureCompat|BenchmarkClosureCompat|ExpectOkCompat)|TestClosureLiftLowersThroughIRPipeline'`
- `go test -count=1 -vet=off ./cmd/osty -run 'TestRunTestMainPassesNativeLLVMTest|TestRunTestMainBenchSupportsMultiFilePackageLowering|TestCompileNativeTestBundleUsesManagedNativeLLVMGenWhenCovered'`
- `go test -count=1 -vet=off ./cmd/osty-vs-go`
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntime(Scheduler$|SchedulerChannels$|MapLockElidesUntilConcurrencyAndProtectsAfterSpawn$|MapRemapsCompactionPhaseD$|MapCompositeValueRemapsCompactionPhaseD$|DebugCollectRespectsRoots$)'`
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntimeSchedulerConcurrentIncrementalPerPhasePause$'`
- `go build -o .bin/osty ./cmd/osty`
- `./.bin/osty test --bench --serial --benchtime 50ms benchmarks/osty-vs-go/record_pipeline/osty`
- `./.bin/osty test --bench --serial --benchtime 50ms benchmarks/osty-vs-go/simd_stats/osty`
- `./.bin/osty test --bench --serial --benchtime 200ms benchmarks/osty-vs-go/word_freq/osty`
- `./.bin/osty test --bench --serial --benchtime 200ms benchmarks/osty-vs-go/record_pipeline/osty`