### PR TITLE
feat(mir+gen): String.substring intrinsic + Byte/Char.toInt widening

### DIFF
--- a/internal/ir/lower.go
+++ b/internal/ir/lower.go
@@ -1953,6 +1953,19 @@ func recoverMethodReturnType(name string, recv Expr) Type {
 		if isPrim(rt, PrimString) {
 			return TString
 		}
+	case "substring", "slice", "replace", "repeat":
+		if isPrim(rt, PrimString) {
+			return TString
+		}
+	case "split":
+		if isPrim(rt, PrimString) {
+			return &NamedType{Name: "List", Builtin: true, Args: []Type{TString}}
+		}
+	case "join":
+		// `parts.join(sep)` on List<String> returns String.
+		if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" {
+			return TString
+		}
 	}
 	// Element-type returns: List<T>.first / .last / .get → T?, .push → Unit.
 	if nt, ok := rt.(*NamedType); ok && nt.Builtin && nt.Name == "List" && len(nt.Args) == 1 {

--- a/internal/llvmgen/mir_generator.go
+++ b/internal/llvmgen/mir_generator.go
@@ -1074,7 +1074,7 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
-		mir.IntrinsicStringJoin:
+		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return true
 	// Concurrency — channels / tasks / select / cancellation / helpers.
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
@@ -1093,6 +1093,10 @@ func isSupportedIntrinsic(k mir.IntrinsicKind) bool {
 		return true
 	// LANG_SPEC §19 runtime sublanguage.
 	case mir.IntrinsicRawNull:
+		return true
+	// Numeric widening from sub-word primitives to Int. Lowered as
+	// LLVM zext — no runtime call needed.
+	case mir.IntrinsicByteToInt, mir.IntrinsicCharToInt:
 		return true
 	}
 	return false
@@ -2592,7 +2596,7 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		mir.IntrinsicStringToInt, mir.IntrinsicStringToFloat,
 		mir.IntrinsicStringContains, mir.IntrinsicStringStartsWith,
 		mir.IntrinsicStringEndsWith, mir.IntrinsicStringSplit,
-		mir.IntrinsicStringJoin:
+		mir.IntrinsicStringJoin, mir.IntrinsicStringSubstring:
 		return g.emitStringIntrinsic(i)
 	case mir.IntrinsicChanMake, mir.IntrinsicChanSend, mir.IntrinsicChanRecv,
 		mir.IntrinsicChanClose, mir.IntrinsicChanIsClosed:
@@ -2610,8 +2614,38 @@ func (g *mirGen) emitIntrinsic(i *mir.IntrinsicInstr) error {
 		return g.emitConcurrencyHelperIntrinsic(i)
 	case mir.IntrinsicRawNull:
 		return g.emitRuntimeRawNull(i)
+	case mir.IntrinsicByteToInt:
+		return g.emitIntegerWidenIntrinsic(i, "i8", "i64")
+	case mir.IntrinsicCharToInt:
+		return g.emitIntegerWidenIntrinsic(i, "i32", "i64")
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("intrinsic %s", mirIntrinsicLabel(i.Kind)))
+}
+
+// emitIntegerWidenIntrinsic emits a `zext` from the source-width type
+// to the destination-width type. Used for `Byte.toInt()` and
+// `Char.toInt()` — lossless widening to i64 without any runtime
+// helper. Stores the result into the intrinsic's Dest if present.
+func (g *mirGen) emitIntegerWidenIntrinsic(i *mir.IntrinsicInstr, fromLLVM, toLLVM string) error {
+	if len(i.Args) < 1 {
+		return unsupported("mir-mvp", fmt.Sprintf("%s with no arg", mirIntrinsicLabel(i.Kind)))
+	}
+	arg := i.Args[0]
+	reg, err := g.evalOperand(arg, arg.Type())
+	if err != nil {
+		return err
+	}
+	next := g.fresh()
+	g.fnBuf.WriteString("  ")
+	g.fnBuf.WriteString(next)
+	g.fnBuf.WriteString(" = zext ")
+	g.fnBuf.WriteString(fromLLVM)
+	g.fnBuf.WriteByte(' ')
+	g.fnBuf.WriteString(reg)
+	g.fnBuf.WriteString(" to ")
+	g.fnBuf.WriteString(toLLVM)
+	g.fnBuf.WriteByte('\n')
+	return g.storeIntrinsicResult(i, &LlvmValue{typ: toLLVM, name: next})
 }
 
 // ==== list / map / set intrinsics ====
@@ -3813,8 +3847,39 @@ func (g *mirGen) emitStringIntrinsic(i *mir.IntrinsicInstr) error {
 		// right shape — just pass it on to the runtime with the
 		// separator arg.
 		return g.emitStringJoin(i, strReg)
+	case mir.IntrinsicStringSubstring:
+		return g.emitStringSubstring(i, strReg)
 	}
 	return unsupported("mir-mvp", fmt.Sprintf("string intrinsic kind %d", i.Kind))
+}
+
+// emitStringSubstring emits `s.substring(start, end)` / `s[a..b]`
+// (when s is String) as a call to
+// `osty_rt_strings_Slice(ptr s, i64 start, i64 end) -> ptr`. Args:
+// [s, start, end]. start/end are byte offsets; the runtime handles
+// clamping and allocation of a fresh managed String.
+func (g *mirGen) emitStringSubstring(i *mir.IntrinsicInstr, strReg string) error {
+	if len(i.Args) < 3 {
+		return unsupported("mir-mvp", "string_substring arity")
+	}
+	startReg, err := g.evalOperand(i.Args[1], mir.TInt)
+	if err != nil {
+		return err
+	}
+	endReg, err := g.evalOperand(i.Args[2], mir.TInt)
+	if err != nil {
+		return err
+	}
+	sym := "osty_rt_strings_Slice"
+	g.declareRuntime(sym, "declare ptr @"+sym+"(ptr, i64, i64)")
+	em := g.ostyEmitter()
+	result := llvmCall(em, "ptr", sym, []*LlvmValue{
+		{typ: "ptr", name: strReg},
+		{typ: "i64", name: startReg},
+		{typ: "i64", name: endReg},
+	})
+	g.flushOstyEmitter(em)
+	return g.storeIntrinsicResult(i, result)
 }
 
 // emitStringJoin emits `strings.join(parts, sep)` / `parts.join(sep)`

--- a/internal/mir/lower.go
+++ b/internal/mir/lower.go
@@ -3149,6 +3149,14 @@ func stdlibIntrinsicForMethod(receiverType Type, name string) IntrinsicKind {
 			return stringIntrinsicForMethod(name)
 		case ir.PrimBytes:
 			return bytesIntrinsicForMethod(name)
+		case ir.PrimByte:
+			if name == "toInt" {
+				return IntrinsicByteToInt
+			}
+		case ir.PrimChar:
+			if name == "toInt" {
+				return IntrinsicCharToInt
+			}
 		}
 		return IntrinsicInvalid
 	}
@@ -3267,6 +3275,8 @@ func stringIntrinsicForMethod(name string) IntrinsicKind {
 		return IntrinsicStringSplit
 	case "join":
 		return IntrinsicStringJoin
+	case "substring", "slice":
+		return IntrinsicStringSubstring
 	case "trim":
 		return IntrinsicStringTrim
 	case "toUpper":
@@ -3367,6 +3377,8 @@ func stdlibStringFreeFnToIntrinsic(qualifier, name string) IntrinsicKind {
 		return IntrinsicStringSplit
 	case "join":
 		return IntrinsicStringJoin
+	case "substring", "slice":
+		return IntrinsicStringSubstring
 	case "trim":
 		return IntrinsicStringTrim
 	case "toUpper":

--- a/internal/mir/mir.go
+++ b/internal/mir/mir.go
@@ -650,6 +650,25 @@ const (
 	// value is acceptable until a typed `osty_rt_list_pop_<suffix>`
 	// runtime family arrives.
 	IntrinsicListPop
+
+	// IntrinsicStringSubstring returns the byte-level slice
+	// `s[start..end]`. Args: [s, start, end]. Routed by both the
+	// `.substring(a, b)` method-call form and the `s[a..b]` slice
+	// sugar when the base is String.
+	IntrinsicStringSubstring
+
+	// IntrinsicByteToInt widens a Byte value (i8) to Int (i64).
+	// Args: [byte]. Used for `.toInt()` method calls on Byte —
+	// `b.toInt()` in toolchain sources pulls a byte into arithmetic
+	// context (hash folds, pack/unpack helpers). Lowers to a plain
+	// `zext i8 to i64` at the LLVM level, no runtime call.
+	IntrinsicByteToInt
+
+	// IntrinsicCharToInt widens a Char value (i32) to Int (i64).
+	// Args: [char]. Used for `.toInt()` method calls on Char to
+	// get the code point in numeric context. Lowers to
+	// `zext i32 to i64`.
+	IntrinsicCharToInt
 )
 
 // StorageLiveInstr marks a local as alive. Optional; backends that do
@@ -1586,6 +1605,12 @@ func (k IntrinsicKind) String() string {
 		return "string_join"
 	case IntrinsicListPop:
 		return "list_pop"
+	case IntrinsicStringSubstring:
+		return "string_substring"
+	case IntrinsicByteToInt:
+		return "byte_to_int"
+	case IntrinsicCharToInt:
+		return "char_to_int"
 	}
 	return "invalid"
 }


### PR DESCRIPTION
## Summary

Advances the native-merged MIR probe past two walls:

1. **`unsupported local type <error> ... written by call substring`** in `mirLowerStripSign` — `text.substring(1, text.len())` wasn't routed to any intrinsic, so MIR emitted a mangled-symbol call whose return type leaked as ErrType.
2. **`call to unresolved symbol toInt`** on Byte/Char receivers — `b.toInt()` / `ch.toInt()` (hash folds, lsp code-point checks, hex byte rendering) hit the generic symbol-mangling path because the MIR dispatch only covered String/Bytes primitives.

## What changed

### `internal/mir/mir.go` — three new intrinsic kinds (appended at enum tail)

- `IntrinsicStringSubstring` — `s.substring(start, end)` / `s[a..b]` on String. Emits `osty_rt_strings_Slice(ptr, i64, i64) -> ptr`.
- `IntrinsicByteToInt` — `b.toInt()` on Byte. Emits `zext i8 to i64`.
- `IntrinsicCharToInt` — `ch.toInt()` on Char. Emits `zext i32 to i64`.

### `internal/mir/lower.go` — method dispatch

- `stringIntrinsicForMethod(\"substring\" | \"slice\")` → `IntrinsicStringSubstring` (also for `std.strings.substring` free-fn via `stdlibStringFreeFnToIntrinsic`).
- Primitive dispatch for `Byte.toInt` / `Char.toInt`.

### `internal/ir/lower.go` — `recoverMethodReturnType` fallbacks

Adds return-type recovery so the dest local gets the right MIR type even when the Go-hosted checker failed to populate it:

- `substring` / `slice` / `replace` / `repeat` on String → String
- `split` on String → `List<String>`
- `join` on `List<String>` → String

### `internal/llvmgen/mir_generator.go` — emission

- `emitStringSubstring` calls `osty_rt_strings_Slice` with the start / end offsets.
- `emitIntegerWidenIntrinsic(from, to)` emits a plain `zext` for Byte/Char → Int widening.
- Whitelist / dispatch cases updated for all three new intrinsics.

## Probe progression

| State | First wall |
|---|---|
| Before (#683 merged) | `<error> in mirLowerStripSign (call substring)` |
| After substring + recovery | `call to unresolved symbol toInt` |
| After Byte/Char.toInt | `call to unresolved symbol runtime.cihost.LoadRunnerState` (different category — runtime FFI signature registration gap) |

Whole-toolchain + native-toolchain AST probes remain CLEAN.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -count=1 ./internal/ir/... ./internal/mir/... ./internal/check/...` all green
- [x] `internal/llvmgen` shows 2 pre-existing failures (`TestGenerateModulePtrBackedListToSetAndBoolPrint`, `TestGenerateModuleBuiltinResultConstructorsTrackLocalContext`) that reproduce on main

## Notes for reviewers

- `recoverMethodReturnType` additions are consistent with earlier patterns in the same function — only names whose return type is uniquely determined by the receiver's kind get a fallback. Per-type specific signatures still defer to the checker.
- `emitIntegerWidenIntrinsic` is a shared helper because the only difference between Byte.toInt and Char.toInt is the source width (i8 vs i32). Future lossless widenings (Int8 → Int, etc.) can reuse the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)