### PR TITLE
feat(pkgmgr): route resolveRegistryGraph through PubGrub + honor locked pins

### DIFF
--- a/toolchain/pkgmgr.osty
+++ b/toolchain/pkgmgr.osty
@@ -940,9 +940,24 @@ fn emptySelfPkgGraphNode() -> SelfPkgGraphNode {
 }
 
 /// selfPkgResolveRegistryGraph resolves direct registry dependencies into a
-/// graph. The input dependency table is pure; a host shim supplies candidates
-/// and their dependency lists after reading registry metadata.
+/// graph. Delegates to the PubGrub solver in `pkgmgr_sat.osty`; that
+/// path handles diamond conflicts and backtracking that the earlier
+/// greedy walk could not. The greedy implementation is preserved as
+/// `selfPkgResolveRegistryGraphGreedy` for comparison / regression
+/// bisection.
 pub fn selfPkgResolveRegistryGraph(
+    deps: List<SelfPkgDependency>,
+    candidates: List<SelfPkgCandidate>,
+    candidateDeps: List<SelfPkgCandidateDeps>,
+    locked: List<SelfPkgLockPackage>,
+) -> SelfPkgGraph {
+    selfPkgResolveRegistryGraphPubGrub(deps, candidates, candidateDeps, locked)
+}
+
+/// selfPkgResolveRegistryGraphGreedy is the original "first-match-wins"
+/// DFS resolver. Kept for diagnostic / comparison use — the public
+/// `selfPkgResolveRegistryGraph` now routes through PubGrub.
+pub fn selfPkgResolveRegistryGraphGreedy(
     deps: List<SelfPkgDependency>,
     candidates: List<SelfPkgCandidate>,
     candidateDeps: List<SelfPkgCandidateDeps>,

--- a/toolchain/pkgmgr_sat.osty
+++ b/toolchain/pkgmgr_sat.osty
@@ -624,12 +624,14 @@ pub fn satDerivation(pkg: String, term: SatTerm, level: Int, cause: Int) -> SatA
 
 /// SatState holds the full solver state: assignments (partial solution,
 /// in insertion order), incompatibility store, current decision level,
-/// and the registry view.
+/// the registry view, and any lockfile pins the caller wants the
+/// decision heuristic to prefer.
 pub struct SatState {
     pub assigns: List<SatAssign>,
     pub incompats: List<SatIncompat>,
     pub decisionLevel: Int,
     pub registry: SatRegistry,
+    pub locked: List<SelfPkgLockPackage>,
     pub rootName: String,
     pub errors: List<String>,
     pub unsat: Bool,
@@ -823,6 +825,31 @@ pub fn satRegistryDeps(reg: SatRegistry, pkg: String, v: SemVersion) -> List<Sel
         }
     }
     []
+}
+
+/// satRegistryHas reports whether the registry carries `(pkg, v)`.
+pub fn satRegistryHas(reg: SatRegistry, pkg: String, v: SemVersion) -> Bool {
+    for p in reg.pkgs {
+        if p.name == pkg {
+            for cand in p.versions {
+                if compareSemVersion(cand, v) == 0 { return true }
+            }
+        }
+    }
+    false
+}
+
+/// satPinnedVersion looks up a lockfile pin for `pkg`. Returned only
+/// when a lock entry exists; the caller is responsible for verifying
+/// the pin is still compatible with the current derived term (locks
+/// are *preferences*, never force a contradiction).
+pub fn satPinnedVersion(state: SatState, pkg: String) -> SatVersionLookup {
+    for entry in state.locked {
+        if entry.name == pkg {
+            return SatVersionLookup { found: true, version: entry.version }
+        }
+    }
+    SatVersionLookup { found: false, version: stableVersion(0, 0, 0) }
 }
 
 // ---------------------------------------------------------------------
@@ -1263,11 +1290,22 @@ pub fn satNextDecision(state: SatState) -> SatDecisionOutcome {
     }
     let mut chosen: SemVersion = stableVersion(0, 0, 0)
     let mut foundVer = false
-    for v in versions {
-        if vsContains(allowed, v) {
-            chosen = v
-            foundVer = true
-            break
+    // Prefer a lock-pinned version when it is still in `allowed` —
+    // keeps `osty.lock` stable across re-resolves that don't widen
+    // the requirement. Falls through to the default newest-first
+    // search when no pin exists or the pin has drifted out of range.
+    let pinned = satPinnedVersion(state, pkg)
+    if pinned.found && vsContains(allowed, pinned.version) && satRegistryHas(state.registry, pkg, pinned.version) {
+        chosen = pinned.version
+        foundVer = true
+    }
+    if !(foundVer) {
+        for v in versions {
+            if vsContains(allowed, v) {
+                chosen = v
+                foundVer = true
+                break
+            }
         }
     }
     if !(foundVer) {
@@ -1423,6 +1461,9 @@ fn satRenderPlan(state: SatState) -> List<SelfPkgResolveDecision> {
         let v = psDecidedVersion(state, a.pkg)
         if !(v.found) { continue }
         let checksum = satRegistryChecksum(state.registry, a.pkg, v.version)
+        let pin = satPinnedVersion(state, a.pkg)
+        let fromLock = pin.found && compareSemVersion(pin.version, v.version) == 0
+        let message = if fromLock { "locked" } else { "pubgrub" }
         out.push(SelfPkgResolveDecision {
             found: true,
             name: a.pkg,
@@ -1430,8 +1471,8 @@ fn satRenderPlan(state: SatState) -> List<SelfPkgResolveDecision> {
             version: v.version,
             source: "registry+default",
             checksum,
-            fromLock: false,
-            message: "pubgrub",
+            fromLock,
+            message,
         })
     }
     out
@@ -1520,7 +1561,6 @@ pub fn selfPkgSolvePubGrubOutcome(
     candidateDeps: List<SelfPkgCandidateDeps>,
     locked: List<SelfPkgLockPackage>,
 ) -> SatSolveOutcome {
-    let _ = locked
     let effectiveRoot = if rootName == "" { "$root" } else { rootName }
     let registry = satRegistryFromPkgmgr(candidates, candidateDeps)
     let mut state = SatState {
@@ -1528,6 +1568,7 @@ pub fn selfPkgSolvePubGrubOutcome(
         incompats: [],
         decisionLevel: 0,
         registry,
+        locked,
         rootName: effectiveRoot,
         errors: [],
         unsat: false,
@@ -1543,4 +1584,46 @@ pub fn selfPkgSolvePubGrubOutcome(
         state.incompats.push(satIncompatDependency(rootTerm, depTerm))
     }
     satSolve(state)
+}
+
+// ---------------------------------------------------------------------
+// 14. Graph assembly — drop-in replacement for the greedy
+// `selfPkgResolveRegistryGraph`. Runs PubGrub, then builds a
+// `SelfPkgGraph` with transitive edges + deterministic topological
+// order (leaves first, same contract as the greedy resolver).
+// ---------------------------------------------------------------------
+
+/// selfPkgResolveRegistryGraphPubGrub resolves `deps` through the
+/// PubGrub solver and packages the result as a `SelfPkgGraph`. The
+/// registry + lock inputs are the same pure-data shapes the rest of
+/// `pkgmgr.osty` consumes.
+pub fn selfPkgResolveRegistryGraphPubGrub(
+    deps: List<SelfPkgDependency>,
+    candidates: List<SelfPkgCandidate>,
+    candidateDeps: List<SelfPkgCandidateDeps>,
+    locked: List<SelfPkgLockPackage>,
+) -> SelfPkgGraph {
+    let outcome = selfPkgSolvePubGrubOutcome("", deps, candidates, candidateDeps, locked)
+    if !(outcome.success) {
+        return SelfPkgGraph { nodes: [], order: [], errors: [outcome.error] }
+    }
+    let registry = satRegistryFromPkgmgr(candidates, candidateDeps)
+    let mut nodes: List<SelfPkgGraphNode> = []
+    for decision in outcome.decisions {
+        let childDeps = satRegistryDeps(registry, decision.packageName, decision.version)
+        let mut childNames: List<String> = []
+        for cd in childDeps {
+            childNames.push(cd.name)
+        }
+        nodes.push(selfPkgGraphNode(
+            decision.name,
+            decision.packageName,
+            decision.version,
+            decision.source,
+            decision.checksum,
+            childNames,
+        ))
+    }
+    let order = selfPkgTopoOrder(nodes)
+    SelfPkgGraph { nodes, order, errors: [] }
 }

--- a/toolchain/pkgmgr_sat_test.osty
+++ b/toolchain/pkgmgr_sat_test.osty
@@ -185,6 +185,163 @@ fn testPubGrubPicksHighestWhenMultipleVersionsSatisfy() {
     testing.assertEq(compareSemVersion(pick.decision.version, stableVersion(1, 5, 0)), 0)
 }
 
+fn testPubGrubHonorsLockedPinWhenStillCompatible() {
+    // Registry has x 1.5.0 (newest) and x 1.2.0. Lock pins 1.2.0 and
+    // the caret req still admits it, so PubGrub must honour the pin.
+    let roots = [satTestDep("x", caretReq(stableVersion(1, 0, 0)))]
+    let candidates = [
+        satTestCand("x", stableVersion(1, 5, 0)),
+        satTestCand("x", stableVersion(1, 2, 0)),
+    ]
+    let candidateDeps = [
+        satTestCandDeps("x", stableVersion(1, 5, 0), []),
+        satTestCandDeps("x", stableVersion(1, 2, 0), []),
+    ]
+    let locked = [
+        selfPkgLockPackage(
+            "x",
+            stableVersion(1, 2, 0),
+            "registry+default",
+            "sha256:x-1.2.0",
+            [],
+        ),
+    ]
+    let plan = selfPkgSolvePubGrub("root", roots, candidates, candidateDeps, locked)
+    testing.assertEq(plan.missing, 0)
+    let pick = satTestFindDecision(plan, "x")
+    testing.assert(pick.found)
+    testing.assertEq(compareSemVersion(pick.decision.version, stableVersion(1, 2, 0)), 0)
+    testing.assert(pick.decision.fromLock)
+}
+
+fn testPubGrubIgnoresIncompatibleLockPin() {
+    // Lock pins 1.2.0 but the caret req has moved past it (>=1.4.0).
+    // The pin must be dropped and the newest allowed version chosen.
+    let roots = [
+        satTestDep(
+            "x",
+            semReq(false, [reqClause(ReqGE, stableVersion(1, 4, 0))]),
+        ),
+    ]
+    let candidates = [
+        satTestCand("x", stableVersion(1, 5, 0)),
+        satTestCand("x", stableVersion(1, 2, 0)),
+    ]
+    let candidateDeps = [
+        satTestCandDeps("x", stableVersion(1, 5, 0), []),
+        satTestCandDeps("x", stableVersion(1, 2, 0), []),
+    ]
+    let locked = [
+        selfPkgLockPackage(
+            "x",
+            stableVersion(1, 2, 0),
+            "registry+default",
+            "sha256:x-1.2.0",
+            [],
+        ),
+    ]
+    let plan = selfPkgSolvePubGrub("root", roots, candidates, candidateDeps, locked)
+    testing.assertEq(plan.missing, 0)
+    let pick = satTestFindDecision(plan, "x")
+    testing.assert(pick.found)
+    testing.assertEq(compareSemVersion(pick.decision.version, stableVersion(1, 5, 0)), 0)
+    testing.assert(!(pick.decision.fromLock))
+}
+
+fn testPubGrubGraphWrapperProducesLeafFirstOrder() {
+    // app 1.0 -> util ^0.2 -> leaf ^0.1. Graph wrapper must produce
+    // [leaf, util, app] in topological (leaves-first) order.
+    let deps = [satTestDep("app", caretReq(stableVersion(1, 0, 0)))]
+    let candidates = [
+        satTestCand("app", stableVersion(1, 0, 0)),
+        satTestCand("util", stableVersion(0, 2, 0)),
+        satTestCand("leaf", stableVersion(0, 1, 0)),
+    ]
+    let candidateDeps = [
+        satTestCandDeps("app", stableVersion(1, 0, 0), [
+            satTestDep("util", caretReq(stableVersion(0, 2, 0))),
+        ]),
+        satTestCandDeps("util", stableVersion(0, 2, 0), [
+            satTestDep("leaf", caretReq(stableVersion(0, 1, 0))),
+        ]),
+        satTestCandDeps("leaf", stableVersion(0, 1, 0), []),
+    ]
+    let graph = selfPkgResolveRegistryGraph(deps, candidates, candidateDeps, [])
+    testing.assertEq(selfPkgGraphErrorCount(graph), 0)
+    testing.assertEq(selfPkgGraphNodeCount(graph), 3)
+    testing.assertEq(graph.order[0], "leaf")
+    testing.assertEq(graph.order[1], "util")
+    testing.assertEq(graph.order[2], "app")
+}
+
+fn testPubGrubGraphWrapperBacktracksUnderDiamond() {
+    // Same backtrack case as the plan-level test, but exercised via the
+    // graph wrapper so regressions in the assembly path are caught too.
+    let deps = [
+        satTestDep("a", caretReq(stableVersion(1, 0, 0))),
+        satTestDep("b", caretReq(stableVersion(1, 0, 0))),
+    ]
+    let candidates = [
+        satTestCand("a", stableVersion(1, 1, 0)),
+        satTestCand("a", stableVersion(1, 0, 0)),
+        satTestCand("b", stableVersion(1, 0, 0)),
+    ]
+    let candidateDeps = [
+        satTestCandDeps("a", stableVersion(1, 1, 0), [
+            satTestDep("b", caretReq(stableVersion(2, 0, 0))),
+        ]),
+        satTestCandDeps("a", stableVersion(1, 0, 0), [
+            satTestDep("b", caretReq(stableVersion(1, 0, 0))),
+        ]),
+        satTestCandDeps("b", stableVersion(1, 0, 0), []),
+    ]
+    let graph = selfPkgResolveRegistryGraph(deps, candidates, candidateDeps, [])
+    testing.assertEq(selfPkgGraphErrorCount(graph), 0)
+    testing.assertEq(selfPkgGraphNodeCount(graph), 2)
+    let node = satTestFindGraphNode(graph, "a")
+    testing.assert(node.found)
+    testing.assertEq(compareSemVersion(node.node.version, stableVersion(1, 0, 0)), 0)
+}
+
+fn testPubGrubGreedyBackendStillCallable() {
+    // `selfPkgResolveRegistryGraphGreedy` is preserved for diagnostic
+    // comparisons. Sanity-check it still returns an acyclic graph for
+    // the simple chain.
+    let deps = [satTestDep("app", caretReq(stableVersion(1, 0, 0)))]
+    let candidates = [
+        satTestCand("app", stableVersion(1, 0, 0)),
+        satTestCand("leaf", stableVersion(0, 1, 0)),
+    ]
+    let candidateDeps = [
+        satTestCandDeps("app", stableVersion(1, 0, 0), [
+            satTestDep("leaf", caretReq(stableVersion(0, 1, 0))),
+        ]),
+        satTestCandDeps("leaf", stableVersion(0, 1, 0), []),
+    ]
+    let graph = selfPkgResolveRegistryGraphGreedy(deps, candidates, candidateDeps, [])
+    testing.assertEq(selfPkgGraphErrorCount(graph), 0)
+    testing.assertEq(selfPkgGraphNodeCount(graph), 2)
+    testing.assertEq(graph.order[0], "leaf")
+    testing.assertEq(graph.order[1], "app")
+}
+
+fn satTestFindGraphNode(graph: SelfPkgGraph, name: String) -> SatTestGraphNodeLookup {
+    for node in graph.nodes {
+        if node.name == name {
+            return SatTestGraphNodeLookup { found: true, node }
+        }
+    }
+    SatTestGraphNodeLookup {
+        found: false,
+        node: selfPkgGraphNode("", "", stableVersion(0, 0, 0), "", "", []),
+    }
+}
+
+pub struct SatTestGraphNodeLookup {
+    pub found: Bool,
+    pub node: SelfPkgGraphNode,
+}
+
 pub struct SatTestDecisionLookup {
     pub found: Bool,
     pub decision: SelfPkgResolveDecision,


### PR DESCRIPTION
## Summary

- `selfPkgResolveRegistryGraph` (the public resolver entry used by vendor / lockfile / ci paths) now delegates to the PubGrub solver landed in #667. Greedy DFS body preserved as `selfPkgResolveRegistryGraphGreedy` for bisection / diagnostic comparison.
- `SatState` gains a `locked: List<SelfPkgLockPackage>` field; `satNextDecision` prefers a lock-compatible version before the default newest-first search. Pins that fall outside the derived term are silently dropped — locks are preferences, never forced UNSAT.
- New graph wrapper `selfPkgResolveRegistryGraphPubGrub` assembles `SelfPkgGraph` from the solver decisions (nodes + edges from `satRegistryDeps`, deterministic leaves-first order via the existing `selfPkgTopoOrder`).
- `satRenderPlan` stamps `fromLock=true` / `message=\"locked\"` when the chosen version matched a pin, matching the greedy `selfPkgSelectRegistryCandidate` convention.

## Why

#667 landed PubGrub as isolated core but left the greedy resolver in place. The diamond / backtrack scenarios PubGrub was introduced for only fire when the public entry uses it — this PR makes that switch. Locked-pin preference is a prerequisite: re-resolving a manifest whose lockfile still fits must keep the pinned versions, otherwise `osty.lock` churns on every call.

## Non-goals

- No Go-side wiring. `internal/pkgmgr/resolve.go` still runs its own greedy DFS and the self-host golegacy adapter path is untouched; switching those over needs a bootstrap regeneration and is a follow-up PR.
- Conflict reporting is still the raw incompat dump from #667 — the PubGrub derivation-tree renderer is the next item on the list.

## Verification

- `osty check toolchain/` — only the pre-existing unrelated `E0501 Manifest` duplicate in `package_entry.osty` remains.
- `just front` green (lexer / parser / resolve / check / diag / format / lint / pipeline).
- `osty test testPubGrub` discovers the now-10 solver tests but the native-test compilation pipeline still panics in `ir.(*lowerer).lowerStringLit` — reproducible on stock toolchain tests, tracks the ongoing MIR-direct migration rather than this change.

## Test plan

- [ ] `osty check toolchain/` clean (pre-existing E0501 only)
- [ ] `just front` green
- [ ] Once native-test compile is repaired: 5 new PubGrub tests (locked honoured, pin drifted out, graph wrapper leaf-first, graph wrapper diamond backtrack, greedy backend still callable) run end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)