### PR TITLE
feat(selfhost): HIR→MIR body lowering scaffold (Stage 4b)

### DIFF
--- a/toolchain/mir_lower.osty
+++ b/toolchain/mir_lower.osty
@@ -576,9 +576,14 @@ pub fn mirLowerEmitScript(l: MirLowerer) {
     let mut main = mirFunction("main", "()", span)
     // Entry block + return slot are stamped by mirLowerSeedFunction.
     mirLowerSeedFunction(main, [], hirTUnit(), span)
-    // Stage 4b lands the body loop. For now, terminate the entry
-    // block with Unreachable so the MIR shape is well-formed.
-    mirLowerFinishPlaceholder(main, span)
+    // Run script statements through the body-state pipeline so any
+    // simple stmt kinds land instructions; unsupported kinds record
+    // an issue and fall through to an implicit unit return.
+    let bs = mirLowerBodyState(l, main, hirTUnit())
+    for s in l.src.script {
+        mirLowerStmt(bs, s)
+    }
+    mirLowerFinishNoReturn(bs, span)
     l.out.functions.push(main)
 }
 
@@ -644,8 +649,57 @@ pub fn mirLowerFunction(
     }
 
     mirLowerSeedFunction(out, params, retT, span)
-    mirLowerFinishPlaceholder(out, span)
+    mirLowerFunctionBody(l, out, decl, retT, asMethod, span)
     out
+}
+
+/// mirLowerFunctionBody drives the real body lowering. Stage 4b wires
+/// simple statement kinds (Block / Let / ExprStmt / Return / Break /
+/// Continue / Defer); the rest (If / For / Match / ChanSend / full
+/// expression lowering) land in subsequent stages and fall through to
+/// `mirLowerNoteIssue` with a "Stage 4x TODO" message.
+///
+/// On exit, if the cursor block has no terminator the lowerer runs
+/// any outstanding defers and either emits Return (unit-returning
+/// fns) or Unreachable (non-unit fns whose body fell through — the
+/// checker already forbids this so the terminator is defensive
+/// poison).
+pub fn mirLowerFunctionBody(
+    l: MirLowerer,
+    out: MirFunction,
+    decl: HirFnDecl,
+    retT: HirType,
+    asMethod: Bool,
+    span: MirSpan,
+) {
+    let bs = mirLowerBodyState(l, out, retT)
+    if asMethod && bs.paramLocals.len() > 0 {
+        bs.self.hasOwner = true
+        bs.self.typeName = mirLowerSelfOwnerName(decl)
+        bs.self.localId = bs.paramLocals[0]
+    }
+    for s in decl.body.stmts {
+        mirLowerStmt(bs, s)
+    }
+    if decl.body.hasResult {
+        // Trailing expression — lower into the return slot and return.
+        mirLowerExprInto(bs, decl.body.result, out.returnLocal, retT)
+        mirLowerRunDefers(bs, span)
+        mirLowerTerminate(bs, mirReturnTerm(span))
+        return
+    }
+    mirLowerFinishNoReturn(bs, span)
+}
+
+/// mirLowerSelfOwnerName recovers the owning type for a method body.
+/// The synthetic self param's type is `HirTypeNamed{Name: owner}`
+/// under the convention used by mirLowerFunction.
+fn mirLowerSelfOwnerName(decl: HirFnDecl) -> String {
+    if decl.params.len() == 0 {
+        return ""
+    }
+    let first = decl.params[0]
+    hirTypeNameOf(first.typ)
 }
 
 /// mirLowerFunctionIsExternal reports whether the fn has no body and
@@ -738,7 +792,14 @@ pub fn mirLowerGlobal(l: MirLowerer, let_: HirLetDecl) -> MirGlobal {
         let initName = "_init_" + let_.name
         let mut initFn = mirFunction(initName, hirTypeString(typ), span)
         mirLowerSeedFunction(initFn, [], typ, span)
-        mirLowerFinishPlaceholder(initFn, span)
+        // Lower the initialiser into the return slot and terminate
+        // with Return. The expression lowerer currently emits a
+        // unit-const placeholder (Stage 4d); once real expr lowering
+        // lands, this path produces the actual initialiser value.
+        let bs = mirLowerBodyState(l, initFn, typ)
+        mirLowerExprInto(bs, let_.value, initFn.returnLocal, typ)
+        mirLowerRunDefers(bs, span)
+        mirLowerTerminate(bs, mirReturnTerm(span))
         l.out.functions.push(initFn)
         g.hasInit = true
         g.initSymbol = initName
@@ -912,4 +973,656 @@ pub fn hirAssignOpToBinOp(op: HirAssignOp) -> MirBinaryOp {
         HirAssignShl -> MirBinShl,
         HirAssignShr -> MirBinShr,
     }
+}
+
+// ====================================================================
+// Body lowering infrastructure (Stage 4b)
+// ====================================================================
+//
+// `MirLowerBodyState` is the per-function cursor + scope + defer
+// stack. Every statement or expression lowering routine mutates one
+// bodyState in place — Go's lower.go uses a method receiver for the
+// same purpose; Osty's convention is to pass the state explicitly.
+//
+// Scope name lookup uses parallel `List<String>` + `List<Int>` arrays
+// per frame (not a Map) so the file stays independent of Map
+// intrinsic codegen status. Lookups are O(n) within a frame but `n`
+// is small (one scope frame per block) and the linear-scan cost is
+// dominated by the per-stmt lowering work.
+//
+// Defer frames are `List<List<HirBlock>>`. Each block push creates a
+// new frame; on fall-through we replay + pop the top, and at
+// return / ? / fall-through we replay every frame in LIFO. Matches
+// Go's `deferFrames` exactly.
+
+/// MirLowerOwnerContext carries the method-receiver info for body
+/// lowering. `hasOwner` gates the field payload so free functions
+/// don't need to invent a type name.
+pub struct MirLowerOwnerContext {
+    pub hasOwner: Bool,
+    pub typeName: String,
+    pub localId: Int,
+}
+
+pub fn mirLowerOwnerNone() -> MirLowerOwnerContext {
+    MirLowerOwnerContext {
+        hasOwner: false,
+        typeName: "",
+        localId: -1,
+    }
+}
+
+/// MirLowerScopeFrame is one lexical scope. `names` + `values` are
+/// parallel arrays that map HIR-visible identifiers to MIR local IDs.
+/// `locals` is the list of locals that should receive StorageDead on
+/// scope exit (params + return slot are excluded — they live for the
+/// whole function).
+pub struct MirLowerScopeFrame {
+    pub names: List<String>,
+    pub values: List<Int>,
+    pub locals: List<Int>,
+}
+
+pub fn mirLowerScopeFrame() -> MirLowerScopeFrame {
+    MirLowerScopeFrame {
+        names: [],
+        values: [],
+        locals: [],
+    }
+}
+
+/// MirLowerLoopFrame is one active loop's break/continue targets +
+/// the defer / scope depth captured at loop entry. Used by Stage 4c
+/// when For / While lowerers push frames; defined here so break and
+/// continue can land in 4b without a second source edit.
+pub struct MirLowerLoopFrame {
+    pub breakBlock: Int,
+    pub continueBlock: Int,
+    pub deferDepth: Int,
+    pub scopeDepth: Int,
+}
+
+pub fn mirLowerLoopFrame(breakBlock: Int, continueBlock: Int, deferDepth: Int, scopeDepth: Int) -> MirLowerLoopFrame {
+    MirLowerLoopFrame {
+        breakBlock,
+        continueBlock,
+        deferDepth,
+        scopeDepth,
+    }
+}
+
+/// MirLowerBodyState is the per-function cursor. All statement /
+/// expression lowerers take it as the first argument and mutate it
+/// in place.
+pub struct MirLowerBodyState {
+    pub l: MirLowerer,
+    pub fn_: MirFunction,
+    pub retType: HirType,
+
+    // Current block id for emission. Instructions and terminators
+    // always target this block.
+    pub cur: Int,
+
+    // Lexical scope stack. `scopes[0]` is the function-level frame
+    // seeded with parameter names.
+    pub scopes: List<MirLowerScopeFrame>,
+
+    // Quick access to parameter locals by positional index.
+    pub paramLocals: List<Int>,
+
+    // Method receiver context. `hasOwner` is false for free fns.
+    pub self: MirLowerOwnerContext,
+
+    // Break/continue target stack. Empty outside loops.
+    pub loopStack: List<MirLowerLoopFrame>,
+
+    // Defer frames. Index 0 is the function-level frame (seeded by
+    // the constructor); each block push adds a new frame on top.
+    pub deferFrames: List<List<HirBlock>>,
+}
+
+/// mirLowerBodyState constructs a bodyState seeded from `out`'s
+/// parameter locals. The function-level scope frame and defer frame
+/// are pushed here so callers can start lowering stmts immediately.
+pub fn mirLowerBodyState(
+    l: MirLowerer,
+    out: MirFunction,
+    retType: HirType,
+) -> MirLowerBodyState {
+    let mut bs = MirLowerBodyState {
+        l,
+        fn_: out,
+        retType,
+        cur: out.entry,
+        scopes: [],
+        paramLocals: [],
+        self: mirLowerOwnerNone(),
+        loopStack: [],
+        deferFrames: [],
+    }
+    // Function-level scope.
+    bs.scopes.push(mirLowerScopeFrame())
+    // Function-level defer frame.
+    let emptyFrame: List<HirBlock> = []
+    bs.deferFrames.push(emptyFrame)
+    // Seed parameter bindings. Parameter locals are already minted by
+    // mirLowerSeedFunction; we just re-index their names here.
+    for pid in out.params {
+        let loc = mirFunctionLocal(out, pid)
+        if loc.name != "" {
+            mirLowerBindName(bs, loc.name, pid)
+        }
+        bs.paramLocals.push(pid)
+    }
+    bs
+}
+
+// ---- Scope helpers -------------------------------------------------
+
+pub fn mirLowerPushScope(bs: MirLowerBodyState) {
+    bs.scopes.push(mirLowerScopeFrame())
+}
+
+/// mirLowerPopScope retires the top scope frame. Before dropping,
+/// StorageDead instructions are emitted for every local registered
+/// to the frame (params + return slot excluded by construction).
+pub fn mirLowerPopScope(bs: MirLowerBodyState) {
+    if bs.scopes.len() == 0 {
+        return
+    }
+    let topIdx = bs.scopes.len() - 1
+    mirLowerEmitStorageDeadForScope(bs, bs.scopes[topIdx])
+    // Drop the frame. Osty's List has no `pop()` intrinsic yet; we
+    // rebuild the list without the last element.
+    let mut kept: List<MirLowerScopeFrame> = []
+    let mut i = 0
+    for f in bs.scopes {
+        if i < topIdx {
+            kept.push(f)
+        }
+        i = i + 1
+    }
+    bs.scopes = kept
+}
+
+/// mirLowerBindName records a `name → localId` binding in the top
+/// scope frame. The empty string is a no-op (matches Go's `bind`).
+pub fn mirLowerBindName(bs: MirLowerBodyState, name: String, id: Int) {
+    if name == "" {
+        return
+    }
+    if bs.scopes.len() == 0 {
+        return
+    }
+    let topIdx = bs.scopes.len() - 1
+    bs.scopes[topIdx].names.push(name)
+    bs.scopes[topIdx].values.push(id)
+}
+
+/// mirLowerLookupName searches every scope frame LIFO for `name`.
+/// Returns -1 when not found.
+pub fn mirLowerLookupName(bs: MirLowerBodyState, name: String) -> Int {
+    let mut i = bs.scopes.len() - 1
+    for i >= 0 {
+        let frame = bs.scopes[i]
+        let mut j = frame.names.len() - 1
+        for j >= 0 {
+            if frame.names[j] == name {
+                return frame.values[j]
+            }
+            j = j - 1
+        }
+        i = i - 1
+    }
+    -1
+}
+
+/// mirLowerRegisterScopeLocal marks `id` as owned by the top scope
+/// so that `mirLowerPopScope` emits a StorageDead for it. Skips
+/// parameters and the return slot — those live for the whole fn.
+pub fn mirLowerRegisterScopeLocal(bs: MirLowerBodyState, id: Int) {
+    if bs.scopes.len() == 0 {
+        return
+    }
+    let loc = mirFunctionLocal(bs.fn_, id)
+    // Skip the return slot (id 0 by convention in mirLowerSeedFunction).
+    if id == bs.fn_.returnLocal {
+        return
+    }
+    // Skip params.
+    for p in bs.paramLocals {
+        if p == id {
+            return
+        }
+    }
+    let _ = loc
+    let topIdx = bs.scopes.len() - 1
+    bs.scopes[topIdx].locals.push(id)
+}
+
+/// mirLowerCurrentScopeDepth returns the current frame count minus 1
+/// (the function-level frame is depth 0). Used by loop frames when
+/// recording the scope depth at loop entry.
+pub fn mirLowerCurrentScopeDepth(bs: MirLowerBodyState) -> Int {
+    bs.scopes.len() - 1
+}
+
+/// mirLowerEmitStorageDeadFromDepth replays StorageDead for every
+/// frame from the top down to `depth` (inclusive). Used by break /
+/// continue before the terminator goto.
+pub fn mirLowerEmitStorageDeadFromDepth(bs: MirLowerBodyState, depth: Int) {
+    let mut d = depth
+    if d < 0 {
+        d = 0
+    }
+    let mut i = bs.scopes.len() - 1
+    for i >= d {
+        mirLowerEmitStorageDeadForScope(bs, bs.scopes[i])
+        i = i - 1
+    }
+}
+
+fn mirLowerEmitStorageDeadForScope(bs: MirLowerBodyState, scope: MirLowerScopeFrame) {
+    if scope.locals.len() == 0 {
+        return
+    }
+    let bb = mirFunctionBlock(bs.fn_, bs.cur)
+    if bb.hasTerm {
+        // Already terminated — StorageDead emission would go into a
+        // dead code region. Drop silently, matching Go's behaviour.
+        return
+    }
+    // Emit in reverse registration order (LIFO).
+    let mut i = scope.locals.len() - 1
+    for i >= 0 {
+        let id = scope.locals[i]
+        let loc = mirFunctionLocal(bs.fn_, id)
+        let instr = mirStorageDeadInstr(id, loc.span)
+        mirLowerEmitInstr(bs, instr)
+        i = i - 1
+    }
+}
+
+/// mirLowerNewLocal mints a fresh local on the enclosing function
+/// and registers it with the current scope frame.
+pub fn mirLowerNewLocal(
+    bs: MirLowerBodyState,
+    name: String,
+    typ: HirType,
+    mutable: Bool,
+    span: MirSpan,
+) -> Int {
+    let id = mirFunctionNewLocal(bs.fn_, name, hirTypeString(typ), mutable, span)
+    mirLowerRegisterScopeLocal(bs, id)
+    id
+}
+
+// ---- Cursor + block helpers ----------------------------------------
+
+/// mirLowerCurrentBlock returns the MIR block the cursor is pointing
+/// at. Returns a sentinel block (id=-1) when the function has no
+/// blocks — this is defensive; seeded functions always have at least
+/// the entry block.
+pub fn mirLowerCurrentBlock(bs: MirLowerBodyState) -> MirBasicBlock {
+    mirFunctionBlock(bs.fn_, bs.cur)
+}
+
+/// mirLowerEmitInstr appends `instr` to the cursor block. When the
+/// block is already terminated, a fresh orphan block is spun up and
+/// becomes the new cursor (matches Go's "unreachable after terminator"
+/// escape hatch so the module still validates).
+pub fn mirLowerEmitInstr(bs: MirLowerBodyState, instr: MirInstr) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        let orphan = mirFunctionNewBlock(bs.fn_, instr.span)
+        bs.cur = orphan
+    }
+    mirFunctionAppend(bs.fn_, bs.cur, instr)
+}
+
+/// mirLowerTerminate installs a terminator on the cursor block. If a
+/// terminator is already installed, this is a no-op (Go's behaviour).
+pub fn mirLowerTerminate(bs: MirLowerBodyState, t: MirTerm) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    mirFunctionTerminate(bs.fn_, bs.cur, t)
+}
+
+/// mirLowerSwitchTo installs a new cursor block and returns the
+/// previous id.
+pub fn mirLowerSwitchTo(bs: MirLowerBodyState, id: Int) -> Int {
+    let prev = bs.cur
+    bs.cur = id
+    prev
+}
+
+/// mirLowerNewBlock allocates a fresh block without switching the
+/// cursor. Returns the new block id.
+pub fn mirLowerNewBlock(bs: MirLowerBodyState, span: MirSpan) -> Int {
+    mirFunctionNewBlock(bs.fn_, span)
+}
+
+/// mirLowerGotoBlock terminates the current block with a goto and
+/// switches the cursor to `target`.
+pub fn mirLowerGotoBlock(bs: MirLowerBodyState, target: Int, span: MirSpan) {
+    mirLowerTerminate(bs, mirGotoTerm(target, span))
+    bs.cur = target
+}
+
+// ---- Defer helpers -------------------------------------------------
+
+pub fn mirLowerPushDeferScope(bs: MirLowerBodyState) {
+    let emptyFrame: List<HirBlock> = []
+    bs.deferFrames.push(emptyFrame)
+}
+
+pub fn mirLowerPopDeferScope(bs: MirLowerBodyState) {
+    if bs.deferFrames.len() == 0 {
+        return
+    }
+    let topIdx = bs.deferFrames.len() - 1
+    let mut kept: List<List<HirBlock>> = []
+    let mut i = 0
+    for f in bs.deferFrames {
+        if i < topIdx {
+            kept.push(f)
+        }
+        i = i + 1
+    }
+    bs.deferFrames = kept
+}
+
+/// mirLowerAddDefer registers a deferred body with the innermost
+/// defer frame. No-op when `body` carries no statements and no
+/// result (empty block).
+pub fn mirLowerAddDefer(bs: MirLowerBodyState, body: HirBlock) {
+    if bs.deferFrames.len() == 0 {
+        return
+    }
+    if body.stmts.len() == 0 && !body.hasResult {
+        return
+    }
+    let topIdx = bs.deferFrames.len() - 1
+    bs.deferFrames[topIdx].push(body)
+}
+
+/// mirLowerReplayTopFrame inlines only the innermost defer frame.
+/// Used for normal block fall-through before popping.
+pub fn mirLowerReplayTopFrame(bs: MirLowerBodyState, span: MirSpan) {
+    if bs.deferFrames.len() == 0 {
+        return
+    }
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    let topIdx = bs.deferFrames.len() - 1
+    mirLowerReplayDeferFrame(bs, bs.deferFrames[topIdx], span)
+}
+
+/// mirLowerReplayDefersFromDepth inlines defer frames from the top
+/// down to `depth` inclusive (LIFO). `depth=0` replays everything.
+pub fn mirLowerReplayDefersFromDepth(bs: MirLowerBodyState, depth: Int, span: MirSpan) {
+    let mut d = depth
+    if d < 0 {
+        d = 0
+    }
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    let mut i = bs.deferFrames.len() - 1
+    for i >= d {
+        mirLowerReplayDeferFrame(bs, bs.deferFrames[i], span)
+        i = i - 1
+    }
+}
+
+/// mirLowerReplayDeferFrame inlines one defer frame's blocks in LIFO
+/// order. Each body runs in its own pushed scope so cleanup names
+/// don't leak into the surrounding block.
+pub fn mirLowerReplayDeferFrame(bs: MirLowerBodyState, frame: List<HirBlock>, span: MirSpan) {
+    let mut i = frame.len() - 1
+    for i >= 0 {
+        let body = frame[i]
+        mirLowerPushScope(bs)
+        for s in body.stmts {
+            mirLowerStmt(bs, s)
+        }
+        if body.hasResult {
+            let _ = mirLowerExprAsOperand(bs, body.result)
+        }
+        mirLowerPopScope(bs)
+        i = i - 1
+    }
+    let _ = span
+}
+
+/// mirLowerRunDefers replays every defer frame (function-level + all
+/// inner frames) at the cursor. Called at return / ? / fall-through.
+pub fn mirLowerRunDefers(bs: MirLowerBodyState, span: MirSpan) {
+    mirLowerReplayDefersFromDepth(bs, 0, span)
+}
+
+pub fn mirLowerCurrentDeferDepth(bs: MirLowerBodyState) -> Int {
+    bs.deferFrames.len()
+}
+
+// ---- Terminal handling ---------------------------------------------
+
+/// mirLowerFinishNoReturn emits the fall-through epilogue: run all
+/// defers, then terminate with Return (unit-returning fns) or
+/// Unreachable (non-unit fns whose body fell through — the checker
+/// already forbids this so the terminator is defensive poison).
+pub fn mirLowerFinishNoReturn(bs: MirLowerBodyState, span: MirSpan) {
+    let bb = mirLowerCurrentBlock(bs)
+    if bb.hasTerm {
+        return
+    }
+    mirLowerRunDefers(bs, span)
+    if hirTypeIsUnit(bs.retType) || hirTypeIsNever(bs.retType) {
+        mirLowerTerminate(bs, mirReturnTerm(span))
+    } else {
+        mirLowerTerminate(bs, mirUnreachableTerm(span))
+    }
+}
+
+// ====================================================================
+// Expression lowering stubs (Stage 4b)
+// ====================================================================
+//
+// Real expression lowering lands in Stage 4d. For now, every
+// operand/place/into path emits a conservative placeholder (unit
+// const operand, no-op Into) and records a one-shot issue so the
+// output module flags the shape the caller tried to lower. Once 4d
+// lands, these stubs get replaced with a full operand/place/rvalue
+// dispatcher driven by HirExprKind.
+
+/// mirLowerExprAsOperand is the placeholder operand producer. Every
+/// call currently returns a unit-const operand and notes a
+/// "Stage 4d TODO" issue with the expression kind that was asked.
+///
+/// When `e` is already the invalid default (HirExprInvalid) no issue
+/// is emitted — this is the "nothing to lower" path used by bare
+/// returns and similar.
+pub fn mirLowerExprAsOperand(bs: MirLowerBodyState, e: HirExpr) -> MirOperand {
+    if !hirExprIsValid(e) {
+        return mirOperandConst(mirConstUnit())
+    }
+    mirLowerNoteIssue(
+        bs.l,
+        "mir_lower Stage 4d TODO: expr kind " + hirExprKindName(e.kind)
+            + " — returning unit-const placeholder operand",
+    )
+    mirOperandConst(mirConstUnit())
+}
+
+/// mirLowerExprInto is the placeholder "lower into dest local"
+/// routine. Stage 4d wires the full RValue-producing dispatcher;
+/// Stage 4b emits a conservative Assign of unit-const into `dest`
+/// and records an issue.
+pub fn mirLowerExprInto(
+    bs: MirLowerBodyState,
+    e: HirExpr,
+    dest: Int,
+    destT: HirType,
+) {
+    if !hirExprIsValid(e) {
+        return
+    }
+    mirLowerNoteIssue(
+        bs.l,
+        "mir_lower Stage 4d TODO: expr kind " + hirExprKindName(e.kind)
+            + " — emitting unit-const Assign into dest",
+    )
+    let destPlace = mirPlace(dest)
+    let rv = mirRVUse(mirOperandConst(mirConstUnit()))
+    let instr = mirAssignInstr(destPlace, rv, mirSpanFromHir(e.span))
+    let _ = destT
+    mirLowerEmitInstr(bs, instr)
+}
+
+// ====================================================================
+// Statement lowering (Stage 4b)
+// ====================================================================
+
+/// mirLowerStmt dispatches on HirStmtKind and routes to the
+/// appropriate handler. Kinds not yet covered by Stage 4b/4c record
+/// a `"Stage 4c TODO: <kind>"` issue and fall through without
+/// emitting instructions.
+pub fn mirLowerStmt(bs: MirLowerBodyState, s: HirStmt) {
+    match s.kind {
+        HirStmtInvalid -> {},
+        HirStmtBlock -> mirLowerBlockStmt(bs, s.block),
+        HirStmtLet -> mirLowerLetStmt(bs, s),
+        HirStmtExpr -> mirLowerExprStmtInner(bs, s),
+        HirStmtReturn -> mirLowerReturnStmt(bs, s),
+        HirStmtBreak -> mirLowerBreakStmt(bs, s),
+        HirStmtContinue -> mirLowerContinueStmt(bs, s),
+        HirStmtDefer -> mirLowerAddDefer(bs, s.deferBody),
+        HirStmtError -> mirLowerNoteIssue(
+            bs.l,
+            "mir_lower: error stmt reached MIR: " + s.errorNote,
+        ),
+        HirStmtAssign -> mirLowerNoteIssue(
+            bs.l,
+            "mir_lower Stage 4c TODO: HirStmtAssign — skipped",
+        ),
+        HirStmtIf -> mirLowerNoteIssue(
+            bs.l,
+            "mir_lower Stage 4c TODO: HirStmtIf — skipped",
+        ),
+        HirStmtFor -> mirLowerNoteIssue(
+            bs.l,
+            "mir_lower Stage 4c TODO: HirStmtFor — skipped",
+        ),
+        HirStmtMatch -> mirLowerNoteIssue(
+            bs.l,
+            "mir_lower Stage 4c TODO: HirStmtMatch — skipped",
+        ),
+        HirStmtChanSend -> mirLowerNoteIssue(
+            bs.l,
+            "mir_lower Stage 4e TODO: HirStmtChanSend — skipped",
+        ),
+    }
+}
+
+/// mirLowerBlockStmt lowers a block used in statement position
+/// (e.g. a bare `{ ... }` scope). Pushes a scope + defer frame,
+/// lowers each inner stmt, runs the top defer frame on fall-through,
+/// then pops both frames.
+pub fn mirLowerBlockStmt(bs: MirLowerBodyState, b: HirBlock) {
+    mirLowerPushScope(bs)
+    mirLowerPushDeferScope(bs)
+    for s in b.stmts {
+        mirLowerStmt(bs, s)
+    }
+    if b.hasResult {
+        // Block used in statement position — discard the value but
+        // still run the expression's side effects.
+        let _ = mirLowerExprAsOperand(bs, b.result)
+    }
+    mirLowerReplayTopFrame(bs, mirSpanFromHir(b.span))
+    mirLowerPopDeferScope(bs)
+    mirLowerPopScope(bs)
+}
+
+/// mirLowerLetStmt handles `let NAME [: T] = value` + `let mut ...`.
+/// Destructuring-pattern lets are deferred to Stage 4c.
+pub fn mirLowerLetStmt(bs: MirLowerBodyState, s: HirStmt) {
+    // Pick the binding type: declared → value-type → ErrType fallback.
+    let mut t = s.letTyp
+    if !hirTypeIsValid(t) && s.letHasValue {
+        t = s.letValue.typ
+    }
+    if !hirTypeIsValid(t) {
+        t = hirTypeErr()
+    }
+    let span = mirSpanFromHir(s.span)
+    if s.letHasPattern {
+        mirLowerNoteIssue(
+            bs.l,
+            "mir_lower Stage 4c TODO: destructuring let — pattern kind "
+                + hirPatternKindName(s.letPattern.kind),
+        )
+        return
+    }
+    if s.letName == "" {
+        mirLowerNoteIssue(bs.l, "mir_lower: let stmt with neither name nor pattern")
+        return
+    }
+    let id = mirLowerNewLocal(bs, s.letName, t, s.letMut, span)
+    mirLowerEmitInstr(bs, mirStorageLiveInstr(id, span))
+    if s.letHasValue {
+        mirLowerExprInto(bs, s.letValue, id, t)
+    }
+    mirLowerBindName(bs, s.letName, id)
+}
+
+/// mirLowerExprStmtInner handles expressions used as statements. The
+/// value is discarded; side effects survive via operand lowering.
+pub fn mirLowerExprStmtInner(bs: MirLowerBodyState, s: HirStmt) {
+    let _ = mirLowerExprAsOperand(bs, s.exprValue)
+}
+
+/// mirLowerReturnStmt lowers `return` / `return value`. Values are
+/// lowered into the function's return slot; bare returns skip the
+/// value-lowering step. Defers always run before the terminator.
+pub fn mirLowerReturnStmt(bs: MirLowerBodyState, s: HirStmt) {
+    let span = mirSpanFromHir(s.span)
+    if s.returnHasValue {
+        mirLowerExprInto(bs, s.returnValue, bs.fn_.returnLocal, bs.retType)
+    }
+    mirLowerRunDefers(bs, span)
+    mirLowerTerminate(bs, mirReturnTerm(span))
+}
+
+/// mirLowerBreakStmt lowers `break` inside a loop. Replays defer
+/// frames owned by the loop body, retires loop-body locals, then
+/// jumps to the recorded break block. Records an issue when invoked
+/// outside any loop.
+pub fn mirLowerBreakStmt(bs: MirLowerBodyState, s: HirStmt) {
+    if bs.loopStack.len() == 0 {
+        mirLowerNoteIssue(bs.l, "mir_lower: break outside loop")
+        return
+    }
+    let span = mirSpanFromHir(s.span)
+    let top = bs.loopStack[bs.loopStack.len() - 1]
+    mirLowerReplayDefersFromDepth(bs, top.deferDepth, span)
+    mirLowerEmitStorageDeadFromDepth(bs, top.scopeDepth)
+    mirLowerTerminate(bs, mirGotoTerm(top.breakBlock, span))
+}
+
+pub fn mirLowerContinueStmt(bs: MirLowerBodyState, s: HirStmt) {
+    if bs.loopStack.len() == 0 {
+        mirLowerNoteIssue(bs.l, "mir_lower: continue outside loop")
+        return
+    }
+    let span = mirSpanFromHir(s.span)
+    let top = bs.loopStack[bs.loopStack.len() - 1]
+    mirLowerReplayDefersFromDepth(bs, top.deferDepth, span)
+    mirLowerEmitStorageDeadFromDepth(bs, top.scopeDepth)
+    mirLowerTerminate(bs, mirGotoTerm(top.continueBlock, span))
 }


### PR DESCRIPTION
## Summary

Follow-up to [#673](https://github.com/choiceoh/osty/pull/673) (Stage 4a — lowerer shell). Adds the per-function body state + simple-statement dispatcher so `mirLowerFunction` no longer terminates every function with a raw `Unreachable`. Real expression lowering is still stubbed — that's Stage 4d — but the control-flow infrastructure (scopes, defers, cursors, break/continue targets) is now in place.

File growth: [toolchain/mir_lower.osty](toolchain/mir_lower.osty) 915 → 1630 lines (+718).

## What's included

### Body state

- `MirLowerBodyState` — cursor + scopes + loop stack + defer frames + paramLocals + self context + return type
- `mirLowerBodyState` constructor — seeds function-level scope + defer frame, re-indexes parameter locals (already minted by `mirLowerSeedFunction`)

### Scope infrastructure

`mirLowerPushScope` / `PopScope` / `BindName` / `LookupName` / `RegisterScopeLocal` / `CurrentScopeDepth` / `EmitStorageDeadFromDepth` / `EmitStorageDeadForScope` / `NewLocal`. Parallel `List<String>` + `List<Int>` arrays for name → local-id lookup (avoids the Map intrinsic codegen gap).

### Cursor + block helpers

`mirLowerCurrentBlock`, `EmitInstr` (with the post-terminator orphan-block escape hatch matching Go), `Terminate`, `SwitchTo`, `NewBlock`, `GotoBlock`.

### Defer infrastructure

`PushDeferScope` / `PopDeferScope` / `AddDefer` / `ReplayTopFrame` / `ReplayDefersFromDepth` / `ReplayDeferFrame` (recurses into bodies in their own pushed scope) / `RunDefers` / `CurrentDeferDepth`.

### Statement dispatch

`mirLowerStmt` routes on `HirStmtKind`:

| Kind | Behaviour |
|---|---|
| Block | push scope + defer, lower children, replay top defer, pop both |
| Let | mints local, emits StorageLive, delegates RHS to expr stub, binds name. Destructuring-pattern lets → Stage 4c TODO |
| ExprStmt | discards via expr stub (side effects only) |
| Return | lowers value into return slot (stub), runs all defers, terminates Return |
| Break / Continue | replays inner defers, emits StorageDead, Goto target. Outside-loop diagnostic |
| Defer | appends body to top defer frame |
| Error | reports note via noteIssue |
| Assign / If / For / Match / ChanSend | Stage 4c/4e TODO issue |

### Expression stubs

`mirLowerExprAsOperand` / `mirLowerExprInto` return unit-const / emit unit-const `Assign` into dest. Every call notes a `"Stage 4d TODO: expr kind <kind>"` issue so a test corpus can enumerate every shape the caller tried to lower. Invalid-default `HirExpr` values are a no-op (bare returns, empty defer bodies).

### Wiring

- `mirLowerFunction` now calls `mirLowerFunctionBody` for real bodies. Trailing-expression form lowers into the return slot + emits `Return`; fall-through form emits `Return` for unit/never returns, `Unreachable` otherwise
- `mirLowerEmitScript` routes the script through a synthetic `main()`'s body state
- `mirLowerGlobal` emits a real `_init_<name>` body (stub → `Return`)

## Verification

- `osty parse toolchain/mir_lower.osty` → exit 0
- `osty check toolchain/mir_lower.osty` → zero mir_lower.osty errors

The output MIR is now structurally well-formed (every block terminated, locals typed, scopes StorageDead cleanly) but all RValue bodies are unit-const placeholders. The issue list on the output MirModule captures every Stage 4c/4d/4e gap a test corpus can exercise.

## What's left

- **Stage 4c**: control flow (If / For / Match / Defer-body expr dispatch)
- **Stage 4d**: real expression lowering into Place / Operand / RValue (replaces the unit-const stubs)
- **Stage 4e**: concurrency intrinsics + stdlib dispatch + closures
- **Stage 4f**: projection walk + variant / struct layout lookup

## Test plan

- [x] `osty parse` / `osty check` pass
- [ ] Stage 4d will exercise this dispatcher by producing real RValues and checking emitted MIR against `mir.Validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)