### PR TITLE
[codex] Speed up indexed string map lookups

### DIFF
--- a/internal/backend/llvm_runtime_map_fastpath_test.go
+++ b/internal/backend/llvm_runtime_map_fastpath_test.go
@@ -1,0 +1,108 @@
+package backend
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundledRuntimeMapIndexedHashCachePreservesStringLookup(t *testing.T) {
+	parallelClangBackendTest(t)
+
+	dir := t.TempDir()
+	runtimePath := filepath.Join(dir, bundledRuntimeSourceName)
+	harnessPath := filepath.Join(dir, "runtime_map_index_hash_harness.c")
+	binaryPath := filepath.Join(dir, "runtime_map_index_hash_harness")
+
+	if err := os.WriteFile(runtimePath, []byte(bundledRuntimeSource), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", runtimePath, err)
+	}
+
+	harness := `#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define OSTY_RT_ABI_STRING 5
+#define OSTY_RT_ABI_I64 1
+
+void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, void *value_trace);
+bool osty_rt_map_get_string(void *raw_map, const char *key, void *out_value);
+bool osty_rt_map_remove_string(void *raw_map, const char *key);
+void osty_rt_map_insert_string(void *raw_map, const char *key, const void *value);
+void osty_rt_map_clear(void *raw_map);
+
+static char *dup_cstr(const char *src) {
+    size_t len = strlen(src);
+    char *dst = (char *)malloc(len + 1);
+    if (dst == NULL) {
+        fprintf(stderr, "oom\n");
+        exit(1);
+    }
+    memcpy(dst, src, len + 1);
+    return dst;
+}
+
+int main(void) {
+    static const char *words[] = {
+        "alpha", "beta", "gamma", "delta", "epsilon",
+        "zeta", "eta", "theta", "iota", "kappa",
+    };
+    void *map = osty_rt_map_new(OSTY_RT_ABI_STRING, OSTY_RT_ABI_I64, (int64_t)sizeof(int64_t), NULL);
+    int64_t out = -1;
+    int64_t sum = 0;
+    for (size_t i = 0; i < sizeof(words) / sizeof(words[0]); ++i) {
+        int64_t value = (int64_t)(i + 1) * 11;
+        osty_rt_map_insert_string(map, words[i], &value);
+    }
+    if (!osty_rt_map_get_string(map, dup_cstr("delta"), &out) || out != 44) {
+        printf("delta-miss %lld\n", (long long)out);
+        return 1;
+    }
+    sum += out;
+    if (!osty_rt_map_remove_string(map, dup_cstr("beta"))) {
+        printf("beta-remove\n");
+        return 1;
+    }
+    if (osty_rt_map_get_string(map, dup_cstr("beta"), &out)) {
+        printf("beta-hit %lld\n", (long long)out);
+        return 1;
+    }
+    if (!osty_rt_map_get_string(map, dup_cstr("theta"), &out) || out != 88) {
+        printf("theta-miss %lld\n", (long long)out);
+        return 1;
+    }
+    sum += out;
+    osty_rt_map_clear(map);
+    {
+        int64_t value = 123;
+        osty_rt_map_insert_string(map, dup_cstr("after-clear"), &value);
+    }
+    if (!osty_rt_map_get_string(map, dup_cstr("after-clear"), &out) || out != 123) {
+        printf("after-clear %lld\n", (long long)out);
+        return 1;
+    }
+    sum += out;
+    printf("%lld\n", (long long)sum);
+    return 0;
+}
+`
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", harnessPath, err)
+	}
+
+	buildOutput, err := exec.Command("clang", "-std=c11", runtimePath, harnessPath, "-o", binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clang failed: %v\n%s", err, buildOutput)
+	}
+	runOutput, err := exec.Command(binaryPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %q failed: %v\n%s", binaryPath, err, runOutput)
+	}
+
+	if got, want := string(runOutput), "255\n"; got != want {
+		t.Fatalf("runtime map indexed hash harness stdout mismatch\n---got---\n%s\n---want---\n%s", got, want)
+	}
+}

--- a/internal/backend/runtime/osty_runtime.c
+++ b/internal/backend/runtime/osty_runtime.c
@@ -405,7 +405,9 @@ typedef struct osty_rt_map {
     int64_t index_cap;
     int64_t index_len;
     int64_t *index_slots;
+    uint32_t *index_hashes;
     int64_t index_inline[OSTY_RT_MAP_INLINE_INDEX_CAP];
+    uint32_t index_hashes_inline[OSTY_RT_MAP_INLINE_INDEX_CAP];
     // Per-map recursive mutex. Public ops elide it while the runtime
     // is still single-threaded, then enable it permanently on first
     // task spawn so concurrent mutation can't realloc the slot arrays
@@ -2603,6 +2605,11 @@ static size_t osty_rt_map_key_hash(int64_t kind, const void *key) {
     }
 }
 
+static inline uint32_t osty_rt_map_key_fingerprint(size_t hash) {
+    uint64_t bits = (uint64_t)hash;
+    return (uint32_t)(bits ^ (bits >> 32));
+}
+
 static void osty_rt_map_trace(void *payload) {
     osty_rt_map *map = (osty_rt_map *)payload;
     int64_t i;
@@ -2629,6 +2636,9 @@ static void osty_rt_map_destroy(void *payload) {
     if (map != NULL) {
         if (map->index_slots != NULL && map->index_slots != map->index_inline) {
             free(map->index_slots);
+        }
+        if (map->index_hashes != NULL && map->index_hashes != map->index_hashes_inline) {
+            free(map->index_hashes);
         }
         free(map->keys);
         free(map->values);
@@ -5628,18 +5638,24 @@ static void osty_rt_map_index_clear(osty_rt_map *map) {
     if (map->index_slots != NULL && map->index_slots != map->index_inline) {
         free(map->index_slots);
     }
+    if (map->index_hashes != NULL && map->index_hashes != map->index_hashes_inline) {
+        free(map->index_hashes);
+    }
     map->index_slots = NULL;
+    map->index_hashes = NULL;
     map->index_cap = 0;
     map->index_len = 0;
 }
 
-static void osty_rt_map_index_insert_slot(osty_rt_map *map, int64_t slot) {
+static void osty_rt_map_index_insert_slot_hashed(osty_rt_map *map, int64_t slot, size_t hash) {
     uint64_t mask = (uint64_t)(map->index_cap - 1);
-    uint64_t idx = (uint64_t)osty_rt_map_key_hash(map->key_kind, osty_rt_map_key_slot(map, slot)) & mask;
+    uint64_t idx = (uint64_t)hash & mask;
+    uint32_t fingerprint = osty_rt_map_key_fingerprint(hash);
     while (map->index_slots[idx] != 0) {
         idx = (idx + 1) & mask;
     }
     map->index_slots[idx] = slot + 1;
+    map->index_hashes[idx] = fingerprint;
     map->index_len += 1;
 }
 
@@ -5665,26 +5681,38 @@ static void osty_rt_map_index_rebuild(osty_rt_map *map, int64_t live_len) {
         if (map->index_slots != NULL && map->index_slots != map->index_inline) {
             free(map->index_slots);
         }
+        if (map->index_hashes != NULL && map->index_hashes != map->index_hashes_inline) {
+            free(map->index_hashes);
+        }
         map->index_slots = map->index_inline;
+        map->index_hashes = map->index_hashes_inline;
         memset(map->index_slots, 0, (size_t)cap * sizeof(int64_t));
+        memset(map->index_hashes, 0, (size_t)cap * sizeof(uint32_t));
         map->index_cap = cap;
     } else {
-        if (map->index_cap != cap || map->index_slots == NULL || map->index_slots == map->index_inline) {
+        if (map->index_cap != cap || map->index_slots == NULL || map->index_slots == map->index_inline ||
+            map->index_hashes == NULL || map->index_hashes == map->index_hashes_inline) {
             if (map->index_slots != NULL && map->index_slots != map->index_inline) {
                 free(map->index_slots);
             }
+            if (map->index_hashes != NULL && map->index_hashes != map->index_hashes_inline) {
+                free(map->index_hashes);
+            }
             map->index_slots = (int64_t *)calloc((size_t)cap, sizeof(int64_t));
-            if (map->index_slots == NULL) {
+            map->index_hashes = (uint32_t *)calloc((size_t)cap, sizeof(uint32_t));
+            if (map->index_slots == NULL || map->index_hashes == NULL) {
                 osty_rt_abort("out of memory");
             }
             map->index_cap = cap;
         } else {
             memset(map->index_slots, 0, (size_t)map->index_cap * sizeof(int64_t));
+            memset(map->index_hashes, 0, (size_t)map->index_cap * sizeof(uint32_t));
         }
     }
     map->index_len = 0;
     for (i = 0; i < map->len; i++) {
-        osty_rt_map_index_insert_slot(map, i);
+        size_t hash = osty_rt_map_key_hash(map->key_kind, osty_rt_map_key_slot(map, i));
+        osty_rt_map_index_insert_slot_hashed(map, i, hash);
     }
 }
 
@@ -5728,9 +5756,11 @@ static int64_t osty_rt_map_find_index_linear(osty_rt_map *map, const void *key) 
 }
 
 static int64_t osty_rt_map_find_index_indexed(osty_rt_map *map, const void *key) {
+    size_t key_hash = osty_rt_map_key_hash(map->key_kind, key);
+    uint32_t key_fingerprint = osty_rt_map_key_fingerprint(key_hash);
     size_t key_size = osty_rt_kind_size(map->key_kind);
     uint64_t mask = (uint64_t)(map->index_cap - 1);
-    uint64_t idx = (uint64_t)osty_rt_map_key_hash(map->key_kind, key) & mask;
+    uint64_t idx = (uint64_t)key_hash & mask;
 
     for (;;) {
         int64_t entry = map->index_slots[idx];
@@ -5740,6 +5770,7 @@ static int64_t osty_rt_map_find_index_indexed(osty_rt_map *map, const void *key)
         }
         slot = entry - 1;
         if (slot >= 0 && slot < map->len &&
+            map->index_hashes[idx] == key_fingerprint &&
             osty_rt_value_equals(osty_rt_map_key_slot(map, slot), key, key_size, map->key_kind)) {
             return slot;
         }
@@ -5777,6 +5808,7 @@ void *osty_rt_map_new(int64_t key_kind, int64_t value_kind, int64_t value_size, 
     map->index_cap = 0;
     map->index_len = 0;
     map->index_slots = NULL;
+    map->index_hashes = NULL;
     osty_rt_map_mutex_init_or_abort(map);
     return map;
 }
@@ -5847,11 +5879,12 @@ static void osty_rt_map_insert_raw(void *raw_map, const void *key, const void *v
     memcpy(osty_rt_map_value_slot(map, index), value, map->value_size);
     if (inserted) {
         if (map->len >= 8) {
-            if (map->index_cap == 0 || map->index_slots == NULL ||
+            if (map->index_cap == 0 || map->index_slots == NULL || map->index_hashes == NULL ||
                 (map->index_len + 1) * 10 >= map->index_cap * 7) {
                 osty_rt_map_index_rebuild(map, map->len);
             } else {
-                osty_rt_map_index_insert_slot(map, index);
+                size_t hash = osty_rt_map_key_hash(map->key_kind, osty_rt_map_key_slot(map, index));
+                osty_rt_map_index_insert_slot_hashed(map, index, hash);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a cached fingerprint alongside the runtime `Map` side index entries
- short-circuit indexed probes before falling through to full key equality
- add a bundled runtime harness that exercises insert/get/remove/clear across indexed string-key maps

## Why
The runtime `Map` side index was only storing slot numbers, so string-keyed lookups still paid full string equality on every occupied probe step. That kept `Map<String, ...>` workloads like `word_freq` and `record_pipeline` hotter than they needed to be even after the index kicked in.

## Impact
String-keyed map probes can now reject non-matching entries with a cheap cached fingerprint before doing the expensive equality path. This is a runtime-level change, so it benefits ordinary Osty programs instead of only the benchmark harness.

On the validation worktree based on current `main`, the target workloads measured:
- `word_freq`: `19100ns`
- `record_pipeline`: `25869ns`

## Validation
- `go test -count=1 -vet=off ./internal/backend -run 'TestBundledRuntimeMapIndexedHashCachePreservesStringLookup'`
- `go build -o .bin/osty ./cmd/osty`
- `./.bin/osty test --bench --serial --benchtime 400ms benchmarks/osty-vs-go/word_freq/osty`
- `./.bin/osty test --bench --serial --benchtime 400ms benchmarks/osty-vs-go/record_pipeline/osty`