### PR TITLE
feat(selfhost): begin HIR→MIR lowerer (Stage 4a — shell)

### DIFF
--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -1,0 +1,915 @@
+// mir_lower.osty — self-hosted HIR → MIR lowering (Stage 4a).
+//
+// This is the Osty port of `internal/mir/lower.go`. It consumes a
+// monomorphic `HirModule` (see `hir.osty`) and produces a `MirModule`
+// (see `mir.osty`). Callers are expected to have already run a future
+// `toolchain/monomorph.osty` equivalent — the lowerer rejects generic
+// declarations and records them as issues.
+//
+// Scope splits so the Osty port can land incrementally (matching how
+// the Go side grew):
+//
+//   Stage 4a (this file): entry + signatures + layouts + use
+//                         passthrough + function shell (empty body)
+//                         + global shell (initialiser stub).
+//                         No stmt / expr lowering yet.
+//   Stage 4b: body lowerer state + lowerStmt for simple kinds
+//             (Block / Let / ExprStmt / Return / Break / Continue).
+//   Stage 4c: control flow (If / For / Match / Defer).
+//   Stage 4d: expression lowering into places / operands / rvalues.
+//   Stage 4e: concurrency + stdlib intrinsics + closures.
+//   Stage 4f: projection walk + variant/struct layout lookup.
+//
+// Until 4b lands, every emitted function carries an empty body — the
+// returned MIR is structurally valid (it has a return local + entry
+// block + a placeholder terminator) but cannot yet be fed through
+// `mir.Validate` / the MIR emitter. Callers that need an end-to-end
+// probe should keep using Go's `mir.Lower` via the Go-side bridge;
+// this file is the Osty surface that future stages extend.
+//
+// Type representation: MIR operates on name-level type strings
+// (`MirLocal.typ: String` etc.), so this lowerer emits MIR-facing
+// types via `hirTypeString(t)` rather than threading HirType values
+// through the MIR API. This matches how `internal/mir/lower.go` uses
+// `t.String()` at every MIR construction site.
+
+use std.strings as strings
+
+// ====================================================================
+// Lookup tables
+// ====================================================================
+
+/// MirLowerFnSignature carries the collected-pass-1 view of a fn or
+/// method. `owner` is empty for free fns; for methods it is the owning
+/// struct / enum name. `symbol` is the mangled MIR symbol name (pass
+/// through `mangleMethodSymbol` for methods, bare `name` for free fns).
+///
+/// Stage 4d will use `params` + `retType` to order call arguments
+/// (keyword → positional), resolve default values, and check arities.
+pub struct MirLowerFnSignature {
+    pub name: String,
+    pub owner: String,
+    pub symbol: String,
+    pub params: List<HirParam>,
+    pub retType: HirType,
+    pub isMethod: Bool,
+    pub span: HirSpan,
+}
+
+pub fn mirLowerFnSignature(
+    name: String,
+    params: List<HirParam>,
+    retType: HirType,
+    span: HirSpan,
+) -> MirLowerFnSignature {
+    MirLowerFnSignature {
+        name,
+        owner: "",
+        symbol: name,
+        params,
+        retType,
+        isMethod: false,
+        span,
+    }
+}
+
+pub fn mirLowerMethodSignature(
+    owner: String,
+    name: String,
+    params: List<HirParam>,
+    retType: HirType,
+    span: HirSpan,
+) -> MirLowerFnSignature {
+    MirLowerFnSignature {
+        name,
+        owner,
+        symbol: mangleMethodSymbol(owner, name),
+        params,
+        retType,
+        isMethod: true,
+        span,
+    }
+}
+
+/// mangleMethodSymbol is the MIR symbol mangling for methods. Must
+/// stay in sync with Go's `mangleMethodSymbol` (`Type__method`); the
+/// LLVM emitter and this lowerer both depend on the exact string
+/// shape.
+pub fn mangleMethodSymbol(owner: String, method: String) -> String {
+    owner + "__" + method
+}
+
+/// methodKey is the lookup key for the method signature table.
+/// Format: `owner::method` (matches Go's `methodKey`).
+pub fn methodKey(owner: String, method: String) -> String {
+    owner + "::" + method
+}
+
+/// mirLowerSignatureDropReceiver returns a copy of `sig` without its
+/// leading receiver parameter. Used at call sites where positional
+/// args never include `self`.
+pub fn mirLowerSignatureDropReceiver(sig: MirLowerFnSignature) -> MirLowerFnSignature {
+    if sig.params.len() == 0 {
+        return sig
+    }
+    let mut tail: List<HirParam> = []
+    let mut i = 0
+    for p in sig.params {
+        if i > 0 {
+            tail.push(p)
+        }
+        i = i + 1
+    }
+    MirLowerFnSignature {
+        name: sig.name,
+        owner: sig.owner,
+        symbol: sig.symbol,
+        params: tail,
+        retType: sig.retType,
+        isMethod: sig.isMethod,
+        span: sig.span,
+    }
+}
+
+// ====================================================================
+// Lowerer state
+// ====================================================================
+
+/// MirLowerer is the per-module lowering context. Pass 1 fills the
+/// lookup tables (`fnSigs` / `methodSigs` / `structs` / `enums` /
+/// `globals` / `useAliases`); pass 2 iterates `src.fns` / `src.structs`
+/// / `src.enums` / `src.lets` again and emits MIR into `out`.
+///
+/// `issues` is an append-only slush pile — non-fatal lowering problems
+/// (e.g. "generic decl reached MIR") get pushed here and the final
+/// MirModule also carries a copy so callers can decide whether to
+/// retry, fall back to the Go pipeline, or report the issue.
+pub struct MirLowerer {
+    pub src: HirModule,
+    pub out: MirModule,
+
+    // Pass-1 lookup tables. Keys are source names (no mangling).
+    pub fnSigs: List<MirLowerFnSignature>,
+    pub fnSigNames: List<String>,
+
+    pub methodSigs: List<MirLowerFnSignature>,
+    pub methodSigKeys: List<String>,
+
+    pub structs: List<HirStructDecl>,
+    pub structNames: List<String>,
+
+    pub enums: List<HirEnumDecl>,
+    pub enumNames: List<String>,
+
+    pub globals: List<HirLetDecl>,
+    pub globalNames: List<String>,
+
+    pub useAliases: List<HirUseDecl>,
+    pub useAliasKeys: List<String>,
+
+    pub issues: List<String>,
+
+    // Monotonically-growing counter used to mint fresh symbols for
+    // synthetic closures (Stage 4e). Kept on the lowerer so multiple
+    // closures in the same compilation unit do not collide.
+    pub closureSeq: Int,
+}
+
+pub fn mirLowerer(src: HirModule) -> MirLowerer {
+    MirLowerer {
+        src,
+        out: mirModule(src.packageName),
+        fnSigs: [],
+        fnSigNames: [],
+        methodSigs: [],
+        methodSigKeys: [],
+        structs: [],
+        structNames: [],
+        enums: [],
+        enumNames: [],
+        globals: [],
+        globalNames: [],
+        useAliases: [],
+        useAliasKeys: [],
+        issues: [],
+        closureSeq: 0,
+    }
+}
+
+/// mirLowerNoteIssue records a non-fatal lowering issue. Issues are
+/// surfaced to callers through `MirModule.Issues` after `run()`.
+pub fn mirLowerNoteIssue(l: MirLowerer, msg: String) {
+    l.issues.push(msg)
+}
+
+// ---- Lookup helpers -------------------------------------------------
+
+/// mirLowerSignatureForFn returns the signature index for the named
+/// free fn or -1 when unknown.
+pub fn mirLowerSignatureForFn(l: MirLowerer, name: String) -> Int {
+    let mut i = 0
+    for n in l.fnSigNames {
+        if n == name {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+/// mirLowerSignatureForMethod returns the signature index for the
+/// named method on `typeName`, or -1 when unknown.
+pub fn mirLowerSignatureForMethod(l: MirLowerer, typeName: String, method: String) -> Int {
+    let key = methodKey(typeName, method)
+    let mut i = 0
+    for k in l.methodSigKeys {
+        if k == key {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+/// mirLowerLookupStruct returns the struct decl index or -1.
+pub fn mirLowerLookupStruct(l: MirLowerer, name: String) -> Int {
+    let mut i = 0
+    for n in l.structNames {
+        if n == name {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+/// mirLowerLookupEnum returns the enum decl index or -1.
+pub fn mirLowerLookupEnum(l: MirLowerer, name: String) -> Int {
+    let mut i = 0
+    for n in l.enumNames {
+        if n == name {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+/// mirLowerLookupGlobal returns the global let decl index or -1.
+pub fn mirLowerLookupGlobal(l: MirLowerer, name: String) -> Int {
+    let mut i = 0
+    for n in l.globalNames {
+        if n == name {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+/// mirLowerLookupUseAlias returns the use decl index by alias or -1.
+pub fn mirLowerLookupUseAlias(l: MirLowerer, alias: String) -> Int {
+    let mut i = 0
+    for k in l.useAliasKeys {
+        if k == alias {
+            return i
+        }
+        i = i + 1
+    }
+    -1
+}
+
+// ====================================================================
+// Entry point + high-level pipeline
+// ====================================================================
+
+/// mirLowerModule is the public entry: HIR → MIR. The returned
+/// MirModule is always non-nil (even on heavy input errors); non-fatal
+/// issues surface via `out.issues`. Callers that want structural
+/// validation should follow up with `mirValidateModule` once Stage 4b
+/// fills in function bodies.
+pub fn mirLowerModule(src: HirModule) -> MirModule {
+    let l = mirLowerer(src)
+    mirLowerRun(l)
+    // copy issues onto the output module so downstream consumers
+    // can decide fallback policy without touching the lowerer state.
+    for msg in l.issues {
+        hirModuleAddIssue(l.out, msg)
+    }
+    l.out
+}
+
+/// mirLowerRun drives the two-pass lowering. Split out from
+/// `mirLowerModule` so tests can seed a lowerer with a partial HIR and
+/// probe intermediate state.
+pub fn mirLowerRun(l: MirLowerer) {
+    mirLowerCollectSignatures(l)
+    mirLowerBuildLayouts(l)
+    mirLowerEmitDeclarations(l)
+    mirLowerEmitScript(l)
+}
+
+// ====================================================================
+// Pass 1: collect signatures + lookup tables
+// ====================================================================
+
+/// mirLowerCollectSignatures walks every top-level decl on the HIR
+/// module and seeds the lowerer's lookup tables. Generic decls
+/// (non-empty `generics`) are skipped with an issue so the pipeline
+/// can flag that monomorphization was missed.
+pub fn mirLowerCollectSignatures(l: MirLowerer) {
+    // Free fns
+    for decl in l.src.fns {
+        if decl.generics.len() > 0 {
+            mirLowerNoteIssue(
+                l,
+                "generic free fn \"" + decl.name + "\" reached MIR (monomorphize first)",
+            )
+        } else {
+            let sig = mirLowerFnSignature(decl.name, decl.params, decl.ret, decl.span)
+            l.fnSigs.push(sig)
+            l.fnSigNames.push(decl.name)
+        }
+    }
+
+    // Struct methods
+    for s in l.src.structs {
+        if s.generics.len() > 0 {
+            mirLowerNoteIssue(
+                l,
+                "generic struct \"" + s.name + "\" reached MIR (monomorphize first)",
+            )
+        } else {
+            l.structs.push(s)
+            l.structNames.push(s.name)
+            for m in s.methods {
+                let sig = mirLowerMethodSignature(s.name, m.name, m.params, m.ret, m.span)
+                l.methodSigs.push(sig)
+                l.methodSigKeys.push(methodKey(s.name, m.name))
+            }
+        }
+    }
+
+    // Enum methods
+    for e in l.src.enums {
+        if e.generics.len() > 0 {
+            mirLowerNoteIssue(
+                l,
+                "generic enum \"" + e.name + "\" reached MIR (monomorphize first)",
+            )
+        } else {
+            l.enums.push(e)
+            l.enumNames.push(e.name)
+            for m in e.methods {
+                let sig = mirLowerMethodSignature(e.name, m.name, m.params, m.ret, m.span)
+                l.methodSigs.push(sig)
+                l.methodSigKeys.push(methodKey(e.name, m.name))
+            }
+        }
+    }
+
+    // Globals
+    for g in l.src.lets {
+        l.globals.push(g)
+        l.globalNames.push(g.name)
+    }
+
+    // Uses (alias table + MIR passthrough)
+    for u in l.src.uses {
+        if u.alias != "" {
+            l.useAliases.push(u)
+            l.useAliasKeys.push(u.alias)
+        }
+        mirLowerEmitUse(l, u)
+    }
+}
+
+/// mirLowerEmitUse copies a HIR use decl into the MIR module's use
+/// list. Keeps FFI metadata (goPath / runtimePath / isGoFFI /
+/// isRuntimeFFI) so downstream backends can route FFI calls without
+/// re-reading the HIR.
+pub fn mirLowerEmitUse(l: MirLowerer, u: HirUseDecl) {
+    let mut mu = mirUse(u.rawPath, u.alias, mirSpanFromHir(u.span))
+    mu.isGoFFI = u.isGoFFI
+    mu.isRuntimeFFI = u.isRuntimeFFI
+    mu.goPath = u.goPath
+    mu.runtimePath = u.runtimePath
+    l.out.uses.push(mu)
+}
+
+// ====================================================================
+// Pass 1b: layout tables
+// ====================================================================
+
+/// mirLowerBuildLayouts emits layout entries for every collected
+/// struct and enum. Layouts carry the field / variant / payload
+/// information backends need to compile aggregate loads, variant
+/// projections, and tag-based discrimination without re-reading HIR.
+pub fn mirLowerBuildLayouts(l: MirLowerer) {
+    for s in l.structs {
+        let sl = mirLowerBuildStructLayout(s)
+        l.out.layouts.structs.push(sl)
+    }
+    for e in l.enums {
+        let el = mirLowerBuildEnumLayout(e)
+        l.out.layouts.enums.push(el)
+    }
+}
+
+fn mirLowerBuildStructLayout(s: HirStructDecl) -> MirStructLayout {
+    let mut fields: List<MirFieldLayout> = []
+    let mut i = 0
+    for f in s.fields {
+        fields.push(MirFieldLayout {
+            index: i,
+            name: f.name,
+            typ: hirTypeString(f.typ),
+        })
+        i = i + 1
+    }
+    MirStructLayout {
+        name: s.name,
+        mangled: s.name,
+        fields,
+        size: 0,
+        align: 0,
+    }
+}
+
+fn mirLowerBuildEnumLayout(e: HirEnumDecl) -> MirEnumLayout {
+    let mut variants: List<MirVariantLayout> = []
+    let mut vi = 0
+    for v in e.variants {
+        let mut payload: List<MirFieldLayout> = []
+        let mut fi = 0
+        for pt in v.payload {
+            payload.push(MirFieldLayout {
+                index: fi,
+                name: mirLowerSyntheticFieldName(fi),
+                typ: hirTypeString(pt),
+            })
+            fi = fi + 1
+        }
+        variants.push(MirVariantLayout {
+            index: vi,
+            name: v.name,
+            payload,
+        })
+        vi = vi + 1
+    }
+    MirEnumLayout {
+        name: e.name,
+        mangled: e.name,
+        discriminant: "Int",
+        variants,
+    }
+}
+
+/// mirLowerSyntheticFieldName returns the positional field name the
+/// layout builder uses for enum-variant payloads without named fields.
+/// Mirrors Go's `fmt.Sprintf("_%d", j)` pattern.
+pub fn mirLowerSyntheticFieldName(i: Int) -> String {
+    "_" + mirLowerIntToString(i)
+}
+
+/// mirLowerIntToString converts a non-negative integer to its decimal
+/// representation. Self-host stdlib exposes no `Int.toString` yet, so
+/// the lowerer walks digits manually.
+pub fn mirLowerIntToString(n: Int) -> String {
+    if n == 0 {
+        return "0"
+    }
+    let mut negative = false
+    let mut value = n
+    if value < 0 {
+        negative = true
+        value = 0 - value
+    }
+    let mut digits: List<String> = []
+    for value > 0 {
+        let d = value % 10
+        digits.push(mirLowerDigitChar(d))
+        value = value / 10
+    }
+    let mut parts: List<String> = []
+    if negative {
+        parts.push("-")
+    }
+    let mut j = digits.len() - 1
+    for j >= 0 {
+        parts.push(digits[j])
+        j = j - 1
+    }
+    strings.join(parts, "")
+}
+
+fn mirLowerDigitChar(d: Int) -> String {
+    match d {
+        0 -> "0",
+        1 -> "1",
+        2 -> "2",
+        3 -> "3",
+        4 -> "4",
+        5 -> "5",
+        6 -> "6",
+        7 -> "7",
+        8 -> "8",
+        9 -> "9",
+        _ -> "?",
+    }
+}
+
+// ====================================================================
+// Span bridging
+// ====================================================================
+
+/// mirSpanFromHir lowers a HirSpan into a MIR span. MIR spans are
+/// byte-offset ranges only; HirSpan's line/column info is dropped.
+pub fn mirSpanFromHir(s: HirSpan) -> MirSpan {
+    mirSpan(s.start.offset, s.end.offset)
+}
+
+// ====================================================================
+// Pass 2: emit declarations (function + global shells)
+// ====================================================================
+
+/// mirLowerEmitDeclarations walks every top-level non-generic decl
+/// and hands control to the per-decl emitters. Method emission walks
+/// struct / enum methods.
+pub fn mirLowerEmitDeclarations(l: MirLowerer) {
+    for decl in l.src.fns {
+        if decl.generics.len() == 0 {
+            let emitted = mirLowerFunction(l, decl, "", false)
+            l.out.functions.push(emitted)
+        }
+    }
+    for s in l.src.structs {
+        if s.generics.len() == 0 {
+            for m in s.methods {
+                let emitted = mirLowerFunction(l, m, s.name, true)
+                l.out.functions.push(emitted)
+            }
+        }
+    }
+    for e in l.src.enums {
+        if e.generics.len() == 0 {
+            for m in e.methods {
+                let emitted = mirLowerFunction(l, m, e.name, true)
+                l.out.functions.push(emitted)
+            }
+        }
+    }
+    for g in l.src.lets {
+        let emitted = mirLowerGlobal(l, g)
+        l.out.globals.push(emitted)
+    }
+}
+
+/// mirLowerEmitScript lowers the module's top-level script (if any)
+/// as the body of a synthetic `main()`. Matches Go's `emitScript`
+/// policy — backends conventionally do the same thing.
+pub fn mirLowerEmitScript(l: MirLowerer) {
+    if l.src.script.len() == 0 {
+        return
+    }
+    let span = mirSpanFromHir(l.src.span)
+    let mut main = mirFunction("main", "()", span)
+    // Entry block + return slot are stamped by mirLowerSeedFunction.
+    mirLowerSeedFunction(main, [], hirTUnit(), span)
+    // Stage 4b lands the body loop. For now, terminate the entry
+    // block with Unreachable so the MIR shape is well-formed.
+    mirLowerFinishPlaceholder(main, span)
+    l.out.functions.push(main)
+}
+
+// ====================================================================
+// Pass 2: per-function lowering (shell only for Stage 4a)
+// ====================================================================
+
+/// mirLowerFunction emits a MIR function shell from one HIR FnDecl.
+/// Stage 4a creates the return slot, parameter locals, entry block,
+/// and an `Unreachable` placeholder terminator; Stage 4b replaces the
+/// placeholder with real body lowering.
+///
+/// External stubs (functions with an empty body AND no scripted
+/// content — used for FFI `use go` decls) set `isExternal = true`
+/// and carry zero blocks, matching the MIR validator's shape
+/// requirement.
+pub fn mirLowerFunction(
+    l: MirLowerer,
+    decl: HirFnDecl,
+    owner: String,
+    asMethod: Bool,
+) -> MirFunction {
+    let retT = if hirTypeIsValid(decl.ret) {
+        decl.ret
+    } else {
+        hirTUnit()
+    }
+
+    let mut symbol = decl.name
+    let mut params = decl.params
+    if asMethod {
+        symbol = mangleMethodSymbol(owner, decl.name)
+        // Synthesise a self parameter at position 0 so downstream
+        // paramLocals[0] is well-defined.
+        let selfParam = hirParam("self", hirTypeNamed(owner, []), decl.span)
+        let mut withSelf: List<HirParam> = []
+        withSelf.push(selfParam)
+        for p in decl.params {
+            withSelf.push(p)
+        }
+        params = withSelf
+    }
+
+    let span = mirSpanFromHir(decl.span)
+    let mut out = mirFunction(symbol, hirTypeString(retT), span)
+    mirLowerCopyFnAnnotations(out, decl)
+
+    out.isIntrinsic = decl.isIntrinsic
+    if decl.isIntrinsic {
+        // Intrinsic fns carry a placeholder body; backends supply the
+        // real IR sequence at each call site (see v0.6 §19.5/§19.7).
+        mirLowerSeedFunction(out, params, retT, span)
+        mirLowerFinishPlaceholder(out, span)
+        return out
+    }
+
+    // Emit a shell. Stage 4b replaces the placeholder terminator with
+    // real body lowering. External fns (empty body, no script) keep
+    // zero blocks per MIR validator rules.
+    if mirLowerFunctionIsExternal(decl) {
+        out.isExternal = true
+        return out
+    }
+
+    mirLowerSeedFunction(out, params, retT, span)
+    mirLowerFinishPlaceholder(out, span)
+    out
+}
+
+/// mirLowerFunctionIsExternal reports whether the fn has no body and
+/// therefore should emit as an external stub. FFI-sourced fns arrive
+/// with empty bodies after the collector.
+fn mirLowerFunctionIsExternal(decl: HirFnDecl) -> Bool {
+    decl.body.stmts.len() == 0 && !decl.body.hasResult
+}
+
+/// mirLowerCopyFnAnnotations copies HIR annotation metadata onto the
+/// MIR function. The MIR side currently stores a subset (export
+/// symbol, C ABI) but the rest of v0.6 A5–A13 annotations are
+/// downstream concerns tracked in `LLVM_MIGRATION_PLAN.md`.
+fn mirLowerCopyFnAnnotations(out: MirFunction, decl: HirFnDecl) {
+    out.exported = decl.exported
+    out.exportSymbol = decl.exportSymbol
+    out.cAbi = decl.cAbi
+}
+
+/// mirLowerSeedFunction stamps the return slot + parameter locals +
+/// entry block onto an otherwise bare `MirFunction`. Matches Go's
+/// `newFunction`. Must run before any body lowering.
+pub fn mirLowerSeedFunction(
+    out: MirFunction,
+    params: List<HirParam>,
+    retT: HirType,
+    span: MirSpan,
+) {
+    // _0 is always the return slot.
+    let retLocal = mirFunctionNewLocal(out, "_return", hirTypeString(retT), true, span)
+    out.returnLocal = retLocal
+
+    // Parameters become subsequent locals.
+    let mut idx = 0
+    for p in params {
+        let paramName = if p.name == "" {
+            "arg" + mirLowerIntToString(idx)
+        } else {
+            p.name
+        }
+        let paramTypeText = hirTypeString(p.typ)
+        let paramSpan = mirSpanFromHir(p.span)
+        let id = mirFunctionNewLocal(out, paramName, paramTypeText, true, paramSpan)
+        out.params.push(id)
+        idx = idx + 1
+    }
+
+    // Entry block.
+    let entry = mirFunctionNewBlock(out, span)
+    out.entry = entry
+}
+
+/// mirLowerFinishPlaceholder installs an Unreachable terminator on the
+/// entry block so the function shell passes the MIR validator's
+/// "every block has a terminator" check before Stage 4b fills in
+/// proper control flow.
+pub fn mirLowerFinishPlaceholder(out: MirFunction, span: MirSpan) {
+    if out.blocks.len() == 0 {
+        return
+    }
+    mirFunctionTerminate(out, out.entry, mirUnreachableTerm(span))
+}
+
+// ====================================================================
+// Pass 2: globals
+// ====================================================================
+
+/// mirLowerGlobal emits a MIR global entry. When the source carried
+/// an initialiser, a zero-arg `_init_<name>` MIR function is minted
+/// alongside (Stage 4b fills its body; Stage 4a leaves it as a
+/// placeholder `Unreachable`).
+pub fn mirLowerGlobal(l: MirLowerer, let_: HirLetDecl) -> MirGlobal {
+    let typ = if hirTypeIsValid(let_.typ) {
+        let_.typ
+    } else if let_.hasValue {
+        let_.value.typ
+    } else {
+        hirTypeInvalid()
+    }
+
+    let span = mirSpanFromHir(let_.span)
+    let mut g = mirGlobal(let_.name, hirTypeString(typ), let_.mutable, span)
+
+    if !hirTypeIsValid(typ) {
+        mirLowerNoteIssue(l, "global \"" + let_.name + "\": unknown type")
+        return g
+    }
+
+    if let_.hasValue {
+        let initName = "_init_" + let_.name
+        let mut initFn = mirFunction(initName, hirTypeString(typ), span)
+        mirLowerSeedFunction(initFn, [], typ, span)
+        mirLowerFinishPlaceholder(initFn, span)
+        l.out.functions.push(initFn)
+        g.hasInit = true
+        g.initSymbol = initName
+    }
+
+    g
+}
+
+// ====================================================================
+// Type bridging helpers (HirType → MIR type strings)
+// ====================================================================
+
+/// hirTypeNameOf returns the source-level bare name of a HIR type, or
+/// the empty string for types with no canonical name. Convenience for
+/// call-site dispatch (e.g. distinguishing stdlib intrinsics from
+/// user calls).
+pub fn hirTypeNameOf(t: HirType) -> String {
+    match t.kind {
+        HirTypeNamed -> t.namedName,
+        _ -> "",
+    }
+}
+
+/// hirTypeIsList reports whether `t` is a `List<_>` builtin type.
+pub fn hirTypeIsList(t: HirType) -> Bool {
+    match t.kind {
+        HirTypeNamed -> {
+            if t.namedName == "List" {
+                true
+            } else {
+                false
+            }
+        },
+        _ -> false,
+    }
+}
+
+/// hirTypeIsMap reports whether `t` is a `Map<_, _>` builtin type.
+pub fn hirTypeIsMap(t: HirType) -> Bool {
+    match t.kind {
+        HirTypeNamed -> {
+            if t.namedName == "Map" {
+                true
+            } else {
+                false
+            }
+        },
+        _ -> false,
+    }
+}
+
+/// hirTypeIsSet reports whether `t` is a `Set<_>` builtin type.
+pub fn hirTypeIsSet(t: HirType) -> Bool {
+    match t.kind {
+        HirTypeNamed -> {
+            if t.namedName == "Set" {
+                true
+            } else {
+                false
+            }
+        },
+        _ -> false,
+    }
+}
+
+/// hirTypeIsChannel reports whether `t` is a channel (`thread.Chan<_>`).
+/// Stage 4e tightens this once concurrency lowering lands.
+pub fn hirTypeIsChannel(t: HirType) -> Bool {
+    match t.kind {
+        HirTypeNamed -> {
+            if t.namedName == "Chan" {
+                true
+            } else {
+                false
+            }
+        },
+        _ -> false,
+    }
+}
+
+/// hirTypeFirstArg returns the first type argument of a generic named
+/// type, or an invalid HirType when `t` has no arguments.
+pub fn hirTypeFirstArg(t: HirType) -> HirType {
+    match t.kind {
+        HirTypeNamed -> {
+            if t.namedArgs.len() > 0 {
+                t.namedArgs[0]
+            } else {
+                hirTypeInvalid()
+            }
+        },
+        _ -> hirTypeInvalid(),
+    }
+}
+
+/// hirTypeSecondArg returns the second type argument of a generic
+/// named type (e.g. `Map<K, V>.V`), or an invalid HirType when absent.
+pub fn hirTypeSecondArg(t: HirType) -> HirType {
+    match t.kind {
+        HirTypeNamed -> {
+            if t.namedArgs.len() >= 2 {
+                t.namedArgs[1]
+            } else {
+                hirTypeInvalid()
+            }
+        },
+        _ -> hirTypeInvalid(),
+    }
+}
+
+// ====================================================================
+// Operator bridging (HIR ops → MIR ops)
+// ====================================================================
+//
+// Stage 4d will route HIR Unary/Binary expressions through these
+// converters when lowering to MIR RValue. They are defined here so
+// Stage 4b can install them for simple passthrough cases earlier.
+
+/// hirUnOpToMir maps HIR unary-op kinds to MIR's enum. Returns
+/// `MirUnInvalid` for the Osty-side `HirUnInvalid`.
+pub fn hirUnOpToMir(op: HirUnOp) -> MirUnaryOp {
+    match op {
+        HirUnInvalid -> MirUnInvalid,
+        HirUnNeg -> MirUnNeg,
+        HirUnPlus -> MirUnPlus,
+        HirUnNot -> MirUnNot,
+        HirUnBitNot -> MirUnBitNot,
+    }
+}
+
+/// hirBinOpToMir maps HIR binary-op kinds to MIR's enum.
+pub fn hirBinOpToMir(op: HirBinOp) -> MirBinaryOp {
+    match op {
+        HirBinInvalid -> MirBinInvalid,
+        HirBinAdd -> MirBinAdd,
+        HirBinSub -> MirBinSub,
+        HirBinMul -> MirBinMul,
+        HirBinDiv -> MirBinDiv,
+        HirBinMod -> MirBinMod,
+        HirBinEq -> MirBinEq,
+        HirBinNeq -> MirBinNeq,
+        HirBinLt -> MirBinLt,
+        HirBinLeq -> MirBinLeq,
+        HirBinGt -> MirBinGt,
+        HirBinGeq -> MirBinGeq,
+        HirBinAnd -> MirBinAnd,
+        HirBinOr -> MirBinOr,
+        HirBinBitAnd -> MirBinBitAnd,
+        HirBinBitOr -> MirBinBitOr,
+        HirBinBitXor -> MirBinBitXor,
+        HirBinShl -> MirBinShl,
+        HirBinShr -> MirBinShr,
+    }
+}
+
+/// hirAssignOpToBinOp maps a compound-assign operator to its
+/// equivalent binary op for lowering `x op= y` into `x = x op y`.
+/// Returns `MirBinInvalid` for plain `=` (no underlying binary op).
+pub fn hirAssignOpToBinOp(op: HirAssignOp) -> MirBinaryOp {
+    match op {
+        HirAssignInvalid -> MirBinInvalid,
+        HirAssignEq -> MirBinInvalid,
+        HirAssignAdd -> MirBinAdd,
+        HirAssignSub -> MirBinSub,
+        HirAssignMul -> MirBinMul,
+        HirAssignDiv -> MirBinDiv,
+        HirAssignMod -> MirBinMod,
+        HirAssignAnd -> MirBinBitAnd,
+        HirAssignOr -> MirBinBitOr,
+        HirAssignXor -> MirBinBitXor,
+        HirAssignShl -> MirBinShl,
+        HirAssignShr -> MirBinShr,
+    }
+}


### PR DESCRIPTION
## Summary

First cut of [toolchain/mir_lower.osty](toolchain/mir_lower.osty) (915 lines) — the self-hosted port of `internal/mir/lower.go`. This PR establishes the top-level entry and pass-1 infrastructure; function bodies and expression lowering land in follow-up stages.

Builds on [#670](https://github.com/choiceoh/osty/pull/670) (HIR data model). Together these cover the data foundation + lowerer skeleton for the HIR → MIR pipeline.

## What's included

**Lookup tables + signature collection:**
- `MirLowerer` state struct — pass-1 tables (fnSigs / methodSigs / structs / enums / globals / useAliases) split into parallel value + key-string lists (avoids Map intrinsic codegen)
- `mirLowerFnSignature` / `mirLowerMethodSignature` + `mangleMethodSymbol` (`Type__method`) + `methodKey` (`Type::method`) + drop-receiver helper

**Entry + two-pass pipeline:**
- `mirLowerModule(src: HirModule) -> MirModule` — public entry
- `collectSignatures` — walks HIR module's fns/structs/enums/lets/uses; skips generic decls with an "reached MIR" issue
- `buildLayouts` — `HirStructDecl` → `MirStructLayout`, `HirEnumDecl` → `MirEnumLayout` (with positional `_N` payload field names, matching Go's `fmt.Sprintf("_%d", j)`)
- `emitUse` — copies HIR use decls (including FFI metadata) into MIR
- `emitDeclarations` — non-generic decls → function shells; `emitScript` synthesises a `main()` for top-level script

**Function shell emission:**
- `mirLowerFunction` — produces a `MirFunction` with the return slot, parameter locals, and entry block, terminated by `Unreachable` as a placeholder (Stage 4b replaces with real body lowering). Method receivers get a synthetic `self` param at position 0
- External stubs (empty body) carry zero blocks per MIR validator rules
- `mirLowerGlobal` — emits a MIR global + `_init_<name>` function shell for initialised globals

**Bridge helpers:**
- `mirSpanFromHir` — HirSpan → MirSpan (drops line/column info)
- Type helpers: `hirTypeNameOf` / `hirTypeIsList` / `hirTypeIsMap` / `hirTypeIsSet` / `hirTypeIsChannel` / `hirTypeFirstArg` / `hirTypeSecondArg` — for Stage 4d/4e call-site dispatch
- Op bridges: `hirUnOpToMir` / `hirBinOpToMir` / `hirAssignOpToBinOp`
- `mirLowerIntToString` — local utility (self-host stdlib has no `Int.toString` yet; used for synthetic arg/field names)

## Verification

- `osty parse toolchain/mir_lower.osty` → exit 0
- `osty check toolchain/mir_lower.osty` → 0 errors related to mir_lower.osty

## What's left

Stage 4 splits so each sub-stage stays reviewable:

- **Stage 4b**: `bodyState` + `lowerStmt` for simple kinds (Block / Let / ExprStmt / Return / Break / Continue)
- **Stage 4c**: control flow (If / For / Match / Defer)
- **Stage 4d**: expression lowering into Place / Operand / RValue
- **Stage 4e**: concurrency + stdlib intrinsics + closures
- **Stage 4f**: projection walk + variant / struct layout lookup

Until Stage 4b lands, emitted MIR functions carry placeholder `Unreachable` terminators — structurally valid but not executable. Callers that need end-to-end HIR→MIR→LLVM should continue using Go's `mir.Lower` via the existing bridge.

## Test plan

- [x] `osty parse` / `osty check` pass
- [ ] Stage 4b will exercise the pass-1 tables by routing stmt lowering through the signature / layout lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)