### PR TITLE
feat(mir+gen): StringJoin intrinsic + ListPop + mid-chain IndexProj write

### DIFF
--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1052,7 +1052,8 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 	case mir.IntrinsicPrintln, mir.IntrinsicPrint:
 		return true
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
-		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet:
+		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
+		mir.IntrinsicListPop:
 		return true
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
@@ -1072,7 +1073,8 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
-		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit:
+		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
+		mir.IntrinsicStringJoin:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -2070,13 +2072,11 @@ func (g *mirGen) emitStorageDead(dead *mir.StorageDeadInstr) error {
 	return nil
 }
 
-// emitIndexedWrite lowers a single-IndexProj AssignInstr — the
-// `xs[i] = v` / `m[k] = v` shape. Routes through the runtime list /
-// map setter so the heap representation stays in sync with what the
-// typed reads expect. Called from emitAssign when Dest has exactly
-// one projection and it's an IndexProj; anything more complex still
-// falls through to the aggregate-insertvalue path (which doesn't yet
-// support IndexProj in the middle of a chain).
+// emitIndexedWrite lowers an AssignInstr whose Dest projection chain
+// ends in an IndexProj — `xs[i] = v` / `m[k] = v` / `env.field[i] = v`.
+// The chain up to (but not including) the final IndexProj is walked
+// with extractvalue to reach the container pointer. The IndexProj
+// itself dispatches to the list / map runtime setter.
 func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mir.IndexProj) error {
 	localT := destLoc.Type
 	slot := g.localSlots[a.Dest.Local]
@@ -2089,6 +2089,41 @@ func (g *mirGen) emitIndexedWrite(a *mir.AssignInstr, destLoc *mir.Local, ip *mi
 	g.fnBuf.WriteString(", ptr ")
 	g.fnBuf.WriteString(slot)
 	g.fnBuf.WriteByte('\n')
+
+	// Walk field/tuple/variant projections preceding the final
+	// IndexProj, extractvalue-ing into the next aggregate each step.
+	// This lets `env.fnIndexValues[slot] = v` reach the List<Int>
+	// pointer stored inside env (CheckEnv struct) before handing off
+	// to the list-set runtime.
+	projs := a.Dest.Projections
+	containerT := localT
+	containerLLVM := localLLVM
+	for i := 0; i < len(projs)-1; i++ {
+		idx, ok := projectionIndex(projs[i])
+		if !ok {
+			return unsupported("mir-mvp", fmt.Sprintf("indexed write preceding projection %T not yet supported in %s", projs[i], g.fn.Name))
+		}
+		nextT := projectionType(projs[i])
+		if nextT == nil {
+			return unsupported("mir-mvp", "indexed write preceding projection missing type")
+		}
+		nextLLVM := g.llvmType(nextT)
+		next := g.fresh()
+		g.fnBuf.WriteString("  ")
+		g.fnBuf.WriteString(next)
+		g.fnBuf.WriteString(" = extractvalue ")
+		g.fnBuf.WriteString(containerLLVM)
+		g.fnBuf.WriteByte(' ')
+		g.fnBuf.WriteString(contReg)
+		g.fnBuf.WriteString(", ")
+		g.fnBuf.WriteString(fmt.Sprint(idx))
+		g.fnBuf.WriteByte('\n')
+		contReg = next
+		containerLLVM = nextLLVM
+		containerT = nextT
+	}
+	localT = containerT
+	_ = containerLLVM
 
 	elemT := ip.ElemType
 	if elemT == nil {
@@ -2199,15 +2234,16 @@ func (g *mirGen) emitAssign(a *mir.AssignInstr) error {
 		g.fnBuf.WriteByte('\n')
 		return nil
 	}
-	// Single-IndexProj write (`xs[i] = v`, `m[k] = v`) — route to the
-	// runtime setter. This is the common shape used by Osty's
-	// list-rebuild / map-update patterns (e.g. `xs[i] = T { ..old, ...
-	// }` from CLAUDE.md's for-loop copy rule). Multi-projection writes
-	// with an IndexProj in the middle still fall through to the
-	// aggregate-insertvalue path below, which currently rejects IndexProj
-	// mid-chain.
-	if len(a.Dest.Projections) == 1 {
-		if ip, ok := a.Dest.Projections[0].(*mir.IndexProj); ok {
+	// IndexProj-tail write (`xs[i] = v`, `m[k] = v`, or a struct-field
+	// chain ending in an index like `env.fnIndexValues[slot] = v`) —
+	// route to the runtime setter. The chain up to (but not including)
+	// the final IndexProj extracts a container pointer out of the
+	// local; the final IndexProj delegates to the list / map write.
+	// Anything with an IndexProj *before* the last position still
+	// falls through to the aggregate-insertvalue rebuild below, which
+	// rejects IndexProj mid-chain.
+	if projs := a.Dest.Projections; len(projs) > 0 {
+		if ip, ok := projs[len(projs)-1].(*mir.IndexProj); ok {
 			return g.emitIndexedWrite(a, destLoc, ip)
 		}
 	}
@@ -2250,7 +2286,7 @@ func (g *mirGen) emitAssign(a *mir.AssignInstr) error {
 	for i, proj := range projs {
 		idx, ok := projectionIndex(proj)
 		if !ok {
-			return unsupported("mir-mvp", fmt.Sprintf("projection %T on write", proj))
+			return unsupported("mir-mvp", fmt.Sprintf("projection %T on write in %s (projs=%d, pos=%d)", proj, g.fn.Name, len(projs), i))
 		}
 		nextT := projectionType(proj)
 		if nextT == nil {
@@ -2538,7 +2574,8 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		}
 		return g.emitPrintlnLike(i.Args[0], i.Kind == mir.IntrinsicPrintln)
 	case mir.IntrinsicListPush, mir.IntrinsicListLen, mir.IntrinsicListGet,
-		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet:
+		mir.IntrinsicListIsEmpty, mir.IntrinsicListSorted, mir.IntrinsicListToSet,
+		mir.IntrinsicListPop:
 		return g.emitListIntrinsic(i)
 	case mir.IntrinsicMapNew, mir.IntrinsicMapGet, mir.IntrinsicMapSet,
 		mir.IntrinsicMapContains, mir.IntrinsicMapLen, mir.IntrinsicMapKeys,
@@ -2554,7 +2591,8 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicStringToUpper, mir.IntrinsicStringToLower,
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
-		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit:
+		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
+		mir.IntrinsicStringJoin:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
@@ -2670,6 +2708,36 @@ func (g *mirGen) emitListIntrinsic(i *mir.IntrinsicInstr) error {
 		result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: listReg}})
 		g.flushOstyEmitter(em)
 		return g.storeIntrinsicResult(i, result)
+	case mir.IntrinsicListPop:
+		// Runtime exposes `osty_rt_list_pop_discard` — drops the last
+		// element without returning it. All toolchain uses of
+		// `xs.pop()` currently discard the result (`let _ = xs.pop()`
+		// or bare-statement form), so the dest gets a zero-initialized
+		// Option<T> placeholder. A future typed-pop runtime family can
+		// replace this with real Some(T) returns.
+		sym := "osty_rt_list_pop_discard"
+		g.declareRuntime(sym, "declare void @"+sym+"(ptr)")
+		g.fnBuf.WriteString("  call void @")
+		g.fnBuf.WriteString(sym)
+		g.fnBuf.WriteString("(ptr ")
+		g.fnBuf.WriteString(listReg)
+		g.fnBuf.WriteString(")\n")
+		if i.Dest == nil {
+			return nil
+		}
+		// Zero-init the dest (None for Option<T>).
+		destLoc := g.fn.Local(i.Dest.Local)
+		if destLoc == nil {
+			return nil
+		}
+		destLLVM := g.llvmType(destLoc.Type)
+		destSlot := g.localSlots[i.Dest.Local]
+		g.fnBuf.WriteString("  store ")
+		g.fnBuf.WriteString(destLLVM)
+		g.fnBuf.WriteString(" zeroinitializer, ptr ")
+		g.fnBuf.WriteString(destSlot)
+		g.fnBuf.WriteByte('\n')
+		return nil
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("list intrinsic kind %d", i.Kind))
 }
@@ -3738,8 +3806,39 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitStringBinaryBoolIntrinsic(i, strReg, llvmStringRuntimeContainsSymbol())
 	case mir.IntrinsicStringSplit:
 		return g.emitStringSplit(i, strReg)
+	case mir.IntrinsicStringJoin:
+		// `strReg` was evaluated above as Args[0] — for join this is
+		// the List<String> parts pointer, not a String. Both map to
+		// LLVM `ptr`, so the evalOperand call we already did is the
+		// right shape — just pass it on to the runtime with the
+		// separator arg.
+		return g.emitStringJoin(i, strReg)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
+}
+
+// emitStringJoin emits `strings.join(parts, sep)` / `parts.join(sep)`
+// as a call to `osty_rt_strings_Join(ptr parts, ptr sep) -> ptr`.
+// Args: [parts List<String>, sep String]. Runtime signature mirrors
+// what the legacy Go-backend emitter calls.
+func (g *mirGen) emitStringJoin(i *mir.IntrinsicInstr, partsReg string) error {
+	if len(i.Args) < 2 {
+		return unsupported("mir-mvp", "string_join without sep arg")
+	}
+	sep := i.Args[1]
+	if !isStringLLVMType(sep.Type()) {
+		return unsupported("mir-mvp", fmt.Sprintf("string_join sep type %s", mirTypeString(sep.Type())))
+	}
+	sepReg, err := g.evalOperand(sep, sep.Type())
+	if err != nil {
+		return err
+	}
+	sym := llvmStringRuntimeJoinSymbol()
+	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, ptr)")
+	em := g.ostyEmitter()
+	result := llvmCall(em, "ptr", sym, []*LlvmValue{{typ: "ptr", name: partsReg}, {typ: "ptr", name: sepReg}})
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, result)
 }
 
 // emitStringConcatBoxed converts a non-String operand into a String

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3157,6 +3157,8 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 		switch name {
 		case "push":
 			return IntrinsicListPush
+		case "pop":
+			return IntrinsicListPop
 		case "len":
 			return IntrinsicListLen
 		case "get":
@@ -3263,6 +3265,8 @@ func stringIntrinsicForMethod(name string) IntrinsicKind {
 		return IntrinsicStringIndexOf
 	case "split":
 		return IntrinsicStringSplit
+	case "join":
+		return IntrinsicStringJoin
 	case "trim":
 		return IntrinsicStringTrim
 	case "toUpper":
@@ -3361,6 +3365,8 @@ func stdlibStringFreeFnToIntrinsic(qualifier, name string) IntrinsicKind {
 		return IntrinsicStringIndexOf
 	case "split":
 		return IntrinsicStringSplit
+	case "join":
+		return IntrinsicStringJoin
 	case "trim":
 		return IntrinsicStringTrim
 	case "toUpper":

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -628,6 +628,28 @@ const (
 	// IntrinsicRawNull returns the null RawPtr. Args: [].
 	// Lowers to `inttoptr i64 0 to ptr` (or `ptr null`).
 	IntrinsicRawNull
+
+	// ---- deferred String family ----
+	//
+	// Appended after the enum's historical tail so pre-existing
+	// kinds keep their numeric value (tests + telemetry that log
+	// "kind=NN" stay meaningful).
+
+	// IntrinsicStringJoin returns a single String built by
+	// concatenating parts with the separator between each adjacent
+	// pair. Args: [parts List<String>, sep String]. Mirrors the
+	// `std.strings.Join(parts, sep)` / `parts.join(sep)` surface.
+	IntrinsicStringJoin
+
+	// IntrinsicListPop discards the last element of a List and
+	// returns an Option<T> that is always None in the current
+	// lowering. Args: [list]. The native LLVM emitter routes this
+	// to `osty_rt_list_pop_discard` which aborts on empty; callers
+	// in toolchain source either ignore the result (`let _ = xs.pop()`)
+	// or immediately pattern-match on None, so losing the popped
+	// value is acceptable until a typed `osty_rt_list_pop_<suffix>`
+	// runtime family arrives.
+	IntrinsicListPop
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do
@@ -1560,6 +1582,10 @@ func (k IntrinsicKind) String() string {
 		return "result_unwrap_or"
 	case IntrinsicRawNull:
 		return "raw_null"
+	case IntrinsicStringJoin:
+		return "string_join"
+	case IntrinsicListPop:
+		return "list_pop"
 	}
 	return "invalid"
 }


### PR DESCRIPTION
## Summary

Three compounded MIR advances knock down four walls in the native-merged toolchain probe. Pattern: add missing intrinsic kinds, wire them through method-call and free-fn dispatch, emit the runtime ABI calls, and extend the write-side projection walker so container-typed struct fields can receive indexed writes.

## What changed

### `internal/mir/mir.go` — new intrinsic kinds

Appended at the enum tail so pre-existing numeric values stay stable (tests + telemetry that log `kind=NN` keep meaning what they did).

- **`IntrinsicStringJoin`** — `parts.join(sep)` / `strings.join(parts, sep)`. Args: `[List<String>, String]`, Dest: `String`.
- **`IntrinsicListPop`** — `xs.pop()`. Args: `[List<T>]`, Dest: `T?`. Runtime currently only exposes `osty_rt_list_pop_discard` so the dest is zero-initialized (None for `Option<T>`). All toolchain uses of `.pop()` discard the result (`let _ = xs.pop()` or bare-statement form); a typed-pop runtime family is a follow-up.

### `internal/mir/lower.go` — dispatch

- `stringIntrinsicForMethod(\"join\")` → `IntrinsicStringJoin` so `parts.join(sep)` routes to the same runtime as the free-fn form.
- `stdlibStringFreeFnToIntrinsic` adds `join` too — `std.strings.join(parts, sep)` hits the same intrinsic.
- `List.pop` method → `IntrinsicListPop`.

### `internal/llvmgen/mir_generator.go` — emission + projection walker

- **`emitStringJoin`** emits `osty_rt_strings_Join(ptr parts, ptr sep)`. Reuses the receiver-evaluated-as-ptr pattern from `emitStringIntrinsic`; List and String both map to LLVM `ptr`.
- **`emitListIntrinsic`'s ListPop case** calls `osty_rt_list_pop_discard(list)` then zero-inits the dest slot (Option<T> → None). Comment documents the toolchain-is-fine assumption and flags the typed-pop follow-up.
- **`emitIndexedWrite`** now walks preceding projections via `extractvalue` before dispatching to the list / map write. This handles `env.fnIndexValues[slot] = v` — the 2-projection shape (`FieldProj` + `IndexProj`) that the `check_env` table-update emits. Anything non-IndexProj-terminal still falls back to the legacy aggregate rebuild.

## Probe progression

| State | First wall |
|---|---|
| Before (#675 merged) | `call to unresolved symbol std.strings.join` |
| After StringJoin | `call to unresolved symbol List__pop` |
| After ListPop | `projection *mir.IndexProj on write` (shape with preceding FieldProj) |
| After projection walker | `call to unresolved symbol toInt` (different category — builtin method routing gap) |

Whole-toolchain + native-toolchain AST probes remain CLEAN.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/ir/... ./internal/mir/... ./internal/check/...` all green
- [x] `internal/llvmgen` shows 2 pre-existing failures (`TestGenerateModulePtrBackedListToSetAndBoolPrint`, `TestGenerateModuleBuiltinResultConstructorsTrackLocalContext`) that reproduce on main — `git stash` verified

## Notes for reviewers

- The ListPop scheme intentionally trades correctness of the returned Option for a clean MIR path. Every current toolchain call site discards the popped value, so None-filling is invisible. If a downstream caller ever starts actually inspecting the pop result, the zero-init is a semantic bug that should be replaced by typed-pop runtimes (`osty_rt_list_pop_i64`, etc.) — noted in the inline comment.
- `emitIndexedWrite`'s new preceding-projection walk only handles field/tuple/variant projections (anything with a static index). An IndexProj in the middle of a chain (e.g. `a[i].b = v`) would need both a runtime read and a runtime write; intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)